### PR TITLE
Camp hardcoded alt

### DIFF
--- a/android/assets/jsons/TileImprovements.json
+++ b/android/assets/jsons/TileImprovements.json
@@ -39,6 +39,7 @@
 	// Resource-specific
 	{
 		"name": "Camp",
+		"resourceTerrainAllow": ["Forest"],
 		"turnsToBuild": 7,
 		"techRequired": "Trapping",
 		"improvingTech": "Economics",

--- a/core/src/com/unciv/logic/map/TileInfo.kt
+++ b/core/src/com/unciv/logic/map/TileInfo.kt
@@ -281,7 +281,7 @@ open class TileInfo {
             improvement.name == "Remove Road" && this.roadStatus == RoadStatus.Road -> true
             improvement.name == "Remove Railroad" && this.roadStatus == RoadStatus.Railroad -> true
             improvement.name == Constants.cancelImprovementOrder && this.improvementInProgress != null -> true
-            topTerrain.unbuildable && !(topTerrain.name == Constants.forest && improvement.name == "Camp") -> false
+            topTerrain.unbuildable && (topTerrain.name !in improvement.resourceTerrainAllow) -> false
             "Can only be built on Coastal tiles" in improvement.uniques && isCoastalTile() -> true
             else -> hasViewableResource(civInfo) && getTileResource().improvement == improvement.name
         }

--- a/core/src/com/unciv/models/ruleset/tile/TileImprovement.kt
+++ b/core/src/com/unciv/models/ruleset/tile/TileImprovement.kt
@@ -11,6 +11,11 @@ import kotlin.math.roundToInt
 class TileImprovement : NamedStats() {
 
     var terrainsCanBeBuiltOn: Collection<String> = ArrayList()
+
+    // Used only for Camp - but avoid hardcoded comparison and *allow modding*
+    // Terrain Features that need not be cleared if the improvement enables a resource
+    var resourceTerrainAllow: Collection<String> = ArrayList()
+
     var techRequired: String? = null
 
     var improvingTech: String? = null


### PR DESCRIPTION
Alternate to #2417 - a bit more resilient to unusual rulesets, but, as you can see, quite worked over trying to optimize a little.