### PR TITLE
Make city center unpillagable using a unique

### DIFF
--- a/android/assets/jsons/Civ V - Vanilla/TileImprovements.json
+++ b/android/assets/jsons/Civ V - Vanilla/TileImprovements.json
@@ -209,8 +209,8 @@
 		"shortcutKey": "F"
 	},
 	
-	{ "name": "Ancient ruins" },
-	{ "name": "City ruins" },
-	{ "name": "City center" },
-	{ "name": "Barbarian encampment" }
+	{ "name": "Ancient ruins", "uniques": ["Unpillagable"] },
+	{ "name": "City ruins", "uniques": ["Unpillagable"] },
+	{ "name": "City center", "uniques": ["Unpillagable"] },
+	{ "name": "Barbarian encampment", "uniques": ["Unpillagable"] }
 ]

--- a/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
@@ -439,9 +439,9 @@ object UnitActions {
     }
 
     fun canPillage(unit: MapUnit, tile: TileInfo): Boolean {
-        if (tile.improvement == null || tile.improvement == Constants.barbarianEncampment
-                || tile.improvement == Constants.ancientRuins
-                || tile.improvement == "City ruins") return false
+        val tileImprovement = tile.getTileImprovement()
+        // City ruins, Ancient Ruins, Barbarian Camp, City Center marked in json
+        if (tileImprovement == null || tileImprovement.hasUnique("Unpillagable")) return false
         val tileOwner = tile.getOwner()
         // Can't pillage friendly tiles, just like you can't attack them - it's an 'act of war' thing
         return tileOwner == null || tileOwner == unit.civInfo || unit.civInfo.isAtWarWith(tileOwner)


### PR DESCRIPTION
Replaces PR #3813, solves #3709. Unique string as requested in 3807 and folded single-use function as requested in 3813.