### PR TITLE
Removed the Hanse, a wrongly implemented BNW-only building

### DIFF
--- a/android/assets/jsons/Civ V - Vanilla/Buildings.json
+++ b/android/assets/jsons/Civ V - Vanilla/Buildings.json
@@ -709,19 +709,19 @@
 		"requiredBuilding": "Market",
 		"requiredTech": "Banking"
 	},
-	{
-		"name": "Hanse",
-		"replaces": "Bank",
-		"uniqueTo": "Germany",
-		"gold": 2,
-		"specialistSlots": {"Merchant": 1},
-		"hurryCostModifier": 15,
-		"percentStatBonus": {"gold": 25},
-		"uniques": ["+5% Production for every Trade Route with a City-State in the empire"],
-		"requiredBuilding": "Market",
-		"requiredTech": "Banking"
-		// will be introduced in BNW expansion pack
-	},
+	// will be introduced in BNW expansion pack
+//	{
+//		"name": "Hanse",
+//		"replaces": "Bank",
+//		"uniqueTo": "Germany",
+//		"gold": 2,
+//		"specialistSlots": {"Merchant": 1},
+//		"hurryCostModifier": 15,
+//		"percentStatBonus": {"gold": 25},
+//		"uniques": ["+5% Production for every Trade Route with a City-State in the empire"],
+//		"requiredBuilding": "Market",
+//		"requiredTech": "Banking"
+//	},
 	{
 		"name": "Forbidden Palace",
 		"culture": 1,


### PR DESCRIPTION
Hanse is a BNW-only building that should provide production boosts only when connecting to city-states via trade routes made by caravans or cargo ships. However, due to those not being in unciv, it was implemented as providing the bonus for any city connection. As city connections are made over water via harbors, this means that in larger games Germany could reliably get +50% production or more in all their cities, which is obviously overpowered.

Fixes #5639.