### PR TITLE
Unit help button

### DIFF
--- a/android/assets/jsons/Translations/Other.json
+++ b/android/assets/jsons/Translations/Other.json
@@ -1058,7 +1058,7 @@
 		Russian:"Город будет расширяться между раундами [turnsToExpansion]"
 		French:"La ville se développera entre [turnsToExpansion] tours"
 		Romanian:"Orașul se va extinde între rundă [turnsToExpansion]"
-		German:"Die Stadt wird sich zwischen [turnsToExpansion]-Runden erweitern"
+		German:"Erweiterung in [turnsToExpansion] Runden"
 		Dutch:"De stad breidt zich uit tussen [turnsToExpansion]-rondes"
 		Spanish:"La ciudad se expandirá entre [turnsToExpansion] rondas"
 		Simplified_Chinese:"这座城市将在[turnsToExpansion]回合后扩张"
@@ -1084,7 +1084,7 @@
 		Russian:"В городе будет новый житель в раундах [turnsToPopulation]"
 		French:"La ville aura un nouveau résident dans [turnsToPopulation]"
 		Romanian:"Orașul va avea un nou rezident în runde [turnsToPopulation]"
-		German:"Die Stadt wird einen neuen Einwohner in [turnsToPopulation]-Runden haben"
+		German:"Neuer Einwohner in [turnsToPopulation] Runden"
 		Dutch:"De stad krijgt een nieuwe inwoner in [turnsToPopulation]-rondes"
 		Spanish:"La ciudad tendrá un nuevo residente en las rondas de [turnsToPopulation]"
 		Simplified_Chinese:"这座城市将在[turnsToPopulation]轮后有1个新市民"
@@ -1863,8 +1863,9 @@
 	}
 
 	"Technologies":{ //You misses this translation, said Smashfanful
-		Italian:"Tecnologie"
-		French:"Technologies"
+		Italian:"Tecnologie",
+		German:"Technologien",
+		French:"Technologies",
 		Simplified_Chinese:"科技"
 	}
 
@@ -3009,7 +3010,7 @@
 
 	"Terrains":{
 		Italian:"Terreni e caratteristiche"
-		German:"Gelände und Geländearten"
+		German:"Gelände"
 		French:"Terrains"
 		Simplified_Chinese:"地形"
 	}

