### PR TITLE
Small changes to city screen

### DIFF
--- a/core/src/com/unciv/models/ruleset/Building.kt
+++ b/core/src/com/unciv/models/ruleset/Building.kt
@@ -75,10 +75,10 @@ class Building : NamedStats(), INonPerpetualConstruction, ICivilopediaText {
     override var civilopediaText = listOf<FormattedLine>()
 
 
+    /** Used for AlertType.WonderBuilt, and as sub-text in Nation and Tech descriptions */
     fun getShortDescription(ruleset: Ruleset): String { // should fit in one line
         val infoList = mutableListOf<String>()
-        val str = getStats(null).toString()
-        if (str.isNotEmpty()) infoList += str
+        getStats(null).toString().also { if (it.isNotEmpty()) infoList += it }
         for (stat in getStatPercentageBonuses(null).toHashMap())
             if (stat.value != 0f) infoList += "+${stat.value.toInt()}% ${stat.key.name.tr()}"
 
@@ -114,13 +114,18 @@ class Building : NamedStats(), INonPerpetualConstruction, ICivilopediaText {
                 ))
     }
     private fun getUniquesStringsWithoutDisablers() = getUniquesStrings()
-        .filterNot { it.startsWith("Hidden ") && it.endsWith(" disabled") || it == "Unbuildable" }
+        .filterNot {
+            it.startsWith("Hidden ") && it.endsWith(" disabled") ||
+            it == "Unbuildable" ||
+            it == "Will not be displayed in Civilopedia"
+        }
 
     /** used in CityScreen (CityInfoTable and ConstructionInfoTable) */
     fun getDescription(cityInfo: CityInfo?, ruleset: Ruleset): String {
         val stats = getStats(cityInfo)
         val lines = ArrayList<String>()
-        if (uniqueTo != null) lines += "Unique to [$uniqueTo], replaces [$replaces]"
+        if (uniqueTo != null) lines += if (replaces == null) "Unique to [$uniqueTo]"
+            else "Unique to [$uniqueTo], replaces [$replaces]"
         if (isWonder) lines += "Wonder"
         if (isNationalWonder) lines += "National Wonder"
         for ((resource, amount) in getResourceRequirements()) {

--- a/core/src/com/unciv/ui/cityscreen/CityInfoTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityInfoTable.kt
@@ -5,6 +5,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.utils.Align
 import com.unciv.UncivGame
 import com.unciv.logic.city.CityInfo
+import com.unciv.models.UncivSound
 import com.unciv.models.ruleset.Building
 import com.unciv.models.stats.Stat
 import com.unciv.models.translations.tr
@@ -71,7 +72,7 @@ class CityInfoTable(private val cityScreen: CityScreen) : Table(CameraStageBaseS
                 val sellBuildingButton = "Sell for [$sellAmount] gold".toTextButton()
                 it.add(sellBuildingButton).pad(5f).row()
 
-                sellBuildingButton.onClick {
+                sellBuildingButton.onClick(UncivSound.Coin) {
                     sellBuildingButton.disable()
                     cityScreen.closeAllPopups()
 

--- a/core/src/com/unciv/ui/cityscreen/CityStatsTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityStatsTable.kt
@@ -90,6 +90,6 @@ class CityStatsTable(val cityScreen: CityScreen): Table() {
         innerTable.addSeparator()
         val label = cityInfo.religion.getMajorityReligion()
             ?: "None"
-        innerTable.add("Majority Religion: [$label]".toLabel())
+        innerTable.add("Majority Religion: [$label]".toLabel()).padTop(5f)
     }
 }


### PR DESCRIPTION
- Majority Religion display in City Screen stats (upper right) some padding
- Sell buildings -> Coins sound
- Building display - Nation-uniques not replacing anything (mods e.g. Ancient Civs) and hide "hide from civilopedia"

Sorry for the `also` - I just stumbled over the uninspired variable name, and this way I didn't have to think up a nicer one