### PR TITLE
Date and time shown bottom-left in load game should be international

### DIFF
--- a/android/assets/jsons/translations/Czech.properties
+++ b/android/assets/jsons/translations/Czech.properties
@@ -373,6 +373,7 @@ If you could copy your game data ("Copy saved game to clipboard" -  = Pokud byst
   paste into an email to yairm210@hotmail.com) =  vložit do e-mailu pro yairm210@hotmail.com)
 I could maybe help you figure out what went wrong, since this isn't supposed to happen! = mohl bych možná zjistit, co se pokazilo, protože tohle by se stávat nemělo!
 Missing mods: [mods] = Chybějící mody: [mods]
+yyyy-MM-dd HH.mm = dd.MM.yyyy HH:mm
 
 # Options
 

--- a/android/assets/jsons/translations/Dutch.properties
+++ b/android/assets/jsons/translations/Dutch.properties
@@ -635,6 +635,7 @@ If you could copy your game data ("Copy saved game to clipboard" -  =
 I could maybe help you figure out what went wrong, since this isn't supposed to happen! = 
  # Requires translation!
 Missing mods: [mods] = 
+yyyy-MM-dd HH.mm = dd-MM-yyyy HH:mm
 
 # Options
 

--- a/android/assets/jsons/translations/English.properties
+++ b/android/assets/jsons/translations/English.properties
@@ -677,6 +677,9 @@ I could maybe help you figure out what went wrong, since this isn't supposed to 
  # Requires translation!
 Missing mods: [mods] = 
 
+# UK would be dd/MM/yy HH:mm or BS ISO 8601:2004
+yyyy-MM-dd HH.mm = MM/dd/yy hh:mm a
+
 # Options
 
  # Requires translation!

--- a/android/assets/jsons/translations/French.properties
+++ b/android/assets/jsons/translations/French.properties
@@ -373,6 +373,7 @@ If you could copy your game data ("Copy saved game to clipboard" -  = Si vous po
   paste into an email to yairm210@hotmail.com) = coller dans un email à yairm210@hotmail.com)
 I could maybe help you figure out what went wrong, since this isn't supposed to happen! = je tenterai de résoudre ce problème : cela n'est pas censé arriver !
 Missing mods: [mods] = Mods manquants : [mods]
+yyyy-MM-dd HH.mm = dd/MM/yy HH:mm
 
 # Options
 

--- a/android/assets/jsons/translations/German.properties
+++ b/android/assets/jsons/translations/German.properties
@@ -373,6 +373,7 @@ If you could copy your game data ("Copy saved game to clipboard" -  = Wenn Sie d
   paste into an email to yairm210@hotmail.com) =   und in eine mail an mich (yairm210@hotmail.com) einfügen,
 I could maybe help you figure out what went wrong, since this isn't supposed to happen! = dann kann ich eventuell helfen den Grund zu finden - das sollte nicht passieren!
 Missing mods: [mods] = Der Spielstand benötigt das/die mod(s) [mods], diese sind aber nicht verfügbar.
+yyyy-MM-dd HH.mm = dd.MM.yy HH:mm
 
 # Options
 

