### PR TITLE
Precursor to mod target check -

### DIFF
--- a/core/src/com/unciv/models/ruleset/Belief.kt
+++ b/core/src/com/unciv/models/ruleset/Belief.kt
@@ -13,10 +13,12 @@ class Belief : INamed, ICivilopediaText, IHasUniques {
     override var name: String = ""
     var type: BeliefType = BeliefType.None
     override var uniques = ArrayList<String>()
-    /** Beliefs are pecial, in that different belief types can accept different unique types -
-     * therefore they have their own special check in Ruleset.checkUniques */
-    override val uniqueTarget = UniqueTarget.FollowerBelief
-    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it, uniqueTarget, name) } }
+
+    override fun getUniqueTarget() =
+        if (type == BeliefType.Founder || type == BeliefType.Enhancer)  UniqueTarget.FounderBelief
+        else UniqueTarget.FollowerBelief
+    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it,
+        getUniqueTarget(), name) } }
 
     override var civilopediaText = listOf<FormattedLine>()
 
@@ -29,12 +31,12 @@ class Belief : INamed, ICivilopediaText, IHasUniques {
         val textList = ArrayList<FormattedLine>()
         if (type != BeliefType.None)
             textList += FormattedLine("{Type}: $type", color = type.color )
-        uniqueObjects.forEach { 
+        uniqueObjects.forEach {
             textList += FormattedLine(it)
         }
         return textList
     }
-    
+
     companion object {
         // private but potentially reusable, therefore not folded into getCivilopediaTextMatching
         private fun getBeliefsMatching(name: String, ruleset: Ruleset): Sequence<Belief> {

--- a/core/src/com/unciv/models/ruleset/Belief.kt
+++ b/core/src/com/unciv/models/ruleset/Belief.kt
@@ -13,7 +13,9 @@ class Belief : INamed, ICivilopediaText, IHasUniques {
     override var name: String = ""
     var type: BeliefType = BeliefType.None
     override var uniques = ArrayList<String>()
-    override val uniqueTarget = UniqueTarget.Belief
+    /** Beliefs are pecial, in that different belief types can accept different unique types -
+     * therefore they have their own special check in Ruleset.checkUniques */
+    override val uniqueTarget = UniqueTarget.FollowerBelief
     override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it, uniqueTarget, name) } }
 
     override var civilopediaText = listOf<FormattedLine>()

--- a/core/src/com/unciv/models/ruleset/Belief.kt
+++ b/core/src/com/unciv/models/ruleset/Belief.kt
@@ -7,13 +7,14 @@ import com.unciv.models.stats.INamed
 import com.unciv.models.translations.tr
 import com.unciv.ui.civilopedia.FormattedLine
 import com.unciv.ui.civilopedia.ICivilopediaText
-import java.util.ArrayList
+import kotlin.collections.ArrayList
 
 class Belief : INamed, ICivilopediaText, IHasUniques {
     override var name: String = ""
     var type: BeliefType = BeliefType.None
     override var uniques = ArrayList<String>()
-    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it, UniqueTarget.Belief, name) } }
+    override val uniqueTarget = UniqueTarget.Belief
+    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it, uniqueTarget, name) } }
 
     override var civilopediaText = listOf<FormattedLine>()
 

