### PR TITLE
Newgame Mod incompatibility toast

### DIFF
--- a/android/assets/jsons/Civ V - Vanilla/Beliefs.json
+++ b/android/assets/jsons/Civ V - Vanilla/Beliefs.json
@@ -244,7 +244,7 @@
     },
 
     ////////////////////////////////////// Enhancer beliefs ///////////////////////////////////////
-    
+
     {
         "name": "Defender of the Faith",
         "type": "Enhancer",
@@ -254,7 +254,7 @@
     {
         "name": "Holy Order",
         "type": "Enhancer",
-        "uniques": ["[Faith] cost of purchasing [Missionary] units [-30]% ", "[Faith] cost of purchasing [Inquisitor] units [-30]% "]
+        "uniques": ["[Faith] cost of purchasing [Missionary] units [-30]%", "[Faith] cost of purchasing [Inquisitor] units [-30]%"]
     },
     {
         "name": "Itinerant Preachers",
@@ -293,4 +293,3 @@
         "uniques": ["[+50 Faith] whenever a Great Person is expended"]
     }
 ]
-

--- a/android/assets/jsons/translations/German.properties
+++ b/android/assets/jsons/translations/German.properties
@@ -1,6 +1,6 @@
- 
-# Tutorial tasks 
-         
+
+# Tutorial tasks
+
 Move a unit!\nClick on a unit > Click on a destination > Click the arrow popup = Eine Einheit bewegen!\nKlicke auf eine Einheit > Klicke auf ein Ziel > Klicke auf das Pfeil-Popup.
 Found a city!\nSelect the Settler (flag unit) > Click on 'Found city' (bottom-left corner) = Eine Stadt gründen!\nWähle den Siedler (Flaggensymbol) > Klicke auf 'Stadt gründen' (unten links).
 Enter the city screen!\nClick the city button twice = Öffne den Stadtbildschirm!\n Klicke zweimal den Stadtknopf.
@@ -15,24 +15,24 @@ Create a trade route!\nConstruct roads between your capital and another city\nOr
 Conquer a city!\nBring an enemy city down to low health > \nEnter the city with a melee unit = Erobere eine Stadt!\nBringe eine feindliche Stadt auf wenig Leben > \nBetrete die Stadt mit einer Nahkampfeinheit.
 Move an air unit!\nSelect an air unit > select another city within range > \nMove the unit to the other city = Bewege eine Lufteinheit!\nWähle eine Lufteinheit > Wähle eine andere Stadt in Reichweite > \nVerschiebe die Einheit zu der anderen Stadt.
 See your stats breakdown!\nEnter the Overview screen (top right corner) >\nClick on 'Stats' = Schaue deine Statistiken an!\nGehe in den Übersichtsbildschirm (obere rechte Ecke) >\nKlicke auf 'Statistiken'.
-         
+
 Oh no! It looks like something went DISASTROUSLY wrong! This is ABSOLUTELY not supposed to happen! Please send me (yairm210@hotmail.com) an email with the game information (menu -> save game -> copy game info -> paste into email) and I'll try to fix it as fast as I can! = Oh nein! Sieht aus, als wäre etwas katastrophal schief gelaufen! Das darf auf keinen Fall passieren! Bitte sende mir (yairm210@hotmail.com) eine Email mit den Spielinformationen (Menü -> Spiel speichern -> Spielinfo kopieren -> in Email einfügen) und ich werde versuchen, es so schnell wie möglich zu beheben!
 Oh no! It looks like something went DISASTROUSLY wrong! This is ABSOLUTELY not supposed to happen! Please send us an report and we'll try to fix it as fast as we can! = Oh nein! Sieht aus, als wäre etwas katastrophal schief gelaufen! Das darf auf keinen Fall passieren! Bitte sende uns einen Bericht und wir werden versuchen, es so schnell wie möglich zu beheben!
-         
-# Buildings 
-         
+
+# Buildings
+
 Unsellable = Unverkäuflich
 Not displayed as an available construction unless [building] is built = Wird nicht als verfügbares Bauwerk angezeigt, bis [building] gebaut ist
 Not displayed as an available construction without [resource] = Wird nicht als verfügbares Bauwerk angezeigt, solange [resource] fehlt
-         
+
 Choose a free great person = Wähle eine kostenlose Große Persönlichkeit
 Get [unitName] = Erhalte [unitName]
-         
+
 Hydro Plant = Wasserkraftwerk
 [buildingName] obsoleted = [buildingName] ist nun veraltet
-         
-# Diplomacy,Trade,Nations 
-         
+
+# Diplomacy,Trade,Nations
+
 Requires [buildingName] to be built in the city = Benötigt den Bau von [buildingName] in der Stadt
 Requires [buildingName] to be built in all cities = Benötigt den Bau von [buildingName] in allen Städten
 Provides a free [buildingName] in the city = Stellt das Gebäude [buildingName] in der Stadt kostenlos bereit
@@ -50,12 +50,12 @@ Requires [PolicyOrNationalWonder] = Benötigt [PolicyOrNationalWonder]
 Cannot be purchased = Kann nicht gekauft werden
 Can only be purchased = Kann nur gekauft werden
 See also = Siehe auch
-         
+
 Requires at least one of the following: = Benötigt eine der folgenden Vorraussetzungen:
 Requires all of the following: = Benötigt folgende Vorraussetzungen:
 Leads to [techName] = [techName] kann nun erforscht werden
 Leads to: = Ermöglicht die Erforschung von:
-         
+
 Current construction = Aktuelle Produktion
 Construction queue = Produktionswarteschlange
 Pick a construction = Wähle ein Bauwerk
@@ -66,7 +66,7 @@ Show stats drilldown = Zeige Statistiken
 Show construction queue = Zeige Produktionswarteschlange
 Save = Speichern
 Cancel = Abbrechen
-         
+
 Diplomacy = Diplomatie
 War = Krieg
 Peace = Frieden
@@ -94,15 +94,15 @@ Indeed! = Auf jeden Fall!
 Denounce [civName]? = [civName] anprangern?
 Denounce ([numberOfTurns] turns) = Anprangern ([numberOfTurns] Runden)
 We will remember this. = Das werden wir nie vergessen!
-         
+
 [civName] has declared war on [targetCivName]! = [civName] hat [targetCivName] den Krieg erklärt!
 [civName] and [targetCivName] have signed a Peace Treaty! = [civName] und [targetCivName] haben einen Friedensvertrag unterzeichnet!
 [civName] and [targetCivName] have signed the Declaration of Friendship! = [civName] und [targetCivName] haben die Freundschaftserklärung unterzeichnet!
 [civName] has denounced [targetCivName]! = [civName] hat [targetCivName] angeprangert!
 Do you want to break your promise to [leaderName]? = Möchtest du dein Versprechen gegenüber [leaderName] brechen?
 We promised not to settle near them ([count] turns remaining) = Wir haben versprochen, nicht in ihrer Nähe zu siedeln ([count] Runden verbleiben)
-They promised not to settle near us ([count] turns remaining) = Sie haben versprochen, nicht in unserer Nähe zu siedeln ([count] Runden verbleiben) 
-         
+They promised not to settle near us ([count] turns remaining) = Sie haben versprochen, nicht in unserer Nähe zu siedeln ([count] Runden verbleiben)
+
 Unforgivable = Todfeind
 Afraid = Gefürchtet
 Enemy = Feind
@@ -111,12 +111,12 @@ Neutral = Neutral
 Favorable = Beliebt
 Friend = Freund
 Ally = Verbündeter
-         
+
 [questName] (+[influenceAmount] influence) = [questName] (+[influenceAmount] Einfluss)
 [remainingTurns] turns remaining = [remainingTurns] Runden verbleiben
-         
-## Diplomatic modifiers 
-         
+
+## Diplomatic modifiers
+
 You declared war on us! = Ihr habt uns den Krieg erklärt!
 Your warmongering ways are unacceptable to us. = Euer kriegerisches Verhalten ist für uns inakzeptabel.
 You have captured our cities! = Ihr habt unsere Städte erobert!
