### PR TITLE
AI will now found & enhance religions -- minor improvement to civilian AI

### DIFF
--- a/core/src/com/unciv/logic/automation/SpecificUnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/SpecificUnitAutomation.kt
@@ -369,4 +369,27 @@ object SpecificUnitAutomation {
         }
         return false
     }
+
+    fun foundReligion(unit: MapUnit) {
+        val cityToFoundReligionAt = unit.civInfo.cities.first { !it.isHolyCity() }
+        if (unit.getTile() != cityToFoundReligionAt.getCenterTile()) {
+            unit.movement.headTowards(cityToFoundReligionAt.getCenterTile())
+            return   
+        }
+        unit.civInfo.religionManager.useGreatProphet(unit)
+        UnitActions.addStatsPerGreatPersonUsage(unit)
+    }
+    
+    fun enhanceReligion(unit: MapUnit) {
+        // Try go to a nearby city
+        if (!unit.getTile().isCityCenter())
+            UnitAutomation.tryEnterOwnClosestCity(unit)
+        
+        // If we were unable to go there this turn, unable to do anything else
+        if (!unit.getTile().isCityCenter())
+            return
+        
+        unit.civInfo.religionManager.useGreatProphet(unit)
+        UnitActions.addStatsPerGreatPersonUsage(unit)
+    }
 }

--- a/core/src/com/unciv/logic/automation/SpecificUnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/SpecificUnitAutomation.kt
@@ -376,8 +376,9 @@ object SpecificUnitAutomation {
             unit.movement.headTowards(cityToFoundReligionAt.getCenterTile())
             return   
         }
-        unit.civInfo.religionManager.useGreatProphet(unit)
-        UnitActions.addStatsPerGreatPersonUsage(unit)
+        
+        UnitActions.getFoundReligionAction(unit)()
+        
     }
     
     fun enhanceReligion(unit: MapUnit) {
@@ -389,7 +390,6 @@ object SpecificUnitAutomation {
         if (!unit.getTile().isCityCenter())
             return
         
-        unit.civInfo.religionManager.useGreatProphet(unit)
-        UnitActions.addStatsPerGreatPersonUsage(unit)
+        UnitActions.getEnhanceReligionAction(unit)()
     }
 }

