### PR TITLE
Stage I of new Player- and Game-ID format

### DIFF
--- a/core/src/com/unciv/ui/MultiplayerScreen.kt
+++ b/core/src/com/unciv/ui/MultiplayerScreen.kt
@@ -3,9 +3,10 @@ package com.unciv.ui
 import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.scenes.scene2d.ui.*
-import com.unciv.logic.GameSaver
-import com.unciv.logic.GameInfo
 import com.unciv.UncivGame
+import com.unciv.logic.GameInfo
+import com.unciv.logic.GameSaver
+import com.unciv.logic.IdChecker
 import com.unciv.models.translations.tr
 import com.unciv.ui.pickerscreens.PickerScreen
 import com.unciv.ui.utils.*
@@ -115,7 +116,7 @@ class MultiplayerScreen() : PickerScreen() {
     fun addMultiplayerGame(gameId: String?, gameName: String = ""){
         try {
             //since the gameId is a String it can contain anything and has to be checked
-            UUID.fromString(gameId!!.trim())
+            UUID.fromString(IdChecker.checkAndReturnGameUuid(gameId!!))
         } catch (ex: Exception) {
             val errorPopup = Popup(this)
             errorPopup.addGoodSizedLabel("Invalid game ID!".tr())

--- a/core/src/com/unciv/ui/newgamescreen/NewGameScreen.kt
+++ b/core/src/com/unciv/ui/newgamescreen/NewGameScreen.kt
@@ -9,6 +9,7 @@ import com.unciv.UncivGame
 import com.unciv.logic.GameInfo
 import com.unciv.logic.GameSaver
 import com.unciv.logic.GameStarter
+import com.unciv.logic.IdChecker
 import com.unciv.logic.civilization.PlayerType
 import com.unciv.models.ruleset.RulesetCache
 import com.unciv.models.translations.tr
@@ -49,7 +50,7 @@ class NewGameScreen: PickerScreen(){
             if (newGameParameters.isOnlineMultiplayer) {
                 for (player in newGameParameters.players.filter { it.playerType == PlayerType.Human }) {
                     try {
-                        UUID.fromString(player.playerId)
+                        UUID.fromString(IdChecker.checkAndReturnPlayerUuid(player.playerId))
                     } catch (ex: Exception) {
                         val invalidPlayerIdPopup = Popup(this)
                         invalidPlayerIdPopup.addGoodSizedLabel("Invalid player ID!".tr()).row()

--- a/core/src/com/unciv/ui/newgamescreen/PlayerPickerTable.kt
+++ b/core/src/com/unciv/ui/newgamescreen/PlayerPickerTable.kt
@@ -9,13 +9,13 @@ import com.badlogic.gdx.scenes.scene2d.ui.TextButton
 import com.badlogic.gdx.scenes.scene2d.ui.TextField
 import com.badlogic.gdx.utils.Align
 import com.unciv.UncivGame
+import com.unciv.logic.IdChecker
 import com.unciv.logic.civilization.PlayerType
 import com.unciv.models.metadata.GameParameters
 import com.unciv.models.metadata.Player
 import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.translations.tr
 import com.unciv.ui.utils.*
-import com.unciv.ui.utils.Popup
 import java.util.*
 
 class PlayerPickerTable(val newGameScreen: NewGameScreen, val newGameParameters: GameParameters): Table() {
@@ -72,8 +72,8 @@ class PlayerPickerTable(val newGameScreen: NewGameScreen, val newGameParameters:
 
             fun onPlayerIdTextUpdated(){
                 try {
-                    val uuid = UUID.fromString(playerIdTextfield.text)
-                    player.playerId = playerIdTextfield.text
+                    UUID.fromString(IdChecker.checkAndReturnPlayerUuid(playerIdTextfield.text))
+                    player.playerId = playerIdTextfield.text.trim()
                     errorLabel.apply { setText("✔");setFontColor(Color.GREEN) }
                 } catch (ex: Exception) {
                     errorLabel.apply { setText("✘");setFontColor(Color.RED) }

--- a/core/src/com/unciv/ui/worldscreen/mainmenu/WorldScreenMenuPopup.kt
+++ b/core/src/com/unciv/ui/worldscreen/mainmenu/WorldScreenMenuPopup.kt
@@ -3,9 +3,9 @@ package com.unciv.ui.worldscreen.mainmenu
 import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.graphics.Color
 import com.unciv.UncivGame
+import com.unciv.logic.IdChecker
 import com.unciv.models.translations.tr
 import com.unciv.ui.CivilopediaScreen
-import com.unciv.ui.victoryscreen.VictoryScreen
 import com.unciv.ui.MultiplayerScreen
 import com.unciv.ui.mapeditor.LoadMapScreen
 import com.unciv.ui.mapeditor.NewMapScreen
@@ -13,6 +13,7 @@ import com.unciv.ui.newgamescreen.NewGameScreen
 import com.unciv.ui.saves.LoadGameScreen
 import com.unciv.ui.saves.SaveGameScreen
 import com.unciv.ui.utils.*
+import com.unciv.ui.victoryscreen.VictoryScreen
 import com.unciv.ui.worldscreen.WorldScreen
 import java.util.*
 import kotlin.concurrent.thread
@@ -105,7 +106,7 @@ class WorldScreenMenuPopup(val worldScreen: WorldScreen) : Popup(worldScreen) {
         multiplayerPopup.addButton("Join Game") {
             val gameId = Gdx.app.clipboard.contents
             try {
-                UUID.fromString(gameId.trim())
+                UUID.fromString(IdChecker.checkAndReturnGameUuid(gameId))
             } catch (ex: Exception) {
                 badGameIdLabel.setText("Invalid game ID!")
                 badGameIdLabel.isVisible = true

--- a/tests/src/com/unciv/testing/IdHelperTests.kt
+++ b/tests/src/com/unciv/testing/IdHelperTests.kt
@@ -1,0 +1,76 @@
+package com.unciv.testing
+
+import com.unciv.logic.IdChecker
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(GdxTestRunner::class)
+class IdHelperTests {
+    @Test
+    fun testCheckDigits() {
+        val correctString = "2ddb3a34-0699-4126-b7a5-38603e665928"
+        val inCorrectString1 = "2ddb3a34-0699-4126-b7a5-38603e665929"
+        val inCorrectString2 = "2ddb3a34-0969-4126-b7a5-38603e665928"
+        val inCorrectString3 = "2ddb3a34-0699-4126-b7a"
+        val inCorrectString4 = "0699-4126-b7a5-38603e665928-2ddb3a34"
+
+        val correctLuhn = IdChecker.getCheckDigit(correctString)
+        val correctLuhn2 = IdChecker.getCheckDigit(correctString)
+        val inCorrectLuhn1 = IdChecker.getCheckDigit(inCorrectString1)
+        val inCorrectLuhn2 = IdChecker.getCheckDigit(inCorrectString2)
+        val inCorrectLuhn3 = IdChecker.getCheckDigit(inCorrectString3)
+        val inCorrectLuhn4 = IdChecker.getCheckDigit(inCorrectString4)
+
+        Assert.assertEquals(correctLuhn, correctLuhn2)
+        Assert.assertNotEquals(inCorrectLuhn1, correctLuhn)
+        Assert.assertNotEquals(inCorrectLuhn2, correctLuhn)
+        Assert.assertNotEquals(inCorrectLuhn3, correctLuhn)
+        Assert.assertNotEquals(inCorrectLuhn4, correctLuhn)
+
+        Assert.assertNotEquals(inCorrectLuhn1, inCorrectLuhn2)
+        Assert.assertNotEquals(inCorrectLuhn1, inCorrectLuhn3)
+        Assert.assertNotEquals(inCorrectLuhn1, inCorrectLuhn4)
+
+        Assert.assertNotEquals(inCorrectLuhn2, inCorrectLuhn3)
+        Assert.assertNotEquals(inCorrectLuhn2, inCorrectLuhn4)
+
+        Assert.assertNotEquals(inCorrectLuhn3, inCorrectLuhn4)
+    }
+
+    @Test
+    fun testIdsSuccess()  {
+        val correctString = "2ddb3a34-0699-4126-b7a5-38603e665928"
+
+        Assert.assertEquals(correctString, IdChecker.checkAndReturnPlayerUuid(correctString))
+        Assert.assertEquals("c872b8e0-f274-47d4-b761-ce684c5d224c", IdChecker.checkAndReturnGameUuid("c872b8e0-f274-47d4-b761-ce684c5d224c"))
+
+        Assert.assertEquals(correctString, IdChecker.checkAndReturnGameUuid("G-" + correctString + "-2"))
+        Assert.assertEquals(correctString, IdChecker.checkAndReturnPlayerUuid("P-" + correctString + "-2"))
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testIdFailure1() {
+        IdChecker.checkAndReturnGameUuid("2ddb3a34-0699-4126-b7a5-38603e66592") // too short
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testIdFailure2() {
+        IdChecker.checkAndReturnGameUuid("P-2ddb3a34-0699-4126-b7a5-38603e665928-2") // wrong prefix
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testIdFailure3() {
+        IdChecker.checkAndReturnPlayerUuid("G-2ddb3a34-0699-4126-b7a5-38603e665928-2") // wrong prefix
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testIdFailure4() {
+        IdChecker.checkAndReturnGameUuid("G-2ddb3a34-0699-4126-b7a5-38603e665928-3") // changed checkDigit
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testIdFailure5() {
+        IdChecker.checkAndReturnGameUuid("G-2ddb3a34-0699-4126-b7a5-48603e665928-2") // changed uuid without changing checkdigit
+    }
+}


### PR DESCRIPTION
At the moment, it's easy to make the mistake of using a Player ID in a place requiring the Game ID, as well as the other way around. Especially since we are working with non-human-readable clipboard values. Also transcription errors can't be detected when retyping IDs by hand.

Therefore I propose a new format:
G-UUID-CheckDigit for Game IDs
P-UUID-CheckDigit for Player IDs

The new ID format cannot be rolled out before all clients are compatible. Therefore I divided the change into two stages:

Stage I: Passively add compatibility for new format. New IDs still follow old pattern. This prepares Unciv clients for Stage II.
Stage II: All new IDs use new format. Stage II will be merged in the future when Stage I has propagated to all users.

