### PR TITLE
Let translators provide strings for MultiplayerTurnCheckWorker

### DIFF
--- a/android/assets/jsons/translations/French.properties
+++ b/android/assets/jsons/translations/French.properties
@@ -4464,3 +4464,10 @@ This is where you spend most of your time playing Unciv. See the world, control 
  # Requires translation!
 What you don't see: The phone/tablet's back button will pop the question whether you wish to leave Unciv and go back to Real Life. On desktop versions, you can use the ESC key. = 
 
+
+################### From XML ###################
+Notify_YourTurn_Short = Unciv - C'est à vous !
+Notify_YourTurn_Long = Vos amis attendent votre action.
+Notify_Error_Long = Service de notification du tour multijoueur terminé
+Notify_Error_Short = Une erreur est survenue
+Notify_Persist_Long_P4 = Configurable dans le menu des options de Unciv

--- a/android/assets/jsons/translations/German.properties
+++ b/android/assets/jsons/translations/German.properties
@@ -4082,3 +4082,20 @@ This is where you spend most of your time playing Unciv. See the world, control 
 ⓩ: And this is the red targeting circle that led to the attack pane back under ⑬. = Ⓩ: Und dies ist der rote Zielkreis, der zum Angriffsfenster zurück unter ⑬ führte.
 What you don't see: The phone/tablet's back button will pop the question whether you wish to leave Unciv and go back to Real Life. On desktop versions, you can use the ESC key. = Was du nicht siehst: Über die Zurück-Taste des Telefons/Tablets erscheint die Frage, ob du Unciv verlassen und ins Real Life zurückkehren möchtest. Bei Desktop-Versionen kannst du die ESC-Taste verwenden.
 
+################### From XML ###################
+Notify_YourTurn_Short = Unciv - Du bist am Zug!
+Notify_YourTurn_Long = Deine Freunde warten auf deinen Zug.
+Notify_Error_Short = Ein Fehler ist aufgetreten
+Notify_Error_Long = Multiplayer Zug Benachrichtigungsdienst wurde beendet.
+Notify_Persist_Short = Letzter online Zugcheck:
+Notify_Persist_Long_P1 = Unciv wird dich benachrichtigen, wenn du im Multiplayer am Zug bist.
+Notify_Persist_Long_P2 = Prüft etwa alle
+Notify_Persist_Long_P3 = Minute(n) wenn Internet vorhanden.
+Notify_Persist_Long_P4 = Konfigurierbar im Unciv Optionsmenü.
+Notify_ChannelInfo_Short = Unciv Multiplayer Zugprüfer Ereignis
+Notify_ChannelInfo_Long = Informiert dich, wenn du im Multiplayer am Zug bist.
+Notify_ChannelService_Short = Unciv Multiplayer Zugprüfer Persistenter Status
+Notify_ChannelService_Long = Permanent angezeigte Benachrichtigung, welche dich über die Hintergrundaktivität des Dienstes informiert.
+Notify_Error_StackTrace_Toast = Stacktraces in Zwischenablage kopiert.
+Notify_Error_CopyAction = Kopiere Stacktraces in Zwischenablage
+Notify_Error_Retrying = Fehler, wiederhole…

--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -1072,3 +1072,20 @@ in all cities with a world wonder =
 in all cities connected to capital = 
 in all cities with a garrison = 
 
+################### From XML ###################
+Notify_YourTurn_Short = 
+Notify_YourTurn_Long = 
+Notify_Error_Short = 
+Notify_Error_Long = 
+Notify_Persist_Short = 
+Notify_Persist_Long_P1 = 
+Notify_Persist_Long_P2 = 
+Notify_Persist_Long_P3 = 
+Notify_Persist_Long_P4 = 
+Notify_ChannelInfo_Short = 
+Notify_ChannelInfo_Long = 
+Notify_ChannelService_Short = 
+Notify_ChannelService_Long = 
+Notify_Error_StackTrace_Toast = 
+Notify_Error_CopyAction = 
+Notify_Error_Retrying = 


### PR DESCRIPTION
I just stumbled upon android/res/values/strings.xml and noticed a certain lack of translations - or the reverse.
- Option 1: Ignore
- Option 2: Delete german and french translations to restore all-humans-are-created-equal
- Option 3: Delegate to our 'normal' translators.

For Option 3, this would be one way. Wait for the `# requires translation` to propagate and the diligent worker bees to provide. Harvest by manual copy and paste. Keys used so format conversion could be done with a simple notepad regex replace.