### PR TITLE
Add `interface ICloneable` and extension functions to unify cloning behaviour.

### DIFF
--- a/core/src/com/unciv/logic/BarbarianManager.kt
+++ b/core/src/com/unciv/logic/BarbarianManager.kt
@@ -5,6 +5,7 @@ import com.unciv.Constants
 import com.unciv.logic.civilization.NotificationIcon
 import com.unciv.logic.map.TileInfo
 import com.unciv.logic.map.TileMap
+import com.unciv.models.helpers.ICloneable
 import com.unciv.models.metadata.GameSpeed
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.ui.utils.randomWeighted
@@ -15,7 +16,7 @@ import kotlin.math.min
 import kotlin.math.pow
 import kotlin.system.measureNanoTime
 
-class BarbarianManager {
+class BarbarianManager: ICloneable<BarbarianManager> {
     val camps = HashMap<Vector2, Encampment>()
 
     @Transient
@@ -24,10 +25,11 @@ class BarbarianManager {
     @Transient
     lateinit var tileMap: TileMap
 
-    fun clone(): BarbarianManager {
+    override fun clone(): BarbarianManager {
         val toReturn = BarbarianManager()
         for (camp in camps.values.map { it.clone() })
             toReturn.camps[camp.position] = camp
+            // Not using the .copy() extension in ICloneable.kt because camp.position, which is mutable, is taken from the clone.
         return toReturn
     }
 
@@ -167,7 +169,7 @@ class BarbarianManager {
     }
 }
 
-class Encampment() {
+class Encampment(): ICloneable<Encampment> {
     val position = Vector2()
     var countdown = 0
     var spawnedUnits = -1
@@ -181,7 +183,7 @@ class Encampment() {
         this.position.y = position.y
     }
 
-    fun clone(): Encampment {
+    override fun clone(): Encampment {
         val toReturn = Encampment(position)
         toReturn.countdown = countdown
         toReturn.spawnedUnits = spawnedUnits

--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -9,6 +9,8 @@ import com.unciv.logic.city.CityInfo
 import com.unciv.logic.map.TileInfo
 import com.unciv.logic.map.TileMap
 import com.unciv.models.Religion
+import com.unciv.models.helpers.ICloneable
+import com.unciv.models.helpers.copy
 import com.unciv.models.metadata.GameParameters
 import com.unciv.models.metadata.GameSpeed
 import com.unciv.models.ruleset.*
@@ -20,7 +22,7 @@ import java.util.*
 
 class UncivShowableException(missingMods: String) : Exception(missingMods)
 
-class GameInfo {
+class GameInfo: ICloneable<GameInfo> {
     //region Fields - Serialized
     var civilizations = mutableListOf<CivilizationInfo>()
     var barbarians = BarbarianManager()
@@ -79,10 +81,10 @@ class GameInfo {
     //endregion
     //region Pure functions
 
-    fun clone(): GameInfo {
+    override fun clone(): GameInfo {
         val toReturn = GameInfo()
         toReturn.tileMap = tileMap.clone()
-        toReturn.civilizations.addAll(civilizations.map { it.clone() })
+        toReturn.civilizations = civilizations.copy()
         toReturn.barbarians = barbarians.clone()
         toReturn.religions.putAll(religions.map { Pair(it.key, it.value.clone()) })
         toReturn.currentPlayer = currentPlayer

--- a/core/src/com/unciv/logic/city/CityConstructions.kt
+++ b/core/src/com/unciv/logic/city/CityConstructions.kt
@@ -4,6 +4,7 @@ import com.unciv.logic.automation.ConstructionAutomation
 import com.unciv.logic.civilization.AlertType
 import com.unciv.logic.civilization.NotificationIcon
 import com.unciv.logic.civilization.PopupAlert
+import com.unciv.models.helpers.ICloneable
 import com.unciv.models.ruleset.Building
 import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.ruleset.unique.StateForConditionals
@@ -31,7 +32,7 @@ import kotlin.math.roundToInt
  * @property currentConstructionIsUserSet a flag indicating if the [currentConstructionFromQueue] has been set by the user or by the AI
  * @property constructionQueue a list of constructions names enqueued
  */
-class CityConstructions {
+class CityConstructions: ICloneable<CityConstructions> {
     @Transient
     lateinit var cityInfo: CityInfo
 
@@ -60,7 +61,7 @@ class CityConstructions {
     val freeBuildingsProvidedFromThisCity: HashMap<String, HashSet<String>> = hashMapOf()
     
     //region pure functions
-    fun clone(): CityConstructions {
+    override fun clone(): CityConstructions {
         val toReturn = CityConstructions()
         toReturn.builtBuildings.addAll(builtBuildings)
         toReturn.inProgressConstructions.putAll(inProgressConstructions)

--- a/core/src/com/unciv/logic/city/CityExpansionManager.kt
+++ b/core/src/com/unciv/logic/city/CityExpansionManager.kt
@@ -5,6 +5,7 @@ import com.unciv.logic.automation.Automation
 import com.unciv.logic.civilization.LocationAction
 import com.unciv.logic.civilization.NotificationIcon
 import com.unciv.logic.map.TileInfo
+import com.unciv.models.helpers.ICloneable
 import com.unciv.ui.utils.toPercent
 import com.unciv.ui.utils.withItem
 import com.unciv.ui.utils.withoutItem
@@ -12,12 +13,12 @@ import kotlin.math.max
 import kotlin.math.pow
 import kotlin.math.roundToInt
 
-class CityExpansionManager {
+class CityExpansionManager: ICloneable<CityExpansionManager> {
     @Transient
     lateinit var cityInfo: CityInfo
     var cultureStored: Int = 0
 
-    fun clone(): CityExpansionManager {
+    override fun clone(): CityExpansionManager {
         val toReturn = CityExpansionManager()
         toReturn.cultureStored = cultureStored
         return toReturn

--- a/core/src/com/unciv/logic/city/CityInfo.kt
+++ b/core/src/com/unciv/logic/city/CityInfo.kt
@@ -11,6 +11,7 @@ import com.unciv.logic.map.RoadStatus
 import com.unciv.logic.map.TileInfo
 import com.unciv.logic.map.TileMap
 import com.unciv.models.Counter
+import com.unciv.models.helpers.ICloneable
 import com.unciv.models.ruleset.unique.Unique
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.ruleset.tile.ResourceSupplyList
@@ -32,7 +33,7 @@ enum class CityFlags {
     Resistance
 }
 
-class CityInfo {
+class CityInfo: ICloneable<CityInfo> {
     @Suppress("JoinDeclarationAndAssignment")
     @Transient
     lateinit var civInfo: CivilizationInfo
@@ -232,7 +233,7 @@ class CityInfo {
 
 
     //region pure functions
-    fun clone(): CityInfo {
+    override fun clone(): CityInfo {
         val toReturn = CityInfo()
         toReturn.location = location
         toReturn.id = id

--- a/core/src/com/unciv/logic/city/CityReligion.kt
+++ b/core/src/com/unciv/logic/city/CityReligion.kt
@@ -4,10 +4,11 @@ import com.unciv.Constants
 import com.unciv.logic.civilization.NotificationIcon
 import com.unciv.models.Counter
 import com.unciv.models.Religion
+import com.unciv.models.helpers.ICloneable
 import com.unciv.models.metadata.GameSpeed
 import com.unciv.models.ruleset.unique.Unique
 
-class CityInfoReligionManager {
+class CityInfoReligionManager: ICloneable<CityInfoReligionManager> {
     @Transient
     lateinit var cityInfo: CityInfo
     
@@ -36,7 +37,7 @@ class CityInfoReligionManager {
         clearAllPressures()
     }
     
-    fun clone(): CityInfoReligionManager {
+    override fun clone(): CityInfoReligionManager {
         val toReturn = CityInfoReligionManager()
         toReturn.cityInfo = cityInfo
         toReturn.religionsAtSomePointAdopted.addAll(religionsAtSomePointAdopted)

--- a/core/src/com/unciv/logic/city/PopulationManager.kt
+++ b/core/src/com/unciv/logic/city/PopulationManager.kt
@@ -4,12 +4,13 @@ import com.unciv.logic.automation.Automation
 import com.unciv.logic.civilization.NotificationIcon
 import com.unciv.logic.map.TileInfo
 import com.unciv.models.Counter
+import com.unciv.models.helpers.ICloneable
 import com.unciv.ui.utils.withItem
 import com.unciv.ui.utils.withoutItem
 import kotlin.math.floor
 import kotlin.math.pow
 
-class PopulationManager {
+class PopulationManager: ICloneable<PopulationManager> {
     @Transient
     lateinit var cityInfo: CityInfo
 
@@ -24,7 +25,7 @@ class PopulationManager {
 
 
     //region pure functions
-    fun clone(): PopulationManager {
+    override fun clone(): PopulationManager {
         val toReturn = PopulationManager()
         toReturn.specialistAllocations.add(specialistAllocations)
         toReturn.population = population

--- a/core/src/com/unciv/logic/civilization/CivConstructions.kt
+++ b/core/src/com/unciv/logic/civilization/CivConstructions.kt
@@ -2,12 +2,13 @@ package com.unciv.logic.civilization
 
 import com.unciv.logic.city.INonPerpetualConstruction
 import com.unciv.models.Counter
+import com.unciv.models.helpers.ICloneable
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.stats.Stat
 import java.util.*
 import kotlin.collections.HashMap
 
-class CivConstructions {
+class CivConstructions: ICloneable<CivConstructions> {
 
     @Transient
     lateinit var civInfo: CivilizationInfo
@@ -33,7 +34,7 @@ class CivConstructions {
         }
     }
 
-    fun clone(): CivConstructions {
+    override fun clone(): CivConstructions {
         val toReturn = CivConstructions()
         toReturn.civInfo = civInfo
         toReturn.freeBuildings.putAll(freeBuildings)

--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -14,6 +14,8 @@ import com.unciv.logic.map.*
 import com.unciv.logic.trade.TradeEvaluation
 import com.unciv.logic.trade.TradeRequest
 import com.unciv.models.Counter
+import com.unciv.models.helpers.ICloneable
+import com.unciv.models.helpers.copy
 import com.unciv.models.ruleset.*
 import com.unciv.models.ruleset.tile.ResourceSupplyList
 import com.unciv.models.ruleset.tile.ResourceType
@@ -45,7 +47,7 @@ enum class Proximity {
     Distant
 }
 
-class CivilizationInfo {
+class CivilizationInfo: ICloneable<CivilizationInfo> {
 
     @Transient
     private var workerAutomationCache: WorkerAutomation? = null
@@ -189,7 +191,7 @@ class CivilizationInfo {
         this.civName = civName
     }
 
-    fun clone(): CivilizationInfo {
+    override fun clone(): CivilizationInfo {
         val toReturn = CivilizationInfo()
         toReturn.gold = gold
         toReturn.playerType = playerType
@@ -205,10 +207,9 @@ class CivilizationInfo {
         toReturn.ruinsManager = ruinsManager.clone()
         toReturn.victoryManager = victoryManager.clone()
         toReturn.allyCivName = allyCivName
-        for (diplomacyManager in diplomacy.values.map { it.clone() })
-            toReturn.diplomacy[diplomacyManager.otherCivName] = diplomacyManager
+        toReturn.diplomacy = diplomacy.copy()
         toReturn.proximity.putAll(proximity)
-        toReturn.cities = cities.map { it.clone() }
+        toReturn.cities = cities.copy()
 
         // This is the only thing that is NOT switched out, which makes it a source of ConcurrentModification errors.
         // Cloning it by-pointer is a horrific move, since the serialization would go over it ANYWAY and still lead to concurrency problems.

--- a/core/src/com/unciv/logic/civilization/GoldenAgeManager.kt
+++ b/core/src/com/unciv/logic/civilization/GoldenAgeManager.kt
@@ -1,8 +1,9 @@
 package com.unciv.logic.civilization
 
+import com.unciv.models.helpers.ICloneable
 import com.unciv.ui.utils.toPercent
 
-class GoldenAgeManager {
+class GoldenAgeManager: ICloneable<GoldenAgeManager> {
     @Transient
     lateinit var civInfo: CivilizationInfo
 
@@ -10,7 +11,7 @@ class GoldenAgeManager {
     private var numberOfGoldenAges = 0
     var turnsLeftForCurrentGoldenAge = 0
 
-    fun clone(): GoldenAgeManager {
+    override fun clone(): GoldenAgeManager {
         val toReturn = GoldenAgeManager()
         toReturn.numberOfGoldenAges = numberOfGoldenAges
         toReturn.storedHappiness = storedHappiness

--- a/core/src/com/unciv/logic/civilization/GreatPersonManager.kt
+++ b/core/src/com/unciv/logic/civilization/GreatPersonManager.kt
@@ -1,13 +1,14 @@
 package com.unciv.logic.civilization
 
 import com.unciv.models.Counter
+import com.unciv.models.helpers.ICloneable
 import java.util.HashSet
 
 // todo: Great Admiral?
 // todo: Free GP from policies and wonders should increase threshold according to the wiki
 // todo: GP from Maya long count should increase threshold as well - implement together
 
-class GreatPersonManager {
+class GreatPersonManager: ICloneable<GreatPersonManager> {
     var pointsForNextGreatPerson = 100
     var pointsForNextGreatGeneral = 200
 
@@ -19,7 +20,7 @@ class GreatPersonManager {
     /** Remaining candidates for maya ability - whenever empty refilled from all GP, starts out empty */
     var longCountGPPool = HashSet<String>()
 
-    fun clone(): GreatPersonManager {
+    override fun clone(): GreatPersonManager {
         val toReturn = GreatPersonManager()
         toReturn.freeGreatPeople = freeGreatPeople
         toReturn.greatPersonPointsCounter = greatPersonPointsCounter.clone()

--- a/core/src/com/unciv/logic/civilization/PolicyManager.kt
+++ b/core/src/com/unciv/logic/civilization/PolicyManager.kt
@@ -1,6 +1,7 @@
 package com.unciv.logic.civilization
 
 import com.unciv.logic.map.MapSize
+import com.unciv.models.helpers.ICloneable
 import com.unciv.models.ruleset.Policy
 import com.unciv.models.ruleset.Policy.PolicyBranchType
 import com.unciv.models.ruleset.unique.UniqueMap
@@ -11,7 +12,7 @@ import kotlin.math.pow
 import kotlin.math.roundToInt
 
 
-class PolicyManager {
+class PolicyManager: ICloneable<PolicyManager> {
 
     @Transient
     lateinit var civInfo: CivilizationInfo
@@ -33,7 +34,7 @@ class PolicyManager {
         private val turnCountRegex by lazy { Regex("for \\[[0-9]*\\] turns") }
     }
     
-    fun clone(): PolicyManager {
+    override fun clone(): PolicyManager {
         val toReturn = PolicyManager()
         toReturn.numberOfAdoptedPolicies = numberOfAdoptedPolicies
         toReturn.adoptedPolicies.addAll(adoptedPolicies)

--- a/core/src/com/unciv/logic/civilization/QuestManager.kt
+++ b/core/src/com/unciv/logic/civilization/QuestManager.kt
@@ -7,6 +7,7 @@ import com.unciv.logic.GameInfo
 import com.unciv.logic.civilization.diplomacy.DiplomacyFlags
 import com.unciv.logic.civilization.diplomacy.DiplomaticStatus
 import com.unciv.logic.map.TileInfo
+import com.unciv.models.helpers.ICloneable
 import com.unciv.models.ruleset.Building
 import com.unciv.models.ruleset.Quest
 import com.unciv.models.ruleset.QuestName
@@ -23,7 +24,7 @@ import kotlin.math.max
 import kotlin.random.Random
 
 @Suppress("NON_EXHAUSTIVE_WHEN")  // Many when uses in here are much clearer this way
-class QuestManager {
+class QuestManager: ICloneable<QuestManager> {
 
     companion object {
         const val UNSET = -1
@@ -78,7 +79,7 @@ class QuestManager {
             investmentQuest.data1.toPercent()
     }
 
-    fun clone(): QuestManager {
+    override fun clone(): QuestManager {
         val toReturn = QuestManager()
         toReturn.globalQuestCountdown = globalQuestCountdown
         toReturn.individualQuestCountdown.putAll(individualQuestCountdown)

--- a/core/src/com/unciv/logic/civilization/ReligionManager.kt
+++ b/core/src/com/unciv/logic/civilization/ReligionManager.kt
@@ -3,13 +3,14 @@ package com.unciv.logic.civilization
 import com.unciv.logic.map.MapUnit
 import com.unciv.models.Counter
 import com.unciv.models.Religion
+import com.unciv.models.helpers.ICloneable
 import com.unciv.models.ruleset.Belief
 import com.unciv.models.ruleset.BeliefType
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.ui.utils.toPercent
 import kotlin.random.Random
 
-class ReligionManager {
+class ReligionManager: ICloneable<ReligionManager> {
 
     @Transient
     lateinit var civInfo: CivilizationInfo
@@ -39,7 +40,7 @@ class ReligionManager {
     private var shouldChoosePantheonBelief: Boolean = false
 
 
-    fun clone(): ReligionManager {
+    override fun clone(): ReligionManager {
         val clone = ReligionManager()
         clone.foundingCityId = foundingCityId
         clone.shouldChoosePantheonBelief = shouldChoosePantheonBelief

--- a/core/src/com/unciv/logic/civilization/RuinsManager/RuinsManager.kt
+++ b/core/src/com/unciv/logic/civilization/RuinsManager/RuinsManager.kt
@@ -4,13 +4,14 @@ import com.unciv.Constants
 import com.unciv.logic.civilization.CivilizationInfo
 import com.unciv.logic.civilization.ReligionState
 import com.unciv.logic.map.MapUnit
+import com.unciv.models.helpers.ICloneable
 import com.unciv.models.ruleset.RuinReward
 import com.unciv.models.ruleset.unique.Unique
 import com.unciv.models.ruleset.unique.UniqueTriggerActivation
 import com.unciv.models.ruleset.unique.UniqueType
 import kotlin.random.Random
 
-class RuinsManager {
+class RuinsManager: ICloneable<RuinsManager> {
     var lastChosenRewards: MutableList<String> = mutableListOf("", "")
     private fun rememberReward(reward: String) {
         lastChosenRewards[0] = lastChosenRewards[1]
@@ -22,7 +23,7 @@ class RuinsManager {
     @Transient
     lateinit var validRewards: List<RuinReward> 
     
-    fun clone(): RuinsManager {
+    override fun clone(): RuinsManager {
         val toReturn = RuinsManager()
         toReturn.lastChosenRewards = lastChosenRewards
         return toReturn

--- a/core/src/com/unciv/logic/civilization/TechManager.kt
+++ b/core/src/com/unciv/logic/civilization/TechManager.kt
@@ -4,6 +4,7 @@ import com.unciv.logic.city.CityInfo
 import com.unciv.logic.map.MapSize
 import com.unciv.logic.map.RoadStatus
 import com.unciv.logic.map.TileInfo
+import com.unciv.models.helpers.ICloneable
 import com.unciv.models.ruleset.unique.UniqueMap
 import com.unciv.models.ruleset.unique.UniqueTriggerActivation
 import com.unciv.models.ruleset.tech.Technology
@@ -19,7 +20,7 @@ import kotlin.math.ceil
 import kotlin.math.max
 import kotlin.math.min
 
-class TechManager {
+class TechManager: ICloneable<TechManager> {
     @Transient
     lateinit var civInfo: CivilizationInfo
     /** This is the Transient list of Technologies */
@@ -61,7 +62,7 @@ class TechManager {
     var goldPercentConvertedToScience = 0.6f
 
     //region state-changing functions
-    fun clone(): TechManager {
+    override fun clone(): TechManager {
         val toReturn = TechManager()
         toReturn.techsResearched.addAll(techsResearched)
         toReturn.freeTechs = freeTechs

--- a/core/src/com/unciv/logic/civilization/VictoryManager.kt
+++ b/core/src/com/unciv/logic/civilization/VictoryManager.kt
@@ -1,10 +1,11 @@
 package com.unciv.logic.civilization
 
 import com.unciv.models.Counter
+import com.unciv.models.helpers.ICloneable
 import com.unciv.models.ruleset.VictoryType
 import com.unciv.models.ruleset.unique.UniqueType
 
-class VictoryManager {
+class VictoryManager: ICloneable<VictoryManager> {
     @Transient
     lateinit var civInfo: CivilizationInfo
 
@@ -19,7 +20,7 @@ class VictoryManager {
         requiredSpaceshipParts.add("SS Stasis Chamber", 1)
     }
 
-    fun clone(): VictoryManager {
+    override fun clone(): VictoryManager {
         val toReturn = VictoryManager()
         toReturn.currentsSpaceshipParts.putAll(currentsSpaceshipParts)
         return toReturn

--- a/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
@@ -6,6 +6,8 @@ import com.unciv.logic.civilization.*
 import com.unciv.logic.trade.Trade
 import com.unciv.logic.trade.TradeOffer
 import com.unciv.logic.trade.TradeType
+import com.unciv.models.helpers.ICloneable
+import com.unciv.models.helpers.copy
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.ruleset.tile.ResourceSupplyList
 import com.unciv.ui.utils.toPercent
@@ -85,7 +87,7 @@ enum class DiplomaticModifiers {
     ReturnedCapturedUnits,
 }
 
-class DiplomacyManager() {
+class DiplomacyManager(): ICloneable<DiplomacyManager> {
 
     companion object {
         /** The value city-state influence can't go below */
@@ -123,11 +125,11 @@ class DiplomacyManager() {
     /** Total of each turn Science during Research Agreement */
     private var totalOfScienceDuringRA = 0
 
-    fun clone(): DiplomacyManager {
+    override fun clone(): DiplomacyManager {
         val toReturn = DiplomacyManager()
         toReturn.otherCivName = otherCivName
         toReturn.diplomaticStatus = diplomaticStatus
-        toReturn.trades.addAll(trades.map { it.clone() })
+        toReturn.trades = trades.copy()
         toReturn.influence = influence
         toReturn.flagsCountdown.putAll(flagsCountdown)
         toReturn.diplomaticModifiers.putAll(diplomaticModifiers)

--- a/core/src/com/unciv/logic/map/MapParameters.kt
+++ b/core/src/com/unciv/logic/map/MapParameters.kt
@@ -4,6 +4,7 @@ import com.unciv.Constants
 import com.unciv.logic.HexMath.getEquivalentHexagonalRadius
 import com.unciv.logic.HexMath.getEquivalentRectangularSize
 import com.unciv.logic.HexMath.getNumberOfTilesInHexagon
+import com.unciv.models.helpers.ICloneable
 import com.unciv.models.metadata.BaseRuleset
 import com.unciv.models.ruleset.RulesetCache
 
@@ -16,7 +17,7 @@ enum class MapSize(val radius: Int, val width: Int, val height: Int) {
     Huge(40, 87, 57)
 }
 
-class MapSizeNew {
+class MapSizeNew: ICloneable<MapSizeNew> {
     var radius = 0
     var width = 0
     var height = 0
@@ -57,7 +58,7 @@ class MapSizeNew {
         this.radius = getEquivalentHexagonalRadius(width, height)
     }
 
-    fun clone() = MapSizeNew().also { 
+    override fun clone() = MapSizeNew().also {
         it.name = name
         it.radius = radius
         it.width = width
@@ -139,7 +140,7 @@ object MapResources {
     const val legendaryStart = "Legendary Start"
 }
 
-class MapParameters {
+class MapParameters: ICloneable<MapParameters> {
     var name = ""
     var type = MapType.pangaea
     var shape = MapShape.hexagonal
@@ -166,7 +167,7 @@ class MapParameters {
     var resourceRichness = 0.1f
     var waterThreshold = 0f
 
-    fun clone() = MapParameters().also {
+    override fun clone() = MapParameters().also {
         it.name = name
         it.type = type
         it.shape = shape

--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -12,6 +12,8 @@ import com.unciv.logic.civilization.LocationAction
 import com.unciv.logic.civilization.NotificationIcon
 import com.unciv.models.helpers.UnitMovementMemoryType
 import com.unciv.models.UnitActionType
+import com.unciv.models.helpers.ICloneable
+import com.unciv.models.helpers.copy
 import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.ruleset.tile.TerrainType
 import com.unciv.models.ruleset.tile.TileImprovement
@@ -29,7 +31,7 @@ import kotlin.math.pow
 /**
  * The immutable properties and mutable game state of an individual unit present on the map
  */
-class MapUnit {
+class MapUnit: ICloneable<MapUnit> {
 
     @Transient
     lateinit var civInfo: CivilizationInfo
@@ -178,20 +180,16 @@ class MapUnit {
      * @property position Position on the map at this instant.
      * @property type Category of the last change in position that brought the unit to this position.
      * */
-    class UnitMovementMemory() {
+    class UnitMovementMemory(): ICloneable<UnitMovementMemory> {
         constructor(position: Vector2, type: UnitMovementMemoryType): this() {
             this.position = position
             this.type = type
         }
         lateinit var position: Vector2
         lateinit var type: UnitMovementMemoryType
-        fun clone() = UnitMovementMemory(Vector2(position), type)
+        override fun clone() = UnitMovementMemory(Vector2(position), type)
         override fun toString() = "${this::class.simpleName}($position, $type)"
     }
-
-    /** Deep clone an ArrayList of [UnitMovementMemory]s. */
-    private fun ArrayList<UnitMovementMemory>.copy() = ArrayList(this.map { it.clone() })
-
     /** FIFO list of this unit's past positions. Should never exceed two items in length. New item added once at end of turn and once at start, to allow rare between-turn movements like melee withdrawal to be distinguished. Used in movement arrow overlay. */
     var movementMemories = ArrayList<UnitMovementMemory>()
 
@@ -214,7 +212,7 @@ class MapUnit {
     var attacksSinceTurnStart = ArrayList<Vector2>()
 
     //region pure functions
-    fun clone(): MapUnit {
+    override fun clone(): MapUnit {
         val toReturn = MapUnit()
         toReturn.baseUnit = baseUnit
         toReturn.name = name

--- a/core/src/com/unciv/logic/map/TileInfo.kt
+++ b/core/src/com/unciv/logic/map/TileInfo.kt
@@ -7,6 +7,8 @@ import com.unciv.logic.HexMath
 import com.unciv.logic.city.CityInfo
 import com.unciv.logic.civilization.CivilizationInfo
 import com.unciv.logic.civilization.PlayerType
+import com.unciv.models.helpers.ICloneable
+import com.unciv.models.helpers.copy
 import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.ruleset.tile.*
@@ -19,7 +21,7 @@ import com.unciv.ui.utils.toPercent
 import kotlin.math.abs
 import kotlin.math.min
 
-open class TileInfo {
+open class TileInfo: ICloneable<TileInfo> {
     @Transient
     lateinit var tileMap: TileMap
 
@@ -81,11 +83,11 @@ open class TileInfo {
     val longitude: Float
         get() = HexMath.getLongitude(position)
 
-    fun clone(): TileInfo {
+    override fun clone(): TileInfo {
         val toReturn = TileInfo()
         if (militaryUnit != null) toReturn.militaryUnit = militaryUnit!!.clone()
         if (civilianUnit != null) toReturn.civilianUnit = civilianUnit!!.clone()
-        for (airUnit in airUnits) toReturn.airUnits.add(airUnit.clone())
+        toReturn.airUnits = airUnits.copy()
         toReturn.position = position.cpy()
         toReturn.baseTerrain = baseTerrain
         toReturn.terrainFeatures.addAll(terrainFeatures)

--- a/core/src/com/unciv/logic/map/TileMap.kt
+++ b/core/src/com/unciv/logic/map/TileMap.kt
@@ -6,6 +6,8 @@ import com.unciv.Constants
 import com.unciv.logic.GameInfo
 import com.unciv.logic.HexMath
 import com.unciv.logic.civilization.CivilizationInfo
+import com.unciv.models.helpers.ICloneable
+import com.unciv.models.helpers.copy
 import com.unciv.models.metadata.Player
 import com.unciv.models.ruleset.Nation
 import com.unciv.models.ruleset.Ruleset
@@ -17,7 +19,7 @@ import kotlin.math.abs
  * 
  * Note: Will be Serialized -> Take special care with lateinit and lazy! 
  */
-class TileMap {
+class TileMap: ICloneable<TileMap> {
     companion object {
         /** Legacy way to store starting locations - now this is used only in [translateStartingLocationsFromMap] */
         const val startingLocationPrefix = "StartingLocation "
@@ -122,9 +124,9 @@ class TileMap {
     //region Operators and Standards
 
     /** @return a deep-copy clone of the serializable fields, no transients initialized */
-    fun clone(): TileMap {
+    override fun clone(): TileMap {
         val toReturn = TileMap()
-        toReturn.tileList.addAll(tileList.map { it.clone() })
+        toReturn.tileList = tileList.copy()
         toReturn.mapParameters = mapParameters
         toReturn.ruleset = ruleset
         toReturn.startingLocations.clear()

--- a/core/src/com/unciv/logic/map/UnitPromotions.kt
+++ b/core/src/com/unciv/logic/map/UnitPromotions.kt
@@ -1,9 +1,10 @@
 package com.unciv.logic.map
 
+import com.unciv.models.helpers.ICloneable
 import com.unciv.models.ruleset.unique.UniqueTriggerActivation
 import com.unciv.models.ruleset.unit.Promotion
 
-class UnitPromotions {
+class UnitPromotions: ICloneable<UnitPromotions> {
     // Having this as mandatory constructor parameter would be safer, but this class is part of a
     // saved game and as usual the json deserializer needs a default constructor.
     // Initialization occurs in setTransients() - called as part of MapUnit.setTransients,
@@ -99,7 +100,7 @@ class UnitPromotions {
             }
     }
 
-    fun clone(): UnitPromotions {
+    override fun clone(): UnitPromotions {
         val toReturn = UnitPromotions()
         toReturn.XP = XP
         toReturn.promotions.addAll(promotions)

--- a/core/src/com/unciv/logic/trade/Trade.kt
+++ b/core/src/com/unciv/logic/trade/Trade.kt
@@ -4,8 +4,9 @@ import com.unciv.Constants
 import com.unciv.logic.civilization.CivilizationInfo
 import com.unciv.logic.civilization.NotificationIcon
 import com.unciv.logic.civilization.diplomacy.DiplomacyFlags
+import com.unciv.models.helpers.ICloneable
 
-class Trade{
+class Trade: ICloneable<Trade> {
 
     val theirOffers = TradeOffersList()
     val ourOffers = TradeOffersList()
@@ -30,7 +31,7 @@ class Trade{
         return true
     }
 
-    fun clone():Trade{
+    override fun clone(): Trade{
         val toReturn = Trade()
         toReturn.theirOffers.addAll(theirOffers)
         toReturn.ourOffers.addAll(ourOffers)

--- a/core/src/com/unciv/models/Counter.kt
+++ b/core/src/com/unciv/models/Counter.kt
@@ -1,10 +1,11 @@
 package com.unciv.models
 
+import com.unciv.models.helpers.ICloneable
 import java.util.*
 import kotlin.collections.ArrayList
 import kotlin.collections.LinkedHashMap
 
-open class Counter<K> : LinkedHashMap<K, Int>() {
+open class Counter<K> : LinkedHashMap<K, Int>(), ICloneable<Counter<K>> {
 
     override operator fun get(key: K): Int? { // don't return null if empty
         if (containsKey(key))

--- a/core/src/com/unciv/models/Religion.kt
+++ b/core/src/com/unciv/models/Religion.kt
@@ -1,12 +1,13 @@
 package com.unciv.models
 
 import com.unciv.logic.GameInfo
+import com.unciv.models.helpers.ICloneable
 import com.unciv.models.ruleset.Belief
 import com.unciv.models.ruleset.BeliefType
 import com.unciv.models.stats.INamed
 
 /** Data object for Religions */
-class Religion() : INamed {
+class Religion() : INamed, ICloneable<Religion> {
 
     override lateinit var name: String
     var displayName: String? = null
@@ -24,7 +25,7 @@ class Religion() : INamed {
         this.gameInfo = gameInfo
     }
 
-    fun clone(): Religion {
+    override fun clone(): Religion {
         val toReturn = Religion(name, gameInfo, foundingCivName)
         toReturn.displayName = displayName
         toReturn.founderBeliefs.addAll(founderBeliefs)

--- a/core/src/com/unciv/models/helpers/ICloneable.kt
+++ b/core/src/com/unciv/models/helpers/ICloneable.kt
@@ -1,0 +1,27 @@
+package com.unciv.models.helpers
+
+/**
+ * Interface for Unciv data models that implement some sort of a deep copy or "clone" functionality.
+ *
+ * @param C This type itself.
+ */
+interface ICloneable<C: ICloneable<C>> {
+    /** @return A recursive copy of this instance. */
+    fun clone(): C
+}
+
+/** @return A new List from calling [ICloneable.clone] on the elements of this one. */
+fun <C: ICloneable<C>> List<C>.copy() = this.map { it.clone() }
+// Saves a loop when returned list implementation doesn't matter.
+// "`.copy`" instead of "`.clone`" because extension functions can't seem to shadow Object.clone(). Also sets apart from ICloneable.
+
+/** @return A new ArrayList MutableList from calling [ICloneable.clone] on the elements of this one. */
+fun <C: ICloneable<C>> MutableList<C>.copy() = ArrayList((this as List<C>).copy())
+// Receiver type as generic as possible, and return type as specific as possible, to cover the most use cases.
+
+/** @return A new Map from reusing the keys and calling [ICloneable.clone] on the values of this one. */
+fun <K, V: ICloneable<V>> Map<K, V>.copy() = this.entries.associate { (key, value) -> key to value.clone() }
+
+/** @return A new HashMap from reusing the keys and calling [ICloneable.clone] on the values of this one. */
+fun <K, V: ICloneable<V>> HashMap<K, V>.copy() = HashMap((this as Map<K, V>).copy())
+// HashMap receiver, instead of MutableMap receiver, because ordering behaviour is different.

--- a/core/src/com/unciv/models/metadata/GameParameters.kt
+++ b/core/src/com/unciv/models/metadata/GameParameters.kt
@@ -2,6 +2,7 @@ package com.unciv.models.metadata
 
 import com.unciv.Constants
 import com.unciv.logic.civilization.PlayerType
+import com.unciv.models.helpers.ICloneable
 import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.ruleset.RulesetCache
 import com.unciv.models.ruleset.VictoryType
@@ -11,7 +12,7 @@ enum class BaseRuleset(val fullName:String){
     Civ_V_GnK("Civ V - Gods & Kings"),
 }
 
-class GameParameters { // Default values are the default new game
+class GameParameters: ICloneable<GameParameters> { // Default values are the default new game
     var difficulty = "Prince"
     var gameSpeed = GameSpeed.Standard
     var players = ArrayList<Player>().apply {
@@ -37,7 +38,7 @@ class GameParameters { // Default values are the default new game
     
     var maxTurns = 500
 
-    fun clone(): GameParameters {
+    override fun clone(): GameParameters {
         val parameters = GameParameters()
         parameters.difficulty = difficulty
         parameters.gameSpeed = gameSpeed

--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -5,6 +5,7 @@ import com.badlogic.gdx.files.FileHandle
 import com.unciv.JsonParser
 import com.unciv.logic.UncivShowableException
 import com.unciv.models.Counter
+import com.unciv.models.helpers.ICloneable
 import com.unciv.models.metadata.BaseRuleset
 import com.unciv.models.ruleset.tech.TechColumn
 import com.unciv.models.ruleset.tech.Technology
@@ -55,7 +56,7 @@ class ModOptions : IHasUniques {
 
 }
 
-class Ruleset {
+class Ruleset: ICloneable<Ruleset> {
 
     private val jsonParser = JsonParser()
 
@@ -84,7 +85,7 @@ class Ruleset {
     val mods = LinkedHashSet<String>()
     var modOptions = ModOptions()
 
-    fun clone(): Ruleset {
+    override fun clone(): Ruleset {
         val newRuleset = Ruleset()
         newRuleset.add(this)
         return newRuleset

--- a/core/src/com/unciv/models/stats/Stats.kt
+++ b/core/src/com/unciv/models/stats/Stats.kt
@@ -1,5 +1,6 @@
 package com.unciv.models.stats
 
+import com.unciv.models.helpers.ICloneable
 import com.unciv.models.translations.tr
 import kotlin.reflect.KMutableProperty0
 
@@ -19,7 +20,7 @@ open class Stats(
     var culture: Float = 0f,
     var happiness: Float = 0f,
     var faith: Float = 0f
-): Iterable<Stats.StatValuePair> {
+): Iterable<Stats.StatValuePair>, ICloneable<Stats> {
     // This is what facilitates indexed access by [Stat] or add(Stat,Float)
     // without additional memory allocation or expensive conditionals
     @delegate:Transient
@@ -55,7 +56,7 @@ open class Stats(
     }
 
     /** @return a new instance containing the same values as `this` */
-    fun clone() = Stats(production, food, gold, science, culture, happiness, faith)
+    override fun clone() = Stats(production, food, gold, science, culture, happiness, faith)
 
     /** @return `true` if all values are zero */
     fun isEmpty() = (

--- a/core/src/com/unciv/ui/tilegroups/TileGroup.kt
+++ b/core/src/com/unciv/ui/tilegroups/TileGroup.kt
@@ -14,10 +14,7 @@ import com.unciv.logic.civilization.CivilizationInfo
 import com.unciv.logic.map.RoadStatus
 import com.unciv.logic.map.TileInfo
 import com.unciv.models.*
-import com.unciv.models.helpers.MapArrowType
-import com.unciv.models.helpers.MiscArrowTypes
-import com.unciv.models.helpers.TintedMapArrow
-import com.unciv.models.helpers.UnitMovementMemoryType
+import com.unciv.models.helpers.*
 import com.unciv.ui.cityscreen.YieldGroup
 import com.unciv.ui.utils.*
 import kotlin.math.*
@@ -34,7 +31,7 @@ open class ActionlessGroup(val checkHit:Boolean=false):Group() {
     }
 }
 
-open class TileGroup(var tileInfo: TileInfo, val tileSetStrings:TileSetStrings, private val groupSize: Float = 54f) : ActionlessGroup(true) {
+open class TileGroup(var tileInfo: TileInfo, val tileSetStrings:TileSetStrings, private val groupSize: Float = 54f) : ActionlessGroup(true), ICloneable<TileGroup> {
     /*
     Layers:
     Base image (+ overlay)
@@ -170,7 +167,7 @@ open class TileGroup(var tileInfo: TileInfo, val tileSetStrings:TileSetStrings, 
         isTransform = false // performance helper - nothing here is rotated or scaled
     }
 
-    open fun clone(): TileGroup = TileGroup(tileInfo, tileSetStrings)
+    override fun clone(): TileGroup = TileGroup(tileInfo, tileSetStrings)
 
 
     //region init functions


### PR DESCRIPTION
There's at least 34 implementations of `fun clone()` in the codebase, and at least 8 uses of `.map { it.clone() }` or similar.

So let's unify it all with an interface, and a couple extension functions for Collections.