### PR TITLE
Unique instead of Building.cannotBeBuiltWith

### DIFF
--- a/android/assets/jsons/Civ V - Vanilla/Buildings.json
+++ b/android/assets/jsons/Civ V - Vanilla/Buildings.json
@@ -1007,9 +1007,8 @@
 		"percentStatBonus": {"production": 15},
 		"requiredBuilding": "Factory",
 		"maintenance": 3,
-		"cannotBeBuiltWith": "Nuclear Plant",
 		"requiredTech": "Ecology",
-		"uniques": ["Must be next to [Desert]"]
+		"uniques": ["Must be next to [Desert]", "Cannot be built with [Nuclear Plant]"]
 	},
 	{
 		"name": "Sydney Opera House",
@@ -1026,9 +1025,9 @@
 		"percentStatBonus": {"production": 15},
 		"requiredBuilding": "Factory",
 		"maintenance": 3,
-		"cannotBeBuiltWith": "Solar Plant",
 		"requiredResource": "Uranium",
-		"requiredTech": "Nuclear Fission"
+		"requiredTech": "Nuclear Fission",
+		"uniques": ["Cannot be built with [Solar Plant]"]
 	},
 	{
 		"name": "Apollo Program",

--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -42,6 +42,7 @@ Wonder is being built elsewhere =
 National Wonder is being built elsewhere = 
 Requires a [buildingName] in all cities = 
 Requires a [buildingName] in this city = 
+Cannot be built with [buildingName] = 
 Consumes 1 [resource] = 
 Consumes [amount] [resource] = 
 Required tech: [requiredTech] = 

--- a/core/src/com/unciv/models/ruleset/Building.kt
+++ b/core/src/com/unciv/models/ruleset/Building.kt
@@ -56,6 +56,7 @@ class Building : NamedStats(), IConstruction, ICivilopediaText {
 
     /** City can only be built if one of these resources is nearby - it must be improved! */
     var requiredNearbyImprovedResources: List<String>? = null
+    @Deprecated("As of 3.15.19, replace with 'Cannot be built with []' unique")
     private var cannotBeBuiltWith: String? = null
     var cityStrength = 0
     var cityHealth = 0
@@ -501,8 +502,13 @@ class Building : NamedStats(), IConstruction, ICivilopediaText {
                 return "Requires a [${requiredBuilding}] in this city, which doesn't seem to exist in this ruleset!"
             return "Requires a [${civInfo.getEquivalentBuilding(requiredBuilding!!)}] in this city"
         }
-        if (cannotBeBuiltWith != null && construction.isBuilt(cannotBeBuiltWith!!))
-            return "Cannot be built with $cannotBeBuiltWith"
+        // cannotBeBuiltWith is Deprecated as of 3.15.19
+        val cannotBeBuiltWith = uniqueObjects
+            .firstOrNull { it.placeholderText == "Cannot be built with []" }
+            ?.params?.get(0)
+            ?: this.cannotBeBuiltWith
+        if (cannotBeBuiltWith != null && construction.isBuilt(cannotBeBuiltWith))
+            return "Cannot be built with [$cannotBeBuiltWith]"
 
         for ((resource, amount) in getResourceRequirements())
             if (civInfo.getCivResourcesByName()[resource]!! < amount) {


### PR DESCRIPTION
Resolves #4690
Deprecate `Building.cannotBeBuiltWith`
Solar/Nuclear Plant exclusion now as unique
Auto-displays in Civilopedia

- Note: String template for rejection reason identical to unique - which it doesn't need to be. We should decide before merging this whether some different wording might be better. Said template included in template.properties as the other rejection reasons are there, too - but the translation writer would pick up the unique anyway. Also, the rejection reason is later used to suppress the construction instead of displaying it as unbuildable, so I don't know whether there is actually any other circumstance where the player could read that rejection reason...