### PR TITLE
Single tap pickers for improvements and promotion

### DIFF
--- a/android/assets/jsons/Translations/Other.json
+++ b/android/assets/jsons/Translations/Other.json
@@ -799,7 +799,7 @@
 		Portuguese:"recursos e melhorias"
 		Japanese:"リソースと改善"
 	}
-	
+
 	"Check for idle units":{
 		Italian:"Controlla unità inutilizzate"
 		Simplified_Chinese:"查看未行动单位"
@@ -869,7 +869,7 @@
 		Dutch:"Voor [amount] gold kopen"
 		Spanish:"Comprar por [amount] de oro"
 		Simplified_Chinese:"购买花费[amount]金钱"
-		Portuguese:"Comprar por [amount] ouro" 
+		Portuguese:"Comprar por [amount] ouro"
 		Japanese:"[amount]ゴールドで購入する"
 	}
 	
@@ -930,6 +930,10 @@
 		Simplified_Chinese:"选择设施"
 		French:"Choisir une amélioration"
 		Portuguese:"Escolha uma melhoria"
+	}
+
+	"Pick now!": {
+		German: "Jetzt wählen!"
 	}
 
 	"Build [building]":{ // eg Build Granary
@@ -1480,7 +1484,7 @@
 		French:"[percentage] de défense"
 	} 
 	
-	
+
 ///////// Unit uniques
 
 	//  - - - NOTE: These need to be moved to the "Units,Promotions" translation file, in their respective places! - - - 
@@ -1584,7 +1588,7 @@
 
 	// for unit action button
 
-	"Discover Technology":{ 
+	"Discover Technology":{
 		Romanian:"Descoperă tehnologie"
 		Spanish:"Descubrir Tecnologia"
 		Simplified_Chinese:"发现科技"
@@ -1655,7 +1659,7 @@
 		Simplified_Chinese:"[policyBranch]政策分支解锁!"
 		Portuguese:"[policyBranch] foi desbloqueado(a)"
 		German:"[policyBranch] Grundsatzzweig wurde freigeschaltet"
-	} 
+	}
 	
 ////// Trade	
 
@@ -2085,7 +2089,7 @@
 	"+1 Gold from each Trade Route, Oil resources provide double quantity":{
 		Italian:"+1 Oro da ogni rotta commerciale, e doppia quantità da ogni risorsa di Petrolio"
 		Simplified_Chinese:"每条贸易路线+1金钱，石油储量加倍"
-		Portuguese:"1 ouro adicional de rotas comerciais e recursos de petróleo geram o dobro" // óleo could mean normal kitchen oil and even fuel from sugar cane 
+		Portuguese:"1 ouro adicional de rotas comerciais e recursos de petróleo geram o dobro" // óleo could mean normal kitchen oil and even fuel from sugar cane
 	}
 	
 	"America":{
@@ -2267,7 +2271,7 @@
 		Italian:"+50% durata delle Età dell'Oro, durante le quali le unità ricevono +1 Movimento e +10% Forza."
 		Portuguese:"Idades douradas duram 50% mais, unidades recebem 1 movimento a mais e um bonus de +10% em força de combate."
 	}
-	
+
 	*/
 	
 	"Uniques":{ // unit uniques, displayed on the new game screen when choosing a civ
@@ -2608,7 +2612,7 @@
 		Simplified_Chinese:"我们的关系："
 		Portuguese:"Nossas relações"
 	}
-	
+
 	"We have encountered the City-State of [name]!":{ // e.g. the Cultured city state of Vienna
 
 		Italian:"Abbiamo incontrato la Citta-Stato di [name]!"
@@ -2753,11 +2757,11 @@
 		Simplified_Chinese:"开放的边界促进了彼此的了解，让我们的人民心心相通！"
 		Portuguese:"Nossa fronteiras abertas nos fizeram mais próximos."
 	}
-	
+
 
 
 	"Your so-called 'friendship' is worth nothing.":{ // When we have a decleration of friendship to someone and we declare war on them
-    Italian:"La tua cosiddetta 'amicizia' non vale nulla!"  
+    Italian:"La tua cosiddetta 'amicizia' non vale nulla!"
 		Portuguese:"Sua chamada 'amizade' não vale nada."
 	}
 
