### PR TITLE
Bug: turnsLabel accumulates touchFocuses endlessly

### DIFF
--- a/core/src/com/unciv/ui/worldscreen/WorldScreenTopBar.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreenTopBar.kt
@@ -58,6 +58,7 @@ class WorldScreenTopBar(val worldScreen: WorldScreen) : Table() {
     private fun getResourceTable(): Table {
         val resourceTable = Table()
         resourceTable.defaults().pad(5f)
+        turnsLabel.onClick { worldScreen.game.setScreen(VictoryScreen(worldScreen)) }
         resourceTable.add(turnsLabel).padRight(20f)
         val revealedStrategicResources = worldScreen.gameInfo.ruleSet.tileResources.values
                 .filter { it.resourceType == ResourceType.Strategic } // && currentPlayerCivInfo.tech.isResearched(it.revealedBy!!) }
@@ -189,8 +190,6 @@ class WorldScreenTopBar(val worldScreen: WorldScreen) : Table() {
 
         val yearText = "[" + abs(year) + "] " + if (year < 0) "BC" else "AD"
         turnsLabel.setText(Fonts.turn + "" + civInfo.gameInfo.turns + " | " + yearText.tr())
-        if (turnsLabel.listeners.isEmpty)
-            turnsLabel.onClick { worldScreen.game.setScreen(VictoryScreen(worldScreen)) }
 
         val nextTurnStats = civInfo.statsForNextTurn
         val goldPerTurn = "(" + (if (nextTurnStats.gold > 0) "+" else "") + nextTurnStats.gold.roundToInt() + ")"

--- a/core/src/com/unciv/ui/worldscreen/WorldScreenTopBar.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreenTopBar.kt
@@ -189,7 +189,8 @@ class WorldScreenTopBar(val worldScreen: WorldScreen) : Table() {
 
         val yearText = "[" + abs(year) + "] " + if (year < 0) "BC" else "AD"
         turnsLabel.setText(Fonts.turn + "" + civInfo.gameInfo.turns + " | " + yearText.tr())
-        turnsLabel.onClick { worldScreen.game.setScreen(VictoryScreen(worldScreen)) }
+        if (turnsLabel.listeners.isEmpty)
+            turnsLabel.onClick { worldScreen.game.setScreen(VictoryScreen(worldScreen)) }
 
         val nextTurnStats = civInfo.statsForNextTurn
         val goldPerTurn = "(" + (if (nextTurnStats.gold > 0) "+" else "") + nextTurnStats.gold.roundToInt() + ")"


### PR DESCRIPTION
To reproduce:
- Continuous rendering on - may or may not be significant
- Sound on and volume audible helps sensing the problem
- Wait a few minutes or play and cause many WorldScreenTopBar.update() calls - idle accumulates at ~1/s
- Click the turn counter up there

I observed:
- Victory screen takes a long time to pop up
- Staccato click sounds
- Breakpointing somewhere in the Victory screen constructor shows breakpoint hits repeatedly
- Some stepping to access stage internals shows the touchFocuses array is pretty crowded, most from our label, and all of those firing for the click

***I am not sure this is the correct fix***
...but it fixes the observed problem

***I have not scanned the UI code for more occurrences***
...but someone should. I, for instance, implicitly assumed an Actor would only have one onClick listener and setting one would replace the previous one