### PR TITLE
Fixed bug where effects of all aquaducts nationwide stacked in each city

### DIFF
--- a/android/assets/jsons/Civ V - Vanilla/Buildings.json
+++ b/android/assets/jsons/Civ V - Vanilla/Buildings.json
@@ -393,7 +393,7 @@
 		"name": "Aqueduct",
 		"maintenance": 1,
 		"hurryCostModifier": 0,
-		"uniques": ["[40]% of food is carried over after population increases [in this city]"],
+		"uniques": ["[40]% of food is carried over [in this city] after population increases"],
 		"requiredTech": "Engineering"
 	},
 	{
@@ -978,7 +978,7 @@
 		"requiredBuilding": "Hospital",
 		"maintenance": 3,
 		"requiredTech": "Pharmaceuticals",
-		"uniques": ["[25]% of food is carried over after population increases [in this city]"]
+		"uniques": ["[25]% of food is carried over [in this city] after population increases"]
 	},
 	{
 		"name": "Manhattan Project",

--- a/android/assets/jsons/Civ V - Vanilla/Buildings.json
+++ b/android/assets/jsons/Civ V - Vanilla/Buildings.json
@@ -393,7 +393,7 @@
 		"name": "Aqueduct",
 		"maintenance": 1,
 		"hurryCostModifier": 0,
-		"uniques": ["[40]% of food is carried over after population increases"],
+		"uniques": ["[40]% of food is carried over after population [in this city] increases"],
 		"requiredTech": "Engineering"
 	},
 	{
@@ -978,7 +978,7 @@
 		"requiredBuilding": "Hospital",
 		"maintenance": 3,
 		"requiredTech": "Pharmaceuticals",
-		"uniques": ["[25]% of food is carried over after population increases"]
+		"uniques": ["[25]% of food is carried over after population [in this city] increases"]
 	},
 	{
 		"name": "Manhattan Project",

--- a/android/assets/jsons/Civ V - Vanilla/Buildings.json
+++ b/android/assets/jsons/Civ V - Vanilla/Buildings.json
@@ -393,7 +393,7 @@
 		"name": "Aqueduct",
 		"maintenance": 1,
 		"hurryCostModifier": 0,
-		"uniques": ["[40]% of food is carried over after population [in this city] increases"],
+		"uniques": ["[40]% of food is carried over after population increases [in this city]"],
 		"requiredTech": "Engineering"
 	},
 	{
@@ -978,7 +978,7 @@
 		"requiredBuilding": "Hospital",
 		"maintenance": 3,
 		"requiredTech": "Pharmaceuticals",
-		"uniques": ["[25]% of food is carried over after population [in this city] increases"]
+		"uniques": ["[25]% of food is carried over after population increases [in this city]"]
 	},
 	{
 		"name": "Manhattan Project",

--- a/core/src/com/unciv/logic/city/PopulationManager.kt
+++ b/core/src/com/unciv/logic/city/PopulationManager.kt
@@ -60,7 +60,7 @@ class PopulationManager {
         if (foodStored >= getFoodToNextPopulation()) {  // growth!
             foodStored -= getFoodToNextPopulation()
             var percentOfFoodCarriedOver = cityInfo
-                .getMatchingUniques("[]% of food is carried over after population [] increases")
+                .getMatchingUniques("[]% of food is carried over after population increases []")
                 .filter { cityInfo.matchesFilter(it.params[1]) }
                 .sumBy { it.params[0].toInt() }
             // Deprecated since 3.15.11

--- a/core/src/com/unciv/logic/city/PopulationManager.kt
+++ b/core/src/com/unciv/logic/city/PopulationManager.kt
@@ -60,9 +60,15 @@ class PopulationManager {
         if (foodStored >= getFoodToNextPopulation()) {  // growth!
             foodStored -= getFoodToNextPopulation()
             var percentOfFoodCarriedOver = cityInfo
-                    .getMatchingUniques("[]% of food is carried over after population increases")
+                .getMatchingUniques("[]% of food is carried over after population [] increases")
+                .filter { cityInfo.matchesFilter(it.params[1]) }
+                .sumBy { it.params[0].toInt() }
+            // Deprecated since 3.15.11
+                percentOfFoodCarriedOver += cityInfo
+                    .getLocalMatchingUniques("[]% of food is carried over after population increases")
                     .sumBy { it.params[0].toInt() }
-            // Try to avoid runaway food gain in mods, just in case mod makes don't notice it
+            //
+            // Try to avoid runaway food gain in mods, just in case 
             if (percentOfFoodCarriedOver > 95) percentOfFoodCarriedOver = 95 
             foodStored += (getFoodToNextPopulation() * percentOfFoodCarriedOver / 100f).toInt()
             population++

--- a/core/src/com/unciv/logic/city/PopulationManager.kt
+++ b/core/src/com/unciv/logic/city/PopulationManager.kt
@@ -60,7 +60,7 @@ class PopulationManager {
         if (foodStored >= getFoodToNextPopulation()) {  // growth!
             foodStored -= getFoodToNextPopulation()
             var percentOfFoodCarriedOver = cityInfo
-                .getMatchingUniques("[]% of food is carried over after population increases []")
+                .getMatchingUniques("[]% of food is carried over [] after population increases")
                 .filter { cityInfo.matchesFilter(it.params[1]) }
                 .sumBy { it.params[0].toInt() }
             // Deprecated since 3.15.11


### PR DESCRIPTION
Added uniques:
- "[amount]% of food is carried over after population [cityFilter] increases"

Deprecated uniques:
- "[amount]% of food is carried over after population increases"