### PR TITLE
Request for comments: Prepare resources for better mod-ability

### DIFF
--- a/android/assets/jsons/Civ V - Vanilla/TileResources.json
+++ b/android/assets/jsons/Civ V - Vanilla/TileResources.json
@@ -227,7 +227,7 @@
 		"gold": 2,
 		"improvement": "Quarry",
 		"improvementStats": {"gold": 1,"production": 1},
-		"unique": "+15% production towards Wonder construction"
+		"uniques": ["[+15]% production towards Wonder construction"]
 	},
 	{
 		"name": "Whales",

--- a/core/src/com/unciv/logic/map/TileInfo.kt
+++ b/core/src/com/unciv/logic/map/TileInfo.kt
@@ -661,8 +661,7 @@ open class TileInfo {
 
         if (resource != null && !ruleset.tileResources.containsKey(resource)) resource = null
         if (resource != null) {
-            val resourceObject = ruleset.tileResources[resource]!!
-            if (resourceObject.terrainsCanBeFoundOn.none { it == baseTerrain || terrainFeatures.contains(it) })
+            if (ruleset.tileResources[resource]!!.mustRemoveFromTile(this))
                 resource = null
         }
 

--- a/core/src/com/unciv/logic/map/mapgenerator/MapGenerator.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/MapGenerator.kt
@@ -137,9 +137,7 @@ class MapGenerator(val ruleset: Ruleset) {
         for (resource in strategicResources) {
             // remove the tiles where previous resources have been placed
             val suitableTiles = candidateTiles
-                    .filterNot { it.baseTerrain == Constants.snow && it.isHill() }
-                    .filter { it.resource == null
-                            && resource.terrainsCanBeFoundOn.contains(it.getLastTerrain().name) }
+                    .filter { it.resource == null && resource.isAllowedOnTile(it) }
 
             val locations = randomness.chooseSpreadOutLocations(resourcesPerType, suitableTiles, distance)
 
@@ -155,8 +153,7 @@ class MapGenerator(val ruleset: Ruleset) {
         val resourcesOfType = ruleset.tileResources.values.filter { it.resourceType == resourceType }
 
         val suitableTiles = tileMap.values
-                .filterNot { it.baseTerrain == Constants.snow && it.isHill() }
-                .filter { it.resource == null && resourcesOfType.any { r -> r.terrainsCanBeFoundOn.contains(it.getLastTerrain().name) } }
+                .filter { it.resource == null && resourcesOfType.any { r -> r.isAllowedOnTile(it) } }
         val numberOfResources = tileMap.values.count { it.isLand && !it.isImpassible() } *
                 tileMap.mapParameters.resourceRichness
         val locations = randomness.chooseSpreadOutLocations(numberOfResources.toInt(), suitableTiles, distance)
@@ -165,7 +162,7 @@ class MapGenerator(val ruleset: Ruleset) {
 
         for (tile in locations) {
             val possibleResources = resourcesOfType
-                    .filter { it.terrainsCanBeFoundOn.contains(tile.getLastTerrain().name) }
+                    .filter { it.isAllowedOnTile(tile) }
                     .map { it.name }
             if (possibleResources.isEmpty()) continue
             val resourceWithLeastAssignments = possibleResources.minByOrNull { resourceToNumber[it]!! }!!

--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -320,13 +320,7 @@ class Ruleset {
         }
 
         for (resource in tileResources.values) {
-            if (resource.revealedBy != null && !technologies.containsKey(resource.revealedBy!!))
-                lines += "${resource.name} revealed by tech ${resource.revealedBy} which does not exist!"
-            if (resource.improvement != null && !tileImprovements.containsKey(resource.improvement!!))
-                lines += "${resource.name} improved by improvement ${resource.improvement} which does not exist!"
-            for (terrain in resource.terrainsCanBeFoundOn)
-                if (!terrains.containsKey(terrain))
-                    lines += "${resource.name} can be found on terrain $terrain which does not exist!"
+            warningCount += resource.checkModLinks(this, lines)
         }
 
         for (improvement in tileImprovements.values) {

--- a/core/src/com/unciv/models/ruleset/tile/Terrain.kt
+++ b/core/src/com/unciv/models/ruleset/tile/Terrain.kt
@@ -55,7 +55,7 @@ class Terrain : NamedStats() {
         if (turnsInto != null)
             sb.appendLine("Placed on [$turnsInto]".tr())
 
-        val resourcesFound = ruleset.tileResources.values.filter { it.terrainsCanBeFoundOn.contains(name) }
+        val resourcesFound = ruleset.tileResources.values.filter { it.isAllowedOnTerrain(name) }
         if (resourcesFound.isNotEmpty())
             sb.appendLine("May contain [${resourcesFound.joinToString(", ") { it.name.tr() }}]".tr())
 

--- a/core/src/com/unciv/models/ruleset/tile/TileResource.kt
+++ b/core/src/com/unciv/models/ruleset/tile/TileResource.kt
@@ -1,11 +1,20 @@
 package com.unciv.models.ruleset.tile
 
+import com.unciv.Constants
+import com.unciv.logic.map.TileInfo
 import com.unciv.models.ruleset.Ruleset
+import com.unciv.models.ruleset.Unique
 import com.unciv.models.stats.NamedStats
 import com.unciv.models.stats.Stats
+import com.unciv.models.translations.Translations
 import com.unciv.models.translations.tr
 import java.util.*
 
+/**
+ * Class representing a Resource.
+ * 
+ * This is deserialized from json, therefore is has a default constructor
+ */
 class TileResource : NamedStats() {
 
     var resourceType: ResourceType = ResourceType.Bonus
@@ -13,9 +22,96 @@ class TileResource : NamedStats() {
     var improvement: String? = null
     var improvementStats: Stats? = null
     var revealedBy: String? = null
+
+    @Deprecated("As of 3.15.x", ReplaceWith("uniques"))
     var unique: String? = null
+    var uniques = ArrayList<String>()
+    val uniqueObjects:List<Unique> by lazy {
+        // Compatibility code for deprecated [unique]
+        if (unique != null) {
+            if (unique!!.isNotEmpty()) uniques.add(unique!!)
+            unique = null
+        }
+        uniques.map { Unique(it) } 
+    }
 
+    /** Can map generator/editor add this resource to a given [tile]?
+     * @param tile The [TileInfo] to check
+     * @return `true` = resource is allowed there, `false` = don't place there
+     */
+    fun isAllowedOnTile(tile: TileInfo): Boolean {
+        // uniques / terrainsCanBeFoundOn: Cannot unique should have highest precedence,
+        // while terrainsCanBeFoundOn and Can unique should be treated like a set union
 
+        getMatchingUniques("Cannot occur on [] tiles").forEach { 
+            if (tile.matchesUniqueFilter(it.params[0])) return false
+        }
+        getMatchingUniques("Can occur on [] tiles").forEach {
+            if (tile.matchesUniqueFilter(it.params[0])) return true
+        }
+
+        // From old code...
+        if (tile.baseTerrain == Constants.snow && tile.isHill()) return false  // todo: this should not be hardcoded
+        // Original logic:
+        return isAllowedOnTerrain(tile.getLastTerrain())
+    }
+
+    /** Should [TileInfo.normalizeToRuleset] remove this resource from a given [tile]?
+     * @param tile The tile to check
+     * @return `true` if normalization should remove the resource 
+     */
+    fun mustRemoveFromTile(tile: TileInfo): Boolean {
+        if (isAllowedOnTerrain(tile.baseTerrain)) return false
+        return tile.terrainFeatures.none { isAllowedOnTerrain(it) }
+    }
+
+    /** Is this resource allowed on a given [terrain]? */
+    private fun isAllowedOnTerrain(terrain: Terrain): Boolean {
+        return isAllowedOnTerrain(terrain.name)
+    }
+
+    /** Is this resource allowed on a [terrain] given as String? */
+    fun isAllowedOnTerrain(terrain: String): Boolean {
+        // todo: Called from Terrain.getDescription - how to support tileFilter=terrain uniques?
+        return terrain in terrainsCanBeFoundOn
+    }
+
+    /** Get a terrain the map editor can use as background
+     * @param ruleset The ruleset to search for viable terrains
+     * @return Terrain name or null if impossible due to [ruleset] inconsistency 
+     */
+    fun getSampleTerrain(ruleset: Ruleset): String? {
+        return terrainsCanBeFoundOn.firstOrNull { it in ruleset.terrains }
+    }
+
+    /** Check if this resource has a certain [unique]
+     * @param placeholderText The unique key to match with [Unique.placeholderText]
+     * @return True if this resource has at least one matching unique
+     */
+    fun hasUnique(placeholderText: String) = getMatchingUniques(placeholderText).any()
+
+    /** Get a sequence of uniques matching a placeholder string
+     * @param placeholderText The unique key to match with [Unique.placeholderText]
+     * @return Sequence<Unique> matching the given placeholderText
+     */
+    fun getMatchingUniques(placeholderText: String): Sequence<Unique> =
+        uniqueObjects.asSequence().filter { it.placeholderText == placeholderText }
+
+    /** Get wonder production bonus - cached
+     * @return Percentage bonus as Float 
+     */
+    fun getWonderProductionBonus(): Float = _wonderProductionBonus
+    private val _wonderProductionBonus: Float by lazy {
+        if (hasUnique("+15% production towards Wonder construction")) 15f
+        else getMatchingUniques("[]% production towards Wonder construction")
+            .map { it.params[0].toFloatOrNull() }.filterNotNull().maxOfOrNull { it } ?: 0f
+    }
+
+    /** Get a description for use by the Civilopedia
+     * @param ruleset The ruleset to check for references to this resource
+     * @return One multiline String describing the properties of this resource
+     */
+    // Needs work, but that is already part of the Civilopedia WIP
     fun getDescription(ruleset: Ruleset): String {
         val stringBuilder = StringBuilder()
         stringBuilder.appendLine(resourceType.name.tr())
@@ -23,7 +119,7 @@ class TileResource : NamedStats() {
         val terrainsCanBeBuiltOnString: ArrayList<String> = arrayListOf()
         terrainsCanBeBuiltOnString.addAll(terrainsCanBeFoundOn.map { it.tr() })
         stringBuilder.appendLine("Can be found on ".tr() + terrainsCanBeBuiltOnString.joinToString(", "))
-        stringBuilder.appendln()
+        stringBuilder.appendLine()
         stringBuilder.appendLine("Improved by [$improvement]".tr())
         stringBuilder.appendLine("{Bonus stats for improvement}: ".tr() + "$improvementStats".tr())
 
@@ -37,8 +133,27 @@ class TileResource : NamedStats() {
             stringBuilder.appendLine("{Units that consume this resource}: ".tr()
                     + unitsThatConsumeThis.joinToString { it.name.tr() })
 
-        if (unique != null) stringBuilder.appendLine(unique!!.tr())
+        for(unique in uniques)
+            stringBuilder.appendLine(Translations.translateBonusOrPenalty(unique))
+
         return stringBuilder.toString()
+    }
+
+    /**
+     * Test mod consistency: Are all foreign keys used in this resource present in a given [ruleset]?
+     * @param ruleset RuleSet to test against
+     * @param lines Array to add error messages to
+     * @return Count of non-fatal lines (used to determine if the end result can be just a 'warning')
+     */
+    fun checkModLinks(ruleset: Ruleset, lines: ArrayList<String>): Int {
+        if (revealedBy != null && !ruleset.technologies.containsKey(revealedBy!!))
+            lines += "$name revealed by tech $revealedBy which does not exist!"
+        if (improvement != null && !ruleset.tileImprovements.containsKey(improvement!!))
+            lines += "$name improved by improvement $improvement which does not exist!"
+        for (terrain in terrainsCanBeFoundOn)
+            if (!ruleset.terrains.containsKey(terrain))
+                lines += "$name can be found on terrain $terrain which does not exist!"
+        return 0
     }
 }
 

--- a/core/src/com/unciv/ui/mapeditor/MapEditorOptionsTable.kt
+++ b/core/src/com/unciv/ui/mapeditor/MapEditorOptionsTable.kt
@@ -313,7 +313,7 @@ class MapEditorOptionsTable(val mapEditorScreen: MapEditorScreen): Table(CameraS
         })
 
         for (resource in ruleset.tileResources.values) {
-            if (resource.terrainsCanBeFoundOn.none { ruleset.terrains.containsKey(it) }) continue // This resource can't be placed
+            val terrain = resource.getSampleTerrain(ruleset) ?: continue // This resource can't be placed
             val resourceHex = getHex(ImageGetter.getResourceImage(resource.name, 40f))
             resourceHex.onClick {
                 tileAction = { it.resource = resource.name }
@@ -321,7 +321,6 @@ class MapEditorOptionsTable(val mapEditorScreen: MapEditorScreen): Table(CameraS
                 // for the tile image
                 val tileInfo = TileInfo()
                 tileInfo.ruleset = mapEditorScreen.ruleset
-                val terrain = resource.terrainsCanBeFoundOn.first { ruleset.terrains.containsKey(it) }
                 val terrainObject = ruleset.terrains[terrain]!!
                 if (terrainObject.type == TerrainType.TerrainFeature) {
                     tileInfo.baseTerrain =


### PR DESCRIPTION
#### Inspired by #3242: Concept on how to begin making resources more mod-able.

- Centralize logic (e.g. terrainsCanBeFoundOn would still work as private)
- Allow more than 1 unique with compatibility
- Parameterize the one existing unique
- Two new uniques as samples

#### Questions:
- Is this the correct approach?
- Why does TileInfo.normalizeToRuleset use a different logic? Would making it use `! isAllowedOnTile` hurt? How? (and if it stays it would need to respect those uniques too)
- That hardcoded Snow Hill exclusion - how to best 'soften' that? I gave it lower precedence so mods could override, but this still looks a tad inelegant
- +15 production could use the stats mechanic, but percent? Smells like it needs an idea, which is why i postponed parameterizing the wonder part