### PR TITLE
Korean translations minor fix

### DIFF
--- a/android/assets/jsons/Translations/Buildings.json
+++ b/android/assets/jsons/Translations/Buildings.json
@@ -217,7 +217,7 @@
 		Czech:"Papírny"
 		Ukrainian:"Папірня"
                 Malay:"Pembuat kertas"
-				Korean:"종이 공방"
+		Korean:"종이 공방"
 }
 
 	"The Great Library":{
@@ -247,7 +247,7 @@
 		German:"Kostenlose Technologie"
 		Ukrainian:"Технологія безкоштово"
                 Malay:"Teknologi Percuma"
-				Korean:"기술 하나를 무료로 획득"
+		Korean:"기술 하나를 무료로 획득"
 }
 
 	"'Libraries are as the shrine where all the relics of the ancient saints, full of true virtue, and all that without delusion or imposture are preserved and reposed.' - Sir Francis Bacon":{
@@ -276,7 +276,7 @@
 		Czech:"Cirkus"
 		Ukrainian:"Цирк"
                 Malay:"Sarkus"
-				Korean:"서커스"
+		Korean:"서커스"
 }
 
 	"Walls":{
@@ -293,7 +293,7 @@
 		Czech:"Hradby"
 		Ukrainian:"Мури"
                 Malay:"Dinding"
-				Korean:"성벽"
+		Korean:"성벽"
 }
 
 	"Walls of Babylon":{
@@ -307,7 +307,7 @@
 		German:"Babylons Mauern"
 		Ukrainian:"Мури Вавілону"
                 Malay:"Dinding Babylon"
-				Korean:"바빌론 성벽"
+		Korean:"바빌론 성벽"
 }
 
 	"The Pyramids":{
@@ -353,7 +353,7 @@
 		Czech:"Rychlost dělníka se zvýšila o 25% "
 		Ukrainian:"Швидкість будівництва +25%"
                 Malay:"Pekerja buruh meningkat 25%"
-				Korean:"타일의 시설 건설 속도 + 25%"
+		Korean:"타일의 시설 건설 속도 + 25%"
 }
 
 	"Provides 2 free workers":{
@@ -371,7 +371,7 @@
 		Czech:"Poskytuje 2 dělníky zdarma"
 		Ukrainian:"Безоплатно надає 2 робітників"
                 Malay:"bagi 2 pekerja secara percuma"
-				Korean:"일꾼 두 명이 도시 근처에 무료로 출현"
+		Korean:"일꾼 두 명이 도시 근처에 무료로 출현"
 }
 
 	"Barracks":{
@@ -471,7 +471,7 @@
 		Czech:"Chrám"
 		Ukrainian:"Храм"
                 Malay:"Kuil"
-				Korean:"사원"
+		Korean:"사원"
 }
 
 	"Burial Tomb":{
@@ -487,7 +487,7 @@
 		Czech:"Hrobka"
 		Ukrainian:"Гробниця"
                 Malay:"Tempat Persemadian"
-				Korean:"왕릉"
+		Korean:"왕릉"
 }
 
 	/*
@@ -498,7 +498,7 @@
 		Czech:"Velká mešita v Djenné"
 		Ukrainian:"Могила Аскіа"
                 Malay:Masjid Piramid Lumpur"
-				Korean:"진흙 피라미드 모스크"
+		Korean:"진흙 피라미드 모스크"
 }
 	*/
 
@@ -560,7 +560,7 @@
 		Czech:"Národní Akademie"
 		Ukrainian:"Державна академія"
                 Malay:"Kolej Kebangsaan"
-				Korean:"국립대학"
+		Korean:"국립대학"
 }
 
 	"Manhattan Project":{
@@ -571,7 +571,7 @@
 		German:"Manhattan-Projekt"
 		Polish:"Projekt Manhattan"
                 Malay:"Projek Manhattan"
-				Korean:"맨해튼 프로젝트"
+		Korean:"맨해튼 프로젝트"
 				
 }
 
@@ -599,7 +599,7 @@
 		Czech:"'Katun je zřízen v Chichén Itza. Tam musí probíhat vypořádání Itzy. Quetzal musí přijít, zelený pták musí přiletět. Ah Kantenal musí přijít. Je to Boží slovo. Itza musí přijde.' - Knihy Chilama Baláma"
 		Russian:"'Катун установлен в Чичен-Итце. Здесь будет поселение Итца. Кетцаль придет, зеленая птица придет. Ах Кантеналь придет. Вот слово Бога. Народ Итца придет.' - из книг Чилам Балам"
 		Ukrainian:"'Катун почався в Чічен-Іці. Поселення Іца розміщене тут. Кетцаль прийде, зелений птах прийде. А-Кантенал прийде. Це слово Бога. Іца прийде.' - Чилам-Балам"
