### PR TITLE
Removed ALL hardcoded decisions in worker AI - we're now fully moddable!

### DIFF
--- a/core/src/com/unciv/logic/automation/ConstructionAutomation.kt
+++ b/core/src/com/unciv/logic/automation/ConstructionAutomation.kt
@@ -168,12 +168,9 @@ class ConstructionAutomation(val cityConstructions: CityConstructions){
                 && it.isBuildable(cityConstructions)
                 && Automation.allowSpendingResource(civInfo, it) }
         if (workerEquivalents.isEmpty()) return // for mods with no worker units
-        if (civInfo.getIdleUnits().any { it.isAutomated() && it.hasUniqueToBuildImprovements })
-            return // If we have automated workers who have no work to do then it's silly to construct new workers.
 
-        val citiesCountedTowardsWorkers = min(5, cities) // above 5 cities, extra cities won't make us want more workers
-        if (workers < citiesCountedTowardsWorkers * 0.6f && civUnits.none { it.hasUniqueToBuildImprovements && it.isIdle() }) {
-            var modifier = citiesCountedTowardsWorkers / (workers + 0.1f)
+        if (workers < cities) {
+            var modifier = cities / (workers + 0.1f) // The worse our worker to city ratio is, the more desperate we are
             if (!cityIsOverAverageProduction) modifier /= 5 // higher production cities will deal with this
             addChoice(relativeCostEffectiveness, workerEquivalents.minByOrNull { it.cost }!!.name, modifier)
         }

--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -1115,8 +1115,9 @@ class MapUnit {
             && improvement.name != Constants.cancelImprovementOrder 
             && tile.improvementInProgress != improvement.name
         ) return false
-        val matchingUniques = getMatchingUniques(UniqueType.BuildImprovements)
-        return matchingUniques.any { improvement.matchesFilter(it.params[0]) || tile.matchesTerrainFilter(it.params[0]) }
+
+        return getMatchingUniques(UniqueType.BuildImprovements)
+            .any { improvement.matchesFilter(it.params[0]) || tile.matchesTerrainFilter(it.params[0]) }
     }
 
     fun getReligionDisplayName(): String? {


### PR DESCRIPTION
I tested this out with RekMOD, 150 simulated turns, to see if this was working.
Not only did I discover that workers were squatting on Antiquity Sites since they had resource improvements that they couldn't build, I also discovered something much worse.
Even after fixing that, most cities were woefully underimproved.
Turns out, the construction automation would limit worker construction to a measly *3 workers* even for a *10 city* civ!
After removing this limitation and making civs aim for a 1:1 ratio between cities and workers, everything started looking much, much better.
I'm not sure what the exact effect on the AI will be but I'm _sure_ that this leads to a major improvement. More improved tiles means more stats means more everything.

Before:
![image](https://user-images.githubusercontent.com/8366208/150148698-46aed410-9061-468f-8fcf-dbdc751e7021.png)

(yes, that's the CAPITAL you see barren before you)

After:
![image](https://user-images.githubusercontent.com/8366208/150147479-df295e1d-f296-48ae-8d47-56a79574b08c.png)

(results achieved by starting 4 civs, large map, RekMOD, and picking the one with the most cities after 150 turns)

(I just noticed that the second image is turn 166, which means I spent 16 turns following the automated workers to see what they were doing, but the point stands. Stats in everything are higher, you can see that the amount of cities for all civs except for the obligatory Culture one is higher, I think this is a huge boost in AI productivity.