### PR TITLE
Prevent packaged exe being shot down by mod atlas packing failures

### DIFF
--- a/desktop/src/com/unciv/app/desktop/ImagePacker.kt
+++ b/desktop/src/com/unciv/app/desktop/ImagePacker.kt
@@ -72,8 +72,13 @@ internal object ImagePacker {
         val modDirectory = File("mods")
         if (modDirectory.exists()) {
             for (mod in modDirectory.listFiles()!!) {
-                if (!mod.isHidden && File(mod.path + "/Images").exists())
-                    packImagesIfOutdated(defaultSettings, mod.path + "/Images", mod.path, "game")
+                if (!mod.isHidden && File(mod.path + "/Images").exists()) {
+                    try {
+                        packImagesIfOutdated(defaultSettings, mod.path + "/Images", mod.path, "game")
+                    } catch (ex: Throwable) {
+                        println("Exception in ImagePacker: ${ex.message}")
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
This partially fixes #5167  - It prevents the "DOS attack" succeeding, but with suppressed console logs I can't really say what the actual exception is.