### PR TITLE
Corrected many building production costs, tech requirements and wonder effects

### DIFF
--- a/android/assets/jsons/Civ V - Vanilla/Buildings.json
+++ b/android/assets/jsons/Civ V - Vanilla/Buildings.json
@@ -1,5 +1,7 @@
 [
 	// Ancient Era
+
+	// Always available
 	{
 		"name": "Palace",
 		"isNationalWonder": true,
@@ -18,6 +20,7 @@
 		"hurryCostModifier": 40,
 		"maintenance": 1
 	},
+	// Column 1
 	{
 		"name": "Granary", 
 		"food": 2,
@@ -28,6 +31,16 @@
 			"[+1 Food] from [Wheat] tiles in this city"],
 		"requiredTech": "Pottery"
 	},
+	{
+		"name": "Temple of Artemis",
+		"culture": 1,
+		"isWonder": true,
+		"greatPersonPoints": {"production": 1},
+		"uniques": ["+[10]% [Food] [in all cities]", "+[15]% Production when constructing [Ranged] units [in all cities]"],
+		"requiredTech": "Archery",
+		"quote": "'It is not so much for its beauty that the forest makes a claim upon men's hearts, as for that subtle something, that quality of air, that emanation from old trees, that so wonderfully changes and renews a weary spirit.'  - Robert Louis Stevenson"
+	},
+	// Column 2
 	{
 		"name": "Stone Works", 
 		"happiness": 1,
@@ -105,16 +118,6 @@
 		"requiredTech": "The Wheel"     
 	},
 	{
-		"name": "Temple of Artemis",
-		"culture": 1,
-		"isWonder": true,
-		"cost": 185,
-		"greatPersonPoints": {"production": 1},
-		"uniques": ["+[10]% [Food] [in all cities]", "+[15]% Production when constructing [Ranged] units [in all cities]"],
-		"requiredTech": "Archery",
-		"quote": "'It is not so much for its beauty that the forest makes a claim upon men's hearts, as for that subtle something, that quality of air, that emanation from old trees, that so wonderfully changes and renews a weary spirit.'  - Robert Louis Stevenson"
-	},
-	{
 		"name": "Walls",
 		"cityStrength": 5,
 		"cityHealth": 50,
@@ -188,9 +191,11 @@
 	},
 	
 	// Classical Era
-	
+
+	// Column 3
 	{
 		"name": "Lighthouse",
+		"cost": 75,
 		"hurryCostModifier": 25,
 		"maintenance": 1,
 		"uniques": ["Must be next to [Coast]", "[+1 Food] from [Ocean] tiles in this city",
@@ -199,10 +204,11 @@
 	},
 	{
 		"name": "The Great Lighthouse",
+		"cost": 185,
 		"culture": 1,
 		"greatPersonPoints": {"gold": 1},
 		"isWonder": true,
-		"providesFreeBuilding":  "Lighthouse",
+		"providesFreeBuilding": "Lighthouse",
 		"uniques": ["Must be next to [Coast]", "+[1] Movement for all [{Military} {Water}] units",
 			"+[1] Sight for all [{Military} {Water}] units"],
 		"requiredTech": "Optics",
@@ -260,6 +266,7 @@
 		"requiredTech": "Construction",
 		"quote": "'Regard your soldiers as your children, and they will follow you into the deepest valleys; look on them as your own beloved sons, and they will stand by you even unto death.'  - Sun Tzu"
 	},
+	// Column 4
 	{
 		"name": "Temple",
 		"culture": 3,
@@ -318,15 +325,6 @@
 		"requiredTech": "Currency"
 	},
 	{
-		"name": "National Treasury",
-		"cost": 125,
-		"gold": 8,
-		"culture": 1,
-		"isNationalWonder": true,
-		"uniques": ["Requires a [Market] in all cities", "Cost increases by [30] per owned city"],
-		"requiredTech": "Currency"
-	},
-	{
 		"name": "Bazaar",
 		"replaces": "Market",
 		"uniqueTo": "Arabia",
@@ -336,6 +334,15 @@
 		"percentStatBonus": {"gold": 25},
 		"uniques": ["Provides 1 extra copy of each improved luxury resource near this City",
 			"[+2 Gold] from [Oil] tiles in this city", "[+2 Gold] from [Oasis] tiles in this city"],
+		"requiredTech": "Currency"
+	},
+	{
+		"name": "National Treasury",
+		"cost": 125,
+		"gold": 8,
+		"culture": 1,
+		"isNationalWonder": true,
+		"uniques": ["Requires a [Market] in all cities", "Cost increases by [30] per owned city"],
 		"requiredTech": "Currency"
 	},
 	{
@@ -367,7 +374,7 @@
 		"culture": 3,
 		"greatPersonPoints": {"production": 1},
 		"isWonder": true,
-		"providesFreeBuilding":  "Walls",
+		"providesFreeBuilding": "Walls",
 		"uniques": ["Enemy land units must spend 1 extra movement point when inside your territory (obsolete upon Dynamite)"],
 		"requiredTech": "Engineering",
 		"quote": "'The art of war teaches us to rely not on the likelihood of the enemy's not attacking, but rather on the fact that we have made our position unassailable.'  - Sun Tzu"
@@ -383,10 +390,10 @@
 	},
 	
 	// Medieval Era
-	
+
+	// Column 5
 	{
 		"name": "Garden",
-		"cost": 120,
 		"uniques": ["+[25]% great person generation in this city", "Must be next to [Fresh water]"],
 		"hurryCostModifier": 25,
 		"maintenance": 1,
@@ -472,8 +479,10 @@
 			"+[15]% Production when constructing [Land] units [in this city]",
 			"[+1 Production] from [Iron] tiles in this city"]
 	},
