### PR TITLE
World Wrap Fixes

### DIFF
--- a/core/src/com/unciv/logic/map/TileMap.kt
+++ b/core/src/com/unciv/logic/map/TileMap.kt
@@ -343,4 +343,25 @@ class TileMap {
             else -> -1
         }
     }
+
+    /**
+     * Returns the closest position to (0, 0) outside the map which can be wrapped
+     * to the position of the given vector
+     */
+    fun getUnWrappedPosition(position: Vector2) : Vector2 {
+        if (!contains(position))
+            return position //The position is outside the map so its unwrapped already
+
+        var radius = mapParameters.size.radius
+        if (mapParameters.shape == MapShape.rectangular)
+            radius = HexMath.getEquivalentRectangularSize(radius).x.toInt() / 2
+
+        val vectorUnwrappedLeft = Vector2(position.x + radius, position.y - radius)
+        val vectorUnwrappedRight = Vector2(position.x - radius, position.y + radius)
+
+        return if (vectorUnwrappedRight.len() < vectorUnwrappedLeft.len())
+            vectorUnwrappedRight
+        else
+            vectorUnwrappedLeft
+    }
 }

--- a/core/src/com/unciv/ui/cityscreen/CityScreen.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityScreen.kt
@@ -214,14 +214,20 @@ class CityScreen(internal val city: CityInfo): CameraStageBaseScreen() {
             }
 
             tileGroups.add(tileGroup)
-
-            val positionalVector = HexMath.hex2WorldCoords(tileInfo.position.cpy().sub(cityInfo.location))
-            val groupSize = 50
-            tileGroup.setPosition(stage.width / 2 + positionalVector.x * 0.8f * groupSize.toFloat(),
-                    stage.height / 2 + positionalVector.y * 0.8f * groupSize.toFloat())
         }
 
-        val tileMapGroup = TileGroupMap(tileGroups, stage.width / 2)
+        val tilesToUnwrap = ArrayList<CityTileGroup>()
+        for (tileGroup in tileGroups) {
+            val xDifference = city.getCenterTile().position.x - tileGroup.tileInfo.position.x
+            val yDifference = city.getCenterTile().position.y - tileGroup.tileInfo.position.y
+            //if difference is bigger than 5 the tileGroup we are looking for is on the other side of the map
+            if (xDifference > 5 || xDifference < -5 || yDifference > 5 || yDifference < -5) {
+                //so we want to unwrap its position
+                tilesToUnwrap.add(tileGroup)
+            }
+        }
+
+        val tileMapGroup = TileGroupMap(tileGroups, stage.width / 2, tileGroupsToUnwrap = tilesToUnwrap)
         val scrollPane = ScrollPane(tileMapGroup)
         scrollPane.setSize(stage.width, stage.height)
         scrollPane.setOrigin(stage.width / 2, stage.height / 2)

--- a/core/src/com/unciv/ui/map/TileGroupMap.kt
+++ b/core/src/com/unciv/ui/map/TileGroupMap.kt
@@ -9,7 +9,7 @@ import com.unciv.ui.tilegroups.TileGroup
 import kotlin.math.max
 import kotlin.math.min
 
-class TileGroupMap<T: TileGroup>(val tileGroups: Collection<T>, val padding: Float, worldWrap: Boolean = false): Group(){
+class TileGroupMap<T: TileGroup>(val tileGroups: Collection<T>, val padding: Float, worldWrap: Boolean = false, tileGroupsToUnwrap: Collection<T>? = null): Group(){
     var topX = -Float.MAX_VALUE
     var topY = -Float.MAX_VALUE
     var bottomX = Float.MAX_VALUE
@@ -25,7 +25,13 @@ class TileGroupMap<T: TileGroup>(val tileGroups: Collection<T>, val padding: Flo
         }
 
         for(tileGroup in tileGroups) {
-            val positionalVector = HexMath.hex2WorldCoords(tileGroup.tileInfo.position)
+            val positionalVector = if (tileGroupsToUnwrap != null && tileGroupsToUnwrap.contains(tileGroup)){
+                HexMath.hex2WorldCoords(
+                        tileGroup.tileInfo.tileMap.getUnWrappedPosition(tileGroup.tileInfo.position)
+                )
+            } else {
+                HexMath.hex2WorldCoords(tileGroup.tileInfo.position)
+            }
 
             tileGroup.setPosition(positionalVector.x * 0.8f * groupSize.toFloat(),
                     positionalVector.y * 0.8f * groupSize.toFloat())

--- a/core/src/com/unciv/ui/tilegroups/TileGroup.kt
+++ b/core/src/com/unciv/ui/tilegroups/TileGroup.kt
@@ -2,6 +2,7 @@ package com.unciv.ui.tilegroups
 
 import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.graphics.g2d.Batch
+import com.badlogic.gdx.math.Vector2
 import com.badlogic.gdx.scenes.scene2d.Actor
 import com.badlogic.gdx.scenes.scene2d.Group
 import com.badlogic.gdx.scenes.scene2d.Touchable
@@ -501,7 +502,15 @@ open class TileGroup(var tileInfo: TileInfo, var tileSetStrings:TileSetStrings) 
             }
             if (neighborOwner != tileOwner && !borderImages.containsKey(neighbor)) { // there should be a border here but there isn't
 
-                val relativeHexPosition = tileInfo.position.cpy().sub(neighbor.position)
+                val relativeHexPosition = when (tileInfo.tileMap.getNeighborTileClockPosition(tileInfo, neighbor)){
+                    2 -> Vector2(0f,-1f)
+                    4 -> Vector2(1f,0f)
+                    6 -> Vector2(1f,1f)
+                    8 -> Vector2(0f,1f)
+                    10 -> Vector2(-1f,0f)
+                    12 -> Vector2(-1f,-1f)
+                    else -> Vector2.Zero
+                }
                 val relativeWorldPosition = HexMath.hex2WorldCoords(relativeHexPosition)
 
                 // This is some crazy voodoo magic so I'll explain.


### PR DESCRIPTION
Fixed: When a city got build on the world's edge the city screen displayed a non wrapped world.
Fixed: City border getting shifted to the map center when the city got build on the world's edge

![borderShift](https://user-images.githubusercontent.com/24532072/109953254-1b736d00-7ce0-11eb-889f-83ee8c365e06.PNG)
![borderShiftFixed](https://user-images.githubusercontent.com/24532072/109953262-1dd5c700-7ce0-11eb-8174-57772573eab7.PNG)
