### PR TITLE
Embarkation of military units treat them as civilians

### DIFF
--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -224,7 +224,7 @@ class MapUnit {
         return false
     }
 
-    fun getEmbarkedMovement(): Int {
+    private fun getEmbarkedMovement(): Int {
         var movement=2
         movement += civInfo.tech.getTechUniques().count { it == "Increases embarked movement +1" }
         return movement
@@ -478,8 +478,8 @@ class MapUnit {
     fun removeFromTile(){
         when {
             type.isAirUnit() -> currentTile.airUnits.remove(this)
-            type.isCivilian() -> getTile().civilianUnit=null
-            else -> getTile().militaryUnit=null
+            this == getTile().civilianUnit -> getTile().civilianUnit = null // civilian or embarked military unit
+            else -> getTile().militaryUnit = null
         }
     }
 
@@ -506,8 +506,8 @@ class MapUnit {
         when {
             !movement.canMoveTo(tile) -> throw Exception("I can't go there!")
             type.isAirUnit() -> tile.airUnits.add(this)
-            type.isCivilian() -> tile.civilianUnit=this
-            else -> tile.militaryUnit=this
+            type.isCivilian() || (tile.isWater && type.isLandUnit()) -> tile.civilianUnit = this
+            else -> tile.militaryUnit = this
         }
         // this check is here in order to not load the fresh built unit into carrier right after the build
         isTransported = !tile.isCityCenter() &&

--- a/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
+++ b/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
@@ -289,9 +289,10 @@ class UnitMovementAlgorithms(val unit:MapUnit) {
         if (!canPassThrough(tile))
             return false
 
-        if (unit.type.isCivilian())
-            return tile.civilianUnit == null && (tile.militaryUnit == null || tile.militaryUnit!!.owner == unit.owner)
-        else return tile.militaryUnit == null && (tile.civilianUnit == null || tile.civilianUnit!!.owner == unit.owner)
+        return when {
+            unit.type.isCivilian() || (tile.isWater && unit.type.isLandUnit()) -> tile.civilianUnit == null && (tile.militaryUnit == null || tile.militaryUnit!!.owner == unit.owner)
+            else -> tile.militaryUnit == null && (tile.civilianUnit == null || tile.civilianUnit!!.owner == unit.owner)
+        }
     }
 
     private fun canAirUnitMoveTo(tile: TileInfo, unit: MapUnit): Boolean {

--- a/core/src/com/unciv/ui/tilegroups/WorldTileGroup.kt
+++ b/core/src/com/unciv/ui/tilegroups/WorldTileGroup.kt
@@ -16,7 +16,7 @@ class WorldTileGroup(internal val worldScreen: WorldScreen, tileInfo: TileInfo, 
 
     fun selectUnit(unit: MapUnit) {
         if(unit.type.isAirUnit()) return // doesn't appear on map so nothing to select
-        val unitImage = if (unit.type.isCivilian()) icons.civilianUnitIcon
+        val unitImage = if (unit.type.isCivilian() || (tileInfo.isWater && unit.type.isLandUnit())) icons.civilianUnitIcon
         else icons.militaryUnitIcon
         unitImage?.selectUnit()
     }


### PR DESCRIPTION
Resolves #2266 
According to the https://civilization.fandom.com/wiki/Embarkation_(Civ5) :
1) The fix does not allow the embarked civilian and military units to be stacked at the same tile.
2) The naval military units can be stacked with other embarked units.