### PR TITLE
Fix bug Carrier-based aircraft not healing

### DIFF
--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -406,7 +406,7 @@ class MapUnit {
 
         var healing = when {
             tileInfo.isCityCenter() -> 20
-            tileInfo.isWater && isFriendlyTerritory && type.isWaterUnit() -> 15 // Water unit on friendly water
+            tileInfo.isWater && isFriendlyTerritory && (type.isWaterUnit() || isTransported) -> 15 // Water unit on friendly water
             tileInfo.isWater -> 0 // All other water cases
             tileInfo.getOwner() == null -> 10 // Neutral territory
             isFriendlyTerritory -> 15 // Allied territory


### PR DESCRIPTION
With reference to issue #3307

I think that aircraft on aircraft carriers were being treated at land units at sea.

I have added the check to test whether they are being transported so that they should now heal whilst on aircraft carriers.