### PR TITLE
Tweak UncivSlider and the one on NewGameScreen

### DIFF
--- a/core/src/com/unciv/ui/newgamescreen/GameOptionsTable.kt
+++ b/core/src/com/unciv/ui/newgamescreen/GameOptionsTable.kt
@@ -96,9 +96,10 @@ class GameOptionsTable(
         val slider = UncivSlider(0f,numberOfCityStates.toFloat(),1f) {
             gameParameters.numberOfCityStates = it.toInt()
         }
-        slider.value = gameParameters.numberOfCityStates.toFloat()
+        slider.permanentTip = true
         slider.isDisabled = locked
-        add(slider).row()
+        add(slider).padTop(10f).row()
+        slider.value = gameParameters.numberOfCityStates.toFloat()
     }
 
     private fun Table.addSelectBox(text: String, values: Collection<String>, initialState: String, onChange: (newValue: String) -> Unit) {

--- a/core/src/com/unciv/ui/utils/UncivSlider.kt
+++ b/core/src/com/unciv/ui/utils/UncivSlider.kt
@@ -81,7 +81,9 @@ class UncivSlider (
 
     // Value tip format
     var tipFormat = "%.1f"
-    
+
+    var permanentTip = false
+
     // Detect changes in isDragging
     private var hasFocus = false
 
@@ -153,7 +155,8 @@ class UncivSlider (
             tipLabel.setText(getTipText!!(slider.value))
         if (!tipHideTask.isScheduled) showTip()
         tipHideTask.cancel()
-        Timer.schedule(tipHideTask, hideDelay)
+        if (!permanentTip)
+            Timer.schedule(tipHideTask, hideDelay)
 
         val enableMinus = slider.value > slider.minValue
         minusButton?.touchable = if(enableMinus) Touchable.enabled else Touchable.disabled
@@ -210,6 +213,7 @@ class UncivSlider (
     private fun showTip() {
         if (tipContainer.hasParent()) return
         tipContainer.pack()
+        if (needsLayout()) pack()
         val pos = slider.localToParentCoordinates(Vector2(slider.width / 2, slider.height))
         tipContainer.run {
             setOrigin(Align.bottom)


### PR DESCRIPTION
- `pack()` improves position calculation that was off by the "-" button's width in some cases
- Slider for Citystate count on NewGameScreen permanently shows the value tip

I can't find the issue that mentioned that last one, but I'm sure that was mentioned.