### PR TITLE
Continuous rendering is not experimental anymore

### DIFF
--- a/android/assets/jsons/translationsByLanguage/Russian.properties
+++ b/android/assets/jsons/translationsByLanguage/Russian.properties
@@ -707,6 +707,7 @@ Show pixel units = Показать текстуру юнитов
 Show pixel improvements = Показать текстуру улучшений
 Enable nuclear weapons = Разрешить использование ядерного оружия
 Fontset = Шрифт
+Continuous rendering = Непрерывная отрисовка
 
 # Notifications
 

--- a/android/assets/jsons/translationsByLanguage/Ukrainian.properties
+++ b/android/assets/jsons/translationsByLanguage/Ukrainian.properties
@@ -711,6 +711,7 @@ Show pixel units = Візуалізовувати підрозділи
 Show pixel improvements = Візуалізовувати вдосконалення
 Enable nuclear weapons = Увімкнути ядерну зброю
 Fontset = Шрифт
+Continuous rendering = Безперервна візуалізація
 
 # Notifications
 

--- a/android/assets/jsons/translationsByLanguage/template.properties
+++ b/android/assets/jsons/translationsByLanguage/template.properties
@@ -707,6 +707,7 @@ Show pixel units =
 Show pixel improvements = 
 Enable nuclear weapons = 
 Fontset = 
+Continuous rendering = 
 
 # Notifications
 

--- a/core/src/com/unciv/models/metadata/GameSettings.kt
+++ b/core/src/com/unciv/models/metadata/GameSettings.kt
@@ -26,7 +26,7 @@ class GameSettings {
     var showPixelImprovements: Boolean = true
     var showPixelResources: Boolean = true
     var nuclearWeaponEnabled = false
-    var continuousRendering = true
+    var continuousRendering = false
     var userId = ""
     var multiplayerTurnCheckerEnabled = true
     var multiplayerTurnCheckerPersistentNotificationEnabled = true

--- a/core/src/com/unciv/ui/worldscreen/mainmenu/WorldScreenOptionsPopup.kt
+++ b/core/src/com/unciv/ui/worldscreen/mainmenu/WorldScreenOptionsPopup.kt
@@ -82,8 +82,7 @@ class WorldScreenOptionsPopup(val worldScreen:WorldScreen) : Popup(worldScreen){
 
         addTileSetSelectBox(innerTable)
 
-        // Do not add to template.properties yet please.
-        innerTable.add("Continuous rendering\n(HIGHLY EXPERIMENTAL)".toLabel())
+        innerTable.add("Continuous rendering".toLabel())
         addButton(innerTable, if (settings.continuousRendering) "Yes" else "No") {
             settings.continuousRendering = !settings.continuousRendering
             Gdx.graphics.isContinuousRendering = settings.continuousRendering

--- a/core/src/com/unciv/ui/worldscreen/mainmenu/WorldScreenOptionsPopup.kt
+++ b/core/src/com/unciv/ui/worldscreen/mainmenu/WorldScreenOptionsPopup.kt
@@ -240,7 +240,7 @@ class WorldScreenOptionsPopup(val worldScreen:WorldScreen) : Popup(worldScreen){
         resolutionArray.addAll("750x500","900x600", "1050x700", "1200x800", "1500x1000")
         resolutionSelectBox.items = resolutionArray
         resolutionSelectBox.selected = UncivGame.Current.settings.resolution
-        innerTable.add(resolutionSelectBox).pad(10f).row()
+        innerTable.add(resolutionSelectBox).minWidth(240f).pad(10f).row()
 
         resolutionSelectBox.addListener(object : ChangeListener() {
             override fun changed(event: ChangeEvent?, actor: Actor?) {
@@ -263,7 +263,7 @@ class WorldScreenOptionsPopup(val worldScreen:WorldScreen) : Popup(worldScreen){
         for(tileset in tileSets) tileSetArray.add(tileset)
         tileSetSelectBox.items = tileSetArray
         tileSetSelectBox.selected = UncivGame.Current.settings.tileSet
-        innerTable.add(tileSetSelectBox).pad(10f).row()
+        innerTable.add(tileSetSelectBox).minWidth(240f).pad(10f).row()
 
         tileSetSelectBox.addListener(object : ChangeListener() {
             override fun changed(event: ChangeEvent?, actor: Actor?) {
@@ -328,7 +328,7 @@ class WorldScreenOptionsPopup(val worldScreen:WorldScreen) : Popup(worldScreen){
         languageSelectBox.items = languageArray
         val matchingLanguage = languageArray.firstOrNull { it.language == UncivGame.Current.settings.language }
         languageSelectBox.selected = if (matchingLanguage != null) matchingLanguage else languageArray.first()
-        innerTable.add(languageSelectBox).pad(10f).row()
+        innerTable.add(languageSelectBox).minWidth(240f).pad(10f).row()
 
         languageSelectBox.addListener(object : ChangeListener() {
             override fun changed(event: ChangeEvent?, actor: Actor?) {


### PR DESCRIPTION
It has passed already a month since @r3versi has introduced this cool improvement.
I believe it works quite well and is not experimental anymore.
This PR makes it turned off by default now.
Also, there is a minor improvement on UI:
**BEFORE:**
![Screenshot 2020-02-23 12 53 41](https://user-images.githubusercontent.com/27405436/75110972-64103900-563d-11ea-9cd8-36a7c961600e.png) 
**AFTER:**
![Screenshot 2020-02-23 13 05 12](https://user-images.githubusercontent.com/27405436/75110977-683c5680-563d-11ea-9b48-fa8fd9d9e3eb.png)