--- a/core/src/com/unciv/models/ruleset/Building.kt
+++ b/core/src/com/unciv/models/ruleset/Building.kt
@@ -67,6 +67,7 @@ class Building : NamedStats(), INonPerpetualConstruction, ICivilopediaText {
     var uniqueTo: String? = null
     var quote: String = ""
     override var uniques = ArrayList<String>()
+    override val uniqueTarget = UniqueTarget.Building
     override val uniqueObjects: List<Unique> by lazy { 
         uniques.map { 
             Unique(it, if (isAnyWonder()) UniqueTarget.Wonder else UniqueTarget.Building, name) 

--- a/core/src/com/unciv/models/ruleset/Building.kt
+++ b/core/src/com/unciv/models/ruleset/Building.kt
@@ -67,7 +67,7 @@ class Building : NamedStats(), INonPerpetualConstruction, ICivilopediaText {
     var uniqueTo: String? = null
     var quote: String = ""
     override var uniques = ArrayList<String>()
-    override val uniqueTarget = UniqueTarget.Building
+    override fun getUniqueTarget() = UniqueTarget.Building
     override val uniqueObjects: List<Unique> by lazy { 
         uniques.map { 
             Unique(it, if (isAnyWonder()) UniqueTarget.Wonder else UniqueTarget.Building, name) 

--- a/core/src/com/unciv/models/ruleset/Era.kt
+++ b/core/src/com/unciv/models/ruleset/Era.kt
@@ -33,8 +33,9 @@ class Era : INamed, IHasUniques {
 
     var iconRGB: List<Int>? = null
     override var uniques: ArrayList<String> = arrayListOf()
-    override val uniqueTarget = UniqueTarget.Era
-    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it, uniqueTarget, name) } }
+    override fun getUniqueTarget() = UniqueTarget.Era
+    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it,
+        getUniqueTarget(), name) } }
 
     private fun initBonuses(bonusMap: Map<String, List<String>>): Map<CityStateType, List<Unique>> {
         val objectMap = HashMap<CityStateType, List<Unique>>()

--- a/core/src/com/unciv/models/ruleset/Era.kt
+++ b/core/src/com/unciv/models/ruleset/Era.kt
@@ -33,7 +33,8 @@ class Era : INamed, IHasUniques {
 
     var iconRGB: List<Int>? = null
     override var uniques: ArrayList<String> = arrayListOf()
-    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it, UniqueTarget.Era, name) } }
+    override val uniqueTarget = UniqueTarget.Era
+    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it, uniqueTarget, name) } }
 
     private fun initBonuses(bonusMap: Map<String, List<String>>): Map<CityStateType, List<Unique>> {
         val objectMap = HashMap<CityStateType, List<Unique>>()

--- a/core/src/com/unciv/models/ruleset/IHasUniques.kt
+++ b/core/src/com/unciv/models/ruleset/IHasUniques.kt
@@ -1,6 +1,7 @@
 package com.unciv.models.ruleset
 
 import com.unciv.models.ruleset.unique.Unique
+import com.unciv.models.ruleset.unique.UniqueTarget
 import com.unciv.models.ruleset.unique.UniqueType
 
 /**
@@ -8,7 +9,9 @@ import com.unciv.models.ruleset.unique.UniqueType
  */
 interface IHasUniques {
     var uniques: ArrayList<String> // Can not be a hashset as that would remove doubles
+    // I bet there's a way of initializing these without having to override it everywhere...
     val uniqueObjects: List<Unique>
+    val uniqueTarget: UniqueTarget
     
     fun getMatchingUniques(uniqueTemplate: String) = uniqueObjects.asSequence().filter { it.placeholderText == uniqueTemplate }
     fun getMatchingUniques(uniqueType: UniqueType) = uniqueObjects.asSequence().filter { it.isOfType(uniqueType) }

--- a/core/src/com/unciv/models/ruleset/IHasUniques.kt
+++ b/core/src/com/unciv/models/ruleset/IHasUniques.kt
@@ -11,7 +11,7 @@ interface IHasUniques {
     var uniques: ArrayList<String> // Can not be a hashset as that would remove doubles
     // I bet there's a way of initializing these without having to override it everywhere...
     val uniqueObjects: List<Unique>
-    val uniqueTarget: UniqueTarget
+    fun getUniqueTarget(): UniqueTarget
     
     fun getMatchingUniques(uniqueTemplate: String) = uniqueObjects.asSequence().filter { it.placeholderText == uniqueTemplate }
     fun getMatchingUniques(uniqueType: UniqueType) = uniqueObjects.asSequence().filter { it.isOfType(uniqueType) }

--- a/core/src/com/unciv/models/ruleset/IHasUniques.kt
+++ b/core/src/com/unciv/models/ruleset/IHasUniques.kt
@@ -11,6 +11,9 @@ interface IHasUniques {
     var uniques: ArrayList<String> // Can not be a hashset as that would remove doubles
     // I bet there's a way of initializing these without having to override it everywhere...
     val uniqueObjects: List<Unique>
+    /** Technically not currently needed, since the unique target can be retrieved from every unique in the uniqueObjects,
+     * But making this a function is relevant for future "unify Unciv object" plans ;)
+     * */
     fun getUniqueTarget(): UniqueTarget
     
     fun getMatchingUniques(uniqueTemplate: String) = uniqueObjects.asSequence().filter { it.placeholderText == uniqueTemplate }

--- a/core/src/com/unciv/models/ruleset/Nation.kt
+++ b/core/src/com/unciv/models/ruleset/Nation.kt
@@ -44,7 +44,8 @@ class Nation : INamed, ICivilopediaText, IHasUniques {
     lateinit var outerColor: List<Int>
     var uniqueName = ""
     override var uniques = ArrayList<String>()
-    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it, UniqueTarget.Nation, name) } }
+    override val uniqueTarget = UniqueTarget.Nation
+    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it, uniqueTarget, name) } }
     var uniqueText = ""
     var innerColor: List<Int>? = null
     var startBias = ArrayList<String>()

