### PR TITLE
Fixed a bug where excess food would not be converted to production for settlers

### DIFF
--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -251,7 +251,10 @@ class BaseUnit : INamed, IConstruction {
             "Military", "military units" -> unitType.isMilitary()
             // Deprecated as of 3.15.2
             "military water" -> unitType.isMilitary() && unitType.isWaterUnit()
-            else -> false
+            else -> {
+                if (uniques.contains(filter)) return true
+                return false
+            }
         }
     }
 


### PR DESCRIPTION
Due to changes in how filters work for units made in #4142, you could no longer filter units by their unique when constructing them.
This resulted in, among other things, building settlers no longer made excess food convert to production.
This PR rectifies this.
Fixes #4218.