### PR TITLE
Fix two sound credits

### DIFF
--- a/core/src/com/unciv/models/UncivSound.kt
+++ b/core/src/com/unciv/models/UncivSound.kt
@@ -14,6 +14,7 @@ private enum class UncivSoundConstants (val value: String) {
     Whoosh("whoosh"),
     Bombard("bombard"),
     Slider("slider"),
+    Construction("construction"),
     Silent(""),
     Custom("")
 }
@@ -52,6 +53,7 @@ class UncivSound private constructor (
         val Whoosh = UncivSound(UncivSoundConstants.Whoosh)
         val Bombard = UncivSound(UncivSoundConstants.Bombard)
         val Slider = UncivSound(UncivSoundConstants.Slider)
+        val Construction = UncivSound(UncivSoundConstants.Construction)
         val Silent = UncivSound(UncivSoundConstants.Silent)
         /** Creates an UncivSound instance for a custom sound.
          * @param filename The base filename without extension.

--- a/core/src/com/unciv/ui/cityscreen/CityConstructionsTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityConstructionsTable.kt
@@ -284,7 +284,9 @@ class CityConstructionsTable(val cityScreen: CityScreen) : Table(CameraStageBase
 
         if (!cannotAddConstructionToQueue(construction, cityScreen.city, cityScreen.city.cityConstructions)) {
             val addToQueueButton = ImageGetter.getImage("OtherIcons/New").apply { color = Color.BLACK }.surroundWithCircle(40f)
-            addToQueueButton.onClick { addConstructionToQueue(construction, cityScreen.city.cityConstructions) }
+            addToQueueButton.onClick(getConstructionSound(construction)) {
+                addConstructionToQueue(construction, cityScreen.city.cityConstructions)
+            }
             pickConstructionButton.add(addToQueueButton)
         }
         pickConstructionButton.row()
@@ -338,7 +340,9 @@ class CityConstructionsTable(val cityScreen: CityScreen) : Table(CameraStageBase
                     || cannotAddConstructionToQueue(construction, city, cityConstructions)) {
                 button.disable()
             } else {
-                button.onClick { addConstructionToQueue(construction, cityConstructions) }
+                button.onClick(getConstructionSound(construction)) {
+                    addConstructionToQueue(construction, cityConstructions)
+                }
             }
         }
 
@@ -360,6 +364,15 @@ class CityConstructionsTable(val cityScreen: CityScreen) : Table(CameraStageBase
         cityScreen.game.settings.addCompletedTutorialTask("Pick construction")
     }
 
+    fun getConstructionSound(construction: IConstruction): UncivSound {
+        return when(construction) {
+            is Building -> UncivSound.Construction
+            is BaseUnit -> UncivSound.Promote
+            PerpetualConstruction.gold -> UncivSound.Coin
+            PerpetualConstruction.science -> UncivSound.Paper
+            else -> UncivSound.Click
+        }
+    }
 
     fun purchaseConstruction(construction: IConstruction) {
         val city = cityScreen.city

--- a/docs/Credits.md
+++ b/docs/Credits.md
@@ -566,6 +566,8 @@ Sounds are from FreeSound.org and are either Creative Commons or Public Domain
 * [Woosh](https://soundbible.com/2068-Woosh.html) by Mark DiAngelo as 'slider' sound (CC Attribution 3.0 license)
 * [Tornado-Siren-II](https://soundbible.com/1937-Tornado-Siren-II.html) by Delilah as part of 'nuke' sound (CC Attribution 3.0 license)
 * [Explosion-Ultra-Bass](https://soundbible.com/1807-Explosion-Ultra-Bass.html) by Mark DiAngelo as part of 'nuke' sound (CC Attribution 3.0 license)
+* [Short Choir](https://freesound.org/people/Breviceps/sounds/444491/) by Breviceps as 'choir' for free great person pick
+
 
 # Music
 The following music is from https://filmmusic.io


### PR DESCRIPTION
There was a sound attribution missing in credits.md and an unused one...

Instead of removing the unused one - I implemented it. 😳🤭

Feel free to reject - in that case copy the 
```markdown
* [Short Choir](https://freesound.org/people/Breviceps/sounds/444491/) by Breviceps as 'choir' for free great person pick
```
line - I'm sure I got the right source.