### PR TITLE
Removed $ signs from translatable strings

### DIFF
--- a/android/assets/jsons/translations/Finnish.properties
+++ b/android/assets/jsons/translations/Finnish.properties
@@ -1036,7 +1036,7 @@ All policies adopted = Kaikki linjaukset valittu
 # Religions
 
 Choose an Icon and name for your Religion = Valitse ikoni ja nimi uskonnollesi
-Choose a [$beliefType] belief! = Valitse [$beliefType] usko
+Choose a [beliefType] belief! = Valitse [beliefType] usko
 Found [religionName] = Perusta [religionName]
 Choose a pantheon = Valitse pantheoni
 Found Religion = Perusta uskonto

--- a/android/assets/jsons/translations/German.properties
+++ b/android/assets/jsons/translations/German.properties
@@ -978,7 +978,7 @@ All policies adopted = Alle Politiken sind bereits verabschiedet
 # Religions
 
 Choose an Icon and name for your Religion = Wähle ein Symbol und einen Namen für deine Religion
-Choose a [$beliefType] belief! = Wähle einen [$beliefType] Glauben!
+Choose a [beliefType] belief! = Wähle einen [beliefType] Glauben!
 Found [religionName] = [religionName] gründen
 Choose a pantheon = Wähle einen Pantheon
 Found Religion = Religion gründen

--- a/android/assets/jsons/translations/Indonesian.properties
+++ b/android/assets/jsons/translations/Indonesian.properties
@@ -811,7 +811,7 @@ Branches completed = Cabang budaya terselesaikan
 Undefeated civs = Peradaban yang belum ditaklukkan
  # The \n here means: put a newline (enter) here. If this is omitted, the sidebox in the diplomacy overview will become _really_ wide.
  # Feel free to replace it with a space and put it somewhere else in your translation
-Turns until the next\ndiplomacy victory vote: [$turnsTillNextDiplomaticVote] = Jumlah giliran sebelum\npemilihan kemenangan diplomasi selanjutnya: [$turnsTillNextDiplomaticVote]
+Turns until the next\ndiplomacy victory vote: [amount] = Jumlah giliran sebelum\npemilihan kemenangan diplomasi selanjutnya: [amount]
 Choose a civ to vote for = Berikan suara kepada peradaban yang ingin dipilih
 Choose who should become the world leader and win a diplomatic victory! = Pilih seseorang untuk menjadi pemimpin dunia dan memenangkan kemenangan diplomatik!
 Voted for = Memilih
@@ -964,7 +964,7 @@ All policies adopted = Semua kebijakan telah diterapkan
 # Religions
 
 Choose an Icon and name for your Religion = Pilih ikon dan nama agamamu
-Choose a [$beliefType] belief! = Pilihlah kepercayaan [$beliefType]!
+Choose a [beliefType] belief! = Pilihlah kepercayaan [beliefType]!
 Found [religionName] = Dirikan agama [religionName]
 Choose a pantheon = Pilih kepercayaan
 Found Religion = Dirikan Agama

--- a/android/assets/jsons/translations/Italian.properties
+++ b/android/assets/jsons/translations/Italian.properties
@@ -811,7 +811,7 @@ Branches completed = Rami completati
 Undefeated civs = Civiltà esistenti
  # The \n here means: put a newline (enter) here. If this is omitted, the sidebox in the diplomacy overview will become _really_ wide.
  # Feel free to replace it with a space and put it somewhere else in your translation
-Turns until the next\ndiplomacy victory vote: [$turnsTillNextDiplomaticVote] = Turni per il prossimo\nvoto di vittoria diplomatica: [$turnsTillNextDiplomaticVote]
+Turns until the next\ndiplomacy victory vote: [amount] = Turni per il prossimo\nvoto di vittoria diplomatica: [amount]
 Choose a civ to vote for = Scegli una civiltà per cui votare
 Choose who should become the world leader and win a diplomatic victory! = Scegli chi dovrebbe diventare Leader del Mondo e ottenere una vittoria diplomatica!
 Voted for = Voto per
@@ -964,7 +964,7 @@ All policies adopted = Tutte le politiche adottate
 # Religions
 
 Choose an Icon and name for your Religion = Scegli un'icona e un nome per la tua Religione
-Choose a [$beliefType] belief! = Scegli una fede [$beliefType]
+Choose a [beliefType] belief! = Scegli una fede [beliefType]
 Found [religionName] = Fonda [religionName]
 Choose a pantheon = Scegli un pantheon
 Found Religion = Fonda religione

--- a/android/assets/jsons/translations/Korean.properties
+++ b/android/assets/jsons/translations/Korean.properties
@@ -986,7 +986,7 @@ All policies adopted = 모든 정책 채택됨
 # Religions
 
 Choose an Icon and name for your Religion = 종교의 이름과 아이콘을 선택하세요
-Choose a [$beliefType] belief! = [$beliefType] 교리 선택
+Choose a [beliefType] belief! = [beliefType] 교리 선택
 Found [religionName] = [religionName] 창시
 Choose a pantheon = 종교관 선택
 Found Religion = 종교 창시

