### PR TITLE
Autogenerate KDocs for Github Pages with Dokka.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,11 @@
 import com.unciv.build.BuildConfig.gdxVersion
-import com.unciv.build.BuildConfig.roboVMVersion
+import com.unciv.build.BuildConfig
+import java.net.URL
 
+plugins {
+    kotlin("jvm") version com.unciv.build.BuildConfig.kotlinVersion
+    id("org.jetbrains.dokka") version (com.unciv.build.BuildConfig.dokkaVersion) apply false
+}
 
 // You'll still get kotlin-reflect-1.3.70.jar in your classpath, but will no longer be used
 configurations.all { resolutionStrategy {
@@ -31,6 +36,8 @@ buildscript {
 
         // This is for wrapping the .jar file into a standalone executable
         classpath("com.github.anuken:packr:-SNAPSHOT")
+
+        classpath("org.jetbrains.dokka:dokka-gradle-plugin:${com.unciv.build.BuildConfig.dokkaVersion}")
     }
 }
         
@@ -55,7 +62,59 @@ allprojects {
         maven { url = uri("https://oss.sonatype.org/content/repositories/releases/") }
         maven{ url = uri("https://jitpack.io") } // for java-discord-rpc
     }
+
+    val subProject = this
+    if (name != "android") {
+        apply(plugin = "org.jetbrains.kotlin.jvm")
+    }
+    apply(plugin = "org.jetbrains.dokka")
+    tasks.withType<org.jetbrains.dokka.gradle.DokkaTaskPartial>().configureEach {
+        // See: https://kotlin.github.io/dokka/1.6.0/user_guide/gradle/usage/#configuration-options
+        suppressInheritedMembers.set(false)
+        suppressObviousFunctions.set(false)
+        offlineMode.set(false)
+        dokkaSourceSets {
+            configureEach {
+                includeNonPublic.set(true)
+//                suppress.set(false)
+                skipDeprecated.set(false) // They're crossed out anyway just like in the official Kotlin docs.
+//                reportUndocumented.set(true)
+                skipEmptyPackages.set(true)
+                platform.set(org.jetbrains.dokka.Platform.jvm)
+//                classpath.from(file(""))
+//                if (subProject.file("Module.md").exists()) { // Works, but honestly I'm not sure it's necessary.
+//                    includes.from("Module.md")
+//                }
+//                samples.from("")
+                sourceLink {
+                    localDirectory.set(file(".")) // I think this is just used to figure out what to append to the GH source URL. Also the source of Gradle warnings.
+                    remoteUrl.set(URL("https://github.com/yairm210/Unciv/tree/master/${rootProject.relativeProjectPath(subProject.name)}"))
+                    remoteLineSuffix.set("#L")
+                }
+                jdkVersion.set(7)
+                noStdlibLink.set(false)
+                noJdkLink.set(false)
+                noAndroidSdkLink.set(false)
+                externalDocumentationLink {
+                    url.set(URL("https://libgdx.badlogicgames.com/ci/nightlies/docs/api/"))
+                }
+                suppressGeneratedFiles.set(false)
+            }
+        }
+    }
 }
+
+apply(plugin = "org.jetbrains.kotlin.jvm")
+apply(plugin = "org.jetbrains.dokka")
+val dokkaPlugin by configurations
+tasks.register<org.jetbrains.dokka.gradle.DokkaMultiModuleTask>("dokkaRoot") {
+    dependencies {
+        dokkaPlugin("org.jetbrains.dokka:all-modules-page-plugin:${com.unciv.build.BuildConfig.dokkaVersion}")
+    }
+    outputDirectory.set(file(BuildConfig.dokkaOutpath))
+    addChildTasks(childProjects.values, "dokkaHtmlPartial")
+}
+
 
 project(":desktop") {
     apply(plugin = "kotlin")
@@ -90,18 +149,18 @@ project(":android") {
     }
 }
 
