### PR TITLE
Persistent new game setup

### DIFF
--- a/core/src/com/unciv/MainMenuScreen.kt
+++ b/core/src/com/unciv/MainMenuScreen.kt
@@ -16,7 +16,7 @@ import com.unciv.logic.map.mapgenerator.MapGenerator
 import com.unciv.models.ruleset.RulesetCache
 import com.unciv.ui.MultiplayerScreen
 import com.unciv.ui.mapeditor.*
-import com.unciv.ui.newgamescreen.GameSetupInfo
+import com.unciv.models.metadata.GameSetupInfo
 import com.unciv.ui.newgamescreen.NewGameScreen
 import com.unciv.ui.pickerscreens.ModManagementScreen
 import com.unciv.ui.saves.LoadGameScreen
@@ -236,7 +236,7 @@ class MainMenuScreen: CameraStageBaseScreen() {
     }
 
     private fun quickstartNewGame() {
-        val newGame = GameStarter.startNewGame(GameSetupInfo().apply { gameParameters.difficulty = "Chieftain" })
+        val newGame = GameStarter.startNewGame(GameSetupInfo.fromSettings("Chieftain"))
         game.loadGame(newGame)
     }
 

--- a/core/src/com/unciv/logic/GameStarter.kt
+++ b/core/src/com/unciv/logic/GameStarter.kt
@@ -2,6 +2,7 @@ package com.unciv.logic
 
 import com.badlogic.gdx.math.Vector2
 import com.unciv.Constants
+import com.unciv.UncivGame
 import com.unciv.logic.civilization.*
 import com.unciv.logic.map.BFS
 import com.unciv.logic.map.TileInfo
@@ -13,7 +14,7 @@ import com.unciv.models.ruleset.ModOptionsConstants
 import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.ruleset.RulesetCache
 import com.unciv.models.ruleset.tile.ResourceType
-import com.unciv.ui.newgamescreen.GameSetupInfo
+import com.unciv.models.metadata.GameSetupInfo
 import java.util.*
 import kotlin.collections.ArrayList
 import kotlin.collections.HashMap
@@ -90,6 +91,10 @@ object GameStarter {
         // This triggers the one-time greeting from Nation.startIntroPart1/2
         addPlayerIntros(gameInfo)
 
+        UncivGame.Current.settings.apply {
+            lastGameSetup = gameSetupInfo
+            save()
+        }
         return gameInfo
     }
 

--- a/core/src/com/unciv/logic/map/MapParameters.kt
+++ b/core/src/com/unciv/logic/map/MapParameters.kt
@@ -57,6 +57,13 @@ class MapSizeNew {
         this.radius = getEquivalentHexagonalRadius(width, height)
     }
 