+	// Column 6
 	{
 		"name": "Harbor",
+		"cost": 120,
 		"maintenance": 2,
 		"hurryCostModifier": 25,
 		"uniques": ["[+1 Production] from [Water resource] tiles in this city",
@@ -523,6 +532,7 @@
 	},
 	{
 		"name": "Mughal Fort",
+		"cost": 150,
 		"replaces": "Castle",
 		"uniqueTo": "India",
 		"cityStrength": 7,
@@ -581,7 +591,8 @@
 	},
 	
 	// Renaissance Era
-	
+
+	// Column 7
 	{
 		"name": "Observatory",
 		"maintenance": 0,
@@ -679,15 +690,7 @@
 		"requiredTech": "Gunpowder",
 		"quote": "'Bushido is realized in the presence of death. This means choosing death whenever there is a choice between life and death. There is no other reasoning.'  - Yamamoto Tsunetomo"
 	},
-	{
-		"name": "Museum",
-		"culture": 5,
-		"specialistSlots": {"Artist": 2},
-		"requiredBuilding": "Opera House",
-		"maintenance": 3,
-		"hurryCostModifier": 0,
-		"requiredTech": "Archaeology"
-	},
+	// Column 8
 	{
 		"name": "Hermitage",
 		"cost": 125,
@@ -696,15 +699,6 @@
 		"isNationalWonder": true,
 		"uniques": ["Requires a [Opera House] in all cities", "Cost increases by [30] per owned city"],
 		"requiredTech": "Archaeology"
-	}, 
-	{
-		"name": "The Louvre",
-		"culture": 1,
-		"happiness": 4,
-		"isWonder": true,
-		"uniques": ["[2] free [Great Artist] units appear"],
-		"requiredTech": "Archaeology",
-		"quote": "'Every genuine work of art has as much reason for being as the earth and the sun'  - Ralph Waldo Emerson"
 	},
 	{
 		"name": "Seaport",
@@ -745,7 +739,26 @@
 	},
 	
 	// Industrial Era
-	
+
+	// Column 9
+	{
+		"name": "Museum",
+		"culture": 5,
+		"specialistSlots": {"Artist": 2},
+		"requiredBuilding": "Opera House",
+		"maintenance": 3,
+		"hurryCostModifier": 0,
+		"requiredTech": "Archaeology"
+	},
+	{
+		"name": "The Louvre",
+		"culture": 1,
+		"happiness": 4,
+		"isWonder": true,
+		"uniques": ["[2] free [Great Artist] units appear"],
+		"requiredTech": "Archaeology",
+		"quote": "'Every genuine work of art has as much reason for being as the earth and the sun'  - Ralph Waldo Emerson"
+	},
 	{
 		"name": "Public School",
 		"science": 3,
@@ -758,6 +771,7 @@
 	},
 	{
 		"name": "Factory",
+		"cost": 360,
 		"production": 4,
 		"percentStatBonus": {"production": 10},
 		"specialistSlots": {"Engineer": 2},
@@ -766,6 +780,16 @@
 		"hurryCostModifier": 0,
 		"requiredResource": "Coal",
 		"requiredTech": "Industrialization"
+	},
+	{
+		"name": "Big Ben",
+		"culture": 1,
+		"gold": 4,
+		"greatPersonPoints": {"gold": 2},
+		"isWonder": true,
+		"uniques": ["Cost of purchasing items in cities reduced by [15]%"],
+		"requiredTech": "Industrialization",
+		"quote": "'To achieve great things, two things are needed: a plan, and not quite enough time.'  - Leonard Bernstein"
 	},
 	{
 		"name": "Arsenal",
@@ -793,6 +817,7 @@
 		"requiredTech": "Military Science",
 		"quote": "'Pale Death beats equally at the poor man's gate and at the palaces of kings.'  - Horace"
 	},
+	// Column 10
 	{
 		"name": "Hospital",
 		"food": 5,
@@ -810,20 +835,9 @@
 		"requiredBuilding": "Bank",
 		"requiredTech": "Electricity"
 	},
-	{
-		"name": "Big Ben",
-		"culture": 1,
-		"gold": 4,
-		"greatPersonPoints": {"gold": 2},
-		"isWonder": true,
-		"uniques": ["Cost of purchasing items in cities reduced by [15]%"],
-		"requiredTech": "Industrialization",
-		"quote": "'To achieve great things, two things are needed: a plan, and not quite enough time.'  - Leonard Bernstein"
-	},
 	/* This works and even has icon but AI cannot manage its Aluminum at this moment
 	{
 		"name": "Hydro Plant",
-		"cost": 360,
 		"requiredResource": "Aluminum",
 		"hurryCostModifier": 0,
 		"maintenance": 3,
@@ -833,7 +847,15 @@
 	*/
 	
 	// Modern Era
-	
+
+	// Column 11
+	{
+		"name": "Stadium",
+		"happiness": 4,
+		"requiredBuilding": "Theatre",
+		"maintenance": 2,
+		"requiredTech": "Refrigeration"
+	},
 	{
 		"name": "Broadcast Tower",
 		"culture": 3,
@@ -853,6 +875,14 @@
 		"quote": "'We live only to discover beauty, all else is a form of waiting'  - Kahlil Gibran"
 	},
 	{
+		"name": "Military Base",
+		"cityStrength": 12,
+		"cityHealth": 25,
+		"hurryCostModifier": 25,
+		"requiredBuilding": "Arsenal",
+		"requiredTech": "Replaceable Parts"
+	},
+	{
 		"name": "Statue of Liberty",
 		"culture": 1,
 		"isWonder": true,
@@ -862,40 +892,18 @@
 		"quote": "'Give me your tired, your poor, your huddled masses yearning to breathe free, the wretched refuse of your teeming shore. Send these, the homeless, tempest-tossed to me, I lift my lamp beside the golden door!'  - Emma Lazarus"
 	},
 	{
-		"name": "Research Lab",
-		"science": 4,		
-		"percentStatBonus": {"science": 50},
-		"specialistSlots": {"Scientist": 1},
-		"requiredBuilding": "Public School",
-		"maintenance": 3,
-		"requiredTech": "Plastics"
-	},
-	{
-		"name": "Stadium",
-		"happiness": 4,
-		"requiredBuilding": "Theatre",
-		"maintenance": 2,
-		"requiredTech": "Refrigeration"
-	},
-	{
-		"name": "Military Base",
-		"cityStrength": 12,
-		"cityHealth": 25,
-		"hurryCostModifier": 25,
-		"requiredBuilding": "Arsenal",
-		"requiredTech": "Replaceable Parts"
-	},
-	{
 		"name": "Cristo Redentor",
+		"cost": 1250,
 		"culture": 5,
 		"isWonder": true,
-		"greatPersonPoints": {"culture": 2},		
+		"greatPersonPoints": {"culture": 2},
 		"uniques": ["Culture cost of adopting new Policies reduced by [10]%"],
 		"requiredTech": "Flight",
 		"quote": "'Come to me, all who labor and are heavy burdened, and I will give you rest.'  - New Testament, Matthew 11:28"
 	},
 	{
 		"name": "Kremlin",
+		"cost": 625,
 		"culture": 3,
 		"cityStrength": 12,
 		"isWonder": true,
@@ -915,9 +923,20 @@
 		"requiredTech": "Railroad",
 		"quote": "'...the location is one of the most beautiful to be found, holy and unapproachable, a worthy temple for the divine friend who has brought salvation and true blessing to the world.'  - King Ludwig II of Bavaria"
 	},
-	
+	// Column 12
+	{
+		"name": "Research Lab",
+		"science": 4,
+		"percentStatBonus": {"science": 50},
+		"specialistSlots": {"Scientist": 1},
+		"requiredBuilding": "Public School",
+		"maintenance": 3,
+		"requiredTech": "Plastics"
+	},
+
 	// Information Era
-	
+
+	// Column 13
 	{
 		"name": "Medical Lab",
 		"requiredBuilding": "Hospital",
@@ -926,21 +945,15 @@
 		"uniques": ["[25]% of food is carried over after population increases"]
 	},
 	{
-		"name": "Manhattan Project",
-		"isNationalWonder": true,
-		"uniques": ["Enables nuclear weapon", "Triggers a global alert upon completion"],
-		"requiredTech": "Nuclear Fission"
+		"name": "Pentagon",
+		"isWonder": true,
+		"culture": 3,
+		"greatPersonPoints": {"production": 2},
+		"uniques": ["Gold cost of upgrading military units reduced by 33%"],
+		"requiredTech": "Combined Arms",
+		"quote": "'In preparing for battle I have always found that plans are useless, but planning is indispensable.'  - Dwight D. Eisenhower"
 	},
-	{
-		"name": "Nuclear Plant",
-		"production": 5,		
-		"percentStatBonus": {"production": 15},
-		"requiredBuilding": "Factory",
-		"maintenance": 3,
-		"cannotBeBuiltWith": "Solar Plant",
-		"requiredResource": "Uranium",
-		"requiredTech": "Nuclear Fission"
-	},
+	// Column 14
 	{
 		"name": "Solar Plant",
 		"production": 5,		
@@ -960,6 +973,34 @@
 		"requiredTech": "Ecology",
 		"quote": "'Those who lose dreaming are lost.'  - Australian Aboriginal saying"
 	},
+	{
+		"name": "Nuclear Plant",
+		"production": 5,
+		"percentStatBonus": {"production": 15},
+		"requiredBuilding": "Factory",
+		"maintenance": 3,
+		"cannotBeBuiltWith": "Solar Plant",
+		"requiredResource": "Uranium",
+		"requiredTech": "Nuclear Fission"
+	},
+	{
+		"name": "Manhattan Project",
+		"cost": 750,
+		"isNationalWonder": true,
+		"uniques": ["Enables nuclear weapon", "Triggers a global alert upon completion"],
+		"requiredTech": "Nuclear Fission"
+	},
+	{
+		"name": "Apollo Program",
+		"cost": 750,
+		"isNationalWonder": true,
+		"uniques": ["Enables construction of Spaceship parts", "Triggers a global alert upon completion"],
+		"requiredTech": "Rocketry"
+	},
+
+	// Future Era
+
+	// Column 15
 	/*
 	{
 		"name": "CN Tower",
@@ -970,24 +1011,24 @@
 		"uniques": ["+1 population in each city","+1 happiness in each city"]
 		"requiredTech": "Telecommunications" // todo doesn't exist yet!
 	},
-	{
-		"name": "United Nations",
-		"isWonder": true,
-		"culture": 1,
-		"greatPersonPoints": {"gold": 2},
-		"uniques": ["Triggers voting for the Diplomatic Victory"],
-		"quote": "'More than ever before in human history, we share a common destiny. We can master it only if we face it together. And that is why we have the United Nations.'  - Kofi Annan"
-		"requiredTech": "Globalization", // todo doesn't exist yet!
-	},
 	*/
 	{
-		"name": "Pentagon",
+		"name": "Hubble Space Telescope",
 		"isWonder": true,
-		"culture": 3,
-		"greatPersonPoints": {"production": 2},
-		"uniques": ["Gold cost of upgrading military units reduced by 33%"],
-		"requiredTech": "Combined Arms",
-		"quote": "'In preparing for battle I have always found that plans are useless, but planning is indispensable.'  - Dwight D. Eisenhower"
+		"greatPersonPoints": {"science": 1},
+		"providesFreeBuilding":  "Spaceship Factory",
+		// If spaceship parts are changed into units, the spaceship part unique should be changed to
+		// "+[25]% Production when constructing [Spaceship part] units [in this city]"
+		"uniques": ["[2] free [Great Scientist] units appear",
+			"+[25]% Production when constructing [Spaceship part] [in this city]"],
+		"requiredTech": "Satellites",
+		"quote": "'The wonder is, not that the field of stars is so vast, but that man has measured it.'  - Anatole France"
+	},
+	{
+		"name": "SS Cockpit",
+		"requiredResource": "Aluminum",
+		"requiredTech": "Satellites",
+		"uniques": ["Spaceship part", "Triggers a global alert upon completion", "Cannot be purchased"]
 	},
 	{
 		"name": "Spaceship Factory",
@@ -1006,35 +1047,18 @@
 		"requiredTech": "Robotics",
 		"uniques": ["Spaceship part", "Triggers a global alert upon completion", "Cannot be purchased"]
 	},
+	// Column 16
+	/*
 	{
-		"name": "Apollo Program",
-		"cost": 1500,
-		"isNationalWonder": true,
-		"uniques": ["Enables construction of Spaceship parts", "Triggers a global alert upon completion"],
-		"requiredTech": "Rocketry"
-	},
-	
-	// Future Era
-	
-	{
-		"name": "Hubble Space Telescope",
-		"cost": 1250,
+		"name": "United Nations",
 		"isWonder": true,
-		"greatPersonPoints": {"science": 1},		
-		"providesFreeBuilding":  "Spaceship Factory",
-		// If spaceship parts are changed into units, the spaceship part unique should be changed to
-		// "+[25]% Production when constructing [Spaceship part] units [in this city]"
-		"uniques": ["[2] free [Great Scientist] units appear",
-			"+[25]% Production when constructing [Spaceship part] [in this city]"],
-		"requiredTech": "Satellites",
-		"quote": "'The wonder is, not that the field of stars is so vast, but that man has measured it.'  - Anatole France"
+		"culture": 1,
+		"greatPersonPoints": {"gold": 2},
+		"uniques": ["Triggers voting for the Diplomatic Victory"],
+		"quote": "'More than ever before in human history, we share a common destiny. We can master it only if we face it together. And that is why we have the United Nations.'  - Kofi Annan"
+		"requiredTech": "Globalization", // todo doesn't exist yet!
 	},
-	{
-		"name": "SS Cockpit",
-		"requiredResource": "Aluminum",
-		"requiredTech": "Satellites",
-		"uniques": ["Spaceship part", "Triggers a global alert upon completion", "Cannot be purchased"]
-	},
+	*/
 	{
 		"name": "SS Engine",
 		"requiredResource": "Aluminum",
@@ -1046,9 +1070,9 @@
 		"requiredResource": "Aluminum",
 		"requiredTech": "Nanotechnology",
 		"uniques": ["Spaceship part", "Triggers a global alert upon completion", "Cannot be purchased"]
-	}
-	
-	// All Era's
+	},
+
+	// All Eras
 	
 	{
 		"name": "Utopia Project",

--- a/android/assets/jsons/Civ V - Vanilla/Buildings.json
+++ b/android/assets/jsons/Civ V - Vanilla/Buildings.json
@@ -750,6 +750,7 @@
 	{
 		"name": "Kremlin",
 		"culture": 3,
+		"cityStrength": 12,
 		"isWonder": true,
 		"uniques": ["Defensive buildings in all cities are 25% more effective"],
 		"requiredTech": "Metallurgy",
@@ -897,7 +898,7 @@
 		"culture": 1,
 		"isWonder": true,
 		"greatPersonPoints": {"production": 2},
-		"uniques": ["[+1 Production] from every specialist", "Free Social Policy"],
+		"uniques": ["[+1 Production] from every specialist"],
 		"requiredTech": "Replaceable Parts",
 		"quote": "'Give me your tired, your poor, your huddled masses yearning to breathe free, the wretched refuse of your teeming shore. Send these, the homeless, tempest-tossed to me, I lift my lamp beside the golden door!'  - Emma Lazarus"
 	},

--- a/android/assets/jsons/Civ V - Vanilla/Buildings.json
+++ b/android/assets/jsons/Civ V - Vanilla/Buildings.json
@@ -550,7 +550,7 @@
 		"greatPersonPoints": {"production": 1},
 		"isWonder": true,
 		"uniques": ["-[25]% Culture cost of acquiring tiles [in all cities]","-[25]% Gold cost of acquiring tiles [in all cities]"],
-		"requiredTech": "Chivalry",
+		"requiredTech": "Education",
 		"quote": "'The temple is like no other building in the world. It has towers and decoration and all the refinements which the human genius can conceive of.'  - Antonio da Magdalena"
 	},
 	{

--- a/android/assets/jsons/Civ V - Vanilla/Buildings.json
+++ b/android/assets/jsons/Civ V - Vanilla/Buildings.json
@@ -944,6 +944,13 @@
 		"uniques": ["[25]% of food is carried over after population increases"]
 	},
 	{
+		"name": "Manhattan Project",
+		"cost": 750,
+		"isNationalWonder": true,
+		"uniques": ["Enables nuclear weapon", "Triggers a global alert upon completion"],
+		"requiredTech": "Atomic Theory"
+	},
+	{
 		"name": "Pentagon",
 		"isWonder": true,
 		"culture": 3,
@@ -980,13 +987,6 @@
 		"maintenance": 3,
 		"cannotBeBuiltWith": "Solar Plant",
 		"requiredResource": "Uranium",
-		"requiredTech": "Nuclear Fission"
-	},
-	{
-		"name": "Manhattan Project",
-		"cost": 750,
-		"isNationalWonder": true,
-		"uniques": ["Enables nuclear weapon", "Triggers a global alert upon completion"],
 		"requiredTech": "Nuclear Fission"
 	},
 	{

--- a/android/assets/jsons/Civ V - Vanilla/Buildings.json
+++ b/android/assets/jsons/Civ V - Vanilla/Buildings.json
@@ -178,16 +178,6 @@
 		"quote": "'He spoke, the son of Kronos, and nodded his head with the dark brows, and the immortally anointed hair of the great god swept from his divine head, and all Olympos was shaken' - The Iliad"
 		// "Requires [Honor]" in BNW
 	},
