### PR TITLE
Resolved #5801 - detailed sources of battle modifiers

### DIFF
--- a/core/src/com/unciv/logic/battle/BattleDamage.kt
+++ b/core/src/com/unciv/logic/battle/BattleDamage.kt
@@ -14,18 +14,18 @@ import kotlin.math.min
 import kotlin.math.pow
 import kotlin.math.roundToInt
 
-class BattleDamageModifier(val vs:String, val modificationAmount:Float){
-    fun getText(): String = "vs $vs"
-}
-
 object BattleDamage {
     
     private fun getModifierStringFromUnique(unique: Unique): String {
-        return when (unique.sourceObjectType) {
+        val source =  when (unique.sourceObjectType) {
             UniqueTarget.Unit -> "Unit ability"
             UniqueTarget.Nation -> "National ability"
             else -> "[${unique.sourceObjectName}] ([${unique.sourceObjectType?.name}])"
         }
+        if (unique.conditionals.isEmpty()) return source
+
+        val conditionalsText = unique.conditionals.joinToString { it.text }
+        return "$source - $conditionalsText"
     }
 
     private fun getGeneralModifiers(combatant: ICombatant, enemy: ICombatant, combatAction: CombatAction): Counter<String> {

--- a/core/src/com/unciv/ui/worldscreen/bottombar/BattleTable.kt
+++ b/core/src/com/unciv/ui/worldscreen/bottombar/BattleTable.kt
@@ -24,7 +24,7 @@ class BattleTable(val worldScreen: WorldScreen): Table() {
     init {
         isVisible = false
         skin = BaseScreen.skin
-        background = ImageGetter.getBackground(ImageGetter.getBlue())
+        background = ImageGetter.getBackground(ImageGetter.getBlue().apply { a=0.8f })
 
         defaults().pad(5f)
         pad(5f)
@@ -130,9 +130,16 @@ class BattleTable(val worldScreen: WorldScreen): Table() {
                     }
                 else listOf()
 
-        for(i in 0..max(attackerModifiers.size,defenderModifiers.size)){
-            if (attackerModifiers.size > i) add(attackerModifiers[i].toLabel(fontSize = 14)) else add()
-            if (defenderModifiers.size > i) add(defenderModifiers[i].toLabel(fontSize = 14)) else add()
+        val quarterScreen = worldScreen.stage.width/4
+        for (i in 0..max(attackerModifiers.size,defenderModifiers.size)) {
+            if (attackerModifiers.size > i)
+                add(attackerModifiers[i].toLabel(fontSize = 14)
+                    .apply { wrap = true }).width(quarterScreen)
+            else add().width(quarterScreen)
+            if (defenderModifiers.size > i)
+                add(defenderModifiers[i].toLabel(fontSize = 14)
+                    .apply { wrap = true }).width(quarterScreen)
+            else add().width(quarterScreen)
             row().pad(2f)
         }
 


### PR DESCRIPTION
Basically, all unit modifiers that are conditional - display that condition to the user, so he knows why it activated here.


![image](https://user-images.githubusercontent.com/8366208/148287384-1f9d8357-9243-49f0-8032-5591fe6fa454.png)

Doesn't look the cleanest when we have lots of similar promotions, but all other configurations look similarly wonky:

![image](https://user-images.githubusercontent.com/8366208/148287788-7a53dc23-0c6c-410c-bf25-41d7d318c86c.png)

![image](https://user-images.githubusercontent.com/8366208/148287842-6a5df297-db0a-4f3d-ae91-d58cdc2203cc.png)

Another effect of this is that with the additional text, the Battle Table is now officially overlaying other UI elements, like the unit table:
![image](https://user-images.githubusercontent.com/8366208/148288128-4a2a81af-1371-45b3-940b-2d4354b088de.png)

And as a bonus this fixes the "left and right sides of battle table are different widths" problem, if at least one of the sides has a battle bonus of any sort :)


(Another thing that came up is that we don't display "strength before modifiers" and "strength after modifiers" but that sounds like a different PR)