### PR TITLE
Performance improvements - inspired by ANR errors for this callstack

### DIFF
--- a/core/src/com/unciv/logic/city/CityInfo.kt
+++ b/core/src/com/unciv/logic/city/CityInfo.kt
@@ -322,10 +322,11 @@ class CityInfo {
                 }
             }
         }
-        
+
+        val freeBuildings = civInfo.civConstructions.getFreeBuildings(id)
         for (building in cityConstructions.getBuiltBuildings()) {
             // Free buildings cost no resources
-            if (building.name in civInfo.civConstructions.getFreeBuildings(id))
+            if (building.name in freeBuildings)
                 continue
             for ((resourceName, amount) in building.getResourceRequirements()) {
                 val resource = getRuleset().tileResources[resourceName]!!

--- a/core/src/com/unciv/logic/civilization/CivConstructions.kt
+++ b/core/src/com/unciv/logic/civilization/CivConstructions.kt
@@ -59,7 +59,10 @@ class CivConstructions {
     fun getFreeBuildings(cityId: String): HashSet<String> {
         val toReturn = freeBuildings[cityId] ?: hashSetOf()
         for (city in civInfo.cities) {
-            toReturn.addAll(city.cityConstructions.freeBuildingsProvidedFromThisCity[cityId] ?: hashSetOf())
+            val freeBuildingsProvided =
+                city.cityConstructions.freeBuildingsProvidedFromThisCity[cityId]
+            if (freeBuildingsProvided != null)
+                toReturn.addAll(freeBuildingsProvided)
         }
         return toReturn
     }

--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -1055,8 +1055,9 @@ class CivilizationInfo {
 
     fun addUnit(unitName: String, city: CityInfo? = null): MapUnit? {
         if (cities.isEmpty()) return null
-        val cityToAddTo = city ?: cities.random()
         if (!gameInfo.ruleSet.units.containsKey(unitName)) return null
+
+        val cityToAddTo = city ?: cities.random()
         val unit = getEquivalentUnit(unitName)
         val placedUnit = placeUnitNearTile(cityToAddTo.location, unit.name)
         // silently bail if no tile to place the unit is found

--- a/core/src/com/unciv/models/ruleset/Building.kt
+++ b/core/src/com/unciv/models/ruleset/Building.kt
@@ -792,13 +792,15 @@ class Building : RulesetStatsObject(), INonPerpetualConstruction {
 
     fun isSellable() = !isAnyWonder() && !hasUnique(UniqueType.Unsellable)
 
-    override fun getResourceRequirements(): HashMap<String, Int> {
+    override fun getResourceRequirements(): HashMap<String, Int> = resourceRequirementsInternal
+
+    private val resourceRequirementsInternal: HashMap<String, Int> by lazy {
         val resourceRequirements = HashMap<String, Int>()
         if (requiredResource != null) resourceRequirements[requiredResource!!] = 1
         for (unique in uniqueObjects)
             if (unique.isOfType(UniqueType.ConsumesResources))
                 resourceRequirements[unique.params[1]] = unique.params[0].toInt()
-        return resourceRequirements
+        resourceRequirements
     }
 
     override fun requiresResource(resource: String): Boolean {

--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -582,13 +582,15 @@ class BaseUnit : RulesetObject(), INonPerpetualConstruction {
 
     fun movesLikeAirUnits() = getType().getMovementType() == UnitMovementType.Air
 
-    override fun getResourceRequirements(): HashMap<String, Int> {
+    override fun getResourceRequirements(): HashMap<String, Int> = resourceRequirementsInternal
+
+    private val resourceRequirementsInternal: HashMap<String, Int> by lazy {
         val resourceRequirements = HashMap<String, Int>()
         if (requiredResource != null) resourceRequirements[requiredResource!!] = 1
         for (unique in uniqueObjects)
             if (unique.isOfType(UniqueType.ConsumesResources))
                 resourceRequirements[unique.params[1]] = unique.params[0].toInt()
-        return resourceRequirements
+        resourceRequirements
     }
 
     override fun requiresResource(resource: String): Boolean {


### PR DESCRIPTION
A. Building and Unit resource requirements are constant - and yet we recalculate them, and create a new Hashmap, every time we want to check them

B. When checking building resource requirements, we would remake the 'which buildings are free from resource requirements' for EVERY building, whether it had resource requirements or not! Now we do that once per city.

Other changes are minor.