### PR TITLE
Fixed a bug where an empty improvement picker screen could open

### DIFF
--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -1050,6 +1050,8 @@ class MapUnit {
     }
 
     fun canBuildImprovement(improvement: TileImprovement, tile: TileInfo = currentTile): Boolean {
+        // Workers (and similar) should never be able to (instantly) construct things, only build them
+        if (improvement.turnsToBuild == 0 && improvement.name != Constants.cancelImprovementOrder) return false
         val matchingUniques = getMatchingUniques(UniqueType.BuildImprovements)
         return matchingUniques.any { improvement.matchesFilter(it.params[0]) || tile.matchesTerrainFilter(it.params[0]) }
     }

--- a/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
@@ -377,8 +377,14 @@ object UnitActions {
         if (unit.isEmbarked()) return
 
         val canConstruct = unit.currentMovement > 0
-                && !tile.isCityCenter()
-                && unit.civInfo.gameInfo.ruleSet.tileImprovements.values.any { tile.canBuildImprovement(it, unit.civInfo) && unit.canBuildImprovement(it) }
+            && !tile.isCityCenter()
+            && unit.civInfo.gameInfo.ruleSet.tileImprovements.values.any { 
+                tile.canBuildImprovement(it, unit.civInfo) 
+                && unit.canBuildImprovement(it)
+                // Excluded actions for water improvements and great improvements, which are handled seperately
+                && it.turnsToBuild != 0 
+            }
+        
 
         actionList += UnitAction(UnitActionType.ConstructImprovement,
             isCurrentAction = unit.currentTile.hasImprovementInProgress(),

--- a/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
@@ -381,8 +381,6 @@ object UnitActions {
             && unit.civInfo.gameInfo.ruleSet.tileImprovements.values.any { 
                 tile.canBuildImprovement(it, unit.civInfo) 
                 && unit.canBuildImprovement(it)
-                // Excluded actions for water improvements and great improvements, which are handled seperately
-                && it.turnsToBuild != 0 
             }
         
 


### PR DESCRIPTION
This happened as for some reason unbuildable improvements (academy, landmark, city center, ancient ruins, etc.) were added to the list of buildable improvements in the action button check, but excluded in the picker screen. This PR fixes this, by also excluding these from the action button check.