### PR TITLE
Fix typos

### DIFF
--- a/core/src/com/unciv/UncivGame.kt
+++ b/core/src/com/unciv/UncivGame.kt
@@ -120,7 +120,7 @@ class UncivGame(
     fun loadGame(gameInfo:GameInfo){
         this.gameInfo = gameInfo
         ImageGetter.ruleset = gameInfo.ruleSet
-        ImageGetter.refreshAltas()
+        ImageGetter.refreshAtlas()
         worldScreen = WorldScreen(gameInfo.getPlayerToViewAs())
         setWorldScreen()
     }
@@ -144,7 +144,7 @@ class UncivGame(
     override fun resume() {
         super.resume()
         if(!isInitialized) return // The stuff from Create() is still happening, so the main screen will load eventually
-        ImageGetter.refreshAltas()
+        ImageGetter.refreshAtlas()
 
         // This is to solve a rare problem -
         // Sometimes, resume() is called and the gameInfo doesn't have any civilizations.

--- a/core/src/com/unciv/ui/utils/ImageGetter.kt
+++ b/core/src/com/unciv/ui/utils/ImageGetter.kt
@@ -38,7 +38,7 @@ object ImageGetter {
 
     fun setTextureRegionDrawables(){
         textureRegionDrawables.clear()
-        // These are the srawables from the base game
+        // These are the drawables from the base game
         for(region in atlas.regions){
             val drawable =TextureRegionDrawable(region)
             textureRegionDrawables[region.name] = drawable
@@ -46,9 +46,9 @@ object ImageGetter {
 
         // These are from the mods
         for(mod in ruleset.mods){
-            val modAltasFile = Gdx.files.local("mods/$mod/game.atlas")
-            if (modAltasFile.exists()) {
-                val modAtlas = TextureAtlas(modAltasFile)
+            val modAtlasFile = Gdx.files.local("mods/$mod/game.atlas")
+            if (modAtlasFile.exists()) {
+                val modAtlas = TextureAtlas(modAtlasFile)
                 for (region in modAtlas.regions) {
                     val drawable = TextureRegionDrawable(region)
                     textureRegionDrawables[region.name] = drawable
@@ -57,7 +57,7 @@ object ImageGetter {
         }
     }
 
-    fun refreshAltas() {
+    fun refreshAtlas() {
         atlas.dispose() // To avoid OutOfMemory exceptions
         atlas = TextureAtlas("game.atlas")
         setTextureRegionDrawables()


### PR DESCRIPTION
I noticed a couple typos - Atlas -> Altas, and drawables -> srawables. Fixed both the callers and the source typos.