### PR TITLE
Fixed typo: Otto von Bismark -> Otto von Bismarck

### DIFF
--- a/android/assets/jsons/Nations/Nations.json
+++ b/android/assets/jsons/Nations/Nations.json
@@ -385,12 +385,12 @@
 	},
 	{
 		"name": "Germany",
-		"leaderName": "Otto von Bismark",
+		"leaderName": "Otto von Bismarck",
 		"adjective": ["German"],
 		"preferredVictoryType": "Scientific",
 		
-		"startIntroPart1": "Hail mighty Bismark, first canchellor of Germany and her empire! Germany is an upstart nation, fashioned from the ruins of the Holy Roman Empire and finally unified in 1871, a little more than a century ago. The German people have proven themselves to be creative, industrious a ferocious warriors. Despite enduring great catastrophes in the first half of the 20th century, Germany remains a worldwide economic, artistic and technological leader.",
-		"startIntroPart2": "Great Prince Bismark, the German people look up too you to lead them to greater days of glory. Their determination is strong, and now they turn to you, their beloved iron chancellor, to guide them once more. Will you rile and conquer through blood and iron, or foster the Germanic arts and industry? Can you build a civilization that will stand the test of time?",
+		"startIntroPart1": "Hail mighty Bismarck, first canchellor of Germany and her empire! Germany is an upstart nation, fashioned from the ruins of the Holy Roman Empire and finally unified in 1871, a little more than a century ago. The German people have proven themselves to be creative, industrious a ferocious warriors. Despite enduring great catastrophes in the first half of the 20th century, Germany remains a worldwide economic, artistic and technological leader.",
+		"startIntroPart2": "Great Prince Bismarck, the German people look up too you to lead them to greater days of glory. Their determination is strong, and now they turn to you, their beloved iron chancellor, to guide them once more. Will you rile and conquer through blood and iron, or foster the Germanic arts and industry? Can you build a civilization that will stand the test of time?",
 		"declaringWar": "I cannot wait until ye grow even mightier. Therefore, prepare for war!",
 		"attacked": "Corrupted villain! We will bring you into the ground!",
 		"defeated": "Germany has been destroyed. I weep for the future generations.",

--- a/android/assets/jsons/Nations/Nations_Italian.json
+++ b/android/assets/jsons/Nations/Nations_Italian.json
@@ -371,7 +371,7 @@
 	{
 		"name": "Germany",
 		"translatedName": "Germania",
-		"leaderName": "Otto von Bismark",
+		"leaderName": "Otto von Bismarck",
 		"adjective": ["tedesco"],
 		
 		"startIntroPart1": "Salve, potente Bismarck, primo cancelliere della Germania e del suo impero! La germania è una delle nazioni più giovani, sorta dalle ceneri del Sacro Romano Impero e poi unificata nel 1871, poco più di un secolo fa. Il popolo tedesco si è rivelato creativo, industrioso e feroce in guerra. Nonostante le catastrofi subite nella prima metà del XX secolo, la Germania è riuscita a imporsi come una delle nazioni più importanti dal punto di vista economico, artistico e tecnologico..",

--- a/android/assets/jsons/Nations/Nations_Japanese.json
+++ b/android/assets/jsons/Nations/Nations_Japanese.json
@@ -385,12 +385,12 @@
 	},
 	{
 		"name": "Germany",
-		"leaderName": "Otto von Bismark",
+		"leaderName": "Otto von Bismarck",
 		"adjective": ["German"],
 		"preferredVictoryType": "Scientific",
 		
-		"startIntroPart1": "Hail mighty Bismark, first canchellor of Germany and her empire! Germany is an upstart nation, fashioned from the ruins of the Holy Roman Empire and finally unified in 1871, a little more than a century ago. The German people have proven themselves to be creative, industrious a ferocious warriors. Despite enduring great catastrophes in the first half of the 20th century, Germany remains a worldwide economic, artistic and technological leader.",
-		"startIntroPart2": "Great Prince Bismark, the German people look up too you to lead them to greater days of glory. Their determination is strong, and now they turn to you, their beloved iron chancellor, to guide them once more. Will you rile and conquer through blood and iron, or foster the Germanic arts and industry? Can you build a civilization that will stand the test of time?",
+		"startIntroPart1": "Hail mighty Bismarck, first canchellor of Germany and her empire! Germany is an upstart nation, fashioned from the ruins of the Holy Roman Empire and finally unified in 1871, a little more than a century ago. The German people have proven themselves to be creative, industrious a ferocious warriors. Despite enduring great catastrophes in the first half of the 20th century, Germany remains a worldwide economic, artistic and technological leader.",
+		"startIntroPart2": "Great Prince Bismarck, the German people look up too you to lead them to greater days of glory. Their determination is strong, and now they turn to you, their beloved iron chancellor, to guide them once more. Will you rile and conquer through blood and iron, or foster the Germanic arts and industry? Can you build a civilization that will stand the test of time?",
 		"declaringWar": "I cannot wait until ye grow even mightier. Therefore, prepare for war!",
 		"attacked": "Corrupted villain! We will bring you into the ground!",
 		"defeated": "Germany has been destroyed. I weep for the future generations.",

--- a/android/assets/jsons/Nations/Nations_Polish.json
+++ b/android/assets/jsons/Nations/Nations_Polish.json
@@ -379,11 +379,11 @@
 	{
 		"name": "Germany",
 		"translatedName": "Niemcy",
-		"leaderName": "Otto von Bismark",
+		"leaderName": "Otto von Bismarck",
 		"adjective": ["Niemiecki"],
 		
-		"startIntroPart1": "Hail mighty Bismark, first canchellor of Germany and her empire! Germany is an upstart nation, fashioned from the ruins of the Holy Roman Empire and finally unified in 1871, a little more than a century ago. The German people have proven themselves to be creative, industrious a ferocious warriors. Despite enduring great catastrophes in the first half of the 20th century, Germany remains a worldwide economic, artistic and technological leader.",
-		"startIntroPart2": "Great Prince Bismark, the German people look up too you to lead them to greater days of glory. Their determination is strong, and now they turn to you, their beloved iron chancellor, to guide them once more. Will you rile and conquer through blood and iron, or foster the Germanic arts and industry? Can you build a civilization that will stand the test of time?",
+		"startIntroPart1": "Hail mighty Bismarck, first canchellor of Germany and her empire! Germany is an upstart nation, fashioned from the ruins of the Holy Roman Empire and finally unified in 1871, a little more than a century ago. The German people have proven themselves to be creative, industrious a ferocious warriors. Despite enduring great catastrophes in the first half of the 20th century, Germany remains a worldwide economic, artistic and technological leader.",
+		"startIntroPart2": "Great Prince Bismarck, the German people look up too you to lead them to greater days of glory. Their determination is strong, and now they turn to you, their beloved iron chancellor, to guide them once more. Will you rile and conquer through blood and iron, or foster the Germanic arts and industry? Can you build a civilization that will stand the test of time?",
 		"declaringWar": "I cannot wait until ye grow even mightier. Therefore, prepare for war!",
 		"attacked": "Corrupted villain! We will bring you into the ground!",
 		"defeated": "Germany has been destroyed. I weep for the future generations.",

--- a/android/assets/jsons/Nations/Nations_Russian.json
+++ b/android/assets/jsons/Nations/Nations_Russian.json
@@ -397,8 +397,8 @@
 		"adjective": ["German"],
 		"preferredVictoryType": "Scientific",
 		
-		"startIntroPart1": "Hail mighty Bismark, first canchellor of Germany and her empire! Germany is an upstart nation, fashioned from the ruins of the Holy Roman Empire and finally unified in 1871, a little more than a century ago. The German people have proven themselves to be creative, industrious a ferocious warriors. Despite enduring great catastrophes in the first half of the 20th century, Germany remains a worldwide economic, artistic and technological leader.",
-		"startIntroPart2": "Great Prince Bismark, the German people look up too you to lead them to greater days of glory. Their determination is strong, and now they turn to you, their beloved iron chancellor, to guide them once more. Will you rile and conquer through blood and iron, or foster the Germanic arts and industry? Can you build a civilization that will stand the test of time?",
+		"startIntroPart1": "Hail mighty Bismarck, first canchellor of Germany and her empire! Germany is an upstart nation, fashioned from the ruins of the Holy Roman Empire and finally unified in 1871, a little more than a century ago. The German people have proven themselves to be creative, industrious a ferocious warriors. Despite enduring great catastrophes in the first half of the 20th century, Germany remains a worldwide economic, artistic and technological leader.",
+		"startIntroPart2": "Great Prince Bismarck, the German people look up too you to lead them to greater days of glory. Their determination is strong, and now they turn to you, their beloved iron chancellor, to guide them once more. Will you rile and conquer through blood and iron, or foster the Germanic arts and industry? Can you build a civilization that will stand the test of time?",
 		"declaringWar": "I cannot wait until ye grow even mightier. Therefore, prepare for war!",
 		"attacked": "Corrupted villain! We will bring you into the ground!",
 		"defeated": "Germany has been destroyed. I weep for the future generations.",

--- a/android/assets/jsons/Nations/Nations_Simplified_Chinese.json
+++ b/android/assets/jsons/Nations/Nations_Simplified_Chinese.json
@@ -394,8 +394,8 @@
 		"leaderName": "奥托·冯·俾斯麦",
 		"adjective": ["德意志的"],
 		
-		"startIntroPart1": "Hail mighty Bismark, first canchellor of Germany and her empire! Germany is an upstart nation, fashioned from the ruins of the Holy Roman Empire and finally unified in 1871, a little more than a century ago. The German people have proven themselves to be creative, industrious a ferocious warriors. Despite enduring great catastrophes in the first half of the 20th century, Germany remains a worldwide economic, artistic and technological leader.",
-		"startIntroPart2": "Great Prince Bismark, the German people look up too you to lead them to greater days of glory. Their determination is strong, and now they turn to you, their beloved iron chancellor, to guide them once more. Will you rile and conquer through blood and iron, or foster the Germanic arts and industry? Can you build a civilization that will stand the test of time?",
+		"startIntroPart1": "Hail mighty Bismarck, first canchellor of Germany and her empire! Germany is an upstart nation, fashioned from the ruins of the Holy Roman Empire and finally unified in 1871, a little more than a century ago. The German people have proven themselves to be creative, industrious a ferocious warriors. Despite enduring great catastrophes in the first half of the 20th century, Germany remains a worldwide economic, artistic and technological leader.",
+		"startIntroPart2": "Great Prince Bismarck, the German people look up too you to lead them to greater days of glory. Their determination is strong, and now they turn to you, their beloved iron chancellor, to guide them once more. Will you rile and conquer through blood and iron, or foster the Germanic arts and industry? Can you build a civilization that will stand the test of time?",
 		"declaringWar": "I cannot wait until ye grow even mightier. Therefore, prepare for war!",
 		"attacked": "Corrupted villain! We will bring you into the ground!",
 		"defeated": "Germany has been destroyed. I weep for the future generations.",

--- a/android/assets/jsons/Nations/Nations_Ukrainian.json
+++ b/android/assets/jsons/Nations/Nations_Ukrainian.json
@@ -397,8 +397,8 @@
 		"adjective": ["Німецька"],
 		"preferredVictoryType": "Scientific",
 
-		"startIntroPart1": "Hail mighty Bismark, first canchellor of Germany and her empire! Germany is an upstart nation, fashioned from the ruins of the Holy Roman Empire and finally unified in 1871, a little more than a century ago. The German people have proven themselves to be creative, industrious a ferocious warriors. Despite enduring great catastrophes in the first half of the 20th century, Germany remains a worldwide economic, artistic and technological leader.",
-		"startIntroPart2": "Great Prince Bismark, the German people look up too you to lead them to greater days of glory. Their determination is strong, and now they turn to you, their beloved iron chancellor, to guide them once more. Will you rile and conquer through blood and iron, or foster the Germanic arts and industry? Can you build a civilization that will stand the test of time?",
+		"startIntroPart1": "Hail mighty Bismarck, first canchellor of Germany and her empire! Germany is an upstart nation, fashioned from the ruins of the Holy Roman Empire and finally unified in 1871, a little more than a century ago. The German people have proven themselves to be creative, industrious a ferocious warriors. Despite enduring great catastrophes in the first half of the 20th century, Germany remains a worldwide economic, artistic and technological leader.",
+		"startIntroPart2": "Great Prince Bismarck, the German people look up too you to lead them to greater days of glory. Their determination is strong, and now they turn to you, their beloved iron chancellor, to guide them once more. Will you rile and conquer through blood and iron, or foster the Germanic arts and industry? Can you build a civilization that will stand the test of time?",
 		"declaringWar": "Ми не можемо допустити вашого посилення. Тож готуйтесь до війни!",
 		"attacked": "Лиходію! Ми зрівняємо вас з землею!",
 		"defeated": "Німеччина була знищена. Мені шкода наступні покоління.",

--- a/android/assets/jsons/translationsByLanguage/Czech.properties
+++ b/android/assets/jsons/translationsByLanguage/Czech.properties
@@ -526,7 +526,7 @@ Oda Nobunaga = Nobunaga Oda
 Units fight as though they were at full strength even when damaged = Jednotky bojují pořád v plné síle, i když jsou zraněné
 
 Germany = Německo
-Otto von Bismark = Otto von Bismarck
+Otto von Bismarck = Otto von Bismarck
 67% chance to earn 25 Gold and recruit a Barbarian unit from a conquered encampment, -25% land units maintenance. = 67% šance získat 25 Zlata a naverbovat Barbarskou jednotku z dobytého tábora, -25% žoldu pro všechny jednotky
 
 India = Indie

--- a/android/assets/jsons/translationsByLanguage/Dutch.properties
+++ b/android/assets/jsons/translationsByLanguage/Dutch.properties
@@ -815,7 +815,7 @@ Units fight as though they were at full strength even when damaged =
  # Requires translation!
 Germany = 
  # Requires translation!
-Otto von Bismark = 
+Otto von Bismarck = 
  # Requires translation!
 67% chance to earn 25 Gold and recruit a Barbarian unit from a conquered encampment, -25% land units maintenance. = 
 

--- a/android/assets/jsons/translationsByLanguage/English.properties
+++ b/android/assets/jsons/translationsByLanguage/English.properties
@@ -885,7 +885,7 @@ Units fight as though they were at full strength even when damaged =
  # Requires translation!
 Germany = 
  # Requires translation!
-Otto von Bismark = 
+Otto von Bismarck = 
  # Requires translation!
 67% chance to earn 25 Gold and recruit a Barbarian unit from a conquered encampment, -25% land units maintenance. = 
 

--- a/android/assets/jsons/translationsByLanguage/French.properties
+++ b/android/assets/jsons/translationsByLanguage/French.properties
@@ -499,7 +499,7 @@ Oda Nobunaga = Oda Nobunaga
 Units fight as though they were at full strength even when damaged = Les unités combattent comme si elles étaient à pleine force même lorsqu'elles sont endommagées
 
 Germany = Allemagne
-Otto von Bismark = Otto von Bismarck
+Otto von Bismarck = Otto von Bismarck
 67% chance to earn 25 Gold and recruit a Barbarian unit from a conquered encampment, -25% land units maintenance. = 67% de chance de gagner 25 or et d'enroler une unité barbare lors de la prise d'un campement barbare. -25% de coût de maintenance pour les unités terrestres.
 
 India = Inde

--- a/android/assets/jsons/translationsByLanguage/German.properties
+++ b/android/assets/jsons/translationsByLanguage/German.properties
@@ -499,7 +499,7 @@ Oda Nobunaga = Oda Nobunaga
 Units fight as though they were at full strength even when damaged = Einheiten kämpfen mit voller Stärke, selbst bei Beschädigung
 
 Germany = Deutschland
-Otto von Bismark = Otto von Bismark
+Otto von Bismarck = Otto von Bismarck
 67% chance to earn 25 Gold and recruit a Barbarian unit from a conquered encampment, -25% land units maintenance. = 67% Chance, 25 Gold zu verdienen und eine barbarische Einheit aus dem eroberten Lager zu rekrutieren, -25% Instandhaltung von Landeinheiten.
 
 India = Indien

--- a/android/assets/jsons/translationsByLanguage/Indonesian.properties
+++ b/android/assets/jsons/translationsByLanguage/Indonesian.properties
@@ -552,7 +552,7 @@ Oda Nobunaga = Oda Nobunaga
 Units fight as though they were at full strength even when damaged = Unit bertarung seperti saat darah penuh walaupun terluka
 
 Germany = Jerman
-Otto von Bismark = Otto von Bismark
+Otto von Bismarck = Otto von Bismarck
 67% chance to earn 25 Gold and recruit a Barbarian unit from a conquered encampment, -25% land units maintenance. = Berkemungkinan 67% untuk mendapatkan 25 Emas dan merekrut unit barbarian saat menguasai perkemahan barbarian, -25% biaya unit darat
 
 India = India

--- a/android/assets/jsons/translationsByLanguage/Italian.properties
+++ b/android/assets/jsons/translationsByLanguage/Italian.properties
@@ -499,7 +499,7 @@ Oda Nobunaga = Oda Nobunaga
 Units fight as though they were at full strength even when damaged = Le unità combattono come se fossero perfettamente sane, anche quando gravemente ferite
 
 Germany = Germania
-Otto von Bismark = Otto von Bismark
+Otto von Bismarck = Otto von Bismarck
 67% chance to earn 25 Gold and recruit a Barbarian unit from a conquered encampment, -25% land units maintenance. = 67% di probabilità di ottenere 25 Oro e reclutare un'unità barbara da un accampamento catturato. -25% mantenimento delle unità terrestri.
 
 India = India

--- a/android/assets/jsons/translationsByLanguage/Japanese.properties
+++ b/android/assets/jsons/translationsByLanguage/Japanese.properties
@@ -510,7 +510,7 @@ Oda Nobunaga = 織田信長
 Units fight as though they were at full strength even when damaged = ダメージを負ってもユニットの攻撃力が下がらない
 
 Germany = ドイツ
-Otto von Bismark = ビスマルク
+Otto von Bismarck = ビスマルク
 67% chance to earn 25 Gold and recruit a Barbarian unit from a conquered encampment, -25% land units maintenance. = 野営地にいる蛮族を倒すと67%の確率で25ゴールドを獲得でき、同様の確率で彼らが仲間になる。陸上ユニットの維持費-25%
 
 India = インド

--- a/android/assets/jsons/translationsByLanguage/Korean.properties
+++ b/android/assets/jsons/translationsByLanguage/Korean.properties
@@ -557,7 +557,7 @@ Oda Nobunaga = 오다 노부나가
 Units fight as though they were at full strength even when damaged = 유닛이 피해를 입어도 전투력이 그대로 유지됩니다.
 
 Germany = 독일
-Otto von Bismark = 오토 폰 비스마르크
+Otto von Bismarck = 오토 폰 비스마르크
 67% chance to earn 25 Gold and recruit a Barbarian unit from a conquered encampment, -25% land units maintenance. = 야만인 주둔지를 점령할 때 67% 확률로 금 25와 야만인 유닛을 획득합니다. 지낭 유닛 유지비 -25%
 
 India = 인도

--- a/android/assets/jsons/translationsByLanguage/Malay.properties
+++ b/android/assets/jsons/translationsByLanguage/Malay.properties
@@ -780,7 +780,7 @@ Units fight as though they were at full strength even when damaged =
 
 Germany = Jerman
  # Requires translation!
-Otto von Bismark = 
+Otto von Bismarck = 
  # Requires translation!
 67% chance to earn 25 Gold and recruit a Barbarian unit from a conquered encampment, -25% land units maintenance. = 
 

--- a/android/assets/jsons/translationsByLanguage/Polish.properties
+++ b/android/assets/jsons/translationsByLanguage/Polish.properties
@@ -499,7 +499,7 @@ Oda Nobunaga = Oda Nobunaga
 Units fight as though they were at full strength even when damaged = Jednostki walczą z pełną sił, nawet kiedy są zranione
 
 Germany = Niemcy
-Otto von Bismark = Otto von Bismarck
+Otto von Bismarck = Otto von Bismarck
 67% chance to earn 25 Gold and recruit a Barbarian unit from a conquered encampment, -25% land units maintenance. = 67% szans na zdobycie 25 Złota i zrekrutowanie Barbażyńskiej jednostki z podbitego obozowiska, -25% do utrzymania jednostek lądowych.
 
 India = Indie

--- a/android/assets/jsons/translationsByLanguage/Portuguese.properties
+++ b/android/assets/jsons/translationsByLanguage/Portuguese.properties
@@ -558,7 +558,7 @@ Oda Nobunaga = Oda Nobunaga
 Units fight as though they were at full strength even when damaged = Unidades lutam como se estivessem em força total mesmo quando danificadas
 
 Germany = Alemanha
-Otto von Bismark = Otto von Bismarck
+Otto von Bismarck = Otto von Bismarck
 67% chance to earn 25 Gold and recruit a Barbarian unit from a conquered encampment, -25% land units maintenance. = 67% de chance de ganhar 25 de ouro e recrutar uma unidade bárbara de um acampamento conquistado e -25% de manutenção para unidades terrestres
 
 India = Índia

--- a/android/assets/jsons/translationsByLanguage/Romanian.properties
+++ b/android/assets/jsons/translationsByLanguage/Romanian.properties
@@ -583,7 +583,7 @@ Oda Nobunaga = Oda Nobunaga
 Units fight as though they were at full strength even when damaged = Unitățile se luptă ca și cum ar fi la putere deplină chiar și atunci când sunt deteriorate
 
 Germany = Germania
-Otto von Bismark = Otto von Bismark
+Otto von Bismarck = Otto von Bismarck
  # Requires translation!
 67% chance to earn 25 Gold and recruit a Barbarian unit from a conquered encampment, -25% land units maintenance. = 
 

--- a/android/assets/jsons/translationsByLanguage/Russian.properties
+++ b/android/assets/jsons/translationsByLanguage/Russian.properties
@@ -499,7 +499,7 @@ Oda Nobunaga = Ода Нобунага
 Units fight as though they were at full strength even when damaged = Юниты сражаются в полную силу, даже будучи ранеными
 
 Germany = Германия
-Otto von Bismark = Отто фон Бисмарк
+Otto von Bismarck = Отто фон Бисмарк
 67% chance to earn 25 Gold and recruit a Barbarian unit from a conquered encampment, -25% land units maintenance. = Шанс 67% получить 25 Золота и варварский юнит из захваченного лагеря. -25% к стоимости содержания наземных юнитов.
 
 India = Индия

--- a/android/assets/jsons/translationsByLanguage/Simplified_Chinese.properties
+++ b/android/assets/jsons/translationsByLanguage/Simplified_Chinese.properties
@@ -499,7 +499,7 @@ Oda Nobunaga = 织田信长
 Units fight as though they were at full strength even when damaged = 受伤单位造成的伤害不减
 
 Germany = 德意志
-Otto von Bismark = 奥托·冯·俾斯麦
+Otto von Bismarck = 奥托·冯·俾斯麦
 67% chance to earn 25 Gold and recruit a Barbarian unit from a conquered encampment, -25% land units maintenance. = 击败蛮族营地中的蛮族单位有67%几率得到25金钱并使其加入，陆上单位维护费-25%
 
 India = 印度

--- a/android/assets/jsons/translationsByLanguage/Spanish.properties
+++ b/android/assets/jsons/translationsByLanguage/Spanish.properties
@@ -527,7 +527,7 @@ Oda Nobunaga = Oda Nobunaga
 Units fight as though they were at full strength even when damaged = Las unidades luchan como si estuvieran con toda su fuerza incluso cuando están dañadas
 
 Germany = Alemania
-Otto von Bismark = Otto von Bismark
+Otto von Bismarck = Otto von Bismarck
 67% chance to earn 25 Gold and recruit a Barbarian unit from a conquered encampment, -25% land units maintenance. = 67% de probabilidad de ganar 25 de oro y reclutar una unidad bárbara de un campamento conquistado, -25% de mantenimiento de unidades terrestres.
 
 India = India

--- a/android/assets/jsons/translationsByLanguage/Thai.properties
+++ b/android/assets/jsons/translationsByLanguage/Thai.properties
@@ -447,7 +447,7 @@ Oda Nobunaga = โอดะ โนบุนากะ
 Units fight as though they were at full strength even when damaged = ยูนิตนิตจะสู้เต็มกำลัง (พลังชีวิตมีผลต่อพลังโจมตีนะครับ) ถึงแม้ว่าจะได้รับความเสียหายมามากก็ตาม
 
 Germany = เยอรมนี
-Otto von Bismark = อ็อทโท ฟ็อน บิสมาร์ค
+Otto von Bismarck = อ็อทโท ฟ็อน บิสมาร์ค
 67% chance to earn 25 Gold and recruit a Barbarian unit from a conquered encampment, -25% land units maintenance. = มีโอกาส 67% ที่จะได้รับ 25 ทอง และการจ้างยูนิตคนเถื่อนจากแคมป์ที่ยึดมาได้, -25% ค่าใช้จ่ายในการทำให้ยูนิตทัพบกคงอยู่
 
 India = อินเดีย

--- a/android/assets/jsons/translationsByLanguage/Traditional_Chinese.properties
+++ b/android/assets/jsons/translationsByLanguage/Traditional_Chinese.properties
@@ -499,7 +499,7 @@ Oda Nobunaga = 織田信長
 Units fight as though they were at full strength even when damaged = 受傷單位造成的傷害不減
 
 Germany = 德意志
-Otto von Bismark = 奧托·馮·俾斯麥
+Otto von Bismarck = 奧托·馮·俾斯麥
 67% chance to earn 25 Gold and recruit a Barbarian unit from a conquered encampment, -25% land units maintenance. = 擊敗蠻族營地中的蠻族單位有67%機率得到25金錢並使其加入，路上單位維護費-25%
 
 India = 印度

--- a/android/assets/jsons/translationsByLanguage/Turkish.properties
+++ b/android/assets/jsons/translationsByLanguage/Turkish.properties
@@ -499,7 +499,7 @@ Oda Nobunaga = Oda Nobunaga
 Units fight as though they were at full strength even when damaged = Birimler hasar gördüklerinde bile tam güçte gibi savaşırlar
 
 Germany = Almanya
-Otto von Bismark = Otto von Bismark
+Otto von Bismarck = Otto von Bismarck
 67% chance to earn 25 Gold and recruit a Barbarian unit from a conquered encampment, -25% land units maintenance. = 67% 25 altın kazanma ve fethedilen bir kamptan bir Barbar birimi toplama şansı, -25% kara birimi bakımı.
 
 India = Hindistan

--- a/android/assets/jsons/translationsByLanguage/Ukrainian.properties
+++ b/android/assets/jsons/translationsByLanguage/Ukrainian.properties
@@ -499,7 +499,7 @@ Oda Nobunaga = Ода Нобунаґа
 Units fight as though they were at full strength even when damaged = Підрозділи завжди воюють з повною силою, навіть якщо вони отримали пошкодження.
 
 Germany = Німеччина
-Otto von Bismark = Отто фон Бісмарк
+Otto von Bismarck = Отто фон Бісмарк
 67% chance to earn 25 Gold and recruit a Barbarian unit from a conquered encampment, -25% land units maintenance. = Є 67% шансу заробити 25 Золота та завербувати варварський загін з завойованого табору, -25% обслуговування сухопутних підрозділів
 
 India = Індія

--- a/android/assets/jsons/translationsByLanguage/template.properties
+++ b/android/assets/jsons/translationsByLanguage/template.properties
@@ -497,7 +497,7 @@ Oda Nobunaga =
 Units fight as though they were at full strength even when damaged = 
 
 Germany = 
-Otto von Bismark = 
+Otto von Bismarck = 
 67% chance to earn 25 Gold and recruit a Barbarian unit from a conquered encampment, -25% land units maintenance. = 
 
 India = 


### PR DESCRIPTION
Otto von Bismarck was misspelled in multiple translation and nation files.