### PR TITLE
Worker AI for mods, step 2

### DIFF
--- a/core/src/com/unciv/Constants.kt
+++ b/core/src/com/unciv/Constants.kt
@@ -63,6 +63,7 @@ object Constants {
 
     const val rising = "Rising"
     const val lowering = "Lowering"
+    const val remove = "Remove "
     
     const val minimumMovementEpsilon = 0.05
 }

--- a/core/src/com/unciv/logic/automation/WorkerAutomation.kt
+++ b/core/src/com/unciv/logic/automation/WorkerAutomation.kt
@@ -333,18 +333,12 @@ class WorkerAutomation(
 
         // turnsToBuild is what defines them as buildable
         val tileImprovements = ruleSet.tileImprovements.filter {
-            it.value.turnsToBuild != 0 && tile.canImprovementBeBuiltHere(
-                it.value,
-                tile.hasViewableResource(civInfo)
-            )
-        }
+            it.value.turnsToBuild != 0 && tile.canImprovementBeBuiltHere(it.value, tile.hasViewableResource(civInfo)) }
         val uniqueImprovement = tileImprovements.values
             .firstOrNull { it.uniqueTo == civInfo.civName }
 
-        val currentlyBuildableImprovements =
-            tileImprovements.values.filter { tile.canBuildImprovement(it, civInfo) }
-        val bestBuildableImprovement =
-            currentlyBuildableImprovements.map { Pair(it, Automation.rankStatsValue(it, civInfo)) }
+        val currentlyBuildableImprovements = tileImprovements.values.filter { tile.canBuildImprovement(it, civInfo) }
+        val bestBuildableImprovement = currentlyBuildableImprovements.map { Pair(it, Automation.rankStatsValue(it, civInfo)) }
                 .filter { it.second > 0f }
                 .maxByOrNull { it.second }?.first
 
