### PR TITLE
 Civilian should not move when bought

### DIFF
--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -154,19 +154,19 @@ class BaseUnit : INamed, IConstruction {
 
     override fun postBuildEvent(construction: CityConstructions, wasBought: Boolean): Boolean {
         val unit = construction.cityInfo.civInfo.placeUnitNearTile(construction.cityInfo.location, name)
-        if(unit==null) return false // couldn't place the unit, so there's actually no unit =(
+        if (unit == null) return false // couldn't place the unit, so there's actually no unit =(
 
         //movement penalty
-        if(!unit.hasUnique("Can move directly once bought") && wasBought)
+        if (wasBought && !unit.hasUnique("Can move directly once bought"))
             unit.currentMovement = 0f
 
-        if(this.unitType.isCivilian()) return true // tiny optimization makes save files a few bytes smaller
+        if (this.unitType.isCivilian()) return true // tiny optimization makes save files a few bytes smaller
 
         var XP = construction.getBuiltBuildings().sumBy { it.xpForNewUnits }
-        if(construction.cityInfo.civInfo.policies.isAdopted("Total War")) XP += 15
+        if (construction.cityInfo.civInfo.policies.isAdopted("Total War")) XP += 15
         unit.promotions.XP = XP
 
-        if(unit.type in listOf(UnitType.Melee,UnitType.Mounted,UnitType.Armor)
+        if (unit.type in listOf(UnitType.Melee,UnitType.Mounted,UnitType.Armor)
             && construction.cityInfo.containsBuildingUnique("All newly-trained melee, mounted, and armored units in this city receive the Drill I promotion"))
             unit.promotions.addPromotion("Drill I", isFree = true)
 

--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -156,6 +156,10 @@ class BaseUnit : INamed, IConstruction {
         val unit = construction.cityInfo.civInfo.placeUnitNearTile(construction.cityInfo.location, name)
         if(unit==null) return false // couldn't place the unit, so there's actually no unit =(
 
+        //movement penalty
+        if(!unit.hasUnique("Can move directly once bought") && wasBought)
+            unit.currentMovement = 0f
+
         if(this.unitType.isCivilian()) return true // tiny optimization makes save files a few bytes smaller
 
         var XP = construction.getBuiltBuildings().sumBy { it.xpForNewUnits }
@@ -165,10 +169,6 @@ class BaseUnit : INamed, IConstruction {
         if(unit.type in listOf(UnitType.Melee,UnitType.Mounted,UnitType.Armor)
             && construction.cityInfo.containsBuildingUnique("All newly-trained melee, mounted, and armored units in this city receive the Drill I promotion"))
             unit.promotions.addPromotion("Drill I", isFree = true)
-
-        //movement penalty
-        if(!unit.hasUnique("Can move directly once bought") && wasBought)
-            unit.currentMovement = 0f
 
         return true
     }


### PR DESCRIPTION
There is a protection to avoid purchasing a horge of military units in one turn, however, it was possible to buy many workers or settlers at the same time. Now it is fixed "in the name of consistency".