### PR TITLE
Make tr() a little faster

### DIFF
--- a/core/src/com/unciv/models/translations/TranslationEntry.kt
+++ b/core/src/com/unciv/models/translations/TranslationEntry.kt
@@ -4,11 +4,10 @@ import java.util.HashMap
 
 class TranslationEntry(val entry: String) : HashMap<String, String>() {
 
-    /** For memory performance on .tr(), which was atrociously memory-expensive */
-    var entryWithShortenedSquareBrackets =""
-
-    init {
-        if(entry.contains('['))
-            entryWithShortenedSquareBrackets=entry.replace(squareBraceRegex,"[]")
-    }
+    // Now stored in the key of the hashmap storing the instances of this class
+//    /** For memory performance on .tr(), which was atrociously memory-expensive */
+//    val entryWithShortenedSquareBrackets =
+//            if (entry.contains('['))
+//                entry.replace(squareBraceRegex,"[]")
+//            else ""
 }

--- a/core/src/com/unciv/models/translations/TranslationFileWriter.kt
+++ b/core/src/com/unciv/models/translations/TranslationFileWriter.kt
@@ -75,13 +75,21 @@ object TranslationFileWriter {
                 }
 
                 val translationKey = line.split(" = ")[0].replace("\\n", "\n")
+                val hashMapKey = if (translationKey.contains('['))
+                            translationKey.replace(squareBraceRegex,"[]")
+                        else translationKey
                 var translationValue = ""
 
-                val translationEntry = translations[translationKey]
+                val translationEntry = translations[hashMapKey]
                 if (translationEntry != null && translationEntry.containsKey(language)) {
                     translationValue = translationEntry[language]!!
                     translationsOfThisLanguage++
                 } else stringBuilder.appendln(" # Requires translation!")
+
+                // Testing assertion only
+                if (translationEntry != null && translationEntry.entry != translationKey) {
+                    println("Assertion failure in generateTranslationFiles: translationEntry.entry != translationKey")
+                }
 
                 val lineToWrite = translationKey.replace("\n", "\\n") +
                         " = " + translationValue.replace("\n", "\\n")
