### PR TITLE
City states button influence bar

### DIFF
--- a/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
@@ -90,7 +90,7 @@ class DiplomacyManager() {
      *  Won't go below [MINIMUM_INFLUENCE] */
     var influence = 0f
         set(value) { field = max(value, MINIMUM_INFLUENCE) }
-
+        get() = if(civInfo.isAtWarWith(otherCiv())) MINIMUM_INFLUENCE else field
     /** For city-states. Resting point is the value of Influence at which it ceases changing by itself */
     var restingPoint = 0f
 
@@ -137,10 +137,9 @@ class DiplomacyManager() {
             return otherCiv().getDiplomacyManager(civInfo).relationshipLevel()
 
         if(civInfo.isCityState()) {
-            if(influence <= -60) return RelationshipLevel.Unforgivable
-            if(influence <= -30 || civInfo.isAtWarWith(otherCiv())) return RelationshipLevel.Enemy
-
-            if(influence >= 60) return RelationshipLevel.Ally
+            if(influence <= -30 || civInfo.isAtWarWith(otherCiv())) return RelationshipLevel.Unforgivable
+            if(influence < 0) return RelationshipLevel.Enemy
+            if(influence >= 60 && civInfo.getAllyCiv() == otherCivName) return RelationshipLevel.Ally
             if(influence >= 30) return RelationshipLevel.Friend
             return RelationshipLevel.Neutral
         }

--- a/core/src/com/unciv/ui/tilegroups/CityButton.kt
+++ b/core/src/com/unciv/ui/tilegroups/CityButton.kt
@@ -45,6 +45,12 @@ class CityButton(val city: CityInfo, private val tileGroup: WorldTileGroup): Tab
         iconTable = getIconTable()
         add(iconTable).row()
 
+        if (city.civInfo.isCityState()) {
+            val diplomacyManager = city.civInfo.getDiplomacyManager(worldScreen.viewingCiv)
+            val influenceBar = ImageGetter.getInfluenceBar(diplomacyManager.influence, diplomacyManager.relationshipLevel())
+            add(influenceBar).row()
+        }
+
         pack()
         setOrigin(Align.center)
         centerX(tileGroup)

--- a/core/src/com/unciv/ui/tilegroups/CityButton.kt
+++ b/core/src/com/unciv/ui/tilegroups/CityButton.kt
@@ -12,9 +12,12 @@ import com.badlogic.gdx.utils.Align
 import com.unciv.logic.city.CityConstructions
 import com.unciv.logic.city.CityInfo
 import com.unciv.logic.city.PerpetualConstruction
+import com.unciv.logic.civilization.diplomacy.RelationshipLevel
 import com.unciv.ui.cityscreen.CityScreen
 import com.unciv.ui.trade.DiplomacyScreen
 import com.unciv.ui.utils.*
+import kotlin.math.max
+import kotlin.math.min
 
 class CityButton(val city: CityInfo, private val tileGroup: WorldTileGroup): Table(CameraStageBaseScreen.skin){
     val worldScreen = tileGroup.worldScreen
@@ -47,7 +50,7 @@ class CityButton(val city: CityInfo, private val tileGroup: WorldTileGroup): Tab
 
         if (city.civInfo.isCityState()) {
             val diplomacyManager = city.civInfo.getDiplomacyManager(worldScreen.viewingCiv)
-            val influenceBar = ImageGetter.getInfluenceBar(diplomacyManager.influence, diplomacyManager.relationshipLevel())
+            val influenceBar = getInfluenceBar(diplomacyManager.influence, diplomacyManager.relationshipLevel())
             add(influenceBar).row()
         }
 
@@ -361,6 +364,65 @@ class CityButton(val city: CityInfo, private val tileGroup: WorldTileGroup): Tab
             group.addActor(productionBar)
         }
         return group
+    }
+
+    companion object {
+        fun getInfluenceBar(influence: Float, relationshipLevel: RelationshipLevel, width: Float = 100f, height: Float = 5f): Table {
+            val normalizedInfluence = max(-60f, min(influence, 60f)) / 30f
+
+            val color = when (relationshipLevel) {
+                RelationshipLevel.Unforgivable -> Color.RED
+                RelationshipLevel.Enemy -> Color.ORANGE
+                RelationshipLevel.Neutral, RelationshipLevel.Friend -> Color.LIME
+                RelationshipLevel.Ally -> Color.SKY
+                else -> Color.DARK_GRAY
+            }
+
+            val percentages = arrayListOf(0f, 0f, 0f, 0f)
+            when {
+                normalizedInfluence < -1f -> {
+                    percentages[0] = -normalizedInfluence - 1f
+                    percentages[1] = 1f
+                }
+                normalizedInfluence < 0f -> percentages[1] = -normalizedInfluence
+                normalizedInfluence < 1f -> percentages[2] = normalizedInfluence
+                else -> {
+                    percentages[2] = 1f
+                    percentages[3] = (normalizedInfluence - 1f)
+                }
+            }
+
+            fun getBarPiece(percentage: Float, color: Color, negative: Boolean): Table{
+                val barPieceSize = width / 4f
+                val barPiece = Table()
+                val full = ImageGetter.getWhiteDot()
+                val empty = ImageGetter.getWhiteDot()
+
+                full.color = color
+                empty.color = Color.DARK_GRAY
+
+                if (negative) {
+                    barPiece.add(empty).size((1f - percentage) * barPieceSize, height)
+                    barPiece.add(full).size(percentage * barPieceSize, height)
+                } else {
+                    barPiece.add(full).size(percentage * barPieceSize, height)
+                    barPiece.add(empty).size((1f - percentage) * barPieceSize, height)
+                }
+
+                return barPiece
+            }
+
+            val influenceBar = Table().apply {
+                defaults().pad(1f)
+                setSize(width, height)
+                background = ImageGetter.getBackground(Color.BLACK)
+            }
+
+            for (i in 0..3)
+                influenceBar.add(getBarPiece(percentages[i], color, i < 2))
+
+            return influenceBar
+        }
     }
 
 }

