### PR TITLE
Add support for loading mods on Android

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -6,6 +6,10 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
 
+    <!-- Required to access mods folder below Android 4.4, but not needed after that -->
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+                     android:maxSdkVersion="18" />
+
     <application
         android:allowBackup="true"
         android:icon="@drawable/uncivicon2"

--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -7,7 +7,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
 
     <!-- Required to access mods folder below Android 4.4, but not needed after that -->
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
                      android:maxSdkVersion="18" />
 
     <application

--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -6,10 +6,6 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
 
-    <!-- Required to access mods folder below Android 4.4, but not needed after that -->
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
-                     android:maxSdkVersion="18" />
-
     <application
         android:allowBackup="true"
         android:icon="@drawable/uncivicon2"

--- a/android/src/com/unciv/app/AndroidLauncher.kt
+++ b/android/src/com/unciv/app/AndroidLauncher.kt
@@ -4,10 +4,26 @@ import android.os.Bundle
 import com.badlogic.gdx.backends.android.AndroidApplication
 import com.badlogic.gdx.backends.android.AndroidApplicationConfiguration
 import com.unciv.UncivGame
+import java.io.File
 
 class AndroidLauncher : AndroidApplication() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        // Mod directory in the internal app data (where Gdx.files.local looks)
+        val internalModsDir = File("${filesDir.path}/mods")
+
+        // Mod directory in the shared app data (where the user can see and modify)
+        val externalModsDir = File("${getExternalFilesDir(null)?.path}/mods")
+
+        // Empty out the mods directory so it can be replaced by the external one
+        // Done to ensure it only contains mods in the external dir (so users can delete some)
+        if (internalModsDir.exists()) internalModsDir.deleteRecursively()
+
+        // Copy external mod directory (with data user put in it) to internal (where it can be read)
+        if (!externalModsDir.exists()) externalModsDir.mkdirs()
+        externalModsDir.copyRecursively(internalModsDir)
+
         val config = AndroidApplicationConfiguration().apply { useImmersiveMode = true }
         val game = UncivGame(BuildConfig.VERSION_NAME,
                             CrashReportSenderAndroid(this))

--- a/android/src/com/unciv/app/AndroidLauncher.kt
+++ b/android/src/com/unciv/app/AndroidLauncher.kt
@@ -10,19 +10,7 @@ class AndroidLauncher : AndroidApplication() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // Mod directory in the internal app data (where Gdx.files.local looks)
-        val internalModsDir = File("${filesDir.path}/mods")
-
-        // Mod directory in the shared app data (where the user can see and modify)
-        val externalModsDir = File("${getExternalFilesDir(null)?.path}/mods")
-
-        // Empty out the mods directory so it can be replaced by the external one
-        // Done to ensure it only contains mods in the external dir (so users can delete some)
-        if (internalModsDir.exists()) internalModsDir.deleteRecursively()
-
-        // Copy external mod directory (with data user put in it) to internal (where it can be read)
-        if (!externalModsDir.exists()) externalModsDir.mkdirs()
-        externalModsDir.copyRecursively(internalModsDir)
+		copyMods()
 
         val config = AndroidApplicationConfiguration().apply { useImmersiveMode = true }
         val game = UncivGame(BuildConfig.VERSION_NAME,
@@ -30,4 +18,25 @@ class AndroidLauncher : AndroidApplication() {
                             {this.finish()}
         initialize(game, config)
     }
+
+	/**
+	 * Copies mods from external data directory (where users can access) to the private one (where
+	 * libGDX reads from). Note: deletes all files currently in the private mod directory and
+	 * replaces them with the ones in the external folder!)
+	 */
+	private fun copyMods() {
+		// Mod directory in the internal app data (where Gdx.files.local looks)
+		val internalModsDir = File("${filesDir.path}/mods")
+
+		// Mod directory in the shared app data (where the user can see and modify)
+		val externalModsDir = File("${getExternalFilesDir(null)?.path}/mods")
+
+		// Empty out the mods directory so it can be replaced by the external one
+		// Done to ensure it only contains mods in the external dir (so users can delete some)
+		if (internalModsDir.exists()) internalModsDir.deleteRecursively()
+
+		// Copy external mod directory (with data user put in it) to internal (where it can be read)
+		if (!externalModsDir.exists()) externalModsDir.mkdirs()
+		externalModsDir.copyRecursively(internalModsDir)
+	}
 }

--- a/android/src/com/unciv/app/AndroidLauncher.kt
+++ b/android/src/com/unciv/app/AndroidLauncher.kt
@@ -1,5 +1,6 @@
 package com.unciv.app
 
+import android.os.Build
 import android.os.Bundle
 import com.badlogic.gdx.backends.android.AndroidApplication
 import com.badlogic.gdx.backends.android.AndroidApplicationConfiguration
@@ -10,7 +11,10 @@ class AndroidLauncher : AndroidApplication() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-		copyMods()
+		// Only allow mods on KK+, to avoid READ_EXTERNAL_STORAGE permission earlier versions need
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+			copyMods()
+		}
 
         val config = AndroidApplicationConfiguration().apply { useImmersiveMode = true }
         val game = UncivGame(BuildConfig.VERSION_NAME,


### PR DESCRIPTION
What I did was set it to copy mods from `/sdcard/Android/data/com.unciv.app/files/mods` to the internal app directory (where libGDX reads files from) every launch. I didn't change anything beyond that (yet), as that was enough to get the example mods to load. 

May not be the best to copy them every launch like I'm doing, but short of replacing `Gdx.files.local` with a function checking that AND the external directory, not sure how else to make it use a location the user can write to.