### PR TITLE
Handling for multiplayer download errors

### DIFF
--- a/core/src/com/unciv/ui/multiplayer/MultiplayerScreen.kt
+++ b/core/src/com/unciv/ui/multiplayer/MultiplayerScreen.kt
@@ -193,20 +193,20 @@ class MultiplayerScreen(previousScreen: BaseScreen) : PickerScreen() {
         loadingGamePopup.add("Loading latest game state...".tr())
         loadingGamePopup.open()
 
-        // For whatever reason, the only way to show the popup before the ANRs started was to
-        // call the loadGame explicitly with a runnable on the main thread.
-        // Maybe this adds just enough lag for the popup to show up
-
-        postCrashHandlingRunnable {
+        crashHandlingThread(name = "JoinMultiplayerGame") {
             try {
-                game.loadGame(OnlineMultiplayer().tryDownloadGame((multiplayerGames[selectedGameFile]!!.gameId)))
+                val gameId = multiplayerGames[selectedGameFile]!!.gameId
+                val gameInfo = OnlineMultiplayer().tryDownloadGame(gameId)
+                postCrashHandlingRunnable { game.loadGame(gameInfo) }
             } catch (ex: Exception) {
-                loadingGamePopup.close()
-                val errorPopup = Popup(this)
-                errorPopup.addGoodSizedLabel("Could not download game!")
-                errorPopup.row()
-                errorPopup.addCloseButton()
-                errorPopup.open()
+                postCrashHandlingRunnable {
+                    loadingGamePopup.close()
+                    val errorPopup = Popup(this)
+                    errorPopup.addGoodSizedLabel("Could not download game!")
+                    errorPopup.row()
+                    errorPopup.addCloseButton()
+                    errorPopup.open()
+                }
             }
         }
     }


### PR DESCRIPTION
From Google Play Console:

```
java.lang.NullPointerException: 
  at com.unciv.ui.MultiplayerScreen$joinMultiplayerGame$1.invoke (MultiplayerScreen.kt:201)
  at com.unciv.ui.MultiplayerScreen$joinMultiplayerGame$1.invoke (MultiplayerScreen.kt:200)
  at com.unciv.ui.utils.ExtensionFunctionsKt$wrapCrashHandling$1.invoke (ExtensionFunctions.kt:333)
  at com.unciv.ui.utils.ExtensionFunctionsKt$wrapCrashHandlingUnit$1.invoke (ExtensionFunctions.kt:360)
  at com.unciv.ui.utils.ExtensionFunctionsKt$wrapCrashHandlingUnit$1.invoke (ExtensionFunctions.kt:360)
  at com.unciv.ui.utils.CrashHandlingThreadKt.postCrashHandlingRunnable$lambda-0 (CrashHandlingThread.kt:25)
  at com.unciv.ui.utils.CrashHandlingThreadKt.$r8$lambda$i-0Qwhv18vHQotMwK6u-N-zChmE (Unknown Source)
  at com.unciv.ui.utils.CrashHandlingThreadKt$$ExternalSyntheticLambda0.run (Unknown Source:2)
  at com.badlogic.gdx.backends.android.AndroidGraphics.onDrawFrame (AndroidGraphics.java:464)
  at android.opengl.GLSurfaceView$GLThread.guardedRun (GLSurfaceView.java:1591)
  at android.opengl.GLSurfaceView$GLThread.run (GLSurfaceView.java:1286)
```

Caused by the replacement of the crash handler with the exception crash handler, but this revealed a non-threaded IO download which should definitely have been threaded.