### PR TITLE
Fixed old worker speed improvement uniques no longer working

### DIFF
--- a/core/src/com/unciv/models/ruleset/tile/TileImprovement.kt
+++ b/core/src/com/unciv/models/ruleset/tile/TileImprovement.kt
@@ -30,13 +30,13 @@ class TileImprovement : NamedStats() {
         var realTurnsToBuild = turnsToBuild.toFloat() * civInfo.gameInfo.gameParameters.gameSpeed.modifier
         for (unique in civInfo.getMatchingUniques("-[]% tile improvement construction time")) {
             realTurnsToBuild *= 1 - unique.params[0].toFloat() / 100f
-            // Deprecated since 3.14.17
-                if (civInfo.hasUnique("Worker construction increased 25%"))
-                    realTurnsToBuild *= 0.75f
-                if (civInfo.hasUnique("Tile improvement speed +25%"))
-                    realTurnsToBuild *= 0.75f
-            //
         }
+        // Deprecated since 3.14.17
+            if (civInfo.hasUnique("Worker construction increased 25%"))
+                realTurnsToBuild *= 0.75f
+            if (civInfo.hasUnique("Tile improvement speed +25%"))
+                realTurnsToBuild *= 0.75f
+        //
         // In some weird cases it was possible for something to take 0 turns, leading to it instead never finishing
         if (realTurnsToBuild < 1) realTurnsToBuild = 1f
         return realTurnsToBuild.roundToInt()


### PR DESCRIPTION
When updating the new uniques for worker improvement speed, I accedentally made the code checking for the old uniques for mod compatability unreachable.
This PR fixes this.