### PR TITLE
GH Actions: Check user privileges before running bots.

### DIFF
--- a/.github/workflows/uncivbot.yml
+++ b/.github/workflows/uncivbot.yml
@@ -6,7 +6,8 @@ on:
 
 jobs:
   summary:
-    if: github.event_name == 'issue_comment' && github.event.comment.body == 'summary'
+    if: github.event_name == 'issue_comment' && github.event.comment.body == 'summary' && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+    # This is the only place I could find an apparent list of valid author associations. Also, at least they're not case-sensitive: https://docs.github.com/en/graphql/reference/enums#commentauthorassociation https://docs.github.com/en/actions/learn-github-actions/expressions#contains
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v3
@@ -55,7 +56,8 @@ jobs:
             })
 
   merge_translations:
-    if: github.event_name == 'workflow_dispatch' || github.event.comment.body == 'merge translations'
+    if: github.event_name == 'workflow_dispatch' || (github.event.comment.body == 'merge translations' && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
+    # This is the only place I could find an apparent list of valid author associations. Also, at least they're not case-sensitive: https://docs.github.com/en/graphql/reference/enums#commentauthorassociation https://docs.github.com/en/actions/learn-github-actions/expressions#contains
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v3


### PR DESCRIPTION
I don't think any of the existing actions would do much harm even if a would-be vandal did run them, but Idk it still seems suboptimal to let any random account sic a bot on the repo.

I have tested the condition expressions in my fork:

https://github.com/will-ca/Unciv/pull/33

Can confirm that the original code let any random account do stuff to the summaries and translations, and this PR stops that while still letting privileged accounts run the bots:

https://github.com/will-ca/Unciv/pull/35