### PR TITLE
AI will never pillage their own tiles anymore

### DIFF
--- a/core/src/com/unciv/logic/automation/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/UnitAutomation.kt
@@ -223,8 +223,9 @@ object UnitAutomation {
         if (unit.type.isCivilian()) return false
         val unitDistanceToTiles = unit.movement.getDistanceToTiles()
         val tilesThatCanWalkToAndThenPillage = unitDistanceToTiles
-                .filter { it.value.totalDistance < unit.currentMovement }.keys
-                .filter { unit.movement.canMoveTo(it) && UnitActions.canPillage(unit, it) }
+            .filter { it.value.totalDistance < unit.currentMovement }.keys
+            .filter { unit.movement.canMoveTo(it) && UnitActions.canPillage(unit, it) }
+            .filter { it.getOwner() != unit.civInfo }
 
         if (tilesThatCanWalkToAndThenPillage.isEmpty()) return false
         val tileToPillage = tilesThatCanWalkToAndThenPillage.maxByOrNull { it: TileInfo -> it.getDefensiveBonus() }!!


### PR DESCRIPTION
In some cases it might be better to pillage your own tiles, but more often than not it is better to not do this.
This PR makes it so AI never pillage their own tiles.
Fixes #4203.

Feel free to discuss if this change makes sense, and in which cases this makes the AI worse, I'll update the PR if need be.