### PR TITLE
Hiding things in civilopedia

### DIFF
--- a/core/src/com/unciv/models/ruleset/Building.kt
+++ b/core/src/com/unciv/models/ruleset/Building.kt
@@ -41,6 +41,9 @@ class Building : NamedStats(), IConstruction {
     var uniques = ArrayList<String>()
     val uniqueObjects:List<Unique> by lazy { uniques.map { Unique(it) } }
 
+    // if this will be shown in Civilopedia
+    var showInPedia = true
+
     /**
      * The bonus stats that a resource gets when this building is built
      */

--- a/core/src/com/unciv/models/ruleset/Difficulty.kt
+++ b/core/src/com/unciv/models/ruleset/Difficulty.kt
@@ -33,6 +33,9 @@ class Difficulty: INamed {
     var turnBarbariansCanEnterPlayerTiles = 0
     var clearBarbarianCampReward = 25
 
+    // if this will be shown in Civilopedia
+    var showInPedia = true
+
     init {
         // For compatibility with old mods that use deprecated var aiFreeUnits and do not have startingUnits, aiCityStateStartingUnits, aiMajorCivStartingUnits
         if (startingUnits.isEmpty()) {

--- a/core/src/com/unciv/models/ruleset/Nation.kt
+++ b/core/src/com/unciv/models/ruleset/Nation.kt
@@ -67,6 +67,9 @@ class Nation : INamed {
     @Transient
     var embarkDisembarkCosts1 = false
 
+    // if this will be shown in Civilopedia
+    var showInPedia = true
+
     fun setTransients() {
         outerColorObject = colorFromRGB(outerColor[0], outerColor[1], outerColor[2])
 

--- a/core/src/com/unciv/models/ruleset/tech/Technology.kt
+++ b/core/src/com/unciv/models/ruleset/tech/Technology.kt
@@ -20,6 +20,9 @@ class Technology {
     var row: Int = 0
     var quote = ""
 
+    // if this will be shown in Civilopedia
+    var showInPedia = true
+
     fun getDescription(ruleset: Ruleset): String {
         val lineList = ArrayList<String>() // more readable than StringBuilder, with same performance for our use-case
         for (unique in uniques) lineList += unique.tr()

--- a/core/src/com/unciv/models/ruleset/tile/Terrain.kt
+++ b/core/src/com/unciv/models/ruleset/tile/Terrain.kt
@@ -38,6 +38,9 @@ class Terrain : NamedStats() {
     var impassable = false
     var rough = false
 
+    // if this will be shown in Civilopedia
+    var showInPedia = true
+
 
     fun getColor(): Color { // Can't be a lazy initialize, because we play around with the resulting color with lerp()s and the like
         if (RGB == null) return Color.GOLD

--- a/core/src/com/unciv/models/ruleset/tile/TileImprovement.kt
+++ b/core/src/com/unciv/models/ruleset/tile/TileImprovement.kt
@@ -27,6 +27,9 @@ class TileImprovement : NamedStats() {
     var uniques = ArrayList<String>()
     val uniqueObjects:List<Unique> by lazy { uniques.map { Unique(it) } }
 
+    // if this will be shown in Civilopedia
+    var showInPedia = true
+
     val turnsToBuild: Int = 0 // This is the base cost.
 
     fun getTurnsToBuild(civInfo: CivilizationInfo): Int {

--- a/core/src/com/unciv/models/ruleset/tile/TileResource.kt
+++ b/core/src/com/unciv/models/ruleset/tile/TileResource.kt
@@ -20,6 +20,9 @@ class TileResource : NamedStats() {
     var revealedBy: String? = null
     var unique: String? = null
 
+    // if this will be shown in Civilopedia
+    var showInPedia = true
+
 
     fun getDescription(ruleset: Ruleset): String {
         val stringBuilder = StringBuilder()

--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -39,6 +39,9 @@ class BaseUnit : INamed, IConstruction {
     var uniqueTo:String?=null
     var attackSound:String?=null
 
+    // if this will be shown in Civilopedia
+    var showInPedia = true
+
 
     fun getShortDescription(): String {
         val infoList = mutableListOf<String>()

--- a/core/src/com/unciv/models/ruleset/unit/Promotion.kt
+++ b/core/src/com/unciv/models/ruleset/unit/Promotion.kt
@@ -13,6 +13,9 @@ class Promotion : INamed{
     val unique:Unique by lazy { Unique(effect) }
     var unitTypes = listOf<String>() // The json parser wouldn't agree to deserialize this as a list of UnitTypes. =(
 
+    // if this will be shown in Civilopedia
+    var showInPedia = true
+
     fun getDescription(promotionsForUnitType: Collection<Promotion>, forCivilopedia:Boolean=false, ruleSet:Ruleset? = null):String {
         // we translate it before it goes in to get uniques like "vs units in rough terrain" and after to get "vs city
         val stringBuilder = StringBuilder()

--- a/core/src/com/unciv/ui/CivilopediaScreen.kt
+++ b/core/src/com/unciv/ui/CivilopediaScreen.kt
@@ -49,28 +49,36 @@ class CivilopediaScreen(ruleset: Ruleset) : CameraStageBaseScreen() {
         onBackButtonClicked { UncivGame.Current.setWorldScreen() }
 
         categoryToEntries["Buildings"] = ruleset.buildings.values
+                .filter { it.showInPedia  }
                 .map { CivilopediaEntry(it.name,it.getDescription(false, null,ruleset),
                         ImageGetter.getConstructionImage(it.name).surroundWithCircle(50f)) }
         categoryToEntries["Resources"] = ruleset.tileResources.values
+                .filter { it.showInPedia  }
                 .map { CivilopediaEntry(it.name,it.getDescription(ruleset),
                         ImageGetter.getResourceImage(it.name,50f)) }
         categoryToEntries["Terrains"] = ruleset.terrains.values
+                .filter { it.showInPedia  }
                 .map { CivilopediaEntry(it.name,it.getDescription(ruleset),
                         terrainImage(it, ruleset) ) }
         categoryToEntries["Tile Improvements"] = ruleset.tileImprovements.values
+                .filter { it.showInPedia  }
                 .map { CivilopediaEntry(it.name,it.getDescription(ruleset,false),
                         ImageGetter.getImprovementIcon(it.name,50f)) }
         categoryToEntries["Units"] = ruleset.units.values
+                .filter { it.showInPedia  }
                 .map { CivilopediaEntry(it.name,it.getDescription(false),
                         ImageGetter.getConstructionImage(it.name).surroundWithCircle(50f)) }
         categoryToEntries["Nations"] = ruleset.nations.values
+                .filter { it.showInPedia  }
                 .filter { it.isMajorCiv() }
                 .map { CivilopediaEntry(it.name,it.getUniqueString(ruleset,false),
                         ImageGetter.getNationIndicator(it,50f)) }
         categoryToEntries["Technologies"] = ruleset.technologies.values
+                .filter { it.showInPedia  }
                 .map { CivilopediaEntry(it.name,it.getDescription(ruleset),
                         ImageGetter.getTechIconGroup(it.name,50f)) }
         categoryToEntries["Promotions"] = ruleset.unitPromotions.values
+                .filter { it.showInPedia  }
                 .map { CivilopediaEntry(it.name,it.getDescription(ruleset.unitPromotions.values, true, ruleset),
                         Table().apply { add(ImageGetter.getPromotionIcon(it.name)) }) }
 
@@ -78,6 +86,7 @@ class CivilopediaScreen(ruleset: Ruleset) : CameraStageBaseScreen() {
                 .map { CivilopediaEntry(it.key.replace("_"," "), it.value.joinToString("\n\n") { line -> line.tr() }) }
 
         categoryToEntries["Difficulty levels"] = ruleset.difficulties.values
+                .filter { it.showInPedia  }
                 .map { CivilopediaEntry(it.name, it.getDescription()) }
 
         val buttonTable = Table()


### PR DESCRIPTION
This allows mods to make items in all categories besides tutorials to not appear in Civilopedia, but still exist in the data of the game.

In vanilla Civ 5 this was made deliberately possibly by the devs because they put in a "ShowInPedia" attribute.
These code modifications will be useful for "overhaul" mods.

In addition to wanting this for my own mods, there are other modders in the discord community who would want it for their overhaul mods.

For examples:
A fantasy world mod where advanced technology doesn't exist (and so doesn't have oil wells, uranium, promotions for aircraft, etc)
A mod where certain nations can't build certain units or buildings, by using an unbuildable replacement unit/building that is not shown in the Civilopedia. 

The attribute for the json files is this:

"showInPedia" - Controls whether they are shown in the Civilopedia. default is true

Here is a mod to test this.
https://cdn.discordapp.com/attachments/670547794951405584/757388324586651688/Test_Hide_In_Civilopedia.zip

This mod hides Anti-Aircraft Gun unit, hides Angkor Wat wonder, Agriculture technology, Trading post improvement, Krakotoa terrain, Cattle resource, Chieftain difficulty, Babylon nation and Heal Instantly promotion from Civilopedia.