### PR TITLE
Mini-UI to see Religion info on foreign cities

### DIFF
--- a/core/src/com/unciv/ui/cityscreen/CityReligionInfoTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityReligionInfoTable.kt
@@ -1,0 +1,77 @@
+package com.unciv.ui.cityscreen
+
+import com.badlogic.gdx.graphics.Color
+import com.badlogic.gdx.scenes.scene2d.ui.Table
+import com.unciv.logic.city.CityInfoReligionManager
+import com.unciv.models.Religion
+import com.unciv.ui.utils.*
+
+class CityReligionInfoTable(
+    private val religionManager: CityInfoReligionManager,
+    showMajority: Boolean = false
+) : Table(CameraStageBaseScreen.skin) {
+    private val gameInfo = religionManager.cityInfo.civInfo.gameInfo
+
+    init {
+        val gridColor = Color.DARK_GRAY
+        val followers = religionManager.getNumberOfFollowers()
+        val futurePressures = religionManager.getPressuresFromSurroundingCities()
+
+        if (showMajority) {
+            val (icon, label) = getIconAndLabel(religionManager.getMajorityReligion())
+            add(ImageGetter.getCircledReligionIcon(icon, 30f)).pad(5f)
+            add()  // skip vertical separator
+            add("Majority Religion: [$label]".toLabel()).colspan(3).center().row()
+        }
+
+        val (icon, label) = getIconAndLabel(religionManager.religionThisIsTheHolyCityOf)
+        if (label != "None") {
+            add(ImageGetter.getCircledReligionIcon(icon, 30f)).pad(5f)
+            add()
+            add("Holy city of: [$label]".toLabel()).colspan(3).center().row()
+        }
+
+        add().pad(5f)  // column for icon
+        addSeparatorVertical(gridColor)
+        add("Followers".toLabel()).pad(5f)
+        addSeparatorVertical(gridColor)
+        add("Pressure".toLabel()).pad(5f).row()
+        addSeparator(gridColor)
+
+        for ((religion, followerCount) in followers) {
+            val iconName = gameInfo.religions[religion]!!.getIconName()
+            add(ImageGetter.getCircledReligionIcon(iconName, 30f)).pad(5f)
+            addSeparatorVertical(gridColor)
+            add(followerCount.toLabel()).pad(5f)
+            addSeparatorVertical(gridColor)
+            if (futurePressures.containsKey(religion))
+                add(("+ [${futurePressures[religion]!!}] pressure").toLabel()).pad(5f)
+            else
+                add()
+            row()
+        }
+    }
+
+    private fun getIconAndLabel(religionName: String?) =
+        getIconAndLabel(gameInfo.religions[religionName])
+    private fun getIconAndLabel(religion: Religion?): Pair<String, String> {
+        return if (religion == null) "Religion" to "None" 
+            else religion.getIconName() to religion.getReligionDisplayName()
+    }
+
+    fun asExpander(onChange: (()->Unit)?): ExpanderTab {
+        val (icon, label) = getIconAndLabel(religionManager.getMajorityReligion())
+        return ExpanderTab(
+                title = "Majority Religion: [$label]",
+                fontSize = 18,
+                icon = ImageGetter.getCircledReligionIcon(icon, 30f),
+                defaultPad = 0f,
+                persistenceID = "CityStatsTable.Religion",
+                startsOutOpened = false,
+                onChange = onChange
+            ) {
+                defaults().center().pad(5f)
+                it.add(this)
+            }
+    }
+}

--- a/core/src/com/unciv/ui/cityscreen/CityStatsTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityStatsTable.kt
@@ -83,67 +83,12 @@ class CityStatsTable(val cityScreen: CityScreen): Table() {
     }
 
     private fun addReligionInfo() {
-        val label = cityInfo.religion.getMajorityReligion()?.getReligionDisplayName()
-            ?: "None"
-        val icon = 
-            if (label == "None") "Religion" 
-            else cityInfo.religion.getMajorityReligion()!!.getIconName()
-        val expanderTab =
-            ExpanderTab(
-                title = "Majority Religion: [$label]",
-                fontSize = 18,
-                icon = ImageGetter.getCircledReligionIcon(icon, 30f),
-                defaultPad = 0f,
-                persistenceID = "CityStatsTable.Religion",
-                startsOutOpened = false,
-                onChange = {
-                    pack()
-                    // We have to re-anchor as our position in the city screen, otherwise it expands upwards.
-                    // ToDo: This probably should be refactored so its placed somewhere else in due time
-                    setPosition(stage.width - CityScreen.posFromEdge, stage.height - CityScreen.posFromEdge, Align.topRight)
-                }
-            ) {
-                if (cityInfo.religion.religionThisIsTheHolyCityOf != null) {
-                    // I want this to be centered, but `.center()` doesn't seem to do anything,
-                    // regardless of where I place it :(
-                    it.add(
-                        "Holy city of: [${cityInfo.civInfo.gameInfo.religions[cityInfo.religion.religionThisIsTheHolyCityOf!!]!!.getReligionDisplayName()}]".toLabel()
-                    ).center().colspan(2).pad(5f).row()
-                }
-                it.add(getReligionsTable()).colspan(2).pad(5f)
-            }
-        
-        innerTable.add(expanderTab).growX().row()
-    }
-    
-    private fun getReligionsTable(): Table {
-        val gridColor = Color.DARK_GRAY
-        val religionsTable = Table(CameraStageBaseScreen.skin)
-        val followers = cityInfo.religion.getNumberOfFollowers()
-        val futurePressures = cityInfo.religion.getPressuresFromSurroundingCities()
-        
-        religionsTable.add().pad(5f)
-        religionsTable.addSeparatorVertical(gridColor)
-        religionsTable.add("Followers".toLabel()).pad(5f)
-        religionsTable.addSeparatorVertical(gridColor)
-        religionsTable.add("Pressure".toLabel()).pad(5f)
-        religionsTable.row()
-        religionsTable.addSeparator(gridColor)
-        
-        for ((religion, followerCount) in followers) {
-            religionsTable.add(
-                ImageGetter.getCircledReligionIcon(cityInfo.civInfo.gameInfo.religions[religion]!!.getIconName(), 30f)
-            ).pad(5f)
-            religionsTable.addSeparatorVertical(gridColor)
-            religionsTable.add(followerCount.toLabel()).pad(5f)
-            religionsTable.addSeparatorVertical(gridColor)
-            if (futurePressures.containsKey(religion))
-                religionsTable.add(("+ [${futurePressures[religion]!!}] pressure").toLabel()).pad(5f)
-            else
-                religionsTable.add()
-            religionsTable.row()
+        val expanderTab = CityReligionInfoTable(cityInfo.religion).asExpander {
+            pack()
+            // We have to re-anchor as our position in the city screen, otherwise it expands upwards.
+            // ToDo: This probably should be refactored so its placed somewhere else in due time
+            setPosition(stage.width - CityScreen.posFromEdge, stage.height - CityScreen.posFromEdge, Align.topRight)
         }
-        
-        return religionsTable
+        innerTable.add(expanderTab).growX().row()
     }
 }


### PR DESCRIPTION
Offer for #4987 

This is a Popup "inserted" between the second click on a foreign city button and the diplomacy. Pass-thru when Religion off.
Safer than putting it in UnitTable - that might be nicer for the user, but managing the situation where the "selection" is a foreign city gets complicated quickly.

Open question: What _else_ about a foreign city should a player be allowed to see that's currently unavailable? Wonders? Spies? :grin:

![image](https://user-images.githubusercontent.com/63000004/134789441-c563e380-2e93-498c-8fef-12ab24db0431.png)