### PR TITLE
Better colors for Katmandu and Almaty

### DIFF
--- a/android/assets/jsons/Nations.json
+++ b/android/assets/jsons/Nations.json
@@ -822,7 +822,7 @@
 		"attacked": "Very well, this shall not be forgotten.",
 		"defeated": "How could we fall to the likes of you?!",
 		"outerColor": [0, 0, 0],
-		"innerColor": [102,0,51],
+		"innerColor": [152,0,241],
 		"cities": ["Almaty"]
 	},
 	{
@@ -894,7 +894,7 @@
 		"attacked": "Very well, this shall not be forgotten.",
 		"defeated": "We... defeated? No... we had so much work to do!",
 		"outerColor": [0, 0, 0],
-		"innerColor": [51,25,0],
+		"innerColor": [151,125,0],
 		"cities": ["Kathmandu"]
 	},
 	{


### PR DESCRIPTION
These nations' colors were barely readable.
| Before | After |
|--------|-------|
| ![Screenshot 2020-04-07 23 52 23](https://user-images.githubusercontent.com/27405436/78718850-a6f74900-792b-11ea-8b89-71faedf21e28.png) ![Screenshot 2020-04-07 23 52 36](https://user-images.githubusercontent.com/27405436/78718860-abbbfd00-792b-11ea-94ef-0f252ceea555.png) | ![Screenshot 2020-04-07 23 55 25](https://user-images.githubusercontent.com/27405436/78718867-afe81a80-792b-11ea-8591-05f30b9a29f4.png) ![Screenshot 2020-04-07 23 49 56](https://user-images.githubusercontent.com/27405436/78718873-b2e30b00-792b-11ea-9abf-aa7a9ff64177.png) |

Also, I tried to keep them still distinctive from other nations' colors.
Tested on a huge map with max number of city-states.