### PR TITLE
Fix: Unit name translation (instance name, religion)

### DIFF
--- a/android/assets/jsons/translations/German.properties
+++ b/android/assets/jsons/translations/German.properties
@@ -3336,20 +3336,11 @@ Send your best explorers on a quest to discover Natural Wonders. Nobody knows th
 
 #################### Lines from Religions from Civ V - Vanilla ####################
 
- # Requires translation!
-Buddhism = 
-
- # Requires translation!
-Christianity = 
-
- # Requires translation!
-Hinduism = 
-
- # Requires translation!
-Islam = 
-
- # Requires translation!
-Taoism = 
+Buddhism = Buddhismus
+Christianity = Christentum
+Hinduism = Hinduismus
+Islam = Islam
+Taoism = Taoismus
 
 
 #################### Lines from Specialists from Civ V - Vanilla ####################

--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -14,7 +14,6 @@ import com.unciv.models.ruleset.tile.TileImprovement
 import com.unciv.models.ruleset.unit.BaseUnit
 import com.unciv.models.ruleset.unit.UnitType
 import java.text.DecimalFormat
-import kotlin.math.pow
 import kotlin.random.Random
 
 /**
@@ -90,11 +89,14 @@ class MapUnit {
 
     /**
      * Name which should be displayed in UI
+     * 
+     * Note this is translated after being returned from this function, so let's pay
+     * attention to combined names (renamed units, religion).
      */
     fun displayName(): String {
         val name = if (instanceName == null) name
-                   else "$instanceName (${name})"
-        return if (religion != null && maxReligionSpreads() > 0) "$name ($religion)"
+                   else "$instanceName ({${name}})"
+        return if (religion != null && maxReligionSpreads() > 0) "[$name] ([$religion])"
                else name
     }
 

--- a/core/src/com/unciv/ui/worldscreen/unit/IdleUnitButton.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/IdleUnitButton.kt
@@ -18,8 +18,6 @@ class IdleUnitButton (
 
     val image = ImageGetter.getImage("OtherIcons/BackArrow")
 
-    fun hasIdleUnits() = unitTable.worldScreen.viewingCiv.getIdleUnits().any()
-
     init {
         val imageSize = 25f
         if(!previous) {

--- a/core/src/com/unciv/ui/worldscreen/unit/UnitTable.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitTable.kt
@@ -91,7 +91,7 @@ class UnitTable(val worldScreen: WorldScreen) : Table(){
                 val position = selectedUnit?.currentTile?.position
                     ?: selectedCity?.location
                 if (position != null)
-                    worldScreen.mapHolder.setCenterPosition(position, false, false)
+                    worldScreen.mapHolder.setCenterPosition(position, immediately = false, selectUnit = false)
             }
         }).expand()
 
@@ -109,7 +109,7 @@ class UnitTable(val worldScreen: WorldScreen) : Table(){
             }
         }
 
-        if (prevIdleUnitButton.hasIdleUnits()) { // more efficient to do this check once for both
+        if (worldScreen.viewingCiv.getIdleUnits().any()) { // more efficient to do this check once for both
             prevIdleUnitButton.enable()
             nextIdleUnitButton.enable()
         } else {


### PR DESCRIPTION
Units with an instance name and/or a religion pass a composite from `getDisplayName()` to `tr()` that doesn't provide for component translation.
<details><summary>Now they do...</summary>

![image](https://user-images.githubusercontent.com/63000004/126902821-01b6d36d-6fc7-484b-89d5-d71525d0dea9.png)
</details>

Folding away the `hasIdleUnits()` function is a leftover - single use class-level function with no relation to its `this`? (The original push was the code duplication in enable()/disable() - but our Extensions target Button, and actually making `IdleUnitButton` into a `Button` isn't pretty. Yes `Button extends Table` so generalizing our Extension receivers should work but I didn't want to test _that_ thoroughly.)