### PR TITLE
Made CN tower functional, and free buildings are removed on capture

### DIFF
--- a/android/assets/jsons/Civ V - Vanilla/Policies.json
+++ b/android/assets/jsons/Civ V - Vanilla/Policies.json
@@ -12,7 +12,7 @@
 			},
 			{
 				"name": "Legalism",
-				"uniques":["Immediately creates the cheapest available cultural building in each of your first [4] cities for free"],
+				"uniques":["Provides the cheapest [Culture] building in your first [4] cities for free"],
 				"row": 1,
 				"column": 3
 			},
@@ -38,7 +38,7 @@
 			},
 			{
 				"name": "Tradition Complete",
-				"uniques": ["+[15]% growth [in all cities]","Immediately creates a [Aqueduct] in each of your first [4] cities for free"]
+				"uniques": ["+[15]% growth [in all cities]","Provides a [Aqueduct] in your first [4] cities for free"]
 			}
 		]
 	},

--- a/core/src/com/unciv/logic/city/CityConstructions.kt
+++ b/core/src/com/unciv/logic/city/CityConstructions.kt
@@ -80,7 +80,7 @@ class CityConstructions {
     
     fun getBasicStatBuildings(stat: Stat) = cityInfo.getRuleset().buildings.values
         .asSequence()
-        .filter { !it.isAnyWonder() && it.replaces == null && it.getStats(cityInfo)[stat] > 0f }
+        .filter { !it.isAnyWonder() && it.replaces == null && it.getStats(null)[stat] > 0f }
 
     /**
      * @return [Stats] provided by all built buildings in city plus the bonus from Library

--- a/core/src/com/unciv/logic/city/CityInfo.kt
+++ b/core/src/com/unciv/logic/city/CityInfo.kt
@@ -467,6 +467,7 @@ class CityInfo {
         // Construct units at the beginning of the turn,
         // so they won't be generated out in the open and vulnerable to enemy attacks before you can control them
         cityConstructions.constructIfEnough()
+        cityConstructions.addFreeBuildings()
         cityStats.update()
         tryUpdateRoadStatus()
         attackedThisTurn = false
@@ -632,8 +633,8 @@ class CityInfo {
     fun matchesFilter(filter: String, viewingCiv: CivilizationInfo = civInfo): Boolean {
         return when (filter) {
             "in this city" -> true
-            "in all cities" -> true // Filtered by the way uniques our found
-            "in other cities" -> true // Filtered by the way uniques our found
+            "in all cities" -> true // Filtered by the way uniques are found
+            "in other cities" -> true // Filtered by the way uniques are found
             "in all coastal cities" -> isCoastal()
             "in capital" -> isCapital()
             "in all non-occupied cities" -> !cityStats.hasExtraAnnexUnhappiness() || isPuppet

--- a/core/src/com/unciv/logic/city/CityInfo.kt
+++ b/core/src/com/unciv/logic/city/CityInfo.kt
@@ -144,7 +144,7 @@ class CityInfo {
                 cityConstructions.addBuilding(uniqueBuilding.name)
         }
 
-        civInfo.policies.tryToAddPolicyBuildings()
+        civInfo.civConstructions.tryAddFreeBuildings()
 
         for (unique in getMatchingUniques("Gain a free [] []")) {
             val freeBuildingName = unique.params[0]

--- a/core/src/com/unciv/logic/civilization/CivConstructions.kt
+++ b/core/src/com/unciv/logic/civilization/CivConstructions.kt
@@ -1,0 +1,157 @@
+package com.unciv.logic.civilization
+
+import com.unciv.logic.city.INonPerpetualConstruction
+import com.unciv.models.Counter
+import com.unciv.models.stats.Stat
+import java.util.*
+import kotlin.collections.HashMap
+
+class CivConstructions() {
+
+    @Transient
+    lateinit var civInfo: CivilizationInfo
+
+    // Maps objects to the amount of times bought
+    val boughtItemsWithIncreasingPrice: Counter<String> = Counter()
+
+    // Maps to cities to all free buildings they contain
+    private val maintenanceFreeBuildings: HashMap<String,HashSet<String>> = hashMapOf()
+
+    // Maps stats to the cities that have received a building of that stat
+    // Android Studio said an EnumMap would be better, so I've used that
+    private val freeStatBuildingsProvided: HashMap<Stat, HashSet<String>> = hashMapOf()
+    
+    // Maps buildings to the cities that have received that building
+    private val freeSpecificBuildingsProvided: HashMap<String, HashSet<String>> = hashMapOf()
+    
+    init {
+        for (stat in Stat.values()) {
+            freeStatBuildingsProvided[stat] = hashSetOf()
+        }
+    }
+    
+    fun clone(): CivConstructions {
+        val toReturn = CivConstructions()
+        toReturn.civInfo = civInfo
+        toReturn.maintenanceFreeBuildings.putAll(maintenanceFreeBuildings)
+        toReturn.freeStatBuildingsProvided.putAll(freeStatBuildingsProvided)
+        toReturn.freeSpecificBuildingsProvided.putAll(freeSpecificBuildingsProvided)
+        toReturn.boughtItemsWithIncreasingPrice.add(boughtItemsWithIncreasingPrice.clone())
+        return toReturn
+    }
+    
+    fun setTransients(civInfo: CivilizationInfo) {
+        this.civInfo = civInfo
+        
+        // civInfo.boughtConstructionsWithGloballyIncreasingPrice deprecated since 3.16.15, this is replacement code
+            if (civInfo.boughtConstructionsWithGloballyIncreasingPrice.isNotEmpty()) {
+                for (item in civInfo.boughtConstructionsWithGloballyIncreasingPrice) {
+                    boughtItemsWithIncreasingPrice.add(item.key, item.value)
+                }
+                civInfo.boughtConstructionsWithGloballyIncreasingPrice.clear()
+            }
+        //
+        
+        // Deprecated variables in civ.policies since 3.16.15, this is replacement code
+            if (civInfo.policies.specificBuildingsAdded.isNotEmpty()) {
+                for ((building, cities) in civInfo.policies.specificBuildingsAdded) {
+                    for (cityId in cities) {
+                        if (building !in freeSpecificBuildingsProvided)
+                            freeSpecificBuildingsProvided[building] = hashSetOf()
+                        freeSpecificBuildingsProvided[building]!!.add(cityId)
+
+                        if (cityId !in maintenanceFreeBuildings)
+                            maintenanceFreeBuildings[cityId] = hashSetOf()
+                        maintenanceFreeBuildings[cityId]!!.add(building)
+                    }
+                }
+                civInfo.policies.specificBuildingsAdded.clear()
+            }
+        
+            if (civInfo.policies.cultureBuildingsAdded.isNotEmpty()) {
+                for ((cityId, building) in civInfo.policies.cultureBuildingsAdded) {
+                    freeStatBuildingsProvided[Stat.Culture]!!.add(cityId)
+                    
+                    if (cityId !in maintenanceFreeBuildings)
+                        maintenanceFreeBuildings[cityId] = hashSetOf()
+                    maintenanceFreeBuildings[cityId]!!.add(building)
+                }
+                civInfo.policies.cultureBuildingsAdded.clear()
+            }
+        //
+    }
+    
+    fun startTurn() {
+        tryAddFreeBuildings()
+    }
+    
+    fun tryAddFreeBuildings() {
+        addFreeStatsBuildings()
+        addFreeSpecificBuildings()
+    }
+    
+    fun getMaintenanceFreeBuildings(cityId: String) = maintenanceFreeBuildings[cityId] ?: hashSetOf()
+    
+    
+    private fun addFreeStatsBuildings() {
+        val statUniquesData = civInfo.getMatchingUniques("Provides the cheapest [] building in your first [] cities for free")
+            .groupBy { it.params[0] }
+            .mapKeys { Stat.valueOf(it.key) }
+            .mapValues { unique -> unique.value.sumOf { it.params[1].toInt() } }
+            .toMutableMap()
+        
+        // Deprecated since 3.16.15
+            statUniquesData[Stat.Culture] = (statUniquesData[Stat.Culture] ?: 0) +
+                civInfo.getMatchingUniques("Immediately creates the cheapest available cultural building in each of your first [] cities for free")
+                    .sumOf { it.params[1].toInt() }
+        //
+        
+        
+        for ((stat, amount) in statUniquesData) {
+            addFreeStatBuildings(stat, amount)
+        }
+    }
+    
+    private fun addFreeStatBuildings(stat: Stat, amount: Int) {
+        for (city in civInfo.cities.take(amount)) {
+            if (freeStatBuildingsProvided[stat]!!.contains(city.id) || !city.cityConstructions.hasBuildableStatBuildings(stat)) continue
+            
+            val builtBuilding = city.cityConstructions.addCheapestBuildableStatBuilding(stat)
+            if (builtBuilding != null) {
+                freeStatBuildingsProvided[stat]!!.add(city.id)
+                if (!maintenanceFreeBuildings.containsKey(city.id))
+                    maintenanceFreeBuildings[city.id] = hashSetOf()
+                maintenanceFreeBuildings[city.id]!!.add(builtBuilding)
+            }
+        }
+    }
+    
+    private fun addFreeSpecificBuildings() {
+        val buildingsUniquesData = (civInfo.getMatchingUniques("Provides a [] in your first [] cities for free")
+            // Deprecated since 3.16.15
+                + civInfo.getMatchingUniques("Immediately creates a [] in each of your first [] cities for free")
+            //
+            ).groupBy { it.params[0] }
+            .mapValues { unique -> unique.value.sumOf { it.params[1].toInt() } }
+
+        for ((building, amount) in buildingsUniquesData) {
+            addFreeBuildings(building, amount)
+        }
+    }
+    
+    private fun addFreeBuildings(building: String, amount: Int) {
+        for (city in civInfo.cities.take(amount)) {
+            if (freeSpecificBuildingsProvided[building]?.contains(city.id) == true || city.cityConstructions.containsBuildingOrEquivalent(building)) continue
+
+            (city.cityConstructions.getConstruction(building) as INonPerpetualConstruction).postBuildEvent(city.cityConstructions)
+            
+            if (!freeSpecificBuildingsProvided.containsKey(building))
+                freeSpecificBuildingsProvided[building] = hashSetOf()
+            freeSpecificBuildingsProvided[building]!!.add(city.id)
+
+            if (!maintenanceFreeBuildings.containsKey(city.id))
+                maintenanceFreeBuildings[city.id] = hashSetOf()
+            maintenanceFreeBuildings[city.id]!!.add(building)
+        }
+    }
+}

--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -101,6 +101,7 @@ class CivilizationInfo {
     var civName = ""
     var tech = TechManager()
     var policies = PolicyManager()
+    var civConstructions = CivConstructions()
     var questManager = QuestManager()
     var religionManager = ReligionManager()
     var goldenAges = GoldenAgeManager()
@@ -124,8 +125,11 @@ class CivilizationInfo {
      */
     val temporaryUniques = ArrayList<Pair<Unique, Int>>()
 
-    /** Maps the name of the construction to the amount of times bought */
-    val boughtConstructionsWithGloballyIncreasingPrice = HashMap<String, Int>()
+    // Deprecated since 3.16.15
+        /** Maps the name of the construction to the amount of times bought */
+        @Deprecated("Deprecated since 3.16.15", replaceWith = ReplaceWith("civWideConstructions.boughtItemsWithIncreasingPrice"))
+        val boughtConstructionsWithGloballyIncreasingPrice = HashMap<String, Int>()
+    //
 
     // if we only use lists, and change the list each time the cities are changed,
     // we won't get concurrent modification exceptions.
@@ -153,6 +157,7 @@ class CivilizationInfo {
         toReturn.civName = civName
         toReturn.tech = tech.clone()
         toReturn.policies = policies.clone()
+        toReturn.civConstructions = civConstructions.clone()
         toReturn.religionManager = religionManager.clone()
         toReturn.questManager = questManager.clone()
         toReturn.goldenAges = goldenAges.clone()
@@ -178,7 +183,9 @@ class CivilizationInfo {
         toReturn.cityStateUniqueUnit = cityStateUniqueUnit
         toReturn.flagsCountdown.putAll(flagsCountdown)
         toReturn.temporaryUniques.addAll(temporaryUniques)
-        toReturn.boughtConstructionsWithGloballyIncreasingPrice.putAll(boughtConstructionsWithGloballyIncreasingPrice)
+        // Deprecated since 3.16.15
+            toReturn.boughtConstructionsWithGloballyIncreasingPrice.putAll(boughtConstructionsWithGloballyIncreasingPrice)
+        //
         toReturn.hasEverOwnedOriginalCapital = hasEverOwnedOriginalCapital
         return toReturn
     }
@@ -557,6 +564,8 @@ class CivilizationInfo {
     fun setTransients() {
         goldenAges.civInfo = this
 
+        civConstructions.setTransients(civInfo = this)
+        
         policies.civInfo = this
         if (policies.adoptedPolicies.size > 0 && policies.numberOfAdoptedPolicies == 0)
             policies.numberOfAdoptedPolicies = policies.adoptedPolicies.count { !Policy.isBranchCompleteByName(it) }
@@ -602,7 +611,7 @@ class CivilizationInfo {
     fun updateDetailedCivResources() = transients().updateDetailedCivResources()
 
     fun startTurn() {
-        policies.startTurn()
+        civConstructions.startTurn()
         updateStatsForNextTurn() // for things that change when turn passes e.g. golden age, city state influence
 
         // Generate great people at the start of the turn,

--- a/core/src/com/unciv/logic/civilization/ReligionManager.kt
+++ b/core/src/com/unciv/logic/civilization/ReligionManager.kt
@@ -28,7 +28,7 @@ class ReligionManager {
     // contain the master list, and the ReligionManagers retrieve it from there every time the game loads.
 
     // Deprecated since 3.16.13
-        @Deprecated("Replace by adding to `civInfo.boughtConstructionsWithGloballyIncreasingPrice`")
+        @Deprecated("Replace by adding to `civInfo.civWideConstructions.boughtItemsWithIncreasingPrice`")
         var greatProphetsEarned = 0
             private set
     //
@@ -67,7 +67,7 @@ class ReligionManager {
         
         // greatProphetsEarned deprecated since 3.16.13, replacement code
             if (greatProphetsEarned != 0) {
-                civInfo.boughtConstructionsWithGloballyIncreasingPrice[getGreatProphetEquivalent()!!] = greatProphetsEarned
+                civInfo.civConstructions.boughtItemsWithIncreasingPrice[getGreatProphetEquivalent()!!] = greatProphetsEarned
                 greatProphetsEarned = 0
             }
         //
@@ -115,7 +115,7 @@ class ReligionManager {
     // https://www.reddit.com/r/civ/comments/2m82wu/can_anyone_detail_the_finer_points_of_great/
     // Game files (globaldefines.xml)
     fun faithForNextGreatProphet(): Int {
-        val greatProphetsEarned = civInfo.boughtConstructionsWithGloballyIncreasingPrice[getGreatProphetEquivalent()!!] ?: 0
+        val greatProphetsEarned = civInfo.civConstructions.boughtItemsWithIncreasingPrice[getGreatProphetEquivalent()!!] ?: 0
         
         var faithCost = 
             (200 + 100 * greatProphetsEarned * (greatProphetsEarned + 1) / 2f) * 
@@ -152,8 +152,7 @@ class ReligionManager {
             val prophet = civInfo.addUnit(prophetUnitName, birthCity) ?: return
             prophet.religion = religion!!.name
             storedFaith -= faithForNextGreatProphet()
-            civInfo.boughtConstructionsWithGloballyIncreasingPrice[prophetUnitName] = 
-                (civInfo.boughtConstructionsWithGloballyIncreasingPrice[prophetUnitName] ?: 0) + 1
+            civInfo.civConstructions.boughtItemsWithIncreasingPrice.add(prophetUnitName, 1)
         }
     }
 

--- a/core/src/com/unciv/logic/civilization/RuinsManager/RuinsManager.kt
+++ b/core/src/com/unciv/logic/civilization/RuinsManager/RuinsManager.kt
@@ -43,7 +43,7 @@ class RuinsManager {
             if (civInfo.gameInfo.difficulty in possibleReward.excludedDifficulties) continue
             if (Constants.hiddenWithoutReligionUnique in possibleReward.uniques && !civInfo.gameInfo.hasReligionEnabled()) continue
             if ("Hidden after generating a Great Prophet" in possibleReward.uniques 
-                && civInfo.boughtConstructionsWithGloballyIncreasingPrice[civInfo.religionManager.getGreatProphetEquivalent()] ?: 0 > 0
+                && civInfo.civConstructions.boughtItemsWithIncreasingPrice[civInfo.religionManager.getGreatProphetEquivalent()] ?: 0 > 0
             ) continue
             if (possibleReward.uniqueObjects.any { unique ->
                 unique.placeholderText == "Only available after [] turns" 

--- a/core/src/com/unciv/models/ruleset/Building.kt
+++ b/core/src/com/unciv/models/ruleset/Building.kt
@@ -151,7 +151,8 @@ class Building : NamedStats(), INonPerpetualConstruction, ICivilopediaText {
     }
 
     fun getStats(city: CityInfo?): Stats {
-        val stats = this.clone()
+        // Calls the clone function of the NamedStats this class is derived from, not a clone function of this class
+        val stats = this.clone() 
         if (city == null) return stats
         val civInfo = city.civInfo
 

--- a/core/src/com/unciv/models/ruleset/Building.kt
+++ b/core/src/com/unciv/models/ruleset/Building.kt
@@ -651,20 +651,7 @@ class Building : NamedStats(), INonPerpetualConstruction, ICivilopediaText {
         }
 
         // "Provides a free [buildingName] [cityFilter]"
-        val freeBuildingUniques = uniqueObjects.asSequence().filter { it.placeholderText=="Provides a free [] []" }
-
-        for (unique in freeBuildingUniques) {
-            val affectedCities =
-                if (unique.params[1] == "in this city") sequenceOf(cityConstructions.cityInfo)
-                else civInfo.cities.asSequence().filter { it.matchesFilter(unique.params[1]) }
-
-            val freeBuildingName = civInfo.getEquivalentBuilding(unique.params[0]).name
-
-            for (city in affectedCities) {
-                if (cityConstructions.containsBuildingOrEquivalent(freeBuildingName)) continue
-                cityConstructions.addBuilding(freeBuildingName)
-            }
-        }
+        cityConstructions.addFreeBuildings()
 
         for (unique in uniqueObjects)
             UniqueTriggerActivation.triggerCivwideUnique(unique, civInfo, cityConstructions.cityInfo)

--- a/core/src/com/unciv/models/ruleset/Unique.kt
+++ b/core/src/com/unciv/models/ruleset/Unique.kt
@@ -457,6 +457,10 @@ object UniqueTriggerActivation {
                     civInfo.addNotification(notification, NotificationIcon.Diplomacy)
                 return true
             }
+            
+            "Provides the cheapest [] building in your first [] cities for free", 
+            "Provides a [] in your first [] cities for free" ->
+                civInfo.civConstructions.tryAddFreeBuildings()
         }
         return false
     }

--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -14,7 +14,6 @@ import com.unciv.ui.civilopedia.FormattedLine
 import com.unciv.ui.civilopedia.ICivilopediaText
 import com.unciv.ui.utils.Fonts
 import com.unciv.ui.utils.toPercent
-import java.util.*
 import kotlin.collections.ArrayList
 import kotlin.collections.HashMap
 import kotlin.collections.HashSet
@@ -254,7 +253,7 @@ class BaseUnit : INamed, INonPerpetualConstruction, ICivilopediaText {
                     getCostForConstructionsIncreasingInPrice(
                         it.params[1].toInt(),
                         it.params[5].toInt(),
-                        cityInfo.civInfo.boughtConstructionsWithGloballyIncreasingPrice[name] ?: 0
+                        cityInfo.civInfo.civConstructions.boughtItemsWithIncreasingPrice[name] ?: 0
                     )
                 }
             )
@@ -267,7 +266,7 @@ class BaseUnit : INamed, INonPerpetualConstruction, ICivilopediaText {
                     getCostForConstructionsIncreasingInPrice(
                         it.params[1].toInt(),
                         it.params[4].toInt(),
-                        cityInfo.civInfo.boughtConstructionsWithGloballyIncreasingPrice[name] ?: 0
+                        cityInfo.civInfo.civConstructions.boughtItemsWithIncreasingPrice[name] ?: 0
                     )        
                 }
             )


### PR DESCRIPTION
This PR adds a CivConstructions class, which keeps track of constructions added to cities by global effects.
It also makes the CN tower functional, fixes #5185:
If the owner of the CN tower changes, the originally placed broadcast towers disappear, and broadcast towers are placed in all the cities of the new owner.
Whenever a city is captured, free buildings are now also removed from it, and new free buildings are added to it immediately.