### PR TITLE
Allow game to run on KitKat

### DIFF
--- a/core/src/com/unciv/MainMenuScreen.kt
+++ b/core/src/com/unciv/MainMenuScreen.kt
@@ -1,5 +1,6 @@
 ﻿package com.unciv
 
+import com.badlogic.gdx.Application
 import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.scenes.scene2d.Touchable
@@ -42,6 +43,31 @@ class MainMenuScreen: CameraStageBaseScreen() {
     init {
         stage.addActor(backgroundTable)
         backgroundTable.center(stage)
+
+        // 21 = Build.VERSION_CODES.LOLLIPOP
+        if ( Gdx.app.type == Application.ApplicationType.Android && Gdx.app.version < 21) {
+            if ("kitkatWarn" !in game.settings.tutorialTasksCompleted) {
+                val kitkatWarn = Popup(this).apply {
+                    addGoodSizedLabel("You are running on Android KitKat or below!")
+                    addSeparator()
+                    add( """
+                        |{Due to platform limitations and bugs, the game might be playable well enough, but some features might not work}.
+                        |
+                        |{Known examples are}:
+                        |
+                        |{Mod manager can neither list nor download mods}.
+                        |{Custom save locations do not work}.
+                        """.trimMargin().toLabel()).row()
+                    //addCloseButton("Sorry!")
+                    addCloseButton() {
+                        game.settings.addCompletedTutorialTask("kitkatWarn")
+                    }
+                }
+                Gdx.app.postRunnable {
+                    kitkatWarn.open(true)
+                }
+            }
+        }
 
         // If we were in a mod, some of the resource images for the background map we're creating
         // will not exist unless we reset the ruleset and images

--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -13,6 +13,7 @@ import com.unciv.models.ruleset.unit.BaseUnit
 import com.unciv.models.ruleset.unit.UnitType
 import java.text.DecimalFormat
 import kotlin.random.Random
+import com.unciv.ui.utils.toIntPlus
 
 /**
  * The immutable properties and mutable game state of an individual unit present on the map
@@ -214,7 +215,7 @@ class MapUnit {
         val tile = getTile()
         for (unique in tile.getAllTerrains().flatMap { it.uniqueObjects })
             if (unique.placeholderText == "[] Sight for [] units" && matchesFilter(unique.params[1]))
-                visibilityRange += unique.params[0].toInt()
+                visibilityRange += unique.params[0].toIntPlus()
 
         viewableTiles = tile.getViewableTilesList(visibilityRange)
 

--- a/core/src/com/unciv/ui/utils/ExtensionFunctions.kt
+++ b/core/src/com/unciv/ui/utils/ExtensionFunctions.kt
@@ -185,3 +185,13 @@ fun <T> List<T>.randomWeighted(weights: List<Float>, random: Random = Random): T
     }
     return this.last()
 }
+
+fun String.toIntPlus(): Int {
+    return when {
+        this.isEmpty() -> 0
+        this == "+" -> return 0
+        this == "+1" -> return 1
+        this[0] == '+' -> Integer.parseInt(this.substring(1))
+        else -> Integer.parseInt(this)
+    }
+}


### PR DESCRIPTION
First off - I'm not really 100% serious here. Go ahead and use the code as you like, but IMHO upping the minimum API to 21 is the marginally better way.

#### Summary: 
* The "+1" not passing String.toInt() is the only real showstopper, and for now catching that in a single place for unit uniques is enough.
* SSL preventing mod manager search and download - virtually unfixable
* Document provider is buggy - not our problem - can't fix custom save locations
* AVD with 768M RAM will refuse to grow dalvik heap beyond 192M, which is enough for 10-11 turns, then it will most likely hang in the AI processing. 512M no-go, 1024 seems to run well past 20 turns.

So - first stable version having deprecated dalvik in favour of ART would be a good choice as minimum, and that's Lillipop 5.0 API level 21.