### PR TITLE
Updated template.properties

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -25,7 +25,6 @@ Choose a free great person =
 Get [unitName] = 
 
 Hydro Plant = 
-+1 population in each city = 
 [buildingName] obsoleted = 
 
 # Diplomacy,Trade,Nations
@@ -245,10 +244,7 @@ Max Coast extension =
 Biome areas extension = 
 Water level = 
 Reset to default = 
-
-Show experimental world wrap for maps = 
-HIGHLY EXPERIMENTAL - YOU HAVE BEEN WARNED! = 
-Enable portrait orientation = 
+        
 Online Multiplayer = 
 
 World Size = 
@@ -390,6 +386,10 @@ Show tile yields =
 Continuous rendering = 
 When disabled, saves battery life but certain animations will be suspended = 
 Order trade offers by amount = 
+Show experimental world wrap for maps = 
+HIGHLY EXPERIMENTAL - YOU HAVE BEEN WARNED! = 
+HIGHLY EXPERIMENTAL - UPDATES WILL BREAK SAVES! = 
+Enable portrait orientation = 
 Generate translation files = 
 Translation files are generated successfully. = 
 Locate mod errors = 
@@ -684,29 +684,35 @@ Stats =
 Policies = 
 Base happiness = 
 Occupied City = 
-Buildings = 
+Buildings =
 
-# For the "when constructing [military units]" translation
-Military = 
-military units = 
-melee units = 
-mounted units = 
-naval units = 
-ranged units = 
-# For the All "newly-trained [relevant] units in this city receive the [] promotion" translation. Relevant as in 'units that can receive'
-relevant = 
-non-air = 
-# For '[stats] from [Water] tiles in this city'
+# terrainFilters (so for uniques like: "[stats] from [terrainFilter] tiles")
+
+All = 
 Water = 
-# For [stats] from [Water resource] tiles in this city
-Water resource = 
+Land = 
+Coastal = 
 River = 
+Open terrain = 
+Rough terrain = 
+Foreign Land = 
+Foreign = 
+Friendly Land = 
+Friendly = 
+Water resource = 
+Bonus resource = 
+Luxury resource = 
+Strategic resource = 
 Fresh water = 
 non-fresh water = 
-Coastal = 
-Bonus resource = 
-Strategic resource = 
-Luxury resource = 
+
+# improvementFilters
+
+All = 
+All Road = 
+Great Improvement = 
+Great = 
+
 
 Wonders = 
 Base values = 
@@ -893,14 +899,9 @@ Unlocked at =
 Gain 2 free technologies = 
 All policies adopted = 
 
-# Technologies
-
-Mass Media = 
-
 # Terrains
 
 Impassable = 
-Fresh water = 
 Rare feature = 
 
 # Resources
@@ -915,40 +916,54 @@ Strategic =
 Bonus = 
 Luxury = 
 
-# Unit types 
+# Unit types
 
+City = 
 Civilian = 
-land units = 
-water units = 
-air units = 
-Barbarian = 
-WaterCivilian = 
 Melee = 
-WaterMelee = 
 Ranged = 
+Scout = 
+Mounted = 
+Armor = 
+Siege = 
+
+WaterCivilian = 
+WaterMelee = 
 WaterRanged = 
 WaterSubmarine = 
-Mounted = 
-Siege = 
-Armor = 
-City = 
-Missile = 
 WaterAircraftCarrier = 
 
-# Units
+Fighter = 
+Bomber = 
+AtomicBomber = 
+Missile = 
 
-Composite Bowman = 
-Foreign Land = 
-Friendly Land = 
+  
+# Unit filters and other unit related things 
+
 Air = 
+air units = 
+All = 
+Barbarian = 
+Barbarians =
+Embarked =
 Land = 
-Wounded = 
-Marine = 
-Mobile SAM = 
-Paratrooper = 
-Helicopter Gunship = 
-Atomic Bomb = 
+land units = 
+Military = 
+# Deprecated since 3.15.2, but should still be translated until it is officially removed 
+military water = 
+non-air = 
+Nuclear Weapon = 
+Submarine = 
 Unbuildable = 
