### PR TITLE
Fix crash caused by cascaded ruins unit gifts

### DIFF
--- a/android/assets/jsons/translations/Czech.properties
+++ b/android/assets/jsons/translations/Czech.properties
@@ -2882,7 +2882,7 @@ Professional Army = Profesionální armáda
 Gold cost of upgrading [unitType] units reduced by [amount]% = 
 Honor Complete = Kompletní Čest
 Honor = Čest
-+[amount]% Strength vs [param] = +[amount]% síly proti [unitType]
++[amount]% Strength vs [param] = +[amount]% síly proti [param]
 Notified of new Barbarian encampments = Upozornění na nový Barbarský tábor
 
 Organized Religion = Organizovaná víra

--- a/android/assets/jsons/translations/Dutch.properties
+++ b/android/assets/jsons/translations/Dutch.properties
@@ -4101,7 +4101,7 @@ Gold cost of upgrading [unitType] units reduced by [amount]% =
  # Requires translation!
 Honor Complete = 
 Honor = Eer
-+[amount]% Strength vs [param] = +[amount]% Kracht vs [unitType]
++[amount]% Strength vs [param] = +[amount]% Kracht vs [param]
  # Requires translation!
 Notified of new Barbarian encampments = 
 

--- a/android/assets/jsons/translations/German.properties
+++ b/android/assets/jsons/translations/German.properties
@@ -2859,7 +2859,7 @@ Professional Army = Berufsarmee
 Gold cost of upgrading [unitType] units reduced by [amount]% = 
 Honor Complete = Ehre vollständig
 Honor = Ehre
-+[amount]% Strength vs [param] = +[amount]% Stärke gegen [unitType]
++[amount]% Strength vs [param] = +[amount]% Stärke gegen [param]
 Notified of new Barbarian encampments = Benachrichtigungen über neue Barbarenlager
 
 Organized Religion = Organisierte Religion

--- a/android/assets/jsons/translations/Indonesian.properties
+++ b/android/assets/jsons/translations/Indonesian.properties
@@ -2885,7 +2885,7 @@ Professional Army = Prajurit Profesional
 Gold cost of upgrading [unitType] units reduced by [amount]% = 
 Honor Complete = Kehormatan Lengkap
 Honor = Kehormatan
-+[amount]% Strength vs [param] = +[amount]% Kekuatan vs [unitType]
++[amount]% Strength vs [param] = +[amount]% Kekuatan vs [param]
 Notified of new Barbarian encampments = Diberi tahu ketika muncul perkemahan orang Barbar baru
 
 Organized Religion = Agama Terorganisasi

--- a/android/assets/jsons/translations/Italian.properties
+++ b/android/assets/jsons/translations/Italian.properties
@@ -2859,7 +2859,7 @@ Professional Army = Esercito professionale
 Gold cost of upgrading [unitType] units reduced by [amount]% = 
 Honor Complete = Onore Completo
 Honor = Onore
-+[amount]% Strength vs [param] = +[amount]% Strength contro [unitType]
++[amount]% Strength vs [param] = +[amount]% Strength contro [param]
 Notified of new Barbarian encampments = Sarai notificato dei nuovi accampamenti barbari
 
 Organized Religion = Religione Organizzata

--- a/android/assets/jsons/translations/Japanese.properties
+++ b/android/assets/jsons/translations/Japanese.properties
@@ -2914,7 +2914,7 @@ Professional Army = 軍隊の常備
 Gold cost of upgrading [unitType] units reduced by [amount]% = 
 Honor Complete = 名誉コンプリート
 Honor = 名誉
-+[amount]% Strength vs [param] = [unitType]に対して戦闘力+[amount]%
++[amount]% Strength vs [param] = [param]に対して戦闘力+[amount]%
 Notified of new Barbarian encampments = 新たな蛮族の野営地が出現すると通知
 
 Organized Religion = 宗教の組織化

