### PR TITLE
Hide Unit or Building as Unique

### DIFF
--- a/core/src/com/unciv/models/ruleset/Building.kt
+++ b/core/src/com/unciv/models/ruleset/Building.kt
@@ -46,10 +46,6 @@ class Building : NamedStats(), IConstruction {
      */
     var resourceBonusStats: Stats? = null
 
-    // whether to show it as a nation's unique
-    var showAsUnique = true
-
-
     fun getShortDescription(ruleset: Ruleset): String { // should fit in one line
         val infoList= mutableListOf<String>()
         val str = getStats(null).toString()

--- a/core/src/com/unciv/models/ruleset/Building.kt
+++ b/core/src/com/unciv/models/ruleset/Building.kt
@@ -46,6 +46,9 @@ class Building : NamedStats(), IConstruction {
      */
     var resourceBonusStats: Stats? = null
 
+    // whether to show it as a nation's unique
+    var showAsUnique = true
+
 
     fun getShortDescription(ruleset: Ruleset): String { // should fit in one line
         val infoList= mutableListOf<String>()

--- a/core/src/com/unciv/models/ruleset/Nation.kt
+++ b/core/src/com/unciv/models/ruleset/Nation.kt
@@ -114,7 +114,7 @@ class Nation : INamed {
 
     private fun addUniqueBuildingsText(textList: ArrayList<String>, ruleset: Ruleset) {
         for (building in ruleset.buildings.values
-                .filter { it.uniqueTo == name && it.showAsUnique }) {
+                .filter { it.uniqueTo == name && "Will not be displayed in Civilopedia" !in it.uniques}) {
             if (building.replaces == null) textList += building.getShortDescription(ruleset)
             else {
                 val originalBuilding = ruleset.buildings[building.replaces!!]!!
@@ -142,7 +142,7 @@ class Nation : INamed {
 
     private fun addUniqueUnitsText(textList: ArrayList<String>, ruleset: Ruleset) {
         for (unit in ruleset.units.values
-                .filter { it.uniqueTo == name && it.showAsUnique }) {
+                .filter { it.uniqueTo == name && "Will not be displayed in Civilopedia" !in it.uniques}) {
             if (unit.replaces != null) {
                 val originalUnit = ruleset.units[unit.replaces!!]!!
                 textList += unit.name.tr() + " - " + "Replaces [${originalUnit.name}]".tr()

--- a/core/src/com/unciv/models/ruleset/Nation.kt
+++ b/core/src/com/unciv/models/ruleset/Nation.kt
@@ -114,7 +114,7 @@ class Nation : INamed {
 
     private fun addUniqueBuildingsText(textList: ArrayList<String>, ruleset: Ruleset) {
         for (building in ruleset.buildings.values
-                .filter { it.uniqueTo == name }) {
+                .filter { it.uniqueTo == name && it.showAsUnique }) {
             if (building.replaces == null) textList += building.getShortDescription(ruleset)
             else {
                 val originalBuilding = ruleset.buildings[building.replaces!!]!!
@@ -142,7 +142,7 @@ class Nation : INamed {
 
     private fun addUniqueUnitsText(textList: ArrayList<String>, ruleset: Ruleset) {
         for (unit in ruleset.units.values
-                .filter { it.uniqueTo == name }) {
+                .filter { it.uniqueTo == name && it.showAsUnique }) {
             if (unit.replaces != null) {
                 val originalUnit = ruleset.units[unit.replaces!!]!!
                 textList += unit.name.tr() + " - " + "Replaces [${originalUnit.name}]".tr()

--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -39,9 +39,6 @@ class BaseUnit : INamed, IConstruction {
     var uniqueTo:String?=null
     var attackSound:String?=null
 
-    // whether to show it as a nation's unique
-    var showAsUnique = true
-
     fun getShortDescription(): String {
         val infoList = mutableListOf<String>()
         if (strength != 0) infoList += "$strength${Fonts.strength}"

--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -39,6 +39,8 @@ class BaseUnit : INamed, IConstruction {
     var uniqueTo:String?=null
     var attackSound:String?=null
 
+    // whether to show it as a nation's unique
+    var showAsUnique = true
 
     fun getShortDescription(): String {
         val infoList = mutableListOf<String>()

--- a/core/src/com/unciv/ui/CivilopediaScreen.kt
+++ b/core/src/com/unciv/ui/CivilopediaScreen.kt
@@ -49,6 +49,7 @@ class CivilopediaScreen(ruleset: Ruleset) : CameraStageBaseScreen() {
         onBackButtonClicked { UncivGame.Current.setWorldScreen() }
 
         categoryToEntries["Buildings"] = ruleset.buildings.values
+                .filter { "Will not be displayed in Civilopedia" !in it.uniques }
                 .map { CivilopediaEntry(it.name,it.getDescription(false, null,ruleset),
                         ImageGetter.getConstructionImage(it.name).surroundWithCircle(50f)) }
         categoryToEntries["Resources"] = ruleset.tileResources.values
@@ -61,6 +62,7 @@ class CivilopediaScreen(ruleset: Ruleset) : CameraStageBaseScreen() {
                 .map { CivilopediaEntry(it.name,it.getDescription(ruleset,false),
                         ImageGetter.getImprovementIcon(it.name,50f)) }
         categoryToEntries["Units"] = ruleset.units.values
+                .filter { "Will not be displayed in Civilopedia" !in it.uniques }
                 .map { CivilopediaEntry(it.name,it.getDescription(false),
                         ImageGetter.getConstructionImage(it.name).surroundWithCircle(50f)) }
         categoryToEntries["Nations"] = ruleset.nations.values


### PR DESCRIPTION
This allows for unique unit or building not to be displayed as a unique on the nation select screen and nation civilopedia entry.

The primary usage of this to allow modders to avoid having their dummy unit/building that is used to disallow a nation from making the unit/building it replaces, from appearing as a unique to the player. In other words, it won't show the comparison stats/etc. 

In conjunction with this PR https://github.com/yairm210/Unciv/pull/3180 (which lets modders hide units/buildings/etc from Civilopedia) it allows modders to cleanly disallow nations from making certain units/buildings.

This would also be useful for Venice from the Brave New World expansion as it cannot build Settlers. https://civilization.fandom.com/wiki/Venetian_(Civ5)

Here is a mod to test this PR:
https://cdn.discordapp.com/attachments/670547794951405584/758550228126793759/Test_Hide_As_Unique.zip

This mod disallows Babylon from making Scout and Horseman and also doesn't show the dummy replacement unit/building on Babylon's nation info.
It also makes Babylon have a unique Monument replacement that it can build, but is still not shown as a unique on Babylon's nation info.
It also adds an example Venice nation that can't build Settlers.