### PR TITLE
Technology and construction bars no longer extend past their maximum

### DIFF
--- a/core/src/com/unciv/ui/cityscreen/ConstructionsTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/ConstructionsTable.kt
@@ -17,6 +17,7 @@ import com.unciv.models.ruleset.unit.BaseUnit
 import com.unciv.models.stats.Stat
 import com.unciv.models.translations.tr
 import com.unciv.ui.utils.*
+import java.lang.Float.min
 import kotlin.concurrent.thread
 import com.unciv.ui.utils.AutoScrollPane as ScrollPane
 
@@ -258,8 +259,9 @@ class ConstructionsTable(val cityScreen: CityScreen) : Table(CameraStageBaseScre
         if (construction is PerpetualConstruction) return Table()
         if (cityConstructions.getWorkDone(constructionName) == 0) return Table()
 
-        val constructionPercentage = cityConstructions.getWorkDone(constructionName) /
-                construction.getProductionCost(cityConstructions.cityInfo.civInfo).toFloat()
+        val constructionPercentage = min(cityConstructions.getWorkDone(constructionName) /
+                construction.getProductionCost(cityConstructions.cityInfo.civInfo).toFloat(),
+                1f)
         return ImageGetter.getProgressBarVertical(2f, 30f, constructionPercentage,
                 Color.BROWN.cpy().lerp(Color.WHITE, 0.5f), Color.WHITE)
     }

--- a/core/src/com/unciv/ui/pickerscreens/TechButton.kt
+++ b/core/src/com/unciv/ui/pickerscreens/TechButton.kt
@@ -26,8 +26,7 @@ class TechButton(techName:String, private val techManager: TechManager, isWorldS
             val techThisTurn = techManager.civInfo.statsForNextTurn.science
 
             val percentComplete = (techCost - remainingTech) / techCost.toFloat()
-            val percentWillBeComplete = (techCost - (remainingTech-techThisTurn)) / techCost.toFloat()
-            if (percentWillBeComplete > 1) percentWillBeComplete = 1
+            val percentWillBeComplete = min((techCost - (remainingTech-techThisTurn)) / techCost.toFloat(), 1f)
             val progressBar = ImageGetter.VerticalProgressBar(2f, 50f)
                     .addColor(Color.WHITE, 1f)
                     .addColor(Color.BLUE.cpy().lerp(Color.WHITE, 0.3f), percentWillBeComplete)

--- a/core/src/com/unciv/ui/pickerscreens/TechButton.kt
+++ b/core/src/com/unciv/ui/pickerscreens/TechButton.kt
@@ -6,6 +6,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.utils.Align
 import com.unciv.logic.civilization.TechManager
 import com.unciv.ui.utils.*
+import java.lang.Float.min
 
 class TechButton(techName:String, private val techManager: TechManager, isWorldScreen: Boolean = true) : Table(CameraStageBaseScreen.skin) {
     val text = "".toLabel().apply { setAlignment(Align.center) }

--- a/core/src/com/unciv/ui/pickerscreens/TechButton.kt
+++ b/core/src/com/unciv/ui/pickerscreens/TechButton.kt
@@ -27,6 +27,7 @@ class TechButton(techName:String, private val techManager: TechManager, isWorldS
 
             val percentComplete = (techCost - remainingTech) / techCost.toFloat()
             val percentWillBeComplete = (techCost - (remainingTech-techThisTurn)) / techCost.toFloat()
+            if (percentWillBeComplete > 1) percentWillBeComplete = 1
             val progressBar = ImageGetter.VerticalProgressBar(2f, 50f)
                     .addColor(Color.WHITE, 1f)
                     .addColor(Color.BLUE.cpy().lerp(Color.WHITE, 0.3f), percentWillBeComplete)

--- a/core/src/com/unciv/ui/tilegroups/CityButton.kt
+++ b/core/src/com/unciv/ui/tilegroups/CityButton.kt
@@ -368,6 +368,7 @@ class CityButton(val city: CityInfo, private val tileGroup: WorldTileGroup): Tab
 
             val constructionPercentage = cityConstructions.getWorkDone(cityCurrentConstruction.name) /
                     cityCurrentConstruction.getProductionCost(cityConstructions.cityInfo.civInfo).toFloat()
+            if (constructionPercentage > 1) constructionPercentage = 1
             val productionBar = ImageGetter.getProgressBarVertical(2f, groupHeight, constructionPercentage,
                     Color.BROWN.cpy().lerp(Color.WHITE, 0.5f), Color.BLACK)
             productionBar.x = 10f

--- a/core/src/com/unciv/ui/tilegroups/CityButton.kt
+++ b/core/src/com/unciv/ui/tilegroups/CityButton.kt
@@ -366,9 +366,9 @@ class CityButton(val city: CityInfo, private val tileGroup: WorldTileGroup): Tab
             label.pack()
             group.addActor(label)
 
-            val constructionPercentage = cityConstructions.getWorkDone(cityCurrentConstruction.name) /
-                    cityCurrentConstruction.getProductionCost(cityConstructions.cityInfo.civInfo).toFloat()
-            if (constructionPercentage > 1) constructionPercentage = 1
+            val constructionPercentage = min(cityConstructions.getWorkDone(cityCurrentConstruction.name) /
+                    cityCurrentConstruction.getProductionCost(cityConstructions.cityInfo.civInfo).toFloat(),
+                    1f)
             val productionBar = ImageGetter.getProgressBarVertical(2f, groupHeight, constructionPercentage,
                     Color.BROWN.cpy().lerp(Color.WHITE, 0.5f), Color.BLACK)
             productionBar.x = 10f


### PR DESCRIPTION
Previously, when you produced more science to finish a technology, the bar would extend past its maximum.
The same was true for constructing things in cities.
Example:
![image](https://user-images.githubusercontent.com/71121390/118248145-41697a80-b4a4-11eb-86df-29a1a48586a2.png)

This has now probably been fixed. I couldn't get Android Studio running so I wasn't able to test it, but based on my understanding of the code, this should do.