### PR TITLE
Fixed rectangular maps center point

### DIFF
--- a/core/src/com/unciv/logic/HexMath.kt
+++ b/core/src/com/unciv/logic/HexMath.kt
@@ -96,7 +96,10 @@ object HexMath {
     }
 
     fun evenQ2HexCoords(evenQCoord: Vector2): Vector2 {
-        return cubic2HexCoords(evenQ2CubicCoords(evenQCoord))
+        return if (evenQCoord == Vector2.Zero)
+            Vector2.Zero
+        else
+            cubic2HexCoords(evenQ2CubicCoords(evenQCoord))
     }
 
     fun roundCubicCoords(cubicCoords: Vector3): Vector3 {


### PR DESCRIPTION
Currently, the center point of a rectangular map is always (-0, -0).
Changing it to (0, 0) allows the map to be centered when starting a game as a spectator and fixing a bug mentioned on the discord server: Starting a game with a rectangular map as a spectator crashes the game in 3.13.5