### PR TITLE
Made water oil wells require the Refrigeration tech

### DIFF
--- a/android/assets/jsons/Civ V - Vanilla/TileImprovements.json
+++ b/android/assets/jsons/Civ V - Vanilla/TileImprovements.json
@@ -49,9 +49,9 @@
 	},
 	{
 		"name": "Oil well",
-		"terrainsCanBeBuiltOn": ["Coast"],
 		"turnsToBuild": 9,
 		"techRequired": "Biology",
+		"uniques": ["Cannot be built on [Coast] tiles until [Refrigeration] is discovered"],
 		"shortcutKey": "W"
 	},
 	{
@@ -78,7 +78,6 @@
 	},
 	{
 		"name": "Fishing Boats",
-		"terrainsCanBeBuiltOn": ["Coast"],
 		"food": 1,
 		"techRequired": "Sailing",
 		"uniques": ["[+1 Gold] once [Compass] is discovered"]

--- a/android/assets/jsons/Civ V - Vanilla/TileImprovements.json
+++ b/android/assets/jsons/Civ V - Vanilla/TileImprovements.json
@@ -49,6 +49,7 @@
 	},
 	{
 		"name": "Oil well",
+		"terrainsCanBeBuiltOn": ["Coast"],
 		"turnsToBuild": 9,
 		"techRequired": "Biology",
 		"uniques": ["Cannot be built on [Coast] tiles until [Refrigeration] is discovered"],
@@ -78,6 +79,7 @@
 	},
 	{
 		"name": "Fishing Boats",
+		"terrainsCanBeBuiltOn": ["Coast"],
 		"food": 1,
 		"techRequired": "Sailing",
 		"uniques": ["[+1 Gold] once [Compass] is discovered"]

--- a/core/src/com/unciv/logic/map/TileInfo.kt
+++ b/core/src/com/unciv/logic/map/TileInfo.kt
@@ -387,6 +387,10 @@ open class TileInfo {
             improvement.uniqueObjects.any {
                 it.placeholderText == "Obsolete with []" && civInfo.tech.isResearched(it.params[0])
             } -> return false
+            improvement.uniqueObjects.any {
+                it.placeholderText == "Cannot be built on [] tiles until [] is discovered" &&
+                matchesTerrainFilter(it.params[0]) && !civInfo.tech.isResearched(it.params[1])
+            } -> false
             else -> canImprovementBeBuiltHere(improvement, hasViewableResource(civInfo))
         }
     }


### PR DESCRIPTION
This strikes off an item from #4697.

Added unique: "Cannot be built on [tileFilter] until [techName] is discovered".

This is not the ideal solution: it would be preferable to support multiple improvements for a single resource, to add offshore platforms as a separate improvement for coastal oil that requires refrigeration and to disable building oil wells on coast. That way, we could also distinguish between oil wells and offshore platforms in other cases. Allowing multiple improvements for a single resource would however be a much more significant refactor. This works for now.