### PR TITLE
various ui improvements

### DIFF
--- a/android/assets/jsons/Translations/Notifications.json
+++ b/android/assets/jsons/Translations/Notifications.json
@@ -315,8 +315,16 @@
             Simplified_Chinese:"在我们的领土附近发现了一个敌人的[unit]"
             Portuguese:"Um(a) [unit] inimigo(a) foi vista dentro de nosso território"
             Japanese:"私たちの領土に敵[unit]が発見されました"
-        }
-        
+        },
+
+        "[amount] enemy units were spotted near our territory": {
+            German:"[amount] feindliche Einheiten wurden nahe unserer Grenzen entdeckt"
+        },
+
+        "[amount] enemy units were spotted in our territory": {
+            German:"[amount] feindliche Einheiten wurden in unseren Grenzen entdeckt"
+        },
+
         "The civilization of [civName] has been destroyed!":{
             Italian:"La civiltà [civName] è stata distrutta!"
             Russian:"Цивилизация [civName] была уничтожена!"

--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -73,12 +73,32 @@ class GameInfo {
                             && (it.getOwner() == thisPlayer || it.neighbors.any { neighbor -> neighbor.getOwner() == thisPlayer })
                 }
 
-        for (enemyUnitTile in enemyUnitsCloseToTerritory) {
-            val inOrNear = if (enemyUnitTile.getOwner() == thisPlayer) "in" else "near"
-            val unitName = enemyUnitTile.militaryUnit!!.name
-            thisPlayer.addNotification("An enemy [$unitName] was spotted $inOrNear our territory", enemyUnitTile.position, Color.RED)
-        }
+        // enemy units ON our territory
+        addEnemyUnitNotification(
+                thisPlayer,
+                enemyUnitsCloseToTerritory.filter { it.getOwner()==thisPlayer },
+                "in"
+        )
+        // enemy units NEAR our territory
+        addEnemyUnitNotification(
+                thisPlayer,
+                enemyUnitsCloseToTerritory.filter { it.getOwner()!=thisPlayer },
+                "near"
+        )
+    }
 
+    private fun addEnemyUnitNotification(thisPlayer: CivilizationInfo, tiles: List<TileInfo>, inOrNear: String) {
+        // don't flood the player with similar messages. instead cycle through units by clicking the message multiple times.
+        if (tiles.size < 3) {
+            for (tile in tiles) {
+                val unitName = tile.militaryUnit!!.name
+                thisPlayer.addNotification("An enemy [$unitName] was spotted $inOrNear our territory", tile.position, Color.RED)
+            }
+        }
+        else {
+            val positions = tiles.map { it.position }
+            thisPlayer.addNotification("[${positions.size}] enemy units were spotted $inOrNear our territory", positions, Color.RED)
+        }
     }
 
     fun placeBarbarianUnit(tileToPlace: TileInfo?) {

--- a/core/src/com/unciv/logic/automation/SpecificUnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/SpecificUnitAutomation.kt
@@ -26,7 +26,7 @@ class SpecificUnitAutomation{
                 val createImprovementAction = UnitActions().getUnitActions(unit, UnCivGame.Current.worldScreen)
                         .firstOrNull { it.name.startsWith("Create") } // could be either fishing boats or oil well
                 if (createImprovementAction != null)
-                    return createImprovementAction.action() // unit is already gone, can't "explore"
+                    return createImprovementAction.action() // unit is already gone, can't "Explore"
             }
         }
         else UnitAutomation().explore(unit, unit.getDistanceToTiles())

--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -301,6 +301,8 @@ class CivilizationInfo {
         units=newList
     }
 
+    fun getIdleUnits() = getCivUnits().filter { it.isIdle() }
+
     fun getDueUnits() = getCivUnits().filter { it.due && it.isIdle() }
 
     fun shouldOpenTechPicker() = tech.freeTechs != 0
