### PR TITLE
Add `tileScale` in `TileSetConfig`.

### DIFF
--- a/core/src/com/unciv/models/tilesets/TileSetConfig.kt
+++ b/core/src/com/unciv/models/tilesets/TileSetConfig.kt
@@ -8,6 +8,7 @@ class TileSetConfig {
     var fogOfWarColor: Color = Color.BLACK
     /** Name of the tileset to use when this one is missing images. Null to disable. */
     var fallbackTileSet: String? = "FantasyHex"
+    var tileScale: Float = 1f
     var ruleVariants: HashMap<String, Array<String>> = HashMap()
 
     fun updateConfig(other: TileSetConfig){

--- a/core/src/com/unciv/models/tilesets/TileSetConfig.kt
+++ b/core/src/com/unciv/models/tilesets/TileSetConfig.kt
@@ -8,6 +8,7 @@ class TileSetConfig {
     var fogOfWarColor: Color = Color.BLACK
     /** Name of the tileset to use when this one is missing images. Null to disable. */
     var fallbackTileSet: String? = "FantasyHex"
+    /** Scale factor for hex images, with hex center as origin. */
     var tileScale: Float = 1f
     var ruleVariants: HashMap<String, Array<String>> = HashMap()
 

--- a/core/src/com/unciv/ui/tilegroups/TileGroup.kt
+++ b/core/src/com/unciv/ui/tilegroups/TileGroup.kt
@@ -246,11 +246,11 @@ open class TileGroup(var tileInfo: TileInfo, val tileSetStrings:TileSetStrings, 
     /** Used for: Underlying tile, unit overlays, border images, perhaps for other things in the future.
      Parent should already be set when calling. */
     private fun setHexagonImageSize(hexagonImage: Image) {
-        // Using "scale" can get really confusing when positioning, how about no
         hexagonImage.setSize(hexagonImageWidth, hexagonImage.height * hexagonImageWidth / hexagonImage.width)
         hexagonImage.setOrigin(hexagonImageOrigin.first, hexagonImageOrigin.second)
         hexagonImage.x = hexagonImagePosition.first
         hexagonImage.y = hexagonImagePosition.second
+        hexagonImage.setScale(tileSetStrings.tileSetConfig.tileScale)
     }
 
     private fun updateTileImage(viewingCiv: CivilizationInfo?) {


### PR DESCRIPTION
Adds `tileScale` TileSetConfig option for all images passed through `setHexagonImageSize` to be effectively scaled up, with the origin at the center of the hex.

Default value does nothing.

This allows for some potentially quite powerful effects to be done on a per-tileset basis, and more easily:

![screenshot](https://user-images.githubusercontent.com/37680486/148012297-f695a1b6-ed18-41d5-8e1a-23ee43757245.png)

![screenshot2](https://user-images.githubusercontent.com/37680486/148012289-02c3ba4a-3deb-4d53-9a7b-4bef04df095f.png)


Super-blended terrain transitions:

![image](https://user-images.githubusercontent.com/37680486/147691627-95b74d6e-890e-4977-a008-9d3269912d93.png)

Mountain shadows:

![image](https://user-images.githubusercontent.com/37680486/147691648-33f360b2-472f-46c8-b339-e4b38e17c310.png)

City search lights:

![image](https://user-images.githubusercontent.com/37680486/147692303-2c1019e1-c39d-40c7-924c-c94e1d3466f3.png)

~~(In these experiments/examples, the terrain is visually misaligned with the hex grid. But I believe that is a limitation of my tileset experiments, not of this PR. Because the scaled-up tile can extend below each hex, the transition zones can (and, in an actual tileset, should) just be shifted south)~~