### PR TITLE
Refund wasted production as gold

### DIFF
--- a/android/assets/jsons/translations/Brazilian_Portuguese.properties
+++ b/android/assets/jsons/translations/Brazilian_Portuguese.properties
@@ -406,7 +406,7 @@ Locate mod errors =
 # Notifications
 
 Research of [technologyName] has completed! = A pesquisa de [technologyName] foi terminada!
-[construction] has been obsolete and will be removed from construction queue in [cityName]! = A [construction] está obsoleta e será removida da fila de construção em [cityName]!
+[construction] has become obsolete and was removed from the queue in [cityName]! = A [construction] está obsoleta e será removida da fila de construção em [cityName]!
 You have entered a Golden Age! = Você entrou em uma idade de ouro!
 [resourceName] revealed near [cityName] = [resourceName] revelado perto de [cityName]
  # Requires translation!

--- a/android/assets/jsons/translations/Bulgarian.properties
+++ b/android/assets/jsons/translations/Bulgarian.properties
@@ -398,7 +398,7 @@ Locate mod errors = Намиране на грешки в мод
 # Notifications
 
 Research of [technologyName] has completed! = Развитието на [technologyName] е готово!
-[construction] has been obsolete and will be removed from construction queue in [cityName]! = [construction] е твърде стара и ще бъде премахната от предстоящите разработки в [cityName]!
+[construction] has become obsolete and was removed from the queue in [cityName]! = [construction] е твърде стара и ще бъде премахната от предстоящите разработки в [cityName]!
 You have entered a Golden Age! = Навлизате в Златна Ера!
 [resourceName] revealed near [cityName] = [resourceName] се разкри близо до [cityName]
  # Requires translation!

--- a/android/assets/jsons/translations/Czech.properties
+++ b/android/assets/jsons/translations/Czech.properties
@@ -395,7 +395,7 @@ Locate mod errors = Lokalizovat chyby modu
 # Notifications
 
 Research of [technologyName] has completed! = Výzkum technologie [technologyName] byl dokončen!
-[construction] has been obsolete and will be removed from construction queue in [cityName]! = Položka [construction] je zastaralá a bude odstraněna z fronty ve městě [cityName]! 
+[construction] has become obsolete and was removed from the queue in [cityName]! = Položka [construction] je zastaralá a bude odstraněna z fronty ve městě [cityName]! 
 You have entered a Golden Age! = Započal Zlatý věk civilizace!
 [resourceName] revealed near [cityName] = Surovina [resourceName] objevena poblíž [cityName]
  # Requires translation!

--- a/android/assets/jsons/translations/Dutch.properties
+++ b/android/assets/jsons/translations/Dutch.properties
@@ -395,8 +395,8 @@ Locate mod errors = Zoek fouten in mods
 # Notifications
 
 Research of [technologyName] has completed! = [technologyName] is onderzocht!
-[construction] has been obsolete and will be removed from construction queue in [cityName]! = [construction] werd overbodig en zal verwijderd worden van de bouwwerkwachtrij in [cityName]!
-[construction] has been obsolete and will be removed from construction queue in [amount] cities! = [construction] werd overbodig en zal verwijderd worden van de bouwwerkwachtrij in [amount] steden!
+[construction] has become obsolete and was removed from the queue in [cityName]! = [construction] is overbodig geworden en in [cityName] van de wachtrij verwijderd!
+[construction] has become obsolete and was removed from the queue in [amount] cities! = [construction] is overbodig geworden en in [amount] steden van de wachtrij verwijderd!
 [cityName] changed production from [oldUnit] to [newUnit] = [cityName] heeft [oldUnit] productie omgezet in [newUnit] productie
 [amount] cities changed production from [oldUnit] to [newUnit] = [amount] steden hebben productie van [oldUnit] in [newUnit] veranderdt
 Excess production for [wonder] converted to [goldAmount] gold = Productie voor [wonder] omgezet naar [goldAmount] goud

--- a/android/assets/jsons/translations/Dutch.properties
+++ b/android/assets/jsons/translations/Dutch.properties
@@ -396,8 +396,10 @@ Locate mod errors = Zoek fouten in mods
 
 Research of [technologyName] has completed! = [technologyName] is onderzocht!
 [construction] has been obsolete and will be removed from construction queue in [cityName]! = [construction] werd overbodig en zal verwijderd worden van de bouwwerkwachtrij in [cityName]!
