### PR TITLE
Fixed assumption that the current game is in the list of games gathered from preview files

### DIFF
--- a/android/src/com/unciv/app/MultiplayerTurnCheckWorker.kt
+++ b/android/src/com/unciv/app/MultiplayerTurnCheckWorker.kt
@@ -186,7 +186,11 @@ class MultiplayerTurnCheckWorker(appContext: Context, workerParams: WorkerParame
 
             if (currentGameInfo.currentPlayerCiv.playerId == settings.userId) {
                 // May be useful to remind a player that he forgot to complete his turn.
-                notifyUserAboutTurn(applicationContext, gameNames[gameIds.indexOf(currentGameInfo.gameId)])
+                val gameIndex = gameIds.indexOf(currentGameInfo.gameId)
+                // Of the turnNotification is OFF, this will be -1 since we never saved this game in the array
+                // Or possibly reading the preview file returned an exception
+                if (gameIndex!=-1)
+                    notifyUserAboutTurn(applicationContext, gameNames[gameIndex])
             } else {
                 val inputData = workDataOf(Pair(FAIL_COUNT, 0), Pair(GAME_ID, gameIds), Pair(GAME_NAME, gameNames),
                         Pair(USER_ID, settings.userId), Pair(CONFIGURED_DELAY, settings.multiplayerTurnCheckerDelayInMinutes),


### PR DESCRIPTION
Context, from Google Play Console:

```
java.lang.RuntimeException: 
  at android.app.ActivityThread.performPauseActivityIfNeeded (ActivityThread.java:4872)
  at android.app.ActivityThread.performPauseActivity (ActivityThread.java:4818)
  at android.app.ActivityThread.handlePauseActivity (ActivityThread.java:4766)
  at android.app.servertransaction.PauseActivityItem.execute (PauseActivityItem.java:46)
  at android.app.servertransaction.TransactionExecutor.executeLifecycleState (TransactionExecutor.java:176)
  at android.app.servertransaction.TransactionExecutor.execute (TransactionExecutor.java:97)
  at android.app.ActivityThread$H.handleMessage (ActivityThread.java:2135)
  at android.os.Handler.dispatchMessage (Handler.java:106)
  at android.os.Looper.loop (Looper.java:236)
  at android.app.ActivityThread.main (ActivityThread.java:8056)
  at java.lang.reflect.Method.invoke (Native Method)
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:656)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:967)
Caused by: java.lang.ArrayIndexOutOfBoundsException: 
  at com.unciv.app.MultiplayerTurnCheckWorker$Companion.startTurnChecker (MultiplayerTurnCheckWorker.kt:189)
  at com.unciv.app.AndroidLauncher.onPause (AndroidLauncher.kt:73)
  at android.app.Activity.performPause (Activity.java:8360)
  at android.app.Instrumentation.callActivityOnPause (Instrumentation.java:1511)
  at android.app.ActivityThread.performPauseActivityIfNeeded (ActivityThread.java:4862)
```

This happens a lot. Like, 240 times in the last month.