### PR TITLE
Updated and generalized more promotions

### DIFF
--- a/android/assets/jsons/Civ V - Vanilla/UnitPromotions.json
+++ b/android/assets/jsons/Civ V - Vanilla/UnitPromotions.json
@@ -370,13 +370,13 @@
 	// Mixed
 	{
 		"name": "Cover I",
-		"effect": "[+25]% Strength when defending vs [Ranged]",
+		"effect": "[+33]% Strength when defending vs [Ranged]",
 		"unitTypes": ["Melee","Ranged","Siege"]
 	},
 	{
 		"name": "Cover II",
 		"prerequisites": ["Cover I"],
-		"effect": "[+25]% Strength when defending vs [Ranged]",
+		"effect": "[+33]% Strength when defending vs [Ranged]",
 		"unitTypes": ["Melee","Ranged","Siege"]
 	},
 	

--- a/android/assets/jsons/Civ V - Vanilla/UnitPromotions.json
+++ b/android/assets/jsons/Civ V - Vanilla/UnitPromotions.json
@@ -370,13 +370,13 @@
 	// Mixed
 	{
 		"name": "Cover I",
-		"effect": "+25% Defence against ranged attacks",
+		"effect": "[+25]% Strength when defending vs [Ranged]",
 		"unitTypes": ["Melee","Ranged","Siege"]
 	},
 	{
 		"name": "Cover II",
 		"prerequisites": ["Cover I"],
-		"effect": "+25% Defence against ranged attacks",
+		"effect": "[+25]% Strength when defending vs [Ranged]",
 		"unitTypes": ["Melee","Ranged","Siege"]
 	},
 	

--- a/android/assets/jsons/Civ V - Vanilla/UnitPromotions.json
+++ b/android/assets/jsons/Civ V - Vanilla/UnitPromotions.json
@@ -350,7 +350,7 @@
 	{
 		"name": "Sortie",
 		"prerequisites": ["Interception II", "Dogfighting II"],
-		"effect": "1 extra Interception may be made per turn",
+		"effect": "[1] extra interceptions may be made per turn",
 		"unitTypes": ["Fighter"]
 	},
 	

--- a/android/assets/jsons/Civ V - Vanilla/UnitPromotions.json
+++ b/android/assets/jsons/Civ V - Vanilla/UnitPromotions.json
@@ -338,19 +338,19 @@
 	// Fighter
 	{
 		"name": "Interception I",
-		"effect": "Bonus when intercepting [33]%",
+		"effect": "[+33]% Damage when intercepting",
 		"unitTypes": ["Fighter"]
 	},
 	{
 		"name": "Interception II",
 		"prerequisites": ["Interception I"],
-		"effect": "Bonus when intercepting [33]%",
+		"effect": "[+33]% Damage when intercepting",
 		"unitTypes": ["Fighter"]
 	},
 	{
 		"name": "Interception III",
 		"prerequisites": ["Interception II"],
-		"effect": "Bonus when intercepting [34]%",
+		"effect": "[+34]% Damage when intercepting",
 		"unitTypes": ["Fighter"]
 	},
 	/*

--- a/android/assets/jsons/Civ V - Vanilla/UnitPromotions.json
+++ b/android/assets/jsons/Civ V - Vanilla/UnitPromotions.json
@@ -497,7 +497,7 @@
 	},
 	{
 		"name": "Haka War Dance", // only for Maori Warrior and subsequent upgrades
-		"effect": "[-10]% Strength for enemy [Military] units in adjacent tiles"
+		"effect": "[-10]% Strength for enemy [Military] units in adjacent [All] tiles"
 	},
 	{
 		"name": "Rejuvenation", // only for Units that have been close to Natural Wonder Fountain of Youth

--- a/android/assets/jsons/Civ V - Vanilla/UnitPromotions.json
+++ b/android/assets/jsons/Civ V - Vanilla/UnitPromotions.json
@@ -403,7 +403,7 @@
 		"name": "Logistics",
 		"prerequisites": ["Accuracy III","Barrage III","Targeting III", "Wolfpack III",
 			"Bombardment III", "Coastal Raider III","Boarding Party III","Siege III"],
-		"effect": "1 additional attack per turn",
+		"effect": "[1] additional attack per turn",
 		"unitTypes": ["Ranged","Siege","WaterMelee","WaterRanged","WaterSubmarine","Fighter","Bomber"]
 	},
 	

--- a/android/assets/jsons/Civ V - Vanilla/UnitPromotions.json
+++ b/android/assets/jsons/Civ V - Vanilla/UnitPromotions.json
@@ -409,13 +409,13 @@
 	
 	{
 		"name": "Ambush I",
-		"effect": "+[25]% Strength vs [Armor]",
+		"effect": "+[33]% Strength vs [Armor]",
 		"unitTypes": ["Melee","Fighter","Bomber"]
 	},
 	{
 		"name": "Ambush II",
 		"prerequisites": ["Ambush I"],
-		"effect": "+[25]% Strength vs [Armor]",
+		"effect": "+[33]% Strength vs [Armor]",
 		"unitTypes": ["Melee","Fighter","Bomber"]
 	},
 	

--- a/android/assets/jsons/Civ V - Vanilla/UnitPromotions.json
+++ b/android/assets/jsons/Civ V - Vanilla/UnitPromotions.json
@@ -229,6 +229,25 @@
 		"unitTypes": ["WaterMelee"]
 	},
 	
+	// Water Ranged
+	{
+		"name": "Targeting I",
+		"effect": "+[15]% Strength vs [water units]",
+		"unitTypes": ["WaterRanged"]
+	},
+	{
+		"name": "Targeting II",
+		"prerequisites": ["Targeting I"],
+		"effect": "+[15]% Strength vs [water units]",
+		"unitTypes": ["WaterRanged"]
+	},
+	{
+		"name": "Targeting III",
+		"prerequisites": ["Targeting II"],
+		"effect": "+[15]% Strength vs [water units]",
+		"unitTypes": ["WaterRanged"]
+	},
+	
 	// Submarine
 	{
 		"name": "Wolfpack I",
@@ -346,6 +365,19 @@
 		"unitTypes": ["Fighter"]
 	}
 	*/
