### PR TITLE
Worldscreen keys F1, C, R, T, U and V open useful screens

### DIFF
--- a/core/src/com/unciv/ui/utils/CameraStageBaseScreen.kt
+++ b/core/src/com/unciv/ui/utils/CameraStageBaseScreen.kt
@@ -48,12 +48,20 @@ open class CameraStageBaseScreen : Screen {
                 object : InputListener() {
                     override fun keyTyped(event: InputEvent?, character: Char): Boolean {
 
-                        if (character.toLowerCase() !in keyPressDispatcher || hasOpenPopups())
+                        // enable using function keys w/o changing type of dispatcher by simply treating keyCode as char,
+                        // using a seldom unused codepoint range U+1D00 to U+1DFF which corresponds to
+                        // Phonetic Extensions, Phonetic Extensions Supplement and Combining Diacritical Marks Supplement.
+                        // So to map Input.Keys.F1 use keyPressDispatcher['\u1d83'],
+                        // Arrows: Left -> '\u1d15', Right -> '\u1d16', Up -> '\u1d13', Down -> '\u1d14'
+                        val index = if (character == '\u0000' && event != null && event.keyCode != 0)
+                            (event.keyCode + 0x1d00).toChar() else character.toLowerCase()
+
+                        if (index !in keyPressDispatcher || hasOpenPopups())
                             return super.keyTyped(event, character)
 
                         //try-catch mainly for debugging. Breakpoints in the vicinity can make the event fire twice in rapid succession, second time the context can be invalid
                         try {
-                            keyPressDispatcher[character.toLowerCase()]?.invoke()
+                            keyPressDispatcher[index]?.invoke()
                         } catch (ex: Exception) {}
                         return true
                     }

--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -180,7 +180,7 @@ class WorldScreen(val gameInfo: GameInfo, val viewingCiv:CivilizationInfo) : Cam
     }
     private fun addKeyboardPresses() {
         // Space and N are assigned in createNextTurnButton
-        keyPressDispatcher['o'] = { openOverviewScreen() }
+        //keyPressDispatcher['o'] = { openOverviewScreen() }   -- will go to last-used overview page in future PR
         keyPressDispatcher['c'] = { openOverviewScreen("Cities") }
         keyPressDispatcher['r'] = { openOverviewScreen("Resources") }
         keyPressDispatcher['t'] = { openOverviewScreen("Trades") }

--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -24,7 +24,9 @@ import com.unciv.models.UncivSound
 import com.unciv.models.ruleset.tile.ResourceType
 import com.unciv.models.ruleset.unit.UnitType
 import com.unciv.models.translations.tr
+import com.unciv.ui.CivilopediaScreen
 import com.unciv.ui.cityscreen.CityScreen
+import com.unciv.ui.overviewscreen.EmpireOverviewScreen
 import com.unciv.ui.pickerscreens.GreatPersonPickerScreen
 import com.unciv.ui.pickerscreens.PolicyPickerScreen
 import com.unciv.ui.pickerscreens.TechButton
@@ -143,8 +145,8 @@ class WorldScreen(val gameInfo: GameInfo, val viewingCiv:CivilizationInfo) : Cam
 
         onBackButtonClicked { backButtonAndESCHandler() }
 
-        addKeyboardListener() // for map panning by W,S,A,D
-
+        addKeyboardListener()   // for map panning by W,S,A,D - continuous
+        addKeyboardPresses()    // for single press keys triggering actions
 
         if (gameInfo.gameParameters.isOnlineMultiplayer && !gameInfo.isUpToDate)
             isPlayersTurn = false // until we're up to date, don't let the player do anything
@@ -173,8 +175,18 @@ class WorldScreen(val gameInfo: GameInfo, val viewingCiv:CivilizationInfo) : Cam
     }
 
     private fun cleanupKeyDispatcher() {
-        val delKeys = keyPressDispatcher.keys.filter { it != ' ' && it != 'n' }
+        val delKeys = keyPressDispatcher.keys.filter { it !in " cnortuv\u1d83" }
         delKeys.forEach { keyPressDispatcher.remove(it) }
+    }
+    private fun addKeyboardPresses() {
+        // Space and N are assigned in createNextTurnButton
+        keyPressDispatcher['o'] = { openOverviewScreen() }
+        keyPressDispatcher['c'] = { openOverviewScreen("Cities") }
+        keyPressDispatcher['r'] = { openOverviewScreen("Resources") }
+        keyPressDispatcher['t'] = { openOverviewScreen("Trades") }
+        keyPressDispatcher['u'] = { openOverviewScreen("Units") }
+        keyPressDispatcher['v'] = { game.setScreen(VictoryScreen(this)) }
+        keyPressDispatcher['\u1d83'] = { game.setScreen(CivilopediaScreen(gameInfo.ruleSet)) }
     }
 
     private fun addKeyboardListener() {
@@ -458,6 +470,10 @@ class WorldScreen(val gameInfo: GameInfo, val viewingCiv:CivilizationInfo) : Cam
         }
         return fogOfWarButton
 
+    }
+
+    fun openOverviewScreen(page: String = "") {
+        game.setScreen(EmpireOverviewScreen(selectedCiv, page))
     }
 
     private fun createNextTurnButton(): TextButton {


### PR DESCRIPTION
Makes Civilopedia, Overview(Cities,Resources,Trades,Units) and Victory screen easily accessibly by keyboard.
Overview(Stats,Diplomacy) will be "OS" and "OD" in future PR
Sorry for the kludge to allow F1, I didn't want to change the type of keyDispatcher