### PR TITLE
Show that air units can move to tiles within attack range

### DIFF
--- a/core/src/com/unciv/ui/worldscreen/WorldMapHolder.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldMapHolder.kt
@@ -309,26 +309,23 @@ class WorldMapHolder(internal val worldScreen: WorldScreen, internal val tileMap
         val isAirUnit = unit.type.isAirUnit()
         val tilesInMoveRange =
                 if (isAirUnit)
-                    unit.getTile().getTilesInDistanceRange(IntRange(unit.getRange(), unit.getRange() * 2))
+                    unit.getTile().getTilesInDistanceRange(IntRange(1, unit.getRange() * 2))
                 else
                     unit.movement.getDistanceToTiles().keys.asSequence()
 
         for (tile in tilesInMoveRange) {
             val tileToColor = tileGroups.getValue(tile)
             if (isAirUnit)
-                tileToColor.showCircle(Color.BLUE, 0.3f)
+                if (tile.aerialDistanceTo(unit.getTile()) <= unit.getRange()) {
+                    // The tile is within attack range
+                    tileToColor.showCircle(Color.RED, 0.3f)
+                } else {
+                    // The tile is within move range
+                    tileToColor.showCircle(Color.BLUE, 0.3f)
+                }
             if (unit.movement.canMoveTo(tile))
                 tileToColor.showCircle(Color.WHITE,
                         if (UncivGame.Current.settings.singleTapMove || isAirUnit) 0.7f else 0.3f)
-        }
-
-        // Mark tiles in air units attack range as RED
-        if (isAirUnit) {
-            val tilesInAirAttackRange = unit.getTile().getTilesInDistance(unit.getRange())
-            for (tile in tilesInAirAttackRange) {
-                val tileToColor = tileGroups.getValue(tile)
-                tileToColor.showCircle(Color.RED, 0.3f)
-            }
         }
 
         val attackableTiles: List<AttackableTile> = if (unit.type.isCivilian()) listOf()


### PR DESCRIPTION
Previously, only tiles (with a city or carrier) outside the
attack range got a white circle. Now all tiles to which the
air unit can move get a white circle.