### PR TITLE
Added `in [tileFilter] tiles` conditional to combat uniques

### DIFF
--- a/android/assets/jsons/Civ V - Vanilla/Beliefs.json
+++ b/android/assets/jsons/Civ V - Vanilla/Beliefs.json
@@ -248,7 +248,7 @@
     {
         "name": "Defender of the Faith",
         "type": "Enhancer",
-        "uniques": ["[+20]% Strength for [All] units in [Friendly Land]"],
+        "uniques": ["[+20]% Strength <for [All] units> <in [Friendly Land] tiles>"],
         // ToDo: Should only be friendly territory of cities that follow this religion
     },
     {
@@ -264,7 +264,7 @@
     {
         "name": "Just War",
         "type": "Enhancer",
-        "uniques": ["[+20]% Strength for [Non-City] units in [Enemy Land]"],
+        "uniques": ["[+20]% Strength <for [All] units> <in [Enemy Land] tiles>"],
         // ToDo: Should only be enemy territory of cities that follow this religion
     },
     {

--- a/android/assets/jsons/Civ V - Vanilla/Buildings.json
+++ b/android/assets/jsons/Civ V - Vanilla/Buildings.json
@@ -756,7 +756,7 @@
 		"culture": 3,
 		"isWonder": true,
 		"greatPersonPoints": {"Great Engineer": 2},
-		"uniques": ["+[15]% Strength for [Non-City] units fighting in [Friendly Land]",
+		"uniques": ["[+15]% Strength <for [All] units> <in [Friendly Land] tiles>",
 			"Provides a free [Castle] [in this city]"],
 		"requiredTech": "Gunpowder",
 		"quote": "'Bushido is realized in the presence of death. This means choosing death whenever there is a choice between life and death. There is no other reasoning.' - Yamamoto Tsunetomo"

--- a/android/assets/jsons/Civ V - Vanilla/Policies.json
+++ b/android/assets/jsons/Civ V - Vanilla/Policies.json
@@ -432,7 +432,7 @@
 		},
 		{
 			"name": "Nationalism",
-			"uniques": ["+[15]% Strength for [Non-City] units fighting in [Friendly Land]"],
+			"uniques": ["[+15]% Strength <for [All] units> <in [Friendly Land] tiles>"],
 			"row": 1,
 			"column": 5
 		},

--- a/android/assets/jsons/Civ V - Vanilla/UnitPromotions.json
+++ b/android/assets/jsons/Civ V - Vanilla/UnitPromotions.json
@@ -9,37 +9,37 @@
 	// Ranged+Siege
 	{
 		"name": "Accuracy I",
-		"uniques": ["+[15]% Strength in [Open terrain]"],
+		"uniques": ["[+15]% Strength <in [Open terrain] tiles> <when attacking>"],
 		"unitTypes": ["Siege","Archery","Ranged Gunpowder"]
 	},
 	{
 		"name": "Accuracy II",
 		"prerequisites": ["Accuracy I"],
-		"uniques": ["+[15]% Strength in [Open terrain]"],
+		"uniques": ["[+15]% Strength <in [Open terrain] tiles> <when attacking>"],
 		"unitTypes": ["Siege","Archery","Ranged Gunpowder"]
 	},
 	{
 		"name": "Accuracy III",
 		"prerequisites": ["Accuracy II"],
-		"uniques": ["+[15]% Strength in [Open terrain]"],
+		"uniques": ["[+15]% Strength <in [Open terrain] tiles> <when attacking>"],
 		"unitTypes": ["Siege","Archery","Ranged Gunpowder"]
 	},
 
 	{
 		"name": "Barrage I",
-		"uniques": ["+[15]% Strength in [Rough terrain]"],
+		"uniques": ["[+15]% Strength <in [Rough terrain] tiles> <when attacking>"],
 		"unitTypes": ["Siege","Archery","Ranged Gunpowder"]
 	},
 	{
 		"name": "Barrage II",
 		"prerequisites": ["Barrage I"],
-		"uniques": ["+[15]% Strength in [Rough terrain]"],
+		"uniques": ["[+15]% Strength <in [Rough terrain] tiles> <when attacking>"],
 		"unitTypes": ["Siege","Archery","Ranged Gunpowder"]
 	},
 	{
 		"name": "Barrage III",
 		"prerequisites": ["Barrage II"],
-		"uniques": ["+[15]% Strength in [Rough terrain]"],
+		"uniques": ["[+15]% Strength <in [Rough terrain] tiles> <when attacking>"],
 		"unitTypes": ["Siege","Archery","Ranged Gunpowder"]
 	},
 
@@ -65,37 +65,37 @@
 	// Melee, Mounted+Armor
 	{
 		"name": "Shock I",
-		"uniques": ["+[15]% Strength in [Open terrain]"],
+		"uniques": ["[+15]% Strength <in [Open terrain] tiles>"],
 		"unitTypes": ["Sword","Gunpowder","Mounted","Armored"]
 	},
 	{
 		"name": "Shock II",
 		"prerequisites": ["Shock I"],
-		"uniques": ["+[15]% Strength in [Open terrain]"],
+		"uniques": ["[+15]% Strength <in [Open terrain] tiles>"],
 		"unitTypes": ["Sword","Gunpowder","Mounted","Armored"]
 	},
 	{
 		"name": "Shock III",
 		"prerequisites": ["Shock II"],
-		"uniques": ["+[15]% Strength in [Open terrain]"],
+		"uniques": ["[+15]% Strength <in [Open terrain] tiles>"],
 		"unitTypes": ["Sword","Gunpowder","Mounted","Armored"]
 	},
 
 	{
 		"name": "Drill I",
-		"uniques": ["+[15]% Strength in [Rough terrain]"],
+		"uniques": ["[+15]% Strength <in [Rough terrain] tiles>"],
 		"unitTypes": ["Sword","Gunpowder","Mounted","Armored"]
 	},
 	{
 		"name": "Drill II",
 		"prerequisites": ["Drill I"],
-		"uniques": ["+[15]% Strength in [Rough terrain]"],
+		"uniques": ["[+15]% Strength <in [Rough terrain] tiles>"],
 		"unitTypes": ["Sword","Gunpowder","Mounted","Armored"]
 	},
 	{
 		"name": "Drill III",
 		"prerequisites": ["Drill II"],
-		"uniques": ["+[15]% Strength in [Rough terrain]"],
+		"uniques": ["[+15]% Strength <in [Rough terrain] tiles>"],
 		"unitTypes": ["Sword","Gunpowder","Mounted","Armored"]
 	},
 	{
@@ -537,6 +537,6 @@
 	},
 	{
 		"name": "Pictish Courage", // only for Pictish Warrior and subsequent upgrades
-		"uniques": ["No movement cost to pillage", "+[20]% Strength in [Foreign Land]"]
+		"uniques": ["No movement cost to pillage", "[+20]% Strength <in [Foreign Land] tiles>"]
 	}
 ]

--- a/android/assets/jsons/Civ V - Vanilla/Units.json
+++ b/android/assets/jsons/Civ V - Vanilla/Units.json
@@ -66,7 +66,7 @@
 		"strength": 8,
 		"cost": 40,
 		"obsoleteTech": "Metal Casting",
-		"uniques": ["+[33]% Strength in [Forest]", "+[33]% Strength in [Jungle]", "Heals [25] damage if it kills a unit"],
+		"uniques": ["[+33]% Strength <in [Forest] tiles>", "[+33]% Strength <in [Jungle] tiles>", "Heals [25] damage if it kills a unit"],
 		"promotions": ["Woodsman"],
 		"upgradesTo": "Swordsman",
 		"attackSound": "nonmetalhit"
@@ -315,7 +315,7 @@
 		"requiredTech": "Bronze Working",
 		"obsoleteTech": "Physics",
 		"upgradesTo": "Trebuchet",
-		"uniques": ["[+300]% Strength <vs cities>", "No defensive terrain bonus", "[-33]% Strength <when defending>",
+		"uniques": ["[+300]% Strength <vs cities> <when attacking>", "No defensive terrain bonus", "[-33]% Strength <when defending>",
 		"[-1] Sight", "Can only attack [City] units"],
 		"promotions":  ["Cover I"],
 		"attackSound": "throw"
@@ -425,7 +425,7 @@
 		"requiredTech": "Mathematics",
 		"obsoleteTech": "Physics",
 		"upgradesTo": "Trebuchet",
-		"uniques": ["[+200]% Strength <vs cities>", "No defensive terrain bonus",
+		"uniques": ["[+200]% Strength <vs cities> <when attacking>", "No defensive terrain bonus",
 			"Must set up to ranged attack", "Limited Visibility"],
 		"hurryCostModifier": 20,
 		"attackSound": "throw"
@@ -442,7 +442,7 @@
 		"requiredTech": "Mathematics",
 		"obsoleteTech": "Physics",
 		"upgradesTo": "Trebuchet",
-		"uniques": ["[+200]% Strength <vs cities>", "No defensive terrain bonus",
+		"uniques": ["[+200]% Strength <vs cities> <when attacking>", "No defensive terrain bonus",
 			"Must set up to ranged attack", "Limited Visibility"],
 		"hurryCostModifier": 20,
 		"attackSound": "throw"
@@ -500,7 +500,7 @@
 		"upgradesTo": "Longswordsman",
 		"obsoleteTech": "Gunpowder",
 		"hurryCostModifier": 20,
-		"uniques": ["+[33]% Strength in [Forest]", "+[33]% Strength in [Jungle]"],
+		"uniques": ["[+33]% Strength <in [Forest] tiles>", "[+33]% Strength <in [Jungle] tiles>"],
 		"attackSound": "metalhit"
 	},
 	/*
@@ -709,7 +709,7 @@
 		"requiredTech": "Physics",
 		"obsoleteTech": "Chemistry",
 		"upgradesTo": "Cannon",
-		"uniques": ["[+200]% Strength <vs cities>","No defensive terrain bonus","Must set up to ranged attack","Limited Visibility"],
+		"uniques": ["[+200]% Strength <vs cities> <when attacking>","No defensive terrain bonus","Must set up to ranged attack","Limited Visibility"],
 		"attackSound": "throw"
 	},
 	{
@@ -985,7 +985,7 @@
 		"requiredTech": "Chemistry",
 		"upgradesTo": "Artillery",
 		"obsoleteTech": "Dynamite",
-		"uniques": ["[+200]% Strength <vs cities>","No defensive terrain bonus","Must set up to ranged attack","Limited Visibility"],
+		"uniques": ["[+200]% Strength <vs cities> <when attacking>","No defensive terrain bonus","Must set up to ranged attack","Limited Visibility"],
 		"attackSound": "cannon"
 	},
 
@@ -1026,9 +1026,9 @@
 		"requiredTech": "Rifling",
 		"obsoleteTech": "Replaceable Parts",
 		"upgradesTo": "Great War Infantry",
-		"uniques": ["+[25]% Strength in [Snow]",
-			"+[25]% Strength in [Tundra]",
-			"+[25]% Strength in [Hill]",
+		"uniques": ["[+25]% Strength <in [Snow] tiles>",
+			"[+25]% Strength <in [Tundra] tiles>",
+			"[+25]% Strength <in [Hill] tiles>",
 			"Double movement in [Snow]",
 			"Double movement in [Tundra]",
 			"Double movement in [Hill]"],
@@ -1116,7 +1116,7 @@
 		"cost": 320,
 		"requiredTech": "Dynamite",
 		"upgradesTo": "Rocket Artillery",
-		"uniques": ["[+200]% Strength <vs cities>","No defensive terrain bonus",
+		"uniques": ["[+200]% Strength <vs cities> <when attacking>","No defensive terrain bonus",
 			"Must set up to ranged attack","Limited Visibility","Ranged attacks may be performed over obstacles"],
 		"attackSound": "artillery"
 	},
@@ -1157,7 +1157,7 @@
 		"requiredTech": "Replaceable Parts",
 		"upgradesTo": "Infantry",
 		"obsoleteTech": "Plastics",
-		"uniques": ["+[20]% Strength in [Foreign Land]"],
+		"uniques": ["[+20]% Strength <in [Foreign Land] tiles>"],
 		"attackSound": "shot"
 	},
 	{
@@ -1426,7 +1426,7 @@
 		"cost": 425,
 		"requiredTech": "Rocketry",
 		"requiredResource": "Aluminum",
-		"uniques": ["[+200]% Strength <vs cities>","No defensive terrain bonus",
+		"uniques": ["[+200]% Strength <vs cities> <when attacking>","No defensive terrain bonus",
 			"Limited Visibility","Ranged attacks may be performed over obstacles"],
 		"attackSound": "artillery"
 	},

--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -1304,11 +1304,17 @@ Invisible to others =
 # In this case "<when at war>" is a conditional.
 when not at war = 
 when at war = 
+during a Golden Age = 
+
 if this city has at least [amount] specialists = 
+
+for [mapUnitFilter] units = 
 vs cities = 
 vs [mapUnitFilter] units = 
 when attacking = 
 when defending = 
+in [tileFilter] tiles = 
+
 
 # In English we just paste all these conditionals at the end of each unique, but in your language that
 # may not turn into valid sentences. Therefore we have the following two translations to determine

--- a/core/src/com/unciv/logic/battle/BattleDamage.kt
+++ b/core/src/com/unciv/logic/battle/BattleDamage.kt
@@ -35,7 +35,7 @@ object BattleDamage {
         if (combatant is MapUnitCombatant) {
             for (unique in combatant.unit.getMatchingUniques(
                 UniqueType.Strength,
-                StateForConditionals(civInfo, defender = enemy, attacker = combatant, combatAction = combatAction))
+                StateForConditionals(civInfo, theirCombatant = enemy, ourCombatant = combatant, combatAction = combatAction))
             ) {
                 modifiers.add(getModifierStringFromUnique(unique), unique.params[0].toInt())
             }

--- a/core/src/com/unciv/models/ruleset/unique/StateForConditionals.kt
+++ b/core/src/com/unciv/models/ruleset/unique/StateForConditionals.kt
@@ -11,9 +11,9 @@ data class StateForConditionals(
     val civInfo: CivilizationInfo? = null,
     val cityInfo: CityInfo? = null,
     val unit: MapUnit? = null,
-    
-    val attacker: ICombatant? = null,
-    val defender: ICombatant? = null,
+
+    val ourCombatant: ICombatant? = null,
+    val theirCombatant: ICombatant? = null,
 //    val attackedTile: TileInfo? = null,
     val combatAction: CombatAction? = null,
 )

--- a/core/src/com/unciv/models/ruleset/unique/StateForConditionals.kt
+++ b/core/src/com/unciv/models/ruleset/unique/StateForConditionals.kt
@@ -14,6 +14,6 @@ data class StateForConditionals(
 
     val ourCombatant: ICombatant? = null,
     val theirCombatant: ICombatant? = null,
-//    val attackedTile: TileInfo? = null,
+    val attackedTile: TileInfo? = null,
     val combatAction: CombatAction? = null,
 )

--- a/core/src/com/unciv/models/ruleset/unique/Unique.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Unique.kt
@@ -56,11 +56,11 @@ class Unique(val text: String, val sourceObjectType: UniqueTarget? = null, val s
                 state.cityInfo != null && state.cityInfo.population.getNumberOfSpecialists() >= condition.params[0].toInt()
             
             UniqueType.ConditionalVsCity ->
-                state.defender != null && state.defender.matchesCategory("City")
+                state.theirCombatant != null && state.theirCombatant.matchesCategory("City")
             UniqueType.ConditionalVsUnits ->
-                state.defender != null && state.defender.matchesCategory(condition.params[0])
+                state.theirCombatant != null && state.theirCombatant.matchesCategory(condition.params[0])
             UniqueType.ConditionalOurUnit ->
-                (state.attacker != null && state.attacker.matchesCategory(condition.params[0]))
+                (state.ourCombatant != null && state.ourCombatant.matchesCategory(condition.params[0]))
                 || (state.unit != null && state.unit.matchesFilter(condition.params[0]))
             UniqueType.ConditionalAttacking -> state.combatAction == CombatAction.Attack
             UniqueType.ConditionalDefending -> state.combatAction == CombatAction.Defend

--- a/core/src/com/unciv/models/ruleset/unique/Unique.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Unique.kt
@@ -64,6 +64,8 @@ class Unique(val text: String, val sourceObjectType: UniqueTarget? = null, val s
                 || (state.unit != null && state.unit.matchesFilter(condition.params[0]))
             UniqueType.ConditionalAttacking -> state.combatAction == CombatAction.Attack
             UniqueType.ConditionalDefending -> state.combatAction == CombatAction.Defend
+            UniqueType.ConditionalInTiles -> 
+                state.attackedTile != null && state.attackedTile.matchesFilter(condition.params[0])
             
             UniqueType.ConditionalNeighborTiles ->
                 state.cityInfo != null &&

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -141,6 +141,15 @@ enum class UniqueType(val text:String, vararg targets: UniqueTarget) {
     DamageForUnits("[mapUnitFilter] units deal +[amount]% damage", UniqueTarget.Global),
     @Deprecated("As of 3.17.5", ReplaceWith("[+10]% Strength <for [All] units> <during a Golden Age>"), DeprecationLevel.WARNING)
     StrengthGoldenAge("+10% Strength for all units during Golden Age", UniqueTarget.Global),
+    @Deprecated("As of 3.17.5", ReplaceWith("[amount]% Strength <in [tileFilter] tiles> <when defending>"), DeprecationLevel.WARNING)
+    StrengthDefenseTiles("+[amount]% defence in [tileFilter] tiles", UniqueTarget.Unit),
+    @Deprecated("As of 3.17.5", ReplaceWith("[amount]% Strength <in [tileFilter] tiles>"), DeprecationLevel.WARNING)
+    StrengthIn("+[amount]% Strength in [tileFilter]", UniqueTarget.Unit),
+    @Deprecated("As of 3.17.5", ReplaceWith("[amount]% Strength <for [mapUnitFilter] units> <in [tileFilter] tiles>"))
+    StrengthUnitsTiles("[amount]% Strength for [mapUnitFilter] units in [tileFilter]", UniqueTarget.Global),
+    @Deprecated("As of 3.17.5", ReplaceWith("[+15]% Strength <for [All] units> <vs cities> <when attacking>"))
+    StrengthVsCities("+15% Combat Strength for all units when attacking Cities", UniqueTarget.Global),
+    
     
     Movement("[amount] Movement", UniqueTarget.Unit, UniqueTarget.Global),
     Sight("[amount] Sight", UniqueTarget.Unit, UniqueTarget.Global),
@@ -217,7 +226,7 @@ enum class UniqueType(val text:String, vararg targets: UniqueTarget) {
     ConditionalAttacking("when attacking", UniqueTarget.Conditional),
     ConditionalDefending("when defending", UniqueTarget.Conditional),
 //    ConditionalIntercepting("when intercepting", UniqueTarget.Conditional),
-//    ConditionalInTiles("fighting in [tileFilter] tiles", UniqueTarget.Conditional),
+    ConditionalInTiles("in [tileFilter] tiles", UniqueTarget.Conditional),
 
     // tile conditionals
     ConditionalNeighborTiles("with [amount] to [amount] neighboring [tileFilter] tiles", UniqueTarget.Conditional),

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -59,6 +59,7 @@ enum class UniqueType(val text:String, vararg targets: UniqueTarget) {
 
     //////////////////////////////////////// GLOBAL UNIQUES ////////////////////////////////////////
 
+    
     /////// Stat providing uniques
 
     Stats("[stats]", UniqueTarget.Global),
@@ -114,10 +115,10 @@ enum class UniqueType(val text:String, vararg targets: UniqueTarget) {
 
     FreeExtraBeliefs("May choose [amount] additional [beliefType] beliefs when [foundingOrEnhancing] a religion", UniqueTarget.Global),
     FreeExtraAnyBeliefs("May choose [amount] additional of any type when [foundingOrEnhancing] a religion", UniqueTarget.Global),
-
     
     ///////////////////////////////////////// UNIT UNIQUES /////////////////////////////////////////
 
+    
     Strength("[amount]% Strength", UniqueTarget.Unit, UniqueTarget.Global),
 
     @Deprecated("As of 3.17.3", ReplaceWith("[amount]% Strength"), DeprecationLevel.WARNING)
@@ -175,10 +176,10 @@ enum class UniqueType(val text:String, vararg targets: UniqueTarget) {
     CanEnterIceTiles("Can enter ice tiles", UniqueTarget.Unit),
     CannotEnterOcean("Cannot enter ocean tiles", UniqueTarget.Unit),
     CannotEnterOceanUntilAstronomy("Cannot enter ocean tiles until Astronomy", UniqueTarget.Unit),
-
     
     //////////////////////////////////////// TERRAIN UNIQUES ////////////////////////////////////////
 
+    
     NaturalWonderNeighborCount("Must be adjacent to [amount] [simpleTerrain] tiles", UniqueTarget.Terrain),
     NaturalWonderNeighborsRange("Must be adjacent to [amount] to [amount] [simpleTerrain] tiles", UniqueTarget.Terrain),
     NaturalWonderSmallerLandmass("Must not be on [amount] largest landmasses", UniqueTarget.Terrain),
@@ -199,6 +200,7 @@ enum class UniqueType(val text:String, vararg targets: UniqueTarget) {
 
     ///////////////////////////////////////// CONDITIONALS /////////////////////////////////////////
 
+    
     // civ conditionals
     ConditionalWar("when at war", UniqueTarget.Conditional),
     ConditionalNotWar("when not at war", UniqueTarget.Conditional),

--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -600,9 +600,11 @@ class BaseUnit : RulesetObject(), INonPerpetualConstruction {
                     if (unique.conditionals.any { it.isOfType(UniqueType.ConditionalVsUnits) } ) { // Bonus vs some units - a quarter of the bonus
                         power *= (unique.params[0].toInt() / 4f).toPercent()
                     } else if (
-                        unique.conditionals.any { it.isOfType(UniqueType.ConditionalVsCity) } || // City Attack - half the bonus
-                        unique.conditionals.any { it.isOfType(UniqueType.ConditionalAttacking) } || // Attack - half the bonus
-                        unique.conditionals.any { it.isOfType(UniqueType.ConditionalDefending) } // Defense - half the bonus
+                        unique.conditionals.any {
+                            it.isOfType(UniqueType.ConditionalVsCity) // City Attack - half the bonus
+                            || it.isOfType(UniqueType.ConditionalAttacking) // Attack - half the bonus
+                            || it.isOfType(UniqueType.ConditionalDefending) // Defense - half the bonus 
+                            || it.isOfType(UniqueType.ConditionalInTiles) } // Bonus in terrain or feature - half the bonus
                     ) {
                         power *= (unique.params[0].toInt() / 2f).toPercent()
                     }
@@ -623,8 +625,10 @@ class BaseUnit : RulesetObject(), INonPerpetualConstruction {
                     -> power += power / 4
                 unique.placeholderText == "Must set up to ranged attack" // Must set up - 20 % penalty
                     -> power -= power / 5
-                unique.placeholderText == "+[]% Strength in []" // Bonus in terrain or feature - half the bonus
-                    -> power += (power * unique.params[0].toInt()) / 200
+                // Deprecated since 3.17.5
+                    unique.isOfType(UniqueType.StrengthIn) // Bonus in terrain or feature - half the bonus
+                        -> power += (power * unique.params[0].toInt()) / 200
+                //
             }
         }
 
@@ -636,9 +640,11 @@ class BaseUnit : RulesetObject(), INonPerpetualConstruction {
                         if (unique.conditionals.any { it.isOfType(UniqueType.ConditionalVsUnits) } ) { // Bonus vs some units - a quarter of the bonus
                             power *= (unique.params[0].toInt() / 4f).toPercent()
                         } else if (
-                            unique.conditionals.any { it.isOfType(UniqueType.ConditionalVsCity) } || // City Attack - half the bonus
-                            unique.conditionals.any { it.isOfType(UniqueType.ConditionalAttacking) } || // Attack - half the bonus
-                            unique.conditionals.any { it.isOfType(UniqueType.ConditionalDefending) } // Defense - half the bonus
+                            unique.conditionals.any { 
+                                it.isOfType(UniqueType.ConditionalVsCity) // City Attack - half the bonus
+                                || it.isOfType(UniqueType.ConditionalAttacking) // Attack - half the bonus
+                                || it.isOfType(UniqueType.ConditionalDefending) // Defense - half the bonus 
+                                || it.isOfType(UniqueType.ConditionalInTiles) } // Bonus in terrain or feature - half the bonus
                         ) {
                             power *= (unique.params[0].toInt() / 2f).toPercent() 
                         }
@@ -657,8 +663,10 @@ class BaseUnit : RulesetObject(), INonPerpetualConstruction {
                     //
                     unique.placeholderText == "[] additional attacks per turn" // Extra attacks - 20% bonus per extra attack
                         -> power += (power * unique.params[0].toInt()) / 5
-                    unique.placeholderText == "+[]% Strength in []" // Bonus in terrain or feature - half the bonus
-                        -> power += (power * unique.params[0].toInt()) / 200
+                    // Deprecated since 3.17.5
+                        unique.isOfType(UniqueType.StrengthIn) // Bonus in terrain or feature - half the bonus
+                            -> power += (power * unique.params[0].toInt()) / 200
+                    //
                 }
             }
 


### PR DESCRIPTION
This PR simplifies combat uniques further using conditionals.
Fixes #4508, and adds the bonus vs cities of siege units only applying when attacking, as noted in #3506.

Added conditionals:
- "in [tileFilter] tiles"

Deprecated uniques:
- "+[amount]% defence in [tileFilter] tiles"
- "+[amount]% Strength in [tileFilter]"
- "[amount]% Strength for [mapUnitFilter] units in [tileFilter]"
- "+15% Combat Strength for all units when attacking Cities"