### PR TITLE
Using reflection to find and report deprecated uniques

### DIFF
--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -23,7 +23,6 @@ import com.unciv.models.stats.Stats
 import com.unciv.models.translations.tr
 import com.unciv.ui.utils.colorFromRGB
 import kotlin.collections.set
-import kotlin.reflect.typeOf
 
 object ModOptionsConstants {
     const val diplomaticRelationshipsCannotChange = "Diplomatic relationships cannot change"

--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -23,6 +23,7 @@ import com.unciv.models.stats.Stats
 import com.unciv.models.translations.tr
 import com.unciv.ui.utils.colorFromRGB
 import kotlin.collections.set
+import kotlin.reflect.typeOf
 
 object ModOptionsConstants {
     const val diplomaticRelationshipsCannotChange = "Diplomatic relationships cannot change"
@@ -312,10 +313,18 @@ class Ruleset {
             if (unique.type == null) continue
             val complianceErrors = unique.type.getComplianceErrors(unique, this)
             for (complianceError in complianceErrors) {
-                if (complianceError.errorSeverity ==  severityToReport)
+                if (complianceError.errorSeverity == severityToReport)
                     lines += "$name's unique \"${unique.text}\" contains parameter ${complianceError.parameterName}," +
                             " which does not fit parameter type" +
                             " ${complianceError.acceptableParameterTypes.joinToString(" or ") { it.parameterName }} !"
+            }
+
+            val deprecationAnnotation = unique.type.declaringClass.getField(unique.type.name)
+                .getAnnotation(Deprecated::class.java)
+            if (deprecationAnnotation != null) {
+                // Not user-visible
+                println("$name's unique \"${unique.text}\" is deprecated ${deprecationAnnotation.message}," +
+                        " replace with \"${deprecationAnnotation.replaceWith.expression}\"")
             }
         }
     }


### PR DESCRIPTION
CLI output (for RekMOD as example):
`Manchuria's unique "-[100]% [Mounted] unit maintenance costs" is deprecated As of 3.16.16, replace with "[amount]% maintenance costs for [mapUnitFilter] units"`

Again we encounter the problem of "how do we display certain errors to the mod creator and not to the users"
For now I'm fine with using the cli, but suggestions are welcome

The reason I removed the deprecation replacement from the UniqueType is because I wanted to give a varargs of acceptable targets for the unique, and I couldn't do that with an "optional" deprecation unless I specified for each one that yes, this is really not deprecated. This way is definitely an improvement over that way.