### PR TITLE
Fixes warnings in `desktop-file-validate`

### DIFF
--- a/desktop/linuxFilesForJar/unciv.desktop
+++ b/desktop/linuxFilesForJar/unciv.desktop
@@ -1,5 +1,4 @@
 [Desktop Entry]
-Encoding=UTF-8
 Comment=Open-source Android/Desktop remake of Civ V
 Exec=Unciv
 GenericName=4X Game
@@ -7,6 +6,6 @@ Icon=unciv
 Name=Unciv
 NoDisplay=false
 StartupNotify=true
-Terminal=0
+Terminal=false
 Type=Application
 Categories=Game


### PR DESCRIPTION
Trying to validate this desktop entry with `desktop-file-validate` (default tool for desktop entry validation) shows the following warnings.
```bash
~$ desktop-file-validate unciv.desktop
unciv.desktop: warning: key "Encoding" in group "Desktop Entry" is deprecated
unciv.desktop: warning: boolean key "Terminal" in group "Desktop Entry" has value "0", which is deprecated: boolean values should be "false" or "true"
```
Thus deprecated lines were removed or edited.