### PR TITLE
Spruced up Civilopedia - phase 6 - uniques

### DIFF
--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -103,14 +103,8 @@ class BaseUnit : INamed, IConstruction, CivilopediaText() {
             textList += FormattedLine(replacementTextForUniques)
         } else if (uniques.isNotEmpty()) {
             textList += FormattedLine()
-            for (uniqueObject in uniqueObjects.sortedBy { it.text }) {
-                if (uniqueObject.placeholderText == "Can construct []") {
-                    val improvement = uniqueObject.params[0]
-                    textList += FormattedLine(uniqueObject.text, link="Improvement/$improvement")
-                } else {
-                    textList += FormattedLine(uniqueObject.text)
-                }
-            }
+            for (uniqueObject in uniqueObjects.sortedBy { it.text })
+                textList += FormattedLine(uniqueObject)
         }
 
         val resourceRequirements = getResourceRequirements()

--- a/core/src/com/unciv/ui/civilopedia/CivilopediaText.kt
+++ b/core/src/com/unciv/ui/civilopedia/CivilopediaText.kt
@@ -5,7 +5,9 @@ import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.scenes.scene2d.Actor
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.utils.Align
+import com.unciv.UncivGame
 import com.unciv.models.ruleset.Ruleset
+import com.unciv.models.ruleset.Unique
 import com.unciv.models.stats.INamed
 import com.unciv.ui.utils.*
 import kotlin.math.max
@@ -65,6 +67,9 @@ class FormattedLine (
     // Note: This gets directly deserialized by Json - please keep all attributes meant to be read
     // from json in the primary constructor parameters above. Everything else should be a fun(),
     // have no backing field, be `by lazy` or use @Transient, Thank you.
+
+    /** Looks for linkable ruleset objects in [Unique] parameters and returns a linked [FormattedLine] if successful, a plain one otherwise */
+    constructor(unique: Unique) : this(unique.text, getUniqueLink(unique))
 
     /** Link types that can be used for [FormattedLine.link] */
     enum class LinkType {
@@ -133,6 +138,43 @@ class FormattedLine (
         const val iconPad = 5f
         /** Padding distance per [indent] level */
         const val indentPad = 30f
+
+        // Helper for constructor(Unique)
+        private fun getUniqueLink(unique: Unique): String {
+            for (parameter in unique.params) {
+                val category = allObjectNamesCategoryMap[parameter] ?: continue
+                return category.name + "/" + parameter
+            }
+            return ""
+        }
+        // Cache to quickly match Categories to names. Takes a few ms to build on a slower desktop and will use just a few 10k bytes.
+        private val allObjectNamesCategoryMap: HashMap<String, CivilopediaCategories> by lazy {
+            //val startTime = System.nanoTime()
+            val ruleSet = UncivGame.Current.gameInfo.ruleSet
+            // order these with the categories that should take precedence in case of name conflicts (e.g. Railroad) _last_
+            val allObjectMapsSequence = sequence {
+                yield(CivilopediaCategories.Difficulty to ruleSet.difficulties)
+                yield(CivilopediaCategories.Promotion to ruleSet.unitPromotions)
+                yield(CivilopediaCategories.Policy to ruleSet.policies)
+                yield(CivilopediaCategories.Terrain to ruleSet.terrains)
+                yield(CivilopediaCategories.Improvement to ruleSet.tileImprovements)
+                yield(CivilopediaCategories.Resource to ruleSet.tileResources)
+                yield(CivilopediaCategories.Nation to ruleSet.nations)
+                yield(CivilopediaCategories.Unit to ruleSet.units)
+                yield(CivilopediaCategories.Technology to ruleSet.technologies)
+                yield(CivilopediaCategories.Building to ruleSet.buildings.filter { !it.value.isAnyWonder() })
+                yield(CivilopediaCategories.Wonder to ruleSet.buildings.filter { it.value.isAnyWonder() })
+            }
+            val result = HashMap<String,CivilopediaCategories>()
+            allObjectMapsSequence.filter { !it.first.hide }
+                .flatMap { pair -> pair.second.keys.asSequence().map { key -> pair.first to key } }
+                .forEach { 
+                    result[it.second] = it.first
+                    //println("  ${it.second} is a ${it.first}")
+                }
+            //println("allObjectNamesCategoryMap took ${System.nanoTime()-startTime}ns to initialize")
+            result
+        }
     }
 
     /** Extension: determines if a [String] looks like a link understood by the OS */


### PR DESCRIPTION
#### Feature:
![image](https://user-images.githubusercontent.com/63000004/126401646-7effa186-8e0f-484a-a4a4-f63b201cfc1e.png)
![image](https://user-images.githubusercontent.com/63000004/126401817-00545303-38a4-4267-b7e9-3d921df4ae72.png)

#### Notes:
- Recognizes any Civilopedia entry name in any unique ***parameter***
- ..If equal to the entire parameter, case-sensitive, meaning Lists are not matched, thus for e.g. Stone Works the _merged_ unique will not link
- Ambiguous names are prioritized
- Maybe I should have made the Civilopedia category per class part of that interface, idea came too late.
- I relented -again- for a few of the Studio inspections... Not the actual loud compiler warnings, though -> separate project