### PR TITLE
Use stat characters in Civilopedia Unit/Building costs

### DIFF
--- a/android/assets/jsons/Civ V - Vanilla/Units.json
+++ b/android/assets/jsons/Civ V - Vanilla/Units.json
@@ -1509,7 +1509,7 @@
 		"name": "Great Prophet",
 		"unitType": "Civilian",
 		"uniques": ["Can construct [Holy site] if it hasn't spread religion yet", "Can spread religion [4] times",
-			"May found a religion", "Great Person - [Faith]", "Unbuildable"],
+			"May found a religion", "Great Person - [Faith]", "Unbuildable", "Hidden when religion is disabled"],
 		"movement": 2
 	},
 	{

--- a/core/src/com/unciv/models/ruleset/Building.kt
+++ b/core/src/com/unciv/models/ruleset/Building.kt
@@ -13,6 +13,7 @@ import com.unciv.models.translations.fillPlaceholders
 import com.unciv.models.translations.tr
 import com.unciv.ui.civilopedia.FormattedLine
 import com.unciv.ui.civilopedia.ICivilopediaText
+import com.unciv.ui.utils.Fonts
 import java.util.*
 import kotlin.collections.ArrayList
 import kotlin.collections.HashMap
@@ -221,8 +222,9 @@ class Building : NamedStats(), IConstruction, ICivilopediaText {
         }
 
         if (cost > 0) {
-            textList += FormattedLine()
-            textList += FormattedLine("{Cost}: $cost")
+            val stats = mutableListOf("$cost${Fonts.production}")
+            if (canBePurchased()) stats += "${(getBaseGoldCost()*0.1).toInt()*10}${Fonts.gold}"
+            textList += FormattedLine(stats.joinToString(", ", "{Cost}: "))
         }
 
         if (requiredTech != null || requiredBuilding != null || requiredBuildingInAllCities != null)
@@ -348,6 +350,8 @@ class Building : NamedStats(), IConstruction, ICivilopediaText {
         productionCost *= civInfo.gameInfo.gameParameters.gameSpeed.modifier
         return productionCost.toInt()
     }
+
+    private fun getBaseGoldCost() = (30.0 * cost).pow(0.75) * (1 + hurryCostModifier / 100.0)
 
     override fun getGoldCost(civInfo: CivilizationInfo): Int {
         // https://forums.civfanatics.com/threads/rush-buying-formula.393892/

--- a/core/src/com/unciv/ui/civilopedia/CivilopediaScreen.kt
+++ b/core/src/com/unciv/ui/civilopedia/CivilopediaScreen.kt
@@ -228,7 +228,9 @@ class CivilopediaScreen(
                     )
                 }
         categoryToEntries[CivilopediaCategories.Unit] = ruleset.units.values
-                .filter { "Will not be displayed in Civilopedia" !in it.uniques }
+                .filter { "Will not be displayed in Civilopedia" !in it.uniques
+                        && !(hideReligionItems && "Hidden when religion is disabled" in it.uniques)
+                }
                 .map {
                     CivilopediaEntry(
                         it.name,


### PR DESCRIPTION
... and hide the Great Prophet if playing without Religion.
![image](https://user-images.githubusercontent.com/63000004/127928678-f6902c3c-49c9-461a-bb4a-7a392020445b.png)
![image](https://user-images.githubusercontent.com/63000004/127928693-afd498a3-3147-4aa3-9491-c98d4766a47d.png)

This displays _base_ cost, for rush buying, too, thus the patch to getBaseGoldCost() which wasn't quite _base_.

Somehow I doubt a little all units should be buyable...