### PR TITLE
Save the sources of uniques with the uniques themselves

### DIFF
--- a/core/src/com/unciv/logic/trade/TradeEvaluation.kt
+++ b/core/src/com/unciv/logic/trade/TradeEvaluation.kt
@@ -254,7 +254,7 @@ class TradeEvaluation {
     fun distanceCityTradeModifier(civInfo: CivilizationInfo, capitalcity: CityInfo, city: CityInfo): Int{
         val distanceBetweenCities = capitalcity.getCenterTile().aerialDistanceTo(city.getCenterTile())
 
-        if (distanceBetweenCities < 500)  return 0
+        if (distanceBetweenCities < 500) return 0
         return min(50,  (500 - distanceBetweenCities) * civInfo.getEraNumber())
     }
 

--- a/core/src/com/unciv/models/ruleset/Belief.kt
+++ b/core/src/com/unciv/models/ruleset/Belief.kt
@@ -2,6 +2,7 @@ package com.unciv.models.ruleset
 
 import com.unciv.UncivGame
 import com.unciv.models.ruleset.unique.Unique
+import com.unciv.models.ruleset.unique.UniqueTarget
 import com.unciv.models.stats.INamed
 import com.unciv.models.translations.tr
 import com.unciv.ui.civilopedia.FormattedLine
@@ -12,7 +13,7 @@ class Belief : INamed, ICivilopediaText, IHasUniques {
     override var name: String = ""
     var type: BeliefType = BeliefType.None
     override var uniques = ArrayList<String>()
-    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it) } }
+    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it, UniqueTarget.Belief, name) } }
 
     override var civilopediaText = listOf<FormattedLine>()
 

--- a/core/src/com/unciv/models/ruleset/Building.kt
+++ b/core/src/com/unciv/models/ruleset/Building.kt
@@ -8,6 +8,7 @@ import com.unciv.models.Counter
 import com.unciv.models.ruleset.tile.ResourceType
 import com.unciv.models.ruleset.tile.TileImprovement
 import com.unciv.models.ruleset.unique.Unique
+import com.unciv.models.ruleset.unique.UniqueTarget
 import com.unciv.models.ruleset.unique.UniqueTriggerActivation
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.stats.NamedStats
@@ -66,7 +67,11 @@ class Building : NamedStats(), INonPerpetualConstruction, ICivilopediaText {
     var uniqueTo: String? = null
     var quote: String = ""
     override var uniques = ArrayList<String>()
-    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it) } }
+    override val uniqueObjects: List<Unique> by lazy { 
+        uniques.map { 
+            Unique(it, if (isAnyWonder()) UniqueTarget.Wonder else UniqueTarget.Building, name) 
+        } 
+    }
     private var replacementTextForUniques = ""
 
     override var civilopediaText = listOf<FormattedLine>()

--- a/core/src/com/unciv/models/ruleset/Era.kt
+++ b/core/src/com/unciv/models/ruleset/Era.kt
@@ -4,6 +4,7 @@ import com.badlogic.gdx.graphics.Color
 import com.unciv.logic.civilization.CityStateType
 import com.unciv.logic.civilization.diplomacy.RelationshipLevel
 import com.unciv.models.ruleset.unique.Unique
+import com.unciv.models.ruleset.unique.UniqueTarget
 import com.unciv.models.stats.INamed
 import com.unciv.ui.utils.colorFromRGB
 
@@ -32,12 +33,12 @@ class Era : INamed, IHasUniques {
 
     var iconRGB: List<Int>? = null
     override var uniques: ArrayList<String> = arrayListOf()
-    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it) } }
+    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it, UniqueTarget.Era, name) } }
 
     private fun initBonuses(bonusMap: Map<String, List<String>>): Map<CityStateType, List<Unique>> {
         val objectMap = HashMap<CityStateType, List<Unique>>()
         for ((cityStateType, bonusList) in bonusMap) {
-            objectMap[CityStateType.valueOf(cityStateType)] = bonusList.map { Unique(it) }
+            objectMap[CityStateType.valueOf(cityStateType)] = bonusList.map { Unique(it, UniqueTarget.CityState) }
         }
         return objectMap
     }

