### PR TITLE
AI rationing of strategic resources; Hydro Plant re-enabled

### DIFF
--- a/android/assets/jsons/Civ V - Vanilla/Buildings.json
+++ b/android/assets/jsons/Civ V - Vanilla/Buildings.json
@@ -915,7 +915,6 @@
 		"requiredBuilding": "Bank",
 		"requiredTech": "Electricity"
 	},
-	/* This works and even has icon but AI cannot manage its Aluminum at this moment
 	{
 		"name": "Hydro Plant",
 		"requiredResource": "Aluminum",
@@ -924,7 +923,6 @@
 		"uniques": ["Must be on [River]","[+1 Production] from [River] tiles [in this city]"],
 		"requiredTech": "Electricity"
 	},
-	*/
 
 	// Modern Era
 

--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -70,6 +70,9 @@ class GameInfo {
     @Transient
     var simulateUntilWin = false
 
+    @Transient
+    var spaceResources = HashSet<String>()
+
     //endregion
     //region Pure functions
 
@@ -374,6 +377,9 @@ class GameInfo {
                 civInfo.hasEverOwnedOriginalCapital = civInfo.cities.any { it.isOriginalCapital }
             }
         }
+
+        spaceResources.addAll(ruleSet.buildings.values.filter { it.hasUnique("Spaceship part") }
+            .flatMap { it.getResourceRequirements().keys } )
     }
 
     //endregion

--- a/core/src/com/unciv/logic/automation/Automation.kt
+++ b/core/src/com/unciv/logic/automation/Automation.kt
@@ -13,7 +13,6 @@ import com.unciv.models.stats.Stats
 import com.unciv.ui.victoryscreen.RankingType
 import kotlin.math.max
 import kotlin.math.sqrt
