### PR TITLE
Shrink maximum Gradle RAM use.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,18 @@
+## For more details on how to configure your build environment visit
+# http://www.gradle.org/docs/current/userguide/build_environment.html
+#
+# Specifies the JVM arguments used for the daemon process.
+# The setting is particularly useful for tweaking memory settings.
+# Default value: -Xmx1024m -XX:MaxPermSize=256m
+# org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+#
+# When configured, Gradle will run in incubating parallel mode.
+# This option should only be used with decoupled projects. More details, visit
+# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
+# org.gradle.parallel=true
+#Mon Dec 13 16:53:36 GMT 2021
+org.gradle.caching=true
+org.gradle.parallel=true
+org.gradle.jvmargs=-Xmx1024M -Dkotlin.daemon.jvm.options\="-Xmx1024M" -XX\:MaxMetaspaceSize\=512m
 android.useAndroidX=true
 android.enableJetifier=true
-org.gradle.parallel=true
-org.gradle.caching=true
-org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=512m


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/37680486/145855250-d2ca81cb-2f6b-4cfd-b6ab-33830fc0ffc1.png)


I mean… 7.5GB just to get a build running in an AVD? Isn't that a bit obscene? I barely managed to run my last PR, and my SSD is just a little bit closer to breaking now for all the processes that ended being pushed into swap.

This is the size I've been using in my feature branch, where I haven't had any problems with it. Maybe release builds might take more? Idk. Android Studio says the default is 1.5GB, though the comments it added to the file seem to say something else.