### PR TITLE
Enable BaseUnit.attackSound

### DIFF
--- a/core/src/com/unciv/models/UncivSound.kt
+++ b/core/src/com/unciv/models/UncivSound.kt
@@ -1,6 +1,9 @@
 package com.unciv.models
 
-enum class UncivSound(val value: String) {
+enum class UncivSound(
+    val value: String,
+    var custom: String? = null
+) {
     Click("click"),
     Fortify("fortify"),
     Promote("promote"),
@@ -12,5 +15,14 @@ enum class UncivSound(val value: String) {
     Policy("policy"),
     Paper("paper"),
     Whoosh("whoosh"),
-    Silent("")
+    Silent(""),
+    Custom("");
+    companion object {
+        fun getCustom(name: String?): UncivSound {
+            if (name == null || name.isEmpty()) return Click
+            val item = Custom
+            item.custom = name
+            return item
+        }
+    }
 }

--- a/core/src/com/unciv/ui/utils/Sounds.kt
+++ b/core/src/com/unciv/ui/utils/Sounds.kt
@@ -2,22 +2,40 @@ package com.unciv.ui.utils
 
 import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.audio.Sound
+import com.badlogic.gdx.files.FileHandle
 import com.unciv.UncivGame
 import com.unciv.models.UncivSound
 
 object Sounds {
-    private val soundMap = HashMap<UncivSound, Sound>()
+    private val soundMap = HashMap<String, Sound?>()
 
-    fun get(sound: UncivSound): Sound {
-        if (!soundMap.containsKey(sound)) {
-            soundMap[sound] = Gdx.audio.newSound(Gdx.files.internal("sounds/${sound.value}.mp3"))
+    fun get(sound: UncivSound): Sound? {
+        val fileName = if (sound == UncivSound.Custom) sound.custom!! else sound.value
+        if (!soundMap.containsKey(fileName)) {
+            val mods = mutableSetOf<String>()
+            if (UncivGame.Current.isInitialized) {
+                mods.addAll(UncivGame.Current.settings.visualMods)
+                mods.addAll(UncivGame.Current.gameInfo.ruleSet.mods)
+            }
+            mods.add("")
+            var file: FileHandle? = null
+            for (mod in mods) {
+                val path = if(mod.isEmpty()) "sounds/$fileName.mp3"
+                    else "mods/$mod/sounds/$fileName.mp3"
+                file = Gdx.files.internal(path)
+                if (file.exists()) break
+            }
+            if (file != null && file.exists())
+                soundMap[fileName] = Gdx.audio.newSound(file)
+            else
+                soundMap[fileName] = null  // remember file is missing
         }
-        return soundMap[sound]!!
+        return soundMap[fileName]
     }
 
     fun play(sound: UncivSound) {
         val volume = UncivGame.Current.settings.soundEffectsVolume
         if (sound == UncivSound.Silent || volume < 0.01) return
-        get(sound).play(volume)
+        get(sound)?.play(volume)
     }
 }

--- a/core/src/com/unciv/ui/worldscreen/bottombar/BattleTable.kt
+++ b/core/src/com/unciv/ui/worldscreen/bottombar/BattleTable.kt
@@ -13,6 +13,7 @@ import com.unciv.logic.automation.UnitAutomation
 import com.unciv.logic.battle.*
 import com.unciv.logic.map.TileInfo
 import com.unciv.models.AttackableTile
+import com.unciv.models.UncivSound
 import com.unciv.models.ruleset.unit.UnitType
 import com.unciv.models.translations.tr
 import com.unciv.ui.utils.*
@@ -46,7 +47,7 @@ class BattleTable(val worldScreen: WorldScreen): Table() {
         if (attacker is MapUnitCombatant && attacker.unit.hasUnique("Nuclear weapon")) {
             val selectedTile = worldScreen.mapHolder.selectedTile
             if (selectedTile == null) { hide(); return } // no selected tile
-            simulateNuke(attacker as MapUnitCombatant, selectedTile)
+            simulateNuke(attacker, selectedTile)
         }
         else {
             val defender = tryGetDefender()
@@ -207,7 +208,12 @@ class BattleTable(val worldScreen: WorldScreen): Table() {
         }
 
         else {
-            attackButton.onClick {
+            // This is more of a demo for now. To do it properly the ICombatant interface would
+            // define how to get an attack sound, and city bombard could actually provide one...
+            val sound = if (attacker is MapUnitCombatant)
+                            UncivSound.getCustom(attacker.unit.baseUnit.attackSound)
+                        else UncivSound.Click
+            attackButton.onClick(sound) {
                 Battle.moveAndAttack(attacker, attackableTile)
                 worldScreen.mapHolder.removeUnitActionOverlay() // the overlay was one of attacking
                 worldScreen.shouldUpdate = true


### PR DESCRIPTION
Actually, inspired by that 3998 issue, this hack just works. Really. My aliens finally fire 'phasers'. :smile:

The ugly hack is that a var property of an enum entry is modified - thus essentially abused as global variable with all the horrors that may bring (comod). I could also envision a variant where the same syntax UncivSound.getCustom() actually produces independent instances - no enum and all previous enum symbols now a kind factory method / lazy val in the companion object / something like that.

Interested? Pursue and polish or ditch and forget?

Oh btw the credits.md does not mention where the current sound mp3's come from, or am I blind? For new sounds - `select * from soundbible.com where license in ('Public Domain','Attribution 3.0')`? :grin: