### PR TITLE
Updated piety policy tree

### DIFF
--- a/android/assets/jsons/Civ V - Vanilla/Policies.json
+++ b/android/assets/jsons/Civ V - Vanilla/Policies.json
@@ -173,7 +173,7 @@
 			},
 			{
 				"name": "Piety Complete",
-				"uniques": ["[Faith] cost of purchasing [Religious] units [-20]%", "[+3 Gold, +3 Culture] from every [Holy site]"]
+				"uniques": ["[Faith] cost of purchasing items in cities [-20]%", "[+3 Gold, +3 Culture] from every [Holy site]"]
 			}
 		]
 	},

--- a/android/assets/jsons/Civ V - Vanilla/Policies.json
+++ b/android/assets/jsons/Civ V - Vanilla/Policies.json
@@ -135,24 +135,24 @@
 	},{
 		"name": "Piety",
 		"era": "Classical era",
-		"uniques": ["+[15]% Production when constructing [Culture] buildings", "Incompatible with [Rationalism]"],
+		"uniques": ["+[100]% Production when constructing [Shrine] buildings", "+[100]% Production when constructing [Temple] buildings", 
+			"Incompatible with [Rationalism]"],
 		"policies": [
 			{
 				"name": "Organized Religion",
-				"uniques": ["[+1 Happiness] from every [Monument]","[+1 Happiness] from every [Amphitheater]",
-					"[+1 Happiness] from every [Monastery]"],
+				"uniques": ["[+1 Faith] from every [Shrine]","[+1 Faith] from every [Temple]"],
 				"row": 1,
 				"column": 2
 			},
 			{
 				"name": "Mandate Of Heaven",
-				"uniques": ["50% of excess happiness added to culture towards policies"],
+				"uniques": ["[50]% of excess happiness converted to [Culture]"],
 				"row": 1,
 				"column": 5
 			},
 			{
 				"name": "Theocracy",
-				"uniques": ["+[10]% [Gold] from every [Amphitheater]"],
+				"uniques": ["+[10]% [Gold] from every [Temple]"],
 				"requires": ["Organized Religion"],
 				"row": 2,
 				"column": 1
@@ -166,26 +166,19 @@
 			},
 			{
 				"name": "Free Religion",
-				"uniques": ["[+1 Culture] from every [Monument]", "[+1 Culture] from every [Amphitheater]", "[+1 Culture] from every [Monastery]",
-					"Free Social Policy"],
-				"requires": ["Mandate Of Heaven","Reformation"],
+				"uniques": ["Culture cost of adopting new Policies reduced by [10]%"],
+				"requires": ["Mandate Of Heaven", "Reformation"],
 				"row": 3,
 				"column": 4
 			},
 			{
 				"name": "Piety Complete",
-				"uniques": ["Culture cost of adopting new Policies reduced by [10]%"]
+				"uniques": ["[Faith] cost of purchasing [Religious] units [-20]%", "[+3 Gold, +3 Culture] from every [Holy site]"]
 			}
 		]
 	},
 	{
-		"name": "Patronage ",
-		// Yes, there is a space behind this word, and yes, this is necessary
-		// This is, because at the time of writing there existed another policy called 'Patronage' that was recently deprecated
-		// It would, however, still be possible for save-files to contain this policy
-		// Therefore, we had to differentiate between these two, and this was the least intrusive way to do so
-		// NOTE: If you remove the space here, also remove the extra space between 'patronage' and 'complete' in the 'patronage  complete' policy.
-		// Otherwise, weird stuff will happen.
+		"name": "Patronage",
 		"era": "Classical era",
 		"uniques": ["City-State Influence degrades [25]% slower"],
 		"policies": [
@@ -224,11 +217,9 @@
 				"column": 4
 			},
 			{
-				"name": "Patronage  Complete",
-				// This extra space is intentional, see above.
+				"name": "Patronage Complete",
 				"uniques": ["Influence of all other civilizations with all city-states degrades [33]% faster", 
 					"Triggers the following global alert: [Our influence with City-States has started dropping faster!]"]
-				// This triggers a global alert in the G&K game also, based on my memory of playing it
 			} 
 		]
 	},

