### PR TITLE
Display an amount of gold when buying the tile

### DIFF
--- a/android/assets/jsons/translations/Russian.properties
+++ b/android/assets/jsons/translations/Russian.properties
@@ -837,6 +837,7 @@ Raze city = Разрушить город
 Stop razing city = Отменить разрушение города
 Buy for [amount] gold = Купить за [amount] золота
 Buy = Купить
+You have [amount] gold = У вас есть [amount] золота
 Currently you have [amount] gold. = Сейчас у вас есть [amount] золота.
 Would you like to purchase [constructionName] for [buildingGoldCost] gold? = Хотите купить [constructionName] за [buildingGoldCost] золота?
 No space available to place [unit] near [city] = Возле [city] нет места, чтобы разместить [unit]

--- a/android/assets/jsons/translations/Ukrainian.properties
+++ b/android/assets/jsons/translations/Ukrainian.properties
@@ -817,6 +817,7 @@ Raze city = Зруйнувати місто
 Stop razing city = Зупинити руйнування міста
 Buy for [amount] gold = Купити за [amount] золота
 Buy = Купити
+You have [amount] gold = У вас є [amount] золота
 Currently you have [amount] gold. = Зараз у вас в наявності [amount] золота.
 Would you like to purchase [constructionName] for [buildingGoldCost] gold? = Бажаєте придбати [constructionName] за [buildingGoldCost] золота?
 No space available to place [unit] near [city] = Біля [city] немає місця, щоб розмістити [unit]

--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -813,6 +813,7 @@ Raze city =
 Stop razing city = 
 Buy for [amount] gold = 
 Buy = 
+You have [amount] gold = 
 Currently you have [amount] gold. = 
 Would you like to purchase [constructionName] for [buildingGoldCost] gold? = 
 No space available to place [unit] near [city] = 

--- a/core/src/com/unciv/ui/cityscreen/CityScreenTileTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityScreenTileTable.kt
@@ -49,7 +49,8 @@ class CityScreenTileTable(val city: CityInfo): Table(){
             if(goldCostOfTile>city.civInfo.gold || city.isPuppet || !UncivGame.Current.worldScreen.isPlayersTurn)
                 buyTileButton.disable()
 
-            innerTable.add(buyTileButton)
+            innerTable.add(buyTileButton).row()
+            innerTable.add("You have [${city.civInfo.gold}] gold".toLabel(Color.YELLOW, 16)).padTop(2f)
         }
         if(city.canAcquireTile(selectedTile)) {
             val acquireTileButton = TextButton("Acquire".tr(), CameraStageBaseScreen.skin)


### PR DESCRIPTION
Resolves #2072 

| Before | After
| --------|-------
| ![ScreenBefore](https://user-images.githubusercontent.com/8366208/76152068-11666080-60c4-11ea-95c6-a8e037389374.png) | ![Screenshot 2020-03-12 00 20 17](https://user-images.githubusercontent.com/27405436/76470041-535f1180-63f8-11ea-89be-f687e5a0ecc5.png)

The hint is displayed only together with the "buy" button.