### PR TITLE
Worker automation uses more resource.

### DIFF
--- a/core/src/com/unciv/logic/automation/WorkerAutomation.kt
+++ b/core/src/com/unciv/logic/automation/WorkerAutomation.kt
@@ -98,7 +98,7 @@ class WorkerAutomation(val unit: MapUnit) {
         val workableTiles = currentTile.getTilesInDistance(4)
                 .filter {
                     (it.civilianUnit== null || it == currentTile)
-                            && (it.improvement == null || (it.hasViewableResource(unit.civInfo) && it.getTileResource().improvement != it.improvement))
+                            && (it.improvement == null || (it.hasViewableResource(unit.civInfo) && !it.containsGreatImprovement() && it.getTileResource().improvement != it.improvement))
                             && it.isLand()
                             && !it.getBaseTerrain().impassable
                             && it.canBuildImprovement(chooseImprovement(it, unit.civInfo), unit.civInfo)

--- a/core/src/com/unciv/logic/automation/WorkerAutomation.kt
+++ b/core/src/com/unciv/logic/automation/WorkerAutomation.kt
@@ -30,7 +30,7 @@ class WorkerAutomation(val unit: MapUnit) {
             return
         }
         if (tile.improvementInProgress == null && tile.isLand()) {
-            val improvement = chooseImprovement(tile)
+            val improvement = chooseImprovement(tile, unit.civInfo)
             if (tile.canBuildImprovement(improvement, unit.civInfo)) {
                 // What if we're stuck on this tile but can't build there?
                 tile.startWorkingOnImprovement(improvement, unit.civInfo)
@@ -98,10 +98,10 @@ class WorkerAutomation(val unit: MapUnit) {
         val workableTiles = currentTile.getTilesInDistance(4)
                 .filter {
                     (it.civilianUnit== null || it == currentTile)
-                            && it.improvement == null
+                            && (it.improvement == null || (it.hasViewableResource(unit.civInfo) && it.getTileResource().improvement != it.improvement))
                             && it.isLand()
                             && !it.getBaseTerrain().impassable
-                            && it.canBuildImprovement(chooseImprovement(it), unit.civInfo)
+                            && it.canBuildImprovement(chooseImprovement(it, unit.civInfo), unit.civInfo)
                             && {val city=it.getCity();  city==null || it.getCity()?.civInfo == unit.civInfo}() // don't work tiles belonging to another civ
                 }.sortedByDescending { getPriority(it, unit.civInfo) }.toMutableList()
 
@@ -131,14 +131,21 @@ class WorkerAutomation(val unit: MapUnit) {
         return priority
     }
 
-    private fun chooseImprovement(tile: TileInfo): TileImprovement {
+    private fun chooseImprovement(tile: TileInfo, civInfo: CivilizationInfo): TileImprovement {
+        val improvementStringForResource : String ?= when {
+            tile.resource == null || !tile.hasViewableResource(civInfo) -> null
+            tile.terrainFeature == "Marsh" -> "Remove Marsh"
+            tile.terrainFeature == "Jungle" -> "Remove Jungle"
+            tile.terrainFeature == "Forest" && tile.getTileResource().improvement!="Camp" -> "Remove Forest"
+            else -> tile.getTileResource().improvement
+        }
+
         val improvementString = when {
             tile.improvementInProgress != null -> tile.improvementInProgress
+            improvementStringForResource != null -> improvementStringForResource
             tile.terrainFeature == "Jungle" -> "Trading post"
             tile.terrainFeature == "Marsh" -> "Remove Marsh"
-            tile.terrainFeature == "Forest" &&
-                    (tile.resource == null || tile.getTileResource().improvement!="Camp") -> "Lumber mill"
-            tile.resource != null -> tile.getTileResource().improvement
+            tile.terrainFeature == "Forest" -> "Lumber mill"
             tile.baseTerrain == "Hill" -> "Mine"
             tile.baseTerrain in listOf("Grassland","Desert","Plains") -> "Farm"
             tile.baseTerrain == "Tundra" -> "Trading post"

--- a/core/src/com/unciv/logic/map/TileInfo.kt
+++ b/core/src/com/unciv/logic/map/TileInfo.kt
@@ -44,6 +44,11 @@ open class TileInfo {
         return toReturn
     }
 
+    fun containsGreatImprovement(): Boolean {
+        if (getTileImprovement() == null) return false
+        return getTileImprovement()!!.name in listOf("Academy", "Landmark", "Manufactory", "Customs house")
+    }
+
     //region pure functions
     fun getUnits(): List<MapUnit> {
         val list = ArrayList<MapUnit>(2)
@@ -162,7 +167,7 @@ open class TileInfo {
             if (improvement.improvingTech != null && observingCiv.tech.isResearched(improvement.improvingTech!!)) stats.add(improvement.improvingTechStats!!) // eg Chemistry for mines
             if (improvement.name == "Trading post" && city != null && city.civInfo.policies.isAdopted("Free Thought"))
                 stats.science += 1f
-            if (improvement.name in listOf("Academy", "Landmark", "Manufactory", "Customs house") && observingCiv.policies.isAdopted("Freedom Complete"))
+            if (containsGreatImprovement() && observingCiv.policies.isAdopted("Freedom Complete"))
                 stats.add(improvement) // again, for the double effect
         }
 

--- a/core/src/com/unciv/logic/trade/TradeLogic.kt
+++ b/core/src/com/unciv/logic/trade/TradeLogic.kt
@@ -155,8 +155,8 @@ class TradeLogic(val ourCivilization:CivilizationInfo, val otherCivilization: Ci
         val ourCombatStrength = Automation().evaluteCombatStrength(ourCivilization)
         val theirCombatStrength = Automation().evaluteCombatStrength(otherCivilization)
         if(ourCombatStrength==theirCombatStrength) return 0
-        if(ourCombatStrength==0) return 1000
-        if(theirCombatStrength==0) return -1000 // Chumps got no cities or units
+        if(ourCombatStrength==0) return -1000
+        if(theirCombatStrength==0) return 1000 // Chumps got no cities or units
         if(ourCombatStrength>theirCombatStrength){
             val absoluteAdvantage = ourCombatStrength-theirCombatStrength
             val percentageAdvantage = absoluteAdvantage / theirCombatStrength.toFloat()


### PR DESCRIPTION
Workers automatically remove jungles/forests for resources if necessary, and can replace existing tile improvements on resources.