### PR TITLE
Great Improvements can be built on rough terrains

### DIFF
--- a/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
@@ -347,7 +347,7 @@ object UnitActions {
                         unit.getTile().improvementInProgress = null
                         unit.getTile().turnsToImprovement = 0
                         unit.destroy()
-                    }.takeIf { unit.currentMovement > 0f && !tile.isWater && !tile.isCityCenter() && !tile.getLastTerrain().unbuildable })
+                    }.takeIf { unit.currentMovement > 0f && !tile.isWater && !tile.isCityCenter() && !tile.getLastTerrain().impassable })
         }
         return null
     }


### PR DESCRIPTION
Resolves #1842 according to https://civilization.fandom.com/wiki/List_of_improvements_in_Civ5#Great_Tile_Improvements
_" All great tile improvements can be built on any **passable** land terrain type."_