### PR TITLE
The world view top panel can open the corresponding screens

### DIFF
--- a/core/src/com/unciv/ui/EmpireOverviewScreen.kt
+++ b/core/src/com/unciv/ui/EmpireOverviewScreen.kt
@@ -23,30 +23,31 @@ import com.unciv.Constants
 import java.text.DecimalFormat
 import kotlin.math.*
 
-class EmpireOverviewScreen(private val viewingPlayer:CivilizationInfo) : CameraStageBaseScreen(){
+class EmpireOverviewScreen(private val viewingPlayer:CivilizationInfo, private val defaultPage: String = "Cities") : CameraStageBaseScreen(){
     private val topTable = Table().apply { defaults().pad(10f) }
     private val centerTable = Table().apply {  defaults().pad(20f) }
 
     init {
         onBackButtonClicked { UncivGame.Current.setWorldScreen() }
+        val clicks = HashMap<String,() -> Unit>()
 
-        val closeButton = TextButton(Constants.close.tr(), skin)
+        val closeButton = Constants.close.toTextButton()
         closeButton.onClick { UncivGame.Current.setWorldScreen() }
         closeButton.y = stage.height - closeButton.height - 5
         topTable.add(closeButton)
 
-        val setCityInfoButton = TextButton("Cities".tr(), skin)
+        val setCityInfoButton = "Cities".toTextButton()
         val setCities = {
             centerTable.clear()
             centerTable.add(getCityInfoTable())
             centerTable.pack()
         }
-        setCities()
+        clicks["Cities"] = setCities
         setCityInfoButton.onClick(setCities)
         topTable.add(setCityInfoButton)
 
-        val setStatsInfoButton = TextButton("Stats".tr(), skin)
-        setStatsInfoButton.onClick {
+        val setStatsInfoButton = "Stats".toTextButton()
+        val setStats = {
             game.settings.addCompletedTutorialTask("See your stats breakdown")
             centerTable.clear()
             centerTable.add(ScrollPane(Table().apply {
@@ -58,9 +59,11 @@ class EmpireOverviewScreen(private val viewingPlayer:CivilizationInfo) : CameraS
             }))
             centerTable.pack()
         }
+        clicks["Stats"] = setStats
+        setStatsInfoButton.onClick(setStats)
         topTable.add(setStatsInfoButton)
 
-        val setCurrentTradesButton = TextButton("Trades".tr(), skin)
+        val setCurrentTradesButton = "Trades".toTextButton()
         setCurrentTradesButton.onClick {
             centerTable.clear()
             centerTable.add(ScrollPane(getTradesTable())).height(stage.height * 0.8f) // so it doesn't cover the navigation buttons
@@ -70,7 +73,7 @@ class EmpireOverviewScreen(private val viewingPlayer:CivilizationInfo) : CameraS
         if (viewingPlayer.diplomacy.values.all { it.trades.isEmpty() })
             setCurrentTradesButton.disable()
 
-        val setUnitsButton = TextButton("Units".tr(), skin)
+        val setUnitsButton = "Units".toTextButton()
         setUnitsButton.onClick {
             centerTable.clear()
             centerTable.add(ScrollPane(getUnitTable()).apply { setOverscroll(false,false) }).height(stage.height * 0.8f)
@@ -79,7 +82,7 @@ class EmpireOverviewScreen(private val viewingPlayer:CivilizationInfo) : CameraS
         topTable.add(setUnitsButton)
 
 
-        val setDiplomacyButton = TextButton("Diplomacy".tr(), skin)
+        val setDiplomacyButton = "Diplomacy".toTextButton()
         setDiplomacyButton.onClick {
             centerTable.clear()
             centerTable.add(getDiplomacyGroup()).height(stage.height * 0.8f)
@@ -87,17 +90,21 @@ class EmpireOverviewScreen(private val viewingPlayer:CivilizationInfo) : CameraS
         }
         topTable.add(setDiplomacyButton)
 
-        val setResourcesButton = TextButton("Resources".tr(), skin)
-        setResourcesButton.onClick {
+        val setResourcesButton = "Resources".toTextButton()
+        val setResources = {
             centerTable.clear()
             centerTable.add(ScrollPane(getResourcesTable())).size(stage.width * 0.8f, stage.height * 0.8f)
             centerTable.pack()
         }
+        clicks["Resources"] = setResources
+        setResourcesButton.onClick(setResources)
         topTable.add(setResourcesButton)
         if (viewingPlayer.detailedCivResources.isEmpty())
             setResourcesButton.disable()
 
         topTable.pack()
+
+        clicks[defaultPage]?.invoke()
 
         val table = Table()
         table.add(topTable).row()

--- a/core/src/com/unciv/ui/worldscreen/WorldScreenTopBar.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreenTopBar.kt
@@ -13,6 +13,8 @@ import com.unciv.models.ruleset.tile.ResourceType
 import com.unciv.models.stats.Stats
 import com.unciv.models.translations.tr
 import com.unciv.ui.EmpireOverviewScreen
+import com.unciv.ui.pickerscreens.PolicyPickerScreen
+import com.unciv.ui.pickerscreens.TechPickerScreen
 import com.unciv.ui.utils.*
 import com.unciv.ui.worldscreen.mainmenu.WorldScreenMenuPopup
 import kotlin.math.abs
@@ -86,7 +88,11 @@ class WorldScreenTopBar(val worldScreen: WorldScreen) : Table() {
         goldImage.onClick(invokeStatsPage)
 
         statsTable.add(scienceLabel) //.apply { setAlignment(Align.center) }).align(Align.top)
-        statsTable.add(ImageGetter.getStatIcon("Science")).padRight(20f).size(20f)
+        val scienceImage = ImageGetter.getStatIcon("Science")
+        statsTable.add(scienceImage).padRight(20f).size(20f)
+        val invokeTechScreen =  { UncivGame.Current.setScreen(TechPickerScreen(worldScreen.viewingCiv)) }
+        scienceLabel.onClick(invokeTechScreen)
+        scienceImage.onClick(invokeTechScreen)
 
         statsTable.add(happinessImage).size(20f)
         statsTable.add(happinessLabel).padRight(20f)//.apply { setAlignment(Align.center) }).align(Align.top)
@@ -95,7 +101,11 @@ class WorldScreenTopBar(val worldScreen: WorldScreen) : Table() {
         happinessLabel.onClick(invokeResourcesPage)
 
         statsTable.add(cultureLabel)//.apply { setAlignment(Align.center) }).align(Align.top)
-        statsTable.add(ImageGetter.getStatIcon("Culture")).size(20f)
+        val cultureImage = ImageGetter.getStatIcon("Culture")
+        statsTable.add(cultureImage).size(20f)
+        val invokePoliciesPage = { UncivGame.Current.setScreen(PolicyPickerScreen(worldScreen)) }
+        cultureLabel.onClick(invokePoliciesPage)
+        cultureImage.onClick(invokePoliciesPage)
 
         statsTable.pack()
         statsTable.width = worldScreen.stage.width - 20

--- a/core/src/com/unciv/ui/worldscreen/WorldScreenTopBar.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreenTopBar.kt
@@ -31,9 +31,9 @@ class WorldScreenTopBar(val worldScreen: WorldScreen) : Table() {
     private val happinessImage = Group()
     // These are all to improve performance IE reduce update time (was 150 ms on my phone, which is a lot!)
     private val malcontentColor = Color.valueOf("ef5350")
-    val happinessColor = colorFromRGB(92, 194, 77)
-    val malcontentGroup = ImageGetter.getStatIcon("Malcontent")
-    val happinessGroup = ImageGetter.getStatIcon("Happiness")
+    private val happinessColor = colorFromRGB(92, 194, 77)
+    private val malcontentGroup = ImageGetter.getStatIcon("Malcontent")
+    private val happinessGroup = ImageGetter.getStatIcon("Happiness")
 
     init {
         background = ImageGetter.getBackground(ImageGetter.getBlue().lerp(Color.BLACK, 0.5f))
@@ -69,28 +69,40 @@ class WorldScreenTopBar(val worldScreen: WorldScreen) : Table() {
             resourceTable.add(resourceLabel)
         }
         resourceTable.pack()
+        resourceTable.onClick { UncivGame.Current.setScreen(EmpireOverviewScreen(worldScreen.viewingCiv, "Resources")) }
+
         return resourceTable
     }
 
     private fun getStatsTable(): Table {
         val statsTable = Table()
         statsTable.defaults().pad(3f)//.align(Align.top)
+
         statsTable.add(goldLabel)
-        statsTable.add(ImageGetter.getStatIcon("Gold")).padRight(20f).size(20f)
+        val goldImage = ImageGetter.getStatIcon("Gold")
+        statsTable.add(goldImage).padRight(20f).size(20f)
+        val invokeStatsPage = { UncivGame.Current.setScreen(EmpireOverviewScreen(worldScreen.viewingCiv, "Stats")) }
+        goldLabel.onClick(invokeStatsPage)
+        goldImage.onClick(invokeStatsPage)
+
         statsTable.add(scienceLabel) //.apply { setAlignment(Align.center) }).align(Align.top)
         statsTable.add(ImageGetter.getStatIcon("Science")).padRight(20f).size(20f)
 
         statsTable.add(happinessImage).size(20f)
         statsTable.add(happinessLabel).padRight(20f)//.apply { setAlignment(Align.center) }).align(Align.top)
+        val invokeResourcesPage = { UncivGame.Current.setScreen(EmpireOverviewScreen(worldScreen.viewingCiv, "Resources")) }
+        happinessImage.onClick(invokeResourcesPage)
+        happinessLabel.onClick(invokeResourcesPage)
 
         statsTable.add(cultureLabel)//.apply { setAlignment(Align.center) }).align(Align.top)
         statsTable.add(ImageGetter.getStatIcon("Culture")).size(20f)
+
         statsTable.pack()
         statsTable.width = worldScreen.stage.width - 20
         return statsTable
     }
 
-    internal fun getMenuButton(): Image {
+    private fun getMenuButton(): Image {
         val menuButton = ImageGetter.getImage("OtherIcons/MenuIcon")
                 .apply { setSize(50f, 50f) }
         menuButton.color = Color.WHITE

--- a/core/src/com/unciv/ui/worldscreen/WorldScreenTopBar.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreenTopBar.kt
@@ -16,6 +16,7 @@ import com.unciv.ui.EmpireOverviewScreen
 import com.unciv.ui.pickerscreens.PolicyPickerScreen
 import com.unciv.ui.pickerscreens.TechPickerScreen
 import com.unciv.ui.utils.*
+import com.unciv.ui.victoryscreen.VictoryScreen
 import com.unciv.ui.worldscreen.mainmenu.WorldScreenMenuPopup
 import kotlin.math.abs
 import kotlin.math.ceil
@@ -69,9 +70,11 @@ class WorldScreenTopBar(val worldScreen: WorldScreen) : Table() {
             val resourceLabel = "0".toLabel()
             resourceLabels[resource.name] = resourceLabel
             resourceTable.add(resourceLabel)
+            val invokeResourcesPage = { UncivGame.Current.setScreen(EmpireOverviewScreen(worldScreen.viewingCiv, "Resources")) }
+            resourceLabel.onClick(invokeResourcesPage)
+            resourceImage.onClick(invokeResourcesPage)
         }
         resourceTable.pack()
-        resourceTable.onClick { UncivGame.Current.setScreen(EmpireOverviewScreen(worldScreen.viewingCiv, "Resources")) }
 
         return resourceTable
     }
@@ -152,6 +155,7 @@ class WorldScreenTopBar(val worldScreen: WorldScreen) : Table() {
 
         val yearText = "["+ abs(year)+"] "+ if (year<0) "BC" else "AD"
         turnsLabel.setText("Turn".tr()+" " + civInfo.gameInfo.turns + " | "+ yearText.tr())
+        turnsLabel.onClick { UncivGame.Current.setScreen(VictoryScreen()) }
 
         val nextTurnStats = civInfo.statsForNextTurn
         val goldPerTurn = "(" + (if (nextTurnStats.gold > 0) "+" else "") + nextTurnStats.gold.roundToInt() + ")"


### PR DESCRIPTION
*Ravignir* has suggested at Discord:
_"Show social policies/tech/display luxuries when you click/tap on culture/science/happiness in the upper bar."_

Now the whole top panel is clickable: each icon opens corresponding screen or page.
Also, the turns counter opens the victory status page (maybe, the Time Victory will be in the game at some point 😉 ).