### PR TITLE
Remove "Camp" hardcoding and allow mods to do similar things

### DIFF
--- a/android/assets/jsons/TileImprovements.json
+++ b/android/assets/jsons/TileImprovements.json
@@ -39,6 +39,7 @@
 	// Resource-specific
 	{
 		"name": "Camp",
+		"resourceTerrainAllow": ["Forest"],
 		"turnsToBuild": 7,
 		"techRequired": "Trapping",
 		"improvingTech": "Economics",

--- a/core/src/com/unciv/logic/map/TileInfo.kt
+++ b/core/src/com/unciv/logic/map/TileInfo.kt
@@ -281,7 +281,7 @@ open class TileInfo {
             improvement.name == "Remove Road" && this.roadStatus == RoadStatus.Road -> true
             improvement.name == "Remove Railroad" && this.roadStatus == RoadStatus.Railroad -> true
             improvement.name == Constants.cancelImprovementOrder && this.improvementInProgress != null -> true
-            topTerrain.unbuildable && !(topTerrain.name == Constants.forest && improvement.name == "Camp") -> false
+            topTerrain.unbuildable && (topTerrain.name !in improvement.resourceTerrainAllow) -> false
             "Can only be built on Coastal tiles" in improvement.uniques && isCoastalTile() -> true
             else -> hasViewableResource(civInfo) && getTileResource().improvement == improvement.name
         }

--- a/core/src/com/unciv/models/ruleset/tile/TileImprovement.kt
+++ b/core/src/com/unciv/models/ruleset/tile/TileImprovement.kt
@@ -11,6 +11,11 @@ import kotlin.math.roundToInt
 class TileImprovement : NamedStats() {
 
     var terrainsCanBeBuiltOn: Collection<String> = ArrayList()
+
+    // Used only for Camp - but avoid hardcoded comparison and *allow modding*
+    // Terrain Features that need not be cleared if the improvement enables a resource
+    var resourceTerrainAllow: Collection<String> = ArrayList()
+
     var techRequired: String? = null
 
     var improvingTech: String? = null


### PR DESCRIPTION
Should a mod try to create an improvement working like Camp does - nope, too hardcoded. This alleviates that, though attempting to change existing code minimally. I originally ended up with a rewritten WorkerAutomation.chooseImprovement and its equivalence was no longer easy to see. I'll show that later separately. Note this will not allow automation to deal with all cases - the AI routine still hardcodes the terrain features it considers removals to allow improving a resouce for. So in theory a human might be able to do stuff the AI does not. Still, such mods would also still lack map generator and map editor support (though I got the latter stashed somewhere).