### PR TITLE
Discrete rendering

### DIFF
--- a/core/src/com/unciv/UncivGame.kt
+++ b/core/src/com/unciv/UncivGame.kt
@@ -51,6 +51,7 @@ class UncivGame(
     val translations = Translations()
 
     override fun create() {
+        Gdx.graphics.setContinuousRendering(false)
         Gdx.input.setCatchKey(Input.Keys.BACK, true)
         if (Gdx.app.type != Application.ApplicationType.Desktop) {
             viewEntireMapForDebug = false

--- a/core/src/com/unciv/UncivGame.kt
+++ b/core/src/com/unciv/UncivGame.kt
@@ -65,7 +65,7 @@ class UncivGame(
         settings = GameSaver().getGeneralSettings() // needed for the screen
         screen = LoadingScreen()
 
-        thread {
+        thread(name="LoadJSON") {
             ruleset = Ruleset(true)
 
             if (rewriteTranslationFiles) { // Yes, also when running from the Jar. Sue me.

--- a/core/src/com/unciv/logic/GameSaver.kt
+++ b/core/src/com/unciv/logic/GameSaver.kt
@@ -6,6 +6,7 @@ import com.badlogic.gdx.utils.Json
 import com.unciv.models.metadata.GameSettings
 import com.unciv.ui.utils.ImageGetter
 import java.io.File
+import kotlin.concurrent.thread
 
 class GameSaver {
     private val saveFilesFolder = "SaveFiles"
@@ -69,7 +70,7 @@ class GameSaver {
         // On the other hand if we alter the game data while it's being serialized we could get a concurrent modification exception.
         // So what we do is we clone all the game data and serialize the clone.
         val gameInfoClone = gameInfo.clone()
-        kotlin.concurrent.thread {
+        thread(name="Autosave") {
             saveGame(gameInfoClone, "Autosave")
 
             // keep auto-saves for the last 10 turns for debugging purposes

--- a/core/src/com/unciv/ui/mapeditor/MapDownloadTable.kt
+++ b/core/src/com/unciv/ui/mapeditor/MapDownloadTable.kt
@@ -22,7 +22,7 @@ class MapDownloadTable(loadMapScreen: LoadMapScreen): PopupTable(loadMapScreen) 
             for (downloadableMap in folderList.entries) {
                 val downloadMapButton = TextButton(downloadableMap.name, CameraStageBaseScreen.skin)
                 downloadMapButton.onClick {
-                    thread {
+                    thread(name="MapDownload") {
                         try {
                             val mapJsonGzipped = DropBox().downloadFileAsString(downloadableMap.path_display)
                             val decodedMapJson = Gzip.unzip(mapJsonGzipped)

--- a/core/src/com/unciv/ui/mapeditor/MapEditorMenuPopup.kt
+++ b/core/src/com/unciv/ui/mapeditor/MapEditorMenuPopup.kt
@@ -65,7 +65,7 @@ class MapEditorMenuPopup(mapEditorScreen: MapEditorScreen): PopupTable(mapEditor
 
         val uploadMapButton = TextButton("Upload map".tr(), skin)
         uploadMapButton.onClick {
-            thread {
+            thread(name="MapUpload") {
                 try {
                     val gzippedMap = Gzip.zip(Json().toJson(mapEditorScreen.tileMap))
                     DropBox().uploadFile("/Maps/" + mapEditorScreen.mapName, gzippedMap)

--- a/core/src/com/unciv/ui/newgamescreen/NewGameScreen.kt
+++ b/core/src/com/unciv/ui/newgamescreen/NewGameScreen.kt
@@ -66,7 +66,7 @@ class NewGameScreen: PickerScreen(){
             rightSideButton.disable()
             rightSideButton.setText("Working...".tr())
 
-            thread {
+            thread(name="NewGame") {
                 // Creating a new game can take a while and we don't want ANRs
                 try {
                     newGame = GameStarter().startNewGame(newGameParameters,mapParameters)

--- a/core/src/com/unciv/ui/saves/SaveGameScreen.kt
+++ b/core/src/com/unciv/ui/saves/SaveGameScreen.kt
@@ -57,7 +57,7 @@ class SaveGameScreen : PickerScreen() {
         rightSideButton.setText("Save game".tr())
         rightSideButton.onClick {
             rightSideButton.setText("Saving...".tr())
-            thread{ 
+            thread(name="SaveGame"){
                 GameSaver().saveGame(UncivGame.Current.gameInfo, textField.text)
                 UncivGame.Current.setWorldScreen()
             }

--- a/core/src/com/unciv/ui/utils/CameraStageBaseScreen.kt
+++ b/core/src/com/unciv/ui/utils/CameraStageBaseScreen.kt
@@ -148,7 +148,7 @@ fun Actor.center(parent:Stage){ centerX(parent); centerY(parent)}
 fun Actor.onClickEvent(sound: UncivSound = UncivSound.Click, function: (event: InputEvent?, x: Float, y: Float) -> Unit) {
     this.addListener(object : ClickListener() {
         override fun clicked(event: InputEvent?, x: Float, y: Float) {
-            thread { Sounds.play(sound) }
+            thread(name="Sound") { Sounds.play(sound) }
             function(event, x, y)
         }
     })

--- a/core/src/com/unciv/ui/utils/UnitGroup.kt
+++ b/core/src/com/unciv/ui/utils/UnitGroup.kt
@@ -57,8 +57,8 @@ class UnitGroup(val unit: MapUnit, val size: Float): Group() {
         spinningCircle.center(this)
         spinningCircle.x += whiteHaloSize / 2 // to edge of white halo
         spinningCircle.setOrigin(spinningCircle.width / 2 - whiteHaloSize / 2, spinningCircle.height / 2)
-        addActor(spinningCircle)
-        spinningCircle.addAction(Actions.repeat(RepeatAction.FOREVER, Actions.rotateBy(90f, 1f)))
+        //addActor(spinningCircle)
+        //spinningCircle.addAction(Actions.repeat(RepeatAction.FOREVER, Actions.rotateBy(90f, 1f)))
         blackSpinningCircle = spinningCircle
     }
 }

--- a/core/src/com/unciv/ui/worldscreen/WorldMapHolder.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldMapHolder.kt
@@ -92,7 +92,7 @@ class WorldMapHolder(internal val worldScreen: WorldScreen, internal val tileMap
     }
 
     private fun addTileOverlaysWithUnitMovement(selectedUnit: MapUnit, tileInfo: TileInfo) {
-        thread {
+        thread(name="TurnsToGetThere") {
             /** LibGdx sometimes has these weird errors when you try to edit the UI layout from 2 separate threads.
              * And so, all UI editing will be done on the main thread.
              * The only "heavy lifting" that needs to be done is getting the turns to get there,

--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -143,7 +143,7 @@ class WorldScreen(val viewingCiv:CivilizationInfo) : CameraStageBaseScreen() {
         val loadingGamePopup = PopupTable(this)
         loadingGamePopup.add("Loading latest game state...")
         loadingGamePopup.open()
-        thread {
+        thread(name="MultiplayerLoad") {
             try {
                 val latestGame = OnlineMultiplayer().tryDownloadGame(gameInfo.gameId)
                 if(gameInfo.isUpToDate && gameInfo.currentPlayer==latestGame.currentPlayer) { // we were trying to download this to see when it's our turn...nothing changed
@@ -379,7 +379,7 @@ class WorldScreen(val viewingCiv:CivilizationInfo) : CameraStageBaseScreen() {
         shouldUpdate = true
 
 
-        thread { // on a separate thread so the user can explore their world while we're passing the turn
+        thread(name="NextTurn") { // on a separate thread so the user can explore their world while we're passing the turn
             val gameInfoClone = gameInfo.clone()
             gameInfoClone.setTransients()
             try {

--- a/core/src/com/unciv/ui/worldscreen/optionstable/WorldScreenMenuTable.kt
+++ b/core/src/com/unciv/ui/worldscreen/optionstable/WorldScreenMenuTable.kt
@@ -118,7 +118,7 @@ class WorldScreenMenuTable(val worldScreen: WorldScreen) : PopupTable(worldScree
                 badGameIdLabel.isVisible = true
                 return@addButton
             }
-            thread {
+            thread(name="MultiplayerDownload") {
                 try {
                     // The tryDownload can take more than 500ms. Therefore, to avoid ANRs,
                     // we need to run it in a different thread.

--- a/core/src/com/unciv/ui/worldscreen/optionstable/WorldScreenOptionsTable.kt
+++ b/core/src/com/unciv/ui/worldscreen/optionstable/WorldScreenOptionsTable.kt
@@ -182,7 +182,7 @@ class WorldScreenOptionsTable(val worldScreen:WorldScreen) : PopupTable(worldScr
 
             downloadMusicButton.onClick {
                 // So the whole game doesn't get stuck while downloading the file
-                thread {
+                thread(name="Music") {
                     try {
                         downloadMusicButton.disable()
                         errorTable.clear()

--- a/core/src/com/unciv/ui/worldscreen/unit/UnitContextMenu.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitContextMenu.kt
@@ -58,7 +58,7 @@ class UnitContextMenu(val tileMapHolder: WorldMapHolder, val selectedUnit: MapUn
 
     fun onMoveButtonClick() {
         // this can take a long time, because of the unit-to-tile calculation needed, so we put it in a different thread
-        thread {
+        thread(name="TileToMoveTo") {
             // these are the heavy parts, finding where we want to go
             // Since this runs in a different thread, even if we check movement.canReach()
             // then it might change until we get to the getTileToMoveTo, so we just try/catch it


### PR DESCRIPTION
For a green world (and a game less heavy on phone battery #1464 ), this is a proposal to switch to discrete rendering.

The only part of the game that requires (and actually forces) continuous rendering is the tiny rotating black circle around a selected icon. 
You can check how impactful on battery this change is. In this PR I just added a flag to Gdx graphics config and commented the two lines responsible of showing the spinning circle. If you agree this should be how the game behaves I can modify this commit and remove the blackSpinningCircle properly.

If you plan to have a game that needs continuous rendering (using several animations) maybe it could be possible to add an option to opt out of the heavily animated version in favor of the light one. As for now I think this should be the default.