### PR TITLE
Better crude maps - zero uncovered tiles impossible

### DIFF
--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -841,21 +841,24 @@ class MapUnit {
         }
 
         // Map of the surrounding area
-        actions.add {
-            val revealCenter = tile.getTilesAtDistance(ANCIENT_RUIN_MAP_REVEAL_OFFSET).toList()
-                .random(tileBasedRandom)
-            val tilesToReveal = revealCenter
-                .getTilesInDistance(ANCIENT_RUIN_MAP_REVEAL_RANGE)
-                .filter { Random.nextFloat() < ANCIENT_RUIN_MAP_REVEAL_CHANCE }
-                .map { it.position }
-            civInfo.exploredTiles.addAll(tilesToReveal)
-            civInfo.updateViewableTiles()
-            civInfo.addNotification(
-                "We have found a crudely-drawn map in the ruins!",
-                tile.position,
-                "ImprovementIcons/Ancient ruins"
-            )
-        }
+        val revealCenter = tile.getTilesAtDistance(ANCIENT_RUIN_MAP_REVEAL_OFFSET)
+            .filter { it.position !in civInfo.exploredTiles }
+            .toList()
+            .randomOrNull(tileBasedRandom)
+        if (revealCenter != null)
+            actions.add {
+                val tilesToReveal = revealCenter
+                    .getTilesInDistance(ANCIENT_RUIN_MAP_REVEAL_RANGE)
+                    .filter { Random.nextFloat() < ANCIENT_RUIN_MAP_REVEAL_CHANCE }
+                    .map { it.position }
+                civInfo.exploredTiles.addAll(tilesToReveal)
+                civInfo.updateViewableTiles()
+                civInfo.addNotification(
+                    "We have found a crudely-drawn map in the ruins!",
+                    tile.position,
+                    "ImprovementIcons/Ancient ruins"
+                )
+            }
 
         (actions.random(tileBasedRandom))()
     }


### PR DESCRIPTION
Small change, improves "crudely drawn map" ancient ruins bonus, partially resolves #4667 - some info over there. 

Basically:
- Old = from a hexagon of fixed radius around the ruin tile, pick any random tile, then pick a filled hexagon of same radius around that tile, and reveal 80% of those tiles. Nowhere do already explored tiles factor in.
- New = From the original hexagon at fixed distance, drop all already explored tiles, then proceed as before.

Not very clever but simple and according to my testing effective. A reward message when actually zero new tiles were uncovered was frequent and is now impossible, getting tile counts below around 8 gets far less likely. Maximum and average are unchanged, variance much lower in my "optimum scenario" tests. Thanks to @ravignir for confirming those statistics are close to original Civ5.