### PR TITLE
City state intrusion anger

### DIFF
--- a/android/assets/jsons/Civ V - Vanilla/Nations.json
+++ b/android/assets/jsons/Civ V - Vanilla/Nations.json
@@ -41,7 +41,7 @@
 		"leaderName": "Alexander",
 		"adjective": ["Greek"],
 		"startBias": ["Coast"],
-//		"preferredVictoryType":"Diplomatic",
+		"preferredVictoryType":"Diplomatic",
 		
 		"startIntroPart1": "May the blessings of the gods be upon you, oh great King Alexander! You are the ruler of the mighty Greek nation. Your people lived for so many years in isolated city-states - legendary cities such as Athens, Sparta, Thebes - where they gave the world many great things, such as democracy, philosophy, tragedy, art and architecture, the very foundation of Western Civilization. Although few in number and often hostile to each other, in the 5th century BC they were able to defeat their much larger neighbor, Persia, on land and sea.",
 		"startIntroPart2": "Alexander, your people stand ready to march to war, to spread the great Greek culture to millions and to bring you everlasting glory. Are you ready to accept your destiny, King Alexander? Will you lead your people to triumph and greatness? Can you build a civilization that will stand the test of time?",
@@ -59,7 +59,7 @@
 		"outerColor": [181, 232, 232],
 		"innerColor": [68,142,249],
 		"uniqueName": "Hellenic League",
-		"uniques": ["City-State Influence degrades [50]% slower", "City-State Influence recovers at twice the normal rate"],
+		"uniques": ["City-State Influence degrades [50]% slower", "City-State Influence recovers at twice the normal rate", "City-State territory always counts as friendly territory"],
 		"cities": ["Athens","Sparta","Corinth","Argos","Knossos","Mycenae","Pharsalos","Ephesus","Halicarnassus","Rhodes",
 			"Eretria","Pergamon","Miletos","Megara","Phocaea","Sicyon","Tiryns","Samos","Mytilene","Chios",
 			"Paros","Elis","Syracuse","Herakleia","Gortyn","Chalkis","Pylos","Pella","Naxos","Sicyon",
@@ -720,7 +720,7 @@
 		"leaderName": "Gustavus Adolphus",
 		"adjective": ["Swedish"],
 		"startBias": ["Tundra"],
-		"preferredVictoryType": "Domination",
+		"preferredVictoryType": "Diplomatic",
 		
 		"startIntroPart1": "All hail the transcendent King Gustavus Adolphus, founder of the Swedish Empire and her most distinguished military tactician. It was during your reign that Sweden emerged as one of the greatest powers in Europe, due in no small part to your wisdom, both on and off the battlefield. As king, you initiated a number of domestic reforms that ensured the economic stability and prosperity of your people. As the general who came to be known as the \"Lion of the North,\" your visionary designs in warfare gained the admiration of military commanders the world over. Thanks to your triumphs in the Thirty Years' War, you were assured a legacy as one of history's greatest generals.",
 		"startIntroPart2": "Oh noble King, the people long for your prudent leadership, hopeful that once again they will see your kingdom rise to glory. Will you devise daring new strategies, leading your armies to victory on the theater of war? Will you build a civilization that stands the test of time?",

--- a/core/src/com/unciv/logic/automation/NextTurnAutomation.kt
+++ b/core/src/com/unciv/logic/automation/NextTurnAutomation.kt
@@ -45,8 +45,8 @@ object NextTurnAutomation {
             issueRequests(civInfo)
             adoptPolicy(civInfo)  // todo can take a second - why?
         } else {
-            getFreeTechForCityStates(civInfo)
-            updateDiplomaticRelationshipForCityStates(civInfo)
+            civInfo.getFreeTechForCityState()
+            civInfo.updateDiplomaticRelationshipForCityState()
         }
 
         chooseTechToResearch(civInfo)
@@ -235,18 +235,6 @@ object NextTurnAutomation {
                     state.tributeGold(civInfo)
             }
         }
