### PR TITLE
wonder building priority.

### DIFF
--- a/core/src/com/unciv/logic/automation/Automation.kt
+++ b/core/src/com/unciv/logic/automation/Automation.kt
@@ -142,7 +142,7 @@ class Automation {
                 val citiesBuildingWonders = cityInfo.civInfo.cities
                         .count { it.cityConstructions.isBuildingWonder() }
                 val wonder = buildableWonders.getRandom()
-                relativeCostEffectiveness.add(ConstructionChoice(wonder.name,3f / (citiesBuildingWonders + 1)))
+                relativeCostEffectiveness.add(ConstructionChoice(wonder.name,5f / (citiesBuildingWonders + 1)))
             }
 
             //other buildings

--- a/core/src/com/unciv/logic/automation/Automation.kt
+++ b/core/src/com/unciv/logic/automation/Automation.kt
@@ -158,7 +158,7 @@ class Automation {
 
             //Work boat
             if (needWorkboat) {
-                relativeCostEffectiveness.add(ConstructionChoice("Work Boats",1.5f))
+                relativeCostEffectiveness.add(ConstructionChoice("Work Boats",0.6f))
             }
 
             //Army


### PR DESCRIPTION
First wonder should have priority ratio 5. Test runs show that even 4 is too small to propose effective wonder racing, because wonders are so expensive.