### PR TITLE
Improved location notifications

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -402,6 +402,7 @@ Enemy city [cityName] has attacked our [ourUnit] =
 An enemy [unit] has captured [cityName] = 
 An enemy [unit] has captured our [ourUnit] = 
 An enemy [unit] has destroyed our [ourUnit] = 
+Your [ourUnit] has destroyed an enemy [unit] = 
 An enemy [RangedUnit] has destroyed the defence of [cityName] = 
 Enemy city [cityName] has destroyed our [ourUnit] = 
 An enemy [unit] was destroyed while attacking [cityName] = 

--- a/core/src/com/unciv/logic/city/CityExpansionManager.kt
+++ b/core/src/com/unciv/logic/city/CityExpansionManager.kt
@@ -2,6 +2,7 @@ package com.unciv.logic.city
 
 import com.badlogic.gdx.math.Vector2
 import com.unciv.logic.automation.Automation
+import com.unciv.logic.civilization.LocationAction
 import com.unciv.logic.civilization.NotificationIcon
 import com.unciv.logic.map.TileInfo
 import com.unciv.ui.utils.withItem
@@ -74,7 +75,7 @@ class CityExpansionManager {
                         it.getOwner() == null
                                 && it.neighbors.any { tile -> tile.getCity() == cityInfo }
                     }
-            val chosenTile = tiles.maxBy { Automation.rankTile(it, cityInfo.civInfo) }
+            val chosenTile = tiles.maxByOrNull { Automation.rankTile(it, cityInfo.civInfo) }
             if (chosenTile != null)
                 return chosenTile
         }
