### PR TITLE
Fixed open terrain bonus working in rough terrain

### DIFF
--- a/android/assets/jsons/Civ V - Vanilla/Terrains.json
+++ b/android/assets/jsons/Civ V - Vanilla/Terrains.json
@@ -21,7 +21,7 @@
 		"food": 2,
 		"movementCost": 1,
 		"RGB": [97,171,58],
-		"uniques": ["Occurs at temperature between [-0.4] and [0.8] and humidity between [0.5] and [1]", "Open terrain"]
+		"uniques": ["Occurs at temperature between [-0.4] and [0.8] and humidity between [0.5] and [1]"]
 	},
 	{
 		"name": "Plains",
@@ -31,7 +31,7 @@
 		"movementCost": 1,
 		"RGB": [168,185,102],
 		"uniques": ["Occurs at temperature between [-0.4] and [0.8] and humidity between [0] and [0.5]",
-			"Occurs at temperature between [0.8] and [1] and humidity between [0.7] and [1]", "Open terrain"]
+			"Occurs at temperature between [0.8] and [1] and humidity between [0.7] and [1]"]
 	},
 	{
 		"name": "Tundra",
@@ -39,14 +39,14 @@
 		"food": 1,
 		"movementCost": 1,
 		"RGB": [189,204,191],
-		"uniques": ["Occurs at temperature between [-1] and [-0.4] and humidity between [0.5] and [1]", "Open terrain"]
+		"uniques": ["Occurs at temperature between [-1] and [-0.4] and humidity between [0.5] and [1]"]
 	},
 	{
 		"name": "Desert",
 		"type": "Land",
 		"movementCost": 1,
 		"RGB": [ 230, 230, 113],
-		"uniques": ["Occurs at temperature between [0.8] and [1] and humidity between [0] and [0.7]", "Open terrain"]
+		"uniques": ["Occurs at temperature between [0.8] and [1] and humidity between [0] and [0.7]"]
 	},
 	{
 		"name": "Lakes",
@@ -69,25 +69,27 @@
 		"type": "Land",
 		"movementCost": 1,
 		"RGB": [231, 242, 249],
-		"uniques": ["Occurs at temperature between [-1] and [-0.4] and humidity between [0] and [0.5]", "Open terrain"]
+		"uniques": ["Occurs at temperature between [-1] and [-0.4] and humidity between [0] and [0.5]"]
 	},
 	
 	// Terrain features
 	{
 		"name": "Hill",
 		"type": "TerrainFeature",
+		"rough": true,
 		"production": 2,
 		"movementCost": 2,
 		"overrideStats": true,
 		"defenceBonus": 0.25,
 		"RGB": [105,125,72],
 		"occursOn": ["Tundra","Plains","Grassland","Desert","Snow"],
-		"uniques": ["Rough terrain", "[+5] Strength for cities built on this terrain",
+		"uniques": ["[+5] Strength for cities built on this terrain",
 			"[+1] Sight for [Land] units", "Has an elevation of [2] for visibility calculations"]
 	},
 	{
 		"name": "Forest",
 		"type": "TerrainFeature",
+		"rough": true,
 		"production": 1,
 		"food": 1,
 		"movementCost": 2,
@@ -95,19 +97,20 @@
 		"unbuildable": true,
 		"defenceBonus": 0.25,
 		"occursOn": ["Tundra","Plains","Grassland","Hill"],
-		"uniques": ["Provides a one-time Production bonus to the closest city when cut down", "Rough terrain",
+		"uniques": ["Provides a one-time Production bonus to the closest city when cut down",
 			"Blocks line-of-sight from tiles at same elevation"]
 	},
 	{
 		"name": "Jungle",
 		"type": "TerrainFeature",
+		"rough": true,
 		"food": 2,
 		"movementCost": 2,
 		"overrideStats": true,
 		"unbuildable": true,
 		"defenceBonus": 0.25,
 		"occursOn": ["Plains","Grassland"],
-		"uniques": ["Rough terrain", "Blocks line-of-sight from tiles at same elevation"]
+		"uniques": ["Blocks line-of-sight from tiles at same elevation"]
 	},
 	{
 		"name": "Marsh",
@@ -147,7 +150,6 @@
 		"movementCost": 1,
 		"defenceBonus": -0.1,
 		"occursOn": ["Desert"]
-		"uniques":["Open terrain"]
 	},
 	{
 		"name": "Ice",

--- a/android/assets/jsons/Civ V - Vanilla/Terrains.json
+++ b/android/assets/jsons/Civ V - Vanilla/Terrains.json
@@ -62,7 +62,7 @@
 		"impassable": true,
 		"defenceBonus": 0.25,
 		"RGB": [120, 120, 120],
-		"uniques":["Has an elevation of [4] for visibility calculations"]
+		"uniques":["Rough terrain", "Has an elevation of [4] for visibility calculations"]
 	},
 	{
 		"name": "Snow",
@@ -76,20 +76,18 @@
 	{
 		"name": "Hill",
 		"type": "TerrainFeature",
-		"rough": true,
 		"production": 2,
 		"movementCost": 2,
 		"overrideStats": true,
 		"defenceBonus": 0.25,
 		"RGB": [105,125,72],
 		"occursOn": ["Tundra","Plains","Grassland","Desert","Snow"],
-		"uniques": ["[+5] Strength for cities built on this terrain",
+		"uniques": ["Rough terrain", "[+5] Strength for cities built on this terrain",
 			"[+1] Sight for [Land] units", "Has an elevation of [2] for visibility calculations"]
 	},
 	{
 		"name": "Forest",
 		"type": "TerrainFeature",
-		"rough": true,
 		"production": 1,
 		"food": 1,
 		"movementCost": 2,
@@ -97,20 +95,19 @@
 		"unbuildable": true,
 		"defenceBonus": 0.25,
 		"occursOn": ["Tundra","Plains","Grassland","Hill"],
-		"uniques": ["Provides a one-time Production bonus to the closest city when cut down",
+		"uniques": ["Rough terrain", "Provides a one-time Production bonus to the closest city when cut down",
 			"Blocks line-of-sight from tiles at same elevation"]
 	},
 	{
 		"name": "Jungle",
 		"type": "TerrainFeature",
-		"rough": true,
 		"food": 2,
 		"movementCost": 2,
 		"overrideStats": true,
 		"unbuildable": true,
 		"defenceBonus": 0.25,
 		"occursOn": ["Plains","Grassland"],
-		"uniques": ["Blocks line-of-sight from tiles at same elevation"]
+		"uniques": ["Rough terrain", "Blocks line-of-sight from tiles at same elevation"]
 	},
 	{
 		"name": "Marsh",

--- a/core/src/com/unciv/logic/map/TileInfo.kt
+++ b/core/src/com/unciv/logic/map/TileInfo.kt
@@ -408,12 +408,12 @@ open class TileInfo {
             "River" -> isAdjacentToRiver()
             improvement -> true
             naturalWonder -> true
+            "Open terrain" -> !isRoughTerrain()
+            "Rough terrain" -> isRoughTerrain()
             "Foreign Land" -> civInfo != null && !isFriendlyTerritory(civInfo)
             "Friendly Land" -> civInfo != null && isFriendlyTerritory(civInfo)
             else -> {
                 if (terrainFeatures.contains(filter)) return true
-                if (filter == "Open terrain" && !isRoughTerrain()) return true
-                if (filter == "Rough terrain" && isRoughTerrain()) return true
                 if (hasUnique(filter)) return true
                 if (resource != null && getTileResource().resourceType.name + " resource" == filter) return true
                 if (civInfo != null && hasViewableResource(civInfo) && resource == filter) return true

--- a/core/src/com/unciv/logic/map/TileInfo.kt
+++ b/core/src/com/unciv/logic/map/TileInfo.kt
@@ -201,6 +201,8 @@ open class TileInfo {
         yieldAll(terrainFeatures.asSequence().mapNotNull { ruleset.terrains[it] })
     }
 
+    fun isRoughTerrain() = getAllTerrains().any{ it.isRough() }
+
     fun hasUnique(unique: String) = getAllTerrains().any { it.uniques.contains(unique) }
 
     fun getWorkingCity(): CityInfo? {
@@ -410,8 +412,9 @@ open class TileInfo {
             "Friendly Land" -> civInfo != null && isFriendlyTerritory(civInfo)
             else -> {
                 if (terrainFeatures.contains(filter)) return true
-                if (baseTerrainObject.uniques.contains(filter)) return true
-                if (terrainFeatures.isNotEmpty() && getTerrainFeatures().last().uniques.contains(filter)) return true
+                if (filter == "Open terrain" && !isRoughTerrain()) return true
+                if (filter == "Rough terrain" && isRoughTerrain()) return true
+                if (hasUnique(filter)) return true
                 if (resource != null && getTileResource().resourceType.name + " resource" == filter) return true
                 if (civInfo != null && hasViewableResource(civInfo) && resource == filter) return true
                 return false

--- a/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
+++ b/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
@@ -43,7 +43,7 @@ class UnitMovementAlgorithms(val unit:MapUnit) {
         if (civInfo.nation.ignoreHillMovementCost && to.isHill())
             return 1f + extraCost // usually hills take 2 movements, so here it is 1
 
-        if (unit.roughTerrainPenalty && to.getAllTerrains().any { it.rough || it.uniques.contains("Rough terrain") })
+        if (unit.roughTerrainPenalty && to.isRoughTerrain())
             return 4f + extraCost
 
         if (unit.doubleMovementInCoast && to.baseTerrain == Constants.coast)

--- a/core/src/com/unciv/models/ruleset/tile/Terrain.kt
+++ b/core/src/com/unciv/models/ruleset/tile/Terrain.kt
@@ -36,22 +36,19 @@ class Terrain : NamedStats() {
     var defenceBonus:Float = 0f
     var impassable = false
 
-    /**
-     * Do not use this directly! Use isRough() instead.
-     * Modded tiles may use the deprecated "Rough terrain" unique instead of this value, which is handled by isRough().
-     */
+    /** Use isRough() instead */
+    @Deprecated("As of 3.14.1")
     var rough = false
 
     fun isRough(): Boolean {
-        // "Rough terrain" unique deprecated since 3.15.4
-        return rough || uniques.contains("Rough terrain")
+        // "rough" property deprecated since 3.14.1
+        return uniques.contains("Rough terrain") || rough
     }
 
     fun getColor(): Color { // Can't be a lazy initialize, because we play around with the resulting color with lerp()s and the like
         if (RGB == null) return Color.GOLD
         return colorFromRGB(RGB!!)
     }
-
 
     fun getDescription(ruleset: Ruleset): String {
         val sb = StringBuilder()
@@ -72,8 +69,7 @@ class Terrain : NamedStats() {
             sb.appendLine("Open terrain".tr())
 
         if(uniques.isNotEmpty())
-            // "Open terrain" and "Rough terrain" uniques deprecated since 3.15.4
-            sb.appendLine(uniques.filter{ it != "Open terrain" && it != "Rough terrain"}.joinToString { it.tr() })
+            sb.appendLine(uniques.filter{ it != "Rough terrain" }.joinToString{ it.tr() })
 
         if (impassable)
             sb.appendLine(Constants.impassable.tr())

--- a/core/src/com/unciv/models/ruleset/tile/Terrain.kt
+++ b/core/src/com/unciv/models/ruleset/tile/Terrain.kt
@@ -35,10 +35,17 @@ class Terrain : NamedStats() {
     var movementCost = 1
     var defenceBonus:Float = 0f
     var impassable = false
-    
-    @Deprecated("As of 3.14.1")
+
+    /**
+     * Do not use this directly! Use isRough() instead.
+     * Modded tiles may use the deprecated "Rough terrain" unique instead of this value, which is handled by isRough().
+     */
     var rough = false
 
+    fun isRough(): Boolean {
+        // "Rough terrain" unique deprecated since 3.15.4
+        return rough || uniques.contains("Rough terrain")
+    }
 
     fun getColor(): Color { // Can't be a lazy initialize, because we play around with the resulting color with lerp()s and the like
         if (RGB == null) return Color.GOLD
@@ -59,8 +66,14 @@ class Terrain : NamedStats() {
         if (resourcesFound.isNotEmpty())
             sb.appendLine("May contain [${resourcesFound.joinToString(", ") { it.name.tr() }}]".tr())
 
+        if (isRough())
+            sb.appendLine("Rough terrain".tr())
+        else
+            sb.appendLine("Open terrain".tr())
+
         if(uniques.isNotEmpty())
-            sb.appendLine(uniques.joinToString { it.tr() })
+            // "Open terrain" and "Rough terrain" uniques deprecated since 3.15.4
+            sb.appendLine(uniques.filter{ it != "Open terrain" && it != "Rough terrain"}.joinToString { it.tr() })
 
         if (impassable)
             sb.appendLine(Constants.impassable.tr())
@@ -69,9 +82,6 @@ class Terrain : NamedStats() {
 
         if (defenceBonus != 0f)
             sb.appendLine("{Defence bonus}: ".tr() + (defenceBonus * 100).toInt() + "%")
-
-        if (rough)
-            sb.appendLine("Rough Terrain".tr())
 
         return sb.toString()
     }


### PR DESCRIPTION
Fixed #4139 - The open terrain combat bonus no longer works in rough terrain.

Deprecated "Open terrain" and "Rough terrain" terrain uniques and undeprecated terrain property "rough", effectively reverting b312d24d4a70092e340b6f3c9a468832c5c846cf (but not https://github.com/yairm210/Unciv/commit/d825352bf42181c4e49c34ec9096de1b54272b1a).

Also made the tileFilter implementation consider uniques of natural wonders, which it didn't before.

Motivation:

Tiles are either open or rough, and cannot be both at the same time. This change makes tiles open until proven otherwise - open unless they have a base terrain, natural wonder or terrain feature that is rough. This is already how it worked for other purposes such as movement costs, though natural wonders were not always considered.

An alternative would be to allow terrain features to "override" the roughness of the base terrain, thereby allowing mods with rough base terrains and features that make those terrains open again. However, this would probably be needlessly complicated, and terrains can have multiple features, so you'd have to consider what to do if a tile has both an open and a rough terrain feature.

Because of the new approach, the "Open terrain" unique wasn't used anymore (except for the terrain description in the civlopedia). Because of this, and the fact that terrain roughness is a very basic concept, I deprecated the uniques in favor of the old "rough" property. Of course, we could also keep using the uniques, or only the "Rough terrain"  unique instead, if that is preferred.