### PR TITLE
New parameterized uniques

### DIFF
--- a/android/assets/jsons/Civ V - Vanilla/Policies.json
+++ b/android/assets/jsons/Civ V - Vanilla/Policies.json
@@ -482,7 +482,7 @@
 			{
 				"name": "Total War",
 				"effect": "+15% production when building military units and new military units start with 15 Experience",
-				"uniques": ["+[15]% Production when constructing [military units]", "New military units start with [15] Experience"],
+				"uniques": ["+[15]% Production when constructing [military units]", "New [military] units start with [15] Experience"],
 				"requires": ["Police State","Fascism"],
 				"row": 3,
 				"column": 4

--- a/android/assets/jsons/Civ V - Vanilla/UnitPromotions.json
+++ b/android/assets/jsons/Civ V - Vanilla/UnitPromotions.json
@@ -208,38 +208,38 @@
 	// Submarine
 	{
 		"name": "Wolfpack I",
-		"effect": "Bonus as Attacker [25]%",
+		"effect": "+[25]% Strength when attacking",
 		"unitTypes": ["WaterSubmarine"]
 	},
 	{
 		"name": "Wolfpack II",
 		"prerequisites": ["Wolfpack I"],
-		"effect": "Bonus as Attacker [25]%",
+		"effect": "+[25]% Strength when attacking",
 		"unitTypes": ["WaterSubmarine"]
 	},
 	{
 		"name": "Wolfpack III",
 		"prerequisites": ["Wolfpack II"],
-		"effect": "Bonus as Attacker [25]%",
+		"effect": "+[25]% Strength when attacking",
 		"unitTypes": ["WaterSubmarine"]
 	},
 	
 	// Aircraft Carrier
 	{
 		"name": "Armor Plating I",
-		"effect": "Bonus as Defender [25]%",
+		"effect": "+[25]% Strength when defending",
 		"unitTypes": ["WaterAircraftCarrier"]
 	},
 	{
 		"name": "Armor Plating II",
 		"prerequisites": ["Armor Plating I"],
-		"effect": "Bonus as Defender [25]%",
+		"effect": "+[25]% Strength when defending",
 		"unitTypes": ["WaterAircraftCarrier"]
 	},
 	{
 		"name": "Armor Plating III",
 		"prerequisites": ["Armor Plating II"],
-		"effect": "Bonus as Defender [25]%",
+		"effect": "+[25]% Strength when defending",
 		"unitTypes": ["WaterAircraftCarrier"]
 	},
 	{

--- a/android/assets/jsons/Civ V - Vanilla/UnitPromotions.json
+++ b/android/assets/jsons/Civ V - Vanilla/UnitPromotions.json
@@ -227,19 +227,19 @@
 	// Aircraft Carrier
 	{
 		"name": "Armor Plating I",
-		"effect": "+25% Combat Bonus when defending",
+		"effect": "Bonus as Defender [25]%",
 		"unitTypes": ["WaterAircraftCarrier"]
 	},
 	{
 		"name": "Armor Plating II",
 		"prerequisites": ["Armor Plating I"],
-		"effect": "+25% Combat Bonus when defending",
+		"effect": "Bonus as Defender [25]%",
 		"unitTypes": ["WaterAircraftCarrier"]
 	},
 	{
 		"name": "Armor Plating III",
 		"prerequisites": ["Armor Plating II"],
-		"effect": "+25% Combat Bonus when defending",
+		"effect": "Bonus as Defender [25]%",
 		"unitTypes": ["WaterAircraftCarrier"]
 	},
 	{

--- a/android/assets/jsons/Civ V - Vanilla/Units.json
+++ b/android/assets/jsons/Civ V - Vanilla/Units.json
@@ -743,7 +743,7 @@
 		"requiredTech": "Gunpowder",
 		"upgradesTo": "Rifleman",
 		"obsoleteTech": "Rifling",
-		"uniques": ["Heals [50] damage if it kills a unit", "Bonus as Attacker [25]%"],
+		"uniques": ["Heals [50] damage if it kills a unit", "+[25]% Strength when attacking"],
 		"attackSound": "shot"
 	},
 	{
@@ -1124,7 +1124,7 @@
 		"cost": 325,
 		"requiredTech": "Refrigeration",
 		// "upgradesTo": "Nuclear Submarine",
-		"uniques": ["Bonus as Attacker [75]%", "Invisible to others", "Can only attack water", "Can attack submarines", "Can enter ice tiles"]
+		"uniques": ["+[75]% Strength when attacking", "Invisible to others", "Can only attack water", "Can attack submarines", "Can enter ice tiles"]
 	},
 	{
 		"name": "Great War Infantry",

--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -595,6 +595,7 @@ Captured! =
 defence vs ranged = 
 [percentage] to unit defence = 
 Attacker Bonus = 
+Defender Bonus = 
 Landing = 
 Flanking = 
 vs [unitType] = 
@@ -622,6 +623,7 @@ Occupied City =
 Buildings = 
 
 # For the "when constructing [military units]" translation
+military =
 military units = 
 melee units = 
 mounted units = 

--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -623,7 +623,7 @@ Occupied City =
 Buildings = 
 
 # For the "when constructing [military units]" translation
-military =
+military = 
 military units = 
 melee units = 
 mounted units = 

--- a/core/src/com/unciv/logic/battle/BattleDamage.kt
+++ b/core/src/com/unciv/logic/battle/BattleDamage.kt
@@ -175,7 +175,8 @@ object BattleDamage {
         modifiers.putAll(getTileSpecificModifiers(defender, tile))
 
         val tileDefenceBonus = tile.getDefensiveBonus()
-        if (!defender.unit.hasUnique("No defensive terrain bonus") || tileDefenceBonus < 0)
+        if ( (!defender.unit.hasUnique("No defensive terrain bonus") && tileDefenceBonus > 0)
+                || (!defender.unit.hasUnique("No defensive terrain penalty") && tileDefenceBonus < 0) )
             modifiers["Tile"] = (tileDefenceBonus*100).toInt()
 
         if (attacker.isRanged()) {
@@ -183,8 +184,13 @@ object BattleDamage {
             if (defenceVsRanged > 0) modifiers["defence vs ranged"] = defenceVsRanged
         }
 
+        // As of 3.11.2 This is to be deprecated and converted to "Bonus as Defender [25]%" - keeping it here to that mods with this can still work for now
         val carrierDefenceBonus = 25 * defender.unit.getUniques().count { it.text == "+25% Combat Bonus when defending" }
-        if (carrierDefenceBonus > 0) modifiers["Armor Plating"] = carrierDefenceBonus
+        if (carrierDefenceBonus > 0) modifiers["Defender Bonus"] = carrierDefenceBonus
+
+        for(unique in defender.unit.getMatchingUniques("Bonus as Defender []%")) {
+            modifiers.add("Defender Bonus", unique.params[0].toInt())
+        }
 
         for(unique in defender.unit.getMatchingUniques("+[]% defence in [] tiles")) {
             if (tile.matchesUniqueFilter(unique.params[1]))

--- a/core/src/com/unciv/logic/battle/BattleDamage.kt
+++ b/core/src/com/unciv/logic/battle/BattleDamage.kt
@@ -118,9 +118,14 @@ object BattleDamage {
         if (attacker is MapUnitCombatant) {
             modifiers.add(getTileSpecificModifiers(attacker, defender.getTile()))
 
+            // As of 3.11.3 This is to be deprecated and converted to "+[]% Strength when attacking" - keeping it here to that mods with this can still work for now
             for (ability in attacker.unit.getUniques()) {
                 if (ability.placeholderText == "Bonus as Attacker []%")
                     modifiers.add("Attacker Bonus", ability.params[0].toInt())
+            }
+
+            for(unique in attacker.unit.getMatchingUniques("+[]% Strength when attacking")) {
+                modifiers.add("Attacker Bonus", unique.params[0].toInt())
             }
 
             if (attacker.unit.isEmbarked() && !attacker.unit.hasUnique("Amphibious"))
@@ -184,11 +189,11 @@ object BattleDamage {
             if (defenceVsRanged > 0) modifiers["defence vs ranged"] = defenceVsRanged
         }
 
-        // As of 3.11.2 This is to be deprecated and converted to "Bonus as Defender [25]%" - keeping it here to that mods with this can still work for now
+        // As of 3.11.2 This is to be deprecated and converted to "+[25]% Strength when defending" - keeping it here to that mods with this can still work for now
         val carrierDefenceBonus = 25 * defender.unit.getUniques().count { it.text == "+25% Combat Bonus when defending" }
         if (carrierDefenceBonus > 0) modifiers["Defender Bonus"] = carrierDefenceBonus
 
-        for(unique in defender.unit.getMatchingUniques("Bonus as Defender []%")) {
+        for(unique in defender.unit.getMatchingUniques("+[]% Strength when defending")) {
             modifiers.add("Defender Bonus", unique.params[0].toInt())
         }
 

--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -683,6 +683,9 @@ class MapUnit {
         if ((category == "Land" || category == "land units") && type.isLandUnit()) return true
         if ((category == "Water" || category == "water units") && type.isWaterUnit()) return true
         if ((category == "Air" || category == "air units") && type.isAirUnit()) return true
+        if (category == "non-air" && !type.isAirUnit()) return true
+        if ((category == "military" || category == "military units") && type.isMilitary()) return true
+        if (hasUnique(category)) return true
 
         return false
     }


### PR DESCRIPTION
-New unit unique "Bonus as Defender []%". "+25% Combat Bonus when defending" now deprecated, but kept for now for mods. Json promotion changed to fit new syntax.
Defender Bonus modifier "Defender Bonus" added to template.properties for translation.

-"All newly-trained [] units in this city receive the [] promotion" now uses unit category checking.

-New building unique "New [] units start with [] Experience in this city"
This can used by Poland's stable unique replacement in BNW, as it gives extra xp for mounted units.
"New [] units start with [] Experience" is the new nation wide version of this.

"New military units start with [] Experience" is now deprecated, but kept for now for mods. Json policy changed to fit new syntax.

-Unit category checking can now check for "non-air", "military", "military units" and uniques.
Added "military" to template.properties for translation.

-New unit unique "No defensive terrain penalty". Admittedly this is for a mod I'm making.