### PR TITLE
Fixed bugs with unit movement

### DIFF
--- a/core/src/com/unciv/Constants.kt
+++ b/core/src/com/unciv/Constants.kt
@@ -78,4 +78,6 @@ object Constants {
 
     const val rising = "Rising"
     const val lowering = "Lowering"
+    
+    const val minimumMovementEpsilon = 0.05
 }

--- a/core/src/com/unciv/logic/automation/SpecificUnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/SpecificUnitAutomation.kt
@@ -273,7 +273,7 @@ object SpecificUnitAutomation {
 
         val citiesByNearbyAirUnits = pathsToCities.keys
                 .groupBy { key ->
-                    key.getTilesInDistance(unit.getRange() * 2)
+                    key.getTilesInDistance(unit.getMaxMovementForAirUnits())
                             .count {
                                 val firstAirUnit = it.airUnits.firstOrNull()
                                 firstAirUnit != null && firstAirUnit.civInfo.isAtWarWith(unit.civInfo)
@@ -358,7 +358,7 @@ object SpecificUnitAutomation {
 
     private fun tryRelocateToCitiesWithEnemyNearBy(unit: MapUnit): Boolean {
         val immediatelyReachableCitiesAndCarriers = unit.currentTile
-                .getTilesInDistance(unit.getRange() * 2).filter { unit.movement.canMoveTo(it) }
+                .getTilesInDistance(unit.getMaxMovementForAirUnits()).filter { unit.movement.canMoveTo(it) }
 
         for (city in immediatelyReachableCitiesAndCarriers) {
             if (city.getTilesInDistance(unit.getRange())

--- a/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
+++ b/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
@@ -463,24 +463,6 @@ class UnitMovementAlgorithms(val unit:MapUnit) {
             && (origin.isCityCenter() || lastReachableTile.isCityCenter())
             && unit.civInfo.hasUnique("Units in cities cost no Maintenance")
         ) unit.civInfo.updateStatsForNextTurn()
-
-        // Move through all intermediate tiles to get ancient ruins, barb encampments
-        // and to view tiles along the way
-        // We only activate the moveThroughTile AFTER the putInTile because of a really weird bug -
-        // If you're going to (or past) a ruin, and you activate the ruin bonus, and A UNIT spawns.
-        // That unit could now be blocking your entrance to the destination, so the putInTile would fail! =0
-        // Instead, we move you to the destination directly, and only afterwards activate the various tiles on the way.
-        
-        // Actually, we will now stop doing that becasue of _another_ really weird bug (actually two)
-        // 1. Through some ancient ruins bonuses, we could upgrade our unit, effectively replacing it
-        // with another unit. However, doing so halfway through a movement would make it impossible
-        // to reach the last tile, as the new unit spawns with 0 movement points and not taking
-        // the old route again. Therefore, we might trigger barbarian encampments or ancient ruins
-        // at the destination field we in fact never reach
-        // 2. Which tile we reach might change during the route. Maybe our route used to go through
-        // fog of war, and it turns out there was an enemy city on the route we should take.
-        // As we can't go through cities, we need to find another route, and therefore this
-        // route should be impossible.
         if (needToFindNewRoute) moveToTile(destination, considerZoneOfControl)
     }
 

--- a/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
+++ b/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
@@ -274,7 +274,7 @@ class UnitMovementAlgorithms(val unit:MapUnit) {
 
     fun canReachInCurrentTurn(destination: TileInfo): Boolean {
         if (unit.baseUnit.movesLikeAirUnits())
-            return unit.currentTile.aerialDistanceTo(destination) <= unit.getRange()*2
+            return unit.currentTile.aerialDistanceTo(destination) <= unit.getMaxMovementForAirUnits()
         if (unit.isPreparingParadrop())
             return getDistance(unit.currentTile.position, destination.position) <= unit.paradropRange && canParadropOn(destination)
         return getDistanceToTiles().containsKey(destination)
@@ -283,7 +283,7 @@ class UnitMovementAlgorithms(val unit:MapUnit) {
     fun getReachableTilesInCurrentTurn(): Sequence<TileInfo> {
         return when {
             unit.baseUnit.movesLikeAirUnits() ->
-                unit.getTile().getTilesInDistanceRange(IntRange(1, unit.getRange() * 2))
+                unit.getTile().getTilesInDistanceRange(IntRange(1, unit.getMaxMovementForAirUnits()))
             unit.isPreparingParadrop() ->
                 unit.getTile().getTilesInDistance(unit.paradropRange)
                     .filter { unit.movement.canParadropOn(it) }
@@ -445,7 +445,8 @@ class UnitMovementAlgorithms(val unit:MapUnit) {
 
         if (!unit.civInfo.gameInfo.gameParameters.godMode) {
             unit.currentMovement -= distanceToTiles[lastReachedEnterableTile]!!.totalDistance
-            if (unit.currentMovement < 0.1) unit.currentMovement = 0f // silly floats which are "almost zero"
+            if (unit.currentMovement < Constants.minimumMovementEpsilon) 
+                unit.currentMovement = 0f // silly floats which are "almost zero"
             // const Epsilon, anyone?
         }
 

--- a/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
+++ b/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
@@ -427,12 +427,13 @@ class UnitMovementAlgorithms(val unit:MapUnit) {
                 // Anyway: PANIC!! We stop this route, and after leaving the game in a valid state,
                 // we try again.
                 needToFindNewRoute = true
-                break
+                break // If you ever remove this break, remove the `assumeCanPassThrough` param below
             }
             unit.moveThroughTile(tile)
             
             // In case something goes wrong, cache the last tile we were able to end on
-            if (unit.movement.canMoveTo(tile)) {
+            // We can assume we can pass through this tile, as we would have broken earlier
+            if (unit.movement.canMoveTo(tile, assumeCanPassThrough = true)) {
                 lastReachedEnterableTile = tile
             }
             
@@ -510,11 +511,11 @@ class UnitMovementAlgorithms(val unit:MapUnit) {
      * Designates whether we can enter the tile - without attacking
      * DOES NOT designate whether we can reach that tile in the current turn
      */
-    fun canMoveTo(tile: TileInfo): Boolean {
+    fun canMoveTo(tile: TileInfo, assumeCanPassThrough: Boolean = false): Boolean {
         if (unit.baseUnit.movesLikeAirUnits())
             return canAirUnitMoveTo(tile, unit)
 
-        if (!canPassThrough(tile))
+        if (!assumeCanPassThrough && !canPassThrough(tile))
             return false
 
         // even if they'll let us pass through, we can't enter their city - unless we just captured it


### PR DESCRIPTION
This PR fixes a few bugs introduced in #5103 when I redesigned the way units move:
- Fixed #5123.
- Fixed a bug were moving automated units would not stop automation
- Made sure units now always end up in valid spots when moving, and don't use more movement than necessary