### PR TITLE
Fixed an infinite loop where foreign legion upgraded to the unit it replaced

### DIFF
--- a/android/assets/jsons/Civ V - Gods & Kings/Units.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Units.json
@@ -1178,7 +1178,7 @@
 		"strength": 50,
 		"cost": 320,
 		"requiredTech": "Replaceable Parts",
-		"upgradesTo": "Rifleman",
+		"upgradesTo": "Infantry",
 		"obsoleteTech": "Plastics",
 		"uniques": ["[+20]% Strength <when fighting in [Foreign Land] tiles>"],
 		"attackSound": "shot"

--- a/android/assets/jsons/Civ V - Gods & Kings/Units.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Units.json
@@ -1178,7 +1178,7 @@
 		"strength": 50,
 		"cost": 320,
 		"requiredTech": "Replaceable Parts",
-		"upgradesTo": "Infantry",
+		"upgradesTo": "Rifleman",
 		"obsoleteTech": "Plastics",
 		"uniques": ["[+20]% Strength <when fighting in [Foreign Land] tiles>"],
 		"attackSound": "shot"

--- a/android/assets/jsons/Civ V - Vanilla/Units.json
+++ b/android/assets/jsons/Civ V - Vanilla/Units.json
@@ -914,7 +914,7 @@
 	{
 		"name": "Foreign Legion",
 		"unitType": "Gunpowder",
-		"replaces": "Infantry",
+		"replaces": "Rifleman",
 		"uniqueTo": "France",
 		"movement": 2,
 		"strength": 50,

--- a/android/assets/jsons/Civ V - Vanilla/Units.json
+++ b/android/assets/jsons/Civ V - Vanilla/Units.json
@@ -919,7 +919,7 @@
 		"movement": 2,
 		"strength": 50,
 		"cost": 320,
-		"requiredTech": "Replaceable Parts",
+		"requiredTech": "Rifling",
 		"upgradesTo": "Infantry",
 		"obsoleteTech": "Plastics",
 		"uniques": ["[+20]% Strength <when fighting in [Foreign Land] tiles>"],

--- a/core/src/com/unciv/logic/automation/NextTurnAutomation.kt
+++ b/core/src/com/unciv/logic/automation/NextTurnAutomation.kt
@@ -767,7 +767,7 @@ object NextTurnAutomation {
                 unit.baseUnit.isRanged() -> rangedUnits.add(unit)
                 unit.baseUnit.isMelee() -> meleeUnits.add(unit)
                 unit.hasUnique("Bonus for units in 2 tile radius 15%")
-                -> generals.add(unit) //generals move after military units
+                    -> generals.add(unit) // Generals move after military units
                 else -> civilianUnits.add(unit)
             }
         }

--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -373,7 +373,7 @@ class Ruleset {
         // When not checking the entire ruleset, we can only really detect ruleset-invariant errors in uniques
 
         for (unit in units.values) {
-            if (unit.upgradesTo == unit.name)
+            if (unit.upgradesTo == unit.name || unit.upgradesTo == unit.replaces)
                 lines += "${unit.name} upgrades to itself!"
             if (!unit.isCivilian() && unit.strength == 0)
                 lines += "${unit.name} is a military unit but has no assigned strength!"

--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -373,7 +373,7 @@ class Ruleset {
         // When not checking the entire ruleset, we can only really detect ruleset-invariant errors in uniques
 
         for (unit in units.values) {
-            if (unit.upgradesTo == unit.name || unit.upgradesTo == unit.replaces)
+            if (unit.upgradesTo == unit.name || (unit.upgradesTo != null && unit.upgradesTo == unit.replaces))
                 lines += "${unit.name} upgrades to itself!"
             if (!unit.isCivilian() && unit.strength == 0)
                 lines += "${unit.name} is a military unit but has no assigned strength!"


### PR DESCRIPTION
Also added a check for this in the `checkModLinks()` function

Note that this check only checks whether the replacement unit is equal to its upgrade, if A upgrades to B upgrades to C upgrades to A (with some replacements somewhere) this might still happen. While this could be solved generally (keep upgrading with a while loop and save all found units in a hashset until either a double is found or all upgrades have be done), I don't have the time to do this now, and really this should be the responsibility of the mod maker in most cases