--- a/android/assets/jsons/translations/Russian.properties
+++ b/android/assets/jsons/translations/Russian.properties
@@ -973,7 +973,7 @@ All policies adopted = Все общественные институты при
 # Religions
 
 Choose an Icon and name for your Religion = Выберите иконку и имя вашей религии
-Choose a [$beliefType] belief! = Выбрать [$beliefType] верование!
+Choose a [beliefType] belief! = Выбрать [beliefType] верование!
 Found [religionName] = Основать [religionName]
 Choose a pantheon = Выберите пантеон
 Found Religion = Основать Религию

--- a/android/assets/jsons/translations/Simplified_Chinese.properties
+++ b/android/assets/jsons/translations/Simplified_Chinese.properties
@@ -980,7 +980,7 @@ All policies adopted = 所有政策皆已推行
 # Religions
 
 Choose an Icon and name for your Religion = 为您的宗教制定一个图标和名称
-Choose a [$beliefType] belief! = 选择一个[$beliefType]信仰！
+Choose a [beliefType] belief! = 选择一个[beliefType]信仰！
 Found [religionName] = 发现宗教[religionName]
 Choose a pantheon = 选择万神殿
 Found Religion = 发现宗教

--- a/android/assets/jsons/translations/Spanish.properties
+++ b/android/assets/jsons/translations/Spanish.properties
@@ -811,7 +811,7 @@ Branches completed = Ramas completadas
 Undefeated civs = Naciones no derrotadas
  # The \n here means: put a newline (enter) here. If this is omitted, the sidebox in the diplomacy overview will become _really_ wide.
  # Feel free to replace it with a space and put it somewhere else in your translation
-Turns until the next\ndiplomacy victory vote: [$turnsTillNextDiplomaticVote] = Turnos hasta la siguiente\n votación de victoria diplomática: [$turnsTillNextDiplomaticVote]
+Turns until the next\ndiplomacy victory vote: [amount] = Turnos hasta la siguiente\n votación de victoria diplomática: [amount]
 Choose a civ to vote for = Escoje una civ por la cual votar
 Choose who should become the world leader and win a diplomatic victory! = ¡Escoje a quien deberia convertirse en líder mundial y ganar una victoria diplomática!
 Voted for = Votó por:
@@ -964,7 +964,7 @@ All policies adopted = Todas las políticas adoptadas
 # Religions
 
 Choose an Icon and name for your Religion = Escoje Simbolo y nombre para tu Religión
-Choose a [$beliefType] belief! = ¡Escoje una creencia de [$beliefType]!
+Choose a [beliefType] belief! = ¡Escoje una creencia de [beliefType]!
 Found [religionName] = Fundar [religionName]
 Choose a pantheon = Escoje un panteón
 Found Religion = Fundar Religión

--- a/android/assets/jsons/translations/Swedish.properties
+++ b/android/assets/jsons/translations/Swedish.properties
@@ -811,7 +811,7 @@ Branches completed = Fullbordade grenar
 Undefeated civs = Obesegrade civilisationer
  # The \n here means: put a newline (enter) here. If this is omitted, the sidebox in the diplomacy overview will become _really_ wide.
  # Feel free to replace it with a space and put it somewhere else in your translation
-Turns until the next\ndiplomacy victory vote: [$turnsTillNextDiplomaticVote] = Drag till nästa\ndiplomatiseger röstning: [$turnsTillNextDiplomaticVote]
+Turns until the next\ndiplomacy victory vote: [amount] = Drag till nästa\ndiplomatiseger röstning: [amount]
 Choose a civ to vote for = Välj en civilisation att rösta på
 Choose who should become the world leader and win a diplomatic victory! = Välj vem som ska bli världsledare och vinna en diplomatiseger!
 Voted for = Röstade på
@@ -964,7 +964,7 @@ All policies adopted = Alla policyer anammade
 # Religions
 
 Choose an Icon and name for your Religion = Välj en Ikon och namn för din Religion
-Choose a [$beliefType] belief! = Välj en [$beliefType]-tro!
+Choose a [beliefType] belief! = Välj en [beliefType]-tro!
 Found [religionName] = Stifta [religionName]
 Choose a pantheon = Välj ett panteon
 Found Religion = Stifta Religion

--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -814,7 +814,7 @@ Branches completed =
 Undefeated civs = 
  # The \n here means: put a newline (enter) here. If this is omitted, the sidebox in the diplomacy overview will become _really_ wide.
  # Feel free to replace it with a space and put it somewhere else in your translation
-Turns until the next\ndiplomacy victory vote: [$turnsTillNextDiplomaticVote] = 
+Turns until the next\ndiplomacy victory vote: [amount] = 
 Choose a civ to vote for = 
 Choose who should become the world leader and win a diplomatic victory! = 
 Voted for = 
@@ -968,7 +968,7 @@ All policies adopted =
 # Religions
 
 Choose an Icon and name for your Religion = 
-Choose a [$beliefType] belief! = 
+Choose a [beliefType] belief! = 
 Found [religionName] = 
 Choose a pantheon = 
 Found Religion = 


### PR DESCRIPTION
Due to some copy+pasting directly from the source files, a few $ could still be found in placeholders for translations.
This PR removes these, and replaces the translations in which they were already changed so they will not be lost