### PR TITLE
Fix: being able to acquire another player's tiles in multiplayer

### DIFF
--- a/core/src/com/unciv/logic/city/CityInfo.kt
+++ b/core/src/com/unciv/logic/city/CityInfo.kt
@@ -522,10 +522,11 @@ class CityInfo {
         tryUpdateRoadStatus()
     }
 
+    // Acquiring in this context means transferring ownership to another city of the same civ
     fun canAcquireTile(newTileInfo: TileInfo): Boolean {
         val owningCity = newTileInfo.getCity()
         if (owningCity!=null && owningCity!=this
-                && newTileInfo.getOwner()!!.isPlayerCivilization()
+                && newTileInfo.getOwner()!!.isCurrentPlayer()
                 && newTileInfo.arialDistanceTo(getCenterTile()) <= 3
                 && newTileInfo.neighbors.any{it.getCity()==this}) {
             return true


### PR DESCRIPTION
JohnnyRaylander on Discord:

> In multiplayer, I'm able to "acquire" a tile from another person from the city screen as if their city was my own.