### PR TITLE
Fixed the game crashing when any main menu option is picked

### DIFF
--- a/core/src/com/unciv/models/stats/Stats.kt
+++ b/core/src/com/unciv/models/stats/Stats.kt
@@ -119,7 +119,7 @@ open class Stats() {
         private val statRegex = Regex(statRegexPattern)
         private val entireStringRegexPattern = Regex("$statRegexPattern(, $statRegexPattern)*")
         fun isStats(string:String): Boolean {
-            if (string[0] != '+' && string[0] != '-') return false // very quick negative check before the heavy Regex
+            if (string.isEmpty() || string[0] !in "+-") return false // very quick negative check before the heavy Regex
             return entireStringRegexPattern.matches(string)
         }
         fun parse(string:String):Stats{


### PR DESCRIPTION
Commit 823e6ffc2a4d14c04a661e2e0f8c2253c0d0844a causes the game to crash when you pick any option in the main menu. This PR fixes this critical bug.

The problem was that the first character of string was accessed without checking whether the string was empty. It's interesting how such a tiny mistake can cause the entire game to be unusable.