### PR TITLE
Hotfix: city-state must get at least 1 starting technology

### DIFF
--- a/core/src/com/unciv/logic/GameStarter.kt
+++ b/core/src/com/unciv/logic/GameStarter.kt
@@ -91,6 +91,8 @@ object GameStarter {
         for (cityStateName in availableCityStatesNames.take(newGameParameters.numberOfCityStates)) {
             val civ = CivilizationInfo(cityStateName)
             gameInfo.civilizations.add(civ)
+            for(tech in ruleset.technologies.values.filter { it.uniques.contains("Starting tech") })
+                civ.tech.techsResearched.add(tech.name) // can't be .addTechnology because the civInfo isn't assigned yet
         }
 
     }


### PR DESCRIPTION
After recent changes to the starting technologies, the game crashes on the very first turns, if it is created with the city-states. That's a fix for the crash.