### PR TITLE
Fix the Military Caste policy

### DIFF
--- a/core/src/com/unciv/logic/city/CityInfo.kt
+++ b/core/src/com/unciv/logic/city/CityInfo.kt
@@ -667,6 +667,7 @@ class CityInfo {
             filter == "in capital" && isCapital() -> true
             filter == "in all cities with a world wonder" && cityConstructions.getBuiltBuildings().any { it.isWonder } -> true
             filter == "in all cities connected to capital" -> isConnectedToCapital()
+            filter == "in all cities with a garrison" && getCenterTile().militaryUnit != null -> true
             else -> false
         }
     }


### PR DESCRIPTION
The Military Caste policy currently doesn't seem to trigger (I believe since [this commit](https://github.com/yairm210/Unciv/commit/b0bf18afa01b6888fef27e9e6d34fdd1a9ea1879?branch=b0bf18afa01b6888fef27e9e6d34fdd1a9ea1879&diff=split#diff-2a2d3eccce78e24ee31b90b57400cb88d2c9140626a393fd5cc9e62e3dcdb1dbR116)). This change adds the check from [CityStats.kt](https://github.com/yairm210/Unciv/blob/84c200bd32899d657381711ca013a79587b2cf22/core/src/com/unciv/logic/city/CityStats.kt#L263) when checking the filters 