### PR TITLE
Civilopedia: Changed geometry to make better use of screen

### DIFF
--- a/core/src/com/unciv/ui/CivilopediaScreen.kt
+++ b/core/src/com/unciv/ui/CivilopediaScreen.kt
@@ -35,29 +35,6 @@ class CivilopediaScreen(ruleset: Ruleset) : CameraStageBaseScreen() {
 
     init {
         onBackButtonClicked { UncivGame.Current.setWorldScreen() }
-        val buttonTable = Table()
-        buttonTable.pad(15f)
-        buttonTable.defaults().pad(10f)
-        val buttonTableScroll = ScrollPane(buttonTable)
-
-        val goToGameButton = TextButton("Close".tr(), skin)
-        goToGameButton.onClick {
-            game.setWorldScreen()
-            dispose()
-        }
-
-        val topTable = Table()
-        topTable.add(goToGameButton).pad(10f)
-        topTable.add(buttonTableScroll)
-
-        val entryTable = Table()
-        val splitPane = SplitPane(topTable, entryTable, true, skin)
-        splitPane.splitAmount = 0.2f
-        splitPane.setFillParent(true)
-
-        stage.addActor(splitPane)
-
-        description.setWrap(true)
 
         categoryToEntries["Buildings"] = ruleset.buildings.values
                 .map { CivilopediaEntry(it.name,it.getDescription(false, null,ruleset),
@@ -87,6 +64,10 @@ class CivilopediaScreen(ruleset: Ruleset) : CameraStageBaseScreen() {
         categoryToEntries["Tutorials"] = tutorialController.getCivilopediaTutorials()
                 .map { CivilopediaEntry(it.key.replace("_"," "), it.value.joinToString("\n\n") { line -> line.tr() }) }
 
+        val buttonTable = Table()
+        buttonTable.pad(15f)
+        buttonTable.defaults().pad(10f)
+
         for (category in categoryToEntries.keys) {
             val button = TextButton(category.tr(), skin)
             button.style = TextButton.TextButtonStyle(button.style)
@@ -94,18 +75,46 @@ class CivilopediaScreen(ruleset: Ruleset) : CameraStageBaseScreen() {
             button.onClick { select(category) }
             buttonTable.add(button)
         }
-        select("Tutorials")
-        val sp = ScrollPane(entrySelectTable)
-        sp.setupOverscroll(5f, 1f, 200f)
-        entryTable.add(sp).width(Value.percentWidth(0.25f, entryTable)).height(Value.percentHeight(0.7f, entryTable))
+
+        buttonTable.pack()
+        buttonTable.width = stage.width
+        val buttonTableScroll = ScrollPane(buttonTable)
+
+        val goToGameButton = TextButton("Close".tr(), skin)
+        goToGameButton.onClick {
+            game.setWorldScreen()
+            dispose()
+        }
+
+        val topTable = Table()
+        topTable.add(goToGameButton).pad(10f)
+        topTable.add(buttonTableScroll)
+        topTable.pack()
+        //buttonTable.height = topTable.height
+
+        val entryTable = Table()
+        val splitPane = SplitPane(topTable, entryTable, true, skin)
+        splitPane.splitAmount = topTable.prefHeight / stage.height
+        entryTable.height = stage.height - topTable.prefHeight
+        splitPane.setFillParent(true)
+
+        stage.addActor(splitPane)
+
+        description.setWrap(true)
+
+        val entrySelectScroll = ScrollPane(entrySelectTable)
+        entrySelectScroll.setupOverscroll(5f, 1f, 200f)
+        entryTable.add(entrySelectScroll)
+                .width(Value.percentWidth(0.25f, entryTable))
+                .fillY()
                 .pad(Value.percentWidth(0.02f, entryTable))
         entryTable.add(ScrollPane(description)).colspan(4)
                 .width(Value.percentWidth(0.65f, entryTable))
-                .height(Value.percentHeight(0.7f, entryTable))
+                .fillY()
                 .pad(Value.percentWidth(0.02f, entryTable))
         // Simply changing these to x*width, y*height won't work
 
-        buttonTable.width = stage.width
+        select("Tutorials")
     }
 
 }


### PR DESCRIPTION
_Important: merging both my previous PR #2395 and this might get messy - just ask, I have a merged file stored locally._

I thought the unused space between entryScroll and screen edge / split limit a bit wasteful. Idea: Top when the buttons are in knows how much space it needs, tell split that, then have the bottom stuff fill up vertically.

I should have done something similar to the entryTable, the buttons cut off a little too often, but I had no clear idea how to best approach that, to horizontally nothing changed.

After at virtual 1500x1000:
![image](https://user-images.githubusercontent.com/63000004/79082145-da6b1680-7d23-11ea-91d9-87ce9e71a5f9.png)
After at virtual 750x500:
![image](https://user-images.githubusercontent.com/63000004/79082165-ef47aa00-7d23-11ea-88a4-edee4713670e.png)
Before at max:
![image](https://user-images.githubusercontent.com/63000004/79082243-8b71b100-7d24-11ea-8f34-30461a5484ad.png)
Before at min:
![image](https://user-images.githubusercontent.com/63000004/79082218-57968b80-7d24-11ea-8a9f-3a8f10cc3028.png)
