### PR TITLE
Fix a few bugs related to nukes

### DIFF
--- a/android/assets/jsons/Civ V - Vanilla/Units.json
+++ b/android/assets/jsons/Civ V - Vanilla/Units.json
@@ -1209,7 +1209,7 @@
 		"requiredTech": "Nuclear Fission",
 		"requiredResource": "Uranium",
 		"promotions" : ["Evasion"],
-		"uniques": ["Nuclear weapon of strength [1]", "Requires [Manhattan Project]", "Self-destructs when attacking",
+		"uniques": ["Nuclear weapon of Strength [1]", "Requires [Manhattan Project]", "Self-destructs when attacking",
 			"Blast radius [2]"],
 		"attackSound": "nuke"
 		// Plane rather than a missile - can be based in city or Carrier only.
@@ -1259,7 +1259,7 @@
 		"range": 12,
 		"cost": 1000,
 		"requiredTech": "Advanced Ballistics",
-		"uniques": ["Self-destructs when attacking", "Nuclear weapon of strength [2]", "Requires [Manhattan Project]",
+		"uniques": ["Self-destructs when attacking", "Nuclear weapon of Strength [2]", "Requires [Manhattan Project]",
 			"Blast radius [2]", "Consumes [2] [Uranium]"],
 		"attackSound": "nuke"
 	},

--- a/android/assets/jsons/translations/German.properties
+++ b/android/assets/jsons/translations/German.properties
@@ -3781,7 +3781,7 @@ Panzer = Panzer
 
 Anti-Tank Gun = Panzerabwehr-Kanone
 
-Nuclear weapon of strength [amount] = Atomwaffe der Stärke [amount]
+Nuclear weapon of Strength [amount] = Atomwaffe der Stärke [amount]
 Self-destructs when attacking = Selbstzerstörung beim Angriff
 Blast radius [amount] = Explosionsradius [amount]
 

--- a/android/assets/jsons/translations/Swedish.properties
+++ b/android/assets/jsons/translations/Swedish.properties
@@ -3784,7 +3784,7 @@ Panzer = Panzer
 
 Anti-Tank Gun = Pansarvärnskanon
 
-Nuclear weapon of strength [amount] = Kärnvapen av styrka [amount]
+Nuclear weapon of Strength [amount] = Kärnvapen av Styrka [amount]
 Self-destructs when attacking = Självdestruerar vid anfall
 Blast radius [amount] = Sprängradie [amount]
 

--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -443,6 +443,7 @@ An enemy [unit] was spotted in our territory =
 [amount] enemy units were spotted near our territory = 
 [amount] enemy units were spotted in our territory = 
 A(n) [nukeType] exploded in our territory! = 
+After being hit by our [nukeType], [civName] has declared war on us!
 The civilization of [civName] has been destroyed! = 
 The City-State of [name] has been destroyed! = 
 We have captured a barbarian encampment and recovered [goldAmount] gold! = 

--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -397,8 +397,8 @@ object Battle {
             else attacker.unit.getMatchingUniques("Blast radius []").first().params[0].toInt()
 
         val strength = when {
-            (attacker.unit.hasUnique("Nuclear weapon of strength []")) ->
-                attacker.unit.getMatchingUniques("Nuclear weapon of strength []").first().params[0].toInt()
+            (attacker.unit.hasUnique("Nuclear weapon of Strength []")) ->
+                attacker.unit.getMatchingUniques("Nuclear weapon of Strength []").first().params[0].toInt()
             // Deprecated since 3.15.3
                 (attacker.unit.hasUnique("Nuclear weapon")) -> 1
             //

--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -389,6 +389,7 @@ object Battle {
                 && civSuffered.getDiplomacyManager(attackingCiv).diplomaticStatus != DiplomaticStatus.War
             ) {
                 attackingCiv.getDiplomacyManager(civSuffered).declareWar()
+                attackingCiv.addNotification("After being hit by our [${attacker.getName()}], [${civSuffered}] has declared war on us!", targetTile.position, NotificationIcon.War)
             }
         }
         

--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -409,8 +409,8 @@ object Battle {
         val hitTiles = targetTile.getTilesInDistance(blastRadius)
         
         // Declare war on the owners of all hit tiles
-        for (hitCiv in hitTiles.map { it.getOwner() }.distinct()) {
-            hitCiv!!.addNotification("A(n) [${attacker.getName()}] exploded in our territory!".tr(), targetTile.position, NotificationIcon.War)
+        for (hitCiv in hitTiles.mapNotNull { it.getOwner() }.distinct()) {
+            hitCiv.addNotification("A(n) [${attacker.getName()}] exploded in our territory!".tr(), targetTile.position, NotificationIcon.War)
             tryDeclareWar(hitCiv)
         }
 

--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -263,7 +263,7 @@ class BaseUnit : INamed, IConstruction {
     fun isGreatPerson() = uniqueObjects.any { it.placeholderText == "Great Person - []" }
 
     // "Nuclear Weapon" unique deprecated since 3.15.4
-    fun isNuclearWeapon() = uniqueObjects.any { it.placeholderText == "Nuclear Weapon" || it.placeholderText == "Nuclear Weapon of strength []" }
+    fun isNuclearWeapon() = uniqueObjects.any { it.placeholderText == "Nuclear Weapon" || it.placeholderText == "Nuclear weapon of Strength []" }
 
     fun movesLikeAirUnits() = unitType.isAirUnit() || unitType.isMissile()
 


### PR DESCRIPTION
Fixes the following bugs:
- Nukes don't work
- Nuking unowned tiles crashes the game
- Adds a notifciation to the attacker which civs have declared war after being hit by the nuke