-[oldUnit] has been obsolete and production will be changed to [newUnit] in [cityName]! = [oldUnit] werd overbodig en productie zal omgezet worden naar [newUnit] in [cityName]!
-Could not continue work on [wonder], excess production converted to [goldAmount] gold = Kon niet verder werken aan [wonder], besteedde productie is omgezet naar [goldAmount] goud
+[construction] has been obsolete and will be removed from construction queue in [amount] cities! = [construction] werd overbodig en zal verwijderd worden van de bouwwerkwachtrij in [amount] steden!
+[cityName] changed production from [oldUnit] to [newUnit] = [cityName] heeft [oldUnit] productie omgezet in [newUnit] productie
+[amount] cities changed production from [oldUnit] to [newUnit] = [amount] steden hebben productie van [oldUnit] in [newUnit] veranderdt
+Excess production for [wonder] converted to [goldAmount] gold = Productie voor [wonder] omgezet naar [goldAmount] goud
 You have entered a Golden Age! = Een gouden eeuw is geariveerd!
 [resourceName] revealed near [cityName] = [resourceName] Ontdekt: in de buurt van [cityName]
  # Requires translation!

--- a/android/assets/jsons/translations/Dutch.properties
+++ b/android/assets/jsons/translations/Dutch.properties
@@ -396,6 +396,8 @@ Locate mod errors = Zoek fouten in mods
 
 Research of [technologyName] has completed! = [technologyName] is onderzocht!
 [construction] has been obsolete and will be removed from construction queue in [cityName]! = [construction] werd overbodig en zal verwijderd worden van de bouwwerkwachtrij in [cityName]!
+[oldUnit] has been obsolete and production will be changed to [newUnit] in [cityName]! = [oldUnit] werd overbodig en productie zal omgezet worden naar [newUnit] in [cityName]!
+Could not continue work on [wonder], excess production converted to [goldAmount] gold = Kon niet verder werken aan [wonder], besteedde productie is omgezet naar [goldAmount] goud
 You have entered a Golden Age! = Een gouden eeuw is geariveerd!
 [resourceName] revealed near [cityName] = [resourceName] Ontdekt: in de buurt van [cityName]
  # Requires translation!

--- a/android/assets/jsons/translations/English.properties
+++ b/android/assets/jsons/translations/English.properties
@@ -713,7 +713,7 @@ Locate mod errors =
  # Requires translation!
 Research of [technologyName] has completed! = 
  # Requires translation!
-[construction] has been obsolete and will be removed from construction queue in [cityName]! = 
+[construction] has become obsolete and was removed from the queue in [cityName]! = 
  # Requires translation!
 You have entered a Golden Age! = 
  # Requires translation!

--- a/android/assets/jsons/translations/Finnish.properties
+++ b/android/assets/jsons/translations/Finnish.properties
@@ -422,7 +422,7 @@ Locate mod errors =
 
 Research of [technologyName] has completed! = [technologyName] tutkittiin!
  # Requires translation!
-[construction] has been obsolete and will be removed from construction queue in [cityName]! = 
+[construction] has become obsolete and was removed from the queue in [cityName]! = 
 You have entered a Golden Age! = Sinulla on alkanut Kultakausi!
 [resourceName] revealed near [cityName] = [resourceName] paljastui lähellä [cityName]
  # Requires translation!

--- a/android/assets/jsons/translations/French.properties
+++ b/android/assets/jsons/translations/French.properties
@@ -397,7 +397,7 @@ Locate mod errors = Localise les erreurs dans les mods
 # Notifications
 
 Research of [technologyName] has completed! = Recherche de [technologyName] terminé !
-[construction] has been obsolete and will be removed from construction queue in [cityName]! = [construction] est obsolete et va être retiré de la queue de construction de [cityName] !
+[construction] has become obsolete and was removed from the queue in [cityName]! = [construction] est obsolete et va être retiré de la queue de construction de [cityName] !
 You have entered a Golden Age! = Vous êtes entré dans un Âge d'Or !
 [resourceName] revealed near [cityName] = [resourceName] découvert près de [cityName]
  # Requires translation!

--- a/android/assets/jsons/translations/German.properties
+++ b/android/assets/jsons/translations/German.properties
@@ -387,7 +387,7 @@ Locate mod errors = Mod-Fehler lokalisieren
 # Notifications
 
 Research of [technologyName] has completed! = [technologyName] wurde erforscht!
-[construction] has been obsolete and will be removed from construction queue in [cityName]! = [construction] ist veraltet und wird aus der Bauwerke-Warteschlange in [cityName] gelöscht!
+[construction] has become obsolete and was removed from the queue in [cityName]! = [construction] ist veraltet und wird aus der Bauwerke-Warteschlange in [cityName] gelöscht!
 You have entered a Golden Age! = Ein Goldenes Zeitalter hat begonnen!
 [resourceName] revealed near [cityName] = [resourceName] gefunden in der Nähe von [cityName]
 [n] sources of [resourceName] revealed, e.g. near [cityName] = [n] Vorkommen von [resourceName] aufgetaucht, z.B. nahe [cityName]

--- a/android/assets/jsons/translations/Hungarian.properties
+++ b/android/assets/jsons/translations/Hungarian.properties
@@ -404,7 +404,7 @@ Locate mod errors =
 # Notifications
 
 Research of [technologyName] has completed! = [technologyName] kutatása kész!
