### PR TITLE
Refactored some code and uniques

### DIFF
--- a/android/assets/jsons/Civ V - Vanilla/Buildings.json
+++ b/android/assets/jsons/Civ V - Vanilla/Buildings.json
@@ -717,7 +717,7 @@
 		"culture": 1,
 		"isWonder": true,
 		"greatPersonPoints": {"Great Artist": 1},
-		"uniques": ["Unhappiness from population decreased by [10]%"],
+		"uniques": ["[-10]% unhappiness from population [in all cities]"],
 		"requiredTech": "Banking",
 		"quote": "'Most of us can, as we choose, make of this world either a palace or a prison' - John Lubbock"
 	},
@@ -969,7 +969,7 @@
 		"culture": 1,
 		"isWonder": true,
 		"greatPersonPoints": {"Great Engineer": 2},
-		"uniques": ["[+1 Production] from every specialist"],
+		"uniques": ["[+1 Production] from every specialist [in all cities]"],
 		"requiredTech": "Replaceable Parts",
 		"quote": "'Give me your tired, your poor, your huddled masses yearning to breathe free, the wretched refuse of your teeming shore. Send these, the homeless, tempest-tossed to me, I lift my lamp beside the golden door!'  - Emma Lazarus"
 	},
@@ -1085,7 +1085,7 @@
 		"cost": 300,
 		"maintenance": 1,
 		"requiredTech": "Telecommunications",
