### PR TITLE
getLastTerrain simple patch

### DIFF
--- a/core/src/com/unciv/logic/map/TileInfo.kt
+++ b/core/src/com/unciv/logic/map/TileInfo.kt
@@ -135,7 +135,8 @@ open class TileInfo {
     fun getCity(): CityInfo? = owningCity
 
     fun getLastTerrain(): Terrain = when {
-        terrainFeatures.isNotEmpty() -> getTerrainFeatures().last()
+        terrainFeatures.isNotEmpty() -> ruleset.terrains[terrainFeatures.last()]
+                ?: getBaseTerrain()  // defense against rare edge cases involving baseTerrain Hill deprecation
         naturalWonder != null -> getNaturalWonder()
         else -> getBaseTerrain()
     }


### PR DESCRIPTION
No-brainer followup to #4784 - satisfies the reason why I originally checked (analyzing some DeCiv save where terrainFeatures was not empty but getTerrainFeatures() was) with a nice "King of Rock and Roll", but - instead of pulling a copy of an ArrayList, mapping through HashMap lookups to objects resulting in a complete materialized List, then taking the last entry and discard the rest - well, take last string, lookup once.

This will yield changed results only in those cases where terrainFeatures does contain invalid entries (and if such a case is still left after initialization is done, then it needs lots of luck to not crash in current master).