### PR TITLE
Refactor more code, hopefully increasing maintainability

### DIFF
--- a/android/assets/jsons/Civ V - Vanilla/Buildings.json
+++ b/android/assets/jsons/Civ V - Vanilla/Buildings.json
@@ -1064,7 +1064,8 @@
 		"name": "Apollo Program",
 		"cost": 750,
 		"isNationalWonder": true,
-		"uniques": ["Enables construction of Spaceship parts", "Triggers a global alert upon completion"],
+		"uniques": ["Enables construction of Spaceship parts", "Triggers a global alert upon completion", 
+			"Hidden when [Scientific] Victory is disabled"],
 		"requiredTech": "Rocketry"
 	},
 
@@ -1091,7 +1092,7 @@
 		"name": "SS Cockpit",
 		"requiredResource": "Aluminum",
 		"requiredTech": "Satellites",
-		"uniques": ["Spaceship part", "Triggers a global alert upon completion", "Cannot be purchased"]
+		"uniques": ["Spaceship part", "Triggers a global alert upon completion", "Cannot be purchased", "Hidden when [Scientific] Victory is disabled"]
 	},
 	{
 		"name": "Hubble Space Telescope",
@@ -1109,7 +1110,7 @@
 		"name": "SS Booster",
 		"requiredResource": "Aluminum",
 		"requiredTech": "Advanced Ballistics",
-		"uniques": ["Spaceship part", "Triggers a global alert upon completion", "Cannot be purchased"]
+		"uniques": ["Spaceship part", "Triggers a global alert upon completion", "Cannot be purchased", "Hidden when [Scientific] Victory is disabled"]
 	},
 	{
 		"name": "Spaceship Factory",
@@ -1136,13 +1137,13 @@
 		"name": "SS Engine",
 		"requiredResource": "Aluminum",
 		"requiredTech": "Particle Physics",
-		"uniques": ["Spaceship part", "Triggers a global alert upon completion", "Cannot be purchased"]
+		"uniques": ["Spaceship part", "Triggers a global alert upon completion", "Cannot be purchased", "Hidden when [Scientific] Victory is disabled"]
 	},
 	{
 		"name": "SS Stasis Chamber",
 		"requiredResource": "Aluminum",
 		"requiredTech": "Nanotechnology",
-		"uniques": ["Spaceship part", "Triggers a global alert upon completion", "Cannot be purchased"]
+		"uniques": ["Spaceship part", "Triggers a global alert upon completion", "Cannot be purchased", "Hidden when [Scientific] Victory is disabled"]
 	},
 
 	// All Eras

