### PR TITLE
Bring Legion Unit closer to wiki?

### DIFF
--- a/android/assets/jsons/Units.json
+++ b/android/assets/jsons/Units.json
@@ -324,7 +324,6 @@
 		"cost": 75,
 		"requiredTech": "Iron Working",
 		"upgradesTo": "Longswordsman",
-		"obsoleteTech": "Steel",
 		"requiredResource": "Iron",
 		"uniques": ["Can construct roads"],
 		"hurryCostModifier": 20,

--- a/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
@@ -110,16 +110,17 @@ object UnitActions {
     }
 
     private fun addConstructRoadsAction(unit: MapUnit, tile: TileInfo, actionList: ArrayList<UnitAction>) {
+        val improvement = RoadStatus.Road.improvement(unit.civInfo.gameInfo.ruleSet) ?: return
         if (unit.hasUnique("Can construct roads")
                 && tile.roadStatus == RoadStatus.None
                 && tile.improvementInProgress != "Road"
                 && tile.isLand
-                && unit.civInfo.tech.isResearched(RoadStatus.Road.improvement(unit.civInfo.gameInfo.ruleSet)!!.techRequired!!))
+                && (improvement.techRequired==null || unit.civInfo.tech.isResearched(improvement.techRequired!!)))
             actionList += UnitAction(
                     type = UnitActionType.ConstructRoad,
                     action = {
                         tile.improvementInProgress = "Road"
-                        tile.turnsToImprovement = 4
+                        tile.turnsToImprovement = improvement.getTurnsToBuild(unit.civInfo)
                     }.takeIf { unit.currentMovement > 0 })
     }
 


### PR DESCRIPTION
The wiki is clear enough: [The Legion never becomes obsolete](https://civilization.fandom.com/wiki/Legion_(Civ5))
Road building speed is now a hard "4" but should at least depend on gamespeed. The Legion entry says nothing about effect of [wonder](https://civilization.fandom.com/wiki/Pyramids_(Civ5)) or [policy](https://civilization.fandom.com/wiki/Citizenship_(Civ5)), but both say "Tile improvement construction speed" - which sounds like it _would_ apply, so I coded that.
(added in a little crashproofing against mad modders)

Not tackled: Fort ability (how exactly would we prefer that? Another entry on the worldscreen or have the Legion open a limited improvement picker if both possible? IMHO fortify-able units should also be able to sleep (meaning they awaken on seeing intruders but get no defense bonus - at least in older civ's this sentry function was normal) - if we had that the Legion could have 2+2+X+D = 6 action buttons. No prob on large screens...)