### PR TITLE
Code style: reformat "object:" to "object :" 

### DIFF
--- a/core/src/com/unciv/ui/cityscreen/CityScreen.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityScreen.kt
@@ -221,7 +221,7 @@ class CityScreen(internal val city: CityInfo): CameraStageBaseScreen() {
         game.setScreen(CityScreen(civInfo.cities[indexOfNextCity]))
     }
 
-    private fun getKeyboardListener(): InputListener = object: InputListener() {
+    private fun getKeyboardListener(): InputListener = object : InputListener() {
         override fun keyDown(event: InputEvent?, keyCode: Int): Boolean {
             if (event == null) return super.keyDown(event, keyCode)
             when(event.keyCode) {

--- a/core/src/com/unciv/ui/utils/ZoomableScrollPane.kt
+++ b/core/src/com/unciv/ui/utils/ZoomableScrollPane.kt
@@ -23,7 +23,7 @@ open class ZoomableScrollPane: ScrollPane(null) {
 
     private fun addZoomListeners() {
 
-        addListener(object: InputListener() {
+        addListener(object : InputListener() {
             override fun scrolled(event: InputEvent?, x: Float, y: Float, amount: Int): Boolean {
                 if(amount > 0) zoom(scaleX * 0.8f)
                 else zoom(scaleX / 0.8f)


### PR DESCRIPTION
I realized that I type "object:" instead of "object :"  in the previous PR (https://github.com/yairm210/Unciv/pull/2663), which does not satisfy the official coding convention (https://kotlinlang.org/docs/reference/coding-conventions.html#colon), and I found the other one as well.

By the way, any interest to use something like (https://github.com/JLLeitschuh/ktlint-gradle) to auto-check the coding style? I can try to work that out if so. 

Or simply encourage people to format their code with Android Studio/Intellij (https://kotlinlang.org/docs/reference/code-style-migration-guide.html) or klint (https://github.com/pinterest/ktlint) before submitting a PR?