### PR TITLE
Hotfix empty entry in construction queue

### DIFF
--- a/core/src/com/unciv/logic/city/CityConstructions.kt
+++ b/core/src/com/unciv/logic/city/CityConstructions.kt
@@ -329,7 +329,7 @@ class CityConstructions {
 
     fun addToQueue(constructionName: String) {
         if (!isQueueFull()) {
-            if (isQueueEmpty() && currentConstruction == "Nothing") {
+            if (isQueueEmpty() && currentConstruction == "" || currentConstruction == "Nothing") {
                 currentConstruction = constructionName
                 currentConstructionIsUserSet = true
             } else


### PR DESCRIPTION
This is a high priority change that should be merged to fix the issue where `currentConstruction = ""` is not treated the same as `"Nothing"`. 

Fix #1722 