@@ -139,15 +139,15 @@ Your arrogant demands are in bad taste = Eure arroganten Forderungen sind geschm
 Your use of nuclear weapons is disgusting! = Euer Einsatz von Atomwaffen ist ekelhaft!
 You have stolen our lands! = Ihr habt unser Land geraubt!
 You gave us units! = Ihr habt uns Einheiten geschenkt!
-         
+
 Demands = Forderungen
 Please don't settle new cities near us. = Bitte gründet keine neuen Städte in unserer Nähe.
 Very well, we shall look for new lands to settle. = Nun gut, wir werden uns nach neuem Land umsehen, um es zu besiedeln.
 We shall do as we please. = Wir werden tun, wie es uns beliebt.
 We noticed your new city near our borders, despite your promise. This will have....implications. = Wir haben eure neue Stadt in der Nähe unserer Grenzen bemerkt, entgegen eures Versprechens. Dies wird....Konsequenzen haben.
-         
-# City-States 
-         
+
+# City-States
+
 Provides [amountOfCulture] culture at 30 Influence = Liefert [amountOfCulture] Kultur ab einem Einfluss von 30
 Provides 3 food in capital and 1 food in other cities at 30 Influence = Liefert 3 Nahrung in die Hauptstadt und 1 Nahrung in alle anderen Städte ab einem Einfluss von 30
 Provides 3 happiness at 30 Influence = Liefert 3 Zufriedenheit ab einem Einfluss von 30
@@ -203,7 +203,7 @@ Take worker (-50 Influence) = Arbeiter nehmen (-50 Einfluss)
 [civName] is afraid of your military power! = [civName] fürchtet sich vor deiner militärischen Macht!
 
 
-# Trades 
+# Trades
 
 Trade = Handel
 Offer trade = Handel anbieten
@@ -228,20 +228,20 @@ Technologies = Technologien
 Declarations of war = Kriegserklärungen
 Introduction to [nation] = Vorstellung der Nation [nation]
 Declare war on [nation] = [nation] den Krieg erklären
-Luxury resources = Luxusressourcen 
+Luxury resources = Luxusressourcen
 Strategic resources = Strategische Ressourcen
 Owned: [amountOwned] = Im Besitz: [amountOwned]
-         
-# Nation picker 
-         
+
+# Nation picker
+
 [resourceName] not required = [resourceName] nicht erforderlich
 Lost ability = Verlorene Fähigkeit
 National ability = Nationalfähigkeit
 [firstValue] vs [secondValue] = [firstValue] anstatt [secondValue]
-         
-         
-# New game screen 
-         
+
+
+# New game screen
+
 Uniques = Unikate
 Promotions = Beförderungen
 Load copied data = Aus Zwischenablage laden
@@ -276,9 +276,9 @@ Cultural = Kulturell
 Map Shape = Kartenform
 Hexagonal = Sechseckig
 Rectangular = Rechteckig
-Height = Höhe 
-Width = Breite 
-Radius = Radius 
+Height = Höhe
+Width = Breite
+Radius = Radius
 Enable Religion = Religion aktivieren
 
 Advanced Settings = Erweiterte Einstellungen
@@ -305,9 +305,9 @@ World wrap requires a minimum width of 32 tiles = 'World Wrap' Karten müssen mi
 The provided map dimensions were too small = Die angegebenen Dimensionen waren zu klein
 The provided map dimensions were too big = Die angegebenen Dimensionen waren zu groß
 The provided map dimensions had an unacceptable aspect ratio = Die angegebenen Dimensionen hatten ein zu extremes Seitenverhältnis
-         
+
 Difficulty = Schwierigkeitsgrad
-         
+
 AI = KI
 Remove = Entfernen
 Random = Zufall
@@ -315,14 +315,14 @@ Human = Mensch
 Hotseat = Schleudersitz
 User ID = Spieler-ID
 Click to copy = Anklicken zum Kopieren
-         
-         
+
+
 Game Speed = Spielgeschwindigkeit
 Quick = Schnell
 Standard = Standard
 Epic = Episch
 Marathon = Marathon
-         
+
 Starting Era = Startzeitalter
 It looks like we can't make a map with the parameters you requested! = Mit den von dir angegebenen Parametern kann keine Karte erzeugt werden!
 Maybe you put too many players into too small a map? = Vielleicht hast du zu viele Spieler in eine zu kleine Karte gepackt?
@@ -330,6 +330,10 @@ No human players selected! = Keine menschlichen Spieler ausgewählt!
 Mods: = Modifikationen:
 Base ruleset mods: = Basisregelsatz Modifikationen:
 Extension mods: = Erweiterungs Modifikationen:
+The mod you selected is incorrectly defined! = Die gewählte Modifikation ist fehlerhaft!
+The mod combination you selected is incorrectly defined! = Die gewählte Kombination von Mods ist fehlerhaft!
+The mod combination you selected has problems. = Die gewählte Kombination von Mods hat Probleme.
+You can play it, but don't expect everything to work! = Du kannst sie spielen, aber erwarte nicht, daß alles perfekt funktioniert!
 Base Ruleset = Basisregelsatz
 [amount] Techs = [amount] Technologien
 [amount] Nations = [amount] Nationen
@@ -339,14 +343,14 @@ Base Ruleset = Basisregelsatz
 [amount] Improvements = [amount] Feldverbesserungen
 [amount] Religions = [amount] Religionen
 [amount] Beliefs = [amount] Glaubenssätze
-         
+
 World Wrap = World Wrap
 World wrap maps are very memory intensive - creating large world wrap maps on Android can lead to crashes! = 'World Wrap' Karten verbrauchen sehr viel Speicher - Das erstellen von großen 'World Wrap' Karten kann bei Android zu einem Absturz führen!
 Anything above 80 by 50 may work very slowly on Android! = Auf Android kann alles über 80 mal 50 sehr langsam sein.
 Anything above 40 may work very slowly on Android! = Auf Android kann alles über 40 sehr langsam sein.
-         
-# Multiplayer 
-         
+
+# Multiplayer
+
 Username = Spielername
 Multiplayer = Mehrspieler
 Could not download game! = Konnte das Spiel nicht herunterladen!
@@ -382,9 +386,9 @@ Resign = Aufgeben
 Are you sure you want to resign? = Willst du wirklich aufgeben?
 You can only resign if it's your turn = Du kannst nur aufgeben, wenn du am Zug bist
 [civName] resigned and is now controlled by AI = [civName] hat aufgegeben und wird nun von der KI gespielt
-         
-# Save game menu 
-         
+
+# Save game menu
+
 Current saves = Gespeicherte Spiele
 Show autosaves = Zeige automatisch gespeicherte Spiele an
 Saved game name = Name des gespeicherten Spiels
@@ -411,9 +415,9 @@ Load from custom location = Laden von externem Speicherort
 Could not load game from custom location! = Laden von externem Speicherort fehlgeschlagen!
 Save to custom location = Speichern in externem Speicherort
 Could not save game to custom location! = Speichern in externem Speicherort fehlgeschlagen!
-         
-# Options 
-         
+
+# Options
+
 Options = Optionen
 Display options = Anzeigeeinstellungen
 Gameplay options = Spielmechanikeinstellungen
@@ -451,9 +455,9 @@ Enable portrait orientation = Hochkant-Orientierung zulassen
 Generate translation files = Erstelle Übersetzungsdateien
 Translation files are generated successfully. = Die Übersetzungsdateien wurden erfolgreich erstellt.
 Locate mod errors = Mod-Fehler lokalisieren
-         
-# Notifications 
-         
+
+# Notifications
+
 Research of [technologyName] has completed! = [technologyName] wurde erforscht!
 [construction] has become obsolete and was removed from the queue in [cityName]! = [construction] ist veraltet und wurde in [cityName] aus der Warteschlange entfernt!
 [construction] has become obsolete and was removed from the queue in [amount] cities! = [construction] ist veraltet und wurde in [amount] Städten aus der Warteschlange entfernt!
@@ -473,7 +477,7 @@ Cannot provide unit upkeep for [unitName] - unit has been disbanded! = Der Unter
 [construction] has been built in [cityName] = [construction] wurde in [cityName] fertiggestellt
 [wonder] has been built in a faraway land = [wonder] wurde in einem fernen Land gebaut
 [civName] has completed [construction]! = [civName] hat [construction] fertiggestellt!
