### PR TITLE
Fix bugs

### DIFF
--- a/core/src/com/unciv/logic/automation/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/UnitAutomation.kt
@@ -48,13 +48,13 @@ object UnitAutomation {
         if (!unit.civInfo.isMajorCiv()) return false // barbs don't have anything to do in ruins
         val unitDistanceToTiles = unit.movement.getDistanceToTiles()
         val tileWithRuinOrEncampment = unitDistanceToTiles.keys
-                .firstOrNull {
-                    (
-                        (it.improvement != null && it.getTileImprovement()!!.isAncientRuinsEquivalent()) 
-                        || it.improvement == Constants.barbarianEncampment
-                    )
-                    && unit.movement.canMoveTo(it)
-                } ?: return false
+            .firstOrNull {
+                (
+                    (it.improvement != null && it.getTileImprovement()!!.isAncientRuinsEquivalent()) 
+                    || it.improvement == Constants.barbarianEncampment
+                )
+                && unit.movement.canMoveTo(it)
+            } ?: return false
         unit.movement.moveToTile(tileWithRuinOrEncampment)
         return true
     }
@@ -492,6 +492,7 @@ object UnitAutomation {
     It also explores, but also has other functions, like healing if necessary. */
     fun automatedExplore(unit: MapUnit) {
         if (tryGoToRuinAndEncampment(unit) && unit.currentMovement == 0f) return
+        if (unit.isDestroyed) return // Opening ruins _might_ have upgraded us to another unit
         if (unit.health < 80 && tryHealUnit(unit)) return
         if (tryExplore(unit)) return
         unit.civInfo.addNotification("[${unit.displayName()}] finished exploring.", unit.currentTile.position, unit.name, "OtherIcons/Sleep")

--- a/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
@@ -595,7 +595,7 @@ class DiplomacyManager() {
         }
 
         otherCivDiplomacy.setModifier(DiplomaticModifiers.DeclaredWarOnUs, -20f)
-        if (otherCiv.isCityState()) otherCivDiplomacy.influence -= 60
+        if (otherCiv.isCityState()) otherCivDiplomacy.setInfluence(-60f)
 
         for (thirdCiv in civInfo.getKnownCivs()) {
             if (thirdCiv.isAtWarWith(otherCiv)) {

--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -35,6 +35,9 @@ class MapUnit {
 
     @Transient
     val movement = UnitMovementAlgorithms(this)
+    
+    @Transient
+    var isDestroyed = false
 
     // This is saved per each unit because if we need to recalculate viewable tiles every time a unit moves,
     //  and we need to go over ALL the units, that's a lot of time spent on updating information we should already know!
@@ -732,6 +735,7 @@ class MapUnit {
         currentTile.getUnits().filter { it.isTransported && isTransportTypeOf(it) }
             .toList() // because we're changing the list
             .forEach { unit -> unit.destroy() }
+        isDestroyed = true
     }
 
     fun gift(recipient: CivilizationInfo) {
@@ -864,7 +868,7 @@ class MapUnit {
         return getMatchingUniques("Can carry [] [] units").any { mapUnit.matchesFilter(it.params[1]) }
     }
     
-    fun carryCapacity(unit: MapUnit): Int {
+    private fun carryCapacity(unit: MapUnit): Int {
         var capacity = getMatchingUniques("Can carry [] [] units").filter { unit.matchesFilter(it.params[1]) }
                 .sumBy { it.params[0].toInt() }
         capacity += getMatchingUniques("Can carry [] extra [] units").filter { unit.matchesFilter(it.params[1]) }


### PR DESCRIPTION
- Fixed a bug where moving a unit through ancient ruins (but not ending there) and have the unit upgrade from entering these ruins would duplicate the unit
- Fixed a bug where auto-exploring with a unit through ancient ruins (but not ending there) and have the unit upgrade from entering these ruins delete the upgraded unit and un-delete the original unit
- Fixed a bug where declaring war on a city state would lower your influence under the possible minimum