### PR TITLE
Sort Civilopedia entries using locale

### DIFF
--- a/core/src/com/unciv/ui/civilopedia/CivilopediaScreen.kt
+++ b/core/src/com/unciv/ui/civilopedia/CivilopediaScreen.kt
@@ -10,6 +10,7 @@ import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.stats.INamed
 import com.unciv.models.translations.tr
 import com.unciv.ui.utils.*
+import java.text.Collator
 import com.unciv.ui.utils.AutoScrollPane as ScrollPane
 
 /** Screen displaying the Civilopedia
@@ -96,7 +97,9 @@ class CivilopediaScreen(
         if (category !in categoryToEntries) return        // defense, allowing buggy panes to remain empty while others work
         var entries = categoryToEntries[category]!!
         if (category != CivilopediaCategories.Difficulty) // this is the only case where we need them in order
-            entries = entries.sortedBy { it.name.tr() }   // Alphabetical order of localized names
+            // Alphabetical order of localized names, using system default locale
+            entries = entries.sortedWith(compareBy(Collator.getInstance(), { it.name.tr() }))
+
         var currentY = -1f
 
         for (entry in entries) {


### PR DESCRIPTION
Before: Sort goes by 'natural order' (from kotlin doc), which can be read as 'binary collation'. After: uses system default locale. Tests for german show Umlauts are now properly sorted with their nearest vowel, not at the end of the lists. Should resolve #4353.

Note: It may be better to use a locale matching the user-selected language, but we'd need a locale code mapping first.