### PR TITLE
Keyboard navigation to switch panes within overview screen

### DIFF
--- a/core/src/com/unciv/models/metadata/GameSettings.kt
+++ b/core/src/com/unciv/models/metadata/GameSettings.kt
@@ -42,6 +42,8 @@ class GameSettings {
     var showExperimentalWorldWrap = false
     var showExperimentalTileLayering = false
 
+    var lastOverviewPage: String = "Cities"
+
     init {
         // 26 = Android Oreo. Versions below may display permanent icon in notification bar.
         if (Gdx.app?.type == Application.ApplicationType.Android && Gdx.app.version < 26) {

--- a/core/src/com/unciv/ui/overviewscreen/EmpireOverviewScreen.kt
+++ b/core/src/com/unciv/ui/overviewscreen/EmpireOverviewScreen.kt
@@ -26,7 +26,7 @@ import kotlin.math.abs
 import kotlin.math.roundToInt
 import com.unciv.ui.utils.AutoScrollPane as ScrollPane
 
-class EmpireOverviewScreen(private var viewingPlayer:CivilizationInfo, defaultPage: String = "Cities") : CameraStageBaseScreen(){
+class EmpireOverviewScreen(private var viewingPlayer:CivilizationInfo, defaultPage: String = "") : CameraStageBaseScreen(){
     private val topTable = Table().apply { defaults().pad(10f) }
     private val centerTable = Table().apply { defaults().pad(5f) }
 
@@ -42,15 +42,24 @@ class EmpireOverviewScreen(private var viewingPlayer:CivilizationInfo, defaultPa
             centerTable.pack()
             for ((key, categoryButton) in categoryButtons.filterNot { it.value.touchable == Touchable.disabled })
                 categoryButton.color = if (key == name) Color.BLUE else Color.WHITE
+            game.settings.lastOverviewPage = name
         }
         setCategoryActions[name] = setCategoryAction
         categoryButtons[name] = button
         button.onClick(setCategoryAction)
         if (disabled) button.disable()
+        else keyPressDispatcher[name[0].toLowerCase()] = setCategoryAction
         topTable.add(button)
     }
 
     init {
+        val page =
+            if (defaultPage != "") {
+                game.settings.lastOverviewPage = defaultPage
+                defaultPage
+            }
+            else game.settings.lastOverviewPage
+
         onBackButtonClicked { game.setWorldScreen() }
 
         addCategory("Cities", CityOverviewTable(viewingPlayer, this))
@@ -69,7 +78,7 @@ class EmpireOverviewScreen(private var viewingPlayer:CivilizationInfo, defaultPa
 
         topTable.pack()
 
-        setCategoryActions[defaultPage]?.invoke()
+        setCategoryActions[page]?.invoke()
 
         val table = Table()
         table.add(topTable).row()


### PR DESCRIPTION
Will work together with #3827 and a future PR which will make the city and more importantly unit lists retain their position - the idea behind making the O key close the overview is to allow 'going through the unit list' via overview screen as quick as possible.

~~Works so far independently from #3827, once both are merged, uncomment one line for the 'O' key from worldview. Commented out since I use the empty string to mean 'last used page' and I saw no clean way to make the helper function agnostic to the default used.~~ (ditched helper function, only 1 key for overview screen)