### PR TITLE
Try to fix #5729 as concurrency issue.

### DIFF
--- a/core/src/com/unciv/logic/civilization/CivInfoStats.kt
+++ b/core/src/com/unciv/logic/civilization/CivInfoStats.kt
@@ -46,7 +46,6 @@ class CivInfoStats(val civInfo: CivilizationInfo) {
         }
 
         val costsToPay = ArrayList<Float>()
-
         for (unit in unitsToPayFor) {
             var unitMaintenance = civWideMaintenance
             for (unique in unit.getMatchingUniques(UniqueType.UnitMaintenanceDiscount)){
@@ -54,11 +53,9 @@ class CivInfoStats(val civInfo: CivilizationInfo) {
             }
             costsToPay.add(unitMaintenance)
         }
-        // Apply global discounts
+
         // Sort by descending maintenance, then drop most expensive X units to make them free
-        // If more free than units left, returns empty sequence
-        // There's something here that causes a bug and I'm not sure where, so let's try taking this apart piece by piece
-        // We tried toInt()ing, didn't help. Let's try converting to a final list before sorting.
+        // If more free than units left, runs sum on empty sequence
         costsToPay.sortDescending()
         val numberOfUnitsToPayFor = max(0.0, costsToPay.asSequence().drop(freeUnits).sumOf { it.toDouble() } ).toFloat()
 

--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -44,9 +44,6 @@ class MapUnit {
     val movement = UnitMovementAlgorithms(this)
 
     @Transient
-    var maintenance = 1f
-
-    @Transient
     var isDestroyed = false
 
     // This is saved per each unit because if we need to recalculate viewable tiles every time a unit moves,


### PR DESCRIPTION
See https://github.com/yairm210/Unciv/issues/5729#issuecomment-1001805689 for explanation.

Tries to get rid of anything that could be modified concurrently.

Also cuts down on the loops and Unique param parsing.

Sort is done with a List instead of a Sequence, but I looked at the Kotlin sources and sorting a Sequence just calls `.toMutableList()` anyway.

Did not test for the crash I'm trying to fix, due to lack of reproducer. If the theory behind this patch is correct, then reliably reproducing the crash is basically impossible due to requiring millisecond-accurate coincidence between threads. So I have no way to tell if this will actually fix it; I assume that's what the Google Play logs are for?

(…Hm. Could stick a semaphore before the area of concern to make the timing likelier, I guess.)

Please verify that this will produce the same results as the original code!