### PR TITLE
Fixed units not immediately teleporting out of sold city tiles, which could cause crashes

### DIFF
--- a/core/src/com/unciv/logic/trade/TradeLogic.kt
+++ b/core/src/com/unciv/logic/trade/TradeLogic.kt
@@ -88,7 +88,14 @@ class TradeLogic(val ourCivilization:CivilizationInfo, val otherCivilization: Ci
                 if (offer.type == TradeType.City) {
                     val city = from.cities.first { it.id == offer.name }
                     city.moveToCiv(to)
-                    city.getCenterTile().getUnits().toList().forEach { it.movement.teleportToClosestMoveableTile() }
+                    city.getCenterTile().getUnits().forEach { it.movement.teleportToClosestMoveableTile() }
+                    city.getTiles().forEach{ tile ->
+                        tile.getUnits().forEach{ unit ->
+                            if (!unit.civInfo.canEnterTiles(to)) {
+                                unit.movement.teleportToClosestMoveableTile()
+                            }
+                        }
+                    }
                     to.updateViewableTiles()
                     from.updateViewableTiles()
                 }


### PR DESCRIPTION
Before, if you accepted a trade in which you sell a city at the beginning of your turn, but you still had units in the territory of that city and your units could not enter the tiles of the civilization you sold the city to, those units would not immediately get teleported out: this would only happen at the beginning of your next turn. This PR fixes this bug.

This bug also used to trigger the crash described in #4049 and #4103, since it allowed units to temporarily stand on a tile they are not actually able to move to. More specifically: if one of the units that were not teleported out was selected and they were able to reach a tile with a same-type unit of their own civ that could also reach them, the unit swapping eligibility checking code would crash because it would try to remove the unit and then place them back on an illegal tile.