### PR TITLE
Improve keyboard shortcut 

### DIFF
--- a/core/src/com/unciv/ui/cityscreen/CityScreen.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityScreen.kt
@@ -221,11 +221,14 @@ class CityScreen(internal val city: CityInfo): CameraStageBaseScreen() {
         game.setScreen(CityScreen(civInfo.cities[indexOfNextCity]))
     }
 
-    private fun getKeyboardListener(): InputListener = object : InputListener() {
-        override fun keyTyped(event: InputEvent?, character: Char): Boolean {
-            if (character != 0.toChar() || event == null) return super.keyTyped(event, character)
-            if (event.keyCode == Input.Keys.LEFT) page(-1)
-            if (event.keyCode == Input.Keys.RIGHT) page(1)
+    private fun getKeyboardListener(): InputListener = object: InputListener() {
+        override fun keyDown(event: InputEvent?, keyCode: Int): Boolean {
+            if (event == null) return super.keyDown(event, keyCode)
+            when(event.keyCode) {
+                Input.Keys.LEFT -> page(-1)
+                Input.Keys.RIGHT -> page(1)
+                else -> return super.keyDown(event, keyCode)
+            }
             return true
         }
     }

--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -634,6 +634,22 @@ class WorldScreen(val viewingCiv:CivilizationInfo) : CameraStageBaseScreen() {
             return
         }
 
+        // Deselect Unit
+        if (bottomUnitTable.selectedUnit != null) {
+            bottomUnitTable.selectedUnit = null
+            bottomUnitTable.isVisible = false
+            shouldUpdate = true
+            return
+        }
+
+        // Deselect city
+        if (bottomUnitTable.selectedCity != null) {
+            bottomUnitTable.selectedCity = null
+            bottomUnitTable.isVisible = false
+            shouldUpdate = true
+            return
+        }
+
         // don't show a dialog, if it can't exit the game
         if (game.exitEvent == null) {
             return

--- a/core/src/com/unciv/ui/worldscreen/unit/UnitActionsTable.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitActionsTable.kt
@@ -2,12 +2,9 @@ package com.unciv.ui.worldscreen.unit
 
 import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.scenes.scene2d.Actor
-import com.badlogic.gdx.scenes.scene2d.InputEvent
 import com.badlogic.gdx.scenes.scene2d.Touchable
 import com.badlogic.gdx.scenes.scene2d.ui.Button
-import com.badlogic.gdx.scenes.scene2d.ui.Label
 import com.badlogic.gdx.scenes.scene2d.ui.Table
-import com.badlogic.gdx.scenes.scene2d.utils.ClickListener
 import com.unciv.Constants
 import com.unciv.UncivGame
 import com.unciv.logic.map.MapUnit
@@ -24,7 +21,7 @@ class UnitActionsTable(val worldScreen: WorldScreen) : Table() {
         touchable = Touchable.enabled
     }
 
-    private fun getIconAnKeyForUnitAction(unitAction: String): UnitIconAndKey {
+    private fun getIconAndKeyForUnitAction(unitAction: String): UnitIconAndKey {
         when {
             unitAction.startsWith("Upgrade to") -> {
                 // Regexplaination: start with a [, take as many non-] chars as you can, until you reach a ].
@@ -74,7 +71,7 @@ class UnitActionsTable(val worldScreen: WorldScreen) : Table() {
 
 
     private fun getUnitActionButton(unitAction: UnitAction): Button {
-        val iconAndKey = getIconAnKeyForUnitAction(unitAction.title)
+        val iconAndKey = getIconAndKeyForUnitAction(unitAction.title)
         val actionButton = Button(CameraStageBaseScreen.skin)
         actionButton.add(iconAndKey.Icon).size(20f).pad(5f)
         val fontColor = if (unitAction.isCurrentAction) Color.YELLOW else Color.WHITE


### PR DESCRIPTION
Here are the changes:

1. Use keyDown instead of keyTyped to handle arrow keys for switching city screen

Reason: My Unciv is compiled with lwjgl3 backend, which doesn't seem to recognize arrow key for `keyTyped` while `keyDown` works fine. Besides, it seems more natural to use `keyDown` to handle arrow since I think `keyTyped` is supposed to return a character where it is undefined for arrow keys.

2. Rename `getIconAnKeyForUnitAction` to `getIconAndKeyForUnitAction`, and clean up dependencies

Reason: I believe `getIconAnKeyForUnitAction` is a misspelled name.

3. Use backButtonAndESCHandler to deselect unit and city

Reason: It is quite clunky to deselect an unit by re-clicking the unit or the "cross". I think it is natural to deselect the unity/city by pressing ESC if there is no popup. And if no unit/city has been selected, it will pop the exit menu.

Potential future improvements: Now, we need to wait until the animation for the city name finishes to deselect the city by ESC. Otherwise the state would be quite weird.