### PR TITLE
Update English.properties. (Remove no-op translations.)

### DIFF
--- a/android/assets/jsons/translations/English.properties
+++ b/android/assets/jsons/translations/English.properties
@@ -1321,12 +1321,12 @@ Stop automation =
 Construct road = 
  # Requires translation!
 Fortify = 
-Fortify until healed = Fortify until healed
+Fortify until healed = 
  # Requires translation!
 Fortification = 
  # Requires translation!
 Sleep = 
-Sleep until healed = Sleep until healed
+Sleep until healed = 
  # Requires translation!
 Moving = 
  # Requires translation!
@@ -7216,19 +7216,19 @@ Wolfpack III =
 
  # Requires translation!
 Aircraft Carrier = 
-Armor Plating I = Armor Plating I
+Armor Plating I = 
 
-Armor Plating II = Armor Plating II
+Armor Plating II = 
 
-Armor Plating III = Armor Plating III
+Armor Plating III = 
 
-Flight Deck I = Flight Deck I
+Flight Deck I = 
  # Requires translation!
 Can carry [amount] extra [mapUnitFilter] units = 
 
-Flight Deck II = Flight Deck II
+Flight Deck II = 
 
-Flight Deck III = Flight Deck III
+Flight Deck III = 
 
  # Requires translation!
 Supply = 
@@ -9175,22 +9175,22 @@ Landship =
 
  # Requires translation!
 Introduction = 
-Welcome to Unciv!\nBecause this is a complex game, there are basic tasks to help familiarize you with the game.\nThese are completely optional, and you're welcome to explore the game on your own! = Welcome to Unciv!\nBecause this is a complex game, there are basic tasks to help familiarize you with the game.\nThese are completely optional, and you're welcome to explore the game on your own!
+Welcome to Unciv!\nBecause this is a complex game, there are basic tasks to help familiarize you with the game.\nThese are completely optional, and you're welcome to explore the game on your own! = 
 
  # Requires translation!
 New Game = 
