### PR TITLE
TileInfoTable translation and padding

### DIFF
--- a/core/src/com/unciv/logic/city/CityConstructions.kt
+++ b/core/src/com/unciv/logic/city/CityConstructions.kt
@@ -157,7 +157,7 @@ class CityConstructions {
                 CivilopediaCategories.Unit.name
             else -> ""
         }
-        var label = currentConstructionSnapshot
+        var label = "{$currentConstructionSnapshot}"
         if (!PerpetualConstruction.perpetualConstructionsMap.containsKey(currentConstructionSnapshot)) {
             val turnsLeft = turnsToConstruction(currentConstructionSnapshot)
             label += " - $turnsLeft${Fonts.turn}"

--- a/core/src/com/unciv/ui/cityscreen/CityScreenTileTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityScreenTileTable.kt
@@ -37,7 +37,7 @@ class CityScreenTileTable(private val cityScreen: CityScreen): Table() {
         innerTable.add( MarkupRenderer.render(selectedTile.toMarkup(city.civInfo)) {
             // Sorry, this will leave the city screen
             UncivGame.Current.setScreen(CivilopediaScreen(city.civInfo.gameInfo.ruleSet, link = it))
-        } ).colspan(2)
+        } )
         innerTable.row()
         innerTable.add(getTileStatsTable(stats)).row()
 
@@ -57,7 +57,7 @@ class CityScreenTileTable(private val cityScreen: CityScreen): Table() {
                     || !cityScreen.canChangeState)
                 buyTileButton.disable()
 
-            innerTable.add(buyTileButton).row()
+            innerTable.add(buyTileButton).padTop(5f).row()
         }
 
         if (city.civInfo.cities.filterNot { it == city }.any { it.isWorked(selectedTile) })
@@ -72,7 +72,7 @@ class CityScreenTileTable(private val cityScreen: CityScreen): Table() {
                     cityScreen.update()
                 }
                 if (!cityScreen.canChangeState) unlockButton.disable()
-                innerTable.add(unlockButton).row()
+                innerTable.add(unlockButton).padTop(5f).row()
             } else {
                 val lockButton = "Lock".toTextButton()
                 lockButton.onClick {
@@ -81,7 +81,7 @@ class CityScreenTileTable(private val cityScreen: CityScreen): Table() {
                     cityScreen.update()
                 }
                 if (!cityScreen.canChangeState) lockButton.disable()
-                innerTable.add(lockButton).row()
+                innerTable.add(lockButton).padTop(5f).row()
             }
         }
         if (selectedTile.isCityCenter() && selectedTile.getCity() != city && selectedTile.getCity()!!.civInfo == city.civInfo)

--- a/core/src/com/unciv/ui/civilopedia/CivilopediaText.kt
+++ b/core/src/com/unciv/ui/civilopedia/CivilopediaText.kt
@@ -84,10 +84,11 @@ object MarkupRenderer {
     fun render(
         lines: Collection<FormattedLine>,
         labelWidth: Float = 0f,
+        padding: Float = defaultPadding,
         linkAction: ((id: String) -> Unit)? = null
     ): Table {
         val skin = CameraStageBaseScreen.skin
-        val table = Table(skin).apply { defaults().pad(defaultPadding).align(Align.left) }
+        val table = Table(skin).apply { defaults().pad(padding).align(Align.left) }
         for (line in lines) {
             if (line.isEmpty()) {
                 table.add().padTop(emptyLineHeight).row()

--- a/core/src/com/unciv/ui/worldscreen/bottombar/TileInfoTable.kt
+++ b/core/src/com/unciv/ui/worldscreen/bottombar/TileInfoTable.kt
@@ -22,9 +22,9 @@ class TileInfoTable(private val viewingCiv :CivilizationInfo) : Table(CameraStag
 
         if (tile != null && (UncivGame.Current.viewEntireMapForDebug || viewingCiv.exploredTiles.contains(tile.position)) ) {
             add(getStatsTable(tile))
-            add( MarkupRenderer.render(tile.toMarkup(viewingCiv) ) {
+            add( MarkupRenderer.render(tile.toMarkup(viewingCiv), padding = 0f) {
                 UncivGame.Current.setScreen(CivilopediaScreen(viewingCiv.gameInfo.ruleSet, link = it))
-            } ).pad(10f)
+            } ).pad(5f)
             // For debug only!
 //            add(tile.position.toString().toLabel()).colspan(2).pad(10f)
         }
@@ -36,10 +36,14 @@ class TileInfoTable(private val viewingCiv :CivilizationInfo) : Table(CameraStag
         val table = Table()
         table.defaults().pad(2f)
 
+        // padLeft = padRight + 5: for symmetry. An extra 5 for the distance yield number to
+        // tile text comes from the pad up there in updateTileTable
         for (entry in tile.getTileStats(viewingCiv).toHashMap()
                 .filterNot { it.value == 0f || it.key.toString() == "" }) {
-            table.add(ImageGetter.getStatIcon(entry.key.toString())).size(20f).align(Align.right)
-            table.add(entry.value.toInt().toString().toLabel()).align(Align.left).padRight(10f)
+            table.add(ImageGetter.getStatIcon(entry.key.toString()))
+                .size(20f).align(Align.right).padLeft(10f)
+            table.add(entry.value.toInt().toLabel())
+                .align(Align.left).padRight(5f)
             table.row()
         }
         return table


### PR DESCRIPTION
Should resolve #4053 
The diff in `CityConstructions.kt` and removing `.colspan(2)` in `CityScreenTileTable.kt` would be actual bugs, the rest just redistribution of padding.