### PR TITLE
Added "All [] Cities get a free []" unique.

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -930,3 +930,5 @@ Must be on [terrain] =
 in this city = 
 in every city = 
 in capital = 
+coastal = 
+new = 

--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -930,5 +930,4 @@ Must be on [terrain] =
 in this city = 
 in every city = 
 in capital = 
-coastal = 
-new = 
+in every coastal city = 

--- a/core/src/com/unciv/logic/city/CityInfo.kt
+++ b/core/src/com/unciv/logic/city/CityInfo.kt
@@ -88,6 +88,15 @@ class CityInfo {
 
         civInfo.policies.tryAddLegalismBuildings()
 
+        for (unique in civInfo.getMatchingUniques("All [] Cities get a free []")) {
+            val cityFilter = unique.params[0]
+            val freeBuildingName = unique.params[1]
+            if (cityFilter == "new" || (cityFilter == "coastal" && getCenterTile().isCoastalTile()) ) {
+                if (!cityConstructions.isBuilt(freeBuildingName))
+                    cityConstructions.addBuilding(freeBuildingName)
+            }
+        }
+
         expansion.reset()
 
 

--- a/core/src/com/unciv/logic/city/CityInfo.kt
+++ b/core/src/com/unciv/logic/city/CityInfo.kt
@@ -88,10 +88,10 @@ class CityInfo {
 
         civInfo.policies.tryAddLegalismBuildings()
 
-        for (unique in civInfo.getMatchingUniques("All [] Cities get a free []")) {
-            val cityFilter = unique.params[0]
-            val freeBuildingName = unique.params[1]
-            if (cityFilter == "new" || (cityFilter == "coastal" && getCenterTile().isCoastalTile()) ) {
+        for (unique in civInfo.getMatchingUniques("Get a free [] []")) {
+            val freeBuildingName = unique.params[0]
+            val cityFilter = unique.params[1]
+            if (cityFilter == "in every city" || (cityFilter == "in every coastal city" && getCenterTile().isCoastalTile()) ) {
                 if (!cityConstructions.isBuilt(freeBuildingName))
                     cityConstructions.addBuilding(freeBuildingName)
             }

--- a/core/src/com/unciv/logic/city/CityInfo.kt
+++ b/core/src/com/unciv/logic/city/CityInfo.kt
@@ -88,7 +88,7 @@ class CityInfo {
 
         civInfo.policies.tryAddLegalismBuildings()
 
-        for (unique in civInfo.getMatchingUniques("Get a free [] []")) {
+        for (unique in civInfo.getMatchingUniques("Gain a free [] []")) {
             val freeBuildingName = unique.params[0]
             val cityFilter = unique.params[1]
             if (cityFilter == "in every city" || (cityFilter == "in every coastal city" && getCenterTile().isCoastalTile()) ) {


### PR DESCRIPTION
Added "All [] Cities get a free []" unique. 

The first parameter is for city type. Currently "new" and "coastal" are supported. 
"new" matches every city and "coastal" matches cities on a coastal tile.
"new" and "coastal" were added to template.properties for translation.

Upon city founding, the second parameter building is added to the city.

In civ 5 G&K, Carthage gets a free harbor for every coastal city.