### PR TITLE
Research Tech Button shows progress; Small bug fix

### DIFF
--- a/core/src/com/unciv/logic/civilization/TechManager.kt
+++ b/core/src/com/unciv/logic/civilization/TechManager.kt
@@ -50,8 +50,9 @@ class TechManager {
 
     /** When moving towards a certain tech, the user doesn't have to manually pick every one. */
     var techsToResearch = ArrayList<String>()
-    private var techsInProgress = HashMap<String, Int>()
     var overflowScience = 0
+    private var techsInProgress = HashMap<String, Int>()
+    fun scienceSpentOnTech(tech: String): Int = if (tech in techsInProgress) techsInProgress[tech]!! else 0
 
     /** In civ IV, you can auto-convert a certain percentage of gold in cities to science */
     var goldPercentConvertedToScience = 0.6f

--- a/core/src/com/unciv/ui/pickerscreens/TechPickerScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/TechPickerScreen.kt
@@ -17,10 +17,9 @@ import java.util.*
 import kotlin.collections.ArrayList
 
 
-class TechPickerScreen(internal val civInfo: CivilizationInfo, centerOnTech: Technology? = null, freeTechPick: Boolean = false) : PickerScreen() {
+class TechPickerScreen(internal val civInfo: CivilizationInfo, centerOnTech: Technology? = null, private val freeTechPick: Boolean = false) : PickerScreen() {
 
     private var techNameToButton = HashMap<String, TechButton>()
-    private var isFreeTechPick: Boolean = false
     private var selectedTech: Technology? = null
     private var civTech: TechManager = civInfo.tech
     private var tempTechsToResearch: ArrayList<String>
@@ -48,7 +47,6 @@ class TechPickerScreen(internal val civInfo: CivilizationInfo, centerOnTech: Tec
     private val turnsToTech = civInfo.gameInfo.ruleSet.technologies.values.associateBy({ it.name }, { civTech.turnsToTech(it.name) })
     
     init {
-        isFreeTechPick = freeTechPick
         setDefaultCloseAction()
         onBackButtonClicked { UncivGame.Current.setWorldScreen() }
         scrollPane.setOverscroll(false, false)
@@ -61,7 +59,7 @@ class TechPickerScreen(internal val civInfo: CivilizationInfo, centerOnTech: Tec
         rightSideButton.setText("Pick a tech".tr())
         rightSideButton.onClick(UncivSound.Paper) {
             game.settings.addCompletedTutorialTask("Pick technology")
-            if (isFreeTechPick) civTech.getFreeTechnology(selectedTech!!.name)
+            if (freeTechPick) civTech.getFreeTechnology(selectedTech!!.name)
             else civTech.techsToResearch = tempTechsToResearch
 
             game.setWorldScreen()
@@ -138,7 +136,7 @@ class TechPickerScreen(internal val civInfo: CivilizationInfo, centerOnTech: Tec
             techButton.color = when {
                 civTech.isResearched(techName) && techName != Constants.futureTech -> researchedTechColor
                 // if we're here to pick a free tech, show the current tech like the rest of the researchables so it'll be obvious what we can pick
-                tempTechsToResearch.firstOrNull() == techName && !isFreeTechPick -> currentTechColor
+                tempTechsToResearch.firstOrNull() == techName && !freeTechPick -> currentTechColor
                 researchableTechs.contains(techName) -> researchableTechColor
                 tempTechsToResearch.contains(techName) -> queuedTechColor
                 else -> Color.GRAY
@@ -223,7 +221,7 @@ class TechPickerScreen(internal val civInfo: CivilizationInfo, centerOnTech: Tec
         // center on technology
         if (center) centerOnTechnology(tech)
 
-        if (isFreeTechPick) {
+        if (freeTechPick) {
             selectTechnologyForFreeTech(tech)
             setButtonsInfo()
             return

--- a/core/src/com/unciv/ui/pickerscreens/TechPickerScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/TechPickerScreen.kt
@@ -17,7 +17,7 @@ import java.util.*
 import kotlin.collections.ArrayList
 
 
-class TechPickerScreen(internal val civInfo: CivilizationInfo, centerOnTech: Technology? = null) : PickerScreen() {
+class TechPickerScreen(internal val civInfo: CivilizationInfo, centerOnTech: Technology? = null, freeTechPick: Boolean = false) : PickerScreen() {
 
     private var techNameToButton = HashMap<String, TechButton>()
     private var isFreeTechPick: Boolean = false
@@ -46,13 +46,9 @@ class TechPickerScreen(internal val civInfo: CivilizationInfo, centerOnTech: Tec
 
 
     private val turnsToTech = civInfo.gameInfo.ruleSet.technologies.values.associateBy({ it.name }, { civTech.turnsToTech(it.name) })
-
-    constructor(freeTechPick: Boolean, civInfo: CivilizationInfo) : this(civInfo) {
-        isFreeTechPick = freeTechPick
-    }
-
-
+    
     init {
+        isFreeTechPick = freeTechPick
         setDefaultCloseAction()
         onBackButtonClicked { UncivGame.Current.setWorldScreen() }
         scrollPane.setOverscroll(false, false)

--- a/core/src/com/unciv/ui/pickerscreens/TechPickerScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/TechPickerScreen.kt
@@ -262,8 +262,17 @@ class TechPickerScreen(internal val civInfo: CivilizationInfo, centerOnTech: Tec
         tempTechsToResearch.clear()
         tempTechsToResearch.addAll(pathToTech.map { it.name })
 
-        pick("Research [${tempTechsToResearch[0]}]".tr())
+        val label = "Research [${tempTechsToResearch[0]}]".tr()
+        val techProgression = getTechProgressLabel(tempTechsToResearch)
+        
+        pick("${label}\n${techProgression}")
         setButtonsInfo()
+    }
+    
+    private fun getTechProgressLabel(techs: List<String>): String {
+        val progress = techs.sumBy { tech -> civTech.scienceSpentOnTech(tech) }
+        val techCost = techs.sumBy { tech -> civInfo.gameInfo.ruleSet.technologies[tech]!!.cost }
+        return "(${progress}/${techCost})"
     }
 
     private fun centerOnTechnology(tech: Technology) {
@@ -275,10 +284,11 @@ class TechPickerScreen(internal val civInfo: CivilizationInfo, centerOnTech: Tec
         }
     }
 
-
     private fun selectTechnologyForFreeTech(tech: Technology) {
         if (researchableTechs.contains(tech.name)) {
-            pick("Pick [${selectedTech!!.name}] as free tech".tr())
+            val label = "Pick [${tech.name}] as free tech".tr()
+            val techProgression = getTechProgressLabel(listOf(tech.name))
+            pick("${label}\n${techProgression}")
         } else {
             rightSideButton.setText("Pick a free tech".tr())
             rightSideButton.disable()

--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -683,7 +683,7 @@ class WorldScreen(val gameInfo: GameInfo, val viewingCiv:CivilizationInfo) : Cam
 
             viewingCiv.shouldOpenTechPicker() ->
                 NextTurnAction("Pick a tech", Color.SKY) {
-                    game.setScreen(TechPickerScreen(viewingCiv.tech.freeTechs != 0, viewingCiv))
+                    game.setScreen(TechPickerScreen(viewingCiv, null, viewingCiv.tech.freeTechs != 0))
                 }
 
             viewingCiv.policies.shouldOpenPolicyPicker || (viewingCiv.policies.freePolicies > 0 && viewingCiv.policies.canAdoptPolicy()) ->


### PR DESCRIPTION
This PR makes some small changes to the TechPicker:
- The "Research [techName]"-button in the bottom right now shows progress in the researched tech. If a path of multiple techs is selected, the sum of the progress of all these techs is shown.
- Previously, whenever you opened the TechPicker for selecting a free tech, it would first still say "Research [techName]", and only after clicking on any tech it would become "Pick [techName] as free tech" (should this be "as _a_ free tech"?). This was due to init blocks being called before constructors, making a variable set late. This has been solved.