### PR TITLE
Updated Tradition branch to G&K

### DIFF
--- a/android/assets/jsons/Civ V - Vanilla/Buildings.json
+++ b/android/assets/jsons/Civ V - Vanilla/Buildings.json
@@ -52,7 +52,7 @@
 		"name": "Library",
 		"hurryCostModifier": 25,
 		"maintenance": 1,
-		"uniques": ["[+1 Science] Per [2] Population in this city"],
+		"uniques": ["[+1 Science] Per [2] Population [in this city]"],
 		"requiredTech": "Writing"
 	},
 	{
@@ -72,7 +72,7 @@
 		"uniqueTo": "China",
 		"hurryCostModifier": 25,
 		"gold": 2,
-		"uniques": ["[+1 Science] Per [2] Population in this city"],
+		"uniques": ["[+1 Science] Per [2] Population [in this city]"],
 		"requiredTech": "Writing"
 	},
 	{
@@ -752,7 +752,7 @@
 		"requiredBuilding": "University",
 		"maintenance": 3,
 		"hurryCostModifier": 0,
-		"uniques": ["[+1 Science] Per [2] Population in this city"],
+		"uniques": ["[+1 Science] Per [2] Population [in this city]"],
 		"requiredTech": "Scientific Theory"
 	},
 	{

--- a/android/assets/jsons/Civ V - Vanilla/Policies.json
+++ b/android/assets/jsons/Civ V - Vanilla/Policies.json
@@ -12,13 +12,13 @@
 			},
 			{
 				"name": "Legalism",
-				"uniques":["Immediately creates a cheapest available cultural building in each of your first 4 cities for free"],
+				"uniques":["Immediately creates the cheapest available cultural building in each of your first [4] cities for free"],
 				"row": 1,
 				"column": 3
 			},
 			{
 				"name": "Oligarchy",
-				"uniques": ["Units in cities cost no Maintenance", "+50% attacking strength for cities with garrisoned units"],
+				"uniques": ["Units in cities cost no Maintenance", "+[50]% attacking strength for cities with garrisoned units"],
 				"row": 1,
 				"column": 5
 			},
@@ -38,7 +38,7 @@
 			},
 			{
 				"name": "Tradition Complete",
-				"uniques": ["+[15]% growth [in all cities]","[+2 Food] [in all cities]"]
+				"uniques": ["+[15]% growth [in all cities]","Immediately creates a [Aqueduct] in each of your first [4] cities for free"]
 			}
 		]
 	},

--- a/android/assets/jsons/Civ V - Vanilla/Policies.json
+++ b/android/assets/jsons/Civ V - Vanilla/Policies.json
@@ -6,7 +6,7 @@
 		"policies": [
 			{
 				"name": "Aristocracy",
-				"uniques": ["+[15]% Production when constructing [Wonders]", "[+1 Happiness] per [10] population in all cities"],
+				"uniques": ["+[15]% Production when constructing [Wonders]", "[+1 Happiness] per [10] population [in all cities]"],
 				"row": 1,
 				"column": 1
 			},

--- a/core/src/com/unciv/logic/battle/BattleDamage.kt
+++ b/core/src/com/unciv/logic/battle/BattleDamage.kt
@@ -167,9 +167,9 @@ object BattleDamage {
                 modifiers["Statue of Zeus"] = 15
         } else if (attacker is CityCombatant) {
             if (attacker.city.getCenterTile().militaryUnit != null) {
-                val olichargyBonus = attacker.getCivInfo().getMatchingUniques("+[]% attacking strength for cities with garrisoned units")
-                    .fold(0) { sum, it -> sum + it.params[0].toInt() }
-                if (olichargyBonus != 0)
+                val garrisonBonus = attacker.getCivInfo().getMatchingUniques("+[]% attacking strength for cities with garrisoned units")
+                    .map {it.params[0].toInt()}.sum()
+                if (garrisonBonus != 0)
                     modifiers["Garrisoned unit"] = olichargyBonus
             }
         }

--- a/core/src/com/unciv/logic/battle/BattleDamage.kt
+++ b/core/src/com/unciv/logic/battle/BattleDamage.kt
@@ -166,11 +166,12 @@ object BattleDamage {
             )
                 modifiers["Statue of Zeus"] = 15
         } else if (attacker is CityCombatant) {
-            if (attacker.getCivInfo()
-                    .hasUnique("+50% attacking strength for cities with garrisoned units")
-                && attacker.city.getCenterTile().militaryUnit != null
-            )
-                modifiers["Oligarchy"] = 50
+            if (attacker.city.getCenterTile().militaryUnit != null) {
+                val olichargyBonus = attacker.getCivInfo().getMatchingUniques("+[]% attacking strength for cities with garrisoned units")
+                    .fold(0) { sum, it -> sum + it.params[0].toInt() }
+                if (olichargyBonus != 0)
+                    modifiers["Garrisoned unit"] = olichargyBonus
+            }
         }
 
         return modifiers

