### PR TITLE
Overview resources untapped

### DIFF
--- a/android/assets/jsons/translations/English.properties
+++ b/android/assets/jsons/translations/English.properties
@@ -1458,7 +1458,10 @@ Community =
  # Requires translation!
 Close = 
  # Requires translation!
-Do you want to exit the game? = 
+Do you want to exit the game? =
+
+Untapped = Unimproved
+untapped~click~help = Label and numbers in the 'Unimproved' row can be selected.
 
 # City screen
 

--- a/android/assets/jsons/translations/English.properties
+++ b/android/assets/jsons/translations/English.properties
@@ -1460,8 +1460,7 @@ Close =
  # Requires translation!
 Do you want to exit the game? =
 
-Untapped = Unimproved
-untapped~click~help = Label and numbers in the 'Unimproved' row can be selected.
+Untapped = 
 
 # City screen
 

--- a/android/assets/jsons/translations/French.properties
+++ b/android/assets/jsons/translations/French.properties
@@ -832,6 +832,9 @@ Social policies = Doctrines
 Community = Communauté
 Close = Fermer
 Do you want to exit the game? = Voulez vous quitter la partie ?
+Untapped = Non amélioré
+untapped~click~help = La ligne 'Non amélioré' offre interaction.
+
 
 # City screen
 

--- a/android/assets/jsons/translations/French.properties
+++ b/android/assets/jsons/translations/French.properties
@@ -833,8 +833,6 @@ Community = Communauté
 Close = Fermer
 Do you want to exit the game? = Voulez vous quitter la partie ?
 Untapped = Non amélioré
-untapped~click~help = La ligne 'Non amélioré' offre interaction.
-
 
 # City screen
 

--- a/android/assets/jsons/translations/German.properties
+++ b/android/assets/jsons/translations/German.properties
@@ -830,7 +830,7 @@ Community = Gemeinschaft
 Close = Schließen
 Do you want to exit the game? = Willst du das Spiel schließen?
 Untapped = Unerschlossen
-untapped~click~help = Zahlen und Beschriftung in der Zeile 'Unerschlossen' sind anwählbar. 
+untapped~click~help = Die Elemente in der Zeile 'Unerschlossen' sind anwählbar. 
 
 # City screen
 

--- a/android/assets/jsons/translations/German.properties
+++ b/android/assets/jsons/translations/German.properties
@@ -830,7 +830,6 @@ Community = Gemeinschaft
 Close = Schließen
 Do you want to exit the game? = Willst du das Spiel schließen?
 Untapped = Unerschlossen
-untapped~click~help = Die Elemente in der Zeile 'Unerschlossen' sind anwählbar. 
 
 # City screen
 

--- a/android/assets/jsons/translations/German.properties
+++ b/android/assets/jsons/translations/German.properties
@@ -829,6 +829,7 @@ Social policies = Sozialpolitiken
 Community = Gemeinschaft
 Close = Schließen
 Do you want to exit the game? = Willst du das Spiel schließen?
+Untapped = Unerschlossen
 
 # City screen
 

--- a/android/assets/jsons/translations/German.properties
+++ b/android/assets/jsons/translations/German.properties
@@ -830,6 +830,7 @@ Community = Gemeinschaft
 Close = Schließen
 Do you want to exit the game? = Willst du das Spiel schließen?
 Untapped = Unerschlossen
+untapped~click~help = Zahlen und Beschriftung in der Zeile 'Unerschlossen' sind anwählbar. 
 
 # City screen
 

--- a/android/assets/jsons/translations/Spanish.properties
+++ b/android/assets/jsons/translations/Spanish.properties
@@ -883,8 +883,6 @@ Community = Comunidad
 Close = Cerrar
 Do you want to exit the game? = ¿Quieres salir del juego?
 Untapped = Sin mejora
-untapped~click~help = Los elementos de la línea 'Sin mejora' tienen interacción. 
-
 
 # City screen
 

