### PR TITLE
Fix for the application crash after the defeat

### DIFF
--- a/core/src/com/unciv/ui/worldscreen/WorldMapHolder.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldMapHolder.kt
@@ -307,7 +307,7 @@ class WorldMapHolder(internal val worldScreen: WorldScreen, internal val tileMap
 
 
     fun setCenterPosition(vector: Vector2, immediately: Boolean = false, selectUnit: Boolean = true) {
-        val tileGroup = tileGroups.values.first { it.tileInfo.position == vector }
+        val tileGroup = tileGroups.values.firstOrNull { it.tileInfo.position == vector } ?: return
         selectedTile = tileGroup.tileInfo
         if(selectUnit)
             worldScreen.bottomUnitTable.tileSelected(selectedTile!!)

--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -244,7 +244,7 @@ class WorldScreen(val viewingCiv:CivilizationInfo) : CameraStageBaseScreen() {
         displayTutorialsOnUpdate()
 
         bottomUnitTable.update()
-        bottomTileInfoTable.updateTileTable(mapHolder.selectedTile!!)
+        bottomTileInfoTable.updateTileTable(mapHolder.selectedTile)
         bottomTileInfoTable.x = stage.width - bottomTileInfoTable.width
         bottomTileInfoTable.y = if (UncivGame.Current.settings.showMinimap) minimapWrapper.height else 0f
         battleTable.update()

--- a/core/src/com/unciv/ui/worldscreen/bottombar/TileInfoTable.kt
+++ b/core/src/com/unciv/ui/worldscreen/bottombar/TileInfoTable.kt
@@ -15,10 +15,10 @@ class TileInfoTable(private val viewingCiv :CivilizationInfo) : Table(CameraStag
         background = ImageGetter.getBackground(ImageGetter.getBlue().lerp(Color.BLACK, 0.5f))
     }
 
-    internal fun updateTileTable(tile: TileInfo) {
+    internal fun updateTileTable(tile: TileInfo?) {
         clearChildren()
 
-        if (UncivGame.Current.viewEntireMapForDebug || viewingCiv.exploredTiles.contains(tile.position)) {
+        if ((tile != null) && (UncivGame.Current.viewEntireMapForDebug || viewingCiv.exploredTiles.contains(tile.position))) {
             add(getStatsTable(tile))
             add(tile.toString(viewingCiv).toLabel()).colspan(2).pad(10f)
         }


### PR DESCRIPTION
Currently, if the defeated player wants to watch the game after the defeat, he/she will get a crash on the "Next turn".
This fix allows still to watch the game.