### PR TITLE
Fix "National Wonder is being built elsewhere" not displayed

### DIFF
--- a/core/src/com/unciv/models/ruleset/Building.kt
+++ b/core/src/com/unciv/models/ruleset/Building.kt
@@ -245,7 +245,7 @@ class Building : NamedStats(), IConstruction {
         return rejectionReason == ""
                 || rejectionReason.startsWith("Requires")
                 || rejectionReason.startsWith("Consumes")
-                || rejectionReason == "Wonder is being built elsewhere"
+                || rejectionReason.endsWith("Wonder is being built elsewhere")
     }
 
     fun getRejectionReason(construction: CityConstructions): String {


### PR DESCRIPTION
Self-explaining?

Anyway, I don't think this is good design, so this is the 'kludge' variant. I'd probably declare a `data class ConstructionRejectionReason(val text: String, val isRejected: Boolean = text.isNotEmpty(), val showRejected: Boolean = false)` and have it filled out by getRejectionReason, but that would take more effort. You think the idea worth it?