### PR TITLE
Pixel unit colors based on civilization colors

### DIFF
--- a/core/src/com/unciv/ui/tilegroups/TileGroup.kt
+++ b/core/src/com/unciv/ui/tilegroups/TileGroup.kt
@@ -53,9 +53,9 @@ open class TileGroup(var tileInfo: TileInfo, var tileSetStrings:TileSetStrings) 
     protected var naturalWonderImage: Image? = null
 
     protected var pixelMilitaryUnitImageLocation = ""
-    protected var pixelMilitaryUnitImage: Image? = null
+    protected var pixelMilitaryUnitGroup = Group().apply { isTransform = false; setSize(groupSize, groupSize) }
     protected var pixelCivilianUnitImageLocation = ""
-    protected var pixelCivilianUnitImage: Image? = null
+    protected var pixelCivilianUnitGroup = Group().apply { isTransform = false; setSize(groupSize, groupSize) }
 
     val miscLayerGroup = Group().apply { isTransform = false; setSize(groupSize, groupSize) }
     var resourceImage: Actor? = null
@@ -92,6 +92,9 @@ open class TileGroup(var tileInfo: TileInfo, var tileSetStrings:TileSetStrings) 
         this.addActor(unitLayerGroup)
         this.addActor(cityButtonLayerGroup)
         this.addActor(circleCrosshairFogLayerGroup)
+
+        terrainFeatureLayerGroup.addActor(pixelMilitaryUnitGroup)
+        terrainFeatureLayerGroup.addActor(pixelCivilianUnitGroup)
 
         updateTileImage(null)
 
@@ -597,15 +600,16 @@ open class TileGroup(var tileInfo: TileInfo, var tileSetStrings:TileSetStrings) 
         }
 
         if (pixelMilitaryUnitImageLocation != newImageLocation) {
-            pixelMilitaryUnitImage?.remove()
-            pixelMilitaryUnitImage = null
+            pixelMilitaryUnitGroup.clear()
             pixelMilitaryUnitImageLocation = newImageLocation
 
             if (newImageLocation != "" && ImageGetter.imageExists(newImageLocation)) {
-                val pixelUnitImage = ImageGetter.getImage(newImageLocation)
-                terrainFeatureLayerGroup.addActor(pixelUnitImage)
-                setHexagonImageSize(pixelUnitImage)// Treat this as A TILE, which gets overlayed on the base tile.
-                pixelMilitaryUnitImage = pixelUnitImage
+                val nation = militaryUnit!!.civInfo.nation
+                val pixelUnitImages = ImageGetter.getLayeredImageColored(newImageLocation, null, nation.getInnerColor(), nation.getOuterColor())
+                for (pixelUnitImage in pixelUnitImages) {
+                    pixelMilitaryUnitGroup.addActor(pixelUnitImage)
+                    setHexagonImageSize(pixelUnitImage)// Treat this as A TILE, which gets overlayed on the base tile.
+                }
             }
         }
     }
