### PR TITLE
Make CivilizationInfo.gold read-only

### DIFF
--- a/core/src/com/unciv/logic/city/CityConstructions.kt
+++ b/core/src/com/unciv/logic/city/CityConstructions.kt
@@ -327,7 +327,7 @@ class CityConstructions {
                 if (construction is Building) {
                     // Production put into wonders gets refunded
                     if (construction.isWonder && getWorkDone(constructionName) != 0) {
-                        cityInfo.civInfo.gold += getWorkDone(constructionName)
+                        cityInfo.civInfo.addGold( getWorkDone(constructionName) )
                         val buildingIcon = "BuildingIcons/${constructionName}"
                         cityInfo.civInfo.addNotification("Excess production for [$constructionName] converted to [${getWorkDone(constructionName)}] gold", NotificationIcon.Gold, buildingIcon)
                     }

--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -70,6 +70,7 @@ class CivilizationInfo {
 
     /** Used in online multiplayer for human players */
     var playerId = ""
+    /** The Civ's gold reserves. Public get, private set - please use [addGold] method to modify. */
     var gold = 0
         private set
     var civName = ""
@@ -544,7 +545,11 @@ class CivilizationInfo {
         updateHasActiveGreatWall()
     }
 
+    /** Modify gold by a given amount making sure it does neither overflow nor underflow.
+     * @param delta the amount to add (can be negative) 
+     */
     fun addGold(delta: Int) {
+        // not using Long.coerceIn - this stays in 32 bits
         gold = when {
             delta > 0 && gold > Int.MAX_VALUE - delta -> Int.MAX_VALUE
             delta < 0 && gold < Int.MIN_VALUE - delta -> Int.MIN_VALUE

--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -71,6 +71,7 @@ class CivilizationInfo {
     /** Used in online multiplayer for human players */
     var playerId = ""
     var gold = 0
+        private set
     var civName = ""
     var tech = TechManager()
     var policies = PolicyManager()


### PR DESCRIPTION
#4065: 
> don't set the value directly

In that case the new `gold+=` from 'refund' should be treated and made sure the next dev knows the method is mandatory...

Btw, PolicyManager.storedCulture works with private set as is...