### PR TITLE
TranslationFileWriter: patch to duplicate less stuff into mods

### DIFF
--- a/core/src/com/unciv/models/translations/TranslationFileWriter.kt
+++ b/core/src/com/unciv/models/translations/TranslationFileWriter.kt
@@ -1,4 +1,4 @@
-﻿package com.unciv.models.translations
+package com.unciv.models.translations
 
 import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.files.FileHandle
@@ -47,7 +47,8 @@ object TranslationFileWriter {
         // read the JSON files
         val generatedStrings = generateStringsFromJSONs(modFolder)
         // Tutorials are a bit special
-        generatedStrings["Tutorials"] = generateTutorialsStrings()
+        if (modFolder == null)          // this is for base only, not mods
+            generatedStrings["Tutorials"] = generateTutorialsStrings()
 
         for (key in generatedStrings.keys) {
             linesFromTemplates.add("\n#################### Lines from $key.json ####################\n")
@@ -212,9 +213,15 @@ object TranslationFileWriter {
     private fun isFieldTranslatable(field: Field, fieldValue: Any?): Boolean {
         return  fieldValue != null &&
                 fieldValue != "" &&
-                field.name !in setOf("startBias", "requiredTech", "uniqueTo",
-                "aiFreeTechs", "aiFreeUnits", "techRequired", "improvingTech", "promotions",
-                "building", "revealedBy", "attackSound", "requiredResource", "obsoleteTech")
+                field.name !in setOf (
+                        "aiFreeTechs", "aiFreeUnits", "attackSound", "building",
+                        "cannotBeBuiltWith", "cultureBuildings", "improvement", "improvingTech",
+                        "obsoleteTech", "occursOn", "prerequisites", "promotions",
+                        "providesFreeBuilding", "replaces", "requiredBuilding", "requiredBuildingInAllCities",
+                        "requiredNearbyImprovedResources", "requiredResource", "requiredTech", "requires",
+                        "resourceTerrainAllow", "revealedBy", "startBias", "techRequired",
+                        "terrainsCanBeBuiltOn", "terrainsCanBeFoundOn", "turnsInto", "uniqueTo", "upgradesTo"
+                    )
     }
 
     private fun getJavaClassByName(name: String): Class<Any> {


### PR DESCRIPTION
Quickest patch possible?

First diff prevents pulling tutorials into the mods translations - that generateTutorialsStrings() function doesn't read from mods, it reads base only.

Second diff = isFieldTranslatable() exclusion list sorted and expanded to include every string or string-collection property that is used to reference something defined elsewhere - yes I went through the classes to get them all. One should consider inverting the test to an inclusion instead of an exclusion... But this is closer to original design and tested.

Note that running the translation writer once pre-this and once post-this and comparing the files will show a lot of differences - I checked them and all are either dupe removals or transpositions - e.g. units now come in their normal json place, not when they are first mentioned by a upgradesTo.