### PR TITLE
Iterate once through all uniques to find those relevant to sat percent bonuses, instead of per-type

### DIFF
--- a/core/src/com/unciv/logic/city/CityInfo.kt
+++ b/core/src/com/unciv/logic/city/CityInfo.kt
@@ -815,7 +815,7 @@ class CityInfo {
     // Finds matching uniques provided from both local and non-local sources.
     fun getMatchingUniques(
         uniqueType: UniqueType,
-        stateForConditionals: StateForConditionals? = null,
+        stateForConditionals: StateForConditionals = StateForConditionals(civInfo, this),
         localUniques: Sequence<Unique> = getLocalMatchingUniques(uniqueType, stateForConditionals),
     ): Sequence<Unique> {
         return civInfo.getMatchingUniques(uniqueType, stateForConditionals, this) +

--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -30,6 +30,7 @@ import com.unciv.ui.utils.MayaCalendar
 import com.unciv.ui.utils.toPercent
 import com.unciv.ui.victoryscreen.RankingType
 import java.util.*
+import java.util.concurrent.ConcurrentHashMap
 import kotlin.collections.ArrayList
 import kotlin.collections.HashMap
 import kotlin.math.max


### PR DESCRIPTION
The same change we made in the move to getStatsFromUniquesBySource()
This should be faster, more generic, more accurate (buildings vs wonders), and catch all usecases (i.e. stat bonuses from uniques attached to *techs* or who knows what else