### PR TITLE
DropBox GH Action.

### DIFF
--- a/.github/workflows/cleanOldDropbox.yml
+++ b/.github/workflows/cleanOldDropbox.yml
@@ -1,0 +1,95 @@
+name: Clean old DropBox files.
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  clean_dropbox:
+    if: always()
+    runs-on: ubuntu-latest
+    env:
+      # TODO: Setup repo, use real secret with key?
+      GH_ARCHIVE_URL: https://secrets.PlaceholderString@github.com/account/repo.git
+      ARCHIVE_DIR: SomeArchiveRepository
+    steps:
+      - name: Setup Python.
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+      - name: Install DropBox.
+        shell: bash
+        run: "pip3 install dropbox"
+      - name: Setup Archive.
+        shell: bash
+        # TODO: Archive old saves in GH repo?
+        run: |
+          set -euo pipefail
+          echo "Cloning archive repository."
+          echo git clone "$GH_ARCHIVE_URL" "$ARCHIVE_DIR"
+          mkdir -p "$ARCHIVE_DIR"
+      - name: Clean DropBox.
+        shell: python
+        # TODO: Put key in secrets instead of hardcoded.
+        env:
+          DROPBOX_KEY: secrets.PLACEHOLDER_KEY
+        run: |
+          import dropbox, os
+          from datetime import datetime
+
+          os.chdir(os.environ['ARCHIVE_DIR'])
+          print(f"In {os.getcwd()}.")
+
+          LAST_YEAR_TO_REMOVE = 2021
+          LAST_MONTH_TO_REMOVE = 3
+          LAST_DAY_TO_REMOVE = 31
+
+
+          last_date_to_remove = datetime(LAST_YEAR_TO_REMOVE, LAST_MONTH_TO_REMOVE, LAST_DAY_TO_REMOVE)
+
+          dbx = dropbox.Dropbox("LTdBbopPUQ0AAAAAAAACxh4_Qd1eVMM7IBK3ULV3BgxzWZDMfhmgFbuUNF_rXQWb")
+          #TODO: Move this to GH secrets.
+          print(f"dbx = dropbox.Dropbox({os.environ['DROPBOX_KEY']})")
+
+          stop = False
+
+          i = 0
+          while True:
+              print("Starting with page {0}".format(i))
+              i += 1
+
+              # We can just use the list_folder and ignore the cursor
+              # as we delete all files anyway
+              folderList = dbx.files_list_folder('/MultiplayerGames')
+
+              for entry in folderList.entries:
+                  print("Found file {0}".format(entry.name))
+                  metadata = dbx.files_download_to_file(entry.name, "/MultiplayerGames/{0}".format(entry.name))
+                  print("Downloaded file {0}".format(entry.name))
+
+                  if (metadata.client_modified <= last_date_to_remove and metadata.server_modified <= last_date_to_remove and entry.name != ""):
+                      #dbx.files_delete("/MultiplayerGames/{0}".format(entry.name)) # TODO: Uncomment this to enable.
+                      print("Deleted file {0}".format(entry.name))
+                      # TODO: If it's decided to archive old saves somewhere, then the deletion should be done only after GH commit. Probably save the file paths in a file somewhere.
+                  else:
+                      stop = True
+                      break
+
+              if (stop):
+                  break
+      - name: Upload to Archive.
+        shell: bash
+        # TODO: Archive old saves in GH repo?
+        run: |
+          set -euo pipefail
+          cd "$ARCHIVE_DIR"
+          echo "In $(pwd)."
+          echo git config user.name "$GITHUB_ACTOR"
+          echo git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          echo git add .
+          echo git diff --stat --cached | cat
+          tree
+          echo git commit --allow-empty -m 'Update multiplayer archive.'
+          echo git push -f
+          echo "Done."


### PR DESCRIPTION
#5901

Python script by @xlenstra taken basically verbatim from the above issue.

Tested in my fork. Looks alright.

Has a lot of placeholders. E.G. Needs GH secrets, optional backup repository, etc. that should be simple enough in principle but I can't add through a PR.

Has code to archive old saves to a GH repository. Can either uncomment it and fill in all the placeholders to enable, or just delete those parts to reject. I like the idea of rescuing old saves. But GH provides only finite space for action runners.

Still needs to be changed to automatically set the date.

Currently the line that deletes DB files is commented out. IDK How DropBox works or is used. Recommend letting it run for a few days (or manually triggering), then uncommenting when logs look right.

---

EDIT: Well, I'll leave this open as an option, but I like @SomeTroglodyte's decentralized approach better:

> Didn't I have a branch months ago that would distribute the deletion load to the players? Like everyone who creates a new MP runs a little snippet that deletes the oldest 10 files? [*]
> 
> […]
> 
> [*] Kept it as patch in case anyone wants a read: [Automatic_DropBox_cleanup_on_newgame1.patch.zip](https://github.com/yairm210/Unciv/files/7809803/Automatic_DropBox_cleanup_on_newgame1.patch.zip)

https://github.com/yairm210/Unciv/issues/5901#issuecomment-1005092095