### PR TITLE
Decrease of the battery usage

### DIFF
--- a/core/src/com/unciv/ui/worldscreen/WorldMapHolder.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldMapHolder.kt
@@ -1,5 +1,6 @@
 package com.unciv.ui.worldscreen
 
+import com.badlogic.gdx.Application
 import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.Input
 import com.badlogic.gdx.graphics.Color
@@ -60,14 +61,15 @@ class WorldMapHolder(internal val worldScreen: WorldScreen, internal val tileMap
 
         layout() // Fit the scroll pane to the contents - otherwise, setScroll won't work!
 
-        addAction(Actions.forever(Actions.delay(0.05f, Actions.run {
-            val amountToMove = 30/scaleX
-            if(Gdx.input.isKeyPressed(Input.Keys.W)) scrollY -= amountToMove
-            if(Gdx.input.isKeyPressed(Input.Keys.S)) scrollY += amountToMove
-            if(Gdx.input.isKeyPressed(Input.Keys.A)) scrollX -= amountToMove
-            if(Gdx.input.isKeyPressed(Input.Keys.D)) scrollX += amountToMove
-            updateVisualScroll()
-        })))
+        if (Gdx.app.type == Application.ApplicationType.Desktop) {
+            addAction(Actions.forever(Actions.delay(0.05f, Actions.run {
+                val amountToMove = 30/scaleX
+                if(Gdx.input.isKeyPressed(Input.Keys.W)) scrollY -= amountToMove
+                if(Gdx.input.isKeyPressed(Input.Keys.S)) scrollY += amountToMove
+                if(Gdx.input.isKeyPressed(Input.Keys.A)) scrollX -= amountToMove
+                if(Gdx.input.isKeyPressed(Input.Keys.D)) scrollX += amountToMove
+                updateVisualScroll()
+            }))) }
     }
 
     private fun onTileClicked(tileInfo: TileInfo) {

--- a/core/src/com/unciv/ui/worldscreen/bottombar/BattleTable.kt
+++ b/core/src/com/unciv/ui/worldscreen/bottombar/BattleTable.kt
@@ -326,11 +326,12 @@ class BattleTable(val worldScreen: WorldScreen): Table() {
         }
         addHealthToBar(ImageGetter.getDot(Color.BLACK), maxHealth-currentHealth)
 
-        val damagedHealth = ImageGetter.getDot(Color.RED)
-        damagedHealth.addAction(Actions.repeat(RepeatAction.FOREVER, Actions.sequence(
-                Actions.color(Color.BLACK,0.7f),
-                Actions.color(Color.RED,0.7f)
-        )))
+        val damagedHealth = ImageGetter.getDot(Color.FIREBRICK)
+        if (UncivGame.Current.settings.continuousRendering) {
+            damagedHealth.addAction(Actions.repeat(RepeatAction.FOREVER, Actions.sequence(
+                    Actions.color(Color.BLACK,0.7f),
+                    Actions.color(Color.FIREBRICK,0.7f)
+            ))) }
         addHealthToBar(damagedHealth,expectedDamage)
 
         val remainingHealth = currentHealth-expectedDamage


### PR DESCRIPTION
1) Disable animation of the damage at the health bar, when continious rendering is off 
The color is altered to be different from "red" which indicates low health.
2) Disable WSAD keys check for Android, assuming nobody plugs a real keyboard to a mobile phone
However, it can be possible scenario for a tablet (or Android TV), so I am working on better solution meanwhile.