### PR TITLE
RFC: Remove TranslationFileWriter knowledge about param values..

### DIFF
--- a/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
@@ -100,6 +100,13 @@ enum class UniqueParameterType(val parameterName:String) {
             return UniqueType.UniqueComplianceErrorSeverity.RulesetSpecific
         }
     },
+    Technology("tech") {
+        override fun getErrorSeverity(parameterText: String, ruleset: Ruleset):
+            UniqueType.UniqueComplianceErrorSeverity? = when (parameterText) {
+                in ruleset.technologies -> null
+                else -> UniqueType.UniqueComplianceErrorSeverity.RulesetSpecific
+            }
+    },
     Promotion("promotion") {
         override fun getErrorSeverity(parameterText: String, ruleset: Ruleset):
             UniqueType.UniqueComplianceErrorSeverity? = when (parameterText) {
@@ -107,16 +114,16 @@ enum class UniqueParameterType(val parameterName:String) {
                 else -> UniqueType.UniqueComplianceErrorSeverity.RulesetSpecific
             }
     },
-    /** Behaves like [Unknown], but states explicitly the parameter is OK and its contents are ignored */
-    Comment("comment") {
-        override fun getErrorSeverity(parameterText: String, ruleset: Ruleset):
-                UniqueType.UniqueComplianceErrorSeverity? = null
-    },
     Unknown("param") {
         override fun getErrorSeverity(parameterText: String, ruleset: Ruleset):
                 UniqueType.UniqueComplianceErrorSeverity? {
             return null
         }
+    },
+    /** Behaves like [Unknown], but states explicitly the parameter is OK and its contents are ignored */
+    Comment("comment") {
+        override fun getErrorSeverity(parameterText: String, ruleset: Ruleset):
+                UniqueType.UniqueComplianceErrorSeverity? = null
     };
 
     abstract fun getErrorSeverity(parameterText:String, ruleset: Ruleset): UniqueType.UniqueComplianceErrorSeverity?


### PR DESCRIPTION
.. rely only on UniqueParameterType

As you can see from the comments another 8 lines or so could go easily, the TFW would still recognize more than before - but some templates would change param names invalidating existing xlations. "building" / "buildingName" being the prime example - somehow a bit pointless.

What do you think? Retro-match a few UniqueParameterType secondary names to keep more xlt's?

