### PR TITLE
Fixed bug which leads to crashes for almost all users

### DIFF
--- a/core/src/com/unciv/ui/trade/DiplomacyScreen.kt
+++ b/core/src/com/unciv/ui/trade/DiplomacyScreen.kt
@@ -56,7 +56,7 @@ class DiplomacyScreen(val viewingCiv:CivilizationInfo):CameraStageBaseScreen() {
     private fun updateLeftSideTable() {
         leftSideTable.clear()
         for (civ in viewingCiv.gameInfo.civilizations
-                .filterNot { it.isDefeated() || it == viewingCiv || it.isBarbarian() || it.isSpectator() || viewingCiv.knows(it) }) {
+                .filterNot { it.isDefeated() || it == viewingCiv || it.isBarbarian() || it.isSpectator() || !viewingCiv.knows(it) }) {
 
             val civIndicator = ImageGetter.getNationIndicator(civ.nation, 100f)
 


### PR DESCRIPTION
So apparently I messed up a double negative, and there should be a ! there.
Without this fix, the diplomacy screen will show all civs the player has _not_ met.
Clicking on any of them will crash your game.

Although it is your choice, I'd advice on bringing out a patch for this.