### PR TITLE
Cultural victory display - new template, Utopia Project

### DIFF
--- a/android/assets/jsons/translations/German.properties
+++ b/android/assets/jsons/translations/German.properties
@@ -737,7 +737,7 @@ Science victory = Wissenschaftssieg
 Cultural victory = Kultursieg
 Conquest victory = Dominanzsieg
 Complete all the spaceship parts\n to win! = Um zu gewinnen, baut\n alle Raumschiffteile!
-Complete 5 policy branches\n to win! = Um zu gewinnen vervollständige\n 5 Politik-Zweige!
+Complete 5 policy branches and build\n the Utopia Project to win! = Um zu gewinnen, vervollständige 5\nPolitik-Zweige und baue das Utopia-Projekt!
 Destroy all enemies\n to win! = Um zu gewinnen besiegt alle Gegner!
 You have won a scientific victory! = Ihr habt den Wissenschaftssieg errungen!
 You have won a cultural victory! = Ihr habt den Kultursieg errungen!
@@ -750,6 +750,7 @@ Your civilization stands above all others! The exploits of your people shall be 
 You have been defeated. Your civilization has been overwhelmed by its many foes. But your people do not despair, for they know that one day you shall return - and lead them forward to victory! = Du wurdest besiegt. Deine Zivilisation wurde von ihren vielen Feinden überwältigt. Aber dein Volk verzweifelt nicht, denn es weiß, dass du eines Tages zurückkehren wirst - und es zum Sieg führen werdet!
 One more turn...! = Nur noch eine Runde...
 Built Apollo Program = Apollo-Programm vollendet
+Built Utopia Project = Utopia-Projekt vollendet
 Destroy [civName] = Zerstört [civName]
 Our status = Unser Status
 Global status = Globaler Status

--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -737,7 +737,7 @@ Science victory =
 Cultural victory = 
 Conquest victory = 
 Complete all the spaceship parts\n to win! = 
-Complete 5 policy branches\n to win! = 
+Complete 5 policy branches and build\n the Utopia Project to win! = 
 Destroy all enemies\n to win! = 
 You have won a scientific victory! = 
 You have won a cultural victory! = 
@@ -750,6 +750,7 @@ Your civilization stands above all others! The exploits of your people shall be 
 You have been defeated. Your civilization has been overwhelmed by its many foes. But your people do not despair, for they know that one day you shall return - and lead them forward to victory! = 
 One more turn...! = 
 Built Apollo Program = 
+Built Utopia Project = 
 Destroy [civName] = 
 Our status = 
 Global status = 

--- a/core/src/com/unciv/ui/victoryscreen/VictoryScreen.kt
+++ b/core/src/com/unciv/ui/victoryscreen/VictoryScreen.kt
@@ -151,9 +151,13 @@ class VictoryScreen(val worldScreen: WorldScreen) : PickerScreen() {
         val t = Table()
         t.defaults().pad(5f)
         for (branch in playerCivInfo.gameInfo.ruleSet.policyBranches.values) {
+            if (!playerCivInfo.policies.isAdopted(branch.name) && !playerCivInfo.policies.isAdoptable(branch, checkEra = false)) continue
             val finisher = branch.policies.last().name
             t.add(getMilestone(finisher, playerCivInfo.policies.isAdopted(finisher))).row()
         }
+
+        t.add(getMilestone("Built Utopia Project",
+            playerCivInfo.hasUnique("Triggers a Cultural Victory upon completion"))).row()
         return t
     }
 


### PR DESCRIPTION
Relatively minor:

- I noticed the new cultural victory didn't update its victory message template - fixed
- Then I thought "If science lists Apollo completion why not list Utopia completion for cultural"
- Then I thought "It's getting a bit cramped - why not drop the locked-out branches"

I think a game where one maxes policies but refuses to build Utopia, then triggers another victory looks better and has good chances to not need scrolling. On the other hand, one starts out with all 10 branches listed as un-completed on the victory screen and that list gets shorter during the game which may confuse some. You decide what's over the top, I'll revert. ;)