### PR TITLE
Added missing unitFilter

### DIFF
--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -521,6 +521,7 @@ class BaseUnit : RulesetObject(), INonPerpetualConstruction {
         return when (filter) {
             unitType -> true
             name -> true
+            replaces -> true
             "All" -> true
 
             "Melee" -> isMelee()


### PR DESCRIPTION
This fixes bugs were replacement units would not receive the bonus for the base unit, e.g. land units moving being over mountains after a taerg lareneg was generated in the upside down mod, due to the unique explicitly requiring a great general to be generated

Fixes #5549 