### PR TITLE
Minor hardening of music against OpenAL quirks

### DIFF
--- a/core/src/com/unciv/ui/audio/MusicTrackController.kt
+++ b/core/src/com/unciv/ui/audio/MusicTrackController.kt
@@ -162,7 +162,7 @@ class MusicTrackController(private var volume: Float) {
             if (!music.isPlaying)  // for fade-over this could be called by the end of the previous track
                 music.play()
             true
-        } catch (ex: Exception) {
+        } catch (ex: Throwable) {
             println("Exception playing music: ${ex.message}")
             if (MusicController.consoleLog)
                 ex.printStackTrace()


### PR DESCRIPTION
I just came across a crash with this log:
```
Exception in thread "MusicTimer" java.lang.UnsatisfiedLinkError: 'int org.lwjgl.openal.AL10.nalGetSourcei(int, int)'
	at org.lwjgl.openal.AL10.nalGetSourcei(Native Method)
	at org.lwjgl.openal.AL10.alGetSourcei(AL10.java:853)
	at com.badlogic.gdx.backends.lwjgl.audio.OpenALLwjglAudio.obtainSource(OpenALLwjglAudio.java:141)
	at com.badlogic.gdx.backends.lwjgl.audio.OpenALMusic.play(OpenALMusic.java:72)
	at com.unciv.ui.audio.MusicTrackController.tryPlay(MusicTrackController.kt:163)
```
We know `UnsatisfiedLinkError` isn't an Exception, so this tiny change should help a little.