### PR TITLE
Spruced up Civilopedia - phase 2 - external links

### DIFF
--- a/core/src/com/unciv/logic/city/CityConstructions.kt
+++ b/core/src/com/unciv/logic/city/CityConstructions.kt
@@ -5,10 +5,13 @@ import com.unciv.logic.civilization.AlertType
 import com.unciv.logic.civilization.NotificationIcon
 import com.unciv.logic.civilization.PopupAlert
 import com.unciv.models.ruleset.Building
+import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.ruleset.UniqueMap
 import com.unciv.models.ruleset.unit.BaseUnit
 import com.unciv.models.stats.Stats
 import com.unciv.models.translations.tr
+import com.unciv.ui.civilopedia.CivilopediaCategories
+import com.unciv.ui.civilopedia.FormattedLine
 import com.unciv.ui.utils.Fonts
 import com.unciv.ui.utils.withItem
 import com.unciv.ui.utils.withoutItem
@@ -139,6 +142,28 @@ class CityConstructions {
             result += " - $turnsLeft${Fonts.turn}"
         }
         return result
+    }
+
+    fun getProductionMarkup(ruleset: Ruleset): FormattedLine {
+        val currentConstructionSnapshot = currentConstructionFromQueue
+        if (currentConstructionSnapshot.isEmpty()) return FormattedLine()
+        val category = when {
+            ruleset.buildings[currentConstructionSnapshot]
+                ?.let{ it.isWonder || it.isNationalWonder } == true ->
+                CivilopediaCategories.Wonder.name
+            currentConstructionSnapshot in ruleset.buildings ->
+                CivilopediaCategories.Building.name
+            currentConstructionSnapshot in ruleset.units ->
+                CivilopediaCategories.Unit.name
+            else -> ""
+        }
+        var label = currentConstructionSnapshot
+        if (!PerpetualConstruction.perpetualConstructionsMap.containsKey(currentConstructionSnapshot)) {
+            val turnsLeft = turnsToConstruction(currentConstructionSnapshot)
+            label += " - $turnsLeft${Fonts.turn}"
+        }
+        return if (category.isEmpty()) FormattedLine(label)
+            else FormattedLine(label, link="$category/$currentConstructionSnapshot")
     }
 
     fun getCurrentConstruction(): IConstruction = getConstruction(currentConstructionFromQueue)

--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -6,6 +6,7 @@ import com.unciv.UncivGame
 import com.unciv.logic.automation.UnitAutomation
 import com.unciv.logic.automation.WorkerAutomation
 import com.unciv.logic.civilization.CivilizationInfo
+import com.unciv.logic.civilization.LocationAction
 import com.unciv.logic.civilization.NotificationIcon
 import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.ruleset.Unique
