### PR TITLE
The original capital can not be razed

### DIFF
--- a/core/src/com/unciv/logic/city/CityInfo.kt
+++ b/core/src/com/unciv/logic/city/CityInfo.kt
@@ -56,6 +56,10 @@ class CityInfo {
     var attackedThisTurn = false
     var hasSoldBuildingThisTurn = false
     var isPuppet = false
+    /** The very first found city is the _original_ capital,
+     * while the _current_ capital can be any other city after the original one is captured.
+     * It is important to distinct them since the original cannot be razed and defines the Domination Victory. */
+    var isOriginalCapital = false
 
     constructor()   // for json parsing, we need to have a default constructor
     constructor(civInfo: CivilizationInfo, cityLocation: Vector2) {  // new city!
@@ -76,6 +80,7 @@ class CityInfo {
 
         name = cityNamePrefix + cityName
 
+        isOriginalCapital = civInfo.citiesCreated == 0
         civInfo.citiesCreated++
 
         civInfo.cities = civInfo.cities.toMutableList().apply { add(this@CityInfo) }
@@ -125,6 +130,7 @@ class CityInfo {
         toReturn.foundingCiv = foundingCiv
         toReturn.turnAcquired = turnAcquired
         toReturn.isPuppet = isPuppet
+        toReturn.isOriginalCapital = isOriginalCapital
         return toReturn
     }
 
@@ -139,7 +145,7 @@ class CityInfo {
         val mediumTypes = civInfo.citiesConnectedToCapitalToMediums[this] ?: return false
         return connectionTypePredicate(mediumTypes)
     }
-    fun isInResistance() = resistanceCounter>0
+    fun isInResistance() = resistanceCounter > 0
 
 
     fun getRuleset() = civInfo.gameInfo.ruleSet

--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -263,10 +263,10 @@ class CivilizationInfo {
     override fun toString(): String {return civName} // for debug
 
     /** Returns true if the civ was fully initialized and has no cities or settlers remaining */
-    fun isDefeated()= cities.isEmpty()
+    fun isDefeated() = cities.isEmpty()  // No cities
             && exploredTiles.isNotEmpty()  // Dirty hack: exploredTiles are empty only before starting units are placed
             && !isBarbarian() // Barbarians can be never defeated
-            && (citiesCreated > 0 || !getCivUnits().any { it.name == Constants.settler })
+            && !getCivUnits().any { it.name == Constants.settler } // No settlers
 
     fun getEra(): TechEra {
         val maxEraOfTech =  tech.researchedTechnologies

--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -262,11 +262,11 @@ class CivilizationInfo {
 
     override fun toString(): String {return civName} // for debug
 
-    /** Returns true if the civ was fully initialized and has no cities or settlers remaining */
-    fun isDefeated() = cities.isEmpty()  // No cities
+    /** Returns true if the civ was fully initialized and has no cities remaining */
+    fun isDefeated()= cities.isEmpty() // No cities
             && exploredTiles.isNotEmpty()  // Dirty hack: exploredTiles are empty only before starting units are placed
             && !isBarbarian() // Barbarians can be never defeated
-            && !getCivUnits().any { it.name == Constants.settler } // No settlers
+            && (citiesCreated > 0 || !getCivUnits().any { it.name == Constants.settler })
 
     fun getEra(): TechEra {
         val maxEraOfTech =  tech.researchedTechnologies

--- a/core/src/com/unciv/ui/cityscreen/CityScreen.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityScreen.kt
@@ -125,7 +125,9 @@ class CityScreen(internal val city: CityInfo): CameraStageBaseScreen() {
             val razeCityButton = "Raze city".toTextButton()
             razeCityButton.labelCell.pad(10f)
             razeCityButton.onClick { city.isBeingRazed=true; update() }
-            if(!UncivGame.Current.worldScreen.isPlayersTurn) razeCityButton.disable()
+            if(!UncivGame.Current.worldScreen.isPlayersTurn || city.isOriginalCapital)
+                razeCityButton.disable()
+
             razeCityButtonHolder.add(razeCityButton).colspan(cityPickerTable.columns)
         } else {
             val stopRazingCityButton = "Stop razing city".toTextButton()

--- a/core/src/com/unciv/ui/worldscreen/AlertPopup.kt
+++ b/core/src/com/unciv/ui/worldscreen/AlertPopup.kt
@@ -99,13 +99,15 @@ class AlertPopup(val worldScreen: WorldScreen, val popupAlert: PopupAlert): Popu
                     addSeparator()
 
 
-                    add("Raze".toTextButton().onClick {
+                    add("Raze".toTextButton().apply {
+                        if (city.isOriginalCapital) disable()
+                        else onClick {
                         city.puppetCity(conqueringCiv)
                         city.annexCity()
                         city.isBeingRazed = true
                         worldScreen.shouldUpdate=true
                         close()
-                    }).row()
+                    }}).row()
                     addGoodSizedLabel("Razing the city annexes it, and starts razing the city to the ground.").row()
                     addGoodSizedLabel("The population will gradually dwindle until the city is destroyed.").row()
                 } else {


### PR DESCRIPTION
**Fallingmeteor** at Discord has reported:
_"Hey i just found this realy useful bug to discover the entire map in lest than 10 turn so first 1.settle a city 2.build settler and wait until it done 3.raze your city and get defeat 4.click "one more turn" on the defeat screen 5.after that you should on spectator mode then just click on your settler and build your city, and now you still keep the Map"_

In order to fix this bug I have made two things:
1) While you have at least 1 settler alive - you are still not defeated (actually, this condition has been there, but did not work properly)
2) Your original capital cannot be razed according to https://civilization.fandom.com/wiki/Victory_(Civ5) _"the original capital city of a civilization can never be completely destroyed; it can only be captured"_. This change is also the first step to the correct implementation of the Domination Victory #2005 