@@ -363,15 +357,13 @@ class WorkerAutomation(
 
         val improvementString = when {
             tile.improvementInProgress != null -> tile.improvementInProgress!!
-            improvementStringForResource != null
-                    && tileImprovements.containsKey(improvementStringForResource) -> improvementStringForResource
+            improvementStringForResource != null && tileImprovements.containsKey(improvementStringForResource) -> improvementStringForResource
             tile.containsGreatImprovement() -> return null
             tile.containsUnfinishedGreatImprovement() -> return null
 
             // Defence is more important that civilian improvements
             // While AI sucks in strategical placement of forts, allow a human does it manually
-            !civInfo.isPlayerCivilization() && evaluateFortPlacement(tile,
-                civInfo,false) -> Constants.fort
+            !civInfo.isPlayerCivilization() && evaluateFortPlacement(tile, civInfo,false) -> Constants.fort
             // I think we can assume that the unique improvement is better
             uniqueImprovement != null && tile.canBuildImprovement(uniqueImprovement, civInfo)
                     && unit.canBuildImprovement(uniqueImprovement, tile) ->

--- a/core/src/com/unciv/logic/automation/WorkerAutomation.kt
+++ b/core/src/com/unciv/logic/automation/WorkerAutomation.kt
@@ -13,6 +13,7 @@ import com.unciv.logic.map.RoadStatus
 import com.unciv.logic.map.TileInfo
 import com.unciv.models.ruleset.tile.Terrain
 import com.unciv.models.ruleset.tile.TileImprovement
+import com.unciv.models.ruleset.unique.UniqueType
 
 private object WorkerAutomationConst {
     /** Controls detailed logging of decisions to the console -Turn off for release builds! */
@@ -370,7 +371,8 @@ class WorkerAutomation(
                 uniqueImprovement.name
 
             lastTerrain.let {
-                isUnbuildableAndRemovable(it) && Automation.rankStatsValue(it, civInfo) < 0
+                isUnbuildableAndRemovable(it) &&
+                        (Automation.rankStatsValue(it, civInfo) < 0 || it.hasUnique(UniqueType.NullifyYields) )
             } -> Constants.remove + lastTerrain.name
             tile.terrainFeatures.contains(Constants.jungle) -> Constants.tradingPost
             tile.terrainFeatures.contains("Oasis") -> return null

--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -628,8 +628,8 @@ class MapUnit {
             UncivGame.Current.settings.addCompletedTutorialTask("Construct an improvement")
 
         when {
-            tile.improvementInProgress!!.startsWith("Remove ") -> {
-                val removedFeatureName = tile.improvementInProgress!!.removePrefix("Remove ")
+            tile.improvementInProgress!!.startsWith(Constants.remove) -> {
+                val removedFeatureName = tile.improvementInProgress!!.removePrefix(Constants.remove)
                 val tileImprovement = tile.getTileImprovement()
                 if (tileImprovement != null
                     && tile.terrainFeatures.any { 

--- a/core/src/com/unciv/logic/map/TileInfo.kt
+++ b/core/src/com/unciv/logic/map/TileInfo.kt
@@ -487,7 +487,7 @@ open class TileInfo {
                     && getTileImprovement().let { it != null && it.hasUnique("Irremovable") } -> false
 
             // Terrain blocks BUILDING improvements - removing things (such as fallout) is fine
-            !improvement.name.startsWith("Remove ") &&
+            !improvement.name.startsWith(Constants.remove) &&
                 getAllTerrains().any { it.getMatchingUniques(UniqueType.RestrictedBuildableImprovements)
                 .any { unique -> !improvement.matchesFilter(unique.params[0]) } } -> false
 

--- a/core/src/com/unciv/ui/mapeditor/MapEditorOptionsTable.kt
+++ b/core/src/com/unciv/ui/mapeditor/MapEditorOptionsTable.kt
@@ -131,7 +131,7 @@ class MapEditorOptionsTable(val mapEditorScreen: MapEditorScreen): Table(BaseScr
         }).row()
 
         for (improvement in ruleset.tileImprovements.values) {
-            if (improvement.name.startsWith("Remove")) continue
+            if (improvement.name.startsWith(Constants.remove)) continue
             if (improvement.name == Constants.cancelImprovementOrder) continue
             val improvementImage = getHex(ImageGetter.getImprovementIcon(improvement.name, 40f))
             improvementImage.onClick {

--- a/core/src/com/unciv/ui/pickerscreens/ImprovementPickerScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/ImprovementPickerScreen.kt
@@ -91,7 +91,9 @@ class ImprovementPickerScreen(val tileInfo: TileInfo, unit: MapUnit, val onAccep
             val provideResource = tileInfo.hasViewableResource(currentPlayerCiv) && tileInfo.tileResource.improvement == improvement.name
             if (provideResource) labelText += "\n" + "Provides [${tileInfo.resource}]".tr()
             val removeImprovement = (improvement.name != RoadStatus.Road.name
-                    && improvement.name != RoadStatus.Railroad.name && !improvement.name.startsWith("Remove") && improvement.name != Constants.cancelImprovementOrder)
+                    && improvement.name != RoadStatus.Railroad.name
+                    && !improvement.name.startsWith(Constants.remove)
+                    && improvement.name != Constants.cancelImprovementOrder)
             if (tileInfo.improvement != null && removeImprovement) labelText += "\n" + "Replaces [${tileInfo.improvement}]".tr()
 
             improvementButtonTable.add(labelText.toLabel()).pad(10f)

--- a/core/src/com/unciv/ui/utils/ImageGetter.kt
+++ b/core/src/com/unciv/ui/utils/ImageGetter.kt
@@ -261,7 +261,7 @@ object ImageGetter {
 
 
     fun getImprovementIcon(improvementName: String, size: Float = 20f): Actor {
-        if (improvementName.startsWith("Remove") || improvementName == Constants.cancelImprovementOrder)
+        if (improvementName.startsWith(Constants.remove) || improvementName == Constants.cancelImprovementOrder)
             return Table().apply { add(getImage("OtherIcons/Stop")).size(size) }
 
         val iconGroup = getImage("ImprovementIcons/$improvementName").surroundWithCircle(size)


### PR DESCRIPTION
Support for removing terrain features, both when we need to get rid of them for a resource, and when they plain reduce the yield of a tile

Note that the "Remove <improvement>" was implemented WAY before templating and uniques were a thing - the correct solution in these enlightened times would be to separate the improvement *name* from the *effect*, so we could have e.g. a "Deforestation" improvement which would contain botth ["Removes [Jungle]", "Removes [Forest]"] or whatnot.

For now I Constant'D the "Remove " so we can at least follow where it's used.