### PR TITLE
A new KeyPressDispatcher supporting function keys with F1 demo

### DIFF
--- a/core/src/com/unciv/ui/utils/CameraStageBaseScreen.kt
+++ b/core/src/com/unciv/ui/utils/CameraStageBaseScreen.kt
@@ -24,6 +24,75 @@ import java.util.HashMap
 import kotlin.concurrent.thread
 import kotlin.random.Random
 
+/*
+ * For now, combination keys cannot easily be expressed.
+ * Pressing Ctrl-Letter will arrive one event for Input.Keys.CONTROL_LEFT and one for the ASCII control code point
+ *      so Ctrl-R can be handled using KeyCharAndCode('\u0012')
+ * Pressing Alt-Something likewise will fire once for Alt and once for the unmodified keys with no indication Alt is held
+ *      (Exception: international keyboard AltGr-combos)
+ * An update supporting easy declarations for any modifier combos would need to use Gdx.input.isKeyPressed()
+ * Gdx seems to omit support for a modifier mask (e.g. Ctrl-Alt-Shift) so we would need to reinvent this
+ */
+
+/**
+ * Represents a key for use in an InputListener keyTyped() handler
+ *
+ * Example: KeyCharAndCode('R'), KeyCharAndCode(Input.Keys.F1)
+ */
+data class KeyCharAndCode(val char: Char, val code: Int) {
+    // express keys with a Char value
+    constructor(char: Char): this(char.toLowerCase(), 0)
+    // express keys that only have a keyCode like F1
+    constructor(code: Int): this(Char.MIN_VALUE, code)
+    // helper for use in InputListener keyTyped()
+    constructor(event: InputEvent?, character: Char)
+            : this (
+                character.toLowerCase(),
+                if (character == Char.MIN_VALUE && event!=null) event.keyCode else 0
+            )
+
+    @ExperimentalStdlibApi
+    override fun toString(): String {
+        // debug helper
+        return when {
+            char == Char.MIN_VALUE -> Input.Keys.toString(code)
+            char < ' ' -> "Ctrl-" + Char(char.toInt()+64)
+            else -> "\"$char\""
+        }
+    }
+}
+
+class KeyPressDispatcher: HashMap<KeyCharAndCode, (() -> Unit)>() {
+    private var checkpoint: Set<KeyCharAndCode> = setOf()
+
+    // access by Char
+    operator fun get(char: Char) = this[KeyCharAndCode(char)]
+    operator fun set(char: Char, action: () -> Unit) {
+        this[KeyCharAndCode(char)] = action
+    }
+    operator fun contains(char: Char) = this.contains(KeyCharAndCode(char))
+    fun remove(char: Char) = this.remove(KeyCharAndCode(char))
+
+    // access by Int keyCodes
+    operator fun get(code: Int) = this[KeyCharAndCode(code)]
+    operator fun set(code: Int, action: () -> Unit) {
+        this[KeyCharAndCode(code)] = action
+    }
+    operator fun contains(code: Int) = this.contains(KeyCharAndCode(code))
+    fun remove(code: Int) = this.remove(KeyCharAndCode(code))
+
+    override fun clear() {
+        checkpoint = setOf()
+        super.clear()
+    }
+    fun setCheckpoint() {
+        checkpoint = keys.toSet()
+    }
+    fun revertToCheckPoint() {
+        keys.minus(checkpoint).forEach { remove(it) }
+    }
+}
+
 open class CameraStageBaseScreen : Screen {
 
     var game: UncivGame = UncivGame.Current
@@ -31,29 +100,26 @@ open class CameraStageBaseScreen : Screen {
 
     protected val tutorialController by lazy { TutorialController(this) }
 
-    // An initialized val always turned out to illegally be null...
-    // Remember to always set LOWER CASE chars as the keys!
-    var keyPressDispatcher: HashMap<Char, (() -> Unit)>
+    val keyPressDispatcher = KeyPressDispatcher()
 
     init {
-        keyPressDispatcher = hashMapOf()
         val resolutions: List<Float> = game.settings.resolution.split("x").map { it.toInt().toFloat() }
         val width = resolutions[0]
         val height = resolutions[1]
 
         stage = Stage(ExtendViewport(width, height), SpriteBatch())
 
-
         stage.addListener(
                 object : InputListener() {
                     override fun keyTyped(event: InputEvent?, character: Char): Boolean {
+                        val key = KeyCharAndCode(event, character)
 
-                        if (character.toLowerCase() !in keyPressDispatcher || hasOpenPopups())
+                        if (key !in keyPressDispatcher || hasOpenPopups())
                             return super.keyTyped(event, character)
 
                         //try-catch mainly for debugging. Breakpoints in the vicinity can make the event fire twice in rapid succession, second time the context can be invalid
                         try {
-                            keyPressDispatcher[character.toLowerCase()]?.invoke()
+                            keyPressDispatcher[key]?.invoke()
                         } catch (ex: Exception) {}
                         return true
                     }

--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -24,6 +24,7 @@ import com.unciv.models.UncivSound
 import com.unciv.models.ruleset.tile.ResourceType
 import com.unciv.models.ruleset.unit.UnitType
 import com.unciv.models.translations.tr
+import com.unciv.ui.CivilopediaScreen
 import com.unciv.ui.cityscreen.CityScreen
 import com.unciv.ui.pickerscreens.GreatPersonPickerScreen
 import com.unciv.ui.pickerscreens.PolicyPickerScreen
@@ -144,6 +145,7 @@ class WorldScreen(val gameInfo: GameInfo, val viewingCiv:CivilizationInfo) : Cam
         onBackButtonClicked { backButtonAndESCHandler() }
 
         addKeyboardListener() // for map panning by W,S,A,D
+        addKeyboardPresses()  // shortcut keys like F1
 
 
         if (gameInfo.gameParameters.isOnlineMultiplayer && !gameInfo.isUpToDate)
@@ -172,9 +174,10 @@ class WorldScreen(val gameInfo: GameInfo, val viewingCiv:CivilizationInfo) : Cam
         }
     }
 
-    private fun cleanupKeyDispatcher() {
-        val delKeys = keyPressDispatcher.keys.filter { it != ' ' && it != 'n' }
-        delKeys.forEach { keyPressDispatcher.remove(it) }
+    private fun addKeyboardPresses() {
+        // Space and N are assigned in createNextTurnButton
+        keyPressDispatcher[Input.Keys.F1] = { game.setScreen(CivilopediaScreen(gameInfo.ruleSet)) }
+        keyPressDispatcher.setCheckpoint()
     }
 
     private fun addKeyboardListener() {
@@ -297,7 +300,7 @@ class WorldScreen(val gameInfo: GameInfo, val viewingCiv:CivilizationInfo) : Cam
         if (fogOfWar) minimapWrapper.update(selectedCiv)
         else minimapWrapper.update(viewingCiv)
 
-        cleanupKeyDispatcher()
+        keyPressDispatcher.revertToCheckPoint()
         unitActionsTable.update(bottomUnitTable.selectedUnit)
         unitActionsTable.y = bottomUnitTable.height
 


### PR DESCRIPTION
So here it is again, replacing #3850 and #3851 both - lazyness, we already discussed basic architecture, and the two-step version required first fixing an incompatible line in WorldSceeen only to throw it overboard in the second stage.

Differences to what you've seen:
* `KeyPressDispatcher` inherits `HashMap` as you've convinced me is clearer
* `KeyCharAndCode.toString` - the experimental annotation only enables showing Ctrl-R as "Ctrl-R" - debug-only, droppable
* Instead of removing key mappings when e.g. a unit is deselected we tell the dispatcher to remember a baseline and then go back to it - thanks to Set operations even transparent to arbitrary remove()'s
* F1 opens Civilopedia as demo, again - I have several of Civ5's bindings stashed

Thanks for your patience.