-Your first mission is to found your capital city.\nThis is actually an important task because your capital city will probably be your most prosperous.\nMany game bonuses apply only to your capital city and it will probably be the center of your empire. = Your first mission is to found your capital city.\nThis is actually an important task because your capital city will probably be your most prosperous.\nMany game bonuses apply only to your capital city and it will probably be the center of your empire.
-How do you know a spot is appropriate?\nThat’s not an easy question to answer, but looking for and building next to luxury resources is a good rule of thumb.\nLuxury resources are tiles that have things like gems, cotton, or silk (indicated by a smiley next to the resource icon)\nThese resources make your civilization happy. You should also keep an eye out for resources needed to build units, such as iron. Cities cannot be built within 3 tiles of existing cities, which is another thing to watch out for! = How do you know a spot is appropriate?\nThat’s not an easy question to answer, but looking for and building next to luxury resources is a good rule of thumb.\nLuxury resources are tiles that have things like gems, cotton, or silk (indicated by a smiley next to the resource icon)\nThese resources make your civilization happy. You should also keep an eye out for resources needed to build units, such as iron.
-However, cities don’t have a set area that they can work - more on that later!\nThis means you don’t have to settle cities right next to resources.\nLet’s say, for example, that you want access to some iron – but the resource is right next to a desert.\nYou don’t have to settle your city next to the desert. You can settle a few tiles away in more prosperous lands.\nYour city will grow and eventually gain access to the resource.\nYou only need to settle right next to resources if you need them immediately – \n   which might be the case now and then, but you’ll usually have the luxury of time. = However, cities don’t have a set area that they can work - more on that later!\nThis means you don’t have to settle cities right next to resources.\nLet’s say, for example, that you want access to some iron – but the resource is right next to a desert.\nYou don’t have to settle your city next to the desert. You can settle a few tiles away in more prosperous lands.\nYour city will grow and eventually gain access to the resource.\nYou only need to settle right next to resources if you need them immediately – \n   which might be the case now and then, but you’ll usually have the luxury of time.
-The first thing coming out of your city should be either a Scout or Warrior.\nI generally prefer the Warrior because it can be used for defense and because it can be upgraded\n  to the Swordsman unit later in the game for a relatively modest sum of gold.\nScouts can be effective, however, if you seem to be located in an area of dense forest and hills.\nScouts don’t suffer a movement penalty in this terrain.\nIf you’re a veteran of the 4x strategy genre your first Warrior or Scout will be followed by a Settler.\nFast expanding is absolutely critical in most games of this type. = The first thing coming out of your city should be either a Scout or Warrior.\nI generally prefer the Warrior because it can be used for defense and because it can be upgraded\n  to the Swordsman unit later in the game for a relatively modest sum of gold.\nScouts can be effective, however, if you seem to be located in an area of dense forest and hills.\nScouts don’t suffer a movement penalty in this terrain.\nIf you’re a veteran of the 4x strategy genre your first Warrior or Scout will be followed by a Settler.\nFast expanding is absolutely critical in most games of this type.
+Your first mission is to found your capital city.\nThis is actually an important task because your capital city will probably be your most prosperous.\nMany game bonuses apply only to your capital city and it will probably be the center of your empire. = 
+How do you know a spot is appropriate?\nThat’s not an easy question to answer, but looking for and building next to luxury resources is a good rule of thumb.\nLuxury resources are tiles that have things like gems, cotton, or silk (indicated by a smiley next to the resource icon)\nThese resources make your civilization happy. You should also keep an eye out for resources needed to build units, such as iron. Cities cannot be built within 3 tiles of existing cities, which is another thing to watch out for! = 
+However, cities don’t have a set area that they can work - more on that later!\nThis means you don’t have to settle cities right next to resources.\nLet’s say, for example, that you want access to some iron – but the resource is right next to a desert.\nYou don’t have to settle your city next to the desert. You can settle a few tiles away in more prosperous lands.\nYour city will grow and eventually gain access to the resource.\nYou only need to settle right next to resources if you need them immediately – \n   which might be the case now and then, but you’ll usually have the luxury of time. = 
+The first thing coming out of your city should be either a Scout or Warrior.\nI generally prefer the Warrior because it can be used for defense and because it can be upgraded\n  to the Swordsman unit later in the game for a relatively modest sum of gold.\nScouts can be effective, however, if you seem to be located in an area of dense forest and hills.\nScouts don’t suffer a movement penalty in this terrain.\nIf you’re a veteran of the 4x strategy genre your first Warrior or Scout will be followed by a Settler.\nFast expanding is absolutely critical in most games of this type. = 
 
-In your first couple of turns, you will have very little options, but as your civilization grows, so do the number of things requiring your attention. = In your first couple of turns, you will have very little options, but as your civilization grows, so do the number of things requiring your attention.
+In your first couple of turns, you will have very little options, but as your civilization grows, so do the number of things requiring your attention. = 
 
  # Requires translation!
 Culture and Policies = 
-Each turn, the culture you gain from all your cities is added to your Civilization's culture.\nWhen you have enough culture, you may pick a Social Policy, each one giving you a certain bonus. = Each turn, the culture you gain from all your cities is added to your Civilization's culture.\nWhen you have enough culture, you may pick a Social Policy, each one giving you a certain bonus.
-The policies are organized into branches, with each branch providing a bonus ability when all policies in the branch have been adopted. = The policies are organized into branches, with each branch providing a bonus ability when all policies in the branch have been adopted.
-With each policy adopted, and with each city built,\n  the cost of adopting another policy rises - so choose wisely! = With each policy adopted, and with each city built,\n  the cost of adopting another policy rises - so choose wisely!
+Each turn, the culture you gain from all your cities is added to your Civilization's culture.\nWhen you have enough culture, you may pick a Social Policy, each one giving you a certain bonus. = 
+The policies are organized into branches, with each branch providing a bonus ability when all policies in the branch have been adopted. = 
+With each policy adopted, and with each city built,\n  the cost of adopting another policy rises - so choose wisely! = 
 
  # Requires translation!
 City Expansion = 
@@ -9201,26 +9201,26 @@ Each additional tile will require more culture, but generally your first cities 
  # Requires translation!
 Although your city will keep expanding forever, your citizens can only work 3 tiles away from city center.\nThis should be taken into account when placing new cities. = 
 
