### PR TITLE
Guard against crash in getNumThreateningBarbarians without barbs

### DIFF
--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -102,16 +102,32 @@ class GameInfo {
                 civIndex++
             }
         }
-        else return getBarbarianCivilization()// you aren't anyone. How did you even get this game? Can you spectate?
+        else return getSpectator(userId)// you aren't anyone. How did you even get this game? Can you spectate?
     }
 
+    /** Get a civ by name
+     *  @throws NoSuchElementException if no civ of than name is in the game (alive or dead)! */
     fun getCivilization(civName: String) = civilizations.first { it.civName == civName }
     fun getCurrentPlayerCivilization() = currentPlayerCiv
-    fun getBarbarianCivilization() = getCivilization(Constants.barbarians)
+    /** Get barbarian civ
+     *  @throws NoSuchElementException in no-barbarians games! */
+    private fun getBarbarianCivilization() = getCivilization(Constants.barbarians)
     fun getDifficulty() = difficultyObject
     fun getCities() = civilizations.asSequence().flatMap { it.cities }
     fun getAliveCityStates() = civilizations.filter { it.isAlive() && it.isCityState() }
     fun getAliveMajorCivs() = civilizations.filter { it.isAlive() && it.isMajorCiv() }
+
+    /** Returns the first spectator for a [playerId] or creates one if none found */
+    fun getSpectator(playerId: String) =
+        civilizations.firstOrNull {
+            it.isSpectator() && it.playerId == playerId
+        } ?:
+        CivilizationInfo(Constants.spectator).also { 
+            it.playerType = PlayerType.Human
+            it.playerId = playerId
+            civilizations.add(it)
+            it.setTransients()
+        }
 
     fun hasReligionEnabled() =
         // Temporary function to check whether religion should be used for this game

--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -126,6 +126,8 @@ class GameInfo {
             it.playerType = PlayerType.Human
             it.playerId = playerId
             civilizations.add(it)
+            it.gameInfo = this
+            it.setNationTransient()
             it.setTransients()
         }
 

--- a/core/src/com/unciv/logic/civilization/CityStateFunctions.kt
+++ b/core/src/com/unciv/logic/civilization/CityStateFunctions.kt
@@ -463,7 +463,10 @@ class CityStateFunctions(val civInfo: CivilizationInfo) {
     }
 
     private fun getNumThreateningBarbarians(): Int {
-        return civInfo.gameInfo.getBarbarianCivilization().getCivUnits().count { it.threatensCiv(civInfo) }
+        if (civInfo.gameInfo.gameParameters.noBarbarians) return 0
+        val barbarianCiv = civInfo.gameInfo.civilizations.firstOrNull { it.isBarbarian() }
+            ?: return 0
+        return barbarianCiv.getCivUnits().count { it.threatensCiv(civInfo) }
     }
 
     fun threateningBarbarianKilledBy(otherCiv: CivilizationInfo) {


### PR DESCRIPTION
For #5171 - that getPlayerToViewAs fallback ~~_untested_~~ half-tested by forcing a singleplayer game into that fallback. Makes you a spectator endlessly "waiting for other players..." - well, maybe in real MP that has a minuscule chance to work.

It's either this or force the player out to the main menu?