### PR TITLE
Randomize textures from variants.

### DIFF
--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -23,6 +23,7 @@ import com.unciv.models.ruleset.unit.UnitType
 import com.unciv.ui.utils.toPercent
 import java.text.DecimalFormat
 import kotlin.math.pow
+import kotlin.random.Random
 
 /**
  * The immutable properties and mutable game state of an individual unit present on the map
@@ -116,6 +117,11 @@ class MapUnit {
     @Transient
     var hasUniqueToBuildImprovements = false    // not canBuildImprovements to avoid confusion
 
+    @Transient
+    /** Random integer for internal use. Shouldn't change. Not guaranteed to be unique. */
+    var randomnessSeed = Random.nextInt()
+        private set
+
     /** civName owning the unit */
     lateinit var owner: String
 
@@ -176,6 +182,7 @@ class MapUnit {
         toReturn.baseUnit = baseUnit
         toReturn.name = name
         toReturn.civInfo = civInfo
+        toReturn.randomnessSeed = randomnessSeed
         toReturn.owner = owner
         toReturn.originalOwner = originalOwner
         toReturn.instanceName = instanceName

--- a/core/src/com/unciv/ui/utils/ImageGetter.kt
+++ b/core/src/com/unciv/ui/utils/ImageGetter.kt
@@ -28,6 +28,7 @@ import kotlin.math.atan2
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.sqrt
+import kotlin.random.Random
 
 object ImageGetter {
     private const val whiteDotLocation = "OtherIcons/whiteDot"
@@ -95,6 +96,42 @@ object ImageGetter {
                 val drawable = TextureRegionDrawable(region)
                 textureRegionDrawables[region.name] = drawable
             }
+        }
+    }
+
+    /**
+     * Get, where available, a random variant of an image.
+     *
+     * Variants are the base file name followed by a hyphen and then a single capital letter.
+     * Variants must be consecutively available in alphabetical order. The first variant that fails to be found terminates the search for further variants.
+     * The base file name itself is always treated as and can always be returned as an available variant.
+     *
+     * The return result is a string, so it can further be used with other image-getting functions, such as [getImage] and [getLayeredImageColored].
+     *
+     * Example: Mountain, Mountain-A, Mountain-B
+     * The selected variant can then be further used with [getLayeredImageColored]. E.G.: Mountain-A, Mountain-A-1, Mountain-A-2
+     *
+     * In some cases, it may be desirable to ensure that the same variant is chosen across different invocations.
+     * To do this, pass the same seed each time.
+     *
+     * @param baseFileName The filename of the base image.
+     * @param seed If given, a number with which different uses must always return the same variant.
+     * @return The path of a variant to use in the place of the base image.
+     */
+    fun getRandomImageVariant(baseFileName: String, seed: Int? = null): String {
+        val candidateNames = arrayListOf(baseFileName)
+        for (char in "ABCDEFGHIJKLMNOPQRSTUVWXYZ") { // Usually I'd encode an incrementing integer in base 26. But as this could be run many times on every update, it's probably faster to loop through a literal.
+            val candidate = "$baseFileName-$char"
+            if (imageExists(candidate))
+                candidateNames.add(candidate)
+            else
+                break
+        }
+        return if (candidateNames.size == 1) { // Skip a couple function calls if no variants found.
+            baseFileName
+        } else {
+            val randomSource = if (seed == null) Random else Random(seed)
+            candidateNames[randomSource.nextInt(candidateNames.size)]
         }
     }
 


### PR DESCRIPTION
Pretend the letters are slightly different textures:

![image](https://user-images.githubusercontent.com/37680486/146888393-303d8f6c-c7bd-47db-8c5a-cab6044f0304.png)

Adds `ImageGetter.getRandomImageVariant(baseFileName: String, seed: Int? = null): String`, which randomly chooses an image variant from all available, following the pattern: `{"baseName", "baseName-A", "baseName-B", …, "baseName-Z"}`.

Short-circuits quickly and should add only minimal overhead if there are no variants available.

Returned result is a new image path String, so it can further be used in other image-getting functions, like `getLayeredImageColored`. (Note the nation-coloured letters above.) (#3231 is also partly inspiration for this.)

Used in all invocations of `.getImage` in `TileGroup`, and only in `TileGroup`.

Hashcode of tile position `Vector2` is used as seed for terrain-y images to make sure the map doesn't change during gameplay.

Added a `var randomnessSeed: Int` to `MapUnit` that is set on construction and preserved on `.clone()` for the same purpose. Currently `@Transient`, deciding a visual effect isn't worth a save file field. I could see myself getting attached to a special Frigate and getting sad when it's changed on a save reload or something, though.

I actually skimmed through all 118 invocations of `.getImage()`, and `TileGroup` was really the only place where it made sense to use random variants. It's just as well to have such a clearly defined scope.

Test files in above screenshot are available as example mod: https://github.com/will-ca/Unciv-Tileset-Variants-Example. If you fork it and tag the fork, I'll delete my repo to keep all the examples consolidated.

---

Why? Abstract reasons: Perfectly repeating patterns are very unnatural and jarring in textures. Randomly mixing just two or three variants is often enough to break up large-scale patterns a lot. Likewise clones don't exist, so slightly different units are always a really cool touch IMO.

Direct reason/Example: I was experimenting with breaking up coastlines/biomes with fractal and blended boundaries (#5835). Some results looked fairly natural. But repeating textures and patterns are still a big immersion breaker— What are the odds of there being fifty of the exact same, very distinctive mountain?

FantasyHex does a really good job hiding the repetition where possible and working it into the visual style otherwise. That gets harder with more realistic tilesets. I notice a lot more repetition with 5Hex. Contemplated CGI-generating a "photorealistic" tileset— Repetition would be a nightmare unless variants are possible.