### PR TITLE
Implement custom save locations for Android and Desktop

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-sdk/>
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
     <application
         android:allowBackup="true"

--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -6,7 +6,6 @@
     <uses-sdk/>
 
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
     <application
         android:allowBackup="true"

--- a/android/src/com/unciv/app/AndroidLauncher.kt
+++ b/android/src/com/unciv/app/AndroidLauncher.kt
@@ -1,7 +1,6 @@
 package com.unciv.app
 
 import android.content.Intent
-import android.content.pm.PackageManager.PERMISSION_GRANTED
 import android.os.Build
 import android.os.Bundle
 import androidx.core.app.NotificationManagerCompat
@@ -83,13 +82,6 @@ class AndroidLauncher : AndroidApplication() {
         }
         catch (ex:Exception){}
         super.onResume()
-    }
-
-    override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>, grantResults: IntArray) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT && requestCode == REQ_WRITE_STORAGE && grantResults[0] == PERMISSION_GRANTED) {
-            customSaveLocationHelper?.continuePreviousRequest()
-        }
-        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {

--- a/android/src/com/unciv/app/AndroidLauncher.kt
+++ b/android/src/com/unciv/app/AndroidLauncher.kt
@@ -96,7 +96,7 @@ class AndroidLauncher : AndroidApplication() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
             // This should only happen on API 19+ but it's wrapped in the if check to keep the
             // compiler happy
-            customSaveLocationHelper?.handleIntentData(data?.data)
+            customSaveLocationHelper?.handleIntentData(requestCode, data?.data)
         }
         super.onActivityResult(requestCode, resultCode, data)
     }

--- a/android/src/com/unciv/app/AndroidLauncher.kt
+++ b/android/src/com/unciv/app/AndroidLauncher.kt
@@ -1,5 +1,6 @@
 package com.unciv.app
 
+import android.content.Intent
 import android.os.Build
 import android.os.Bundle
 import androidx.core.app.NotificationManagerCompat
@@ -13,8 +14,12 @@ import com.unciv.ui.utils.ORIGINAL_FONT_SIZE
 import java.io.File
 
 class AndroidLauncher : AndroidApplication() {
+    private var customSaveLocationHelper: CustomSaveLocationHelperAndroid? = null
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+            customSaveLocationHelper = CustomSaveLocationHelperAndroid(this)
+        }
         MultiplayerTurnCheckWorker.createNotificationChannels(applicationContext)
 
 		// Only allow mods on KK+, to avoid READ_EXTERNAL_STORAGE permission earlier versions need
@@ -29,7 +34,8 @@ class AndroidLauncher : AndroidApplication() {
                 version = BuildConfig.VERSION_NAME,
                 crashReportSender = CrashReportSenderAndroid(this),
                 exitEvent = this::finish,
-                fontImplementation = NativeFontAndroid(ORIGINAL_FONT_SIZE.toInt())
+                fontImplementation = NativeFontAndroid(ORIGINAL_FONT_SIZE.toInt()),
+                customSaveLocationHelper = customSaveLocationHelper
         )
         val game = UncivGame ( androidParameters )
         initialize(game, config)
@@ -76,5 +82,14 @@ class AndroidLauncher : AndroidApplication() {
         }
         catch (ex:Exception){}
         super.onResume()
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+            // This should only happen on API 19+ but it's wrapped in the if check to keep the
+            // compiler happy
+            customSaveLocationHelper?.handleIntentData(data?.data)
+        }
+        super.onActivityResult(requestCode, resultCode, data)
     }
 }

--- a/android/src/com/unciv/app/AndroidLauncher.kt
+++ b/android/src/com/unciv/app/AndroidLauncher.kt
@@ -1,6 +1,7 @@
 package com.unciv.app
 
 import android.content.Intent
+import android.content.pm.PackageManager.PERMISSION_GRANTED
 import android.os.Build
 import android.os.Bundle
 import androidx.core.app.NotificationManagerCompat
@@ -82,6 +83,13 @@ class AndroidLauncher : AndroidApplication() {
         }
         catch (ex:Exception){}
         super.onResume()
