### PR TITLE
UI bugfixes: city info and aircrafts

### DIFF
--- a/core/src/com/unciv/ui/tilegroups/CityButton.kt
+++ b/core/src/com/unciv/ui/tilegroups/CityButton.kt
@@ -28,15 +28,16 @@ class CityButton(val city: CityInfo, private val tileGroup: WorldTileGroup, skin
     private val listOfHiddenUnitMarkers: MutableList<Actor> = mutableListOf()
     private lateinit var iconTable: Table
     private var isButtonMoved = false
+    private var showAdditionalInfoTags = false
 
     fun update(isCityViewable:Boolean) {
+        showAdditionalInfoTags = isCityViewable
+
         clear()
-
         setButtonActions()
-
         addAirUnitTable()
 
-        if (isCityViewable && city.health < city.getMaxHealth().toFloat()) {
+        if (showAdditionalInfoTags && city.health < city.getMaxHealth().toFloat()) {
             val healthBar = ImageGetter.getHealthBar(city.health.toFloat(), city.getMaxHealth().toFloat(), 100f)
             add(healthBar).row()
         }
@@ -58,6 +59,9 @@ class CityButton(val city: CityInfo, private val tileGroup: WorldTileGroup, skin
         for (marker in listOfHiddenUnitMarkers)
             iconTable.removeActor(marker)
         listOfHiddenUnitMarkers.clear()
+
+        if (!showAdditionalInfoTags) return
+
         // detect civilian in the city center
         if (!isButtonMoved && (tileGroup.tileInfo.civilianUnit != null))
             insertHiddenUnitMarker(HiddenUnitMarkerPosition.Center)
@@ -111,7 +115,7 @@ class CityButton(val city: CityInfo, private val tileGroup: WorldTileGroup, skin
     }
 
     private fun addAirUnitTable() {
-        if (tileGroup.tileInfo.airUnits.isEmpty()) return
+        if (!showAdditionalInfoTags || tileGroup.tileInfo.airUnits.isEmpty()) return
         val secondarycolor = city.civInfo.nation.getInnerColor()
         val airUnitTable = Table().apply { defaults().pad(5f) }
         airUnitTable.background = ImageGetter.getRoundedEdgeTableBackground(city.civInfo.nation.getOuterColor())

--- a/core/src/com/unciv/ui/tilegroups/TileGroupIcons.kt
+++ b/core/src/com/unciv/ui/tilegroups/TileGroupIcons.kt
@@ -66,7 +66,7 @@ class TileGroupIcons(val tileGroup: TileGroup){
             newImage.y += yFromCenter
 
             // Display number of carried air units
-            if (unit.getTile().airUnits.any { unit.canTransport(it) } && !unit.getTile().isCityCenter()) {
+            if (unit.getTile().airUnits.any { unit.isTransportTypeOf(it) } && !unit.getTile().isCityCenter()) {
                 val holder = Table()
                 val secondarycolor = unit.civInfo.nation.getInnerColor()
                 val airUnitTable = Table().apply { defaults().pad(5f) }


### PR DESCRIPTION
Two UI bugs are fixed (both are reported in Discord channel):
1) When the airplane carrier is full, the number of planes is hidden
2) When the enemy city is in the fog, it is still possible to see the number of planes in the city