### PR TITLE
Fix autocracy bonus accidentally being disabled

### DIFF
--- a/core/src/com/unciv/logic/battle/BattleDamage.kt
+++ b/core/src/com/unciv/logic/battle/BattleDamage.kt
@@ -137,7 +137,7 @@ object BattleDamage {
                 }
             }
 
-            for (unique in attacker.getCivInfo().getMatchingUniques("[]% attack strength to all [] units for [] turns")) {
+            for (unique in attacker.getCivInfo().getMatchingUniques("+[]% attack strength to all [] units for [] turns")) {
                 if (attacker.matchesCategory(unique.params[1])) {
                     modifiers.add("Temporary Bonus", unique.params[0].toInt())
                 }


### PR DESCRIPTION
So in commit 1070584180738a9a77e91a4bc55add592fbf3ece a lot of old uniques were deprecated. 
One of them was the old autocracy finisher. 
The new one that replaced it, however, had its + sign removed in some cases but not in others.
Namely, in `BattleDamage.kt` the + sign was removed, while in all other contexts it remained with a + sign.
This PR rectifies this oversight by readding the + sing in `BattleDamage.kt`.

I have chosen for readding the + sign instead of removing it in other spots, as the [Uniques wiki page](https://github.com/yairm210/Unciv/wiki/Uniques) and the Discord announcement posted by Yairm both still included the + sign for this unique. 
Removing the + sign would needlessly confuse modders that were given this information.