### PR TITLE
resourceIsVisible to be checked before getting tile resource

### DIFF
--- a/core/src/com/unciv/logic/map/TileInfo.kt
+++ b/core/src/com/unciv/logic/map/TileInfo.kt
@@ -315,7 +315,7 @@ open class TileInfo {
             improvement.hasUnique("Can also be built on tiles adjacent to fresh water")
                     && isAdjacentToFreshwater -> true
             "Can only be built on Coastal tiles" in improvement.uniques && isCoastalTile() -> true
-            else -> getTileResource().improvement == improvement.name && resourceIsVisible
+            else -> resourceIsVisible && getTileResource().improvement == improvement.name
         }
     }
 


### PR DESCRIPTION
.. to prevent a potential `NullPointerException` when `resource = null`