### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,6 +136,6 @@ android/release/
 
 android/assets/mods/
 android/assets/SaveFiles/
-android/assets/GameSettingsOld.json
 android/assets/scenarios/
 android/assets/MultiplayerGames/
+android/assets/music/


### PR DESCRIPTION
Follow-up to #5017 ? Better?
- That GameSettingsOld.json was from my predecessor account 17 months ago, an unwitting inclusion of a change meant for local use only.
- Maybe inform Collaborators that `.git/info/exclude` is the correct place for 'personal' exclusions...