### PR TITLE
Add a "Reset to defaults" button to the Newgame screen

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -249,6 +249,7 @@ Uniques =
 Promotions = 
 Load copied data = 
 Could not load game from clipboard! = 
+Reset to defaults = 
 Start game! = 
 Map Options = 
 Game Options = 

--- a/core/src/com/unciv/ui/newgamescreen/NewGameScreen.kt
+++ b/core/src/com/unciv/ui/newgamescreen/NewGameScreen.kt
@@ -44,6 +44,15 @@ class NewGameScreen(
 
         updateRuleset()
 
+        if (UncivGame.Current.settings.lastGameSetup != null) {
+            val resetToDefaultsButton = "Reset to defaults".toTextButton()
+            resetToDefaultsButton.padBottom(5f)
+            rightSideGroup.addActorAt(0, resetToDefaultsButton)
+            resetToDefaultsButton.onClick {
+                game.setScreen(NewGameScreen(previousScreen, GameSetupInfo()))
+            }
+        }
+
         rightSideButton.enable()
         rightSideButton.setText("Start game!".tr())
         rightSideButton.onClick {

--- a/core/src/com/unciv/ui/pickerscreens/PickerScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/PickerScreen.kt
@@ -10,7 +10,7 @@ open class PickerScreen(disableScroll: Boolean = false) : CameraStageBaseScreen(
 
     internal var closeButton: TextButton = Constants.close.toTextButton()
     protected var descriptionLabel: Label
-    private var rightSideGroup = VerticalGroup()
+    protected var rightSideGroup = VerticalGroup()
     protected var rightSideButton: TextButton
     private val screenSplit = 0.85f
     private val maxBottomTableHeight = 150f     // about 7 lines of normal text


### PR DESCRIPTION
@ravignir inspired, not sure there's an issue to link. It's in the `rightSideGroup` which seems to me existed for that purpose.. The saved settings are not forgotten until you actually start a game with the freshly reset defaults, which is cool.

Conflicts with my earlier PR touching PickerScreen expected. Or maybe not - I made sure that visibility change is the same in both.