### PR TITLE
multiple game support for TurnChecker

### DIFF
--- a/android/src/com/unciv/app/MultiplayerTurnCheckWorker.kt
+++ b/android/src/com/unciv/app/MultiplayerTurnCheckWorker.kt
@@ -12,7 +12,6 @@ import androidx.core.app.NotificationCompat.DEFAULT_VIBRATE
 import androidx.core.app.NotificationManagerCompat
 import androidx.work.*
 import com.badlogic.gdx.backends.android.AndroidApplication
-import com.unciv.UncivGame
 import com.unciv.logic.GameInfo
 import com.unciv.logic.GameSaver
 import com.unciv.models.metadata.GameSettings
@@ -22,7 +21,6 @@ import java.io.StringWriter
 import java.io.Writer
 import java.util.*
 import java.util.concurrent.TimeUnit
-import kotlin.concurrent.thread
 
 
 class MultiplayerTurnCheckWorker(appContext: Context, workerParams: WorkerParameters)

--- a/core/src/com/unciv/logic/GameSaver.kt
+++ b/core/src/com/unciv/logic/GameSaver.kt
@@ -163,5 +163,14 @@ object GameSaver {
         val game = json().fromJson(GameInfo::class.java, gameData)
         return game.getCivilization(game.currentPlayer)
     }
+
+    /**
+     * Returns the gameId from a GameInfo which was saved as JSON for multiplayer
+     * Does not initialize transitive GameInfo data.
+     * It is therefore stateless and save to call for Multiplayer Turn Notifier.
+     */
+    fun getGameIdFromFile(gameFile: FileHandle): String {
+        return json().fromJson(GameInfo::class.java, gameFile).gameId
+    }
 }
 

--- a/core/src/com/unciv/logic/GameSaver.kt
+++ b/core/src/com/unciv/logic/GameSaver.kt
@@ -77,6 +77,15 @@ object GameSaver {
         return game
     }
 
+    /**
+     * WARNING! transitive GameInfo data not initialized
+     * The returned GameInfo can not be used for most circumstances because its not initialized!
+     * It is therefore stateless and save to call for Multiplayer Turn Notifier, unlike gameInfoFromString().
+     */
+    fun gameInfoFromStringWithoutTransients(gameData: String): GameInfo {
+        return json().fromJson(GameInfo::class.java, gameData)
+    }
+
     fun deleteSave(GameName: String, multiplayer: Boolean = false){
         getSave(GameName, multiplayer).delete()
     }

--- a/core/src/com/unciv/logic/GameSaver.kt
+++ b/core/src/com/unciv/logic/GameSaver.kt
@@ -164,16 +164,6 @@ object GameSaver {
     }
 
     /**
-     * Returns current turn's player from GameInfo JSON-String for multiplayer.
-     * Does not initialize transitive GameInfo data.
-     * It is therefore stateless and save to call for Multiplayer Turn Notifier, unlike gameInfoFromString().
-     */
-    fun currentTurnCivFromString(gameData: String): CivilizationInfo {
-        val game = json().fromJson(GameInfo::class.java, gameData)
-        return game.getCivilization(game.currentPlayer)
-    }
-
-    /**
      * Returns the gameId from a GameInfo which was saved as JSON for multiplayer
      * Does not initialize transitive GameInfo data.
      * It is therefore stateless and save to call for Multiplayer Turn Notifier.

--- a/core/src/com/unciv/ui/worldscreen/mainmenu/DropBox.kt
+++ b/core/src/com/unciv/ui/worldscreen/mainmenu/DropBox.kt
@@ -127,6 +127,16 @@ class OnlineMultiplayer {
     }
 
     /**
+     * WARNING!
+     * Does not initialize transitive GameInfo data.
+     * It is therefore stateless and save to call for Multiplayer Turn Notifier, unlike tryDownloadGame().
+     */
+    fun tryDownloadGameUninitialized(gameId: String): GameInfo {
+        val zippedGameInfo = DropBox.downloadFileAsString(getGameLocation(gameId))
+        return GameSaver.gameInfoFromStringWithoutTransients(Gzip.unzip(zippedGameInfo))
+    }
+
+    /**
      * Returns current turn's player.
      * Does not initialize transitive GameInfo data.
      * It is therefore stateless and save to call for Multiplayer Turn Notifier, unlike tryDownloadGame().

--- a/core/src/com/unciv/ui/worldscreen/mainmenu/DropBox.kt
+++ b/core/src/com/unciv/ui/worldscreen/mainmenu/DropBox.kt
@@ -135,16 +135,6 @@ class OnlineMultiplayer {
         val zippedGameInfo = DropBox.downloadFileAsString(getGameLocation(gameId))
         return GameSaver.gameInfoFromStringWithoutTransients(Gzip.unzip(zippedGameInfo))
     }
-
-    /**
-     * Returns current turn's player.
-     * Does not initialize transitive GameInfo data.
-     * It is therefore stateless and save to call for Multiplayer Turn Notifier, unlike tryDownloadGame().
-     */
-    fun tryDownloadCurrentTurnCiv(gameId: String): CivilizationInfo {
-        val zippedGameInfo = DropBox.downloadFileAsString(getGameLocation(gameId))
-        return GameSaver.currentTurnCivFromString(Gzip.unzip(zippedGameInfo))
-    }
 }
 
 object Github {


### PR DESCRIPTION
With this, the TurnChecker sends a notification if it's the user's turn in any of the multiplayer games and not just the currently running one.
It also saves the files after downloading them so the multiplayer screen stays up to date.