### PR TITLE
The civilization whose area is nuked must declear a war

### DIFF
--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -334,17 +334,24 @@ object Battle {
                 destroyIfDefeated(city.civInfo,attackingCiv)
             }
 
+            fun declareWar(civSuffered: CivilizationInfo) {
+                if (civSuffered != attackingCiv
+                        && civSuffered.knows(attackingCiv)
+                        && civSuffered.getDiplomacyManager(attackingCiv).canDeclareWar()) {
+                    civSuffered.getDiplomacyManager(attackingCiv).declareWar()
+                }
+            }
+
             for(unit in tile.getUnits()){
                 unit.destroy()
                 postBattleNotifications(attacker, MapUnitCombatant(unit), unit.currentTile)
-                if(unit.civInfo!=attackingCiv
-                        && unit.civInfo.knows(attackingCiv)
-                        && unit.civInfo.getDiplomacyManager(attackingCiv).canDeclareWar()){
-                    unit.civInfo.getDiplomacyManager(attackingCiv).declareWar()
-                }
-
+                declareWar(unit.civInfo)
                 destroyIfDefeated(unit.civInfo, attackingCiv)
             }
+
+            // this tile belongs to some civilization who is not happy of nuking it
+            if (city != null)
+                declareWar(city.civInfo)
 
             tile.improvement = null
             tile.improvementInProgress = null


### PR DESCRIPTION
Without this fix it is possible to nuke several cities with no declaration of war.
![Screenshot_20200215-084009](https://user-images.githubusercontent.com/27405436/74584716-0137f580-4fde-11ea-899a-c348805974fa.png)
BOOM! ...and still everybody is happy.
![Screenshot_20200215-084018](https://user-images.githubusercontent.com/27405436/74584717-02692280-4fde-11ea-9550-e194d7d6732b.png)

However, according to the #1375 
> 2. Any civ whose territory is affected by a nuclear blast should consider that a declaration of war.

So this is the fix.