### PR TITLE
Proper great general points

### DIFF
--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -395,7 +395,7 @@ object Battle {
         thisCombatant.unit.promotions.XP += xpGained
 
 
-        if (thisCombatant.getCivInfo().isMajorCiv()) {
+        if (thisCombatant.getCivInfo().isMajorCiv() && !otherCombatant.getCivInfo().isBarbarian()) { // Can't get great generals from Barbarians
             var greatGeneralPointsModifier = 1f
             for (unique in thisCombatant.getMatchingUniques("[] is earned []% faster")) {
                 val unitName = unique.params[0]

--- a/core/src/com/unciv/logic/civilization/GreatPersonManager.kt
+++ b/core/src/com/unciv/logic/civilization/GreatPersonManager.kt
@@ -6,7 +6,7 @@ import com.unciv.models.stats.Stats
 
 class GreatPersonManager {
     var pointsForNextGreatPerson = 100
-    var pointsForNextGreatGeneral = 30
+    var pointsForNextGreatGeneral = 200
 
     var greatPersonPointsCounter = Counter<String>()
     var greatGeneralPoints = 0


### PR DESCRIPTION
Two modifications to great general points to bring them in line with the original (and make them much scarcer!):

- 200 points are needed for the first general (not 30)
- You can't get great general points from fighting barbarians