### PR TITLE
Separate unit automation

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -653,6 +653,7 @@ Waiting for other players... =
 Waiting for [civName]... = 
 in = 
 Next turn = 
+Move automated units = 
 [currentPlayerCiv] ready? = 
 1 turn = 
 [numberOfTurns] turns = 

--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -181,6 +181,8 @@ class CivilizationInfo {
     var totalCultureForContests = 0
     var totalFaithForContests = 0
 
+    var hasMovedAutomatedUnits = false
+
     @Transient
     var hasLongCountDisplayUnique = false
 
@@ -234,6 +236,7 @@ class CivilizationInfo {
         toReturn.numMinorCivsAttacked = numMinorCivsAttacked
         toReturn.totalCultureForContests = totalCultureForContests
         toReturn.totalFaithForContests = totalFaithForContests
+        toReturn.hasMovedAutomatedUnits = hasMovedAutomatedUnits
         return toReturn
     }
 
@@ -779,6 +782,7 @@ class CivilizationInfo {
         for (city in cities) city.startTurn()  // Most expensive part of startTurn
 
         for (unit in getCivUnits()) unit.startTurn()
+        hasMovedAutomatedUnits = false
 
         for (tradeRequest in tradeRequests.toList()) { // remove trade requests where one of the sides can no longer supply
             val offeringCiv = gameInfo.getCivilization(tradeRequest.requestingCiv)

--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -709,8 +709,6 @@ class MapUnit {
     }
 
     fun endTurn() {
-        doAction()
-
         if (currentMovement > 0 &&
             getTile().improvementInProgress != null
             && canBuildImprovement(getTile().getTileImprovementInProgress()!!)

--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -683,14 +683,20 @@ class WorldScreen(val gameInfo: GameInfo, val viewingCiv:CivilizationInfo) : Cam
 
     private fun getNextTurnAction(): NextTurnAction {
         return when {
-            !isPlayersTurn && gameInfo.gameParameters.isOnlineMultiplayer -> NextTurnAction("Waiting for [${gameInfo.currentPlayerCiv}]...", Color.GRAY) {}
-            !isPlayersTurn && !gameInfo.gameParameters.isOnlineMultiplayer -> NextTurnAction("Waiting for other players...", Color.GRAY) {}
+            !isPlayersTurn && gameInfo.gameParameters.isOnlineMultiplayer ->
+                NextTurnAction("Waiting for [${gameInfo.currentPlayerCiv}]...", Color.GRAY) {}
+            !isPlayersTurn && !gameInfo.gameParameters.isOnlineMultiplayer ->
+                NextTurnAction("Waiting for other players...",Color.GRAY) {}
 
             viewingCiv.shouldGoToDueUnit() ->
                 NextTurnAction("Next unit", Color.LIGHT_GRAY) {
                     val nextDueUnit = viewingCiv.getNextDueUnit()
                     if (nextDueUnit != null) {
-                        mapHolder.setCenterPosition(nextDueUnit.currentTile.position, immediately = false, selectUnit = false)
+                        mapHolder.setCenterPosition(
+                            nextDueUnit.currentTile.position,
+                            immediately = false,
+                            selectUnit = false
+                        )
                         bottomUnitTable.selectUnit(nextDueUnit)
                         shouldUpdate = true
                     }
@@ -699,13 +705,17 @@ class WorldScreen(val gameInfo: GameInfo, val viewingCiv:CivilizationInfo) : Cam
             viewingCiv.cities.any { it.cityConstructions.currentConstructionFromQueue == "" } ->
                 NextTurnAction("Pick construction", Color.CORAL) {
                     val cityWithNoProductionSet = viewingCiv.cities
-                            .firstOrNull { it.cityConstructions.currentConstructionFromQueue == "" }
-                    if (cityWithNoProductionSet != null) game.setScreen(CityScreen(cityWithNoProductionSet))
+                        .firstOrNull { it.cityConstructions.currentConstructionFromQueue == "" }
+                    if (cityWithNoProductionSet != null) game.setScreen(
+                        CityScreen(cityWithNoProductionSet)
+                    )
                 }
 
             viewingCiv.shouldOpenTechPicker() ->
                 NextTurnAction("Pick a tech", Color.SKY) {
-                    game.setScreen(TechPickerScreen(viewingCiv, null, viewingCiv.tech.freeTechs != 0))
+                    game.setScreen(
+                        TechPickerScreen(viewingCiv, null, viewingCiv.tech.freeTechs != 0)
+                    )
                 }
 
             viewingCiv.policies.shouldOpenPolicyPicker || (viewingCiv.policies.freePolicies > 0 && viewingCiv.policies.canAdoptPolicy()) ->
@@ -718,30 +728,43 @@ class WorldScreen(val gameInfo: GameInfo, val viewingCiv:CivilizationInfo) : Cam
                 NextTurnAction("Found Pantheon", Color.WHITE) {
                     game.setScreen(PantheonPickerScreen(viewingCiv, gameInfo))
                 }
-            
+
             viewingCiv.religionManager.religionState == ReligionState.FoundingReligion ->
                 NextTurnAction("Found Religion", Color.WHITE) {
-                    game.setScreen(ReligiousBeliefsPickerScreen(
-                        viewingCiv, 
-                        gameInfo,
-                        viewingCiv.religionManager.getBeliefsToChooseAtFounding(),
-                        pickIconAndName = true
-                    ))
+                    game.setScreen(
+                        ReligiousBeliefsPickerScreen(
+                            viewingCiv,
+                            gameInfo,
+                            viewingCiv.religionManager.getBeliefsToChooseAtFounding(),
+                            pickIconAndName = true
+                        )
+                    )
                 }
-            
-            viewingCiv.religionManager.religionState == ReligionState.EnhancingReligion -> 
+
+            viewingCiv.religionManager.religionState == ReligionState.EnhancingReligion ->
                 NextTurnAction("Enhance Religion", Color.ORANGE) {
-                    game.setScreen(ReligiousBeliefsPickerScreen(
-                        viewingCiv,
-                        gameInfo,
-                        viewingCiv.religionManager.getBeliefsToChooseAtEnhancing(),
-                        pickIconAndName = false
-                    ))
+                    game.setScreen(
+                        ReligiousBeliefsPickerScreen(
+                            viewingCiv,
+                            gameInfo,
+                            viewingCiv.religionManager.getBeliefsToChooseAtEnhancing(),
+                            pickIconAndName = false
+                        )
+                    )
                 }
-            
+
             viewingCiv.mayVoteForDiplomaticVictory() ->
                 NextTurnAction("Vote for World Leader", Color.RED) {
                     game.setScreen(DiplomaticVotePickerScreen(viewingCiv))
+                }
+
+            !viewingCiv.hasMovedAutomatedUnits && viewingCiv.getCivUnits()
+                .any { it.isMoving() || it.isAutomated() || it.isExploring() } ->
+                NextTurnAction("Move automated units", Color.LIGHT_GRAY) {
+                    viewingCiv.hasMovedAutomatedUnits = true
+                    for (unit in viewingCiv.getCivUnits())
+                        unit.doAction()
+                    shouldUpdate = true
                 }
 
             else ->

--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -762,9 +762,17 @@ class WorldScreen(val gameInfo: GameInfo, val viewingCiv:CivilizationInfo) : Cam
                 .any { it.isMoving() || it.isAutomated() || it.isExploring() } ->
                 NextTurnAction("Move automated units", Color.LIGHT_GRAY) {
                     viewingCiv.hasMovedAutomatedUnits = true
-                    for (unit in viewingCiv.getCivUnits())
-                        unit.doAction()
-                    shouldUpdate = true
+                    isPlayersTurn = false // Disable state changes
+                    nextTurnButton.disable()
+                    thread(name="Move automated units") {
+                        for (unit in viewingCiv.getCivUnits())
+                            unit.doAction()
+                        Gdx.app.postRunnable {
+                            shouldUpdate = true
+                            isPlayersTurn = true //Re-enable state changes
+                            nextTurnButton.enable()
+                        }
+                    }
                 }
 
             else ->


### PR DESCRIPTION
Should resolve #5534 and the long-standing request of "move after automate" by separating the automated movement from the actual end of turn
Compare and contrast - #5591