### PR TITLE
Alternative fix for the open-rough terrain problem

### DIFF
--- a/android/assets/jsons/Civ V - Vanilla/TerrainTypes.json
+++ b/android/assets/jsons/Civ V - Vanilla/TerrainTypes.json
@@ -1,0 +1,10 @@
+[
+    {
+        "name": "Rough terrain",
+        "priority": 1
+    },
+    {
+        "name": "Open terrain",
+        "priority": 0
+    }
+]

--- a/android/assets/jsons/Civ V - Vanilla/Terrains.json
+++ b/android/assets/jsons/Civ V - Vanilla/Terrains.json
@@ -6,14 +6,16 @@
 		"food": 1,
 		"gold": 1,
 		"movementCost": 1,
-		"RGB": [45,108,145]
+		"RGB": [45,108,145],
+		"uniques": ["Open terrain"]
 	},
 	{
 		"name": "Coast",
 		"type": "Water",
 		"food": 1,
 		"movementCost": 1,
-		"RGB": [107,167,193]
+		"RGB": [107,167,193],
+		"uniques": ["Open terrain"]
 	},
 	{
 		"name": "Grassland",

--- a/android/assets/jsons/Civ V - Vanilla/Terrains.json
+++ b/android/assets/jsons/Civ V - Vanilla/Terrains.json
@@ -7,7 +7,7 @@
 		"gold": 1,
 		"movementCost": 1,
 		"RGB": [45,108,145],
-		"uniques": ["Open terrain"]
+		"terrainType": "Open terrain",
 	},
 	{
 		"name": "Coast",
@@ -15,7 +15,7 @@
 		"food": 1,
 		"movementCost": 1,
 		"RGB": [107,167,193],
-		"uniques": ["Open terrain"]
+		"terrainType": "Open terrain"
 	},
 	{
 		"name": "Grassland",
@@ -23,7 +23,8 @@
 		"food": 2,
 		"movementCost": 1,
 		"RGB": [97,171,58],
-		"uniques": ["Occurs at temperature between [-0.4] and [0.8] and humidity between [0.5] and [1]", "Open terrain"]
+		"uniques": ["Occurs at temperature between [-0.4] and [0.8] and humidity between [0.5] and [1]"],
+		"terrainType": "Open terrain"
 	},
 	{
 		"name": "Plains",
@@ -33,7 +34,8 @@
 		"movementCost": 1,
 		"RGB": [168,185,102],
 		"uniques": ["Occurs at temperature between [-0.4] and [0.8] and humidity between [0] and [0.5]",
-			"Occurs at temperature between [0.8] and [1] and humidity between [0.7] and [1]", "Open terrain"]
+			"Occurs at temperature between [0.8] and [1] and humidity between [0.7] and [1]"],
+		"terrainType": "Open terrain"
 	},
 	{
 		"name": "Tundra",
@@ -41,14 +43,16 @@
 		"food": 1,
 		"movementCost": 1,
 		"RGB": [189,204,191],
-		"uniques": ["Occurs at temperature between [-1] and [-0.4] and humidity between [0.5] and [1]", "Open terrain"]
+		"uniques": ["Occurs at temperature between [-1] and [-0.4] and humidity between [0.5] and [1]"],
+		"terrainType": "Open terrain"
 	},
 	{
 		"name": "Desert",
 		"type": "Land",
 		"movementCost": 1,
 		"RGB": [ 230, 230, 113],
-		"uniques": ["Occurs at temperature between [0.8] and [1] and humidity between [0] and [0.7]", "Open terrain"]
+		"uniques": ["Occurs at temperature between [0.8] and [1] and humidity between [0] and [0.7]"],
+		"terrainType": "Open terrain"
 	},
 	{
 		"name": "Lakes",
@@ -56,7 +60,8 @@
 		"food": 2,
 		"gold": 1,
 		"RGB": [ 123, 202, 226],
-		"uniques": ["Fresh water"]
+		"uniques": ["Fresh water"],
+		"terrainType": "Open terrain"
 	},
 	{
 		"name": "Mountain",
@@ -64,14 +69,16 @@
 		"impassable": true,
 		"defenceBonus": 0.25,
 		"RGB": [120, 120, 120],
-		"uniques":["Has an elevation of [4] for visibility calculations"]
+		"uniques":["Has an elevation of [4] for visibility calculations"],
+		"terrainType": "Rough terrain"
 	},
 	{
 		"name": "Snow",
 		"type": "Land",
 		"movementCost": 1,
 		"RGB": [231, 242, 249],
-		"uniques": ["Occurs at temperature between [-1] and [-0.4] and humidity between [0] and [0.5]", "Open terrain"]
+		"uniques": ["Occurs at temperature between [-1] and [-0.4] and humidity between [0] and [0.5]"],
+		"terrainType": "Open terrain"
 	},
 	
 	// Terrain features
