### PR TITLE
Free buildings part 2 - works for Carthage too

### DIFF
--- a/core/src/com/unciv/logic/city/CityConstructions.kt
+++ b/core/src/com/unciv/logic/city/CityConstructions.kt
@@ -163,7 +163,10 @@ class CityConstructions {
     
     fun addFreeBuildings() {
         // "Gain a free [buildingName] [cityFilter]"
-        for (unique in cityInfo.getLocalMatchingUniques(UniqueType.GainFreeBuildings, StateForConditionals(cityInfo.civInfo, cityInfo))) {
+        val uniqueList = cityInfo.getLocalMatchingUniques(UniqueType.GainFreeBuildings, StateForConditionals(cityInfo.civInfo, cityInfo)).toMutableList()
+        // Deprecated - "Provides a free [buildingName] [cityFilter]"
+        uniqueList.addAll(cityInfo.getLocalMatchingUniques(UniqueType.ProvidesFreeBuildings, StateForConditionals(cityInfo.civInfo, cityInfo)))
+        for (unique in uniqueList) {
             val freeBuildingName = cityInfo.civInfo.getEquivalentBuilding(unique.params[0]).name
             val citiesThatApply = when (unique.params[1]) {
                 "in this city" -> listOf(cityInfo)
@@ -178,6 +181,18 @@ class CityConstructions {
                     freeBuildingsProvidedFromThisCity[city.id] = hashSetOf()
 
                 freeBuildingsProvidedFromThisCity[city.id]!!.add(freeBuildingName)
+            }
+        }
+
+        // Civ-level uniques - for these only add free buildings from each city to itself to avoid weirdness on city conquest
+        for (unique in cityInfo.civInfo.getMatchingUniques(UniqueType.GainFreeBuildings, stateForConditionals = StateForConditionals(cityInfo.civInfo, cityInfo))) {
+            val freeBuildingName = unique.params[0]
+            if (cityInfo.matchesFilter(unique.params[1])) {
+                if (cityInfo.id !in freeBuildingsProvidedFromThisCity)
+                    freeBuildingsProvidedFromThisCity[cityInfo.id] = hashSetOf()
+                freeBuildingsProvidedFromThisCity[cityInfo.id]!!.add(freeBuildingName)
+                if (!isBuilt(freeBuildingName))
+                    addBuilding(freeBuildingName)
             }
         }
     }

--- a/core/src/com/unciv/logic/city/CityInfo.kt
+++ b/core/src/com/unciv/logic/city/CityInfo.kt
@@ -160,18 +160,7 @@ class CityInfo {
         }
 
         civInfo.civConstructions.tryAddFreeBuildings()
-        addFreeBuildingsFromUniques()
-    }
-    
-    private fun addFreeBuildingsFromUniques() {
-        for (unique in getMatchingUniques(UniqueType.GainFreeBuildings, stateForConditionals = StateForConditionals(civInfo, this))) {
-            val freeBuildingName = unique.params[0]
-            if (matchesFilter(unique.params[1])) {
-                civInfo.civConstructions.addFreeBuilding(id, freeBuildingName)
-                if (!cityConstructions.isBuilt(freeBuildingName))
-                    (cityConstructions.getConstruction(freeBuildingName) as INonPerpetualConstruction).postBuildEvent(cityConstructions)
-            }
-        }
+        cityConstructions.addFreeBuildings()
     }
 
     private fun setNewCityName(civInfo: CivilizationInfo) {
@@ -493,7 +482,6 @@ class CityInfo {
         // so they won't be generated out in the open and vulnerable to enemy attacks before you can control them
         cityConstructions.constructIfEnough()
         cityConstructions.addFreeBuildings()
-        addFreeBuildingsFromUniques()
         
         cityStats.update()
         tryUpdateRoadStatus()

--- a/core/src/com/unciv/logic/civilization/CivConstructions.kt
+++ b/core/src/com/unciv/logic/civilization/CivConstructions.kt
@@ -101,7 +101,7 @@ class CivConstructions {
         return toReturn
     }
 
-    fun addFreeBuilding(cityId: String, building: String) {
+    private fun addFreeBuilding(cityId: String, building: String) {
         if (!freeBuildings.containsKey(cityId))
             freeBuildings[cityId] = hashSetOf()
         freeBuildings[cityId]!!.add(building)

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -114,7 +114,10 @@ enum class UniqueType(val text:String, vararg targets: UniqueTarget) {
     GrowthPercentBonusPositive("+[amount]% growth [cityFilter]", UniqueTarget.Global),
     @Deprecated("As of 3.16.14", ReplaceWith("[amount]% growth [cityFilter] <when not at war>"), DeprecationLevel.WARNING)
     GrowthPercentBonusWhenNotAtWar("+[amount]% growth [cityFilter] when not at war", UniqueTarget.Global),
+
     GainFreeBuildings("Gain a free [buildingName] [cityFilter]", UniqueTarget.Global),
+    @Deprecated("As of 3.17.7", ReplaceWith("Gain a free [buildingName] [cityFilter]"), DeprecationLevel.WARNING)
+    ProvidesFreeBuildings("Provides a free [buildingName] [cityFilter]", UniqueTarget.Global),
 
     FreeExtraBeliefs("May choose [amount] additional [beliefType] beliefs when [foundingOrEnhancing] a religion", UniqueTarget.Global),
     FreeExtraAnyBeliefs("May choose [amount] additional belief(s) of any type when [foundingOrEnhancing] a religion", UniqueTarget.Global),


### PR DESCRIPTION
- Free buildings gained from civ uniques (ie Carthage) are now registered as free buildings and get the same benefits as free buildings from other sources in #5466 
- Changes all "provides a free [] []" into "gain a free [] []"

I think this should cover all sources of free buildings - civ uniques, other buildings (ie wonders), and policies all work as expected.