-An unknown civilization has completed [construction]! = Eine unbekannte Zivilisation hat [construction] fertiggestellt! 
+An unknown civilization has completed [construction]! = Eine unbekannte Zivilisation hat [construction] fertiggestellt!
 The city of [cityname] has started constructing [construction]! = Die Stadt [cityname] hat den Bau von [construction] begonnen!
 [civilization] has started constructing [construction]! = [civilization] hat den Bau von [construction] begonnen!
 An unknown civilization has started constructing [construction]! = Eine unbekannte Zivilisation hat den Bau von [construction] begonnen!
@@ -563,8 +567,8 @@ Your city [cityName] was converted to [religionName]! = Deine Stadt [cityName] k
 Your [unitName] lost its faith after spending too long inside enemy territory! = Deine [unitName] Einheit hat ihren Glauben verloren, nachdem sie zu lange in feindlichem Gebiet war!
 
 
-# World Screen UI 
-         
+# World Screen UI
+
 Working... = Bitte warten...
 Waiting for other players... = Warte auf andere Spieler...
 in = in
@@ -617,7 +621,7 @@ Yes = Ja
 No = Nein
 Acquire = Übernehmen
 Under construction = Im Bau
-         
+
 Food = Nahrung
 Production = Produktion
 Gold = Gold
@@ -625,7 +629,7 @@ Happiness = Zufriedenheit
 Culture = Kultur
 Science = Wissenschaft
 Faith = Glaube
-         
+
 Crop Yield = Ernteertrag
 Territory = Territorium
 Force = Kampfkraft
@@ -634,7 +638,7 @@ Golden Age = Goldenes Zeitalter
 [year] BC = [year] v. Chr.
 [year] AD = [year] n. Chr.
 Civilopedia = Civilopedia
-         
+
 Start new game = Neues Spiel
 Save game = Spiel speichern
 Load game = Spiel laden
@@ -650,9 +654,9 @@ Close = Schließen
 Do you want to exit the game? = Willst du das Spiel beenden?
 Start bias: = Start-Präferenz:
 Avoid [terrain] = Meide [terrain]
-         
-# City screen 
-         
+
+# City screen
+
 Exit city = Stadt verlassen
 Raze city = Stadt niederreißen
 Stop razing city = Niederreißen der Stadt stoppen
@@ -704,9 +708,9 @@ Move to city = Zur Stadt bewegen
 Invalid input! Please enter a different string. = 
  # Requires translation!
 Please enter some text = 
-         
-# Technology UI 
-         
+
+# Technology UI
+
 Pick a tech = Technologie auswählen
 Pick a free tech = Kostenlose Technologie auswählen
 Research [technology] = [technology] erforschen
@@ -729,9 +733,9 @@ Attack = Angreifen
 Bombard = Bombardieren
 NUKE = Atomisieren
 Captured! = Gefangen!
-         
-# Battle modifier categories 
-         
+
+# Battle modifier categories
+
 defence vs ranged = Verteidigung gegen Fernkampf
 [percentage] to unit defence = [percentage] erhöhte Verteidigungsstärke
 Attacker Bonus = Angriffsbonus
@@ -753,11 +757,11 @@ defence vs [unitType] = Verteidigung gegen [unitType]
 [tileFilter] defence = [tileFilter] Verteidigung
 Defensive Bonus = Verteidigungsbonus
 Stacked with [unitType] = Auf gleichem Feld mit [unitType]
-         
+
 The following improvements [stats]: = Die folgenden Verbesserungen [stats]:
 The following improvements on [tileType] tiles [stats]: = Die folgenden Verbesserungen auf [tileType] Feldern [stats]:
-         
-         
+
+
 Hurry Research = Forschung beschleunigen
 Conduct Trade Mission = Handelsmission durchführen
 Your trade mission to [civName] has earned you [goldAmount] gold and [influenceAmount] influence! = Deine Handelsmission zu [civName] hat dir [goldAmount] Gold und [influenceAmount] Einfluss eingebracht!
@@ -780,9 +784,9 @@ Policies = Politiken
 Base happiness = Grundzufriedenheit
 Occupied City = Besetzte Städte
 Buildings = Gebäude
-         
-# terrainFilters (so for uniques like: "[stats] from [terrainFilter] tiles") 
-         
+
+# terrainFilters (so for uniques like: "[stats] from [terrainFilter] tiles")
+
 All = Alle
 Water = Wasser
 Land = Land
@@ -800,14 +804,14 @@ Strategic resource = Strategische Ressource
 Fresh water = Frischwasser
 non-fresh water = nicht frisches Wasser
 Natural Wonder = Naturwunder
-         
-# improvementFilters 
-         
+
+# improvementFilters
+
 All Road = Alle Straßen
 Great Improvement = Große Verbesserung
 Great = Große
-         
-         
+
+
 Wonders = Wunder
 Base values = Grundwerte
 Bonuses = Boni
@@ -833,9 +837,9 @@ Known and defeated ([numberOfCivs]) =  Bekannt und besiegt ([numberOfCivs])
 Tiles = Felder
 Natural Wonders = Naturwunder
 Treasury deficit = Schatzkammerdefizit
-         
-# Victory 
-         
+
+# Victory
+
 Science victory = Wissenschaftssieg
 Cultural victory = Kultursieg
 Conquest victory = Dominanzsieg
@@ -864,7 +868,7 @@ Rankings = Ranglisten
 Spaceship parts remaining = Fehlende Raumschiffteile
 Branches completed = Vollständige Zweige
 Undefeated civs = Unbesiegte Zivilisationen
- # The \n here means: put a newline (enter) here. If this is omitted, the sidebox in the diplomacy overview will become _really_ wide. 
+ # The \n here means: put a newline (enter) here. If this is omitted, the sidebox in the diplomacy overview will become _really_ wide.
  # Feel free to replace it with a space and put it between other words in your translation
 Turns until the next\ndiplomacy victory vote: [amount] = Runden bis zur nächsten Abstimmung\nüber den Diplomatiesieg: [amount]
 Choose a civ to vote for = Wähle eine Zivilisation für die du abstimmen möchtest
@@ -874,9 +878,9 @@ Vote for [civilizationName] = Abstimmen für [civilizationName]
 Continue = Fortfahren
 Abstained = Enthalten
 Vote for World Leader = Stimme für den Anführer der Welt ab
-         
-# Capturing a city 
-         
+
+# Capturing a city
+
 What would you like to do with the city? = Was möchtet Ihr mit dieser Stadt machen?
 Annex = Annektieren
 Annexed cities become part of your regular empire. = Annektierte Städte werden Teil Eures Reichs
@@ -896,14 +900,14 @@ Destroying the city instantly razes the city to the ground. = Zerstören macht d
 Remove your troops in our border immediately! = Entferne sofort deine Truppen aus unserem Gebiet!
 Sorry. = Entschuldigung.
 Never! = Niemals!
-         
+
 Offer Declaration of Friendship ([30] turns) = Freundschaftserklärung anbieten ([30] Runden)
 My friend, shall we declare our friendship to the world? = Mein Freund, sollen wir unsere Freundschaft der Welt kundtun?
 Sign Declaration of Friendship ([30] turns) = Freundschaftserklärung unterzeichnen ([30] Runden)
 We are not interested. = Wir sind nicht interessiert.
 We have signed a Declaration of Friendship with [otherCiv]! = Wir haben eine Freundschaftserklärung mit [otherCiv] unterzeichnet!
 [otherCiv] has denied our Declaration of Friendship! = [otherCiv] hat unsere Freundschaftserklärung abgelehnt!
-         
+
 Basics = Spielkonzepte
 Resources = Ressourcen
 Terrains = Gelände
@@ -971,8 +975,8 @@ Terrain feature [feature] does not exist in ruleset! = Geländemerkmal [feature]
 Resource [resource] does not exist in ruleset! = Ressource [resource] fehlt im Regelsatz!
 Improvement [improvement] does not exist in ruleset! = Verbesserung [improvement] fehlt im Regelsatz!
 Change map to fit selected ruleset? = Karte ändern, um sie dem neuen Regelsatz anzupassen?
