### PR TITLE
Resolved #5988 - Allow modded improvements

### DIFF
--- a/core/src/com/unciv/logic/map/TileInfo.kt
+++ b/core/src/com/unciv/logic/map/TileInfo.kt
@@ -472,7 +472,7 @@ open class TileInfo {
     /** Without regards to what CivInfo it is, a lot of the checks are just for the improvement on the tile.
      *  Doubles as a check for the map editor.
      */
-    private fun canImprovementBeBuiltHere(improvement: TileImprovement, resourceIsVisible: Boolean = resource != null): Boolean {
+    fun canImprovementBeBuiltHere(improvement: TileImprovement, resourceIsVisible: Boolean = resource != null): Boolean {
         val topTerrain = getLastTerrain()
 
         return when {


### PR DESCRIPTION
Current worker automation assumes A LOT about the current ruleset.
This is only step 1, which allows skipping irrelevant improvements to reach actually useful improvements.
Comments welcome.