### PR TITLE
Cultural expansion pauses when no more tiles available

### DIFF
--- a/core/src/com/unciv/logic/city/CityExpansionManager.kt
+++ b/core/src/com/unciv/logic/city/CityExpansionManager.kt
@@ -21,12 +21,12 @@ class CityExpansionManager {
     }
 
     fun tilesClaimed() = cityInfo.tiles.size - 7
+
     // This one has conflicting sources -
     // http://civilization.wikia.com/wiki/Mathematics_of_Civilization_V says it's 20+(10(t-1))^1.1
     // https://www.reddit.com/r/civ/comments/58rxkk/how_in_gods_name_do_borders_expand_in_civ_vi/ has it
     //   (per game XML files) at 6*(t+0.4813)^1.3
     // The second seems to be more based, so I'll go with that
-
     fun getCultureToNextTile(): Int {
         var cultureToNextTile = 6 * (tilesClaimed() + 1.4813).pow(1.3)
         if (cityInfo.civInfo.containsBuildingUnique("Cost of acquiring new tiles reduced by 25%"))
@@ -88,13 +88,14 @@ class CityExpansionManager {
             takeOwnership(tile)
     }
 
-    private fun addNewTileWithCulture() {
-        cultureStored -= getCultureToNextTile()
-
+    private fun addNewTileWithCulture(): Boolean {
         val chosenTile = chooseNewTileToOwn()
-        if(chosenTile!=null){
+        if (chosenTile!=null) {
+            cultureStored -= getCultureToNextTile()
             takeOwnership(chosenTile)
+            return true
         }
+        return false
     }
 
     fun relinquishOwnership(tileInfo: TileInfo){
@@ -128,8 +129,8 @@ class CityExpansionManager {
     fun nextTurn(culture: Float) {
         cultureStored += culture.toInt()
         if (cultureStored >= getCultureToNextTile()) {
-            addNewTileWithCulture()
-            cityInfo.civInfo.addNotification("["+cityInfo.name + "] has expanded its borders!", cityInfo.location, Color.PURPLE)
+            if (addNewTileWithCulture())
+                cityInfo.civInfo.addNotification("["+cityInfo.name + "] has expanded its borders!", cityInfo.location, Color.PURPLE)
         }
     }
 

--- a/core/src/com/unciv/logic/city/CityExpansionManager.kt
+++ b/core/src/com/unciv/logic/city/CityExpansionManager.kt
@@ -21,6 +21,7 @@ class CityExpansionManager {
     }
 
     fun tilesClaimed() = cityInfo.tiles.size - 7
+    fun isAreaMaxed(): Boolean = (cityInfo.tiles.size >= 90)
 
     // This one has conflicting sources -
     // http://civilization.wikia.com/wiki/Mathematics_of_Civilization_V says it's 20+(10(t-1))^1.1
@@ -89,6 +90,10 @@ class CityExpansionManager {
     }
 
     private fun addNewTileWithCulture(): Boolean {
+        if ( isAreaMaxed() ) {
+            cultureStored = 0
+            return false
+        }
         val chosenTile = chooseNewTileToOwn()
         if (chosenTile!=null) {
             cultureStored -= getCultureToNextTile()

--- a/core/src/com/unciv/ui/cityscreen/CityStatsTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityStatsTable.kt
@@ -52,7 +52,7 @@ class CityStatsTable(val cityScreen: CityScreen): Table() {
                 " " + cityInfo.population.getFreePopulation().toString() + "/" + cityInfo.population.population
 
         var turnsToExpansionString =
-                if (cityInfo.cityStats.currentCityStats.culture > 0) {
+                if (cityInfo.cityStats.currentCityStats.culture > 0 && cityInfo.expansion.chooseNewTileToOwn() != null) {
                     val remainingCulture = cityInfo.expansion.getCultureToNextTile() - cityInfo.expansion.cultureStored
                     var turnsToExpansion = ceil(remainingCulture / cityInfo.cityStats.currentCityStats.culture).toInt()
                     if (turnsToExpansion < 1) turnsToExpansion = 1

--- a/core/src/com/unciv/ui/cityscreen/CityStatsTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityStatsTable.kt
@@ -60,7 +60,8 @@ class CityStatsTable(val cityScreen: CityScreen): Table() {
                 } else {
                     "Stopped expansion".tr()
                 }
-        turnsToExpansionString += " (" + cityInfo.expansion.cultureStored + "/" +
+        if (!cityInfo.expansion.isAreaMaxed())
+            turnsToExpansionString += " (" + cityInfo.expansion.cultureStored + "/" +
                 cityInfo.expansion.getCultureToNextTile() + ")"
 
         var turnsToPopString =


### PR DESCRIPTION
Mainly I turned off the messages 'x has expanded its borders' when in fact it has not. Also, what happens when a city cannot expand due to all tiles taken, this goes on for a while, then land is freed by conquest: right now there's some almost-unpredictability involved as its pool will be emptied in intervals, and where you are in that cycle depends on complex stuff. I can't pinpoint sources, but I think such a situation should lead to the city immediately expanding on the next turn. At least once.

My proposal will leave a city accumulating culture while it's stunted, uncapped. My preference but definitely arguable. Cap at cost of next tile? Just stop whereever the pool is? Cap at some set number or multiple of next-tile-cost? Slow down smoothly along a gauss curve?