### PR TITLE
Fix potential corrency problem

### DIFF
--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -578,8 +578,8 @@ class WorldScreen(val gameInfo: GameInfo, val viewingCiv:CivilizationInfo) : Cam
         shouldUpdate = true
 
 
+        val gameInfoClone = gameInfo.clone()
         thread(name = "NextTurn") { // on a separate thread so the user can explore their world while we're passing the turn
-            val gameInfoClone = gameInfo.clone()
             gameInfoClone.setTransients()
             try {
                 gameInfoClone.nextTurn()


### PR DESCRIPTION
This probably fixes #4198, by making the copy of the complete gameInfo on the main thread, so it cannot be changed midcopy, resulting to the behaviour described in this problem.
NOTE: Merging this may result in a small window in time in which the game is unresponsive, especially for larger longer games. 
That might be enough reason to close this PR already.