### PR TITLE
Hide hotkeys on devices without keyboard

### DIFF
--- a/core/src/com/unciv/ui/worldscreen/unit/UnitActionsTable.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitActionsTable.kt
@@ -15,7 +15,7 @@ import com.unciv.ui.utils.*
 import com.unciv.ui.worldscreen.WorldScreen
 import kotlin.concurrent.thread
 
-private data class UnitIconAndKey (val Icon: Actor, val key: Char = 0.toChar())
+private data class UnitIconAndKey(val Icon: Actor, var key: Char = 0.toChar())
 
 class UnitActionsTable(val worldScreen: WorldScreen) : Table() {
 
@@ -71,6 +71,12 @@ class UnitActionsTable(val worldScreen: WorldScreen) : Table() {
 
     private fun getUnitActionButton(unitAction: UnitAction): Button {
         val iconAndKey = getIconAndKeyForUnitAction(unitAction.title)
+
+        // If android version detected, hotkeys will not be displayed
+        var hotKeys = true
+        if (this.worldScreen.game.version == "android"){hotKeys = false}
+        if (!hotKeys){iconAndKey.key = 0.toChar()}
+
         val actionButton = Button(CameraStageBaseScreen.skin)
         actionButton.add(iconAndKey.Icon).size(20f).pad(5f)
         val fontColor = if (unitAction.isCurrentAction) Color.YELLOW else Color.WHITE

--- a/core/src/com/unciv/ui/worldscreen/unit/UnitActionsTable.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitActionsTable.kt
@@ -1,5 +1,7 @@
 package com.unciv.ui.worldscreen.unit
 
+import com.badlogic.gdx.Gdx
+import com.badlogic.gdx.Input
 import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.scenes.scene2d.Actor
 import com.badlogic.gdx.scenes.scene2d.Touchable
@@ -72,10 +74,9 @@ class UnitActionsTable(val worldScreen: WorldScreen) : Table() {
     private fun getUnitActionButton(unitAction: UnitAction): Button {
         val iconAndKey = getIconAndKeyForUnitAction(unitAction.title)
 
-        // If android version detected, hotkeys will not be displayed
-        var hotKeys = true
-        if (this.worldScreen.game.version == "android"){hotKeys = false}
-        if (!hotKeys){iconAndKey.key = 0.toChar()}
+        // If peripheral keyboard not detected, hotkeys will not be displayed
+        val keyboardAvailable = Gdx.input.isPeripheralAvailable(Input.Peripheral.HardwareKeyboard)
+        if (!keyboardAvailable){iconAndKey.key = 0.toChar()}
 
         val actionButton = Button(CameraStageBaseScreen.skin)
         actionButton.add(iconAndKey.Icon).size(20f).pad(5f)


### PR DESCRIPTION
With reference to issue #3348.

I have changed it so that keyboard hotkeys are not displayed if the game is detected to be booted in "android". 

A better way to do this would be to detect the presence/absence of a keyboard, in case a user has a keyboard plugged in to an android device. 

![image](https://user-images.githubusercontent.com/18306309/99527522-d3307900-2994-11eb-8ac8-ab307407a4e4.png)
![image](https://user-images.githubusercontent.com/18306309/99528139-bf394700-2995-11eb-90dd-7b8d6925e13c.png)