--- a/core/src/com/unciv/logic/battle/BattleDamage.kt
+++ b/core/src/com/unciv/logic/battle/BattleDamage.kt
@@ -170,7 +170,7 @@ object BattleDamage {
                 val garrisonBonus = attacker.getCivInfo().getMatchingUniques("+[]% attacking strength for cities with garrisoned units")
                     .map {it.params[0].toInt()}.sum()
                 if (garrisonBonus != 0)
-                    modifiers["Garrisoned unit"] = olichargyBonus
+                    modifiers["Garrisoned unit"] = garrisonBonus
             }
         }
 

--- a/core/src/com/unciv/logic/battle/BattleDamage.kt
+++ b/core/src/com/unciv/logic/battle/BattleDamage.kt
@@ -168,7 +168,7 @@ object BattleDamage {
         } else if (attacker is CityCombatant) {
             if (attacker.city.getCenterTile().militaryUnit != null) {
                 val garrisonBonus = attacker.getCivInfo().getMatchingUniques("+[]% attacking strength for cities with garrisoned units")
-                    .map {it.params[0].toInt()}.sum()
+                    .sumBy { it.params[0].toInt() }
                 if (garrisonBonus != 0)
                     modifiers["Garrisoned unit"] = garrisonBonus
             }

--- a/core/src/com/unciv/logic/city/CityConstructions.kt
+++ b/core/src/com/unciv/logic/city/CityConstructions.kt
@@ -81,7 +81,8 @@ class CityConstructions {
             stats.add(building.getStats(cityInfo.civInfo))
 
         for (unique in builtBuildingUniqueMap.getAllUniques()) when (unique.placeholderText) {
-            "[] Per [] Population in this city" -> stats.add(unique.stats.times(cityInfo.population.population / unique.params[1].toFloat()))
+            "[] Per [] Population []" -> if (cityInfo.matchesFilter(unique.params[2])) 
+                stats.add(unique.stats.times(cityInfo.population.population / unique.params[1].toFloat()))
             "[] once [] is discovered" -> if (cityInfo.civInfo.tech.isResearched(unique.params[1])) stats.add(unique.stats)
         }
 

--- a/core/src/com/unciv/logic/city/CityConstructions.kt
+++ b/core/src/com/unciv/logic/city/CityConstructions.kt
@@ -92,14 +92,17 @@ class CityConstructions {
      * @return Maintenance cost of all built buildings
      */
     fun getMaintenanceCosts(): Int {
-        var maintenanceCost = getBuiltBuildings().sumBy { it.maintenance }
-        val policyManager = cityInfo.civInfo.policies
-        if (cityInfo.id in policyManager.legalismState) {
-            val buildingName = policyManager.legalismState[cityInfo.id]
-            maintenanceCost -= cityInfo.getRuleset().buildings[buildingName]!!.maintenance
+        return getBuiltBuildings().sumBy { it.maintenance } - getMaintenanceReductionForFreeBuildings()
+    }
+    
+    /** Calculates the amount of maintenance reduced by buildings granted by policies */
+    fun getMaintenanceReductionForFreeBuildings(): Int {
+        var maintenanceReduction = 0
+        var freeBuildings = cityInfo.civInfo.policies.getListOfFreeBuildings(cityInfo.id)!!
+        for (building in freeBuildings) {
+            maintenanceReduction += cityInfo.getRuleset().buildings[building]!!.maintenance
         }
-
-        return maintenanceCost
+        return maintenanceReduction
     }
 
     /**

--- a/core/src/com/unciv/logic/city/CityConstructions.kt
+++ b/core/src/com/unciv/logic/city/CityConstructions.kt
@@ -92,17 +92,15 @@ class CityConstructions {
      * @return Maintenance cost of all built buildings
      */
     fun getMaintenanceCosts(): Int {
-        return getBuiltBuildings().sumBy { it.maintenance } - getMaintenanceReductionForFreeBuildings()
-    }
-    
-    /** Calculates the amount of maintenance reduced by buildings granted by policies */
-    fun getMaintenanceReductionForFreeBuildings(): Int {
-        var maintenanceReduction = 0
-        var freeBuildings = cityInfo.civInfo.policies.getListOfFreeBuildings(cityInfo.id)!!
-        for (building in freeBuildings) {
-            maintenanceReduction += cityInfo.getRuleset().buildings[building]!!.maintenance
+        var maintenanceCost = 0
+        // We cache this to increase performance
+        val freeBuildings = cityInfo.civInfo.policies.getListOfFreeBuildings(cityInfo.id)
+        for (building in getBuiltBuildings()) {
+            if (building.name !in freeBuildings) {
+                maintenanceCost += building.maintenance
+            }
         }
-        return maintenanceReduction
+        return maintenanceCost
     }
 
     /**

--- a/core/src/com/unciv/logic/city/CityConstructions.kt
+++ b/core/src/com/unciv/logic/city/CityConstructions.kt
@@ -81,9 +81,12 @@ class CityConstructions {
             stats.add(building.getStats(cityInfo.civInfo))
 
         for (unique in builtBuildingUniqueMap.getAllUniques()) when (unique.placeholderText) {
-            "[] Per [] Population []" -> if (cityInfo.matchesFilter(unique.params[2])) 
+            "[] per [] population []" -> if (cityInfo.matchesFilter(unique.params[2])) 
                 stats.add(unique.stats.times(cityInfo.population.population / unique.params[1].toFloat()))
             "[] once [] is discovered" -> if (cityInfo.civInfo.tech.isResearched(unique.params[1])) stats.add(unique.stats)
+            // Deprecated since 3.14.17, left for modding compatibility
+            "[] Per [] Population in this city" ->
+                stats.add(unique.stats.times(cityInfo.population.population / unique.params[1].toFloat()))
         }
 
         return stats

--- a/core/src/com/unciv/logic/city/CityInfo.kt
+++ b/core/src/com/unciv/logic/city/CityInfo.kt
@@ -88,7 +88,7 @@ class CityInfo {
 
         if (civInfo.cities.size == 1) cityConstructions.addBuilding(capitalCityIndicator())
 
-        civInfo.policies.tryAddLegalismBuildings()
+        civInfo.policies.tryToAddPolicyBuildings()
 
         for (unique in civInfo.getMatchingUniques("Gain a free [] []")) {
             val freeBuildingName = unique.params[0]

--- a/core/src/com/unciv/logic/city/CityStats.kt
+++ b/core/src/com/unciv/logic/city/CityStats.kt
@@ -158,13 +158,9 @@ class CityStats {
 
     fun getGrowthBonusFromPoliciesAndWonders(): Float {
         var bonus = 0f
-        // This requires more... complex navigation of the local uniques to merge into "+[amount]% growth [cityFilter]"
-        for (unique in cityInfo.civInfo.getMatchingUniques("+[]% growth in all cities"))
-            bonus += unique.params[0].toFloat()
-
         // "+[amount]% growth [cityFilter]"
         for (unique in cityInfo.civInfo.getMatchingUniques("+[]% growth []"))
-            if (cityInfo.matchesFilter(unique.params[0]))
+            if (cityInfo.matchesFilter(unique.params[1]))
                 bonus += unique.params[0].toFloat()
         return bonus / 100
     }
@@ -440,7 +436,7 @@ class CityStats {
         First we see how much food we generate. Then we apply production bonuses to it.
         Up till here, business as usual.
         Then, we deduct food eaten (from the total produced).
-        Now we have the excess food, whih has its own things. If we're unhappy, cut it by 1/4.
+        Now we have the excess food, which has its own things. If we're unhappy, cut it by 1/4.
         Some policies have bonuses for excess food only, not general food production.
          */
 

--- a/core/src/com/unciv/logic/civilization/PolicyManager.kt
+++ b/core/src/com/unciv/logic/civilization/PolicyManager.kt
@@ -43,6 +43,7 @@ class PolicyManager {
         toReturn.storedCulture = storedCulture
         toReturn.cultureBuildingsAdded.putAll(cultureBuildingsAdded)
         toReturn.specificBuildingsAdded.putAll(specificBuildingsAdded)
+        toReturn.maintenanceFreeBuildings.putAll(maintenanceFreeBuildings)
         toReturn.autocracyCompletedTurns = autocracyCompletedTurns
         return toReturn
     }
@@ -210,9 +211,6 @@ class PolicyManager {
     }
     
     fun getListOfFreeBuildings(cityId: String): MutableSet<String> {
-        println(maintenanceFreeBuildings[cityId])
-        println(cultureBuildingsAdded[cityId])
-        println(specificBuildingsAdded.filter{it.value.contains(cityId)})
         if (cityId in maintenanceFreeBuildings.keys) return maintenanceFreeBuildings[cityId]!!
         return mutableSetOf()
     }

--- a/core/src/com/unciv/logic/civilization/PolicyManager.kt
+++ b/core/src/com/unciv/logic/civilization/PolicyManager.kt
@@ -20,7 +20,6 @@ class PolicyManager {
 
     var freePolicies = 0
     var storedCulture = 0
-        set(value) = addCulture(value)
     internal val adoptedPolicies = HashSet<String>()
     var numberOfAdoptedPolicies = 0
     var shouldOpenPolicyPicker = false
@@ -210,7 +209,11 @@ class PolicyManager {
         maintenanceFreeBuildings[cityId]!!.add(building)
     }
     
-    fun getListOfFreeBuildings(cityId: String): MutableSet<String>? {
-        return maintenanceFreeBuildings[cityId]
+    fun getListOfFreeBuildings(cityId: String): MutableSet<String> {
+        println(maintenanceFreeBuildings[cityId])
+        println(cultureBuildingsAdded[cityId])
+        println(specificBuildingsAdded.filter{it.value.contains(cityId)})
+        if (cityId in maintenanceFreeBuildings.keys) return maintenanceFreeBuildings[cityId]!!
+        return mutableSetOf()
     }
 }

--- a/core/src/com/unciv/logic/civilization/PolicyManager.kt
+++ b/core/src/com/unciv/logic/civilization/PolicyManager.kt
@@ -20,12 +20,20 @@ class PolicyManager {
 
     var freePolicies = 0
     var storedCulture = 0
+        set(value) = addCulture(value)
     internal val adoptedPolicies = HashSet<String>()
     var numberOfAdoptedPolicies = 0
     var shouldOpenPolicyPicker = false
         get() = field && canAdoptPolicy()
-    var legalismState = HashMap<String, String>()
+
+    private var cultureBuildingsAdded = HashMap<String, String>() // Maps cities to buildings
+    private var specificBuildingsAdded = HashMap<String, MutableSet<String>>() // Maps buildings to cities
+    private var maintenanceFreeBuildings = HashMap<String, MutableSet<String>>() // Maps cities to buildings
     var autocracyCompletedTurns = 0
+    
+    @Deprecated("Deprecated since 3.14.16") // Replaced with cultureBuildingsAdded
+    var legalismState = cultureBuildingsAdded // Maps cities to buildings
+    // We make it a reference copy of the original variable. This way, it can still works in older versions
 
     fun clone(): PolicyManager {
         val toReturn = PolicyManager()
@@ -34,7 +42,8 @@ class PolicyManager {
         toReturn.freePolicies = freePolicies
         toReturn.shouldOpenPolicyPicker = shouldOpenPolicyPicker
         toReturn.storedCulture = storedCulture
-        toReturn.legalismState.putAll(legalismState)
+        toReturn.cultureBuildingsAdded.putAll(cultureBuildingsAdded)
+        toReturn.specificBuildingsAdded.putAll(specificBuildingsAdded)
         toReturn.autocracyCompletedTurns = autocracyCompletedTurns
         return toReturn
     }
@@ -52,7 +61,7 @@ class PolicyManager {
     }
 
     fun startTurn() {
-        tryAddLegalismBuildings()
+        tryToAddPolicyBuildings()
     }
 
     fun addCulture(culture: Int) {
@@ -133,7 +142,7 @@ class PolicyManager {
         for (unique in policy.uniqueObjects)
             UniqueTriggerActivation.triggerCivwideUnique(unique, civInfo)
 
-        tryAddLegalismBuildings()
+        tryToAddPolicyBuildings()
 
         // This ALSO has the side-effect of updating the CivInfo statForNextTurn so we don't need to call it explicitly
         for (cityInfo in civInfo.cities)
@@ -141,22 +150,67 @@ class PolicyManager {
 
         if (!canAdoptPolicy()) shouldOpenPolicyPicker = false
     }
+    
+    fun tryToAddPolicyBuildings() {
+        tryAddCultureBuildings()
+        tryAddFreeBuildings()
+    }
 
-    fun tryAddLegalismBuildings() {
-        if (!civInfo.hasUnique("Immediately creates a cheapest available cultural building in each of your first 4 cities for free"))
-            return
-        if (legalismState.size >= 4) return
+    private fun tryAddCultureBuildings() {
+        val cultureBuildingUniques = civInfo.getMatchingUniques("Immediately creates the cheapest available cultural building in each of your first [] cities for free")
+        val citiesToReceiveCultureBuilding = cultureBuildingUniques.sumOf { it.params[0].toInt() }
+        if (!cultureBuildingUniques.any()) return
+        if (cultureBuildingsAdded.size >= citiesToReceiveCultureBuilding) return
 
         val candidateCities = civInfo.cities
                 .sortedBy { it.turnAcquired }
-                .subList(0, min(4, civInfo.cities.size))
+                .subList(0, min(citiesToReceiveCultureBuilding, civInfo.cities.size))
                 .filter {
-                    it.id !in legalismState
+                    it.id !in cultureBuildingsAdded
                             && it.cityConstructions.hasBuildableCultureBuilding()
                 }
         for (city in candidateCities) {
             val builtBuilding = city.cityConstructions.addCultureBuilding()
-            if (builtBuilding != null) legalismState[city.id] = builtBuilding!!
+            if (builtBuilding != null) {
+                cultureBuildingsAdded[city.id] = builtBuilding!!
+                addMaintenanceFreeBuilding(city.id, builtBuilding)
+            }
         }
+    }
+    
+    private fun tryAddFreeBuildings() {
+        val matchingUniques = civInfo.getMatchingUniques("Immediately creates a [] in each of your first [] cities for free")
+        // If we have "create a free aqueduct in first 3 cities" and "create free aqueduct in first 4 cities", we do: "create free aqueduct in first 3+4=7 cities"
+        val sortedUniques = matchingUniques.groupBy {it.params[0]}
+        for (unique in sortedUniques) {
+            tryAddSpecificBuilding(unique.key, unique.value.sumBy {it.params[1].toInt()})
+        }
+    }
+    
+    private fun tryAddSpecificBuilding(building: String, cityCount: Int) {
+        if (specificBuildingsAdded[building] == null) specificBuildingsAdded[building] = mutableSetOf()
+        val citiesAlreadyGivenBuilding = specificBuildingsAdded[building]
+        if (citiesAlreadyGivenBuilding!!.size >= cityCount) return
+        val candidateCities = civInfo.cities
+            .sortedBy { it.turnAcquired }
+            .subList(0, min(cityCount, civInfo.cities.size))
+            .filter {
+                it.id !in citiesAlreadyGivenBuilding && !it.cityConstructions.containsBuildingOrEquivalent(building)
+            }
+        
+        for (city in candidateCities) {
+            city.cityConstructions.getConstruction(building).postBuildEvent(city.cityConstructions, false)
+            addMaintenanceFreeBuilding(city.id, building)
+            citiesAlreadyGivenBuilding.add(city.id) 
+        }
+    }
+    
+    private fun addMaintenanceFreeBuilding(cityId: String, building: String) {
+        if (cityId !in maintenanceFreeBuildings.keys) maintenanceFreeBuildings[cityId] = mutableSetOf()
+        maintenanceFreeBuildings[cityId]!!.add(building)
+    }
+    
+    fun getListOfFreeBuildings(cityId: String): MutableSet<String>? {
+        return maintenanceFreeBuildings[cityId]
     }
 }

--- a/core/src/com/unciv/models/ruleset/Building.kt
+++ b/core/src/com/unciv/models/ruleset/Building.kt
@@ -441,7 +441,9 @@ class Building : NamedStats(), IConstruction {
     fun isStatRelated(stat: Stat): Boolean {
         if (get(stat) > 0) return true
         if (getStatPercentageBonuses(null).get(stat) > 0) return true
-        if (uniqueObjects.any { it.placeholderText == "[] Per [] Population []]" && it.stats.get(stat) > 0 }) return true
+        if (uniqueObjects.any { it.placeholderText == "[] per [] population []" && it.stats.get(stat) > 0 }) return true
+        // Deprecated since 3.14.17, left for modding compatibility
+        if (uniqueObjects.any { it.placeholderText == "[] Per [] Population in this city"}) return true
         return false
     }
 

--- a/core/src/com/unciv/models/ruleset/Building.kt
+++ b/core/src/com/unciv/models/ruleset/Building.kt
@@ -441,7 +441,7 @@ class Building : NamedStats(), IConstruction {
     fun isStatRelated(stat: Stat): Boolean {
         if (get(stat) > 0) return true
         if (getStatPercentageBonuses(null).get(stat) > 0) return true
-        if (uniqueObjects.any { it.placeholderText == "[] Per [] Population in this city" && it.stats.get(stat) > 0 }) return true
+        if (uniqueObjects.any { it.placeholderText == "[] Per [] Population []]" && it.stats.get(stat) > 0 }) return true
         return false
     }
 


### PR DESCRIPTION
First part of the split of #4084 into multiple PR's for each branch.
This PR updates the Tradition branch to have G&K effects instead of those currently present.
It also modifies the existing policy uniques so that they are more moddable.
This also fixes #4109 and the bugs noted in the conversation there.

Added uniques:
- "Immediately creates a [building] in each of your first [int] cities for free"
- "Immediately creates the cheapest available cultural building in each of your first [int] cities for free"
- "+[int]% attacking strength for cities with garrisoned units"
- "[stats] Per [int] Population [cityFilter]"

Removed uniques:
- "Immediately creates a cheapest available cultural building in each of your first 4 cities for free"
- "+50% attacking strength for cities with garrisoned units"
- "[stats] per [int] population in all cities"
- "[stats] per [int] population in this city"

This version has backwards compatibility with older versions.
One of the variables previously used in PolicyManager() has been renamed to reflect the changes to uniques, and the old version has been deprecated because of this. For now they point to the same Hashmap, making it backwards compatible.
