### PR TITLE
Rectangular maps, maps generator, bugfixes (part 1)

### DIFF
--- a/core/src/com/unciv/logic/GameStarter.kt
+++ b/core/src/com/unciv/logic/GameStarter.kt
@@ -11,7 +11,7 @@ import java.util.*
 import kotlin.collections.ArrayList
 import kotlin.math.max
 
-class GameStarter{
+class GameStarter {
 
     fun startNewGame(newGameParameters: GameParameters, mapParameters: MapParameters): GameInfo {
         val gameInfo = GameInfo()
@@ -19,9 +19,9 @@ class GameStarter{
         gameInfo.gameParameters = newGameParameters
         val ruleset = RulesetCache.getComplexRuleset(newGameParameters.mods)
 
-        if(mapParameters.name!="")
+        if(mapParameters.name != "")
             gameInfo.tileMap = MapSaver().loadMap(mapParameters.name)
-        else gameInfo.tileMap = MapGenerator().generateMap(mapParameters, ruleset)
+        else gameInfo.tileMap = MapGenerator(ruleset).generateMap(mapParameters)
         gameInfo.tileMap.mapParameters = mapParameters
 
         gameInfo.tileMap.setTransients(ruleset)

--- a/core/src/com/unciv/logic/HexMath.kt
+++ b/core/src/com/unciv/logic/HexMath.kt
@@ -14,6 +14,32 @@ object HexMath {
         return getVectorForAngle((2 * Math.PI * (hour / 12f)).toFloat())
     }
 
+    /** returns the number of tiles in a hexagonal map of radius size*/
+    fun getNumberOfTilesInHexagon(size: Int): Int {
+        if (size < 0) return 0
+        return 1 + 6 * size * (size + 1) / 2
+    }
+
+    /* In our reference system latitude, i.e. how distant from equator we are is proportional to x + y*/
+    fun getLatitude(vector: Vector2): Float {
+        return vector.x + vector.y
+    }
+    fun getLongitude(vector: Vector2): Float {
+        return vector.x - vector.y
+    }
+
+    /** returns a vector containing width and height a rectangular map should have to have
+     * approximately the same number of tiles as an hexagonal map given a height/width ratio */
+    fun getEquivalentRectangularSize(size: Int, ratio: Float = 0.65f): Vector2 {
+        if (size < 0)
+            return Vector2.Zero
+
+        val nTiles = getNumberOfTilesInHexagon(size)
+        val width = round(sqrt(nTiles.toFloat()/ratio))
+        val height = round(width * ratio)
+        return Vector2(width, height)
+    }
+
     fun getAdjacentVectors(origin: Vector2): ArrayList<Vector2> {
         val vectors = arrayListOf(
                 Vector2(1f, 0f),
@@ -57,6 +83,20 @@ object HexMath {
 
     fun cubic2HexCoords(cubicCoord: Vector3): Vector2 {
         return Vector2(cubicCoord.y, -cubicCoord.z)
+    }
+
+    fun cubic2EvenQCoords(cubicCoord: Vector3): Vector2 {
+        return Vector2(cubicCoord.x, cubicCoord.z + (cubicCoord.x + (cubicCoord.x.toInt() and 1)) / 2)
+    }
+    fun evenQ2CubicCoords(evenQCoord: Vector2): Vector3 {
+        val x = evenQCoord.x
+        val z = evenQCoord.y - (evenQCoord.x + (evenQCoord.x.toInt() and 1)) / 2
+        val y = -x-z
+        return Vector3(x,y,z)
+    }
+
+    fun evenQ2HexCoords(evenQCoord: Vector2): Vector2 {
+        return cubic2HexCoords(evenQ2CubicCoords(evenQCoord))
     }
 
     fun roundCubicCoords(cubicCoords: Vector3): Vector3 {

--- a/core/src/com/unciv/logic/map/MapParameters.kt
+++ b/core/src/com/unciv/logic/map/MapParameters.kt
@@ -8,10 +8,41 @@ enum class MapSize(val radius: Int) {
     Huge(40)
 }
 
+object MapShape {
+    const val hexagonal = "Hexagonal"
+    const val rectangular = "Rectangular"
+}
+
+object MapType {
+    const val pangaea = "Pangaea"
+    const val continents = "Continents"
+    const val perlin = "Perlin"
+
+    // Cellular automata
+    const val default = "Default"
+
+    // Non-generated maps
+    const val custom = "Custom"
+
+    // All ocean tiles
+    const val empty = "Empty"
+}
+
 class MapParameters {
     var name = ""
     var type = MapType.pangaea
+    var shape = MapShape.hexagonal
     var size: MapSize = MapSize.Medium
     var noRuins = false
-    var noNaturalWonders = true
+    var noNaturalWonders = false
+
+    var seed: Long = 0
+    var tilesPerBiomeArea = 6
+    var maxCoastExtension = 2
+    var mountainProbability = 0.10f
+    var temperatureExtremeness = 0.30f
+    var terrainFeatureRichness = 0.30f
+    var resourceRichness = 0.10f
+    var waterProbability = 0.05f
+    var landProbability = 0.55f
 }

--- a/core/src/com/unciv/logic/map/TileMap.kt
+++ b/core/src/com/unciv/logic/map/TileMap.kt
@@ -10,14 +10,14 @@ import com.unciv.models.ruleset.Ruleset
 class TileMap {
 
     @Transient lateinit var gameInfo: GameInfo
-    @Transient var tileMatrix=ArrayList<ArrayList<TileInfo?>>() // this works several times faster than a hashmap, the performance difference is really astounding
-    @Transient var leftX=0
-    @Transient var bottomY=0
+    @Transient var tileMatrix = ArrayList<ArrayList<TileInfo?>>() // this works several times faster than a hashmap, the performance difference is really astounding
+    @Transient var leftX = 0
+    @Transient var bottomY = 0
 
     @Deprecated("as of 2.7.10")
     private var tiles = HashMap<String, TileInfo>()
 
-    var mapParameters= MapParameters()
+    var mapParameters = MapParameters()
     private var tileList = ArrayList<TileInfo>()
 
     constructor()  // for json parsing, we need to have a default constructor
@@ -33,10 +33,20 @@ class TileMap {
         get() = tileList
 
 
-
+    /** generates an hexagonal map of given radius */
     constructor(radius:Int, ruleset: Ruleset){
         for(vector in HexMath.getVectorsInDistance(Vector2.Zero, radius))
-            tileList.add(TileInfo().apply { position = vector; baseTerrain= Constants.grassland })
+            tileList.add(TileInfo().apply { position = vector; baseTerrain = Constants.grassland })
+        setTransients(ruleset)
+    }
+
+    /** generates a rectangular map of given width and height*/
+    constructor(width: Int, height: Int, ruleset: Ruleset) {
+        for(x in -width/2..width/2)
+            for (y in -height/2..height/2)
+                tileList.add(TileInfo().apply {
+                    position = HexMath.evenQ2HexCoords(Vector2(x.toFloat(),y.toFloat()))
+                    baseTerrain = Constants.grassland })
         setTransients(ruleset)
     }
 
@@ -230,8 +240,5 @@ class TileMap {
             tileInfo.setTransients()
         }
     }
-
-
-
 }
 

--- a/core/src/com/unciv/ui/mapeditor/NewMapScreen.kt
+++ b/core/src/com/unciv/ui/mapeditor/NewMapScreen.kt
@@ -46,7 +46,7 @@ class NewMapScreen : PickerScreen() {
                 try {
                     // Map generation can take a while and we don't want ANRs
                     val ruleset = RulesetCache.getBaseRuleset()
-                    generatedMap = MapGenerator().generateMap(mapParameters, ruleset)
+                    generatedMap = MapGenerator(ruleset).generateMap(mapParameters)
 
                     Gdx.app.postRunnable {
                         UncivGame.Current.setScreen(MapEditorScreen(generatedMap!!))

--- a/core/src/com/unciv/ui/newgamescreen/MapParametersTable.kt
+++ b/core/src/com/unciv/ui/newgamescreen/MapParametersTable.kt
@@ -2,13 +2,17 @@ package com.unciv.ui.newgamescreen
 
 import com.badlogic.gdx.scenes.scene2d.Actor
 import com.badlogic.gdx.scenes.scene2d.ui.CheckBox
+import com.badlogic.gdx.scenes.scene2d.ui.Slider
 import com.badlogic.gdx.scenes.scene2d.ui.Table
+import com.badlogic.gdx.scenes.scene2d.ui.TextButton
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener
 import com.unciv.logic.map.MapParameters
+import com.unciv.logic.map.MapShape
 import com.unciv.logic.map.MapSize
 import com.unciv.logic.map.MapType
 import com.unciv.models.translations.tr
 import com.unciv.ui.utils.CameraStageBaseScreen
+import com.unciv.ui.utils.onClick
 import com.unciv.ui.utils.toLabel
 
 /** Table for editing [mapParameters]
@@ -17,21 +21,40 @@ import com.unciv.ui.utils.toLabel
  *
  *  @param isEmptyMapAllowed whether the [MapType.empty] option should be present. Is used by the Map Editor, but should **never** be used with the New Game
  * */
-class MapParametersTable(val mapParameters: MapParameters, val isEmptyMapAllowed: Boolean = false) :
+class MapParametersTable(val mapParameters: MapParameters, val isEmptyMapAllowed: Boolean = false):
     Table() {
 
     lateinit var noRuinsCheckbox: CheckBox
     lateinit var noNaturalWondersCheckbox: CheckBox
 
     init {
+        skin = CameraStageBaseScreen.skin
+        defaults().pad(5f)
+        addMapShapeSelectBox()
         addMapTypeSelectBox()
         addWorldSizeSelectBox()
         addNoRuinsCheckbox()
         addNoNaturalWondersCheckbox()
     }
 
+    private fun addMapShapeSelectBox() {
+        val mapShapes = listOfNotNull(
+                MapShape.hexagonal,
+                MapShape.rectangular
+        )
+        val mapShapeSelectBox =
+                TranslatedSelectBox(mapShapes, mapParameters.shape, skin)
+        mapShapeSelectBox.addListener(object : ChangeListener() {
+            override fun changed(event: ChangeEvent?, actor: Actor?) {
+                mapParameters.shape = mapShapeSelectBox.selected.value
+            }
+        })
+
+        add ("{Map shape}:".toLabel()).left()
+        add(mapShapeSelectBox).fillX().row()
+    }
+
     private fun addMapTypeSelectBox() {
-        add("{Map generation type}:".toLabel())
 
         val mapTypes = listOfNotNull(
             MapType.default,
@@ -41,7 +64,7 @@ class MapParametersTable(val mapParameters: MapParameters, val isEmptyMapAllowed
             if (isEmptyMapAllowed) MapType.empty else null
         )
         val mapTypeSelectBox =
-            TranslatedSelectBox(mapTypes, mapParameters.type, CameraStageBaseScreen.skin)
+            TranslatedSelectBox(mapTypes, mapParameters.type, skin)
 
         mapTypeSelectBox.addListener(object : ChangeListener() {
             override fun changed(event: ChangeEvent?, actor: Actor?) {
@@ -52,17 +75,17 @@ class MapParametersTable(val mapParameters: MapParameters, val isEmptyMapAllowed
                 noNaturalWondersCheckbox.isVisible = mapParameters.type != MapType.empty
             }
         })
-        add(mapTypeSelectBox).row()
+
+        add("{Map generation type}:".toLabel()).left()
+        add(mapTypeSelectBox).fillX().row()
     }
 
 
     private fun addWorldSizeSelectBox() {
-
-        val worldSizeLabel = "{World size}:".toLabel()
         val worldSizeSelectBox = TranslatedSelectBox(
             MapSize.values().map { it.name },
             mapParameters.size.name,
-            CameraStageBaseScreen.skin
+            skin
         )
 
         worldSizeSelectBox.addListener(object : ChangeListener() {
@@ -71,12 +94,12 @@ class MapParametersTable(val mapParameters: MapParameters, val isEmptyMapAllowed
             }
         })
 
-        add(worldSizeLabel)
-        add(worldSizeSelectBox).pad(10f).row()
+        add("{World size}:".toLabel()).left()
+        add(worldSizeSelectBox).fillX().row()
     }
 
     private fun addNoRuinsCheckbox() {
-        noRuinsCheckbox = CheckBox("No ancient ruins".tr(), CameraStageBaseScreen.skin)
+        noRuinsCheckbox = CheckBox("No ancient ruins".tr(), skin)
         noRuinsCheckbox.isChecked = mapParameters.noRuins
         noRuinsCheckbox.addListener(object : ChangeListener() {
             override fun changed(event: ChangeEvent?, actor: Actor?) {
@@ -87,7 +110,7 @@ class MapParametersTable(val mapParameters: MapParameters, val isEmptyMapAllowed
     }
 
     private fun addNoNaturalWondersCheckbox() {
-        noNaturalWondersCheckbox = CheckBox("No Natural Wonders".tr(), CameraStageBaseScreen.skin)
+        noNaturalWondersCheckbox = CheckBox("No Natural Wonders".tr(), skin)
         noNaturalWondersCheckbox.isChecked = mapParameters.noNaturalWonders
         noNaturalWondersCheckbox.addListener(object : ChangeListener() {
             override fun changed(event: ChangeEvent?, actor: Actor?) {

--- a/core/src/com/unciv/ui/newgamescreen/MapParametersTable.kt
+++ b/core/src/com/unciv/ui/newgamescreen/MapParametersTable.kt
@@ -23,7 +23,7 @@ import com.unciv.ui.utils.toLabel
  * */
 class MapParametersTable(val mapParameters: MapParameters, val isEmptyMapAllowed: Boolean = false):
     Table() {
-
+    lateinit var mapTypeSelectBox: TranslatedSelectBox
     lateinit var noRuinsCheckbox: CheckBox
     lateinit var noNaturalWondersCheckbox: CheckBox
 
@@ -35,6 +35,7 @@ class MapParametersTable(val mapParameters: MapParameters, val isEmptyMapAllowed
         addWorldSizeSelectBox()
         addNoRuinsCheckbox()
         addNoNaturalWondersCheckbox()
+        addAdvancedSettings()
     }
 
     private fun addMapShapeSelectBox() {
@@ -63,8 +64,8 @@ class MapParametersTable(val mapParameters: MapParameters, val isEmptyMapAllowed
             MapType.perlin,
             if (isEmptyMapAllowed) MapType.empty else null
         )
-        val mapTypeSelectBox =
-            TranslatedSelectBox(mapTypes, mapParameters.type, skin)
+
+        mapTypeSelectBox = TranslatedSelectBox(mapTypes, mapParameters.type, skin)
 
         mapTypeSelectBox.addListener(object : ChangeListener() {
             override fun changed(event: ChangeEvent?, actor: Actor?) {
@@ -118,5 +119,121 @@ class MapParametersTable(val mapParameters: MapParameters, val isEmptyMapAllowed
             }
         })
         add(noNaturalWondersCheckbox).colspan(2).row()
+    }
+
+    private fun addAdvancedSettings() {
+        val button = TextButton("Show advanced settings".tr(), skin)
+        val advancedSettingsTable = Table().apply {isVisible = false; defaults().pad(5f)}
+
+        add(button).colspan(2).row()
+        val advancedSettingsCell = add(Table()).colspan(2)
+        row()
+
+        button.onClick {
+            if (!advancedSettingsTable.isVisible) {
+                button.setText("Show advanced settings".tr())
+                advancedSettingsCell.setActor(advancedSettingsTable)
+            } else {
+                button.setText("Hide advanced settings".tr())
+                advancedSettingsCell.setActor(Table())
+            }
+            advancedSettingsTable.isVisible = !advancedSettingsTable.isVisible
+        }
+
+
+        val averageHeightSlider = Slider(0f,1f,0.01f, false, skin).apply {
+            addListener(object : ChangeListener() {
+                override fun changed(event: ChangeEvent?, actor: Actor?) {
+                    mapParameters.mountainProbability = this@apply.value
+                }
+            })
+        }
+        averageHeightSlider.value = mapParameters.mountainProbability
+        advancedSettingsTable.add("Map Height".toLabel()).left()
+        advancedSettingsTable.add(averageHeightSlider).fillX().row()
+
+
+        val tempExtremeSlider = Slider(0f,1f,0.01f, false, skin).apply {
+            addListener(object : ChangeListener() {
+                override fun changed(event: ChangeEvent?, actor: Actor?) {
+                    mapParameters.temperatureExtremeness = this@apply.value
+                }
+            })
+        }
+        tempExtremeSlider.value = mapParameters.temperatureExtremeness
+        advancedSettingsTable.add("Temperature extremeness".toLabel()).left()
+        advancedSettingsTable.add(tempExtremeSlider).fillX().row()
+
+
+        val resourceRichnessSlider = Slider(0f,1f,0.01f, false, skin).apply {
+            addListener(object : ChangeListener() {
+                override fun changed(event: ChangeEvent?, actor: Actor?) {
+                    mapParameters.resourceRichness = this@apply.value
+                }
+            })
+        }
+        resourceRichnessSlider.value = mapParameters.resourceRichness
+        advancedSettingsTable.add("Resource richness".toLabel()).left()
+        advancedSettingsTable.add(resourceRichnessSlider).fillX().row()
+
+
+        val terrainFeatureRichnessSlider = Slider(0f,1f,0.01f, false, skin).apply {
+            addListener(object : ChangeListener() {
+                override fun changed(event: ChangeEvent?, actor: Actor?) {
+                    mapParameters.terrainFeatureRichness = this@apply.value
+                }
+            })
+        }
+        terrainFeatureRichnessSlider.value = mapParameters.terrainFeatureRichness
+        advancedSettingsTable.add("Terrain Features richness".toLabel()).left()
+        advancedSettingsTable.add(terrainFeatureRichnessSlider).fillX().row()
+
+
+        val maxCoastExtensionSlider = Slider(0f,5f,1f, false, skin).apply {
+            addListener(object : ChangeListener() {
+                override fun changed(event: ChangeEvent?, actor: Actor?) {
+                    mapParameters.maxCoastExtension = this@apply.value.toInt()
+                }
+            })
+        }
+        maxCoastExtensionSlider.value = mapParameters.maxCoastExtension.toFloat()
+        advancedSettingsTable.add("Max Coast extension".toLabel()).left()
+        advancedSettingsTable.add(maxCoastExtensionSlider).fillX().row()
+
+
+        val tilesPerBiomeAreaSlider = Slider(0f,15f,1f, false, skin).apply {
+            addListener(object : ChangeListener() {
+                override fun changed(event: ChangeEvent?, actor: Actor?) {
+                    mapParameters.tilesPerBiomeArea = this@apply.value.toInt()
+                }
+            })
+        }
+        tilesPerBiomeAreaSlider.value = mapParameters.tilesPerBiomeArea.toFloat()
+        advancedSettingsTable.add("Biome areas extension".toLabel()).left()
+        advancedSettingsTable.add(tilesPerBiomeAreaSlider).fillX().row()
+
+
+        val waterPercentSlider = Slider(0f,1f,0.01f, false, skin).apply {
+            addListener(object : ChangeListener() {
+                override fun changed(event: ChangeEvent?, actor: Actor?) {
+                    mapParameters.waterProbability = this@apply.value
+                }
+            })
+        }
+        waterPercentSlider.value = mapParameters.waterProbability
+        advancedSettingsTable.add("Water percent".toLabel()).left()
+        advancedSettingsTable.add(waterPercentSlider).fillX().row()
+
+
+        val landPercentSlider = Slider(0f,1f,0.01f, false, skin).apply {
+            addListener(object : ChangeListener() {
+                override fun changed(event: ChangeEvent?, actor: Actor?) {
+                    mapParameters.landProbability = this@apply.value
+                }
+            })
+        }
+        landPercentSlider.value = mapParameters.landProbability
+        advancedSettingsTable.add("Land percent".toLabel()).left()
+        advancedSettingsTable.add(landPercentSlider).fillX().row()
     }
 }

--- a/core/src/com/unciv/ui/newgamescreen/MapParametersTable.kt
+++ b/core/src/com/unciv/ui/newgamescreen/MapParametersTable.kt
@@ -130,14 +130,15 @@ class MapParametersTable(val mapParameters: MapParameters, val isEmptyMapAllowed
         row()
 
         button.onClick {
-            if (!advancedSettingsTable.isVisible) {
-                button.setText("Show advanced settings".tr())
+            advancedSettingsTable.isVisible = !advancedSettingsTable.isVisible
+
+            if (advancedSettingsTable.isVisible) {
+                button.setText("Hide advanced settings".tr())
                 advancedSettingsCell.setActor(advancedSettingsTable)
             } else {
-                button.setText("Hide advanced settings".tr())
+                button.setText("Show advanced settings".tr())
                 advancedSettingsCell.setActor(Table())
             }
-            advancedSettingsTable.isVisible = !advancedSettingsTable.isVisible
         }
 
 

--- a/core/src/com/unciv/ui/newgamescreen/NewGameScreen.kt
+++ b/core/src/com/unciv/ui/newgamescreen/NewGameScreen.kt
@@ -32,7 +32,7 @@ class NewGameScreen: PickerScreen(){
 
         val playerPickerTable = PlayerPickerTable(this, newGameParameters)
         val newGameScreenOptionsTable = NewGameScreenOptionsTable(this) { playerPickerTable.update() }
-        topTable.add(ScrollPane(newGameScreenOptionsTable)).height(topTable.parent.height)
+        topTable.add(ScrollPane(newGameScreenOptionsTable).apply{setOverscroll(false,false)}).height(topTable.parent.height)
         topTable.add(playerPickerTable).pad(10f)
         topTable.pack()
         topTable.setFillParent(true)
@@ -90,6 +90,8 @@ class NewGameScreen: PickerScreen(){
                     cantMakeThatMapPopup.addCloseButton()
                     cantMakeThatMapPopup.open()
                     Gdx.input.inputProcessor = stage
+                    rightSideButton.enable()
+                    rightSideButton.setText("Start game!".tr())
                 }
             }
         }

--- a/core/src/com/unciv/ui/newgamescreen/NewGameScreenOptionsTable.kt
+++ b/core/src/com/unciv/ui/newgamescreen/NewGameScreenOptionsTable.kt
@@ -64,13 +64,14 @@ class NewGameScreenOptionsTable(val newGameScreen: NewGameScreen, val updatePlay
 
         fun updateOnMapTypeChange() {
             mapTypeSpecificTable.clear()
-            if (mapParameters.type == MapType.custom) {
+            if (mapTypeSelectBox.selected.value == MapType.custom) {
                 mapParameters.type = MapType.custom
-                mapTypeSpecificTable.add(savedMapOptionsTable)
                 mapParameters.name = mapFileSelectBox.selected
+                mapTypeSpecificTable.add(savedMapOptionsTable)
             } else {
-                mapTypeSpecificTable.add(generatedMapOptionsTable)
                 mapParameters.name = ""
+                mapParameters.type = generatedMapOptionsTable.mapTypeSelectBox.selected.value
+                mapTypeSpecificTable.add(generatedMapOptionsTable)
             }
         }
 

--- a/core/src/com/unciv/ui/newgamescreen/NewGameScreenOptionsTable.kt
+++ b/core/src/com/unciv/ui/newgamescreen/NewGameScreenOptionsTable.kt
@@ -1,12 +1,14 @@
 package com.unciv.ui.newgamescreen
 
 import com.badlogic.gdx.scenes.scene2d.Actor
+import com.badlogic.gdx.scenes.scene2d.ui.Cell
 import com.badlogic.gdx.scenes.scene2d.ui.CheckBox
 import com.badlogic.gdx.scenes.scene2d.ui.SelectBox
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener
 import com.badlogic.gdx.utils.Array
 import com.unciv.logic.MapSaver
+import com.unciv.logic.map.MapType
 import com.unciv.models.metadata.GameSpeed
 import com.unciv.models.ruleset.RulesetCache
 import com.unciv.models.ruleset.VictoryType
@@ -22,8 +24,14 @@ class NewGameScreenOptionsTable(val newGameScreen: NewGameScreen, val updatePlay
     val mapParameters = newGameScreen.mapParameters
     val ruleset = newGameScreen.ruleset
 
+    private var mapTypeSpecificTable = Table()
+    private val generatedMapOptionsTable = MapParametersTable(mapParameters)
+    private val savedMapOptionsTable = Table()
+
     init {
         pad(10f)
+        top()
+        defaults().pad(5f)
         add("Map options".toLabel(fontSize = 24)).colspan(2).row()
         addMapTypeSelection()
 
@@ -36,8 +44,7 @@ class NewGameScreenOptionsTable(val newGameScreen: NewGameScreen, val updatePlay
         addBarbariansCheckbox()
         addOneCityChallengeCheckbox()
         addIsOnlineMultiplayerCheckbox()
-
-         addModCheckboxes()
+        addModCheckboxes()
 
         pack()
     }
@@ -45,33 +52,30 @@ class NewGameScreenOptionsTable(val newGameScreen: NewGameScreen, val updatePlay
     private fun addMapTypeSelection() {
         add("{Map type}:".toLabel())
         val mapTypes = arrayListOf("Generated")
-        if (MapSaver().getMaps().isNotEmpty()) mapTypes.add("Existing")
-
-        val mapFileLabel = "{Map file}:".toLabel()
-        val mapFileSelectBox = getMapFileSelectBox()
-        mapFileLabel.isVisible = false
-        mapFileSelectBox.isVisible = false
-
+        if (MapSaver().getMaps().isNotEmpty()) mapTypes.add(MapType.custom)
         val mapTypeSelectBox = TranslatedSelectBox(mapTypes, "Generated", CameraStageBaseScreen.skin)
 
-        val mapParameterTable = MapParametersTable(mapParameters)
+        val mapFileSelectBox = getMapFileSelectBox()
+        savedMapOptionsTable.defaults().pad(5f)
+        savedMapOptionsTable.add("{Map file}:".toLabel()).left()
+        // because SOME people gotta give the hugest names to their maps
+        savedMapOptionsTable.add(mapFileSelectBox).maxWidth(newGameScreen.stage.width / 2)
+                .right().row()
 
         fun updateOnMapTypeChange() {
-            mapParameters.type = mapTypeSelectBox.selected.value
-            if (mapParameters.type == "Existing") {
-                mapParameterTable.isVisible = false
-                mapFileSelectBox.isVisible = true
-                mapFileLabel.isVisible = true
+            mapTypeSpecificTable.clear()
+            if (mapParameters.type == MapType.custom) {
+                mapParameters.type = MapType.custom
+                mapTypeSpecificTable.add(savedMapOptionsTable)
                 mapParameters.name = mapFileSelectBox.selected
             } else {
-                mapParameterTable.isVisible = true
-                mapFileSelectBox.isVisible = false
-                mapFileLabel.isVisible = false
+                mapTypeSpecificTable.add(generatedMapOptionsTable)
                 mapParameters.name = ""
             }
         }
 
-        updateOnMapTypeChange() // activate once, so when we had a file map before we'll have the right things set for another one
+        // activate once, so when we had a file map before we'll have the right things set for another one
+        updateOnMapTypeChange()
 
         mapTypeSelectBox.addListener(object : ChangeListener() {
             override fun changed(event: ChangeEvent?, actor: Actor?) {
@@ -79,12 +83,8 @@ class NewGameScreenOptionsTable(val newGameScreen: NewGameScreen, val updatePlay
             }
         })
 
-        add(mapTypeSelectBox).pad(10f).row()
-        add(mapParameterTable).colspan(2).row()
-
-        add(mapFileLabel)
-        add(mapFileSelectBox).maxWidth(newGameScreen.stage.width / 2) // because SOME people gotta give the hugest names to their maps
-            .pad(10f).row()
+        add(mapTypeSelectBox).row()
+        add(mapTypeSpecificTable).colspan(2).row()
     }
 
 
@@ -147,7 +147,7 @@ class NewGameScreenOptionsTable(val newGameScreen: NewGameScreen, val updatePlay
         (0..ruleset.nations.filter { it.value.isCityState() }.size).forEach { cityStatesArray.add(it) }
         cityStatesSelectBox.items = cityStatesArray
         cityStatesSelectBox.selected = newGameParameters.numberOfCityStates
-        add(cityStatesSelectBox).pad(10f).row()
+        add(cityStatesSelectBox).row()
         cityStatesSelectBox.addListener(object : ChangeListener() {
             override fun changed(event: ChangeEvent?, actor: Actor?) {
                 newGameParameters.numberOfCityStates = cityStatesSelectBox.selected
@@ -163,7 +163,7 @@ class NewGameScreenOptionsTable(val newGameScreen: NewGameScreen, val updatePlay
                 newGameParameters.difficulty = difficultySelectBox.selected.value
             }
         })
-        add(difficultySelectBox).pad(10f).row()
+        add(difficultySelectBox).fillX().row()
     }
 
     private fun addGameSpeedSelectBox() {
@@ -174,7 +174,7 @@ class NewGameScreenOptionsTable(val newGameScreen: NewGameScreen, val updatePlay
                 newGameParameters.gameSpeed = GameSpeed.valueOf(gameSpeedSelectBox.selected.value)
             }
         })
-        add(gameSpeedSelectBox).pad(10f).row()
+        add(gameSpeedSelectBox).fillX().row()
     }
 
     private fun addEraSelectBox() {
@@ -187,16 +187,16 @@ class NewGameScreenOptionsTable(val newGameScreen: NewGameScreen, val updatePlay
                 newGameParameters.startingEra = TechEra.valueOf(eraSelectBox.selected.value.replace(" era", ""))
             }
         })
-        add(eraSelectBox).pad(10f).row()
+        add(eraSelectBox).fillX().row()
     }
 
 
     private fun addVictoryTypeCheckboxes() {
-        add("{Victory conditions}:".tr()).colspan(2).row()
+        add("{Victory conditions}:".toLabel()).colspan(2).row()
 
         // Create a checkbox for each VictoryType existing
         var i = 0
-        val victoryConditionsTable = Table().apply { defaults().pad(10f) }
+        val victoryConditionsTable = Table().apply { defaults().pad(5f) }
         for (victoryType in VictoryType.values()) {
             if (victoryType == VictoryType.Neutral) continue
             val victoryCheckbox = CheckBox(victoryType.name.tr(), CameraStageBaseScreen.skin)
@@ -212,7 +212,7 @@ class NewGameScreenOptionsTable(val newGameScreen: NewGameScreen, val updatePlay
                     }
                 }
             })
-            victoryConditionsTable.add(victoryCheckbox)
+            victoryConditionsTable.add(victoryCheckbox).left()
             if (++i % 2 == 0) victoryConditionsTable.row()
         }
         add(victoryConditionsTable).colspan(2).row()
@@ -233,7 +233,7 @@ class NewGameScreenOptionsTable(val newGameScreen: NewGameScreen, val updatePlay
         }
 
         add("{Mods}:".tr()).colspan(2).row()
-        val modCheckboxTable = Table().apply { defaults().pad(10f) }
+        val modCheckboxTable = Table().apply { defaults().pad(5f) }
         for(mod in modRulesets){
             val checkBox = CheckBox(mod.name,CameraStageBaseScreen.skin)
             checkBox.addListener(object : ChangeListener() {


### PR DESCRIPTION
This is part 1 of maps related work I've done together with Cpt. Klutz during these days. 

- **Rectangular maps support**: `TileMap` rectangular constructor and `MapShape` class added
- UI change to let the user pick rectangular maps
- `Perlin` noise refactor:
  - gradients bugfix
  - in order to have smooth and coherent multitiles structure the value of perlin noise for each tile is calculated based on `WorldCoords` rather than `HexCoords` (to reflect the actual placing of tiles on screen)
  - utility function to combine several octaves
- `MapGenerator` refactor:
  - equal `mapParameters` generate identical maps: all `RNG` calls a common `RNG` properly seeded
  - the landmass generator is a singleton
  - parametrized several `mapParameters` to let the user change the default value in future
- MapTypes: `Pangea`, `Continents` and `Perlin` landmass generator changed to perlin, the only type using the cellular automata landmass generator is `Default`. 

- `NewGameScreen` & `MapParametersTable` UI changes: all labels aligned to left.
- Bugfixes on `NewGameScreen`:
  - the `MapType` cannot be set to `Generated` anymore (as `Generated` is a _macrotype_ rather than a _type_)
  - generating a non-valid map doesn't force the user to close and reopen the app to try creating a new game.

Close #1219
