### PR TITLE
Add 2 map parameters; One for ruins, and one for strategic resources

### DIFF
--- a/core/src/com/unciv/logic/map/MapGenerator.kt
+++ b/core/src/com/unciv/logic/map/MapGenerator.kt
@@ -212,7 +212,7 @@ class MapGenerator(val ruleset: Ruleset) {
         if(map.mapParameters.noRuins)
             return
         val suitableTiles = map.values.filter { it.isLand && !it.getBaseTerrain().impassable }
-        val locations = chooseSpreadOutLocations(suitableTiles.size/100,
+        val locations = chooseSpreadOutLocations( (map.mapParameters.ruinsRichness.pow(2)).toInt() * suitableTiles.size/100,
                 suitableTiles, 10)
         for(tile in locations)
             tile.improvement = Constants.ancientRuins
@@ -488,7 +488,7 @@ class MapGenerator(val ruleset: Ruleset) {
     private fun spreadStrategicResources(mapToReturn: TileMap, distance: Int) {
         val resourcesOfType = ruleset.tileResources.values.filter { it.resourceType == ResourceType.Strategic }
         val totalNumberOfResources = mapToReturn.values.count { it.isLand && !it.getBaseTerrain().impassable } *
-                mapToReturn.mapParameters.resourceRichness
+                mapToReturn.mapParameters.strategicResourceRichness
         val resourcesPerType = (totalNumberOfResources/resourcesOfType.size).toInt()
         for (resource in resourcesOfType) {
             val suitableTiles = mapToReturn.values

--- a/core/src/com/unciv/logic/map/MapParameters.kt
+++ b/core/src/com/unciv/logic/map/MapParameters.kt
@@ -43,6 +43,8 @@ class MapParameters {
     var temperatureExtremeness = 0.30f
     var terrainFeatureRichness = 0.30f
     var resourceRichness = 0.10f
+    var strategicResourceRichness = 0.10f
+    var ruinsRichness = 1f
     var waterProbability = 0.05f
     var landProbability = 0.55f
 
@@ -53,6 +55,8 @@ class MapParameters {
         temperatureExtremeness = 0.30f
         terrainFeatureRichness = 0.30f
         resourceRichness = 0.10f
+        strategicResourceRichness = 0.10f
+        ruinsRichness = 1f
         waterProbability = 0.05f
         landProbability = 0.55f
     }

--- a/core/src/com/unciv/ui/newgamescreen/MapParametersTable.kt
+++ b/core/src/com/unciv/ui/newgamescreen/MapParametersTable.kt
@@ -177,6 +177,17 @@ class MapParametersTable(val mapParameters: MapParameters, val isEmptyMapAllowed
         advancedSettingsTable.add("Resource richness".toLabel()).left()
         advancedSettingsTable.add(resourceRichnessSlider).fillX().row()
 
+        val strategicResourceRichnessSlider = Slider(0f,0.2f,0.01f, false, skin).apply {
+            addListener(object : ChangeListener() {
+                override fun changed(event: ChangeEvent?, actor: Actor?) {
+                    mapParameters.strategicResourceRichness = this@apply.value
+                }
+            })
+        }
+        strategicResourceRichnessSlider.value = mapParameters.strategicResourceRichness
+        advancedSettingsTable.add("Strategic Resource richness".toLabel()).left()
+        advancedSettingsTable.add(strategicResourceRichnessSlider).fillX().row()
+
 
         val terrainFeatureRichnessSlider = Slider(0f,1f,0.01f, false, skin).apply {
             addListener(object : ChangeListener() {
@@ -188,6 +199,18 @@ class MapParametersTable(val mapParameters: MapParameters, val isEmptyMapAllowed
         terrainFeatureRichnessSlider.value = mapParameters.terrainFeatureRichness
         advancedSettingsTable.add("Terrain Features richness".toLabel()).left()
         advancedSettingsTable.add(terrainFeatureRichnessSlider).fillX().row()
+
+
+        val ruinsRichnessSlider = Slider(0f,10f,1f, false, skin).apply {
+            addListener(object : ChangeListener() {
+                override fun changed(event: ChangeEvent?, actor: Actor?) {
+                    mapParameters.ruinsRichness = this@apply.value
+                }
+            })
+        }
+        ruinsRichnessSlider.value = mapParameters.ruinsRichness
+        advancedSettingsTable.add("Ancient Ruin density".toLabel()).left()
+        advancedSettingsTable.add(ruinsRichnessSlider).fillX().row()
 
 
         val maxCoastExtensionSlider = Slider(0f,5f,1f, false, skin).apply {
@@ -243,7 +266,9 @@ class MapParametersTable(val mapParameters: MapParameters, val isEmptyMapAllowed
             averageHeightSlider.value = mapParameters.mountainProbability
             tempExtremeSlider.value = mapParameters.temperatureExtremeness
             resourceRichnessSlider.value = mapParameters.resourceRichness
+            strategicResourceRichnessSlider.value = mapParameters.strategicResourceRichness
             terrainFeatureRichnessSlider.value = mapParameters.terrainFeatureRichness
+            ruinsRichnessSlider.value = mapParameters.ruinsRichness
             maxCoastExtensionSlider.value = mapParameters.maxCoastExtension.toFloat()
             tilesPerBiomeAreaSlider.value = mapParameters.tilesPerBiomeArea.toFloat()
             waterPercentSlider.value = mapParameters.waterProbability


### PR DESCRIPTION
This adds two parameters and their corresponding sliders. 

The first affects the density of ancient ruins. The default setting is a relative density of one, and 11 slider values allow this value to be any square number from 0 to 100.

The second is designed to separate the two types of resources into strategic and non-strategic. This allows for more tweaking of the map generation, as some players will want to control each type of resource individually. Each one uses the same scaling.

Here are some images:
Default values 
![image](https://user-images.githubusercontent.com/38208100/76162447-297ac600-613e-11ea-99f1-5aeba3700a37.png)

An example map generated with non-default values
![image](https://user-images.githubusercontent.com/38208100/76162427-0819da00-613e-11ea-8775-a9fa716b89f5.png)