### PR TITLE
Battle table no longer pops up when clicking on invisible submarines.

### DIFF
--- a/core/src/com/unciv/ui/worldscreen/bottombar/BattleTable.kt
+++ b/core/src/com/unciv/ui/worldscreen/bottombar/BattleTable.kt
@@ -56,6 +56,13 @@ class BattleTable(val worldScreen: WorldScreen): Table() {
             hide()
             return
         }
+
+        if(defender.isInvisible()
+                && attacker.getCivInfo().viewableInvisibleUnitsTiles.contains(selectedTile)) {
+            hide()
+            return
+        }
+
         simulateBattle(attacker, defender)
     }
 


### PR DESCRIPTION
Solves https://github.com/yairm210/UnCiv/issues/623