+    fun clone() = MapSizeNew().also { 
+        it.name = name
+        it.radius = radius
+        it.width = width
+        it.height = height
+    }
+
     /** Check custom dimensions, fix if too extreme
      * @param worldWrap whether world wrap is on
      * @return null if size was acceptable, otherwise untranslated reason message
@@ -140,6 +147,26 @@ class MapParameters {
     var rareFeaturesRichness = 0.05f
     var resourceRichness = 0.1f
     var waterThreshold = 0f
+
+    fun clone() = MapParameters().also {
+        it.name = name
+        it.type = type
+        it.shape = shape
+        it.mapSize = mapSize.clone()
+        it.noRuins = noRuins
+        it.noNaturalWonders = noNaturalWonders
+        it.worldWrap = worldWrap
+        it.mods = LinkedHashSet(mods)
+        it.seed = seed
+        it.tilesPerBiomeArea = tilesPerBiomeArea
+        it.maxCoastExtension = maxCoastExtension
+        it.elevationExponent = elevationExponent
+        it.temperatureExtremeness = temperatureExtremeness
+        it.vegetationRichness = vegetationRichness
+        it.rareFeaturesRichness = rareFeaturesRichness
+        it.resourceRichness = resourceRichness
+        it.waterThreshold = waterThreshold
+    }
 
     fun reseed() {
         seed = System.currentTimeMillis()

--- a/core/src/com/unciv/models/metadata/GameSettings.kt
+++ b/core/src/com/unciv/models/metadata/GameSettings.kt
@@ -47,6 +47,9 @@ class GameSettings {
 
     var allowAndroidPortrait = false    // Opt-in to allow Unciv to follow a screen rotation to portrait
 
+    /** Saves the last successful new game's setup */
+    var lastGameSetup: GameSetupInfo? = null
+
     init {
         // 26 = Android Oreo. Versions below may display permanent icon in notification bar.
         if (Gdx.app?.type == Application.ApplicationType.Android && Gdx.app.version < 26) {

--- a/core/src/com/unciv/models/metadata/GameSetupInfo.kt
+++ b/core/src/com/unciv/models/metadata/GameSetupInfo.kt
@@ -1,0 +1,36 @@
+package com.unciv.models.metadata
+
+import com.badlogic.gdx.files.FileHandle
+import com.unciv.UncivGame
+import com.unciv.logic.GameInfo
+import com.unciv.logic.map.MapParameters
+import com.unciv.models.ruleset.Difficulty
+
+class GameSetupInfo(
+    var gameParameters: GameParameters = GameParameters(),
+    var mapParameters: MapParameters = MapParameters()
+) {
+    @Transient
+    var mapFile: FileHandle? = null
+
+    // This constructor is used for starting a new game from a running one, cloning the setup
+    constructor(gameInfo: GameInfo) : this(gameInfo.gameParameters.clone(), gameInfo.tileMap.mapParameters.clone())
+    // Cloning constructor used for [fromSettings] and [GameParametersScreen]
+    constructor(setup: GameSetupInfo): this(setup.gameParameters.clone(), setup.mapParameters.clone())
+
+    companion object {
+        /**
+         * Get a cloned and reseeded [GameSetupInfo] from saved settings if present, otherwise a default instance.
+         * @param defaultDifficulty Overrides difficulty only when no saved settings found, so a virgin
+         *          Unciv installation can QuickStart with a different difficulty than New Game defaults to.
+         */
+        fun fromSettings(defaultDifficulty: String? = null) = UncivGame.Current.settings.run {
+            if (lastGameSetup == null) GameSetupInfo().apply { 
+                if (defaultDifficulty != null) gameParameters.difficulty = defaultDifficulty
+            }
+            else GameSetupInfo(lastGameSetup!!).apply {
+                mapParameters.reseed()
+            }
+        }
+    }
+}

--- a/core/src/com/unciv/models/metadata/GameSetupInfo.kt
+++ b/core/src/com/unciv/models/metadata/GameSetupInfo.kt
@@ -13,9 +13,9 @@ class GameSetupInfo(
     @Transient
     var mapFile: FileHandle? = null
 
-    // This constructor is used for starting a new game from a running one, cloning the setup
+    // This constructor is used for starting a new game from a running one, cloning the setup, including map seed
     constructor(gameInfo: GameInfo) : this(gameInfo.gameParameters.clone(), gameInfo.tileMap.mapParameters.clone())
-    // Cloning constructor used for [fromSettings] and [GameParametersScreen]
+    // Cloning constructor used for [fromSettings] and [GameParametersScreen], reseeds map
     constructor(setup: GameSetupInfo): this(setup.gameParameters.clone(), setup.mapParameters.clone())
 
     companion object {

--- a/core/src/com/unciv/models/simulation/Simulation.kt
+++ b/core/src/com/unciv/models/simulation/Simulation.kt
@@ -3,7 +3,7 @@ package com.unciv.models.simulation
 import com.unciv.logic.GameInfo
 import com.unciv.logic.GameStarter
 import com.unciv.models.ruleset.VictoryType
-import com.unciv.ui.newgamescreen.GameSetupInfo
+import com.unciv.models.metadata.GameSetupInfo
 import java.lang.Integer.max
 import java.time.Duration
 import kotlin.concurrent.thread

--- a/core/src/com/unciv/ui/mapeditor/GameParametersScreen.kt
+++ b/core/src/com/unciv/ui/mapeditor/GameParametersScreen.kt
@@ -5,6 +5,7 @@ import com.unciv.UncivGame
 import com.unciv.models.ruleset.RulesetCache
 import com.unciv.models.translations.tr
 import com.unciv.ui.newgamescreen.GameOptionsTable
+import com.unciv.models.metadata.GameSetupInfo
 import com.unciv.ui.newgamescreen.PlayerPickerTable
 import com.unciv.ui.newgamescreen.IPreviousScreen
 import com.unciv.ui.pickerscreens.PickerScreen
@@ -18,7 +19,7 @@ import com.unciv.ui.utils.*
  * @param [mapEditorScreen] previous screen from map editor.
  */
 class GameParametersScreen(var mapEditorScreen: MapEditorScreen): IPreviousScreen, PickerScreen(disableScroll = true) {
-    override var gameSetupInfo = mapEditorScreen.gameSetupInfo.clone()
+    override var gameSetupInfo = GameSetupInfo(mapEditorScreen.gameSetupInfo)
     override var ruleset = RulesetCache.getComplexRuleset(gameSetupInfo.gameParameters.mods)
     var playerPickerTable = PlayerPickerTable(this, gameSetupInfo.gameParameters)
     var gameOptionsTable = GameOptionsTable(this) { desiredCiv: String -> playerPickerTable.update(desiredCiv) }

--- a/core/src/com/unciv/ui/mapeditor/MapEditorScreen.kt
+++ b/core/src/com/unciv/ui/mapeditor/MapEditorScreen.kt
@@ -10,7 +10,7 @@ import com.unciv.logic.map.TileInfo
 import com.unciv.logic.map.TileMap
 import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.ruleset.RulesetCache
-import com.unciv.ui.newgamescreen.GameSetupInfo
+import com.unciv.models.metadata.GameSetupInfo
 import com.unciv.ui.utils.*
 
 class MapEditorScreen(): CameraStageBaseScreen() {

--- a/core/src/com/unciv/ui/newgamescreen/IPreviousScreen.kt
+++ b/core/src/com/unciv/ui/newgamescreen/IPreviousScreen.kt
@@ -1,6 +1,7 @@
 package com.unciv.ui.newgamescreen
 
 import com.badlogic.gdx.scenes.scene2d.Stage
+import com.unciv.models.metadata.GameSetupInfo
 import com.unciv.models.ruleset.Ruleset
 
 /**

--- a/core/src/com/unciv/ui/newgamescreen/NewGameScreen.kt
+++ b/core/src/com/unciv/ui/newgamescreen/NewGameScreen.kt
@@ -1,7 +1,6 @@
 package com.unciv.ui.newgamescreen
 
 import com.badlogic.gdx.Gdx
-import com.badlogic.gdx.files.FileHandle
 import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.scenes.scene2d.ui.SelectBox
 import com.badlogic.gdx.scenes.scene2d.ui.Skin
@@ -9,41 +8,24 @@ import com.badlogic.gdx.utils.Array
 import com.unciv.UncivGame
 import com.unciv.logic.*
 import com.unciv.logic.civilization.PlayerType
-import com.unciv.logic.map.MapParameters
 import com.unciv.logic.map.MapType
-import com.unciv.models.metadata.GameParameters
+import com.unciv.models.metadata.GameSetupInfo
 import com.unciv.models.ruleset.RulesetCache
 import com.unciv.models.translations.tr
 import com.unciv.ui.pickerscreens.PickerScreen
 import com.unciv.ui.utils.*
 import com.unciv.ui.worldscreen.mainmenu.OnlineMultiplayer
 import java.util.*
-import kotlin.collections.HashSet
 import kotlin.concurrent.thread
 import com.unciv.ui.utils.AutoScrollPane as ScrollPane
 
-
-class GameSetupInfo(var gameId:String, var gameParameters: GameParameters, var mapParameters: MapParameters) {
-    var mapFile: FileHandle? = null
-    constructor() : this("", GameParameters(), MapParameters())
-    constructor(gameInfo: GameInfo) : this("", gameInfo.gameParameters.clone(), gameInfo.tileMap.mapParameters)
-    constructor(gameParameters: GameParameters, mapParameters: MapParameters) : this("", gameParameters, mapParameters)
-
-    fun clone(): GameSetupInfo {
-        val toReturn = GameSetupInfo()
-        toReturn.gameId = this.gameId
-        toReturn.gameParameters = this.gameParameters
-        toReturn.mapParameters = this.mapParameters
-        return toReturn
-    }
-}
 
 class NewGameScreen(
     private val previousScreen: CameraStageBaseScreen,
     _gameSetupInfo: GameSetupInfo? = null
 ): IPreviousScreen, PickerScreen() {
 
-    override val gameSetupInfo = _gameSetupInfo ?: GameSetupInfo()
+    override val gameSetupInfo = _gameSetupInfo ?: GameSetupInfo.fromSettings()
     override var ruleset = RulesetCache.getComplexRuleset(gameSetupInfo.gameParameters.mods) // needs to be set because the GameOptionsTable etc. depend on this
     private val newGameOptionsTable = GameOptionsTable(this, isNarrowerThan4to3()) { desiredCiv: String -> playerPickerTable.update(desiredCiv) }
 

--- a/core/src/com/unciv/ui/victoryscreen/VictoryScreen.kt
+++ b/core/src/com/unciv/ui/victoryscreen/VictoryScreen.kt
@@ -9,7 +9,7 @@ import com.unciv.models.ruleset.Policy
 import com.unciv.models.ruleset.VictoryType
 import com.unciv.models.translations.getPlaceholderParameters
 import com.unciv.models.translations.tr
-import com.unciv.ui.newgamescreen.GameSetupInfo
+import com.unciv.models.metadata.GameSetupInfo
 import com.unciv.ui.newgamescreen.NewGameScreen
 import com.unciv.ui.overviewscreen.EmpireOverviewScreen
 import com.unciv.ui.pickerscreens.PickerScreen

--- a/core/src/com/unciv/ui/worldscreen/mainmenu/WorldScreenMenuPopup.kt
+++ b/core/src/com/unciv/ui/worldscreen/mainmenu/WorldScreenMenuPopup.kt
@@ -3,7 +3,7 @@ package com.unciv.ui.worldscreen.mainmenu
 import com.badlogic.gdx.Gdx
 import com.unciv.MainMenuScreen
 import com.unciv.ui.civilopedia.CivilopediaScreen
-import com.unciv.ui.newgamescreen.GameSetupInfo
+import com.unciv.models.metadata.GameSetupInfo
 import com.unciv.ui.newgamescreen.NewGameScreen
 import com.unciv.ui.saves.LoadGameScreen
 import com.unciv.ui.saves.SaveGameScreen

--- a/desktop/src/com/unciv/app/desktop/ConsoleLauncher.kt
+++ b/desktop/src/com/unciv/app/desktop/ConsoleLauncher.kt
@@ -14,7 +14,7 @@ import com.unciv.models.metadata.Player
 import com.unciv.models.ruleset.RulesetCache
 import com.unciv.models.simulation.Simulation
 import com.unciv.models.tilesets.TileSetCache
-import com.unciv.ui.newgamescreen.GameSetupInfo
+import com.unciv.models.metadata.GameSetupInfo
 
 internal object ConsoleLauncher {
     @JvmStatic

--- a/tests/src/com/unciv/testing/SerializationTests.kt
+++ b/tests/src/com/unciv/testing/SerializationTests.kt
@@ -13,7 +13,7 @@ import com.unciv.models.metadata.GameParameters
 import com.unciv.models.metadata.GameSettings
 import com.unciv.models.metadata.Player
 import com.unciv.models.ruleset.RulesetCache
-import com.unciv.ui.newgamescreen.GameSetupInfo
+import com.unciv.models.metadata.GameSetupInfo
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test


### PR DESCRIPTION
- GameParameters and MapParameters are now saved and reused for a fresh New Game from main menu
- Save happens only when the start was successful, right before `GameStarter.startNewGame` is done
- Reuse happens from main menu New Game or Quickstart, _not_ map editor new map from current or worldscreen popup - new game from running one (or victory screen) -> **debatable**
- Moved `GameSetupInfo` to metadata - it was _very_ out of place in the ui packages
- Made cloning more consistent - defensive choice
- Removed `GameSetupInfo.gameId` : never written, only cloned. True gameId lives in GameInfo
- Tried hard not to touch MapParameters.reseed behaviour though I would liked to have made it `@ Transient`. Currently, only `Simulation` gets a verbatim clone without reseeding, and I kept it that way.