@@ -613,9 +617,10 @@ open class TileGroup(var tileInfo: TileInfo, var tileSetStrings:TileSetStrings) 
 
     fun updatePixelCivilianUnit(tileIsViewable: Boolean) {
         var newImageLocation = ""
+        val civilianUnit = tileInfo.civilianUnit
 
-        if (tileInfo.civilianUnit != null && tileIsViewable) {
-            val specificUnitIconLocation = tileSetStrings.unitsLocation + tileInfo.civilianUnit!!.name
+        if (civilianUnit != null && tileIsViewable) {
+            val specificUnitIconLocation = tileSetStrings.unitsLocation + civilianUnit.name
             newImageLocation = when {
                 !UncivGame.Current.settings.showPixelUnits -> ""
                 ImageGetter.imageExists(specificUnitIconLocation) -> specificUnitIconLocation
@@ -624,15 +629,16 @@ open class TileGroup(var tileInfo: TileInfo, var tileSetStrings:TileSetStrings) 
         }
 
         if (pixelCivilianUnitImageLocation != newImageLocation) {
-            pixelCivilianUnitImage?.remove()
-            pixelCivilianUnitImage = null
+            pixelCivilianUnitGroup.clear()
             pixelCivilianUnitImageLocation = newImageLocation
 
             if (newImageLocation != "" && ImageGetter.imageExists(newImageLocation)) {
-                val pixelUnitImage = ImageGetter.getImage(newImageLocation)
-                terrainFeatureLayerGroup.addActor(pixelUnitImage)
-                setHexagonImageSize(pixelUnitImage)// Treat this as A TILE, which gets overlayed on the base tile.
-                pixelCivilianUnitImage = pixelUnitImage
+                val nation = civilianUnit!!.civInfo.nation
+                val pixelUnitImages = ImageGetter.getLayeredImageColored(newImageLocation, null, nation.getInnerColor(), nation.getOuterColor())
+                for (pixelUnitImage in pixelUnitImages) {
+                    pixelCivilianUnitGroup.addActor(pixelUnitImage)
+                    setHexagonImageSize(pixelUnitImage)// Treat this as A TILE, which gets overlayed on the base tile.
+                }
             }
         }
     }

--- a/core/src/com/unciv/ui/utils/ImageGetter.kt
+++ b/core/src/com/unciv/ui/utils/ImageGetter.kt
@@ -96,9 +96,10 @@ object ImageGetter {
      *      GOLD and the third in RED.
      */
     fun getLayeredImageColored(baseFileName: String, vararg colors: Color?): ArrayList<Image> {
+        val regex = Regex("^$baseFileName(?>-\\d+)?$")
         val layerList = arrayListOf<Image>()
         val layers = textureRegionDrawables.keys
-                .filter { it.startsWith(baseFileName) }
+                .filter { regex.matches(it) }
                 .sorted()
 
         for (i in layers.indices) {

--- a/core/src/com/unciv/ui/utils/ImageGetter.kt
+++ b/core/src/com/unciv/ui/utils/ImageGetter.kt
@@ -77,33 +77,43 @@ object ImageGetter {
      * @param   colors          The list of colors, one per layer. No coloring is applied to layers
      *                              whose color is null.
      *
-     * @return  The list of layers colored. The layers are sorted by alphabetical order and colors
-     *              are applied, one per layer, in the same order. If a color is null, no coloring is
-     *              performed on such layer (it stays as it is). If there are less colors than layers,
-     *              the last layers are not colored. Defaults to an empty list if there is no layer
-     *              corresponding to baseFileName.
+     * @return  The list of layers colored. The layers are sorted by NUMBER (see example below) order
+     *              and colors are applied, one per layer, in the same order. If a color is null, no
+     *              coloring is performed on such layer (it stays as it is). If there are less colors
+     *              than layers, the last layers are not colored. Defaults to an empty list if there
+     *              is no layer corresponding to baseFileName.
      *
      * Example:
      *      getLayeredImageColored("TileSets/FantasyHex/Units/Warrior", null, Color.GOLD, Color.RED)
      *
      *      All images in the atlas that match the pattern "TileSets/FantasyHex/Units/Warrior" or
-     *      "TileSets/FantasyHex/Units/Warrior-NUMBER" are retrieved alphabetically:
+     *      "TileSets/FantasyHex/Units/Warrior-NUMBER" are retrieved. NUMBERs must start from 1 and
+     *      be incremented by 1 per layer. If the n-th NUMBER is missing, the (n-1)-th layer is the
+     *      last one retrieved:
+     *      Given the layer names:
      *          - TileSets/FantasyHex/Units/Warrior
      *          - TileSets/FantasyHex/Units/Warrior-1
-     *          - TileSets/FantasyHex/Units/Warrior-2983
-     *
-     *      It returns a list in which first layer has unmodified colors, the second is colored in
-     *      GOLD and the third in RED.
+     *          - TileSets/FantasyHex/Units/Warrior-2
+     *          - TileSets/FantasyHex/Units/Warrior-4
+     *      Only the base layer and layers 1 and 2 are retrieved.
+     *      The method returns then a list in which first layer has unmodified colors, the second is
+     *      colored in GOLD and the third in RED.
      */
     fun getLayeredImageColored(baseFileName: String, vararg colors: Color?): ArrayList<Image> {
-        val regex = Regex("^$baseFileName(?>-\\d+)?$")
-        val layerList = arrayListOf<Image>()
-        val layers = textureRegionDrawables.keys
-                .filter { regex.matches(it) }
-                .sorted()
+        if (!imageExists(baseFileName))
+            return arrayListOf()
 
-        for (i in layers.indices) {
-            val image = getImage(layers[i])
+        val layerNames = mutableListOf(baseFileName)
+        val layerList = arrayListOf<Image>()
+
+        var i = 1
+        while (imageExists("$baseFileName-$i")) {
+            layerNames.add("$baseFileName-$i")
+            ++i
+        }
+
+        for (i in layerNames.indices) {
+            val image = getImage(layerNames[i])
             if (i < colors.size && colors[i] != null)
                 image.color = colors[i]
             layerList.add(image)

--- a/core/src/com/unciv/ui/utils/ImageGetter.kt
+++ b/core/src/com/unciv/ui/utils/ImageGetter.kt
@@ -86,11 +86,11 @@ object ImageGetter {
      * Example:
      *      getLayeredImageColored("TileSets/FantasyHex/Units/Warrior", null, Color.GOLD, Color.RED)
      *
-     *      All images in the atlas that starts with "TileSets/FantasyHex/Units/Warrior" are retrieved
-     *      alphabetically:
+     *      All images in the atlas that match the pattern "TileSets/FantasyHex/Units/Warrior" or
+     *      "TileSets/FantasyHex/Units/Warrior-NUMBER" are retrieved alphabetically:
      *          - TileSets/FantasyHex/Units/Warrior
      *          - TileSets/FantasyHex/Units/Warrior-1
-     *          - TileSets/FantasyHex/Units/Warrior-2
+     *          - TileSets/FantasyHex/Units/Warrior-2983
      *
      *      It returns a list in which first layer has unmodified colors, the second is colored in
      *      GOLD and the third in RED.

--- a/core/src/com/unciv/ui/utils/ImageGetter.kt
+++ b/core/src/com/unciv/ui/utils/ImageGetter.kt
@@ -67,6 +67,50 @@ object ImageGetter {
         }
     }
 
+
+    /**
+     * Colors a multilayer image and returns it as a list of layers (Image).
+     *
+     * @param   baseFileName    The filename of the base image.
+     *                              For example: TileSets/FantasyHex/Units/Warrior
+     *
+     * @param   colors          The list of colors, one per layer. No coloring is applied to layers
+     *                              whose color is null.
+     *
+     * @return  The list of layers colored. The layers are sorted by alphabetical order and colors
+     *              are applied, one per layer, in the same order. If a color is null, no coloring is
+     *              performed on such layer (it stays as it is). If there are less colors than layers,
+     *              the last layers are not colored. Defaults to an empty list if there is no layer
+     *              corresponding to baseFileName.
+     *
+     * Example:
+     *      getLayeredImageColored("TileSets/FantasyHex/Units/Warrior", null, Color.GOLD, Color.RED)
+     *
+     *      All images in the atlas that starts with "TileSets/FantasyHex/Units/Warrior" are retrieved
+     *      alphabetically:
+     *          - TileSets/FantasyHex/Units/Warrior
+     *          - TileSets/FantasyHex/Units/Warrior-1
+     *          - TileSets/FantasyHex/Units/Warrior-2
+     *
+     *      It returns a list in which first layer has unmodified colors, the second is colored in
+     *      GOLD and the third in RED.
+     */
+    fun getLayeredImageColored(baseFileName: String, vararg colors: Color?): ArrayList<Image> {
+        val layerList = arrayListOf<Image>()
+        val layers = textureRegionDrawables.keys
+                .filter { it.startsWith(baseFileName) }
+                .sorted()
+
+        for (i in layers.indices) {
+            val image = getImage(layers[i])
+            if (i < colors.size && colors[i] != null)
+                image.color = colors[i]
+            layerList.add(image)
+        }
+
+        return layerList
+    }
+
     /*fun refreshAtlas() {
         atlas.dispose() // To avoid OutOfMemory exceptions
         atlas = TextureAtlas("game.atlas")


### PR DESCRIPTION
The idea is to have pixel unit sprites composed of 3 layers (it is not mandatory):
- the **first layer** is the base sprite we are used to: for example for Warrior ("TileSets/FantasyHex/Units/Warrior");
>![Warrior](https://user-images.githubusercontent.com/17114100/95103863-73a84200-0735-11eb-958e-b3c87ea72714.png)
- the **second layer** is a white sprite (can have transparency for _pro_ shading) that will be colored with the nation **inner color** ("TileSets/FantasyHex/Units/Warrior-1");
> ![Warrior-1](https://user-images.githubusercontent.com/17114100/95103865-7440d880-0735-11eb-9fe3-8060d54d9d07.png)
- the **third layer** is just like the second, but it will be colored with the nation **outer color** ("TileSets/FantasyHex/Units/Warrior-2").
> ![Warrior-2](https://user-images.githubusercontent.com/17114100/95103866-7440d880-0735-11eb-964d-05a21143ed07.png)

I implemented a generic method `getLayeredImageColored` that could be useful in the future to support image layers for different kind of entities.

The rules for naming layers are:
* A layer name must start with the same name as the base layer. I.e. `Warrior`, followed by a `-` and any number of digits.
* The layers are ordered alphabetically by their names. 

Here is an example of the effect obtained by using the following two detail layers for warriors:

![warriors-shaded](https://user-images.githubusercontent.com/17114100/95103891-7acf5000-0735-11eb-8ccf-d0aa5b610138.png)

