### PR TITLE
Remaining helicopter unique stuff

### DIFF
--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -63,7 +63,7 @@ object Battle {
         postBattleNationUniques(defender, attackedTile, attacker)
 
         // This needs to come BEFORE the move-to-tile, because if we haven't conquered it we can't move there =)
-        if (defender.isDefeated() && defender is CityCombatant && attacker.isMelee())
+        if (defender.isDefeated() && defender is CityCombatant && attacker is MapUnitCombatant && attacker.isMelee() && !attacker.unit.hasUnique("Unable to capture cities"))
             conquerCity(defender.city, attacker)
 
         // we're a melee unit and we destroyed\captured an enemy unit

--- a/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
+++ b/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
@@ -8,11 +8,13 @@ class UnitMovementAlgorithms(val unit:MapUnit) {
 
     // This function is called ALL THE TIME and should be as time-optimal as possible!
     fun getMovementCostBetweenAdjacentTiles(from: TileInfo, to: TileInfo, civInfo: CivilizationInfo): Float {
-        if (unit.allTilesCosts1)
-            return 1f
 
         if ((from.isLand != to.isLand) && !unit.civInfo.nation.embarkDisembarkCosts1 && unit.type.isLandUnit())
             return 100f // this is embarkment or disembarkment, and will take the entire turn
+
+        // land units will still spend all movement points to embark even with this unique
+        if (unit.allTilesCosts1)
+            return 1f
 
         var extraCost = 0f
 


### PR DESCRIPTION
-"Unable to capture cities" unique prevents the unit from conquering/capturing a city.
-Units with "All tiles costs 1" unique now spend all movement points when embarking. 

Technically, in CIV 5, helicopters do not embark or spend all movement units when moving to water, if embarkation (Optics) isn't researched. 

IMO, though, it is so unlikely that someone will have helicopters researched but not embarkation, that I don't think it is worth editing the code for this fringe case.