### PR TITLE
Bugfix tutorial tasks

### DIFF
--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -169,8 +169,9 @@ class WorldScreen(val viewingCiv:CivilizationInfo) : CameraStageBaseScreen() {
         battleTable.update()
 
         tutorialTaskTable.clear()
+        tutorialTaskTable.isVisible = game.settings.showTutorials
         val tutorialTask = getCurrentTutorialTask()
-        if (tutorialTask == "" || !game.settings.showTutorials) {
+        if (tutorialTask == "") {
             tutorialTaskTable.isVisible = false
         } else {
             tutorialTaskTable.add(tutorialTask.toLabel()


### PR DESCRIPTION
Activating / deactivating tutorials has immediate effect on tutorial task visibility (previously one had to close and relaunch the game for the change to take effect).