### PR TITLE
Add missing Forge and Seaport production bonus uniques

### DIFF
--- a/android/assets/jsons/Buildings.json
+++ b/android/assets/jsons/Buildings.json
@@ -410,7 +410,8 @@
 		"hurryCostModifier": 25,
 		"requiredNearbyImprovedResources": ["Iron"],
 		"resourceBonusStats": {"production": 1},
-		"requiredTech": "Metal Casting"
+		"requiredTech": "Metal Casting",
+		"uniques": ["+15% production of land units"]
 	},
 	{
 		"name": "Harbor",

--- a/android/assets/jsons/translationsByLanguage/Czech.properties
+++ b/android/assets/jsons/translationsByLanguage/Czech.properties
@@ -139,6 +139,8 @@ Longhouse = Dlouhý dům
 +1 Production from each worked Forest tile = +1 produkce pro každého dělníka na políčku s lesem
 
 Forge = Kovárna
+ # Requires translation!
++15% production of land units = 
 
 Harbor = Přístav
 +1 production from all sea resources worked by the city = +1 produkce ze všech mořských zdrojů využívaných městem

--- a/android/assets/jsons/translationsByLanguage/Dutch.properties
+++ b/android/assets/jsons/translationsByLanguage/Dutch.properties
@@ -189,7 +189,9 @@ Longhouse =
 +1 Production from each worked Forest tile = 
 
  # Requires translation!
-Forge = 
+Forge =
+ # Requires translation!
++15% production of land units = 
 
  # Requires translation!
 Harbor = 

--- a/android/assets/jsons/translationsByLanguage/English.properties
+++ b/android/assets/jsons/translationsByLanguage/English.properties
@@ -227,7 +227,9 @@ Longhouse =
 +1 Production from each worked Forest tile = 
 
  # Requires translation!
-Forge = 
+Forge =
+ # Requires translation!
++15% production of land units = 
 
  # Requires translation!
 Harbor = 

--- a/android/assets/jsons/translationsByLanguage/French.properties
+++ b/android/assets/jsons/translationsByLanguage/French.properties
@@ -134,6 +134,7 @@ Longhouse = Longère
 +1 Production from each worked Forest tile = +1 production pour chaque cases de forêt exploitées par la ville.
 
 Forge = Forge
++15% production of land units = +15% à la production d'unités terrestre
 
 Harbor = Havre
 +1 production from all sea resources worked by the city = +1 de production pour toutes les ressources maritimes exploitées par la ville

--- a/android/assets/jsons/translationsByLanguage/German.properties
+++ b/android/assets/jsons/translationsByLanguage/German.properties
@@ -139,6 +139,8 @@ Longhouse = Langhaus
 +1 Production from each worked Forest tile = +1 Produktion von jedem bewirtschafteten Waldfeld
 
 Forge = Schmiede
+ # Requires translation!
++15% production of land units = 
 
 Harbor = Hafen
 +1 production from all sea resources worked by the city = +1 Produktion von allen Meer Ressourcen die von dieser Stadt bewirtschaftet werden

--- a/android/assets/jsons/translationsByLanguage/Indonesian.properties
+++ b/android/assets/jsons/translationsByLanguage/Indonesian.properties
@@ -141,6 +141,8 @@ Longhouse = Bengkel Panjang
 +1 Production from each worked Forest tile = +1 Produksi dari daerah hutan yang dikelolah
 
 Forge = Penempa Besi
+ # Requires translation!
++15% production of land units = 
 
 Harbor = Pelabuhan
 +1 production from all sea resources worked by the city = +1 Produksi dari semua sumber daya laut yang dikelolah di kota ini

--- a/android/assets/jsons/translationsByLanguage/Italian.properties
+++ b/android/assets/jsons/translationsByLanguage/Italian.properties
@@ -134,6 +134,8 @@ Longhouse = Casa Lunga
 +1 Production from each worked Forest tile = +1 Produzione da ogni casella di Foresta sfruttata dalla città
 
 Forge = Fucina
+ # Requires translation!
++15% production of land units = 
 
 Harbor = Porto
 +1 production from all sea resources worked by the city = +1 Produzione per ogni risorsa marittima sfruttata

--- a/android/assets/jsons/translationsByLanguage/Korean.properties
+++ b/android/assets/jsons/translationsByLanguage/Korean.properties
@@ -151,6 +151,8 @@ Longhouse = 롱하우스
 +1 Production from each worked Forest tile = 도시에서 작업하는 숲 타일마다 생산력 +1
 
 Forge = 대장간
+ # Requires translation!
++15% production of land units = 
 
 Harbor = 항만
 +1 production from all sea resources worked by the city = 도시에서 작업하는 모든 해양 자원의 생산력 +1

--- a/android/assets/jsons/translationsByLanguage/Malay.properties
+++ b/android/assets/jsons/translationsByLanguage/Malay.properties
@@ -206,7 +206,9 @@ Longhouse =
 +1 Production from each worked Forest tile = 
 
  # Requires translation!
-Forge = 
+Forge =
+ # Requires translation!
++15% production of land units = 
 
  # Requires translation!
 Harbor = 

--- a/android/assets/jsons/translationsByLanguage/Polish.properties
+++ b/android/assets/jsons/translationsByLanguage/Polish.properties
@@ -134,6 +134,8 @@ Longhouse = Długi dom
 +1 Production from each worked Forest tile = +1 do produkcji za każde pracujące pole lasu
 
 Forge = Kuźnia
+ # Requires translation!
++15% production of land units = 
 
 Harbor = Port
 +1 production from all sea resources worked by the city = +1 do produkcji za każdy wydobywany surowiec morski

--- a/android/assets/jsons/translationsByLanguage/Portuguese.properties
+++ b/android/assets/jsons/translationsByLanguage/Portuguese.properties
@@ -139,6 +139,8 @@ Longhouse = Casa longa
 +1 Production from each worked Forest tile = +1 de produção de cada solo de floresta trabalhado.
 
 Forge = Forja
+ # Requires translation!
++15% production of land units = 
 
 Harbor = Porto
 +1 production from all sea resources worked by the city = 1+ de produção de todos os recursos marítimos trabalhados pelo cidade

--- a/android/assets/jsons/translationsByLanguage/Romanian.properties
+++ b/android/assets/jsons/translationsByLanguage/Romanian.properties
@@ -163,6 +163,8 @@ Longhouse =
 +1 Production from each worked Forest tile = 
 
 Forge = Forjă
+ # Requires translation!
++15% production of land units = 
 
 Harbor = Port
 +1 production from all sea resources worked by the city = +1 producție din toate resursele maritime prelucrate de oraș

--- a/android/assets/jsons/translationsByLanguage/Russian.properties
+++ b/android/assets/jsons/translationsByLanguage/Russian.properties
@@ -134,6 +134,8 @@ Longhouse = Длинный дом
 +1 Production from each worked Forest tile = +1 Производства за каждую обрабатываемую лесную клетку
 
 Forge = Кузница
+ # Requires translation!
++15% production of land units = 
 
 Harbor = Порт
 +1 production from all sea resources worked by the city = +1 Производство от всех обрабатываемых городом морских клеток

--- a/android/assets/jsons/translationsByLanguage/Simplified_Chinese.properties
+++ b/android/assets/jsons/translationsByLanguage/Simplified_Chinese.properties
@@ -137,6 +137,8 @@ Longhouse = 长屋
 +1 Production from each worked Forest tile = 每个工作的森林地块+1产能
 
 Forge = 锻造场
+ # Requires translation!
++15% production of land units = 
 
 Harbor = 港口
 +1 production from all sea resources worked by the city = 所在城市每个已开发的海洋资源+1产能

--- a/android/assets/jsons/translationsByLanguage/Spanish.properties
+++ b/android/assets/jsons/translationsByLanguage/Spanish.properties
@@ -134,6 +134,8 @@ Longhouse = Casa comunal
 +1 Production from each worked Forest tile = +1 de producción por cada casilla de Bosque explotada
 
 Forge = Forja
+ # Requires translation!
++15% production of land units = 
 
 Harbor = Puerto
 +1 production from all sea resources worked by the city = +1 de produccion a todos los recursos acuaticos trabajados por la ciudad

--- a/android/assets/jsons/translationsByLanguage/Thai.properties
+++ b/android/assets/jsons/translationsByLanguage/Thai.properties
@@ -128,6 +128,8 @@ Longhouse = บ้านหลังยาวของชาวป่า
 +1 Production from each worked Forest tile = +1 การผลิตจากการทำงานบนช่องพื้นที่ป่า
 
 Forge = โรงตีเหล็ก
+ # Requires translation!
++15% production of land units = 
 
 Harbor = ท่าเรือ
 +1 production from all sea resources worked by the city = +1 การผลิตจากทรัพยากรทางทะเลทั้งหมดที่ได้จากการทำงานใกล้เมือง

--- a/android/assets/jsons/translationsByLanguage/Traditional_Chinese.properties
+++ b/android/assets/jsons/translationsByLanguage/Traditional_Chinese.properties
@@ -138,6 +138,8 @@ Longhouse = 長屋
 +1 Production from each worked Forest tile = 每個工作的森林地區+1產能
 
 Forge = 鍛造場
+ # Requires translation!
++15% production of land units = 
 
 Harbor = 港口
 +1 production from all sea resources worked by the city = 所在城市每個已開發的海洋資源+1產能

--- a/android/assets/jsons/translationsByLanguage/Turkish.properties
+++ b/android/assets/jsons/translationsByLanguage/Turkish.properties
@@ -134,6 +134,8 @@ Longhouse = Uzun Ev
 +1 Production from each worked Forest tile = Çalışılan her Ormandan +1 üretim
 
 Forge = Demirci Ocağı
+ # Requires translation!
++15% production of land units = 
 
 Harbor = Liman
 +1 production from all sea resources worked by the city = Şehrin çalıştığı tüm deniz kaynaklarından +1 üretim

--- a/android/assets/jsons/translationsByLanguage/Ukrainian.properties
+++ b/android/assets/jsons/translationsByLanguage/Ukrainian.properties
@@ -133,6 +133,8 @@ Longhouse = Довгий будинок
 +1 Production from each worked Forest tile = +1 виробництво за кожну робочу лісову клітинку
 
 Forge = Кузня
+ # Requires translation!
++15% production of land units = 
 
 Harbor = Гавань
 +1 production from all sea resources worked by the city = +1 виробництво за усі робочі морські ресурси міста

--- a/android/assets/jsons/translationsByLanguage/template.properties
+++ b/android/assets/jsons/translationsByLanguage/template.properties
@@ -132,7 +132,9 @@ Workshop =
 Longhouse = 
 +1 Production from each worked Forest tile = 
 
-Forge = 
+Forge =
+ # Requires translation!
++15% production of land units = 
 
 Harbor = 
 +1 production from all sea resources worked by the city = 

--- a/core/src/com/unciv/logic/city/CityStats.kt
+++ b/core/src/com/unciv/logic/city/CityStats.kt
@@ -289,10 +289,12 @@ class CityStats {
     }
 
     private fun getStatPercentBonusesFromBuildings(): Stats {
-        val stats = cityInfo.cityConstructions.getStatPercentBonuses()
-        if (cityInfo.civInfo.containsBuildingUnique("Culture in all cities increased by 25%")) stats.culture += 25f
-
+        val stats               = cityInfo.cityConstructions.getStatPercentBonuses()
         val currentConstruction = cityInfo.cityConstructions.getCurrentConstruction()
+
+        if (cityInfo.civInfo.containsBuildingUnique("Culture in all cities increased by 25%"))
+            stats.culture += 25f
+
         if (currentConstruction is Building && currentConstruction.uniques.contains("Spaceship part")) {
             if (cityInfo.civInfo.containsBuildingUnique("Increases production of spaceship parts by 25%"))
                 stats.production += 25
@@ -300,9 +302,17 @@ class CityStats {
                 stats.production += 50
         }
 
-        if (currentConstruction is BaseUnit && currentConstruction.unitType == UnitType.Mounted
-                && cityInfo.containsBuildingUnique("+15% Production when building Mounted Units in this city"))
-            stats.production += 15
+        if (currentConstruction is BaseUnit) {
+            if (currentConstruction.unitType == UnitType.Mounted
+                    && cityInfo.containsBuildingUnique("+15% Production when building Mounted Units in this city"))
+                stats.production += 15
+            if (currentConstruction.unitType.isLandUnit()
+                    && cityInfo.containsBuildingUnique("+15% production of land units"))
+                stats.production += 15
+            if (currentConstruction.unitType.isWaterUnit()
+                    && cityInfo.containsBuildingUnique("+15% production of naval units"))
+                stats.production += 15
+        }
 
         return stats
     }


### PR DESCRIPTION
Parital fix for #1762
- Add unique feature to Forge "+15% production of land units"
- Implements Seaport feature "+15% production of naval units" that exists but was non-functional