### PR TITLE
Tile stats are shown on a row, rather than on a column

### DIFF
--- a/core/src/com/unciv/ui/cityscreen/CityScreenTileTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityScreenTileTable.kt
@@ -68,8 +68,7 @@ class CityScreenTileTable(val city: CityInfo): Table(){
         statsTable.defaults().pad(2f)
         for (entry in stats.toHashMap().filterNot { it.value == 0f }) {
             statsTable.add(ImageGetter.getStatIcon(entry.key.toString())).size(20f)
-            statsTable.add(entry.value.roundToInt().toString().toLabel())
-            statsTable.row()
+            statsTable.add(entry.value.roundToInt().toString().toLabel()).padRight(5f)
         }
         return statsTable
     }


### PR DESCRIPTION
![tilestats](https://user-images.githubusercontent.com/17114100/74594966-733f2780-503c-11ea-975b-8e3f3c6a029a.png)
