### PR TITLE
Fix: NPE when rankTileForHealing is called for barbarians

### DIFF
--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -389,7 +389,7 @@ class MapUnit {
     /** Returns the health points [MapUnit] will receive if healing on [tileInfo] */
     fun rankTileForHealing(tileInfo: TileInfo): Int {
         val tileOwner = tileInfo.getOwner()
-        val isAlliedTerritory = if (tileOwner != null)
+        val isAlliedTerritory = if (tileOwner != null && !civInfo.isBarbarian())
             tileOwner == civInfo || tileOwner.getDiplomacyManager(civInfo).isConsideredAllyTerritory()
         else
             false


### PR DESCRIPTION
PSN: AlexKrolya on Discord:
> Got an error on a desktop
> Russia Novgorod attacked Barbarians Scout
> Exception in thread "NextTurn" kotlin.KotlinNullPointerException
>         at com.unciv.logic.civilization.CivilizationInfo.getDiplomacyManager(CivilizationInfo.kt:135)
>         at com.unciv.logic.civilization.CivilizationInfo.getDiplomacyManager(CivilizationInfo.kt:134)
>         at com.unciv.logic.map.MapUnit.rankTileForHealing(MapUnit.kt:402)
>         at com.unciv.logic.automation.BarbarianAutomation.automateCombatUnit(BarbarianAutomation.kt:64)
>         at com.unciv.logic.automation.BarbarianAutomation.automateUnit(BarbarianAutomation.kt:34)
>         at com.unciv.logic.automation.BarbarianAutomation.automate(BarbarianAutomation.kt:26)
>         at com.unciv.logic.automation.NextTurnAutomation.automateCivMoves(NextTurnAutomation.kt:23)
>         at com.unciv.logic.GameInfo.nextTurn(GameInfo.kt:87)
>         at com.unciv.ui.worldscreen.WorldScreen$nextTurn$1.invoke(WorldScreen.kt:385)
>         at com.unciv.ui.worldscreen.WorldScreen$nextTurn$1.invoke(WorldScreen.kt:38)
>         at kotlin.concurrent.ThreadsKt$thread$thread$1.run(Thread.kt:30)
> Cannot go further 115 Turn

Apparently, they don't have DiplomacyManagers.
Surprisingly enough, I was lucky to not get it when simulating to turn 1000 on the original commit.
