### PR TITLE
Fix application crash when city area is too small

### DIFF
--- a/core/src/com/unciv/logic/city/CityExpansionManager.kt
+++ b/core/src/com/unciv/logic/city/CityExpansionManager.kt
@@ -28,7 +28,7 @@ class CityExpansionManager {
     // The second seems to be more based, so I'll go with that
 
     fun getCultureToNextTile(): Int {
-        var cultureToNextTile = 6 * (tilesClaimed() + 1.4813).pow(1.3)
+        var cultureToNextTile = 6 * (kotlin.math.max(0, tilesClaimed()) + 1.4813).pow(1.3)
         if (cityInfo.civInfo.containsBuildingUnique("Cost of acquiring new tiles reduced by 25%"))
             cultureToNextTile *= 0.75 //Speciality of Angkor Wat
         if(cityInfo.containsBuildingUnique("Culture and Gold costs of acquiring new tiles reduced by 25% in this city"))


### PR DESCRIPTION
Sometimes the game crashes with:
> Exception in thread "NextTurn" java.lang.IllegalArgumentException: Cannot round NaN value.
> 	at kotlin.math.MathKt__MathJVMKt.roundToInt(MathJVM.kt:602)
> 	at com.unciv.logic.city.CityExpansionManager.getCultureToNextTile(CityExpansionManager.kt:38)

The investigation shows if the city is found on the edge of the map (or close to another civ) its initial area is less than 7 tiles.
`tilesClaimed` returns a negative number and `+1.4813` is not enough to compensate that.
Thus, we have a negative number raised to power 1.3, while `pow` description says:
> `b.pow(x)` is `NaN` for `b < 0` and `x` is finite and not an integer

The fix just does not allow to get a negative argument for `pow` rounding the initial city area like it was 7.