### PR TITLE
Option Screen choices visible on minimap toggle buttons immediately -…

### DIFF
--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -51,7 +51,7 @@ class WorldScreen(val gameInfo: GameInfo, val viewingCiv:CivilizationInfo) : Cam
     private var waitingForAutosave = false
 
     val mapHolder = WorldMapHolder(this, gameInfo.tileMap)
-    private val minimapWrapper = MinimapHolder(mapHolder)
+    internal val minimapWrapper = MinimapHolder(mapHolder)
 
     private val topBar = WorldScreenTopBar(this)
     val bottomUnitTable = UnitTable(this)

--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -51,7 +51,7 @@ class WorldScreen(val gameInfo: GameInfo, val viewingCiv:CivilizationInfo) : Cam
     private var waitingForAutosave = false
 
     val mapHolder = WorldMapHolder(this, gameInfo.tileMap)
-    internal val minimapWrapper = MinimapHolder(mapHolder)
+    private val minimapWrapper = MinimapHolder(mapHolder)
 
     private val topBar = WorldScreenTopBar(this)
     val bottomUnitTable = UnitTable(this)
@@ -648,7 +648,8 @@ class WorldScreen(val gameInfo: GameInfo, val viewingCiv:CivilizationInfo) : Cam
 
         val scrollPos = Vector2(mapHolder.scrollX, mapHolder.scrollY)
         val viewScale = Vector2(mapHolder.scaleX, mapHolder.scaleY)
-        minimapWrapper.minimap.updateScrollPosistion(scrollPos, viewScale)
+        minimapWrapper.minimap.updateScrollPosition(scrollPos, viewScale)
+        minimapWrapper.syncButtonStates()
 
         super.render(delta)
     }

--- a/core/src/com/unciv/ui/worldscreen/mainmenu/OptionsPopup.kt
+++ b/core/src/com/unciv/ui/worldscreen/mainmenu/OptionsPopup.kt
@@ -13,7 +13,6 @@ import com.unciv.models.translations.TranslationFileWriter
 import com.unciv.models.translations.Translations
 import com.unciv.models.translations.tr
 import com.unciv.ui.utils.*
-import com.unciv.ui.worldscreen.MinimapHolder.MinimapToggleButtons
 import com.unciv.ui.worldscreen.WorldScreen
 import java.util.*
 import kotlin.concurrent.thread
@@ -65,17 +64,6 @@ class OptionsPopup(val previousScreen:CameraStageBaseScreen) : Popup(previousScr
         }
         innerTable2.add(button).row()
     }
