### PR TITLE
Translations for the mods

### DIFF
--- a/core/src/com/unciv/models/translations/TranslationFileWriter.kt
+++ b/core/src/com/unciv/models/translations/TranslationFileWriter.kt
@@ -36,7 +36,7 @@ object TranslationFileWriter {
 
     private fun getFileHandle(modFolder: FileHandle?, fileLocation: String) =
             if (modFolder != null) modFolder.child(fileLocation)
-            else Gdx.files.internal(fileLocation)
+            else Gdx.files.local(fileLocation)
 
     private fun generateTranslationFiles(translations: Translations, modFolder: FileHandle? = null): HashMap<String, Int> {
         // read the template

--- a/core/src/com/unciv/models/translations/Translations.kt
+++ b/core/src/com/unciv/models/translations/Translations.kt
@@ -69,6 +69,7 @@ class Translations : LinkedHashMap<String, TranslationEntry>(){
         tryReadTranslationForLanguage(UncivGame.Current.settings.language)
     }
 
+    // This function is too strange for me, however, let's keep it "as is" for now. - JackRainy
     private fun getLanguagesWithTranslationFile(): List<String> {
 
         val languages = ArrayList<String>()
@@ -119,30 +120,6 @@ class Translations : LinkedHashMap<String, TranslationEntry>(){
 
         val translationFilesTime = System.currentTimeMillis() - startTime
         println("Loading percent complete of languages - "+translationFilesTime+"ms")
-    }
-
-    fun calculatePercentageCompleteOfLanguages():HashMap<String,Int> {
-        val percentComplete = HashMap<String,Int>()
-        val translationStart = System.currentTimeMillis()
-
-        var allTranslations = TranslationFileWriter.getGeneratedStringsSize()
-        Gdx.files.internal(TranslationFileWriter.templateFileLocation)
-                .reader().forEachLine { if(it.contains(" = ")) allTranslations+=1 }
-
-        for(language in getLanguagesWithTranslationFile()){
-            val translationFileName = "jsons/translations/$language.properties"
-            var translationsOfThisLanguage=0
-            Gdx.files.internal(translationFileName).reader()
-                    .forEachLine { if(it.contains(" = ") && !it.endsWith(" = "))
-                        translationsOfThisLanguage+=1 }
-
-            percentComplete[language] = translationsOfThisLanguage*100/allTranslations
-        }
-
-
-        val translationFilesTime = System.currentTimeMillis() - translationStart
-        println("Calculating percentage complete of languages - "+translationFilesTime+"ms")
-        return percentComplete
     }
 
     companion object {

--- a/core/src/com/unciv/models/translations/Translations.kt
+++ b/core/src/com/unciv/models/translations/Translations.kt
@@ -44,6 +44,13 @@ class Translations : LinkedHashMap<String, TranslationEntry>(){
             return
         }
 
+        // try to load the translations from the mods
+        for(modFolder in Gdx.files.local("mods").list()) {
+            val modTranslationFile = modFolder.child(translationFileName)
+            if (modTranslationFile.exists())
+                languageTranslations.putAll(TranslationFileReader.read(modTranslationFile.path()))
+        }
+
         for (translation in languageTranslations) {
             if (!containsKey(translation.key))
                 this[translation.key] = TranslationEntry(translation.key)


### PR DESCRIPTION
Resolves #2219 

The changes are:
* Newly generated language files contain emply lines separation between key elements (leftover from #2205 )
* The language files in the mods folders are used for the translations
* The `TranslationFileWriter` is simplified a bit: no redundant calls - no caching needed
* Percentage calculation is done on-the-fly while forming the new files (instead of an extra run as it was before)
* Running the app with `rewriteTranslationFiles = true` will also create the translation files for the mods (if any found). The additional template files can be also used, if needed.
