### PR TITLE
Tile healing rate evaluation fixes

### DIFF
--- a/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
@@ -221,6 +221,14 @@ class DiplomacyManager() {
     /** Returns the [civilizations][CivilizationInfo] that know about both sides ([civInfo] and [otherCiv]) */
     fun getCommonKnownCivs(): Set<CivilizationInfo> = civInfo.getKnownCivs().intersect(otherCiv().getKnownCivs())
 
+    /** Returns true when the [civInfo]'s territory is considered allied for [otherCiv].
+     * 
+     *  This includes friendly and allied city-states and the open border treaties.
+     */
+    fun isConsideredAllyTerritory(): Boolean {
+        return (hasOpenBorders)
+                || (civInfo.isCityState() && relationshipLevel() >= RelationshipLevel.Friend)
+    }
     //endregion
 
     //region state-changing functions


### PR DESCRIPTION
Fixes a bunch of bugs:
* Naval units healing outside the allied territory
* City-states with the `RelationshipLevel` less than `Friend` were giving bonus healing (which also resulted in trespassing while auto exploring and losing influence)
* `Medic` promotion only taking effect on the enemy territory

I've also considered moving the check for nearby `Medic`s from `MapUnit.heal()` to `MapUnit.rankTileForHealing()`, so the automation considers this when moving units. It is, however, a somewhat expensive operation and the average call time went from `60_000 ns` to `770_000 ns` on average even for the first stages of the game, when the unit max movement is rather little.
I can add it back, if it's a justifiable performance hit