### PR TITLE
Scroll indicators are displayed more consistently on the NewGameScreen

### DIFF
--- a/core/src/com/unciv/ui/newgamescreen/NewGameScreen.kt
+++ b/core/src/com/unciv/ui/newgamescreen/NewGameScreen.kt
@@ -52,10 +52,13 @@ class NewGameScreen(previousScreen:CameraStageBaseScreen, _gameSetupInfo: GameSe
         topTable.add(ScrollPane(newGameOptionsTable, skin).apply { setOverscroll(false, false) })
                 .maxHeight(topTable.parent.height).width(stage.width / 3).padTop(20f).top()
         topTable.addSeparatorVertical()
-        topTable.add(ScrollPane(mapOptionsTable).apply { setOverscroll(false, false) })
+        topTable.add(ScrollPane(mapOptionsTable, skin).apply { setOverscroll(false, false) })
                 .maxHeight(topTable.parent.height).width(stage.width / 3).padTop(20f).top()
         topTable.addSeparatorVertical()
-        topTable.add(playerPickerTable).maxHeight(topTable.parent.height).width(stage.width / 3).padTop(20f).top()
+        topTable.add(ScrollPane(playerPickerTable, skin)
+                .apply { setOverscroll(false, false) }
+                .apply { setScrollingDisabled(true, false) })
+                .maxHeight(topTable.parent.height).width(stage.width / 3).padTop(20f).top()
 
         topTable.pack()
         topTable.setFillParent(true)


### PR DESCRIPTION
Hi, I felt that 2 thirds of the NewGameScreen not showing scroll indicators was unintentional. It's a minor change, but I thought it was worth adjusting anyway.