### PR TITLE
Fix a situation after razing

### DIFF
--- a/core/src/com/unciv/logic/city/CityReligion.kt
+++ b/core/src/com/unciv/logic/city/CityReligion.kt
@@ -126,6 +126,7 @@ class CityInfoReligionManager {
         val oldMajorityReligion = getMajorityReligion()
         
         followers.clear()
+        if (cityInfo.population.population <= 0) return
 
         val remainders = HashMap<String, Float>()
         val pressurePerFollower = pressures.values.sum() / cityInfo.population.population


### PR DESCRIPTION
updateNumberOfFollowers _is_ called one last time after a city has been raZed to the grOund.

Fixes #4880 and #4891  - ah yes Xander _has_ commented the same. I assumed someone would be faster, so this got "delayed". Credit to @xlenstra