### PR TITLE
Fixed inconsistent map size

### DIFF
--- a/core/src/com/unciv/logic/map/MapParameters.kt
+++ b/core/src/com/unciv/logic/map/MapParameters.kt
@@ -23,8 +23,8 @@ class MapSizeNew {
     constructor()
 
     constructor(name: String) {
-        /** Hard coded values from getEquivalentRectangularSize() */
         this.name = name
+        /** Hard coded values from getEquivalentRectangularSize() */
         when (name) {
             Constants.tiny -> { radius = 10; width = 23; height = 15 }
             Constants.small -> { radius = 15; width = 33; height = 21 }
@@ -33,6 +33,7 @@ class MapSizeNew {
             Constants.huge -> { radius = 40; width = 87; height = 57 }
         }
     }
+
     constructor(radius: Int) {
         name = Constants.custom
         this.radius = radius
@@ -48,8 +49,6 @@ class MapSizeNew {
         this.radius = getEquivalentHexagonalRadius(width, height)
 
     }
-
-
 }
 
 object MapShape {

--- a/core/src/com/unciv/logic/map/MapParameters.kt
+++ b/core/src/com/unciv/logic/map/MapParameters.kt
@@ -24,6 +24,7 @@ class MapSizeNew {
 
     constructor(name: String) {
         /** Hard coded values from getEquivalentRectangularSize() */
+        this.name = name
         when (name) {
             Constants.tiny -> { radius = 10; width = 23; height = 15 }
             Constants.small -> { radius = 15; width = 33; height = 21 }

--- a/core/src/com/unciv/logic/map/TileMap.kt
+++ b/core/src/com/unciv/logic/map/TileMap.kt
@@ -63,7 +63,6 @@ class TileMap {
     }
 
     fun clone(): TileMap {
-        println(mapParameters.mapSize.radius)
         val toReturn = TileMap()
         toReturn.tileList.addAll(tileList.map { it.clone() })
         toReturn.mapParameters = mapParameters

--- a/core/src/com/unciv/logic/map/TileMap.kt
+++ b/core/src/com/unciv/logic/map/TileMap.kt
@@ -63,6 +63,7 @@ class TileMap {
     }
 
     fun clone(): TileMap {
+        println(mapParameters.mapSize.radius)
         val toReturn = TileMap()
         toReturn.tileList.addAll(tileList.map { it.clone() })
         toReturn.mapParameters = mapParameters
@@ -135,9 +136,9 @@ class TileMap {
         if (!mapParameters.worldWrap)
             return null
 
-        var radius = mapParameters.size.radius
+        var radius = mapParameters.mapSize.radius
         if (mapParameters.shape == MapShape.rectangular)
-            radius = HexMath.getEquivalentRectangularSize(radius).x.toInt() / 2
+            radius = mapParameters.mapSize.width / 2
 
         //tile is outside of the map
         if (contains(x + radius, y - radius)) { //tile is on right side
@@ -322,9 +323,9 @@ class TileMap {
      * Returns -1 if not neighbors
      */
     fun getNeighborTileClockPosition(tile: TileInfo, otherTile: TileInfo): Int {
-        var radius = mapParameters.size.radius
+        var radius = mapParameters.mapSize.radius
         if (mapParameters.shape == MapShape.rectangular)
-            radius = HexMath.getEquivalentRectangularSize(radius).x.toInt() / 2
+            radius = mapParameters.mapSize.width / 2
 
         val xDifference = tile.position.x - otherTile.position.x
         val yDifference = tile.position.y - otherTile.position.y
@@ -352,9 +353,9 @@ class TileMap {
         if (!contains(position))
             return position //The position is outside the map so its unwrapped already
 
-        var radius = mapParameters.size.radius
+        var radius = mapParameters.mapSize.radius
         if (mapParameters.shape == MapShape.rectangular)
-            radius = HexMath.getEquivalentRectangularSize(radius).x.toInt() / 2
+            radius = mapParameters.mapSize.width / 2
 
         val vectorUnwrappedLeft = Vector2(position.x + radius, position.y - radius)
         val vectorUnwrappedRight = Vector2(position.x - radius, position.y + radius)


### PR DESCRIPTION
Since MapSizeNew.name never got set the map radius always got converted back to 20 in gameInfo.setTransients() L279 resulting in inconsistent map size. Also because TileMap still used the old MapSize the neighbors did not get calculated correctly.