### PR TITLE
Fix era of Wonders without tech in Wonder overview

### DIFF
--- a/core/src/com/unciv/ui/overviewscreen/WonderOverviewTable.kt
+++ b/core/src/com/unciv/ui/overviewscreen/WonderOverviewTable.kt
@@ -115,7 +115,7 @@ class WonderOverviewTable(
         val wonderEraMap: Map<String, Era> =
             ruleSet.buildings.values.asSequence()
             .filter { it.isWonder }
-            .map { it.name to ruleSet.eras[ruleSet.technologies[it.requiredTech]?.era()]!! }
+            .map { it.name to (ruleSet.eras[ruleSet.technologies[it.requiredTech]?.era()] ?: viewingPlayer.getEra()) }
             .toMap()
 
         // Maps all World Wonders by their position in sort order to their name


### PR DESCRIPTION
Might fix #5332 - though that crash must be mod-caused, as vanilla afaik only has the Utopia era-less, and that is a national which aren't pulled by the overview anyway.