### PR TITLE
ExpanderTab had only one use outside its package - moved

### DIFF
--- a/core/src/com/unciv/ui/trade/ExpanderTab.kt
+++ b/core/src/com/unciv/ui/trade/ExpanderTab.kt
@@ -1,4 +1,4 @@
-package com.unciv.ui.cityscreen
+package com.unciv.ui.trade
 
 import com.badlogic.gdx.scenes.scene2d.Touchable
 import com.badlogic.gdx.scenes.scene2d.ui.Skin

--- a/core/src/com/unciv/ui/trade/OffersListScroll.kt
+++ b/core/src/com/unciv/ui/trade/OffersListScroll.kt
@@ -9,7 +9,6 @@ import com.unciv.logic.trade.TradeOffersList
 import com.unciv.logic.trade.TradeType
 import com.unciv.logic.trade.TradeType.*
 import com.unciv.models.translations.tr
-import com.unciv.ui.cityscreen.ExpanderTab
 import com.unciv.ui.utils.CameraStageBaseScreen
 import com.unciv.ui.utils.disable
 import com.unciv.ui.utils.onClick


### PR DESCRIPTION
As in "homed in package cityscreen but only used in package trade"
Silly, just improves code clarity by 0.001% - or does it?