### PR TITLE
Reinstated translations that were previously added in #4820, but reversed when 3.16.3 was released

### DIFF
--- a/android/assets/jsons/translations/Malay.properties
+++ b/android/assets/jsons/translations/Malay.properties
@@ -1,95 +1,66 @@
-# Language settings
-
-# Equivalent of a space in your language
-# If your language doesn't use spaces, just add "" as a translation, otherwise " "
- # Requires translation!
-" " = 
-
-# If the first word in a sentence starts with a capital in your language, 
-# put the english word 'true' behind the '=', otherwise 'false'.
-# Don't translate these words to your language, only put 'true' or 'false'.
- # Requires translation!
-StartWithCapitalLetter = 
-
-
-
-# Starting from here normal translations start, as written on
-# https://github.com/yairm210/Unciv/wiki/Translating
-
 # Tutorial tasks
 
 Move a unit!\nClick on a unit > Click on a destination > Click the arrow popup = Gerakkan satu unit!\nKlik pada satu unit > Klik pada jubin untuk destinasi > Klik pada anak panah yang terpapar
-Found a city!\nSelect the Settler (flag unit) > Click on 'Found city' (bottom-left corner) = Cipta bandar!\nPilih Peneroka (unit bendera) > Klik 'Cipta bandar' (sudut bawah kiri)
+Found a city!\nSelect the Settler (flag unit) > Click on 'Found city' (bottom-left corner) = Asaskan bandar!\nPilih Peneroka (unit bendera) > Klik 'Asas bandar' (sudut kiri bawah)
 Enter the city screen!\nClick the city button twice = Masuk ke skrin bandar! \nKlik butang bandar dua kali
 Pick a technology to research!\nClick on the tech button (greenish, top left) > \n select technology > click 'Research' (bottom right) = Pilih teknologi untuk diselidik! \nKlik butang teknologi (warna kehijauan, kiri atas) > \npilih teknologi > klik 'Selidik' (kanan bawah)
-Pick a construction!\nEnter city screen > Click on a unit or building (bottom left side) > \n click 'add to queue' = Pilih pembinaan! \nMasuk ke skrin bandar > Klik pada unit atau bangunan (sebelah kiri bawah) > \nklik 'tambah ke aturan'
-Pass a turn!\nCycle through units with 'Next unit' > Click 'Next turn' = Melepaskan giliran! \nGerakkan unit dengan 'Unit seterusnya' > Klik 'Giliran seterusnya'
+Pick a construction!\nEnter city screen > Click on a unit or building (bottom left side) > \n click 'add to queue' = Pilih pembinaan! \nMasuk ke skrin bandar > Klik pada unit atau bangunan (sebelah kiri bawah) > \n klik 'tambah ke aturan'
+Pass a turn!\nCycle through units with 'Next unit' > Click 'Next turn' = Melepaskan giliran! \nKitarkan unit-unit dengan 'Unit seterusnya' > Klik 'Giliran seterusnya'
 Reassign worked tiles!\nEnter city screen > click the assigned (green) tile to unassign > \n click an unassigned tile to assign population = Tetapkan semula jubin yang berfungsi! \nMasuk ke skrin bandar > klik jubin yang ditugaskan (hijau) untuk membatalkan penetapan > \nklik jubin yang belum ditugaskan untuk menetapkan populasi
-Meet another civilization!\nExplore the map until you encounter another civilization! = Temui peradaban yang lain! \nTinjau peta sehingga anda menemui peradaban lain!
+Meet another civilization!\nExplore the map until you encounter another civilization! = Temui tamadun yang lain! \nTeroka peta sehingga anda menemui tamadun lain!
 Open the options table!\nClick the menu button (top left) > click 'Options' = Buka menu tetapan! \nKlik butang menu (kiri atas) > klik 'Tetapan'
-Construct an improvement!\nConstruct a Worker unit > Move to a Plains or Grassland tile > \n Click 'Create improvement' (above the unit table, bottom left)\n > Choose the farm > \n Leave the worker there until it's finished = Bina peningkatan! \nBina unit pekerja > Pindah ke jubin Dataran atau Padang Rumput > \nKlik 'Buat penambahbaikan' (di atas tetapan pilihan unit, kiri bawah)\n > Pilih ladang > \n Biarkan pekerja di sana sehingga selesai
-Create a trade route!\nConstruct roads between your capital and another city\nOr, automate your worker and let him get to that eventually = Buat laluan perdagangan! \nBina jalan antara ibu kota anda dan bandar lain\nAtau, automatik pekerja anda dan biarkan dia sampai ke situ akhirnya
-Conquer a city!\nBring an enemy city down to low health > \nEnter the city with a melee unit = Menakluk bandar! \nSerang bandar musuh ke tahap kesihatan yang rendah > \nMasuk ke bandar dengan unit tempur jarak dekat
+Construct an improvement!\nConstruct a Worker unit > Move to a Plains or Grassland tile > \n Click 'Create improvement' (above the unit table, bottom left)\n > Choose the farm > \n Leave the worker there until it's finished = Bina peningkatan! \nBina unit pekerja > Pindah ke jubin Dataran atau Padang Rumput > \nKlik 'Buat peningkatan' (di atas tetapan pilihan unit, kiri bawah)\n > Pilih ladang > \n Biarkan pekerja di sana sehingga selesai
+Create a trade route!\nConstruct roads between your capital and another city\nOr, automate your worker and let him get to that eventually = Buat laluan perdagangan! \nBina jalan antara ibu kota anda dan bandar lain\nAtau, automasikan pekerja anda dan biarkan dia buat demikian akhirnya
+Conquer a city!\nBring an enemy city down to low health > \nEnter the city with a melee unit = Taklukkan bandar! \nSerang bandar musuh ke tahap kesihatan yang rendah > \nMasuk ke bandar dengan unit tempur jarak dekat
 Move an air unit!\nSelect an air unit > select another city within range > \nMove the unit to the other city = Pindahkan unit udara! \nPilih unit udara > pilih bandar lain dalam sasaran berdekatan > \nPindahkan unit ke bandar lain
 See your stats breakdown!\nEnter the Overview screen (top right corner) >\nClick on 'Stats' = Lihat perincian statistik anda! \nMasuk ke skrin Gambaran Keseluruhan (sudut kanan atas) > \nKlik pada 'Stat'
-
  # Requires translation!
-Oh no! It looks like something went DISASTROUSLY wrong! This is ABSOLUTELY not supposed to happen! Please send me (yairm210@hotmail.com) an email with the game information (menu -> save game -> copy game info -> paste into email) and I'll try to fix it as fast as I can! = 
+Oh no! It looks like something went DISASTROUSLY wrong! This is ABSOLUTELY not supposed to happen! Please send me (yairm210@hotmail.com) an email with the game information (menu -> save game -> copy game info -> paste into email) and I'll try to fix it as fast as I can! = Alamak! Nampaknya ada yang SANGAT TIDAK KENA! Isu ini MEMANG tidak sepatutnya berlaku! Sila hantarkan emel kepada saya (yairm210@hotmail.com) dengan maklumat permainan (menu -> simpan permainan -> salin maklumat permainan -> tampal dalam emel) dan saya akan cuba membetulkan isu ini dengan secepat mungkin!
  # Requires translation!
-Oh no! It looks like something went DISASTROUSLY wrong! This is ABSOLUTELY not supposed to happen! Please send us an report and we'll try to fix it as fast as we can! = 
-
+Oh no! It looks like something went DISASTROUSLY wrong! This is ABSOLUTELY not supposed to happen! Please send us an report and we'll try to fix it as fast as we can! = Alamak! Nampaknya ada yang SANGAT TIDAK KENA! Isu ini MEMANG tidak sepatutnya berlaku! Sila laporkan kepada kami dan kami akan cuba membetulkan isu ini dengan secepat mungkin!
 # Buildings
-
  # Requires translation!
-Unsellable = 
+Unsellable = Tidak terjual
  # Requires translation!
-Not displayed as an available construction unless [building] is built = 
+Not displayed as an available construction unless [building] is built = Tidak dipaparkan sebagai pembinaan yang ada melainkan [building] sudah dibina
  # Requires translation!
-Not displayed as an available construction without [resource] = 
-
-Choose a free great person = Pilih orang hebat yang tidak kerja
+Not displayed as an available construction without [resource] = Tidak dipaparkan sebagai pembinaan yang ada tampa [resource]
+Choose a free great person = Pilih seorang wira bebas
 Get [unitName] = Dapatkan [unitName]
-
 Hydro Plant = Loji Hidro
-[buildingName] obsoleted = [buildingName] lapuk
-
+[buildingName] obsoleted = [buildingName] diusangkan
 # Diplomacy,Trade,Nations
-
 Requires [buildingName] to be built in the city = Memerlukan [buildingName] dibina di bandar
 Requires [buildingName] to be built in all cities = Memerlukan [buildingName] dibina di semua bandar
 Provides a free [buildingName] in the city = Menyediakan [buildingName] percuma di bandar
-Requires worked [resource] near city = Memerlukan [resource] berhampiran bandar
+Requires worked [resource] near city = Memerlukan [resource] yang berfungsi berhampiran bandar
  # Requires translation!
-Requires at least one of the following resources worked near the city: = 
-Wonder is being built elsewhere = Wonder sedang dibina di tempat lain
+Requires at least one of the following resources worked near the city: = Memerlukan sekurang-kurangnya satu daripada sumber-sumber berikutan difungsikan berhampiran bandar
+Wonder is being built elsewhere = Keajaiban sedang dibina di tempat lain
  # Requires translation!
-National Wonder is being built elsewhere = 
+National Wonder is being built elsewhere = Keajaiban Kebangsaan sedang dibina di tempat lain
 Requires a [buildingName] in all cities = Memerlukan [buildingName] di semua bandar
- # Requires translation!
-[buildingName] required: = 
 Requires a [buildingName] in this city = Memerlukan [buildingName] di bandar ini
  # Requires translation!
-Cannot be built with [buildingName] = 
+Cannot be built with [buildingName] = Tidak boleh dibina dengan [buildingName]
 Consumes 1 [resource] = Menggunakan 1 [resource]
 Consumes [amount] [resource] = Menggunakan [amount] [resource]
 Required tech: [requiredTech] = Teknologi yang diperlukan: [requiredTech]
 Requires [PolicyOrNationalWonder] = Memerlukan [PolicyOrNationalWonder]
 Cannot be purchased = Tidak boleh dibeli
  # Requires translation!
-Can only be purchased = 
+Can only be purchased = Hanya boleh dibeli
  # Requires translation!
-See also = 
-
+See also = Lihat juga
  # Requires translation!
-Requires at least one of the following: = 
+Requires at least one of the following: = Memerlukan sekurang-kurangnya satu daripada yang berikut
  # Requires translation!
-Requires all of the following: = 
+Requires all of the following: = Memerlukan semua yang berikut
  # Requires translation!
-Leads to [techName] = 
+Leads to [techName] = Membawa kepada [techName]
  # Requires translation!
-Leads to: = 
-
-Current construction = Pembinaan terkini
+Leads to: = Membawa kepada
+Current construction = Pembinaan semasa
 Construction queue = Aturan pembinaan
 Pick a construction = Pilih pembinaan
 Queue empty = Aturan kosong
@@ -98,402 +69,249 @@ Remove from queue = Buang daripada aturan
 Show stats drilldown = Tunjukkan paparan statistik
 Show construction queue = Tunjuk aturan pembinaan
  # Requires translation!
-Save = 
+Save = Simpan
  # Requires translation!
-Cancel = 
-
+Cancel = Batal
  # Requires translation!
-Diplomacy = 
+Diplomacy = Diplomasi
  # Requires translation!
-War = 
+War = Perang
  # Requires translation!
-Peace = 
+Peace = Keamanan
 Research Agreement = Perjanjian Penyelidikan
 Declare war = Isytiharkan perang
 Declare war on [civName]? = Isytiharkan perang keatas [civName]?
  # Requires translation!
-Let's begin! = 
-[civName] has declared war on us! = [civName] telah mengisytiharkan perang pada kita
+Let's begin! = Mari kita mulakan!
+[civName] has declared war on us! = [civName] telah mengisytiharkan perang pada kami
 [leaderName] of [nation] = [leaderName] dari [nation]
 You'll pay for this! = Bersedialah untuk serangan balas!
-Negotiate Peace = Berunding keamanan
+Negotiate Peace = Runding keamanan
 Peace with [civName]? = Beraman dengan [civName]?
 Very well. = Baiklah.
 Farewell. = Selamat tinggal.
 Sounds good! = Bagus juga!
-Not this time. = Bukan sekarang
+Not this time. = Bukan sekarang.
 Excellent! = Bagus!
 How about something else... = Mungkin benda lain...
-A pleasure to meet you. = Selamat berkenalan
+A pleasure to meet you. = Selamat berkenalan.
 Our relationship = Hubungan kita
  # Requires translation!
-We have encountered the City-State of [name]! = 
-Declare Friendship ([numberOfTurns] turns) = Isytihar Persahabatan ([numberOfTurns] pusingan)
-May our nations forever remain united! = Harap negara ini kekal bersatu selamanya
-Indeed! = Sesungguhnya
+We have encountered the City-State of [name]! = Kami bertemu dengan Negara Kota [name]!
+Declare Friendship ([numberOfTurns] turns) = Isytihar Persahabatan ([numberOfTurns] giliran)
+May our nations forever remain united! = Harap negara kita kekal bersatu selamanya!
+Indeed! = Sesungguhnya!
  # Requires translation!
-Denounce [civName]? = 
-Denounce ([numberOfTurns] turns) = Kecam ([numberOfTurns] pusingan)
-We will remember this. = Tungu ko ak bagi tau mak aku
-
+Denounce [civName]? = Kecam [civName]?
+Denounce ([numberOfTurns] turns) = Kecam ([numberOfTurns] giliran)
+We will remember this. = Kami akan ingat peristiwa ini.
  # Requires translation!
-[civName] has declared war on [targetCivName]! = 
+[civName] has declared war on [targetCivName]! = [civName] telah mengisytiharkan perang pada [targetCivName]!
  # Requires translation!
-[civName] and [targetCivName] have signed a Peace Treaty! = 
+[civName] and [targetCivName] have signed a Peace Treaty! = [civName] dan [targetCivName] telah menandatangani Perjanjian Damai!
  # Requires translation!
-[civName] and [targetCivName] have signed the Declaration of Friendship! = 
+[civName] and [targetCivName] have signed the Declaration of Friendship! = [civName] dan [targetCivName] telah menandatangani Pengisytiharan Persahabatan!
  # Requires translation!
-[civName] has denounced [targetCivName]! = 
+[civName] has denounced [targetCivName]! = [civName] telah mengecam [targetCivName]!
  # Requires translation!
-Do you want to break your promise to [leaderName]? = 
+Do you want to break your promise to [leaderName]? = Adakah anda ingin memungkirkan janji anda kepada [leaderName]?
  # Requires translation!
-We promised not to settle near them ([count] turns remaining) = 
+We promised not to settle near them ([count] turns remaining) = Kami berjanji tidak akan tetap berhampiran mereka (baki [count] giliran)
  # Requires translation!
-They promised not to settle near us ([count] turns remaining) = 
-
- # Requires translation!
-[civName] is upset that you demanded tribute from [cityState], whom they have pledged to protect! = 
- # Requires translation!
-[civName] is upset that you attacked [cityState], whom they have pledged to protect! = 
- # Requires translation!
-[civName] is outraged that you destroyed [cityState], whom they had pledged to protect! = 
- # Requires translation!
-[civName] has destroyed [cityState], whom you had pledged to protect! = 
-
+They promised not to settle near us ([count] turns remaining) = Mereka berjanji tidak akan tetap berhampiran kami (baki [count] giliran)
 Unforgivable = Tidak dapat dimaafkan
- # Requires translation!
-Afraid = 
 Enemy = Musuh
-Competitor = Persaingan
-Neutral = Neutral
+Competitor = Pesaingan
+Neutral = Berkecuali
 Favorable = Disukai
 Friend = Kawan
 Ally = Pakatan
-
  # Requires translation!
-[questName] (+[influenceAmount] influence) = 
+[questName] (+[influenceAmount] influence) = [questName] (+[influenceAmount] pengaruhan)
  # Requires translation!
-[remainingTurns] turns remaining = 
- # Requires translation!
-Current leader is [civInfo] with [amount] [stat] generated. = 
- # Requires translation!
-Current leader is [civInfo] with [amount] Technologies discovered. = 
-
+[remainingTurns] turns remaining = Baki [remainingTurns] giliran
 ## Diplomatic modifiers
-
-You declared war on us! = Kamu isytihar perang pada saya
-Your warmongering ways are unacceptable to us. = asyik perang ja ko kimak
-You have captured our cities! = Kamu tawan bandar kami
-We applaud your liberation of our conquered cities! = wa anda bebas kn kami tq brutha
-We applaud your liberation of conquered cities! = anda bebas kn kami anda mmg bff kami
-Years of peace have strengthened our relations. = Keamanan bertahun-tahun telah menguatkan hubungan kita.
-Our mutual military struggle brings us closer together. = ko sama mcm ak serabut nk perang jom jdi member 
-We have signed a public declaration of friendship = yo kami kawan lol
-You have declared friendship with our enemies! = Ko nk damai sma musuh
-You have declared friendship with our allies = damai sma teman
-Our open borders have brought us closer together. = buka celana nya
-Your so-called 'friendship' is worth nothing. = kata member tpi tikam belakang
-You have publicly denounced us! = Kamu telah mengutuk kami secara awam!
-You have denounced our allies = Kamu telah kutuk pakatan kamu
-You have denounced our enemies = Kamu telah kutuk musuh kamu
-You betrayed your promise to not settle cities near us = kata tak nak buat bandar dekat ii babi
-You fulfilled your promise to stop settling cities near us! = wa baik nya anda tak buat bandar dekat ngn kitorg
-You refused to stop settling cities near us = ko degil nak juga buat banda dekat ii gay ke sial
-Your arrogant demands are in bad taste = amboi amboi bnyk songeh ye mampus anda
-Your use of nuclear weapons is disgusting! = oi main bom bom pulak cibai
-You have stolen our lands! = Kamu telah curi tanah kami! 
+You declared war on us! = Kamu mengisytiharkan perang pada saya!
+Your warmongering ways are unacceptable to us. = Cara peperangan kamu tidak diterima oleh kami.
+You have captured our cities! = Kamu tawan bandar-bandar kami!
+We applaud your liberation of our conquered cities! = Kami memuji pembebasan anda bandar kami yang ditakluki!
+We applaud your liberation of conquered cities! = Kami memuji pembebasan anda bandar yang ditakluki!
+Years of peace have strengthened our relations. = Keamanan bertahun-tahunan telah menguatkan hubungan kita.
+Our mutual military struggle brings us closer together. = Perjuangan ketenteraan kita yang sama telah mendekatkan hubungan kita.
+We have signed a public declaration of friendship = Kita telah menandatangani pengisytiharan persahabatan awam
+You have declared friendship with our enemies! = Kamu mengisytiharkan persahabatan dengan musuh kami!
+You have declared friendship with our allies = Kamu mengisytiharkan persahabatan dengan pakatan kami
+Our open borders have brought us closer together. = Sempadan terbuka kita telah mendekatkan hubungan kita.
+Your so-called 'friendship' is worth nothing. = Persahabatan kamu kononnya tidak bernilai.
+You have publicly denounced us! = Kamu telah mengecam kami secara awam!
+You have denounced our allies = Kamu telah mengecam pakatan kami
+You have denounced our enemies = Kamu telah mengecam musuh kami
+You betrayed your promise to not settle cities near us = Kamu telah mengkhianati janji tidak tetapkan bandar berhampiran kami
+You fulfilled your promise to stop settling cities near us! = Kamu memenuhi janji tidak tetapkan bandar berhampiran kami!
+You refused to stop settling cities near us = Kamu enggan berhenti menetapkan bandar berhampiran kami
+Your arrogant demands are in bad taste = Tuntutan sombong kamu tidak disenangi kami
+Your use of nuclear weapons is disgusting! = Penggunaan senjata nuklear kamu sangat menjijikan!
+You have stolen our lands! = Kamu telah curi tanah kami!
  # Requires translation!
-You gave us units! = 
- # Requires translation!
-You destroyed City States that were under our protection! = 
- # Requires translation!
-You attacked City States that were under our protection! = 
- # Requires translation!
-You demanded tribute from City States that were under our protection! = 
- # Requires translation!
-You sided with a City State over us = 
- # Requires translation!
-You returned captured units to us = 
-
+You gave us units! = Kamu beri kami unit!
 Demands = Permintaan
 Please don't settle new cities near us. = Tolong jangan menetap berdekatan bandar kami
-Very well, we shall look for new lands to settle. = yela yela kitorang bla
-We shall do as we please. = mampus la asal sebok
-We noticed your new city near our borders, despite your promise. This will have....implications. = aik kata tak nak buat da butoh la janji melayu
- # Requires translation!
-I've been informed that my armies have taken tribute from [civName], a city-state under your protection.\nI assure you, this was quite unintentional, and I hope that this does not serve to drive us apart. = 
- # Requires translation!
-We asked [civName] for a tribute recently and they gave in.\nYou promised to protect them from such things, but we both know you cannot back that up. = 
- # Requires translation!
-It's come to my attention that I may have attacked [civName], a city-state under your protection.\nWhile it was not my goal to be at odds with your empire, this was deemed a necessary course of action. = 
- # Requires translation!
-I thought you might like to know that I've launched an invasion of one of your little pet states.\nThe lands of [civName] will make a fine addition to my own. = 
-
- # Requires translation!
-Return [unitName] to [civName]? = 
- # Requires translation!
-The [unitName] we liberated originally belonged to [civName]. They will be grateful if we return it to them. = 
-
- # Requires translation!
-Enter the amount of gold = 
+Very well, we shall look for new lands to settle. = Baiklah, kami akan menerokai tanah baru untuk ditetapkan.
+We shall do as we please. = Kami buat sesuka hati kami.
+We noticed your new city near our borders, despite your promise. This will have....implications. = Kami perhatikan bandar baru kamu berhampiran dengan sempadan kami walaupun janji kami. Tindakan kamu ada....implikasi.
 
 # City-States
 
  # Requires translation!
-Provides [amountOfCulture] culture at 30 Influence = 
+Provides [amountOfCulture] culture at 30 Influence = Menyediakan [amountOfCulture] budaya di 30 Pengaruhan
  # Requires translation!
-Provides 3 food in capital and 1 food in other cities at 30 Influence = 
+Provides 3 food in capital and 1 food in other cities at 30 Influence = Menyediakan 3 makanan di ibu negara dan 1 makanan di bandar-bandar yang lain di 30 Pengaruhan
  # Requires translation!
-Provides 3 happiness at 30 Influence = 
+Provides 3 happiness at 30 Influence = Menberikan 3 kegembiraan di 30 Pengaruhan
  # Requires translation!
-Provides land units every 20 turns at 30 Influence = 
+Provides land units every 20 turns at 30 Influence = Menyediakan tentera darat setip 20 giliran di 30 Pengaruhan
  # Requires translation!
-Give a Gift = 
+Give a Gift = Memberikan Hadiah
  # Requires translation!
-Gift [giftAmount] gold (+[influenceAmount] influence) = 
+Gift [giftAmount] gold (+[influenceAmount] influence) = Memberikan [giftAmount] emas (+[influenceAmount] pengaruhan)
  # Requires translation!
-Relationship changes in another [turnsToRelationshipChange] turns = 
+Relationship changes in another [turnsToRelationshipChange] turns = Hubungan ubah dalam [turnsToRelationshipChange] giliran
  # Requires translation!
-Protected by = 
+Protected by = Dilindungi
  # Requires translation!
-Revoke Protection = 
+Revoke Protection = Batalkan perlindungan
  # Requires translation!
-Pledge to protect = 
+Pledge to protect = Janji perlindungan
  # Requires translation!
-Declare Protection of [cityStateName]? = 
+Declare Protection of [cityStateName]? = Isytiharkan perlindungan [cityStateName]?
  # Requires translation!
-Build [improvementName] on [resourceName] (200 Gold) = 
+Build [improvementName] on [resourceName] (200 Gold) = Bina [improvementName] pada [resourceName] (200 Emas)
  # Requires translation!
-Gift Improvement = 
- # Requires translation!
-[civName] is able to provide [unitName] once [techName] is researched. = 
+Gift Improvement = Peningkatan Hadiah
 
- # Requires translation!
-Diplomatic Marriage ([amount] Gold) = 
- # Requires translation!
-We have married into the ruling family of [civName], bringing them under our control. = 
- # Requires translation!
-[civName] has married into the ruling family of [civName2], bringing them under their control. = 
- # Requires translation!
-You have broken your Pledge to Protect [civName]! = 
- # Requires translation!
-City-States grow wary of your aggression. The resting point for Influence has decreased by [amount] for [civName]. = 
 
+Cultured = Berbudaya
+Maritime = Maritim
  # Requires translation!
-[cityState] is being attacked by [civName] and asks all major civilizations to help them out by gifting them military units. = 
+Mercantile = Perdagangan
  # Requires translation!
-[cityState] is being invaded by Barbarians! Destroy Barbarians near their territory to earn Influence. = 
- # Requires translation!
-[cityState] is grateful that you killed a Barbarian that was threatening them! = 
- # Requires translation!
-[cityState] is being attacked by [civName]! Kill [amount] of the attacker's military units and they will be immensely grateful. = 
- # Requires translation!
-[cityState] is deeply grateful for your assistance in the war against [civName]! = 
- # Requires translation!
-[cityState] no longer needs your assistance against [civName]. = 
- # Requires translation!
-War against [civName] = 
- # Requires translation!
-We need you to help us defend against [civName]. Killing [amount] of their military units would slow their offensive. = 
- # Requires translation!
-Currently you have killed [amount] of their military units. = 
- # Requires translation!
-You need to find them first! = 
-
-Cultured = budaya bangsa
-Maritime = maritim
- # Requires translation!
-Mercantile = 
- # Requires translation!
-Militaristic = 
+Militaristic = Ketenteraan
 Type = Jenis
-Friendly = aman
-Hostile = tak aman ni
+Friendly = Ramah
+Hostile = Bermusuhan
  # Requires translation!
-Irrational = 
-Personality = personaliti
-Influence = hasutan
-Reach 30 for friendship. = nk jadi member kne la ad 30 point boss kur
-Reach highest influence above 60 for alliance. = 60 pulak la 30 buat pa
- # Requires translation!
-When Friends: = 
- # Requires translation!
-When Allies: = 
- # Requires translation!
-The unique luxury is one of: = 
-
- # Requires translation!
-Demand Tribute = 
- # Requires translation!
-Tribute Willingness = 
- # Requires translation!
-At least 0 to take gold, at least 30 and size 4 city for worker = 
- # Requires translation!
-Major Civ = 
- # Requires translation!
-No Cities = 
- # Requires translation!
-Base value = 
- # Requires translation!
-Has Ally = 
- # Requires translation!
-Has Protector = 
- # Requires translation!
-Demanding a Worker = 
- # Requires translation!
-Demanding a Worker from small City-State = 
- # Requires translation!
-Very recently paid tribute = 
- # Requires translation!
-Recently paid tribute = 
- # Requires translation!
-Influence below -30 = 
- # Requires translation!
-Military Rank = 
- # Requires translation!
-Military near City-State = 
- # Requires translation!
-Sum: = 
- # Requires translation!
-Take [amount] gold (-15 Influence) = 
- # Requires translation!
-Take worker (-50 Influence) = 
- # Requires translation!
-[civName] is afraid of your military power! = 
-
+Irrational = Tidak rational
+Personality = Personaliti
+Influence = Pengaruhan
+Reach 30 for friendship. = Capai 30 untuk persahabatan.
+Reach highest influence above 60 for alliance. = Capai pengaruhan tertinggi melebihi 60 untuk pakatan
 
 # Trades
 
-Trade = Dagang
-Offer trade = Tawar dagang
+Trade = Perdagangan
+Offer trade = Tawar perdagangan
 Retract offer = Tarik balik tawaran
-What do you have in mind? = ap dlm otak ko 
-Our items = barang kami
-Our trade offer = kita punya tawar dagang
+What do you have in mind? = Apa yang ada dalam fikiran anda?
+Our items = Barang kami
+Our trade offer = Tawaran perdaganan kami
  # Requires translation!
-[otherCiv]'s trade offer = 
+[otherCiv]'s trade offer = Tawaran perdagangan [otherCiv]
  # Requires translation!
-[otherCiv]'s items = 
- # Requires translation!
-+[amount] untradable copy = 
- # Requires translation!
-+[amount] untradable copies = 
-Pleasure doing business with you! = nice anda pling nice
-I think not. = Mampus
+[otherCiv]'s items = Barang [otherCiv]
+Pleasure doing business with you! = Kami gembira berdagang dengan kamu!
+I think not. = Saya rasa tidak.
 That is acceptable. = Ini boleh diterima.
-Accept = nak
+Accept = Terima
 Keep going = Teruskan
-There's nothing on the table = takde ap kat meja
-Peace Treaty = Triti Keamanan
-Agreements = setuju
-Open Borders = Buka Sempadan
-Gold per turn = Emas setiap pusingan
+There's nothing on the table = Tiada apa-apa dalam tawaran
+Peace Treaty = Perjanjian Damai
+Agreements = Perjanjian
+Open Borders = Sempadan Terbuka
+Gold per turn = Emas setiap giliran
 Cities = Bandar
 Technologies = Teknologi
 Declarations of war = Pengisytiharan perang
  # Requires translation!
-Introduction to [nation] = 
-Declare war on [nation] = Isytihar perang pada [nation]
+Introduction to [nation] = Pengenalan kepada [nation]
+Declare war on [nation] = Isytiharkan perang pada [nation]
  # Requires translation!
-Luxury resources = 
+Luxury resources = Sumber mewah
  # Requires translation!
-Strategic resources = 
+Strategic resources = Sumber strategik
  # Requires translation!
-Owned: [amountOwned] = 
-
+Owned: [amountOwned] = Dimiliki: [amountOwned]
 # Nation picker
-
  # Requires translation!
-[resourceName] not required = 
-Lost ability = hilang kemampuan
-National ability = kemampuan kebangsaan 
+[resourceName] not required = [resourceName] tidak diperlukan
+Lost ability = Hilang kemampuan
+National ability = Kemampuan kebangsaan
  # Requires translation!
-[firstValue] vs [secondValue] = 
-
-
+[firstValue] vs [secondValue] = [firstValue] lawan [secondValue]
 # New game screen
-
-Uniques = Unik
+Uniques = Keunikan
 Promotions = Promosi
  # Requires translation!
-Load copied data = 
-Could not load game from clipboard! = tak bole load game kat clipboard asu
- # Requires translation!
-Reset to defaults = 
- # Requires translation!
-Are you sure you want to reset all game options to defaults? = 
-Start game! = Ayuh!!
-Map Options = option peta
-Game Options = option game
-Civilizations = Peradaban
+Load copied data = Memuatkan data yang disalin
+Could not load game from clipboard! = Tidak dapat memuatkan permainan dari 'clipboard'!
+Start game! = Mulakan permainan!
+Map Options = Pilihan Peta
+Game Options = Pilihan Permainan
+Civilizations = Tamadun
 Map Type = Jenis Peta
 Map file = Fail Peta
  # Requires translation!
-Could not load map! = 
+Could not load map! = Tidak dapat memuatkan peta!
+Generated = Dihasilkan
+Existing = Yang sedia ada
+Custom = Dibuat khas
  # Requires translation!
-Invalid map: Area ([area]) does not match saved dimensions ([dimensions]). = 
+Map Generation Type = Jenis Penghasilan Peta
+Default = Asal
+Pangaea = Pangea
  # Requires translation!
-The dimensions have now been fixed for you. = 
-Generated = generate
-Existing = yang ada
-Custom = custom
- # Requires translation!
-Map Generation Type = 
-Default = Biasa
-Pangaea = Pangaea
- # Requires translation!
-Perlin = 
+Perlin = 'Perlin'
 Continents = Benua
  # Requires translation!
-Four Corners = 
+Four Corners = Empat Penjuru
 Archipelago = Kepulauan
- # Requires translation!
-Inner Sea = 
-Number of City-States = jumlah bandar
-One City Challenge = anda pro main satu bandar jela
-No Barbarians = x de org barbar
- # Requires translation!
-Raging Barbarians = 
-No Ancient Ruins = tak de tingalan purba
-No Natural Wonders = tak de keajaiban dunia
+Number of City-States = Jumlah Negara Kota
+One City Challenge = Cabaran Bandar Tunggal
+No Barbarians = Tiada Orang Barbar
+No Ancient Ruins = Tiada Runtuhan Purba
+No Natural Wonders = Tiada Keajaiban Dunia
 Victory Conditions = Syarat Kemenangan
 Scientific = Saintifik
 Domination = Dominasi
  # Requires translation!
-Cultural = 
- # Requires translation!
-Diplomatic = 
-
+Cultural = Kebudayaan
 Map Shape = Bentuk Peta
-Hexagonal = heksagon
-Rectangular = petak kot
+Hexagonal = Heksagon
+Rectangular = Segi Empat Tepat
  # Requires translation!
-Height = 
+Height = Ketinggian
  # Requires translation!
-Width = 
+Width = Kelebaran
  # Requires translation!
-Radius = 
+Radius = Jejari
  # Requires translation!
-Enable Religion = 
-
+Enable Religion = Aktifkan Agama
  # Requires translation!
-Advanced Settings = 
+Advanced Settings = Tetapan Lanjutan
  # Requires translation!
-RNG Seed = 
-Map Elevation = ketingian peta
-Temperature extremeness = panas ke tak 
-Resource richness = kekayaan hasil
-Vegetation richness = kekayaan sayur sayur
+RNG Seed = Benih Penjana Nombor Rawak
+Map Height = Ketinggian Peta
+Temperature extremeness = Keterlaluan suhu
+Resource richness = Kekayaan sumber
+Vegetation richness = Kekayaan flora
  # Requires translation!
-Rare features richness = 
+Rare features richness = Kekayaan ciri-ciri jarang
  # Requires translation!
-Max Coast extension = 
+Max Coast extension = Peluasan Pantai Maximum
  # Requires translation!
-Biome areas extension = 
-Water level = paras air
-
-Online Multiplayer = multi player online
-
+Biome areas extension = Peluasan kawasan bioma
+Water level = Paras air
+Reset to default = Tetapkan semula ke asal
+Online Multiplayer = Multipemain dalam Talian
 World Size = Saiz Dunia
 Tiny = Mikro
 Small = Kecil
@@ -501,1776 +319,1506 @@ Medium = Sederhana
 Large = Besar
 Huge = Gergasi
  # Requires translation!
-World wrap requires a minimum width of 32 tiles = 
+World wrap requires a minimum width of 32 tiles = Balut dunia memerlukan sekurang-kurangnya 32 jubin kelebaran
  # Requires translation!
-The provided map dimensions were too small = 
+The provided map dimensions were too small = Dimensi peta yang diberikan terlalu kecil
  # Requires translation!
-The provided map dimensions were too big = 
+The provided map dimensions were too big = Dimensi peta yang diberikan tertalu besar
  # Requires translation!
-The provided map dimensions had an unacceptable aspect ratio = 
-
+The provided map dimensions had an unacceptable aspect ratio = Dimensi peta yang diberikan mempunyai nisbah aspek yang tidak diterima
 Difficulty = Kesukaran
-
 AI = AI
 Remove = Buang
 Random = Rawak
 Human = Manusia
  # Requires translation!
-Hotseat = 
+Hotseat = Hotseat
 User ID = ID Pengguna
 Click to copy = Tekan untuk salin
-
-
-Game Speed = kelajuan permainan
-Quick = cepat
-Standard = biasa
-Epic = epic
-Marathon = speedrun
-
-Starting Era = era pemulaan
-It looks like we can't make a map with the parameters you requested! = hmmm tak bole buat map ni la sori
-Maybe you put too many players into too small a map? = banyak nya player asu map kecik ja
-No human players selected! = Spe yg nak main nya
-Mods: = mod
+Game Speed = Kelajuan Permainan
+Quick = Cepat
+Standard = Biasa
+Epic = Epik
+Marathon = Maraton
+Starting Era = Era Permulaan
+It looks like we can't make a map with the parameters you requested! = Nampaknya kita tidak dapat menghasilkan peta mengikuti parameter yang diberikan!
+Maybe you put too many players into too small a map? = Mungkin anda memberikan terlalu banyak pemain dalam peta yang terlalu kecil?
+No human players selected! = Tiada pemain manusia terpilih!
+Mods: = Mod:
  # Requires translation!
-Extension mods: = 
+Base ruleset mods: = Mod peraturan asas:
  # Requires translation!
-Base ruleset: = 
+Extension mods: = Mod tambahan:
  # Requires translation!
-The mod you selected is incorrectly defined! = 
+Base Ruleset = Peraturan Asas
  # Requires translation!
-The mod combination you selected is incorrectly defined! = 
+[amount] Techs = [amount] Teknologi
  # Requires translation!
-The mod combination you selected has problems. = 
+[amount] Nations = [amount] Bangsa
  # Requires translation!
-You can play it, but don't expect everything to work! = 
+[amount] Units = [amount] Unit
  # Requires translation!
-This base ruleset is not compatible with the previously selected\nextension mods. They have been disabled. = 
+[amount] Buildings = [amount] Bangunan
  # Requires translation!
-Base Ruleset = 
+[amount] Resources = [amount] Sumber
  # Requires translation!
-[amount] Techs = 
+[amount] Improvements = [amount] Peningkatan
  # Requires translation!
-[amount] Nations = 
+[amount] Religions = [amount] Agama
  # Requires translation!
-[amount] Units = 
- # Requires translation!
-[amount] Buildings = 
- # Requires translation!
-[amount] Resources = 
- # Requires translation!
-[amount] Improvements = 
- # Requires translation!
-[amount] Religions = 
- # Requires translation!
-[amount] Beliefs = 
+[amount] Beliefs = [amount] Kepercayaan
 
  # Requires translation!
-World Wrap = 
+World Wrap = Balut Dunia
  # Requires translation!
-World wrap maps are very memory intensive - creating large world wrap maps on Android can lead to crashes! = 
+World wrap maps are very memory intensive - creating large world wrap maps on Android can lead to crashes! = Peta balut dunia amat intensif memorinya - penjanaan peta balut dunia yang besar di Android boleh puncakan ketidakresponsi sistem!
  # Requires translation!
-Anything above 80 by 50 may work very slowly on Android! = 
+Anything above 80 by 50 may work very slowly on Android! = Apa-apa di atas 80 dari 50 boleh menyebabkan kelambatan di sistem Android!
  # Requires translation!
-Anything above 40 may work very slowly on Android! = 
+Anything above 40 may work very slowly on Android! = Apa-apa di atas 40 boleh menyebabkan kelambatan di sistem Android!
 
 # Multiplayer
 
 Username = Nama pengguna
-Multiplayer = multipalyer
+Multiplayer = Multipemain
  # Requires translation!
-Could not download game! = 
+Could not download game! = Tidak dapat muat turun permainan!
  # Requires translation!
-Could not upload game! = 
-Join game = join permianan
-Invalid game ID! = id tak btol
-Copy user ID = salin id penguna
-Copy game ID = salin id permainan
-UserID copied to clipboard = dah salin
-GameID copied to clipboard = dah salin
-Set current user = set penguna
+Could not upload game! = Tidak dapat muat naik permainan!
+Join game = Sertai permianan
+Invalid game ID! = ID permainan tidak sah!
+Copy user ID = Salin ID penguna
+Copy game ID = Salin ID permainan
+UserID copied to clipboard = ID Pengguna disalin
+GameID copied to clipboard = ID Permainan disalin
+Set current user = Set pengguna semasa
  # Requires translation!
-Player ID from clipboard = 
+Player ID from clipboard = ID Pemain dari 'clipboard'
  # Requires translation!
-To create a multiplayer game, check the 'multiplayer' toggle in the New Game screen, and for each human player insert that player's user ID. = 
+To create a multiplayer game, check the 'multiplayer' toggle in the New Game screen, and for each human player insert that player's user ID. = Untuk memulakan permainan multipemain, semak togol 'multipemain' di skrin Permainan Baru, dan masukkan ID pemain untuk setiap pemain manusia.
  # Requires translation!
-You can assign your own user ID there easily, and other players can copy their user IDs here and send them to you for you to include them in the game. = 
+You can assign your own user ID there easily, and other players can copy their user IDs here and send them to you for you to include them in the game. = Anda boleh memyediakan ID pengguna sendiri di sana dengan mudah, dan pemain lain boleh salin ID penggunanya dan hantar kepada anda untuk dimasukkan di dalam permainan.
  # Requires translation!
-Once you've created your game, the Game ID gets automatically copied to your clipboard so you can send it to the other players. = 
+Once you've created your game, the Game ID gets automatically copied to your clipboard so you can send it to the other players. = Setelah permainan anda dimulakan, ID Permainan akan disalin ke 'clipboard' anda secara automatik supaya anda boleh hantarkannya kepada pemain lain.
  # Requires translation!
-Players can enter your game by copying the game ID to the clipboard, and clicking on the 'Add multiplayer game' button = 
+Players can enter your game by copying the game ID to the clipboard, and clicking on the 'Add multiplayer game' button =
  # Requires translation!
-The symbol of your nation will appear next to the game when it's your turn = 
-Back = balik
-Rename = tukar nama
-Game settings = setting permainan
-Add multiplayer game = tambah multipalyer
-Refresh list = refresh
-Could not save game! = tak bole save asu
-Could not delete game! = tak bole delete
+The symbol of your nation will appear next to the game when it's your turn = Simbol bangsa anda akan muncul sebelah permainan apabila ia merupakan giliran anda
+Back = Balik
+Rename = Tukar nama
+Game settings = Tetapan permainan
+Add multiplayer game = Tambah multipemain
+Refresh list = Refresh
+Could not save game! = Tidak dapat simpan permainan!
+Could not delete game! = Tidak dapat padam permainan!
  # Requires translation!
-Could not refresh! = 
+Could not refresh! = Tidak dapat 'refresh'!
  # Requires translation!
-Last refresh: [time] minutes ago = 
-Current Turn: = turn sekarang
+Last refresh: [time] minutes ago = 'Refresh' terakhir: [time] minit yang lalu
+Current Turn: = Giliran sekarang
  # Requires translation!
-Add Currently Running Game = 
-Game name = nama permainan
+Add Currently Running Game = Tambah Permainan yang sedang Dijalankan
+Game name = Nama permainan
  # Requires translation!
-Loading latest game state... = 
+Loading latest game state... = Muatkan keadaan permainan terkini
  # Requires translation!
-Couldn't download the latest game state! = 
+Couldn't download the latest game state! = Tidak dapat muat turun keadaan permainan terkini!
  # Requires translation!
-Resign = 
+Resign = Serah kalah
  # Requires translation!
-Are you sure you want to resign? = 
+Are you sure you want to resign? = Adakah anda pasti ingin menyerah kalah?
  # Requires translation!
-You can only resign if it's your turn = 
+You can only resign if it's your turn = Anda hanya boleh menyerah kalah dalam giliran anda
  # Requires translation!
-[civName] resigned and is now controlled by AI = 
- # Requires translation!
-Last refresh: [time] [timeUnit] ago = 
- # Requires translation!
-Current Turn: [civName] since [time] [timeUnit] ago = 
- # Requires translation!
-Minutes = 
- # Requires translation!
-Hours = 
- # Requires translation!
-Days = 
-
+[civName] resigned and is now controlled by AI = [civName] menyerah kalah dan sekarang dikawal oleh AI
 # Save game menu
-
-Current saves = simpanan skarng
-Show autosaves = tunjuk auto save
-Saved game name = nama permainan yg disimpan
-Copy to clipboard = salin 
+Current saves = Simpanan semasa
+Show autosaves = Tunjuk simpanan auto
+Saved game name = Nama permainan yang disimpan
+Copy to clipboard = Salin
  # Requires translation!
-Copy saved game to clipboard = 
-Could not load game = x bole lo
+Copy saved game to clipboard = Salin permainan disimpan
+Could not load game = Tidak dapat muatkan permainan
  # Requires translation!
-Load [saveFileName] = 
-Delete save = buang simpanan
-Saved at = simpan di
+Load [saveFileName] = Muatkan [saveFileName]
+Delete save = Padam simpanan
+Saved at = Simpan di
  # Requires translation!
-Load map = 
-Delete map = buang map
-Are you sure you want to delete this map? = sries a nak buang jgn nyesal
+Load map = Muatkan peta
+Delete map = Padam peta
+Are you sure you want to delete this map? = Adakah anda panti ingin memadamkan peta ini?
  # Requires translation!
-Upload map = 
+Upload map = Muat naikkan peta
  # Requires translation!
-Could not upload map! = 
+Could not upload map! = Tidak dapat muat naik peta!
  # Requires translation!
-Map uploaded successfully! = 
-Saving... = tgh save..
-Overwrite existing file? = sries ganti yang ni
+Map uploaded successfully! = Peta berjaya dimuat-naikkan
+Saving... = Sedang disimpan...
+Overwrite existing file? = Ganti fail yang sedia ada?
  # Requires translation!
-It looks like your saved game can't be loaded! = 
+It looks like your saved game can't be loaded! = Nampaknya permainan yang disimpan tidak dapat dimuatkan!
  # Requires translation!
-If you could copy your game data ("Copy saved game to clipboard" -  = 
+If you could copy your game data ("Copy saved game to clipboard" -  = Kalau anda dapat menyalinkan maklumat permainan anda ("Salin permainan disimpan ke 'clipboard'" -
  # Requires translation!
-  paste into an email to yairm210@hotmail.com) = 
+  paste into an email to yairm210@hotmail.com) = tampalnya di emel kepada yairm210@hotmail.com)
  # Requires translation!
-I could maybe help you figure out what went wrong, since this isn't supposed to happen! = 
+I could maybe help you figure out what went wrong, since this isn't supposed to happen! = Mungkin saya boleh tolong anda untuk memikirkan apa-apa yang berlaku, sebab isu ini tidak patut berlaku!
  # Requires translation!
-Missing mods: [mods] = 
+Missing mods: [mods] = Mod hilang: [mods]
  # Requires translation!
-Load from custom location = 
+Load from custom location = Muat dari lokasi dibuat-khas
  # Requires translation!
-Could not load game from custom location! = 
+Could not load game from custom location! = Tidak dapat muatkan permainan dari lokasi dibuat-khas!
  # Requires translation!
-Save to custom location = 
+Save to custom location = Simpan di lokasi dibuat-khas
  # Requires translation!
-Could not save game to custom location! = 
-
+Could not save game to custom location! = Tidak dapat simpankan permainan di lokasi dibuat-khas!
 # Options
-
  # Requires translation!
-Options = 
+Options = Pilihan
  # Requires translation!
-About = 
+Display options = Pilihan paparan
  # Requires translation!
-Display = 
+Gameplay options = Pilihan permainan
  # Requires translation!
-Gameplay = 
+Other options = Pilihan lain
  # Requires translation!
-Sound = 
+Turns between autosaves = Giliran antara simpanan auto
+Sound effects volume = Kelantangan suara
+Music volume = Kelantangan muzik
+Download music = Muat turun muzik
+Downloading... = Sedang dimuat-turunkan...
+Could not download music! = Tidak dapat memuat-turunkan muzik!
+Show = Tunjuk
+Hide = Sembunyi
+Show worked tiles = Tunjuk jubin yang berfungsi
  # Requires translation!
-Advanced = 
+Show resources and improvements = Tunjuk sumber dan peningkatan
+Check for idle units = Semak unit yang terbiar
+Move units with a single tap = Gerak unit dengan seketik
+Show tutorials = Tunjuk tutorial
  # Requires translation!
-Locate mod errors = 
+Auto-assign city production = Tugaskan pengeluaran bandar secara automatik
+Auto-build roads = Bina jalan secara automatik
  # Requires translation!
-Debug = 
-
+Automated workers replace improvements = Pekerja automatik gantikan peningkatan
+Show minimap = Tunjuk peta mini
  # Requires translation!
-See online Readme = 
+off = Padamkan
+Show pixel units = Tunjuk unit piksel
  # Requires translation!
-Turns between autosaves = 
-Sound effects volume = bunyi efek
-Music volume = bunyi lagu
+Show pixel improvements = Tunjuk peningkatan piksel
+Enable nuclear weapons = Membolehkan senjata nuklear
  # Requires translation!
-Pause between tracks = 
+Fontset = Fon huruf
  # Requires translation!
-Currently playing: [title] = 
-Download music = download lagu
-Downloading... = sabar ya asu
-Could not download music! = tak bole la
-Show = tunjuk
-Hide = sorok
-Show worked tiles = tunjuk yg dah dibina
+Show tile yields = Tunjuk hasil jubin
  # Requires translation!
-Show resources and improvements = 
-Check for idle units = cek unit yg duk diam
-Move units with a single tap = gerak kan unit dgn tekan skali jA
-Show tutorials = tunjuk kan tutorial
+Continuous rendering = Rendering berterusan
+When disabled, saves battery life but certain animations will be suspended = Bila ditutup, hayat bateri dijimatkan tetapi sesetengah animasi akan digantung
  # Requires translation!
-Auto-assign city production = 
-Auto-build roads = buat jalan auto
+Order trade offers by amount = Pesan tawaran perdagangan mengikut jumlah
  # Requires translation!
-Automated workers replace improvements = 
-Show minimap = tunjuk map kecil
+Show experimental world wrap for maps = Tunjuk balut dunia percubaan untuk peta
+HIGHLY EXPERIMENTAL - YOU HAVE BEEN WARNED! = PERKEMBANGAN MASIH AWAL - ANDA TELAH DIBERI AMARAN!
  # Requires translation!
-off = 
-Show pixel units = tunjuk unit 
+HIGHLY EXPERIMENTAL - UPDATES WILL BREAK SAVES! = PERKEMBANGAN MASIH AWAL - KEMASKINI AKAN MENGGANGGUKAN SALINAN!
  # Requires translation!
-Show pixel improvements = 
-Enable nuclear weapons = on senjata nuklear
+Enable portrait orientation = Membolehkan orientasi potret
  # Requires translation!
-Show tile yields = 
+Generate translation files = Bina fail terjemahan
  # Requires translation!
-Continuous rendering = 
-When disabled, saves battery life but certain animations will be suspended = bila di tututp jimat bateri tapi perfomance hmmm
+Translation files are generated successfully. = Fail terjemahan berjana dibina
  # Requires translation!
-Order trade offers by amount = 
- # Requires translation!
-Check extension mods based on vanilla = 
- # Requires translation!
-Checking mods for errors... = 
- # Requires translation!
-Show experimental world wrap for maps = 
-HIGHLY EXPERIMENTAL - YOU HAVE BEEN WARNED! = ni masih  eksperimen klo rosak mampus anda
- # Requires translation!
-Enable portrait orientation = 
- # Requires translation!
-Generate translation files = 
- # Requires translation!
-Translation files are generated successfully. = 
- # Requires translation!
-Please note that translations are a community-based work in progress and are INCOMPLETE! The percentage shown is how much of the language is translated in-game. If you want to help translating the game into your language, click here. = 
-
+Locate mod errors = Cari ralat mod
 # Notifications
-
  # Requires translation!
-Research of [technologyName] has completed! = 
+Research of [technologyName] has completed! = Penyelidikan [technologyName] telah selesai!
  # Requires translation!
-[construction] has become obsolete and was removed from the queue in [cityName]! = 
+[construction] has become obsolete and was removed from the queue in [cityName]! = [construction] telah menjadi usang dan dibatalkan dari aturan di [cityName]!
  # Requires translation!
-[construction] has become obsolete and was removed from the queue in [amount] cities! = 
+[construction] has become obsolete and was removed from the queue in [amount] cities! = [construction] telah menjadi usang dan dibatalkan dari aturan di [amount] bandar!
  # Requires translation!
-[cityName] changed production from [oldUnit] to [newUnit] = 
+[cityName] changed production from [oldUnit] to [newUnit] = [cityName] menukarkan pengeluaran dari [oldUnit] ke [newUnit]
  # Requires translation!
-[amount] cities changed production from [oldUnit] to [newUnit] = 
+[amount] cities changed production from [oldUnit] to [newUnit] = [amount] bandar menukarkan pengeluaran dari [oldUnit] ke [newUnit]
  # Requires translation!
-Excess production for [wonder] converted to [goldAmount] gold = 
+Excess production for [wonder] converted to [goldAmount] gold = Pengeluaran berlebihan untuk [wonder] ditukarkan ke [goldAmount] emas
  # Requires translation!
-You have entered a Golden Age! = 
+You have entered a Golden Age! = Anda berada dalam Zaman Kegemilangan!
  # Requires translation!
-[resourceName] revealed near [cityName] = 
+[resourceName] revealed near [cityName] = [resourceName] terjumpa berhampiran [cityName]
  # Requires translation!
-[n] sources of [resourceName] revealed, e.g. near [cityName] = 
+[n] sources of [resourceName] revealed, e.g. near [cityName] = [n] sumber [resourceName] terjumpa, misalnya berhampiran [cityName]
  # Requires translation!
-A [greatPerson] has been born in [cityName]! = 
+A [greatPerson] has been born in [cityName]! = Seorang [greatPerson] dilahirkan di [cityName]!
  # Requires translation!
-We have encountered [civName]! = 
+We have encountered [civName]! = Kami bertembung dengan [civName]
  # Requires translation!
-[cityStateName] has given us [stats] as a token of goodwill for meeting us = 
+[cityStateName] has given us [stats] as a token of goodwill for meeting us = [cityStateName] memberikan kami [stats] sebagai tanda muhibah kerana bertembung dengan kami
  # Requires translation!
-[cityStateName] has given us [stats] as we are the first major civ to meet them = 
+[cityStateName] has given us [stats] as we are the first major civ to meet them = [cityStateName] memberikan kami [stats] kerana kami tamadun utama pertama yang bertembung dengan mereka
  # Requires translation!
-[cityStateName] has also given us [stats] = 
+Cannot provide unit upkeep for [unitName] - unit has been disbanded! = Tidak dapat memelihara unit untuk [unitName] - unit telah dibubarkan!
  # Requires translation!
-Cannot provide unit upkeep for [unitName] - unit has been disbanded! = 
+[cityName] has grown! = [cityName] telah bertumbuh!
  # Requires translation!
-[cityName] has grown! = 
+[cityName] is starving! = [cityName] sedang mengalami kelaparan!
  # Requires translation!
-[cityName] is starving! = 
+[construction] has been built in [cityName] = [construction] dibina di [cityName]
  # Requires translation!
-[construction] has been built in [cityName] = 
+[wonder] has been built in a faraway land = [wonder] dibina di suatu tempat yang jauh
  # Requires translation!
-[wonder] has been built in a faraway land = 
+[civName] has completed [construction]! = [civName] telah siap membina [construction]!
  # Requires translation!
-[civName] has completed [construction]! = 
+An unknown civilization has completed [construction]! = Sebuah tamadun yang tiak diketahui telah siap membina [construction]!
  # Requires translation!
-An unknown civilization has completed [construction]! = 
+The city of [cityname] has started constructing [construction]! = Bandar [cityname] mula membina [construction]!
  # Requires translation!
-The city of [cityname] has started constructing [construction]! = 
+[civilization] has started constructing [construction]! = [civilization] mula membina [construction]!
  # Requires translation!
-[civilization] has started constructing [construction]! = 
+An unknown civilization has started constructing [construction]! = Sebuah tamadun yang tidak diketahui mula membina [construction]!
  # Requires translation!
-An unknown civilization has started constructing [construction]! = 
+Work has started on [construction] = Kerja pembinaan [construction] dimulakan
  # Requires translation!
-Work has started on [construction] = 
+[cityName] cannot continue work on [construction] = [cityName] tidak dapat meneruskan kerja pembinaan [construction]
  # Requires translation!
-[cityName] cannot continue work on [construction] = 
+[cityName] has expanded its borders! = [cityName] telah mengembangkan sempadannya!
  # Requires translation!
-[cityName] has expanded its borders! = 
+Your Golden Age has ended. = Zaman Kegemilangan anda telah tamat.
  # Requires translation!
-Your Golden Age has ended. = 
+[cityName] has been razed to the ground! = [cityName] telah dirobohkan!
  # Requires translation!
-[cityName] has been razed to the ground! = 
+We have conquered the city of [cityName]! = Kami telah menakluki bandar [cityName]!
  # Requires translation!
-We have conquered the city of [cityName]! = 
+An enemy [unit] has attacked [cityName] = Sebuah [unit] musuh telah menyerangi [cityName]
  # Requires translation!
-An enemy [unit] has attacked [cityName] = 
+An enemy [unit] has attacked our [ourUnit] = Sebuah [unit] musuh telah menyerangi [ourUnit]
  # Requires translation!
-An enemy [unit] has attacked our [ourUnit] = 
+Enemy city [cityName] has attacked our [ourUnit] = Bandar musuh [cityName] telah menyerangi [ourUnit] kami
  # Requires translation!
-Enemy city [cityName] has attacked our [ourUnit] = 
+An enemy [unit] has captured [cityName] = Sebuah [unit] musuh telah menawankan [cityName]
  # Requires translation!
-An enemy [unit] has captured [cityName] = 
+An enemy [unit] has captured our [ourUnit] = Sebuah [unit] musuh telah menangkap [ourUnit] kami
  # Requires translation!
-An enemy [unit] has raided [cityName] = 
+An enemy [unit] has destroyed our [ourUnit] = Sebuah [unit] musuh telah memusnahkan [ourUnit] kami
  # Requires translation!
-An enemy [unit] has captured our [ourUnit] = 
+Your [ourUnit] has destroyed an enemy [unit] = [ourUnit] anda telah memusnahkan sebuah [unit] musuh
  # Requires translation!
-An enemy [unit] has destroyed our [ourUnit] = 
+An enemy [RangedUnit] has destroyed the defence of [cityName] = Sebuah [RangedUnit] musuh telah memusnahkan pertahanan [cityName]
  # Requires translation!
-Your [ourUnit] has destroyed an enemy [unit] = 
+Enemy city [cityName] has destroyed our [ourUnit] = Bandar musuh [cityName] telah memusnahkan [ourUnit] kami
  # Requires translation!
-An enemy [RangedUnit] has destroyed the defence of [cityName] = 
+An enemy [unit] was destroyed while attacking [cityName] = Sebuah [unit] musuh dimusnahkan semasa menyerangi [cityName]
  # Requires translation!
-Enemy city [cityName] has destroyed our [ourUnit] = 
+An enemy [unit] was destroyed while attacking our [ourUnit] = Sebuah [unit] musuh dimusnahkan semasa menyerangi [ourUnit]
  # Requires translation!
-An enemy [unit] was destroyed while attacking [cityName] = 
+Our [attackerName] was destroyed by an intercepting [interceptorName] = [attackerName] kami dimusnahkan oleh [interceptorName] memintas
  # Requires translation!
-An enemy [unit] was destroyed while attacking our [ourUnit] = 
+Our [interceptorName] intercepted and destroyed an enemy [attackerName] = [interceptorName] kami telah memintas dan memusnahkan [attackerName] musuh
  # Requires translation!
-Our [attackerName] was destroyed by an intercepting [interceptorName] = 
+Our [attackerName] was attacked by an intercepting [interceptorName] = [attackerName] kami diserangi oleh [interceptorName] memintas
  # Requires translation!
-Our [interceptorName] intercepted and destroyed an enemy [attackerName] = 
+Our [interceptorName] intercepted and attacked an enemy [attackerName] = [interceptorName] kami telah memintas dan menyerangi [attackerName] musuh
  # Requires translation!
-Our [attackerName] was attacked by an intercepting [interceptorName] = 
+An enemy [unit] was spotted near our territory = Sebuah [unit] musuh terjumpa berhampiran kawasan kami
  # Requires translation!
-Our [interceptorName] intercepted and attacked an enemy [attackerName] = 
+An enemy [unit] was spotted in our territory = Sebuah [unit] musuh terjumpa di dalam kawasan kami
  # Requires translation!
-An enemy [unit] was spotted near our territory = 
+[amount] enemy units were spotted near our territory = [amount] unit musuh terjumpa berhampiran kawasan kami
  # Requires translation!
-An enemy [unit] was spotted in our territory = 
+[amount] enemy units were spotted in our territory = [amount] unit musuh terjumpa di dalam kawasan kami
  # Requires translation!
-Your city [cityName] can bombard the enemy! = 
+A(n) [nukeType] exploded in our territory! = [nukeType] terletup di dalam kawasan kami!
  # Requires translation!
-[amount] of your cities can bombard the enemy! = 
+After being hit by our [nukeType], [civName] has declared war on us! = Selepas terkena [nukeType] kami, [civName] mengisytiharkan perang pada kami!
  # Requires translation!
-[amount] enemy units were spotted near our territory = 
+The civilization of [civName] has been destroyed! = Tamadun [civName] telah dijatuhkan!
  # Requires translation!
-[amount] enemy units were spotted in our territory = 
+The City-State of [name] has been destroyed! = Negara Kota [name] telah dimusnahkan!
  # Requires translation!
-A(n) [nukeType] exploded in our territory! = 
+Your [ourUnit] captured an enemy [theirUnit]! = [ourUnit] anda telah menangkap [theirUnit] musuh!
  # Requires translation!
-After being hit by our [nukeType], [civName] has declared war on us! = 
+Your [ourUnit] plundered [amount] [Stat] from [theirUnit] = [ourUnit] anda telah menjalah [amount] [Stat] daripada [theirUnit]
  # Requires translation!
-The civilization of [civName] has been destroyed! = 
+We have captured a barbarian encampment and recovered [goldAmount] gold! = Kami telah menangkapkan sebuah kem barbar dan memulihkan [goldAmount] emas!
  # Requires translation!
-The City-State of [name] has been destroyed! = 
+A barbarian [unitType] has joined us! = Sebuah [unitType] barbar telah menyertai kami!
  # Requires translation!
-Your [ourUnit] captured an enemy [theirUnit]! = 
+We have found survivors in the ruins - population added to [cityName] = Kami terjumpa mangsa yang selamat di runtuhan purba - populasi ditambahkan di [cityName]
  # Requires translation!
-Your [ourUnit] plundered [amount] [Stat] from [theirUnit] = 
+We have discovered cultural artifacts in the ruins! (+20 Culture) = Kami terjumpa artifak budaya di runtuhan purba! (+20 Budaya)
  # Requires translation!
-We have captured a barbarian encampment and recovered [goldAmount] gold! = 
+We have discovered the lost technology of [techName] in the ruins! = Kami terjumpa teknologi [techName] yang telah hilang di runtuhan purba!
  # Requires translation!
-A barbarian [unitType] has joined us! = 
+A [unitName] has joined us! = Sebuah [unitName] menyertai kami!
  # Requires translation!
-We have found survivors in the ruins - population added to [cityName] = 
+An ancient tribe trains our [unitName] in their ways of combat! = Sebuah suku kuno melatih [unitName] kami cara pertempuran mereka!
  # Requires translation!
-We have discovered cultural artifacts in the ruins! (+20 Culture) = 
+We have found a stash of [amount] gold in the ruins! = Kami terjumpa harta bernilai [amount] emas di runtuhan purba!
  # Requires translation!
-We have discovered the lost technology of [techName] in the ruins! = 
+We have found a crudely-drawn map in the ruins! = Kami terjumpa sebuah peta yang dilukis dengan kasar di runtuhan purba!
  # Requires translation!
-A [unitName] has joined us! = 
+[unit] finished exploring. = [unit] telah siap penerokaan.
  # Requires translation!
-An ancient tribe trains our [unitName] in their ways of combat! = 
+[unit] has no work to do. = [unit] tiada kerja untuk dijalankan.
  # Requires translation!
-We have found a stash of [amount] gold in the ruins! = 
+You're losing control of [name]. = Anda hilang kawalan [name].
  # Requires translation!
-We have found a crudely-drawn map in the ruins! = 
+You and [name] are no longer friends! = Anda dan [name] tidak lagi berkawan!
  # Requires translation!
-[unit] finished exploring. = 
+Your alliance with [name] is faltering. = Pakatan anda dengan [name] semakin berkurangan.
  # Requires translation!
-[unit] has no work to do. = 
+You and [name] are no longer allies! = Kamu dan [name] tidak lagi berpakatan!
  # Requires translation!
-You're losing control of [name]. = 
+[civName] gave us a [unitName] as gift near [cityName]! = [civName] memberikan kami [unitName] berhampiran [cityName] sebagai hadiah!
  # Requires translation!
-You and [name] are no longer friends! = 
+[civName] has denounced us! = [civName] telah mengecam kami!
  # Requires translation!
-Your alliance with [name] is faltering. = 
+[cityName] has been connected to your capital! = [cityName] telah dihubungkan dengan ibu negara anda!
  # Requires translation!
-You and [name] are no longer allies! = 
+[cityName] has been disconnected from your capital! = [cityName] tiada lagi dihubungkan dengan ibu negara anda!
  # Requires translation!
-[civName] gave us a [unitName] as gift near [cityName]! = 
+[civName] has accepted your trade request = [civName] terima permintaan perdagangan anda
  # Requires translation!
-[civName] has denounced us! = 
+[civName] has denied your trade request = [civName] tolah permintaan perdagangan anda
  # Requires translation!
-[cityName] has been connected to your capital! = 
+[tradeOffer] from [otherCivName] has ended = [tradeOffer] daripada [otherCivName] ditamatkan
  # Requires translation!
-[cityName] has been disconnected from your capital! = 
+[tradeOffer] to [otherCivName] has ended = [tradeOffer] kepada [otherCivName] ditamatkan
  # Requires translation!
-[civName] has accepted your trade request = 
+One of our trades with [nation] has ended = Salah satu perdagangan kami dengan [nation] ditamatkan
  # Requires translation!
-[civName] has made a counteroffer to your trade request = 
+One of our trades with [nation] has been cut short = Salah satu perdagangan kami dengan [nation] dipotong pendek
  # Requires translation!
-[civName] has denied your trade request = 
+[nation] agreed to stop settling cities near us! = [nation] janji untuk hentikan penempatan bandar berhampiran kami!
  # Requires translation!
-[tradeOffer] from [otherCivName] has ended = 
+[nation] refused to stop settling cities near us! = [nation] tolak permintaan kami untuk hentikan penempatan bandar berhampiran kami!
  # Requires translation!
-[tradeOffer] to [otherCivName] has ended = 
+We have allied with [nation]. = Kami berpakatan dengan [nation].
  # Requires translation!
-One of our trades with [nation] has ended = 
+We have lost alliance with [nation]. = Kami hilang pakatan dengan [nation].
  # Requires translation!
-One of our trades with [nation] has been cut short = 
+We have discovered [naturalWonder]! = Kami terjumpa [naturalWonder]!
  # Requires translation!
-[nation] agreed to stop settling cities near us! = 
+We have received [goldAmount] Gold for discovering [naturalWonder] = Kami menerima [goldAmount] Emas sebab terjumpa [naturalWonder]
  # Requires translation!
-[nation] refused to stop settling cities near us! = 
+Your relationship with [cityStateName] is about to degrade = Hubungan kami dengan [cityStateName] hampir rosot
  # Requires translation!
-We have allied with [nation]. = 
+Your relationship with [cityStateName] degraded = Hubungan kami dengan [cityStateName] telah rosot
  # Requires translation!
-We have lost alliance with [nation]. = 
+A new barbarian encampment has spawned! = Sebuah kem barbar baru terbentuk!
  # Requires translation!
-We have discovered [naturalWonder]! = 
+Received [goldAmount] Gold for capturing [cityName] = Terima [goldAmount] Emas sebab menawankan [cityName]
  # Requires translation!
-We have received [goldAmount] Gold for discovering [naturalWonder] = 
+Our proposed trade is no longer relevant! = Perdagangan cadangan kami tidak lagi relevan!
  # Requires translation!
-Your relationship with [cityStateName] is about to degrade = 
+[defender] could not withdraw from a [attacker] - blocked. = [defender] tidak sempat menarik diri daripada [attacker] - disekat.
  # Requires translation!
-Your relationship with [cityStateName] degraded = 
+[defender] withdrew from a [attacker] = [defender] menarik diri daripada [attacker]
  # Requires translation!
-A new barbarian encampment has spawned! = 
+[building] has provided [amount] Gold! = [building] menyediakan [amount] Emas!
  # Requires translation!
-Barbarians raided [cityName] and stole [amount] Gold from your treasury! = 
+[civName] has stolen your territory! = Kawasan kami dicuri [civName]!
  # Requires translation!
-Received [goldAmount] Gold for capturing [cityName] = 
+Clearing a [forest] has created [amount] Production for [cityName] = Pembersihan [forest] memberikan [amount] pengeluaran kepada [cityName]
  # Requires translation!
-Our proposed trade is no longer relevant! = 
+[civName] assigned you a new quest: [questName]. = [civName] memberikan anda sebuah tugas baru: [questName].
  # Requires translation!
-[defender] could not withdraw from a [attacker] - blocked. = 
+[civName] rewarded you with [influence] influence for completing the [questName] quest. = [civName] memberikan [influence] pengaruhan sebagai ganjaran menunaikan tugas [questName].
  # Requires translation!
-[defender] withdrew from a [attacker] = 
+The resistance in [cityName] has ended! = Pemberontakan di [cityName] telah tamat!
  # Requires translation!
-By expending your [unit] you gained [Stats]! = 
+Our [name] took [tileDamage] tile damage and was destroyed = [name] kami dikena [tileDamage] kerosakan jubin dan dimusnahkan
  # Requires translation!
-[civName] has stolen your territory! = 
+Our [name] took [tileDamage] tile damage = [name] kami dikena [tileDamage] kerosakan jubin
  # Requires translation!
-Clearing a [forest] has created [amount] Production for [cityName] = 
+[civName] has adopted the [policyName] policy = [civName] telah mengamalkan polisi [policyName]
  # Requires translation!
-[civName] assigned you a new quest: [questName]. = 
+An unknown civilization has adopted the [policyName] policy = Sebuah tamadun yang tidak diketahui telah mengamalkan policy [policyName]
  # Requires translation!
-[civName] rewarded you with [influence] influence for completing the [questName] quest. = 
- # Requires translation!
-[civName] no longer needs your help with the [questName] quest. = 
- # Requires translation!
-The [questName] quest for [civName] has ended. It was won by [civNames]. = 
- # Requires translation!
-The resistance in [cityName] has ended! = 
- # Requires translation!
-[cityName] demands [resource]! = 
- # Requires translation!
-Because they have [resource], the citizens of [cityName] are celebrating We Love The King Day! = 
- # Requires translation!
-We Love The King Day in [cityName] has ended. = 
- # Requires translation!
-Our [name] took [tileDamage] tile damage and was destroyed = 
- # Requires translation!
-Our [name] took [tileDamage] tile damage = 
- # Requires translation!
-[civName] has adopted the [policyName] policy = 
- # Requires translation!
-An unknown civilization has adopted the [policyName] policy = 
- # Requires translation!
-Our influence with City-States has started dropping faster! = 
- # Requires translation!
-You gained [Stats] as your religion was spread to [cityName] = 
- # Requires translation!
-You gained [Stats] as your religion was spread to an unknown city = 
- # Requires translation!
-Your city [cityName] was converted to [religionName]! = 
- # Requires translation!
-Your [unitName] lost its faith after spending too long inside enemy territory! = 
- # Requires translation!
-You have unlocked [ability] = 
- # Requires translation!
-A new b'ak'tun has just begun! = 
- # Requires translation!
-A Great Person joins you! = 
-
+Our influence with City-States has started dropping faster! = Pengaruhan kami dengan negara-negara kota sedang merosot!
 
 # World Screen UI
 
-Working... = sedang berkerja sabar
-Waiting for other players... = Tungu palyer lain
+Working... = Sedang bekerja...
+Waiting for other players... = Tunggu pemain lain...
  # Requires translation!
-Waiting for [civName]... = 
+in = di
+Next turn = Giliran seterusnya
  # Requires translation!
-in = 
-Next turn = pusingan seterusnya
+[currentPlayerCiv] ready? = [currentPlayerCiv] sedia?
+1 turn = 1 giliran
  # Requires translation!
-Move automated units = 
- # Requires translation!
-[currentPlayerCiv] ready? = 
-1 turn = pusingan
- # Requires translation!
-[numberOfTurns] turns = 
-Turn = pusingan
-turns = pusingan
-turn = pusingan
-Next unit = unit sterusnya
-Fog of War = kabus tebal
+[numberOfTurns] turns = [numberOfTurns] giliran
+Turn = Giliran
+turns = giliran
+turn = giliran
+Next unit = Unit sterusnya
+Fog of War = Kabut Perang
 Pick a policy = Pilih polisi
-Movement = Gerakkan
+Movement = Pergerakan
 Strength = Kekuatan
-Ranged strength = kekuatab jarak jauh
-Bombard strength = kekuatan bom
-Range = jarak jauh
-Move unit = gerakkan unit
-Stop movement = berhenti
+Ranged strength = Kekuatan jarak jauh
+Bombard strength = Kekuatan pengebom
+Range = Jarak
+Move unit = Gerakkan unit
+Stop movement = Berhenti
  # Requires translation!
-Swap units = 
+Swap units = Tukarkan unit
  # Requires translation!
-Construct improvement = 
-Automate = gerak sndri
-Stop automation = berhenti gerak sndri
-Construct road = buat jalan
-Fortify = bertahan
-Fortify until healed = bertahan hinga sembuh
+Construct improvement = Bina peningkatan
+Automate = Automatikkan
+Stop automation = Hentikan automasi
+Construct road = Bina jalan
+Fortify = Benteng
+Fortify until healed = Benteng hingga sembuh
  # Requires translation!
-Fortification = 
-Sleep = Tidur
-Sleep until healed = tidur smpai sihat
-Moving = sdang bergerak
-Set up = set
+Fortification = Perkubuan
+Sleep = Rehat
+Sleep until healed = Rehat hingga sembuh
+Moving = Sedang bergerak
+Set up = Tubuhkan
  # Requires translation!
-Paradrop = 
+Paradrop = Payung terjun
  # Requires translation!
-Upgrade to [unitType] ([goldCost] gold) = 
-Found city = asas bandar
-Promote = promot
-Health = nyawa
-Disband unit = mamapus kau
-Do you really want to disband this unit? = sries nk mmpus kn ini anjing
+Upgrade to [unitType] ([goldCost] gold) = Naik taraf ke [unitType] ([goldCost] emas)
+Found city = Asaskan bandar
+Promote = Naik pangkat
+Health = Kesihatan
+Disband unit = Bubarkan unit
+Do you really want to disband this unit? = Adakah anda ingin membubarkan unit ini?
  # Requires translation!
-Disband this unit for [goldAmount] gold? = 
+Disband this unit for [goldAmount] gold? = Bubarkan unit ini untuk [goldAmount] emas?
  # Requires translation!
-Gift unit = 
-Explore = Jelajah
-Stop exploration = berhenti jelajah
-Pillage = rompak
+Gift unit = Unit hadiah
+Explore = Teroka
+Stop exploration = Henti penerokaan
+Pillage = Rompak
  # Requires translation!
-Are you sure you want to pillage this [improvement]? = 
+Are you sure you want to pillage this [improvement]? = Adakah anda pasti ingin merompak [improvement] ini?
  # Requires translation!
-Create [improvement] = 
-Start Golden Age = mulakan zaman kegemilangan
+Create [improvement] = Bina [improvement]
+Start Golden Age = Mulakan Zaman Kegemilangan
  # Requires translation!
-Show more = 
-Yes = yela gial
-No = Tak nak la
+Show more = Tunjuk lebih banyak
+Yes = Betul
+No = Tidak
  # Requires translation!
-Acquire = 
-Under construction = sedang dibina
+Acquire = Perolehi
+Under construction = Sedang dibina
 
 Food = Makanan
-Production = Pembuatan
+Production = Pengeluaran
 Gold = Emas
 Happiness = Kegembiraan
 Culture = Budaya
 Science = Sains
  # Requires translation!
-Faith = 
+Faith = Kepercayaan
 
  # Requires translation!
-Crop Yield = 
+Crop Yield = Hasil Tanaman
  # Requires translation!
-Territory = 
+Territory = Kawasan
 Force = Kekuatan
-GOLDEN AGE = zaman kegemilangan
-Golden Age = zaman kegemilangan
- # Requires translation!
-We Love The King Day = 
-[year] BC = [year] sebelum Masihi
-[year] AD = [year] selepas Masihi
-Civilopedia = kamus civ
+GOLDEN AGE = ZAMAN KEGEMILANGAN
+Golden Age = Zaman Kegemilangan
+[year] BC = [year] Sebelum Masihi
+[year] AD = [year] Selepas Masihi
+Civilopedia = Civilopedia
 
-Start new game = mula kan permainan baru
-Save game = simpan
-Load game = load
-Main menu = menu
-Resume = teruskan
-Cannot resume game! = tak bole teruskan asu
+Start new game = Mula permainan baru
+Save game = Simpan permainan
+Load game = Muat permainan
+Main menu = Menu utama
+Resume = Teruskan
+Cannot resume game! = Tidak dapat teruskan permainan!
  # Requires translation!
-Not enough memory on phone to load game! = 
- # Requires translation!
-Quickstart = 
- # Requires translation!
-Cannot start game with the default new game parameters! = 
+Not enough memory on phone to load game! = Tidak cukup memori dalam telefon bimbit untuk memuatkan permainan!
+Quickstart = Permulaan pantas
 Victory status = Status kemenangan
 Social policies = Polisi sosial
 Community = Komuniti
  # Requires translation!
-Close = 
-Do you want to exit the game? = sries a nak bla dah awallagi ni
+Close = Tutup
+Do you want to exit the game? = Adakah anda ingin menutupkan permainan?
  # Requires translation!
-Start bias: = 
+Start bias: = Bias permulaan:
  # Requires translation!
-Avoid [terrain] = 
-
-# Maya calendar popup
-
- # Requires translation!
-The Mayan Long Count = 
- # Requires translation!
-Your scientists and theologians have devised a systematic approach to measuring long time spans - the Long Count. During the festivities whenever the current b'ak'tun ends, a Great Person will join you. = 
- # Requires translation!
-While the rest of the world calls the current year [year], in the Maya Calendar that is: = 
- # Requires translation!
-[amount] b'ak'tun, [amount2] k'atun, [amount3] tun = 
+Avoid [terrain] = Elakkan [terrain]
 
 # City screen
 
-Exit city = back
-Raze city = hancur kan bandar
-Stop razing city = berhenti
+Exit city = Keluar bandar
+Raze city = Robohkan bandar
+Stop razing city = Henti robohkan bandar
  # Requires translation!
-Buy for [amount] gold = 
+Buy for [amount] gold = Beli dengan [amount] emas
 Buy = Beli
  # Requires translation!
-Currently you have [amount] [stat]. = 
+Currently you have [amount] gold. = Sekarang anda mempunyai [amount] emas.
  # Requires translation!
-Would you like to purchase [constructionName] for [buildingGoldCost] [stat]? = 
+Would you like to purchase [constructionName] for [buildingGoldCost] gold? = Adakah anda ingin beli [constructionName] dengan [buildingGoldCost] emas?
  # Requires translation!
-No space available to place [unit] near [city] = 
-Maintenance cost = kos menten
-Pick construction = pilih kontruksi
-Pick improvement = pilih kenaik tarafan
+No space available to place [unit] near [city] = Tiada ruang untuk menetapkan [unit] berhampiran [city]
+Maintenance cost = Kos penyelenggaraan
+Pick construction = Pilih pembinaan
+Pick improvement = Pilih peningkatan
  # Requires translation!
-Provides [resource] = 
+Provides [resource] = Sediakan [resource]
  # Requires translation!
-Provides [amount] [resource] = 
+Provides [amount] [resource] = Sediakan [amount] [resource]
  # Requires translation!
-Replaces [improvement] = 
-Pick now! = pilih skarang!!
+Replaces [improvement] = Gantikan [improvement]
+Pick now! = Pilih sekarang!
 Build [building] = Bina [building]
  # Requires translation!
-Train [unit] = 
+Train [unit] = Latih [unit]
  # Requires translation!
-Produce [thingToProduce] = 
-Nothing = tak de ape
+Produce [thingToProduce] = Hasil [thingToProduce]
+Nothing = Tiada apa-apa
  # Requires translation!
-Annex city = 
-Specialist Buildings = bagunan spesial
+Annex city = Ilhakkan bandar
+Specialist Buildings = Bangunan Pakar
  # Requires translation!
-Specialist Allocation = 
-Specialists = ahli special
+Specialist Allocation = Peruntukan Pakar
+Specialists = Pakar
  # Requires translation!
-[specialist] slots = 
+[specialist] slots = Slot [specialist]
  # Requires translation!
-Food eaten = 
-Growth bonus = bonus pembesran
-Unassigned population = populasi yg tolol
+Food eaten = Makanan dijamu
+Growth bonus = Bonus pertumbuhan
+Unassigned population = Populasi yg tidak ditugaskan
  # Requires translation!
-[turnsToExpansion] turns to expansion = 
-Stopped expansion = berhenti pembesaran
+[turnsToExpansion] turns to expansion = [turnsToExpansion] giliran ke perkembangan
+Stopped expansion = Henti perkembangan
  # Requires translation!
-[turnsToPopulation] turns to new population = 
-Food converts to production = tukar makanan ke produksi
+[turnsToPopulation] turns to new population = [turnsToPopulation] giliran ke populasi baru
+Food converts to production = Makanan ditukarkan ke pengeluaran
  # Requires translation!
-[turnsToStarvation] turns to lose population = 
-Stopped population growth = henti pembesaran populasi
+[turnsToStarvation] turns to lose population = [turnsToStarvation] giliran ke kehilangan populasi
+Stopped population growth = Henti pertumbuhan populasi
  # Requires translation!
-In resistance for another [numberOfTurns] turns = 
+In resistance for another [numberOfTurns] turns = Dalam pemberontakan selama [numberOfTurns] giliran lagi
  # Requires translation!
-We Love The King Day for another [numberOfTurns] turns = 
+Sell for [sellAmount] gold = Jual untuk [sellAmount] emas
  # Requires translation!
-Demanding [resource] = 
+Are you sure you want to sell this [building]? = Adakah anda pasti ingin menjualkan [building] ini?
  # Requires translation!
-Sell for [sellAmount] gold = 
+[greatPerson] points = Mata [greatPerson]
+Great person points = Mata wira
+Current points = Mata semasa
+Points per turn = Mata setiap giliran
  # Requires translation!
-Are you sure you want to sell this [building]? = 
+Convert production to gold at a rate of 4 to 1 = Tukarkan pengeluaran ke emas dalam kadar 4 hingga 1
  # Requires translation!
-Free = 
+Convert production to science at a rate of [rate] to 1 = Tukarkan pengeluaran ke sains dalam kadar [rate] hingga 1
+The city will not produce anything. = Bandar tidak akan menghasilkan apa-apa.
  # Requires translation!
-[greatPerson] points = 
-Great person points = point orang jago
-Current points = point sekarang
-Points per turn = point setiap turn
- # Requires translation!
-Convert production to gold at a rate of 4 to 1 = 
- # Requires translation!
-Convert production to science at a rate of [rate] to 1 = 
-The city will not produce anything. = bandar tak hasil kan apa apa
- # Requires translation!
-Worked by [cityName] = 
-Lock = kunci
-Unlock = un-kunci
-Move to city = pegi ke bandar
- # Requires translation!
-Please enter a new name for your city = 
-
-# Ask for text or numbers popup UI
-
- # Requires translation!
-Invalid input! Please enter a different string. = 
- # Requires translation!
-Please enter some text = 
+Worked by [cityName] = Dikerjakan oleh [cityName]
+Lock = Kuncikan
+Unlock = Sediakan
+Move to city = Gerak ke bandar
 
 # Technology UI
 
-Pick a tech = pilih teknologi
-Pick a free tech = pilih teknologi free
+Pick a tech = Pilih teknologi
+Pick a free tech = Pilih teknologi percuma
  # Requires translation!
-Research [technology] = 
+Research [technology] = Selidik [technology]
  # Requires translation!
-Pick [technology] as free tech = 
-Units enabled = unit tolol
-Buildings enabled = bangunan-on
+Pick [technology] as free tech = Pilih [technology] sebagai teknologi percuma
+Units enabled = Unit diaktifkan
+Buildings enabled = Bangunan diaktifkan
  # Requires translation!
-Wonder = 
+Wonder = Keajaiban
  # Requires translation!
-National Wonder = 
+National Wonder = Keajaiban Kebangsaan
  # Requires translation!
-National Wonders = 
+National Wonders = Keajaiban Kebangsaan
  # Requires translation!
-Wonders enabled = 
+Wonders enabled = Keajaiban diaktifkan
  # Requires translation!
-Tile improvements enabled = 
+Tile improvements enabled = Peningkatan jubin diaktifkan
  # Requires translation!
-Reveals [resource] on the map = 
-XP for new units = exp untuk unit baru
+Reveals [resource] on the map = Dedahkan [resource] dalam peta
+XP for new units = XP untuk unit baru
  # Requires translation!
-provide = 
+provide = sediakan
  # Requires translation!
-provides = 
-City strength = kekuatan bandar
-City health = pertahanan bandar
+provides = sediakan
+City strength = Kekuatan bandar
+City health = Kesihatan bandar
  # Requires translation!
-Occupied! = 
-Attack = serang boss
-Bombard = bom 
-NUKE = nuklear
-Captured! = dah tangkap
+Occupied! = Diduduk
+Attack = Serang
+Bombard = Bom
+NUKE = Lancarkan senjata nuklear
+Captured! = Tertawan!
 
 # Battle modifier categories
 
  # Requires translation!
-defence vs ranged = 
+defence vs ranged = Pertahanan terhadap senjata jarak jauh
  # Requires translation!
-[percentage] to unit defence = 
-Attacker Bonus = bonus penyerang
-Defender Bonus = ponus bertahan
-Landing = mendarat
+[percentage] to unit defence = [percentage] ke pertahanan unit
+Attacker Bonus = Bonus Penyerang
+Defender Bonus = Bonus Pertahanan
+Landing = Mendarat
  # Requires translation!
-Flanking = 
+Flanking = Merusuk
  # Requires translation!
-vs [unitType] = 
+vs [unitType] = lawan [unitType]
  # Requires translation!
-Terrain = 
+Terrain = Rupa bumi
  # Requires translation!
-Tile = 
+Tile = Jubin
  # Requires translation!
-Missing resource = 
+Missing resource = Sumber hilang
  # Requires translation!
-Adjacent units = 
+Adjacent units = Unit bersebelahan
  # Requires translation!
-Adjacent enemy units = 
+Adjacent enemy units = Unit musuh bersebelahan
  # Requires translation!
-Combat Strength = 
+Combat Strength = Kekuatan Pertempuran
  # Requires translation!
-Across river = 
+Across river = Seberang sungai
  # Requires translation!
-Temporary Bonus = 
+Temporary Bonus = Bonus Sementara
  # Requires translation!
-Garrisoned unit = 
+Garrisoned unit = Unit garison
  # Requires translation!
-Attacking Bonus = 
+Attacking Bonus = Bonus Serang
  # Requires translation!
-defence vs [unitType] = 
+defence vs [unitType] = Pertahanan terhadap [unitType]
  # Requires translation!
-[tileFilter] defence = 
+[tileFilter] defence = Pertahanan [tileFilter]
  # Requires translation!
-Defensive Bonus = 
+Defensive Bonus = Bonus Pertahanan
  # Requires translation!
-Stacked with [unitType] = 
+Stacked with [unitType] = Tumpuk dengan [unitType]
 
  # Requires translation!
-Unit ability = 
+The following improvements [stats]: = Peningkatan yang berikut [stats]:
+ # Requires translation!
+The following improvements on [tileType] tiles [stats]: = Peningkatan yang berikut di jubin [tileType] [stats]:
 
- # Requires translation!
-The following improvements [stats]: = 
- # Requires translation!
-The following improvements on [tileType] tiles [stats]: = 
 
-# Unit actions
-
-Hurry Research = cepat kn research lambat sgt sal
-Conduct Trade Mission = kita jual diri
+Hurry Research = Cepatkan Penyelidikan
+Conduct Trade Mission = Jalankan Misi Perdagangan
  # Requires translation!
-Your trade mission to [civName] has earned you [goldAmount] gold and [influenceAmount] influence! = 
+Your trade mission to [civName] has earned you [goldAmount] gold and [influenceAmount] influence! = Misi perdagangan anda ke [civName] memberikan anda [goldAmount] emas dan [influenceAmount] pengaruhan!
  # Requires translation!
-Hurry Wonder = 
+Hurry Wonder = Cepatkan Keajaiban
  # Requires translation!
-Hurry Construction = 
+Spread Religion = Sebar Agama
  # Requires translation!
-Hurry Construction (+[productionAmount]) = 
+Spread [religionName] = Sebar [religionName]
  # Requires translation!
-Spread Religion = 
+Found a Religion = Asaskan Agama
  # Requires translation!
-Spread [religionName] = 
+Your citizens have been happy with your rule for so long that the empire enters a Golden Age! = Rakyat anda gembira akan pemerintahan anda sekian lama sehingga empayar anda memasuki Zaman Kegemilangan!
  # Requires translation!
-Remove Heresy = 
+You have entered the [newEra]! = Anda memasuki [newEra]!
  # Requires translation!
-Found a Religion = 
+[civName] has entered the [eraName]! = [civName] memasuki [eraName]!
  # Requires translation!
-Enhance a Religion = 
+[policyBranch] policy branch unlocked! = Cawangan polici [policyBranch] disediakan!
  # Requires translation!
-Your citizens have been happy with your rule for so long that the empire enters a Golden Age! = 
- # Requires translation!
-You have entered the [newEra]! = 
- # Requires translation!
-[civName] has entered the [eraName]! = 
- # Requires translation!
-[policyBranch] policy branch unlocked! = 
-
-# Overview screens
-
- # Requires translation!
-Overview = 
+Overview = Gambar Keseluruhan
 Total = Jumlah
 Stats = Statistik
-Policies = polisi
+Policies = Polisi
  # Requires translation!
-Base happiness = 
+Base happiness = Kegembiraan asas
  # Requires translation!
-Occupied City = 
-Buildings = binaan
- # Requires translation!
-Wonders = 
- # Requires translation!
-Base values = 
-Bonuses = bonus
-Final = last
-Other = Lain-lain
-Population = Populasi
- # Requires translation!
-City-States = 
- # Requires translation!
-Tile yields = 
- # Requires translation!
-Trade routes = 
- # Requires translation!
-Maintenance = 
- # Requires translation!
-Transportation upkeep = 
- # Requires translation!
-Unit upkeep = 
-Trades = Dagangan
- # Requires translation!
-Units = 
- # Requires translation!
-Unit Supply = 
- # Requires translation!
-Base Supply = 
- # Requires translation!
-Total Supply = 
- # Requires translation!
-In Use = 
- # Requires translation!
-Supply Deficit = 
- # Requires translation!
-Production Penalty = 
- # Requires translation!
-Increase your supply or reduce the amount of units to remove the production penalty = 
-Name = Nama
-Closest city = Bandar terdekat
- # Requires translation!
-Action = 
-Defeated = kalah asu
- # Requires translation!
-[numberOfCivs] Civilizations in the game = 
-Our Civilization: = tamadun kita
- # Requires translation!
-Known and alive ([numberOfCivs]) = 
- # Requires translation!
-Known and defeated ([numberOfCivs]) = 
- # Requires translation!
-Tiles = 
- # Requires translation!
-Natural Wonders = 
- # Requires translation!
-Treasury deficit = 
- # Requires translation!
-Unknown = 
- # Requires translation!
-Not built = 
- # Requires translation!
-Not found = 
- # Requires translation!
-Known = 
- # Requires translation!
-Owned = 
- # Requires translation!
-Near [city] = 
- # Requires translation!
-Somewhere around [city] = 
- # Requires translation!
-Far away = 
- # Requires translation!
-Status = 
- # Requires translation!
-Location = 
-
-# Victory
-
-Science victory = menang sbb sains
-Cultural victory = menang sebab budaya
-Conquest victory = menang sebab anda padu
- # Requires translation!
-Diplomatic victory = 
-Complete all the spaceship parts\n to win! = bina setiap bahagian kapal angkasa klo nk menang
- # Requires translation!
-Complete 5 policy branches\n to win! = 
- # Requires translation!
-Complete 5 policy branches and build\n the Utopia Project to win! = 
-Destroy all enemies\n to win! = musnah kan semua orang untuk menang
-You have won a scientific victory! = yehe ak saintis dan ak hensem
-You have won a cultural victory! = ak ad budaya yg padu
-You have won a domination victory! = anda adalah jeneral pling padu
- # Requires translation!
-You have won a diplomatic victory! = 
-You have won! = menang choi
- # Requires translation!
-You have achieved victory through the awesome power of your Culture. Your civilization's greatness - the magnificence of its monuments and the power of its artists - have astounded the world! Poets will honor you as long as beauty brings gladness to a weary heart. = 
- # Requires translation!
-The world has been convulsed by war. Many great and powerful civilizations have fallen, but you have survived - and emerged victorious! The world will long remember your glorious triumph! = 
- # Requires translation!
-You have achieved victory through mastery of Science! You have conquered the mysteries of nature and led your people on a voyage to a brave new world! Your triumph will be remembered as long as the stars burn in the night sky! = 
- # Requires translation!
-Your civilization stands above all others! The exploits of your people shall be remembered until the end of civilization itself! = 
- # Requires translation!
-You have been defeated. Your civilization has been overwhelmed by its many foes. But your people do not despair, for they know that one day you shall return - and lead them forward to victory! = 
- # Requires translation!
-You have triumphed over your foes through the art of diplomacy! Your cunning and wisdom have earned you great friends - and divided and sown confusion among your enemies! Forever will you be remembered as the leader who brought peace to this weary world! = 
-One more turn...! = Blom lagi!!!
-Built Apollo Program = bina apolo
- # Requires translation!
-Destroy [civName] = 
-Our status = status kita
-Global status = status dunia
- # Requires translation!
-Rankings = 
-Spaceship parts remaining = bahagian kapal
- # Requires translation!
-Branches completed = 
- # Requires translation!
-Undefeated civs = 
- # The \n here means: put a newline (enter) here. If this is omitted, the sidebox in the diplomacy overview will become _really_ wide.
- # Feel free to replace it with a space and put it between other words in your translation
- # Requires translation!
-Turns until the next\ndiplomacy victory vote: [amount] = 
- # Requires translation!
-Choose a civ to vote for = 
- # Requires translation!
-Choose who should become the world leader and win a diplomatic victory! = 
- # Requires translation!
-Voted for = 
- # Requires translation!
-Vote for [civilizationName] = 
- # Requires translation!
-Continue = 
- # Requires translation!
-Abstained = 
- # Requires translation!
-Vote for World Leader = 
-
-# Capturing a city
-
-What would you like to do with the city? = nak buat pa ngan bandar ni
- # Requires translation!
-Annex = 
-Annexed cities become part of your regular empire. = anex jdi bandar biasa
- # Requires translation!
-Their citizens generate 2x the unhappiness, unless you build a courthouse. = 
-Puppet = patung??
-Puppeted cities do not increase your tech or policy cost, but their citizens generate 1.5x the regular unhappiness. = Penduduk bandar jdi benci sma anda
-You have no control over the the production of puppeted cities. = anda tolol sgt untuk kawal bandar patung
-Puppeted cities also generate 25% less Gold and Science. = bandar pupet juga usless
-A puppeted city can be annexed at any time. = ko nk anex pon bole klo da pupet(ak pon x tau ap tu pupet anex mampus)
- # Requires translation!
-Liberate (city returns to [originalOwner]) = 
- # Requires translation!
-Liberating a city returns it to its original owner, giving you a massive relationship boost with them! = 
- # Requires translation!
-Raze = 
- # Requires translation!
-Razing the city annexes it, and starts razing the city to the ground. = 
- # Requires translation!
-The population will gradually dwindle until the city is destroyed. = 
- # Requires translation!
-Destroy = 
- # Requires translation!
-Destroying the city instantly razes the city to the ground. = 
- # Requires translation!
-Remove your troops in our border immediately! = 
-Sorry. = Maaf.
-Never! = mampus kau
-
- # Requires translation!
-Offer Declaration of Friendship ([30] turns) = 
-My friend, shall we declare our friendship to the world? = nk tayang kedunia ka yang kita ni member?
- # Requires translation!
-Sign Declaration of Friendship ([30] turns) = 
-We are not interested. = Tak nak busuk
- # Requires translation!
-We have signed a Declaration of Friendship with [otherCiv]! = 
- # Requires translation!
-[otherCiv] has denied our Declaration of Friendship! = 
-
-Basics = asas
- # Requires translation!
-Resources = 
- # Requires translation!
-Terrains = 
- # Requires translation!
-Tile Improvements = 
- # Requires translation!
-Unique to [civName], replaces [unitName] = 
- # Requires translation!
-Unique to [civName] = 
- # Requires translation!
-Tutorials = 
-Cost = Harga
- # Requires translation!
-May contain [listOfResources] = 
- # Requires translation!
-May contain: = 
- # Requires translation!
-Can upgrade from [unit] = 
- # Requires translation!
-Can upgrade from: = 
- # Requires translation!
-Upgrades to [upgradedUnit] = 
- # Requires translation!
-Obsolete with [obsoleteTech] = 
- # Requires translation!
-Occurs on [listOfTerrains] = 
- # Requires translation!
-Occurs on: = 
- # Requires translation!
-Placed on [terrainType] = 
- # Requires translation!
-Can be found on = 
- # Requires translation!
-Improved by [improvement] = 
- # Requires translation!
-Bonus stats for improvement = 
-Buildings that consume this resource = binaan yang makan ini bahan
- # Requires translation!
-Buildings that require this resource worked near the city = 
-Units that consume this resource = orang yang makan ini bahan
-Can be built on = bole dibina di
- # Requires translation!
-or [terrainType] = 
- # Requires translation!
-Can be constructed by = 
-Defence bonus = bonus pertahanan
-Movement cost = kos pergerakan
- # Requires translation!
-Open terrain = 
- # Requires translation!
-Rough Terrain = 
-for = untuk
- # Requires translation!
-Missing translations: = 
-Version = versi
-Resolution = resolusi
- # Requires translation!
-Tileset = 
-Map editor = editor mal
-Create = buat
-New map = map baru
-Empty = kosong
-Language = bahasa
- # Requires translation!
-Terrains & Resources = 
-Improvements = peningkatan
- # Requires translation!
-Clear current map = 
-Save map = simpan map
-Download map = download map
-Loading... = sabar...
- # Requires translation!
-Error loading map! = 
- # Requires translation!
-Filter: = 
-OK = ok
-Exit map editor = bla dri map editor
- # Requires translation!
-[nation] starting location = 
- # Requires translation!
-Clear terrain features = 
- # Requires translation!
-Clear improvements = 
- # Requires translation!
-Clear resource = 
-Remove units = buang unit
- # Requires translation!
-Player [index] = 
- # Requires translation!
-Player [playerIndex] starting location = 
- # Requires translation!
-Bottom left river = 
- # Requires translation!
-Bottom right river = 
- # Requires translation!
-Bottom river = 
-Requires = perlukan
-Menu = menu
-Brush Size = sais anu
-Map saved = map telah disimpan
- # Requires translation!
-Change ruleset = 
- # Requires translation!
-Base terrain [terrain] does not exist in ruleset! = 
- # Requires translation!
-Terrain feature [feature] does not exist in ruleset! = 
- # Requires translation!
-Resource [resource] does not exist in ruleset! = 
- # Requires translation!
-Improvement [improvement] does not exist in ruleset! = 
- # Requires translation!
-Change map to fit selected ruleset? = 
-
-# Civilopedia difficulty levels
-Player settings = seting pemain
- # Requires translation!
-Base Happiness = 
- # Requires translation!
-Extra happiness per luxury = 
- # Requires translation!
-Research cost modifier = 
- # Requires translation!
-Unit cost modifier = 
- # Requires translation!
-Building cost modifier = 
- # Requires translation!
-Policy cost modifier = 
- # Requires translation!
-Unhappiness modifier = 
- # Requires translation!
-Bonus vs. Barbarians = 
- # Requires translation!
-Barbarian spawning delay = 
- # Requires translation!
-Bonus starting units = 
-
- # Requires translation!
-AI settings = 
- # Requires translation!
-AI city growth modifier = 
- # Requires translation!
-AI unit cost modifier = 
- # Requires translation!
-AI building cost modifier = 
- # Requires translation!
-AI wonder cost modifier = 
- # Requires translation!
-AI building maintenance modifier = 
- # Requires translation!
-AI unit maintenance modifier = 
- # Requires translation!
-AI unhappiness modifier = 
- # Requires translation!
-AI free techs = 
- # Requires translation!
-Major AI civilization bonus starting units = 
- # Requires translation!
-City state bonus starting units = 
- # Requires translation!
-Turns until barbarians enter player tiles = 
- # Requires translation!
-Gold reward for clearing barbarian camps = 
-
-# Other civilopedia things
- # Requires translation!
-Nations = 
- # Requires translation!
-Available for [unitTypes] = 
- # Requires translation!
-Available for: = 
- # Requires translation!
-Free promotion: = 
- # Requires translation!
-Free promotions: = 
- # Requires translation!
-Free for [units] = 
- # Requires translation!
-Free for: = 
- # Requires translation!
-Granted by [param] = 
- # Requires translation!
-Granted by: = 
- # Requires translation!
-[bonus] with [tech] = 
- # Requires translation!
-Difficulty levels = 
-
-# Policies
-
-Adopt policy = Amalkan dasar
- # Requires translation!
-Adopt free policy = 
- # Requires translation!
-Unlocked at = 
- # Requires translation!
-Gain 2 free technologies = 
- # Requires translation!
-All policies adopted = 
- # Requires translation!
-Policy branch: [branchName] = 
-
-# Religions
-
- # Requires translation!
-Choose an Icon and name for your Religion = 
- # Requires translation!
-Choose a name for your religion = 
- # Requires translation!
-Choose a [beliefType] belief! = 
- # Requires translation!
-Choose any belief! = 
- # Requires translation!
-Found [religionName] = 
- # Requires translation!
-Enhance [religionName] = 
- # Requires translation!
-Choose a pantheon = 
- # Requires translation!
-Found Religion = 
- # Requires translation!
-Found Pantheon = 
- # Requires translation!
-Follow [belief] = 
- # Requires translation!
-Religions and Beliefs = 
- # Requires translation!
-Majority Religion: [name] = 
- # Requires translation!
-+ [amount] pressure = 
- # Requires translation!
-Holy city of: [religionName] = 
- # Requires translation!
-Pressure = 
-
-# Religion overview screen
- # Requires translation!
-Religion Name: = 
- # Requires translation!
-Founding Civ: = 
- # Requires translation!
-Holy City: = 
- # Requires translation!
-Cities following this religion: = 
- # Requires translation!
-Click an icon to see the stats of this religion = 
- # Requires translation!
-Religion: Off = 
- # Requires translation!
-Minimal faith required for\nthe next [Great Prophet]: = 
- # Requires translation!
-Religions founded: = 
- # Requires translation!
-Religious status: = 
-
- # Requires translation!
-None = 
- # Requires translation!
-Pantheon = 
- # Requires translation!
-Founding religion = 
- # Requires translation!
-Religion = 
- # Requires translation!
-Enhancing religion = 
- # Requires translation!
-Enhanced religion = 
-
-# Terrains
-
- # Requires translation!
-Impassable = 
- # Requires translation!
-Rare feature = 
+Occupied City = Bandar Diduduki
+Buildings = Bangunan
 
 # terrainFilters (so for uniques like: "[stats] from [terrainFilter] tiles")
 
  # Requires translation!
-All = 
-Water = air
+All = Semua
+Water = Air
 Land = Tanah
  # Requires translation!
-Coastal = 
-River = sungai
+Coastal = Pantai
+River = Sungai
  # Requires translation!
-Rough terrain = 
+Open terrain = Medan terbuka
  # Requires translation!
-Foreign Land = 
+Rough terrain = Medan kasar
  # Requires translation!
-Foreign = 
+Foreign Land = Tanah Asing
  # Requires translation!
-Friendly Land = 
-Water resource = sumber air
+Foreign = Asing
  # Requires translation!
-Bonus resource = 
+Friendly Land = Tanah Sahabat
+Water resource = Sumber air
  # Requires translation!
-Luxury resource = 
+Bonus resource = Sumber bonus
  # Requires translation!
-Strategic resource = 
-Fresh water = air suci
-non-fresh water = air taik
+Luxury resource = Sumber mewah
  # Requires translation!
-Natural Wonder = 
+Strategic resource = Sumber strategik
+Fresh water = Air tawar
+non-fresh water = Air tidak tawar
  # Requires translation!
-Hybrid = 
- # Requires translation!
-Undesirable = 
- # Requires translation!
-Desirable = 
+Natural Wonder = Keajaiban Semula Jadi
 
 # improvementFilters
 
  # Requires translation!
-All Road = 
+All Road = Semua Jalan
  # Requires translation!
-Great Improvement = 
+Great Improvement = Peningkatan Hebat
  # Requires translation!
-Great = 
+Great = Hebat
 
+
+ # Requires translation!
+Wonders = Keajaiban
+ # Requires translation!
+Base values = Nilai asas
+Bonuses = Bonus
+Final = Akhir
+Other = Lain-lain
+Population = Populasi
+ # Requires translation!
+City-States = Negara Kota
+ # Requires translation!
+Tile yields = Hasil jubin
+ # Requires translation!
+Trade routes = Laluan perdagangan
+ # Requires translation!
+Maintenance = Penyelenggaraan
+ # Requires translation!
+Transportation upkeep = Penyelenggaraan pengangkutan
+ # Requires translation!
+Unit upkeep = Pemeliharaan unit
+Trades = Perdagangan
+ # Requires translation!
+Units = Unit
+Name = Nama
+Closest city = Bandar terdekat
+ # Requires translation!
+Action = Tindakan
+Defeated = Dikalahkan
+ # Requires translation!
+[numberOfCivs] Civilizations in the game = [numberOfCivs] Tamadun di permainan
+Our Civilization: = Tamadun kami
+ # Requires translation!
+Known and alive ([numberOfCivs]) = Dikenali dan hidup ([numberOfCivs])
+ # Requires translation!
+Known and defeated ([numberOfCivs]) = Dikenali dan ditewas ([numberOfCivs])
+ # Requires translation!
+Tiles = Jubin
+ # Requires translation!
+Natural Wonders = Keajaiban Semula Jadi
+ # Requires translation!
+Treasury deficit = Defisit perbendaharaan
+
+# Victory
+
+Science victory = Kemenangan saintifik
+Cultural victory = Kemenangan kebudayaan
+Conquest victory = Kemenangan peperangan
+ # Requires translation!
+Diplomatic victory = Kemenangan diplomatik
+Complete all the spaceship parts\n to win! = Lengkapkan semua bahagian kapal angkasa\n untuk menang!
+ # Requires translation!
+Complete 5 policy branches\n to win! = Lengkapkan 5 cawangan polisi\n untuk menang!
+ # Requires translation!
+Complete 5 policy branches and build\n the Utopia Project to win! = Lengkapkan 5 cawangan polisi dan bina\n Projek Utopia untuk menang!
+Destroy all enemies\n to win! = Tewaskan semua musuh\n untuk menang!
+You have won a scientific victory! = Anda tercapai kemenangan saintifik!
+You have won a cultural victory! = Anda tercapai kemenangan kebudayaan!
+You have won a domination victory! = Anda tercapai kemenangan peperangan!
+ # Requires translation!
+You have won a diplomatic victory! = Anda tercapai kemenangan diplomatik!
+You have won! = Anda menang!
+ # Requires translation!
+You have achieved victory through the awesome power of your Culture. Your civilization's greatness - the magnificence of its monuments and the power of its artists - have astounded the world! Poets will honor you as long as beauty brings gladness to a weary heart. = Anda tercapai kemenangan melalui kehebatan Budaya anda. Kehebatan tamadun anda - kemegahan tugu-tugu dan seniman tamadun anda - telah mengegarkan seluruh dunia! Penyair-penyair memuji anda serupa kecantikan mengindahkan hati yang tenat.
+ # Requires translation!
+The world has been convulsed by war. Many great and powerful civilizations have fallen, but you have survived - and emerged victorious! The world will long remember your glorious triumph! = Seluruh dunia dilanda kederitaan peperangan. Ramai tamadun yang hebat dan berkuasa telah dijatuhkan, tetapi anda terselamat - dan muncul sebagai pemenang! Dunia akan mengingati kemenangan anda yang gemilang!
+ # Requires translation!
+You have achieved victory through mastery of Science! You have conquered the mysteries of nature and led your people on a voyage to a brave new world! Your triumph will be remembered as long as the stars burn in the night sky! = Anda mencapai kemenangan melalui penguasaan Sains! Anda membongkarkan misteri-misteri alam semula jadi dan memimpin rakyat anda dalam pelayaran ke dunia baru! Kemenangan anda akan diingati selagi bintang-bintang bersinar di langit malam!
+ # Requires translation!
+Your civilization stands above all others! The exploits of your people shall be remembered until the end of civilization itself! = Tamadun anda berdiri di atas tamadun-tamadun lain! Eksploitasi bangsa anda akan diingati sehingga akhir zaman tamadun anda!
+ # Requires translation!
+You have been defeated. Your civilization has been overwhelmed by its many foes. But your people do not despair, for they know that one day you shall return - and lead them forward to victory! = Anda telah ditewaskan. Tamadun anda ditimpa banyak musuh. Walaubagaimanapun, rakyat anda tidak putus asa, nescaya anda akan kembali - dan memimpin mereka menuju ke kegemilangan!
+ # Requires translation!
+You have triumphed over your foes through the art of diplomacy! Your cunning and wisdom have earned you great friends - and divided and sown confusion among your enemies! Forever will you be remembered as the leader who brought peace to this weary world! = Anda telah memenangi musuh anda melalui seni diplomasi! Kelicikan dan kebijaksanaan anda telah memperolehkan anda sahabat-sahabat yang hebat - dan membahagikan dan mengelirukan musuh-musuh anda! Selamanya anda akan diingati sebagai pemimpin yang membawa keamanan di dunia yang lesu ini!
+One more turn...! = Satu giliran lagi...!
+Built Apollo Program = Bina Program Apollo
+ # Requires translation!
+Destroy [civName] = Tewas [civName]
+Our status = Status Kami
+Global status = Status dunia
+ # Requires translation!
+Rankings = Kedudukan
+Spaceship parts remaining = Baki bahagian kapal angkasa
+ # Requires translation!
+Branches completed = Cawangan diselesaikan
+ # Requires translation!
+Undefeated civs = Tamadun yang belum dikalahkan
+ # The \n here means: put a newline (enter) here. If this is omitted, the sidebox in the diplomacy overview will become _really_ wide.
+ # Feel free to replace it with a space and put it somewhere else in your translation
+ # Requires translation!
+Turns until the next\ndiplomacy victory vote: [amount] = Giliran hingga nota\nkemenangan diplomasi seterusnya: [amount]
+ # Requires translation!
+Choose a civ to vote for = Pilih sebuah tamadun untuk undi
+ # Requires translation!
+Choose who should become the world leader and win a diplomatic victory! = Pilih siapa yang patut memimpin dunia dan menang secara diplomatik!
+ # Requires translation!
+Voted for = Telah mengundi
+ # Requires translation!
+Vote for [civilizationName] = Undi [civilizationName]
+ # Requires translation!
+Continue = Teruskan
+ # Requires translation!
+Abstained = Kecualikan
+ # Requires translation!
+Vote for World Leader = Undi Ketua Dunia
+# Capturing a city
+What would you like to do with the city? = Apakah yang anda ingin lakukan untuk bandar ini?
+ # Requires translation!
+Annex = Ilhak
+Annexed cities become part of your regular empire. = Bandar yang diilhakkan menjadi sebahagian daripada empayar biasa anda.
+ # Requires translation!
+Their citizens generate 2x the unhappiness, unless you build a courthouse. = Rakyat mereka menyebabkan 2x ketidakgembiraan, melainkan anda membina sebuah mahkamah.
+Puppet = Bonekakan
+Puppeted cities do not increase your tech or policy cost, but their citizens generate 1.5x the regular unhappiness. = Bandar boneka tidak meningkatkan kos teknologi atau polisi anda, tetapi rakyat mereka menyebabkan 1.5x ketidakgembiraan biasa.
+You have no control over the the production of puppeted cities. = Anda tiada kawalan akan pengeluaran bandar boneka.
+Puppeted cities also generate 25% less Gold and Science. = Bandar boneka juga memberikan 25% Emas dan Sains kurang dari biasa.
+A puppeted city can be annexed at any time. = Bandar boneka boleh diilhakkan pada bila-bila masa.
+ # Requires translation!
+Liberate (city returns to [originalOwner]) = Bebaskan (bandar dikembalikan kepada [originalOwner])
+ # Requires translation!
+Liberating a city returns it to its original owner, giving you a massive relationship boost with them! = Bandar yang dibebaskan akan dikembalikan kepada pemilik asal, dan hubungan anda dengan mereka akan ditambah baik secara besar-besaran!
+ # Requires translation!
+Raze = Robohkan
+ # Requires translation!
+Razing the city annexes it, and starts razing the city to the ground. = Bandar yang ingin dirobohkan akan diilhakkan dahulu.
+ # Requires translation!
+The population will gradually dwindle until the city is destroyed. = Populasi akan berkurang secara beransur-ansuran sehingga bandar dihancurkan.
+ # Requires translation!
+Destroy = Hancurkan
+ # Requires translation!
+Destroying the city instantly razes the city to the ground. = Bandar yang dihancurkan akan dirobohkan dengan serta-merta.
+ # Requires translation!
+Remove your troops in our border immediately! = Pindahkan askar kamu yang berada di sempadan kami dengan serta-merta!
+Sorry. = Maaf.
+Never! = Tidak!
+ # Requires translation!
+Offer Declaration of Friendship ([30] turns) = Tawar Pengisytiharan Persahabatan ([30] giliran)
+My friend, shall we declare our friendship to the world? = Kawanku, apa kata kita mengisytiharkan persahabatan kita kepada seluruh dunia?
+ # Requires translation!
+Sign Declaration of Friendship ([30] turns) = Tandatangan Pengisytiharan Persahabatan ([30] giliran)
+We are not interested. = Kami tidak berminat
+ # Requires translation!
+We have signed a Declaration of Friendship with [otherCiv]! = Kami menandatangani Pengisytiharan Persahabatan dengan [otherCiv]!
+ # Requires translation!
+[otherCiv] has denied our Declaration of Friendship! = [otherCiv] tolak Pengisytiharan Persahabatan kami!
+Basics = Asas
+ # Requires translation!
+Resources = Sumber
+ # Requires translation!
+Terrains = Rupa bumi
+ # Requires translation!
+Tile Improvements = Peningkatan Jubin
+ # Requires translation!
+Unique to [civName], replaces [unitName] = Unik kepada [civName], menggantikan [unitName]
+ # Requires translation!
+Unique to [civName] = Unik kepada [civName]
+ # Requires translation!
+Tutorials = Tutorial
+Cost = Kos
+ # Requires translation!
+May contain [listOfResources] = Mungkin mengandungi [listOfResources]
+ # Requires translation!
+May contain: = Mungkin mengandungi:
+ # Requires translation!
+Upgrades to [upgradedUnit] = Naik taraf ke [upgradedUnit]
+ # Requires translation!
+Obsolete with [obsoleteTech] = Diusangkan dengan [obsoleteTech]
+ # Requires translation!
+Occurs on [listOfTerrains] = Terjadi di [listOfTerrains]
+ # Requires translation!
+Occurs on: = Terjadi di:
+ # Requires translation!
+Placed on [terrainType] = Ditetapkan di [terrainType]
+ # Requires translation!
+Can be found on = Boleh dijumpa di
+ # Requires translation!
+Improved by [improvement] = Ditingkatkan oleh [improvement]
+ # Requires translation!
+Bonus stats for improvement = Statistik bonus peningkatan
+Buildings that consume this resource = Bangunan yang menggunakan sumber ini
+ # Requires translation!
+Buildings that require this resource worked near the city = Bangunan yang memerlukan sumber ini dikerjakan berhampiran bandar
+Units that consume this resource = Unit yang menggunakan sumber ini
+Can be built on = Boleh dibina di
+ # Requires translation!
+or [terrainType] = atau [terrainType]
+ # Requires translation!
+Can be constructed by = Boleh dibina oleh
+Defence bonus = Bonus pertahanan
+Movement cost = Kos pergerakan
+ # Requires translation!
+Rough Terrain = Medan kasar
+for = untuk
+ # Requires translation!
+Missing translations: = Terjemahan hilang:
+Version = Versi
+Resolution = Resolusi
+ # Requires translation!
+Tileset = Jubin
+Map editor = Editor peta
+Create = Buat
+New map = Peta baru
+Empty = Kosong
+Language = Bahasa
+ # Requires translation!
+Terrains & Resources = Rupa Bumi & Sumber
+Improvements = Peningkatan
+ # Requires translation!
+Clear current map = Bersihkan peta semasa
+Save map = Simpan peta
+Download map = Muat turn peta
+Loading... = Sedang dimuatkan...
+ # Requires translation!
+Error loading map! = Ralat memuatkan peta!
+ # Requires translation!
+Filter: = Tapisan:
+OK = OK
+Exit map editor = Keluar editor peta
+ # Requires translation!
+[nation] starting location = Lokasi mula [nation]
+ # Requires translation!
+Clear terrain features = Batalkan ciri rupa bumi
+ # Requires translation!
+Clear improvements = Batalkan peningkatan
+ # Requires translation!
+Clear resource = Batalkan sumber
+Remove units = Buangkan unit
+ # Requires translation!
+Player [index] = Pemain [index]
+ # Requires translation!
+Player [playerIndex] starting location = Lokasi mula pemain [playerIndex]
+ # Requires translation!
+Bottom left river = Sungai kiri bawah
+ # Requires translation!
+Bottom right river = Sungai kanan bawah
+ # Requires translation!
+Bottom river = Sugai bawah
+Requires = Perlukan
+Menu = Menu
+Brush Size = Sais berus
+Map saved = Peta disimpan
+ # Requires translation!
+Change ruleset = Tukar peraturan
+ # Requires translation!
+Base terrain [terrain] does not exist in ruleset! = Rupa bumi asas [terrain] tidak wujud dalam peraturan!
+ # Requires translation!
+Terrain feature [feature] does not exist in ruleset! = Ciri rupa bumi [feature] tidak wujud dalam peraturan!
+ # Requires translation!
+Resource [resource] does not exist in ruleset! = Sumber [resource] tidak wujud dalam peraturan!
+ # Requires translation!
+Improvement [improvement] does not exist in ruleset! = Peningkatan [improvement] tidak wujud dalam peraturan!
+ # Requires translation!
+Change map to fit selected ruleset? = Tukar peta untuk memadankan peraturan terpilih?
+# Civilopedia difficulty levels
+Player settings = Tetapan pemain
+ # Requires translation!
+Base Happiness = Kegembiraan Asas
+ # Requires translation!
+Happiness per luxury = Kegembiraan setiap Kemewahan
+ # Requires translation!
+Research cost modifier = Pengubah kos penyelidikan
+ # Requires translation!
+Unit cost modifier = Pengubah kos unit
+ # Requires translation!
+Building cost modifier = Pengubah kos bangunan
+ # Requires translation!
+Policy cost modifier = Pengubah kos polisi
+ # Requires translation!
+Unhappiness modifier = Pengubah ketidakgembiraan
+ # Requires translation!
+Bonus vs. Barbarians = Bonus terhadap Orang Barbar
+ # Requires translation!
+AI settings = Tetapan AI
+ # Requires translation!
+AI city growth modifier = Pengubah pertumbuhan bandar AI
+ # Requires translation!
+AI unit cost modifier = Pengubah kos unit AI
+ # Requires translation!
+AI building cost modifier = Pengubah kos bangunan AI
+ # Requires translation!
+AI wonder cost modifier = Pengubah kos keajaiban AI
+ # Requires translation!
+AI building maintenance modifier = Pengubah penyelenggaraan bangunan AI
+ # Requires translation!
+AI unit maintenance modifier = Pengubah pemulihan unit AI
+ # Requires translation!
+AI unhappiness modifier = Pengubah ketidakgembiraan AI
+ # Requires translation!
+Turns until barbarians enter player tiles = Giliran hingga orang barbar memasuki jubin pemain
+ # Requires translation!
+Gold reward for clearing barbarian camps = Gajaran emas menghapuskan kem barbar
+# Other civilopedia things
+ # Requires translation!
+Nations = Bangsa
+ # Requires translation!
+Available for [unitTypes] = Sedia ada untuk [unitTypes]
+ # Requires translation!
+Available for: = Sedia ada untuk:
+ # Requires translation!
+Free promotion: = Kenaikan pangkat percuma:
+ # Requires translation!
+Free promotions: = Kenaikan pangkat percuma:
+ # Requires translation!
+Free for [units] = Percuma untuk [units]
+ # Requires translation!
+Free for: = Percuma untuk:
+ # Requires translation!
+Granted by [param] = Diberikan oleh [param]
+ # Requires translation!
+Granted by: = Diberikan oleh:
+ # Requires translation!
+[bonus] with [tech] = [bonus] dengan [tech]
+ # Requires translation!
+Difficulty levels = Tahap kesukaran
+# Policies
+Adopt policy = Amalkan polisi
+ # Requires translation!
+Adopt free policy = Amalkan polisi percuma
+ # Requires translation!
+Unlocked at = Disediakan di
+ # Requires translation!
+Gain 2 free technologies = Perolehi 2 teknologi percuma
+ # Requires translation!
+All policies adopted = Semua polisi diamalkan
+# Religions
+ # Requires translation!
+Choose an Icon and name for your Religion = Pilih Ikon dan nama untuk Agama anda
+ # Requires translation!
+Choose a [beliefType] belief! = Pilih satu kepercayaan [beliefType]
+ # Requires translation!
+Found [religionName] = Asaskan [religionName]
+ # Requires translation!
+Choose a pantheon = Pilih pantheon
+ # Requires translation!
+Found Religion = Asaskan Agama
+ # Requires translation!
+Found Pantheon = Asaskan Pantheon
+ # Requires translation!
+Follow [belief] = Ikut [belief]
+ # Requires translation!
+Religions and Beliefs = Agama dan Kepercayaan
+# Terrains
+ # Requires translation!
+Impassable = Tidak dapat dilalui
+ # Requires translation!
+Rare feature = Ciri jarang
 # Resources
-
  # Requires translation!
-Bison = 
+Bison = Bison
 Copper = Tembaga
 Cocoa = Koko
 Crab = Ketam
  # Requires translation!
-Citrus = 
+Citrus = Sitrus
  # Requires translation!
-Truffles = 
+Truffles = Truffle
 Strategic = Strategik
 Bonus = Bonus
  # Requires translation!
-Luxury = 
-
+Luxury = Kemewahan
 # Unit types
-
 City = Bandar
  # Requires translation!
-Civilian = 
+Civilian = Orang Awam
  # Requires translation!
-Melee = 
+Melee = Unit Tempur Jarak Dekat
  # Requires translation!
-Ranged = 
+Ranged = Unit Jarak Jauh
  # Requires translation!
-Scout = 
+Scout = Peninjau
  # Requires translation!
-Mounted = 
+Mounted = Terpasang
  # Requires translation!
-Armor = 
+Armor = Perisai
  # Requires translation!
-Siege = 
-
+Siege = Pengepungan
  # Requires translation!
-WaterCivilian = 
+WaterCivilian = Orang Awam Air
  # Requires translation!
-WaterMelee = 
+WaterMelee = Unit Tempur Jarak Dekat Air
  # Requires translation!
-WaterRanged = 
+WaterRanged = Unit Jarak Jauh Air
  # Requires translation!
-WaterSubmarine = 
+WaterSubmarine = Kapal Selam Air
  # Requires translation!
-WaterAircraftCarrier = 
-
-Fighter = Pejuang
-Bomber = Pengebom
+WaterAircraftCarrier = Kapal Induk Pesawat Udara Air
+Fighter = Pesawat Pejuang
+Bomber = Pesawat Pengebom
  # Requires translation!
-AtomicBomber = 
-Missile = Misil
-
-
+AtomicBomber = Pesawat Pengebom Atom
+Missile = Peluru Berpandu
 # Unit filters and other unit related things
-
  # Requires translation!
-Air = 
+Air = Udara
  # Requires translation!
-air units = 
+air units = unit udara
  # Requires translation!
-Barbarian = 
+Barbarian = Orang Barbar
  # Requires translation!
-Barbarians = 
+Barbarians = Orang barbar
  # Requires translation!
-Embarked = 
+Embarked = Mulakan
  # Requires translation!
-land units = 
-Military = askar
+land units = unit darat
+Military = Tentera
 # Deprecated since 3.15.2, but should still be translated until it is officially removed
  # Requires translation!
-military water = 
+military water = Tentera air
 non-air = bukan udara
  # Requires translation!
-Nuclear Weapon = 
+Nuclear Weapon = Senjata Nuklear
 Submarine = Kapal Selam
  # Requires translation!
-submarine units = 
+submarine units = unit kapal selam
  # Requires translation!
-Unbuildable = 
+Unbuildable = Tidak dapat dibina
  # Requires translation!
-water units = 
+water units = unit air
  # Requires translation!
-wounded units = 
+wounded units = unit tercedera
  # Requires translation!
-Wounded = 
-
-# For the "All newly-trained [relevant] units in this city receive the [] promotion" translation. Relevant as in 'units that can receive'
+Wounded = Tercedera
+# For the All "newly-trained [relevant] units in this city receive the [] promotion" translation. Relevant as in 'units that can receive'
  # Requires translation!
-relevant = 
-
-# For "May choose [amount] additional [beliefType] beliefs when [founding/enhancing] a religion"
- # Requires translation!
-founding = 
- # Requires translation!
-enhancing = 
-
+relevant = relevan
 # Promotions
-
  # Requires translation!
-Pick promotion = 
+Pick promotion = Pilih pangkat
  # Requires translation!
- OR  = 
+ OR  = ATAU
  # Requires translation!
-units in open terrain = 
+units in open terrain = unit di medan terbuka
  # Requires translation!
-units in rough terrain = 
+units in rough terrain = unit di medan kasar
  # Requires translation!
-Targeting II (air) = 
+Targeting II (air) = Sasaran II (udara)
  # Requires translation!
-Targeting III (air) = 
+Targeting III (air) = Sasaran III (udara)
  # Requires translation!
-Bonus when performing air sweep [bonusAmount]% = 
+Bonus when performing air sweep [bonusAmount]% = Bonus ketika sapuan udara [bonusAmount]&
  # Requires translation!
-Dogfighting I = 
+Dogfighting I = Pertarungan Pesawat I
  # Requires translation!
-Dogfighting II = 
+Dogfighting II = Pertarungan Pesawat II
  # Requires translation!
-Dogfighting III = 
+Dogfighting III = Pertarungan Pesawat III
  # Requires translation!
-Choose name for [unitName] = 
+Choose name for [unitName] = Pilih nama untuk [unitName]
  # Requires translation!
-[unitFilter] units gain the [promotion] promotion = 
-
+[unitFilter] units gain the [promotion] promotion = [unitFilter] unit memperolehi pangkat [promotion]
 # Multiplayer Turn Checker Service
-
  # Requires translation!
-Enable out-of-game turn notifications = 
+Multiplayer options = Pilihan multipemain
  # Requires translation!
-Time between turn checks out-of-game (in minutes) = 
+Enable out-of-game turn notifications = Aktifkan notifikasi giliran luar permainan
  # Requires translation!
-Show persistent notification for turn notifier service = 
+Time between turn checks out-of-game (in minutes) = Masa antara giliaran yang disemak luar permainan (dalam minit)
  # Requires translation!
-Take user ID from clipboard = 
+Show persistent notification for turn notifier service = Tunjuk notifikasi berterusan untuk servis notifikasi giliran
  # Requires translation!
-Doing this will reset your current user ID to the clipboard contents - are you sure? = 
+Take user ID from clipboard = Ambil ID pengguna dari 'clipboard'
  # Requires translation!
-ID successfully set! = 
+Doing this will reset your current user ID to the clipboard contents - are you sure? = Melakukan sedemikian akan menetapkan semula pengguna ID yang sedia ada ke kandungan 'clipboard' - adakah anda pasti?
  # Requires translation!
-Invalid ID! = 
-
-
+ID successfully set! = ID berjaya ditetapkan!
+ # Requires translation!
+Invalid ID! = ID tidak sah!
 # Mods
-
  # Requires translation!
-Mods = 
+Mods = Mod
  # Requires translation!
-Download [modName] = 
+Download [modName] = Muat turun [modName]
  # Requires translation!
-Update [modName] = 
+Update [modName] = Kemas kini [modName]
  # Requires translation!
-Could not download mod list = 
+Could not download mod list = Tidak dapat muat turn senarai mod
  # Requires translation!
-Download mod from URL = 
+Download mod from URL = Muat naik mod dari URL
  # Requires translation!
-Please enter the mod repository -or- archive zip url: = 
+Please enter the mod repository -or- archive zip url: = Sila masukkan repositori mod -atau- url arkib zip:
  # Requires translation!
-Download = 
+Download = Muat turun
  # Requires translation!
-Done! = 
+Done! = Selesai!
  # Requires translation!
-Delete [modName] = 
+Delete [modName] = Padam [modName]
  # Requires translation!
-Are you SURE you want to delete this mod? = 
+Are you SURE you want to delete this mod? = Adakah anda PASTI ingin memadamkan mod ini?
  # Requires translation!
-[mod] was deleted. = 
+[mod] was deleted. = [mod] telah dipadamkan.
  # Requires translation!
-Updated = 
+Updated = Dikemas kini
  # Requires translation!
-Current mods = 
+Current mods = Mod semasa
  # Requires translation!
-Downloadable mods = 
+Downloadable mods = Mod yang boleh dimuat turun
  # Requires translation!
-Mod info and options = 
+Next page = Halaman seterusnya
  # Requires translation!
-Next page = 
+Open Github page = Buka halaman Github
  # Requires translation!
-Open Github page = 
+Permanent audiovisual mod = Mod audiovisual kekal
  # Requires translation!
-Permanent audiovisual mod = 
+Installed = Dipasang
  # Requires translation!
-Installed = 
+Downloaded! = Dimuat-turun!
  # Requires translation!
-Downloaded! = 
+[modName] Downloaded! = [modName] dimuat-turn!
  # Requires translation!
-[modName] Downloaded! = 
+Could not download [modName] = Tidak dapat muat turunkan [modName]
  # Requires translation!
-Could not download [modName] = 
+Online query result is incomplete = Hasil pertanyaan dalam talian tidak lengkap
  # Requires translation!
-Online query result is incomplete = 
+No description provided = Tiada penerangan diberi
  # Requires translation!
-No description provided = 
+[stargazers]✯ = [stargazers]✯
  # Requires translation!
-[stargazers]✯ = 
+Author: [author] = Pengarang: [author]
  # Requires translation!
-Author: [author] = 
+Size: [size] kB = Sais: [size] kB
  # Requires translation!
-Size: [size] kB = 
- # Requires translation!
-The mod you selected is incompatible with the defined ruleset! = 
- # Requires translation!
-Sort and Filter = 
- # Requires translation!
-Enter search text = 
- # Requires translation!
-Sort Current: = 
- # Requires translation!
-Sort Downloadable: = 
- # Requires translation!
-Name ￪ = 
- # Requires translation!
-Name ￬ = 
- # Requires translation!
-Date ￪ = 
- # Requires translation!
-Date ￬ = 
- # Requires translation!
-Stars ￬ = 
- # Requires translation!
-Status ￬ = 
-
-
+The mod you selected is incompatible with the defined ruleset! = Mod yang dipilih tidak sesuai dengan peraturan yang ditakrifkan!
 # Uniques that are relevant to more than one type of game object
-
  # Requires translation!
-[stats] from every [param] = 
+[stats] from every [param] = [stats] dari setiap [param]
  # Requires translation!
-[stats] from [param] tiles in this city = 
+[stats] from [param] tiles in this city = [stats] dari jubin [param] di bandar ini
  # Requires translation!
-[stats] from every [param] on [tileFilter] tiles = 
+[stats] from every [param] on [tileFilter] tiles = [stats] dari setip [param] di [tileFilter]
  # Requires translation!
-[stats] for each adjacent [param] = 
+[stats] for each adjacent [param] = [stats] untuk setiap [param] bersebelahan
  # Requires translation!
-Must be next to [terrain] = 
+Must be next to [terrain] = Mesti bersebelahan dengan [terrain]
  # Requires translation!
-Must be on [terrain] = 
+Must be on [terrain] = Mesti berada di [terrain]
  # Requires translation!
-+[amount]% vs [unitType] = 
++[amount]% vs [unitType] = +[amount]% terhadap [unitType]
  # Requires translation!
-+[amount] Movement for all [unitType] units = 
++[amount] Movement for all [unitType] units = +[amount] Pergerakan untuk semua unit [unitType]
  # Requires translation!
-+[amount]% Production when constructing [param] = 
++[amount]% Production when constructing [param] = +[amount] Pengeluaran semasa membina [param]
  # Requires translation!
-Can only be built on [tileFilter] tiles = 
+Can only be built on [tileFilter] tiles = Hanya boleh dibina di jubin [tileFilter]
  # Requires translation!
-Cannot be built on [tileFilter] tiles = 
+Cannot be built on [tileFilter] tiles = Tidak boleh dibina di jubin [tileFilter]
  # Requires translation!
-Does not need removal of [feature] = 
+Does not need removal of [feature] = Tidak perlu memadamkan [feature]
  # Requires translation!
-Gain a free [building] [cityFilter] = 
-
+Gain a free [building] [cityFilter] = Perolehi sebuah [building] [cityFilter] percuma
+# City filters
+ # Requires translation!
+in this city = di bandar ini
+ # Requires translation!
+in all cities = di semua bandar
+ # Requires translation!
+in all coastal cities = di semua bandar pantai
+ # Requires translation!
+in capital = di ibu negara
+ # Requires translation!
+in all non-occupied cities = di semua bandar yang tidak diduduki
+ # Requires translation!
+in all cities with a world wonder = di semua bandar yang mempunyai keajaiban dunia
+ # Requires translation!
+in all cities connected to capital = di semua bandar yang berhubung dengan ibu negara
+ # Requires translation!
+in all cities with a garrison = di semua bandar yang mempunyai garison
 # Uniques not found in JSON files
+ # Requires translation!
+Only available after [] turns = Hanya ada selepas [] giliran
+ # Requires translation!
+This Unit upgrades for free = Unit ini dinaik taraf secare percuma
+#################### Lines from Beliefs from Civ V - Vanilla ####################
+ # Requires translation!
+Ancestor Worship =
+ # Requires translation!
+Pantheon =
+ # Requires translation!
+Dance of the Aurora =
+ # Requires translation!
+[stats] from [tileFilter] tiles without [tileFilter2] [cityFilter] =
+ # Requires translation!
+Desert Folklore =
+ # Requires translation!
+Faith Healers =
+ # Requires translation!
+[param] Units adjacent to this city heal [amount] HP per turn when healing =
+ # Requires translation!
+Fertility Rites =
+ # Requires translation!
++[amount]% Growth [cityFilter] =
+ # Requires translation!
+God of Craftsman =
+ # Requires translation!
+[stats] in cities with [amount] or more population =
+ # Requires translation!
+God of the Open Sky =
+ # Requires translation!
+God of the Sea =
+ # Requires translation!
+God of War =
+ # Requires translation!
+Earn [amount]% of [unitType] unit's [param] as [stat] when killed within 4 tiles of a city following this religion =
 
  # Requires translation!
-Only available after [] turns = 
- # Requires translation!
-This Unit upgrades for free = 
- # Requires translation!
-[stats] when a city adopts this religion for the first time = 
- # Requires translation!
-Never destroyed when the city is captured = 
- # Requires translation!
-Invisible to others = 
-
-
-# Conditionals
-# These are optional parts that can be added to uniques to allow them only to function in some cases,
-# denoted by placing them between <> brackets. An example would be: "[amount]% Strength <when at war>". 
-# In this case "<when at war>" is a conditional.
- # Requires translation!
-when not at war = 
- # Requires translation!
-when at war = 
- # Requires translation!
-while the empire is happy = 
- # Requires translation!
-during a Golden Age = 
+Goddess of Festivals =
 
  # Requires translation!
-if this city has at least [amount] specialists = 
+Goddess of Love =
 
  # Requires translation!
-for [mapUnitFilter] units = 
+Goddess of Protection =
  # Requires translation!
-vs cities = 
- # Requires translation!
-vs [mapUnitFilter] units = 
- # Requires translation!
-for combat in [tileFilter] tiles = 
- # Requires translation!
-when attacking = 
- # Requires translation!
-when defending = 
-
-
-# In English we just paste all these conditionals at the end of each unique, but in your language that
-# may not turn into valid sentences. Therefore we have the following two translations to determine
-# where they should go. 
-# The first determines whether the conditionals should be placed before or after the base unique.
-# It should be translated with only the untranslated english word 'before' or 'after', without the quotes.
-# Example: In the unique "+20% Strength <for [unitFilter] units>", should the <for [unitFilter] units>
-# be translated before or after the "+20% Strength"?
+[amount]% attacking Strength for cities =
 
  # Requires translation!
-ConditionalsPlacement = 
-
-# The second determines the exact ordering of all conditionals that are to be translated.
-# ALL conditionals that exist will be part of this line, and they may be moved around and rearranged as you please.
-# However, you should not translate the parts between the brackets, only move them around so that when
-# translated in your language the sentence sounds natural.
-#
-# Example: "+20% Strength <for [unitFilter] units> <when attacking> <vs [unitFilter] units> <in [tileFilter] tiles> <during the [eraName]>"
-# In what order should these conditionals between <> be translated?
-# Note that this example currently doesn't make sense yet, as those conditionals do not exist, but they will in the future.
-#
-# As this is still under development, conditionals will be added al the time. As a result,
-# any translations added for this string will be removed immediately in the next version when more
-# conditionals are added. As we don't want to make you retranslate this same line over and over,
-# it's removed for now, but it will return once all planned conditionals have been added.
-
-
-
-
-
-########################### AUTOMATICALLY GENERATED TRANSLATABLE STRINGS ########################### 
-
-
-
-######### City filters ###########
+Goddess of the Hunt =
 
  # Requires translation!
-in this city = 
+Messenger of the Gods =
  # Requires translation!
-in all cities = 
+[stats] from each Trade Route =
+
  # Requires translation!
-in all coastal cities = 
+Monument to the Gods =
+
  # Requires translation!
-in capital = 
+One with Nature =
+
  # Requires translation!
-in all non-occupied cities = 
+Oral Tradition =
+
  # Requires translation!
-in all cities with a world wonder = 
+Religious Idols =
+
  # Requires translation!
-in all cities connected to capital = 
+Religious Settlements =
  # Requires translation!
-in all cities with a garrison = 
+[amount]% cost of natural border growth =
+
  # Requires translation!
-in all cities in which the majority religion is a major religion = 
+Sacred Path =
+
  # Requires translation!
-in all cities in which the majority religion is an enhanced religion = 
+Sacred Waters =
  # Requires translation!
-in non-enemy foreign cities = 
+[stats] in cities on [param] tiles =
+
  # Requires translation!
-in foreign cities = 
+Stone Circles =
+
  # Requires translation!
-in annexed cities = 
+Cathedrals =
  # Requires translation!
-in holy cities = 
+Follower =
  # Requires translation!
-in City-State cities = 
+May buy [building] buildings for [amount] [stat] [cityFilter] =
+
  # Requires translation!
-in cities following this religion = 
+Divine inspiration =
+ # Requires translation!
+[stats] from every Wonder =
+
+ # Requires translation!
+Feed the World =
+
+ # Requires translation!
+Guruship =
+ # Requires translation!
+[stats] if this city has at least [amount] specialists =
+
+ # Requires translation!
+Monasteries =
+
+ # Requires translation!
+Mosques =
+
+ # Requires translation!
+Pagodas =
+
+ # Requires translation!
+Peace Gardens =
+
+ # Requires translation!
+Religious Art =
+
+ # Requires translation!
+Swords into Ploughshares =
+ # Requires translation!
+[amount]% growth [cityFilter] when not at war =
+
 
 #################### Lines from Buildings from Civ V - Vanilla ####################
 
-Palace = Istana
  # Requires translation!
-Indicates the capital city = 
+Indicates the capital city =
+Palace = Istana
 
 Monument = Tugu
- # Requires translation!
-Destroyed when the city is captured = 
 
  # Requires translation!
-Granary = 
+[stats] from [resource] tiles [cityFilter] =
  # Requires translation!
-[stats] from [tileFilter] tiles [cityFilter] = 
+Granary =
 
  # Requires translation!
-'It is not so much for its beauty that the forest makes a claim upon men's hearts, as for that subtle something, that quality of air, that emanation from old trees, that so wonderfully changes and renews a weary spirit.' - Robert Louis Stevenson = 
+Hidden when religion is disabled =
+ # Requires translation!
+Shrine =
+
+ # Requires translation!
+'It is not so much for its beauty that the forest makes a claim upon men's hearts, as for that subtle something, that quality of air, that emanation from old trees, that so wonderfully changes and renews a weary spirit.'  - Robert Louis Stevenson =
+ # Requires translation!
++[amount]% [stat] [cityFilter] =
+ # Requires translation!
++[amount]% Production when constructing [unitType] units [cityFilter] =
 Temple of Artemis = Temple of Artemis
  # Requires translation!
-[amount]% [stat] [cityFilter] = 
+Must not be on [tileFilter] =
  # Requires translation!
-[amount]% Production when constructing [baseUnitFilter] units [cityFilter] = 
-
+Stone Works =
  # Requires translation!
-'They that go down to the sea in ships, that do business in great waters; these see the works of the Lord, and his wonders in the deep.' - The Bible, Psalms 107:23-24 = 
- # Requires translation!
-The Great Lighthouse = 
- # Requires translation!
-[amount] Movement = 
- # Requires translation!
-[amount] Sight = 
-
- # Requires translation!
-Stone Works = 
- # Requires translation!
-Must not be on [terrainFilter] = 
-
- # Requires translation!
-'Time crumbles things; everything grows old and is forgotten under the power of time' - Aristotle = 
+'Time crumbles things; everything grows old and is forgotten under the power of time' - Aristotle =
 Stonehenge = Stonehenge
 
-Library = Perpustakaan
  # Requires translation!
-[stats] per [amount] population [cityFilter] = 
+[stats] per [amount] population [cityFilter] =
+Library = Perpustakaan
 
 Paper Maker = Pembuat kertas
 
  # Requires translation!
-'Libraries are as the shrine where all the relics of the ancient saints, full of true virtue, and all that without delusion or imposture are preserved and reposed.' - Sir Francis Bacon = 
+'Libraries are as the shrine where all the relics of the ancient saints, full of true virtue, and all that without delusion or imposture are preserved and reposed.' - Sir Francis Bacon =
  # Requires translation!
-The Great Library = 
+Free Technology =
  # Requires translation!
-Free Technology = 
+Provides a free [building] [cityFilter] =
+ # Requires translation!
+The Great Library =
 
 Circus = Sarkus
 
  # Requires translation!
-Water Mill = 
+Water Mill =
 
 Floating Gardens = Taman Terapung
 
@@ -2279,364 +1827,387 @@ Walls = Dinding
 Walls of Babylon = Dinding Babylon
 
  # Requires translation!
-'O, let not the pains of death which come upon thee enter into my body. I am the god Tem, and I am the foremost part of the sky, and the power which protecteth me is that which is with all the gods forever.' - The Book of the Dead, translated by Sir Ernest Alfred Wallis Budge = 
+'O, let not the pains of death which come upon thee enter into my body. I am the god Tem, and I am the foremost part of the sky, and the power which protecteth me is that which is with all the gods forever.'  - The Book of the Dead, translated by Sir Ernest Alfred Wallis Budge =
+ # Requires translation!
+[amount]% tile improvement construction time =
+ # Requires translation!
+[amount] free [unit] units appear =
 The Pyramids = Piramid
- # Requires translation!
-[amount]% tile improvement construction time = 
- # Requires translation!
-[amount] free [baseUnitFilter] units appear = 
 
  # Requires translation!
-'The whole earth is the tomb of heroic men and their story is not given only on stone over their clay but abides everywhere without visible symbol woven into the stuff of other men's lives.' - Pericles = 
+'The whole earth is the tomb of heroic men and their story is not given only on stone over their clay but abides everywhere without visible symbol woven into the stuff of other men's lives.' - Pericles =
  # Requires translation!
-Mausoleum of Halicarnassus = 
+Provides a sum of gold each time you spend a Great Person =
  # Requires translation!
-Provides a sum of gold each time you spend a Great Person = 
-
+Mausoleum of Halicarnassus =
  # Requires translation!
-Barracks = 
+New [unitType] units start with [amount] Experience [cityFilter] =
  # Requires translation!
-New [unitType] units start with [amount] Experience [cityFilter] = 
-
+Barracks =
  # Requires translation!
-Krepost = 
+-[amount]% Culture cost of acquiring tiles [cityFilter] =
  # Requires translation!
--[amount]% Culture cost of acquiring tiles [cityFilter] = 
+-[amount]% Gold cost of acquiring tiles [cityFilter] =
  # Requires translation!
--[amount]% Gold cost of acquiring tiles [cityFilter] = 
-
+Krepost =
  # Requires translation!
-'He spoke, the son of Kronos, and nodded his head with the dark brows, and the immortally anointed hair of the great god swept from his divine head, and all Olympos was shaken' - The Iliad = 
+'He spoke, the son of Kronos, and nodded his head with the dark brows, and the immortally anointed hair of the great god swept from his divine head, and all Olympos was shaken' - The Iliad =
  # Requires translation!
-Statue of Zeus = 
++15% Combat Strength for all units when attacking Cities =
  # Requires translation!
-[amount]% Strength = 
-
+Statue of Zeus =
 Lighthouse = Rumah Api
+ # Requires translation!
+'They that go down to the sea in ships, that do business in great waters; these see the works of the Lord, and his wonders in the deep.' - The Bible, Psalms 107:23-24 =
+ # Requires translation!
++[amount] Sight for all [param] units =
+ # Requires translation!
+The Great Lighthouse =
 
 Stable = Kandang
 
-Courthouse = Makamah
  # Requires translation!
-Remove extra unhappiness from annexed cities = 
+Cost increases by [amount] per owned city =
  # Requires translation!
-Can only be built [cityFilter] = 
+Circus Maximus =
 
  # Requires translation!
-'I think that if ever a mortal heard the word of God it would be in a garden at the cool of the day.' - F. Frankfort Moore = 
+Remove extra unhappiness from annexed cities =
+ # Requires translation!
+Can only be built in annexed cities =
+Courthouse = Makamah
+
+ # Requires translation!
+'I think that if ever a mortal heard the word of God it would be in a garden at the cool of the day.'  - F. Frankfort Moore =
 Hanging Gardens = Taman Tergantung
 
 Colosseum = Kolosseum
 
  # Requires translation!
-Circus Maximus = 
+'Regard your soldiers as your children, and they will follow you into the deepest valleys; look on them as your own beloved sons, and they will stand by you even unto death.'  - Sun Tzu =
  # Requires translation!
-Cost increases by [amount] per owned city = 
+Terracotta Army =
 
  # Requires translation!
-'The art of war teaches us to rely not on the likelihood of the enemy's not attacking, but rather on the fact that we have made our position unassailable.' - Sun Tzu = 
- # Requires translation!
-Great Wall = 
- # Requires translation!
-Enemy land units must spend 1 extra movement point when inside your territory (obsolete upon Dynamite) = 
-
- # Requires translation!
-Temple = 
-
-Burial Tomb = Tempat Persemadian
- # Requires translation!
-Doubles Gold given to enemy if city is captured = 
-
- # Requires translation!
-Mud Pyramid Mosque = 
+Temple =
 
 National College = Kolej Kebangsaan
 
  # Requires translation!
-'The ancient Oracle said that I was the wisest of all the Greeks. It is because I alone, of all the Greeks, know that I know nothing' - Socrates = 
- # Requires translation!
-The Oracle = 
+'The ancient Oracle said that I was the wisest of all the Greeks. It is because I alone, of all the Greeks, know that I know nothing'  - Socrates =
 Free Social Policy = Polisi Sosial Percuma
+ # Requires translation!
+The Oracle =
 
  # Requires translation!
-National Epic = 
+Amphitheater =
+
  # Requires translation!
-[amount]% great person generation [cityFilter] = 
+Doubles Gold given to enemy if city is captured =
+Burial Tomb = Tempat Persemadian
+
+ # Requires translation!
+Mud Pyramid Mosque =
+
+ # Requires translation!
+[amount]% great person generation [cityFilter] =
+ # Requires translation!
+National Epic =
 
 Market = Pasar
 
+ # Requires translation!
+Provides 1 extra copy of each improved luxury resource near this City =
 Bazaar = Bazar
- # Requires translation!
-Provides 1 extra copy of each improved luxury resource near this City = 
 
  # Requires translation!
-Mint = 
+Mint =
 
  # Requires translation!
-Aqueduct = 
+'...who drinks the water I shall give him, says the Lord, will have a spring inside him welling up for eternal life. Let them bring me to your holy mountain in the place where you dwell. Across the desert and through the mountain to the Canyon of the Crescent Moon...'  - Indiana Jones =
  # Requires translation!
-[amount]% of food is carried over [cityFilter] after population increases = 
+[stats] once [tech] is discovered =
+ # Requires translation!
+Petra =
 
  # Requires translation!
-Heroic Epic = 
+[amount]% of food is carried over [cityFilter] after population increases =
  # Requires translation!
-All newly-trained [unitType] units [cityFilter] receive the [promotion] promotion = 
+Aqueduct =
 
  # Requires translation!
-'Why man, he doth bestride the narrow world like a colossus, and we petty men walk under his huge legs, and peep about to find ourselves dishonorable graves.' - William Shakespeare, Julius Caesar = 
+'The art of war teaches us to rely not on the likelihood of the enemy's not attacking, but rather on the fact that we have made our position unassailable.'  - Sun Tzu =
  # Requires translation!
-Colossus = 
-
+Enemy land units must spend 1 extra movement point when inside your territory (obsolete upon Dynamite) =
+ # Requires translation!
+Great Wall =
+ # Requires translation!
+All newly-trained [unitType] units [cityFilter] receive the [promotion] promotion =
+ # Requires translation!
+Heroic Epic =
+ # Requires translation!
+'Why man, he doth bestride the narrow world like a colossus, and we petty men walk under his huge legs, and peep about to find ourselves dishonorable graves.' - William Shakespeare, Julius Caesar =
+ # Requires translation!
+Colossus =
 Garden = Taman
-
  # Requires translation!
-Monastery = 
-
+'For it soars to a height to match the sky, and as if surging up from among the other buildings it stands on high and looks down upon the remainder of the city, adorning it, because it is a part of it, but glorying in its own beauty'  - Procopius, De Aedificis =
  # Requires translation!
-'For it soars to a height to match the sky, and as if surging up from among the other buildings it stands on high and looks down upon the remainder of the city, adorning it, because it is a part of it, but glorying in its own beauty' - Procopius, De Aedificis = 
+Free Great Person =
  # Requires translation!
-Hagia Sophia = 
-
+Hagia Sophia =
  # Requires translation!
-'The temple is like no other building in the world. It has towers and decoration and all the refinements which the human genius can conceive of.' - Antonio da Magdalena = 
-Angkor Wat = Angkor Wat 
-
+'The katun is established at Chichen Itza. The settlement of the Itza shall take place there. The quetzal shall come, the green bird shall come. Ah Kantenal shall come. It is the word of God. The Itza shall come.'  - The Books of Chilam Balam =
  # Requires translation!
-'The katun is established at Chichen Itza. The settlement of the Itza shall take place there. The quetzal shall come, the green bird shall come. Ah Kantenal shall come. It is the word of God. The Itza shall come.' - The Books of Chilam Balam = 
+Golden Age length increased by [amount]% =
  # Requires translation!
-Chichen Itza = 
- # Requires translation!
-Golden Age length increased by [amount]% = 
-
+Chichen Itza =
 National Treasury = Perbendaharaan Nasional
-
  # Requires translation!
-'Few romances can ever surpass that of the granite citadel on top of the beetling precipices of Machu Picchu, the crown of Inca Land.' - Hiram Bingham = 
+'Few romances can ever surpass that of the granite citadel on top of the beetling precipices of Machu Picchu, the crown of Inca Land.'  - Hiram Bingham =
  # Requires translation!
-Machu Picchu = 
+Gold from all trade routes +25% =
  # Requires translation!
-Gold from all trade routes +25% = 
+Must have an owned [tileFilter] within [amount] tiles =
  # Requires translation!
-Must have an owned [tileFilter] within [amount] tiles = 
-
+Machu Picchu =
  # Requires translation!
-Workshop = 
-
+Workshop =
  # Requires translation!
-Longhouse = 
-
+Longhouse =
  # Requires translation!
-Forge = 
++[amount]% Production when constructing [param] [cityFilter] =
  # Requires translation!
-[amount]% Production when constructing [buildingFilter] buildings [cityFilter] = 
-
+Forge =
+ # Requires translation!
+Connects trade routes over water =
 Harbor = Perlabuhan
- # Requires translation!
-Connects trade routes over water = 
-
 University = Universiti
-
  # Requires translation!
-Wat = 
-
+Wat =
 Oxford University = Universiti Oxford
-
  # Requires translation!
-'Architecture has recorded the great ideas of the human race. Not only every religious symbol, but every human thought has its page in that vast book.' - Victor Hugo = 
- # Requires translation!
-Notre Dame = 
-
+'The temple is like no other building in the world. It has towers and decoration and all the refinements which the human genius can conceive of.'  - Antonio da Magdalena =
+Angkor Wat = Angkor Wat
 Castle = Istana
-
  # Requires translation!
-Mughal Fort = 
+Mughal Fort =
  # Requires translation!
-[stats] = 
-
+'Justice is an unassailable fortress, built on the brow of a mountain which cannot be overthrown by the violence of torrents, nor demolished by the force of armies.'  - Joseph Addison =
  # Requires translation!
-'Bushido is realized in the presence of death. This means choosing death whenever there is a choice between life and death. There is no other reasoning.' - Yamamoto Tsunetomo = 
+Alhambra =
  # Requires translation!
-Himeji Castle = 
-
+Ironworks =
  # Requires translation!
-Ironworks = 
-
+'Architecture has recorded the great ideas of the human race. Not only every religious symbol, but every human thought has its page in that vast book.'  - Victor Hugo =
+ # Requires translation!
+Notre Dame =
 Armory = Gudang Senjata
-
  # Requires translation!
-Observatory = 
-
+Observatory =
 Opera House = Rumah Opera
-
  # Requires translation!
-'I live and love in God's peculiar light.' - Michelangelo Buonarroti = 
+'I live and love in God's peculiar light.' - Michelangelo Buonarroti =
  # Requires translation!
-Sistine Chapel = 
+Sistine Chapel =
 
 Bank = Bank
 
  # Requires translation!
-Satrap's Court = 
-
+Satrap's Court =
  # Requires translation!
-'Most of us can, as we choose, make of this world either a palace or a prison' - John Lubbock = 
++5% Production for every Trade Route with a City-State in the empire =
  # Requires translation!
-Forbidden Palace = 
+Hanse =
  # Requires translation!
-[amount]% unhappiness from population [cityFilter] = 
-
+'Most of us can, as we choose, make of this world either a palace or a prison' - John Lubbock =
+ # Requires translation!
+Unhappiness from population decreased by [amount]% =
+ # Requires translation!
+Forbidden Palace =
 Theatre = Teater
-
+ # Requires translation!
+'Don't clap too hard - it's a very old building.' - John Osbourne =
+ # Requires translation!
+Leaning Tower of Pisa =
+ # Requires translation!
+'Bushido is realized in the presence of death. This means choosing death whenever there is a choice between life and death. There is no other reasoning.'  - Yamamoto Tsunetomo =
+ # Requires translation!
++[amount]% Strength for units fighting in [tileFilter] =
+ # Requires translation!
+Himeji Castle =
 Seaport = Pelabuhan
-
  # Requires translation!
-Hermitage = 
-
+Hermitage =
  # Requires translation!
-'The Taj Mahal rises above the banks of the river like a solitary tear suspended on the cheek of time.' - Rabindranath Tagore = 
+'The Taj Mahal rises above the banks of the river like a solitary tear suspended on the cheek of time.'  - Rabindranath Tagore =
  # Requires translation!
-Taj Mahal = 
+Empire enters golden age =
  # Requires translation!
-Empire enters golden age = 
-
+Taj Mahal =
  # Requires translation!
-'Things always seem fairer when we look back at them, and it is out of that inaccessible tower of the past that Longing leans and beckons.' - James Russell Lowell = 
+'Things always seem fairer when we look back at them, and it is out of that inaccessible tower of the past that Longing leans and beckons.'  - James Russell Lowell =
  # Requires translation!
-Porcelain Tower = 
+Free [unit] appears =
  # Requires translation!
-Free [baseUnitFilter] appears = 
+Science gained from research agreements [amount]% =
  # Requires translation!
-Science gained from research agreements [amount]% = 
-
+Porcelain Tower =
  # Requires translation!
-Windmill = 
-
+Windmill =
  # Requires translation!
-'The Law is a fortress on a hill that armies cannot take or floods wash away.' - The Prophet Muhammed = 
+Arsenal =
+ # Requires translation!
+'The Law is a fortress on a hill that armies cannot take or floods wash away.'  - The Prophet Muhammed =
+ # Requires translation!
+Defensive buildings in all cities are 25% more effective =
 Kremlin = Kremlin
- # Requires translation!
-Defensive buildings in all cities are 25% more effective = 
-
 Museum = Muzium
-
  # Requires translation!
-'Every genuine work of art has as much reason for being as the earth and the sun' - Ralph Waldo Emerson = 
+'Every genuine work of art has as much reason for being as the earth and the sun'  - Ralph Waldo Emerson =
  # Requires translation!
-The Louvre = 
-
+The Louvre =
 Public School = Sekolah Kerajaan
-
 Factory = Kilang
-
  # Requires translation!
-'To achieve great things, two things are needed: a plan, and not quite enough time.' - Leonard Bernstein = 
+'To achieve great things, two things are needed: a plan, and not quite enough time.'  - Leonard Bernstein =
+ # Requires translation!
+[stat] cost of purchasing items in cities [amount]% =
 Big Ben = Big Ben
- # Requires translation!
-[stat] cost of purchasing items in cities [amount]% = 
-
 Military Academy = Akedemi Tentera
-
  # Requires translation!
-'Pale Death beats equally at the poor man's gate and at the palaces of kings.' - Horace = 
+'Pale Death beats equally at the poor man's gate and at the palaces of kings.'  - Horace =
  # Requires translation!
-Brandenburg Gate = 
-
- # Requires translation!
-Arsenal = 
+Brandenburg Gate =
 
 Hospital = Hospital
 
 Stock Exchange = Bursa Saham
 
+Stadium = Stadium
+
 Broadcast Tower = Menara Pencawang
 
  # Requires translation!
-'We live only to discover beauty, all else is a form of waiting' - Kahlil Gibran = 
+'We live only to discover beauty, all else is a form of waiting'  - Kahlil Gibran =
+ # Requires translation!
+Provides 1 happiness per 2 additional social policies adopted =
 Eiffel Tower = Menara Eiffel
- # Requires translation!
-Provides 1 happiness per 2 additional social policies adopted = 
 
  # Requires translation!
-'Give me your tired, your poor, your huddled masses yearning to breathe free, the wretched refuse of your teeming shore. Send these, the homeless, tempest-tossed to me, I lift my lamp beside the golden door!' - Emma Lazarus = 
+Military Base =
+
+ # Requires translation!
+'Give me your tired, your poor, your huddled masses yearning to breathe free, the wretched refuse of your teeming shore. Send these, the homeless, tempest-tossed to me, I lift my lamp beside the golden door!'  - Emma Lazarus =
+ # Requires translation!
+[stats] from every specialist =
 Statue of Liberty = Patung Liberty
- # Requires translation!
-[stats] from every specialist [cityFilter] = 
 
  # Requires translation!
-Military Base = 
-
+'...the location is one of the most beautiful to be found, holy and unapproachable, a worthy temple for the divine friend who has brought salvation and true blessing to the world.'  - King Ludwig II of Bavaria =
  # Requires translation!
-'Come to me, all who labor and are heavy burdened, and I will give you rest.' - New Testament, Matthew 11:28 = 
- # Requires translation!
-Cristo Redentor = 
- # Requires translation!
-Culture cost of adopting new Policies reduced by [amount]% = 
+Neuschwanstein =
 
 Research Lab = Makmal Penyelidik
 
+ # Requires translation!
+'Come to me, all who labor and are heavy burdened, and I will give you rest.'  - New Testament, Matthew 11:28 =
+ # Requires translation!
+Culture cost of adopting new Policies reduced by [amount]% =
+ # Requires translation!
+Cristo Redentor =
+
 Medical Lab = Makmal Medik
 
-
-Stadium = Stadium
-
  # Requires translation!
-'Those who lose dreaming are lost.' - Australian Aboriginal saying = 
-Sydney Opera House = Rumah Sydney Opera
-
+Enables nuclear weapon =
+ # Requires translation!
+Triggers a global alert upon completion =
 Manhattan Project = Projek Manhattan
- # Requires translation!
-Enables nuclear weapon = 
- # Requires translation!
-Triggers a global alert upon completion = 
 
  # Requires translation!
-'In preparing for battle I have always found that plans are useless, but planning is indispensable.' - Dwight D. Eisenhower = 
-Pentagon = Pentagon
+'In preparing for battle I have always found that plans are useless, but planning is indispensable.'  - Dwight D. Eisenhower =
  # Requires translation!
-Gold cost of upgrading [unitType] units reduced by [amount]% = 
+Gold cost of upgrading military units reduced by 33% =
+Pentagon = Pentagon
 
 Solar Plant = Ladang Solar
 
+ # Requires translation!
+'Those who lose dreaming are lost.'  - Australian Aboriginal saying =
+Sydney Opera House = Rumah Sydney Opera
+
 Nuclear Plant = Penjana Nuklear
 
+ # Requires translation!
+Enables construction of Spaceship parts =
 Apollo Program = Program Apollo
- # Requires translation!
-Enables construction of Spaceship parts = 
- # Requires translation!
-Hidden when [param] Victory is disabled = 
 
  # Requires translation!
-SS Cockpit = 
+'Nothing travels faster than light with the possible exception of bad news, which obeys its own special rules.' - Douglas Adams =
  # Requires translation!
-Spaceship part = 
+[amount] population [cityFilter] =
+ # Requires translation!
+[stats] [cityFilter] =
+ # Requires translation!
+CN Tower =
 
  # Requires translation!
-SS Booster = 
+Population loss from nuclear attacks -[amount]% =
+ # Requires translation!
+Bomb Shelter =
 
  # Requires translation!
-Spaceship Factory = 
+Spaceship part =
+ # Requires translation!
+SS Cockpit =
 
  # Requires translation!
-'More than ever before in human history, we share a common destiny. We can master it only if we face it together. And that is why we have the United Nations.' - Kofi Annan = 
+'The wonder is, not that the field of stars is so vast, but that man has measured it.'  - Anatole France =
  # Requires translation!
-United Nations = 
- # Requires translation!
-Triggers voting for the Diplomatic Victory = 
+Hubble Space Telescope =
 
  # Requires translation!
-SS Engine = 
+SS Booster =
 
  # Requires translation!
-SS Stasis Chamber = 
+Spaceship Factory =
 
  # Requires translation!
-Utopia Project = 
+'More than ever before in human history, we share a common destiny. We can master it only if we face it together. And that is why we have the United Nations.' - Kofi Annan =
  # Requires translation!
-Hidden until [amount] social policy branches have been completed = 
+Triggers voting for the Diplomatic Victory =
  # Requires translation!
-Triggers a global alert upon build start = 
+Hidden when [param] Victory is disabled =
  # Requires translation!
-Triggers a Cultural Victory upon completion = 
+United Nations =
+
+ # Requires translation!
+SS Engine =
+
+ # Requires translation!
+SS Stasis Chamber =
+
+ # Requires translation!
+Hidden until [amount] social policy branches have been completed =
+ # Requires translation!
+Triggers a global alert upon build start =
+ # Requires translation!
+Triggers a Cultural Victory upon completion =
+ # Requires translation!
+Utopia Project =
+
+ # Requires translation!
+Cathedral =
+
+ # Requires translation!
+Monastery =
+
+ # Requires translation!
+Mosque =
+
+ # Requires translation!
+Pagoda =
 
 
 #################### Lines from Difficulties from Civ V - Vanilla ####################
@@ -2644,26 +2215,26 @@ Triggers a Cultural Victory upon completion =
 Settler = Peneroka
 
  # Requires translation!
-Chieftain = 
+Chieftain =
 
  # Requires translation!
-Warlord = 
+Warlord =
 
 Prince = Putera
 
 King = Raja
  # Requires translation!
-Era Starting Unit = 
+Era Starting Unit =
 
  # Requires translation!
-Emperor = 
+Emperor =
 
  # Requires translation!
-Immortal = 
+Immortal =
 Worker = Pekerja
 
  # Requires translation!
-Deity = 
+Deity =
 
 
 #################### Lines from Eras from Civ V - Vanilla ####################
@@ -2673,27 +2244,28 @@ Warrior = Pejuang
 
 Classical era = Era Klasik
  # Requires translation!
-Spearman = 
+Spearman =
 
 Medieval era = Era Pertengahan
 
 Renaissance era = Era Pembaharuan
  # Requires translation!
-Pikeman = 
+Pikeman =
 
 Industrial era = Era Industri
  # Requires translation!
-Musketman = 
+Musketman =
 
 Modern era = Era Moden
  # Requires translation!
-Rifleman = 
+Rifleman =
 
  # Requires translation!
-Atomic era = 
+Atomic era =
 Infantry = Infantri
 
 Information era = Era Informasi
+Marine = Marin
 
 Future era = Era Masa Hadapan
 
@@ -2701,6751 +2273,4601 @@ Future era = Era Masa Hadapan
 #################### Lines from Nations from Civ V - Vanilla ####################
 
  # Requires translation!
-Spectator = 
+Spectator =
 
- # Requires translation!
-Nebuchadnezzar II = 
- # Requires translation!
-The demon wants the blood of soldiers! = 
- # Requires translation!
-Oh well, I presume you know what you're doing. = 
- # Requires translation!
-It is over. Perhaps now I shall have peace, at last. = 
- # Requires translation!
-Are you real or a phantom? = 
- # Requires translation!
-It appears that you do have a reason for existing – to make this deal with me. = 
- # Requires translation!
-Greetings. = 
- # Requires translation!
-What do YOU want?! = 
- # Requires translation!
-Ingenuity = 
- # Requires translation!
-May the blessings of heaven be upon you, O great Nebuchadnezzar, father of mighty and ancient Babylon! Young was the world when Sargon built Babylon some five thousand years ago, long did it grow and prosper, gaining its first empire the eighteenth century BC, under godlike Hammurabi, the giver of law. Although conquered by the Kassites and then by the Assyrians, Babylon endured, emerging phoenix-like from its ashes of destruction and regaining its independence despite its many enemies. Truly was Babylon the center of arts and learning in the ancient world. O Nebuchadnezzar, your empire endured but a short time after your death, falling to the mighty Persians, and then to the Greeks, until the great city was destroyed by 141 BC. = 
- # Requires translation!
-But is Babylon indeed gone forever, great Nebuchadnezzar? Your people look to you to bring the empire back to life once more. Will you accept the challenge? Will you build a civilization that will stand the test of time? = 
 Babylon = Babylon
  # Requires translation!
-Akkad = 
+Nebuchadnezzar II =
  # Requires translation!
-Dur-Kurigalzu = 
+The demon wants the blood of soldiers! =
  # Requires translation!
-Nippur = 
+Oh well, I presume you know what you're doing. =
  # Requires translation!
-Borsippa = 
+It is over. Perhaps now I shall have peace, at last. =
  # Requires translation!
-Sippar = 
+Are you real or a phantom? =
  # Requires translation!
-Opis = 
+It appears that you do have a reason for existing – to make this deal with me. =
  # Requires translation!
-Mari = 
+Greetings. =
  # Requires translation!
-Shushan = 
+What do YOU want?! =
  # Requires translation!
-Eshnunna = 
+Ingenuity =
  # Requires translation!
-Ellasar = 
+Receive free [unit] when you discover [tech] =
  # Requires translation!
-Erech = 
+[unit] is earned [amount]% faster =
  # Requires translation!
-Kutha = 
+May the blessings of heaven be upon you, O great Nebuchadnezzar, father of mighty and ancient Babylon! Young was the world when Sargon built Babylon some five thousand years ago, long did it grow and prosper, gaining its first empire the eighteenth century BC, under godlike Hammurabi, the giver of law. Although conquered by the Kassites and then by the Assyrians, Babylon endured, emerging phoenix-like from its ashes of destruction and regaining its independence despite its many enemies. Truly was Babylon the center of arts and learning in the ancient world. O Nebuchadnezzar, your empire endured but a short time after your death, falling to the mighty Persians, and then to the Greeks, until the great city was destroyed by 141 BC. =
  # Requires translation!
-Sirpurla = 
+But is Babylon indeed gone forever, great Nebuchadnezzar? Your people look to you to bring the empire back to life once more. Will you accept the challenge? Will you build a civilization that will stand the test of time? =
  # Requires translation!
-Neribtum = 
+Akkad =
  # Requires translation!
-Ashur = 
+Dur-Kurigalzu =
  # Requires translation!
-Ninveh = 
+Nippur =
  # Requires translation!
-Nimrud = 
+Borsippa =
  # Requires translation!
-Arbela = 
+Sippar =
  # Requires translation!
-Nuzi = 
+Opis =
  # Requires translation!
-Arrapkha = 
+Mari =
  # Requires translation!
-Tutub = 
+Shushan =
  # Requires translation!
-Shaduppum = 
+Eshnunna =
  # Requires translation!
-Rapiqum = 
+Ellasar =
  # Requires translation!
-Mashkan Shapir = 
+Erech =
  # Requires translation!
-Tuttul = 
+Kutha =
  # Requires translation!
-Ramad = 
+Sirpurla =
  # Requires translation!
-Ana = 
+Neribtum =
  # Requires translation!
-Haradum = 
+Ashur =
  # Requires translation!
-Agrab = 
+Ninveh =
  # Requires translation!
-Uqair = 
+Nimrud =
  # Requires translation!
-Gubba = 
+Arbela =
  # Requires translation!
-Hafriyat = 
+Nuzi =
  # Requires translation!
-Nagar = 
+Arrapkha =
  # Requires translation!
-Shubat Enlil = 
+Tutub =
  # Requires translation!
-Urhai = 
+Shaduppum =
  # Requires translation!
-Urkesh = 
+Rapiqum =
  # Requires translation!
-Awan = 
+Mashkan Shapir =
  # Requires translation!
-Riblah = 
+Tuttul =
  # Requires translation!
-Tayma = 
+Ramad =
  # Requires translation!
-Receive free [unit] when you discover [tech] = 
+Ana =
  # Requires translation!
-[unit] is earned [amount]% faster = 
-
+Haradum =
  # Requires translation!
-Alexander = 
+Agrab =
  # Requires translation!
-You are in my way, you must be destroyed. = 
+Uqair =
  # Requires translation!
-As a matter of fact I too grow weary of peace. = 
+Gubba =
  # Requires translation!
-You have somehow become my undoing! What kind of beast are you? = 
+Hafriyat =
  # Requires translation!
-Hello stranger! I am Alexandros, son of kings and grandson of the gods! = 
+Nagar =
  # Requires translation!
-My friend, does this seem reasonable to you? = 
+Shubat Enlil =
  # Requires translation!
-Greetings! = 
+Urhai =
  # Requires translation!
-What? = 
+Urkesh =
  # Requires translation!
-Hellenic League = 
+Awan =
  # Requires translation!
-May the blessings of the gods be upon you, oh great King Alexander! You are the ruler of the mighty Greek nation. Your people lived for so many years in isolated city-states - legendary cities such as Athens, Sparta, Thebes - where they gave the world many great things, such as democracy, philosophy, tragedy, art and architecture, the very foundation of Western Civilization. Although few in number and often hostile to each other, in the 5th century BC they were able to defeat their much larger neighbor, Persia, on land and sea. = 
+Riblah =
  # Requires translation!
-Alexander, your people stand ready to march to war, to spread the great Greek culture to millions and to bring you everlasting glory. Are you ready to accept your destiny, King Alexander? Will you lead your people to triumph and greatness? Can you build a civilization that will stand the test of time? = 
- # Requires translation!
-Athens = 
- # Requires translation!
-Sparta = 
- # Requires translation!
-Corinth = 
- # Requires translation!
-Argos = 
- # Requires translation!
-Knossos = 
- # Requires translation!
-Mycenae = 
- # Requires translation!
-Pharsalos = 
- # Requires translation!
-Ephesus = 
- # Requires translation!
-Halicarnassus = 
- # Requires translation!
-Rhodes = 
- # Requires translation!
-Eretria = 
- # Requires translation!
-Pergamon = 
- # Requires translation!
-Miletos = 
- # Requires translation!
-Megara = 
- # Requires translation!
-Phocaea = 
- # Requires translation!
-Sicyon = 
- # Requires translation!
-Tiryns = 
- # Requires translation!
-Samos = 
- # Requires translation!
-Mytilene = 
- # Requires translation!
-Chios = 
- # Requires translation!
-Paros = 
- # Requires translation!
-Elis = 
- # Requires translation!
-Syracuse = 
- # Requires translation!
-Herakleia = 
- # Requires translation!
-Gortyn = 
- # Requires translation!
-Chalkis = 
- # Requires translation!
-Pylos = 
- # Requires translation!
-Pella = 
- # Requires translation!
-Naxos = 
- # Requires translation!
-Larissa = 
- # Requires translation!
-Apollonia = 
- # Requires translation!
-Messene = 
- # Requires translation!
-Orchomenos = 
- # Requires translation!
-Ambracia = 
- # Requires translation!
-Kos = 
- # Requires translation!
-Knidos = 
- # Requires translation!
-Amphipolis = 
- # Requires translation!
-Patras = 
- # Requires translation!
-Lamia = 
- # Requires translation!
-Nafplion = 
- # Requires translation!
-Apolyton = 
+Tayma =
 Greece = Yunani
  # Requires translation!
-City-State Influence degrades [amount]% slower = 
+Alexander =
  # Requires translation!
-City-State Influence recovers at twice the normal rate = 
+You are in my way, you must be destroyed. =
  # Requires translation!
-City-State territory always counts as friendly territory = 
-
+As a matter of fact I too grow weary of peace. =
  # Requires translation!
-Wu Zetian = 
+You have somehow become my undoing! What kind of beast are you? =
  # Requires translation!
-You won't ever be able to bother me again. Go meet Yama. = 
+Hello stranger! I am Alexandros, son of kings and grandson of the gods! =
  # Requires translation!
-Fool! I will disembowel you all! = 
+My friend, does this seem reasonable to you? =
  # Requires translation!
-You have proven to be a cunning and competent adversary. I congratulate you on your victory. = 
+Greetings! =
  # Requires translation!
-Greetings, I am Empress Wu Zetian. China desires peace and development. You leave us alone, we'll leave you alone. = 
+What? =
  # Requires translation!
-My friend, do you think you can accept this request? = 
+Hellenic League =
  # Requires translation!
-How are you today? = 
+City-State Influence degrades [amount]% slower =
  # Requires translation!
-Oh. It's you? = 
+City-State Influence recovers at twice the normal rate =
  # Requires translation!
-Art of War = 
+May the blessings of the gods be upon you, oh great King Alexander! You are the ruler of the mighty Greek nation. Your people lived for so many years in isolated city-states - legendary cities such as Athens, Sparta, Thebes - where they gave the world many great things, such as democracy, philosophy, tragedy, art and architecture, the very foundation of Western Civilization. Although few in number and often hostile to each other, in the 5th century BC they were able to defeat their much larger neighbor, Persia, on land and sea. =
  # Requires translation!
-The Blessings of Heaven be upon you. Empress Wu Zetian, most beautiful and haughty ruler of China! Oh great Empress, whose shadow causes the flowers to blossom and the rivers to flow! You are the leader of the Chinese, the oldest and the greatest civilization that humanity has ever produced. China's history stretches back into the mists of time, its people achieving many great things long before the other upstart civilizations were even conceived. China's contributions to the arts and sciences are too many and too wondrous to do justice to - the printing press, gunpowder, the works of Confucius - these are but a few of the gifts China has given to an undeserving world! = 
+Alexander, your people stand ready to march to war, to spread the great Greek culture to millions and to bring you everlasting glory. Are you ready to accept your destiny, King Alexander? Will you lead your people to triumph and greatness? Can you build a civilization that will stand the test of time? =
  # Requires translation!
-You, great Queen, who, with cunning and beauty, rose from the position of lowly concubine to that of Divine Empress - your people call out to you to lead them! Great China is once again beset on all sides by barbarians. Can you defeat all your many foes and return your country to greatness? Can you build a civilization to stand the test of time? = 
+Athens =
  # Requires translation!
-Beijing = 
+Sparta =
  # Requires translation!
-Shanghai = 
+Corinth =
  # Requires translation!
-Guangzhou = 
+Argos =
  # Requires translation!
-Nanjing = 
+Knossos =
  # Requires translation!
-Xian = 
+Mycenae =
  # Requires translation!
-Chengdu = 
+Pharsalos =
  # Requires translation!
-Hangzhou = 
+Ephesus =
  # Requires translation!
-Tianjin = 
+Halicarnassus =
  # Requires translation!
-Macau = 
+Rhodes =
  # Requires translation!
-Shandong = 
+Eretria =
  # Requires translation!
-Kaifeng = 
+Pergamon =
  # Requires translation!
-Ningbo = 
+Miletos =
  # Requires translation!
-Baoding = 
+Megara =
  # Requires translation!
-Yangzhou = 
+Phocaea =
  # Requires translation!
-Harbin = 
+Sicyon =
  # Requires translation!
-Chongqing = 
+Tiryns =
  # Requires translation!
-Luoyang = 
+Samos =
  # Requires translation!
-Kunming = 
+Mytilene =
  # Requires translation!
-Taipei = 
+Chios =
  # Requires translation!
-Shenyang = 
+Paros =
  # Requires translation!
-Taiyuan = 
+Elis =
  # Requires translation!
-Tainan = 
+Syracuse =
  # Requires translation!
-Dalian = 
+Herakleia =
  # Requires translation!
-Lijiang = 
+Gortyn =
  # Requires translation!
-Wuxi = 
+Chalkis =
  # Requires translation!
-Suzhou = 
+Pylos =
  # Requires translation!
-Maoming = 
+Pella =
  # Requires translation!
-Shaoguan = 
+Naxos =
  # Requires translation!
-Yangjiang = 
+Larissa =
  # Requires translation!
-Heyuan = 
+Apollonia =
  # Requires translation!
-Huangshi = 
+Messene =
  # Requires translation!
-Yichang = 
+Orchomenos =
  # Requires translation!
-Yingtian = 
+Ambracia =
  # Requires translation!
-Xinyu = 
+Kos =
  # Requires translation!
-Xinzheng = 
+Knidos =
  # Requires translation!
-Handan = 
+Amphipolis =
  # Requires translation!
-Dunhuang = 
+Patras =
  # Requires translation!
-Gaoyu = 
+Lamia =
  # Requires translation!
-Nantong = 
+Nafplion =
  # Requires translation!
-Weifang = 
- # Requires translation!
-Xikang = 
+Apolyton =
 China = Cina
  # Requires translation!
-Great General provides double combat bonus = 
+Wu Zetian =
+ # Requires translation!
+You won't ever be able to bother me again. Go meet Yama. =
+ # Requires translation!
+Fool! I will disembowel you all! =
+ # Requires translation!
+You have proven to be a cunning and competent adversary. I congratulate you on your victory. =
+ # Requires translation!
+Greetings, I am Empress Wu Zetian. China desires peace and development. You leave us alone, we'll leave you alone. =
+ # Requires translation!
+My friend, do you think you can accept this request? =
+ # Requires translation!
+How are you today? =
+ # Requires translation!
+Oh. It's you? =
+ # Requires translation!
+Art of War =
+ # Requires translation!
+Great General provides double combat bonus =
+ # Requires translation!
+The Blessings of Heaven be upon you. Empress Wu Zetian, most beautiful and haughty ruler of China! Oh great Empress, whose shadow causes the flowers to blossom and the rivers to flow! You are the leader of the Chinese, the oldest and the greatest civilization that humanity has ever produced. China's history stretches back into the mists of time, its people achieving many great things long before the other upstart civilizations were even conceived. China's contributions to the arts and sciences are too many and too wondrous to do justice to - the printing press, gunpowder, the works of Confucius - these are but a few of the gifts China has given to an undeserving world! =
+ # Requires translation!
+You, great Queen, who, with cunning and beauty, rose from the position of lowly concubine to that of Divine Empress - your people call out to you to lead them! Great China is once again beset on all sides by barbarians. Can you defeat all your many foes and return your country to greatness? Can you build a civilization to stand the test of time? =
+ # Requires translation!
+Beijing =
+ # Requires translation!
+Shanghai =
+ # Requires translation!
+Guangzhou =
+ # Requires translation!
+Nanjing =
+ # Requires translation!
+Xian =
+ # Requires translation!
+Chengdu =
+ # Requires translation!
+Hangzhou =
+ # Requires translation!
+Tianjin =
+ # Requires translation!
+Macau =
+ # Requires translation!
+Shandong =
+ # Requires translation!
+Kaifeng =
+ # Requires translation!
+Ningbo =
+ # Requires translation!
+Baoding =
+ # Requires translation!
+Yangzhou =
+ # Requires translation!
+Harbin =
+ # Requires translation!
+Chongqing =
+ # Requires translation!
+Luoyang =
+ # Requires translation!
+Kunming =
+ # Requires translation!
+Taipei =
+ # Requires translation!
+Shenyang =
+ # Requires translation!
+Taiyuan =
+ # Requires translation!
+Tainan =
+ # Requires translation!
+Dalian =
+ # Requires translation!
+Lijiang =
+ # Requires translation!
+Wuxi =
+ # Requires translation!
+Suzhou =
+ # Requires translation!
+Maoming =
+ # Requires translation!
+Shaoguan =
+ # Requires translation!
+Yangjiang =
+ # Requires translation!
+Heyuan =
+ # Requires translation!
+Huangshi =
+ # Requires translation!
+Yichang =
+ # Requires translation!
+Yingtian =
+ # Requires translation!
+Xinyu =
+ # Requires translation!
+Xinzheng =
+ # Requires translation!
+Handan =
+ # Requires translation!
+Dunhuang =
+ # Requires translation!
+Gaoyu =
+ # Requires translation!
+Nantong =
+ # Requires translation!
+Weifang =
+ # Requires translation!
+Xikang =
 
- # Requires translation!
-Ramesses II = 
- # Requires translation!
-You are but a pest on this Earth, prepare to be eliminated! = 
- # Requires translation!
-You are a fool who evokes pity. You have brought my hostility upon yourself and your repulsive civilization! = 
- # Requires translation!
-Strike me down and my soul will torment yours forever, you have won nothing. = 
- # Requires translation!
-Greetings, I am Ramesses the god. I am the living embodiment of Egypt, mother and father of all civilizations. = 
- # Requires translation!
-Generous Egypt makes you this offer. = 
- # Requires translation!
-Good day. = 
- # Requires translation!
-Oh, it's you. = 
- # Requires translation!
-Monument Builders = 
- # Requires translation!
-We greet thee, oh great Ramesses, Pharaoh of Egypt, who causes the sun to rise and the Nile to flow, and who blesses his fortunate people with all the good things of life! Oh great lord, from time immemorial your people lived on the banks of the Nile river, where they brought writing to the world, and advanced mathematics, sculpture, and architecture. Thousands of years ago they created the great monuments which still stand tall and proud. = 
- # Requires translation!
-Oh, Ramesses, for uncounted years your people endured, as other petty nations around them have risen and then fallen into dust. They look to you to lead them once more into greatness. Can you honor the gods and bring Egypt back to her rightful place at the very center of the world? Can you build a civilization that will stand the test of time? = 
- # Requires translation!
-Thebes = 
- # Requires translation!
-Memphis = 
- # Requires translation!
-Heliopolis = 
- # Requires translation!
-Elephantine = 
- # Requires translation!
-Alexandria = 
- # Requires translation!
-Pi-Ramesses = 
- # Requires translation!
-Giza = 
- # Requires translation!
-Byblos = 
- # Requires translation!
-Akhetaten = 
- # Requires translation!
-Hieraconpolis = 
- # Requires translation!
-Abydos = 
- # Requires translation!
-Asyut = 
- # Requires translation!
-Avaris = 
- # Requires translation!
-Lisht = 
- # Requires translation!
-Buto = 
- # Requires translation!
-Edfu = 
- # Requires translation!
-Pithom = 
- # Requires translation!
-Busiris = 
- # Requires translation!
-Kahun = 
- # Requires translation!
-Athribis = 
- # Requires translation!
-Mendes = 
- # Requires translation!
-Elashmunein = 
- # Requires translation!
-Tanis = 
- # Requires translation!
-Bubastis = 
- # Requires translation!
-Oryx = 
- # Requires translation!
-Sebennytus = 
- # Requires translation!
-Akhmin = 
- # Requires translation!
-Karnak = 
- # Requires translation!
-Luxor = 
- # Requires translation!
-El Kab = 
- # Requires translation!
-Armant = 
- # Requires translation!
-Balat = 
- # Requires translation!
-Ellahun = 
- # Requires translation!
-Hawara = 
- # Requires translation!
-Dashur = 
- # Requires translation!
-Damanhur = 
- # Requires translation!
-Abusir = 
- # Requires translation!
-Herakleopolis = 
- # Requires translation!
-Akoris = 
- # Requires translation!
-Benihasan = 
- # Requires translation!
-Badari = 
- # Requires translation!
-Hermopolis = 
- # Requires translation!
-Amrah = 
- # Requires translation!
-Koptos = 
- # Requires translation!
-Ombos = 
- # Requires translation!
-Naqada = 
- # Requires translation!
-Semna = 
- # Requires translation!
-Soleb = 
 Egypt = Mesir
  # Requires translation!
-[amount]% Production when constructing [buildingFilter] wonders [cityFilter] = 
-
+Ramesses II =
  # Requires translation!
-Elizabeth = 
+You are but a pest on this Earth, prepare to be eliminated! =
  # Requires translation!
-By the grace of God, your days are numbered. = 
+You are a fool who evokes pity. You have brought my hostility upon yourself and your repulsive civilization! =
  # Requires translation!
-We shall never surrender. = 
+Strike me down and my soul will torment yours forever, you have won nothing. =
  # Requires translation!
-You have triumphed over us. The day is yours. = 
+Greetings, I am Ramesses the god. I am the living embodiment of Egypt, mother and father of all civilizations. =
  # Requires translation!
-We are pleased to meet you. = 
+Generous Egypt makes you this offer. =
  # Requires translation!
-Would you be interested in a trade agreement with England? = 
+Good day. =
  # Requires translation!
-Hello, again. = 
+Oh, it's you. =
  # Requires translation!
-Oh, it's you! = 
+Monument Builders =
  # Requires translation!
-Sun Never Sets = 
+We greet thee, oh great Ramesses, Pharaoh of Egypt, who causes the sun to rise and the Nile to flow, and who blesses his fortunate people with all the good things of life! Oh great lord, from time immemorial your people lived on the banks of the Nile river, where they brought writing to the world, and advanced mathematics, sculpture, and architecture. Thousands of years ago they created the great monuments which still stand tall and proud. =
  # Requires translation!
-Praises upon her serene highness, Queen Elizabeth Gloriana. You lead and protect the celebrated maritime nation of England. England is an ancient land, settled as early as 35,000 years ago. The island has seen countless waves of invaders, each in turn becoming a part of the fabric of the people. Although England is a small island, for many years your people dominated the world stage. Their matchless navy, brilliant artists and shrewd merchants, giving them power and influence far in excess of their mere numbers. = 
+Oh, Ramesses, for uncounted years your people endured, as other petty nations around them have risen and then fallen into dust. They look to you to lead them once more into greatness. Can you honor the gods and bring Egypt back to her rightful place at the very center of the world? Can you build a civilization that will stand the test of time? =
  # Requires translation!
-Queen Elizabeth, will you bring about a new golden age for the English people? They look to you once more to return peace and prosperity to the nation. Will you take up the mantle of greatness? Can you build a civilization that will stand the test of time? = 
+Thebes =
  # Requires translation!
-London = 
+Memphis =
  # Requires translation!
-York = 
+Heliopolis =
  # Requires translation!
-Nottingham = 
+Elephantine =
  # Requires translation!
-Hastings = 
+Alexandria =
  # Requires translation!
-Canterbury = 
+Pi-Ramesses =
  # Requires translation!
-Coventry = 
+Giza =
  # Requires translation!
-Warwick = 
+Byblos =
  # Requires translation!
-Newcastle = 
+Akhetaten =
  # Requires translation!
-Oxford = 
+Hieraconpolis =
  # Requires translation!
-Liverpool = 
+Abydos =
  # Requires translation!
-Dover = 
+Asyut =
  # Requires translation!
-Brighton = 
+Avaris =
  # Requires translation!
-Norwich = 
+Lisht =
  # Requires translation!
-Leeds = 
+Buto =
  # Requires translation!
-Reading = 
+Edfu =
  # Requires translation!
-Birmingham = 
+Pithom =
  # Requires translation!
-Richmond = 
+Busiris =
  # Requires translation!
-Exeter = 
+Kahun =
  # Requires translation!
-Cambridge = 
+Athribis =
  # Requires translation!
-Gloucester = 
+Mendes =
  # Requires translation!
-Manchester = 
+Elashmunein =
  # Requires translation!
-Bristol = 
+Tanis =
  # Requires translation!
-Leicester = 
+Bubastis =
  # Requires translation!
-Carlisle = 
+Oryx =
  # Requires translation!
-Ipswich = 
+Sebennytus =
  # Requires translation!
-Portsmouth = 
+Akhmin =
  # Requires translation!
-Berwick = 
+Karnak =
  # Requires translation!
-Bath = 
+Luxor =
  # Requires translation!
-Mumbles = 
+El Kab =
  # Requires translation!
-Southampton = 
+Armant =
  # Requires translation!
-Sheffield = 
+Balat =
  # Requires translation!
-Salisbury = 
+Ellahun =
  # Requires translation!
-Colchester = 
+Hawara =
  # Requires translation!
-Plymouth = 
+Dashur =
  # Requires translation!
-Lancaster = 
+Damanhur =
  # Requires translation!
-Blackpool = 
+Abusir =
  # Requires translation!
-Winchester = 
+Herakleopolis =
  # Requires translation!
-Hull = 
+Akoris =
+ # Requires translation!
+Benihasan =
+ # Requires translation!
+Badari =
+ # Requires translation!
+Hermopolis =
+ # Requires translation!
+Amrah =
+ # Requires translation!
+Koptos =
+ # Requires translation!
+Ombos =
+ # Requires translation!
+Naqada =
+ # Requires translation!
+Semna =
+ # Requires translation!
+Soleb =
 England = England
+ # Requires translation!
+Elizabeth =
+ # Requires translation!
+By the grace of God, your days are numbered. =
+ # Requires translation!
+We shall never surrender. =
+ # Requires translation!
+You have triumphed over us. The day is yours. =
+ # Requires translation!
+We are pleased to meet you. =
+ # Requires translation!
+Would you be interested in a trade agreement with England? =
+ # Requires translation!
+Hello, again. =
+ # Requires translation!
+Oh, it's you! =
+ # Requires translation!
+Sun Never Sets =
+ # Requires translation!
+Praises upon her serene highness, Queen Elizabeth Gloriana. You lead and protect the celebrated maritime nation of England. England is an ancient land, settled as early as 35,000 years ago. The island has seen countless waves of invaders, each in turn becoming a part of the fabric of the people. Although England is a small island, for many years your people dominated the world stage. Their matchless navy, brilliant artists and shrewd merchants, giving them power and influence far in excess of their mere numbers. =
+ # Requires translation!
+Queen Elizabeth, will you bring about a new golden age for the English people? They look to you once more to return peace and prosperity to the nation. Will you take up the mantle of greatness? Can you build a civilization that will stand the test of time? =
+ # Requires translation!
+London =
+ # Requires translation!
+York =
+ # Requires translation!
+Nottingham =
+ # Requires translation!
+Hastings =
+ # Requires translation!
+Canterbury =
+ # Requires translation!
+Coventry =
+ # Requires translation!
+Warwick =
+ # Requires translation!
+Newcastle =
+ # Requires translation!
+Oxford =
+ # Requires translation!
+Liverpool =
+ # Requires translation!
+Dover =
+ # Requires translation!
+Brighton =
+ # Requires translation!
+Norwich =
+ # Requires translation!
+Leeds =
+ # Requires translation!
+Reading =
+ # Requires translation!
+Birmingham =
+ # Requires translation!
+Richmond =
+ # Requires translation!
+Exeter =
+ # Requires translation!
+Cambridge =
+ # Requires translation!
+Gloucester =
+ # Requires translation!
+Manchester =
+ # Requires translation!
+Bristol =
+ # Requires translation!
+Leicester =
+ # Requires translation!
+Carlisle =
+ # Requires translation!
+Ipswich =
+ # Requires translation!
+Portsmouth =
+ # Requires translation!
+Berwick =
+ # Requires translation!
+Bath =
+ # Requires translation!
+Mumbles =
+ # Requires translation!
+Southampton =
+ # Requires translation!
+Sheffield =
+ # Requires translation!
+Salisbury =
+ # Requires translation!
+Colchester =
+ # Requires translation!
+Plymouth =
+ # Requires translation!
+Lancaster =
+ # Requires translation!
+Blackpool =
+ # Requires translation!
+Winchester =
+ # Requires translation!
+Hull =
 
- # Requires translation!
-Napoleon = 
- # Requires translation!
-You're disturbing us, prepare for war. = 
- # Requires translation!
-You've fallen into my trap. I'll bury you. = 
- # Requires translation!
-I congratulate you for your victory. = 
- # Requires translation!
-Welcome. I'm Napoleon, of France; the smartest military man in world history. = 
- # Requires translation!
-France offers you this exceptional proposition. = 
- # Requires translation!
-Hello. = 
- # Requires translation!
-It's you. = 
- # Requires translation!
-Ancien Régime = 
- # Requires translation!
-Long life and triumph to you, First Consul and Emperor of France, Napoleon I, ruler of the French people. France lies at the heart of Europe. Long has Paris been the world center of culture, arts and letters. Although surrounded by competitors - and often enemies - France has endured as a great nation. Its armies have marched triumphantly into battle from one end of the world to the other, its soldiers and generals among the best in history. = 
- # Requires translation!
-Napoleon Bonaparte, France yearns for you to rebuild your empire, to lead her once more to glory and greatness, to make France once more the epicenter of culture and refinement. Emperor, will you ride once more against your foes? Can you build a civilization that will stand the test of time? = 
- # Requires translation!
-Paris = 
- # Requires translation!
-Orleans = 
- # Requires translation!
-Lyon = 
- # Requires translation!
-Troyes = 
- # Requires translation!
-Tours = 
- # Requires translation!
-Marseille = 
- # Requires translation!
-Chartres = 
- # Requires translation!
-Avignon = 
- # Requires translation!
-Rouen = 
- # Requires translation!
-Grenoble = 
- # Requires translation!
-Dijon = 
- # Requires translation!
-Amiens = 
- # Requires translation!
-Cherbourg = 
- # Requires translation!
-Poitiers = 
- # Requires translation!
-Toulouse = 
- # Requires translation!
-Bayonne = 
- # Requires translation!
-Strasbourg = 
- # Requires translation!
-Brest = 
- # Requires translation!
-Bordeaux = 
- # Requires translation!
-Rennes = 
- # Requires translation!
-Nice = 
- # Requires translation!
-Saint Etienne = 
- # Requires translation!
-Nantes = 
- # Requires translation!
-Reims = 
- # Requires translation!
-Le Mans = 
- # Requires translation!
-Montpellier = 
- # Requires translation!
-Limoges = 
- # Requires translation!
-Nancy = 
- # Requires translation!
-Lille = 
- # Requires translation!
-Caen = 
- # Requires translation!
-Toulon = 
- # Requires translation!
-Le Havre = 
- # Requires translation!
-Lourdes = 
- # Requires translation!
-Cannes = 
- # Requires translation!
-Aix-En-Provence = 
- # Requires translation!
-La Rochelle = 
- # Requires translation!
-Bourges = 
- # Requires translation!
-Calais = 
 France = Perancis
  # Requires translation!
-[stats] per turn from cities before [tech/policy] = 
-
+Napoleon =
  # Requires translation!
-Catherine = 
+You're disturbing us, prepare for war. =
  # Requires translation!
-You've behaved yourself very badly, you know it. Now it's payback time. = 
+You've fallen into my trap. I'll bury you. =
  # Requires translation!
-You've mistaken my passion for a weakness, you'll regret about this. = 
+I congratulate you for your victory. =
  # Requires translation!
-We were defeated, so this makes me your prisoner. I suppose there are worse fates. = 
+Welcome. I'm Napoleon, of France; the smartest military man in world history. =
  # Requires translation!
-I greet you, stranger! If you are as intelligent and tactful as you are attractive, we'll get along just fine. = 
+France offers you this exceptional proposition. =
  # Requires translation!
-How would you like it if I propose this kind of exchange? = 
+Hello. =
  # Requires translation!
-Hello! = 
+It's you. =
  # Requires translation!
-What do you need?! = 
+Ancien Régime =
  # Requires translation!
-Siberian Riches = 
+[stats] per turn from cities before [tech] =
  # Requires translation!
-Greetings upon thee, Your Imperial Majesty Catherine, wondrous Empress of all the Russias. At your command lies the largest country in the world. Mighty Russia stretches from the Pacific Ocean in the east to the Baltic Sea in the west. Despite wars, droughts, and every manner of disaster the heroic Russian people survive and prosper, their artists and scientists among the best in the world. The Empire today remains one of the strongest ever seen in human history - a true superpower, with the greatest destructive force ever devised at her command. = 
+Long life and triumph to you, First Consul and Emperor of France, Napoleon I, ruler of the French people. France lies at the heart of Europe. Long has Paris been the world center of culture, arts and letters. Although surrounded by competitors - and often enemies - France has endured as a great nation. Its armies have marched triumphantly into battle from one end of the world to the other, its soldiers and generals among the best in history. =
  # Requires translation!
-Catherine, your people look to you to bring forth glorious days for Russia and her people, to revitalize the land and recapture the wonder of the Enlightenment. Will you lead your people once more into greatness? Can you build a civilization that will stand the test of time? = 
+Napoleon Bonaparte, France yearns for you to rebuild your empire, to lead her once more to glory and greatness, to make France once more the epicenter of culture and refinement. Emperor, will you ride once more against your foes? Can you build a civilization that will stand the test of time? =
  # Requires translation!
-Moscow = 
+Paris =
  # Requires translation!
-St. Petersburg = 
+Orleans =
  # Requires translation!
-Novgorod = 
+Lyon =
  # Requires translation!
-Rostov = 
+Troyes =
  # Requires translation!
-Yaroslavl = 
+Tours =
  # Requires translation!
-Yekaterinburg = 
+Marseille =
  # Requires translation!
-Yakutsk = 
+Chartres =
  # Requires translation!
-Vladivostok = 
+Avignon =
  # Requires translation!
-Smolensk = 
+Rouen =
  # Requires translation!
-Orenburg = 
+Grenoble =
  # Requires translation!
-Krasnoyarsk = 
+Dijon =
  # Requires translation!
-Khabarovsk = 
+Amiens =
  # Requires translation!
-Bryansk = 
+Cherbourg =
  # Requires translation!
-Tver = 
+Poitiers =
  # Requires translation!
-Novosibirsk = 
+Toulouse =
  # Requires translation!
-Magadan = 
+Bayonne =
  # Requires translation!
-Murmansk = 
+Strasbourg =
  # Requires translation!
-Irkutsk = 
+Brest =
  # Requires translation!
-Chita = 
+Bordeaux =
  # Requires translation!
-Samara = 
+Rennes =
  # Requires translation!
-Arkhangelsk = 
+Nice =
  # Requires translation!
-Chelyabinsk = 
+Saint Etienne =
  # Requires translation!
-Tobolsk = 
+Nantes =
  # Requires translation!
-Vologda = 
+Reims =
  # Requires translation!
-Omsk = 
+Le Mans =
  # Requires translation!
-Astrakhan = 
+Montpellier =
  # Requires translation!
-Kursk = 
+Limoges =
  # Requires translation!
-Saratov = 
+Nancy =
  # Requires translation!
-Tula = 
+Lille =
  # Requires translation!
-Vladimir = 
+Caen =
  # Requires translation!
-Perm = 
+Toulon =
  # Requires translation!
-Voronezh = 
+Le Havre =
  # Requires translation!
-Pskov = 
+Lourdes =
  # Requires translation!
-Starayarussa = 
+Cannes =
  # Requires translation!
-Kostoma = 
+Aix-En-Provence =
  # Requires translation!
-Nizhniy Novgorod = 
+La Rochelle =
  # Requires translation!
-Suzdal = 
+Bourges =
  # Requires translation!
-Magnitogorsk = 
+Calais =
 Russia = Rusia
  # Requires translation!
-Double quantity of [resource] produced = 
+Catherine =
+ # Requires translation!
+You've behaved yourself very badly, you know it. Now it's payback time. =
+ # Requires translation!
+You've mistaken my passion for a weakness, you'll regret about this. =
+ # Requires translation!
+We were defeated, so this makes me your prisoner. I suppose there are worse fates. =
+ # Requires translation!
+I greet you, stranger! If you are as intelligent and tactful as you are attractive, we'll get along just fine. =
+ # Requires translation!
+How would you like it if I propose this kind of exchange? =
+ # Requires translation!
+Hello! =
+ # Requires translation!
+What do you need?! =
+ # Requires translation!
+Siberian Riches =
+ # Requires translation!
+Double quantity of [resource] produced =
+ # Requires translation!
+Greetings upon thee, Your Imperial Majesty Catherine, wondrous Empress of all the Russias. At your command lies the largest country in the world. Mighty Russia stretches from the Pacific Ocean in the east to the Baltic Sea in the west. Despite wars, droughts, and every manner of disaster the heroic Russian people survive and prosper, their artists and scientists among the best in the world. The Empire today remains one of the strongest ever seen in human history - a true superpower, with the greatest destructive force ever devised at her command. =
+ # Requires translation!
+Catherine, your people look to you to bring forth glorious days for Russia and her people, to revitalize the land and recapture the wonder of the Enlightenment. Will you lead your people once more into greatness? Can you build a civilization that will stand the test of time? =
+ # Requires translation!
+Moscow =
+ # Requires translation!
+St. Petersburg =
+ # Requires translation!
+Novgorod =
+ # Requires translation!
+Rostov =
+ # Requires translation!
+Yaroslavl =
+ # Requires translation!
+Yekaterinburg =
+ # Requires translation!
+Yakutsk =
+ # Requires translation!
+Vladivostok =
+ # Requires translation!
+Smolensk =
+ # Requires translation!
+Orenburg =
+ # Requires translation!
+Krasnoyarsk =
+ # Requires translation!
+Khabarovsk =
+ # Requires translation!
+Bryansk =
+ # Requires translation!
+Tver =
+ # Requires translation!
+Novosibirsk =
+ # Requires translation!
+Magadan =
+ # Requires translation!
+Murmansk =
+ # Requires translation!
+Irkutsk =
+ # Requires translation!
+Chita =
+ # Requires translation!
+Samara =
+ # Requires translation!
+Arkhangelsk =
+ # Requires translation!
+Chelyabinsk =
+ # Requires translation!
+Tobolsk =
+ # Requires translation!
+Vologda =
+ # Requires translation!
+Omsk =
+ # Requires translation!
+Astrakhan =
+ # Requires translation!
+Kursk =
+ # Requires translation!
+Saratov =
+ # Requires translation!
+Tula =
+ # Requires translation!
+Vladimir =
+ # Requires translation!
+Perm =
+ # Requires translation!
+Voronezh =
+ # Requires translation!
+Pskov =
+ # Requires translation!
+Starayarussa =
+ # Requires translation!
+Kostoma =
+ # Requires translation!
+Nizhniy Novgorod =
+ # Requires translation!
+Suzdal =
+ # Requires translation!
+Magnitogorsk =
 
- # Requires translation!
-Augustus Caesar = 
- # Requires translation!
-My treasury contains little and my soldiers are getting impatient... ...therefore you must die. = 
- # Requires translation!
-So brave, yet so stupid! If only you had a brain similar to your courage. = 
- # Requires translation!
-The gods have deprived Rome of their favour. We have been defeated. = 
- # Requires translation!
-I greet you. I am Augustus, Imperator and Pontifex Maximus of Rome. If you are a friend of Rome, you are welcome. = 
- # Requires translation!
-I offer this, for your consideration. = 
- # Requires translation!
-Hail. = 
- # Requires translation!
-What do you want? = 
- # Requires translation!
-The Glory of Rome = 
- # Requires translation!
-The blessings of the gods be upon you, Caesar Augustus, emperor of Rome and all her holdings. Your empire was the greatest and longest lived of all in Western civilization. And your people single-handedly shaped its culture, law, art, and warfare like none other, before or since. Through years of glorious conquest, Rome came to dominate all the lands of the Mediterranean from Spain in the west to Syria in the east. And her dominion would eventually expand to cover much of England and northern Germany. Roman art and architecture still awe and inspire the world. And she remains the envy of all lesser civilizations who have followed. = 
- # Requires translation!
-O mighty emperor, your people turn to you to once more reclaim the glory of Rome! Will you see to it that your empire rises again, bringing peace and order to all? Will you make Rome once again center of the world? Can you build a civilization that will stand the test of time? = 
 Rome = Rom
  # Requires translation!
-Antium = 
+Augustus Caesar =
  # Requires translation!
-Cumae = 
+My treasury contains little and my soldiers are getting impatient... <sigh> ...therefore you must die. =
  # Requires translation!
-Neapolis = 
+So brave, yet so stupid! If only you had a brain similar to your courage. =
  # Requires translation!
-Ravenna = 
+The gods have deprived Rome of their favour. We have been defeated. =
  # Requires translation!
-Arretium = 
+I greet you. I am Augustus, Imperator and Pontifex Maximus of Rome. If you are a friend of Rome, you are welcome. =
  # Requires translation!
-Mediolanum = 
+I offer this, for your consideration. =
  # Requires translation!
-Arpinum = 
+Hail. =
  # Requires translation!
-Circei = 
+What do you want? =
  # Requires translation!
-Setia = 
+The Glory of Rome =
  # Requires translation!
-Satricum = 
++25% Production towards any buildings that already exist in the Capital =
  # Requires translation!
-Ardea = 
+The blessings of the gods be upon you, Caesar Augustus, emperor of Rome and all her holdings. Your empire was the greatest and longest lived of all in Western civilization. And your people single-handedly shaped its culture, law, art, and warfare like none other, before or since. Through years of glorious conquest, Rome came to dominate all the lands of the Mediterranean from Spain in the west to Syria in the east. And her dominion would eventually expand to cover much of England and northern Germany. Roman art and architecture still awe and inspire the world. And she remains the envy of all lesser civilizations who have followed. =
  # Requires translation!
-Ostia = 
+O mighty emperor, your people turn to you to once more reclaim the glory of Rome! Will you see to it that your empire rises again, bringing peace and order to all? Will you make Rome once again center of the world? Can you build a civilization that will stand the test of time? =
  # Requires translation!
-Velitrae = 
+Antium =
  # Requires translation!
-Viroconium = 
+Cumae =
  # Requires translation!
-Tarentum = 
+Neapolis =
  # Requires translation!
-Brundisium = 
+Ravenna =
  # Requires translation!
-Caesaraugusta = 
+Arretium =
  # Requires translation!
-Caesarea = 
+Mediolanum =
  # Requires translation!
-Palmyra = 
+Arpinum =
  # Requires translation!
-Signia = 
+Circei =
  # Requires translation!
-Aquileia = 
+Setia =
  # Requires translation!
-Clusium = 
+Satricum =
  # Requires translation!
-Sutrium = 
+Ardea =
  # Requires translation!
-Cremona = 
+Ostia =
  # Requires translation!
-Placentia = 
+Velitrae =
  # Requires translation!
-Hispalis = 
+Viroconium =
  # Requires translation!
-Artaxata = 
+Tarentum =
  # Requires translation!
-Aurelianorum = 
+Brundisium =
  # Requires translation!
-Nicopolis = 
+Caesaraugusta =
  # Requires translation!
-Agrippina = 
+Caesarea =
  # Requires translation!
-Verona = 
+Palmyra =
  # Requires translation!
-Corfinium = 
+Signia =
  # Requires translation!
-Treverii = 
+Aquileia =
  # Requires translation!
-Sirmium = 
+Clusium =
  # Requires translation!
-Augustadorum = 
+Sutrium =
  # Requires translation!
-Curia = 
+Cremona =
  # Requires translation!
-Interrama = 
+Placentia =
  # Requires translation!
-Adria = 
+Hispalis =
  # Requires translation!
-+25% Production towards any buildings that already exist in the Capital = 
+Artaxata =
+ # Requires translation!
+Aurelianorum =
+ # Requires translation!
+Nicopolis =
+ # Requires translation!
+Agrippina =
+ # Requires translation!
+Verona =
+ # Requires translation!
+Corfinium =
+ # Requires translation!
+Treverii =
+ # Requires translation!
+Sirmium =
+ # Requires translation!
+Augustadorum =
+ # Requires translation!
+Curia =
+ # Requires translation!
+Interrama =
+ # Requires translation!
+Adria =
 
+Arabia = Arab
  # Requires translation!
-Harun al-Rashid = 
+Harun al-Rashid =
  # Requires translation!
-The world will be more beautiful without you. Prepare for war. = 
+The world will be more beautiful without you. Prepare for war. =
  # Requires translation!
-Fool! You will soon regret dearly! I swear it! = 
+Fool! You will soon regret dearly! I swear it! =
  # Requires translation!
-You have won, congratulations. My palace is now in your possession, and I beg that you care well for the peacock. = 
+You have won, congratulations. My palace is now in your possession, and I beg that you care well for the peacock. =
  # Requires translation!
-Welcome foreigner, I am Harun Al-Rashid, Caliph of the Arabs. Come and tell me about your empire. = 
+Welcome foreigner, I am Harun Al-Rashid, Caliph of the Arabs. Come and tell me about your empire. =
  # Requires translation!
-Come forth, let's do business. = 
+Come forth, let's do business. =
  # Requires translation!
-Peace be upon you. = 
+Peace be upon you. =
  # Requires translation!
-Trade Caravans = 
+Trade Caravans =
  # Requires translation!
-Blessings of God be upon you oh great caliph Harun al-Rashid, leader of the pious Arabian people! The Muslim empire, the Caliphate was born in the turbulent years after the death of the prophet Muhammad in 632 AD, as his followers sought to extend the rule of God to all of the people of the earth. The caliphate grew mighty indeed at the height of its power, ruling Spain, North Africa, the Middle East, Anatolia, the Balkans and Persia. An empire as great as or even greater than that of Rome. The arts and sciences flourished in Arabia during the Middle Ages, even as the countries of Europe descended into ignorance and chaos. The Caliphate survived for six hundred years, until finally succumbing to attack from the Mongols, those destroyers of Empires. = 
+Blessings of God be upon you oh great caliph Harun al-Rashid, leader of the pious Arabian people! The Muslim empire, the Caliphate was born in the turbulent years after the death of the prophet Muhammad in 632 AD, as his followers sought to extend the rule of God to all of the people of the earth. The caliphate grew mighty indeed at the height of its power, ruling Spain, North Africa, the Middle East, Anatolia, the Balkans and Persia. An empire as great as or even greater than that of Rome. The arts and sciences flourished in Arabia during the Middle Ages, even as the countries of Europe descended into ignorance and chaos. The Caliphate survived for six hundred years, until finally succumbing to attack from the Mongols, those destroyers of Empires. =
  # Requires translation!
-Great Caliph Harun al Rashid, your people look to you to return them to greatness! To make Arabia once again an enlightened land of arts and knowledge, a powerful nation who needs fear no enemy! Oh Caliph, will you take up the challenge? Can you build a civilization that will stand the test of time? = 
+Great Caliph Harun al Rashid, your people look to you to return them to greatness! To make Arabia once again an enlightened land of arts and knowledge, a powerful nation who needs fear no enemy! Oh Caliph, will you take up the challenge? Can you build a civilization that will stand the test of time? =
 Mecca = Mekah
 Medina = Madinah
 Damascus = Damsyik
  # Requires translation!
-Baghdad = 
+Baghdad =
  # Requires translation!
-Najran = 
+Najran =
  # Requires translation!
-Kufah = 
+Kufah =
  # Requires translation!
-Basra = 
+Basra =
  # Requires translation!
-Khurasan = 
+Khurasan =
  # Requires translation!
-Anjar = 
+Anjar =
  # Requires translation!
-Fustat = 
+Fustat =
  # Requires translation!
-Aden = 
+Aden =
  # Requires translation!
-Yamama = 
+Yamama =
  # Requires translation!
-Muscat = 
+Muscat =
  # Requires translation!
-Mansura = 
+Mansura =
  # Requires translation!
-Bukhara = 
+Bukhara =
  # Requires translation!
-Fez = 
+Fez =
  # Requires translation!
-Shiraz = 
+Shiraz =
  # Requires translation!
-Merw = 
+Merw =
  # Requires translation!
-Balkh = 
+Balkh =
  # Requires translation!
-Mosul = 
+Mosul =
  # Requires translation!
-Aydab = 
+Aydab =
  # Requires translation!
-Bayt = 
+Bayt =
  # Requires translation!
-Suhar = 
+Suhar =
  # Requires translation!
-Taif = 
+Taif =
  # Requires translation!
-Hama = 
+Hama =
  # Requires translation!
-Tabuk = 
+Tabuk =
  # Requires translation!
-Sana'a = 
+Sana'a =
  # Requires translation!
-Shihr = 
+Shihr =
  # Requires translation!
-Tripoli = 
+Tripoli =
  # Requires translation!
-Tunis = 
+Tunis =
  # Requires translation!
-Kairouan = 
+Kairouan =
  # Requires translation!
-Algiers = 
+Algiers =
  # Requires translation!
-Oran = 
-Arabia = Arab
- # Requires translation!
-[stats] from each Trade Route = 
+Oran =
 
+America = Amerika
  # Requires translation!
-George Washington = 
+George Washington =
  # Requires translation!
-Your wanton aggression leaves us no choice. Prepare for war! = 
+Your wanton aggression leaves us no choice. Prepare for war! =
  # Requires translation!
-You have mistaken our love of peace for weakness. You shall regret this! = 
+You have mistaken our love of peace for weakness. You shall regret this! =
  # Requires translation!
-The day...is yours. I hope you will be merciful in your triumph. = 
+The day...is yours. I hope you will be merciful in your triumph. =
  # Requires translation!
-The people of the United States of America welcome you. = 
+The people of the United States of America welcome you. =
  # Requires translation!
-Is the following trade of interest to you? = 
+Is the following trade of interest to you? =
  # Requires translation!
-Well? = 
+Well? =
  # Requires translation!
-Manifest Destiny = 
+Manifest Destiny =
  # Requires translation!
-Welcome President Washington! You lead the industrious American civilization! Formed in the conflagration of revolution in the 18th century, within a hundred years, the young nation became embroiled in a terrible civil war that nearly tore the country apart, but it was just a few short years later in the 20th century that the United States reached the height of its power, emerging triumphant and mighty from the two terrible wars that destroyed so many other great nations. The United States is a nation of immigrants, filled with optimism and determination. They lack only a leader to help them fulfill their promise. = 
+Welcome President Washington! You lead the industrious American civilization! Formed in the conflagration of revolution in the 18th century, within a hundred years, the young nation became embroiled in a terrible civil war that nearly tore the country apart, but it was just a few short years later in the 20th century that the United States reached the height of its power, emerging triumphant and mighty from the two terrible wars that destroyed so many other great nations. The United States is a nation of immigrants, filled with optimism and determination. They lack only a leader to help them fulfill their promise. =
  # Requires translation!
-President Washington, can you lead the American people to greatness? Can you build a civilization that will stand the test of time? = 
+President Washington, can you lead the American people to greatness? Can you build a civilization that will stand the test of time? =
  # Requires translation!
-Washington = 
+Washington =
  # Requires translation!
-New York = 
+New York =
  # Requires translation!
-Boston = 
+Boston =
  # Requires translation!
-Philadelphia = 
+Philadelphia =
  # Requires translation!
-Atlanta = 
+Atlanta =
  # Requires translation!
-Chicago = 
+Chicago =
  # Requires translation!
-Seattle = 
+Seattle =
  # Requires translation!
-San Francisco = 
+San Francisco =
  # Requires translation!
-Los Angeles = 
+Los Angeles =
  # Requires translation!
-Houston = 
+Houston =
  # Requires translation!
-Portland = 
+Portland =
  # Requires translation!
-St. Louis = 
+St. Louis =
  # Requires translation!
-Miami = 
+Miami =
  # Requires translation!
-Buffalo = 
+Buffalo =
  # Requires translation!
-Detroit = 
+Detroit =
  # Requires translation!
-New Orleans = 
+New Orleans =
  # Requires translation!
-Baltimore = 
+Baltimore =
  # Requires translation!
-Denver = 
+Denver =
  # Requires translation!
-Cincinnati = 
+Cincinnati =
  # Requires translation!
-Dallas = 
+Dallas =
  # Requires translation!
-Cleveland = 
+Cleveland =
 Kansas City = Bandar Kansas
  # Requires translation!
-San Diego = 
+San Diego =
  # Requires translation!
-Las Vegas = 
+Las Vegas =
  # Requires translation!
-Phoenix = 
+Phoenix =
  # Requires translation!
-Albuquerque = 
+Albuquerque =
  # Requires translation!
-Minneapolis = 
+Minneapolis =
  # Requires translation!
-Pittsburgh = 
+Pittsburgh =
  # Requires translation!
-Oakland = 
+Oakland =
  # Requires translation!
-Tampa Bay = 
+Tampa Bay =
  # Requires translation!
-Orlando = 
+Orlando =
  # Requires translation!
-Tacoma = 
+Tacoma =
  # Requires translation!
-Santa Fe = 
+Santa Fe =
  # Requires translation!
-Olympia = 
+Olympia =
  # Requires translation!
-Hunt Valley = 
+Hunt Valley =
  # Requires translation!
-Springfield = 
+Springfield =
  # Requires translation!
-Palo Alto = 
+Palo Alto =
  # Requires translation!
-Centralia = 
+Centralia =
  # Requires translation!
-Spokane = 
+Spokane =
  # Requires translation!
-Jacksonville = 
+Jacksonville =
  # Requires translation!
-Svannah = 
+Svannah =
  # Requires translation!
-Charleston = 
+Charleston =
  # Requires translation!
-San Antonio = 
+San Antonio =
  # Requires translation!
-Anchorage = 
+Anchorage =
  # Requires translation!
-Sacramento = 
+Sacramento =
  # Requires translation!
-Reno = 
+Reno =
  # Requires translation!
-Salt Lake City = 
+Salt Lake City =
  # Requires translation!
-Boise = 
+Boise =
  # Requires translation!
-Milwaukee = 
+Milwaukee =
  # Requires translation!
-Santa Cruz = 
+Santa Cruz =
  # Requires translation!
-Little Rock = 
-America = Amerika
+Little Rock =
 
- # Requires translation!
-Oda Nobunaga = 
- # Requires translation!
-I hereby inform you of our intention to wipe out your civilization from this world. = 
- # Requires translation!
-Pitiful fool! Now we shall destroy you! = 
- # Requires translation!
-You were much wiser than I thought. = 
- # Requires translation!
-We hope for a fair and just relationship with you, who are renowned for military bravery. = 
- # Requires translation!
-I would be grateful if you agreed on the following proposal. = 
- # Requires translation!
-Oh, it's you... = 
- # Requires translation!
-Bushido = 
- # Requires translation!
-Blessings upon you, noble Oda Nobunaga, ruler of Japan, the land of the Rising Sun! May you long walk among its flowering blossoms. The Japanese are an island people, proud and pious with a rich culture of arts and letters. Your civilization stretches back thousands of years, years of bloody warfare, expansion and isolation, great wealth and great poverty. In addition to their prowess on the field of battle, your people are also immensely industrious, and their technological innovation and mighty factories are the envy of lesser people everywhere. = 
- # Requires translation!
-Legendary daimyo, will you grab the reins of destiny? Will you bring your family and people the honor and glory they deserve? Will you once again pick up the sword and march to triumph? Will you build a civilization that stands the test of time? = 
- # Requires translation!
-Kyoto = 
- # Requires translation!
-Osaka = 
- # Requires translation!
-Tokyo = 
- # Requires translation!
-Satsuma = 
- # Requires translation!
-Kagoshima = 
- # Requires translation!
-Nara = 
- # Requires translation!
-Nagoya = 
- # Requires translation!
-Izumo = 
- # Requires translation!
-Nagasaki = 
- # Requires translation!
-Yokohama = 
- # Requires translation!
-Shimonoseki = 
- # Requires translation!
-Matsuyama = 
- # Requires translation!
-Sapporo = 
- # Requires translation!
-Hakodate = 
- # Requires translation!
-Ise = 
- # Requires translation!
-Toyama = 
- # Requires translation!
-Fukushima = 
- # Requires translation!
-Suo = 
- # Requires translation!
-Bizen = 
- # Requires translation!
-Echizen = 
- # Requires translation!
-Izumi = 
- # Requires translation!
-Omi = 
- # Requires translation!
-Echigo = 
- # Requires translation!
-Kozuke = 
- # Requires translation!
-Sado = 
- # Requires translation!
-Kobe = 
- # Requires translation!
-Nagano = 
- # Requires translation!
-Hiroshima = 
- # Requires translation!
-Takayama = 
- # Requires translation!
-Akita = 
- # Requires translation!
-Fukuoka = 
- # Requires translation!
-Aomori = 
- # Requires translation!
-Kamakura = 
- # Requires translation!
-Kochi = 
- # Requires translation!
-Naha = 
- # Requires translation!
-Sendai = 
- # Requires translation!
-Gifu = 
- # Requires translation!
-Yamaguchi = 
- # Requires translation!
-Ota = 
- # Requires translation!
-Tottori = 
 Japan = Jepun
  # Requires translation!
-Units fight as though they were at full strength even when damaged = 
-
+Oda Nobunaga =
  # Requires translation!
-Gandhi = 
+I hereby inform you of our intention to wipe out your civilization from this world. =
  # Requires translation!
-I have just received a report that large numbers of my troops have crossed your borders. = 
+Pitiful fool! Now we shall destroy you! =
  # Requires translation!
-My attempts to avoid violence have failed. An eye for an eye only makes the world blind. = 
+You were much wiser than I thought. =
  # Requires translation!
-You can chain me, you can torture me, you can even destroy this body, but you will never imprison my mind. = 
+We hope for a fair and just relationship with you, who are renowned for military bravery. =
  # Requires translation!
-Hello, I am Mohandas Gandhi. My people call me Bapu, but please, call me friend. = 
+I would be grateful if you agreed on the following proposal. =
  # Requires translation!
-My friend, are you interested in this arrangement? = 
+Oh, it's you... =
  # Requires translation!
-I wish you peace. = 
+Bushido =
  # Requires translation!
-Population Growth = 
+Units fight as though they were at full strength even when damaged =
  # Requires translation!
-Delhi = 
+Blessings upon you, noble Oda Nobunaga, ruler of Japan, the land of the Rising Sun! May you long walk among its flowering blossoms. The Japanese are an island people, proud and pious with a rich culture of arts and letters. Your civilization stretches back thousands of years, years of bloody warfare, expansion and isolation, great wealth and great poverty. In addition to their prowess on the field of battle, your people are also immensely industrious, and their technological innovation and mighty factories are the envy of lesser people everywhere. =
  # Requires translation!
-Mumbai = 
+Legendary daimyo, will you grab the reins of destiny? Will you bring your family and people the honor and glory they deserve? Will you once again pick up the sword and march to triumph? Will you build a civilization that stands the test of time? =
  # Requires translation!
-Vijayanagara = 
+Kyoto =
  # Requires translation!
-Pataliputra = 
+Osaka =
  # Requires translation!
-Varanasi = 
+Tokyo =
  # Requires translation!
-Agra = 
+Satsuma =
  # Requires translation!
-Calcutta = 
+Kagoshima =
  # Requires translation!
-Lahore = 
+Nara =
  # Requires translation!
-Bangalore = 
+Nagoya =
  # Requires translation!
-Hyderabad = 
+Izumo =
  # Requires translation!
-Madurai = 
+Nagasaki =
  # Requires translation!
-Ahmedabad = 
+Yokohama =
  # Requires translation!
-Kolhapur = 
+Shimonoseki =
  # Requires translation!
-Prayaga = 
+Matsuyama =
  # Requires translation!
-Ayodhya = 
+Sapporo =
  # Requires translation!
-Indraprastha = 
+Hakodate =
  # Requires translation!
-Mathura = 
+Ise =
  # Requires translation!
-Ujjain = 
+Toyama =
  # Requires translation!
-Gulbarga = 
+Fukushima =
  # Requires translation!
-Jaunpur = 
+Suo =
  # Requires translation!
-Rajagriha = 
+Bizen =
  # Requires translation!
-Sravasti = 
+Echizen =
  # Requires translation!
-Tiruchirapalli = 
+Izumi =
  # Requires translation!
-Thanjavur = 
+Omi =
  # Requires translation!
-Bodhgaya = 
+Echigo =
  # Requires translation!
-Kushinagar = 
+Kozuke =
  # Requires translation!
-Amaravati = 
+Sado =
  # Requires translation!
-Gaur = 
+Kobe =
  # Requires translation!
-Gwalior = 
+Nagano =
  # Requires translation!
-Jaipur = 
+Hiroshima =
  # Requires translation!
-Karachi = 
+Takayama =
  # Requires translation!
-India = 
+Akita =
  # Requires translation!
-Unhappiness from number of Cities doubled = 
-
+Fukuoka =
  # Requires translation!
-Otto von Bismarck = 
+Aomori =
  # Requires translation!
-I cannot wait until ye grow even mightier. Therefore, prepare for war! = 
+Kamakura =
  # Requires translation!
-Corrupted villain! We will bring you into the ground! = 
+Kochi =
  # Requires translation!
-Germany has been destroyed. I weep for the future generations. = 
+Naha =
  # Requires translation!
-Guten tag. In the name of the great German people, I bid you welcome. = 
+Sendai =
  # Requires translation!
-It would be in your best interest, to carefully consider this proposal. = 
+Gifu =
  # Requires translation!
-What now? = 
+Yamaguchi =
  # Requires translation!
-So, out with it! = 
+Ota =
  # Requires translation!
-Furor Teutonicus = 
+Tottori =
  # Requires translation!
-Hail mighty Bismarck, first chancellor of Germany and her empire! Germany is an upstart nation, fashioned from the ruins of the Holy Roman Empire and finally unified in 1871, a little more than a century ago. The German people have proven themselves to be creative, industrious and ferocious warriors. Despite enduring great catastrophes in the first half of the 20th century, Germany remains a worldwide economic, artistic and technological leader. = 
+India =
  # Requires translation!
-Great Prince Bismarck, the German people look up to you to lead them to greater days of glory. Their determination is strong, and now they turn to you, their beloved iron chancellor, to guide them once more. Will you rule and conquer through blood and iron, or foster the Germanic arts and industry? Can you build a civilization that will stand the test of time? = 
+Gandhi =
  # Requires translation!
-Berlin = 
+I have just received a report that large numbers of my troops have crossed your borders. =
  # Requires translation!
-Hamburg = 
+My attempts to avoid violence have failed. An eye for an eye only makes the world blind. =
  # Requires translation!
-Munich = 
+You can chain me, you can torture me, you can even destroy this body, but you will never imprison my mind.  =
  # Requires translation!
-Cologne = 
+Hello, I am Mohandas Gandhi. My people call me Bapu, but please, call me friend. =
  # Requires translation!
-Frankfurt = 
+My friend, are you interested in this arrangement? =
  # Requires translation!
-Essen = 
+I wish you peace. =
  # Requires translation!
-Dortmund = 
+Population Growth =
  # Requires translation!
-Stuttgart = 
+Unhappiness from number of Cities doubled =
  # Requires translation!
-Düsseldorf = 
+Greetings, President Mahatma Gandhi, great souled leader of India! You are the ruler of one of the oldest countries in the world with history stretching back almost 10,000 years. A spiritual country, India is the birthplace of three of the world's great religions - Hinduism, Buddhism and Jainism. This is a passionate land of music and color, a land of great wealth and grinding poverty. For centuries, India was divided into kingdoms who fought constantly with each other and against outside invaders. That was, however, after empires such as Maratha, Maurya and Gupta. In the 12th century AD, India was conquered by Muslim Turks who fled from the Mongols. In the early 17th century, the English arrived, and through a combination of shrewd diplomacy and technological superiority, they conquered your fragmented nation. England remained in power for some two centuries until driven out by a rising wave of Indian nationalism, a peaceful rebellion unlike any before seen in history, one led by you! =
  # Requires translation!
-Bremen = 
+Gandhi, your people look to you to lead them to even greater heights of glory! Can you help your people realize their great potential, to once again become the world's center of arts, culture and religion? Can you build a civilization that will stand the test of time? =
  # Requires translation!
-Hannover = 
+Delhi =
  # Requires translation!
-Duisburg = 
+Mumbai =
  # Requires translation!
-Leipzig = 
+Vijayanagara =
  # Requires translation!
-Dresden = 
+Pataliputra =
  # Requires translation!
-Bonn = 
+Varanasi =
  # Requires translation!
-Bochum = 
+Agra =
  # Requires translation!
-Bielefeld = 
+Calcutta =
  # Requires translation!
-Karlsruhe = 
+Lahore =
  # Requires translation!
-Gelsenkirchen = 
+Bangalore =
  # Requires translation!
-Wiesbaden = 
+Hyderabad =
  # Requires translation!
-Münster = 
+Madurai =
  # Requires translation!
-Rostock = 
+Ahmedabad =
  # Requires translation!
-Chemnitz = 
+Kolhapur =
  # Requires translation!
-Braunschweig = 
+Prayaga =
  # Requires translation!
-Halle = 
+Ayodhya =
  # Requires translation!
-Mönchengladbach = 
+Indraprastha =
  # Requires translation!
-Kiel = 
+Mathura =
  # Requires translation!
-Wuppertal = 
+Ujjain =
  # Requires translation!
-Freiburg = 
+Gulbarga =
  # Requires translation!
-Hagen = 
+Jaunpur =
  # Requires translation!
-Erfurt = 
+Rajagriha =
  # Requires translation!
-Kaiserslautern = 
+Sravasti =
  # Requires translation!
-Kassel = 
+Tiruchirapalli =
  # Requires translation!
-Oberhausen = 
+Thanjavur =
  # Requires translation!
-Hamm = 
+Bodhgaya =
  # Requires translation!
-Saarbrücken = 
+Kushinagar =
  # Requires translation!
-Krefeld = 
+Amaravati =
  # Requires translation!
-Pirmasens = 
+Gaur =
  # Requires translation!
-Potsdam = 
+Gwalior =
  # Requires translation!
-Solingen = 
+Jaipur =
  # Requires translation!
-Osnabrück = 
- # Requires translation!
-Ludwigshafen = 
- # Requires translation!
-Leverkusen = 
- # Requires translation!
-Oldenburg = 
- # Requires translation!
-Neuss = 
- # Requires translation!
-Mülheim = 
- # Requires translation!
-Darmstadt = 
- # Requires translation!
-Herne = 
- # Requires translation!
-Würzburg = 
- # Requires translation!
-Recklinghausen = 
- # Requires translation!
-Göttingen = 
- # Requires translation!
-Wolfsburg = 
- # Requires translation!
-Koblenz = 
- # Requires translation!
-Hildesheim = 
- # Requires translation!
-Erlangen = 
+Karachi =
 Germany = Jerman
  # Requires translation!
-67% chance to earn 25 Gold and recruit a Barbarian unit from a conquered encampment = 
+Otto von Bismarck =
  # Requires translation!
-[amount]% maintenance costs for [mapUnitFilter] units = 
-
+I cannot wait until ye grow even mightier. Therefore, prepare for war! =
  # Requires translation!
-Suleiman I = 
+Corrupted villain! We will bring you into the ground! =
  # Requires translation!
-Your continued insolence and failure to recognize and preeminence leads us to war. = 
+Germany has been destroyed. I weep for the future generations. =
  # Requires translation!
-Good. The world shall witness the incontestable might of my armies and the glory of the Empire. = 
+Guten tag. In the name of the great German people, I bid you welcome. =
  # Requires translation!
-Ruin! Ruin! Istanbul becomes Iram of the Pillars, remembered only by the melancholy poets. = 
+It would be in your best interest, to carefully consider this proposal. =
  # Requires translation!
-From the magnificence of Topkapi, the Ottoman nation greets you, stranger! I'm Suleiman, Kayser-I Rum, and I bestow upon you my welcome! = 
+What now? =
  # Requires translation!
-Let us do business! Would you be interested? = 
+So, out with it! =
  # Requires translation!
-Barbary Corsairs = 
+Furor Teutonicus =
  # Requires translation!
-Blessings of God be upon you, oh Great Emperor Suleiman! Your power, wealth and generosity awe the world! Truly, are you called 'Magnificent!' Your empire began in Bithynia, a small country in Eastern Anatolia in 12th century. Taking advantage in the decline of the great Seljuk Sultanate of Rum, King Osman I of Bithynia expanded west into Anatolia. Over the next century, your subjects brought down the empire of Byzantium, taking its holdings in Turkey and then the Balkans. In the mid 15th century, the Ottomans captured ancient Constantinople, gaining control of the strategic link between Europe and the Middle East. Your people's empire would continue to expand for centuries governing much of North Africa, the Middle East and Eastern Europe at its height. = 
+67% chance to earn 25 Gold and recruit a Barbarian unit from a conquered encampment =
  # Requires translation!
-Mighty Sultan, heed the call of your people! Bring your empire back to the height of its power and glory and once again the world will look upon your greatness with awe and admiration! Will you accept the challenge, great emperor? Will you build an empire that will stand the test of time? = 
+-[amount]% [param] unit maintenance costs =
  # Requires translation!
-Istanbul = 
+Hail mighty Bismarck, first chancellor of Germany and her empire! Germany is an upstart nation, fashioned from the ruins of the Holy Roman Empire and finally unified in 1871, a little more than a century ago. The German people have proven themselves to be creative, industrious and ferocious warriors. Despite enduring great catastrophes in the first half of the 20th century, Germany remains a worldwide economic, artistic and technological leader. =
  # Requires translation!
-Edirne = 
+Great Prince Bismarck, the German people look up to you to lead them to greater days of glory. Their determination is strong, and now they turn to you, their beloved iron chancellor, to guide them once more. Will you rule and conquer through blood and iron, or foster the Germanic arts and industry? Can you build a civilization that will stand the test of time? =
  # Requires translation!
-Ankara = 
+Berlin =
  # Requires translation!
-Bursa = 
+Hamburg =
  # Requires translation!
-Konya = 
+Munich =
  # Requires translation!
-Samsun = 
+Cologne =
  # Requires translation!
-Gaziantep = 
+Frankfurt =
  # Requires translation!
-Diyarbakır = 
+Essen =
  # Requires translation!
-Izmir = 
+Dortmund =
  # Requires translation!
-Kayseri = 
+Stuttgart =
  # Requires translation!
-Malatya = 
+Düsseldorf =
  # Requires translation!
-Mersin = 
+Bremen =
  # Requires translation!
-Antalya = 
+Hannover =
  # Requires translation!
-Zonguldak = 
+Duisburg =
  # Requires translation!
-Denizli = 
+Leipzig =
  # Requires translation!
-Ordu = 
+Dresden =
  # Requires translation!
-Muğla = 
+Bonn =
  # Requires translation!
-Eskişehir = 
+Bochum =
  # Requires translation!
-Inebolu = 
+Bielefeld =
  # Requires translation!
-Sinop = 
+Karlsruhe =
  # Requires translation!
-Adana = 
+Gelsenkirchen =
  # Requires translation!
-Artvin = 
+Wiesbaden =
  # Requires translation!
-Bodrum = 
+Münster =
  # Requires translation!
-Eregli = 
+Rostock =
  # Requires translation!
-Silifke = 
+Chemnitz =
  # Requires translation!
-Sivas = 
+Braunschweig =
  # Requires translation!
-Amasya = 
+Halle =
  # Requires translation!
-Marmaris = 
+Mönchengladbach =
  # Requires translation!
-Trabzon = 
+Kiel =
  # Requires translation!
-Erzurum = 
+Wuppertal =
  # Requires translation!
-Urfa = 
+Freiburg =
  # Requires translation!
-Izmit = 
+Hagen =
  # Requires translation!
-Afyonkarahisar = 
+Erfurt =
  # Requires translation!
-Bitlis = 
+Kaiserslautern =
  # Requires translation!
-Yalova = 
+Kassel =
+ # Requires translation!
+Oberhausen =
+ # Requires translation!
+Hamm =
+ # Requires translation!
+Saarbrücken =
+ # Requires translation!
+Krefeld =
+ # Requires translation!
+Pirmasens =
+ # Requires translation!
+Potsdam =
+ # Requires translation!
+Solingen =
+ # Requires translation!
+Osnabrück =
+ # Requires translation!
+Ludwigshafen =
+ # Requires translation!
+Leverkusen =
+ # Requires translation!
+Oldenburg =
+ # Requires translation!
+Neuss =
+ # Requires translation!
+Mülheim =
+ # Requires translation!
+Darmstadt =
+ # Requires translation!
+Herne =
+ # Requires translation!
+Würzburg =
+ # Requires translation!
+Recklinghausen =
+ # Requires translation!
+Göttingen =
+ # Requires translation!
+Wolfsburg =
+ # Requires translation!
+Koblenz =
+ # Requires translation!
+Hildesheim =
+ # Requires translation!
+Erlangen =
 The Ottomans = Uthmaniyyah
  # Requires translation!
-50% chance of capturing defeated Barbarian naval units and earning 25 Gold = 
-
+Suleiman I =
  # Requires translation!
-Sejong = 
+Your continued insolence and failure to recognize and preeminence leads us to war. =
  # Requires translation!
-Jip-hyun-jun (Hall of Worthies) will no longer tolerate your irksome behavior. We will liberate the citizens under your oppression even with force, and enlighten them! = 
+Good. The world shall witness the incontestable might of my armies and the glory of the Empire. =
  # Requires translation!
-Foolish, miserable wretch! You will be crushed by this country's magnificent scientific power! = 
+Ruin! Ruin! Istanbul becomes Iram of the Pillars, remembered only by the melancholy poets. =
  # Requires translation!
-Now the question is who will protect my people. A dark age has come. = 
+From the magnificence of Topkapi, the Ottoman nation greets you, stranger! I'm Suleiman, Kayser-I Rum, and I bestow upon you my welcome! =
  # Requires translation!
-Welcome to the palace of Choson, stranger. I am the learned King Sejong, who looks after his great people. = 
+Let us do business! Would you be interested? =
  # Requires translation!
-We have many things to discuss and have much to benefit from each other. = 
+Barbary Corsairs =
  # Requires translation!
-Oh, it's you = 
+50% chance of capturing defeated Barbarian naval units and earning 25 Gold =
  # Requires translation!
-Scholars of the Jade Hall = 
+Blessings of God be upon you, oh Great Emperor Suleiman! Your power, wealth and generosity awe the world! Truly, are you called 'Magnificent!' Your empire began in Bithynia, a small country in Eastern Anatolia in 12th century. Taking advantage in the decline of the great Seljuk Sultanate of Rum, King Osman I of Bithynia expanded west into Anatolia. Over the next century, your subjects brought down the empire of Byzantium, taking its holdings in Turkey and then the Balkans. In the mid 15th century, the Ottomans captured ancient Constantinople, gaining control of the strategic link between Europe and the Middle East. Your people's empire would continue to expand for centuries governing much of North Africa, the Middle East and Eastern Europe at its height. =
  # Requires translation!
-Greetings to you, exalted King Sejong the Great, servant to the people and protector of the Choson Dynasty! Your glorious vision of prosperity and overwhelming benevolence towards the common man made you the most beloved of all Korean kings. From the earliest days of your reign, the effort you took to provide a fair and just society for all was surpassed only by the technological advances spurred onwards by your unquenched thirst for knowledge. Guided by your wisdom, the scholars of the Jade Hall developed Korea's first written language, Hangul, bringing the light of literature and science to the masses after centuries of literary darkness. = 
+Mighty Sultan, heed the call of your people! Bring your empire back to the height of its power and glory and once again the world will look upon your greatness with awe and admiration! Will you accept the challenge, great emperor? Will you build an empire that will stand the test of time? =
  # Requires translation!
-Honorable Sejong, once more the people look to your for guidance. Will you rise to the occasion, bringing harmony and understanding to the people? Can you once again advance your kingdom's standing to such wondrous heights? Can you build a civilization that stands the test of time? = 
+Istanbul =
  # Requires translation!
-Seoul = 
+Edirne =
  # Requires translation!
-Busan = 
+Ankara =
  # Requires translation!
-Jeonju = 
+Bursa =
  # Requires translation!
-Daegu = 
+Konya =
  # Requires translation!
-Pyongyang = 
+Samsun =
  # Requires translation!
-Kaesong = 
+Gaziantep =
  # Requires translation!
-Suwon = 
+Diyarbakır =
  # Requires translation!
-Gwangju = 
+Izmir =
  # Requires translation!
-Gangneung = 
+Kayseri =
  # Requires translation!
-Hamhung = 
+Malatya =
  # Requires translation!
-Wonju = 
+Mersin =
  # Requires translation!
-Ulsan = 
+Antalya =
  # Requires translation!
-Changwon = 
+Zonguldak =
  # Requires translation!
-Andong = 
+Denizli =
  # Requires translation!
-Gongju = 
+Ordu =
  # Requires translation!
-Haeju = 
+Muğla =
  # Requires translation!
-Cheongju = 
+Eskişehir =
  # Requires translation!
-Mokpo = 
+Inebolu =
  # Requires translation!
-Dongducheon = 
+Sinop =
  # Requires translation!
-Geoje = 
+Adana =
  # Requires translation!
-Suncheon = 
+Artvin =
  # Requires translation!
-Jinju = 
+Bodrum =
  # Requires translation!
-Sangju = 
+Eregli =
  # Requires translation!
-Rason = 
+Silifke =
  # Requires translation!
-Gyeongju = 
+Sivas =
  # Requires translation!
-Chungju = 
+Amasya =
  # Requires translation!
-Sacheon = 
+Marmaris =
  # Requires translation!
-Gimje = 
+Trabzon =
  # Requires translation!
-Anju = 
+Erzurum =
+ # Requires translation!
+Urfa =
+ # Requires translation!
+Izmit =
+ # Requires translation!
+Afyonkarahisar =
+ # Requires translation!
+Bitlis =
+ # Requires translation!
+Yalova =
 Korea = Korea
-Receive a tech boost when scientific buildings/wonders are built in capital =  
-
  # Requires translation!
-Hiawatha = 
+Sejong =
  # Requires translation!
-You are a plague upon Mother Earth! Prepare for battle! = 
+Jip-hyun-jun (Hall of Worthies) will no longer tolerate your irksome behavior. We will liberate the citizens under your oppression even with force, and enlighten them! =
  # Requires translation!
-You evil creature! My braves will slaughter you! = 
+Foolish, miserable wretch! You will be crushed by this country's magnificent scientific power! =
  # Requires translation!
-You have defeated us... but our spirits will never be vanquished! We shall return! = 
+Now the question is who will protect my people. A dark age has come. =
  # Requires translation!
-Greetings, stranger. I am Hiawatha, speaker for the Iroquois. We seek peace with all, but we do not shrink from war. = 
+Welcome to the palace of Choson, stranger. I am the learned King Sejong, who looks after his great people. =
  # Requires translation!
-Does this trade work for you, my friend? = 
+We have many things to discuss and have much to benefit from each other. =
  # Requires translation!
-The Great Warpath = 
+Oh, it's you =
  # Requires translation!
-Greetings, noble Hiawatha, leader of the mighty Iroquois nations! Long have your people lived near the great and holy lake Ontario in the land that has come to be known as the New York state in North America. In the mists of antiquity, the five peoples of Seneca, Onondaga, Mohawks, Cayugas and Oneida united into one nation, the Haudenosaunee, the Iroquois. With no written language, the wise men of your nation created the great law of peace, the model for many constitutions including that of the United States. For many years, your people battled great enemies, such as the Huron, and the French and English invaders. Tough outnumbered and facing weapons far more advanced than the ones your warriors wielded, the Iroquois survived and prospered, until they were finally overwhelmed by the mighty armies of the new United States. = 
+Scholars of the Jade Hall =
+Receive a tech boost when scientific buildings/wonders are built in capital =
  # Requires translation!
-Oh noble Hiawatha, listen to the cries of your people! They call out to you to lead them in peace and war, to rebuild the great longhouse and unite the tribes once again. Will you accept this challenge, great leader? Will you build a civilization that will stand the test of time? = 
+Greetings to you, exalted King Sejong the Great, servant to the people and protector of the Choson Dynasty! Your glorious vision of prosperity and overwhelming benevolence towards the common man made you the most beloved of all Korean kings. From the earliest days of your reign, the effort you took to provide a fair and just society for all was surpassed only by the technological advances spurred onwards by your unquenched thirst for knowledge. Guided by your wisdom, the scholars of the Jade Hall developed Korea's first written language, Hangul, bringing the light of literature and science to the masses after centuries of literary darkness. =
  # Requires translation!
-Onondaga = 
+Honorable Sejong, once more the people look to your for guidance. Will you rise to the occasion, bringing harmony and understanding to the people? Can you once again advance your kingdom's standing to such wondrous heights? Can you build a civilization that stands the test of time? =
  # Requires translation!
-Osininka = 
+Seoul =
  # Requires translation!
-Grand River = 
+Busan =
  # Requires translation!
-Akwesasme = 
+Jeonju =
  # Requires translation!
-Buffalo Creek = 
+Daegu =
  # Requires translation!
-Brantford = 
+Pyongyang =
  # Requires translation!
-Montreal = 
+Kaesong =
  # Requires translation!
-Genesse River = 
+Suwon =
  # Requires translation!
-Canandaigua Lake = 
+Gwangju =
  # Requires translation!
-Lake Simcoe = 
+Gangneung =
  # Requires translation!
-Salamanca = 
+Hamhung =
  # Requires translation!
-Gowanda = 
+Wonju =
  # Requires translation!
-Cuba = 
+Ulsan =
  # Requires translation!
-Akron = 
+Changwon =
  # Requires translation!
-Kanesatake = 
+Andong =
  # Requires translation!
-Ganienkeh = 
+Gongju =
  # Requires translation!
-Cayuga Castle = 
+Haeju =
  # Requires translation!
-Chondote = 
+Cheongju =
  # Requires translation!
-Canajoharie = 
+Mokpo =
  # Requires translation!
-Nedrow = 
+Dongducheon =
  # Requires translation!
-Oneida Lake = 
+Geoje =
  # Requires translation!
-Kanonwalohale = 
+Suncheon =
  # Requires translation!
-Green Bay = 
+Jinju =
  # Requires translation!
-Southwold = 
+Sangju =
  # Requires translation!
-Mohawk Valley = 
+Rason =
  # Requires translation!
-Schoharie = 
+Gyeongju =
  # Requires translation!
-Bay of Quinte = 
+Chungju =
  # Requires translation!
-Kanawale = 
+Sacheon =
  # Requires translation!
-Kanatsiokareke = 
+Gimje =
  # Requires translation!
-Tyendinaga = 
+Anju =
  # Requires translation!
-Hahta = 
+Iroquois =
  # Requires translation!
-Iroquois = 
+Hiawatha =
  # Requires translation!
-All units move through Forest and Jungle Tiles in friendly territory as if they have roads. These tiles can be used to establish City Connections upon researching the Wheel. = 
-
+You are a plague upon Mother Earth! Prepare for battle! =
  # Requires translation!
-Darius I = 
+You evil creature! My braves will slaughter you! =
  # Requires translation!
-Your continue existence is an embarrassment to all leaders everywhere! You must be destroyed! = 
+You have defeated us... but our spirits will never be vanquished! We shall return! =
  # Requires translation!
-Curse you! You are beneath me, son of a donkey driver! I will crush you! = 
+Greetings, stranger. I am Hiawatha, speaker for the Iroquois. We seek peace with all, but we do not shrink from war. =
  # Requires translation!
-You mongrel! Cursed be you! The world will long lament your heinous crime! = 
+Does this trade work for you, my friend? =
  # Requires translation!
-Peace be on you! I am Darius, the great and outstanding king of kings of great Persia... but I suppose you knew that. = 
+The Great Warpath =
  # Requires translation!
-In my endless magnanimity, I am making you this offer. You agree, of course? = 
+All units move through Forest and Jungle Tiles in friendly territory as if they have roads. These tiles can be used to establish City Connections upon researching the Wheel. =
  # Requires translation!
-Good day to you! = 
+Greetings, noble Hiawatha, leader of the mighty Iroquois nations! Long have your people lived near the great and holy lake Ontario in the land that has come to be known as the New York state in North America. In the mists of antiquity, the five peoples of Seneca, Onondaga, Mohawks, Cayugas and Oneida united into one nation, the Haudenosaunee, the Iroquois. With no written language, the wise men of your nation created the great law of peace, the model for many constitutions including that of the United States. For many years, your people battled great enemies, such as the Huron, and the French and English invaders. Tough outnumbered and facing weapons far more advanced than the ones your warriors wielded, the Iroquois survived and prospered, until they were finally overwhelmed by the mighty armies of the new United States. =
  # Requires translation!
-Ahh... you... = 
+Oh noble Hiawatha, listen to the cries of your people! They call out to you to lead them in peace and war, to rebuild the great longhouse and unite the tribes once again. Will you accept this challenge, great leader? Will you build a civilization that will stand the test of time? =
  # Requires translation!
-Achaemenid Legacy = 
+Onondaga =
  # Requires translation!
-The blessings of heaven be upon you, beloved king Darius of Persia! You lead a strong and wise people. In the morning of the world, the great Persian leader Cyrus revolted against the mighty Median empire and by 550 BC, the Medes were no more. Through cunning diplomacy and military prowess, great Cyrus conquered wealthy Lydia and powerful Babylon, his son conquering proud Egypt some years later. Over time, Persian might expanded into far away Macedonia, at the very door of the upstart Greek city-states. Long would Persia prosper until the upstart villain Alexander of Macedon, destroyed the great empire in one shocking campaign. = 
+Osininka =
  # Requires translation!
-Darius, your people look to you to once again bring back the days of power and glory for Persia! The empire of your ancestors must emerge again, to triumph over its foes and to bring peace and order to the world! O king, will you answer the call? Can you build a civilization that will stand the test of time? = 
+Grand River =
  # Requires translation!
-Persepolis = 
+Akwesasme =
  # Requires translation!
-Parsagadae = 
+Buffalo Creek =
  # Requires translation!
-Susa = 
+Brantford =
  # Requires translation!
-Ecbatana = 
+Montreal =
  # Requires translation!
-Tarsus = 
+Genesse River =
  # Requires translation!
-Gordium = 
+Canandaigua Lake =
  # Requires translation!
-Bactra = 
+Lake Simcoe =
  # Requires translation!
-Sardis = 
+Salamanca =
  # Requires translation!
-Ergili = 
+Gowanda =
  # Requires translation!
-Dariushkabir = 
+Cuba =
  # Requires translation!
-Ghulaman = 
+Akron =
  # Requires translation!
-Zohak = 
+Kanesatake =
  # Requires translation!
-Istakhr = 
+Ganienkeh =
  # Requires translation!
-Jinjan = 
+Cayuga Castle =
  # Requires translation!
-Borazjan = 
+Chondote =
  # Requires translation!
-Herat = 
+Canajoharie =
  # Requires translation!
-Dakyanus = 
+Nedrow =
  # Requires translation!
-Bampur = 
+Oneida Lake =
  # Requires translation!
-Turengtepe = 
+Kanonwalohale =
  # Requires translation!
-Rey = 
+Green Bay =
  # Requires translation!
-Thuspa = 
+Southwold =
  # Requires translation!
-Hasanlu = 
+Mohawk Valley =
  # Requires translation!
-Gabae = 
+Schoharie =
  # Requires translation!
-Merv = 
+Bay of Quinte =
  # Requires translation!
-Behistun = 
+Kanawale =
  # Requires translation!
-Kandahar = 
+Kanatsiokareke =
  # Requires translation!
-Altintepe = 
+Tyendinaga =
  # Requires translation!
-Bunyan = 
- # Requires translation!
-Charsadda = 
- # Requires translation!
-Uratyube = 
- # Requires translation!
-Dura Europos = 
- # Requires translation!
-Aleppo = 
- # Requires translation!
-Qatna = 
- # Requires translation!
-Kabul = 
- # Requires translation!
-Capisa = 
- # Requires translation!
-Kyreskhata = 
- # Requires translation!
-Marakanda = 
- # Requires translation!
-Peshawar = 
- # Requires translation!
-Van = 
- # Requires translation!
-Pteira = 
- # Requires translation!
-Arshada = 
- # Requires translation!
-Artakaona = 
- # Requires translation!
-Aspabota = 
- # Requires translation!
-Autiyara = 
- # Requires translation!
-Bagastana = 
- # Requires translation!
-Baxtri = 
- # Requires translation!
-Darmasa = 
- # Requires translation!
-Daphnai = 
- # Requires translation!
-Drapsaka = 
- # Requires translation!
-Eion = 
- # Requires translation!
-Gandutava = 
- # Requires translation!
-Gaugamela = 
- # Requires translation!
-Harmozeia = 
- # Requires translation!
-Ekatompylos = 
- # Requires translation!
-Izata = 
- # Requires translation!
-Kampada = 
- # Requires translation!
-Kapisa = 
- # Requires translation!
-Karmana = 
- # Requires translation!
-Kounaxa = 
- # Requires translation!
-Kuganaka = 
- # Requires translation!
-Nautaka = 
- # Requires translation!
-Paishiyauvada = 
- # Requires translation!
-Patigrbana = 
- # Requires translation!
-Phrada = 
+Hahta =
 Persia = Parsi
-
  # Requires translation!
-Kamehameha I = 
+Darius I =
  # Requires translation!
-The ancient fire flashing across the sky is what proclaimed that this day would come, though I had foolishly hoped for a different outcome. = 
+Your continue existence is an embarrassment to all leaders everywhere! You must be destroyed! =
  # Requires translation!
-It is obvious now that I misjudged you and your true intentions. = 
+Curse you! You are beneath me, son of a donkey driver! I will crush you! =
  # Requires translation!
-The hard-shelled crab yields, and the lion lies down to sleep. Kanaloa comes for me now. = 
+You mongrel! Cursed be you! The world will long lament your heinous crime! =
  # Requires translation!
-Aloha! Greetings and blessings upon you, friend. I am Kamehameha, Great King of this strand of islands. = 
+Peace be on you! I am Darius, the great and outstanding king of kings of great Persia... but I suppose you knew that. =
  # Requires translation!
-Come, let our people feast together! = 
+In my endless magnanimity, I am making you this offer. You agree, of course? =
  # Requires translation!
-Welcome, friend! = 
+Good day to you! =
  # Requires translation!
-Wayfinding = 
+Ahh... you... =
  # Requires translation!
-Greetings and blessings be upon you, Kamehameha the Great, chosen by the heavens to unite your scattered peoples. Oh mighty King, you were the first to bring the Big Island of Hawai'i under one solitary rule in 1791 AD. This was followed by the merging of all the remaining islands under your standard in 1810. As the first King of Hawai'i, you standardized the legal and taxation systems and instituted the Mamalahoe Kawanai, an edict protecting civilians in times of war. You ensured the continued unification and sovereignty of the islands by your strong laws and deeds, even after your death in 1819. = 
+Achaemenid Legacy =
  # Requires translation!
-Oh wise and exalted King, your people wish for a kingdom of their own once more and require a leader of unparalleled greatness! Will you answer their call and don the mantle of the Lion of the Pacific? Will you build a kingdom that stands the test of time? = 
++1 Movement for all units during Golden Age =
  # Requires translation!
-Honolulu = 
++10% Strength for all units during Golden Age =
  # Requires translation!
-Samoa = 
+The blessings of heaven be upon you, beloved king Darius of Persia! You lead a strong and wise people. In the morning of the world, the great Persian leader Cyrus revolted against the mighty Median empire and by 550 BC, the Medes were no more. Through cunning diplomacy and military prowess, great Cyrus conquered wealthy Lydia and powerful Babylon, his son conquering proud Egypt some years later. Over time, Persian might expanded into far away Macedonia, at the very door of the upstart Greek city-states. Long would Persia prosper until the upstart villain Alexander of Macedon, destroyed the great empire in one shocking campaign. =
  # Requires translation!
-Tonga = 
+Darius, your people look to you to once again bring back the days of power and glory for Persia! The empire of your ancestors must emerge again, to triumph over its foes and to bring peace and order to the world! O king, will you answer the call? Can you build a civilization that will stand the test of time? =
  # Requires translation!
-Nuku Hiva = 
+Persepolis =
  # Requires translation!
-Raiatea = 
+Parsagadae =
  # Requires translation!
-Aotearoa = 
+Susa =
  # Requires translation!
-Tahiti = 
+Ecbatana =
  # Requires translation!
-Hilo = 
+Tarsus =
  # Requires translation!
-Te Wai Pounamu = 
+Gordium =
  # Requires translation!
-Rapa Nui = 
+Bactra =
  # Requires translation!
-Tuamotu = 
+Sardis =
  # Requires translation!
-Rarotonga = 
+Ergili =
  # Requires translation!
-Tuvalu = 
+Dariushkabir =
  # Requires translation!
-Tubuai = 
+Ghulaman =
  # Requires translation!
-Mangareva = 
+Zohak =
  # Requires translation!
-Oahu = 
+Istakhr =
  # Requires translation!
-Kiritimati = 
+Jinjan =
  # Requires translation!
-Ontong Java = 
+Borazjan =
  # Requires translation!
-Niue = 
+Herat =
  # Requires translation!
-Rekohu = 
+Dakyanus =
  # Requires translation!
-Rakahanga = 
+Bampur =
  # Requires translation!
-Bora Bora = 
+Turengtepe =
  # Requires translation!
-Kailua = 
+Rey =
  # Requires translation!
-Uvea = 
+Thuspa =
  # Requires translation!
-Futuna = 
+Hasanlu =
  # Requires translation!
-Rotuma = 
+Gabae =
  # Requires translation!
-Tokelau = 
+Merv =
  # Requires translation!
-Lahaina = 
+Behistun =
  # Requires translation!
-Bellona = 
+Kandahar =
  # Requires translation!
-Mungava = 
+Altintepe =
  # Requires translation!
-Tikopia = 
+Bunyan =
  # Requires translation!
-Emae = 
+Charsadda =
  # Requires translation!
-Kapingamarangi = 
+Uratyube =
  # Requires translation!
-Takuu = 
+Dura Europos =
  # Requires translation!
-Nukuoro = 
+Aleppo =
  # Requires translation!
-Sikaiana = 
+Qatna =
  # Requires translation!
-Anuta = 
+Kabul =
  # Requires translation!
-Nuguria = 
+Capisa =
  # Requires translation!
-Pileni = 
+Kyreskhata =
  # Requires translation!
-Nukumanu = 
+Marakanda =
+ # Requires translation!
+Peshawar =
+ # Requires translation!
+Van =
+ # Requires translation!
+Pteira =
+ # Requires translation!
+Arshada =
+ # Requires translation!
+Artakaona =
+ # Requires translation!
+Aspabota =
+ # Requires translation!
+Autiyara =
+ # Requires translation!
+Bagastana =
+ # Requires translation!
+Baxtri =
+ # Requires translation!
+Darmasa =
+ # Requires translation!
+Daphnai =
+ # Requires translation!
+Drapsaka =
+ # Requires translation!
+Eion =
+ # Requires translation!
+Gandutava =
+ # Requires translation!
+Gaugamela =
+ # Requires translation!
+Harmozeia =
+ # Requires translation!
+Ekatompylos =
+ # Requires translation!
+Izata =
+ # Requires translation!
+Kampada =
+ # Requires translation!
+Kapisa =
+ # Requires translation!
+Karmana =
+ # Requires translation!
+Kounaxa =
+ # Requires translation!
+Kuganaka =
+ # Requires translation!
+Nautaka =
+ # Requires translation!
+Paishiyauvada =
+ # Requires translation!
+Patigrbana =
+ # Requires translation!
+Phrada =
 Polynesia = Polinesia
  # Requires translation!
-Can embark and move over Coasts and Oceans immediately = 
+Kamehameha I =
  # Requires translation!
-Normal vision when embarked = 
+The ancient fire flashing across the sky is what proclaimed that this day would come, though I had foolishly hoped for a different outcome. =
  # Requires translation!
-+[amount]% Strength if within [amount2] tiles of a [tileImprovement] = 
-
+It is obvious now that I misjudged you and your true intentions. =
  # Requires translation!
-Ramkhamhaeng = 
+The hard-shelled crab yields, and the lion lies down to sleep. Kanaloa comes for me now. =
  # Requires translation!
-You lowly, arrogant fool! I will make you regret of your insolence! = 
+Aloha! Greetings and blessings upon you, friend. I am Kamehameha, Great King of this strand of islands. =
  # Requires translation!
-You scoundrel! I shall prepare to fend you off! = 
+Come, let our people feast together! =
  # Requires translation!
-Although I lost, my honor shall endure. I wish you good luck. = 
+Welcome, friend! =
  # Requires translation!
-I, Pho Kun Ramkhamhaeng, King of Siam, consider it a great honor that you have walked to visit my country of Siam. = 
+Wayfinding =
  # Requires translation!
-Greetings. I believe this is a fair proposal for both parties. What do you think? = 
+Can embark and move over Coasts and Oceans immediately =
  # Requires translation!
-Welcome. = 
++[amount]% Strength if within [amount2] tiles of a [tileImprovement] =
  # Requires translation!
-Father Governs Children = 
+Greetings and blessings be upon you, Kamehameha the Great, chosen by the heavens to unite your scattered peoples. Oh mighty King, you were the first to bring the Big Island of Hawai'i under one solitary rule in 1791 AD. This was followed by the merging of all the remaining islands under your standard in 1810. As the first King of Hawai'i, you standardized the legal and taxation systems and instituted the Mamalahoe Kawanai, an edict protecting civilians in times of war. You ensured the continued unification and sovereignty of the islands by your strong laws and deeds, even after your death in 1819. =
  # Requires translation!
-Greetings to you, Great King Ramkhamhaeng, leader of the glorious Siamese people! O mighty King, your people bow down before you in awe and fear! You are the ruler of Siam, an ancient country in the heart of Southeast Asia, a beautiful and mysterious land. Surrounded by foes, beset by bloody war and grinding poverty, the clever and loyal Siamese people have endured and triumphed. King Ramkhamhaeng, your empire was once part of the Khmer Empire, until the 13th century AD, when your ancestors revolted, forming the small Sukhothai kingdom. Through successful battle and cunning diplomacy, the tiny kingdom grew into a mighty empire, an empire which would dominate South East Asia for more than a century! = 
+Oh wise and exalted King, your people wish for a kingdom of their own once more and require a leader of unparalleled greatness! Will you answer their call and don the mantle of the Lion of the Pacific? Will you build a kingdom that stands the test of time? =
  # Requires translation!
-Oh, wise and puissant King Ramkhamhaeng, your people need you to once again lead them to greatness! Can you use your wits and strength of arms to protect your people and defeat your foes? Can you build a civilization that will stand the test of time? = 
+Honolulu =
  # Requires translation!
-Sukhothai = 
+Samoa =
  # Requires translation!
-Si Satchanalai = 
+Tonga =
  # Requires translation!
-Muang Saluang = 
+Nuku Hiva =
  # Requires translation!
-Lampang = 
+Raiatea =
  # Requires translation!
-Phitsanulok = 
+Aotearoa =
  # Requires translation!
-Kamphaeng Pet = 
+Tahiti =
  # Requires translation!
-Nakhom Chum = 
+Hilo =
  # Requires translation!
-Vientiane = 
+Te Wai Pounamu =
  # Requires translation!
-Nakhon Si Thammarat = 
+Rapa Nui =
  # Requires translation!
-Martaban = 
+Tuamotu =
  # Requires translation!
-Nakhon Sawan = 
+Rarotonga =
  # Requires translation!
-Chainat = 
+Tuvalu =
  # Requires translation!
-Luang Prabang = 
+Tubuai =
  # Requires translation!
-Uttaradit = 
+Mangareva =
  # Requires translation!
-Chiang Thong = 
+Oahu =
  # Requires translation!
-Phrae = 
+Kiritimati =
  # Requires translation!
-Nan = 
+Ontong Java =
  # Requires translation!
-Tak = 
+Niue =
  # Requires translation!
-Suphanburi = 
+Rekohu =
  # Requires translation!
-Hongsawadee = 
+Rakahanga =
  # Requires translation!
-Thawaii = 
+Bora Bora =
  # Requires translation!
-Ayutthaya = 
+Kailua =
  # Requires translation!
-Taphan Hin = 
+Uvea =
  # Requires translation!
-Uthai Thani = 
+Futuna =
  # Requires translation!
-Lap Buri = 
+Rotuma =
  # Requires translation!
-Ratchasima = 
+Tokelau =
  # Requires translation!
-Ban Phai = 
+Lahaina =
  # Requires translation!
-Loci = 
+Bellona =
  # Requires translation!
-Khon Kaen = 
+Mungava =
  # Requires translation!
-Surin = 
+Tikopia =
+ # Requires translation!
+Emae =
+ # Requires translation!
+Kapingamarangi =
+ # Requires translation!
+Takuu =
+ # Requires translation!
+Nukuoro =
+ # Requires translation!
+Sikaiana =
+ # Requires translation!
+Anuta =
+ # Requires translation!
+Nuguria =
+ # Requires translation!
+Pileni =
+ # Requires translation!
+Nukumanu =
 Siam = Siam
  # Requires translation!
-[amount]% [stat] from City-States = 
+Ramkhamhaeng =
  # Requires translation!
-Military Units gifted from City-States start with [amount] XP = 
-
+You lowly, arrogant fool! I will make you regret of your insolence! =
  # Requires translation!
-Isabella = 
+You scoundrel! I shall prepare to fend you off! =
  # Requires translation!
-God will probably forgive you... but I shall not. Prepare for war. = 
+Although I lost, my honor shall endure. I wish you good luck. =
  # Requires translation!
-Repugnant spawn of the devil! You will pay! = 
+I, Pho Kun Ramkhamhaeng, King of Siam, consider it a great honor that you have walked to visit my country of Siam. =
  # Requires translation!
-If my defeat is, without any doubt, the will of God, then I will accept it. = 
+Greetings. I believe this is a fair proposal for both parties. What do you think? =
  # Requires translation!
-God blesses those who deserve it. I am Isabel of Spain. = 
+Welcome. =
  # Requires translation!
-I hope this deal will receive your blessing. = 
+Father Governs Children =
  # Requires translation!
-Seven Cities of Gold = 
+Food and Culture from Friendly City-States are increased by 50% =
  # Requires translation!
-Blessed Isabella, servant of God, holy queen of Castille and León! Your people greet and welcome you. You are the ruler of Spain, a beautiful and ancient country at the crossroads of the world between Europe and Africa, one shore on the Mediterranean and the other on the mighty Atlantic Ocean. The Spanish are a multicultural people with roots in the Muslim and Christian worlds. A seafaring race, Spanish explorers found and conquered much of the New World, and, for many centuries, its gold and silver brought Spain unrivalled wealth and power, making the Spanish court the envy of the world. = 
+Greetings to you, Great King Ramkhamhaeng, leader of the glorious Siamese people! O mighty King, your people bow down before you in awe and fear! You are the ruler of Siam, an ancient country in the heart of Southeast Asia, a beautiful and mysterious land. Surrounded by foes, beset by bloody war and grinding poverty, the clever and loyal Siamese people have endured and triumphed. King Ramkhamhaeng, your empire was once part of the Khmer Empire, until the 13th century AD, when your ancestors revolted, forming the small Sukhothai kingdom. Through successful battle and cunning diplomacy, the tiny kingdom grew into a mighty empire, an empire which would dominate South East Asia for more than a century! =
  # Requires translation!
-O fair and virtuous Isabella! Will you rebuild the Spanish empire and show the world again the greatness of your people? Will you take up the mantle of the holy monarchy, and vanquish your foes under heaven's watchful eyes? Your adoring subjects await your command! Will you build a civilization that stands the test of time? = 
+Oh, wise and puissant King Ramkhamhaeng, your people need you to once again lead them to greatness! Can you use your wits and strength of arms to protect your people and defeat your foes? Can you build a civilization that will stand the test of time? =
  # Requires translation!
-Madrid = 
+Sukhothai =
  # Requires translation!
-Barcelona = 
+Si Satchanalai =
  # Requires translation!
-Seville = 
+Muang Saluang =
  # Requires translation!
-Cordoba = 
+Lampang =
  # Requires translation!
-Toledo = 
+Phitsanulok =
  # Requires translation!
-Santiago = 
+Kamphaeng Pet =
  # Requires translation!
-Murcia = 
+Nakhom Chum =
  # Requires translation!
-Valencia = 
+Vientiane =
  # Requires translation!
-Zaragoza = 
+Nakhon Si Thammarat =
  # Requires translation!
-Pamplona = 
+Martaban =
  # Requires translation!
-Vitoria = 
+Nakhon Sawan =
  # Requires translation!
-Santander = 
+Chainat =
  # Requires translation!
-Oviedo = 
+Luang Prabang =
  # Requires translation!
-Jaen = 
+Uttaradit =
  # Requires translation!
-Logroño = 
+Chiang Thong =
  # Requires translation!
-Valladolid = 
+Phrae =
  # Requires translation!
-Palma = 
+Nan =
  # Requires translation!
-Teruel = 
+Tak =
  # Requires translation!
-Almeria = 
+Suphanburi =
  # Requires translation!
-Leon = 
+Hongsawadee =
  # Requires translation!
-Zamora = 
+Thawaii =
  # Requires translation!
-Mida = 
+Ayutthaya =
  # Requires translation!
-Lugo = 
+Taphan Hin =
  # Requires translation!
-Alicante = 
+Uthai Thani =
  # Requires translation!
-Càdiz = 
+Lap Buri =
  # Requires translation!
-Eiche = 
+Ratchasima =
  # Requires translation!
-Alcorcon = 
+Ban Phai =
  # Requires translation!
-Burgos = 
+Loci =
  # Requires translation!
-Vigo = 
+Khon Kaen =
  # Requires translation!
-Badajoz = 
- # Requires translation!
-La Coruña = 
- # Requires translation!
-Guadalquivir = 
- # Requires translation!
-Bilbao = 
- # Requires translation!
-San Sebastian = 
- # Requires translation!
-Granada = 
- # Requires translation!
-Mérida = 
- # Requires translation!
-Huelva = 
- # Requires translation!
-Ibiza = 
- # Requires translation!
-Las Palmas = 
- # Requires translation!
-Tenerife = 
+Surin =
 Spain = Sepanyol
  # Requires translation!
-100 Gold for discovering a Natural Wonder (bonus enhanced to 500 Gold if first to discover it) = 
+Isabella =
  # Requires translation!
-Double Happiness from Natural Wonders = 
+God will probably forgive you... but I shall not. Prepare for war. =
  # Requires translation!
-Tile yields from Natural Wonders doubled = 
+Repugnant spawn of the devil! You will pay! =
+ # Requires translation!
+If my defeat is, without any doubt, the will of God, then I will accept it. =
+ # Requires translation!
+God blesses those who deserve it. I am Isabel of Spain. =
+ # Requires translation!
+I hope this deal will receive your blessing. =
+ # Requires translation!
+Seven Cities of Gold =
+ # Requires translation!
+100 Gold for discovering a Natural Wonder (bonus enhanced to 500 Gold if first to discover it) =
+ # Requires translation!
+Double Happiness from Natural Wonders =
+ # Requires translation!
+Tile yields from Natural Wonders doubled =
+ # Requires translation!
+Blessed Isabella, servant of God, holy queen of Castille and León! Your people greet and welcome you. You are the ruler of Spain, a beautiful and ancient country at the crossroads of the world between Europe and Africa, one shore on the Mediterranean and the other on the mighty Atlantic Ocean. The Spanish are a multicultural people with roots in the Muslim and Christian worlds. A seafaring race, Spanish explorers found and conquered much of the New World, and, for many centuries, its gold and silver brought Spain unrivalled wealth and power, making the Spanish court the envy of the world. =
+ # Requires translation!
+O fair and virtuous Isabella! Will you rebuild the Spanish empire and show the world again the greatness of your people? Will you take up the mantle of the holy monarchy, and vanquish your foes under heaven's watchful eyes? Your adoring subjects await your command! Will you build a civilization that stands the test of time? =
+ # Requires translation!
+Madrid =
+ # Requires translation!
+Barcelona =
+ # Requires translation!
+Seville =
+ # Requires translation!
+Cordoba =
+ # Requires translation!
+Toledo =
+ # Requires translation!
+Santiago =
+ # Requires translation!
+Murcia =
+ # Requires translation!
+Valencia =
+ # Requires translation!
+Zaragoza =
+ # Requires translation!
+Pamplona =
+ # Requires translation!
+Vitoria =
+ # Requires translation!
+Santander =
+ # Requires translation!
+Oviedo =
+ # Requires translation!
+Jaen =
+ # Requires translation!
+Logroño =
+ # Requires translation!
+Valladolid =
+ # Requires translation!
+Palma =
+ # Requires translation!
+Teruel =
+ # Requires translation!
+Almeria =
+ # Requires translation!
+Leon =
+ # Requires translation!
+Zamora =
+ # Requires translation!
+Mida =
+ # Requires translation!
+Lugo =
+ # Requires translation!
+Alicante =
+ # Requires translation!
+Càdiz =
+ # Requires translation!
+Eiche =
+ # Requires translation!
+Alcorcon =
+ # Requires translation!
+Burgos =
+ # Requires translation!
+Vigo =
+ # Requires translation!
+Badajoz =
+ # Requires translation!
+La Coruña =
+ # Requires translation!
+Guadalquivir =
+ # Requires translation!
+Bilbao =
+ # Requires translation!
+San Sebastian =
+ # Requires translation!
+Granada =
+ # Requires translation!
+Mérida =
+ # Requires translation!
+Huelva =
+ # Requires translation!
+Ibiza =
+ # Requires translation!
+Las Palmas =
+ # Requires translation!
+Tenerife =
 
  # Requires translation!
-Askia = 
+Songhai =
  # Requires translation!
-You are an abomination to heaven and earth, the chief of ignorant savages! You must be destroyed! = 
+Askia =
  # Requires translation!
-Fool! You have doomed your people to fire and destruction! = 
+You are an abomination to heaven and earth, the chief of ignorant savages! You must be destroyed! =
  # Requires translation!
-We have been consumed by the fires of hatred and rage. Enjoy your victory in this world - you shall pay a heavy price in the next! = 
+Fool! You have doomed your people to fire and destruction! =
  # Requires translation!
-I am Askia of the Songhai. We are a fair people - but those who cross us will find only destruction. You would do well to avoid repeating the mistakes others have made in the past. = 
+We have been consumed by the fires of hatred and rage. Enjoy your victory in this world - you shall pay a heavy price in the next! =
  # Requires translation!
-Can I interest you in this deal? = 
+I am Askia of the Songhai. We are a fair people - but those who cross us will find only destruction. You would do well to avoid repeating the mistakes others have made in the past. =
  # Requires translation!
-River Warlord = 
+Can I interest you in this deal? =
  # Requires translation!
-May the blessings of God, who is greatest of all, be upon you Askia, leader of the Songhai people! For many years your kingdom was a vassal of the mighty West African state of Mali, until the middle of the 14th century, when King Sunni Ali Ber wrested independence from the Mali, conquering much territory and fighting off numerous foes who sought to destroy him. Ultimately, his conquest of the wealthy cities of Timbuktu and Jenne gave the growing Songhai empire the economic power to survive for some 100 years, until the empire was destroyed by foes with advanced technology - muskets against spearmen. = 
+River Warlord =
  # Requires translation!
-King Askia, your people look to you to lead them to glory. To make them powerful and wealthy, to keep them supplied with the weapons they need to defeat any foe. Can you save them from destruction, oh King? Can you build a civilization that will stand the test of time? = 
+Receive triple Gold from Barbarian encampments and pillaging Cities =
  # Requires translation!
-Gao = 
+Embarked units can defend themselves =
  # Requires translation!
-Tombouctu = 
+May the blessings of God, who is greatest of all, be upon you Askia, leader of the Songhai people! For many years your kingdom was a vassal of the mighty West African state of Mali, until the middle of the 14th century, when King Sunni Ali Ber wrested independence from the Mali, conquering much territory and fighting off numerous foes who sought to destroy him. Ultimately, his conquest of the wealthy cities of Timbuktu and Jenne gave the growing Songhai empire the economic power to survive for some 100 years, until the empire was destroyed by foes with advanced technology - muskets against spearmen. =
  # Requires translation!
-Jenne = 
+King Askia, your people look to you to lead them to glory. To make them powerful and wealthy, to keep them supplied with the weapons they need to defeat any foe. Can you save them from destruction, oh King? Can you build a civilization that will stand the test of time? =
  # Requires translation!
-Taghaza = 
+Gao =
  # Requires translation!
-Tondibi = 
+Tombouctu =
  # Requires translation!
-Kumbi Saleh = 
+Jenne =
  # Requires translation!
-Kukia = 
+Taghaza =
  # Requires translation!
-Walata = 
+Tondibi =
  # Requires translation!
-Tegdaoust = 
+Kumbi Saleh =
  # Requires translation!
-Argungu = 
+Kukia =
  # Requires translation!
-Gwandu = 
+Walata =
  # Requires translation!
-Kebbi = 
+Tegdaoust =
  # Requires translation!
-Boussa = 
+Argungu =
  # Requires translation!
-Motpi = 
+Gwandu =
  # Requires translation!
-Bamako = 
+Kebbi =
  # Requires translation!
-Wa = 
+Boussa =
  # Requires translation!
-Kayes = 
+Motpi =
  # Requires translation!
-Awdaghost = 
+Bamako =
  # Requires translation!
-Ouadane = 
+Wa =
  # Requires translation!
-Dakar = 
+Kayes =
  # Requires translation!
-Tadmekket = 
+Awdaghost =
  # Requires translation!
-Tekedda = 
+Ouadane =
  # Requires translation!
-Kano = 
+Dakar =
  # Requires translation!
-Agadez = 
+Tadmekket =
  # Requires translation!
-Niamey = 
+Tekedda =
  # Requires translation!
-Torodi = 
+Kano =
  # Requires translation!
-Ouatagouna = 
+Agadez =
  # Requires translation!
-Dori = 
+Niamey =
  # Requires translation!
-Bamba = 
+Torodi =
  # Requires translation!
-Segou = 
+Ouatagouna =
  # Requires translation!
-Songhai = 
+Dori =
  # Requires translation!
-Receive triple Gold from Barbarian encampments and pillaging Cities = 
+Bamba =
  # Requires translation!
-Embarked units can defend themselves = 
+Segou =
 
  # Requires translation!
-Genghis Khan = 
+Mongolia =
  # Requires translation!
-You stand in the way of my armies. Let us solve this like warriors! = 
+Genghis Khan =
  # Requires translation!
-No more words. Today, Mongolia charges toward your defeat. = 
+You stand in the way of my armies. Let us solve this like warriors! =
  # Requires translation!
-You have hobbled the Mongolian clans. My respect for you nearly matches the loathing. I am waiting for my execution. = 
+No more words. Today, Mongolia charges toward your defeat. =
  # Requires translation!
-I am Temuujin, conqueror of cities and countries. Before me lie future Mongolian lands. Behind me is the only cavalry that matters. = 
+You have hobbled the Mongolian clans. My respect for you nearly matches the loathing. I am waiting for my execution. =
  # Requires translation!
-I am not always this generous, but we hope you take this rare opportunity we give you. = 
+I am Temuujin, conqueror of cities and countries. Before me lie future Mongolian lands. Behind me is the only cavalry that matters. =
  # Requires translation!
-So what now? = 
+I am not always this generous, but we hope you take this rare opportunity we give you. =
  # Requires translation!
-Mongol Terror = 
+So what now? =
  # Requires translation!
-Greetings, o great Temuujin, immortal emperor of the mighty Mongol Empire! Your fists shatter walls of cities and your voice brings despair to your enemies. O Khan! You united the warring tribes of Northern Asia into a mighty people, creating the greatest cavalry force the world has ever witnessed. Your people's cunning diplomacy divided their enemies, making them weak and helpless before Mongolia's conquering armies. In a few short years, your people's soldiers conquered most of China and Eastern Asia, and the empire continued to grow until it reached west into Europe and south to Korea. Indeed, it was the greatest empire ever seen, dwarfing those pathetic conquests of the Romans or the Greeks. = 
+Mongol Terror =
  # Requires translation!
-Temuujin, your people call upon you once more to lead them to battle and conquest. Will the world once again tremble at the thunderous sound of your cavalry, sweeping down from the steppes? Will you build a civilization that stands the test of time? = 
++30% Strength when fighting City-State units and cities =
  # Requires translation!
-Karakorum = 
+Greetings, o great Temuujin, immortal emperor of the mighty Mongol Empire! Your fists shatter walls of cities and your voice brings despair to your enemies. O Khan! You united the warring tribes of Northern Asia into a mighty people, creating the greatest cavalry force the world has ever witnessed. Your people's cunning diplomacy divided their enemies, making them weak and helpless before Mongolia's conquering armies. In a few short years, your people's soldiers conquered most of China and Eastern Asia, and the empire continued to grow until it reached west into Europe and south to Korea. Indeed, it was the greatest empire ever seen, dwarfing those pathetic conquests of the Romans or the Greeks. =
  # Requires translation!
-Beshbalik = 
+Temuujin, your people call upon you once more to lead them to battle and conquest. Will the world once again tremble at the thunderous sound of your cavalry, sweeping down from the steppes? Will you build a civilization that stands the test of time? =
  # Requires translation!
-Turfan = 
+Karakorum =
  # Requires translation!
-Hsia = 
+Beshbalik =
  # Requires translation!
-Old Sarai = 
+Turfan =
  # Requires translation!
-New Sarai = 
+Hsia =
  # Requires translation!
-Tabriz = 
+Old Sarai =
  # Requires translation!
-Tiflis = 
+New Sarai =
  # Requires translation!
-Otrar = 
+Tabriz =
  # Requires translation!
-Sanchu = 
+Tiflis =
  # Requires translation!
-Kazan = 
+Otrar =
  # Requires translation!
-Almarikh = 
+Sanchu =
  # Requires translation!
-Ulaanbaatar = 
+Kazan =
  # Requires translation!
-Hovd = 
+Almarikh =
  # Requires translation!
-Darhan = 
+Ulaanbaatar =
  # Requires translation!
-Dalandzadgad = 
+Hovd =
  # Requires translation!
-Mandalgovi = 
+Darhan =
  # Requires translation!
-Choybalsan = 
+Dalandzadgad =
  # Requires translation!
-Erdenet = 
+Mandalgovi =
  # Requires translation!
-Tsetserieg = 
+Choybalsan =
  # Requires translation!
-Baruun-Urt = 
+Erdenet =
  # Requires translation!
-Ereen = 
+Tsetserieg =
  # Requires translation!
-Batshireet = 
+Baruun-Urt =
  # Requires translation!
-Choyr = 
+Ereen =
  # Requires translation!
-Ulaangom = 
+Batshireet =
  # Requires translation!
-Tosontsengel = 
+Choyr =
  # Requires translation!
-Altay = 
+Ulaangom =
  # Requires translation!
-Uliastay = 
+Tosontsengel =
  # Requires translation!
-Bayanhongor = 
+Altay =
  # Requires translation!
-Har-Ayrag = 
+Uliastay =
  # Requires translation!
-Nalayh = 
+Bayanhongor =
  # Requires translation!
-Tes = 
+Har-Ayrag =
  # Requires translation!
-Mongolia = 
+Nalayh =
  # Requires translation!
-+30% Strength when fighting City-State units and cities = 
+Tes =
+ # Requires translation!
+Aztecs =
+ # Requires translation!
+Montezuma I =
+ # Requires translation!
+Xi-miqa-can! Xi-miqa-can! Xi-miqa-can! (Die, die, die!) =
+ # Requires translation!
+Excellent! Let the blood flow in raging torrents! =
+ # Requires translation!
+Monster! Who are you to destroy my greatness? =
+ # Requires translation!
+What do I see before me? Another beating heart for my sacrificial fire. =
+ # Requires translation!
+Accept this agreement or suffer the consequences. =
+ # Requires translation!
+Welcome, friend. =
+ # Requires translation!
+Sacrificial Captives =
+ # Requires translation!
+Earn [amount]% of killed [unitType] unit's [param] as [stat] =
+ # Requires translation!
+Welcome, O divine Montezuma! We grovel in awe at your magnificence! May the heaven shower all manner of good things upon you all the days of your life! You are the leader of the mighty Aztec people, wandering nomads from a lost home in the north who in the 12th century came to live in the mesa central in the heart of what would come to be called Mexico. Surrounded by many tribes fighting to control the rich land surrounding the sacred lakes of Texcoco, Xaltocan and Zampango, through cunning alliances and martial prowess, within a mere two hundred years, the Aztecs came to dominate the Central American basin, ruling a mighty empire stretching from sea to sea. But the empire fell at last under the assault of foreign devils - the accursed Spaniards! - wielding fiendish weapons the likes of which your faithful warriors had never seen. =
+ # Requires translation!
+O great king Montezuma, your people call upon you once more, to rise up and lead them to glory, bring them wealth and power, and give them dominion over their foes and rivals. Will you answer their call, glorious leader? Will you build a civilization that stands the test of time? =
+ # Requires translation!
+Tenochtitlan =
+ # Requires translation!
+Teotihuacan =
+ # Requires translation!
+Tlatelolco =
+ # Requires translation!
+Texcoco =
+ # Requires translation!
+Tlaxcala =
+ # Requires translation!
+Calixtlahuaca =
+ # Requires translation!
+Xochicalco =
+ # Requires translation!
+Tlacopan =
+ # Requires translation!
+Atzcapotzalco =
+ # Requires translation!
+Tzintzuntzan =
+ # Requires translation!
+Malinalco =
+ # Requires translation!
+Tamuin =
+ # Requires translation!
+Teayo =
+ # Requires translation!
+Cempoala =
+ # Requires translation!
+Chalco =
+ # Requires translation!
+Tlalmanalco =
+ # Requires translation!
+Ixtapaluca =
+ # Requires translation!
+Huexotla =
+ # Requires translation!
+Tepexpan =
+ # Requires translation!
+Tepetlaoxtoc =
+ # Requires translation!
+Chiconautla =
+ # Requires translation!
+Zitlaltepec =
+ # Requires translation!
+Coyotepec =
+ # Requires translation!
+Tequixquiac =
+ # Requires translation!
+Jilotzingo =
+ # Requires translation!
+Tlapanaloya =
+ # Requires translation!
+Tultitan =
+ # Requires translation!
+Ecatepec =
+ # Requires translation!
+Coatepec =
+ # Requires translation!
+Chalchiuites =
+ # Requires translation!
+Chiauhita =
+ # Requires translation!
+Chapultepec =
+ # Requires translation!
+Itzapalapa =
+ # Requires translation!
+Ayotzinco =
+ # Requires translation!
+Iztapam =
 
  # Requires translation!
-Montezuma I = 
+Inca =
  # Requires translation!
-Xi-miqa-can! Xi-miqa-can! Xi-miqa-can! (Die, die, die!) = 
+Pachacuti =
  # Requires translation!
-Excellent! Let the blood flow in raging torrents! = 
+Resistance is futile! You cannot hope to stand against the mighty Incan empire. If you will not surrender immediately, then prepare for war! =
  # Requires translation!
-Monster! Who are you to destroy my greatness? = 
+Declare war on me?!? You can't, because I declare war on you first! =
  # Requires translation!
-What do I see before me? Another beating heart for my sacrificial fire. = 
+How did you darken the sun? I ruled with diligence and mercy—see that you do so as well. =
  # Requires translation!
-Accept this agreement or suffer the consequences. = 
+How are you? You stand before Pachacuti Inca Yupanqui. =
  # Requires translation!
-Welcome, friend. = 
+The Incan people offer this fair trade. =
  # Requires translation!
-Sacrificial Captives = 
+How are you doing? =
  # Requires translation!
-Welcome, O divine Montezuma! We grovel in awe at your magnificence! May the heaven shower all manner of good things upon you all the days of your life! You are the leader of the mighty Aztec people, wandering nomads from a lost home in the north who in the 12th century came to live in the mesa central in the heart of what would come to be called Mexico. Surrounded by many tribes fighting to control the rich land surrounding the sacred lakes of Texcoco, Xaltocan and Zampango, through cunning alliances and martial prowess, within a mere two hundred years, the Aztecs came to dominate the Central American basin, ruling a mighty empire stretching from sea to sea. But the empire fell at last under the assault of foreign devils - the accursed Spaniards! - wielding fiendish weapons the likes of which your faithful warriors had never seen. = 
+What do you want now? =
  # Requires translation!
-O great king Montezuma, your people call upon you once more, to rise up and lead them to glory, bring them wealth and power, and give them dominion over their foes and rivals. Will you answer their call, glorious leader? Will you build a civilization that stands the test of time? = 
+Great Andean Road =
  # Requires translation!
-Tenochtitlan = 
+Units ignore terrain costs when moving into any tile with Hills =
  # Requires translation!
-Teotihuacan = 
+Maintenance on roads & railroads reduced by [amount]% =
  # Requires translation!
-Tlatelolco = 
+No Maintenance costs for improvements in [tileFilter] tiles =
  # Requires translation!
-Texcoco = 
+Oh ye who remakes the world, your loyal subjects greet you, King Pachacuti Sapa Inca, ruler of Tawantinsuyu and the Inca people! From the beginnings in the small state of Cusco, the Incans displayed their potential for greatness, marching to war against their many enemies, crushing their armies into dust and carving for themselves a mighty empire stretching from Ecuador to Chile. Indeed, they built the greatest empire ever seen in pre-Columbian America. More than mere soldiers, your people were great builders and artists as well, and the remnants of their works still awe and inspire the world today. =
  # Requires translation!
-Tlaxcala = 
+Oh King Pachacuti, truly are you called 'Earth Shaker'! Will you once again call upon the ground itself to a fight at your side? Your armies await your signal. Will you restore the glory of your empire? Can you build a civilization that will stand the test of time? =
  # Requires translation!
-Calixtlahuaca = 
+Cuzco =
  # Requires translation!
-Xochicalco = 
+Tiwanaku =
  # Requires translation!
-Tlacopan = 
+Machu =
  # Requires translation!
-Atzcapotzalco = 
+Ollantaytambo =
  # Requires translation!
-Tzintzuntzan = 
+Corihuayrachina =
  # Requires translation!
-Malinalco = 
+Huamanga =
  # Requires translation!
-Tamuin = 
+Rumicucho =
  # Requires translation!
-Teayo = 
+Vilcabamba =
  # Requires translation!
-Cempoala = 
+Vitcos =
  # Requires translation!
-Chalco = 
+Andahuaylas =
  # Requires translation!
-Tlalmanalco = 
+Ica =
  # Requires translation!
-Ixtapaluca = 
+Arequipa =
  # Requires translation!
-Huexotla = 
+Nasca =
  # Requires translation!
-Tepexpan = 
+Atico =
  # Requires translation!
-Tepetlaoxtoc = 
+Juli =
  # Requires translation!
-Chiconautla = 
+Chuito =
  # Requires translation!
-Zitlaltepec = 
+Chuquiapo =
  # Requires translation!
-Coyotepec = 
+Huanuco Pampa =
  # Requires translation!
-Tequixquiac = 
+Tamboccocha =
  # Requires translation!
-Jilotzingo = 
+Huaras =
  # Requires translation!
-Tlapanaloya = 
+Riobamba =
  # Requires translation!
-Tultitan = 
+Caxamalca =
  # Requires translation!
-Ecatepec = 
+Sausa =
  # Requires translation!
-Coatepec = 
+Tambo Colorado =
  # Requires translation!
-Chalchiuites = 
+Huaca =
  # Requires translation!
-Chiauhita = 
+Tumbes =
  # Requires translation!
-Chapultepec = 
+Chan Chan =
  # Requires translation!
-Itzapalapa = 
+Sipan =
  # Requires translation!
-Ayotzinco = 
+Pachacamac =
  # Requires translation!
-Iztapam = 
+Llactapata =
  # Requires translation!
-Aztecs = 
+Pisac =
  # Requires translation!
-Earn [amount]% of killed [unitType] unit's [param] as [stat] = 
+Kuelap =
+ # Requires translation!
+Pajaten =
+ # Requires translation!
+Chucuito =
+ # Requires translation!
+Choquequirao =
+ # Requires translation!
+Denmark =
+ # Requires translation!
+Harald Bluetooth =
+ # Requires translation!
+If I am to be honest, I tire of those pointless charades. Why don't we settle our disputes on the field of battle, like true men? Perhaps the skalds will sing of your valor... or mine! =
+ # Requires translation!
+Ahahah! You seem to show some skills of a true Viking! Too bad that I'll probably kill you! =
+ # Requires translation!
+Loki must have stood by you, for a common man alone could not have defeated me... Oh well! I will join the einherjar in Valhalla and feast, while you toil away here. =
+ # Requires translation!
+Harald Bluetooth bids you welcome to his lands, a Viking unlike any the seas and lands have ever known! Hah, are you afraid? =
+ # Requires translation!
+This is a fine deal! Even a drunk beggar would agree! =
+ # Requires translation!
+Hail to you. =
+ # Requires translation!
+Viking Fury =
+ # Requires translation!
++1 Movement for all embarked units =
+ # Requires translation!
+Units pay only 1 movement point to disembark =
+ # Requires translation!
+Melee units pay no movement cost to pillage =
+ # Requires translation!
+Honor and glory be yours, Harald Bluetooth Gormsson, mighty heir of King Gorm of the Old and Thyra Dannebod. Not only were you victorious on the battlefield against the armies of Norway, you also completed massive construction project across the land - numerous Ring Fortresses to protect the populace from invasion and internal strife. You successfully drove off waves of German settlers in 983 AD and sheltered your kingdom from unwanted foreign influence. =
+ # Requires translation!
+Stalwart Viking, the time for greatness is upon you once more. You are called to rise up and lead your people to renewed power and triumph! Will you make the world shudder once more at the very thought of your great armies of Northsmen? Will you let the Viking battle cry ring out across the crashing waves? Will you build a civilization to stand the test of time? =
+ # Requires translation!
+Copenhagen =
+ # Requires translation!
+Aarhus =
+ # Requires translation!
+Kaupang =
+ # Requires translation!
+Ribe =
+ # Requires translation!
+Viborg =
+ # Requires translation!
+Tunsberg =
+ # Requires translation!
+Roskilde =
+ # Requires translation!
+Hedeby =
+ # Requires translation!
+Oslo =
+ # Requires translation!
+Jelling =
+ # Requires translation!
+Truso =
+ # Requires translation!
+Bergen =
+ # Requires translation!
+Faeroerne =
+ # Requires translation!
+Reykjavik =
+ # Requires translation!
+Trondheim =
+ # Requires translation!
+Godthab =
+ # Requires translation!
+Helluland =
+ # Requires translation!
+Lillehammer =
+ # Requires translation!
+Markland =
+ # Requires translation!
+Elsinore =
+ # Requires translation!
+Sarpsborg =
+ # Requires translation!
+Odense =
+ # Requires translation!
+Aalborg =
+ # Requires translation!
+Stavanger =
+ # Requires translation!
+Vorbasse =
+ # Requires translation!
+Schleswig =
+ # Requires translation!
+Kristiansand =
+ # Requires translation!
+Halogaland =
+ # Requires translation!
+Randers =
+ # Requires translation!
+Fredrikstad =
+ # Requires translation!
+Kolding =
+ # Requires translation!
+Horsens =
+ # Requires translation!
+Tromsoe =
+ # Requires translation!
+Vejle =
+ # Requires translation!
+Koge =
+ # Requires translation!
+Sandnes =
+ # Requires translation!
+Holstebro =
+ # Requires translation!
+Slagelse =
+ # Requires translation!
+Drammen =
+ # Requires translation!
+Hillerod =
+ # Requires translation!
+Sonderborg =
+ # Requires translation!
+Skien =
+ # Requires translation!
+Svendborg =
+ # Requires translation!
+Holbaek =
+ # Requires translation!
+Hjorring =
+ # Requires translation!
+Fladstrand =
+ # Requires translation!
+Haderslev =
+ # Requires translation!
+Ringsted =
+ # Requires translation!
+Skrive =
+ # Requires translation!
+The Huns =
+ # Requires translation!
+Attila the Hun =
+ # Requires translation!
+I grow tired of this throne. I think I should like to have yours instead. =
+ # Requires translation!
+Now what is this?! You ask me to add your riches to my great avails. The invitation is accepted. =
+ # Requires translation!
+My people will mourn me not with tears, but with human blood. =
+ # Requires translation!
+You are in the presence of Attila, scourge of Rome. Do not let hubris be your downfall as well. =
+ # Requires translation!
+This is better than you deserve, but let it not be said that I am an unfair man. =
+ # Requires translation!
+Good day to you. =
+ # Requires translation!
+Scourge of God =
+ # Requires translation!
+Cities are razed [amount] times as fast =
+ # Requires translation!
+Starts with [tech] =
+ # Requires translation!
+"Borrows" city names from other civilizations in the game =
+ # Requires translation!
+Your men stand proudly to greet you, Great Attila, grand warrior and ruler of the Hunnic empire. Together with your brother Bleda you expanded the boundaries of your empire, becoming the most powerful and frightening force of the 5th century. You bowed the Eastern Roman Emperors to your will and took kingdom after kingdom along the Danube and Nisava Rivers. As the sovereign ruler of the Huns, you marched your army across Europe into Gaul, planning to extend your already impressive lands all the way to the Atlantic Ocean. Your untimely death led to the quick disintegration and downfall of your empire, but your name and deeds have created an everlasting legacy for your people.  =
+ # Requires translation!
+Fearsome General, your people call for the recreation of a new Hunnic Empire, one which will make the exploits and histories of the former seem like the faded dreaming of a dying sun. Will you answer their call to regain your rightful prominence and glory? Will you mount your steadfast steed and lead your armies to victory? Will you build a civilization that stands the test of time?  =
+ # Requires translation!
+Atilla's Court =
 
  # Requires translation!
-Pachacuti = 
+The Netherlands =
  # Requires translation!
-Resistance is futile! You cannot hope to stand against the mighty Incan empire. If you will not surrender immediately, then prepare for war! = 
+William of Orange =
  # Requires translation!
-Declare war on me?!? You can't, because I declare war on you first! = 
+As much as I despise war, I consider it a, hahaha, contribution to the common cause to erase your existence. =
  # Requires translation!
-How did you darken the sun? I ruled with diligence and mercy—see that you do so as well. = 
+You call yourself an exalted ruler, but I see nothing more than a smartly dressed barbarian! =
  # Requires translation!
-How are you? You stand before Pachacuti Inca Yupanqui. = 
+My God, be merciful to my soul. My God, feel pity for this... my poor people! =
  # Requires translation!
-The Incan people offer this fair trade. = 
+I am William of Orange, stadtholder of The Netherlands. Did you need anything? I still have a lot to do. =
  # Requires translation!
-How are you doing? = 
+I believe I have something that may be of some importance to you. =
  # Requires translation!
-What do you want now? = 
+Once again, greetings. =
  # Requires translation!
-Great Andean Road = 
+Dutch East India Company =
  # Requires translation!
-Oh ye who remakes the world, your loyal subjects greet you, King Pachacuti Sapa Inca, ruler of Tawantinsuyu and the Inca people! From the beginnings in the small state of Cusco, the Incans displayed their potential for greatness, marching to war against their many enemies, crushing their armies into dust and carving for themselves a mighty empire stretching from Ecuador to Chile. Indeed, they built the greatest empire ever seen in pre-Columbian America. More than mere soldiers, your people were great builders and artists as well, and the remnants of their works still awe and inspire the world today. = 
+Retain [amount]% of the happiness from a luxury after the last copy has been traded away =
  # Requires translation!
-Oh King Pachacuti, truly are you called 'Earth Shaker'! Will you once again call upon the ground itself to a fight at your side? Your armies await your signal. Will you restore the glory of your empire? Can you build a civilization that will stand the test of time? = 
+Hail stalwart Prince William of Orange, liberator of the Netherlands and hero to the Dutch people. It was your courageous effort in the 1568 rebellion against Spanish dominion that led the Dutch to freedom, and ultimately resulted in the Eighty Years' War. Your undertaking allowed for the creation of one of Europe's first modern republics, the Seven United Provinces. You gave your life to the rebellion, falling at the hands of an assassin in 1584, but your death would only serve to embolden the people's charge, and your legacy as "Father of the Fatherland" will stand as a symbol of Dutch independence for all time. =
  # Requires translation!
-Cuzco = 
+Brave prince, the people again yearn for the wise stewardship your wisdom afforded them. Can you once again secure the sovereignty of your kingdom and lead your people to greatness? Can you build a civilization that stands the test of time? =
  # Requires translation!
-Tiwanaku = 
+Amsterdam =
  # Requires translation!
-Machu = 
+Rotterdam =
  # Requires translation!
-Ollantaytambo = 
+Utrecht =
  # Requires translation!
-Corihuayrachina = 
+Groningen =
  # Requires translation!
-Huamanga = 
+Breda =
  # Requires translation!
-Rumicucho = 
+Nijmegen =
  # Requires translation!
-Vilcabamba = 
+Den Haag =
  # Requires translation!
-Vitcos = 
+Haarlem =
  # Requires translation!
-Andahuaylas = 
+Arnhem =
  # Requires translation!
-Ica = 
+Zutphen =
  # Requires translation!
-Arequipa = 
+Maastricht =
  # Requires translation!
-Nasca = 
+Tilburg =
  # Requires translation!
-Atico = 
+Eindhoven =
  # Requires translation!
-Juli = 
+Dordrecht =
  # Requires translation!
-Chuito = 
+Leiden =
  # Requires translation!
-Chuquiapo = 
+'s Hertogenbosch =
  # Requires translation!
-Huanuco Pampa = 
+Almere =
  # Requires translation!
-Tamboccocha = 
+Alkmaar =
  # Requires translation!
-Huaras = 
+Brielle =
  # Requires translation!
-Riobamba = 
+Vlissingen =
  # Requires translation!
-Caxamalca = 
+Apeldoorn =
  # Requires translation!
-Sausa = 
+Enschede =
  # Requires translation!
-Tambo Colorado = 
+Amersfoort =
  # Requires translation!
-Huaca = 
+Zwolle =
  # Requires translation!
-Tumbes = 
+Venlo =
  # Requires translation!
-Chan Chan = 
+Uden =
  # Requires translation!
-Sipan = 
+Grave =
  # Requires translation!
-Pachacamac = 
+Delft =
  # Requires translation!
-Llactapata = 
+Gouda =
  # Requires translation!
-Pisac = 
+Nieuwstadt =
  # Requires translation!
-Kuelap = 
+Weesp =
  # Requires translation!
-Pajaten = 
+Coevorden =
  # Requires translation!
-Chucuito = 
- # Requires translation!
-Choquequirao = 
- # Requires translation!
-Inca = 
- # Requires translation!
-Units ignore terrain costs when moving into any tile with Hills = 
- # Requires translation!
-Maintenance on roads & railroads reduced by [amount]% = 
- # Requires translation!
-No Maintenance costs for improvements in [tileFilter] tiles = 
+Kerkrade =
 
  # Requires translation!
-Harald Bluetooth = 
+Sweden =
  # Requires translation!
-If I am to be honest, I tire of those pointless charades. Why don't we settle our disputes on the field of battle, like true men? Perhaps the skalds will sing of your valor... or mine! = 
+Gustavus Adolphus =
  # Requires translation!
-Ahahah! You seem to show some skills of a true Viking! Too bad that I'll probably kill you! = 
+The Hakkapeliittas will ride again and your men will fall just at the sight of my cavalry! God with us! =
  # Requires translation!
-Loki must have stood by you, for a common man alone could not have defeated me... Oh well! I will join the einherjar in Valhalla and feast, while you toil away here. = 
+Ha ha ha, captain Gars will be very glad to head out to war again. =
  # Requires translation!
-Harald Bluetooth bids you welcome to his lands, a Viking unlike any the seas and lands have ever known! Hah, are you afraid? = 
+I am Sweden's king. You can take my lands, my people, my kingdom, but you will never reach the House of Vasa. =
  # Requires translation!
-This is a fine deal! Even a drunk beggar would agree! = 
+Stranger, welcome to the Snow King's kingdom! I am Gustavus Adolphus, member of the esteemed House of Vasa =
  # Requires translation!
-Hail to you. = 
+My friend, it is my belief that this settlement can benefit both our peoples. =
  # Requires translation!
-Viking Fury = 
+Oh, welcome! =
  # Requires translation!
-Honor and glory be yours, Harald Bluetooth Gormsson, mighty heir of King Gorm of the Old and Thyra Dannebod. Not only were you victorious on the battlefield against the armies of Norway, you also completed massive construction project across the land - numerous Ring Fortresses to protect the populace from invasion and internal strife. You successfully drove off waves of German settlers in 983 AD and sheltered your kingdom from unwanted foreign influence. = 
+Oh, it is you. =
  # Requires translation!
-Stalwart Viking, the time for greatness is upon you once more. You are called to rise up and lead your people to renewed power and triumph! Will you make the world shudder once more at the very thought of your great armies of Northsmen? Will you let the Viking battle cry ring out across the crashing waves? Will you build a civilization to stand the test of time? = 
+Nobel Prize =
  # Requires translation!
-Copenhagen = 
+Gain [amount] Influence with a [param] gift to a City-State =
  # Requires translation!
-Aarhus = 
+When declaring friendship, both parties gain a [amount]% boost to great person generation =
  # Requires translation!
-Kaupang = 
+All hail the transcendent King Gustavus Adolphus, founder of the Swedish Empire and her most distinguished military tactician. It was during your reign that Sweden emerged as one of the greatest powers in Europe, due in no small part to your wisdom, both on and off the battlefield. As king, you initiated a number of domestic reforms that ensured the economic stability and prosperity of your people. As the general who came to be known as the "Lion of the North," your visionary designs in warfare gained the admiration of military commanders the world over. Thanks to your triumphs in the Thirty Years' War, you were assured a legacy as one of history's greatest generals. =
  # Requires translation!
-Ribe = 
+Oh noble King, the people long for your prudent leadership, hopeful that once again they will see your kingdom rise to glory. Will you devise daring new strategies, leading your armies to victory on the theater of war? Will you build a civilization that stands the test of time? =
  # Requires translation!
-Viborg = 
+Stockholm =
  # Requires translation!
-Tunsberg = 
+Uppsala =
  # Requires translation!
-Roskilde = 
+Gothenburg =
  # Requires translation!
-Hedeby = 
+Malmö =
  # Requires translation!
-Oslo = 
+Linköping =
  # Requires translation!
-Jelling = 
+Kalmar =
  # Requires translation!
-Truso = 
+Skara =
  # Requires translation!
-Bergen = 
+Västerås =
  # Requires translation!
-Faeroerne = 
+Jönköping =
  # Requires translation!
-Reykjavik = 
+Visby =
  # Requires translation!
-Trondheim = 
+Falun =
  # Requires translation!
-Godthab = 
+Norrköping =
  # Requires translation!
-Helluland = 
+Gävle =
  # Requires translation!
-Lillehammer = 
+Halmstad =
  # Requires translation!
-Markland = 
+Karlskrona =
  # Requires translation!
-Elsinore = 
+Hudiksvall =
  # Requires translation!
-Sarpsborg = 
+Örebro =
  # Requires translation!
-Odense = 
+Umeå =
  # Requires translation!
-Aalborg = 
+Karlstad =
  # Requires translation!
-Stavanger = 
+Helsingborg =
  # Requires translation!
-Vorbasse = 
+Härnösand =
  # Requires translation!
-Schleswig = 
+Vadstena =
  # Requires translation!
-Kristiansand = 
+Lund =
  # Requires translation!
-Halogaland = 
+Västervik =
  # Requires translation!
-Randers = 
+Enköping =
  # Requires translation!
-Fredrikstad = 
+Skövde =
  # Requires translation!
-Kolding = 
+Eskilstuna =
  # Requires translation!
-Horsens = 
+Luleå =
  # Requires translation!
-Tromsoe = 
+Lidköping =
  # Requires translation!
-Vejle = 
+Södertälje =
  # Requires translation!
-Koge = 
+Mariestad =
  # Requires translation!
-Sandnes = 
+Östersund =
  # Requires translation!
-Holstebro = 
+Borås =
  # Requires translation!
-Slagelse = 
+Sundsvall =
  # Requires translation!
-Drammen = 
+Vimmerby =
  # Requires translation!
-Hillerod = 
+Köping =
  # Requires translation!
-Sonderborg = 
+Mora =
  # Requires translation!
-Skien = 
+Arboga =
  # Requires translation!
-Svendborg = 
+Växjö =
  # Requires translation!
-Holbaek = 
+Gränna =
  # Requires translation!
-Hjorring = 
+Kiruna =
  # Requires translation!
-Fladstrand = 
+Borgholm =
  # Requires translation!
-Haderslev = 
+Strängnäs =
  # Requires translation!
-Ringsted = 
- # Requires translation!
-Skrive = 
- # Requires translation!
-Denmark = 
- # Requires translation!
-Units pay only 1 movement point to disembark = 
- # Requires translation!
-Melee units pay no movement cost to pillage = 
+Sveg =
 
  # Requires translation!
-You leave us no choice. War it must be. = 
+Milan =
  # Requires translation!
-Very well, this shall not be forgotten. = 
+You leave us no choice. War it must be. =
  # Requires translation!
-I guess you weren't here for the sprouts after all... = 
+Very well, this shall not be forgotten. =
  # Requires translation!
-Brussels = 
+You fiend! History shall remember this! =
 
  # Requires translation!
-And so the flower of Florence falls to barbaric hands... = 
+Florence =
  # Requires translation!
-Florence = 
+And so the flower of Florence falls to barbaric hands... =
 
  # Requires translation!
-So this is how it feels to die... = 
+Rio de Janeiro =
  # Requires translation!
-Hanoi = 
+I have to do this, for the sake of progress if nothing else. You must be opposed! =
+ # Requires translation!
+You can see how fruitless this will be for you... right? =
+ # Requires translation!
+May God grant me these last wishes - peace and prosperity for Brazil. =
 
  # Requires translation!
-Unacceptable! = 
-
-Today, the Malay people obey you, but do not think this is over... = Hari ini, orang Melayu taat pada kamu, tetapi jangan fikir ini sudah tamat...
-Kuala Lumpur = Kuala Lumpur
-
+Antwerp =
  # Requires translation!
-Perhaps now we will find peace in death... = 
- # Requires translation!
-Lhasa = 
+They will write songs of this.... pray that they shall be in your favor. =
 
  # Requires translation!
-You fiend! History shall remember this! = 
+Dublin =
  # Requires translation!
-Milan = 
+War lingers in our hearts. Why carry on with a false peace? =
+ # Requires translation!
+You gormless radger! You'll dine on your own teeth before you set foot in Ireland! =
+ # Requires translation!
+A lonely wind blows through the highlands today. A dirge for Ireland. Can you hear it? =
+ # Requires translation!
+Tyre =
+ # Requires translation!
+We never fully trusted you from the start. =
+ # Requires translation!
+Ur =
+ # Requires translation!
+I will enjoy hearing your last breath as you witness the destruction of your realm! =
+ # Requires translation!
+Why do we fight? Because Inanna demands it. Now, witness the power of the Sumerians! =
+ # Requires translation!
+What treachery has struck us? No, what evil? =
+ # Requires translation!
+Genoa =
+ # Requires translation!
+How barbaric. Those who live by the sword shall perish by the sword. =
+ # Requires translation!
+Venice =
+ # Requires translation!
+You have revealed your purposes a bit too early, my friend... =
+ # Requires translation!
+A wrong calculation, on my part. =
+ # Requires translation!
+Brussels =
+ # Requires translation!
+I guess you weren't here for the sprouts after all... =
 
  # Requires translation!
-We were too weak to protect ourselves... = 
- # Requires translation!
-Quebec City = 
+Unacceptable! =
 
  # Requires translation!
-I have failed. May you, at least, know compassion towards our people. = 
+Sidon =
  # Requires translation!
-Cape Town = 
+What a fine battle! Sidon is willing to serve you! =
 
  # Requires translation!
-The day of judgement has come to us. But rest assured, the same will go for you! = 
+Almaty =
  # Requires translation!
-Helsinki = 
+How could we fall to the likes of you?! =
 
  # Requires translation!
-Ah, Gods! Why have you forsaken us? = 
+Edinburgh =
  # Requires translation!
-Manila = 
+You shall stain this land no longer with your vileness! To arms, my countrymen - we ride to war! =
+ # Requires translation!
+Traitorous man! The Celtic peoples will not stand for such wanton abuse and slander - I shall have your head! =
+ # Requires translation!
+Vile ruler, know that you 'won' this war in name only! =
 
- # Requires translation!
-Congratulations, conqueror. This tribe serves you now. = 
- # Requires translation!
-Mogadishu = 
-
- # Requires translation!
-I have to do this, for the sake of progress if nothing else. You must be opposed! = 
- # Requires translation!
-You can see how fruitless this will be for you... right? = 
- # Requires translation!
-May God grant me these last wishes - peace and prosperity for Brazil. = 
- # Requires translation!
-Rio de Janeiro = 
-
- # Requires translation!
-After thorough deliberation, Australia finds itself at a crossroads. Prepare yourself, for war is upon us. = 
- # Requires translation!
-We will mobilize every means of resistance to stop this transgression against our nation! = 
- # Requires translation!
-The principles for which we have fought will survive longer than any nation you could ever build. = 
- # Requires translation!
-Sydney = 
-
- # Requires translation!
-I will enjoy hearing your last breath as you witness the destruction of your realm! = 
- # Requires translation!
-Why do we fight? Because Inanna demands it. Now, witness the power of the Sumerians! = 
- # Requires translation!
-What treachery has struck us? No, what evil? = 
- # Requires translation!
-Ur = 
-
- # Requires translation!
-In responding to the unstinting malignancy that has heretofore defined your relationship with Canada, we can have no recourse but war! = 
- # Requires translation!
-As we can reach no peaceful resolution with you, Canada must turn, with reluctance, to war. = 
- # Requires translation!
-I regret not defending my country to the last, although it was not of use. = 
- # Requires translation!
-Vancouver = 
-
- # Requires translation!
-You have revealed your purposes a bit too early, my friend... = 
- # Requires translation!
-A wrong calculation, on my part. = 
- # Requires translation!
-Venice = 
-
- # Requires translation!
-They will write songs of this.... pray that they shall be in your favor. = 
- # Requires translation!
-Antwerp = 
-
- # Requires translation!
-How barbaric. Those who live by the sword shall perish by the sword. = 
- # Requires translation!
-Genoa = 
-
- # Requires translation!
-We... defeated? No... we had so much work to do! = 
- # Requires translation!
-Kathmandu = 
-
- # Requires translation!
-Perhaps, in another world, we could have been friends... = 
 Singapore = Singapura
+ # Requires translation!
+Perhaps, in another world, we could have been friends... =
 
  # Requires translation!
-We never fully trusted you from the start. = 
+Zanzibar =
  # Requires translation!
-Tyre = 
+May the Heavens forgive you for inflicting this humiliation to our people. =
 
  # Requires translation!
-May the Heavens forgive you for inflicting this humiliation to our people. = 
+Sydney =
  # Requires translation!
-Zanzibar = 
+After thorough deliberation, Australia finds itself at a crossroads. Prepare yourself, for war is upon us. =
+ # Requires translation!
+We will mobilize every means of resistance to stop this transgression against our nation! =
+ # Requires translation!
+The principles for which we have fought will survive longer than any nation you could ever build. =
 
  # Requires translation!
-How could we fall to the likes of you?! = 
+Cape Town =
  # Requires translation!
-Almaty = 
+I have failed. May you, at least, know compassion towards our people. =
 
  # Requires translation!
-Let's have a nice little War, shall we? = 
+Kathmandu =
  # Requires translation!
-If you need your nose bloodied, we'll happily serve. = 
- # Requires translation!
-The serbian guerilla will never stop haunting you! = 
- # Requires translation!
-Belgrade = 
+We... defeated? No... we had so much work to do! =
 
  # Requires translation!
-War lingers in our hearts. Why carry on with a false peace? = 
+Hanoi =
  # Requires translation!
-You gormless radger! You'll dine on your own teeth before you set foot in Ireland! = 
- # Requires translation!
-A lonely wind blows through the highlands today. A dirge for Ireland. Can you hear it? = 
- # Requires translation!
-Dublin = 
- # Requires translation!
-Will not be displayed in Civilopedia = 
- # Requires translation!
-Will not be chosen for new games = 
+So this is how it feels to die... =
 
  # Requires translation!
-You shall stain this land no longer with your vileness! To arms, my countrymen - we ride to war! = 
+Quebec City =
  # Requires translation!
-Traitorous man! The Celtic peoples will not stand for such wanton abuse and slander - I shall have your head! = 
- # Requires translation!
-Vile ruler, know that you 'won' this war in name only! = 
- # Requires translation!
-Edinburgh = 
+We were too weak to protect ourselves... =
 
  # Requires translation!
-Do you really think you can walk over us so easily? I will not let it happen. Not to Kongo - not to my people! = 
+Helsinki =
  # Requires translation!
-We are no strangers to war. You have strayed from the right path, and now we will correct it. = 
- # Requires translation!
-You are nothing but a glorified barbarian. Cruel, and ruthless. = 
- # Requires translation!
-M'Banza-Kongo = 
+The day of judgement has come to us. But rest assured, the same will go for you! =
+
+Kuala Lumpur = Kuala Lumpur
+Today, the Malay people obey you, but do not think this is over... = Hari ini, orang Melayu taat pada kamu, tetapi jangan fikir ini sudah tamat...
 
  # Requires translation!
-What a fine battle! Sidon is willing to serve you! = 
+Manila =
  # Requires translation!
-Sidon = 
+Ah, Gods! Why have you forsaken us? =
 
  # Requires translation!
-We don't like your face. To arms! = 
+Lhasa =
  # Requires translation!
-You will see you have just bitten off more than you can chew. = 
- # Requires translation!
-This ship may sink, but our spirits will linger. = 
- # Requires translation!
-Valletta = 
+Perhaps now we will find peace in death... =
 
  # Requires translation!
-Can only heal by pillaging = 
+Vancouver =
+ # Requires translation!
+In responding to the unstinting malignancy that has heretofore defined your relationship with Canada, we can have no recourse but war! =
+ # Requires translation!
+As we can reach no peaceful resolution with you, Canada must turn, with reluctance, to war. =
+ # Requires translation!
+I regret not defending my country to the last, although it was not of use. =
 
-
+ # Requires translation!
+M'Banza-Kongo =
+ # Requires translation!
+Do you really think you can walk over us so easily? I will not let it happen. Not to Kongo - not to my people! =
+ # Requires translation!
+We are no strangers to war. You have strayed from the right path, and now we will correct it. =
+ # Requires translation!
+You are nothing but a glorified barbarian. Cruel, and ruthless. =
+ # Requires translation!
+Mogadishu =
+ # Requires translation!
+Congratulations, conqueror. This tribe serves you now. =
+ # Requires translation!
+Can only heal by pillaging =
 #################### Lines from Policies from Civ V - Vanilla ####################
-
  # Requires translation!
-Aristocracy = 
+Aristocracy =
  # Requires translation!
-Legalism = 
+Legalism =
  # Requires translation!
-Provides the cheapest [stat] building in your first [amount] cities for free = 
+Immediately creates the cheapest available cultural building in each of your first [amount] cities for free =
  # Requires translation!
-Oligarchy = 
+Oligarchy =
  # Requires translation!
-Units in cities cost no Maintenance = 
+Units in cities cost no Maintenance =
  # Requires translation!
-+[amount]% attacking strength for cities with garrisoned units = 
++[amount]% attacking strength for cities with garrisoned units =
  # Requires translation!
-Landed Elite = 
+Landed Elite =
  # Requires translation!
-[amount]% growth [cityFilter] = 
- # Requires translation!
-[stats] [cityFilter] = 
++[amount]% growth [cityFilter] =
 Monarchy = Monarki
  # Requires translation!
-Tradition Complete = 
-Tradition = Tradisi
-
+Tradition Complete =
  # Requires translation!
-Collective Rule = 
-Citizenship = Warganegara
+Immediately creates a [building] in each of your first [amount] cities for free =
+Tradition = Tradisi
 Republic = Republik
+Citizenship = Warganegara
+ # Requires translation!
+Collective Rule =
 Representation = Perwakilan
  # Requires translation!
-Each city founded increases culture cost of policies [amount]% less than normal = 
+Each city founded increases culture cost of policies [amount]% less than normal =
  # Requires translation!
-Meritocracy = 
+Meritocracy =
  # Requires translation!
-Liberty Complete = 
+Unhappiness from population decreased by [amount]% [cityFilter] =
  # Requires translation!
-Free Great Person = 
+Liberty Complete =
  # Requires translation!
-Liberty = 
-
+Liberty =
  # Requires translation!
-Warrior Code = 
+Warrior Code =
 Discipline = Disipin
  # Requires translation!
-[amount]% Strength for [unitType] units which have another [unitType2] unit in an adjacent tile = 
+[amount]% Strength for [unitType] units which have another [unitType2] unit in an adjacent tile =
  # Requires translation!
-Military Tradition = 
+Military Tradition =
  # Requires translation!
-[unitType] units gain [amount]% more Experience from combat = 
+[unitType] units gain [amount]% more Experience from combat =
  # Requires translation!
-Military Caste = 
+Military Caste =
  # Requires translation!
-Professional Army = 
+Professional Army =
  # Requires translation!
-Honor Complete = 
+Gold cost of upgrading [unitType] units reduced by [amount]% =
  # Requires translation!
-Honor = 
-
+Honor Complete =
  # Requires translation!
-Organized Religion = 
+Honor =
  # Requires translation!
-Mandate Of Heaven = 
++[amount]% Strength vs [param] =
  # Requires translation!
-[amount]% of excess happiness converted to [stat] = 
+Notified of new Barbarian encampments =
  # Requires translation!
-Theocracy = 
+Organized Religion =
  # Requires translation!
-+[amount]% [stat] from every [building] = 
+Mandate Of Heaven =
+ # Requires translation!
+50% of excess happiness added to culture towards policies =
+ # Requires translation!
+Theocracy =
+ # Requires translation!
++[amount]% [stat] from every [building] =
 Reformation = Reformasi
  # Requires translation!
-Free Religion = 
+Free Religion =
  # Requires translation!
-Piety Complete = 
+Piety Complete =
  # Requires translation!
-Piety = 
-
+Piety =
  # Requires translation!
-Philantropy = 
++[amount]% Production when constructing [stat] buildings =
  # Requires translation!
-Gifts of Gold to City-States generate [amount]% more Influence = 
+Incompatible with [param] =
  # Requires translation!
-Aesthetics = 
+Philantropy =
  # Requires translation!
-Resting point for Influence with City-States is increased by [amount] = 
+Gifts of Gold to City-States generate [amount]% more Influence =
  # Requires translation!
-Scholasticism = 
+Aesthetics =
  # Requires translation!
-Allied City-States provide [stat] equal to [amount]% of what they produce for themselves = 
+Resting point for Influence with City-States is increased by [amount] =
  # Requires translation!
-Cultural Diplomacy = 
+Scholasticism =
  # Requires translation!
-Quantity of Resources gifted by City-States increased by [amount]% = 
+Allied City-States provide [stat] equal to [amount]% of what they produce for themselves =
  # Requires translation!
-Happiness from Luxury Resources gifted by City-States increased by [amount]% = 
+Cultural Diplomacy =
  # Requires translation!
-Educated Elite = 
+Quantity of Resources gifted by City-States increased by [amount]% =
  # Requires translation!
-Allied City-States will occasionally gift Great People = 
+Happiness from Luxury Resources gifted by City-States increased by [amount]% =
  # Requires translation!
-Patronage Complete = 
+Educated Elite =
  # Requires translation!
-Influence of all other civilizations with all city-states degrades [amount]% faster = 
+Allied City-States will occasionally gift Great People =
  # Requires translation!
-Triggers the following global alert: [param] = 
+Patronage  Complete =
  # Requires translation!
-Patronage = 
-
+Influence of all other civilizations with all city-states degrades [amount]% faster =
  # Requires translation!
-Naval Tradition = 
+Triggers the following global alert: [param] =
  # Requires translation!
-Trade Unions = 
+Patronage  =
  # Requires translation!
-Merchant Navy = 
+Naval Tradition =
  # Requires translation!
-Mercantilism = 
+Trade Unions =
  # Requires translation!
-Protectionism = 
+Merchant Navy =
  # Requires translation!
-+[amount] happiness from each type of luxury resource = 
+Mercantilism =
  # Requires translation!
-Commerce Complete = 
+Protectionism =
  # Requires translation!
-Commerce = 
-
++[amount] happiness from each type of luxury resource =
+ # Requires translation!
+Commerce Complete =
+ # Requires translation!
+Double gold from Great Merchant trade missions =
+ # Requires translation!
+Commerce =
 Secularism = Sekularisme
  # Requires translation!
-Humanism = 
+Humanism =
  # Requires translation!
-Free Thought = 
+Free Thought =
  # Requires translation!
-Sovereignty = 
+Sovereignty =
  # Requires translation!
-[amount]% [stat] = 
+[stats] from all [stat] buildings =
  # Requires translation!
-Scientific Revolution = 
+Scientific Revolution =
  # Requires translation!
-[amount] Free Technologies = 
+Rationalism Complete =
  # Requires translation!
-Rationalism Complete = 
- # Requires translation!
-[stats] from all [stat] buildings = 
+[amount] Free Technologies =
 Rationalism = Rasionalisme
-
+ # Requires translation!
+[amount]% [stat] while the empire is happy =
 Constitution = Perlembagaan
  # Requires translation!
-[stats] from every Wonder = 
+Universal Suffrage =
  # Requires translation!
-Universal Suffrage = 
++[amount]% Defensive Strength for cities =
  # Requires translation!
-+[amount]% Defensive Strength for cities = 
+Civil Society =
  # Requires translation!
-Civil Society = 
- # Requires translation!
-[amount]% food consumption by specialists [cityFilter] = 
+-[amount]% food consumption by specialists =
 Free Speech = Kebebasan Bersuara
  # Requires translation!
-[amount] units cost no maintenance = 
+[amount] units cost no maintenance =
 Democracy = Demokrasi
  # Requires translation!
-[amount]% unhappiness from specialists [cityFilter] = 
+Specialists only produce [amount]% of normal unhappiness =
  # Requires translation!
-Freedom Complete = 
+Freedom Complete =
  # Requires translation!
-+[amount]% yield from every [tileImprovement] = 
++[amount]% yield from every [tileImprovement] =
  # Requires translation!
-Freedom = 
-
+Freedom =
  # Requires translation!
-Populism = 
+Populism =
  # Requires translation!
-Militarism = 
+[param] units deal +[amount]% damage =
  # Requires translation!
-[stat] cost of purchasing [param] units [amount]% = 
+Militarism =
  # Requires translation!
-Fascism = 
+[stat] cost of purchasing [param] units [amount]% =
  # Requires translation!
-Quantity of strategic resources produced by the empire +[amount]% = 
+Fascism =
  # Requires translation!
-Police State = 
+Quantity of strategic resources produced by the empire +[amount]% =
  # Requires translation!
-Total War = 
+Police State =
  # Requires translation!
-Autocracy Complete = 
+Total War =
  # Requires translation!
-+[amount]% attack strength to all [unitType] units for [amount2] turns = 
+Autocracy Complete =
  # Requires translation!
-Autocracy = 
-
++[amount]% attack strength to all [unitType] units for [amount2] turns =
  # Requires translation!
-United Front = 
+Autocracy =
  # Requires translation!
-Militaristic City-States grant units [amount] times as fast when you are at war with a common nation = 
+-[amount]% unit upkeep costs =
  # Requires translation!
-Planned Economy = 
+Upon capturing a city, receive [amount] times its [stat] production as [stat2] immediately =
  # Requires translation!
-Nationalism = 
+United Front =
  # Requires translation!
-Socialism = 
+Militaristic City-States grant units [amount] times as fast when you are at war with a common nation =
  # Requires translation!
--[amount]% maintenance cost for buildings [cityFilter] = 
+Planned Economy =
  # Requires translation!
-Communism = 
++[amount]% Production when constructing a [building] =
  # Requires translation!
-Order Complete = 
+Nationalism =
  # Requires translation!
-Order = 
-
-
+Socialism =
+ # Requires translation!
+-[amount]% maintenance cost for buildings [cityFilter] =
+ # Requires translation!
+Communism =
+ # Requires translation!
+Order Complete =
+ # Requires translation!
+Order =
 #################### Lines from Quests from Civ V - Vanilla ####################
-
  # Requires translation!
-Route = 
+Route =
  # Requires translation!
-Build a road to connect your capital to our city. = 
-
+Build a road to connect your capital to our city. =
  # Requires translation!
-Clear Barbarian Camp = 
+Clear Barbarian Camp =
  # Requires translation!
-We feel threatened by a Barbarian Camp near our city. Please take care of it. = 
-
+We feel threatened by a Barbarian Camp near our city. Please take care of it. =
  # Requires translation!
-Connect Resource = 
+Connect Resource =
  # Requires translation!
-In order to make our civilizations stronger, connect [param] to your trade network. = 
-
+In order to make our civilizations stronger, connect [param] to your trade network. =
  # Requires translation!
-Construct Wonder = 
+Construct Wonder =
  # Requires translation!
-We recommend you to start building [param] to show the whole world your civilization strength. = 
-
+We recommend you to start building [param] to show the whole world your civilization strength. =
  # Requires translation!
-Acquire Great Person = 
+Acquire Great Person =
  # Requires translation!
-Great People can change the course of a Civilization! You will be rewarded for acquiring a new [param]. = 
-
+Great People can change the course of a Civilization! You will be rewarded for acquiring a new [param]. =
  # Requires translation!
-Conquer City State = 
+Find Player =
  # Requires translation!
-It's time to erase the City State of [param] from the map. You will be greatly rewarded for conquering them! = 
-
+You have yet to discover where [param] set up their cities. You will be rewarded for finding their territories. =
  # Requires translation!
-Find Player = 
+Find Natural Wonder =
  # Requires translation!
-You have yet to discover where [param] set up their cities. You will be rewarded for finding their territories. = 
-
+Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [param] yet. =
+#################### Lines from Religions from Civ V - Vanilla ####################
  # Requires translation!
-Find Natural Wonder = 
+Buddhism =
  # Requires translation!
-Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [param] yet. = 
-
+Christianity =
  # Requires translation!
-Give Gold = 
+Confucianism =
  # Requires translation!
-We are suffering great poverty after being robbed by [param], and unless we receive a sum of Gold, it's only a matter of time before we collapse. = 
-
+Hinduism =
  # Requires translation!
-Pledge to Protect = 
+Islam =
  # Requires translation!
-We need your protection to stop the aggressions of [param]. By signing a Pledge of Protection, you'll confirm the bond that ties us. = 
-
+Judaism =
  # Requires translation!
-Contest Culture = 
+Shinto =
  # Requires translation!
-The civilization with the largest Culture growth will gain a reward. = 
-
+Sikhism =
  # Requires translation!
-Contest Faith = 
+Taoism =
  # Requires translation!
-The civilization with the largest Faith growth will gain a reward. = 
-
+Tengriism =
  # Requires translation!
-Contest Technologies = 
- # Requires translation!
-The civilization with the largest number of new Technologies researched will gain a reward. = 
-
- # Requires translation!
-Invest = 
- # Requires translation!
-Our people are rejoicing thanks to a tourism boom. For a certain amount of time, any Gold donation will yield [amount]% extra Influence. = 
-
- # Requires translation!
-Bully City State = 
- # Requires translation!
-We are tired of the pretensions of [param]. If someone were to put them in their place by Demanding Tribute from them, they would be rewarded. = 
-
- # Requires translation!
-Denounce Civilization = 
- # Requires translation!
-We have been forced to pay tribute to [param]! We need you to tell the world of their ill deeds. = 
-
- # Requires translation!
-We have heard the tenets of [param] and are most curious. Will you send missionaries to teach us about your religion? = 
-
-
-#################### Lines from Ruins from Civ V - Vanilla ####################
-
- # Requires translation!
-We have discovered cultural artifacts in the ruins! (+20 culture) = 
- # Requires translation!
-discover cultural artifacts = 
-
- # Requires translation!
-squatters willing to work for you = 
-
- # Requires translation!
-squatters wishing to settle under your rule = 
-
- # Requires translation!
-An ancient tribe trained us in their ways of combat! = 
- # Requires translation!
-your exploring unit receives training = 
-
- # Requires translation!
-We have found survivors in the ruins! Population added to [param]. = 
- # Requires translation!
-survivors (adds population to a city) = 
-
- # Requires translation!
-We have found a stash of [param] Gold in the ruins! = 
- # Requires translation!
-a stash of gold = 
-
- # Requires translation!
-discover a lost technology = 
-
- # Requires translation!
-Our unit finds advanced weaponry hidden in the ruins! = 
- # Requires translation!
-advanced weaponry for your explorer = 
-
- # Requires translation!
-You find evidence of Barbarian activity. Nearby Barbarian camps are revealed! = 
- # Requires translation!
-reveal nearby Barbarian camps = 
-
- # Requires translation!
-find a crudely-drawn map = 
-
- # Requires translation!
-We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[param] Faith) = 
- # Requires translation!
-discover holy symbols = 
-
- # Requires translation!
-We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[param] Faith) = 
- # Requires translation!
-an ancient prophecy = 
-
-
+Zoroastrianism =
 #################### Lines from Specialists from Civ V - Vanilla ####################
-
  # Requires translation!
-Scientist = 
-
+Scientist =
  # Requires translation!
-Merchant = 
-
+Merchant =
  # Requires translation!
-Artist = 
-
+Artist =
  # Requires translation!
-Engineer = 
-
-
+Engineer =
 #################### Lines from Techs from Civ V - Vanilla ####################
-
- # Requires translation!
-'Where tillage begins, other arts follow. The farmers therefore are the founders of human civilization.' - Daniel Webster = 
 Agriculture = Pertanian
  # Requires translation!
-Starting tech = 
-
+Starting tech =
  # Requires translation!
-'Shall the clay say to him that fashioneth it, what makest thou?' - Bible Isaiah 45:9 = 
+'Where tillage begins, other arts follow. The farmers therefore are the founders of human civilization.' - Daniel Webster =
 Pottery = Tembikar
  # Requires translation!
-'Thou shalt not muzzle the ox when he treadeth out the corn.' - Bible Deuteronomy 25:4 = 
+'Shall the clay say to him that fashioneth it, what makest thou?' - Bible Isaiah 45:9 =
 Animal Husbandry = Penternakan Haiwan
  # Requires translation!
-'The haft of the arrow has been feathered with one of the eagle's own plumes, we often give our enemies the means of our own destruction' - Aesop = 
+'Thou shalt not muzzle the ox when he treadeth out the corn.' - Bible Deuteronomy 25:4 =
 Archery = Memanah
  # Requires translation!
-'The meek shall inherit the Earth, but not its mineral rights.' - J. Paul Getty = 
+'The haft of the arrow has been feathered with one of the eagle's own plumes, we often give our enemies the means of our own destruction' - Aesop =
 Mining = Perlombongan
-
  # Requires translation!
-'He who commands the sea has command of everything.' - Themistocles = 
+'The meek shall inherit the Earth, but not its mineral rights.' - J. Paul Getty =
+
 Sailing = Berlayar
  # Requires translation!
-'So teach us to number our days, so that we may apply our hearts unto wisdom.' - Bible Psalms 90:12 = 
+'He who commands the sea has command of everything.' - Themistocles =
 Calendar = Kalendar
  # Requires translation!
-'He who destroys a good book kills reason itself.' - John Milton = 
+'So teach us to number our days, so that we may apply our hearts unto wisdom.' - Bible Psalms 90:12 =
 Writing = Penulisan
  # Requires translation!
-Enables Open Borders agreements = 
- # Requires translation!
-'Even brute beasts and wandering birds do not fall into the same traps or nets twice.' - Saint Jerome = 
+'He who destroys a good book kills reason itself.' - John Milton =
 Trapping = Perangkap
  # Requires translation!
-'Wisdom and virtue are like the two wheels of a cart.' - Japanese proverb = 
+'Even brute beasts and wandering birds do not fall into the same traps or nets twice.' - Saint Jerome =
 The Wheel = Tayar
  # Requires translation!
-'How happy are those whose walls already rise!' - Virgil = 
+'Wisdom and virtue are like the two wheels of a cart.' - Japanese proverb =
 Masonry = Pertukangan Batu
  # Requires translation!
-'Here Hector entered, with a spear eleven cubits long in his hand; the bronze point gleamed in front of him, and was fastened to the shaft of the spear by a ring of gold.' - Homer = 
+'How happy are those whose walls already rise!' - Virgil =
 Bronze Working = Pekerja Gangsa
-
  # Requires translation!
-'He made an instrument to know if the moon shine at full or no.' - Samuel Butler = 
+'Here Hector entered, with a spear eleven cubits long in his hand; the bronze point gleamed in front of him, and was fastened to the shaft of the spear by a ring of gold.' - Homer =
+
 Optics = Optik
  # Requires translation!
-Enables embarkation for land units = 
+Enables embarkation for land units =
  # Requires translation!
-'There is only one good, knowledge, and one evil, ignorance.' - Socrates = 
-Philosophy = Falsafah
- # Requires translation!
-Enables Research agreements = 
- # Requires translation!
-'A Horse! A Horse! My kingdom for a horse!' - Shakespeare (Richard III) = 
+'He made an instrument to know if the moon shine at full or no.' - Samuel Butler =
 Horseback Riding = Tunggang Kuda
  # Requires translation!
-'Mathematics is the gate and key to the sciences.' - Roger Bacon = 
+'A Horse! A Horse! My kingdom for a horse!' - Shakespeare (Richard III) =
 Mathematics = Matematik
  # Requires translation!
-'Three things are to be looked to in a building: that it stands on the right spot; that it be securely founded; that it be successfully executed.' - Johann Wolfgang von Goethe = 
+'Mathematics is the gate and key to the sciences.' - Roger Bacon =
 Construction = Pembinaan
  # Requires translation!
-'Do not wait to strike til the iron is hot, but make it hot by striking.' - William Butler Yeats = 
-Iron Working = Pekerja Besi
+'Three things are to be looked to in a building: that it stands on the right spot; that it be securely founded; that it be successfully executed.' - Johann Wolfgang von Goethe =
 
+Philosophy = Falsafah
  # Requires translation!
-'Three things are necessary for the salvation of man: to know what he ought to believe; to know what he ought to desire; and to know what he ought to do' - St. Thomas Aquinas = 
-Theology = Keagamaan
+'There is only one good, knowledge, and one evil, ignorance.' - Socrates =
  # Requires translation!
-'The only thing that saves us from the bureaucracy is its inefficiency' - Eugene McCarthy = 
-Civil Service = Perkhidmatan Awam
+Drama and Poetry =
  # Requires translation!
-'Better is bread with a happy heart than wealth with vexation.' - Amenemope = 
+'What is drama but life with the dull bits cut out.' - Alfred Hitchcock =
 Currency = Mata Wang
  # Requires translation!
-Enables conversion of city production to gold = 
- # Requires translation!
-'Instrumental or mechanical science is the noblest and, above all others, the most useful.' - Leonardo da Vinci = 
+'Better is bread with a happy heart than wealth with vexation.' - Amenemope =
 Engineering = Kejuruteraan
  # Requires translation!
-Roads connect tiles across rivers = 
+Roads connect tiles across rivers =
  # Requires translation!
-'When pieces of bronze or gold or iron break, the metal-smith welds them together again in the fire, and the bond is established.' - Sri Guru Granth Sahib = 
-Metal Casting = Acuan Besi
+'Instrumental or mechanical science is the noblest and, above all others, the most useful.' - Leonardo da Vinci =
+Iron Working = Pekerja Besi
+ # Requires translation!
+'Do not wait to strike til the iron is hot, but make it hot by striking.' - William Butler Yeats =
 
+Theology = Keagamaan
  # Requires translation!
-'I find the great thing in this world is not so much where we stand, as in what direction we are moving.' - Oliver Wendell Holmes = 
+'Three things are necessary for the salvation of man: to know what he ought to believe; to know what he ought to desire; and to know what he ought to do' - St. Thomas Aquinas =
+Civil Service = Perkhidmatan Awam
+ # Requires translation!
+Enables Open Borders agreements =
+ # Requires translation!
+'The only thing that saves us from the bureaucracy is its inefficiency' - Eugene McCarthy =
+Guilds = Persatuan
+ # Requires translation!
+Enables conversion of city production to gold =
+ # Requires translation!
+'The merchants and the traders have come; their profits are pre-ordained...' - Sri Guru Granth Sahib =
+Metal Casting = Acuan Besi
+ # Requires translation!
+'When pieces of bronze or gold or iron break, the metal-smith welds them together again in the fire, and the bond is established.' - Sri Guru Granth Sahib =
+
 Compass = Kompas
  # Requires translation!
-'Education is the best provision for old age.' - Aristotle = 
+'I find the great thing in this world is not so much where we stand, as in what direction we are moving.' - Oliver Wendell Holmes =
 Education = Pelajaran
  # Requires translation!
-Enables conversion of city production to science = 
+Enables conversion of city production to science =
  # Requires translation!
-'Whoso pulleth out this sword of this stone and anvil, is rightwise king born of all England.' - Malory = 
+Enables Research agreements =
+ # Requires translation!
+'Education is the best provision for old age.' - Aristotle =
 Chivalry = Kesatriaan
  # Requires translation!
-'The press is the best instrument for enlightening the mind of man, and improving him as a rational, moral and social being.' - Thomas Jefferson = 
+'Whoso pulleth out this sword of this stone and anvil, is rightwise king born of all England.' - Malory =
 Machinery = Mesin
  # Requires translation!
-Improves movement speed on roads = 
+Improves movement speed on roads =
  # Requires translation!
-'Measure what is measurable, and make measurable what is not so.' - Galileo Galilei = 
+'The press is the best instrument for enlightening the mind of man, and improving him as a rational, moral and social being.' - Thomas Jefferson =
 Physics = Fizik
  # Requires translation!
-'John Henry said to his Captain, / 'A man ain't nothin' but a man, / And before I'll let your steam drill beat me down, / I'll die with the hammer in my hand.'' - Anonymous: The Ballad of John Henry, the Steel-Drivin' Man = 
+'Measure what is measurable, and make measurable what is not so.' - Galileo Galilei =
 Steel = Keluli
-
  # Requires translation!
-'Joyfully to the breeze royal Odysseus spread his sail, and with his rudder skillfully he steered.' - Homer = 
+'John Henry said to his Captain, / 'A man ain't nothin' but a man, / And before I'll let your steam drill beat me down, / I'll die with the hammer in my hand.'' - Anonymous: The Ballad of John Henry, the Steel-Drivin' Man =
 Astronomy = Astronomi
  # Requires translation!
-Enables embarked units to enter ocean tiles = 
+Increases embarked movement +1 =
  # Requires translation!
-'Their rising all at once was as the sound of thunder heard remote' - Milton = 
+Enables embarked units to enter ocean tiles =
+ # Requires translation!
+'Joyfully to the breeze royal Odysseus spread his sail, and with his rudder skillfully he steered.' - Homer =
 Acoustics = Akustik
  # Requires translation!
-'Happiness: a good bank account, a good cook and a good digestion' - Jean Jacques Rousseau = 
+'Their rising all at once was as the sound of thunder heard remote' - Milton =
 Banking = Perbankan
  # Requires translation!
-'It is a newspaper's duty to print the news and raise hell.' - The Chicago Times = 
+'Happiness: a good bank account, a good cook and a good digestion' - Jean Jacques Rousseau =
 Printing Press = Media Cetak
  # Requires translation!
-'The day when two army corps can annihilate each other in one second, all civilized nations, it is to be hoped, will recoil from war and discharge their troops.' - Alfred Nobel = 
+'It is a newspaper's duty to print the news and raise hell.' - The Chicago Times =
 Gunpowder = Sumbu
-
  # Requires translation!
-'The winds and the waves are always on the side of the ablest navigators.' - Edward Gibbon = 
+'The day when two army corps can annihilate each other in one second, all civilized nations, it is to be hoped, will recoil from war and discharge their troops.' - Alfred Nobel =
+
 Navigation = Navigasi
  # Requires translation!
-'Compound interest is the most powerful force in the universe.' - Albert Einstein = 
+'The winds and the waves are always on the side of the ablest navigators.' - Edward Gibbon =
+Architecture = Seni Bina
+ # Requires translation!
+'Architecture begins where engineering ends.' - Walter Gropius =
 Economics = Ekonomi
  # Requires translation!
-'Wherever we look, the work of the chemist has raised the level of our civilization and has increased the productive capacity of the nation.' - Calvin Coolidge = 
+'Compound interest is the most powerful force in the universe.' - Albert Einstein =
+Metallurgy = Kaji Logam
+ # Requires translation!
+'There never was a good knife made of bad steel.' - Benjamin Franklin =
 Chemistry = Kimia
  # Requires translation!
-'There never was a good knife made of bad steel.' - Benjamin Franklin = 
-Metallurgy = Kaji Logam
+'Wherever we look, the work of the chemist has raised the level of our civilization and has increased the productive capacity of the nation.' - Calvin Coolidge =
 
- # Requires translation!
-'Those who cannot remember the past are condemned to repeat it.' - George Santayana = 
 Archaeology = Arkeologi
  # Requires translation!
-'Every great advance in science has issued from a new audacity of imagination.' - John Dewey = 
+'Those who cannot remember the past are condemned to repeat it.' - George Santayana =
 Scientific Theory = Teori Saintifik
  # Requires translation!
-'Wars may be fought with weapons, but they are won by men. It is the spirit of the men who follow and of the man who leads that gains the victory.' - George S. Patton = 
+'Every great advance in science has issued from a new audacity of imagination.' - John Dewey =
+Industrialization = Perindustrian
+ # Requires translation!
+'Industrialization based on machinery, already referred to as a characteristic of our age, is but one aspect of the revolution that is being wrought by technology.' - Emily Greene Balch =
+Rifling = Senapang
+ # Requires translation!
+'It is well that war is so terrible, or we should grow too fond of it.' - Robert E. Lee =
 Military Science = Sains Tentera
  # Requires translation!
-'The nation that destroys its soil destroys itself.' - Franklin Delano Roosevelt = 
+'Wars may be fought with weapons, but they are won by men. It is the spirit of the men who follow and of the man who leads that gains the victory.' - George S. Patton =
 Fertilizer = Pembajaan
  # Requires translation!
-'It is well that war is so terrible, or we should grow too fond of it.' - Robert E. Lee = 
-Rifling = Senapang
+'The nation that destroys its soil destroys itself.' - Franklin Delano Roosevelt =
 
- # Requires translation!
-'If the brain were so simple we could understand it, we would be so simple we couldn't.' - Lyall Watson = 
 Biology = Biologi
  # Requires translation!
-'The nations of the West hope that by means of steam communication all the world will become as one family.' - Townsend Harris = 
-Steam Power = Kuasa Wap
- # Requires translation!
-'As soon as men decide that all means are permitted to fight an evil, then their good becomes indistinguishable from the evil that they set out to destroy.' - Christopher Dawson = 
-Dynamite = Dinamit
-
- # Requires translation!
-'Is it a fact - or have I dreamt it - that, by means of electricity, the world of matter has become a great nerve, vibrating thousands of miles in a breathless point of time?' - Nathaniel Hawthorne = 
+'If the brain were so simple we could understand it, we would be so simple we couldn't.' - Lyall Watson =
 Electricity = Eletrik
  # Requires translation!
-'Nothing is particularly hard if you divide it into small jobs.' - Henry Ford = 
-Replaceable Parts = Barang Ganti
+'Is it a fact - or have I dreamt it - that, by means of electricity, the world of matter has become a great nerve, vibrating thousands of miles in a breathless point of time?' - Nathaniel Hawthorne =
+Steam Power = Kuasa Wap
  # Requires translation!
-'The introduction of so powerful an agent as steam to a carriage on wheels will make a great change in the situation of man.' - Thomas Jefferson = 
+'The nations of the West hope that by means of steam communication all the world will become as one family.' - Townsend Harris =
+Dynamite = Dinamit
  # Requires translation!
-Railroads = 
-
- # Requires translation!
-'And homeless near a thousand homes I stood, and near a thousand tables pined and wanted food.' - William Wordsworth = 
+'As soon as men decide that all means are permitted to fight an evil, then their good becomes indistinguishable from the evil that they set out to destroy.' - Christopher Dawson =
 Refrigeration = Penyejukan
  # Requires translation!
-'I once sent a dozen of my friends a telegram saying 'flee at once-all is discovered!' They all left town immediately.' - Mark Twain = 
- # Requires translation!
-Telegraph = 
- # Requires translation!
-'The whole country was tied together by radio. We all experienced the same heroes and comedians and singers. They were giants.' - Woody Allen = 
+'And homeless near a thousand homes I stood, and near a thousand tables pined and wanted food.' - William Wordsworth =
 Radio = Radio
  # Requires translation!
-'Aeronautics was neither an industry nor a science. It was a miracle.' - Igor Sikorsky = 
+'The whole country was tied together by radio. We all experienced the same heroes and comedians and singers. They were giants.' - Woody Allen =
+Replaceable Parts = Barang Ganti
+ # Requires translation!
+'Nothing is particularly hard if you divide it into small jobs.' - Henry Ford =
 Flight = Penerbangan
  # Requires translation!
-'Any man who can drive safely while kissing a pretty girl is simply not giving the kiss the attention it deserves.' - Albert Einstein = 
-Combustion = Pembakaran
-
+'Aeronautics was neither an industry nor a science. It was a miracle.' - Igor Sikorsky =
  # Requires translation!
-'In nothing do men more nearly approach the gods than in giving health to men.' - Cicero = 
-Pharmaceuticals = Ilmu Ubat
+Railroads =
  # Requires translation!
-'Ben, I want to say one word to you, just one word: plastics.' - Buck Henry and Calder Willingham, The Graduate = 
+'The introduction of so powerful an agent as steam to a carriage on wheels will make a great change in the situation of man.' - Thomas Jefferson =
 Plastics = Plastik
  # Requires translation!
-'There's a basic principle about consumer electronics: it gets more powerful all the time and it gets cheaper all the time.' - Trip Hawkins = 
+'Ben, I want to say one word to you, just one word: plastics.' - Buck Henry and Calder Willingham, The Graduate =
 Electronics = Elektronik
  # Requires translation!
-'The speed of communications is wondrous to behold, it is also true that speed does multiply the distribution of information that we know to be untrue.' – Edward R. Murrow = 
+'There's a basic principle about consumer electronics: it gets more powerful all the time and it gets cheaper all the time.' - Trip Hawkins =
+Ballistics = Balistik
  # Requires translation!
-Mass Media = 
+'Men, like bullets, go farthest when they are smoothest.' - Jean Paul =
+Combustion = Pembakaran
  # Requires translation!
-'Vision is the art of seeing things invisible.' - Jonathan Swift = 
+'Any man who can drive safely while kissing a pretty girl is simply not giving the kiss the attention it deserves.' - Albert Einstein =
+
+Pharmaceuticals = Ilmu Ubat
+ # Requires translation!
+'In nothing do men more nearly approach the gods than in giving health to men.' - Cicero =
+Atomic Theory = Teori Atom
+ # Requires translation!
+'The unleashed power of the atom has changed everything save our modes of thinking, and we thus drift toward unparalleled catastrophes.' - Albert Einstein =
 Radar = Radar
  # Requires translation!
-'The unleashed power of the atom has changed everything save our modes of thinking, and we thus drift toward unparalleled catastrophes.' - Albert Einstein = 
-Atomic Theory = Teori Atom
-
+'Vision is the art of seeing things invisible.' - Jonathan Swift =
+Combined Arms = Senjata Bersama
  # Requires translation!
-'Only within the moment of time represented by the present century has one species, man, acquired significant power to alter the nature of his world.' - Rachel Carson = 
+'The root of the evil is not the construction of new, more dreadful weapons. It is the spirit of conquest.' - Ludwig von Mises =
+
 Ecology = Ekologi
  # Requires translation!
-'Computers are like Old Testament gods: lots of rules and no mercy.' - Joseph Campbell = 
-Computers = Komputer
+'Only within the moment of time represented by the present century has one species, man, acquired significant power to alter the nature of his world.' - Rachel Carson =
+Nuclear Fission = Pembelahan Nuklear
  # Requires translation!
-'A good rule for rocket experimenters to follow is this: always assume that it will explode.' - Astronautics Magazine, 1937 = 
+'I am become Death, the destroyer of worlds.' - J. Robert Oppenheimer =
 Rocketry = Ilmu Roket
  # Requires translation!
-'The night is far spent, the day is at hand: let us therefore cast off the works of darkness, and let us put on the armor of light.' - The Holy Bible: Romans, 13:12 = 
-Lasers = Laser
+'A good rule for rocket experimenters to follow is this: always assume that it will explode.' - Astronautics Magazine, 1937 =
+Computers = Komputer
  # Requires translation!
-'I am become Death, the destroyer of worlds.' - J. Robert Oppenheimer = 
-Nuclear Fission = Pembelahan Nuklear
+'Computers are like Old Testament gods: lots of rules and no mercy.' - Joseph Campbell =
 
  # Requires translation!
-'The new electronic interdependence recreates the world in the image of a global village.' - Marshall McLuhan = 
+Telecommunications =
  # Requires translation!
-Globalization = 
+'The more we elaborate our means of communication, the less we communicate.' - J.B. Priestly =
+Mobile Tactics = Taktik Mudah Alih
  # Requires translation!
-'1. A robot may not injure a human being or, through inaction, allow a human being to come to harm. 2. A robot must obey any orders given to it by human beings, except when such orders would conflict with the First Law. 3. A robot must protect its own existence as long as such protection does not conflict with the First or Second Law.' - Isaac Asimov = 
-Robotics = Robotik
+'All men can see these tactics whereby I conquer, but what none can see is the strategy out of which victory is evolved.' - Sun Tzu =
  # Requires translation!
-'Now, somehow, in some new way, the sky seemed almost alien.' - Lyndon B. Johnson = 
+Advanced Ballistics =
+ # Requires translation!
+'Our scientific power has outrun our spiritual power, we have guided missiles and misguided men.' – Martin Luther King Jr. =
 Satellites = Satelit
  # Requires translation!
-Reveals the entire map = 
+Reveals the entire map =
  # Requires translation!
-'Be extremely subtle, even to the point of formlessness, be extremely mysterious, even to the point of soundlessness. Thereby you can be the director of the opponent's fate.' - Sun Tzu = 
+'Now, somehow, in some new way, the sky seemed almost alien.' - Lyndon B. Johnson =
+Robotics = Robotik
  # Requires translation!
-Stealth = 
+'1. A robot may not injure a human being or, through inaction, allow a human being to come to harm. 2. A robot must obey any orders given to it by human beings, except when such orders would conflict with the First Law. 3. A robot must protect its own existence as long as such protection does not conflict with the First or Second Law.' - Isaac Asimov =
+Lasers = Laser
  # Requires translation!
-'Our scientific power has outrun our spiritual power, we have guided missiles and misguided men.' – Martin Luther King Jr. = 
- # Requires translation!
-Advanced Ballistics = 
+'The night is far spent, the day is at hand: let us therefore cast off the works of darkness, and let us put on the armor of light.' - The Holy Bible: Romans, 13:12 =
 
  # Requires translation!
-'Every particle of matter is attracted by or gravitates to every other particle of matter with a force inversely proportional to the squares of their distances.' - Isaac Newton = 
+Globalization =
+ # Requires translation!
+'The new electronic interdependence recreates the world in the image of a global village.' - Marshall McLuhan =
 Particle Physics = Fizik Partikel
  # Requires translation!
-'The release of atomic energy has not created a new problem. It has readily made more urgent the necessity of solving an existing one.' - Albert Einstein = 
+'Every particle of matter is attracted by or gravitates to every other particle of matter with a force inversely proportional to the squares of their distances.' - Isaac Newton =
  # Requires translation!
-Nuclear Fusion = 
-
+Nuclear Fusion =
  # Requires translation!
-'The impact of nanotechnology is expected to exceed the impact that the electronics revolution has had on our lives.' - Richard Schwartz = 
+'The release of atomic energy has not created a new problem. It has readily made more urgent the necessity of solving an existing one.' - Albert Einstein =
 Nanotechnology = Teknologi Nano
-
  # Requires translation!
-'I think we agree, the past is over.' - George W. Bush = 
+'The impact of nanotechnology is expected to exceed the impact that the electronics revolution has had on our lives.' - Richard Schwartz =
+ # Requires translation!
+Stealth =
+ # Requires translation!
+'Be extremely subtle, even to the point of formlessness, be extremely mysterious, even to the point of soundlessness. Thereby you can be the director of the opponent's fate.' - Sun Tzu =
 Future Tech = Teknologi Masa Depan
  # Requires translation!
-Who knows what the future holds? = 
+Who knows what the future holds? =
  # Requires translation!
-Can be continually researched = 
-
-
+Can be continually researched =
+ # Requires translation!
+'I think we agree, the past is over.' - George W. Bush =
 #################### Lines from Terrains from Civ V - Vanilla ####################
-
 Ocean = Lautan
-
 Coast = Pesisiran
-
  # Requires translation!
-Grassland = 
-
+Occurs at temperature between [amount] and [amount2] and humidity between [amount3] and [amount4] =
  # Requires translation!
-Plains = 
-
+Grassland =
  # Requires translation!
-Tundra = 
-
+Plains =
+ # Requires translation!
+Tundra =
 Desert = Gurun
-
 Lakes = Tasik
-
+ # Requires translation!
+Has an elevation of [amount] for visibility calculations =
+ # Requires translation!
+Occurs in chains at high elevations =
 Mountain = Gunung
- # Requires translation!
-Has an elevation of [amount] for visibility calculations = 
- # Requires translation!
-Units ending their turn on this terrain take [amount] damage = 
-
 Snow = Salji
-
+ # Requires translation!
+[amount] Strength for cities built on this terrain =
+ # Requires translation!
+[amount] Sight for [param] units =
+ # Requires translation!
+Occurs in groups around high elevations =
 Hill = Bukit
  # Requires translation!
-[amount] Strength for cities built on this terrain = 
-
+Provides a one-time Production bonus to the closest city when cut down =
+ # Requires translation!
+Blocks line-of-sight from tiles at same elevation =
+ # Requires translation!
+Resistant to nukes =
+ # Requires translation!
+Can be destroyed by nukes =
+ # Requires translation!
+A Camp can be built here without cutting it down =
 Forest = Hutan
  # Requires translation!
-Provides a one-time Production bonus to the closest city when cut down = 
+Jungle =
  # Requires translation!
-Blocks line-of-sight from tiles at same elevation = 
+Only Polders can be built here =
  # Requires translation!
-Resistant to nukes = 
+Marsh =
  # Requires translation!
-Can be destroyed by nukes = 
- # Requires translation!
-A Camp can be built here without cutting it down = 
-
- # Requires translation!
-Jungle = 
-
- # Requires translation!
-Marsh = 
- # Requires translation!
-Only Polders can be built here = 
-
- # Requires translation!
-Fallout = 
- # Requires translation!
-Nullifies all other stats this tile provides = 
-
+Fallout =
 Oasis = Oasis
  # Requires translation!
-Only [improvementFilter] improvements may be built on this tile = 
-
- # Requires translation!
-Flood plains = 
-
+Flood plains =
 Ice = Ais
-
  # Requires translation!
-Atoll = 
-
+Atoll =
  # Requires translation!
-Great Barrier Reef = 
-
+Great Barrier Reef =
  # Requires translation!
-Old Faithful = 
-
+Old Faithful =
  # Requires translation!
-El Dorado = 
+Grants 500 Gold to the first civilization to discover it =
  # Requires translation!
-Grants 500 Gold to the first civilization to discover it = 
-
+El Dorado =
  # Requires translation!
-Fountain of Youth = 
+Grants Rejuvenation (all healing effects doubled) to adjacent military land units for the rest of the game =
  # Requires translation!
-Grants [promotion] ([comment]) to adjacent [mapUnitFilter] units for the rest of the game = 
+Fountain of Youth =
  # Requires translation!
-Tile provides yield without assigned population = 
-
+Grand Mesa =
  # Requires translation!
-Grand Mesa = 
-
+Mount Fuji =
  # Requires translation!
-Mount Fuji = 
-
+Krakatoa =
  # Requires translation!
-Krakatoa = 
-
+Rock of Gibraltar =
  # Requires translation!
-Rock of Gibraltar = 
-
+Cerro de Potosi =
  # Requires translation!
-Cerro de Potosi = 
-
- # Requires translation!
-Barringer Crater = 
-
- # Requires translation!
-Mount Kailash = 
-
- # Requires translation!
-Mount Sinai = 
-
- # Requires translation!
-Sri Pada = 
-
- # Requires translation!
-Uluru = 
-
-
+Barringer Crater =
 #################### Lines from TileImprovements from Civ V - Vanilla ####################
-
+ # Requires translation!
+Can also be built on tiles adjacent to fresh water =
+ # Requires translation!
+[stats] on [tileFilter] tiles once [tech] is discovered =
 Farm = Ladang
  # Requires translation!
-Can also be built on tiles adjacent to fresh water = 
- # Requires translation!
-[stats] from [tileFilter] tiles = 
-
- # Requires translation!
-Lumber mill = 
-
+Lumber mill =
 Mine = Lombong
-
  # Requires translation!
-Trading post = 
-
+Trading post =
 Camp = Kem
-
  # Requires translation!
-Oil well = 
+Oil well =
  # Requires translation!
-Cannot be built on [tileFilter] tiles until [tech] is discovered = 
-
- # Requires translation!
-Pasture = 
-
+Pasture =
 Plantation = Rerladangan
-
 Quarry = Kuari
-
  # Requires translation!
-Fishing Boats = 
-
+Fishing Boats =
+ # Requires translation!
+Can be built outside your borders =
+ # Requires translation!
+Gives a defensive bonus of [amount]% =
 Fort = Kubu
  # Requires translation!
-Can be built outside your borders = 
+Costs [amount] gold per turn when in your territory =
  # Requires translation!
-Gives a defensive bonus of [amount]% = 
-
+Reduces movement cost to ½ if the other tile also has a Road or Railroad =
+ # Requires translation!
+Reduces movement cost to ⅓ with Machinery =
+ # Requires translation!
+Requires Engineering to bridge rivers =
 Road = Jalan
  # Requires translation!
-Costs [amount] gold per turn when in your territory = 
- # Requires translation!
-Reduces movement cost to ½ if the other tile also has a Road or Railroad = 
- # Requires translation!
-Reduces movement cost to ⅓ with Machinery = 
- # Requires translation!
-Requires Engineering to bridge rivers = 
-
+Reduces movement cost to ⅒ if the other tile also has a Railroad =
 Railroad = Landasan Keretapi
  # Requires translation!
-Reduces movement cost to ⅒ if the other tile also has a Railroad = 
-
+Provides a one-time Production bonus depending on distance to the closest city once finished =
  # Requires translation!
-Remove Forest = 
+Remove Forest =
  # Requires translation!
-Provides a one-time Production bonus depending on distance to the closest city once finished = 
-
+Remove Jungle =
  # Requires translation!
-Remove Jungle = 
-
+Remove Fallout =
  # Requires translation!
-Remove Fallout = 
-
+Remove Marsh =
  # Requires translation!
-Remove Marsh = 
-
+Remove Road =
  # Requires translation!
-Remove Road = 
-
+Remove Railroad =
  # Requires translation!
-Remove Railroad = 
-
+Cancel improvement order =
  # Requires translation!
-Cancel improvement order = 
-
+Academy =
  # Requires translation!
-Academy = 
-
+Landmark =
  # Requires translation!
-Landmark = 
-
+Manufactory =
  # Requires translation!
-Manufactory = 
-
+Customs house =
  # Requires translation!
-Customs house = 
-
+Holy site =
  # Requires translation!
-Holy site = 
-
+Deal 30 damage to adjacent enemy units =
  # Requires translation!
-Citadel = 
+Can be built just outside your borders =
  # Requires translation!
-Adjacent enemy units ending their turn take [amount] damage = 
+Constructing it will take over the tiles around it and assign them to your closest city =
  # Requires translation!
-Can be built just outside your borders = 
+Citadel =
  # Requires translation!
-Constructing it will take over the tiles around it and assign them to your closest city = 
-
+Moai =
  # Requires translation!
-Moai = 
-
+Terrace farm =
  # Requires translation!
-Terrace farm = 
-
+Polder =
  # Requires translation!
-Ancient ruins = 
+Unpillagable =
  # Requires translation!
-Unpillagable = 
+Provides a random bonus when entered =
  # Requires translation!
-Provides a random bonus when entered = 
-
+Ancient ruins provide a one-time random bonus when explored =
  # Requires translation!
-City ruins = 
+The possible rewards are: =
  # Requires translation!
-A bleak reminder of the destruction wreaked by War = 
-
+a stash of gold =
  # Requires translation!
-City center = 
+survivors (adds population to a city) =
  # Requires translation!
-Indestructible = 
+discover a lost technology =
  # Requires translation!
-Marks the center of a city = 
+a unit joins you =
  # Requires translation!
-Appearance changes with the technological era of the owning civilization = 
-
+your exploring unit receives training =
  # Requires translation!
-Barbarian encampment = 
+discover cultural artifacts =
  # Requires translation!
-Home to uncivilized barbarians, will spawn a hostile unit from time to time = 
-
-
+find a crudely-drawn map =
+ # Requires translation!
+Ancient ruins =
+ # Requires translation!
+A bleak reminder of the destruction wreaked by War =
+ # Requires translation!
+City ruins =
+ # Requires translation!
+Indestructible =
+ # Requires translation!
+Marks the center of a city =
+ # Requires translation!
+Appearance changes with the technological era of the owning civilization =
+ # Requires translation!
+City center =
+ # Requires translation!
+Home to uncivilized barbarians, will spawn a hostile unit from time to time =
+ # Requires translation!
+Barbarian encampment =
 #################### Lines from TileResources from Civ V - Vanilla ####################
-
  # Requires translation!
-Cattle = 
-
+Cattle =
 Sheep = Kambing biri-biri
-
 Deer = Rusa
-
 Bananas = Pisang
-
 Wheat = Gandum
-
 Stone = Batu
-
 Fish = Ikan
-
 Horses = Kuda
-
 Iron = Besi
-
 Coal = Arang
-
 Oil = Minyak
- # Requires translation!
-Deposits in [tileFilter] tiles always provide [amount] resources = 
-
 Aluminum = Aluminum
-
  # Requires translation!
-Uranium = 
-
+Uranium =
 Furs = Bulu
-
 Cotton = Kapas
-
  # Requires translation!
-Dyes = 
-
+Dyes =
  # Requires translation!
-Gems = 
-
+Gems =
  # Requires translation!
-Gold Ore = 
-
+Gold Ore =
 Silver = Perak
-
  # Requires translation!
-Incense = 
-
+Incense =
  # Requires translation!
-Ivory = 
-
+Ivory =
 Silk = Sutera
-
 Spices = Rempah-ratus
-
 Wine = Wain
-
 Sugar = Gula
-
+ # Requires translation!
++15% production towards Wonder construction =
 Marble = Marmar
-
 Whales = Ikan Paus
-
  # Requires translation!
-Pearls = 
-
+Pearls =
  # Requires translation!
-Jewelry = 
+Can only be created by Mercantile City-States =
  # Requires translation!
-Can only be created by Mercantile City-States = 
-
+Jewelry =
  # Requires translation!
-Porcelain = 
-
-
-
-
- # Requires translation!
-Salt = 
-
-
-
+Porcelain =
 #################### Lines from UnitPromotions from Civ V - Vanilla ####################
-
  # Requires translation!
-Sword = 
+Heal Instantly =
  # Requires translation!
-Ranged Gunpowder = 
+Sword =
  # Requires translation!
-Armored = 
+Ranged Gunpowder =
  # Requires translation!
-Melee Water = 
+Armored =
  # Requires translation!
-Ranged Water = 
+Melee Water =
  # Requires translation!
-Heal Instantly = 
+Ranged Water =
  # Requires translation!
-Heal this unit by [amount] HP = 
+Heal this unit by [amount] HP =
  # Requires translation!
-Doing so will consume this opportunity to choose a Promotion = 
-
+Doing so will consume this opportunity to choose a Promotion =
  # Requires translation!
-Accuracy I = 
-
+Accuracy I =
  # Requires translation!
-Accuracy II = 
-
++[amount]% Strength in [param] =
  # Requires translation!
-Accuracy III = 
-
+Accuracy II =
  # Requires translation!
-Barrage I = 
-
+Accuracy III =
  # Requires translation!
-Barrage II = 
-
+Barrage I =
  # Requires translation!
-Barrage III = 
-
+Barrage II =
  # Requires translation!
-Volley = 
-
+Barrage III =
  # Requires translation!
-Extended Range = 
+Volley =
  # Requires translation!
-[amount] Range = 
-
+Extended Range =
  # Requires translation!
-Indirect Fire = 
+[amount] Range =
  # Requires translation!
-Ranged attacks may be performed over obstacles = 
-
+Indirect Fire =
  # Requires translation!
-Shock I = 
-
+Ranged attacks may be performed over obstacles =
  # Requires translation!
-Shock II = 
-
+Shock I =
  # Requires translation!
-Shock III = 
-
+Shock II =
  # Requires translation!
-Drill I = 
-
+Shock III =
  # Requires translation!
-Drill II = 
-
+Drill I =
  # Requires translation!
-Drill III = 
-
+Drill II =
  # Requires translation!
-Charge = 
-
+Drill III =
  # Requires translation!
-Besiege = 
-
+Charge =
  # Requires translation!
-Formation I = 
-
+Besiege =
  # Requires translation!
-Formation II = 
-
+Formation I =
  # Requires translation!
-Blitz = 
+Formation II =
  # Requires translation!
-[amount] additional attacks per turn = 
-
+Blitz =
  # Requires translation!
-Woodsman = 
+[amount] additional attacks per turn =
  # Requires translation!
-Double movement in [terrainFilter] = 
-
+Woodsman =
  # Requires translation!
-Amphibious = 
+Double movement rate through Forest and Jungle =
  # Requires translation!
-Eliminates combat penalty for attacking over a river = 
+Amphibious =
  # Requires translation!
-Eliminates combat penalty for attacking from the sea = 
-
+Eliminates combat penalty for attacking over a river =
  # Requires translation!
-Medic = 
+Eliminates combat penalty for attacking from the sea =
  # Requires translation!
-All adjacent units heal [amount] HP when healing = 
-
+Medic =
  # Requires translation!
-Medic II = 
+[amount] HP when healing =
  # Requires translation!
-[amount] HP when healing in [tileFilter] tiles = 
-
+All adjacent units heal [amount] HP when healing =
  # Requires translation!
-Scouting I = 
-
+Medic II =
  # Requires translation!
-Scouting II = 
-
+[amount] HP when healing in [tileFilter] tiles =
  # Requires translation!
-Scouting III = 
-
+Scouting I =
  # Requires translation!
-Survivalism I = 
-
+[amount] Visibility Range =
  # Requires translation!
-Survivalism II = 
-
+Scouting II =
  # Requires translation!
-Survivalism III = 
+Scouting III =
  # Requires translation!
-Unit will heal every turn, even if it performs an action = 
+[amount] Movement =
  # Requires translation!
-May withdraw before melee ([amount]%) = 
-
+Survivalism I =
  # Requires translation!
-Boarding Party I = 
-
++[amount]% Strength when defending =
  # Requires translation!
-Boarding Party II = 
-
+Survivalism II =
  # Requires translation!
-Boarding Party III = 
-
+Survivalism III =
  # Requires translation!
-Coastal Raider I = 
+Unit will heal every turn, even if it performs an action =
  # Requires translation!
-Earn [amount]% of the damage done to [unitType] units as [stat] = 
-
+May withdraw before melee ([amount]%) =
  # Requires translation!
-Coastal Raider II = 
-
+Boarding Party I =
  # Requires translation!
-Coastal Raider III = 
-
+Boarding Party II =
  # Requires translation!
-Targeting I = 
-
+Boarding Party III =
  # Requires translation!
-Targeting II = 
-
+Coastal Raider I =
  # Requires translation!
-Targeting III = 
-
+Earn [amount]% of the damage done to [unitType] units as [stat] =
  # Requires translation!
-Wolfpack I = 
-
+Coastal Raider II =
  # Requires translation!
-Wolfpack II = 
-
+Coastal Raider III =
  # Requires translation!
-Wolfpack III = 
-
+Targeting I =
  # Requires translation!
-Aircraft Carrier = 
+Targeting II =
  # Requires translation!
-Armor Plating I = 
-
+Targeting III =
  # Requires translation!
-Armor Plating II = 
-
+Wolfpack I =
  # Requires translation!
-Armor Plating III = 
-
++[amount]% Strength when attacking =
  # Requires translation!
-Flight Deck I = 
+Wolfpack II =
  # Requires translation!
-Can carry [amount] extra [mapUnitFilter] units = 
-
+Wolfpack III =
  # Requires translation!
-Flight Deck II = 
-
+Armor Plating I =
  # Requires translation!
-Flight Deck III = 
-
+Aircraft Carrier =
  # Requires translation!
-Supply = 
+Armor Plating II =
  # Requires translation!
-May heal outside of friendly territory = 
-
+Armor Plating III =
  # Requires translation!
-Siege I = 
-
+Flight Deck I =
  # Requires translation!
-Siege II = 
-
+Can carry [amount] extra [param] units =
  # Requires translation!
-Siege III = 
-
+Flight Deck II =
  # Requires translation!
-Evasion = 
+Flight Deck III =
  # Requires translation!
-Damage taken from interception reduced by [amount]% = 
-
+Supply =
  # Requires translation!
-Interception I = 
+May heal outside of friendly territory =
  # Requires translation!
-[amount]% Damage when intercepting = 
-
+Siege I =
  # Requires translation!
-Interception II = 
-
+Siege II =
  # Requires translation!
-Interception III = 
-
+Siege III =
  # Requires translation!
-Air Targeting I = 
-
+Evasion =
  # Requires translation!
-Air Targeting II = 
-
+Damage taken from interception reduced by [amount]% =
  # Requires translation!
-Sortie = 
+Interception I =
  # Requires translation!
-[amount] extra interceptions may be made per turn = 
-
+[amount]% Damage when intercepting =
  # Requires translation!
-Operational Range = 
-
+Interception II =
  # Requires translation!
-Helicopter = 
+Interception III =
  # Requires translation!
-Air Repair = 
-
+Air Targeting I =
  # Requires translation!
-Mobility I = 
-
+Air Targeting II =
  # Requires translation!
-Mobility II = 
-
+Sortie =
  # Requires translation!
-Anti-Armor I = 
-
+[amount] extra interceptions may be made per turn =
  # Requires translation!
-Anti-Armor II = 
-
+Operational Range =
  # Requires translation!
-Cover I = 
-
+Air Repair =
  # Requires translation!
-Cover II = 
-
+Helicopter =
  # Requires translation!
-March = 
-
+Mobility I =
  # Requires translation!
-Mobility = 
-
+Mobility II =
  # Requires translation!
-Sentry = 
-
+Anti-Armor I =
+ # Requires translation!
+Anti-Armor II =
+ # Requires translation!
+Cover I =
+ # Requires translation!
+[amount]% Strength when defending vs [unitType] units =
+ # Requires translation!
+Cover II =
+ # Requires translation!
+March =
+ # Requires translation!
+Mobility =
+ # Requires translation!
+Sentry =
 Logistics = Logistik
-
  # Requires translation!
-Ambush I = 
-
+Ambush I =
  # Requires translation!
-Ambush II = 
-
+Ambush II =
  # Requires translation!
-Bombardment I = 
-
+Bombardment I =
  # Requires translation!
-Bombardment II = 
-
+Bombardment II =
  # Requires translation!
-Bombardment III = 
-
+Bombardment III =
  # Requires translation!
-Morale = 
-
+Morale =
  # Requires translation!
-Great Generals I = 
-
++[amount]% Combat Strength =
  # Requires translation!
-Great Generals II = 
-
+Great Generals I =
  # Requires translation!
-Quick Study = 
+Great Generals II =
  # Requires translation!
-[amount]% Bonus XP gain = 
-
+Quick Study =
  # Requires translation!
-Haka War Dance = 
+[amount]% Bonus XP gain =
  # Requires translation!
-[amount]% Strength for enemy [unitType] units in adjacent [param] tiles = 
-
+Haka War Dance =
  # Requires translation!
-Rejuvenation = 
+[amount]% Strength for enemy [unitType] units in adjacent [param] tiles =
  # Requires translation!
-All healing effects doubled = 
-
+Rejuvenation =
  # Requires translation!
-Slinger Withdraw = 
-
+All healing effects doubled =
  # Requires translation!
-Ignore terrain cost = 
- # Requires translation!
-Ignores terrain cost = 
-
- # Requires translation!
-Pictish Courage = 
- # Requires translation!
-No movement cost to pillage = 
-
- # Requires translation!
-Home Sweet Home = 
- # Requires translation!
-[amount]% Strength decreasing with distance from the capital = 
-
-
+Slinger Withdraw =
 #################### Lines from UnitTypes from Civ V - Vanilla ####################
-
-
-
-
-
-
-
-
-
-
  # Requires translation!
-Civilian Water = 
-
-
-
+Civilian Water =
  # Requires translation!
-Can enter ice tiles = 
+Can enter ice tiles =
  # Requires translation!
-Invisible to non-adjacent units = 
+Invisible to others =
  # Requires translation!
-Can see invisible [mapUnitFilter] units = 
-
-
+Aircraft =
  # Requires translation!
-Aircraft = 
+6 tiles in every direction always visible =
  # Requires translation!
-6 tiles in every direction always visible = 
-
-
+Atomic Bomber =
  # Requires translation!
-Atomic Bomber = 
-
+Self-destructs when attacking =
  # Requires translation!
-Self-destructs when attacking = 
+Cannot be intercepted =
  # Requires translation!
-Cannot be intercepted = 
-
- # Requires translation!
-Can pass through impassable tiles = 
-
-
-
-
-
-
-
-
-
-
-
+Can pass through impassable tiles =
 #################### Lines from Units from Civ V - Vanilla ####################
-
  # Requires translation!
-Can build [improvementFilter/terrainFilter] improvements on tiles = 
-
+Can build [param] improvements on tiles =
  # Requires translation!
-Founds a new city = 
+Founds a new city =
  # Requires translation!
-Excess Food converted to Production when under construction = 
+Excess Food converted to Production when under construction =
  # Requires translation!
-Requires at least [amount] population = 
-
+Requires at least [amount] population =
  # Requires translation!
-May upgrade to [unit] through ruins-like effects = 
-
+Ignores terrain cost =
  # Requires translation!
-This is your basic, club-swinging fighter. = 
-
+May upgrade to [unit] through ruins-like effects =
  # Requires translation!
-Maori Warrior = 
-
+This is your basic, club-swinging fighter. =
  # Requires translation!
-Jaguar = 
+Maori Warrior =
  # Requires translation!
-Heals [amount] damage if it kills a unit = 
-
+Jaguar =
  # Requires translation!
-Brute = 
-
+Heals [amount] damage if it kills a unit =
  # Requires translation!
-Archer = 
-
+Brute =
  # Requires translation!
-Bowman = 
-
+Archer =
  # Requires translation!
-Slinger = 
-
+Bowman =
  # Requires translation!
-Skirmisher = 
-
+Slinger =
  # Requires translation!
-Work Boats = 
+Work Boats =
  # Requires translation!
-Cannot enter ocean tiles until Astronomy = 
+Cannot enter ocean tiles until Astronomy =
  # Requires translation!
-May create improvements on water resources = 
+May create improvements on water resources =
  # Requires translation!
-Uncapturable = 
-
+Trireme =
  # Requires translation!
-Trireme = 
+Cannot enter ocean tiles =
  # Requires translation!
-Cannot enter ocean tiles = 
-
+Chariot Archer =
  # Requires translation!
-Galley = 
-
+No defensive terrain bonus =
  # Requires translation!
-Chariot Archer = 
+Rough terrain penalty =
  # Requires translation!
-No defensive terrain bonus = 
+War Chariot =
  # Requires translation!
-Rough terrain penalty = 
-
+Horse Archer =
  # Requires translation!
-War Chariot = 
-
+War Elephant =
  # Requires translation!
-War Elephant = 
-
-
+Hoplite =
  # Requires translation!
-Hoplite = 
-
+Persian Immortal =
  # Requires translation!
-Persian Immortal = 
+Battering Ram =
  # Requires translation!
-[amount] HP when healing = 
-
+-[amount] Visibility Range =
  # Requires translation!
-Marauder = 
-
+Can only attack [unitType] units =
  # Requires translation!
-Horseman = 
+Horseman =
  # Requires translation!
-Can move after attacking = 
-
+Can move after attacking =
  # Requires translation!
-Companion Cavalry = 
-
+-[amount]% Strength vs [unitType] =
  # Requires translation!
-Catapult = 
+Companion Cavalry =
  # Requires translation!
-Must set up to ranged attack = 
-
+Catapult =
  # Requires translation!
-Ballista = 
-
+Must set up to ranged attack =
  # Requires translation!
-Swordsman = 
-
+Limited Visibility =
  # Requires translation!
-Legion = 
-
+Ballista =
  # Requires translation!
-Mohawk Warrior = 
-
-
+Composite Bowman =
  # Requires translation!
-Landsknecht = 
+Swordsman =
  # Requires translation!
-Can move immediately once bought = 
-
+Legion =
+ # Requires translation!
+Mohawk Warrior =
+ # Requires translation!
+Landsknecht =
+ # Requires translation!
+Can move immediately once bought =
+ # Requires translation!
+Galleass =
 Knight = Kesatria
+ # Requires translation!
+Camel Archer =
+ # Requires translation!
+Conquistador =
+ # Requires translation!
+Defense bonus when embarked =
+ # Requires translation!
+Naresuan's Elephant =
 
  # Requires translation!
-Camel Archer = 
+Mandekalu Cavalry =
 
  # Requires translation!
-Conquistador = 
- # Requires translation!
-Defense bonus when embarked = 
+Keshik =
 
  # Requires translation!
-Naresuan's Elephant = 
+Crossbowman =
 
  # Requires translation!
-Mandekalu Cavalry = 
+Chu-Ko-Nu =
 
  # Requires translation!
-Keshik = 
+Longbowman =
 
  # Requires translation!
-Crossbowman = 
+Trebuchet =
 
  # Requires translation!
-Chu-Ko-Nu = 
-
+Hwach'a =
  # Requires translation!
-Longbowman = 
-
+Longswordsman =
  # Requires translation!
-Trebuchet = 
-
+Samurai =
  # Requires translation!
-Hwach'a = 
-
+Berserker =
  # Requires translation!
-Longswordsman = 
-
+Caravel =
  # Requires translation!
-Samurai = 
-
+Turtle Ship =
  # Requires translation!
-Berserker = 
-
+Musketeer =
  # Requires translation!
-Caravel = 
-
+Janissary =
  # Requires translation!
-Turtle Ship = 
-
-
+Minuteman =
  # Requires translation!
-Musketeer = 
-
+Tercio =
  # Requires translation!
-Janissary = 
-
+Privateer =
  # Requires translation!
-Minuteman = 
-
+May capture killed [param] units =
  # Requires translation!
-Tercio = 
-
+Sea Beggar =
  # Requires translation!
-Frigate = 
-
+Frigate =
  # Requires translation!
-Ship of the Line = 
-
+Ship of the Line =
  # Requires translation!
-Lancer = 
-
+Lancer =
  # Requires translation!
-Sipahi = 
-
+Sipahi =
+ # Requires translation!
+No movement cost to pillage =
+ # Requires translation!
+Hakkapeliitta =
+ # Requires translation!
+Transfer Movement to [unit] =
+ # Requires translation!
+[amount]% Strength when stacked with [unit] =
 Cannon = Meriam
-
-
  # Requires translation!
-Norwegian Ski Infantry = 
-
+Gatling Gun =
  # Requires translation!
-Cavalry = 
-
+Norwegian Ski Infantry =
  # Requires translation!
-Cossack = 
-
+Double movement in Snow, Tundra and Hills =
  # Requires translation!
-Ironclad = 
-
+Carolean =
+ # Requires translation!
+Cavalry =
+ # Requires translation!
+Cossack =
+ # Requires translation!
+Ironclad =
+ # Requires translation!
+Double movement in coast =
 Artillery = Artileri
-
  # Requires translation!
-Can only attack [param] tiles = 
-
+Can only attack [param] tiles =
+Can attack submarines = Boleh serang kapal selam
  # Requires translation!
-Foreign Legion = 
-
-
+Great War Infantry =
  # Requires translation!
-[amount]% chance to intercept air attacks = 
-
+Foreign Legion =
+ # Requires translation!
+Triplane =
+ # Requires translation!
+[amount]% chance to intercept air attacks =
+ # Requires translation!
+Great War Bomber =
 Carrier = Pengangkut
  # Requires translation!
-Cannot attack = 
+Cannot attack =
  # Requires translation!
-Can carry [amount] [mapUnitFilter] units = 
-
+Can carry [amount] [param] units =
 Battleship = Kapal Perang
-
+Machine Gun = Mesingan
  # Requires translation!
-Anti-Aircraft Gun = 
-
+Anti-Aircraft Gun =
+ # Requires translation!
+Landship =
 Destroyer = Pemusnah
-
  # Requires translation!
-Zero = 
-
-
+[amount] Sight for all [param] units =
  # Requires translation!
-B17 = 
-
+Zero =
  # Requires translation!
-Paratrooper = 
+B17 =
  # Requires translation!
-May Paradrop up to [amount] tiles from inside friendly territory = 
-
+Paratrooper =
+ # Requires translation!
+May Paradrop up to [amount] tiles from inside friendly territory =
 Tank = Kereta Kebal
-
  # Requires translation!
-Panzer = 
-
+Panzer =
  # Requires translation!
-Anti-Tank Gun = 
-
+Anti-Tank Gun =
 Atomic Bomb = Bom Atom
  # Requires translation!
-Nuclear weapon of Strength [amount] = 
+Nuclear weapon of Strength [amount] =
  # Requires translation!
-Blast radius [amount] = 
-
- # Requires translation!
-Rocket Artillery = 
-
- # Requires translation!
-Mobile SAM = 
-
- # Requires translation!
-Guided Missile = 
- # Requires translation!
-[amount]% maintenance costs = 
-
- # Requires translation!
-Nuclear Missile = 
-
- # Requires translation!
-Helicopter Gunship = 
- # Requires translation!
-All tiles cost 1 movement = 
- # Requires translation!
-Ignores Zone of Control = 
- # Requires translation!
-Unable to capture cities = 
-
- # Requires translation!
-Nuclear Submarine = 
-
- # Requires translation!
-Mechanized Infantry = 
-
- # Requires translation!
-Missile Cruiser = 
-
- # Requires translation!
-Modern Armor = 
-
- # Requires translation!
-Jet Fighter = 
-
- # Requires translation!
-Giant Death Robot = 
-
- # Requires translation!
-Stealth Bomber = 
- # Requires translation!
-Cannot be carried by [mapUnitFilter] units = 
-
- # Requires translation!
-Great Artist = 
- # Requires translation!
-Can start an [amount]-turn golden age = 
- # Requires translation!
-Can construct [tileImprovement] = 
- # Requires translation!
-Great Person - [stat] = 
-
- # Requires translation!
-Great Scientist = 
- # Requires translation!
-Can hurry technology research = 
-
- # Requires translation!
-Great Merchant = 
- # Requires translation!
-Can undertake a trade mission with City-State, giving a large sum of gold and [amount] Influence = 
-
- # Requires translation!
-Great Engineer = 
- # Requires translation!
-Can speed up construction of a building = 
-
- # Requires translation!
-Great Prophet = 
- # Requires translation!
-Can construct [tileImprovement] if it hasn't used other actions yet = 
- # Requires translation!
-Can [param] [amount] times = 
- # Requires translation!
-Removes other religions when spreading religion = 
- # Requires translation!
-May found a religion = 
- # Requires translation!
-May enhance a religion = 
- # Requires translation!
-May enter foreign tiles without open borders = 
- # Requires translation!
-Religious Unit = 
- # Requires translation!
-Hidden when religion is disabled = 
- # Requires translation!
-Takes your religion over the one in their birth city = 
-
- # Requires translation!
-Great General = 
- # Requires translation!
-Bonus for units in 2 tile radius 15% = 
-
- # Requires translation!
-Khan = 
-
- # Requires translation!
-Missionary = 
- # Requires translation!
-May enter foreign tiles without open borders, but loses [amount] religious strength each turn it ends there = 
- # Requires translation!
-Can be purchased with [stat] [cityFilter] = 
-
- # Requires translation!
-Inquisitor = 
- # Requires translation!
-Prevents spreading of religion to the city it is next to = 
-
-
-#################### Lines from Beliefs from Civ V - Gods & Kings ####################
-
- # Requires translation!
-Ancestor Worship = 
-
- # Requires translation!
-Dance of the Aurora = 
- # Requires translation!
-[stats] from [tileFilter] tiles without [tileFilter2] [cityFilter] = 
-
- # Requires translation!
-Desert Folklore = 
-
- # Requires translation!
-Faith Healers = 
- # Requires translation!
-[param] Units adjacent to this city heal [amount] HP per turn when healing = 
-
- # Requires translation!
-Fertility Rites = 
-
- # Requires translation!
-God of Craftsman = 
- # Requires translation!
-[stats] in cities with [amount] or more population = 
-
- # Requires translation!
-God of the Open Sky = 
-
- # Requires translation!
-God of the Sea = 
-
- # Requires translation!
-God of War = 
- # Requires translation!
-Earn [amount]% of [unitType] unit's [param] as [stat] when killed within 4 tiles of a city following this religion = 
-
- # Requires translation!
-Goddess of Festivals = 
-
- # Requires translation!
-Goddess of Love = 
-
- # Requires translation!
-Goddess of Protection = 
- # Requires translation!
-[amount]% attacking Strength for cities = 
-
- # Requires translation!
-Goddess of the Hunt = 
-
- # Requires translation!
-Messenger of the Gods = 
-
- # Requires translation!
-Monument to the Gods = 
-
- # Requires translation!
-One with Nature = 
-
- # Requires translation!
-Oral Tradition = 
-
- # Requires translation!
-Religious Idols = 
-
- # Requires translation!
-Religious Settlements = 
- # Requires translation!
-[amount]% cost of natural border growth = 
-
- # Requires translation!
-Sacred Path = 
-
- # Requires translation!
-Sacred Waters = 
- # Requires translation!
-[stats] in cities on [terrainFilter] tiles = 
-
- # Requires translation!
-Stone Circles = 
-
- # Requires translation!
-Follower = 
- # Requires translation!
-Asceticism = 
- # Requires translation!
-[stats] from every [param] in cities where this religion has at least [amount] followers = 
-
- # Requires translation!
-Cathedrals = 
- # Requires translation!
-May buy [buildingFilter] buildings with [stat] [cityFilter] = 
-
- # Requires translation!
-Choral Music = 
-
- # Requires translation!
-Divine inspiration = 
-
- # Requires translation!
-Feed the World = 
-
- # Requires translation!
-Guruship = 
-
- # Requires translation!
-Holy Warriors = 
- # Requires translation!
-May buy [baseUnitFilter] units with [stat] for [amount] times their normal Production cost = 
-
- # Requires translation!
-Liturgical Drama = 
-
- # Requires translation!
-Monasteries = 
-
- # Requires translation!
-Mosques = 
-
- # Requires translation!
-Pagodas = 
-
- # Requires translation!
-Peace Gardens = 
-
- # Requires translation!
-Religious Art = 
-
- # Requires translation!
-Religious Center = 
-
- # Requires translation!
-Religious Community = 
- # Requires translation!
-[amount]% [stat] from every follower, up to [amount2]% = 
-
- # Requires translation!
-Swords into Ploughshares = 
-
- # Requires translation!
-Founder = 
- # Requires translation!
-Ceremonial Burial = 
- # Requires translation!
-[stats] for each global city following this religion = 
-
- # Requires translation!
-Church Property = 
-
- # Requires translation!
-Initiation Rites = 
- # Requires translation!
-[stats] when a city adopts this religion for the first time (modified by game speed) = 
-
- # Requires translation!
-Interfaith Dialogue = 
- # Requires translation!
-When spreading religion to a city, gain [amount] times the amount of followers of other religions as [stat] = 
-
- # Requires translation!
-Papal Primacy = 
+Blast radius [amount] =
  # Requires translation!
-Resting point for Influence with City-States following this religion [amount] = 
-
+Rocket Artillery =
  # Requires translation!
-Peace Loving = 
+Mobile SAM =
  # Requires translation!
-[stats] for every [amount] global followers [cityFilter] = 
-
+Guided Missile =
  # Requires translation!
-Pilgrimage = 
-
+Nuclear Missile =
  # Requires translation!
-Tithe = 
-
+Helicopter Gunship =
  # Requires translation!
-World Church = 
-
+All tiles cost 1 movement =
  # Requires translation!
-Enhancer = 
+Unable to capture cities =
  # Requires translation!
-Defender of the Faith = 
-
+Nuclear Submarine =
  # Requires translation!
-Holy Order = 
-
+Mechanized Infantry =
  # Requires translation!
-Itinerant Preachers = 
+Missile Cruiser =
  # Requires translation!
-Religion naturally spreads to cities [amount] tiles away = 
-
+Modern Armor =
  # Requires translation!
-Just War = 
-
+Jet Fighter =
  # Requires translation!
-Messiah = 
+Giant Death Robot =
  # Requires translation!
-[amount]% Spread Religion Strength = 
+Stealth Bomber =
  # Requires translation!
-[amount]% Faith cost of generating Great Prophet equivalents = 
+Cannot be carried by [unit] units =
  # Requires translation!
-[stat] cost for [unit] units [amount]% = 
-
+Great Artist =
  # Requires translation!
-Missionary Zeal = 
-
+Can start an [amount]-turn golden age =
  # Requires translation!
-Religious Texts = 
+Can construct [tileImprovement] =
  # Requires translation!
-[amount]% Natural religion spread [cityFilter] = 
+Great Person - [stat] =
  # Requires translation!
-[amount]% Natural religion spread [cityFilter] with [tech] = 
-
+Great Scientist =
  # Requires translation!
-Religious Unity = 
+Can hurry technology research =
  # Requires translation!
-[amount]% Natural religion spread to [cityFilter] = 
-
+Great Merchant =
  # Requires translation!
-Reliquary = 
+Can undertake a trade mission with City-State, giving a large sum of gold and [amount] Influence =
  # Requires translation!
-[stats] whenever a Great Person is expended = 
-
-
-#################### Lines from Buildings from Civ V - Gods & Kings ####################
-
-
-
+Great Engineer =
  # Requires translation!
-Stele = 
-
-
+Can speed up construction of a wonder =
  # Requires translation!
-Shrine = 
-
+Great Prophet =
  # Requires translation!
-Pyramid = 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+Can construct [tileImprovement] if it hasn't spread religion yet =
  # Requires translation!
-'Regard your soldiers as your children, and they will follow you into the deepest valleys; look on them as your own beloved sons, and they will stand by you even unto death.' - Sun Tzu = 
+Can spread religion [amount] times =
  # Requires translation!
-Terracotta Army = 
-
-
-
-
-
-
+May found a religion =
  # Requires translation!
-Amphitheater = 
-
-
-
+Religious Unit =
 
-
  # Requires translation!
-'...who drinks the water I shall give him, says the Lord, will have a spring inside him welling up for eternal life. Let them bring me to your holy mountain in the place where you dwell. Across the desert and through the mountain to the Canyon of the Crescent Moon...' - Indiana Jones = 
+Great General =
  # Requires translation!
-Petra = 
-
-
-
+Bonus for units in 2 tile radius 15% =
 
-
-
-
- # Requires translation!
-'With the magnificence of eternity before us, let time, with all its fluctuations, dwindle into its own littleness.' - Thomas Chalmers = 
  # Requires translation!
-Great Mosque of Djenne = 
+Khan =
  # Requires translation!
-[unit] units built [cityFilter] can [param] [amount] extra times = 
-
- # Requires translation!
-Grand Temple = 
-
-
-
-
-
-
+Heal adjacent units for an additional 15 HP per turn =
 
-
-
-
-
-
-
-
- # Requires translation!
-'Justice is an unassailable fortress, built on the brow of a mountain which cannot be overthrown by the violence of torrents, nor demolished by the force of armies.' - Joseph Addison = 
  # Requires translation!
-Alhambra = 
-
-
-
-
-
-
+Missionary =
  # Requires translation!
-Ceilidh Hall = 
-
-
-
-
-
-
- # Requires translation!
-'Don't clap too hard - it's a very old building.' - John Osbourne = 
- # Requires translation!
-Leaning Tower of Pisa = 
-
-
-
-
-
-
-
- # Requires translation!
-Coffee House = 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
- # Requires translation!
-'...the location is one of the most beautiful to be found, holy and unapproachable, a worthy temple for the divine friend who has brought salvation and true blessing to the world.' - King Ludwig II of Bavaria = 
- # Requires translation!
-Neuschwanstein = 
-
-
-
-
-
-
-
- # Requires translation!
-Recycling Center = 
- # Requires translation!
-Limited to [amount] per Civilization = 
-
-
-
-
- # Requires translation!
-'Nothing travels faster than light with the possible exception of bad news, which obeys its own special rules.' - Douglas Adams = 
- # Requires translation!
-CN Tower = 
- # Requires translation!
-[amount] population [cityFilter] = 
-
- # Requires translation!
-Bomb Shelter = 
- # Requires translation!
-Population loss from nuclear attacks [amount]% [cityFilter] = 
-
-
- # Requires translation!
-'The wonder is, not that the field of stars is so vast, but that man has measured it.' - Anatole France = 
- # Requires translation!
-Hubble Space Telescope = 
-
-
-
-
-
-
-
- # Requires translation!
-Cathedral = 
-
-
- # Requires translation!
-Mosque = 
-
- # Requires translation!
-Pagoda = 
-
-
-#################### Lines from Difficulties from Civ V - Gods & Kings ####################
-
-
-
-
-
-
-
-
-
-
-#################### Lines from Eras from Civ V - Gods & Kings ####################
-
-
-
-
-
- # Requires translation!
-May not generate great prophet equivalents naturally = 
- # Requires translation!
-May buy [baseUnitFilter] units for [amount] [stat] [cityFilter] at an increasing price ([amount2]) = 
- # Requires translation!
-Starting in this era disables religion = 
-
-
-
-Marine = Marin
-
-
-
-#################### Lines from Nations from Civ V - Gods & Kings ####################
-
-
- # Requires translation!
-Islam = 
-
- # Requires translation!
-Christianity = 
-
-
-
-
-
-
-
-
-
- # Requires translation!
-Shinto = 
-
- # Requires translation!
-Greetings, President Mahatma Gandhi, great souled leader of India! You are the ruler of one of the oldest countries in the world with history stretching back almost 10,000 years. A spiritual country, India is the birthplace of three of the world's great religions - Hinduism, Buddhism and Jainism. This is a passionate land of music and color, a land of great wealth and grinding poverty. For centuries, India was divided into kingdoms who fought constantly with each other and against outside invaders. That was, however, after empires such as Maratha, Maurya and Gupta. In the 12th century AD, India was conquered by Muslim Turks who fled from the Mongols. In the early 17th century, the English arrived, and through a combination of shrewd diplomacy and technological superiority, they conquered your fragmented nation. England remained in power for some two centuries until driven out by a rising wave of Indian nationalism, a peaceful rebellion unlike any before seen in history, one led by you! = 
- # Requires translation!
-Gandhi, your people look to you to lead them to even greater heights of glory! Can you help your people realize their great potential, to once again become the world's center of arts, culture and religion? Can you build a civilization that will stand the test of time? = 
- # Requires translation!
-Hinduism = 
-
-
-
- # Requires translation!
-Confucianism = 
-
-
- # Requires translation!
-Zoroastrianism = 
-
-
- # Requires translation!
-Buddhism = 
-
-
-
- # Requires translation!
-Tengriism = 
-
-
-
-
- # Requires translation!
-Attila the Hun = 
- # Requires translation!
-I grow tired of this throne. I think I should like to have yours instead. = 
- # Requires translation!
-Now what is this?! You ask me to add your riches to my great avails. The invitation is accepted. = 
- # Requires translation!
-My people will mourn me not with tears, but with human blood. = 
- # Requires translation!
-You are in the presence of Attila, scourge of Rome. Do not let hubris be your downfall as well. = 
- # Requires translation!
-This is better than you deserve, but let it not be said that I am an unfair man. = 
- # Requires translation!
-Good day to you. = 
- # Requires translation!
-Scourge of God = 
- # Requires translation!
-Your men stand proudly to greet you, Great Attila, grand warrior and ruler of the Hunnic empire. Together with your brother Bleda you expanded the boundaries of your empire, becoming the most powerful and frightening force of the 5th century. You bowed the Eastern Roman Emperors to your will and took kingdom after kingdom along the Danube and Nisava Rivers. As the sovereign ruler of the Huns, you marched your army across Europe into Gaul, planning to extend your already impressive lands all the way to the Atlantic Ocean. Your untimely death led to the quick disintegration and downfall of your empire, but your name and deeds have created an everlasting legacy for your people. = 
- # Requires translation!
-Fearsome General, your people call for the recreation of a new Hunnic Empire, one which will make the exploits and histories of the former seem like the faded dreaming of a dying sun. Will you answer their call to regain your rightful prominence and glory? Will you mount your steadfast steed and lead your armies to victory? Will you build a civilization that stands the test of time? = 
- # Requires translation!
-Atilla's Court = 
- # Requires translation!
-The Huns = 
- # Requires translation!
-Cities are razed [amount] times as fast = 
- # Requires translation!
-Starts with [tech] = 
- # Requires translation!
-"Borrows" city names from other civilizations in the game = 
-
- # Requires translation!
-William of Orange = 
- # Requires translation!
-As much as I despise war, I consider it a, hahaha, contribution to the common cause to erase your existence. = 
- # Requires translation!
-You call yourself an exalted ruler, but I see nothing more than a smartly dressed barbarian! = 
- # Requires translation!
-My God, be merciful to my soul. My God, feel pity for this... my poor people! = 
- # Requires translation!
-I am William of Orange, stadtholder of The Netherlands. Did you need anything? I still have a lot to do. = 
- # Requires translation!
-I believe I have something that may be of some importance to you. = 
- # Requires translation!
-Once again, greetings. = 
- # Requires translation!
-Dutch East India Company = 
- # Requires translation!
-Hail stalwart Prince William of Orange, liberator of the Netherlands and hero to the Dutch people. It was your courageous effort in the 1568 rebellion against Spanish dominion that led the Dutch to freedom, and ultimately resulted in the Eighty Years' War. Your undertaking allowed for the creation of one of Europe's first modern republics, the Seven United Provinces. You gave your life to the rebellion, falling at the hands of an assassin in 1584, but your death would only serve to embolden the people's charge, and your legacy as "Father of the Fatherland" will stand as a symbol of Dutch independence for all time. = 
- # Requires translation!
-Brave prince, the people again yearn for the wise stewardship your wisdom afforded them. Can you once again secure the sovereignty of your kingdom and lead your people to greatness? Can you build a civilization that stands the test of time? = 
- # Requires translation!
-Amsterdam = 
- # Requires translation!
-Rotterdam = 
- # Requires translation!
-Utrecht = 
- # Requires translation!
-Groningen = 
- # Requires translation!
-Breda = 
- # Requires translation!
-Nijmegen = 
- # Requires translation!
-Den Haag = 
- # Requires translation!
-Haarlem = 
- # Requires translation!
-Arnhem = 
- # Requires translation!
-Zutphen = 
- # Requires translation!
-Maastricht = 
- # Requires translation!
-Tilburg = 
- # Requires translation!
-Eindhoven = 
- # Requires translation!
-Dordrecht = 
- # Requires translation!
-Leiden = 
- # Requires translation!
-'s Hertogenbosch = 
- # Requires translation!
-Almere = 
- # Requires translation!
-Alkmaar = 
- # Requires translation!
-Brielle = 
- # Requires translation!
-Vlissingen = 
- # Requires translation!
-Apeldoorn = 
- # Requires translation!
-Enschede = 
- # Requires translation!
-Amersfoort = 
- # Requires translation!
-Zwolle = 
- # Requires translation!
-Venlo = 
- # Requires translation!
-Uden = 
- # Requires translation!
-Grave = 
- # Requires translation!
-Delft = 
- # Requires translation!
-Gouda = 
- # Requires translation!
-Nieuwstadt = 
- # Requires translation!
-Weesp = 
- # Requires translation!
-Coevorden = 
- # Requires translation!
-Kerkrade = 
- # Requires translation!
-The Netherlands = 
- # Requires translation!
-Retain [amount]% of the happiness from a luxury after the last copy has been traded away = 
-
- # Requires translation!
-Gustavus Adolphus = 
- # Requires translation!
-The Hakkapeliittas will ride again and your men will fall just at the sight of my cavalry! God with us! = 
- # Requires translation!
-Ha ha ha, captain Gars will be very glad to head out to war again. = 
- # Requires translation!
-I am Sweden's king. You can take my lands, my people, my kingdom, but you will never reach the House of Vasa. = 
- # Requires translation!
-Stranger, welcome to the Snow King's kingdom! I am Gustavus Adolphus, member of the esteemed House of Vasa = 
- # Requires translation!
-My friend, it is my belief that this settlement can benefit both our peoples. = 
- # Requires translation!
-Oh, welcome! = 
- # Requires translation!
-Oh, it is you. = 
- # Requires translation!
-Nobel Prize = 
- # Requires translation!
-All hail the transcendent King Gustavus Adolphus, founder of the Swedish Empire and her most distinguished military tactician. It was during your reign that Sweden emerged as one of the greatest powers in Europe, due in no small part to your wisdom, both on and off the battlefield. As king, you initiated a number of domestic reforms that ensured the economic stability and prosperity of your people. As the general who came to be known as the "Lion of the North," your visionary designs in warfare gained the admiration of military commanders the world over. Thanks to your triumphs in the Thirty Years' War, you were assured a legacy as one of history's greatest generals. = 
- # Requires translation!
-Oh noble King, the people long for your prudent leadership, hopeful that once again they will see your kingdom rise to glory. Will you devise daring new strategies, leading your armies to victory on the theater of war? Will you build a civilization that stands the test of time? = 
- # Requires translation!
-Stockholm = 
- # Requires translation!
-Uppsala = 
- # Requires translation!
-Gothenburg = 
- # Requires translation!
-Malmö = 
- # Requires translation!
-Linköping = 
- # Requires translation!
-Kalmar = 
- # Requires translation!
-Skara = 
- # Requires translation!
-Västerås = 
- # Requires translation!
-Jönköping = 
- # Requires translation!
-Visby = 
- # Requires translation!
-Falun = 
- # Requires translation!
-Norrköping = 
- # Requires translation!
-Gävle = 
- # Requires translation!
-Halmstad = 
- # Requires translation!
-Karlskrona = 
- # Requires translation!
-Hudiksvall = 
- # Requires translation!
-Örebro = 
- # Requires translation!
-Umeå = 
- # Requires translation!
-Karlstad = 
- # Requires translation!
-Helsingborg = 
- # Requires translation!
-Härnösand = 
- # Requires translation!
-Vadstena = 
- # Requires translation!
-Lund = 
- # Requires translation!
-Västervik = 
- # Requires translation!
-Enköping = 
- # Requires translation!
-Skövde = 
- # Requires translation!
-Eskilstuna = 
- # Requires translation!
-Luleå = 
- # Requires translation!
-Lidköping = 
- # Requires translation!
-Södertälje = 
- # Requires translation!
-Mariestad = 
- # Requires translation!
-Östersund = 
- # Requires translation!
-Borås = 
- # Requires translation!
-Sundsvall = 
- # Requires translation!
-Vimmerby = 
- # Requires translation!
-Köping = 
- # Requires translation!
-Mora = 
- # Requires translation!
-Arboga = 
- # Requires translation!
-Växjö = 
- # Requires translation!
-Gränna = 
- # Requires translation!
-Kiruna = 
- # Requires translation!
-Borgholm = 
- # Requires translation!
-Strängnäs = 
- # Requires translation!
-Sveg = 
- # Requires translation!
-Sweden = 
- # Requires translation!
-Gain [amount] Influence with a [param] gift to a City-State = 
- # Requires translation!
-When declaring friendship, both parties gain a [amount]% boost to great person generation = 
-
- # Requires translation!
-Maria Theresa = 
- # Requires translation!
-Shame that it has come this far. But ye wished it so. Next time, be so good, choose your words more wisely. = 
- # Requires translation!
-What a fool ye are! Ye will end swiftly and miserably. = 
- # Requires translation!
-The world is pitiful! There's no beauty in it, no wisdom. I am almost glad to go. = 
- # Requires translation!
-The archduchess of Austria welcomes your Eminence to... Oh let's get this over with! I have a luncheon at four o'clock. = 
- # Requires translation!
-I see you admire my new damask. Nobody should say that I am an unjust woman. Let's reach an agreement! = 
- # Requires translation!
-Oh, it's ye! = 
- # Requires translation!
-Diplomatic Marriage = 
- # Requires translation!
-Noble and virtuous Queen Maria Theresa, Holy Roman Empress and sovereign of Austria, the people bow to your gracious will. Following the death of your father King Charles VI, you ascended the thone of Austria during a time of great instability, but the empty coffers and diminished military did litle to dissuade your ambitions. Faced with war almost immediately upon your succession to the thron, you managed to fend off your foes, and in naming your husband Francis Stephen co-ruler, assured your place as Empress of the Holy Roman Empire. During your reigh, you guided Austria on a new path of reform - strengthening the military, replenishing the treasury, and improving the educational system of the kingdom. = 
- # Requires translation!
-Oh great queen, bold and dignified, the time has come for you to rise and guide the kingdom once again. Can you return your people to the height of prosperity and splendor? Will you build a civilization that stands the test of time? = 
- # Requires translation!
-Vienna = 
- # Requires translation!
-Salzburg = 
- # Requires translation!
-Graz = 
- # Requires translation!
-Linz = 
- # Requires translation!
-Klagenfurt = 
- # Requires translation!
-Bregenz = 
- # Requires translation!
-Innsbruck = 
- # Requires translation!
-Kitzbühel = 
- # Requires translation!
-St. Pölten = 
- # Requires translation!
-Eisenstadt = 
- # Requires translation!
-Villach = 
- # Requires translation!
-Zwettl = 
- # Requires translation!
-Traun = 
- # Requires translation!
-Wels = 
- # Requires translation!
-Dornbirn = 
- # Requires translation!
-Feldkirch = 
- # Requires translation!
-Amstetten = 
- # Requires translation!
-Bad Ischl = 
- # Requires translation!
-Wolfsberg = 
- # Requires translation!
-Kufstein = 
- # Requires translation!
-Leoben = 
- # Requires translation!
-Klosterneuburg = 
- # Requires translation!
-Leonding = 
- # Requires translation!
-Kapfenberg = 
- # Requires translation!
-Hallein = 
- # Requires translation!
-Bischofshofen = 
- # Requires translation!
-Waidhofen = 
- # Requires translation!
-Saalbach = 
- # Requires translation!
-Lienz = 
- # Requires translation!
-Steyr = 
- # Requires translation!
-Austria = 
- # Requires translation!
-Can spend Gold to annex or puppet a City-State that has been your ally for [amount] turns. = 
-
- # Requires translation!
-Dido = 
- # Requires translation!
-Tell me, do you all know how numerous my armies, elephants and the gdadons are? No? Today, you shall find out! = 
- # Requires translation!
-Fate is against you. You earned the animosity of Carthage in your exploration. Your days are numbered. = 
- # Requires translation!
-The fates became to hate me. This is it? You wouldn't destroy us so without their help. = 
- # Requires translation!
-The Phoenicians welcome you to this most pleasant kingdom. I am Dido, the queen of Carthage and all that belongs to it. = 
- # Requires translation!
-I just had the marvelous idea, and I think you'll appreciate it too. = 
- # Requires translation!
-What is it now? = 
- # Requires translation!
-Phoenician Heritage = 
- # Requires translation!
-Blessings and salutations to you, revered Queen Dido, founder of the legendary kingdom of Carthage. Chronicled by the words of the great poet Virgil, your husband Acerbas was murdered at the hands of your own brother, King Pygmalion of Tyre, who subsequently claimed the treasures of Acerbas that were now rightfully yours. Fearing the lengths from which your brother would pursue this vast wealth, you and your compatriots sailed for new lands. Arriving on the shores of North Africa, you tricked the local king with the simple manipulation of an ox hide, laying out a vast expanse of territory for your new home, the future kingdom of Carthage. = 
- # Requires translation!
-Clever and inquisitive Dido, the world longs for a leader who can provide a shelter from the coming storm, guided by brilliant intuition and cunning. Can you lead the people in the creation of a new kingdom to rival that of once mighty Carthage? Can you build a civilization that will stand the test of time? = 
- # Requires translation!
-Carthage = 
- # Requires translation!
-Utique = 
- # Requires translation!
-Hippo Regius = 
- # Requires translation!
-Gades = 
- # Requires translation!
-Saguntum = 
- # Requires translation!
-Carthago Nova = 
- # Requires translation!
-Panormus = 
- # Requires translation!
-Lilybaeum = 
- # Requires translation!
-Hadrumetum = 
- # Requires translation!
-Zama Regia = 
- # Requires translation!
-Karalis = 
- # Requires translation!
-Malaca = 
- # Requires translation!
-Leptis Magna = 
- # Requires translation!
-Hippo Diarrhytus = 
- # Requires translation!
-Motya = 
- # Requires translation!
-Sulci = 
- # Requires translation!
-Leptis Parva = 
- # Requires translation!
-Tharros = 
- # Requires translation!
-Soluntum = 
- # Requires translation!
-Lixus = 
- # Requires translation!
-Oea = 
- # Requires translation!
-Theveste = 
- # Requires translation!
-Ibossim = 
- # Requires translation!
-Thapsus = 
- # Requires translation!
-Aleria = 
- # Requires translation!
-Tingis = 
- # Requires translation!
-Abyla = 
- # Requires translation!
-Sabratha = 
- # Requires translation!
-Rusadir = 
- # Requires translation!
-Baecula = 
- # Requires translation!
-Saldae = 
- # Requires translation!
-Land units may cross [tileFilter] tiles after the first [unit] is earned = 
- # Requires translation!
-Units ending their turn on [tileFilter] tiles take [amount] damage = 
-
- # Requires translation!
-Theodora = 
- # Requires translation!
-It is always a shame to destroy a thing of beauty. Happily, you are not one. = 
- # Requires translation!
-Now darling, tantrums are most unbecoming. I shall have to teach you a lesson. = 
- # Requires translation!
-Like a child playing with toys you are. My people will never love you, nor suffer this indignation gracefully. = 
- # Requires translation!
-My, isn't this a pleasant surprise - what may I call you, oh mysterious stranger? I am Theodora, beloved of Byzantium. = 
- # Requires translation!
-I have heard that you adept at certain kinds of ... interactions. Show me. = 
- # Requires translation!
-Hello again. = 
- # Requires translation!
-Patriarchate of Constantinople = 
- # Requires translation!
-All hail the most magnificent and magnanimous Empress Theodora, beloved of Byzantium and of Rome! From the lowly ranks of actress and courtesan you became the most powerful woman in the Roman Empire, consort to Justinian I. Starting in the late 520's AD, you joined your husband in a series of important spiritual and legal reforms, creating many laws which elevated the status of and promoted equal treatment of women in the empire. You also aided in the restoration and construction of many aqueducts, bridges, and churches across Constantinople, culminating in the creation of the Hagia Sophia, one of the most splendid architectural wonders of the world. = 
- # Requires translation!
-Beautiful Empress, Byzantium is in need of your wisdom and strength - her people are lost without your light to lead them. The Byzantine Empire may have fallen once, but its spirit is still intact waiting to be reborn anew. Can you return Byzantium to the heights of glory it once enjoyed? Can you create a civilization to stand the test of time? = 
- # Requires translation!
-Constantinople = 
- # Requires translation!
-Adrianople = 
- # Requires translation!
-Nicaea = 
- # Requires translation!
-Antioch = 
- # Requires translation!
-Varna = 
- # Requires translation!
-Ohrid = 
- # Requires translation!
-Nicomedia = 
- # Requires translation!
-Trebizond = 
- # Requires translation!
-Cherson = 
- # Requires translation!
-Sardica = 
- # Requires translation!
-Ani = 
- # Requires translation!
-Dyrrachium = 
- # Requires translation!
-Edessa = 
- # Requires translation!
-Chalcedon = 
- # Requires translation!
-Naissus = 
- # Requires translation!
-Bari = 
- # Requires translation!
-Iconium = 
- # Requires translation!
-Prilep = 
- # Requires translation!
-Samosata = 
- # Requires translation!
-Kars = 
- # Requires translation!
-Theodosiopolis = 
- # Requires translation!
-Tyana = 
- # Requires translation!
-Gaza = 
- # Requires translation!
-Kerkyra = 
- # Requires translation!
-Phoenice = 
- # Requires translation!
-Selymbria = 
- # Requires translation!
-Sillyon = 
- # Requires translation!
-Chrysopolis = 
- # Requires translation!
-Vodena = 
- # Requires translation!
-Traianoupoli = 
- # Requires translation!
-Constantia = 
- # Requires translation!
-Patra = 
- # Requires translation!
-Korinthos = 
- # Requires translation!
-Byzantium = 
- # Requires translation!
-May choose [amount] additional belief(s) of any type when [foundingOrEnhancing] a religion = 
-
- # Requires translation!
-Boudicca = 
- # Requires translation!
-You shall stain this land no longer with your vileness! To arms, my countrymen. We ride to war! = 
- # Requires translation!
-Traitorous man! The Celtic peoples will not stand for such wanton abuse and slander - I shall have your balls! = 
- # Requires translation!
-Vile ruler, know you have won this war in name alone. Your cities lie buried and your troops defeated. I have my own victory. = 
- # Requires translation!
-I am Boudicca, Queen of the Celts. Let no-one underestimate me! = 
- # Requires translation!
-Let us join our forces together and reap the rewards. = 
- # Requires translation!
-God has given good to you. = 
- # Requires translation!
-Druidic Lore = 
- # Requires translation!
-Eternal glory and praise for you, fierce and vengeful Warrior Queen! In a time dominated by men, you not only secured your throne and sovereign rule, but also successfully defied the power of the Roman Empire. After suffering terrible punishment and humiliation at the hand of the Roman invaders, you rallied your people in a bloody and terrifying revolt. Legions fell under your chariot wheels and the city of London burned. While in the end the Romans retained ownership of the isles, you alone made Nero consider withdrawing all troops and leaving Britain forever. = 
- # Requires translation!
-Oh sleeping lioness, your people desire that you rise and lead them again in the calling that is your namesake. Will you meet their challenge on the open field and lead the Celts to everlasting victory? Will you restore your lands and build an empire to stand the test of time? = 
- # Requires translation!
-Cardiff = 
- # Requires translation!
-Truro = 
- # Requires translation!
-Douglas = 
- # Requires translation!
-Glasgow = 
- # Requires translation!
-Cork = 
- # Requires translation!
-Aberystwyth = 
- # Requires translation!
-Penzance = 
- # Requires translation!
-Ramsey = 
- # Requires translation!
-Inverness = 
- # Requires translation!
-Limerick = 
- # Requires translation!
-Swansea = 
- # Requires translation!
-St. Ives = 
- # Requires translation!
-Peel = 
- # Requires translation!
-Aberdeen = 
- # Requires translation!
-Belfast = 
- # Requires translation!
-Caernarfon = 
- # Requires translation!
-Newquay = 
- # Requires translation!
-Saint-Nazaire = 
- # Requires translation!
-Castletown = 
- # Requires translation!
-Stirling = 
- # Requires translation!
-Galway = 
- # Requires translation!
-Conwy = 
- # Requires translation!
-St. Austell = 
- # Requires translation!
-Saint-Malo = 
- # Requires translation!
-Onchan = 
- # Requires translation!
-Dundee = 
- # Requires translation!
-Londonderry = 
- # Requires translation!
-Llanfairpwllgwyngyll = 
- # Requires translation!
-Falmouth = 
- # Requires translation!
-Lorient = 
- # Requires translation!
-Celts = 
-
- # Requires translation!
-Haile Selassie = 
- # Requires translation!
-I have tried all other avenues, but yet you persist in this madness. I hope, for your sake, your end is swift. = 
- # Requires translation!
-It is silence that allows evil to triumph. We will not stand mute and allow you to continue on this mad quest unchecked. = 
- # Requires translation!
-God and history will remember your actions this day. I hope you are ready for your impending judgment. = 
- # Requires translation!
-A thousand welcomes to our fair nation. I am Selassie, the Ras Tafari Makonnen and Emperor of Ethiopia, your humble servant. = 
- # Requires translation!
-I request that you consider this offer between our two peoples. I believe it will do us both good. = 
- # Requires translation!
-Spirit of Adwa = 
- # Requires translation!
-Blessings be upon you, honorable and righteous Emperor of Ethiopia, Haile Selassie. Your legacy as one of Ethiopia's greatest rulers, and as the spiritual leader to the Rastafarian movement, is outshone only by the influence you had on diplomacy and political cooperation throughout the world. In introducing Ethiopia's first written constitution, you planted the seeds of democracy that would take root over the coming years, and your infinitely wise grasp of global affairs secured Ethiopia's place as a charter member of the United Nations. Spearheading efforts to reform and modernize the nation during your reign, you changed the course of Ethiopian history forever = 
- # Requires translation!
-Revered king, your composed demeanor once protected the people from the many conflicts that plague the nations of men, and the kingdom looks to you to assure peace once again. Will you lead the people with courage and authority, moving forward into a new age? Will you build a civilization that stands the test of time? = 
- # Requires translation!
-Addis Ababa = 
- # Requires translation!
-Harar = 
- # Requires translation!
-Adwa = 
- # Requires translation!
-Lalibela = 
- # Requires translation!
-Gondar = 
- # Requires translation!
-Axum = 
- # Requires translation!
-Dire Dawa = 
- # Requires translation!
-Bahir Dar = 
- # Requires translation!
-Adama = 
- # Requires translation!
-Mek'ele = 
- # Requires translation!
-Awasa = 
- # Requires translation!
-Jimma = 
- # Requires translation!
-Jijiga = 
- # Requires translation!
-Dessie = 
- # Requires translation!
-Debre Berhan = 
- # Requires translation!
-Shashamane = 
- # Requires translation!
-Debre Zeyit = 
- # Requires translation!
-Sodo = 
- # Requires translation!
-Hosaena = 
- # Requires translation!
-Nekemte = 
- # Requires translation!
-Asella = 
- # Requires translation!
-Dila = 
- # Requires translation!
-Adigrat = 
- # Requires translation!
-Debre Markos = 
- # Requires translation!
-Kombolcha = 
- # Requires translation!
-Debre Tabor = 
- # Requires translation!
-Sebeta = 
- # Requires translation!
-Shire = 
- # Requires translation!
-Ambo = 
- # Requires translation!
-Negele Arsi = 
- # Requires translation!
-Gambela = 
- # Requires translation!
-Ziway = 
- # Requires translation!
-Weldiya = 
- # Requires translation!
-Ethiopia = 
-
- # Requires translation!
-Pacal = 
- # Requires translation!
-A sacrifice unlike all others must be made! = 
- # Requires translation!
-Muahahahahahaha! = 
- # Requires translation!
-Today comes a great searing pain. With you comes the path to the black storm. = 
- # Requires translation!
-Greetings, wayward one. I am known as Pacal. = 
- # Requires translation!
-Friend, I believe I may have found a way to save us all! Look, look and accept my offering! = 
- # Requires translation!
-A fine day, it helps you. = 
- # Requires translation!
-The Long Count = 
- # Requires translation!
-Your people kneel before you, exalted King Pacal the Great, favored son of the gods and shield to the citizens of the Palenque domain. After years of strife at the hands of your neighboring rivals, you struck back at the enemies of your people, sacrificing their leaders in retribution for the insults dealt to your predecessors. The glory of Palenque was restored only by the guidance afforded by your wisdom, as you orchestrated vast reconstruction efforts within the city, creating some of the greatest monuments and architecture your people - and the world - have ever known. = 
- # Requires translation!
-Illustrious King, your people once again look to you for leadership and counsel in the coming days. Will you channel the will of the gods and restore your once proud kingdom to its greatest heights? Will you build new monuments to forever enshrine the memories of your people? Can you build a civilization that will stand the test of time? = 
- # Requires translation!
-Palenque = 
- # Requires translation!
-Tikal = 
- # Requires translation!
-Uxmal = 
- # Requires translation!
-Tulum = 
- # Requires translation!
-Copan = 
- # Requires translation!
-Coba = 
- # Requires translation!
-El Mirador = 
- # Requires translation!
-Calakmul = 
- # Requires translation!
-Edzna = 
- # Requires translation!
-Lamanai = 
- # Requires translation!
-Izapa = 
- # Requires translation!
-Uaxactun = 
- # Requires translation!
-Comalcalco = 
- # Requires translation!
-Piedras Negras = 
- # Requires translation!
-Cancuen = 
- # Requires translation!
-Yaxha = 
- # Requires translation!
-Quirigua = 
- # Requires translation!
-Q'umarkaj = 
- # Requires translation!
-Nakbe = 
- # Requires translation!
-Cerros = 
- # Requires translation!
-Xunantunich = 
- # Requires translation!
-Takalik Abaj = 
- # Requires translation!
-Cival = 
- # Requires translation!
-San Bartolo = 
- # Requires translation!
-Altar de Sacrificios = 
- # Requires translation!
-Seibal = 
- # Requires translation!
-Caracol = 
- # Requires translation!
-Naranjo = 
- # Requires translation!
-Dos Pilas = 
- # Requires translation!
-Mayapan = 
- # Requires translation!
-Ixinche = 
- # Requires translation!
-Zaculeu = 
- # Requires translation!
-Kabah = 
- # Requires translation!
-The Maya = 
- # Requires translation!
-Receive a free Great Person at the end of every [comment] (every 394 years), after researching [tech]. Each bonus person can only be chosen once. = 
- # Requires translation!
-Once The Long Count activates, the year on the world screen displays as the traditional Mayan Long Count. = 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
- # Requires translation!
-I didn't want to do this. We declare war. = 
- # Requires translation!
-I will fear no evil. For god is with me! = 
- # Requires translation!
-Why have you forsaken us my lord? = 
- # Requires translation!
-Bratislava = 
-
- # Requires translation!
-We have wanted this for a LONG time. War it shall be. = 
- # Requires translation!
-Very well, we will kick you back to the ancient era! = 
- # Requires translation!
-This isn't how it is supposed to be! = 
- # Requires translation!
-Cahokia = 
-
- # Requires translation!
-By god's grace we will not allow these atrocities to occur any longer. We declare war! = 
- # Requires translation!
-May god have mercy on your evil soul. = 
- # Requires translation!
-I for one welcome our new conquer overlord! = 
- # Requires translation!
-Jerusalem = 
-
-
-
-#################### Lines from Policies from Civ V - Gods & Kings ####################
-
- # Requires translation!
-Provides a [buildingName] in your first [amount] cities for free = 
-
-
-
-
-
- # Requires translation!
-Double gold from Great Merchant trade missions = 
-
-
-
-
-
-
-#################### Lines from Quests from Civ V - Gods & Kings ####################
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-#################### Lines from Religions from Civ V - Gods & Kings ####################
-
-
-
-
-
-
- # Requires translation!
-Judaism = 
-
-
- # Requires translation!
-Sikhism = 
-
- # Requires translation!
-Taoism = 
-
-
-
-
-#################### Lines from Ruins from Civ V - Gods & Kings ####################
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-#################### Lines from Specialists from Civ V - Gods & Kings ####################
-
-
-
-
-
-
-#################### Lines from Techs from Civ V - Gods & Kings ####################
-
-
-
-
-
- # Requires translation!
-'What is drama but life with the dull bits cut out.' - Alfred Hitchcock = 
- # Requires translation!
-Drama and Poetry = 
-
- # Requires translation!
-'The merchants and the traders have come; their profits are pre-ordained...' - Sri Guru Granth Sahib = 
-Guilds = Persatuan
-
-
-
- # Requires translation!
-'Architecture begins where engineering ends.' - Walter Gropius = 
-Architecture = Seni Bina
-
- # Requires translation!
-'Industrialization based on machinery, already referred to as a characteristic of our age, is but one aspect of the revolution that is being wrought by technology.' - Emily Greene Balch = 
-Industrialization = Perindustrian
-
-
-
- # Requires translation!
-'Men, like bullets, go farthest when they are smoothest.' - Jean Paul = 
-Ballistics = Balistik
-
- # Requires translation!
-'The root of the evil is not the construction of new, more dreadful weapons. It is the spirit of conquest.' - Ludwig von Mises = 
-Combined Arms = Senjata Bersama
-
-
- # Requires translation!
-'The more we elaborate our means of communication, the less we communicate.' - J.B. Priestly = 
- # Requires translation!
-Telecommunications = 
- # Requires translation!
-'All men can see these tactics whereby I conquer, but what none can see is the strategy out of which victory is evolved.' - Sun Tzu = 
-Mobile Tactics = Taktik Mudah Alih
-
-
-
-
-#################### Lines from Terrains from Civ V - Gods & Kings ####################
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-#################### Lines from TileImprovements from Civ V - Gods & Kings ####################
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
- # Requires translation!
-Polder = 
-
-
-
-
-
-
-#################### Lines from TileResources from Civ V - Gods & Kings ####################
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-#################### Lines from UnitPromotions from Civ V - Gods & Kings ####################
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-#################### Lines from UnitTypes from Civ V - Gods & Kings ####################
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-#################### Lines from Units from Civ V - Gods & Kings ####################
-
-
-
-
-
-
-
-
-
-
-
- # Requires translation!
-Atlatlist = 
-
-
-
-
- # Requires translation!
-Quinquereme = 
-
- # Requires translation!
-Dromon = 
-
-
-
-
- # Requires translation!
-Horse Archer = 
-
-
-
-
-
- # Requires translation!
-Battering Ram = 
- # Requires translation!
-Can only attack [unitType] units = 
-
- # Requires translation!
-Pictish Warrior = 
-
-
-
-
- # Requires translation!
-African Forest Elephant = 
-
- # Requires translation!
-Cataphract = 
-
-
-
- # Requires translation!
-Composite Bowman = 
-
-
-
-
-
-
- # Requires translation!
-Galleass = 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
- # Requires translation!
-Privateer = 
- # Requires translation!
-May capture killed [param] units = 
-
- # Requires translation!
-Sea Beggar = 
-
-
-
-
-
- # Requires translation!
-Hakkapeliitta = 
- # Requires translation!
-Transfer Movement to [unit] = 
- # Requires translation!
-[amount]% Strength when stacked with [unit] = 
-
-
- # Requires translation!
-Gatling Gun = 
-
-
-
- # Requires translation!
-Carolean = 
-
- # Requires translation!
-Mehal Sefari = 
-
-
-
- # Requires translation!
-Hussar = 
- # Requires translation!
-[amount]% to Flank Attack bonuses = 
-
-
-
-
- # Requires translation!
-Great War Infantry = 
-
-
- # Requires translation!
-Triplane = 
-
- # Requires translation!
-Great War Bomber = 
-
-
-
-
-Machine Gun = Mesingan
-
-
- # Requires translation!
-Landship = 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+Can be purchased with [stat] [cityFilter] =
 
 
 #################### Lines from Tutorials ####################
 
  # Requires translation!
-Introduction = 
+Introduction =
  # Requires translation!
-Welcome to Unciv!\nBecause this is a complex game, there are basic tasks to help familiarize you with the game.\nThese are completely optional, and you're welcome to explore the game on your own! = 
+Welcome to Unciv!\nBecause this is a complex game, there are basic tasks to help familiarize you with the game.\nThese are completely optional, and you're welcome to explore the game on your own! =
+ # Requires translation!
+New Game =
+ # Requires translation!
+Your first mission is to found your capital city.\nThis is actually an important task because your capital city will probably be your most prosperous.\nMany game bonuses apply only to your capital city and it will probably be the center of your empire. =
+ # Requires translation!
+How do you know a spot is appropriate?\nThat’s not an easy question to answer, but looking for and building next to luxury resources is a good rule of thumb.\nLuxury resources are tiles that have things like gems, cotton, or silk (indicated by a smiley next to the resource icon)\nThese resources make your civilization happy. You should also keep an eye out for resources needed to build units, such as iron. Cities cannot be built within 3 tiles of existing cities, which is another thing to watch out for! =
+ # Requires translation!
+However, cities don’t have a set area that they can work - more on that later!\nThis means you don’t have to settle cities right next to resources.\nLet’s say, for example, that you want access to some iron – but the resource is right next to a desert.\nYou don’t have to settle your city next to the desert. You can settle a few tiles away in more prosperous lands.\nYour city will grow and eventually gain access to the resource.\nYou only need to settle right next to resources if you need them immediately – \n   which might be the case now and then, but you’ll usually have the luxury of time. =
+ # Requires translation!
+The first thing coming out of your city should be either a Scout or Warrior.\nI generally prefer the Warrior because it can be used for defense and because it can be upgraded\n  to the Swordsman unit later in the game for a relatively modest sum of gold.\nScouts can be effective, however, if you seem to be located in an area of dense forest and hills.\nScouts don’t suffer a movement penalty in this terrain.\nIf you’re a veteran of the 4x strategy genre your first Warrior or Scout will be followed by a Settler.\nFast expanding is absolutely critical in most games of this type. =
+ # Requires translation!
+In your first couple of turns, you will have very little options, but as your civilization grows, so do the number of things requiring your attention =
+ # Requires translation!
+Culture and Policies =
+ # Requires translation!
+Each turn, the culture you gain from all your cities is added to your Civilization's culture.\nWhen you have enough culture, you may pick a Social Policy, each one giving you a certain bonus. =
+ # Requires translation!
+The policies are organized into branches, with each branch providing a bonus ability when all policies in the branch have been adopted. =
+ # Requires translation!
+With each policy adopted, and with each city built,\n  the cost of adopting another policy rises - so choose wisely! =
 
  # Requires translation!
-New Game = 
+City Expansion =
  # Requires translation!
-Your first mission is to found your capital city.\nThis is actually an important task because your capital city will probably be your most prosperous.\nMany game bonuses apply only to your capital city and it will probably be the center of your empire. = 
+Once a city has gathered enough Culture, it will expand into a neighboring tile.\nYou have no control over the tile it will expand into, but tiles with resources and higher yields are prioritized. =
  # Requires translation!
-How do you know a spot is appropriate?\nThat’s not an easy question to answer, but looking for and building next to luxury resources is a good rule of thumb.\nLuxury resources are tiles that have things like gems, cotton, or silk (indicated by a smiley next to the resource icon)\nThese resources make your civilization happy. You should also keep an eye out for resources needed to build units, such as iron. Cities cannot be built within 3 tiles of existing cities, which is another thing to watch out for! = 
+Each additional tile will require more culture, but generally your first cities will eventually expand to a wide tile range. =
  # Requires translation!
-However, cities don’t have a set area that they can work - more on that later!\nThis means you don’t have to settle cities right next to resources.\nLet’s say, for example, that you want access to some iron – but the resource is right next to a desert.\nYou don’t have to settle your city next to the desert. You can settle a few tiles away in more prosperous lands.\nYour city will grow and eventually gain access to the resource.\nYou only need to settle right next to resources if you need them immediately – \n   which might be the case now and then, but you’ll usually have the luxury of time. = 
- # Requires translation!
-The first thing coming out of your city should be either a Scout or Warrior.\nI generally prefer the Warrior because it can be used for defense and because it can be upgraded\n  to the Swordsman unit later in the game for a relatively modest sum of gold.\nScouts can be effective, however, if you seem to be located in an area of dense forest and hills.\nScouts don’t suffer a movement penalty in this terrain.\nIf you’re a veteran of the 4x strategy genre your first Warrior or Scout will be followed by a Settler.\nFast expanding is absolutely critical in most games of this type. = 
+Although your city will keep expanding forever, your citizens can only work 3 tiles away from city center.\nThis should be taken into account when placing new cities. =
 
  # Requires translation!
-In your first couple of turns, you will have very little options, but as your civilization grows, so do the number of things requiring your attention. = 
+As cities grow in size and influence, you have to deal with a happiness mechanic that is no longer tied to each individual city.\nInstead, your entire empire shares the same level of satisfaction.\nAs your cities grow in population you’ll find that it is more and more difficult to keep your empire happy. =
+ # Requires translation!
+In addition, you can’t even build any city improvements that increase happiness until you’ve done the appropriate research.\nIf your empire’s happiness ever goes below zero the growth rate of your cities will be hurt.\nIf your empire becomes severely unhappy (as indicated by the smiley-face icon at the top of the interface)\n  your armies will have a big penalty slapped on to their overall combat effectiveness. =
+ # Requires translation!
+This means that it is very difficult to expand quickly in Unciv.\nIt isn’t impossible, but as a new player you probably shouldn’t do it.\nSo what should you do? Chill out, scout, and improve the land that you do have by building Workers.\nOnly build new cities once you have found a spot that you believe is appropriate. =
 
  # Requires translation!
-Culture and Policies = 
+Unhappiness =
  # Requires translation!
-Each turn, the culture you gain from all your cities is added to your Civilization's culture.\nWhen you have enough culture, you may pick a Social Policy, each one giving you a certain bonus. = 
+It seems that your citizens are unhappy!\nWhile unhappy, cities  will grow at 1/4 the speed, and your units will suffer a 2% penalty for each unhappiness =
  # Requires translation!
-The policies are organized into branches, with each branch providing a bonus ability when all policies in the branch have been adopted. = 
+Unhappiness has two main causes: Population and cities\n  Each city causes 3 unhappiness, and each population, 1 =
  # Requires translation!
-With each policy adopted, and with each city built,\n  the cost of adopting another policy rises - so choose wisely! = 
+There are 2 main ways to combat unhappiness:\n  by building happiness buildings for your population\n  or by having improved luxury resources within your borders =
 
  # Requires translation!
-City Expansion = 
- # Requires translation!
-Once a city has gathered enough Culture, it will expand into a neighboring tile.\nYou have no control over the tile it will expand into, but tiles with resources and higher yields are prioritized. = 
- # Requires translation!
-Each additional tile will require more culture, but generally your first cities will eventually expand to a wide tile range. = 
- # Requires translation!
-Although your city will keep expanding forever, your citizens can only work 3 tiles away from city center.\nThis should be taken into account when placing new cities. = 
+You have entered a Golden Age!\nGolden age points are accumulated each turn by the total happiness \n  of your civilization\nWhen in a golden age, culture and production generation increases +20%,\n  and every tile already providing at least one gold will provide an extra gold. =
 
  # Requires translation!
-As cities grow in size and influence, you have to deal with a happiness mechanic that is no longer tied to each individual city.\nInstead, your entire empire shares the same level of satisfaction.\nAs your cities grow in population you’ll find that it is more and more difficult to keep your empire happy. = 
+Roads and Railroads =
  # Requires translation!
-In addition, you can’t even build any city improvements that increase happiness until you’ve done the appropriate research.\nIf your empire’s happiness ever goes below zero the growth rate of your cities will be hurt.\nIf your empire becomes severely unhappy (as indicated by the smiley-face icon at the top of the interface)\n  your armies will have a big penalty slapped on to their overall combat effectiveness. = 
- # Requires translation!
-This means that it is very difficult to expand quickly in Unciv.\nIt isn’t impossible, but as a new player you probably shouldn't do it.\nSo what should you do? Chill out, scout, and improve the land that you do have by building Workers.\nOnly build new cities once you have found a spot that you believe is appropriate. = 
+Connecting your cities to the capital by roads\n  will generate gold via the trade route.\nNote that each road costs 1 gold Maintenance per turn, and each Railroad costs 2 gold,\n  so it may be more economical to wait until the cities grow! =
 
  # Requires translation!
-Unhappiness = 
+Victory Types =
  # Requires translation!
-It seems that your citizens are unhappy!\nWhile unhappy, cities  will grow at 1/4 the speed, and your units will suffer a 2% penalty for each unhappiness = 
+Once you’ve settled your first two or three cities you’re probably 100 to 150 turns into the game.\nNow is a good time to start thinking about how, exactly, you want to win – if you haven’t already. =
  # Requires translation!
-Unhappiness has two main causes: Population and cities.\n  Each city causes 3 unhappiness, and each population, 1 = 
+There are three ways to win in Unciv. They are:\n - Cultural Victory: Complete 5 Social Policy Trees\n - Domination Victory: Survive as the last civilization\n - Science Victory: Be the first to construct a spaceship to Alpha Centauri =
  # Requires translation!
-There are 2 main ways to combat unhappiness:\n  by building happiness buildings for your population\n  or by having improved luxury resources within your borders. = 
+So to sum it up, these are the basics of Unciv – Found a prosperous first city, expand slowly to manage happiness,\n   and set yourself up for the victory condition you wish to pursue.\nObviously, there is much more to it than that, but it is important not to jump into the deep end before you know how to swim. =
 
  # Requires translation!
-You have entered a Golden Age!\nGolden age points are accumulated each turn by the total happiness \n  of your civilization\nWhen in a golden age, culture and production generation increases +20%,\n  and every tile already providing at least one gold will provide an extra gold. = 
+Enemy City =
+ # Requires translation!
+Cities can be conquered by reducing their health to 1, and entering the city with a melee unit.\nSince cities heal each turn, it is best to attack with ranged units and use your melee units to defend them until the city has been defeated! =
 
  # Requires translation!
-Roads and Railroads = 
+Luxury Resource =
  # Requires translation!
-Connecting your cities to the capital by roads\n  will generate gold via the trade route.\nNote that each road costs 1 gold Maintenance per turn, and each Railroad costs 2 gold,\n  so it may be more economical to wait until the cities grow! = 
+Luxury resources within your domain and with their specific improvement are connected to your trade network.\nEach unique Luxury resource you have adds 5 happiness to your civilization, but extra resources of the same type don't add anything, so use them for trading with other civilizations! =
+ # Requires translation!
+Strategic Resource =
+ # Requires translation!
+Strategic resources within your domain and with their specific improvement are connected to your trade network.\nStrategic resources allow you to train units and construct buildings that require those specific resources, for example the Horseman requires Horses. =
+ # Requires translation!
+Unlike Luxury Resources, each Strategic Resource on the map provides more than one of that resource.\nThe top bar keeps count of how many unused strategic resources you own.\nA full drilldown of resources is available in the Resources tab in the Overview screen. =
+ # Requires translation!
+The city can no longer put up any resistance!\nHowever, to conquer it, you must enter the city with a melee unit =
+ # Requires translation!
+After Conquering =
+ # Requires translation!
+When conquering a city, you can now choose to either  or raze, puppet, or annex the city.\nRazing the city will lower its population by 1 each turn until the city is destroyed. =
+ # Requires translation!
+Puppeting the city will mean that you have no control on the city's production.\nThe city will not increase your tech or policy cost, but its citizens will generate 1.5x the regular unhappiness.\nAnnexing the city will give you control over the production, but will increase the citizen's unhappiness to 2x!\nThis can be mitigated by building a courthouse in the city, returning the citizen's unhappiness to normal.\nA puppeted city can be annexed at any time, but annexed cities cannot be returned to a puppeted state! =
 
  # Requires translation!
-Victory Types = 
+You have encountered a barbarian unit!\nBarbarians attack everyone indiscriminately, so don't let your \n  civilian units go near them, and be careful of your scout! =
  # Requires translation!
-Once you’ve settled your first two or three cities you’re probably 100 to 150 turns into the game.\nNow is a good time to start thinking about how, exactly, you want to win – if you haven’t already. = 
+You have encountered another civilization!\nOther civilizations start out peaceful, and you can trade with them,\n  but they may choose to declare war on you later on =
  # Requires translation!
-There are four ways to win in Unciv. They are:\n - Cultural Victory: Complete 5 Social Policy Trees and build the Utopia Project\n - Domination Victory: Survive as the last civilization\n - Science Victory: Be the first to construct a spaceship to Alpha Centauri\n - Diplomatic Victory: Build the United Nations and win the vote = 
+Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities\n (with the relevant technologies) to win a scientific victory! =
  # Requires translation!
-So to sum it up, these are the basics of Unciv – Found a prosperous first city, expand slowly to manage happiness, and set yourself up for the victory condition you wish to pursue.\nObviously, there is much more to it than that, but it is important not to jump into the deep end before you know how to swim. = 
+Injured Units =
+ # Requires translation!
+Injured units deal less damage, but recover after turns that they have been inactive\nUnits heal 5 health per turn in enemy territory, 10 in neutral land,\n  15 inside your territory and 20 in your cities =
+ # Requires translation!
+Workers =
+ # Requires translation!
+Workers are vital to your cities' growth, since only they can construct improvements on tiles\nImprovements raise the yield of your tiles, allowing your city to produce more and grow faster while working the same amount of tiles! =
 
  # Requires translation!
-Enemy City = 
+Siege Units =
  # Requires translation!
-Cities can be conquered by reducing their health to 1, and entering the city with a melee unit.\nSince cities heal each turn, it is best to attack with ranged units and use your melee units to defend them until the city has been defeated! = 
+Siege units are extremely powerful against cities, but need to be Set Up before they can attack.\nOnce your siege unit is set up, it can attack from the current tile,\n  but once moved to another tile, it will need to be set up again. =
 
  # Requires translation!
-Luxury Resource = 
+Embarking =
  # Requires translation!
-Luxury resources within your domain and with their specific improvement are connected to your trade network.\nEach unique Luxury resource you have adds 5 happiness to your civilization, but extra resources of the same type don't add anything, so use them for trading with other civilizations! = 
+Once a certain tech is researched, your land units can embark, allowing them to traverse water tiles.\nEntering or leaving water takes the entire turn.\nUnits are defenseless while embarked, so be careful! =
 
  # Requires translation!
-Strategic Resource = 
+Idle Units =
  # Requires translation!
-Strategic resources within your domain and with their specific improvement are connected to your trade network.\nStrategic resources allow you to train units and construct buildings that require those specific resources, for example the Horseman requires Horses. = 
- # Requires translation!
-Unlike Luxury Resources, each Strategic Resource on the map provides more than one of that resource.\nThe top bar keeps count of how many unused strategic resources you own.\nA full drilldown of resources is available in the Resources tab in the Overview screen. = 
+If you don't want to move a unit this turn, you can skip it by clicking 'Next unit' again.\nIf you won't be moving it for a while, you can have the unit enter Fortify or Sleep mode - \n  units in Fortify or Sleep are not considered idle units.\nIf you want to disable the 'Next unit' feature entirely, you can toggle it in Menu -> Check for idle units =
 
  # Requires translation!
-The city can no longer put up any resistance!\nHowever, to conquer it, you must enter the city with a melee unit = 
+Contact Me =
+ # Requires translation!
+Hi there! If you've played this far, you've probably seen that the game is currently incomplete.\n UnCiv is meant to be open-source and free, forever.\n That means no ads or any other nonsense. =
+ # Requires translation!
+What motivates me to keep working on it, \n  besides the fact I think it's amazingly cool that I can,\n  is the support from the players - you guys are the best! =
+ # Requires translation!
+Every rating and review that I get puts a smile on my face =)\n  So contact me! Send me an email, review, Github issue\n  or mail pigeon, and let's figure out how to make the game \n  even more awesome!\n(Contact info is in the Play Store) =
 
  # Requires translation!
-After Conquering = 
+Pillaging =
  # Requires translation!
-When conquering a city, you can now choose to either  or raze, puppet, or annex the city.\nRazing the city will lower its population by 1 each turn until the city is destroyed. = 
- # Requires translation!
-Puppeting the city will mean that you have no control on the city's production.\nThe city will not increase your tech or policy cost, but its citizens will generate 1.5x the regular unhappiness.\nAnnexing the city will give you control over the production, but will increase the citizen's unhappiness to 2x!\nThis can be mitigated by building a courthouse in the city, returning the citizen's unhappiness to normal.\nA puppeted city can be annexed at any time, but annexed cities cannot be returned to a puppeted state! = 
+Military units can pillage improvements, which heals them 25 health and ruins the improvement.\nThe tile can still be worked, but advantages from the improvement - stat bonuses and resources - will be lost.\nWorkers can repair these improvements, which takes less time than building the improvement from scratch. =
 
  # Requires translation!
-You have encountered a barbarian unit!\nBarbarians attack everyone indiscriminately, so don't let your \n  civilian units go near them, and be careful of your scout! = 
+Experience =
+ # Requires translation!
+Units that enter combat gain experience, which can then be used on promotions for that unit.\nUnits gain more experience when in Melee combat than Ranged, and more when attacking than when defending. =
+ # Requires translation!
+Units can only gain up to 30 XP from Barbarian units - meaning up to 2 promotions. After that, Barbarian units will provide no experience. =
 
  # Requires translation!
-You have encountered another civilization!\nOther civilizations start out peaceful, and you can trade with them,\n  but they may choose to declare war on you later on = 
+Combat =
+ # Requires translation!
+Unit and cities are worn down by combat, which is affected by a number of different values.\nEach unit has a certain 'base' combat value, which can be improved by certain conditions, promotions and locations. =
+ # Requires translation!
+Units use the 'Strength' value as the base combat value when melee attacking and when defending.\nWhen using a ranged attack, they will the use the 'Ranged Strength' value instead. =
+ # Requires translation!
+Ranged attacks can be done from a distance, dependent on the 'Range' value of the unit.\nWhile melee attacks allow the defender to damage the attacker in retaliation, ranged attacks do not. =
 
  # Requires translation!
-Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities\n (with the relevant technologies) to win a scientific victory! = 
+Research Agreements =
+ # Requires translation!
+In research agreements, you and another civilization decide to jointly research technology.\nAt the end of the agreement, you will both receive a 'lump sum' of Science, which will go towards one of your unresearched technologies. =
+ # Requires translation!
+The amount of Science you receive at the end is dependent on the science generated by your cities and the other civilization's cities during the agreement - the more, the better! =
+ # Requires translation!
+Not all nations are contending with you for victory.\nCity-states are nations that can't win, don't conquer other cities and can't be traded with. =
+ # Requires translation!
+Instead, diplomatic relations with city-states are determined by Influence - a meter of 'how much the City-state likes you'.\nInfluence can be increased by attacking their enemies, liberating their city, and giving them sums of gold. =
+ # Requires translation!
+Certain bonuses are given when you are at above 30 influence.\nWhen you have above 60 Influence, and you have the highest influence with them of all civilizations, you are considered their 'Ally', and gain further bonuses and access to the Luxury and Strategic resources in their lands. =
 
  # Requires translation!
-Injured Units = 
+Great People =
  # Requires translation!
-Injured units deal less damage, but recover after turns that they have been inactive.\nUnits heal 5 health per turn in enemy territory, 10 in neutral land,\n  15 inside your territory and 20 in your cities. = 
-
+Certain buildings, and specialists in cities, generate Great Person points per turn.\nThere are several types of Great People, and their points accumulate separately.\nThe number of points per turn and accumulated points can be viewed in the Overview screen. =
  # Requires translation!
-Workers = 
+Once enough points have been accumulated, a Great Person of that type will be created!\nEach Great Person can construct a certain Great Improvement which gives large yields over time, or immediately consumed to provide a certain bonus now. =
  # Requires translation!
-Workers are vital to your cities' growth, since only they can construct improvements on tiles.\nImprovements raise the yield of your tiles, allowing your city to produce more and grow faster while working the same amount of tiles! = 
-
+Great Improvements also provide any strategic resources that are under them, so you don't need to worry if resources are revealed underneath your improvements! =
  # Requires translation!
-Siege Units = 
+Removing Terrain Features =
  # Requires translation!
-Siege units are extremely powerful against cities, but need to be Set Up before they can attack.\nOnce your siege unit is set up, it can attack from the current tile,\n  but once moved to another tile, it will need to be set up again. = 
-
+Certain tiles have terrain features - like Flood plains or Forests -  on top of them. Some of these layers, like Jungle, Marsh and Forest, can be removed by workers.\nRemoving the terrain feature does not remove any resources in the tile, and is usually required in order to work those resources. =
  # Requires translation!
-Embarking = 
+Natural Wonders, such as the Mt. Fuji, the Rock of Gibraltar and the Great Barrier Reef, are unique, impassable terrain features, masterpieces of mother Nature, which possess exceptional qualities that make them very different from the average terrain.\nThey benefit by giving you large sums of Culture, Science, Gold or Production if worked by your Cities, which is why you might need to bring them under your empire as soon as possible. =
  # Requires translation!
-Once a certain tech is researched, your land units can embark, allowing them to traverse water tiles.\nEntering or leaving water takes the entire turn.\nUnits are defenseless while embarked, so be careful! = 
-
+Keyboard =
  # Requires translation!
-Idle Units = 
+If you have a keyboard, some shortcut keys become available. Unit command or improvement picker keys, for example, are shown directly in their corresponding buttons. =
  # Requires translation!
-If you don't want to move a unit this turn, you can skip it by clicking 'Next unit' again.\nIf you won't be moving it for a while, you can have the unit enter Fortify or Sleep mode - \n  units in Fortify or Sleep are not considered idle units.\nIf you want to disable the 'Next unit' feature entirely, you can toggle it in Menu -> Check for idle units. = 
-
+On the world screen the hotkeys are as follows: =
  # Requires translation!
-Contact Me = 
+Space or 'N' - Next unit or turn\n'E' - Empire overview (last viewed page)\n'+', '-' - Zoom in / out\nHome - center on capital or open its city screen if already centered =
  # Requires translation!
-Hi there! If you've played this far, you've probably seen that the game is currently incomplete.\n UnCiv is meant to be open-source and free, forever.\n That means no ads or any other nonsense. = 
+F1 - Open Civilopedia\nF2 - Empire overview Trades\nF3 - Empire overview Units\nF4 - Empire overview Diplomacy\nF5 - Social policies\nF6 - Technologies\nF7 - Empire overview Cities\nF8 - Victory Progress\nF9 - Empire overview Stats\nF10 - Empire overview Resources\nF11 - Quicksave\nF12 - Quickload =
  # Requires translation!
-What motivates me to keep working on it, \n  besides the fact I think it's amazingly cool that I can,\n  is the support from the players - you guys are the best! = 
+Ctrl-R - Toggle tile resource display\nCtrl-Y - Toggle tile yield display\nCtrl-O - Game options\nCtrl-S - Save game\nCtrl-L - Load game =
  # Requires translation!
-Every rating and review that I get puts a smile on my face =)\n  So contact me! Send me an email, review, Github issue\n  or mail pigeon, and let's figure out how to make the game \n  even more awesome!\n(Contact info is in the Play Store) = 
-
+World Screen =
  # Requires translation!
-Pillaging = 
+This is where you spend most of your time playing Unciv. See the world, control your units, access other screens from here. =
  # Requires translation!
-Military units can pillage improvements, which heals them 25 health and ruins the improvement.\nThe tile can still be worked, but advantages from the improvement - stat bonuses and resources - will be lost.\nWorkers can repair these improvements, which takes less time than building the improvement from scratch. = 
-
+①: The menu button - civilopedia, save, load, options... =
  # Requires translation!
-Experience = 
+②: The player/nation whose turn it is - click for diplomacy overview. =
  # Requires translation!
-Units that enter combat gain experience, which can then be used on promotions for that unit.\nUnits gain more experience when in Melee combat than Ranged, and more when attacking than when defending. = 
+③: The Technology Button - shows the tech tree which allows viewing or researching technologies. =
  # Requires translation!
-Units can only gain up to 30 XP from Barbarian units - meaning up to 2 promotions. After that, Barbarian units will provide no experience. = 
-
+④: The Social Policies Button - shows enacted and selectable policies, and with enough culture points you can enact new ones. =
  # Requires translation!
-Combat = 
+⑤: The Diplomacy Button - shows the diplomacy manager where you can talk to other civilizations. =
  # Requires translation!
-Unit and cities are worn down by combat, which is affected by a number of different values.\nEach unit has a certain 'base' combat value, which can be improved by certain conditions, promotions and locations. = 
+⑥: Unit Action Buttons - while a unit is selected its possible actions appear here. =
  # Requires translation!
-Units use the 'Strength' value as the base combat value when melee attacking and when defending.\nWhen using a ranged attack, they will the use the 'Ranged Strength' value instead. = 
+⑦: The unit/city info pane - shows information about a selected unit or city. =
  # Requires translation!
-Ranged attacks can be done from a distance, dependent on the 'Range' value of the unit.\nWhile melee attacks allow the defender to damage the attacker in retaliation, ranged attacks do not. = 
-
+⑧: The name (and unit icon) of the selected unit or city, with current health if wounded. Clicking a unit name or icon will open its civilopedia entry. =
  # Requires translation!
-Research Agreements = 
+⑨: The arrow buttons allow jumping to the next/previous unit. =
  # Requires translation!
-In research agreements, you and another civilization decide to jointly research technology.\nAt the end of the agreement, you will both receive a 'lump sum' of Science, which will go towards one of your unresearched technologies. = 
+⑩: For a selected unit, its promotions appear here, and clicking leads to the promotions screen for that unit. =
  # Requires translation!
-The amount of Science you receive at the end is dependent on the science generated by your cities and the other civilization's cities during the agreement - the more, the better! = 
-
+⑪: Remaining/per turn movement points, strength and experience / XP needed for promotion. For cities, you get its combat strength. =
  # Requires translation!
-Not all nations are contending with you for victory.\nCity-states are nations that can't win, don't conquer other cities and can't be traded with. = 
+⑫: This button closes the selected unit/city info pane. =
  # Requires translation!
-Instead, diplomatic relations with city-states are determined by Influence - a meter of 'how much the City-state likes you'.\nInfluence can be increased by attacking their enemies, liberating their city, and giving them sums of gold. = 
+⑬: This pane appears when you order a unit to attack an enemy. On top are attacker and defender with their respective base strengths. =
  # Requires translation!
-Certain bonuses are given when you are at above 30 influence.\nWhen you have above 60 Influence, and you have the highest influence with them of all civilizations, you are considered their 'Ally', and gain further bonuses and access to the Luxury and Strategic resources in their lands. = 
-
+⑭: Below that are strength boni or mali and health bars projecting before / after the attack. =
  # Requires translation!
-Great People = 
+⑮: The Attack Button - let blood flow! =
  # Requires translation!
-Certain buildings, and specialists in cities, generate Great Person points per turn.\nThere are several types of Great People, and their points accumulate separately.\nThe number of points per turn and accumulated points can be viewed in the Overview screen. = 
+⑯: The minimap shows an overview over the world, with known cities, terrain and fog of war. Clicking will position the main map. =
  # Requires translation!
-Once enough points have been accumulated, a Great Person of that type will be created!\nEach Great Person can construct a certain Great Improvement which gives large yields over time, or immediately consumed to provide a certain bonus now. = 
+⑰: To the side of the minimap are display feature toggling buttons - tile yield, worked indicator, show/hide resources. These mirror setting on the options screen and are hidden if you deactivate the minimap. =
  # Requires translation!
-Great Improvements also provide any strategic resources that are under them, so you don't need to worry if resources are revealed underneath your improvements! = 
-
+⑱: Tile information for the selected hex - current or potential yield, terrain, effects, present units, city located there and such. Where appropriate, clicking a line opens the corresponding civilopedia entry. =
  # Requires translation!
-Removing Terrain Features = 
+⑲: Notifications - what happened during the last 'next turn' phase. Some are clickable to show a relevant place on the map, some even show several when you click repeatedly. =
  # Requires translation!
-Certain tiles have terrain features - like Flood plains or Forests -  on top of them. Some of these layers, like Jungle, Marsh and Forest, can be removed by workers.\nRemoving the terrain feature does not remove any resources in the tile, and is usually required in order to add improvements exploiting those resources. = 
-
+⑳: The Next Turn Button - unless there are things to do, in which case the label changes to 'next unit', 'pick policy' and so on. =
  # Requires translation!
-Natural Wonders, such as the Mt. Fuji, the Rock of Gibraltar and the Great Barrier Reef, are unique, impassable terrain features, masterpieces of mother Nature, which possess exceptional qualities that make them very different from the average terrain.\nThey benefit by giving you large sums of Culture, Science, Gold or Production if worked by your Cities, which is why you might need to bring them under your empire as soon as possible. = 
-
+ⓐ: The overview button leads to the empire overview screen with various tabs (the last one viewed is remembered) holding vital information about the state of your civilization in the world. =
  # Requires translation!
-Keyboard = 
+ⓑ: The culture icon shows accumulated culture and culture needed for the next policy - in this case, the exclamation mark tells us a next policy can be enacted. Clicking is another way to the policies manager. =
  # Requires translation!
-If you have a keyboard, some shortcut keys become available. Unit command or improvement picker keys, for example, are shown directly in their corresponding buttons. = 
+ⓒ: Your known strategic resources are displayed here with the available (usage already deducted) number - click to go to the resources overview screen. =
  # Requires translation!
-On the world screen the hotkeys are as follows: = 
+ⓓ: Happiness/unhappiness balance and either golden age with turns left or accumulated happiness with amount needed for a golden age is shown next to the smiley. Clicking also leads to the resources overview screen as luxury resources are a way to improve happiness. =
  # Requires translation!
-Space or 'N' - Next unit or turn\n'E' - Empire overview (last viewed page)\n'+', '-' - Zoom in / out\nHome - center on capital or open its city screen if already centered = 
+ⓔ: The science icon shows the number of science points produced per turn. Clicking leads to the technology tree. =
  # Requires translation!
-F1 - Open Civilopedia\nF2 - Empire overview Trades\nF3 - Empire overview Units\nF4 - Empire overview Diplomacy\nF5 - Social policies\nF6 - Technologies\nF7 - Empire overview Cities\nF8 - Victory Progress\nF9 - Empire overview Stats\nF10 - Empire overview Resources\nF11 - Quicksave\nF12 - Quickload = 
+ⓕ: Number of turns played with translation into calendar years. Click to see the victory overview. =
  # Requires translation!
-Ctrl-R - Toggle tile resource display\nCtrl-Y - Toggle tile yield display\nCtrl-O - Game options\nCtrl-S - Save game\nCtrl-L - Load game = 
-
+ⓖ: The number of gold coins in your treasury and income. Clicks lead to the Stats overview screen. =
  # Requires translation!
-World Screen = 
+ⓧ: In the center of all this - the world map! Here, the "X" marks a spot outside the map. Yes, unless the wrap option was used, Unciv worlds are flat. Don't worry, your ships won't fall off the edge. =
  # Requires translation!
-This is where you spend most of your time playing Unciv. See the world, control your units, access other screens from here. = 
+ⓨ: By the way, here's how an empire border looks like - it's in the national colours of the nation owning the territory. =
  # Requires translation!
-①: The menu button - civilopedia, save, load, options... = 
- # Requires translation!
-②: The player/nation whose turn it is - click for diplomacy overview. = 
- # Requires translation!
-③: The Technology Button - shows the tech tree which allows viewing or researching technologies. = 
- # Requires translation!
-④: The Social Policies Button - shows enacted and selectable policies, and with enough culture points you can enact new ones. = 
- # Requires translation!
-⑤: The Diplomacy Button - shows the diplomacy manager where you can talk to other civilizations. = 
- # Requires translation!
-⑥: Unit Action Buttons - while a unit is selected its possible actions appear here. = 
- # Requires translation!
-⑦: The unit/city info pane - shows information about a selected unit or city. = 
- # Requires translation!
-⑧: The name (and unit icon) of the selected unit or city, with current health if wounded. Clicking a unit name or icon will open its civilopedia entry. = 
- # Requires translation!
-⑨: The arrow buttons allow jumping to the next/previous unit. = 
- # Requires translation!
-⑩: For a selected unit, its promotions appear here, and clicking leads to the promotions screen for that unit. = 
- # Requires translation!
-⑪: Remaining/per turn movement points, strength and experience / XP needed for promotion. For cities, you get its combat strength. = 
- # Requires translation!
-⑫: This button closes the selected unit/city info pane. = 
- # Requires translation!
-⑬: This pane appears when you order a unit to attack an enemy. On top are attacker and defender with their respective base strengths. = 
- # Requires translation!
-⑭: Below that are strength bonuses or penalties and health bars projecting before / after the attack. = 
- # Requires translation!
-⑮: The Attack Button - let blood flow! = 
- # Requires translation!
-⑯: The minimap shows an overview over the world, with known cities, terrain and fog of war. Clicking will position the main map. = 
- # Requires translation!
-⑰: To the side of the minimap are display feature toggling buttons - tile yield, worked indicator, show/hide resources. These mirror setting on the options screen and are hidden if you deactivate the minimap. = 
- # Requires translation!
-⑱: Tile information for the selected hex - current or potential yield, terrain, effects, present units, city located there and such. Where appropriate, clicking a line opens the corresponding civilopedia entry. = 
- # Requires translation!
-⑲: Notifications - what happened during the last 'next turn' phase. Some are clickable to show a relevant place on the map, some even show several when you click repeatedly. = 
- # Requires translation!
-⑳: The Next Turn Button - unless there are things to do, in which case the label changes to 'next unit', 'pick policy' and so on. = 
- # Requires translation!
-ⓐ: The overview button leads to the empire overview screen with various tabs (the last one viewed is remembered) holding vital information about the state of your civilization in the world. = 
- # Requires translation!
-ⓑ: The culture icon shows accumulated culture and culture needed for the next policy - in this case, the exclamation mark tells us a next policy can be enacted. Clicking is another way to the policies manager. = 
- # Requires translation!
-ⓒ: Your known strategic resources are displayed here with the available (usage already deducted) number - click to go to the resources overview screen. = 
- # Requires translation!
-ⓓ: Happiness/unhappiness balance and either golden age with turns left or accumulated happiness with amount needed for a golden age is shown next to the smiley. Clicking also leads to the resources overview screen as luxury resources are a way to improve happiness. = 
- # Requires translation!
-ⓔ: The science icon shows the number of science points produced per turn. Clicking leads to the technology tree. = 
- # Requires translation!
-ⓕ: Number of turns played with translation into calendar years. Click to see the victory overview. = 
- # Requires translation!
-ⓖ: The number of gold coins in your treasury and income. Clicks lead to the Stats overview screen. = 
- # Requires translation!
-ⓧ: In the center of all this - the world map! Here, the "X" marks a spot outside the map. Yes, unless the wrap option was used, Unciv worlds are flat. Don't worry, your ships won't fall off the edge. = 
- # Requires translation!
-ⓨ: By the way, here's how an empire border looks like - it's in the national colours of the nation owning the territory. = 
- # Requires translation!
-ⓩ: And this is the red targeting circle that led to the attack pane back under ⑬. = 
- # Requires translation!
-What you don't see: The phone/tablet's back button will pop the question whether you wish to leave Unciv and go back to Real Life. On desktop versions, you can use the ESC key. = 
-
- # Requires translation!
-After building a shrine, your civilization will start generating Faith☮. = 
- # Requires translation!
-When enough Faith☮ has been generated, you will be able to found a pantheon. = 
- # Requires translation!
-A pantheon will provide a small bonus for your civilization that will apply to all your cities. = 
- # Requires translation!
-Each civilization can only choose a single pantheon belief, and each pantheon can only be chosen once. = 
- # Requires translation!
-Generating more faith will allow you to found a religion. = 
-
- # Requires translation!
-Keep generating Faith☮, and eventually a great prophet will be born in one of your cities. = 
- # Requires translation!
-This great prophet can be used for multiple things: Constructing a holy site, founding a religion and spreading your religion. = 
- # Requires translation!
-When founding your religion, you may choose another two beliefs. The founder belief will only apply to you, while the follower belief will apply to all cities following your religion. = 
- # Requires translation!
-Additionally, the city where you used your great prophet will become the holy city of that religion. = 
- # Requires translation!
-Once you have founded a religion, great prophets will keep being born every so often, though the amount of Faith☮ you have to save up will be higher. = 
- # Requires translation!
-One of these great prophets can then be used to enhance your religion. = 
- # Requires translation!
-This will allow you to choose another follower belief, as well as an enhancer belief, that only applies to you. = 
- # Requires translation!
-Do take care founding a religion soon, only about half the players in the game are able to found a religion! = 
-
- # Requires translation!
-Beliefs = 
- # Requires translation!
-There are four types of beliefs: Pantheon, Founder, Follower and Enhancer beliefs. = 
- # Requires translation!
-Pantheon and Follower beliefs apply to each city following your religion, while Founder and Enhancer beliefs only apply to the founder of a religion. = 
-
- # Requires translation!
-Religion inside cities = 
- # Requires translation!
-When founding a city, it won't follow a religion immediately. = 
- # Requires translation!
-The religion a city follows depends on the total pressure each religion has within the city. = 
- # Requires translation!
-Followers are allocated in the same proportions as these pressures, and these followers can be viewed in the city screen. = 
- # Requires translation!
-Based on this, you can get a feel for which religions have a lot of pressure built up in the city, and which have almost none. = 
- # Requires translation!
-The city follows a religion if a majority of its population follows that religion, and will only then receive the effects of Follower and Pantheon beliefs of that religion. = 
-
- # Requires translation!
-Spreading Religion = 
- # Requires translation!
-Spreading religion happens naturally, but can be sped up using missionaries or great prophets. = 
- # Requires translation!
-Missionaries can be bought in cities following a major religion, and will take the religion of that city. = 
- # Requires translation!
-So do take care where you are buying them! If another civilization has converted one of your cities to their religion, missionaries bought there will follow their religion. = 
- # Requires translation!
-Great prophets always have your religion when they appear, even if they are bought in cities following other religions, but captured great prophets do retain their original religion. = 
- # Requires translation!
-Both great prophets and missionaries are able to spread religion to cities when they are inside its borders, even cities of other civilizations. = 
- # Requires translation!
-These two units can even enter tiles of civilizations with whom you don't have an open borders agreement! = 
- # Requires translation!
-But do take care, missionaries will lose 250 religious strength each turn they end while in foreign lands. = 
- # Requires translation!
-This diminishes their effectiveness when spreading religion, and if their religious strength ever reaches 0, they have lost their faith and disappear. = 
- # Requires translation!
-When you do spread your religion, the religious strength of the unit is added as pressure for that religion. = 
- # Requires translation!
-Cities also passively add pressure of their majority religion to nearby cities. = 
- # Requires translation!
-Each city provides +6 pressure per turn to all cities within 10 tiles, though the exact amount of pressure depends on the game speed. = 
- # Requires translation!
-This pressure can also be seen in the city screen, and gives you an idea of how religions in your cities will evolve if you don't do anything. = 
- # Requires translation!
-Holy cities also provide +30 pressure of the religion founded there to themselves, making it very difficult to effectively convert a holy city. = 
- # Requires translation!
-Lastly, before founding a religion, new cities you settle will start with 200 pressure for your pantheon. = 
- # Requires translation!
-This way, all your cities will starting following your pantheon as long as you haven't founded a religion yet. = 
-
- # Requires translation!
-Inquisitors = 
- # Requires translation!
-Inquisitors are the last religious unit, and their strength is removing other religions. = 
- # Requires translation!
-They can remove all other religions from one of your own cities, removing any pressures built up. = 
- # Requires translation!
-Great prophets also have this ability, and remove all other religions in the city when spreading their religion. = 
- # Requires translation!
-Often this results in the city immediately converting to their religion = 
- # Requires translation!
-Additionally, when an inquisitor is stationed in or directly next to a city center, units of other religions cannot spread their faith there, though natural spread is uneffected. = 
-
- # Requires translation!
-Maya Long Count calendar cycle = 
- # Requires translation!
-The Mayan unique ability, 'The Long Count', comes with a side effect: = 
- # Requires translation!
-Once active, the game's year display will use mayan notation. = 
- # Requires translation!
-The Maya measured time in days from what we would call 11th of August, 3114 BCE. A day is called K'in, 20 days are a Winal, 18 Winals are a Tun, 20 Tuns are a K'atun, 20 K'atuns are a B'ak'tun, 20 B'ak'tuns a Piktun, and so on. = 
- # Requires translation!
-Unciv only displays ය B'ak'tuns, ඹ K'atuns and ම Tuns (from left to right) since that is enough to approximate gregorian calendar years. The Maya numerals are pretty obvious to understand. Have fun deciphering them! = 
-
- # Requires translation!
-Your cities will periodically demand different luxury goods to satisfy their desire for new things in life. = 
- # Requires translation!
-If you manage to acquire the demanded luxury by trade, expansion, or conquest, the city will celebrate We Love The King Day for 20 turns. = 
- # Requires translation!
-During the We Love The King Day, the city will grow 25% faster. = 
- # Requires translation!
-This means exploration and trade is important to grow your cities! = 
-
+ⓩ: And this is the red targeting circle that led to the attack pane back under ⑬. =


### PR DESCRIPTION
According to a Malay speaker in discord, the current Malay translation contains multiple swear words and other degenerate words, that seem to have been added #3595. These were then removed in #4820, but for some reason that commit was reverted in the next release (3.16.3), for reasons unbeknownst to me. This PR reapplies this same PR, fixing these problems and also adding back 3700 other lines added in #4820. This file has not been touched since, so this does not remove other translations added.
I am, however, not a Malay speaker, so I personally cannot vouch for the correctness of these translations.
Additionally, all lines that have been added since 3.16.3 to be translated, have been removed from this file, making the change seem larger than it really is.
All credit for these changes go to @kyliow.