### PR TITLE
Barbarians don't move/attack on the turn of their spawning

### DIFF
--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -73,7 +73,6 @@ class GameInfo {
             currentPlayerIndex = (currentPlayerIndex+1) % civilizations.size
             if(currentPlayerIndex==0){
                 turns++
-                if (turns % 10 == 0 && !gameParameters.noBarbarians) placeBarbarians()
             }
             thisPlayer = civilizations[currentPlayerIndex]
             thisPlayer.startTurn()
@@ -82,8 +81,14 @@ class GameInfo {
         switchTurn()
 
         while(thisPlayer.playerType==PlayerType.AI){
-            if(thisPlayer.isBarbarian() || !thisPlayer.isDefeated())
+            if(thisPlayer.isBarbarian() || !thisPlayer.isDefeated()) {
                 NextTurnAutomation().automateCivMoves(thisPlayer)
+
+                // Placing barbarians after their turn
+                if (thisPlayer.isBarbarian()
+                        && !gameParameters.noBarbarians
+                        && turns % 10 == 0) placeBarbarians()
+            }
             switchTurn()
         }
 

--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -42,6 +42,7 @@ class MapUnit {
     lateinit var name: String
     var currentMovement: Float = 0f
     var health:Int = 100
+    var createdThisTurn = true
 
     var mapUnitAction : MapUnitAction? = null
 
@@ -77,6 +78,7 @@ class MapUnit {
         toReturn.name=name
         toReturn.currentMovement=currentMovement
         toReturn.health=health
+        toReturn.createdThisTurn=createdThisTurn
         toReturn.action=action
         toReturn.attacksThisTurn=attacksThisTurn
         toReturn.promotions=promotions.clone()
@@ -397,6 +399,7 @@ class MapUnit {
 
 
     fun endTurn() {
+        createdThisTurn = false
         doPostTurnAction()
         if(currentMovement== getMaxMovement().toFloat() // didn't move this turn
                 || getUniques().contains("Unit will heal every turn, even if it performs an action")){
@@ -405,7 +408,7 @@ class MapUnit {
     }
 
     fun startTurn(){
-        currentMovement = getMaxMovement().toFloat()
+        currentMovement = if (createdThisTurn && civInfo.isBarbarian()) 0f else getMaxMovement().toFloat()
         attacksThisTurn=0
         due = true
 

--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -42,7 +42,6 @@ class MapUnit {
     lateinit var name: String
     var currentMovement: Float = 0f
     var health:Int = 100
-    var createdThisTurn = true
 
     var mapUnitAction : MapUnitAction? = null
 
@@ -78,7 +77,6 @@ class MapUnit {
         toReturn.name=name
         toReturn.currentMovement=currentMovement
         toReturn.health=health
-        toReturn.createdThisTurn=createdThisTurn
         toReturn.action=action
         toReturn.attacksThisTurn=attacksThisTurn
         toReturn.promotions=promotions.clone()
@@ -399,7 +397,6 @@ class MapUnit {
 
 
     fun endTurn() {
-        createdThisTurn = false
         doPostTurnAction()
         if(currentMovement== getMaxMovement().toFloat() // didn't move this turn
                 || getUniques().contains("Unit will heal every turn, even if it performs an action")){
@@ -408,7 +405,7 @@ class MapUnit {
     }
 
     fun startTurn(){
-        currentMovement = if (createdThisTurn && civInfo.isBarbarian()) 0f else getMaxMovement().toFloat()
+        currentMovement = getMaxMovement().toFloat()
         attacksThisTurn=0
         due = true
 


### PR DESCRIPTION
Hipster69 on Discord:
> Don't let spawned barbarian camps and units attack in the very same turn. There is no counter attack for this. They suddenly spawn, they spawn units too, and they kill your units immediately.
![image](https://user-images.githubusercontent.com/26433289/72666422-29eebe80-3a23-11ea-923f-cdcb9a48bb6c.png)
