### PR TITLE
Allow queuing dependents

### DIFF
--- a/core/src/com/unciv/logic/city/CityConstructions.kt
+++ b/core/src/com/unciv/logic/city/CityConstructions.kt
@@ -389,6 +389,7 @@ class CityConstructions {
             currentConstructionIsUserSet = true
         } else
             constructionQueue.add(constructionName)
+        validateConstructionQueue()
     }
 
     /** If this was done automatically, we should automatically try to choose a new construction and treat it as such */
@@ -398,8 +399,10 @@ class CityConstructions {
             if(automatic) chooseNextConstruction()
             else constructionQueue.add("Nothing") // To prevent Construction Automation
             currentConstructionIsUserSet = false
+        } else { // we're just continuing the regular queue
+            currentConstructionIsUserSet = true
+            validateConstructionQueue()
         }
-        else currentConstructionIsUserSet = true // we're just continuing the regular queue
     }
 
     fun raisePriority(constructionQueueIndex: Int): Boolean {

--- a/core/src/com/unciv/logic/city/CityConstructions.kt
+++ b/core/src/com/unciv/logic/city/CityConstructions.kt
@@ -254,6 +254,7 @@ class CityConstructions {
      * @return Boolean: true when any change has been applied
     */
     fun validateConstructionQueue(): Boolean {
+        if (constructionQueue.isEmpty()) return false
         val tempQueue = mutableListOf<String>()
         var anyChange = false
         val lastConstruction = constructionQueue.last()

--- a/core/src/com/unciv/logic/city/CityInfo.kt
+++ b/core/src/com/unciv/logic/city/CityInfo.kt
@@ -556,6 +556,7 @@ class CityInfo {
     fun sellBuilding(buildingName:String){
         cityConstructions.builtBuildings.remove(buildingName)
         cityConstructions.removeBuilding(buildingName)
+        cityConstructions.validateConstructionQueue()       // if true queue display needs updating - unnecessary right now
         civInfo.gold += getGoldForSellingBuilding(buildingName)
         hasSoldBuildingThisTurn=true
 

--- a/core/src/com/unciv/logic/city/IConstruction.kt
+++ b/core/src/com/unciv/logic/city/IConstruction.kt
@@ -9,6 +9,8 @@ interface IConstruction : INamed {
     fun getProductionCost(civInfo: CivilizationInfo): Int
     fun getGoldCost(civInfo: CivilizationInfo): Int
     fun isBuildable(cityConstructions: CityConstructions): Boolean
+    fun isBuildableWithQueue(cityConstructions: CityConstructions, queueToConsiderBuilt: Collection<String>): Boolean
+        = isBuildable(cityConstructions)
     fun shouldBeDisplayed(cityConstructions: CityConstructions): Boolean
     fun postBuildEvent(construction: CityConstructions, wasBought: Boolean = false): Boolean  // Yes I'm hilarious.
     fun getResource(): String?

--- a/core/src/com/unciv/ui/cityscreen/ConstructionsTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/ConstructionsTable.kt
@@ -371,11 +371,12 @@ class ConstructionsTable(val cityScreen: CityScreen) : Table(CameraStageBaseScre
     // we need to prevent queue reordering to mess that up. Without this guard, validateConstructionQueue
     // would simply remove the offending entries
     private fun isRaisePriorityOK(constructionQueueIndex: Int, name: String, city: CityInfo): Boolean {
+        if (constructionQueueIndex <= 0) return false       // safeguard, should never be called so
         val construction = city.cityConstructions.getConstruction(name)
         // Perpetuals please never move up
         if (construction is PerpetualConstruction) return false
         // Get the part of the queue above this if this were moved one up
-        val upperQueue = city.cityConstructions.constructionQueue.take(constructionQueueIndex)
+        val upperQueue = city.cityConstructions.constructionQueue.take(constructionQueueIndex - 1)
         // now test if it can still be built with those in-queue prerequisites
         return construction.isBuildableWithQueue(city.cityConstructions, upperQueue)
     }


### PR DESCRIPTION
(from commit comment): Allow queuing constructions with prerequisites if those are in the queue
+ UI safeguards against reordering those
+ Queue cleanup after selling a building
+ Disabled Queue reordering buttons (e.g. isPuppet) now visibly grayed out
+ Side effect: cannotBeBuiltWith is now respected within the queue
+ Perpetuals can only exist at the end of the queue, auto move
+ Queueing another perpetual overrides an existing one

![Peek 2020-04-16 20-50](https://user-images.githubusercontent.com/63000004/79495278-a7c36580-8024-11ea-91e7-d1d0bc8009eb.gif)

Reworked #2428 / #2424