+
+	{
+		"name": "Air Targeting I",
+		"prerequisites": ["Interception I","Dogfighting I", "Siege I","Bombardment I"],
+		"effect": "+[33]% Strength vs [water units]",
+		"unitTypes": ["Fighter","Bomber"]
+	},
+	{
+		"name": "Air Targeting II",
+		"prerequisites": ["Air Targeting I"],
+		"effect": "+[33]% Strength vs [water units]",
+		"unitTypes": ["Fighter","Bomber"]
+	},
 	
 	{
 		"name": "Sortie",
@@ -437,31 +469,6 @@
 		"prerequisites": ["Bombardment II"],
 		"effect": "+[34]% Strength vs [land units]",
 		"unitTypes": ["WaterRanged","Fighter","Bomber"]
-	},
-	
-	// Targeting I has different requirements for air and waterranged units, this was the cleanest way to do so
-	{
-		"name": "Targeting I",
-		"effect": "+[15]% Strength vs [water units]",
-		"unitTypes": ["WaterRanged"]
-	},
-	{
-		"name": "Targeting I (air)",
-		"prerequisites": ["Interception I","Dogfighting I", "Siege I","Bombardment I"],
-		"effect": "+[15]% Strength vs [water units]",
-		"unitTypes": ["Fighter","Bomber"]
-	},
-	{
-		"name": "Targeting II",
-		"prerequisites": ["Targeting I","Targeting I (air)"],
-		"effect": "+[15]% Strength vs [water units]",
-		"unitTypes": ["WaterRanged","Fighter","Bomber"]
-	},
-	{
-		"name": "Targeting III",
-		"prerequisites": ["Targeting II"],
-		"effect": "+[15]% Strength vs [water units]",
-		"unitTypes": ["WaterRanged"]
 	},
 	
 	// Uniques

--- a/android/assets/jsons/Civ V - Vanilla/UnitPromotions.json
+++ b/android/assets/jsons/Civ V - Vanilla/UnitPromotions.json
@@ -293,7 +293,7 @@
 	{
 		"name": "Flight Deck II",
 		"prerequisites": ["Flight Deck I"],
-		"effect": " Can carry [1] extra [Air] units",
+		"effect": "Can carry [1] extra [Air] units",
 		"unitTypes": ["WaterAircraftCarrier"]
 	},
 	{
@@ -301,6 +301,13 @@
 		"prerequisites": ["Flight Deck II"],
 		"effect": "Can carry [1] extra [Air] units",
 		"unitTypes": ["WaterAircraftCarrier"]
+	},
+	
+	// Mixed Water
+	{
+		"name" : "Supply",
+		"prerequisites": ["Bombardment III", "Targeting III", "Boarding Party III", "Coastal Raider III"],
+		"uniques": ["May heal outside of friendly territory", "[+15] HP when healing in [Foreign Land] tiles"],
 	},
 
 	// Bomber

