### PR TITLE
Add remove button for construction queue items

### DIFF
--- a/core/src/com/unciv/ui/cityscreen/ConstructionsTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/ConstructionsTable.kt
@@ -206,6 +206,8 @@ class ConstructionsTable(val cityScreen: CityScreen) : Table(CameraStageBaseScre
             table.add(getLowerPriorityButton(constructionQueueIndex, name, city)).right()
         else table.add().right()
 
+        table.add(getRemoveFromQueueButton(constructionQueueIndex, city)).right()
+
         table.touchable = Touchable.enabled
         table.onClick {
             cityScreen.selectedConstruction = cityConstructions.getConstruction(name)
@@ -385,6 +387,21 @@ class ConstructionsTable(val cityScreen: CityScreen) : Table(CameraStageBaseScre
                 cityScreen.selectedConstruction = cityScreen.city.cityConstructions.getConstruction(name)
                 cityScreen.selectedTile = null
                 selectedQueueEntry = constructionQueueIndex + 1
+                cityScreen.update()
+            }
+        }
+        return tab
+    }
+
+    private fun getRemoveFromQueueButton(constructionQueueIndex: Int, city: CityInfo): Table {
+        val tab = Table()
+        tab.add(ImageGetter.getImage("OtherIcons/Stop").surroundWithCircle(40f))
+        if (UncivGame.Current.worldScreen.isPlayersTurn && !city.isPuppet) {
+            tab.touchable = Touchable.enabled
+            tab.onClick {
+                tab.touchable = Touchable.disabled
+                city.cityConstructions.removeFromQueue(constructionQueueIndex,false)
+                cityScreen.selectedConstruction = null
                 cityScreen.update()
             }
         }

--- a/core/src/com/unciv/ui/utils/ImageGetter.kt
+++ b/core/src/com/unciv/ui/utils/ImageGetter.kt
@@ -149,7 +149,7 @@ object ImageGetter {
     fun getConstructionImage(construction: String): Image {
         if(ruleset.buildings.containsKey(construction)) return getImage("BuildingIcons/$construction")
         if(ruleset.units.containsKey(construction)) return getUnitIcon(construction)
-        if(construction=="Nothing") return getImage("OtherIcons/Stop")
+        if(construction=="Nothing") return getImage("OtherIcons/Sleep")
         return getStatIcon(construction)
     }
 


### PR DESCRIPTION
In my last game it bugged me, that there is no button to one-click remove items from the city construction queue. So I added it with this PR.

## Changes
- Add a remove button right of the raise/lower priority buttons. This button uses `OtherIcons/Stop`
- Changed the icon for the "Nothing" production in the queue from `OtherIcons/Stop` to `OtherIcons/Sleep` (see screenshots).
  - This change effects the construction and map screen.
  - Imho it's so much more understandable with this icon, because it symbolizes that the production sleeps. Also the stop icon is used for cancellation on other occasions.



### Screenshots to show the changes

####  Before the PR
![before](https://user-images.githubusercontent.com/1376279/82735218-5ba0ca80-9d20-11ea-8c48-2c034b3987f8.png)

#### With the PR
![remove-filled](https://user-images.githubusercontent.com/1376279/82735269-ae7a8200-9d20-11ea-9876-bfe6d0975300.png)
![remove-empty](https://user-images.githubusercontent.com/1376279/82735268-ade1eb80-9d20-11ea-94a8-7a86af10529f.png)

