### PR TITLE
Missing quests implemented

### DIFF
--- a/android/assets/jsons/Civ V - Vanilla/Quests.json
+++ b/android/assets/jsons/Civ V - Vanilla/Quests.json
@@ -4,7 +4,6 @@
     "description": "Build a road to connect your capital to our city.",
     "influence": 50
   },
-  /*
   {
     "name": "Kill Camp",
     "description": "We feel threatened by a Barbarian Camp near our city. Please take care of it.",
@@ -15,11 +14,11 @@
   {
     "name": "Connect Resource",
     "description": "In order to make our civilizations stronger, connect [Resource] to your trade network."
-  },*/
+  },
   {
     "name": "Construct Wonder",
     "description": "We recommend you to start building [Wonder] to show the whole world your civilization strength."
-  },/*
+  },
   {
     "name": "Great Person",
     "description": "Great People can change the course of a Civilization! You will be rewarded for acquiring a new [Great Person]."
@@ -37,7 +36,7 @@
   {
     "name": "Find Natural Wonder",
     "description": "Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [Natural Wonder] yet."
-  },*/
+  },
   /* G&K */
   /*
   {
@@ -53,14 +52,13 @@
     "duration": 30
   },
   */
-  /*
   {
     "name": "Contest Culture",
     "description": "The civilization with the largest Culture growth will gain a reward.",
     "type": "Global",
     "duration": 30,
     "minimumCivs": 3
-  },*/
+  },
   /*
   {
     "name": "Contest Faith",

--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -238,6 +238,16 @@ class GameInfo {
                 .forEach { it.addNotification("A new barbarian encampment has spawned!", tile.position, Color.RED) }
     }
 
+    fun notifyCityStatesOfBarbarianEncampmentCleared(killer: CivilizationInfo, target: TileInfo) {
+        for (cityState in getAliveCityStates())
+            cityState.questManager.campKillNotification(killer, target)
+    }
+
+    fun notifyCityStatesOfConquest(killer: CivilizationInfo, target: CivilizationInfo) {
+        for (cityState in getAliveCityStates())
+            cityState.questManager.cityStateKillNotification(killer, target)
+    }
+
     // All cross-game data which needs to be altered (e.g. when removing or changing a name of a building/tech)
     // will be done here, and not in CivInfo.setTransients or CityInfo
     fun setTransients() {

--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -267,6 +267,8 @@ object Battle {
 
         attackerCiv.addNotification("We have conquered the city of [${city.name}]!", city.location, Color.RED)
 
+        attackerCiv.gameInfo.notifyCityStatesOfConquest(attackerCiv, city.civInfo)
+
         city.getCenterTile().apply {
             if(militaryUnit!=null) militaryUnit!!.destroy()
             if(civilianUnit!=null) captureCivilianUnit(attacker, MapUnitCombatant(civilianUnit!!))

--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -168,8 +168,8 @@ class CivilizationInfo {
 
     fun getViewableResources(): Sequence<TileResource> =
             gameInfo.ruleSet.tileResources.values
-                    .filter { it.revealedBy == null || tech.isResearched(it.revealedBy!!) }
                     .asSequence()
+                    .filter { it.revealedBy == null || tech.isResearched(it.revealedBy!!) }
 
     fun isCapitalConnectedToCity(city: CityInfo): Boolean = citiesConnectedToCapitalToMediums.keys.contains(city)
 

--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -138,6 +138,7 @@ class CivilizationInfo {
     fun isMajorCiv() = nation.isMajorCiv()
     fun isAlive(): Boolean = !isDefeated()
     fun hasEverBeenFriendWith(otherCiv: CivilizationInfo): Boolean = getDiplomacyManager(otherCiv).everBeenFriends()
+    fun hasMetCivTerritory(otherCiv: CivilizationInfo) = exploredTiles.any { gameInfo.tileMap[it].getOwner() == otherCiv }
 
     fun victoryType(): VictoryType {
         if(gameInfo.gameParameters.victoryTypes.size==1)
@@ -164,6 +165,11 @@ class CivilizationInfo {
             newResourceSupplyList.add(resourceSupply.resource,resourceSupply.amount,"All")
         return newResourceSupplyList
     }
+
+    fun getViewableResources(): Sequence<TileResource> =
+            gameInfo.ruleSet.tileResources.values
+                    .filter { it.revealedBy == null || tech.isResearched(it.revealedBy!!) }
+                    .asSequence()
 
     fun isCapitalConnectedToCity(city: CityInfo): Boolean = citiesConnectedToCapitalToMediums.keys.contains(city)
 
@@ -193,6 +199,8 @@ class CivilizationInfo {
 
     //region Units
     fun getCivUnits(): Sequence<MapUnit> = units.asSequence()
+    fun getCivGreatPeople(): Sequence<MapUnit> =
+            getCivUnits().filter { mapUnit -> mapUnit.baseUnit.uniques.any { it.equalsPlaceholderText("Great Person - []") } }
 
     fun addUnit(mapUnit: MapUnit, updateCivInfo:Boolean=true){
         val newList = ArrayList(units)

--- a/core/src/com/unciv/logic/civilization/PolicyManager.kt
+++ b/core/src/com/unciv/logic/civilization/PolicyManager.kt
@@ -19,6 +19,8 @@ class PolicyManager {
 
     var freePolicies = 0
     var storedCulture = 0
+    /** Logs the total amount of culture generated */
+    var totalAccumulatedCulture = 0
     internal val adoptedPolicies = HashSet<String>()
     var numberOfAdoptedPolicies = 0
     var shouldOpenPolicyPicker = false
