### PR TITLE
Consolidated Generic Tile Bonus Uniques (including Friendly Land, Foreign Land)

### DIFF
--- a/android/assets/jsons/Civ V - Vanilla/Buildings.json
+++ b/android/assets/jsons/Civ V - Vanilla/Buildings.json
@@ -676,7 +676,7 @@
 		"isWonder": true,
 		"greatPersonPoints": {"production": 2},
 		"providesFreeBuilding": "Castle",
-		"uniques": ["+15% combat strength for units fighting in friendly territory"],
+		"uniques": ["+[15]% combat bonus for units fighting in [Friendly Land]"],
 		"requiredTech": "Gunpowder",
 		"quote": "'Bushido is realized in the presence of death. This means choosing death whenever there is a choice between life and death. There is no other reasoning.'  - Yamamoto Tsunetomo"
 	},

--- a/android/assets/jsons/Civ V - Vanilla/Units.json
+++ b/android/assets/jsons/Civ V - Vanilla/Units.json
@@ -1149,7 +1149,7 @@
 		"requiredTech": "Replaceable Parts",
 		"upgradesTo": "Infantry",
 		"obsoleteTech": "Plastics",
-		"uniques": ["+20% bonus outside friendly territory"],
+		"uniques": ["+[20]% combat bonus in [Foreign Land]"],
 		"attackSound": "shot"
 	},
 	/*

--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -859,6 +859,7 @@ WaterAircraftCarrier =
 
 Composite Bowman = 
 Foreign Land = 
+Friendly Land = 
 Marine = 
 Mobile SAM = 
 Paratrooper = 

--- a/core/src/com/unciv/logic/battle/BattleDamage.kt
+++ b/core/src/com/unciv/logic/battle/BattleDamage.kt
@@ -214,12 +214,12 @@ object BattleDamage {
     private fun getTileSpecificModifiers(unit: MapUnitCombatant, tile: TileInfo): HashMap<String,Float> {
         val modifiers = HashMap<String,Float>()
 
-        // As of 3.11.0 This is to be deprecated and converted to "+[15]% combat strength for units fighting in friendly territory" - keeping it here to that mods with this can still work for now
+        // As of 3.11.0 This is to be deprecated and converted to "+[15]% combat bonus for units fighting in [Friendly Land]" - keeping it here to that mods with this can still work for now
         // Civ 5 does not use "Himeji Castle"
         if(tile.isFriendlyTerritory(unit.getCivInfo()) && unit.getCivInfo().hasUnique("+15% combat strength for units fighting in friendly territory"))
             addStackingModifier(modifiers, "Friendly Land", 0.15f)
 
-        // As of 3.11.0 This is to be deprecated and converted to "+[20]% bonus outside friendly territory" - keeping it here to that mods with this can still work for now
+        // As of 3.11.0 This is to be deprecated and converted to "+[20]% combat bonus in [Foreign Land]" - keeping it here to that mods with this can still work for now
         if(!tile.isFriendlyTerritory(unit.getCivInfo()) && unit.unit.hasUnique("+20% bonus outside friendly territory"))
             addStackingModifier(modifiers, "Foreign Land", 0.2f)
 


### PR DESCRIPTION
Redid things with help from HadeanLake:

-"+[]% combat bonus in []" Unit Unique
-"+[]% combat bonus for units fighting in []" Nation Unique
-Both of these can check for terrain or Friendly Land or Foreign Land
-Function to add stacking modifiers
-Himeji Castle and Foreign Legion had uniques changed to fit this syntax
-Old way still works for now, but deprecated
-"Friendly Land" added to template.properties for translation