### PR TITLE
Wakeup call

### DIFF
--- a/android/assets/jsons/translations/Czech.properties
+++ b/android/assets/jsons/translations/Czech.properties
@@ -2882,7 +2882,7 @@ Professional Army = Profesionální armáda
 Gold cost of upgrading [unitType] units reduced by [amount]% = 
 Honor Complete = Kompletní Čest
 Honor = Čest
-+[amount]% Strength vs [param] = +[amount]% síly proti [unitType]
++[amount]% Strength vs [param] = +[amount]% síly proti [param]
 Notified of new Barbarian encampments = Upozornění na nový Barbarský tábor
 
 Organized Religion = Organizovaná víra

--- a/android/assets/jsons/translations/Dutch.properties
+++ b/android/assets/jsons/translations/Dutch.properties
@@ -4101,7 +4101,7 @@ Gold cost of upgrading [unitType] units reduced by [amount]% =
  # Requires translation!
 Honor Complete = 
 Honor = Eer
-+[amount]% Strength vs [param] = +[amount]% Kracht vs [unitType]
++[amount]% Strength vs [param] = +[amount]% Kracht vs [param]
  # Requires translation!
 Notified of new Barbarian encampments = 
 

--- a/android/assets/jsons/translations/German.properties
+++ b/android/assets/jsons/translations/German.properties
@@ -2859,7 +2859,7 @@ Professional Army = Berufsarmee
 Gold cost of upgrading [unitType] units reduced by [amount]% = 
 Honor Complete = Ehre vollständig
 Honor = Ehre
-+[amount]% Strength vs [param] = +[amount]% Stärke gegen [unitType]
++[amount]% Strength vs [param] = +[amount]% Stärke gegen [param]
 Notified of new Barbarian encampments = Benachrichtigungen über neue Barbarenlager
 
 Organized Religion = Organisierte Religion

--- a/android/assets/jsons/translations/Indonesian.properties
+++ b/android/assets/jsons/translations/Indonesian.properties
@@ -2885,7 +2885,7 @@ Professional Army = Prajurit Profesional
 Gold cost of upgrading [unitType] units reduced by [amount]% = 
 Honor Complete = Kehormatan Lengkap
 Honor = Kehormatan
-+[amount]% Strength vs [param] = +[amount]% Kekuatan vs [unitType]
++[amount]% Strength vs [param] = +[amount]% Kekuatan vs [param]
 Notified of new Barbarian encampments = Diberi tahu ketika muncul perkemahan orang Barbar baru
 
 Organized Religion = Agama Terorganisasi

--- a/android/assets/jsons/translations/Italian.properties
+++ b/android/assets/jsons/translations/Italian.properties
@@ -2859,7 +2859,7 @@ Professional Army = Esercito professionale
 Gold cost of upgrading [unitType] units reduced by [amount]% = 
 Honor Complete = Onore Completo
 Honor = Onore
-+[amount]% Strength vs [param] = +[amount]% Strength contro [unitType]
++[amount]% Strength vs [param] = +[amount]% Strength contro [param]
 Notified of new Barbarian encampments = Sarai notificato dei nuovi accampamenti barbari
 
 Organized Religion = Religione Organizzata

--- a/android/assets/jsons/translations/Japanese.properties
+++ b/android/assets/jsons/translations/Japanese.properties
@@ -2914,7 +2914,7 @@ Professional Army = 軍隊の常備
 Gold cost of upgrading [unitType] units reduced by [amount]% = 
 Honor Complete = 名誉コンプリート
 Honor = 名誉
-+[amount]% Strength vs [param] = [unitType]に対して戦闘力+[amount]%
++[amount]% Strength vs [param] = [param]に対して戦闘力+[amount]%
 Notified of new Barbarian encampments = 新たな蛮族の野営地が出現すると通知
 
 Organized Religion = 宗教の組織化

--- a/android/assets/jsons/translations/Polish.properties
+++ b/android/assets/jsons/translations/Polish.properties
@@ -2954,7 +2954,7 @@ Professional Army = Armia Zawodowa
 Gold cost of upgrading [unitType] units reduced by [amount]% = 
 Honor Complete = Ukończony Honor
 Honor = Honor
