### PR TITLE
Fixed units not being removed from open borders area after declaring war

### DIFF
--- a/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
@@ -505,8 +505,6 @@ class DiplomacyManager() {
 
     /** Everything that happens to both sides equally when war is delcared by one side on the other */
     private fun onWarDeclared() {
-        diplomaticStatus = DiplomaticStatus.War
-
         // Cancel all trades.
         for (trade in trades)
             for (offer in trade.theirOffers.filter { it.duration > 0 })
@@ -514,6 +512,8 @@ class DiplomacyManager() {
         trades.clear()
         updateHasOpenBorders()
 
+        diplomaticStatus = DiplomaticStatus.War
+        
         removeModifier(DiplomaticModifiers.YearsOfPeace)
         setFlag(DiplomacyFlags.DeclinedPeace, 10)/// AI won't propose peace for 10 turns
         setFlag(DiplomacyFlags.DeclaredWar, 10) // AI won't agree to trade for 10 turns
@@ -526,7 +526,7 @@ class DiplomacyManager() {
 
         onWarDeclared()
         otherCivDiplomacy.onWarDeclared()
-
+        
         otherCiv.addNotification("[${civInfo.civName}] has declared war on us!", NotificationIcon.War, civInfo.civName)
         otherCiv.popupAlerts.add(PopupAlert(AlertType.WarDeclaration, civInfo.civName))
 
@@ -582,8 +582,7 @@ class DiplomacyManager() {
             }
         }
 
-        if (otherCiv.isCityState())
-        {
+        if (otherCiv.isCityState()) {
             for (thirdCiv in otherCiv.getProtectorCivs()) {
                 if (thirdCiv.knows(civInfo)
                     && thirdCiv.getDiplomacyManager(civInfo).canDeclareWar()) {


### PR DESCRIPTION
Previously, when declaring war on a civilization with whom you had an open borders agreement and had troops in their territory, the troops would be moved to seemingly random tiles.
This PR fixes this, and correctly moves them outside the borders of the attacked nation, conform the base game.