### PR TITLE
Added the distributionSha256Sum property

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -4,3 +4,4 @@ distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionSha256Sum=53b71812f18cdb2777e9f1b2a0f2038683907c90bdc406bc64d8b400e1fb2c3b


### PR DESCRIPTION
Added the property for the Hash of the gradle distribution for security reasons.

Suggested by the F-Droid submission bot [here](https://gitlab.com/fdroid/rfp/issues/1027#note_187318632) and the [gradle docs](https://docs.gradle.org/current/userguide/gradle_wrapper.html#configuring_checksum_verification)