### PR TITLE
Updated Freedom branch to G&K

### DIFF
--- a/android/assets/jsons/Civ V - Vanilla/Policies.json
+++ b/android/assets/jsons/Civ V - Vanilla/Policies.json
@@ -358,40 +358,40 @@
 			},
 			{
 				"name": "Universal Suffrage",
-				"uniques": ["[+1 Production] per [5] population in all cities"],
+				"uniques": ["+[33]% Defensive Strength for cities"],
 				"row": 1,
 				"column": 3
 			},
 			{
 				"name": "Civil Society",
-				"uniques": ["-50% food consumption by specialists"],
+				"uniques": ["-[50]% food consumption by specialists"],
 				"row": 1,
 				"column": 5
 			},
 			{
 				"name": "Free Speech",
-				"uniques": ["[+1 Culture] per [2] population in all cities"],
+				"uniques": ["[8] units cost no maintenance"],
 				"requires": ["Constitution"],
 				"row": 2,
 				"column": 1
 			},
 			{
 				"name": "Democracy",
-				"uniques": ["Specialists produce half normal unhappiness"],
+				"uniques": ["Specialists only produce [50]% of normal unhappiness"],
 				"requires": ["Civil Society"],
 				"row": 2,
 				"column": 5
 			},
 			{
 				"name": "Freedom Complete",
-				"uniques": ["Tile yield from Great Improvements +100%", "Golden Age length increased by [50]%"]
+				"uniques": ["Tile yield from [Great Improvements] +[100]%", "Golden Age length increased by [50]%"]
 			}
 		]
 	},
 	{
 		"name": "Autocracy",
 		"era": "Industrial era",
-		"uniques": ["-33% unit upkeep costs"],
+		"uniques": ["-[33]% unit upkeep costs"],
 		"policies": [
 			{
 				"name": "Populism",

--- a/android/assets/jsons/Civ V - Vanilla/Policies.json
+++ b/android/assets/jsons/Civ V - Vanilla/Policies.json
@@ -391,7 +391,7 @@
 	{
 		"name": "Autocracy",
 		"era": "Industrial era",
-		"uniques": ["-[33]% unit upkeep costs"],
+		"uniques": ["-33% unit upkeep costs"],
 		"policies": [
 			{
 				"name": "Populism",

--- a/android/assets/jsons/Civ V - Vanilla/Policies.json
+++ b/android/assets/jsons/Civ V - Vanilla/Policies.json
@@ -384,7 +384,7 @@
 			},
 			{
 				"name": "Freedom Complete",
-				"uniques": ["Tile yield from [Great Improvements] +[100]%", "Golden Age length increased by [50]%"]
+				"uniques": ["+[100]% yield from [Great Improvements]", "Golden Age length increased by [50]%"]
 			}
 		]
 	},

--- a/core/src/com/unciv/logic/battle/BattleDamage.kt
+++ b/core/src/com/unciv/logic/battle/BattleDamage.kt
@@ -192,50 +192,57 @@ object BattleDamage {
         return modifiers
     }
 
-    fun getDefenceModifiers(attacker: ICombatant, defender: MapUnitCombatant): Counter<String> {
+    fun getDefenceModifiers(attacker: ICombatant, defender: ICombatant): Counter<String> {
         val modifiers = getGeneralModifiers(defender, attacker)
         val tile = defender.getTile()
+    
+        if (defender is MapUnitCombatant) {
 
-        if (defender.unit.isEmbarked()) {
-            // embarked units get no defensive modifiers apart from this unique
-            if (defender.unit.hasUnique("Defense bonus when embarked") ||
-                defender.getCivInfo().hasUnique("Embarked units can defend themselves")
+            if (defender.unit.isEmbarked()) {
+                // embarked units get no defensive modifiers apart from this unique
+                if (defender.unit.hasUnique("Defense bonus when embarked") ||
+                    defender.getCivInfo().hasUnique("Embarked units can defend themselves")
+                )
+                    modifiers["Embarked"] = 100
+
+                return modifiers
+            }
+
+            modifiers.putAll(getTileSpecificModifiers(defender, tile))
+
+            val tileDefenceBonus = tile.getDefensiveBonus()
+            if (!defender.unit.hasUnique("No defensive terrain bonus") && tileDefenceBonus > 0
+                || !defender.unit.hasUnique("No defensive terrain penalty") && tileDefenceBonus < 0
             )
-                modifiers["Embarked"] = 100
+                modifiers["Tile"] = (tileDefenceBonus * 100).toInt()
 
-            return modifiers
+            if (attacker.isRanged()) {
+                val defenceVsRanged = 25 * defender.unit.getUniques()
+                    .count { it.text == "+25% Defence against ranged attacks" }
+                if (defenceVsRanged > 0) modifiers["defence vs ranged"] = defenceVsRanged
+            }
+
+            for (unique in defender.unit.getMatchingUniques("+[]% Strength when defending")) {
+                modifiers.add("Defender Bonus", unique.params[0].toInt())
+            }
+
+            for (unique in defender.unit.getMatchingUniques("+[]% defence in [] tiles")) {
+                if (tile.matchesUniqueFilter(unique.params[1]))
+                    modifiers["[${unique.params[1]}] defence"] = unique.params[0].toInt()
+            }
+
+            if (defender.unit.isFortified())
+                modifiers["Fortification"] = 20 * defender.unit.getFortificationTurns()
+        } else if (defender is CityCombatant) {
+            
+            modifiers["Defensive Bonus"] = defender.city.civInfo.getMatchingUniques("+[]% Defensive strength for cities")
+                .fold(0f) { sum, it -> sum + it.params[0].toFloat() / 100f }.toInt()
+            
         }
-
-        modifiers.putAll(getTileSpecificModifiers(defender, tile))
-
-        val tileDefenceBonus = tile.getDefensiveBonus()
-        if (!defender.unit.hasUnique("No defensive terrain bonus") && tileDefenceBonus > 0
-            || !defender.unit.hasUnique("No defensive terrain penalty") && tileDefenceBonus < 0
-        )
-            modifiers["Tile"] = (tileDefenceBonus * 100).toInt()
-
-        if (attacker.isRanged()) {
-            val defenceVsRanged = 25 * defender.unit.getUniques()
-                .count { it.text == "+25% Defence against ranged attacks" }
-            if (defenceVsRanged > 0) modifiers["defence vs ranged"] = defenceVsRanged
-        }
-
-        for (unique in defender.unit.getMatchingUniques("+[]% Strength when defending")) {
-            modifiers.add("Defender Bonus", unique.params[0].toInt())
-        }
-
-        for (unique in defender.unit.getMatchingUniques("+[]% defence in [] tiles")) {
-            if (tile.matchesUniqueFilter(unique.params[1]))
-                modifiers["[${unique.params[1]}] defence"] = unique.params[0].toInt()
-        }
-
-
-        if (defender.unit.isFortified())
-            modifiers["Fortification"] = 20 * defender.unit.getFortificationTurns()
 
         return modifiers
     }
-
+    
     private fun getTileSpecificModifiers(unit: MapUnitCombatant, tile: TileInfo): Counter<String> {
         val modifiers = Counter<String>()
 
@@ -294,8 +301,7 @@ object BattleDamage {
         tileToAttackFrom: TileInfo?,
         defender: ICombatant
     ): Float {
-        val attackModifier =
-            modifiersToMultiplicationBonus(getAttackModifiers(attacker, defender))
+        val attackModifier = modifiersToMultiplicationBonus(getAttackModifiers(attacker, defender))
         return attacker.getAttackingStrength() * attackModifier
     }
 
@@ -304,9 +310,7 @@ object BattleDamage {
      * Includes defence modifiers
      */
     private fun getDefendingStrength(attacker: ICombatant, defender: ICombatant): Float {
-        var defenceModifier = 1f
-        if (defender is MapUnitCombatant) defenceModifier =
-            modifiersToMultiplicationBonus(getDefenceModifiers(attacker, defender))
+        val defenceModifier = modifiersToMultiplicationBonus(getDefenceModifiers(attacker, defender))
         return defender.getDefendingStrength() * defenceModifier
     }
 

--- a/core/src/com/unciv/logic/battle/BattleDamage.kt
+++ b/core/src/com/unciv/logic/battle/BattleDamage.kt
@@ -236,7 +236,7 @@ object BattleDamage {
         } else if (defender is CityCombatant) {
             
             modifiers["Defensive Bonus"] = defender.city.civInfo.getMatchingUniques("+[]% Defensive strength for cities")
-                .fold(0f) { sum, it -> sum + it.params[0].toFloat() / 100f }.toInt()
+                .map { it.params[0].toFloat() / 100f }.sum().toInt()
             
         }
 

--- a/core/src/com/unciv/logic/city/CityStats.kt
+++ b/core/src/com/unciv/logic/city/CityStats.kt
@@ -182,9 +182,7 @@ class CityStats {
 
         var unhappinessFromCitizens = cityInfo.population.population.toFloat()
         var unhappinessFromSpecialists = cityInfo.population.getNumberOfSpecialists().toFloat()
-        
-        unhappinessFromCitizens -= unhappinessFromSpecialists
-        
+        val baseUnhappinessFromSpecialists = cityInfo.population.getNumberOfSpecialists().toFloat()
         
         for (unique in civInfo.getMatchingUniques("Specialists only produce []% of normal unhappiness")) {
             unhappinessFromSpecialists *= (1f - unique.params[0].toFloat() / 100f)
@@ -194,7 +192,7 @@ class CityStats {
                 unhappinessFromSpecialists *= 0.5f
         //
         
-        unhappinessFromCitizens += unhappinessFromSpecialists
+        unhappinessFromCitizens += - baseUnhappinessFromSpecialists + unhappinessFromSpecialists 
 
         if (cityInfo.isPuppet)
             unhappinessFromCitizens *= 1.5f
@@ -511,8 +509,8 @@ class CityStats {
     private fun updateFoodEaten() {
         foodEaten = cityInfo.population.population.toFloat() * 2
         var foodEatenBySpecialists = 2f * cityInfo.population.getNumberOfSpecialists()
+        val baseFoodEatenBySpecialists = 2f * cityInfo.population.getNumberOfSpecialists()
         
-        foodEaten -= foodEatenBySpecialists
         for (unique in cityInfo.civInfo.getMatchingUniques("-[]% food consumption by specialists")) 
             foodEatenBySpecialists *= 1f - unique.params[0].toFloat() / 100f
         
@@ -521,6 +519,6 @@ class CityStats {
                 foodEatenBySpecialists *= 0.5f
         //
         
-        foodEaten += foodEatenBySpecialists
+        foodEaten += -baseFoodEatenBySpecialists + foodEatenBySpecialists
     }
 }

--- a/core/src/com/unciv/logic/city/CityStats.kt
+++ b/core/src/com/unciv/logic/city/CityStats.kt
@@ -517,7 +517,7 @@ class CityStats {
             foodEatenBySpecialists *= 1f - unique.params[0].toFloat() / 100f
         
         // Deprecated since 3.15
-            if (cityInfo.civInfo.hasUnique("Specialists produce half normal unhappiness"))
+            if (cityInfo.civInfo.hasUnique("-50% food consumption by specialists"))
                 foodEatenBySpecialists *= 0.5f
         //
         

--- a/core/src/com/unciv/logic/city/CityStats.kt
+++ b/core/src/com/unciv/logic/city/CityStats.kt
@@ -182,7 +182,6 @@ class CityStats {
 
         var unhappinessFromCitizens = cityInfo.population.population.toFloat()
         var unhappinessFromSpecialists = cityInfo.population.getNumberOfSpecialists().toFloat()
-        val baseUnhappinessFromSpecialists = cityInfo.population.getNumberOfSpecialists().toFloat()
         
         for (unique in civInfo.getMatchingUniques("Specialists only produce []% of normal unhappiness")) {
             unhappinessFromSpecialists *= (1f - unique.params[0].toFloat() / 100f)
@@ -192,7 +191,7 @@ class CityStats {
                 unhappinessFromSpecialists *= 0.5f
         //
         
-        unhappinessFromCitizens += - baseUnhappinessFromSpecialists + unhappinessFromSpecialists 
+        unhappinessFromCitizens -= cityInfo.population.getNumberOfSpecialists().toFloat() - unhappinessFromSpecialists 
 
         if (cityInfo.isPuppet)
             unhappinessFromCitizens *= 1.5f
@@ -394,7 +393,7 @@ class CityStats {
     fun update(currentConstruction: IConstruction = cityInfo.cityConstructions.getCurrentConstruction()) {
 
         val citySpecificUniques: Sequence<Unique> = cityInfo.cityConstructions.builtBuildingUniqueMap.getAllUniques()
-            .filter { it.params.isNotEmpty() && it.params.last()=="in this city" }
+            .filter { it.params.isNotEmpty() && it.params.last() == "in this city" }
         // We need to compute Tile yields before happiness
         updateBaseStatList()
         updateCityHappiness()
@@ -509,7 +508,6 @@ class CityStats {
     private fun updateFoodEaten() {
         foodEaten = cityInfo.population.population.toFloat() * 2
         var foodEatenBySpecialists = 2f * cityInfo.population.getNumberOfSpecialists()
-        val baseFoodEatenBySpecialists = 2f * cityInfo.population.getNumberOfSpecialists()
         
         for (unique in cityInfo.civInfo.getMatchingUniques("-[]% food consumption by specialists")) 
             foodEatenBySpecialists *= 1f - unique.params[0].toFloat() / 100f
@@ -519,6 +517,6 @@ class CityStats {
                 foodEatenBySpecialists *= 0.5f
         //
         
-        foodEaten += -baseFoodEatenBySpecialists + foodEatenBySpecialists
+        foodEaten -= 2f * cityInfo.population.getNumberOfSpecialists() - foodEatenBySpecialists
     }
 }

--- a/core/src/com/unciv/logic/civilization/CivInfoStats.kt
+++ b/core/src/com/unciv/logic/civilization/CivInfoStats.kt
@@ -16,7 +16,11 @@ class CivInfoStats(val civInfo: CivilizationInfo) {
 
     private fun getUnitMaintenance(): Int {
         val baseUnitCost = 0.5f
-        val freeUnits = 3
+        var freeUnits = 3
+        for (unique in civInfo.getMatchingUniques("[] units cost no maintenance")) {
+            freeUnits += unique.params[0].toInt()
+        }
+        
         var unitsToPayFor = civInfo.getCivUnits()
         if (civInfo.hasUnique("Units in cities cost no Maintenance"))
         // Only land military units can truly "garrison"
@@ -39,7 +43,15 @@ class CivInfoStats(val civInfo: CivilizationInfo) {
         cost = cost.pow(1 + gameProgress / 3) // Why 3? To spread 1 to 1.33
         if (!civInfo.isPlayerCivilization())
             cost *= civInfo.gameInfo.getDifficulty().aiUnitMaintenanceModifier
-        if (civInfo.hasUnique("-33% unit upkeep costs")) cost *= 0.66f
+        
+        for (unique in civInfo.getMatchingUniques("-[]% unit upkeep costs")) {
+            cost *= 1f - unique.params[0].toFloat()
+        }
+        
+        // Deprecated since 3.15
+            if (civInfo.hasUnique("-33% unit upkeep costs")) cost *= 0.67f
+        //
+        
         return cost.toInt()
     }
 

--- a/core/src/com/unciv/logic/civilization/CivInfoStats.kt
+++ b/core/src/com/unciv/logic/civilization/CivInfoStats.kt
@@ -45,7 +45,7 @@ class CivInfoStats(val civInfo: CivilizationInfo) {
             cost *= civInfo.gameInfo.getDifficulty().aiUnitMaintenanceModifier
         
         for (unique in civInfo.getMatchingUniques("-[]% unit upkeep costs")) {
-            cost *= 1f - unique.params[0].toFloat()
+            cost *= 1f - unique.params[0].toFloat() / 100f
         }
         
         // Deprecated since 3.15

--- a/core/src/com/unciv/models/ruleset/tile/TileImprovement.kt
+++ b/core/src/com/unciv/models/ruleset/tile/TileImprovement.kt
@@ -94,5 +94,14 @@ class TileImprovement : NamedStats() {
                 && it.params[0] == name
         }.any()
     }
+    
+    fun matchesFilter(filter: String): Boolean {
+        return when (filter) {
+            name -> true
+            "All" -> true
+            "Great Improvement" -> isGreatImprovement()
+            else -> false
+        }
+    }
 }
 

--- a/core/src/com/unciv/models/stats/Stats.kt
+++ b/core/src/com/unciv/models/stats/Stats.kt
@@ -64,6 +64,12 @@ open class Stats() {
         for (stat in Stat.values()) hashMap[stat] = number * hashMap[stat]!!
         return Stats(hashMap)
     }
+    
+    fun timesInPlace(number: Float) {
+        val hashMap = toHashMap()
+        for (stat in Stat.values()) hashMap[stat] = number * hashMap[stat]!!
+        setStats(hashMap)
+    }
 
     fun isEmpty() = equals(Stats())
 


### PR DESCRIPTION
Sixth part of the split of #4084 into multiple PR's for each branch.
This PR updates the Freedom branch to have G&K effects instead of those currently present.
It also modifies the existing policy uniques so that they are more moddable.

Added uniques:
- "-[int]% food consumption by specialists"
- "[int] units cost no maintenance"
- "Specialists only produce [int]% of normal unhappiness"
- "Tile yield from [tileFilter] +[int]%"
- "-[int]% unit upkeep costs"

Deprecated uniques:
- "-50% food consumption by specialists"
- "Specialists produce half normal unhappiness"
- "Tile yield from Great Improvements +100%"
- "-33% unit upkeep costs"

This PR is fully backwards compatible.