### PR TITLE
Keyboard support for next turn button and unit actions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ buildscript {
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.6'
-        classpath 'com.android.tools.build:gradle:3.6.1'
+        classpath 'com.android.tools.build:gradle:3.6.2'
         classpath 'com.mobidevelop.robovm:robovm-gradle-plugin:2.3.1'
 
         // This is for wrapping the .jar file into a standalone executable

--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -189,11 +189,10 @@ class WorldScreen(val viewingCiv:CivilizationInfo) : CameraStageBaseScreen() {
                 }
 
                 override fun keyTyped(event: InputEvent?, character: Char): Boolean {
-                    if (character in keyPressDispatcher) {
-                        println("keyTyped: '$character'")
+                    if (character.toLowerCase() in keyPressDispatcher) {
                         //try-catch mainly for debugging. Breakpoints in the vicinity can make the event fire twice in rapid succession, second time the context can be invalid
                         try {
-                            keyPressDispatcher[character]?.invoke()
+                            keyPressDispatcher[character.toLowerCase()]?.invoke()
                         } catch (ex: Exception) {}
                         return true
                     }

--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -143,6 +143,11 @@ class WorldScreen(val viewingCiv:CivilizationInfo) : CameraStageBaseScreen() {
         shouldUpdate = true
     }
 
+    private fun cleanupKeyDispatcher() {
+        val delKeys = keyPressDispatcher.keys.filter { it!=' ' && it!='n' }
+        delKeys.forEach { keyPressDispatcher.remove(it) }
+    }
+
     private fun addKeyboardListener() {
         stage.addListener(
             object : InputListener() {
@@ -255,6 +260,7 @@ class WorldScreen(val viewingCiv:CivilizationInfo) : CameraStageBaseScreen() {
         }
 
         minimapWrapper.update(viewingCiv)
+        cleanupKeyDispatcher()
         unitActionsTable.update(bottomUnitTable.selectedUnit)
         unitActionsTable.y = bottomUnitTable.height
 

--- a/core/src/com/unciv/ui/worldscreen/unit/UnitActionsTable.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitActionsTable.kt
@@ -26,14 +26,14 @@ class UnitActionsTable(val worldScreen: WorldScreen) : Table(){
                 // Regexplaination: start with a [, take as many non-] chars as you can, until you reach a ].
                 // What you find between the first [ and the first ] that comes after it, will be group no. 1
                 val unitToUpgradeTo = Regex("""Upgrade to \[([^\]]*)\]""").find(unitAction)!!.groups[1]!!.value
-                return UnitIconAndKey(ImageGetter.getUnitIcon(unitToUpgradeTo))
+                return UnitIconAndKey(ImageGetter.getUnitIcon(unitToUpgradeTo), 'u')
             }
             unitAction.startsWith("Sleep") -> return UnitIconAndKey(ImageGetter.getImage("OtherIcons/Sleep"),'f')
             unitAction.startsWith("Fortify") -> return UnitIconAndKey(ImageGetter.getImage("OtherIcons/Shield").apply { color= Color.BLACK },'f')
             else -> when(unitAction){
                 "Move unit" -> return UnitIconAndKey(ImageGetter.getStatIcon("Movement"))
                 "Stop movement"-> return UnitIconAndKey(ImageGetter.getStatIcon("Movement").apply { color= Color.RED }, '.')
-                "Promote" -> return UnitIconAndKey(ImageGetter.getImage("OtherIcons/Star").apply { color= Color.GOLD }, 'p')
+                "Promote" -> return UnitIconAndKey(ImageGetter.getImage("OtherIcons/Star").apply { color= Color.GOLD }, 'o')
                 "Construct improvement" -> return UnitIconAndKey(ImageGetter.getUnitIcon(Constants.worker),'i')
                 "Automate" -> return UnitIconAndKey(ImageGetter.getUnitIcon("Great Engineer"), 'm')
                 "Stop automation" -> return UnitIconAndKey(ImageGetter.getImage("OtherIcons/Stop"), 'm')
@@ -46,7 +46,7 @@ class UnitActionsTable(val worldScreen: WorldScreen) : Table(){
                 "Construct Manufactory" -> return UnitIconAndKey(ImageGetter.getImprovementIcon("Manufactory"), 'i')
                 "Conduct Trade Mission" -> return UnitIconAndKey(ImageGetter.getUnitIcon("Great Merchant"), 'g')
                 "Construct Customs House" -> return UnitIconAndKey(ImageGetter.getImprovementIcon("Customs house"), 'i')
-                "Set up" -> return UnitIconAndKey(ImageGetter.getUnitIcon("Catapult"), 'u')
+                "Set up" -> return UnitIconAndKey(ImageGetter.getUnitIcon("Catapult"), 't')
                 "Disband unit" -> return UnitIconAndKey(ImageGetter.getImage("OtherIcons/DisbandUnit"))
                 "Explore" -> return UnitIconAndKey(ImageGetter.getUnitIcon("Scout"), 'x')
                 "Stop exploration" -> return UnitIconAndKey(ImageGetter.getImage("OtherIcons/Stop"), 'x')

--- a/core/src/com/unciv/ui/worldscreen/unit/UnitActionsTable.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitActionsTable.kt
@@ -12,47 +12,49 @@ import com.unciv.models.UnitAction
 import com.unciv.ui.utils.*
 import com.unciv.ui.worldscreen.WorldScreen
 
+private data class UnitIconAndKey (val Icon: Actor, val key: Char = 0.toChar())
+
 class UnitActionsTable(val worldScreen: WorldScreen) : Table(){
 
     init {
         touchable = Touchable.enabled
     }
     
-    private fun getIconForUnitAction(unitAction:String): Actor {
+    private fun getIconAnKeyForUnitAction(unitAction:String): UnitIconAndKey {
         when {
             unitAction.startsWith("Upgrade to") -> {
                 // Regexplaination: start with a [, take as many non-] chars as you can, until you reach a ].
                 // What you find between the first [ and the first ] that comes after it, will be group no. 1
                 val unitToUpgradeTo = Regex("""Upgrade to \[([^\]]*)\]""").find(unitAction)!!.groups[1]!!.value
-                return ImageGetter.getUnitIcon(unitToUpgradeTo)
+                return UnitIconAndKey(ImageGetter.getUnitIcon(unitToUpgradeTo))
             }
-            unitAction.startsWith("Sleep") -> return ImageGetter.getImage("OtherIcons/Sleep")
-            unitAction.startsWith("Fortify") -> return ImageGetter.getImage("OtherIcons/Shield").apply { color= Color.BLACK }
+            unitAction.startsWith("Sleep") -> return UnitIconAndKey(ImageGetter.getImage("OtherIcons/Sleep"),'f')
+            unitAction.startsWith("Fortify") -> return UnitIconAndKey(ImageGetter.getImage("OtherIcons/Shield").apply { color= Color.BLACK },'f')
             else -> when(unitAction){
-                "Move unit" -> return ImageGetter.getStatIcon("Movement")
-                "Stop movement"-> return ImageGetter.getStatIcon("Movement").apply { color= Color.RED }
-                "Promote" -> return ImageGetter.getImage("OtherIcons/Star").apply { color= Color.GOLD }
-                "Construct improvement" -> return ImageGetter.getUnitIcon(Constants.worker)
-                "Automate" -> return ImageGetter.getUnitIcon("Great Engineer")
-                "Stop automation" -> return ImageGetter.getImage("OtherIcons/Stop")
-                "Found city" -> return ImageGetter.getUnitIcon(Constants.settler)
-                "Hurry Research" -> return ImageGetter.getUnitIcon("Great Scientist")
-                "Construct Academy" -> return ImageGetter.getImprovementIcon("Academy")
-                "Start Golden Age" -> return ImageGetter.getUnitIcon("Great Artist")
-                "Construct Landmark" -> return ImageGetter.getImprovementIcon("Landmark")
-                "Hurry Wonder" -> return ImageGetter.getUnitIcon("Great Engineer")
-                "Construct Manufactory" -> return ImageGetter.getImprovementIcon("Manufactory")
-                "Conduct Trade Mission" -> return ImageGetter.getUnitIcon("Great Merchant")
-                "Construct Customs House" -> return ImageGetter.getImprovementIcon("Customs house")
-                "Set up" -> return ImageGetter.getUnitIcon("Catapult")
-                "Disband unit" -> return ImageGetter.getImage("OtherIcons/DisbandUnit")
-                "Explore" -> return ImageGetter.getUnitIcon("Scout")
-                "Stop exploration" -> return ImageGetter.getImage("OtherIcons/Stop")
-                "Create Fishing Boats" -> return ImageGetter.getImprovementIcon("Fishing Boats")
-                "Create Oil well" -> return ImageGetter.getImprovementIcon("Oil well")
-                "Pillage" -> return ImageGetter.getImage("OtherIcons/Pillage")
-                "Construct road" -> return ImageGetter.getImprovementIcon("Road")
-                else -> return ImageGetter.getImage("OtherIcons/Star")
+                "Move unit" -> return UnitIconAndKey(ImageGetter.getStatIcon("Movement"))
+                "Stop movement"-> return UnitIconAndKey(ImageGetter.getStatIcon("Movement").apply { color= Color.RED }, '.')
+                "Promote" -> return UnitIconAndKey(ImageGetter.getImage("OtherIcons/Star").apply { color= Color.GOLD }, 'p')
+                "Construct improvement" -> return UnitIconAndKey(ImageGetter.getUnitIcon(Constants.worker),'i')
+                "Automate" -> return UnitIconAndKey(ImageGetter.getUnitIcon("Great Engineer"), 'm')
+                "Stop automation" -> return UnitIconAndKey(ImageGetter.getImage("OtherIcons/Stop"), 'm')
+                "Found city" -> return UnitIconAndKey(ImageGetter.getUnitIcon(Constants.settler),'f')
+                "Hurry Research" -> return UnitIconAndKey(ImageGetter.getUnitIcon("Great Scientist"), 'g')
+                "Construct Academy" -> return UnitIconAndKey(ImageGetter.getImprovementIcon("Academy"), 'i')
+                "Start Golden Age" -> return UnitIconAndKey(ImageGetter.getUnitIcon("Great Artist"), 'g')
+                "Construct Landmark" -> return UnitIconAndKey(ImageGetter.getImprovementIcon("Landmark"), 'i')
+                "Hurry Wonder" -> return UnitIconAndKey(ImageGetter.getUnitIcon("Great Engineer"), 'g')
+                "Construct Manufactory" -> return UnitIconAndKey(ImageGetter.getImprovementIcon("Manufactory"), 'i')
+                "Conduct Trade Mission" -> return UnitIconAndKey(ImageGetter.getUnitIcon("Great Merchant"), 'g')
+                "Construct Customs House" -> return UnitIconAndKey(ImageGetter.getImprovementIcon("Customs house"), 'i')
+                "Set up" -> return UnitIconAndKey(ImageGetter.getUnitIcon("Catapult"), 'u')
+                "Disband unit" -> return UnitIconAndKey(ImageGetter.getImage("OtherIcons/DisbandUnit"))
+                "Explore" -> return UnitIconAndKey(ImageGetter.getUnitIcon("Scout"), 'x')
+                "Stop exploration" -> return UnitIconAndKey(ImageGetter.getImage("OtherIcons/Stop"), 'x')
+                "Create Fishing Boats" -> return UnitIconAndKey(ImageGetter.getImprovementIcon("Fishing Boats"),'i')
+                "Create Oil well" -> return UnitIconAndKey(ImageGetter.getImprovementIcon("Oil well"),'i')
+                "Pillage" -> return UnitIconAndKey(ImageGetter.getImage("OtherIcons/Pillage"),'p')
+                "Construct road" -> return UnitIconAndKey(ImageGetter.getImprovementIcon("Road"),'r')
+                else -> return UnitIconAndKey(ImageGetter.getImage("OtherIcons/Star"))
             }
         }
     }
@@ -68,16 +70,21 @@ class UnitActionsTable(val worldScreen: WorldScreen) : Table(){
 
 
     private fun getUnitActionButton(unitAction: UnitAction): Button {
+        val iconAndKey = getIconAnKeyForUnitAction(unitAction.title)
         val actionButton = Button(CameraStageBaseScreen.skin)
-        actionButton.add(getIconForUnitAction(unitAction.title)).size(20f).pad(5f)
+        actionButton.add(iconAndKey.Icon).size(20f).pad(5f)
         val fontColor = if(unitAction.isCurrentAction) Color.YELLOW else Color.WHITE
         actionButton.add(unitAction.title.toLabel(fontColor)).pad(5f)
         actionButton.pack()
-        actionButton.onClick(unitAction.uncivSound) {
+        val actionLambda = {
             unitAction.action?.invoke()
             UncivGame.Current.worldScreen.shouldUpdate=true
         }
+        actionButton.onClick(unitAction.uncivSound,actionLambda)
         if (unitAction.action == null) actionButton.disable()
+        else if (iconAndKey.key != 0.toChar()) {
+            worldScreen.keyPressDispatcher[iconAndKey.key] = actionLambda
+        }
         return actionButton
     }
 }

--- a/core/src/com/unciv/ui/worldscreen/unit/UnitActionsTable.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitActionsTable.kt
@@ -91,7 +91,7 @@ class UnitActionsTable(val worldScreen: WorldScreen) : Table(){
         val fontColor = if(unitAction.isCurrentAction) Color.YELLOW else Color.WHITE
         actionButton.add(unitAction.title.toLabel(fontColor)).pad(5f)
         if (iconAndKey.key != 0.toChar()) {
-            val keyLabel = "(${iconAndKey.key.toUpperCase()})".toLabel(Color.LIGHT_GRAY).apply { isVisible = false }
+            val keyLabel = "(${iconAndKey.key.toUpperCase()})".toLabel(Color.WHITE).apply { isVisible = false }
             actionButton.add(keyLabel)
             actionButton.addListener(UnitActionButtonOnHoverListener(actionButton, keyLabel))
         }


### PR DESCRIPTION
Small convenience feature: keyboard support on world screen. Works in Android emulator, too.

key | function
 --- | ---
space or n | whatever the next turn button currently offers
. | stop movement
f | sleep / fortify / found city
g | great person ability (not construct improvement)
i | improve / great person construct improvement / work boats build
m | start / stop automation
o | promote
p | pillage 
r | build road (only for the legion unit, only the actual UnitActionsTable buttons have a key)
t | set up
u | upgrade
x | start / stop exploration

Conflicts: last one from UnitActions.getUnitActions()  wins, which works nicely e.g. for the settler and 'f'.