--- a/core/src/com/unciv/models/ruleset/Nation.kt
+++ b/core/src/com/unciv/models/ruleset/Nation.kt
@@ -5,6 +5,7 @@ import com.unciv.Constants
 import com.unciv.UncivGame
 import com.unciv.logic.civilization.CityStateType
 import com.unciv.models.ruleset.unique.Unique
+import com.unciv.models.ruleset.unique.UniqueTarget
 import com.unciv.models.stats.INamed
 import com.unciv.models.translations.squareBraceRegex
 import com.unciv.models.translations.tr
@@ -43,7 +44,7 @@ class Nation : INamed, ICivilopediaText, IHasUniques {
     lateinit var outerColor: List<Int>
     var uniqueName = ""
     override var uniques = ArrayList<String>()
-    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it) } }
+    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it, UniqueTarget.Nation, name) } }
     var uniqueText = ""
     var innerColor: List<Int>? = null
     var startBias = ArrayList<String>()

--- a/core/src/com/unciv/models/ruleset/Policy.kt
+++ b/core/src/com/unciv/models/ruleset/Policy.kt
@@ -1,6 +1,7 @@
 package com.unciv.models.ruleset
 
 import com.unciv.models.ruleset.unique.Unique
+import com.unciv.models.ruleset.unique.UniqueTarget
 import com.unciv.models.stats.INamed
 import com.unciv.models.translations.tr
 import com.unciv.ui.civilopedia.FormattedLine
@@ -11,7 +12,7 @@ open class Policy : INamed, IHasUniques, ICivilopediaText {
 
     override lateinit var name: String
     override var uniques: ArrayList<String> = ArrayList()
-    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it) } }
+    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it, UniqueTarget.Policy, name) } }
     var row: Int = 0
     var column: Int = 0
     var requires: ArrayList<String>? = null

--- a/core/src/com/unciv/models/ruleset/RuinReward.kt
+++ b/core/src/com/unciv/models/ruleset/RuinReward.kt
@@ -1,6 +1,7 @@
 package com.unciv.models.ruleset
 
 import com.unciv.models.ruleset.unique.Unique
+import com.unciv.models.ruleset.unique.UniqueTarget
 import com.unciv.models.stats.INamed
 import com.unciv.ui.civilopedia.FormattedLine
 import com.unciv.ui.civilopedia.ICivilopediaText
@@ -10,7 +11,7 @@ class RuinReward : INamed, ICivilopediaText, IHasUniques {
     val notification: String = ""
     override var uniques = ArrayList<String>()
     @delegate:Transient     // Defense in depth against mad modders
-    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it) } }
+    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it, UniqueTarget.Ruins, name) } }
     
     val excludedDifficulties: List<String> = listOf()
     val weight: Int = 1

--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -12,6 +12,7 @@ import com.unciv.models.ruleset.tile.Terrain
 import com.unciv.models.ruleset.tile.TileImprovement
 import com.unciv.models.ruleset.tile.TileResource
 import com.unciv.models.ruleset.unique.Unique
+import com.unciv.models.ruleset.unique.UniqueTarget
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.ruleset.unit.BaseUnit
 import com.unciv.models.ruleset.unit.Promotion
@@ -153,7 +154,7 @@ class Ruleset {
             try {
                 modOptions = jsonParser.getFromJson(ModOptions::class.java, modOptionsFile)
             } catch (ex: Exception) {}
-            modOptions.uniqueObjects = modOptions.uniques.map { Unique(it) }
+            modOptions.uniqueObjects = modOptions.uniques.map { Unique(it, UniqueTarget.ModOptions) }
         }
 
         val techFile = folderHandle.child("Techs.json")

--- a/core/src/com/unciv/models/ruleset/tech/Technology.kt
+++ b/core/src/com/unciv/models/ruleset/tech/Technology.kt
@@ -7,6 +7,7 @@ import com.unciv.models.ruleset.Building
 import com.unciv.models.ruleset.IHasUniques
 import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.ruleset.unique.Unique
+import com.unciv.models.ruleset.unique.UniqueTarget
 import com.unciv.models.translations.tr
 import com.unciv.models.ruleset.unit.BaseUnit
 import com.unciv.models.stats.INamed