--- a/core/src/com/unciv/ui/worldscreen/NotificationsScroll.kt
+++ b/core/src/com/unciv/ui/worldscreen/NotificationsScroll.kt
@@ -25,7 +25,7 @@ class NotificationsScroll(internal val worldScreen: WorldScreen) : ScrollPane(nu
             minitable.add(ImageGetter.getCircle()
                     .apply { color=notification.color }).size(10f).pad(5f)
             minitable.background(ImageGetter.getDrawable("OtherIcons/civTableBackground.png"))
-            minitable.add(label).pad(3f).padRight(10f)
+            minitable.add(label).pad(5f).padRight(10f)
 
             if (notification.location != null) {
                 minitable.onClick {

--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -263,7 +263,7 @@ class WorldScreen : CameraStageBaseScreen() {
 
                 val gameInfoClone = gameInfo.clone()
                 kotlin.concurrent.thread {
-                    // the save takes a long time( up to a second!) and we can do it while the player continues his game.
+                    // the save takes a long time (up to a second!) and we can do it while the player continues his game.
                     // On the other hand if we alter the game data while it's being serialized we could get a concurrent modification exception.
                     // So what we do is we clone all the game data and serialize the clone.
                     if(gameInfo.turns % game.settings.turnsBetweenAutosaves == 0)
@@ -278,6 +278,7 @@ class WorldScreen : CameraStageBaseScreen() {
                 // That's why this needs to be after the game is saved.
                 shouldUpdate=true
 
+                updateNextTurnButton()
                 Gdx.input.inputProcessor = stage
             }
         }

--- a/core/src/com/unciv/ui/worldscreen/bottombar/WorldScreenBottomBar.kt
+++ b/core/src/com/unciv/ui/worldscreen/bottombar/WorldScreenBottomBar.kt
@@ -10,7 +10,7 @@ class WorldScreenBottomBar(val worldScreen: WorldScreen) : Table(){
     val tileInfoTable = TileInfoTable(worldScreen)
 
     init {
-        add(unitTable).width(worldScreen.stage.width/3).fill()
+        add(unitTable).width(worldScreen.stage.width/3).bottom().fillX()
         add().width(worldScreen.stage.width/3) // empty space for the battle table
         add(tileInfoTable).width(worldScreen.stage.width/3).fill()
 

--- a/core/src/com/unciv/ui/worldscreen/unit/UnitTable.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitTable.kt
@@ -2,14 +2,14 @@ package com.unciv.ui.worldscreen.unit
 
 import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.scenes.scene2d.Touchable
-import com.badlogic.gdx.scenes.scene2d.ui.Image
-import com.badlogic.gdx.scenes.scene2d.ui.Label
-import com.badlogic.gdx.scenes.scene2d.ui.Table
+import com.badlogic.gdx.scenes.scene2d.ui.*
+import com.unciv.UnCivGame
 import com.unciv.logic.battle.CityCombatant
 import com.unciv.logic.city.CityInfo
 import com.unciv.logic.map.MapUnit
 import com.unciv.logic.map.TileInfo
 import com.unciv.models.gamebasics.tr
+import com.unciv.ui.CivilopediaScreen
 import com.unciv.ui.utils.*
 import com.unciv.ui.worldscreen.WorldScreen
 
@@ -25,6 +25,7 @@ class UnitTable(val worldScreen: WorldScreen) : Table(){
     var currentlyExecutingAction : String? = null
     var lastSelectedCityButton : Boolean = false
     val deselectUnitButton = Table()
+    val helpUnitButton = Table()
 
     // This is so that not on every update(), we will update the unit table.
     // Most of the time it's the same unit with the same stats so why waste precious time?
@@ -33,23 +34,41 @@ class UnitTable(val worldScreen: WorldScreen) : Table(){
 
     init {
         pad(5f)
+
         background = ImageGetter.getBackground(ImageGetter.getBlue().lerp(Color.BLACK, 0.5f))
 
-        add(Table().apply {
-            add(prevIdleUnitButton)
-            add(unitIconHolder)
-            add(unitNameLabel).pad(5f)
-            add(nextIdleUnitButton)
-        }).colspan(2).row()
-        separator= addSeparator().actor!!
-        add(promotionsTable).colspan(2).row()
-        add(unitDescriptionTable)
+        add(VerticalGroup().apply {
+            pad(5f)
 
-        deselectUnitButton.add(Label("X",CameraStageBaseScreen.skin).setFontColor(Color.WHITE)).pad(20f)
-        deselectUnitButton.pack()
-        deselectUnitButton.touchable = Touchable.enabled
-        deselectUnitButton.onClick { selectedUnit=null; selectedCity=null; worldScreen.shouldUpdate=true }
-        addActor(deselectUnitButton)
+            deselectUnitButton.add(Label("X",CameraStageBaseScreen.skin).setFontColor(Color.WHITE)).pad(10f)
+            deselectUnitButton.pack()
+            deselectUnitButton.touchable = Touchable.enabled
+            deselectUnitButton.onClick { selectedUnit=null; selectedCity=null; worldScreen.shouldUpdate=true }
+            addActor(deselectUnitButton)
+
+            helpUnitButton.add(Label("?",CameraStageBaseScreen.skin).setFontColor(Color.WHITE)).pad(10f)
+            helpUnitButton.pack()
+            helpUnitButton.touchable = Touchable.enabled
+            helpUnitButton.onClick { UnCivGame.Current.screen = CivilopediaScreen() }
+            addActor(helpUnitButton)
+
+        }).left()
+
+        add(prevIdleUnitButton)
+
+        add(Table().apply {
+            add(Table().apply {
+                add(unitIconHolder)
+                add(unitNameLabel).pad(5f)
+
+            }).colspan(2).fill().row()
+            separator= addSeparator().actor!!
+            add(promotionsTable).colspan(2).row()
+            add(unitDescriptionTable)
+        }).expand()
+
+        add(nextIdleUnitButton)
+
     }
 
     fun update() {

--- a/core/src/com/unciv/ui/worldscreen/unit/UnitTable.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitTable.kt
@@ -49,7 +49,13 @@ class UnitTable(val worldScreen: WorldScreen) : Table(){
             helpUnitButton.add(Label("?",CameraStageBaseScreen.skin).setFontColor(Color.WHITE)).pad(10f)
             helpUnitButton.pack()
             helpUnitButton.touchable = Touchable.enabled
-            helpUnitButton.onClick { UnCivGame.Current.screen = CivilopediaScreen() }
+            helpUnitButton.onClick {
+                val pedia = CivilopediaScreen()
+                if (selectedUnit != null) {
+                    pedia.select("Units", selectedUnit?.name)
+                }
+                UnCivGame.Current.screen = pedia
+            }
             addActor(helpUnitButton)
 
         }).left()


### PR DESCRIPTION
This PR adds a help button (?) to the unit panel. When a unit is selected, it will link to its entry in the Civilopedia. If no unit is selected, it will just open the civilipedia. Just adding a little more comfort for newbies =)

Along the way, I fixed the UnitTable a little - there is less jumping of the ui elements now, so it appears a little more steady and stable.