### PR TITLE
Use tileset fallbacks for missing images.

### DIFF
--- a/android/assets/jsons/TileSets/Default.json
+++ b/android/assets/jsons/TileSets/Default.json
@@ -1,0 +1,3 @@
+{
+    "fallbackTileSet": null,
+}

--- a/android/assets/jsons/TileSets/FantasyHex.json
+++ b/android/assets/jsons/TileSets/FantasyHex.json
@@ -1,5 +1,6 @@
 {
     "useColorAsBaseTerrain": "false",
+    "fallbackTileSet": null,
     "ruleVariants": {
         //Legacy hill support
         "Hill": ["Grassland","Hill"],

--- a/core/src/com/unciv/models/tilesets/TileSetCache.kt
+++ b/core/src/com/unciv/models/tilesets/TileSetCache.kt
@@ -26,11 +26,11 @@ object TileSetCache : HashMap<String, TileSetConfig>() {
         mods.addAll(ruleSetMods)
         clear()
         for (mod in mods.distinct()) {
-            val entry = allConfigs.entries.firstOrNull { it.key.mod == mod } ?: continue
-
-            val tileSet = entry.key.tileSet
-            if (tileSet in this) this[tileSet]!!.updateConfig(entry.value)
-            else this[tileSet] = entry.value
+            for (entry in allConfigs.entries.filter { it.key.mod == mod } ) { // Built-in tilesets all have empty strings as their `.mod`, so loop through all of them.
+                val tileSet = entry.key.tileSet
+                if (tileSet in this) this[tileSet]!!.updateConfig(entry.value)
+                else this[tileSet] = entry.value
+            }
         }
     }
 

--- a/core/src/com/unciv/models/tilesets/TileSetConfig.kt
+++ b/core/src/com/unciv/models/tilesets/TileSetConfig.kt
@@ -6,7 +6,7 @@ class TileSetConfig {
     var useColorAsBaseTerrain = true
     var unexploredTileColor: Color = Color.DARK_GRAY
     var fogOfWarColor: Color = Color.BLACK
-    /** Name of the tileset to use when this one is missing images. */
+    /** Name of the tileset to use when this one is missing images. Null to disable. */
     var fallbackTileSet: String? = "FantasyHex"
     var ruleVariants: HashMap<String, Array<String>> = HashMap()
 

--- a/core/src/com/unciv/models/tilesets/TileSetConfig.kt
+++ b/core/src/com/unciv/models/tilesets/TileSetConfig.kt
@@ -6,12 +6,15 @@ class TileSetConfig {
     var useColorAsBaseTerrain = true
     var unexploredTileColor: Color = Color.DARK_GRAY
     var fogOfWarColor: Color = Color.BLACK
+    /** Name of the tileset to use when this one is missing images. */
+    var fallbackTileSet: String? = "FantasyHex"
     var ruleVariants: HashMap<String, Array<String>> = HashMap()
 
     fun updateConfig(other: TileSetConfig){
         useColorAsBaseTerrain = other.useColorAsBaseTerrain
         unexploredTileColor = other.unexploredTileColor
         fogOfWarColor = other.fogOfWarColor
+        fallbackTileSet = other.fallbackTileSet
         for ((tileSetString, renderOrder) in other.ruleVariants){
             ruleVariants[tileSetString] = renderOrder
         }

--- a/core/src/com/unciv/ui/tilegroups/TileSetStrings.kt
+++ b/core/src/com/unciv/ui/tilegroups/TileSetStrings.kt
@@ -7,10 +7,10 @@ import com.unciv.models.tilesets.TileSetConfig
 import com.unciv.ui.utils.ImageGetter
 
 /**
- * @param tileSet Name of the tileset. Defaults to active.
+ * @param tileSet Name of the tileset. Defaults to active at time of instantiation.
  * @param fallbackDepth Maximum number of fallback tilesets to try. Used to prevent infinite recursion.
  * */
-class TileSetStrings(val tileSet: String = UncivGame.Current.settings.tileSet, fallbackDepth: Int = 1) {
+class TileSetStrings(tileSet: String = UncivGame.Current.settings.tileSet, fallbackDepth: Int = 1) {
 
     // this is so that when we have 100s of TileGroups, they won't all individually come up with all these strings themselves,
     // it gets pretty memory-intensive (10s of MBs which is a lot for lower-end phones)

--- a/core/src/com/unciv/ui/tilegroups/TileSetStrings.kt
+++ b/core/src/com/unciv/ui/tilegroups/TileSetStrings.kt
@@ -4,12 +4,18 @@ import com.unciv.UncivGame
 import com.unciv.logic.map.RoadStatus
 import com.unciv.models.tilesets.TileSetCache
 import com.unciv.models.tilesets.TileSetConfig
+import com.unciv.ui.utils.ImageGetter
 
-class TileSetStrings {
+/**
+ * @param tileSet Name of the tileset. Defaults to active.
+ * @param fallbackDepth Maximum number of fallback tilesets to try. Used to prevent infinite recursion.
+ * */
+class TileSetStrings(val tileSet: String = UncivGame.Current.settings.tileSet, fallbackDepth: Int = 1) {
+
     // this is so that when we have 100s of TileGroups, they won't all individually come up with all these strings themselves,
     // it gets pretty memory-intensive (10s of MBs which is a lot for lower-end phones)
-    val tileSetLocation = "TileSets/" + UncivGame.Current.settings.tileSet + "/"
-    val tileSetConfig = TileSetCache[UncivGame.Current.settings.tileSet] ?: TileSetConfig()
+    val tileSetLocation = "TileSets/$tileSet/"
+    val tileSetConfig = TileSetCache[tileSet] ?: TileSetConfig()
 
     val hexagon = tileSetLocation + "Hexagon"
     val crosshatchHexagon = tileSetLocation + "CrosshatchHexagon"
@@ -66,4 +72,30 @@ class TileSetStrings {
         if (baseTerrain != null) return getString(tilesLocation, baseTerrain, "+", city)
         else return cityTile
     }
+
+    /** Fallback [TileSetStrings] to use when the currently chosen tileset is missing an image. */
+    val fallback by lazy {
+        if (fallbackDepth <= 0 || tileSetConfig.fallbackTileSet == null)
+            null
+        else
+            TileSetStrings(tileSetConfig.fallbackTileSet!!, fallbackDepth-1)
+    }
+    /**
+     * @param image An image path string, such as returned from an instance of [TileSetStrings].
+     * @param fallbackImage A lambda function that will be run with the [fallback] as its receiver if the original image does not exist according to [ImageGetter.imageExists].
+     * @return The original image path string if its image exists, or the return result of the [fallbackImage] lambda if the original image does not exist.
+     * */
+    fun orFallback(image: String, fallbackImage: TileSetStrings.() -> String): String {
+        return if (fallback == null || ImageGetter.imageExists(image))
+            image
+        else
+            fallback!!.run(fallbackImage)
+    }
+    /** @see orFallback */
+    fun orFallback(image: TileSetStrings.() -> String, fallbackImage: TileSetStrings.() -> String)
+            = orFallback(this.run(image), fallbackImage)
+    /** @see orFallback */
+    fun orFallback(image: TileSetStrings.() -> String)
+            = orFallback(image, image)
+
 }


### PR DESCRIPTION
Lets tilesets specify a `fallbackTileSet` to use when no valid images are found. Defaults to `"FantasyHex"`. `null` disables.

General control flow:
1. Go through all existing checks, fallbacks, etc, to find an image either provided as a file or explicitly specified through configuration in the active tileset.
2. If no image is found or specified anywhere in the active tileset, then look in the fallback tileset. So custom (and even invalid) `ruleVariants`, those giant `when () {}` blocks for pixel units, etc, should all work same as before when images are present.

In "Modding requests": https://github.com/yairm210/Unciv/issues/3242#issuecomment-1000976826

Discussion:
https://github.com/AdityaMH/Pix5-Tileset/pull/2#issuecomment-998692019
https://github.com/AdityaMH/Pix5-Tileset/issues/3#issuecomment-1001080034

(Not just the new arrows, though. Previously, missing roads would also be white boxes, missing tiles would be blank hexagons, missing pixel units would be… Missing, etc.)

Also made the checks for `unitWithSprite` around `TileGroup:680` use `imageExists` instead of `unitIconExists`… I think the previous behaviour might have been incorrect; Unit icons have nothing to do with the value that check is supposed to validate AFAICT.

The fallback is configurable and disableable in order to not break the old "Default" tileset. Modded tilesets can also disable this, if they wish, by setting `"fallbackTileSet": null`.

May have some issues with #5834 in rare cases.