-+[amount]% Strength vs [param] = +[amount]% Siły w wlace z [unitType]
++[amount]% Strength vs [param] = +[amount]% Siły w wlace z [param]
 Notified of new Barbarian encampments = Powiadomiono o nowych obozach Barbarzyńców
 
 Organized Religion = Hierarchia Kościelna

--- a/android/assets/jsons/translations/Russian.properties
+++ b/android/assets/jsons/translations/Russian.properties
@@ -2902,7 +2902,7 @@ Professional Army = Профессиональная армия
 Gold cost of upgrading [unitType] units reduced by [amount]% = 
 Honor Complete = Честь завершена
 Honor = Честь
-+[amount]% Strength vs [param] = +[amount]% Силы против [unitType]
++[amount]% Strength vs [param] = +[amount]% Силы против [param]
 Notified of new Barbarian encampments = Вы будете получать извещение всякий раз, когда варвары будут ставить новый лагерь
 
 Organized Religion = Организованная религия

--- a/android/assets/jsons/translations/Simplified_Chinese.properties
+++ b/android/assets/jsons/translations/Simplified_Chinese.properties
@@ -2897,7 +2897,7 @@ Professional Army = 职业军队
 Gold cost of upgrading [unitType] units reduced by [amount]% = 
 Honor Complete = 完整的荣誉政策
 Honor = 荣誉政策
-+[amount]% Strength vs [param] = 对战[unitType]时+[amount]%战斗力
++[amount]% Strength vs [param] = 对战[param]时+[amount]%战斗力
 Notified of new Barbarian encampments = 新的蛮族营地出现时将会通知
 
 Organized Religion = 教会组织

--- a/android/assets/jsons/translations/Spanish.properties
+++ b/android/assets/jsons/translations/Spanish.properties
@@ -2859,7 +2859,7 @@ Professional Army = Ejercito Profesional
 Gold cost of upgrading [unitType] units reduced by [amount]% = 
 Honor Complete = Honor Completado
 Honor = Honor
-+[amount]% Strength vs [param] = +[amount]% de Fuerza vs [unitType]
++[amount]% Strength vs [param] = +[amount]% de Fuerza vs [param]
 Notified of new Barbarian encampments = Notificado de nuevos campamentos Bárbaros
 
 Organized Religion = Religión Organizada

--- a/android/assets/jsons/translations/Swedish.properties
+++ b/android/assets/jsons/translations/Swedish.properties
@@ -2885,7 +2885,7 @@ Professional Army = Professionell Armé
 Gold cost of upgrading [unitType] units reduced by [amount]% = 
 Honor Complete = Heder Fullbordat
 Honor = Heder
-+[amount]% Strength vs [param] = +[amount]% Styrka mot [unitType]
++[amount]% Strength vs [param] = +[amount]% Styrka mot [param]
 Notified of new Barbarian encampments = Uppmärksammas på nya Barbarläger
 
 Organized Religion = Organiserad Religion

--- a/android/assets/jsons/translations/Traditional_Chinese.properties
+++ b/android/assets/jsons/translations/Traditional_Chinese.properties
@@ -2917,7 +2917,7 @@ Professional Army = 職業軍隊
 Gold cost of upgrading [unitType] units reduced by [amount]% = 
 Honor Complete = 完整的榮譽政策
 Honor = 榮譽政策
-+[amount]% Strength vs [param] = 對戰[unitType]時+[amount]%戰鬥力
++[amount]% Strength vs [param] = 對戰[param]時+[amount]%戰鬥力
 Notified of new Barbarian encampments = 新的蠻族營地出現時將會通知
 
 Organized Religion = 教會組織

