### PR TITLE
Map editor: Placed improvement check updated: Potentially resolves #2489

### DIFF
--- a/core/src/com/unciv/logic/map/TileInfo.kt
+++ b/core/src/com/unciv/logic/map/TileInfo.kt
@@ -337,7 +337,7 @@ open class TileInfo {
         }
         lineList += baseTerrain.tr()
         if (terrainFeature != null) lineList += terrainFeature!!.tr()
-        if (viewingCiv==null && resource!=null || viewingCiv!=null && hasViewableResource(viewingCiv)) lineList += resource!!.tr()
+        if (resource!=null && (viewingCiv==null || hasViewableResource(viewingCiv))) lineList += resource!!.tr()
         if (naturalWonder != null) lineList += naturalWonder!!.tr()
         if (roadStatus !== RoadStatus.None && !isCityCenter()) lineList += roadStatus.toString().tr()
         if (improvement != null) lineList += improvement!!.tr()

--- a/core/src/com/unciv/logic/map/TileInfo.kt
+++ b/core/src/com/unciv/logic/map/TileInfo.kt
@@ -337,7 +337,7 @@ open class TileInfo {
         }
         lineList += baseTerrain.tr()
         if (terrainFeature != null) lineList += terrainFeature!!.tr()
-        if (viewingCiv==null || hasViewableResource(viewingCiv)) lineList += resource!!.tr()
+        if (viewingCiv==null && resource!=null || viewingCiv!=null && hasViewableResource(viewingCiv)) lineList += resource!!.tr()
         if (naturalWonder != null) lineList += naturalWonder!!.tr()
         if (roadStatus !== RoadStatus.None && !isCityCenter()) lineList += roadStatus.toString().tr()
         if (improvement != null) lineList += improvement!!.tr()