--- a/core/src/com/unciv/logic/BackwardCompatibility.kt
+++ b/core/src/com/unciv/logic/BackwardCompatibility.kt
@@ -65,6 +65,13 @@ object BackwardCompatibility {
             for (tech in civInfo.tech.techsResearched.toList())
                 if (!ruleSet.technologies.containsKey(tech))
                     civInfo.tech.techsResearched.remove(tech)
+            for (policy in civInfo.policies.adoptedPolicies.toList())
+                if (!ruleSet.policies.containsKey(policy)
+                    // Converstion code for deprecated policies since 3.16.15
+                        && !(policy == "Patronage " || policy == "Patronage  Complete")
+                    //
+                )
+                    civInfo.policies.adoptedPolicies.remove(policy)
         }
     }
 

--- a/core/src/com/unciv/logic/civilization/CivInfoStats.kt
+++ b/core/src/com/unciv/logic/civilization/CivInfoStats.kt
@@ -178,10 +178,19 @@ class CivInfoStats(val civInfo: CivilizationInfo) {
                     )
         }
 
-
-        if (civInfo.hasUnique("50% of excess happiness added to culture towards policies")) {
-            val happiness = civInfo.getHappiness()
-            if (happiness > 0) statMap.add("Policies", Stats(culture = happiness / 2f))
+        // Deprecated since 3.16.15
+            if (civInfo.hasUnique("50% of excess happiness added to culture towards policies")) {
+                val happiness = civInfo.getHappiness()
+                if (happiness > 0) statMap.add("Policies", Stats(culture = happiness / 2f))
+            }
+        //
+        
+        if (civInfo.getHappiness() > 0) {
+            val excessHappinessConversion = Stats()
+            for (unique in civInfo.getMatchingUniques("[]% of excess happiness converted to []")) {
+                excessHappinessConversion.add(Stat.valueOf(unique.params[1]), (unique.params[0].toInt() / 100 * civInfo.getHappiness()).toFloat())
+            }
+            statMap.add("Policies", excessHappinessConversion)
         }
 
         // negative gold hurts science

--- a/core/src/com/unciv/logic/civilization/PolicyManager.kt
+++ b/core/src/com/unciv/logic/civilization/PolicyManager.kt
@@ -50,6 +50,17 @@ class PolicyManager {
     fun getPolicyByName(name: String): Policy = civInfo.gameInfo.ruleSet.policies[name]!!
 
     fun setTransients() {
+        // Deprecated "Patronage " policy since 3.16.15
+            if (adoptedPolicies.contains("Patronage ")) {
+                adoptedPolicies.remove("Patronage ")
+                adoptedPolicies.add("Patronage")
+            }
+            if (adoptedPolicies.contains("Patronage  Complete")) {
+                adoptedPolicies.remove("Patronage  Complete")
+                adoptedPolicies.add("Patronage Complete")
+            }
+        //
+        
         for (policyName in adoptedPolicies)
             addPolicyToTransients(getPolicyByName(policyName))
     }

--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -476,6 +476,7 @@ class BaseUnit : INamed, INonPerpetualConstruction, ICivilopediaText {
 
             "Nuclear Weapon" -> isNuclearWeapon()
             "Great Person", "Great" -> isGreatPerson()
+            "Religious", "religious" -> uniques.contains("Religious Unit")
             else -> {
                 if (getType().matchesFilter(filter)) return true
                 if (

--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -476,7 +476,7 @@ class BaseUnit : INamed, INonPerpetualConstruction, ICivilopediaText {
 
             "Nuclear Weapon" -> isNuclearWeapon()
             "Great Person", "Great" -> isGreatPerson()
-            "Religious", "religious" -> uniques.contains("Religious Unit")
+            "Religious" -> uniques.contains("Religious Unit")
             else -> {
                 if (getType().matchesFilter(filter)) return true
                 if (


### PR DESCRIPTION
This PR updates the piety policy tree to G&K, continuing development of religion (see #4290) and finally finishing off development of policies (see #4084), thereby fixes #4068.
It also removes the space added to the "Patronage " and "Patronage  Complete" policies earlier for differentiating it from the then-recently removed "Patronage" policy.

Added uniques:
"[amount]% of excess happiness converted to [Stat]"

Deprecated uniques:
"50% of excess happiness added to culture towards policies"