### PR TITLE
Promotions with multiple uniques

### DIFF
--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -132,7 +132,11 @@ class MapUnit {
         val uniques = ArrayList<Unique>()
         val baseUnit = baseUnit()
         uniques.addAll(baseUnit.uniqueObjects)
-        uniques.addAll(promotions.promotions.map { currentTile.tileMap.gameInfo.ruleSet.unitPromotions[it]!!.unique })
+
+        for (promotion in promotions.promotions) {
+            uniques.addAll(currentTile.tileMap.gameInfo.ruleSet.unitPromotions[promotion]!!.uniqueObjects)
+        }
+
         tempUniques = uniques
 
         ignoresTerrainCost = hasUnique("Ignores terrain cost")

--- a/core/src/com/unciv/models/ruleset/unit/Promotion.kt
+++ b/core/src/com/unciv/models/ruleset/unit/Promotion.kt
@@ -9,14 +9,19 @@ import com.unciv.models.translations.tr
 class Promotion : INamed{
     override lateinit var name: String
     var prerequisites = listOf<String>()
-    var effect=""
-    val unique:Unique by lazy { Unique(effect) }
+    var effect = ""
     var unitTypes = listOf<String>() // The json parser wouldn't agree to deserialize this as a list of UnitTypes. =(
+
+    var uniques = listOf<String>()
+    val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it) } + Unique(effect)  }
 
     fun getDescription(promotionsForUnitType: Collection<Promotion>, forCivilopedia:Boolean=false, ruleSet:Ruleset? = null):String {
         // we translate it before it goes in to get uniques like "vs units in rough terrain" and after to get "vs city
         val stringBuilder = StringBuilder()
-        stringBuilder.appendln(Translations.translateBonusOrPenalty(effect.tr()))
+
+        for (unique in uniques + effect) {
+            stringBuilder.appendln(Translations.translateBonusOrPenalty(unique))
+        }
 
         if(prerequisites.isNotEmpty()) {
             val prerequisitesString: ArrayList<String> = arrayListOf()


### PR DESCRIPTION
Problem: Some promotions in CIV 5 have multiple effects, but Unciv promotions only allow for one effect

Solution: This PR adds "uniques" field to allow for multiple promotion uniques, while keeping "effect" field so that rulesets prior to this PR can still work.