### PR TITLE
Allow sight bonus to specifically target land military unit

### DIFF
--- a/android/assets/jsons/Civ V - Vanilla/Nations.json
+++ b/android/assets/jsons/Civ V - Vanilla/Nations.json
@@ -262,7 +262,7 @@
 		"outerColor": [ 28,51,119],
 		"innerColor": [255,255,255],
 		"uniqueName": "Manifest Destiny",
-		"uniques": ["+1 Sight for all land military units", "-[50]% Gold cost of acquiring tiles [in all cities]"],
+		"uniques": ["+[1] Sight for all [military land] units", "-[50]% Gold cost of acquiring tiles [in all cities]"],
 		"cities": ["Washington","New York","Boston","Philadelphia","Atlanta","Chicago","Seattle","San Francisco","Los Angeles","Houston",
 			"Portland","St. Louis","Miami","Buffalo","Detroit","New Orleans","Baltimore","Denver","Cincinnati","Dallas","Memphis",
 			"Cleveland","Kansas City","San Diego","Richmond","Las Vegas","Phoenix","Albuquerque","Minneapolis","Pittsburgh",

--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -242,6 +242,7 @@ class BaseUnit : INamed, IConstruction {
             "non-air" -> !unitType.isAirUnit()
             "Military", "military units" -> unitType.isMilitary()
             "military water" -> unitType.isMilitary() && unitType.isWaterUnit()
+            "military land" -> unitType.isMilitary() && unitType.isLandUnit()
             else -> false
         }
     }


### PR DESCRIPTION
This will make it possible to target just military land units, similar to how it is now possible to target military water units. This also updates the American unique to make it entirely parameterized.