-[construction] has been obsolete and will be removed from construction queue in [cityName]! = [construction] termelése elavult és eltávolításra kerül [cityName] termelési sorából!
+[construction] has become obsolete and was removed from the queue in [cityName]! = [construction] termelése elavult és eltávolításra kerül [cityName] termelési sorából!
 You have entered a Golden Age! = Aranykorba léptél!
 [resourceName] revealed near [cityName] = [resourceName] tűnt fel [cityName] mellett
  # Requires translation!

--- a/android/assets/jsons/translations/Indonesian.properties
+++ b/android/assets/jsons/translations/Indonesian.properties
@@ -383,7 +383,7 @@ Locate mod errors = Temukan eror mod
 # Notifications
 
 Research of [technologyName] has completed! = Riset untuk [technologyName] sudah selesai
-[construction] has been obsolete and will be removed from construction queue in [cityName]! = [construction] sudah ketinggalan zaman dan akan dihapus dari antrean konstruksi di [cityName]!
+[construction] has become obsolete and was removed from the queue in [cityName]! = [construction] sudah ketinggalan zaman dan akan dihapus dari antrean konstruksi di [cityName]!
 You have entered a Golden Age! = Kamu telah memasuki masa kejayaan!
 [resourceName] revealed near [cityName] = [resourceName] terlihat di dekat [cityName]
 [n] sources of [resourceName] revealed, e.g. near [cityName] = [n] sumber daya [resourceName] ditemukan, salah satunya di dekat [cityName]

--- a/android/assets/jsons/translations/Italian.properties
+++ b/android/assets/jsons/translations/Italian.properties
@@ -383,7 +383,7 @@ Locate mod errors = Trova errori di mod
 # Notifications
 
 Research of [technologyName] has completed! = Abbiamo scoperto la tecnologia [technologyName]!
-[construction] has been obsolete and will be removed from construction queue in [cityName]! = [cityName] non può più costruire [construction]!
+[construction] has become obsolete and was removed from the queue in [cityName]! = [cityName] non può più costruire [construction]!
 You have entered a Golden Age! = È iniziata un'Età dell'Oro!
 [resourceName] revealed near [cityName] = Fonte di [resourceName] scoperta vicino a [cityName]
 [n] sources of [resourceName] revealed, e.g. near [cityName] = [n] fonti di [resourceName] scoperte nei pressi di [cityName]

--- a/android/assets/jsons/translations/Japanese.properties
+++ b/android/assets/jsons/translations/Japanese.properties
@@ -395,7 +395,7 @@ Locate mod errors = modのエラーを検出
 # Notifications
 
 Research of [technologyName] has completed! = [technologyName]の研究が完了
-[construction] has been obsolete and will be removed from construction queue in [cityName]! = [construction]は廃止され、[cityName]の建設キューから削除されます
+[construction] has become obsolete and was removed from the queue in [cityName]! = [construction]は廃止され、[cityName]の建設キューから削除されます
 You have entered a Golden Age! = あなたは黄金時代に入りました
 [resourceName] revealed near [cityName] = [cityName]の近くに[resourceName]が表れました
  # Requires translation!

--- a/android/assets/jsons/translations/Korean.properties
+++ b/android/assets/jsons/translations/Korean.properties
@@ -406,7 +406,7 @@ Locate mod errors =
 # Notifications
 
 Research of [technologyName] has completed! = [technologyName]의 연구가 끝났습니다!
-[construction] has been obsolete and will be removed from construction queue in [cityName]! = [construction]이(가) 쇠퇴하여 [cityName]의 대기열에서 삭제되었습니다!
+[construction] has become obsolete and was removed from the queue in [cityName]! = [construction]이(가) 쇠퇴하여 [cityName]의 대기열에서 삭제되었습니다!
 You have entered a Golden Age! = 황금기가 시작되었습니다!
 [resourceName] revealed near [cityName] = [cityName] 주변에서 [resourceName] 자원을 발견했습니다
  # Requires translation!

--- a/android/assets/jsons/translations/Lithuanian.properties
+++ b/android/assets/jsons/translations/Lithuanian.properties
@@ -428,7 +428,7 @@ Locate mod errors =
 
 Research of [technologyName] has completed! = [technologyName] tyrimas baigtas!
  # Requires translation!
-[construction] has been obsolete and will be removed from construction queue in [cityName]! = 
+[construction] has become obsolete and was removed from the queue in [cityName]! = 
 You have entered a Golden Age! = Jūs įžengėte į aukso amžių! 
 [resourceName] revealed near [cityName] = [resourceName] parodytas šalia [cityName]
  # Requires translation!

--- a/android/assets/jsons/translations/Malay.properties
+++ b/android/assets/jsons/translations/Malay.properties
@@ -484,7 +484,7 @@ Locate mod errors =
  # Requires translation!
 Research of [technologyName] has completed! = 
  # Requires translation!