--- a/android/assets/jsons/translations/Spanish.properties
+++ b/android/assets/jsons/translations/Spanish.properties
@@ -882,6 +882,9 @@ Social policies = Políticas sociales
 Community = Comunidad
 Close = Cerrar
 Do you want to exit the game? = ¿Quieres salir del juego?
+Untapped = Sin mejora
+untapped~click~help = Los elementos de la línea 'Sin mejora' tienen interacción. 
+
 
 # City screen
 

--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -805,7 +805,7 @@ Social policies =
 Community = 
 Close = 
 Do you want to exit the game? = 
-Untapped =
+Untapped = 
 
 # City screen
 

--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -806,7 +806,6 @@ Community =
 Close = 
 Do you want to exit the game? = 
 Untapped = 
-untapped~click~help = 
 
 # City screen
 

--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -805,6 +805,7 @@ Social policies =
 Community = 
 Close = 
 Do you want to exit the game? = 
+Untapped =
 
 # City screen
 

--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -805,8 +805,8 @@ Social policies =
 Community = 
 Close = 
 Do you want to exit the game? = 
-Untapped =
-untapped~click~help =
+Untapped = 
+untapped~click~help = 
 
 # City screen
 

--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -805,7 +805,8 @@ Social policies =
 Community = 
 Close = 
 Do you want to exit the game? = 
-Untapped = 
+Untapped =
+untapped~click~help =
 
 # City screen
 

--- a/core/src/com/unciv/logic/city/CityInfo.kt
+++ b/core/src/com/unciv/logic/city/CityInfo.kt
@@ -171,6 +171,20 @@ class CityInfo {
         return cityResources
     }
 
+    fun getCityUntappedResources(): ResourceSupplyList {
+        val cityResources = ResourceSupplyList()
+
+        // count missed chances: resource is known, tile owned, but not improved or improvement not matching / not active
+        for (tileInfo in getTiles().filter { it.resource != null }) {
+            val resource = tileInfo.getTileResource()
+            if (resource.resourceType==ResourceType.Bonus) continue
+            if (resource.revealedBy!=null && !civInfo.tech.isResearched(resource.revealedBy!!)) continue
+            if (getTileResourceAmount(tileInfo)==0)
+                cityResources.add(resource, -1, "Untapped")
+        }
+        return cityResources
+    }
+
     fun getTileResourceAmount(tileInfo: TileInfo): Int {
         if (tileInfo.resource == null) return 0
         val resource = tileInfo.getTileResource()

--- a/core/src/com/unciv/logic/city/CityInfo.kt
+++ b/core/src/com/unciv/logic/city/CityInfo.kt
@@ -17,7 +17,9 @@ import com.unciv.logic.trade.TradeOffer
 import com.unciv.logic.trade.TradeType
 import com.unciv.models.ruleset.tile.ResourceSupplyList
 import com.unciv.models.ruleset.tile.ResourceType
+import com.unciv.models.ruleset.tile.TileResource
 import com.unciv.models.stats.Stats
+import com.unciv.models.translations.tr
 import com.unciv.ui.utils.withoutItem
 import java.util.*
 import kotlin.collections.HashMap
@@ -180,9 +182,26 @@ class CityInfo {
             if (resource.resourceType==ResourceType.Bonus) continue
             if (resource.revealedBy!=null && !civInfo.tech.isResearched(resource.revealedBy!!)) continue
             if (getTileResourceAmount(tileInfo)==0)
-                cityResources.add(resource, -1, "Untapped")
+                cityResources.add(resource, 1, "Untapped")
         }
         return cityResources
+    }
+    fun showCityUntappedResources(selectResource: TileResource?): Vector2? {
+        var firstPos: Vector2? = null
+        for (tileInfo in getTiles().filter { it.resource != null }) {
+            val resource = tileInfo.getTileResource()
+            if (selectResource != null) {   // show specific resource: no need to check type or tech
+                if (selectResource.name != tileInfo.resource) continue
+            } else {        // wildcard for all discovered but untapped resources: need tests
+                if (resource.resourceType == ResourceType.Bonus) continue
+                if (resource.revealedBy != null && !civInfo.tech.isResearched(resource.revealedBy!!)) continue
+            }
+            if (getTileResourceAmount(tileInfo)==0) {
+                if (firstPos == null) firstPos = tileInfo.position
+                civInfo.addNotification("[${resource}] revealed near [${name}]", tileInfo.position, Color.BLUE )
+            }
+        }
+        return firstPos
     }
 
     fun getTileResourceAmount(tileInfo: TileInfo): Int {

--- a/core/src/com/unciv/ui/EmpireOverviewScreen.kt
+++ b/core/src/com/unciv/ui/EmpireOverviewScreen.kt
@@ -534,13 +534,11 @@ class EmpireOverviewScreen(private val viewingPlayer:CivilizationInfo) : CameraS
         }
         resourcesTable.addSeparator()
 
