### PR TITLE
Adding convert Function

### DIFF
--- a/core/src/com/unciv/logic/map/TileInfo.kt
+++ b/core/src/com/unciv/logic/map/TileInfo.kt
@@ -54,6 +54,7 @@ open class TileInfo {
     val terrainFeatures: ArrayList<String> = ArrayList()
 
     @Transient // So it won't be serialized from now on
+    @Deprecated(message = "Since 3.13.7 - gets replaced by terrainFeatures")
     var terrainFeature: String? = null
         get() = terrainFeatures.firstOrNull()
                 ?: field //if terrainFeatures contains no terrainFeature maybe one got deserialized to field
@@ -65,6 +66,18 @@ open class TileInfo {
                 if (value != null) terrainFeatures.add(value)
             }
         }
+
+    private fun convertTerrainFeatureToArray() {
+        if (terrainFeatures.firstOrNull() == null && terrainFeature != null)// -> terranFeature getter returns terrainFeature field
+            terrainFeature = terrainFeature // getter returns field, setter calls terrainFeatures.add()
+        //Note to Future GGGuenni
+        //TODO Use the following when terrainFeature got changed everywhere to support old saves in the future
+        //if (terrainFeature != null){
+            //terrainFeatures.add(terrainFeature)
+            //terrainFeature = null
+        //}
+    }
+
     var naturalWonder: String? = null
     var resource: String? = null
     var improvement: String? = null
@@ -92,6 +105,7 @@ open class TileInfo {
         toReturn.position = position.cpy()
         toReturn.baseTerrain = baseTerrain
 //        toReturn.terrainFeature = terrainFeature
+        convertTerrainFeatureToArray()
         toReturn.terrainFeatures.addAll(terrainFeatures)
         toReturn.naturalWonder = naturalWonder
         toReturn.resource = resource
@@ -538,9 +552,7 @@ open class TileInfo {
 
     //region state-changing functions
     fun setTransients() {
-        if (terrainFeatures.firstOrNull() == null && terrainFeature != null) {// -> terranFeature getter returns terrainFeature field
-            terrainFeature = terrainFeature // getter returns field, setter calls terrainFeatures.add()
-        }
+        convertTerrainFeatureToArray()
         setTerrainTransients()
         setUnitTransients(true)
     }

--- a/core/src/com/unciv/logic/map/TileInfo.kt
+++ b/core/src/com/unciv/logic/map/TileInfo.kt
@@ -65,6 +65,7 @@ open class TileInfo {
             } else {
                 if (value != null) terrainFeatures.add(value)
             }
+            field = null
         }
 
     private fun convertTerrainFeatureToArray() {


### PR DESCRIPTION
The change you made yesterday made all terrainFeatures disappear in all old saves again.
Because calling terrainFeature in clone copied the data to terrainFeatures and I realized this morning this was the point that worked that I didn't understand
```
//toReturn.terrainFeature = terrainFeature
toReturn.terrainFeatures.addAll(terrainFeatures)
```

I added a function to do the copy and added it to clone()
also deprecated terrainFeature

also added field = null when terrainFeature gets set just to be sure the field is not interfering in any way