-         
-# Civilopedia difficulty levels 
+
+# Civilopedia difficulty levels
 Player settings = Spieler-Einstellungen
 Base Happiness = Basiszufriedenheit
 Extra happiness per luxury = Zusätzliche Zufriedenheit pro Luxusgut
@@ -997,8 +1001,8 @@ Major AI civilization bonus starting units = Haupt-KI Zivilisationsbonus Startei
 City state bonus starting units = Stadtstaaten Bonus Starteinheiten
 Turns until barbarians enter player tiles = Züge bis Barbaren Spielerfelder betreten
 Gold reward for clearing barbarian camps = Gold-Belohnung für das Räumen von Barbarenlagern
-         
-# Other civilopedia things 
+
+# Other civilopedia things
 Nations = Nationen
 Available for [unitTypes] = Verfügbar für [unitTypes]
 Available for: = Verfügbar für:
@@ -1010,9 +1014,9 @@ Granted by [param] = Von [param] erteilt
 Granted by: = Erteilt von:
 [bonus] with [tech] = [bonus] mit [tech]
 Difficulty levels = Schwierigkeitsgrade
-         
-# Policies 
-         
+
+# Policies
+
 Adopt policy = Politik verabschieden
 Adopt free policy = Freie Politik verabschieden
 Unlocked at = Freigeschaltet bei
@@ -1047,13 +1051,13 @@ Holy City: =
 Cities following this religion: = Städte die dieser Religion folgen
 Click an icon to see the stats of this religion = Klicke auf ein Icon, um die Statistiken dieser Religion anzuzeigen
 
-# Terrains 
-         
+# Terrains
+
 Impassable = Unpassierbar
 Rare feature = Seltene Geländeform
-         
-# Resources 
-         
+
+# Resources
+
 Bison = Bisons
 Copper = Kupfer
 Cocoa = Kakao
@@ -1063,9 +1067,9 @@ Truffles = Trüffel
 Strategic = Strategisch
 Bonus = Bonus
 Luxury = Luxus
-         
-# Unit types 
-         
+
+# Unit types
+
 City = Stadt
 Civilian = Zivilist
 Melee = Nahkampf
@@ -1074,21 +1078,21 @@ Scout = Späher
 Mounted = Beritten
 Armor = Panzerung
 Siege = Belagerung
-         
+
 WaterCivilian = Wasser-Zivilist
 WaterMelee = Wassernahkampf
 WaterRanged = Wasserfernkampf
 WaterSubmarine = U-Boote
 WaterAircraftCarrier = Flugzeugträger
-         
+
 Fighter = Jagdflugzeug
 Bomber = Bomber
 AtomicBomber = Atombomber
 Missile = Rakete
-         
-         
-# Unit filters and other unit related things 
-         
+
+
+# Unit filters and other unit related things
+
 Air = Luft
 air units = Lufteinheiten
 Barbarian = Barbar
@@ -1096,7 +1100,7 @@ Barbarians = Barbaren
 Embarked = Eingeschifft
 land units = Landeinheiten
 Military = militärisch
-# Deprecated since 3.15.2, but should still be translated until it is officially removed 
+# Deprecated since 3.15.2, but should still be translated until it is officially removed
 military water = militärisches Wasser
 non-air = nicht-fliegend
 Nuclear Weapon = Atomwaffe
@@ -1106,13 +1110,13 @@ Unbuildable = nicht baubar
 water units = Wassereinheiten
 wounded units = verwundete Einheiten
 Wounded = Verwundet
-         
-# For the All "newly-trained [relevant] units in this city receive the [] promotion" translation. Relevant as in 'units that can receive' 
+
+# For the All "newly-trained [relevant] units in this city receive the [] promotion" translation. Relevant as in 'units that can receive'
 relevant = relevante
-         
-         
-# Promotions 
-         
+
+
+# Promotions
+
 Pick promotion = Wähle eine Beförderung
  OR  =  ODER 
 units in open terrain = Einheiten im offenen Gelände
@@ -1125,9 +1129,9 @@ Dogfighting II = Kurvenkampf II
 Dogfighting III = Kurvenkampf III
 Choose name for [unitName] = Wähle Namen für [unitName]
 [unitFilter] units gain the [promotion] promotion = [unitFilter] Einheiten erhalten die [promotion] Beförderung
-         
-# Multiplayer Turn Checker Service 
-         
+
+# Multiplayer Turn Checker Service
+
 Multiplayer options = Mehrspieler Einstellungen
 Enable out-of-game turn notifications = Aktiviere Zug Benachrichtigungen außerhalb des Spiels
 Time between turn checks out-of-game (in minutes) = Intervall zwischen Zug Prüfungen (in Minuten)
@@ -1136,10 +1140,10 @@ Take user ID from clipboard = Spieler-ID aus der Zwischenablage übernehmen
 Doing this will reset your current user ID to the clipboard contents - are you sure? = Dies wird deine Spieler-ID auf den Inhalt der Zwischenablage zurücksetzen - bist du sicher?
 ID successfully set! = Spieler-ID erfolgreich gesetzt!
 Invalid ID! = Ungültige Spieler-ID!
-         
-         
-# Mods 
-         
+
+
+# Mods
+
 Mods = Modifikationen
 Download [modName] = [modName] herunterladen
 Update [modName] = [modName] aktualisieren
@@ -1167,9 +1171,9 @@ No description provided = Keine Beschreibung mitgeliefert
 Author: [author] = Autor: [author]
 Size: [size] kB = Größe: [size] kB
 The mod you selected is incompatible with the defined ruleset! = Die gewählte Modifikation ist inkompatibel!
-         
-# Uniques that are relevant to more than one type of game object 
-         
+
+# Uniques that are relevant to more than one type of game object
+
 [stats] from every [param] = Alle [param] geben [stats]
 [stats] from [param] tiles in this city = [stats] von [param] Feld in dieser Stadt
 [stats] from every [param] on [tileFilter] tiles = [stats] von jedem [param] auf [tileFilter] Feldern
@@ -1183,8 +1187,8 @@ Can only be built on [tileFilter] tiles = Kann nur auf [tileFilter]-Feldern geba
 Cannot be built on [tileFilter] tiles = Kann nicht auf [tileFilter]-Feldern gebaut werden
 Does not need removal of [feature] = Hierfür muß [feature] nicht entfernt werden
 Gain a free [building] [cityFilter] = Erhalte [building] umsonst [cityFilter]
-         
-# City filters 
+
+# City filters
 in this city = in dieser Stadt
 in all cities = in allen Städten
 in all coastal cities = in allen Küstenstädten
@@ -1213,7 +1217,7 @@ Dance of the Aurora = Tanz der Aurora
 Desert Folklore = Wüsten-Folklore
 
 Faith Healers = Glaubensheiler
-[param] Units adjacent to this city heal [amount] HP per turn when healing = Während Heilen, erhalten [param] Einheiten, die benachbart zu dieser Stadt sind, [amount] LP pro Runde 
+[param] Units adjacent to this city heal [amount] HP per turn when healing = Während Heilen, erhalten [param] Einheiten, die benachbart zu dieser Stadt sind, [amount] LP pro Runde
 
 Fertility Rites = Fruchtbarkeitsraten
 +[amount]% Growth [cityFilter] = +[amount]% Wachstum [cityFilter]
@@ -1324,7 +1328,7 @@ Enhancer = Verbesserung
 [amount]% Strength for [param] units in [tileFilter] = [amount]% Stärke für [param] Einheiten in [tileFilter]
 
 Holy Order = Heiliger Orden
-[stat] cost of purchasing [unit] units [amount]%  = [stat] Kosten für den Kauf von [unit] Einheiten [amount]% 
+[stat] cost of purchasing [unit] units [amount]%  = [stat] Kosten für den Kauf von [unit] Einheiten [amount]%
 
 Itinerant Preachers = Wanderprediger
 Religion naturally spreads to cities [amount] tiles away = Religion breitet sich auf natürliche Weise in [amount] Felder entfernte Städte aus
