### PR TITLE
Update translationFileWriter to include missing strings

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -562,12 +562,13 @@ No =
 Acquire = 
 Under construction = 
 
-Gold = 
-Science = 
-Happiness = 
-Production = 
-Culture = 
 Food = 
+Production = 
+Gold = 
+Happiness = 
+Culture = 
+Science = 
+Faith = 
 
 Crop Yield = 
 Territory = 
@@ -734,6 +735,7 @@ Luxury resource =
 Strategic resource = 
 Fresh water = 
 non-fresh water = 
+Natural Wonder = 
 
 # improvementFilters
 
@@ -933,6 +935,10 @@ All policies adopted =
 Choose an Icon and name for your Religion = 
 Choose a [$beliefType] belief! = 
 Found [religionName] = 
+Choose a pantheon = 
+Found Religion = 
+Found Pantheon = 
+Follow [belief] = 
 
 # Terrains
 

--- a/core/src/com/unciv/models/ruleset/unit/Promotion.kt
+++ b/core/src/com/unciv/models/ruleset/unit/Promotion.kt
@@ -11,7 +11,7 @@ class Promotion : INamed{
     var effect = ""
     var unitTypes = listOf<String>() // The json parser wouldn't agree to deserialize this as a list of UnitTypes. =(
 
-    var uniques = listOf<String>()
+    var uniques = ArrayList<String>()
     val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it) } + Unique(effect)  }
 
     fun getDescription(promotionsForUnitType: Collection<Promotion>, forCivilopedia:Boolean=false, ruleSet:Ruleset? = null):String {

--- a/core/src/com/unciv/models/translations/TranslationFileWriter.kt
+++ b/core/src/com/unciv/models/translations/TranslationFileWriter.kt
@@ -280,6 +280,10 @@ object TranslationFileWriter {
             }
 
             fun serializeElement(element: Any) {
+                if (element is String) {
+                    submitString(element)
+                    return
+                }
                 val allFields = (element.javaClass.declaredFields + element.javaClass.fields
                         + element.javaClass.superclass.declaredFields) // This is so the main PolicyBranch, which inherits from Policy, will recognize its Uniques and have them translated
                         .filter {
@@ -333,11 +337,14 @@ object TranslationFileWriter {
 
     private fun getJavaClassByName(name: String): Class<Any> {
         return when (name) {
+            "Beliefs" -> emptyArray<Belief>().javaClass
             "Buildings" -> emptyArray<Building>().javaClass
             "Difficulties" -> emptyArray<Difficulty>().javaClass
+            "Eras" -> emptyArray<Era>().javaClass
             "Nations" -> emptyArray<Nation>().javaClass
             "Policies" -> emptyArray<PolicyBranch>().javaClass
             "Quests" -> emptyArray<Quest>().javaClass
+            "Religions" -> emptyArray<String>().javaClass
             "Specialists" -> emptyArray<Specialist>().javaClass
             "Techs" -> emptyArray<TechColumn>().javaClass
             "Terrains" -> emptyArray<Terrain>().javaClass

--- a/core/src/com/unciv/models/translations/TranslationFileWriter.kt
+++ b/core/src/com/unciv/models/translations/TranslationFileWriter.kt
@@ -222,6 +222,7 @@ object TranslationFileWriter {
                                     || parameter == "non-fresh water"
                                     || parameter == "Open Terrain"
                                     || parameter == "Rough Terrain"
+                                    || parameter == "Natural Wonder"
                             -> "tileFilter"
                             RulesetCache.getBaseRuleset().units.containsKey(parameter) -> "unit"
                             RulesetCache.getBaseRuleset().tileImprovements.containsKey(parameter)


### PR DESCRIPTION
Recently, multiple new JSON files with data were added. 
However, the translationFileWriter was never told what data classes these files contained, and subsequently never added the data from these files to the translation files.
This PR fixes this.

Another problem was that the translationFileWriter didn't read the value of the `uniques` variable of unit promotions, as it was a `List` instead of an `ArrayList`.
Due to this, promotions with multiple uniques would not get their uniques translated.
This PR also fixes this.

It also adds the few missing translatable strings that were noted in #4575.

Replaces #4575.