### PR TITLE
Fixed bug with the G&K split

### DIFF
--- a/core/src/com/unciv/logic/map/MapParameters.kt
+++ b/core/src/com/unciv/logic/map/MapParameters.kt
@@ -142,7 +142,7 @@ class MapParameters {
 
     /** This is used mainly for the map editor, so you can continue editing a map under the same ruleset you started with */
     var mods = LinkedHashSet<String>()
-    var baseRuleset = BaseRuleset.Civ_V_Vanilla.name // Hardcoded as the Rulesetcache is not yet initialized when starting up 
+    var baseRuleset = BaseRuleset.Civ_V_GnK.fullName // Hardcoded as the Rulesetcache is not yet initialized when starting up 
 
     /** Unciv Version of creation for support cases */
     var createdWithVersion = ""

--- a/core/src/com/unciv/ui/mapeditor/SaveAndLoadMapScreen.kt
+++ b/core/src/com/unciv/ui/mapeditor/SaveAndLoadMapScreen.kt
@@ -66,8 +66,13 @@ class SaveAndLoadMapScreen(mapToSave: TileMap?, save:Boolean = false, previousSc
                     }
                     try {
                         val map = MapSaver.loadMap(chosenMap!!, checkSizeErrors = false)
-
+                        
                         val missingMods = map.mapParameters.mods.filter { it !in RulesetCache }.toMutableList()
+                        // [TEMPORARY] conversion of old maps with a base ruleset contained in the mods
+                            val newBaseRuleset = map.mapParameters.mods.filter { it !in missingMods }.firstOrNull { RulesetCache[it]!!.modOptions.isBaseRuleset }
+                            if (newBaseRuleset != null) map.mapParameters.baseRuleset = newBaseRuleset
+                        //
+                        
                         if (map.mapParameters.baseRuleset !in RulesetCache) missingMods += map.mapParameters.baseRuleset
                         
                         if (missingMods.isNotEmpty()) {


### PR DESCRIPTION
Fixes bug:
- Map editor maps created before the G&K split PR could no longer be opened after

Also, some additional notes on known issues after the split:
- In Modded multiplayer games where one player is on 3.18.1 or later and another is on an earlier version, a crash will happen when the game is opened in 3.18.0 or earlier. This crash is handled gracefully by showing the "SOMETHING WENT WRONG" error to the user. This doesn't corrupt the save, and after updating, it can be played again. 
- G&K maps created in the map editor in 3.18.1 and later cannot be opened in 3.18.0 and earlier

Bugs & crashes I've discovered while testing that were also present before the split and I've also not fixed (might do that later):
- Trying to load a modded custom map while no mods are loaded or vise versa crashes the game
- Selecting a different custom map resets the selected mods
- Having "Deciv Redux" as the base ruleset saved in settings (done by f.e. starting a game), will have every instance of "Ancient Ruins" be translated to "Survivor Camps", even in entirely different contexts, such as when choosing the parameters for a new map editor map


I'll push some more PR's this evening with some code cleaning, as suggested in #5647, as well as some PR's removing buildings, units & nations not present in vanilla.