### PR TITLE
Keyboard mapping by keyCode

### DIFF
--- a/core/src/com/unciv/ui/mapeditor/SaveAndLoadMapScreen.kt
+++ b/core/src/com/unciv/ui/mapeditor/SaveAndLoadMapScreen.kt
@@ -95,7 +95,7 @@ class SaveAndLoadMapScreen(mapToSave: TileMap?, save:Boolean = false, previousSc
                 Gdx.app.clipboard.contents = base64Gzip
             }
             copyMapAsTextButton.onClick (copyMapAsTextAction)
-            keyPressDispatcher['\u0003'] = copyMapAsTextAction   // Ctrl-C
+            keyPressDispatcher[KeyCharAndCode.ctrl('C')] = copyMapAsTextAction
             rightSideTable.add(copyMapAsTextButton).row()
         } else {
             val loadFromClipboardButton = "Load copied data".toTextButton()
@@ -111,7 +111,7 @@ class SaveAndLoadMapScreen(mapToSave: TileMap?, save:Boolean = false, previousSc
                 }
             }
             loadFromClipboardButton.onClick(loadFromClipboardAction)
-            keyPressDispatcher['\u0016'] = loadFromClipboardAction   // Ctrl-V
+            keyPressDispatcher[KeyCharAndCode.ctrl('V')] = loadFromClipboardAction
             rightSideTable.add(loadFromClipboardButton).row()
             rightSideTable.add(couldNotLoadMapLabel).row()
         }
@@ -123,7 +123,7 @@ class SaveAndLoadMapScreen(mapToSave: TileMap?, save:Boolean = false, previousSc
             }, this).open()
         }
         deleteButton.onClick(deleteAction)
-        keyPressDispatcher['\u007f'] = deleteAction     // Input.Keys.DEL but ascii has precedence
+        keyPressDispatcher[KeyCharAndCode.DEL] = deleteAction
         rightSideTable.add(deleteButton).row()
 
         topTable.add(rightSideTable)

--- a/core/src/com/unciv/ui/utils/KeyPressDispatcher.kt
+++ b/core/src/com/unciv/ui/utils/KeyPressDispatcher.kt
@@ -25,8 +25,10 @@ import com.badlogic.gdx.scenes.scene2d.Stage
  * Example: KeyCharAndCode('R'), KeyCharAndCode(Input.Keys.F1)
  */
 data class KeyCharAndCode(val char: Char, val code: Int) {
+    /** helper 'cloning constructor' to allow feeding both fields from a factory function */
+    private constructor(from: KeyCharAndCode): this(from.char, from.code)
     /** Map keys from a Char - will detect by keycode if one can be mapped, by character otherwise */
-    constructor(char: Char): this(mapCharPart(char), mapCodePart(char))
+    constructor(char: Char): this(mapChar(char))
     /** express keys that only have a keyCode like F1 */
     constructor(code: Int): this(Char.MIN_VALUE, code)
 
@@ -60,14 +62,10 @@ data class KeyCharAndCode(val char: Char, val code: Int) {
         /** mini-factory for KeyCharAndCode values to be compared by character, not by code */
         fun ascii(char: Char) = KeyCharAndCode(char.toLowerCase(), 0)
         
-        // Separate into two parts so it can be used in a constructor
-        private fun mapCharPart(char: Char): Char {
+        /** factory maps a Char to a keyCode if possible, returns a Char-based instance otherwise */
+        fun mapChar(char: Char): KeyCharAndCode {
             val code = Input.Keys.valueOf(char.toUpperCase().toString())
-            return if (code == -1) char else Char.MIN_VALUE
-        }
-        private fun mapCodePart(char: Char): Int {
-            val code = Input.Keys.valueOf(char.toUpperCase().toString())
-            return if (code == -1) 0 else code
+            return if (code == -1) KeyCharAndCode(char,0) else KeyCharAndCode(Char.MIN_VALUE, code)
         }
     }
 }

--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -251,11 +251,11 @@ class WorldScreen(val gameInfo: GameInfo, val viewingCiv:CivilizationInfo) : Cam
             if (!mapHolder.setCenterPosition(capital.location))
                 game.setScreen(CityScreen(capital))
         }
-        keyPressDispatcher['\u000F'] = { this.openOptionsPopup() }    //   Ctrl-O: Game Options
-        keyPressDispatcher['\u0013'] = { game.setScreen(SaveGameScreen(gameInfo)) }    //   Ctrl-S: Save
-        keyPressDispatcher['\u000C'] = { game.setScreen(LoadGameScreen(this)) }    //   Ctrl-L: Load
-        keyPressDispatcher['+'] = { this.mapHolder.zoomIn() }    //   '+' Zoom - Input.Keys.NUMPAD_ADD would need dispatcher patch
-        keyPressDispatcher['-'] = { this.mapHolder.zoomOut() }    //   '-' Zoom
+        keyPressDispatcher[KeyCharAndCode.ctrl('O')] = { this.openOptionsPopup() }    //   Game Options
+        keyPressDispatcher[KeyCharAndCode.ctrl('S')] = { game.setScreen(SaveGameScreen(gameInfo)) }    //   Save
+        keyPressDispatcher[KeyCharAndCode.ctrl('L')] = { game.setScreen(LoadGameScreen(this)) }    //   Load
+        keyPressDispatcher[Input.Keys.NUMPAD_ADD] = { this.mapHolder.zoomIn() }    //   '+' Zoom
+        keyPressDispatcher[Input.Keys.NUMPAD_SUBTRACT] = { this.mapHolder.zoomOut() }    //   '-' Zoom
         keyPressDispatcher.setCheckpoint()
     }
 


### PR DESCRIPTION
Result of earlier discussion. Resolve #4430 - This is almost a re-write of that earlier draft, as I tried to avoid touching existing caller code - except those using `'\u00nn'` - those had to go, I thought I had replaced those with the ctrl() factory ages ago...

~~No I couldn't find a cleaner way to get one function to feed both primary constructor values - at least not yesterday (answer: make the primary constructor take only one value, _then_ build the secondaries - too lazy now). Calling the lookup twice isn't so bad, java caches the mappings under the hood.~~ I do like this better even though it incurs an extra copying just to allow the Char constructor to include the mapping to codes.