### PR TITLE
Fix: ships being teleported into landlocked cities

### DIFF
--- a/core/src/com/unciv/logic/city/CityInfo.kt
+++ b/core/src/com/unciv/logic/city/CityInfo.kt
@@ -130,9 +130,6 @@ class CityInfo {
     fun isConnectedToCapital() = civInfo.citiesConnectedToCapital.contains(this)
     fun isInResistance() = resistanceCounter>0
 
-    /** Returns true when there is at least one water tile next to city center  */
-    fun isCoastal() = getCenterTile().getTilesAtDistance(1).any { it.isWater }
-
 
     fun getRuleset() = civInfo.gameInfo.ruleSet
 

--- a/core/src/com/unciv/logic/city/CityInfo.kt
+++ b/core/src/com/unciv/logic/city/CityInfo.kt
@@ -130,6 +130,9 @@ class CityInfo {
     fun isConnectedToCapital() = civInfo.citiesConnectedToCapital.contains(this)
     fun isInResistance() = resistanceCounter>0
 
+    /** Returns true when there is at least one water tile next to city center  */
+    fun isCoastal() = getCenterTile().getTilesAtDistance(1).any { it.isWater }
+
 
     fun getRuleset() = civInfo.gameInfo.ruleSet
 

--- a/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
+++ b/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
@@ -188,6 +188,7 @@ class UnitMovementAlgorithms(val unit:MapUnit) {
     fun teleportToClosestMoveableTile(){
         var allowedTile:TileInfo? = null
         var distance=0
+        // When we didn't limit the allowed distance the game would sometimes spend a whole minute looking for a suitable tile.
         while(allowedTile==null && distance<5){
             distance++
             allowedTile = unit.getTile().getTilesAtDistance(distance)
@@ -195,10 +196,9 @@ class UnitMovementAlgorithms(val unit:MapUnit) {
         }
 
         // No tile within 4 spaces? move him to a city.
-        // When we didn't limit the allowed distance the game would sometimes spend a whole minute looking for a suitable tile.
         if(allowedTile==null){
             for(city in unit.civInfo.cities){
-                allowedTile = city.getCenterTile().getTilesInDistance(1)
+                allowedTile = city.getTiles()
                         .firstOrNull { canMoveTo(it) }
                 if(allowedTile!=null) break
             }

--- a/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
+++ b/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
@@ -276,7 +276,10 @@ class UnitMovementAlgorithms(val unit:MapUnit) {
     // because optimization on this function results in massive benefits!
     fun canPassThrough(tile: TileInfo):Boolean{
         if(tile.getBaseTerrain().impassable) return false
-        if(tile.isLand && unit.type.isWaterUnit() && !tile.isCityCenter())
+        if (tile.isLand
+                && unit.type.isWaterUnit()
+                // Check that the tile is not a coastal city's center
+                && !(tile.isCityCenter() && tile.getCity()?.isCoastal() == true))
             return false
 
         if(tile.isWater && unit.type.isLandUnit()){

--- a/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
+++ b/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
@@ -279,7 +279,7 @@ class UnitMovementAlgorithms(val unit:MapUnit) {
         if (tile.isLand
                 && unit.type.isWaterUnit()
                 // Check that the tile is not a coastal city's center
-                && !(tile.isCityCenter() && tile.getCity()?.isCoastal() == true))
+                && !(tile.isCityCenter() && tile.isCoastalTile()))
             return false
 
         if(tile.isWater && unit.type.isLandUnit()){


### PR DESCRIPTION
Cpt. Klutz on Discord:
> Naval units trapped in expanding borders can be moved to landlocked cities
(actually quite hilarious)
![image](https://user-images.githubusercontent.com/26433289/72664598-f30fad00-3a10-11ea-86fc-f6f965543e78.png)

Why I didn't use existing `TileInfo.isCoastalTile()`: 
I am pretty sure if the someone creates a custom map where the land is surrounded directly by Ocean and not Coast, this would fail