### PR TITLE
Rename "Haka War Dance" effect to "Intimidation"

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ buildscript {
     dependencies {
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${com.unciv.build.BuildConfig.kotlinVersion}")
         classpath("de.richsource.gradle.plugins:gwt-gradle-plugin:0.6")
-        classpath("com.android.tools.build:gradle:4.1.0")
+        classpath("com.android.tools.build:gradle:4.1.1")
         classpath("com.mobidevelop.robovm:robovm-gradle-plugin:2.3.1")
 
         // This is for wrapping the .jar file into a standalone executable

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ buildscript {
     dependencies {
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${com.unciv.build.BuildConfig.kotlinVersion}")
         classpath("de.richsource.gradle.plugins:gwt-gradle-plugin:0.6")
-        classpath("com.android.tools.build:gradle:4.1.1")
+        classpath("com.android.tools.build:gradle:4.1.0")
         classpath("com.mobidevelop.robovm:robovm-gradle-plugin:2.3.1")
 
         // This is for wrapping the .jar file into a standalone executable

--- a/core/src/com/unciv/logic/battle/BattleDamage.kt
+++ b/core/src/com/unciv/logic/battle/BattleDamage.kt
@@ -219,7 +219,7 @@ object BattleDamage {
 
         if (tile.neighbors.flatMap { it.getUnits() }
                         .any { it.hasUnique("-10% combat strength for adjacent enemy units") && it.civInfo.isAtWarWith(unit.getCivInfo()) })
-            modifiers["Haka War Dance"] = -10
+            modifiers["Intimidation"] = -10
 
 
         val isRoughTerrain = tile.isRoughTerrain()

--- a/core/src/com/unciv/logic/city/CityStats.kt
+++ b/core/src/com/unciv/logic/city/CityStats.kt
@@ -354,6 +354,10 @@ class CityStats {
         if (uniques.any { it.text == "Culture in all cities increased by 25%" })
             stats.culture += 25f
 
+        for (unique in uniques.filter {"+[]% [] in all cities"}) {
+            stats.add(Stat.valueOf(unique.params[1]), unique.params[0].toFloat())
+        }
+
         return stats
     }
 

--- a/core/src/com/unciv/logic/city/CityStats.kt
+++ b/core/src/com/unciv/logic/city/CityStats.kt
@@ -354,10 +354,6 @@ class CityStats {
         if (uniques.any { it.text == "Culture in all cities increased by 25%" })
             stats.culture += 25f
 
-        for (unique in uniques.filter {"+[]% [] in all cities"}) {
-            stats.add(Stat.valueOf(unique.params[1]), unique.params[0].toFloat())
-        }
-
         return stats
     }
 


### PR DESCRIPTION
In the expansions, the Haka War Dance's area effect is shared by the African Forest Elephant, under the name "Feared Elephant". The common denominator is intimidation - striking fear into the enemy. This renaming allows the existing unique and its effects to be applied to all kinds of units without specifically referencing the Maori Warrior, which will enable modders (and hopefully one day the base game) to have fearsome units without having elephants doing the Haka.