### PR TITLE
Effect of rationalism was not visible in city UI

### DIFF
--- a/core/src/com/unciv/Constants.kt
+++ b/core/src/com/unciv/Constants.kt
@@ -61,4 +61,6 @@ object Constants {
     const val tutorialPopupNamePrefix = "Tutorial: "
 
     const val close = "Close"
+
+    const val scienceConversionEffect = "Production to science conversion in cities increased by 33%"
 }

--- a/core/src/com/unciv/logic/city/CityStats.kt
+++ b/core/src/com/unciv/logic/city/CityStats.kt
@@ -64,7 +64,7 @@ class CityStats {
             "Gold" -> stats.gold += production / 4
             "Science" -> {
                 var scienceProduced = production / 4
-                if (cityInfo.civInfo.policies.hasEffect("Production to science conversion in cities increased by 33%")) scienceProduced *= 1.33f
+                if (cityInfo.civInfo.policies.hasEffect(Constants.scienceConversionEffect)) scienceProduced *= 1.33f
                 stats.science += scienceProduced
             }
         }

--- a/core/src/com/unciv/ui/cityscreen/ConstructionInfoTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/ConstructionInfoTable.kt
@@ -66,7 +66,7 @@ class ConstructionInfoTable(val city: CityInfo): Table() {
         else if (construction is Building)
             description = construction.getDescription(true, city.civInfo, city.civInfo.gameInfo.ruleSet)
         else if(construction is PerpetualConstruction)
-            description = construction.description.tr()
+            description = construction.description.replace("[rate]","[${construction.getConversionRate(city)}]") .tr()
         else description="" // Should never happen
 
         val descriptionLabel = description.toLabel()


### PR DESCRIPTION
**Careful: translation patch coming separately** - probably works by ditching this and using 2442 only since I didn't rebase. Still, separate is good as perhaps you want to do this differently - I'm all ears should someone have a better idea.

Well, with rationalism UI was wrong, mechanics right.
![image](https://user-images.githubusercontent.com/63000004/79511088-e2d29280-803e-11ea-9227-3fa4369999a5.png)
