### PR TITLE
Patch of the promotion exploit

### DIFF
--- a/core/src/com/unciv/ui/pickerscreens/PromotionPickerScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/PromotionPickerScreen.kt
@@ -4,7 +4,6 @@ import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.scenes.scene2d.Touchable
 import com.badlogic.gdx.scenes.scene2d.ui.Button
 import com.badlogic.gdx.scenes.scene2d.ui.Table
-import com.badlogic.gdx.scenes.scene2d.ui.VerticalGroup
 import com.badlogic.gdx.utils.Align
 import com.unciv.UncivGame
 import com.unciv.logic.map.MapUnit
@@ -17,13 +16,17 @@ import com.unciv.ui.utils.*
 class PromotionPickerScreen(val unit: MapUnit) : PickerScreen() {
     private var selectedPromotion: Promotion? = null
 
+    private fun acceptPromotion(promotion: Promotion?) {
+        // if user managed to click disabled button, still do nothing
+        if (promotion == null) return
 
-    fun acceptPromotion(promotion: Promotion?) {
-        unit.promotions.addPromotion(promotion!!.name)
-        if(unit.promotions.canBePromoted()) game.setScreen(PromotionPickerScreen(unit))
-        else game.setWorldScreen()
+        unit.promotions.addPromotion(promotion.name)
+        if (unit.promotions.canBePromoted())
+            game.setScreen(PromotionPickerScreen(unit))
+        else
+            game.setWorldScreen()
         dispose()
-        game.worldScreen.shouldUpdate=true
+        game.worldScreen.shouldUpdate = true
     }
 
     init {
@@ -37,7 +40,7 @@ class PromotionPickerScreen(val unit: MapUnit) : PickerScreen() {
         }
         val canBePromoted = unit.promotions.canBePromoted()
         val canChangeState = game.worldScreen.canChangeState
-        if(!canBePromoted || !canChangeState)
+        if (!canBePromoted || !canChangeState)
             rightSideButton.disable()
 
         val availablePromotionsGroup = Table()
@@ -59,10 +62,13 @@ class PromotionPickerScreen(val unit: MapUnit) : PickerScreen() {
             selectPromotionButton.add(promotion.name.toLabel()).pad(10f).padRight(20f)
             selectPromotionButton.touchable = Touchable.enabled
             selectPromotionButton.onClick {
-                if(canBePromoted && isPromotionAvailable && !unitHasPromotion && canChangeState)
+                if(canBePromoted && isPromotionAvailable && !unitHasPromotion && canChangeState) {
+                    selectedPromotion = promotion
                     rightSideButton.enable()
-                else rightSideButton.disable()
-                selectedPromotion = promotion
+                } else {
+                    selectedPromotion = null
+                    rightSideButton.disable()
+                }
                 rightSideButton.setText(promotion.name.tr())
 
                 descriptionLabel.setText(promotion.getDescription(promotionsForUnitType))
@@ -70,7 +76,7 @@ class PromotionPickerScreen(val unit: MapUnit) : PickerScreen() {
 
             availablePromotionsGroup.add(selectPromotionButton)
 
-            if(canBePromoted && isPromotionAvailable && canChangeState) {
+            if (canBePromoted && isPromotionAvailable && canChangeState) {
                 val pickNow = "Pick now!".toLabel()
                 pickNow.setAlignment(Align.center)
                 pickNow.onClick {
@@ -78,7 +84,7 @@ class PromotionPickerScreen(val unit: MapUnit) : PickerScreen() {
                 }
                 availablePromotionsGroup.add(pickNow).padLeft(10f).fillY()
             }
-            else if(unitHasPromotion) selectPromotionButton.color= Color.GREEN
+            else if (unitHasPromotion) selectPromotionButton.color = Color.GREEN
             else selectPromotionButton.color= Color.GRAY
 
             availablePromotionsGroup.row()


### PR DESCRIPTION
This PR resolves #2954 .

The problem was that both buttons (illegal promotion and apply) have been clicked together.
While the mechanism of disabling button is slow, the assignment of `selectedPromotion` is really quick, so the handler of the button could already work with assigned value.

After the fix, there can be several scenarios in such case:
1) The "apply" button has been disabled (cheater was too slow) - nothing happens since it is disabled and `selectedPromotion` is set to null.
2) The "apply" button is still enabled, but the `selectedPromotion` is already set to null - nothing happens again.
3) The "apply" button is still enabled, and the `selectedPromotion` is not updated yet  - the previously selected legal promotion will be applied (same as if illegal promotion was not clicked at all).
As for me, all three scenarios are acceptable.