### PR TITLE
Fixed crashes on loading save games with religion

### DIFF
--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -285,8 +285,8 @@ class GameInfo {
         for (civInfo in civilizations) civInfo.gameInfo = this
 
         difficultyObject = ruleSet.difficulties[difficulty]!!
-
-
+        
+        for (religion in religions.values) religion.setTransients(this)
 
         // This doesn't HAVE to go here, but why not.
 

--- a/core/src/com/unciv/logic/civilization/ReligionManager.kt
+++ b/core/src/com/unciv/logic/civilization/ReligionManager.kt
@@ -22,7 +22,7 @@ class ReligionManager {
     // in some cases. We only save one of them in this class to reduce the amount of logic necessary.
     // But the other one should still be _somehwere_. So our only option is to have the GameInfo
     // contain the master list, and the ReligionManagers retrieve it from there every time the game loads.
-    
+
     private var greatProphetsEarned = 0
 
     fun clone(): ReligionManager {
@@ -30,17 +30,17 @@ class ReligionManager {
         clone.storedFaith = storedFaith
         return clone
     }
-    
+
     fun setTransients() {
         // Find our religion from the map of founded religions.
         // First check if there is any major religion
-        religion = civInfo.gameInfo.religions.values.firstOrNull { 
-            it.foundingCiv.civName == civInfo.civName && it.isMajorReligion()
+        religion = civInfo.gameInfo.religions.values.firstOrNull {
+            it.foundingCivName == civInfo.civName && it.isMajorReligion()
         }
         // If there isn't, check for just pantheons.
         if (religion != null) return
         religion = civInfo.gameInfo.religions.values.firstOrNull {
-            it.foundingCiv.civName == civInfo.civName
+            it.foundingCivName == civInfo.civName
         }
     }
 
@@ -57,11 +57,11 @@ class ReligionManager {
             }
         }
     }
-    
+
     fun endTurn(faithFromNewTurn: Int) {
         storedFaith += faithFromNewTurn
     }
-    
+
     private fun faithForPantheon() = 10 + civInfo.gameInfo.civilizations.count { it.isMajorCiv() && it.religionManager.religion != null } * 5
 
     fun canFoundPantheon(): Boolean {
@@ -82,17 +82,17 @@ class ReligionManager {
 
     fun choosePantheonBelief(belief: Belief) {
         storedFaith -= faithForPantheon()
-        religion = Religion(belief.name, civInfo)
+        religion = Religion(belief.name, civInfo.gameInfo, civInfo.civName)
         religion!!.pantheonBeliefs.add(belief.name)
         civInfo.gameInfo.religions[belief.name] = religion!!
         // This should later be changed when religions can have multiple beliefs
         civInfo.getCapital().religion[belief.name] = 100 // Capital is religious, other cities are not
     }
-    
+
     // https://www.reddit.com/r/civ/comments/2m82wu/can_anyone_detail_the_finer_points_of_great/
     // Game files (globaldefines.xml)
     fun faithForNextGreatProphet() = ((200 + 100 * greatProphetsEarned * (greatProphetsEarned + 1)/2) * civInfo.gameInfo.gameParameters.gameSpeed.modifier).toInt()
-    
+
     fun canGenerateProphet(): Boolean {
         if (religion == null || !religion!!.hasPantheon()) return false // First get a pantheon, then we'll talk about a real religion
         if (storedFaith < faithForNextGreatProphet()) return false

--- a/core/src/com/unciv/models/Religion.kt
+++ b/core/src/com/unciv/models/Religion.kt
@@ -1,26 +1,42 @@
 package com.unciv.models
 
+import com.unciv.logic.GameInfo
 import com.unciv.logic.civilization.CivilizationInfo
 import com.unciv.models.ruleset.Unique
 import com.unciv.models.stats.INamed
 
 /** Data object for Religions */
-class Religion(override var name: String, val foundingCiv: CivilizationInfo) : INamed {
+class Religion() : INamed {
     
     var pantheonBeliefs: HashSet<String> = hashSetOf()
     var founderBeliefs: HashSet<String> = hashSetOf()
     var followerBeliefs: HashSet<String> = hashSetOf()
-
+    override lateinit var name: String
+    lateinit var foundingCivName: String
+    
+    @Transient
+    lateinit var gameInfo: GameInfo
+    
+    constructor(name: String, gameInfo: GameInfo, foundingCivName: String) : this() {
+        this.name = name
+        this.foundingCivName = foundingCivName
+        this.gameInfo = gameInfo
+    }
+    
     fun clone(): Religion {
-        val toReturn = Religion(name, foundingCiv)
+        val toReturn = Religion(name, gameInfo, foundingCivName)
         toReturn.pantheonBeliefs.addAll(pantheonBeliefs)
         toReturn.founderBeliefs.addAll(founderBeliefs)
         toReturn.followerBeliefs.addAll(followerBeliefs)
         return toReturn
     }
     
+    fun setTransients(gameInfo: GameInfo) {
+        this.gameInfo = gameInfo
+    }
+    
     private fun getUniquesOfBeliefs(beliefs: HashSet<String>): Sequence<Unique> {
-        val rulesetBeliefs = foundingCiv.gameInfo.ruleSet.beliefs
+        val rulesetBeliefs = gameInfo.ruleSet.beliefs
         return beliefs.mapNotNull {
             if (it !in rulesetBeliefs) null
             else rulesetBeliefs[it]!!.uniqueObjects


### PR DESCRIPTION
So for some reason I had the brilliant idea to save an object of the civ founding a religion inside the religion itself. This went about as well as you would expect, and led to crashes on loading saves with a religion. This PR fixes this by removing the variable all together, instead having a transient GameInfo object, and a string of the name of the civ.