--- a/core/src/com/unciv/ui/trade/DiplomacyScreen.kt
+++ b/core/src/com/unciv/ui/trade/DiplomacyScreen.kt
@@ -18,6 +18,7 @@ import com.unciv.logic.trade.TradeType
 import com.unciv.models.ruleset.ModOptionsConstants
 import com.unciv.models.ruleset.Quest
 import com.unciv.models.translations.tr
+import com.unciv.ui.tilegroups.CityButton
 import com.unciv.ui.utils.*
 import kotlin.math.floor
 import kotlin.math.roundToInt
@@ -391,7 +392,14 @@ class DiplomacyScreen(val viewingCiv:CivilizationInfo):CameraStageBaseScreen() {
             else -> Color.RED
         }
 
-        relationshipTable.add(relationshipText.toLabel(relationshipColor))
+        relationshipTable.add(relationshipText.toLabel(relationshipColor)).row()
+        if (otherCivDiplomacyManager.civInfo.isCityState())
+            relationshipTable.add(
+                    CityButton.getInfluenceBar(
+                            otherCivDiplomacyManager.influence,
+                            otherCivDiplomacyManager.relationshipLevel(),
+                            200f, 10f)
+            ).colspan(2).pad(5f)
         return relationshipTable
     }
 

--- a/core/src/com/unciv/ui/utils/ImageGetter.kt
+++ b/core/src/com/unciv/ui/utils/ImageGetter.kt
@@ -258,63 +258,6 @@ object ImageGetter {
         return advancementGroup
     }
 
