### PR TITLE
Keyboard support for pickers and popups

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -764,6 +764,7 @@ Clear resource =
 Requires = 
 Menu = 
 Brush Size = 
+Could not load map! = 
 
 # Civilopedia Tutorials names
 

--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -373,6 +373,7 @@ If you could copy your game data ("Copy saved game to clipboard" -  =
   paste into an email to yairm210@hotmail.com) = 
 I could maybe help you figure out what went wrong, since this isn't supposed to happen! = 
 Missing mods: [mods] = 
+Could not load map! = 
 
 # Options
 
@@ -764,7 +765,6 @@ Clear resource =
 Requires = 
 Menu = 
 Brush Size = 
-Could not load map! = 
 
 # Civilopedia Tutorials names
 

--- a/core/src/com/unciv/Constants.kt
+++ b/core/src/com/unciv/Constants.kt
@@ -58,4 +58,8 @@ object Constants {
 
     const val asciiEscape = '\u001B'        // Character Escape (not to be confused with Input.Keys.ESCAPE, a virtual key code)
     const val asciiDelete = '\u007F'        // Character Delete
+    const val asciiCtrlC  = '\u0003'        // Control-C: Save game to Clipboard
+    const val asciiCtrlV  = '\u0016'        // Control-V: Load game from Clipboard
+    const val asciiCtrlX  = '\u0018'        // Control-X: ?
+
 }

--- a/core/src/com/unciv/Constants.kt
+++ b/core/src/com/unciv/Constants.kt
@@ -55,4 +55,7 @@ object Constants {
 
     const val cancelImprovementOrder = "Cancel improvement order"
     const val tutorialPopupNamePrefix = "Tutorial: "
+
+    const val asciiEscape = '\u001B'        // Character Escape (not to be confused with Input.Keys.ESCAPE, a virtual key code)
+    const val asciiDelete = '\u007F'        // Character Delete
 }

--- a/core/src/com/unciv/Constants.kt
+++ b/core/src/com/unciv/Constants.kt
@@ -60,6 +60,6 @@ object Constants {
     const val asciiDelete = '\u007F'        // Character Delete
     const val asciiCtrlC  = '\u0003'        // Control-C: Save game to Clipboard
     const val asciiCtrlV  = '\u0016'        // Control-V: Load game from Clipboard
-    const val asciiCtrlX  = '\u0018'        // Control-X: ?
+    const val asciiNull   = '\u0000'        // keyPressed sends this for function keys
 
 }

--- a/core/src/com/unciv/ui/LanguagePickerScreen.kt
+++ b/core/src/com/unciv/ui/LanguagePickerScreen.kt
@@ -2,6 +2,7 @@ package com.unciv.ui
 
 import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.scenes.scene2d.Touchable
+import com.badlogic.gdx.scenes.scene2d.ui.ScrollPane
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.unciv.UncivGame
 import com.unciv.models.translations.tr
@@ -29,19 +30,22 @@ class LanguageTable(val language:String, val percentComplete: Int):Table(){
         pack()
     }
 
-    fun update(chosenLanguage:String){
+    fun update(chosenLanguage:String, scrollPane: ScrollPane? = null){
         background = ImageGetter.getBackground( if(chosenLanguage==language) blue else darkBlue)
+        if (chosenLanguage==language) {
+            scrollPane?.scrollTo (x, y, width, height)
+        }
     }
 
 }
 
