### PR TITLE
Fixed coastal buildings can no longer be built

### DIFF
--- a/core/src/com/unciv/logic/map/TileInfo.kt
+++ b/core/src/com/unciv/logic/map/TileInfo.kt
@@ -399,6 +399,7 @@ open class TileInfo {
     fun matchesUniqueFilter(filter: String, civInfo: CivilizationInfo? = null): Boolean {        
         return when (filter) {
             "All" -> true
+            baseTerrain -> true
             "Water" -> isWater
             "Land" -> isLand
             "Coastal" -> isCoastalTile()


### PR DESCRIPTION
While updating & reordering the `matchesUniqueFilter` of the `TileInfo`, I somehow missed one of the options.
This led to it being impossible to build coastal buildings (lighthouse, etc.) in coastal cities.
This PR rectifies this.