### PR TITLE
Tint colour and not alpha in CityTileGroup.

### DIFF
--- a/core/src/com/unciv/ui/tilegroups/TileGroup.kt
+++ b/core/src/com/unciv/ui/tilegroups/TileGroup.kt
@@ -57,7 +57,7 @@ open class TileGroup(var tileInfo: TileInfo, val tileSetStrings:TileSetStrings, 
     class BaseLayerGroupClass:ActionlessGroup()
     val baseLayerGroup = BaseLayerGroupClass().apply { isTransform = false; setSize(groupSize, groupSize)  }
 
-    private var tileBaseImages: ArrayList<Image> = ArrayList()
+    val tileBaseImages: ArrayList<Image> = ArrayList()
     /** List of image locations comprising the layers so we don't need to change images all the time */
     private var tileImageIdentifiers = listOf<String>()
 

--- a/core/src/com/unciv/ui/utils/BaseScreen.kt
+++ b/core/src/com/unciv/ui/utils/BaseScreen.kt
@@ -46,7 +46,7 @@ open class BaseScreen : Screen {
     override fun show() {}
 
     override fun render(delta: Float) {
-        Gdx.gl.glClearColor(0f, 0f, 0.2f, 1f)
+        Gdx.gl.glClearColor(clearColor.r, clearColor.g, clearColor.b, clearColor.a)
         Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT)
 
         stage.act()
@@ -102,6 +102,8 @@ open class BaseScreen : Screen {
             skin.get(SelectBox.SelectBoxStyle::class.java).font = Fonts.font.apply { data.setScale(20 / Fonts.ORIGINAL_FONT_SIZE) }
             skin.get(SelectBox.SelectBoxStyle::class.java).listStyle.font = Fonts.font.apply { data.setScale(20 / Fonts.ORIGINAL_FONT_SIZE) }
         }
+        /** Colour to use for empty sections of the screen. */
+        val clearColor = Color(0f, 0f, 0.2f, 1f)
     }
 
     fun onBackButtonClicked(action: () -> Unit) {


### PR DESCRIPTION
Closes #5954.

#5874 made it possible for tilesets to blend tile images by overlapping each other.

However, CityTileGroup uses alpha to dim tiles, which means that can lead to unexpected results. So this PR changes the dimming to work through non-alpha components instead.

Secondary effect: Fixes layered rendering in dimmed areas. Before, GDX seemed to do something weird to the children of a Group with fractional alpha, which looks more like additive or divisive blending than alpha compositing. (Something, something, straight premultiplied.) See: ghostly white hills, lime green forests, very soft iconographic overlays in Default, strangely bright boundaries between tiles.

Secondary effect: Terrain features that extend "above" the hex cover up the hexes to the north instead of being translucent. In a way this is more realistic, because it's like the entire tile is in shadow. See the mountain southeast of the city in the comparisons.

Visual difference: Alpha fadeout squeezes both white and black to the background colour at full strength. Multiplicative tinting remaps white but leaves black at black. Hence this PR may look darker in some cases (while preserving the same amount of contrast). See the Pix5 oceans.

Tested with FantasyHex, Default, (blended) 5Hex, and Pix5. Checked existing calls/assignments to the `.color`s being set, clicked around a bit on the CityScreen, didn't find any conflicts.

Previous is left. This PR is right. Clearer at full size:

![Dim](https://user-images.githubusercontent.com/37680486/149556100-dd3d3acc-f402-43ff-9cc0-6475af6c75c7.png)
