### PR TITLE
Being able to spectate the battle of two AI's

### DIFF
--- a/core/src/com/unciv/ui/mapeditor/MapEditorScreen.kt
+++ b/core/src/com/unciv/ui/mapeditor/MapEditorScreen.kt
@@ -1,6 +1,5 @@
 package com.unciv.ui.mapeditor
 
-import com.badlogic.gdx.Game
 import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.math.Vector2
 import com.badlogic.gdx.scenes.scene2d.InputEvent
@@ -15,10 +14,10 @@ import com.unciv.logic.map.TileInfo
 import com.unciv.logic.map.TileMap
 import com.unciv.models.translations.tr
 import com.unciv.ui.newgamescreen.GameSetupInfo
-import com.unciv.ui.newgamescreen.PreviousScreenInterface
+import com.unciv.ui.newgamescreen.IPreviousScreen
 import com.unciv.ui.utils.*
 
-class MapEditorScreen(): PreviousScreenInterface, CameraStageBaseScreen() {
+class MapEditorScreen(): IPreviousScreen, CameraStageBaseScreen() {
     // need for compatibility with NewGameScreen: PickerScreen
     override fun setRightSideButtonEnabled(boolean: Boolean) {}
 

--- a/core/src/com/unciv/ui/newgamescreen/IPreviousScreen.kt
+++ b/core/src/com/unciv/ui/newgamescreen/IPreviousScreen.kt
@@ -11,15 +11,10 @@ import com.unciv.ui.utils.CameraStageBaseScreen
  * or CameraBackStageScreen class for map editing
  */
 
-interface PreviousScreenInterface {
+interface IPreviousScreen {
     val gameSetupInfo: GameSetupInfo
     var stage: Stage
 
     // added for compatibility with NewGameScreen: PickerScreen
     fun setRightSideButtonEnabled(boolean: Boolean)
 }
-
-//abstract class GameParametersPreviousScreen: PickerScreen() {
-//    abstract var gameSetupInfo: GameSetupInfo
-//    abstract val ruleset: Ruleset
-//}

--- a/core/src/com/unciv/ui/newgamescreen/NewGameScreen.kt
+++ b/core/src/com/unciv/ui/newgamescreen/NewGameScreen.kt
@@ -27,7 +27,7 @@ class GameSetupInfo(var gameId:String, var gameParameters: GameParameters, var m
     constructor(gameParameters: GameParameters, mapParameters: MapParameters) : this("", gameParameters, mapParameters)
 }
 
-class NewGameScreen(previousScreen:CameraStageBaseScreen, _gameSetupInfo: GameSetupInfo?=null): PreviousScreenInterface, PickerScreen() {
+class NewGameScreen(previousScreen:CameraStageBaseScreen, _gameSetupInfo: GameSetupInfo?=null): IPreviousScreen, PickerScreen() {
     override val gameSetupInfo =  _gameSetupInfo ?: GameSetupInfo()
     var playerPickerTable = PlayerPickerTable(this, gameSetupInfo.gameParameters)
     var newGameOptionsTable = GameOptionsTable(gameSetupInfo) { desiredCiv: String -> playerPickerTable.update(desiredCiv) }

--- a/core/src/com/unciv/ui/newgamescreen/PlayerPickerTable.kt
+++ b/core/src/com/unciv/ui/newgamescreen/PlayerPickerTable.kt
@@ -18,7 +18,7 @@ import com.unciv.models.translations.tr
 import com.unciv.ui.utils.*
 import java.util.*
 
-class PlayerPickerTable(val previousScreen: PreviousScreenInterface, var gameParameters: GameParameters): Table() {
+class PlayerPickerTable(val previousScreen: IPreviousScreen, var gameParameters: GameParameters): Table() {
     val playerListTable = Table()
     val nationsPopupWidth = previousScreen.stage.width / 2f
     val civBlocksWidth = previousScreen.stage.width / 3


### PR DESCRIPTION
Hi,

While waiting for scenario feature review I would like to start work on spectator mode.
The simplest case is to spectate two AI's battle. Could you give some step-wise plan and ideas for this feature? Like you wrote few steps for scenario, that helped a lot.

I have tried to navigate the sources and figure it out myself, however I ended up with necessity of presence of `gameInfo.currentPlayerCiv`, which couldn't be empty.
Another idea would be to simply use `NextTurnAutomation` for two `Human` players. But in these cases sometimes it gets buggy, when it expects user action - like city capture.