### PR TITLE
Fixed comodification errors under certain circumstances

### DIFF
--- a/core/src/com/unciv/logic/trade/TradeLogic.kt
+++ b/core/src/com/unciv/logic/trade/TradeLogic.kt
@@ -89,8 +89,8 @@ class TradeLogic(val ourCivilization:CivilizationInfo, val otherCivilization: Ci
                     val city = from.cities.first { it.id == offer.name }
                     city.moveToCiv(to)
                     city.getCenterTile().getUnits().forEach { it.movement.teleportToClosestMoveableTile() }
-                    city.getTiles().forEach{ tile ->
-                        tile.getUnits().forEach{ unit ->
+                    for (tile in city.getTiles()) {
+                        for (unit in tile.getUnits().toList()) {
                             if (!unit.civInfo.canEnterTiles(to)) {
                                 unit.movement.teleportToClosestMoveableTile()
                             }


### PR DESCRIPTION
Under very peculiar circumstances, trading a city with multiple units in it could lead to a comodification crash.
This PR fixes this.