### PR TITLE
Options screen cleanup

### DIFF
--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -328,7 +328,7 @@ class Ruleset {
 
                 val allOtherPrereqs = tech.prerequisites.asSequence().filterNot { it == prereq }.flatMap { getPrereqTree(it) }
                 if (allOtherPrereqs.contains(prereq))
-                    println("No need to add $prereq as a prerequisite of ${tech.name} - it is already implicit from the other prerequisites!")
+                    lines += "No need to add $prereq as a prerequisite of ${tech.name} - it is already implicit from the other prerequisites!"
             }
         }
         return lines.joinToString("\n")


### PR DESCRIPTION
Strange - same method and conditions, but not same problem as #3933, this diff looks like intended.

- Some nicer names in the code - cosmetic
- Prevent buttons glued together
- Click on version goes to changelog for that version
- Modchecker a tad nicer - and it shows that one missing tech prereq test - unless that was intentional, in which case exclude commit #f611d31