### PR TITLE
Religion goes from alpha into beta: available from start screen immediately

### DIFF
--- a/core/src/com/unciv/models/metadata/GameSettings.kt
+++ b/core/src/com/unciv/models/metadata/GameSettings.kt
@@ -47,7 +47,6 @@ class GameSettings {
     var visualMods = HashSet<String>()
 
     var showExperimentalWorldWrap = false // We're keeping this as a config due to ANR problems on Android phones for people who don't know what they're doing :/
-    var showExperimentalReligion = false
 
     var lastOverviewPage: String = "Cities"
 

--- a/core/src/com/unciv/ui/newgamescreen/GameOptionsTable.kt
+++ b/core/src/com/unciv/ui/newgamescreen/GameOptionsTable.kt
@@ -48,8 +48,7 @@ class GameOptionsTable(
         checkboxTable.addOneCityChallengeCheckbox()
         checkboxTable.addNuclearWeaponsCheckbox()
         checkboxTable.addIsOnlineMultiplayerCheckbox()
-        if (UncivGame.Current.settings.showExperimentalReligion)
-            checkboxTable.addReligionCheckbox()
+        checkboxTable.addReligionCheckbox()
         add(checkboxTable).center().row()
 
         if (!withoutMods)

--- a/core/src/com/unciv/ui/worldscreen/mainmenu/OptionsPopup.kt
+++ b/core/src/com/unciv/ui/worldscreen/mainmenu/OptionsPopup.kt
@@ -241,10 +241,6 @@ class OptionsPopup(val previousScreen: CameraStageBaseScreen) : Popup(previousSc
             settings.showExperimentalWorldWrap) {
             settings.showExperimentalWorldWrap = it
         }
-        addYesNoRow("{Enable experimental religion in start games}\n{HIGHLY EXPERIMENTAL - UPDATES WILL BREAK SAVES!}",
-            settings.showExperimentalReligion) {
-            settings.showExperimentalReligion = it
-        }
 
         if (previousScreen.game.limitOrientationsHelper != null) {
             addYesNoRow("Enable portrait orientation", settings.allowAndroidPortrait) {


### PR DESCRIPTION
As almost all the most important parts of religion are implemented at this point, I feel like it is time to open it up to a wider audience.
Some features are still lacking, (most of which can be found in #4290) making this the main reason the option is disabled by default.
After merging this PR, updates to religion should also not invalidate existing saves, and I'll take care to do that.

Starting from this PR, more intrusive features can be added, such as changing existing natural wonders to provide faith, or redesigning the piety tree to provide more faith-related bonuses, even in games with religion disabled.