### PR TITLE
Show construction icons in Cities Overview.

### DIFF
--- a/core/src/com/unciv/ui/overviewscreen/CityOverviewTable.kt
+++ b/core/src/com/unciv/ui/overviewscreen/CityOverviewTable.kt
@@ -141,6 +141,8 @@ class CityOverviewTable(private val viewingPlayer: CivilizationInfo, private val
             }
             citiesTable.add(button)
 
+            citiesTable.add(ImageGetter.getConstructionImage(city.cityConstructions.currentConstructionFromQueue).surroundWithCircle(iconSize*0.8f)).padRight(paddingHorz)
+
             val cell = citiesTable.add(city.cityConstructions.getCityProductionTextForCityButton().toLabel())
             constructionCells.add(cell)
 

--- a/core/src/com/unciv/ui/overviewscreen/CityOverviewTable.kt
+++ b/core/src/com/unciv/ui/overviewscreen/CityOverviewTable.kt
@@ -141,7 +141,11 @@ class CityOverviewTable(private val viewingPlayer: CivilizationInfo, private val
             }
             citiesTable.add(button)
 
-            citiesTable.add(ImageGetter.getConstructionImage(city.cityConstructions.currentConstructionFromQueue).surroundWithCircle(iconSize*0.8f)).padRight(paddingHorz)
+            if (city.cityConstructions.currentConstructionFromQueue.length > 0) {
+                citiesTable.add(ImageGetter.getConstructionImage(city.cityConstructions.currentConstructionFromQueue).surroundWithCircle(iconSize*0.8f)).padRight(paddingHorz)
+            } else {
+                citiesTable.add()
+            }
 
             val cell = citiesTable.add(city.cityConstructions.getCityProductionTextForCityButton().toLabel())
             constructionCells.add(cell)


### PR DESCRIPTION
Personally I find icons way easier to scan in a big table than text that has alternating lines between it and doesn't always look aligned (due to different lengths).

It's especially easier to find the city specializations (E.G. "Produce Science"), which you probably want to be the most aware of due to their potential to waste dozens of turns, as they have different colours.

I think Civ V shows icons.

The icons are non-interactive. The city buttons right next to them can be clicked anyway.

Also, I've often been thinking: Good job to whoever designed the icons. Dozens of different options are all fairly distinctive and recognizable with only a tiny silhouette.

`*0.8f` puts them at the same size as in `CityConstructionsTable.kt`.

Before:

![image](https://user-images.githubusercontent.com/37680486/139513834-74859170-6fbd-469a-811e-92dde07bf0e7.png)

After:

![image](https://user-images.githubusercontent.com/37680486/139513843-37a38c19-efae-44ea-865e-7556d0d55923.png)

First time doing anything with Kotlin. First time writing in anything where typing is an integral part of the program logic, actually.. May have copied and pasted/poked through some Java a while ago.