### PR TITLE
Reverting getTerrainFeatureOverlay changes

### DIFF
--- a/core/src/com/unciv/ui/tilegroups/TileGroup.kt
+++ b/core/src/com/unciv/ui/tilegroups/TileGroup.kt
@@ -616,8 +616,8 @@ open class TileGroup(var tileInfo: TileInfo, var tileSetStrings:TileSetStrings) 
             if (terrainFeatureOverlayImage != null) terrainFeatureOverlayImage!!.remove()
             terrainFeatureOverlayImage = null
 
-            if (terrainFeatures.isNotEmpty()) {
-                val terrainFeatureOverlayLocation = tileSetStrings.getTerrainFeatureOverlay(terrainFeatures)
+            for (terrainFeature in terrainFeatures) {
+                val terrainFeatureOverlayLocation = tileSetStrings.getTerrainFeatureOverlay(terrainFeature)
                 if (!ImageGetter.imageExists(terrainFeatureOverlayLocation)) return
                 terrainFeatureOverlayImage = ImageGetter.getImage(terrainFeatureOverlayLocation)
                 terrainFeatureLayerGroup.addActor(terrainFeatureOverlayImage)

--- a/core/src/com/unciv/ui/tilegroups/TileSetStrings.kt
+++ b/core/src/com/unciv/ui/tilegroups/TileSetStrings.kt
@@ -51,16 +51,7 @@ class TileSetStrings {
     val tag = "-"
     fun getTile(baseTerrain: String) = getString(tilesLocation, baseTerrain)
     fun getBaseTerrainOverlay(baseTerrain: String) = getString(tileSetLocation, baseTerrain, overlay)
-    fun getTerrainFeatureOverlay(terrainFeatures: Collection<String>): String {
-        val iterator = terrainFeatures.iterator()
-        val out = Array(terrainFeatures.size * 2 - 1){ //"+" gets added in front of each element except the first hence * 2 - 1
-            if (it % 2 == 0)
-                iterator.next()
-            else
-                "+"
-        }
-        return getString(tileSetLocation, *out, overlay)
-    }
+    fun getTerrainFeatureOverlay(terrainFeature: String) = getString(tileSetLocation, terrainFeature, overlay)
 
     fun getCityTile(baseTerrain: String?, era: String?): String {
         if (baseTerrain != null && era != null) return getString(tilesLocation, baseTerrain, city, tag, era)


### PR DESCRIPTION
I realized getTerrainFeatureOverlay is only used for the default Tileset which is overlay-based anyway. Well, yea obviously it's even called getTerrainFeatureOVERLAY.
So the changes I made can be easily done with just one for loop and without even making new images with stacked overlays...