### PR TITLE
Quick access to civilizations' diplomacy screen

### DIFF
--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -522,13 +522,13 @@ class CivilizationInfo {
 
             if (newAllyName != "") {
                 val newAllyCiv = gameInfo.getCivilization(newAllyName)
-                newAllyCiv.addNotification("We have allied with [${civName}].", Color.GREEN)
+                newAllyCiv.addNotification("We have allied with [${civName}].", getCapital().location, Color.GREEN)
                 newAllyCiv.updateViewableTiles()
                 newAllyCiv.updateDetailedCivResources()
             }
             if (oldAllyName != "") {
                 val oldAllyCiv = gameInfo.getCivilization(oldAllyName)
-                oldAllyCiv.addNotification("We have lost alliance with [${civName}].", Color.RED)
+                oldAllyCiv.addNotification("We have lost alliance with [${civName}].", getCapital().location, Color.RED)
                 oldAllyCiv.updateViewableTiles()
                 oldAllyCiv.updateDetailedCivResources()
             }

--- a/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
@@ -264,10 +264,10 @@ class DiplomacyManager() {
         else influence = restingPoint
 
         if (getTurnsToRelationshipChange() == 1)
-            otherCiv().addNotification("Your relationship with [${civInfo.civName}] is about to degrade", null, Color.GOLD)
+            otherCiv().addNotification("Your relationship with [${civInfo.civName}] is about to degrade", civInfo.getCapital().location, Color.GOLD)
 
         if (initialRelationshipLevel >= RelationshipLevel.Friend && initialRelationshipLevel != relationshipLevel())
-            otherCiv().addNotification("Your relationship with [${civInfo.civName}] degraded", null, Color.GOLD)
+            otherCiv().addNotification("Your relationship with [${civInfo.civName}] degraded", civInfo.getCapital().location, Color.GOLD)
     }
 
     private fun nextTurnFlags() {

--- a/core/src/com/unciv/ui/tilegroups/CityButton.kt
+++ b/core/src/com/unciv/ui/tilegroups/CityButton.kt
@@ -14,6 +14,7 @@ import com.unciv.logic.city.CityConstructions
 import com.unciv.logic.city.CityInfo
 import com.unciv.logic.city.SpecialConstruction
 import com.unciv.ui.cityscreen.CityScreen
+import com.unciv.ui.trade.DiplomacyScreen
 import com.unciv.ui.utils.*
 
 class CityButton(val city: CityInfo, internal val tileGroup: WorldTileGroup, skin: Skin): Table(skin){
@@ -61,11 +62,12 @@ class CityButton(val city: CityInfo, internal val tileGroup: WorldTileGroup, ski
     private fun setButtonActions() {
 
         val unitTable = tileGroup.worldScreen.bottomUnitTable
+
+        // So you can click anywhere on the button to go to the city
+        touchable = Touchable.childrenOnly
+
         if (UncivGame.Current.viewEntireMapForDebug || belongsToViewingCiv()) {
-
-            // So you can click anywhere on the button to go to the city
-            touchable = Touchable.childrenOnly
-
+            // If this city belongs to you,
             // clicking swings the button a little down to allow selection of units there.
             // this also allows to target selected units to move to the city tile from elsewhere.
             // second tap on the button will go to the city screen
@@ -76,6 +78,17 @@ class CityButton(val city: CityInfo, internal val tileGroup: WorldTileGroup, ski
                     moveButtonDown()
                     if (unitTable.selectedUnit == null || unitTable.selectedUnit!!.currentMovement == 0f)
                         tileGroup.selectCity(city)
+                }
+            }
+        } else {
+            onClick {
+                // If city doesn't belong to you, go directly to its owner's diplomacy screen,
+                // only when you don't have a unit selected for attacking that same city.
+                if (unitTable.selectedUnit == null)
+                {
+                    val screen = DiplomacyScreen(UncivGame.Current.worldScreen.viewingCiv)
+                    screen.updateRightSide(city.civInfo)
+                    UncivGame.Current.setScreen(screen)
                 }
             }
         }


### PR DESCRIPTION
I like to play with many city-states, but it's difficult to fish out the one whose alliance/friendship status is about to change from the current diplomacy screen. Only the civilization icons are shown at the moment, leading to "Which one of these same-shape-but-different-color guys is Florence again?"

Clicking on another civilization's cities should lead to its diplomacy screen now, just like in the original game. Also, notifications related to city-states' pending or occurred status change lead the camera right to them so you can pay another 250 gold right away.

I think it's still preferred to display names on the left panel in the diplomacy screen though, so we don't have to click through each and every icon to find whomever is needed. I can work on this in another PR.