### PR TITLE
Add a fixed base strength to motivationToAttack

### DIFF
--- a/core/src/com/unciv/logic/automation/NextTurnAutomation.kt
+++ b/core/src/com/unciv/logic/automation/NextTurnAutomation.kt
@@ -498,8 +498,9 @@ object NextTurnAutomation {
     }
 
     private fun motivationToAttack(civInfo: CivilizationInfo, otherCiv: CivilizationInfo): Int {
-        val ourCombatStrength = civInfo.getStatForRanking(RankingType.Force).toFloat()
-        var theirCombatStrength = otherCiv.getStatForRanking(RankingType.Force).toFloat()
+        val baseForce = 30f
+        val ourCombatStrength = civInfo.getStatForRanking(RankingType.Force).toFloat() + baseForce
+        var theirCombatStrength = otherCiv.getStatForRanking(RankingType.Force).toFloat() + baseForce
 
         //for city-states, also consider there protectors
         if(otherCiv.isCityState() and otherCiv.getProtectorCivs().isNotEmpty()) {


### PR DESCRIPTION
The problem: The new force evaluation algorithm does not add city strengths. In very early game city-states have no army which makes the AI think it has overwhelming odds of attacking them.
The solution: As in civ V's equivalent function `CvDiplomacyAI::DoUpdateOnePlayerMilitaryStrength`, adds a base value of 30 (slightly more than a Warrior) to the force evaluations to reduce swinginess in early game.