-As cities grow in size and influence, you have to deal with a happiness mechanic that is no longer tied to each individual city.\nInstead, your entire empire shares the same level of satisfaction.\nAs your cities grow in population you’ll find that it is more and more difficult to keep your empire happy. = As cities grow in size and influence, you have to deal with a happiness mechanic that is no longer tied to each individual city.\nInstead, your entire empire shares the same level of satisfaction.\nAs your cities grow in population you’ll find that it is more and more difficult to keep your empire happy.
-In addition, you can’t even build any city improvements that increase happiness until you’ve done the appropriate research.\nIf your empire’s happiness ever goes below zero the growth rate of your cities will be hurt.\nIf your empire becomes severely unhappy (as indicated by the smiley-face icon at the top of the interface)\n  your armies will have a big penalty slapped on to their overall combat effectiveness. = In addition, you can’t even build any city improvements that increase happiness until you’ve done the appropriate research.\nIf your empire’s happiness ever goes below zero the growth rate of your cities will be hurt.\nIf your empire becomes severely unhappy (as indicated by the smiley-face icon at the top of the interface)\n  your armies will have a big penalty slapped on to their overall combat effectiveness.
+As cities grow in size and influence, you have to deal with a happiness mechanic that is no longer tied to each individual city.\nInstead, your entire empire shares the same level of satisfaction.\nAs your cities grow in population you’ll find that it is more and more difficult to keep your empire happy. = 
+In addition, you can’t even build any city improvements that increase happiness until you’ve done the appropriate research.\nIf your empire’s happiness ever goes below zero the growth rate of your cities will be hurt.\nIf your empire becomes severely unhappy (as indicated by the smiley-face icon at the top of the interface)\n  your armies will have a big penalty slapped on to their overall combat effectiveness. = 
  # Requires translation!
 This means that it is very difficult to expand quickly in Unciv.\nIt isn’t impossible, but as a new player you probably shouldn't do it.\nSo what should you do? Chill out, scout, and improve the land that you do have by building Workers.\nOnly build new cities once you have found a spot that you believe is appropriate. = 
 
-Unhappiness = Unhappiness
-It seems that your citizens are unhappy!\nWhile unhappy, cities  will grow at 1/4 the speed, and your units will suffer a 2% penalty for each unhappiness = It seems that your citizens are unhappy!\nWhile unhappy, cities  will grow at 1/4 the speed, and your units will suffer a 2% penalty for each unhappiness
-Unhappiness has two main causes: Population and cities.\n  Each city causes 3 unhappiness, and each population, 1 = Unhappiness has two main causes: Population and cities.\n  Each city causes 3 unhappiness, and each population, 1
+Unhappiness = 
+It seems that your citizens are unhappy!\nWhile unhappy, cities  will grow at 1/4 the speed, and your units will suffer a 2% penalty for each unhappiness = 
+Unhappiness has two main causes: Population and cities.\n  Each city causes 3 unhappiness, and each population, 1 = 
  # Requires translation!
 There are 2 main ways to combat unhappiness:\n  by building happiness buildings for your population\n  or by having improved luxury resources within your borders. = 
 
-You have entered a Golden Age!\nGolden age points are accumulated each turn by the total happiness \n  of your civilization\nWhen in a golden age, culture and production generation increases +20%,\n  and every tile already providing at least one gold will provide an extra gold. = You have entered a Golden Age!\nGolden age points are accumulated each turn by the total happiness \n  of your civilization\nWhen in a golden age, culture and production generation increases +20%,\n  and every tile already providing at least one gold will provide an extra gold.
+You have entered a Golden Age!\nGolden age points are accumulated each turn by the total happiness \n  of your civilization\nWhen in a golden age, culture and production generation increases +20%,\n  and every tile already providing at least one gold will provide an extra gold. = 
 
  # Requires translation!
 Roads and Railroads = 