--- a/core/src/com/unciv/logic/automation/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/UnitAutomation.kt
@@ -96,6 +96,18 @@ object UnitAutomation {
             if (unit.hasUniqueToBuildImprovements)
                 return WorkerAutomation.automateWorkerAction(unit)
 
+            if (unit.hasUnique("May found a religion")
+                && unit.civInfo.religionManager.religionState < ReligionState.Religion
+                && unit.civInfo.religionManager.mayFoundReligionAtAll(unit)
+            )
+                return SpecificUnitAutomation.foundReligion(unit)
+
+            if (unit.hasUnique("May enhance a religion")
+                && unit.civInfo.religionManager.religionState < ReligionState.EnhancedReligion
+                && unit.civInfo.religionManager.mayEnhanceReligionAtAll(unit)
+            )
+                return SpecificUnitAutomation.enhanceReligion(unit)
+
             if (unit.hasUnique(Constants.workBoatsUnique))
                 return SpecificUnitAutomation.automateWorkBoats(unit)
 
@@ -104,19 +116,7 @@ object UnitAutomation {
 
             if (unit.hasUnique("Can construct []"))
                 return SpecificUnitAutomation.automateImprovementPlacer(unit) // includes great people plus moddable units
-            
-            if (unit.hasUnique("May found a religion") 
-                && unit.civInfo.religionManager.religionState < ReligionState.Religion 
-                && unit.civInfo.religionManager.mayFoundReligionAtAll(unit)
-            )
-                return SpecificUnitAutomation.foundReligion(unit)
-            
-            if (unit.hasUnique("May enhance a religion") 
-                && unit.civInfo.religionManager.religionState < ReligionState.EnhancedReligion
-                && unit.civInfo.religionManager.mayEnhanceReligionAtAll(unit)
-            )
-                return SpecificUnitAutomation.enhanceReligion(unit)
-            
+
             // ToDo: automation of great people skills (may speed up construction, provides a science boost, etc.)
             
             return // The AI doesn't know how to handle unknown civilian units

--- a/core/src/com/unciv/logic/automation/WorkerAutomation.kt
+++ b/core/src/com/unciv/logic/automation/WorkerAutomation.kt
@@ -124,19 +124,6 @@ class WorkerAutomation(
      * Automate one Worker - decide what to do and where, move, start or continue work.
      */
     fun automateWorkerAction(unit: MapUnit) {
-
-        // This is a little 'Bugblatter Beast of Traal': Run if we can attack an enemy
-        // Cheaper than determining which enemies could attack us next turn
-        //todo - stay when we're stacked with a good military unit???
-        val enemyUnitsInWalkingDistance = unit.movement.getDistanceToTiles().keys
-            .filter { UnitAutomation.containsEnemyMilitaryUnit(unit, it) }
-
-        if (enemyUnitsInWalkingDistance.isNotEmpty() && !unit.baseUnit.isMilitary()) {
-            if (WorkerAutomationConst.consoleOutput)
-                println("WorkerAutomation: ${unit.label()} -> run away")
-            return UnitAutomation.runAway(unit)
-        }
-
         val currentTile = unit.getTile()
         val tileToWork = findTileToWork(unit)
 

--- a/core/src/com/unciv/logic/civilization/ReligionManager.kt
+++ b/core/src/com/unciv/logic/civilization/ReligionManager.kt
@@ -131,19 +131,6 @@ class ReligionManager {
             greatProphetsEarned += 1
         }
     }
-    
-    fun useGreatProphet(prophet: MapUnit) {
-        if (religionState <= ReligionState.Pantheon) {
-            if (!mayFoundReligionNow(prophet)) return // How did you do this?
-            religionState = ReligionState.FoundingReligion
-            foundingCityId = prophet.getTile().getCity()!!.id
-            prophet.destroy()
-        } else if (religionState == ReligionState.Religion) {
-            if (!mayEnhanceReligionNow(prophet)) return
-            religionState = ReligionState.EnhancingReligion
-            prophet.destroy()
-        }
-    }
 
     fun mayFoundReligionAtAll(prophet: MapUnit): Boolean {
         if (religionState >= ReligionState.Religion) return false // Already created a major religion
@@ -178,6 +165,12 @@ class ReligionManager {
         if (prophet.getTile().getCity()!!.isHolyCity()) return false 
         // No double holy cities. Not sure if these were allowed in the base game 
         return true
+    }
+
+    fun useProphetForFoundingReligion(prophet: MapUnit) {
+        if (!mayFoundReligionNow(prophet)) return // How did you do this?
+        religionState = ReligionState.FoundingReligion
+        civInfo.religionManager.foundingCityId = prophet.getTile().getCity()!!.id
     }
     
     fun getBeliefsToChooseAtFounding(): BeliefContainer {
@@ -250,6 +243,11 @@ class ReligionManager {
         if (!mayEnhanceReligionAtAll(prophet)) return false
         if (!prophet.getTile().isCityCenter()) return false
         return true
+    }
+
+    fun useProphetForEnhancingReligion(prophet: MapUnit) {
+        if (!mayFoundReligionNow(prophet)) return // How did you do this?
+        religionState = ReligionState.EnhancingReligion
     }
 
     fun getBeliefsToChooseAtEnhancing(): BeliefContainer {

--- a/core/src/com/unciv/logic/civilization/ReligionManager.kt
+++ b/core/src/com/unciv/logic/civilization/ReligionManager.kt
@@ -137,9 +137,11 @@ class ReligionManager {
             if (!mayFoundReligionNow(prophet)) return // How did you do this?
             religionState = ReligionState.FoundingReligion
             foundingCityId = prophet.getTile().getCity()!!.id
+            prophet.destroy()
         } else if (religionState == ReligionState.Religion) {
             if (!mayEnhanceReligionNow(prophet)) return
             religionState = ReligionState.EnhancingReligion
+            prophet.destroy()
         }
     }
 
@@ -173,6 +175,8 @@ class ReligionManager {
     fun mayFoundReligionNow(prophet: MapUnit): Boolean {
         if (!mayFoundReligionAtAll(prophet)) return false
         if (!prophet.getTile().isCityCenter()) return false
+        if (prophet.getTile().getCity()!!.isHolyCity()) return false 
+        // No double holy cities. Not sure if these were allowed in the base game 
         return true
     }
     

--- a/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
+++ b/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
@@ -289,7 +289,6 @@ class UnitMovementAlgorithms(val unit:MapUnit) {
                     .filter { unit.movement.canParadropOn(it) }
             else ->
                 unit.movement.getDistanceToTiles().keys.asSequence()
-
         }
     }
 

--- a/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
@@ -489,7 +489,6 @@ object UnitActions {
             action = {
                 addStatsPerGreatPersonUsage(unit)
                 unit.civInfo.religionManager.useGreatProphet(unit)
-                unit.destroy()
             }.takeIf { unit.civInfo.religionManager.mayFoundReligionNow(unit) }
         )
     }
@@ -502,7 +501,6 @@ object UnitActions {
             action = {
                 addStatsPerGreatPersonUsage(unit)
                 unit.civInfo.religionManager.useGreatProphet(unit)
-                unit.destroy()
             }.takeIf { unit.civInfo.religionManager.mayEnhanceReligionNow(unit) }
         )
     }
@@ -650,7 +648,7 @@ object UnitActions {
             otherCiv.addNotification("[${unit.civInfo}] has stolen your territory!", unit.currentTile.position, unit.civInfo.civName, NotificationIcon.War)
     }
 
-    private fun addStatsPerGreatPersonUsage(unit: MapUnit) {
+    fun addStatsPerGreatPersonUsage(unit: MapUnit) {
         if (!unit.isGreatPerson()) return
         
         val civInfo = unit.civInfo

--- a/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
@@ -8,6 +8,7 @@ import com.unciv.logic.city.CityInfo
 import com.unciv.logic.civilization.CivilizationInfo
 import com.unciv.logic.civilization.NotificationIcon
 import com.unciv.logic.civilization.PlayerType
+import com.unciv.logic.civilization.ReligionState
 import com.unciv.logic.civilization.diplomacy.DiplomacyFlags
 import com.unciv.logic.civilization.diplomacy.DiplomaticModifiers
 import com.unciv.logic.map.MapUnit
@@ -486,23 +487,33 @@ object UnitActions {
         if (!unit.hasUnique("May found a religion")) return 
         if (!unit.civInfo.religionManager.mayFoundReligionAtAll(unit)) return
         actionList += UnitAction(UnitActionType.FoundReligion,
-            action = {
-                addStatsPerGreatPersonUsage(unit)
-                unit.civInfo.religionManager.useGreatProphet(unit)
-            }.takeIf { unit.civInfo.religionManager.mayFoundReligionNow(unit) }
+            action = getFoundReligionAction(unit).takeIf { unit.civInfo.religionManager.mayFoundReligionNow(unit) }
         )
     }
     
+    fun getFoundReligionAction(unit: MapUnit): () -> Unit {
+        return {
+            addStatsPerGreatPersonUsage(unit)
+            unit.civInfo.religionManager.useProphetForFoundingReligion(unit)
+            unit.destroy()
+        }
+    }
+
     private fun addEnhanceReligionAction(unit: MapUnit, actionList: ArrayList<UnitAction>) {
         if (!unit.hasUnique("May enhance a religion")) return
         if (!unit.civInfo.religionManager.mayEnhanceReligionAtAll(unit)) return
         actionList += UnitAction(UnitActionType.EnhanceReligion,
             title = "Enhance [${unit.civInfo.religionManager.religion!!.name}]",
-            action = {
-                addStatsPerGreatPersonUsage(unit)
-                unit.civInfo.religionManager.useGreatProphet(unit)
-            }.takeIf { unit.civInfo.religionManager.mayEnhanceReligionNow(unit) }
+            action = getEnhanceReligionAction(unit).takeIf { unit.civInfo.religionManager.mayEnhanceReligionNow(unit) }
         )
+    }
+    
+    fun getEnhanceReligionAction(unit: MapUnit): () -> Unit {
+        return {
+            addStatsPerGreatPersonUsage(unit)
+            unit.civInfo.religionManager.useProphetForEnhancingReligion(unit)
+            unit.destroy()
+        }
     }
 
     private fun addActionsWithLimitedUses(unit: MapUnit, actionList: ArrayList<UnitAction>, tile: TileInfo) {


### PR DESCRIPTION
This PR adds simple functionality for AI players to found and enhance religions.
It also gives an AI for prophets to use their 'found religion' and 'enhance religion' actions, though no other actions are supported as of yet, most notably 'spread religion'.
The beliefs for these are chosen randomly, I'll port the AI from the original in another PR.

I've also made some changes to automated civilian movements, mostly that if there is danger nearby they will always try to flee to either a city or a military unit, hopefully leading to less of them being destroyed and/or captured.