+Water = 
+water units = 
+wounded units = 
+Wounded =
+
+# For the All "newly-trained [relevant] units in this city receive the [] promotion" translation. Relevant as in 'units that can receive'
+relevant =
+
 
 # Promotions
 
@@ -1024,6 +1039,8 @@ in this city =
 in all cities = 
 in all coastal cities = 
 in capital = 
+in all non-occupied cities =
 in all cities with a world wonder = 
 in all cities connected to capital = 
 in all cities with a garrison = 
+

--- a/core/src/com/unciv/logic/map/TileInfo.kt
+++ b/core/src/com/unciv/logic/map/TileInfo.kt
@@ -232,12 +232,8 @@ open class TileInfo {
             for (unique in cityWideUniques + civWideUniques + religionUniques) {
                 val tileType = unique.params[1]
                 if (tileType == improvement) continue // This is added to the calculation in getImprovementStats. we don't want to add it twice
-                if (matchesTerrainFilter(tileType, observingCiv)
-                        || tileType == "Strategic resource" && hasViewableResource(observingCiv) && getTileResource().resourceType == ResourceType.Strategic
-                        || tileType == "Luxury resource" && hasViewableResource(observingCiv) && getTileResource().resourceType == ResourceType.Luxury
-                        || tileType == "Bonus resource" && hasViewableResource(observingCiv) && getTileResource().resourceType == ResourceType.Bonus
-                        || tileType == "Water resource" && isWater && hasViewableResource(observingCiv)
-                ) stats.add(unique.stats)
+                if (matchesTerrainFilter(tileType, observingCiv)) 
+                    stats.add(unique.stats)
             }
         }
 
@@ -412,10 +408,14 @@ open class TileInfo {
             "Foreign Land", "Foreign" -> observingCiv != null && !isFriendlyTerritory(observingCiv)
             "Friendly Land", "Friendly" -> observingCiv != null && isFriendlyTerritory(observingCiv)
             resource -> observingCiv != null && hasViewableResource(observingCiv)
+            "Water resource" -> isWater && observingCiv != null && hasViewableResource(observingCiv)
             else -> {
                 if (terrainFeatures.contains(filter)) return true
                 if (hasUnique(filter)) return true
-                if (resource != null && getTileResource().resourceType.name + " resource" == filter) return true
+                // Checks 'luxury resource', 'strategic resource' and 'bonus resource' - only those that are visible of course
+                if (observingCiv != null && hasViewableResource(observingCiv) 
+                    && getTileResource().resourceType.name + " resource" == filter) 
+                        return true
                 return false
             }
         }

--- a/core/src/com/unciv/ui/worldscreen/mainmenu/OptionsPopup.kt
+++ b/core/src/com/unciv/ui/worldscreen/mainmenu/OptionsPopup.kt
@@ -139,7 +139,7 @@ class OptionsPopup(val previousScreen:CameraStageBaseScreen) : Popup(previousScr
                 settings.showExperimentalWorldWrap) {
             settings.showExperimentalWorldWrap = it
         }
-        addYesNoRow("{Enable experimental religion in start games}\n{HIHGLY EXPERIMENTAL - UPDATES WILL BREAK SAVES!}".tr(),
+        addYesNoRow("{Enable experimental religion in start games}\n{HIGHLY EXPERIMENTAL - UPDATES WILL BREAK SAVES!}".tr(),
                 settings.showExperimentalReligion) {
             settings.showExperimentalReligion = it
         }


### PR DESCRIPTION
This adds a few translations that were previously missed (most notably updates unitFilter, tileFitler and cityFilter to contain all the values currently allowed), and shuffles the rest of the file around so that strings about similar things are closer together. Also removed a few strings that should really be included in the automatic generation (mass media, +1 population in each city).