-Connecting your cities to the capital by roads\n  will generate gold via the trade route.\nNote that each road costs 1 gold Maintenance per turn, and each Railroad costs 2 gold,\n  so it may be more economical to wait until the cities grow! = Connecting your cities to the capital by roads\n  will generate gold via the trade route.\nNote that each road costs 1 gold Maintenance per turn, and each Railroad costs 2 gold,\n  so it may be more economical to wait until the cities grow!
+Connecting your cities to the capital by roads\n  will generate gold via the trade route.\nNote that each road costs 1 gold Maintenance per turn, and each Railroad costs 2 gold,\n  so it may be more economical to wait until the cities grow! = 
 
  # Requires translation!
 Victory Types = 
-Once you’ve settled your first two or three cities you’re probably 100 to 150 turns into the game.\nNow is a good time to start thinking about how, exactly, you want to win – if you haven’t already. = Once you’ve settled your first two or three cities you’re probably 100 to 150 turns into the game.\nNow is a good time to start thinking about how, exactly, you want to win – if you haven’t already.
+Once you’ve settled your first two or three cities you’re probably 100 to 150 turns into the game.\nNow is a good time to start thinking about how, exactly, you want to win – if you haven’t already. = 
  # Requires translation!
 There are four ways to win in Unciv. They are:\n - Cultural Victory: Complete 5 Social Policy Trees and build the Utopia Project\n - Domination Victory: Survive as the last civilization\n - Science Victory: Be the first to construct a spaceship to Alpha Centauri\n - Diplomatic Victory: Build the United Nations and win the vote = 
  # Requires translation!
@@ -9228,11 +9228,11 @@ So to sum it up, these are the basics of Unciv – Found a prosperous first city
 
  # Requires translation!
 Enemy City = 
-Cities can be conquered by reducing their health to 1, and entering the city with a melee unit.\nSince cities heal each turn, it is best to attack with ranged units and use your melee units to defend them until the city has been defeated! = Cities can be conquered by reducing their health to 1, and entering the city with a melee unit.\nSince cities heal each turn, it is best to attack with ranged units and use your melee units to defend them until the city has been defeated!
+Cities can be conquered by reducing their health to 1, and entering the city with a melee unit.\nSince cities heal each turn, it is best to attack with ranged units and use your melee units to defend them until the city has been defeated! = 
 
  # Requires translation!
 Luxury Resource = 
-Luxury resources within your domain and with their specific improvement are connected to your trade network.\nEach unique Luxury resource you have adds 5 happiness to your civilization, but extra resources of the same type don't add anything, so use them for trading with other civilizations! = Luxury resources within your domain and with their specific improvement are connected to your trade network.\nEach unique Luxury resource you have adds 5 happiness to your civilization, but extra resources of the same type don't add anything, so use them for trading with other civilizations!
+Luxury resources within your domain and with their specific improvement are connected to your trade network.\nEach unique Luxury resource you have adds 5 happiness to your civilization, but extra resources of the same type don't add anything, so use them for trading with other civilizations! = 
 
  # Requires translation!
 Strategic Resource = 
@@ -9241,48 +9241,48 @@ Strategic resources within your domain and with their specific improvement are c
  # Requires translation!
 Unlike Luxury Resources, each Strategic Resource on the map provides more than one of that resource.\nThe top bar keeps count of how many unused strategic resources you own.\nA full drilldown of resources is available in the Resources tab in the Overview screen. = 
 
-The city can no longer put up any resistance!\nHowever, to conquer it, you must enter the city with a melee unit = The city can no longer put up any resistance!\nHowever, to conquer it, you must enter the city with a melee unit
+The city can no longer put up any resistance!\nHowever, to conquer it, you must enter the city with a melee unit = 
 
  # Requires translation!
 After Conquering = 
 When conquering a city, you can now choose to either  or raze, puppet, or annex the city.\nRazing the city will lower its population by 1 each turn until the city is destroyed. = When conquering a city, you can now choose to either  or raze, puppet, or annex the city.\nRazing the city will lower its population by 1 each turn until the city is destroyed.
 Puppeting the city will mean that you have no control on the city's production.\nThe city will not increase your tech or policy cost, but its citizens will generate 1.5x the regular unhappiness.\nAnnexing the city will give you control over the production, but will increase the citizen's unhappiness to 2x!\nThis can be mitigated by building a courthouse in the city, returning the citizen's unhappiness to normal.\nA puppeted city can be annexed at any time, but annexed cities cannot be returned to a puppeted state! = Puppeting the city will mean that you have no control on the city's production.\nThe city will not increase your tech or policy cost, but its citizens will generate 1.5x the regular unhappiness.\nAnnexing the city will give you control over the production, but will increase the citizen's unhappiness to 2x!\nThis can be mitigated by building a courthouse in the city, returning the citizen's unhappiness to normal.\nA puppeted city can be annexed at any time, but annexed cities cannot be returned to a puppeted state!
 
