### PR TITLE
Zoomable tech tree

### DIFF
--- a/core/src/com/unciv/ui/pickerscreens/PickerScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/PickerScreen.kt
@@ -4,7 +4,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.*
 import com.unciv.Constants
 import com.unciv.UncivGame
 import com.unciv.ui.utils.*
-import com.unciv.ui.utils.AutoScrollPane as ScrollPane
+import com.unciv.ui.utils.AutoScrollPane
 
 open class PickerScreen(disableScroll: Boolean = false) : CameraStageBaseScreen() {
     /** The close button on the lower left of [bottomTable], see [setDefaultCloseAction] */
@@ -47,7 +47,7 @@ open class PickerScreen(disableScroll: Boolean = false) : CameraStageBaseScreen(
         bottomTable.height = (stage.height * (1 - screenSplit)).coerceAtMost(maxBottomTableHeight)
 
         topTable = Table()
-        scrollPane = ScrollPane(topTable)
+        scrollPane = AutoScrollPane(topTable)
 
         scrollPane.setScrollingDisabled(disableScroll, disableScroll)  // lock scrollPane
         if (disableScroll) scrollPane.clearListeners()  // remove focus capture of AutoScrollPane too

--- a/core/src/com/unciv/ui/pickerscreens/TechPickerScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/TechPickerScreen.kt
@@ -45,8 +45,17 @@ class TechPickerScreen(internal val civInfo: CivilizationInfo, centerOnTech: Tec
 
 
     private val turnsToTech = civInfo.gameInfo.ruleSet.technologies.values.associateBy({ it.name }, { civTech.turnsToTech(it.name) })
-    
+
     init {
+        // Replace the PickerScreen AutoScrollPane with a ZoomableScrollPane
+        topTable.remove()
+        scrollPane.remove()
+        scrollPane = ZoomableScrollPane(0.1f, 4f) {
+            scrollPane.setSize(stage.width / it, (stage.height - bottomTable.height) / it)
+        }
+        scrollPane.actor = topTable
+        splitPane.setFirstWidget(scrollPane)
+
         setDefaultCloseAction()
         onBackButtonClicked { UncivGame.Current.setWorldScreen() }
         scrollPane.setOverscroll(false, false)

--- a/core/src/com/unciv/ui/utils/Fonts.kt
+++ b/core/src/com/unciv/ui/utils/Fonts.kt
@@ -121,7 +121,7 @@ object Fonts {
 
     /** All text is originally rendered in 50px (set in AndroidLauncher and DesktopLauncher), and thn scaled to fit the size of the text we need now.
      * This has several advantages: It means we only render each character once (good for both runtime and RAM),
-     * AND it means that our 'custom' emojis only need to be once size (50px) and they'll be rescaled for what's needed. */
+     * AND it means that our 'custom' emojis only need to be one size (50px) and they'll be rescaled for what's needed. */
     const val ORIGINAL_FONT_SIZE = 50f
 
     lateinit var font:BitmapFont

--- a/core/src/com/unciv/ui/utils/ZoomableScrollPane.kt
+++ b/core/src/com/unciv/ui/utils/ZoomableScrollPane.kt
@@ -7,7 +7,11 @@ import com.badlogic.gdx.scenes.scene2d.utils.ActorGestureListener
 import kotlin.math.sqrt
 
 
-open class ZoomableScrollPane: ScrollPane(null) {
+open class ZoomableScrollPane(
+    private val minScale: Float = 0.5f,
+    private val maxScale: Float = 2f,
+    private val notifyZoom: ((Float)->Unit)? = null
+): ScrollPane(null) {
     var continuousScrollingX = false
 
     init{
@@ -15,8 +19,9 @@ open class ZoomableScrollPane: ScrollPane(null) {
     }
 
     open fun zoom(zoomScale: Float) {
-        if (zoomScale < 0.5f || zoomScale > 2f) return
+        if (zoomScale < minScale || zoomScale > maxScale) return
         setScale(zoomScale)
+        notifyZoom?.invoke(zoomScale)
     }
     fun zoomIn() {
         zoom(scaleX / 0.8f)


### PR DESCRIPTION
This is ***broken*** - last version of #5127

I just present it like this in case someone finds out what's wrong with it (my guess: Gdx is what's wrong).

Symptom: Everything is fine until you click a tech while zoomed out. The ScrollPane clips to the size it would have had before the resize to respect scale. Size fixes itself with another zoom - but scroll position has already been broken. In the 'broken' state all dimensions visible in the debugger seem to be identical to the ones before breaking. Breaking occurs as soon as the description label is updated - and that's neither an ascendant nor descendant of anything important. Resizing after selectTechnology doesn't help. Overriding getPref* and returning _any_ values changes nothing.  Programatically zooming after the selectTechnology call doesn't help, neither does picking apart the widget hierarchy between splitPane and techTable, packing, reassembling, in various combinations.

I give up.