### PR TITLE
Translation code cleanup - purely decorative changes

### DIFF
--- a/core/src/com/unciv/models/translations/TranslationEntry.kt
+++ b/core/src/com/unciv/models/translations/TranslationEntry.kt
@@ -2,12 +2,14 @@ package com.unciv.models.translations
 
 import java.util.HashMap
 
+/**
+ *  One 'translatable' string
+ *
+ *  @property entry:    Original translatable string as defined in the game,
+ *                       including [placeholders] or {subsentences}
+ *  @property keys:     The languages
+ *  @property values:   The translations
+ *  @see      Translations
+ */
 class TranslationEntry(val entry: String) : HashMap<String, String>() {
-
-    // Now stored in the key of the hashmap storing the instances of this class
-//    /** For memory performance on .tr(), which was atrociously memory-expensive */
-//    val entryWithShortenedSquareBrackets =
-//            if (entry.contains('['))
-//                entry.replace(squareBraceRegex,"[]")
-//            else ""
 }

--- a/core/src/com/unciv/models/translations/TranslationFileWriter.kt
+++ b/core/src/com/unciv/models/translations/TranslationFileWriter.kt
@@ -87,11 +87,6 @@ object TranslationFileWriter {
                     translationsOfThisLanguage++
                 } else stringBuilder.appendln(" # Requires translation!")
 
-                // Testing assertion only
-                if (translationEntry != null && translationEntry.entry != translationKey) {
-                    println("Assertion failure in generateTranslationFiles: translationEntry.entry != translationKey")
-                }
-
                 val lineToWrite = translationKey.replace("\n", "\\n") +
                         " = " + translationValue.replace("\n", "\\n")
                 stringBuilder.appendln(lineToWrite)
@@ -222,6 +217,11 @@ object TranslationFileWriter {
     }
 
     private fun isFieldTranslatable(field: Field, fieldValue: Any?): Boolean {
+        // Exclude fields by name that contain references to items defined elsewhere
+        // - the definition should cause the inclusion in our translatables list, not the reference.
+        // This prevents duplication within the base game (e.g. Mines were duplicated by being output
+        // by both TerrainResources and TerrainImprovements) and duplication of base game items into
+        // mods. Note "uniques" is not in this list and might still generate dupes - TODO
         return  fieldValue != null &&
                 fieldValue != "" &&
                 field.name !in setOf (


### PR DESCRIPTION
Just decorative stuff, and one test-only block has to go (I mostly needed at line to place a breakpoint at)

I trimmed earlier comments under the premise 'is this really useful for a future collaborator?' - and ended removing most and having a KDoc for the three main components instead. Maybe you like it, or not - no big deal.

P.S.: I absolutely adore the line "[city] hast die worken onner [building] gerfinishen"