### PR TITLE
Moving a city to a cityless Civ flags it as capital

### DIFF
--- a/core/src/com/unciv/logic/city/CityInfo.kt
+++ b/core/src/com/unciv/logic/city/CityInfo.kt
@@ -448,12 +448,17 @@ class CityInfo {
         for(building in cityConstructions.getBuiltBuildings().filter { it.requiredBuildingInAllCities!=null })
             cityConstructions.removeBuilding(building.name)
 
-        // Remove/relocate palace
+        // Remove/relocate palace for old Civ
         if(cityConstructions.isBuilt("Palace")){
             cityConstructions.removeBuilding("Palace")
             if(oldCiv.cities.isNotEmpty()){
                 oldCiv.cities.first().cityConstructions.addBuilding("Palace") // relocate palace
             }
+        }
+
+        // Locate palace for newCiv if this is the only city they have
+        if (newCivInfo.cities.count() == 1) {
+            cityConstructions.addBuilding("Palace")
         }
 
         isBeingRazed=false

--- a/core/src/com/unciv/logic/civilization/CivInfoTransientUpdater.kt
+++ b/core/src/com/unciv/logic/civilization/CivInfoTransientUpdater.kt
@@ -182,7 +182,7 @@ class CivInfoTransientUpdater(val civInfo: CivilizationInfo){
 
         if(!initialSetup){ // In the initial setup we're loading an old game state, so it doesn't really count
             for(city in citiesReachedToMediums.keys)
-                if(city !in civInfo.citiesConnectedToCapital && city.civInfo == civInfo)
+                if(city !in civInfo.citiesConnectedToCapital && city.civInfo == civInfo && city != civInfo.getCapital())
                     civInfo.addNotification("[${city.name}] has been connected to your capital!",city.location, Color.GOLD)
 
             for(city in civInfo.citiesConnectedToCapital)


### PR DESCRIPTION
**Before this fix:**
If a player without cities buys a city from another civ the game crashes because no city is flagged as capital.

