### PR TITLE
Fix canImprovementBeBuiltHere regression

### DIFF
--- a/core/src/com/unciv/logic/map/TileInfo.kt
+++ b/core/src/com/unciv/logic/map/TileInfo.kt
@@ -430,9 +430,12 @@ open class TileInfo {
             // deprecated as of 3.15.15
                 "Can only be built on Coastal tiles" in improvement.uniques && isCoastalTile() -> true
             //
-            improvement.uniqueObjects.filter { it.placeholderText == "Can only be built on [] tiles" }.all {
-                unique -> matchesTerrainFilter(unique.params[0])
+
+            // If an unique of this type exists, we want all to match (e.g. Hill _and_ Forest would be meaningful).
+            improvement.uniqueObjects.filter { it.placeholderText == "Can only be built on [] tiles" }.let {
+                it.any() && it.all { unique -> matchesTerrainFilter(unique.params[0]) }
             } -> true
+
             else -> resourceIsVisible && getTileResource().improvement == improvement.name
         }
     }

--- a/tests/src/com/unciv/logic/map/TileImprovementConstructionTests.kt
+++ b/tests/src/com/unciv/logic/map/TileImprovementConstructionTests.kt
@@ -90,11 +90,43 @@ class TileImprovementConstructionTests {
     }
 
     @Test
+    fun coastalImprovementsCanNOTBeBuiltInland() {
+        tile.baseTerrain = "Plains"
+        tile.setTransients()
+
+        for (improvement in ruleSet.tileImprovements.values) {
+            if (!improvement.uniques.contains("Can only be built on [Coastal] tiles")) continue
+            civInfo.civName = improvement.uniqueTo ?: "OtherCiv"
+            val canBeBuilt = tile.canBuildImprovement(improvement, civInfo)
+            Assert.assertFalse(improvement.name, canBeBuilt)
+        }
+    }
+
+    @Test
     fun uniqueToOtherImprovementsCanNOTBeBuilt() {
         for (improvement in ruleSet.tileImprovements.values) {
             if (improvement.uniqueTo == null) continue
             civInfo.civName = "OtherCiv"
             tile.baseTerrain = "Plains"
+            tile.setTransients()
+            val canBeBuilt = tile.canBuildImprovement(improvement, civInfo)
+            Assert.assertFalse(improvement.name, canBeBuilt)
+        }
+    }
+
+    @Test
+    fun improvementsCanNOTBeBuiltOnWrongResource() {
+        tile.baseTerrain = "Plains"
+        civInfo.civName = "OtherCiv"
+
+        for (resource in ruleSet.tileResources.values) {
+            if (resource.improvement == null) continue
+            val improvement = ruleSet.tileImprovements[resource.improvement]!!
+            if (improvement.terrainsCanBeBuiltOn.isNotEmpty()) continue
+            val wrongResource = ruleSet.tileResources.values.firstOrNull { 
+                it != resource && it.improvement != improvement.name 
+            } ?: continue
+            tile.resource = wrongResource.name
             tile.setTransients()
             val canBeBuilt = tile.canBuildImprovement(improvement, civInfo)
             Assert.assertFalse(improvement.name, canBeBuilt)


### PR DESCRIPTION
I'm so ashamed of #4581 - this fixes the ImprovementPicker offering far too many options, and adds unit tests which would have caught the blunder.