### PR TITLE
Fix: cities connections via coast

### DIFF
--- a/core/src/com/unciv/logic/civilization/CivInfoTransientUpdater.kt
+++ b/core/src/com/unciv/logic/civilization/CivInfoTransientUpdater.kt
@@ -161,7 +161,10 @@ class CivInfoTransientUpdater(val civInfo: CivilizationInfo){
                         && cityToConnectFrom.cityConstructions.containsBuildingOrEquivalent(harbor)){
                     val seaBfs = BFS(cityToConnectFrom.getCenterTile()) { it.isWater || it.isCityCenter() }
                     seaBfs.stepToEnd()
-                    val reachedCities = allCivCities.filter { seaBfs.tilesReached.containsKey(it.getCenterTile())}
+                    val reachedCities = allCivCities.filter {
+                        seaBfs.tilesReached.containsKey(it.getCenterTile())
+                                && it.cityConstructions.containsBuildingOrEquivalent(harbor)
+                    }
                     for(reachedCity in reachedCities){
                         if(!citiesReachedToMediums.containsKey(reachedCity)){
                             newCitiesToCheck.add(reachedCity)


### PR DESCRIPTION
Cities could be connected to capital via coast even if they don't have `Harbor` building becaused they weren't checked if they have it, only the `cityToConnectFrom` was.

Reported by discord@`tap wature`