### PR TITLE
Patch ModManager exit to allow deactivating a selected tileset

### DIFF
--- a/core/src/com/unciv/logic/map/TileInfo.kt
+++ b/core/src/com/unciv/logic/map/TileInfo.kt
@@ -450,18 +450,17 @@ open class TileInfo {
     /** Shows important properties of this tile for debugging _only_, it helps to see what you're doing */
     override fun toString(): String {
         val lineList = arrayListOf("TileInfo @$position")
-        if (this::baseTerrain.isInitialized) {
-            if (isCityCenter()) lineList += getCity()!!.name
-            lineList += baseTerrain
-            for (terrainFeature in terrainFeatures) lineList += terrainFeature
-            if (resource != null) lineList += resource!!
-            if (naturalWonder != null) lineList += naturalWonder!!
-            if (roadStatus !== RoadStatus.None && !isCityCenter()) lineList += roadStatus.name
-            if (improvement != null) lineList += improvement!!
-            if (civilianUnit != null) lineList += civilianUnit!!.name + " - " + civilianUnit!!.civInfo.civName
-            if (militaryUnit != null) lineList += militaryUnit!!.name + " - " + militaryUnit!!.civInfo.civName
-            if (this::baseTerrainObject.isInitialized && isImpassible()) lineList += Constants.impassable
-        } else lineList += "uninitialized"
+        if (!this::baseTerrain.isInitialized) return lineList[0] + ", uninitialized"
+        if (isCityCenter()) lineList += getCity()!!.name
+        lineList += baseTerrain
+        for (terrainFeature in terrainFeatures) lineList += terrainFeature
+        if (resource != null) lineList += resource!!
+        if (naturalWonder != null) lineList += naturalWonder!!
+        if (roadStatus !== RoadStatus.None && !isCityCenter()) lineList += roadStatus.name
+        if (improvement != null) lineList += improvement!!
+        if (civilianUnit != null) lineList += civilianUnit!!.name + " - " + civilianUnit!!.civInfo.civName
+        if (militaryUnit != null) lineList += militaryUnit!!.name + " - " + militaryUnit!!.civInfo.civName
+        if (this::baseTerrainObject.isInitialized && isImpassible()) lineList += Constants.impassable
         return lineList.joinToString()
     }
 

--- a/core/src/com/unciv/logic/map/TileInfo.kt
+++ b/core/src/com/unciv/logic/map/TileInfo.kt
@@ -449,17 +449,19 @@ open class TileInfo {
 
     /** Shows important properties of this tile for debugging _only_, it helps to see what you're doing */
     override fun toString(): String {
-        val lineList = arrayListOf("TileInfo @($position)")
-        if (isCityCenter()) lineList += getCity()!!.name
-        lineList += baseTerrain
-        for (terrainFeature in terrainFeatures) lineList += terrainFeature
-        if (resource != null ) lineList += resource!!
-        if (naturalWonder != null) lineList += naturalWonder!!
-        if (roadStatus !== RoadStatus.None && !isCityCenter()) lineList += roadStatus.name
-        if (improvement != null) lineList += improvement!!
-        if (civilianUnit != null) lineList += civilianUnit!!.name + " - " + civilianUnit!!.civInfo.civName
-        if (militaryUnit != null) lineList += militaryUnit!!.name + " - " + militaryUnit!!.civInfo.civName
-        if (isImpassible()) lineList += Constants.impassable
+        val lineList = arrayListOf("TileInfo @$position")
+        if (this::baseTerrain.isInitialized) {
+            if (isCityCenter()) lineList += getCity()!!.name
+            lineList += baseTerrain
+            for (terrainFeature in terrainFeatures) lineList += terrainFeature
+            if (resource != null) lineList += resource!!
+            if (naturalWonder != null) lineList += naturalWonder!!
+            if (roadStatus !== RoadStatus.None && !isCityCenter()) lineList += roadStatus.name
+            if (improvement != null) lineList += improvement!!
+            if (civilianUnit != null) lineList += civilianUnit!!.name + " - " + civilianUnit!!.civInfo.civName
+            if (militaryUnit != null) lineList += militaryUnit!!.name + " - " + militaryUnit!!.civInfo.civName
+            if (this::baseTerrainObject.isInitialized && isImpassible()) lineList += Constants.impassable
+        } else lineList += "uninitialized"
         return lineList.joinToString()
     }
 

--- a/core/src/com/unciv/ui/pickerscreens/ModManagementScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/ModManagementScreen.kt
@@ -37,7 +37,19 @@ class ModManagementScreen: PickerScreen(disableScroll = true) {
     val modDescriptions: HashMap<String, String> = hashMapOf()
 
     init {
-        setDefaultCloseAction(MainMenuScreen())
+        
+        //setDefaultCloseAction(screen) // this would initialize the new MainMenuScreen immediately
+        val closeAction = {
+            val tileSets = ImageGetter.getAvailableTilesets()
+            if (game.settings.tileSet !in tileSets) {
+                game.settings.tileSet = tileSets.first()
+            }
+            game.setScreen(MainMenuScreen())
+            dispose()
+        }
+        closeButton.onClick(closeAction)
+        onBackButtonClicked(closeAction)
+
         refreshModTable()
 
         topTable.add("Current mods".toLabel()).padRight(35f) // 35 = 10 default pad + 25 to compensate for permanent visual mod decoration icon


### PR DESCRIPTION
... and make TileInfo debug display a little nicer.

Resolves #4016 part (a) - though I'm not sure the extra code is worth fixing such a borderline non-crashing situation. You throw the dice.