### PR TITLE
Map editor fix translations, a few keys

### DIFF
--- a/android/assets/jsons/translations/German.properties
+++ b/android/assets/jsons/translations/German.properties
@@ -818,8 +818,12 @@ Requires = Benötigt
 Menu = Menü
 Brush Size = Pinselgröße
 Map saved = Karte gespeichert
-Change ruleset = Ändere Regelsatz
-Change map to fit selected ruleset? = Karte ändern, um ausgewählten Regelsatz anzupassen?
+Change ruleset = Regelsatz ändern
+Base terrain [terrain] does not exist in ruleset! = Gelände [terrain] fehlt im Regelsatz!
+Terrain feature [feature] does not exist in ruleset! = Geländemerkmal [feature] fehlt im Regelsatz!
+Resource [resource] does not exist in ruleset! = Ressource [resource] fehlt im Regelsatz!
+Improvement [improvement] does not exist in ruleset! = Verbesserung [improvement] fehlt im Regelsatz!
+Change map to fit selected ruleset? = Karte ändern, um sie dem neuen Regelsatz anzupassen?
 
 # Civilopedia difficulty levels
 Player settings = Spieler Einstellungen

--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -813,6 +813,10 @@ Menu =
 Brush Size = 
 Map saved = 
 Change ruleset = 
+Base terrain [terrain] does not exist in ruleset! = 
+Terrain feature [feature] does not exist in ruleset! = 
+Resource [resource] does not exist in ruleset! = 
+Improvement [improvement] does not exist in ruleset! = 
 Change map to fit selected ruleset? = 
 
 # Civilopedia difficulty levels

--- a/core/src/com/unciv/logic/map/TileInfo.kt
+++ b/core/src/com/unciv/logic/map/TileInfo.kt
@@ -563,12 +563,15 @@ open class TileInfo {
 
     fun getRulesetIncompatibility(ruleset: Ruleset): HashSet<String> {
         val out = HashSet<String>()
-        if (!ruleset.terrains.containsKey(baseTerrain)) out.add("Base terrain $baseTerrain does not exist in ruleset!")
+        if (!ruleset.terrains.containsKey(baseTerrain))
+            out.add("Base terrain [$baseTerrain] does not exist in ruleset!")
         for (terrainFeature in terrainFeatures.filter { !ruleset.terrains.containsKey(it) })
-            out.add("Terrain feature $terrainFeature does not exist in ruleset!")
-        if (resource != null && !ruleset.tileResources.containsKey(resource)) out.add("Resource $resource does not exist in ruleset!")
+            out.add("Terrain feature [$terrainFeature] does not exist in ruleset!")
+        if (resource != null && !ruleset.tileResources.containsKey(resource))
+            out.add("Resource [$resource] does not exist in ruleset!")
         if (improvement != null && !improvement!!.startsWith("StartingLocation")
-                && !ruleset.tileImprovements.containsKey(improvement)) out.add("Improvement $improvement does not exist in ruleset!")
+                && !ruleset.tileImprovements.containsKey(improvement))
+            out.add("Improvement [$improvement] does not exist in ruleset!")
         return out
     }
 

--- a/core/src/com/unciv/ui/mapeditor/MapEditorMenuPopup.kt
+++ b/core/src/com/unciv/ui/mapeditor/MapEditorMenuPopup.kt
@@ -2,7 +2,6 @@ package com.unciv.ui.mapeditor
 
 import com.badlogic.gdx.scenes.scene2d.ui.ScrollPane
 import com.badlogic.gdx.scenes.scene2d.ui.Table
-import com.unciv.Constants
 import com.unciv.MainMenuScreen
 import com.unciv.UncivGame
 import com.unciv.models.ruleset.RulesetCache
