### PR TITLE
Decrease CPU load for multiplayer game

### DIFF
--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -126,6 +126,7 @@ class WorldScreen(val viewingCiv:CivilizationInfo) : CameraStageBaseScreen() {
 
         if(gameInfo.gameParameters.isOnlineMultiplayer && !gameInfo.isUpToDate)
             isPlayersTurn = false // until we're up to date, don't let the player do anything
+        
         if(gameInfo.gameParameters.isOnlineMultiplayer && !isPlayersTurn) {
             // restart the timer
             if (multiPlayerRefresher != null) {
@@ -136,7 +137,7 @@ class WorldScreen(val viewingCiv:CivilizationInfo) : CameraStageBaseScreen() {
             multiPlayerRefresher = Timer("multiPlayerRefresh", true).apply {
                 scheduleAtFixedRate(object : TimerTask() {
                     override fun run() { Gdx.app.postRunnable{ loadLatestMultiplayerState() } }
-                }, 0, 10000) // 10 sec
+                }, 0, 10000) // 10 seconds
             }
         }
 
@@ -641,7 +642,7 @@ class WorldScreen(val viewingCiv:CivilizationInfo) : CameraStageBaseScreen() {
 
 
     companion object {
-        // these object must not be created multiple times
+        // this object must not be created multiple times
         private var multiPlayerRefresher : Timer? = null
     }
 }


### PR DESCRIPTION
It has been noticed that while waiting for the opponent turn in the multiplayer the CPU load is increased (up to 40%) even higher than during the game.
The root cause has been already known `Actions.forever`, so after rework of the update trigger the load has gone.
| Before | After |
|--------|-------|
|  ![Screenshot 2020-04-22 21 25 46](https://user-images.githubusercontent.com/27405436/80034327-ea8aaf00-84f6-11ea-91b3-23b0a8d1923f.png) | ![Screenshot 2020-04-22 23 54 06](https://user-images.githubusercontent.com/27405436/80034347-f4acad80-84f6-11ea-8f37-d50cc7c5d8e1.png) |