@@ -134,7 +135,7 @@ class CityExpansionManager {
         cityInfo.civInfo.updateDetailedCivResources()
         cityInfo.cityStats.update()
 
-        for (unit in tileInfo.getUnits().toList()) // tolisted because we're modifying
+        for (unit in tileInfo.getUnits().toList()) // toListed because we're modifying
             if (!unit.civInfo.canEnterTiles(cityInfo.civInfo))
                 unit.movement.teleportToClosestMoveableTile()
 
@@ -145,8 +146,10 @@ class CityExpansionManager {
         cultureStored += culture.toInt()
         if (cultureStored >= getCultureToNextTile()) {
             val location = addNewTileWithCulture()
-            if (location != null)
-                cityInfo.civInfo.addNotification("[" + cityInfo.name + "] has expanded its borders!", location, NotificationIcon.Culture)
+            if (location != null) {
+                val locations = LocationAction(listOf(location, cityInfo.location))
+                cityInfo.civInfo.addNotification("[" + cityInfo.name + "] has expanded its borders!", locations, NotificationIcon.Culture)
+            }
         }
     }
 

--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -638,15 +638,16 @@ class CivilizationInfo {
     }
 
     fun giftMilitaryUnitTo(otherCiv: CivilizationInfo) {
-        val city = NextTurnAutomation.getClosestCities(this, otherCiv).city1
+        val cities = NextTurnAutomation.getClosestCities(this, otherCiv)
+        val city = cities.city1
         val militaryUnit = city.cityConstructions.getConstructableUnits()
                 .filter { !it.unitType.isCivilian() && it.unitType.isLandUnit() }
                 .toList().random()
         // placing the unit may fail - in that case stay quiet
         val placedUnit = placeUnitNearTile(city.location, militaryUnit.name) ?: return
-        // Point to the places mentioned in the message in that order
+        // Point to the places mentioned in the message _in that order_ (debatable)
         val placedLocation = placedUnit.getTile().position
-        val locations = LocationAction(listOf(getCapital().location, placedLocation, city.location))
+        val locations = LocationAction(listOf(placedLocation, cities.city1.location, city.location))
         addNotification("[${otherCiv.civName}] gave us a [${militaryUnit.name}] as gift near [${city.name}]!", locations, otherCiv.civName, militaryUnit.name)
     }
 

--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -647,7 +647,7 @@ class CivilizationInfo {
         val placedUnit = placeUnitNearTile(city.location, militaryUnit.name) ?: return
         // Point to the places mentioned in the message _in that order_ (debatable)
         val placedLocation = placedUnit.getTile().position
-        val locations = LocationAction(listOf(placedLocation, cities.city1.location, city.location))
+        val locations = LocationAction(listOf(placedLocation, cities.city2.location, city.location))
         addNotification("[${otherCiv.civName}] gave us a [${militaryUnit.name}] as gift near [${city.name}]!", locations, otherCiv.civName, militaryUnit.name)
     }
 

--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -302,7 +302,8 @@ class CivilizationInfo {
 
     fun getEquivalentUnit(baseUnitName: String): BaseUnit {
         val baseUnit = gameInfo.ruleSet.units[baseUnitName]
-            ?: throw UncivShowableException("Unit $baseUnitName doesn't seem to exist!")
+        @Suppress("FoldInitializerAndIfToElvis")
+        if (baseUnit == null) throw UncivShowableException("Unit $baseUnitName doesn't seem to exist!")
         if (baseUnit.replaces != null) return getEquivalentUnit(baseUnit.replaces!!) // Equivalent of unique unit is the equivalent of the replaced unit
 
         for (unit in gameInfo.ruleSet.units.values)
@@ -577,10 +578,9 @@ class CivilizationInfo {
         if (!gameInfo.ruleSet.units.containsKey(unitName)) return
         val unit = getEquivalentUnit(unitName)
         // silently bail if no tile to place the unit is found
-        val placedUnit = placeUnitNearTile(cityToAddTo.location, unit.name) ?: return
-        if (unit.isGreatPerson()) {
-            val locations = LocationAction(listOf(placedUnit.getTile().position,cityToAddTo.location))
-            addNotification("A [${unit.name}] has been born in [${cityToAddTo.name}]!", locations, unit.name)
+        val placedUnit = placeUnitNearTile(cityToAddTo.location, unit.name)
+        if (placedUnit != null && unit.isGreatPerson()) {
+            addNotification("A [${unit.name}] has been born in [${cityToAddTo.name}]!", placedUnit.getTile().position, unit.name)
         }
     }
 

--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -6,6 +6,7 @@ import com.unciv.UncivGame
 import com.unciv.logic.automation.UnitAutomation
 import com.unciv.logic.automation.WorkerAutomation
 import com.unciv.logic.civilization.CivilizationInfo
+import com.unciv.logic.civilization.LocationAction
 import com.unciv.logic.civilization.NotificationIcon
 import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.ruleset.Unique
@@ -442,16 +443,16 @@ class MapUnit {
     private fun tryProvideProductionToClosestCity(removedTerrainFeature: String) {
         val tile = getTile()
         val closestCity = civInfo.cities.minByOrNull { it.getCenterTile().aerialDistanceTo(tile) }
-        if (closestCity == null) return
+            ?: return
         val distance = closestCity.getCenterTile().aerialDistanceTo(tile)
         var productionPointsToAdd = if (distance == 1) 20 else 20 - (distance - 2) * 5
         if (tile.owningCity == null || tile.owningCity!!.civInfo != civInfo) productionPointsToAdd = productionPointsToAdd * 2 / 3
         if (productionPointsToAdd > 0) {
             closestCity.cityConstructions.addProductionPoints(productionPointsToAdd)
+            val locations = LocationAction(listOf(tile.position, closestCity.location))
             civInfo.addNotification("Clearing a [$removedTerrainFeature] has created [$productionPointsToAdd] Production for [${closestCity.name}]",
-                    closestCity.location, NotificationIcon.Construction)
+                locations, NotificationIcon.Construction)
         }
-
     }
 
     private fun heal() {
@@ -630,7 +631,8 @@ class MapUnit {
             val city = civInfo.cities.random(tileBasedRandom)
             city.population.population++
             city.population.autoAssignPopulation()
-            civInfo.addNotification("We have found survivors in the ruins - population added to [" + city.name + "]", tile.position, NotificationIcon.Growth)
+            val locations = LocationAction(listOf(tile.position, city.location))
+            civInfo.addNotification("We have found survivors in the ruins - population added to [" + city.name + "]", locations, NotificationIcon.Growth)
         }
         val researchableAncientEraTechs = tile.tileMap.gameInfo.ruleSet.technologies.values
                 .filter {
@@ -752,21 +754,24 @@ class MapUnit {
     }
 
     private fun getCitadelDamage() {
-        // Check for Citadel damage
-        val applyCitadelDamage = currentTile.neighbors
-                .filter { it.getOwner() != null && civInfo.isAtWarWith(it.getOwner()!!) }
-                .map { it.getTileImprovement() }
-                .filter { it != null && it.hasUnique("Deal 30 damage to adjacent enemy units") }
-                .any()
+        // Check for Citadel damage - note: 'Damage does not stack with other Citadels'
+        val citadelTile = currentTile.neighbors
+                .filter {
+                    it.getOwner() != null && civInfo.isAtWarWith(it.getOwner()!!) &&
+                    with (it.getTileImprovement()) {
+                        this != null && this.hasUnique("Deal 30 damage to adjacent enemy units")
+                    }
+                }
+                .firstOrNull()
 
-        if (applyCitadelDamage) {
+        if (citadelTile != null) {
             health -= 30
-
+            val locations = LocationAction(listOf(citadelTile.position,currentTile.position))
             if (health <= 0) {
-                civInfo.addNotification("An enemy [Citadel] has destroyed our [$name]", currentTile.position, name, NotificationIcon.Death)
-                // todo - add notification for attacking civ
+                civInfo.addNotification("An enemy [Citadel] has destroyed our [$name]", locations, name, NotificationIcon.Death)
+                citadelTile.getOwner()?.addNotification("Your [Citadel] has destroyed an enemy [$name]", locations, name, NotificationIcon.Death)
                 destroy()
-            } else civInfo.addNotification("An enemy [Citadel] has attacked our [$name]", currentTile.position, name)
+            } else civInfo.addNotification("An enemy [Citadel] has attacked our [$name]", locations, name, NotificationIcon.War)
         }
     }
 

--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -440,10 +440,12 @@ class MapUnit {
         tile.improvementInProgress = null
     }
 
+    
     private fun tryProvideProductionToClosestCity(removedTerrainFeature: String) {
         val tile = getTile()
         val closestCity = civInfo.cities.minByOrNull { it.getCenterTile().aerialDistanceTo(tile) }
-            ?: return
+        @Suppress("FoldInitializerAndIfToElvis")
+        if (closestCity == null) return
         val distance = closestCity.getCenterTile().aerialDistanceTo(tile)
         var productionPointsToAdd = if (distance == 1) 20 else 20 - (distance - 2) * 5
         if (tile.owningCity == null || tile.owningCity!!.civInfo != civInfo) productionPointsToAdd = productionPointsToAdd * 2 / 3


### PR DESCRIPTION
Went through all uses of the `addNotification(String,Vector2...` overload and checked whether more locations might be useful. I think they might be... e.g. Forest cut -> show where the forest was and the recipient city, show both attacker and defender in battles and so on.
Found a todo close by and obeyed (Citadel notification for attacking civ if victim destroyed).
Also 'linted' all files touched until 'Problems' window empty.
Had my doubts about `CivInfo.getLeaderDisplayName` - shouldn't it reduce to undecorated `Nation.getLeaderDisplayName` in purely single-player games? Well, left logic as it was just followed the IDE's 'lift out and fold' moanings.