### PR TITLE
Unified exit game popups, removed obsolete closing handler

### DIFF
--- a/core/src/com/unciv/MainMenuScreen.kt
+++ b/core/src/com/unciv/MainMenuScreen.kt
@@ -14,7 +14,6 @@ import com.unciv.logic.map.MapSize
 import com.unciv.logic.map.MapSizeNew
 import com.unciv.logic.map.MapType
 import com.unciv.models.ruleset.RulesetCache
-import com.unciv.models.translations.tr
 import com.unciv.ui.MultiplayerScreen
 import com.unciv.ui.mapeditor.*
 import com.unciv.ui.newgamescreen.GameSetupInfo
@@ -22,7 +21,6 @@ import com.unciv.ui.newgamescreen.NewGameScreen
 import com.unciv.ui.pickerscreens.ModManagementScreen
 import com.unciv.ui.saves.LoadGameScreen
 import com.unciv.ui.utils.*
-import com.unciv.ui.worldscreen.mainmenu.OptionsPopup
 import kotlin.concurrent.thread
 
 class MainMenuScreen: CameraStageBaseScreen() {
@@ -128,13 +126,7 @@ class MainMenuScreen: CameraStageBaseScreen() {
                 closeAllPopups()
                 return@onBackButtonClicked
             }
-            val promptWindow = Popup(this)
-            promptWindow.addGoodSizedLabel("Do you want to exit the game?".tr())
-            promptWindow.row()
-            promptWindow.addButton("Yes") { Gdx.app.exit() }
-            promptWindow.addButton("No") { promptWindow.close() }
-            // show the dialog
-            promptWindow.open()     // true = always on top
+            ExitGamePopup(this)
         }
     }
 

--- a/core/src/com/unciv/ui/tutorials/TutorialController.kt
+++ b/core/src/com/unciv/ui/tutorials/TutorialController.kt
@@ -19,10 +19,7 @@ class TutorialController(screen: CameraStageBaseScreen) {
         showTutorialIfNeeded()
     }
 
-    fun removeTutorial(tutorialName: String) {
-        Tutorial.valueOf(tutorialName).let { removeTutorial(it) }
-    }
-    fun removeTutorial(tutorial: Tutorial) {
+    private fun removeTutorial(tutorial: Tutorial) {
         isTutorialShowing = false
         tutorialQueue.remove(tutorial)
         with(UncivGame.Current.settings) {

--- a/core/src/com/unciv/ui/tutorials/TutorialRender.kt
+++ b/core/src/com/unciv/ui/tutorials/TutorialRender.kt
@@ -28,13 +28,11 @@ class TutorialRender(private val screen: CameraStageBaseScreen) {
 
             tutorialPopup.addGoodSizedLabel(texts[0]).row()
 
-            val button = Constants.close.toTextButton()
-            button.onClick {
+            tutorialPopup.addCloseButton(additionalKey = KeyCharAndCode(' ')) {
                 tutorialPopup.remove()
                 texts.removeIndex(0)
                 showDialog(tutorialName, texts, closeAction)
             }
-            tutorialPopup.add(button).pad(10f)
             tutorialPopup.open()
         }
     }

--- a/core/src/com/unciv/ui/utils/Popup.kt
+++ b/core/src/com/unciv/ui/utils/Popup.kt
@@ -72,7 +72,7 @@ open class Popup(val screen: CameraStageBaseScreen): Table(CameraStageBaseScreen
     }
 
     /* All additions to the popup are to the inner table - we shouldn't care that there's an inner table at all */
-    override fun <T : Actor?> add(actor: T): Cell<T> = innerTable.add(actor)
+    final override fun <T : Actor?> add(actor: T): Cell<T> = innerTable.add(actor)
     override fun row(): Cell<Actor> = innerTable.row()
     fun addSeparator() = innerTable.addSeparator()
 

--- a/core/src/com/unciv/ui/utils/YesNoPopup.kt
+++ b/core/src/com/unciv/ui/utils/YesNoPopup.kt
@@ -1,5 +1,6 @@
 package com.unciv.ui.utils
 
+import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.Input
 import com.unciv.UncivGame
 
@@ -9,7 +10,7 @@ import com.unciv.UncivGame
  * @param screen The parent screen - see [Popup.screen]. Optional, defaults to the current [WorldScreen][com.unciv.ui.worldscreen.WorldScreen]
  * @param restoreDefault A lambda to execute when "No" is chosen
  */
-class YesNoPopup (
+open class YesNoPopup (
             question:String,
             action:()->Unit,
             screen: CameraStageBaseScreen = UncivGame.Current.worldScreen,
@@ -24,5 +25,17 @@ class YesNoPopup (
         addButtonInRow("No", 'n', no)
         keyPressDispatcher['\r'] = yes
         keyPressDispatcher[Input.Keys.BACK] = no
+    }
+}
+
+/** Shortcut to open a [YesNoPopup] with the exit game question */
+class ExitGamePopup(screen: CameraStageBaseScreen, force: Boolean = false)
+    : YesNoPopup (
+        question = "Do you want to exit the game?",
+        action = { Gdx.app.exit() },
+        screen = screen
+    ) {
+    init {
+        open(force)
     }
 }

--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -760,19 +760,6 @@ class WorldScreen(val gameInfo: GameInfo, val viewingCiv:CivilizationInfo) : Cam
 
     private fun backButtonAndESCHandler() {
 
-        // Since Popups including the Main Menu and the Options screen have no own back button
-        // listener and no trivial way to set one, back/esc with one of them open ends up here.
-        // Also, the reaction of other popups like 'disband this unit' to back/esc feels nicer this way.
-        // After removeListener just in case this is slow (enumerating all stage actors)
-        if (hasOpenPopups()) {
-            val closedName = closeOneVisiblePopup() ?: return
-            if (closedName.startsWith(Constants.tutorialPopupNamePrefix)) {
-                closedName.removePrefix(Constants.tutorialPopupNamePrefix)
-                tutorialController.removeTutorial(closedName)
-            }
-            return
-        }
-
         // Deselect Unit
         if (bottomUnitTable.selectedUnit != null) {
             bottomUnitTable.selectUnit()
@@ -789,13 +776,8 @@ class WorldScreen(val gameInfo: GameInfo, val viewingCiv:CivilizationInfo) : Cam
             return
         }
 
-        val promptWindow = Popup(this)
-        promptWindow.addGoodSizedLabel("Do you want to exit the game?".tr())
-        promptWindow.row()
-        promptWindow.addButton("Yes") { Gdx.app.exit() }
-        promptWindow.addButton("No") { promptWindow.close() }
-        // show the dialog
-        promptWindow.open(true)     // true = always on top
+        ExitGamePopup(this, true)
+
     }
 
 


### PR DESCRIPTION
Next step in the 'keyboard project'.
Only one exit game prompt - as YesNoPopup subclass. Side effect: arrangement of yes and no same as everywhere else - no, I think there's still maybe a popup asking yes and no but not using yesno out there... Those will be assimilated later.
Both analysis and testing shows the normal popup 'close' handling is sufficient for the tutorial logic - though I may have missed something? The comment was outdated anyway.