### PR TITLE
ExpanderTab revisited

### DIFF
--- a/core/src/com/unciv/ui/trade/ExpanderTab.kt
+++ b/core/src/com/unciv/ui/trade/ExpanderTab.kt
@@ -1,45 +1,100 @@
 package com.unciv.ui.trade
 
+import com.badlogic.gdx.graphics.Color
+import com.badlogic.gdx.math.Interpolation
 import com.badlogic.gdx.scenes.scene2d.Touchable
-import com.badlogic.gdx.scenes.scene2d.ui.Skin
+import com.badlogic.gdx.scenes.scene2d.actions.FloatAction
 import com.badlogic.gdx.scenes.scene2d.ui.Table
+import com.badlogic.gdx.utils.Align
+import com.unciv.UncivGame
+import com.unciv.ui.utils.CameraStageBaseScreen
 import com.unciv.ui.utils.ImageGetter
 import com.unciv.ui.utils.onClick
 import com.unciv.ui.utils.toLabel
 
-class ExpanderTab(private val title:String,skin: Skin): Table(skin){
-    private val toggle = Table(skin) // the show/hide toggler
-    private val tab = Table() // what holds the information to be shown/hidden
-    val innerTable= Table() // the information itself
-    var isOpen=true
+/**
+ * A widget with a header that when clicked shows/hides a sub-Table
+ * 
+ * Add content to be shown/hidden to [innerTable]!
+ * 
+ * @param title The header text, automatically translated
+ * @param initialOpen Should it start out opened? Defaults to `true`.
+ */
+class ExpanderTab(
+    title: String,
+    initialOpen: Boolean = true,
+    defaultPad: Float = 10f,
+    initContent: ((Table) -> Unit)? = null
+): Table(CameraStageBaseScreen.skin) {
+    private companion object {
+        const val fontSize = 24
+        const val arrowSize = 18f
+        const val arrowImage = "OtherIcons/BackArrow"
+        val arrowColor = Color(1f,0.96f,0.75f,1f)
+        const val animationDuration = 0.2f
+    }
 
-    init{
-        toggle.defaults().pad(10f)
-        toggle.touchable= Touchable.enabled
-        toggle.background(ImageGetter.getBackground(ImageGetter.getBlue()))
-        toggle.add("+ $title".toLabel(fontSize = 24))
-        toggle.onClick {
-            if(isOpen) close()
-            else open()
+    private val header = Table(skin)  // Header with label and icon, touchable to show/hide
+    private val headerLabel = title.toLabel(fontSize = fontSize)
+    private val headerIcon = ImageGetter.getImage(arrowImage)
+    private val contentWrapper = Table()  // Wrapper for innerTable, this is what will be shown/hidden
+
+    /** The container where the client should add the content to toggle */
+    val innerTable = Table()
+
+    /** Indicates whether the contents are currently shown */
+    var isOpen = initialOpen
+        private set(value) {
+            if (value == field) return
+            field = value
+            update()
         }
-        add(toggle).fill().row()
-        tab.add(innerTable).pad(10f)
-        add(tab)
+
+    init {
+        header.defaults().pad(10f)
+        headerIcon.setSize(arrowSize, arrowSize)
+        headerIcon.setOrigin(Align.center)
+        headerIcon.rotation = 180f
+        headerIcon.color = arrowColor
+        header.background(ImageGetter.getBackground(ImageGetter.getBlue()))
+        header.add(headerLabel)
+        header.add(headerIcon).size(arrowSize).align(Align.center)
+        header.touchable= Touchable.enabled
+        header.onClick { toggle() }
+        add(header).expandX().fill().row()
+        contentWrapper.defaults().pad(defaultPad)
+        add(contentWrapper).expandX()
+        initContent?.invoke(innerTable)
+        update(noAnimation = true)
     }
 
-    fun close(){
-        if(!isOpen) return
-        toggle.clearChildren()
-        toggle.add("- $title".toLabel(fontSize = 24))
-        tab.clear()
-        isOpen=false
+    private fun update(noAnimation: Boolean = false) {
+        if (noAnimation || !UncivGame.Current.settings.continuousRendering) {
+            contentWrapper.clear()
+            if (isOpen) contentWrapper.add(innerTable)
+            headerIcon.rotation = if (isOpen) 90f else 180f
+            return
+        }
+        val action = object: FloatAction ( 90f, 180f, animationDuration, Interpolation.linear) {
+            override fun update(percent: Float) {
+                super.update(percent)
+                headerIcon.rotation = this.value
+                if (this.isComplete) {
+                    contentWrapper.clear()
+                    if (isOpen) contentWrapper.add(innerTable)
+                }
+            }
+        }.apply { isReverse = isOpen }
+        addAction(action)
     }
 
-    fun open(){
-        if(isOpen) return
-        toggle.clearChildren()
-        toggle.add("+ $title".toLabel(fontSize = 24))
-        tab.add(innerTable)
-        isOpen=true
+    fun close() {
+        isOpen = false
+    }
+    fun open() {
+        isOpen = true
+    }
+    fun toggle() {
+        isOpen = !isOpen
     }
 }

--- a/core/src/com/unciv/ui/trade/ExpanderTab.kt
+++ b/core/src/com/unciv/ui/trade/ExpanderTab.kt
@@ -13,16 +13,15 @@ import com.unciv.ui.utils.onClick
 import com.unciv.ui.utils.toLabel
 
 /**
- * A widget with a header that when clicked shows/hides a sub-Table
+ * A widget with a header that when clicked shows/hides a sub-Table.
  * 
- * Add content to be shown/hidden to [innerTable]!
- * 
- * @param title The header text, automatically translated
- * @param initialOpen Should it start out opened? Defaults to `true`.
+ * @param title The header text, automatically translated.
+ * @param defaultPad Padding between content and wrapper. Header padding is currently not modifiable.
+ * @param initContent Optional lambda with [innerTable] as parameter, to help initialize content.
  */
 class ExpanderTab(
     title: String,
-    initialOpen: Boolean = true,
+    startsOutOpened: Boolean = true,
     defaultPad: Float = 10f,
     initContent: ((Table) -> Unit)? = null
 ): Table(CameraStageBaseScreen.skin) {
@@ -42,8 +41,8 @@ class ExpanderTab(
     /** The container where the client should add the content to toggle */
     val innerTable = Table()
 
-    /** Indicates whether the contents are currently shown */
-    var isOpen = initialOpen
+    /** Indicates whether the contents are currently shown, changing this will animate the widget */
+    var isOpen = startsOutOpened
         private set(value) {
             if (value == field) return
             field = value
@@ -88,12 +87,7 @@ class ExpanderTab(
         addAction(action)
     }
 
-    fun close() {
-        isOpen = false
-    }
-    fun open() {
-        isOpen = true
-    }
+    /** Toggle [isOpen], animated */
     fun toggle() {
         isOpen = !isOpen
     }

--- a/core/src/com/unciv/ui/trade/OffersListScroll.kt
+++ b/core/src/com/unciv/ui/trade/OffersListScroll.kt
@@ -30,8 +30,8 @@ class OffersListScroll(val onOfferClicked: (TradeOffer) -> Unit) : ScrollPane(nu
         table.clear()
         expanderTabs.clear()
 
-        for (offertype in values()) {
-            val labelName = when(offertype){
+        for (offerType in values()) {
+            val labelName = when(offerType){
                 Gold, Gold_Per_Turn, Treaty,Agreement,Introduction -> ""
                 Luxury_Resource -> "Luxury resources"
                 Strategic_Resource -> "Strategic resources"
@@ -39,10 +39,11 @@ class OffersListScroll(val onOfferClicked: (TradeOffer) -> Unit) : ScrollPane(nu
                 WarDeclaration -> "Declarations of war"
                 City -> "Cities"
             }
-            val offersOfType = offersToDisplay.filter { it.type == offertype }
-            if (labelName!="" && offersOfType.any()) {
-                expanderTabs[offertype] = ExpanderTab(labelName.tr(), CameraStageBaseScreen.skin)
-                expanderTabs[offertype]!!.innerTable.defaults().pad(5f)
+            val offersOfType = offersToDisplay.filter { it.type == offerType }
+            if (labelName.isNotEmpty() && offersOfType.any()) {
+                expanderTabs[offerType] = ExpanderTab(labelName) {
+                    it.defaults().pad(5f)
+                }
             }
         }
 


### PR DESCRIPTION
#### Motivation:
`ExpanderTab` is underused, there's independent code duplicating the feature, and I have a new usecase. The existing felt too unclear - it's not obvious enough to the user this is a control and what it's good for. So I tried to 'spruce it up'.
This works and is an improvement over the current behaviour, but I'll only 'draft' it due to the open ***questions*** below. 

The following clip is done with stashed code not part of this PR, the visuals are just a bit clearer here than in a trade offer:

https://user-images.githubusercontent.com/63000004/124360455-32908000-dc2a-11eb-8b8f-411b8d83cf43.mp4

#### Questions:
- I have tried and failed to animate the 'content' part. Gdx just seems to ignore everything I tried - the best result ***was*** a gradual swipe-type showing and hiding, but it kept the total height reserved - ugly. Any idea how to clip _and_ limit the height of a larger widget? Typing this I get 'ScrollPane' - maybe I'll try later.
- With the bottom part not animating I've chosen to show/hide it at the _end_ of the arrow animation. Would beginning or middle be nicer?
- Applied to city constructions as in the video it shows a non-related problem there: While the container is nicely glued to the top left, its height is most of the available screen and the sub-contents will center within that if smaller... This, too, resists any .top() or .align(Align.top) instructions I threw at it. Hmm... maybe an empty row with expandY() at the bottom will do it? Anyway - would the shown reaction to all construction categories minimized be a showstopper?
- Another non-related thing: "Queue empty" is in the code but never shown, as queue.size is always at least 1. The video shows if(size>1) - but I'd actually prefer it gone _along_ with the header if the current construction is the only one... Your preference?

#### Plans
- Move to ui.utils once more than 1 use
- The `CityInfoTable` can be converted easily to use the ExpanderTab
- `CityConstructionsTable` might profit - per se not too useful, but if we persist open/closed state across cities then it could make thinks like adding a bank to all cities _much_ easier.
- I would use it to make NewGameScreen portrait-compatible.