### PR TITLE
Diplomacy: City State resource UI, improvement gift effect

### DIFF
--- a/core/src/com/unciv/ui/trade/DiplomacyScreen.kt
+++ b/core/src/com/unciv/ui/trade/DiplomacyScreen.kt
@@ -20,8 +20,10 @@ import com.unciv.models.ruleset.ModOptionsConstants
 import com.unciv.models.ruleset.Quest
 import com.unciv.models.ruleset.tile.ResourceType
 import com.unciv.models.translations.tr
+import com.unciv.ui.civilopedia.CivilopediaScreen
 import com.unciv.ui.tilegroups.CityButton
 import com.unciv.ui.utils.*
+import com.unciv.ui.utils.UncivTooltip.Companion.addTooltip
 import kotlin.math.floor
 import kotlin.math.roundToInt
 import com.unciv.ui.utils.AutoScrollPane as ScrollPane
@@ -103,15 +105,26 @@ class DiplomacyScreen(val viewingCiv:CivilizationInfo):CameraStageBaseScreen() {
         diplomacyTable.add("{Type}:  {${otherCiv.cityStateType}}".toLabel()).row()
         diplomacyTable.add("{Personality}:  {${otherCiv.cityStatePersonality}}".toLabel()).row()
 
-        val resourcesTable = Table()
-        resourcesTable.add("{Resources:}  ".toLabel()).padRight(10f)
-        for (supplyList in otherCiv.detailedCivResources) {
-            if (supplyList.resource.resourceType == ResourceType.Bonus)
-                continue
-            resourcesTable.add(ImageGetter.getResourceImage(supplyList.resource.name, 30f)).padRight(5f)
-            resourcesTable.add(supplyList.amount.toLabel()).padRight(20f)
+        if (otherCiv.detailedCivResources.any { it.resource.resourceType != ResourceType.Bonus }) {
+            val resourcesTable = Table()
+            resourcesTable.add("{Resources:}  ".toLabel()).padRight(10f)
+            for (supplyList in otherCiv.detailedCivResources) {
+                if (supplyList.resource.resourceType == ResourceType.Bonus)
+                    continue
+                val name = supplyList.resource.name
+                val wrapper = Table()
+                val image = ImageGetter.getResourceImage(name, 30f)
+                wrapper.add(image).padRight(5f)
+                wrapper.add(supplyList.amount.toLabel())
+                resourcesTable.add(wrapper).padRight(20f)
+                wrapper.addTooltip(name, 18f)
+                wrapper.onClick { 
+                    val pedia = CivilopediaScreen(UncivGame.Current.gameInfo.ruleSet, link = "Resource/$name")
+                    UncivGame.Current.setScreen(pedia)
+                }
+            }
+            diplomacyTable.add(resourcesTable).row()
         }
-        diplomacyTable.add(resourcesTable).row()
 
         otherCiv.updateAllyCivForCityState()
         val ally = otherCiv.getAllyCiv()
@@ -194,7 +207,6 @@ class DiplomacyScreen(val viewingCiv:CivilizationInfo):CameraStageBaseScreen() {
 
         if (isNotPlayersTurn() || otherCivDiplomacyManager.influence < 60 || !needsImprovements)
             improveTileButton.disable()
-
 
 
         diplomacyTable.add(improveTileButton).row()

--- a/core/src/com/unciv/ui/trade/DiplomacyScreen.kt
+++ b/core/src/com/unciv/ui/trade/DiplomacyScreen.kt
@@ -297,15 +297,18 @@ class DiplomacyScreen(val viewingCiv:CivilizationInfo):CameraStageBaseScreen() {
         val improvementGiftTable = getCityStateDiplomacyTableHeader(otherCiv)
         improvementGiftTable.addSeparator()
 
-        val improvableTiles = otherCiv.getCapital().getImprovableTiles().filterNot {it.getTileResource().resourceType == ResourceType.Bonus}.toList()
+        val improvableTiles = otherCiv.getCapital().getImprovableTiles()
+            .filterNot { it.getTileResource().resourceType == ResourceType.Bonus }.toList()
         val tileImprovements = otherCiv.gameInfo.ruleSet.tileImprovements.filter { it.value.turnsToBuild != 0 }
 
         for (improvableTile in improvableTiles){
             for (tileImprovement in tileImprovements.values){
-                if (improvableTile.canBuildImprovement(tileImprovement, otherCiv) && improvableTile.getTileResource().improvement == tileImprovement.name){
+                if (improvableTile.canBuildImprovement(tileImprovement, otherCiv) &&
+                        improvableTile.getTileResource().improvement == tileImprovement.name) {
                     val improveTileButton = "Build [${tileImprovement}] on [${improvableTile.getTileResource()}] (200 Gold)".toTextButton()
                     improveTileButton.onClick {
-                        viewingCiv.giveGoldGift(otherCiv, 200)
+                        viewingCiv.addGold(-200)
+                        improvableTile.stopWorkingOnImprovement()
                         improvableTile.improvement = tileImprovement.name
                         otherCiv.updateDetailedCivResources()
                         rightSideTable.clear()

--- a/core/src/com/unciv/ui/trade/DiplomacyScreen.kt
+++ b/core/src/com/unciv/ui/trade/DiplomacyScreen.kt
@@ -307,6 +307,7 @@ class DiplomacyScreen(val viewingCiv:CivilizationInfo):CameraStageBaseScreen() {
                     improveTileButton.onClick {
                         viewingCiv.giveGoldGift(otherCiv, 200)
                         improvableTile.improvement = tileImprovement.name
+                        otherCiv.updateDetailedCivResources()
                         rightSideTable.clear()
                         rightSideTable.add(ScrollPane(getCityStateDiplomacyTable(otherCiv)))
                     }

--- a/core/src/com/unciv/ui/utils/ExtensionFunctions.kt
+++ b/core/src/com/unciv/ui/utils/ExtensionFunctions.kt
@@ -30,7 +30,7 @@ fun Button.enable() {
     touchable = Touchable.enabled
 }
 /** Enable or disable a [Button] by setting its [touchable][Button.touchable] and [color][Button.color] properties,
- *  or returns the corresponding state. *
+ *  or returns the corresponding state.
  *
  *  Do not confuse with Gdx' builtin [isDisabled][Button.isDisabled] property,
  *  which is more appropriate to toggle On/Off buttons, while this one is good for 'click-to-do-something' buttons.

--- a/core/src/com/unciv/ui/utils/UncivTooltip.kt
+++ b/core/src/com/unciv/ui/utils/UncivTooltip.kt
@@ -152,6 +152,7 @@ class UncivTooltip <T: Actor>(
          * 
          * Tip is positioned over top right corner, slightly overshooting the receiver widget, longer tip [text]s will extend to the left.
          * 
+         * @param text Automatically translated tooltip text
          * @param size _Vertical_ size of the entire Tooltip including background
          * @param always override requirement: presence of physical keyboard
          */


### PR DESCRIPTION
Looking at #4755 in action I made this - careful - commit 2 is effectively a rule change, and I'm not sure the resulting rules are 'correct':

<details><summary>Demo Clip</summary>

https://user-images.githubusercontent.com/63000004/128544594-004fddca-59e5-434b-aba6-ef67d5dc17dc.mp4
</details>

- The resources have a tooltip showing name in case you don't know all the icons, or clicking leads to Civilopedia if still unsure... Of course, we still can't return from there.
- The freshly improved resource shows up immediately. This raises the question...

Current effect of this '200 Gold for improvement' gift:
- You lose 200 gold
- The CS gains 200 gold
- You gain Influence same as normal gold gifts
- The improvement is placed on the tile, but the resource is not added to the CS's pool until endTurn

Change: CS available resources updated immediately

Questionable: Should the CS really keep that gold if they also gained an improvement?