### PR TITLE
Disable France culture boost after Steam Power research (#1662)

### DIFF
--- a/core/src/com/unciv/logic/city/CityStats.kt
+++ b/core/src/com/unciv/logic/city/CityStats.kt
@@ -110,7 +110,8 @@ class CityStats {
         val stats = Stats()
 
         val civUnique = cityInfo.civInfo.nation.unique
-        if (civUnique == "+2 Culture per turn from cities before discovering Steam Power")
+        if (civUnique == "+2 Culture per turn from cities before discovering Steam Power"
+            && !cityInfo.civInfo.tech.isResearched("Steam Power"))
             stats.culture += 2
 
         return stats


### PR DESCRIPTION
The fix for the bug: **France gets the culture boost even when "Steam power" is researched** #1662