### PR TITLE
Reworked buying buildings & units with stats a bit

### DIFF
--- a/android/assets/jsons/Civ V - Vanilla/Beliefs.json
+++ b/android/assets/jsons/Civ V - Vanilla/Beliefs.json
@@ -128,7 +128,7 @@
     {
         "name": "Cathedrals",
         "type": "Follower",
-        "uniques": ["May buy [Cathedral] buildings for [200] [Faith] [in cities following this religion]"]
+        "uniques": ["May buy [Cathedral] buildings with [Faith] [in cities following this religion]"]
     },
     {
         "name": "Choral Music",
@@ -163,17 +163,17 @@
     {
         "name": "Monasteries",
         "type": "Follower",
-        "uniques": ["May buy [Monastery] buildings for [200] [Faith] [in cities following this religion]"]
+        "uniques": ["May buy [Monastery] buildings with [Faith] [in cities following this religion]"]
     },
     {
         "name": "Mosques",
         "type": "Follower",
-        "uniques": ["May buy [Mosque] buildings for [200] [Faith] [in cities following this religion]"]
+        "uniques": ["May buy [Mosque] buildings with [Faith] [in cities following this religion]"]
     },
     {
         "name": "Pagodas",
         "type": "Follower",
-        "uniques": ["May buy [Pagoda] buildings for [200] [Faith] [in cities following this religion]"]
+        "uniques": ["May buy [Pagoda] buildings with [Faith] [in cities following this religion]"]
     },
     {
         "name": "Peace Gardens",

--- a/core/src/com/unciv/models/ruleset/Building.kt
+++ b/core/src/com/unciv/models/ruleset/Building.kt
@@ -346,12 +346,12 @@ class Building : RulesetStatsObject(), INonPerpetualConstruction {
         return (
             cityInfo.getMatchingUniques(UniqueType.BuyBuildingsIncreasingCost, conditionalState)
                 .any {
-                    matchesFilter(it.params[0])
+                    it.params[2] == stat.name
+                    && matchesFilter(it.params[0])
                     && cityInfo.matchesFilter(it.params[3])
-                    && it.params[2] == stat.name
                 }
             || cityInfo.getMatchingUniques(UniqueType.BuyBuildingsByProductionCost, conditionalState)
-                .any { matchesFilter(it.params[0]) && it.params[1] == stat.name }
+                .any { it.params[1] == stat.name && matchesFilter(it.params[0]) }
             || cityInfo.getMatchingUniques(UniqueType.BuyBuildingsWithStat, conditionalState)
                 .any {
                     it.params[1] == stat.name
@@ -378,9 +378,9 @@ class Building : RulesetStatsObject(), INonPerpetualConstruction {
                 yield(baseCost)
             yieldAll(cityInfo.getMatchingUniques(UniqueType.BuyBuildingsIncreasingCost, conditionalState)
                 .filter {
-                    matchesFilter(it.params[0])
+                    it.params[2] == stat.name
+                    && matchesFilter(it.params[0])
                     && cityInfo.matchesFilter(it.params[3])
-                    && it.params[2] == stat.name
                 }.map {
                     getCostForConstructionsIncreasingInPrice(
                         it.params[1].toInt(),

--- a/core/src/com/unciv/models/ruleset/Building.kt
+++ b/core/src/com/unciv/models/ruleset/Building.kt
@@ -6,10 +6,7 @@ import com.unciv.logic.civilization.CivilizationInfo
 import com.unciv.models.Counter
 import com.unciv.models.ruleset.tile.ResourceType
 import com.unciv.models.ruleset.tile.TileImprovement
-import com.unciv.models.ruleset.unique.Unique
-import com.unciv.models.ruleset.unique.UniqueTarget
-import com.unciv.models.ruleset.unique.UniqueTriggerActivation
-import com.unciv.models.ruleset.unique.UniqueType
+import com.unciv.models.ruleset.unique.*
 import com.unciv.models.stats.Stat
 import com.unciv.models.stats.Stats
 import com.unciv.models.translations.fillPlaceholders
@@ -343,27 +340,76 @@ class Building : RulesetStatsObject(), INonPerpetualConstruction {
 
     override fun canBePurchasedWithStat(cityInfo: CityInfo?, stat: Stat): Boolean {
         if (stat == Stat.Gold && isAnyWonder()) return false
-        // May buy [buildingFilter] buildings for [amount] [Stat] [cityFilter]
-        if (cityInfo != null && cityInfo.getMatchingUniques("May buy [] buildings for [] [] []")
-                .any { it.params[2] == stat.name && matchesFilter(it.params[0]) && cityInfo.matchesFilter(it.params[3]) }
-        ) return true
-        return super.canBePurchasedWithStat(cityInfo, stat)
+        if (cityInfo == null) return super.canBePurchasedWithStat(cityInfo, stat)
+        
+        val conditionalState = StateForConditionals(civInfo = cityInfo.civInfo, cityInfo = cityInfo)
+        return (
+            cityInfo.getMatchingUniques(UniqueType.BuyBuildingsIncreasingCost, conditionalState)
+                .any {
+                    matchesFilter(it.params[0])
+                    && cityInfo.matchesFilter(it.params[3])
+                    && it.params[2] == stat.name
+                }
+            || cityInfo.getMatchingUniques(UniqueType.BuyBuildingsByProductionCost, conditionalState)
+                .any { matchesFilter(it.params[0]) && it.params[1] == stat.name }
+            || cityInfo.getMatchingUniques(UniqueType.BuyBuildingsWithStat, conditionalState)
+                .any {
+                    it.params[1] == stat.name
+                    && matchesFilter(it.params[0])
+                    && cityInfo.matchesFilter(it.params[2])
+                }
+            || cityInfo.getMatchingUniques(UniqueType.BuyBuildingsForAmountStat, conditionalState)
+                .any {
+                    it.params[2] == stat.name
+                    && matchesFilter(it.params[0])
+                    && cityInfo.matchesFilter(it.params[3])
+                }
+            || return super.canBePurchasedWithStat(cityInfo, stat)
+        )
     }
 
     override fun getBaseBuyCost(cityInfo: CityInfo, stat: Stat): Int? {
         if (stat == Stat.Gold) return getBaseGoldCost(cityInfo.civInfo).toInt()
-
-        return (
-            sequenceOf(super.getBaseBuyCost(cityInfo, stat)).filterNotNull()
-            // May buy [buildingFilter] buildings for [amount] [Stat] [cityFilter]
-            + cityInfo.getMatchingUniques("May buy [] buildings for [] [] []")
+        val conditionalState = StateForConditionals(civInfo = cityInfo.civInfo, cityInfo = cityInfo)
+        
+        return sequence {
+            val baseCost = super.getBaseBuyCost(cityInfo, stat)
+            if (baseCost != null)
+                yield(baseCost)
+            yieldAll(cityInfo.getMatchingUniques(UniqueType.BuyBuildingsIncreasingCost, conditionalState)
                 .filter {
-                    it.params[2] == stat.name && matchesFilter(it.params[0]) && cityInfo.matchesFilter(
-                        it.params[3]
+                    matchesFilter(it.params[0])
+                    && cityInfo.matchesFilter(it.params[3])
+                    && it.params[2] == stat.name
+                }.map {
+                    getCostForConstructionsIncreasingInPrice(
+                        it.params[1].toInt(),
+                        it.params[4].toInt(),
+                        cityInfo.civInfo.civConstructions.boughtItemsWithIncreasingPrice[name] ?: 0
                     )
                 }
-                .map { it.params[1].toInt() }
-        ).minOrNull()
+            )
+            yieldAll(cityInfo.getMatchingUniques(UniqueType.BuyBuildingsByProductionCost, conditionalState)
+                .filter { it.params[1] == stat.name && matchesFilter(it.params[0]) }
+                .map { getProductionCost(cityInfo.civInfo) * it.params[2].toInt() }
+            )
+            if (cityInfo.getMatchingUniques(UniqueType.BuyBuildingsWithStat, conditionalState)
+                .any {
+                    it.params[1] == stat.name
+                    && matchesFilter(it.params[0])
+                    && cityInfo.matchesFilter(it.params[2])
+                }
+            ) {
+                yield(cityInfo.civInfo.getEra().baseUnitBuyCost)
+            }
+            yieldAll(cityInfo.getMatchingUniques(UniqueType.BuyBuildingsForAmountStat, conditionalState)
+                .filter {
+                    it.params[2] == stat.name 
+                    && matchesFilter(it.params[0]) 
+                    && cityInfo.matchesFilter(it.params[3])
+                }.map { it.params[1].toInt() }
+            )
+        }.minOrNull()
     }
 
     override fun getStatBuyCost(cityInfo: CityInfo, stat: Stat): Int? {

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -150,12 +150,20 @@ enum class UniqueType(val text:String, vararg targets: UniqueTarget) {
     FreeExtraBeliefs("May choose [amount] additional [beliefType] beliefs when [foundingOrEnhancing] a religion", UniqueTarget.Global),
     FreeExtraAnyBeliefs("May choose [amount] additional belief(s) of any type when [foundingOrEnhancing] a religion", UniqueTarget.Global),
 
+    // There is potential to merge these
     BuyUnitsIncreasingCost("May buy [baseUnitFilter] units for [amount] [stat] [cityFilter] at an increasing price ([amount])", UniqueTarget.Global),
     BuyBuildingsIncreasingCost("May buy [buildingFilter] buildings for [amount] [stat] [cityFilter] at an increasing price ([amount])", UniqueTarget.Global),
-    @Deprecated("As of 3.17.9", ReplaceWith ("May buy [baseUnitFilter] units for [amount] [stat] [cityFilter] at an increasing price ([amount]) <starting from the [era]>"))
-    BuyUnitsIncreasingCostEra("May buy [baseUnitFilter] units for [amount] [stat] [cityFilter] starting from the [era] at an increasing price ([amount])", UniqueTarget.Global),    
+    BuyUnitsForAmountStat("May buy [baseUnitFilter] units for [amount] [stat] [cityFilter]", UniqueTarget.Global, UniqueTarget.FollowerBelief),
+    BuyBuildingsForAmountStat("May buy [baseUnitFilter] buildings for [amount] [stat] [cityFilter]", UniqueTarget.Global, UniqueTarget.FollowerBelief),
+    BuyUnitsWithStat("May buy [baseUnitFilter] units with [stat] [cityFilter]", UniqueTarget.Global, UniqueTarget.FollowerBelief),
+    BuyBuildingsWithStat("May buy [buildingFilter] buildings with [stat] [cityFilter]", UniqueTarget.Global, UniqueTarget.FollowerBelief),
+    
     BuyUnitsByProductionCost("May buy [baseUnitFilter] units with [stat] for [amount] times their normal Production cost", UniqueTarget.FollowerBelief, UniqueTarget.Global),
+    BuyBuildingsByProductionCost("May buy [buildingFilter] buildings with [stat] for [amount] times their normal Production cost", UniqueTarget.FollowerBelief, UniqueTarget.Global),
 
+    @Deprecated("As of 3.17.9", ReplaceWith ("May buy [baseUnitFilter] units for [amount] [stat] [cityFilter] at an increasing price ([amount]) <starting from the [era]>"))
+    BuyUnitsIncreasingCostEra("May buy [baseUnitFilter] units for [amount] [stat] [cityFilter] starting from the [era] at an increasing price ([amount])", UniqueTarget.Global),
+    
     MayanGainGreatPerson("Receive a free Great Person at the end of every [comment] (every 394 years), after researching [tech]. Each bonus person can only be chosen once.", UniqueTarget.Nation),
     MayanCalendarDisplay("Once The Long Count activates, the year on the world screen displays as the traditional Mayan Long Count.", UniqueTarget.Nation),
 
@@ -165,6 +173,7 @@ enum class UniqueType(val text:String, vararg targets: UniqueTarget) {
     Unbuildable("Unbuildable", UniqueTarget.Building, UniqueTarget.Unit),
     CannotBePurchased("Cannot be purchased", UniqueTarget.Building, UniqueTarget.Unit),
     CanBePurchasedWithStat("Can be purchased with [stat] [cityFilter]", UniqueTarget.Building, UniqueTarget.Unit),
+    CanBePurchasedForAmountStat("Can be purchased for [amount] [stat] [cityFilter]", UniqueTarget.Building, UniqueTarget.Unit),
 
 
     ///////////////////////////////////////// BUILDING UNIQUES /////////////////////////////////////////

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -154,7 +154,7 @@ enum class UniqueType(val text:String, vararg targets: UniqueTarget) {
     BuyUnitsIncreasingCost("May buy [baseUnitFilter] units for [amount] [stat] [cityFilter] at an increasing price ([amount])", UniqueTarget.Global),
     BuyBuildingsIncreasingCost("May buy [buildingFilter] buildings for [amount] [stat] [cityFilter] at an increasing price ([amount])", UniqueTarget.Global),
     BuyUnitsForAmountStat("May buy [baseUnitFilter] units for [amount] [stat] [cityFilter]", UniqueTarget.Global, UniqueTarget.FollowerBelief),
-    BuyBuildingsForAmountStat("May buy [baseUnitFilter] buildings for [amount] [stat] [cityFilter]", UniqueTarget.Global, UniqueTarget.FollowerBelief),
+    BuyBuildingsForAmountStat("May buy [buildingFilter] buildings for [amount] [stat] [cityFilter]", UniqueTarget.Global, UniqueTarget.FollowerBelief),
     BuyUnitsWithStat("May buy [baseUnitFilter] units with [stat] [cityFilter]", UniqueTarget.Global, UniqueTarget.FollowerBelief),
     BuyBuildingsWithStat("May buy [buildingFilter] buildings with [stat] [cityFilter]", UniqueTarget.Global, UniqueTarget.FollowerBelief),
     

--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -250,48 +250,51 @@ class BaseUnit : RulesetObject(), INonPerpetualConstruction {
     }
 
     override fun canBePurchasedWithStat(cityInfo: CityInfo?, stat: Stat): Boolean {
-        // May buy [unitFilter] units for [amount] [Stat] [cityFilter] starting from the [eraName] at an increasing price ([amount])
-        if (cityInfo != null && cityInfo.getMatchingUniques("May buy [] units for [] [] [] starting from the [] at an increasing price ([])")
-            .any { 
-                matchesFilter(it.params[0])
-                && cityInfo.matchesFilter(it.params[3])        
-                && cityInfo.civInfo.getEraNumber() >= ruleset.eras[it.params[4]]!!.eraNumber 
-                && it.params[2] == stat.name
-            }
-        ) return true
+        if (cityInfo == null) return super.canBePurchasedWithStat(cityInfo, stat)
+        val conditionalState = StateForConditionals(civInfo = cityInfo.civInfo, cityInfo = cityInfo)
         
-        // May buy [unitFilter] units for [amount] [Stat] [cityFilter] at an increasing price ([amount])
-        if (cityInfo != null && cityInfo.getMatchingUniques("May buy [] units for [] [] [] at an increasing price ([])")
-            .any {
-                matchesFilter(it.params[0])
-                && cityInfo.matchesFilter(it.params[3])
-                && it.params[2] == stat.name
-            }
-        ) return true
-        
-        if (cityInfo != null && cityInfo.getMatchingUniques(
-                UniqueType.BuyUnitsByProductionCost, 
-                stateForConditionals = StateForConditionals(civInfo = cityInfo.civInfo, cityInfo = cityInfo)
-            ).any {
-                matchesFilter(it.params[0])
-                && it.params[1] == stat.name
-            }
-        ) return true
-
-        return super.canBePurchasedWithStat(cityInfo, stat)
-    }
-
-    private fun getCostForConstructionsIncreasingInPrice(baseCost: Int, increaseCost: Int, previouslyBought: Int): Int {
-        return (baseCost + increaseCost / 2f * ( previouslyBought * previouslyBought + previouslyBought )).toInt()        
+        return (
+            cityInfo.getMatchingUniques(UniqueType.BuyUnitsIncreasingCostEra, conditionalState)
+                .any {
+                    matchesFilter(it.params[0])
+                        && cityInfo.matchesFilter(it.params[3])
+                        && cityInfo.civInfo.getEraNumber() >= ruleset.eras[it.params[4]]!!.eraNumber
+                        && it.params[2] == stat.name
+                }
+            || cityInfo.getMatchingUniques(UniqueType.BuyUnitsIncreasingCost, conditionalState)
+                .any {
+                    matchesFilter(it.params[0])
+                        && cityInfo.matchesFilter(it.params[3])
+                        && it.params[2] == stat.name
+                }
+            || cityInfo.getMatchingUniques(UniqueType.BuyUnitsByProductionCost, conditionalState)
+                .any { matchesFilter(it.params[0]) && it.params[1] == stat.name }
+            || cityInfo.getMatchingUniques(UniqueType.BuyUnitsWithStat, conditionalState)
+                .any {
+                    it.params[1] == stat.name
+                        && matchesFilter(it.params[0])
+                        && cityInfo.matchesFilter(it.params[2])
+                }
+            || cityInfo.getMatchingUniques(UniqueType.BuyUnitsForAmountStat, conditionalState)
+                .any {
+                    it.params[2] == stat.name
+                    && matchesFilter(it.params[0])
+                    && cityInfo.matchesFilter(it.params[3])
+                }
+            || return super.canBePurchasedWithStat(cityInfo, stat)
+        )
     }
 
     override fun getBaseBuyCost(cityInfo: CityInfo, stat: Stat): Int? {
         if (stat == Stat.Gold) return getBaseGoldCost(cityInfo.civInfo).toInt()
         val conditionalState = StateForConditionals(civInfo = cityInfo.civInfo, cityInfo = cityInfo)
-        return (
-            sequenceOf(super.getBaseBuyCost(cityInfo, stat)).filterNotNull()
+
+        return sequence {
+            val baseCost = super.getBaseBuyCost(cityInfo, stat)
+            if (baseCost != null)
+                yield(baseCost)
             // Deprecated since 3.17.9
-                + (cityInfo.getMatchingUniques(UniqueType.BuyUnitsIncreasingCostEra, conditionalState)
+                yieldAll(cityInfo.getMatchingUniques(UniqueType.BuyUnitsIncreasingCostEra, conditionalState)
                     .filter {
                         matchesFilter(it.params[0])
                         && cityInfo.matchesFilter(it.params[3])
@@ -306,7 +309,7 @@ class BaseUnit : RulesetObject(), INonPerpetualConstruction {
                     }
                 )
             //
-            + (cityInfo.getMatchingUniques(UniqueType.BuyUnitsIncreasingCost, conditionalState)
+            yieldAll(cityInfo.getMatchingUniques(UniqueType.BuyUnitsIncreasingCost, conditionalState)
                 .filter {
                     matchesFilter(it.params[0])
                     && cityInfo.matchesFilter(it.params[3])
@@ -316,18 +319,30 @@ class BaseUnit : RulesetObject(), INonPerpetualConstruction {
                         it.params[1].toInt(),
                         it.params[4].toInt(),
                         cityInfo.civInfo.civConstructions.boughtItemsWithIncreasingPrice[name] ?: 0
-                    )        
+                    )
                 }
             )
-            + (cityInfo.getMatchingUniques(UniqueType.BuyUnitsByProductionCost, conditionalState)
-                .filter {
+            yieldAll(cityInfo.getMatchingUniques(UniqueType.BuyUnitsByProductionCost, conditionalState)
+                .filter { it.params[1] == stat.name && matchesFilter(it.params[0]) }
+                .map { getProductionCost(cityInfo.civInfo) * it.params[2].toInt() }
+            )
+            if (cityInfo.getMatchingUniques(UniqueType.BuyUnitsWithStat, conditionalState)
+                .any {
                     it.params[1] == stat.name
                     && matchesFilter(it.params[0])
-                }.map {
-                    getProductionCost(cityInfo.civInfo) * it.params[2].toInt()
+                    && cityInfo.matchesFilter(it.params[2])
                 }
+            ) {
+                yield(cityInfo.civInfo.getEra().baseUnitBuyCost)
+            }
+            yieldAll(cityInfo.getMatchingUniques(UniqueType.BuyUnitsForAmountStat, conditionalState)
+                .filter {
+                    it.params[2] == stat.name
+                    && matchesFilter(it.params[0])
+                    && cityInfo.matchesFilter(it.params[3])
+                }.map { it.params[1].toInt() }
             )
-        ).minOrNull()
+        }.minOrNull()
     }
 
     override fun getStatBuyCost(cityInfo: CityInfo, stat: Stat): Int? {

--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -256,24 +256,24 @@ class BaseUnit : RulesetObject(), INonPerpetualConstruction {
         return (
             cityInfo.getMatchingUniques(UniqueType.BuyUnitsIncreasingCostEra, conditionalState)
                 .any {
-                    matchesFilter(it.params[0])
-                        && cityInfo.matchesFilter(it.params[3])
-                        && cityInfo.civInfo.getEraNumber() >= ruleset.eras[it.params[4]]!!.eraNumber
-                        && it.params[2] == stat.name
+                    it.params[2] == stat.name
+                    && cityInfo.civInfo.getEraNumber() >= ruleset.eras[it.params[4]]!!.eraNumber
+                    && matchesFilter(it.params[0])
+                    && cityInfo.matchesFilter(it.params[3])
                 }
             || cityInfo.getMatchingUniques(UniqueType.BuyUnitsIncreasingCost, conditionalState)
                 .any {
-                    matchesFilter(it.params[0])
-                        && cityInfo.matchesFilter(it.params[3])
-                        && it.params[2] == stat.name
+                    it.params[2] == stat.name
+                    && matchesFilter(it.params[0])
+                    && cityInfo.matchesFilter(it.params[3])
                 }
             || cityInfo.getMatchingUniques(UniqueType.BuyUnitsByProductionCost, conditionalState)
-                .any { matchesFilter(it.params[0]) && it.params[1] == stat.name }
+                .any { it.params[1] == stat.name && matchesFilter(it.params[0]) }
             || cityInfo.getMatchingUniques(UniqueType.BuyUnitsWithStat, conditionalState)
                 .any {
                     it.params[1] == stat.name
-                        && matchesFilter(it.params[0])
-                        && cityInfo.matchesFilter(it.params[2])
+                    && matchesFilter(it.params[0])
+                    && cityInfo.matchesFilter(it.params[2])
                 }
             || cityInfo.getMatchingUniques(UniqueType.BuyUnitsForAmountStat, conditionalState)
                 .any {
@@ -296,10 +296,10 @@ class BaseUnit : RulesetObject(), INonPerpetualConstruction {
             // Deprecated since 3.17.9
                 yieldAll(cityInfo.getMatchingUniques(UniqueType.BuyUnitsIncreasingCostEra, conditionalState)
                     .filter {
-                        matchesFilter(it.params[0])
+                        it.params[2] == stat.name
+                        && matchesFilter(it.params[0])
                         && cityInfo.matchesFilter(it.params[3])
                         && cityInfo.civInfo.getEraNumber() >= ruleset.eras[it.params[4]]!!.eraNumber
-                        && it.params[2] == stat.name
                     }.map {
                         getCostForConstructionsIncreasingInPrice(
                             it.params[1].toInt(),
@@ -311,9 +311,9 @@ class BaseUnit : RulesetObject(), INonPerpetualConstruction {
             //
             yieldAll(cityInfo.getMatchingUniques(UniqueType.BuyUnitsIncreasingCost, conditionalState)
                 .filter {
-                    matchesFilter(it.params[0])
+                    it.params[2] == stat.name
+                    && matchesFilter(it.params[0])
                     && cityInfo.matchesFilter(it.params[3])
-                    && it.params[2] == stat.name
                 }.map {
                     getCostForConstructionsIncreasingInPrice(
                         it.params[1].toInt(),


### PR DESCRIPTION
Reworked the system for buying units & buildings a bit, unifying uniques for them, enumifying them, adding support for conditionals and fixing a few bugs.

Bugs fixed:
- Faith cost for buying faith buildings should increase based on the era you're in
- Trying to buy a great artist before the industrial era crashes the game

Uniques now supported:
- May buy [baseUnitFilter] units for [amount] [stat] [cityFilter] at an increasing price ([amount])
- May buy [baseUnitFilter] units for [amount] [stat] [cityFilter]
- May buy [baseUnitFilter] units with [stat] [cityFilter]
- May buy [baseUnitFilter] units with [stat] for [amount] times their normal Production cost
- All of the above, but for buildings instead of units.