### PR TITLE
Accelerate Load Game Screen Info

### DIFF
--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -1,6 +1,5 @@
 package com.unciv.logic
 
-import com.badlogic.gdx.graphics.Color
 import com.unciv.Constants
 import com.unciv.UncivGame
 import com.unciv.logic.automation.NextTurnAutomation
@@ -392,4 +391,15 @@ class GameInfo {
             cityConstructions.inProgressConstructions.remove(oldBuildingName)
         }
     }
+}
+
+// reduced variant only for load preview
+class GameInfoPreview {
+    var civilizations = mutableListOf<CivilizationInfoPreview>()
+    var difficulty = "Chieftain"
+    var gameParameters = GameParameters()
+    var turns = 0
+    var gameId = ""
+    var currentPlayer = ""
+    fun getCivilization(civName: String) = civilizations.first { it.civName == civName }
 }

--- a/core/src/com/unciv/logic/GameSaver.kt
+++ b/core/src/com/unciv/logic/GameSaver.kt
@@ -4,9 +4,7 @@ import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.files.FileHandle
 import com.badlogic.gdx.utils.Json
 import com.unciv.UncivGame
-import com.unciv.logic.civilization.CivilizationInfo
 import com.unciv.models.metadata.GameSettings
-import com.unciv.ui.utils.ImageGetter
 import java.io.File
 import kotlin.concurrent.thread
 
@@ -66,6 +64,10 @@ object GameSaver {
         val game = json().fromJson(GameInfo::class.java, gameFile)
         game.setTransients()
         return game
+    }
+
+    fun loadGamePreviewFromFile(gameFile: FileHandle): GameInfoPreview {
+        return json().fromJson(GameInfoPreview::class.java, gameFile)
     }
 
     fun loadGameFromCustomLocation(loadCompletionCallback: (GameInfo?, Exception?) -> Unit) {

--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -681,3 +681,11 @@ class CivilizationInfo {
 
     //endregion
 }
+
+// reduced variant only for load preview
+class CivilizationInfoPreview {
+    var civName = ""
+    var playerType = PlayerType.AI
+    var playerId = ""
+    fun isPlayerCivilization() = playerType == PlayerType.Human
+}

--- a/core/src/com/unciv/ui/saves/LoadGameScreen.kt
+++ b/core/src/com/unciv/ui/saves/LoadGameScreen.kt
@@ -170,29 +170,31 @@ class LoadGameScreen(previousScreen:CameraStageBaseScreen) : PickerScreen() {
     private fun onSaveSelected(save: FileHandle) {
         selectedSave = save.name()
         copySavedGameToClipboardButton.enable()
-        var textToSet = save.name()
+
+        rightSideButton.setText("Load [${save.name()}]".tr())
+        rightSideButton.enable()
+        deleteSaveButton.enable()
+        deleteSaveButton.color = Color.RED
+        descriptionLabel.setText("Loading...".tr())
+
 
         val savedAt = Date(save.lastModified())
-        descriptionLabel.setText("Loading...".tr())
-        textToSet += "\n{Saved at}: ".tr() + SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.US).format(savedAt)
+        var textToSet = save.name() +
+             "\n${"Saved at".tr()}: " + SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.US).format(savedAt)
         thread { // Even loading the game to get its metadata can take a long time on older phones
             try {
-                val game = GameSaver.loadGameFromFile(save)
+                val game = GameSaver.loadGamePreviewFromFile(save)
                 val playerCivNames = game.civilizations.filter { it.isPlayerCivilization() }.joinToString { it.civName.tr() }
                 textToSet += "\n" + playerCivNames +
                         ", " + game.difficulty.tr() + ", ${Fonts.turn}" + game.turns
                 if (game.gameParameters.mods.isNotEmpty())
-                    textToSet += "\n {Mods:} ".tr() + game.gameParameters.mods.joinToString()
+                    textToSet += "\n${"Mods:".tr()} " + game.gameParameters.mods.joinToString()
             } catch (ex: Exception) {
-                textToSet += "\n{Could not load game}!".tr()
+                textToSet += "\n${"Could not load game".tr()}!"
             }
 
             Gdx.app.postRunnable {
                 descriptionLabel.setText(textToSet)
-                rightSideButton.setText("Load [${save.name()}]".tr())
-                rightSideButton.enable()
-                deleteSaveButton.enable()
-                deleteSaveButton.color = Color.RED
             }
         }
     }


### PR DESCRIPTION
On the load game screen, you have to wait a second or several between clicking a save and being allowed to actually load the game. This is because the button enabling waits for the info label to update, which is slow. There's no reason for this dependency.

The info label uses a full game load to pull out just a few variables. The new code avoids initializing transients like multiplayer code does, but also allows the json parser to skip large portions (and not allocate memory) by specifying a trimmed version of the destination class. Total gain is 1-2 orders of magnitude, admittedly the transients thing constitutes the majority of that, but still.

I haven't touched the multiplayer code though it has two functions which could profit (one cascaded through several functions) a little - but the 'Preview' classes are prepared to include everything those functions need.

Sorry for the marginal changes in string handling in the descriptionLabel preparation - I only wanted to remove the leading space on the mods line and noticed it passes the translation engine - and then I figured why use Unciv tr() templating when Kotlin string templating is sufficient because the constant portions are whitespace and punctuation only? Those "\n {}:" and similar wrapper strings do not appear as translatable anyway.

A note on "Mods" vs "Mods:" - both appear in the translations and could perhaps be unified? I didn't because the "Mods:" variant has a few more translations.