### PR TITLE
Added game name to turn notification

### DIFF
--- a/android/res/values-de/strings.xml
+++ b/android/res/values-de/strings.xml
@@ -2,7 +2,7 @@
 <resources>
     <string name="app_name">UnCiv</string>
     <string name="Notify_YourTurn_Short">Unciv - Du bist am Zug!</string>
-    <string name="Notify_YourTurn_Long">Deine Freunde warten auf deinen Zug.</string>
+    <string name="Notify_YourTurn_Long">Deine Freunde warten auf deinen Zug in [gameName].</string>
     <string name="Notify_Error_Short">Ein Fehler ist aufgetreten</string>
     <string name="Notify_Error_Long">Multiplayer Zug Benachrichtigungsdienst wurde beendet.</string>
     <string name="Notify_Persist_Short">Letzter online Zugcheck:</string>

--- a/android/res/values-fr/strings.xml
+++ b/android/res/values-fr/strings.xml
@@ -2,7 +2,7 @@
 <resources>
     <string name="app_name">UnCiv</string>
     <string name="Notify_YourTurn_Short">Unciv - C\'est à vous !</string>
-    <string name="Notify_YourTurn_Long">Vos amis attendent votre action.</string>
+    <string name="Notify_YourTurn_Long">Vos amis attendent votre action dans [gameName].</string>
     <string name="Notify_Error_Long">Service de notification du tour multijoueur terminé</string>
     <string name="Notify_Error_Short">Une erreur est survenue</string>
     <string name="Notify_Persist_Long_P4">Configurable dans le menu des options de Unciv</string>

--- a/android/res/values/strings.xml
+++ b/android/res/values/strings.xml
@@ -2,7 +2,7 @@
 <resources>
     <string name="app_name">UnCiv</string>
     <string name="Notify_YourTurn_Short">Unciv - It\'s your turn!</string>
-    <string name="Notify_YourTurn_Long">Your friends are waiting on your turn.</string>
+    <string name="Notify_YourTurn_Long">Your friends are waiting for your turn in [gameName].</string>
     <string name="Notify_Error_Short">An error has occurred</string>
     <string name="Notify_Error_Long">Multiplayer turn notifier service terminated.</string>
     <string name="Notify_Persist_Short">Last online turn check:</string>

--- a/android/src/com/unciv/app/AndroidLauncher.kt
+++ b/android/src/com/unciv/app/AndroidLauncher.kt
@@ -69,7 +69,7 @@ open class AndroidLauncher : AndroidApplication() {
         if (UncivGame.Companion.isCurrentInitialized()
                 && UncivGame.Current.isGameInfoInitialized()
                 && UncivGame.Current.settings.multiplayerTurnCheckerEnabled
-                && UncivGame.Current.gameInfo.gameParameters.isOnlineMultiplayer) {
+                && GameSaver.getSaves(true).any()) {
             MultiplayerTurnCheckWorker.startTurnChecker(applicationContext, UncivGame.Current.gameInfo, UncivGame.Current.settings)
         }
         super.onPause()


### PR DESCRIPTION
To be able to better understand problems that are related to the turn notifier (like #5116) and give the user a better overview of why the notification pops, I've added the name of the game that triggers the notification to it.

I've also changed one of the turn checker start conditions from "the current game must be a multiplayer game" to "any multiplayer game exists in the multiplayer list". 
I'm not entirely sure why the condition "a current game must be initialized" is implemented though. Shouldn't the turn checker start every time the game is closed and not only when a game is initialized? Starting Unciv without starting a game currently does not enable the turn checker which might be irritating for a user who is waiting to be notified but isn't because the checker didn't start, only because no game was loaded.