-import kotlin.system.measureNanoTime
 
 object Automation {
 

--- a/core/src/com/unciv/logic/automation/Automation.kt
+++ b/core/src/com/unciv/logic/automation/Automation.kt
@@ -118,7 +118,6 @@ object Automation {
             return true
 
         val civResources = civInfo.getCivResourcesByName()
-        val spaceRequired = if (civInfo.nation.preferredVictoryType == VictoryType.Scientific) 3 else 2
 
         // Rule of thumb: reserve 2-3 for spaceship, then reserve half each for buildings and units
         // Assume that no buildings provide any resources
@@ -137,7 +136,8 @@ object Automation {
             }
 
             // Make sure we have some for space
-            if (resource in civInfo.gameInfo.spaceResources && civResources[resource]!! - amount - futureForBuildings - futureForUnits < spaceRequired) {
+            if (resource in civInfo.gameInfo.spaceResources && civResources[resource]!! - amount - futureForBuildings - futureForUnits
+                < getReservedSpaceResourceAmount(civInfo)) {
                 return false
             }
 
@@ -168,6 +168,10 @@ object Automation {
             }
         }
         return true
+    }
+
+    fun getReservedSpaceResourceAmount(civInfo: CivilizationInfo): Int {
+        return if (civInfo.nation.preferredVictoryType == VictoryType.Scientific) 3 else 2
     }
 
     fun threatAssessment(assessor: CivilizationInfo, assessed: CivilizationInfo): ThreatLevel {

--- a/core/src/com/unciv/logic/automation/ConstructionAutomation.kt
+++ b/core/src/com/unciv/logic/automation/ConstructionAutomation.kt
@@ -286,7 +286,7 @@ class ConstructionAutomation(val cityConstructions: CityConstructions){
 
     private fun addProductionBuildingChoice() {
         val productionBuilding = buildableNotWonders.asSequence()
-            .filter { it.isStatRelated(Stat.Production) }
+            .filter { it.isStatRelated(Stat.Production) && Automation.allowSpendingResource(civInfo, it) }
             .minByOrNull { it.cost }
         if (productionBuilding != null) {
             addChoice(relativeCostEffectiveness, productionBuilding.name, 1.5f)

--- a/core/src/com/unciv/logic/automation/ConstructionAutomation.kt
+++ b/core/src/com/unciv/logic/automation/ConstructionAutomation.kt
@@ -115,7 +115,8 @@ class ConstructionAutomation(val cityConstructions: CityConstructions){
 
     private fun addWorkBoatChoice() {
         val buildableWorkboatUnits = cityInfo.cityConstructions.getConstructableUnits()
-                .filter { it.uniques.contains(Constants.workBoatsUnique) }
+                .filter { it.uniques.contains(Constants.workBoatsUnique)
+                        && Automation.allowSpendingResource(civInfo, it) }
         val canBuildWorkboat = buildableWorkboatUnits.any()
                 && !cityInfo.getTiles().any { it.civilianUnit?.hasUnique(Constants.workBoatsUnique) == true }
         if (!canBuildWorkboat) return
@@ -140,7 +141,8 @@ class ConstructionAutomation(val cityConstructions: CityConstructions){
         val workerEquivalents = civInfo.gameInfo.ruleSet.units.values
                 .filter { it.uniques.any {
                         unique -> unique.equalsPlaceholderText(Constants.canBuildImprovements)
-                } && it.isBuildable(cityConstructions) }
+                } && it.isBuildable(cityConstructions)
+                && Automation.allowSpendingResource(civInfo, it) }
         if (workerEquivalents.isEmpty()) return // for mods with no worker units
         if (civInfo.getIdleUnits().any { it.isAutomated() && it.hasUniqueToBuildImprovements })
             return // If we have automated workers who have no work to do then it's silly to construct new workers.
@@ -155,7 +157,8 @@ class ConstructionAutomation(val cityConstructions: CityConstructions){
 
     private fun addCultureBuildingChoice() {
         val cultureBuilding = buildableNotWonders
-                .filter { it.isStatRelated(Stat.Culture) }.minByOrNull { it.cost }
+                .filter { it.isStatRelated(Stat.Culture)
+                        && Automation.allowSpendingResource(civInfo, it) }.minByOrNull { it.cost }
         if (cultureBuilding != null) {
             var modifier = 0.5f
             if (cityInfo.cityStats.currentCityStats.culture == 0f) // It won't grow if we don't help it
@@ -175,7 +178,8 @@ class ConstructionAutomation(val cityConstructions: CityConstructions){
     }
 
     private fun addOtherBuildingChoice() {
-        val otherBuilding = buildableNotWonders.minByOrNull { it.cost }
+        val otherBuilding = buildableNotWonders
+            .filter { Automation.allowSpendingResource(civInfo, it) }.minByOrNull { it.cost }
         if (otherBuilding != null) {
             val modifier = 0.6f
             addChoice(relativeCostEffectiveness, otherBuilding.name, modifier)
@@ -211,6 +215,7 @@ class ConstructionAutomation(val cityConstructions: CityConstructions){
         if (!buildableWonders.any()) return
 
         val highestPriorityWonder = buildableWonders
+            .filter { Automation.allowSpendingResource(civInfo, it) }
             .maxByOrNull { getWonderPriority(it) }!!
         val citiesBuildingWonders = civInfo.cities
                 .count { it.cityConstructions.isBuildingWonder() }
@@ -222,7 +227,8 @@ class ConstructionAutomation(val cityConstructions: CityConstructions){
 
     private fun addUnitTrainingBuildingChoice() {
         val unitTrainingBuilding = buildableNotWonders.asSequence()
-                .filter { it.hasUnique("New [] units start with [] Experience []") }.minByOrNull { it.cost }
+                .filter { it.hasUnique("New [] units start with [] Experience []")
+                        && Automation.allowSpendingResource(civInfo, it)}.minByOrNull { it.cost }
         if (unitTrainingBuilding != null && (preferredVictoryType != VictoryType.Cultural || isAtWar)) {
             var modifier = if (cityIsOverAverageProduction) 0.5f else 0.1f // You shouldn't be cranking out units anytime soon
             if (isAtWar) modifier *= 2
@@ -234,7 +240,8 @@ class ConstructionAutomation(val cityConstructions: CityConstructions){
 
     private fun addDefenceBuildingChoice() {
         val defensiveBuilding = buildableNotWonders.asSequence()
-                .filter { it.cityStrength > 0 }.minByOrNull { it.cost }
+                .filter { it.cityStrength > 0
+                        && Automation.allowSpendingResource(civInfo, it)}.minByOrNull { it.cost }
         if (defensiveBuilding != null && (isAtWar || preferredVictoryType != VictoryType.Cultural)) {
             var modifier = 0.2f
             if (isAtWar) modifier = 0.5f
@@ -250,8 +257,9 @@ class ConstructionAutomation(val cityConstructions: CityConstructions){
 
     private fun addHappinessBuildingChoice() {
         val happinessBuilding = buildableNotWonders.asSequence()
-                .filter { it.isStatRelated(Stat.Happiness)
-                        || it.uniques.contains("Remove extra unhappiness from annexed cities") }
+                .filter { (it.isStatRelated(Stat.Happiness)
+                        || it.uniques.contains("Remove extra unhappiness from annexed cities"))
+                        && Automation.allowSpendingResource(civInfo, it)}
             .minByOrNull { it.cost }
         if (happinessBuilding != null) {
             var modifier = 1f
@@ -265,7 +273,8 @@ class ConstructionAutomation(val cityConstructions: CityConstructions){
     private fun addScienceBuildingChoice() {
         if (allTechsAreResearched) return
         val scienceBuilding = buildableNotWonders.asSequence()
-            .filter { it.isStatRelated(Stat.Science) }
+            .filter { it.isStatRelated(Stat.Science)
+            && Automation.allowSpendingResource(civInfo, it)}
             .minByOrNull { it.cost }
         if (scienceBuilding != null) {
             var modifier = 1.1f
@@ -276,7 +285,8 @@ class ConstructionAutomation(val cityConstructions: CityConstructions){
     }
 
     private fun addGoldBuildingChoice() {
-        val goldBuilding = buildableNotWonders.asSequence().filter { it.isStatRelated(Stat.Gold) }
+        val goldBuilding = buildableNotWonders.asSequence().filter { it.isStatRelated(Stat.Gold)
+            && Automation.allowSpendingResource(civInfo, it)}
             .minByOrNull { it.cost }
         if (goldBuilding != null) {
             val modifier = if (civInfo.statsForNextTurn.gold < 0) 3f else 1.2f
@@ -294,8 +304,9 @@ class ConstructionAutomation(val cityConstructions: CityConstructions){
     }
 
     private fun addFoodBuildingChoice() {
-        val foodBuilding = buildableNotWonders.asSequence().filter { it.isStatRelated(Stat.Food)
-                || it.uniqueObjects.any { it.placeholderText=="[]% of food is carried over after population increases" }}
+        val foodBuilding = buildableNotWonders.asSequence().filter { (it.isStatRelated(Stat.Food)
+                || it.uniqueObjects.any { it.placeholderText=="[]% of food is carried over after population increases" })
+                && Automation.allowSpendingResource(civInfo, it) }
             .minByOrNull { it.cost }
         if (foodBuilding != null) {
             var modifier = 1f

--- a/core/src/com/unciv/logic/automation/NextTurnAutomation.kt
+++ b/core/src/com/unciv/logic/automation/NextTurnAutomation.kt
@@ -302,7 +302,7 @@ object NextTurnAutomation {
     }
 
     /** If we are able to build a spaceship but have already spent our resources, try disbanding
-     *  a unit and selling a building to make room. */
+     *  a unit and selling a building to make room. Can happen due to trades etc */
     private fun freeUpSpaceResources(civInfo: CivilizationInfo) {
         // Can't build spaceships
         if (!civInfo.hasUnique("Enables construction of Spaceship parts"))

--- a/core/src/com/unciv/logic/automation/NextTurnAutomation.kt
+++ b/core/src/com/unciv/logic/automation/NextTurnAutomation.kt
@@ -45,6 +45,7 @@ object NextTurnAutomation {
             exchangeLuxuries(civInfo)
             issueRequests(civInfo)
             adoptPolicy(civInfo)  // todo can take a second - why?
+            freeUpSpaceResources(civInfo)
         } else {
             civInfo.getFreeTechForCityState()
             civInfo.updateDiplomaticRelationshipForCityState()
@@ -297,6 +298,39 @@ object NextTurnAutomation {
 
             val policyToAdopt = preferredPolicies.random()
             civInfo.policies.adopt(policyToAdopt)
+        }
+    }
+
+    /** If we are able to build a spaceship but have already spent our resources, try disbanding
+     *  a unit and selling a building to make room. */
+    private fun freeUpSpaceResources(civInfo: CivilizationInfo) {
+        // Can't build spaceships
+        if (!civInfo.hasUnique("Enables construction of Spaceship parts"))
+            return
+
+        for (resource in civInfo.gameInfo.spaceResources) {
+            // Have enough resources already
+            if (civInfo.getCivResourcesByName()[resource]!! >= Automation.getReservedSpaceResourceAmount(civInfo))
+                continue
+
+            val unitToDisband = civInfo.getCivUnits()
+                .filter { it.baseUnit.getResourceRequirements().containsKey(resource) }
+                .toList().minByOrNull { it.getForceEvaluation() }
+            if (unitToDisband != null) {
+                unitToDisband.disband()
+            }
+
+            for (city in civInfo.cities) {
+                if (city.hasSoldBuildingThisTurn)
+                    continue
+                val buildingToSell = civInfo.gameInfo.ruleSet.buildings.values.filter {
+                        it.name in city.cityConstructions.builtBuildings
+                        && it.getResourceRequirements().containsKey(resource) }.randomOrNull()
+                if (buildingToSell != null) {
+                    city.sellBuilding(buildingToSell.name)
+                    break
+                }
+            }
         }
     }
 

--- a/core/src/com/unciv/logic/automation/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/UnitAutomation.kt
@@ -78,6 +78,11 @@ object UnitAutomation {
         val upgradedUnit = unit.getUnitToUpgradeTo()
         if (!upgradedUnit.isBuildable(unit.civInfo)) return false // for resource reasons, usually
 
+        if (upgradedUnit.getResourceRequirements().keys.any { it !in unit.baseUnit.getResourceRequirements().keys }) {
+            // The upgrade requires resources, so check if we are willing to invest them
+            if (!Automation.allowSpendingResource(unit.civInfo, upgradedUnit)) return false
+        }
+
         val upgradeAction = UnitActions.getUpgradeAction(unit)
             ?: return false
 

--- a/core/src/com/unciv/logic/trade/TradeEvaluation.kt
+++ b/core/src/com/unciv/logic/trade/TradeEvaluation.kt
@@ -191,6 +191,11 @@ class TradeEvaluation {
                 else 500 // you want to take away our last lux of this type?!
             }
             TradeType.Strategic_Resource -> {
+                if (civInfo.gameInfo.spaceResources.contains(offer.name) &&
+                    (civInfo.hasUnique("Enables construction of Spaceship parts") ||
+                    tradePartner.hasUnique("Enables construction of Spaceship parts")))
+                        return 10000 // We'd rather win the game, thanks
+
                 if (!civInfo.isAtWar()) return 50 * offer.amount
 
                 val canUseForUnits = civInfo.gameInfo.ruleSet.units.values

--- a/core/src/com/unciv/models/ruleset/Building.kt
+++ b/core/src/com/unciv/models/ruleset/Building.kt
@@ -690,6 +690,7 @@ class Building : RulesetStatsObject(), INonPerpetualConstruction {
         if (get(stat) > 0) return true
         if (getStatPercentageBonuses(null)[stat] > 0) return true
         if (uniqueObjects.any { it.placeholderText == "[] per [] population []" && it.stats[stat] > 0 }) return true
+        if (uniqueObjects.any { it.placeholderText == "[] from [] tiles []" && it.stats[stat] > 0 }) return true
         return false
     }
 


### PR DESCRIPTION
This PR adds code for the AI to ration certain strategic resources. Gets rid of the old hardcoded "Aluminum" reserves.
Resources that will be needed for space victory are saved for that purpose and even units disbanded and buildings sold when really needed. AI will not trade space race resources when Apollo Project is built. The AI is now a contender in the space race.
Otherwise, when a resource is needed both for non-obsolete units and for buildings (mainly coal and aluminum in the base game), the AI will try to use 50% of its resource for each.
Adds back in the Hydro Plant which the AI is now able to build responsibly.