### PR TITLE
Renamed "Gold Ore" back to "Gold" to not break older games

### DIFF
--- a/android/assets/jsons/Civ V - Vanilla/TileResources.json
+++ b/android/assets/jsons/Civ V - Vanilla/TileResources.json
@@ -157,7 +157,7 @@
 		"improvementStats": {"gold": 1}
 	},
 	{
-		"name": "Gold Ore", // Not called "Gold" in order to not conflict with siege type units for translations
+		"name": "Gold",
 		"resourceType": "Luxury",
 		"terrainsCanBeFoundOn": ["Grassland","Plains","Desert","Hill"],
 		"gold": 2,


### PR DESCRIPTION
Hello, I noticed that after updating to version 1.13.3 I could not update an older running multiplayer game. Removing it and adding it again did not fix the problem either. I was able to reproduce the problem on multiple devices (desktop and Android).

After some research, I found that renaming "Gold Ore" to "Gold" in TileResources.json fixes the problem immediately. This is probably not a real solution to the problem, but a quick fix nonetheless. 