### PR TITLE
World Wrap v0.4

### DIFF
--- a/core/src/com/unciv/logic/HexMath.kt
+++ b/core/src/com/unciv/logic/HexMath.kt
@@ -136,23 +136,14 @@ object HexMath {
         }
         for (i in 0 until distance) { // 8 to 10
             vectors += current.cpy()
-            if (worldWrap){
-                if ((distance != maxDistance))
-                    vectors += origin.cpy().scl(2f).sub(current) // Get vector on other side of clock
-            } else {
+            if (!worldWrap || distance != maxDistance)
                 vectors += origin.cpy().scl(2f).sub(current) // Get vector on other side of clock
-            }
             current.add(1f, 1f)
         }
         for (i in 0 until distance) { // 10 to 12
             vectors += current.cpy()
-            if (worldWrap){
-                if ((distance != maxDistance ||  i != 0)){
-                    vectors += origin.cpy().scl(2f).sub(current) // Get vector on other side of clock
-                }
-            } else {
+            if (!worldWrap || distance != maxDistance ||  i != 0)
                 vectors += origin.cpy().scl(2f).sub(current) // Get vector on other side of clock
-            }
             current.add(0f, 1f)
         }
         return vectors

--- a/core/src/com/unciv/logic/HexMath.kt
+++ b/core/src/com/unciv/logic/HexMath.kt
@@ -122,7 +122,7 @@ object HexMath {
         return cubic2HexCoords(roundCubicCoords(hex2CubicCoords(hexCoord)))
     }
 
-    fun getVectorsAtDistance(origin: Vector2, distance: Int): List<Vector2> {
+    fun getVectorsAtDistance(origin: Vector2, distance: Int, maxDistance: Int, worldWrap: Boolean): List<Vector2> {
         val vectors = mutableListOf<Vector2>()
         if (distance == 0) {
             vectors += origin.cpy()
@@ -136,21 +136,32 @@ object HexMath {
         }
         for (i in 0 until distance) { // 8 to 10
             vectors += current.cpy()
-            vectors += origin.cpy().scl(2f).sub(current) // Get vector on other side of clock
+            if (worldWrap){
+                if ((distance != maxDistance))
+                    vectors += origin.cpy().scl(2f).sub(current) // Get vector on other side of clock
+            } else {
+                vectors += origin.cpy().scl(2f).sub(current) // Get vector on other side of clock
+            }
             current.add(1f, 1f)
         }
         for (i in 0 until distance) { // 10 to 12
             vectors += current.cpy()
-            vectors += origin.cpy().scl(2f).sub(current) // Get vector on other side of clock
+            if (worldWrap){
+                if ((distance != maxDistance ||  i != 0)){
+                    vectors += origin.cpy().scl(2f).sub(current) // Get vector on other side of clock
+                }
+            } else {
+                vectors += origin.cpy().scl(2f).sub(current) // Get vector on other side of clock
+            }
             current.add(0f, 1f)
         }
         return vectors
     }
 
-    fun getVectorsInDistance(origin: Vector2, distance: Int): List<Vector2> {
+    fun getVectorsInDistance(origin: Vector2, distance: Int, worldWrap: Boolean): List<Vector2> {
         val hexesToReturn = mutableListOf<Vector2>()
         for (i in 0 .. distance) {
-            hexesToReturn += getVectorsAtDistance(origin, i)
+            hexesToReturn += getVectorsAtDistance(origin, i, distance, worldWrap)
         }
         return hexesToReturn
     }

--- a/core/src/com/unciv/logic/map/TileMap.kt
+++ b/core/src/com/unciv/logic/map/TileMap.kt
@@ -52,7 +52,7 @@ class TileMap {
 
     /** generates a rectangular map of given width and height*/
     constructor(width: Int, height: Int, ruleset: Ruleset, worldWrap: Boolean = false) {
-        for (x in -width / 2..width / 2)
+        for (x in -width / 2 .. if (worldWrap) { width / 2 - 1 } else { width / 2 })
             for (y in -height / 2..height / 2)
                 tileList.add(TileInfo().apply {
                     position = HexMath.evenQ2HexCoords(Vector2(x.toFloat(), y.toFloat()))

--- a/core/src/com/unciv/logic/map/TileMap.kt
+++ b/core/src/com/unciv/logic/map/TileMap.kt
@@ -44,14 +44,14 @@ class TileMap {
     constructor()
 
     /** generates an hexagonal map of given radius */
-    constructor(radius: Int, ruleset: Ruleset) {
-        for (vector in HexMath.getVectorsInDistance(Vector2.Zero, radius))
+    constructor(radius: Int, ruleset: Ruleset, worldWrap: Boolean = false) {
+        for (vector in HexMath.getVectorsInDistance(Vector2.Zero, radius, worldWrap))
             tileList.add(TileInfo().apply { position = vector; baseTerrain = Constants.grassland })
         setTransients(ruleset)
     }
 
     /** generates a rectangular map of given width and height*/
-    constructor(width: Int, height: Int, ruleset: Ruleset) {
+    constructor(width: Int, height: Int, ruleset: Ruleset, worldWrap: Boolean = false) {
         for (x in -width / 2..width / 2)
             for (y in -height / 2..height / 2)
                 tileList.add(TileInfo().apply {


### PR DESCRIPTION
This is an important part of world wrap.
With the current world gen, you can't create a wrapping world because two different tiles are getting generated which are in fact the same tile in a wrapping world.
This PR changes the world gen to leave out the tiles which are on the right side of the world. The mirror tiles from v0.2 will take their place though