### PR TITLE
fix bug on capturing capital

### DIFF
--- a/core/src/com/unciv/logic/city/CityInfoConquestFunctions.kt
+++ b/core/src/com/unciv/logic/city/CityInfoConquestFunctions.kt
@@ -37,6 +37,7 @@ class CityInfoConquestFunctions(val city: CityInfo){
             for (building in cityConstructions.getBuiltBuildings()) {
                 when {
                     building.hasUnique("Never destroyed when the city is captured") || building.isWonder -> continue
+                    building.hasUnique("Indicates the capital city") -> continue // Palace needs to stay a just a bit longer so moveToCiv isn't confused
                     building.hasUnique("Destroyed when the city is captured") ->
                         cityConstructions.removeBuilding(building.name)
                     else -> {


### PR DESCRIPTION
Fixes #5262 
The issue was that `destroyBuildingsOnCapture` which is called prior to `moveToCiv`, had a random chance of destroying the Palace. `moveToCiv` did then not know to assign a new capital, and so next call of `getCapital` crashes the game.
Added a check to `destroyBuildingsOnCapture` so the Palace is not destroyed just yet.