### PR TITLE
Change improvement picker key indicators to tooltip

### DIFF
--- a/core/src/com/unciv/ui/pickerscreens/ImprovementPickerScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/ImprovementPickerScreen.kt
@@ -14,6 +14,7 @@ import com.unciv.models.ruleset.tile.TileImprovement
 import com.unciv.models.stats.Stats
 import com.unciv.models.translations.tr
 import com.unciv.ui.utils.*
+import com.unciv.ui.utils.StaticTooltip.Companion.addStaticTip
 import kotlin.math.round
 
 class ImprovementPickerScreen(val tileInfo: TileInfo, val onAccept: ()->Unit) : PickerScreen() {
@@ -81,7 +82,6 @@ class ImprovementPickerScreen(val tileInfo: TileInfo, val onAccept: ()->Unit) : 
             }
 
             var labelText = improvement.name.tr()
-            if (shortcutKey != null) labelText += " ($shortcutKey)"
             val turnsToBuild = if (tileInfo.improvementInProgress == improvement.name) tileInfo.turnsToImprovement
             else improvement.getTurnsToBuild(currentPlayerCiv)
             if (turnsToBuild > 0) labelText += " - $turnsToBuild${Fonts.turn}"
@@ -104,10 +104,6 @@ class ImprovementPickerScreen(val tileInfo: TileInfo, val onAccept: ()->Unit) : 
                 "Pick now!".toLabel().onClick { accept(improvement) }
             else "Current construction".toLabel()
 
-            if (shortcutKey != null)
-                keyPressDispatcher[shortcutKey] = { accept(improvement) }
-
-
             val statIcons = getStatIconsTable(provideResource, removeImprovement)
 
             // get benefits of the new improvement
@@ -129,6 +125,12 @@ class ImprovementPickerScreen(val tileInfo: TileInfo, val onAccept: ()->Unit) : 
             improvementButton.add(improvementButtonTable).pad(5f).fillY()
             if (improvement.name == tileInfo.improvementInProgress) improvementButton.color = Color.GREEN
             regularImprovements.add(improvementButton)
+
+            if (shortcutKey != null) {
+                keyPressDispatcher[shortcutKey] = { accept(improvement) }
+                improvementButton.addStaticTip(shortcutKey)
+            }
+
             regularImprovements.add(pickNow).padLeft(10f).fillY()
             regularImprovements.row()
         }


### PR DESCRIPTION
One existing set of "(K)" key indicators I overlooked now use tooltips.

Simple enough - buuuuut - not affecting _this_ PR - I want to allow longer tooltip texts, and need advice. In the following clip I have two tooltips showing "W" - the bottom one is the type merged in master now. The middle one (and top) use a different approach.

https://user-images.githubusercontent.com/63000004/122274248-a4ef2980-cee2-11eb-8ae8-83933428f8a2.mp4

Note how the bottom tip is perfectly round and centered but pixelated - and the middle one is not quite perfectly round but antialiased. The bottom tip can scale (not shown) linearly to more or less any size, while the new variant won't scale smaller cleanly while larger scales would make it a rounded rectangle. You guessed it, no longer an Image.surroundWithCircle but a Label on a getRoundedEdgeRectangle - but - the original of that wouldn't do it nicely at all so I had to create a dupe right down to the backing png. Also, for the new one the ratio of space reserved for descenders becomes relevant for visually pleasing centering, and is now empirically hacked, so scaling up may also affect that.

Questions:
- Is it even worth the effort to allow longer text in tooltips?
- The discrepancy smooth/pixelated is more eye-catching elsewhere - there are surroundWithCircle's inside a ninepatch button, and you _do_ see it. Ideas what to do about that? _Can_ a scaled circle be forced to antialias in Gdx at all?
- If "yes we want all that" - the half-radius getRoundedEdgeRectangle should also go in ImageGetter, yes? Separate fun or by parameter?