-[construction] has been obsolete and will be removed from construction queue in [cityName]! = 
+[construction] has become obsolete and was removed from the queue in [cityName]! = 
  # Requires translation!
 You have entered a Golden Age! = 
  # Requires translation!

--- a/android/assets/jsons/translations/Persian_(Pinglish-DIN).properties
+++ b/android/assets/jsons/translations/Persian_(Pinglish-DIN).properties
@@ -419,7 +419,7 @@ Locate mod errors =
 
 Research of [technologyName] has completed! = Tahğig darbāre ye [technologyName] be natije resid!
  # Requires translation!
-[construction] has been obsolete and will be removed from construction queue in [cityName]! = 
+[construction] has become obsolete and was removed from the queue in [cityName]! = 
 You have entered a Golden Age! = Šomā vāred e yek asr e talāi šodid!
 [resourceName] revealed near [cityName] = [resourceName] kenār e [cityName] peydā šode ast
  # Requires translation!

--- a/android/assets/jsons/translations/Persian_(Pinglish-UN).properties
+++ b/android/assets/jsons/translations/Persian_(Pinglish-UN).properties
@@ -416,7 +416,7 @@ Locate mod errors =
 
 Research of [technologyName] has completed! = Tahghig darbaare ye [technologyName] be natije resid!
  # Requires translation!
-[construction] has been obsolete and will be removed from construction queue in [cityName]! = 
+[construction] has become obsolete and was removed from the queue in [cityName]! = 
 You have entered a Golden Age! = Shomaa vaared e yek asr e talaai shodid!
 [resourceName] revealed near [cityName] = [resourceName] kenaar e [cityName] peydaa shode ast
  # Requires translation!

--- a/android/assets/jsons/translations/Polish.properties
+++ b/android/assets/jsons/translations/Polish.properties
@@ -397,7 +397,7 @@ Locate mod errors = Zlokalizuj błędy modyfikacji
 # Notifications
 
 Research of [technologyName] has completed! = Ukończono badania: [technologyName]!
-[construction] has been obsolete and will be removed from construction queue in [cityName]! = [construction] - jest teraz przestarzały i zostanie usunięty z kolejki produkcji w mieście [cityName]!
+[construction] has become obsolete and was removed from the queue in [cityName]! = [construction] - jest teraz przestarzały i zostanie usunięty z kolejki produkcji w mieście [cityName]!
 You have entered a Golden Age! = Wkraczasz w Złotą Erę!
 [resourceName] revealed near [cityName] = Odkryto [resourceName] w pobliżu [cityName]
  # Requires translation!

--- a/android/assets/jsons/translations/Portuguese.properties
+++ b/android/assets/jsons/translations/Portuguese.properties
@@ -400,7 +400,7 @@ Locate mod errors =
 # Notifications
 
 Research of [technologyName] has completed! = A pesquisa de [technologyName] foi terminada!
-[construction] has been obsolete and will be removed from construction queue in [cityName]! = [construction] está obsoleta e será removida da fila de construção em [cityName]!
+[construction] has become obsolete and was removed from the queue in [cityName]! = [construction] está obsoleta e será removida da fila de construção em [cityName]!
 You have entered a Golden Age! = Você entrou em uma idade dourada!
 [resourceName] revealed near [cityName] = [resourceName] revelado perto de [cityName]
  # Requires translation!

--- a/android/assets/jsons/translations/Romanian.properties
+++ b/android/assets/jsons/translations/Romanian.properties
@@ -427,7 +427,7 @@ Locate mod errors =
 
 Research of [technologyName] has completed! = Cercetarea pentru [technologyName] s-a încheiat!
  # Requires translation!
-[construction] has been obsolete and will be removed from construction queue in [cityName]! = 
+[construction] has become obsolete and was removed from the queue in [cityName]! = 
 You have entered a Golden Age! = Ai intrat într-o epocă de aur!
 [resourceName] revealed near [cityName] = [resourceName] a fost dezvăluit lângă [cityName]
  # Requires translation!

--- a/android/assets/jsons/translations/Russian.properties
+++ b/android/assets/jsons/translations/Russian.properties
@@ -393,7 +393,7 @@ Locate mod errors = Ошибка в расположении мода
 # Notifications
 
 Research of [technologyName] has completed! = Исследование завершено: [technologyName]
-[construction] has been obsolete and will be removed from construction queue in [cityName]! = Юнит [construction] устарел и был убран из очереди в городе [cityName]!
+[construction] has become obsolete and was removed from the queue in [cityName]! = Юнит [construction] устарел и был убран из очереди в городе [cityName]!
 You have entered a Golden Age! = Вы вошли в золотой век!
 [resourceName] revealed near [cityName] = Ресурс [resourceName] обнаружен вблизи г. [cityName]
  # Requires translation!