-		Korean:"'치첸 이사에 카툰이 서리라. 이트사가 그곳에 정착하리라. 케살이 오리라, 푸른 새가 오리라. 아 칸테날이 오리라. 이는 신의 말씀이라. 이트사가 오리라.' - 칠람 발람의 서"
+		Korean:"'치첸 이트사에 카툰이 서리라. 이트사가 그곳에 정착하리라. 케살이 오리라, 푸른 새가 오리라. 아 칸테날이 오리라. 이는 신의 말씀이라. 이트사가 오리라.' - 칠람 발람의 서"
 }
 
 	"Golden Age length increases +50%":{
@@ -626,7 +626,7 @@
 		Ukrainian:"Доступна ядерна зброя"
 		German:"Erlaubt Kernwaffen"
 		Polish:"Umożliwia broń nuklearną"
-		Korean:"원자폭탄과 핵미사일 생산 가능"
+		Korean:"원자 폭탄과 핵미사일 생산 가능"
 }
 
 	"Lighthouse":{
@@ -643,7 +643,7 @@
 		Czech:"Maják"
 		Ukrainian:"Маяк"
                 Malay:"Rumah Api"
-				Korean:"등대"
+		Korean:"등대"
 }
 
 	"Can only be built in coastal cities":{
@@ -658,7 +658,7 @@
 		Russian:"Может быть построен только в прибрежных городах"
 		Czech:"Lze budovat pouze ve městech na pobřeží"
 		Ukrainian:"Можна збудувати тільки в набережних містах"
-		Korean:"도시가 해안에 인접해 있어야 함."
+		Korean:"해안에 인접한 도시에만 건설 가능"
 }
 
 	"+1 food from Ocean and Coast tiles":{
@@ -729,7 +729,7 @@
 		German:"Gerichtsgebäude"
 		Ukrainian:"Суд"
                 Malay:"Makamah"
-				Korean:"법원"
+		Korean:"법원"
 }
 
 	"Remove extra unhappiness from annexed cities":{
@@ -772,7 +772,7 @@
 		Czech:"Stáje"
 		Ukrainian:"Стайня"
                 Malay:"Stabil"
-				Korean:"마구간"
+		Korean:"마구간"
 }
 
 	"+15% Production when building Mounted Units in this city":{
@@ -818,7 +818,7 @@
 		Czech:"Visuté zahrady Semiramidiny"
 		Ukrainian:"Висячі Сади Семіраміди"
                 Malay:"Taman Tergantung"
-				Korean:"공중 정원"
+		Korean:"공중 정원"
 }
 
 	"'I think that if ever a mortal heard the word of God it would be in a garden at the cool of the day.'  - F. Frankfort Moore":{
@@ -890,7 +890,7 @@
 		Czech:"+2 zlata za každý zdroj Mramoru a Kamene"
 		Ukrainian:"З кожного джерела мармуру і каміння +2 золота"
                 Malay:"+2 Emas daripada setiap sumber batu dan mamar"
-				Korean:"개발한 대리석 또는 석재 산지에서 금 +2"
+		Korean:"개발한 대리석 또는 석재 산지에서 금 +2"
 }
 
 	"Gain 100 Gold when you use a Great Person.":{
@@ -960,7 +960,7 @@
 		Czech:"Koloseum"
 		Ukrainian:"Колізей"
                 Malay:"Kolosseum"
-				Korean:"콜로세움"
+		Korean:"콜로세움"
 }
 
 	"Terracotta Army":{
@@ -1002,7 +1002,7 @@
 		Czech:"Tržiště"
 		Ukrainian:"Ринок"
                 Malay:"Pasar"
-				Korean:"시장"
+		Korean:"시장"
 }
 
 	"Bazaar":{ // Arabian unique - transliterate?
@@ -1018,7 +1018,7 @@
 		Czech:"Bazar Chán al-Chalílí"
 		Ukrainian:"Базар"
                 Malay:"Bazar"
-				Korean:"바자"
+		Korean:"바자"
 }
 
 	"Provides 1 extra copy of each improved luxury resource near this City":{
@@ -1390,7 +1390,7 @@
 		Czech:"Univerzita"
 		Ukrainian:"Університет"
                 Malay:"Universiti"
-				Korean:"대학"
+		Korean:"대학"
 }
 
 	"+2 Science from each worked Jungle tile":{
@@ -1435,7 +1435,7 @@
 		Czech:"Oxfordská Universita"
 		Ukrainian:"Оксфордський університет"
                 Malay:"Universiti Oxford"
-				Korean:"옥스퍼드 대학"
+		Korean:"옥스퍼드 대학"
 }
 
 	"Castle":{
@@ -1452,7 +1452,7 @@
 		Czech:"Hrad"
 		Ukrainian:"Замок"
                 Malay:"Istana"
-				Korean:"성"
+		Korean:"성"
 }
 
 	"Mughal Fort":{	//Indian unique
@@ -1656,7 +1656,7 @@
 		Czech:"Operní dům"
 		Ukrainian:"Оперний театр"
                 Malay:"Rumah Opera"
-				Korean:"오페라 극장"
+		Korean:"오페라 극장"
 }
 
 	"Sistine Chapel":{
@@ -1717,7 +1717,7 @@
 		Czech:"Banka"
 		Ukrainian:"Банк"
                 Malay:"Bank"
-				Korean:"은행"
+		Korean:"은행"
 }
 
 	"Hanse":{	//German unique
@@ -1883,7 +1883,7 @@
 		Polish:"Otrzymaj"
 		Ukrainian:"Отримати:"
                 Malay:"Dapat"
-				Korean:"얻기: "
+		Korean:"얻기: "
 		French:"Obtenir "
 }
 
