### PR TITLE
Exits simulation mode when player wins or losses.

### DIFF
--- a/core/src/com/unciv/UncivGame.kt
+++ b/core/src/com/unciv/UncivGame.kt
@@ -40,7 +40,7 @@ class UncivGame(
     val superchargedForDebug = false
 
     /** Simulate until this turn on the first "Next turn" button press.
-     *  Also finishes simulation when player wins or looses.
+     *  Also finishes simulation when player wins or loses.
      *  Does not update World View changes until finished.
      *  Set to 0 to disable.
      */
@@ -198,5 +198,4 @@ class LoadingScreen:CameraStageBaseScreen() {
         stage.addActor(happinessImage)
     }
 }
-
 

--- a/core/src/com/unciv/UncivGame.kt
+++ b/core/src/com/unciv/UncivGame.kt
@@ -40,11 +40,21 @@ class UncivGame(
     val superchargedForDebug = false
 
     /** Simulate until this turn on the first "Next turn" button press.
-     *  Also finishes simulation when player wins or loses.
      *  Does not update World View changes until finished.
      *  Set to 0 to disable.
      */
-    var simulateUntilTurnForDebug: Int = 0
+    val simulateUntilTurnForDebug: Int = 0
+
+    /** Simulate until any player wins or loses,
+     *  or turns exceeds indicated number
+     *  Does not update World View changes until finished.
+     *  Set to 0 to disable.
+     */
+    var simulateUntilWinOrLose: Int = 1000
+
+    /** Console log battles
+     */
+    val alertBattle = true
 
     lateinit var worldScreen: WorldScreen
 

--- a/core/src/com/unciv/UncivGame.kt
+++ b/core/src/com/unciv/UncivGame.kt
@@ -40,10 +40,11 @@ class UncivGame(
     val superchargedForDebug = false
 
     /** Simulate until this turn on the first "Next turn" button press.
+     *  Also finishes simulation when player wins or looses.
      *  Does not update World View changes until finished.
      *  Set to 0 to disable.
      */
-    val simulateUntilTurnForDebug: Int = 0
+    var simulateUntilTurnForDebug: Int = 0
 
     lateinit var worldScreen: WorldScreen
 

--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -103,7 +103,7 @@ class GameInfo {
                     println("Simulation stopped on turn $turns")
                     for (civ in UncivGame.Current.gameInfo.civilizations) {
                         val victoryType = civ.victoryManager.hasWonVictoryType()
-                        if (civ.victoryManager.hasWon()) {println("$civ won $victoryType victory")}
+                        if (civ.victoryManager.hasWon()) println("$civ won $victoryType victory")
                     }
                 }
             }

--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -95,6 +95,17 @@ class GameInfo {
                 if (thisPlayer.isBarbarian()
                         && !gameParameters.noBarbarians
                         && turns % 10 == 0) placeBarbarians()
+
+                // exit simulation mode when player wins or looses
+                if (thisPlayer.isDefeated() || thisPlayer.victoryManager.hasWon()) {
+                    // stop simulation
+                    UncivGame.Current.simulateUntilTurnForDebug = turns
+                    println("Simulation stopped on turn $turns")
+                    for (civ in UncivGame.Current.gameInfo.civilizations) {
+                        val victoryType = civ.victoryManager.hasWonVictoryType()
+                        if (civ.victoryManager.hasWon()) {println("$civ won $victoryType victory")}
+                    }
+                }
             }
             switchTurn()
         }

--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -84,6 +84,7 @@ class GameInfo {
 
         while (thisPlayer.playerType == PlayerType.AI
             || UncivGame.Current.simulateUntilTurnForDebug > turns
+                || UncivGame.Current.simulateUntilWinOrLose > turns
                 // For multiplayer, if there are 3+ players and one is defeated,
                 // we'll want to skip over their turn
                 || (thisPlayer.isDefeated() && gameParameters.isOnlineMultiplayer)
@@ -97,9 +98,11 @@ class GameInfo {
                         && turns % 10 == 0) placeBarbarians()
 
                 // exit simulation mode when player wins or loses
-                if (thisPlayer.isDefeated() || thisPlayer.victoryManager.hasWon()) {
+                if (thisPlayer.isDefeated() || thisPlayer.victoryManager.hasWon()
+                        && UncivGame.Current.simulateUntilWinOrLose != 0
+                ) {
                     // stop simulation
-                    UncivGame.Current.simulateUntilTurnForDebug = turns
+                    UncivGame.Current.simulateUntilWinOrLose = turns
                     println("Simulation stopped on turn $turns")
                     for (civ in UncivGame.Current.gameInfo.civilizations) {
                         val victoryType = civ.victoryManager.hasWonVictoryType()

--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -96,7 +96,7 @@ class GameInfo {
                         && !gameParameters.noBarbarians
                         && turns % 10 == 0) placeBarbarians()
 
-                // exit simulation mode when player wins or looses
+                // exit simulation mode when player wins or loses
                 if (thisPlayer.isDefeated() || thisPlayer.victoryManager.hasWon()) {
                     // stop simulation
                     UncivGame.Current.simulateUntilTurnForDebug = turns
@@ -380,4 +380,3 @@ class GameInfo {
 
 
 }
-

--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -33,8 +33,10 @@ object Battle {
     }
 
     fun attack(attacker: ICombatant, defender: ICombatant) {
-        println(attacker.getCivInfo().civName+" "+attacker.getName()+" attacked "+
-                defender.getCivInfo().civName+" "+defender.getName())
+        if (UncivGame.Current.alertBattle) {
+            println(attacker.getCivInfo().civName+" "+attacker.getName()+" attacked "+
+                    defender.getCivInfo().civName+" "+defender.getName())
+        }
         val attackedTile = defender.getTile()
 
         if(attacker is MapUnitCombatant && attacker.getUnitType().isAirUnit()){


### PR DESCRIPTION
Hi,

My name is Alex and this is my first commit ever on open source. I am mainly interested in machine learning so unciv turn base game seems to be a good starting point for trying out different strategies. In order to do so, I am planning to add some features needed to create environment suitable for machine learning. For the moment I have no professional programming experience so please don't judge too harshly if something went wrong.

Back to the current feature. I used it in two player simulation when one of the players already lost and there there is no point in continuing the simulation. Can I change simulateUntilTurnForDebug mechanics or it's better to add separate var simulateUntilWinOrLose?

Also I have a foregoing plans on what could be done, like automated game simulation between AI, spectator Mode, replay recording and playing, adding units on MapEditor etc. Are there any channel/forum/chat where I can ask dumb questions before starting to work on each feature? Would be great if you could give me your view on how some features should be implemented before I actually start coding them. So any comment any additional information would be much appreciated :)

Thanks.