@@ -2349,7 +2353,7 @@ India = Indien
 Gandhi = Mahatma Gandhi
 I have just received a report that large numbers of my troops have crossed your borders. = Ich habe gerade gehört, dass viele Truppen von mir Ihre Grenzen übertreten haben.
 My attempts to avoid violence have failed. An eye for an eye only makes the world blind. = Meine Versuche Gewalt zu vermeiden haben versagt. Auge um Auge führt nur dazu, dass am Ende niemand mehr sehen kann.
-You can chain me, you can torture me, you can even destroy this body, but you will never imprison my mind.  = Und sperrt man mich ein \nIm finsteren Kerker, \nDas alles sind rein \nVergebliche Werke; \nDenn meine Gedanken \nZerreißen die Schranken \nUnd Mauern entzwei: \nDie Gedanken sind frei. 
+You can chain me, you can torture me, you can even destroy this body, but you will never imprison my mind.  = Und sperrt man mich ein \nIm finsteren Kerker, \nDas alles sind rein \nVergebliche Werke; \nDenn meine Gedanken \nZerreißen die Schranken \nUnd Mauern entzwei: \nDie Gedanken sind frei.
 Hello, I am Mohandas Gandhi. My people call me Bapu, but please, call me friend. = Hallo, ich bin Mahatma Gandhi. Meine Leute nennen mich Bapu, aber nennt mich bitte Freund.
 My friend, are you interested in this arrangement? = Mein Freund, seit Ihr an diesem Tausch interessiert?
 I wish you peace. = Ich wünsche Euch Frieden.
@@ -3403,7 +3407,7 @@ Allied City-States will occasionally gift Great People = Verbündete Stadtstaate
 Patronage  Complete = Gunst vollständig
 Influence of all other civilizations with all city-states degrades [amount]% faster = Der Einfluss aller anderen Zivilisationen bei allen Stadtstaaten sinkt um [amount]% schneller
 Triggers the following global alert: [param] = Löst den folgenden globalen Alarm aus: [param]
-Patronage  = Gunst 
+Patronage  = Gunst
 
 Naval Tradition = Marine Tradition
 Trade Unions = Handelsunion
@@ -3786,7 +3790,7 @@ Occurs in groups around high elevations = Tritt gruppiert auf rund um größere 
 Hill = Hügel
 
 Provides a one-time Production bonus to the closest city when cut down = Bietet der nächstgelegenen Stadt einen einmaligen Produktionsbonus, wenn niedergeschnitten
-Blocks line-of-sight from tiles at same elevation = Felder mit identischer Erhebung blockieren die Sichtlinie 
+Blocks line-of-sight from tiles at same elevation = Felder mit identischer Erhebung blockieren die Sichtlinie
 Resistant to nukes = Resistent gegen Atombomben
 Can be destroyed by nukes = Kann durch Atombomben zerstört werden
 A Camp can be built here without cutting it down = Hier kann ein Lager gebaut werden, ohne dass er abgeholzt werden muss

--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -1,6 +1,6 @@
- 
-# Tutorial tasks 
-         
+
+# Tutorial tasks
+
 Move a unit!\nClick on a unit > Click on a destination > Click the arrow popup = 
 Found a city!\nSelect the Settler (flag unit) > Click on 'Found city' (bottom-left corner) = 
 Enter the city screen!\nClick the city button twice = 
@@ -15,24 +15,24 @@ Create a trade route!\nConstruct roads between your capital and another city\nOr
 Conquer a city!\nBring an enemy city down to low health > \nEnter the city with a melee unit = 
 Move an air unit!\nSelect an air unit > select another city within range > \nMove the unit to the other city = 
 See your stats breakdown!\nEnter the Overview screen (top right corner) >\nClick on 'Stats' = 
-         
+
 Oh no! It looks like something went DISASTROUSLY wrong! This is ABSOLUTELY not supposed to happen! Please send me (yairm210@hotmail.com) an email with the game information (menu -> save game -> copy game info -> paste into email) and I'll try to fix it as fast as I can! = 
 Oh no! It looks like something went DISASTROUSLY wrong! This is ABSOLUTELY not supposed to happen! Please send us an report and we'll try to fix it as fast as we can! = 
-         
-# Buildings 
-         
+
+# Buildings
+
 Unsellable = 
 Not displayed as an available construction unless [building] is built = 
 Not displayed as an available construction without [resource] = 
-         
+
 Choose a free great person = 
 Get [unitName] = 
-         
+
 Hydro Plant = 
 [buildingName] obsoleted = 
-         
-# Diplomacy,Trade,Nations 
-         
+
+# Diplomacy,Trade,Nations
+
 Requires [buildingName] to be built in the city = 
 Requires [buildingName] to be built in all cities = 
 Provides a free [buildingName] in the city = 
@@ -50,12 +50,12 @@ Requires [PolicyOrNationalWonder] =
 Cannot be purchased = 
 Can only be purchased = 
 See also = 
-         
+
 Requires at least one of the following: = 
 Requires all of the following: = 
 Leads to [techName] = 
 Leads to: = 
-         
+
 Current construction = 
 Construction queue = 
 Pick a construction = 
@@ -66,7 +66,7 @@ Show stats drilldown =
 Show construction queue = 
 Save = 
 Cancel = 
-         
+
 Diplomacy = 
 War = 
 Peace = 
@@ -94,7 +94,7 @@ Indeed! =
 Denounce [civName]? = 
 Denounce ([numberOfTurns] turns) = 
 We will remember this. = 
-         
+
 [civName] has declared war on [targetCivName]! = 
 [civName] and [targetCivName] have signed a Peace Treaty! = 
 [civName] and [targetCivName] have signed the Declaration of Friendship! = 
@@ -102,7 +102,7 @@ We will remember this. =
 Do you want to break your promise to [leaderName]? = 
 We promised not to settle near them ([count] turns remaining) = 
 They promised not to settle near us ([count] turns remaining) = 
-         
+
 Unforgivable = 
 Afraid = 
 Enemy = 
@@ -111,12 +111,12 @@ Neutral =
 Favorable = 
 Friend = 
 Ally = 
-         
+
 [questName] (+[influenceAmount] influence) = 
 [remainingTurns] turns remaining = 
-         
-## Diplomatic modifiers 
-         
+
+## Diplomatic modifiers
+
 You declared war on us! = 
 Your warmongering ways are unacceptable to us. = 
 You have captured our cities! = 
@@ -139,15 +139,15 @@ Your arrogant demands are in bad taste =
 Your use of nuclear weapons is disgusting! = 
 You have stolen our lands! = 
 You gave us units! = 
-         
+
 Demands = 
 Please don't settle new cities near us. = 
 Very well, we shall look for new lands to settle. = 
 We shall do as we please. = 
 We noticed your new city near our borders, despite your promise. This will have....implications. = 
-         
-# City-States 
-         
+
+# City-States
+
 Provides [amountOfCulture] culture at 30 Influence = 
 Provides 3 food in capital and 1 food in other cities at 30 Influence = 
 Provides 3 happiness at 30 Influence = 
@@ -204,7 +204,7 @@ Take worker (-50 Influence) =
 [civName] is afraid of your military power! = 
 
 
-# Trades 
+# Trades
 
 Trade = 
 Offer trade = 
@@ -232,17 +232,17 @@ Declare war on [nation] =
 Luxury resources = 
 Strategic resources = 
 Owned: [amountOwned] = 
-         
-# Nation picker 
-         
+
+# Nation picker
+
 [resourceName] not required = 
 Lost ability = 
 National ability = 
 [firstValue] vs [secondValue] = 
-         
-         
-# New game screen 
-         
+
+
+# New game screen
+
 Uniques = 
 Promotions = 
 Load copied data = 
@@ -306,9 +306,9 @@ World wrap requires a minimum width of 32 tiles =
 The provided map dimensions were too small = 
 The provided map dimensions were too big = 
 The provided map dimensions had an unacceptable aspect ratio = 
-         
+
 Difficulty = 
-         
+
 AI = 
 Remove = 
 Random = 
@@ -316,14 +316,14 @@ Human =
 Hotseat = 
 User ID = 
 Click to copy = 
