### PR TITLE
A few translatable lines missing from template

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -891,3 +891,7 @@ Multiplayer options =
 Enable out-of-game turn notifications = 
 Time between turn checks out-of-game (in minutes) = 
 Show persistent notification for turn notifier service = 
+Take user ID from clipboard = 
+Doing this will reset your current user ID to the clipboard contents - are you sure? = 
+ID successfully set! = 
+Invalid ID! = 


### PR DESCRIPTION
One part of the options screen sticks out when using a near-100% non-English language :)