### PR TITLE
Fixed "Take UserID from Clipboard" button not working in main menu

### DIFF
--- a/core/src/com/unciv/ui/worldscreen/mainmenu/OptionsPopup.kt
+++ b/core/src/com/unciv/ui/worldscreen/mainmenu/OptionsPopup.kt
@@ -153,7 +153,7 @@ class OptionsPopup(val previousScreen:CameraStageBaseScreen) : Popup(previousScr
                                     settings.userId = clipboardContents
                                     settings.save()
                                     idSetLabel.setFontColor(Color.WHITE).setText("ID successfully set!".tr())
-                                }).open(true)
+                                }, previousScreen).open(true)
                         idSetLabel.isVisible = true
                     } catch (ex: Exception) {
                         idSetLabel.isVisible = true


### PR DESCRIPTION
#3293 isn't entirely correct. It was possible to take the userID to Android but not in the main menu because SetUserId was calling YesNoPopup without a screen parameter. YesNoPopup would then try to use uncivgame.current.worldscreen which it could not find.