--- a/android/assets/jsons/Civ V - Vanilla/UnitPromotions.json
+++ b/android/assets/jsons/Civ V - Vanilla/UnitPromotions.json
@@ -490,7 +490,7 @@
 	},
 	{
 		"name": "Haka War Dance", // only for Maori Warrior and subsequent upgrades
-		"effect": "-10% combat strength for adjacent enemy units"
+		"effect": "[-10]% Strength for enemy [Military] units in adjacent tiles"
 	},
 	{
 		"name": "Rejuvenation", // only for Units that have been close to Natural Wonder Fountain of Youth

--- a/core/src/com/unciv/logic/battle/BattleDamage.kt
+++ b/core/src/com/unciv/logic/battle/BattleDamage.kt
@@ -61,8 +61,8 @@ object BattleDamage {
                 }
             }
             
-            for (unique in adjacentUnits.flatMap { it.getMatchingUniques("[]% Strength for [] units in adjacent tiles you are at war with") })
-                if (combatant.matchesCategory(unique.params[1]))
+            for (unique in adjacentUnits.flatMap { it.getMatchingUniques("[]% Strength for enemy [] units in adjacent [] tiles") })
+                if (combatant.matchesCategory(unique.params[1]) && combatant.getTile().matchesFilter(unique.params[2]))
                     modifiers.add("Adjacent enemy units", unique.params[0].toInt())
 
             val civResources = civInfo.getCivResourcesByName()

--- a/core/src/com/unciv/logic/battle/BattleDamage.kt
+++ b/core/src/com/unciv/logic/battle/BattleDamage.kt
@@ -196,11 +196,18 @@ object BattleDamage {
             )
                 modifiers["Tile"] = (tileDefenceBonus * 100).toInt()
 
