### PR TITLE
Prevent city states from taunting you when declaring war

### DIFF
--- a/core/src/com/unciv/logic/civilization/CityStateFunctions.kt
+++ b/core/src/com/unciv/logic/civilization/CityStateFunctions.kt
@@ -525,6 +525,7 @@ class CityStateFunctions(val civInfo: CivilizationInfo) {
     /** A city state was attacked. What are its protectors going to do about it??? Also checks for Wary */
     fun cityStateAttacked(attacker: CivilizationInfo) {
         if (!civInfo.isCityState()) return // What are we doing here?
+        if (attacker.isCityState()) return // City states can't be upset with each other
 
         // We might become wary!
         if (attacker.isMinorCivWarmonger()) { // They've attacked a lot of city-states


### PR DESCRIPTION
From Discord: a major civ with city state allies attacking your protected city state can lead to city states phoning you up and taunting you about it. While amusing, this is not intended behavior.

![ur](https://user-images.githubusercontent.com/63475501/136094193-bd811fd7-4068-4dff-9a8d-05bccdc41978.png)
