### PR TITLE
Energy saving: music and sounds

### DIFF
--- a/core/src/com/unciv/UncivGame.kt
+++ b/core/src/com/unciv/UncivGame.kt
@@ -96,7 +96,7 @@ class UncivGame(
             Gdx.app.postRunnable {
                 CameraStageBaseScreen.resetFonts()
                 autoLoadGame()
-                thread { startMusic() }
+                thread(name="Music") { startMusic() }
                 isInitialized = true
             }
         }
@@ -114,6 +114,7 @@ class UncivGame(
     }
 
     fun startMusic() {
+        if (settings.musicVolume < 0.01) return
 
         val musicFile = Gdx.files.local(musicLocation)
         if (musicFile.exists()) {

--- a/core/src/com/unciv/ui/utils/Sounds.kt
+++ b/core/src/com/unciv/ui/utils/Sounds.kt
@@ -16,7 +16,8 @@ object Sounds {
     }
 
     fun play(sound: UncivSound) {
-        if (sound == UncivSound.Silent) return
-        get(sound).play(UncivGame.Current.settings.soundEffectsVolume)
+        val volume = UncivGame.Current.settings.soundEffectsVolume
+        if (sound == UncivSound.Silent || volume < 0.01) return
+        get(sound).play(volume)
     }
 }

--- a/core/src/com/unciv/ui/worldscreen/mainmenu/WorldScreenOptionsPopup.kt
+++ b/core/src/com/unciv/ui/worldscreen/mainmenu/WorldScreenOptionsPopup.kt
@@ -201,7 +201,12 @@ class WorldScreenOptionsPopup(val worldScreen:WorldScreen) : Popup(worldScreen){
                 override fun changed(event: ChangeEvent?, actor: Actor?) {
                     UncivGame.Current.settings.musicVolume = musicVolumeSlider.value
                     UncivGame.Current.settings.save()
-                    UncivGame.Current.music?.volume = 0.4f * musicVolumeSlider.value
+
+                    val music = UncivGame.Current.music
+                    if (music == null) // restart music, if it was off at the app start
+                        thread(name="Music") { UncivGame.Current.startMusic() }
+
+                    music?.volume = 0.4f * musicVolumeSlider.value
                 }
             })
             innerTable.add(musicVolumeSlider).pad(10f).row()


### PR DESCRIPTION
Currently there is a thread which is always running in background and trying to play the music even if the volume is set to 0.
The same about the sounds, each(!) click triggers the access to the file system, getting the sound file and playing it - [quite expensive, yeah?] and all that happens even with the sound volume = 0.

That's a total waste of hardware resources with no benefits to the user !!!

This PR does the checks for volume parameters and does not trigger all that hell, if there is no need for that.