### PR TITLE
Add new universal crash handlers and error reporting screen.

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -42,7 +42,7 @@ You can also report this on the issue tracker. =
 Copy = 
 Error report copied. = 
 Open Issue Tracker = 
-Please copy the error message first. = 
+Please copy the error report first. = 
 Close Unciv = 
 
 # Buildings

--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -34,6 +34,17 @@ See your stats breakdown!\nEnter the Overview screen (top right corner) >\nClick
 Oh no! It looks like something went DISASTROUSLY wrong! This is ABSOLUTELY not supposed to happen! Please send me (yairm210@hotmail.com) an email with the game information (menu -> save game -> copy game info -> paste into email) and I'll try to fix it as fast as I can! = 
 Oh no! It looks like something went DISASTROUSLY wrong! This is ABSOLUTELY not supposed to happen! Please send us an report and we'll try to fix it as fast as we can! = 
 
+# Crash screen
+
+An unrecoverable error has occurred in Unciv: = 
+If this keeps happening, you can try disabling mods. = 
+You can also report this on the issue tracker. = 
+Copy = 
+Error report copied. = 
+Open Issue Tracker = 
+Please copy the error message first. = 
+Close Unciv = 
+
 # Buildings
 
 Unsellable = 

--- a/core/src/com/unciv/CrashHandlingStage.kt
+++ b/core/src/com/unciv/CrashHandlingStage.kt
@@ -6,7 +6,7 @@ import com.badlogic.gdx.utils.viewport.Viewport
 import com.unciv.ui.utils.*
 
 /** Stage that safely brings the game to a [CrashScreen] if any event handlers throw an exception or an error that doesn't get otherwise handled. */
