### PR TITLE
Added more translations

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -572,6 +572,7 @@ Happiness =
 Production = 
 Culture = 
 Food = 
+Faith = 
 
 Crop Yield = 
 Territory = 
@@ -771,6 +772,7 @@ Known and alive ([numberOfCivs]) =
 Known and defeated ([numberOfCivs]) = 
 Tiles = 
 Natural Wonders = 
+Natural Wonder = 
 Treasury deficit = 
 
 # Victory
@@ -937,6 +939,59 @@ All policies adopted =
 Choose an Icon and name for your Religion = 
 Choose a [$beliefType] belief! = 
 Found [religionName] = 
+Choose a pantheon = 
+Found Religion = 
+Found Pantheon = 
+Follow [belief] = 
+Pantheon = 
+Follower = 
+
+Buddhism = 
+Christianity = 
+Hinduism = 
+Islam = 
+Taoism = 
+
+# Beliefs
+
+Ancestor Worship = 
+Dance of the Aurora = 
+Desert Folklore = 
+Faith Healers = 
+[unitType] Units adjacent to this city heal [amount] HP per turn when healing = 
+Fertility Rates = 
+God of Craftsman = 
+[stats] in cities with [amount] or more population = 
+God of the Open Sky = 
+God of the Sea = 
+God of War = 
+Earn [amount]% of [unitType] unit's [param] as [stats] when killed within 4 tiles of a city following this religion = 
+Goddess of Festivals = 
+Goddess of Love = 
+[stats] in cities with [amount] or more population = 
+Goddess of Protection = 
+[amount]% attacking Strength for cities = 
+Goddess of the Hunt = 
+Messenger of the Gods = 
+Monument to the Gods = 
+One with Nature = 
+Oral Tradition = 
+Religious Idols = 
+Religious Settlements = 
+[amount]% cost of natural border growth = 
+Sacred Path = 
+Sacred Waters = 
+[stats] in cities on [feature] tiles = 
+Stone Circles = 
+
+Divine inspiration = 
+Feed the World = 
+Guruship = 
+[stats] if this city has at least [amount] specialists = 
+Peace Gardens = 
+Religious Art = 
+Swords into Ploughshares = 
+[amount]% growth [cityFilter] when not at war = 
 
 # Terrains
 
@@ -1065,6 +1120,7 @@ The mod you selected is incompatible with the defined ruleset! =
 # Uniques that are relevant to more than one type of game object
 
 [stats] from every [param] = 
+[stats] from [tileFilter] tiles without [feature] [cityFilter] = 
 [stats] from [param] tiles in this city = 
 [stats] from every [param] on [tileFilter] tiles = 
 [stats] for each adjacent [param] = 
@@ -1088,3 +1144,14 @@ in all cities with a world wonder =
 in all cities connected to capital = 
 in all cities with a garrison = 
 
+# Promotions
+
+Heal this unit by [amount] HP = 
+Doing so will consume this opportunity to choose a Promotion = 
+Eliminates combat penalty for attacking over a river = 
+Eliminates combat penalty for attacking from the sea = 
+[amount] HP when healing = 
+All adjacent units heal [amount] HP when healing = 
+Earn [amount]% of the damage done to [unitType] units as [stat] = 
+May heal outside of friendly territory = 
+[amount] HP when healing in [tileFilter] tiles = 


### PR DESCRIPTION
Not gonna add civilopedia texts yet, but here's what is already added:
* Promotions' effects
* Currently implemented Pantheon and Follower beliefs
* Religion-related actions' text
* Religions names (Would be nice if those were customisable as in civ5)
* Natural Wonder separately since One with Nature has it so as the unique