### PR TITLE
Generalized building of improvements

### DIFF
--- a/android/assets/jsons/Civ V - Vanilla/Units.json
+++ b/android/assets/jsons/Civ V - Vanilla/Units.json
@@ -7,7 +7,7 @@
 		"name": "Worker",
 		"unitType": "Civilian",
 		"movement": 2,
-		"uniques": ["Can build improvements on tiles"],
+		"uniques": ["Can build [Land] improvements on tiles"],
 		"cost": 70
 	},
 	{
@@ -372,10 +372,9 @@
 		"upgradesTo": "Longswordsman",
 		"obsoleteTech": "Gunpowder",
 		"requiredResource": "Iron",
-		"uniques": ["Can construct roads"],
+		"uniques": ["Can build [Road] improvements on tiles", "Can build [Fort] improvements on tiles"],
 		"hurryCostModifier": 20,
 		"attackSound": "metalhit"
-		// can construct fort (if required for fort tech is researched)
 	},
 	{
 		"name": "Mohawk Warrior",

--- a/core/src/com/unciv/Constants.kt
+++ b/core/src/com/unciv/Constants.kt
@@ -2,7 +2,7 @@ package com.unciv
 
 object Constants {
     const val worker = "Worker"
-    const val workerUnique = "Can build improvements on tiles"
+    const val canBuildImprovements = "Can build [] improvements on tiles"
     const val settler = "Settler"
     const val settlerUnique = "Founds a new city"
 

--- a/core/src/com/unciv/Constants.kt
+++ b/core/src/com/unciv/Constants.kt
@@ -3,6 +3,9 @@ package com.unciv
 object Constants {
     const val worker = "Worker"
     const val canBuildImprovements = "Can build [] improvements on tiles"
+    // Deprecated as of 3.15.5
+        const val workerUnique = "Can build improvements on tiles"
+    //
     const val settler = "Settler"
     const val settlerUnique = "Founds a new city"
 

--- a/core/src/com/unciv/logic/automation/ConstructionAutomation.kt
+++ b/core/src/com/unciv/logic/automation/ConstructionAutomation.kt
@@ -28,7 +28,7 @@ class ConstructionAutomation(val cityConstructions: CityConstructions){
     val civUnits = civInfo.getCivUnits()
     val militaryUnits = civUnits.count { !it.type.isCivilian() }
     // Constants.workerUnique deprecated since 3.15.5
-    val workers = civUnits.count { (it.hasUnique(Constants.canBuildImprovements) || it.hasUnique(Constants.workerUnique)) && !it.type.isMilitary() }.toFloat()
+    val workers = civUnits.count { (it.hasUnique(Constants.canBuildImprovements) || it.hasUnique(Constants.workerUnique)) && it.type.isCivilian() }.toFloat()
     val cities = civInfo.cities.size
     val allTechsAreResearched = civInfo.tech.getNumberOfTechsResearched() >= civInfo.gameInfo.ruleSet.technologies.size
 
@@ -150,7 +150,7 @@ class ConstructionAutomation(val cityConstructions: CityConstructions){
 
         val citiesCountedTowardsWorkers = min(5, cities) // above 5 cities, extra cities won't make us want more workers
         // Constants.workerUnique deprecated since 3.15.5
-        if (workers < citiesCountedTowardsWorkers * 0.6f && civUnits.none { (it.hasUnique(Constants.canBuildImprovements) || it.hasUnique(Constants.workerUnique))&& it.isIdle() }) {
+        if (workers < citiesCountedTowardsWorkers * 0.6f && civUnits.none { (it.hasUnique(Constants.canBuildImprovements) || it.hasUnique(Constants.workerUnique)) && it.isIdle() }) {
             var modifier = citiesCountedTowardsWorkers / (workers + 0.1f)
             if (!cityIsOverAverageProduction) modifier /= 5 // higher production cities will deal with this
             addChoice(relativeCostEffectiveness, workerEquivalents.minByOrNull { it.cost }!!.name, modifier)

--- a/core/src/com/unciv/logic/automation/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/UnitAutomation.kt
@@ -89,7 +89,7 @@ object UnitAutomation {
             if (unit.hasUnique(Constants.settlerUnique))
                 return SpecificUnitAutomation.automateSettlerActions(unit)
 
-            if (unit.hasUnique(Constants.workerUnique))
+            if (unit.hasUnique(Constants.canBuildImprovements))
                 return WorkerAutomation(unit).automateWorkerAction()
 
             if (unit.name == "Work Boats")

--- a/core/src/com/unciv/logic/automation/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/UnitAutomation.kt
@@ -89,10 +89,11 @@ object UnitAutomation {
             if (unit.hasUnique(Constants.settlerUnique))
                 return SpecificUnitAutomation.automateSettlerActions(unit)
 
-            if (unit.hasUnique(Constants.canBuildImprovements))
+            // Constants.workerUnique deprecated since 3.15.5
+            if (unit.hasUnique(Constants.canBuildImprovements) || unit.hasUnique(Constants.workerUnique))
                 return WorkerAutomation(unit).automateWorkerAction()
 
-            if (unit.name == "Work Boats")
+            if (unit.name == "Work Boats") // This is really not modular
                 return SpecificUnitAutomation.automateWorkBoats(unit)
 
             if (unit.hasUnique("Bonus for units in 2 tile radius 15%"))

--- a/core/src/com/unciv/logic/automation/WorkerAutomation.kt
+++ b/core/src/com/unciv/logic/automation/WorkerAutomation.kt
@@ -187,7 +187,6 @@ class WorkerAutomation(val unit: MapUnit) {
         }
 
         // turnsToBuild is what defines them as buildable
-        // ^ that sounds quite ugly
         val tileImprovements = civInfo.gameInfo.ruleSet.tileImprovements.filter { it.value.turnsToBuild != 0 }
         val uniqueImprovement = tileImprovements.values
                 .firstOrNull { it.uniqueTo == civInfo.civName }

--- a/core/src/com/unciv/logic/automation/WorkerAutomation.kt
+++ b/core/src/com/unciv/logic/automation/WorkerAutomation.kt
@@ -15,34 +15,29 @@ class WorkerAutomation(val unit: MapUnit) {
         val enemyUnitsInWalkingDistance = unit.movement.getDistanceToTiles().keys
                 .filter { UnitAutomation.containsEnemyMilitaryUnit(unit, it) }
 
-        if (enemyUnitsInWalkingDistance.isNotEmpty() && unit.type.isCivilian()) return UnitAutomation.runAway(unit)
+        if (enemyUnitsInWalkingDistance.isNotEmpty() && !unit.type.isMilitary()) return UnitAutomation.runAway(unit)
 
         val currentTile = unit.getTile()
         val tileToWork = findTileToWork()
         
-        println("cp1")
         if (getPriority(tileToWork, unit.civInfo) < 3) { // building roads is more important
             if (tryConnectingCities(unit)) return
         }
 
-        println("cp2" + tileToWork.position)
         if (tileToWork != currentTile) {
             val reachedTile = unit.movement.headTowards(tileToWork)
             if (reachedTile != currentTile) unit.doAction() // otherwise, we get a situation where the worker is automated, so it tries to move but doesn't, then tries to automate, then move, etc, forever. Stack overflow exception!
             return
         }
 
-        println("cp3")
         if (currentTile.improvementInProgress == null && currentTile.isLand
                 && tileCanBeImproved(currentTile, unit.civInfo)) {
             return currentTile.startWorkingOnImprovement(chooseImprovement(currentTile, unit.civInfo)!!, unit.civInfo)
         }
 
-        println("cp4")
         if (currentTile.improvementInProgress != null) return // we're working!
         if (tryConnectingCities(unit)) return //nothing to do, try again to connect cities
 
-        println("cp5")
         val citiesToNumberOfUnimprovedTiles = HashMap<String, Int>()
         for (city in unit.civInfo.cities) {
             citiesToNumberOfUnimprovedTiles[city.id] = city.getTiles()
@@ -123,7 +118,6 @@ class WorkerAutomation(val unit: MapUnit) {
      * Returns the current tile if no tile to work was found
      */
     private fun findTileToWork(): TileInfo {
-        println("cp1a")
         val currentTile = unit.getTile()
         val workableTiles = currentTile.getTilesInDistance(4)
                 .filter {
@@ -139,19 +133,15 @@ class WorkerAutomation(val unit: MapUnit) {
         // but only for the tile that's about to be chosen.
         val selectedTile = workableTiles.firstOrNull { unit.movement.canReach(it) }
 
-        println("cp2a")
         return if (selectedTile != null
                 && getPriority(selectedTile, unit.civInfo) > 1
                 && (!workableTiles.contains(currentTile)
-                        || getPriority(selectedTile, unit.civInfo) > getPriority(currentTile, unit.civInfo))) {
-                            println("cp2b1")
+                    || getPriority(selectedTile, unit.civInfo) > getPriority(currentTile, unit.civInfo)))
             selectedTile
-        }
-        else { println("cp2b2"); currentTile }
+        else currentTile
     }
 
     private fun tileCanBeImproved(tile: TileInfo, civInfo: CivilizationInfo): Boolean {
-        println("cp3a")
         if (!tile.isLand || tile.isImpassible() || tile.isCityCenter())
             return false
         val city = tile.getCity()
@@ -160,18 +150,15 @@ class WorkerAutomation(val unit: MapUnit) {
         if (tile.improvement != null && !UncivGame.Current.settings.automatedWorkersReplaceImprovements)
             return false
 
-        println("cp3b")
         if (tile.improvement == null) {
             if (tile.improvementInProgress != null && unit.canBuildImprovement(tile.getTileImprovementInProgress()!!, tile)) return true
             val chosenImprovement = chooseImprovement(tile, civInfo)
-            if (chosenImprovement != null) println(" " + chosenImprovement.name + " " + tile.canBuildImprovement(chosenImprovement, civInfo) + " " + unit.canBuildImprovement(chosenImprovement))
             if (chosenImprovement != null && tile.canBuildImprovement(chosenImprovement, civInfo) && unit.canBuildImprovement(chosenImprovement, tile)) return true
         } else if (!tile.containsGreatImprovement() && tile.hasViewableResource(civInfo)
                 && tile.getTileResource().improvement != tile.improvement
                 && chooseImprovement(tile, civInfo) // if the chosen improvement is not null and buildable
-                        .let { it != null && tile.canBuildImprovement(it, civInfo) && unit.canBuildImprovement(it, tile)})
+                    .let { it != null && tile.canBuildImprovement(it, civInfo) && unit.canBuildImprovement(it, tile)})
             return true
-        println("cp3c")
         return false // couldn't find anything to construct here
     }
 
@@ -200,7 +187,7 @@ class WorkerAutomation(val unit: MapUnit) {
         }
 
         // turnsToBuild is what defines them as buildable
-        // ^ that sound quite ugly
+        // ^ that sounds quite ugly
         val tileImprovements = civInfo.gameInfo.ruleSet.tileImprovements.filter { it.value.turnsToBuild != 0 }
         val uniqueImprovement = tileImprovements.values
                 .firstOrNull { it.uniqueTo == civInfo.civName }

--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -259,8 +259,7 @@ class MapUnit {
     fun isIdle(): Boolean {
         if (currentMovement == 0f) return false
         // Constants.workerUnique deprecated since 3.15.5
-        if ((hasUnique(Constants.canBuildImprovements) || hasUnique(Constants.workerUnique)) 
-            && getTile().improvementInProgress != null 
+        if (getTile().improvementInProgress != null 
             && canBuildImprovement(getTile().getTileImprovementInProgress()!!)) 
                 return false
         // unique "Can construct roads" deprecated since 3.15.5
@@ -549,8 +548,7 @@ class MapUnit {
 
         if (currentMovement > 0 && 
             // Constants.workerUnique deprecated since 3.15.5
-            (hasUnique(Constants.canBuildImprovements) || hasUnique(Constants.workerUnique)) 
-            && getTile().improvementInProgress != null
+            getTile().improvementInProgress != null
             && canBuildImprovement(getTile().getTileImprovementInProgress()!!)
         ) workOnImprovement()
         // unique "Can construct roads" deprecated since 3.15.4

--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -258,11 +258,12 @@ class MapUnit {
 
     fun isIdle(): Boolean {
         if (currentMovement == 0f) return false
-        if (hasUnique(Constants.canBuildImprovements) 
+        // Constants.workerUnique deprecated since 3.15.5
+        if ((hasUnique(Constants.canBuildImprovements) || hasUnique(Constants.workerUnique)) 
             && getTile().improvementInProgress != null 
             && canBuildImprovement(getTile().getTileImprovementInProgress()!!)) 
                 return false
-        // unique "Can construct roads" deprecated since 3.15.4
+        // unique "Can construct roads" deprecated since 3.15.5
             if (hasUnique("Can construct roads") && currentTile.improvementInProgress == "Road") return false
         //
         if (isFortified()) return false
@@ -546,11 +547,13 @@ class MapUnit {
     fun endTurn() {
         doAction()
 
-        if (currentMovement > 0 && hasUnique(Constants.canBuildImprovements) 
+        if (currentMovement > 0 && 
+            // Constants.workerUnique deprecated since 3.15.5
+            (hasUnique(Constants.canBuildImprovements) || hasUnique(Constants.workerUnique)) 
             && getTile().improvementInProgress != null
             && canBuildImprovement(getTile().getTileImprovementInProgress()!!)
         ) workOnImprovement()
-        // unique "Can constrcut raods" deprecated since 3.15.4
+        // unique "Can construct roads" deprecated since 3.15.4
             if (currentMovement > 0 && hasUnique("Can construct roads")
                 && currentTile.improvementInProgress == "Road"
             ) workOnImprovement()
@@ -924,7 +927,9 @@ class MapUnit {
     }
 
     fun canBuildImprovement(improvement: TileImprovement, tile: TileInfo = currentTile): Boolean {
-        return getMatchingUniques(Constants.canBuildImprovements).any { improvement.matchesFilter(it.params[0]) || tile.matchesTerrainFilter(it.params[0]) }
+        // Constants.workerUnique deprecated since 3.15.5
+        val matchingUniques = getMatchingUniques(Constants.canBuildImprovements) + getMatchingUniques(Constants.workerUnique)
+        return matchingUniques.any { improvement.matchesFilter(it.params[0]) || tile.matchesTerrainFilter(it.params[0]) }
     }
 
     //endregion

--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -10,6 +10,7 @@ import com.unciv.logic.civilization.LocationAction
 import com.unciv.logic.civilization.NotificationIcon
 import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.ruleset.Unique
+import com.unciv.models.ruleset.tile.TileImprovement
 import com.unciv.models.ruleset.unit.BaseUnit
 import com.unciv.models.ruleset.unit.UnitType
 import java.text.DecimalFormat
@@ -257,8 +258,13 @@ class MapUnit {
 
     fun isIdle(): Boolean {
         if (currentMovement == 0f) return false
-        if (hasUnique(Constants.workerUnique) && getTile().improvementInProgress != null) return false
-        if (hasUnique("Can construct roads") && currentTile.improvementInProgress == "Road") return false
+        if (hasUnique(Constants.canBuildImprovements) 
+            && getTile().improvementInProgress != null 
+            && canBuildImprovement(getTile().getTileImprovementInProgress()!!)) 
+                return false
+        // unique "Can construct roads" deprecated since 3.15.4
+            if (hasUnique("Can construct roads") && currentTile.improvementInProgress == "Road") return false
+        //
         if (isFortified()) return false
         if (action == Constants.unitActionExplore || isSleeping()
             || action == Constants.unitActionAutomation || isMoving()
@@ -540,12 +546,15 @@ class MapUnit {
     fun endTurn() {
         doAction()
 
-        if (currentMovement > 0 && hasUnique(Constants.workerUnique)
+        if (currentMovement > 0 && hasUnique(Constants.canBuildImprovements) 
             && getTile().improvementInProgress != null
+            && canBuildImprovement(getTile().getTileImprovementInProgress()!!)
         ) workOnImprovement()
-        if (currentMovement > 0 && hasUnique("Can construct roads")
-            && currentTile.improvementInProgress == "Road"
-        ) workOnImprovement()
+        // unique "Can constrcut raods" deprecated since 3.15.4
+            if (currentMovement > 0 && hasUnique("Can construct roads")
+                && currentTile.improvementInProgress == "Road"
+            ) workOnImprovement()
+        //
         if (currentMovement == getMaxMovement().toFloat() && isFortified()) {
             val currentTurnsFortified = getFortificationTurns()
             if (currentTurnsFortified < 2)
@@ -912,6 +921,10 @@ class MapUnit {
                 return false
             }
         }
+    }
+
+    fun canBuildImprovement(improvement: TileImprovement, tile: TileInfo = currentTile): Boolean {
+        return getMatchingUniques(Constants.canBuildImprovements).any { improvement.matchesFilter(it.params[0]) || tile.matchesTerrainFilter(it.params[0]) }
     }
 
     //endregion

--- a/core/src/com/unciv/logic/map/TileInfo.kt
+++ b/core/src/com/unciv/logic/map/TileInfo.kt
@@ -154,6 +154,7 @@ open class TileInfo {
     fun isImpassible() = getLastTerrain().impassable
 
     fun getTileImprovement(): TileImprovement? = if (improvement == null) null else ruleset.tileImprovements[improvement!!]
+    fun getTileImprovementInProgress(): TileImprovement? = if (improvementInProgress == null) null else ruleset.tileImprovements[improvementInProgress!!]
 
 
     // This is for performance - since we access the neighbors of a tile ALL THE TIME,

--- a/core/src/com/unciv/models/UnitAction.kt
+++ b/core/src/com/unciv/models/UnitAction.kt
@@ -26,7 +26,9 @@ enum class UnitActionType(val value: String) {
     SetUp("Set up"),
     FoundCity("Found city"),
     ConstructImprovement("Construct improvement"),
-    ConstructRoad("Construct road"),
+    // Deprecated since 3.15.4
+        ConstructRoad("Construct road"),
+    //
     Create("Create"),
     HurryResearch("Hurry Research"),
     StartGoldenAge("Start Golden Age"),

--- a/core/src/com/unciv/models/ruleset/tile/TileImprovement.kt
+++ b/core/src/com/unciv/models/ruleset/tile/TileImprovement.kt
@@ -99,7 +99,8 @@ class TileImprovement : NamedStats() {
         return when (filter) {
             name -> true
             "All" -> true
-            "Great Improvement" -> isGreatImprovement()
+            "All Road" -> name == "road" || name == "railroad"
+            "Great Improvement", "Great" -> isGreatImprovement()
             else -> false
         }
     }

--- a/core/src/com/unciv/ui/pickerscreens/ImprovementPickerScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/ImprovementPickerScreen.kt
@@ -8,6 +8,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.utils.Align
 import com.unciv.Constants
 import com.unciv.UncivGame
+import com.unciv.logic.map.MapUnit
 import com.unciv.logic.map.RoadStatus
 import com.unciv.logic.map.TileInfo
 import com.unciv.models.ruleset.tile.TileImprovement
@@ -17,7 +18,7 @@ import com.unciv.ui.utils.*
 import com.unciv.ui.utils.StaticTooltip.Companion.addStaticTip
 import kotlin.math.round
 
-class ImprovementPickerScreen(val tileInfo: TileInfo, val onAccept: ()->Unit) : PickerScreen() {
+class ImprovementPickerScreen(val tileInfo: TileInfo, unit: MapUnit, val onAccept: ()->Unit) : PickerScreen() {
     private var selectedImprovement: TileImprovement? = null
     private val gameInfo = tileInfo.tileMap.gameInfo
     private val ruleSet = gameInfo.ruleSet
@@ -56,8 +57,9 @@ class ImprovementPickerScreen(val tileInfo: TileInfo, val onAccept: ()->Unit) : 
         for (improvement in ruleSet.tileImprovements.values) {
             // canBuildImprovement() would allow e.g. great improvements thus we need to exclude them - except cancel
             if (improvement.turnsToBuild == 0 && improvement.name != Constants.cancelImprovementOrder) continue
-            if (improvement.name == tileInfo.improvement) continue      // also checked by canImprovementBeBuiltHere, but after more expensive tests
+            if (improvement.name == tileInfo.improvement) continue // also checked by canImprovementBeBuiltHere, but after more expensive tests
             if (!tileInfo.canBuildImprovement(improvement, currentPlayerCiv)) continue
+            if (!unit.canBuildImprovement(improvement)) continue
 
             val improvementButtonTable = Table()
 

--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -478,7 +478,7 @@ class WorldScreen(val gameInfo: GameInfo, val viewingCiv:CivilizationInfo) : Cam
 
         displayTutorial(Tutorial.InjuredUnits) { gameInfo.getCurrentPlayerCivilization().getCivUnits().any { it.health < 100 } }
 
-        displayTutorial(Tutorial.Workers) { gameInfo.getCurrentPlayerCivilization().getCivUnits().any { it.hasUnique(Constants.workerUnique) } }
+        displayTutorial(Tutorial.Workers) { gameInfo.getCurrentPlayerCivilization().getCivUnits().any { it.hasUnique(Constants.canBuildImprovements) && !it.type.isMilitary() } }
     }
 
     private fun updateDiplomacyButton(civInfo: CivilizationInfo) {

--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -478,7 +478,12 @@ class WorldScreen(val gameInfo: GameInfo, val viewingCiv:CivilizationInfo) : Cam
 
         displayTutorial(Tutorial.InjuredUnits) { gameInfo.getCurrentPlayerCivilization().getCivUnits().any { it.health < 100 } }
 
-        displayTutorial(Tutorial.Workers) { gameInfo.getCurrentPlayerCivilization().getCivUnits().any { (it.hasUnique(Constants.canBuildImprovements) || it.hasUnique(Constants.workerUnique)) && !it.type.isMilitary() } }
+        displayTutorial(Tutorial.Workers) { 
+            gameInfo.getCurrentPlayerCivilization().getCivUnits().any { 
+                (it.hasUnique(Constants.canBuildImprovements) || it.hasUnique(Constants.workerUnique)) 
+                    && it.type.isCivilian() 
+            } 
+        }
     }
 
     private fun updateDiplomacyButton(civInfo: CivilizationInfo) {

--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -478,7 +478,7 @@ class WorldScreen(val gameInfo: GameInfo, val viewingCiv:CivilizationInfo) : Cam
 
         displayTutorial(Tutorial.InjuredUnits) { gameInfo.getCurrentPlayerCivilization().getCivUnits().any { it.health < 100 } }
 
-        displayTutorial(Tutorial.Workers) { gameInfo.getCurrentPlayerCivilization().getCivUnits().any { it.hasUnique(Constants.canBuildImprovements) && !it.type.isMilitary() } }
+        displayTutorial(Tutorial.Workers) { gameInfo.getCurrentPlayerCivilization().getCivUnits().any { (it.hasUnique(Constants.canBuildImprovements) || it.hasUnique(Constants.workerUnique)) && !it.type.isMilitary() } }
     }
 
     private fun updateDiplomacyButton(civInfo: CivilizationInfo) {

--- a/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
@@ -32,7 +32,7 @@ object UnitActions {
 
         if (unit.isMoving()) actionList += UnitAction(UnitActionType.StopMovement) { unit.action = null }
 
-        val workingOnImprovement = unit.hasUnique("Can build improvements on tiles")
+        val workingOnImprovement = unit.hasUnique(Constants.canBuildImprovements)
                 && unit.currentTile.hasImprovementInProgress()
         if (!unit.isFortified() && !unit.canFortify() && unit.currentMovement > 0 && !workingOnImprovement) {
             addSleepActions(actionList, unit, unitTable)
@@ -58,7 +58,9 @@ object UnitActions {
         addSetupAction(unit, actionList)
         addFoundCityAction(unit, actionList, tile)
         addWorkerActions(unit, actionList, tile, worldScreen, unitTable)
-        addConstructRoadsAction(unit, tile, actionList)
+        // Deprecated since 3.15.4
+            addConstructRoadsAction(unit, tile, actionList)
+        //
         addCreateWaterImprovements(unit, actionList)
         addGreatPersonActions(unit, actionList, tile)
         actionList += getImprovementConstructionActions(unit, tile)
@@ -121,20 +123,22 @@ object UnitActions {
 
         return null
     }
-
-    private fun addConstructRoadsAction(unit: MapUnit, tile: TileInfo, actionList: ArrayList<UnitAction>) {
-        val improvement = RoadStatus.Road.improvement(unit.civInfo.gameInfo.ruleSet) ?: return
-        if (unit.hasUnique("Can construct roads")
-                && tile.roadStatus == RoadStatus.None
-                && tile.improvementInProgress != "Road"
-                && tile.isLand
-                && (improvement.techRequired == null || unit.civInfo.tech.isResearched(improvement.techRequired!!)))
-            actionList += UnitAction(UnitActionType.ConstructRoad,
-                    action = {
-                        tile.improvementInProgress = "Road"
-                        tile.turnsToImprovement = improvement.getTurnsToBuild(unit.civInfo)
-                    }.takeIf { unit.currentMovement > 0 })
-    }
+    
+    // This entire function is deprecated since 3.15.4, as the 'can construct roads' unique is deprecated
+        private fun addConstructRoadsAction(unit: MapUnit, tile: TileInfo, actionList: ArrayList<UnitAction>) {
+            val improvement = RoadStatus.Road.improvement(unit.civInfo.gameInfo.ruleSet) ?: return
+            if (unit.hasUnique("Can construct roads")
+                    && tile.roadStatus == RoadStatus.None
+                    && tile.improvementInProgress != "Road"
+                    && tile.isLand
+                    && (improvement.techRequired == null || unit.civInfo.tech.isResearched(improvement.techRequired!!)))
+                actionList += UnitAction(UnitActionType.ConstructRoad,
+                        action = {
+                            tile.improvementInProgress = "Road"
+                            tile.turnsToImprovement = improvement.getTurnsToBuild(unit.civInfo)
+                        }.takeIf { unit.currentMovement > 0 })
+        }
+    //
 
     private fun addFoundCityAction(unit: MapUnit, actionList: ArrayList<UnitAction>, tile: TileInfo) {
         val getFoundCityAction = getFoundCityAction(unit, tile)
@@ -330,7 +334,7 @@ object UnitActions {
     }
 
     private fun addWorkerActions(unit: MapUnit, actionList: ArrayList<UnitAction>, tile: TileInfo, worldScreen: WorldScreen, unitTable: UnitTable) {
-        if (!unit.hasUnique("Can build improvements on tiles")) return
+        if (!unit.hasUnique(Constants.canBuildImprovements)) return
 
         // Allow automate/unautomate when embarked, but not building improvements - see #1963
         if (Constants.unitActionAutomation == unit.action) {
@@ -347,12 +351,12 @@ object UnitActions {
 
         val canConstruct = unit.currentMovement > 0
                 && !tile.isCityCenter()
-                && unit.civInfo.gameInfo.ruleSet.tileImprovements.values.any { tile.canBuildImprovement(it, unit.civInfo) }
-
+                && unit.civInfo.gameInfo.ruleSet.tileImprovements.values.any { tile.canBuildImprovement(it, unit.civInfo) && unit.canBuildImprovement(it) }
+        
         actionList += UnitAction(UnitActionType.ConstructImprovement,
                 isCurrentAction = unit.currentTile.hasImprovementInProgress(),
                 action = {
-                    worldScreen.game.setScreen(ImprovementPickerScreen(tile) { unitTable.selectUnit() })
+                    worldScreen.game.setScreen(ImprovementPickerScreen(tile, unit) { unitTable.selectUnit() })
                 }.takeIf { canConstruct })
     }
 
@@ -361,22 +365,22 @@ object UnitActions {
         if (unit.currentMovement > 0) for (unique in unit.getUniques()) when (unique.placeholderText) {
             "Can hurry technology research" -> {
                 actionList += UnitAction(UnitActionType.HurryResearch,
-                        uncivSound = UncivSound.Chimes,
-                        action = {
-                            unit.civInfo.tech.addScience(unit.civInfo.tech.getScienceFromGreatScientist())
-                            addGoldPerGreatPersonUsage(unit.civInfo)
-                            unit.destroy()
-                        }.takeIf { unit.civInfo.tech.currentTechnologyName() != null })
+                    uncivSound = UncivSound.Chimes,
+                    action = {
+                        unit.civInfo.tech.addScience(unit.civInfo.tech.getScienceFromGreatScientist())
+                        addGoldPerGreatPersonUsage(unit.civInfo)
+                        unit.destroy()
+                    }.takeIf { unit.civInfo.tech.currentTechnologyName() != null })
             }
             "Can start an []-turn golden age" -> {
                 val turnsToGoldenAge = unique.params[0].toInt()
                 actionList += UnitAction(UnitActionType.StartGoldenAge,
-                        uncivSound = UncivSound.Chimes,
-                        action = {
-                            unit.civInfo.goldenAges.enterGoldenAge(turnsToGoldenAge)
-                            addGoldPerGreatPersonUsage(unit.civInfo)
-                            unit.destroy()
-                        }.takeIf { unit.currentTile.getOwner() != null && unit.currentTile.getOwner() == unit.civInfo })
+                    uncivSound = UncivSound.Chimes,
+                    action = {
+                        unit.civInfo.goldenAges.enterGoldenAge(turnsToGoldenAge)
+                        addGoldPerGreatPersonUsage(unit.civInfo)
+                        unit.destroy()
+                    }.takeIf { unit.currentTile.getOwner() != null && unit.currentTile.getOwner() == unit.civInfo })
             }
             "Can speed up construction of a wonder" -> {
                 val canHurryWonder = if (!tile.isCityCenter()) false
@@ -386,39 +390,38 @@ object UnitActions {
                     else currentConstruction.isWonder || currentConstruction.isNationalWonder
                 }
                 actionList += UnitAction(UnitActionType.HurryWonder,
-                        uncivSound = UncivSound.Chimes,
-                        action = {
-                            tile.getCity()!!.cityConstructions.apply {
-                                addProductionPoints(300 + 30 * tile.getCity()!!.population.population) //http://civilization.wikia.com/wiki/Great_engineer_(Civ5)
-                                constructIfEnough()
-                            }
-                            addGoldPerGreatPersonUsage(unit.civInfo)
-                            unit.destroy()
-                        }.takeIf { canHurryWonder })
+                    uncivSound = UncivSound.Chimes,
+                    action = {
+                        tile.getCity()!!.cityConstructions.apply {
+                            addProductionPoints(300 + 30 * tile.getCity()!!.population.population) //http://civilization.wikia.com/wiki/Great_engineer_(Civ5)
+                            constructIfEnough()
+                        }
+                        addGoldPerGreatPersonUsage(unit.civInfo)
+                        unit.destroy()
+                    }.takeIf { canHurryWonder })
             }
             "Can undertake a trade mission with City-State, giving a large sum of gold and [] Influence" -> {
                 val canConductTradeMission = tile.owningCity?.civInfo?.isCityState() == true
                         && tile.owningCity?.civInfo?.isAtWarWith(unit.civInfo) == false
                 val influenceEarned = unique.params[0].toInt()
                 actionList += UnitAction(UnitActionType.ConductTradeMission,
-                        uncivSound = UncivSound.Chimes,
-                        action = {
-                            // http://civilization.wikia.com/wiki/Great_Merchant_(Civ5)
-                            var goldEarned = ((350 + 50 * unit.civInfo.getEraNumber()) * unit.civInfo.gameInfo.gameParameters.gameSpeed.modifier).toInt()
-                            if (unit.civInfo.hasUnique("Double gold from Great Merchant trade missions"))
-                                goldEarned *= 2
-                            unit.civInfo.addGold(goldEarned)
-                            tile.owningCity!!.civInfo.getDiplomacyManager(unit.civInfo).influence += influenceEarned
-                            unit.civInfo.addNotification("Your trade mission to [${tile.owningCity!!.civInfo}] has earned you [${goldEarned}] gold and [$influenceEarned] influence!",
-                                    tile.owningCity!!.civInfo.civName, NotificationIcon.Gold, NotificationIcon.Culture)
-                            addGoldPerGreatPersonUsage(unit.civInfo)
-                            unit.destroy()
-                        }.takeIf { canConductTradeMission })
+                    uncivSound = UncivSound.Chimes,
+                    action = {
+                        // http://civilization.wikia.com/wiki/Great_Merchant_(Civ5)
+                        var goldEarned = ((350 + 50 * unit.civInfo.getEraNumber()) * unit.civInfo.gameInfo.gameParameters.gameSpeed.modifier).toInt()
+                        if (unit.civInfo.hasUnique("Double gold from Great Merchant trade missions"))
+                            goldEarned *= 2
+                        unit.civInfo.addGold(goldEarned)
+                        tile.owningCity!!.civInfo.getDiplomacyManager(unit.civInfo).influence += influenceEarned
+                        unit.civInfo.addNotification("Your trade mission to [${tile.owningCity!!.civInfo}] has earned you [${goldEarned}] gold and [$influenceEarned] influence!",
+                            tile.owningCity!!.civInfo.civName, NotificationIcon.Gold, NotificationIcon.Culture)
+                        addGoldPerGreatPersonUsage(unit.civInfo)
+                        unit.destroy()
+                    }.takeIf { canConductTradeMission })
             }
         }
     }
-
-
+    
     fun getImprovementConstructionActions(unit: MapUnit, tile: TileInfo): ArrayList<UnitAction> {
         val finalActions = ArrayList<UnitAction>()
         for (unique in unit.getMatchingUniques("Can construct []")) {
@@ -426,28 +429,28 @@ object UnitActions {
             val improvement = tile.ruleset.tileImprovements[improvementName]
             if (improvement == null) continue
             finalActions += UnitAction(UnitActionType.Create,
-                    title = "Create [$improvementName]",
-                    uncivSound = UncivSound.Chimes,
-                    action = {
-                        val unitTile = unit.getTile()
-                        for (terrainFeature in tile.terrainFeatures.filter { unitTile.ruleset.tileImprovements.containsKey("Remove $it") })
-                            unitTile.terrainFeatures.remove(terrainFeature)// remove forest/jungle/marsh
-                        unitTile.improvement = improvementName
-                        unitTile.improvementInProgress = null
-                        unitTile.turnsToImprovement = 0
-                        if (improvementName == Constants.citadel)
-                            takeOverTilesAround(unit)
-                        val city = unitTile.getCity()
-                        if (city != null) {
-                            city.cityStats.update()
-                            city.civInfo.updateDetailedCivResources()
-                        }
-                        addGoldPerGreatPersonUsage(unit.civInfo)
-                        unit.destroy()
-                    }.takeIf {
-                        unit.currentMovement > 0f && tile.canBuildImprovement(improvement, unit.civInfo)
-                                && !tile.isImpassible() // Not 100% sure that this check is necessary...
-                    })
+                title = "Create [$improvementName]",
+                uncivSound = UncivSound.Chimes,
+                action = {
+                    val unitTile = unit.getTile()
+                    for (terrainFeature in tile.terrainFeatures.filter { unitTile.ruleset.tileImprovements.containsKey("Remove $it") })
+                        unitTile.terrainFeatures.remove(terrainFeature)// remove forest/jungle/marsh
+                    unitTile.improvement = improvementName
+                    unitTile.improvementInProgress = null
+                    unitTile.turnsToImprovement = 0
+                    if (improvementName == Constants.citadel)
+                        takeOverTilesAround(unit)
+                    val city = unitTile.getCity()
+                    if (city != null) {
+                        city.cityStats.update()
+                        city.civInfo.updateDetailedCivResources()
+                    }
+                    addGoldPerGreatPersonUsage(unit.civInfo)
+                    unit.destroy()
+                }.takeIf {
+                    unit.currentMovement > 0f && tile.canBuildImprovement(improvement, unit.civInfo)
+                            && !tile.isImpassible() // Not 100% sure that this check is necessary...
+                })
         }
         return finalActions
     }

--- a/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
@@ -33,9 +33,7 @@ object UnitActions {
         if (unit.isMoving()) actionList += UnitAction(UnitActionType.StopMovement) { unit.action = null }
 
         // Constants.workerUnique deprecated since 3.15.5
-        val workingOnImprovement = (unit.hasUnique(Constants.canBuildImprovements) || unit.hasUnique(Constants.workerUnique))
-                && unit.currentTile.hasImprovementInProgress()
-                && unit.canBuildImprovement(unit.currentTile.getTileImprovementInProgress()!!)
+        val workingOnImprovement = unit.currentTile.hasImprovementInProgress() && unit.canBuildImprovement(unit.currentTile.getTileImprovementInProgress()!!)
         if (!unit.isFortified() && !unit.canFortify() && unit.currentMovement > 0 && !workingOnImprovement) {
             addSleepActions(actionList, unit, unitTable)
         }


### PR DESCRIPTION
This PR generalizes the concept of building improvements. This is mostly done to combine the 'build road' and 'build fort' unit actions into the 'build improvements' unit action, but is made extendible enough that mods can implement units that only create certain types of improvements.
Another advantage of this implementation, is that the Legion unit now has an 'automate' button, which will automatically build roads between cities. While I have not tested this, it should also be possible for modded units that can only build some improvements to be automated without problems.

I was thinking about also including fishing boats & great improvements into this same system, but decided against it, as they are built immediately and therefore need a different system.

Added uniques:
- "Can build [tileFilter] improvements on tiles"

Deprecated uniques:
- "Can build improvements on tiles"
- "Can construct roads"