### PR TITLE
Added influence map and major tweeks to AI unit logic

### DIFF
--- a/core/src/com/unciv/logic/automation/Automation.kt
+++ b/core/src/com/unciv/logic/automation/Automation.kt
@@ -82,6 +82,19 @@ object Automation {
         else { // randomize type of unit and take the most expensive of its kind
             val availableTypes = militaryUnits.map { it.unitType }.distinct().filterNot { it == UnitType.Scout }.toList()
             if (availableTypes.isEmpty()) return null
+            
+            var otherCivCities = city.civInfo.gameInfo.civilizations
+                    .flatMap { it.cities }.asSequence()
+                    .filter { it.location in city.civInfo.exploredTiles }
+
+            val closestOtherCivCities = otherCivCities
+                    .asSequence().map { it.getCenterTile() }
+                    .sortedBy { cityCenterTile ->
+                        // sort enemy cities by closeness to our cities, and only then choose the first reachable - checking canReach is comparatively very time-intensive!
+                        city.civInfo.cities.asSequence().map { cityCenterTile.aerialDistanceTo(it.getCenterTile()) }.min()!!
+                    }
+
+
             val randomType = availableTypes.random()
             chosenUnit = militaryUnits.filter { it.unitType == randomType }.maxBy { it.cost }!!
         }

--- a/core/src/com/unciv/logic/automation/BattleHelper.kt
+++ b/core/src/com/unciv/logic/automation/BattleHelper.kt
@@ -142,7 +142,8 @@ object BattleHelper {
             enemyTileToAttack = capturableCity // enter it quickly, top priority!
 
         else if (nonCityTilesToAttack.isNotEmpty()) // second priority, units
-            enemyTileToAttack = nonCityTilesToAttack.minBy { Battle.getMapCombatantOfTile(it.tileToAttack)!!.getHealth() }
+            //enemyTileToAttack = nonCityTilesToAttack.minBy { Battle.getMapCombatantOfTile(it.tileToAttack)!!.getHealth() }
+            enemyTileToAttack = nonCityTilesToAttack.minBy { it.tileToAttack.getInfluence() } // See if influence mapping helps
         else if (cityWithHealthLeft != null) enemyTileToAttack = cityWithHealthLeft // third priority, city
 
         return enemyTileToAttack

--- a/core/src/com/unciv/logic/automation/NextTurnAutomation.kt
+++ b/core/src/com/unciv/logic/automation/NextTurnAutomation.kt
@@ -42,6 +42,7 @@ object NextTurnAutomation {
             updateDiplomaticRelationshipForCityStates(civInfo)
         }
 
+        updateMemory(civInfo)
         chooseTechToResearch(civInfo)
         automateCityBombardment(civInfo)
         useGold(civInfo)
@@ -274,6 +275,23 @@ object NextTurnAutomation {
             if ((1..10).random() <= 5)
                 civInfo.getDiplomacyManager(civ).signDeclarationOfFriendship()
         }
+    }
+    
+    private fun updateMemory(civInfo: CivilizationInfo) {
+        civInfo.memoryManager.seenPrevLastRound = civInfo.memoryManager.seenLastRound
+        civInfo.memoryManager.setBaselineStrength()
+        var otherCivUnits = civInfo.viewableTiles.asSequence()
+                .map { it.getUnits() }.flatten()
+                .filter { it.civInfo != civInfo && it.type.isMilitary() }
+
+        var otherCivUnitsCount = otherCivUnits.count()
+
+        if (otherCivUnitsCount > civInfo.memoryManager.seenLastRound && civInfo.memoryManager.seenLastRound >= civInfo.memoryManager.seenPrevLastRound) {
+            for (unit in otherCivUnits) {
+                civInfo.memoryManager.addCivUnit(unit)
+            }
+        }
+        civInfo.memoryManager.seenLastRound = otherCivUnitsCount
     }
 
     private fun offerResearchAgreement(civInfo: CivilizationInfo) {

--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -12,6 +12,7 @@ import com.unciv.logic.civilization.diplomacy.DiplomacyFlags
 import com.unciv.logic.civilization.diplomacy.DiplomacyManager
 import com.unciv.logic.civilization.diplomacy.DiplomaticStatus
 import com.unciv.logic.civilization.diplomacy.RelationshipLevel
+import com.unciv.logic.map.InfluenceMap.setInfluenceScore
 import com.unciv.logic.map.MapUnit
 import com.unciv.logic.map.TileInfo
 import com.unciv.logic.trade.TradeEvaluation
@@ -62,6 +63,7 @@ class CivilizationInfo {
     var greatPeople = GreatPersonManager()
     var victoryManager=VictoryManager()
     var diplomacy = HashMap<String, DiplomacyManager>()
+    var memoryManager = MemoryManager()
     var notifications = ArrayList<Notification>()
     val popupAlerts = ArrayList<PopupAlert>()
     private var allyCivName = ""
@@ -95,6 +97,7 @@ class CivilizationInfo {
         toReturn.goldenAges = goldenAges.clone()
         toReturn.greatPeople = greatPeople.clone()
         toReturn.victoryManager = victoryManager.clone()
+        toReturn.memoryManager = memoryManager.clone()
         toReturn.allyCivName = allyCivName
         for (diplomacyManager in diplomacy.values.map { it.clone() })
             toReturn.diplomacy.put(diplomacyManager.otherCivName, diplomacyManager)
@@ -382,6 +385,7 @@ class CivilizationInfo {
 
     fun setTransients() {
         goldenAges.civInfo = this
+        memoryManager.civInfo = this
 
         policies.civInfo = this
         if(policies.adoptedPolicies.size>0 && policies.numberOfAdoptedPolicies == 0)
@@ -423,6 +427,7 @@ class CivilizationInfo {
     fun updateDetailedCivResources() = transients().updateDetailedCivResources()
 
     fun startTurn() {
+        setInfluenceScore(this)
         policies.startTurn()
         updateStatsForNextTurn() // for things that change when turn passes e.g. golden age, city state influence
 

--- a/core/src/com/unciv/logic/civilization/MemoryManager.kt
+++ b/core/src/com/unciv/logic/civilization/MemoryManager.kt
@@ -1,0 +1,79 @@
+package com.unciv.logic.civilization
+
+import com.unciv.logic.automation.Automation.evaluteCombatStrength
+import com.unciv.logic.map.MapUnit
+import com.unciv.models.ruleset.unit.UnitType
+import kotlin.math.max
+import kotlin.math.sqrt
+
+data class MemoryUnit(val civName: String,
+                      val type: UnitType,
+                      val number: Int = 0
+                      )
+
+class MemoryManager() {
+    @Transient lateinit var civInfo: CivilizationInfo
+    
+    var seenLastRound = 0
+    var seenPrevLastRound = 0
+
+    var listOfUnits: MutableList<MemoryUnit> = mutableListOf()
+
+    fun clone(): MemoryManager {
+        val toReturn = MemoryManager()
+        toReturn.listOfUnits.addAll(listOfUnits)
+        toReturn.seenLastRound = seenLastRound
+        toReturn.seenPrevLastRound = seenPrevLastRound
+        return toReturn
+    }
+
+    fun addCivUnit(unit: MapUnit) {
+        var unitFound = listOfUnits.find { it.civName == unit.civInfo.civName && it.type == unit.type }
+
+        if (unitFound != null) {
+            var unitIndex = listOfUnits.indexOf(unitFound)
+            listOfUnits[unitIndex] = MemoryUnit(unit.civInfo.civName, unit.type, listOfUnits[unitIndex].number + 1)
+        } else {
+            listOfUnits.add(MemoryUnit(unit.civInfo.civName, unit.type, 1))
+        }
+    }
+    
+    fun subtractCivUnit(unit: MapUnit) {
+        var unitFound = listOfUnits.find { it.civName == unit.civInfo.civName && it.type == unit.type }
+
+        if (unitFound != null) {
+            var unitIndex = listOfUnits.indexOf(unitFound)
+            listOfUnits[unitIndex] = MemoryUnit(unit.civInfo.civName, unit.type, if (listOfUnits[unitIndex].number == 0) 0 else listOfUnits[unitIndex].number - 1)
+        } else {
+            listOfUnits.add(MemoryUnit(unit.civInfo.civName, unit.type, 1))
+        }
+    }
+    
+    fun setCivUnit(unit: MapUnit, unitNumber: Int) {
+        var unitFound = listOfUnits.find { it.civName == unit.civInfo.civName && it.type == unit.type }
+
+        if (unitFound != null) {
+            var unitIndex = listOfUnits.indexOf(unitFound)
+            listOfUnits[unitIndex] = MemoryUnit(unit.civInfo.civName, unit.type, unitNumber)
+        } else {
+            listOfUnits.add(MemoryUnit(unit.civInfo.civName, unit.type, unitNumber))
+        }
+    }
+    
+    fun setBaselineStrength() {
+        for (civ in civInfo.getKnownCivs()) {
+            var numberOfMilitaryUnits = civ.getCivUnits().filter { it.type.isMilitary() }.count()
+            
+            var perceivedNumberOfMilitaryUnits = listOfUnits.filter { it.civName == civ.civName }.sumBy { it.number }
+            
+            if (perceivedNumberOfMilitaryUnits > numberOfMilitaryUnits) { // If Strength is a known demographic then I figure anyone can get a rough estimate by seeing the units and comparing it the leaderboard
+                for (unit in listOfUnits.filter { it.civName == civ.civName }) {
+                    var unitIndex = listOfUnits.indexOf(unit)
+                    listOfUnits[unitIndex] = MemoryUnit(listOfUnits[unitIndex].civName, listOfUnits[unitIndex].type, if (listOfUnits[unitIndex].number <= 0) 0 else listOfUnits[unitIndex].number - 1)
+                }
+            }
+        }
+
+    }
+    
+}

--- a/core/src/com/unciv/logic/map/InfluenceMap.kt
+++ b/core/src/com/unciv/logic/map/InfluenceMap.kt
@@ -1,0 +1,206 @@
+package com.unciv.logic.map
+
+import com.unciv.Constants
+import com.unciv.logic.battle.CityCombatant
+import com.unciv.logic.civilization.CivilizationInfo
+
+object InfluenceMap {
+
+    fun setInfluenceScore(viewingCiv: CivilizationInfo, tilesToCheck: List<TileInfo>? = null) {
+        val viewable = viewingCiv.gameInfo.tileMap.values
+        
+        //Such a dirty hack, need to actually create an object that holds these for each Civ
+        for (tile in viewable) {
+            tile.enemyInfluenceScore = 0.0F
+            tile.friendlyInfluenceScore = 0.0F
+        }
+        val tilesWithEnemies = (tilesToCheck ?: viewable)
+                .filter { containsEnemyUnit(it, viewingCiv) }
+        val tilesWithNeutralCombatant = (tilesToCheck ?: viewable)
+                .filter { containsNeutralUnit(it, viewingCiv) }
+        val tilesWithFriendlyCombatant = (tilesToCheck ?: viewable)
+                .filter { containsFriendlyUnit(it, viewingCiv) }
+        setEnemyTiles(tilesWithEnemies)
+        setNeutralTiles(tilesWithNeutralCombatant)
+        setFriendlyTiles(tilesWithFriendlyCombatant)
+
+    }
+    
+    private fun setEnemyTiles(enemyTiles: List<TileInfo>) {
+        for (enemyTile in enemyTiles) {
+            for (unit in enemyTile.getUnits()) {
+                if (unit.type.isMilitary()) {
+                    enemyTile.enemyInfluenceScore += (unit.baseUnit.strength * (1 + enemyTile.getDefensiveBonus())) * (unit.health/100.0F)
+                    if (unit.type.isMelee()) {
+                        val tilesInMoveRange = unit.movement.getDistanceToTilesWithinTurn(
+                            unit.getTile().position,
+                            unit.getMaxMovement().toFloat()
+                        ).keys.asSequence().filter { it.position != enemyTile.position }
+                        for (tile in tilesInMoveRange) {
+                            tile.enemyInfluenceScore += (unit.baseUnit.strength * (1 + tile.getDefensiveBonus())) * (unit.health / 100.0F)
+                        }
+                    }
+                    if (unit.type.isRanged()) {
+                        val rangeOfAttack = unit.getRange()
+                        val tilesInTargetRange =
+                                if (unit.hasUnique("Ranged attacks may be performed over obstacles") || unit.type.isAirUnit())
+                                    enemyTile.getTilesInDistance(rangeOfAttack)
+                                else enemyTile.getViewableTilesList(rangeOfAttack)
+                                        .asSequence()
+                        for (tile in tilesInTargetRange) {
+                            tile.enemyInfluenceScore += (unit.baseUnit.rangedStrength * (1 + tile.getDefensiveBonus())) * (unit.health / 100.0F)
+                        }
+                    }
+                } else if (unit.name == Constants.greatGeneral || unit.baseUnit.replaces == Constants.greatGeneral) {
+                    val tilesInAffectedRange = enemyTile.getTilesInDistance(2)
+                    for (tile in tilesInAffectedRange) {
+                        tile.enemyInfluenceScore *= 1.15F
+                    }
+                } else if (unit.type.isCivilian()) {
+                    enemyTile.enemyInfluenceScore = -2.0F
+                }
+            }
+            if (enemyTile.isCityCenter()) {
+                val enemyCity = enemyTile.getCity()
+                val tilesInTargetRange = enemyCity?.getCenterTile()?.getTilesInDistance(enemyCity.range)?.asSequence()?.filter { it.position != enemyTile.position }
+                    val enemyCityStrength = enemyCity?.let { CityCombatant(it).getCityStrength() }
+                enemyTile.enemyInfluenceScore += (enemyCityStrength?.toFloat()!! / 2.0F)
+                if (tilesInTargetRange != null) {
+                    for (tile in tilesInTargetRange) {
+                        tile.enemyInfluenceScore += (enemyCityStrength.toFloat() / 2.0F)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun setFriendlyTiles(friendlyTiles: List<TileInfo>) {
+        for (friendlyTile in friendlyTiles) {
+            for (unit in friendlyTile.getUnits()) {
+                if (unit.type.isMilitary()) {
+                    friendlyTile.friendlyInfluenceScore += (-unit.baseUnit.strength * (1 + friendlyTile.getDefensiveBonus())) * (unit.health/100.0F)
+                    if (unit.type.isMelee()) {
+                        val tilesInMoveRange = unit.movement.getDistanceToTilesWithinTurn(
+                                unit.getTile().position,
+                                unit.getMaxMovement().toFloat()
+                        ).keys.asSequence().filter { it.position != friendlyTile.position }
+                        for (tile in tilesInMoveRange) {
+                            tile.friendlyInfluenceScore += (-unit.baseUnit.strength * (1 + tile.getDefensiveBonus())) * (unit.health / 100.0F)
+                        }
+                    }
+                    if (unit.type.isRanged()) {
+                        val rangeOfAttack = unit.getRange()
+                        val tilesInTargetRange =
+                                if (unit.hasUnique("Ranged attacks may be performed over obstacles") || unit.type.isAirUnit())
+                                    friendlyTile.getTilesInDistance(rangeOfAttack)
+                                else friendlyTile.getViewableTilesList(rangeOfAttack)
+                                        .asSequence()
+                        for (tile in tilesInTargetRange) {
+                            tile.friendlyInfluenceScore += (-unit.baseUnit.rangedStrength * (1 + tile.getDefensiveBonus())) * (unit.health / 100.0F)
+                        }
+                    }
+                } else if (unit.name == Constants.greatGeneral || unit.baseUnit.replaces == Constants.greatGeneral) {
+                    val tilesInAffectedRange = friendlyTile.getTilesInDistance(2)
+                    for (tile in tilesInAffectedRange) {
+                        tile.friendlyInfluenceScore *= 1.15F
+                    }
+                } else if (unit.type.isCivilian()) {
+                    friendlyTile.friendlyInfluenceScore += 2.0F
+                }
+            }
+            if (friendlyTile.isCityCenter()) {
+                val friendlyCity = friendlyTile.getCity()
+                val tilesInTargetRange = friendlyCity?.getCenterTile()?.getTilesInDistance(friendlyCity.range)?.asSequence()?.filter { it.position != friendlyTile.position }
+                val friendlyCityStrength = friendlyCity?.let { CityCombatant(it).getCityStrength() }
+                friendlyTile.friendlyInfluenceScore += -friendlyCityStrength?.toFloat()!!
+                if (tilesInTargetRange != null) {
+                    for (tile in tilesInTargetRange) {
+                        tile.friendlyInfluenceScore += -friendlyCityStrength.toFloat()
+                    }
+                }
+            }
+        }
+    }
+
+    private fun setNeutralTiles(neutralTiles: List<TileInfo>) {
+        for (neutralTile in neutralTiles) {
+            for (unit in neutralTile.getUnits()) {
+                if (unit.type.isMilitary()) {
+                    neutralTile.enemyInfluenceScore += (unit.baseUnit.strength * (1 + neutralTile.getDefensiveBonus())) * (unit.health / 100.0F) * 0.5F
+                    if (unit.type.isMelee()) {
+                        val tilesInMoveRange = unit.movement.getDistanceToTilesWithinTurn(
+                                unit.getTile().position,
+                                unit.getMaxMovement().toFloat()
+                        ).keys.asSequence().filter { it.position != neutralTile.position }
+                        for (tile in tilesInMoveRange) {
+                            tile.enemyInfluenceScore += (unit.baseUnit.strength * (1 + tile.getDefensiveBonus())) * (unit.health / 100.0F)
+                        }
+                    }
+                    if (unit.type.isRanged()) {
+                        val rangeOfAttack = unit.getRange()
+                        val tilesInTargetRange =
+                                if (unit.hasUnique("Ranged attacks may be performed over obstacles") || unit.type.isAirUnit())
+                                    neutralTile.getTilesInDistance(rangeOfAttack)
+                                else neutralTile.getViewableTilesList(rangeOfAttack)
+                                        .asSequence()
+                        for (tile in tilesInTargetRange) {
+                            tile.enemyInfluenceScore += (unit.baseUnit.rangedStrength * (1 + tile.getDefensiveBonus())) * (unit.health / 100.0F)
+                        }
+                    }
+                } else if (unit.name == Constants.greatGeneral || unit.baseUnit.replaces == Constants.greatGeneral) {
+                    val tilesInAffectedRange = neutralTile.getTilesInDistance(2)
+                    for (tile in tilesInAffectedRange) {
+                        tile.enemyInfluenceScore *= 1.15F
+                    }
+                } else if (unit.type.isCivilian()) {
+                    neutralTile.enemyInfluenceScore += -2.0F
+                }
+            }
+            if (neutralTile.isCityCenter()) {
+                val neutralCity = neutralTile.getCity()
+                val tilesInTargetRange = neutralCity?.getCenterTile()?.getTilesInDistance(neutralCity.range)?.asSequence()?.filter { it.position != neutralTile.position }
+                    val neutralCityStrength = neutralCity?.let { CityCombatant(it).getCityStrength() }
+                neutralTile.enemyInfluenceScore += ((neutralCityStrength?.toFloat()!! / 2.0F) * 0.5F)
+                if (tilesInTargetRange != null) {
+                    for (tile in tilesInTargetRange) {
+                        tile.enemyInfluenceScore += ((neutralCityStrength?.toFloat()!! / 2.0F) * 0.5F)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun containsEnemyUnit(tile: TileInfo, viewingCiv: CivilizationInfo): Boolean {
+        for (unit in tile.getUnits()) {
+            if (unit.civInfo == viewingCiv) return false
+            if (unit.civInfo.isAtWarWith(viewingCiv)) return true
+        }
+        if (tile.isCityCenter()) {
+            if (tile.getCity()?.civInfo == viewingCiv) return false
+            if (tile.getCity()?.civInfo?.isAtWarWith(viewingCiv)!!) return true
+        }
+        return false
+    }
+
+    private fun containsNeutralUnit(tile: TileInfo, viewingCiv: CivilizationInfo): Boolean {
+        for (unit in tile.getUnits()) {
+            if (unit.civInfo == viewingCiv) return false
+            if (!unit.civInfo.isAtWarWith(viewingCiv)) return true
+        }
+        if (tile.isCityCenter()) {
+            if (tile.getCity()?.civInfo == viewingCiv) return false
+            if (!tile.getCity()?.civInfo?.isAtWarWith(viewingCiv)!!) return true
+        }
+        return false
+    }
+
+    private fun containsFriendlyUnit(tile: TileInfo, viewingCiv: CivilizationInfo): Boolean {
+        for (unit in tile.getUnits()) {
+            if (unit.civInfo == viewingCiv) return true
+        }
+        if (tile.isCityCenter()) {
+            if (tile.getCity()?.civInfo == viewingCiv) return true
+        }
+        return false
+    }
+}

--- a/core/src/com/unciv/logic/map/TileInfo.kt
+++ b/core/src/com/unciv/logic/map/TileInfo.kt
@@ -55,6 +55,9 @@ open class TileInfo {
     val longitude: Float
         get() = HexMath.getLongitude(position)
 
+    var friendlyInfluenceScore: Float = 0F
+    var enemyInfluenceScore: Float = 0F
+
     fun clone(): TileInfo {
         val toReturn = TileInfo()
         if (militaryUnit != null) toReturn.militaryUnit = militaryUnit!!.clone()
@@ -102,6 +105,8 @@ open class TileInfo {
         if (airUnits.isNotEmpty()) return airUnits.first()
         return null
     }
+    
+    fun getInfluence(): Float = friendlyInfluenceScore + enemyInfluenceScore
 
     fun getCity(): CityInfo? = owningCity
 

--- a/core/src/com/unciv/models/metadata/GameSettings.kt
+++ b/core/src/com/unciv/models/metadata/GameSettings.kt
@@ -9,6 +9,7 @@ data class WindowState (val width:Int=0, val height:Int=0)
 class GameSettings {
     var showWorkedTiles: Boolean = false
     var showResourcesAndImprovements: Boolean = true
+    var showInfluenceMap: Boolean = false
     var checkForDueUnits: Boolean = true
     var singleTapMove: Boolean = false
     var language: String = "English"

--- a/core/src/com/unciv/ui/tilegroups/TileGroupIcons.kt
+++ b/core/src/com/unciv/ui/tilegroups/TileGroupIcons.kt
@@ -18,6 +18,7 @@ class TileGroupIcons(val tileGroup: TileGroup){
 
     var improvementIcon: Actor? = null
     var populationIcon: Image? = null //reuse for acquire icon
+    var influenceSizeTable: Table? = null
 
     var civilianUnitIcon: UnitGroup? = null
     var militaryUnitIcon: UnitGroup? = null
@@ -25,11 +26,30 @@ class TileGroupIcons(val tileGroup: TileGroup){
     fun update(showResourcesAndImprovements: Boolean, tileIsViewable: Boolean, showMilitaryUnit: Boolean, viewingCiv:CivilizationInfo?) {
         updateResourceIcon(showResourcesAndImprovements)
         updateImprovementIcon(showResourcesAndImprovements)
+        /*
+        if (viewingCiv != null) {
+            InfluenceMap.setInfluenceScore(viewingCiv, viewingCiv.viewableTiles)
+        }
+        */
 
         civilianUnitIcon = newUnitIcon(tileGroup.tileInfo.civilianUnit, civilianUnitIcon,
                 tileIsViewable, -20f, viewingCiv)
         militaryUnitIcon = newUnitIcon(tileGroup.tileInfo.militaryUnit, militaryUnitIcon,
                 tileIsViewable && showMilitaryUnit, 20f, viewingCiv)
+    }
+    
+    fun addInfluenceScore(table: Table = Table().apply { defaults().pad(5f) }) {
+        influenceSizeTable?.remove()
+        influenceSizeTable = table
+        influenceSizeTable!!.add(tileGroup.tileInfo.getInfluence().toString().toLabel(Color.BLACK, 16))
+        influenceSizeTable!!.setOrigin(Align.center)
+        influenceSizeTable!!.center(tileGroup)
+        tileGroup.miscLayerGroup.addActor(influenceSizeTable)
+    }
+    
+    fun removeInfluenceScore() {
+        influenceSizeTable?.remove()
+        influenceSizeTable = null
     }
 
     fun addPopulationIcon(icon: Image = ImageGetter.getStatIcon("Population")

--- a/core/src/com/unciv/ui/tilegroups/WorldTileGroup.kt
+++ b/core/src/com/unciv/ui/tilegroups/WorldTileGroup.kt
@@ -25,12 +25,17 @@ class WorldTileGroup(internal val worldScreen: WorldScreen, tileInfo: TileInfo, 
         val city = tileInfo.getCity()
 
         icons.removePopulationIcon()
+        icons.removeInfluenceScore()
         val tileIsViewable = isViewable(viewingCiv)
         val showEntireMap = UncivGame.Current.viewEntireMapForDebug
 
         if (tileIsViewable && tileInfo.isWorked() && UncivGame.Current.settings.showWorkedTiles
                 && city!!.civInfo == viewingCiv)
             icons.addPopulationIcon()
+
+        if (tileIsViewable && UncivGame.Current.settings.showInfluenceMap)
+            icons.addInfluenceScore()
+
         // update city buttons in explored tiles or entire map
         if (showEntireMap || viewingCiv.exploredTiles.contains(tileInfo.position))
             updateCityButton(city, tileIsViewable || showEntireMap) // needs to be before the update so the units will be above the city button

--- a/core/src/com/unciv/ui/worldscreen/Minimap.kt
+++ b/core/src/com/unciv/ui/worldscreen/Minimap.kt
@@ -154,6 +154,16 @@ class MinimapHolder(mapHolder: WorldMapHolder): Table(){
             worldScreen.shouldUpdate=true
         }
         toggleIconTable.add(resourceImage)
+        
+        val influenceMapImage = ImageGetter.getStatIcon("Specialist").surroundWithCircle(40f)
+        influenceMapImage.circle.color = Color.BLACK
+        influenceMapImage.actor.color.a = if(settings.showInfluenceMap) 1f else 0.5f
+        influenceMapImage.onClick {
+            settings.showInfluenceMap = !settings.showInfluenceMap
+            influenceMapImage.actor.color.a = if(settings.showInfluenceMap) 1f else 0.5f
+            worldScreen.shouldUpdate=true
+        }
+        toggleIconTable.add(influenceMapImage).row()
         toggleIconTable.pack()
         return toggleIconTable
     }

--- a/core/src/com/unciv/ui/worldscreen/bottombar/TileInfoTable.kt
+++ b/core/src/com/unciv/ui/worldscreen/bottombar/TileInfoTable.kt
@@ -21,8 +21,14 @@ class TileInfoTable(private val viewingCiv :CivilizationInfo) : Table(CameraStag
         if (tile != null && (UncivGame.Current.viewEntireMapForDebug || viewingCiv.exploredTiles.contains(tile.position)) ) {
             add(getStatsTable(tile))
             add(tile.toString(viewingCiv).toLabel()).colspan(2).pad(10f)
-        }
+            row()
+            add("Total Influence: " + tile.getInfluence().toString()).colspan(3).align(Align.right)
+            row()
+            add("Friendly Influence: " + tile.friendlyInfluenceScore.toString()).colspan(3).align(Align.right)
+            row()
+            add("Enemy Influence: " + tile.enemyInfluenceScore.toString()).colspan(3).align(Align.right)
 
+        }
         pack()
     }
 


### PR DESCRIPTION
Added Influence Map so that AI can see areas of enemy influence and "try" to act accordingly. This is a hack as far as I'm concerned, while it implements fine, I think a lot of optimization can be done there. Basically what happens is that every turn it iterates though the whole map and add up the strength of the units in the tiles and the tiles it can reach for each Civ.

I changed BattleHelper.kt to have units attack units in areas of lowest influence

I did some major tweeks to UnitAutomation.kt. I created five new function to help units act in a more logical way.

For tryTakeBackCapturedCity I made the AI do an all out move to try and take back a captured city. I didn't see much improvement in the AI but it's there. I also made a tryHeadTowardsSiegedCity to motivate the AI to protect cities under attack. It seems to do the job actually, It definitely takes more units to fight a city.

For tryHeadTowardsWeakestCity I made the AI choose to attack the city with the weakest influence. It seems it works pretty well but you do have some edge cases were the AI attacks enclaves or island cities. Maybe some more logic could help it.

For tryPatrolBoarders I made the AI move Units to areas it perceives as weakest, this prevents some wacky behavior were they would just have a ton of ships of their shores or just have units in illogical places.

I changed tryHealUnit where units don't stay in areas they get attacked from ranged units. They also try to move to areas that has the most friendly influence.

For the UI I've added a button to show the influence on the Map just to make sure numbers look right. I've also added it to the TitleInfoTable. That probably can be removed.

This is my first major contribution to a FOSS project, so be gentle?