### PR TITLE
The land is view obstacle from the sea

### DIFF
--- a/core/src/com/unciv/logic/map/TileInfo.kt
+++ b/core/src/com/unciv/logic/map/TileInfo.kt
@@ -130,6 +130,7 @@ open class TileInfo {
     // and the toSequence so that aggregations (like neighbors.flatMap{it.units} don't take up their own space
 
     fun getHeight(): Int {
+        if (isWater) return -1
         if (baseTerrain == Constants.mountain) return 4
         if (isHill()) return 2
         if (terrainFeature == Constants.forest || terrainFeature == Constants.jungle) return 1

--- a/core/src/com/unciv/logic/map/TileMap.kt
+++ b/core/src/com/unciv/logic/map/TileMap.kt
@@ -196,16 +196,18 @@ class TileMap {
                 /*
             Okay so, if we're looking at a tile from a to c with b in the middle,
             we have several scenarios:
-            1. a>b -  - I can see everything, b does not hide c
+            1. a>b
+                1.1. a>b, a>c - I can see everything, b does not hide c
+                1.2. a>b, a==c - pitfall between a and c, no hiding
             2. a==b
-                2.1 a==b==0, all flat ground, no hiding
+                2.1 a==b==c, all flat ground or water, no hiding
                 2.2 a>0, b>=c - b hides c from view (say I am in a forest/jungle and b is a forest/jungle, or hill)
                 2.3 a>0, c>b - c is tall enough I can see it over b!
             3. a<b
                 3.1 b>=c - b hides c
                 3.2 b<c - c is tall enough I can see it over b!
 
-            This can all be summed up as "I can see c if a>b || c>b || b==0 "
+            This can all be summed up as "I can see c if a>b || c>b || a==c && a>=b "
             */
 
                 val containsViewableNeighborThatCanSeeOver = tile.neighbors.any {
@@ -213,7 +215,7 @@ class TileMap {
                     viewableTiles.contains(it) && (
                             currentTileHeight > neighborHeight // a>b
                                     || targetTileHeight > neighborHeight // c>b
-                                    || neighborHeight == 0) // b==0
+                                    || neighborHeight <= currentTileHeight && currentTileHeight == targetTileHeight) // a==c && a>=b
                 }
                 if (containsViewableNeighborThatCanSeeOver) tilesToAddInDistanceI.add(tile)
             }

--- a/tests/src/com/unciv/logic/map/TileMapTests.kt
+++ b/tests/src/com/unciv/logic/map/TileMapTests.kt
@@ -1,0 +1,201 @@
+package com.unciv.logic.map
+
+import com.badlogic.gdx.math.Vector2
+import com.unciv.Constants
+import com.unciv.models.ruleset.Ruleset
+import com.unciv.models.ruleset.RulesetCache
+import com.unciv.testing.GdxTestRunner
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(GdxTestRunner::class)
+class TileMapTests {
+
+    private var map = TileMap()
+    private var tile1 = TileInfo()
+    private var tile2 = TileInfo()
+    private var tile3 = TileInfo()
+    private var ruleSet = Ruleset()
+
+    @Before
+    fun initTheWorld() {
+        RulesetCache.loadRulesets()
+        ruleSet = RulesetCache.getBaseRuleset()
+        map = TileMap()
+
+        tile1.position = Vector2(0f, 0f)
+        tile1.tileMap = map
+        tile1.ruleset = ruleSet
+
+        tile2.position = Vector2(0f, 1f)
+        tile2.tileMap = map
+        tile2.ruleset = ruleSet
+
+        tile3.position = Vector2(0f, 2f)
+        tile3.tileMap = map
+        tile3.ruleset = ruleSet
+
+        map.tileMatrix.add(arrayListOf(tile1, tile2, tile3))
+    }
+
+    @Test
+    fun canSeeOnFlatGround() {
+        tile1.baseTerrain = Constants.grassland
+        tile1.setTerrainTransients()
+        tile2.baseTerrain = Constants.desert
+        tile2.setTerrainTransients()
+        tile3.baseTerrain = Constants.snow
+        tile3.setTerrainTransients()
+
+        val visibleTiles = map.getViewableTiles(tile1.position,2)
+        Assert.assertTrue(tile2 in visibleTiles)
+        Assert.assertTrue(tile3 in visibleTiles)
+    }
+
+    @Test
+    fun canSeeOnFlatWater() {
+        tile1.baseTerrain = Constants.ocean
+        tile1.setTerrainTransients()
+        tile2.baseTerrain = Constants.coast
+        tile2.setTerrainTransients()
+        tile3.baseTerrain = Constants.ocean
+        tile3.setTerrainTransients()
+
+        val visibleTiles = map.getViewableTiles(tile1.position,2)
+        Assert.assertTrue(tile2 in visibleTiles)
+        Assert.assertTrue(tile3 in visibleTiles)
+    }
+
+    @Test
+    fun canSeeFromHills() {
+        tile1.baseTerrain = Constants.hill
+        tile1.setTerrainTransients()
+        tile2.baseTerrain = Constants.grassland
+        tile2.setTerrainTransients()
+        tile3.baseTerrain = Constants.coast
+        tile3.setTerrainTransients()
+
+        val visibleTiles = map.getViewableTiles(tile1.position,2)
+        Assert.assertTrue(tile2 in visibleTiles)
+        Assert.assertTrue(tile3 in visibleTiles)
+    }
+
+    @Test
+    fun canSeeOverForestFromHills() {
+        tile1.baseTerrain = Constants.hill
+        tile1.setTerrainTransients()
+        tile2.baseTerrain = Constants.grassland
+        tile2.terrainFeature = Constants.forest
+        tile2.setTerrainTransients()
+        tile3.baseTerrain = Constants.coast
+        tile3.setTerrainTransients()
+
+        val visibleTiles = map.getViewableTiles(tile1.position,2)
+        Assert.assertTrue(tile2 in visibleTiles)
+        Assert.assertTrue(tile3 in visibleTiles)
+    }
+
+    @Test
+    fun canSeeMountainOverHills() {
+        tile1.baseTerrain = Constants.grassland
+        tile1.setTerrainTransients()
+        tile2.baseTerrain = Constants.hill
+        tile2.setTerrainTransients()
+        tile3.baseTerrain = Constants.mountain
+        tile3.setTerrainTransients()
+
+        val visibleTiles = map.getViewableTiles(tile1.position,2)
+        Assert.assertTrue(tile2 in visibleTiles)
+        Assert.assertTrue(tile3 in visibleTiles)
+    }
+
+    @Test
+    fun canSeeMountainFromForestOverHills() {
+        tile1.baseTerrain = Constants.grassland
+        tile1.terrainFeature = Constants.forest
+        tile1.setTerrainTransients()
+        tile2.baseTerrain = Constants.hill
+        tile2.setTerrainTransients()
+        tile3.baseTerrain = Constants.mountain
+        tile3.setTerrainTransients()
+
+        val visibleTiles = map.getViewableTiles(tile1.position,2)
+        Assert.assertTrue(tile2 in visibleTiles)
+        Assert.assertTrue(tile3 in visibleTiles)
+    }
+
+    @Test
+    fun canSeeHillsFromHills() {
+        tile1.baseTerrain = Constants.hill
+        tile1.setTerrainTransients()
+        tile2.baseTerrain = Constants.grassland
+        tile2.terrainFeature = Constants.forest
+        tile2.setTerrainTransients()
+        tile3.baseTerrain = Constants.hill
+        tile3.setTerrainTransients()
+
+        val visibleTiles = map.getViewableTiles(tile1.position,2)
+        Assert.assertTrue(tile2 in visibleTiles)
+        Assert.assertTrue(tile3 in visibleTiles)
+    }
+
+    @Test
+    fun canNOTSeeGrassOverHills() {
+        tile1.baseTerrain = Constants.grassland
+        tile1.setTerrainTransients()
+        tile2.baseTerrain = Constants.hill
+        tile2.setTerrainTransients()
+        tile3.baseTerrain = Constants.grassland
+        tile3.setTerrainTransients()
+
+        val visibleTiles = map.getViewableTiles(tile1.position,2)
+        Assert.assertTrue(tile2 in visibleTiles)
+        Assert.assertFalse(tile3 in visibleTiles)
+    }
+
+    @Test
+    fun canNOTSeeHillsOverHills() {
+        tile1.baseTerrain = Constants.grassland
+        tile1.setTerrainTransients()
+        tile2.baseTerrain = Constants.hill
+        tile2.setTerrainTransients()
+        tile3.baseTerrain = Constants.hill
+        tile3.setTerrainTransients()
+
+        val visibleTiles = map.getViewableTiles(tile1.position,2)
+        Assert.assertTrue(tile2 in visibleTiles)
+        Assert.assertFalse(tile3 in visibleTiles)
+    }
+
+    @Test
+    fun canNOTSeeOutThroughForest() {
+        tile1.baseTerrain = Constants.grassland
+        tile1.terrainFeature = Constants.forest
+        tile1.setTerrainTransients()
+        tile2.baseTerrain = Constants.grassland
+        tile2.terrainFeature = Constants.forest
+        tile2.setTerrainTransients()
+        tile3.baseTerrain = Constants.grassland
+        tile3.setTerrainTransients()
+
+        val visibleTiles = map.getViewableTiles(tile1.position,2)
+        Assert.assertTrue(tile2 in visibleTiles)
+        Assert.assertFalse(tile3 in visibleTiles)
+    }
+
+    @Test
+    fun canNOTSeeWaterOverLand() {
+        tile1.baseTerrain = Constants.coast
+        tile1.setTerrainTransients()
+        tile2.baseTerrain = Constants.grassland
+        tile2.setTerrainTransients()
+        tile3.baseTerrain = Constants.coast
+        tile3.setTerrainTransients()
+
+        val visibleTiles = map.getViewableTiles(tile1.position,2)
+        Assert.assertTrue(tile2 in visibleTiles)
+        Assert.assertFalse(tile3 in visibleTiles)
+    }
+}


### PR DESCRIPTION
This PR fixes #2863 .

Currently the land has the same height as water, however, in real world that's not true and the land is over the sea level.
In order to have the land as a view obstacle, I set the water level below the land as in real world.

The logic of the view checks are quite complicated, thus, having a goal to not break anything, I have implemented the set of unit tests for that.
