### PR TITLE
Fixed intercept chance being inverted

### DIFF
--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -717,7 +717,7 @@ object Battle {
         if (attacker.unit.hasUnique("Cannot be intercepted")) return
         for (interceptor in interceptingCiv.getCivUnits()
             .filter { it.canIntercept(attackedTile) }) {
-            if (Random().nextFloat() > 100f / interceptor.interceptChance()) continue
+            if (Random().nextFloat() > interceptor.interceptChance() / 100f) continue
 
             var damage = BattleDamage.calculateDamageToDefender(
                 MapUnitCombatant(interceptor),


### PR DESCRIPTION
If I'm not mistaken, this fixes a bug where interceptions would only fail if there is more than 100% chance to intercept. I've made this edit on mobile, so I can't test the effects though