### PR TITLE
Add global alerts for certain constructions

### DIFF
--- a/android/assets/jsons/Civ V - Vanilla/Buildings.json
+++ b/android/assets/jsons/Civ V - Vanilla/Buildings.json
@@ -937,7 +937,7 @@
 	{
 		"name": "Manhattan Project",
 		"isNationalWonder": true,
-		"uniques": ["Enables nuclear weapon"],
+		"uniques": ["Enables nuclear weapon", "Triggers a global alert upon completion"],
 		"requiredTech": "Nuclear Fission"
 	},
 	{
@@ -1014,13 +1014,13 @@
 		"name": "SS Booster",
 		"requiredResource": "Aluminum",
 		"requiredTech": "Robotics",
-		"uniques": ["Spaceship part", "Cannot be purchased"]
+		"uniques": ["Spaceship part", "Triggers a global alert upon completion", "Cannot be purchased"]
 	},
 	{
 		"name": "Apollo Program",
 		"cost": 1500,
 		"isNationalWonder": true,
-		"uniques": ["Enables construction of Spaceship parts"],
+		"uniques": ["Enables construction of Spaceship parts", "Triggers a global alert upon completion"],
 		"requiredTech": "Rocketry"
 	},
 	
@@ -1044,18 +1044,18 @@
 		"name": "SS Cockpit",
 		"requiredResource": "Aluminum",
 		"requiredTech": "Satellites",
-		"uniques": ["Spaceship part", "Cannot be purchased"]
+		"uniques": ["Spaceship part", "Triggers a global alert upon completion", "Cannot be purchased"]
 	},
 	{
 		"name": "SS Engine",
 		"requiredResource": "Aluminum",
 		"requiredTech": "Particle Physics",
-		"uniques": ["Spaceship part", "Cannot be purchased"]
+		"uniques": ["Spaceship part", "Triggers a global alert upon completion", "Cannot be purchased"]
 	},
 	{
 		"name": "SS Stasis Chamber",
 		"requiredResource": "Aluminum",
 		"requiredTech": "Nanotechnology",
-		"uniques": ["Spaceship part", "Cannot be purchased"]
+		"uniques": ["Spaceship part", "Triggers a global alert upon completion", "Cannot be purchased"]
 	}
 ]

--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -41,6 +41,7 @@ Consumes 1 [resource] =
 Consumes [amount] [resource] = 
 Required tech: [requiredTech] = 
 Requires [PolicyOrNationalWonder] = 	
+Triggers a global alert upon completion = 
 Cannot be purchased = 
 
 Current construction = 
@@ -395,6 +396,8 @@ Cannot provide unit upkeep for [unitName] - unit has been disbanded! =
 [cityName] is starving! = 
 [construction] has been built in [cityName] = 
 [wonder] has been built in a faraway land = 
+[civName] has completed [construction]! = 
+An unknown civilization has completed [construction]! = 
 Work has started on [construction] = 
 [cityName] cannot continue work on [construction] = 
 [cityName] has expanded its borders! = 

--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -41,7 +41,6 @@ Consumes 1 [resource] =
 Consumes [amount] [resource] = 
 Required tech: [requiredTech] = 
 Requires [PolicyOrNationalWonder] = 	
-Triggers a global alert upon completion = 
 Cannot be purchased = 
 
 Current construction = 

--- a/core/src/com/unciv/logic/city/CityConstructions.kt
+++ b/core/src/com/unciv/logic/city/CityConstructions.kt
@@ -347,7 +347,16 @@ class CityConstructions {
             cityInfo.civInfo.addNotification("[${construction.name}] has been built in [" + cityInfo.name + "]",
                     cityInfo.location, NotificationIcon.Construction, icon)
         }
-
+        if (construction is Building && "Triggers a global alert upon completion" in construction.uniques) {
+            for (otherCiv in cityInfo.civInfo.gameInfo.civilizations) {
+                // No need to notify ourself, since we already got the building notification anyway
+                if (otherCiv == cityInfo.civInfo) continue
+                val completingCivDescription =
+                    if (otherCiv.knows(cityInfo.civInfo)) "[${cityInfo.civInfo.civName}]" else "An unknown civilization"
+                otherCiv.addNotification("$completingCivDescription has completed [${construction.name}]!",
+                    NotificationIcon.Construction, buildingIcon)
+            }
+        }
     }
 
     fun addBuilding(buildingName: String) {

--- a/core/src/com/unciv/models/ruleset/Building.kt
+++ b/core/src/com/unciv/models/ruleset/Building.kt
@@ -3,7 +3,6 @@ package com.unciv.models.ruleset
 import com.unciv.logic.city.CityConstructions
 import com.unciv.logic.city.IConstruction
 import com.unciv.logic.civilization.CivilizationInfo
-import com.unciv.logic.civilization.NotificationIcon
 import com.unciv.models.Counter
 import com.unciv.models.ruleset.tile.TileImprovement
 import com.unciv.models.stats.NamedStats
@@ -409,18 +408,6 @@ class Building : NamedStats(), IConstruction {
 
     override fun postBuildEvent(cityConstructions: CityConstructions, wasBought: Boolean): Boolean {
         val civInfo = cityConstructions.cityInfo.civInfo
-
-        if ("Triggers a global alert upon completion" in uniques) {
-            val buildingIcon = "BuildingIcons/${name}"
-            for (otherCiv in civInfo.gameInfo.civilizations) {
-                // No need to notify ourself, since we get the building notification anyway
-                if (otherCiv == civInfo) continue
-                val completingCivDescription =
-                    if (otherCiv.knows(civInfo)) "[${civInfo.civName}]" else "An unknown civilization"
-                otherCiv.addNotification("$completingCivDescription has completed [${name}]!",
-                        NotificationIcon.Construction, buildingIcon)
-            }
-        }
 
         if ("Spaceship part" in uniques) {
             civInfo.victoryManager.currentsSpaceshipParts.add(name, 1)


### PR DESCRIPTION
In the original game, certain constructions alert all players upon their completion (see for example https://civilization.fandom.com/wiki/Apollo_Program_(Civ5)). This PR introduces a new unique for this behavior and adds this unique to the relevant constructions. The global alert is implemented as a notification.

To my knowledge, the relevant constructions are Manhattan Project, Apollo Project and all space parts. If there are any more, please let me know!

I was unsure whether to place the code that implements the unique in Building.postBuildEvent or in CityConstructions.constructionComplete. I choose the former, since the unique is currently only used by buildings. If other kinds of constructions require a global alert as well, the code could be moved to CityConstructions.constructionComplete.