### PR TITLE
Minor UI improvements construction menu

### DIFF
--- a/core/src/com/unciv/ui/cityscreen/CityInfoTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityInfoTable.kt
@@ -22,6 +22,8 @@ class CityInfoTable(private val cityScreen: CityScreen) : Table(CameraStageBaseS
     private val innerTable = Table(skin)
 
     init {
+        align(Align.topLeft)
+
         showConstructionsTableButton.onClick {
             cityScreen.showConstructionsTable = true
             cityScreen.update()
@@ -52,15 +54,25 @@ class CityInfoTable(private val cityScreen: CityScreen) : Table(CameraStageBaseS
     }
 
     private fun Table.addCategory(str: String, showHideTable: Table) {
-        val titleTable = Table().background(ImageGetter.getBackground(ImageGetter.getBlue()))
-        val width = cityScreen.stage.width/4 - 2*pad
+        val width = cityScreen.stage.width / 4 - 2 * pad
         val showHideTableWrapper = Table()
-        showHideTableWrapper.add(showHideTable).minWidth(width)
-        titleTable.add(str.toLabel(fontSize = 24))
-        titleTable.onClick {
-            if(showHideTableWrapper.hasChildren()) showHideTableWrapper.clear()
-            else showHideTableWrapper.add(showHideTable).minWidth(width)
-        }
+                .add(showHideTable)
+                .minWidth(width)
+                .table
+
+        val titleTable = Table()
+                .background(ImageGetter.getBackground(ImageGetter.getBlue()))
+                .pad(4f)
+                .addCell(str.toLabel(fontSize = FONT_SIZE_CATEGORY_HEADER))
+                .onClick {
+                    if (showHideTableWrapper.hasChildren()) {
+                        showHideTableWrapper.clear()
+                    } else {
+                        showHideTableWrapper.add(showHideTable).minWidth(width)
+                    }
+                }
+        addSeparator()
+
         add(titleTable).minWidth(width).row()
         add(showHideTableWrapper).row()
     }
@@ -166,7 +178,7 @@ class CityInfoTable(private val cityScreen: CityScreen) : Table(CameraStageBaseS
             val statValuesTable = Table().apply { defaults().pad(2f) }
             addCategory(stat.name, statValuesTable)
 
-            statValuesTable.add("Base values".toLabel(fontSize= 24)).colspan(2).row()
+            statValuesTable.add("Base values".toLabel(fontSize= FONT_SIZE_STAT_INFO_HEADER)).pad(4f).colspan(2).row()
             var sumOfAllBaseValues = 0f
             for(entry in relevantBaseStats) {
                 val specificStatValue = entry.value.get(stat)
@@ -180,7 +192,7 @@ class CityInfoTable(private val cityScreen: CityScreen) : Table(CameraStageBaseS
 
             val relevantBonuses = cityStats.statPercentBonusList.filter { it.value.get(stat)!=0f }
             if(relevantBonuses.isNotEmpty()) {
-                statValuesTable.add("Bonuses".toLabel(fontSize = 24)).colspan(2).padTop(20f).row()
+                statValuesTable.add("Bonuses".toLabel(fontSize = FONT_SIZE_STAT_INFO_HEADER)).colspan(2).padTop(20f).row()
                 var sumOfBonuses = 0f
                 for (entry in relevantBonuses) {
                     val specificStatValue = entry.value.get(stat)
@@ -198,7 +210,7 @@ class CityInfoTable(private val cityScreen: CityScreen) : Table(CameraStageBaseS
             }
 
 
-            statValuesTable.add("Final".toLabel(fontSize = 24)).colspan(2).padTop(20f).row()
+            statValuesTable.add("Final".toLabel(fontSize = FONT_SIZE_STAT_INFO_HEADER)).colspan(2).padTop(20f).row()
             var finalTotal = 0f
             for (entry in cityStats.finalStatList) {
                 val specificStatValue = entry.value.get(stat)
@@ -210,6 +222,8 @@ class CityInfoTable(private val cityScreen: CityScreen) : Table(CameraStageBaseS
             statValuesTable.addSeparator()
             statValuesTable.add("Total".toLabel())
             statValuesTable.add(DecimalFormat("0.#").format(finalTotal).toLabel()).row()
+
+            statValuesTable.padBottom(4f)
         }
     }
 
@@ -230,6 +244,11 @@ class CityInfoTable(private val cityScreen: CityScreen) : Table(CameraStageBaseS
                 greatPersonTable.add(DecimalFormat("0.#").format(value).toLabel()).row()
             }
         }
+    }
+
+    companion object {
+        private const val FONT_SIZE_CATEGORY_HEADER: Int = 24
+        private const val FONT_SIZE_STAT_INFO_HEADER = 22
     }
 
 }

--- a/core/src/com/unciv/ui/cityscreen/ConstructionsTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/ConstructionsTable.kt
@@ -409,11 +409,10 @@ class ConstructionsTable(val cityScreen: CityScreen) : Table(CameraStageBaseScre
     }
 
     private fun getHeader(title: String): Table {
-        val headerTable = Table()
-        headerTable.background = ImageGetter.getBackground(ImageGetter.getBlue())
-        headerTable.add(title.toLabel(fontSize = 24)).fillX()
-        headerTable.pad(4f)
-        return headerTable
+        return Table()
+                .background(ImageGetter.getBackground(ImageGetter.getBlue()))
+                .addCell(title.toLabel(fontSize = 24))
+                .pad(4f)
     }
 
     private fun Table.addCategory(title: String, list: ArrayList<Table>, prefWidth: Float) {

--- a/core/src/com/unciv/ui/cityscreen/ConstructionsTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/ConstructionsTable.kt
@@ -47,7 +47,7 @@ class ConstructionsTable(val cityScreen: CityScreen) : Table(CameraStageBaseScre
 
         add(showCityInfoTableButton).left().padLeft(pad).padBottom(pad).row()
         add(constructionsQueueScrollPane).left().padBottom(pad).row()
-        add(buttons).center().bottom().padBottom(pad).row()
+        add(buttons).left().bottom().padBottom(pad).row()
         add(availableConstructionsScrollPane).left().bottom().row()
     }
 

--- a/core/src/com/unciv/ui/cityscreen/ConstructionsTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/ConstructionsTable.kt
@@ -412,6 +412,7 @@ class ConstructionsTable(val cityScreen: CityScreen) : Table(CameraStageBaseScre
         val headerTable = Table()
         headerTable.background = ImageGetter.getBackground(ImageGetter.getBlue())
         headerTable.add(title.toLabel(fontSize = 24)).fillX()
+        headerTable.pad(4f)
         return headerTable
     }
 
@@ -419,7 +420,7 @@ class ConstructionsTable(val cityScreen: CityScreen) : Table(CameraStageBaseScre
         if (list.isEmpty()) return
 
         addSeparator()
-        add(getHeader(title)).fill().row()
+        add(getHeader(title).pad(4f)).fill().row()
         addSeparator()
 
         for (table in list) {

--- a/core/src/com/unciv/ui/cityscreen/ConstructionsTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/ConstructionsTable.kt
@@ -165,11 +165,11 @@ class ConstructionsTable(val cityScreen: CityScreen) : Table(CameraStageBaseScre
                             + specialConstruction.getProductionTooltip(city))
         }
 
-        availableConstructionsTable.addCategory("Units", units)
-        availableConstructionsTable.addCategory("Wonders", buildableWonders)
-        availableConstructionsTable.addCategory("National Wonders", buildableNationalWonders)
-        availableConstructionsTable.addCategory("Buildings", buildableBuildings)
-        availableConstructionsTable.addCategory("Other", specialConstructions)
+        availableConstructionsTable.addCategory("Units", units, constructionsQueueTable.width)
+        availableConstructionsTable.addCategory("Wonders", buildableWonders, constructionsQueueTable.width)
+        availableConstructionsTable.addCategory("National Wonders", buildableNationalWonders, constructionsQueueTable.width)
+        availableConstructionsTable.addCategory("Buildings", buildableBuildings, constructionsQueueTable.width)
+        availableConstructionsTable.addCategory("Other", specialConstructions, constructionsQueueTable.width)
     }
 
     private fun getQueueEntry(constructionQueueIndex: Int, name: String): Table {
@@ -416,11 +416,11 @@ class ConstructionsTable(val cityScreen: CityScreen) : Table(CameraStageBaseScre
         return headerTable
     }
 
-    private fun Table.addCategory(title: String, list: ArrayList<Table>) {
+    private fun Table.addCategory(title: String, list: ArrayList<Table>, prefWidth: Float) {
         if (list.isEmpty()) return
 
         addSeparator()
-        add(getHeader(title).pad(4f)).fill().row()
+        add(getHeader(title).pad(4f)).prefWidth(prefWidth).fill().row()
         addSeparator()
 
         for (table in list) {

--- a/core/src/com/unciv/ui/cityscreen/ConstructionsTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/ConstructionsTable.kt
@@ -97,6 +97,7 @@ class ConstructionsTable(val cityScreen: CityScreen) : Table(CameraStageBaseScre
 
         constructionsQueueTable.defaults().pad(0f)
         constructionsQueueTable.add(getHeader("Current construction".tr())).fillX()
+
         constructionsQueueTable.addSeparator()
 
         if (currentConstruction != "")
@@ -107,7 +108,6 @@ class ConstructionsTable(val cityScreen: CityScreen) : Table(CameraStageBaseScre
 
         constructionsQueueTable.addSeparator()
         constructionsQueueTable.add(getHeader("Construction queue".tr())).fillX()
-        constructionsQueueTable.addSeparator()
 
         if (queue.isNotEmpty()) {
             queue.forEachIndexed { i, constructionName ->
@@ -420,7 +420,7 @@ class ConstructionsTable(val cityScreen: CityScreen) : Table(CameraStageBaseScre
         if (list.isEmpty()) return
 
         addSeparator()
-        add(getHeader(title).pad(4f)).prefWidth(prefWidth).fill().row()
+        add(getHeader(title)).prefWidth(prefWidth).fill().row()
         addSeparator()
 
         for (table in list) {

--- a/core/src/com/unciv/ui/utils/CameraStageBaseScreen.kt
+++ b/core/src/com/unciv/ui/utils/CameraStageBaseScreen.kt
@@ -193,6 +193,11 @@ fun Table.addSeparatorVertical(): Cell<Image> {
     return cell
 }
 
+fun <T : Actor> Table.addCell(actor: T): Table {
+    add(actor)
+    return this
+}
+
 /**
  * Solves concurrent modification problems - everyone who had a reference to the previous arrayList can keep using it because it hasn't changed
  */


### PR DESCRIPTION
As the title says, I did some minor UI improvements.

### Construction Menu
- Padding for header title in the construction menu. Until now the hadn't a padding and the text clipped the the border (e.g. the upper case "C" from "Current construction")
- Width of the queue and available construction table are synced so they always the same. Imho it looks more pleasant this way
- Left align the "Add to queue" button and prevent that it jumps slightly to left when the first item is added
- Remove some duplicate separater and padding that led to double thick lines

![construction-before](https://user-images.githubusercontent.com/1376279/82754550-d247d180-9dcd-11ea-9ce3-5016f1dbde7b.png)
![construction-after](https://user-images.githubusercontent.com/1376279/82754549-d247d180-9dcd-11ea-97ca-e2e5ac86595b.png)

### City info table
- Align it top left. So when elements are collapsed the table doesn't move to center of the screen
- Fix the padding for the headers and adjust font size.
- Separator lines in top of the header title

![cityinfo-before](https://user-images.githubusercontent.com/1376279/82754548-d1af3b00-9dcd-11ea-979a-c35122423305.png)
![cityinfo-after](https://user-images.githubusercontent.com/1376279/82754546-d07e0e00-9dcd-11ea-9d56-96108ae26c48.png)


