### PR TITLE
Fix not translated notifications

### DIFF
--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -479,7 +479,7 @@ class CivilizationInfo {
 
     fun addNotification(text: String, color: Color, action: NotificationAction?=null) {
         if (playerType == PlayerType.AI) return // no point in lengthening the saved game info if no one will read it
-        notifications.add(Notification(text, color, action))
+        notifications.add(Notification(text.tr(), color, action))
     }
 
     fun addGreatPerson(greatPerson: String){

--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -479,7 +479,7 @@ class CivilizationInfo {
 
     fun addNotification(text: String, color: Color, action: NotificationAction?=null) {
         if (playerType == PlayerType.AI) return // no point in lengthening the saved game info if no one will read it
-        notifications.add(Notification(text.tr(), color, action))
+        notifications.add(Notification(text, color, action))
     }
 
     fun addGreatPerson(greatPerson: String){

--- a/tests/src/com/unciv/testing/TranslationTests.kt
+++ b/tests/src/com/unciv/testing/TranslationTests.kt
@@ -78,7 +78,7 @@ class TranslationTests {
             val placeholders = placeholderPattern.findAll(translationEntry).map { it.value }.toList()
             for (language in languages) {
                 for (placeholder in placeholders) {
-                    val output = translations.get(translationEntry, language)
+                    val output = translations.getText(translationEntry, language)
                     if (!output.contains(placeholder)) {
                         allTranslationsHaveCorrectPlaceholders = false
                         println("Placeholder `$placeholder` not found in `$language` for entry `$translationEntry`")


### PR DESCRIPTION
### Bugfix
This PR fixes two issues based on #2703:
- Translations with a placeholder (`[]`) didn't check if the active mods provide a translation.
- ~Some text for the notifications weren't translated. Fixed this with a `tr()` call when setting the translations~

### Testing
- Create a mod with translations including translations with placeholder
- Start a game using this mod
=> Should be translated correctly