### PR TITLE
Solve continentSizes serialization by removing it

### DIFF
--- a/core/src/com/unciv/logic/GameStarter.kt
+++ b/core/src/com/unciv/logic/GameStarter.kt
@@ -84,7 +84,7 @@ object GameStarter {
 
         if (tileMap.continentSizes.isEmpty())   // Probably saved map without continent data
             runAndMeasure("assignContinents") {
-                tileMap.assignContinents()
+                tileMap.assignContinents(TileMap.AssignContinentsMode.Ensure)
             }
 
         runAndMeasure("addCivStartingUnits") {
@@ -353,7 +353,7 @@ object GameStarter {
         tileMap: TileMap,
         startScores: HashMap<TileInfo, Float>
     ): Map<TileInfo, Float> {
-        if (tileMap.continentSizes.isEmpty()) tileMap.assignContinents()
+        tileMap.assignContinents(TileMap.AssignContinentsMode.Ensure)
 
         // We want to  distribute starting locations fairly, and thus not place anybody on a small island
         // - unless necessary. Old code would only consider landmasses >= 20 tiles.

--- a/core/src/com/unciv/logic/MapSaver.kt
+++ b/core/src/com/unciv/logic/MapSaver.kt
@@ -33,6 +33,7 @@ object MapSaver {
         }
     }
     fun mapToSavedString(tileMap: TileMap): String {
+        tileMap.assignContinents(TileMap.AssignContinentsMode.Reassign)
         val mapJson = json().toJson(tileMap)
         return if (saveZipped) Gzip.zip(mapJson) else mapJson
     }

--- a/core/src/com/unciv/logic/map/TileInfo.kt
+++ b/core/src/com/unciv/logic/map/TileInfo.kt
@@ -804,5 +804,8 @@ open class TileInfo {
         this.continent = continent
     }
 
+    /** Clear continent ID, for map editor */
+    fun clearContinent() { continent = -1 }
+
     //endregion
 }

--- a/core/src/com/unciv/logic/map/mapgenerator/MapGenerator.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/MapGenerator.kt
@@ -74,7 +74,7 @@ class MapGenerator(val ruleset: Ruleset) {
             spawnIce(map)
         }
         runAndMeasure("assignContinents") {
-            map.assignContinents()
+            map.assignContinents(TileMap.AssignContinentsMode.Assign)
         }
         runAndMeasure("NaturalWonderGenerator") {
             NaturalWonderGenerator(ruleset, randomness).spawnNaturalWonders(map)

--- a/core/src/com/unciv/ui/tilegroups/TileGroupIcons.kt
+++ b/core/src/com/unciv/ui/tilegroups/TileGroupIcons.kt
@@ -184,6 +184,7 @@ class TileGroupIcons(val tileGroup: TileGroup) {
         // different stacking order of the same nations in the same editing session
         val nations = tileInfo.tileMap.startingLocationsByNation.asSequence()
             .filter { tileInfo in it.value }
+            .filter { it.key in tileInfo.tileMap.ruleset!!.nations } // Ignore missing nations
             .map { it.key to tileInfo.tileMap.ruleset!!.nations[it.key]!! }
             .sortedWith(compareBy({ it.second.isCityState() }, { it.first }))
             .toList()


### PR DESCRIPTION
... from serialization.
- Starting games from saved maps with continent data was impossible (exception, caught, unspecific "something went wrong message) - works now, even for maps saved with the problematic code
- Starting games from saved maps with incorrect continent data will just not distribute the random starting location as nicely
- Map editor save will no longer save incorrect continent data, a simple load-resave will fix existing maps
- Ability to regenerate entire continent data if missing or continent size data from tiles on demand