### PR TITLE
Options: Turning on city production autoassign affects world immediately

### DIFF
--- a/core/src/com/unciv/ui/worldscreen/mainmenu/WorldScreenOptionsPopup.kt
+++ b/core/src/com/unciv/ui/worldscreen/mainmenu/WorldScreenOptionsPopup.kt
@@ -7,6 +7,7 @@ import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.scenes.scene2d.ui.*
 import com.badlogic.gdx.utils.Array
 import com.unciv.UncivGame
+import com.unciv.logic.civilization.PlayerType
 import com.unciv.models.UncivSound
 import com.unciv.models.translations.TranslationFileWriter
 import com.unciv.models.translations.Translations
@@ -110,8 +111,13 @@ class WorldScreenOptionsPopup(val worldScreen:WorldScreen) : Popup(worldScreen) 
         addYesNoRow ("Move units with a single tap", settings.singleTapMove) {
             settings.singleTapMove = it
         }
-        addYesNoRow ("Auto-assign city production", settings.autoAssignCityProduction) {
+        addYesNoRow ("Auto-assign city production", settings.autoAssignCityProduction, true) {
             settings.autoAssignCityProduction = it
+            if (it && UncivGame.Current.gameInfo.currentPlayerCiv.playerType == PlayerType.Human) {
+                UncivGame.Current.gameInfo.currentPlayerCiv.cities.forEach {
+                    city -> city.cityConstructions.chooseNextConstruction()
+                }
+            }
         }
         addYesNoRow ("Auto-build roads", settings.autoBuildingRoads) {
             settings.autoBuildingRoads = it

--- a/core/src/com/unciv/ui/worldscreen/mainmenu/WorldScreenOptionsPopup.kt
+++ b/core/src/com/unciv/ui/worldscreen/mainmenu/WorldScreenOptionsPopup.kt
@@ -113,7 +113,7 @@ class WorldScreenOptionsPopup(val worldScreen:WorldScreen) : Popup(worldScreen) 
         }
         addYesNoRow ("Auto-assign city production", settings.autoAssignCityProduction, true) {
             settings.autoAssignCityProduction = it
-            if (it && UncivGame.Current.gameInfo.currentPlayerCiv.playerType == PlayerType.Human) {
+            if (it && worldScreen.viewingCiv.isCurrentPlayer() && worldScreen.viewingCiv.playerType == PlayerType.Human) {
                 UncivGame.Current.gameInfo.currentPlayerCiv.cities.forEach {
                     city -> city.cityConstructions.chooseNextConstruction()
                 }


### PR DESCRIPTION
Optional: Right now toggling city auto on or off only affects next turn - one could have it 'work' right away, and the little 'true' in line 114 would make the change on the next turn button visible right away (if it was at choose prod).

Toss a dice and just close this if you think it's BS. I coded it to see if I'd like it and came up undecided.