@@ -2014,7 +2014,7 @@
 		Czech:"Muzeum"
 		Ukrainian:"Музей"
                 Malay:"Muzium"
-				Korean:"박물관"
+		Korean:"박물관"
 }
 
 	"Hermitage":{
@@ -2092,7 +2092,7 @@
 		Czech:"Námořní přístav"
 		Ukrainian:"Морський порт"
                 Malay:"Pelabuhan"
-				Korean:"항구"
+		Korean:"항구"
 }
 
 	"+1 production and gold from all sea resources worked by the city":{
@@ -2141,7 +2141,7 @@
 		Czech:"Veřejná škola"
 		Ukrainian:"Публічна школа"
                 Malay:"Sekolah Kerajaan"
-				Korean:"공립학교"
+		Korean:"공립학교"
 }
 
 	"Hospital":{
@@ -2158,7 +2158,7 @@
 		Czech:"Nemocnice"
 		Ukrainian:"Шпиталь"
                 Malay:"Hospital"
-				Korean:"병원"
+		Korean:"병원"
 }
 
 	"25% of food is carried over after a new citizen is born":{
@@ -2192,7 +2192,7 @@
 		Czech:"Továrna"
 		Ukrainian:"Фабрика"
                 Malay:"Kilang"
-				Korean:"공장"
+		Korean:"공장"
 }
 
 	"Stock Exchange":{
@@ -2209,7 +2209,7 @@
 		Czech:"Burza"
 		Ukrainian:"Біржа"
                 Malay:"Bursa Saham"
-				Korean:"증권 거래소"
+		Korean:"증권 거래소"
 }
 
     	"Big Ben":{
@@ -2223,7 +2223,7 @@
 		German:"Big Ben"
 		Ukrainian:"Біг-Бен"
                 Malay:"Big Ben"
-				Korean:"빅 벤"
+		Korean:"빅 벤"
 }
 
 	"'To achieve great things, two things are needed: a plan, and not quite enough time.'  - Leonard Bernstein":{
@@ -2308,7 +2308,7 @@
 		Czech:"Kreml"
 		Ukrainian:"Кремль"
                 Malay:"Kremlin"
-				Korean:"크렘린 궁전"
+		Korean:"크렘린 궁전"
 }
 
 	"'The Law is a fortress on a hill that armies cannot take or floods wash away.'   –- The Prophet Muhammed":{
@@ -2386,7 +2386,7 @@
 		Czech:"Vojenská akademie"
 		Ukrainian:"Військова академія"
                 Malay:"Akedemi Tentera"
-				Korean:"사관 학교"
+		Korean:"사관 학교"
 	}
 	
 	"Brandenburg Gate":{
@@ -2438,7 +2438,7 @@
 		Czech:"Vysílací věž"
 		Ukrainian:"Радіовежа"
                 Malay:"Menara Pencawang"
-				Korean:"방송탑"
+		Korean:"방송탑"
 }
 
 	"Eiffel Tower":{
@@ -2455,7 +2455,7 @@
 		Czech:"Eiffelova věž"
 		Ukrainian:"Ейфелева вежа"
                 Malay:"Menara Eiffel"
-				Korean:"에펠탑"
+		Korean:"에펠탑"
 }
 
 	"'We live only to discover beauty, all else is a form of waiting'  - Kahlil Gibran":{
@@ -2498,7 +2498,7 @@
 		Czech:"Socha Svobody"
 		Ukrainian:"Статуя Свободи"
                 Malay:"Patung Liberty"
-				Korean:"자유의 여신상"
+		Korean:"자유의 여신상"
 }
 
 	"'Give me your tired, your poor, your huddled masses yearning to breathe free, the wretched refuse of your teeming shore. Send these, the homeless, tempest-tossed to me, I lift my lamp beside the golden door!'  - Emma Lazarus":{
@@ -2555,7 +2555,7 @@
 		Czech:"Výzkumná laboratoř"
 		Ukrainian:"Дослідницька лабораторія"
                 Malay:"Makmal Penyelidik"
-				Korean:"연구소"
+		Korean:"연구소"
 }
 
 	"Hydro Plant":{
@@ -2588,7 +2588,7 @@
 		Czech:"Stadión"
 		Ukrainian:"Стадіон"
                 Malay:"Stadium"
-				Korean:"경기장"
+		Korean:"경기장"
 }
 
 	"Solar Plant":{
@@ -2652,7 +2652,7 @@
 		Czech:"Opera v Sydney"
 		Ukrainian:"Сіднейський оперний театр"
                 Malay:"Rumah Sydney Opera"
-				Korean:"시드니 오페라 하우스"
+		Korean:"시드니 오페라 하우스"
 }
 
 	"'Those who lose dreaming are lost.'  - Australian Aboriginal saying":{
@@ -2679,7 +2679,7 @@
 		Czech:"CN Tower"
 		Ukrainian:"Сі-Ен-Тавер"
                 Malay:"Menara CN"
-				Korean:"CN 타워"
+		Korean:"CN 타워"
 }
 	*/
 