-    private fun addYesNoRow(text: String, initialValue: Boolean, which: MinimapToggleButtons, action: ((Boolean) -> Unit)) {
-        innerTable2.add(text.toLabel())
-        val button = YesNoButton(initialValue, CameraStageBaseScreen.skin) {
-            if (previousScreen is WorldScreen)
-                previousScreen.minimapWrapper.setToggleButton(which, it)
-            else
-                action(it)
-            settings.save()
-        }
-        innerTable2.add(button).row()
-    }
 
     private fun reloadWorldAndOptions() {
         settings.save()
@@ -94,9 +82,9 @@ class OptionsPopup(val previousScreen:CameraStageBaseScreen) : Popup(previousScr
 
         addHeader("Display options")
 
-        addYesNoRow("Show worked tiles", settings.showWorkedTiles, MinimapToggleButtons.WORKED) { settings.showWorkedTiles = it }
-        addYesNoRow("Show resources and improvements", settings.showResourcesAndImprovements, MinimapToggleButtons.RESOURCES) { settings.showResourcesAndImprovements = it }
-        addYesNoRow("Show tile yields", settings.showTileYields, MinimapToggleButtons.YIELD) { settings.showTileYields = it } // JN
+        addYesNoRow("Show worked tiles", settings.showWorkedTiles, true) { settings.showWorkedTiles = it }
+        addYesNoRow("Show resources and improvements", settings.showResourcesAndImprovements, true) { settings.showResourcesAndImprovements = it }
+        addYesNoRow("Show tile yields", settings.showTileYields, true) { settings.showTileYields = it } // JN
         addYesNoRow("Show tutorials", settings.showTutorials, true) { settings.showTutorials = it }
         addYesNoRow("Show minimap", settings.showMinimap, true) { settings.showMinimap = it }
         addYesNoRow("Show pixel units", settings.showPixelUnits, true) { settings.showPixelUnits = it }

--- a/core/src/com/unciv/ui/worldscreen/mainmenu/OptionsPopup.kt
+++ b/core/src/com/unciv/ui/worldscreen/mainmenu/OptionsPopup.kt
@@ -13,6 +13,7 @@ import com.unciv.models.translations.TranslationFileWriter
 import com.unciv.models.translations.Translations
 import com.unciv.models.translations.tr
 import com.unciv.ui.utils.*
+import com.unciv.ui.worldscreen.MinimapHolder.MinimapToggleButtons
 import com.unciv.ui.worldscreen.WorldScreen
 import java.util.*
 import kotlin.concurrent.thread
@@ -64,6 +65,17 @@ class OptionsPopup(val previousScreen:CameraStageBaseScreen) : Popup(previousScr
         }
         innerTable2.add(button).row()
     }
+    private fun addYesNoRow(text: String, initialValue: Boolean, which: MinimapToggleButtons, action: ((Boolean) -> Unit)) {
+        innerTable2.add(text.toLabel())
+        val button = YesNoButton(initialValue, CameraStageBaseScreen.skin) {
+            if (previousScreen is WorldScreen)
+                previousScreen.minimapWrapper.setToggleButton(which, it)
+            else
+                action(it)
+            settings.save()
+        }
+        innerTable2.add(button).row()
+    }
 
     private fun reloadWorldAndOptions() {
         settings.save()
@@ -82,9 +94,9 @@ class OptionsPopup(val previousScreen:CameraStageBaseScreen) : Popup(previousScr
 
         addHeader("Display options")
 
-        addYesNoRow("Show worked tiles", settings.showWorkedTiles, true) { settings.showWorkedTiles = it }
-        addYesNoRow("Show resources and improvements", settings.showResourcesAndImprovements, true) { settings.showResourcesAndImprovements = it }
-        addYesNoRow("Show tile yields", settings.showTileYields, true) { settings.showTileYields = it } // JN
+        addYesNoRow("Show worked tiles", settings.showWorkedTiles, MinimapToggleButtons.WORKED) { settings.showWorkedTiles = it }
+        addYesNoRow("Show resources and improvements", settings.showResourcesAndImprovements, MinimapToggleButtons.RESOURCES) { settings.showResourcesAndImprovements = it }
+        addYesNoRow("Show tile yields", settings.showTileYields, MinimapToggleButtons.YIELD) { settings.showTileYields = it } // JN
         addYesNoRow("Show tutorials", settings.showTutorials, true) { settings.showTutorials = it }
         addYesNoRow("Show minimap", settings.showMinimap, true) { settings.showMinimap = it }
         addYesNoRow("Show pixel units", settings.showPixelUnits, true) { settings.showPixelUnits = it }


### PR DESCRIPTION
… using lambdas. This is how I would resolve #3854.

The references version was very close to this, but as I said required Kotlin reflection.

I removed the Pixel-Unit-Toggle commit, that would be a 3-liner:
```kotlin
        PIXELUNIT { override val icon = "TileSets/FantasyHex/Units/Warrior" },
                MinimapToggleButtons.PIXELUNIT -> ToggleButtonInfo(image, {showPixelUnits}, {showPixelUnits = it})
        addYesNoRow("Show pixel units", settings.showPixelUnits, MinimapToggleButtons.PIXELUNIT) { settings.showPixelUnits = it }
```
Where which line goes = puzzle for the reader. Just reusing the tiny warrior icon is ugly anyways.