### PR TITLE
Revert close buttons + usability improvement

### DIFF
--- a/core/src/com/unciv/ui/EmpireOverviewScreen.kt
+++ b/core/src/com/unciv/ui/EmpireOverviewScreen.kt
@@ -1,4 +1,4 @@
-package com.unciv.ui
+﻿package com.unciv.ui
 
 import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.scenes.scene2d.Actor
@@ -26,8 +26,7 @@ class EmpireOverviewScreen(private val viewingPlayer:CivilizationInfo) : CameraS
     init {
         onBackButtonClicked { UncivGame.Current.setWorldScreen() }
 
-        val closeButton = "×".toLabel(Color.BLACK, 30).apply { this.setAlignment(Align.center) }
-                .surroundWithCircle(50f).apply { circle.color = Color.RED.cpy().lerp(Color.BLACK, 0.1f) }
+        val closeButton = TextButton("Close".tr(), skin)
         closeButton.onClick { UncivGame.Current.setWorldScreen() }
         closeButton.y = stage.height - closeButton.height - 5
         topTable.add(closeButton)

--- a/core/src/com/unciv/ui/EmpireOverviewScreen.kt
+++ b/core/src/com/unciv/ui/EmpireOverviewScreen.kt
@@ -3,6 +3,7 @@
 import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.scenes.scene2d.Actor
 import com.badlogic.gdx.scenes.scene2d.Group
+import com.badlogic.gdx.scenes.scene2d.Touchable
 import com.badlogic.gdx.scenes.scene2d.ui.*
 import com.badlogic.gdx.utils.Align
 import com.unciv.UncivGame
@@ -382,6 +383,7 @@ class EmpireOverviewScreen(private val viewingPlayer:CivilizationInfo) : CameraS
             val vector = HexMath.getVectorForAngle(2 * Math.PI.toFloat() *i / relevantCivs.size)
             civGroup.center(group)
             civGroup.moveBy(vector.x*freeWidth/2.5f, vector.y*freeHeight/2.5f)
+            civGroup.touchable = Touchable.enabled
             civGroup.onClick {
                 onCivClicked(civLines, civ.civName)
             }

--- a/core/src/com/unciv/ui/trade/DiplomacyScreen.kt
+++ b/core/src/com/unciv/ui/trade/DiplomacyScreen.kt
@@ -5,7 +5,6 @@ import com.badlogic.gdx.scenes.scene2d.ui.ScrollPane
 import com.badlogic.gdx.scenes.scene2d.ui.SplitPane
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton
-import com.badlogic.gdx.utils.Align
 import com.unciv.Constants
 import com.unciv.UncivGame
 import com.unciv.logic.civilization.AlertType
@@ -42,9 +41,11 @@ class DiplomacyScreen(val viewingCiv:CivilizationInfo):CameraStageBaseScreen() {
         stage.addActor(splitPane)
 
 
-        val closeButton = "×".toLabel(Color.BLACK,24).apply { this.setAlignment(Align.center) }
-                .surroundWithCircle(24f).apply { circle.color=Color.RED }
+        val closeButton = TextButton("Close".tr(), skin)
         closeButton.onClick { UncivGame.Current.setWorldScreen() }
+        closeButton.label.setFontSize(24)
+        closeButton.labelCell.pad(10f)
+        closeButton.pack()
         closeButton.y = stage.height - closeButton.height - 10
         closeButton.x = 10f
         stage.addActor(closeButton) // This must come after the split pane so it will be above, that the button will be clickable


### PR DESCRIPTION
While the changes to specialists allocation from #2069 are good, the changes to the close buttons contradict to the design rules: they are not aligned with other buttons, the red color distracts from the main form, as the most clickable button it's too small. Thus I decided to revert that change.
| Current | Reverted |
---------|-----------
| <img src="https://user-images.githubusercontent.com/27405436/75851129-8c442880-5df1-11ea-8cdd-0babf1b6ff46.png" width="300" /> | <img src="https://user-images.githubusercontent.com/27405436/75851363-24421200-5df2-11ea-91bf-2b11882a4f63.png" width="300" /> |
| <img src="https://user-images.githubusercontent.com/27405436/75851127-8bab9200-5df1-11ea-9521-ef17ae8bd3ba.png" width="300" /> | <img src="https://user-images.githubusercontent.com/27405436/75851362-23a97b80-5df2-11ea-83d8-e2890566efdb.png" width="300" /> |