### PR TITLE
Changes to terrain combat bonuses

### DIFF
--- a/android/assets/jsons/Civ V - Vanilla/Terrains.json
+++ b/android/assets/jsons/Civ V - Vanilla/Terrains.json
@@ -20,7 +20,6 @@
 		"type": "Land",
 		"food": 2,
 		"movementCost": 1,
-		"defenceBonus": -0.1,
 		"RGB": [97,171,58],
 		"uniques": ["Occurs at temperature between [-0.4] and [0.8] and humidity between [0.5] and [1]", "Open terrain"]
 	},
@@ -30,7 +29,6 @@
 		"food": 1,
 		"production": 1,
 		"movementCost": 1,
-		"defenceBonus": -0.1,
 		"RGB": [168,185,102],
 		"uniques": ["Occurs at temperature between [-0.4] and [0.8] and humidity between [0] and [0.5]",
 			"Occurs at temperature between [0.8] and [1] and humidity between [0.7] and [1]", "Open terrain"]
@@ -40,7 +38,6 @@
 		"type": "Land",
 		"food": 1,
 		"movementCost": 1,
-		"defenceBonus": -0.1,
 		"RGB": [189,204,191],
 		"uniques": ["Occurs at temperature between [-1] and [-0.4] and humidity between [0.5] and [1]", "Open terrain"]
 	},
@@ -48,7 +45,6 @@
 		"name": "Desert",
 		"type": "Land",
 		"movementCost": 1,
-		"defenceBonus": -0.1,
 		"RGB": [ 230, 230, 113],
 		"uniques": ["Occurs at temperature between [0.8] and [1] and humidity between [0] and [0.7]", "Open terrain"]
 	},
@@ -64,6 +60,7 @@
 		"name": "Mountain",
 		"type": "Land",
 		"impassable": true,
+		"defenceBonus": 0.25,
 		"RGB": [120, 120, 120],
 		"uniques":["Has an elevation of [4] for visibility calculations"]
 	},
@@ -71,7 +68,6 @@
 		"name": "Snow",
 		"type": "Land",
 		"movementCost": 1,
-		"defenceBonus": -0.1,
 		"RGB": [231, 242, 249],
 		"uniques": ["Occurs at temperature between [-1] and [-0.4] and humidity between [0] and [0.5]", "Open terrain"]
 	},


### PR DESCRIPTION
as in civ5, all base terrain have no penalty/bonuses, mountain has +25%.
![image](https://user-images.githubusercontent.com/30041793/119368945-e4e03980-bcb3-11eb-871d-4b77126607a7.png)
