### PR TITLE
Activate Piety bonus

### DIFF
--- a/core/src/com/unciv/logic/city/CityStats.kt
+++ b/core/src/com/unciv/logic/city/CityStats.kt
@@ -275,7 +275,7 @@ class CityStats {
         if(policies.contains("Warrior Code") && currentConstruction is BaseUnit && currentConstruction.unitType.isMelee())
             stats.production += 20
         if (policies.contains("Piety")
-            && listOf("Monument", "Temple", "Opera House", "Museum").contains(currentConstruction.name)) 
+            && listOf("Monument", "Temple", "Opera House", "Museum", "Broadcast Tower").contains(currentConstruction.name)) 
             stats.production += 15f
         if (policies.contains("Reformation") && cityConstructions.getBuiltBuildings().any { it.isWonder })
             stats.culture += 33f

--- a/core/src/com/unciv/logic/city/CityStats.kt
+++ b/core/src/com/unciv/logic/city/CityStats.kt
@@ -274,6 +274,9 @@ class CityStats {
             stats.production += 5f
         if(policies.contains("Warrior Code") && currentConstruction is BaseUnit && currentConstruction.unitType.isMelee())
             stats.production += 20
+        if (policies.contains("Piety")
+            && listOf("Monument", "Temple", "Opera House", "Museum").contains(currentConstruction.name)) 
+            stats.production += 15f
         if (policies.contains("Reformation") && cityConstructions.getBuiltBuildings().any { it.isWonder })
             stats.culture += 33f
         if (policies.contains("Commerce") && cityInfo.isCapital())


### PR DESCRIPTION
N.B.
The same condition may be found in `Building.kt`, so 
- may be add a function `isCultural`
or
- add a property `cultural:true` or even `type:[military, cultural, productive, financial, scientific, wonder]` to `Buildings.json` and get rid of `isWonder` there