### PR TITLE
More terrainFeature refactoring

### DIFF
--- a/core/src/com/unciv/logic/map/TileInfo.kt
+++ b/core/src/com/unciv/logic/map/TileInfo.kt
@@ -543,14 +543,15 @@ open class TileInfo {
                     && (terrainFeatures.contains(Constants.jungle) || terrainFeatures.contains(Constants.forest))
                     && isFriendlyTerritory(civInfo)
 
-    fun getRulesetIncompatability(ruleset: Ruleset): String {
-        if (!ruleset.terrains.containsKey(baseTerrain)) return "Base terrain $baseTerrain does not exist in ruleset!"
-        //TODO change getRulesetIncompatability to support multiple missing terrain features at once
-        if (terrainFeature != null && !ruleset.terrains.containsKey(terrainFeature)) return "Terrain feature $terrainFeature does not exist in ruleset!"
-        if (resource != null && !ruleset.tileResources.containsKey(resource)) return "Resource $resource does not exist in ruleset!"
+    fun getRulesetIncompatibility(ruleset: Ruleset): HashSet<String> {
+        val out = HashSet<String>()
+        if (!ruleset.terrains.containsKey(baseTerrain)) out.add("Base terrain $baseTerrain does not exist in ruleset!")
+        for (terrainFeature in terrainFeatures.filter { !ruleset.terrains.containsKey(it) })
+            out.add("Terrain feature $terrainFeature does not exist in ruleset!")
+        if (resource != null && !ruleset.tileResources.containsKey(resource)) out.add("Resource $resource does not exist in ruleset!")
         if (improvement != null && !improvement!!.startsWith("StartingLocation")
-                && !ruleset.tileImprovements.containsKey(improvement)) return "Improvement $improvement does not exist in ruleset!"
-        return ""
+                && !ruleset.tileImprovements.containsKey(improvement)) out.add("Improvement $improvement does not exist in ruleset!")
+        return out
     }
 
 

--- a/core/src/com/unciv/logic/map/TileInfo.kt
+++ b/core/src/com/unciv/logic/map/TileInfo.kt
@@ -558,12 +558,12 @@ open class TileInfo {
 
     //region state-changing functions
     fun setTransients() {
-        convertTerrainFeatureToArray()
         setTerrainTransients()
         setUnitTransients(true)
     }
 
     fun setTerrainTransients() {
+        convertTerrainFeatureToArray()
         if (!ruleset.terrains.containsKey(baseTerrain))
             throw Exception()
         baseTerrainObject = ruleset.terrains[baseTerrain]!!

--- a/core/src/com/unciv/ui/mapeditor/MapEditorMenuPopup.kt
+++ b/core/src/com/unciv/ui/mapeditor/MapEditorMenuPopup.kt
@@ -5,8 +5,6 @@ import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.unciv.Constants
 import com.unciv.MainMenuScreen
 import com.unciv.UncivGame
-import com.unciv.logic.map.TileMap
-import com.unciv.models.metadata.Player
 import com.unciv.models.ruleset.RulesetCache
 import com.unciv.ui.newgamescreen.ModCheckboxTable
 import com.unciv.ui.utils.*
@@ -41,7 +39,9 @@ class MapEditorMenuPopup(var mapEditorScreen: MapEditorScreen): Popup(mapEditorS
             add(ScrollPane(checkboxTable)).maxHeight(mapEditorScreen.stage.height * 0.8f).row()
 
             addButton("Save") {
-                val incompatibilities = mapEditorScreen.tileMap.values.map { it.getRulesetIncompatability(ruleset) }.toHashSet()
+                val incompatibilities = HashSet<String>()
+                for (set in mapEditorScreen.tileMap.values.map { it.getRulesetIncompatibility(ruleset) })
+                    incompatibilities.addAll(set)
                 incompatibilities.remove("")
 
                 if (incompatibilities.isEmpty()) {

--- a/core/src/com/unciv/ui/newgamescreen/NewGameScreen.kt
+++ b/core/src/com/unciv/ui/newgamescreen/NewGameScreen.kt
@@ -97,16 +97,15 @@ class NewGameScreen(previousScreen:CameraStageBaseScreen, _gameSetupInfo: GameSe
 
             if (mapOptionsTable.mapTypeSelectBox.selected.value == MapType.custom){
                 val map = MapSaver.loadMap(gameSetupInfo.mapFile!!)
-                val rulesetIncompatabilities = HashSet<String>()
-                for(tile in map.values) {
-                    val rulesetIncompat = tile.getRulesetIncompatability(ruleset)
-                    if (rulesetIncompat != "") rulesetIncompatabilities.add(rulesetIncompat)
-                }
+                val rulesetIncompatibilities = HashSet<String>()
+                for (set in map.values.map { it.getRulesetIncompatibility(ruleset) })
+                    rulesetIncompatibilities.addAll(set)
+                rulesetIncompatibilities.remove("")
 
-                if (rulesetIncompatabilities.isNotEmpty()) {
+                if (rulesetIncompatibilities.isNotEmpty()) {
                     val incompatibleMap = Popup(this)
                     incompatibleMap.addGoodSizedLabel("Map is incompatible with the chosen ruleset!".tr()).row()
-                    for(incompat in rulesetIncompatabilities)
+                    for(incompat in rulesetIncompatibilities)
                         incompatibleMap.addGoodSizedLabel(incompat).row()
                     incompatibleMap.addCloseButton()
                     incompatibleMap.open()

--- a/core/src/com/unciv/ui/tilegroups/TileGroup.kt
+++ b/core/src/com/unciv/ui/tilegroups/TileGroup.kt
@@ -63,7 +63,7 @@ open class TileGroup(var tileInfo: TileInfo, var tileSetStrings:TileSetStrings) 
 
     // These are for OLD tiles - for instance the "forest" symbol on the forest
     protected var terrainFeatureOverlayImage: Image? = null
-    protected var terrainFeature: String? = null
+    protected val terrainFeatures: ArrayList<String> = ArrayList()
     protected var cityImage: Image? = null
     protected var naturalWonderImage: Image? = null
 
@@ -205,9 +205,9 @@ open class TileGroup(var tileInfo: TileInfo, var tileSetStrings:TileSetStrings) 
         }
 
 
-        if (tileInfo.terrainFeature != null) {
+        if (tileInfo.terrainFeatures.isNotEmpty()) {
             // e.g. Grassland+Forest
-            val baseTerrainAndFeatureTileLocation = "$baseTerrainTileLocation+${tileInfo.terrainFeature}"
+            val baseTerrainAndFeatureTileLocation = "$baseTerrainTileLocation+${tileInfo.terrainFeatures.joinToString(separator = "+")}"
             if (shouldShowImprovement && shouldShowResource) {
                 // e.g. Grassland+Forest+Deer+Camp
                 val baseFeatureImprovementAndResourceLocation =
@@ -610,13 +610,14 @@ open class TileGroup(var tileInfo: TileInfo, var tileSetStrings:TileSetStrings) 
     }
 
     private fun updateTerrainFeatureImage() {
-        if (tileInfo.terrainFeature != terrainFeature) {
-            terrainFeature = tileInfo.terrainFeature
+        if (tileInfo.terrainFeatures != terrainFeatures) {
+            terrainFeatures.clear()
+            terrainFeatures.addAll(tileInfo.terrainFeatures)
             if (terrainFeatureOverlayImage != null) terrainFeatureOverlayImage!!.remove()
             terrainFeatureOverlayImage = null
 
-            if (terrainFeature != null) {
-                val terrainFeatureOverlayLocation = tileSetStrings.getTerrainFeatureOverlay(terrainFeature!!)
+            if (terrainFeatures.isNotEmpty()) {
+                val terrainFeatureOverlayLocation = tileSetStrings.getTerrainFeatureOverlay(terrainFeatures.joinToString(separator = "+"))
                 if (!ImageGetter.imageExists(terrainFeatureOverlayLocation)) return
                 terrainFeatureOverlayImage = ImageGetter.getImage(terrainFeatureOverlayLocation)
                 terrainFeatureLayerGroup.addActor(terrainFeatureOverlayImage)

--- a/core/src/com/unciv/ui/tilegroups/TileGroup.kt
+++ b/core/src/com/unciv/ui/tilegroups/TileGroup.kt
@@ -617,7 +617,7 @@ open class TileGroup(var tileInfo: TileInfo, var tileSetStrings:TileSetStrings) 
             terrainFeatureOverlayImage = null
 
             if (terrainFeatures.isNotEmpty()) {
-                val terrainFeatureOverlayLocation = tileSetStrings.getTerrainFeatureOverlay(terrainFeatures.joinToString(separator = "+"))
+                val terrainFeatureOverlayLocation = tileSetStrings.getTerrainFeatureOverlay(terrainFeatures)
                 if (!ImageGetter.imageExists(terrainFeatureOverlayLocation)) return
                 terrainFeatureOverlayImage = ImageGetter.getImage(terrainFeatureOverlayLocation)
                 terrainFeatureLayerGroup.addActor(terrainFeatureOverlayImage)

--- a/core/src/com/unciv/ui/tilegroups/TileSetStrings.kt
+++ b/core/src/com/unciv/ui/tilegroups/TileSetStrings.kt
@@ -51,7 +51,7 @@ class TileSetStrings {
     val tag = "-"
     fun getTile(baseTerrain: String) = getString(tilesLocation, baseTerrain)
     fun getBaseTerrainOverlay(baseTerrain: String) = getString(tileSetLocation, baseTerrain, overlay)
-    fun getTerrainFeatureOverlay(terrainFeature: String) = getString(tileSetLocation, terrainFeature, overlay)
+    fun getTerrainFeatureOverlay(terrainFeatures: Collection<String>) = getString(tileSetLocation, *terrainFeatures.toTypedArray(), overlay)
 
     fun getCityTile(baseTerrain: String?, era: String?): String {
         if (baseTerrain != null && era != null) return getString(tilesLocation, baseTerrain, city, tag, era)

--- a/core/src/com/unciv/ui/tilegroups/TileSetStrings.kt
+++ b/core/src/com/unciv/ui/tilegroups/TileSetStrings.kt
@@ -51,7 +51,16 @@ class TileSetStrings {
     val tag = "-"
     fun getTile(baseTerrain: String) = getString(tilesLocation, baseTerrain)
     fun getBaseTerrainOverlay(baseTerrain: String) = getString(tileSetLocation, baseTerrain, overlay)
-    fun getTerrainFeatureOverlay(terrainFeatures: Collection<String>) = getString(tileSetLocation, *terrainFeatures.toTypedArray(), overlay)
+    fun getTerrainFeatureOverlay(terrainFeatures: Collection<String>): String {
+        val iterator = terrainFeatures.iterator()
+        val out = Array(terrainFeatures.size * 2 - 1){ //"+" gets added in front of each element except the first hence * 2 - 1
+            if (it % 2 == 0)
+                iterator.next()
+            else
+                "+"
+        }
+        return getString(tileSetLocation, *out, overlay)
+    }
 
     fun getCityTile(baseTerrain: String?, era: String?): String {
         if (baseTerrain != null && era != null) return getString(tilesLocation, baseTerrain, city, tag, era)


### PR DESCRIPTION
I realized that setTransients doesn't get called on deserialization. Only setTerrainTransients and setUnitTransients do. So I moved the convertTerrainFeature call into setTerrainTransients. Well, given the name it also rather belongs there :D
Since you said we can assume terrainFeatures to always be in the correct order the refactoring in TileGroup was fairly straightforward.