### PR TITLE
Small fixes

### DIFF
--- a/core/src/com/unciv/logic/city/CityInfo.kt
+++ b/core/src/com/unciv/logic/city/CityInfo.kt
@@ -599,7 +599,7 @@ class CityInfo {
     }
     
     fun canBeDestroyed(): Boolean {
-        return !isCapital() && !isHolyCity()
+        return !isOriginalCapital && !isCapital() && !isHolyCity()
     }
 
     //endregion

--- a/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
@@ -490,10 +490,8 @@ object UnitActions {
                         city.cityStats.update()
                         city.civInfo.updateDetailedCivResources()
                     }
-                    // Why is this here? How do we now the unit is actually a great person?
-                    // What if in some mod some unit can construct a certain type of improvement using the "Can construct []" unique?
-                    // That unit does not need to be a great person at all, and yet it would trigger mausoleum of halicarnassus (?) here.
-                    addGoldPerGreatPersonUsage(unit.civInfo)
+                    if (unit.hasUnique("Great Person - []"))
+                        addGoldPerGreatPersonUsage(unit.civInfo)
                     unit.destroy()
                 }.takeIf {
                     unit.currentMovement > 0f && tile.canBuildImprovement(improvement, unit.civInfo)

--- a/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
@@ -113,22 +113,20 @@ object UnitActions {
         val tile = unit.currentTile
         if (!tile.isWater || !unit.hasUnique("May create improvements on water resources") || tile.resource == null) return null
 
-        val improvement = tile.getTileResource().improvement
+        val improvementName = tile.getTileResource().improvement ?: return null
+        val improvement = tile.ruleset.tileImprovements[improvementName] ?: return null
+        if (!tile.canBuildImprovement(improvement, unit.civInfo)) return null
 
-        if (tile.improvement == null && tile.ruleset.tileImprovements.containsKey(improvement)
-                && tile.ruleset.tileImprovements[improvement]!!.techRequired.let { it == null || unit.civInfo.tech.isResearched(it) })
-            return UnitAction(UnitActionType.Create, "Create [$improvement]",
-                    action = {
-                        tile.improvement = improvement
-                        val city = tile.getCity()
-                        if (city != null) {
-                            city.cityStats.update()
-                            city.civInfo.updateDetailedCivResources()
-                        }
-                        unit.destroy()
-                    }.takeIf { unit.currentMovement > 0 })
-
-        return null
+        return UnitAction(UnitActionType.Create, "Create [$improvementName]",
+            action = {
+                tile.improvement = improvementName
+                val city = tile.getCity()
+                if (city != null) {
+                    city.cityStats.update()
+                    city.civInfo.updateDetailedCivResources()
+                }
+                unit.destroy()
+            }.takeIf { unit.currentMovement > 0 })
     }
     
     // This entire function is deprecated since 3.15.4, as the 'can construct roads' unique is deprecated

--- a/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
@@ -120,6 +120,11 @@ object UnitActions {
             return UnitAction(UnitActionType.Create, "Create [$improvement]",
                     action = {
                         tile.improvement = improvement
+                        val city = tile.getCity()
+                        if (city != null) {
+                            city.cityStats.update()
+                            city.civInfo.updateDetailedCivResources()
+                        }
                         unit.destroy()
                     }.takeIf { unit.currentMovement > 0 })
 


### PR DESCRIPTION
Single commits - their descriptions says it all, except:
"create water improvements outside borders" - can't find evidence, but I think allowing them everywhere is silly. If the rules are correct as they are, this commit would still be OK - the offshore platform and fishing boats in this case should get the allowed outside borders unique. This way means better moddability, too. I think.