### PR TITLE
Fix that when WindowState's width and height = 0 the app window will disappear

### DIFF
--- a/core/src/com/unciv/models/metadata/GameSettings.kt
+++ b/core/src/com/unciv/models/metadata/GameSettings.kt
@@ -4,7 +4,7 @@ import com.badlogic.gdx.Application
 import com.badlogic.gdx.Gdx
 import com.unciv.logic.GameSaver
 
-data class WindowState (val width:Int=0, val height:Int=0)
+data class WindowState (val width: Int = 900, val height: Int = 600)
 
 class GameSettings {
     var showWorkedTiles: Boolean = false


### PR DESCRIPTION
@yairm210 I am sorry😄
This bug will appear in this condition:
At the first time you open the app, the file "GameSettings.json" doesn't exist, and then in the pick language screen you close the app directly, at this time although the file "GameSettings.json" have existed but WindowState's width and height = 0