-		"uniques": ["Population loss from nuclear attacks -[75]%"]
+		"uniques": ["Population loss from nuclear attacks [-75]% [in this city]"]
 	},
 	{
 		"name": "SS Cockpit",

--- a/android/assets/jsons/Civ V - Vanilla/Nations.json
+++ b/android/assets/jsons/Civ V - Vanilla/Nations.json
@@ -314,7 +314,7 @@
 		"outerColor": [16,126,5],
 		"innerColor": [255,153,51],
 		"uniqueName": "Population Growth",
-		"uniques": ["Unhappiness from number of Cities doubled", "Unhappiness from population decreased by [50]%"],
+		"uniques": ["Unhappiness from number of Cities doubled", "[-50%]% unhappiness from population [in all cities]"],
 		"cities": ["Delhi","Mumbai","Vijayanagara","Pataliputra","Varanasi","Agra","Calcutta","Lahore","Bangalore","Hyderabad","Madurai","Ahmedabad",
 			"Kolhapur","Prayaga","Ayodhya","Indraprastha","Mathura","Ujjain","Gulbarga","Jaunpur","Rajagriha","Sravasti","Tiruchirapalli","Thanjavur",
 			"Bodhgaya","Kushinagar","Amaravati","Gaur","Gwalior","Jaipur","Karachi"]
@@ -392,7 +392,7 @@
 		"outerColor": [26,32,96],
 		"innerColor": [255,0,0],
 		"uniqueName": "Scholars of the Jade Hall",
-        "uniques": ["[+2 Science] from every specialist", "[+2 Science] from every [Great Improvement]","Receive a tech boost when scientific buildings/wonders are built in capital"],
+        "uniques": ["[+2 Science] from every specialist [in all cities]", "[+2 Science] from every [Great Improvement]","Receive a tech boost when scientific buildings/wonders are built in capital"],
 		"cities": ["Seoul","Busan","Jeonju","Daegu","Pyongyang","Kaesong","Suwon","Gwangju","Gangneung","Hamhung","Wonju","Ulsan",
 			"Changwon","Andong","Gongju","Haeju","Cheongju","Mokpo","Dongducheon","Geoje","Suncheon","Jinju","Sangju",
 			"Rason","Gyeongju","Chungju","Sacheon","Gimje","Anju"]

--- a/android/assets/jsons/Civ V - Vanilla/Nations.json
+++ b/android/assets/jsons/Civ V - Vanilla/Nations.json
@@ -314,7 +314,7 @@
 		"outerColor": [16,126,5],
 		"innerColor": [255,153,51],
 		"uniqueName": "Population Growth",
-		"uniques": ["Unhappiness from number of Cities doubled", "[-50%]% unhappiness from population [in all cities]"],
+		"uniques": ["Unhappiness from number of Cities doubled", "[-50]% unhappiness from population [in all cities]"],
 		"cities": ["Delhi","Mumbai","Vijayanagara","Pataliputra","Varanasi","Agra","Calcutta","Lahore","Bangalore","Hyderabad","Madurai","Ahmedabad",
 			"Kolhapur","Prayaga","Ayodhya","Indraprastha","Mathura","Ujjain","Gulbarga","Jaunpur","Rajagriha","Sravasti","Tiruchirapalli","Thanjavur",
 			"Bodhgaya","Kushinagar","Amaravati","Gaur","Gwalior","Jaipur","Karachi"]

--- a/android/assets/jsons/Civ V - Vanilla/Policies.json
+++ b/android/assets/jsons/Civ V - Vanilla/Policies.json
@@ -75,7 +75,7 @@
 			},
 			{
 				"name": "Meritocracy",
-				"uniques": ["[+1 Happiness] [in all cities connected to capital]", "Unhappiness from population decreased by [5]% [in all non-occupied cities]"],
+				"uniques": ["[+1 Happiness] [in all cities connected to capital]", "[-5]% unhappiness from population [in all non-occupied cities]"],
 				"requires": ["Citizenship"],
 				"row": 2,
 				"column": 5
@@ -286,7 +286,7 @@
 		"policies": [
 			{
 				"name": "Secularism",
-				"uniques": ["[+2 Science] from every specialist"],
+				"uniques": ["[+2 Science] from every specialist [in all cities]"],
 				"row": 1,
 				"column": 2
 			},
@@ -343,7 +343,7 @@
 			},
 			{
 				"name": "Civil Society",
-				"uniques": ["-[50]% food consumption by specialists"],
+				"uniques": ["-[50]% food consumption by specialists [in all cities]"],
 				"row": 1,
 				"column": 5
 			},
@@ -356,7 +356,7 @@
 			},
 			{
 				"name": "Democracy",
-				"uniques": ["Specialists only produce [50]% of normal unhappiness"],
+				"uniques": ["[-50]% unhappiness from specialists [in all cities]"],
 				"requires": ["Civil Society"],
 				"row": 2,
 				"column": 5

--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -292,22 +292,20 @@ class GameInfo {
         for (baseUnit in ruleSet.units.values)
             baseUnit.ruleset = ruleSet
 
+        // This needs to go before tileMap.setTransients, as units need to access 
+        // the nation of their civilization when setting transients
+        for (civInfo in civilizations) civInfo.gameInfo = this
+        for (civInfo in civilizations) civInfo.setNationTransient()
+        
         tileMap.setTransients(ruleSet)
 
         if (currentPlayer == "") currentPlayer = civilizations.first { it.isPlayerCivilization() }.civName
         currentPlayerCiv = getCivilization(currentPlayer)
 
-        // this is separated into 2 loops because when we activate updateVisibleTiles in civ.setTransients,
-        //  we try to find new civs, and we check if civ is barbarian, which we can't know unless the gameInfo is already set.
-        for (civInfo in civilizations) civInfo.gameInfo = this
-
         difficultyObject = ruleSet.difficulties[difficulty]!!
         
         for (religion in religions.values) religion.setTransients(this)
 
-        // This doesn't HAVE to go here, but why not.
-
-        for (civInfo in civilizations) civInfo.setNationTransient()
         for (civInfo in civilizations) civInfo.setTransients()
         for (civInfo in civilizations) civInfo.updateSightAndResources()
 

--- a/core/src/com/unciv/logic/automation/NextTurnAutomation.kt
+++ b/core/src/com/unciv/logic/automation/NextTurnAutomation.kt
@@ -488,7 +488,7 @@ object NextTurnAutomation {
 
             val unitsInBorder = otherCiv.getCivUnits().count { !it.isCivilian() && it.getTile().getOwner() == civInfo }
             if (unitsInBorder > 0 && diplomacy.relationshipLevel() < RelationshipLevel.Friend) {
-                diplomacy.influence -= 10f
+                diplomacy.addInfluence(-10f)
                 if (!diplomacy.hasFlag(DiplomacyFlags.BorderConflict)) {
                     otherCiv.popupAlerts.add(PopupAlert(AlertType.BorderConflict, civInfo.civName))
                     diplomacy.setFlag(DiplomacyFlags.BorderConflict, 10)

--- a/core/src/com/unciv/logic/battle/MapUnitCombatant.kt
+++ b/core/src/com/unciv/logic/battle/MapUnitCombatant.kt
@@ -4,6 +4,7 @@ import com.unciv.logic.civilization.CivilizationInfo
 import com.unciv.logic.map.MapUnit
 import com.unciv.logic.map.TileInfo
 import com.unciv.models.UncivSound
+import com.unciv.models.ruleset.Unique
 import com.unciv.models.ruleset.unit.UnitType
 
 class MapUnitCombatant(val unit: MapUnit) : ICombatant {
@@ -43,5 +44,6 @@ class MapUnitCombatant(val unit: MapUnit) : ICombatant {
         return unit.name+" of "+unit.civInfo.civName
     }
 
+    fun getMatchingUniques(uniqueTemplate: String): Sequence<Unique> = unit.getMatchingUniques(uniqueTemplate)
 
 }

--- a/core/src/com/unciv/logic/city/CityInfo.kt
+++ b/core/src/com/unciv/logic/city/CityInfo.kt
@@ -141,7 +141,7 @@ class CityInfo {
 
         civInfo.policies.tryToAddPolicyBuildings()
 
-        for (unique in civInfo.getMatchingUniques("Gain a free [] []")) {
+        for (unique in getMatchingUniques("Gain a free [] []")) {
             val freeBuildingName = unique.params[0]
             if (matchesFilter(unique.params[1])) {
                 if (!cityConstructions.isBuilt(freeBuildingName))
@@ -370,15 +370,15 @@ class CityInfo {
             }
 
             // Sweden UP
-            for (otherciv in civInfo.getKnownCivs()) {
-                if (!civInfo.getDiplomacyManager(otherciv)
+            for (otherCiv in civInfo.getKnownCivs()) {
+                if (!civInfo.getDiplomacyManager(otherCiv)
                         .hasFlag(DiplomacyFlags.DeclarationOfFriendship)
                 ) continue
 
-                for (ourunique in civInfo.getMatchingUniques("When declaring friendship, both parties gain a []% boost to great person generation"))
-                    allGppPercentageBonus += ourunique.params[0].toInt()
-                for (theirunique in otherciv.getMatchingUniques("When declaring friendship, both parties gain a []% boost to great person generation"))
-                    allGppPercentageBonus += theirunique.params[0].toInt()
+                for (ourUnique in civInfo.getMatchingUniques("When declaring friendship, both parties gain a []% boost to great person generation"))
+                    allGppPercentageBonus += ourUnique.params[0].toInt()
+                for (theirUnique in otherCiv.getMatchingUniques("When declaring friendship, both parties gain a []% boost to great person generation"))
+                    allGppPercentageBonus += theirUnique.params[0].toInt()
             }
 
             for (unitName in gppCounter.keys)

--- a/core/src/com/unciv/logic/city/CityInfoConquestFunctions.kt
+++ b/core/src/com/unciv/logic/city/CityInfoConquestFunctions.kt
@@ -181,7 +181,7 @@ class CityInfoConquestFunctions(val city: CityInfo){
                     .addModifier(DiplomaticModifiers.CapturedOurCities, respectForLiberatingOurCity)
         } else {
             //Liberating a city state gives a large amount of influence, and peace
-            foundingCiv.getDiplomacyManager(conqueringCiv).influence = 90f
+            foundingCiv.getDiplomacyManager(conqueringCiv).setInfluence(90f)
             if (foundingCiv.isAtWarWith(conqueringCiv)) {
                 val tradeLogic = TradeLogic(foundingCiv, conqueringCiv)
                 tradeLogic.currentTrade.ourOffers.add(TradeOffer(Constants.peaceTreaty, TradeType.Treaty))

--- a/core/src/com/unciv/logic/city/CityReligion.kt
+++ b/core/src/com/unciv/logic/city/CityReligion.kt
@@ -294,10 +294,7 @@ class CityInfoReligionManager {
         
         for (unique in cityInfo.getMatchingUniques("[]% Natural religion spread [] with []"))
             if (pressuredCity.matchesFilter(unique.params[1]) 
-                && (
-                    cityInfo.civInfo.tech.isResearched(unique.params[2]) 
-                    || cityInfo.civInfo.policies.isAdopted(unique.params[2])
-                )
+                && cityInfo.civInfo.hasTechOrPolicy(unique.params[2])
             ) pressure *= 1f + unique.params[0].toFloat() / 100f
         
         return pressure.toInt()

--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -506,6 +506,9 @@ class CivilizationInfo {
         return if (!gameInfo.hasReligionEnabled()) greatPeople.filter { !it.uniques.contains("Great Person - [Faith]")}.toHashSet()
         else greatPeople.toHashSet()
     }
+    
+    fun hasTechOrPolicy(techOrPolicyName: String) =
+        tech.isResearched(techOrPolicyName) || policies.isAdopted(techOrPolicyName)
 
     //endregion
 
@@ -877,8 +880,7 @@ class CivilizationInfo {
         if (!cityState.isCityState()) throw Exception("You can only gain influence with City-States!")
         addGold(-giftAmount)
         cityState.addGold(giftAmount)
-        cityState.getDiplomacyManager(this).influence += influenceGainedByGift(giftAmount)
-        cityState.updateAllyCivForCityState()
+        cityState.getDiplomacyManager(this).addInfluence(influenceGainedByGift(giftAmount).toFloat())
         updateStatsForNextTurn()
     }
 
@@ -936,20 +938,20 @@ class CivilizationInfo {
     }
 
     fun addProtectorCiv(otherCiv: CivilizationInfo) {
-        if(!this.isCityState() or !otherCiv.isMajorCiv() or otherCiv.isDefeated()) return
-        if(!knows(otherCiv) or isAtWarWith(otherCiv)) return //Exception
+        if (!isCityState() || !otherCiv.isMajorCiv() || otherCiv.isDefeated()) return
+        if (!knows(otherCiv) || isAtWarWith(otherCiv)) return //Exception
 
         val diplomacy = getDiplomacyManager(otherCiv.civName)
         diplomacy.diplomaticStatus = DiplomaticStatus.Protector
     }
 
     fun removeProtectorCiv(otherCiv: CivilizationInfo) {
-        if(!this.isCityState() or !otherCiv.isMajorCiv() or otherCiv.isDefeated()) return
-        if(!knows(otherCiv) or isAtWarWith(otherCiv)) return //Exception
+        if (!isCityState() || !otherCiv.isMajorCiv() || otherCiv.isDefeated()) return
+        if (!knows(otherCiv) || isAtWarWith(otherCiv)) return //Exception
 
         val diplomacy = getDiplomacyManager(otherCiv.civName)
         diplomacy.diplomaticStatus = DiplomaticStatus.Peace
-        diplomacy.influence -= 20
+        diplomacy.addInfluence(-20f)
     }
 
     fun updateAllyCivForCityState() {
@@ -1132,9 +1134,8 @@ class CivilizationInfo {
         if (!cityState.isCityState()) throw Exception("You can only demand gold from City-States!")
         val goldAmount = goldGainedByTribute()
         addGold(goldAmount)
-        cityState.getDiplomacyManager(this).influence -= 15
+        cityState.getDiplomacyManager(this).addInfluence(-15f)
         cityState.addFlag(CivFlags.RecentlyBullied.name, 20)
-        cityState.updateAllyCivForCityState()
         updateStatsForNextTurn()
     }
 
@@ -1149,9 +1150,8 @@ class CivilizationInfo {
         if (buildableWorkerLikeUnits.isEmpty()) return  // Bad luck?
         placeUnitNearTile(cityState.getCapital().location, buildableWorkerLikeUnits.keys.random())
 
-        cityState.getDiplomacyManager(this).influence -= 50
+        cityState.getDiplomacyManager(this).addInfluence(-50f)
         cityState.addFlag(CivFlags.RecentlyBullied.name, 20)
-        cityState.updateAllyCivForCityState()
     }
 
     fun canGiveStat(statType: Stat): Boolean {

--- a/core/src/com/unciv/logic/civilization/QuestManager.kt
+++ b/core/src/com/unciv/logic/civilization/QuestManager.kt
@@ -343,7 +343,7 @@ class QuestManager {
         val rewardInfluence = civInfo.gameInfo.ruleSet.quests[assignedQuest.questName]!!.influece
         val assignee = civInfo.gameInfo.getCivilization(assignedQuest.assignee)
 
-        civInfo.getDiplomacyManager(assignedQuest.assignee).influence += rewardInfluence
+        civInfo.getDiplomacyManager(assignedQuest.assignee).addInfluence(rewardInfluence)
         if (rewardInfluence > 0)
             assignee.addNotification(
                 "[${civInfo.civName}] rewarded you with [${rewardInfluence.toInt()}] influence for completing the [${assignedQuest.questName}] quest.",

--- a/core/src/com/unciv/logic/civilization/ReligionManager.kt
+++ b/core/src/com/unciv/logic/civilization/ReligionManager.kt
@@ -110,7 +110,7 @@ class ReligionManager {
             civInfo.gameInfo.gameParameters.gameSpeed.modifier
         
         for (unique in civInfo.getMatchingUniques("[]% Faith cost of generating Great Prophet equivalents"))
-            faithCost *= 1f + unique.params[0].toFloat() / 100f
+            faithCost *= unique.params[0].toPercent()
         
         return faithCost.toInt()
     }

--- a/core/src/com/unciv/logic/civilization/ReligionManager.kt
+++ b/core/src/com/unciv/logic/civilization/ReligionManager.kt
@@ -6,6 +6,7 @@ import com.unciv.models.Religion
 import com.unciv.models.ruleset.Belief
 import com.unciv.models.ruleset.BeliefType
 import com.unciv.ui.pickerscreens.BeliefContainer
+import com.unciv.ui.utils.toPercent
 import kotlin.random.Random
 
 class ReligionManager {

--- a/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
@@ -100,9 +100,7 @@ class DiplomacyManager() {
     /** For city-states. Influence is saved in the CITY STATE -> major civ Diplomacy, NOT in the major civ -> city state diplomacy.
      *  Won't go below [MINIMUM_INFLUENCE]. Note this declaration leads to Major Civs getting MINIMUM_INFLUENCE serialized, but that is ignored. */
     var influence = 0f
-        set(value) {
-            field = max(value, MINIMUM_INFLUENCE)
-        }
+        private set
         get() = if (civInfo.isAtWarWith(otherCiv())) MINIMUM_INFLUENCE else field
 
     /** Total of each turn Science during Research Agreement */
@@ -197,6 +195,15 @@ class DiplomacyManager() {
             "Neutral" -> relationshipLevel == RelationshipLevel.Neutral
             else -> false
         }
+    }
+    
+    fun addInfluence(amount: Float) {
+        setInfluence(max(influence + amount, MINIMUM_INFLUENCE))
+    }
+    
+    fun setInfluence(amount: Float) {
+        influence = amount
+        civInfo.updateAllyCivForCityState()
     }
 
     // To be run from City-State DiplomacyManager, which holds the influence. Resting point for every major civ can be different.
@@ -393,6 +400,7 @@ class DiplomacyManager() {
             val increment = getCityStateInfluenceRecovery()
             influence = min(restingPoint, influence + increment)
         }
+        civInfo.updateAllyCivForCityState()
 
         if (!civInfo.isDefeated()) { // don't display city state relationship notifications when the city state is currently defeated
             val civCapitalLocation = if (civInfo.cities.isNotEmpty()) civInfo.getCapital().location else null
@@ -658,7 +666,7 @@ class DiplomacyManager() {
                 thirdCiv.getDiplomacyManager(otherCiv).makePeace()
             // Other city states that are not our ally don't like the fact that we made peace with their enemy
             if (thirdCiv.getAllyCiv() != civInfo.civName && thirdCiv.isAtWarWith(otherCiv))
-                thirdCiv.getDiplomacyManager(civInfo).influence -= 10
+                thirdCiv.getDiplomacyManager(civInfo).addInfluence(-10f)
         }
     }
 

--- a/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
@@ -198,11 +198,11 @@ class DiplomacyManager() {
     }
     
     fun addInfluence(amount: Float) {
-        setInfluence(max(influence + amount, MINIMUM_INFLUENCE))
+        setInfluence(influence + amount)
     }
     
     fun setInfluence(amount: Float) {
-        influence = amount
+        influence = max(amount, MINIMUM_INFLUENCE)
         civInfo.updateAllyCivForCityState()
     }
 

--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -168,9 +168,10 @@ class MapUnit {
 
     fun getTile(): TileInfo = currentTile
     fun getMaxMovement(): Int {
-        if (isEmbarked()) return getEmbarkedMovement()
-
-        var movement = baseUnit.movement
+        var movement = 
+            if (isEmbarked()) 2
+            else baseUnit.movement
+        
         movement += getMatchingUniques("[] Movement").sumBy { it.params[0].toInt() }
 
         for (unique in civInfo.getMatchingUniques("+[] Movement for all [] units"))
@@ -181,6 +182,13 @@ class MapUnit {
             civInfo.hasUnique("+1 Movement for all units during Golden Age")
         )
             movement += 1
+
+        // Deprecated since 3.16.11
+            if (isEmbarked()) {
+                movement += civInfo.getMatchingUniques("Increases embarked movement +1").count()
+                if (civInfo.hasUnique("+1 Movement for all embarked units")) movement += 1
+            }
+        //
 
         return movement
     }
@@ -194,10 +202,11 @@ class MapUnit {
     fun getUniques(): ArrayList<Unique> = tempUniques
 
     fun getMatchingUniques(placeholderText: String): Sequence<Unique> =
-        tempUniques.asSequence().filter { it.placeholderText == placeholderText }
+        tempUniques.asSequence().filter { it.placeholderText == placeholderText } + 
+            civInfo.getMatchingUniques(placeholderText)
 
     fun hasUnique(unique: String): Boolean {
-        return getUniques().any { it.placeholderText == unique }
+        return getUniques().any { it.placeholderText == unique } || civInfo.hasUnique(unique)
     }
 
     fun updateUniques() {
@@ -341,7 +350,6 @@ class MapUnit {
         return range
     }
 
-
     fun isEmbarked(): Boolean {
         if (!baseUnit.isLandUnit()) return false
         return currentTile.isWater
@@ -355,13 +363,6 @@ class MapUnit {
                 it.getOwner() == to || it.getUnits().any { unit -> unit.owner == to.civName }
             }
         return false
-    }
-
-    fun getEmbarkedMovement(): Int {
-        var movement = 2
-        movement += civInfo.getMatchingUniques("Increases embarked movement +1").count()
-        if (civInfo.hasUnique("+1 Movement for all embarked units")) movement += 1
-        return movement
     }
 
     fun getUnitToUpgradeTo(): BaseUnit {

--- a/core/src/com/unciv/logic/map/TileMap.kt
+++ b/core/src/com/unciv/logic/map/TileMap.kt
@@ -392,7 +392,7 @@ class TileMap {
             unitName: String,
             civInfo: CivilizationInfo
     ): MapUnit? {
-        val unit = gameInfo.ruleSet.units[unitName]!!.getMapUnit(gameInfo.ruleSet)
+        val unit = gameInfo.ruleSet.units[unitName]!!.getMapUnit(civInfo)
 
         fun getPassableNeighbours(tileInfo: TileInfo): Set<TileInfo> =
                 tileInfo.neighbors.filter { unit.movement.canPassThrough(it) }.toSet()

--- a/core/src/com/unciv/models/ruleset/Building.kt
+++ b/core/src/com/unciv/models/ruleset/Building.kt
@@ -192,10 +192,8 @@ class Building : NamedStats(), INonPerpetualConstruction, ICivilopediaText {
         val stats = percentStatBonus?.clone() ?: Stats()
         val civInfo = cityInfo?.civInfo ?: return stats  // initial stats
 
-        val baseBuildingName = getBaseBuilding(civInfo.gameInfo.ruleSet).name
-
         for (unique in civInfo.getMatchingUniques("+[]% [] from every []")) {
-            if (unique.params[2] == baseBuildingName)
+            if (matchesFilter(unique.params[2]))
                 stats.add(Stat.valueOf(unique.params[1]), unique.params[0].toFloat())
         }
 
@@ -527,7 +525,7 @@ class Building : NamedStats(), INonPerpetualConstruction, ICivilopediaText {
                 val filter = unique.params[0]
                 if (filter in civInfo.gameInfo.ruleSet.buildings) {
                     if (civInfo.cities.none { it.cityConstructions.containsBuildingOrEquivalent(filter) }) return unique.text // Wonder is not built
-                } else if (!civInfo.policies.adoptedPolicies.contains(filter)) return "Policy is not adopted" // this reason should not be displayed
+                } else if (!civInfo.policies.isAdopted(filter)) return "Policy is not adopted" // this reason should not be displayed
             }
 
             "Requires a [] in this city" -> {
@@ -677,10 +675,6 @@ class Building : NamedStats(), INonPerpetualConstruction, ICivilopediaText {
         if (getStatPercentageBonuses(null)[stat] > 0) return true
         if (uniqueObjects.any { it.placeholderText == "[] per [] population []" && it.stats[stat] > 0 }) return true
         return false
-    }
-
-    fun getBaseBuilding(ruleset: Ruleset): Building {
-        return if (replaces == null) this else ruleset.buildings[replaces!!]!!
     }
 
     fun getImprovement(ruleset: Ruleset): TileImprovement? {

--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -191,11 +191,14 @@ class BaseUnit : INamed, INonPerpetualConstruction, ICivilopediaText {
         return textList
     }
 
-    fun getMapUnit(ruleset: Ruleset): MapUnit {
+    fun getMapUnit(civInfo: CivilizationInfo): MapUnit {
         val unit = MapUnit()
         unit.name = name
+        unit.civInfo = civInfo
 
-        unit.setTransients(ruleset) // must be after setting name because it sets the baseUnit according to the name
+        // must be after setting name & civInfo because it sets the baseUnit according to the name
+        // and the civInfo is required for using `hasUnique` when determining its movement options  
+        unit.setTransients(civInfo.gameInfo.ruleSet) 
 
         return unit
     }

--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -282,15 +282,16 @@ class BaseUnit : INamed, INonPerpetualConstruction, ICivilopediaText {
         ) return "Disabled by setting"
 
         for (unique in uniqueObjects.filter { it.placeholderText == "Unlocked with []" })
-            if (civInfo.tech.researchedTechnologies.none { it.era() == unique.params[0] || it.name == unique.params[0] }
-                    && !civInfo.policies.isAdopted(unique.params[0]))
-                return unique.text
+            // ToDo: Clean this up when eras.json is required
+            if ((civInfo.gameInfo.ruleSet.getEraNumber(unique.params[0]) != -1 && civInfo.getEraNumber() >= civInfo.gameInfo.ruleSet.getEraNumber(unique.params[0]))
+                || civInfo.hasTechOrPolicy(unique.params[0])
+            ) return unique.text
 
         for (unique in uniqueObjects.filter { it.placeholderText == "Requires []" }) {
             val filter = unique.params[0]
             if (!ignoreTechPolicyRequirements && filter in civInfo.gameInfo.ruleSet.buildings) {
                 if (civInfo.cities.none { it.cityConstructions.containsBuildingOrEquivalent(filter) }) return unique.text // Wonder is not built
-            } else if (!ignoreTechPolicyRequirements && !civInfo.policies.adoptedPolicies.contains(filter)) return "Policy is not adopted"
+            } else if (!ignoreTechPolicyRequirements && !civInfo.policies.isAdopted(filter)) return "Policy is not adopted"
         }
 
         for ((resource, amount) in getResourceRequirements())

--- a/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
@@ -770,12 +770,12 @@ object UnitActions {
                     if ((unit.isGreatPerson() && unique.params[1] == "Great Person")
                         || unit.matchesFilter(unique.params[1])
                     ) {
-                        recipient.getDiplomacyManager(unit.civInfo).addInfluence(unique.params[0].toInt() - 5)
+                        recipient.getDiplomacyManager(unit.civInfo).addInfluence(unique.params[0].toFloat() - 5f)
                         break
                     }
                 }
 
-                recipient.getDiplomacyManager(unit.civInfo).addInfluence(5)
+                recipient.getDiplomacyManager(unit.civInfo).addInfluence(5f)
             }
             else recipient.getDiplomacyManager(unit.civInfo).addModifier(DiplomaticModifiers.GaveUsUnits, 5f)
 


### PR DESCRIPTION
This PR doesn't add any features, but refactors a lot of small things in the codebase.
I started with the idea of allowing the `MapUnit.getMatchingUniques` access to the uniques of the main civ, like I had done previously with cities, but ended up just changing a lot of random things. Included are:
- `MapUnit.getMatchingUniques` now has access to the civ uniques
- Added `CivilizationInfo.hasTechOrPolicy`, to easier check for `with []` uniques
- Made the setter of the `influence` variable for city states private, only allowing access via `DiplomacyManager.addInfluence` and `.setInfluence` so the allying civ is always updated
- Fixed a bug where trading away luxuries provided by city states would still give additional bonuses from luxuries from city states
- Converted some things from `1 + thing.toFloat() / 100f` to `thing.toPercent()`
- Refactored the way embarked movement is determined
- Rewrote a few uniques to allow them to be used not only for techs/policies/founding beliefs but also buildings/follower beliefs:

Added uniques:
- "[signedAmount]% unhappiness from population [cityFilter]"
- "[Stats] from every specialist [cityFilter]"
- "Population loss from nuclear attacks [signedAmount]% [cityFilter]"
- "[signedAmount]% unhappiness from specialists [cityFilter]"
- "[signedAmount]% unhappiness from population [cityFilter]"

Deprecated uniques:
- "Unhappiness from population decreased by [amount]%"
- "[Stats] from every specialist"
- "Population loss from nuclear attacks -[amount]%"
- "+2 Culture per turn from cities before discovering Steam Power"
- "Specialists only produce [amount]% of normal unhappiness"
- "Unhappiness from population decreased by [amount]%"
- "Unhappiness from population decreased by [amount]% [cityFilter]"
- "Increases embarked movement +1"
- "+1 Movement for all embarked units" -- Use "+[1] movement for all [Embarked] units" instead