### PR TITLE
parameterized some uniques, fixes some minor bugs

### DIFF
--- a/android/assets/jsons/Civ V - Vanilla/Buildings.json
+++ b/android/assets/jsons/Civ V - Vanilla/Buildings.json
@@ -33,7 +33,7 @@
 		"resourceBonusStats": {"production": 1},
 		"maintenance": 1,
 		"hurryCostModifier": 25,
-		"uniques": ["Must not be on plains"],
+		"uniques": ["Must not be on [Plains]"],
 		"requiredTech": "Calendar"
 	},
 	{
@@ -84,7 +84,7 @@
 		"food": 2,
 		"production": 1,
 		"hurryCostModifier": 25,
-		"uniques": ["Must be next to river"],
+		"uniques": ["Must be on [River]"],
 		"requiredTech": "The Wheel"
 	},
 	{
@@ -94,7 +94,7 @@
 		"cost": 75,
 		"food": 2,
 		"production": 1,
-		"uniques": ["[+2 Food] from [Lakes] tiles in this city", "Must border a source of fresh water"],
+		"uniques": ["[+2 Food] from [Lakes] tiles in this city", "Must be on [tile adjacent to source of fresh water]"],
 		"hurryCostModifier": 25,
 		"maintenance": 1,
 		"percentStatBonus": {"food": 15},
@@ -149,7 +149,7 @@
 		"gold": 5,
 		"greatPersonPoints": {"gold": 1},
 		"isWonder": true,
-		"uniques": ["Can only be built in coastal cities", "[+1 Gold] from [Water] tiles in this city"],
+		"uniques": ["Must be on [seacoast]", "[+1 Gold] from [Water] tiles in this city"],
 		"requiredTech": "Iron Working",
 		"quote": "'Why man, he doth bestride the narrow world like a colossus, and we petty men walk under his huge legs, and peep about to find ourselves dishonorable graves.' - William Shakespeare, Julius Caesar"
 	},
@@ -189,7 +189,7 @@
 		"hurryCostModifier": 25,
 		"maintenance": 1,
 		"resourceBonusStats": {"food": 1},
-		"uniques": ["Can only be built in coastal cities", "[+1 Food] from [Ocean] tiles in this city", "[+1 Food] from [Coast] tiles in this city"],
+		"uniques": ["Must be on [seacoast]", "[+1 Food] from [Ocean] tiles in this city", "[+1 Food] from [Coast] tiles in this city"],
 		"requiredTech": "Optics"
 	},
 	{
@@ -198,7 +198,7 @@
 		"greatPersonPoints": {"gold": 1},
 		"isWonder": true,
 		"providesFreeBuilding":  "Lighthouse",
-		"uniques": ["Can only be built in coastal cities", "All military naval units receive +1 movement and +1 sight"],
+		"uniques": ["Must be on [seacoast]", "All military naval units receive +1 movement and +1 sight"],
 		"requiredTech": "Optics",
 		"quote": "'They that go down to the sea in ships, that do business in great waters; these see the works of the Lord, and his wonders in the deep.' - The Bible, Psalms 107:23-24"
 	},
@@ -353,7 +353,7 @@
 	{
 		"name": "Garden",
 		"cost": 120,
-		"uniques": ["+[25]% great person generation in this city", "Must border a source of fresh water"],
+		"uniques": ["+[25]% great person generation in this city", "Must be on [tile adjacent to source of fresh water]"],
 		"hurryCostModifier": 25,
 		"maintenance": 1,
 		"requiredTech": "Theology"
@@ -406,7 +406,7 @@
 		"greatPersonPoints": {"gold": 1},
 		"culture": 1,
 		"isWonder": true,
-		"uniques": ["Gold from all trade routes +25%","Must have an owned mountain within 2 tiles"],
+		"uniques": ["Gold from all trade routes +25%","Must have an owned [Mountain] within [2] tiles"],
 		"requiredTech": "Guilds",
 		"quote": "'Few romances can ever surpass that of the granite citadel on top of the beetling precipices of Machu Picchu, the crown of Inca Land.'  - Hiram Bingham"
 	},
