### PR TITLE
Fix: Capturing the cities must not improve relations

### DIFF
--- a/core/src/com/unciv/logic/city/CityInfo.kt
+++ b/core/src/com/unciv/logic/city/CityInfo.kt
@@ -402,7 +402,7 @@ class CityInfo {
 
     private fun diplomaticRepercussionsForConqueringCity(oldCiv: CivilizationInfo, conqueringCiv: CivilizationInfo) {
         val currentPopulation = population.population
-        val percentageOfCivPopulationInThatCity = currentPopulation * 100f / civInfo.cities.sumBy { it.population.population }
+        val percentageOfCivPopulationInThatCity = currentPopulation * 100f / oldCiv.cities.sumBy { it.population.population }
         val aggroGenerated = 10f + percentageOfCivPopulationInThatCity.roundToInt()
 
         // How can you conquer a city but not know the civ you conquered it from?!
@@ -415,7 +415,7 @@ class CityInfo {
 
         for (thirdPartyCiv in conqueringCiv.getKnownCivs().filter { it.isMajorCiv() }) {
             val aggroGeneratedForOtherCivs = (aggroGenerated / 10).roundToInt().toFloat()
-            if (thirdPartyCiv.isAtWarWith(civInfo)) // You annoyed our enemy?
+            if (thirdPartyCiv.isAtWarWith(oldCiv)) // You annoyed our enemy?
                 thirdPartyCiv.getDiplomacyManager(conqueringCiv)
                         .addModifier(DiplomaticModifiers.SharedEnemy, aggroGeneratedForOtherCivs) // Cool, keep at at! =D
             else thirdPartyCiv.getDiplomacyManager(conqueringCiv)


### PR DESCRIPTION
**Bug description:**
When you capture the city of your enemy the relationship with it and other enemies improve suddenly.


![Unciv 2020-02-02 15 23 40](https://user-images.githubusercontent.com/27405436/73608939-554fdc80-45d1-11ea-840f-75d06571c7c6.png)

The root of the bug was in the `diplomaticRepercussionsForConqueringCity()` which is called when the captured city already belongs to you, so the fix is to calculate the relations according to the previous owner.

**After the fix:**
![Unciv 2020-02-02 15 28 30](https://user-images.githubusercontent.com/27405436/73608970-a233b300-45d1-11ea-9718-431cd3cbddf0.png)

Also, the `aggroGenerated` value must be calculated according to the previous owner: for example, if you captured the city which was 50% of their empire, it must cause a huge effect, disregard of the size of your own civilization.