### PR TITLE
Fixed captured units not teleporting out of liberated cities

### DIFF
--- a/core/src/com/unciv/logic/city/CityInfoConquestFunctions.kt
+++ b/core/src/com/unciv/logic/city/CityInfoConquestFunctions.kt
@@ -127,6 +127,8 @@ class CityInfoConquestFunctions(val city: CityInfo){
             cityStats.update()
 
             // Move units out of the city when liberated
+            for (unit in getCenterTile().getUnits())
+                unit.movement.teleportToClosestMoveableTile()
             for (unit in getTiles().flatMap { it.getUnits() }.toList())
                 if (!unit.movement.canPassThrough(unit.currentTile))
                     unit.movement.teleportToClosestMoveableTile()


### PR DESCRIPTION
This fixes case 2 of #4237, and as such, fixes #4231. See #4231 for the details on the cause of the problem, and why this fixes it.