### PR TITLE
ImprovementPicker: R key 'moves' from Road to Railroad

### DIFF
--- a/android/assets/jsons/Civ V - Vanilla/TileImprovements.json
+++ b/android/assets/jsons/Civ V - Vanilla/TileImprovements.json
@@ -52,7 +52,8 @@
 		"name": "Oil well",
 		"terrainsCanBeBuiltOn": ["Coast"],
 		"turnsToBuild": 9,
-		"techRequired": "Biology"
+		"techRequired": "Biology",
+		"shortcutKey": "W"
 	},
 	{
 		"name": "Pasture",
@@ -106,7 +107,8 @@
 		"name": "Railroad",
 		"turnsToBuild": 4,
 		"techRequired": "Railroad",
-		"uniques": ["Can be built outside your borders", "Costs [2] gold per turn when in your territory"]
+		"uniques": ["Can be built outside your borders", "Costs [2] gold per turn when in your territory"],
+		"shortcutKey": "R"
 	},
 	
 	// Removals
@@ -156,7 +158,8 @@
 	},
 	{
 		"name": "Cancel improvement order",
-		"uniques": ["Can be built outside your borders"]
+		"uniques": ["Can be built outside your borders"],
+		"shortcutKey": "."
 	},
 	
 	// Great Person improvements

--- a/core/src/com/unciv/ui/pickerscreens/ImprovementPickerScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/ImprovementPickerScreen.kt
@@ -18,7 +18,12 @@ import kotlin.math.round
 
 class ImprovementPickerScreen(val tileInfo: TileInfo, val onAccept: ()->Unit) : PickerScreen() {
     private var selectedImprovement: TileImprovement? = null
-    val currentPlayerCiv = tileInfo.tileMap.gameInfo.getCurrentPlayerCivilization()
+    private val gameInfo = tileInfo.tileMap.gameInfo
+    private val ruleSet = gameInfo.ruleSet
+    private val currentPlayerCiv = gameInfo.getCurrentPlayerCivilization()
+
+    private fun getRequiredTechColumn(improvement: TileImprovement) =
+        ruleSet.technologies[improvement.techRequired]?.column?.columnNumber ?: -1
 
     fun accept(improvement: TileImprovement?) {
         if (improvement == null) return
@@ -47,10 +52,10 @@ class ImprovementPickerScreen(val tileInfo: TileInfo, val onAccept: ()->Unit) : 
         val regularImprovements = Table()
         regularImprovements.defaults().pad(5f)
 
-        for (improvement in tileInfo.tileMap.gameInfo.ruleSet.tileImprovements.values) {
+        for (improvement in ruleSet.tileImprovements.values) {
             // canBuildImprovement() would allow e.g. great improvements thus we need to exclude them - except cancel
             if (improvement.turnsToBuild == 0 && improvement.name != Constants.cancelImprovementOrder) continue
-            if (improvement.name == tileInfo.improvement) continue
+            if (improvement.name == tileInfo.improvement) continue      // also checked by canImprovementBeBuiltHere, but after more expensive tests
             if (!tileInfo.canBuildImprovement(improvement, currentPlayerCiv)) continue
 
             val improvementButtonTable = Table()
@@ -59,8 +64,24 @@ class ImprovementPickerScreen(val tileInfo: TileInfo, val onAccept: ()->Unit) : 
 
             improvementButtonTable.add(image).size(30f).pad(10f)
 
+            // allow multiple key mappings to technologically supersede each other
+            var shortcutKey = improvement.shortcutKey
+            if (shortcutKey != null) {
+                val techLevel = getRequiredTechColumn(improvement)
+                val isSuperseded = ruleSet.tileImprovements.values.asSequence()
+                    // *other* improvements with same shortcutKey
+                    .filter { it.shortcutKey == improvement.shortcutKey && it != improvement }
+                    // civ can build it (checks tech researched)
+                    .filter { tileInfo.canBuildImprovement(it, currentPlayerCiv) }
+                    // is technologically more advanced
+                    .filter { getRequiredTechColumn(it) > techLevel }
+                    .any()
+                // another supersedes this - ignore key binding
+                if (isSuperseded) shortcutKey = null
+            }
+
             var labelText = improvement.name.tr()
-            if (improvement.shortcutKey != null) labelText += " (${improvement.shortcutKey})"
+            if (shortcutKey != null) labelText += " ($shortcutKey)"
             val turnsToBuild = if (tileInfo.improvementInProgress == improvement.name) tileInfo.turnsToImprovement
             else improvement.getTurnsToBuild(currentPlayerCiv)
             if (turnsToBuild > 0) labelText += " - $turnsToBuild${Fonts.turn}"
@@ -76,7 +97,6 @@ class ImprovementPickerScreen(val tileInfo: TileInfo, val onAccept: ()->Unit) : 
             improvementButtonTable.onClick {
                 selectedImprovement = improvement
                 pick(improvement.name.tr())
-                val ruleSet = tileInfo.tileMap.gameInfo.ruleSet
                 descriptionLabel.setText(improvement.getDescription(ruleSet))
             }
 
@@ -84,8 +104,8 @@ class ImprovementPickerScreen(val tileInfo: TileInfo, val onAccept: ()->Unit) : 
                 "Pick now!".toLabel().onClick { accept(improvement) }
             else "Current construction".toLabel()
 
-            if (improvement.shortcutKey != null)
-                keyPressDispatcher[improvement.shortcutKey.toLowerCase()] = { accept(improvement) }
+            if (shortcutKey != null)
+                keyPressDispatcher[shortcutKey] = { accept(improvement) }
 
 
             val statIcons = getStatIconsTable(provideResource, removeImprovement)


### PR DESCRIPTION
replaces PR #3867 - remerged.

Oh and I forgot a question: One change drops a `toLowerCase` because the dispatcher is now case insensitive by default. Now might be the time to invest a few nanoseconds to compare visions:
* key bindings stay case-insensitive for all time and we remove redundant toLowerCase when we get around to it
* we *want* to support binding un-shift-ed and shifted keys to different actions -> redesign dispatcher a little, possibly indicating desired shortcutKey case sensitivity in json
* we want Alt+Key support as well -> some more redesign (with considerations like catching keyUp instead of keyPress, or using isKeyPressed), but better now than later

see also comment block I left in CameraStageBaseScreen.kt