### PR TITLE
Clean up redundant stuff found in save files

### DIFF
--- a/core/src/com/unciv/logic/city/CityConstructions.kt
+++ b/core/src/com/unciv/logic/city/CityConstructions.kt
@@ -6,6 +6,7 @@ import com.unciv.logic.automation.ConstructionAutomation
 import com.unciv.logic.civilization.AlertType
 import com.unciv.logic.civilization.PopupAlert
 import com.unciv.models.ruleset.Building
+import com.unciv.models.ruleset.unit.BaseUnit
 import com.unciv.models.stats.Stats
 import com.unciv.models.translations.tr
 import com.unciv.ui.cityscreen.ConstructionInfoTable
@@ -261,6 +262,23 @@ class CityConstructions {
         for (construction in queueSnapshot) {
             if (getConstruction(construction).isBuildable(this))
                 constructionQueue.add(construction)
+        }
+        // remove obsolete stuff from in progress constructions - happens often and leaves clutter in memory and save files
+        // should have NO visible consequences - any accumulated points that may be reused later should stay (nukes when manhattan project city lost, nat wonder when conquered an empty city...)
+        val inProgressSnapshot = inProgressConstructions.keys.filter { it != currentConstruction }
+        for (constructionName in inProgressSnapshot) {
+            val rejectionReason:String =
+                    when (val construction = getConstruction(constructionName)) {
+                        is Building -> construction.getRejectionReason(this)
+                        is BaseUnit -> construction.getRejectionReason(this)
+                        else -> ""
+                    }
+            if (!(  rejectionReason.endsWith("lready built")
+                            || rejectionReason.startsWith("Cannot be built with")
+                            || rejectionReason.startsWith("Don't need to build any more")
+                            || rejectionReason.startsWith("Obsolete")
+                            )) continue
+            inProgressConstructions.remove(constructionName)
         }
     }
 

--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -152,6 +152,8 @@ class BaseUnit : INamed, IConstruction {
         val unit = construction.cityInfo.civInfo.placeUnitNearTile(construction.cityInfo.location, name)
         if(unit==null) return false // couldn't place the unit, so there's actually no unit =(
 
+        if(this.unitType.isCivilian()) return true // tiny optimization makes save files a few bytes smaller
+
         var XP = construction.getBuiltBuildings().sumBy { it.xpForNewUnits }
         if(construction.cityInfo.civInfo.policies.isAdopted("Total War")) XP += 15
         unit.promotions.XP = XP


### PR DESCRIPTION
It's still two weeks early for this (minus a few hours depending on time zone), but - it works as intended. Otherwise very much tongue-in-cheek.

Note: One should be able to show a difference in gameplay: Build half a building normally, then buy it, then sell it, then build it again. Before: Progress preserved. After: Progress discarded. There's no hurry discount for partial work or carryover production in genuine Civ5 as there was in other 4x games, right? Purposeful design decision -> IMHO buying in Civ5 is a conscious decision to discard what your city was building - points should be gone. 