### PR TITLE
Key dispatcher update and WorldScreen F1 key

### DIFF
--- a/core/src/com/unciv/ui/utils/CameraStageBaseScreen.kt
+++ b/core/src/com/unciv/ui/utils/CameraStageBaseScreen.kt
@@ -24,7 +24,21 @@ import java.util.HashMap
 import kotlin.concurrent.thread
 import kotlin.random.Random
 
-// Gdx Input.Keys.F1 _is_ of type Int
+/*
+ * For now, combination keys cannot easily be expressed.
+ * Pressing Ctrl-Letter will arrive one event for Input.Keys.CONTROL_LEFT and one for the ASCII control code point
+ *      so Ctrl-R can be handled using KeyCharAndCode('\u0012')
+ * Pressing Alt-Something likewise will fire once for Alt and once for the unmodified keys with no indication Alt is held
+ *      (Exception: international keyboard AltGr-combos)
+ * An update supporting easy declarations for any modifier combos would need to use Gdx.input.isKeyPressed()
+ * Gdx seems to omit support for a modifier mask (e.g. Ctrl-Alt-Shift) so we would need to reinvent this
+ */
+
+/**
+ * Represents a key for use in an InputListener keyTyped() handler
+ *
+ * Example: KeyCharAndCode('R'), KeyCharAndCode(Input.Keys.F1)
+ */
 data class KeyCharAndCode(val char: Char, val code: Int) {
     // express keys with a Char value
     constructor(char: Char): this(char.toLowerCase(), 0)
@@ -37,9 +51,14 @@ data class KeyCharAndCode(val char: Char, val code: Int) {
                 if (character == Char.MIN_VALUE && event!=null) event.keyCode else 0
             )
 
+    @ExperimentalStdlibApi
     override fun toString(): String {
         // debug helper
-        return if (char == Char.MIN_VALUE) Input.Keys.toString(code) else "\"$char\""
+        return when {
+            char == Char.MIN_VALUE -> Input.Keys.toString(code)
+            char < ' ' -> "Ctrl-" + Char(char.toInt()+64)
+            else -> "\"$char\""
+        }
     }
 }
 

--- a/core/src/com/unciv/ui/utils/CameraStageBaseScreen.kt
+++ b/core/src/com/unciv/ui/utils/CameraStageBaseScreen.kt
@@ -36,10 +36,16 @@ data class KeyCharAndCode(val char: Char, val code: Int) {
                 character.toLowerCase(),
                 if (character == Char.MIN_VALUE && event!=null) event.keyCode else 0
             )
+
+    override fun toString(): String {
+        // debug helper
+        return if (char == Char.MIN_VALUE) Input.Keys.toString(code) else "\"$char\""
+    }
 }
 
 class KeyPressDispatcher {
     private val keyMap: HashMap<KeyCharAndCode, (() -> Unit)> = hashMapOf()
+    private var checkpoint: Set<KeyCharAndCode> = setOf()
 
     // access by our data class
     val keys: Set<KeyCharAndCode>
@@ -66,6 +72,17 @@ class KeyPressDispatcher {
     }
     operator fun contains(code: Int) = keyMap.contains(KeyCharAndCode(code))
     fun remove(code: Int) = keyMap.remove(KeyCharAndCode(code))
+
+    fun clear() {
+        checkpoint = setOf()
+        keyMap.clear()
+    }
+    fun setCheckpoint() {
+        checkpoint = keyMap.keys.toSet()
+    }
+    fun revertToCheckPoint() {
+        keyMap.keys.minus(checkpoint).forEach { remove(it) }
+    }
 }
 
 open class CameraStageBaseScreen : Screen {

--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -173,7 +173,7 @@ class WorldScreen(val gameInfo: GameInfo, val viewingCiv:CivilizationInfo) : Cam
     }
 
     private fun cleanupKeyDispatcher() {
-        val delKeys = keyPressDispatcher.keys.filter { it != ' ' && it != 'n' }
+        val delKeys = keyPressDispatcher.keys.filter { it.char != ' ' && it.char != 'n' }
         delKeys.forEach { keyPressDispatcher.remove(it) }
     }
 

--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -24,6 +24,7 @@ import com.unciv.models.UncivSound
 import com.unciv.models.ruleset.tile.ResourceType
 import com.unciv.models.ruleset.unit.UnitType
 import com.unciv.models.translations.tr
+import com.unciv.ui.CivilopediaScreen
 import com.unciv.ui.cityscreen.CityScreen
 import com.unciv.ui.pickerscreens.GreatPersonPickerScreen
 import com.unciv.ui.pickerscreens.PolicyPickerScreen
@@ -144,6 +145,7 @@ class WorldScreen(val gameInfo: GameInfo, val viewingCiv:CivilizationInfo) : Cam
         onBackButtonClicked { backButtonAndESCHandler() }
 
         addKeyboardListener() // for map panning by W,S,A,D
+        addKeyboardPresses()  // shortcut keys like F1
 
 
         if (gameInfo.gameParameters.isOnlineMultiplayer && !gameInfo.isUpToDate)
@@ -172,9 +174,10 @@ class WorldScreen(val gameInfo: GameInfo, val viewingCiv:CivilizationInfo) : Cam
         }
     }
 
-    private fun cleanupKeyDispatcher() {
-        val delKeys = keyPressDispatcher.keys.filter { it.char != ' ' && it.char != 'n' }
-        delKeys.forEach { keyPressDispatcher.remove(it) }
+    private fun addKeyboardPresses() {
+        // Space and N are assigned in createNextTurnButton
+        keyPressDispatcher[Input.Keys.F1] = { game.setScreen(CivilopediaScreen(gameInfo.ruleSet)) }
+        keyPressDispatcher.setCheckpoint()
     }
 
     private fun addKeyboardListener() {
@@ -297,7 +300,7 @@ class WorldScreen(val gameInfo: GameInfo, val viewingCiv:CivilizationInfo) : Cam
         if (fogOfWar) minimapWrapper.update(selectedCiv)
         else minimapWrapper.update(viewingCiv)
 
-        cleanupKeyDispatcher()
+        keyPressDispatcher.revertToCheckPoint()
         unitActionsTable.update(bottomUnitTable.selectedUnit)
         unitActionsTable.y = bottomUnitTable.height
 


### PR DESCRIPTION
**Based on #3850:** A little polish for the dispatcher including a 'checkpoint' (name debatable) that replaces the old way to distinguish permanent and transient keys on the world screen, plus worldscreen implementation up to the point that F1 works to open Civilopedia.

Left for later:
* E key for Overview incl. button decoration
* About 15 other keys, most corresponding directly to the actual Civ5 bindings
* A fix for the problem that changing one of the options using the options screen that has a corresponding minimapholder button will not update that button's color -> then enable solution to allow Ctrl-Y and Ctrl-R to work as expected