### PR TITLE
Added health conditionals

### DIFF
--- a/core/src/com/unciv/models/ruleset/unique/Unique.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Unique.kt
@@ -83,6 +83,10 @@ class Unique(val text: String, val sourceObjectType: UniqueTarget? = null, val s
                 || (state.unit != null && state.unit.matchesFilter(condition.params[0]))
             UniqueType.ConditionalAttacking -> state.combatAction == CombatAction.Attack
             UniqueType.ConditionalDefending -> state.combatAction == CombatAction.Defend
+            UniqueType.ConditionalAboveHP -> 
+                state.ourCombatant != null && state.ourCombatant.getHealth() > condition.params[0].toInt()
+            UniqueType.ConditionalBelowHP ->
+                state.ourCombatant != null && state.ourCombatant.getHealth() < condition.params[0].toInt()
             UniqueType.ConditionalInTiles -> 
                 state.attackedTile != null && state.attackedTile.matchesFilter(condition.params[0])
             UniqueType.ConditionalVsLargerCiv -> {

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -433,6 +433,8 @@ enum class UniqueType(val text:String, vararg targets: UniqueTarget, val flags: 
     ConditionalDefending("when defending", UniqueTarget.Conditional),
     ConditionalInTiles("when fighting in [tileFilter] tiles", UniqueTarget.Conditional),
     ConditionalForeignContinent("on foreign continents", UniqueTarget.Conditional),
+    ConditionalAboveHP("above [amount] HP", UniqueTarget.Conditional),
+    ConditionalBelowHP("below [amount] HP", UniqueTarget.Conditional),
 
     /////// tile conditionals
     ConditionalNeighborTiles("with [amount] to [amount] neighboring [tileFilter] tiles", UniqueTarget.Conditional),

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -433,8 +433,8 @@ enum class UniqueType(val text:String, vararg targets: UniqueTarget, val flags: 
     ConditionalDefending("when defending", UniqueTarget.Conditional),
     ConditionalInTiles("when fighting in [tileFilter] tiles", UniqueTarget.Conditional),
     ConditionalForeignContinent("on foreign continents", UniqueTarget.Conditional),
-    ConditionalAboveHP("above [amount] HP", UniqueTarget.Conditional),
-    ConditionalBelowHP("below [amount] HP", UniqueTarget.Conditional),
+    ConditionalAboveHP("when above [amount] HP", UniqueTarget.Conditional),
+    ConditionalBelowHP("when below [amount] HP", UniqueTarget.Conditional),
 
     /////// tile conditionals
     ConditionalNeighborTiles("with [amount] to [amount] neighboring [tileFilter] tiles", UniqueTarget.Conditional),

--- a/core/src/com/unciv/models/translations/Translations.kt
+++ b/core/src/com/unciv/models/translations/Translations.kt
@@ -213,7 +213,7 @@ class Translations : LinkedHashMap<String, TranslationEntry>(){
         // Whenever this string is changed, it should also be changed in the translation files!
         // It is mostly used as the template for translating the order of conditionals   
         const val englishConditionalOrderingString = 
-            "<for [mapUnitFilter] units> <vs cities> <vs [mapUnitFilter] units> <when fighting in [tileFilter] tiles> <when attacking> <when defending> <if this city has at least [amount] specialists> <when at war> <when not at war> <while the empire is happy> <during a Golden Age> <during the [era]> <before the [era]> <starting from the [era]> <with [techOrPolicy]> <without [techOrPolicy]>"
+            "<for [mapUnitFilter] units> <above [amount] HP> <below [amount] HP> <vs cities> <vs [mapUnitFilter] units> <when fighting in [tileFilter] tiles> <when attacking> <when defending> <if this city has at least [amount] specialists> <when at war> <when not at war> <while the empire is happy> <during a Golden Age> <during the [era]> <before the [era]> <starting from the [era]> <with [techOrPolicy]> <without [techOrPolicy]>"
         const val conditionalUniqueOrderString = "ConditionalsPlacement"
         const val shouldCapitalizeString = "StartWithCapitalLetter"
     }


### PR DESCRIPTION
Added conditionals:
- \<when above [amount] HP>
- \<when below [amount] HP>

Those both only apply to our unit, so for a pikeman with "[+20]% Strength <vs [All] units> <when below [20] HP>" attacking a swordsman, the pikeman would only receive the bonus if it less than 20 HP, regardless of the HP of the swordsman. For this reason, the conditionals are automatically reordered such that these conditionals are always in front of the 'vs' conditionals: "[+20]% Strength <when below [20] HP> <vs [All] units>".
As requested in #3242