### PR TITLE
Show unit damage/heal labels.

### DIFF
--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -214,6 +214,9 @@ class MapUnit {
     /** Array list of all the tiles that this unit has attacked since the start of its most recent turn. Used in movement arrow overlay. */
     var attacksSinceTurnStart = ArrayList<Vector2>()
 
+    /** This unit's [health] at the end of its last turn. Used to display damage/heal text. */
+    var lastTurnHealth: Int? = null
+
     //region pure functions
     fun clone(): MapUnit {
         val toReturn = MapUnit()
@@ -236,6 +239,7 @@ class MapUnit {
         toReturn.movementMemories = movementMemories.copy()
         toReturn.mostRecentMoveType = mostRecentMoveType
         toReturn.attacksSinceTurnStart = ArrayList(attacksSinceTurnStart.map { Vector2(it) })
+        toReturn.lastTurnHealth = lastTurnHealth
         return toReturn
     }
 
@@ -740,6 +744,7 @@ class MapUnit {
     }
 
     fun endTurn() {
+        lastTurnHealth = health
         if (currentMovement > 0 &&
             getTile().improvementInProgress != null
             && canBuildImprovement(getTile().getTileImprovementInProgress()!!)

--- a/core/src/com/unciv/logic/map/TileMap.kt
+++ b/core/src/com/unciv/logic/map/TileMap.kt
@@ -497,6 +497,7 @@ class TileMap {
         unit.putInTile(unitToPlaceTile)
         unit.currentMovement = unit.getMaxMovement().toFloat()
         unit.addMovementMemory()
+        unit.lastTurnHealth = unit.health
 
         // Only once we add the unit to the civ we can activate addPromotion, because it will try to update civ viewable tiles
         for (promotion in unit.baseUnit.promotions)

--- a/core/src/com/unciv/models/metadata/GameSettings.kt
+++ b/core/src/com/unciv/models/metadata/GameSettings.kt
@@ -15,6 +15,7 @@ class GameSettings {
     var showResourcesAndImprovements: Boolean = true
     var showTileYields: Boolean = false
     var showUnitMovements: Boolean = false
+    var showUnitDamage: Boolean = false
 
     var checkForDueUnits: Boolean = true
     var singleTapMove: Boolean = false

--- a/core/src/com/unciv/ui/worldscreen/mainmenu/OptionsPopup.kt
+++ b/core/src/com/unciv/ui/worldscreen/mainmenu/OptionsPopup.kt
@@ -161,16 +161,19 @@ class OptionsPopup(val previousScreen: BaseScreen) : Popup(previousScreen) {
         addYesNoRow("Show tile yields", settings.showTileYields, true) { settings.showTileYields = it } // JN
         addYesNoRow("Show worked tiles", settings.showWorkedTiles, true) { settings.showWorkedTiles = it }
         addYesNoRow("Show resources and improvements", settings.showResourcesAndImprovements, true) { settings.showResourcesAndImprovements = it }
+        addYesNoRow("Show unit damage and heal", settings.showUnitDamage, true) { settings.showUnitDamage = it }
+
+        addSeparator().padTop(20f).padBottom(20f)
+
         addYesNoRow("Show tutorials", settings.showTutorials, true) { settings.showTutorials = it }
         addMinimapSizeSlider()
-
         addYesNoRow("Show pixel units", settings.showPixelUnits, true) { settings.showPixelUnits = it }
         addYesNoRow("Show pixel improvements", settings.showPixelImprovements, true) { settings.showPixelImprovements = it }
 
+        addSeparator().padTop(20f).padBottom(20f)
+
         addResolutionSelectBox()
-
         addTileSetSelectBox()
-
         addYesNoRow("Continuous rendering", settings.continuousRendering) {
             settings.continuousRendering = it
             Gdx.graphics.isContinuousRendering = it


### PR DESCRIPTION
#3997

![image](https://user-images.githubusercontent.com/37680486/147537958-62a7f9d0-5c08-4083-816f-c5e6bbadd673.png)

With arrows:

![image](https://user-images.githubusercontent.com/37680486/147537970-5efe30ca-df4f-427e-a1ed-2aa9ffa446d3.png)

Idk. I wasn't really seeing the need for this personally, but it seemed like easy pickings.

Could make last turn's health Transient, to not add the save field. Meh, I kinda like the save-reload persistence.

Displays delta since last turn end of the unit. So it doesn't show damage taken by foreign attackers during their own turn, or taken by foreign units that were attacked before their turn. Would probably have to add a history/memory queue for health like I did for the movement arrows to change this, and altered as it's not just the unit's turn but all civs' turns that matter— Not terribly complicated, but also not really worth it. For the purposes of assessing damage taken, healed, and dealt by your own units the current system should already be fine.

Togglable in options. Only for military units.

Unlike Civ, the text is permanent and cumulative over the course of a turn. Could also make it reset on unit movement or selection/click (or even have a thread sleep to reset it after X seconds), I guess.