@@ -442,14 +443,17 @@ class MapUnit {
     private fun tryProvideProductionToClosestCity(removedTerrainFeature: String) {
         val tile = getTile()
         val closestCity = civInfo.cities.minByOrNull { it.getCenterTile().aerialDistanceTo(tile) }
+        @Suppress("FoldInitializerAndIfToElvis")
         if (closestCity == null) return
         val distance = closestCity.getCenterTile().aerialDistanceTo(tile)
         var productionPointsToAdd = if (distance == 1) 20 else 20 - (distance - 2) * 5
-        if (productionPointsToAdd <= 0) return
         if (tile.owningCity == null || tile.owningCity!!.civInfo != civInfo) productionPointsToAdd = productionPointsToAdd * 2 / 3
-        closestCity.cityConstructions.addProductionPoints(productionPointsToAdd)
-        civInfo.addNotification("Clearing a [$removedTerrainFeature] has created [$productionPointsToAdd] Production for [${closestCity.name}]",
-                closestCity.location, NotificationIcon.Construction)
+        if (productionPointsToAdd > 0) {
+            closestCity.cityConstructions.addProductionPoints(productionPointsToAdd)
+            val locations = LocationAction(listOf(tile.position, closestCity.location))
+            civInfo.addNotification("Clearing a [$removedTerrainFeature] has created [$productionPointsToAdd] Production for [${closestCity.name}]",
+                locations, NotificationIcon.Construction)
+        }
     }
 
     private fun heal() {

--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -445,13 +445,11 @@ class MapUnit {
         if (closestCity == null) return
         val distance = closestCity.getCenterTile().aerialDistanceTo(tile)
         var productionPointsToAdd = if (distance == 1) 20 else 20 - (distance - 2) * 5
-        if (productionPointsToAdd > 0) {
-            if (tile.owningCity == null || tile.owningCity!!.civInfo != civInfo) productionPointsToAdd = productionPointsToAdd * 2 / 3
-            closestCity.cityConstructions.addProductionPoints(productionPointsToAdd)
-            civInfo.addNotification("Clearing a [$removedTerrainFeature] has created [$productionPointsToAdd] Production for [${closestCity.name}]",
-                    closestCity.location, NotificationIcon.Construction)
-        }
-
+        if (productionPointsToAdd <= 0) return
+        if (tile.owningCity == null || tile.owningCity!!.civInfo != civInfo) productionPointsToAdd = productionPointsToAdd * 2 / 3
+        closestCity.cityConstructions.addProductionPoints(productionPointsToAdd)
+        civInfo.addNotification("Clearing a [$removedTerrainFeature] has created [$productionPointsToAdd] Production for [${closestCity.name}]",
+                closestCity.location, NotificationIcon.Construction)
     }
 
     private fun heal() {

--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -445,8 +445,8 @@ class MapUnit {
         if (closestCity == null) return
         val distance = closestCity.getCenterTile().aerialDistanceTo(tile)
         var productionPointsToAdd = if (distance == 1) 20 else 20 - (distance - 2) * 5
-        if (tile.owningCity == null || tile.owningCity!!.civInfo != civInfo) productionPointsToAdd = productionPointsToAdd * 2 / 3
         if (productionPointsToAdd > 0) {
+            if (tile.owningCity == null || tile.owningCity!!.civInfo != civInfo) productionPointsToAdd = productionPointsToAdd * 2 / 3
             closestCity.cityConstructions.addProductionPoints(productionPointsToAdd)
             civInfo.addNotification("Clearing a [$removedTerrainFeature] has created [$productionPointsToAdd] Production for [${closestCity.name}]",
                     closestCity.location, NotificationIcon.Construction)

--- a/core/src/com/unciv/ui/cityscreen/CityScreenTileTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityScreenTileTable.kt
@@ -7,6 +7,8 @@ import com.unciv.logic.map.TileInfo
 import com.unciv.models.UncivSound
 import com.unciv.models.stats.Stats
 import com.unciv.models.translations.tr
+import com.unciv.ui.civilopedia.CivilopediaScreen
+import com.unciv.ui.civilopedia.MarkupRenderer
 import com.unciv.ui.utils.*
 import kotlin.math.roundToInt
 
@@ -32,7 +34,10 @@ class CityScreenTileTable(private val cityScreen: CityScreen): Table() {
         val stats = selectedTile.getTileStats(city, city.civInfo)
         innerTable.pad(5f)
 
-        innerTable.add(selectedTile.toString(city.civInfo).toLabel()).colspan(2)
+        innerTable.add( MarkupRenderer.render(selectedTile.toMarkup(city.civInfo)) {
+            // Sorry, this will leave the city screen
+            UncivGame.Current.setScreen(CivilopediaScreen(city.civInfo.gameInfo.ruleSet, link = it))
+        } ).colspan(2)
         innerTable.row()
         innerTable.add(getTileStatsTable(stats)).row()
 

--- a/core/src/com/unciv/ui/civilopedia/CivilopediaCategories.kt
+++ b/core/src/com/unciv/ui/civilopedia/CivilopediaCategories.kt
@@ -28,7 +28,11 @@ object CivilopediaImageGetters {
             }
             TerrainType.TerrainFeature -> {
                 tileInfo.terrainFeatures.add(terrain.name)
-                tileInfo.baseTerrain = terrain.occursOn.lastOrNull() ?: Constants.grassland
+                tileInfo.baseTerrain =
+                    if (terrain.occursOn.isEmpty() || terrain.occursOn.contains(Constants.grassland))
+                        Constants.grassland
+                    else
+                        terrain.occursOn.lastOrNull()!!
             }
             else ->
                 tileInfo.baseTerrain = terrain.name

--- a/core/src/com/unciv/ui/civilopedia/CivilopediaText.kt
+++ b/core/src/com/unciv/ui/civilopedia/CivilopediaText.kt
@@ -1,0 +1,116 @@
+package com.unciv.ui.civilopedia
+
+import com.badlogic.gdx.Gdx
+import com.badlogic.gdx.scenes.scene2d.Actor
+import com.badlogic.gdx.scenes.scene2d.ui.Skin
+import com.badlogic.gdx.scenes.scene2d.ui.Table
+import com.badlogic.gdx.utils.Align
+import com.unciv.ui.utils.*
+
+
+/** Represents a text line with optional linking capability.
+ *  Special cases:
+ *  - Automatic external links (no [text] but [link] begins with a URL protocol)
+ * 
+ * @param text          Text to display.
+ * @param link          Create link: Line gets a 'Link' icon and is linked to either 
+ *                      an Unciv object (format `category/entryname`) or an external URL.
+ */
+class FormattedLine (
+    val text: String = "",
+    val link: String = "",
+) {
+    // Note: This gets directly deserialized by Json - please keep all attributes meant to be read
+    // from json in the primary constructor parameters above. Everything else should be a fun(),
+    // have no backing field, be `by lazy` or use @Transient, Thank you.
+
+    /** Link types that can be used for [FormattedLine.link] */
+    enum class LinkType {
+        None,
+        /** Link points to a Civilopedia entry in the form `category/item` **/
+        Internal,
+        /** Link opens as URL in external App - begins with `https://`, `http://` or `mailto:` **/
+        External
+    }
+
+    /** The type of the [link]'s destination */
+    val linkType: LinkType by lazy {
+        when {
+            link.hasProtocol() -> LinkType.External
+            link.isNotEmpty() -> LinkType.Internal
+            else -> LinkType.None
+        }
+    }
+
+    private val textToDisplay: String by lazy {
+        if (text.isEmpty() && linkType == LinkType.External) link else text
+    }
+    
+    /** Returns true if this formatted line will not display anything */
+    fun isEmpty(): Boolean = text.isEmpty() && link.isEmpty() 
+
+    /** Extension: determines if a [String] looks like a link understood by the OS */
+    private fun String.hasProtocol() = startsWith("http://") || startsWith("https://") || startsWith("mailto:")
+
+    /**
+     * Renders the formatted line as a scene2d [Actor] (currently always a [Table])
+     * @param skin  The [Skin] to use for contained actors.
+     * @param labelWidth Total width to render into, needed to support wrap on Labels.
+     */
+    fun render(skin: Skin, labelWidth: Float): Actor {
+        val table = Table(skin)
+        if (textToDisplay.isNotEmpty()) {
+            val label = textToDisplay.toLabel()
+            label.wrap = labelWidth > 0f
+            if (labelWidth == 0f)
+                table.add(label)
+            else
+                table.add(label).width(labelWidth)
+        }
+        return table
+    }
+}
+
+/** Makes [renderer][render] available outside [ICivilopediaText] */
+object MarkupRenderer {
+    private const val emptyLineHeight = 10f
+    private const val defaultPadding = 2.5f
+
+    /**
+     *  Build a Gdx [Table] showing [formatted][FormattedLine] [content][lines].
+     *
+     *  @param lines
+     *  @param skin
+     *  @param labelWidth       Available width needed for wrapping labels and [centered][FormattedLine.centered] attribute.
+     *  @param linkAction       Delegate to call for internal links. Leave null to suppress linking.
+     */
+    fun render(
+        lines: Collection<FormattedLine>,
+        skin: Skin? = null,
+        labelWidth: Float = 0f,
+        linkAction: ((id: String) -> Unit)? = null
+    ): Table {
+        val skinToUse = skin ?: CameraStageBaseScreen.skin
+        val table = Table(skinToUse).apply { defaults().pad(defaultPadding).align(Align.left) }
+        for (line in lines) {
+            if (line.isEmpty()) {
+                table.add().padTop(emptyLineHeight).row()
+                continue
+            }
+            val actor = line.render(skinToUse, labelWidth)
+            if (line.linkType == FormattedLine.LinkType.Internal && linkAction != null)
+                actor.onClick {
+                    linkAction(line.link)
+                }
+            else if (line.linkType == FormattedLine.LinkType.External)
+                actor.onClick {
+                    Gdx.net.openURI(line.link)
+                }
+            if (labelWidth == 0f)
+                table.add(actor).row()
+            else
+                table.add(actor).width(labelWidth).row()
+        }
+        return table.apply { pack() }
+    }
+}

--- a/core/src/com/unciv/ui/civilopedia/CivilopediaText.kt
+++ b/core/src/com/unciv/ui/civilopedia/CivilopediaText.kt
@@ -2,7 +2,6 @@ package com.unciv.ui.civilopedia
 
 import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.scenes.scene2d.Actor
-import com.badlogic.gdx.scenes.scene2d.ui.Skin
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.utils.Align
 import com.unciv.ui.utils.*
@@ -54,11 +53,10 @@ class FormattedLine (
 
     /**
      * Renders the formatted line as a scene2d [Actor] (currently always a [Table])
-     * @param skin  The [Skin] to use for contained actors.
      * @param labelWidth Total width to render into, needed to support wrap on Labels.
      */
-    fun render(skin: Skin, labelWidth: Float): Actor {
-        val table = Table(skin)
+    fun render(labelWidth: Float): Actor {
+        val table = Table(CameraStageBaseScreen.skin)
         if (textToDisplay.isNotEmpty()) {
             val label = textToDisplay.toLabel()
             label.wrap = labelWidth > 0f
@@ -79,25 +77,23 @@ object MarkupRenderer {
     /**
      *  Build a Gdx [Table] showing [formatted][FormattedLine] [content][lines].
      *
-     *  @param lines
-     *  @param skin
+     *  @param lines            The formatted content to render.
      *  @param labelWidth       Available width needed for wrapping labels and [centered][FormattedLine.centered] attribute.
      *  @param linkAction       Delegate to call for internal links. Leave null to suppress linking.
      */
     fun render(
         lines: Collection<FormattedLine>,
-        skin: Skin? = null,
         labelWidth: Float = 0f,
         linkAction: ((id: String) -> Unit)? = null
     ): Table {
-        val skinToUse = skin ?: CameraStageBaseScreen.skin
-        val table = Table(skinToUse).apply { defaults().pad(defaultPadding).align(Align.left) }
+        val skin = CameraStageBaseScreen.skin
+        val table = Table(skin).apply { defaults().pad(defaultPadding).align(Align.left) }
         for (line in lines) {
             if (line.isEmpty()) {
                 table.add().padTop(emptyLineHeight).row()
                 continue
             }
-            val actor = line.render(skinToUse, labelWidth)
+            val actor = line.render(labelWidth)
             if (line.linkType == FormattedLine.LinkType.Internal && linkAction != null)
                 actor.onClick {
                     linkAction(line.link)

--- a/core/src/com/unciv/ui/worldscreen/WorldMapHolder.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldMapHolder.kt
@@ -471,8 +471,15 @@ class WorldMapHolder(internal val worldScreen: WorldScreen, internal val tileMap
     }
 
     var blinkAction: Action? = null
-    fun setCenterPosition(vector: Vector2, immediately: Boolean = false, selectUnit: Boolean = true) {
-        val tileGroup = allWorldTileGroups.firstOrNull { it.tileInfo.position == vector } ?: return
+
+    /** Scrolls the world map to specified coordinates.
+     * @param vector Position to center on
+     * @param immediately Do so without animation
+     * @param selectUnit Select a unit at the destination
+     * @return `true` if scroll position was changed, `false` otherwise
+     */
+    fun setCenterPosition(vector: Vector2, immediately: Boolean = false, selectUnit: Boolean = true): Boolean {
+        val tileGroup = allWorldTileGroups.firstOrNull { it.tileInfo.position == vector } ?: return false
         selectedTile = tileGroup.tileInfo
         if (selectUnit)
             worldScreen.bottomUnitTable.tileSelected(selectedTile!!)
@@ -486,6 +493,8 @@ class WorldMapHolder(internal val worldScreen: WorldScreen, internal val tileMap
 
         // Here it's the same, only the Y axis is inverted - when at 0 we're at the top, not bottom - so we invert it back.
         val finalScrollY = maxY - (tileGroup.y + tileGroup.width / 2 - height / 2)
+
+        if (finalScrollX == originalScrollX && finalScrollY == originalScrollY) return false
 
         if (immediately) {
             scrollX = finalScrollX
@@ -513,6 +522,7 @@ class WorldMapHolder(internal val worldScreen: WorldScreen, internal val tileMap
         addAction(blinkAction) // Don't set it on the group because it's an actionlss group
 
         worldScreen.shouldUpdate = true
+        return true
     }
 
     override fun zoom(zoomScale: Float) {

--- a/core/src/com/unciv/ui/worldscreen/bottombar/TileInfoTable.kt
+++ b/core/src/com/unciv/ui/worldscreen/bottombar/TileInfoTable.kt
@@ -22,7 +22,7 @@ class TileInfoTable(private val viewingCiv :CivilizationInfo) : Table(CameraStag
 
         if (tile != null && (UncivGame.Current.viewEntireMapForDebug || viewingCiv.exploredTiles.contains(tile.position)) ) {
             add(getStatsTable(tile))
-            add( MarkupRenderer.render(tile.toMarkup(viewingCiv), skin) {
+            add( MarkupRenderer.render(tile.toMarkup(viewingCiv) ) {
                 UncivGame.Current.setScreen(CivilopediaScreen(viewingCiv.gameInfo.ruleSet, link = it))
             } ).pad(10f)
             // For debug only!

--- a/core/src/com/unciv/ui/worldscreen/bottombar/TileInfoTable.kt
+++ b/core/src/com/unciv/ui/worldscreen/bottombar/TileInfoTable.kt
@@ -6,6 +6,8 @@ import com.badlogic.gdx.utils.Align
 import com.unciv.UncivGame
 import com.unciv.logic.civilization.CivilizationInfo
 import com.unciv.logic.map.TileInfo
+import com.unciv.ui.civilopedia.CivilopediaScreen
+import com.unciv.ui.civilopedia.MarkupRenderer
 import com.unciv.ui.utils.CameraStageBaseScreen
 import com.unciv.ui.utils.ImageGetter
 import com.unciv.ui.utils.toLabel
@@ -20,7 +22,9 @@ class TileInfoTable(private val viewingCiv :CivilizationInfo) : Table(CameraStag
 
         if (tile != null && (UncivGame.Current.viewEntireMapForDebug || viewingCiv.exploredTiles.contains(tile.position)) ) {
             add(getStatsTable(tile))
-            add(tile.toString(viewingCiv).toLabel()).colspan(2).pad(10f)
+            add( MarkupRenderer.render(tile.toMarkup(viewingCiv), skin) {
+                UncivGame.Current.setScreen(CivilopediaScreen(viewingCiv.gameInfo.ruleSet, link = it))
+            } ).pad(10f)
             // For debug only!
 //            add(tile.position.toString().toLabel()).colspan(2).pad(10f)
         }

--- a/core/src/com/unciv/ui/worldscreen/unit/UnitTable.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitTable.kt
@@ -13,6 +13,8 @@ import com.unciv.logic.city.CityInfo
 import com.unciv.logic.map.MapUnit
 import com.unciv.logic.map.TileInfo
 import com.unciv.models.translations.tr
+import com.unciv.ui.civilopedia.CivilopediaCategories
+import com.unciv.ui.civilopedia.CivilopediaScreen
 import com.unciv.ui.pickerscreens.PromotionPickerScreen
 import com.unciv.ui.utils.*
 import com.unciv.ui.worldscreen.WorldScreen
@@ -78,7 +80,9 @@ class UnitTable(val worldScreen: WorldScreen) : Table(){
             touchable = Touchable.enabled
             onClick {
                 selectedUnit?.currentTile?.position?.let {
-                    worldScreen.mapHolder.setCenterPosition(it, false, false)
+                    if ( !worldScreen.mapHolder.setCenterPosition(it, false, false) && selectedUnit != null ) {
+                        worldScreen.game.setScreen(CivilopediaScreen(worldScreen.gameInfo.ruleSet, CivilopediaCategories.Unit, selectedUnit!!.name))
+                    }
                 }
             }
         }).expand()


### PR DESCRIPTION
So this is the bare minimum to get _any_ linking to work without toppling the model of the finished product completely. Plus any pure linting I've done while the project grew to get it out of the way.

Visible features:
- Clicking the unit name in the UnitTable will first center the screen on the unit as before - but if it's already centered you get 'help' instead.
- TileInfoTable lines will link if appropriate, same for the little brother in the city screen.

This also demonstrates a basic problem of the project - discussion expected :smiley_cat: :
- Generating a collection of `FormattedLine` instead of a multiline String is done in a copy of any old `describeme()` function - and that may or may not become obsolete. In this case, it was TileInfo.toString(viewingCiv) (dubious choice anyway) - I could have left it, that worked. I chose the other route - rework any other clients and remove. In this case, there's a new pure-debug toString() and the other use changed to also use the `FormattedLine` generator - and allow linking in the process.

The rewrite to dispense with markup from a parser is complete, the working thing online as [backup branch](https://github.com/SomeTroglodyte/Unciv/tree/Civilopedia-linked-backup2) just in case. It fits together much nicer than the parsing version, though I have found two "parsing" issues where I'd like your input:
- I've left 'link' a partially parsed property - internal links need to be "category/entry". I'm 60:40 in favour of leaving this as it is instead of separating category and entry:
        a) internally we'd like to pass category as its Enum value but the json parser won't feed that nicely (I suppose we could switch to a json serializer that allows 'hooks' and do some subclassing magic - there's examples online - too major an undertaking)... Which means some otherwise redundant Enum-String conversions are necessary anyway and
        b) much more readable when actually declaring in json, while
        c) the overhead to build the string is not so bad.
    Still, I hesitated - could go the other way - we should decide before merging this.

- The world screen instructions I did ([graphic](https://github.com/SomeTroglodyte/Unciv/blob/Civilopedia-linked-backup2/android/assets/ExtraImages/WorldScreenHelp.png) with explanations) is a tutorial - and those are not a container object I could add the interface to. I'd tend do replace the tutorial text model in the future, but for now I kludged it as a trivial 2-feature parser... Converting an array of Strings to a collection of `FormattedLine` on the fly is easy, getting a `FormattedLine` pulling an image instead of displaying text needs the kludge. Ideas?

