### PR TITLE
Fixed autocracy complete bonus not continuing after updating to 3.15.2

### DIFF
--- a/core/src/com/unciv/logic/civilization/PolicyManager.kt
+++ b/core/src/com/unciv/logic/civilization/PolicyManager.kt
@@ -1,6 +1,7 @@
 package com.unciv.logic.civilization
 
 import com.unciv.models.ruleset.Policy
+import com.unciv.models.ruleset.Unique
 import com.unciv.models.ruleset.UniqueMap
 import com.unciv.models.ruleset.UniqueTriggerActivation
 import kotlin.math.min
@@ -68,9 +69,16 @@ class PolicyManager {
         for (policyName in adoptedPolicies)
             addPolicyToTransients(getPolicyByName(policyName))
         // Deprecated since 3.14.17, left for backwards compatibility
-        if (cultureBuildingsAdded.isEmpty() && legalismState.isNotEmpty()) {
-            cultureBuildingsAdded.putAll(legalismState)
-        }
+            if (cultureBuildingsAdded.isEmpty() && legalismState.isNotEmpty()) {
+                cultureBuildingsAdded.putAll(legalismState)
+            }
+        //
+        
+        // Deprecated since 3.15.2, left for backwards compatibility
+            if (autocracyCompletedTurns != 0) {
+                civInfo.temporaryUniques.add(Pair(Unique("+[25]% attack strength to all [Military] units for [50] turns"), autocracyCompletedTurns))
+            }
+        //
     }
 
     fun addPolicyToTransients(policy: Policy) {

--- a/core/src/com/unciv/logic/civilization/PolicyManager.kt
+++ b/core/src/com/unciv/logic/civilization/PolicyManager.kt
@@ -77,6 +77,7 @@ class PolicyManager {
         // Deprecated since 3.15.2, left for backwards compatibility
             if (autocracyCompletedTurns != 0) {
                 civInfo.temporaryUniques.add(Pair(Unique("+[25]% attack strength to all [Military] units for [50] turns"), autocracyCompletedTurns))
+                autocracyCompletedTurns = 0
             }
         //
     }


### PR DESCRIPTION
So if you complete the autocracy branch, you get a temporary strength bonus to all attacks.
However, the system managing this bonus was revamped in 3.15.2, and during that refactor I forgot to add already ongoing bonuses into the new system.
This PR rectifies this mistake.