-class SafeCrashStage: Stage {
+class CrashHandlingStage: Stage {
     constructor(): super()
     constructor(viewport: Viewport): super(viewport)
     constructor(viewport: Viewport, batch: Batch) : super(viewport, batch)

--- a/core/src/com/unciv/CrashHandlingStage.kt
+++ b/core/src/com/unciv/CrashHandlingStage.kt
@@ -38,9 +38,14 @@ class CrashHandlingStage: Stage {
 
 // Another stack trace from an exception after setting TileInfo.naturalWonder to an invalid value is below that.
 
+// Below that are another two exceptions from a lambda given to Gdx.app.postRunnable{} and another to thread{}.
+
 // Stage()'s event handlers seem to be the most universal place to intercept exceptions from events.
 
 // Events and the render loop are the main ways that code gets run with GDX, right? So if we wrap both of those in exception handling, it should hopefully gracefully catch most unhandled exceptions… Threads may be the exception, hence why I put the wrapping as extension functions that can be invoked on the lambdas passed to threads.
+
+
+// Button click (event):
 
 /*
 Exception in thread "main" com.badlogic.gdx.utils.GdxRuntimeException: java.lang.Exception
@@ -79,6 +84,8 @@ E/AndroidRuntime: FATAL EXCEPTION: GLThread 299
         at android.opengl.GLSurfaceView$GLThread.run(GLSurfaceView.java:1239)
  */
 
+// Invalid Natural Wonder (rendering):
+
 /*
 Exception in thread "main" java.lang.NullPointerException
         at com.unciv.logic.map.TileInfo.getNaturalWonder(TileInfo.kt:149)
@@ -93,4 +100,26 @@ Exception in thread "main" java.lang.NullPointerException
         at com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application.loop(Lwjgl3Application.java:143)
         at com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application.<init>(Lwjgl3Application.java:116)
         at com.unciv.app.desktop.DesktopLauncher.main(DesktopLauncher.kt:61)
+ */
+
+// Thread:
+
+/*
+Exception in thread "Thread-5" java.lang.Exception
+        at com.unciv.MainMenuScreen$newGameButton$1$1.invoke(MainMenuScreen.kt:107)
+        at com.unciv.MainMenuScreen$newGameButton$1$1.invoke(MainMenuScreen.kt:107)
+        at kotlin.concurrent.ThreadsKt$thread$thread$1.run(Thread.kt:30)
+ */
+
+// Gdx.app.postRunnable:
+
+/*
+Exception in thread "main" com.badlogic.gdx.utils.GdxRuntimeException: java.lang.Exception
+        at com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application.<init>(Lwjgl3Application.java:122)
+        at com.unciv.app.desktop.DesktopLauncher.main(DesktopLauncher.kt:61)
+Caused by: java.lang.Exception
+        at com.unciv.MainMenuScreen$loadGameTable$1.invoke$lambda-0(MainMenuScreen.kt:112)
+        at com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application.loop(Lwjgl3Application.java:159)
+        at com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application.<init>(Lwjgl3Application.java:116)
+        ... 1 more
  */

--- a/core/src/com/unciv/CrashScreen.kt
+++ b/core/src/com/unciv/CrashScreen.kt
@@ -26,6 +26,7 @@ class CrashScreen(message: String): BaseScreen() {
     val text = generateReportHeader() + message
 
     var copied = false
+        private set
 
     fun generateReportHeader(): String {
         return """
@@ -69,8 +70,8 @@ class CrashScreen(message: String): BaseScreen() {
             ).padTop(15f)
                 .width(stage.width)
                 .row()
-            layoutTable.add(Table().also { table ->
-                table.add(
+            layoutTable.add(Table().also { buttonsTable ->
+                buttonsTable.add(
                     "Copy".toButton()
                         .onClick {
                             Gdx.app.clipboard.contents = text
@@ -81,7 +82,7 @@ class CrashScreen(message: String): BaseScreen() {
                             )
                         }
                 ).pad(10f)
-                table.add(
+                buttonsTable.add(
                     "Open Issue Tracker".toButton(icon = "OtherIcons/Link")
                         .onClick {
                             if (copied) {
@@ -96,10 +97,10 @@ class CrashScreen(message: String): BaseScreen() {
                 ).pad(10f).also {
                     if (isCrampedPortrait()) {
                         it.row()
-                        table.add()
+                        buttonsTable.add()
                     }
                 }
-                table.add(
+                buttonsTable.add(
                     "Close Unciv".toButton()
                         .onClick {
                             Gdx.app.exit()

--- a/core/src/com/unciv/CrashScreen.kt
+++ b/core/src/com/unciv/CrashScreen.kt
@@ -13,6 +13,7 @@ import java.io.StringWriter
 
 /** Screen to crash to when an otherwise unhandled exception or error is thrown. */
 class CrashScreen(message: String): BaseScreen() {
+    constructor(exception: Throwable): this(exception.stringify())
 
     private companion object {
         fun Throwable.stringify(): String {
@@ -22,10 +23,7 @@ class CrashScreen(message: String): BaseScreen() {
         }
     }
 
-    constructor(exception: Throwable): this(exception.stringify())
-
     val text = generateReportHeader() + message
-
     var copied = false
         private set
 
@@ -50,37 +48,27 @@ class CrashScreen(message: String): BaseScreen() {
             it.width = stage.width
             it.height = stage.height
         }
-
-        layoutTable.add(
-            makeTitleLabel()
-        ).padBottom(15f)
+        layoutTable.add(makeTitleLabel())
+            .padBottom(15f)
             .width(stage.width)
             .row()
-
-        layoutTable.add(
-            makeErrorScroll()
-        ).maxWidth(stage.width * 0.7f)
+        layoutTable.add(makeErrorScroll())
+            .maxWidth(stage.width * 0.7f)
             .maxHeight(stage.height * 0.5f)
             .minHeight(stage.height * 0.2f)
             .row()
-
-        layoutTable.add(
-            makeInstructionLabel()
-        ).padTop(15f)
+        layoutTable.add(makeInstructionLabel())
+            .padTop(15f)
             .width(stage.width)
             .row()
-
-        layoutTable.add(
-            makeActionButtonsTable()
-        ).padTop(10f)
-
+        layoutTable.add(makeActionButtonsTable())
+            .padTop(10f)
         return layoutTable
     }
 
     /** @return Label for title at top of screen. */
     private fun makeTitleLabel()
-        = "An unrecoverable error has occurred in Unciv:"
-        .toLabel(fontSize = 24)
+        = "An unrecoverable error has occurred in Unciv:".toLabel(fontSize = 24)
         .apply {
             wrap = true
             setAlignment(Align.center)
@@ -92,18 +80,15 @@ class CrashScreen(message: String): BaseScreen() {
             setFontSize(15)
         }
         val errorTable = Table()
-        errorTable.add(
-            errorLabel
-        ).pad(10f)
-        return AutoScrollPane(
-            errorTable
-        ).addBorder(4f, Color.DARK_GRAY)
+        errorTable.add(errorLabel)
+            .pad(10f)
+        return AutoScrollPane(errorTable)
+            .addBorder(4f, Color.DARK_GRAY)
     }
 
     /** @return Label to give the user more information and context below the error report. */
     private fun makeInstructionLabel()
-        = "{If this keeps happening, you can try disabling mods.}\n{You can also report this on the issue tracker.}"
-        .toLabel()
+        = "{If this keeps happening, you can try disabling mods.}\n{You can also report this on the issue tracker.}".toLabel()
         .apply {
             wrap = true
             setAlignment(Align.center)
@@ -111,9 +96,7 @@ class CrashScreen(message: String): BaseScreen() {
 
     /** @return Table that displays decision buttons for the bottom of the screen. */
     private fun makeActionButtonsTable(): Table {
-        val copyButton
-            = "Copy"
-            .toButton()
+        val copyButton = "Copy".toButton()
             .onClick {
                 Gdx.app.clipboard.contents = text
                 copied = true
@@ -122,9 +105,7 @@ class CrashScreen(message: String): BaseScreen() {
                     this@CrashScreen
                 )
             }
-        val reportButton
-            = "Open Issue Tracker"
-            .toButton(icon = "OtherIcons/Link")
+        val reportButton = "Open Issue Tracker".toButton(icon = "OtherIcons/Link")
             .onClick {
                 if (copied) {
                     Gdx.net.openURI("https://github.com/yairm210/Unciv/issues")
@@ -135,8 +116,7 @@ class CrashScreen(message: String): BaseScreen() {
                     )
                 }
             }
-        val closeButton
-            = "Close Unciv".toButton()
+        val closeButton = "Close Unciv".toButton()
             .onClick {
                 Gdx.app.exit()
             }

--- a/core/src/com/unciv/CrashScreen.kt
+++ b/core/src/com/unciv/CrashScreen.kt
@@ -1,0 +1,112 @@
+package com.unciv
+
+import com.badlogic.gdx.Gdx
+import com.badlogic.gdx.graphics.Color
+import com.badlogic.gdx.scenes.scene2d.ui.Label
+import com.badlogic.gdx.scenes.scene2d.ui.Table
+import com.badlogic.gdx.utils.Align
+import com.unciv.models.ruleset.RulesetCache
+import com.unciv.ui.utils.*
+import java.io.PrintWriter
+import java.io.StringWriter
+
+/** Screen to crash to when an otherwise unhandled exception or error is thrown. */
+class CrashScreen(message: String): BaseScreen() {
+
+    private companion object {
+        fun Throwable.stringify(): String {
+            val out = StringWriter()
+            this.printStackTrace(PrintWriter(out))
+            return out.toString()
+        }
+    }
+
+    constructor(exception: Throwable): this(exception.stringify())
+
+    val text = generateReportHeader() + message
+
+    var copied = false
+
+    fun generateReportHeader(): String {
+        return """
+            Platform: ${Gdx.app.type}
+            Version: ${UncivGame.Current.version}
+            Rulesets: ${RulesetCache.keys}
+            
+            
+            """.trimIndent()
+    }
+
+    init {
+        println(text) // Also print to system terminal.
+        stage.addActor(Table().also { layoutTable ->
+        layoutTable.width = stage.width
+            layoutTable.height = stage.height
+            layoutTable.add(
+                "An unrecoverable error has occurred in Unciv:".toLabel(fontSize = 24).also {
+                    it.wrap = true
+                    it.setAlignment(Align.center)
+                }
+            ).padBottom(15f)
+                .width(stage.width)
+                .row()
+            layoutTable.add(
+                AutoScrollPane(Table().also {
+                    it.add(Label(text, skin).apply {
+                        setFontSize(15)
+                    }).pad(10f)
+                        .row()
+                }).addBorder(4f, Color.DARK_GRAY)
+            ).maxWidth(stage.width * 0.7f)
+                .maxHeight(stage.height * 0.5f)
+                .minHeight(stage.height * 0.2f)
+                .row()
+            layoutTable.add(
+                "{If this keeps happening, you can try disabling mods.}\n{You can also report this on the issue tracker.}".toLabel().also {
+                    it.wrap = true
+                    it.setAlignment(Align.center)
+                }
+            ).padTop(15f)
+                .width(stage.width)
+                .row()
+            layoutTable.add(Table().also { table ->
+                table.add(
+                    "Copy".toButton()
+                        .onClick {
+                            Gdx.app.clipboard.contents = text
+                            copied = true
+                            ToastPopup(
+                                "Error report copied.",
+                                this@CrashScreen
+                            )
+                        }
+                ).pad(10f)
+                table.add(
+                    "Open Issue Tracker".toButton(icon = "OtherIcons/Link")
+                        .onClick {
+                            if (copied) {
+                                Gdx.net.openURI("https://github.com/yairm210/Unciv/issues")
+                            } else {
+                                ToastPopup(
+                                    "Please copy the error message first.",
+                                    this@CrashScreen
+                                )
+                            }
+                        }
+                ).pad(10f).also {
+                    if (isCrampedPortrait()) {
+                        it.row()
+                        table.add()
+                    }
+                }
+                table.add(
+                    "Close Unciv".toButton()
+                        .onClick {
+                            Gdx.app.exit()
+                        }
+                ).pad(10f)
+            }).padTop(10f)
+        })
+
+    }
+}

--- a/core/src/com/unciv/CrashScreen.kt
+++ b/core/src/com/unciv/CrashScreen.kt
@@ -2,6 +2,7 @@ package com.unciv
 
 import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.graphics.Color
+import com.badlogic.gdx.scenes.scene2d.Actor
 import com.badlogic.gdx.scenes.scene2d.ui.Label
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.utils.Align
@@ -40,74 +41,120 @@ class CrashScreen(message: String): BaseScreen() {
 
     init {
         println(text) // Also print to system terminal.
-        stage.addActor(Table().also { layoutTable ->
-        layoutTable.width = stage.width
-            layoutTable.height = stage.height
-            layoutTable.add(
-                "An unrecoverable error has occurred in Unciv:".toLabel(fontSize = 24).also {
-                    it.wrap = true
-                    it.setAlignment(Align.center)
-                }
-            ).padBottom(15f)
-                .width(stage.width)
-                .row()
-            layoutTable.add(
-                AutoScrollPane(Table().also {
-                    it.add(Label(text, skin).apply {
-                        setFontSize(15)
-                    }).pad(10f)
-                        .row()
-                }).addBorder(4f, Color.DARK_GRAY)
-            ).maxWidth(stage.width * 0.7f)
-                .maxHeight(stage.height * 0.5f)
-                .minHeight(stage.height * 0.2f)
-                .row()
-            layoutTable.add(
-                "{If this keeps happening, you can try disabling mods.}\n{You can also report this on the issue tracker.}".toLabel().also {
-                    it.wrap = true
-                    it.setAlignment(Align.center)
-                }
-            ).padTop(15f)
-                .width(stage.width)
-                .row()
-            layoutTable.add(Table().also { buttonsTable ->
-                buttonsTable.add(
-                    "Copy".toButton()
-                        .onClick {
-                            Gdx.app.clipboard.contents = text
-                            copied = true
-                            ToastPopup(
-                                "Error report copied.",
-                                this@CrashScreen
-                            )
-                        }
-                ).pad(10f)
-                buttonsTable.add(
-                    "Open Issue Tracker".toButton(icon = "OtherIcons/Link")
-                        .onClick {
-                            if (copied) {
-                                Gdx.net.openURI("https://github.com/yairm210/Unciv/issues")
-                            } else {
-                                ToastPopup(
-                                    "Please copy the error report first.",
-                                    this@CrashScreen
-                                )
-                            }
-                        }
-                ).pad(10f).also {
-                    if (isCrampedPortrait()) {
-                        it.row()
-                        buttonsTable.add()
-                    }
-                }
-                buttonsTable.add(
-                    "Close Unciv".toButton()
-                        .onClick {
-                            Gdx.app.exit()
-                        }
-                ).pad(10f)
-            }).padTop(10f)
-        })
+        stage.addActor(makeLayoutTable())
+    }
 
+    /** @return A Table containing the layout of the whole screen. */
+    private fun makeLayoutTable(): Table {
+        val layoutTable = Table().also {
+            it.width = stage.width
+            it.height = stage.height
+        }
+
+        layoutTable.add(
+            makeTitleLabel()
+        ).padBottom(15f)
+            .width(stage.width)
+            .row()
+
+        layoutTable.add(
+            makeErrorScroll()
+        ).maxWidth(stage.width * 0.7f)
+            .maxHeight(stage.height * 0.5f)
+            .minHeight(stage.height * 0.2f)
+            .row()
+
+        layoutTable.add(
+            makeInstructionLabel()
+        ).padTop(15f)
+            .width(stage.width)
+            .row()
+
+        layoutTable.add(
+            makeActionButtonsTable()
+        ).padTop(10f)
+
+        return layoutTable
+    }
+
+    /** @return Label for title at top of screen. */
+    private fun makeTitleLabel()
+        = "An unrecoverable error has occurred in Unciv:"
+        .toLabel(fontSize = 24)
+        .apply {
+            wrap = true
+            setAlignment(Align.center)
+        }
+
+    /** @return Actor that displays a scrollable view of the error report text. */
+    private fun makeErrorScroll(): Actor {
+        val errorLabel = Label(text, skin).apply {
+            setFontSize(15)
+        }
+        val errorTable = Table()
+        errorTable.add(
+            errorLabel
+        ).pad(10f)
+        return AutoScrollPane(
+            errorTable
+        ).addBorder(4f, Color.DARK_GRAY)
+    }
+
+    /** @return Label to give the user more information and context below the error report. */
+    private fun makeInstructionLabel()
+        = "{If this keeps happening, you can try disabling mods.}\n{You can also report this on the issue tracker.}"
+        .toLabel()
+        .apply {
+            wrap = true
+            setAlignment(Align.center)
+        }
+
+    /** @return Table that displays decision buttons for the bottom of the screen. */
+    private fun makeActionButtonsTable(): Table {
+        val copyButton
+            = "Copy"
+            .toButton()
+            .onClick {
+                Gdx.app.clipboard.contents = text
+                copied = true
+                ToastPopup(
+                    "Error report copied.",
+                    this@CrashScreen
+                )
+            }
+        val reportButton
+            = "Open Issue Tracker"
+            .toButton(icon = "OtherIcons/Link")
+            .onClick {
+                if (copied) {
+                    Gdx.net.openURI("https://github.com/yairm210/Unciv/issues")
+                } else {
+                    ToastPopup(
+                        "Please copy the error report first.",
+                        this@CrashScreen
+                    )
+                }
+            }
+        val closeButton
+            = "Close Unciv".toButton()
+            .onClick {
+                Gdx.app.exit()
+            }
+
+        val buttonsTable = Table()
+        buttonsTable.add(copyButton)
+            .pad(10f)
+        buttonsTable.add(reportButton)
+            .pad(10f)
+            .also {
+                if (isCrampedPortrait()) {
+                    it.row()
+                    buttonsTable.add()
+                }
+            }
+        buttonsTable.add(closeButton)
+            .pad(10f)
+
+        return buttonsTable
     }
 }

--- a/core/src/com/unciv/CrashScreen.kt
+++ b/core/src/com/unciv/CrashScreen.kt
@@ -89,7 +89,7 @@ class CrashScreen(message: String): BaseScreen() {
                                 Gdx.net.openURI("https://github.com/yairm210/Unciv/issues")
                             } else {
                                 ToastPopup(
-                                    "Please copy the error message first.",
+                                    "Please copy the error report first.",
                                     this@CrashScreen
                                 )
                             }

--- a/core/src/com/unciv/SafeCrashStage.kt
+++ b/core/src/com/unciv/SafeCrashStage.kt
@@ -1,0 +1,96 @@
+package com.unciv
+
+import com.badlogic.gdx.graphics.g2d.Batch
+import com.badlogic.gdx.scenes.scene2d.Stage
+import com.badlogic.gdx.utils.viewport.Viewport
+import com.unciv.ui.utils.*
+
+/** Stage that safely brings the game to a [CrashScreen] if any event handlers throw an exception or an error that doesn't get otherwise handled. */
+class SafeCrashStage: Stage {
+    constructor(): super()
+    constructor(viewport: Viewport): super(viewport)
+    constructor(viewport: Viewport, batch: Batch) : super(viewport, batch)
+
+    override fun draw() = { super.draw() }.wrapCrashHandlingUnit()()
+    override fun act() = { super.act() }.wrapCrashHandlingUnit()()
+    override fun act(delta: Float) = { super.act(delta) }.wrapCrashHandlingUnit()()
+
+    override fun touchDown(screenX: Int, screenY: Int, pointer: Int, button: Int)
+        = { super.touchDown(screenX, screenY, pointer, button) }.wrapCrashHandling()() ?: true
+    override fun touchDragged(screenX: Int, screenY: Int, pointer: Int)
+        = { super.touchDragged(screenX, screenY, pointer) }.wrapCrashHandling()() ?: true
+    override fun touchUp(screenX: Int, screenY: Int, pointer: Int, button: Int)
+        = { super.touchUp(screenX, screenY, pointer, button) }.wrapCrashHandling()() ?: true
+    override fun mouseMoved(screenX: Int, screenY: Int)
+        = { super.mouseMoved(screenX, screenY) }.wrapCrashHandling()() ?: true
+    override fun scrolled(amountX: Float, amountY: Float)
+        = { super.scrolled(amountX, amountY) }.wrapCrashHandling()() ?: true
+    override fun keyDown(keyCode: Int)
+        = { super.keyDown(keyCode) }.wrapCrashHandling()() ?: true
+    override fun keyUp(keyCode: Int)
+        = { super.keyUp(keyCode) }.wrapCrashHandling()() ?: true
+    override fun keyTyped(character: Char)
+        = { super.keyTyped(character) }.wrapCrashHandling()() ?: true
+
+}
+
+// Example Stack traces from unhandled exceptions after a button click on Desktop and on Android are below.
+
+// Another stack trace from an exception after setting TileInfo.naturalWonder to an invalid value is below that.
+
+// Stage()'s event handlers seem to be the most universal place to intercept exceptions from events.
+
+// Events and the render loop are the main ways that code gets run with GDX, right? So if we wrap both of those in exception handling, it should hopefully gracefully catch most unhandled exceptions… Threads may be the exception, hence why I put the wrapping as extension functions that can be invoked on the lambdas passed to threads.
+
+/*
+Exception in thread "main" com.badlogic.gdx.utils.GdxRuntimeException: java.lang.Exception
+        at com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application.<init>(Lwjgl3Application.java:122)
+        at com.unciv.app.desktop.DesktopLauncher.main(DesktopLauncher.kt:61)
+Caused by: java.lang.Exception
+        at com.unciv.MainMenuScreen$newGameButton$1.invoke(MainMenuScreen.kt:107)
+        at com.unciv.MainMenuScreen$newGameButton$1.invoke(MainMenuScreen.kt:106)
+        at com.unciv.ui.utils.ExtensionFunctionsKt$onClick$1.invoke(ExtensionFunctions.kt:64)
+        at com.unciv.ui.utils.ExtensionFunctionsKt$onClick$1.invoke(ExtensionFunctions.kt:64)
+        at com.unciv.ui.utils.ExtensionFunctionsKt$onClickEvent$1.clicked(ExtensionFunctions.kt:57)
+        at com.badlogic.gdx.scenes.scene2d.utils.ClickListener.touchUp(ClickListener.java:88)
+        at com.badlogic.gdx.scenes.scene2d.InputListener.handle(InputListener.java:71)
+        at com.badlogic.gdx.scenes.scene2d.Stage.touchUp(Stage.java:355)
+        at com.badlogic.gdx.InputEventQueue.drain(InputEventQueue.java:70)
+        at com.badlogic.gdx.backends.lwjgl3.DefaultLwjgl3Input.update(DefaultLwjgl3Input.java:189)
+        at com.badlogic.gdx.backends.lwjgl3.Lwjgl3Window.update(Lwjgl3Window.java:394)
+        at com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application.loop(Lwjgl3Application.java:143)
+        at com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application.<init>(Lwjgl3Application.java:116)
+        ... 1 more
+
+E/AndroidRuntime: FATAL EXCEPTION: GLThread 299
+    Process: com.unciv.app, PID: 5910
+    java.lang.Exception
+        at com.unciv.MainMenuScreen$newGameButton$1.invoke(MainMenuScreen.kt:107)
+        at com.unciv.MainMenuScreen$newGameButton$1.invoke(MainMenuScreen.kt:106)
+        at com.unciv.ui.utils.ExtensionFunctionsKt$onClick$1.invoke(ExtensionFunctions.kt:64)
+        at com.unciv.ui.utils.ExtensionFunctionsKt$onClick$1.invoke(ExtensionFunctions.kt:64)
+        at com.unciv.ui.utils.ExtensionFunctionsKt$onClickEvent$1.clicked(ExtensionFunctions.kt:57)
+        at com.badlogic.gdx.scenes.scene2d.utils.ClickListener.touchUp(ClickListener.java:88)
+        at com.badlogic.gdx.scenes.scene2d.InputListener.handle(InputListener.java:71)
+        at com.badlogic.gdx.scenes.scene2d.Stage.touchUp(Stage.java:355)
+        at com.badlogic.gdx.backends.android.DefaultAndroidInput.processEvents(DefaultAndroidInput.java:425)
+        at com.badlogic.gdx.backends.android.AndroidGraphics.onDrawFrame(AndroidGraphics.java:469)
+        at android.opengl.GLSurfaceView$GLThread.guardedRun(GLSurfaceView.java:1522)
+        at android.opengl.GLSurfaceView$GLThread.run(GLSurfaceView.java:1239)
+ */
+
+/*
+Exception in thread "main" java.lang.NullPointerException
+        at com.unciv.logic.map.TileInfo.getNaturalWonder(TileInfo.kt:149)
+        at com.unciv.logic.map.TileInfo.getTileStats(TileInfo.kt:255)
+        at com.unciv.logic.map.TileInfo.getTileStats(TileInfo.kt:240)
+        at com.unciv.ui.worldscreen.bottombar.TileInfoTable.getStatsTable(TileInfoTable.kt:43)
+        at com.unciv.ui.worldscreen.bottombar.TileInfoTable.updateTileTable$core(TileInfoTable.kt:25)
+        at com.unciv.ui.worldscreen.WorldScreen.update(WorldScreen.kt:383)
+        at com.unciv.ui.worldscreen.WorldScreen.render(WorldScreen.kt:828)
+        at com.badlogic.gdx.Game.render(Game.java:46)
+        at com.badlogic.gdx.backends.lwjgl3.Lwjgl3Window.update(Lwjgl3Window.java:403)
+        at com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application.loop(Lwjgl3Application.java:143)
+        at com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application.<init>(Lwjgl3Application.java:116)
+        at com.unciv.app.desktop.DesktopLauncher.main(DesktopLauncher.kt:61)
+ */

--- a/core/src/com/unciv/UncivGame.kt
+++ b/core/src/com/unciv/UncivGame.kt
@@ -65,7 +65,7 @@ class UncivGame(parameters: UncivGameParameters) : Game() {
     var isInitialized = false
 
     /** A wrapped render() method that crashes to [CrashScreen] on a unhandled exception or error. */
-    val wrappedCrashHandlingingRender = { super.render() }.wrapCrashHandlingUnit()
+    private val wrappedCrashHandlingRender = { super.render() }.wrapCrashHandlingUnit()
     // Stored here because I imagine that might be slightly faster than allocating for a new lambda every time, and the render loop is possibly one of the only places where that could have a significant impact.
 
 
@@ -173,7 +173,7 @@ class UncivGame(parameters: UncivGameParameters) : Game() {
         screen.resize(width, height)
     }
 
-    override fun render() = wrappedCrashHandlingingRender()
+    override fun render() = wrappedCrashHandlingRender()
 
     override fun dispose() {
         cancelDiscordEvent?.invoke()

--- a/core/src/com/unciv/UncivGame.kt
+++ b/core/src/com/unciv/UncivGame.kt
@@ -22,6 +22,8 @@ import com.unciv.ui.worldscreen.WorldScreen
 import java.util.*
 import kotlin.concurrent.thread
 
+
+
 class UncivGame(parameters: UncivGameParameters) : Game() {
     // we need this secondary constructor because Java code for iOS can't handle Kotlin lambda parameters
     constructor(version: String) : this(UncivGameParameters(version, null))
@@ -61,6 +63,10 @@ class UncivGame(parameters: UncivGameParameters) : Game() {
     lateinit var worldScreen: WorldScreen
 
     var isInitialized = false
+
+    /** A wrapped render() method that crashes to [CrashScreen] on a unhandled exception or error. */
+    val wrappedCrashHandlingingRender = { super.render() }.wrapCrashHandlingUnit()
+    // Stored here because I imagine that might be slightly faster than allocating for a new lambda every time, and the render loop is possibly one of the only places where that could have a significant impact.
 
 
     val translations = Translations()
@@ -166,6 +172,8 @@ class UncivGame(parameters: UncivGameParameters) : Game() {
     override fun resize(width: Int, height: Int) {
         screen.resize(width, height)
     }
+
+    override fun render() = wrappedCrashHandlingingRender()
 
     override fun dispose() {
         cancelDiscordEvent?.invoke()

--- a/core/src/com/unciv/ui/utils/BaseScreen.kt
+++ b/core/src/com/unciv/ui/utils/BaseScreen.kt
@@ -11,7 +11,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.*
 import com.badlogic.gdx.scenes.scene2d.utils.Drawable
 import com.badlogic.gdx.utils.viewport.ExtendViewport
 import com.unciv.MainMenuScreen
-import com.unciv.SafeCrashStage
+import com.unciv.CrashHandlingStage
 import com.unciv.UncivGame
 import com.unciv.models.Tutorial
 import com.unciv.ui.tutorials.TutorialController
@@ -33,7 +33,7 @@ open class BaseScreen : Screen {
         val height = resolutions[1]
 
         /** The ExtendViewport sets the _minimum_(!) world size - the actual world size will be larger, fitted to screen/window aspect ratio. */
-        stage = SafeCrashStage(ExtendViewport(height, height), SpriteBatch())
+        stage = CrashHandlingStage(ExtendViewport(height, height), SpriteBatch())
 
         if (enableSceneDebug) {
             stage.setDebugUnderMouse(true)

--- a/core/src/com/unciv/ui/utils/BaseScreen.kt
+++ b/core/src/com/unciv/ui/utils/BaseScreen.kt
@@ -11,6 +11,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.*
 import com.badlogic.gdx.scenes.scene2d.utils.Drawable
 import com.badlogic.gdx.utils.viewport.ExtendViewport
 import com.unciv.MainMenuScreen
+import com.unciv.SafeCrashStage
 import com.unciv.UncivGame
 import com.unciv.models.Tutorial
 import com.unciv.ui.tutorials.TutorialController
@@ -32,7 +33,7 @@ open class BaseScreen : Screen {
         val height = resolutions[1]
 
         /** The ExtendViewport sets the _minimum_(!) world size - the actual world size will be larger, fitted to screen/window aspect ratio. */
-        stage = Stage(ExtendViewport(height, height), SpriteBatch())
+        stage = SafeCrashStage(ExtendViewport(height, height), SpriteBatch())
 
         if (enableSceneDebug) {
             stage.setDebugUnderMouse(true)

--- a/core/src/com/unciv/ui/utils/ExtensionFunctions.kt
+++ b/core/src/com/unciv/ui/utils/ExtensionFunctions.kt
@@ -317,6 +317,7 @@ object UncivDateFormat {
  * In case an exception or error is thrown, the return will be null. Therefore the return type is always nullable.
  *
  * @param postToMainThread Whether the [CrashScreen] should be opened by posting a runnable to the main thread, instead of directly. Set this to true if the function is going to run on any thread other than the main loop.
+ * @return Result from the function, or null if an exception is thrown.
  * */
 fun <R> (() -> R).wrapCrashHandling(postToMainThread: Boolean = false): () -> R? = {
         try {
@@ -339,4 +340,5 @@ fun <R> (() -> R).wrapCrashHandling(postToMainThread: Boolean = false): () -> R?
  * @param postToMainThread Whether the [CrashScreen] should be opened by posting a runnable to the main thread, instead of directly. Set this to true if the function is going to run on any thread other than the main loop.
  * */
 fun (() -> Unit).wrapCrashHandlingUnit(postToMainThread: Boolean = false): () -> Unit
-    = { this.wrapCrashHandling(postToMainThread)() ?: Unit }
+    = with(this.wrapCrashHandling(postToMainThread)) // Don't instantiate a new lambda every time.
+        { { this() ?: Unit } }

--- a/core/src/com/unciv/ui/utils/ExtensionFunctions.kt
+++ b/core/src/com/unciv/ui/utils/ExtensionFunctions.kt
@@ -1,13 +1,13 @@
 package com.unciv.ui.utils
 
+import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.graphics.Color
-import com.badlogic.gdx.scenes.scene2d.Actor
-import com.badlogic.gdx.scenes.scene2d.InputEvent
-import com.badlogic.gdx.scenes.scene2d.Stage
-import com.badlogic.gdx.scenes.scene2d.Touchable
+import com.badlogic.gdx.scenes.scene2d.*
 import com.badlogic.gdx.scenes.scene2d.ui.*
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener
 import com.badlogic.gdx.scenes.scene2d.utils.ClickListener
+import com.unciv.CrashScreen
+import com.unciv.UncivGame
 import com.unciv.models.UncivSound
 import com.unciv.models.translations.tr
 import java.text.SimpleDateFormat
@@ -91,6 +91,16 @@ fun Actor.addBorder(size:Float, color: Color, expandCell:Boolean = false): Table
     cell.fill()
     table.pack()
     return table
+}
+
+/** Wrap an [Actor] in a [Group] of a given size */
+fun Actor.sizeWrapped(x: Float, y: Float) = Group().also {
+    it.isTransform =
+        false // performance helper - nothing here is rotated or scaled
+    it.setSize(x, y)
+    this.setSize(x, y)
+    this.center(it)
+    it.addActor(this)
 }
 
 /** get background Image for a new separator */
@@ -183,6 +193,21 @@ fun Float.toPercent() = 1 + this/100
 
 /** Translate a [String] and make a [TextButton] widget from it */
 fun String.toTextButton() = TextButton(this.tr(), BaseScreen.skin)
+
+/** Translate a [String] and make a [Button] widget from it, with control over font size, font colour, and an optional icon. */
+fun String.toButton(fontColor: Color = Color.WHITE, fontSize: Int = 24, icon: String? = null): Button {
+    val button = Button(BaseScreen.skin)
+    if (icon != null) {
+        val size = fontSize.toFloat()
+        button.add(
+            ImageGetter.getImage(icon).sizeWrapped(size, size)
+        ).padRight(size / 3)
+    }
+    button.add(
+        this.toLabel(fontColor, fontSize)
+    )
+    return button
+}
 
 /** Translate a [String] and make a [Label] widget from it */
 fun String.toLabel() = Label(this.tr(), BaseScreen.skin)
@@ -284,3 +309,34 @@ object UncivDateFormat {
      */
     fun String.parseDate(): Date = utcFormat.parse(this)
 }
+
+
+/**
+ * Returns a wrapped version of a function that safely crashes the game to [CrashScreen] if an exception or error is thrown.
+ *
+ * In case an exception or error is thrown, the return will be null. Therefore the return type is always nullable.
+ *
+ * @param postToMainThread Whether the [CrashScreen] should be opened by posting a runnable to the main thread, instead of directly. Set this to true if the function is going to run on any thread other than the main loop.
+ * */
+fun <R> (() -> R).wrapCrashHandling(postToMainThread: Boolean = false): () -> R? = {
+        try {
+            this()
+        } catch (e: Throwable) {
+            if (postToMainThread) {
+                Gdx.app.postRunnable {
+                    UncivGame.Current.setScreen(CrashScreen(e))
+                }
+            } else {
+                UncivGame.Current.setScreen(CrashScreen(e))
+            }
+            null
+        }
+    }
+
+/**
+ * Returns a wrapped a version of a Unit-returning function which safely crashes the game to [CrashScreen] if an exception or error is thrown.
+ *
+ * @param postToMainThread Whether the [CrashScreen] should be opened by posting a runnable to the main thread, instead of directly. Set this to true if the function is going to run on any thread other than the main loop.
+ * */
+fun (() -> Unit).wrapCrashHandlingUnit(postToMainThread: Boolean = false): () -> Unit
+    = { this.wrapCrashHandling(postToMainThread)() ?: Unit }

--- a/core/src/com/unciv/ui/utils/ExtensionFunctions.kt
+++ b/core/src/com/unciv/ui/utils/ExtensionFunctions.kt
@@ -99,10 +99,8 @@ fun Actor.sizeWrapped(x: Float, y: Float): Group {
         isTransform = false // performance helper - nothing here is rotated or scaled
         setSize(x, y)
     }
-    this.apply {
-        setSize(x, y)
-        center(wrapper)
-    }
+    setSize(x, y)
+    center(wrapper)
     wrapper.addActor(this)
     return wrapper
 }

--- a/core/src/com/unciv/ui/utils/TabbedPager.kt
+++ b/core/src/com/unciv/ui/utils/TabbedPager.kt
@@ -238,15 +238,8 @@ class TabbedPager(
             name = caption  // enable finding pages by untranslated caption without needing our own field
             if (icon != null) {
                 if (iconSize != 0f) {
-                    val wrapper = Group().apply {
-                        isTransform =
-                            false // performance helper - nothing here is rotated or scaled
-                        setSize(iconSize, iconSize)
-                        icon.setSize(iconSize, iconSize)
-                        icon.center(this)
-                        addActor(icon)
-                    }
-                    add(wrapper).padRight(headerPadding * 0.5f)
+                    add(icon.sizeWrapped(iconSize, iconSize))
+                        .padRight(headerPadding * 0.5f)
                 } else {
                     add(icon)
                 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/37680486/146316598-f630bdd6-02f8-4007-8900-137701ce53a9.png)

![image](https://user-images.githubusercontent.com/37680486/146316729-44c064a0-b63d-440d-8899-28de15ad2cef.png)

Gives user explanation.

May make crashes easier to report.

Should catch *most* errors and exceptions, I think. Wraps `Stage`'s event handling, and `Game`'s rendering, the two of which I think most code goes through. Prominent remaining gap is exceptions in threads— Crash handling is an extension on function types, so should be easy enough to wrap the lambda passed to threads too.

"Open Issue Tracker" shows a ToastPopup asking user to copy the report first if it hasn't already been copied.

IIRC I also read somewhere Google adjusts Play store rankings based on app stability. So this should turn most strikes in that regard into graceful exits.

Tested both the event and the renderer crash catchers, on both Desktop and AVD.

Ulterior motive: In the scripting API branch, I catch and handle all exceptions that occur during script execution. But it's still possible for misbehaving scripts to modify data in ways that lead to exceptions later on, E.G., by recklessly mutating tile or ruleset data. So, I'm trying to make up for the potential future decrease in stability by making existing crashes better handled and easier to report too.

…Honestly I wasn't aware of, or had forgotten about, the existing CrashController until after I was basically done this PR. But it looks like that one only handles crashes in a specific part of `WorldScreen.nextTurn()`? And it only shows a dialog on the next game launch/save load?