### PR TITLE
Fix banking's required techs

### DIFF
--- a/android/assets/jsons/Civ V - Vanilla/Techs.json
+++ b/android/assets/jsons/Civ V - Vanilla/Techs.json
@@ -279,7 +279,7 @@
 			{
 				"name": "Banking",
 				"row": 6,
-				"prerequisites": ["Chivalry"],
+				"prerequisites": ["Chivalry", "Education"],
 				"quote": "'Happiness: a good bank account, a good cook and a good digestion' - Jean Jacques Rousseau"
 			},
 			{


### PR DESCRIPTION
will this break a hypothetical save where someone is now researching a tech and has all required techs for now but not the new to be added requirement? 