### PR TITLE
Resolved #2893 - Use list_folder/continue to get the whole folder listing when downloading a file

### DIFF
--- a/core/src/com/unciv/ui/mapeditor/MapDownloadPopup.kt
+++ b/core/src/com/unciv/ui/mapeditor/MapDownloadPopup.kt
@@ -49,7 +49,7 @@ class MapDownloadPopup(loadMapScreen: LoadMapScreen): Popup(loadMapScreen) {
             val folderList = DropBox.getFolderList("/Maps")
             Gdx.app.postRunnable {
                 scrollableMapTable.apply { defaults().pad(10f) }
-                for (downloadableMap in folderList.entries) {
+                for (downloadableMap in folderList) {
                     val downloadMapButton = downloadableMap.name.toTextButton()
                     listOfMaps.add(downloadMapButton)
                     downloadMapButton.onClick {


### PR DESCRIPTION
I decided to use list_folder/continue instead of the search API (at least for now).