### PR TITLE
Few translation and unique fixes

### DIFF
--- a/core/src/com/unciv/logic/city/CityStats.kt
+++ b/core/src/com/unciv/logic/city/CityStats.kt
@@ -216,6 +216,8 @@ class CityStats {
         val happinessFromBuildings = cityInfo.cityConstructions.getStats().happiness.toInt().toFloat()
         newHappinessList["Buildings"] = happinessFromBuildings
 
+        newHappinessList["National ability"] = getStatsFromUniques(cityInfo.civInfo.nation.uniqueObjects.asSequence()).happiness
+
         newHappinessList["Wonders"] = getStatsFromUniques(civInfo.getBuildingUniques()).happiness
 
         newHappinessList["Tile yields"] = getStatsFromTiles().happiness

--- a/core/src/com/unciv/models/ruleset/Nation.kt
+++ b/core/src/com/unciv/models/ruleset/Nation.kt
@@ -154,7 +154,7 @@ class Nation : INamed {
                 for (unique in unit.uniques.filterNot { it in originalUnit.uniques })
                     textList += "  " + Translations.translateBonusOrPenalty(unique)
                 for (unique in originalUnit.uniques.filterNot { it in unit.uniques })
-                    textList += "  " + "Lost ability".tr() + "(vs " + originalUnit.name.tr() + "): " + Translations.translateBonusOrPenalty(unique)
+                    textList += "  " + "Lost ability".tr() + "(" + "vs [${originalUnit.name}]".tr() + "): " + Translations.translateBonusOrPenalty(unique)
                 for (promotion in unit.promotions.filter { it !in originalUnit.promotions })
                     textList += "  " + promotion.tr() + " (" + Translations.translateBonusOrPenalty(ruleset.unitPromotions[promotion]!!.effect) + ")"
             } else {

--- a/core/src/com/unciv/ui/mapeditor/GameParametersScreen.kt
+++ b/core/src/com/unciv/ui/mapeditor/GameParametersScreen.kt
@@ -4,6 +4,7 @@ import com.unciv.UncivGame
 import com.unciv.logic.map.Scenario
 import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.ruleset.RulesetCache
+import com.unciv.models.translations.tr
 import com.unciv.ui.newgamescreen.GameOptionsTable
 import com.unciv.ui.newgamescreen.GameSetupInfo
 import com.unciv.ui.newgamescreen.PlayerPickerTable
@@ -32,7 +33,7 @@ class GameParametersScreen(var mapEditorScreen: MapEditorScreen): IPreviousScree
                 .maxHeight(topTable.parent.height).width(stage.width / 2).padTop(20f).top()
         topTable.addSeparatorVertical()
         topTable.add(playerPickerTable).maxHeight(topTable.parent.height).width(stage.width / 2).padTop(20f).top()
-        rightSideButton.setText("OK")
+        rightSideButton.setText("OK".tr())
         rightSideButton.onClick {
             mapEditorScreen.gameSetupInfo = gameSetupInfo
             mapEditorScreen.scenario = Scenario(mapEditorScreen.tileMap, mapEditorScreen.gameSetupInfo.gameParameters)

--- a/core/src/com/unciv/ui/mapeditor/LoadMapScreen.kt
+++ b/core/src/com/unciv/ui/mapeditor/LoadMapScreen.kt
@@ -91,8 +91,8 @@ class LoadMapScreen(previousMap: TileMap?) : PickerScreen(){
         deleteButton.color = Color.RED
 
         if (scenarioMap) {
-            deleteButton.setText("Delete Scenario Map")
-            rightSideButton.setText("Load Scenario Map")
+            deleteButton.setText("Delete Scenario Map".tr())
+            rightSideButton.setText("Load Scenario Map".tr())
 
             mapsTable.clear()
             for (scenario in MapSaver.getScenarios()) {
@@ -106,8 +106,8 @@ class LoadMapScreen(previousMap: TileMap?) : PickerScreen(){
                 mapsTable.add(loadScenarioButton).row()
             }
         } else {
-            deleteButton.setText("Delete map")
-            rightSideButton.setText("Load map")
+            deleteButton.setText("Delete map".tr())
+            rightSideButton.setText("Load map".tr())
 
             mapsTable.clear()
             for (map in MapSaver.getMaps()) {

--- a/core/src/com/unciv/ui/mapeditor/MapEditorMenuPopup.kt
+++ b/core/src/com/unciv/ui/mapeditor/MapEditorMenuPopup.kt
@@ -11,6 +11,7 @@ import com.unciv.logic.map.MapType
 import com.unciv.logic.map.RoadStatus
 import com.unciv.logic.map.Scenario
 import com.unciv.logic.map.TileMap
+import com.unciv.models.translations.tr
 import com.unciv.models.metadata.Player
 import com.unciv.ui.saves.Gzip
 import com.unciv.ui.utils.*
@@ -163,9 +164,9 @@ class MapEditorMenuPopup(var mapEditorScreen: MapEditorScreen): Popup(mapEditorS
     private fun Popup.addScenarioButton() {
         var scenarioButton = "".toTextButton()
         if (mapEditorScreen.hasScenario()) {
-            scenarioButton.setText("Edit scenario parameters")
+            scenarioButton.setText("Edit scenario parameters".tr())
         } else {
-            scenarioButton.setText("Create scenario map")
+            scenarioButton.setText("Create scenario map".tr())
             // for newly created scenarios read players from tileMap
             val players = getPlayersFromMap(mapEditorScreen.tileMap)
             mapEditorScreen.gameSetupInfo.gameParameters.players = players

--- a/core/src/com/unciv/ui/mapeditor/TileEditorOptionsTable.kt
+++ b/core/src/com/unciv/ui/mapeditor/TileEditorOptionsTable.kt
@@ -184,7 +184,7 @@ class TileEditorOptionsTable(val mapEditorScreen: MapEditorScreen): Table(Camera
                     }
 
                     val nationIcon = getHex(Color.WHITE, ImageGetter.getNationIndicator(nation, 40f))
-                    setCurrentHex(nationIcon,"Player $playerIndex starting location")
+                    setCurrentHex(nationIcon,"Player [$playerIndex] starting location")
                 }
                 nationTable.add(nationImage).row()
             }
@@ -315,7 +315,7 @@ class TileEditorOptionsTable(val mapEditorScreen: MapEditorScreen): Table(Camera
 
     private fun getPlayerIndexString(player: Player): String {
         val index = gameParameters.players.indexOf(player) + 1
-        return "Player $index"
+        return "Player [$index]".tr()
     }
 
     private fun getCrossedIcon(): Actor {


### PR DESCRIPTION
Fixed:
* Fixed "[+X Happiness] in all cities" and "[+X Happiness] in capital" national unique
* translation of "vs original Unit name" in nation description
e.g. `Lost ability(vs Knight): Penalty vs City 33%`
* translations of some button texts and labels from map editor