@@ -84,8 +91,9 @@
 		"defenceBonus": 0.25,
 		"RGB": [105,125,72],
 		"occursOn": ["Tundra","Plains","Grassland","Desert","Snow"],
-		"uniques": ["Rough terrain", "[+5] Strength for cities built on this terrain",
-			"[+1] Sight for [Land] units", "Has an elevation of [2] for visibility calculations"]
+		"uniques": ["[+5] Strength for cities built on this terrain",
+			"[+1] Sight for [Land] units", "Has an elevation of [2] for visibility calculations"],
+		"terrainType": "Rough terrain"
 	},
 	{
 		"name": "Forest",
@@ -97,8 +105,9 @@
 		"unbuildable": true,
 		"defenceBonus": 0.25,
 		"occursOn": ["Tundra","Plains","Grassland","Hill"],
-		"uniques": ["Provides a one-time Production bonus to the closest city when cut down", "Rough terrain",
-			"Blocks line-of-sight from tiles at same elevation"]
+		"uniques": ["Provides a one-time Production bonus to the closest city when cut down",
+			"Blocks line-of-sight from tiles at same elevation"],
+		"terrainType": "Rough terrain"
 	},
 	{
 		"name": "Jungle",
@@ -109,7 +118,8 @@
 		"unbuildable": true,
 		"defenceBonus": 0.25,
 		"occursOn": ["Plains","Grassland"],
-		"uniques": ["Rough terrain", "Blocks line-of-sight from tiles at same elevation"]
+		"uniques": ["Blocks line-of-sight from tiles at same elevation"],
+		"terrainType": "Rough terrain"
 	},
 	{
 		"name": "Marsh",
@@ -119,7 +129,8 @@
 		"unbuildable": true,
 		"defenceBonus": -0.15,
 		"occursOn": ["Grassland"],
-		"uniques": ["Rare feature"]
+		"uniques": ["Rare feature"],
+		"terrainType": "Open terrain"
 	},
 	{
 		"name": "Fallout",
@@ -140,7 +151,8 @@
 		"unbuildable": true,
 		"defenceBonus": -0.1,
 		"occursOn": ["Desert"],
-		"uniques": ["Fresh water", "Rare feature"]
+		"uniques": ["Fresh water", "Rare feature"],
+		"terrainType": "Open terrain"
 	},
 	{
 		"name": "Flood plains",
@@ -148,15 +160,16 @@
 		"food": 2,
 		"movementCost": 1,
 		"defenceBonus": -0.1,
-		"occursOn": ["Desert"]
-		"uniques":["Open terrain"]
+		"occursOn": ["Desert"],
+		"terrainType": "Open terrain"
 	},
 	{
 		"name": "Ice",
 		"type": "TerrainFeature",
 		"impassable": true,
 		"overrideStats": true,
-		"occursOn": ["Ocean", "Coast"]
+		"occursOn": ["Ocean", "Coast"],
+		"terrainType": "Open terrain"
 	},
 	{
 		"name": "Atoll",
@@ -165,7 +178,8 @@
 		"food": 1,
 		"production": 1,
 		"occursOn": ["Coast"],
-		"uniques": ["Rare feature"]
+		"uniques": ["Rare feature"],
+		"terrainType": "Open terrain"
 	},
  
 	// Natural Wonders

