### PR TITLE
Show name when icon is tapped in resource overview

### DIFF
--- a/core/src/com/unciv/ui/EmpireOverviewScreen.kt
+++ b/core/src/com/unciv/ui/EmpireOverviewScreen.kt
@@ -378,8 +378,38 @@ class EmpireOverviewScreen(val viewingPlayer:CivilizationInfo) : CameraStageBase
         val resources = resourceDrilldown.map { it.resource }
                 .filter { it.resourceType!=ResourceType.Bonus }.distinct().sortedBy { it.resourceType }
 
-        for(resource in resources)
-            resourcesTable.add(ImageGetter.getResourceImage(resource.name,50f))
+        var visibleLabel: Label? = null
+        for(resource in resources) {
+            // Create a group of label and icon for each resource.
+            val resourceImage = ImageGetter.getResourceImage(resource.name,50f)
+            val resourceLabel = resource.name.toLabel()
+            val labelPadding = 10f
+            // Using a table here leads to spacing issues
+            // due to different label lengths.
+            val holder = Group()
+            resourceImage.onClick {
+                if (visibleLabel != null)
+                    visibleLabel!!.setVisible(false)
+                resourceLabel.setVisible(true)
+                visibleLabel = resourceLabel
+            }
+            holder.addActor(resourceImage)
+            holder.addActor(resourceLabel)
+            holder.setSize(resourceImage.getWidth(),
+                    resourceImage.getHeight() + resourceLabel.getHeight() + labelPadding)
+            // Center-align all labels, but right-align the last couple resources' labels
+            // because they may get clipped otherwise. The leftmost label should be fine
+            // center-aligned (if there are more than 2 resources), because the left side
+            // has more padding.
+            val alignFactor = when {
+                (resources.indexOf(resource) + 2 >= resources.count()) -> 1
+                else -> 2
+            }
+            resourceLabel.moveBy((resourceImage.getWidth() - resourceLabel.getWidth()) / alignFactor,
+                    resourceImage.getHeight() + labelPadding)
+            resourceLabel.setVisible(false)
+            resourcesTable.add(holder)
+        }
         resourcesTable.addSeparator()
 
         val origins = resourceDrilldown.map { it.origin }.distinct()


### PR DESCRIPTION
This reimplements @Azzurite's idea in #1763 with feedback in that PR taken into consideration. Addressed issue: #1684.

Preview:
![gif](https://user-images.githubusercontent.com/12586523/73526270-b6a36000-43c5-11ea-8c44-8c3d268d8844.gif)

Btw, the above gif doesn't reflect a new change I added to also right-align the 2nd rightmost label, which could clip depending on its length. I made this change because the longest name I found ("Gems" in Russian) spans the width of 3 icons + spacing:

![image](https://user-images.githubusercontent.com/12586523/73587390-ea3ac480-446f-11ea-8773-0252c445bd28.png)

So... Until a translation spans more than 5 icons' width, we should be OK(tm).