### PR TITLE
Fix Educated Elite

### DIFF
--- a/core/src/com/unciv/logic/automation/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/UnitAutomation.kt
@@ -7,6 +7,7 @@ import com.unciv.logic.civilization.ReligionState
 import com.unciv.logic.civilization.diplomacy.DiplomaticStatus
 import com.unciv.logic.map.MapUnit
 import com.unciv.logic.map.TileInfo
+import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.ui.worldscreen.unit.UnitActions
 
 object UnitAutomation {
@@ -106,13 +107,13 @@ object UnitAutomation {
             if (unit.hasUniqueToBuildImprovements)
                 return WorkerAutomation.automateWorkerAction(unit)
 
-            if (unit.hasUnique("May found a religion")
+            if (unit.hasUnique(UniqueType.MayFoundReligion)
                 && unit.civInfo.religionManager.religionState < ReligionState.Religion
                 && unit.civInfo.religionManager.mayFoundReligionAtAll(unit)
             )
                 return SpecificUnitAutomation.foundReligion(unit)
 
-            if (unit.hasUnique("May enhance a religion")
+            if (unit.hasUnique(UniqueType.MayEnhanceReligion)
                 && unit.civInfo.religionManager.religionState < ReligionState.EnhancedReligion
                 && unit.civInfo.religionManager.mayEnhanceReligionAtAll(unit)
             )

--- a/core/src/com/unciv/logic/civilization/CityStateFunctions.kt
+++ b/core/src/com/unciv/logic/civilization/CityStateFunctions.kt
@@ -75,7 +75,7 @@ class CityStateFunctions(val civInfo: CivilizationInfo) {
 
         // Great Prophets can't be gotten from CS
         val giftableUnits = civInfo.gameInfo.ruleSet.units.values.filter { it.isGreatPerson()
-                && !it.hasUnique("May found a religion") }
+                && !it.hasUnique(UniqueType.MayFoundReligion) }
         if (giftableUnits.isEmpty()) // For badly defined mods that don't have great people but do have the policy that makes city states grant them
             return
         val giftedUnit = giftableUnits.random()

--- a/core/src/com/unciv/logic/civilization/ReligionManager.kt
+++ b/core/src/com/unciv/logic/civilization/ReligionManager.kt
@@ -139,7 +139,7 @@ class ReligionManager {
     }
     
     fun getGreatProphetEquivalent(): String? {
-        return civInfo.gameInfo.ruleSet.units.values.firstOrNull { it.hasUnique("May found a religion") }?.name
+        return civInfo.gameInfo.ruleSet.units.values.firstOrNull { it.hasUnique(UniqueType.MayFoundReligion) }?.name
     }
 
     private fun generateProphet() {

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -161,6 +161,8 @@ enum class UniqueType(val text:String, vararg targets: UniqueTarget) {
     Movement("[amount] Movement", UniqueTarget.Unit, UniqueTarget.Global),
     Sight("[amount] Sight", UniqueTarget.Unit, UniqueTarget.Global),
     SpreadReligionStrength("[amount]% Spread Religion Strength", UniqueTarget.Unit, UniqueTarget.Global),
+    MayFoundReligion("May found a religion", UniqueTarget.Unit),
+    MayEnhanceReligion("May enhance a religion", UniqueTarget.Unit),
 
     @Deprecated("As of 3.17.5", ReplaceWith("[amount] Movement <for [mapUnitFilter] units>"), DeprecationLevel.WARNING)
     MovementUnits("+[amount] Movement for all [mapUnitFilter] units", UniqueTarget.Global),

--- a/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
@@ -481,7 +481,7 @@ object UnitActions {
     }
 
     private fun addFoundReligionAction(unit: MapUnit, actionList: ArrayList<UnitAction>) {
-        if (!unit.hasUnique("May found a religion")) return 
+        if (!unit.hasUnique(UniqueType.MayFoundReligion)) return
         if (!unit.civInfo.religionManager.mayFoundReligionAtAll(unit)) return
         actionList += UnitAction(UnitActionType.FoundReligion,
             action = getFoundReligionAction(unit).takeIf { unit.civInfo.religionManager.mayFoundReligionNow(unit) }
@@ -497,7 +497,7 @@ object UnitActions {
     }
 
     private fun addEnhanceReligionAction(unit: MapUnit, actionList: ArrayList<UnitAction>) {
-        if (!unit.hasUnique("May enhance a religion")) return
+        if (!unit.hasUnique(UniqueType.MayEnhanceReligion)) return
         if (!unit.civInfo.religionManager.mayEnhanceReligionAtAll(unit)) return
         actionList += UnitAction(UnitActionType.EnhanceReligion,
             title = "Enhance [${unit.civInfo.religionManager.religion!!.getReligionDisplayName()}]",


### PR DESCRIPTION
Fixes #5306 
Credit to @SomeTroglodyte for finding the bug - sorry if you were working on a different fix.

Solves the bug by reverting from addUnit to placeUnitNearTile which will not exchange the unit for an equivalent. Great Prophets are not supposed to be gotten from Educated Elite, even in games with religion.