### PR TITLE
Display the indicators of hidden units near the city

### DIFF
--- a/core/src/com/unciv/ui/tilegroups/WorldTileGroup.kt
+++ b/core/src/com/unciv/ui/tilegroups/WorldTileGroup.kt
@@ -12,7 +12,7 @@ import com.unciv.ui.worldscreen.WorldScreen
 class WorldTileGroup(internal val worldScreen: WorldScreen, tileInfo: TileInfo, tileSetStrings: TileSetStrings)
     : TileGroup(tileInfo,tileSetStrings) {
 
-    var cityButton: CityButton? = null
+    private var cityButton: CityButton? = null
 
     fun selectUnit(unit: MapUnit) {
         if(unit.type.isAirUnit()) return // doesn't appear on map so nothing to select


### PR DESCRIPTION
Resolves #2113 (it has been mentioned quite often but can't find other reported issues on this).

The suggested solution:
![ezgif-4-978b486372c7](https://user-images.githubusercontent.com/27405436/77832827-72240e80-7141-11ea-850c-066cd2cfddee.gif)

The arrows at the city button give a hint to shift the button and see the unit under it.