### PR TITLE
Polynesia Unique Fix

### DIFF
--- a/core/src/com/unciv/logic/map/TileInfo.kt
+++ b/core/src/com/unciv/logic/map/TileInfo.kt
@@ -332,6 +332,7 @@ open class TileInfo {
                 || filter == terrainFeature
                 || baseTerrainObject.uniques.contains(filter)
                 || terrainFeature != null && getTerrainFeature()!!.uniques.contains(filter)
+                || improvement == filter
                 || filter == "Water" && isWater
     }
 


### PR DESCRIPTION
Polynesia's unique "+[10]% Strength if within [2] tiles of a [Moai]" was not working correctly. The matchesUniqueFilter function didn't check for improvement on the tile. This was corrected and now Polynesia's unique works correctly. Any other improvement besides Moai will also work for modded uniques.