### PR TITLE
Don't reveal submarine position by city markers

### DIFF
--- a/core/src/com/unciv/logic/map/TileInfo.kt
+++ b/core/src/com/unciv/logic/map/TileInfo.kt
@@ -435,7 +435,7 @@ open class TileInfo {
         turnsToImprovement = 0
     }
 
-    fun hasEnemySubmarine(viewingCiv: CivilizationInfo): Boolean {
+    fun hasEnemyInvisibleUnit(viewingCiv: CivilizationInfo): Boolean {
         val unitsInTile = getUnits()
         if (unitsInTile.none()) return false
         if (unitsInTile.first().civInfo != viewingCiv &&

--- a/core/src/com/unciv/ui/tilegroups/CityButton.kt
+++ b/core/src/com/unciv/ui/tilegroups/CityButton.kt
@@ -77,13 +77,13 @@ class CityButton(val city: CityInfo, private val tileGroup: WorldTileGroup): Tab
                     (tile.civilianUnit != null) && direction.epsilonEquals(0f, 1f) ->
                         insertHiddenUnitMarker(HiddenUnitMarkerPosition.Left)
                     // detect military under the city
-                    (tile.militaryUnit != null) && direction.epsilonEquals(1f, 1f) ->
+                    (tile.militaryUnit != null && !tile.hasEnemyInvisibleUnit(worldScreen.viewingCiv)) && direction.epsilonEquals(1f, 1f) ->
                         insertHiddenUnitMarker(HiddenUnitMarkerPosition.Center)
                     // detect civilian right-below the city
                     (tile.civilianUnit != null) && direction.epsilonEquals(1f, 0f) ->
                         insertHiddenUnitMarker(HiddenUnitMarkerPosition.Right)
                 }
-            } else if (tile.militaryUnit != null) {
+            } else if (tile.militaryUnit != null && !tile.hasEnemyInvisibleUnit(worldScreen.viewingCiv)) {
                 when {
                     // detect military left from the city
                     direction.epsilonEquals(0f, 1f) ->

--- a/core/src/com/unciv/ui/tilegroups/TileGroup.kt
+++ b/core/src/com/unciv/ui/tilegroups/TileGroup.kt
@@ -269,7 +269,7 @@ open class TileGroup(var tileInfo: TileInfo, var tileSetStrings:TileSetStrings) 
 
     fun showMilitaryUnit(viewingCiv: CivilizationInfo) = showEntireMap
             || viewingCiv.viewableInvisibleUnitsTiles.contains(tileInfo)
-            || !tileInfo.hasEnemySubmarine(viewingCiv)
+            || !tileInfo.hasEnemyInvisibleUnit(viewingCiv)
 
     fun isViewable(viewingCiv: CivilizationInfo) = showEntireMap
             || viewingCiv.viewableTiles.contains(tileInfo)


### PR DESCRIPTION
These small markers reveal the position of the hidden unit, such as submarine, which is obviously a minor cheat.
<img src="https://user-images.githubusercontent.com/27405436/82488774-25c5d100-9ae9-11ea-97fe-35109549eb38.png" width="250"/> <img src="https://user-images.githubusercontent.com/27405436/82488775-265e6780-9ae9-11ea-85a7-c4ed6543673b.png" width="250"/>
After the fix they are shown for your own submarines only.