@@ -143,7 +151,10 @@ object TranslationFileWriter {
         val jsonParser = JsonParser()
         val folderHandler = if(modFolder!=null) getFileHandle(modFolder,"jsons")
         else getFileHandle(modFolder, "jsons/Civ V - Vanilla")
-        val listOfJSONFiles = folderHandler.list{file -> file.name.endsWith(".json", true)}
+        val listOfJSONFiles = folderHandler
+                .list{file -> file.name.endsWith(".json", true)}
+                .sortedBy { it.name() }       // generatedStrings maintains order, so let's feed it a predictable one
+
         for (jsonFile in listOfJSONFiles)
         {
             val filename = jsonFile.nameWithoutExtension()

--- a/core/src/com/unciv/models/translations/Translations.kt
+++ b/core/src/com/unciv/models/translations/Translations.kt
@@ -142,6 +142,7 @@ class Translations : LinkedHashMap<String, TranslationEntry>(){
     }
 }
 
+
 // we don't need to allocate different memory for these every time we .tr() - or recompile them.
 
         // Expect a literal [ followed by a captured () group and a literal ].
@@ -149,10 +150,10 @@ class Translations : LinkedHashMap<String, TranslationEntry>(){
 val squareBraceRegex = Regex("""\[([^]]*)]""")
 
         // Just look for either [ or ]
-val eitherSquareBraceRegex=Regex("""\[|]""")
+val eitherSquareBraceRegex = Regex("""\[|]""")
 
         // Analogous as above: Expect a {} pair with any chars but } in between and capture that
-val curlyBraceRegex =Regex("""\{([^}]*)}""")
+val curlyBraceRegex = Regex("""\{([^}]*)}""")
 
 
 fun String.tr(): String {

--- a/core/src/com/unciv/models/translations/Translations.kt
+++ b/core/src/com/unciv/models/translations/Translations.kt
@@ -55,7 +55,7 @@ class Translations : LinkedHashMap<String, TranslationEntry>(){
             // The key for placeholder-containing entries was unused before, let's make it useful
             // What was previously stored as entryWithShortenedSquareBrackets is now the key
             val hashKey = if (translation.key.contains('['))
-                translation.key.replace(squareBraceRegex,"[]")
+                    translation.key.replace(squareBraceRegex,"[]")
                 else translation.key
             if (!containsKey(hashKey))
                 this[hashKey] = TranslationEntry(translation.key)

--- a/core/src/com/unciv/models/translations/Translations.kt
+++ b/core/src/com/unciv/models/translations/Translations.kt
@@ -52,13 +52,18 @@ class Translations : LinkedHashMap<String, TranslationEntry>(){
         }
 
         for (translation in languageTranslations) {
-            if (!containsKey(translation.key))
-                this[translation.key] = TranslationEntry(translation.key)
+            // The key for placeholder-containing entries was unused before, let's make it useful
+            // What was previously stored as entryWithShortenedSquareBrackets is now the key
+            val hashKey = if (translation.key.contains('['))
+                translation.key.replace(squareBraceRegex,"[]")
+                else translation.key
+            if (!containsKey(hashKey))
+                this[hashKey] = TranslationEntry(translation.key)
 
             // why not in one line, Because there were actual crashes.
             // I'm pretty sure I solved this already, but hey double-checking doesn't cost anything.
-            val entry = this[translation.key]
-            if(entry!=null) entry[language] = translation.value
+            val entry = this[hashKey]
+            if (entry!=null) entry[language] = translation.value
         }
 
         val translationFilesTime = System.currentTimeMillis() - translationStart
@@ -137,14 +142,33 @@ class Translations : LinkedHashMap<String, TranslationEntry>(){
     }
 }
 
-val squareBraceRegex = Regex("\\[(.*?)\\]") // we don't need to allocate different memory for this every time we .tr()
+// we don't need to allocate different memory for these every time we .tr() - or recompile them.
 
-val eitherSquareBraceRegex=Regex("\\[|\\]")
+        // Expect a literal [ followed by a captured () group and a literal ].
+        // The group may contain any number of any character except ] - pattern [^]]
+val squareBraceRegex = Regex("""\[([^]]*)]""")
+
+        // Just look for either [ or ]
+val eitherSquareBraceRegex=Regex("""\[|]""")
+
+        // Analogous as above: Expect a {} pair with any chars but } in between and capture that
+val curlyBraceRegex =Regex("""\{([^}]*)}""")
+
 
 fun String.tr(): String {
+    // Latest optimizations: cached precompiled curlyBraceRegex and converted loop-based placeholder
+    // lookup into hash key lookup. Test result: 50s -> 24s
+    // *Discarded optimizations*:
+    //      String.indexOf(Char) looks like it might be better than String.contains(String),
+    //      (Char test should be cheaper than string comparison, and contains delegates to indexOf anyway)
+    //      but measurements are equal within margin of error.
+    //      Making our get() overload do two hash lookups instead of up to five: Zero difference.
+    //          val entry: TranslationEntry = this[text] ?: return text
+    //          return entry[language] ?: text
+
 
     // THIS IS INCREDIBLY INEFFICIENT and causes loads of memory problems!
-    if(contains("[")){ // Placeholders!
+    if (contains("[")) { // Placeholders!
         /**
          * I'm SURE there's an easier way to do this but I can't think of it =\
          * So what's all this then?
@@ -158,12 +182,12 @@ fun String.tr(): String {
          * We will find the german placeholder text, and replace the placeholders with what was filled in the text we got!
          */
 
-        val translationStringWithSquareBracketsOnly = replace(squareBraceRegex,"[]")
+        // Convert "work on [building] has completed in [city]" to "work on [] has completed in []"
+        val translationStringWithSquareBracketsOnly = this.replace(squareBraceRegex,"[]")
+        // That is now the key into the translation HashMap!
+        val translationEntry = UncivGame.Current.translations[translationStringWithSquareBracketsOnly]
 
-        val translationEntry = UncivGame.Current.translations.values
-                .firstOrNull { translationStringWithSquareBracketsOnly == it.entryWithShortenedSquareBrackets }
-
-        if(translationEntry==null ||
+        if (translationEntry==null ||
                 !translationEntry.containsKey(UncivGame.Current.settings.language)){
             // Translation placeholder doesn't exist for this language, default to English
             return this.replace(eitherSquareBraceRegex,"")
@@ -171,18 +195,18 @@ fun String.tr(): String {
 
         val termsInMessage = squareBraceRegex.findAll(this).map { it.groups[1]!!.value }.toList()
         val termsInTranslationPlaceholder = squareBraceRegex.findAll(translationEntry.entry).map { it.value }.toList()
-        if(termsInMessage.size!=termsInTranslationPlaceholder.size)
+        if (termsInMessage.size!=termsInTranslationPlaceholder.size)
             throw Exception("Message $this has a different number of terms than the placeholder $translationEntry!")
 
         var languageSpecificPlaceholder = translationEntry[UncivGame.Current.settings.language]!!
-        for(i in termsInMessage.indices){
+        for (i in termsInMessage.indices) {
             languageSpecificPlaceholder = languageSpecificPlaceholder.replace(termsInTranslationPlaceholder[i], termsInMessage[i].tr())
         }
-        return languageSpecificPlaceholder.tr()
+        return languageSpecificPlaceholder      // every component is already translated
     }
 
-    if(contains("{")){ // sentence
-        return Regex("\\{(.*?)\\}").replace(this) { it.groups[1]!!.value.tr() }
+    if (contains("{")) { // sentence
+        return curlyBraceRegex.replace(this) { it.groups[1]!!.value.tr() }
     }
 
     return UncivGame.Current.translations

--- a/tests/src/com/unciv/testing/TranslationTests.kt
+++ b/tests/src/com/unciv/testing/TranslationTests.kt
@@ -46,11 +46,13 @@ class TranslationTests {
     }
 
     private fun allStringAreTranslated(strings: Set<String>): Boolean {
+        val squareBraceRegex = Regex("""\[([^]]*)]""")
         var allStringsHaveTranslation = true
-        for (key in strings) {
+        for (entry in strings) {
+            val key = if(entry.contains('[')) entry.replace(squareBraceRegex,"[]") else entry
             if (!translations.containsKey(key)) {
                 allStringsHaveTranslation = false
-                println(key)
+                println(entry)
             }
         }
         return allStringsHaveTranslation
@@ -72,12 +74,14 @@ class TranslationTests {
         var allTranslationsHaveCorrectPlaceholders = true
         val languages = translations.getLanguages()
         for (key in translations.keys) {
-            val placeholders = placeholderPattern.findAll(key).map { it.value }.toList()
+            val translationEntry = translations[key]!!.entry
+            val placeholders = placeholderPattern.findAll(translationEntry).map { it.value }.toList()
             for (language in languages) {
                 for (placeholder in placeholders) {
-                    if (!translations.get(key, language).contains(placeholder)) {
+                    val output = translations.get(translationEntry, language)
+                    if (!output.contains(placeholder)) {
                         allTranslationsHaveCorrectPlaceholders = false
-                        println("Placeholder `$placeholder` not found in `$language` for key `$key`")
+                        println("Placeholder `$placeholder` not found in `$language` for entry `$translationEntry`")
                     }
                 }
             }
@@ -85,6 +89,26 @@ class TranslationTests {
         Assert.assertTrue(
                 "This test will only pass when all translations' placeholders match those of the key",
                 allTranslationsHaveCorrectPlaceholders
+        )
+    }
+
+    @Test
+    fun allPlaceholderKeysMatchEntry() {
+        val squareBraceRegex = Regex("""\[([^]]*)]""")
+        var allPlaceholderKeysMatchEntry = true
+        for (key in translations.keys) {
+            if ( !key.contains('[') ) continue
+            val translationEntry = translations[key]!!.entry
+            val keyFromEntry = translationEntry.replace(squareBraceRegex,"[]")
+            if (key != keyFromEntry) {
+                allPlaceholderKeysMatchEntry = false
+                println("Entry $translationEntry found under bad key $key")
+                break
+            }
+        }
+        Assert.assertTrue(
+                "This test will only pass when all placeholder translations'keys match their entry with shortened placeholders",
+                allPlaceholderKeysMatchEntry
         )
     }
 


### PR DESCRIPTION
Comments are too verbose for now.

I actually took the Unciv global dependency out of tr() to be able to build a test harness - translate every known string into every known language 1k times, with 50 rounds unmeasured warmup. Went from ~50s to ~24s (on a box already running at 100% load, so precision is a bit questionable, but the improvement is large enough to be significant). Memory and GC load are less, too.

Price:
* A tiny little slower loading (below tolerance with the existing instrumentation).
* Two entries like "[civ] builds [wonder]" and "[city] builds [unit]" - well, before both were stored but only one was ever used, now only one is stored - and the actually used one was the first one read and is now the last one read. Makes no difference right now as I could find no examples.