@@ -22,7 +23,7 @@ class Technology: INamed, ICivilopediaText, IHasUniques {
     var cost: Int = 0
     var prerequisites = HashSet<String>()
     override var uniques = ArrayList<String>()
-    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it) } }
+    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it, UniqueTarget.Tech, name) } }
 
     var column: TechColumn? = null // The column that this tech is in the tech tree
     var row: Int = 0

--- a/core/src/com/unciv/models/ruleset/tile/Terrain.kt
+++ b/core/src/com/unciv/models/ruleset/tile/Terrain.kt
@@ -6,6 +6,7 @@ import com.unciv.models.ruleset.Belief
 import com.unciv.models.ruleset.IHasUniques
 import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.ruleset.unique.Unique
+import com.unciv.models.ruleset.unique.UniqueTarget
 import com.unciv.models.stats.NamedStats
 import com.unciv.ui.civilopedia.FormattedLine
 import com.unciv.ui.civilopedia.ICivilopediaText
@@ -28,7 +29,7 @@ class Terrain : NamedStats(), ICivilopediaText, IHasUniques {
 
     /** Uniques (Properties such as Temp/humidity, Fresh water, elevation, rough, defense, Natural Wonder specials) */
     override var uniques = ArrayList<String>()
-    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it) } }
+    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it, UniqueTarget.Terrain, name) } }
 
     /** Natural Wonder weight: probability to be picked */
     var weight = 10

--- a/core/src/com/unciv/models/ruleset/tile/TileImprovement.kt
+++ b/core/src/com/unciv/models/ruleset/tile/TileImprovement.kt
@@ -8,6 +8,7 @@ import com.unciv.logic.map.RoadStatus
 import com.unciv.models.ruleset.IHasUniques
 import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.ruleset.unique.Unique
+import com.unciv.models.ruleset.unique.UniqueTarget
 import com.unciv.models.stats.NamedStats
 import com.unciv.models.translations.tr
 import com.unciv.ui.civilopedia.FormattedLine
@@ -22,7 +23,7 @@ class TileImprovement : NamedStats(), ICivilopediaText, IHasUniques {
     var techRequired: String? = null
     var uniqueTo:String? = null
     override var uniques = ArrayList<String>()
-    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it) } }
+    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it, UniqueTarget.Improvement, name) } }
     val shortcutKey: Char? = null
     val turnsToBuild: Int = 0 // This is the base cost.
 

--- a/core/src/com/unciv/models/ruleset/tile/TileResource.kt
+++ b/core/src/com/unciv/models/ruleset/tile/TileResource.kt
@@ -4,6 +4,7 @@ import com.unciv.models.ruleset.Belief
 import com.unciv.models.ruleset.IHasUniques
 import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.ruleset.unique.Unique
+import com.unciv.models.ruleset.unique.UniqueTarget
 import com.unciv.models.stats.NamedStats
 import com.unciv.models.stats.Stats
 import com.unciv.ui.civilopedia.FormattedLine
@@ -19,7 +20,7 @@ class TileResource : NamedStats(), ICivilopediaText, IHasUniques {
     @Deprecated("As of 3.16.16 - replaced by uniques")
     var unique: String? = null
     override var uniques: ArrayList<String> = arrayListOf()
-    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it) } }
+    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it, UniqueTarget.Resource, name) } }
 
     override var civilopediaText = listOf<FormattedLine>()
 

--- a/core/src/com/unciv/models/ruleset/unique/Unique.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Unique.kt
@@ -7,7 +7,7 @@ import com.unciv.logic.civilization.CivilizationInfo
 import com.unciv.models.ruleset.Ruleset
 
 
