### PR TITLE
Citizenship and Legalism description changed.

### DIFF
--- a/android/assets/jsons/Policies.json
+++ b/android/assets/jsons/Policies.json
@@ -12,7 +12,7 @@
 			},
 			{
 				name:"Legalism",
-				description:"Free culture building in your first 4 cities",
+				description:"Immediately creates a cheapest available cultural building in each of your first 4 cities for free",
 				row:1,
 				column:3
 			},
@@ -49,13 +49,13 @@
 		policies:[
 			{
 				name:"Collective Rule",
-				description:"Training of settlers increased +50% in capital, receive a new settler near capital",
+				description:"Training of settlers increased +50% in capital, receive a new settler near the capital",
 				row:1,
 				column:1
 			},
 			{
 				name:"Citizenship",
-				description:"+25% construction rate of workers, receive free worker near the capital",
+				description:"Tile improvement speed +25%, receive a free worker near the capital",
 				row:1,
 				column:4
 			},


### PR DESCRIPTION
Unclear description fixed. I have almost created a pull request for `CityStats.kt`: 
```
if (policies.contains("Citizenship")  && currentConstruction.name == "Worker")
stats.production += 25f
```
as I thought it should boost training of Workers.

I also attach #423 contents of  with a similar unclarity of Legalism.