### PR TITLE
Remove support for stat-named specialists

### DIFF
--- a/core/src/com/unciv/models/ruleset/Building.kt
+++ b/core/src/com/unciv/models/ruleset/Building.kt
@@ -26,20 +26,8 @@ class Building : RulesetStatsObject(), INonPerpetualConstruction {
     var cost: Int = 0
     var maintenance = 0
     private var percentStatBonus: Stats? = null
-    private var specialistSlots: Counter<String>? = null
-    fun newSpecialists(): Counter<String> {
-        if (specialistSlots == null) return Counter()
-        // Could have old specialist values of "gold", "science" etc - change them to the new specialist names
-        val counter = Counter<String>()
-        for ((entry, amount) in specialistSlots!!) {
-            val equivalentStat = Stat.values().firstOrNull { it.name.lowercase() == entry }
-
-            if (equivalentStat != null)
-                counter[Specialist.specialistNameByStat(equivalentStat)] = amount
-            else counter[entry] = amount
-        }
-        return counter
-    }
+    var specialistSlots: Counter<String> = Counter()
+    fun newSpecialists(): Counter<String>  = specialistSlots
 
     var greatPersonPoints = Counter<String>()
 

--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -456,6 +456,10 @@ class Ruleset {
         for (building in buildings.values) {
             if (building.requiredTech != null && !technologies.containsKey(building.requiredTech!!))
                 lines += "${building.name} requires tech ${building.requiredTech} which does not exist!"
+
+            for (specialistName in building.specialistSlots.keys)
+                if (!specialists.containsKey(specialistName))
+                    lines += "${building.name} provides specialist $specialistName which does not exist!"
             for (resource in building.getResourceRequirements().keys)
                 if (!tileResources.containsKey(resource))
                     lines += "${building.name} requires resource $resource which does not exist!"


### PR DESCRIPTION
Way back when we moved from designating specialists by stat, {"science":2}, to by name, {"scientist":2}.
We still left in support for the old way.
But it's high time we removed that.