+    }
+
+    override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>, grantResults: IntArray) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT && requestCode == REQ_WRITE_STORAGE && grantResults[0] == PERMISSION_GRANTED) {
+            customSaveLocationHelper?.continuePreviousRequest()
+        }
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {

--- a/android/src/com/unciv/app/CustomSaveLocationHelperAndroid.kt
+++ b/android/src/com/unciv/app/CustomSaveLocationHelperAndroid.kt
@@ -6,37 +6,58 @@ import android.content.Intent
 import android.content.pm.PackageManager.PERMISSION_GRANTED
 import android.net.Uri
 import android.os.Build
+import androidx.annotation.GuardedBy
 import androidx.annotation.RequiresApi
 import androidx.core.content.ContextCompat
 import com.unciv.logic.CustomSaveLocationHelper
 import com.unciv.logic.GameInfo
 import com.unciv.logic.GameSaver
 import com.unciv.logic.GameSaver.json
-import java.util.concurrent.atomic.AtomicReference
 
-const val REQ_SAVE_GAME = 1
-const val REQ_LOAD_GAME = 2
 const val REQ_WRITE_STORAGE = 3
 
 // The Storage Access Framework is available from API 19 and up:
 // https://developer.android.com/guide/topics/providers/document-provider
 @RequiresApi(Build.VERSION_CODES.KITKAT)
 class CustomSaveLocationHelperAndroid(private val activity: Activity) : CustomSaveLocationHelper {
-    private val callback = AtomicReference<Pair<Thread, (Uri?) -> Unit>?>()
-    private var cachedSaveRequest: SaveRequest? = null
+    // This looks a little scary but it's really not so bad. Whenever a load or save operation is
+    // attempted, the game automatically autosaves as well (but on a separate thread), so we end up
+    // with a race condition when trying to handle both operations in parallel. In order to work
+    // around that, the callbacks are given an arbitrary index beginning at 100 and incrementing
+    // each time, and this index is used as the requestCode for the call to startActivityForResult()
+    // so that we can map it back to the corresponding callback when onActivityResult is called
+    @GuardedBy("this")
+    @Volatile
+    private var callbackIndex = 100
+    @GuardedBy("this")
+    private val callbacks = ArrayList<IndexedCallback>()
+
+    /**
+     * Used to keep track of the callback that's saved before requesting write permissions so we can
+     * continue where we left off once the permission is granted
+     */
+    @GuardedBy("this")
+    private var pendingCallbackIndex: Pair<Int, String>? = null
         @Synchronized get
         @Synchronized set
 
     override fun saveGame(gameInfo: GameInfo, gameName: String, forcePrompt: Boolean, block: (() -> Unit)?) {
-        callback.set(Thread.currentThread() to { uri ->
-            uri?.let {
-                saveGame(gameInfo, it)
-            }
-            block?.invoke()
-        })
+        val callbackIndex = synchronized(this) {
+            val index = callbackIndex++
+            callbacks.add(IndexedCallback(
+                    index,
+                    { uri ->
+                        uri?.let {
+                            saveGame(gameInfo, it)
+                        }
+                        block?.invoke()
+                    }
+            ))
+            index
+        }
         gameInfo.customSaveLocation?.let { customSaveLocation ->
             if (!forcePrompt) {
-                handleIntentData(Uri.parse(customSaveLocation))
+                handleIntentData(callbackIndex, Uri.parse(customSaveLocation))
                 return
             }
         }
@@ -46,7 +67,7 @@ class CustomSaveLocationHelperAndroid(private val activity: Activity) : CustomSa
         // a "Save as" operation then we need to get permission to write first
         if (ContextCompat.checkSelfPermission(activity, WRITE_EXTERNAL_STORAGE) != PERMISSION_GRANTED
                 && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            cachedSaveRequest = SaveRequest(gameInfo, gameName, forcePrompt, block)
+            pendingCallbackIndex = callbackIndex to gameName
             activity.requestPermissions(arrayOf(WRITE_EXTERNAL_STORAGE), REQ_WRITE_STORAGE)
             return
         }
@@ -54,23 +75,30 @@ class CustomSaveLocationHelperAndroid(private val activity: Activity) : CustomSa
         Intent(Intent.ACTION_CREATE_DOCUMENT).apply {
             type = "application/json"
             putExtra(Intent.EXTRA_TITLE, gameName)
-            activity.startActivityForResult(this, REQ_SAVE_GAME)
+            activity.startActivityForResult(this, callbackIndex)
         }
     }
 
     fun continuePreviousRequest() {
-        cachedSaveRequest?.let {
-            saveGame(it.gameInfo, it.gameName, it.forcePrompt, it.block)
-            cachedSaveRequest = null
+        pendingCallbackIndex?.let {
+            Intent(Intent.ACTION_CREATE_DOCUMENT).apply {
+                type = "application/json"
+                putExtra(Intent.EXTRA_TITLE, it.second)
+                activity.startActivityForResult(this, it.first)
+            }
+            pendingCallbackIndex = null
         }
     }
 
     // This will be called on the main thread
-    fun handleIntentData(uri: Uri?) {
-        callback.getAndSet(null)?.let {
-            it.first.run {
-                it.second.invoke(uri)
-            }
+    fun handleIntentData(requestCode: Int, uri: Uri?) {
+        val callback = synchronized(this) {
+            val index = callbacks.indexOfFirst { it.index == requestCode }
+            if (index == -1) return
+            callbacks.removeAt(index)
+        }
+        callback.thread.run {
+            callback.callback(uri)
         }
     }
 
@@ -84,32 +112,38 @@ class CustomSaveLocationHelperAndroid(private val activity: Activity) : CustomSa
     }
 
     override fun loadGame(block: (GameInfo) -> Unit) {
-        callback.set(Thread.currentThread() to { uri ->
-            uri?.let {
-                val game = activity.contentResolver.openInputStream(it)
-                        ?.reader()
-                        ?.readText()
-                        ?.run {
-                            GameSaver.gameInfoFromString(this)
-                        } ?: return@let
-                // If the user has saved the game from another platform (like Android),
-                // then the save location might not be right so we have to correct for that
-                // here
-                game.customSaveLocation = it.toString()
-                block(game)
-            }
-        })
+        val callbackIndex = synchronized(this) {
+            val index = callbackIndex++
+            callbacks.add(IndexedCallback(
+                    index,
+                    { uri ->
+                        uri?.let {
+                            val game = activity.contentResolver.openInputStream(it)
+                                    ?.reader()
+                                    ?.readText()
+                                    ?.run {
+                                        GameSaver.gameInfoFromString(this)
+                                    } ?: return@let
+                            // If the user has saved the game from another platform (like Android),
+                            // then the save location might not be right so we have to correct for that
+                            // here
+                            game.customSaveLocation = it.toString()
+                            block(game)
+                        }
+                    }
+            ))
+            index
+        }
 
         Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
             type = "*/*"
-            activity.startActivityForResult(this, REQ_LOAD_GAME)
+            activity.startActivityForResult(this, callbackIndex)
         }
     }
 }
 
-data class SaveRequest(
-        val gameInfo: GameInfo,
-        val gameName: String,
-        val forcePrompt: Boolean,
-        val block: (() -> Unit)?
+data class IndexedCallback(
+        val index: Int,
+        val callback: (Uri?) -> Unit,
+        val thread: Thread = Thread.currentThread()
 )

--- a/android/src/com/unciv/app/CustomSaveLocationHelperAndroid.kt
+++ b/android/src/com/unciv/app/CustomSaveLocationHelperAndroid.kt
@@ -1,0 +1,84 @@
+package com.unciv.app
+
+import android.app.Activity
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import androidx.annotation.RequiresApi
+import com.unciv.logic.CustomSaveLocationHelper
+import com.unciv.logic.GameInfo
+import com.unciv.logic.GameSaver
+import com.unciv.logic.GameSaver.json
+import java.util.concurrent.atomic.AtomicReference
+
+const val REQ_SAVE_GAME = 1
+const val REQ_LOAD_GAME = 2
+
+// The Storage Access Framework is available from API 19 and up:
+// https://developer.android.com/guide/topics/providers/document-provider
+@RequiresApi(Build.VERSION_CODES.KITKAT)
+class CustomSaveLocationHelperAndroid(private val activity: Activity) : CustomSaveLocationHelper {
+    private val callback = AtomicReference<Pair<Thread, (Uri?) -> Unit>?>()
+
+    override fun saveGame(gameInfo: GameInfo, gameName: String, forcePrompt: Boolean, block: (() -> Unit)?) {
+        callback.set(Thread.currentThread() to { uri ->
+            uri?.let {
+                saveGame(gameInfo, it)
+            }
+            block?.invoke()
+        })
+        gameInfo.customSaveLocation?.let { customSaveLocation ->
+            if (!forcePrompt) {
+                handleIntentData(Uri.parse(customSaveLocation))
+                return
+            }
+        }
+        Intent(Intent.ACTION_CREATE_DOCUMENT).apply {
+            type = "application/json"
+            putExtra(Intent.EXTRA_TITLE, gameName)
+            activity.startActivityForResult(this, REQ_SAVE_GAME)
+        }
+    }
+
+
+    // This will be called on the main thread
+    fun handleIntentData(uri: Uri?) {
+        callback.getAndSet(null)?.let {
+            it.first.run {
+                it.second.invoke(uri)
+            }
+        }
+    }
+
+    private fun saveGame(gameInfo: GameInfo, uri: Uri) {
+        gameInfo.customSaveLocation = uri.toString()
+        activity.contentResolver.openOutputStream(uri, "rwt")
+                ?.writer()
+                ?.use {
+                    it.write(json().toJson(gameInfo))
+                }
+    }
+
+    override fun loadGame(block: (GameInfo) -> Unit) {
+        callback.set(Thread.currentThread() to { uri ->
+            uri?.let {
+                val game = activity.contentResolver.openInputStream(it)
+                                ?.reader()
+                                ?.readText()
+                                ?.run {
+                                    GameSaver.gameInfoFromString(this)
+                                }?: return@let
+                // If the user has saved the game from another platform (like Android),
+                // then the save location might not be right so we have to correct for that
+                // here
+                game.customSaveLocation = it.toString()
+                block(game)
+            }
+        })
+
+        Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
+            type = "*/*"
+            activity.startActivityForResult(this, REQ_LOAD_GAME)
+        }
+    }
+}

--- a/android/src/com/unciv/app/CustomSaveLocationHelperAndroid.kt
+++ b/android/src/com/unciv/app/CustomSaveLocationHelperAndroid.kt
@@ -81,21 +81,20 @@ class CustomSaveLocationHelperAndroid(private val activity: Activity) : CustomSa
             val index = callbackIndex++
             callbacks.add(IndexedCallback(
                     index,
-                    { uri ->
-                        if (uri != null) {
-                            val game = activity.contentResolver.openInputStream(uri)
-                                    ?.reader()
-                                    ?.readText()
-                                    ?.run {
-                                        GameSaver.gameInfoFromString(this)
-                                    }
-                            if (game != null) {
-                                // If the user has saved the game from another platform (like Android),
-                                // then the save location might not be right so we have to correct for that
-                                // here
-                                game.customSaveLocation = uri.toString()
-                                block(game)
-                            }
+                    callback@{ uri ->
+                        if (uri == null) return@callback
+                        val game = activity.contentResolver.openInputStream(uri)
+                                ?.reader()
+                                ?.readText()
+                                ?.run {
+                                    GameSaver.gameInfoFromString(this)
+                                }
+                        if (game != null) {
+                            // If the user has saved the game from another platform (like Android),
+                            // then the save location might not be right so we have to correct for that
+                            // here
+                            game.customSaveLocation = uri.toString()
+                            block(game)
                         }
                     }
             ))

--- a/android/src/com/unciv/app/CustomSaveLocationHelperAndroid.kt
+++ b/android/src/com/unciv/app/CustomSaveLocationHelperAndroid.kt
@@ -1,10 +1,13 @@
 package com.unciv.app
 
+import android.Manifest.permission.WRITE_EXTERNAL_STORAGE
 import android.app.Activity
 import android.content.Intent
+import android.content.pm.PackageManager.PERMISSION_GRANTED
 import android.net.Uri
 import android.os.Build
 import androidx.annotation.RequiresApi
+import androidx.core.content.ContextCompat
 import com.unciv.logic.CustomSaveLocationHelper
 import com.unciv.logic.GameInfo
 import com.unciv.logic.GameSaver
@@ -13,12 +16,16 @@ import java.util.concurrent.atomic.AtomicReference
 
 const val REQ_SAVE_GAME = 1
 const val REQ_LOAD_GAME = 2
+const val REQ_WRITE_STORAGE = 3
 
 // The Storage Access Framework is available from API 19 and up:
 // https://developer.android.com/guide/topics/providers/document-provider
 @RequiresApi(Build.VERSION_CODES.KITKAT)
 class CustomSaveLocationHelperAndroid(private val activity: Activity) : CustomSaveLocationHelper {
     private val callback = AtomicReference<Pair<Thread, (Uri?) -> Unit>?>()
+    private var cachedSaveRequest: SaveRequest? = null
+        @Synchronized get
+        @Synchronized set
 
     override fun saveGame(gameInfo: GameInfo, gameName: String, forcePrompt: Boolean, block: (() -> Unit)?) {
         callback.set(Thread.currentThread() to { uri ->
@@ -33,6 +40,17 @@ class CustomSaveLocationHelperAndroid(private val activity: Activity) : CustomSa
                 return
             }
         }
+
+        // For some reason it seems you can save to an existing file that you open without the
+        // permission, but you can't write to a file that you've requested be created so if this is
+        // a "Save as" operation then we need to get permission to write first
+        if (ContextCompat.checkSelfPermission(activity, WRITE_EXTERNAL_STORAGE) != PERMISSION_GRANTED
+                && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            cachedSaveRequest = SaveRequest(gameInfo, gameName, forcePrompt, block)
+            activity.requestPermissions(arrayOf(WRITE_EXTERNAL_STORAGE), REQ_WRITE_STORAGE)
+            return
+        }
+
         Intent(Intent.ACTION_CREATE_DOCUMENT).apply {
             type = "application/json"
             putExtra(Intent.EXTRA_TITLE, gameName)
@@ -40,6 +58,12 @@ class CustomSaveLocationHelperAndroid(private val activity: Activity) : CustomSa
         }
     }
 
+    fun continuePreviousRequest() {
+        cachedSaveRequest?.let {
+            saveGame(it.gameInfo, it.gameName, it.forcePrompt, it.block)
+            cachedSaveRequest = null
+        }
+    }
 
     // This will be called on the main thread
     fun handleIntentData(uri: Uri?) {
@@ -63,11 +87,11 @@ class CustomSaveLocationHelperAndroid(private val activity: Activity) : CustomSa
         callback.set(Thread.currentThread() to { uri ->
             uri?.let {
                 val game = activity.contentResolver.openInputStream(it)
-                                ?.reader()
-                                ?.readText()
-                                ?.run {
-                                    GameSaver.gameInfoFromString(this)
-                                }?: return@let
+                        ?.reader()
+                        ?.readText()
+                        ?.run {
+                            GameSaver.gameInfoFromString(this)
+                        } ?: return@let
                 // If the user has saved the game from another platform (like Android),
                 // then the save location might not be right so we have to correct for that
                 // here
@@ -82,3 +106,10 @@ class CustomSaveLocationHelperAndroid(private val activity: Activity) : CustomSa
         }
     }
 }
+
+data class SaveRequest(
+        val gameInfo: GameInfo,
+        val gameName: String,
+        val forcePrompt: Boolean,
+        val block: (() -> Unit)?
+)

--- a/core/src/com/unciv/UncivGame.kt
+++ b/core/src/com/unciv/UncivGame.kt
@@ -13,7 +13,10 @@ import com.unciv.models.metadata.GameSettings
 import com.unciv.models.ruleset.RulesetCache
 import com.unciv.models.translations.Translations
 import com.unciv.ui.LanguagePickerScreen
-import com.unciv.ui.utils.*
+import com.unciv.ui.utils.CameraStageBaseScreen
+import com.unciv.ui.utils.CrashController
+import com.unciv.ui.utils.ImageGetter
+import com.unciv.ui.utils.center
 import com.unciv.ui.worldscreen.WorldScreen
 import java.util.*
 import kotlin.concurrent.thread
@@ -28,6 +31,7 @@ class UncivGame(parameters: UncivGameParameters) : Game() {
     val cancelDiscordEvent = parameters.cancelDiscordEvent
     val fontImplementation = parameters.fontImplementation
     val consoleMode = parameters.consoleMode
+    val customSaveLocationHelper = parameters.customSaveLocationHelper
 
     lateinit var gameInfo: GameInfo
     fun isGameInfoInitialized() = this::gameInfo.isInitialized
@@ -69,6 +73,7 @@ class UncivGame(parameters: UncivGameParameters) : Game() {
         Current = this
 
 
+        GameSaver.customSaveLocationHelper = customSaveLocationHelper
         // If this takes too long players, especially with older phones, get ANR problems.
         // Whatever needs graphics needs to be done on the main thread,
         // So it's basically a long set of deferred actions.

--- a/core/src/com/unciv/UncivGameParameters.kt
+++ b/core/src/com/unciv/UncivGameParameters.kt
@@ -1,5 +1,6 @@
 package com.unciv
 
+import com.unciv.logic.CustomSaveLocationHelper
 import com.unciv.ui.utils.CrashReportSender
 import com.unciv.ui.utils.NativeFontImplementation
 
@@ -8,5 +9,6 @@ class UncivGameParameters(val version: String,
                           val exitEvent: (()->Unit)? = null,
                           val cancelDiscordEvent: (()->Unit)? = null,
                           val fontImplementation: NativeFontImplementation? = null,
-                          val consoleMode: Boolean = false) {
+                          val consoleMode: Boolean = false,
+                          val customSaveLocationHelper: CustomSaveLocationHelper? = null) {
 }

--- a/core/src/com/unciv/logic/CustomSaveLocationHelper.kt
+++ b/core/src/com/unciv/logic/CustomSaveLocationHelper.kt
@@ -1,0 +1,28 @@
+package com.unciv.logic
+
+/**
+ * Contract for platform-specific helper classes to handle saving and loading games to and from
+ * arbitrary external locations
+ */
+interface CustomSaveLocationHelper {
+    /**
+     * Saves a game asynchronously with a given default name and then calls the [block] callback
+     * upon completion. The [block] callback will be called from the same thread that this method
+     * is called from. If the [GameInfo] object already has the
+     * [customSaveLocation][GameInfo.customSaveLocation] property defined (not null), then the user
+     * will not be prompted to select a location for the save unless [forcePrompt] is set to true
+     * (think of this like "Save as...")
+     */
+    fun saveGame(
+            gameInfo: GameInfo,
+            gameName: String,
+            forcePrompt: Boolean = false,
+            block: (() -> Unit)? = null
+    )
+
+    /**
+     * Loads a game from an external source asynchronously, then calls [block] with the loaded
+     * [GameInfo]
+     */
+    fun loadGame(block: (GameInfo) -> Unit)
+}

--- a/core/src/com/unciv/logic/CustomSaveLocationHelper.kt
+++ b/core/src/com/unciv/logic/CustomSaveLocationHelper.kt
@@ -6,8 +6,8 @@ package com.unciv.logic
  */
 interface CustomSaveLocationHelper {
     /**
-     * Saves a game asynchronously with a given default name and then calls the [block] callback
-     * upon completion. The [block] callback will be called from the same thread that this method
+     * Saves a game asynchronously with a given default name and then calls the [saveCompleteCallback] callback
+     * upon completion. The [saveCompleteCallback] callback will be called from the same thread that this method
      * is called from. If the [GameInfo] object already has the
      * [customSaveLocation][GameInfo.customSaveLocation] property defined (not null), then the user
      * will not be prompted to select a location for the save unless [forcePrompt] is set to true
@@ -17,12 +17,12 @@ interface CustomSaveLocationHelper {
             gameInfo: GameInfo,
             gameName: String,
             forcePrompt: Boolean = false,
-            block: (() -> Unit)? = null
+            saveCompleteCallback: ((Exception?) -> Unit)? = null
     )
 
     /**
-     * Loads a game from an external source asynchronously, then calls [block] with the loaded
+     * Loads a game from an external source asynchronously, then calls [loadCompleteCallback] with the loaded
      * [GameInfo]
      */
-    fun loadGame(block: (GameInfo) -> Unit)
+    fun loadGame(loadCompleteCallback: (GameInfo?, Exception?) -> Unit)
 }

--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -35,6 +35,8 @@ class GameInfo {
     var oneMoreTurnMode=false
     var currentPlayer=""
     var gameId = UUID.randomUUID().toString() // random string
+    @Volatile
+    var customSaveLocation: String? = null
 
     /** Simulate until any player wins,
      *  or turns exceeds indicated number
@@ -55,6 +57,7 @@ class GameInfo {
         toReturn.gameParameters = gameParameters
         toReturn.gameId = gameId
         toReturn.oneMoreTurnMode = oneMoreTurnMode
+        toReturn.customSaveLocation = customSaveLocation
         return toReturn
     }
 

--- a/core/src/com/unciv/logic/GameSaver.kt
+++ b/core/src/com/unciv/logic/GameSaver.kt
@@ -133,8 +133,9 @@ object GameSaver {
         // game to their Google Drive folder, they'll probably want that progress to be synced to
         // other devices automatically so they don't have to remember to manually save before
         // exiting the game.
-        gameInfo.customSaveLocation?.let {
-            saveGame(gameInfo,gameInfo.currentPlayer + " -  " + gameInfo.turns + " turns", false)
+        if (gameInfo.customSaveLocation != null) {
+            // GameName is unused here since we're just overwriting the existing file
+            saveGame(gameInfo, "", false)
             return
         }
         saveGame(gameInfo, "Autosave")
@@ -143,8 +144,10 @@ object GameSaver {
         val newAutosaveFilename = saveFilesFolder + File.separator + "Autosave-${gameInfo.currentPlayer}-${gameInfo.turns}"
         getSave("Autosave").copyTo(Gdx.files.local(newAutosaveFilename))
 
-        fun getAutosaves(): Sequence<FileHandle> { return getSaves().filter { it.name().startsWith("Autosave") } }
-        while(getAutosaves().count()>10){
+        fun getAutosaves(): Sequence<FileHandle> {
+            return getSaves().filter { it.name().startsWith("Autosave") }
+        }
+        while (getAutosaves().count() > 10) {
             val saveToDelete = getAutosaves().minBy { it.lastModified() }!!
             deleteSave(saveToDelete.name())
         }

--- a/core/src/com/unciv/logic/GameSaver.kt
+++ b/core/src/com/unciv/logic/GameSaver.kt
@@ -39,19 +39,19 @@ object GameSaver {
         return localSaves + Gdx.files.absolute(externalFilesDirForAndroid + "/${getSubfolder(multiplayer)}").list().asSequence()
     }
 
-    fun saveGame(game: GameInfo, GameName: String, multiplayer: Boolean = false, forcePrompt: Boolean = false, block: (() -> Unit)? = null) {
+    fun saveGame(game: GameInfo, GameName: String, multiplayer: Boolean = false, forcePrompt: Boolean = false, saveCompletionCallback: ((Exception?) -> Unit)? = null) {
         val customSaveLocation = game.customSaveLocation
         val customSaveLocationHelper = this.customSaveLocationHelper
         if (customSaveLocation != null && customSaveLocationHelper != null) {
-            customSaveLocationHelper.saveGame(game, GameName, forcePrompt, block)
+            customSaveLocationHelper.saveGame(game, GameName, forcePrompt, saveCompletionCallback)
         } else {
-            json().toJson(game,getSave(GameName, multiplayer))
-            block?.invoke()
+            json().toJson(game, getSave(GameName, multiplayer))
+            saveCompletionCallback?.invoke(null)
         }
     }
 
-    fun saveGameToCustomLocation(game: GameInfo, GameName: String, block: () -> Unit) {
-        customSaveLocationHelper!!.saveGame(game, GameName, forcePrompt = true, block =block)
+    fun saveGameToCustomLocation(game: GameInfo, GameName: String, saveCompletionCallback: (Exception?) -> Unit) {
+        customSaveLocationHelper!!.saveGame(game, GameName, forcePrompt = true, saveCompleteCallback = saveCompletionCallback)
     }
 
     fun loadGameByName(GameName: String, multiplayer: Boolean = false) =
@@ -63,15 +63,15 @@ object GameSaver {
         return game
     }
 
-    fun loadGameFromCustomLocation(block: (GameInfo) -> Unit) {
-        customSaveLocationHelper!!.loadGame { game ->
-            block(game.apply { setTransients() })
+    fun loadGameFromCustomLocation(loadCompletionCallback: (GameInfo?, Exception?) -> Unit) {
+        customSaveLocationHelper!!.loadGame { game, e ->
+            loadCompletionCallback(game?.apply { setTransients() }, e)
         }
     }
 
     fun canLoadFromCustomSaveLocation() = customSaveLocationHelper != null
 
-    fun gameInfoFromString(gameData:String): GameInfo {
+    fun gameInfoFromString(gameData: String): GameInfo {
         val game = json().fromJson(GameInfo::class.java, gameData)
         game.setTransients()
         return game

--- a/core/src/com/unciv/ui/saves/LoadGameScreen.kt
+++ b/core/src/com/unciv/ui/saves/LoadGameScreen.kt
@@ -85,7 +85,7 @@ class LoadGameScreen(previousScreen:CameraStageBaseScreen) : PickerScreen() {
                     game.loadGame(it)
                 }
             }
-            rightSideTable.add(loadFromCustomLocation).row()
+            rightSideTable.add(loadFromCustomLocation).pad(10f).row()
         }
         rightSideTable.add(errorLabel).row()
 

--- a/core/src/com/unciv/ui/saves/LoadGameScreen.kt
+++ b/core/src/com/unciv/ui/saves/LoadGameScreen.kt
@@ -78,6 +78,15 @@ class LoadGameScreen(previousScreen:CameraStageBaseScreen) : PickerScreen() {
             }
         }
         rightSideTable.add(loadFromClipboardButton).row()
+        if (GameSaver.canLoadFromCustomSaveLocation()) {
+            val loadFromCustomLocation = "Load from custom location".toTextButton()
+            loadFromCustomLocation.onClick {
+                GameSaver.loadGameFromCustomLocation {
+                    game.loadGame(it)
+                }
+            }
+            rightSideTable.add(loadFromCustomLocation).row()
+        }
         rightSideTable.add(errorLabel).row()
 
         deleteSaveButton.onClick {

--- a/core/src/com/unciv/ui/saves/LoadGameScreen.kt
+++ b/core/src/com/unciv/ui/saves/LoadGameScreen.kt
@@ -13,6 +13,7 @@ import com.unciv.ui.pickerscreens.PickerScreen
 import com.unciv.ui.utils.*
 import java.text.SimpleDateFormat
 import java.util.*
+import java.util.concurrent.CancellationException
 import kotlin.concurrent.thread
 import com.unciv.ui.utils.AutoScrollPane as ScrollPane
 
@@ -81,8 +82,13 @@ class LoadGameScreen(previousScreen:CameraStageBaseScreen) : PickerScreen() {
         if (GameSaver.canLoadFromCustomSaveLocation()) {
             val loadFromCustomLocation = "Load from custom location".toTextButton()
             loadFromCustomLocation.onClick {
-                GameSaver.loadGameFromCustomLocation {
-                    game.loadGame(it)
+                GameSaver.loadGameFromCustomLocation { gameInfo, exception ->
+                    if (gameInfo != null) {
+                        game.loadGame(gameInfo)
+                    } else if (exception !is CancellationException) {
+                        errorLabel.setText("Could not load game from custom location!".tr())
+                        exception?.printStackTrace()
+                    }
                 }
             }
             rightSideTable.add(loadFromCustomLocation).pad(10f).row()

--- a/core/src/com/unciv/ui/saves/SaveGameScreen.kt
+++ b/core/src/com/unciv/ui/saves/SaveGameScreen.kt
@@ -40,6 +40,20 @@ class SaveGameScreen : PickerScreen() {
             Gdx.app.clipboard.contents = base64Gzip
         }
         newSave.add(copyJsonButton).row()
+        if (GameSaver.canLoadFromCustomSaveLocation()) {
+            val saveToCustomLocation = "Save to custom location".toTextButton()
+            saveToCustomLocation.enable()
+            saveToCustomLocation.onClick {
+                saveToCustomLocation.setText("Saving...".tr())
+                saveToCustomLocation.disable()
+                thread(name = "SaveGame") {
+                    GameSaver.saveGameToCustomLocation(UncivGame.Current.gameInfo, textField.text) {
+                        Gdx.app.postRunnable { UncivGame.Current.setWorldScreen() }
+                    }
+                }
+            }
+            newSave.add(saveToCustomLocation).row()
+        }
 
 
         val showAutosavesCheckbox = CheckBox("Show autosaves".tr(), skin)
@@ -56,8 +70,9 @@ class SaveGameScreen : PickerScreen() {
         rightSideButton.onClick {
             rightSideButton.setText("Saving...".tr())
             thread(name = "SaveGame") {
-                GameSaver.saveGame(UncivGame.Current.gameInfo, textField.text)
-                Gdx.app.postRunnable { UncivGame.Current.setWorldScreen() }
+                GameSaver.saveGame(UncivGame.Current.gameInfo, textField.text) {
+                    Gdx.app.postRunnable { UncivGame.Current.setWorldScreen() }
+                }
             }
         }
         rightSideButton.enable()

--- a/core/src/com/unciv/ui/saves/SaveGameScreen.kt
+++ b/core/src/com/unciv/ui/saves/SaveGameScreen.kt
@@ -1,6 +1,7 @@
 package com.unciv.ui.saves
 
 import com.badlogic.gdx.Gdx
+import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.scenes.scene2d.ui.CheckBox
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.scenes.scene2d.ui.TextField
@@ -10,6 +11,7 @@ import com.unciv.logic.GameSaver
 import com.unciv.models.translations.tr
 import com.unciv.ui.pickerscreens.PickerScreen
 import com.unciv.ui.utils.*
+import java.util.concurrent.CancellationException
 import kotlin.concurrent.thread
 import com.unciv.ui.utils.AutoScrollPane as ScrollPane
 
@@ -42,17 +44,26 @@ class SaveGameScreen : PickerScreen() {
         newSave.add(copyJsonButton).row()
         if (GameSaver.canLoadFromCustomSaveLocation()) {
             val saveToCustomLocation = "Save to custom location".toTextButton()
+            val errorLabel = "".toLabel(Color.RED)
             saveToCustomLocation.enable()
             saveToCustomLocation.onClick {
+                errorLabel.setText("")
                 saveToCustomLocation.setText("Saving...".tr())
                 saveToCustomLocation.disable()
                 thread(name = "SaveGame") {
-                    GameSaver.saveGameToCustomLocation(UncivGame.Current.gameInfo, textField.text) {
-                        Gdx.app.postRunnable { UncivGame.Current.setWorldScreen() }
+                    GameSaver.saveGameToCustomLocation(UncivGame.Current.gameInfo, textField.text) { e ->
+                        if (e == null) {
+                            Gdx.app.postRunnable { UncivGame.Current.setWorldScreen() }
+                        } else if (e !is CancellationException) {
+                            errorLabel.setText("Could not save game to custom location".tr())
+                            e.printStackTrace()
+                        }
+                        saveToCustomLocation.enable()
                     }
                 }
             }
             newSave.add(saveToCustomLocation).pad(10f).row()
+            newSave.add(errorLabel).pad(0f, 10f, 10f, 10f).row()
         }
 
 

--- a/core/src/com/unciv/ui/saves/SaveGameScreen.kt
+++ b/core/src/com/unciv/ui/saves/SaveGameScreen.kt
@@ -52,7 +52,7 @@ class SaveGameScreen : PickerScreen() {
                     }
                 }
             }
-            newSave.add(saveToCustomLocation).row()
+            newSave.add(saveToCustomLocation).pad(10f).row()
         }
 
 

--- a/desktop/src/com/unciv/app/desktop/CustomSaveLocationHelperDesktop.kt
+++ b/desktop/src/com/unciv/app/desktop/CustomSaveLocationHelperDesktop.kt
@@ -12,21 +12,20 @@ import javax.swing.JFrame
 
 class CustomSaveLocationHelperDesktop : CustomSaveLocationHelper {
     override fun saveGame(gameInfo: GameInfo, gameName: String, forcePrompt: Boolean, block: (() -> Unit)?) {
-        gameInfo.customSaveLocation?.let {
-            if (!forcePrompt) {
-                File(it).outputStream()
-                        .writer()
-                        .use { writer ->
-                            writer.write(json().toJson(gameInfo))
-                        }
-                block?.invoke()
-                return
-            }
+        val customSaveLocation = gameInfo.customSaveLocation
+        if (customSaveLocation != null && !forcePrompt) {
+            File(customSaveLocation).outputStream()
+                    .writer()
+                    .use { writer ->
+                        writer.write(json().toJson(gameInfo))
+                    }
+            block?.invoke()
+            return
         }
 
         val fileChooser = JFileChooser().apply fileChooser@{
             currentDirectory = Gdx.files.local("").file()
-            selectedFile = File(gameInfo.customSaveLocation?: gameName)
+            selectedFile = File(gameInfo.customSaveLocation ?: gameName)
         }
 
         JFrame().apply frame@{
@@ -36,7 +35,8 @@ class CustomSaveLocationHelperDesktop : CustomSaveLocationHelper {
             fileChooser.showSaveDialog(this@frame)
             dispatchEvent(WindowEvent(this, WindowEvent.WINDOW_CLOSING))
         }
-        fileChooser.selectedFile?.let { file ->
+        val file = fileChooser.selectedFile
+        if (file != null) {
             gameInfo.customSaveLocation = file.absolutePath
             file.outputStream()
                     .writer()
@@ -59,7 +59,8 @@ class CustomSaveLocationHelperDesktop : CustomSaveLocationHelper {
             fileChooser.showOpenDialog(this@frame)
             dispatchEvent(WindowEvent(this, WindowEvent.WINDOW_CLOSING))
         }
-        fileChooser.selectedFile?.let { file ->
+        val file = fileChooser.selectedFile
+        if (file != null) {
             file.inputStream()
                     .reader()
                     .readText()

--- a/desktop/src/com/unciv/app/desktop/CustomSaveLocationHelperDesktop.kt
+++ b/desktop/src/com/unciv/app/desktop/CustomSaveLocationHelperDesktop.kt
@@ -19,6 +19,7 @@ class CustomSaveLocationHelperDesktop : CustomSaveLocationHelper {
                         .use { writer ->
                             writer.write(json().toJson(gameInfo))
                         }
+                block?.invoke()
                 return
             }
         }

--- a/desktop/src/com/unciv/app/desktop/CustomSaveLocationHelperDesktop.kt
+++ b/desktop/src/com/unciv/app/desktop/CustomSaveLocationHelperDesktop.kt
@@ -1,0 +1,75 @@
+package com.unciv.app.desktop
+
+import com.badlogic.gdx.Gdx
+import com.unciv.logic.CustomSaveLocationHelper
+import com.unciv.logic.GameInfo
+import com.unciv.logic.GameSaver
+import com.unciv.logic.GameSaver.json
+import java.awt.event.WindowEvent
+import java.io.File
+import javax.swing.JFileChooser
+import javax.swing.JFrame
+
+class CustomSaveLocationHelperDesktop : CustomSaveLocationHelper {
+    override fun saveGame(gameInfo: GameInfo, gameName: String, forcePrompt: Boolean, block: (() -> Unit)?) {
+        gameInfo.customSaveLocation?.let {
+            if (!forcePrompt) {
+                File(it).outputStream()
+                        .writer()
+                        .use { writer ->
+                            writer.write(json().toJson(gameInfo))
+                        }
+                return
+            }
+        }
+
+        val fileChooser = JFileChooser().apply fileChooser@{
+            currentDirectory = Gdx.files.local("").file()
+            selectedFile = File(gameInfo.customSaveLocation?: gameName)
+        }
+
+        JFrame().apply frame@{
+            setLocationRelativeTo(null)
+            isVisible = true
+            toFront()
+            fileChooser.showSaveDialog(this@frame)
+            dispatchEvent(WindowEvent(this, WindowEvent.WINDOW_CLOSING))
+        }
+        fileChooser.selectedFile?.let { file ->
+            gameInfo.customSaveLocation = file.absolutePath
+            file.outputStream()
+                    .writer()
+                    .use {
+                        it.write(json().toJson(gameInfo))
+                    }
+        }
+        block?.invoke()
+    }
+
+    override fun loadGame(block: (GameInfo) -> Unit) {
+        val fileChooser = JFileChooser().apply fileChooser@{
+            currentDirectory = Gdx.files.local("").file()
+        }
+
+        JFrame().apply frame@{
+            setLocationRelativeTo(null)
+            isVisible = true
+            toFront()
+            fileChooser.showOpenDialog(this@frame)
+            dispatchEvent(WindowEvent(this, WindowEvent.WINDOW_CLOSING))
+        }
+        fileChooser.selectedFile?.let { file ->
+            file.inputStream()
+                    .reader()
+                    .readText()
+                    .run { GameSaver.gameInfoFromString(this) }
+                    .apply {
+                        // If the user has saved the game from another platform (like Android),
+                        // then the save location might not be right so we have to correct for that
+                        // here
+                        customSaveLocation = file.absolutePath
+                        block(this)
+                    }
+        }
+    }
+}

--- a/desktop/src/com/unciv/app/desktop/CustomSaveLocationHelperDesktop.kt
+++ b/desktop/src/com/unciv/app/desktop/CustomSaveLocationHelperDesktop.kt
@@ -7,19 +7,24 @@ import com.unciv.logic.GameSaver
 import com.unciv.logic.GameSaver.json
 import java.awt.event.WindowEvent
 import java.io.File
+import java.util.concurrent.CancellationException
 import javax.swing.JFileChooser
 import javax.swing.JFrame
 
 class CustomSaveLocationHelperDesktop : CustomSaveLocationHelper {
-    override fun saveGame(gameInfo: GameInfo, gameName: String, forcePrompt: Boolean, block: (() -> Unit)?) {
+    override fun saveGame(gameInfo: GameInfo, gameName: String, forcePrompt: Boolean, saveCompleteCallback: ((Exception?) -> Unit)?) {
         val customSaveLocation = gameInfo.customSaveLocation
         if (customSaveLocation != null && !forcePrompt) {
-            File(customSaveLocation).outputStream()
-                    .writer()
-                    .use { writer ->
-                        writer.write(json().toJson(gameInfo))
-                    }
-            block?.invoke()
+            try {
+                File(customSaveLocation).outputStream()
+                        .writer()
+                        .use { writer ->
+                            writer.write(json().toJson(gameInfo))
+                        }
+                saveCompleteCallback?.invoke(null)
+            } catch (e: Exception) {
+                saveCompleteCallback?.invoke(e)
+            }
             return
         }
 
@@ -36,18 +41,25 @@ class CustomSaveLocationHelperDesktop : CustomSaveLocationHelper {
             dispatchEvent(WindowEvent(this, WindowEvent.WINDOW_CLOSING))
         }
         val file = fileChooser.selectedFile
+        var exception: Exception? = null
         if (file != null) {
             gameInfo.customSaveLocation = file.absolutePath
-            file.outputStream()
-                    .writer()
-                    .use {
-                        it.write(json().toJson(gameInfo))
-                    }
+            try {
+                file.outputStream()
+                        .writer()
+                        .use {
+                            it.write(json().toJson(gameInfo))
+                        }
+            } catch (e: Exception) {
+                exception = e
+            }
+        } else {
+            exception = CancellationException()
         }
-        block?.invoke()
+        saveCompleteCallback?.invoke(exception)
     }
 
-    override fun loadGame(block: (GameInfo) -> Unit) {
+    override fun loadGame(loadCompleteCallback: (GameInfo?, Exception?) -> Unit) {
         val fileChooser = JFileChooser().apply fileChooser@{
             currentDirectory = Gdx.files.local("").file()
         }
@@ -60,18 +72,27 @@ class CustomSaveLocationHelperDesktop : CustomSaveLocationHelper {
             dispatchEvent(WindowEvent(this, WindowEvent.WINDOW_CLOSING))
         }
         val file = fileChooser.selectedFile
+        var exception: Exception? = null
+        var gameInfo: GameInfo? = null
         if (file != null) {
-            file.inputStream()
-                    .reader()
-                    .readText()
-                    .run { GameSaver.gameInfoFromString(this) }
-                    .apply {
-                        // If the user has saved the game from another platform (like Android),
-                        // then the save location might not be right so we have to correct for that
-                        // here
-                        customSaveLocation = file.absolutePath
-                        block(this)
-                    }
+            try {
+                file.inputStream()
+                        .reader()
+                        .readText()
+                        .run { GameSaver.gameInfoFromString(this) }
+                        .apply {
+                            // If the user has saved the game from another platform (like Android),
+                            // then the save location might not be right so we have to correct for that
+                            // here
+                            customSaveLocation = file.absolutePath
+                            gameInfo = this
+                        }
+            } catch (e: Exception) {
+                exception = e
+            }
+        } else {
+            exception = CancellationException()
         }
+        loadCompleteCallback(gameInfo, exception)
     }
 }

--- a/desktop/src/com/unciv/app/desktop/DesktopLauncher.kt
+++ b/desktop/src/com/unciv/app/desktop/DesktopLauncher.kt
@@ -47,7 +47,8 @@ internal object DesktopLauncher {
                 versionFromJar,
                 exitEvent = { exitProcess(0) },
                 cancelDiscordEvent = { discordTimer?.cancel() },
-                fontImplementation = NativeFontDesktop(ORIGINAL_FONT_SIZE.toInt())
+                fontImplementation = NativeFontDesktop(ORIGINAL_FONT_SIZE.toInt()),
+                customSaveLocationHelper = CustomSaveLocationHelperDesktop()
         )
 
         val game = UncivGame ( desktopParameters )


### PR DESCRIPTION
This PR allows the user to select a custom location for saving their game. For the save screen, a "Save to custom location" button is added:

![image](https://user-images.githubusercontent.com/11827417/93691794-4c981200-fa9f-11ea-9896-f67f886f6160.png)

On the desktop, this will open up a Swing file chooser to save the game:

![image](https://user-images.githubusercontent.com/11827417/93691801-66395980-fa9f-11ea-98b5-0ed8df8df7f1.png)

On Android, this will use the device's built-in file selector to save the game:

![image](https://user-images.githubusercontent.com/11827417/93691815-941e9e00-fa9f-11ea-8daa-7d7c9a9c11f2.png)

The loading works similarly, just with slightly different wording on the button:

![image](https://user-images.githubusercontent.com/11827417/93691823-b3b5c680-fa9f-11ea-9c3e-e4fbc5c26c75.png)

_After_ I had written all of this code and tested it, I noticed that #2517 already existed, but it seems like it hasn't been touched for a few months and it only supports Android if I'm not mistaken. Anyways, this should solve for #1710, and could be used to justify closing #2825 as you can see from the screenshots that I was able to start a game on desktop, save it to my Google Drive folder, then switch seamlessly to my phone and back again.

The only major change I had to make was to the autosave feature. When using a custom save location, the autosave will overwrite the game file instead of saving to an internal "Autosave" file. I think this makes more sense for the use case I described in the comments.

With all that out of the way, I wanted to bring up another approach I tried that didn't work, which was to [allow the user to select a custom folder for game saves](https://github.com/wbrawner/Unciv/tree/custom-saves-folder) instead of choosing where to save each game individually. It actually did work on desktop, but on Android selecting a folder from a cloud storage app like Google Drive or OneDrive requires said app to implement some document tree API that of course neither of those two do. Interestingly enough the Nextcloud app actually did implement it, but I don't think catering to a minority use case makes a whole lot of sense. Thus I had to shift gears and take this approach instead.