### PR TITLE
Added desktop resolutions

### DIFF
--- a/core/src/com/unciv/ui/worldscreen/mainmenu/OptionsPopup.kt
+++ b/core/src/com/unciv/ui/worldscreen/mainmenu/OptionsPopup.kt
@@ -31,7 +31,7 @@ class OptionsPopup(val previousScreen:CameraStageBaseScreen) : Popup(previousScr
     private var selectedLanguage: String = "English"
     private val settings = previousScreen.game.settings
     private val optionsTable = Table(CameraStageBaseScreen.skin)
-    private val resolutionArray = GdxArray(arrayOf("750x500", "900x600", "1050x700", "1200x800", "1500x1000"))
+    private val resolutionArray = GdxArray(arrayOf("750x500", "900x600", "1050x700", "1200x800", "1280x720", "1366x768", "1440x900", "1500x1000", "1536x864", "1920x1080"))
 
     init {
         settings.addCompletedTutorialTask("Open the options table")


### PR DESCRIPTION
Added 5 most common desktop resolutions according to [statcounter](https://gs.statcounter.com/screen-resolution-stats/desktop/worldwide).

When installing the game on my mac i noticed that it looked a bit weird, after having added the correct resolution (1440x900) to the game it now looks like it should. I decided to add the most common desktop resolutions to the game as there seemed to be no desktop resolutions in the game at the moment.