### PR TITLE
Map climate overhaul

### DIFF
--- a/android/assets/jsons/Civ V - Vanilla/Terrains.json
+++ b/android/assets/jsons/Civ V - Vanilla/Terrains.json
@@ -21,7 +21,14 @@
 		"food": 2,
 		"movementCost": 1,
 		"RGB": [97,171,58],
-		"uniques": ["Occurs at temperature between [-0.4] and [0.8] and humidity between [0.5] and [1]"]
+		"uniques": ["Occurs at temperature between [-0.3] and [0] and humidity between [0.5] and [0.6]",
+			    "Occurs at temperature between [-0.4] and [0.3] and humidity between [0.6] and [0.7]",
+			    "Occurs at temperature between [-0.4] and [0.4] and humidity between [0.7] and [0.8]",
+			    "Occurs at temperature between [-0.5] and [1] and humidity between [0.8] and [1]",
+			    "Occurs at temperature between [-0.2] and [-0.1] and humidity between [0.5] and [0.6]",
+			    "Occurs at temperature between [0.9] and [1] and humidity between [0.2] and [0.8]",
+			    "Occurs at temperature between [0.8] and [0.9] and humidity between [0.5] and [0.8]",
+			    "Occurs at temperature between [0.7] and [0.8] and humidity between [0.7] and [0.8]"]
 	},
 	{
 		"name": "Plains",
@@ -30,8 +37,21 @@
 		"production": 1,
 		"movementCost": 1,
 		"RGB": [168,185,102],
-		"uniques": ["Occurs at temperature between [-0.4] and [0.8] and humidity between [0] and [0.5]",
-			"Occurs at temperature between [0.8] and [1] and humidity between [0.7] and [1]"]
+		"uniques": ["Occurs at temperature between [-0.6] and [-0.5] and humidity between [0.8] and [1]",
+			    "Occurs at temperature between [-0.5] and [-0.4] and humidity between [0.6] and [0.8]",
+			    "Occurs at temperature between [-0.4] and [-0.3] and humidity between [0.4] and [0.6]",
+			    "Occurs at temperature between [-0.3] and [-0.2] and humidity between [0.2] and [0.5]",
+			    "Occurs at temperature between [-0.2] and [-0.1] and humidity between [0] and [0.5]",
+			    "Occurs at temperature between [-0.1] and [0] and humidity between [0.2] and [0.5]",
+			    "Occurs at temperature between [0] and [0.2] and humidity between [0.2] and [0.6]",
+			    "Occurs at temperature between [0.2] and [0.3] and humidity between [0.3] and [0.6]",
+			    "Occurs at temperature between [0.3] and [0.4] and humidity between [0.3] and [0.7]",
+			    "Occurs at temperature between [0.4] and [0.5] and humidity between [0.4] and [0.8]",
+			    "Occurs at temperature between [0.5] and [0.6] and humidity between [0.6] and [0.8]",
+			    "Occurs at temperature between [0.6] and [0.7] and humidity between [0.4] and [0.8]",
+			    "Occurs at temperature between [0.7] and [0.8] and humidity between [0.3] and [0.7]",
+			    "Occurs at temperature between [0.8] and [0.9] and humidity between [0.1] and [0.5]",
+			    "Occurs at temperature between [0.9] and [1] and humidity between [0] and [0.2]",]
 	},
 	{
 		"name": "Tundra",
@@ -39,14 +59,24 @@
 		"food": 1,
 		"movementCost": 1,
 		"RGB": [189,204,191],
-		"uniques": ["Occurs at temperature between [-1] and [-0.4] and humidity between [0.5] and [1]"]
+		"uniques": ["Occurs at temperature between [-0.9] and [-0.8] and humidity between [0.9] and [1]",
+			    "Occurs at temperature between [-0.8] and [-0.7] and humidity between [0.6] and [1]",
+			    "Occurs at temperature between [-0.7] and [-0.6] and humidity between [0.4] and [1]",
+			    "Occurs at temperature between [-0.6] and [-0.5] and humidity between [0.3] and [0.8]",
+			    "Occurs at temperature between [-0.5] and [-0.4] and humidity between [0.1] and [0.6]",
+			    "Occurs at temperature between [-0.4] and [-0.3] and humidity between [0] and [0.4]",
+			    "Occurs at temperature between [-0.3] and [-0.2] and humidity between [0] and [0.2]"]
 	},
 	{
 		"name": "Desert",
 		"type": "Land",
 		"movementCost": 1,
 		"RGB": [ 230, 230, 113],
-		"uniques": ["Occurs at temperature between [0.8] and [1] and humidity between [0] and [0.7]"]
+		"uniques": ["Occurs at temperature between [-0.1] and [0.9] and humidity between [0] and [0.1]",
+			    "Occurs at temperature between [-0.1] and [0.8] and humidity between [0.1] and [0.2]",
+			    "Occurs at temperature between [0.2] and [0.8] and humidity between [0.2] and [0.3]",
+			    "Occurs at temperature between [0.4] and [0.7] and humidity between [0.3] and [0.4]",
+			    "Occurs at temperature between [0.5] and [0.6] and humidity between [0.4] and [0.6]"]
 	},
 	{
 		"name": "Lakes",
@@ -69,7 +99,12 @@
 		"type": "Land",
 		"movementCost": 1,
 		"RGB": [231, 242, 249],
-		"uniques": ["Occurs at temperature between [-1] and [-0.4] and humidity between [0] and [0.5]"]
+		"uniques": ["Occurs at temperature between [-1] and [-0.4] and humidity between [0] and [0.1]",
+			    "Occurs at temperature between [-1] and [-0.5] and humidity between [0.1] and [0.3]",
+			    "Occurs at temperature between [-1] and [-0.6] and humidity between [0.3] and [0.4]",
+			    "Occurs at temperature between [-1] and [-0.7] and humidity between [0.4] and [0.6]",
+			    "Occurs at temperature between [-1] and [-0.8] and humidity between [0.6] and [0.9]",
+			    "Occurs at temperature between [-1] and [-0.9] and humidity between [0.9] and [1]"]
 	},
 
 	// Terrain features


### PR DESCRIPTION
This should make the map look more like a civ5 map:
here is a spreadsheet i've created and used to make these changes: https://drive.google.com/file/d/18uacHvZlh4FoM8xEVH4J9jaAmtHomutr/view?usp=sharing
What it does:
- makes center of a map mostly Grassland with some bits of Plains
- next biome is Desert and Plains with a rare patches of Grasslands.
- next biome is again Grasslands and Plains (in about equal proportions)
- final biome is Tundra that turns into Snow towards poles.
- makes the whole map look less stripy.

It looks kind of messy, but i tried to make it as compact as i could.

![1z](https://user-images.githubusercontent.com/30041793/127394680-53f5cacd-2c48-4903-943c-571fcbdc9fb7.png)

civ5 map (apparently oval map shape is closer to unciv pangaea)
![2x](https://user-images.githubusercontent.com/30041793/127395227-47d3cf59-8d69-4525-895f-82601320a8c8.png)