-project(":ios") {
-    apply(plugin = "kotlin")
-    apply(plugin = "robovm")
-
-    dependencies {
-        "implementation"(project(":core"))
-        "implementation"("com.mobidevelop.robovm:robovm-rt:$roboVMVersion")
-        "implementation"("com.mobidevelop.robovm:robovm-cocoatouch:$roboVMVersion")
-        "implementation"("com.badlogicgames.gdx:gdx-backend-robovm:$gdxVersion")
-        "implementation"("com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-ios")
-    }
-}
+//project(":ios") { // Entire build script got red squigglies on enabling Dokka multimodule, but IOS is explicitly unsupported anyway.
+//    apply(plugin = "kotlin")
+//    apply(plugin = "robovm")
+//
+//    dependencies {
+//        "implementation"(project(":core"))
+//        "implementation"("com.mobidevelop.robovm:robovm-rt:$roboVMVersion")
+//        "implementation"("com.mobidevelop.robovm:robovm-cocoatouch:$roboVMVersion")
+//        "implementation"("com.badlogicgames.gdx:gdx-backend-robovm:$gdxVersion")
+//        "implementation"("com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-ios")
+//    }
+//}
 
 
 project(":core") {

--- a/buildSrc/src/main/kotlin/BuildConfig.kt
+++ b/buildSrc/src/main/kotlin/BuildConfig.kt
@@ -8,4 +8,7 @@ object BuildConfig {
 
     const val gdxVersion = "1.10.0"
     const val roboVMVersion = "2.3.1"
+
+    const val dokkaVersion = "1.5.30"
+    const val dokkaOutpath = "docs/dokka/"
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,16 @@
+[Main repository](https://github.com/yairm210/Unciv)
+
+---
+
+[Credits.md](Credits)
+
+[Game Making Tips.md](Game%20Making%20Tips)
+
+[Uniques.md](uniques)
+
+---
+
+[API Docs](dokka/)
+
+* [ScriptingScope](dokka/core/com.unciv.scripting.api/-scripting-scope/)
+

--- a/ios/build.gradle.kts
+++ b/ios/build.gradle.kts
@@ -1,3 +1,5 @@
+// Entire build script got red squigglies on enabling Dokka multimodule, but IOS is explicitly unsupported anyway.
+/*
 import com.android.build.gradle.internal.tasks.factory.dependsOn
 import com.unciv.build.BuildConfig
 
@@ -37,3 +39,4 @@ eclipse.project {
     name = "${BuildConfig.appName}-ios"
     natures("org.robovm.eclipse.RoboVMNature")
 }
+*/


### PR DESCRIPTION
Why? The direct reason is that I realized the other day that a way of specifying reflective operations I added early on in the scripting API branch is actually a domain-specific language that itself can already be used for a significant amount of scripting, so I'm probably going to be able to have a (series of many) PR(s) ready for Android-compatible mod-scripted event handlers somewhat sooner than I'd originally expected— Which means that I should also make sure there's a way for modders to explore the APIs available to them in scripting languages without having to dig through or read the Kotlin code.

But aside from there, there's also been a couple times while I was coding where I thought it would be helpful if I could get an overview of a class's members without having to find it in the source.

The generated HTML includes links to Github sources, Kotlin docs, Java 7 docs, Android SDK docs, and GDX docs, where applicable.

Example output currently hosted at the GH page of my fork:

https://will-ca.github.io/Unciv/dokka/

To generate/update docs:

```bash
$ ./gradlew dokkaRoot
```

The final assembled web files go into `/docs/dokka/`, as that can easily be exposed by Github Pages. Intermediate files stay in `build/` in each subproject.

Dokka takes up to a couple minutes for this project, so it's probably best to like, either manually or automatically update the docs before every major release or something.

HTML output from Dokka currently works best with an HTTP server. The one that comes with Python can be used for testing. This should expose the same directories as do Github pages:

```bash
$ python3 -m http.server 8000 --bind 127.0.0.1 -d docs
```

Then go to `http://localhost:8000/dokka/` to view them.

~~A separate PR will include the docs as web files.~~ Actually, no. No need to PR 100K LoC of opaque code when it can just be generated from this one.

Recommend: Making a separate `dokka-html` branch in this repository, running the task only in there so the `master` branch history and forks aren't bombarded with millions of lines of HTML, and setting the Github pages of the project to point there:

![image](https://user-images.githubusercontent.com/37680486/146247454-45a865d7-95cd-4299-8f19-90c8ecc319c4.png)