### PR TITLE
Better Resource order in empire overview screen

### DIFF
--- a/core/src/com/unciv/ui/EmpireOverviewScreen.kt
+++ b/core/src/com/unciv/ui/EmpireOverviewScreen.kt
@@ -542,8 +542,11 @@ class EmpireOverviewScreen(private val viewingPlayer:CivilizationInfo, private v
 
         // First row of table has all the icons
         resourcesTable.add()
+        // Order of source ResourceSupplyList: by tiles, enumerating the map in that spiral pattern
+        // UI should not surprise player, thus we need a deterministic and guessable order
         val resources = resourceDrilldown.map { it.resource }
-                .filter { it.resourceType!=ResourceType.Bonus }.distinct().sortedBy { it.resourceType }
+                .filter { it.resourceType!=ResourceType.Bonus }.distinct()
+                .sortedWith(compareBy( { it.resourceType }, { it.name.tr() } ))
 
         var visibleLabel: Label? = null
         for(resource in resources) {


### PR DESCRIPTION
Currently, resources in the overview screen are grouped by resource type, but within the type ordering might seem surprising, and it changes over the course of a game. This is because it's fed from a ResourceSupplyList using stable-sort and order-preserving operations, the ResourceSupplyList is ordered Fifo-like and built by a map scan + some followups. So, the resources are very roughly ordered by distance from map center of their first occurrence. 

Explicitly sorting by name should make their placement a little more transparent to the player.