### PR TITLE
Avoid overflow of the construction bar

### DIFF
--- a/core/src/com/unciv/ui/utils/ImageGetter.kt
+++ b/core/src/com/unciv/ui/utils/ImageGetter.kt
@@ -316,7 +316,9 @@ object ImageGetter {
 
     fun getProgressBarVertical(width: Float, height: Float, percentComplete: Float, progressColor: Color, backgroundColor: Color): Table {
         val advancementGroup = Table()
-        val completionHeight = height * percentComplete
+        var completionHeight = height * percentComplete
+        if (completionHeight > height)
+            completionHeight = height
         advancementGroup.add(getImage(whiteDotLocation).apply { color = backgroundColor })
                 .size(width, height - completionHeight).row()
         advancementGroup.add(getImage(whiteDotLocation).apply { color = progressColor }).size(width, completionHeight)


### PR DESCRIPTION
Avoiding overflow when the percentComplete parameter for getProgressBarVertical is > 1 by resetting to max height
![bug](https://user-images.githubusercontent.com/24532072/106788870-d4974680-6651-11eb-8660-90ae792d7383.PNG)
![bugFix](https://user-images.githubusercontent.com/24532072/106788877-d6610a00-6651-11eb-9ebf-a7dbabbaa7f0.PNG)
This also fixes the same overflow in the construction table
