### PR TITLE
Add popup on Overview -> Resources (#1684) 

### DIFF
--- a/core/src/com/unciv/ui/EmpireOverviewScreen.kt
+++ b/core/src/com/unciv/ui/EmpireOverviewScreen.kt
@@ -378,8 +378,17 @@ class EmpireOverviewScreen(val viewingPlayer:CivilizationInfo) : CameraStageBase
         val resources = resourceDrilldown.map { it.resource }
                 .filter { it.resourceType!=ResourceType.Bonus }.distinct().sortedBy { it.resourceType }
 
-        for(resource in resources)
-            resourcesTable.add(ImageGetter.getResourceImage(resource.name,50f))
+        for(resource in resources) {
+            val resourceImage = ImageGetter.getResourceImage(resource.name, 50f)
+            resourceImage.onClick {
+                val popup = Popup(this)
+                popup.add(resource.name)
+                popup.row()
+                popup.addCloseButton()
+                popup.open()
+            }
+            resourcesTable.add(resourceImage)
+        }
         resourcesTable.addSeparator()
 
         val origins = resourceDrilldown.map { it.origin }.distinct()

--- a/core/src/com/unciv/ui/worldscreen/WorldScreenTopBar.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreenTopBar.kt
@@ -94,10 +94,7 @@ class WorldScreenTopBar(val worldScreen: WorldScreen) : Table() {
         val menuButton = ImageGetter.getImage("OtherIcons/MenuIcon")
                 .apply { setSize(50f, 50f) }
         menuButton.color = Color.WHITE
-        menuButton.onClick {
-            if(worldScreen.stage.actors.none { it is WorldScreenMenuPopup })
-                WorldScreenMenuPopup(worldScreen)
-        }
+        menuButton.onClick { WorldScreenMenuPopup(worldScreen) }
         menuButton.centerY(this)
         menuButton.x = menuButton.y
         return menuButton


### PR DESCRIPTION
I really tried to get the "touch to show resource name" behavior. There is a really nice libgdx class `TextTooltip` which I would've liked to use. It looked very nice on desktop.

However (obviously) it didn't work out of the box on Android (as tooltips normally don't make much sense there). However, in this case, without there being an action behind the resource icons, it would've been nice to have a "touch for tooltip" behavior. The `Tooltip` classes though are so badly extensible that it is completely impossible to add this behavior without completely rewriting them from scratch. Thus I have chosen to use a simple `Popup`.

That works, but the Popup blocks view of the table while open and requires another click to close. But whatever, you're not going to use it very often and it didn't require to add a whole new set of class(es) which actually would add the behavior I would've wanted. Now it's just a few lines of code.