### PR TITLE
Improvements to TurnChecker data usage

### DIFF
--- a/android/src/com/unciv/app/MultiplayerTurnCheckWorker.kt
+++ b/android/src/com/unciv/app/MultiplayerTurnCheckWorker.kt
@@ -16,6 +16,7 @@ import com.unciv.logic.GameInfo
 import com.unciv.logic.GameSaver
 import com.unciv.models.metadata.GameSettings
 import com.unciv.ui.worldscreen.mainmenu.OnlineMultiplayer
+import java.io.FileNotFoundException
 import java.io.PrintWriter
 import java.io.StringWriter
 import java.io.Writer
@@ -175,6 +176,7 @@ class MultiplayerTurnCheckWorker(appContext: Context, workerParams: WorkerParame
                         gameIds[count] = gamePreview.gameId
                         gameNames[count] = gameFile.name()
                         count++
+                    }
                 } catch (ex: Throwable) {
                     //only loadGamePreviewFromFile can throw an exception
                     //nothing will be added to the arrays if it fails

--- a/android/src/com/unciv/app/MultiplayerTurnCheckWorker.kt
+++ b/android/src/com/unciv/app/MultiplayerTurnCheckWorker.kt
@@ -170,11 +170,13 @@ class MultiplayerTurnCheckWorker(appContext: Context, workerParams: WorkerParame
             var count = 0
             for (gameFile in gameFiles) {
                 try {
-                    gameIds[count] = GameSaver.getGameIdFromFile(gameFile)
-                    gameNames[count] = gameFile.name()
-                    count++
+                    val gamePreview = GameSaver.loadGamePreviewFromFile(gameFile)
+                    if (gamePreview.turnNotification) {
+                        gameIds[count] = gamePreview.gameId
+                        gameNames[count] = gameFile.name()
+                        count++
                 } catch (ex: Throwable) {
-                    //only getGameIdFromFile can throw an exception
+                    //only loadGamePreviewFromFile can throw an exception
                     //nothing will be added to the arrays if it fails
                     //just skip one file
                 }
@@ -231,35 +233,45 @@ class MultiplayerTurnCheckWorker(appContext: Context, workerParams: WorkerParame
             var arrayIndex = 0
             // We only want to notify the user or update persisted notification once but still want
             // to download all games to update the files hence this bool
-            var foundGame = false
+            var foundGame = ""
 
             for (gameId in gameIds){
                 //gameId could be an empty string if startTurnChecker fails to load all files
                 if (gameId.isEmpty())
                     continue
 
-                val game = OnlineMultiplayer().tryDownloadGameUninitialized(gameId)
-                val currentTurnPlayer = game.getCivilization(game.currentPlayer)
+                try {
+                    val gamePreview = OnlineMultiplayer().tryDownloadGamePreview(gameId)
+                    val currentTurnPlayer = gamePreview.getCivilization(gamePreview.currentPlayer)
 
-                //Save game so MultiplayerScreen gets updated
-                /*
-                I received multiple reports regarding broken save games.
-                All of them where missing a few thousand chars at the end of the save game.
-                I assume this happened because the TurnCheckerWorker gets canceled by the AndroidLauncher
-                while saves are getting saved right here.
-                 */
-                //GameSaver.saveGame(game, gameNames[arrayIndex], true)
+                    //Save game so MultiplayerScreen gets updated
+                    /*
+                    I received multiple reports regarding broken save games.
+                    All of them where missing a few thousand chars at the end of the save game.
+                    I assume this happened because the TurnCheckerWorker gets canceled by the AndroidLauncher
+                    while saves are getting saved right here.
+                    Lets hope it works with gamePreview as they are a lot smaller and faster to save
+                     */
+                    GameSaver.saveGame(gamePreview, gameNames[arrayIndex])
 
-                if (currentTurnPlayer.playerId == inputData.getString(USER_ID)!!) {
-                    foundGame = true
-                    //As we do not need to look any further we can just break here
-                    break
+                    if (currentTurnPlayer.playerId == inputData.getString(USER_ID)!! && foundGame.isEmpty()) {
+                        // We only save the first found game as the player will go into the
+                        // multiplayer screen anyway to join the game and see the other ones
+                        foundGame = gameNames[arrayIndex]
+                    }
+                    arrayIndex++
+                } catch (ex: FileNotFoundException){
+                    // FileNotFoundException is thrown by OnlineMultiplayer().tryDownloadGamePreview(gameId)
+                    // and indicates that there is no game preview present for this game
+                    // in the dropbox so we should not check for this game in the future anymore
+                    val currentGamePreview = GameSaver.loadGamePreviewByName(gameNames[arrayIndex])
+                    currentGamePreview.turnNotification = false
+                    GameSaver.saveGame(currentGamePreview, gameNames[arrayIndex])
                 }
-                arrayIndex++
             }
 
-            if (foundGame){
-                notifyUserAboutTurn(applicationContext, gameNames[arrayIndex])
+            if (foundGame.isNotEmpty()){
+                notifyUserAboutTurn(applicationContext, foundGame)
                 with(NotificationManagerCompat.from(applicationContext)) {
                     cancel(NOTIFICATION_ID_SERVICE)
                 }

--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -495,4 +495,18 @@ class GameInfoPreview() {
 
         return this
     }
+
+    /**
+     * Updates the current player and turn information in the GameInfoPreview object with the
+     * help of another GameInfoPreview object.
+     */
+    fun updateCurrentTurn(gameInfo: GameInfoPreview) : GameInfoPreview {
+        currentPlayer = gameInfo.currentPlayer
+        turns = gameInfo.turns
+        currentTurnStartTime = gameInfo.currentTurnStartTime
+        //We update the civilizations in case someone is removed from the game (resign/kick)
+        civilizations = gameInfo.civilizations
+
+        return this
+    }
 }

--- a/core/src/com/unciv/logic/GameSaver.kt
+++ b/core/src/com/unciv/logic/GameSaver.kt
@@ -63,14 +63,17 @@ object GameSaver {
         customSaveLocationHelper!!.saveGame(game, GameName, forcePrompt = true, saveCompleteCallback = saveCompletionCallback)
     }
 
-    fun loadGameByName(GameName: String, multiplayer: Boolean = false) =
-            loadGameFromFile(getSave(GameName, multiplayer))
+    fun loadGameByName(GameName: String) =
+            loadGameFromFile(getSave(GameName))
 
     fun loadGameFromFile(gameFile: FileHandle): GameInfo {
         val game = json().fromJson(GameInfo::class.java, gameFile)
         game.setTransients()
         return game
     }
+
+    fun loadGamePreviewByName(GameName: String) =
+            loadGamePreviewFromFile(getSave(GameName, true))
 
     fun loadGamePreviewFromFile(gameFile: FileHandle): GameInfoPreview {
         return json().fromJson(GameInfoPreview::class.java, gameFile)
@@ -167,14 +170,5 @@ object GameSaver {
             val saveToDelete = getAutosaves().minByOrNull { it: FileHandle -> it.lastModified() }!!
             deleteSave(saveToDelete.name())
         }
-    }
-
-    /**
-     * Returns the gameId from a GameInfo which was saved as JSON for multiplayer
-     * Does not initialize transitive GameInfo data.
-     * It is therefore stateless and save to call for Multiplayer Turn Notifier.
-     */
-    fun getGameIdFromFile(gameFile: FileHandle): String {
-        return json().fromJson(GameInfo::class.java, gameFile).gameId
     }
 }

--- a/core/src/com/unciv/ui/multiplayer/MultiplayerScreen.kt
+++ b/core/src/com/unciv/ui/multiplayer/MultiplayerScreen.kt
@@ -153,7 +153,6 @@ class MultiplayerScreen(previousScreen: BaseScreen) : PickerScreen() {
 
                 Gdx.app.postRunnable { reloadGameListUI() }
             } catch (ex: FileNotFoundException) {
-                println("TEST FILENOTFOUND")
                 // Game is so old that a preview could not be found on dropbox lets try the real gameInfo instead
                 try {
                     val gamePreview = OnlineMultiplayer().tryDownloadGame(gameId.trim()).asPreview()

--- a/core/src/com/unciv/ui/worldscreen/mainmenu/DropBox.kt
+++ b/core/src/com/unciv/ui/worldscreen/mainmenu/DropBox.kt
@@ -38,7 +38,12 @@ object DropBox {
             } catch (ex: Exception) {
                 println(ex.message)
                 val reader = BufferedReader(InputStreamReader(errorStream))
-                println(reader.readText())
+                val responseString = reader.readText()
+                println(responseString)
+
+                // Throw Exceptions based on the HTTP response from dropbox
+                if (responseString.contains("path/not_found/"))
+                    throw FileNotFoundException()
                 return null
             } catch (error: Error) {
                 println(error.message)
@@ -144,15 +149,5 @@ class OnlineMultiplayer {
     fun tryDownloadGamePreview(gameId: String): GameInfoPreview {
         val zippedGameInfo = DropBox.downloadFileAsString("${getGameLocation(gameId)}_Preview")
         return GameSaver.gameInfoPreviewFromString(Gzip.unzip(zippedGameInfo))
-    }
-
-    /**
-     * WARNING!
-     * Does not initialize transitive GameInfo data.
-     * It is therefore stateless and safe to call for Multiplayer Turn Notifier, unlike tryDownloadGame().
-     */
-    fun tryDownloadGameUninitialized(gameId: String): GameInfo {
-        val zippedGameInfo = DropBox.downloadFileAsString(getGameLocation(gameId))
-        return GameSaver.gameInfoFromStringWithoutTransients(Gzip.unzip(zippedGameInfo))
     }
 }


### PR DESCRIPTION
Finally implemented the use of GameInfoPreview for the TurnChecker and MultiplayerScreen which I wanted to do almost two months ago. (Oops 😬)

Resolves #5756 as the saving of the files after the TurnChecker download has been reimplemented. I hope it does not make any problems again, but it shouldn't (fingers crossed) since the preview files are way smaller and thus saved faster.
Also closes #5533 as the download size per game is reduced to a few hundred bytes.