-You have encountered a barbarian unit!\nBarbarians attack everyone indiscriminately, so don't let your \n  civilian units go near them, and be careful of your scout! = You have encountered a barbarian unit!\nBarbarians attack everyone indiscriminately, so don't let your \n  civilian units go near them, and be careful of your scout!
+You have encountered a barbarian unit!\nBarbarians attack everyone indiscriminately, so don't let your \n  civilian units go near them, and be careful of your scout! = 
 
-You have encountered another civilization!\nOther civilizations start out peaceful, and you can trade with them,\n  but they may choose to declare war on you later on = You have encountered another civilization!\nOther civilizations start out peaceful, and you can trade with them,\n  but they may choose to declare war on you later on
+You have encountered another civilization!\nOther civilizations start out peaceful, and you can trade with them,\n  but they may choose to declare war on you later on = 
 
-Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities\n (with the relevant technologies) to win a Scientific Victory! = Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities\n (with the relevant technologies) to win a Scientific Victory!
+Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities\n (with the relevant technologies) to win a Scientific Victory! = 
 
  # Requires translation!
 Injured Units = 
-Injured units deal less damage, but recover after turns that they have been inactive.\nUnits heal 5 health per turn in enemy territory, 10 in neutral land,\n  15 inside your territory and 20 in your cities. = Injured units deal less damage, but recover after turns that they have been inactive.\nUnits heal 5 health per turn in enemy territory, 10 in neutral land,\n  15 inside your territory and 20 in your cities.
+Injured units deal less damage, but recover after turns that they have been inactive.\nUnits heal 5 health per turn in enemy territory, 10 in neutral land,\n  15 inside your territory and 20 in your cities. = 
 
  # Requires translation!
 Workers = 
-Workers are vital to your cities' growth, since only they can construct improvements on tiles.\nImprovements raise the yield of your tiles, allowing your city to produce more and grow faster while working the same amount of tiles! = Workers are vital to your cities' growth, since only they can construct improvements on tiles.\nImprovements raise the yield of your tiles, allowing your city to produce more and grow faster while working the same amount of tiles!
+Workers are vital to your cities' growth, since only they can construct improvements on tiles.\nImprovements raise the yield of your tiles, allowing your city to produce more and grow faster while working the same amount of tiles! = 
 
  # Requires translation!
 Siege Units = 
-Siege units are extremely powerful against cities, but need to be Set Up before they can attack.\nOnce your siege unit is set up, it can attack from the current tile,\n  but once moved to another tile, it will need to be set up again. = Siege units are extremely powerful against cities, but need to be Set Up before they can attack.\nOnce your siege unit is set up, it can attack from the current tile,\n  but once moved to another tile, it will need to be set up again.
+Siege units are extremely powerful against cities, but need to be Set Up before they can attack.\nOnce your siege unit is set up, it can attack from the current tile,\n  but once moved to another tile, it will need to be set up again. = 
 
  # Requires translation!
 Embarking = 
-Once a certain tech is researched, your land units can embark, allowing them to traverse water tiles.\nEntering or leaving water takes the entire turn.\nUnits are defenseless while embarked, so be careful! = Once a certain tech is researched, your land units can embark, allowing them to traverse water tiles.\nEntering or leaving water takes the entire turn.\nUnits are defenseless while embarked, so be careful!
+Once a certain tech is researched, your land units can embark, allowing them to traverse water tiles.\nEntering or leaving water takes the entire turn.\nUnits are defenseless while embarked, so be careful! = 
 
  # Requires translation!
 Idle Units = 