-class LanguagePickerScreen: PickerScreen(){
+class LanguagePickerScreen: PickerScreen() {
     var chosenLanguage = "English"
 
     private val languageTables = ArrayList<LanguageTable>()
 
     fun update(){
-        languageTables.forEach { it.update(chosenLanguage) }
+        languageTables.forEach { it.update(chosenLanguage, scrollPane) }
     }
 
     init {
@@ -62,16 +66,17 @@ class LanguagePickerScreen: PickerScreen(){
                 .sortedByDescending { it.percentComplete} )
 
         languageTables.forEach {
-            it.onClick {
+            val action = {
                 chosenLanguage = it.language
                 rightSideButton.enable()
                 update()
             }
+            it.onClick (action)
+            registerKeyHandler (it.language, action)
             topTable.add(it).pad(10f).row()
         }
 
-        rightSideButton.setText("Pick language".tr())
-        rightSideButton.onClick {
+        setAcceptButtonAction ("Pick language") {
             pickLanguage()
         }
     }

--- a/core/src/com/unciv/ui/pickerscreens/GreatPersonPickerScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/GreatPersonPickerScreen.kt
@@ -1,6 +1,7 @@
 package com.unciv.ui.pickerscreens
 
 import com.badlogic.gdx.scenes.scene2d.ui.Button
+import com.badlogic.gdx.scenes.scene2d.ui.Label
 import com.unciv.UncivGame
 import com.unciv.logic.civilization.CivilizationInfo
 import com.unciv.logic.civilization.GreatPersonManager
@@ -9,14 +10,12 @@ import com.unciv.models.ruleset.unit.BaseUnit
 import com.unciv.models.translations.tr
 import com.unciv.ui.utils.ImageGetter
 import com.unciv.ui.utils.onClick
-import com.unciv.ui.utils.toLabel
 
 class GreatPersonPickerScreen(val civInfo:CivilizationInfo) : PickerScreen() {
     private var theChosenOne: BaseUnit? = null
 
     init {
-        closeButton.isVisible=false
-        rightSideButton.setText("Choose a free great person".tr())
+        closeButton.isVisible = false
 
         val greatPersonNames = GreatPersonManager().statToGreatPersonMapping.values
                 .union(listOf("Great General"))
@@ -25,24 +24,27 @@ class GreatPersonPickerScreen(val civInfo:CivilizationInfo) : PickerScreen() {
         {
             val button = Button(skin)
 
+            val unitTranslated = unit.name.tr()
+            val unitDescription = unit.getShortDescription()
             button.add(ImageGetter.getUnitIcon(unit.name)).size(30f).pad(10f)
-            button.add(unit.name.toLabel()).pad(10f)
+            button.add(Label(unitTranslated,skin)).pad(10f)
             button.pack()
-            button.onClick {
+            val action = {
                 theChosenOne = unit
-                val unitDescription=HashSet<String>()
-                unit.uniques.forEach { unitDescription.add(it.tr()) }
-                pick("Get ".tr() +unit.name.tr())
-                descriptionLabel.setText(unitDescription.joinToString())
+                pick("Get ".tr() + unitTranslated)
+                descriptionLabel.setText(unitDescription)
             }
+            button.onClick (UncivSound.Choir, action)
+            registerKeyHandler (unitTranslated, action)
             topTable.add(button).pad(10f).row()
         }
 
-        rightSideButton.onClick(UncivSound.Choir) {
+        val action = {
             civInfo.placeUnitNearTile(civInfo.cities[0].location, theChosenOne!!.name)
             civInfo.greatPeople.freeGreatPeople--
             UncivGame.Current.setWorldScreen()
         }
+        setAcceptButtonAction("Choose a free great person", UncivSound.Choir, action)
 
     }
 }

--- a/core/src/com/unciv/ui/pickerscreens/ImprovementPickerScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/ImprovementPickerScreen.kt
@@ -5,7 +5,6 @@ import com.badlogic.gdx.scenes.scene2d.Group
 import com.badlogic.gdx.scenes.scene2d.Touchable
 import com.badlogic.gdx.scenes.scene2d.ui.Button
 import com.badlogic.gdx.scenes.scene2d.ui.Table
-import com.badlogic.gdx.scenes.scene2d.ui.VerticalGroup
 import com.badlogic.gdx.utils.Align
 import com.unciv.Constants
 import com.unciv.logic.map.RoadStatus
@@ -37,8 +36,7 @@ class ImprovementPickerScreen(tileInfo: TileInfo, onAccept: ()->Unit) : PickerSc
             }
         }
 
-        rightSideButton.setText("Pick improvement".tr())
-        rightSideButton.onClick {
+        setAcceptButtonAction("Pick improvement") {
             accept(selectedImprovement)
         }
 
@@ -68,12 +66,14 @@ class ImprovementPickerScreen(tileInfo: TileInfo, onAccept: ()->Unit) : PickerSc
             group.add(labelText.toLabel()).pad(10f)
 
             group.touchable = Touchable.enabled
-            group.onClick {
+            val action = {
                 selectedImprovement = improvement
                 pick(improvement.name.tr())
                 val ruleSet = tileInfo.tileMap.gameInfo.ruleSet
                 descriptionLabel.setText(improvement.getDescription(ruleSet))
             }
+            group.onClick (action)
+            registerKeyHandler (labelText, action)
 
             val pickNow = "Pick now!".toLabel()
             pickNow.onClick {

--- a/core/src/com/unciv/ui/pickerscreens/PickerScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/PickerScreen.kt
@@ -70,12 +70,14 @@ open class PickerScreen : CameraStageBaseScreen() {
 
         keyListener = getKeyboardListener()
         keyPressDispatcher = hashMapOf()
+        UncivGame.Current.worldScreen.pauseWASDListener = true
         stage.addListener(keyListener)
     }
 
     override fun dispose() {
         @Suppress ("UNNECESSARY_SAFE_CALL")
             stage?.removeListener(keyListener)    // Compiler says cannot ever be null but ?. is still necessary
+        UncivGame.Current.worldScreen.pauseWASDListener = false
         super.dispose()
     }
 

--- a/core/src/com/unciv/ui/pickerscreens/PickerScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/PickerScreen.kt
@@ -1,10 +1,18 @@
 package com.unciv.ui.pickerscreens
 
+import com.badlogic.gdx.Input
+import com.badlogic.gdx.scenes.scene2d.InputEvent
+import com.badlogic.gdx.scenes.scene2d.InputListener
+import com.badlogic.gdx.scenes.scene2d.Touchable
 import com.unciv.ui.utils.AutoScrollPane as ScrollPane
 import com.badlogic.gdx.scenes.scene2d.ui.*
+import com.unciv.Constants
 import com.unciv.UncivGame
+import com.unciv.models.UncivSound
 import com.unciv.models.translations.tr
 import com.unciv.ui.utils.*
+import kotlin.math.absoluteValue
+import kotlin.math.sign
 
 open class PickerScreen : CameraStageBaseScreen() {
 
@@ -17,6 +25,23 @@ open class PickerScreen : CameraStageBaseScreen() {
     var bottomTable:Table = Table()
     internal var splitPane: SplitPane
     protected var scrollPane: ScrollPane
+    private val closeAction = {
+        game.setWorldScreen()
+        dispose()
+    }
+    private var keyListener: InputListener
+    private data class KeyPressDispatcherEntry (val actions: MutableList<() -> Unit> = mutableListOf(), var next: Int = 0 )
+    private val keyPressDispatcher: HashMap<Char,KeyPressDispatcherEntry>
+    private val markedCharRegex = Regex("""_([\w])_""")
+    private data class ArrowActionEntry (val action: ()->Unit, val x: Int, val y: Int, val index: Int)
+    private var arrowIndex = -1
+    private val arrowActionList = ArrayList<ArrowActionEntry>()
+    private val arrowListIsCircular: Boolean by lazy {
+        arrowActionList.all { it.x == 0 && it.y == it.index }
+    }
+    var arrowKeyStraightLineBias = 2        // added to 'distance' if it's not in a direct horizontal or vertical line
+    var arrowKeyWrongQuadrantBias = 12      // distance multiplicator if incorrect general direction
+    var arrowKeyThreshold = 12              // cutoff - virtual weighted distances greater than this are not considered at all
 
     init {
         bottomTable.add(closeButton).pad(10f)
@@ -42,17 +67,160 @@ open class PickerScreen : CameraStageBaseScreen() {
         splitPane.splitAmount = screenSplit
         splitPane.setFillParent(true)
         stage.addActor(splitPane)
+
+        keyListener = getKeyboardListener()
+        keyPressDispatcher = hashMapOf()
+        stage.addListener(keyListener)
     }
 
-    fun setDefaultCloseAction() {
-        closeButton.onClick {
-            game.setWorldScreen()
-            dispose()
+    override fun dispose() {
+        @Suppress ("UNNECESSARY_SAFE_CALL")
+            stage?.removeListener(keyListener)    // Compiler says cannot ever be null but ?. is still necessary
+        super.dispose()
+    }
+
+    private fun getKeyboardListener(): InputListener = object : InputListener() {
+        override fun keyTyped(event: InputEvent?, character: Char): Boolean {
+            //println("PickerScreen keyTyped ('$character' ${character.toInt()})")
+            return keyPressed(character.toLowerCase()) || super.keyTyped(event, character)
         }
+
+        override fun keyUp(event: InputEvent?, keycode: Int): Boolean {
+            return when (keycode) {
+                Input.Keys.UP -> arrowPressed (0,-1)
+                Input.Keys.DOWN -> arrowPressed (0,1)
+                Input.Keys.LEFT -> arrowPressed (-1,0)
+                Input.Keys.RIGHT -> arrowPressed (1,0)
+                else -> super.keyUp(event, keycode)
+            }
+        }
+    }
+
+    private fun keyPressed (char: Char): Boolean {
+        if (char !in keyPressDispatcher) return false
+        val keyEntry = keyPressDispatcher[char]!!
+        if (keyEntry.actions.isNotEmpty()) {
+            // When there are more than one handler for a key, do a round-robin
+            keyEntry.actions[keyEntry.next].invoke()
+            keyEntry.next = (keyEntry.next + 1) %  keyEntry.actions.size
+        }
+        // All other key handlers get their round-robin reset
+        keyPressDispatcher.values.forEach {
+            if (it !== keyEntry) it.next = 0
+        }
+        return true
+    }
+
+    private fun arrowPressed(directionX: Int, directionY: Int): Boolean {
+        if (arrowActionList.size == 0) return false
+        var newIndex = arrowIndex
+        if (arrowIndex < 0) {
+            newIndex = if (arrowListIsCircular && directionY == -1) arrowActionList.size - 1 else 0
+        } else if (arrowListIsCircular) {
+            if (directionY!=0) {
+                newIndex = (arrowIndex + directionY + arrowActionList.size) % arrowActionList.size
+            }
+        } else {
+            val currentX = arrowActionList[arrowIndex].x
+            val currentY = arrowActionList[arrowIndex].y
+            var bestDistance = arrowKeyThreshold
+            arrowActionList.forEach {
+                val deltaX = (it.x - currentX).absoluteValue
+                val deltaY = (it.y - currentY).absoluteValue
+                if (deltaX > 0 || deltaY > 0) {
+                    // In which general direction is this? Ensure the diagonals count for both possible directions
+                    val vX = if (deltaX > deltaY || deltaX == deltaY && directionX != 0) (it.x - currentX).sign else 0
+                    val vY = if (deltaY > deltaX || deltaX == deltaY && directionY != 0) (it.y - currentY).sign else 0
+                    // more of a 'closest to user expectation' than an actual distance
+                    val distance =
+                            deltaX * (if (vX == directionX) 1 else arrowKeyWrongQuadrantBias) +     // malus for wrong quadrant
+                            (if (directionX == 0 && deltaX == 0) 0 else arrowKeyStraightLineBias) + // bonus for straight vertical
+                            deltaY * (if (vY == directionY) 1 else arrowKeyWrongQuadrantBias) +     // malus for wrong quadrant
+                            (if (directionY == 0 && deltaY == 0) 0 else arrowKeyStraightLineBias)   // bonus for straight horizontal
+                    if (distance < bestDistance) {
+                        bestDistance = distance
+                        newIndex = it.index
+                    }
+                }
+            }
+        }
+        if (newIndex == arrowIndex) return false
+        arrowIndex = newIndex
+        arrowActionList[newIndex].action()
+        return true
+    }
+
+    fun setDefaultCloseAction() = setCloseAction(closeAction)
+    fun setCloseAction(action: () -> Unit) {
+        closeButton.onClick(action)
+        registerKeyHandler (Constants.asciiEscape, action)
+    }
+
+    // Label the accept button and associate an accept action (right button click or enter key)
+    fun setAcceptButtonAction (buttonText: String, sound: UncivSound, action: () -> Unit) {
+        rightSideButton.setText (buttonText.tr())
+        rightSideButton.onClick (sound, action)
+        registerKeyHandler('\r', { if (rightSideButton.touchable == Touchable.enabled) action.invoke() })
+    }
+    fun setAcceptButtonAction (buttonText: String, action: () -> Unit) {
+        setAcceptButtonAction (buttonText, UncivSound.Click, action)
     }
 
     protected fun pick(rightButtonText: String) {
         if(UncivGame.Current.worldScreen.isPlayersTurn) rightSideButton.enable()
         rightSideButton.setText(rightButtonText)
     }
+
+    // Forget registered key handlers except accept and close
+    fun clearKeyHandlers() {
+        val delKeys = keyPressDispatcher.keys.filter { it!='\r' && it!=Constants.asciiEscape }
+        delKeys.forEach { keyPressDispatcher.remove(it) }
+    }
+
+    // Register a new key handler for a specific character
+    // One key can have multiple actions associated, and new actions can go either to the end or the beginning of the list.
+    // The listener will 'play' these actions (when the same key is pressed repeatedly)
+    // in a round-robin fashion beginning at the head of the list. All other key handlers will be
+    // reset to the beginnings of their respective lists.
+    fun registerKeyHandler(char: Char, action: () -> Unit, priority: Boolean = false) {
+        val charLower = char.toLowerCase()
+        when {
+            charLower !in keyPressDispatcher ->
+                keyPressDispatcher[charLower] = KeyPressDispatcherEntry(mutableListOf(action))
+            priority ->
+                keyPressDispatcher[charLower]!!.actions.add(0, action)
+            else ->
+                keyPressDispatcher[charLower]!!.actions += action
+        }
+    }
+
+    // Register a key handler for a selectable item
+    // Input: label - e.g. the string used as labeling a choice.
+    // Passing a label text directly is just a suggestion - only one character is extracted.
+    // If the string contains a pattern like _X_ then the handler is registered for key "X"
+    // with priority (it goes to the head of the action list for that key).
+    // Otherwise, if the string begins with a letter or digit, that character is registered but
+    // goes to the end of the action list.
+    // Actions registered this way will also be selectable using the Up/Down keys - so
+    // it is assumed the supplied action will give a visual feedback.
+    // If this doesn't fit your Picker, use setKeyHandler(Char) only.
+    // The overload accepting x and y coordinates enables 2D navigation using all four arrow
+    // keys, the x/y pairs need not have any specific meaning except expressing a spatial relationship
+    // so the user's concept of 'direction' associated with the arrows doesn't get disapponted.
+    fun registerKeyHandler(label: String, action: () -> Unit) =
+            registerKeyHandler (label, action, 0, arrowActionList.size, false)
+    fun registerKeyHandler(label: String, action: () -> Unit, x: Int, y: Int) =
+            registerKeyHandler (label, action, x, y, false)
+    fun registerKeyHandler(label: String, action: () -> Unit, x: Int, y: Int, selected: Boolean) {
+        val matchResult = markedCharRegex.find(label)
+        when {
+            matchResult != null ->
+                registerKeyHandler (matchResult.groups[1]!!.value[0], action, priority = true)
+            label[0].isLetterOrDigit() ->
+                registerKeyHandler (label[0], action)
+        }
+        if (selected) arrowIndex = arrowActionList.size
+        arrowActionList += ArrowActionEntry (action, x, y, arrowActionList.size)
+    }
+
 }

--- a/core/src/com/unciv/ui/saves/SaveGameScreen.kt
+++ b/core/src/com/unciv/ui/saves/SaveGameScreen.kt
@@ -2,10 +2,9 @@ package com.unciv.ui.saves
 
 import com.unciv.ui.utils.AutoScrollPane as ScrollPane
 import com.badlogic.gdx.Gdx
-import com.badlogic.gdx.scenes.scene2d.Actor
 import com.badlogic.gdx.scenes.scene2d.ui.*
-import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener
 import com.badlogic.gdx.utils.Json
+import com.unciv.Constants
 import com.unciv.UncivGame
 import com.unciv.logic.GameSaver
 import com.unciv.models.translations.tr
@@ -31,31 +30,32 @@ class SaveGameScreen : PickerScreen() {
         val newSave = Table()
         val defaultSaveName = game.gameInfo.currentPlayer+" -  "+game.gameInfo.turns+" turns"
         textField.text = defaultSaveName
+        textField.selectAll()
 
         newSave.add("Saved game name".toLabel()).row()
         newSave.add(textField).width(300f).pad(10f).row()
 
         val copyJsonButton = TextButton("Copy to clipboard".tr(),skin)
-        copyJsonButton.onClick {
+        val copyClipboardAction = {
             val json = Json().toJson(game.gameInfo)
             val base64Gzip = Gzip.zip(json)
             Gdx.app.clipboard.contents =  base64Gzip
         }
-        newSave.add(copyJsonButton).row()
-
+        copyJsonButton.onClick (copyClipboardAction)
+        newSave.add(copyJsonButton).pad(5f).row()
+        registerKeyHandler(Constants.asciiCtrlC, copyClipboardAction)
 
         val showAutosavesCheckbox = CheckBox("Show autosaves".tr(), skin)
         showAutosavesCheckbox.isChecked = false
         showAutosavesCheckbox.onChange {
                 updateShownSaves(showAutosavesCheckbox.isChecked)
             }
-        newSave.add(showAutosavesCheckbox).row()
+        newSave.add(showAutosavesCheckbox).pad(5f).row()
 
         topTable.add(newSave)
         topTable.pack()
 
-        rightSideButton.setText("Save game".tr())
-        rightSideButton.onClick {
+        setAcceptButtonAction("Save game") {
             rightSideButton.setText("Saving...".tr())
             thread(name="SaveGame"){
                 GameSaver.saveGame(UncivGame.Current.gameInfo, textField.text)
@@ -63,10 +63,13 @@ class SaveGameScreen : PickerScreen() {
             }
         }
         rightSideButton.enable()
+
+        stage.keyboardFocus = textField
     }
 
     fun updateShownSaves(showAutosaves:Boolean){
         currentSaves.clear()
+        clearKeyHandlers()
         val saves = GameSaver.getSaves()
                 .sortedByDescending { GameSaver.getSave(it).lastModified() }
         for (saveGameName in saves) {

--- a/core/src/com/unciv/ui/utils/Popup.kt
+++ b/core/src/com/unciv/ui/utils/Popup.kt
@@ -50,11 +50,13 @@ open class Popup(val screen: CameraStageBaseScreen): Table(CameraStageBaseScreen
         screen.stage.addActor(this)
         pack()
         center(screen.stage)
+        (screen as? WorldScreen)?.pauseWASDListener = true
         stage.addListener(keyListener)
     }
 
     open fun close() {
         stage?.removeListener(keyListener)
+        (screen as? WorldScreen)?.pauseWASDListener = false
         remove()
         if (screen.popups.isNotEmpty()) screen.popups[0].isVisible = true
     }

--- a/core/src/com/unciv/ui/utils/YesNoPopup.kt
+++ b/core/src/com/unciv/ui/utils/YesNoPopup.kt
@@ -1,14 +1,12 @@
 package com.unciv.ui.utils
 
-import com.badlogic.gdx.scenes.scene2d.ui.TextButton
 import com.unciv.UncivGame
-import com.unciv.models.translations.tr
 
 class YesNoPopup(question:String, action:()->Unit,
-                 screen: CameraStageBaseScreen = UncivGame.Current.worldScreen, restoredefault:()->Unit = {}) : Popup(screen){
+                 screen: CameraStageBaseScreen = UncivGame.Current.worldScreen, restoreDefault:()->Unit = {}) : Popup(screen){
     init{
         add(question.toLabel()).colspan(2).row()
-        add(TextButton("No".tr(), skin).onClick { close(); restoredefault() })
-        add(TextButton("Yes".tr(), skin).onClick { close(); action() })
+        addInlineButton("No") { close(); restoreDefault() }
+        addInlineButton("Yes") { close(); action() }
     }
 }

--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -64,6 +64,7 @@ class WorldScreen(val viewingCiv:CivilizationInfo) : CameraStageBaseScreen() {
     var shouldUpdate = false
 
     private var backButtonListener : InputListener
+    var pauseWASDListener = false
 
     // An initialized val always turned out to illegally be null...
     lateinit var keyPressDispatcher: HashMap<Char,(() -> Unit)>
@@ -160,7 +161,7 @@ class WorldScreen(val viewingCiv:CivilizationInfo) : CameraStageBaseScreen() {
                 private val ALLOWED_KEYS = setOf(Input.Keys.W,Input.Keys.S,Input.Keys.A,Input.Keys.D)
 
                 override fun keyDown(event: InputEvent?, keycode: Int): Boolean {
-                    if (keycode !in ALLOWED_KEYS) return false
+                    if (keycode !in ALLOWED_KEYS || pauseWASDListener) return false
 
                     pressedKeys.add(keycode)
                     if (infiniteAction == null) {
@@ -172,6 +173,17 @@ class WorldScreen(val viewingCiv:CivilizationInfo) : CameraStageBaseScreen() {
                 }
 
                 fun whileKeyPressedLoop() {
+                    if (pauseWASDListener || pressedKeys.isEmpty()) {
+                        pressedKeys.clear()
+                        if (infiniteAction != null) {
+                            // stop the loop otherwise it keeps going even after removal
+                            infiniteAction?.finish()
+                            // remove and nil the action
+                            mapHolder.removeAction(infiniteAction)
+                            infiniteAction = null
+                        }
+                        return
+                    }
                     for (keycode in pressedKeys) {
                         when (keycode) {
                             Input.Keys.W -> mapHolder.scrollY -= amountToMove
@@ -185,15 +197,7 @@ class WorldScreen(val viewingCiv:CivilizationInfo) : CameraStageBaseScreen() {
 
                 override fun keyUp(event: InputEvent?, keycode: Int): Boolean {
                     if (keycode !in ALLOWED_KEYS) return false
-
                     pressedKeys.remove(keycode)
-                    if (infiniteAction != null && pressedKeys.isEmpty()) {
-                        // stop the loop otherwise it keeps going even after removal
-                        infiniteAction?.finish()
-                        // remove and nil the action
-                        mapHolder.removeAction(infiniteAction)
-                        infiniteAction = null
-                    }
                     return true
                 }
 

--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -35,6 +35,7 @@ import com.unciv.ui.utils.*
 import com.unciv.ui.worldscreen.bottombar.BattleTable
 import com.unciv.ui.worldscreen.bottombar.TileInfoTable
 import com.unciv.ui.worldscreen.mainmenu.OnlineMultiplayer
+import com.unciv.ui.worldscreen.mainmenu.WorldScreenMenuPopup
 import com.unciv.ui.worldscreen.unit.UnitActionsTable
 import com.unciv.ui.worldscreen.unit.UnitTable
 import kotlin.concurrent.thread
@@ -202,6 +203,11 @@ class WorldScreen(val viewingCiv:CivilizationInfo) : CameraStageBaseScreen() {
                 }
 
                 override fun keyTyped(event: InputEvent?, character: Char): Boolean {
+                    if (character == Constants.asciiNull && event?.keyCode == Input.Keys.F12) {
+                        if (popups.none { it is WorldScreenMenuPopup })
+                            WorldScreenMenuPopup(this@WorldScreen).open(force = true)
+                        return true
+                    }
                     if (character.toLowerCase() in keyPressDispatcher && !hasOpenPopups()) {
                         //try-catch mainly for debugging. Breakpoints in the vicinity can make the event fire twice in rapid succession, second time the context can be invalid
                         try {

--- a/core/src/com/unciv/ui/worldscreen/mainmenu/WorldScreenMenuPopup.kt
+++ b/core/src/com/unciv/ui/worldscreen/mainmenu/WorldScreenMenuPopup.kt
@@ -100,9 +100,10 @@ class WorldScreenMenuPopup(val worldScreen: WorldScreen) : Popup(worldScreen) {
         mapEditorPopup.addButton("Load map") {
             val loadMapScreen = LoadMapScreen(null)
             loadMapScreen.closeButton.isVisible = true
-            loadMapScreen.closeButton.onClick {
+            loadMapScreen.setCloseAction {
                 UncivGame.Current.setWorldScreen()
-                loadMapScreen.dispose() }
+                loadMapScreen.dispose()
+            }
             UncivGame.Current.setScreen(loadMapScreen)
             mapEditorPopup.close()
         }

--- a/core/src/com/unciv/ui/worldscreen/mainmenu/WorldScreenMenuPopup.kt
+++ b/core/src/com/unciv/ui/worldscreen/mainmenu/WorldScreenMenuPopup.kt
@@ -23,60 +23,60 @@ class WorldScreenMenuPopup(val worldScreen: WorldScreen) : Popup(worldScreen) {
     init {
         val width = 200f
         val height = 30f
-        addSquareButton("Map editor".tr()){
+        addSquareButton("Map editor") {
             openMapEditorPopup()
             close()
         }.size(width,height)
         addSeparator()
 
-        addSquareButton("Civilopedia".tr()){
+        addSquareButton("Civilopedia") {
             UncivGame.Current.setScreen(CivilopediaScreen(worldScreen.gameInfo.ruleSet))
             close()
         }.size(width,height)
         addSeparator()
 
-        addSquareButton("Load game".tr()){
+        addSquareButton("Load game") {
             UncivGame.Current.setScreen(LoadGameScreen())
             close()
         }.size(width,height)
         addSeparator()
 
-        addSquareButton("Save game".tr()){
+        addSquareButton("Save game") {
             UncivGame.Current.setScreen(SaveGameScreen())
             close()
         }.size(width,height)
         addSeparator()
 
-        addSquareButton("Start new game".tr()){ 
+        addSquareButton("Start new game") {
             UncivGame.Current.setScreen(NewGameScreen()) 
         }.size(width,height)
         addSeparator()
 
-        addSquareButton("Multiplayer".tr()){
+        addSquareButton("Multiplayer") {
             UncivGame.Current.setScreen(MultiplayerScreen()) 
             close()
         }.size(width,height)
         addSeparator()
 
-        addSquareButton("Victory status".tr()){ 
+        addSquareButton("Victory status") {
             UncivGame.Current.setScreen(VictoryScreen())
             close()
         }.size(width,height)
         addSeparator()
 
-        addSquareButton("Options".tr()){
+        addSquareButton("Options") {
             WorldScreenOptionsPopup(worldScreen).open(force = true)
             close()
         }.size(width,height)
         addSeparator()
 
-        addSquareButton("Community"){
+        addSquareButton("Community") {
             WorldScreenCommunityPopup(worldScreen).open(force = true)
             close()
         }.size(width,height)
         addSeparator()
 
-        addSquareButton("Close"){
+        addSquareButton("Close") {
             close()
         }.size(width,height)
     }

--- a/core/src/com/unciv/ui/worldscreen/unit/UnitActionsTable.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitActionsTable.kt
@@ -89,7 +89,7 @@ class UnitActionsTable(val worldScreen: WorldScreen) : Table(){
         actionButton.add(iconAndKey.Icon).size(20f).pad(5f)
         val fontColor = if(unitAction.isCurrentAction) Color.YELLOW else Color.WHITE
         actionButton.add(unitAction.title.toLabel(fontColor)).pad(5f)
-        if (iconAndKey.key != 0.toChar()) {
+        if (iconAndKey.key != Constants.asciiNull) {
             val keyLabel = "(${iconAndKey.key.toUpperCase()})".toLabel(Color.WHITE).apply { isVisible = false }
             actionButton.add(keyLabel)
             actionButton.addListener(UnitActionButtonOnHoverListener(actionButton, keyLabel))
@@ -102,7 +102,7 @@ class UnitActionsTable(val worldScreen: WorldScreen) : Table(){
         if (unitAction.action == null) actionButton.disable()
         else {
             actionButton.onClick(unitAction.uncivSound,action)
-            if (iconAndKey.key != 0.toChar())
+            if (iconAndKey.key != Constants.asciiNull)
                 worldScreen.keyPressDispatcher[iconAndKey.key] = action
         }
 


### PR DESCRIPTION
### Request for comments on architectural aspects
This works so far, but I'm not happy about some aspects:

* The way I used to keep the WASD feature from interfering
* Similar but not identical implementation in two places: PickerScreen and Popup
* My implementation to better visualize what's selected in Promotion and Policy
* No visualization which keys do what. Yet. Big enough for now.

[WASD]: Being able to scroll the map under the main menu was cool, however if you want 'S' to now go to the Savegame screen...
Found no solution or a better workaround. Bugs be to no end. No success with removeListener, keyboardFocus= or other approaches. Ideas?

[2 Places]: Would a consolidation be worthwhile? If so, subclass CameraStageBaseScreen then have the two subclass that?

[Selection visualization]: These were those screens where it was most obvious more feedback would be nice when moving selection with the arrow keys. Done by copy&paste instead of proper service in the framework. Implementation is mostly identical, so it _should_ go in PickerScreen - I just thad no idea for a clean efficient interface. Ideas? And aesthetics: Color.Goldenrod OK?

### Other notes
Main menu - most not all items went through .tr() and then .toLabel() which translates as well. I removed the first tr() and changed the toLabel() to tr() for my reuse. Yes should have gone separately.

F12 for the main menu - good choice? Or remap ESC and have 'leave game' as menu item? Other keys (but not Pause - that does fire keyPressed but with character and event.keycode zero)?

Key assignment: The framework does automatically assign keys, but I allowed for declarative assignment: Surround your letter with underscores in the translated string. I have included no example, however - best done separately. Doing so in json or hardcoded strings isn't strictly necessary, doing it in the translation files is enough - would work even for english. Also, I abused the tibit that '_' is missing from the character set so these would be invisible without coding their removal.

Auto-Keys in pickers: First character of the translated label if it's a \w one. I used framework .isLetterOrDigit so I hope that works in asian languages too - untested. Multiple instances of the same letter will all work and cycle through entries (nice in the tech picker - or try 'r' in the language picker).

Keys in popups: Autoassignment picks the first isLetterOrDigit from the translated label not yet used, top-down. Yes, can be surprising e.g. english main menu reacts to 'e' for Close (but that's on esc too). Still, I think the effect can be learned quickly.