### PR TITLE
City screen stats no double separators

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -989,7 +989,8 @@ Found Religion =
 Found Pantheon = 
 Follow [belief] = 
 Religions and Beliefs = 
-         
+Majority Religion: [name] = 
+
 # Religion overview screen
 Religion Name: = 
 Founding Civ: = 

--- a/core/src/com/unciv/ui/cityscreen/CityStatsTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityStatsTable.kt
@@ -2,6 +2,7 @@ package com.unciv.ui.cityscreen
 
 import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.scenes.scene2d.ui.Table
+import com.unciv.logic.civilization.ReligionState
 import com.unciv.models.stats.Stat
 import com.unciv.models.translations.tr
 import com.unciv.ui.utils.ImageGetter
@@ -29,23 +30,23 @@ class CityStatsTable(val cityScreen: CityScreen): Table() {
     fun update() {
         innerTable.clear()
 
-        val ministatsTable = Table()
+        val miniStatsTable = Table()
         for ((stat, amount) in cityInfo.cityStats.currentCityStats.toHashMap()) {
             if (stat == Stat.Faith && !cityInfo.civInfo.gameInfo.hasReligionEnabled()) continue
-            ministatsTable.add(ImageGetter.getStatIcon(stat.name)).size(20f).padRight(5f)
+            miniStatsTable.add(ImageGetter.getStatIcon(stat.name)).size(20f).padRight(5f)
             val valueToDisplay = if (stat == Stat.Happiness) cityInfo.cityStats.happinessList.values.sum() else amount
-            ministatsTable.add(round(valueToDisplay).toInt().toString().toLabel()).padRight(10f)
+            miniStatsTable.add(round(valueToDisplay).toInt().toLabel()).padRight(10f)
         }
-        innerTable.add(ministatsTable)
+        innerTable.add(miniStatsTable)
 
         innerTable.addSeparator()
         addText()
-        innerTable.addSeparator()
-        innerTable.add(SpecialistAllocationTable(cityScreen).apply { update() })
-        if (cityInfo.civInfo.gameInfo.hasReligionEnabled()) {
+        if (!cityInfo.population.getMaxSpecialists().isEmpty()) {
             innerTable.addSeparator()
-            addReligionInfo()
+            innerTable.add(SpecialistAllocationTable(cityScreen).apply { update() })
         }
+
+        addReligionInfo()
 
         pack()
     }
@@ -85,8 +86,10 @@ class CityStatsTable(val cityScreen: CityScreen): Table() {
 
     private fun addReligionInfo() {
         // This will later become large enough to be its own class, but for now it is small enough to fit inside a single function
-        val majorityReligion = cityInfo.religion.getMajorityReligion()
-        val label = majorityReligion ?: "None"
-        innerTable.add("Majority Religion: $label".toLabel())
+        if(cityInfo.civInfo.religionManager.religionState == ReligionState.None) return
+        innerTable.addSeparator()
+        val label = cityInfo.religion.getMajorityReligion()
+            ?: "None"
+        innerTable.add("Majority Religion: [$label]".toLabel())
     }
 }


### PR DESCRIPTION
Mi no lika dees:
![image](https://user-images.githubusercontent.com/63000004/128702189-97f57e2e-3527-427a-bd99-35816001d36d.png)

- No more double Separators or at end of table
- Majority Religion not shown until there's a Pantheon
@xlenstra - the `gameInfo.hasReligionEnabled` check _is_ redundant this way, right?