### PR TITLE
ResponsePopup Fix

### DIFF
--- a/core/src/com/unciv/ui/utils/ResponsePopup.kt
+++ b/core/src/com/unciv/ui/utils/ResponsePopup.kt
@@ -5,16 +5,25 @@ import kotlin.concurrent.thread
 //Its a popUp which will close itself after a given amount of time
 //Standard time is one second (in milliseconds)
 class ResponsePopup (message: String, screen: CameraStageBaseScreen, time: Long = 1000) : Popup(screen){
+    private val visibilityTime = time
     init {
+        addGoodSizedLabel(message)
+        open()
+        //move it to the top so its not in the middle of the screen
+        //have to be done after open() because open() centers the popup
+        y = screen.stage.height - (height + padTop)
+    }
+
+    private fun startTimer(){
         thread (name = "ResponsePopup") {
-            val responsePopup = Popup(screen)
-            responsePopup.addGoodSizedLabel(message)
-            responsePopup.open()
-            //move it to the top so its not in the middle of the screen
-            //have to be done after open() because open() centers the popup
-            responsePopup.y = screen.stage.height - (responsePopup.height + responsePopup.padTop)
-            Thread.sleep(time)
-            responsePopup.close()
+            Thread.sleep(visibilityTime)
+            this.close()
         }
+    }
+
+    override fun setVisible(visible: Boolean) {
+        if (visible)
+            startTimer()
+        super.setVisible(visible)
     }
 }


### PR DESCRIPTION
ResponsePopup is now working as intended.
Its timer no longer starts when popup has not been shown yet.