### PR TITLE
Fix spaceship part production boosts

### DIFF
--- a/android/assets/jsons/Civ V - Vanilla/Buildings.json
+++ b/android/assets/jsons/Civ V - Vanilla/Buildings.json
@@ -468,7 +468,9 @@
 		"hurryCostModifier": 25,
 		"requiredNearbyImprovedResources": ["Iron"],
 		"requiredTech": "Metal Casting",
-		"uniques": ["+[15]% Production when constructing [Spaceship part] units [in this city]",
+		// If spaceship parts are changed into units, the spaceship part unique should be changed to
+		// "+[15]% Production when constructing [Spaceship part] units [in this city]"
+		"uniques": ["+[15]% Production when constructing [Spaceship part] [in this city]",
 			"+[15]% Production when constructing [Land] units [in this city]",
 			"[+1 Production] from [Iron] tiles in this city"]
 	},
@@ -1003,7 +1005,9 @@
 		"requiredResource": "Aluminum",
 		"cost": 360,
 		"requiredBuilding": "Factory",
-		"uniques": ["+[50]% Production when constructing [Spaceship part] units [in this city]"],
+		// If spaceship parts are changed into units, this unique should be changed to
+		// "+[50]% Production when constructing [Spaceship part] units [in this city]"
+		"uniques": ["+[50]% Production when constructing [Spaceship part] [in this city]"],
 		"requiredTech": "Robotics"
 	},
 	{
@@ -1028,8 +1032,10 @@
 		"isWonder": true,
 		"greatPersonPoints": {"science": 1},		
 		"providesFreeBuilding":  "Spaceship Factory",
+		// If spaceship parts are changed into units, the spaceship part unique should be changed to
+		// "+[25]% Production when constructing [Spaceship part] units [in this city]"
 		"uniques": ["[2] free [Great Scientist] units appear",
-			"+[25]% Production when constructing [Spaceship part] units [in this city]"],
+			"+[25]% Production when constructing [Spaceship part] [in this city]"],
 		"requiredTech": "Satellites",
 		"quote": "'The wonder is, not that the field of stars is so vast, but that man has measured it.'  - Anatole France"
 		// will be introduced in G&K expansion pack


### PR DESCRIPTION
Buildings and wonders that should boost spaceship part production do not provide this boost: see #3952 for the details.
These changes fix the issue.

The problem was caused by the fact that the spaceship part-boosting uniques would only boost spaceship part UNITS even though spaceship parts are currently buildings.

Because I expect that spaceship parts will eventually become units (there are commented out entries in `Units.json`), I have also added some comments that serve as a reminder to change the uniques later.
To avoid this need to change the uniques later on, the buildings could alternatively be given both the old unit-boosting unique and the new building-boosting one, but that seemed ugly to me.

Side question: when posting a bugfix PR such as this one, is it preferred to post both an issue and a PR as I have done, or would only the PR suffice?