### PR TITLE
Idle worker try to connect cities with roads.

### DIFF
--- a/core/src/com/unciv/logic/automation/WorkerAutomation.kt
+++ b/core/src/com/unciv/logic/automation/WorkerAutomation.kt
@@ -38,6 +38,7 @@ class WorkerAutomation(val unit: MapUnit) {
             }
         }
         if(tile.improvementInProgress!=null) return // we're working!
+        if(tryConnectingCities()) return //nothing to do, try again to connect cities
     }
 
 


### PR DESCRIPTION
https://github.com/yairm210/UnCiv/issues/398

Worker automation will choose current tile to work on if no other tiles are worth working on, and fail finding an improvement to build. That's why they stay idle when there are roads to build.
In this case, call tryConnectCities() again to allow workers to build roads.