### PR TITLE
Fixed can't press nextTurn in multiplayer game

### DIFF
--- a/core/src/com/unciv/ui/newgamescreen/NewGameScreen.kt
+++ b/core/src/com/unciv/ui/newgamescreen/NewGameScreen.kt
@@ -148,7 +148,7 @@ class NewGameScreen(previousScreen:CameraStageBaseScreen, _gameSetupInfo: GameSe
                 // Save gameId to clipboard because you have to do it anyway.
                 Gdx.app.clipboard.contents = newGame!!.gameId
                 // Popup to notify the User that the gameID got copied to the clipboard
-                Gdx.app.postRunnable { ToastPopup("gameID copied to clipboard".tr(), UncivGame.Current.worldScreen, 2500) }
+                Gdx.app.postRunnable { ToastPopup("gameID copied to clipboard".tr(), game.worldScreen, 2500) }
 
                 GameSaver.autoSave(newGame!!) {}
 

--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -312,6 +312,7 @@ class WorldScreen(val gameInfo: GameInfo, val viewingCiv:CivilizationInfo) : Cam
         techPolicyAndVictoryHolder.setPosition(10f, topBar.y - techPolicyAndVictoryHolder.height - 5f)
         updateDiplomacyButton(viewingCiv)
 
+        isPlayersTurn = viewingCiv == gameInfo.currentPlayerCiv
 
         if (!hasOpenPopups() && isPlayersTurn) {
             when {


### PR DESCRIPTION
isPlayersTurn did not get updated so setting it to false resulted in it never getting changed back to true. I just put it into the update function I think that's ok. I'm not entirely sure though. Since it gets set to false in init and nextTurn(), setting it to its real value (viewingCiv == gameInfo.currentPlayerCiv) in update() could maybe result in problems.

Also, there was a crash when creating a multiplayer game with just one human player because UncivGame.Current.worldScreen was not initialized then but I don't know why it only happens with one human player.