### PR TITLE
Add a very simple display for the religion in a city

### DIFF
--- a/core/src/com/unciv/ui/cityscreen/CityStatsTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityStatsTable.kt
@@ -42,6 +42,10 @@ class CityStatsTable(val cityScreen: CityScreen): Table() {
         addText()
         innerTable.addSeparator()
         innerTable.add(SpecialistAllocationTable(cityScreen).apply { update() })
+        if (cityInfo.civInfo.gameInfo.hasReligionEnabled()) {
+            innerTable.addSeparator()
+            addReligionInfo()
+        }
 
         pack()
     }
@@ -77,5 +81,12 @@ class CityStatsTable(val cityScreen: CityScreen): Table() {
         innerTable.add(turnsToPopString.toLabel()).row()
         if (cityInfo.isInResistance())
             innerTable.add("In resistance for another [${cityInfo.resistanceCounter}] turns".toLabel()).row()
+    }
+
+    private fun addReligionInfo() {
+        // This will later become large enough to be its own class, but for now it is small enough to fit inside a single function
+        val majorityReligion = cityInfo.religion.getMajorityReligion()
+        val label = majorityReligion ?: "None"
+        innerTable.add("Majority Religion: $label".toLabel())
     }
 }


### PR DESCRIPTION
Later this will probably split off into its own class, but for now something as small as this will work

![image](https://user-images.githubusercontent.com/71121390/124337889-329a6c80-dba5-11eb-9219-c3adc3512e82.png)
![image](https://user-images.githubusercontent.com/71121390/124337895-3a5a1100-dba5-11eb-8a64-171cd99d1cb2.png)

The double separator is due to there being one for specialists and another for religion.

If this city has specialist slots, it looks like this:

![image](https://user-images.githubusercontent.com/71121390/124358928-dfff9580-dc22-11eb-9c7e-75aae64b2524.png)
