### PR TITLE
toast popup not screen blocking again

### DIFF
--- a/core/src/com/unciv/ui/utils/ToastPopup.kt
+++ b/core/src/com/unciv/ui/utils/ToastPopup.kt
@@ -3,21 +3,25 @@ package com.unciv.ui.utils
 import com.badlogic.gdx.Gdx
 import kotlin.concurrent.thread
 
-//Its a popUp which will close itself after a given amount of time
-//Standard time is one second (in milliseconds)
-class ToastPopup (message: String, screen: CameraStageBaseScreen, time: Long = 1000) : Popup(screen){
-    private val visibilityTime = time
+/**
+ * This is an unobtrusive popup which will close itself after a given amount of time.
+ * Default time is two seconds (in milliseconds)
+ */
+class ToastPopup (message: String, screen: CameraStageBaseScreen, val time: Long = 2000) : Popup(screen){
     init {
+        //Make this popup unobtrusive
+        setFillParent(false)
+
         addGoodSizedLabel(message)
         open()
         //move it to the top so its not in the middle of the screen
         //have to be done after open() because open() centers the popup
-        y = screen.stage.height - (height + padTop)
+        y = screen.stage.height - (height + 20f)
     }
 
     private fun startTimer(){
         thread (name = "ResponsePopup") {
-            Thread.sleep(visibilityTime)
+            Thread.sleep(time)
             Gdx.app.postRunnable { this.close() }
         }
     }


### PR DESCRIPTION
I also increased the timer to two seconds, so it's easier to read the popup.
I hardcoded padTop since it is 0 because of innerTable. But I think it doesn't matter.