### PR TITLE
Fix mod sounds from local, Android SoundPool issues, more commenting

### DIFF
--- a/core/src/com/unciv/UncivGame.kt
+++ b/core/src/com/unciv/UncivGame.kt
@@ -15,10 +15,7 @@ import com.unciv.models.ruleset.RulesetCache
 import com.unciv.models.tilesets.TileSetCache
 import com.unciv.models.translations.Translations
 import com.unciv.ui.LanguagePickerScreen
-import com.unciv.ui.utils.CameraStageBaseScreen
-import com.unciv.ui.utils.CrashController
-import com.unciv.ui.utils.ImageGetter
-import com.unciv.ui.utils.center
+import com.unciv.ui.utils.*
 import com.unciv.ui.worldscreen.PlayerReadyScreen
 import com.unciv.ui.worldscreen.WorldScreen
 import java.util.*
@@ -180,8 +177,9 @@ class UncivGame(parameters: UncivGameParameters) : Game() {
 
     override fun dispose() {
         cancelDiscordEvent?.invoke()
+        Sounds.clearCache()
 
-        // Log still running threads (should be only this one and "DestroyJavaVM")
+        // Log still running threads (on desktop that should be only this one and "DestroyJavaVM")
         val numThreads = Thread.activeCount()
         val threadList = Array(numThreads) { _ -> Thread() }
         Thread.enumerate(threadList)

--- a/core/src/com/unciv/ui/utils/Sounds.kt
+++ b/core/src/com/unciv/ui/utils/Sounds.kt
@@ -1,22 +1,51 @@
 package com.unciv.ui.utils
 
+import com.badlogic.gdx.Application
 import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.audio.Sound
 import com.badlogic.gdx.files.FileHandle
 import com.unciv.UncivGame
 import com.unciv.models.UncivSound
 import java.io.File
+import kotlin.concurrent.thread
+
+/*
+ * Problems on Android
+ * 
+ * Essentially the freshly created Gdx Sound object from newSound() is not immediately usable, it
+ * needs some preparation time - buffering, decoding, whatever. Calling play() immediately will result
+ * in no sound, a logcat warning (not ready), and nothing else - specifically no exceptions. Also,
+ * keeping a Sound object for longer than necessary to play it once will trigger CloseGuard warnings
+ * (resource failed to clean up). Also, Gdx will attempt fast track, which will cause logcat entries,
+ * and these will be warnings if the sound file's sample rate (not bitrate) does not match the device's
+ * hardware preferred bitrate. On a Xiaomi Mi8 that is 48kHz, not 44.1kHz. Channel count also must match.
+ * 
+ * @see "https://github.com/libgdx/libgdx/issues/1775"
+ * logcat entry "W/System: A resource failed to call end.":
+ *  unavoidable as long as we cache Gdx Sound objects loaded from assets
+ * logcat entry "W/SoundPool: sample X not READY":
+ *  could be avoided by preloading the 'cache' or otherwise ensuring a minimum delay between
+ *  newSound() and play() - there's no test function that does not trigger logcat warnings.
+ * 
+ * Current approach: Cache on demand as before, catch stream not ready and retry. This maximizes
+ * logcat messages but user experience is acceptable. Empiric delay needed was measured a 40ms
+ * so that is the minimum wait before attempting play when we know the sound is freshly cached
+ * and the system is Android.
+ */
 
 /**
  * Generates Gdx [Sound] objects from [UncivSound] ones on demand, only once per key
  * (two UncivSound custom instances with the same filename are considered equal).
- * 
+ *
  * Gdx asks Sound usage to respect the Disposable contract, but since we're only caching
  * a handful of them in memory we should be able to get away with keeping them alive for the
- * app lifetime.
+ * app lifetime - and we do dispose them when the app is disposed.
  */
 object Sounds {
-    private enum class SupportedExtensions { mp3, ogg, wav }    // Gdx won't do aac/m4a
+    private const val debugMessages = true
+
+    @Suppress("EnumEntryName")
+    private enum class SupportedExtensions { mp3, ogg, wav }    // Per Gdx docs, no aac/m4a
     
     private val soundMap = HashMap<UncivSound, Sound?>()
     
@@ -29,16 +58,25 @@ object Sounds {
         if (!UncivGame.isCurrentInitialized()) return
         val game = UncivGame.Current
 
-        // Get a hash covering all mods - quickly, so don't map cast or copy the Set types
+        // Get a hash covering all mods - quickly, so don't map, cast or copy the Set types
         val hash1 = if (game.isGameInfoInitialized()) game.gameInfo.ruleSet.mods.hashCode() else 0
         val newHash = hash1.xor(game.settings.visualMods.hashCode())
+
         // If hash the same, leave the cache as is
         if (modListHash != Int.MIN_VALUE && modListHash == newHash) return
 
         // Seems the mod list has changed - clear the cache
+        clearCache()
+        modListHash = newHash
+        if (debugMessages) println("Sound cache cleared")
+    }
+
+    /** Release cached Sound resources */
+    // Called from UncivGame.dispose() to honor Gdx docs
+    fun clearCache() {
         for (sound in soundMap.values) sound?.dispose()
         soundMap.clear()
-        modListHash = newHash
+        modListHash = Int.MIN_VALUE
     }
 
     /** Build list of folders to look for sounds */
@@ -50,40 +88,88 @@ object Sounds {
         val game = UncivGame.Current
 
         // Allow mod sounds - preferentially so they can override built-in sounds
-        // audiovisual mods first, these are already available when game.gameInfo is not 
-        val modList: MutableSet<String> = game.settings.visualMods
+        // audiovisual mods after game mods but before built-in sounds
+        // (these can already be available when game.gameInfo is not)
+        val modList: MutableSet<String> = mutableSetOf()
         if (game.isGameInfoInitialized())
             modList.addAll(game.gameInfo.ruleSet.mods)  // Sounds from game mods
+        modList.addAll(game.settings.visualMods)
 
+        // Translate the basic mod list into relative folder names so only sounds/name.ext needs
+        // to be added. Thus the empty string, added last, represents the builtin sounds folder.
         return modList.asSequence()
             .map { "mods$separator$it$separator" } +
-            sequenceOf("")  // represents builtin sounds folder
+            sequenceOf("")
     } 
 
-    fun get(sound: UncivSound): Sound? {
+    /** Holds a Gdx Sound and a flag indicating the sound is freshly loaded and not from cache */
+    private data class GetSoundResult(val resource: Sound, val isFresh: Boolean)
+
+    /** Retrieve (if not cached create from resources) a Gdx Sound from an UncivSound
+     * @param sound The sound to fetch
+     * @return `null` if file cannot be found, a [GetSoundResult] otherwise
+     */
+    private fun get(sound: UncivSound): GetSoundResult? {
         checkCache()
-        if (sound in soundMap) return soundMap[sound]
+        // Look for cached sound
+        if (sound in soundMap) 
+            return if(soundMap[sound] == null) null
+            else GetSoundResult(soundMap[sound]!!, false)
+
+        // Not cached - try loading it
         val fileName = sound.value
         var file: FileHandle? = null
-        for ( (modFolder, extension) in getFolders().flatMap { 
+        for ( (modFolder, extension) in getFolders().flatMap {
+            // This is essentially a cross join. To operate on all combinations, we pack both lambda
+            // parameters into a Pair (using `to`) and unwrap that in the loop using automatic data
+            // class deconstruction `(,)`. All this avoids a double break when a match is found.
             folder -> SupportedExtensions.values().asSequence().map { folder to it } 
         } ) {
             val path = "${modFolder}sounds$separator$fileName.${extension.name}"
+            file = Gdx.files.local(path)
+            if (file.exists()) break
             file = Gdx.files.internal(path)
             if (file.exists()) break
         }
-        val newSound =
-            if (file == null || !file.exists()) null
-            else Gdx.audio.newSound(file)
 
-        // Store Sound for reuse or remember that the actual file is missing
-        soundMap[sound] = newSound
-        return newSound
+        @Suppress("LiftReturnOrAssignment")
+        if (file == null || !file.exists()) {
+            if (debugMessages) println("Sound ${sound.value} not found!")
+            // remember that the actual file is missing
+            soundMap[sound] = null
+            return null
+        } else {
+            if (debugMessages) println("Sound ${sound.value} loaded from ${file.path()}")
+            val newSound = Gdx.audio.newSound(file)
+            // Store Sound for reuse
+            soundMap[sound] = newSound
+            return GetSoundResult(newSound, true)
+        }
     }
 
+    /** Find, cache and play a Sound
+     *
+     * Sources are mods from a loaded game, then mods marked as permanent audiovisual,
+     * and lastly Unciv's own assets/sounds. Will fail silently if the sound file cannot be found.
+     * 
+     * This will wait for the Stream to become ready (Android issue) if necessary, and do so on a
+     * separate thread. No new thread is created if the sound can be played immediately.
+     * 
+     * @param sound The sound to play
+     */
     fun play(sound: UncivSound) {
         val volume = UncivGame.Current.settings.soundEffectsVolume
         if (sound == UncivSound.Silent || volume < 0.01) return
-        get(sound)?.play(volume)
+        val (resource, isFresh) = get(sound) ?: return
+        val initialDelay = if (isFresh && Gdx.app.type == Application.ApplicationType.Android) 40 else 0
+
+        if (initialDelay > 0 || resource.play(volume) == -1L) {
+            thread (name = "DelayedSound") {
+                Thread.sleep(initialDelay.toLong())
+                while (resource.play(volume) == -1L) {
+                    Thread.sleep(20L)
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
#4295 is buggy, very sorry. I postponed checking the external/internal/local thingy until I forgot. This now always checks local (where the mods are) and internal (where builtin sounds are).
I also reevaluated the order and changed my mind - permanent audiovisual mods now come between game-chosen mods and builtins, so they never override sounds in other mods. This was a 55/45 kind of decision. "If aliens mod comes with a Penguin Hatchery improvement and supplies Images/TileSets/5Hex/Tiles/Penguin Hatchery.png, and then ravignir has the wild idea to add a Penguin Hatchery to 5Hex which I have perma-visual'ed, _which one do I want to see?_"

The Android SoundPool issue is explained in a long comment - I thought leaving that in for the next guy coming along might be good. Threading choice is mentioned in the `play()` doc - if it has to wait because the stream isn't ready it spawns a new thread, otherwise not.

The logs below -just in case you are especially curious- are done as follows: start debugger, wait for background, click on Options (if sound silent, back, retry), tap the map slider, exit. Entire logcat output unchanged except for some bolding. `Sounds.debugMessages` is on for "After".

<details><summary><b>Before (3.15.6):</b></summary>

06/29 23:19:01: Launching 'android' on Xiaomi MI 8.
App restart successful without requiring a re-install.
$ adb shell am start -n "com.unciv.app/com.unciv.app.AndroidLauncher" -a android.intent.action.MAIN -c android.intent.category.LAUNCHER -D
Waiting for application to come online: com.unciv.app.test | com.unciv.app
Waiting for application to come online: com.unciv.app.test | com.unciv.app
Connected to process 17282 on device 'xiaomi-mi_8-40493f83'.
Waiting for application to come online: com.unciv.app.test | com.unciv.app
Connecting to com.unciv.app
Connected to the target VM, address: 'localhost:37773', transport: 'socket'
Capturing and displaying logcat messages from application. This behavior can be disabled in the "Logcat output" section of the "Debugger" settings page.
I/com.unciv.app: Late-enabling -Xcheck:jni
W/ActivityThread: Application com.unciv.app is waiting for the debugger on port 8100...
I/System.out: Sending WAIT chunk
I/System.out: Debugger has connected
    waiting for debugger to settle...
I/chatty: uid=10158(com.unciv.app) identical 5 lines
I/System.out: waiting for debugger to settle...
I/System.out: debugger has settled (1306)
W/com.unciv.app: Accessing hidden field Landroid/os/Trace;->TRACE_TAG_APP:J (light greylist, reflection)
    Accessing hidden method Landroid/os/Trace;->isTagEnabled(J)Z (light greylist, reflection)
D/WM-WrkMgrInitializer: Initializing WorkManager with default configuration.
I/Adreno: QUALCOMM build                   : 84ea314, I37527e3d62
    Build Date                       : 01/12/19
    OpenGL ES Shader Compiler Version: EV031.25.03.02
    Local Branch                     : 
    Remote Branch                    : 
    Remote Branch                    : 
    Reconstruct Branch               : 
    Build Config                     : S P 6.0.7 AArch64
I/Adreno: PFP: 0x016ee180, ME: 0x00000000
I/ConfigStore: android::hardware::configstore::V1_0::ISurfaceFlingerConfigs::hasWideColorDisplay retrieved: 1
    android::hardware::configstore::V1_0::ISurfaceFlingerConfigs::hasHDRDisplay retrieved: 0
D/OpenGLRenderer: Skia GL Pipeline
I/AndroidInput: sensor listener setup
I/Adreno: QUALCOMM build                   : 84ea314, I37527e3d62
    Build Date                       : 01/12/19
    OpenGL ES Shader Compiler Version: EV031.25.03.02
    Local Branch                     : 
    Remote Branch                    : 
    Remote Branch                    : 
    Reconstruct Branch               : 
    Build Config                     : S P 6.0.7 AArch64
I/Adreno: PFP: 0x016ee180, ME: 0x00000000
I/ConfigStore: android::hardware::configstore::V1_0::ISurfaceFlingerConfigs::hasWideColorDisplay retrieved: 1
    android::hardware::configstore::V1_0::ISurfaceFlingerConfigs::hasHDRDisplay retrieved: 0
I/OpenGLRenderer: Initialized EGL, version 1.4
D/OpenGLRenderer: Swap behavior 2
W/GL2JNIView: creating OpenGL ES 2.0 context
W/GL2JNIView: Returning a GLES 2 context
I/AndroidGraphics: OGL renderer: Adreno (TM) 630
    OGL vendor: Qualcomm
    OGL version: OpenGL ES 3.2 V@331.0 (GIT@84ea314, I37527e3d62) (Date:01/12/19)
    OGL extensions: GL_OES_EGL_image GL_OES_EGL_image_external GL_OES_EGL_sync GL_OES_vertex_half_float GL_OES_framebuffer_object GL_OES_rgb8_rgba8 GL_OES_compressed_ETC1_RGB8_texture GL_AMD_compressed_ATC_texture GL_KHR_texture_compression_astc_ldr GL_KHR_texture_compression_astc_hdr GL_OES_texture_compression_astc GL_OES_texture_npot GL_EXT_texture_filter_anisotropic GL_EXT_texture_format_BGRA8888 GL_OES_texture_3D GL_EXT_color_buffer_float GL_EXT_color_buffer_half_float GL_QCOM_alpha_test GL_OES_depth24 GL_OES_packed_depth_stencil GL_OES_depth_texture GL_OES_depth_texture_cube_map GL_EXT_sRGB GL_OES_texture_float GL_OES_texture_float_linear GL_OES_texture_half_float GL_OES_texture_half_float_linear GL_EXT_texture_type_2_10_10_10_REV GL_EXT_texture_sRGB_decode GL_EXT_texture_format_sRGB_override GL_OES_element_index_uint GL_EXT_copy_image GL_EXT_geometry_shader GL_EXT_tessellation_shader GL_OES_texture_stencil8 GL_EXT_shader_io_blocks GL_OES_shader_image_atomic GL_OES_sample_variables GL_EXT_texture_border_clamp GL_EXT_EGL_image_external_wrap_modes GL_EXT_multisampled_render_to_texture GL_EXT_multisampled_render_to_texture2 GL_OES_shader_multisample_interpolation GL_EXT_texture_cube_map_array GL_EXT_draw_buffers_indexed GL_EXT_gpu_shader5 GL_EXT_robustness GL_EXT_texture_buffer GL_EXT_shader_framebuffer_fetch GL_ARM_shader_framebuffer_fetch_depth_stencil GL_OES_texture_storage_multisample_2d_array GL_OES_sample_shading GL_OES_get_program_binary GL_EXT_debug_label GL_KHR_blend_equation_advanced GL_KHR_blend_equation_advanced_coherent GL_QCOM_tiled_rendering GL_ANDROID_extension_pack_es31a GL_EXT_primitive_bounding_box GL_OES_standard_derivatives GL_OES_vertex_array_object GL_EXT_disjoint_timer_query GL_KHR_debug GL_EXT_YUV_target GL_EXT_sRGB_write_control GL_EXT_texture_norm16 GL_EXT_discard_framebuffer GL_OES_surfaceless_context GL_OVR_multiview GL_OVR_multiview2 GL_EXT_texture_sRGB_R8 GL_KHR_no_error GL_EXT_debug_marker GL_OES_EGL_image_external_essl3 GL_OVR_multiview_multisampled_render_to_texture GL_EXT_buffer_storage GL_EXT_external_buffer GL_EXT_blit_framebuffer_params GL_EXT_clip_cull_distance GL_EXT_protected_textures GL_EXT_shader_non_constant_global_initializers GL_QCOM_texture_foveated GL_QCOM_shader_framebuffer_fetch_noncoherent GL_EXT_memory_object GL_EXT_memory_object_fd GL_EXT_EGL_image_array GL_NV_shader_noperspective_interpolation GL_KHR_robust_buffer_access_behavior GL_EXT_EGL_image_storage GL_EXT_blend_func_extended GL_EXT_clip_control 
I/AndroidGraphics: framebuffer: (8, 8, 8, 0)
    depthbuffer: (16)
    stencilbuffer: (0)
    samples: (0)
    coverage sampling: (false)
I/AndroidGraphics: Managed meshes/app: { }
    Managed textures/app: { }
I/AndroidGraphics: Managed cubemap/app: { }
I/AndroidGraphics: Managed shaders/app: { }
    Managed buffers/app: { }
W/com.unciv.app: JNI critical lock held for 35.733ms on Thread[19,tid=17334,Runnable,Thread*=0x72801ea000,peer=0x17068160,"GLThread 2342"]
W/com.unciv.app: JNI critical lock held for 30.245ms on Thread[19,tid=17334,Runnable,Thread*=0x72801ea000,peer=0x17068160,"GLThread 2342"]
W/com.unciv.app: JNI critical lock held for 50.862ms on Thread[19,tid=17334,Runnable,Thread*=0x72801ea000,peer=0x17068160,"GLThread 2342"]
I/System.out: Loading ruleset - 501ms
I/System.out: Loading ruleset - 7ms
    Mod loaded successfully: Unciv leader portrait mod example
I/System.out: Loading ruleset - 30ms
    Mod loaded successfully: Aliens have crashed on Earth
I/System.out: Loading ruleset - 4ms
    Mod loaded successfully: Higher quality builtin sounds
I/System.out: Loading ruleset - 5ms
    Mod loaded successfully: 5Hex Tileset
I/System.out: Loading ruleset - 1ms
    Mod loaded successfully: Wikia Leader Portraits
I/System.out: Loading percent complete of languages - 2ms
I/System.out: TileSetConfig loaded successfully: FantasyHex.json
I/System.out: TileSetConfig loaded successfully: mods/5Hex Tileset/jsons/TileSets/5Hex.json
I/System.out: Natural Wonders for this game: [Cerro de Potosi]
<b>W/SoundPool:   sample 1 not READY</b>
I/OMXClient: IOmx service obtained
<b>W/AudioTrack: AUDIO_OUTPUT_FLAG_FAST denied by server; frameCount 0 -> 9216</b>
<b>W/SoundPool:   sample 2 not READY</b>
I/OMXClient: IOmx service obtained
I/AudioTrack: AUDIO_OUTPUT_FLAG_FAST successful; frameCount 0 -> 14412
W/AudioTrack: AUDIO_OUTPUT_FLAG_FAST denied by server; frameCount 0 -> 9216
I/AndroidGraphics: paused
I/AndroidInput: sensor listener tear down
I/AndroidGraphics: Managed meshes/app: { }
    Managed textures/app: { }
    Managed cubemap/app: { }
    Managed shaders/app: { }
    Managed buffers/app: { }
I/System.out:     Thread main still running in UncivGame.dispose().
I/System.out:     Thread Jit thread pool worker thread 0 still running in UncivGame.dispose().
        Thread Binder:17282_1 still running in UncivGame.dispose().
        Thread Binder:17282_2 still running in UncivGame.dispose().
        Thread Binder:17282_3 still running in UncivGame.dispose().
        Thread Binder:17282_4 still running in UncivGame.dispose().
        Thread pool-2-thread-1 still running in UncivGame.dispose().
I/System.out:     Thread pool-2-thread-2 still running in UncivGame.dispose().
        Thread pool-2-thread-3 still running in UncivGame.dispose().
        Thread pool-2-thread-4 still running in UncivGame.dispose().
        Thread RenderThread still running in UncivGame.dispose().
        Thread hwuiTask1 still running in UncivGame.dispose().
I/System.out:     Thread HwBinder:17282_1 still running in UncivGame.dispose().
        Thread Binder:17282_5 still running in UncivGame.dispose().
        Thread Binder:17282_6 still running in UncivGame.dispose().
I/AndroidGraphics: destroyed
</details>


<details><summary><b>After:</b></summary>

06/29 23:12:07: Launching 'android' on Xiaomi MI 8.
App restart successful without requiring a re-install.
$ adb shell am start -n "com.unciv.app/com.unciv.app.AndroidLauncher" -a android.intent.action.MAIN -c android.intent.category.LAUNCHER -D
Waiting for application to come online: com.unciv.app.test | com.unciv.app
Waiting for application to come online: com.unciv.app.test | com.unciv.app
Connected to process 16798 on device 'xiaomi-mi_8-40493f83'.
Capturing and displaying logcat messages from application. This behavior can be disabled in the "Logcat output" section of the "Debugger" settings page.
W/ActivityThread: Application com.unciv.app is waiting for the debugger on port 8100...
I/System.out: Sending WAIT chunk
Waiting for application to come online: com.unciv.app.test | com.unciv.app
Connecting to com.unciv.app
Connected to the target VM, address: 'localhost:32951', transport: 'socket'
Capturing and displaying logcat messages from application. This behavior can be disabled in the "Logcat output" section of the "Debugger" settings page.
I/com.unciv.app: Late-enabling -Xcheck:jni
W/ActivityThread: Application com.unciv.app is waiting for the debugger on port 8100...
I/System.out: Sending WAIT chunk
I/System.out: Debugger has connected
    waiting for debugger to settle...
I/chatty: uid=10158(com.unciv.app) identical 5 lines
I/System.out: waiting for debugger to settle...
I/System.out: debugger has settled (1326)
W/com.unciv.app: Accessing hidden field Landroid/os/Trace;->TRACE_TAG_APP:J (light greylist, reflection)
    Accessing hidden method Landroid/os/Trace;->isTagEnabled(J)Z (light greylist, reflection)
D/WM-WrkMgrInitializer: Initializing WorkManager with default configuration.
I/Adreno: QUALCOMM build                   : 84ea314, I37527e3d62
    Build Date                       : 01/12/19
    OpenGL ES Shader Compiler Version: EV031.25.03.02
    Local Branch                     : 
    Remote Branch                    : 
    Remote Branch                    : 
    Reconstruct Branch               : 
    Build Config                     : S P 6.0.7 AArch64
I/Adreno: PFP: 0x016ee180, ME: 0x00000000
I/ConfigStore: android::hardware::configstore::V1_0::ISurfaceFlingerConfigs::hasWideColorDisplay retrieved: 1
    android::hardware::configstore::V1_0::ISurfaceFlingerConfigs::hasHDRDisplay retrieved: 0
D/OpenGLRenderer: Skia GL Pipeline
I/AndroidInput: sensor listener setup
I/Adreno: QUALCOMM build                   : 84ea314, I37527e3d62
    Build Date                       : 01/12/19
    OpenGL ES Shader Compiler Version: EV031.25.03.02
    Local Branch                     : 
    Remote Branch                    : 
    Remote Branch                    : 
    Reconstruct Branch               : 
    Build Config                     : S P 6.0.7 AArch64
I/Adreno: PFP: 0x016ee180, ME: 0x00000000
I/ConfigStore: android::hardware::configstore::V1_0::ISurfaceFlingerConfigs::hasWideColorDisplay retrieved: 1
    android::hardware::configstore::V1_0::ISurfaceFlingerConfigs::hasHDRDisplay retrieved: 0
I/OpenGLRenderer: Initialized EGL, version 1.4
D/OpenGLRenderer: Swap behavior 2
W/GL2JNIView: creating OpenGL ES 2.0 context
W/GL2JNIView: Returning a GLES 2 context
I/AndroidGraphics: OGL renderer: Adreno (TM) 630
    OGL vendor: Qualcomm
    OGL version: OpenGL ES 3.2 V@331.0 (GIT@84ea314, I37527e3d62) (Date:01/12/19)
    OGL extensions: GL_OES_EGL_image GL_OES_EGL_image_external GL_OES_EGL_sync GL_OES_vertex_half_float GL_OES_framebuffer_object GL_OES_rgb8_rgba8 GL_OES_compressed_ETC1_RGB8_texture GL_AMD_compressed_ATC_texture GL_KHR_texture_compression_astc_ldr GL_KHR_texture_compression_astc_hdr GL_OES_texture_compression_astc GL_OES_texture_npot GL_EXT_texture_filter_anisotropic GL_EXT_texture_format_BGRA8888 GL_OES_texture_3D GL_EXT_color_buffer_float GL_EXT_color_buffer_half_float GL_QCOM_alpha_test GL_OES_depth24 GL_OES_packed_depth_stencil GL_OES_depth_texture GL_OES_depth_texture_cube_map GL_EXT_sRGB GL_OES_texture_float GL_OES_texture_float_linear GL_OES_texture_half_float GL_OES_texture_half_float_linear GL_EXT_texture_type_2_10_10_10_REV GL_EXT_texture_sRGB_decode GL_EXT_texture_format_sRGB_override GL_OES_element_index_uint GL_EXT_copy_image GL_EXT_geometry_shader GL_EXT_tessellation_shader GL_OES_texture_stencil8 GL_EXT_shader_io_blocks GL_OES_shader_image_atomic GL_OES_sample_variables GL_EXT_texture_border_clamp GL_EXT_EGL_image_external_wrap_modes GL_EXT_multisampled_render_to_texture GL_EXT_multisampled_render_to_texture2 GL_OES_shader_multisample_interpolation GL_EXT_texture_cube_map_array GL_EXT_draw_buffers_indexed GL_EXT_gpu_shader5 GL_EXT_robustness GL_EXT_texture_buffer GL_EXT_shader_framebuffer_fetch GL_ARM_shader_framebuffer_fetch_depth_stencil GL_OES_texture_storage_multisample_2d_array GL_OES_sample_shading GL_OES_get_program_binary GL_EXT_debug_label GL_KHR_blend_equation_advanced GL_KHR_blend_equation_advanced_coherent GL_QCOM_tiled_rendering GL_ANDROID_extension_pack_es31a GL_EXT_primitive_bounding_box GL_OES_standard_derivatives GL_OES_vertex_array_object GL_EXT_disjoint_timer_query GL_KHR_debug GL_EXT_YUV_target GL_EXT_sRGB_write_control GL_EXT_texture_norm16 GL_EXT_discard_framebuffer GL_OES_surfaceless_context GL_OVR_multiview GL_OVR_multiview2 GL_EXT_texture_sRGB_R8 GL_KHR_no_error GL_EXT_debug_marker GL_OES_EGL_image_external_essl3 GL_OVR_multiview_multisampled_render_to_texture GL_EXT_buffer_storage GL_EXT_external_buffer GL_EXT_blit_framebuffer_params GL_EXT_clip_cull_distance GL_EXT_protected_textures GL_EXT_shader_non_constant_global_initializers GL_QCOM_texture_foveated GL_QCOM_shader_framebuffer_fetch_noncoherent GL_EXT_memory_object GL_EXT_memory_object_fd GL_EXT_EGL_image_array GL_NV_shader_noperspective_interpolation GL_KHR_robust_buffer_access_behavior GL_EXT_EGL_image_storage GL_EXT_blend_func_extended GL_EXT_clip_control 
    framebuffer: (8, 8, 8, 0)
I/AndroidGraphics: depthbuffer: (16)
    stencilbuffer: (0)
    samples: (0)
    coverage sampling: (false)
I/AndroidGraphics: Managed meshes/app: { }
    Managed textures/app: { }
    Managed cubemap/app: { }
I/AndroidGraphics: Managed shaders/app: { }
    Managed buffers/app: { }
W/com.unciv.app: JNI critical lock held for 35.415ms on Thread[18,tid=16841,Runnable,Thread*=0x728f416c00,peer=0x16dde468,"GLThread 2329"]
W/com.unciv.app: JNI critical lock held for 33.782ms on Thread[18,tid=16841,Runnable,Thread*=0x728f416c00,peer=0x16dde468,"GLThread 2329"]
W/com.unciv.app: JNI critical lock held for 46.494ms on Thread[18,tid=16841,Runnable,Thread*=0x728f416c00,peer=0x16dde468,"GLThread 2329"]
I/System.out: Loading ruleset - 497ms
I/System.out: Loading ruleset - 7ms
    Mod loaded successfully: Unciv leader portrait mod example
I/System.out: Loading ruleset - 29ms
    Mod loaded successfully: Aliens have crashed on Earth
I/System.out: Loading ruleset - 4ms
I/System.out: Mod loaded successfully: Higher quality builtin sounds
I/System.out: Loading ruleset - 5ms
    Mod loaded successfully: 5Hex Tileset
I/System.out: Loading ruleset - 1ms
    Mod loaded successfully: Wikia Leader Portraits
I/System.out: Loading percent complete of languages - 2ms
I/System.out: TileSetConfig loaded successfully: FantasyHex.json
I/System.out: TileSetConfig loaded successfully: mods/5Hex Tileset/jsons/TileSets/5Hex.json
I/System.out: Natural Wonders for this game: [Krakatoa]
I/System.out: Sound cache cleared
<b>I/System.out: Sound click loaded from mods/Higher quality builtin sounds/sounds/click.ogg</b>
I/OMXClient: IOmx service obtained
<b>I/AudioTrack: AUDIO_OUTPUT_FLAG_FAST successful; frameCount 0 -> 7677</b>
I/System.out: Sound slider loaded from mods/Higher quality builtin sounds/sounds/slider.ogg
I/OMXClient: IOmx service obtained
I/AudioTrack: AUDIO_OUTPUT_FLAG_FAST successful; frameCount 0 -> 14412
W/AudioTrack: AUDIO_OUTPUT_FLAG_FAST denied by server; frameCount 0 -> 7677
I/AndroidGraphics: paused
I/AndroidInput: sensor listener tear down
I/AndroidGraphics: Managed meshes/app: { }
I/AndroidGraphics: Managed textures/app: { }
I/AndroidGraphics: Managed cubemap/app: { }
I/AndroidGraphics: Managed shaders/app: { }
    Managed buffers/app: { }
I/System.out:     Thread main still running in UncivGame.dispose().
I/System.out:     Thread Jit thread pool worker thread 0 still running in UncivGame.dispose().
        Thread Binder:16798_1 still running in UncivGame.dispose().
        Thread Binder:16798_2 still running in UncivGame.dispose().
        Thread Binder:16798_3 still running in UncivGame.dispose().
        Thread pool-2-thread-1 still running in UncivGame.dispose().
I/System.out:     Thread pool-2-thread-2 still running in UncivGame.dispose().
        Thread pool-2-thread-3 still running in UncivGame.dispose().
        Thread pool-2-thread-4 still running in UncivGame.dispose().
        Thread RenderThread still running in UncivGame.dispose().
        Thread hwuiTask1 still running in UncivGame.dispose().
I/System.out:     Thread HwBinder:16798_1 still running in UncivGame.dispose().
        Thread Binder:16798_4 still running in UncivGame.dispose().
I/AndroidGraphics: destroyed
</details>

One of the bold-marked improvements is this PR, the other my mod standardizing on 48kHz sample rate and forcing mono sources to joint stereo coding, in this case the click sound.