### PR TITLE
Fix Mod unpack folder move

### DIFF
--- a/core/src/com/unciv/ui/worldscreen/mainmenu/GitHub.kt
+++ b/core/src/com/unciv/ui/worldscreen/mainmenu/GitHub.kt
@@ -111,6 +111,9 @@ object Github {
     private fun FileHandle.renameOrMove(dest: FileHandle) {
         // Gdx tries a java rename for Absolute and External, but NOT for Local - rectify that
         if (type() == Files.FileType.Local) {
+            // See #5346: renameTo 'unpacks' a source folder if the destination exists and is an
+            // empty folder, dropping the name of the source entirely.
+            // Safer to ask for a move to the not-yet-existing full resulting path instead.
             if (isDirectory)
                 if (file().renameTo(dest.child(name()).file())) return
             else

--- a/core/src/com/unciv/ui/worldscreen/mainmenu/GitHub.kt
+++ b/core/src/com/unciv/ui/worldscreen/mainmenu/GitHub.kt
@@ -107,10 +107,15 @@ object Github {
 
         return finalDestination
     }
-    
+
     private fun FileHandle.renameOrMove(dest: FileHandle) {
         // Gdx tries a java rename for Absolute and External, but NOT for Local - rectify that
-        if (type() == Files.FileType.Local && file().renameTo(dest.file())) return
+        if (type() == Files.FileType.Local) {
+            if (isDirectory)
+                if (file().renameTo(dest.child(name()).file())) return
+            else
+                if (file().renameTo(dest.file())) return
+        } 
         moveTo(dest)
     }
 


### PR DESCRIPTION
I got mod unpacking errors with ChooseYourDestinymod on desktop, and it boiled down to java rename not moving a folder but its contents to a destination in some cases but not in others. Related to #5309 but slightly different.

I originally inserted that helper because on Android the extra time for a copy-and-delete is noticeable. The OS _is_ capable of just moving a filesystem object without actually copying the data, so why does Gdx's moveTo avoid that? This variant, specifying the full destination name for folders (which at that point is guaranteed to not exist), fixed that for desktop runs without breaking any of the 20+ mods I tried. Tests on Android a few mods less, but all worked, including ChooseYourDestinymod.

***Question***: The more _careful_ choice would be to revert this helper entirely and put up with the ~100% longer unpacking time, increased SSD wear and tear, and increased battery drain... Your opinion?