-         
-         
+
+
 Game Speed = 
 Quick = 
 Standard = 
 Epic = 
 Marathon = 
-         
+
 Starting Era = 
 It looks like we can't make a map with the parameters you requested! = 
 Maybe you put too many players into too small a map? = 
@@ -331,6 +331,10 @@ No human players selected! =
 Mods: = 
 Base ruleset mods: = 
 Extension mods: = 
+The mod you selected is incorrectly defined! = 
+The mod combination you selected is incorrectly defined! = 
+The mod combination you selected has problems. = 
+You can play it, but don't expect everything to work! = 
 Base Ruleset = 
 [amount] Techs = 
 [amount] Nations = 
@@ -340,14 +344,14 @@ Base Ruleset =
 [amount] Improvements = 
 [amount] Religions = 
 [amount] Beliefs = 
-         
+
 World Wrap = 
 World wrap maps are very memory intensive - creating large world wrap maps on Android can lead to crashes! = 
 Anything above 80 by 50 may work very slowly on Android! = 
 Anything above 40 may work very slowly on Android! = 
-         
-# Multiplayer 
-         
+
+# Multiplayer
+
 Username = 
 Multiplayer = 
 Could not download game! = 
@@ -383,9 +387,9 @@ Resign =
 Are you sure you want to resign? = 
 You can only resign if it's your turn = 
 [civName] resigned and is now controlled by AI = 
-         
-# Save game menu 
-         
+
+# Save game menu
+
 Current saves = 
 Show autosaves = 
 Saved game name = 
@@ -412,9 +416,9 @@ Load from custom location =
 Could not load game from custom location! = 
 Save to custom location = 
 Could not save game to custom location! = 
-         
-# Options 
-         
+
+# Options
+
 Options = 
 Display options = 
 Gameplay options = 
@@ -452,9 +456,9 @@ Enable portrait orientation =
 Generate translation files = 
 Translation files are generated successfully. = 
 Locate mod errors = 
-         
-# Notifications 
-         
+
+# Notifications
+
 Research of [technologyName] has completed! = 
 [construction] has become obsolete and was removed from the queue in [cityName]! = 
 [construction] has become obsolete and was removed from the queue in [amount] cities! = 
@@ -547,7 +551,7 @@ Received [goldAmount] Gold for capturing [cityName] =
 Our proposed trade is no longer relevant! = 
 [defender] could not withdraw from a [attacker] - blocked. = 
 [defender] withdrew from a [attacker] = 
-By expending your [unit] you gained [Stats]! =  
+By expending your [unit] you gained [Stats]! = 
 [civName] has stolen your territory! = 
 Clearing a [forest] has created [amount] Production for [cityName] = 
 [civName] assigned you a new quest: [questName]. = 
@@ -564,8 +568,8 @@ Your city [cityName] was converted to [religionName]! =
 Your [unitName] lost its faith after spending too long inside enemy territory! = 
 
 
-# World Screen UI 
-         
+# World Screen UI
+
 Working... = 
 Waiting for other players... = 
 in = 
@@ -618,7 +622,7 @@ Yes =
 No = 
 Acquire = 
 Under construction = 
-         
+
 Food = 
 Production = 
 Gold = 
@@ -626,7 +630,7 @@ Happiness =
 Culture = 
 Science = 
 Faith = 
-         
+
 Crop Yield = 
 Territory = 
 Force = 
@@ -635,7 +639,7 @@ Golden Age =
 [year] BC = 
 [year] AD = 
 Civilopedia = 
-         
+
 Start new game = 
 Save game = 
 Load game = 
@@ -651,9 +655,9 @@ Close =
 Do you want to exit the game? = 
 Start bias: = 
 Avoid [terrain] = 
-         
-# City screen 
-         
+
+# City screen
+
 Exit city = 
 Raze city = 
 Stop razing city = 
@@ -703,9 +707,9 @@ Unlock =
 Move to city = 
 Invalid input! Please enter a different string. = 
 Please enter some text = 
-         
-# Technology UI 
-         
+
+# Technology UI
+
 Pick a tech = 
 Pick a free tech = 
 Research [technology] = 
@@ -728,9 +732,9 @@ Attack =
 Bombard = 
 NUKE = 
 Captured! = 
-         
-# Battle modifier categories 
-         
+
+# Battle modifier categories
+
 defence vs ranged = 
 [percentage] to unit defence = 
 Attacker Bonus = 
@@ -752,11 +756,11 @@ defence vs [unitType] =
 [tileFilter] defence = 
 Defensive Bonus = 
 Stacked with [unitType] = 
-         
+
 The following improvements [stats]: = 
 The following improvements on [tileType] tiles [stats]: = 
-         
-         
+
+
 Hurry Research = 
 Conduct Trade Mission = 
 Your trade mission to [civName] has earned you [goldAmount] gold and [influenceAmount] influence! = 
@@ -779,9 +783,9 @@ Policies =
 Base happiness = 
 Occupied City = 
 Buildings = 
-         
-# terrainFilters (so for uniques like: "[stats] from [terrainFilter] tiles") 
-         
+
+# terrainFilters (so for uniques like: "[stats] from [terrainFilter] tiles")
+
 All = 
 Water = 
 Land = 
@@ -800,15 +804,15 @@ Strategic resource =
 Fresh water = 
 non-fresh water = 
 Natural Wonder = 
-         
-# improvementFilters 
-         
+
+# improvementFilters
+
 All = 
 All Road = 
 Great Improvement = 
 Great = 
-         
-         
+
+
 Wonders = 
 Base values = 
 Bonuses = 
@@ -834,9 +838,9 @@ Known and defeated ([numberOfCivs]) =
 Tiles = 
 Natural Wonders = 
 Treasury deficit = 
-         
-# Victory 
-         
+
+# Victory
+
 Science victory = 
 Cultural victory = 
 Conquest victory = 
@@ -865,7 +869,7 @@ Rankings =
 Spaceship parts remaining = 
 Branches completed = 
 Undefeated civs = 
- # The \n here means: put a newline (enter) here. If this is omitted, the sidebox in the diplomacy overview will become _really_ wide. 
+ # The \n here means: put a newline (enter) here. If this is omitted, the sidebox in the diplomacy overview will become _really_ wide.
  # Feel free to replace it with a space and put it between other words in your translation
 Turns until the next\ndiplomacy victory vote: [amount] = 
 Choose a civ to vote for = 
@@ -875,9 +879,9 @@ Vote for [civilizationName] =
 Continue = 
 Abstained = 
 Vote for World Leader = 
-         
-# Capturing a city 
-         
+
+# Capturing a city
+
 What would you like to do with the city? = 
 Annex = 
 Annexed cities become part of your regular empire. = 
@@ -897,14 +901,14 @@ Destroying the city instantly razes the city to the ground. =
 Remove your troops in our border immediately! = 
 Sorry. = 
 Never! = 
-         
+
 Offer Declaration of Friendship ([30] turns) = 
 My friend, shall we declare our friendship to the world? = 
 Sign Declaration of Friendship ([30] turns) = 
 We are not interested. = 
 We have signed a Declaration of Friendship with [otherCiv]! = 
 [otherCiv] has denied our Declaration of Friendship! = 
-         
+
 Basics = 
 Resources = 
 Terrains = 
@@ -973,8 +977,8 @@ Terrain feature [feature] does not exist in ruleset! =
 Resource [resource] does not exist in ruleset! = 
 Improvement [improvement] does not exist in ruleset! = 
 Change map to fit selected ruleset? = 
-         
-# Civilopedia difficulty levels 
+
+# Civilopedia difficulty levels
 Player settings = 
 Base Happiness = 
 Extra happiness per luxury = 
@@ -999,8 +1003,8 @@ Major AI civilization bonus starting units =
 City state bonus starting units = 
 Turns until barbarians enter player tiles = 
 Gold reward for clearing barbarian camps = 
-         
-# Other civilopedia things 
+
+# Other civilopedia things
 Nations = 
 Available for [unitTypes] = 
 Available for: = 
@@ -1012,9 +1016,9 @@ Granted by [param] =
 Granted by: = 
 [bonus] with [tech] = 
 Difficulty levels = 