-	{
-		"name": "Colossus",
-		"culture": 1,
-		"gold": 5,
-		"greatPersonPoints": {"gold": 1},
-		"isWonder": true,
-		"uniques": ["Must be next to [Coast]", "[+1 Gold] from [Water] tiles in this city"],
-		"requiredTech": "Iron Working",
-		"quote": "'Why man, he doth bestride the narrow world like a colossus, and we petty men walk under his huge legs, and peep about to find ourselves dishonorable graves.' - William Shakespeare, Julius Caesar"
-	},
 	
 	// Classical Era
 
@@ -397,6 +387,17 @@
 		"uniques": ["Requires a [Barracks] in all cities", "All newly-trained [non-air] units in this city receive the [Morale] promotion",
 			"Cost increases by [30] per owned city"],
 		"requiredTech": "Iron Working"
+	},
+	{
+		"name": "Colossus",
+		"cost": 185,
+		"culture": 1,
+		"gold": 5,
+		"greatPersonPoints": {"gold": 1},
+		"isWonder": true,
+		"uniques": ["Must be next to [Coast]", "[+1 Gold] from [Water] tiles in this city"],
+		"requiredTech": "Iron Working",
+		"quote": "'Why man, he doth bestride the narrow world like a colossus, and we petty men walk under his huge legs, and peep about to find ourselves dishonorable graves.' - William Shakespeare, Julius Caesar"
 	},
 	
 	// Medieval Era