--- a/core/src/com/unciv/models/ruleset/Nation.kt
+++ b/core/src/com/unciv/models/ruleset/Nation.kt
@@ -44,8 +44,9 @@ class Nation : INamed, ICivilopediaText, IHasUniques {
     lateinit var outerColor: List<Int>
     var uniqueName = ""
     override var uniques = ArrayList<String>()
-    override val uniqueTarget = UniqueTarget.Nation
-    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it, uniqueTarget, name) } }
+    override fun getUniqueTarget() = UniqueTarget.Nation
+    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it,
+        getUniqueTarget(), name) } }
     var uniqueText = ""
     var innerColor: List<Int>? = null
     var startBias = ArrayList<String>()

--- a/core/src/com/unciv/models/ruleset/Policy.kt
+++ b/core/src/com/unciv/models/ruleset/Policy.kt
@@ -12,7 +12,8 @@ open class Policy : INamed, IHasUniques, ICivilopediaText {
 
     override lateinit var name: String
     override var uniques: ArrayList<String> = ArrayList()
-    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it, UniqueTarget.Policy, name) } }
+    override val uniqueTarget = UniqueTarget.Policy
+    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it, uniqueTarget, name) } }
     var row: Int = 0
     var column: Int = 0
     var requires: ArrayList<String>? = null

--- a/core/src/com/unciv/models/ruleset/Policy.kt
+++ b/core/src/com/unciv/models/ruleset/Policy.kt
@@ -12,8 +12,9 @@ open class Policy : INamed, IHasUniques, ICivilopediaText {
 
     override lateinit var name: String
     override var uniques: ArrayList<String> = ArrayList()
-    override val uniqueTarget = UniqueTarget.Policy
-    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it, uniqueTarget, name) } }
+    override fun getUniqueTarget() = UniqueTarget.Policy
+    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it,
+        getUniqueTarget(), name) } }
     var row: Int = 0
     var column: Int = 0
     var requires: ArrayList<String>? = null

--- a/core/src/com/unciv/models/ruleset/RuinReward.kt
+++ b/core/src/com/unciv/models/ruleset/RuinReward.kt
@@ -11,7 +11,7 @@ class RuinReward : INamed, ICivilopediaText, IHasUniques {
     val notification: String = ""
     override var uniques = ArrayList<String>()
 
-    override val uniqueTarget = UniqueTarget.Ruins
+    override fun getUniqueTarget() = UniqueTarget.Ruins
     @delegate:Transient     // Defense in depth against mad modders
     override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it, UniqueTarget.Ruins, name) } }
 

--- a/core/src/com/unciv/models/ruleset/RuinReward.kt
+++ b/core/src/com/unciv/models/ruleset/RuinReward.kt
@@ -10,9 +10,11 @@ class RuinReward : INamed, ICivilopediaText, IHasUniques {
     override lateinit var name: String  // Displayed in Civilopedia!
     val notification: String = ""
     override var uniques = ArrayList<String>()
+
+    override val uniqueTarget = UniqueTarget.Ruins
     @delegate:Transient     // Defense in depth against mad modders
     override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it, UniqueTarget.Ruins, name) } }
