### PR TITLE
StartingLocation-Improvements-be-gone phase 2

### DIFF
--- a/core/src/com/unciv/logic/GameStarter.kt
+++ b/core/src/com/unciv/logic/GameStarter.kt
@@ -21,8 +21,8 @@ import kotlin.math.max
 
 object GameStarter {
     // temporary instrumentation while tuning/debugging
-    private const val consoleOutput = true
-    private const val consoleTimings = true
+    private const val consoleOutput = false
+    private const val consoleTimings = false
 
     fun startNewGame(gameSetupInfo: GameSetupInfo): GameInfo {
         if (consoleOutput || consoleTimings)

--- a/core/src/com/unciv/logic/MapSaver.kt
+++ b/core/src/com/unciv/logic/MapSaver.kt
@@ -10,7 +10,7 @@ object MapSaver {
     fun json() = GameSaver.json()
 
     private const val mapsFolder = "maps"
-    private const val saveZipped = false
+    private const val saveZipped = true
 
     private fun getMap(mapName:String) = Gdx.files.local("$mapsFolder/$mapName")
 

--- a/core/src/com/unciv/logic/map/MapParameters.kt
+++ b/core/src/com/unciv/logic/map/MapParameters.kt
@@ -158,6 +158,14 @@ class MapParameters {
     }
 
     // For debugging and MapGenerator console output
-    override fun toString() = if (name.isNotEmpty()) "\"$name\""
-        else "($mapSize ${if (worldWrap)"wrapped " else ""}$shape $type, Seed $seed, $elevationExponent/$temperatureExtremeness/$resourceRichness/$vegetationRichness/$rareFeaturesRichness/$maxCoastExtension/$tilesPerBiomeArea/$waterThreshold)"
+    override fun toString() = sequence {
+        if (name.isNotEmpty()) yield("\"$name\" ")
+        yield("($mapSize ")
+        if (worldWrap) yield("wrapped ")
+        yield(shape)
+        if (name.isEmpty()) return@sequence
+        yield(" $type, Seed $seed, ")
+        yield("$elevationExponent/$temperatureExtremeness/$resourceRichness/$vegetationRichness/")
+        yield("$rareFeaturesRichness/$maxCoastExtension/$tilesPerBiomeArea/$waterThreshold")
+    }.joinToString("", postfix = ")")
 }

--- a/core/src/com/unciv/logic/map/TileInfo.kt
+++ b/core/src/com/unciv/logic/map/TileInfo.kt
@@ -757,11 +757,6 @@ open class TileInfo {
     }
 
     private fun normalizeTileImprovement(ruleset: Ruleset) {
-        // This runs from map editor too, so the Pseudo-improvements for starting locations need to stay.
-        if (improvement!!.startsWith(TileMap.startingLocationPrefix)) {
-            if (!isLand || getLastTerrain().impassable) improvement = null
-            return
-        }
         val improvementObject = ruleset.tileImprovements[improvement]
         if (improvementObject == null) {
             improvement = null

--- a/core/src/com/unciv/models/metadata/GameParameters.kt
+++ b/core/src/com/unciv/models/metadata/GameParameters.kt
@@ -49,23 +49,21 @@ class GameParameters { // Default values are the default new game
         return parameters
     }
 
-    // For debugging and MapGenerator console output
-    override fun toString() = "($difficulty $gameSpeed $startingEra, " +
-            "${players.count { it.playerType == PlayerType.Human }} ${PlayerType.Human} " +
-            "${players.count { it.playerType == PlayerType.AI }} ${PlayerType.AI} " +
-            "$numberOfCityStates CS, " +
-            sequence<String> {
-                if (isOnlineMultiplayer) yield("Online Multiplayer")
-                if (noBarbarians) yield("No barbs")
-                if (oneCityChallenge) yield("OCC")
-                if (!nuclearWeaponsEnabled) yield("No nukes")
-                if (religionEnabled) yield("Religion")
-                if (godMode) yield("God mode")
-                if (VictoryType.Cultural !in victoryTypes) yield("No ${VictoryType.Cultural} Victory")
-                if (VictoryType.Diplomatic in victoryTypes) yield("${VictoryType.Diplomatic} Victory")
-                if (VictoryType.Domination !in victoryTypes) yield("No ${VictoryType.Domination} Victory")
-                if (VictoryType.Scientific !in victoryTypes) yield("No ${VictoryType.Scientific} Victory")
-            }.joinToString() +
-            (if (mods.isEmpty()) ", no mods" else mods.joinToString(",", ", mods=(", ")", 6) ) +
-            ")"
+    // For debugging and GameStarter console output
+    override fun toString() = sequence<String> {
+            yield("$difficulty $gameSpeed $startingEra")
+            yield("${players.count { it.playerType == PlayerType.Human }} ${PlayerType.Human}")
+            yield("${players.count { it.playerType == PlayerType.AI }} ${PlayerType.AI}")
+            yield("$numberOfCityStates CS")
+            if (isOnlineMultiplayer) yield("Online Multiplayer")
+            if (noBarbarians) yield("No barbs")
+            if (oneCityChallenge) yield("OCC")
+            if (!nuclearWeaponsEnabled) yield("No nukes")
+            if (religionEnabled) yield("Religion")
+            if (godMode) yield("God mode")
+            for (victoryType in VictoryType.values()) {
+                if (victoryType !in victoryTypes) yield("No $victoryType Victory")
+            }
+            yield(if (mods.isEmpty()) "no mods" else mods.joinToString(",", "mods=(", ")", 6) )
+        }.joinToString(prefix = "(", postfix = ")")
 }

--- a/core/src/com/unciv/ui/mapeditor/MapEditorScreen.kt
+++ b/core/src/com/unciv/ui/mapeditor/MapEditorScreen.kt
@@ -36,7 +36,6 @@ class MapEditorScreen(): CameraStageBaseScreen() {
         ImageGetter.setNewRuleset(ruleset)
         tileMap.setTransients(ruleset,false)
         tileMap.setStartingLocationsTransients()
-        tileMap.translateStartingLocationsToMap()
         UncivGame.Current.translations.translationActiveMods = ruleset.mods
 
         mapHolder = EditorMapHolder(this, tileMap)

--- a/core/src/com/unciv/ui/mapeditor/SaveAndLoadMapScreen.kt
+++ b/core/src/com/unciv/ui/mapeditor/SaveAndLoadMapScreen.kt
@@ -182,8 +182,8 @@ class SaveAndLoadMapScreen(mapToSave: TileMap?, save:Boolean = false, previousSc
         }
     }
 
-    fun getMapCloneForSave(mapToSave: TileMap) = mapToSave!!.clone().also {
-            it.setTransients(setUnitCivTransients = false)
-            it.translateStartingLocationsFromMap()
+    private fun getMapCloneForSave(mapToSave: TileMap) =
+        mapToSave.clone().apply {
+            setTransients(setUnitCivTransients = false)
         }
 }

--- a/core/src/com/unciv/ui/tilegroups/TileGroup.kt
+++ b/core/src/com/unciv/ui/tilegroups/TileGroup.kt
@@ -332,15 +332,6 @@ open class TileGroup(var tileInfo: TileInfo, var tileSetStrings:TileSetStrings, 
     }
 
     private fun removeMissingModReferences() {
-        // This runs from map editor too, so the Pseudo-improvements for starting locations need to stay.
-        // The nations can be checked.
-        val improvementName = tileInfo.improvement
-        if (improvementName != null && improvementName.startsWith(TileMap.startingLocationPrefix)) {
-            val nationName = improvementName.removePrefix(TileMap.startingLocationPrefix)
-            if (!tileInfo.ruleset.nations.containsKey(nationName))
-                tileInfo.improvement = null
-        }
-
         for (unit in tileInfo.getUnits())
             if (!tileInfo.ruleset.nations.containsKey(unit.owner)) unit.removeFromTile()
     }

--- a/core/src/com/unciv/ui/utils/ImageGetter.kt
+++ b/core/src/com/unciv/ui/utils/ImageGetter.kt
@@ -254,11 +254,6 @@ object ImageGetter {
     fun getImprovementIcon(improvementName: String, size: Float = 20f): Actor {
         if (improvementName.startsWith("Remove") || improvementName == Constants.cancelImprovementOrder)
             return Table().apply { add(getImage("OtherIcons/Stop")).size(size) }
-        if (improvementName.startsWith(TileMap.startingLocationPrefix)) {
-            val nationName = improvementName.removePrefix(TileMap.startingLocationPrefix)
-            val nation = ruleset.nations[nationName]!!
-            return getNationIndicator(nation, size)
-        }
 
         val iconGroup = getImage("ImprovementIcons/$improvementName").surroundWithCircle(size)
 


### PR DESCRIPTION
Sequel to #4951 - maybe a bit over the top.

## Features:
- All traces of "StartingLocation " prefix gone except for legacy map loader
- Tile renderer learned to render them. Might benefit from some global "I'm not in the map editor" switch, but I don't think this overhead is that much costlier than that string comparison.
- Editor now places and removes them using the new structure. A starting location and an improvement on the same tile now no problem.
- (The over the top bit) any number of starting locations per nation and any number of starting locations per tile allowed - and they work! The existing placement code with the small patch from phase 1 will both choose a random one from several on offer for a nation, and prevent following up on several nations per tile. The minimum distance between two nations may be ignored, but that was also the case before = responsibility of the map maker.

## Questions:
- Hide the multi-assignment capabilities from the users?
- Is having the nation icons transparent, too, OK? I think it's fitting that they look a little ghostly.
- There's a display limit of 3 icons, but not a placement limit - a "..." or hard limit or suppress feature entirely?
- What to do with the dead code for unit placement?
- Why does TileGroupIcons render improvements with transparency, but not resources?

## Screenshozz
<details><summary>open sesame</summary>

I placed the nation icons now in the center of the tile, shows coexistence start location-improvement, and multiple choice start location:
![image](https://user-images.githubusercontent.com/63000004/130510575-7467fc4b-38d3-4ee7-a342-562afb8d97a0.png)

A start from that map - yup, it just chose one randomly:
![image](https://user-images.githubusercontent.com/63000004/130510617-608a16fc-5b80-4be0-b417-36359e9c99a4.png)

And the mad bit (it works exactly as intended!):
![image](https://user-images.githubusercontent.com/63000004/130510704-89b6831d-d5e7-4f2c-9f1d-0a090896f669.png)

</details>