### PR TITLE
Update template.properties: missing entry

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -662,6 +662,7 @@ Final =
 Other = 
 Population = 
 City States = 
+City-States = 
 Tile yields = 
 Trade routes = 
 Maintenance = 


### PR DESCRIPTION
City-States are used like this as resource origin in the empire overview screen (well, in CityInfo.getCityResourcesForAlly()). Whether the variant without dash is unused I haven't checked.