### PR TITLE
Fix: do not trim the text in the statistics screen

### DIFF
--- a/core/src/com/unciv/ui/cityscreen/CityInfoTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityInfoTable.kt
@@ -56,13 +56,13 @@ class CityInfoTable(private val cityScreen: CityScreen) : Table(CameraStageBaseS
         val titleTable = Table().background(ImageGetter.getBackground(ImageGetter.getBlue()))
         val width = cityScreen.stage.width/4 - 2*pad
         val showHideTableWrapper = Table()
-        showHideTableWrapper.add(showHideTable).width(width)
+        showHideTableWrapper.add(showHideTable).minWidth(width)
         titleTable.add(str.toLabel(fontSize = 24))
         titleTable.onClick {
             if(showHideTableWrapper.hasChildren()) showHideTableWrapper.clear()
-            else showHideTableWrapper.add(showHideTable).width(width)
+            else showHideTableWrapper.add(showHideTable).minWidth(width)
         }
-        add(titleTable).width(width).row()
+        add(titleTable).minWidth(width).row()
         add(showHideTableWrapper).row()
     }
 


### PR DESCRIPTION
When the language is different from English, the translated names of the buildings might not fit into the table. This PR resolves that.

BEFORE:
![Unciv 2020-01-30 23 51 24](https://user-images.githubusercontent.com/27405436/73497591-cc178a80-43c3-11ea-9f23-a9e6ebf1b67f.png)

AFTER:
![Unciv 2020-01-31 00 41 17](https://user-images.githubusercontent.com/27405436/73497597-d174d500-43c3-11ea-92a1-5c7bc3a9d24c.png)