--- a/core/src/com/unciv/logic/map/TileInfo.kt
+++ b/core/src/com/unciv/logic/map/TileInfo.kt
@@ -201,7 +201,10 @@ open class TileInfo {
         yieldAll(terrainFeatures.asSequence().mapNotNull { ruleset.terrains[it] })
     }
     fun getDominantTerrainType(): String? {
-        return terrainFeatures.maxByOrNull { ruleset.terrainTypes[it]!!.priority }
+        val terrainsToCheck = getAllTerrains()
+        val terrainTypes = terrainsToCheck.map { it.terrainType }
+        if (terrainTypes.none { it != null }) return null
+        return terrainTypes.maxByOrNull { ruleset.terrainTypes[it]!!.priority }
     }
 
     fun hasUnique(unique: String) = getAllTerrains().any { it.uniques.contains(unique) }

--- a/core/src/com/unciv/logic/map/TileInfo.kt
+++ b/core/src/com/unciv/logic/map/TileInfo.kt
@@ -200,6 +200,9 @@ open class TileInfo {
         if (naturalWonder != null) yield(getNaturalWonder())
         yieldAll(terrainFeatures.asSequence().mapNotNull { ruleset.terrains[it] })
     }
+    fun getDominantTerrainType(): String? {
+        return terrainFeatures.maxByOrNull { ruleset.terrainTypes[it]!!.priority }
+    }
 
     fun hasUnique(unique: String) = getAllTerrains().any { it.uniques.contains(unique) }
 