--- a/android/assets/jsons/translations/Simplified_Chinese.properties
+++ b/android/assets/jsons/translations/Simplified_Chinese.properties
@@ -388,7 +388,7 @@ Locate mod errors = 定位模组错误
 # Notifications
 
 Research of [technologyName] has completed! = [technologyName]的研究已完成！
-[construction] has been obsolete and will be removed from construction queue in [cityName]! = [construction]已经过时，将从[cityName]里的建设列队中移除!
+[construction] has become obsolete and was removed from the queue in [cityName]! = [construction]已经过时，将从[cityName]里的建设列队中移除!
 You have entered a Golden Age! = 你开启了一个黄金时代！
 [resourceName] revealed near [cityName] = 我们在[cityName]附近发现了[resourceName] 
  # Requires translation!

--- a/android/assets/jsons/translations/Spanish.properties
+++ b/android/assets/jsons/translations/Spanish.properties
@@ -383,7 +383,7 @@ Locate mod errors = Encontrar errores en mods
 # Notifications
 
 Research of [technologyName] has completed! = ¡Investigación de [technologyName] completada!
-[construction] has been obsolete and will be removed from construction queue in [cityName]! = ¡[construction] ha quedado obsoleta y se eliminará de la cola de obras en [cityName]
+[construction] has become obsolete and was removed from the queue in [cityName]! = ¡[construction] ha quedado obsoleta y se eliminará de la cola de obras en [cityName]
 You have entered a Golden Age! = ¡Has entrado en una edad dorada!
 [resourceName] revealed near [cityName] = [resourceName] descubierto cerca de [cityName]
 [n] sources of [resourceName] revealed, e.g. near [cityName] = [n] fuentes de [resourceName] reveladas, e.j. cerca de [cityName]

--- a/android/assets/jsons/translations/Swedish.properties
+++ b/android/assets/jsons/translations/Swedish.properties
@@ -388,7 +388,7 @@ Locate mod errors = Hitta modfel
 # Notifications
 
 Research of [technologyName] has completed! = Forskning i [technologyName] fullbordat!
-[construction] has been obsolete and will be removed from construction queue in [cityName]! = [construction] är föråldrad och kommer tas bort från byggnadskön i [cityName]!
+[construction] has become obsolete and was removed from the queue in [cityName]! = [construction] är föråldrad och kommer tas bort från byggnadskön i [cityName]!
 You have entered a Golden Age! = Du har gått in i en Guldålder!
 [resourceName] revealed near [cityName] = [resourceName] upptäckt nära [cityName]
 [n] sources of [resourceName] revealed, e.g. near [cityName] = [n] källor till [resourceName] upptäckta, t ex nära [cityName]

--- a/android/assets/jsons/translations/Traditional_Chinese.properties
+++ b/android/assets/jsons/translations/Traditional_Chinese.properties
@@ -395,7 +395,7 @@ Locate mod errors = 定位模組錯誤
 # Notifications
 
 Research of [technologyName] has completed! = [technologyName]的研究已完成!
-[construction] has been obsolete and will be removed from construction queue in [cityName]! = [construction]已經過時，將從[cityName]裡的建設列隊中移除!
+[construction] has become obsolete and was removed from the queue in [cityName]! = [construction]已經過時，將從[cityName]裡的建設列隊中移除!
 You have entered a Golden Age! = 你開啟了一個黃金時代!
 [resourceName] revealed near [cityName] = 我們在[cityName]附近發現了[resourceName] 
  # Requires translation!

--- a/android/assets/jsons/translations/Turkish.properties
+++ b/android/assets/jsons/translations/Turkish.properties
@@ -392,7 +392,7 @@ Locate mod errors = Mod hatalarını bulun
 # Notifications
 
 Research of [technologyName] has completed! = [technologyName] araştırması tamamlandı!
-[construction] has been obsolete and will be removed from construction queue in [cityName]! = [construction] yapısı eskidi, [cityName] şehrindeki inşaat sırasından kaldırılacak!
+[construction] has become obsolete and was removed from the queue in [cityName]! = [construction] yapısı eskidi, [cityName] şehrindeki inşaat sırasından kaldırılacak!
 You have entered a Golden Age! = Altın Çağ'a girdiniz!
 [resourceName] revealed near [cityName] = [resourceName], [cityName] yakınlarında görüldü
  # Requires translation!

--- a/android/assets/jsons/translations/Ukrainian.properties
+++ b/android/assets/jsons/translations/Ukrainian.properties
@@ -397,7 +397,7 @@ Locate mod errors = Знайти помилки модифікації
 # Notifications
 
 Research of [technologyName] has completed! = [technologyName]: досліджено!