-    
+
     val excludedDifficulties: List<String> = listOf()
     val weight: Int = 1
     val color: String = ""  // For Civilopedia

--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -51,7 +51,7 @@ class ModOptions : IHasUniques {
     override var uniques = ArrayList<String>()
     // If this is delegated with "by lazy", the mod download process crashes and burns
     override var uniqueObjects: List<Unique> = listOf()
-    override val uniqueTarget = UniqueTarget.ModOptions
+    override fun getUniqueTarget() = UniqueTarget.ModOptions
 
 }
 
@@ -308,11 +308,7 @@ class Ruleset {
                 lines.add(deprecationText, severity)
             }
 
-            val acceptableUniqueType = when {
-                uniqueContainer !is Belief -> uniqueContainer.uniqueTarget
-                uniqueContainer.type == BeliefType.Founder || uniqueContainer.type == BeliefType.Enhancer -> UniqueTarget.FounderBelief
-                else -> UniqueTarget.FollowerBelief
-            }
+            val acceptableUniqueType = uniqueContainer.getUniqueTarget()
             if (unique.type.targetTypes.none { acceptableUniqueType.canAcceptUniqueTarget(it) })
                 lines.add(
                     "$name's unique \"${unique.text}\" cannot be put on this type of object!",

--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -298,14 +298,27 @@ class Ruleset {
             val deprecationAnnotation = unique.type.declaringClass.getField(unique.type.name)
                 .getAnnotation(Deprecated::class.java)
             if (deprecationAnnotation != null) {
-                val deprecationText = "$name's unique \"${unique.text}\" is deprecated ${deprecationAnnotation.message}," +
-                        " replace with \"${deprecationAnnotation.replaceWith.expression}\""
-                val severity = if(deprecationAnnotation.level == DeprecationLevel.WARNING)
+                val deprecationText =
+                    "$name's unique \"${unique.text}\" is deprecated ${deprecationAnnotation.message}," +
+                            " replace with \"${deprecationAnnotation.replaceWith.expression}\""
+                val severity = if (deprecationAnnotation.level == DeprecationLevel.WARNING)
                     RulesetErrorSeverity.WarningOptionsOnly // Not user-visible
                 else RulesetErrorSeverity.Warning // User visible
 
                 lines.add(deprecationText, severity)
             }
+
+            val acceptableUniqueType = when {
+                uniqueContainer !is Belief -> uniqueContainer.uniqueTarget
+                uniqueContainer.type == BeliefType.Founder || uniqueContainer.type == BeliefType.Enhancer -> UniqueTarget.FounderBelief
+                else -> UniqueTarget.FollowerBelief
+            }
+            if (unique.type.targetTypes.none { acceptableUniqueType.canAcceptUniqueTarget(it) })
+                lines.add(
+                    "$name's unique \"${unique.text}\" cannot be put on this type of object!",
+                    RulesetErrorSeverity.Warning
+                )
+
         }
     }
 

--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -51,6 +51,8 @@ class ModOptions : IHasUniques {
     override var uniques = ArrayList<String>()
     // If this is delegated with "by lazy", the mod download process crashes and burns
     override var uniqueObjects: List<Unique> = listOf()
+    override val uniqueTarget = UniqueTarget.ModOptions
+
 }
 
 class Ruleset {

--- a/core/src/com/unciv/models/ruleset/tech/Technology.kt
+++ b/core/src/com/unciv/models/ruleset/tech/Technology.kt
@@ -23,7 +23,8 @@ class Technology: INamed, ICivilopediaText, IHasUniques {
     var cost: Int = 0
     var prerequisites = HashSet<String>()
     override var uniques = ArrayList<String>()
-    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it, UniqueTarget.Tech, name) } }
+    override val uniqueTarget = UniqueTarget.Tech
+    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it, uniqueTarget, name) } }
 
     var column: TechColumn? = null // The column that this tech is in the tech tree
     var row: Int = 0

