### PR TITLE
Fixed a bug where AI would not found religions

### DIFF
--- a/core/src/com/unciv/logic/automation/SpecificUnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/SpecificUnitAutomation.kt
@@ -378,11 +378,13 @@ object SpecificUnitAutomation {
     }
 
     fun foundReligion(unit: MapUnit) {
-        val cityToFoundReligionAt = unit.civInfo.cities.firstOrNull {
-            !it.isHolyCity()
-                    && unit.movement.canMoveTo(it.getCenterTile())
-                    && unit.movement.canReach(it.getCenterTile())
-        }
+        val cityToFoundReligionAt =
+            if (unit.getTile().isCityCenter() && !unit.getTile().owningCity!!.isHolyCity()) unit.getTile().owningCity 
+            else unit.civInfo.cities.firstOrNull {
+                !it.isHolyCity()
+                && unit.movement.canMoveTo(it.getCenterTile())
+                && unit.movement.canReach(it.getCenterTile())
+            }
         if (cityToFoundReligionAt == null) return
         if (unit.getTile() != cityToFoundReligionAt.getCenterTile()) {
             unit.movement.headTowards(cityToFoundReligionAt.getCenterTile())


### PR DESCRIPTION
Fixes #5542.
The problem was the following:
Great prophets try to move to the closest unoccupied city to found a religion. However, when arriving at that city center, it would be marked occupied as they were on that tile _themselves_. I've added a check specifically checking for that first (as its cheaper too) which solves the problem.