@@ -2694,7 +2694,7 @@
 		Czech:"+1 Populace v každém městě"
 		Ukrainian:"У кожному місті населення +1"
                 Malay:"+1 populasi di setiap bandar"
-				Korean:"각 도시마다 인구 +1"
+		Korean:"각 도시마다 인구 +1"
 }
 
 	"+1 happiness in each city":{
@@ -2708,7 +2708,7 @@
 		Czech:"+1 Spokojenost v každém městě"
 		Ukrainian:"У кожному місті щастя +1"
                 Malay:"+1 kegembiraan di setiap bandar"
-				Korean:"각 도시마다 행복 +1"
+		Korean:"각 도시마다 행복 +1"
 }
 
 	"Pentagon":{
@@ -2722,7 +2722,7 @@
 		Czech:"Pentagon"
 		Ukrainian:"Пентагон"
                 Malay:"Pentagon"
-				Korean:"펜타곤"
+		Korean:"펜타곤"
 }
 
 	"'In preparing for battle I have always found that plans are useless, but planning is indispensable.'  - Dwight D. Eisenhower":{
@@ -2766,7 +2766,7 @@
 		Czech:"Program Apollo"
 		Ukrainian:"Програма Аполлон"
                 Malay:"Program Apollo"
-				Korean:"아폴로 프로그램"
+		Korean:"아폴로 프로그램"
 }
 
 	"Enables construction of Spaceship parts":{
@@ -2800,7 +2800,7 @@
 		Czech:"Jaderná elektrárna"
 		Ukrainian:"Ядерна електростанція"
                 Malay:"Penjana Nuklear"
-				Korean:"원자력 발전소"
+		Korean:"원자력 발전소"
 }
 
 	"Spaceship Factory":{

--- a/android/assets/jsons/Translations/Notifications.json
+++ b/android/assets/jsons/Translations/Notifications.json
@@ -73,7 +73,7 @@
 		Czech:"[cityName] - Narodil se [greatPerson]",
 		Ukrainian:"[cityName] - Народився [greatPerson]!",
 		Polish:"[cityName] - [greatPerson] urodził/a się!"
-		Korean:"[cityName]에 [greatPerson]이(가) 탄생했습니다!"
+		Korean:"[cityName]에서 [greatPerson]이(가) 탄생했습니다!"
 	}
 
 	"We have encountered [civName]!":{
@@ -165,7 +165,7 @@
 		Czech:"Ve městě [cityName] začal hladomor"
 		Ukrainian:"Голодує місто [cityName]!"
 		Polish:"[cityName] głoduje!"
-		Korean:"[cityName]이(가) 굶고 있습니다!"
+		Korean:"[cityName]이(가) 굶주리고 있습니다!"
 	}
 
 	"[construction] has been built in [cityName]":{
@@ -183,7 +183,7 @@
 		Czech:"[construction] - stavba dokončena ve městě [cityName]"
 		Ukrainian:"Споруда [construction] збудована в місті [cityName]"
 		Polish:"Prace nad [construction] w mieście [cityName] zostały zakończone"
-		Korean:"[constuction]이(가) [cityName]에 지어졌습니다."
+		Korean:"[construction]이(가) [cityName]에 지어졌습니다."
 	}
 
 	"[wonder] has been built in a faraway land":{
@@ -229,7 +229,7 @@
 		Ukrainian:"[construction]: неможливо продовжити будувати в місті [cityName]"
 		German:"[cityName] kann nicht weiter an [construction] arbeiten"
 		Polish:"Miasto [cityName] nie może dalej pracować nad [construction]"
-		Korean:"[cityName]이(가) 더이상 [construction]을(를) 건설할 수 없습니다."
+		Korean:"[cityName]이(가) 더 이상 [construction]을(를) 건설할 수 없습니다."
 	}
 
 
@@ -248,7 +248,7 @@
 		Czech:"Město [cityname] rozšířilo své hranice!"
 		Ukrainian:"Місто [cityname] розширило межі!"
 		Polish:"Granice miasta [cityname] poszerzyły się!"
-		Korean:"[cityName]의 영토가 확장되었습니다!"
+		Korean:"[cityname]의 영토가 확장되었습니다!"
 	}
 
 	/////////////	war, fight, ennemy
@@ -286,7 +286,7 @@
 		Czech:"Dobyli jsme město [cityname]!"
 		Ukrainian:"Загарбано місто [cityname]!"
 		Polish:"Napotkaliśmy miasto [cityname]!"
