### PR TITLE
Disabled the recolouring of yield icons in labels

### DIFF
--- a/core/src/com/unciv/ui/utils/ExtensionFunctions.kt
+++ b/core/src/com/unciv/ui/utils/ExtensionFunctions.kt
@@ -235,7 +235,7 @@ fun String.toLabel(fontColor: Color = Color.WHITE, fontSize: Int = 18): Label {
     if (fontColor != Color.WHITE) {
         // uncolour any font characters that should not be coloured
         for (char in Fonts.uncolorableFontCharacters) {
-            translatedText = translatedText.replace(char.toString(), "[][#ffffff]${char}[][#${fontColor}]")
+            translatedText = translatedText.replace(char.toString(), "[#ffffff]${char}[]")
         }
     }
     return Label(translatedText, labelStyle).apply { setFontScale(fontSize / Fonts.ORIGINAL_FONT_SIZE) }

--- a/core/src/com/unciv/ui/utils/ExtensionFunctions.kt
+++ b/core/src/com/unciv/ui/utils/ExtensionFunctions.kt
@@ -221,13 +221,24 @@ fun Int.toLabel() = this.toString().toLabel()
 fun String.toLabel(fontColor: Color = Color.WHITE, fontSize: Int = 18): Label {
     // We don't want to use setFontSize and setFontColor because they set the font,
     //  which means we need to rebuild the font cache which means more memory allocation.
+    
+    // To avoid recolouring icons, we use the colour markdown syntax, 
+    // instead of just applying a color via the style
+    // We also translate the string, as that fills in the placeholder tags, which prevents a 
+    // conflict between the square brackets used for those and those used for colour markdown.
+    var translatedText = "[#${fontColor}]${this.tr()}[]"
     var labelStyle = BaseScreen.skin.get(Label.LabelStyle::class.java)
-    if (fontColor != Color.WHITE || fontSize != 18) { // if we want the default we don't need to create another style
+    if (fontSize != 18) { // if we want the default we don't need to create another style
         labelStyle = Label.LabelStyle(labelStyle) // clone this to another
-        labelStyle.fontColor = fontColor
         if (fontSize != 18) labelStyle.font = Fonts.font
     }
-    return Label(this.tr(), labelStyle).apply { setFontScale(fontSize / Fonts.ORIGINAL_FONT_SIZE) }
+    if (fontColor != Color.WHITE) {
+        // uncolour any font characters that should not be coloured
+        for (char in Fonts.uncolorableFontCharacters) {
+            translatedText = translatedText.replace(char.toString(), "[][#ffffff]${char}[][#${fontColor}]")
+        }
+    }
+    return Label(translatedText, labelStyle).apply { setFontScale(fontSize / Fonts.ORIGINAL_FONT_SIZE) }
 }
 
 /**

--- a/core/src/com/unciv/ui/utils/Fonts.kt
+++ b/core/src/com/unciv/ui/utils/Fonts.kt
@@ -128,11 +128,12 @@ object Fonts {
      * AND it means that our 'custom' emojis only need to be once size (50px) and they'll be rescaled for what's needed. */
     const val ORIGINAL_FONT_SIZE = 50f
 
-    lateinit var font:BitmapFont
+    lateinit var font: BitmapFont
     fun resetFont() {
         val fontData = NativeBitmapFontData(UncivGame.Current.fontImplementation!!)
         font = BitmapFont(fontData, fontData.regions, false)
         font.setOwnsTexture(true)
+        font.data.markupEnabled = true;
     }
 
     // From https://stackoverflow.com/questions/29451787/libgdx-textureregion-to-pixmap
@@ -171,6 +172,8 @@ object Fonts {
     const val happiness = '⌣'           // U+2323 'smile' (😀 U+1F600 'grinning face')
     const val faith = '☮'               // U+262E 'peace symbol' (🕊 U+1F54A 'dove of peace')
 
+    val uncolorableFontCharacters = listOf(production, gold, food, science, culture, happiness, faith)
+    
     fun statToChar(stat: Stat): Char {
         return when (stat) {
             Stat.Food -> food


### PR DESCRIPTION
Fixes #5893 by using the colour markdown after translating the string, to avoid conflicts with the placeholder tags used in translations.

This does work, as can be seen in the picture below, but the other question is whether this switch to the markdown is desirable at all.
![image](https://user-images.githubusercontent.com/71121390/148293428-e06dbc4b-d733-4784-bc7b-5e0977ce6e25.png)
