### PR TITLE
Civilopedia: Graphic decoration for terrain, fix movement/impassable

### DIFF
--- a/core/src/com/unciv/Constants.kt
+++ b/core/src/com/unciv/Constants.kt
@@ -5,6 +5,7 @@ object Constants {
     const val settler = "Settler"
     const val greatGeneral = "Great General"
 
+    const val impassable = "Impassable"
     const val ocean = "Ocean"
     const val coast = "Coast"
     const val mountain = "Mountain"

--- a/core/src/com/unciv/logic/map/TileInfo.kt
+++ b/core/src/com/unciv/logic/map/TileInfo.kt
@@ -363,7 +363,7 @@ open class TileInfo {
             if(!defencePercentString.startsWith("-")) defencePercentString = "+$defencePercentString"
             lineList += "[$defencePercentString] to unit defence".tr()
         }
-        if(getBaseTerrain().impassable) lineList += "Impassable".tr()
+        if(getBaseTerrain().impassable) lineList += Constants.impassable.tr()
 
         return lineList.joinToString("\n")
     }

--- a/core/src/com/unciv/models/ruleset/tile/Terrain.kt
+++ b/core/src/com/unciv/models/ruleset/tile/Terrain.kt
@@ -1,6 +1,7 @@
 package com.unciv.models.ruleset.tile
 
 import com.badlogic.gdx.graphics.Color
+import com.unciv.Constants
 import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.stats.NamedStats
 import com.unciv.models.translations.tr
@@ -23,7 +24,10 @@ class Terrain : NamedStats() {
         if(uniques.isNotEmpty())
             sb.appendln(uniques.joinToString { it.tr() })
 
-        sb.appendln("{Movement cost}: $movementCost".tr())
+        if (impassable)
+            sb.appendln(Constants.impassable.tr())
+        else
+            sb.appendln("{Movement cost}: $movementCost".tr())
 
         if (defenceBonus != 0f)
             sb.appendln("{Defence bonus}: ".tr() + (defenceBonus * 100).toInt() + "%")


### PR DESCRIPTION
Just a bit of visual sugar.

The detail that the hexes spill over their buttons and touch - I left it intentionally like that, I think it looks cute. Especially forest. (Hope spanish translation isn't 'arboles'...)

Also, the description for Mountains and N Wonders is more plausible, implemented right in Terrain since a - that method is only called by the civilopedia anyway and b - if someone uses it elsewhere in the future, it's likely that this will serve better.

Regarding refactoring - the code to get a fake TileInfo here should be unified with what the map editor does, and the code from TileEditorOptionsTable.makeTileGroup as well. Suggestions as to where exactly that should live? TileInfo.getSampleForTerrain(t) or Terrain.getSampleTileInfo()? Turn into an overloaded TileGroup constructor? Teach TileEditorOptionsTable not to recreate TileSetStrings() so often but cache it? (...)

![image](https://user-images.githubusercontent.com/63000004/79081662-c9b8a180-7d1f-11ea-91ec-233d21264002.png)

