### PR TITLE
Updated Honor branch to G&K

### DIFF
--- a/android/assets/jsons/Civ V - Vanilla/Policies.json
+++ b/android/assets/jsons/Civ V - Vanilla/Policies.json
@@ -89,7 +89,7 @@
 	{
 		"name": "Honor",
 		"era": "Ancient era",
-		"uniques": ["+[33]% bonus vs Barbarians", "Earn [100]% of killed [Barbarian] unit's [Strength] as [Culture]",
+		"uniques": ["+[33]% Strength vs [Barbarians]", "Earn [100]% of killed [Barbarian] unit's [Strength] as [Culture]",
 			"Notified of new Barbarian encampments"],
 		"policies": [
 			{

--- a/android/assets/jsons/Civ V - Vanilla/Policies.json
+++ b/android/assets/jsons/Civ V - Vanilla/Policies.json
@@ -100,7 +100,7 @@
 			},
 			{
 				"name": "Discipline",
-				"uniques":["+[15]% combat strength for [Melee] units which have another [military] unit in an adjacent tile"],
+				"uniques":["+[15]% Strength for [Melee] units which have another [military] unit in an adjacent tile"],
 				"row": 1, 
 				"column": 4
 			},
@@ -120,7 +120,7 @@
 			},
 			{
 				"name": "Professional Army",
-				"uniques": ["Gold cost of upgrading military units reduced by [33]%", "[+1 Happiness] from every [Walls]", 
+				"uniques": ["Gold cost of upgrading [military] units reduced by [33]%", "[+1 Happiness] from every [Walls]", 
 					"[+1 Happiness] from every [Castle]", "[+1 Happiness] from every [Arsenal]", "[+1 Happiness] from every [Military Base]"
 				],
 				"requires": ["Military Caste"],

--- a/android/assets/jsons/Civ V - Vanilla/Policies.json
+++ b/android/assets/jsons/Civ V - Vanilla/Policies.json
@@ -89,19 +89,19 @@
 	{
 		"name": "Honor",
 		"era": "Ancient era",
-		"uniques": ["+25% bonus vs Barbarians", "Earn [100]% of killed [Barbarian] unit's [Strength] as [Culture]",
+		"uniques": ["+[33]% bonus vs Barbarians", "Earn [100]% of killed [Barbarian] unit's [Strength] as [Culture]",
 			"Notified of new Barbarian encampments"],
 		"policies": [
 			{
 				"name": "Warrior Code",
-				"uniques":["+[20]% Production when constructing [Melee] units [in all cities]"],
+				"uniques":["+[15]% Production when constructing [Melee] units [in all cities]", "Free [Great General] appears"],
 				"row": 1,
 				"column": 2
 			},
 			{
 				"name": "Discipline",
-				"uniques":["+15% combat strength for melee units which have another military unit in an adjacent tile"],
-				"row": 1,
+				"uniques":["+[15]% combat strength for [Melee] units which have another [military] unit in an adjacent tile"],
+				"row": 1, 
 				"column": 4
 			},
 			{
@@ -120,7 +120,9 @@
 			},
 			{
 				"name": "Professional Army",
-				"uniques": ["Gold cost of upgrading military units reduced by 33%"],
+				"uniques": ["Gold cost of upgrading military units reduced by [33]%", "[+1 Happiness] from every [Walls]", 
+					"[+1 Happiness] from every [Castle]", "[+1 Happiness] from every [Arsenal]", "[+1 Happiness] from every [Military Base]"
+				],
 				"requires": ["Military Caste"],
 				"row": 3,
 				"column": 4

--- a/core/src/com/unciv/logic/battle/BattleDamage.kt
+++ b/core/src/com/unciv/logic/battle/BattleDamage.kt
@@ -114,10 +114,6 @@ object BattleDamage {
         if (enemy.getCivInfo().isBarbarian()) {
             modifiers["Difficulty"] =
                 (civInfo.gameInfo.getDifficulty().barbarianBonus * 100).toInt()
-            val barbarianBonus = civInfo.getMatchingUniques("+[]% bonus vs Barbarians")
-                .map { it.params[0].toInt() }.sum()
-            if (barbarianBonus > 0)
-                modifiers["vs Barbarians"] = barbarianBonus 
         }
 
         return modifiers

--- a/core/src/com/unciv/logic/battle/BattleDamage.kt
+++ b/core/src/com/unciv/logic/battle/BattleDamage.kt
@@ -76,7 +76,7 @@ object BattleDamage {
             }
 
             var adjacentUnitBonus = 0;
-            for (unique in civInfo.getMatchingUniques("+[]% combat strength for [] units which have another [] unit in an adjacent tile")) {
+            for (unique in civInfo.getMatchingUniques("+[]% Strength for [] units which have another [] unit in an adjacent tile")) {
                 if (combatant.matchesCategory(unique.params[1])
                     && combatant.getTile().neighbors.flatMap { it.getUnits() }
                     .any { it.civInfo == civInfo && it.matchesFilter(unique.params[2]) } 
@@ -108,12 +108,24 @@ object BattleDamage {
                     .isCityState() && civInfo.hasUnique("+30% Strength when fighting City-State units and cities")
             )
                 modifiers["vs [City-States]"] = 30
+            
+            // Deprecated since 3.14.17
+            if (civInfo.hasUnique("+15% combat strength for melee units which have another military unit in an adjacent tile")
+                && combatant.isMelee()
+                && combatant.getTile().neighbors.flatMap { it.getUnits() }
+                    .any { it.civInfo == civInfo && !it.type.isCivilian() && !it.type.isAirUnit() }
+            )
+                modifiers["Discipline"] = 15
 
         }
 
         if (enemy.getCivInfo().isBarbarian()) {
             modifiers["Difficulty"] =
                 (civInfo.gameInfo.getDifficulty().barbarianBonus * 100).toInt()
+            // Deprecated since 3.14.17
+            if (civInfo.hasUnique("+25% bonus vs Barbarians")) {
+                modifiers["vs Barbarians (deprecated)"] = 25
+            }
         }
 
         return modifiers

--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -319,11 +319,12 @@ class MapUnit {
 
     fun getCostOfUpgrade(): Int {
         val unitToUpgradeTo = getUnitToUpgradeTo()
-        var goldCostOfUpgrade = (unitToUpgradeTo.cost - baseUnit().cost) * 2 + 10
-        for (unique in civInfo.getMatchingUniques("Gold cost of upgrading military units reduced by 33%"))
-            goldCostOfUpgrade = (goldCostOfUpgrade * 0.66f).toInt()
+        var goldCostOfUpgrade = (unitToUpgradeTo.cost - baseUnit().cost) * 2f + 10f
+        for (unique in civInfo.getMatchingUniques("Gold cost of upgrading military units reduced by []%")) {
+            goldCostOfUpgrade *= (1 - unique.params[0].toFloat() / 100f)
+        }
         if (goldCostOfUpgrade < 0) return 0 // For instance, Landsknecht costs less than Spearman, so upgrading would cost negative gold
-        return goldCostOfUpgrade
+        return goldCostOfUpgrade.toInt()
     }
 
 

--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -320,9 +320,16 @@ class MapUnit {
     fun getCostOfUpgrade(): Int {
         val unitToUpgradeTo = getUnitToUpgradeTo()
         var goldCostOfUpgrade = (unitToUpgradeTo.cost - baseUnit().cost) * 2f + 10f
-        for (unique in civInfo.getMatchingUniques("Gold cost of upgrading military units reduced by []%")) {
-            goldCostOfUpgrade *= (1 - unique.params[0].toFloat() / 100f)
+        for (unique in civInfo.getMatchingUniques("Gold cost of upgrading [] units reduced by []%")) {
+            if (matchesFilter(unique.params[0])) 
+                goldCostOfUpgrade *= (1 - unique.params[1].toFloat() / 100f)
         }
+        // Deprecated since 3.14.17
+            if (civInfo.hasUnique("Gold cost of upgrading military units reduced by 33%")) {
+                goldCostOfUpgrade *= 0.67f
+            }
+        //
+        
         if (goldCostOfUpgrade < 0) return 0 // For instance, Landsknecht costs less than Spearman, so upgrading would cost negative gold
         return goldCostOfUpgrade.toInt()
     }


### PR DESCRIPTION
Third part of the split of #4084 into multiple PR's for each branch.
This PR updates the Honor branch to have G&K effects instead of those currently present.
It also modifies the existing policy uniques so that they are more moddable.

Added uniques:
- "+[int]% combat strength for [unitFilter] units which have another [unitFilter] unit in an adjacent tile"
- "Gold cost of upgrading military units reduced by [int]%"

Removed uniques:
- "+15% combat strength for melee units which have another military unit in an adjacent tile"
- "+25% bonus vs Barbarians"
- "Gold cost of upgrading military units reduced by 33%"

This PR has full backwards compatibility with older versions.