-            if (attacker.isRanged()) {
-                val defenceVsRanged = 25 * defender.unit.getUniques()
-                    .count { it.text == "+25% Defence against ranged attacks" }
-                if (defenceVsRanged > 0) modifiers["defence vs ranged"] = defenceVsRanged
+            for (unique in defender.unit.getMatchingUniques("[]% Strength when defending vs []")) {
+                if (attacker.matchesCategory(unique.params[1]))
+                    modifiers.add("defence vs [${unique.params[1]}] ", unique.params[0].toInt())
             }
+            
+            // Deprecated since 3.15.7
+                if (attacker.isRanged()) {
+                    val defenceVsRanged = 25 * defender.unit.getUniques()
+                        .count { it.text == "+25% Defence against ranged attacks" }
+                    if (defenceVsRanged > 0) modifiers.add("defence vs ranged", defenceVsRanged)
+                }
+            //
 
             for (unique in defender.unit.getMatchingUniques("+[]% Strength when defending")) {
                 modifiers.add("Defender Bonus", unique.params[0].toInt())
@@ -208,7 +215,7 @@ object BattleDamage {
 
             for (unique in defender.unit.getMatchingUniques("+[]% defence in [] tiles")) {
                 if (tile.matchesFilter(unique.params[1]))
-                    modifiers["[${unique.params[1]}] defence"] = unique.params[0].toInt()
+                    modifiers.add("[${unique.params[1]}] defence", unique.params[0].toInt())
             }
 
             if (defender.unit.isFortified())

--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -527,7 +527,7 @@ class MapUnit {
         if (civInfo.hasUnique("Can only heal by pillaging")) return
 
         var amountToHealBy = rankTileForHealing(getTile())
-        if (amountToHealBy == 0) return
+        if (amountToHealBy == 0 && !(hasUnique("May heal outside of friendly territory") && !getTile().isFriendlyTerritory(civInfo))) return
 
         // Deprecated since 3.15.6
             if (hasUnique("+10 HP when healing")) amountToHealBy += 10

--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -848,7 +848,9 @@ class MapUnit {
         if (interceptChance() == 0) return false
         val maxAttacksPerTurn = 1 + 
             getMatchingUniques("[] extra interceptions may be made per turn").sumBy { it.params[0].toInt() } + 
-            getMatchingUniques("1 extra interception may be made per turn").sumBy { 1 } 
+            // Deprecated since 3.15.7
+                getMatchingUniques("1 extra interception may be made per turn").sumBy { 1 }
+            //
         if (attacksThisTurn >= maxAttacksPerTurn) return false
         if (currentTile.aerialDistanceTo(attackedTile) > baseUnit.interceptRange) return false
         return true
@@ -882,7 +884,8 @@ class MapUnit {
     }
 
     fun interceptDamagePercentBonus(): Int {
-        return getUniques().filter { it.placeholderText == "Bonus when intercepting []%" }
+        // "Bonus when intercepting []%" deprecated since 3.15.7
+        return getUniques().filter { it.placeholderText == "Bonus when intercepting []%" || it.placeholderText == "[]% Damage when intercepting"}
             .sumBy { it.params[0].toInt() }
     }
 

--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -560,15 +560,18 @@ class MapUnit {
             isFriendlyTerritory -> 15 // Allied territory
             else -> 5 // Enemy territory
         }
+        
+        val mayHeal = healing > 0 || (tileInfo.isWater && hasUnique("May heal outside of friendly territory"))
 
         // Deprecated since 3.15.6
             if (hasUnique("This unit and all others in adjacent tiles heal 5 additional HP. This unit heals 5 additional HP outside of friendly territory.")
                 && !isFriendlyTerritory
-                && healing > 0
+                && mayHeal
             )// Additional healing from medic is only applied when the unit is able to heal
                 healing += 5
         //
-        if (healing > 0) {
+        
+        if (mayHeal) {
             for (unique in getMatchingUniques("[] HP when healing in [] tiles")) {
                 if (tileInfo.matchesFilter(unique.params[1])) {
                     healing += unique.params[0].toInt()

--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -842,9 +842,11 @@ class MapUnit {
     }
 
     fun canIntercept(attackedTile: TileInfo): Boolean {
-        if (attacksThisTurn > 1) return false
         if (interceptChance() == 0) return false
-        if (attacksThisTurn > 0 && !hasUnique("1 extra Interception may be made per turn")) return false
+        val maxAttacksPerTurn = 1 + 
+            getMatchingUniques("[] extra interceptions may be made per turn").sumBy { it.params[0].toInt() } + 
+            getMatchingUniques("1 extra interception may be made per turn").sumBy { 1 } 
+        if (attacksThisTurn >= maxAttacksPerTurn) return false
         if (currentTile.aerialDistanceTo(attackedTile) > baseUnit.interceptRange) return false
         return true
     }

--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -849,7 +849,7 @@ class MapUnit {
         val maxAttacksPerTurn = 1 + 
             getMatchingUniques("[] extra interceptions may be made per turn").sumBy { it.params[0].toInt() } + 
             // Deprecated since 3.15.7
-                getMatchingUniques("1 extra interception may be made per turn").sumBy { 1 }
+                getMatchingUniques("1 extra interception may be made per turn").count()
             //
         if (attacksThisTurn >= maxAttacksPerTurn) return false
         if (currentTile.aerialDistanceTo(attackedTile) > baseUnit.interceptRange) return false


### PR DESCRIPTION
This PR is the follow-up for #4292, generalizing and updating basically all other promotions.
Again, each commit only changes a single promotion to allow for easier reviewing.
The following promotion was added:
- Supply: Water units can heal outside of friendly territory (15 hp/turn). Note that in the base game this was locked behind Tier II promotions. I choose to lock it behind Tier III promotions instead as it is very powerful in my opinion.

Added uniques:
- "[amount] extra interceptions may be made per turn"
- "[signedAmount]% Strength when defending vs [unitFilter]"
- "[signedAmount]% Strength for enemy [unitFilter] units in adjacent tiles"
- "May heal outside of friendly territory" - for water units
- [signedAmount]% Damage when intercepting

Deprecated uniques:
- "1 extra Interception may be made per turn"
- "+25% Defence against ranged attacks"
- "-10% combat strength for adjacent enemy units"
- "Bonus when intercepting [amount]%"