### PR TITLE
Forge increases production of the space parts (#1902)

### DIFF
--- a/android/assets/jsons/Buildings.json
+++ b/android/assets/jsons/Buildings.json
@@ -411,7 +411,7 @@
 		"requiredNearbyImprovedResources": ["Iron"],
 		"resourceBonusStats": {"production": 1},
 		"requiredTech": "Metal Casting",
-		"uniques": ["+15% production of land units"]
+		"uniques": ["+15% production of land units", "Increases production of spaceship parts by 15%"]
 	},
 	{
 		"name": "Harbor",

--- a/android/assets/jsons/translationsByLanguage/English.properties
+++ b/android/assets/jsons/translationsByLanguage/English.properties
@@ -230,6 +230,8 @@ Longhouse =
 Forge = 
  # Requires translation!
 +15% production of land units = 
+ # Requires translation!
+Increases production of spaceship parts by 15% = Increases production of spaceship parts by 15%
 
  # Requires translation!
 Harbor = 

--- a/android/assets/jsons/translationsByLanguage/template.properties
+++ b/android/assets/jsons/translationsByLanguage/template.properties
@@ -134,6 +134,7 @@ Longhouse =
 
 Forge = 
 +15% production of land units = 
+Increases production of spaceship parts by 15% = 
 
 Harbor = 
 +1 production from all sea resources worked by the city = 

--- a/core/src/com/unciv/logic/city/CityStats.kt
+++ b/core/src/com/unciv/logic/city/CityStats.kt
@@ -300,8 +300,6 @@ class CityStats {
                 stats.production += 25
             if (cityInfo.containsBuildingUnique("Increases production of spaceship parts by 50%"))
                 stats.production += 50
-            if (cityInfo.containsBuildingUnique("+15% production of land units")) // Forge
-                stats.production += 15
         }
 
         if (currentConstruction is BaseUnit) {

--- a/core/src/com/unciv/logic/city/CityStats.kt
+++ b/core/src/com/unciv/logic/city/CityStats.kt
@@ -300,6 +300,8 @@ class CityStats {
                 stats.production += 25
             if (cityInfo.containsBuildingUnique("Increases production of spaceship parts by 50%"))
                 stats.production += 50
+            if (cityInfo.containsBuildingUnique("+15% production of land units")) // Forge
+                stats.production += 15
         }
 
         if (currentConstruction is BaseUnit) {

--- a/core/src/com/unciv/logic/city/CityStats.kt
+++ b/core/src/com/unciv/logic/city/CityStats.kt
@@ -296,6 +296,8 @@ class CityStats {
             stats.culture += 25f
 
         if (currentConstruction is Building && currentConstruction.uniques.contains("Spaceship part")) {
+            if (cityInfo.containsBuildingUnique("Increases production of spaceship parts by 15%"))
+                stats.production += 15
             if (cityInfo.civInfo.containsBuildingUnique("Increases production of spaceship parts by 25%"))
                 stats.production += 25
             if (cityInfo.containsBuildingUnique("Increases production of spaceship parts by 50%"))


### PR DESCRIPTION
There are 4 possible fixes for the issue #1902 .
1) Add a check for the space parts production for "+15% to the land units" which brings the forge 
2) Add a new unique ability to the forge: "+15% for space parts", and check for it
3) Add a check for the space parts production for the building name "Forge"
4) Add the space parts to the list of the land units
Out of these, the most reasonable solution seems to me the 1st one.