--- a/core/src/com/unciv/models/ruleset/tech/Technology.kt
+++ b/core/src/com/unciv/models/ruleset/tech/Technology.kt
@@ -23,8 +23,9 @@ class Technology: INamed, ICivilopediaText, IHasUniques {
     var cost: Int = 0
     var prerequisites = HashSet<String>()
     override var uniques = ArrayList<String>()
-    override val uniqueTarget = UniqueTarget.Tech
-    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it, uniqueTarget, name) } }
+    override fun getUniqueTarget() = UniqueTarget.Tech
+    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it,
+        getUniqueTarget(), name) } }
 
     var column: TechColumn? = null // The column that this tech is in the tech tree
     var row: Int = 0

--- a/core/src/com/unciv/models/ruleset/tile/Terrain.kt
+++ b/core/src/com/unciv/models/ruleset/tile/Terrain.kt
@@ -29,8 +29,9 @@ class Terrain : NamedStats(), ICivilopediaText, IHasUniques {
 
     /** Uniques (Properties such as Temp/humidity, Fresh water, elevation, rough, defense, Natural Wonder specials) */
     override var uniques = ArrayList<String>()
-    override val uniqueTarget = UniqueTarget.Terrain
-    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it, uniqueTarget, name) } }
+    override fun getUniqueTarget() = UniqueTarget.Terrain
+    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it,
+        getUniqueTarget(), name) } }
 
     /** Natural Wonder weight: probability to be picked */
     var weight = 10

--- a/core/src/com/unciv/models/ruleset/tile/Terrain.kt
+++ b/core/src/com/unciv/models/ruleset/tile/Terrain.kt
@@ -29,7 +29,8 @@ class Terrain : NamedStats(), ICivilopediaText, IHasUniques {
 
     /** Uniques (Properties such as Temp/humidity, Fresh water, elevation, rough, defense, Natural Wonder specials) */
     override var uniques = ArrayList<String>()
-    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it, UniqueTarget.Terrain, name) } }
+    override val uniqueTarget = UniqueTarget.Terrain
+    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it, uniqueTarget, name) } }
 
     /** Natural Wonder weight: probability to be picked */
     var weight = 10

--- a/core/src/com/unciv/models/ruleset/tile/TileImprovement.kt
+++ b/core/src/com/unciv/models/ruleset/tile/TileImprovement.kt
@@ -23,7 +23,8 @@ class TileImprovement : NamedStats(), ICivilopediaText, IHasUniques {
     var techRequired: String? = null
     var uniqueTo:String? = null
     override var uniques = ArrayList<String>()
-    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it, UniqueTarget.Improvement, name) } }
+    override val uniqueTarget = UniqueTarget.Improvement
+    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it, uniqueTarget, name) } }
     val shortcutKey: Char? = null
     val turnsToBuild: Int = 0 // This is the base cost.
 

--- a/core/src/com/unciv/models/ruleset/tile/TileImprovement.kt
+++ b/core/src/com/unciv/models/ruleset/tile/TileImprovement.kt
@@ -23,8 +23,9 @@ class TileImprovement : NamedStats(), ICivilopediaText, IHasUniques {
     var techRequired: String? = null
     var uniqueTo:String? = null
     override var uniques = ArrayList<String>()
-    override val uniqueTarget = UniqueTarget.Improvement
-    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it, uniqueTarget, name) } }
+    override fun getUniqueTarget() = UniqueTarget.Improvement
+    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it,
+        getUniqueTarget(), name) } }
     val shortcutKey: Char? = null
     val turnsToBuild: Int = 0 // This is the base cost.
 

--- a/core/src/com/unciv/models/ruleset/tile/TileResource.kt
+++ b/core/src/com/unciv/models/ruleset/tile/TileResource.kt
@@ -20,7 +20,8 @@ class TileResource : NamedStats(), ICivilopediaText, IHasUniques {
     @Deprecated("As of 3.16.16 - replaced by uniques")
     var unique: String? = null
     override var uniques: ArrayList<String> = arrayListOf()
-    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it, UniqueTarget.Resource, name) } }
+    override val uniqueTarget = UniqueTarget.Resource
+    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it, uniqueTarget, name) } }
 
     override var civilopediaText = listOf<FormattedLine>()
 

