### PR TITLE
Hide unique buildings, units, improvements from Nation Picker

### DIFF
--- a/core/src/com/unciv/models/ruleset/Nation.kt
+++ b/core/src/com/unciv/models/ruleset/Nation.kt
@@ -37,6 +37,7 @@ class Nation : INamed {
     var hateHello = ""
 
     lateinit var outerColor: List<Int>
+    val hideUniques = ""
     var uniqueName = ""
     var uniques = HashSet<String>()
     val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it) } }
@@ -111,6 +112,7 @@ class Nation : INamed {
     }
 
     private fun addUniqueBuildingsText(textList: ArrayList<String>, ruleset: Ruleset) {
+        if (hideUniques.contains("Buildings")) return
         for (building in ruleset.buildings.values
                 .filter { it.uniqueTo == name && "Will not be displayed in Civilopedia" !in it.uniques}) {
             if (building.replaces != null && ruleset.buildings.containsKey(building.replaces!!)) {
@@ -140,6 +142,7 @@ class Nation : INamed {
     }
 
     private fun addUniqueUnitsText(textList: ArrayList<String>, ruleset: Ruleset) {
+        if (hideUniques.contains("Units")) return
         for (unit in ruleset.units.values
                 .filter { it.uniqueTo == name && "Will not be displayed in Civilopedia" !in it.uniques}) {
             if (unit.replaces != null && ruleset.units.containsKey(unit.replaces!!)) {
@@ -176,6 +179,7 @@ class Nation : INamed {
     }
 
     private fun addUniqueImprovementsText(textList: ArrayList<String>, ruleset: Ruleset) {
+        if (hideUniques.contains("Improvements")) return
         for (improvement in ruleset.tileImprovements.values
                 .filter { it.uniqueTo == name }) {
 


### PR DESCRIPTION
For brevity & readability in Nation Picker, in mods with large numbers of civ unique replacements

(currently, this can only be achieved with "will not be displayed in Civiliopedia")

new value in nations.json "hideUniques" - string that can contain "Buildings" "Units" "Improvements"