### PR TITLE
improved CityButton

### DIFF
--- a/core/src/com/unciv/ui/tilegroups/CityButton.kt
+++ b/core/src/com/unciv/ui/tilegroups/CityButton.kt
@@ -77,7 +77,11 @@ class CityButton(val city: CityInfo, internal val tileGroup: WorldTileGroup, ski
         }
 
         // when deselected, move city button to its original position
-        if (tileGroup.worldScreen.bottomBar.unitTable.selectedCity == null && isButtonMoved) {
+        val unitTable = tileGroup.worldScreen.bottomBar.unitTable
+        if (isButtonMoved
+                && unitTable.selectedCity == null
+                && unitTable.selectedUnit?.currentTile != city.ccenterTile) {
+
             isButtonMoved = false
             val floatAction = object : FloatAction(0f, 1f, 0.4f) {
                 override fun update(percent: Float) {

--- a/core/src/com/unciv/ui/tilegroups/WorldTileGroup.kt
+++ b/core/src/com/unciv/ui/tilegroups/WorldTileGroup.kt
@@ -71,7 +71,6 @@ class WorldTileGroup(internal val worldScreen: WorldScreen, tileInfo: TileInfo) 
             }
 
             cityButton!!.update(viewable)
-            cityButton!!.center(this)
         }
     }
 

--- a/core/src/com/unciv/ui/worldscreen/TileMapHolder.kt
+++ b/core/src/com/unciv/ui/worldscreen/TileMapHolder.kt
@@ -1,6 +1,7 @@
 package com.unciv.ui.worldscreen
 
 import com.badlogic.gdx.graphics.Color
+import com.badlogic.gdx.math.Interpolation
 import com.badlogic.gdx.math.Vector2
 import com.badlogic.gdx.scenes.scene2d.Actor
 import com.badlogic.gdx.scenes.scene2d.Group
@@ -264,13 +265,15 @@ class TileMapHolder(internal val worldScreen: WorldScreen, internal val tileMap:
             updateVisualScroll()
         }
         else {
-            addAction(object : FloatAction(0f, 1f, 0.4f) {
+            val action = object : FloatAction(0f, 1f, 0.4f) {
                 override fun update(percent: Float) {
                     scrollX = finalScrollX * percent + originalScrollX * (1 - percent)
                     scrollY = finalScrollY * percent + originalScrollY * (1 - percent)
                     updateVisualScroll()
                 }
-            })
+            }
+            action.interpolation = Interpolation.sine
+            addAction(action)
         }
 
         worldScreen.shouldUpdate=true


### PR DESCRIPTION
now this is something cool and I'm pretty sure you guys will like it =)

When clicking on the city button, it will gently move out of your way, so you can
- see the city tile :)
- select units that sit on the city tile
- click the city button again to enter the city (as before)

Whenever you deselect the city, the button gently floats back to it's place.

Furthermore, it's possible to enter the city with a single click by clicking the button on the far left or right (outside the city name).