### PR TITLE
Show encampments revealed by ruins directly

### DIFF
--- a/core/src/com/unciv/logic/civilization/CivInfoTransientUpdater.kt
+++ b/core/src/com/unciv/logic/civilization/CivInfoTransientUpdater.kt
@@ -98,7 +98,6 @@ class CivInfoTransientUpdater(val civInfo: CivilizationInfo) {
         if (civInfo.playerType == PlayerType.AI) return // don't bother for AI, they don't really use the info anyway
 
         for (tile in civInfo.viewableTiles) {
-            val before = civInfo.lastSeenImprovement[tile.position]
             if (tile.improvement == null)
                 civInfo.lastSeenImprovement.remove(tile.position)
             else

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -401,12 +401,19 @@ object UniqueTriggerActivation {
                     }
                     .map { it.position }
                 if (nearbyRevealableTiles.none()) return false
-                civInfo.exploredTiles.addAll(nearbyRevealableTiles
-                    .shuffled(tileBasedRandom)
-                    .apply {
-                        if (unique.params[0] != "All") this.take(unique.params[0].toInt())
-                    }
-                )
+                val revealedTiles = nearbyRevealableTiles
+                        .shuffled(tileBasedRandom)
+                        .apply {
+                            if (unique.params[0] != "All") this.take(unique.params[0].toInt())
+                        }
+                for (position in revealedTiles) {
+                    civInfo.exploredTiles.add(position)
+                    val revealedTileInfo = civInfo.gameInfo.tileMap[position]
+                    if (revealedTileInfo.improvement == null)
+                        civInfo.lastSeenImprovement.remove(position)
+                    else
+                        civInfo.lastSeenImprovement[position] = revealedTileInfo.improvement!!
+                }
 
                 if (notification != null) {
                     civInfo.addNotification(


### PR DESCRIPTION
Updates lastSeenImprovement when encampments are revealed by ruins, so you see them right away.