### PR TITLE
Double range of rebase for air units

### DIFF
--- a/core/src/com/unciv/logic/automation/SpecificUnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/SpecificUnitAutomation.kt
@@ -196,7 +196,7 @@ class SpecificUnitAutomation {
 
         // TODO Implement consideration for landing on aircraft carrier
 
-        val immediatelyReachableCities = tilesInRange
+        val immediatelyReachableCities = unit.currentTile.getTilesInDistance(unit.getRange()*2)
                 .filter { it.isCityCenter() && it.getOwner() == unit.civInfo && unit.movement.canMoveTo(it) }
 
         for (city in immediatelyReachableCities) {
@@ -212,7 +212,7 @@ class SpecificUnitAutomation {
 
         val citiesByNearbyAirUnits = pathsToCities.keys
                 .groupBy { key ->
-                    key.getTilesInDistance(unit.getRange())
+                    key.getTilesInDistance(unit.getRange()*2)
                             .count {
                                 val firstAirUnit = it.airUnits.firstOrNull()
                                 firstAirUnit != null && firstAirUnit.civInfo.isAtWarWith(unit.civInfo)
@@ -236,7 +236,7 @@ class SpecificUnitAutomation {
     fun automateBomber(unit: MapUnit) {
         if (battleHelper.tryAttackNearbyEnemy(unit)) return
 
-        val tilesInRange = unit.currentTile.getTilesInDistance(unit.getRange())
+        val tilesInRange = unit.currentTile.getTilesInDistance(unit.getRange()*2)
 
         // TODO Implement consideration for landing on aircraft carrier
 
@@ -276,7 +276,7 @@ class SpecificUnitAutomation {
     fun automateMissile(unit: MapUnit) {
         if (battleHelper.tryAttackNearbyEnemy(unit)) return
 
-        val tilesInRange = unit.currentTile.getTilesInDistance(unit.getRange())
+        val tilesInRange = unit.currentTile.getTilesInDistance(unit.getRange()*2)
 
         val immediatelyReachableCities = tilesInRange
                 .filter { it.isCityCenter() && it.getOwner() == unit.civInfo && unit.movement.canMoveTo(it) }

--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -545,13 +545,6 @@ class MapUnit {
         if (currentTile.getOwner() == civInfo)
             civInfo.gold += baseUnit.getDisbandGold()
         if (civInfo.isDefeated()) civInfo.destroy()
-        for (unit in currentTile.getUnits().filter { it.type.isAirUnit() && it.isTransported }) {
-            if (unit.movement.canMoveTo(currentTile)) continue // we disbanded a carrier in a city, it can still stay in the city
-            val tileCanMoveTo = unit.currentTile.getTilesInDistance(unit.getRange()*2)
-                    .firstOrNull { unit.movement.canMoveTo(it) }
-            if (tileCanMoveTo != null) unit.movement.moveToTile(tileCanMoveTo)
-            else unit.disband()
-        }
     }
 
     private fun getAncientRuinBonus(tile: TileInfo) {

--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -532,7 +532,7 @@ class MapUnit {
                 if (unit.currentMovement < 0.1)
                     unit.disband()
                 // let's find closest city or another carrier where it can be evacuated
-                val tileCanMoveTo = unit.currentTile.getTilesInDistance(unit.getRange()).
+                val tileCanMoveTo = unit.currentTile.getTilesInDistance(unit.getRange()*2).
                         filterNot { it == currentTile }.firstOrNull{unit.movement.canMoveTo(it)}
 
                 if (tileCanMoveTo!=null)
@@ -547,7 +547,7 @@ class MapUnit {
         if (civInfo.isDefeated()) civInfo.destroy()
         for (unit in currentTile.getUnits().filter { it.type.isAirUnit() && it.isTransported }) {
             if (unit.movement.canMoveTo(currentTile)) continue // we disbanded a carrier in a city, it can still stay in the city
-            val tileCanMoveTo = unit.currentTile.getTilesInDistance(unit.getRange())
+            val tileCanMoveTo = unit.currentTile.getTilesInDistance(unit.getRange()*2)
                     .firstOrNull { unit.movement.canMoveTo(it) }
             if (tileCanMoveTo != null) unit.movement.moveToTile(tileCanMoveTo)
             else unit.disband()

--- a/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
+++ b/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
@@ -184,7 +184,7 @@ class UnitMovementAlgorithms(val unit:MapUnit) {
 
     fun canReach(destination: TileInfo): Boolean {
         if (unit.type.isAirUnit())
-            return unit.currentTile.aerialDistanceTo(destination) <= unit.getRange()
+            return unit.currentTile.aerialDistanceTo(destination) <= unit.getRange()*2
         return getShortestPath(destination).any()
     }
 

--- a/core/src/com/unciv/ui/worldscreen/WorldMapHolder.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldMapHolder.kt
@@ -253,7 +253,7 @@ class WorldMapHolder(internal val worldScreen: WorldScreen, internal val tileMap
         val isAirUnit = unit.type.isAirUnit()
         val tilesInMoveRange =
                 if (isAirUnit)
-                    unit.getTile().getTilesInDistance(unit.getRange())
+                    unit.getTile().getTilesInDistance(unit.getRange()*2)
                 else
                     unit.movement.getDistanceToTiles().keys.asSequence()
 


### PR DESCRIPTION
Resolves #2144 according to https://www.carlsguides.com/strategy/civilization5/units/aircraft-nukes.php

1) There is a need to understand whether an air unit attacks or just moves - therefore, sometimes it needs double range and sometimes not.
I tried to find all places (could miss one?) where it is about movement, not attack, and added "x2" there. _"Beware of dragons!"_ Please, review this commit carefully.

2) Also, there is a small refactoring of automation to seek not only cities but also carriers for planes' and missiles' rebase.

3) Finally, clean up of never used code, all work is done a few lines before it.
Please, review this commit thoroughly as well, probably, I did misunderstand some the logic there.