--- a/android/assets/jsons/Civ V - Vanilla/Buildings.json
+++ b/android/assets/jsons/Civ V - Vanilla/Buildings.json
@@ -42,7 +42,7 @@
 	},
 	// Column 2
 	{
-		"name": "Stone Works", 
+		"name": "Stone Works",
 		"happiness": 1,
 		"production": 1,
 		"requiredNearbyImprovedResources": ["Marble", "Stone"],
@@ -69,6 +69,15 @@
 		"requiredTech": "Writing"
 	},
 	{
+		"name": "Paper Maker",
+		"replaces": "Library",
+		"uniqueTo": "China",
+		"hurryCostModifier": 25,
+		"gold": 2,
+		"uniques": ["[+1 Science] per [2] population [in this city]"],
+		"requiredTech": "Writing"
+	},
+	{
 		"name": "The Great Library",
 		"science": 3,
 		"culture": 1,
@@ -80,16 +89,7 @@
 		"quote": "'Libraries are as the shrine where all the relics of the ancient saints, full of true virtue, and all that without delusion or imposture are preserved and reposed.' - Sir Francis Bacon"
 	},
 	{
-		"name": "Paper Maker",
-		"replaces": "Library",
-		"uniqueTo": "China",
-		"hurryCostModifier": 25,
-		"gold": 2,
-		"uniques": ["[+1 Science] per [2] population [in this city]"],
-		"requiredTech": "Writing"
-	},
-	{
-		"name": "Circus", 
+		"name": "Circus",
 		"requiredNearbyImprovedResources": ["Ivory","Horses"],
 		"happiness": 2,
 		"hurryCostModifier": 25,
@@ -108,7 +108,6 @@
 		"name": "Floating Gardens",
 		"replaces": "Water Mill",
 		"uniqueTo": "Aztecs",
-		"cost": 75,
 		"food": 2,
 		"production": 1,
 		"uniques": ["[+2 Food] from [Lakes] tiles in this city", "Must be next to [Fresh water]"],
@@ -144,21 +143,21 @@
 		"quote": "'O, let not the pains of death which come upon thee enter into my body. I am the god Tem, and I am the foremost part of the sky, and the power which protecteth me is that which is with all the gods forever.'  - The Book of the Dead, translated by Sir Ernest Alfred Wallis Budge"
 	},
 	{
+		"name": "Mausoleum of Halicarnassus",
+		"culture": 1,
+		"greatPersonPoints": {"gold": 1},
+		"isWonder": true,
+		"uniques": ["Provides a sum of gold each time you spend a Great Person",
+			"[+2 Gold] from [Marble] tiles in this city", "[+2 Gold] from [Stone] tiles in this city"],
+		"requiredTech": "Masonry",
+		"quote": "'The whole earth is the tomb of heroic men and their story is not given only on stone over their clay but abides everywhere without visible symbol woven into the stuff of other men's lives.' - Pericles"
+	},
+	{
 		"name": "Barracks",
 		"xpForNewUnits": 15,
 		"hurryCostModifier": 25,
 		"maintenance": 1,
 		"requiredTech": "Bronze Working"
-	},
-	{
-		"name": "Colossus",
-		"culture": 1,
-		"gold": 5,
-		"greatPersonPoints": {"gold": 1},
-		"isWonder": true,
-		"uniques": ["Must be next to [Coast]", "[+1 Gold] from [Water] tiles in this city"],
-		"requiredTech": "Iron Working",
-		"quote": "'Why man, he doth bestride the narrow world like a colossus, and we petty men walk under his huge legs, and peep about to find ourselves dishonorable graves.' - William Shakespeare, Julius Caesar"
 	},
 	{
 		"name": "Krepost",
@@ -180,14 +179,14 @@
 		// "Requires [Honor]" in BNW
 	},
 	{
-		"name": "Mausoleum of Halicarnassus",
+		"name": "Colossus",
 		"culture": 1,
+		"gold": 5,
 		"greatPersonPoints": {"gold": 1},
 		"isWonder": true,
-		"uniques": ["Provides a sum of gold each time you spend a Great Person",
-			"[+2 Gold] from [Marble] tiles in this city", "[+2 Gold] from [Stone] tiles in this city"],
-		"requiredTech": "Masonry",
-		"quote": "'The whole earth is the tomb of heroic men and their story is not given only on stone over their clay but abides everywhere without visible symbol woven into the stuff of other men's lives.' - Pericles"
+		"uniques": ["Must be next to [Coast]", "[+1 Gold] from [Water] tiles in this city"],
+		"requiredTech": "Iron Working",
+		"quote": "'Why man, he doth bestride the narrow world like a colossus, and we petty men walk under his huge legs, and peep about to find ourselves dishonorable graves.' - William Shakespeare, Julius Caesar"
 	},
 	
 	// Classical Era
