### PR TITLE
Fixed strategic resources generation

### DIFF
--- a/core/src/com/unciv/logic/map/mapgenerator/MapGenerator.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/MapGenerator.kt
@@ -126,7 +126,7 @@ class MapGenerator(val ruleset: Ruleset) {
     private fun spreadStrategicResources(tileMap: TileMap, distance: Int) {
         val strategicResources = ruleset.tileResources.values.filter { it.resourceType == ResourceType.Strategic }
         // passable land tiles (no mountains, no wonders) without resources yet
-        val candidateTiles = tileMap.values.filter { it.resource == null && !it.getLastTerrain().impassable }
+        val candidateTiles = tileMap.values.filter { it.resource == null && it.isLand && !it.getLastTerrain().impassable }
         val totalNumberOfResources = candidateTiles.size * tileMap.mapParameters.resourceRichness
         val resourcesPerType = (totalNumberOfResources/strategicResources.size).toInt()
         for (resource in strategicResources) {

--- a/core/src/com/unciv/logic/map/mapgenerator/MapGenerator.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/MapGenerator.kt
@@ -126,15 +126,14 @@ class MapGenerator(val ruleset: Ruleset) {
     private fun spreadStrategicResources(tileMap: TileMap, distance: Int) {
         val strategicResources = ruleset.tileResources.values.filter { it.resourceType == ResourceType.Strategic }
         // passable land tiles (no mountains, no wonders) without resources yet
-        val candidateTiles = tileMap.values.filter { it.resource == null && it.isLand && !it.getLastTerrain().impassable }
+        val candidateTiles = tileMap.values.filter { it.resource == null && !it.getLastTerrain().impassable }
         val totalNumberOfResources = candidateTiles.size * tileMap.mapParameters.resourceRichness
         val resourcesPerType = (totalNumberOfResources/strategicResources.size).toInt()
         for (resource in strategicResources) {
             // remove the tiles where previous resources have been placed
             val suitableTiles = candidateTiles
                     .filter { it.resource == null
-                            && resource.terrainsCanBeFoundOn.contains(it.getBaseTerrain().name)
-                            && (it.terrainFeature==null || ruleset.tileImprovements.containsKey("Remove "+it.terrainFeature)) }
+                            && resource.terrainsCanBeFoundOn.contains(it.getLastTerrain().name) }
 
             val locations = randomness.chooseSpreadOutLocations(resourcesPerType, suitableTiles, distance)
 


### PR DESCRIPTION
1. The tile's terrain feature was never checked against `TileResource.terrainsCanBeFoundOn`
~~2. Oil never spawned on Coast tiles~~ I've noticed @ninjatao already has a PR for that

Fixes #2724 