### PR TITLE
Refactor and unify some buttons that have a label next to an icon.

### DIFF
--- a/core/src/com/unciv/CrashScreen.kt
+++ b/core/src/com/unciv/CrashScreen.kt
@@ -171,7 +171,7 @@ class CrashScreen(val exception: Throwable): BaseScreen() {
 
     /** @return Table that displays decision buttons for the bottom of the screen. */
     private fun makeActionButtonsTable(): Table {
-        val copyButton = "Copy".toButton()
+        val copyButton = "Copy".toButton(fontSize = 24)
             .onClick {
                 Gdx.app.clipboard.contents = text
                 copied = true
@@ -180,7 +180,7 @@ class CrashScreen(val exception: Throwable): BaseScreen() {
                     this@CrashScreen
                 )
             }
-        val reportButton = "Open Issue Tracker".toButton(icon = "OtherIcons/Link")
+        val reportButton = "Open Issue Tracker".toButton(fontSize = 24, icon = ImageGetter.getImage("OtherIcons/Link"))
             .onClick {
                 if (copied) {
                     Gdx.net.openURI("https://github.com/yairm210/Unciv/issues")
@@ -191,7 +191,7 @@ class CrashScreen(val exception: Throwable): BaseScreen() {
                     )
                 }
             }
-        val closeButton = "Close Unciv".toButton()
+        val closeButton = "Close Unciv".toButton(fontSize = 24)
             .onClick { Gdx.app.exit() }
 
         val buttonsTable = Table()

--- a/core/src/com/unciv/CrashScreen.kt
+++ b/core/src/com/unciv/CrashScreen.kt
@@ -171,7 +171,7 @@ class CrashScreen(val exception: Throwable): BaseScreen() {
 
     /** @return Table that displays decision buttons for the bottom of the screen. */
     private fun makeActionButtonsTable(): Table {
-        val copyButton = "Copy".toButton(fontSize = 24, icon = null) // Explicit null because I haven't been able to figure out how to make Kotlin infer a generic from a default parameter.
+        val copyButton = IconTextButton("Copy", null, 24) // Explicit null because I haven't been able to figure out how to make Kotlin infer a generic from a default parameter.
             .onClick {
                 Gdx.app.clipboard.contents = text
                 copied = true
@@ -180,7 +180,7 @@ class CrashScreen(val exception: Throwable): BaseScreen() {
                     this@CrashScreen
                 )
             }
-        val reportButton = "Open Issue Tracker".toButton(fontSize = 24, icon = ImageGetter.getImage("OtherIcons/Link"))
+        val reportButton = IconTextButton("Open Issue Tracker", ImageGetter.getImage("OtherIcons/Link"), 24)
             .onClick {
                 if (copied) {
                     Gdx.net.openURI("https://github.com/yairm210/Unciv/issues")
@@ -191,7 +191,7 @@ class CrashScreen(val exception: Throwable): BaseScreen() {
                     )
                 }
             }
-        val closeButton = "Close Unciv".toButton(fontSize = 24, icon = null) // Explicit null because I haven't been able to figure out how to make Kotlin infer a generic from a default parameter.
+        val closeButton = IconTextButton("Close Unciv", null, 24) // Explicit null because I haven't been able to figure out how to make Kotlin infer a generic from a default parameter.
             .onClick { Gdx.app.exit() }
 
         val buttonsTable = Table()

--- a/core/src/com/unciv/CrashScreen.kt
+++ b/core/src/com/unciv/CrashScreen.kt
@@ -171,7 +171,7 @@ class CrashScreen(val exception: Throwable): BaseScreen() {
 
     /** @return Table that displays decision buttons for the bottom of the screen. */
     private fun makeActionButtonsTable(): Table {
-        val copyButton = "Copy".toButton(fontSize = 24)
+        val copyButton = "Copy".toButton(fontSize = 24, icon = null) // Explicit null because I haven't been able to figure out how to make Kotlin infer a generic from a default parameter.
             .onClick {
                 Gdx.app.clipboard.contents = text
                 copied = true
@@ -191,7 +191,7 @@ class CrashScreen(val exception: Throwable): BaseScreen() {
                     )
                 }
             }
-        val closeButton = "Close Unciv".toButton(fontSize = 24)
+        val closeButton = "Close Unciv".toButton(fontSize = 24, icon = null) // Explicit null because I haven't been able to figure out how to make Kotlin infer a generic from a default parameter.
             .onClick { Gdx.app.exit() }
 
         val buttonsTable = Table()

--- a/core/src/com/unciv/CrashScreen.kt
+++ b/core/src/com/unciv/CrashScreen.kt
@@ -171,7 +171,7 @@ class CrashScreen(val exception: Throwable): BaseScreen() {
 
     /** @return Table that displays decision buttons for the bottom of the screen. */
     private fun makeActionButtonsTable(): Table {
-        val copyButton = IconTextButton("Copy", null, 24) // Explicit null because I haven't been able to figure out how to make Kotlin infer a generic from a default parameter.
+        val copyButton = IconTextButton("Copy", fontSize = 24)
             .onClick {
                 Gdx.app.clipboard.contents = text
                 copied = true
@@ -191,7 +191,7 @@ class CrashScreen(val exception: Throwable): BaseScreen() {
                     )
                 }
             }
-        val closeButton = IconTextButton("Close Unciv", null, 24) // Explicit null because I haven't been able to figure out how to make Kotlin infer a generic from a default parameter.
+        val closeButton = IconTextButton("Close Unciv", fontSize = 24)
             .onClick { Gdx.app.exit() }
 
         val buttonsTable = Table()

--- a/core/src/com/unciv/ui/civilopedia/CivilopediaScreen.kt
+++ b/core/src/com/unciv/ui/civilopedia/CivilopediaScreen.kt
@@ -223,10 +223,7 @@ class CivilopediaScreen(
 
         var currentX = 10f  // = padLeft
         for (categoryKey in categoryToEntries.keys) {
-            val button = Button(skin)
-            if (categoryKey.headerIcon.isNotEmpty())
-                button.add(ImageGetter.getImage(categoryKey.headerIcon)).size(20f).padRight(5f)
-            button.add(categoryKey.label.toLabel())
+            val button = categoryKey.label.toButton(icon = if (categoryKey.headerIcon.isNotEmpty()) ImageGetter.getImage(categoryKey.headerIcon) else null)
             button.addTooltip(categoryKey.key)
 //            button.style = ImageButton.ImageButtonStyle(button.style)
             button.onClick { selectCategory(categoryKey) }

--- a/core/src/com/unciv/ui/civilopedia/CivilopediaScreen.kt
+++ b/core/src/com/unciv/ui/civilopedia/CivilopediaScreen.kt
@@ -223,7 +223,8 @@ class CivilopediaScreen(
 
         var currentX = 10f  // = padLeft
         for (categoryKey in categoryToEntries.keys) {
-            val button = IconTextButton(categoryKey.label, if (categoryKey.headerIcon.isNotEmpty()) ImageGetter.getImage(categoryKey.headerIcon) else null)
+            val icon = if (categoryKey.headerIcon.isNotEmpty()) ImageGetter.getImage(categoryKey.headerIcon) else null
+            val button = IconTextButton(categoryKey.label, icon)
             button.addTooltip(categoryKey.key)
 //            button.style = ImageButton.ImageButtonStyle(button.style)
             button.onClick { selectCategory(categoryKey) }

--- a/core/src/com/unciv/ui/civilopedia/CivilopediaScreen.kt
+++ b/core/src/com/unciv/ui/civilopedia/CivilopediaScreen.kt
@@ -223,7 +223,7 @@ class CivilopediaScreen(
 
         var currentX = 10f  // = padLeft
         for (categoryKey in categoryToEntries.keys) {
-            val button = categoryKey.label.toButton(icon = if (categoryKey.headerIcon.isNotEmpty()) ImageGetter.getImage(categoryKey.headerIcon) else null)
+            val button = IconTextButton(categoryKey.label, if (categoryKey.headerIcon.isNotEmpty()) ImageGetter.getImage(categoryKey.headerIcon) else null)
             button.addTooltip(categoryKey.key)
 //            button.style = ImageButton.ImageButtonStyle(button.style)
             button.onClick { selectCategory(categoryKey) }

--- a/core/src/com/unciv/ui/overviewscreen/EmpireOverviewScreen.kt
+++ b/core/src/com/unciv/ui/overviewscreen/EmpireOverviewScreen.kt
@@ -54,7 +54,7 @@ class EmpireOverviewScreen(private var viewingPlayer:CivilizationInfo, defaultPa
                 game.settings.addCompletedTutorialTask("See your stats breakdown")
             game.settings.lastOverviewPage = name
         }
-        val button = name.toButton(icon = if (iconAndKey.icon != "") ImageGetter.getImage(iconAndKey.icon) else null)
+        val button = IconTextButton(name, if (iconAndKey.icon != "") ImageGetter.getImage(iconAndKey.icon) else null)
         if (!disabled && keyboardAvailable && iconAndKey.key != Char.MIN_VALUE) {
             button.addTooltip(iconAndKey.key)
             keyPressDispatcher[iconAndKey.key] = setCategoryAction

--- a/core/src/com/unciv/ui/overviewscreen/EmpireOverviewScreen.kt
+++ b/core/src/com/unciv/ui/overviewscreen/EmpireOverviewScreen.kt
@@ -54,12 +54,7 @@ class EmpireOverviewScreen(private var viewingPlayer:CivilizationInfo, defaultPa
                 game.settings.addCompletedTutorialTask("See your stats breakdown")
             game.settings.lastOverviewPage = name
         }
-        val button = Button(skin)
-        if (iconAndKey.icon != "") {
-            val image = ImageGetter.getImage(iconAndKey.icon)
-            button.add(image).size(20f).pad(5f)
-        }
-        button.add(name.toLabel(Color.WHITE)).pad(5f)
+        val button = name.toButton(icon = if (iconAndKey.icon != "") ImageGetter.getImage(iconAndKey.icon) else null)
         if (!disabled && keyboardAvailable && iconAndKey.key != Char.MIN_VALUE) {
             button.addTooltip(iconAndKey.key)
             keyPressDispatcher[iconAndKey.key] = setCategoryAction

--- a/core/src/com/unciv/ui/overviewscreen/EmpireOverviewScreen.kt
+++ b/core/src/com/unciv/ui/overviewscreen/EmpireOverviewScreen.kt
@@ -54,7 +54,8 @@ class EmpireOverviewScreen(private var viewingPlayer:CivilizationInfo, defaultPa
                 game.settings.addCompletedTutorialTask("See your stats breakdown")
             game.settings.lastOverviewPage = name
         }
-        val button = IconTextButton(name, if (iconAndKey.icon != "") ImageGetter.getImage(iconAndKey.icon) else null)
+        val icon = if (iconAndKey.icon != "") ImageGetter.getImage(iconAndKey.icon) else null
+        val button = IconTextButton(name, icon)
         if (!disabled && keyboardAvailable && iconAndKey.key != Char.MIN_VALUE) {
             button.addTooltip(iconAndKey.key)
             keyPressDispatcher[iconAndKey.key] = setCategoryAction

--- a/core/src/com/unciv/ui/overviewscreen/UnitOverviewTable.kt
+++ b/core/src/com/unciv/ui/overviewscreen/UnitOverviewTable.kt
@@ -82,7 +82,7 @@ class UnitOverviewTable(
             )) {
                 val baseUnit = unit.baseUnit()
 
-                val button = unit.displayName().toButton(icon = UnitGroup(unit, 20f))
+                val button = IconTextButton(unit.displayName(), UnitGroup(unit, 20f))
                 button.onClick {
                     game.setWorldScreen()
                     game.worldScreen.mapHolder.setCenterPosition(unit.currentTile.position)

--- a/core/src/com/unciv/ui/overviewscreen/UnitOverviewTable.kt
+++ b/core/src/com/unciv/ui/overviewscreen/UnitOverviewTable.kt
@@ -1,7 +1,6 @@
 package com.unciv.ui.overviewscreen
 
 import com.badlogic.gdx.graphics.Color
-import com.badlogic.gdx.scenes.scene2d.ui.Button
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.unciv.logic.civilization.CivilizationInfo
 import com.unciv.models.translations.tr
@@ -83,9 +82,7 @@ class UnitOverviewTable(
             )) {
                 val baseUnit = unit.baseUnit()
 
-                val button = Button(skin)
-                button.add(UnitGroup(unit, 20f)).padRight(5f)
-                button.add(unit.displayName().toLabel())
+                val button = unit.displayName().toButton(icon = UnitGroup(unit, 20f))
                 button.onClick {
                     game.setWorldScreen()
                     game.worldScreen.mapHolder.setCenterPosition(unit.currentTile.position)

--- a/core/src/com/unciv/ui/pickerscreens/DiplomaticVotePickerScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/DiplomaticVotePickerScreen.kt
@@ -1,13 +1,11 @@
 package com.unciv.ui.pickerscreens
 
-import com.badlogic.gdx.scenes.scene2d.ui.Button
 import com.unciv.UncivGame
 import com.unciv.logic.civilization.CivilizationInfo
 import com.unciv.models.UncivSound
 import com.unciv.models.translations.tr
 import com.unciv.ui.utils.ImageGetter
 import com.unciv.ui.utils.onClick
-import com.unciv.ui.utils.toLabel
 
 class DiplomaticVotePickerScreen(private val votingCiv: CivilizationInfo) : PickerScreen() {
     private var chosenCiv: String? = null
@@ -21,10 +19,7 @@ class DiplomaticVotePickerScreen(private val votingCiv: CivilizationInfo) : Pick
         val choosableCivs = votingCiv.gameInfo.civilizations.filter { it.isMajorCiv() && it != votingCiv && !it.isDefeated() }
         for (civ in choosableCivs)
         {
-            val button = Button(skin)
-
-            button.add(ImageGetter.getNationIndicator(civ.nation, 30f)).pad(10f)
-            button.add(civ.civName.toLabel()).pad(10f)
+            val button = getPickerOptionButton(ImageGetter.getNationIndicator(civ.nation, pickerOptionIconSize), civ.civName)
             button.pack()
             button.onClick {
                 chosenCiv = civ.civName

--- a/core/src/com/unciv/ui/pickerscreens/GreatPersonPickerScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/GreatPersonPickerScreen.kt
@@ -1,15 +1,11 @@
 package com.unciv.ui.pickerscreens
 
-import com.badlogic.gdx.scenes.scene2d.ui.Button
 import com.unciv.UncivGame
 import com.unciv.logic.civilization.CivilizationInfo
 import com.unciv.models.UncivSound
 import com.unciv.models.ruleset.unit.BaseUnit
 import com.unciv.models.translations.tr
-import com.unciv.ui.utils.ImageGetter
-import com.unciv.ui.utils.isEnabled
-import com.unciv.ui.utils.onClick
-import com.unciv.ui.utils.toLabel
+import com.unciv.ui.utils.*
 
 class GreatPersonPickerScreen(val civInfo:CivilizationInfo) : PickerScreen() {
     private var theChosenOne: BaseUnit? = null
@@ -22,10 +18,7 @@ class GreatPersonPickerScreen(val civInfo:CivilizationInfo) : PickerScreen() {
         val useMayaLongCount = civInfo.greatPeople.mayaLimitedFreeGP > 0
 
         for (unit in greatPersonUnits) {
-            val button = Button(skin)
-
-            button.add(ImageGetter.getUnitIcon(unit.name)).size(30f).pad(10f)
-            button.add(unit.name.toLabel()).pad(10f)
+            val button = getPickerOptionButton(ImageGetter.getUnitIcon(unit.name), unit.name)
             button.pack()
             button.isEnabled = !useMayaLongCount || unit.name in civInfo.greatPeople.longCountGPPool
             if (button.isEnabled) button.onClick {

--- a/core/src/com/unciv/ui/pickerscreens/ImprovementPickerScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/ImprovementPickerScreen.kt
@@ -2,8 +2,6 @@ package com.unciv.ui.pickerscreens
 
 import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.scenes.scene2d.Group
-import com.badlogic.gdx.scenes.scene2d.Touchable
-import com.badlogic.gdx.scenes.scene2d.ui.Button
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.utils.Align
 import com.unciv.Constants
@@ -16,7 +14,6 @@ import com.unciv.models.stats.Stats
 import com.unciv.models.translations.tr
 import com.unciv.ui.utils.*
 import com.unciv.ui.utils.UncivTooltip.Companion.addTooltip
-import kotlin.math.round
 import kotlin.math.roundToInt
 
 class ImprovementPickerScreen(val tileInfo: TileInfo, unit: MapUnit, val onAccept: ()->Unit) : PickerScreen() {
@@ -62,11 +59,7 @@ class ImprovementPickerScreen(val tileInfo: TileInfo, unit: MapUnit, val onAccep
             if (!tileInfo.canBuildImprovement(improvement, currentPlayerCiv)) continue
             if (!unit.canBuildImprovement(improvement)) continue
 
-            val improvementButtonTable = Table()
-
             val image = ImageGetter.getImprovementIcon(improvement.name, 30f)
-
-            improvementButtonTable.add(image).size(30f).pad(10f)
 
             // allow multiple key mappings to technologically supersede each other
             var shortcutKey = improvement.shortcutKey
@@ -94,15 +87,6 @@ class ImprovementPickerScreen(val tileInfo: TileInfo, unit: MapUnit, val onAccep
                     && improvement.name != RoadStatus.Railroad.name && !improvement.name.startsWith("Remove") && improvement.name != Constants.cancelImprovementOrder)
             if (tileInfo.improvement != null && removeImprovement) labelText += "\n" + "Replaces [${tileInfo.improvement}]".tr()
 
-            improvementButtonTable.add(labelText.toLabel()).pad(10f)
-
-            improvementButtonTable.touchable = Touchable.enabled
-            improvementButtonTable.onClick {
-                selectedImprovement = improvement
-                pick(improvement.name.tr())
-                descriptionLabel.setText(improvement.getDescription(ruleSet))
-            }
-
             val pickNow = if (tileInfo.improvementInProgress != improvement.name)
                 "Pick now!".toLabel().onClick { accept(improvement) }
             else "Current construction".toLabel()
@@ -124,8 +108,13 @@ class ImprovementPickerScreen(val tileInfo: TileInfo, unit: MapUnit, val onAccep
 
             regularImprovements.add(statIcons).align(Align.right)
 
-            val improvementButton = Button(skin)
-            improvementButton.add(improvementButtonTable).pad(5f).fillY()
+            val improvementButton = getPickerOptionButton(image, labelText)
+            improvementButton.onClick {
+                selectedImprovement = improvement
+                pick(improvement.name.tr())
+                descriptionLabel.setText(improvement.getDescription(ruleSet))
+            }
+
             if (improvement.name == tileInfo.improvementInProgress) improvementButton.color = Color.GREEN
             regularImprovements.add(improvementButton)
 

--- a/core/src/com/unciv/ui/pickerscreens/PickerScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/PickerScreen.kt
@@ -1,5 +1,6 @@
 package com.unciv.ui.pickerscreens
 
+import com.badlogic.gdx.scenes.scene2d.Actor
 import com.badlogic.gdx.scenes.scene2d.ui.*
 import com.unciv.Constants
 import com.unciv.UncivGame
@@ -87,5 +88,17 @@ open class PickerScreen(disableScroll: Boolean = false) : BaseScreen() {
     /** Remove listeners from [rightSideButton] to prepare giving it a new onClick */
     fun removeRightSideClickListeners() {
         rightSideButton.clearListeners()
+    }
+
+    companion object {
+        /** Icon size used in [getPickerOptionButton]. */
+        const val pickerOptionIconSize = 30f
+        /** Return a button for picker screens that display a list of big buttons with icons and labels. */
+        fun <I: Actor?> getPickerOptionButton(icon: I, label: String): Button {
+            return label.toButton(icon = icon) {
+                iconCell!!.size(pickerOptionIconSize).pad(10f)
+                labelCell.pad(10f)
+            }
+        }
     }
 }

--- a/core/src/com/unciv/ui/pickerscreens/PickerScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/PickerScreen.kt
@@ -94,7 +94,7 @@ open class PickerScreen(disableScroll: Boolean = false) : BaseScreen() {
         /** Icon size used in [getPickerOptionButton]. */
         const val pickerOptionIconSize = 30f
         /** Return a button for picker screens that display a list of big buttons with icons and labels. */
-        fun <I: Actor?> getPickerOptionButton(icon: I, label: String): Button {
+        fun getPickerOptionButton(icon: Actor, label: String): Button {
             return IconTextButton(label, icon).apply {
                 iconCell!!.size(pickerOptionIconSize).pad(10f)
                 labelCell.pad(10f)

--- a/core/src/com/unciv/ui/pickerscreens/PickerScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/PickerScreen.kt
@@ -95,7 +95,7 @@ open class PickerScreen(disableScroll: Boolean = false) : BaseScreen() {
         const val pickerOptionIconSize = 30f
         /** Return a button for picker screens that display a list of big buttons with icons and labels. */
         fun <I: Actor?> getPickerOptionButton(icon: I, label: String): Button {
-            return label.toButton(icon = icon) {
+            return IconTextButton(label, icon).apply {
                 iconCell!!.size(pickerOptionIconSize).pad(10f)
                 labelCell.pad(10f)
             }

--- a/core/src/com/unciv/ui/pickerscreens/PromotionPickerScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/PromotionPickerScreen.kt
@@ -1,7 +1,6 @@
 package com.unciv.ui.pickerscreens
 
 import com.badlogic.gdx.graphics.Color
-import com.badlogic.gdx.scenes.scene2d.ui.Button
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.utils.Align
 import com.unciv.UncivGame
@@ -77,9 +76,7 @@ class PromotionPickerScreen(val unit: MapUnit) : PickerScreen() {
             val isPromotionAvailable = promotion in unitAvailablePromotions
             val unitHasPromotion = unit.promotions.promotions.contains(promotion.name)
 
-            val selectPromotionButton = Button(skin)
-            selectPromotionButton.add(ImageGetter.getPromotionIcon(promotion.name)).size(30f).pad(10f)
-            selectPromotionButton.add(promotion.name.toLabel()).pad(10f).padRight(20f)
+            val selectPromotionButton = getPickerOptionButton(ImageGetter.getPromotionIcon(promotion.name), promotion.name)
             selectPromotionButton.isEnabled = true
             selectPromotionButton.onClick {
                 val enable = canBePromoted && isPromotionAvailable && !unitHasPromotion && canChangeState

--- a/core/src/com/unciv/ui/trade/OffersListScroll.kt
+++ b/core/src/com/unciv/ui/trade/OffersListScroll.kt
@@ -76,7 +76,7 @@ class OffersListScroll(
                         ImageGetter.getNationIndicator(UncivGame.Current.gameInfo.ruleSet.nations[offer.name]!!, 30f)
                     else -> null
                 }
-                val tradeButton = tradeLabel.toButton(icon = tradeIcon) {
+                val tradeButton = IconTextButton(tradeLabel, tradeIcon).apply {
                     iconCell?.size(30f)
                     label.setAlignment(Align.center)
                     labelCell.pad(5f).grow()

--- a/core/src/com/unciv/ui/trade/OffersListScroll.kt
+++ b/core/src/com/unciv/ui/trade/OffersListScroll.kt
@@ -2,6 +2,7 @@ package com.unciv.ui.trade
 
 import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.scenes.scene2d.ui.Table
+import com.badlogic.gdx.utils.Align
 import com.unciv.Constants
 import com.unciv.UncivGame
 import com.unciv.logic.trade.TradeOffer
@@ -67,14 +68,18 @@ class OffersListScroll(
             }
 
             for (offer in offersOfType) {
-                val tradeButton = offer.getOfferText(untradableOffers.filter { it.resource.name == offer.name }.sumOf { it.amount }).toTextButton()
-                tradeButton.labelCell.pad(5f)
-                when (offer.type) {
+                val tradeLabel = offer.getOfferText(untradableOffers.filter { it.resource.name == offer.name }.sumOf { it.amount })
+                val tradeIcon = when (offer.type) {
                     Luxury_Resource, Strategic_Resource ->
-                        tradeButton.add(ImageGetter.getResourceImage(offer.name, 30f))
+                        ImageGetter.getResourceImage(offer.name, 30f)
                     WarDeclaration ->
-                        tradeButton.add(ImageGetter.getNationIndicator(UncivGame.Current.gameInfo.ruleSet.nations[offer.name]!!, 30f))
-                    else -> Unit // Remove warning
+                        ImageGetter.getNationIndicator(UncivGame.Current.gameInfo.ruleSet.nations[offer.name]!!, 30f)
+                    else -> null
+                }
+                val tradeButton = tradeLabel.toButton(icon = tradeIcon) {
+                    iconCell?.size(30f)
+                    label.setAlignment(Align.center)
+                    labelCell.pad(5f).grow()
                 }
                 
                 val amountPerClick =

--- a/core/src/com/unciv/ui/utils/ExtensionFunctions.kt
+++ b/core/src/com/unciv/ui/utils/ExtensionFunctions.kt
@@ -92,18 +92,6 @@ fun Actor.addBorder(size:Float, color: Color, expandCell:Boolean = false): Table
     return table
 }
 
-/** Wrap an [Actor] in a [Group] of a given size */
-fun Actor.sizeWrapped(x: Float, y: Float): Group {
-    val wrapper = Group().apply {
-        isTransform = false // performance helper - nothing here is rotated or scaled
-        setSize(x, y)
-    }
-    setSize(x, y)
-    center(wrapper)
-    wrapper.addActor(this)
-    return wrapper
-}
-
 
 /** get background Image for a new separator */
 private fun getSeparatorImage(color: Color) = ImageGetter.getDot(
@@ -197,13 +185,11 @@ fun Float.toPercent() = 1 + this/100
 fun String.toTextButton() = TextButton(this.tr(), BaseScreen.skin)
 
 /** Translate a [String] and make a [Button] widget from it, with control over font size, font colour, and an optional icon. */
-fun String.toButton(fontColor: Color = Color.WHITE, fontSize: Int = 18, icon: Actor? = null): Button {
+fun String.toButton(fontColor: Color = Color.WHITE, fontSize: Int = 18, icon: Actor? = null, iconSize: Float? = null): Button {
     val button = Button(BaseScreen.skin)
     if (icon != null) {
-        val size = fontSize.toFloat()
-        button.add(
-            icon.sizeWrapped(size, size)
-        ).padRight(size / 3)
+        val size = iconSize ?: fontSize.toFloat()
+        button.add(icon).size(size).padRight(size / 3)
     }
     button.add(
         this.toLabel(fontColor, fontSize)

--- a/core/src/com/unciv/ui/utils/ExtensionFunctions.kt
+++ b/core/src/com/unciv/ui/utils/ExtensionFunctions.kt
@@ -197,12 +197,12 @@ fun Float.toPercent() = 1 + this/100
 fun String.toTextButton() = TextButton(this.tr(), BaseScreen.skin)
 
 /** Translate a [String] and make a [Button] widget from it, with control over font size, font colour, and an optional icon. */
-fun String.toButton(fontColor: Color = Color.WHITE, fontSize: Int = 24, icon: String? = null): Button {
+fun String.toButton(fontColor: Color = Color.WHITE, fontSize: Int = 18, icon: Actor? = null): Button {
     val button = Button(BaseScreen.skin)
     if (icon != null) {
         val size = fontSize.toFloat()
         button.add(
-            ImageGetter.getImage(icon).sizeWrapped(size, size)
+            icon.sizeWrapped(size, size)
         ).padRight(size / 3)
     }
     button.add(

--- a/core/src/com/unciv/ui/utils/ExtensionFunctions.kt
+++ b/core/src/com/unciv/ui/utils/ExtensionFunctions.kt
@@ -184,60 +184,6 @@ fun Float.toPercent() = 1 + this/100
 /** Translate a [String] and make a [TextButton] widget from it */
 fun String.toTextButton() = TextButton(this.tr(), BaseScreen.skin)
 
-/**
- * Builder-like configuration scope for [String.toButton].
- *
- * Properties: [button], [icon], [label], [iconCell], [labelCell]
- *
- * @param I [Actor] subclass of the icon given to [String.toButton].
- * */
-interface IIconAndLabelCellsInButton<I: Actor?> {
-    /** [Button] produced and to be returned by [String.toButton]. */
-    val button: Button
-    /** [Actor] subclass [I] instance, or `null`, as given to [String.toButton]. */
-    val icon: I?
-    /** [Label] instance produced by and with content and formatting as specified to [String.toButton]. */
-    val label: Label
-    /** [Cell]<[I]> instance containing the [icon] if any, or `null`. */
-    val iconCell: Cell<I>?
-    /** [Cell]<[Label]> instance containing the [label]. */
-    val labelCell: Cell<Label>
-}
-
-/**
- * Translate a [String] and make a [Button] widget from it, with control over font size, font colour, an optional icon, and custom formatting.
- *
- * @receiver Text of the button.
- * @param I [Actor] subclass of the [icon].
- *
- * @param fontColor Text colour for [String.toLabel].
- * @param fontSize Text size for [String.toLabel].
- * @param icon If non-null, [Actor] instance for icon left of the label. Often an [Image].
- * @param configure If non-null, function to modify this button and its layout. Is given an anonymous [IIconAndLabelCellsInButton] as receiver. Can be used to E.G. customize padding.
- *
- * @return New [Button] with the given parameters applied.
- */
-fun <I: Actor?> String.toButton(fontColor: Color = Color.WHITE, fontSize: Int = 18, icon: I? = null, configure: (IIconAndLabelCellsInButton<I>.() -> Unit)? = null): Button {
-    val button = Button(BaseScreen.skin)
-    val label = this.toLabel(fontColor, fontSize)
-    var iconCell: Cell<I>? = null
-    if (icon != null) {
-        val size = fontSize.toFloat()
-        iconCell = button.add(icon).size(size).padRight(size / 3)
-    }
-    val labelCell = button.add(label)
-    if (configure != null) {
-        (object: IIconAndLabelCellsInButton<I> {
-            override val button = button
-            override val icon = icon
-            override val label = label
-            override val iconCell = iconCell
-            override val labelCell = labelCell
-        }).run(configure)
-    }
-    return button
-}
-
 /** Translate a [String] and make a [Label] widget from it */
 fun String.toLabel() = Label(this.tr(), BaseScreen.skin)
 /** Make a [Label] widget containing this [Int] as text */

--- a/core/src/com/unciv/ui/utils/ExtensionFunctions.kt
+++ b/core/src/com/unciv/ui/utils/ExtensionFunctions.kt
@@ -184,16 +184,57 @@ fun Float.toPercent() = 1 + this/100
 /** Translate a [String] and make a [TextButton] widget from it */
 fun String.toTextButton() = TextButton(this.tr(), BaseScreen.skin)
 
-/** Translate a [String] and make a [Button] widget from it, with control over font size, font colour, and an optional icon. */
-fun String.toButton(fontColor: Color = Color.WHITE, fontSize: Int = 18, icon: Actor? = null, iconSize: Float? = null): Button {
+/**
+ * Builder-like configuration scope for [String.toButton].
+ *
+ * Properties: [button], [icon], [label], [iconCell], [labelCell]
+ *
+ * @param I [Actor] subclass of the icon given to [String.toButton].
+ * */
+interface IIconAndLabelCellsInButton<I: Actor?> {
+    /** [Button] produced and to be returned by [String.toButton]. */
+    val button: Button
+    /** [Actor] subclass [I] instance, or `null`, as given to [String.toButton]. */
+    val icon: I?
+    /** [Label] instance produced by and with content and formatting as specified to [String.toButton]. */
+    val label: Label
+    /** [Cell]<[I]> instance containing the [icon] if any, or `null`. */
+    val iconCell: Cell<I>?
+    /** [Cell]<[Label]> instance containing the [label]. */
+    val labelCell: Cell<Label>
+}
+
+/**
+ * Translate a [String] and make a [Button] widget from it, with control over font size, font colour, an optional icon, and custom formatting.
+ *
+ * @receiver Text of the button.
+ * @param I [Actor] subclass of the [icon].
+ *
+ * @param fontColor Text colour for [String.toLabel].
+ * @param fontSize Text size for [String.toLabel].
+ * @param icon If non-null, [Actor] instance for icon left of the label. Often an [Image].
+ * @param configure If non-null, function to modify this button and its layout. Is given an anonymous [IIconAndLabelCellsInButton] as receiver. Can be used to E.G. customize padding.
+ *
+ * @return New [Button] with the given parameters applied.
+ */
+fun <I: Actor?> String.toButton(fontColor: Color = Color.WHITE, fontSize: Int = 18, icon: I? = null, configure: (IIconAndLabelCellsInButton<I>.() -> Unit)? = null): Button {
     val button = Button(BaseScreen.skin)
+    val label = this.toLabel(fontColor, fontSize)
+    var iconCell: Cell<I>? = null
     if (icon != null) {
-        val size = iconSize ?: fontSize.toFloat()
-        button.add(icon).size(size).padRight(size / 3)
+        val size = fontSize.toFloat()
+        iconCell = button.add(icon).size(size).padRight(size / 3)
     }
-    button.add(
-        this.toLabel(fontColor, fontSize)
-    )
+    val labelCell = button.add(label)
+    if (configure != null) {
+        (object: IIconAndLabelCellsInButton<I> {
+            override val button = button
+            override val icon = icon
+            override val label = label
+            override val iconCell = iconCell
+            override val labelCell = labelCell
+        }).run(configure)
+    }
     return button
 }
 

--- a/core/src/com/unciv/ui/utils/IconTextButton.kt
+++ b/core/src/com/unciv/ui/utils/IconTextButton.kt
@@ -1,0 +1,30 @@
+package com.unciv.ui.utils
+
+import com.badlogic.gdx.graphics.Color
+import com.badlogic.gdx.scenes.scene2d.Actor
+import com.badlogic.gdx.scenes.scene2d.ui.Button
+import com.badlogic.gdx.scenes.scene2d.ui.Cell
+import com.badlogic.gdx.scenes.scene2d.ui.Label
+
+/**
+ * Translate a [String] and make a [Button] widget from it, with control over font size, font colour, an optional icon, and custom formatting.
+ *
+ * @param text Text of the button.
+ * @property icon If non-null, [Actor] instance for icon left of the label.
+ * @param fontSize Text size for [String.toLabel].
+ * @param fontColor Text colour for [String.toLabel].
+ */
+class IconTextButton(text: String, val icon: Actor? = null, fontSize: Int = 18, fontColor: Color = Color.WHITE): Button(BaseScreen.skin) {
+    val button = Button(BaseScreen.skin)
+    /** [Label] instance produced by and with content and formatting as specified to [String.toLabel]. */
+    val label = text.toLabel(fontColor, fontSize)
+    /** Table cell containing the [icon] if any, or `null`. */
+    val iconCell: Cell<Actor>? = if (icon != null) {
+            val size = fontSize.toFloat()
+            add(icon).size(size).padRight(size / 3)
+        } else {
+            null
+        }
+    /** Table cell instance containing the [label]. */
+    val labelCell: Cell<Label> = add(label)
+}

--- a/core/src/com/unciv/ui/utils/TabbedPager.kt
+++ b/core/src/com/unciv/ui/utils/TabbedPager.kt
@@ -46,14 +46,25 @@ class TabbedPager(
 ) : Table() {
 
     private class PageState(
+        caption: String,
         var content: Actor,
         var disabled: Boolean = false,
-        val onActivation: ((Int, String)->Unit)? = null
+        val onActivation: ((Int, String)->Unit)? = null,
+        icon: Actor? = null,
+        iconSize: Float = 0f,
+        pager: TabbedPager
     ) {
+
         var scrollX = 0f
         var scrollY = 0f
 
-        var button: Button = Button(BaseScreen.skin)
+        val button = caption.toButton(pager.headerFontColor, pager.headerFontSize, icon) {
+            if (icon != null) {
+                if (iconSize != 0f)
+                    iconCell!!.size(iconSize)
+                iconCell!!.padRight(pager.headerPadding * 0.5f)
+            }
+        }
         var buttonX = 0f
         var buttonW = 0f
     }
@@ -233,18 +244,17 @@ class TabbedPager(
         onActivation: ((Int, String)->Unit)? = null
     ): Int {
         // Build page descriptor and header button
-        val page = PageState(content ?: Group(), disabled, onActivation)
+        val page = PageState(
+                caption = caption,
+                content = content ?: Group(),
+                disabled = disabled,
+                onActivation = onActivation,
+                icon = icon,
+                iconSize = iconSize,
+                pager = this
+        )
         page.button.apply {
             name = caption  // enable finding pages by untranslated caption without needing our own field
-            if (icon != null) {
-                if (iconSize != 0f) {
-                    add(icon.sizeWrapped(iconSize, iconSize))
-                        .padRight(headerPadding * 0.5f)
-                } else {
-                    add(icon)
-                }
-            }
-            add(caption.toLabel(headerFontColor, headerFontSize))
             isEnabled = !disabled
             onClick {
                 selectPage(page)

--- a/core/src/com/unciv/ui/utils/TabbedPager.kt
+++ b/core/src/com/unciv/ui/utils/TabbedPager.kt
@@ -58,7 +58,7 @@ class TabbedPager(
         var scrollX = 0f
         var scrollY = 0f
 
-        val button = caption.toButton(pager.headerFontColor, pager.headerFontSize, icon) {
+        val button = IconTextButton(caption, icon, pager.headerFontSize, pager.headerFontColor).apply {
             if (icon != null) {
                 if (iconSize != 0f)
                     iconCell!!.size(iconSize)

--- a/core/src/com/unciv/ui/worldscreen/unit/UnitActionsTable.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitActionsTable.kt
@@ -10,7 +10,6 @@ import com.unciv.ui.utils.*
 import com.unciv.ui.utils.KeyPressDispatcher.Companion.keyboardAvailable
 import com.unciv.ui.utils.UncivTooltip.Companion.addTooltip
 import com.unciv.ui.worldscreen.WorldScreen
-import kotlin.concurrent.thread
 
 class UnitActionsTable(val worldScreen: WorldScreen) : Table() {
 
@@ -29,10 +28,8 @@ class UnitActionsTable(val worldScreen: WorldScreen) : Table() {
         // If peripheral keyboard not detected, hotkeys will not be displayed
         val key = if (keyboardAvailable) unitAction.type.key else KeyCharAndCode.UNKNOWN
 
-        val actionButton = Button(BaseScreen.skin)
-        actionButton.add(icon).size(20f).pad(5f)
         val fontColor = if (unitAction.isCurrentAction) Color.YELLOW else Color.WHITE
-        actionButton.add(unitAction.title.toLabel(fontColor)).pad(5f)
+        val actionButton = unitAction.title.toButton(fontColor, icon = icon)
         actionButton.addTooltip(key)
         actionButton.pack()
         val action = {

--- a/core/src/com/unciv/ui/worldscreen/unit/UnitActionsTable.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitActionsTable.kt
@@ -29,7 +29,7 @@ class UnitActionsTable(val worldScreen: WorldScreen) : Table() {
         val key = if (keyboardAvailable) unitAction.type.key else KeyCharAndCode.UNKNOWN
 
         val fontColor = if (unitAction.isCurrentAction) Color.YELLOW else Color.WHITE
-        val actionButton = unitAction.title.toButton(fontColor, icon = icon)
+        val actionButton = IconTextButton(unitAction.title, icon, fontColor = fontColor)
         actionButton.addTooltip(key)
         actionButton.pack()
         val action = {


### PR DESCRIPTION
This is something that shows up a fair bit in the UI.

Everything should be mostly visually equivalent:
- Some icons are sized at `18f` instead of `20f` due to using the `fontSize`.
- The padding in the Promotions and Improvement picker screens are a bit smaller (and unified with the Great Person picker).
- The trade deal item buttons have icons on the left instead of the right.

…Hm. I'm also noticing that some of the font sizes look smaller, but I'm just using the same `18` font size in those cases that's also the default in `.toLabel(…)`, so it seems that the two existing overloads for `.toLabel()` behave inconsistently, with the zero-arg one producing slightly bigger text. That may be an existing bug. Some of the WorldScreen top bar labels are bigger than the others too, depending on which `.toLabel()` they use. Will try to diagnose/document and open a separate PR or issue.

After one rebase I ran into a mysterious issue where it seemed Gradle wasn't adding `:core` to the classpath of `:desktop` or something… It spat out dozens of "Unresolved reference"s at first, and then it seemed to finish the build but crash with `NoClassDefFoundError: com/unciv/UncivGame` on run. Seems fine now.