### PR TITLE
Fix/city buy sell exploits

### DIFF
--- a/core/src/com/unciv/ui/cityscreen/CityInfoTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityInfoTable.kt
@@ -90,12 +90,18 @@ class CityInfoTable(private val cityScreen: CityScreen) : Table(CameraStageBaseS
                     wonderDetailsTable.add(sellBuildingButton).pad(5f).row()
 
                     sellBuildingButton.onClick {
+                        sellBuildingButton.disable()
+                        cityScreen.closeAllPopups()
+
                         YesNoPopup("Are you sure you want to sell this [${building.name}]?".tr(),
                                 {
                                     cityScreen.city.sellBuilding(building.name)
                                     cityScreen.city.cityStats.update()
                                     cityScreen.update()
-                                }, cityScreen).open()
+                                }, cityScreen,
+                                {
+                                    cityScreen.update()
+                                }).open()
                     }
                     if (cityScreen.city.hasSoldBuildingThisTurn || cityScreen.city.isPuppet
                             || !UncivGame.Current.worldScreen.isPlayersTurn)

--- a/core/src/com/unciv/ui/cityscreen/ConstructionsTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/ConstructionsTable.kt
@@ -310,9 +310,12 @@ class ConstructionsTable(val cityScreen: CityScreen) : Table(CameraStageBaseScre
             button.add(ImageGetter.getStatIcon(Stat.Gold.name)).size(20f).padBottom(2f)
 
             button.onClick(UncivSound.Coin) {
+                button.disable()
+                cityScreen.closeAllPopups()
+
                 val purchasePrompt = "Currently you have [${city.civInfo.gold}] gold.".tr() + "\n\n" +
                         "Would you like to purchase [${construction.name}] for [$constructionGoldCost] gold?".tr()
-                YesNoPopup(purchasePrompt, { purchaseConstruction() }, cityScreen).open()
+                YesNoPopup(purchasePrompt, { purchaseConstruction() }, cityScreen, { cityScreen.update() }).open()
             }
 
             if (constructionGoldCost > city.civInfo.gold)

--- a/core/src/com/unciv/ui/cityscreen/ConstructionsTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/ConstructionsTable.kt
@@ -295,7 +295,7 @@ class ConstructionsTable(val cityScreen: CityScreen) : Table(CameraStageBaseScre
                     if (isSelectedQueueEntry()) {
                         // currentConstruction is removed from the queue by purchaseConstruction
                         // to avoid conflicts with NextTurnAutomation
-                        if (!isSelectedCurrentConstruction())
+                        if (!isSelectedCurrentConstruction() && cityConstructions.constructionQueue[selectedQueueEntry] == construction.name)
                             cityConstructions.removeFromQueue(selectedQueueEntry)
                         selectedQueueEntry = -2
                         cityScreen.selectedConstruction = null

--- a/core/src/com/unciv/ui/utils/Popup.kt
+++ b/core/src/com/unciv/ui/utils/Popup.kt
@@ -67,6 +67,7 @@ open class Popup(val screen: CameraStageBaseScreen): Table(CameraStageBaseScreen
 }
 
 fun CameraStageBaseScreen.hasOpenPopups(): Boolean = stage.actors.any { it is Popup && it.isVisible }
+fun CameraStageBaseScreen.closeAllPopups() { for (popup in popups) popup.close() }
 
 val CameraStageBaseScreen.popups: List<Popup>
     get() = stage.actors.filterIsInstance<Popup>()


### PR DESCRIPTION
**Bugfixes**

- Clicking multiple times on **Buy/Sell** in `CityScreen` no longer let you buy/sell more than one construction
- Construction no longer removed from queue if it doesn't correspond to the one being bought