### PR TITLE
improved "next turn" - button

### DIFF
--- a/core/src/com/unciv/GameSettings.kt
+++ b/core/src/com/unciv/GameSettings.kt
@@ -5,7 +5,7 @@ import com.unciv.logic.GameSaver
 class GameSettings {
     var showWorkedTiles: Boolean = false
     var showResourcesAndImprovements: Boolean = true
-    var checkForDueUnits: Boolean = true
+    var checkForDueUnits: Boolean = false
     var language: String = "English"
     var resolution: String = "1050x700"
     var tutorialsShown = ArrayList<String>()

--- a/core/src/com/unciv/GameSettings.kt
+++ b/core/src/com/unciv/GameSettings.kt
@@ -5,6 +5,7 @@ import com.unciv.logic.GameSaver
 class GameSettings {
     var showWorkedTiles: Boolean = false
     var showResourcesAndImprovements: Boolean = true
+    var checkForDueUnits: Boolean = true
     var language: String = "English"
     var resolution: String = "1050x700"
     var tutorialsShown = ArrayList<String>()

--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -307,6 +307,8 @@ class CivilizationInfo {
     fun shouldOpenTechPicker() = tech.freeTechs != 0
             || tech.currentTechnology()==null && cities.isNotEmpty()
 
+    fun shouldGoToDueUnit() = UnCivGame.Current.settings.checkForDueUnits && hasDueUnits()
+
     fun getNextDueUnit(selectedUnit: MapUnit?): MapUnit? {
         val dueUnits = getDueUnits()
         if(dueUnits.isNotEmpty()) {

--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -302,7 +302,10 @@ class CivilizationInfo {
 
     fun getDueUnits() = getCivUnits().filter { it.due }
 
-    fun hasDueUnits() = getDueUnits().isEmpty()
+    fun hasDueUnits() = getDueUnits().isNotEmpty()
+
+    fun shouldOpenTechPicker() = tech.freeTechs != 0
+            || tech.currentTechnology()==null && cities.isNotEmpty()
 
     fun getNextDueUnit(selectedUnit: MapUnit?): MapUnit? {
         val dueUnits = getDueUnits()

--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -300,6 +300,21 @@ class CivilizationInfo {
         units=newList
     }
 
+    fun getDueUnits() = getCivUnits().filter { it.due }
+
+    fun hasDueUnits() = getDueUnits().isEmpty()
+
+    fun getNextDueUnit(selectedUnit: MapUnit?): MapUnit? {
+        val dueUnits = getDueUnits()
+        if(dueUnits.isNotEmpty()) {
+            var index = dueUnits.indexOf(selectedUnit)
+            index = ++index % dueUnits.size // for looping
+            val unit = dueUnits[index]
+            unit.due = false
+            return unit
+        }
+        return null
+    }
 
     fun updateViewableTiles() {
         val newViewableTiles = HashSet<TileInfo>()

--- a/core/src/com/unciv/logic/civilization/PolicyManager.kt
+++ b/core/src/com/unciv/logic/civilization/PolicyManager.kt
@@ -15,6 +15,7 @@ class PolicyManager {
     internal val adoptedPolicies = HashSet<String>()
     var numberOfAdoptedPolicies = 0
     var shouldOpenPolicyPicker = false
+            get() = field && canAdoptPolicy()
 
     // from https://forums.civfanatics.com/threads/the-number-crunching-thread.389702/
     // round down to nearest 5

--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -35,6 +35,8 @@ class MapUnit {
     var action: String? = null // work, automation, fortifying, I dunno what.
     var attacksThisTurn = 0
     var promotions = UnitPromotions()
+    var due: Boolean = true
+        get() = field && isIdle()
 
     //region pure functions
     fun clone(): MapUnit {
@@ -402,6 +404,7 @@ class MapUnit {
     fun startTurn(){
         currentMovement = getMaxMovement().toFloat()
         attacksThisTurn=0
+        due = true
         val tileOwner = getTile().getOwner()
         if(tileOwner!=null && !civInfo.canEnterTiles(tileOwner) && !tileOwner.isCityState()) // if an enemy city expanded onto this tile while I was in it
             movementAlgs().teleportToClosestMoveableTile()

--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -224,7 +224,7 @@ class WorldScreen : CameraStageBaseScreen() {
 
     private fun createNextTurnButton(): TextButton {
 
-        val nextTurnButton = TextButton(getNextTurnCaption(), skin)
+        val nextTurnButton = TextButton("", skin) // text is set in update()
 
         nextTurnButton.onClick {
 
@@ -235,19 +235,12 @@ class WorldScreen : CameraStageBaseScreen() {
                 return@onClick
             }
 
-            if(currentPlayerCiv.policies.shouldOpenPolicyPicker && !currentPlayerCiv.policies.canAdoptPolicy())
-                currentPlayerCiv.policies.shouldOpenPolicyPicker = false // something has changed and we can no longer adopt the policy, e.g. we conquered another city
-
-            if (currentPlayerCiv.tech.freeTechs != 0) {
-                game.screen = TechPickerScreen(true, currentPlayerCiv)
+            if (currentPlayerCiv.shouldOpenTechPicker()) {
+                game.screen = TechPickerScreen(currentPlayerCiv.tech.freeTechs != 0, currentPlayerCiv)
                 return@onClick
             } else if (currentPlayerCiv.policies.shouldOpenPolicyPicker) {
                 game.screen = PolicyPickerScreen(currentPlayerCiv)
                 currentPlayerCiv.policies.shouldOpenPolicyPicker = false
-                return@onClick
-            }
-            else if (currentPlayerCiv.tech.currentTechnology() == null && currentPlayerCiv.cities.isNotEmpty()) {
-                game.screen = TechPickerScreen(currentPlayerCiv)
                 return@onClick
             }
 
@@ -292,12 +285,18 @@ class WorldScreen : CameraStageBaseScreen() {
     }
 
     fun updateNextTurnButton() {
-        nextTurnButton.setText(getNextTurnCaption())
-        nextTurnButton.color = if(currentPlayerCiv.hasDueUnits()) Color.WHITE else Color.GRAY
+        val text = if (currentPlayerCiv.hasDueUnits())
+            "Next unit"
+        else if(currentPlayerCiv.shouldOpenTechPicker())
+            "Pick a tech"
+        else if(currentPlayerCiv.policies.shouldOpenPolicyPicker)
+            "Pick a policy"
+        else
+            "Next turn"
+        nextTurnButton.setText(text.tr())
+        nextTurnButton.color = if(text=="Next turn") Color.WHITE else Color.GRAY
+        nextTurnButton.pack()
     }
-
-    private fun getNextTurnCaption() =
-            if (currentPlayerCiv.hasDueUnits()) "Next turn".tr() else "Next unit".tr()
 
     override fun resize(width: Int, height: Int) {
         if (stage.viewport.screenWidth != width || stage.viewport.screenHeight != height) {

--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -48,8 +48,6 @@ class WorldScreen : CameraStageBaseScreen() {
         topBar.setPosition(0f, stage.height - topBar.height)
         topBar.width = stage.width
 
-        nextTurnButton.setPosition(stage.width - nextTurnButton.width - 10f,
-                topBar.y - nextTurnButton.height - 10f)
         notificationsScroll = NotificationsScroll(this)
         notificationsScroll.width = stage.width/3
 
@@ -229,10 +227,12 @@ class WorldScreen : CameraStageBaseScreen() {
         nextTurnButton.onClick {
 
             // cycle through units not yet done
-            currentPlayerCiv.getNextDueUnit(bottomBar.unitTable.selectedUnit)?.let {
-                tileMapHolder.setCenterPosition(it.currentTile.position)
-                shouldUpdate=true
-                return@onClick
+            if (currentPlayerCiv.shouldGoToDueUnit()) {
+                currentPlayerCiv.getNextDueUnit(bottomBar.unitTable.selectedUnit)?.let {
+                    tileMapHolder.setCenterPosition(it.currentTile.position)
+                    shouldUpdate=true
+                    return@onClick
+                }
             }
 
             if (currentPlayerCiv.shouldOpenTechPicker()) {
@@ -285,7 +285,7 @@ class WorldScreen : CameraStageBaseScreen() {
     }
 
     fun updateNextTurnButton() {
-        val text = if (currentPlayerCiv.hasDueUnits())
+        val text = if (currentPlayerCiv.shouldGoToDueUnit())
             "Next unit"
         else if(currentPlayerCiv.shouldOpenTechPicker())
             "Pick a tech"
@@ -296,6 +296,7 @@ class WorldScreen : CameraStageBaseScreen() {
         nextTurnButton.setText(text.tr())
         nextTurnButton.color = if(text=="Next turn") Color.WHITE else Color.GRAY
         nextTurnButton.pack()
+        nextTurnButton.setPosition(stage.width - nextTurnButton.width - 10f, topBar.y - nextTurnButton.height - 10f)
     }
 
     override fun resize(width: Int, height: Int) {

--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -6,11 +6,11 @@ import com.badlogic.gdx.math.Vector2
 import com.badlogic.gdx.scenes.scene2d.Touchable
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton
+import com.unciv.Constants
 import com.unciv.UnCivGame
 import com.unciv.logic.GameSaver
 import com.unciv.logic.civilization.CivilizationInfo
 import com.unciv.logic.civilization.diplomacy.DiplomaticStatus
-import com.unciv.Constants
 import com.unciv.models.gamebasics.GameBasics
 import com.unciv.models.gamebasics.tile.ResourceType
 import com.unciv.models.gamebasics.tr
@@ -222,8 +222,24 @@ class WorldScreen : CameraStageBaseScreen() {
     }
 
     private fun createNextTurnButton(): TextButton {
-        val nextTurnButton = TextButton("Next turn".tr(), skin)
+
+        val nextTurnButton = TextButton(getNextTurnCaption(), skin)
+
         nextTurnButton.onClick {
+
+            // cycle through units not yet done
+            val dueUnits = getDueUnits()
+            if(dueUnits.isNotEmpty()) {
+                var index = dueUnits.indexOf(bottomBar.unitTable.selectedUnit)
+                index = ++index % dueUnits.size // for looping
+                val unit = dueUnits[index]
+                unit.due = false
+                setNextTurnButtonCaption()
+                tileMapHolder.setCenterPosition(unit.currentTile.position)
+                shouldUpdate=true
+                return@onClick
+            }
+
             if(currentPlayerCiv.policies.shouldOpenPolicyPicker && !currentPlayerCiv.policies.canAdoptPolicy())
                 currentPlayerCiv.policies.shouldOpenPolicyPicker = false // something has changed and we can no longer adopt the policy, e.g. we conquered another city
 
@@ -264,6 +280,7 @@ class WorldScreen : CameraStageBaseScreen() {
                     if(gameInfo.turns % game.settings.turnsBetweenAutosaves == 0)
                         GameSaver().saveGame(gameInfoClone, "Autosave")
                     nextTurnButton.enable() // only enable the user to next turn once we've saved the current one
+                    setNextTurnButtonCaption()
                 }
 
                 // If we put this BEFORE the save game, then we try to save the game...
@@ -272,13 +289,22 @@ class WorldScreen : CameraStageBaseScreen() {
                 // That's why this needs to be after the game is saved.
                 shouldUpdate=true
 
-                nextTurnButton.setText("Next turn".tr())
                 Gdx.input.inputProcessor = stage
             }
         }
 
         return nextTurnButton
     }
+
+    fun getDueUnits() = currentPlayerCiv.getCivUnits().filter { it.due }
+
+    fun setNextTurnButtonCaption() {
+        nextTurnButton.setText(getNextTurnCaption())
+        nextTurnButton.color = if(getDueUnits().isEmpty()) Color.WHITE else Color.GRAY
+    }
+
+    private fun getNextTurnCaption() =
+            if (getDueUnits().isEmpty()) "Next turn".tr() else "Next unit".tr()
 
     override fun resize(width: Int, height: Int) {
         if (stage.viewport.screenWidth != width || stage.viewport.screenHeight != height) {

--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -143,6 +143,7 @@ class WorldScreen : CameraStageBaseScreen() {
 
         updateTechButton(cloneCivilization)
         updateDiplomacyButton(cloneCivilization)
+        updateNextTurnButton()
 
         bottomBar.update(tileMapHolder.selectedTile) // has to come before tilemapholder update because the tilemapholder actions depend on the selected unit!
         battleTable.update()
@@ -234,7 +235,6 @@ class WorldScreen : CameraStageBaseScreen() {
                 index = ++index % dueUnits.size // for looping
                 val unit = dueUnits[index]
                 unit.due = false
-                setNextTurnButtonCaption()
                 tileMapHolder.setCenterPosition(unit.currentTile.position)
                 shouldUpdate=true
                 return@onClick
@@ -280,7 +280,7 @@ class WorldScreen : CameraStageBaseScreen() {
                     if(gameInfo.turns % game.settings.turnsBetweenAutosaves == 0)
                         GameSaver().saveGame(gameInfoClone, "Autosave")
                     nextTurnButton.enable() // only enable the user to next turn once we've saved the current one
-                    setNextTurnButtonCaption()
+                    updateNextTurnButton()
                 }
 
                 // If we put this BEFORE the save game, then we try to save the game...
@@ -298,7 +298,7 @@ class WorldScreen : CameraStageBaseScreen() {
 
     fun getDueUnits() = currentPlayerCiv.getCivUnits().filter { it.due }
 
-    fun setNextTurnButtonCaption() {
+    fun updateNextTurnButton() {
         nextTurnButton.setText(getNextTurnCaption())
         nextTurnButton.color = if(getDueUnits().isEmpty()) Color.WHITE else Color.GRAY
     }

--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -229,13 +229,8 @@ class WorldScreen : CameraStageBaseScreen() {
         nextTurnButton.onClick {
 
             // cycle through units not yet done
-            val dueUnits = getDueUnits()
-            if(dueUnits.isNotEmpty()) {
-                var index = dueUnits.indexOf(bottomBar.unitTable.selectedUnit)
-                index = ++index % dueUnits.size // for looping
-                val unit = dueUnits[index]
-                unit.due = false
-                tileMapHolder.setCenterPosition(unit.currentTile.position)
+            currentPlayerCiv.getNextDueUnit(bottomBar.unitTable.selectedUnit)?.let {
+                tileMapHolder.setCenterPosition(it.currentTile.position)
                 shouldUpdate=true
                 return@onClick
             }
@@ -296,15 +291,13 @@ class WorldScreen : CameraStageBaseScreen() {
         return nextTurnButton
     }
 
-    fun getDueUnits() = currentPlayerCiv.getCivUnits().filter { it.due }
-
     fun updateNextTurnButton() {
         nextTurnButton.setText(getNextTurnCaption())
-        nextTurnButton.color = if(getDueUnits().isEmpty()) Color.WHITE else Color.GRAY
+        nextTurnButton.color = if(currentPlayerCiv.hasDueUnits()) Color.WHITE else Color.GRAY
     }
 
     private fun getNextTurnCaption() =
-            if (getDueUnits().isEmpty()) "Next turn".tr() else "Next unit".tr()
+            if (currentPlayerCiv.hasDueUnits()) "Next turn".tr() else "Next unit".tr()
 
     override fun resize(width: Int, height: Int) {
         if (stage.viewport.screenWidth != width || stage.viewport.screenHeight != height) {

--- a/core/src/com/unciv/ui/worldscreen/optionstable/WorldScreenOptionsTable.kt
+++ b/core/src/com/unciv/ui/worldscreen/optionstable/WorldScreenOptionsTable.kt
@@ -50,6 +50,12 @@ class WorldScreenOptionsTable(screen:WorldScreen) : PopupTable(screen){
             addButton("Hide") { settings.showResourcesAndImprovements = false; update() }
         else addButton("Show") { settings.showResourcesAndImprovements = true; update() }
 
+        add("Check for idle units".toLabel())
+        addButton(if(settings.checkForDueUnits) "Yes" else "No") {
+            settings.checkForDueUnits = !settings.checkForDueUnits
+            update()
+        }
+
         addLanguageSelectBox()
 
         addResolutionSelectBox()


### PR DESCRIPTION
This PR introduces two things:

* change the label of the "next turn button" to "pick a tech" or "pick a policy" when needed
* also shows "next unit" as long as there are units "due"

The cycling through "due" units is done only once for each unit to make sure you didn't miss any idle unit. Works pretty well when playing. No need to constantly check the "next/previous" unit arrows in the lower left. Less eye movement - better UX :)

Let me know what you think about both the general idea and about this implementation in particular. It's my first PR, so it might not meet the quality standards yet :)