### PR TITLE
Fix: Promotions broken by #4717

### DIFF
--- a/core/src/com/unciv/logic/map/UnitPromotions.kt
+++ b/core/src/com/unciv/logic/map/UnitPromotions.kt
@@ -46,7 +46,7 @@ class UnitPromotions{
 
     fun getAvailablePromotions(): List<Promotion> {
         return unit.civInfo.gameInfo.ruleSet.unitPromotions.values
-                .filter { unit.type.toString() in it.unitTypes && it.name !in promotions }
+                .filter { unit.type.name in it.unitTypes && it.name !in promotions }
                 .filter { it.prerequisites.isEmpty() || it.prerequisites.any { p->p in promotions } }
     }
 

--- a/core/src/com/unciv/ui/pickerscreens/PromotionPickerScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/PromotionPickerScreen.kt
@@ -47,7 +47,7 @@ class PromotionPickerScreen(val unit: MapUnit) : PickerScreen() {
 
         val unitType = unit.type
         val promotionsForUnitType = unit.civInfo.gameInfo.ruleSet.unitPromotions.values.filter {
-            it.unitTypes.contains(unitType.toString())
+            it.unitTypes.contains(unitType.name)
                     || unit.promotions.promotions.contains(it.name) }
         val unitAvailablePromotions = unit.promotions.getAvailablePromotions()
 


### PR DESCRIPTION
UnitType.toString() is no longer what you expect...
 it's "com.unciv.models.ruleset.unit.UnitType:@1BAFF8" or something similar, therefore no unit, no matter how much XP it has, will be able to promote