### PR TITLE
hide replaced constructions when tech requirements differ

### DIFF
--- a/core/src/com/unciv/models/ruleset/tech/Technology.kt
+++ b/core/src/com/unciv/models/ruleset/tech/Technology.kt
@@ -85,8 +85,7 @@ class Technology {
                     it.uniqueTo == null || it.uniqueTo == civInfo.civName
         }
         val replacedBuildings = enabledBuildings.mapNotNull { it.replaces }
-        enabledBuildings = enabledBuildings.filter { it.name !in replacedBuildings }
-        enabledBuildings = enabledBuildings.filter { it.requiredTech == name }
+        enabledBuildings = enabledBuildings.filter { it.name !in replacedBuildings && it.requiredTech == name }
 
         if (!civInfo.gameInfo.gameParameters.nuclearWeaponsEnabled)
             enabledBuildings = enabledBuildings.filterNot { it.name == "Manhattan Project" }

--- a/core/src/com/unciv/models/ruleset/tech/Technology.kt
+++ b/core/src/com/unciv/models/ruleset/tech/Technology.kt
@@ -82,11 +82,11 @@ class Technology {
 
     fun getEnabledBuildings(civInfo: CivilizationInfo): List<Building> {
         var enabledBuildings = civInfo.gameInfo.ruleSet.buildings.values.filter {
-            it.requiredTech == name &&
-                    (it.uniqueTo == null || it.uniqueTo == civInfo.civName)
+                    it.uniqueTo == null || it.uniqueTo == civInfo.civName
         }
         val replacedBuildings = enabledBuildings.mapNotNull { it.replaces }
         enabledBuildings = enabledBuildings.filter { it.name !in replacedBuildings }
+        enabledBuildings = enabledBuildings.filter { it.requiredTech == name }
 
         if (!civInfo.gameInfo.gameParameters.nuclearWeaponsEnabled)
             enabledBuildings = enabledBuildings.filterNot { it.name == "Manhattan Project" }


### PR DESCRIPTION
just a small change to the order of things, previously if you had unique constructions that used a different tech, the original still showed up in the tech tree