### PR TITLE
civInfo.exploredTiles immutability

### DIFF
--- a/core/src/com/unciv/logic/civilization/CivInfoTransientUpdater.kt
+++ b/core/src/com/unciv/logic/civilization/CivInfoTransientUpdater.kt
@@ -16,14 +16,15 @@ class CivInfoTransientUpdater(val civInfo: CivilizationInfo) {
 
         updateLastSeenImprovements()
 
-        // updating the viewable tiles also affects the explored tiles, obviously.
-        // So why don't we play switcharoo with the explored tiles as well?
-        // Well, because it gets REALLY LARGE so it's a lot of memory space,
-        // and we never actually iterate on the explored tiles (only check contains()),
-        // so there's no fear of concurrency problems.
+
         val newlyExploredTiles = civInfo.viewableTiles.asSequence().map { it.position }
-                .filterNot { civInfo.exploredTiles.contains(it) }
-        civInfo.exploredTiles.addAll(newlyExploredTiles)
+            .filterNot { civInfo.exploredTiles.contains(it) }
+        if (newlyExploredTiles.any()) { // no need to allocate memory if no new tiles are added
+            val newExploredTiles = HashSet(civInfo.exploredTiles)
+            newExploredTiles.addAll(newlyExploredTiles)
+            civInfo.exploredTiles = newExploredTiles
+        }
+
 
 
         val viewedCivs = HashMap<CivilizationInfo, TileInfo>()

--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -154,7 +154,9 @@ class CivilizationInfo {
     // This is basically a way to ensure our lists are immutable.
     var cities = listOf<CityInfo>()
     var citiesCreated = 0
-    var exploredTiles = HashSet<Vector2>()
+    /** Do not add tiles to this directly - instead, create a copy, add to the copy, and switch to retain immutability
+     * Unfortunately we can't make this a setOf since the json parser doesn't know what to make of existing data... */
+    var exploredTiles = hashSetOf<Vector2>()
 
     // This double construction because for some reason the game wants to load a
     // map<Vector2, String> as a map<String, String> causing all sorts of type problems.
@@ -240,7 +242,7 @@ class CivilizationInfo {
         // This is the only thing that is NOT switched out, which makes it a source of ConcurrentModification errors.
         // Cloning it by-pointer is a horrific move, since the serialization would go over it ANYWAY and still lead to concurrency problems.
         // Cloning it by iterating on the tilemap values may seem ridiculous, but it's a perfectly thread-safe way to go about it, unlike the other solutions.
-        toReturn.exploredTiles.addAll(gameInfo.tileMap.values.asSequence().map { it.position }.filter { it in exploredTiles })
+        toReturn.exploredTiles = exploredTiles
         toReturn.lastSeenImprovementSaved.putAll(lastSeenImprovement.mapKeys { it.key.toString() })
         toReturn.notifications.addAll(notifications)
         toReturn.citiesCreated = citiesCreated

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -257,8 +257,9 @@ object UniqueTriggerActivation {
                 if (notification != null) {
                     civInfo.addNotification(notification, "UnitIcons/Scout")
                 }
-                return civInfo.exploredTiles.addAll(
-                    civInfo.gameInfo.tileMap.values.asSequence().map { it.position })
+                civInfo.exploredTiles = civInfo.gameInfo.tileMap.values
+                    .asSequence().map { it.position }.toHashSet()
+                return true
             }
 
             UnitsGainPromotion -> {
@@ -406,8 +407,12 @@ object UniqueTriggerActivation {
                         .apply {
                             if (unique.params[0] != "All") this.take(unique.params[0].toInt())
                         }
+
+                val newExploredTiles = civInfo.exploredTiles.toHashSet()
+                newExploredTiles.addAll(revealedTiles)
+                civInfo.exploredTiles = newExploredTiles
+
                 for (position in revealedTiles) {
-                    civInfo.exploredTiles.add(position)
                     val revealedTileInfo = civInfo.gameInfo.tileMap[position]
                     if (revealedTileInfo.improvement == null)
                         civInfo.lastSeenImprovement.remove(position)
@@ -435,7 +440,11 @@ object UniqueTriggerActivation {
                     .getTilesInDistance(unique.params[1].toInt())
                     .map { it.position }
                     .filter { tileBasedRandom.nextFloat() < unique.params[2].toFloat() / 100f }
-                civInfo.exploredTiles.addAll(tilesToReveal)
+
+                val newExploredTiles = civInfo.exploredTiles.toHashSet()
+                newExploredTiles.addAll(tilesToReveal)
+                civInfo.exploredTiles = newExploredTiles
+
                 civInfo.updateViewableTiles()
                 if (notification != null)
                     civInfo.addNotification(


### PR DESCRIPTION
exploredTiles being mutable has been causing concurrency errors when autosaving for a while now. it's time to come to terms with the fact that exploredTiles needs to be immutable as well, and switched out upon change.