### PR TITLE
Typos in json and translations: Suzdal, Edinburgh defeat

### DIFF
--- a/android/assets/jsons/Nations.json
+++ b/android/assets/jsons/Nations.json
@@ -178,7 +178,7 @@
 		"cities": ["Moscow","St. Petersburg","Novgorod","Rostov","Yaroslavl","Yekaterinburg","Yakutsk","Vladivostok","Smolensk","Orenburg",
 			"Krasnoyarsk","Khabarovsk","Bryansk","Tver","Novosibirsk","Magadan","Murmansk","Irkutsk","Chita","Samara",
 			"Arkhangelsk","Chelyabinsk","Tobolsk","Vologda","Omsk","Astrakhan","Kursk","Saratov","Tula","Vladimir","Perm",
-			"Voronezh","Pskov","Starayarussa","Kostoma","Nizhniy Novgorod","Sudzal","Magnitogorsk"]
+			"Voronezh","Pskov","Starayarussa","Kostoma","Nizhniy Novgorod","Suzdal","Magnitogorsk"]
 	},
 	{
 		"name": "Rome",
@@ -830,7 +830,7 @@
 
 		"declaringWar": "You shall stain this land no longer with your vileness! To arms, my countrymen - we ride to war!",
 		"attacked": "Traitorous man! The Celtic peoples will not stand for such wanton abuse and slander - I shall have your head!",
-		"defeated": "Vile ruler, kow that you 'won' this war in name only!",
+		"defeated": "Vile ruler, know that you 'won' this war in name only!",
 		"outerColor": [0, 0, 0],
 		"innerColor": [0,102,102],
 		"cities": ["Edinburgh"]

--- a/android/assets/jsons/translations/Czech.properties
+++ b/android/assets/jsons/translations/Czech.properties
@@ -1846,7 +1846,7 @@ Kostoma =
  # Requires translation!
 Nizhniy Novgorod = 
  # Requires translation!
-Sudzal = 
+Suzdal = 
  # Requires translation!
 Magnitogorsk = 
 
@@ -3437,7 +3437,7 @@ You shall stain this land no longer with your vileness! To arms, my countrymen -
  # Requires translation!
 Traitorous man! The Celtic peoples will not stand for such wanton abuse and slander - I shall have your head! = 
  # Requires translation!
-Vile ruler, kow that you 'won' this war in name only! = 
+Vile ruler, know that you 'won' this war in name only! = 
 
 Singapore = Singapur
  # Requires translation!

--- a/android/assets/jsons/translations/Dutch.properties
+++ b/android/assets/jsons/translations/Dutch.properties
@@ -2618,7 +2618,7 @@ Kostoma =
  # Requires translation!
 Nizhniy Novgorod = 
  # Requires translation!
-Sudzal = 
+Suzdal = 
  # Requires translation!
 Magnitogorsk = 
 
@@ -4324,7 +4324,7 @@ You shall stain this land no longer with your vileness! To arms, my countrymen -
  # Requires translation!
 Traitorous man! The Celtic peoples will not stand for such wanton abuse and slander - I shall have your head! = 
  # Requires translation!
-Vile ruler, kow that you 'won' this war in name only! = 
+Vile ruler, know that you 'won' this war in name only! = 
 
  # Requires translation!
 Singapore = 

--- a/android/assets/jsons/translations/English.properties
+++ b/android/assets/jsons/translations/English.properties
@@ -2864,7 +2864,7 @@ Kostoma =
  # Requires translation!
 Nizhniy Novgorod = 
  # Requires translation!
-Sudzal = 
+Suzdal = 
  # Requires translation!
 Magnitogorsk = 
 
@@ -4571,7 +4571,7 @@ You shall stain this land no longer with your vileness! To arms, my countrymen -
  # Requires translation!
 Traitorous man! The Celtic peoples will not stand for such wanton abuse and slander - I shall have your head! = 
  # Requires translation!
-Vile ruler, kow that you 'won' this war in name only! = 
+Vile ruler, know that you 'won' this war in name only! = 
 
  # Requires translation!
 Singapore = 

--- a/android/assets/jsons/translations/French.properties
+++ b/android/assets/jsons/translations/French.properties
@@ -1571,7 +1571,7 @@ Pskov = Pskov
 Starayarussa = Staraïa Roussa
 Kostoma = Kostoma
 Nizhniy Novgorod = Nijni Novgorod
-Sudzal = Soudzal
+Suzdal = Souzdal
 Magnitogorsk = Magnitogorsk
 
 Rome = Rome
@@ -2731,7 +2731,7 @@ How could we fall to the likes of you?! = Comment avons-nous pu perdre contre de
 Edinburgh = Édimbourg
 You shall stain this land no longer with your vileness! To arms, my countrymen - we ride to war! = Vous ne souillerez cette terre plus longtemps ! Aux armes, chevauchons en guerre !
 Traitorous man! The Celtic peoples will not stand for such wanton abuse and slander - I shall have your head! = Traître ! Les peuples celtes ne supporteront pas vos caprices et vos calomnies plus longtemps ! Nous repartirons avec votre tête !
-Vile ruler, kow that you 'won' this war in name only! = Sachez que vous n'avez gagné cette guerre que sur le papier !
+Vile ruler, know that you 'won' this war in name only! = Sachez que vous n'avez gagné cette guerre que sur le papier !
 
 Singapore = Singapour
 Perhaps, in another world, we could have been friends... = Dans un autre monde nous aurions pu être amis...

--- a/android/assets/jsons/translations/German.properties
+++ b/android/assets/jsons/translations/German.properties
@@ -1805,7 +1805,7 @@ Kostoma =
  # Requires translation!
 Nizhniy Novgorod = 
  # Requires translation!
-Sudzal = 
+Suzdal = 
  # Requires translation!
 Magnitogorsk = 
 
@@ -3204,7 +3204,7 @@ You shall stain this land no longer with your vileness! To arms, my countrymen -
  # Requires translation!
 Traitorous man! The Celtic peoples will not stand for such wanton abuse and slander - I shall have your head! = 
  # Requires translation!
-Vile ruler, kow that you 'won' this war in name only! = 
+Vile ruler, know that you 'won' this war in name only! = 
 
 Singapore = Singapur
  # Requires translation!

--- a/android/assets/jsons/translations/Indonesian.properties
+++ b/android/assets/jsons/translations/Indonesian.properties
@@ -1565,7 +1565,7 @@ Pskov = Pskov
 Starayarussa = Starayarussa
 Kostoma = Kostoma
 Nizhniy Novgorod = Nizhniy Novgorod
-Sudzal = Sudzal
+Suzdal = Suzdal
 Magnitogorsk = Magnitogorsk
 
 Rome = Roma
@@ -2434,7 +2434,7 @@ How could we fall to the likes of you?! = Bagaimana bisa kami jatuh ke tanganmu?
 Edinburgh = Edinburgh
 You shall stain this land no longer with your vileness! To arms, my countrymen - we ride to war! = Kamu tidak boleh menodai tanah ini dengan kekejianmu! Bersiaplah, bangsaku - kita pergi berperang!
 Traitorous man! The Celtic peoples will not stand for such wanton abuse and slander - I shall have your head! = Pengkhianat! Orang Kelt tidak akan mendukung perlakuan kasar dan pemfitnahan - Aku akan mendapatkan kepalamu!
-Vile ruler, kow that you 'won' this war in name only! = Penguasa keji, ketahuilah bahwa hanya namamu saja yang 'memenangkan' pertempuran ini!
+Vile ruler, know that you 'won' this war in name only! = Penguasa keji, ketahuilah bahwa hanya namamu saja yang 'memenangkan' pertempuran ini!
 
 Singapore = Singapura
 Perhaps, in another world, we could have been friends... = Mungkin, di dunia lain, kita bisa menjadi teman...

--- a/android/assets/jsons/translations/Italian.properties
+++ b/android/assets/jsons/translations/Italian.properties
@@ -1572,7 +1572,7 @@ Pskov = Pskov
 Starayarussa = Starayarussa
 Kostoma = Kostoma
 Nizhniy Novgorod = Nizhniy Novgorod
-Sudzal = Sudzal
+Suzdal = Suzdal
 Magnitogorsk = Magnitogorsk
 
 Rome = Roma
@@ -2441,7 +2441,7 @@ How could we fall to the likes of you?! = Quale è stato il tuo segreto per scon
 Edinburgh = Edimburgo
 You shall stain this land no longer with your vileness! To arms, my countrymen - we ride to war! = Non macchierai più questo suolo con le tue viltà! Alle armi, miei compagni... si va in guerra!
 Traitorous man! The Celtic peoples will not stand for such wanton abuse and slander - I shall have your head! = Essere spregevole! I Celti non sopporteranno più i tuoi volubili abusi! Avremo la tua testa!
-Vile ruler, kow that you 'won' this war in name only! = Sovrano ripugnante... sappi che hai 'vinto' questa guerra solo nel nome!
+Vile ruler, know that you 'won' this war in name only! = Sovrano ripugnante... sappi che hai 'vinto' questa guerra solo nel nome!
 
 Singapore = Singapore
 Perhaps, in another world, we could have been friends... = Magari, in un altro mondo, saremmo stati amici...

--- a/android/assets/jsons/translations/Japanese.properties
+++ b/android/assets/jsons/translations/Japanese.properties
@@ -1796,7 +1796,7 @@ Kostoma =
  # Requires translation!
 Nizhniy Novgorod = 
  # Requires translation!
-Sudzal = 
+Suzdal = 
  # Requires translation!
 Magnitogorsk = 
 
@@ -3460,7 +3460,7 @@ You shall stain this land no longer with your vileness! To arms, my countrymen -
  # Requires translation!
 Traitorous man! The Celtic peoples will not stand for such wanton abuse and slander - I shall have your head! = 
  # Requires translation!
-Vile ruler, kow that you 'won' this war in name only! = 
+Vile ruler, know that you 'won' this war in name only! = 
 
 Singapore = シンガポール
  # Requires translation!

--- a/android/assets/jsons/translations/Korean.properties
+++ b/android/assets/jsons/translations/Korean.properties
@@ -1823,7 +1823,7 @@ Kostoma =
  # Requires translation!
 Nizhniy Novgorod = 
  # Requires translation!
-Sudzal = 
+Suzdal = 
  # Requires translation!
 Magnitogorsk = 
 
@@ -2947,7 +2947,7 @@ How could we fall to the likes of you?! = 당신같은 사람에게 질 수밖�
 Edinburgh = 에든버러
 You shall stain this land no longer with your vileness! To arms, my countrymen - we ride to war! = 선택의 여지를 주지 않는군요. 전쟁을 일으켜야만 하겠습니다.
 Traitorous man! The Celtic peoples will not stand for such wanton abuse and slander - I shall have your head! = 그렇게 나오시는군요. 이 일은 잊지 않겠습니다.
-Vile ruler, kow that you 'won' this war in name only! = 우리보다 강한 나라에게 지는 것은 치욕적이지 않습니다.
+Vile ruler, know that you 'won' this war in name only! = 우리보다 강한 나라에게 지는 것은 치욕적이지 않습니다.
 
 Singapore = 싱가포르
 Perhaps, in another world, we could have been friends... = 어딘가 다른 우주에서는, 우리가 친구였을 수도 있겠지요...

--- a/android/assets/jsons/translations/Malay.properties
+++ b/android/assets/jsons/translations/Malay.properties
@@ -2773,7 +2773,7 @@ Kostoma =
  # Requires translation!
 Nizhniy Novgorod = 
  # Requires translation!
-Sudzal = 
+Suzdal = 
  # Requires translation!
 Magnitogorsk = 
 
@@ -4473,7 +4473,7 @@ You shall stain this land no longer with your vileness! To arms, my countrymen -
  # Requires translation!
 Traitorous man! The Celtic peoples will not stand for such wanton abuse and slander - I shall have your head! = 
  # Requires translation!
-Vile ruler, kow that you 'won' this war in name only! = 
+Vile ruler, know that you 'won' this war in name only! = 
 
  # Requires translation!
 Singapore = 

--- a/android/assets/jsons/translations/Polish.properties
+++ b/android/assets/jsons/translations/Polish.properties
@@ -1588,7 +1588,7 @@ Pskov = Psków
 Starayarussa = Stara Russa
 Kostoma = Kostroma
 Nizhniy Novgorod = Niżny Nowogród
-Sudzal = Suzdal
+Suzdal = Suzdal
 Magnitogorsk = Magnitogorsk
 
 Rome = Rzym
@@ -2577,7 +2577,8 @@ How could we fall to the likes of you?! = Jak mogliśmy przez ciebie upaść!?
 Edinburgh = Edynburg
 You shall stain this land no longer with your vileness! To arms, my countrymen - we ride to war! = Nie pozostawiasz nam wybor. Wojna musi się rozpocząć.
 Traitorous man! The Celtic peoples will not stand for such wanton abuse and slander - I shall have your head! = Bardzo dobrze, to nie zostanie Tobie zapomnane.
-Vile ruler, kow that you 'won' this war in name only! = There is no dishonor in losing to a worthier foe.
+ # Requires translation!
+Vile ruler, know that you 'won' this war in name only! = 
 
 Singapore = Singapur
 Perhaps, in another world, we could have been friends... = Być może, w innym świecie, moglibyśmy być przyjaciółmi...

--- a/android/assets/jsons/translations/Portuguese.properties
+++ b/android/assets/jsons/translations/Portuguese.properties
@@ -2157,7 +2157,7 @@ Kostoma =
  # Requires translation!
 Nizhniy Novgorod = 
  # Requires translation!
-Sudzal = 
+Suzdal = 
  # Requires translation!
 Magnitogorsk = 
 
@@ -3846,7 +3846,7 @@ You shall stain this land no longer with your vileness! To arms, my countrymen -
  # Requires translation!
 Traitorous man! The Celtic peoples will not stand for such wanton abuse and slander - I shall have your head! = 
  # Requires translation!
-Vile ruler, kow that you 'won' this war in name only! = 
+Vile ruler, know that you 'won' this war in name only! = 
 
  # Requires translation!
 Singapore = 

--- a/android/assets/jsons/translations/Romanian.properties
+++ b/android/assets/jsons/translations/Romanian.properties
@@ -2123,7 +2123,7 @@ Kostoma =
  # Requires translation!
 Nizhniy Novgorod = 
  # Requires translation!
-Sudzal = 
+Suzdal = 
  # Requires translation!
 Magnitogorsk = 
 
@@ -3821,7 +3821,7 @@ You shall stain this land no longer with your vileness! To arms, my countrymen -
  # Requires translation!
 Traitorous man! The Celtic peoples will not stand for such wanton abuse and slander - I shall have your head! = 
  # Requires translation!
-Vile ruler, kow that you 'won' this war in name only! = 
+Vile ruler, know that you 'won' this war in name only! = 
 
  # Requires translation!
 Singapore = 

--- a/android/assets/jsons/translations/Russian.properties
+++ b/android/assets/jsons/translations/Russian.properties
@@ -1591,7 +1591,7 @@ Pskov = Псков
 Starayarussa = Старая Русса
 Kostoma = Кострома
 Nizhniy Novgorod = Нижний Новгород
-Sudzal = Суздаль
+Suzdal = Суздаль
 Magnitogorsk = Магнитогорск
 
 Rome = Рим
@@ -2797,7 +2797,8 @@ How could we fall to the likes of you?! = Как мы могли пасть до
 Edinburgh = Эдинбург
 You shall stain this land no longer with your vileness! To arms, my countrymen - we ride to war! = Ты не оставил нам выбора. Войне быть.
 Traitorous man! The Celtic peoples will not stand for such wanton abuse and slander - I shall have your head! = Очень хорошо, мы никогда не забудем это.
-Vile ruler, kow that you 'won' this war in name only! = There is no dishonor in losing to a worthier foe.
+ # Requires translation!
+Vile ruler, know that you 'won' this war in name only! = 
 
 Singapore = Сингапур
 Perhaps, in another world, we could have been friends... = Возможно, в другой жизни мы могли бы быть друзьями...

--- a/android/assets/jsons/translations/Simplified_Chinese.properties
+++ b/android/assets/jsons/translations/Simplified_Chinese.properties
@@ -1606,7 +1606,7 @@ Starayarussa = 斯塔尔亚鲁萨
 Kostoma = 
 Nizhniy Novgorod = 下诺夫哥罗德
  # Requires translation!
-Sudzal = 
+Suzdal = 
 Magnitogorsk = 马格尼托哥尔斯克
 
 Rome = 罗马
@@ -2789,7 +2789,7 @@ How could we fall to the likes of you?! = 我们怎么会落到你这样的人�
 Edinburgh = 爱丁堡
 You shall stain this land no longer with your vileness! To arms, my countrymen - we ride to war! = 你再也不能用你的卑鄙来玷污这片土地了！为了武器，我的同胞们-我们骑马去打仗！
 Traitorous man! The Celtic peoples will not stand for such wanton abuse and slander - I shall have your head! = 叛徒！凯尔特人不会容忍这种肆无忌惮的辱骂和诽谤——我要你的头！
-Vile ruler, kow that you 'won' this war in name only! = 卑鄙的统治者，知道你只是名义上赢得了这场战争！
+Vile ruler, know that you 'won' this war in name only! = 卑鄙的统治者，知道你只是名义上赢得了这场战争！
 
 Singapore = 新加坡
 Perhaps, in another world, we could have been friends... = 也许，在另一个世界里，我们可以成为朋友...

--- a/android/assets/jsons/translations/Spanish.properties
+++ b/android/assets/jsons/translations/Spanish.properties
@@ -1574,7 +1574,7 @@ Pskov = Pskov
 Starayarussa = Stáraya Rusa
 Kostoma = Kostroma
 Nizhniy Novgorod = Nizhni Nóvgorod
-Sudzal = Sudzal
+Suzdal = Suzdal
 Magnitogorsk = Magnitogorsk
 
 Rome = Roma
@@ -3178,7 +3178,7 @@ You shall stain this land no longer with your vileness! To arms, my countrymen -
  # Requires translation!
 Traitorous man! The Celtic peoples will not stand for such wanton abuse and slander - I shall have your head! = 
  # Requires translation!
-Vile ruler, kow that you 'won' this war in name only! = 
+Vile ruler, know that you 'won' this war in name only! = 
 
  # Requires translation!
 Singapore = 

--- a/android/assets/jsons/translations/Traditional_Chinese.properties
+++ b/android/assets/jsons/translations/Traditional_Chinese.properties
@@ -1908,7 +1908,7 @@ Kostoma =
  # Requires translation!
 Nizhniy Novgorod = 
  # Requires translation!
-Sudzal = 
+Suzdal = 
  # Requires translation!
 Magnitogorsk = 
 
@@ -3567,7 +3567,7 @@ You shall stain this land no longer with your vileness! To arms, my countrymen -
  # Requires translation!
 Traitorous man! The Celtic peoples will not stand for such wanton abuse and slander - I shall have your head! = 
  # Requires translation!
-Vile ruler, kow that you 'won' this war in name only! = 
+Vile ruler, know that you 'won' this war in name only! = 
 
 Singapore = 新加坡
  # Requires translation!

--- a/android/assets/jsons/translations/Turkish.properties
+++ b/android/assets/jsons/translations/Turkish.properties
@@ -1694,7 +1694,7 @@ Pskov = Pskov
 Starayarussa = Strayarussa
 Kostoma = Kostoma
 Nizhniy Novgorod = Nizhniy Novgorod
-Sudzal = Suzd
+Suzdal = Suzd
 Magnitogorsk = Magnitogorsk
 
 Rome = Roma
@@ -3081,7 +3081,7 @@ You shall stain this land no longer with your vileness! To arms, my countrymen -
  # Requires translation!
 Traitorous man! The Celtic peoples will not stand for such wanton abuse and slander - I shall have your head! = 
  # Requires translation!
-Vile ruler, kow that you 'won' this war in name only! = 
+Vile ruler, know that you 'won' this war in name only! = 
 
 Singapore = Singapur
  # Requires translation!

--- a/android/assets/jsons/translations/Ukrainian.properties
+++ b/android/assets/jsons/translations/Ukrainian.properties
@@ -1559,7 +1559,7 @@ Pskov = Псков
 Starayarussa = Старарусса
 Kostoma = Кострома
 Nizhniy Novgorod = Нижній Новгород
-Sudzal = Суздаль
+Suzdal = Суздаль
 Magnitogorsk = Магнітогорськ
 
 Rome = Рим
@@ -2542,7 +2542,7 @@ How could we fall to the likes of you?! = Як ми могли пасти пер
 Edinburgh = Единбург
 You shall stain this land no longer with your vileness! To arms, my countrymen - we ride to war! = Ви не залишили нам вибору. Війні бути.
 Traitorous man! The Celtic peoples will not stand for such wanton abuse and slander - I shall have your head! = Прекрасно, ми цього не забудемо.
-Vile ruler, kow that you 'won' this war in name only! = Немає безчестя в програші гідному ворогу.
+Vile ruler, know that you 'won' this war in name only! = Немає безчестя в програші гідному ворогу.
 
 Singapore = Сінгапур
 Perhaps, in another world, we could have been friends... = Можливо, в іншому світі ми будемо друзями...


### PR DESCRIPTION
I think you said you wanted the Sudzal/Suzdal typo fixed the radical way. Found another. A line having unrelated english on the translation side in russian and polish un-translated.
Note: I've no idea why thai doesn't have any city-related lines.