### PR TITLE
Translation of the mod's name

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -317,6 +317,7 @@ Starting Era =
 It looks like we can't make a map with the parameters you requested! = 
 Maybe you put too many players into too small a map? = 
 No human players selected! = 
+Mods: = 
 
 # Multiplayer
 

--- a/core/src/com/unciv/ui/newgamescreen/NewGameScreenOptionsTable.kt
+++ b/core/src/com/unciv/ui/newgamescreen/NewGameScreenOptionsTable.kt
@@ -233,10 +233,10 @@ class NewGameScreenOptionsTable(val newGameScreen: NewGameScreen, val updatePlay
             ImageGetter.setTextureRegionDrawables()
         }
 
-        add("{Mods}:".tr().toLabel(fontSize = 24)).padTop(16f).colspan(2).row()
+        add("Mods:".tr().toLabel(fontSize = 24)).padTop(16f).colspan(2).row()
         val modCheckboxTable = Table().apply { defaults().pad(5f) }
         for(mod in modRulesets){
-            val checkBox = CheckBox(mod.name,CameraStageBaseScreen.skin)
+            val checkBox = CheckBox(mod.name.tr(),CameraStageBaseScreen.skin)
             if (mod.name in newGameParameters.mods) checkBox.isChecked = true
             checkBox.addListener(object : ChangeListener() {
                 override fun changed(event: ChangeEvent?, actor: Actor?) {


### PR DESCRIPTION
Currently, the name of the mod is the name of the mod's folder.
Now it is possible to add a line (e.g. `modName = модНейм`) to the mod's translation files ( e.g.  `assets\mods\modName\jsons\translations\*.properties` ) and it will be translated in the Start Game list.