-    }
-
-    private fun getFreeTechForCityStates(civInfo: CivilizationInfo) {
-        // City-States automatically get all techs that at least half of the major civs know
-        val researchableTechs = civInfo.gameInfo.ruleSet.technologies.keys
-            .filter { civInfo.tech.canBeResearched(it) }
-        for (tech in researchableTechs) {
-            val aliveMajorCivs = civInfo.gameInfo.getAliveMajorCivs()
-            if (aliveMajorCivs.count { it.tech.isResearched(tech) } >= aliveMajorCivs.count() / 2)
-                civInfo.tech.addTechnology(tech)
-        }
-        return
     }
 
     private fun chooseTechToResearch(civInfo: CivilizationInfo) {
@@ -473,23 +461,6 @@ object NextTurnAutomation {
             tradeLogic.currentTrade.theirOffers.add(TradeOffer(Constants.researchAgreement, TradeType.Treaty, cost))
 
             otherCiv.tradeRequests.add(TradeRequest(civInfo.civName, tradeLogic.currentTrade.reverse()))
-        }
-    }
-
-    private fun updateDiplomaticRelationshipForCityStates(civInfo: CivilizationInfo) {
-        // Check if city-state invaded by other civs
-        for (otherCiv in civInfo.getKnownCivs().filter { it.isMajorCiv() }) {
-            if (civInfo.isAtWarWith(otherCiv)) continue
-            val diplomacy = civInfo.getDiplomacyManager(otherCiv)
-
-            val unitsInBorder = otherCiv.getCivUnits().count { !it.isCivilian() && it.getTile().getOwner() == civInfo }
-            if (unitsInBorder > 0 && diplomacy.relationshipLevel() < RelationshipLevel.Friend) {
-                diplomacy.addInfluence(-10f)
-                if (!diplomacy.hasFlag(DiplomacyFlags.BorderConflict)) {
-                    otherCiv.popupAlerts.add(PopupAlert(AlertType.BorderConflict, civInfo.civName))
-                    diplomacy.setFlag(DiplomacyFlags.BorderConflict, 10)
-                }
-            }
         }
     }
 

--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -4,7 +4,6 @@ import com.unciv.Constants
 import com.unciv.UncivGame
 import com.unciv.logic.city.CityInfo
 import com.unciv.logic.civilization.*
-import com.unciv.logic.civilization.diplomacy.DiplomacyFlags
 import com.unciv.logic.civilization.diplomacy.DiplomaticModifiers
 import com.unciv.logic.civilization.diplomacy.DiplomaticStatus
 import com.unciv.logic.map.MapUnit
