### PR TITLE
Minimap size may be a matter of taste (or screen size)

### DIFF
--- a/core/src/com/unciv/models/metadata/GameSettings.kt
+++ b/core/src/com/unciv/models/metadata/GameSettings.kt
@@ -34,6 +34,8 @@ class GameSettings {
     var orderTradeOffersByAmount = true
     var windowState = WindowState()
     var isFreshlyCreated = false
+    var minimapSize = 20
+    var minimapSquare = false
 
     init {
         // 26 = Android Oreo. Versions below may display permanent icon in notification bar.

--- a/core/src/com/unciv/ui/worldscreen/Minimap.kt
+++ b/core/src/com/unciv/ui/worldscreen/Minimap.kt
@@ -17,6 +17,7 @@ import com.unciv.ui.utils.onClick
 import com.unciv.ui.utils.surroundWithCircle
 import kotlin.math.max
 import kotlin.math.min
+import kotlin.math.sqrt
 
 class Minimap(val mapHolder: WorldMapHolder) : ScrollPane(null){
     val allTiles = Group()
@@ -109,7 +110,15 @@ class MinimapHolder(mapHolder: WorldMapHolder): Table(){
 
     fun getWrappedMinimap(): Table {
         val internalMinimapWrapper = Table()
-        internalMinimapWrapper.add(minimap).size(worldScreen.stage.width/5,worldScreen.stage.height/5)
+
+        val sizePercent = worldScreen.game.settings.minimapSize
+        val sizeWinX = worldScreen.stage.width * sizePercent / 100
+        val sizeWinY = worldScreen.stage.height * sizePercent / 100
+        val isSquare = worldScreen.game.settings.minimapSquare
+        val sizeX = if (isSquare) sqrt(sizeWinX * sizeWinY) else sizeWinX
+        val sizeY = if (isSquare) sizeX else sizeWinY
+        internalMinimapWrapper.add(minimap).size(sizeX,sizeY)
+
         internalMinimapWrapper.background=ImageGetter.getBackground(Color.GRAY)
         internalMinimapWrapper.pack()
 


### PR DESCRIPTION
... and I liked square better. I could add an UI for this, too.

I liked whole-world better, too, even with a huge map, but then I've got a 32" monitor. 

Ideal might be minimap zoomable like the big one, limits ~ 20hexes to whole-world maybe, saved with game, and if it shows significantly more than the main map then mark the main window viewport as rectangle on the minimap. I wouldn't have any concept on how to achieve that - transform world map holder to world map coords? No idea. Paint a rectangle? You'd probably have to do the lines as textured thin actors? Beyond me. I didn't even find an alternative to having setScrollTomapHolder() fire like a gatling for anything - there *is* no event for when a fling-pan settles that I could find. Except doing a timer.