### PR TITLE
RNG Seed: fixed reproducibility and UX

### DIFF
--- a/core/src/com/unciv/logic/map/MapParameters.kt
+++ b/core/src/com/unciv/logic/map/MapParameters.kt
@@ -140,8 +140,12 @@ class MapParameters {
     var resourceRichness = 0.1f
     var waterThreshold = 0f
 
-    fun resetAdvancedSettings() {
+    fun reseed() {
         seed = System.currentTimeMillis()
+    }
+
+    fun resetAdvancedSettings() {
+        reseed()
         tilesPerBiomeArea = 6
         maxCoastExtension = 2
         elevationExponent = 0.7f

--- a/core/src/com/unciv/logic/map/mapgenerator/MapGenerator.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/MapGenerator.kt
@@ -348,7 +348,7 @@ class MapGenerationRandomness{
                         .sortedBy { it.value }.map { it.key }
                 val firstKeyWithTilesLeft = orderedKeys
                         .first { availableTiles.any { tile -> tile.baseTerrain== it} }
-                val chosenTile = availableTiles.filter { it.baseTerrain==firstKeyWithTilesLeft }.random()
+                val chosenTile = availableTiles.filter { it.baseTerrain==firstKeyWithTilesLeft }.random(RNG)
                 availableTiles = availableTiles.filter { it.aerialDistanceTo(chosenTile) > distanceBetweenResources }
                 chosenTiles.add(chosenTile)
                 baseTerrainsToChosenTiles[firstKeyWithTilesLeft] = baseTerrainsToChosenTiles[firstKeyWithTilesLeft]!!+1

--- a/core/src/com/unciv/ui/mapeditor/MapEditorMenuPopup.kt
+++ b/core/src/com/unciv/ui/mapeditor/MapEditorMenuPopup.kt
@@ -1,5 +1,6 @@
 package com.unciv.ui.mapeditor
 
+import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.scenes.scene2d.ui.ScrollPane
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.unciv.MainMenuScreen
@@ -12,9 +13,15 @@ class MapEditorMenuPopup(var mapEditorScreen: MapEditorScreen): Popup(mapEditorS
 
     init {
         defaults().fillX()
-        addButton("New map", 'n') { UncivGame.Current.setScreen(NewMapScreen(mapEditorScreen.tileMap.mapParameters)) }
-        addButton("Save map", 's') { mapEditorScreen.game.setScreen(SaveAndLoadMapScreen(mapEditorScreen.tileMap, true, mapEditorScreen)); this.close() }
-        addButton("Load map", 'l') { mapEditorScreen.game.setScreen(SaveAndLoadMapScreen(mapEditorScreen.tileMap, false, mapEditorScreen)); this.close() }
+        add(("{RNG Seed} " + mapEditorScreen.tileMap.mapParameters.seed.toString()).toLabel()).row()
+        addButton("Copy to clipboard") { Gdx.app.clipboard.contents = mapEditorScreen.tileMap.mapParameters.seed.toString() }
+        addSeparator()
+        addButton("New map", 'n') {
+            mapEditorScreen.tileMap.mapParameters.reseed()
+            UncivGame.Current.setScreen(NewMapScreen(mapEditorScreen.tileMap.mapParameters))
+        }
+        addButton("Save map", 's') { mapEditorScreen.game.setScreen(SaveAndLoadMapScreen(mapEditorScreen.tileMap, true, mapEditorScreen)); close() }
+        addButton("Load map", 'l') { mapEditorScreen.game.setScreen(SaveAndLoadMapScreen(mapEditorScreen.tileMap, false, mapEditorScreen)); close() }
         addButton("Exit map editor", 'x') { mapEditorScreen.game.setScreen(MainMenuScreen()); mapEditorScreen.dispose() }
         addButton("Change ruleset", 'c') { MapEditorRulesetPopup(mapEditorScreen).open(); close() }
         addCloseButton()

--- a/core/src/com/unciv/ui/victoryscreen/VictoryScreen.kt
+++ b/core/src/com/unciv/ui/victoryscreen/VictoryScreen.kt
@@ -100,7 +100,9 @@ class VictoryScreen(val worldScreen: WorldScreen) : PickerScreen() {
         rightSideButton.isVisible = true
         rightSideButton.enable()
         rightSideButton.onClick {
-            game.setScreen(NewGameScreen(this, GameSetupInfo(gameInfo)))
+            val newGameSetupInfo = GameSetupInfo(gameInfo)
+            newGameSetupInfo.mapParameters.reseed()
+            game.setScreen(NewGameScreen(this, newGameSetupInfo))
         }
 
         closeButton.setText("One more turn...!".tr())

--- a/core/src/com/unciv/ui/worldscreen/mainmenu/WorldScreenMenuPopup.kt
+++ b/core/src/com/unciv/ui/worldscreen/mainmenu/WorldScreenMenuPopup.kt
@@ -1,10 +1,6 @@
 package com.unciv.ui.worldscreen.mainmenu
 
 import com.badlogic.gdx.Gdx
-import com.badlogic.gdx.scenes.scene2d.Touchable
-import com.badlogic.gdx.scenes.scene2d.ui.Cell
-import com.badlogic.gdx.scenes.scene2d.ui.Table
-import com.unciv.Constants
 import com.unciv.MainMenuScreen
 import com.unciv.ui.civilopedia.CivilopediaScreen
 import com.unciv.ui.newgamescreen.GameSetupInfo
@@ -12,9 +8,6 @@ import com.unciv.ui.newgamescreen.NewGameScreen
 import com.unciv.ui.saves.LoadGameScreen
 import com.unciv.ui.saves.SaveGameScreen
 import com.unciv.ui.utils.Popup
-import com.unciv.ui.utils.addSeparator
-import com.unciv.ui.utils.onClick
-import com.unciv.ui.utils.toLabel
 import com.unciv.ui.victoryscreen.VictoryScreen
 import com.unciv.ui.worldscreen.WorldScreen
 
@@ -27,7 +20,9 @@ class WorldScreenMenuPopup(val worldScreen: WorldScreen) : Popup(worldScreen) {
         addButton("Load game") { worldScreen.game.setScreen(LoadGameScreen(worldScreen)) }
 
         addButton("Start new game") {
-            val newGameScreen = NewGameScreen(worldScreen, GameSetupInfo(worldScreen.gameInfo))
+            val newGameSetupInfo = GameSetupInfo(worldScreen.gameInfo)
+            newGameSetupInfo.mapParameters.reseed()
+            val newGameScreen = NewGameScreen(worldScreen, newGameSetupInfo)
             worldScreen.game.setScreen(newGameScreen)
         }
 


### PR DESCRIPTION
**Fixed RNG: Maps reproducibility**
* The RNG for picking resources locations and rivers starting points was not seeded properly. Maps are now fully reproducible by passing the same set of MapParameters

**RNG Seed in Map Editor**
* Creating a new map from MapEditorMenuPopup reseeds automatically the RNG
* Added Seed on top of MapEditorMenuPopup
* Added Copy to clipboard button on top of MapEditorMenuPopup to copy the currently used RNG Seed
* UI FIX: Buttons in MapEditorMenuPopup have all the same width
![Screenshot from 2021-06-11 16-28-56](https://user-images.githubusercontent.com/17114100/121702434-28b7a900-cad2-11eb-8da8-55662bc109ef.png)

**Fixed RNG Seed in NewGameScreen**
* When clicking on "Start new game" from VictoryScreen, a new seed is generated
* When clicking on "Start new game" from WorldScreenMenuPopup, a new seed is generated