### PR TITLE
Cities needlessly drop land units in water

### DIFF
--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -371,6 +371,7 @@ class MapUnit {
                         && tileImprovement.terrainsCanBeBuiltOn.contains(tile.terrainFeature)
                         && !tileImprovement.terrainsCanBeBuiltOn.contains(tile.baseTerrain)) {
                     tile.improvement = null // We removed a terrain (e.g. Forest) and the improvement (e.g. Lumber mill) requires it!
+                    if (tile.resource!=null) civInfo.updateDetailedCivResources()        // unlikely, but maybe a mod makes a resource improvement dependent on a terrain feature
                 }
                 if(tile.improvementInProgress=="Remove Road" || tile.improvementInProgress=="Remove Railroad")
                     tile.roadStatus = RoadStatus.None
@@ -378,7 +379,10 @@ class MapUnit {
             }
             tile.improvementInProgress == "Road" -> tile.roadStatus = RoadStatus.Road
             tile.improvementInProgress == "Railroad" -> tile.roadStatus = RoadStatus.Railroad
-            else -> tile.improvement = tile.improvementInProgress
+            else -> {
+                tile.improvement = tile.improvementInProgress
+                if (tile.resource!=null) civInfo.updateDetailedCivResources()
+            }
         }
         tile.improvementInProgress = null
     }

--- a/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
@@ -176,6 +176,7 @@ object UnitActions {
                         tile.turnsToImprovement = 2
                     }
                     tile.improvement = null
+                    if (tile.resource!=null) tile.getOwner()?.updateDetailedCivResources()    // this might take away a resource
                     if (!unit.hasUnique("No movement cost to pillage")) unit.useMovementPoints(1f)
                     unit.healBy(25)
                 }.takeIf { unit.currentMovement > 0 && canPillage(unit, tile) })


### PR DESCRIPTION
   If the tile just north of your production center happens to be coast
   and it is free and the city is garrisoned a new warrior goes swimming,
   taking an extra turn to get back onto the road network...

Please double-check for unwanted side effects. Function is at least also used to place barbarians, and I checked that and think my change can't hurt - but - four eyes see more than two.