### PR TITLE
Fixed crash when borrowing names

### DIFF
--- a/core/src/com/unciv/models/ruleset/Nation.kt
+++ b/core/src/com/unciv/models/ruleset/Nation.kt
@@ -94,7 +94,7 @@ class Nation : INamed, ICivilopediaText {
         disembarkCosts1 = uniques.contains("Units pay only 1 movement point to disembark")
     }
 
-    lateinit var cities: ArrayList<String>
+    var cities: ArrayList<String> = arrayListOf()
 
 
     /** Used only by NewGame Nation picker */

--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -305,6 +305,12 @@ class Ruleset {
             if (building.requiredTech == null && building.cost == 0)
                 lines += "${building.name} must either have an explicit cost or reference an existing tech!"
         }
+        
+        for (nation in nations.values) {
+            if (nation.cities.isEmpty() && !nation.isSpectator() && !nation.isBarbarian()) {
+                lines += "${nation.name} can settle cities, but has no city names!"
+            }
+        }
 
         if (!modOptions.isBaseRuleset) return CheckModLinksResult(warningCount, lines)
 


### PR DESCRIPTION
Fixes #4799.
The problem was the following:
When the Huns ran out of names to borrow from the civs currently in the game, they would do so from civs not currently in the game.
However, one of these players was the spectator, which had no cities defined. This meant that its lateinit property 'cities' was not initalized, causing a crash when looking these up.
This PR fixes this, by initializing the `cities` property to an empty list, and checking when loading mods whether there is a non-spectator non-barbarian player to avoid potential crashes over there.