### PR TITLE
Adding fallout on nuke again

### DIFF
--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -402,7 +402,7 @@ object Battle {
             tile.improvementInProgress = null
             tile.turnsToImprovement = 0
             tile.roadStatus = RoadStatus.None
-            if (tile.isLand && !tile.isImpassible()) tile.terrainFeatures.contains("Fallout")
+            if (tile.isLand && !tile.isImpassible()) tile.terrainFeatures.add("Fallout")
         }
 
         for (civ in attacker.getCivInfo().getKnownCivs()) {


### PR DESCRIPTION
I made a mistake on my second PR regarding terrainFeature refactor. There I changed 
tile.terrainFeature = "Fallout"
to
tile.terrainFeatures.contains("Fallout")