--- a/android/assets/jsons/translations/Polish.properties
+++ b/android/assets/jsons/translations/Polish.properties
@@ -2954,7 +2954,7 @@ Professional Army = Armia Zawodowa
 Gold cost of upgrading [unitType] units reduced by [amount]% = 
 Honor Complete = Ukończony Honor
 Honor = Honor
-+[amount]% Strength vs [param] = +[amount]% Siły w wlace z [unitType]
++[amount]% Strength vs [param] = +[amount]% Siły w wlace z [param]
 Notified of new Barbarian encampments = Powiadomiono o nowych obozach Barbarzyńców
 
 Organized Religion = Hierarchia Kościelna

--- a/android/assets/jsons/translations/Russian.properties
+++ b/android/assets/jsons/translations/Russian.properties
@@ -2902,7 +2902,7 @@ Professional Army = Профессиональная армия
 Gold cost of upgrading [unitType] units reduced by [amount]% = 
 Honor Complete = Честь завершена
 Honor = Честь
-+[amount]% Strength vs [param] = +[amount]% Силы против [unitType]
++[amount]% Strength vs [param] = +[amount]% Силы против [param]
 Notified of new Barbarian encampments = Вы будете получать извещение всякий раз, когда варвары будут ставить новый лагерь
 
 Organized Religion = Организованная религия

--- a/android/assets/jsons/translations/Simplified_Chinese.properties
+++ b/android/assets/jsons/translations/Simplified_Chinese.properties
@@ -2897,7 +2897,7 @@ Professional Army = 职业军队
 Gold cost of upgrading [unitType] units reduced by [amount]% = 
 Honor Complete = 完整的荣誉政策
 Honor = 荣誉政策
-+[amount]% Strength vs [param] = 对战[unitType]时+[amount]%战斗力
++[amount]% Strength vs [param] = 对战[param]时+[amount]%战斗力
 Notified of new Barbarian encampments = 新的蛮族营地出现时将会通知
 
 Organized Religion = 教会组织

--- a/android/assets/jsons/translations/Spanish.properties
+++ b/android/assets/jsons/translations/Spanish.properties
@@ -2859,7 +2859,7 @@ Professional Army = Ejercito Profesional
 Gold cost of upgrading [unitType] units reduced by [amount]% = 
 Honor Complete = Honor Completado
 Honor = Honor
-+[amount]% Strength vs [param] = +[amount]% de Fuerza vs [unitType]
++[amount]% Strength vs [param] = +[amount]% de Fuerza vs [param]
 Notified of new Barbarian encampments = Notificado de nuevos campamentos Bárbaros
 
 Organized Religion = Religión Organizada

--- a/android/assets/jsons/translations/Swedish.properties
+++ b/android/assets/jsons/translations/Swedish.properties
@@ -2885,7 +2885,7 @@ Professional Army = Professionell Armé
 Gold cost of upgrading [unitType] units reduced by [amount]% = 
 Honor Complete = Heder Fullbordat
 Honor = Heder
-+[amount]% Strength vs [param] = +[amount]% Styrka mot [unitType]
++[amount]% Strength vs [param] = +[amount]% Styrka mot [param]
 Notified of new Barbarian encampments = Uppmärksammas på nya Barbarläger
 
 Organized Religion = Organiserad Religion

--- a/android/assets/jsons/translations/Traditional_Chinese.properties
+++ b/android/assets/jsons/translations/Traditional_Chinese.properties
@@ -2917,7 +2917,7 @@ Professional Army = 職業軍隊
 Gold cost of upgrading [unitType] units reduced by [amount]% = 
 Honor Complete = 完整的榮譽政策
 Honor = 榮譽政策
-+[amount]% Strength vs [param] = 對戰[unitType]時+[amount]%戰鬥力
++[amount]% Strength vs [param] = 對戰[param]時+[amount]%戰鬥力
 Notified of new Barbarian encampments = 新的蠻族營地出現時將會通知
 
 Organized Religion = 教會組織

--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -607,6 +607,11 @@ class CivilizationInfo {
         }
     }
 
