### PR TITLE
Band-aided a bug with building unique application

### DIFF
--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -343,7 +343,7 @@ class CivilizationInfo {
         cities.asSequence().flatMap {
             city ->
                 if (cityItIsFor != null && city == cityItIsFor)
-                    city.getAllUniquesWithNonLocalEffects().filter { it.params.none { param -> param == "in other cities" } }
+                    city.getAllUniquesWithNonLocalEffects().filter { it.params.none { param -> param == "in other cities" || param == "in all cities" } }
                 else city.getAllUniquesWithNonLocalEffects()
         }
 


### PR DESCRIPTION
Building uniques applying to all cities, such as Temple of Artemis and Sistene Chapel would apply their bonus twice to the city they were build in.
This was a result of it both being found as a non-local unique due to it having an effect outside the city and thus being classified as wonder, and as a building, as it was built in the city and had an effect on it.
This patch is _untested_ and only a band-aid.
The real solution would be to start using the sources of uniques saved in the uniques themselves to classify were uniques are received from.
Implementing this is somewhere on my todo-list, but due to uni won't happen anytime soon.