@@ -2859,7 +2863,7 @@
 		Portuguese:"De outros"
 		Simplified_Chinese:"其他"
 		Portuguese:"Outros"
-	} 
+	}
 
 	"Population":{	
 		Italian:"Popolazione"
@@ -2982,7 +2986,7 @@
 		German:"Nächstgelegene Stadt"
 	}
 
-	"Go to unit":{	
+	"Go to unit":{
 		Italian:"Vai a unità"
 		Simplified_Chinese:"跳转至所在地图位置"
 		Portuguese:"Ir para a unidade"
@@ -3102,8 +3106,8 @@
 		French:"Détruiser [civName]"
 		Russian:"Уничтожить [civName]"
 		Simplified_Chinese:"摧毁[civName]文明"
-		Portuguese:"Destruir [civName]" //what's the context? as in it being a question, or a pre-requisite for conquest victory? 
-	}	
+		Portuguese:"Destruir [civName]" //what's the context? as in it being a question, or a pre-requisite for conquest victory?
+	}
 	
 	
 ////// Civilopedia texts

--- a/core/src/com/unciv/ui/pickerscreens/ImprovementPickerScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/ImprovementPickerScreen.kt
@@ -1,17 +1,14 @@
 package com.unciv.ui.pickerscreens
 
 import com.badlogic.gdx.graphics.Color
-import com.badlogic.gdx.scenes.scene2d.ui.Button
-import com.badlogic.gdx.scenes.scene2d.ui.Label
-import com.badlogic.gdx.scenes.scene2d.ui.Table
-import com.badlogic.gdx.scenes.scene2d.ui.VerticalGroup
+import com.badlogic.gdx.scenes.scene2d.Touchable
+import com.badlogic.gdx.scenes.scene2d.ui.*
+import com.badlogic.gdx.utils.Align
 import com.unciv.logic.map.TileInfo
 import com.unciv.models.gamebasics.GameBasics
 import com.unciv.models.gamebasics.tile.TileImprovement
 import com.unciv.models.gamebasics.tr
