### PR TITLE
Fix typo in Techs.json

### DIFF
--- a/android/assets/jsons/Techs.json
+++ b/android/assets/jsons/Techs.json
@@ -176,7 +176,7 @@
 				name:"Theology",
 				row:2,
 				prerequisites:["Philosophy"],
-				quote:"'Three things are necessary for the salvarion of man: to know what he ought to believe; to know what he ought to desire; and to know what he ought to do' - St. Thomas Aquinas"
+				quote:"'Three things are necessary for the salvation of man: to know what he ought to believe; to know what he ought to desire; and to know what he ought to do' - St. Thomas Aquinas"
 			},
 			{
 				name:"Civil Service",


### PR DESCRIPTION
Theology tech had `salvarion` instead of `salvation` in the quote.