### PR TITLE
Do units with orders just _before_ nextTurn

### DIFF
--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -844,6 +844,15 @@ class CivilizationInfo {
         cachedMilitaryMight = -1    // Reset so we don't use a value from a previous turn
     }
 
+    /** Call doAction on all MapUnit's of this Civ, processing their orders
+     *  @return whether after the processing any [due][MapUnit.due] units remain */
+    fun doAllUnitActions(): Boolean {
+        getCivUnits().forEach {
+            it.doAction()
+        }
+        return getDueUnits().any()
+    }
+
     private fun startTurnFlags() {
         for (flag in flagsCountdown.keys.toList()) {
             // In case we remove flags while iterating

--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -555,11 +555,15 @@ class MapUnit {
         if (action == null) return
         if (currentMovement == 0f) return  // We've already done stuff this turn, and can't do any more stuff
 
+        fun abortAction() {
+            action = null
+            due = currentMovement > 0
+        }
         val enemyUnitsInWalkingDistance = movement.getDistanceToTiles().keys
             .filter { it.militaryUnit != null && civInfo.isAtWarWith(it.militaryUnit!!.civInfo) }
         if (enemyUnitsInWalkingDistance.isNotEmpty()) {
             if (isMoving()) // stop on enemy in sight
-                action = null
+                abortAction()
             return  // Don't you dare move.
         }
 
@@ -568,13 +572,13 @@ class MapUnit {
             val destinationTile = getMovementDestination()
             if (!movement.canReach(destinationTile)) { // That tile that we were moving towards is now unreachable -
                 // for instance we headed towards an unknown tile and it's apparently unreachable
-                action = null
+                abortAction()
                 return
             }
             val gotTo = movement.headTowards(destinationTile)
             if (gotTo == currentTile) // We didn't move at all
                 return
-            if (gotTo.position == destinationTile.position) action = null
+            if (gotTo.position == destinationTile.position) abortAction()
             if (currentMovement > 0) doAction()
             return
         }

--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -17,6 +17,7 @@ import com.unciv.UncivGame
 import com.unciv.logic.GameInfo
 import com.unciv.logic.GameSaver
 import com.unciv.logic.civilization.CivilizationInfo
+import com.unciv.logic.civilization.PlayerType
 import com.unciv.logic.civilization.ReligionState
 import com.unciv.logic.civilization.diplomacy.DiplomaticStatus
 import com.unciv.models.Tutorial
@@ -718,7 +719,7 @@ class WorldScreen(val gameInfo: GameInfo, val viewingCiv:CivilizationInfo) : Cam
                 NextTurnAction("Found Pantheon", Color.WHITE) {
                     game.setScreen(PantheonPickerScreen(viewingCiv, gameInfo))
                 }
-            
+
             viewingCiv.religionManager.religionState == ReligionState.FoundingReligion ->
                 NextTurnAction("Found Religion", Color.WHITE) {
                     game.setScreen(ReligiousBeliefsPickerScreen(
@@ -728,7 +729,7 @@ class WorldScreen(val gameInfo: GameInfo, val viewingCiv:CivilizationInfo) : Cam
                         pickIconAndName = true
                     ))
                 }
-            
+
             viewingCiv.religionManager.religionState == ReligionState.EnhancingReligion -> 
                 NextTurnAction("Enhance Religion", Color.ORANGE) {
                     game.setScreen(ReligiousBeliefsPickerScreen(
@@ -738,7 +739,7 @@ class WorldScreen(val gameInfo: GameInfo, val viewingCiv:CivilizationInfo) : Cam
                         pickIconAndName = false
                     ))
                 }
-            
+
             viewingCiv.mayVoteForDiplomaticVictory() ->
                 NextTurnAction("Vote for World Leader", Color.RED) {
                     game.setScreen(DiplomaticVotePickerScreen(viewingCiv))
@@ -746,8 +747,13 @@ class WorldScreen(val gameInfo: GameInfo, val viewingCiv:CivilizationInfo) : Cam
 
             else ->
                 NextTurnAction("${Fonts.turn}{Next turn}", Color.WHITE) {
-                    game.settings.addCompletedTutorialTask("Pass a turn")
-                    nextTurn()
+                    if (viewingCiv.playerType == PlayerType.Human && viewingCiv.doAllUnitActions()) {
+                        // A unit with orders has decided to stop and is now due
+                        shouldUpdate = true
+                    } else {
+                        game.settings.addCompletedTutorialTask("Pass a turn")
+                        nextTurn()
+                    }
                 }
         }
     }


### PR DESCRIPTION
...and allow units ending their orders to cancel the nextTurn and go back to cycling these due units.

From the resulting experience this improves #5534 nicely, and probably also solves the long standing issue of multiturn moves arriving with points left to waste a turn unless you pick them out manually.......

Not production ready because some people do 200 automated Workers on a 5000 tile map, and the extra loop runs on the main thread.

### Requesting input 
- Is this a good idea at all
- Thread decouple by running a dedicated thread while blocking Gdx input processing, by moving the check to inside the thread and deal with false tutorial completion and the clone complications, or another idea entirely?
- Add that menu option, and if so what wording? "Execute outstanding orders" perhaps?