### PR TITLE
Civilopedia remove migration-only interface elements

### DIFF
--- a/core/src/com/unciv/models/ruleset/Belief.kt
+++ b/core/src/com/unciv/models/ruleset/Belief.kt
@@ -17,8 +17,6 @@ class Belief : INamed, ICivilopediaText, IHasUniques {
 
     override fun makeLink() = "Belief/$name"
     override fun getCivilopediaTextHeader() = FormattedLine(name, icon = makeLink(), header = 2, color = if (type == BeliefType.None) "#e34a2b" else "")
-    override fun replacesCivilopediaDescription() = true
-    override fun hasCivilopediaTextLines() = true
     override fun getSortGroup(ruleset: Ruleset) = type.ordinal
     override fun getIconName() = if (type == BeliefType.None) "Religion" else type.name
 

--- a/core/src/com/unciv/models/ruleset/Building.kt
+++ b/core/src/com/unciv/models/ruleset/Building.kt
@@ -16,7 +16,6 @@ import com.unciv.ui.civilopedia.FormattedLine
 import com.unciv.ui.civilopedia.ICivilopediaText
 import com.unciv.ui.utils.Fonts
 import com.unciv.ui.utils.toPercent
-import java.util.*
 import kotlin.collections.ArrayList
 import kotlin.collections.HashMap
 
@@ -28,13 +27,13 @@ class Building : NamedStats(), INonPerpetualConstruction, ICivilopediaText {
     var cost: Int = 0
     var maintenance = 0
     private var percentStatBonus: Stats? = null
-    var specialistSlots: Counter<String>? = null
+    private var specialistSlots: Counter<String>? = null
     fun newSpecialists(): Counter<String> {
         if (specialistSlots == null) return Counter()
         // Could have old specialist values of "gold", "science" etc - change them to the new specialist names
         val counter = Counter<String>()
         for ((entry, amount) in specialistSlots!!) {
-            val equivalentStat = Stat.values().firstOrNull { it.name.toLowerCase(Locale.ENGLISH) == entry }
+            val equivalentStat = Stat.values().firstOrNull { it.name.lowercase() == entry }
 
             if (equivalentStat != null)
                 counter[Specialist.specialistNameByStat(equivalentStat)] = amount
@@ -58,8 +57,6 @@ class Building : NamedStats(), INonPerpetualConstruction, ICivilopediaText {
 
     /** City can only be built if one of these resources is nearby - it must be improved! */
     var requiredNearbyImprovedResources: List<String>? = null
-    @Deprecated("As of 3.15.19, replace with 'Cannot be built with []' unique")
-    private var cannotBeBuiltWith: String? = null
     var cityStrength = 0
     var cityHealth = 0
     var replaces: String? = null
@@ -67,7 +64,7 @@ class Building : NamedStats(), INonPerpetualConstruction, ICivilopediaText {
     var quote: String = ""
     override var uniques = ArrayList<String>()
     override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it) } }
-    var replacementTextForUniques = ""
+    private var replacementTextForUniques = ""
 
     override var civilopediaText = listOf<FormattedLine>()
 
@@ -167,6 +164,7 @@ class Building : NamedStats(), INonPerpetualConstruction, ICivilopediaText {
             if (unique.params[2].toInt() <= city.religion.getFollowersOfMajorityReligion() && matchesFilter(unique.params[1]))
                 stats.add(unique.stats)
 
+        @Suppress("RemoveRedundantQualifierName")  // make it clearer Building inherits Stats
         for (unique in uniqueObjects)
             if (unique.placeholderText == "[] with []" && civInfo.hasResource(unique.params[1])
                     && Stats.isStats(unique.params[0]))
@@ -198,10 +196,7 @@ class Building : NamedStats(), INonPerpetualConstruction, ICivilopediaText {
         return stats
     }
 
-    override fun getCivilopediaTextHeader() = FormattedLine(name, header=2, icon=makeLink())
     override fun makeLink() = if (isAnyWonder()) "Wonder/$name" else "Building/$name"
-    override fun hasCivilopediaTextLines() = true
-    override fun replacesCivilopediaDescription() = true
 
     override fun getCivilopediaTextLines(ruleset: Ruleset): List<FormattedLine> {
         fun Float.formatSignedInt() = (if (this > 0f) "+" else "") + this.toInt().toString()

--- a/core/src/com/unciv/models/ruleset/Difficulty.kt
+++ b/core/src/com/unciv/models/ruleset/Difficulty.kt
@@ -1,6 +1,5 @@
 package com.unciv.models.ruleset
 
-import com.unciv.Constants
 import com.unciv.models.stats.INamed
 import com.unciv.ui.civilopedia.ICivilopediaText
 import com.unciv.ui.civilopedia.FormattedLine
@@ -33,7 +32,7 @@ class Difficulty: INamed, ICivilopediaText {
     var aiUnhappinessModifier = 1f
     var turnBarbariansCanEnterPlayerTiles = 0
     var clearBarbarianCampReward = 25
-    
+
     // property defined in json but so far unused:
     // var aisExchangeTechs = false
 
@@ -41,8 +40,6 @@ class Difficulty: INamed, ICivilopediaText {
 
 
     override fun makeLink() = "Difficulty/$name"
-    override fun replacesCivilopediaDescription() = true
-    override fun hasCivilopediaTextLines() = true
 
     private fun Float.toPercent() = (this * 100).toInt()
     override fun getCivilopediaTextLines(ruleset: Ruleset): List<FormattedLine> {

--- a/core/src/com/unciv/models/ruleset/Nation.kt
+++ b/core/src/com/unciv/models/ruleset/Nation.kt
@@ -194,8 +194,6 @@ class Nation : INamed, ICivilopediaText, IHasUniques {
     }
 
     override fun makeLink() = "Nation/$name"
-    override fun replacesCivilopediaDescription() = true
-    override fun hasCivilopediaTextLines() = true
     override fun getSortGroup(ruleset: Ruleset) = when {
         isCityState() -> 1
         isBarbarian() -> 9

--- a/core/src/com/unciv/models/ruleset/Policy.kt
+++ b/core/src/com/unciv/models/ruleset/Policy.kt
@@ -51,8 +51,6 @@ open class Policy : INamed, IHasUniques, ICivilopediaText {
     }
 
     override fun makeLink() = "Policy/$name"
-    override fun replacesCivilopediaDescription() = true
-    override fun hasCivilopediaTextLines() = true
     override fun getSortGroup(ruleset: Ruleset) =
         ruleset.eras[branch.era]!!.eraNumber * 10000 +
                 ruleset.policyBranches.keys.indexOf(branch.name) * 100 +

--- a/core/src/com/unciv/models/ruleset/tech/Technology.kt
+++ b/core/src/com/unciv/models/ruleset/tech/Technology.kt
@@ -144,8 +144,6 @@ class Technology: INamed, ICivilopediaText, IHasUniques {
 
 
     override fun makeLink() = "Technology/$name"
-    override fun hasCivilopediaTextLines() = true
-    override fun replacesCivilopediaDescription() = true
 
     override fun getCivilopediaTextLines(ruleset: Ruleset): List<FormattedLine> {
         val lineList = ArrayList<FormattedLine>()

--- a/core/src/com/unciv/models/ruleset/tile/Terrain.kt
+++ b/core/src/com/unciv/models/ruleset/tile/Terrain.kt
@@ -62,8 +62,6 @@ class Terrain : NamedStats(), ICivilopediaText, IHasUniques {
     }
 
     override fun makeLink() = "Terrain/$name"
-    override fun hasCivilopediaTextLines() = true
-    override fun replacesCivilopediaDescription() = true
 
     override fun getCivilopediaTextLines(ruleset: Ruleset): List<FormattedLine> {
         //todo where should we explain Rivers?

--- a/core/src/com/unciv/models/ruleset/tile/TileImprovement.kt
+++ b/core/src/com/unciv/models/ruleset/tile/TileImprovement.kt
@@ -101,8 +101,6 @@ class TileImprovement : NamedStats(), ICivilopediaText, IHasUniques {
     }
 
     override fun makeLink() = "Improvement/$name"
-    override fun hasCivilopediaTextLines() = true
-    override fun replacesCivilopediaDescription() = true
 
     override fun getCivilopediaTextLines(ruleset: Ruleset): List<FormattedLine> {
         val textList = ArrayList<FormattedLine>()

--- a/core/src/com/unciv/models/ruleset/tile/TileResource.kt
+++ b/core/src/com/unciv/models/ruleset/tile/TileResource.kt
@@ -22,8 +22,6 @@ class TileResource : NamedStats(), ICivilopediaText {
 
 
     override fun makeLink() = "Resource/$name"
-    override fun hasCivilopediaTextLines() = true
-    override fun replacesCivilopediaDescription() = true
 
     override fun getCivilopediaTextLines(ruleset: Ruleset): List<FormattedLine> {
         val textList = ArrayList<FormattedLine>()

--- a/core/src/com/unciv/models/ruleset/unit/Promotion.kt
+++ b/core/src/com/unciv/models/ruleset/unit/Promotion.kt
@@ -46,8 +46,6 @@ class Promotion : INamed, ICivilopediaText, IHasUniques {
     }
 
     override fun makeLink() = "Promotion/$name"
-    override fun hasCivilopediaTextLines() = true
-    override fun replacesCivilopediaDescription() = true
 
     override fun getCivilopediaTextLines(ruleset: Ruleset): List<FormattedLine> {
         val textList = ArrayList<FormattedLine>()

--- a/core/src/com/unciv/ui/civilopedia/CivilopediaScreen.kt
+++ b/core/src/com/unciv/ui/civilopedia/CivilopediaScreen.kt
@@ -6,10 +6,7 @@ import com.badlogic.gdx.scenes.scene2d.Touchable
 import com.badlogic.gdx.scenes.scene2d.ui.*
 import com.unciv.Constants
 import com.unciv.UncivGame
-import com.unciv.models.ruleset.Belief
-import com.unciv.models.ruleset.Ruleset
-import com.unciv.models.ruleset.Unique
-import com.unciv.models.ruleset.VictoryType
+import com.unciv.models.ruleset.*
 import com.unciv.models.stats.INamed
 import com.unciv.models.translations.tr
 import com.unciv.ui.utils.*
@@ -29,7 +26,6 @@ class CivilopediaScreen(
 
     /** Container collecting data per Civilopedia entry
      * @param name From [Ruleset] object [INamed.name]
-     * @param description Multiline text
      * @param image Icon for button
      * @param flavour [ICivilopediaText]
      * @param y Y coordinate for scrolling to
@@ -37,14 +33,13 @@ class CivilopediaScreen(
      */
     private class CivilopediaEntry (
         val name: String,
-        val description: String,
         val image: Actor? = null,
         val flavour: ICivilopediaText? = null,
         val y: Float = 0f,              // coordinates of button cell used to scroll to entry
         val height: Float = 0f,
         val sortBy: Int = 0             // optional, enabling overriding alphabetical order
     ) {
-        fun withCoordinates(y: Float, height: Float) = CivilopediaEntry(name, description, image, flavour, y, height, sortBy)
+        fun withCoordinates(y: Float, height: Float) = CivilopediaEntry(name, image, flavour, y, height, sortBy)
     }
 
     private val categoryToEntries = LinkedHashMap<CivilopediaCategories, Collection<CivilopediaEntry>>()
@@ -53,7 +48,6 @@ class CivilopediaScreen(
 
     private val entrySelectTable = Table().apply { defaults().pad(6f).left() }
     private val entrySelectScroll: ScrollPane
-    private val descriptionLabel = "".toLabel()
     private val flavourTable = Table()
 
     private var currentCategory: CivilopediaCategories = CivilopediaCategories.Tutorial
@@ -90,7 +84,6 @@ class CivilopediaScreen(
         currentCategory = category
         entrySelectTable.clear()
         entryIndex.clear()
-        descriptionLabel.setText("")
         flavourTable.clear()
 
         for (button in categoryToButtons.values) button.color = Color.WHITE
@@ -147,13 +140,6 @@ class CivilopediaScreen(
     }
     private fun selectEntry(entry: CivilopediaEntry) {
         currentEntry = entry.name
-        if(entry.flavour != null && entry.flavour.replacesCivilopediaDescription()) {
-            descriptionLabel.setText("")
-            descriptionLabel.isVisible = false
-        } else {
-            descriptionLabel.setText(entry.description)
-            descriptionLabel.isVisible = true
-        }
         flavourTable.clear()
         if (entry.flavour != null) {
             flavourTable.isVisible = true
@@ -207,11 +193,11 @@ class CivilopediaScreen(
             if (hideReligionItems && loopCategory == CivilopediaCategories.Belief) continue
             categoryToEntries[loopCategory] =
                 getCategoryIterator(loopCategory)
-                    .filter { it.getUniquesAsObjects()?.let { uniques -> shouldBeDisplayed(uniques) } ?: true }
+                    .filter { (it as? IHasUniques)?.let { obj -> shouldBeDisplayed(obj.uniqueObjects) } ?: true }
                     .map { CivilopediaEntry(
-                        (it as INamed).name, "",
+                        (it as INamed).name,
                         loopCategory.getImage?.invoke(it.getIconName(), imageSize),
-                        it.takeUnless { ct -> ct.isCivilopediaTextEmpty() },
+                        flavour = it,
                         sortBy = it.getSortGroup(ruleset)
                     ) }
         }
@@ -257,8 +243,6 @@ class CivilopediaScreen(
         entrySelectScroll.setOverscroll(false, false)
         val descriptionTable = Table()
         descriptionTable.add(flavourTable).row()
-        descriptionLabel.wrap = true            // requires explicit cell width!
-        descriptionTable.add(descriptionLabel).width(stage.width * 0.5f).padTop(10f).row()
         val entrySplitPane = SplitPane(entrySelectScroll, ScrollPane(descriptionTable), false, skin)
         entrySplitPane.splitAmount = 0.3f
         entryTable.addActor(entrySplitPane)

--- a/core/src/com/unciv/ui/tutorials/TutorialController.kt
+++ b/core/src/com/unciv/ui/tutorials/TutorialController.kt
@@ -62,8 +62,7 @@ class TutorialController(screen: CameraStageBaseScreen) {
         lines: Array<String>
     ) : INamed, SimpleCivilopediaText(
         sequenceOf(FormattedLine(extraImage = rawName)),
-        lines.asSequence(),
-        true
+        lines.asSequence()
     ) {
         override var name = rawName.replace("_", " ")
     }


### PR DESCRIPTION
Yes, more than two elements of the interface gone. Should also bring warnings down by 1 or 2.

Unrelated changes:
`toLowerCase(Locale.ENGLISH) -> lowercase()` changes the locale to the invariant one, but for the context that's OK.
`cannotBeBuiltWith` had zero references
`@param ignoreTechPolicyRequirements` - param was already gone