### PR TITLE
Fix bug with cancelling quests when city states bullied

### DIFF
--- a/core/src/com/unciv/logic/civilization/QuestManager.kt
+++ b/core/src/com/unciv/logic/civilization/QuestManager.kt
@@ -506,7 +506,7 @@ class QuestManager {
         if (civInfo == cityState) {
             // Revoke most quest types from the bully
             val revokedQuests = assignedQuests.asSequence()
-                .filter { it.isIndividual() || it.questName == QuestName.Invest.value }
+                .filter { it.assignee == bully.civName && (it.isIndividual() || it.questName == QuestName.Invest.value) }
             assignedQuests.removeAll(revokedQuests)
             if (revokedQuests.count() > 0)
                 bully.addNotification("[${civInfo.civName}] cancelled the quests they had given you because you demanded tribute from them.",


### PR DESCRIPTION
Fixes #5597 

The issue was that a bullied city state would cancel all quests not only with the bully but with every other civ as well.