### PR TITLE
Custom Nation Unique Text

### DIFF
--- a/core/src/com/unciv/models/ruleset/Nation.kt
+++ b/core/src/com/unciv/models/ruleset/Nation.kt
@@ -39,6 +39,7 @@ class Nation : INamed {
     var uniqueName = ""
     var uniques = HashSet<String>()
     val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it) } }
+    var uniqueText = ""
     var innerColor: List<Int>? = null
     var startBias = ArrayList<String>()
 
@@ -92,8 +93,13 @@ class Nation : INamed {
         }
 
         if (uniqueName != "") textList += uniqueName.tr() + ":"
-        textList += "  " + uniques.joinToString(", ") { it.tr() }
-        textList += ""
+        if (uniqueText != "") {
+            textList += " " + uniqueText.tr()
+        }
+        else {
+            textList += "  " + uniques.joinToString(", ") { it.tr() }
+            textList += ""
+        }
 
         if (startBias.isNotEmpty()) {
             textList += "Start bias:".tr() + startBias.joinToString(", ", " ") { it.tr() }


### PR DESCRIPTION
This allows mods to override unique text for nations. This is useful for using uniques but phrasing them differently when shown to the player. 

The attribute in the nation json to change this is "uniqueText"

A mod to test this is here, it changes Babylon's unique text to "Test Babylon Unique Text"
https://cdn.discordapp.com/attachments/670547794951405584/757393404924526672/Test_Custom_Nation_Unique_Text.zip

