### PR TITLE
Refactor MiniMapHolder's little green map overlay toggle icons.

### DIFF
--- a/core/src/com/unciv/ui/worldscreen/Minimap.kt
+++ b/core/src/com/unciv/ui/worldscreen/Minimap.kt
@@ -231,7 +231,6 @@ class MinimapHolder(val mapHolder: WorldMapHolder): Table() {
         setter = { UncivGame.Current.settings.showResourcesAndImprovements = it },
         backgroundColor = Color.GREEN
     )
-    // Hm. If I put these into a MutableList instead, scripted mods (WIP in fork) would immediately be able to inject their own fully functional toggles. But then again, scripted mods can *already* inject UI elements basically anywhere they want, and the canonical way to do that is by adding to the correct Table themselves on Screen/layout instantiation.
 
     init {
         rebuildIfSizeChanged()

--- a/core/src/com/unciv/ui/worldscreen/Minimap.kt
+++ b/core/src/com/unciv/ui/worldscreen/Minimap.kt
@@ -212,20 +212,20 @@ class MinimapHolder(val mapHolder: WorldMapHolder): Table() {
     }
 
     /** Button, next to the minimap, to toggle the tile yield map overlay. */
-    protected val yieldImageButton = MapOverlayToggleButton(
+    val yieldImageButton = MapOverlayToggleButton(
         ImageGetter.getImage("StatIcons/Food"),
         // This is a use in the UI that has little to do with the stat… These buttons have more in common with each other than they do with other uses of getStatIcon().
         getter = { UncivGame.Current.settings.showTileYields },
         setter = { UncivGame.Current.settings.showTileYields = it }
     )
     /** Button, next to the minimap, to toggle the worked tiles map overlay. */
-    protected val populationImageButton = MapOverlayToggleButton(
+    val populationImageButton = MapOverlayToggleButton(
         ImageGetter.getImage("StatIcons/Population"),
         getter = { UncivGame.Current.settings.showWorkedTiles },
         setter = { UncivGame.Current.settings.showWorkedTiles = it }
     )
     /** Button, next to the minimap, to toggle the resource icons map overlay. */
-    protected val resourceImageButton = MapOverlayToggleButton(
+    val resourceImageButton = MapOverlayToggleButton(
         ImageGetter.getImage("ResourceIcons/Cattle"),
         getter = { UncivGame.Current.settings.showResourcesAndImprovements },
         setter = { UncivGame.Current.settings.showResourcesAndImprovements = it },


### PR DESCRIPTION
There was a lot of repetition.

Also removed a redundant `yieldImage.actor.color.a = if (settings.showTileYields) 1f else 0.5f` from the `onClick`s, which wasn't needed because the `worldScreen.shouldUpdate` was already propagating to `MiniMapHolder.update()`.

…I can't believe the line count actually increased??? Ah well, there's some KDocs, and the repetition and complexity per added button is way down.
