### PR TITLE
Fix silent crash when ancient ruins cascade gifted units

### DIFF
--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -607,6 +607,11 @@ class CivilizationInfo {
         }
     }
 
+    /** Tries to place the a [unitName] unit into the [TileInfo] closest to the given the [position]
+     * @param location where to try to place the unit
+     * @param unitName name of the [BaseUnit] to create and place
+     * @return created [MapUnit] or null if no suitable location was found
+     * */
     fun placeUnitNearTile(location: Vector2, unitName: String): MapUnit? {
         return gameInfo.tileMap.placeUnitNearTile(location, unitName, this)
     }

--- a/core/src/com/unciv/logic/map/TileMap.kt
+++ b/core/src/com/unciv/logic/map/TileMap.kt
@@ -157,7 +157,9 @@ class TileMap {
     }
 
 
-    /** Tries to place the [unitName] into the [TileInfo] closest to the given the [position]
+    /** Tries to place the [unitName] into the [TileInfo] closest to the given [position]
+     * @param position where to try to place the unit (or close - max 10 tiles distance)
+     * @param unitName name of the [BaseUnit] to create and place
      * @param civInfo civilization to assign unit to
      * @return created [MapUnit] or null if no suitable location was found
      * */

--- a/core/src/com/unciv/ui/worldscreen/WorldMapHolder.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldMapHolder.kt
@@ -202,6 +202,8 @@ class WorldMapHolder(internal val worldScreen: WorldScreen, internal val tileMap
             try {
                 tileToMoveTo = selectedUnit.movement.getTileToMoveToThisTurn(targetTile)
             } catch (ex: Exception) {
+                println("Exception in getTileToMoveToThisTurn: ${ex.message}")
+                ex.printStackTrace()
                 return@thread
             } // can't move here
 
@@ -224,7 +226,9 @@ class WorldMapHolder(internal val worldScreen: WorldScreen, internal val tileMap
                     if (selectedUnits.size > 1) { // We have more tiles to move
                         moveUnitToTargetTile(selectedUnits.subList(1, selectedUnits.size), targetTile)
                     } else removeUnitActionOverlay() //we're done here
-                } catch (e: Exception) {
+                } catch (ex: Exception) {
+                    println("Exception in moveUnitToTargetTile: ${ex.message}")
+                    ex.printStackTrace()
                 }
             }
         }


### PR DESCRIPTION
Probability on generated maps near zero, but on edited maps it's just quite small. Scenario: An ancient ruin pops a unit of the same civilian/military class as the unit that stepped on the ruins, and that new unit is placed onto another ruin, and that ruin chooses the unit gift, too. The second will eventually call `civInfo.updateStatsForNextTurn` _before_ the first unit is fully initialized, namely before it has a valid `currentTile`. :bomb: 

Took me a few minutes to debug due to being buried under a few thread switches and a try catch{}. (actually - debugging on hardware your process would die _while_ you were single stepping something else or analyzing watches - and desktop died with zero messages, not even 'gradle build failed' - but one step _after_ the problem). Therefore I left all the purely 'defensive' changes _in_ this PR.