### PR TITLE
Re-enable playability of mods with less severe errors

### DIFF
--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -227,9 +227,37 @@ class Ruleset {
         return stringList.joinToString()
     }
 
-
-    fun checkModLinks(): String {
+    /** Severity level of Mod RuleSet check */
+    enum class CheckModLinksStatus {OK, Warning, Error}
+    /** Result of a Mod RuleSet check */
+    // essentially a named Pair with a few shortcuts
+    class CheckModLinksResult(val status: CheckModLinksStatus, val message: String) {
+        // Empty constructor just makes the Complex Mod Check on the new game screen shorter 
+        constructor(): this(CheckModLinksStatus.OK, "")
+        // Constructor that joins lines
+        constructor(status: CheckModLinksStatus, lines: ArrayList<String>):
+                this (status,
+                    lines.joinToString("\n"))
+        // Constructor that auto-determines severity
+        constructor(warningCount: Int, lines: ArrayList<String>):
+                this (
+                    when {
+                        lines.isEmpty() -> CheckModLinksStatus.OK
+                        lines.size == warningCount -> CheckModLinksStatus.Warning
+                        else -> CheckModLinksStatus.Error
+                    },
+                    lines)
+        // Allows $this in format strings 
+        override fun toString() = message
+        // Readability shortcuts
+        val isError
+            get() = status == CheckModLinksStatus.Error
+        val isNotOK
+            get() = status != CheckModLinksStatus.OK
+    }
+    fun checkModLinks(): CheckModLinksResult {
         val lines = ArrayList<String>()
+        var warningCount = 0
 
         // Checks for all mods
         for (unit in units.values) {
@@ -253,7 +281,7 @@ class Ruleset {
                 lines += "${building.name} must either have an explicit cost or reference an existing tech!"
         }
 
-        if (!modOptions.isBaseRuleset) return lines.joinToString("\n")
+        if (!modOptions.isBaseRuleset) return CheckModLinksResult(warningCount, lines)
 
 
         for (unit in units.values) {
@@ -329,11 +357,13 @@ class Ruleset {
                 }
 
                 val allOtherPrereqs = tech.prerequisites.asSequence().filterNot { it == prereq }.flatMap { getPrereqTree(it) }
-                if (allOtherPrereqs.contains(prereq))
+                if (allOtherPrereqs.contains(prereq)) {
                     lines += "No need to add $prereq as a prerequisite of ${tech.name} - it is already implicit from the other prerequisites!"
+                    warningCount++
+                }
             }
         }
-        return lines.joinToString("\n")
+        return CheckModLinksResult(warningCount, lines)
     }
 }
 

--- a/core/src/com/unciv/ui/worldscreen/mainmenu/OptionsPopup.kt
+++ b/core/src/com/unciv/ui/worldscreen/mainmenu/OptionsPopup.kt
@@ -249,11 +249,11 @@ class OptionsPopup(val previousScreen:CameraStageBaseScreen) : Popup(previousScr
             val lines = ArrayList<String>()
             for (mod in RulesetCache.values) {
                 val modLinks = mod.checkModLinks()
-                if (modLinks != "") {
+                if (modLinks.isNotOK) {
                     lines += ""
                     lines += mod.name
                     lines += ""
-                    lines += modLinks
+                    lines += modLinks.message
                     lines += ""
                 }
             }


### PR DESCRIPTION
Just noticed we (ahem, me, sorry) stopped mods with redundant tech prerequisites from being playable at all (or more accurately from starting a new game with). This is  one possible way to deal with that - could be cleaner (e.g. each test decides its own severity which is max() ed at the end) but so far it works...

Examples: DeCiv, PolyCiv, Plants vs UnZombies, Civ 6 mod.

![image](https://user-images.githubusercontent.com/63000004/120393645-8e699f80-c332-11eb-9963-71d4ded426ee.png)
