### PR TITLE
Fishing boats: Simplified and closer to land improvement rules???

### DIFF
--- a/android/assets/jsons/Civ V - Vanilla/TileImprovements.json
+++ b/android/assets/jsons/Civ V - Vanilla/TileImprovements.json
@@ -74,7 +74,8 @@
 	},
 	{
 		"name": "Fishing Boats",
-		"terrainsCanBeBuiltOn": ["Coast"],
+		//"terrainsCanBeBuiltOn": ["Coast"] - no, this is a resouce-bound improvement
+		"turnsToBuild": 1,
 		"food": 1,
 		"techRequired": "Sailing",
 		"improvingTech": "Compass",
@@ -83,11 +84,11 @@
 
 	// Military improvement
 	{
-		name: "Fort",
-		terrainsCanBeBuiltOn: ["Plains","Grassland","Desert","Hill","Tundra","Snow"],
-		turnsToBuild: 6,
-		techRequired: "Engineering",
-		uniques: ["Gives a defensive bonus of 50%"]
+		"name": "Fort",
+		"terrainsCanBeBuiltOn": ["Plains","Grassland","Desert","Hill","Tundra","Snow"],
+		"turnsToBuild": 6,
+		"techRequired": "Engineering",
+		"uniques": ["Gives a defensive bonus of 50%"]
 	},
 
 	// Transportation
@@ -165,9 +166,9 @@
 		"improvingTechStats": {"gold": 1}
 	},
 	{
-		name: "Citadel",
-		uniques: ["Gives a defensive bonus of 100%", "Deal 30 damage to adjacent enemy units"]
-		// TODO (G&K): adds every tile around it to your territory
+		"name": "Citadel",
+		"uniques": ["Gives a defensive bonus of 100%", "Deal 30 damage to adjacent enemy units"]
+		// Adds every tile around it to your territory: hardcoded in UnitActions.takeOverTilesAround()
 	},
 
 	//Civilization unique improvements

--- a/core/src/com/unciv/ui/mapeditor/TileEditorOptionsTable.kt
+++ b/core/src/com/unciv/ui/mapeditor/TileEditorOptionsTable.kt
@@ -409,8 +409,7 @@ class TileEditorOptionsTable(val mapEditorScreen: MapEditorScreen): Table(Camera
                         && tileInfo.resource != null
                         && resource?.resourceType == ResourceType.Bonus
                 -> tileInfo.improvement = null      // forbid if this unique matches
-            tileInfo.isLand      // Fishing boats have Coast allowed even though they're meant resource-only
-                        && topTerrain.name in improvement.terrainsCanBeBuiltOn
+            topTerrain.name in improvement.terrainsCanBeBuiltOn
                 -> Unit     // allow where top terrain explicitly named
             resource?.improvement == improvement.name
                         && (!topTerrain.unbuildable || topTerrain.name in improvement.resourceTerrainAllow)


### PR DESCRIPTION
Little actual benefit, but please comment:
* getWaterImprovementAction() is a little less hardcoded and a little more resistant to mods causing null exceptions like this - behaviour does not change at least not in my tests
* JR's json style changed closer to standard
* It bugged me the fishing boats are defined differently from oil wells, so I tried out what would happen if I defined them differently, and that's the rest of the changes - I do think terrainsCanBeBuiltOn should express resource-independent 'allows' and work identically on land and water, and it works, though there's still enough hardcoding that one won't really notice. The turnsToBuild is there to make the map editor not lump the boats in with ruins&so on. Works, but honestly - exchanging one unclean-looking thing for another (Type flags??). If we would endeavour to make mods able to define water improvements not bound to resources, then yes we should start somewhat like this. Together with the getWaterImprovementAction change it might even be already enough, though as of now it's untested. So - set a course, captain (?).