### PR TITLE
Fixed crash when a city had negative population due to faster razing

### DIFF
--- a/core/src/com/unciv/logic/city/CityInfo.kt
+++ b/core/src/com/unciv/logic/city/CityInfo.kt
@@ -409,7 +409,7 @@ class CityInfo {
         cityConstructions.endTurn(stats)
         expansion.nextTurn(stats.culture)
         if (isBeingRazed) {
-            val removedPopulation = 1 + civInfo.getMatchingUniques("Cities are razed [] times as fast").sumBy { it.params[0].toInt() }
+            val removedPopulation = 1 + civInfo.getMatchingUniques("Cities are razed [] times as fast").sumBy { it.params[0].toInt() - 1 }
             population.addPopulation(-1 * removedPopulation)
             if (population.population <= 0) { 
                 civInfo.addNotification("[$name] has been razed to the ground!", location, "OtherIcons/Fire")

--- a/core/src/com/unciv/logic/city/PopulationManager.kt
+++ b/core/src/com/unciv/logic/city/PopulationManager.kt
@@ -73,6 +73,7 @@ class PopulationManager {
 
     internal fun addPopulation(count: Int) {
         population += count
+        if (population < 0) population = 0
         val freePopulation = getFreePopulation()
         if (freePopulation < 0) {
             unassignExtraPopulation()


### PR DESCRIPTION
Also changes it so that the 'razes city [amount] times as fast' doesn't raze too fast