### PR TITLE
Name error in english of one russian city

### DIFF
--- a/android/assets/jsons/translations/English.properties
+++ b/android/assets/jsons/translations/English.properties
@@ -2852,7 +2852,7 @@ Kostoma =
  # Requires translation!
 Nizhniy Novgorod = 
  # Requires translation!
-Sudzal = 
+Sudzal = Suzdal
  # Requires translation!
 Magnitogorsk = 
 


### PR DESCRIPTION
You can't find Sudzal on maps, but Suzdal you can - Fix like this or the noncompromising way?