### PR TITLE
Map name field adjusted, map saving exceptions shouldn't crash, threaded

### DIFF
--- a/core/src/com/unciv/ui/mapeditor/MapEditorMenuPopup.kt
+++ b/core/src/com/unciv/ui/mapeditor/MapEditorMenuPopup.kt
@@ -70,6 +70,7 @@ class MapEditorMenuPopup(mapEditorScreen: MapEditorScreen): Popup(mapEditorScree
                 }
             }
         }
+        saveMapButton.isEnabled = mapNameEditor.text.isNotEmpty()
         add(saveMapButton).row()
         mapNameEditor.addListener {
             mapEditorScreen.mapName = mapNameEditor.text

--- a/core/src/com/unciv/ui/mapeditor/MapEditorMenuPopup.kt
+++ b/core/src/com/unciv/ui/mapeditor/MapEditorMenuPopup.kt
@@ -12,6 +12,8 @@ import com.unciv.logic.map.RoadStatus
 import com.unciv.models.translations.tr
 import com.unciv.ui.saves.Gzip
 import com.unciv.ui.utils.Popup
+import com.unciv.ui.utils.enable
+import com.unciv.ui.utils.isEnabled
 import com.unciv.ui.utils.onClick
 import com.unciv.ui.worldscreen.mainmenu.DropBox
 import kotlin.concurrent.thread
@@ -19,8 +21,10 @@ import kotlin.concurrent.thread
 class MapEditorMenuPopup(mapEditorScreen: MapEditorScreen): Popup(mapEditorScreen){
     init{
         val mapNameEditor = TextField(mapEditorScreen.mapName, skin)
-        mapNameEditor.addListener{ mapEditorScreen.mapName=mapNameEditor.text; true }
-        add(mapNameEditor).row()
+        add(mapNameEditor).fillX().row()
+        mapNameEditor.selectAll()
+        mapNameEditor.maxLength = 240       // A few under max for most filesystems
+        mapEditorScreen.stage.keyboardFocus = mapNameEditor
 
         val newMapButton = TextButton("New map".tr(),skin)
         newMapButton.onClick {
@@ -51,10 +55,27 @@ class MapEditorMenuPopup(mapEditorScreen: MapEditorScreen): Popup(mapEditorScree
         saveMapButton.onClick {
             mapEditorScreen.tileMap.mapParameters.name=mapEditorScreen.mapName
             mapEditorScreen.tileMap.mapParameters.type=MapType.custom
-            MapSaver.saveMap(mapEditorScreen.mapName,mapEditorScreen.tileMap)
-            UncivGame.Current.setWorldScreen()
+            thread ( name = "SaveMap" ) {
+                try {
+                    MapSaver.saveMap(mapEditorScreen.mapName, mapEditorScreen.tileMap)
+                    UncivGame.Current.setWorldScreen()
+                } catch (ex: Exception) {
+                    ex.printStackTrace()
+                    Gdx.app.postRunnable {
+                        val cantLoadGamePopup = Popup(mapEditorScreen)
+                        cantLoadGamePopup.addGoodSizedLabel("It looks like your map can't be saved!").row()
+                        cantLoadGamePopup.addCloseButton()
+                        cantLoadGamePopup.open(force = true)
+                    }
+                }
+            }
         }
         add(saveMapButton).row()
+        mapNameEditor.addListener {
+            mapEditorScreen.mapName = mapNameEditor.text
+            saveMapButton.isEnabled = mapNameEditor.text.isNotEmpty()
+            true
+        }
 
         val copyMapAsTextButton = TextButton("Copy to clipboard".tr(), skin)
         copyMapAsTextButton.onClick {

--- a/core/src/com/unciv/ui/mapeditor/MapEditorScreen.kt
+++ b/core/src/com/unciv/ui/mapeditor/MapEditorScreen.kt
@@ -18,7 +18,7 @@ import com.unciv.ui.utils.setFontSize
 
 class MapEditorScreen(): CameraStageBaseScreen() {
     val ruleset = RulesetCache.getBaseRuleset()
-    var mapName = "My first map"
+    var mapName = ""
 
     var tileMap = TileMap()
     lateinit var mapHolder: EditorMapHolder

--- a/core/src/com/unciv/ui/utils/CameraStageBaseScreen.kt
+++ b/core/src/com/unciv/ui/utils/CameraStageBaseScreen.kt
@@ -113,7 +113,10 @@ fun Button.enable() {
     color = Color.WHITE
     touchable = Touchable.enabled
 }
-
+var Button.isEnabled: Boolean
+    //Todo: Use in PromotionPickerScreen, TradeTable, WorldScreen.updateNextTurnButton
+    get() = touchable == Touchable.enabled
+    set(value) = if (value) enable() else disable()
 
 fun colorFromRGB(r: Int, g: Int, b: Int): Color {
     return Color(r/255f, g/255f, b/255f, 1f)


### PR DESCRIPTION
Note: Game load / save + map load / save should all have the same thread-decoupling and exception handling. Right now there's some discrepancy.

* Should to/from clipboard be running on a thread?
* Map load runs in MapEditorScreen.constructor: Not a good place I think. Any input on how that might be tackled?

That convenience extension property on Button - I couldn't resist. I refrained from touching the other places where using it would be clearer for now, documented them instead. Surprising it's so few.