### PR TITLE
Fixed Forest on Hill does not show

### DIFF
--- a/android/assets/jsons/TileSets/FantasyHex.json
+++ b/android/assets/jsons/TileSets/FantasyHex.json
@@ -1,9 +1,11 @@
 {
     "useColorAsBaseTerrain": "false",
     "ruleVariants": {
+        //Legacy hill support
         "Hill": ["Grassland","Hill"],
-		
         "Hill+Forest+Uranium": ["Grassland","Hill","Uranium","Forest"],
+        "Hill+Forest+Furs": ["Grassland","Hill","Furs","HillForest"],
+        "Hill+Forest+Deer": ["Grassland","Hill","Deer","HillForest"],
 		
         //Special forest and jungle
         "Grassland+Forest": ["Grassland","GrasslandForest"],
@@ -84,8 +86,6 @@
         "Tundra+Hill+Forest+Uranium": ["Tundra","Hill","Uranium","TundraForest"],
         "Tundra+Hill+Forest+Furs": ["Tundra","Hill","Furs","TundraForest"],
         "Tundra+Hill+Forest+Deer": ["Tundra","Hill","Deer","TundraForest"],
-        "Hill+Forest+Furs": ["Grassland","Hill","Furs","HillForest"],
-        "Hill+Forest+Deer": ["Grassland","Hill","Deer","HillForest"],
 		
         "Grassland+Forest+Ancient ruins": ["Grassland","Ancient ruins", "GrasslandForest"],
         "Grassland+Cattle+Ancient ruins": ["Grassland","Ancient ruins","Cattle"],

--- a/android/assets/jsons/TileSets/FantasyHex.json
+++ b/android/assets/jsons/TileSets/FantasyHex.json
@@ -3,15 +3,11 @@
     "ruleVariants": {
         "Hill": ["Grassland","Hill"],
 		
-        "Hill+Forest+Uranium": ["Grassland","Hill","Uranium","HillForest"],
-        "Grassland+Hill+Forest+Uranium": ["Grassland","Hill","Uranium","HillForest"],
+        "Hill+Forest+Uranium": ["Grassland","Hill","Uranium","Forest"],
 		
         //Special forest and jungle
         "Grassland+Forest": ["Grassland","GrasslandForest"],
         "Plains+Forest": ["Plains","PlainsForest"],
-		
-        "Grassland+Jungle+Oil": ["Grassland","Oil","GrasslandJungle"],
-        "Plains+Jungle+Oil": ["Plains","Oil","PlainsJungle"],
         "Plains+Jungle": ["Plains","PlainsJungle"],
         "Tundra+Forest": ["Tundra","TundraForest"],
         "Tundra+Hill+Forest": ["Tundra","Hill","TundraForest"],
@@ -87,15 +83,9 @@
         "Tundra+Hill+Forest+Aluminum": ["Tundra","Hill","Aluminum","TundraForest"],
         "Tundra+Hill+Forest+Uranium": ["Tundra","Hill","Uranium","TundraForest"],
         "Tundra+Hill+Forest+Furs": ["Tundra","Hill","Furs","TundraForest"],
-        "Tundra+Hill+Forest+Deer": ["Tundra","Hill","Deer","TundraForest"]
+        "Tundra+Hill+Forest+Deer": ["Tundra","Hill","Deer","TundraForest"],
         "Hill+Forest+Furs": ["Grassland","Hill","Furs","HillForest"],
         "Hill+Forest+Deer": ["Grassland","Hill","Deer","HillForest"],
-		
-        "Grassland+Hill+Forest": ["Grassland","Hill","HillForest"],
-        "Plains+Hill+Forest": ["Plains","Hill","HillForest"],
-        "Tundra+Hill+Forest": ["Tundra","Hill","HillForest"],
-        "Desert+Hill+Forest": ["Desert","Hill","HillForest"],
-        "Snow+Hill+Forest": ["Snow","Hill","HillForest"],
 		
         "Grassland+Forest+Ancient ruins": ["Grassland","Ancient ruins", "GrasslandForest"],
         "Grassland+Cattle+Ancient ruins": ["Grassland","Ancient ruins","Cattle"],


### PR DESCRIPTION
A quick fix that removes duplicates and HillForest since the image "HillForest" was renamed to "Forest" to reduce rule variants in my draft request.