### PR TITLE
Removed "patronage " to "patronage" policy conversion

### DIFF
--- a/core/src/com/unciv/logic/civilization/PolicyManager.kt
+++ b/core/src/com/unciv/logic/civilization/PolicyManager.kt
@@ -42,17 +42,6 @@ class PolicyManager {
     fun getPolicyByName(name: String): Policy = civInfo.gameInfo.ruleSet.policies[name]!!
 
     fun setTransients() {
-        // Deprecated "Patronage " policy since 3.16.15
-            if (adoptedPolicies.contains("Patronage ")) {
-                adoptedPolicies.remove("Patronage ")
-                adoptedPolicies.add("Patronage")
-            }
-            if (adoptedPolicies.contains("Patronage  Complete")) {
-                adoptedPolicies.remove("Patronage  Complete")
-                adoptedPolicies.add("Patronage Complete")
-            }
-        //
-        
         for (policyName in adoptedPolicies)
             addPolicyToTransients(getPolicyByName(policyName))
     }


### PR DESCRIPTION
In `BackwardCompatability.kt` some code exited that allowed "patronage " and "patronage &nbsp;complete" as valid policies regardless whether they were part of the used ruleset. This code was removed in 3.18.2, but the conversion code still exists. This PR removes that conversion code.