### PR TITLE
Newly Allied city states declare war on your enemies, even unmet ones

### DIFF
--- a/core/src/com/unciv/logic/civilization/CityStateFunctions.kt
+++ b/core/src/com/unciv/logic/civilization/CityStateFunctions.kt
@@ -226,6 +226,17 @@ class CityStateFunctions(val civInfo: CivilizationInfo) {
                 newAllyCiv.updateDetailedCivResources()
                 for (unique in newAllyCiv.getMatchingUniques("Can spend Gold to annex or puppet a City-State that has been your ally for [] turns."))
                     newAllyCiv.getDiplomacyManager(civInfo.civName).setFlag(DiplomacyFlags.MarriageCooldown, unique.params[0].toInt())
+
+                // Join the wars of our new ally - loop through all civs they are at war with
+                for (newEnemy in civInfo.gameInfo.civilizations.filter { it.isAtWarWith(newAllyCiv) && it.isAlive() } ) {
+                    if (civInfo.knows(newEnemy) && !civInfo.isAtWarWith(newEnemy))
+                        civInfo.getDiplomacyManager(newEnemy).declareWar()
+                    else if (!civInfo.knows(newEnemy)) {
+                        // We have to meet first
+                        civInfo.makeCivilizationsMeet(newEnemy, warOnContact = true)
+                        civInfo.getDiplomacyManager(newEnemy).declareWar()
+                    }
+                }
             }
             if (oldAllyName != null) {
                 val oldAllyCiv = civInfo.gameInfo.getCivilization(oldAllyName)

--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -450,12 +450,12 @@ class CivilizationInfo {
         return baseUnit
     }
 
-    fun makeCivilizationsMeet(otherCiv: CivilizationInfo) {
-        meetCiv(otherCiv)
-        otherCiv.meetCiv(this)
+    fun makeCivilizationsMeet(otherCiv: CivilizationInfo, warOnContact: Boolean = false) {
+        meetCiv(otherCiv, warOnContact)
+        otherCiv.meetCiv(this, warOnContact)
     }
 
-    private fun meetCiv(otherCiv: CivilizationInfo) {
+    private fun meetCiv(otherCiv: CivilizationInfo, warOnContact: Boolean = false) {
         diplomacy[otherCiv.civName] = DiplomacyManager(this, otherCiv.civName)
             .apply { diplomaticStatus = DiplomaticStatus.Peace }
 
@@ -465,6 +465,7 @@ class CivilizationInfo {
             UncivGame.Current.settings.addCompletedTutorialTask("Meet another civilization")
         
         if (!(isCityState() && otherCiv.isMajorCiv())) return
+        if (warOnContact) return // No gift if we are just about to be at war
 
         val cityStateLocation = if (cities.isEmpty()) null else getCapital().location
 

--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -465,7 +465,7 @@ class CivilizationInfo {
             UncivGame.Current.settings.addCompletedTutorialTask("Meet another civilization")
         
         if (!(isCityState() && otherCiv.isMajorCiv())) return
-        if (warOnContact) return // No gift if we are just about to be at war
+        if (warOnContact || otherCiv.isMinorCivAggressor()) return // No gift if they are bad people, or we are just about to be at war
 
         val cityStateLocation = if (cities.isEmpty()) null else getCapital().location
 

--- a/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
@@ -675,21 +675,32 @@ class DiplomacyManager() {
         }
         otherCivDiplomacy.removeFlag(DiplomacyFlags.ResearchAgreement)
 
+        // Go through our city state allies.
         if (!civInfo.isCityState()) {
             for (thirdCiv in civInfo.getKnownCivs()) {
-                if (thirdCiv.isCityState() && thirdCiv.getAllyCiv() == civInfo.civName
-                        && thirdCiv.knows(otherCiv)
-                        && thirdCiv.getDiplomacyManager(otherCiv).canDeclareWar()) {
-                    thirdCiv.getDiplomacyManager(otherCiv).declareWar()
+                if (thirdCiv.isCityState() && thirdCiv.getAllyCiv() == civInfo.civName) {
+                    if (thirdCiv.knows(otherCiv) && !thirdCiv.isAtWarWith(otherCiv))
+                        thirdCiv.getDiplomacyManager(otherCiv).declareWar()
+                    else if (!thirdCiv.knows(otherCiv)) {
+                        // Our city state ally has not met them yet, so they have to meet first
+                        thirdCiv.makeCivilizationsMeet(otherCiv, warOnContact = true)
+                        thirdCiv.getDiplomacyManager(otherCiv).declareWar()
+                    }
                 }
             }
         }
+
+        // Go through their city state allies.
         if (!otherCiv.isCityState()) {
             for (thirdCiv in otherCiv.getKnownCivs()) {
-                if (thirdCiv.isCityState() && thirdCiv.getAllyCiv() == otherCiv.civName
-                        && thirdCiv.knows(civInfo)
-                        && thirdCiv.getDiplomacyManager(civInfo).canDeclareWar()) {
-                    thirdCiv.getDiplomacyManager(civInfo).declareWar()
+                if (thirdCiv.isCityState() && thirdCiv.getAllyCiv() == otherCiv.civName) {
+                    if (thirdCiv.knows(civInfo) && !thirdCiv.isAtWarWith(civInfo))
+                        thirdCiv.getDiplomacyManager(civInfo).declareWar()
+                    else if (!thirdCiv.knows(civInfo)) {
+                        // Their city state ally has not met us yet, so we have to meet first
+                        thirdCiv.makeCivilizationsMeet(civInfo, warOnContact = true)
+                        thirdCiv.getDiplomacyManager(civInfo).declareWar()
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fixes #5284
Newly allied city-states now properly declare war on all the new allies enemies.
I also noticed that city-states can't declare war on civs that haven't met them, so I added a check for this. If a city-state is forced to declare war on a civ it hasn't met, they first meet the civ (but without giving them a gift) and then declare.
If a civ is a minor civ aggressor (has declared war on city states twice) it also does not get a gift.