@@ -12,12 +11,12 @@ import com.unciv.ui.utils.*
 class MapEditorMenuPopup(var mapEditorScreen: MapEditorScreen): Popup(mapEditorScreen) {
 
     init {
-        addButton("New map") { UncivGame.Current.setScreen(NewMapScreen(mapEditorScreen.tileMap.mapParameters)) }
-        addButton("Save map") { mapEditorScreen.game.setScreen(SaveAndLoadMapScreen(mapEditorScreen.tileMap, true, mapEditorScreen)); this.close() }
-        addButton("Load map") { mapEditorScreen.game.setScreen(SaveAndLoadMapScreen(mapEditorScreen.tileMap, false, mapEditorScreen)); this.close() }
-        addButton("Exit map editor") { mapEditorScreen.game.setScreen(MainMenuScreen()); mapEditorScreen.dispose() }
-        addButton("Change ruleset") { MapEditorRulesetPopup(mapEditorScreen).open(); close() }
-        addButton(Constants.close) { close() }
+        addButton("New map", 'n') { UncivGame.Current.setScreen(NewMapScreen(mapEditorScreen.tileMap.mapParameters)) }
+        addButton("Save map", 's') { mapEditorScreen.game.setScreen(SaveAndLoadMapScreen(mapEditorScreen.tileMap, true, mapEditorScreen)); this.close() }
+        addButton("Load map", 'l') { mapEditorScreen.game.setScreen(SaveAndLoadMapScreen(mapEditorScreen.tileMap, false, mapEditorScreen)); this.close() }
+        addButton("Exit map editor", 'x') { mapEditorScreen.game.setScreen(MainMenuScreen()); mapEditorScreen.dispose() }
+        addButton("Change ruleset", 'c') { MapEditorRulesetPopup(mapEditorScreen).open(); close() }
+        addCloseButton()
     }
 
     class MapEditorRulesetPopup(mapEditorScreen: MapEditorScreen) : Popup(mapEditorScreen) {
@@ -36,9 +35,9 @@ class MapEditorMenuPopup(var mapEditorScreen: MapEditorScreen): Popup(mapEditorS
                 ImageGetter.setNewRuleset(ruleset)
             }
 
-            add(ScrollPane(checkboxTable)).maxHeight(mapEditorScreen.stage.height * 0.8f).row()
+            add(ScrollPane(checkboxTable)).maxHeight(mapEditorScreen.stage.height * 0.8f).colspan(2).row()
 
-            addButton("Save") {
+            addButtonInRow("Save", '\r') {
                 val incompatibilities = HashSet<String>()
                 for (set in mapEditorScreen.tileMap.values.map { it.getRulesetIncompatibility(ruleset) })
                     incompatibilities.addAll(set)
@@ -47,24 +46,24 @@ class MapEditorMenuPopup(var mapEditorScreen: MapEditorScreen): Popup(mapEditorS
                 if (incompatibilities.isEmpty()) {
                     mapEditorScreen.tileMap.mapParameters.mods = mods
                     mapEditorScreen.game.setScreen(MapEditorScreen(mapEditorScreen.tileMap)) // reset all images etc.
-                    return@addButton
+                    return@addButtonInRow
                 }
 
-                val incompatTable = Table()
+                val incompatibilityTable = Table()
                 for (inc in incompatibilities)
-                    incompatTable.add(inc.toLabel()).row()
-                val incompatPopup = Popup(screen)
-                incompatPopup.add(ScrollPane(incompatTable)).maxHeight(stage.height * 0.8f).row()
-                incompatPopup.add("Change map to fit selected ruleset?").row()
-                incompatPopup.addButton("Yes") {
-                    for (tile in mapEditorScreen.tileMap.values)
-                        tile.normalizeToRuleset(ruleset)
-                    mapEditorScreen.tileMap.mapParameters.mods = mods
-                    mapEditorScreen.game.setScreen(MapEditorScreen(mapEditorScreen.tileMap))
-                }
-                incompatPopup.addButton("No") { incompatPopup.close() }
-                incompatPopup.open(true)
-
+                    incompatibilityTable.add(inc.toLabel()).row()
+                Popup(screen).apply {
+                    add(ScrollPane(incompatibilityTable)).colspan(2)
+                        .maxHeight(screen.stage.height * 0.8f).row()
+                    add("Change map to fit selected ruleset?".toLabel()).colspan(2).row()
+                    addButtonInRow("Yes", 'y') {
+                        for (tile in mapEditorScreen.tileMap.values)
+                            tile.normalizeToRuleset(ruleset)
+                        mapEditorScreen.tileMap.mapParameters.mods = mods
+                        mapEditorScreen.game.setScreen(MapEditorScreen(mapEditorScreen.tileMap))
+                    }
+                    addButtonInRow("No", 'n') { close() }
+                }.open(true)
             }
 
             // Reset - no changes

--- a/core/src/com/unciv/ui/mapeditor/MapEditorScreen.kt
+++ b/core/src/com/unciv/ui/mapeditor/MapEditorScreen.kt
@@ -1,10 +1,12 @@
 package com.unciv.ui.mapeditor
 
+import com.badlogic.gdx.Input
 import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.math.Vector2
 import com.badlogic.gdx.scenes.scene2d.InputEvent
 import com.badlogic.gdx.scenes.scene2d.InputListener
 import com.badlogic.gdx.scenes.scene2d.actions.Actions
+import com.unciv.UncivGame
 import com.unciv.logic.map.TileInfo
 import com.unciv.logic.map.TileMap
 import com.unciv.models.ruleset.Ruleset
@@ -34,6 +36,7 @@ class MapEditorScreen(): CameraStageBaseScreen() {
     private fun initialize() {
         ImageGetter.setNewRuleset(ruleset)
         tileMap.setTransients(ruleset,false)
+        UncivGame.Current.translations.translationActiveMods = ruleset.mods
 
         mapHolder = EditorMapHolder(this, tileMap)
         mapHolder.addTiles(stage.width, stage.height)
@@ -59,13 +62,13 @@ class MapEditorScreen(): CameraStageBaseScreen() {
                 stage.height - showHideEditorOptionsButton.height - 10f)
         stage.addActor(showHideEditorOptionsButton)
 
-
-        val optionsMenuButton = "Menu".toTextButton()
-        optionsMenuButton.onClick {
-            if (popups.any { it is MapEditorMenuPopup })
-                return@onClick // already open
-            MapEditorMenuPopup(this).open(force = true)
+        val openOptionsMenu = {
+            if (popups.none { it is MapEditorMenuPopup })
+                MapEditorMenuPopup(this).open(force = true)
         }
+        val optionsMenuButton = "Menu".toTextButton()
+        optionsMenuButton.onClick(openOptionsMenu)
+        keyPressDispatcher[Input.Keys.BACK] = openOptionsMenu
         optionsMenuButton.label.setFontSize(24)
         optionsMenuButton.labelCell.pad(20f)
         optionsMenuButton.pack()


### PR DESCRIPTION
- Currently the map editor ignores translations in its loaded mods
- The checks when changing mods lack translation support
- Back/ESC does nothing, some may expect a reaction

These changes allow e.g.:
![image](https://user-images.githubusercontent.com/63000004/120871454-f2db6780-c59b-11eb-8a2f-d4b2ba407fa8.png)
...the modded penguin hatchery _is_ now xlated.

German already included _for testing_.

@Mape6 FYI: Those two lines of yours I changed - this fits context better IMHO.