### PR TITLE
Remove `String.toLabel()` overload, fix uneven fonts?

### DIFF
--- a/core/src/com/unciv/ui/utils/ExtensionFunctions.kt
+++ b/core/src/com/unciv/ui/utils/ExtensionFunctions.kt
@@ -211,12 +211,10 @@ fun String.toButton(fontColor: Color = Color.WHITE, fontSize: Int = 24, icon: St
     return button
 }
 
-/** Translate a [String] and make a [Label] widget from it */
-fun String.toLabel() = Label(this.tr(), BaseScreen.skin)
 /** Make a [Label] widget containing this [Int] as text */
 fun Int.toLabel() = this.toString().toLabel()
 
-/** Translate a [String] and make a [Label] widget from it with a specified font color and size */
+/** Translate a [String] and make a [Label] widget from it with an optionally specified font color and size */
 fun String.toLabel(fontColor: Color = Color.WHITE, fontSize: Int = 18): Label {
     // We don't want to use setFontSize and setFontColor because they set the font,
     //  which means we need to rebuild the font cache which means more memory allocation.

--- a/core/src/com/unciv/ui/worldscreen/bottombar/BattleTable.kt
+++ b/core/src/com/unciv/ui/worldscreen/bottombar/BattleTable.kt
@@ -107,7 +107,7 @@ class BattleTable(val worldScreen: WorldScreen): Table() {
         add(attackerNameWrapper)
 
         val defenderNameWrapper = Table()
-        val defenderLabel = Label(defender.getName().tr(), skin)
+        val defenderLabel = defender.getName().toLabel()
         defenderNameWrapper.add(getIcon(defender)).padRight(5f)
 
         defenderNameWrapper.add(defenderLabel)
@@ -252,7 +252,7 @@ class BattleTable(val worldScreen: WorldScreen): Table() {
         for (tile in targetTile.getTilesInDistance(blastRadius)) {
             val defender = tryGetDefenderAtTile(tile, true) ?: continue
             
-            val defenderLabel = Label(defender.getName().tr(), skin)
+            val defenderLabel = defender.getName().toLabel()
             defenderNameWrapper.add(getIcon(defender)).padRight(5f)
             defenderNameWrapper.add(defenderLabel).row()
         }


### PR DESCRIPTION
I noticed the two overloads seem to produce different font sizes. `String.toLabel(…)` with the default arguments is not the same as `String.toLabel()`. The `.fontScale` properties don't make much sense either:

Before:
![image](https://user-images.githubusercontent.com/37680486/149839580-76752b8c-a5c1-4bb8-96b6-3c694e49477c.png)
After:
![image](https://user-images.githubusercontent.com/37680486/149840860-223cf5c5-6ac0-4207-aa6b-2c08adc84611.png)


Also visible in the WorldScreenTopBar. The turn count, happiness, and resource labels are slightly bigger than the rest of the stat labels:

Before:
![image](https://user-images.githubusercontent.com/37680486/149839716-476c0c64-cf7d-459e-9088-4a1a281a546c.png)
After:
![image](https://user-images.githubusercontent.com/37680486/149840678-a6ca67c7-e13a-4021-8e18-0af5f0f24561.png)

`String.toLabel()` commit: https://github.com/yairm210/Unciv/commit/9ba360408c8f8b631c04b0e37c2ad59613769462
`String.toLabel(fontColor: Color, fontSize: Int)` commit: https://github.com/yairm210/Unciv/commit/de3038253681c3597801503d9e80954ac4ce4cd0

Test code:

```kotlin
val labelTable = Table()
val label1 = "ZERO-ARG".toLabel()
labelTable.add(label1)
val label2 = "DEFAULT-ARGS".toLabel(Color.WHITE, 18)
labelTable.add(label2).row()
labelTable.add("fontScale: ${label1.fontScaleX}, ${label1.fontScaleY}".toLabel(fontSize = 10))
labelTable.add("fontScale: ${label2.fontScaleX}, ${label2.fontScaleY}".toLabel(fontSize = 10)).row()
labelTable.background = ImageGetter.getRoundedEdgeRectangle(Color.BLACK)
```

The zero-arg one apparently has ~227 uses plus at least another ~43 through `Int.toLabel()`, compared to ~97 for the configurable one. Not sure about call frequency. …Well, it's for building the UI, so I suppose the tiny CPU difference isn't going to be noticeable. Biggest concern aside from consistency and maintainability would perhaps be memory use, then? But it looks like the configurable one is already reusing stuff when it can. I suppose the other options are to either 1. Ignore the uneven spacing or 2. Keep both overloads and harmonize them.