### PR TITLE
Fix : city might have negative free population after been conquered.

### DIFF
--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -139,8 +139,8 @@ class Battle(val gameInfo:GameInfo) {
                 city.expansion.cultureStored = 0
                 city.expansion.reset()
             }
-            city.moveToCiv(attacker.getCivilization())
             city.population.unassignExtraPopulation()
+            city.moveToCiv(attacker.getCivilization())
         }
 
         if(city.cityConstructions.isBuilt("Palace")){

--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -140,6 +140,7 @@ class Battle(val gameInfo:GameInfo) {
                 city.expansion.reset()
             }
             city.moveToCiv(attacker.getCivilization())
+            city.population.unassignExtraPopulation()
         }
 
         if(city.cityConstructions.isBuilt("Palace")){


### PR DESCRIPTION
Population decreased when conquered, but working tiles didn't get rechecked.