### PR TITLE
Added more yield icons to the city stats table

### DIFF
--- a/core/src/com/unciv/ui/cityscreen/CityStatsTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityStatsTable.kt
@@ -63,7 +63,7 @@ class CityStatsTable(val cityScreen: CityScreen): Table() {
                 } else "Stopped expansion".tr()
         if (cityInfo.expansion.chooseNewTileToOwn() != null)
             turnsToExpansionString +=
-                    " (${cityInfo.expansion.cultureStored}♪/${cityInfo.expansion.getCultureToNextTile()}♪)"
+                    " (${cityInfo.expansion.cultureStored}${Fonts.culture}/${cityInfo.expansion.getCultureToNextTile()}${Fonts.culture})"
 
         var turnsToPopString =
                 when {
@@ -74,7 +74,7 @@ class CityStatsTable(val cityScreen: CityScreen): Table() {
                     -> "Food converts to production"
                     else -> "Stopped population growth"
                 }.tr()
-        turnsToPopString += " (${cityInfo.population.foodStored}⁂/${cityInfo.population.getFoodToNextPopulation()}⁂)"
+        turnsToPopString += " (${cityInfo.population.foodStored}${Fonts.food}/${cityInfo.population.getFoodToNextPopulation()}${Fonts.food})"
 
         innerTable.add(unassignedPopString.toLabel()).row()
         innerTable.add(turnsToExpansionString.toLabel()).row()

--- a/core/src/com/unciv/ui/cityscreen/CityStatsTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityStatsTable.kt
@@ -63,7 +63,7 @@ class CityStatsTable(val cityScreen: CityScreen): Table() {
                 } else "Stopped expansion".tr()
         if (cityInfo.expansion.chooseNewTileToOwn() != null)
             turnsToExpansionString +=
-                    " (${cityInfo.expansion.cultureStored}/${cityInfo.expansion.getCultureToNextTile()})"
+                    " (${cityInfo.expansion.cultureStored}♪/${cityInfo.expansion.getCultureToNextTile()}♪)"
 
         var turnsToPopString =
                 when {
@@ -74,17 +74,26 @@ class CityStatsTable(val cityScreen: CityScreen): Table() {
                     -> "Food converts to production"
                     else -> "Stopped population growth"
                 }.tr()
-        turnsToPopString += " (${cityInfo.population.foodStored}/${cityInfo.population.getFoodToNextPopulation()})"
+        turnsToPopString += " (${cityInfo.population.foodStored}⁂/${cityInfo.population.getFoodToNextPopulation()}⁂)"
 
         innerTable.add(unassignedPopString.toLabel()).row()
         innerTable.add(turnsToExpansionString.toLabel()).row()
         innerTable.add(turnsToPopString.toLabel()).row()
-        if (cityInfo.isInResistance())
-            innerTable.add("In resistance for another [${cityInfo.getFlag(CityFlags.Resistance)}] turns".toLabel()).row()
-        if (cityInfo.isWeLoveTheKingDay())
-            innerTable.add("We Love The King Day for another [${cityInfo.getFlag(CityFlags.WeLoveTheKing)}] turns".toLabel()).row()
-        else if (cityInfo.demandedResource != "")
-            innerTable.add("Demanding [${cityInfo.demandedResource}]".toLabel()).row()
+        
+        val tableWithIcons = Table()
+        tableWithIcons.defaults().pad(2f)
+        if (cityInfo.isInResistance()) {
+            tableWithIcons.add(ImageGetter.getImage("StatIcons/Resistance")).size(20f)
+            tableWithIcons.add("In resistance for another [${cityInfo.getFlag(CityFlags.Resistance)}] turns".toLabel()).row()
+        }
+        if (cityInfo.isWeLoveTheKingDay()) {
+            tableWithIcons.add(ImageGetter.getStatIcon("Food")).size(20f)
+            tableWithIcons.add("We Love The King Day for another [${cityInfo.getFlag(CityFlags.WeLoveTheKing)}] turns".toLabel()).row()
+        } else if (cityInfo.demandedResource != "") {
+            tableWithIcons.add(ImageGetter.getResourceImage(cityInfo.demandedResource, 20f)).padRight(5f)
+            tableWithIcons.add("Demanding [${cityInfo.demandedResource}]".toLabel()).left().row()
+        }
+        innerTable.add(tableWithIcons).row()
     }
 
     private fun addReligionInfo() {

--- a/core/src/com/unciv/ui/utils/ExtensionFunctions.kt
+++ b/core/src/com/unciv/ui/utils/ExtensionFunctions.kt
@@ -222,7 +222,7 @@ fun String.toLabel(fontColor: Color = Color.WHITE, fontSize: Int = 18): Label {
     // We don't want to use setFontSize and setFontColor because they set the font,
     //  which means we need to rebuild the font cache which means more memory allocation.
     var labelStyle = BaseScreen.skin.get(Label.LabelStyle::class.java)
-    if(fontColor != Color.WHITE || fontSize != 18) { // if we want the default we don't need to create another style
+    if (fontColor != Color.WHITE || fontSize != 18) { // if we want the default we don't need to create another style
         labelStyle = Label.LabelStyle(labelStyle) // clone this to another
         labelStyle.fontColor = fontColor
         if (fontSize != 18) labelStyle.font = Fonts.font

--- a/core/src/com/unciv/ui/utils/Fonts.kt
+++ b/core/src/com/unciv/ui/utils/Fonts.kt
@@ -123,7 +123,7 @@ class NativeBitmapFontData(
 
 object Fonts {
 
-    /** All text is originally rendered in 50px (set in AndroidLauncher and DesktopLauncher), and thn scaled to fit the size of the text we need now.
+    /** All text is originally rendered in 50px (set in AndroidLauncher and DesktopLauncher), and then scaled to fit the size of the text we need now.
      * This has several advantages: It means we only render each character once (good for both runtime and RAM),
      * AND it means that our 'custom' emojis only need to be once size (50px) and they'll be rescaled for what's needed. */
     const val ORIGINAL_FONT_SIZE = 50f


### PR DESCRIPTION
E.g.:
![image](https://user-images.githubusercontent.com/71121390/147857251-41157762-e149-4309-9807-cc1f819d19bd.png)
![image](https://user-images.githubusercontent.com/71121390/147857254-2d021edc-2ee9-46ed-a850-95eadc0d3887.png)
![image](https://user-images.githubusercontent.com/71121390/147857261-ec2a6e08-da5d-49c7-85bf-d14e6aac52ed.png)

Alternatively, I could only put the culture and food icons after the second number, or use the happiness icon for an active 'we love the king' day.