### PR TITLE
Fixed bug where on quick game speed, educated elite would yield a great person every turn

### DIFF
--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -753,7 +753,7 @@ class CivilizationInfo {
         addNotification( "[${givingCityState.civName}] gave us a [${giftedUnit.name}] as a gift!", locations, givingCityState.civName, giftedUnit.name)
     }
 
-    fun turnsForGreatPersonFromCityState(): Int = (40 + -2 + Random().nextInt(5)) * gameInfo.gameParameters.gameSpeed.modifier.toInt()
+    fun turnsForGreatPersonFromCityState(): Int = ((40 + -2 + Random().nextInt(5)) * gameInfo.gameParameters.gameSpeed.modifier).toInt()
         // There seems to be some randomness in the amount of turns between receiving each great person,
         // but I have no idea what the actual lower and upper bound are, so this is just an approximation
     


### PR DESCRIPTION
This was caused by `.toInt()` being called on the wrong moment, multiplying the amount of turns till the next great person by 0