### PR TITLE
"Luxury resource" and "Bonus resource" parameters for uniques

### DIFF
--- a/core/src/com/unciv/logic/map/TileInfo.kt
+++ b/core/src/com/unciv/logic/map/TileInfo.kt
@@ -208,6 +208,8 @@ open class TileInfo {
                 if (matchesUniqueFilter(tileType)
                         || (resource == tileType && hasViewableResource(observingCiv))
                         || (tileType == "Strategic resource" && hasViewableResource(observingCiv) && getTileResource().resourceType == ResourceType.Strategic)
+                        || (tileType == "Luxury resource" && hasViewableResource(observingCiv) && getTileResource().resourceType == ResourceType.Luxury)
+                        || (tileType == "Bonus resource" && hasViewableResource(observingCiv) && getTileResource().resourceType == ResourceType.Bonus)
                         || (tileType == "Water resource" && isWater && hasViewableResource(observingCiv))
                 ) stats.add(unique.stats)
             }


### PR DESCRIPTION
My first real pull request :P. I saw ResourceType.Luxury and ResourceType.Bonus being used in MapGenerator.kt so I thought why not make them accessible as a parameter for uniques?