### PR TITLE
fixed baseTerrain can differ from getBaseTerrain

### DIFF
--- a/core/src/com/unciv/logic/map/mapgenerator/MapGenerator.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/MapGenerator.kt
@@ -192,6 +192,7 @@ class MapGenerator(val ruleset: Ruleset) {
                 elevation <= 0.7 -> tile.baseTerrain = Constants.hill
                 elevation <= 1.0 -> tile.baseTerrain = Constants.mountain
             }
+            tile.setTerrainTransients()
         }
     }
 
@@ -230,6 +231,7 @@ class MapGenerator(val ruleset: Ruleset) {
                         Constants.lakes
                     }
                 }
+                tile.setTerrainTransients()
                 continue
             }
 
@@ -246,6 +248,7 @@ class MapGenerator(val ruleset: Ruleset) {
                 tile.baseTerrain = ruleset.terrains.keys.first()
                 println("Temperature: $temperature, humidity: $humidity")
             }
+            tile.setTerrainTransients()
         }
     }
 


### PR DESCRIPTION
I found this bug while working on my HillAsTerrainFeature branch. 

This is a print from Version 3.13.4:
baseTerrain: Grassland
getBaseTerrain.name: Plains
\-------------------------
baseTerrain: Tundra
getBaseTerrain.name: Plains

It happened because not every time baseTerrain got set tileInfo.setTerrainTransients got called to modify the baseTerrainObject.
I just added the calls in now but having to call setTerrainTransients every time you set baseTerrain leaves potential for bugs.
I would prefer changing getBaseTerrain to just get the right terrain every time:
```
fun getBaseTerrain(): Terrain {
        if (baseTerrain != baseTerrainObject.name)
            setTerrainTransients()
        return baseTerrainObject
    }
```