### PR TITLE
Adding Multiplayer ID:Filename Cache

### DIFF
--- a/core/src/com/unciv/logic/GameSaver.kt
+++ b/core/src/com/unciv/logic/GameSaver.kt
@@ -29,7 +29,10 @@ class GameSaver {
     }
 
     fun saveGame(game: GameInfo, GameName: String, multiplayer: Boolean = false) {
-        json().toJson(game,getSave(GameName, multiplayer))
+        var name = GameName
+        if (multiplayer)
+            name = addGame(game.gameId, name)
+        json().toJson(game,getSave(name, multiplayer))
     }
 
     fun loadGameByName(GameName: String, multiplayer: Boolean = false) : GameInfo {
@@ -46,6 +49,16 @@ class GameSaver {
 
     fun deleteSave(GameName: String, multiplayer: Boolean = false){
         getSave(GameName, multiplayer).delete()
+        if (multiplayer)
+            removeGameFromListByValue(GameName)
+    }
+
+    fun deleteMultplayerGameById(gameId: String){
+        val fileName = multiplayerGameList[gameId]
+        if (fileName != null) {
+            getSave(fileName, true).delete()
+            removeGameFromList(gameId)
+        }
     }
 
     fun getGeneralSettingsFile(): FileHandle {
@@ -105,6 +118,97 @@ class GameSaver {
     fun currentTurnCivFromString(gameData: String): CivilizationInfo {
         val game = json().fromJson(GameInfo::class.java, gameData)
         return game.getCivilization(game.currentPlayer)
+    }
+  
+    //The file manager allows easy access to the gameID and the name of its corresponding file for every saved multiplayer game
+    companion object MultiplayerFileManager{
+
+        private var multiplayerGameList = mutableMapOf<String, String>()
+
+        init {
+            loadAllGamesIntoList()
+        }
+
+        fun gameIsAlreadySavedAsMultiplayer(gameId: String) : Boolean{
+            return multiplayerGameList.containsKey(gameId)
+        }
+
+        //returns a read only map
+        fun getMutliplayerGameList(): Map<String, String>{
+            return multiplayerGameList.toMap()
+        }
+
+        //adds the given game to the file manager and returns the new filename in case the given name was already taken
+        private fun addGame(gameId: String, gameName: String): String{
+            val oldFileName = multiplayerGameList[gameId]
+            var newFileName = gameName
+            //There is already a game saved with this ID and the filename got not changed so no need to change anything
+            if (oldFileName == gameName)
+                return gameName
+
+            val count = getNumberForUsedGameName(gameName)
+            //Check if there is already a game saved with this name
+            if (count != 0)
+                newFileName = "$newFileName($count)"
+
+            //Delete old save file since we will created a new file
+            if (oldFileName != null)
+                GameSaver().getSave(oldFileName, true).delete()
+
+            multiplayerGameList[gameId] = newFileName
+
+            return newFileName
+        }
+
+        //returns the first unused number for a already used fileName
+        private fun getNumberForUsedGameName(gameFileName: String): Int{
+            val gameNames = multiplayerGameList.values
+            //name is not used
+            if (!gameNames.contains(gameFileName))
+                return 0
+
+            //test for all games with a name like "[gamename]([count])"
+            var count = 1
+            while (gameNames.contains("$gameFileName($count)")){
+                count++
+            }
+            return count
+        }
+
+        private fun removeGameFromList(gameId: String){
+            multiplayerGameList.remove(gameId)
+        }
+
+        private fun removeGameFromListByValue(gameFileName: String){
+            //This should always have just one entry because files can't have the same name
+            val keySet = multiplayerGameList.filterValues { it == gameFileName }.keys
+            //if its > 1 something crazy happened so we better don't delete anything
+            //if its < 1 then there was a SaveFile without list entry. This happens when File got renamed
+            if (keySet.size != 1)
+                return
+            multiplayerGameList.remove(keySet.elementAt(0))
+        }
+
+        private fun loadAllGamesIntoList(){
+            val gameFileNames : List<String>?
+
+            multiplayerGameList.clear()
+
+            try {
+                gameFileNames = GameSaver().getSaves(true)
+            }catch (ex: Exception) {
+                return
+            }
+
+            for (gameFileName in gameFileNames){
+                try {
+                    val game = GameSaver().loadGameByName(gameFileName, true)
+                    multiplayerGameList[game.gameId] = gameFileName
+                }catch (ex: Exception){
+                    continue
+                }
+            }
+        }    
     }
 }
 

--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -159,7 +159,12 @@ object RulesetCache :HashMap<String,Ruleset>(){
         }
     }
 
-    fun getBaseRuleset() = this[""]!!
+    //Do a null check in case loadRulesets() wasn't called before getBaseRuleset(). We can't rely on that.
+    fun getBaseRuleset(): Ruleset{
+        if (this[""] == null)
+            this[""] = Ruleset().apply { load(Gdx.files.internal("jsons")) }
+        return this[""]!!
+    }
 
     fun getComplexRuleset(mods:Collection<String>): Ruleset {
         val newRuleset = Ruleset()


### PR DESCRIPTION
I introduced it to remove the caching from the UI class because I will need the caching information on the TurnChecker start later.
Also, I don't think having caching logic inside a UI class is a clever thing to do.

All the UX improvements from my previous PR aren't included in this PR