### PR TITLE
Re-show redundant tech prereq mod errors without impeding playability

### DIFF
--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -250,10 +250,8 @@ class Ruleset {
         // Allows $this in format strings 
         override fun toString() = message
         // Readability shortcuts
-        val isError
-            get() = status == CheckModLinksStatus.Error
-        val isNotOK
-            get() = status != CheckModLinksStatus.OK
+        fun isError() = status == CheckModLinksStatus.Error
+        fun isNotOK() = status != CheckModLinksStatus.OK
     }
     fun checkModLinks(): CheckModLinksResult {
         val lines = ArrayList<String>()

--- a/core/src/com/unciv/ui/newgamescreen/ModCheckboxTable.kt
+++ b/core/src/com/unciv/ui/newgamescreen/ModCheckboxTable.kt
@@ -23,9 +23,9 @@ class ModCheckboxTable(val mods:LinkedHashSet<String>, val screen: CameraStageBa
             checkBox.onChange {
                 if (checkBox.isChecked) {
                     val modLinkErrors = mod.checkModLinks()
-                    if (modLinkErrors.isNotOK) {
+                    if (modLinkErrors.isNotOK()) {
                         ToastPopup("The mod you selected is incorrectly defined!\n\n$modLinkErrors", screen)
-                        if (modLinkErrors.isError) {
+                        if (modLinkErrors.isError()) {
                             checkBox.isChecked = false
                             return@onChange
                         }
@@ -45,7 +45,7 @@ class ModCheckboxTable(val mods:LinkedHashSet<String>, val screen: CameraStageBa
                         val newRuleset = RulesetCache.getComplexRuleset(mods)
                         newRuleset.modOptions.isBaseRuleset = true // This is so the checkModLinks finds all connections
                         complexModLinkCheck = newRuleset.checkModLinks()
-                        isCompatibleWithCurrentRuleset = !complexModLinkCheck.isError
+                        isCompatibleWithCurrentRuleset = !complexModLinkCheck.isError()
                     } catch (x: Exception) {
                         // This happens if a building is dependent on a tech not in the base ruleset
                         //  because newRuleset.updateBuildingCosts() in getComplexRuleset() throws an error

--- a/core/src/com/unciv/ui/worldscreen/mainmenu/OptionsPopup.kt
+++ b/core/src/com/unciv/ui/worldscreen/mainmenu/OptionsPopup.kt
@@ -249,11 +249,11 @@ class OptionsPopup(val previousScreen:CameraStageBaseScreen) : Popup(previousScr
             val lines = ArrayList<String>()
             for (mod in RulesetCache.values) {
                 val modLinks = mod.checkModLinks()
-                if (modLinks != "") {
+                if (modLinks.isNotOK) {
                     lines += ""
                     lines += mod.name
                     lines += ""
-                    lines += modLinks
+                    lines += modLinks.message
                     lines += ""
                 }
             }

--- a/core/src/com/unciv/ui/worldscreen/mainmenu/OptionsPopup.kt
+++ b/core/src/com/unciv/ui/worldscreen/mainmenu/OptionsPopup.kt
@@ -249,7 +249,7 @@ class OptionsPopup(val previousScreen:CameraStageBaseScreen) : Popup(previousScr
             val lines = ArrayList<String>()
             for (mod in RulesetCache.values) {
                 val modLinks = mod.checkModLinks()
-                if (modLinks.isNotOK) {
+                if (modLinks.isNotOK()) {
                     lines += ""
                     lines += mod.name
                     lines += ""

--- a/tests/src/com/unciv/testing/BasicTests.kt
+++ b/tests/src/com/unciv/testing/BasicTests.kt
@@ -81,8 +81,8 @@ class BasicTests {
     fun baseRulesetHasNoBugs() {
         ruleset.modOptions.isBaseRuleset=true
         val modCheck = ruleset.checkModLinks()
-        if(modCheck.isNotOK) println(modCheck)
-        Assert.assertFalse(modCheck.isNotOK)
+        if(modCheck.isNotOK()) println(modCheck)
+        Assert.assertFalse(modCheck.isNotOK())
     }
 
 }

--- a/tests/src/com/unciv/testing/BasicTests.kt
+++ b/tests/src/com/unciv/testing/BasicTests.kt
@@ -81,8 +81,8 @@ class BasicTests {
     fun baseRulesetHasNoBugs() {
         ruleset.modOptions.isBaseRuleset=true
         val modCheck = ruleset.checkModLinks()
-        if(modCheck!="") println(modCheck)
-        Assert.assertTrue(modCheck == "")
+        if(modCheck.isNotOK) println(modCheck)
+        Assert.assertFalse(modCheck.isNotOK)
     }
 
 }


### PR DESCRIPTION
Combination of my #4035 and your [commit a70bb43d](https://github.com/yairm210/Unciv/commit/a70bb43daefa7e05aa94aa4f796dcda8b6d3c9f5). Screenshot over there still applies.
DeCiv and the likes are nagged about in both options-modcheck and newgame, but can be played.
Would make adding other non-fatal checks in the future easier.

Not really important anymore, but if you like...