### PR TITLE
Kotlin 1.5 new warnings - partial - Unit

### DIFF
--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -177,7 +177,7 @@ class MapUnit {
             if (isEmbarked()) 2
             else baseUnit.movement
         
-        movement += getMatchingUniques("[] Movement").sumBy { it.params[0].toInt() }
+        movement += getMatchingUniques("[] Movement").sumOf { it.params[0].toInt() }
 
         for (unique in civInfo.getMatchingUniques("+[] Movement for all [] units"))
             if (matchesFilter(unique.params[1]))
@@ -272,7 +272,7 @@ class MapUnit {
                 visibilityRange += unique.params[0].toInt()
 
         // TODO: This should be replaced with "Sight" like others, for naming consistency
-        visibilityRange += getMatchingUniques("[] Visibility Range").sumBy { it.params[0].toInt() }
+        visibilityRange += getMatchingUniques("[] Visibility Range").sumOf { it.params[0].toInt() }
         
         if (hasUnique("Limited Visibility")) visibilityRange -= 1
 
@@ -339,7 +339,7 @@ class MapUnit {
     }
 
     fun maxAttacksPerTurn(): Int {
-        var maxAttacksPerTurn = 1 + getMatchingUniques("[] additional attacks per turn").sumBy { it.params[0].toInt() }
+        var maxAttacksPerTurn = 1 + getMatchingUniques("[] additional attacks per turn").sumOf { it.params[0].toInt() }
         return maxAttacksPerTurn
     }
     
@@ -351,7 +351,7 @@ class MapUnit {
     fun getRange(): Int {
         if (baseUnit.isMelee()) return 1
         var range = baseUnit().range
-        range += getMatchingUniques("[] Range").sumBy { it.params[0].toInt() }
+        range += getMatchingUniques("[] Range").sumOf { it.params[0].toInt() }
         return range
     }
 
@@ -435,7 +435,7 @@ class MapUnit {
     }
 
     private fun adjacentHealingBonus(): Int {
-        return getMatchingUniques("All adjacent units heal [] HP when healing").sumBy { it.params[0].toInt() }
+        return getMatchingUniques("All adjacent units heal [] HP when healing").sumOf { it.params[0].toInt() }
     }
 
     fun canGarrison() = baseUnit.isMilitary() && baseUnit.isLandUnit()
@@ -464,7 +464,7 @@ class MapUnit {
                 for (ability in abilityUsedCount) {
                     val maxUsesOfThisAbility = getMatchingUniques("Can [] [] times")
                         .filter { it.params[0] == ability.key }
-                        .sumBy { it.params[1].toInt() }
+                        .sumOf { it.params[1].toInt() }
                     abilityUsesLeft[ability.key] = maxUsesOfThisAbility - ability.value
                     maxAbilityUses[ability.key] = maxUsesOfThisAbility
                 }
@@ -590,7 +590,7 @@ class MapUnit {
         var amountToHealBy = rankTileForHealing(getTile())
         if (amountToHealBy == 0 && !(hasUnique("May heal outside of friendly territory") && !getTile().isFriendlyTerritory(civInfo))) return
 
-        amountToHealBy += getMatchingUniques("[] HP when healing").sumBy { it.params[0].toInt() }
+        amountToHealBy += getMatchingUniques("[] HP when healing").sumOf { it.params[0].toInt() }
         
         val maxAdjacentHealingBonus = currentTile.getTilesInDistance(1)
             .flatMap { it.getUnits().asSequence() }.map { it.adjacentHealingBonus() }.maxOrNull()
@@ -853,13 +853,13 @@ class MapUnit {
     fun canIntercept(): Boolean {
         if (interceptChance() == 0) return false
         val maxAttacksPerTurn = 1 +
-            getMatchingUniques("[] extra interceptions may be made per turn").sumBy { it.params[0].toInt() }
+            getMatchingUniques("[] extra interceptions may be made per turn").sumOf { it.params[0].toInt() }
         if (attacksThisTurn >= maxAttacksPerTurn) return false
         return true
     }
 
     fun interceptChance(): Int {
-        return getMatchingUniques("[]% chance to intercept air attacks").sumBy { it.params[0].toInt() }
+        return getMatchingUniques("[]% chance to intercept air attacks").sumOf { it.params[0].toInt() }
     }
 
     fun isTransportTypeOf(mapUnit: MapUnit): Boolean {
@@ -867,13 +867,12 @@ class MapUnit {
         if (!mapUnit.baseUnit.movesLikeAirUnits()) return false
         return getMatchingUniques("Can carry [] [] units").any { mapUnit.matchesFilter(it.params[1]) }
     }
-    
+
     private fun carryCapacity(unit: MapUnit): Int {
-        var capacity = getMatchingUniques("Can carry [] [] units").filter { unit.matchesFilter(it.params[1]) }
-                .sumBy { it.params[0].toInt() }
-        capacity += getMatchingUniques("Can carry [] extra [] units").filter { unit.matchesFilter(it.params[1]) }
-            .sumBy { it.params[0].toInt() }
-        return capacity
+        return (getMatchingUniques("Can carry [] [] units")
+                + getMatchingUniques("Can carry [] extra [] units"))
+            .filter { unit.matchesFilter(it.params[1]) }
+            .sumOf { it.params[0].toInt() }
     }
 
     fun canTransport(unit: MapUnit): Boolean {
@@ -886,7 +885,7 @@ class MapUnit {
 
     fun interceptDamagePercentBonus(): Int {
         return getUniques().filter { it.placeholderText == "[]% Damage when intercepting"}
-            .sumBy { it.params[0].toInt() }
+            .sumOf { it.params[0].toInt() }
     }
 
     fun receivedInterceptDamageFactor(): Float {
@@ -994,9 +993,9 @@ class MapUnit {
     fun getBaseMaxActionUses(action: String): Int {
         return getMatchingUniques("Can [] [] times")
             .filter { it.params[0] == action }
-            .sumBy { it.params[1].toInt() }
+            .sumOf { it.params[1].toInt() }
     }
-    
+
     fun setupAbilityUses(buildCity: CityInfo? = null) {
         for (action in religiousActionsUnitCanDo()) {
             val baseAmount = getBaseMaxActionUses(action)
@@ -1004,15 +1003,14 @@ class MapUnit {
                 if (buildCity == null) 0
                 else buildCity.getMatchingUniques("[] units built [] can [] [] extra times")
                     .filter { matchesFilter(it.params[0]) && buildCity.matchesFilter(it.params[1]) && it.params[2] == action }
-                    .sumBy { println("Addition ability found: ${it.params[1]}"); it.params[3].toInt() }
-            
+                    .sumOf { it.params[3].toInt() }
+
             maxAbilityUses[action] = baseAmount + additional
-            
-            abilityUsesLeft[action] = maxAbilityUses[action]!!
+            abilityUsesLeft[action] = baseAmount + additional
         }
     }
-    
-    
+
+
     fun getPressureAddedFromSpread(): Int {
         var pressureAdded = baseUnit.religiousStrength.toFloat()
         for (unique in civInfo.getMatchingUniques("[]% Spread Religion Strength for [] units"))

--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -482,8 +482,8 @@ class BaseUnit : INamed, INonPerpetualConstruction, ICivilopediaText {
                 if (getType().matchesFilter(filter)) return true
                 if (
                     filter.endsWith(" units")
-                    // "military units" --> "Military"
-                    && matchesFilter(filter.removeSuffix(" units").toLowerCase(Locale.ENGLISH).capitalize(Locale.ENGLISH))
+                    // "military units" --> "Military", using invariant locale
+                    && matchesFilter(filter.removeSuffix(" units").lowercase().replaceFirstChar { it.uppercaseChar() })
                 ) return true
                 return uniques.contains(filter)
             }

--- a/core/src/com/unciv/ui/cityscreen/CityScreenCityPickerTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityScreenCityPickerTable.kt
@@ -58,7 +58,6 @@ class CityScreenCityPickerTable(private val cityScreen: CityScreen) : Table() {
                 actionOnOk = { text ->
                     city.name = text
                     cityScreen.game.setScreen(CityScreen(city))
-                    true
                 }
             ).open()
         }

--- a/core/src/com/unciv/ui/civilopedia/CivilopediaScreen.kt
+++ b/core/src/com/unciv/ui/civilopedia/CivilopediaScreen.kt
@@ -173,7 +173,6 @@ class CivilopediaScreen(
         onBackButtonClicked { UncivGame.Current.setWorldScreen() }
 
         val hideReligionItems = !game.gameInfo.hasReligionEnabled()
-        val noCulturalVictory = VictoryType.Cultural !in game.gameInfo.gameParameters.victoryTypes
 
         fun shouldBeDisplayed(uniqueObjects: List<Unique>): Boolean {
             val uniques = uniqueObjects.map { it.placeholderText }

--- a/core/src/com/unciv/ui/utils/AskTextPopup.kt
+++ b/core/src/com/unciv/ui/utils/AskTextPopup.kt
@@ -13,8 +13,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.TextField
  * @param maxLength The maximal amount of characters the user may input
  * @param validate Function that should return `true` when a valid input is entered, false otherwise
  * @param actionOnOk Lambda that will be executed after pressing 'OK'. 
- * Gets the text the user inputted as a parameter. Should return `true` if ready to close,
- * `false` if `errorText` is to be displayed
+ * Gets the text the user inputted as a parameter.
  */
 class AskTextPopup(
     screen: CameraStageBaseScreen,


### PR DESCRIPTION
Another set of files - this time the most interesting change was the `capitalize` call in `BaseUnit.matchesFilter` where the replacement Studio offered was a bit.. obese. I effectively changed the locale used to the invariant one as that simplified the code and since that line deals in pre-translation uniques anyway that should be fine.