### PR TITLE
fix duplicated city-state bonus bug

### DIFF
--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -1160,11 +1160,12 @@ class CivilizationInfo {
         if (!isCityState())
             return false
         val eraInfo = getEraObject()
-        val bonuses = if (eraInfo == null) null
+        val allyBonuses = if (eraInfo == null) null
             else eraInfo.allyBonus[cityStateType.name]
-        if (bonuses != null) {
+        if (allyBonuses != null) {
             // Defined city states in json
-            bonuses.addAll(eraInfo!!.friendBonus[cityStateType.name]!!)
+            val bonuses = allyBonuses + eraInfo!!.friendBonus[cityStateType.name]!!
+            println(bonuses)
             for (bonus in bonuses) {
                 if (statType == Stat.Happiness && bonus.getPlaceholderText() == "Provides [] Happiness")
                     return true

--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -1165,7 +1165,6 @@ class CivilizationInfo {
         if (allyBonuses != null) {
             // Defined city states in json
             val bonuses = allyBonuses + eraInfo!!.friendBonus[cityStateType.name]!!
-            println(bonuses)
             for (bonus in bonuses) {
                 if (statType == Stat.Happiness && bonus.getPlaceholderText() == "Provides [] Happiness")
                     return true


### PR DESCRIPTION
Fixes #5037 
The `canGiveStat` function I wrote was unintentionally duplicating the allyBonus list for certain city-states every turn. Sorry.