### PR TITLE
Fix cancel improvement order

### DIFF
--- a/core/src/com/unciv/logic/map/TileInfo.kt
+++ b/core/src/com/unciv/logic/map/TileInfo.kt
@@ -352,6 +352,8 @@ open class TileInfo {
                     && improvement.name != "Remove Road" && improvement.name != "Remove Railroad"
                     && getTileImprovement().let { it != null && it.hasUnique("Irremovable") } -> false
 
+            // Decide cancelImprovementOrder earlier, otherwise next check breaks it
+            improvement.name == Constants.cancelImprovementOrder -> (this.improvementInProgress != null)
             // Tiles with no terrains, and no turns to build, are like great improvements - they're placeable
             improvement.terrainsCanBeBuiltOn.isEmpty() && improvement.turnsToBuild == 0 && isLand -> true
             improvement.terrainsCanBeBuiltOn.contains(topTerrain.name) -> true
@@ -364,7 +366,6 @@ open class TileInfo {
             improvement.name == "Railroad" && this.roadStatus != RoadStatus.Railroad && !isWater -> true
             improvement.name == "Remove Road" && this.roadStatus == RoadStatus.Road -> true
             improvement.name == "Remove Railroad" && this.roadStatus == RoadStatus.Railroad -> true
-            improvement.name == Constants.cancelImprovementOrder && this.improvementInProgress != null -> true
             topTerrain.unbuildable && (topTerrain.name !in improvement.resourceTerrainAllow) -> false
             // DO NOT reverse this &&. isAdjacentToFreshwater() is a lazy which calls a function, and reversing it breaks the tests.
             improvement.hasUnique("Can also be built on tiles adjacent to fresh water") && isAdjacentToFreshwater -> true

--- a/core/src/com/unciv/ui/pickerscreens/ImprovementPickerScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/ImprovementPickerScreen.kt
@@ -48,7 +48,8 @@ class ImprovementPickerScreen(val tileInfo: TileInfo, val onAccept: ()->Unit) : 
         regularImprovements.defaults().pad(5f)
 
         for (improvement in tileInfo.tileMap.gameInfo.ruleSet.tileImprovements.values) {
-            if (improvement.turnsToBuild == 0) continue
+            // canBuildImprovement() would allow e.g. great improvements thus we need to exclude them - except cancel
+            if (improvement.turnsToBuild == 0 && improvement.name != Constants.cancelImprovementOrder) continue
             if (improvement.name == tileInfo.improvement) continue
             if (!tileInfo.canBuildImprovement(improvement, currentPlayerCiv)) continue
 


### PR DESCRIPTION
It finally dawned on me the "Cancel improvement order" option no longer appears in the improvement picker...

This is only a quick patch. I Somehow have the feeling this should be made simpler using json declarations - but I have no clear vision how that might work best. If we change this, we should also allow for modded sea workers that need N turns to build something and/or upgradeable workers (some Civ had those - CTP?) including the possibility to allow different improvements by unit type (e.g. you need to upgrade your worker to engineer before he can clean fallout).......