--- a/core/src/com/unciv/models/ruleset/tile/TileImprovement.kt
+++ b/core/src/com/unciv/models/ruleset/tile/TileImprovement.kt
@@ -23,7 +23,7 @@ class TileImprovement : NamedStats() {
     var uniqueTo:String? = null
     var uniques = ArrayList<String>()
 
-    private val turnsToBuild: Int = 0 // This is the base cost.
+    val turnsToBuild: Int = 0 // This is the base cost.
 
 
     fun getTurnsToBuild(civInfo: CivilizationInfo): Int {

--- a/core/src/com/unciv/ui/mapeditor/TileEditorOptionsTable.kt
+++ b/core/src/com/unciv/ui/mapeditor/TileEditorOptionsTable.kt
@@ -12,6 +12,7 @@ import com.unciv.logic.civilization.CivilizationInfo
 import com.unciv.logic.map.MapUnit
 import com.unciv.logic.map.RoadStatus
 import com.unciv.logic.map.TileInfo
+import com.unciv.models.ruleset.tile.ResourceType
 import com.unciv.models.ruleset.tile.TerrainType
 import com.unciv.models.translations.tr
 import com.unciv.ui.tilegroups.TileGroup
@@ -85,7 +86,8 @@ class TileEditorOptionsTable(val mapEditorScreen: MapEditorScreen): Table(Camera
         }).row()
 
         for(improvement in ruleset.tileImprovements.values){
-            if(improvement.name.startsWith("Remove")) continue
+            if (improvement.name.startsWith("Remove")) continue
+            if (improvement.name == Constants.cancelImprovementOrder) continue
             val improvementImage = getHex(Color.WHITE, ImageGetter.getImprovementIcon(improvement.name, 40f))
             improvementImage.onClick {
                 tileAction = {
@@ -373,34 +375,60 @@ class TileEditorOptionsTable(val mapEditorScreen: MapEditorScreen): Table(Camera
             tileInfo.improvement = null
         }
 
-        if(tileInfo.terrainFeature!=null){
+        if (tileInfo.terrainFeature != null) {
             val terrainFeature = tileInfo.getTerrainFeature()!!
             if(terrainFeature.occursOn!=null && !terrainFeature.occursOn.contains(tileInfo.baseTerrain))
                 tileInfo.terrainFeature=null
         }
-        if(tileInfo.resource!=null){
+        if (tileInfo.resource != null) {
             val resource = tileInfo.getTileResource()
             if(resource.terrainsCanBeFoundOn.none { it==tileInfo.baseTerrain || it==tileInfo.terrainFeature })
                 tileInfo.resource=null
         }
-        if(tileInfo.improvement!=null) {
-            if (tileInfo.improvement!!.startsWith("StartingLocation")) {
-                if (tileInfo.isWater || tileInfo.getBaseTerrain().impassable)
-                    tileInfo.improvement = null
-            } else {
-                val improvement = tileInfo.getTileImprovement()!!
-                if (tileInfo.getBaseTerrain().impassable) tileInfo.improvement = null
-                if (improvement.terrainsCanBeBuiltOn.isEmpty() && tileInfo.isWater)
-                    tileInfo.improvement = null
-                if (improvement.terrainsCanBeBuiltOn.isNotEmpty() // for "everywhere" improvements like city ruins, encampments, ancient ruins
-                        && improvement.terrainsCanBeBuiltOn.none { it == tileInfo.baseTerrain || it == tileInfo.terrainFeature })
-                    tileInfo.improvement = null
-            }
+        if (tileInfo.improvement!=null) {
+            normalizeTileImprovement(tileInfo)
         }
-        if(tileInfo.getBaseTerrain().impassable || tileInfo.isWater)
+        if (tileInfo.getBaseTerrain().impassable || tileInfo.isWater)
             tileInfo.roadStatus= RoadStatus.None
     }
 
+    private fun normalizeTileImprovement(tileInfo: TileInfo) {
+        if (tileInfo.improvement!!.startsWith("StartingLocation")) {
+            if (!tileInfo.isLand || tileInfo.getBaseTerrain().impassable)
+                tileInfo.improvement = null
+            return
+        }
+        val improvement = tileInfo.getTileImprovement()!!
+        val topTerrain = tileInfo.getLastTerrain()
+        val resource = if (tileInfo.resource!=null) tileInfo.getTileResource() else null
+        when {
+            // Precedence, simplified: terrainsCanBeBuiltOn, then improves-resource, then 'everywhere', default to false
+            // 'everywhere' improvements (city ruins, encampments, ancient ruins, great improvements)
+            // are recognized as without terrainsCanBeBuiltOn and with turnsToBuild == 0
+            "Cannot be built on bonus resource" in improvement.uniques
+                        && tileInfo.resource != null
+                        && resource?.resourceType == ResourceType.Bonus
+                -> tileInfo.improvement = null      // forbid if this unique matches
+            tileInfo.isLand      // Fishing boats have Coast allowed even though they're meant resource-only
+                        && topTerrain.name in improvement.terrainsCanBeBuiltOn
+                -> Unit     // allow where top terrain explicitly named
+            resource?.improvement == improvement.name
+                        && (!topTerrain.unbuildable || topTerrain.name in improvement.resourceTerrainAllow)
+                -> Unit     // allow where it improves a resource and feature OK
+            tileInfo.isWater || topTerrain.impassable
+                -> tileInfo.improvement = null      // forbid if water or mountains
+            improvement.terrainsCanBeBuiltOn.isEmpty() && improvement.turnsToBuild == 0
+                    // Allow Great Improvement but clear unbuildable terrain feature
+                    // Allow barbarian camps, ruins and similar without clear
+                -> if (topTerrain.unbuildable && improvement.name in Constants.greatImprovements)
+                    tileInfo.terrainFeature = null
+            topTerrain.unbuildable
+                -> tileInfo.improvement = null      // forbid on unbuildable feature
+            "Can only be built on Coastal tiles" in improvement.uniques && tileInfo.isCoastalTile()
+                -> Unit                             // allow Moai where appropriate
+            else -> tileInfo.improvement = null
+        }
+    }
 
     private fun setCurrentHex(tileInfo: TileInfo, text:String){
         val tileGroup = TileGroup(tileInfo, TileSetStrings())
@@ -423,6 +451,5 @@ class TileEditorOptionsTable(val mapEditorScreen: MapEditorScreen): Table(Camera
         currentHex.setPosition(stage.width - currentHex.width-10, 10f)
         stage.addActor(currentHex)
     }
-
 
 }


### PR DESCRIPTION
This is what I came up with after reading #2489.

First of all, it's a matter of policy - the map editor always has allowed rule violations, and even with this, still does (e.g. I didn't touch resource placement). So - do we want it simple but potentially rule-breaking, or do we want it to be sticky with the rules?

If the latter, then this may serve, though one might want to consider first whether rule interpretation shouldn't be one central code for editor and e.g. worker UI - and possibly consider whether a pre-check and modification prevention might not be cleaner than the 'force first and then fix' approach.

Note: The TileInfo.toString() change is an independent bugfix affecting only debugger evaluation - it would crash if ever called from the app with a null viewing civ on a resouce-carrying tile (currently the's no such call I'm aware of). Still important as it can be called from simple mouseovers, and A-Studio is already monstrously crash-prone on tooltips and any no-window-border popups.