### PR TITLE
Fixed military might calculation

### DIFF
--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -29,6 +29,7 @@ import com.unciv.ui.victoryscreen.RankingType
 import java.util.*
 import kotlin.collections.ArrayList
 import kotlin.collections.HashMap
+import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.roundToInt
 import kotlin.math.sqrt
@@ -524,9 +525,8 @@ class CivilizationInfo {
             else
                 unit.getForceEvaluation()
         }
-        val goldBonus = sqrt(gold.toFloat()).toPercent()  // 2f if gold == 10000
+        val goldBonus = sqrt(max(0f, gold.toFloat())).toPercent()  // 2f if gold == 10000
         sum = (sum * min(goldBonus, 2f)).toInt()    // 2f is max bonus
-
         return sum
     }
 


### PR DESCRIPTION
This PR removes a spot where the sqrt of a negative number would be called. This in turn fixes a bug where having negative gold would result in your military might being 0.