### PR TITLE
Fix Fountain of Youth yield as per wiki

### DIFF
--- a/android/assets/jsons/Civ V - Vanilla/Nations.json
+++ b/android/assets/jsons/Civ V - Vanilla/Nations.json
@@ -804,7 +804,7 @@
 		"name": "Byzantium",
 		"leaderName": "Theodora",
 		"adjective": ["Byzantine"],
-		"startBias": ["Coats"],
+		"startBias": ["Coast"],
 		"preferredVictoryType": "Cultural",
 		
 		"startIntroPart1": "All hail the most magnificent and magnanimous Empress Theodora, beloved of Byzantium and of Rome! From the lowly ranks of actress and courtesan you became the most powerful woman in the Roman Empire, consort to Justinian I. Starting in the late 520's AD, you joined your husband in a series of important spiritual and legal reforms, creating many laws which elevated the status of and promoted equal treatment of women in the empire. You also aided in the restoration and construction of many aqueducts, bridges, and churches across Constantinople, culminating in the creation of the Hagia Sophia, one of the most splendid architectural wonders of the world.",

--- a/android/assets/jsons/Civ V - Vanilla/Terrains.json
+++ b/android/assets/jsons/Civ V - Vanilla/Terrains.json
@@ -251,8 +251,7 @@
 		"impassable": true,
 		"unbuildable": true,
 		"uniques": ["Must be adjacent to [0] [Coast] tiles",
-			"Grants [Rejuvenation] ([all healing effects doubled]) to adjacent [{Military} {Land}] units for the rest of the game",
-			"Tile provides yield without assigned population"],
+			"Grants [Rejuvenation] ([all healing effects doubled]) to adjacent [{Military} {Land}] units for the rest of the game"],
 		"weight": 1
 	},
 	{

--- a/android/assets/jsons/Civ V - Vanilla/Terrains.json
+++ b/android/assets/jsons/Civ V - Vanilla/Terrains.json
@@ -251,7 +251,8 @@
 		"impassable": true,
 		"unbuildable": true,
 		"uniques": ["Must be adjacent to [0] [Coast] tiles",
-			"Grants [Rejuvenation] ([all healing effects doubled]) to adjacent [{Military} {Land}] units for the rest of the game"],
+			"Grants [Rejuvenation] ([all healing effects doubled]) to adjacent [{Military} {Land}] units for the rest of the game",
+			"Tile provides yield without assigned population"],
 		"weight": 1
 	},
 	{

--- a/core/src/com/unciv/logic/city/CityStats.kt
+++ b/core/src/com/unciv/logic/city/CityStats.kt
@@ -43,8 +43,14 @@ class CityStats(val cityInfo: CityInfo) {
     private fun getStatsFromTiles(): Stats {
         val stats = Stats()
         for (cell in cityInfo.tilesInRange
-                .filter { cityInfo.location == it.position || cityInfo.isWorked(it) ||
-                        it.getTileImprovement()?.hasUnique(UniqueType.TileProvidesYieldWithoutPopulation)==true && it.owningCity == cityInfo })
+                .filter {
+                    cityInfo.location == it.position ||
+                    cityInfo.isWorked(it) ||
+                    it.owningCity == cityInfo && (
+                        it.getTileImprovement()?.hasUnique(UniqueType.TileProvidesYieldWithoutPopulation)==true ||
+                        it.hasUnique(UniqueType.TileProvidesYieldWithoutPopulation)
+                    )
+                })
             stats.add(cell.getTileStats(cityInfo, cityInfo.civInfo))
         return stats
     }

--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -338,7 +338,7 @@ class CivilizationInfo {
     fun hasUnique(uniqueType: UniqueType) = getMatchingUniques(uniqueType).any()
     fun hasUnique(unique: String) = getMatchingUniques(unique).any()
 
-    /** Destined to replace getMatchingUniques, gradually, as we fill the enum */
+    /** Destined to replace getMatchingUniques(uniqueTemplate), gradually, as we fill the enum */
     fun getMatchingUniques(uniqueType: UniqueType, cityToIgnore: CityInfo?=null): Sequence<Unique> {
         val ruleset = gameInfo.ruleSet
         return nation.uniqueObjects.asSequence().filter { it.matches(uniqueType, ruleset) } +

--- a/core/src/com/unciv/logic/map/TileInfo.kt
+++ b/core/src/com/unciv/logic/map/TileInfo.kt
@@ -194,7 +194,8 @@ open class TileInfo {
 
     fun isRoughTerrain() = getAllTerrains().any{ it.isRough() }
 
-    fun hasUnique(unique: String) = getAllTerrains().any { it.uniques.contains(unique) }
+    fun hasUnique(unique: String) = getAllTerrains().any { it.hasUnique(unique) }
+    fun hasUnique(uniqueType: UniqueType) = getAllTerrains().any { it.hasUnique(uniqueType) }
 
     fun getWorkingCity(): CityInfo? {
         val civInfo = getOwner() ?: return null
@@ -202,8 +203,12 @@ open class TileInfo {
     }
 
     fun isWorked(): Boolean = getWorkingCity() != null
-    fun providesYield() = getCity() != null && (isCityCenter() || isWorked()
-            || getTileImprovement()?.hasUnique(UniqueType.TileProvidesYieldWithoutPopulation) == true)
+    fun providesYield() = getCity() != null && (
+            isCityCenter() ||
+            isWorked() ||
+            getTileImprovement()?.hasUnique(UniqueType.TileProvidesYieldWithoutPopulation) == true ||
+            hasUnique(UniqueType.TileProvidesYieldWithoutPopulation)
+        )
 
     fun isLocked(): Boolean {
         val workingCity = getWorkingCity()

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -78,7 +78,7 @@ enum class UniqueType(val text:String, vararg targets: UniqueTarget) {
     @Deprecated("As of 3.16.14", ReplaceWith("[amount]% growth [cityFilter] <when not at war>"), DeprecationLevel.WARNING)
     GrowthPercentBonusWhenNotAtWar("+[amount]% growth [cityFilter] when not at war", UniqueTarget.Global),
 
-    TileProvidesYieldWithoutPopulation("Tile provides yield without assigned population", UniqueTarget.Improvement),
+    TileProvidesYieldWithoutPopulation("Tile provides yield without assigned population", UniqueTarget.Terrain, UniqueTarget.Improvement),
 
 
     @Deprecated("As of 3.16.16", ReplaceWith("[amount]% maintenance costs for [mapUnitFilter] units"), DeprecationLevel.WARNING)


### PR DESCRIPTION
- F of Y "Tile provides yield without assigned population"
- Made that unique work on terrain
- Byzantium startBias fix - a pity - "Coats" sounds so nice. Should have done a terrain "Coats" instead.

Open question: This works to provide yield (and prevent worker assignment) when within the workable radius of a city and owned. How it should behave when owned by - 4 tiles from city center - I'm not sure.