### PR TITLE
Desugar Java 8 APIs for older Android devices.

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -24,7 +24,7 @@ android {
     }
     defaultConfig {
         applicationId = "com.unciv.app"
-        minSdk = 17
+        minSdk = 21
         targetSdk = 30 // See #5044
         versionCode = BuildConfig.appCodeNumber
         versionName = BuildConfig.appVersion
@@ -60,6 +60,7 @@ android {
         disable("MissingTranslation")
     }
     compileOptions {
+        isCoreLibraryDesugaringEnabled = true // https://developer.android.com/studio/write/java8-support
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
     }
@@ -124,4 +125,5 @@ dependencies {
     //   run `./gradlew build --scan` to see details
     implementation("androidx.core:core-ktx:1.6.0")
     implementation("androidx.work:work-runtime-ktx:2.6.0")
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:1.1.5")
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,18 @@
+## For more details on how to configure your build environment visit
+# http://www.gradle.org/docs/current/userguide/build_environment.html
+#
+# Specifies the JVM arguments used for the daemon process.
+# The setting is particularly useful for tweaking memory settings.
+# Default value: -Xmx1024m -XX:MaxPermSize=256m
+# org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+#
+# When configured, Gradle will run in incubating parallel mode.
+# This option should only be used with decoupled projects. More details, visit
+# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
+# org.gradle.parallel=true
+#Thu Dec 02 17:27:46 GMT 2021
+org.gradle.caching=true
+org.gradle.parallel=true
+org.gradle.jvmargs=-Xmx1536M -Dkotlin.daemon.jvm.options\="-Xmx1536M" -XX\:MaxMetaspaceSize\=512m
 android.useAndroidX=true
 android.enableJetifier=true
-org.gradle.parallel=true
-org.gradle.caching=true
-org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=512m


### PR DESCRIPTION
[Recent-ish](https://developer.android.com/studio/releases/gradle-plugin#4-0-0) versions of the Android Gradle plugin purport to support certain Java 8 features through some compiler translation thing, even on phones that only support Java 7:

https://developer.android.com/studio/write/java8-support

Also switched to `minSdk = 21`, as otherwise `multiDexEnabled = true` would have to set for desugaring. 20's only for wearables, and there are unresolved critical bugs at 19 anyway (#3927).

APK size impact:

```bash
$ du -s master/**/*.apk desugar/**/*.apk
12004	master/android/build/outputs/apk/debug/Unciv-debug.apk
12400	desugar/android/build/outputs/apk/debug/Unciv-debug.apk
```

MultiDex would, IIRC, add around another ~0.5MB.

Tested on 24 as that's the AVD I have. If merged, I will/can install a 21 AVD and see if everything works there.

Some relevant code paths/commits:

https://github.com/yairm210/Unciv/commit/cbeb9a96a64948c10cf983313488102ee16f0615

https://github.com/yairm210/Unciv/commit/24d71c345037522e67350bca03c6be7a81799180

https://github.com/yairm210/Unciv/blob/7ddbac1f07dd6a836830c5454bcb3312216cf56b/core/src/com/unciv/ui/pickerscreens/ModManagementScreen.kt#L118-L124

(I just searched for "Java 8".)

There's also an unrelated minor change to `gradle.properties` here. I mean, it builds fine with 1.5GB of memory, and the 4GB setting was causing pretty bad swapping and freezing my fairly high-RAM laptop, but I can remove or separate the change if that would be preferred.
