### PR TITLE
Updated Liberty branch to G&K

### DIFF
--- a/android/assets/jsons/Civ V - Vanilla/Buildings.json
+++ b/android/assets/jsons/Civ V - Vanilla/Buildings.json
@@ -136,7 +136,7 @@
 		"culture": 1,
 		"greatPersonPoints": {"production": 1},
 		"isWonder": true,
-		"uniques": ["Worker construction increased 25%","[2] free [Worker] units appear"],
+		"uniques": ["Tile improvement build time -[25]%","[2] free [Worker] units appear"],
 		"requiredTech": "Masonry",
 		"quote": "'O, let not the pains of death which come upon thee enter into my body. I am the god Tem, and I am the foremost part of the sky, and the power which protecteth me is that which is with all the gods forever.'  - The Book of the Dead, translated by Sir Ernest Alfred Wallis Budge"
 	},

--- a/android/assets/jsons/Civ V - Vanilla/Buildings.json
+++ b/android/assets/jsons/Civ V - Vanilla/Buildings.json
@@ -136,7 +136,7 @@
 		"culture": 1,
 		"greatPersonPoints": {"production": 1},
 		"isWonder": true,
-		"uniques": ["Tile improvement build time -[25]%","[2] free [Worker] units appear"],
+		"uniques": ["-[25]% tile improvement construction time","[2] free [Worker] units appear"],
 		"requiredTech": "Masonry",
 		"quote": "'O, let not the pains of death which come upon thee enter into my body. I am the god Tem, and I am the foremost part of the sky, and the power which protecteth me is that which is with all the gods forever.'  - The Book of the Dead, translated by Sir Ernest Alfred Wallis Budge"
 	},