-		Korean:"[cityName]을(를) 점령했습니다!"
+		Korean:"[cityname]을(를) 점령했습니다!"
 	}
 
 	"An enemy [unit] has attacked [cityname]":{
@@ -304,7 +304,7 @@
 		Czech:"Npřátelská jednotka [unit] zaútočila na město [cityname]"
 		Ukrainian:"Ворожий підрозділ [unit] атакував наше місто [cityname]"
 		Polish:"Wrogie jednostki [unit] ruszyły na [cityname]"
-		Korean:"적 [unit]이(가) [cityname]을(를) 공격했습니다."
+		Korean:"적 [unit]이(가) [cityname]을(를) 공격했습니다"
 	}
 
 	"An enemy [unit] has attacked our [ourUnit]":{
@@ -322,7 +322,7 @@
 		Czech:"Nepřátelská jednotka [unit] zaútočila na naši jednotku [ourUnit]"
 		Ukrainian:"Ворожий підрозділ [unit] атакував наш підрозділ [ourUnit]"
 		Polish:"Wrogie jednostki [unit] zaatakowały nasze oddziały [ourUnit]"
-		Korean:"적 [unit]이(가) [ourUnit]을(를) 공격했습니다."
+		Korean:"적 [unit]이(가) [ourUnit]을(를) 공격했습니다"
 	}
 
 	"Enemy city [cityName] has attacked our [ourUnit]":{
@@ -336,7 +336,7 @@
 		Dutch:"Vijandelijke stad [cityName] heeft onze [ourUnit] aangevallen"
 		German:"Feindliche Stadt [cityName] hat unsere Einheit [ourUnit] angegriffen"
 		Polish:"Wrogie miasto [cityName] zaatakowało nasze jednostki [ourUnit]"
-		Korean:"적의 도시 [cityName]이(가) 우리의 [ourUnit]을(를) 공격했습니다."
+		Korean:"적의 도시 [cityName]이(가) 우리의 [ourUnit]을(를) 공격했습니다"
 	}
 
 	"An enemy [unit] has captured [cityname]":{
@@ -354,7 +354,7 @@
 		Czech:"Nepřátelská jednotka [unit] dobyla město [cityname]"
 		Ukrainian:"Ворожий підрозділ [unit] захопив наше місто [cityname]"
 		Polish:"Wrogie jednostki [unit] przejeły miasto [cityname]"
-		Korean:"적 [unit]이(가) [cityname]을(를) 점령했습니다."
+		Korean:"적 [unit]이(가) [cityname]을(를) 점령했습니다"
 	}
 
 	"An enemy [unit] has captured our [ourUnit]":{
@@ -453,7 +453,7 @@
 		Czech:"Nepřátelská jednotka [unit] byla zničena, když napadla naši jednotku [ourUnit]"
 		Ukrainian:"Ворожий підрозділ [unit] знищено при атаці нашого підрозділу [ourUnit]"
 		Polish:"Nasze jednostki [ourUnit] odparły atak wrogich jednostek [unit]"
-		Korean:"적 [unit]이(가) [ourUnit]을(를) 공격하던 도중 파괴되었습니다"
+		Korean:"적 [unit]이(가) 아군 [ourUnit]을(를) 공격하던 도중 파괴되었습니다"
 	}
 
 	"Our [attackerName] was destroyed by an intercepting [interceptorName]":{
@@ -493,7 +493,7 @@
 		Ukrainian:"Наш підрозділ [$attackerName] атаковано ворожим перехоплювачем [$interceptorName]"
 		German:"Unser(e) [$attackerName] wurde von einem abfangenden [$interceptorName] angegriffen."
 		Polish:"Nasz [$attackerName] został zaatakowany przez [$interceptorName]" //checking for context - will remove soon [MFOX]
-		Korean:"아군 [$attackerName]이(가) 적 [attackerName]에게 요격되어 피해를 입었습니다"
+		Korean:"아군 [$attackerName]이(가) 적 [$interceptorName]에게 요격되어 피해를 입었습니다"
 	}
 
 	"Our [$interceptorName] intercepted and attacked an enemy [$attackerName]":{
@@ -506,7 +506,7 @@
 		Ukrainian:"Наш підрозділ [$interceptorName] перехопив і атакував ворожий підрозділ [$attackerName]"
 		German:"Unser(e) [$interceptorName] hat einen feindlichen [$attackerName] abgefangen und angegriffen."
 		Polish:"Nasza jednostka przechwytująca [$interceptorName] przechwyciła i zaatakowała [$attackerName]"
-		Korean:"아군 [$interceptorName]이(가) 적 [attackerName]을(를) 요격해 피해를 입혔습니다"
+		Korean:"아군 [$interceptorName]이(가) 적 [$attackerName]을(를) 요격해 피해를 입혔습니다"
 	}
 
 	"An enemy [unit] was spotted near our territory":{
@@ -570,7 +570,7 @@
 		Dutch:"[amount] vijandelijke eenheden werden gespot op ons grondgebied"
 		Ukrainian:"На нашій території помічено ворожих підрозділів: [amount]"
 		Polish:"[amount] wrogich jednostek zostało zauważonych na naszym terytorium"
-		Korean: "[amount] 명의 적들이 아군 영토 근처에서 발견되었습니다"
+		Korean: "[amount] 명의 적들이 아군 영토에서 발견되었습니다"
 	}
 
 	"The civilization of [civName] has been destroyed!":{
@@ -759,7 +759,7 @@
 		Ukrainian:"Втрачається контроль над містом-державою [name]."
 		German:"Die Freundschaft mit [name] wird brüchig."
 		Polish:"Tracisz kontrolę nad [name]."
-		Korean:"도시국가 [name]에 대한 영향력을 잃기 직전입니다."
+		Korean:"도시 국가 [name]에 대한 영향력을 잃기 직전입니다."
 	}
 
 	"You and [name] are no longer friends!":{ // When you lose friendship with a City-State (Relationship fall less than 30)
@@ -772,7 +772,7 @@
 		Ukrainian:"Припинилася дружба з містом-державою [name]!"
 		German:"Du und [name] seid nicht mehr befreundet!"
 		Polish:"Ty i [name] przestaliście być przyjaciółmi!"
-		Korean:"도시국가 [name]와(과) 더이상 우호 관계가 아닙니다!"
+		Korean:"도시 국가 [name]와(과) 더 이상 우호 관계가 아닙니다!"
 	}
 
 	"Your alliance with [name] is faltering.":{ //When you're about to lose your alliance with a City-State
@@ -785,7 +785,7 @@
 		Ukrainian:"Захитався альянс з містом-державою [name]"
 		German:"Die Allianz mit [name] wird brüchig."
 		Polish:"Twój sojusz z [name] osłabł."
-		Korean:"도시국가 [name]와(과)의 동맹 관계가 파기되기 직전입니다."
+		Korean:"도시 국가 [name]와(과)의 동맹 관계가 파기되기 직전입니다."
 	}
 
 	"You and [name] are no longer allies!":{ // When you lose alliance with a City-State (Relationship fall less than 60)
@@ -798,7 +798,7 @@
 		Ukrainian:"Розірвано альянс з містом-державою [name]"
 		German:"Du und [name] seid nicht mehr alliiert!"
 		Polish:"Ty i [name] przestaliście być sojusznikami!"
-		Korean:"도시국가 [name]와(과) 더이상 동맹이 아닙니다!"
+		Korean:"도시 국가 [name]와(과) 더 이상 동맹이 아닙니다!"
 	}
 
 	"[civName] gave us a [unitName] as gift near [cityName]!":{ // When a city state gives a unit as gift.
@@ -845,7 +845,7 @@
 		Traditional_Chinese:"[cityName]與您的首都的連接已經中斷！"
 		German:"Die Verbindung von [cityName] zur Hauptstadt ist unterbrochen!"
 		Polish:"Miasto [cityName] zostało odłączone od Twojej stolicy!"
-		Korean:"[cityName]와(과) 수도와의 연결이 끊겼습니다!"
+		Korean:"[cityName]와(과) 수도의 연결이 끊겼습니다!"
 	}
 
 	// Trade
