### PR TITLE
Can now raze cities Austria has married

### DIFF
--- a/core/src/com/unciv/logic/civilization/CityStateFunctions.kt
+++ b/core/src/com/unciv/logic/civilization/CityStateFunctions.kt
@@ -294,6 +294,7 @@ class CityStateFunctions(val civInfo: CivilizationInfo) {
             city.moveToCiv(otherCiv)
             city.isPuppet = true // Human players get a popup that allows them to annex instead
             city.foundingCiv = "" // This is no longer a city-state
+            city.isOriginalCapital = false // It's now an ordinary city and can be razed in later conquests
         }
         civInfo.destroy()
     }


### PR DESCRIPTION
Cities Austria gains from Diplomatic Marriage should be just like normal cities and so should be able to be razed on subsequent conquests.