### PR TITLE
Nicer distribution of policy picker branches

### DIFF
--- a/core/src/com/unciv/logic/civilization/PolicyManager.kt
+++ b/core/src/com/unciv/logic/civilization/PolicyManager.kt
@@ -133,14 +133,14 @@ class PolicyManager {
      * Test whether a policy is adoptable according to the RuleSet (ignoring cost).
      * Note: branch completion policies are automatic and therefore not adoptable in this test.
      * @param policy The Policy to check
-     * @param testEra Include era test (with false the function returns whether the policy is adoptable now or in the future)
+     * @param checkEra Include era test (with false the function returns whether the policy is adoptable now or in the future)
      * @return `true` if the policy can be adopted, `false` if some rule prevents it (including when it's already adopted) 
      */
-    fun isAdoptable(policy: Policy, testEra: Boolean = true): Boolean {
+    fun isAdoptable(policy: Policy, checkEra: Boolean = true): Boolean {
         if (isAdopted(policy.name)) return false
         if (policy.name.endsWith("Complete")) return false
         if (!getAdoptedPolicies().containsAll(policy.requires!!)) return false
-        if (testEra && civInfo.gameInfo.ruleSet.getEraNumber(policy.branch.era) > civInfo.getEraNumber()) return false
+        if (checkEra && civInfo.gameInfo.ruleSet.getEraNumber(policy.branch.era) > civInfo.getEraNumber()) return false
         if (policy.uniqueObjects.any { it.placeholderText == "Incompatible with []" && adoptedPolicies.contains(it.params[0]) }) return false
         return true
     }

--- a/core/src/com/unciv/logic/civilization/PolicyManager.kt
+++ b/core/src/com/unciv/logic/civilization/PolicyManager.kt
@@ -129,11 +129,18 @@ class PolicyManager {
 
     fun isAdopted(policyName: String): Boolean = adoptedPolicies.contains(policyName)
 
-    fun isAdoptable(policy: Policy): Boolean {
+    /**
+     * Test whether a policy is adoptable according to the RuleSet (ignoring cost).
+     * Note: branch completion policies are automatic and therefore not adoptable in this test.
+     * @param policy The Policy to check
+     * @param testEra Include era test (with false the function returns whether the policy is adoptable now or in the future)
+     * @return `true` if the policy can be adopted, `false` if some rule prevents it (including when it's already adopted) 
+     */
+    fun isAdoptable(policy: Policy, testEra: Boolean = true): Boolean {
         if (isAdopted(policy.name)) return false
         if (policy.name.endsWith("Complete")) return false
         if (!getAdoptedPolicies().containsAll(policy.requires!!)) return false
-        if (civInfo.gameInfo.ruleSet.getEraNumber(policy.branch.era) > civInfo.getEraNumber()) return false
+        if (testEra && civInfo.gameInfo.ruleSet.getEraNumber(policy.branch.era) > civInfo.getEraNumber()) return false
         if (policy.uniqueObjects.any { it.placeholderText == "Incompatible with []" && adoptedPolicies.contains(it.params[0]) }) return false
         return true
     }

--- a/core/src/com/unciv/ui/pickerscreens/PolicyPickerScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/PolicyPickerScreen.kt
@@ -25,7 +25,7 @@ class PolicyPickerScreen(val worldScreen: WorldScreen, civInfo: CivilizationInfo
         displayTutorial(Tutorial.CultureAndPolicies)
 
         if (viewingCiv.gameInfo.ruleSet.policies.values.none {
-                viewingCiv.policies.isAdoptable(it, testEra = false) 
+                viewingCiv.policies.isAdoptable(it, checkEra = false) 
         })
             rightSideButton.setText("All policies adopted".tr())
         else
@@ -102,6 +102,7 @@ class PolicyPickerScreen(val worldScreen: WorldScreen, civInfo: CivilizationInfo
             val hScroll = min(20f, scrollPane.maxX / 2)
             scrollPane.scrollX = hScroll
         }
+        scrollPane.updateVisualScroll()
     }
 
     private fun pickPolicy(policy: Policy) {


### PR DESCRIPTION
My attempt to make the Policy Picker a little prettier on cramped screen space or portrait orientations. Should resolve #4172.

Notes:
- Includes alternate approach to displaying "All policies adopted" which is currently impossible - as of now untested, test underway.
- Not 100% happy with two mechanisms to decide when a break is needed, but out of ideas on how to make one of the approaches also fit the other's usecase.
- Not 100% happy with the padding above and below the separator line. On high resolutions it's a bit small, under cramped screen space it's better this way... Make it dependent on resolution?

- Alternate approach: Save space by reducing number of "branch boxes". e.g. Piety might be completely absent once Rationalism is chosen and vice versa, and while neither is chosen we display one box containing only the starting choices, same for the evil/neutral/good trio -> down to 7 branches... A bit more complex, but doable even in a mod-flexible way. Not in this PR though.

Might do screenies later, and for now I'll leave this a normal PR because I'm pretty sure it improves things despite the notes above :) Critiques of course welcome.