### PR TITLE
Fixed bug where research agreements in the Atomic Era cost 0 gold

### DIFF
--- a/core/src/com/unciv/Constants.kt
+++ b/core/src/com/unciv/Constants.kt
@@ -76,6 +76,7 @@ object Constants {
     const val medievalEra = "Medieval era"
     const val renaissanceEra = "Renaissance era"
     const val industrialEra = "Industrial era"
+    const val atomicEra = "Atomic era"
     const val modernEra = "Modern era"
     const val informationEra = "Information era"
     const val futureEra = "Future era"

--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -722,8 +722,8 @@ class CivilizationInfo {
             Constants.medievalEra, Constants.renaissanceEra -> 250
             Constants.industrialEra -> 300
             Constants.modernEra -> 350
-            Constants.informationEra, Constants.futureEra -> 400
-            else -> 0
+            Constants.atomicEra, Constants.informationEra, Constants.futureEra -> 400
+            else -> 300
         }
         return (basicGoldCostOfSignResearchAgreement * gameInfo.gameParameters.gameSpeed.modifier).toInt()
     }


### PR DESCRIPTION
Due to the cost of research agreements being hardcoded per era, this wasn't updated after in #4252 the Era names where updated.