### PR TITLE
Fixed bug where units could still be purchased if they used a depleted resource

### DIFF
--- a/core/src/com/unciv/logic/city/CityConstructions.kt
+++ b/core/src/com/unciv/logic/city/CityConstructions.kt
@@ -365,12 +365,11 @@ class CityConstructions {
         val inProgressSnapshot = inProgressConstructions.keys.filter { it != currentConstructionFromQueue }
         for (constructionName in inProgressSnapshot) {
             val construction = getConstruction(constructionName)
-            val rejectionReason: String =
-                    when (construction) {
-                        is Building -> construction.getRejectionReason(this)
-                        is BaseUnit -> construction.getRejectionReason(this)
-                        else -> ""
-                    }
+            // Perpetual constructions should always still be valid (I hope)
+            if (construction is PerpetualConstruction) continue
+            
+            val rejectionReason = 
+                (construction as INonPerpetualConstruction).getRejectionReason(this)
 
             if (rejectionReason.endsWith("lready built")
                     || rejectionReason.startsWith("Cannot be built with")

--- a/core/src/com/unciv/logic/city/IConstruction.kt
+++ b/core/src/com/unciv/logic/city/IConstruction.kt
@@ -22,6 +22,7 @@ interface INonPerpetualConstruction : IConstruction, INamed {
 
     fun getProductionCost(civInfo: CivilizationInfo): Int
     fun getStatBuyCost(cityInfo: CityInfo, stat: Stat): Int?
+    fun getRejectionReason(cityConstructions: CityConstructions): String
     
     private fun getMatchingUniques(uniqueTemplate: String): Sequence<Unique> {
         return uniqueObjects.asSequence().filter { it.placeholderText == uniqueTemplate }
@@ -40,6 +41,13 @@ interface INonPerpetualConstruction : IConstruction, INamed {
                 .any { it.params[1] == stat.name && ( ignoreCityRequirements || cityInfo.matchesFilter(it.params[2])) }
         ) return true
         return false
+    }
+
+    /** Checks if the construction should be purchasable, not whether it can be bought with a stat at all */
+    fun isPurchasable(cityConstructions: CityConstructions): Boolean {
+        val rejectionReason = getRejectionReason(cityConstructions)
+        return rejectionReason == ""
+                || rejectionReason == "Can only be purchased"
     }
     
     fun canBePurchasedWithAnyStat(cityInfo: CityInfo): Boolean {
@@ -107,7 +115,7 @@ open class PerpetualConstruction(override var name: String, val description: Str
 
     override fun isBuildable(cityConstructions: CityConstructions): Boolean =
             throw Exception("Impossible!")
-
+    
     override fun postBuildEvent(cityConstructions: CityConstructions, wasBought: Boolean) =
             throw Exception("Impossible!")
 

--- a/core/src/com/unciv/models/ruleset/Building.kt
+++ b/core/src/com/unciv/models/ruleset/Building.kt
@@ -392,7 +392,7 @@ class Building : NamedStats(), INonPerpetualConstruction, ICivilopediaText {
                 || rejectionReason == "Can only be purchased"
     }
 
-    fun getRejectionReason(construction: CityConstructions): String {
+    override fun getRejectionReason(construction: CityConstructions): String {
         if (construction.isBuilt(name)) return "Already built"
         // for buildings that are created as side effects of other things, and not directly built
         // unless they can be bought with faith

--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -240,7 +240,7 @@ class BaseUnit : INamed, INonPerpetualConstruction, CivilopediaText() {
                 || rejectionReason == "Can only be purchased"
     }
 
-    fun getRejectionReason(cityConstructions: CityConstructions): String {
+    override fun getRejectionReason(cityConstructions: CityConstructions): String {
         if (isWaterUnit() && !cityConstructions.cityInfo.isCoastal())
             return "Can only build water units in coastal cities"
         val civInfo = cityConstructions.cityInfo.civInfo

--- a/core/src/com/unciv/ui/cityscreen/CityConstructionsTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityConstructionsTable.kt
@@ -429,11 +429,12 @@ class CityConstructionsTable(val cityScreen: CityScreen) : Table(CameraStageBase
             }
             
             if (!cityScreen.canChangeState
-                    || city.isPuppet 
-                    || city.isInResistance()
-                    || !city.canPurchase(construction)
-                    || (constructionBuyCost > city.getStatReserve(stat) && !city.civInfo.gameInfo.gameParameters.godMode))
-                button.disable()
+                || !construction.isPurchasable(city.cityConstructions)
+                || city.isPuppet 
+                || city.isInResistance()
+                || !city.canPurchase(construction)
+                || (constructionBuyCost > city.getStatReserve(stat) && !city.civInfo.gameInfo.gameParameters.godMode)
+            ) button.disable()
         }
 
         button.labelCell.pad(5f)


### PR DESCRIPTION
In my missionaries PR I removed a statement checking whether the unit to buy was still buildable, thinking that would not change anything. Turns out it did, as it allowed other units to be bought when they required  strategic resources or other things.
This PR fixes this.