### PR TITLE
Added a way to add moddable constants

### DIFF
--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -417,7 +417,10 @@ object Battle {
     private fun addXp(thisCombatant: ICombatant, amount: Int, otherCombatant: ICombatant) {
         var baseXP = amount
         if (thisCombatant !is MapUnitCombatant) return
-        if (thisCombatant.unit.promotions.totalXpProduced() >= thisCombatant.unit.civInfo.gameInfo.ruleSet.modOptions.maxXPfromBarbarians
+        if (
+            (thisCombatant.unit.promotions.totalXpProduced() >= thisCombatant.unit.civInfo.gameInfo.ruleSet.modOptions.maxXPfromBarbarians
+                || thisCombatant.unit.promotions.totalXpProduced() >= thisCombatant.unit.civInfo.gameInfo.ruleSet.modOptions.constants.maxXPfromBarbarians
+            )
             && otherCombatant.getCivInfo().isBarbarian()
         ) {
             return

--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -417,10 +417,8 @@ object Battle {
     private fun addXp(thisCombatant: ICombatant, amount: Int, otherCombatant: ICombatant) {
         var baseXP = amount
         if (thisCombatant !is MapUnitCombatant) return
-        if (
-            (thisCombatant.unit.promotions.totalXpProduced() >= thisCombatant.unit.civInfo.gameInfo.ruleSet.modOptions.maxXPfromBarbarians
-                || thisCombatant.unit.promotions.totalXpProduced() >= thisCombatant.unit.civInfo.gameInfo.ruleSet.modOptions.constants.maxXPfromBarbarians
-            )
+        val modConstants = thisCombatant.unit.civInfo.gameInfo.ruleSet.modOptions.constants
+        if (thisCombatant.unit.promotions.totalXpProduced() >= modConstants.maxXPfromBarbarians
             && otherCombatant.getCivInfo().isBarbarian()
         ) {
             return

--- a/core/src/com/unciv/logic/battle/CityCombatant.kt
+++ b/core/src/com/unciv/logic/battle/CityCombatant.kt
@@ -37,6 +37,7 @@ class CityCombatant(val city: CityInfo) : ICombatant {
     }
 
     fun getCityStrength(): Int { // Civ fanatics forum, from a modder who went through the original code
+        val modConstants = getCivInfo().gameInfo.ruleSet.modOptions.constants
         var strength = 8f
         strength += (city.population.population / 5) * 2 // Each 5 pop gives 2 defence
         val cityTile = city.getCenterTile()
@@ -45,7 +46,7 @@ class CityCombatant(val city: CityInfo) : ICombatant {
         // as tech progresses so does city strength
         val techCount = getCivInfo().gameInfo.ruleSet.technologies.count()
         val techsPercentKnown: Float = if (techCount > 0) city.civInfo.tech.techsResearched.count().toFloat() / techCount else 0.5f // for mods with no tech
-        strength += (techsPercentKnown * 5.5).pow(2.8).toFloat()
+        strength += (techsPercentKnown * modConstants.cityStrengthFromTechsMultiplier).pow(modConstants.cityStrengthFromTechsExponent).toFloat()
 
 
         // The way all of this adds up...

--- a/core/src/com/unciv/models/ModConstants.kt
+++ b/core/src/com/unciv/models/ModConstants.kt
@@ -1,0 +1,13 @@
+package com.unciv.models
+
+class ModConstants {
+    // Max amount of experience that can be gained from combat with barbarians
+    val maxXPfromBarbarians = 30
+
+    // Formula for city Strength:
+    // Strength = baseStrength * (%techs * multiplier) ^ exponent
+    // If no techs exist in this ruleset, %techs = 0.5
+    val cityStrengthFromTechsMultiplier = 5.5
+    val cityStrengthFromTechsExponent = 2.8
+    
+}

--- a/core/src/com/unciv/models/ModConstants.kt
+++ b/core/src/com/unciv/models/ModConstants.kt
@@ -2,7 +2,7 @@ package com.unciv.models
 
 class ModConstants {
     // Max amount of experience that can be gained from combat with barbarians
-    val maxXPfromBarbarians = 30
+    var maxXPfromBarbarians = 30
 
     // Formula for city Strength:
     // Strength = baseStrength * (%techs * multiplier) ^ exponent

--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -159,6 +159,8 @@ class Ruleset {
         if (modOptionsFile.exists()) {
             try {
                 modOptions = jsonParser.getFromJson(ModOptions::class.java, modOptionsFile)
+                if (modOptions.maxXPfromBarbarians != 30)
+                    modOptions.constants.maxXPfromBarbarians = modOptions.constants.maxXPfromBarbarians
             } catch (ex: Exception) {}
             modOptions.uniqueObjects = modOptions.uniques.map { Unique(it, UniqueTarget.ModOptions) }
         }

--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -5,6 +5,7 @@ import com.badlogic.gdx.files.FileHandle
 import com.unciv.JsonParser
 import com.unciv.logic.UncivShowableException
 import com.unciv.models.Counter
+import com.unciv.models.ModConstants
 import com.unciv.models.metadata.BaseRuleset
 import com.unciv.models.ruleset.tech.TechColumn
 import com.unciv.models.ruleset.tech.Technology
@@ -46,6 +47,7 @@ class ModOptions : IHasUniques {
     var author = ""
     var modSize = 0
  
+    @Deprecated("As of 3.18.15")
     val maxXPfromBarbarians = 30
 
     override var uniques = ArrayList<String>()
@@ -53,6 +55,8 @@ class ModOptions : IHasUniques {
     override var uniqueObjects: List<Unique> = listOf()
     override fun getUniqueTarget() = UniqueTarget.ModOptions
 
+    val constants = ModConstants()
+    
 }
 
 class Ruleset {
@@ -581,6 +585,10 @@ class Ruleset {
         }
         for (unitType in unitTypes.values) {
             checkUniques(unitType, lines, UniqueType.UniqueComplianceErrorSeverity.RulesetSpecific)
+        }
+        
+        if (modOptions.maxXPfromBarbarians != 30) {
+            lines.add("maxXPfromBarbarians is moved to the constants object, instead use: \nconstants: {\n    maxXPfromBarbarians: ${modOptions.maxXPfromBarbarians},\n}", RulesetErrorSeverity.Warning)
         }
 
         return lines


### PR DESCRIPTION
The original game had a file named `globalDefines.xml`, which contained a lot of constants that could easily change the formula's the game uses. Until now, Unciv didn't have any equivalent of that, which for example required the techstopper mod series to add a lot of bogus techs to the end of the tech tree, in order to avoid city strength getting to information-era levels in the renaissance.
This PR creates a way to change these constants, by adding them as optional parameters in the `ModOptions.json` file. It can later be extended in a similar manner to allow for more moddability of similar formula's. An additional idea for the `ModConstants` file is to be understandable by non-coders, and reference all formula's the constants are used in in there as well.
