### PR TITLE
No starting location/unit editing for Spectator and Random players

### DIFF
--- a/core/src/com/unciv/ui/mapeditor/TileEditorOptionsTable.kt
+++ b/core/src/com/unciv/ui/mapeditor/TileEditorOptionsTable.kt
@@ -165,37 +165,38 @@ class TileEditorOptionsTable(val mapEditorScreen: MapEditorScreen): Table(Camera
 
         if (UncivGame.Current.scenarioDebugSwitch) {
             /** new scenario/improvements functionality
-             * There shoudn't be random players in scenario
+             * We shouldn't be able to edit random players or spectators
              * */
             for (player in gameParameters.players) {
                 val playerIndex = gameParameters.players.indexOf(player) + 1
-                    if (player.chosenCiv != "Random") {
-                        val nation = ruleset.nations[player.chosenCiv]!!
-                        val nationImage = ImageGetter.getNationIndicator(nation, 40f)
-                        nationImage.onClick {
-                            val improvementName = "StartingLocation " + nation.name
-                            tileAction = {
-                                it.improvement = improvementName
-                                for (tileGroup in mapEditorScreen.mapHolder.tileGroups.values) {
-                                    val tile = tileGroup.tileInfo
-                                    if (tile.improvement == improvementName && tile != it)
-                                        tile.improvement = null
-                                    tile.setTerrainTransients()
-                                    tileGroup.update()
-                                }
-                            }
-
-                            val nationIcon = getHex(Color.WHITE, ImageGetter.getNationIndicator(nation, 40f))
-                            setCurrentHex(nationIcon,"Player $playerIndex starting location")
+                if (player.chosenCiv == Constants.random || player.chosenCiv == Constants.spectator)
+                    continue
+                val nation = ruleset.nations[player.chosenCiv]!!
+                val nationImage = ImageGetter.getNationIndicator(nation, 40f)
+                nationImage.onClick {
+                    val improvementName = "StartingLocation " + nation.name
+                    tileAction = {
+                        it.improvement = improvementName
+                        for (tileGroup in mapEditorScreen.mapHolder.tileGroups.values) {
+                            val tile = tileGroup.tileInfo
+                            if (tile.improvement == improvementName && tile != it)
+                                tile.improvement = null
+                            tile.setTerrainTransients()
+                            tileGroup.update()
                         }
-                        nationTable.add(nationImage).row()
-
                     }
+
+                    val nationIcon = getHex(Color.WHITE, ImageGetter.getNationIndicator(nation, 40f))
+                    setCurrentHex(nationIcon,"Player $playerIndex starting location")
                 }
+                nationTable.add(nationImage).row()
+            }
         } else {
             /** old way improvements for all civs
              * */
             for(nation in ruleset.nations.values){
+                if (nation.isSpectator()) continue  // no improvements for spectator
+
                 val nationImage = getHex(Color.WHITE, ImageGetter.getNationIndicator(nation, 40f))
                 nationImage.onClick {
                     val improvementName = "StartingLocation "+nation.name
@@ -225,7 +226,7 @@ class TileEditorOptionsTable(val mapEditorScreen: MapEditorScreen): Table(Camera
 
         val nationsTable = Table()
 
-        // default player - first non-random player or barbarians
+        // default player - barbarians
         var currentPlayer = ""
         var currentNation: Nation? = ruleset.nations.values.firstOrNull{ it.isBarbarian() }
 
@@ -265,15 +266,15 @@ class TileEditorOptionsTable(val mapEditorScreen: MapEditorScreen): Table(Camera
 
         // player icons
         for (player in gameParameters.players) {
-            if (player.chosenCiv != "Random") {
-                val nation = ruleset.nations[player.chosenCiv]!!
-                val nationImage = ImageGetter.getNationIndicator(nation, 40f)
-                nationsTable.add(nationImage).row()
-                nationImage.onClick {
-                    currentNation = nation;
-                    currentPlayer = getPlayerIndexString(player)
-                    setUnitTileAction() }
-            }
+            if (player.chosenCiv == Constants.random || player.chosenCiv == Constants.spectator)
+                continue
+            val nation = ruleset.nations[player.chosenCiv]!!
+            val nationImage = ImageGetter.getNationIndicator(nation, 40f)
+            nationsTable.add(nationImage).row()
+            nationImage.onClick {
+                currentNation = nation;
+                currentPlayer = getPlayerIndexString(player)
+                setUnitTileAction() }
         }
 
         // barbarians icon


### PR DESCRIPTION
Fixed a bug when players can add units/starting locations for Spectator player.