### PR TITLE
Ellis is misspelled - fix at root?

### DIFF
--- a/android/assets/jsons/Civ V - Vanilla/Nations.json
+++ b/android/assets/jsons/Civ V - Vanilla/Nations.json
@@ -53,7 +53,7 @@
 		"unique": "HELLENIC_LEAGUE",
 		"cities": ["Athens","Sparta","Corinth","Argos","Knossos","Mycenae","Pharsalos","Ephesus","Halicarnassus","Rhodes",
 			"Eretria","Pergamon","Miletos","Megara","Phocaea","Sicyon","Tiryns","Samos","Mytilene","Chios",
-			"Paros","Ellis","Syracuse","Herakleia","Gortyn","Chalkis","Pylos","Pella","Naxos","Sicyon",
+			"Paros","Elis","Syracuse","Herakleia","Gortyn","Chalkis","Pylos","Pella","Naxos","Sicyon",
 			"Larissa","Apollonia","Messene","Orchomenos","Ambracia","Kos","Knidos","Amphipolis",
 			"Patras","Lamia","Nafplion","Apolyton"]
 	},


### PR DESCRIPTION
Proper name of contemporary peloponnes distict and ancient greek city is _Elis_ - I stumbled when I looked it up for the german file, but didn't get it. Asked an expert later. Thanks Daffy for lifting the veil.

Changing this here will cause the 'generate' run to remove existing translation lines - alternate fix = english.properties??