### PR TITLE
Fix Citadel not quite buildable where it should be

### DIFF
--- a/android/assets/jsons/Civ V - Vanilla/TileImprovements.json
+++ b/android/assets/jsons/Civ V - Vanilla/TileImprovements.json
@@ -183,7 +183,7 @@
 	},
 	{
 		"name": "Citadel",
-		"uniques": ["Gives a defensive bonus of [100]%", "Deal 30 damage to adjacent enemy units", "Great Improvement"]
+		"uniques": ["Gives a defensive bonus of [100]%", "Deal 30 damage to adjacent enemy units", "Great Improvement", "Can be built just outside your borders"]
 	},
 
 	//Civilization unique improvements

--- a/core/src/com/unciv/logic/map/TileInfo.kt
+++ b/core/src/com/unciv/logic/map/TileInfo.kt
@@ -323,7 +323,11 @@ open class TileInfo {
         return when {
             improvement.uniqueTo != null && improvement.uniqueTo != civInfo.civName -> false
             improvement.techRequired != null && !civInfo.tech.isResearched(improvement.techRequired!!) -> false
-            getOwner() != civInfo && !improvement.hasUnique("Can be built outside your borders") -> false
+            getOwner() != civInfo && ! (
+                        improvement.hasUnique("Can be built outside your borders")
+                        // citadel can be built only next to or within own borders
+                        || improvement.hasUnique("Can be built just outside your borders") && neighbors.any { it.getOwner() == civInfo }
+                    ) -> false
             improvement.uniqueObjects.any {
                 it.placeholderText == "Obsolete with []" && civInfo.tech.isResearched(it.params[0])
             } -> return false

--- a/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
@@ -352,10 +352,7 @@ object UnitActions {
                         unit.destroy()
                     }.takeIf {
                         unit.currentMovement > 0f && tile.canBuildImprovement(improvement, unit.civInfo)
-                                && !tile.isImpassible() && // Not 100% sure that this check is necessary...
-                                // citadel can be built only next to or within own borders
-                                (improvementName != Constants.citadel ||
-                                        tile.neighbors.any { it.getOwner() == unit.civInfo })
+                                && !tile.isImpassible() // Not 100% sure that this check is necessary...
                     })
         }
         return finalActions


### PR DESCRIPTION
I originally [commented](https://github.com/yairm210/Unciv/issues/663#issuecomment-819111590) on #663 but then got the itch to try this right away - also to get an example to jot down hot to rebase before pushing for my [documentation WIP](https://github.com/SomeTroglodyte/Scratchpad/tree/master/Unciv-notes).

This takes the approach to make the Citadel 'where' rules a specific unique, which might have the added bonus to make this rule visible in the civilopedia?