--- a/android/assets/jsons/Civ V - Vanilla/Policies.json
+++ b/android/assets/jsons/Civ V - Vanilla/Policies.json
@@ -48,21 +48,21 @@
 		"uniques": ["[+1 Culture] [in all cities]"],
 		"policies": [
 			{
-				"name": "Collective Rule",
-				"uniques": ["+[50]% Production when constructing [Settler] units [in capital]", "Free [Settler] appears"],
+				"name": "Republic",
+				"uniques": ["[+1 Production] [in all cities]", "+[5]% Production when constructing [Buildings]"],
 				"row": 1,
 				"column": 1
 			},
 			{
 				"name": "Citizenship",
-				"uniques": ["Tile improvement speed +25%", "Free [Worker] appears"],
+				"uniques": ["Tile improvement build time -[25]%", "Free [Worker] appears"],
 				"row": 1,
 				"column": 4
 			},
 			{
-				"name": "Republic",
-				"uniques": ["[+1 Production] [in all cities]", "+[5]% Production when constructing [Buildings]"],
-				"requires": ["Collective Rule"],
+				"name": "Collective Rule",
+				"uniques": ["+[50]% Production when constructing [Settler] units [in capital]", "Free [Settler] appears"],
+				"requires": ["Republic"],
 				"row": 2,
 				"column": 1
 			},
@@ -76,6 +76,7 @@
 			{
 				"name": "Meritocracy",
 				"uniques": ["[+1 Happiness] [in all cities connected to capital]", "Unhappiness from population decreased by [5]%"],
+				// Should only be unhappiness from population in non-occupied cities
 				"requires": ["Citizenship"],
 				"row": 2,
 				"column": 5

--- a/android/assets/jsons/Civ V - Vanilla/Policies.json
+++ b/android/assets/jsons/Civ V - Vanilla/Policies.json
@@ -75,8 +75,7 @@
 			},
 			{
 				"name": "Meritocracy",
-				"uniques": ["[+1 Happiness] [in all cities connected to capital]", "Unhappiness from population decreased by [5]%"],
-				// Should only be unhappiness from population in non-occupied cities
+				"uniques": ["[+1 Happiness] [in all cities connected to capital]", "Unhappiness from population decreased by [5]% [in all non-occupied cities]"],
 				"requires": ["Citizenship"],
 				"row": 2,
 				"column": 5

--- a/android/assets/jsons/Civ V - Vanilla/Policies.json
+++ b/android/assets/jsons/Civ V - Vanilla/Policies.json
@@ -55,7 +55,7 @@
 			},
 			{
 				"name": "Citizenship",
-				"uniques": ["Tile improvement build time -[25]%", "Free [Worker] appears"],
+				"uniques": ["-[25]% tile improvement construction time", "Free [Worker] appears"],
 				"row": 1,
 				"column": 4
 			},

--- a/core/src/com/unciv/logic/city/CityInfo.kt
+++ b/core/src/com/unciv/logic/city/CityInfo.kt
@@ -467,14 +467,15 @@ class CityInfo {
     }
 
     fun matchesFilter(filter: String): Boolean {
-        return when {
-            filter == "in this city" -> true
-            filter == "in all cities" -> true
-            filter == "in all coastal cities" && getCenterTile().isCoastalTile() -> true
-            filter == "in capital" && isCapital() -> true
-            filter == "in all cities with a world wonder" && cityConstructions.getBuiltBuildings().any { it.isWonder } -> true
-            filter == "in all cities connected to capital" -> isConnectedToCapital()
-            filter == "in all cities with a garrison" && getCenterTile().militaryUnit != null -> true
+        return when (filter) {
+            "in this city" -> true
+            "in all cities" -> true
+            "in all coastal cities" -> getCenterTile().isCoastalTile()
+            "in capital" -> isCapital()
+            "in all non-occupied cities" -> !cityStats.hasExtraAnnexUnhappiness()
+            "in all cities with a world wonder" -> cityConstructions.getBuiltBuildings().any { it.isWonder }
+            "in all cities connected to capital" -> isConnectedToCapital()
+            "in all cities with a garrison" -> getCenterTile().militaryUnit != null
             else -> false
         }
     }

--- a/core/src/com/unciv/logic/city/CityInfo.kt
+++ b/core/src/com/unciv/logic/city/CityInfo.kt
@@ -472,7 +472,7 @@ class CityInfo {
             "in all cities" -> true
             "in all coastal cities" -> getCenterTile().isCoastalTile()
             "in capital" -> isCapital()
-            "in all non-occupied cities" -> !cityStats.hasExtraAnnexUnhappiness()
+            "in all non-occupied cities" -> !cityStats.hasExtraAnnexUnhappiness() || isPuppet
             "in all cities with a world wonder" -> cityConstructions.getBuiltBuildings().any { it.isWonder }
             "in all cities connected to capital" -> isConnectedToCapital()
             "in all cities with a garrison" -> getCenterTile().militaryUnit != null

--- a/core/src/com/unciv/logic/city/CityStats.kt
+++ b/core/src/com/unciv/logic/city/CityStats.kt
@@ -195,6 +195,10 @@ class CityStats {
 
         for (unique in civInfo.getMatchingUniques("Unhappiness from population decreased by []%"))
             unhappinessFromCitizens *= (1 - unique.params[0].toFloat() / 100)
+        
+        for (unique in civInfo.getMatchingUniques("Unhappiness from population decreased by []% []"))
+            if (cityInfo.matchesFilter(unique.params[1]))
+                unhappinessFromCitizens *= (1 - unique.params[0].toFloat() / 100)
 
         newHappinessList["Population"] = -unhappinessFromCitizens * unhappinessModifier
 
@@ -222,7 +226,7 @@ class CityStats {
     }
 
 
-    private fun hasExtraAnnexUnhappiness(): Boolean {
+    fun hasExtraAnnexUnhappiness(): Boolean {
         if (cityInfo.civInfo.civName == cityInfo.foundingCiv || cityInfo.foundingCiv == "" || cityInfo.isPuppet) return false
         return !cityInfo.containsBuildingUnique("Remove extra unhappiness from annexed cities")
     }

--- a/core/src/com/unciv/models/ruleset/tile/TileImprovement.kt
+++ b/core/src/com/unciv/models/ruleset/tile/TileImprovement.kt
@@ -28,8 +28,15 @@ class TileImprovement : NamedStats() {
 
     fun getTurnsToBuild(civInfo: CivilizationInfo): Int {
         var realTurnsToBuild = turnsToBuild.toFloat() * civInfo.gameInfo.gameParameters.gameSpeed.modifier
-        for (unique in civInfo.getMatchingUniques("Tile improvement build time -[]%"))
+        for (unique in civInfo.getMatchingUniques("-[]% tile improvement construction time")) {
             realTurnsToBuild *= 1 - unique.params[0].toFloat() / 100f
+            // Deprecated since 3.14.17
+                if (civInfo.hasUnique("Worker construction increased 25%"))
+                    realTurnsToBuild *= 0.75f
+                if (civInfo.hasUnique("Tile improvement speed +25%"))
+                    realTurnsToBuild *= 0.75f
+            //
+        }
         // In some weird cases it was possible for something to take 0 turns, leading to it instead never finishing
         if (realTurnsToBuild < 1) realTurnsToBuild = 1f
         return realTurnsToBuild.roundToInt()

--- a/core/src/com/unciv/models/ruleset/tile/TileImprovement.kt
+++ b/core/src/com/unciv/models/ruleset/tile/TileImprovement.kt
@@ -28,11 +28,10 @@ class TileImprovement : NamedStats() {
 
     fun getTurnsToBuild(civInfo: CivilizationInfo): Int {
         var realTurnsToBuild = turnsToBuild.toFloat() * civInfo.gameInfo.gameParameters.gameSpeed.modifier
-        // todo UNIFY THESE
-        if (civInfo.hasUnique("Worker construction increased 25%"))
-            realTurnsToBuild *= 0.75f
-        if (civInfo.hasUnique("Tile improvement speed +25%"))
-            realTurnsToBuild *= 0.75f
+        for (unique in civInfo.getMatchingUniques("Tile improvement build time -[]%"))
+            realTurnsToBuild *= 1 - unique.params[0].toFloat() / 100f
+        // In some weird cases it was possible for something to take 0 turns, leading to it instead never finishing
+        if (realTurnsToBuild < 1) realTurnsToBuild = 1f
         return realTurnsToBuild.roundToInt()
     }
 


### PR DESCRIPTION
Second part of the split of #4084 into multiple PR's for each branch.
This PR updates the Liberty branch to have G&K effects instead of those currently present.
This PR also unifies the citizenship and pyramids uniques, which both impact the build speed of improvements.
It also modifies the existing policy uniques so that they are more moddable.

Added uniques:
- "Tile improvement build time -[int]%"
- "Unhappiness from population decreased by [int]% [cityFilter]"

Removed uniques:
- "Worker construction increased 25%"
- "Tile improvement speed +25%"

This version mostly has backwards compatibility with older versions.
Previously, the republic policy was locked behind the collective rule policy, but it now is the opposite.
Due to this, some players may suddenly find themselves having a policy without having its required policies.
This is minor, and should not impact the game that much.