### PR TITLE
Sorted list of the promotions' icons

### DIFF
--- a/core/src/com/unciv/ui/worldscreen/unit/UnitTable.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitTable.kt
@@ -167,7 +167,7 @@ class UnitTable(val worldScreen: WorldScreen) : Table(){
 
         if(selectedUnit!=null) {
             unitIconHolder.add(UnitGroup(selectedUnit!!,30f)).pad(5f)
-            for(promotion in selectedUnit!!.promotions.promotions)
+            for(promotion in selectedUnit!!.promotions.promotions.sorted())
                 promotionsTable.add(ImageGetter.getPromotionIcon(promotion))
 
             // Since Clear also clears the listeners, we need to re-add it every time


### PR DESCRIPTION
Resolves #2160 

Before:
![Screenshot 2020-03-16 08 08 44](https://user-images.githubusercontent.com/27405436/76728035-3ad75a00-675e-11ea-8540-85e97d57df0e.png)

After:
![Screenshot 2020-03-16 08 11 55](https://user-images.githubusercontent.com/27405436/76728048-4034a480-675e-11ea-8eb0-804708c4c3c6.png)
