### PR TITLE
Updated some outdated statements in the feature request issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -9,9 +9,9 @@ assignees: ''
 
 **BEFORE creating (delete this in the actual issue)**
 
-Is your feature a gameplay feature from Civ VI, or from G&K or BNW? If so, don't open it in the first place - see Roadmap
+Is your feature a gameplay feature from Civ VI, or from BNW? If so, don't open it in the first place - see Roadmap
 
-Is your feature a gameplay feature from Vanilla Civ V? If so, it should go in https://github.com/yairm210/Unciv/issues/663 - post a comment there!
+Is your feature a gameplay feature from Vanilla Civ V or from G&K? If so, it should go in https://github.com/yairm210/Unciv/issues/4697 - post a comment there!
 
 Is your feature related to a crash or things that are already implemented but implemented wrong? Please open a Bug Report issue instead!
 


### PR DESCRIPTION
This updates the feature request issue template to reflect the fact that development is currently targeting G&K and to refer to #4697 instead of the deprecated #663.