--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -64,6 +64,10 @@ object Battle {
         if (defender.isDefeated() && defender is CityCombatant && attacker is MapUnitCombatant && attacker.isMelee() && !attacker.unit.hasUnique("Unable to capture cities"))
             conquerCity(defender.city, attacker)
 
+        // Exploring units surviving an attack should "wake up"
+        if (!defender.isDefeated() && defender is MapUnitCombatant && defender.unit.action == Constants.unitActionExplore)
+            defender.unit.action = null
+
         // we're a melee unit and we destroyed\captured an enemy unit
         postBattleMoveToAttackedTile(attacker, defender, attackedTile)
 

--- a/core/src/com/unciv/logic/city/CityExpansionManager.kt
+++ b/core/src/com/unciv/logic/city/CityExpansionManager.kt
@@ -107,6 +107,11 @@ class CityExpansionManager {
         return null
     }
 
+    /**
+     * Removes one tile from this city's owned tiles, unconditionally, and updates dependent
+     * things like worked tiles, locked tiles, and stats.
+     * @param tileInfo The tile to relinquish
+     */
     fun relinquishOwnership(tileInfo: TileInfo) {
         cityInfo.tiles = cityInfo.tiles.withoutItem(tileInfo.position)
         for (city in cityInfo.civInfo.cities) {
@@ -124,6 +129,14 @@ class CityExpansionManager {
         cityInfo.cityStats.update()
     }
 
+    /**
+     * Takes one tile into possession of this city, either unowned or owned by any other city.
+     *
+     * Also manages consequences like auto population reassign, stats, and displacing units
+     * that are no longer allowed on that tile.
+     *
+     * @param tileInfo The tile to take over
+     */
     fun takeOwnership(tileInfo: TileInfo) {
         if (tileInfo.isCityCenter()) throw Exception("What?!")
         if (tileInfo.getCity() != null)

--- a/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
+++ b/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
@@ -284,7 +284,12 @@ class UnitMovementAlgorithms(val unit:MapUnit) {
         return true
     }
 
-
+    /**
+     * Displace a unit - choose a viable tile close by if possible and 'teleport' the unit there.
+     * This will not use movement points or check for a possible route.
+     * It is used e.g. if an enemy city expands its borders, or trades or diplomacy change a unit's
+     * allowed position.
+     */
     fun teleportToClosestMoveableTile() {
         var allowedTile: TileInfo? = null
         var distance = 0
@@ -304,8 +309,12 @@ class UnitMovementAlgorithms(val unit:MapUnit) {
             }
         }
         unit.removeFromTile() // we "teleport" them away
-        if (allowedTile != null) // it's possible that there is no close tile, and all the guy's cities are full. Screw him then.
+        if (allowedTile != null) { // it's possible that there is no close tile, and all the guy's cities are full. Screw him then.
             unit.putInTile(allowedTile)
+            // Cancel sleep or fortification if forcibly displaced - for now, leave movement / auto / explore orders
+            if (unit.isSleeping() || unit.isFortified())
+                unit.action = null
+        }
     }
 
     fun moveToTile(destination: TileInfo) {

--- a/core/src/com/unciv/models/translations/TranslationFileWriter.kt
+++ b/core/src/com/unciv/models/translations/TranslationFileWriter.kt
@@ -4,7 +4,6 @@ import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.files.FileHandle
 import com.badlogic.gdx.utils.Array
 import com.unciv.JsonParser
-import com.unciv.logic.battle.BattleDamage
 import com.unciv.models.metadata.BaseRuleset
 import com.unciv.models.ruleset.*
 import com.unciv.models.ruleset.tech.TechColumn
@@ -228,10 +227,6 @@ object TranslationFileWriter {
 
                         stringToTranslate = stringToTranslate.replace(parameter, parameterName)
                     }
-                } else {
-                    // substitute the regex for "Bonus/Penalty vs ..."
-                    val match = Regex(BattleDamage.BONUS_VS_UNIT_TYPE).matchEntire(string)
-                    if (match != null) stringToTranslate = "${match.groupValues[1]} vs [unitType]"
                 }
                 resultStrings!!.add("$stringToTranslate = ")
                 return


### PR DESCRIPTION
Discussed in #4107 but not answering the original issue

- Wake up sleeping units now uses visibility not 'in 2 tiles radius' (yes someone sneaking up behind a hill could wake a cannon)
- Fortified/Sleeping units displaced by expansion or diplomacy wake up and lose fortification bonus if any
- Exploring units wake up, too - when attacked

I'm sure @ravignir agrees this is closer to original Civ5 than what we did before