### PR TITLE
Display price for temporary unavailable purchases

### DIFF
--- a/core/src/com/unciv/ui/cityscreen/ConstructionsTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/ConstructionsTable.kt
@@ -333,11 +333,9 @@ class ConstructionsTable(val cityScreen: CityScreen) : Table(CameraStageBaseScre
         val button = TextButton("", CameraStageBaseScreen.skin)
 
         if (construction == null || !construction.canBePurchased()
-                || !construction.isBuildable(cityConstructions)
-                || !UncivGame.Current.worldScreen.isPlayersTurn
-                || city.isPuppet || city.isInResistance()
-                || !city.canPurchase(construction)
         ) {
+            // fully disable a "buy" button only for "priceless" buildings such as wonders
+            // for all other cases, the price should be displayed
             button.setText("Buy".tr())
             button.disable()
         } else {
@@ -354,7 +352,11 @@ class ConstructionsTable(val cityScreen: CityScreen) : Table(CameraStageBaseScre
                 YesNoPopup(purchasePrompt, { purchaseConstruction(construction) }, cityScreen, { cityScreen.update() }).open()
             }
 
-            if (constructionGoldCost > city.civInfo.gold)
+            if ( !construction.isBuildable(cityConstructions)
+                    || !UncivGame.Current.worldScreen.isPlayersTurn
+                    || city.isPuppet || city.isInResistance()
+                    || !city.canPurchase(construction)
+                    || constructionGoldCost > city.civInfo.gold )
                 button.disable()
         }
 


### PR DESCRIPTION
There was a complaint that it is not possible to see the price of the unit when the same type of unit is in the city which is a temporary state. That's a fix for that.