### PR TITLE
Display Movement Paths

### DIFF
--- a/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
+++ b/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
@@ -113,7 +113,7 @@ class UnitMovementAlgorithms(val unit:MapUnit) {
     }
 
     /**
-     * Does not consider if the destination tile can actually be entered, use canMoveTo for that.
+     * Does not consider if the [destination] tile can actually be entered, use [canMoveTo] for that.
      * Returns an empty list if there's no way to get to the destination.
      */
     fun getShortestPath(destination: TileInfo): List<TileInfo> {
@@ -152,7 +152,7 @@ class UnitMovementAlgorithms(val unit:MapUnit) {
                 val path = mutableListOf(destination) // Traverse the tree upwards to get the list of tiles leading to the destination,
                 // Get the tile from which the distance to the final tile in least -
                 // this is so that when we finally get there, we'll have as many movement points as possible
-                var intermediateTile = distanceToDestination.minBy { it.value }!!.key
+                var intermediateTile = distanceToDestination.minByOrNull { it.value }!!.key
                 while (intermediateTile != currentTile) {
                     path.add(intermediateTile)
                     intermediateTile = movementTreeParents[intermediateTile]!!


### PR DESCRIPTION
This implements and close #3434 

It was a low-hanging fruit: we were already calculating shortest paths towards a tile. I only added very-basic visualization logic.
I believe this is could also be a useful tool to debug and improve current BFS that is the guy draining our batteries :)

Further steps might include:
- [ ] Showing a dotted line between tiles
- [ ] Showing a number, representing the turn the tile will be occupied by the unit (potential issues in case of multiple selected units). How does Civ implements this?

![Screenshot from 2021-06-11 18-37-33](https://user-images.githubusercontent.com/17114100/121721074-21010000-cae4-11eb-9b94-1d2982a72014.png)