--- a/android/assets/jsons/translations/Indonesian.properties
+++ b/android/assets/jsons/translations/Indonesian.properties
@@ -417,6 +417,7 @@ If you could copy your game data ("Copy saved game to clipboard" -  =
 I could maybe help you figure out what went wrong, since this isn't supposed to happen! = 
  # Requires translation!
 Missing mods: [mods] = 
+yyyy-MM-dd HH.mm = dd-MM-yyyy HH:mm
 
 # Options
 

--- a/android/assets/jsons/translations/Italian.properties
+++ b/android/assets/jsons/translations/Italian.properties
@@ -373,6 +373,7 @@ If you could copy your game data ("Copy saved game to clipboard" -  = Prova a co
   paste into an email to yairm210@hotmail.com) = e incolla su un'email inviata a yairm210@hotmail.com).
 I could maybe help you figure out what went wrong, since this isn't supposed to happen! = Potrei aiutarti a capire cosa è andato storto, visto che questo errore è imprevisto!
 Missing mods: [mods] = Mod mancanti: [mods]
+yyyy-MM-dd HH.mm = dd/MM/yyyy HH:mm
 
 # Options
 

--- a/android/assets/jsons/translations/Japanese.properties
+++ b/android/assets/jsons/translations/Japanese.properties
@@ -407,6 +407,7 @@ If you could copy your game data ("Copy saved game to clipboard" -  =
 I could maybe help you figure out what went wrong, since this isn't supposed to happen! = 
  # Requires translation!
 Missing mods: [mods] = 
+yyyy-MM-dd HH.mm = yyyy年MM月dd日 HH.mm
 
 # Options
 

--- a/android/assets/jsons/translations/Korean.properties
+++ b/android/assets/jsons/translations/Korean.properties
@@ -452,6 +452,7 @@ If you could copy your game data ("Copy saved game to clipboard" -  =
 I could maybe help you figure out what went wrong, since this isn't supposed to happen! = 
  # Requires translation!
 Missing mods: [mods] = 
+yyyy-MM-dd HH.mm = yyyy-MM-dd HH.mm
 
 # Options
 

--- a/android/assets/jsons/translations/Malay.properties
+++ b/android/assets/jsons/translations/Malay.properties
@@ -628,6 +628,7 @@ If you could copy your game data ("Copy saved game to clipboard" -  =
 I could maybe help you figure out what went wrong, since this isn't supposed to happen! = 
  # Requires translation!
 Missing mods: [mods] = 
+yyyy-MM-dd HH.mm = dd-MM-yyyy HH.mm
 
 # Options
 

--- a/android/assets/jsons/translations/Polish.properties
+++ b/android/assets/jsons/translations/Polish.properties
@@ -373,6 +373,7 @@ If you could copy your game data ("Copy saved game to clipboard" -  = Gdybyś m�
   paste into an email to yairm210@hotmail.com) = a następnie wkleić je i wysłać na adres e-mail yairm210@hotmail.com)
 I could maybe help you figure out what went wrong, since this isn't supposed to happen! = Może byłbym wstanie pomóc dowiedzieć się co poszło nie tak, ponieważ nie powinno to mieć miejsca!.
 Missing mods: [mods] = Brakujące modyfikacje: [mods]
+yyyy-MM-dd HH.mm = dd.MM.yyyy HH.mm
 
 # Options
 

--- a/android/assets/jsons/translations/Portuguese.properties
+++ b/android/assets/jsons/translations/Portuguese.properties
@@ -447,6 +447,7 @@ If you could copy your game data ("Copy saved game to clipboard" -  =
 I could maybe help you figure out what went wrong, since this isn't supposed to happen! = 
  # Requires translation!
 Missing mods: [mods] = 
+yyyy-MM-dd HH.mm = dd/MM/yyyy HH.mm
 
 # Options
 

--- a/android/assets/jsons/translations/Romanian.properties
+++ b/android/assets/jsons/translations/Romanian.properties
@@ -474,6 +474,7 @@ If you could copy your game data ("Copy saved game to clipboard" -  =
 I could maybe help you figure out what went wrong, since this isn't supposed to happen! = 
  # Requires translation!
 Missing mods: [mods] = 
+yyyy-MM-dd HH.mm = dd.MM.yyyy HH.mm
 
 # Options
 

--- a/android/assets/jsons/translations/Russian.properties
+++ b/android/assets/jsons/translations/Russian.properties
@@ -379,6 +379,7 @@ If you could copy your game data ("Copy saved game to clipboard" -  =
 I could maybe help you figure out what went wrong, since this isn't supposed to happen! = 
  # Requires translation!
 Missing mods: [mods] = 
+yyyy-MM-dd HH.mm = dd.MM.yyyy HH.mm
 
 # Options
 

--- a/android/assets/jsons/translations/Simplified_Chinese.properties
+++ b/android/assets/jsons/translations/Simplified_Chinese.properties
@@ -382,6 +382,7 @@ If you could copy your game data ("Copy saved game to clipboard" -  = 如果可�
   paste into an email to yairm210@hotmail.com) = 
 I could maybe help you figure out what went wrong, since this isn't supposed to happen! = 我也许可以帮你找出哪里出了问题，因为这不应该发生！
 Missing mods: [mods] = Missing mods:[mods]
+yyyy-MM-dd HH.mm = yyyy-MM-dd HH.mm
 
 # Options
 

--- a/android/assets/jsons/translations/Spanish.properties
+++ b/android/assets/jsons/translations/Spanish.properties
@@ -435,6 +435,7 @@ If you could copy your game data ("Copy saved game to clipboard" -  =
 I could maybe help you figure out what went wrong, since this isn't supposed to happen! = 
  # Requires translation!
 Missing mods: [mods] = 
+yyyy-MM-dd HH.mm = dd/MM/yyyy HH.mm
 
 # Options
 

--- a/android/assets/jsons/translations/Thai.properties
+++ b/android/assets/jsons/translations/Thai.properties
@@ -498,6 +498,7 @@ Are you sure you want to delete this map? = อยากจะลบแผนท
 Upload map = อัพโหลดแผนที่
 Could not upload map! = ไม่สามารถอัพโหลดแผนที่ได้
 Map uploaded successfully! = อัพโหลดแผนที่สำเร็จแล้ว
+yyyy-MM-dd HH.mm = dd/MM/yyyy HH:mm
 
 # Options
 

--- a/android/assets/jsons/translations/Traditional_Chinese.properties
+++ b/android/assets/jsons/translations/Traditional_Chinese.properties
@@ -373,6 +373,7 @@ If you could copy your game data ("Copy saved game to clipboard" -  = 如果你�
   paste into an email to yairm210@hotmail.com) = 將複製的數據貼在給我的電郵 yairm210@hotmail.com )
 I could maybe help you figure out what went wrong, since this isn't supposed to happen! = 我能幫助你找出問題所在，因為對玩家造成困擾的問題是不應該發生的！
 Missing mods: [mods] = 模組遺失： [mods]
+yyyy-MM-dd HH.mm = yyyy年M月d日 HH.mm
 
 # Options
 

--- a/android/assets/jsons/translations/Turkish.properties
+++ b/android/assets/jsons/translations/Turkish.properties
@@ -381,6 +381,7 @@ If you could copy your game data ("Copy saved game to clipboard" -  =
 I could maybe help you figure out what went wrong, since this isn't supposed to happen! = 
  # Requires translation!
 Missing mods: [mods] = 
+yyyy-MM-dd HH.mm = dd.MM.yyyy HH.mm
 
 # Options
 

--- a/android/assets/jsons/translations/Ukrainian.properties
+++ b/android/assets/jsons/translations/Ukrainian.properties
@@ -373,6 +373,7 @@ If you could copy your game data ("Copy saved game to clipboard" -  = Якщо �
   paste into an email to yairm210@hotmail.com) = та вставити у лист до yairm210@hotmail.com)
 I could maybe help you figure out what went wrong, since this isn't supposed to happen! = Можливо, я зможу допомогти вам з'ясувати, що пішло не так, бо цього не мало трапитись!
 Missing mods: [mods] = Відсутні модифікації: [mods]
+yyyy-MM-dd HH.mm = dd.MM.yyyy HH.mm
 
 # Options
 

--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -373,6 +373,7 @@ If you could copy your game data ("Copy saved game to clipboard" -  =
   paste into an email to yairm210@hotmail.com) = 
 I could maybe help you figure out what went wrong, since this isn't supposed to happen! = 
 Missing mods: [mods] = 
+yyyy-MM-dd HH.mm = 
 
 # Options
 

--- a/core/src/com/unciv/ui/saves/LoadGameScreen.kt
+++ b/core/src/com/unciv/ui/saves/LoadGameScreen.kt
@@ -118,8 +118,9 @@ class LoadGameScreen : PickerScreen() {
                 copySavedGameToClipboardButton.enable()
                 var textToSet = save
 
+                // See also: https://en.wikipedia.org/wiki/Date_format_by_country
                 val savedAt = Date(GameSaver.getSave(save).lastModified())
-                textToSet += "\n{Saved at}: ".tr() + SimpleDateFormat("dd-MM-yy HH.mm").format(savedAt)
+                textToSet += "\n{Saved at}: ".tr() + SimpleDateFormat("yyyy-MM-dd HH.mm".tr()).format(savedAt)
                 try {
                     val game = GameSaver.loadGameByName(save)
                     val playerCivNames = game.civilizations.filter { it.isPlayerCivilization() }.joinToString { it.civName.tr() }


### PR DESCRIPTION
Tiny thing, ugly under the hood. 

The IDEA intentions tell you to use
  `DateFormat.getDateTimeInstance(DateFormat.SHORT,DateFormat.SHORT).format()` 
or something like that, but I have **_not_** been able to get that to work properly on my system. It would aways use en_US locale _even if directly fed_ Locale("de_DE") (Linux Mint 19 with LANGUAGE="en_US" _but_ LC_TIME="de_DE.UTF-8": Yes I detest miserable translations)...

So I tied the format into the translation system and looked each existing one up. Java will still modify the separator characters, pity, I can just hope the '.' for ':' replacements I have seen in testing are appropriate.

I would actually prefer Unciv to use ISO 8601, period.