### PR TITLE
Workers stop building (most) duplicate roads connecting cities.

### DIFF
--- a/core/src/com/unciv/logic/automation/WorkerAutomation.kt
+++ b/core/src/com/unciv/logic/automation/WorkerAutomation.kt
@@ -75,7 +75,7 @@ class WorkerAutomation(val unit: MapUnit) {
         if(citiesThatNeedConnecting.none()) return false // do nothing.
 
         val citiesThatNeedConnectingBfs = citiesThatNeedConnecting
-                .sortedBy { it.getCenterTile().aerialDistanceTo(unit.getTile()) }
+                .sortedBy { it.getCenterTile().aerialDistanceTo(unit.civInfo.getCapital().getCenterTile()) }
                 .map { city -> BFS(city.getCenterTile()){it.isLand && unit.movement.canPassThrough(it)} }
 
         val connectedCities = unit.civInfo.cities.filter { it.isCapital() || it.cityStats.isConnectedToCapital(targetRoad) }


### PR DESCRIPTION
Make workers build roads considering only cities' locations instead of their individual positions.

This makes roads radiating from capital to nearest cities, before trying to connect very far cities directly to capital. Workers used to build many unfinished/useless railroads when Railroad was researched.