### PR TITLE
Fix: Unit Range in Civilopedia Nation Unique Units

### DIFF
--- a/core/src/com/unciv/models/ruleset/Nation.kt
+++ b/core/src/com/unciv/models/ruleset/Nation.kt
@@ -133,7 +133,7 @@ class Nation : INamed {
             if (unit.rangedStrength != originalUnit.rangedStrength)
                 textList += "  {Ranged strength} " + "[${unit.rangedStrength}] vs [${originalUnit.rangedStrength}]".tr()
             if (unit.range != originalUnit.range)
-                textList += "  {Range} " + unit.range + "[${unit.range}] vs [${originalUnit.range}]".tr()
+                textList += "  {Range} " + "[${unit.range}] vs [${originalUnit.range}]".tr()
             if (unit.movement != originalUnit.movement)
                 textList += "  {Movement} " + "[${unit.movement}] vs [${originalUnit.movement}]".tr()
             if (originalUnit.requiredResource != null && unit.requiredResource == null)


### PR DESCRIPTION
unit range when shown as difference to base unit for a unique unit is placed twice.
I haven't checked the impact on translations or playtested.