### PR TITLE
Fix crash at conquest, empty religion icon

### DIFF
--- a/core/src/com/unciv/logic/city/CityReligion.kt
+++ b/core/src/com/unciv/logic/city/CityReligion.kt
@@ -190,13 +190,13 @@ class CityInfoReligionManager {
      *  Should be called whenever a city changes hands, e.g. conquering and trading
      */
     fun removeUnknownPantheons() {
-        for (pressure in pressures) {
-            if (pressure.key == Constants.noReligionName) continue
-            val correspondingReligion = cityInfo.civInfo.gameInfo.religions[pressure.key]!!
+        for (pressure in pressures.keys.toList()) {  // Copy the keys because we might modify
+            if (pressure == Constants.noReligionName) continue
+            val correspondingReligion = cityInfo.civInfo.gameInfo.religions[pressure]!!
             if (correspondingReligion.isPantheon() 
                 && correspondingReligion.foundingCivName != cityInfo.civInfo.civName
             ) {
-                pressures.remove(pressure.key)
+                pressures.remove(pressure)
             }
         }
         updateNumberOfFollowers()

--- a/core/src/com/unciv/ui/cityscreen/CityStatsTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityStatsTable.kt
@@ -85,11 +85,12 @@ class CityStatsTable(val cityScreen: CityScreen): Table() {
     private fun addReligionInfo() {
         val label = cityInfo.religion.getMajorityReligionName()
             ?: "None"
+        val icon = if (label == "None") "Religion" else label
         val expanderTab =
             ExpanderTab(
                 title = "Majority Religion: [$label]",
                 fontSize = 18,
-                icon = ImageGetter.getCircledReligionIcon(label, 30f),
+                icon = ImageGetter.getCircledReligionIcon(icon, 30f),
                 defaultPad = 0f,
                 persistenceID = "CityStatsTable.Religion",
                 startsOutOpened = false,


### PR DESCRIPTION
- CityReligion.removeUnknownPantheons iterated a HashMap and removed entries in the loop
- The nice new Religion info can display "None", and there is no ReligionIcons\None.png

Iterate-remove sounds like there is a pattern I (we?) haven't learned. There's doc that says you can iterate certain views and the iterator then has a remove method that _is_ allowed... Anyone has an example?