### PR TITLE
Allow embarked units to attack land units, like in civ5.

### DIFF
--- a/core/src/com/unciv/logic/automation/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/UnitAutomation.kt
@@ -139,8 +139,6 @@ class UnitAutomation{
                 .filter { unit.currentMovement - it.value > 0.1 }
                 .map { it.key }
                 .filter { unit.canMoveTo(it) || it==unit.getTile() }
-        if(unit.type.isLandUnit())
-            tilesToAttackFrom = tilesToAttackFrom.filter { it.getBaseTerrain().type==TerrainType.Land }
 
         for(reachableTile in tilesToAttackFrom){  // tiles we'll still have energy after we reach there
             val tilesInAttackRange = if (unit.hasUnique("Indirect fire")) reachableTile.getTilesInDistance(rangeOfAttack)


### PR DESCRIPTION
Wiki says embarked melee units should be able to attack land targets.

I have encountered an 1-tile island with an AI city on it 😄 I realized that I have no way to capture it after bombarding the defense.