### PR TITLE
Fix: Oligarchy

### DIFF
--- a/core/src/com/unciv/logic/civilization/CivInfoStats.kt
+++ b/core/src/com/unciv/logic/civilization/CivInfoStats.kt
@@ -18,7 +18,11 @@ class CivInfoStats(val civInfo: CivilizationInfo){
         val freeUnits = 3
         var unitsToPayFor = civInfo.getCivUnits()
         if(civInfo.policies.isAdopted("Oligarchy"))
-            unitsToPayFor = unitsToPayFor.filterNot { it.getTile().isCityCenter() }
+            // Only land military units can truly "garrison"
+            unitsToPayFor = unitsToPayFor.filterNot {
+                it.getTile().isCityCenter()
+                        && it.canGarrison()
+            }
 
         var numberOfUnitsToPayFor = max(0f, unitsToPayFor.count().toFloat() - freeUnits)
         if(civInfo.nation.unique=="67% chance to earn 25 Gold and recruit a Barbarian unit from a conquered encampment, -25% land units maintenance."){

--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -280,6 +280,8 @@ class MapUnit {
         if(hasUnique("This unit and all others in adjacent tiles heal 5 additional HP. This unit heals 5 additional HP outside of friendly territory.")) healingBonus +=5
         return healingBonus
     }
+    
+    fun canGarrison() = type.isMilitary() && type.isLandUnit()
 
     //endregion
 

--- a/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
+++ b/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
@@ -243,6 +243,12 @@ class UnitMovementAlgorithms(val unit:MapUnit) {
         unit.removeFromTile()
         unit.putInTile(destination)
 
+        // Unit maintenance changed
+        if (unit.canGarrison()
+            && (origin.isCityCenter() || destination.isCityCenter())
+            && unit.civInfo.policies.isAdopted("Oligarchy")
+        ) unit.civInfo.updateStatsForNextTurn()
+
         if(unit.type.isAircraftCarrierUnit() || unit.type.isMissileCarrierUnit()){ // bring along the payloads
             for(airUnit in origin.airUnits.filter { !it.isUnitInCity }){
                 airUnit.removeFromTile()


### PR DESCRIPTION
* Added `CivInfo.updateStatsForNextTurn()` call when the unit enters/leaves the city and the Oligarchy is adopted
* Narrowed down the Oligarchy effect to match original civ5 (Air/Water/Civilian units can't be garrisoned)