@@ -309,11 +311,10 @@ class CivilizationInfo {
     fun shouldGoToDueUnit() = UnCivGame.Current.settings.checkForDueUnits && getDueUnits().isNotEmpty()
 
     fun getNextDueUnit(selectedUnit: MapUnit?): MapUnit? {
+        selectedUnit?.due = false
         val dueUnits = getDueUnits()
         if(dueUnits.isNotEmpty()) {
-            var index = dueUnits.indexOf(selectedUnit)
-            index = ++index % dueUnits.size // for looping
-            val unit = dueUnits[index]
+            val unit = dueUnits[0]
             unit.due = false
             return unit
         }

--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -501,8 +501,13 @@ class CivilizationInfo {
     }
 
     fun addNotification(text: String, location: Vector2?,color: Color) {
+        val locations = if(location!=null) listOf(location) else emptyList()
+        addNotification(text, locations, color)
+    }
+
+    fun addNotification(text: String, locations: List<Vector2>, color: Color) {
         if(playerType==PlayerType.AI) return // no point in lengthening the saved game info if no one will read it
-        notifications.add(Notification(text, location,color))
+        notifications.add(Notification(text, locations,color))
     }
 
     fun addGreatPerson(greatPerson: String, city:CityInfo = cities.random()) {

--- a/core/src/com/unciv/logic/civilization/Notification.kt
+++ b/core/src/com/unciv/logic/civilization/Notification.kt
@@ -5,14 +5,14 @@ import com.badlogic.gdx.math.Vector2
 
 class Notification {
     var text: String = ""
-    var location: Vector2? = null
-    var color:Color = Color.BLACK
+    var locations: List<Vector2> = listOf()
+    var color: Color = Color.BLACK
 
     internal constructor() // Needed for json deserialization
 
-    constructor(text: String, location: Vector2?,color: Color) {
+    constructor(text: String, location: List<Vector2> = listOf(), color: Color) {
         this.text = text
-        this.location = location
-        this.color=color
+        this.locations = location
+        this.color = color
     }
 }

--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -117,7 +117,7 @@ class MapUnit {
     }
 
     fun isFortified(): Boolean {
-        return action!=null && action!!.startsWith("Fortify")
+        return action?.startsWith("Fortify") == true
     }
 
     fun getFortificationTurns(): Int {
@@ -311,7 +311,7 @@ class MapUnit {
 
         if (action == "automation") WorkerAutomation(this).automateWorkerAction()
 
-        if(action == "explore") UnitAutomation().automatedExplore(this)
+        if(action == "Explore") UnitAutomation().automatedExplore(this)
     }
 
     private fun doPostTurnAction() {

--- a/core/src/com/unciv/ui/worldscreen/NotificationsScroll.kt
+++ b/core/src/com/unciv/ui/worldscreen/NotificationsScroll.kt
@@ -33,8 +33,11 @@ class NotificationsScroll(internal val worldScreen: WorldScreen) : ScrollPane(nu
                 add(listItem).pad(3f)
                 touchable = Touchable.enabled
                 onClick {
-                    if (notification.location != null)
-                        worldScreen.tileMapHolder.setCenterPosition(notification.location!!)
+                    if (notification.locations.isNotEmpty()) {
+                        var index = notification.locations.indexOf(worldScreen.tileMapHolder.selectedTile?.position)
+                        index = ++index % notification.locations.size // cycle through locations
+                        worldScreen.tileMapHolder.setCenterPosition(notification.locations[index])
+                    }
                 }
             }
 

--- a/core/src/com/unciv/ui/worldscreen/NotificationsScroll.kt
+++ b/core/src/com/unciv/ui/worldscreen/NotificationsScroll.kt
@@ -1,10 +1,10 @@
 package com.unciv.ui.worldscreen
 
 import com.badlogic.gdx.graphics.Color
+import com.badlogic.gdx.scenes.scene2d.Touchable
 import com.badlogic.gdx.scenes.scene2d.ui.ScrollPane
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.unciv.logic.civilization.Notification
-import com.unciv.models.gamebasics.tr
 import com.unciv.ui.utils.*
 import kotlin.math.min
 
@@ -12,7 +12,8 @@ class NotificationsScroll(internal val worldScreen: WorldScreen) : ScrollPane(nu
     private var notificationsTable = Table()
 
     init {
-        widget = notificationsTable
+        actor = notificationsTable.right()
+        touchable = Touchable.childrenOnly
     }
 
     internal fun update(notifications: MutableList<Notification>) {
@@ -20,21 +21,24 @@ class NotificationsScroll(internal val worldScreen: WorldScreen) : ScrollPane(nu
         for (notification in notifications.toList()) { // tolist to avoid concurrecy problems
             val label = notification.text.toLabel().setFontColor(Color.BLACK)
                     .setFontSize(14)
-            val minitable = Table()
+            val listItem = Table()
 
-            minitable.add(ImageGetter.getCircle()
+            listItem.add(ImageGetter.getCircle()
                     .apply { color=notification.color }).size(10f).pad(5f)
-            minitable.background(ImageGetter.getDrawable("OtherIcons/civTableBackground.png"))
-            minitable.add(label).pad(5f).padRight(10f)
+            listItem.background(ImageGetter.getDrawable("OtherIcons/civTableBackground.png"))
+            listItem.add(label).pad(5f).padRight(10f)
 
-            if (notification.location != null) {
-                minitable.onClick {
-                    worldScreen.tileMapHolder.setCenterPosition(notification.location!!)
+            // using a larger click area to avoid miss-clicking in between the messages on the map
+            val clickArea = Table().apply {
+                add(listItem).pad(3f)
+                touchable = Touchable.enabled
+                onClick {
+                    if (notification.location != null)
+                        worldScreen.tileMapHolder.setCenterPosition(notification.location!!)
                 }
             }
 
-            notificationsTable.add(minitable).pad(3f)
-            notificationsTable.row()
+            notificationsTable.add(clickArea).right().row()
         }
         notificationsTable.pack()
         pack()

--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -49,7 +49,8 @@ class WorldScreen : CameraStageBaseScreen() {
         topBar.width = stage.width
 
         notificationsScroll = NotificationsScroll(this)
-        notificationsScroll.width = stage.width/3
+        // notifications are right-aligned, they take up only as much space as necessary.
+        notificationsScroll.width = stage.width/2
 
         minimapWrapper.x = stage.width - minimapWrapper.width
 
@@ -150,7 +151,7 @@ class WorldScreen : CameraStageBaseScreen() {
         minimapWrapper.y = bottomBar.height // couldn't be bothered to create a separate val for minimap wrapper
 
         unitActionsTable.update(bottomBar.unitTable.selectedUnit)
-        unitActionsTable.y = bottomBar.height
+        unitActionsTable.y = bottomBar.unitTable.height
 
         // if we use the clone, then when we update viewable tiles
         // it doesn't update the explored tiles of the civ... need to think about that harder
@@ -159,7 +160,6 @@ class WorldScreen : CameraStageBaseScreen() {
 
         topBar.update(cloneCivilization)
         notificationsScroll.update(currentPlayerCiv.notifications)
-        notificationsScroll.width = stage.width/3
         notificationsScroll.setPosition(stage.width - notificationsScroll.width - 5f,
                 nextTurnButton.y - notificationsScroll.height - 5f)
 

--- a/core/src/com/unciv/ui/worldscreen/bottombar/BattleTable.kt
+++ b/core/src/com/unciv/ui/worldscreen/bottombar/BattleTable.kt
@@ -1,6 +1,7 @@
 package com.unciv.ui.worldscreen.bottombar
 
 import com.badlogic.gdx.graphics.Color
+import com.badlogic.gdx.scenes.scene2d.Touchable
 import com.badlogic.gdx.scenes.scene2d.actions.Actions
 import com.badlogic.gdx.scenes.scene2d.actions.RepeatAction
 import com.badlogic.gdx.scenes.scene2d.ui.Image
@@ -24,6 +25,7 @@ class BattleTable(val worldScreen: WorldScreen): Table() {
         skin = CameraStageBaseScreen.skin
         background = ImageGetter.getBackground(ImageGetter.getBlue())
         pad(5f)
+        touchable = Touchable.enabled
     }
 
     fun hide(){

--- a/core/src/com/unciv/ui/worldscreen/unit/UnitActionsTable.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitActionsTable.kt
@@ -68,7 +68,9 @@ class UnitActionsTable(val worldScreen: WorldScreen) : Table(){
     private fun getUnitActionButton(unitAction: UnitAction): Button {
         val actionButton = Button(CameraStageBaseScreen.skin)
         actionButton.add(getIconForUnitAction(unitAction.name)).size(20f).pad(5f)
-        actionButton.add(Label(unitAction.name.tr(),CameraStageBaseScreen.skin).setFontColor(Color.WHITE))
+        actionButton.add(
+                Label(unitAction.title,CameraStageBaseScreen.skin)
+                        .setFontColor(if(unitAction.currentAction) Color.YELLOW else Color.WHITE))
                 .pad(5f)
         actionButton.pack()
         actionButton.onClick(unitAction.sound) { unitAction.action(); UnCivGame.Current.worldScreen.shouldUpdate=true }

--- a/core/src/com/unciv/ui/worldscreen/unit/UnitActionsTable.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitActionsTable.kt
@@ -2,6 +2,7 @@ package com.unciv.ui.worldscreen.unit
 
 import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.scenes.scene2d.Actor
+import com.badlogic.gdx.scenes.scene2d.Touchable
 import com.badlogic.gdx.scenes.scene2d.ui.Button
 import com.badlogic.gdx.scenes.scene2d.ui.Label
 import com.badlogic.gdx.scenes.scene2d.ui.Table
@@ -14,6 +15,10 @@ import com.unciv.ui.worldscreen.WorldScreen
 
 class UnitActionsTable(val worldScreen: WorldScreen) : Table(){
 
+    init {
+        touchable = Touchable.enabled
+    }
+    
     fun getIconForUnitAction(unitAction:String): Actor {
         if(unitAction.startsWith("Upgrade to")){
             // Regexplaination: start with a [, take as many non-] chars as you can, until you reach a ].

--- a/core/src/com/unciv/ui/worldscreen/unit/UnitTable.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitTable.kt
@@ -92,7 +92,7 @@ class UnitTable(val worldScreen: WorldScreen) : Table(){
             }
         }
 
-        if(prevIdleUnitButton.getTilesWithIdleUnits().isNotEmpty()) { // more efficient to do this check once for both
+        if(prevIdleUnitButton.hasIdleUnits()) { // more efficient to do this check once for both
             prevIdleUnitButton.enable()
             nextIdleUnitButton.enable()
         }

--- a/core/src/com/unciv/ui/worldscreen/unit/UnitTable.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitTable.kt
@@ -128,13 +128,6 @@ class UnitTable(val worldScreen: WorldScreen) : Table(){
                 unitDescriptionTable.add(unit.promotions.XP.toString()+"/"+unit.promotions.xpForNextPromotion())
             }
 
-            if(unit.isFortified() && unit.getFortificationTurns()>0) {
-                unitDescriptionTable.row()
-                unitDescriptionTable.add("Fortification")
-                unitDescriptionTable.add(""+unit.getFortificationTurns() * 20 + "%")
-            }
-            unitDescriptionTable.pack()
-
             if(unit.promotions.promotions.size != promotionsTable.children.size) // The unit has been promoted! Reload promotions!
                 selectedUnitHasChanged = true
         }
@@ -159,6 +152,7 @@ class UnitTable(val worldScreen: WorldScreen) : Table(){
             unitNameLabel.setText("")
             unitDescriptionTable.clear()
             unitIconHolder.clear()
+            promotionsTable.clear()
         }
 
         if(!selectedUnitHasChanged) return

--- a/core/src/com/unciv/ui/worldscreen/unit/UnitTable.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitTable.kt
@@ -34,7 +34,7 @@ class UnitTable(val worldScreen: WorldScreen) : Table(){
 
     init {
         pad(5f)
-
+        touchable = Touchable.enabled
         background = ImageGetter.getBackground(ImageGetter.getBlue().lerp(Color.BLACK, 0.5f))
 
         add(VerticalGroup().apply {


### PR DESCRIPTION
I worked my way through with some UI improvements:

- Notification window
  - the messages are right-aligned to keep as much of the map usable as possible
  - you can click through the scrollview on the map
  - you can't click *in between the messages* on the map. this avoids accidental actions
  - the message type "enemy spottet" is collapsed to a single message when occouring more than 3 times. Clicking on that message multiple times will cycle through the different locations
- the UnitTable and BattleTable are now touchable. That way you can't click "through" them on the map.
- the "idle units buttons" not only select the correct tile, but also the correct unit, which also gets due=false set.
- the unit action buttons now also reflect what a unit is actually doing, which wasn't always clear before
  - if it's sleeping, it will highlight that button
  - if it's setting up or set up (eg catapult), the set up button will be highlighted
  - if it's fortified/fortifying the button will be highlighted showing eg "Fortification 20%"
    - this also solves a layout problem on android phones where this information won't fit into the UnitTable

also a few minor bugs were fixed