### PR TITLE
City construction queue Redone: Allow dependents, cleaner perpetuals

### DIFF
--- a/core/src/com/unciv/logic/city/CityConstructions.kt
+++ b/core/src/com/unciv/logic/city/CityConstructions.kt
@@ -242,7 +242,7 @@ class CityConstructions {
             addProductionPoints(cityStats.production.roundToInt())
     }
 
-    private fun validateConstructionQueue(): Boolean {
+    fun validateConstructionQueue(): Boolean {
         // Let's try to remove the building from the city, and see if we can still build it (we need to remove because of wonders etc.)
         val construction = getConstruction(currentConstruction)
 

--- a/core/src/com/unciv/logic/city/CityInfo.kt
+++ b/core/src/com/unciv/logic/city/CityInfo.kt
@@ -550,6 +550,7 @@ class CityInfo {
     fun sellBuilding(buildingName:String){
         cityConstructions.builtBuildings.remove(buildingName)
         cityConstructions.removeBuilding(buildingName)
+        cityConstructions.validateConstructionQueue()       // if true queue display needs updating - unnecessary right now
         civInfo.gold += getGoldForSellingBuilding(buildingName)
         hasSoldBuildingThisTurn=true
 

--- a/core/src/com/unciv/logic/city/IConstruction.kt
+++ b/core/src/com/unciv/logic/city/IConstruction.kt
@@ -9,6 +9,8 @@ interface IConstruction : INamed {
     fun getProductionCost(civInfo: CivilizationInfo): Int
     fun getGoldCost(civInfo: CivilizationInfo): Int
     fun isBuildable(construction: CityConstructions): Boolean
+    fun isBuildableWithQueue(construction: CityConstructions, queueToConsiderBuilt: Collection<String>): Boolean
+        = isBuildable(construction)
     fun shouldBeDisplayed(cityConstructions: CityConstructions): Boolean
     fun postBuildEvent(construction: CityConstructions, wasBought: Boolean = false): Boolean  // Yes I'm hilarious.
     fun getResource(): String?

--- a/core/src/com/unciv/logic/map/TileInfo.kt
+++ b/core/src/com/unciv/logic/map/TileInfo.kt
@@ -289,7 +289,9 @@ open class TileInfo {
 
     fun hasImprovementInProgress() = improvementInProgress!=null
 
-    fun isCoastalTile() = neighbors.any { it.baseTerrain==Constants.coast }
+    @delegate:Transient
+    private val _isCoastalTile: Boolean by lazy { neighbors.any { it.baseTerrain==Constants.coast } }
+    fun isCoastalTile() = _isCoastalTile
 
     fun hasViewableResource(civInfo: CivilizationInfo): Boolean =
             resource != null && (getTileResource().revealedBy == null || civInfo.tech.isResearched(getTileResource().revealedBy!!))

--- a/core/src/com/unciv/models/ruleset/Building.kt
+++ b/core/src/com/unciv/models/ruleset/Building.kt
@@ -237,7 +237,7 @@ class Building : NamedStats(), IConstruction{
                 || rejectionReason == "Wonder is being built elsewhere"
     }
 
-    fun getRejectionReason(construction: CityConstructions):String{
+    fun getRejectionReason(construction: CityConstructions, queueToConsiderBuilt: Collection<String> = listOf()):String{
         if (construction.isBuilt(name)) return "Already built"
 
         val cityCenter = construction.cityInfo.getCenterTile()
@@ -294,8 +294,13 @@ class Building : NamedStats(), IConstruction{
             if (civInfo.cities.any {it.cityConstructions.isBuilt(name) })
                 return "National Wonder is already built"
             if (requiredBuildingInAllCities!=null
-                    && civInfo.cities.any { !it.isPuppet && !it.cityConstructions
-                            .containsBuildingOrEquivalent(requiredBuildingInAllCities!!) })
+                    && civInfo.cities.any {
+                        !it.isPuppet &&
+                        ! (
+                            it.cityConstructions.containsBuildingOrEquivalent(requiredBuildingInAllCities!!)
+                                || it == construction.cityInfo && queueToConsiderBuilt.contains(requiredBuildingInAllCities!!)
+                        )
+                    })
                 return "Requires a [$requiredBuildingInAllCities] in all cities"
             if (civInfo.cities.any {it!=construction.cityInfo && it.cityConstructions.isBeingConstructedOrEnqueued(name) })
                 return "National Wonder is being built elsewhere"
@@ -303,9 +308,15 @@ class Building : NamedStats(), IConstruction{
                 return "No national wonders for city-states"
         }
 
-        if (requiredBuilding != null && !construction.containsBuildingOrEquivalent(requiredBuilding!!))
+        if (requiredBuilding != null && ! (
+                        construction.containsBuildingOrEquivalent(requiredBuilding!!)
+                            || queueToConsiderBuilt.contains(requiredBuilding!!)
+                    ))
             return "Requires a [$requiredBuilding] in this city"
-        if (cannotBeBuiltWith != null && construction.isBuilt(cannotBeBuiltWith!!))
+        if (cannotBeBuiltWith != null && (
+                        construction.isBuilt(cannotBeBuiltWith!!)
+                            || queueToConsiderBuilt.contains(cannotBeBuiltWith!!)
+                    ))
             return "Cannot be built with $cannotBeBuiltWith"
 
         if (requiredResource != null && !civInfo.hasResource(requiredResource!!))
@@ -324,7 +335,9 @@ class Building : NamedStats(), IConstruction{
 
         if ("Spaceship part" in uniques) {
             if (!civInfo.containsBuildingUnique("Enables construction of Spaceship parts")) return "Apollo project not built!"
-            if (civInfo.victoryManager.unconstructedSpaceshipParts()[name] == 0) return "Don't need to build any more of these!"
+            val unconstructedParts = (civInfo.victoryManager.unconstructedSpaceshipParts()[name] ?: 0)
+                    - queueToConsiderBuilt.count { it == name }
+            if (unconstructedParts <= 0) return "Don't need to build any more of these!"
         }
 
         if(!civInfo.gameInfo.gameParameters.victoryTypes.contains(VictoryType.Scientific)
@@ -335,7 +348,10 @@ class Building : NamedStats(), IConstruction{
     }
 
     override fun isBuildable(construction: CityConstructions): Boolean {
-        return getRejectionReason(construction)==""
+        return getRejectionReason(construction).isEmpty()
+    }
+    override fun isBuildableWithQueue(construction: CityConstructions, queueToConsiderBuilt: Collection<String>): Boolean {
+        return getRejectionReason(construction, queueToConsiderBuilt).isEmpty()
     }
 
     override fun postBuildEvent(cityConstructions: CityConstructions, wasBought: Boolean): Boolean {

--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -123,34 +123,39 @@ class BaseUnit : INamed, IConstruction {
                 || rejectionReason.startsWith("Consumes")
     }
 
-    fun getRejectionReason(construction: CityConstructions): String {
-        if(unitType.isWaterUnit() && !construction.cityInfo.getCenterTile().isCoastalTile())
-            return "Can't build water units by the coast"
-        val civRejectionReason = getRejectionReason(construction.cityInfo.civInfo)
-        if(civRejectionReason!="") return civRejectionReason
-        return ""
+    fun getRejectionReason(construction: CityConstructions, queueToConsiderBuilt: Collection<String> = listOf()): String {
+        return if(unitType.isWaterUnit() && !construction.cityInfo.getCenterTile().isCoastalTile())
+            "Can't build water units by the coast"
+        else getRejectionReason(construction.cityInfo.civInfo, queueToConsiderBuilt)
     }
 
-    fun getRejectionReason(civInfo: CivilizationInfo): String {
-        if (unbuildable) return "Unbuildable"
-        if (requiredTech!=null && !civInfo.tech.isResearched(requiredTech!!)) return "$requiredTech not researched"
-        if (obsoleteTech!=null && civInfo.tech.isResearched(obsoleteTech!!)) return "Obsolete by $obsoleteTech"
-        if (uniqueTo!=null && uniqueTo!=civInfo.civName) return "Unique to $uniqueTo"
-        if (civInfo.gameInfo.ruleSet.units.values.any { it.uniqueTo==civInfo.civName && it.replaces==name }) return "Our unique unit replaces this"
-        if (!civInfo.gameInfo.gameParameters.nuclearWeaponsEnabled
-                && uniques.contains("Requires Manhattan Project")) return "Disabled by setting"
-        if (uniques.contains("Requires Manhattan Project") && !civInfo.containsBuildingUnique("Enables nuclear weapon"))
-            return "Requires Manhattan Project"
-        if (requiredResource!=null && !civInfo.hasResource(requiredResource!!)) return "Consumes 1 [$requiredResource]"
-        if (name == Constants.settler && civInfo.isCityState()) return "No settler for city-states"
-        if (name == Constants.settler && civInfo.isOneCityChallenger()) return "No settler for players in One City Challenge"
-        return ""
+    fun getRejectionReason(civInfo: CivilizationInfo, queueToConsiderBuilt: Collection<String> = listOf()): String {
+        return when {
+            unbuildable -> "Unbuildable"
+            requiredTech!=null && !civInfo.tech.isResearched(requiredTech!!) -> "$requiredTech not researched"
+            obsoleteTech!=null && civInfo.tech.isResearched(obsoleteTech!!) -> "Obsolete by $obsoleteTech"
+            uniqueTo!=null && uniqueTo!=civInfo.civName -> "Unique to $uniqueTo"
+            civInfo.gameInfo.ruleSet.units.values.any { it.uniqueTo==civInfo.civName && it.replaces==name } -> "Our unique unit replaces this"
+            !civInfo.gameInfo.gameParameters.nuclearWeaponsEnabled
+                    && uniques.contains("Requires Manhattan Project") -> "Disabled by setting"
+            uniques.contains("Requires Manhattan Project") && ! (
+                    civInfo.containsBuildingUnique("Enables nuclear weapon")
+                        || queueToConsiderBuilt.any { civInfo.gameInfo.ruleSet.buildings[it]?.uniques?.any { it == "Enables nuclear weapon" } ?: false }
+                ) -> "Requires Manhattan Project"
+            requiredResource!=null && !civInfo.hasResource(requiredResource!!) -> "Consumes 1 [$requiredResource]"
+            name == Constants.settler && civInfo.isCityState() -> "No settler for city-states"
+            name == Constants.settler && civInfo.isOneCityChallenger() -> "No settler for players in One City Challenge"
+            else -> ""
+        }
     }
 
     fun isBuildable(civInfo: CivilizationInfo) = getRejectionReason(civInfo)==""
 
     override fun isBuildable(construction: CityConstructions): Boolean {
-        return getRejectionReason(construction) == ""
+        return getRejectionReason(construction).isEmpty()
+    }
+    override fun isBuildableWithQueue(construction: CityConstructions, queueToConsiderBuilt: Collection<String>): Boolean {
+        return getRejectionReason(construction, queueToConsiderBuilt).isEmpty()
     }
 
     override fun postBuildEvent(construction: CityConstructions, wasBought: Boolean): Boolean {

--- a/core/src/com/unciv/ui/cityscreen/ConstructionsTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/ConstructionsTable.kt
@@ -185,7 +185,7 @@ class ConstructionsTable(val cityScreen: CityScreen) : Table(CameraStageBaseScre
         val isFirstConstructionOfItsKind = cityConstructions.isFirstConstructionOfItsKind(constructionQueueIndex, name)
         val turnsToComplete = cityConstructions.turnsToConstruction(name, isFirstConstructionOfItsKind)
         var text = name.tr() +
-                if (name in PerpetualConstruction.perpetualConstructionsMap) "\n8"
+                if (name in PerpetualConstruction.perpetualConstructionsMap) "\n∞"
                 else turnOrTurns(turnsToComplete)
 
         val constructionResource = cityConstructions.getConstruction(name).getResource()

--- a/core/src/com/unciv/ui/cityscreen/ConstructionsTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/ConstructionsTable.kt
@@ -139,7 +139,7 @@ class ConstructionsTable(val cityScreen: CityScreen) : Table(CameraStageBaseScre
 
             val productionButton = getProductionButton(unit,
                     buttonText,
-                    unit.getRejectionReason(cityConstructions))
+                    unit.getRejectionReason(cityConstructions, cityConstructions.getCompleteConstructionQueue()))
             units.add(productionButton)
         }
 
@@ -150,7 +150,7 @@ class ConstructionsTable(val cityScreen: CityScreen) : Table(CameraStageBaseScre
                 buttonText += "\n"+"Consumes 1 [${building.requiredResource}]".tr()
             val productionTextButton = getProductionButton(building,
                     buttonText,
-                    building.getRejectionReason(cityConstructions)
+                    building.getRejectionReason(cityConstructions, cityConstructions.getCompleteConstructionQueue())
             )
             if (building.isWonder) buildableWonders += productionTextButton
             else if (building.isNationalWonder) buildableNationalWonders += productionTextButton
@@ -184,7 +184,9 @@ class ConstructionsTable(val cityScreen: CityScreen) : Table(CameraStageBaseScre
 
         val isFirstConstructionOfItsKind = cityConstructions.isFirstConstructionOfItsKind(constructionQueueIndex, name)
         val turnsToComplete = cityConstructions.turnsToConstruction(name, isFirstConstructionOfItsKind)
-        var text = name.tr() + turnOrTurns(turnsToComplete)
+        var text = name.tr() +
+                if (name in PerpetualConstruction.perpetualConstructionsMap) "\n8"
+                else turnOrTurns(turnsToComplete)
 
         val constructionResource = cityConstructions.getConstruction(name).getResource()
 
@@ -278,7 +280,7 @@ class ConstructionsTable(val cityScreen: CityScreen) : Table(CameraStageBaseScre
             button = TextButton("Add to queue".tr(), CameraStageBaseScreen.skin)
             if (construction == null
                     || cityConstructions.isQueueFull()
-                    || !cityConstructions.getConstruction(construction.name).isBuildable(cityConstructions)
+                    || !cityConstructions.getConstruction(construction.name).isBuildableWithQueue(cityConstructions, cityConstructions.getCompleteConstructionQueue())
                     || !UncivGame.Current.worldScreen.isPlayersTurn
                     || construction is PerpetualConstruction && cityConstructions.isBeingConstructedOrEnqueued(construction.name)
                     || city.isPuppet) {
@@ -364,18 +366,48 @@ class ConstructionsTable(val cityScreen: CityScreen) : Table(CameraStageBaseScre
         return button
     }
 
+    // Now that buildings can be queued if their prerequisites are in the queue (not already built)
+    // we need to prevent queue reordering to mess that up. Without this guard, validateConstructionQueue
+    // would simply remove the offending entries
+    private fun isRaisePriorityOK(constructionQueueIndex: Int, name: String, city: CityInfo): Boolean {
+        val construction = city.cityConstructions.getConstruction(name)
+        // Perpetuals please never move up
+        if (construction is PerpetualConstruction) return false
+        // valid construction prerequisites from queue left after this were moved one up
+        val upperQueue = city.cityConstructions.getCompleteConstructionQueue().take(constructionQueueIndex)
+        // now test if it can still be built with those in-queue prerequisites
+        return construction.isBuildableWithQueue(city.cityConstructions, upperQueue)
+    }
+    private fun isLowerPriorityOK(constructionQueueIndex: Int, name: String, city: CityInfo)
+        = isRaisePriorityOK(constructionQueueIndex+1, city.cityConstructions.constructionQueue[constructionQueueIndex+1], city)
+
+    private fun raiseLowerCommmonHandler(constructionQueueIndex: Int, name: String, direction: Int, validationFailure: Boolean) {
+        if (validationFailure) {
+            cityScreen.selectedConstruction = null
+            selectedQueueEntry = -2
+        } else {
+            cityScreen.selectedConstruction = cityScreen.city.cityConstructions.getConstruction(name)
+            selectedQueueEntry = constructionQueueIndex + direction
+        }
+        cityScreen.selectedTile = null
+        cityScreen.update()
+    }
+
     private fun getRaisePriorityButton(constructionQueueIndex: Int, name: String, city: CityInfo): Table {
         val tab = Table()
-        tab.add(ImageGetter.getImage("OtherIcons/Up").surroundWithCircle(40f))
-        if (UncivGame.Current.worldScreen.isPlayersTurn && !city.isPuppet) {
+        val image = ImageGetter.getImage("OtherIcons/Up").surroundWithCircle(40f)
+        val enable = UncivGame.Current.worldScreen.isPlayersTurn && !city.isPuppet
+                && isRaisePriorityOK(constructionQueueIndex, name, city)
+        if (!enable) image.circle.color = Color.DARK_GRAY
+        tab.add(image)
+        if (enable) {
             tab.touchable = Touchable.enabled
             tab.onClick {
                 tab.touchable = Touchable.disabled
-                city.cityConstructions.raisePriority(constructionQueueIndex)
-                cityScreen.selectedConstruction = cityScreen.city.cityConstructions.getConstruction(name)
-                cityScreen.selectedTile = null
-                selectedQueueEntry = constructionQueueIndex - 1
-                cityScreen.update()
+                raiseLowerCommmonHandler(
+                        constructionQueueIndex, name, direction = -1,
+                        validationFailure = city.cityConstructions.raisePriority(constructionQueueIndex)
+                )
             }
         }
         return tab
@@ -383,16 +415,19 @@ class ConstructionsTable(val cityScreen: CityScreen) : Table(CameraStageBaseScre
 
     private fun getLowerPriorityButton(constructionQueueIndex: Int, name: String, city: CityInfo): Table {
         val tab = Table()
-        tab.add(ImageGetter.getImage("OtherIcons/Down").surroundWithCircle(40f))
-        if (UncivGame.Current.worldScreen.isPlayersTurn && !city.isPuppet) {
+        val image = ImageGetter.getImage("OtherIcons/Down").surroundWithCircle(40f)
+        val enable = UncivGame.Current.worldScreen.isPlayersTurn && !city.isPuppet
+                && isLowerPriorityOK(constructionQueueIndex, name, city)
+        if (!enable) image.circle.color = Color.DARK_GRAY
+        tab.add(image)
+        if (enable) {
             tab.touchable = Touchable.enabled
             tab.onClick {
                 tab.touchable = Touchable.disabled
-                city.cityConstructions.lowerPriority(constructionQueueIndex)
-                cityScreen.selectedConstruction = cityScreen.city.cityConstructions.getConstruction(name)
-                cityScreen.selectedTile = null
-                selectedQueueEntry = constructionQueueIndex + 1
-                cityScreen.update()
+                raiseLowerCommmonHandler(
+                        constructionQueueIndex, name, direction = 1,
+                        validationFailure = city.cityConstructions.lowerPriority(constructionQueueIndex)
+                )
             }
         }
         return tab


### PR DESCRIPTION
was #2424 until git royally messed it up, so this is the same re-merged externally + fix for 'bux gold for x gold'

@JackRainy : That bug was 'simply' UI not taking into account that the 'validator' decided to reorg the queue. I both hardened the UI onclick (in a KISS way - the validator runs in the logic layer and has not enough context to clean up UI stuff or inform it how to do so, so I bubbled up a Boolean false=was already valid / true = cleaned and just select nothing if true) ...and disabled the buttons for that case. And I couldn't resist redoing the '0 turn' line after you screenshotted it so prominently. Looks better without the symbol, but after being quite surprised it even got included in the charset I had to leave it there.