### PR TITLE
Conquistadors only settle other continents

### DIFF
--- a/android/assets/jsons/Civ V - Vanilla/Units.json
+++ b/android/assets/jsons/Civ V - Vanilla/Units.json
@@ -617,7 +617,7 @@
 		"requiredResource": "Horses",
 		"upgradesTo": "Cavalry",
 		"obsoleteTech": "Military Science",
-		"uniques": ["Can move after attacking","No defensive terrain bonus", "Founds a new city on foreign continents", "[+2] Sight", "Defense bonus when embarked"],
+		"uniques": ["Can move after attacking","No defensive terrain bonus", "Founds a new city <on foreign continents>", "[+2] Sight", "Defense bonus when embarked"],
 		"attackSound": "horse"
 		//Conquistador should have no penalty attacking cities
 		//Ability to found new cities can only be used on a foreign continent that does not contain the Spanish capital.

--- a/core/src/com/unciv/models/ruleset/unique/Unique.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Unique.kt
@@ -82,6 +82,9 @@ class Unique(val text: String, val sourceObjectType: UniqueTarget? = null, val s
                 val theirCities = state.theirCombatant?.getCivInfo()?.cities?.size ?: 0
                 yourCities < theirCities
             }
+            UniqueType.ConditionalForeignContinent -> state.unit != null &&
+                    (state.unit.civInfo.cities.isEmpty() ||
+                            state.unit.civInfo.getCapital().getCenterTile().getContinent() != state.unit.getTile().getContinent())
 
             UniqueType.ConditionalNeighborTiles ->
                 state.cityInfo != null &&

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -178,7 +178,6 @@ enum class UniqueType(val text:String, vararg targets: UniqueTarget) {
     ///////////////////////////////////////// UNIT UNIQUES /////////////////////////////////////////
 
     FoundCity("Founds a new city", UniqueTarget.Unit),
-    FoundCityNewContinent("Founds a new city on foreign continents", UniqueTarget.Unit),
     BuildImprovements("Can build [improvementFilter/terrainFilter] improvements on tiles", UniqueTarget.Unit),
     CreateWaterImprovements("May create improvements on water resources", UniqueTarget.Unit),
     CanSeeInvisibleUnits("Can see invisible [mapUnitFilter] units", UniqueTarget.Unit),
@@ -364,6 +363,7 @@ enum class UniqueType(val text:String, vararg targets: UniqueTarget) {
     ConditionalAttacking("when attacking", UniqueTarget.Conditional),
     ConditionalDefending("when defending", UniqueTarget.Conditional),
     ConditionalInTiles("when fighting in [tileFilter] tiles", UniqueTarget.Conditional),
+    ConditionalForeignContinent("on foreign continents", UniqueTarget.Conditional),
 
     /////// tile conditionals
     ConditionalNeighborTiles("with [amount] to [amount] neighboring [tileFilter] tiles", UniqueTarget.Conditional),

--- a/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
@@ -16,6 +16,7 @@ import com.unciv.models.UncivSound
 import com.unciv.models.UnitAction
 import com.unciv.models.UnitActionType
 import com.unciv.models.ruleset.Building
+import com.unciv.models.ruleset.unique.StateForConditionals
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.stats.Stat
 import com.unciv.models.stats.Stats
@@ -161,17 +162,14 @@ object UnitActions {
      * (no movement left, too close to another city).
       */
     fun getFoundCityAction(unit: MapUnit, tile: TileInfo): UnitAction? {
-        if (!(unit.hasUnique(UniqueType.FoundCity) || unit.hasUnique(UniqueType.FoundCityNewContinent))
+        if (!(unit.hasUnique(UniqueType.FoundCity))
                 || tile.isWater || tile.isImpassible()) return null
         // Spain should still be able to build Conquistadors in a one city challenge - but can't settle them
         if (unit.civInfo.isOneCityChallenger() && unit.civInfo.hasEverOwnedOriginalCapital == true) return null
 
         if (unit.currentMovement <= 0 ||
                 tile.getTilesInDistance(2).any { it.isCityCenter() } ||
-                tile.getTilesAtDistance(3).any { it.isCityCenter() && it.getContinent() == tile.getContinent() } ||
-                    (unit.hasUnique(UniqueType.FoundCityNewContinent) &&
-                    unit.civInfo.cities.isNotEmpty() &&
-                    unit.civInfo.getCapital().getCenterTile().getContinent() == unit.getTile().getContinent()))
+                tile.getTilesAtDistance(3).any { it.isCityCenter() && it.getContinent() == tile.getContinent() })
             return UnitAction(UnitActionType.FoundCity, action = null)
 
         val foundAction = {


### PR DESCRIPTION
This PR prevents conquistadors from settling cities on the same continent as the capital.
It also allows a one-city-challenger Spain to build conquistadors, but they can't be used to settle cities in that case.