@@ -947,7 +947,7 @@
 		Ukrainian:"[nation]: відмова не будувати міста поруч з нами!"
 		German:"[nation] hat sich geweigert, keine Städte mehr in unserer Nähe zu gründen!"
 		Polish:"Nacja [nation] nadal będzie zakładać nowe miasta w pobliżu nas!"
-		Korean:"[nation]이(가) 우리 근처에 도시를 세우지 않겠다는 것을 거절했습니다!"
+		Korean:"[nation]이(가) 우리 근처에 도시를 세우지 않는 것을 거절했습니다!"
 	}
 
 	"We have allied with [nation].": {

--- a/android/assets/jsons/Translations/Other.json
+++ b/android/assets/jsons/Translations/Other.json
@@ -237,7 +237,7 @@
     		Ukrainian:"Дальність"
 		German:"Reichweite"
 		French:"Portée"
-			Korean:"공격범위"
+			Korean:"공격 범위"
 }
 
 /////// Unit actions
@@ -564,7 +564,7 @@
 		Japanese:"あなたは本当にこのユニットを解散したいですか？"
 		Czech:"Opravdu chcete propustit tuto jednotku?"
 		Ukrainian:"Ви дійсно хочете розформувати цей підрозділ?"
-		Korean:"이 유닛을 정말 제거하겠습니까?"
+		Korean:"이 유닛을 정말 삭제하겠습니까?"
 }
 	"Disband this unit for [goldAmount] gold?":{
 		Italian:"Vuoi sciogliere questa unità per [goldAmount] Oro?"
@@ -580,7 +580,7 @@
 		Russian:"Распустить юнит за [goldAmount] золота?",
 		Czech:"Propustit tuto jednotku - dostaneme [goldAmount] zlata?"
 		Ukrainian:"Розформувати цей підрозділ за [goldAmount] золота?"
-		Korean:"이 유닛을 제거하면 금 [goldAmount]을 얻습니다. 제거하겠습니까?"
+		Korean:"이 유닛을 삭제하면 금 [goldAmount]을 얻습니다. 삭제하겠습니까?"
 }
 
 	"Create [improvement]":{ // for great units, fishing boats, etc.
@@ -702,7 +702,7 @@
 		Japanese:"幸福"
 		Czech:"Spokojenost"
 		Ukrainian:"Щастя"
-		Korean:"행복"
+		Korean:"행복도"
 }
 
 	"Production":{
@@ -795,7 +795,7 @@
 		Ukrainian:"до н.е."
 		German:"[year] v. Chr."
 		French:"[year] avant J.C."
-		Korean:"기원전 [year]년 BC"
+		Korean:"기원전 [year]년"
 }
 
 	"[year] AD":{ // Anno Domini
@@ -1104,7 +1104,7 @@
 		Ukrainian:"Забезпечити [resource]"
 		German:"Stellt [resource] zur Verfügung"
 		French:"Fournit [resource]"
-			Korean:"[resource]을(를) 제공합니다"
+		Korean:"[resource]을(를) 제공합니다"
 }
 
 	"Replaces [improvement]":{
@@ -1361,7 +1361,7 @@
 		Russian:"Обмен еды на производство"
 		German:"Nahrung in Produktion verwandeln"
 		French:"Nourriture convertie en production"
-		Korean:"식량이 생산량으로 전환됨"
+		Korean:"식량이 생산력으로 전환됨"
 }
 
 	"[turnsToStarvation] turns to lose population":{
@@ -1378,7 +1378,7 @@
 		Japanese:"[turnsToStarvation]人口を減らす",
 		Czech:"[turnsToStarvation] tah(y/ů) do ztráty populace"
 		Ukrainian:"[turnsToStarvation] ходів до зменшення населення"
-		Korean:"인구 수가 줄기까지 [turnsToStarvation]턴"
+		Korean:"인구 감소까지 [turnsToStarvation]턴"
 }
 
 	"Stopped population growth":{
@@ -2167,7 +2167,7 @@
 		Russian:"Базовое счастье"
 		German:"Besetzte Städte"
 		French:"Cité Occupée"
-			Korean:"점령한 도시"
+		Korean:"점령한 도시"
 }
 
 	"Buildings":{
@@ -2657,7 +2657,7 @@
 		Portuguese:"Um turno mais...!"
 		Czech:"Ještě jedno kolo..."
 		Ukrainian:"Ще один хід..."
-		Korean:"하,한 턴만 더..."
+		Korean:"한 턴만 더...!"
 }
 
 	"Built Apollo Program":{ // Menu -> Victory status -> Science victory -> Built Apollo Program (header)
@@ -2683,7 +2683,7 @@
 		Portuguese:"Destruir [civName]" //what's the context? as in it being a question, or a pre-requisite for conquest victory?
 		Czech:"Zničit [civName]"
 		Ukrainian:"Знищити [civName]"
-		Korean:"[civName] 점령"
+		Korean:"[civName] 정복"
 }
 
 	"Our status":{

--- a/android/assets/jsons/Translations/Policies.json
+++ b/android/assets/jsons/Translations/Policies.json
@@ -258,7 +258,7 @@
 		German:"+15% Wachstum und +2 Nahrung in allen Städten"
 		French:"+15% de croissance et +2 nourriture dans toutes les villes"
 		Czech:"+15% růst a +2 jídla ve všech městech"
-		Korean:"모든 도시에 성장률 +15%, 식량 +2"
+		Korean:"모든 도시에서 성장률 +15%, 식량 +2"
 }
 
 ////// Liberty branch
