### PR TITLE
Fixed Multiplayer bugs

### DIFF
--- a/android/src/com/unciv/app/MultiplayerTurnCheckWorker.kt
+++ b/android/src/com/unciv/app/MultiplayerTurnCheckWorker.kt
@@ -242,7 +242,13 @@ class MultiplayerTurnCheckWorker(appContext: Context, workerParams: WorkerParame
                 val currentTurnPlayer = game.getCivilization(game.currentPlayer)
 
                 //Save game so MultiplayerScreen gets updated
-                GameSaver.saveGame(game, gameNames[arrayIndex], true)
+                /*
+                I received multiple reports regarding broken save games.
+                All of them where missing a few thousand chars at the end of the save game.
+                I assume this happened because the TurnCheckerWorker gets canceled by the AndroidLauncher
+                while saves are getting saved right here.
+                 */
+                //GameSaver.saveGame(game, gameNames[arrayIndex], true)
 
                 if (currentTurnPlayer.playerId == inputData.getString(USER_ID)!!) {
                     foundGame = true

--- a/core/src/com/unciv/ui/multiplayer/MultiplayerScreen.kt
+++ b/core/src/com/unciv/ui/multiplayer/MultiplayerScreen.kt
@@ -295,15 +295,16 @@ class MultiplayerScreen(previousScreen: CameraStageBaseScreen) : PickerScreen() 
 
         //One thread for all downloads
         thread(name = "multiplayerGameDownload") {
-            for (entry in multiplayerGames) {
+            for ((fileHandle, gameInfo) in multiplayerGames) {
                 try {
-                    val game = OnlineMultiplayer().tryDownloadGame(entry.value.gameId)
-                    GameSaver.saveGame(game, entry.key.name(), true)
+                    val game = OnlineMultiplayer().tryDownloadGame(gameInfo.gameId)
+                    GameSaver.saveGame(game, fileHandle.name(), true)
+                    multiplayerGames[fileHandle] = game
                 } catch (ex: Exception) {
                     //skipping one is not fatal
                     //Trying to use as many prev. used strings as possible
                     Gdx.app.postRunnable {
-                        ToastPopup("Could not download game!" + " ${entry.key.name()}", this)
+                        ToastPopup("Could not download game!" + " ${fileHandle.name()}", this)
                     }
                     continue
                 }

--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -513,7 +513,7 @@ class WorldScreen(val gameInfo: GameInfo, val viewingCiv:CivilizationInfo) : Cam
                             cantUploadNewGamePopup.open()
                         }
                         isPlayersTurn = true // Since we couldn't push the new game clone, then it's like we never clicked the "next turn" button
-                        shouldUpdate = false
+                        shouldUpdate = true
                         return@thread
                     }
                 }

--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -242,10 +242,8 @@ class WorldScreen(val gameInfo: GameInfo, val viewingCiv:CivilizationInfo) : Cam
             val latestGame = OnlineMultiplayer().tryDownloadGame(gameInfo.gameId)
 
             // if we find it still isn't player's turn...nothing changed
-            if (gameInfo.currentPlayer == latestGame.currentPlayer) {
+            if (viewingCiv.civName != latestGame.currentPlayer) {
                 Gdx.app.postRunnable { loadingGamePopup.close() }
-                // edge case - if there's only one player in a multiplayer game, we still check online, but it could be that we were correct and it is our turn
-                isPlayersTurn = latestGame.currentPlayer == viewingCiv.civName
                 shouldUpdate = true
                 return
             } else { //else we found it is the player's turn again, turn off polling and load turn

--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -513,7 +513,7 @@ class WorldScreen(val gameInfo: GameInfo, val viewingCiv:CivilizationInfo) : Cam
                             cantUploadNewGamePopup.open()
                         }
                         isPlayersTurn = true // Since we couldn't push the new game clone, then it's like we never clicked the "next turn" button
-                        shouldUpdate = true
+                        shouldUpdate = false
                         return@thread
                     }
                 }


### PR DESCRIPTION
The first bug is regarding turns getting reset because the game didn't update properly. Users, therefore, uploaded an old save.
`gameInfo.currentPlayer == latestGame.currentPlayer` worked but since gameInfo could be a game from a week ago I assume this was the code causing the problem. I hope at least...

The second bug has been brought to my attention more often lately where multiplayer saves just broke. Every save I got was missing a few thousand chars at the end of the save game. So I assume this happened because in specific circumstances the TurnCheckerWorker got canceled by the AndroidLauncher while saves were getting saved. I will have to observe if I get any more broken saves after this patch.