### PR TITLE
Minimap size options added to user interface

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -409,6 +409,9 @@ When disabled, saves battery life but certain animations will be suspended =
 Order trade offers by amount = 
 Generate translation files = 
 Translation files are generated successfully. = 
+Off = 
+Square = 
+Minimap size = 
 
 # Notifications
 

--- a/core/src/com/unciv/ui/worldscreen/mainmenu/WorldScreenOptionsPopup.kt
+++ b/core/src/com/unciv/ui/worldscreen/mainmenu/WorldScreenOptionsPopup.kt
@@ -82,9 +82,9 @@ class WorldScreenOptionsPopup(val worldScreen:WorldScreen) : Popup(worldScreen) 
         addYesNoRow ("Show tutorials", settings.showTutorials, true) {
             settings.showTutorials = it
         }
-        addYesNoRow ("Show minimap", settings.showMinimap, true) {
-            settings.showMinimap = it
-        }
+
+        addMinimapControl()
+
         addYesNoRow ("Show pixel units", settings.showPixelUnits, true) {
             settings.showPixelUnits = it
         }
@@ -326,6 +326,35 @@ class WorldScreenOptionsPopup(val worldScreen:WorldScreen) : Popup(worldScreen) 
         reloadWorldAndOptions()
     }
 
+    private fun addMinimapControl() {
+        innerTable.add("Show minimap".toLabel())
+        val minimapSelectBox = SelectBox<String>(skin)
+        val minimapArray = Array<String>()
+        minimapArray.addAll("Off".tr(), "Default".tr(), "Square".tr())
+        minimapSelectBox.items = minimapArray
+        minimapSelectBox.selected = minimapArray[if (settings.showMinimap) if (settings.minimapSquare) 2 else 1 else 0]
+        innerTable.add(minimapSelectBox).minWidth(240f).pad(10f).row()
+
+        minimapSelectBox.onChange {
+            when (minimapSelectBox.selected) {
+                minimapArray[1] -> { settings.minimapSquare = false; settings.showMinimap = true }
+                minimapArray[2] -> { settings.minimapSquare = true; settings.showMinimap = true }
+                else -> { settings.showMinimap = false }
+            }
+            reloadWorldAndOptions()
+        }
+
+        innerTable.add("Minimap size".tr())
+        val minimapSlider = Slider(15f, 40f, 5f, false, skin)
+        minimapSlider.value = settings.minimapSize.toFloat()
+        innerTable.add(minimapSlider).pad(10f).row()
+
+        minimapSlider.onChange {
+            settings.minimapSize = minimapSlider.value.toInt()
+            settings.save()
+            reloadWorldAndOptions()
+        }
+    }
 }
 
 /*


### PR DESCRIPTION
Kinda cute, except maybe the size change becoming visible in the background should be deferred. Then again, nobody will touch this often.

"Default" is also already used for a map generator type - rename this one? Or rename the map one now that master Conway has passed to "Cellular Automata"? I mean - sounds good and is just as cryptic to the layman as another in the list? For now we could leave it like this, just be aware.