-[construction] has been obsolete and will be removed from construction queue in [cityName]! = Підрозділ «[construction]» застарів та був видалений з черги у місті [cityName]!
+[construction] has become obsolete and was removed from the queue in [cityName]! = Підрозділ «[construction]» застарів та був видалений з черги у місті [cityName]!
 You have entered a Golden Age! = Розпочалась Золота доба!
 [resourceName] revealed near [cityName] = [resourceName] виявлено біля [cityName]
  # Requires translation!

--- a/android/assets/jsons/translations/Vietnamese.properties
+++ b/android/assets/jsons/translations/Vietnamese.properties
@@ -418,7 +418,7 @@ Translation files are generated successfully. = Các tệp dịch thuật đã �
 # Notifications
 
 Research of [technologyName] has completed! = [technologyName] đã được nguyên cứu thành công!
-[construction] has been obsolete and will be removed from construction queue in [cityName]! = [construction] đã lỗi thời và sẽ được hủy bỏ trong hàng chờ thi công tại [cityName]!
+[construction] has become obsolete and was removed from the queue in [cityName]! = [construction] đã lỗi thời và sẽ được hủy bỏ trong hàng chờ thi công tại [cityName]!
 You have entered a Golden Age! = Bạn đã bước vào Thời kì Hoàng kim!
 [resourceName] revealed near [cityName] = [resourceName] được hiện lên gần [cityName]
 A [greatPerson] has been born in [cityName]! = Một [greatPerson] đã được sinh ra ở [cityName]!

--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -385,6 +385,8 @@ Locate mod errors =
 
 Research of [technologyName] has completed! = 
 [construction] has been obsolete and will be removed from construction queue in [cityName]! = 
+[oldUnit] has been obsolete and production will be changed to [newUnit] in [cityName]! = 
+Could not continue work on [wonder], excess production converted to [goldAmount] gold = 
 You have entered a Golden Age! = 
 [resourceName] revealed near [cityName] = 
 [n] sources of [resourceName] revealed, e.g. near [cityName] = 

--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -384,8 +384,8 @@ Locate mod errors =
 # Notifications
 
 Research of [technologyName] has completed! = 
-[construction] has been obsolete and will be removed from construction queue in [cityName]! = 
-[construction] has been obsolete and will be removed from construction queue in [amount] cities! = 
+[construction] has become obsolete and was removed from the queue in [cityName]! = 
+[construction] has become obsolete and was removed from the queue in [amount] cities! = 
 [cityName] changed production from [oldUnit] to [newUnit] = 
 [amount] cities changed production from [oldUnit] to [newUnit] = 
 Excess production for [wonder] converted to [goldAmount] gold = 

--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -385,8 +385,10 @@ Locate mod errors =
 
 Research of [technologyName] has completed! = 
 [construction] has been obsolete and will be removed from construction queue in [cityName]! = 
-[oldUnit] has been obsolete and production will be changed to [newUnit] in [cityName]! = 
-Could not continue work on [wonder], excess production converted to [goldAmount] gold = 
+[construction] has been obsolete and will be removed from construction queue in [amount] cities! = 
+[cityName] changed production from [oldUnit] to [newUnit] = 
+[amount] cities changed production from [oldUnit] to [newUnit] = 
+Excess production for [wonder] converted to [goldAmount] gold = 
 You have entered a Golden Age! = 
 [resourceName] revealed near [cityName] = 
 [n] sources of [resourceName] revealed, e.g. near [cityName] = 