-    fun getInfluenceBar(influence: Float, relationshipLevel: RelationshipLevel, influenceBarSize: Float = 100f): Table {
-        val normalizedInfluence = max(-60f, min(influence, 60f)) / 30f
-
-        val color = when (relationshipLevel) {
-            RelationshipLevel.Unforgivable -> Color.RED
-            RelationshipLevel.Enemy -> Color.ORANGE
-            RelationshipLevel.Neutral, RelationshipLevel.Friend -> Color.LIME
-            RelationshipLevel.Ally -> Color.SKY
-            else -> Color.DARK_GRAY
-        }
-
-        val percentages = arrayListOf(0f, 0f, 0f, 0f)
-        when {
-            normalizedInfluence < -1f -> {
-                percentages[0] = -normalizedInfluence - 1f
-                percentages[1] = 1f
-            }
-            normalizedInfluence < 0f -> percentages[1] = -normalizedInfluence
-            normalizedInfluence < 1f -> percentages[2] = normalizedInfluence
-            else -> {
-                percentages[2] = 1f
-                percentages[3] = (normalizedInfluence - 1f)
-            }
-        }
-
-        fun getBarPiece(percentage: Float, color: Color, negative: Boolean): Table{
-            val barPieceSize = influenceBarSize / 4f
-            val barPiece = Table()
-            val full = getWhiteDot()
-            val empty = getWhiteDot()
-
-            full.color = color
-            empty.color = Color.DARK_GRAY
-
-            if (negative) {
-                barPiece.add(empty).size((1f - percentage) * barPieceSize, 5f)
-                barPiece.add(full).size(percentage * barPieceSize, 5f)
-            } else {
-                barPiece.add(full).size(percentage * barPieceSize, 5f)
-                barPiece.add(empty).size((1f - percentage) * barPieceSize, 5f)
-            }
-
-            return barPiece
-        }
-
-        val influenceBar = Table().apply {
-            defaults().pad(1f)
-            setSize(influenceBarSize, 5f)
-            background = getBackground(Color.BLACK)
-        }
-
-        for (i in 0..3)
-            influenceBar.add(getBarPiece(percentages[i], color, i < 2))
-
-        return influenceBar
-    }
-
     fun getHealthBar(currentHealth: Float, maxHealth: Float, healthBarSize: Float): Table {
         val healthPercent = currentHealth / maxHealth
         val healthBar = Table()

--- a/core/src/com/unciv/ui/utils/ImageGetter.kt
+++ b/core/src/com/unciv/ui/utils/ImageGetter.kt
@@ -15,10 +15,12 @@ import com.badlogic.gdx.scenes.scene2d.utils.NinePatchDrawable
 import com.badlogic.gdx.scenes.scene2d.utils.TextureRegionDrawable
 import com.badlogic.gdx.utils.Align
 import com.unciv.Constants
+import com.unciv.logic.civilization.diplomacy.RelationshipLevel
 import com.unciv.models.ruleset.Nation
 import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.ruleset.tile.ResourceType
-import com.unciv.models.stats.Stat
+import kotlin.math.max
+import kotlin.math.min
 
 object ImageGetter {
     private const val whiteDotLocation = "OtherIcons/whiteDot"
@@ -254,6 +256,63 @@ object ImageGetter {
         advancementGroup.add(getImage(whiteDotLocation).apply { color = progressColor }).size(width, completionHeight)
         advancementGroup.pack()
         return advancementGroup
+    }
+
+    fun getInfluenceBar(influence: Float, relationshipLevel: RelationshipLevel, influenceBarSize: Float = 100f): Table {
+        val normalizedInfluence = max(-60f, min(influence, 60f)) / 30f
+
+        val color = when (relationshipLevel) {
+            RelationshipLevel.Unforgivable -> Color.RED
+            RelationshipLevel.Enemy -> Color.ORANGE
+            RelationshipLevel.Neutral, RelationshipLevel.Friend -> Color.LIME
+            RelationshipLevel.Ally -> Color.SKY
+            else -> Color.DARK_GRAY
+        }
+
+        val percentages = arrayListOf(0f, 0f, 0f, 0f)
+        when {
+            normalizedInfluence < -1f -> {
+                percentages[0] = -normalizedInfluence - 1f
+                percentages[1] = 1f
+            }
+            normalizedInfluence < 0f -> percentages[1] = -normalizedInfluence
+            normalizedInfluence < 1f -> percentages[2] = normalizedInfluence
+            else -> {
+                percentages[2] = 1f
+                percentages[3] = (normalizedInfluence - 1f)
+            }
+        }
+
+        fun getBarPiece(percentage: Float, color: Color, negative: Boolean): Table{
+            val barPieceSize = influenceBarSize / 4f
+            val barPiece = Table()
+            val full = getWhiteDot()
+            val empty = getWhiteDot()
+
+            full.color = color
+            empty.color = Color.DARK_GRAY
+
+            if (negative) {
+                barPiece.add(empty).size((1f - percentage) * barPieceSize, 5f)
+                barPiece.add(full).size(percentage * barPieceSize, 5f)
+            } else {
+                barPiece.add(full).size(percentage * barPieceSize, 5f)
+                barPiece.add(empty).size((1f - percentage) * barPieceSize, 5f)
+            }
+
+            return barPiece
+        }
+
+        val influenceBar = Table().apply {
+            defaults().pad(1f)
+            setSize(influenceBarSize, 5f)
+            background = getBackground(Color.BLACK)
+        }
+
+        for (i in 0..3)
+            influenceBar.add(getBarPiece(percentages[i], color, i < 2))
+
+        return influenceBar
     }
 
     fun getHealthBar(currentHealth: Float, maxHealth: Float, healthBarSize: Float): Table {


### PR DESCRIPTION
![influence_bar](https://user-images.githubusercontent.com/17114100/95583479-79a36900-0a3c-11eb-8c94-7a9e5f4d17f7.png)

I also changed the thresholds of influence for city states, because the state `Unforgivable` wasn't "reachable" in practice:
* `< 30 || atWar` -> `Unforgivable`
* `<0` -> `Enemy`
* `< 30` -> `Neutral` 
* `< 60` -> `Friend`
* `>60 && allied` -> `Ally`