@@ -316,7 +316,7 @@
 		German:"Ausbildung von SiedlerInnen in der Hauptstadt ist um 50% erhöht; ein(e) kostenlose(r) Siedler(in) erscheint in der Hauptstadt."
 		French:"La vitesse de formation des colons augmente de 50% dans la capital capitale et un colon gratuit apparaît à proximité"
 		Czech:"Vycvičení osadníka zrychleno o 50% v hlavním městě, zdarma obdržíte osadníka v blízkosti hlavního města"
-		Korean:"수도의 개척자 생산 속도 +50%, 수도 근처에 무료 개척자 출현"
+		Korean:"수도에서 개척자 생산 속도 +50%, 수도 근처에서 무료 개척자 출현"
 }
 
 	"Citizenship":{
@@ -344,7 +344,7 @@
 		German:"+25% Baugeschwindigkeit für Felderverbesserungen bei ArbeiterInnenn; ein(e) kostenlose(r) Arbeiter(in) erscheint in der Hauptstadt"
 		French:"La vitesse de construction des ouvriers augmente de 25% et un ouvrier apparaît près de la capitale"
 		Czech:"Rychlost vylepšení na políčkách vzroste o 25%, zdarma obdržíte dělníka v blízkosti hlavního města"
-		Korean:"타일 시설 건설 속도 +25%, 수도 근처에 무료 노동자 출현"
+		Korean:"타일 시설 건설 속도 +25%, 수도 근처에서 무료 노동자 출현"
 }
 
 	"Republic":{
@@ -698,7 +698,7 @@
 		German:"+1 Zufriedenheit für jedes Monument, Kloster und Tempel"
 		French:"+1 bonheur pour chaque monument, temple et monastère"
 		Czech:"+1 spokojenost za každý pomník, chrám a klášter"
-		Korean:"기념비, 사원, 수도원 하나마다 행복 +1"
+		Korean:"기념비, 사원, 수도원 하나당 행복 +1"
 }
 
 	"Mandate Of Heaven":{
@@ -824,7 +824,7 @@
 		German:"Frömmigkeit vollständig"
 		French:"Piété complète"
 		Czech:"Kompletní Zbožnost"
-		Korean:"후원 정책 완성"
+		Korean:"신앙 정책 완성"
 }
 
 	"Reduce culture cost of future policies by 10%":{
@@ -898,7 +898,7 @@
 		Italian:"Le Città-Stato tue alleate ti donano un bonus scientifico del 25% rispetto a quello che producono da sole."
 		Czech:"Všechny městské státy, se kterými máme alianci, poskytují Výzkumný bonus ve výši 25% z jejich celkového výzkumu."
 		German:"Alle verbündeten Stadtstaaten geben einen Wissenschaftsbonus von 25% ihrer eigenen Produktion."
-		Korean:"동맹 상태인 모든 도시국가가 생산하는 과학력의 25%를 제공받음"
+		Korean:"동맹 상태인 모든 도시 국가가 생산하는 과학력의 25%를 제공받음"
 }
 
 	"Cultural Diplomacy":{ //Needs Scholasticism
@@ -1164,7 +1164,7 @@
 		German:"Umwandlung von Produktion in Wissenschaft in Städten ist um 33% erhöht."
 		French:"+33% de production lors de conversion de la production en science"
 		Czech:"Konverze produkce na výzkum ve městech se zvyšuje o 33%"
-		Korean:"도시에서 과학력을 생산 시 변환량 +33%"
+		Korean:"도시에서 생산력을 과학력으로 변환 시 변환량 +33%"
 }
 
 	"Secularism":{
@@ -1192,7 +1192,7 @@
 		German:"+2 Wissenschaft durch jede(n) Spezialistin"
 		French:"Spécialiste : science +2."
 		Czech:"+2 výzkum za každého specialistu"
-		Korean:"전문가 하나 당 과학 +2"
+		Korean:"전문가 하나당 과학 +2"
 }
 
 	"Humanism":{
@@ -1220,7 +1220,7 @@
 		German:"+1 Zufriedenheit durch jede Universität, öffentliche Schule oder Observatorium."
 		French:"+1 bonheur pour chaque université, observatoire et école publique"
 		Czech:"+1 spokojenost za každou univerzitu, observatoř a veřejnou školu"
-		Korean:"대학, 천문대, 공립학교 하나마다 행복 +1"
+		Korean:"대학, 천문대, 공립학교 하나당 행복 +1"
 }
 
 	"Free Thought":{
@@ -1372,7 +1372,7 @@
 	"Militaristic City-States grant units twice as often when you are at war with a common foe":{
 		Italian:"Le Città Stato militaristiche ti danno unità a doppia velocità quando siete in guerra con un nemico in comune"
 		German:"Militärische Stadtstaaten gewähren Einheiten doppelt so oft, wenn man mit einem gemeinsamen Gegner im Krieg ist."
-		Korean:"군사적 도시국가와 같은 적을 두고 싸울 시 그 도시 국가에서 유닛을 두 배로 자주 제공함"
+		Korean:"군사적 도시 국가와 같은 적을 두고 싸울 시 그 도시 국가에서 유닛을 두 배로 자주 제공함"
 	}
 
 	"Planned economy":{
@@ -1812,7 +1812,7 @@
         Traditional_Chinese:"每座城牆、城堡和兵工廠+1快樂"
 		Czech:"+1 spokojenost za každou Hradbu, Hrad a Zbrojnici"
 		German:"+1 Zufriedenheit für jede Mauer, jedes Schloss und jedes Arsenal"
-		Korean:"성벽, 성, 무기고 하나마다 행복 +1"
+		Korean:"성벽, 성, 무기고 하나당 행복 +1"
 }
 
 }


### PR DESCRIPTION
Fixed some typo.

Also resolved...
- City name is displayed as "cityName" 
![image](https://user-images.githubusercontent.com/27040628/70374800-323ede80-193a-11ea-9502-809aaf2ce3d1.png)
- Construction name is displayed as "constuction"
![image](https://user-images.githubusercontent.com/27040628/70374851-c6a94100-193a-11ea-8cd3-56b4a471feae.png)
