### PR TITLE
Adds support for opening debug menu on MacOS

### DIFF
--- a/core/src/com/unciv/ui/worldscreen/mainmenu/OptionsPopup.kt
+++ b/core/src/com/unciv/ui/worldscreen/mainmenu/OptionsPopup.kt
@@ -78,7 +78,7 @@ class OptionsPopup(val previousScreen: CameraStageBaseScreen) : Popup(previousSc
                 if (modCheckFirstRun) runModChecker()
             }
         }
-        if (Gdx.input.isKeyPressed(Input.Keys.SHIFT_RIGHT) && Gdx.input.isKeyPressed(Input.Keys.CONTROL_RIGHT)) {
+        if (Gdx.input.isKeyPressed(Input.Keys.SHIFT_RIGHT) && (Gdx.input.isKeyPressed(Input.Keys.CONTROL_RIGHT) || Gdx.input.isKeyPressed(Input.Keys.ALT_RIGHT))) {
             tabs.addPage("Debug", getDebugTab(), ImageGetter.getImage("OtherIcons/SecretOptions"), 24f, secret = true)
         }
 


### PR DESCRIPTION
This PR adds support for opening the debug menu added in #5081 on MacOS.

The reason it wasn't possible to open this menu before on MacOS was because you needed to hold down `Shift Right` and `Control Right` whilst left clicking the options button on the main menu screen. When holding down `Control` on MacOS and left clicking it automaticity converts the click to a right click instead. (Known as a Control Click on MacOS.) This means the menu will not open since you now `Shift Right` + `Right Clicked` instead.

_As far as I could find there is no way to disable Control Click on MacOS without having to download external programs._

I choose to add `Alt Right` as I thought it kept with the theme of buttons on the right side of the keyboard. I wasn't sure if you wanted to keep the `Control Right` option too so I decided to make it possible to use both `Control Right `and `Alt Right`.