@@ -33,6 +35,7 @@ class PolicyManager {
         toReturn.freePolicies = freePolicies
         toReturn.shouldOpenPolicyPicker = shouldOpenPolicyPicker
         toReturn.storedCulture = storedCulture
+        toReturn.totalAccumulatedCulture = totalAccumulatedCulture
         toReturn.legalismState.putAll(legalismState)
         toReturn.autocracyCompletedTurns = autocracyCompletedTurns
         return toReturn
@@ -60,6 +63,7 @@ class PolicyManager {
     fun addCulture(culture: Int){
         val couldAdoptPolicyBefore = canAdoptPolicy()
         storedCulture += culture
+        totalAccumulatedCulture += culture
         if (!couldAdoptPolicyBefore && canAdoptPolicy())
             shouldOpenPolicyPicker = true
     }

--- a/core/src/com/unciv/logic/civilization/QuestManager.kt
+++ b/core/src/com/unciv/logic/civilization/QuestManager.kt
@@ -79,7 +79,7 @@ class QuestManager {
 
         decrementQuestCountdowns()
 
-        handleGlobalQuests()
+        handleExpiredGlobalQuests()
         handleIndividualQuests()
 
         tryStartNewGlobalQuest()
@@ -208,13 +208,13 @@ class QuestManager {
         }
     }
 
-    private fun handleGlobalQuests() {
+    private fun handleExpiredGlobalQuests() {
         val globalQuestsExpired = assignedQuests.filter { it.isGlobal() && it.isExpired() }.map { it.questName }.distinct()
         for (globalQuestName in globalQuestsExpired)
-            handleGlobalQuest(globalQuestName)
+            handleExpiredGlobalQuest(globalQuestName)
     }
 
-    private fun handleGlobalQuest(questName: String) {
+    private fun handleExpiredGlobalQuest(questName: String) {
         val quests = assignedQuests.filter { it.questName == questName }
         if (quests.isEmpty())
             return

--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -533,6 +533,9 @@ class MapUnit {
 
         civInfo.gold += goldGained.toInt()
         civInfo.addNotification("We have captured a barbarian encampment and recovered [${goldGained.toInt()}] gold!", tile.position, Color.RED)
+
+        // Notify City States that someone cleared this camp to dispatch quest rewards
+        civInfo.gameInfo.notifyCityStatesOfBarbarianEncampmentCleared(civInfo, tile)
     }
 
     fun disband() {

--- a/core/src/com/unciv/logic/map/TileInfo.kt
+++ b/core/src/com/unciv/logic/map/TileInfo.kt
@@ -330,6 +330,7 @@ open class TileInfo {
     }
 
     fun hasImprovementInProgress() = improvementInProgress != null
+    fun hasBarbarianEncampment(): Boolean = improvement == Constants.barbarianEncampment
 
     @delegate:Transient
     private val _isCoastalTile: Boolean by lazy { neighbors.any { it.baseTerrain == Constants.coast } }

--- a/core/src/com/unciv/logic/map/TileMap.kt
+++ b/core/src/com/unciv/logic/map/TileMap.kt
@@ -18,6 +18,7 @@ class TileMap {
     @Transient var bottomY = 0
     @delegate:Transient val maxLatitude: Float by lazy { if (values.isEmpty()) 0f else values.map { abs(it.latitude) }.max()!! }
     @delegate:Transient val maxLongitude: Float by lazy { if (values.isEmpty()) 0f else values.map { abs(it.longitude) }.max()!! }
+    @Transient val naturalWonders = ArrayList<String>()
 
     var mapParameters = MapParameters()
 
@@ -268,6 +269,8 @@ class TileMap {
             tileInfo.ruleset = ruleset
             tileInfo.setTerrainTransients()
             tileInfo.setUnitTransients(setUnitCivTransients)
+            if (tileInfo.isNaturalWonder())
+                naturalWonders.add(tileInfo.naturalWonder!!)
         }
     }
 }

--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -88,6 +88,13 @@ class BaseUnit : INamed, IConstruction {
         return unit
     }
 
+    fun getThisOrReplacedBaseUnit(ruleset: Ruleset): BaseUnit {
+        if (replaces != null)
+            return ruleset.units[replaces!!]!!
+        else
+            return ruleset.units[name]!!
+    }
+
     override fun canBePurchased() = "Cannot be purchased" !in uniques
 
     override fun getProductionCost(civInfo: CivilizationInfo): Int {


### PR DESCRIPTION
Follow up on #3183 

* Kill City States: required a special notification (`GameInfo.notifyCityStateOfConquest` and `QuestManager.cityStateKillNotification`) to all city states because it is impossible to infer from game state if the player that controls the city state is the one who conquered it as first.

* Kill Barbarian Camp: required a special notification (`GameInfo.notifyCityStateOfBarbarianEncampmentCleared` and `QuestManager.campKillNotification`) to all city states because it is impossible to infer from game state if the camp was cleared by the quest assignee.

* Find Player: introduced utility function `CivilizationInfo.hasMetCivTerritory` to check if the civilization can see any territory of an other civilization.

* Connect Resource: introduced utility function `CivilizationInfo.getViewableResources` to get a `Sequence` of `TileResource`s that the player is able to see.

* Great Person: introduced utility function `CivilizationInfo.getCivGreatPeople` to get a `Sequence` of Great People `BaseUnit`s of the civilization. Added `BaseUnit.getThisOrReplacedBaseUnit` to return the Great Person itself or the unit it replaces, if any. It is needed to check quest completeness if the Great Person to be acquired is replaced by a unique one (i.e. Mongolia)

* Contest Culture: in order to keep track of the culture accumulated during the quest, introduced a variable `PolicyManager.totalAccumulatedCulture` that stores the whole amount of culture generated during a game.

* Find Natural Wonder: added a transient variable `TileMap.naturalWonders` to have a list of `NaturalWonder`s for the game. It would be inefficient to check all `TileInfo`s to get this information every time it is needed.