### PR TITLE
Show which cities are missing required buildings for National Wonders.

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -56,6 +56,7 @@ Requires at least one of the following resources worked near the city: =
 Wonder is being built elsewhere = 
 National Wonder is being built elsewhere = 
 Requires a [buildingName] in all cities = 
+[buildingName] required: = 
 Requires a [buildingName] in this city = 
 Cannot be built with [buildingName] = 
 Consumes 1 [resource] = 


### PR DESCRIPTION
Hides the Unique's text and shows list of cities missing required building if any:

![image](https://user-images.githubusercontent.com/37680486/143690684-68f71752-503c-4144-8f34-4602c60286ad.png)

If all cities have the required building, then behaviour is unchanged:

![image](https://user-images.githubusercontent.com/37680486/143690741-2d75c995-f548-4e49-99e8-d59f6fb84c35.png)

Surprisingly legible, even with small screen size and lots of cities:

![image](https://user-images.githubusercontent.com/37680486/143691051-c2118593-6024-4bde-8ef9-17f94b61d8ab.png)

Could also truncate list if too long, I guess. But that may require adding something like "and {n} other cities…" to be clearest, which itself is worth a couple city names in length, and would make translation more complicated.

Civ V (at least G&K/BNW/BE) does something similar.

Line count/Diff is inflated by editor stripping trailing spaces.