### PR TITLE
Fix right side of player nation picker no longer entirely clickable

### DIFF
--- a/core/src/com/unciv/ui/newgamescreen/PlayerPickerTable.kt
+++ b/core/src/com/unciv/ui/newgamescreen/PlayerPickerTable.kt
@@ -323,6 +323,7 @@ private class NationPickerPopup(
         okButton.setPosition(innerTable.width - buttonsOffsetFromEdge, buttonsOffsetFromEdge, Align.bottomRight)
         innerTable.addActor(okButton)
 
+        nationDetailsTable.touchable = Touchable.enabled
         nationDetailsTable.onClick { returnSelected() }
     }
 
@@ -338,7 +339,7 @@ private class NationPickerPopup(
     }
 
     private fun setNationDetails(nation: Nation) {
-        nationDetailsTable.clear()
+        nationDetailsTable.clearChildren()  // .clear() also clears listeners!
 
         nationDetailsTable.add(NationTable(nation, civBlocksWidth, partHeight, ruleset))
         selectedNation = nation


### PR DESCRIPTION
Regression caused by #5287 - right now you need to click the checkmark, but it was meant as visual addon while having the entire nation detail active for selection as before.