### PR TITLE
Gradle upgrade fixes

### DIFF
--- a/.github/workflows/buildAndDeploy.yml
+++ b/.github/workflows/buildAndDeploy.yml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: actions/setup-java@v1
         with:
-          java-version: '8'
+          java-version: '11'
 
       # Runs a set of commands using the runners shell
       - name: check

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 android {
-    compileSdkVersion(30)
+    compileSdk = 30
     sourceSets {
         getByName("main").apply {
             manifest.srcFile("AndroidManifest.xml")
@@ -20,12 +20,12 @@ android {
         }
     }
     packagingOptions {
-        exclude("META-INF/robovm/ios/robovm.xml")
+        resources.excludes.add("META-INF/robovm/ios/robovm.xml")
     }
     defaultConfig {
         applicationId = "com.unciv.app"
-        minSdkVersion(14)
-        targetSdkVersion(30)
+        minSdk = 14
+        targetSdk = 30
         versionCode = BuildConfig.appCodeNumber
         versionName = BuildConfig.appVersion
 
@@ -56,13 +56,16 @@ android {
         }
 
     }
-    lintOptions {
-        disable("MissingTranslation")
+
+    lint {
+        isAbortOnError = false
     }
+
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_7
         targetCompatibility = JavaVersion.VERSION_1_7
     }
+
     androidResources {
         ignoreAssetsPattern = "!SaveFiles:!fonts:!maps:!music:!mods"
     }

--- a/android/res/values-fr/strings.xml
+++ b/android/res/values-fr/strings.xml
@@ -6,4 +6,15 @@
     <string name="Notify_Error_Long">Service de notification du tour multijoueur terminé</string>
     <string name="Notify_Error_Short">Une erreur est survenue</string>
     <string name="Notify_Persist_Long_P4">Configurable dans le menu des options de Unciv</string>
+    <string name="Notify_Persist_Short">Dernière contrôle en ligne</string>
+    <string name="Notify_Persist_Long_P2">Contrôles environ chaque</string>
+    <string name="Notify_Persist_Long_P3">minutes si l\'internet est disponible</string>
+    <string name="Notify_Persist_Long_P1">Unciv va pleurnicher lors que c\'est ton tour en multi-joueurs</string>
+    <string name="Notify_Error_StackTrace_Toast">Stacktraces mises au presse-papiers</string>
+    <string name="Notify_Error_Retrying">échoué, essayant encore une fois...</string>
+    <string name="Notify_Error_CopyAction">Mettre le Stacktrace au presse-papiers</string>
+    <string name="Notify_ChannelService_Short">Contrôle tour de multi-joueurs Unciv</string>
+    <string name="Notify_ChannelService_Long">Notification persistente permet à Unciv de réagir vitement aux fin de tour des autres joueurs.</string>
+    <string name="Notify_ChannelInfo_Short">Notification contrôle tour Unciv</string>
+    <string name="Notify_ChannelInfo_Long">Cette notification de Unciv vous informe que c\'est votre tour.</string>
 </resources>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,11 @@ import com.unciv.build.BuildConfig.gdxVersion
 import com.unciv.build.BuildConfig.kotlinVersion
 import com.unciv.build.BuildConfig.roboVMVersion
 
+// You'll still get kotlin-reflect-1.3.70.jar in your classpath, but lint no longer crashes?
+configurations.all { resolutionStrategy {
+    force("org.jetbrains.kotlin:kotlin-reflect:1.4.30")
+} }
+
 buildscript {
 
     repositories {
@@ -15,9 +20,11 @@ buildscript {
         mavenCentral()
         maven { url = uri("https://oss.sonatype.org/content/repositories/snapshots/") }
         gradlePluginPortal()
-        maven{ url = uri("https://jitpack.io") } // for the anuken packr
+        maven { url = uri("https://jitpack.io") } // for the anuken packr
     }
+
     dependencies {
+        @Suppress("RemoveRedundantQualifierName")  // accessing module-level stuff just fails to compile 
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${com.unciv.build.BuildConfig.kotlinVersion}")
         classpath("de.richsource.gradle.plugins:gwt-gradle-plugin:0.6")
         classpath("com.android.tools.build:gradle:7.0.0")
@@ -27,7 +34,7 @@ buildscript {
         classpath("com.github.anuken:packr:-SNAPSHOT")
     }
 }
-        
+
 allprojects {
     apply(plugin  = "eclipse")
     apply(plugin  = "idea")
@@ -118,7 +125,7 @@ project(":core") {
              * If you do have some classes to test in os specific code you may want to uncomment
              * some of these lines.
              *
-             * BUT: I recommend to create seperate test sub projects for each platform. Trust me :)
+             * BUT: I recommend to create separate test sub projects for each platform. Trust me :)
              *
              */
 
@@ -141,7 +148,8 @@ project(":core") {
             "testImplementation"("com.badlogicgames.gdx:gdx:$gdxVersion")
             "testImplementation"("com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-desktop")
         }
-    }}
+    }
+}
 
 tasks {
     "eclipse" {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -3,5 +3,5 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()  // "JFrog announced JCenter's shutdown in February 2021"
 }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_6
+    sourceCompatibility = JavaVersion.VERSION_1_7
 }
 
 tasks {

--- a/desktop/build.gradle.kts
+++ b/desktop/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_6
+    sourceCompatibility = JavaVersion.VERSION_1_7
 }
 sourceSets {
     main {

--- a/tests/build.gradle.kts
+++ b/tests/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_6
+    sourceCompatibility = JavaVersion.VERSION_1_7
     targetCompatibility = JavaVersion.VERSION_1_7
 }
 


### PR DESCRIPTION
For #4861 

- build JVM from 8 to 11
- sourceCompatibility from 1_6 to 1_7
- updated deprecated gradle language
- Satisfies :android:lintDebug errors
- Tries to prevent it crashing all the time by matching kotlin-reflect to main kotlin version (1.5.20 soon please)
- Some linting

*** Still fails ***

Mix and match as you wish.