### PR TITLE
Enable Piety when building Broadcast Tower

### DIFF
--- a/core/src/com/unciv/models/gamebasics/Building.kt
+++ b/core/src/com/unciv/models/gamebasics/Building.kt
@@ -178,7 +178,7 @@ class Building : NamedStats(), IConstruction{
             if (civInfo.policies.adoptedPolicies.contains("Mercantilism")) cost *= 0.75
             if (civInfo.getBuildingUniques().contains("-15% to purchasing items in cities")) cost *= 0.85
             if (civInfo.policies.adoptedPolicies.contains("Patronage")
-                    && listOf("Monument", "Temple", "Opera House", "Museum").contains(name)) cost *= 0.5
+                    && listOf("Monument", "Temple", "Opera House", "Museum", "Broadcast Tower").contains(name)) cost *= 0.5
         }
 
         return (cost / 10).toInt() * 10


### PR DESCRIPTION
someone wrote [it should work for Broadcast Towers](https://forums.civfanatics.com/resources/social-policy-piety-vanilla.25659/#1) as well.