--- a/core/src/com/unciv/models/ruleset/tile/TileResource.kt
+++ b/core/src/com/unciv/models/ruleset/tile/TileResource.kt
@@ -20,8 +20,9 @@ class TileResource : NamedStats(), ICivilopediaText, IHasUniques {
     @Deprecated("As of 3.16.16 - replaced by uniques")
     var unique: String? = null
     override var uniques: ArrayList<String> = arrayListOf()
-    override val uniqueTarget = UniqueTarget.Resource
-    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it, uniqueTarget, name) } }
+    override fun getUniqueTarget() = UniqueTarget.Resource
+    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it,
+        getUniqueTarget(), name) } }
 
     override var civilopediaText = listOf<FormattedLine>()
 

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -3,27 +3,36 @@ package com.unciv.models.ruleset.unique
 import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.translations.getPlaceholderParameters
 import com.unciv.models.translations.getPlaceholderText
+import kotlin.collections.ArrayList
+import kotlin.collections.HashSet
 
-/** Buildings, units, nations, policies, religions, techs etc.
- * Basically anything caught by CivInfo.getMatchingUniques. */
-enum class UniqueTarget {
+/** inheritsFrom means that all such uniques are acceptable as well.
+ * For example, all Global uniques are acceptable for Nations, Eras, etc. */
+enum class UniqueTarget(val inheritsFrom:UniqueTarget?=null) {
+
+    /** Buildings, units, nations, policies, religions, techs etc.
+     * Basically anything caught by CivInfo.getMatchingUniques. */
     Global,
 
     // Civilization-specific
-    Nation,
-    Era,
-    Tech,
-    Policy,
-    Belief,
+    Nation(Global),
+    Era(Global),
+    Tech(Global),
+    Policy(Global),
+    Belief(Global),
 
     // City-specific
-    Building,
-    Wonder,
+    /** This is used as the base when checking buildings */
+    Building(Global),
+    Wonder(Building),
 
     // Unit-specific
+    // These are a bit of a lie. There's no "Promotion only" or "UnitType only" uniques,
+    //  they're all just Unit uniques in different places.
+    //  So there should be no uniqueType that has a Promotion or UnitType target.
     Unit,
-    UnitType,
-    Promotion,
+    UnitType(Unit),
+    Promotion(Unit),
 
     // Tile-specific
     Terrain,
@@ -35,9 +44,16 @@ enum class UniqueTarget {
     CityState,
     ModOptions,
     Conditional,
+    ;
+
+    fun canAcceptUniqueTarget(uniqueTarget: UniqueTarget): Boolean {
+        if (this == uniqueTarget) return true
+        if (inheritsFrom != null) return inheritsFrom.canAcceptUniqueTarget(uniqueTarget)
+        return false
+    }
 }
 
-enum class UniqueType(val text:String, vararg target: UniqueTarget) {
+enum class UniqueType(val text:String, vararg targets: UniqueTarget) {
 
     Stats("[stats]", UniqueTarget.Global),
     StatsPerCity("[stats] [cityFilter]", UniqueTarget.Global),
@@ -91,7 +107,7 @@ enum class UniqueType(val text:String, vararg target: UniqueTarget) {
     /** For uniques that have "special" parameters that can accept multiple types, we can override them manually
      *  For 95% of cases, auto-matching is fine. */
     val parameterTypeMap = ArrayList<List<UniqueParameterType>>()
-    val replacedBy: UniqueType? = null
+    val targetTypes = HashSet<UniqueTarget>()
 
     init {
         for (placeholder in text.getPlaceholderParameters()) {
@@ -100,6 +116,7 @@ enum class UniqueType(val text:String, vararg target: UniqueTarget) {
                     ?: UniqueParameterType.Unknown
             parameterTypeMap.add(listOf(matchingParameterType))
         }
+        targetTypes.addAll(targets)
     }
 
     val placeholderText = text.getPlaceholderText()

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -19,7 +19,9 @@ enum class UniqueTarget(val inheritsFrom:UniqueTarget?=null) {
     Era(Global),
     Tech(Global),
     Policy(Global),
-    Belief(Global),
+    FounderBelief(Global),
+    /** These apply only to cities where the religion is the majority religion */
+    FollowerBelief,
 
     // City-specific
     /** This is used as the base when checking buildings */

--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -40,8 +40,11 @@ class BaseUnit : INamed, INonPerpetualConstruction, ICivilopediaText {
     fun getType() = ruleset.unitTypes[unitType]!!
     var requiredTech: String? = null
     private var requiredResource: String? = null
+
     override var uniques = ArrayList<String>() // Can not be a hashset as that would remove doubles
-    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it, UniqueTarget.Unit, name) } }
+    override val uniqueTarget = UniqueTarget.Unit
+    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it, uniqueTarget, name) } }
+
     private var replacementTextForUniques = ""
     var promotions = HashSet<String>()
     var obsoleteTech: String? = null

--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -42,8 +42,9 @@ class BaseUnit : INamed, INonPerpetualConstruction, ICivilopediaText {
     private var requiredResource: String? = null
 
     override var uniques = ArrayList<String>() // Can not be a hashset as that would remove doubles
-    override val uniqueTarget = UniqueTarget.Unit
-    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it, uniqueTarget, name) } }
+    override fun getUniqueTarget() = UniqueTarget.Unit
+    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it,
+        getUniqueTarget(), name) } }
 
     private var replacementTextForUniques = ""
     var promotions = HashSet<String>()

