### PR TITLE
Fix negative turnsToNewPopulation while razing

### DIFF
--- a/core/src/com/unciv/logic/city/CityInfo.kt
+++ b/core/src/com/unciv/logic/city/CityInfo.kt
@@ -221,6 +221,7 @@ class CityInfo {
                 if(population.foodStored>=population.getFoodToNextPopulation()) {//if surplus in the granary...
                     population.foodStored=population.getFoodToNextPopulation()-1//...reduce below the new growth treshold
                 }
+            }
         }
         else population.nextTurn(stats.food)
 

--- a/core/src/com/unciv/logic/city/CityInfo.kt
+++ b/core/src/com/unciv/logic/city/CityInfo.kt
@@ -217,7 +217,10 @@ class CityInfo {
                 destroyCity()
                 if(isCapital() && civInfo.cities.isNotEmpty()) // Yes, we actually razed the capital. Some people do this.
                     civInfo.cities.first().cityConstructions.addBuilding("Palace")
-            }
+            }else{//if not razed yet:
+                if(population.foodStored>=population.getFoodToNextPopulation()) {//if surplus in the granary...
+                    population.foodStored=population.getFoodToNextPopulation()-1//...reduce below the new growth treshold
+                }
         }
         else population.nextTurn(stats.food)
 


### PR DESCRIPTION
Now when razing, city's food storage is carried over from the stage when city's population was +1 larger and FoodToNextPopulation was respectively larger. If a player would like to stop razing, such city would spring up immediately growing next turn or further on. Another side effect is negative turnsToNewPopulation in the city screen.

The same surplus cut off could be done to production if a Great Engineer speeds wonder production the same way and if negative turnsToComplete is possible (but have not spotted this line yet).