### PR TITLE
Fixes #3729 "Android crash on loading from custom location"

### DIFF
--- a/core/src/com/unciv/ui/saves/LoadGameScreen.kt
+++ b/core/src/com/unciv/ui/saves/LoadGameScreen.kt
@@ -96,7 +96,9 @@ class LoadGameScreen(previousScreen:CameraStageBaseScreen) : PickerScreen() {
             loadFromCustomLocation.onClick {
                 GameSaver.loadGameFromCustomLocation { gameInfo, exception ->
                     if (gameInfo != null) {
-                        game.loadGame(gameInfo)
+                        Gdx.app.postRunnable {
+                            game.loadGame(gameInfo)
+                        }
                     } else if (exception !is CancellationException) {
                         errorLabel.setText("Could not load game from custom location!".tr())
                         exception?.printStackTrace()


### PR DESCRIPTION
See issue comments as well.
One difference between save and load to/from custom locations is - save does not do any UI work while load ends up in loadGame still within the activity callback - and loadGame instantiates new screens so it needs GL context. Thus postpone loadGame until Gdx is back in charge.