@@ -445,7 +445,7 @@
 		"maintenance": 2,
 		"hurryCostModifier": 25,
 		"uniques": ["[+1 Production] from [Water resource] tiles in this city",
-			"Connects trade routes over water","Can only be built in coastal cities"],
+			"Connects trade routes over water","Must be on [seacoast]"],
 		"requiredTech": "Compass"
 	},
 	{
@@ -677,7 +677,7 @@
 		"maintenance": 2,
 		"requiredBuilding": "Harbor",
 		"uniques": ["[+1 Production, +1 Gold] from [Water resource] tiles in this city",
-			"Can only be built in coastal cities", "+[15]% production when building [naval units] in this city"],
+			"Must be on [seacoast]", "+[15]% production when building [naval units] in this city"],
 		"requiredTech": "Navigation"
 	},
 	{
@@ -706,7 +706,7 @@
 		"hurryCostModifier": 25,
 		"maintenance": 2,
 		"percentStatBonus": {"production": 10},
-		"uniques": ["Must not be on hill"],
+		"uniques": ["Must not be on [Hill]"],
 		"requiredTech": "Economics"
 	},
 	
@@ -785,7 +785,7 @@
 		"requiredResource": "Aluminum",
 		"hurryCostModifier": 25,
 		"maintenance": 3,
-		"uniques": ["Must be next to river","[+1 Production] from [River] tiles in this city"],
+		"uniques": ["Must be on [River]","[+1 Production] from [River] tiles in this city"],
 		"requiredTech": "Electricity"
 	},
 	*/
@@ -861,7 +861,7 @@
 		"greatPersonPoints": {"gold": 1},
 		"isWonder": true,
 		"uniques": ["[+1 Happiness, +2 Culture, +3 Gold] from every [Castle]",
-			"Must have an owned mountain within 2 tiles"],
+			"Must have an owned [Mountain] within [2] tiles"],
 		"requiredTech": "Railroad",
 		"quote": "'...the location is one of the most beautiful to be found, holy and unapproachable, a worthy temple for the divine friend who has brought salvation and true blessing to the world.'  - King Ludwig II of Bavaria"
 		
@@ -901,7 +901,7 @@
 		"isWonder": true,
 		"greatPersonPoints": {"culture": 2},
 		"percentStatBonus": {"culture": 50},
-		"uniques": ["Free Social Policy","Can only be built in coastal cities"],
+		"uniques": ["Free Social Policy","Must be on [seacoast]"],
 		"requiredTech": "Ecology",
 		"quote": "'Those who lose dreaming are lost.'  - Australian Aboriginal saying"
 	},

--- a/android/assets/jsons/Civ V - Vanilla/Terrains.json
+++ b/android/assets/jsons/Civ V - Vanilla/Terrains.json
@@ -110,7 +110,8 @@
 		"movementCost": 3,
 		"unbuildable": true,
 		"defenceBonus": -0.15,
-		"occursOn": ["Grassland"]
+		"occursOn": ["Grassland"],
+		"uniques": ["Rare feature"]
 	},
 	{
 		"name": "Fallout",
@@ -131,7 +132,7 @@
 		"unbuildable": true,
 		"defenceBonus": -0.1,
 		"occursOn": ["Desert"],
-		"uniques": ["Fresh water"]
+		"uniques": ["Fresh water", "Rare feature"]
 	},
 	{
 		"name": "Flood plains",
@@ -154,7 +155,8 @@
 		"movementCost": 1,
 		"food": 1,
 		"production": 1,
-		"occursOn": ["Coast"]
+		"occursOn": ["Coast"],
+		"uniques": ["Rare feature"]
 	},
  
 	// Natural Wonders

--- a/android/assets/jsons/Civ V - Vanilla/TileImprovements.json
+++ b/android/assets/jsons/Civ V - Vanilla/TileImprovements.json
@@ -175,9 +175,8 @@
 		"uniqueTo": "Polynesia",
 		"culture": 1,
 		"turnsToBuild": 4,
-		"uniques": ["[+1 Culture] for each adjacent [Moai]", "Can only be built on Coastal tiles"],
-		"techRequired": "Construction",
-		"uniques": ["[+1 Gold] once [Flight] is discovered"]
+		"uniques": ["[+1 Culture] for each adjacent [Moai]", "Can only be built on Coastal tiles", "[+1 Gold] once [Flight] is discovered"],
+		"techRequired": "Construction"
 	},
 	{
 		"name": "Terrace farm",

--- a/android/assets/jsons/Civ V - Vanilla/Units.json
+++ b/android/assets/jsons/Civ V - Vanilla/Units.json
@@ -1269,6 +1269,21 @@
 		"uniques": ["Evasion"]
 		"attackSound": "shot"
 	},
