### PR TITLE
Implement limitations for pledge/revoke protection

### DIFF
--- a/core/src/com/unciv/logic/automation/NextTurnAutomation.kt
+++ b/core/src/com/unciv/logic/automation/NextTurnAutomation.kt
@@ -213,11 +213,11 @@ object NextTurnAutomation {
         for (state in civInfo.getKnownCivs().filter{!it.isDefeated() && it.isCityState()}) {
             val diplomacyManager = state.getDiplomacyManager(civInfo.civName)
             if(diplomacyManager.relationshipLevel() >= RelationshipLevel.Friend
-                    && diplomacyManager.diplomaticStatus == DiplomaticStatus.Peace)
+                && state.otherCivCanPledgeProtection(civInfo))
             {
                 state.addProtectorCiv(civInfo)
             } else if (diplomacyManager.relationshipLevel() < RelationshipLevel.Friend
-                    && diplomacyManager.diplomaticStatus == DiplomaticStatus.Protector) {
+                && state.otherCivCanWithdrawProtection(civInfo)) {
                 state.removeProtectorCiv(civInfo)
             }
         }

--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -889,6 +889,8 @@ class CivilizationInfo {
     fun removeProtectorCiv(otherCiv: CivilizationInfo) {
         cityStateFunctions.removeProtectorCiv(otherCiv)
     }
+    fun otherCivCanPledgeProtection(otherCiv: CivilizationInfo) = cityStateFunctions.otherCivCanPledgeProtection(otherCiv)
+    fun otherCivCanWithdrawProtection(otherCiv: CivilizationInfo) = cityStateFunctions.otherCivCanWithdrawProtection(otherCiv)
     fun updateAllyCivForCityState() {
         cityStateFunctions.updateAllyCivForCityState()
     }

--- a/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
@@ -40,7 +40,9 @@ enum class DiplomacyFlags{
     ProvideMilitaryUnit,
     EverBeenFriends,
     MarriageCooldown,
-    NotifiedAfraid
+    NotifiedAfraid,
+    RecentlyPledgedProtection,
+    RecentlyWithdrewProtection,
 }
 
 enum class DiplomaticModifiers{

--- a/core/src/com/unciv/ui/trade/DiplomacyScreen.kt
+++ b/core/src/com/unciv/ui/trade/DiplomacyScreen.kt
@@ -236,7 +236,7 @@ class DiplomacyScreen(val viewingCiv:CivilizationInfo):CameraStageBaseScreen() {
                 }, this).open()
             }
             diplomacyTable.add(revokeProtectionButton).row()
-            if (isNotPlayersTurn()) revokeProtectionButton.disable()
+            if (isNotPlayersTurn() || !otherCiv.otherCivCanWithdrawProtection(viewingCiv)) revokeProtectionButton.disable()
         } else {
             val protectionButton = "Pledge to protect".toTextButton()
             protectionButton.onClick {
@@ -246,11 +246,8 @@ class DiplomacyScreen(val viewingCiv:CivilizationInfo):CameraStageBaseScreen() {
                     updateRightSide(otherCiv)
                 }, this).open()
             }
-            if (viewingCiv.isAtWarWith(otherCiv)) {
-                protectionButton.disable()
-            }
             diplomacyTable.add(protectionButton).row()
-            if (isNotPlayersTurn()) protectionButton.disable()
+            if (isNotPlayersTurn() || !otherCiv.otherCivCanPledgeProtection(viewingCiv)) protectionButton.disable()
         }
 
         val demandTributeButton = "Demand Tribute".toTextButton()


### PR DESCRIPTION
As described in #4602
This PR adds a timer for 10 turns before you can revoke protection, and 20 turns before you can re-pledge after revoking.
The logic for when pledging/revoking is split out to a separate function so code isn't duplicated between logic/AI/diplomacy interface.