### PR TITLE
Avoid overflow of the health bar in the overkill situation

### DIFF
--- a/core/src/com/unciv/ui/worldscreen/bottombar/BattleTable.kt
+++ b/core/src/com/unciv/ui/worldscreen/bottombar/BattleTable.kt
@@ -309,8 +309,9 @@ class BattleTable(val worldScreen: WorldScreen): Table() {
     private fun getHealthBar(currentHealth: Int, maxHealth: Int, expectedDamage:Int): Table {
         val healthBar = Table()
         val totalWidth = 100f
-        fun addHealthToBar(image: Image, amount:Int){
-            healthBar.add(image).size(amount*totalWidth/maxHealth,3f)
+        fun addHealthToBar(image: Image, amount:Int) {
+            val width = totalWidth * amount/maxHealth
+            healthBar.add(image).size(width.coerceIn(0f,totalWidth),3f)
         }
         addHealthToBar(ImageGetter.getDot(Color.BLACK), maxHealth-currentHealth)
 


### PR DESCRIPTION
Fixes #3541 

In the rare situations the unit causes/receives too much damage, so it causes the overflow of the health bar and it stretches out.
The solution is to keep the width of the health bar within the reasonable frame.