### PR TITLE
Fix tile yields in city screen

### DIFF
--- a/core/src/com/unciv/ui/cityscreen/CityTileGroup.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityTileGroup.kt
@@ -59,7 +59,7 @@ class CityTileGroup(private val city: CityInfo, tileInfo: TileInfo, tileSetStrin
     }
 
     private fun updateYieldGroup() {
-        yieldGroup.setStats(tileInfo.getTileStats(city, city.civInfo.gameInfo.getCurrentPlayerCivilization()))
+        yieldGroup.setStats(tileInfo.getTileStats(city, city.civInfo))
         yieldGroup.setOrigin(Align.center)
         yieldGroup.setScale(0.7f)
         yieldGroup.toFront()


### PR DESCRIPTION
Tile yields in CityTileGroup was calculated as seen by the current player, rather than the city owner.