### PR TITLE
Update Korean.properties

### DIFF
--- a/android/assets/jsons/translations/Korean.properties
+++ b/android/assets/jsons/translations/Korean.properties
@@ -232,16 +232,16 @@ Food and Culture from Friendly City-States are increased by 50% = 우호적인 �
 Father Governs Children = 군신은 부자와 같다
 
 Receive triple Gold from Barbarian encampments and pillaging Cities. Embarked units can defend themselves. = 야만인 주둔지나 도시 약탈에서 얻는 금이 세 배가 됩니다. 승선한 유닛들이 스스로를 방어할 수 있습니다.
-River Warlord = 공포의 몽골
+River Warlord = 수로의 지배자
 
 100 Gold for discovering a Natural Wonder (bonus enhanced to 500 Gold if first to discover it). Culture, Happiness and tile yields from Natural Wonders doubled. = 자연 경관을 발견했을 때 금 100 (제일 먼저 발견시 금 500). 자연 경관에서 문화, 행복도, 타일 두 배.
-Seven Cities of Gold = 포로 공양
+Seven Cities of Gold = 일곱 개의 황금 도시
 
 Combat Strength +30% when fighting City-State units or attacking a City-State itself. All mounted units have +1 Movement. = 도시 국가 유닛과 싸우거나 도시 국가를 공격할 때 전투력 +30%. 모든 유닛 행동력 +1.
-Mongol Terror = 일곱 개의 황금 도시
+Mongol Terror = 공포의 몽골
 
 Units ignore terrain costs when moving into any tile with Hills. No maintenance costs for improvements in Hills; half cost elsewhere. = 유닛이 언덕에서 이동할 때 행동력 소모 없음. 언덕에서 개발 비용 없음. 다른 곳에서는 절반의 비용 소모.
-Great Andean Road = 수로의 지배자
+Great Andean Road = 위대한 안데스의 길
 
 +1 Movement to all embarked units, units pay only 1 movement point to embark and disembark. Melee units pay no movement cost to pillage. = 모든 승선 유닛 행동력 +1, 승하선시 행동력 1개만 지불. 근거리 유닛은 약탈시 행동력 소모 없음. 
 Viking Fury = 바이킹의 분노


### PR DESCRIPTION
스페인 잉카 몽골 송가이 문명 특성 번역에 잘못된 것이 있어 정정하였습니다.
Edited civ. property translation of Spain, Inca, Mongol, Songhai.