### PR TITLE
Fix: ability to buy the same building multiple times

### DIFF
--- a/core/src/com/unciv/ui/cityscreen/ConstructionsTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/ConstructionsTable.kt
@@ -251,6 +251,7 @@ class ConstructionsTable(val cityScreen: CityScreen) : Table(CameraStageBaseScre
                     && !city.isPuppet) {
                 button.onClick {
                     cityConstructions.addToQueue(construction.name)
+                    if (!construction.shouldBeDisplayed(cityConstructions)) cityScreen.selectedConstruction = null
                     cityScreen.update()
                 }
             } else {
@@ -286,6 +287,7 @@ class ConstructionsTable(val cityScreen: CityScreen) : Table(CameraStageBaseScre
                         selectedQueueEntry = -2
                         cityScreen.selectedConstruction = null
                     }
+                    if (!construction.shouldBeDisplayed(cityConstructions)) cityScreen.selectedConstruction = null
                     cityScreen.update()
                 }, cityScreen)
             }


### PR DESCRIPTION
As mentioned by `Hero of Legend` on Discord:

> When you purchase a building from the building queue,  the buy button remains active after the transaction so long as you don't navigate to a different city or to the overworld map. This allows you to buy duplicates of buildings in a single city.
![image](https://user-images.githubusercontent.com/26433289/72337408-968c5500-36d3-11ea-87e1-d7c7627967d9.png)

The building stayed "selected" after buying/adding it to the queue