### PR TITLE
ExpanderTab revisited - move and apply to city screen

### DIFF
--- a/core/src/com/unciv/ui/trade/OffersListScroll.kt
+++ b/core/src/com/unciv/ui/trade/OffersListScroll.kt
@@ -9,10 +9,7 @@ import com.unciv.logic.trade.TradeOffersList
 import com.unciv.logic.trade.TradeType
 import com.unciv.logic.trade.TradeType.*
 import com.unciv.models.translations.tr
-import com.unciv.ui.utils.CameraStageBaseScreen
-import com.unciv.ui.utils.disable
-import com.unciv.ui.utils.onClick
-import com.unciv.ui.utils.toTextButton
+import com.unciv.ui.utils.*
 import kotlin.math.min
 import com.unciv.ui.utils.AutoScrollPane as ScrollPane
 

--- a/core/src/com/unciv/ui/utils/ExpanderTab.kt
+++ b/core/src/com/unciv/ui/utils/ExpanderTab.kt
@@ -1,32 +1,34 @@
-package com.unciv.ui.trade
+package com.unciv.ui.utils
 
 import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.math.Interpolation
+import com.badlogic.gdx.scenes.scene2d.Actor
 import com.badlogic.gdx.scenes.scene2d.Touchable
 import com.badlogic.gdx.scenes.scene2d.actions.FloatAction
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.utils.Align
 import com.unciv.UncivGame
-import com.unciv.ui.utils.CameraStageBaseScreen
-import com.unciv.ui.utils.ImageGetter
-import com.unciv.ui.utils.onClick
-import com.unciv.ui.utils.toLabel
 
 /**
  * A widget with a header that when clicked shows/hides a sub-Table.
  * 
  * @param title The header text, automatically translated.
+ * @param fontSize Size applied to header text (only)
+ * @param icon Optional icon - please use [Image][com.badlogic.gdx.scenes.scene2d.ui.Image] or [IconCircleGroup]
  * @param defaultPad Padding between content and wrapper. Header padding is currently not modifiable.
+ * @param expanderWidth If set initializes header width
  * @param initContent Optional lambda with [innerTable] as parameter, to help initialize content.
  */
 class ExpanderTab(
     title: String,
+    fontSize: Int = 24,
+    icon: Actor? = null,
     startsOutOpened: Boolean = true,
     defaultPad: Float = 10f,
+    expanderWidth: Float = 0f,
     initContent: ((Table) -> Unit)? = null
 ): Table(CameraStageBaseScreen.skin) {
     private companion object {
-        const val fontSize = 24
         const val arrowSize = 18f
         const val arrowImage = "OtherIcons/BackArrow"
         val arrowColor = Color(1f,0.96f,0.75f,1f)
@@ -56,14 +58,25 @@ class ExpanderTab(
         headerIcon.rotation = 180f
         headerIcon.color = arrowColor
         header.background(ImageGetter.getBackground(ImageGetter.getBlue()))
+        if (icon != null) header.add(icon)
         header.add(headerLabel)
         header.add(headerIcon).size(arrowSize).align(Align.center)
         header.touchable= Touchable.enabled
         header.onClick { toggle() }
-        add(header).expandX().fill().row()
-        contentWrapper.defaults().pad(defaultPad)
-        add(contentWrapper).expandX()
+        if (expanderWidth != 0f)
+            defaults().minWidth(expanderWidth)
+        defaults().growX()
+        contentWrapper.defaults().growX().pad(defaultPad)
+        innerTable.defaults().growX()
+        add(header).fillY().row()
+        add(contentWrapper)
+        contentWrapper.add(innerTable)      // update will revert this
         initContent?.invoke(innerTable)
+        if (expanderWidth == 0f) {
+            // Measure content width incl. pad, set header to same width
+            if (innerTable.needsLayout()) contentWrapper.pack()
+            getCell(header).minWidth(contentWrapper.width)
+        }
         update(noAnimation = true)
     }
 


### PR DESCRIPTION
Sequel to #4357 

- ExpanderTab moved to package utils
- Added features to support usecases from city screen (building icon, width)
- A little extra effort to guarantee the construction type expanders have the same width
- The buildings under CityInfoTable actually look different because I did not add even more modifiers to ExpanderTab (remove background and animated arrow), otherwise they _would_ look almost identical to before. I think it's a pleasant change:
![image](https://user-images.githubusercontent.com/63000004/124664512-d89eed00-deab-11eb-91c1-c578748ec5f1.png)
(left = half way, only the categories rewritten, right = this PR)

### Question:
- I didn't move the separator under an 'opened' building (see screenie above), but I think it's ~~wrong~~ suboptimal. Shouldn't be between a building and its specialists. We decide and change that later, agreed? Any input on desired outcome? A case for an inconspicuous (gray/1f) separator, permanent instead of toggled with the info?
- I'd like to persist startsOutOpened at least between screen invocations -> OffersListScroll expanders are almost pointless because each added offer makes the screen forget every expander state, sequentially going through all cities to add a researched building could profit....
Architecture? One non-serialized subproperty of `GameSettings` - `expanderStates` - each usecase a HashSet<String> under that, listing the closed ones by title?