### PR TITLE
Fixed crash in some mods

### DIFF
--- a/core/src/com/unciv/logic/civilization/PolicyManager.kt
+++ b/core/src/com/unciv/logic/civilization/PolicyManager.kt
@@ -56,11 +56,15 @@ class PolicyManager {
 
     fun setTransients() {
         // Reassign policies deprecated in 3.14.17, left for backwards compatibility
-            if (adoptedPolicies.contains("Patronage")) {
+            if (adoptedPolicies.contains("Patronage") && 
+                !civInfo.gameInfo.ruleSet.policies.contains("Patronage")
+            ) {
                 adoptedPolicies.add("Merchant Navy")
                 adoptedPolicies.remove("Patronage")
             }
-            if (adoptedPolicies.contains("Entrepreneurship")) {
+            if (adoptedPolicies.contains("Entrepreneurship") &&
+                !civInfo.gameInfo.ruleSet.policies.contains("Entrepreneurship")
+            ) {
                 adoptedPolicies.add("Naval Tradition")
                 adoptedPolicies.remove("Entrepreneurship")
             }


### PR DESCRIPTION
Fixed an issue where mods with either the 'patronage' or 'entrepreneurschip' policy would crash upon the player adopting it.