+    /** Tries to place the a [unitName] unit into the [TileInfo] closest to the given the [position]
+     * @param location where to try to place the unit
+     * @param unitName name of the [BaseUnit] to create and place
+     * @return created [MapUnit] or null if no suitable location was found
+     * */
     fun placeUnitNearTile(location: Vector2, unitName: String): MapUnit? {
         return gameInfo.tileMap.placeUnitNearTile(location, unitName, this)
     }

--- a/core/src/com/unciv/logic/map/TileMap.kt
+++ b/core/src/com/unciv/logic/map/TileMap.kt
@@ -157,7 +157,9 @@ class TileMap {
     }
 
 
-    /** Tries to place the [unitName] into the [TileInfo] closest to the given the [position]
+    /** Tries to place the [unitName] into the [TileInfo] closest to the given [position]
+     * @param position where to try to place the unit (or close - max 10 tiles distance)
+     * @param unitName name of the [BaseUnit] to create and place
      * @param civInfo civilization to assign unit to
      * @return created [MapUnit] or null if no suitable location was found
      * */

--- a/core/src/com/unciv/models/translations/TranslationFileWriter.kt
+++ b/core/src/com/unciv/models/translations/TranslationFileWriter.kt
@@ -4,7 +4,6 @@ import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.files.FileHandle
 import com.badlogic.gdx.utils.Array
 import com.unciv.JsonParser
-import com.unciv.logic.battle.BattleDamage
 import com.unciv.models.metadata.BaseRuleset
 import com.unciv.models.ruleset.*
 import com.unciv.models.ruleset.tech.TechColumn
@@ -228,10 +227,6 @@ object TranslationFileWriter {
 
                         stringToTranslate = stringToTranslate.replace(parameter, parameterName)
                     }
-                } else {
-                    // substitute the regex for "Bonus/Penalty vs ..."
-                    val match = Regex(BattleDamage.BONUS_VS_UNIT_TYPE).matchEntire(string)
-                    if (match != null) stringToTranslate = "${match.groupValues[1]} vs [unitType]"
                 }
                 resultStrings!!.add("$stringToTranslate = ")
                 return

--- a/core/src/com/unciv/ui/worldscreen/WorldMapHolder.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldMapHolder.kt
@@ -202,6 +202,8 @@ class WorldMapHolder(internal val worldScreen: WorldScreen, internal val tileMap
             try {
                 tileToMoveTo = selectedUnit.movement.getTileToMoveToThisTurn(targetTile)
             } catch (ex: Exception) {
+                println("Exception in getTileToMoveToThisTurn: ${ex.message}")
+                ex.printStackTrace()
                 return@thread
             } // can't move here
 
@@ -224,7 +226,9 @@ class WorldMapHolder(internal val worldScreen: WorldScreen, internal val tileMap
                     if (selectedUnits.size > 1) { // We have more tiles to move
                         moveUnitToTargetTile(selectedUnits.subList(1, selectedUnits.size), targetTile)
                     } else removeUnitActionOverlay() //we're done here
-                } catch (e: Exception) {
+                } catch (ex: Exception) {
+                    println("Exception in moveUnitToTargetTile: ${ex.message}")
+                    ex.printStackTrace()
                 }
             }
         }


### PR DESCRIPTION
#4131 retry, now based on #4132 - I'm super curious whether the github builds will be OK...

Original comment:
Probability on generated maps near zero, but on edited maps it's just quite small. Scenario: An ancient ruin pops a unit of the same civilian/military class as the unit that stepped on the ruins, and that new unit is placed onto another ruin, and that ruin chooses the unit gift, too. The second will eventually call civInfo.updateStatsForNextTurn before the first unit is fully initialized, namely before it has a valid currentTile. bomb

Took me a few minutes to debug due to being buried under a few thread switches and a try catch{}. (actually - debugging on hardware your process would die while you were single stepping something else or analyzing watches - and desktop died with zero messages, not even 'gradle build failed' - but one step after the problem). Therefore I left all the purely 'defensive' changes in this PR.

