### PR TITLE
Fix options screen leaving next turn button disabled

### DIFF
--- a/core/src/com/unciv/Constants.kt
+++ b/core/src/com/unciv/Constants.kt
@@ -56,4 +56,6 @@ object Constants {
 
     const val cancelImprovementOrder = "Cancel improvement order"
     const val tutorialPopupNamePrefix = "Tutorial: "
+
+    const val close = "Close"
 }

--- a/core/src/com/unciv/ui/CivilopediaScreen.kt
+++ b/core/src/com/unciv/ui/CivilopediaScreen.kt
@@ -93,7 +93,7 @@ class CivilopediaScreen(ruleset: Ruleset) : CameraStageBaseScreen() {
         buttonTable.width = stage.width
         val buttonTableScroll = ScrollPane(buttonTable)
 
-        val goToGameButton = TextButton("Close".tr(), skin)
+        val goToGameButton = TextButton(Constants.close.tr(), skin)
         goToGameButton.onClick {
             game.setWorldScreen()
             dispose()

--- a/core/src/com/unciv/ui/EmpireOverviewScreen.kt
+++ b/core/src/com/unciv/ui/EmpireOverviewScreen.kt
@@ -1,4 +1,4 @@
-﻿package com.unciv.ui
+package com.unciv.ui
 
 import com.unciv.ui.utils.AutoScrollPane as ScrollPane
 import com.badlogic.gdx.graphics.Color
@@ -19,6 +19,7 @@ import com.unciv.models.translations.tr
 import com.unciv.ui.cityscreen.CityScreen
 import com.unciv.ui.pickerscreens.PromotionPickerScreen
 import com.unciv.ui.utils.*
+import com.unciv.Constants
 import java.text.DecimalFormat
 import kotlin.math.*
 
@@ -29,7 +30,7 @@ class EmpireOverviewScreen(private val viewingPlayer:CivilizationInfo) : CameraS
     init {
         onBackButtonClicked { UncivGame.Current.setWorldScreen() }
 
-        val closeButton = TextButton("Close".tr(), skin)
+        val closeButton = TextButton(Constants.close.tr(), skin)
         closeButton.onClick { UncivGame.Current.setWorldScreen() }
         closeButton.y = stage.height - closeButton.height - 5
         topTable.add(closeButton)

--- a/core/src/com/unciv/ui/mapeditor/MapEditorMenuPopup.kt
+++ b/core/src/com/unciv/ui/mapeditor/MapEditorMenuPopup.kt
@@ -120,7 +120,7 @@ class MapEditorMenuPopup(mapEditorScreen: MapEditorScreen): Popup(mapEditorScree
         exitMapEditorButton.onClick { UncivGame.Current.setWorldScreen(); mapEditorScreen.dispose() }
         add(exitMapEditorButton ).row()
 
-        val closeOptionsButton = TextButton("Close".tr(), skin)
+        val closeOptionsButton = TextButton(Constants.close.tr(), skin)
         closeOptionsButton.onClick { close() }
         add(closeOptionsButton).row()
     }

--- a/core/src/com/unciv/ui/pickerscreens/PickerScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/PickerScreen.kt
@@ -2,13 +2,14 @@ package com.unciv.ui.pickerscreens
 
 import com.unciv.ui.utils.AutoScrollPane as ScrollPane
 import com.badlogic.gdx.scenes.scene2d.ui.*
+import com.unciv.Constants
 import com.unciv.UncivGame
 import com.unciv.models.translations.tr
 import com.unciv.ui.utils.*
 
 open class PickerScreen : CameraStageBaseScreen() {
 
-    internal var closeButton: TextButton = TextButton("Close".tr(), skin)
+    internal var closeButton: TextButton = TextButton(Constants.close.tr(), skin)
     protected var descriptionLabel: Label
     protected var rightSideGroup = VerticalGroup()
     protected var rightSideButton: TextButton

--- a/core/src/com/unciv/ui/trade/DiplomacyScreen.kt
+++ b/core/src/com/unciv/ui/trade/DiplomacyScreen.kt
@@ -40,7 +40,7 @@ class DiplomacyScreen(val viewingCiv:CivilizationInfo):CameraStageBaseScreen() {
         stage.addActor(splitPane)
 
 
-        val closeButton = TextButton("Close".tr(), skin)
+        val closeButton = TextButton(Constants.close.tr(), skin)
         closeButton.onClick { UncivGame.Current.setWorldScreen() }
         closeButton.label.setFontSize(24)
         closeButton.labelCell.pad(10f)
@@ -326,7 +326,7 @@ class DiplomacyScreen(val viewingCiv:CivilizationInfo):CameraStageBaseScreen() {
         }
         demandsTable.add(dontSettleCitiesButton).row()
 
-        demandsTable.add(TextButton("Close".tr(),skin).onClick { updateRightSide(otherCiv) })
+        demandsTable.add(TextButton(Constants.close.tr(),skin).onClick { updateRightSide(otherCiv) })
         return demandsTable
     }
 

--- a/core/src/com/unciv/ui/tutorials/TutorialRender.kt
+++ b/core/src/com/unciv/ui/tutorials/TutorialRender.kt
@@ -33,7 +33,7 @@ class TutorialRender(private val screen: CameraStageBaseScreen) {
 
             tutorialPopup.addGoodSizedLabel(texts[0]).row()
 
-            val button = TextButton("Close".tr(), CameraStageBaseScreen.skin)
+            val button = TextButton(Constants.close.tr(), CameraStageBaseScreen.skin)
             button.onClick {
                 tutorialPopup.remove()
                 texts.removeIndex(0)

--- a/core/src/com/unciv/ui/utils/Popup.kt
+++ b/core/src/com/unciv/ui/utils/Popup.kt
@@ -7,6 +7,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.Label
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton
 import com.badlogic.gdx.utils.Align
+import com.unciv.Constants
 import com.unciv.models.translations.tr
 
 /**
@@ -63,7 +64,12 @@ open class Popup(val screen: CameraStageBaseScreen): Table(CameraStageBaseScreen
         return add(button).apply { row() }
     }
 
-    fun addCloseButton() = addButton("Close") { close() }
+    fun addCloseButton(action: (()->Unit)? = null): Cell<TextButton> {
+        return if (action==null)
+            addButton(Constants.close) { close() }
+        else
+            addButton(Constants.close) { close(); action() }
+    }
 }
 
 fun CameraStageBaseScreen.hasOpenPopups(): Boolean = stage.actors.any { it is Popup && it.isVisible }

--- a/core/src/com/unciv/ui/worldscreen/AlertPopup.kt
+++ b/core/src/com/unciv/ui/worldscreen/AlertPopup.kt
@@ -2,6 +2,7 @@ package com.unciv.ui.worldscreen
 
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton
+import com.unciv.Constants
 import com.unciv.logic.civilization.AlertType
 import com.unciv.logic.civilization.CivilizationInfo
 import com.unciv.logic.civilization.PopupAlert
@@ -157,7 +158,7 @@ class AlertPopup(val worldScreen: WorldScreen, val popupAlert: PopupAlert): Popu
                 centerTable.add(wonder.getShortDescription(worldScreen.gameInfo.ruleSet)
                         .toLabel().apply { setWrap(true) }).width(worldScreen.stage.width/3)
                 add(centerTable).row()
-                add(getCloseButton("Close"))
+                add(getCloseButton(Constants.close))
             }
             AlertType.TechResearched -> {
                 val gameBasics = worldScreen.gameInfo.ruleSet
@@ -169,13 +170,13 @@ class AlertPopup(val worldScreen: WorldScreen, val popupAlert: PopupAlert): Popu
                 centerTable.add(ImageGetter.getTechIconGroup(tech.name,100f)).pad(20f)
                 centerTable.add(tech.getDescription(gameBasics).toLabel().apply { setWrap(true) }).width(worldScreen.stage.width/3)
                 add(centerTable).row()
-                add(getCloseButton("Close"))
+                add(getCloseButton(Constants.close))
             }
             AlertType.GoldenAge -> {
                 addGoodSizedLabel("GOLDEN AGE")
                 addSeparator()
                 addGoodSizedLabel("Your citizens have been happy with your rule for so long that the empire enters a Golden Age!").row()
-                add(getCloseButton("Close"))
+                add(getCloseButton(Constants.close))
             }
         }
     }

--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -506,9 +506,11 @@ class WorldScreen(val viewingCiv:CivilizationInfo) : CameraStageBaseScreen() {
         nextTurnButton.setText(action.text.tr())
         nextTurnButton.color = if (action.text == "Next turn") Color.WHITE else Color.GRAY
         nextTurnButton.pack()
-        if (isSomethingOpen || !isPlayersTurn || waitingForAutosave) nextTurnButton.disable()
-        else nextTurnButton.enable()
+        nextTurnButton.isEnabled = !isSomethingOpen && isPlayersTurn && !waitingForAutosave
         nextTurnButton.setPosition(stage.width - nextTurnButton.width - 10f, topBar.y - nextTurnButton.height - 10f)
+    }
+    fun enableNextTurnButtonAfterOptions() {
+        nextTurnButton.isEnabled = isPlayersTurn && !waitingForAutosave
     }
 
     private fun getNextTurnAction(): NextTurnAction {

--- a/core/src/com/unciv/ui/worldscreen/mainmenu/WorldScreenMenuPopup.kt
+++ b/core/src/com/unciv/ui/worldscreen/mainmenu/WorldScreenMenuPopup.kt
@@ -2,6 +2,7 @@ package com.unciv.ui.worldscreen.mainmenu
 
 import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.graphics.Color
+import com.unciv.Constants
 import com.unciv.UncivGame
 import com.unciv.logic.IdChecker
 import com.unciv.models.translations.tr
@@ -76,7 +77,7 @@ class WorldScreenMenuPopup(val worldScreen: WorldScreen) : Popup(worldScreen) {
         }.size(width,height)
         addSeparator()
 
-        addSquareButton("Close"){
+        addSquareButton(Constants.close){
             close()
         }.size(width,height)
     }

--- a/core/src/com/unciv/ui/worldscreen/mainmenu/WorldScreenOptionsPopup.kt
+++ b/core/src/com/unciv/ui/worldscreen/mainmenu/WorldScreenOptionsPopup.kt
@@ -38,7 +38,7 @@ class WorldScreenOptionsPopup(val worldScreen:WorldScreen) : Popup(worldScreen) 
         scrollPane.setScrollingDisabled(true, false)
         add(scrollPane).maxHeight(screen.stage.height * 0.6f).row()
 
-        addCloseButton()
+        addCloseButton() { worldScreen.enableNextTurnButtonAfterOptions() }
 
         pack() // Needed to show the background.
         center(UncivGame.Current.worldScreen.stage)

--- a/core/src/com/unciv/ui/worldscreen/mainmenu/WorldScreenOptionsPopup.kt
+++ b/core/src/com/unciv/ui/worldscreen/mainmenu/WorldScreenOptionsPopup.kt
@@ -7,6 +7,7 @@ import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.scenes.scene2d.ui.*
 import com.badlogic.gdx.utils.Array
 import com.unciv.UncivGame
+import com.unciv.logic.civilization.PlayerType
 import com.unciv.models.UncivSound
 import com.unciv.models.translations.TranslationFileWriter
 import com.unciv.models.translations.Translations
@@ -104,7 +105,7 @@ class WorldScreenOptionsPopup(val worldScreen:WorldScreen) : Popup(worldScreen) 
 
         addHeader("Gameplay options")
 
-        addYesNoRow ("Check for idle units", settings.checkForDueUnits) {
+        addYesNoRow ("Check for idle units", settings.checkForDueUnits, true) {
             settings.checkForDueUnits = it
         }
         addYesNoRow ("Move units with a single tap", settings.singleTapMove) {


### PR DESCRIPTION
... and toggling unit idle check is immediately seen on the button (probably worked before #2367, sorry)
... and refactoring about 10 occurrences of the "Close" literal