### PR TITLE
Diplomatic penalty of stealing lands decreases by time.

### DIFF
--- a/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
@@ -428,6 +428,7 @@ class DiplomacyManager() {
         revertToZero(DiplomaticModifiers.BetrayedPromiseToNotSettleCitiesNearUs, 1 / 8f) // That's a bastardly thing to do
         revertToZero(DiplomaticModifiers.UnacceptableDemands, 1 / 4f)
         revertToZero(DiplomaticModifiers.LiberatedCity, 1 / 8f)
+        revertToZero(DiplomaticModifiers.StealingTerritory, 1 / 4f)
 
         setFriendshipBasedModifier()
 


### PR DESCRIPTION
Fix : "You have stolen our lands!" penalty never decreased.