### PR TITLE
Fixes #891

### DIFF
--- a/core/src/com/unciv/ui/worldscreen/TileMapHolder.kt
+++ b/core/src/com/unciv/ui/worldscreen/TileMapHolder.kt
@@ -92,6 +92,7 @@ class TileMapHolder(internal val worldScreen: WorldScreen, internal val tileMap:
             override fun zoom(event: InputEvent?, initialDistance: Float, distance: Float) {
                 // deselect any unit, as zooming occasionally forwards clicks on to the map
                 worldScreen.bottomUnitTable.selectedUnit = null
+                worldScreen.shouldUpdate = true
                 if (lastInitialDistance != initialDistance) {
                     lastInitialDistance = initialDistance
                     lastScale = scaleX


### PR DESCRIPTION
After a zoom gesture the World Screen needs to be updated in order to properly show that any unit previously selected has been deselected.