### PR TITLE
Better alignment for "Pick now!" in the pickerscreens

### DIFF
--- a/core/src/com/unciv/ui/pickerscreens/ImprovementPickerScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/ImprovementPickerScreen.kt
@@ -6,6 +6,7 @@ import com.badlogic.gdx.scenes.scene2d.Touchable
 import com.badlogic.gdx.scenes.scene2d.ui.Button
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.scenes.scene2d.ui.VerticalGroup
+import com.badlogic.gdx.utils.Align
 import com.unciv.logic.map.RoadStatus
 import com.unciv.logic.map.TileInfo
 import com.unciv.models.ruleset.tile.TileImprovement
@@ -35,8 +36,8 @@ class ImprovementPickerScreen(tileInfo: TileInfo, onAccept: ()->Unit) : PickerSc
             accept(selectedImprovement)
         }
 
-        val regularImprovements = VerticalGroup()
-        regularImprovements.space(10f)
+        val regularImprovements = Table()
+        regularImprovements.defaults().pad(5f)
 
         for (improvement in tileInfo.tileMap.gameInfo.ruleSet.tileImprovements.values) {
             if (!tileInfo.canBuildImprovement(improvement, currentPlayerCiv)) continue
@@ -71,7 +72,7 @@ class ImprovementPickerScreen(tileInfo: TileInfo, onAccept: ()->Unit) : PickerSc
                 accept(improvement)
             }
 
-            val improvementRow = Table()
+            val statIcons = Table()
 
             // get benefits of the new improvement
             val stats = tileInfo.getImprovementStats(improvement, currentPlayerCiv, tileInfo.getCity())
@@ -100,7 +101,7 @@ class ImprovementPickerScreen(tileInfo: TileInfo, onAccept: ()->Unit) : PickerSc
 
             // icon for adding the resource by improvement
             if (provideResource)
-                improvementRow.add(ImageGetter.getResourceImage(tileInfo.resource.toString(), 30f)).pad(3f)
+                statIcons.add(ImageGetter.getResourceImage(tileInfo.resource.toString(), 30f)).pad(3f)
 
             // icon for removing the resource by replacing improvement
             if (removeImprovement && tileInfo.hasViewableResource(currentPlayerCiv) && tileInfo.getTileResource().improvement == tileInfo.improvement) {
@@ -111,18 +112,17 @@ class ImprovementPickerScreen(tileInfo: TileInfo, onAccept: ()->Unit) : PickerSc
                 val resourceIcon = ImageGetter.getResourceImage(tileInfo.resource.toString(), 30f)
                 crossedResource.addActor(resourceIcon)
                 crossedResource.addActor(cross)
-                improvementRow.add(crossedResource).padTop(30f).padRight(33f)
+                statIcons.add(crossedResource).padTop(30f).padRight(33f)
             }
 
-            improvementRow.add(statsTable).padLeft(13f)
+            statIcons.add(statsTable).padLeft(13f)
+            regularImprovements.add(statIcons).align(Align.right)
 
             val improvementButton = Button(skin)
-            improvementButton.add(group).padRight(10f).fillY()
-            improvementButton.addSeparatorVertical()
-            improvementButton.add(pickNow).padLeft(10f).fill()
-            improvementRow.add(improvementButton)
-
-            regularImprovements.addActor(improvementRow)
+            improvementButton.add(group).pad(5f).fillY()
+            regularImprovements.add(improvementButton)
+            regularImprovements.add(pickNow).padLeft(10f)
+            regularImprovements.row()
         }
         topTable.add(regularImprovements)
     }

--- a/core/src/com/unciv/ui/pickerscreens/PromotionPickerScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/PromotionPickerScreen.kt
@@ -38,8 +38,8 @@ class PromotionPickerScreen(val unit: MapUnit) : PickerScreen() {
         if(!canBePromoted)
             rightSideButton.disable()
 
-        val availablePromotionsGroup = VerticalGroup()
-        availablePromotionsGroup.space(10f)
+        val availablePromotionsGroup = Table()
+        availablePromotionsGroup.defaults().pad(5f)
 
         val unitType = unit.type
         val promotionsForUnitType = unit.civInfo.gameInfo.ruleSet.unitPromotions.values.filter {
@@ -67,9 +67,7 @@ class PromotionPickerScreen(val unit: MapUnit) : PickerScreen() {
                 descriptionLabel.setText(promotion.getDescription(promotionsForUnitType))
             }
 
-            val promotionTable = Table()
-            promotionTable.add(selectPromotionButton)
-
+            availablePromotionsGroup.add(selectPromotionButton)
 
             if(canBePromoted && isPromotionAvailable) {
                 val pickNow = "Pick now!".toLabel()
@@ -77,12 +75,13 @@ class PromotionPickerScreen(val unit: MapUnit) : PickerScreen() {
                 pickNow.onClick {
                     acceptPromotion(promotion)
                 }
-                promotionTable.add(pickNow).padLeft(10f).fillY()
+                availablePromotionsGroup.add(pickNow).padLeft(10f).fillY()
             }
             else if(unitHasPromotion) selectPromotionButton.color= Color.GREEN
             else selectPromotionButton.color= Color.GRAY
 
-            availablePromotionsGroup.addActor(promotionTable)
+            availablePromotionsGroup.row()
+
         }
         topTable.add(availablePromotionsGroup)
     }


### PR DESCRIPTION
According to the @lishaoxia1985 feedback in the #1955 , I suggest the alternative UI for "Pick now".
It is still functional, and I assume a bit better looking.

**BEFORE:** | **AFTER:**
--------------|--------------
![Screenshot 2020-02-21 23 23 27](https://user-images.githubusercontent.com/27405436/75073343-e98ece80-5501-11ea-9ab4-8271dcac2ed7.png) | ![Screenshot 2020-02-21 23 21 37](https://user-images.githubusercontent.com/27405436/75073363-f4496380-5501-11ea-88f3-227aa908c714.png)
![Screenshot 2020-02-21 23 10 20](https://user-images.githubusercontent.com/27405436/75073350-ee538280-5501-11ea-8127-71f02641a69e.png) | ![Screenshot 2020-02-21 23 09 19](https://user-images.githubusercontent.com/27405436/75073370-f7dcea80-5501-11ea-9f0d-53ce5b4bafe4.png)

