### PR TITLE
Band-aided a bug where players in multiplayer games were waiting for themselves

### DIFF
--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -120,7 +120,7 @@ class GameInfo {
     }
 
     /** Get a civ by name
-     *  @throws NoSuchElementException if no civ of than name is in the game (alive or dead)! */
+     *  @throws NoSuchElementException if no civ of that name is in the game (alive or dead)! */
     fun getCivilization(civName: String) = civilizations.first { it.civName == civName }
     fun getCurrentPlayerCivilization() = currentPlayerCiv
     fun getCivilizationsAsPreviews() = civilizations.map { it.asPreview() }.toMutableList()

--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -335,7 +335,12 @@ class WorldScreen(val gameInfo: GameInfo, val viewingCiv:CivilizationInfo) : Bas
             val latestGame = OnlineMultiplayer().tryDownloadGame(gameInfo.gameId)
 
             // if we find the current player didn't change, don't update
-            if (gameInfo.currentPlayer == latestGame.currentPlayer) {
+            // Additionally, check if we are the current player, and in that case always stop
+            // This fixes a bug where for some reason players were waiting for themselves.
+            if (gameInfo.currentPlayer == latestGame.currentPlayer 
+                && gameInfo.turns == latestGame.turns 
+                && latestGame.currentPlayer != gameInfo.getPlayerToViewAs().civName
+            ) {
                 Gdx.app.postRunnable { loadingGamePopup.close() }
                 shouldUpdate = true
                 return


### PR DESCRIPTION
A user on discord and @avdstaaij reported they had a multiplayer game in which they were seemingly waiting for their own civilization to finish its turn. This is likely caused by the change in 623420039b9150ad2431a647e1906152a2e4ce94 and the fix applied #5753, combined with the game somehow loading twice. As a result, the player in the loaded game was already the same as the player in the locally stored game, and so the player never got their turn.

This PR fixes this, by specifically always loading the game if the player whose turn it is, is the player currently logged in.
I've also added an extra condition for checking the turn, which may be relevant if the player is making turns on multiple devices, and fixed a typo.

I advise to bring out a patch for this, as this could potentially result in many multiplayer games not being able to continue.