-import com.unciv.ui.utils.ImageGetter
-import com.unciv.ui.utils.onClick
-import com.unciv.ui.utils.setFontColor
+import com.unciv.ui.utils.*
 
 class ImprovementPickerScreen(tileInfo: TileInfo) : PickerScreen() {
     private var selectedImprovement: TileImprovement? = null
@@ -34,36 +31,45 @@ class ImprovementPickerScreen(tileInfo: TileInfo) : PickerScreen() {
             accept(selectedImprovement)
         }
 
-        val regularImprovements = Table()
+        val regularImprovements = VerticalGroup()
+        regularImprovements.space(10f)
 
         for (improvement in GameBasics.TileImprovements.values) {
             if (!tileInfo.canBuildImprovement(improvement, currentPlayerCiv)) continue
             if(improvement.name == tileInfo.improvement) continue
             if(improvement.name==tileInfo.improvementInProgress) continue
 
-            val improvementButton = Button(skin)
+            val group = Table()
 
-            if(improvement.name.startsWith("Remove"))
-                improvementButton.add(ImageGetter.getImage("OtherIcons/Stop.png")).size(30f).pad(10f)
-            else improvementButton.add(ImageGetter.getImprovementIcon(improvement.name,30f)).pad(10f)
+            val image = if(improvement.name.startsWith("Remove"))
+                ImageGetter.getImage("OtherIcons/Stop.png")
+            else
+                ImageGetter.getImprovementIcon(improvement.name,30f)
 
-            improvementButton.add(Label(improvement.name.tr() + " - " + improvement.getTurnsToBuild(currentPlayerCiv) + " {turns}".tr(),skin)
+            group.add(image).size(30f).pad(10f)
+
+            group.add(Label(improvement.name.tr() + " - " + improvement.getTurnsToBuild(currentPlayerCiv) + " {turns}".tr(),skin)
                     .setFontColor(Color.WHITE)).pad(10f)
 
-            improvementButton.onClick {
+            group.touchable = Touchable.enabled
+            group.onClick {
                 accept(improvement)
             }
-            regularImprovements.add(improvementButton)
 
-            val helpButton = Button(skin)
-            helpButton.add(Label("?", skin)).pad(15f)
-
-            helpButton.onClick {
+            val help = Label("?", skin)
+            help.setAlignment(Align.center)
+            help.touchable = Touchable.enabled
+            help.onClick {
                 selectedImprovement = improvement
                 pick(improvement.name)
                 descriptionLabel.setText(improvement.description)
             }
-            regularImprovements.add(helpButton).pad(5f).row()
+
+            val improvementButton = Button(skin)
+            improvementButton.add(group).fillY()
+            improvementButton.addSeparatorVertical()
+            improvementButton.add(help).width(40f).fillY()
+            regularImprovements.addActor(improvementButton)
 
         }
         topTable.add(regularImprovements)

--- a/core/src/com/unciv/ui/pickerscreens/ImprovementPickerScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/ImprovementPickerScreen.kt
@@ -3,6 +3,7 @@ package com.unciv.ui.pickerscreens
 import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.scenes.scene2d.ui.Button
 import com.badlogic.gdx.scenes.scene2d.ui.Label
+import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.scenes.scene2d.ui.VerticalGroup
 import com.unciv.logic.map.TileInfo
 import com.unciv.models.gamebasics.GameBasics
@@ -19,16 +20,21 @@ class ImprovementPickerScreen(tileInfo: TileInfo) : PickerScreen() {
         val currentPlayerCiv = game.gameInfo.getCurrentPlayerCivilization()
         setDefaultCloseAction()
 
-        rightSideButton.setText("Pick improvement".tr())
-        rightSideButton.onClick {
-            tileInfo.startWorkingOnImprovement(selectedImprovement!!, currentPlayerCiv)
-            if(tileInfo.civilianUnit!=null) tileInfo.civilianUnit!!.action=null // this is to "wake up" the worker if it's sleeping
-            game.setWorldScreen()
-            dispose()
+        fun accept(improvement: TileImprovement?) {
+            if (improvement != null) {
+                tileInfo.startWorkingOnImprovement(improvement, currentPlayerCiv)
+                if (tileInfo.civilianUnit != null) tileInfo.civilianUnit!!.action = null // this is to "wake up" the worker if it's sleeping
+                game.setWorldScreen()
+                dispose()
+            }
         }
 
-        val regularImprovements = VerticalGroup()
-        regularImprovements.space(10f)
+        rightSideButton.setText("Pick improvement".tr())
+        rightSideButton.onClick {
+            accept(selectedImprovement)
+        }
+
+        val regularImprovements = Table()
 
         for (improvement in GameBasics.TileImprovements.values) {
             if (!tileInfo.canBuildImprovement(improvement, currentPlayerCiv)) continue
@@ -45,11 +51,20 @@ class ImprovementPickerScreen(tileInfo: TileInfo) : PickerScreen() {
                     .setFontColor(Color.WHITE)).pad(10f)
 
             improvementButton.onClick {
-                    selectedImprovement = improvement
-                    pick(improvement.name)
-                    descriptionLabel.setText(improvement.description)
-                }
-            regularImprovements.addActor(improvementButton)
+                accept(improvement)
+            }
+            regularImprovements.add(improvementButton)
+
+            val helpButton = Button(skin)
+            helpButton.add(Label("?", skin)).pad(15f)
+
+            helpButton.onClick {
+                selectedImprovement = improvement
+                pick(improvement.name)
+                descriptionLabel.setText(improvement.description)
+            }
+            regularImprovements.add(helpButton).pad(5f).row()
+
         }
         topTable.add(regularImprovements)
     }

--- a/core/src/com/unciv/ui/pickerscreens/ImprovementPickerScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/ImprovementPickerScreen.kt
@@ -54,22 +54,21 @@ class ImprovementPickerScreen(tileInfo: TileInfo, onAccept: ()->Unit) : PickerSc
 
             group.touchable = Touchable.enabled
             group.onClick {
-                accept(improvement)
-            }
-
-            val help = Label("?", skin)
-            help.setAlignment(Align.center)
-            help.touchable = Touchable.enabled
-            help.onClick {
                 selectedImprovement = improvement
                 pick(improvement.name)
                 descriptionLabel.setText(improvement.description)
             }
 
+            val pickNow = Label("Pick now!", skin)
+            pickNow.touchable = Touchable.enabled
+            pickNow.onClick {
+                accept(improvement)
+            }
+
             val improvementButton = Button(skin)
-            improvementButton.add(group).fillY()
+            improvementButton.add(group).padRight(10f).fillY()
             improvementButton.addSeparatorVertical()
-            improvementButton.add(help).width(40f).fillY()
+            improvementButton.add(pickNow).padLeft(10f).fill()
             regularImprovements.addActor(improvementButton)
 
         }

--- a/core/src/com/unciv/ui/pickerscreens/PickerScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/PickerScreen.kt
@@ -17,20 +17,19 @@ open class PickerScreen : CameraStageBaseScreen() {
     internal var splitPane: SplitPane
 
     init {
-        bottomTable.add(closeButton).width(stage.width / 4)
+        bottomTable.add(closeButton).pad(10f)
 
         descriptionLabel = "".toLabel()
         descriptionLabel.setWrap(true)
         val labelScroll = ScrollPane(descriptionLabel)
-        bottomTable.add(labelScroll).pad(5f).width(stage.width / 2)
+        bottomTable.add(labelScroll).pad(5f).fill().expand()
 
         rightSideButton = TextButton("", skin)
         rightSideButton.disable()
         rightSideGroup.addActor(rightSideButton)
 
-        bottomTable.add(rightSideGroup).width(stage.width / 4)
+        bottomTable.add(rightSideGroup).pad(10f).right()
         bottomTable.height = stage.height * (1 - screenSplit)
-        bottomTable.align(Align.center)
 
         topTable = Table()
         val scrollPane = ScrollPane(topTable)

--- a/core/src/com/unciv/ui/pickerscreens/PolicyPickerScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/PolicyPickerScreen.kt
@@ -33,7 +33,13 @@ class PolicyPickerScreen(internal val civInfo: CivilizationInfo) : PickerScreen(
             civInfo.policies.adopt(pickedPolicy!!)
 
             // If we've moved to another screen in the meantime (great person pick, victory screen) ignore this
-            if(game.screen is PolicyPickerScreen) game.screen = PolicyPickerScreen(civInfo)
+            if(game.screen is PolicyPickerScreen){
+                // update policies
+                // game.screen = PolicyPickerScreen(civInfo)
+                game.setWorldScreen()
+                dispose()
+            }
+
         }
 
 

--- a/core/src/com/unciv/ui/pickerscreens/PromotionPickerScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/PromotionPickerScreen.kt
@@ -55,13 +55,6 @@ class PromotionPickerScreen(mapUnit: MapUnit) : PickerScreen() {
 
             group.touchable = Touchable.enabled
             group.onClick {
-                accept(promotion)
-            }
-
-            val help = Label("?", skin)
-            help.touchable = Touchable.enabled
-            help.setAlignment(Align.center)
-            help.onClick {
                 selectedPromotion = promotion
                 rightSideButton.setText(promotion.name.tr())
                 if(isPromotionAvailable && !unitHasPromotion) rightSideButton.enable()
@@ -72,12 +65,19 @@ class PromotionPickerScreen(mapUnit: MapUnit) : PickerScreen() {
 
                 if(promotion.prerequisites.isNotEmpty()) {
                     val prerequisitesString:ArrayList<String> = arrayListOf()
-                   for (i in promotion.prerequisites.filter { promotionsForUnitType.any { promotion ->  promotion.name==it } }){
-                       prerequisitesString.add(i.tr())
-                   }
+                    for (i in promotion.prerequisites.filter { promotionsForUnitType.any { promotion ->  promotion.name==it } }){
+                        prerequisitesString.add(i.tr())
+                    }
                     descriptionText +="\n{Requires}: ".tr()+prerequisitesString.joinToString(" OR ".tr())
                 }
                 descriptionLabel.setText(descriptionText)
+            }
+
+            val pickNow = Label("Pick now!", skin)
+            pickNow.touchable = Touchable.enabled
+            pickNow.setAlignment(Align.center)
+            pickNow.onClick {
+                accept(promotion)
             }
 
 
@@ -86,7 +86,7 @@ class PromotionPickerScreen(mapUnit: MapUnit) : PickerScreen() {
 
             if(isPromotionAvailable) {
                 promotionButton.addSeparatorVertical()
-                promotionButton.add(help).width(40f).fillY()
+                promotionButton.add(pickNow).padLeft(10f).fillY()
             }
             else {
                 group.touchable = Touchable.disabled

--- a/core/src/com/unciv/ui/pickerscreens/PromotionPickerScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/PromotionPickerScreen.kt
@@ -2,6 +2,8 @@ package com.unciv.ui.pickerscreens
 
 import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.scenes.scene2d.ui.Button
+import com.badlogic.gdx.scenes.scene2d.ui.Label
+import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.scenes.scene2d.ui.VerticalGroup
 import com.unciv.UnCivGame
 import com.unciv.logic.map.MapUnit
@@ -18,16 +20,21 @@ class PromotionPickerScreen(mapUnit: MapUnit) : PickerScreen() {
     init {
         onBackButtonClicked { UnCivGame.Current.setWorldScreen() }
         setDefaultCloseAction()
-        rightSideButton.setText("Pick promotion".tr())
-        rightSideButton.onClick("promote") {
-            mapUnit.promotions.addPromotion(selectedPromotion!!.name)
+
+        fun accept(promotion: Promotion?) {
+            mapUnit.promotions.addPromotion(promotion!!.name)
             if(mapUnit.promotions.canBePromoted()) game.screen = PromotionPickerScreen(mapUnit)
             else game.setWorldScreen()
             dispose()
         }
 
-        val availablePromotionsGroup = VerticalGroup()
-        availablePromotionsGroup.space(10f)
+        rightSideButton.setText("Pick promotion".tr())
+        rightSideButton.onClick("promote") {
+          accept(selectedPromotion)
+        }
+
+        val availablePromotionsGroup = Table()
+
         val unitType = mapUnit.type
         val promotionsForUnitType = GameBasics.UnitPromotions.values.filter { it.unitTypes.contains(unitType.toString()) }
         val unitAvailablePromotions = mapUnit.promotions.getAvailablePromotions()
@@ -38,13 +45,23 @@ class PromotionPickerScreen(mapUnit: MapUnit) : PickerScreen() {
             val unitHasPromotion = mapUnit.promotions.promotions.contains(promotion.name)
             val promotionButton = Button(skin)
 
-            if(!isPromotionAvailable) promotionButton.color = Color.GRAY
+            if(!isPromotionAvailable) promotionButton.disable()
             promotionButton.add(ImageGetter.getPromotionIcon(promotion.name)).size(30f).pad(10f)
             promotionButton.add(promotion.name.toLabel()
                     .setFontColor(Color.WHITE)).pad(10f)
             if(unitHasPromotion) promotionButton.color = Color.GREEN
 
             promotionButton.onClick {
+                accept(promotion)
+            }
+
+            availablePromotionsGroup.add(promotionButton)
+
+
+            val helpButton = Button(skin)
+            helpButton.add(Label("?", skin)).pad(15f)
+
+            helpButton.onClick {
                 selectedPromotion = promotion
                 rightSideButton.setText(promotion.name.tr())
                 if(isPromotionAvailable && !unitHasPromotion) rightSideButton.enable()
@@ -62,7 +79,7 @@ class PromotionPickerScreen(mapUnit: MapUnit) : PickerScreen() {
                 }
                 descriptionLabel.setText(descriptionText)
             }
-            availablePromotionsGroup.addActor(promotionButton)
+            availablePromotionsGroup.add(helpButton).pad(5f).row()
         }
         topTable.add(availablePromotionsGroup)
     }

--- a/core/src/com/unciv/ui/pickerscreens/PromotionPickerScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/PromotionPickerScreen.kt
@@ -1,10 +1,12 @@
 package com.unciv.ui.pickerscreens
 
 import com.badlogic.gdx.graphics.Color
+import com.badlogic.gdx.scenes.scene2d.Touchable
 import com.badlogic.gdx.scenes.scene2d.ui.Button
 import com.badlogic.gdx.scenes.scene2d.ui.Label
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.scenes.scene2d.ui.VerticalGroup
+import com.badlogic.gdx.utils.Align
 import com.unciv.UnCivGame
 import com.unciv.logic.map.MapUnit
 import com.unciv.models.gamebasics.GameBasics
@@ -33,7 +35,8 @@ class PromotionPickerScreen(mapUnit: MapUnit) : PickerScreen() {
           accept(selectedPromotion)
         }
 
-        val availablePromotionsGroup = Table()
+        val availablePromotionsGroup = VerticalGroup()
+        availablePromotionsGroup.space(10f)
 
         val unitType = mapUnit.type
         val promotionsForUnitType = GameBasics.UnitPromotions.values.filter { it.unitTypes.contains(unitType.toString()) }
@@ -43,25 +46,22 @@ class PromotionPickerScreen(mapUnit: MapUnit) : PickerScreen() {
             if(promotion.name=="Heal Instantly" && mapUnit.health==100) continue
             val isPromotionAvailable = promotion in unitAvailablePromotions
             val unitHasPromotion = mapUnit.promotions.promotions.contains(promotion.name)
-            val promotionButton = Button(skin)
 
-            if(!isPromotionAvailable) promotionButton.disable()
-            promotionButton.add(ImageGetter.getPromotionIcon(promotion.name)).size(30f).pad(10f)
-            promotionButton.add(promotion.name.toLabel()
-                    .setFontColor(Color.WHITE)).pad(10f)
-            if(unitHasPromotion) promotionButton.color = Color.GREEN
+            val group = Table()
 
-            promotionButton.onClick {
+            group.add(ImageGetter.getPromotionIcon(promotion.name)).size(30f).pad(10f)
+            group.add(promotion.name.toLabel()
+                    .setFontColor(Color.WHITE)).pad(10f).padRight(20f)
+
+            group.touchable = Touchable.enabled
+            group.onClick {
                 accept(promotion)
             }
 
-            availablePromotionsGroup.add(promotionButton)
-
-
-            val helpButton = Button(skin)
-            helpButton.add(Label("?", skin)).pad(15f)
-
-            helpButton.onClick {
+            val help = Label("?", skin)
+            help.touchable = Touchable.enabled
+            help.setAlignment(Align.center)
+            help.onClick {
                 selectedPromotion = promotion
                 rightSideButton.setText(promotion.name.tr())
                 if(isPromotionAvailable && !unitHasPromotion) rightSideButton.enable()
@@ -79,7 +79,23 @@ class PromotionPickerScreen(mapUnit: MapUnit) : PickerScreen() {
                 }
                 descriptionLabel.setText(descriptionText)
             }
-            availablePromotionsGroup.add(helpButton).pad(5f).row()
+
+
+            val promotionButton = Button(skin)
+            promotionButton.add(group).fillY()
+
+            if(isPromotionAvailable) {
+                promotionButton.addSeparatorVertical()
+                promotionButton.add(help).width(40f).fillY()
+            }
+            else {
+                group.touchable = Touchable.disabled
+                promotionButton.disable()
+            }
+            if(unitHasPromotion) promotionButton.color = Color.GREEN
+            availablePromotionsGroup.addActor(promotionButton)
+
+
         }
         topTable.add(availablePromotionsGroup)
     }

--- a/core/src/com/unciv/ui/utils/CameraStageBaseScreen.kt
+++ b/core/src/com/unciv/ui/utils/CameraStageBaseScreen.kt
@@ -160,6 +160,12 @@ fun Table.addSeparator(): Cell<Image> {
     return cell
 }
 
+fun Table.addSeparatorVertical(): Cell<Image> {
+    val image = ImageGetter.getWhiteDot()
+    val cell = add(image).width(2f).fillY()
+    return cell
+}
+
 /**
  * Solves concurrent modification problems - everyone who had a reference to the previous arrayList can keep using it because it hasn't changed
  */


### PR DESCRIPTION
The idea here is to let the user choose a worker's improvement and a military unit's promotion _in a single tap_. To make this work in the UI, the choice buttons are now split with a question mark to the right. That way the user has the choice to read information about the item or choose to take it right away.