### PR TITLE
Show a mod loader exception in console

### DIFF
--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -155,7 +155,9 @@ object RulesetCache :HashMap<String,Ruleset>(){
                 modRuleset.name = modFolder.name()
                 this[modRuleset.name] = modRuleset
             }
-            catch (ex:Exception){}
+            catch (ex:Exception){
+                println( "Exception loading " + modFolder.name() + ": " + ex.message )
+            }
         }
     }
 


### PR DESCRIPTION
Tiny but may encourage modders - I did need this when I started with your now fixed example mod.

To consider: Mention on the modding page that launching the desktop jar from a terminal could be helpful while developing a mode?