### PR TITLE
Choose a better visible color for the religious symbol on the city button

### DIFF
--- a/core/src/com/unciv/ui/tilegroups/CityButton.kt
+++ b/core/src/com/unciv/ui/tilegroups/CityButton.kt
@@ -263,7 +263,7 @@ class CityButton(val city: CityInfo, private val tileGroup: WorldTileGroup): Tab
         if (!forPopup) {
             val cityReligion = city.religion.getMajorityReligion()
             if (cityReligion != null) {
-                val religionImage = ImageGetter.getReligionImage(cityReligion.getIconName())
+                val religionImage = ImageGetter.getReligionImage(cityReligion.getIconName()).apply { color = city.civInfo.nation.getInnerColor() }
                 iconTable.add(religionImage).size(20f).padLeft(5f).fillY()
             }
         }


### PR DESCRIPTION
It now takes the inner color of the civilization owning the city, to always allow for good contrast.

![image](https://user-images.githubusercontent.com/71121390/137389534-96347493-1826-48ae-a6fa-d0a0c2e63183.png)
