### PR TITLE
Create Persian_PingilishDIN.properties

### DIFF
--- a/android/assets/jsons/translations/Persian_PingilishDIN.properties
+++ b/android/assets/jsons/translations/Persian_PingilishDIN.properties
@@ -1,0 +1,926 @@
+
+
+# If you want to add new translations, please follow these guidelines (for unification purposes):
+# In order to make the words short and clean, please use these special characters instead: (if you don’t want to copy paste these letters every time, you can simply use Microsoft Word and make a shortcut for each one of them in “Insert >> Symbol”)
+# aa = ā (as in “āb” = water) (Ā, ā)
+# ch = č (as in “čera” = why) (Č, č)
+# kh = ḵ (as in “ḵām” = raw) (Ḵ, ḵ)
+# zh = ž (as in “pižāme” = pajamas) (Ž, ž)
+# sh = š (as in “šab” = night) (Š, š)
+# gh = ğ (as in “ğāšoğ” = spoon) (Ğ, ğ)
+# Please note that the letter ع(ein) does not have a direct translation, Simply because there is no need to, like in “edālat”(=justice) or “abas”(=vain) however, In words like “Sa’adi”(a famous poet) where the /∅/ is tangible, I opted to use apostrophe (‘) and put the two vowels that are heard before and after ‘ein’ around it, Like in Sa’adi (sa + a + di) you hear ‘a’ before and after ‘ein’, In a word like “sa’ādat” (=happiness, felicity, well-being) since its pronounced as (sa + ā + dat), I put “a’ā” instead of ‘ein’.
+# If you encountered a word which had ‘tashdid’ (it was intensified in pronunciation), Like “Mohabbat” (=kindness) just write the vowel that was intensified twice.
+# Don’t use ‘u’ instead of ‘oo’ (like “rood” (= river) instead of “rud”).
+# Avoid using ‘ee’ as much as possible, use ‘i’instead (like “ḵātere i ḵoob” (= a good memory), instead of “ḵātere ee ḵoob”)
+# And also just like English, use capital letters for special names and at the beginning of sentences.
+# To make the translations more in line with the contemporaneous Persian language I have changed some nouns to a more common one, or something that makes sense, like there is no direct translation for ‘warpath’ so considering the phrase (The Great Warpath) I opted to translate it as ‘warrior’ instead.
+
+# PLEASE NOTE! This alphabet was derivated from “DIN 31635” standard however, IT’S NOT COMMON AMONG IRANIANS TO WRITE PINGLISH LIKE THIS. They usually use “ch”, “kh”, “zh”, etc. instead of these letters, So if you decided to make this translation obey those rules, please add it as a new language called “Persian (Pinglish UN)” since that is the alphabet which is approved by the United Nations as a substitute for the official Persian alphabet.
+
+
+# Tutorial tasks
+
+Move a unit!\nClick on a unit > Click on a destination > Click the arrow popup = Yek niroo rā harekat dahid!\nRooye yek niroo kilik konid > Rooye yek mağsad kilik konid > Rooye feleš e zāher šode kilik konid
+Found a city!\nSelect the Settler (flag unit) > Click on 'Found city' (bottom-left corner) = Sāḵt e šahr!\nKoloni rā enteḵāb konid (Nirooyi ke parčam dārad) > Rooye ‘Sāḵt e šahr’ kilik konid (gooše pāyin samt e chap)
+Enter the city screen!\nClick the city button twice = Vāred safhe ye šahr šavid!\nRooye gozine ye šahr 2 bar kilik konid
+Pick a technology to research!\nClick on the tech button (greenish, top left) > \n select technology > click 'Research' (bottom right) = Yek teknoloji barāye tahğiğ enteḵāb konid!\nRooye gozine teknoloji kilik konid (sabz, bālā chap) > \n teknoloji enteḵāb konid > rooye ‘tahğiğ’ kilik konid (pāyin rāst)
+Pick a construction!\nEnter city screen > Click on a unit or building (bottom left side) > \n click 'add to queue' = yek sāḵt-o-sāz enteḵāb konid!\nVared safhe ye šahr šavid > Rooye yek Niroo yā sāḵtemān kilik konid (samt e pāyin chap) > \n rooye ‘Ezāfe kardan be saf’ kilik konid
+Pass a turn!\nCycle through units with 'Next unit' > Click 'Next turn' = Yek nobat begozarid!\nBa ‘Niroo ye ba’adi’ tooye niroo ha čarḵ bezanid > Rooye ‘Nobat e ba’adi’ kilik konid
+Reassign worked tiles!\nEnter city screen > click the assigned (green) tile to unassign > \n click an unassigned tile to assign population = zamin hāye kār šode rā dobāre entesāb konid!\nVāred safhe ye šahr šavid > Rooye zamin e entesāb šode (sabz) kilik konid tā entesāb bardāšte šavad > \n rooye yek zamin e entesāb našode kilik konid tā šahrvandi be ān entesāb šavad
+Meet another civilization!\nExplore the map until you encounter another civilization! = Bā yek tamaddon e digar āšna šavid!\nNağše rā kāvoš konid ta bā yek tamaddon e digar rooberoo šavid!
+Open the options table!\nClick the menu button (top left) > click 'Options' = Menoye tanzimāt rā bāz konid!\nRooye dokme ye meno kilik konid (bālā čap) > rooye ‘Tanzimat’ kilik konid
+Construct an improvement!\nConstruct a Worker unit > Move to a Plains or Grassland tile > \n Click 'Create improvement' (above the unit table, bottom left)\n > Choose the farm > \n Leave the worker there until it's finished = yek zamin rā behbood bebaḵšid!\nYek niroo ye Kārgar besāzid > Be yek zamin e dašt yā čamanzār harekat konid > \n Rooye ‘Behbood baḵšidan’ kilik konid (bālāye panjere ye niroo, pāyin čap)\n > Mazra’e rā enteḵāb konid > \n Kārgar rā ānja bogzārid tā kār tamām šavad
+Create a trade route!\nConstruct roads between your capital and another city\nOr, automate your worker and let him get to that eventually = Yek masir e tejāri besāzid!\nBein pāytaḵtetoon va yek šahr digar jādde bekešid\nYā, kārgar ḵod rā rooye ḵodkār begozārid va sabr konid tā oo dar nahāyat in kār rā bokonad
+Conquer a city!\nBring an enemy city down to low health > \nEnter the city with a melee unit = Yek šahr rā fath konid!\nJoon e yek šahr e došman rā kam konid > \nBā yek niroo ye zamini ye nazdik-bord vāred šahr šavid
+Move an air unit!\nSelect an air unit > select another city within range > \nMove the unit to the other city = Yek niroo ye havāi rā harekat dahid!\nYek niroo ye havāi rā enteḵab konid > yek šahr digar ke dar bord ast rā enteḵāb konid > \nNiroo rā be ān šahr montağel konid
+See your stats breakdown!\nEnter the Overview screen (top right corner) >\nClick on 'Stats' = Barresi āmari ḵod rā bebinid!\nVāred e safhe ye Barresi šavid (gooše ye bālā rāst) >\nRooye ‘Āmār’ kilik konid
+
+Oh no! It looks like something went DISASTROUSLY wrong! This is ABSOLUTELY not supposed to happen! Please send me (yairm210@hotmail.com) an email with the game information (menu -> save game -> copy game info -> paste into email) and I'll try to fix it as fast as I can! = Vāy na! Be nazar yek moškel FĀJE’E ĀMIZ be vojood āmad! Hamčin čizi ĞATA’AN nabāyad ettefāgh bioftad! Lotfan be man yek email (yairm210@hotmail.com) bā ettelā’āt bāzi bezanid (meno -> zaḵire ye bāzi -> ettelā’āt bāzi rā kopi konid -> dar email peyst konid) va man sa’ay ḵāham kard dar asra’e e vağt ānrā dorost konam!
+Oh no! It looks like something went DISASTROUSLY wrong! This is ABSOLUTELY not supposed to happen! Please send us an report and we'll try to fix it as fast as we can! = Vāy na! Be nazar yek moškel FĀJE’E ĀMIZ be vojood āmad! Hamčin čizi ĞATA’AN nabāyad ettefāgh bioftad! Lotfan be mā yek gozāreš befrestid va mā sa’ay ḵāhim kard ānrā dar asra’e e vağt dorost konim!
+
+# Buildings
+
+Choose a free great person = Yek fard e bozorg rā rāygān begirid
+Get  =  Begirid
+
+Hydro Plant = Niroogāh e Ābi
++1 population in each city = +1 jame’iat dar har šahr
++1 happiness in each city = +1 rezāyat dar har šahr
+
+# Diplomacy,Trade,Nations
+
+Requires [buildingName] to be built in the city = Niāz dārad ke [buildingName] dar šahr sāḵte šode bāšad
+Requires [buildingName] to be built in all cities = Niāz dārad ke [buildingName] dar hame ye šahr hā sāḵte šode bāšad
+Provides a free [buildingName] in the city = Yek [buildingName] e rāygān dar šahr erāe midahad
+Requires worked [resource] near city = Niāz be yek [resource] kār šode nazdik e šahr dārad
+Wonder is being built elsewhere = In O’ejoobe dar jāye digari dar hāl sāḵte šodan ast
+Requires a [buildingName] in all cities = Niāz dārad ke yek [buildingName] dar hame ye šahr hā bāšad
+Requires a [buildingName] in this city = Niāz dārad ke yek [buildingName] dar in šahr bāšad
+Consumes 1 [resource] = 1 [resource] masraf mikonad
+Required tech: [requiredTech] = Teknoloji mored e niāz: [requiredTech]
+
+Current construction = Sāḵt-o-sāz e dar hāl e hāzer
+Construction queue =  Sāḵt-o-sāz e dar saf
+Pick a construction = Yek sāḵt-o-sāz enteḵāb konid
+Queue empty = Saf ḵāli ast
+Add to queue = Ezāfe kardan be saf
+Remove from queue = Hazf kardan az saf
+Show stats drilldown = Nešān dādan e āmār be joze’eiat
+Show construction queue = Nešan dādan e saf e sāḵt-o-sāz
+
+Diplomacy = Diplomasi
+War = Jang
+Peace = Solh
+Research Agreement = Tavāfoğ e Tahğiğāti
+Declare war = E’elām e jang
+Declare war on [civName]? = E’elām e jang be [civName]?
+[civName] has declared war on us! = [civName] be mā e’elām e jang karde ast!
+[leaderName] of [nation] = [leaderName] az [nation]
+You'll pay for this! = Hazine ye in kār rā pardāḵt ḵāhi kard!
+Negotiate Peace = Mozākere dar bāre ye Solh
+Peace with [civName]? = Solh kardan bā [civName]?
+Very well. = Ḵeyle ḵob.
+Farewell. = Ḵoda Negahdār.
+Sounds good! = Be nazar ḵoob miād!
+Not this time. = In dafe’e na.
+Excellent! = Ālie!
+How about something else... = Yek čiz e dige četore...
+A pleasure to meet you. = Az molāğāt bā šomā ḵošbaḵtam.
+Our relationship:  = Ravābet e ma:
+We have encountered the City-State of [name]! = Mā be Šahrestān e [name] barḵord kardim!
+Declare Friendship ([numberOfTurns] turns) = E’elām doosti ([numberOfTurns] nobat)
+May our nations forever remain united! = Bāšad ke dolat hāye mā barāye hamiše mottahed bemānand!
+Indeed! = Albate!
+Denounce ([numberOfTurns] turns) = Dar jāme’e ye jahāni mahkoom kardan ([numberOfTurns] turns)
+We will remember this. = Mā inrā be yād ḵāhim dāšt.
+
+[civName] has declared war on [targetCivName]! = [civName] be [targetCivName] e’elām jang karde ast!
+[civName] and [targetCivName] have signed the Peace Treaty! = [civName] va [targetCivName] bā ham Mo’āhede ye Solh bastand!
+[civName] and [targetCivName] have signed the Declaration of Friendship! = [civName] va [targetCivName] bā ham peymān doosti bastand!
+[civName] has denounced [targetCivName]! = [civName], [targetCivName] rā mahkoom karde ast!
+
+Unforgivable = Ğeyr e Ğābel e Baḵšeš
+Enemy = Došman
+Competitor = Rağib
+Neutral = Āddi
+Favorable = Tarafdār
+Friend = Doost
+Ally = Ham-Peymān
+
+## Diplomatic modifiers
+
+You declared war on us! = Šomā be mā e’elām e jang kardid
+Your warmongering ways are unacceptable to us. = Rāh hāye jang talabāne ye šoma barāye mā ğābel e ğabool nist.
+You have captured our cities! = Šoma šahr e mā rā tasḵir karde id!
+We applaud your liberation of our conquered cities! = Mā āzad kardan e šahr e tasḵir šode ye mān, be dast šomā rā, tahsin mikonim!
+Years of peace have strengthened our relations. = Sāl hāye motemādi e solh ravābet mārā mohkam karde ast.
+Our mutual military struggle brings us closer together. = Taghallā ye nezāmi e moštarak e mā, mā rā be ham nazdik tar karde.
+We have signed a public declaration of friendship = Mā yek peymān doosti e omoomi baste im
+You have declared friendship with our enemies! = Šomā be došmanān mā e’elām doosti karde id!
+You have declared friendship with our allies = Šomā be ham-peymānān mā e’elām doosti karde id
+Our open borders have brought us closer together. = Marz hāye bāz e mā, mā rā be ham nazdik tar karde ast.
+Your so-called 'friendship' is worth nothing. = In be-estelāh ‘doosti’ e šomā hič arzeši nadārad.
+You have publicly denounced us! = Šomā mā rā be soorat e omoomi mahkoom kardid!
+You have denounced our allies = Šomā ham-peymānān mā rā mahkoom karde id!
+You have denounced our enemies = Šomā došmanān mā rā mahkoom karde id!
+You betrayed your promise to not settle cities near us = Šomā ğol ḵod ke kenār šahr hāye mā mostağar našid rā zir e pā gozaštid
+You fulfilled your promise to stop settling cities near us! = Šomā be ğol ḵod ke kenār šahr hāye mā mostağar našid amal kardid!
+You refused to stop settling cities near us = Šomā ğabool nakardid ke kenār šahr hāye mā mostağar našid
+Your arrogant demands are in bad taste = tağāzā hāye mağroorāne ye šoma aziat konande ast
+Your use of nuclear weapons is disgusting! = Estefāde šoma az selāh hāye haste i, hāl-behamzan ast.
+You have stolen our lands! = Šomā zamin hāye mārā dozdide id!
+
+Demands = Ḵāste hā
+Please don't settle new cities near us. = Lotfan nazdik e mā šahr jadid nasāzid.
+Very well, we shall look for new lands to settle. = ḵeyle ḵob, mā donbāl e zamin hāye jadid barāye mostağar šodan ḵāhim gašt.
+We shall do as we please. = Mā har kāri delemān beḵāhad anjām midahim.
+We noticed your new city near our borders, despite your promise. This will have....implications. = Mā motevajje šodim alā-rağm e ğoli ke dādid nazdik e marz hāye mā šahr sāḵte id. In... payāmad hāyi ḵāhad dāšt.
+
+# City-States
+
+Provides [amountOfCulture] culture at 30 Influence = Dar 30 Nofooz,  [amountOfCulture] farhang midahad
+Provides 3 food in capital and 1 food in other cities at 30 Influence = Dar 30 Nofooz, 3 ğazā dar pāytaḵt va 1 ğazā dar šahr hāye digar midahad
+Provides 3 happiness at 30 Influence = Dar 30 Nofooz, 3 rezāyat midahad
+Provides land units every 20 turns at 30 Influence = dar 30 Nofooz, har 20 nobat niroo hāye zamini midahad
+Gift [giftAmount] gold (+[influenceAmount] influence) = hadie dādan e [giftAmount] talā (+[influenceAmount] Nofooz)
+Relationship changes in another [turnsToRelationshipChange] turns = Ravābet dar [turnsToRelationshipChange] nobat e digar, avaz mishavand.
+
+Cultured = Bā Farhang
+Maritime = Daryāi
+Mercantile = Bāzargāni
+Militaristic = Nezāmi
+Type:  = noe’e:
+Influence:  = Nofooz
+Reach 30 for friendship. = Baraye doosti be 30 beresid.
+Reach highest influence above 60 for alliance. = Be bištarin Nofooz, bālāye 60, beresid to ham-peymān šavid.
+Ally:  = Ham-Peymān:  
+
+# Trades 
+
+Trade = Tejārat
+Offer trade = Pišnahād tejārat
+Retract offer = Pas gereftan e pišnahād
+What do you have in mind? = če čizi dar nazar dārid?
+Our items = Āytem hāye mā
+Our trade offer = Pišnahād e tejāri e mā
+[otherCiv]'s trade offer = Pišnahād e tejāri e [otherCiv]
+[otherCiv]'s items = Āytem hāye [otherCiv]
+Pleasure doing business with you! = Kār kardan bā šomā bāes e efteḵāre!
+I think not. = Movāfeğ nistam.
+That is acceptable. = In ğābel e ğabool ast.
+Accept = Ğabool
+Keep going = Edāme bede
+There's nothing on the table = Hič pišnahādi rooye miz nist
+Peace Treaty = Mo’āhede ye Solh
+Agreements = Tavāfoğ hā
+Open Borders = Bāz Kardan Marz Hā
+Gold per turn = Tala dar har nobat
+Cities = Šahr Hā
+Technologies = Teknoloji Hā
+Declarations of war = E’elām jang hā
+Introduction to [nation] = Mo’arefi kardan be [nation]
+Declare war on [nation] = E’elām jang be [nation]
+Luxury resources = Manābe’e loox
+Strategic resources = Manābe’e esterātejik
+Owned: [amountOwned] = Dārim: [amountOwned]
+
+# Nation picker 
+
+[resourceName] not required = Niāzi be [resourceName] nist
+Lost ability = Tavānāi az dast rafte
+National ability = Tavānāi melli
+[firstValue] vs [secondValue] = [firstValue] bar alayh e [secondValue]
+
+# Nations
+
+Receive free Great Scientist when you discover Writing, Earn Great Scientists 50% faster = Yek Dānešmand e Bozorg e rāygān vağti Neveštan rā kašf mikonid daryāft konid, Dānešmand hāye Bozorg rā 50% sari’e tar daryāft konid
+Ingenuity = Nobooğ
+
+City-State Influence degrades at half and recovers at twice the normal rate = Nofooz rooye Šahrestān hā bā nesf e sora’at e āddi kam mišavad va bā 2 barābar e sora’at e āddi ziād mišavad
+Hellenic League = Ettehād e Yoonāni
+
+Great general provides double combat bonus, and spawns 50% faster = Farmānde Ye Bozorg 2 barābar jāyeze ye nezami midahad, va 50$ sari’e tar zāher mišavad
+Art of War = Honar e Jang
+
++20% production towards Wonder construction = +20% tolid barāye sāḵt e Ajāyeb
+Monument Builders = Sāzandegan e Āsār e Yādbood
+
++2 movement for all naval units = +2 harekat barāye tamām e niroo hāye daryāi
+Sun Never Sets = Ḵoršid Hičvağt Ğoroob Nemikonad
+
++2 Culture per turn from cities before discovering Steam Power = +2 Farhang az šahr hā dar har nobat, tā ğabl az kašf e Motore e Boḵār
+Ancien Régime = Hokoomat e Kohan
+
+Strategic Resources provide +1 Production, and Horses, Iron and Uranium Resources provide double quantity = Manābe’e Esterātejik +1 Tolid ezāfe erāe midahand hamčenin, Manābe’e Asb, Āhan va Orāniom 2 barābar e meğdār e āddi midahand
+Siberian Riches = Servatmandān e Siberiai
+
++25% Production towards any buildings that already exist in the Capital = +25% Tolid barāye sāḵt e har sāḵtemāni ke ğablan dar Pāytaḵt sāḵte šode bāšad
+The Glory of Rome = Šokooh e Rom
+
++1 Gold from each Trade Route, Oil resources provide double quantity = +1 Talā be ezāye har Masir e Tejāri, Manābe’e Naft 2 barābar e meğdār e āddi midahand
+Trade Caravans = Kārevān Hāye Bāzargāni
+
+All land military units have +1 sight, 50% discount when purchasing tiles = Tamām niroo hāye nezāmi e zamini +1 Did bištar dārand, 50% taḵfif barāye ḵarid ḵane hā
+Manifest Destiny = Sarnevešt e Āšekār
+
+Units fight as though they were at full strength even when damaged = Niroo hā hengāmi ke āsib dide and tori mijangand ke engār āsibi nadide and
+Bushido = Boošido
+
+67% chance to earn 25 Gold and recruit a Barbarian unit from a conquered encampment, -25% land units maintenance. = 67% ehtemāl dārad ke az yek ordoogāh e Barbar tasḵir šode 25 Talā va yek niroo ye Barbar daryāft konid, -25% negahdāri e niroo hāye zamini
+Furor Teutonicus = Ḵašm e Ālmāni
+
+Unhappiness from number of Cities doubled, Unhappiness from number of Citizens halved. = Nārezāyati az tedād e Šahr hā 2 barābar mišavad, ammā Nārezayati az tedād e Šahrvandān nesf mišavad.
+Population Growth = Rošd e Jame’iat
+
+Pay only one third the usual cost for naval unit maintenance. Melee naval units have a 1/3 chance to capture defeated naval units. = 1/3 hazine ye negahdāri e niroo hāye daryāi rā bepardāzid. Niroo hāye daryāi nazdik-bord 1/3 šāns dārand ke niroo hāye daryāi šekast ḵorde rā tasḵir konand.
+Barbary Corsairs = Dozdān Daryāi e Barbar
+
++2 Science for all specialists and Great Person tile improvements = +2 Elm barāye har moteḵasses va zamin hāye behbood baḵšide šode tavasot e Afrād e Bozorg
+Scholars of the Jade Hall = Pažoohešgarān e Tālār e Jeyd
+
+All units move through Forest and Jungle Tiles in friendly territory as if they have roads. These tiles can be used to establish City Connections upon researching the Wheel. = Tamām e niroo hā tori toye Jangal va Biše hā dar ğalamro e ḵodi harekat mikonand ke engār jādde dārand. Az in zamin hā hamčenin mitavān pas az tahğiğ va kašf e Čarḵ, barāye mottasel kardan šahr hā estefāde kard.
+The Great Warpath = Jangjooye Bozorg
+
+Golden Ages last 50% longer. During a Golden Age, units receive +1 Movement and +10% Strength = Asr hāye Talāi 50% bištar davām dārand. Hengām e yek Asr e Talāi, niroo hā +1 Harekat va +10% Ğovvat daryāft mikonand
+Achaemenid Legacy = Mirās e Haḵāmaneši
+
+Can embark and move over Coasts and Oceans immediately. +1 Sight when embarked. +10% Combat Strength bonus if within 2 tiles of a Moai. = Mitavān mostağiman az daryā be sāhel raft va bar aks. +1 Did vağti dar daryā hastid. +10% Ğovvat e Jangi agar be fāsele ye 2 ḵāne az yek Moāy bāšid.
+Wayfinding = Masiryābi
+
+Food and Culture from Friendly City-States are increased by 50% = Ğazā va Farhang az Šahrestān hāye doost 50% afzāyeš miyāband.
+Father Governs Children = Pedar bar Farzandān Hokoomat Mikonad
+
+Receive triple Gold from Barbarian encampments and pillaging Cities. Embarked units can defend themselves. = 3 barābar Talā az Ordoogāh hāye Barbar va az ğārat e Šahr hā bedast avarid. Niroo hāye zamini mostağar dar āb mitavānand az ḵod defā konand.
+River Warlord = Sepahbod e Daryā hā
+
+100 Gold for discovering a Natural Wonder (bonus enhanced to 500 Gold if first to discover it). Culture, Happiness and tile yields from Natural Wonders doubled. = 100 talā barāye kašf kardan e yeki az Ajāyeb e Tabi’I (500 talā agar avvalin nafari bašid ke kašfaš mikonad). Farhang, Rezāyat, va zamin hāye dāde šode az Ajāyeb e Tabi’i 2 barābar mišavand.
+Seven Cities of Gold = Haft Šahr e Talā
+
+Combat Strength +30% when fighting City-State units or attacking a City-State itself. All mounted units have +1 Movement. = +30% Ğovvat e Jangi vağti be niroo hāye yek šahrestān yā be ḵod šahrestān hamle mikonid. Tamām niroo hāye savāre +1 Harekat ḵāhand dāšt.
+Mongol Terror = Tars az Moğol
+
+Units ignore terrain costs when moving into any tile with Hills. No maintenance costs for improvements in Hills; half cost elsewhere. = Niroo hā hazine ye harekat be zamini ke tappe dārad rā nmidahand. Hazine ye negahdāri barāye zamin hāye tappe i behbood baḵšide šode napardāzid. Hazine ye tamām zamin hāye digar ham nesf mišavaf.
+Great Andean Road = Jāde ye Azim e Kooh hāye Ānd
+
++1 Movement to all embarked units, units pay only 1 movement point to embark and disembark. Melee units pay no movement cost to pillage. = +1 Harekat barāye tamām niroo hāye zamini e dar daryā, Niroo hā fağat 1 Harekat barāye ḵarej va vāred be āb šodan mipardāzand. Niroo hāye nazdik-bord barāye ğārat hič Harekati az dast nemidahand.
+Viking Fury = Ḵašt Vāyking hā
+
+Sacrificial Captives = Asir hāye Ğorbāni
+Gain Culture for the empire from each enemy unit killed = be ezāye har niroo ye došman ke košte mišavad Farhang daryāft konid.
+
+# New game screen
+
+Uniques = Bi Mānand hā
+Promotions = Beh-sāzi hā
+Load copied data = Bārgozāri e Etela’at Kopi Šode
+Could not load game from clipboard! = Bāzi e kopi šode bārgozāri našod!
+Start game! = Šoro’e bāzi!
+Map Options = Tanzimāt e Nağše
+Game Options = Tanzimāt e Bāzi
+Civilizations = Tamaddon hā
+Map Type = No’e Nağše
+Generated = Jadid dorost kardan
+Existing = Mojood
+Custom = Delḵāh
+Map Generation Type = No’e Doros Kardan Nağše
+Default = Pišfarz
+Pangaea = Pānge-ā
+Perlin = Perlin
+Continents = Ğārre hā
+Archipelago = Majma’ol Jazāyer
+Number of City-States = Tedād e Šahrestān hā
+One City Challenge = Čāleš tak šahri
+No Barbarians = Bedoon Barbar hā
+No Ancient Ruins = Bedoon Ḵarābe hāye Bāstāni
+No Natural Wonders = Bedun Ajāyeb e Tabi’i
+Victory Conditions = Šarāyet e Piroozi
+Scientific = Elmi
+Domination = Solte bar Digarān
+Cultural = Farhangi
+
+Map Shape = Šekl e Nağše
+Hexagonal = Šeš-zeli
+Rectangular = Morabbari
+
+Show advanced settings = Nešān dādan e tanzimāt e pišrafte
+Hide advanced settings = Bastan e tanzimāt e pišrafte
+Map Height = Ertefa’e Nağše
+Temperature extremeness = Šeddat e damā
+Resource richness = Mizān e manābe
+Vegetation richness = Mizān e sarsabzi
+Rare features richness = Mizān e vižegi hāye kamyāb
+Max Coast extension = Haddeaksar e pišravi e sāhel
+Biome areas extension = Haddeaksar e tose’e ye zist-boom hā
+Water level = Sath e āb
+Reset to default = Bāzgardāni be pišfarz
+
+HIGHLY EXPERIMENTAL - YOU HAVE BEEN WARNED! = ŠADIDAN ĀZMĀYEŠI – BE ŠOMA EḴTĀR DĀDE MIŠAVAD!
+Online Multiplayer = Čand-nafare e Ānlāyn
+
+World Size = Āndāze ye Jahān
+Tiny = Riz
+Small = Koočak
+Medium = Motevasset
+Large = Bozorg
+Huge = Azim
+
+Difficulty = Daraje ye Saḵti
+
+AI = Hooš-Masnooi
+Remove = Hazf
+Random = Tasādofi
+Human = Ensān
+Hotseat = Masool
+User ID = ID e Karbar
+Click to copy = Barāye kopi kilik konid
+
+
+Game Speed = Sorat e Bāzi
+Quick = Sari
+Standard = Motevasset
+Epic = Arām
+Marathon = Mārāton
+
+Starting Era = Asr e Hāzer dar Ebtedā
+It looks like we can't make a map with the parameters you requested! = Be nazar miād nemitavānim nağše i bā in pārāmetr hā dorost konim!
+Maybe you put too many players into too small a map? = Šayad tedād ziādi bāzikon dar yek nağše ye koočak ğarār dāde id.
+No human players selected! = Hič bāzikon e ensāni enteḵāb našode ast!
+Mods: = Mod hā:
+
+# Multiplayer
+
+Username = Nām e Kārbari
+Multiplayer = Čand-nafare
+Could not download game! = Bāzi dānlod našod!
+Could not upload game! = Bāzi āplod našod!
+Join Game = Peyvastan be Bāzi
+Invalid game ID! = ID e bāzi nā-motabar ast!
+Copy User ID = Kopi Kardan e ID e Kārbari
+Copy Game ID = Kopi Kardan e ID e Bāzi
+UserID copied to clipboard = ID e Kārbari kopi šod
+GameID copied to clipboard = ID e Bāzi kopi šod
+Set current user = Ğarār dādan e hamin kārbar
+Player ID from clipboard = ID e Kārbari e kopi šode
+To create a multiplayer game, check the 'multiplayer' toggle in the New Game screen, and for each human player insert that player's user ID. = Barāye sāḵt e yek bāzi čand-nafare, tik e ‘čand-nafare’ rā dar safhe ye Bāzi e Jadid bezanid, va be ezāye har fard ID oo rā vāred konid.
+You can assign your own user ID there easily, and other players can copy their user IDs here and send them to you for you to include them in the game. = Šomā mitavānid ID ḵod rā ānjā be rāhati vāred konid, va bāzikonān digar ham mitavānand ID hāye ḵod rā az injā kopi konand va barāye šoma befrestand tā dar bāzi ğarārešān dahid.
+Once you've created your game, the Game ID gets automatically copied to your clipboard so you can send it to the other players. = Vağti bāzi e ḵod rā sāḵtid, ID e Bāzi barāye šomā ḵodkār kopi mišavad tā šomā betavānid ānrā be bāzikonān e digar befrestid.
+Players can enter your game by copying the game ID to the clipboard, and clicking on the 'Add Multiplayer Game' button = Bāzikonān bā kopi kardan e ID e Bāzi va kilik rooye ‘Ezāfe Kardan e Bāzi e Čand-nafare’, vāred e bāzi šomā šavand.
+The symbol of your nation will appear next to the game when it's your turn = Namād e mellat e šoma vağti nobatetān mišavad, kenār e bāzi namāyān mišavad
+Back = Ağab
+Rename = Tağyir e Nām
+Edit Game Info = Tağyir e Etelā’āt e Bāzi
+Add Multiplayer Game = Ezāfe Kardan e Bāzi e Čand-nafare
+Refresh List = Rifereš Kardan e List
+Could not save game! = Bāzi zaḵire našod!
+Could not delete game! = Bāzi hazf našod!
+Could not refresh! = Rifereš anjām našod!
+Last refresh: [time] minutes ago = Āḵarin rifereš: [time] dağiğe piš
+Current Turn: = Nobat e Fe’eli:
+Add Currently Running Game = Ezāfe Kardan Bāzi e Dar Hāl e Anjām
+Game name = Nām e bāzi
+Loading latest game state... = Bārgozāri e āḵarin vaze’iat e bāzi
+Couldn't download the latest game state! = Āḵarin vaze’iat e bāzi dānlod našod!
+
+# Save game menu
+
+Current saves = Zaḵire-sāzi hāye fe’eli
+Show autosaves = Nešān dādan e Zaḵire-sāzi hāye ḵodkār
+Saved game name = Nām e bāzi e zaḵire šode
+Copy to clipboard = Kopi
+Copy saved game to clipboard = Kopi kardan e bāzi e zaḵire šode
+Could not load game = Bāzi bārgozāri našod
+Load [saveFileName] = Bārgozāri e [saveFileName]
+Delete save = Hazf e zaḵire-sāzi
+Saved at = Zaḵire šode dar
+Load map = Bārgozāri e nağše
+Delete map = Hazf e nağše
+Are you sure you want to delete this map? = Āyā az hazf e in nağše motma’en hastid?
+Upload map = Āplod e nağše
+Could not upload map! = Nağše āplod našod!
+Map uploaded successfully! = Nağše bā movaffaği’at āplod šod!
+Saving... = zaḵire sāzi …
+It looks like your saved game can't be loaded! = Be nazar miresad bāzi e zaḵire šode ye šomā, bārgozāri nemišavad!
+If you could copy your game data ("Copy saved game to clipboard" -  = agar tavānestid etelā’āt e bāzi ḵod rā kopi konid (“Kopi kardan e bāzi e zaḵire šode” -
+  paste into an email to yairm210@hotmail.com) = anrā dar emaili be yairm210@hotmail.com peyst konid)
+I could maybe help you figure out what went wrong, since this isn't supposed to happen! = Man ehtemālan mitavānam komaketān konam moškel rā peydā konim, čerā ke in nabāyad ettefāğ mioftād!
+Missing mods: [mods] = Mod hāye mafğood: [mods]
+
+# Options
+
+Options = Tanzimāt
+Display options = Tanzimāt e safhe
+Gameplay options = Tanzimāt e geym-peley
+Other options = Tanzimāt e digar
+Turns between autosaves = Tedād e nobat hā beyn e har zaḵire-sāzi ḵodkār
+Sound effects volume = Hajm e sedā ye efekt hāye soti
+Music volume = Hajm e sedā ye mosiği
+Download music = Dānlod e mosiği
+Downloading... = Dar hāl e dānlod...
+Could not download music! = Mosiği dānlod našod!
+Show = Nešān dādan
+Hide = Bastan
+Show worked tiles = Nešān dādan e zamin hāye kār šode
+Show resources and improvements = Nešān dādan e manābe’ va behbood-šazi hā
+Check for idle units = Gaštan barāye niroo hāye bikār
+Move units with a single tap = Harekat dādan e niroo hā bā yek kilik
+Show tutorials = Nešān dādan e rāhnamāi
+Auto-assign city production = Enteḵāb e ḵodkār e sāḵt-o-sāz barāye šahr
+Auto-build roads = sāḵt e ḵodkār jādde
+Show minimap = Nešān dādan e minimap
+Show pixel units = Nešān dādan e tasviri e niroo hā
+Show pixel improvements = Nešān dādan e tasviri e behbood-sāzi hā
+Enable nuclear weapons = Fa’āl kardan e selāh hāye haste i
+Fontset = Noe Font
+Continuous rendering = Render e peyvaste
+When disabled, saves battery life but certain animations will be suspended = Vağti ğeyr e fa’āl ast bātri rā kamtar masraf mikonad vali ba’azi animeyšen hā ğeyr fa’āl mišavand
+Order trade offers by amount = Morattab kardan e pišnahād hāye tejāri az meğdārešoon
+Generate translation files = Sāḵt e fāyl e tajome
+Translation files are generated successfully. = Fāyl hāye tarjome bā movaffaği’at sāḵte šodand.
+
+# Notifications
+
+Research of [technologyName] has completed! = Tahğig darbāre ye [technologyName] be natije resid!
+You have entered a golden age! = Šomā vāred e yek asr e talāi šodid!
+[resourceName] revealed near [cityName] = [resourceName] kenār e [cityName] peydā šode ast
+A [greatPerson] has been born in [cityName]! = Yek [greatPerson] dar [cityName] be donyā āmade ast!
+We have encountered [civName]! = Mā bā [civName] movāje šodim!
+Cannot provide unit upkeep for [unitName] - unit has been disbanded! = Hazine ye negahdāri barāye [unitName] tamin našod – niroo monhal šod!
+[cityName] has grown! = [cityName] rošd karde ast!  
+[cityName] has been founded! = [cityName] sāḵte šod!
+[cityName] is starving! = [cityName] gorosnegi mikešad!
+[construction] has been built in [cityName] = [construction] dar [cityName] sāḵte šod
+[wonder] has been built in a faraway land = [wonder] dar sarzamini door sāḵte šod
+Work has started on [construction] = Kār bar rooye [construction] šoroo šod
+[cityName] cannot continue work on [construction] = [cityName] nemitavānad be kār bar rooye [construction] edāme dahad
+[cityname] has expanded its borders! = [cityname] marz hāyaš rā gostareš dād!
+Your Golden Age has ended. = Asr e Talāi e šomā be pāyān resid.
+[cityName] has been razed to the ground! = [cityName] virān šod!
+We have conquered the city of [cityname]! = Mā bā šahrestān e [cityname] movāje šodim!
+An enemy [unit] has attacked [cityname] = Yek [unit] e došman, be [cityname] hamle kard
+An enemy [unit] has attacked our [ourUnit] = Yek [unit] e došman, be [ourUnit] e mā hamle kard
+Enemy city [cityName] has attacked our [ourUnit] = Šahr e [cityName] e došman be [ourUnit] e mā hamle kard
+An enemy [unit] has captured [cityname] = Yek [unit] e došman, [cityname] rā tasḵir kard
+An enemy [unit] has captured our [ourUnit] = Yek [unit] e došman, [ourUnit] e mā rā tasḵir kard
+An enemy [unit] has destroyed our [ourUnit] = Yek [unit] e došman, [ourUnit] mā rā nābood kard
+An enemy [RangedUnit] has destroyed the defence of [cityname] = Yek [RangedUnit] e došman, defā e [cityname] rā nābood kard
+Enemy city [cityName] has destroyed our [ourUnit] = Šahr e [cityName] e došman, [ourUnit] e mā rā nābood kard
+An enemy [unit] was destroyed while attacking [cityname] = Yek [unit] e došman, dar heyn e hamle be [cityname] nābood šod
+An enemy [unit] was destroyed while attacking our [ourUnit] = Yek [unit] e došman dar heyn e hamle be [ourUnit] e mā nābood šod
+Our [attackerName] was destroyed by an intercepting [interceptorName] = [attackerName] e mā, tavasot e yek [interceptorName] e modāfe nābood šod
+Our [interceptorName] intercepted and destroyed an enemy [attackerName] = [interceptorName] defā kard va yek [attackerName] e došman rā nābood kard
+Our [$attackerName] was attacked by an intercepting [$interceptorName] = be [$attackerName] e mā tavasot yek [$interceptorName] e došman hamle šod
+Our [$interceptorName] intercepted and attacked an enemy [$attackerName] = [$interceptorName] e mā defā kard va be yek [$attackerName] e došman hamle kard
+An enemy [unit] was spotted near our territory = Yek [unit] e došman kenār e ğalamro e mā dide šod
+An enemy [unit] was spotted in our territory = Yek [unit] e došman dar ğalamro e mā dide šod
+[amount] enemy units were spotted near our territory = [amount] niroo ye došman kenār e ğalamro e mā dide šod
+[amount] enemy units were spotted in our territory = [amount] niroo ye došman dar ğalamro e mā dide šod
+The civilization of [civName] has been destroyed! = Tamaddon e [civName] nābood šod!
+The City-State of [name] has been destroyed! = Šahrestān e [name] nābood šod!
+We have captured a barbarian encampment and recovered [goldAmount] gold! = Mā yek ordoogāh e Barbari rā tasḵir kadim va [goldAmount] Talā bedast āvardim!
+A barbarian [unitType] has joined us! = Yek [unitType] Barbari be mā molhağ šod!
+We have found survivors in the ruins - population added to [cityName] = Mā bāzmāndegāni dar ḵarābe hā peydā kardim - jame’iati be [cityName] ezāfe šod
+We have discovered the lost technology of [techName] in the ruins! = Mā teknoloji e gom šode ye [techName] rā dar ḵarābe hā peydā kardim!
+A [unitName] has joined us! = Yek [unitName] be mā molhağ šod!
+An ancient tribe trains our [unitName] in their ways of combat! = Yek ğabile ye bāstāni, raveš hāye jangidan ḵod rā be [unitName] e mā āmoozeš midahad!
+We have found a stash of [amount] gold in the ruins! = Mā yek anbār bā [amount] Talā dar ḵarābe hā peydā kardim!  
+We have found a crudely-drawn map in the ruins! = Mā yek nağše bā ḵotoot e kaj-o-ma’avaj dar ḵarābe hā peydā kardim!
+[unit] finished exploring. = [unit] Kāvošaš tamām šod.
+[unit] has no work to do. = [unit] kāri baraye anjām nadārad.
+You're losing control of [name]. = Šomā dārid kontorol e [name] rā az dast midahid.
+You and [name] are no longer friends! = Šomā va [name] digar doost nistid!
+Your alliance with [name] is faltering. = Ham-peymāni e šomā bā [name] dar hāl e tazalzol peydā kardan ast.
+You and [name] are no longer allies! = Šomā va [name] digar ham-peymān nistid!
+[civName] gave us a [unitName] as gift near [cityName]! = [civName] be onvān e hadie be mā yek [unitName] dar nazdiki e [cityName] dād!
+[civName] has denounced us! = [civName] mā rā dar jāme’e ye jahāni mahkoom karde ast!
+[cityName] has been connected to your capital! = [cityName] be pāytaḵt e šomā vasl šod!
+[cityName] has been disconnected from your capital! = Etesāl e [cityName] az pāytaḵt e šomā ğat šod!
+[civName] has accepted your trade request = [civName] darḵāst e tejāri šomā rā ğabool kard
+[civName] has denied your trade request = [civName] darḵāst e tejāri šomā rā rad kard
+[tradeOffer] from [otherCivName] has ended = [tradeOffer] az [otherCivName] be pāyān resid
+[tradeOffer] to [otherCivName] has ended = [tradeOffer] be [otherCivName] be pāyān resid
+One of our trades with [nation] has ended = Yeki az tejārat hāye mā bā [nation] be pāyān resid
+One of our trades with [nation] has been cut short = Yeki az tejārat hāye mā bā [nation] fasḵ šod
+[nation] agreed to stop settling cities near us! = [nation] ğabool kard ke nazdik e mā šahr nasāzad!
+[nation] refused to stop settling cities near us! = [nation] ğabool nakard ke nazdik e mā šahr nasāzad!
+We have allied with [nation]. = Mā bā [nation] ham-peymān šodim.
+We have lost alliance with [nation]. = Mā digar bā [nation] ham-peymān nistim.
+We have discovered [naturalWonder]! = Mā [naturalWonder] rā kašf kardim!
+We have received [goldAmount] Gold for discovering [naturalWonder] = Mā [goldAmount] Talā barāye kašf e [naturalWonder] daryāft kardim
+Your relationship with [cityStateName] is about to degrade = Ravābet e šomā bā [cityStateName] dar šorof e tazalzol peydā kardan ast
+Your relationship with [cityStateName] degraded = Ravābet e šomā bā [cityStateName] tazalzol peydā kard
+A new barbarian encampment has spawned! = Yek ordoogāh e Barbari jadid be vojood āmad!
+Received [goldAmount] Gold for capturing [cityName] = [goldAmount] Talā barāye tasḵir e [cityName] daryāft šod
+Our proposed trade request is no longer relevant! = Darḵāst e tejāri pišnahādi ye mā digar monāseb nist!
+[defender] could not withdraw from a [attacker] - blocked. = [defender] natavānest az yek [attacker] ağab-nešini konad – masir masdood ast.
+[defender] withdrew from a [attacker] = [defender] az yek [attacker] ağab-nešini kard
+[building] has provided [amount] Gold! = [building], [amount] Talā erā’e dāde ast!
+[civName] has stolen your territory! = [civName] zamin hāye mā rā dozdid!
+
+
+# World Screen UI
+
+Working... = dar hāl e kār...
+Waiting for other players... = Montazer barāye bağie ye bāzikonan...
+in = Dāḵel
+Next turn = Nobat e ba’adi
+Turn = Nobat
+turns = nobat
+turn = nobat
+Next unit = Niroo ye ba’adi
+Pick a policy = Yek siāsat enteḵāb konid
+Movement = Harekat
+Strength = Ğovvat
+Ranged strength = Ğovvat e door-bord 
+Bombard strength = Ğovvat e bomb-bārān
+Range = Bord
+Move unit = Harekat dādan e niroo
+Stop movement = Tavağğof e harekat
+Construct improvement = Behbood baḵšidan
+Automate = Ḵodkār kardan
+Stop automation = Tavağğof e ḵodkār kāri
+Construct road = Sāḵt e jādde
+Fortify = Moğāvem sāzi
+Fortify until healed = Moğāvem sāzi tā eltiām yāftan
+Fortification = Moğāvem sāzi
+Sleep = Ḵābidan
+Sleep until healed = Ḵābidan tā eltiām yāftan
+Moving = dar hāl e harekat
+Set up = Barpā kardan
+Upgrade to [unitType] ([goldCost] gold) = Behine kardan be [unitType] ([goldCost] Talā)
+Found city = Sāḵt e šahr
+Promote = Erteğā dādan
+Health = Joon
+Disband unit = Monhal kardan e niroo
+Explore = Kāvoš kardan
+Stop exploration = Tavağğof e kāvoš
+Pillage = Ğārat kardan
+Do you really want to disband this unit? = Āyā az monhal kardan e in niroo motma’enid?
+Disband this unit for [goldAmount] gold? = Monhal kardan e in niroo barāye [goldAmount] Talā?
+Create [improvement] = Sāḵt e [improvement]
+Start Golden Age = Šoro’e Asr e Talāi
+Yes = Bale
+No = Ḵeyr
+Acquire = Gereftan
+Science = Elm
+Happiness = Rezāyat
+Production = Tolid
+Culture = Farhang
+Food = Ğazā
+Crop Yield = Bardāšt mahsool
+Land = Zamin
+Force = Ğovā
+GOLDEN AGE = ASR E TALĀI 
+Golden Age = Asr e Talāi
+[year] BC = [year] Ğable Milād
+[year] AD = [year] Ba’ade Milād
+Civilopedia = Dāeratolma’āref
+Start new game = Šoro kardan e bāzi e jadid
+Save game = Zaḵire sāzi e bāzi
+Load game = Bārgozāri e bāzi
+Main menu = Meno ye asli
+Resume = Edāme dādan
+Cannot resume game! = Bāzi edāme dāde našod!
+Not enough memory on phone to load game! = Gooši hāfeze ye kāfi barāye bārgozāri e bāzi nadārad!
+Quickstart = Šoro e sari
+Victory status = Vazi’at e piroozi
+Social policies = Siāsat hāye ejtemāi
+Community = Anjoman
+Close = Bastan
+Do you want to exit the game? = Āyā miḵāhid az bāzi ḵārej šavid?
+Start bias: = Āvāntāj hengām e šoro
+Avoid [terrain] = Ejtenāb kardan az [terrain]
+
+# City screen
+
+Exit city = Ḵorooj az šahr
+Raze city = Virān kardan e šahr
+Stop razing city = Tavvağof e bā ḵāk yeksān sāzi
+Buy for [amount] gold = Ḵarid be ezāye [amount] Talā
+Buy = Ḵarid
+You have [amount] gold = Šomā [amount] Talā dārid
+Currently you have [amount] gold. = Dar hāl e hāzer šomā [amount] Talā dārid
+Would you like to purchase [constructionName] for [buildingGoldCost] gold? = Āyā miḵāhid [constructionName] rā be ezāye [buildingGoldCost] Talā beḵarid?
+No space available to place [unit] near [city] = Hič fazāi barāye ğarār dādan e [unit] kenār e [city] nist
+Maintenance cost = Hazine ye negahdāri
+Pick construction = Enteḵāb e sāḵt-o-sāz
+Pick improvement = Enteḵāb e behbood sāzi
+Provides [resource] = [resource] erāe midahad
+Replaces [improvement] = Jaygozin e [improvement] mišavad
+Pick now! = Hamin alān enteḵāb konid!
+Build [building] = Sāḵt e [building]
+Train [unit] = Āmoozeš dādan e [unit]
+Produce [thingToProduce] = Tolid e [thingToProduce]
+Nothing = Hič kāri
+Annex city = Mosta’emere kardan e šahr
+Specialist Buildings = Sāḵtemān hāye moteḵasesin
+Specialist Allocation = Taḵsis e moteḵasesin
+Specialists = Moteḵasesin
+[specialist] slots = Jāygāh e [specialist]
+Engineer specialist = Moteḵasses e mohandesi
+Merchant specialist = Moteḵasses e tejārat
+Scientist specialist = Moteḵasses e elmi
+Artist specialist = Moteḵasses e honari
+Food eaten = Ğazā ye ḵorde šode
+Growth bonus = Jāyeze e rošd
+Unassigned population = Jame’iat e entesāb našode
+[turnsToExpansion] turns to expansion = [turnsToExpansion] nobat tā tose’e
+Stopped expansion = Tose’e motevağef šode
+[turnsToPopulation] turns to new population = [turnsToPopulation] nobat tā jame’iat jadid
+Food converts to production = Ğazā be Tolid tabdil mišavad
+[turnsToStarvation] turns to lose population = [turnsToStarvation] nobat tā az dast dādan e jame’iat
+Stopped population growth = Rošd e jame’iat motevağef šode
+In resistance for another [numberOfTurns] turns = Dar moğāvemat barāye [numberOfTurns] nobat e digar
+Sell for [sellAmount] gold = Forooš barāye [sellAmount] Talā
+Are you sure you want to sell this [building]? = Āyā az forooš e in [building] motma’enid?
+[greatPerson] points = [greatPerson] Emtiāz
+Great person points = Emtiāz e Afrād e Bozorg
+Current points = Emtiāz e fe’eli
+Points per turn = Tağyir e emtiāz dar har nobat
+Convert production to gold at a rate of 4 to 1 = Tolid rā be Talā bā nesbat e 4 be 1 tabdil konid
+Convert production to science at a rate of [rate] to 1 = Tolid rā be Elm bā nesbat e [rate] be 1 tabdil konid
+The city will not produce anything. = In šahr čizi tolid naḵāhad kard.
+Worked by [cityName] = Dar dast e ejrā dar [cityName]
+Lock = Ğofl
+
+# Technology UI
+
+Pick a tech = Yek teknoloji enteḵāb konid
+Pick a free tech = Yek teknoloji ye rāygān ente
+Research [technology] = [technology] tahğiğ šavad
+Pick [technology] as free tech = [technology] rā be onvān teknoloji e rāygān enteḵāb konid
+Units enabled = Niroo hāye fa’āl šode
+Buildings enabled = Sāḵtemān hāye fa’āl šode
+Wonder = Ojoobe
+National Wonder = Ojoobe ye melli
+National Wonders = Ajāyeb e melli
+Wonders enabled = Ajāyeb e fa’āl šode
+Tile improvements enabled = Behbood sāzi hāye fa’āl šode
+Reveals [resource] on the map = [resource] rā rooye nağše āškār mikonad
+XP for new units = XP barāye niroo hāye jadid
+provide = Farāham kardan
+provides = Farāham mikonad
+City strength = Ğovvat e šahr
+City health = Joon e šahr
+Occupied! = Mašğool!
+Attack = Hamle
+Bombard = Bomb-bārān
+NUKE = HAMLE HASTE I
+Captured! = Tasḵir šode!
+defence vs ranged = Defā bar alayh bord
+[percentage] to unit defence = [percentage] be defā’e niroo
+Attacker Bonus = Jayeze ye hamle konande
+Landing = Dar hāl forood
+Flanking = Dar hāl hamle az pošt
+vs [unitType] = bar alayh [unitType]
+Terrain = No’e zamin
+Missing resource = Manabe’e nā mojood
+
+
+Hurry Research = Sorat baḵšidan be tahğiğ
+Conduct Trade Mission = Pardāḵtan be mamooriat e tejāri
+Your trade mission to [civName] has earned you [goldAmount] gold and [influenceAmount] influence! = Mamoriat e tejāri šoma be [civName] bāes e bedast āvardan e [goldAmount] Talā va [influenceAmount] Nofooz šod!
+Hurry Wonder = Sorat baḵšidan be Ojoobe
+Your citizens have been happy with your rule for so long that the empire enters a Golden Age! = Šahrvandān e šomā be haddi az hokoomat e šomā rāzi and ke vared e yek Asr e Talāi šodid!
+You have entered the [newEra]! = Šomā vāred e [newEra] šodid!
+[civName] has entered the [eraName]! = [civName] vāred e [eraName] šod!
+[policyBranch] policy branch unlocked! = Šāḵe ye siāsat e [policyBranch] bāz šod!
+Overview = Barresi
+Total = Majmoo’
+Stats = Āmār
+Policies = Siāsat hā
+Base happiness = Rezāyat e pāye
+Occupied City = Šahr e tasḵir šode
+Buildings = Sāḵtemān hā
+Wonders = Ajāyeb
+Base values = Meğdār hāye pāye
+Bonuses = Jayeze hā
+Final = Nahāi
+Other = Digar
+Population = Jame’iat
+City-States = Šahrestān hā
+Tile yields = Mahsool e zamin hā
+Trade routes = Masir hāye tejāri
+Maintenance = Negahdāri
+Transportation upkeep = Hazine ye negah dāri masir hā
+Unit upkeep = Hazine ye negah dāri niroo hā
+Trades = Tejārat hā
+Units = Niroo hā
+Name = Nām
+Closest city = Nazdik tarin šahr
+Action = Eğdām
+Defeated = Šekast ḵordid
+Tiles = Zamin hā
+Natural Wonders = Ajāyeb e Tabi’i
+Treasury deficit = Kasri ye ḵazāne
+
+# Victory
+
+Science victory = Piroozi e elmi
+Cultural victory = Piroozi e farhangi
+Conquest victory = Pirooze bā tasḵir
+Complete all the spaceship parts\n to win! = Tamām e baḵš hāye fazāpeymā rā takmil konid\n tā bebarid!
+Complete 5 policy branches\n to win! = 5 šāḵe ye siasat rā takmil konid\n tā bebarid!
+Destroy all enemies\n to win! = Tamām e došmanān rā nabood konid\n tā bebarid!
+You have won a scientific victory! = Šomā bā piroozi e elmi barande šodid!
+You have won a cultural victory! = Šomā bā piroozi e farhangi barande šodid!
+You have won a domination victory! = Šomā be piroozi bā tasḵir barande šodid!
+You have achieved victory through the awesome power of your Culture. Your civilization's greatness - the magnificence of its monuments and the power of its artists - have astounded the world! Poets will honor you as long as beauty brings gladness to a weary heart. = Šomā be komak e ğodrat e āli e farhangetoon be piroozi residid. Azemat e tamaddon e šoma – tajalol e banā hā va ğodrate honarmandān – jahān rā heyrat zade karde! Šaerān tā vağti ke zibāi be deli pir šadi mibaḵše az šomā yād ḵāhand kard.
+The world has been convulsed by war. Many great and powerful civilizations have fallen, but you have survived - and emerged victorious! The world will long remember your glorious triumph! = Jahān bā jang motešannej šode. Besiyāri az tamaddon hāye bozorg va ğodratmand soğoot karde and, vali šomā davām avardid – va yek barande zāher šodid! Jahān tā moddat hā piroozi ye bā šokooh e šomā rā be yād ḵāhad dāšt!
+#############################################################################
+You have achieved victory through mastery of Science! You have conquered the mysteries of nature and led your people on a voyage to a brave new world! Your triumph will be remembered as long as the stars burn in the night sky! = Šomā bā tasallot bar elm be piroozi residid! Šomā bar romooz e tabi’at solte peydā kardid va mardometoon rā be dorāni movaffağ va omidvārāne hedāyat kardid! Piroozi e šomā tā moğe i ke setāre hā dar āsemān e šab mideraḵšand dar yād hā bāği ḵāhad mānd!
+You have been defeated. Your civilization has been overwhelmed by its many foes. But your people do not despair, for they know that one day you shall return - and lead them forward to victory! = Šomā šekast ḵordid. Tamaddon e šomā tavassot e došmanān e besiāraš pāymāl šod. Vali mardom e šomā ma’ayoos nistand, čerā ke midānand roozi šomā bar migardid – va ānhā rā mostağim be pirooze hedāyat mikonid!
+One more turn...! = Yek nobat dige...!
+Built Apollo Program = Barnāme ye Apollo ro sāḵt
+Destroy [civName] = Nabood kardan e [civName]
+Our status = Vazi’at e mā
+Global status = Vazi’at e jahāni
+Rankings = Rade bandi hā
+Spaceship parts remaining = Ğesmat hāye mānde ye fazāpeymā
+Branches completed = Šāḵe hāye takmil šode
+Undefeated civs = Tamaddon hāye šekast naḵorde
+
+# Capturing a city
+
+What would you like to do with the city? = Bā šahr če kāri miḵāhid bokonid?
+Annex = Zamime
+Annexed cities become part of your regular empire. = Šahr hāye zamime šode baḵši az emperātoori e āddi e šomā mišavand.
+Their citizens generate 2x the unhappiness, unless you build a courthouse. = Šahrvandān e ānhā 2 barābar Nārezāyati toolid mikonand, magar inke yek dādgāh besāzid
+Puppet = Mosta’emere
+Puppeted cities do not increase your tech or policy cost, but their citizens generate 1.5x the regular unhappiness. = Šahr hāye mosta’emere hazine ye teknoloji yā siāsat šomā rā ziad nemikonand, vali šahrvandān e ānhā 1.5 barābar e hālat e ma’amool Nārezāyati toolid mikonand.
+You have no control over the the production of puppeted cities. = Šomā hič kontoroli be sāḵt-o-sāz e šahr hāye mosta’emere nadārid.
+Puppeted cities also generate 25% less Gold and Science. = Šahr hāye mosta’emere hamčenin 25% Talā va Elm e kamtari toolid mikonand.
+A puppeted city can be annexed at any time. = Yek šahr e mosta’emere harvağti mitavānad zamime šavad.
+Liberate = Āzād Kardan
+Liberating a city returns it to its original owner, giving you a massive relationship boost with them! = Āzād kardan e yek šahr ān rā be sāheb e asli aš bar migardānad, yek komak bozorg dar ravābet e šomā bā ānhā mikonad!
+Raze = Virān Kardan
+Razing the city annexes it, and starts razing the city to the ground. = Virān karadn e šahr ānrā zamime mikonad, sepas šoro be virān kardan mikonad tā bā ḵāk yeksān šavad.
+The population will gradually dwindle until the city is destroyed. = Jame’iat
+Remove your troops in our border immediately! = Jame’iat be tadrij kāheš miyābad tā vağti ke šahr nābood šavad.
+Sorry. = Bebaḵšid.
+Never! = Hargez!
+
+Offer Declaration of Friendship ([30] turns) = Pišnahād e Ezhārnāme ye Doosti dādan ([30] turns)
+My friend, shall we declare our friendship to the world? = Doost e man, Doosti e mān rā be jahān e’elām konim?
+Sign Declaration of Friendship ([30] turns) = Emzā kardan e Ezhārnāme ye Doosti
+We are not interested. = Mā alāğe i nadārim.
+We have signed a Declaration of Friendship with [otherCiv]! = Mā yek Ezhārnāme ye Doosti bā [otherCiv] emzā kardim!
+[otherCiv] has denied our Declaration of Friendship! = [otherCiv] Ezhārnāme ye Doosti e mā rā rad kard!
+
+Basics = Mabāni
+Resources = Manābe
+Terrains = zamin hāye yek no’e
+Tile Improvements = Behbood sāzi hāye zamin
+Unique to [civName], replaces [unitName] = Monhaser be fard e [civName], Jāygozin e [unitName] mišavad
+Unique to [civName] = Monhaser be fard e [civName]
+Tutorials = Āmoozeš
+Cost = Hazine
+May contain [listOfResources] = Momken ast dārāye [listOfResources] bāšad
+Upgrades to [upgradedUnit] = Be [upgradedUnit] behine mišavad
+Obsolete with [obsoleteTech] = Bā [obsoleteTech] mansooḵ mišavad
+Occurs on [listOfTerrains] = Rooye [listOfTerrains] etefāğ mioftad
+Placed on [terrainType] = Ğarār gerefte rooye [terrainType]
+Can be found on  = Peydā mišavad rooye
+Improved by [improvement] = Behbood-sāḵte šode bā [improvement]
+Bonus stats for improvement:  = Ḵavās ezāfe šode beḵāter e behbood-sāzi
+Buildings that consume this resource:  = Sāḵtemān hāyi ke in manba rā masraf mikonand:
+Units that consume this resource:  = Niroo hāyi ke in manba rā masraf mikonand:
+Can be built on  = Mitavānad sāḵte šavad rooye 
+Defence bonus = Emtiāz e defāi
+Movement cost = Hazine ye harekat
+Rough Terrain = Zamin e nāhamvār
+ for  =  barāye 
+Missing translations: = Tarjome hāye nāmojood:
+Version = Nosḵe 
+Resolution = Vozooh e tasvir 
+Tileset = No’e zamin 
+Map editor = Virāyešgar e nağše
+Create = Sāḵtan
+New map = Nağše ye jadid
+Empty = Ḵāli
+Language = Zabān 
+Terrains & Resources = Anvā’e zamin hā va manābe
+Improvements = Behbood-sāzi hā
+Clear current map = pāk kardan e nağše ye fe’eli
+Save map = Zaḵire kardan e nağše 
+Download map = Dānlod e nağše 
+Loading... = dar hāl e bargozāri...
+Filter: = Filter: 
+Exit map editor = Ḵorooj az virāyešgar e nağše
+[nation] starting location = Mahalle šoro’e [nation]
+Clear terrain features = Pāk kardan e ḵavās e zamin
+Clear improvements = Pāk kardan e behbood-sāzi hā
+Clear resource = Pāk kardan e manabe
+Requires = Niaz dārad be
+Menu = Meno
+Brush Size = Andāze ye ğalam
+Map saved = Nağše zaḵire šod
+
+# Civilopedia difficulty levels
+Player settings = Tanzimāt e bāzikon
+Base Happiness = Rezāyati e pāye
+Happiness per luxury = Rezāyat be ezaye har manba’e loox
+Research cost modifier = Zarib e hazine ye tahğiğ
+Unit cost modifier = Zarib e hazine ye niroo
+Building cost modifier = Zarib e hazine ye sāḵtemān
+Policy cost modifier = Zarib e hazine ye siāsat 
+Unhappiness modifier = Zarib e Nārezāyati
+Bonus vs. Barbarians = komak bar alayh e Barbar hā
+
+AI settings = Tanzimāt e hooš-masnooi
+AI city growth modifier = Zarib e rošd e šahr hāye hooš-masnooi
+AI unit cost modifier = Zarib e hazine ye niroo hāye hooš-masnooi
+AI building cost modifier = Zarib e hazine ye sāḵtemān hāye hooš-masnooi
+AI wonder cost modifier = Zarib e hazine ye ajāyeb barāye hooš-masnooi
+AI building maintenance modifier = Zarib e hazine ye negahdāri e sāḵtemān hā barāye hooš-masnooi
+AI unit maintenance modifier = Zarib e hazine ye negahdāri e niroo hā barāye hooš-masnooi
+AI unhappiness modifier = Zarib e Nārezāyati e hooš-masnooi
+
+Turns until barbarians enter player tiles = Tedād nobat tā inke Barbar hā vāred zamin hāye bāzikon šavand
+Gold reward for clearing barbarian camps = Talā ye jayeze barāye pāk kardan e ordoogāh hāye Barbar hā
+
+# Other civilopedia things
+Nations = Melal 
+Available for [unitTypes] = Ğābel estefāde barāye [unitTypes]
+Free promotion: = Beh-sāzi ye rāygān
+Free promotions: = Beh-sāzi ye rāygān
+Free for [units] = Rāygān barāye [units]
+[bonus] with [tech] = [bonus] bā [tech]
+Difficulty levels = Sotooh e saḵti
+
+# Policies
+
+Adopt policy = Etteḵāz e siāsat
+Adopt free policy = Etteḵāz e siāsat e rāygān
+Unlocked at = Bāz-šode dar 
+Gain 2 free technologies = 2 teknoloji e rāygān begirid 
+
+# Technologies
+
+Mass Media = Resāne hāye jame’i
+
+# Terrains
+
+Impassable = Ğeyr e ğābel e oboor
+
+# Resources
+
+Bison = Ğāv
+Copper = Mes
+Cocoa = Kākāoo
+Crab = Ḵarčang
+Citrus = Morakkabāt
+Truffles = Ğārč
+
+# Unit types 
+
+Civilian = Šahrvand
+land units = Niroo hāye zamini
+water units = Niroo hāye daryāi
+air units = Niroo hāye havāi 
+WaterCivilian = Šahrvand
+Melee = Nazdik-bord
+WaterMelee = Nazdik-bord
+Ranged = Door-bord
+WaterRanged = Door-bord
+WaterSubmarine = Zirdaryāi
+Mounted = Savāre
+Armor = Zereh
+City = Šahr
+Missile = Moošak
+WaterAircraftCarrier = Nāv e havāpeymā bar
+
+# Units
+
+Composite Bowman = Kamāndār e morakkab
+Foreign Land = Zamin e ḵāreji
+Marine = Daryāi
+Mobile SAM = Moošak e zamin-be-havā ye moteharrek
+Paratrooper = Čatrbāz
+Helicopter Gunship = Bālgard e nezāmi 
+Atomic Bomb = Bomb e haste i
+Unbuildable = Ğeyr e ğābel e sāḵt
+
+# Promotions
+
+Pick promotion = Enteḵāb e behsāzi
+ OR  =  YĀ 
+units in open terrain = Niroo hā dar zamin e hamvār
+units in rough terrain = Niroo hā dar zamin e nāhamvār
+wounded units = Niroo hā majrooh
+Targeting II (air) = Nešāne giri 2
+Targeting III (air) = Nešāne giri 3
+Bonus when performing air sweep [bonusAmount]% = [bonusAmount]% komak hendām defā’e havāi
+Dogfighting I = Mobāreze ye nazdik 1
+Dogfighting II = Mobāreze ye nazdik 2
+Dogfighting III = Mobāreze ye nazdik 3
+# Multiplayer Turn Checker Service
+
+Multiplayer options = Tanzimāt e čand-nafare
+Enable out-of-game turn notifications = Fa’āl kardan e yādāvar e nobat dar ḵārej e bāzi 
+Time between turn checks out-of-game (in minutes) = Moddat mian har barresi e nobat (dağiğe) 
+Show persistent notification for turn notifier service = Nešān dādan e yādāvar e nobat e modāvem 
+Take user ID from clipboard = Peyst kardan e ID e kārbari e kopi šode
+Doing this will reset your current user ID to the clipboard contents - are you sure? = Bā in kor ID e kārbari e šomā be ID kopi šode tağyir dāde mišavad – āyā motmaenid?
+ID successfully set! = ID bā movafağiat tanzim šod
+Invalid ID! = ID e nā motabar!
+


### PR DESCRIPTION
This is the Persian translation for UnCiv, please note that since the Persian has its own alphabet (which is from right to left). Thankfully, this is not a new problem for Persian people, They've faced this problem since the early days of chatrooms. While they usually just use the English alphabet to type in Persian, I just used an alphabet derived from the DIN 31635 standard made by "Deutsches Institut für Normung". 
I will also make another translation using only the English alphabet, That will make the sentences a bit longer and harder to read, but people are more used to it.