-        var showUntappedHelp = false
         val origins = resourceDrilldown.map { it.origin }.distinct()
         for(origin in origins){
             val rowLabel = origin.toLabel()
             if (origin == "Untapped") {
                 rowLabel.onClick { untappedOnClick(null) }
-                showUntappedHelp = true
             }
             resourcesTable.add(rowLabel)
             for(resource in resources){
@@ -570,17 +568,11 @@ class EmpireOverviewScreen(private val viewingPlayer:CivilizationInfo) : CameraS
                 resourcesTable.add()
         }
 
-        if (showUntappedHelp && !game.settings.tutorialTasksCompleted.contains("Untapped-Help-Done")) {
-            resourcesTable.row()
-            resourcesTable.add("untapped~click~help".toLabel(Color.RED)).colspan(resources.count() + 1)
-        }
         return resourcesTable
     }
 
     private fun untappedOnClick(selectResource: TileResource?) {
         var newPosition: Vector2? = null
-        // ... maybe not.  viewingPlayer.notifications.removeIf { it.color == Color.BLUE }
-        game.settings.addCompletedTutorialTask("Untapped-Help-Done")
         for (city in viewingPlayer.cities) {
             val pos = city.showCityUntappedResources(selectResource)
             if (newPosition == null && pos != null) newPosition = pos

--- a/core/src/com/unciv/ui/EmpireOverviewScreen.kt
+++ b/core/src/com/unciv/ui/EmpireOverviewScreen.kt
@@ -544,8 +544,12 @@ class EmpireOverviewScreen(private val viewingPlayer:CivilizationInfo) : CameraS
 
         resourcesTable.add("Total".toLabel())
         for(resource in resources){
-            val sum = resourceDrilldown.filter { it.resource==resource && it.amount > 0 }.sumBy { it.amount }       // negatives used for untapped tiles
-            resourcesTable.add(sum.toString().toLabel())
+            val resourceOrigins = resourceDrilldown.filter { it.resource==resource }
+            if (resourceOrigins.any { it.origin!="Untapped" }) {
+                val sum = resourceOrigins.filter { it.origin != "Untapped" }.sumBy { it.amount }
+                resourcesTable.add(sum.toString().toLabel())
+            } else
+                resourcesTable.add()
         }
 
         return resourcesTable


### PR DESCRIPTION
A row showing how many owned tiles contain unimproved luxury or strategic resources (or having the wrong improvement) - in other words 'to-do''s. Does only help finding them a treensy tiny little bit, but can still save time.

I'm not completely convinced this is perfect, as the other rows operate on a different scale, but still...

And sorry I didn't add the empty rows to the other translation files, I assume there's a tool for that.

![image](https://user-images.githubusercontent.com/16001896/77009316-fddeb380-6967-11ea-8c04-b40c41f0c708.png)