--- a/core/src/com/unciv/models/ruleset/unit/Promotion.kt
+++ b/core/src/com/unciv/models/ruleset/unit/Promotion.kt
@@ -23,7 +23,8 @@ class Promotion : INamed, ICivilopediaText, IHasUniques {
         if (effect.isNotEmpty()) yield(effect)
         yieldAll(uniques)
     }
-    override val uniqueObjects: List<Unique> by lazy { uniquesWithEffect().map { Unique(it, UniqueTarget.Promotion, name) }.toList() }
+    override val uniqueTarget = UniqueTarget.Promotion
+    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it, uniqueTarget, name) } }
 
     override var civilopediaText = listOf<FormattedLine>()
 

--- a/core/src/com/unciv/models/ruleset/unit/Promotion.kt
+++ b/core/src/com/unciv/models/ruleset/unit/Promotion.kt
@@ -23,8 +23,10 @@ class Promotion : INamed, ICivilopediaText, IHasUniques {
         if (effect.isNotEmpty()) yield(effect)
         yieldAll(uniques)
     }
-    override val uniqueTarget = UniqueTarget.Promotion
-    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it, uniqueTarget, name) } }
+
+    override fun getUniqueTarget() = UniqueTarget.Promotion
+    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it,
+        getUniqueTarget(), name) } }
 
     override var civilopediaText = listOf<FormattedLine>()
 

--- a/core/src/com/unciv/models/ruleset/unit/UnitType.kt
+++ b/core/src/com/unciv/models/ruleset/unit/UnitType.kt
@@ -24,8 +24,9 @@ class UnitType() : INamed, IHasUniques {
     private val unitMovementType: UnitMovementType? by lazy { if (movementType == null) null else UnitMovementType.valueOf(movementType!!) }
     
     override var uniques: ArrayList<String> = ArrayList()
-    override val uniqueTarget = UniqueTarget.UnitType
-    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it, uniqueTarget, name) } }
+    override fun getUniqueTarget() = UniqueTarget.UnitType
+    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it,
+        getUniqueTarget(), name) } }
     
     constructor(name: String, domain: String? = null) : this() {
         this.name = name

--- a/core/src/com/unciv/models/ruleset/unit/UnitType.kt
+++ b/core/src/com/unciv/models/ruleset/unit/UnitType.kt
@@ -24,7 +24,8 @@ class UnitType() : INamed, IHasUniques {
     private val unitMovementType: UnitMovementType? by lazy { if (movementType == null) null else UnitMovementType.valueOf(movementType!!) }
     
     override var uniques: ArrayList<String> = ArrayList()
-    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it, UniqueTarget.Unit, name) } }
+    override val uniqueTarget = UniqueTarget.UnitType
+    override val uniqueObjects: List<Unique> by lazy { uniques.map { Unique(it, uniqueTarget, name) } }
     
     constructor(name: String, domain: String? = null) : this() {
         this.name = name


### PR DESCRIPTION
Define acceptable targets for each unique holder
We can then compare each unique against the acceptable targets of the host and warn against incorrectly placed uniques