### PR TITLE
Include Nations in the calculation of a translation`s percentage

### DIFF
--- a/core/src/com/unciv/models/translations/Translations.kt
+++ b/core/src/com/unciv/models/translations/Translations.kt
@@ -147,7 +147,7 @@ class Translations : LinkedHashMap<String, TranslationEntry>(){
         return percentComplete
     }
 
-    private fun calculatePercentageForNationsFile(language: String, notTranslatedNations: Array<Nation>): Pair<Int, Int> {
+    private fun calculatePercentageForNationsFile(language: String, originalNations: Array<Nation>): Pair<Int, Int> {
 
         val translationFileName = "jsons/Nations/Nations_$language.json"
         val translationFile = Gdx.files.internal(translationFileName)
@@ -155,7 +155,7 @@ class Translations : LinkedHashMap<String, TranslationEntry>(){
             // calculate how many fields are missing
             val allTranslatables = Nation::class.java.declaredFields.count {
                 it.type == String::class.java || it.type == ArrayList::class.java}
-            return Pair(0, allTranslatables*notTranslatedNations.size)
+            return Pair(0, allTranslatables*originalNations.size)
         }
 
         var translationsOfThisLanguage = 0
@@ -163,7 +163,7 @@ class Translations : LinkedHashMap<String, TranslationEntry>(){
 
         val translatedNations = JsonParser().getFromJson(emptyArray<Nation>().javaClass, translationFileName)
 
-        for (nation in notTranslatedNations)
+        for (nation in originalNations)
         {
             val translatedNation = translatedNations.find { it.name == nation.name }
 

--- a/core/src/com/unciv/models/translations/Translations.kt
+++ b/core/src/com/unciv/models/translations/Translations.kt
@@ -170,9 +170,12 @@ class Translations : LinkedHashMap<String, TranslationEntry>(){
             for (field in nation.javaClass.declaredFields.
                     filter { it.type == String::class.java || it.type == ArrayList::class.java}) {
                 field.isAccessible = true
+                val originalValue = field.get(nation)
                 if (translatedNation != null && // we could exit *before* this loop, however, we need it here to count not translated fields
                         (field.name in setOf("name", "startBias") || // skip fields which must not be translated
-                        field.get(nation) != field.get(translatedNation)))
+                        originalValue == null || originalValue == "" ||
+                        ((originalValue is ArrayList<*>) && originalValue.isEmpty()) ||
+                        originalValue != field.get(translatedNation)))
                     translationsOfThisLanguage++
 
                 allTranslations++


### PR DESCRIPTION
Currently the calculation of the translations percentage includes only `language.properties`.
So the percentage can be 100% while a lot of text in the game from Nations_language.json is not translated. This PR fixes that.