--- a/core/src/com/unciv/logic/city/CityConstructions.kt
+++ b/core/src/com/unciv/logic/city/CityConstructions.kt
@@ -329,7 +329,7 @@ class CityConstructions {
                     if (construction.isWonder && getWorkDone(constructionName) != 0) {
                         cityInfo.civInfo.gold += getWorkDone(constructionName)
                         val buildingIcon = "BuildingIcons/${constructionName}"
-                        cityInfo.civInfo.addNotification("Could not continue work on [${constructionName}], excess production converted to [${getWorkDone(constructionName)}] gold", NotificationIcon.Gold, buildingIcon)
+                        cityInfo.civInfo.addNotification("Excess production for [$constructionName] converted to [${getWorkDone(constructionName)}] gold", NotificationIcon.Gold, buildingIcon)
                     }
                 } else if (construction is BaseUnit) {
                     // Production put into upgradable units gets put into upgraded version

--- a/core/src/com/unciv/logic/city/CityConstructions.kt
+++ b/core/src/com/unciv/logic/city/CityConstructions.kt
@@ -334,6 +334,7 @@ class CityConstructions {
                 } else if (construction is BaseUnit) {
                     // Production put into upgradable units gets put into upgraded version
                     if (rejectionReason.startsWith("Obsolete") && construction.upgradesTo != null) {
+                        // I'd love to use the '+=' operator but since 'inProgressConstructions[...]' can be null, kotlin doesn't allow me to
                         if (!inProgressConstructions.contains(construction.upgradesTo)) {
                             inProgressConstructions[construction.upgradesTo!!] = getWorkDone(constructionName)
                         } else {

--- a/core/src/com/unciv/logic/city/CityConstructions.kt
+++ b/core/src/com/unciv/logic/city/CityConstructions.kt
@@ -272,6 +272,9 @@ class CityConstructions {
     fun constructIfEnough() {
         validateConstructionQueue()
 
+        // Update InProgressConstructions for any available refunds
+        validateInProgressConstructions()
+
         val construction = getConstruction(currentConstructionFromQueue)
         if (construction is PerpetualConstruction) chooseNextConstruction() // check every turn if we could be doing something better, because this doesn't end by itself
         else {
@@ -296,16 +299,16 @@ class CityConstructions {
         val queueSnapshot = constructionQueue.toMutableList()
         constructionQueue.clear()
 
-        for (construction in queueSnapshot) {
-            if (getConstruction(construction).isBuildable(this))
-                constructionQueue.add(construction)
+        for (constructionName in queueSnapshot) {
+            if (getConstruction(constructionName).isBuildable(this))
+                constructionQueue.add(constructionName)
         }
     }
 
     private fun validateInProgressConstructions() {
         // remove obsolete stuff from in progress constructions - happens often and leaves clutter in memory and save files
-        // should have NO visible consequences - any accumulated points that may be reused later should stay (nukes when manhattan project city lost, nat wonder when conquered an empty city...)
-        // Needs only be called once in a while - endTurn is enough
+        // should have little visible consequences - any accumulated points that may be reused later should stay (nukes when manhattan project city lost, nat wonder when conquered an empty city...), all other points should be refunded
+        // Should at least be called before each turn - if another civ completes a wonder after our previous turn, we should get the refund this turn
         val inProgressSnapshot = inProgressConstructions.keys.filter { it != currentConstructionFromQueue }
         for (constructionName in inProgressSnapshot) {
             val rejectionReason: String =
@@ -319,7 +322,10 @@ class CityConstructions {
                     || rejectionReason.startsWith("Cannot be built with")
                     || rejectionReason.startsWith("Don't need to build any more")
                     || rejectionReason.startsWith("Obsolete")
-            ) inProgressConstructions.remove(constructionName)
+            ) {
+              cityInfo.civInfo.gold += getWorkDone(constructionName)
+              inProgressConstructions.remove(constructionName)
+            }
         }
     }
 

--- a/core/src/com/unciv/logic/civilization/TechManager.kt
+++ b/core/src/com/unciv/logic/civilization/TechManager.kt
@@ -1,5 +1,6 @@
 package com.unciv.logic.civilization
 
+import com.unciv.logic.civilization.LocationAction
 import com.unciv.logic.city.CityInfo
 import com.unciv.logic.map.MapSize
 import com.unciv.logic.map.RoadStatus
@@ -263,22 +264,46 @@ class TechManager {
         if (civInfo.playerType == PlayerType.Human) notifyRevealedResources(techName)
 
         val obsoleteUnits = getRuleset().units.values.filter { it.obsoleteTech == techName }.map { it.name }
+        val unitUpgrades = HashMap<String, ArrayList<CityInfo>>()
         for (city in civInfo.cities) {
             // Do not use replaceAll - that's a Java 8 feature and will fail on older phones!
             val oldQueue = city.cityConstructions.constructionQueue.toList()  // copy, since we're changing the queue
             city.cityConstructions.constructionQueue.clear()
             for (constructionName in oldQueue) {
                 if (constructionName in obsoleteUnits) {
+                    if (constructionName !in unitUpgrades.keys) {
+                        unitUpgrades[constructionName] = ArrayList<CityInfo>()
+                    }
+                    unitUpgrades[constructionName]?.add(city)
                     val construction = city.cityConstructions.getConstruction(constructionName)
                     if (construction is BaseUnit && construction.upgradesTo != null) {
-                        val text = "[${constructionName}] has been obsolete and production will be changed to [${construction.upgradesTo!!}] in [${city.name}]!"
-                        civInfo.addNotification(text, city.location, constructionName, NotificationIcon.Construction, construction.upgradesTo!!)
                         city.cityConstructions.constructionQueue.add(construction.upgradesTo!!)
-                    } else {
-                        val text = "[$constructionName] has been obsolete and will be removed from construction queue in [${city.name}]!"
-                        civInfo.addNotification(text, city.location, NotificationIcon.Construction)
                     }
                 } else city.cityConstructions.constructionQueue.add(constructionName)
+            }
+        }
+
+        // Add notifications for obsolete units/constructions
+        for ((unit, cities) in unitUpgrades) {
+            val construction = cities[0].cityConstructions.getConstruction(unit)
+            if (cities.size == 1) {
+                val city = cities[0]
+                if (construction is BaseUnit && construction.upgradesTo != null) {
+                    val text = "[${city.name}] changed production from [$unit] to [${construction.upgradesTo!!}]"
+                    civInfo.addNotification(text, city.location, unit, NotificationIcon.Construction, construction.upgradesTo!!)
+                } else {
+                    val text = "[$unit] has been obsolete and will be removed from construction queue in [${city.name}]!"
+                    civInfo.addNotification(text, city.location, NotificationIcon.Construction)
+                }
+            } else {
+                val locationAction = LocationAction(cities.map { it.location })
+                if (construction is BaseUnit && construction.upgradesTo != null) {
+                    val text = "[${cities.size}] cities changed production from [$unit] to [${construction.upgradesTo!!}]"
+                    civInfo.addNotification(text, locationAction, unit, NotificationIcon.Construction, construction.upgradesTo!!)
+                } else {
+                    val text = "[$unit] has been obsolete and will be removed from construction queue in [${cities.size}] cities!"
+                    civInfo.addNotification(text, locationAction, NotificationIcon.Construction)
+                }
             }
         }
 

--- a/core/src/com/unciv/logic/civilization/TechManager.kt
+++ b/core/src/com/unciv/logic/civilization/TechManager.kt
@@ -292,7 +292,7 @@ class TechManager {
                     val text = "[${city.name}] changed production from [$unit] to [${construction.upgradesTo!!}]"
                     civInfo.addNotification(text, city.location, unit, NotificationIcon.Construction, construction.upgradesTo!!)
                 } else {
-                    val text = "[$unit] has been obsolete and will be removed from construction queue in [${city.name}]!"
+                    val text = "[$unit] has become obsolete and was removed from the queue in [${city.name}]!"
                     civInfo.addNotification(text, city.location, NotificationIcon.Construction)
                 }
             } else {
@@ -301,7 +301,7 @@ class TechManager {
                     val text = "[${cities.size}] cities changed production from [$unit] to [${construction.upgradesTo!!}]"
                     civInfo.addNotification(text, locationAction, unit, NotificationIcon.Construction, construction.upgradesTo!!)
                 } else {
-                    val text = "[$unit] has been obsolete and will be removed from construction queue in [${cities.size}] cities!"
+                    val text = "[$unit] has become osbolete and was removed from the queue in [${cities.size}] cities!"
                     civInfo.addNotification(text, locationAction, NotificationIcon.Construction)
                 }
             }

--- a/core/src/com/unciv/logic/civilization/TechManager.kt
+++ b/core/src/com/unciv/logic/civilization/TechManager.kt
@@ -6,6 +6,7 @@ import com.unciv.logic.map.RoadStatus
 import com.unciv.logic.map.TileInfo
 import com.unciv.models.ruleset.Unique
 import com.unciv.models.ruleset.UniqueTriggerActivation
+import com.unciv.models.ruleset.unit.BaseUnit
 import com.unciv.models.ruleset.tech.Technology
 import com.unciv.ui.utils.withItem
 import java.util.*
@@ -268,8 +269,15 @@ class TechManager {
             city.cityConstructions.constructionQueue.clear()
             for (constructionName in oldQueue) {
                 if (constructionName in obsoleteUnits) {
-                    val text = "[$constructionName] has been obsolete and will be removed from construction queue in [${city.name}]!"
-                    civInfo.addNotification(text, city.location, NotificationIcon.Construction)
+                    val construction = city.cityConstructions.getConstruction(constructionName)
+                    if (construction is BaseUnit && construction.upgradesTo != null) {
+                        val text = "[${constructionName}] has been obsolete and production will be changed to [${construction.upgradesTo!!}] in [${city.name}]!"
+                        civInfo.addNotification(text, city.location, constructionName, NotificationIcon.Construction, construction.upgradesTo!!)
+                        city.cityConstructions.constructionQueue.add(construction.upgradesTo!!)
+                    } else {
+                        val text = "[$constructionName] has been obsolete and will be removed from construction queue in [${city.name}]!"
+                        civInfo.addNotification(text, city.location, NotificationIcon.Construction)
+                    }
                 } else city.cityConstructions.constructionQueue.add(constructionName)
             }
         }


### PR DESCRIPTION
Any wasted production, from for instance a partially completed wonder or obsolete units, will now be refunded as gold (in a 1:1 ratio). When obsolete units get replaced by their new version, this code should probably be updated.

I first added the gold refund code in `validateInProgressConstructions`, but this function is only called upon `endTurn`. Hence a refund for a wonder build elsewhere would occur after the relevant turn instead of before the turn. Hence the implementation is now put in `validateConstructionQueue`.

The current implementation does result in code duplication between `validateInProgressConstructions` and `validateConstructionQueue`. Any ideas on how to neatly remove this duplication are appreciated.

Another thing to consider would be a notification/popup explaining why the gold was added, but this probably clutters the interface too much.

Fixes #4047