### PR TITLE
minimum city production

### DIFF
--- a/core/src/com/unciv/logic/city/CityStats.kt
+++ b/core/src/com/unciv/logic/city/CityStats.kt
@@ -541,7 +541,7 @@ class CityStats {
             newFinalStatList.clear()  // NOPE
 
         if (newFinalStatList.values.map { it.production }.sum() < 1)  // Minimum production for things to progress
-            newFinalStatList["Production"] = Stats().apply { production += 1 }
+            newFinalStatList["Production"] = Stats().apply { production = 1F }
         finalStatList = newFinalStatList
     }
 


### PR DESCRIPTION
= 1F instead of += 1

![unknown](https://user-images.githubusercontent.com/65415105/103376778-82548a00-4ad5-11eb-9767-8be8e218b93d.png)
in this modded game, negative production buildings lead to a total negative score that the original code can't handle