### PR TITLE
Fix Ctrl-S going to save game screen will not stop scrolling the map

### DIFF
--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -257,7 +257,7 @@ class WorldScreen(val gameInfo: GameInfo, val viewingCiv:CivilizationInfo) : Cam
 
                     override fun keyDown(event: InputEvent?, keycode: Int): Boolean {
                         if (keycode !in ALLOWED_KEYS) return false
-                        // Without the following keyPressDispatcher Ctrl-S (or WAD) would have a slight problem
+                        // Without the following keyPressDispatcher Ctrl-S would leave WASD map scrolling stuck
                         if (Gdx.input.isKeyPressed(Input.Keys.CONTROL_LEFT) || Gdx.input.isKeyPressed(Input.Keys.CONTROL_RIGHT)) return false
 
                         pressedKeys.add(keycode)

--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -257,6 +257,8 @@ class WorldScreen(val gameInfo: GameInfo, val viewingCiv:CivilizationInfo) : Cam
 
                     override fun keyDown(event: InputEvent?, keycode: Int): Boolean {
                         if (keycode !in ALLOWED_KEYS) return false
+                        // Without the following keyPressDispatcher Ctrl-S (or WAD) would have a slight problem
+                        if (Gdx.input.isKeyPressed(Input.Keys.CONTROL_LEFT) || Gdx.input.isKeyPressed(Input.Keys.CONTROL_RIGHT)) return false
 
                         pressedKeys.add(keycode)
                         if (infiniteAction == null) {


### PR DESCRIPTION
To repro: Map large enough, go to north pole, hit Ctrl-S, close. Observe how it scrolls until you press s and release again...

Sorry I couldn't come up with a cleaner fix. Detaching the WASD listener on keyPressed is too late, having it check a class-level flag might be even more expensive than this (in terms of how exactly the listener code _gets_ to that flag)...