-If you don't want to move a unit this turn, you can skip it by clicking 'Next unit' again.\nIf you won't be moving it for a while, you can have the unit enter Fortify or Sleep mode - \n  units in Fortify or Sleep are not considered idle units.\nIf you want to disable the 'Next unit' feature entirely, you can toggle it in Menu -> Check for idle units. = If you don't want to move a unit this turn, you can skip it by clicking 'Next unit' again.\nIf you won't be moving it for a while, you can have the unit enter Fortify or Sleep mode - \n  units in Fortify or Sleep are not considered idle units.\nIf you want to disable the 'Next unit' feature entirely, you can toggle it in Menu -> Check for idle units.
+If you don't want to move a unit this turn, you can skip it by clicking 'Next unit' again.\nIf you won't be moving it for a while, you can have the unit enter Fortify or Sleep mode - \n  units in Fortify or Sleep are not considered idle units.\nIf you want to disable the 'Next unit' feature entirely, you can toggle it in Menu -> Check for idle units. = 
 
  # Requires translation!
 Contact Me = 
-Hi there! If you've played this far, you've probably seen that the game is currently incomplete.\n UnCiv is meant to be open-source and free, forever.\n That means no ads or any other nonsense. = Hi there! If you've played this far, you've probably seen that the game is currently incomplete.\n UnCiv is meant to be open-source and free, forever.\n That means no ads or any other nonsense.
-What motivates me to keep working on it, \n  besides the fact I think it's amazingly cool that I can,\n  is the support from the players - you guys are the best! = What motivates me to keep working on it, \n  besides the fact I think it's amazingly cool that I can,\n  is the support from the players - you guys are the best!
-Every rating and review that I get puts a smile on my face =)\n  So contact me! Send me an email, review, Github issue\n  or mail pigeon, and let's figure out how to make the game \n  even more awesome!\n(Contact info is in the Play Store) = Every rating and review that I get puts a smile on my face =)\n  So contact me! Send me an email, review, Github issue\n  or mail pigeon, and let's figure out how to make the game \n  even more awesome!\n(Contact info is in the Play Store)
+Hi there! If you've played this far, you've probably seen that the game is currently incomplete.\n UnCiv is meant to be open-source and free, forever.\n That means no ads or any other nonsense. = 
+What motivates me to keep working on it, \n  besides the fact I think it's amazingly cool that I can,\n  is the support from the players - you guys are the best! = 
+Every rating and review that I get puts a smile on my face =)\n  So contact me! Send me an email, review, Github issue\n  or mail pigeon, and let's figure out how to make the game \n  even more awesome!\n(Contact info is in the Play Store) = 
 
  # Requires translation!
 Pillaging = 
-Military units can pillage improvements, which heals them 25 health and ruins the improvement.\nThe tile can still be worked, but advantages from the improvement - stat bonuses and resources - will be lost.\nWorkers can repair these improvements, which takes less time than building the improvement from scratch. = Military units can pillage improvements, which heals them 25 health and ruins the improvement.\nThe tile can still be worked, but advantages from the improvement - stat bonuses and resources - will be lost.\nWorkers can repair these improvements, which takes less time than building the improvement from scratch.
+Military units can pillage improvements, which heals them 25 health and ruins the improvement.\nThe tile can still be worked, but advantages from the improvement - stat bonuses and resources - will be lost.\nWorkers can repair these improvements, which takes less time than building the improvement from scratch. = 
 
  # Requires translation!
 Experience = 


### PR DESCRIPTION
REGEX search: `^(.+) = \1`

Skipped the AfterConquering tutorial strings as they would conflict with #5976.

Four translations remain in English.properties, which seem to add spaces/remove a word from "WaterCivilian", "WaterMelee", "WaterRanged", and "WaterSubmarine".

Found and may fix one apparent case where the template string was updated at some point without updating the English translation, which would have probably led to the updated version being hidden. ("Cities cannot be built within 3 tiles of…")

I don't know what the original reason was for duplicating so many strings… Seems a holdover from an old refactor of the translations system (#2114), maybe a convention that was never adopted or a precaution that became unnecessary?