### PR TITLE
CityButton: render units in front

### DIFF
--- a/core/src/com/unciv/ui/tilegroups/CityButton.kt
+++ b/core/src/com/unciv/ui/tilegroups/CityButton.kt
@@ -41,16 +41,16 @@ class CityButton(val city: CityInfo, internal val tileGroup: WorldTileGroup, ski
             touchable = Touchable.enabled
             label.touchable = Touchable.enabled
 
-            // clicking on the button swings the button a little down to allow selection of units there.
+            // clicking on the label swings the button a little down to allow selection of units there.
             // this also allows to target selected units to move to the city tile from elsewhere.
             // second tap on the button will go to the city screen
-            onClick {
-                if (!isButtonMoved) {
+            onClickEvent { _, x, y ->
+                if (hit(x, y, true) == label) {
                     moveButtonDown()
-                    if (unitTable.selectedUnit == null || unitTable.selectedUnit!!.currentMovement == 0f)
+                    if (unitTable.selectedUnit == null || unitTable.selectedUnit!!.currentMovement==0f)
                         tileGroup.selectCity(city)
-
                 } else {
+                    // clicking anywhere else on the button opens the city screen immediately
                     UnCivGame.Current.screen = CityScreen(city)
                 }
             }

--- a/core/src/com/unciv/ui/tilegroups/CityButton.kt
+++ b/core/src/com/unciv/ui/tilegroups/CityButton.kt
@@ -41,17 +41,16 @@ class CityButton(val city: CityInfo, internal val tileGroup: WorldTileGroup, ski
             touchable = Touchable.enabled
             label.touchable = Touchable.enabled
 
-            // clicking on the label swings the button a little down to allow selection of units there.
+            // clicking swings the button a little down to allow selection of units there.
             // this also allows to target selected units to move to the city tile from elsewhere.
             // second tap on the button will go to the city screen
-            onClickEvent { _, x, y ->
-                if (hit(x, y, true) == label) {
+            onClick {
+                if (isButtonMoved) {
+                    UnCivGame.Current.screen = CityScreen(city)
+                } else {
                     moveButtonDown()
                     if (unitTable.selectedUnit == null || unitTable.selectedUnit!!.currentMovement==0f)
                         tileGroup.selectCity(city)
-                } else {
-                    // clicking anywhere else on the button opens the city screen immediately
-                    UnCivGame.Current.screen = CityScreen(city)
                 }
             }
 

--- a/core/src/com/unciv/ui/worldscreen/TileGroupMap.kt
+++ b/core/src/com/unciv/ui/worldscreen/TileGroupMap.kt
@@ -48,8 +48,8 @@ class TileGroupMap<T: TileGroup>(val tileGroups:Collection<T>, padding:Float): G
         for(group in miscLayers) addActor(group)
         for(group in circleCrosshairFogLayers) addActor(group)
         for(group in tileGroups) addActor(group) // The above layers are for the visual layers, this is for the clickability
-        for(group in unitLayers) addActor(group) // Aaand units above everything else.
         for(group in cityButtonLayers) addActor(group) // city buttons clickability
+        for(group in unitLayers) addActor(group) // Aaand units above everything else.
 
 
         // there are tiles "below the zero",

--- a/core/src/com/unciv/ui/worldscreen/unit/UnitTable.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitTable.kt
@@ -181,18 +181,14 @@ class UnitTable(val worldScreen: WorldScreen) : Table(){
 
     fun citySelected(cityInfo: CityInfo) : Boolean {
         if (cityInfo == selectedCity) return false
-        lastSelectedCityButton = true
         selectedCity = cityInfo
         selectedUnit = null
         selectedUnitHasChanged = true
+        worldScreen.shouldUpdate = true
         return true
     }
 
     fun tileSelected(selectedTile: TileInfo) {
-        if (lastSelectedCityButton) {
-            lastSelectedCityButton = false
-            return
-        }
 
         val previouslySelectedUnit = selectedUnit
         if(currentlyExecutingAction=="moveTo"){


### PR DESCRIPTION
This is a rather small PR:
- don't hide units behind the city button
- clicking on the very right of the city button will open the city screen immediatly
- I removed `lastSelectedCityButton` from `UnitTable` as this is now obsolete

I like how you solved the problem without the need for a click area! good work :-)