@@ -160,13 +159,7 @@ object Battle {
         if (defeatedUnit.matchesCategory("{Barbarian} {Military}") && civUnit.getCivInfo().isMajorCiv()) {
             for (cityState in UncivGame.Current.gameInfo.getAliveCityStates()) {
                 if (attackedTile.getOwner() == cityState || attackedTile.neighbors.any { it.getOwner() == cityState }) {
-                    val diplomacy = cityState.getDiplomacyManager(civUnit.getCivInfo())
-                    diplomacy.addInfluence(12f)
-                    if (diplomacy.hasFlag(DiplomacyFlags.AngerFreeIntrusion))
-                        diplomacy.setFlag(DiplomacyFlags.AngerFreeIntrusion, diplomacy.getFlag(DiplomacyFlags.AngerFreeIntrusion) + 5)
-                    else
-                        diplomacy.setFlag(DiplomacyFlags.AngerFreeIntrusion, 5)
-                    println("Thx, from " + cityState.civName + ". Feel free to stay for " + diplomacy.getFlag(DiplomacyFlags.AngerFreeIntrusion).toString() + " more turns.")
+                    cityState.threateningBarbarianKilledBy(civUnit.getCivInfo())
                 }
             }
         }

--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -93,10 +93,10 @@ object Battle {
         // Add culture when defeating a barbarian when Honor policy is adopted, gold from enemy killed when honor is complete
         // or any enemy military unit with Sacrificial captives unique (can be either attacker or defender!)
         if (defender.isDefeated() && defender is MapUnitCombatant && !defender.unit.isCivilian()) {
-            tryEarnFromKilling(attacker, defender, attackedTile)
+            tryEarnFromKilling(attacker, defender)
             tryHealAfterKilling(attacker)
         } else if (attacker.isDefeated() && attacker is MapUnitCombatant && !attacker.unit.isCivilian()) {
-            tryEarnFromKilling(defender, attacker, attackedTile)
+            tryEarnFromKilling(defender, attacker)
             tryHealAfterKilling(defender)
         }
 
@@ -116,7 +116,7 @@ object Battle {
         if (!isAlreadyDefeatedCity) postBattleAddXp(attacker, defender)
     }
 
-    private fun tryEarnFromKilling(civUnit: ICombatant, defeatedUnit: MapUnitCombatant, attackedTile: TileInfo) {
+    private fun tryEarnFromKilling(civUnit: ICombatant, defeatedUnit: MapUnitCombatant) {
         val unitStr = max(defeatedUnit.unit.baseUnit.strength, defeatedUnit.unit.baseUnit.rangedStrength)
         val unitCost = defeatedUnit.unit.baseUnit.cost
         var bonusUniquePlaceholderText = "Earn []% of killed [] unit's [] as []"
@@ -156,9 +156,9 @@ object Battle {
         }
 
         // CS friendship from killing barbarians
-        if (defeatedUnit.matchesCategory("{Barbarian} {Military}") && civUnit.getCivInfo().isMajorCiv()) {
+        if (defeatedUnit.matchesCategory("Barbarian") && defeatedUnit.matchesCategory("Military") && civUnit.getCivInfo().isMajorCiv()) {
             for (cityState in UncivGame.Current.gameInfo.getAliveCityStates()) {
-                if (attackedTile.getOwner() == cityState || attackedTile.neighbors.any { it.getOwner() == cityState }) {
+                if (defeatedUnit.unit.threatensCiv(cityState)) {
                     cityState.threateningBarbarianKilledBy(civUnit.getCivInfo())
                 }
             }

--- a/core/src/com/unciv/logic/civilization/CityStateFunctions.kt
+++ b/core/src/com/unciv/logic/civilization/CityStateFunctions.kt
@@ -378,13 +378,7 @@ class CityStateFunctions(val civInfo: CivilizationInfo) {
     }
 
     private fun getNumThreateningBarbarians(): Int {
-        var count = 0
-        for (barb in civInfo.gameInfo.getBarbarianCivilization().getCivUnits()) {
-            // Check if barb in or adjacent to our tiles
-            if (barb.getTile().getTilesInDistance(1).any { it.getOwner() == civInfo })
-                count++
-        }
-        return count
+        return civInfo.gameInfo.getBarbarianCivilization().getCivUnits().count { it.threatensCiv(civInfo) }
     }
 
 }

--- a/core/src/com/unciv/logic/civilization/CityStateFunctions.kt
+++ b/core/src/com/unciv/logic/civilization/CityStateFunctions.kt
@@ -381,4 +381,13 @@ class CityStateFunctions(val civInfo: CivilizationInfo) {
         return civInfo.gameInfo.getBarbarianCivilization().getCivUnits().count { it.threatensCiv(civInfo) }
     }
 
+    fun threateningBarbarianKilledBy(otherCiv: CivilizationInfo) {
+        val diplomacy = civInfo.getDiplomacyManager(otherCiv)
+        diplomacy.addInfluence(12f)
+        if (diplomacy.hasFlag(DiplomacyFlags.AngerFreeIntrusion))
+            diplomacy.setFlag(DiplomacyFlags.AngerFreeIntrusion, diplomacy.getFlag(DiplomacyFlags.AngerFreeIntrusion) + 5)
+        else
+            diplomacy.setFlag(DiplomacyFlags.AngerFreeIntrusion, 5)
+    }
+
 }

--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -915,6 +915,9 @@ class CivilizationInfo {
     fun getFreeTechForCityState() {
         cityStateFunctions.getFreeTechForCityState()
     }
+    fun threateningBarbarianKilledBy(otherCiv: CivilizationInfo) {
+        cityStateFunctions.threateningBarbarianKilledBy(otherCiv)
+    }
     
     fun getAllyCiv() = allyCivName
     fun setAllyCiv(newAllyName: String?) { allyCivName = newAllyName }

--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -909,6 +909,12 @@ class CivilizationInfo {
         cityStateFunctions.tributeWorker(demandingCiv)
     }
     fun canGiveStat(statType: Stat) = cityStateFunctions.canGiveStat(statType)
+    fun updateDiplomaticRelationshipForCityState() {
+        cityStateFunctions.updateDiplomaticRelationshipForCityState()
+    }
+    fun getFreeTechForCityState() {
+        cityStateFunctions.getFreeTechForCityState()
+    }
     
     fun getAllyCiv() = allyCivName
     fun setAllyCiv(newAllyName: String?) { allyCivName = newAllyName }

--- a/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
@@ -323,7 +323,8 @@ class DiplomacyManager() {
      *  This includes friendly and allied city-states and the open border treaties.
      */
     fun isConsideredFriendlyTerritory(): Boolean {
-        if (civInfo.isCityState() && relationshipLevel() >= RelationshipLevel.Friend)
+        if (civInfo.isCityState() &&
+            (relationshipLevel() >= RelationshipLevel.Friend || otherCiv().hasUnique("City-State territory always counts as friendly territory")))
             return true
         return hasOpenBorders
     }

--- a/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
@@ -40,7 +40,8 @@ enum class DiplomacyFlags{
     ProvideMilitaryUnit,
     EverBeenFriends,
     MarriageCooldown,
-    NotifiedAfraid
+    NotifiedAfraid,
+    AngerFreeIntrusion
 }
 
 enum class DiplomaticModifiers{

--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -1037,5 +1037,11 @@ class MapUnit {
         return power
     }
 
+    fun threatensCiv(civInfo: CivilizationInfo): Boolean {
+        if (getTile().getOwner() == civInfo)
+            return true
+        return getTile().neighbors.any { it.getOwner() == civInfo }
+    }
+
     //endregion
 }


### PR DESCRIPTION
Fixes part of #4602.

- `getFreeTechForCityStates` and `updateDiplomaticRelationshipForCityStates` are moved to `CityStateFunctions.kt`
- Civs can enter CS territory without anger if there are barbarians adjacent to CS territory.
- For every such barbarian killed, the civ gets a credit of 5 turns further anger-free intrusion.
- Greece gets an explicit unique: "City-State territory always counts as friendly territory", can always enter CS territory and get healing bonus as if from friendly territory.
- While I was at it, also sets preferred victory for both Greece and Sweden to Diplomatic.

These are all civ V behavior.