### PR TITLE
Missing translation templates from BattleDamage modifiers

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -659,6 +659,9 @@ Attack =
 Bombard = 
 NUKE = 
 Captured! = 
+
+# Battle modifier categories
+
 defence vs ranged = 
 [percentage] to unit defence = 
 Attacker Bonus = 
@@ -669,6 +672,17 @@ vs [unitType] =
 Terrain = 
 Tile = 
 Missing resource = 
+Adjacent units = 
+Adjacent enemy units = 
+Combat Strength = 
+Across river = 
+Temporary Bonus = 
+Garrisoned unit = 
+Attacking Bonus = 
+defence vs [unitType] = 
+[tileFilter] defence = 
+Defensive Bonus = 
+
 The following improvements [stats]: = 
 The following improvements on [tileType] tiles [stats]: = 
 


### PR DESCRIPTION
Possibly not all of them and possibly including deprecated ones. I just went through the source after seeing a few untranslated and untemplated ones. By the way, `class BattleDamageModifier` is a corpse.