### PR TITLE
Throw exceptions for better debugging of saved games with missing mods

### DIFF
--- a/core/src/com/unciv/logic/city/CityConstructions.kt
+++ b/core/src/com/unciv/logic/city/CityConstructions.kt
@@ -210,7 +210,8 @@ class CityConstructions {
 
     //region state changing functions
     fun setTransients(){
-        builtBuildingObjects = ArrayList(builtBuildings.map { cityInfo.getRuleset().buildings[it]!! })
+        builtBuildingObjects = ArrayList(builtBuildings.map { cityInfo.getRuleset().buildings[it]
+                    ?: throw java.lang.Exception("Building $it is not found!")})
     }
 
     fun addProductionPoints(productionToAdd: Int) {

--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -338,7 +338,8 @@ class CivilizationInfo {
      *  And if they civs on't yet know who they are then they don;t know if they're barbarians =\
      *  */
     fun setNationTransient(){
-        nation = gameInfo.ruleSet.nations[civName]!!
+        nation = gameInfo.ruleSet.nations[civName]
+                ?: throw java.lang.Exception("Nation $civName is not found!")
     }
 
     fun setTransients() {

--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -307,7 +307,8 @@ class MapUnit {
     fun setTransients(ruleset: Ruleset) {
         promotions.unit=this
         mapUnitAction?.unit = this
-        baseUnit=ruleset.units[name]!!
+        baseUnit=ruleset.units[name]
+                ?: throw java.lang.Exception("Unit $name is not found!")
         updateUniques()
     }
 

--- a/core/src/com/unciv/ui/saves/LoadGameScreen.kt
+++ b/core/src/com/unciv/ui/saves/LoadGameScreen.kt
@@ -42,11 +42,13 @@ class LoadGameScreen : PickerScreen() {
                 if (ex is UncivShowableException && ex.localizedMessage != null) {
                     // thrown exceptions are our own tests and can be shown to the user
                     cantLoadGamePopup.addGoodSizedLabel(ex.localizedMessage).row()
+                    cantLoadGamePopup.addCloseButton()
                     cantLoadGamePopup.open()
                 } else {
                     cantLoadGamePopup.addGoodSizedLabel("If you could copy your game data (\"Copy saved game to clipboard\" - ").row()
                     cantLoadGamePopup.addGoodSizedLabel("  paste into an email to yairm210@hotmail.com)").row()
                     cantLoadGamePopup.addGoodSizedLabel("I could maybe help you figure out what went wrong, since this isn't supposed to happen!").row()
+                    cantLoadGamePopup.addCloseButton()
                     cantLoadGamePopup.open()
                     ex.printStackTrace()
                 }


### PR DESCRIPTION
More and more often I face the situation when a bug reporter provides the save saying "it requires mod A and mod B", I install them, try to load it and it does not load because the versions of the mods are different: they are named the same, but the content is different (some units, buildings and nations are still missing).
The best I can do in such situation is to mock the missing items with some fakes named the same. These exceptions like `Building Ducal Stable is not found!` are much better for that rather than existing NullPointer exceptions.