### PR TITLE
Clarify relation Oil well / Refrigeration a little

### DIFF
--- a/core/src/com/unciv/models/ruleset/tech/Technology.kt
+++ b/core/src/com/unciv/models/ruleset/tech/Technology.kt
@@ -92,6 +92,10 @@ class Technology: RulesetObject() {
         if (tileImprovements.isNotEmpty())
             lineList += "{Tile improvements enabled}: " + tileImprovements.joinToString { it.name.tr() }
 
+        val seeAlsoObjects = getSeeAlsoObjects(ruleset)
+        if (seeAlsoObjects.any())
+            lineList += "{See also}: " + seeAlsoObjects.joinToString { it.name }
+
         return lineList.joinToString("\n") { it.tr() }
     }
 
@@ -110,7 +114,7 @@ class Technology: RulesetObject() {
     // Used for Civilopedia, Alert and Picker, so if any of these decide to ignore the "Will not be displayed in Civilopedia" unique this needs refactoring
     fun getObsoletedBuildings(civInfo: CivilizationInfo) = getFilteredBuildings(civInfo)
         { it.uniqueObjects.any { unique -> unique.placeholderText == "Obsolete with []" && unique.params[0] == name } }
-    
+
     // Helper: common filtering for both getEnabledBuildings and getObsoletedBuildings, difference via predicate parameter
     private fun getFilteredBuildings(civInfo: CivilizationInfo, predicate: (Building)->Boolean): Sequence<Building> {
         val nuclearWeaponsEnabled = civInfo.gameInfo.gameParameters.nuclearWeaponsEnabled
@@ -144,6 +148,17 @@ class Technology: RulesetObject() {
                 && Constants.hideFromCivilopediaUnique !in it.uniques
             }
     }
+
+    /** Get improvements related to this tech by a unique */
+    private fun getSeeAlsoObjects(ruleset: Ruleset) =
+        // This is a band-aid to clarify the relation Offshore platform - Refrigeration. A generic variant
+        // covering all mentions in uniques in all ruleset objects would be possible here but - overkill for now.
+        ruleset.tileImprovements.values.asSequence()
+        .filter { improvement ->
+            improvement.getMatchingUniques(UniqueType.RequiresTechToBuildOnTile).any {
+                it.params[1] == name
+            }
+        }
 
 
     override fun makeLink() = "Technology/$name"
@@ -180,7 +195,7 @@ class Technology: RulesetObject() {
                 }
             }
         }
-        
+
         if (uniques.isNotEmpty()) {
             lineList += FormattedLine()
             for (unique in uniqueObjects) lineList += FormattedLine(unique)
@@ -259,6 +274,15 @@ class Technology: RulesetObject() {
             lineList += FormattedLine()
             lineList += FormattedLine("{Tile improvements enabled}:")
             tileImprovements.forEach {
+                lineList += FormattedLine(it.name, link = it.makeLink())
+            }
+        }
+
+        val seeAlsoObjects = getSeeAlsoObjects(ruleset)
+        if (seeAlsoObjects.any()) {
+            lineList += FormattedLine()
+            lineList += FormattedLine("{See also}:")
+            seeAlsoObjects.forEach {
                 lineList += FormattedLine(it.name, link = it.makeLink())
             }
         }

--- a/core/src/com/unciv/ui/pickerscreens/TechPickerScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/TechPickerScreen.kt
@@ -12,12 +12,18 @@ import com.unciv.logic.civilization.TechManager
 import com.unciv.models.UncivSound
 import com.unciv.models.ruleset.tech.Technology
 import com.unciv.models.translations.tr
+import com.unciv.ui.civilopedia.CivilopediaCategories
+import com.unciv.ui.civilopedia.CivilopediaScreen
 import com.unciv.ui.utils.*
 import java.util.*
 import kotlin.collections.ArrayList
 
 
-class TechPickerScreen(internal val civInfo: CivilizationInfo, centerOnTech: Technology? = null, private val freeTechPick: Boolean = false) : PickerScreen() {
+class TechPickerScreen(
+    internal val civInfo: CivilizationInfo,
+    centerOnTech: Technology? = null,
+    private val freeTechPick: Boolean = false
+) : PickerScreen() {
 
     private var techNameToButton = HashMap<String, TechButton>()
     private var selectedTech: Technology? = null
@@ -45,11 +51,17 @@ class TechPickerScreen(internal val civInfo: CivilizationInfo, centerOnTech: Tec
 
 
     private val turnsToTech = civInfo.gameInfo.ruleSet.technologies.values.associateBy({ it.name }, { civTech.turnsToTech(it.name) })
-    
+
     init {
         setDefaultCloseAction()
         onBackButtonClicked { UncivGame.Current.setWorldScreen() }
         scrollPane.setOverscroll(false, false)
+
+        descriptionLabel.onClick {
+            if (selectedTech != null)
+                game.setScreen(CivilopediaScreen(civInfo.gameInfo.ruleSet, CivilopediaCategories.Technology, selectedTech!!.name))
+        }
+
         tempTechsToResearch = ArrayList(civTech.techsToResearch)
 
         createTechTable()


### PR DESCRIPTION
Simplest way to resolve #5537 I could think of.
- Civilopedia for a Tech lists improvements carrying UniqueType.RequiresTechToBuildOnTile as "See also"
- The same is added to the text-only description, appears in tech picker and tech completed alert
- clicking the description label of the tech picker links to the tech

The terseness is intentional for now, saves need for template+translations, and we can ponder the well/platform dilemma thoroughly, maybe obsoleting this soon...

<details><summary>skrynshutz</summary>

![image](https://user-images.githubusercontent.com/63000004/138926999-dc8cd150-2db6-4daf-96ae-6feeb438d10d.png)
![image](https://user-images.githubusercontent.com/63000004/138927006-c793e9a3-4d7e-4be4-8ef4-2fcf586cbb37.png)
</details>