### PR TITLE
Update Unciv.sh to suppress warnings under newer JRE

### DIFF
--- a/desktop/linuxFilesForJar/Unciv.sh
+++ b/desktop/linuxFilesForJar/Unciv.sh
@@ -43,4 +43,4 @@ fi
 
 mkdir -p "$CONFIG_DIR"
 cd "$CONFIG_DIR" || fail "Could not 'cd' to '$CONFIG_DIR'"
-java -jar /usr/share/Unciv/Unciv.jar
+java --add-opens=java.base/java.lang=ALL-UNNAMED -jar /usr/share/Unciv/Unciv.jar


### PR DESCRIPTION
Under a default Mint 20.1 installation (ubuntu 20.04 focal based), which comes with java 11
```
~/Games/Unciv$ java --version
openjdk 11.0.10 2021-01-19
OpenJDK Runtime Environment (build 11.0.10+9-Ubuntu-0ubuntu1.20.04)
OpenJDK 64-Bit Server VM (build 11.0.10+9-Ubuntu-0ubuntu1.20.04, mixed mode, sharing)
```
starting Unciv.jar will produce the following warnings:
```
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.lwjgl.LWJGLUtil$3 (file:/home/bob/Games/Unciv/Unciv.jar) to method java.lang.ClassLoader.findLibrary(java.lang.String)
WARNING: Please consider reporting this to the maintainers of org.lwjgl.LWJGLUtil$3
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
```
As this seems to be caused by libGDX suggesting Unciv cannot prevent these, it might be best to suppress as shown.