### PR TITLE
enable Sentry for water melee units

### DIFF
--- a/android/assets/jsons/UnitPromotions.json
+++ b/android/assets/jsons/UnitPromotions.json
@@ -140,7 +140,7 @@
 	
 	{
 		name:"Sentry",
-		prerequisites:["Accuracy I","Barrage I","Shock II","Drill II","Bombardment I","Targeting I"],
+		prerequisites:["Accuracy I","Barrage I","Shock II","Drill II","Bombardment I","Targeting I","Boarding Party I","Coastal Raider I"],
 		effect:"+1 Visibility Range",
 		unitTypes:["Melee","Mounted","WaterRanged","Armor","WaterMelee"]
 	}


### PR DESCRIPTION
There is contradictory information on units that can receive Sentry promotion, but this has been already enabled, so **adding missing prerequisites** so as water melee can get it as well as water ranged now.