### PR TITLE
Fixes #3799 preventing pillaging a 'city center' improvement

### DIFF
--- a/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
@@ -439,9 +439,12 @@ object UnitActions {
     }
 
     fun canPillage(unit: MapUnit, tile: TileInfo): Boolean {
-        if (tile.improvement == null || tile.improvement == Constants.barbarianEncampment
+        if (tile.improvement == null
+                || tile.improvement == Constants.barbarianEncampment
                 || tile.improvement == Constants.ancientRuins
-                || tile.improvement == "City ruins") return false
+                || tile.improvement == "City ruins"
+                || tile.improvement == "City center"
+            ) return false
         val tileOwner = tile.getOwner()
         // Can't pillage friendly tiles, just like you can't attack them - it's an 'act of war' thing
         return tileOwner == null || tileOwner == unit.civInfo || unit.civInfo.isAtWarWith(tileOwner)


### PR DESCRIPTION
'Non-pillage-a-bility' would be better as a property of the improvement itself. New class property or new entry in uniques?
For those variants, see the branches for [unique](https://github.com/SomeTroglodyte/Unciv/tree/Pillage-permission-in-unique) or [property](https://github.com/SomeTroglodyte/Unciv/tree/Pillage-Permission-in-json) in my fork. Just indicate preference.

On that note - the unique of course is visible in civilopedia, so - please remind me what was best practice for introducing new translatable strings in a fix/feature? Do include an entry in `template.properties` or not?

By the way, prettifying civilopedia especially for these improvements that up to now displayed nothing is already on [my list](https://github.com/SomeTroglodyte/Scratchpad/blob/master/Unciv-notes/unciv-notes.md).