### PR TITLE
Templated rule variants 

### DIFF
--- a/core/src/com/unciv/models/tilesets/TileSetCache.kt
+++ b/core/src/com/unciv/models/tilesets/TileSetCache.kt
@@ -15,22 +15,7 @@ object TileSetCache : HashMap<String, TileSetConfig>(){
 
         for (configFile in fileHandles){
             tileSetName = configFile.nameWithoutExtension().removeSuffix("Config")
-            try {
-                if (this[tileSetName] == null)
-                    this[tileSetName] = JsonParser().getFromJson(TileSetConfig::class.java, configFile)
-                else
-                    this[tileSetName]!!.updateConfig(JsonParser().getFromJson(TileSetConfig::class.java, configFile))
-                if (printOutput) {
-                    println("TileSetConfig loaded successfully: ${configFile.name()}")
-                    println()
-                }
-            } catch (ex: Exception){
-                if (printOutput){
-                    println("Exception loading TileSetConfig '${configFile.path()}':")
-                    println("  ${ex.localizedMessage}")
-                    println("  (Source file ${ex.stackTrace[0].fileName} line ${ex.stackTrace[0].lineNumber})")
-                }
-            }
+            loadConfig(tileSetName, configFile, printOutput)
         }
 
         //load mod TileSets
@@ -41,24 +26,30 @@ object TileSetCache : HashMap<String, TileSetConfig>(){
             if (modFolder.name().startsWith('.')) continue
             if (!modFolder.isDirectory) continue
 
-            try {
-                for (configFile in modFolder.child("jsons/TileSets").list()){
-                    tileSetName = configFile.nameWithoutExtension().removeSuffix("Config")
-                    if (this[tileSetName] == null)
-                        this[tileSetName] = JsonParser().getFromJson(TileSetConfig::class.java, configFile)
-                    else
-                        this[tileSetName]!!.updateConfig(JsonParser().getFromJson(TileSetConfig::class.java, configFile))
-                    if (printOutput) {
-                        println("TileSetConfig loaded successfully: ${configFile.path()}")
-                        println()
-                    }
-                }
-            } catch (ex: Exception){
-                if (printOutput) {
-                    println("Exception loading TileSetConfig '${modFolder.name()}/jsons/TileSets/${tileSetName}':")
-                    println("  ${ex.localizedMessage}")
-                    println("  (Source file ${ex.stackTrace[0].fileName} line ${ex.stackTrace[0].lineNumber})")
-                }
+            for (configFile in modFolder.child("jsons/TileSets").list()){
+                tileSetName = configFile.nameWithoutExtension().removeSuffix("Config")
+                loadConfig(tileSetName, configFile, printOutput)
+            }
+        }
+    }
+
+    private fun loadConfig(tileSetName: String, configFile: FileHandle, printOutput: Boolean){
+        try {
+            if (this[tileSetName] == null)
+                this[tileSetName] = JsonParser().getFromJson(TileSetConfig::class.java, configFile)
+            else
+                this[tileSetName]!!.updateConfig(JsonParser().getFromJson(TileSetConfig::class.java, configFile))
+            this[tileSetName]!!.setTransients()
+
+            if (printOutput) {
+                println("TileSetConfig loaded successfully: ${configFile.name()}")
+                println()
+            }
+        } catch (ex: Exception){
+            if (printOutput){
+                println("Exception loading TileSetConfig '${configFile.path()}':")
+                println("  ${ex.localizedMessage}")
+                println("  (Source file ${ex.stackTrace[0].fileName} line ${ex.stackTrace[0].lineNumber})")
             }
         }
     }

--- a/core/src/com/unciv/models/tilesets/TileSetConfig.kt
+++ b/core/src/com/unciv/models/tilesets/TileSetConfig.kt
@@ -8,6 +8,11 @@ class TileSetConfig {
     var fogOfWarColor: Color = Color.BLACK
     var ruleVariants: HashMap<String, Array<String>> = HashMap()
 
+    @Transient
+    private val templatedRuleVariants: HashSet<Pair<TileComposition, Array<RuleContainer>>> = HashSet()
+    @Transient
+    private val templateDictionary = HashMap<String, Sequence<String?>>()
+
     fun updateConfig(other: TileSetConfig){
         useColorAsBaseTerrain = other.useColorAsBaseTerrain
         unexploredTileColor = other.unexploredTileColor
@@ -16,4 +21,138 @@ class TileSetConfig {
             ruleVariants[tileSetString] = renderOrder
         }
     }
+
+    fun setTransients(){
+        val ruleVariantsToRemove = ArrayList<String>()
+
+        for ((tileCompositionString, renderOrder) in ruleVariants){
+            if (tileCompositionString.contains('!')){
+                ruleVariantsToRemove.add(tileCompositionString)
+                val splitTileCompString = tileCompositionString.split('+')
+                if (splitTileCompString.size < 5)
+                    continue // forcing the existence of a full composition makes handling templated rule variants easier
+                templatedRuleVariants.add(Pair(toTileComposition(splitTileCompString), toRuleContainer(renderOrder)))
+            }
+        }
+
+        //remove all templatedRuleVariants from ruleVariants
+        for (ruleVariant in ruleVariantsToRemove)
+            ruleVariants.remove(ruleVariant)
+    }
+
+    /**
+     * Returns a list if a templated rule variant exists which matches the given sequences or else null.
+     * If a template is found the tile composition will be added to ruleVariants. The sequences must contain null
+     * for each element which is not existing.
+     */
+    fun getTemplatedRuleVariant(terrainSequence: Sequence<String?>, resAndImpSequence: Sequence<String?>): List<String>?{
+        for ((tileComposition, renderOrder) in templatedRuleVariants){
+            templateDictionary.clear()
+
+            //check if template matches
+            if (!addToTemplateDictionary(tileComposition.baseTerrain, terrainSequence.first()) ||
+                    !addToTemplateDictionary(tileComposition.terrainFeatures, terrainSequence.drop(1)) ||
+                    !addToTemplateDictionary(tileComposition.baseTerrain, resAndImpSequence.first()) ||
+                    !addToTemplateDictionary(tileComposition.baseTerrain, resAndImpSequence.last()))
+                continue
+
+            val finalRenderOrder = ArrayList<String>()
+            for (element in renderOrder){
+                if (element.isTemplate && templateDictionary[element.name] != null)
+                    finalRenderOrder.addAll(templateDictionary[element.name]!!.filterNotNull())
+                else
+                    element.name
+            }
+
+            // This tile composition gets mapped to finalRenderOrder by a templated rule variant.
+            // We can add it to ruleVariants to save time next time we search for this composition.
+            ruleVariants[(terrainSequence + resAndImpSequence).filterNotNull().joinToString("+")] = finalRenderOrder.toTypedArray()
+
+            return finalRenderOrder
+        }
+
+        return null
+    }
+
+    private data class RuleContainer(val name: String, val isTemplate: Boolean)
+
+    private data class TileComposition(val baseTerrain: RuleContainer, val terrainFeatures: Array<RuleContainer>, val resource: RuleContainer, val improvement: RuleContainer)
+
+    private fun addToTemplateDictionary(rules: Array<RuleContainer>, tileElements: Sequence<String?>): Boolean {
+        var startTemplateStrings = sequenceOf<String?>()
+        var endTemplateStrings = sequenceOf<String?>()
+        val iterator = tileElements.iterator()
+        var nextMustMatch = false
+
+        //We look at all rule elements which are no templates
+        nextRuleElement@for (ruleIndex in 1 .. rules.size - 2){
+            //we check all tileElements until we find a match for this rule element
+            while (iterator.hasNext()){
+                val next = iterator.next()
+                if (next != rules[ruleIndex].name) {
+                    // we had a match before but this one is non -> return false
+                    if (nextMustMatch)
+                        return false
+                    // if non matched yet -> add to start template
+                    startTemplateStrings += next
+                } else {
+                    //After the first match all following once must match
+                    nextMustMatch = true
+                    continue@nextRuleElement
+                }
+            }
+            // if there are still rule elements but no tile elements this template can not match
+            return false
+        }
+
+        //Add all remaining elements to end template
+        while (iterator.hasNext())
+            endTemplateStrings += iterator.next()
+
+        templateDictionary[rules.first().name] = startTemplateStrings
+        templateDictionary[rules.last().name] = endTemplateStrings
+
+        return true
+    }
+
+    private fun addToTemplateDictionary(rule: RuleContainer, tileElement: String?): Boolean {
+        if (rule.isTemplate){
+            templateDictionary[rule.name] = sequenceOf(tileElement)
+            return true
+        }
+        if (rule.name == tileElement)
+            return true
+
+        return false
+    }
+
+    private fun toRuleContainer(input: Array<String>) =
+            input.map {
+                if (it.startsWith('!'))
+                    RuleContainer(it.drop(1), true)
+                else
+                    RuleContainer(it, false)
+            }.toTypedArray()
+
+    private fun toRuleContainer(input: List<String>) =
+            input.map {
+                if (it.startsWith('!'))
+                    RuleContainer(it.drop(1), true)
+                else
+                    RuleContainer(it, false)
+            }.toTypedArray()
+
+    private fun toRuleContainer(input: String) =
+            if (input.startsWith('!'))
+                RuleContainer(input.drop(1), true)
+            else
+                RuleContainer(input, false)
+
+    private fun toTileComposition(input: List<String>) =
+            TileComposition(
+                    toRuleContainer(input.first()),
+                    toRuleContainer(input.slice(1..input.size-3)),
+                    toRuleContainer(input[input.size-2]),
+                    toRuleContainer(input.last())
+            )
 }

--- a/core/src/com/unciv/models/tilesets/TileSetConfig.kt
+++ b/core/src/com/unciv/models/tilesets/TileSetConfig.kt
@@ -7,6 +7,7 @@ class TileSetConfig {
     var unexploredTileColor: Color = Color.DARK_GRAY
     var fogOfWarColor: Color = Color.BLACK
     var ruleVariants: HashMap<String, List<String>> = HashMap()
+    var templateIndicator: Char = '?'
 
     @Transient
     private val templatedRuleVariants: HashSet<Pair<TileComposition, List<RuleContainer>>> = HashSet()
@@ -26,7 +27,7 @@ class TileSetConfig {
         val ruleVariantsToRemove = ArrayList<String>()
 
         for ((tileCompositionString, renderOrder) in ruleVariants){
-            if (tileCompositionString.contains('!')){
+            if (tileCompositionString.contains(templateIndicator)){
                 ruleVariantsToRemove.add(tileCompositionString)
                 val splitTileCompString = tileCompositionString.split('+')
                 if (splitTileCompString.size < 5)
@@ -128,14 +129,14 @@ class TileSetConfig {
 
     private fun toRuleContainer(input: List<String>) =
             input.map {
-                if (it.startsWith('!'))
+                if (it.startsWith(templateIndicator))
                     RuleContainer(it.drop(1), true)
                 else
                     RuleContainer(it, false)
             }
 
     private fun toRuleContainer(input: String) =
-            if (input.startsWith('!'))
+            if (input.startsWith(templateIndicator))
                 RuleContainer(input.drop(1), true)
             else
                 RuleContainer(input, false)

--- a/core/src/com/unciv/models/tilesets/TileSetConfig.kt
+++ b/core/src/com/unciv/models/tilesets/TileSetConfig.kt
@@ -52,16 +52,16 @@ class TileSetConfig {
             //check if template matches
             if (!addToTemplateDictionary(tileComposition.baseTerrain, terrainSequence.first()) ||
                     !addToTemplateDictionary(tileComposition.terrainFeatures, terrainSequence.drop(1)) ||
-                    !addToTemplateDictionary(tileComposition.baseTerrain, resAndImpSequence.first()) ||
-                    !addToTemplateDictionary(tileComposition.baseTerrain, resAndImpSequence.last()))
+                    !addToTemplateDictionary(tileComposition.resource, resAndImpSequence.first()) ||
+                    !addToTemplateDictionary(tileComposition.improvement, resAndImpSequence.last()))
                 continue
 
             val finalRenderOrder = ArrayList<String>()
             for (element in renderOrder){
-                if (element.isTemplate && templateDictionary[element.name] != null)
+                if (!element.isTemplate)
+                    finalRenderOrder.add(element.name)
+                else if (templateDictionary[element.name] != null)
                     finalRenderOrder.addAll(templateDictionary[element.name]!!.filterNotNull())
-                else
-                    element.name
             }
 
             // This tile composition gets mapped to finalRenderOrder by a templated rule variant.

--- a/core/src/com/unciv/ui/tilegroups/TileGroup.kt
+++ b/core/src/com/unciv/ui/tilegroups/TileGroup.kt
@@ -176,15 +176,17 @@ open class TileGroup(var tileInfo: TileInfo, var tileSetStrings:TileSetStrings, 
         val shouldShowResource = UncivGame.Current.settings.showPixelImprovements && tileInfo.resource != null &&
                 (showEntireMap || viewingCiv == null || tileInfo.hasViewableResource(viewingCiv))
 
-        var resourceAndImprovementSequence = sequenceOf<String?>()
-        if (shouldShowResource) resourceAndImprovementSequence += sequenceOf(tileInfo.resource)
-        else resourceAndImprovementSequence += null // we need null to check against for templated ruleVariants
-        if (shouldShowImprovement) resourceAndImprovementSequence += sequenceOf(tileInfo.improvement)
-        else resourceAndImprovementSequence += null // we need null to check against for templated ruleVariants
+        val resourceAndImprovementSequence = when {
+            shouldShowResource && shouldShowImprovement -> sequenceOf(tileInfo.resource, tileInfo.improvement)
+            shouldShowResource -> sequenceOf(tileInfo.resource, null)
+            shouldShowImprovement -> sequenceOf(null, tileInfo.improvement)
+            else -> sequenceOf(null, null) // we need null to check against for templated ruleVariants
+        }
 
-        var terrainImages: Sequence<String?> = sequenceOf(tileInfo.baseTerrain)
-        if (tileInfo.terrainFeatures.isEmpty()) terrainImages += sequenceOf(null) // we need null to check against for templated ruleVariants
-        else terrainImages += tileInfo.terrainFeatures.asSequence()
+        val terrainImages = when {
+            tileInfo.terrainFeatures.isEmpty() -> sequenceOf(tileInfo.baseTerrain, null) // we need null to check against for templated ruleVariants
+            else -> sequenceOf(tileInfo.baseTerrain) + tileInfo.terrainFeatures
+        }
 
         val allTogether = (terrainImages + resourceAndImprovementSequence).filterNotNull().joinToString("+")
         val allTogetherLocation = tileSetStrings.getTile(allTogether)

--- a/core/src/com/unciv/ui/tilegroups/TileGroup.kt
+++ b/core/src/com/unciv/ui/tilegroups/TileGroup.kt
@@ -186,18 +186,16 @@ open class TileGroup(var tileInfo: TileInfo, var tileSetStrings:TileSetStrings, 
         if (tileInfo.terrainFeatures.isEmpty()) terrainImages += sequenceOf(null) // we need null to check against for templated ruleVariants
         else terrainImages += tileInfo.terrainFeatures.asSequence()
 
-        val templatedRuleVariant = tileSetStrings.tileSetConfig.getTemplatedRuleVariant(terrainImages, resourceAndImprovementSequence)
-        resourceAndImprovementSequence = resourceAndImprovementSequence.filterNotNull()
-        terrainImages = terrainImages.filterNotNull()
-
-        val allTogether = (terrainImages + resourceAndImprovementSequence).joinToString("+")
+        val allTogether = (terrainImages + resourceAndImprovementSequence).filterNotNull().joinToString("+")
         val allTogetherLocation = tileSetStrings.getTile(allTogether)
 
+        val tileSetConfig = tileSetStrings.tileSetConfig
+
         return when {
-            tileSetStrings.tileSetConfig.ruleVariants[allTogether] != null -> tileSetStrings.tileSetConfig.ruleVariants[allTogether]!!.map { tileSetStrings.getTile(it) }
+            tileSetConfig.ruleVariants[allTogether] != null -> tileSetConfig.ruleVariants[allTogether]!!.map { tileSetStrings.getTile(it) }
             ImageGetter.imageExists(allTogetherLocation) -> listOf(allTogetherLocation)
-            templatedRuleVariant != null -> templatedRuleVariant.map { tileSetStrings.getTile(it) }
-            else -> getTerrainImageLocations(terrainImages) + getImprovementAndResourceImages(resourceAndImprovementSequence)
+            tileSetConfig.generateRuleVariant(terrainImages, resourceAndImprovementSequence) -> tileSetConfig.ruleVariants[allTogether]!!.map { tileSetStrings.getTile(it) }
+            else -> getTerrainImageLocations(terrainImages.filterNotNull()) + getImprovementAndResourceImages(resourceAndImprovementSequence.filterNotNull())
         }
     }
 


### PR DESCRIPTION
So here is my shot at templated rule variants. 

It works like this:
The modder can define a template indicator in the config. Default is '?'. I choose '?' because files on windows can't contain a question mark and it feels like a better fit than '/'. A template can have any name you like.
It's necessary to add either a template or a specific element to the rule for BaseTerrain, Resource, and Improvement.
Also, for TerrainFeatures the modder must add two templates. One at the start of the feature list and one at the end.
So:
"?Base+Forest+?Res+?Imp" -> Not allowed
"?Base+?start+Forest+?end+?Res+?Imp" -> allowed
"Grassland+?s+?e+Stone+?i" -> allowed

If a tile gets matched with a templated rule variant it will be added as a normal rule variant to save time on a second search.
Is that wise? And would it be wise to do the same with tiles that get caught in the else clause? 
```
getTerrainImageLocations(terrainImages.filterNotNull()) + getImprovementAndResourceImages(resourceAndImprovementSequence.filterNotNull())
```
Or is the memory cost too high?

Also, I changed ruleVariants from Array to List so I don't have to cast all the time. It changes nothing for the .json files.