### PR TITLE
More terrainFeature refactors

### DIFF
--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -332,8 +332,8 @@ class GameInfo {
     // So we remove them so the game doesn't crash when it tries to access them.
     private fun removeMissingModReferences() {
         for (tile in tileMap.values) {
-            if (tile.terrainFeature != null && !ruleSet.terrains.containsKey(tile.terrainFeature!!))
-                tile.terrainFeature = null
+            for (terrainFeature in tile.terrainFeatures.filter{ !ruleSet.terrains.containsKey(it) })
+                tile.terrainFeatures.remove(terrainFeature)
             if (tile.resource != null && !ruleSet.tileResources.containsKey(tile.resource!!))
                 tile.resource = null
             if (tile.improvement != null && !ruleSet.tileImprovements.containsKey(tile.improvement!!)

--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -404,7 +404,7 @@ object Battle {
             tile.improvementInProgress = null
             tile.turnsToImprovement = 0
             tile.roadStatus = RoadStatus.None
-            if (tile.isLand && !tile.isImpassible()) tile.terrainFeature = "Fallout"
+            if (tile.isLand && !tile.isImpassible()) tile.terrainFeatures.contains("Fallout")
         }
 
         for (civ in attacker.getCivInfo().getKnownCivs()) {

--- a/core/src/com/unciv/logic/city/CityInfo.kt
+++ b/core/src/com/unciv/logic/city/CityInfo.kt
@@ -116,8 +116,8 @@ class CityInfo {
         tryUpdateRoadStatus()
 
         val tile = getCenterTile()
-        if (getRuleset().tileImprovements.containsKey("Remove " + tile.terrainFeature))
-            tile.terrainFeature = null
+        for (terrainFeature in tile.terrainFeatures.filter { getRuleset().tileImprovements.containsKey("Remove $it") })
+            tile.terrainFeatures.remove(terrainFeature)
 
         tile.improvement = null
         tile.improvementInProgress = null

--- a/core/src/com/unciv/logic/civilization/CivInfoStats.kt
+++ b/core/src/com/unciv/logic/civilization/CivInfoStats.kt
@@ -60,7 +60,7 @@ class CivInfoStats(val civInfo: CivilizationInfo) {
                 if (tile.isCityCenter()) continue
                 if (ignoreHillTiles && tile.isHill()) continue
 
-                if (tile.terrainFeature in ignoredTileTypes || tile.baseTerrain in ignoredTileTypes) {
+                if (tile.terrainFeatures.any { it in ignoredTileTypes }  || tile.baseTerrain in ignoredTileTypes) {
                     continue
                 }
 

--- a/core/src/com/unciv/logic/map/mapgenerator/MapGenerator.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/MapGenerator.kt
@@ -260,7 +260,7 @@ class MapGenerator(val ruleset: Ruleset) {
             val vegetation = (randomness.getPerlinNoise(tile, vegetationSeed, scale = 3.0, nOctaves = 1) + 1.0) / 2.0
 
             if (vegetation <= tileMap.mapParameters.vegetationRichness)
-                tile.terrainFeature = Constants.vegetation.filter { ruleset.terrains[it]!!.occursOn.contains(tile.baseTerrain) }.random(randomness.RNG)
+                tile.terrainFeatures.add(Constants.vegetation.filter { ruleset.terrains[it]!!.occursOn.contains(tile.baseTerrain) }.random(randomness.RNG))
         }
     }
     /**
@@ -275,7 +275,7 @@ class MapGenerator(val ruleset: Ruleset) {
                 val possibleFeatures = rareFeatures.filter { it.occursOn.contains(tile.baseTerrain)
                         && (!tile.isHill() || it.occursOn.contains(Constants.hill)) }
                 if (possibleFeatures.any())
-                    tile.terrainFeature = possibleFeatures.random(randomness.RNG).name
+                    tile.terrainFeatures.add(possibleFeatures.random(randomness.RNG).name)
             }
         }
     }

--- a/core/src/com/unciv/logic/map/mapgenerator/RiverGenerator.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/RiverGenerator.kt
@@ -22,7 +22,7 @@ class RiverGenerator(val randomness: MapGenerationRandomness){
 
         for(tile in map.values){
             if(tile.isAdjacentToRiver()){
-                if(tile.baseTerrain== Constants.desert && !tile.isHill()) tile.terrainFeature= Constants.floodPlains
+                if(tile.baseTerrain== Constants.desert && !tile.isHill()) tile.terrainFeatures.add(Constants.floodPlains)
                 else if(tile.baseTerrain== Constants.snow) tile.baseTerrain = Constants.tundra
                 else if(tile.baseTerrain== Constants.tundra) tile.baseTerrain = Constants.plains
                 tile.setTerrainTransients()

--- a/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
@@ -367,9 +367,8 @@ object UnitActions {
                     uncivSound = UncivSound.Chimes,
                     action = {
                         val unitTile = unit.getTile()
-                        if (unitTile.terrainFeature != null &&
-                                unitTile.ruleset.tileImprovements.containsKey("Remove " + unitTile.terrainFeature))
-                            unitTile.terrainFeature = null // remove forest/jungle/marsh
+                        for (terrainFeature in tile.terrainFeatures.filter{ unitTile.ruleset.tileImprovements.containsKey("Remove $it") })
+                            unitTile.terrainFeatures.remove(terrainFeature)// remove forest/jungle/marsh
                         unitTile.improvement = improvementName
                         unitTile.improvementInProgress = null
                         unitTile.turnsToImprovement = 0


### PR DESCRIPTION
These are all which seemed easy to handle to me. There are 5 more classes that all seemed to need a bit more work to work properly in the end.

I've got a question regarding the image names. If we turn for example hill into a terrain feature and we have a tile that has hill and forest on it, those can occur in any order inside terrainFeatures. But we will only have one image for this config. How do we call the image? Grassland+Hill+Forest or Grassland+Forest+Hill? I would go for terrain features in alphabetical order now.