-         
-# Policies 
-         
+
+# Policies
+
 Adopt policy = 
 Adopt free policy = 
 Unlocked at = 
@@ -1046,13 +1050,13 @@ Holy City: =
 Cities following this religion: = 
 Click an icon to see the stats of this religion = 
 
-# Terrains 
-         
+# Terrains
+
 Impassable = 
 Rare feature = 
-         
-# Resources 
-         
+
+# Resources
+
 Bison = 
 Copper = 
 Cocoa = 
@@ -1062,9 +1066,9 @@ Truffles =
 Strategic = 
 Bonus = 
 Luxury = 
-         
-# Unit types 
-         
+
+# Unit types
+
 City = 
 Civilian = 
 Melee = 
@@ -1073,21 +1077,21 @@ Scout =
 Mounted = 
 Armor = 
 Siege = 
-         
+
 WaterCivilian = 
 WaterMelee = 
 WaterRanged = 
 WaterSubmarine = 
 WaterAircraftCarrier = 
-         
+
 Fighter = 
 Bomber = 
 AtomicBomber = 
 Missile = 
-         
-         
-# Unit filters and other unit related things 
-         
+
+
+# Unit filters and other unit related things
+
 Air = 
 air units = 
 All = 
@@ -1097,7 +1101,7 @@ Embarked =
 Land = 
 land units = 
 Military = 
-# Deprecated since 3.15.2, but should still be translated until it is officially removed 
+# Deprecated since 3.15.2, but should still be translated until it is officially removed
 military water = 
 non-air = 
 Nuclear Weapon = 
@@ -1108,13 +1112,13 @@ Water =
 water units = 
 wounded units = 
 Wounded = 
-         
-# For the All "newly-trained [relevant] units in this city receive the [] promotion" translation. Relevant as in 'units that can receive' 
+
+# For the All "newly-trained [relevant] units in this city receive the [] promotion" translation. Relevant as in 'units that can receive'
 relevant = 
-         
-         
-# Promotions 
-         
+
+
+# Promotions
+
 Pick promotion = 
  OR  = 
 units in open terrain = 
@@ -1128,9 +1132,9 @@ Dogfighting II =
 Dogfighting III = 
 Choose name for [unitName] = 
 [unitFilter] units gain the [promotion] promotion = 
-         
-# Multiplayer Turn Checker Service 
-         
+
+# Multiplayer Turn Checker Service
+
 Multiplayer options = 
 Enable out-of-game turn notifications = 
 Time between turn checks out-of-game (in minutes) = 
@@ -1139,10 +1143,10 @@ Take user ID from clipboard =
 Doing this will reset your current user ID to the clipboard contents - are you sure? = 
 ID successfully set! = 
 Invalid ID! = 
-         
-         
-# Mods 
-         
+
+
+# Mods
+
 Mods = 
 Download [modName] = 
 Update [modName] = 
@@ -1170,9 +1174,9 @@ No description provided =
 Author: [author] = 
 Size: [size] kB = 
 The mod you selected is incompatible with the defined ruleset! = 
-         
-# Uniques that are relevant to more than one type of game object 
-         
+
+# Uniques that are relevant to more than one type of game object
+
 [stats] from every [param] = 
 [stats] from [param] tiles in this city = 
 [stats] from every [param] on [tileFilter] tiles = 
@@ -1186,8 +1190,8 @@ Can only be built on [tileFilter] tiles =
 Cannot be built on [tileFilter] tiles = 
 Does not need removal of [feature] = 
 Gain a free [building] [cityFilter] = 
-         
-# City filters 
+
+# City filters
 in this city = 
 in all cities = 
 in all coastal cities = 

--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -17,6 +17,7 @@ import com.unciv.models.ruleset.unit.UnitType
 import com.unciv.models.stats.INamed
 import com.unciv.models.stats.NamedStats
 import com.unciv.models.stats.Stat
+import com.unciv.models.stats.Stats
 import com.unciv.models.translations.tr
 import com.unciv.ui.utils.colorFromRGB
 import kotlin.collections.set
