### PR TITLE
Initial unique compliance detection - buildings only.

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -1242,3 +1242,4 @@ This Unit upgrades for free =
 [stats] when a city adopts this religion for the first time = 
 Never destroyed when the city is captured = 
 Invisible to others = 
+Will not be displayed in Civilopedia = 

--- a/core/src/com/unciv/UncivGame.kt
+++ b/core/src/com/unciv/UncivGame.kt
@@ -98,8 +98,8 @@ class UncivGame(parameters: UncivGameParameters) : Game() {
         Gdx.graphics.isContinuousRendering = settings.continuousRendering
 
         thread(name = "LoadJSON") {
-            RulesetCache.loadRulesets(printOutput = true)
             translations.tryReadTranslationForCurrentLanguage()
+            RulesetCache.loadRulesets(printOutput = true) // needs to be after translation loading, for the ruleset checks
             translations.loadPercentageCompleteOfLanguages()
             TileSetCache.loadTileSetConfigs(printOutput = true)
 

--- a/core/src/com/unciv/models/translations/TranslationFileReader.kt
+++ b/core/src/com/unciv/models/translations/TranslationFileReader.kt
@@ -10,30 +10,35 @@ object TranslationFileReader {
     const val percentagesFileLocation = "jsons/translations/completionPercentages.properties"
     val charset: String = Charset.forName("UTF-8").name()
 
-    fun read(file: FileHandle): LinkedHashMap<String, String> {
+    fun read(file:FileHandle): LinkedHashMap<String, String> {
         val translations = LinkedHashMap<String, String>()
         file.reader(charset).forEachLine { line ->
-            if(!line.contains(" = ")) return@forEachLine
+            if (!line.contains(" = ")) return@forEachLine
             val splitLine = line.split(" = ")
-            if(splitLine[1]!="") { // the value is empty, this means this wasn't translated yet
-                val value = splitLine[1].replace("\\n","\n")
-                val key = splitLine[0].replace("\\n","\n")
-                translations[key] = value
-            }
+            val value = splitLine[1].replace("\\n", "\n")
+            val key = splitLine[0].replace("\\n", "\n")
+            translations[key] = value
         }
         return translations
     }
 
-    fun readLanguagePercentages():HashMap<String,Int>{
+    fun readAndFilterEmpty(file: FileHandle): LinkedHashMap<String, String> {
+        val allTranslations = read(file)
+        for ((key, value) in allTranslations.toList())
+            if (value == "")
+                allTranslations.remove(key)
+        return allTranslations
+    }
 
-        val hashmap = HashMap<String,Int>()
+    fun readLanguagePercentages(): HashMap<String, Int> {
+
+        val hashmap = HashMap<String, Int>()
         val percentageFile = Gdx.files.internal(percentagesFileLocation)
-        if(!percentageFile.exists()) return hashmap
-        for(line in percentageFile.reader().readLines()){
+        if (!percentageFile.exists()) return hashmap
+        for (line in percentageFile.reader().readLines()) {
             val splitLine = line.split(" = ")
-            hashmap[splitLine[0]]=splitLine[1].toInt()
+            hashmap[splitLine[0]] = splitLine[1].toInt()
         }
         return hashmap
     }
-
 }

--- a/core/src/com/unciv/models/translations/Translations.kt
+++ b/core/src/com/unciv/models/translations/Translations.kt
@@ -84,7 +84,7 @@ class Translations : LinkedHashMap<String, TranslationEntry>(){
         val languageTranslations: HashMap<String, String>
         try { // On some devices we get a weird UnsupportedEncodingException
             // which is super odd because everyone should support UTF-8
-            languageTranslations = TranslationFileReader.read(Gdx.files.internal(translationFileName))
+            languageTranslations = TranslationFileReader.readAndFilterEmpty(Gdx.files.internal(translationFileName))
         } catch (ex: Exception) {
             return
         }
@@ -94,7 +94,7 @@ class Translations : LinkedHashMap<String, TranslationEntry>(){
             val modTranslationFile = modFolder.child(translationFileName)
             if (modTranslationFile.exists()) {
                 val translationsForMod = Translations()
-                createTranslations(language, TranslationFileReader.read(modTranslationFile), translationsForMod)
+                createTranslations(language, TranslationFileReader.readAndFilterEmpty(modTranslationFile), translationsForMod)
 
                 modsWithTranslations[modFolder.name()] = translationsForMod
             }


### PR DESCRIPTION
This is the first level of compliance detection.
Using the translation files, where all existing unique formats should be stored, we can root out bad uniques when mod checking.
Furthermore, using the auto-generated *values* for placeholders, we can detect bad *values* of placeholders for uniques.

All of these should be warnings for several reasons:
A. When deprecating a unique, since its value  will not be used by the base game anymore, its translation will be auto-removed the next version. However, it will still work. Having the deprecated unique show up as a warning is a good thing in keeping mod uniques up to date, but this shouldn't stop the mods from working.
B. Some mod uniques are flavor text. This is absolutely fine!
C. Some uniques are special and used for filtering. For example, you can add a "Magic" unique to units so that you can catch them with a "[Magic] units" unitFilter.

Asking for your thoughts on this. Once the initial form of the compliance checking is in place, expanding it to include all other unique-containing ruleset objects, and expanding the placeholder checks to include e.g. Stat and Stats, should be simple enough.