### PR TITLE
Gave anti-air units a bonus vs helicopters

### DIFF
--- a/android/assets/jsons/Civ V - Vanilla/Units.json
+++ b/android/assets/jsons/Civ V - Vanilla/Units.json
@@ -1074,7 +1074,7 @@
 		"requiredResource": "Oil",
 		"upgradesTo": "Fighter",
 		"obsoleteTech": "Radar",
-		"uniques": ["[50]% chance to intercept air attacks","+[50]% Strength vs [Bomber]"],
+		"uniques": ["[50]% chance to intercept air attacks", "+[150]% Strength vs [Bomber]", "+[150]% Strength vs [Helicopter]"],
 		"attackSound": "machinegun"
 	},
 	{
@@ -1148,7 +1148,7 @@
 		"requiredTech": "Ballistics",
 		"upgradesTo": "Mobile SAM",
 		"obsoleteTech": "Rocketry",
-		"uniques": ["[100]% chance to intercept air attacks","+[150]% Strength vs [air units]"],
+		"uniques": ["[100]% chance to intercept air attacks", "+[150]% Strength vs [air units]", "+[150]% Strength vs [Helicopter]"],
 		"attackSound": "machinegun"
 	},
 	{
@@ -1202,7 +1202,7 @@
 		"requiredTech": "Radar",
 		"requiredResource": "Oil",
 		"upgradesTo": "Jet Fighter",
-		"uniques": ["[100]% chance to intercept air attacks", "+[150]% Strength vs [Bomber]"],
+		"uniques": ["[100]% chance to intercept air attacks", "+[150]% Strength vs [Bomber]", "+[150]% Strength vs [Helicopter]"],
 		"attackSound": "machinegun"
 	},
 	{
@@ -1218,8 +1218,8 @@
 		"cost": 375,
 		"requiredTech": "Radar",
 		"upgradesTo": "Jet Fighter",
-		"uniques": ["[100]% chance to intercept air attacks","+[150]% Strength vs [Bomber]","+[33]% Strength vs [Fighter]",
-			"6 tiles in every direction always visible"],
+		"uniques": ["[100]% chance to intercept air attacks", "+[150]% Strength vs [Bomber]", "+[150]% Strength vs [Helicopter]",
+			"+[33]% Strength vs [Fighter]"],
 		"attackSound": "machinegun"
 	},
 	{
@@ -1338,7 +1338,7 @@
 		"strength": 65,
 		"cost": 425,
 		"requiredTech": "Rocketry",
-		"uniques": ["[100]% chance to intercept air attacks","+[150]% Strength vs [air units]"],
+		"uniques": ["[100]% chance to intercept air attacks", "+[150]% Strength vs [air units]", "+[150]% Strength vs [Helicopter]"],
 		"attackSound": "missile"
 	},
 	{
@@ -1441,7 +1441,7 @@
 		"cost": 425,
 		"requiredTech": "Lasers",
 		"requiredResource": "Aluminum",
-		"uniques": ["[100]% chance to intercept air attacks", "+[150]% Strength vs [Bomber]"],
+		"uniques": ["[100]% chance to intercept air attacks", "+[150]% Strength vs [Bomber]", "+[150]% Strength vs [Helicopter]"],
 		"attackSound": "jetgun"
 	},
 	{


### PR DESCRIPTION
This strikes off an item from #4697, in the way described in https://github.com/yairm210/Unciv/issues/4697#issuecomment-898682581.

Also corrected the damage bonus of triplanes and removed a redundant "6 tiles in every direction always visible" unique.