### PR TITLE
Fix Legionary and Worker building road should not stack

### DIFF
--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -357,8 +357,14 @@ class MapUnit {
     }
 
     private fun doPostTurnAction() {
-        if (name == Constants.worker && getTile().improvementInProgress != null) workOnImprovement()
-        if(hasUnique("Can construct roads") && currentTile.improvementInProgress=="Road") workOnImprovement()
+        if (name == Constants.worker) {
+            if (getTile().improvementInProgress != null && action?.startsWith("moveTo") != true)
+                workOnImprovement()
+        } else if (hasUnique("Can construct roads") && currentTile.improvementInProgress=="Road") {
+            val civilianInSameTile = getTile().civilianUnit
+            if (civilianInSameTile==null || civilianInSameTile?.name != Constants.worker || civilianInSameTile?.action?.startsWith("moveTo") == true )
+                workOnImprovement()
+        }
         if(currentMovement == getMaxMovement().toFloat()
                 && isFortified()){
             val currentTurnsFortified = getFortificationTurns()


### PR DESCRIPTION
**_Careful_** - Rule change needs consideration _and_ untested.

I know Legion+Worker in a tile builing a road gives 2 points per turn. And [wiki](https://civilization.fandom.com/wiki/Legion_(Civ5)) says "and a Legion cannot build on a tile if a Worker is already building something there" - so this piece of code needs a fix.

But - the routine gets called in order of when a unit was built, so deciding for the Legion cannot easily draw from knowledge what the Worker may have done - it may come before or after. So its presence alone is no good. Then again, I always thought a Worker 'just passing through' with orders to move somewhere else should not progress a tile improvement. With this implemented for the worker the Legion's test becomes meaningful - if it's there and not moving, then I can be sure its contribution has been or will be booked. This assumes two things: No other factor moves workers while this is evaluated for all units (right now `civInfo.endTurn()` -> `getCivUnits().forEach { it.endTurn() }` -> `doPostTurnAction` is OK), and that movement action is cleared immediately on reaching a destination, and for multiturn moves I'm not too sure about that......

While here we should also consider whether Workers/Legion with no movement left (or a mod unit having build road + move after attacking when it has attacked) should be able to contrubute to improvement progress - I always thought this is a rule-bending exploit...

Lastly, that worker test should be a test for the effect, not by name (too lazy now, let's decide first)....

So, what do you think the rules should be exactly...?