-class Unique(val text:String) {
+class Unique(val text: String, val sourceObjectType: UniqueTarget? = null, val sourceObjectName: String? = null) {
     /** This is so the heavy regex-based parsing is only activated once per unique, instead of every time it's called
      *  - for instance, in the city screen, we call every tile unique for every tile, which can lead to ANRs */
     val placeholderText = text.getPlaceholderText()

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -4,14 +4,36 @@ import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.translations.getPlaceholderParameters
 import com.unciv.models.translations.getPlaceholderText
 
-enum class UniqueTarget{
+enum class UniqueTarget {
     /** Buildings, units, nations, policies, religions, techs etc.
      * Basically anything caught by CivInfo.getMatchingUniques. */
     Global,
+    
+    // Civilization-specific
+    Nation,
+    Era,
+    Tech,
+    Policy,
+    Belief,
+    
+    // City-specific
     Building,
+    Wonder,
+    
+    // Unit-specific
     Unit,
+    UnitType,
+    Promotion,
+    
+    // Tile-specific
+    Terrain,
     Improvement,
-    CityState
+    Resource,
+    Ruins,
+    
+    // Other
+    CityState,
+    ModOptions,
 }
 
 enum class UniqueType(val text:String, vararg target: UniqueTarget) {

--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -7,6 +7,7 @@ import com.unciv.logic.civilization.CivilizationInfo
 import com.unciv.logic.map.MapUnit
 import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.ruleset.unique.Unique
+import com.unciv.models.ruleset.unique.UniqueTarget
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.stats.INamed
 import com.unciv.models.stats.Stat
@@ -40,7 +41,7 @@ class BaseUnit : INamed, INonPerpetualConstruction, ICivilopediaText {
     var requiredTech: String? = null
     private var requiredResource: String? = null
     override var uniques = ArrayList<String>() // Can not be a hashset as that would remove doubles
-    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it) } }
+    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it, UniqueTarget.Unit, name) } }
     private var replacementTextForUniques = ""
     var promotions = HashSet<String>()
     var obsoleteTech: String? = null

--- a/core/src/com/unciv/models/ruleset/unit/Promotion.kt
+++ b/core/src/com/unciv/models/ruleset/unit/Promotion.kt
@@ -3,6 +3,7 @@ package com.unciv.models.ruleset.unit
 import com.unciv.models.ruleset.IHasUniques
 import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.ruleset.unique.Unique
+import com.unciv.models.ruleset.unique.UniqueTarget
 import com.unciv.models.stats.INamed
 import com.unciv.models.translations.tr
 import com.unciv.ui.civilopedia.FormattedLine
@@ -22,7 +23,7 @@ class Promotion : INamed, ICivilopediaText, IHasUniques {
         if (effect.isNotEmpty()) yield(effect)
         yieldAll(uniques)
     }
-    override val uniqueObjects: List<Unique> by lazy { uniquesWithEffect().map { Unique(it) }.toList() }
+    override val uniqueObjects: List<Unique> by lazy { uniquesWithEffect().map { Unique(it, UniqueTarget.Promotion, name) }.toList() }
 
     override var civilopediaText = listOf<FormattedLine>()
 

--- a/core/src/com/unciv/models/ruleset/unit/UnitType.kt
+++ b/core/src/com/unciv/models/ruleset/unit/UnitType.kt
@@ -2,6 +2,7 @@ package com.unciv.models.ruleset.unit
 
 import com.unciv.models.ruleset.IHasUniques
 import com.unciv.models.ruleset.unique.Unique
+import com.unciv.models.ruleset.unique.UniqueTarget
 import com.unciv.models.stats.INamed
 
 
@@ -23,7 +24,7 @@ class UnitType() : INamed, IHasUniques {
     private val unitMovementType: UnitMovementType? by lazy { if (movementType == null) null else UnitMovementType.valueOf(movementType!!) }
     
     override var uniques: ArrayList<String> = ArrayList()
-    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it) } }
+    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it, UniqueTarget.Unit, name) } }
     
     constructor(name: String, domain: String? = null) : this() {
         this.name = name


### PR DESCRIPTION
This PR tells each unique what type of object it source was, and was that instance of object is called, conform #5091.
This has multiple applications, none of which are implemented in this PR:
- Comparing with the types saved in the `UniqueType` enum to see if it is on a valid object
- Better determining the source of stat bonuses in the `CityStatsTable`
- After the unification of Strength bonuses for uniques (#4777), still having something reasonable to display as its source (e.g.: "Autocracy Complete (Policy)")