@@ -409,8 +412,7 @@ open class TileInfo {
             "Foreign Land" -> civInfo != null && !isFriendlyTerritory(civInfo)
             "Friendly Land" -> civInfo != null && isFriendlyTerritory(civInfo)
             else -> {
-                // This one should be on top, as it has to be checked before all other uniques
-                if (filter.endsWith(" terrain")) return getLastTerrain().uniques.contains(filter)
+                if (getDominantTerrainType() == filter) return true
                 if (terrainFeatures.contains(filter)) return true
                 if (baseTerrainObject.uniques.contains(filter)) return true
                 if (terrainFeatures.isNotEmpty() && getTerrainFeatures().last().uniques.contains(filter)) return true

--- a/core/src/com/unciv/logic/map/TileInfo.kt
+++ b/core/src/com/unciv/logic/map/TileInfo.kt
@@ -409,6 +409,8 @@ open class TileInfo {
             "Foreign Land" -> civInfo != null && !isFriendlyTerritory(civInfo)
             "Friendly Land" -> civInfo != null && isFriendlyTerritory(civInfo)
             else -> {
+                // This one should be on top, as it has to be checked before all other uniques
+                if (filter.endsWith(" terrain")) return getLastTerrain().uniques.contains(filter)
                 if (terrainFeatures.contains(filter)) return true
                 if (baseTerrainObject.uniques.contains(filter)) return true
                 if (terrainFeatures.isNotEmpty() && getTerrainFeatures().last().uniques.contains(filter)) return true

--- a/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
+++ b/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
@@ -43,7 +43,7 @@ class UnitMovementAlgorithms(val unit:MapUnit) {
         if (civInfo.nation.ignoreHillMovementCost && to.isHill())
             return 1f + extraCost // usually hills take 2 movements, so here it is 1
 
-        if (unit.roughTerrainPenalty && to.getAllTerrains().any { it.rough || it.uniques.contains("Rough terrain") })
+        if (unit.roughTerrainPenalty && to.getAllTerrains().any { it.rough } || to.getDominantTerrainType() == "Rough terrain" )
             return 4f + extraCost
 
         if (unit.doubleMovementInCoast && to.baseTerrain == Constants.coast)

--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -8,6 +8,7 @@ import com.unciv.models.metadata.BaseRuleset
 import com.unciv.models.ruleset.tech.TechColumn
 import com.unciv.models.ruleset.tech.Technology
 import com.unciv.models.ruleset.tile.Terrain
+import com.unciv.models.ruleset.tile.TerrainType2
 import com.unciv.models.ruleset.tile.TileImprovement
 import com.unciv.models.ruleset.tile.TileResource
 import com.unciv.models.ruleset.unit.BaseUnit
@@ -45,6 +46,7 @@ class Ruleset {
     var name = ""
     val buildings = LinkedHashMap<String, Building>()
     val terrains = LinkedHashMap<String, Terrain>()
+    val terrainTypes = LinkedHashMap<String, TerrainType2>()
     val tileResources = LinkedHashMap<String, TileResource>()
     val tileImprovements = LinkedHashMap<String, TileImprovement>()
     val technologies = LinkedHashMap<String, Technology>()
@@ -86,6 +88,7 @@ class Ruleset {
         technologies.putAll(ruleset.technologies)
         for (techToRemove in ruleset.modOptions.techsToRemove) technologies.remove(techToRemove)
         terrains.putAll(ruleset.terrains)
+        terrainTypes.putAll(ruleset.terrainTypes)
         tileImprovements.putAll(ruleset.tileImprovements)
         tileResources.putAll(ruleset.tileResources)
         unitPromotions.putAll(ruleset.unitPromotions)
@@ -106,6 +109,7 @@ class Ruleset {
         technologies.clear()
         buildings.clear()
         terrains.clear()
+        terrainTypes.clear()
         tileImprovements.clear()
         tileResources.clear()
         unitPromotions.clear()
@@ -143,6 +147,9 @@ class Ruleset {
         val terrainsFile = folderHandle.child("Terrains.json")
         if (terrainsFile.exists()) terrains += createHashmap(jsonParser.getFromJson(Array<Terrain>::class.java, terrainsFile))
 
+        val terrainTypesFile = folderHandle.child("TerrainTypes.json")
+        if (terrainTypesFile.exists()) terrainTypes += createHashmap(jsonParser.getFromJson(Array<TerrainType2>::class.java, terrainTypesFile))
+        
         val resourcesFile = folderHandle.child("TileResources.json")
         if (resourcesFile.exists()) tileResources += createHashmap(jsonParser.getFromJson(Array<TileResource>::class.java, resourcesFile))
 

--- a/core/src/com/unciv/models/ruleset/tile/Terrain.kt
+++ b/core/src/com/unciv/models/ruleset/tile/Terrain.kt
@@ -38,6 +38,8 @@ class Terrain : NamedStats() {
     
     @Deprecated("As of 3.14.1")
     var rough = false
+    
+    var terrainType: String? = null
 
 
     fun getColor(): Color { // Can't be a lazy initialize, because we play around with the resulting color with lerp()s and the like
@@ -60,7 +62,8 @@ class Terrain : NamedStats() {
             sb.appendLine("May contain [${resourcesFound.joinToString(", ") { it.name.tr() }}]".tr())
 
         if(uniques.isNotEmpty())
-            sb.appendLine(uniques.joinToString { it.tr() })
+            // "Open terrain" and "Rough terrain" uniques deprecated since 3.15.4
+            sb.appendLine(uniques.filter{ it != "Open terrain" && it != "Rough terrain"}.joinToString { it.tr() })
 
         if (impassable)
             sb.appendLine(Constants.impassable.tr())
@@ -70,9 +73,9 @@ class Terrain : NamedStats() {
         if (defenceBonus != 0f)
             sb.appendLine("{Defence bonus}: ".tr() + (defenceBonus * 100).toInt() + "%")
 
-        if (rough)
-            sb.appendLine("Rough Terrain".tr())
-
+        if (terrainType != null)
+            sb.appendLine(terrainType!!.tr())
+        
         return sb.toString()
     }
 }

--- a/core/src/com/unciv/models/ruleset/tile/TerrainType.kt
+++ b/core/src/com/unciv/models/ruleset/tile/TerrainType.kt
@@ -1,8 +1,15 @@
 package com.unciv.models.ruleset.tile
 
+import com.unciv.models.stats.NamedStats
+
 enum class TerrainType {
     Land,
     Water,
     TerrainFeature,
     NaturalWonder
+}
+
+class TerrainType2 : NamedStats() {
+    lateinit var type: String
+    var priority = 0
 }


### PR DESCRIPTION
This is a counter-PR to #4219, with the intent of solving the same problem in a more modular way.
As it was quickly thrown together, some variables names still need to change (TerrainType2, for example), but it should work. The current version is for showing an alternative fix, that, if deemed better than the previous proposed, can be developed further into a quality PR.
Fixes #4139.

What this PR does, is create a new JSON file named 'terrainType.json', in which the different types of terrain - open, rough - are written, along with a priority. When a test is run if a certain tile is of a certain terrain type, only the terrain with the highest priority will be used. This way, there will be no ambiguity about which terrain type a certain tile has, yet still provides modders with all the tools they need to change everything they want.



Note; I spoke with @avdstaaij before making this PR, and he was fine with me proposing this alternate fix.