@@ -235,6 +234,14 @@
 		"requiredTech": "Horseback Riding"
 	},
 	{
+		"name": "Courthouse",
+		"maintenance": 4,
+		"hurryCostModifier": 50,
+		"uniques": ["Remove extra unhappiness from annexed cities",
+			"Can only be built in annexed cities"],
+		"requiredTech": "Mathematics"
+	},
+	{
 		"name": "Hanging Gardens",
 		"greatPersonPoints": {"culture": 1},
 		"food": 6,
@@ -243,14 +250,6 @@
 		"providesFreeBuilding": "Garden",
 		"requiredTech": "Mathematics",
 		"quote": "'I think that if ever a mortal heard the word of God it would be in a garden at the cool of the day.'  - F. Frankfort Moore"
-	},
-	{
-		"name": "Courthouse",
-		"maintenance": 4,
-		"hurryCostModifier": 50,
-		"uniques": ["Remove extra unhappiness from annexed cities",
-			"Can only be built in annexed cities"],
-		"requiredTech": "Mathematics"
 	},
 	{
 		"name": "Colosseum", 
@@ -301,13 +300,14 @@
 		"requiredTech": "Philosophy"
 	},
 	{
-		"name": "The Oracle",
-		"culture": 3,
-		"greatPersonPoints": {"science": 1},
-		"isWonder": true,
-		"uniques": ["Free Social Policy"],
-		"requiredTech": "Philosophy",
-		"quote": "'The ancient Oracle said that I was the wisest of all the Greeks. It is because I alone, of all the Greeks, know that I know nothing'  - Socrates"
+		"name": "National College",
+		"cost": 125,
+		"science": 3,
+		"culture": 1,
+		"isNationalWonder": true,
+		"percentStatBonus": {"science": 50},
+		"uniques": ["Requires a [Library] in all cities", "Cost increases by [30] per owned city"],
+		"requiredTech": "Philosophy"
 	},
 	{
 		"name": "National Epic",
@@ -316,6 +316,15 @@
 		"isNationalWonder": true,
 		"uniques": ["Requires a [Monument] in all cities", "+[25]% great person generation in this city", "Cost increases by [30] per owned city"],
 		"requiredTech": "Philosophy"
+	},
+	{
+		"name": "The Oracle",
+		"culture": 3,
+		"greatPersonPoints": {"science": 1},
+		"isWonder": true,
+		"uniques": ["Free Social Policy"],
+		"requiredTech": "Philosophy",
+		"quote": "'The ancient Oracle said that I was the wisest of all the Greeks. It is because I alone, of all the Greeks, know that I know nothing'  - Socrates"
 	},
 	{
 		"name": "Market",
@@ -338,20 +347,20 @@
 		"requiredTech": "Currency"
 	},
 	{
+		"name": "Mint",
+		"maintenance": 0,
+		"requiredNearbyImprovedResources": ["Gold Ore", "Silver"],
+		"hurryCostModifier": 25,
+		"uniques": ["[+2 Gold] from [Gold Ore] tiles in this city", "[+2 Gold] from [Silver] tiles in this city"],
+		"requiredTech": "Currency"
+	},
+	{
 		"name": "National Treasury",
 		"cost": 125,
 		"gold": 8,
 		"culture": 1,
 		"isNationalWonder": true,
 		"uniques": ["Requires a [Market] in all cities", "Cost increases by [30] per owned city"],
-		"requiredTech": "Currency"
-	},
-	{
-		"name": "Mint",
-		"maintenance": 0,
-		"requiredNearbyImprovedResources": ["Gold Ore", "Silver"],
-		"hurryCostModifier": 25,
-		"uniques": ["[+2 Gold] from [Gold Ore] tiles in this city", "[+2 Gold] from [Silver] tiles in this city"],
 		"requiredTech": "Currency"
 	},
 	{ // Flood plains are not supposed to be affected by this wonder. Add stats to all desert tiles and then add negative stats to flood plains to undo the effect on them for now
@@ -416,16 +425,6 @@
 		"uniques": ["+[25]% great person generation in all cities"],
 		"requiredTech": "Theology",
 		"quote": "'For it soars to a height to match the sky, and as if surging up from among the other buildings it stands on high and looks down upon the remainder of the city, adorning it, because it is a part of it, but glorying in its own beauty'  - Procopius, De Aedificis"
-	},
-	{
-		"name": "National College",
-		"cost": 125,
-		"science": 3,
-		"culture": 1,
-		"isNationalWonder": true,
-		"percentStatBonus": {"science": 50},
-		"uniques": ["Requires a [Library] in all cities", "Cost increases by [30] per owned city"],
-		"requiredTech": "Philosophy"
 	},
 	{
 		"name": "Chichen Itza",
@@ -523,6 +522,15 @@
 		"requiredTech": "Education"
 	},
 	{
+		"name": "Angkor Wat",
+		"culture": 1,
+		"greatPersonPoints": {"production": 1},
+		"isWonder": true,
+		"uniques": ["-[25]% Culture cost of acquiring tiles [in all cities]","-[25]% Gold cost of acquiring tiles [in all cities]"],
+		"requiredTech": "Education",
+		"quote": "'The temple is like no other building in the world. It has towers and decoration and all the refinements which the human genius can conceive of.'  - Antonio da Magdalena"
+	},
+	{
 		"name": "Castle",
 		"cityStrength": 7,
 		"cityHealth": 25,
@@ -543,15 +551,6 @@
 		"requiredBuilding": "Walls",
 		"uniques": ["[+1 Gold] once [Flight] is discovered"],
 		"requiredTech": "Chivalry"
-	},
-	{
-		"name": "Angkor Wat",
-		"culture": 1,
-		"greatPersonPoints": {"production": 1},
-		"isWonder": true,
-		"uniques": ["-[25]% Culture cost of acquiring tiles [in all cities]","-[25]% Gold cost of acquiring tiles [in all cities]"],
-		"requiredTech": "Education",
-		"quote": "'The temple is like no other building in the world. It has towers and decoration and all the refinements which the human genius can conceive of.'  - Antonio da Magdalena"
 	},
 	{
 		"name": "Alhambra",
@@ -1012,6 +1011,12 @@
 	},
 	*/
 	{
+		"name": "SS Cockpit",
+		"requiredResource": "Aluminum",
+		"requiredTech": "Satellites",
+		"uniques": ["Spaceship part", "Triggers a global alert upon completion", "Cannot be purchased"]
+	},
+	{
 		"name": "Hubble Space Telescope",
 		"isWonder": true,
 		"greatPersonPoints": {"science": 1},
@@ -1024,9 +1029,9 @@
 		"quote": "'The wonder is, not that the field of stars is so vast, but that man has measured it.'  - Anatole France"
 	},
 	{
-		"name": "SS Cockpit",
+		"name": "SS Booster",
 		"requiredResource": "Aluminum",
-		"requiredTech": "Satellites",
+		"requiredTech": "Robotics",
 		"uniques": ["Spaceship part", "Triggers a global alert upon completion", "Cannot be purchased"]
 	},
 	{
@@ -1039,12 +1044,6 @@
 		// "+[50]% Production when constructing [Spaceship part] units [in this city]"
 		"uniques": ["+[50]% Production when constructing [Spaceship part] [in this city]"],
 		"requiredTech": "Robotics"
-	},
-	{
-		"name": "SS Booster",
-		"requiredResource": "Aluminum",
-		"requiredTech": "Robotics",
-		"uniques": ["Spaceship part", "Triggers a global alert upon completion", "Cannot be purchased"]
 	},
 	// Column 16
 	/*

--- a/android/assets/jsons/Civ V - Vanilla/Buildings.json
+++ b/android/assets/jsons/Civ V - Vanilla/Buildings.json
@@ -677,7 +677,7 @@
 		"culture": 1,
 		"isWonder": true,
 		"greatPersonPoints": {"culture": 1},		
-		"uniques": ["Free Great Person"],
+		"uniques": ["+[25]% great person generation in all cities", "Free Great Person"],
 		"requiredTech": "Printing Press",
 		"quote": "'Don't clap too hard - it's a very old building.' - John Osbourne"
 	},

--- a/android/assets/jsons/Civ V - Vanilla/Buildings.json
+++ b/android/assets/jsons/Civ V - Vanilla/Buildings.json
@@ -237,9 +237,10 @@
 	{
 		"name": "Hanging Gardens",
 		"greatPersonPoints": {"culture": 1},
-		"food": 10,
+		"food": 6,
 		"culture": 1,
 		"isWonder": true,
+		"providesFreeBuilding": "Garden",
 		"requiredTech": "Mathematics",
 		"quote": "'I think that if ever a mortal heard the word of God it would be in a garden at the cool of the day.'  - F. Frankfort Moore"
 	},

--- a/android/assets/jsons/Civ V - Vanilla/Buildings.json
+++ b/android/assets/jsons/Civ V - Vanilla/Buildings.json
@@ -738,6 +738,14 @@
 		"uniques": ["Must not be on [Hill]", "+[10]% Production when constructing [Buildings] [in this city]"],
 		"requiredTech": "Economics"
 	},
+	{
+		"name": "Kremlin",
+		"culture": 3,
+		"isWonder": true,
+		"uniques": ["Defensive buildings in all cities are 25% more effective"],
+		"requiredTech": "Metallurgy",
+		"quote": "'The Law is a fortress on a hill that armies cannot take or floods wash away.'   –- The Prophet Muhammed"
+	},
 	
 	// Industrial Era
 
@@ -891,15 +899,6 @@
 		"uniques": ["[+1 Production] from every specialist", "Free Social Policy"],
 		"requiredTech": "Replaceable Parts",
 		"quote": "'Give me your tired, your poor, your huddled masses yearning to breathe free, the wretched refuse of your teeming shore. Send these, the homeless, tempest-tossed to me, I lift my lamp beside the golden door!'  - Emma Lazarus"
-	},
-	{
-		"name": "Kremlin",
-		"cost": 625,
-		"culture": 3,
-		"isWonder": true,
-		"uniques": ["Defensive buildings in all cities are 25% more effective"],
-		"requiredTech": "Railroad",
-		"quote": "'The Law is a fortress on a hill that armies cannot take or floods wash away.'   –- The Prophet Muhammed"
 	},
 	{
 		"name": "Neuschwanstein",

--- a/android/assets/jsons/Civ V - Vanilla/Buildings.json
+++ b/android/assets/jsons/Civ V - Vanilla/Buildings.json
@@ -888,7 +888,7 @@
 		"culture": 1,
 		"isWonder": true,
 		"greatPersonPoints": {"production": 2},
-		"uniques": ["[+1 Production] from every specialist"],
+		"uniques": ["[+1 Production] from every specialist", "Free Social Policy"],
 		"requiredTech": "Replaceable Parts",
 		"quote": "'Give me your tired, your poor, your huddled masses yearning to breathe free, the wretched refuse of your teeming shore. Send these, the homeless, tempest-tossed to me, I lift my lamp beside the golden door!'  - Emma Lazarus"
 	},

--- a/android/assets/jsons/Civ V - Vanilla/Buildings.json
+++ b/android/assets/jsons/Civ V - Vanilla/Buildings.json
@@ -893,16 +893,6 @@
 		"quote": "'Give me your tired, your poor, your huddled masses yearning to breathe free, the wretched refuse of your teeming shore. Send these, the homeless, tempest-tossed to me, I lift my lamp beside the golden door!'  - Emma Lazarus"
 	},
 	{
-		"name": "Cristo Redentor",
-		"cost": 1250,
-		"culture": 5,
-		"isWonder": true,
-		"greatPersonPoints": {"culture": 2},
-		"uniques": ["Culture cost of adopting new Policies reduced by [10]%"],
-		"requiredTech": "Flight",
-		"quote": "'Come to me, all who labor and are heavy burdened, and I will give you rest.'  - New Testament, Matthew 11:28"
-	},
-	{
 		"name": "Kremlin",
 		"cost": 625,
 		"culture": 3,
@@ -933,6 +923,15 @@
 		"requiredBuilding": "Public School",
 		"maintenance": 3,
 		"requiredTech": "Plastics"
+	},
+	{
+		"name": "Cristo Redentor",
+		"culture": 5,
+		"isWonder": true,
+		"greatPersonPoints": {"culture": 2},
+		"uniques": ["Culture cost of adopting new Policies reduced by [10]%"],
+		"requiredTech": "Plastics",
+		"quote": "'Come to me, all who labor and are heavy burdened, and I will give you rest.'  - New Testament, Matthew 11:28"
 	},
 
 	// Information Era

--- a/android/assets/jsons/Civ V - Vanilla/Buildings.json
+++ b/android/assets/jsons/Civ V - Vanilla/Buildings.json
@@ -693,15 +693,6 @@
 	},
 	// Column 8
 	{
-		"name": "Hermitage",
-		"cost": 125,
-		"percentStatBonus": {"culture": 50},
-		"culture": 5,
-		"isNationalWonder": true,
-		"uniques": ["Requires a [Opera House] in all cities", "Cost increases by [30] per owned city"],
-		"requiredTech": "Archaeology"
-	},
-	{
 		"name": "Seaport",
 		"hurryCostModifier": 25,
 		"maintenance": 3,
@@ -709,6 +700,15 @@
 		"uniques": ["[+1 Production, +1 Gold] from [Water resource] tiles in this city",
 			"Must be next to [Coast]", "+[15]% Production when constructing [Water] units [in this city]"],
 		"requiredTech": "Navigation"
+	},
+	{
+		"name": "Hermitage",
+		"cost": 125,
+		"percentStatBonus": {"culture": 50},
+		"culture": 5,
+		"isNationalWonder": true,
+		"uniques": ["Requires a [Opera House] in all cities", "Cost increases by [30] per owned city"],
+		"requiredTech": "Architecture"
 	},
 	{
 		"name": "Taj Mahal",

--- a/android/assets/jsons/Civ V - Vanilla/Buildings.json
+++ b/android/assets/jsons/Civ V - Vanilla/Buildings.json
@@ -896,7 +896,6 @@
 		"name": "Kremlin",
 		"cost": 625,
 		"culture": 3,
-		"cityStrength": 12,
 		"isWonder": true,
 		"uniques": ["Defensive buildings in all cities are 25% more effective"],
 		"requiredTech": "Railroad",

--- a/android/assets/jsons/Civ V - Vanilla/Buildings.json
+++ b/android/assets/jsons/Civ V - Vanilla/Buildings.json
@@ -739,6 +739,15 @@
 		"requiredTech": "Economics"
 	},
 	{
+		"name": "Arsenal",
+		"cost": 300,
+		"cityStrength": 9,
+		"cityHealth": 25,
+		"hurryCostModifier": 25,
+		"requiredBuilding": "Castle",
+		"requiredTech": "Metallurgy"
+	},
+	{
 		"name": "Kremlin",
 		"culture": 3,
 		"isWonder": true,
@@ -799,14 +808,6 @@
 		"uniques": ["Cost of purchasing items in cities reduced by [15]%"],
 		"requiredTech": "Industrialization",
 		"quote": "'To achieve great things, two things are needed: a plan, and not quite enough time.'  - Leonard Bernstein"
-	},
-	{
-		"name": "Arsenal",
-		"cityStrength": 9,
-		"cityHealth": 25,
-		"hurryCostModifier": 25,
-		"requiredBuilding": "Castle",
-		"requiredTech": "Metallurgy"
 	},
 	{
 		"name": "Military Academy",

--- a/android/assets/jsons/Civ V - Vanilla/Buildings.json
+++ b/android/assets/jsons/Civ V - Vanilla/Buildings.json
@@ -344,15 +344,6 @@
 		"uniques": ["[+2 Gold] from [Gold Ore] tiles in this city", "[+2 Gold] from [Silver] tiles in this city"],
 		"requiredTech": "Currency"
 	},
-	{
-		"name": "National Treasury",
-		"cost": 125,
-		"gold": 8,
-		"culture": 1,
-		"isNationalWonder": true,
-		"uniques": ["Requires a [Market] in all cities", "Cost increases by [30] per owned city"],
-		"requiredTech": "Currency"
-	},
 	{ // Flood plains are not supposed to be affected by this wonder. Add stats to all desert tiles and then add negative stats to flood plains to undo the effect on them for now
 		"name": "Petra",
 		"culture": 1,
@@ -436,6 +427,15 @@
 		"uniques": ["Golden Age length increased by [50]%"],
 		"requiredTech": "Civil Service",
 		"quote": "'The katun is established at Chichen Itza. The settlement of the Itza shall take place there. The quetzal shall come, the green bird shall come. Ah Kantenal shall come. It is the word of God. The Itza shall come.'  - The Books of Chilam Balam"
+	},
+	{
+		"name": "National Treasury",
+		"cost": 125,
+		"gold": 8,
+		"culture": 1,
+		"isNationalWonder": true,
+		"uniques": ["Requires a [Market] in all cities", "Cost increases by [30] per owned city"],
+		"requiredTech": "Guilds"
 	},
 	{
 		"name": "Machu Picchu",

--- a/android/assets/jsons/Civ V - Vanilla/Techs.json
+++ b/android/assets/jsons/Civ V - Vanilla/Techs.json
@@ -18,6 +18,7 @@
 		"era": "Ancient era",
 		"techCost": 35, 
 		"buildingCost": 60,
+		"wonderCost": 185,
 		"techs": [
 			{
 				"name": "Pottery",
@@ -136,8 +137,8 @@
 		"columnNumber": 4,
 		"era": "Classical era",
 		"techCost": 175, 
-		"buildingCost": 120,
-		"wonderCost": 300,
+		"buildingCost": 100,
+		"wonderCost": 250,
 		"techs": [
 			{
 				"name": "Philosophy",
@@ -170,8 +171,8 @@
 		"columnNumber": 5,
 		"era": "Medieval era",
 		"techCost": 275,
-		"buildingCost": 160,
-		"wonderCost": 400,
+		"buildingCost": 120,
+		"wonderCost": 300,
 		"techs": [
 			{
 				"name": "Theology",
@@ -205,8 +206,8 @@
 		"columnNumber": 6,
 		"era": "Medieval era",
 		"techCost": 485, 
-		"buildingCost": 200,
-		"wonderCost": 500,
+		"buildingCost": 160,
+		"wonderCost": 400,
 		"techs": [
 			{
 				"name": "Compass",
@@ -253,8 +254,8 @@
 		"columnNumber": 7,
 		"era": "Renaissance era",
 		"techCost": 780, 
-		"buildingCost": 250,
-		"wonderCost": 625,
+		"buildingCost": 200,
+		"wonderCost": 500,
 		"techs": [
 			{
 				"name": "Astronomy",
@@ -293,8 +294,8 @@
 		"columnNumber": 8,
 		"era": "Renaissance era",
 		"techCost": 1150, 
-		"buildingCost": 300,
-		"wonderCost": 750,
+		"buildingCost": 250,
+		"wonderCost": 625,
 		"techs": [
 			{
 				"name": "Navigation",
@@ -332,8 +333,8 @@
 		"columnNumber": 9,
 		"era": "Industrial era",
 		"techCost": 1600,
-		"buildingCost": 360,
-		"wonderCost": 920,
+		"buildingCost": 300,
+		"wonderCost": 750,
 		"techs": [
 			{
 				"name": "Archaeology",
@@ -377,8 +378,8 @@
 		"columnNumber": 10,
 		"era": "Industrial era",
 		"techCost": 2350,
-		"buildingCost": 500,
-		"wonderCost": 1060,
+		"buildingCost": 360,
+		"wonderCost": 900, // Note that this column doesn't actually have any wonders. This just continues the wonderCost = 2.5 * buildingCost pattern from the last few columns.
 		"techs": [
 			{
 				"name": "Biology",
@@ -412,7 +413,7 @@
 		"era": "Modern era",
 		"techCost": 3100,
 		"buildingCost": 500,
-		"wonderCost": 1250,
+		"wonderCost": 1060,
 		"techs": [
 			{
 				"name": "Refrigeration",
@@ -516,8 +517,8 @@
 		"columnNumber": 14,
 		"era": "Information era",
 		"techCost": 6400,
-		"buildingCost": 750,
-		"wonderCost": 2000,
+		"buildingCost": 500,
+		"wonderCost": 1250,
 		"techs": [
 			{
 				"name": "Ecology",


### PR DESCRIPTION
Many, and I do mean many, of the building production costs are wrong according to the wiki.
Each column of the tech tree has a building cost (of which only a few buildings deviate). The primary source of errors is that these building costs have been shifted one column over starting from column 4, the second column of the Renaissance, causing almost all buildings from that point on to be too expensive. There were a few other errors as well, all causing buildings to be too expensive. This PR corrects all of the production costs.

Furthermore, This PR also corrects many tech requirements and wonder behaviors: many of these were incorrect as well. Note that while the building corrections are exhaustive, these may not be. I would have done this in a separate PRs, but they would no doubt have had conflicts with the cost changes, so I just put everything in a single PR.

Here is the full changelog:

---

Production cost changes:
(Changes marked with "(!)" are different from the tech column cost shift)
```
Lighthouse         100 -> 75  (!)
Great Lighthouse   250 -> 185 (!)

Temple             120 -> 100
Burial Tomb        120 -> 100
Mud Pyramid Mosque 120 -> 100
Market             120 -> 100
Bazaar             120 -> 100
Mint               120 -> 100
Aqueduct           120 -> 100
The Oracle         300 -> 250
Petra              300 -> 250
Great Wall         300 -> 250
Colossus           300 -> 185 (!)

Monastery          160 -> 120
Workshop           160 -> 120
Forge              160 -> 120
Hagia Sophia       400 -> 300
Chichen Itza       400 -> 300
Machu Picchu       400 -> 300

Harbor             200 -> 120 (!)
University         200 -> 160
Wat                200 -> 160
Castle             200 -> 160
Mughal Fort        200 -> 150 (!)
Armory             200 -> 160
Angkor Wat         500 -> 400
Alhambra           500 -> 400
Notre Dame         500 -> 400

Observatory        250 -> 200
Opera House        250 -> 200
Bank               250 -> 200
Satrap's Court     250 -> 200
Hanse              250 -> 200
Theatre            250 -> 200
Sistine Chapel     625 -> 500
Forbidden Palace   625 -> 500
L. Tower of Pisa   625 -> 500
Himeji Castle      625 -> 500

Seaport            300 -> 250
Windmill           300 -> 250
Taj Mahal          750 -> 625
Porcelain Tower    750 -> 625
Kremlin            1250 -> 625 (!)

Museum             360 -> 300
Public School      360 -> 300
Military Academy   360 -> 300
Louvre             920 -> 750
Big Ben            920 -> 750
Brandenburg Gate   920 -> 750

Hospital           500 -> 360
Stock Exchange     500 -> 360

Eiffel Tower       1250 -> 1060
Statue of Liberty  1250 -> 1060
Neuschwanstein     1250 -> 1060

Manhattan Project  2000 -> 750  (!)

Solar Plant        750  -> 500
Nuclear Plant      750  -> 500
Sydney Opera House 2000 -> 1250
Apollo Program     1500 -> 750  (!)
```

Tech requirement and wonder effect changes:
```
Hanging gardens:
10 food -> 6 food
Now provides a free Garden

National Treasury:
Now unlocked with Guilds instead of Currency

Angkor Wat:
Now unlocked with Education instead of Chivalry

Leaning Tower of Pisa:
Now provides +25% great person generation in all cities

Hermitage:
Now unlocked with Architecture instead of Archaeology

Kremlin:
Now unlocked with Metallurgy instead of Railroad

Cristo Redentor:
Now unlocked with Plastics instead of Flight

Manhattan Project:
Now unlocked with Atomic Theory instead of Nuclear Fission
This does buff nuclear missiles quite a bit, since you no longer need
Nuclear Fission, but that's only because the last part of the tech tree
is very incomplete, and provides nuclear missiles too early. We need to
start correcting it somewhere.
```

---

Final note: according to the wiki, National Treasury has a base cost of 120 instead of 125. However, every single other national wonder has a base cost of 125, so I just left the base cost in Unciv at 125. EDIT: @xlenstra has confirmed that the wiki is in error on this one.

EDIT: made some more corrections, which have been included in the changelog.
EDIT: reverted some incorrect corrections identified by @ravignir and updated the changelog.