### PR TITLE
Added quick access to diplomacy screen with other civilizations

### DIFF
--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -541,13 +541,13 @@ class CivilizationInfo {
 
             if (newAllyName != "") {
                 val newAllyCiv = gameInfo.getCivilization(newAllyName)
-                newAllyCiv.addNotification("We have allied with [${civName}].", Color.GREEN)
+                newAllyCiv.addNotification("We have allied with [${civName}].", getCapital().location, Color.GREEN)
                 newAllyCiv.updateViewableTiles()
                 newAllyCiv.updateDetailedCivResources()
             }
             if (oldAllyName != "") {
                 val oldAllyCiv = gameInfo.getCivilization(oldAllyName)
-                oldAllyCiv.addNotification("We have lost alliance with [${civName}].", Color.RED)
+                oldAllyCiv.addNotification("We have lost alliance with [${civName}].", getCapital().location, Color.RED)
                 oldAllyCiv.updateViewableTiles()
                 oldAllyCiv.updateDetailedCivResources()
             }

--- a/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
@@ -275,10 +275,10 @@ class DiplomacyManager() {
         else influence = restingPoint
 
         if (getTurnsToRelationshipChange() == 1)
-            otherCiv().addNotification("Your relationship with [${civInfo.civName}] is about to degrade", null, Color.GOLD)
+            otherCiv().addNotification("Your relationship with [${civInfo.civName}] is about to degrade", civInfo.getCapital().location, Color.GOLD)
 
         if (initialRelationshipLevel >= RelationshipLevel.Friend && initialRelationshipLevel != relationshipLevel())
-            otherCiv().addNotification("Your relationship with [${civInfo.civName}] degraded", null, Color.GOLD)
+            otherCiv().addNotification("Your relationship with [${civInfo.civName}] degraded", civInfo.getCapital().location, Color.GOLD)
     }
 
     private fun nextTurnFlags() {

--- a/core/src/com/unciv/ui/tilegroups/CityButton.kt
+++ b/core/src/com/unciv/ui/tilegroups/CityButton.kt
@@ -14,6 +14,7 @@ import com.unciv.logic.city.CityConstructions
 import com.unciv.logic.city.CityInfo
 import com.unciv.logic.city.SpecialConstruction
 import com.unciv.ui.cityscreen.CityScreen
+import com.unciv.ui.trade.DiplomacyScreen
 import com.unciv.ui.utils.*
 
 class CityButton(val city: CityInfo, internal val tileGroup: WorldTileGroup, skin: Skin): Table(skin){
@@ -61,22 +62,29 @@ class CityButton(val city: CityInfo, internal val tileGroup: WorldTileGroup, ski
     private fun setButtonActions() {
 
         val unitTable = tileGroup.worldScreen.bottomUnitTable
-        if (UncivGame.Current.viewEntireMapForDebug || belongsToViewingCiv()) {
 
-            // So you can click anywhere on the button to go to the city
-            touchable = Touchable.childrenOnly
+        // So you can click anywhere on the button to go to the city
+        touchable = Touchable.childrenOnly
 
+        onClick {
             // clicking swings the button a little down to allow selection of units there.
             // this also allows to target selected units to move to the city tile from elsewhere.
-            // second tap on the button will go to the city screen
-            onClick {
-                if (isButtonMoved) {
+            if (isButtonMoved) {
+                // second tap on the button will go to the city screen
+                // if this city belongs to you
+                if (UncivGame.Current.viewEntireMapForDebug || belongsToViewingCiv()) {
                     UncivGame.Current.setScreen(CityScreen(city))
                 } else {
-                    moveButtonDown()
-                    if (unitTable.selectedUnit == null || unitTable.selectedUnit!!.currentMovement == 0f)
-                        tileGroup.selectCity(city)
+                    // If city doesn't belong to you, go directly to its owner's diplomacy screen.
+                    val screen = DiplomacyScreen(UncivGame.Current.worldScreen.viewingCiv)
+                    screen.updateRightSide(city.civInfo)
+                    UncivGame.Current.setScreen(screen)
                 }
+            } else {
+                moveButtonDown()
+                if ((unitTable.selectedUnit == null || unitTable.selectedUnit!!.currentMovement == 0f) &&
+                            belongsToViewingCiv())
+                    tileGroup.selectCity(city)
             }
         }
 


### PR DESCRIPTION
by tapping on their city buttons.

This is a resubmission of PR #1738 per @yairm210's comment.

Implemented with @Azzurite's suggestions to match the button's behavior with the player's own city buttons:
* First tap slides the city button down so that the underlying tile is visible.
* Second tap on the button presents the diplomacy screen focused on the city's owner civ.

Preview GIF since it's a UI change: (My second tap in the GIF is actually outside the button to return it to the original location)
![test](https://user-images.githubusercontent.com/12586523/73130226-4782d180-3fa9-11ea-9016-70c36812f42d.gif)
