### PR TITLE
units get promotions and xp bonuses from CS buildings

### DIFF
--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -888,6 +888,9 @@ class CivilizationInfo {
         for (unique in getMatchingUniques("Military Units gifted from City-States start with [] XP")) {
             placedUnit.promotions.XP += unique.params[0].toInt()
         }
+        // The unit should have bonuses from Barracks, Alhambra etc as if it was built in the CS capital
+        militaryUnit.addConstructionBonuses(placedUnit, otherCiv.getCapital().cityConstructions)
+
         // Point to the places mentioned in the message _in that order_ (debatable)
         val placedLocation = placedUnit.getTile().position
         val locations = LocationAction(listOf(placedLocation, cities.city2.location, city.location))

--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -884,12 +884,15 @@ class CivilizationInfo {
                 .toList().random()
         // placing the unit may fail - in that case stay quiet
         val placedUnit = placeUnitNearTile(city.location, militaryUnit.name) ?: return
+
+        // The unit should have bonuses from Barracks, Alhambra etc as if it was built in the CS capital
+        militaryUnit.addConstructionBonuses(placedUnit, otherCiv.getCapital().cityConstructions)
+
         // Siam gets +10 XP for all CS units
         for (unique in getMatchingUniques("Military Units gifted from City-States start with [] XP")) {
             placedUnit.promotions.XP += unique.params[0].toInt()
         }
-        // The unit should have bonuses from Barracks, Alhambra etc as if it was built in the CS capital
-        militaryUnit.addConstructionBonuses(placedUnit, otherCiv.getCapital().cityConstructions)
+
 
         // Point to the places mentioned in the message _in that order_ (debatable)
         val placedLocation = placedUnit.getTile().position

--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -334,16 +334,22 @@ class BaseUnit : INamed, INonPerpetualConstruction, ICivilopediaText {
 
         if (this.isCivilian()) return true // tiny optimization makes save files a few bytes smaller
 
+        addConstructionBonuses(unit, cityConstructions)
+
+        return true
+    }
+
+    fun addConstructionBonuses(unit: MapUnit, cityConstructions: CityConstructions) {
+        val civInfo = cityConstructions.cityInfo.civInfo
         var XP = cityConstructions.getBuiltBuildings().sumBy { it.xpForNewUnits }
 
-
         for (unique in
-            cityConstructions.cityInfo.getMatchingUniques("New [] units start with [] Experience []")
-                .filter { cityConstructions.cityInfo.matchesFilter(it.params[2]) } +
-            // Deprecated since 3.15.9
+        cityConstructions.cityInfo.getMatchingUniques("New [] units start with [] Experience []")
+            .filter { cityConstructions.cityInfo.matchesFilter(it.params[2]) } +
+                // Deprecated since 3.15.9
                 cityConstructions.cityInfo.getMatchingUniques("New [] units start with [] Experience") +
                 cityConstructions.cityInfo.getLocalMatchingUniques("New [] units start with [] Experience in this city")
-            //
+        //
         ) {
             if (unit.matchesFilter(unique.params[0]))
                 XP += unique.params[1].toInt()
@@ -351,30 +357,28 @@ class BaseUnit : INamed, INonPerpetualConstruction, ICivilopediaText {
         unit.promotions.XP = XP
 
         for (unique in
-            cityConstructions.cityInfo.getMatchingUniques("All newly-trained [] units [] receive the [] promotion")
-                .filter { cityConstructions.cityInfo.matchesFilter(it.params[1]) } +
-            // Deprecated since 3.15.9
+        cityConstructions.cityInfo.getMatchingUniques("All newly-trained [] units [] receive the [] promotion")
+            .filter { cityConstructions.cityInfo.matchesFilter(it.params[1]) } +
+                // Deprecated since 3.15.9
                 cityConstructions.cityInfo.getLocalMatchingUniques("All newly-trained [] units in this city receive the [] promotion")
-            //
+        //
         ) {
             val filter = unique.params[0]
             val promotion = unique.params.last()
 
             if (unit.matchesFilter(filter) ||
                 (
-                    filter == "relevant" &&
-                        civInfo.gameInfo.ruleSet.unitPromotions.values
-                        .any {
-                            it.name == promotion
-                            && unit.type.name in it.unitTypes
-                        }
-                )
+                        filter == "relevant" &&
+                                civInfo.gameInfo.ruleSet.unitPromotions.values
+                                    .any {
+                                        it.name == promotion
+                                                && unit.type.name in it.unitTypes
+                                    }
+                        )
             ) {
                 unit.promotions.addPromotion(promotion, isFree = true)
             }
         }
-
-        return true
     }
 
 


### PR DESCRIPTION
As described in #4602.
Newly gifted units from militaristic city states start with bonus XP and promotions as if they were built by the CS.