### PR TITLE
Move `CityButton` back up as soon as selecting unit in it.

### DIFF
--- a/core/src/com/unciv/ui/tilegroups/CityButton.kt
+++ b/core/src/com/unciv/ui/tilegroups/CityButton.kt
@@ -169,10 +169,7 @@ class CityButton(val city: CityInfo, private val tileGroup: WorldTileGroup): Tab
         }
 
         // when deselected, move city button to its original position
-        if (isButtonMoved
-                && unitTable.selectedCity != city
-                && unitTable.selectedUnit?.currentTile != city.getCenterTile()) {
-
+        if (isButtonMoved && unitTable.selectedCity != city) {
             moveButtonUp()
         }
     }


### PR DESCRIPTION
I already created a local branch for it, so I figure I may as submit a PR to possibly close #5604.

I explain my reasoning for this change in the issue.

I get that the original behaviour had some value for indicating selection state, but practically speaking, I found it extremely frustrating both to select air units when the city button is active and to move mobile units when it's covering up the tiles right around the city.