### PR TITLE
Save game UI patch

### DIFF
--- a/core/src/com/unciv/MainMenuScreen.kt
+++ b/core/src/com/unciv/MainMenuScreen.kt
@@ -149,7 +149,7 @@ class MainMenuScreen: CameraStageBaseScreen() {
             add(newMapButton).row()
 
             val loadMapButton = screen.getTableBlock("Load map", "OtherIcons/Load") {
-                val loadMapScreen = SaveAndLoadMapScreen(null)
+                val loadMapScreen = SaveAndLoadMapScreen(null, false, screen)
                 loadMapScreen.closeButton.isVisible = true
                 loadMapScreen.closeButton.onClick {
                     screen.game.setScreen(MainMenuScreen())

--- a/core/src/com/unciv/ui/mapeditor/GameParametersScreen.kt
+++ b/core/src/com/unciv/ui/mapeditor/GameParametersScreen.kt
@@ -8,14 +8,15 @@ import com.unciv.ui.newgamescreen.PlayerPickerTable
 import com.unciv.ui.newgamescreen.IPreviousScreen
 import com.unciv.ui.pickerscreens.PickerScreen
 import com.unciv.ui.utils.*
+
 /**
  * This [Screen] is used for editing game parameters when scenario is edited/created in map editor.
- * Implements [PreviousScreenInterface] for compatibility with [PlayerPickerTable], [GameOptionsTable]
+ * Implements [IPreviousScreen] for compatibility with [PlayerPickerTable], [GameOptionsTable]
  * Uses [PlayerPickerTable] and [GameOptionsTable] to change local [gameSetupInfo]. Upon confirmation
  * updates [mapEditorScreen] and switches to it.
  * @param [mapEditorScreen] previous screen from map editor.
  */
-class GameParametersScreen(var mapEditorScreen: MapEditorScreen): IPreviousScreen, PickerScreen() {
+class GameParametersScreen(var mapEditorScreen: MapEditorScreen): IPreviousScreen, PickerScreen(disableScroll = true) {
     override var gameSetupInfo = mapEditorScreen.gameSetupInfo.clone()
     override var ruleset = RulesetCache.getComplexRuleset(gameSetupInfo.gameParameters.mods)
     var playerPickerTable = PlayerPickerTable(this, gameSetupInfo.gameParameters)
@@ -24,7 +25,6 @@ class GameParametersScreen(var mapEditorScreen: MapEditorScreen): IPreviousScree
 
     init {
         setDefaultCloseAction(mapEditorScreen)
-        scrollPane.setScrollingDisabled(true, true)
 
         topTable.add(AutoScrollPane(gameOptionsTable).apply { setScrollingDisabled(true, false) })
                 .maxHeight(topTable.parent.height).width(stage.width / 2).padTop(20f).top()

--- a/core/src/com/unciv/ui/mapeditor/MapEditorMenuPopup.kt
+++ b/core/src/com/unciv/ui/mapeditor/MapEditorMenuPopup.kt
@@ -13,8 +13,8 @@ class MapEditorMenuPopup(var mapEditorScreen: MapEditorScreen): Popup(mapEditorS
 
     init {
         addButton("New map") { UncivGame.Current.setScreen(NewMapScreen(mapEditorScreen.tileMap.mapParameters)) }
-        addButton("Save map") { mapEditorScreen.game.setScreen(SaveAndLoadMapScreen(mapEditorScreen.tileMap, true)) }
-        addButton("Load map") { mapEditorScreen.game.setScreen(SaveAndLoadMapScreen(mapEditorScreen.tileMap)) }
+        addButton("Save map") { mapEditorScreen.game.setScreen(SaveAndLoadMapScreen(mapEditorScreen.tileMap, true, mapEditorScreen)); this.close() }
+        addButton("Load map") { mapEditorScreen.game.setScreen(SaveAndLoadMapScreen(mapEditorScreen.tileMap, false, mapEditorScreen)); this.close() }
         addButton("Exit map editor") { mapEditorScreen.game.setScreen(MainMenuScreen()); mapEditorScreen.dispose() }
         addButton("Change ruleset") { MapEditorRulesetPopup(mapEditorScreen).open(); close() }
         addButton(Constants.close) { close() }

--- a/core/src/com/unciv/ui/mapeditor/SaveAndLoadMapScreen.kt
+++ b/core/src/com/unciv/ui/mapeditor/SaveAndLoadMapScreen.kt
@@ -19,7 +19,8 @@ import com.unciv.ui.utils.*
 import kotlin.concurrent.thread
 import com.unciv.ui.utils.AutoScrollPane as ScrollPane
 
-class SaveAndLoadMapScreen(mapToSave: TileMap?, save:Boolean = false) : PickerScreen(disableScroll = true) {
+class SaveAndLoadMapScreen(mapToSave: TileMap?, save:Boolean = false, previousScreen: CameraStageBaseScreen)
+        : PickerScreen(disableScroll = true) {
     var chosenMap: FileHandle? = null
     val deleteButton = "Delete map".toTextButton()
     val mapsTable = Table().apply { defaults().pad(10f) }
@@ -116,13 +117,13 @@ class SaveAndLoadMapScreen(mapToSave: TileMap?, save:Boolean = false) : PickerSc
         deleteButton.onClick {
             YesNoPopup("Are you sure you want to delete this map?", {
                 chosenMap!!.delete()
-                game.setScreen(SaveAndLoadMapScreen(mapToSave))
+                game.setScreen(SaveAndLoadMapScreen(mapToSave, save, previousScreen))
             }, this).open()
         }
         rightSideTable.add(deleteButton).row()
 
         topTable.add(rightSideTable)
-        setDefaultCloseAction(MainMenuScreen())
+        setDefaultCloseAction(previousScreen)
 
         update()
     }

--- a/core/src/com/unciv/ui/mapeditor/SaveAndLoadMapScreen.kt
+++ b/core/src/com/unciv/ui/mapeditor/SaveAndLoadMapScreen.kt
@@ -19,7 +19,7 @@ import com.unciv.ui.utils.*
 import kotlin.concurrent.thread
 import com.unciv.ui.utils.AutoScrollPane as ScrollPane
 
-class SaveAndLoadMapScreen(mapToSave: TileMap?, save:Boolean = false) : PickerScreen() {
+class SaveAndLoadMapScreen(mapToSave: TileMap?, save:Boolean = false) : PickerScreen(disableScroll = true) {
     var chosenMap: FileHandle? = null
     val deleteButton = "Delete map".toTextButton()
     val mapsTable = Table().apply { defaults().pad(10f) }

--- a/core/src/com/unciv/ui/newgamescreen/NewGameScreen.kt
+++ b/core/src/com/unciv/ui/newgamescreen/NewGameScreen.kt
@@ -36,7 +36,7 @@ class GameSetupInfo(var gameId:String, var gameParameters: GameParameters, var m
     }
 }
 
-class NewGameScreen(private val previousScreen: CameraStageBaseScreen, _gameSetupInfo: GameSetupInfo?=null): IPreviousScreen, PickerScreen() {
+class NewGameScreen(private val previousScreen: CameraStageBaseScreen, _gameSetupInfo: GameSetupInfo?=null): IPreviousScreen, PickerScreen(disableScroll = true) {
     override val gameSetupInfo = _gameSetupInfo ?: GameSetupInfo()
     override var ruleset = RulesetCache.getComplexRuleset(gameSetupInfo.gameParameters.mods) // needs to be set because the gameoptionstable etc. depend on this
     var newGameOptionsTable = GameOptionsTable(this) { desiredCiv: String -> playerPickerTable.update(desiredCiv) }
@@ -48,7 +48,6 @@ class NewGameScreen(private val previousScreen: CameraStageBaseScreen, _gameSetu
 
     init {
         setDefaultCloseAction(previousScreen)
-        scrollPane.setScrollingDisabled(true, true)
 
         topTable.add(ScrollPane(newGameOptionsTable).apply { setOverscroll(false, false) })
                 .width(stage.width / 3).padTop(20f).top()

--- a/core/src/com/unciv/ui/pickerscreens/ModManagementScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/ModManagementScreen.kt
@@ -23,7 +23,9 @@ import java.util.*
 import kotlin.collections.HashMap
 import kotlin.concurrent.thread
 
-class ModManagementScreen: PickerScreen() {
+// All picker screens auto-wrap the top table in a ScrollPane.
+// Since we want the different parts to scroll separately, we disable the default ScrollPane, which would scroll everything at once.
+class ModManagementScreen: PickerScreen(disableScroll = true) {
 
     val modTable = Table().apply { defaults().pad(10f) }
     val downloadTable = Table().apply { defaults().pad(10f) }
@@ -42,11 +44,6 @@ class ModManagementScreen: PickerScreen() {
         topTable.add("Downloadable mods".toLabel())
 //        topTable.add("Mod actions")
         topTable.row()
-
-
-        // All picker screens auto-wrap the top table in a scrollpane.
-        // Since we want the different parts to scroll separately, we disable the default scrollpane, which would scroll everything at once.
-        scrollPane.setScrollingDisabled(true, true)
 
         topTable.add(ScrollPane(modTable)).pad(10f)
 

--- a/core/src/com/unciv/ui/pickerscreens/PickerScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/PickerScreen.kt
@@ -7,7 +7,7 @@ import com.unciv.UncivGame
 import com.unciv.models.translations.tr
 import com.unciv.ui.utils.*
 
-open class PickerScreen : CameraStageBaseScreen() {
+open class PickerScreen(val disableScroll: Boolean = false) : CameraStageBaseScreen() {
 
     internal var closeButton: TextButton = Constants.close.toTextButton()
     protected var descriptionLabel: Label
@@ -42,6 +42,7 @@ open class PickerScreen : CameraStageBaseScreen() {
         topTable = Table()
         scrollPane = ScrollPane(topTable)
 
+        scrollPane.setScrollingDisabled(disableScroll, disableScroll)
         scrollPane.setSize(stage.width, stage.height * screenSplit)
 
         splitPane = SplitPane(scrollPane, bottomTable, true, skin)

--- a/core/src/com/unciv/ui/saves/LoadGameScreen.kt
+++ b/core/src/com/unciv/ui/saves/LoadGameScreen.kt
@@ -20,7 +20,7 @@ import java.util.concurrent.CancellationException
 import kotlin.concurrent.thread
 import com.unciv.ui.utils.AutoScrollPane as ScrollPane
 
-class LoadGameScreen(previousScreen:CameraStageBaseScreen) : PickerScreen() {
+class LoadGameScreen(previousScreen:CameraStageBaseScreen) : PickerScreen(disableScroll = true) {
     lateinit var selectedSave: String
     private val copySavedGameToClipboardButton = "Copy saved game to clipboard".toTextButton()
     private val saveTable = Table()

--- a/core/src/com/unciv/ui/saves/LoadGameScreen.kt
+++ b/core/src/com/unciv/ui/saves/LoadGameScreen.kt
@@ -73,6 +73,7 @@ class LoadGameScreen(previousScreen:CameraStageBaseScreen) : PickerScreen(disabl
 
     private fun getRightSideTable(): Table {
         val rightSideTable = Table()
+        rightSideTable.defaults().pad(10f)
 
         val errorLabel = "".toLabel(Color.RED)
         val loadFromClipboardButton = "Load copied data".toTextButton()
@@ -105,7 +106,7 @@ class LoadGameScreen(previousScreen:CameraStageBaseScreen) : PickerScreen(disabl
                     }
                 }
             }
-            rightSideTable.add(loadFromCustomLocation).pad(10f).row()
+            rightSideTable.add(loadFromCustomLocation).row()
         }
         rightSideTable.add(errorLabel).row()
 

--- a/core/src/com/unciv/ui/saves/SaveGameScreen.kt
+++ b/core/src/com/unciv/ui/saves/SaveGameScreen.kt
@@ -25,16 +25,17 @@ class SaveGameScreen(val gameInfo: GameInfo) : PickerScreen(disableScroll = true
         setDefaultCloseAction()
 
         gameNameTextField.textFieldFilter = TextField.TextFieldFilter { _, char -> char != '\\' && char != '/' }
-        currentSaves.add("Current saves".toLabel()).row()
+        topTable.add("Current saves".toLabel()).pad(10f).row()
         updateShownSaves(false)
         topTable.add(ScrollPane(currentSaves))
 
         val newSave = Table()
+        newSave.defaults().pad(5f, 10f, 5f, 10f)
         val defaultSaveName = gameInfo.currentPlayer + " -  " + gameInfo.turns + " turns"
         gameNameTextField.text = defaultSaveName
 
         newSave.add("Saved game name".toLabel()).row()
-        newSave.add(gameNameTextField).width(300f).pad(10f).row()
+        newSave.add(gameNameTextField).width(300f).row()
 
         val copyJsonButton = "Copy to clipboard".toTextButton()
         copyJsonButton.onClick {
@@ -63,8 +64,8 @@ class SaveGameScreen(val gameInfo: GameInfo) : PickerScreen(disableScroll = true
                     }
                 }
             }
-            newSave.add(saveToCustomLocation).pad(10f).row()
-            newSave.add(errorLabel).pad(0f, 10f, 10f, 10f).row()
+            newSave.add(saveToCustomLocation).row()
+            newSave.add(errorLabel).row()
         }
 
 

--- a/core/src/com/unciv/ui/saves/SaveGameScreen.kt
+++ b/core/src/com/unciv/ui/saves/SaveGameScreen.kt
@@ -17,7 +17,7 @@ import kotlin.concurrent.thread
 import com.unciv.ui.utils.AutoScrollPane as ScrollPane
 
 
-class SaveGameScreen(val gameInfo: GameInfo) : PickerScreen() {
+class SaveGameScreen(val gameInfo: GameInfo) : PickerScreen(disableScroll = true) {
     val gameNameTextField = TextField("", skin)
     val currentSaves = Table()
 


### PR DESCRIPTION
Resolve #3892

Method: optional Constructor parameter on PickerScreen, idea: all callers will use named parameter syntax to improve readability and search-ability.

GameParametersScreen - new pattern applied
LoadGameScreen - had the problem
MultiplayerScreen - similar pattern but retains horizontal scroll of PickerScreen.scrollPane - untouched
ModManagementScreen - new pattern applied
NewGameScreen - new pattern applied
NewMapScreen - not fully understood: it fills topTable with nothing but its own ScrollPane, but until I see why I won't touch it
SaveAndLoadMapScreen - had the problem
SaveGameScreen - had the problem
_all_ other PickerScreens checked and unaffected

Second commit fixes minor annoyances I saw while testing - buttons glued together on load screen, labels added and immediately cleared away, map editor save load did not return as expected on close.

P.S.: I did _not_ try to fix these warnings:
```
w: ~/core/src/com/unciv/ui/mapeditor/GameParametersScreen.kt: (18, 1): Names of the parameter #1 conflict in the following members of supertypes: 'public abstract fun setRightSideButtonEnabled(boolean: Boolean): Unit defined in com.unciv.ui.newgamescreen.IPreviousScreen, public final fun setRightSideButtonEnabled(bool: Boolean): Unit defined in com.unciv.ui.pickerscreens.PickerScreen'. This may cause problems when calling this function with named arguments.
w: ~/core/src/com/unciv/ui/newgamescreen/NewGameScreen.kt: (39, 1): Names of the parameter #1 conflict in the following members of supertypes: 'public abstract fun setRightSideButtonEnabled(boolean: Boolean): Unit defined in com.unciv.ui.newgamescreen.IPreviousScreen, public final fun setRightSideButtonEnabled(bool: Boolean): Unit defined in com.unciv.ui.pickerscreens.PickerScreen'. This may cause problems when calling this function with named arguments.
```
Well, the compiler is obviously right if you inherit (not implement - does kotlin even have implements?) from an interface and a class in parallel which themselves have no relationship, then you get an ambiguity for every member with identical signature... 