### PR TITLE
Extra embarrassing fix - Textures missing on Android

### DIFF
--- a/core/src/com/unciv/ui/utils/ImageGetter.kt
+++ b/core/src/com/unciv/ui/utils/ImageGetter.kt
@@ -19,7 +19,6 @@ import com.badlogic.gdx.utils.Align
 import com.unciv.Constants
 import com.unciv.UncivGame
 import com.unciv.logic.GameSaver
-import com.unciv.models.ruleset.Era
 import com.unciv.models.ruleset.Nation
 import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.ruleset.tile.ResourceType
@@ -64,7 +63,7 @@ object ImageGetter {
         }
 
         // Load base (except game.atlas which is already loaded)
-        loadModAtlases("", Gdx.files.internal("."))
+        loadModAtlases("", Gdx.files.internal(""))
 
         // These are from the mods
         for (mod in UncivGame.Current.settings.visualMods + ruleset.mods) {


### PR DESCRIPTION
Sorry about this. "." as representing "current directory" doesn't work inside APK assets (though list() _does_) - ~~still needs cross-check with running from a jar.~~ seems apk-debug, jar and desktop-debug work this way.