### PR TITLE
Trim down custom save to export/import only

### DIFF
--- a/core/src/com/unciv/logic/CustomSaveLocationHelper.kt
+++ b/core/src/com/unciv/logic/CustomSaveLocationHelper.kt
@@ -5,13 +5,19 @@ package com.unciv.logic
  * arbitrary external locations
  */
 interface CustomSaveLocationHelper {
-    /**
+    /**### Save to custom location
      * Saves a game asynchronously with a given default name and then calls the [saveCompleteCallback] callback
      * upon completion. The [saveCompleteCallback] callback will be called from the same thread that this method
      * is called from. If the [GameInfo] object already has the
      * [customSaveLocation][GameInfo.customSaveLocation] property defined (not null), then the user
      * will not be prompted to select a location for the save unless [forcePrompt] is set to true
      * (think of this like "Save as...")
+     * On success, this is also expected to set [customSaveLocation][GameInfo.customSaveLocation].
+     *
+     *  @param  gameInfo Game data to save
+     *  @param  gameName Suggestion for the save name
+     *  @param  forcePrompt Bypass UI if location contained in [gameInfo] and [forcePrompt]==`false`
+     *  @param  saveCompleteCallback Action to call upon completion (success _and_ failure)
      */
     fun saveGame(
             gameInfo: GameInfo,
@@ -20,9 +26,12 @@ interface CustomSaveLocationHelper {
             saveCompleteCallback: ((Exception?) -> Unit)? = null
     )
 
-    /**
-     * Loads a game from an external source asynchronously, then calls [loadCompleteCallback] with the loaded
-     * [GameInfo]
+    /**### Load from custom location
+     * Loads a game from an external source asynchronously, then calls [loadCompleteCallback] with the loaded [GameInfo].
+     * On success, this is also expected to set the loaded [GameInfo]'s property [customSaveLocation][GameInfo.customSaveLocation].
+     * Note that there is no hint so pass a default location or a way to remember the folder the user chose last time.
+     *
+     *  @param  loadCompleteCallback  Action to call upon completion (success _and_ failure)
      */
     fun loadGame(loadCompleteCallback: (GameInfo?, Exception?) -> Unit)
 }

--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -41,6 +41,12 @@ class GameInfo {
     var currentPlayer = ""
     var gameId = UUID.randomUUID().toString() // random string
 
+    /**Keep track of a custom location this game was saved to _or_ loaded from
+     *
+     * Note this was used as silent autosave destination, but it was decided (#3898) to
+     * make the custom location feature a one-shot import/export kind of operation.
+     * The tracking is left in place, however [GameSaver.autoSaveSingleThreaded] no longer uses it
+     */
     @Volatile
     var customSaveLocation: String? = null
 

--- a/core/src/com/unciv/logic/GameSaver.kt
+++ b/core/src/com/unciv/logic/GameSaver.kt
@@ -38,18 +38,12 @@ object GameSaver {
         return localSaves + Gdx.files.absolute(externalFilesDirForAndroid + "/${getSubfolder(multiplayer)}").list().asSequence()
     }
 
-    fun saveGame(game: GameInfo, GameName: String, multiplayer: Boolean = false, forcePrompt: Boolean = false, saveCompletionCallback: ((Exception?) -> Unit)? = null) {
-        val customSaveLocation = game.customSaveLocation
-        val customSaveLocationHelper = this.customSaveLocationHelper
-        if (customSaveLocation != null && customSaveLocationHelper != null) {
-            customSaveLocationHelper.saveGame(game, GameName, forcePrompt, saveCompletionCallback)
-        } else {
-            try {
-                json().toJson(game, getSave(GameName, multiplayer))
-                saveCompletionCallback?.invoke(null)
-            } catch (ex: Exception) {
-                saveCompletionCallback?.invoke(ex)
-            }
+    fun saveGame(game: GameInfo, GameName: String, multiplayer: Boolean = false, saveCompletionCallback: ((Exception?) -> Unit)? = null) {
+        try {
+            json().toJson(game, getSave(GameName, multiplayer))
+            saveCompletionCallback?.invoke(null)
+        } catch (ex: Exception) {
+            saveCompletionCallback?.invoke(ex)
         }
     }
 
@@ -134,13 +128,13 @@ object GameSaver {
         thread(name = "Autosave") {
             autoSaveSingleThreaded(gameInfoClone)
             // do this on main thread
-            Gdx.app.postRunnable {
-                postRunnable()
-            }
+            Gdx.app.postRunnable ( postRunnable )
         }
     }
 
     fun autoSaveSingleThreaded(gameInfo: GameInfo) {
+/*
+        ... out of order until further notice, see #3898
         // If the user has chosen a custom save location outside of the usual game directories,
         // they'll probably expect us to overwrite that instead. E.g. if the user is saving their
         // game to their Google Drive folder, they'll probably want that progress to be synced to
@@ -151,6 +145,8 @@ object GameSaver {
             saveGame(gameInfo, "", false)
             return
         }
+*/
+
         saveGame(gameInfo, "Autosave")
 
         // keep auto-saves for the last 10 turns for debugging purposes


### PR DESCRIPTION
This would be what I outlined in (resolves #3898) plus all the comments I left while analyzing how the custom save location feature works - just an offer to consider. We might just as well remove one `return` and autosave both normally and update the once-set custom location... Tested _only_ on desktop so far.