### PR TITLE
City states adjustments

### DIFF
--- a/core/src/com/unciv/logic/GameStarter.kt
+++ b/core/src/com/unciv/logic/GameStarter.kt
@@ -290,11 +290,11 @@ object GameStarter {
 
             
             if (civ.isCityState()) {
+                // City states should spawn with one settler only irregardless of era and difficulty
                 val startingSettlers = startingUnits.filter { settlerLikeUnits.contains(it) }
-                if (startingSettlers.count() > 1) {
-                    startingUnits = startingUnits.filter { !settlerLikeUnits.contains(it) }.toMutableList()
-                    startingUnits.add(startingSettlers.random())
-                }
+
+                startingUnits.clear()
+                startingUnits.add( startingSettlers.random() )
             }
 
             for (unit in startingUnits) {

--- a/core/src/com/unciv/logic/automation/SpecificUnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/SpecificUnitAutomation.kt
@@ -154,7 +154,8 @@ object SpecificUnitAutomation {
             }
         }
 
-        if (unit.getTile().militaryUnit == null) return // Don't move until you're accompanied by a military unit
+        if (unit.getTile().militaryUnit == null     // Don't move until you're accompanied by a military unit
+            && !unit.civInfo.isCityState()) return  // ..unless you're a city state that was unable to settle its city on turn 1
 
         val tilesNearCities = unit.civInfo.gameInfo.getCities().asSequence()
                 .flatMap {

--- a/core/src/com/unciv/logic/automation/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/UnitAutomation.kt
@@ -19,6 +19,7 @@ object UnitAutomation {
                 && (tile.getOwner() == null || !tile.getOwner()!!.isCityState())
                 && tile.neighbors.any { it.position !in unit.civInfo.exploredTiles }
                 && unit.movement.canReach(tile)
+                && (!unit.civInfo.isCityState() || tile.neighbors.any { it.getOwner() == unit.civInfo }) // Don't want city-states exploring far outside their borders
     }
 
     internal fun tryExplore(unit: MapUnit): Boolean {

--- a/core/src/com/unciv/logic/city/CityExpansionManager.kt
+++ b/core/src/com/unciv/logic/city/CityExpansionManager.kt
@@ -8,6 +8,7 @@ import com.unciv.logic.map.TileInfo
 import com.unciv.ui.utils.withItem
 import com.unciv.ui.utils.withoutItem
 import kotlin.math.max
+import kotlin.math.min
 import kotlin.math.pow
 import kotlin.math.roundToInt
 
@@ -160,7 +161,7 @@ class CityExpansionManager {
     }
 
     fun nextTurn(culture: Float) {
-        cultureStored += culture.toInt()
+        cultureStored += if (cityInfo.civInfo.isCityState()) max(1, culture.toInt() / 4) else culture.toInt()   // City states expand slower
         if (cultureStored >= getCultureToNextTile()) {
             val location = addNewTileWithCulture()
             if (location != null) {

--- a/core/src/com/unciv/logic/city/CityExpansionManager.kt
+++ b/core/src/com/unciv/logic/city/CityExpansionManager.kt
@@ -36,6 +36,10 @@ class CityExpansionManager {
     // The second seems to be more based, so I'll go with that
     fun getCultureToNextTile(): Int {
         var cultureToNextTile = 6 * (max(0, tilesClaimed()) + 1.4813).pow(1.3)
+
+        if (cityInfo.civInfo.isCityState())
+            cultureToNextTile *= 1.5f   // City states grow slower, perhaps 150% cost?
+
         for (unique in cityInfo.civInfo.getMatchingUniques("-[]% Culture cost of acquiring tiles []")) {
             if (cityInfo.matchesFilter(unique.params[1]))
                 cultureToNextTile *= (100 - unique.params[0].toFloat()) / 100
@@ -161,7 +165,7 @@ class CityExpansionManager {
     }
 
     fun nextTurn(culture: Float) {
-        cultureStored += if (cityInfo.civInfo.isCityState()) max(1, culture.toInt() / 4) else culture.toInt()   // City states expand slower
+        cultureStored += culture.toInt()
         if (cultureStored >= getCultureToNextTile()) {
             val location = addNewTileWithCulture()
             if (location != null) {

--- a/core/src/com/unciv/logic/city/PopulationManager.kt
+++ b/core/src/com/unciv/logic/city/PopulationManager.kt
@@ -42,6 +42,8 @@ class PopulationManager {
     fun getFoodToNextPopulation(): Int {
         // civ v math, civilization.wikia
         var foodRequired = 15 + 6 * (population - 1) + floor((population - 1).toDouble().pow(1.8))
+        if (cityInfo.civInfo.isCityState())
+            foodRequired *= 1.5f
         if (!cityInfo.civInfo.isPlayerCivilization())
             foodRequired *= cityInfo.civInfo.gameInfo.getDifficulty().aiCityGrowthModifier
         return foodRequired.toInt()

--- a/core/src/com/unciv/models/metadata/GameParameters.kt
+++ b/core/src/com/unciv/models/metadata/GameParameters.kt
@@ -15,7 +15,7 @@ class GameParameters { // Default values are the default new game
         add(Player().apply { playerType = PlayerType.Human })
         for (i in 1..3) add(Player())
     }
-    var numberOfCityStates = 8 // Civ V's default
+    var numberOfCityStates = 6
 
     var noBarbarians = false
     var oneCityChallenge = false

--- a/core/src/com/unciv/models/metadata/GameParameters.kt
+++ b/core/src/com/unciv/models/metadata/GameParameters.kt
@@ -15,7 +15,7 @@ class GameParameters { // Default values are the default new game
         add(Player().apply { playerType = PlayerType.Human })
         for (i in 1..3) add(Player())
     }
-    var numberOfCityStates = 2
+    var numberOfCityStates = 8 // Civ V's default
 
     var noBarbarians = false
     var oneCityChallenge = false

--- a/core/src/com/unciv/models/ruleset/Building.kt
+++ b/core/src/com/unciv/models/ruleset/Building.kt
@@ -338,6 +338,8 @@ class Building : NamedStats(), IConstruction, ICivilopediaText {
         for (unique in uniqueObjects.filter { it.placeholderText == "Cost increases by [] per owned city" })
             productionCost += civInfo.cities.count() * unique.params[0].toInt()
 
+        if (civInfo.isCityState())
+            productionCost *= 1.5f
         if (civInfo.isPlayerCivilization()) {
             if (!isWonder)
                 productionCost *= civInfo.getDifficulty().buildingCostModifier

--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -172,6 +172,8 @@ class BaseUnit : INamed, IConstruction, CivilopediaText() {
 
     override fun getProductionCost(civInfo: CivilizationInfo): Int {
         var productionCost = cost.toFloat()
+        if (civInfo.isCityState())
+            productionCost *= 1.5f
         if (civInfo.isPlayerCivilization())
             productionCost *= civInfo.getDifficulty().unitCostModifier
         else


### PR DESCRIPTION
Adds extra checks for city states to make them behave more like Civ V
- City states spawn only with one settler regardless of difficulty and era
- City states will not explore more than one hex outside their territory. They will still go after barbarians and enemy civs.
- EDIT: Added factors for slower production, pop growth, and border expansion for city states.
- Default number of city states in a new game is now 8 (the Civ V default; they are now less annoying than before)