+	{
+		// "Hovering unit" unique gives ability to get into impassable tiles - and only that (no vision bonus or flying over ocean)
+		// Unit embarks like any other ground unit and has penalty for attacking over river or from embarked state
+		// "Unable to capture cities"
+		"name": "Helicopter Gunship",
+		"unitType": "Melee",
+		"movement": 6,
+		"strength": 60,
+		"cost": 425,
+		"requiredTech": "Computers",
+		"requiredResource": "Aluminum",
+		"uniques": ["Bonus vs Armor 100%", "Ignores terrain cost", "No defensive terrain bonuses", "Can move after attacking"],
+		"attackSound": "shot",
+		"hurryCostModifier": 20
+	},
 	*/
 	
 	/*

--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -635,6 +635,9 @@ Water resource =
 River = 
 fresh water = 
 non-fresh water = 
+# For Must be on []
+seacoast = 
+tile adjacent to source of fresh water = 
 
 Wonders = 
 Base values = 
@@ -820,6 +823,7 @@ Mass Media =
 
 Impassable = 
 Fresh water = 
+Rare feature = 
 
 # Resources
 

--- a/core/src/com/unciv/logic/map/TileInfo.kt
+++ b/core/src/com/unciv/logic/map/TileInfo.kt
@@ -308,6 +308,17 @@ open class TileInfo {
         }
     }
 
+    fun fitsUniqueFilter(filter:String): Boolean {
+        return filter == baseTerrain
+                || filter == "River" && isAdjacentToRiver()
+                || filter == "seacoast" && isCoastalTile()
+                || filter == "tile adjacent to source of fresh water" && isAdjacentToFreshwater
+                || filter == terrainFeature
+                || baseTerrainObject.uniques.contains(filter)
+                || terrainFeature != null && getTerrainFeature()!!.uniques.contains(filter)
+                || filter == "Water" && isWater
+    }
+
     fun hasImprovementInProgress() = improvementInProgress != null
 
     @delegate:Transient

--- a/core/src/com/unciv/logic/map/mapgenerator/MapGenerator.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/MapGenerator.kt
@@ -246,10 +246,7 @@ class MapGenerator(val ruleset: Ruleset) {
      */
     private fun spawnRareFeatures(tileMap: TileMap) {
         val rareFeatures = ruleset.terrains.values.filter {
-            it.type == TerrainType.TerrainFeature &&
-            it.name !in Constants.vegetation &&
-            it.name != Constants.floodPlains &&
-            it.name != Constants.ice
+            it.type == TerrainType.TerrainFeature && it.uniques.contains("Rare feature")
         }
         for (tile in tileMap.values.asSequence().filter { it.terrainFeature == null }) {
             if (randomness.RNG.nextDouble() <= tileMap.mapParameters.rareFeaturesRichness) {

--- a/core/src/com/unciv/ui/tilegroups/TileGroup.kt
+++ b/core/src/com/unciv/ui/tilegroups/TileGroup.kt
@@ -398,6 +398,11 @@ open class TileGroup(var tileInfo: TileInfo, var tileSetStrings:TileSetStrings) 
             if (!ImageGetter.imageExists(naturalWonderOverlay)) // Assume no natural wonder overlay = dedicated tile image
                 return
 
+            if (baseTerrainOverlayImage != null) {
+                baseTerrainOverlayImage!!.remove()
+                baseTerrainOverlayImage = null
+            }
+
             naturalWonderImage = ImageGetter.getImage(naturalWonderOverlay)
             terrainFeatureLayerGroup.addActor(naturalWonderImage)
             naturalWonderImage!!.run {


### PR DESCRIPTION
Fixed Moai
Wonder overlay will remove terrain overlay in default tileset
![wonder In default tileset](https://user-images.githubusercontent.com/69697985/92379035-6d5f7f80-f10f-11ea-91c3-8248509bcbe5.png)
Oasis, Marsh and Atoll now have "Rare feature" unique, rare features can be added by mods
implemented TileInfo.fitsUniqueFilter(filterText:String): Boolean
parameterized uniques:
* "Must have an owned [Mountain] within [2] tiles"
* "Must be on [River]" - not to be confused with "Must be next to [River]" - the tile city on must have river at its border, not the adjacent tile
* "Must not be on [Hill]"
* "Must not be next to []"
* "Must be on [seacoast]" - next to "Coast" tile
* "Must be on [tile adjacent to source of fresh water]"
* "Must be next to [Water]" - next to any water tile, including "Lakes"
* "Must be next to [terrainFeature]"
* "Must be next to [unique]" - e.g "Must be next to [Rare feature]" - next to terrain or terrain feature having this unique