@@ -353,7 +354,9 @@ class Ruleset {
                 val improvementName = unique.params[0]
                 if (improvementName !in tileImprovements)
                     lines += "${unit.name} can place improvement $improvementName which does not exist!"
-                else if (tileImprovements[improvementName]!!.firstOrNull() == null && !unit.hasUnique("Bonus for units in 2 tile radius 15%")) {
+                else if ((tileImprovements[improvementName] as Stats).none() &&
+                        unit.isCivilian() &&
+                        !unit.hasUnique("Bonus for units in 2 tile radius 15%")) {
                     lines += "${unit.name} can place improvement $improvementName which has no stats, preventing unit automation!"
                     warningCount++
                 }
@@ -498,6 +501,10 @@ object RulesetCache : HashMap<String,Ruleset>() {
 
     fun getBaseRuleset() = this[BaseRuleset.Civ_V_Vanilla.fullName]!!.clone() // safeguard, so no-one edits the base ruleset by mistake
 
+    /**
+     * Creates a combined [Ruleset] from a list of mods. If no baseRuleset is listed in [mods],
+     * then the vanilla Ruleset is included automatically.
+     */
     fun getComplexRuleset(mods: LinkedHashSet<String>): Ruleset {
         val newRuleset = Ruleset()
         val loadedMods = mods.filter { containsKey(it) }.map { this[it]!! }
@@ -519,13 +526,28 @@ object RulesetCache : HashMap<String,Ruleset>() {
         if (newRuleset.unitTypes.isEmpty()) {
             newRuleset.unitTypes.putAll(getBaseRuleset().unitTypes)
         }
-        
+
         // This one should be permanent
         if (newRuleset.ruinRewards.isEmpty()) {
             newRuleset.ruinRewards.putAll(getBaseRuleset().ruinRewards)
         }
-        
+
         return newRuleset
+    }
+
+    /**
+     * Runs [Ruleset.checkModLinks] on a temporary [combined Ruleset][getComplexRuleset] for a list of [mods]
+     */
+    fun checkCombinedModLinks(mods: LinkedHashSet<String>): Ruleset.CheckModLinksResult {
+        return try {
+            val newRuleset = getComplexRuleset(mods)
+            newRuleset.modOptions.isBaseRuleset = true // This is so the checkModLinks finds all connections
+            newRuleset.checkModLinks()
+        } catch (ex: Exception) {
+            // This happens if a building is dependent on a tech not in the base ruleset
+            //  because newRuleset.updateBuildingCosts() in getComplexRuleset() throws an error
+            Ruleset.CheckModLinksResult(Ruleset.CheckModLinksStatus.Error, ex.localizedMessage)
+        }
     }
 
 }

--- a/core/src/com/unciv/ui/cityscreen/CityConstructionsTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityConstructionsTable.kt
@@ -481,7 +481,7 @@ class CityConstructionsTable(private val cityScreen: CityScreen) {
     /** This tests whether the buy button should be _shown_ */
     private fun isConstructionPurchaseShown(construction: INonPerpetualConstruction, stat: Stat): Boolean {
         val city = cityScreen.city
-        return construction.canBePurchasedWithStat(city, stat) || city.civInfo.gameInfo.gameParameters.godMode
+        return construction.canBePurchasedWithStat(city, stat)
     }
 
     /** This tests whether the buy button should be _enabled_ */

--- a/core/src/com/unciv/ui/civilopedia/CivilopediaText.kt
+++ b/core/src/com/unciv/ui/civilopedia/CivilopediaText.kt
@@ -249,7 +249,7 @@ class FormattedLine (
         }
 
         val fontSize = when {
-            header in headerSizes.indices -> headerSizes[header]
+            header in 1 until headerSizes.size -> headerSizes[header]
             size == Int.MIN_VALUE -> defaultSize
             else -> size
         }

--- a/core/src/com/unciv/ui/newgamescreen/ModCheckboxTable.kt
+++ b/core/src/com/unciv/ui/newgamescreen/ModCheckboxTable.kt
@@ -6,6 +6,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.ruleset.Ruleset.CheckModLinksResult
 import com.unciv.models.ruleset.RulesetCache
+import com.unciv.models.translations.tr
 import com.unciv.ui.utils.*
 
 class ModCheckboxTable(
@@ -15,9 +16,10 @@ class ModCheckboxTable(
     onUpdate: (String) -> Unit
 ): Table(){
     private val modRulesets = RulesetCache.values.filter { it.name != "" }
+    private val baseRulesetCheckboxes = ArrayList<CheckBox>()
+    private var lastToast: ToastPopup? = null
 
     init {
-        val baseRulesetCheckboxes = ArrayList<CheckBox>()
         val extensionRulesetModButtons = ArrayList<CheckBox>()
 
         for (mod in modRulesets.sortedBy { it.name }) {
@@ -51,49 +53,56 @@ class ModCheckboxTable(
             }).padTop(padTop).growX().row()
         }
     }
-    
+
     private fun checkBoxChanged(checkBox: CheckBox, mod: Ruleset): Boolean {
         if (checkBox.isChecked) {
+            // First the quick standalone check
             val modLinkErrors = mod.checkModLinks()
-            if (modLinkErrors.isNotOK()) {
-                ToastPopup("The mod you selected is incorrectly defined!\n\n$modLinkErrors", screen)
+            if (modLinkErrors.isError()) {
+                lastToast?.close()
+                val toastMessage =
+                    "The mod you selected is incorrectly defined!".tr() + "\n\n$modLinkErrors"
+                lastToast = ToastPopup(toastMessage, screen, 5000L)
                 if (modLinkErrors.isError()) {
                     checkBox.isChecked = false
                     return false
                 }
             }
 
+            // Save selection for a rollback
             val previousMods = mods.toList()
 
-            if (mod.modOptions.isBaseRuleset)
+            // Ensure only one base can be selected
+            if (mod.modOptions.isBaseRuleset) {
                 for (oldBaseRuleset in previousMods) // so we don't get concurrent modification exceptions
-                    if (modRulesets.firstOrNull { it.name == oldBaseRuleset }?.modOptions?.isBaseRuleset == true)
+                    if (RulesetCache[oldBaseRuleset]?.modOptions?.isBaseRuleset == true)
                         mods.remove(oldBaseRuleset)
+                baseRulesetCheckboxes.filter { it != checkBox }.forEach { it.isChecked = false }
+            }
             mods.add(mod.name)
 
-            var complexModLinkCheck: CheckModLinksResult
-            try {
-                val newRuleset = RulesetCache.getComplexRuleset(mods)
-                newRuleset.modOptions.isBaseRuleset = true // This is so the checkModLinks finds all connections
-                complexModLinkCheck = newRuleset.checkModLinks()
-            } catch (ex: Exception) {
-                // This happens if a building is dependent on a tech not in the base ruleset
-                //  because newRuleset.updateBuildingCosts() in getComplexRuleset() throws an error
-                complexModLinkCheck = CheckModLinksResult(Ruleset.CheckModLinksStatus.Error, ex.localizedMessage)
-            }
+            // Check over complete combination of selected mods
+            val complexModLinkCheck = RulesetCache.checkCombinedModLinks(mods)
+            if (complexModLinkCheck.isNotOK()) {
+                lastToast?.close()
+                val toastMessage = (
+                        if (complexModLinkCheck.isError()) "The mod combination you selected is incorrectly defined!"
+                        else "{The mod combination you selected has problems.}\n{You can play it, but don't expect everything to work!}"
+                        ).tr() + "\n\n$complexModLinkCheck"
+                lastToast = ToastPopup(toastMessage, screen, 5000L)
 
-            if (complexModLinkCheck.isError()) {
-                ToastPopup("{The mod you selected is incompatible with the defined ruleset!}\n\n{$complexModLinkCheck}", screen)
-                checkBox.isChecked = false
-                mods.clear()
-                mods.addAll(previousMods)
-                return false
+                if (complexModLinkCheck.isError()) {
+                    checkBox.isChecked = false
+                    mods.clear()
+                    mods.addAll(previousMods)
+                    return false
+                }
             }
 
         } else {
             mods.remove(mod.name)
         }
 
-        return true      
+        return true
     }
 }

--- a/core/src/com/unciv/ui/utils/ExtensionFunctions.kt
+++ b/core/src/com/unciv/ui/utils/ExtensionFunctions.kt
@@ -190,16 +190,16 @@ fun String.toLabel() = Label(this.tr(), CameraStageBaseScreen.skin)
 fun Int.toLabel() = this.toString().toLabel()
 
 /** Translate a [String] and make a [Label] widget from it with a specified font color and size */
-fun String.toLabel(fontColor: Color = Color.WHITE, fontSize:Int=18): Label {
+fun String.toLabel(fontColor: Color = Color.WHITE, fontSize: Int = 18): Label {
     // We don't want to use setFontSize and setFontColor because they set the font,
     //  which means we need to rebuild the font cache which means more memory allocation.
     var labelStyle = CameraStageBaseScreen.skin.get(Label.LabelStyle::class.java)
-    if(fontColor!= Color.WHITE || fontSize!=18) { // if we want the default we don't need to create another style
+    if(fontColor != Color.WHITE || fontSize != 18) { // if we want the default we don't need to create another style
         labelStyle = Label.LabelStyle(labelStyle) // clone this to another
         labelStyle.fontColor = fontColor
         if (fontSize != 18) labelStyle.font = Fonts.font
     }
-    return Label(this.tr(), labelStyle).apply { setFontScale(fontSize/Fonts.ORIGINAL_FONT_SIZE) }
+    return Label(this.tr(), labelStyle).apply { setFontScale(fontSize / Fonts.ORIGINAL_FONT_SIZE) }
 }
 
 /**

--- a/core/src/com/unciv/ui/utils/ToastPopup.kt
+++ b/core/src/com/unciv/ui/utils/ToastPopup.kt
@@ -1,6 +1,7 @@
 package com.unciv.ui.utils
 
 import com.badlogic.gdx.Gdx
+import com.badlogic.gdx.scenes.scene2d.Touchable
 import kotlin.concurrent.thread
 
 /**
@@ -11,6 +12,7 @@ class ToastPopup (message: String, screen: CameraStageBaseScreen, val time: Long
     init {
         //Make this popup unobtrusive
         setFillParent(false)
+        onClick { close() }  // or `touchable = Touchable.disabled` so you can operate what's behind
 
         addGoodSizedLabel(message)
         open()

--- a/core/src/com/unciv/ui/utils/UncivTooltip.kt
+++ b/core/src/com/unciv/ui/utils/UncivTooltip.kt
@@ -12,7 +12,7 @@ import com.unciv.models.translations.tr
 /**
  * A **Replacement** for Gdx [Tooltip], placement does not follow the mouse.
  * 
- * Usage: [group][Group].addStaticTip([text][String], size) builds a [Label] as tip actor and attaches it to your [Group].
+ * Usage: [group][Group].addTooltip([text][String], size) builds a [Label] as tip actor and attaches it to your [Group].
  *
  * @param target        The widget the tooltip will be added to - take care this is the same for which addListener is called
  * @param content       The actor to display as Tooltip
@@ -145,7 +145,7 @@ class UncivTooltip <T: Actor>(
         return super.touchDown(event, x, y, pointer, button)
     }
     //endregion
-    
+
     companion object {
         /**
          * Add a [Label]-based Tooltip with a rounded-corner background to a [Table] or other [Group].


### PR DESCRIPTION
As @ravignir hinted elsewhere (#5010), the display of the mod checker on the newgame screen can be too discouraging. This set out to improve only that, but now it's got most minor fixes and lints from the tabbed options, and is based on #5073 plus its effect on german.

- There could be two toasts, one replacing the other quickly
- Display time increased, and to compensate you can click them away, or selection of other mods also removes them.
- Fixes mod checker improvement placer stats test never meant for military units
- Fixes Holy Order - nice how translators already came up with distinct translations for the _two_ templates
- There's about 4-5 nation messages with extraneous trailing blanks (and not caught and matched by the translators) - India, Austria, Huns.. ***not*** fixed here.
- Fixes godmode crashing cityscreen (at least with religion on) and CivilopediaText size not displaying as intended
- Some linting