--- a/core/src/com/unciv/logic/city/CityConstructions.kt
+++ b/core/src/com/unciv/logic/city/CityConstructions.kt
@@ -375,14 +375,10 @@ class CityConstructions {
             // Perpetual constructions should always still be valid (I hope)
             if (construction is PerpetualConstruction) continue
             
-            val rejectionReason = 
-                (construction as INonPerpetualConstruction).getRejectionReason(this)
+            val rejectionReasons = 
+                (construction as INonPerpetualConstruction).getRejectionReasons(this)
 
-            if (rejectionReason.endsWith("lready built")
-                    || rejectionReason.startsWith("Cannot be built with")
-                    || rejectionReason.startsWith("Don't need to build any more")
-                    || rejectionReason.startsWith("Obsolete")
-            ) {
+            if (rejectionReasons.hasAReasonToBeRemovedFromQueue()) {
                 if (construction is Building) {
                     // Production put into wonders gets refunded
                     if (construction.isWonder && getWorkDone(constructionName) != 0) {
@@ -392,7 +388,7 @@ class CityConstructions {
                     }
                 } else if (construction is BaseUnit) {
                     // Production put into upgradable units gets put into upgraded version
-                    if (rejectionReason.startsWith("Obsolete") && construction.upgradesTo != null) {
+                    if (rejectionReasons.all { it == RejectionReason.Obsoleted } && construction.upgradesTo != null) {
                         // I'd love to use the '+=' operator but since 'inProgressConstructions[...]' can be null, kotlin doesn't allow me to
                         if (!inProgressConstructions.contains(construction.upgradesTo)) {
                             inProgressConstructions[construction.upgradesTo!!] = getWorkDone(constructionName)

--- a/core/src/com/unciv/logic/city/IConstruction.kt
+++ b/core/src/com/unciv/logic/city/IConstruction.kt
@@ -31,17 +31,17 @@ interface INonPerpetualConstruction : IConstruction, INamed, IHasUniques {
         return uniqueObjects.any { it.placeholderText == uniqueTemplate }
     }
     
-    fun canBePurchasedWithStat(cityInfo: CityInfo, stat: Stat, ignoreCityRequirements: Boolean = false): Boolean {
+    fun canBePurchasedWithStat(cityInfo: CityInfo?, stat: Stat): Boolean {
         if (stat in listOf(Stat.Production, Stat.Happiness)) return false
         if ("Cannot be purchased" in uniques) return false
         if (stat == Stat.Gold) return !uniques.contains("Unbuildable")
         // Can be purchased with [Stat] [cityFilter]
         if (getMatchingUniques("Can be purchased with [] []")
-                .any { it.params[0] == stat.name && (ignoreCityRequirements || cityInfo.matchesFilter(it.params[1])) }
+                .any { it.params[0] == stat.name && (cityInfo != null && cityInfo.matchesFilter(it.params[1])) }
         ) return true
         // Can be purchased for [amount] [Stat] [cityFilter]
         if (getMatchingUniques("Can be purchased for [] [] []")
-                .any { it.params[1] == stat.name && ( ignoreCityRequirements || cityInfo.matchesFilter(it.params[2])) }
+                .any { it.params[1] == stat.name && (cityInfo != null && cityInfo.matchesFilter(it.params[2])) }
         ) return true
         return false
     }

--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -927,10 +927,7 @@ class CivilizationInfo {
         addNotification( "[${givingCityState.civName}] gave us a [${giftedUnit.name}] as a gift!", locations, givingCityState.civName, giftedUnit.name)
     }
 
-    fun turnsForGreatPersonFromCityState(): Int = ((40 + -2 + Random().nextInt(5)) * gameInfo.gameParameters.gameSpeed.modifier).toInt()
-        // There seems to be some randomness in the amount of turns between receiving each great person,
-        // but I have no idea what the actual lower and upper bound are, so this is just an approximation
-    
+    fun turnsForGreatPersonFromCityState(): Int = ((37 + Random().nextInt(7)) * gameInfo.gameParameters.gameSpeed.modifier).toInt()    
 
     fun getAllyCiv() = allyCivName
 

--- a/core/src/com/unciv/models/ruleset/Building.kt
+++ b/core/src/com/unciv/models/ruleset/Building.kt
@@ -228,7 +228,7 @@ class Building : NamedStats(), INonPerpetualConstruction, ICivilopediaText {
 
         if (cost > 0) {
             val stats = mutableListOf("$cost${Fonts.production}")
-            if (canBePurchasedWithStat(CityInfo(), Stat.Gold, true)) {
+            if (canBePurchasedWithStat(null, Stat.Gold)) {
                 stats += "${getBaseGoldCost(UncivGame.Current.gameInfo.currentPlayerCiv).toInt() / 10 * 10}${Fonts.gold}"
             }
             textList += FormattedLine(stats.joinToString(", ", "{Cost}: "))
@@ -352,13 +352,13 @@ class Building : NamedStats(), INonPerpetualConstruction, ICivilopediaText {
     }
 
 
-    override fun canBePurchasedWithStat(cityInfo: CityInfo, stat: Stat, ignoreCityRequirements: Boolean): Boolean {
+    override fun canBePurchasedWithStat(cityInfo: CityInfo?, stat: Stat): Boolean {
         if (stat == Stat.Gold && isAnyWonder()) return false
         // May buy [buildingFilter] buildings for [amount] [Stat] [cityFilter]
-        if (!ignoreCityRequirements && cityInfo.getMatchingUniques("May buy [] buildings for [] [] []")
+        if (cityInfo != null && cityInfo.getMatchingUniques("May buy [] buildings for [] [] []")
                 .any { it.params[2] == stat.name && matchesFilter(it.params[0]) && cityInfo.matchesFilter(it.params[3]) }
         ) return true
-        return super.canBePurchasedWithStat(cityInfo, stat, ignoreCityRequirements)
+        return super.canBePurchasedWithStat(cityInfo, stat)
     }
 
     override fun getBaseBuyCost(cityInfo: CityInfo, stat: Stat): Int? {

--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -126,7 +126,7 @@ class BaseUnit : INamed, INonPerpetualConstruction, ICivilopediaText {
         if (cost > 0) {
             stats.clear()
             stats += "$cost${Fonts.production}"
-            if (canBePurchasedWithStat(CityInfo(), Stat.Gold, true))
+            if (canBePurchasedWithStat(null, Stat.Gold))
                 stats += "${getBaseGoldCost(UncivGame.Current.gameInfo.currentPlayerCiv).toInt() / 10 * 10}${Fonts.gold}"
             textList += FormattedLine(stats.joinToString(", ", "{Cost}: "))
         }
@@ -216,13 +216,9 @@ class BaseUnit : INamed, INonPerpetualConstruction, ICivilopediaText {
         return productionCost.toInt()
     }
 
-    override fun canBePurchasedWithStat(
-        cityInfo: CityInfo,
-        stat: Stat,
-        ignoreCityRequirements: Boolean
-    ): Boolean {
+    override fun canBePurchasedWithStat(cityInfo: CityInfo?, stat: Stat): Boolean {
         // May buy [unitFilter] units for [amount] [Stat] starting from the [eraName] at an increasing price ([amount])
-        if (cityInfo.civInfo.getMatchingUniques("May buy [] units for [] [] [] starting from the [] at an increasing price ([])")
+        if (cityInfo != null && cityInfo.civInfo.getMatchingUniques("May buy [] units for [] [] [] starting from the [] at an increasing price ([])")
             .any { 
                 matchesFilter(it.params[0])
                 && cityInfo.matchesFilter(it.params[3])        
@@ -231,7 +227,7 @@ class BaseUnit : INamed, INonPerpetualConstruction, ICivilopediaText {
             }
         ) return true
         
-        return super.canBePurchasedWithStat(cityInfo, stat, ignoreCityRequirements)
+        return super.canBePurchasedWithStat(cityInfo, stat)
     }
     
     private fun getCostForConstructionsIncreasingInPrice(baseCost: Int, increaseCost: Int, previouslyBought: Int): Int {
@@ -466,8 +462,10 @@ class BaseUnit : INamed, INonPerpetualConstruction, ICivilopediaText {
             "non-air" -> !movesLikeAirUnits()
 
             "Nuclear Weapon" -> isNuclearWeapon()
+            "Great Person", "Great" -> isGreatPerson()
             // Deprecated as of 3.15.2
-            "military water" -> isMilitary() && isWaterUnit()
+                "military water" -> isMilitary() && isWaterUnit()
+            //
             else -> {
                 if (getType().matchesFilter(filter)) return true
                 if (

--- a/core/src/com/unciv/ui/cityscreen/CityConstructionsTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityConstructionsTable.kt
@@ -165,19 +165,30 @@ class CityConstructionsTable(private val cityScreen: CityScreen) {
             val useStoredProduction = entry is Building || !cityConstructions.isBeingConstructedOrEnqueued(entry.name)
             var buttonText = entry.name.tr() + cityConstructions.getTurnsToConstructionString(entry.name, useStoredProduction)
             for ((resource, amount) in entry.getResourceRequirements()) {
-                buttonText += "\n" + (if (amount == 1) "Consumes 1 [$resource]"
-                    else "Consumes [$amount] [$resource]").tr()
+                buttonText += "\n" + (
+                    if (amount == 1) "Consumes 1 [$resource]"
+                    else "Consumes [$amount] [$resource]"
+                ).tr()
             }
 
-            constructionButtonDTOList.add(ConstructionButtonDTO(entry, buttonText,
-                entry.getRejectionReason(cityConstructions)))
+            constructionButtonDTOList.add(
+                ConstructionButtonDTO(
+                    entry, 
+                    buttonText,
+                    entry.getRejectionReasons(cityConstructions).getMostImportantRejectionReason()
+                )
+            )
         }
 
         for (specialConstruction in PerpetualConstruction.perpetualConstructionsMap.values
-                .filter { it.shouldBeDisplayed(cityConstructions) }) {
-            constructionButtonDTOList.add(ConstructionButtonDTO(specialConstruction,
-                    "Produce [${specialConstruction.name}]".tr()
-                            + specialConstruction.getProductionTooltip(city)))
+                .filter { it.shouldBeDisplayed(cityConstructions) }
+        ) {
+            constructionButtonDTOList.add(
+                ConstructionButtonDTO(
+                    specialConstruction,
+                    "Produce [${specialConstruction.name}]".tr() + specialConstruction.getProductionTooltip(city)
+                )
+            )
         }
 
         return constructionButtonDTOList
@@ -297,7 +308,7 @@ class CityConstructionsTable(private val cityScreen: CityScreen) {
                 Color.BROWN.cpy().lerp(Color.WHITE, 0.5f), Color.WHITE)
     }
 
-    private class ConstructionButtonDTO(val construction: IConstruction, val buttonText: String, val rejectionReason: String = "")
+    private class ConstructionButtonDTO(val construction: IConstruction, val buttonText: String, val rejectionReason: String? = null)
 
     private fun getConstructionButton(constructionButtonDTO: ConstructionButtonDTO): Table {
         val construction = constructionButtonDTO.construction
@@ -325,7 +336,7 @@ class CityConstructionsTable(private val cityScreen: CityScreen) {
         pickConstructionButton.row()
 
         // no rejection reason means we can build it!
-        if (constructionButtonDTO.rejectionReason != "") {
+        if (constructionButtonDTO.rejectionReason != null) {
             pickConstructionButton.color = Color.GRAY
             pickConstructionButton.add(constructionButtonDTO.rejectionReason.toLabel(Color.RED).apply { wrap = true })
                     .colspan(pickConstructionButton.columns).fillX().left().padTop(2f)

--- a/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
@@ -769,8 +769,7 @@ object UnitActions {
         val giftAction = {
             if (recipient.isCityState()) {
                 for (unique in unit.civInfo.getMatchingUniques("Gain [] Influence with a [] gift to a City-State")) {
-                    if ((unit.isGreatPerson() && unique.params[1] == "Great Person")
-                        || unit.matchesFilter(unique.params[1])
+                    if (unit.matchesFilter(unique.params[1])
                     ) {
                         recipient.getDiplomacyManager(unit.civInfo).addInfluence(unique.params[0].toFloat() - 5f)
                         break


### PR DESCRIPTION
This PR refactors more code, solving a few small bugs as well as refactoring the `getRejectionReason()` functions to return a `HashSet` of reasons why the building was rejected. The elements of these hashSets are Enum values. This removes dependencies of the ordering of statements in these functions, and makes it easier to modify existing behaviour, by changing the enums in stead of having to wade through 200 line long functions to find the right spot to put your new check.

The small bugs fixed are the following:
- Fixed randomness in great person gifts from city states to match up with the behaviour from the original
- Removed a boolean that really should have been a nullable value
- Made "Great person" a check in `BaseUnit.matchesFilter`, removing the check from elsewhere.

This PR might have conflicts with #4617 