### PR TITLE
Key dispatcher precedence with several Popups open

### DIFF
--- a/core/src/com/unciv/ui/utils/CameraStageBaseScreen.kt
+++ b/core/src/com/unciv/ui/utils/CameraStageBaseScreen.kt
@@ -28,7 +28,7 @@ open class CameraStageBaseScreen : Screen {
 
     protected val tutorialController by lazy { TutorialController(this) }
 
-    val keyPressDispatcher = KeyPressDispatcher()
+    val keyPressDispatcher = KeyPressDispatcher(this.javaClass.simpleName)
 
     init {
         val resolutions: List<Float> = game.settings.resolution.split("x").map { it.toInt().toFloat() }
@@ -37,7 +37,7 @@ open class CameraStageBaseScreen : Screen {
         /** The ExtendViewport sets the _minimum_(!) world size - the actual world size will be larger, fitted to screen/window aspect ratio. */
         stage = Stage(ExtendViewport(height, height), SpriteBatch())
 
-        keyPressDispatcher.install(stage, this.javaClass.simpleName) { hasOpenPopups() }
+        keyPressDispatcher.install(stage) { hasOpenPopups() }
     }
 
     override fun show() {}

--- a/core/src/com/unciv/ui/utils/ExtensionFunctions.kt
+++ b/core/src/com/unciv/ui/utils/ExtensionFunctions.kt
@@ -36,7 +36,6 @@ fun Button.enable() {
  *  which is more appropriate to toggle On/Off buttons, while this one is good for 'click-to-do-something' buttons.
  */
 var Button.isEnabled: Boolean
-    //Todo: Use in PromotionPickerScreen, TradeTable, WorldScreen.updateNextTurnButton
     get() = touchable == Touchable.enabled
     set(value) = if (value) enable() else disable()
 

--- a/core/src/com/unciv/ui/utils/KeyPressDispatcher.kt
+++ b/core/src/com/unciv/ui/utils/KeyPressDispatcher.kt
@@ -138,13 +138,9 @@ class KeyPressDispatcher(val name: String? = null) : HashMap<KeyCharAndCode, (()
                     val key = KeyCharAndCode(event, character)
 
                     // see if we want to handle this key, and if not, let it propagate
-                    if (!contains(key) || (checkIgnoreKeys?.invoke() == true)) {
-                        // println(this@KeyPressDispatcher.toString() + ": ignore " + key.toString())
+                    if (!contains(key) || (checkIgnoreKeys?.invoke() == true))
                         return super.keyTyped(event, character)
-                    }
                     
-                    // println(this@KeyPressDispatcher.toString() + ": key " + key.toString())
-
                     //try-catch mainly for debugging. Breakpoints in the vicinity can make the event fire twice in rapid succession, second time the context can be invalid
                     try {
                         this@KeyPressDispatcher[key]?.invoke()
@@ -172,11 +168,9 @@ class KeyPressDispatcher(val name: String? = null) : HashMap<KeyCharAndCode, (()
     private fun checkInstall(forceRemove: Boolean = false) {
         if (listener == null || installStage == null) return
         if (listenerInstalled && (isEmpty() || isPaused || forceRemove)) {
-            // println(toString() + ": Removing listener" + (if(forceRemove) " for uninstall" else ""))
             listenerInstalled = false
             installStage!!.removeListener(listener)
         } else if (!listenerInstalled && !(isEmpty() || isPaused)) {
-            // println(toString() + ": Adding listener")
             installStage!!.addListener(listener)
             listenerInstalled = true
         }


### PR DESCRIPTION
The 'keyboard project' still has some way to go, but I pulled this forward.

Motivation: Popups stacked onto each other should be closed one by one with back/esc, and some skipped to the bottom-most non-Popup screen.

Key point I learned:
- Gdx listeners get called in the order they were defined - it's an Array deep down and it is enumerated 'normally'. This means the bottom-most/oldest widget/screen gets the events first and decides whether the stacked widgets get the right to be informed, too. I fully expected otherwise, so I had to think for a while how to handle this.

Dismissed ideas: Fork Gdx and reverse - ouch. KeyPressDispatcher tracking its instances and auto-disabling some - died when I found some popups get created in advance and I had to admit that even if I 'fixed' that one I can't guarantee the last-created instance should always be the only active one.

Pragmatic solution: Similar to hasOpenPopups() - but counting them. Rearranged some code so a popup can count itself. I left all changes to purely debugging help stuff in - markedly the move of KeyPressDispatcher's naming. I propose if we want we can remove that at the end of the keyboard 'project'?

Future roadmap:
- Unify the two Exit game prompts and base them on YesNoPopup.
- Main menu - while there I explored the option to show supported keys as Gdx ToolTip instead of the "(X)" way we did so far. Surprise - they do work and are nicely easy. Not so nice - two differences to what we're used elsewhere (long initial delay, after that all tips on screen react immediately, they show initially where the pointer is but don't follow it) actually make them feel klunky, plus touchscreens need test -> postponed as 'need more investigation'. Please comment?
- Map editor some obvious nice-to-have keys and fixing some translation issues I found while there.
- Scan _all_ Popup uses and adapt them - a few (text + 1-button ones) probably using a new subclass InfoPopup.