### PR TITLE
Proposal: remove ability to gain information about unexplored tiles

### DIFF
--- a/core/src/com/unciv/ui/worldscreen/WorldMapHolder.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldMapHolder.kt
@@ -72,12 +72,15 @@ class WorldMapHolder(internal val worldScreen: WorldScreen, internal val tileMap
         val newSelectedUnit = unitTable.selectedUnit
 
         if (previousSelectedUnit != null && previousSelectedUnit.getTile() != tileInfo
-                && worldScreen.isPlayersTurn
-                && previousSelectedUnit.movement.canMoveTo(tileInfo) && previousSelectedUnit.movement.canReach(tileInfo)) {
+            && worldScreen.isPlayersTurn
+            && previousSelectedUnit.movement.canMoveTo(tileInfo)
+            && previousSelectedUnit.movement.canReach(tileInfo)
+            // Do not show for the unexplored tiles
+            && (tileInfo.position in previousSelectedUnit.civInfo.exploredTiles || UncivGame.Current.viewEntireMapForDebug)
+        ) {
             // this can take a long time, because of the unit-to-tile calculation needed, so we put it in a different thread
             addTileOverlaysWithUnitMovement(previousSelectedUnit, tileInfo)
-        }
-        else addTileOverlays(tileInfo) // no unit movement but display the units in the tile etc.
+        } else addTileOverlays(tileInfo) // no unit movement but display the units in the tile etc.
 
 
         if(newSelectedUnit==null || newSelectedUnit.type==UnitType.Civilian){
@@ -259,9 +262,12 @@ class WorldMapHolder(internal val worldScreen: WorldScreen, internal val tileMap
                 tileGroups[tile]!!.showCircle(Color.BLUE,0.3f)
 
         for (tile: TileInfo in tilesInMoveRange)
-            if (unit.movement.canMoveTo(tile))
-                tileGroups[tile]!!.showCircle(Color.WHITE,
-                        if (UncivGame.Current.settings.singleTapMove || isAirUnit) 0.7f else 0.3f)
+            if (unit.movement.canMoveTo(tile) && 
+                (tile.position in unit.civInfo.exploredTiles || UncivGame.Current.viewEntireMapForDebug))
+                tileGroups[tile]!!.showCircle(
+                    Color.WHITE,
+                    if (UncivGame.Current.settings.singleTapMove || isAirUnit) 0.7f else 0.3f
+                )
 
 
         val unitType = unit.type


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/26433289/73660590-8996cc00-46a9-11ea-84d6-d61e054b17c9.png)
You can actually find out the entire outline of the continent just by clicking tiles with a ship unit

After:
![image](https://user-images.githubusercontent.com/26433289/73660760-e3979180-46a9-11ea-85c4-f5953754343e.png)

This does, however, complicate exploring for the player in a way, since the same amount of movement can require 4 or even more clicks instead of 2