### PR TITLE
Minimap resizeable and scroll position indicator redone

### DIFF
--- a/core/src/com/unciv/models/metadata/GameSettings.kt
+++ b/core/src/com/unciv/models/metadata/GameSettings.kt
@@ -27,6 +27,7 @@ class GameSettings {
     var automatedWorkersReplaceImprovements = true
 
     var showMinimap: Boolean = true
+    var minimapSize: Int = 1
     var showPixelUnits: Boolean = false
     var showPixelImprovements: Boolean = true
     var continuousRendering = false

--- a/core/src/com/unciv/ui/mapeditor/EditorMapHolder.kt
+++ b/core/src/com/unciv/ui/mapeditor/EditorMapHolder.kt
@@ -18,7 +18,7 @@ class EditorMapHolder(private val mapEditorScreen: MapEditorScreen, internal val
     private val allTileGroups = ArrayList<TileGroup>()
 
     init {
-        continousScrollingX = tileMap.mapParameters.worldWrap
+        continuousScrollingX = tileMap.mapParameters.worldWrap
     }
 
     internal fun addTiles(leftAndRightPadding: Float, topAndBottomPadding: Float) {
@@ -26,12 +26,12 @@ class EditorMapHolder(private val mapEditorScreen: MapEditorScreen, internal val
         val tileSetStrings = TileSetStrings()
         val daTileGroups = tileMap.values.map { TileGroup(it, tileSetStrings) }
 
-        tileGroupMap = TileGroupMap(daTileGroups, leftAndRightPadding, topAndBottomPadding, continousScrollingX)
+        tileGroupMap = TileGroupMap(daTileGroups, leftAndRightPadding, topAndBottomPadding, continuousScrollingX)
         actor = tileGroupMap
         val mirrorTileGroups = tileGroupMap.getMirrorTiles()
 
         for (tileGroup in daTileGroups) {
-            if (continousScrollingX){
+            if (continuousScrollingX){
                 val mirrorTileGroupLeft = mirrorTileGroups[tileGroup.tileInfo]!!.first
                 val mirrorTileGroupRight = mirrorTileGroups[tileGroup.tileInfo]!!.second
 

--- a/core/src/com/unciv/ui/utils/ZoomableScrollPane.kt
+++ b/core/src/com/unciv/ui/utils/ZoomableScrollPane.kt
@@ -8,7 +8,7 @@ import kotlin.math.sqrt
 
 
 open class ZoomableScrollPane: ScrollPane(null) {
-    var continousScrollingX = false
+    var continuousScrollingX = false
 
     init{
         // Remove the existing inputListener
@@ -65,10 +65,10 @@ open class ZoomableScrollPane: ScrollPane(null) {
 
                 //this is the new feature to fake an infinite scroll
                 when {
-                    continousScrollingX && scrollPercentX >= 1 && deltaX < 0 -> {
+                    continuousScrollingX && scrollPercentX >= 1 && deltaX < 0 -> {
                         scrollPercentX = 0f
                     }
-                    continousScrollingX && scrollPercentX <= 0 && deltaX > 0-> {
+                    continuousScrollingX && scrollPercentX <= 0 && deltaX > 0-> {
                         scrollPercentX = 1f
                     }
                 }

--- a/core/src/com/unciv/ui/worldscreen/WorldMapHolder.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldMapHolder.kt
@@ -46,7 +46,7 @@ class WorldMapHolder(internal val worldScreen: WorldScreen, internal val tileMap
 
     init {
         if (Gdx.app.type == Application.ApplicationType.Desktop) this.setFlingTime(0f)
-        continousScrollingX = tileMap.mapParameters.worldWrap
+        continuousScrollingX = tileMap.mapParameters.worldWrap
     }
 
     // Used to transfer data on the "move here" button that should be created, from the side thread to the main thread
@@ -55,11 +55,11 @@ class WorldMapHolder(internal val worldScreen: WorldScreen, internal val tileMap
     internal fun addTiles() {
         val tileSetStrings = TileSetStrings()
         val daTileGroups = tileMap.values.map { WorldTileGroup(worldScreen, it, tileSetStrings) }
-        val tileGroupMap = TileGroupMap(daTileGroups, worldScreen.stage.width, worldScreen.stage.height, continousScrollingX)
+        val tileGroupMap = TileGroupMap(daTileGroups, worldScreen.stage.width, worldScreen.stage.height, continuousScrollingX)
         val mirrorTileGroups = tileGroupMap.getMirrorTiles()
 
         for (tileGroup in daTileGroups) {
-            if (continousScrollingX) {
+            if (continuousScrollingX) {
                 val mirrorTileGroupLeft = mirrorTileGroups[tileGroup.tileInfo]!!.first
                 val mirrorTileGroupRight = mirrorTileGroups[tileGroup.tileInfo]!!.second
 

--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -711,9 +711,7 @@ class WorldScreen(val gameInfo: GameInfo, val viewingCiv:CivilizationInfo) : Cam
         }
 //        topBar.selectedCivLabel.setText(Gdx.graphics.framesPerSecond) // for framerate testing
 
-        val scrollPos = Vector2(mapHolder.scrollX, mapHolder.scrollY)
-        val viewScale = Vector2(mapHolder.scaleX, mapHolder.scaleY)
-        minimapWrapper.minimap.updateScrollPosistion(scrollPos, viewScale)
+        minimapWrapper.minimap.updateScrollPosition()
 
         super.render(delta)
     }


### PR DESCRIPTION
Note some of these changes might be useful even if we reject #3911 - you choose, I'll repackage.

- Two typo fixes so the number of touched lines escalated a little: posistion->position (got lost with the clicks lost debacle) and continous->continuous.
- I redid Minimap updateScrollPosition as I couldn't for the life of me get to understand it - sorry - and it failed with changed minimap sizes. The new one uses oneshot helper functions (can't yet inline them) for purely readability purposes - hope you don't mind. Additionally, I'm sure it is now correct where the old one wasn't. Just zoom out max with the old one, zoom in one step and it's visible the change is not proportional. 1/x != (2-x).
- One factor in there is empiric - or it is deterministic but I don't understand why: the `/ 2` to get world screen visible size at scale 1. I checked by zooming in on screenshots and tile count is exact for the outer edge of the 'camera'.
- updateScrollPosition took parameters built from mapHolder then accessed other mapHolder properties through the local reference - better all through params or all through local ref - chose the latter. There's just the single call site so easy enough.
- The scroll position indicator still lies - due to the texture being a trapezoid. The lie looks cool so I refrained from touching it. Could use a higher resolution though now it is correct on largest zoom-out.
- The strange initalization of Minimap allows re-creating it with a new scale without recreating the holder. Open to discussion. Was necessary only to allow changes to desired minimap size in options to show immediately. An alternative would be to allow the option only when OptionsPopup runs from the main menu - might simplify a few things.
- As UI I chose one slider with the 0 position turning minimap off, but the backing values in GameSettings preserves the old Boolean - doable in other ways, sure, and I did not compare alternatives thoroughly.
- I thought Array shadowing Array on the OptionsPopup (Gdx vs Kotlin) confusing, so I clarified that - Gdx Arrays are not compatible enough for me to just in-place substitute them. Can revert if you mind.
- Size step is 50% of old size -> '1' is mapped to 100% old size by adding 1 in groupSize calculation then multiplying by 200f instead of 400f
- Max selectable size depends on resolution, and it needs to. It was lucky happenstance that a linear dependence to array index fits in all cases so enough room is left for tile info between the new turn button and the minimap. Not that Unciv would break down with a ruthlessly oversized minimap, I tried to ensure having this 'soft' limit is OK even if a mod provokes 20-line tile infos.
- At 750x500 the limit is 1, so the option reverts to a "yes/no" _slider_ - actually replacing the slider with the old button in this case might be nicer, but extra code I avoided for now.
- I had no good idea for the slider label so I left the old button's text - would just "Minimap size" be clear enough?
- The largest minimat (typo too lovely to fix) at 1500x1000 is a giant - hell, even size 3 is plenty - but then nobody is forced to use that setting :) - would be no problem toning it down though.
