### PR TITLE
Fixed crash when selecting worker in mods

### DIFF
--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -925,7 +925,8 @@ class MapUnit {
 
     fun canBuildImprovement(improvement: TileImprovement, tile: TileInfo = currentTile): Boolean {
         // Constants.workerUnique deprecated since 3.15.5
-        val matchingUniques = getMatchingUniques(Constants.canBuildImprovements) + getMatchingUniques(Constants.workerUnique)
+        if (hasUnique(Constants.workerUnique)) return true
+        val matchingUniques = getMatchingUniques(Constants.canBuildImprovements)
         return matchingUniques.any { improvement.matchesFilter(it.params[0]) || tile.matchesTerrainFilter(it.params[0]) }
     }
 


### PR DESCRIPTION
When making the changes in workers in #4252, I accidentally overlooked that Constants.workerUnique doesn't have params, which might lead to crashes. In normal unciv everything still works fine, but for most mods that did not immediately update, selecting a worker units immeidately crashes the game.