### PR TITLE
Fix uneven fonts, unify font sizes.

### DIFF
--- a/core/src/com/unciv/Constants.kt
+++ b/core/src/com/unciv/Constants.kt
@@ -66,4 +66,6 @@ object Constants {
     const val remove = "Remove "
     
     const val minimumMovementEpsilon = 0.05
+    const val defaultFontSize = 18
+    const val headingFontSize = 24
 }

--- a/core/src/com/unciv/CrashScreen.kt
+++ b/core/src/com/unciv/CrashScreen.kt
@@ -143,7 +143,7 @@ class CrashScreen(val exception: Throwable): BaseScreen() {
 
     /** @return Label for title at top of screen. */
     private fun makeTitleLabel() =
-        "An unrecoverable error has occurred in Unciv:".toLabel(fontSize = 24)
+        "An unrecoverable error has occurred in Unciv:".toLabel(fontSize = Constants.headingFontSize)
             .apply {
                 wrap = true
                 setAlignment(Align.center)
@@ -171,7 +171,7 @@ class CrashScreen(val exception: Throwable): BaseScreen() {
 
     /** @return Table that displays decision buttons for the bottom of the screen. */
     private fun makeActionButtonsTable(): Table {
-        val copyButton = IconTextButton("Copy", fontSize = 24)
+        val copyButton = IconTextButton("Copy", fontSize = Constants.headingFontSize)
             .onClick {
                 Gdx.app.clipboard.contents = text
                 copied = true
@@ -180,7 +180,7 @@ class CrashScreen(val exception: Throwable): BaseScreen() {
                     this@CrashScreen
                 )
             }
-        val reportButton = IconTextButton("Open Issue Tracker", ImageGetter.getImage("OtherIcons/Link"), 24)
+        val reportButton = IconTextButton("Open Issue Tracker", ImageGetter.getImage("OtherIcons/Link"), Constants.headingFontSize)
             .onClick {
                 if (copied) {
                     Gdx.net.openURI("https://github.com/yairm210/Unciv/issues")
@@ -191,7 +191,7 @@ class CrashScreen(val exception: Throwable): BaseScreen() {
                     )
                 }
             }
-        val closeButton = IconTextButton("Close Unciv", fontSize = 24)
+        val closeButton = IconTextButton("Close Unciv", fontSize = Constants.headingFontSize)
             .onClick { Gdx.app.exit() }
 
         val buttonsTable = Table()

--- a/core/src/com/unciv/ui/cityscreen/CityConstructionsTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityConstructionsTable.kt
@@ -8,6 +8,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.Cell
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton
 import com.badlogic.gdx.utils.Align
+import com.unciv.Constants
 import com.unciv.logic.city.*
 import com.unciv.models.UncivSound
 import com.unciv.models.ruleset.Building
@@ -580,7 +581,7 @@ class CityConstructionsTable(private val cityScreen: CityScreen) {
     private fun getHeader(title: String): Table {
         return Table()
                 .background(ImageGetter.getBackground(ImageGetter.getBlue()))
-                .addCell(title.toLabel(fontSize = 24))
+                .addCell(title.toLabel(fontSize = Constants.headingFontSize))
                 .pad(4f)
     }
 

--- a/core/src/com/unciv/ui/cityscreen/CityInfoTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityInfoTable.kt
@@ -3,6 +3,7 @@ package com.unciv.ui.cityscreen
 import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.utils.Align
+import com.unciv.Constants
 import com.unciv.UncivGame
 import com.unciv.logic.city.CityInfo
 import com.unciv.models.UncivSound
@@ -65,7 +66,7 @@ class CityInfoTable(private val cityScreen: CityScreen) : Table(BaseScreen.skin)
         val icon = ImageGetter.getConstructionImage(building.name).surroundWithCircle(30f)
         val isFree = building.name in cityScreen.city.civInfo.civConstructions.getFreeBuildings(cityScreen.city.id)
         val displayName = if (isFree) "{${building.name}} ({Free})" else building.name
-        val buildingNameAndIconTable = ExpanderTab(displayName, 18, icon, false, 5f) {
+        val buildingNameAndIconTable = ExpanderTab(displayName, Constants.defaultFontSize, icon, false, 5f) {
             val detailsString = building.getDescription(cityScreen.city, cityScreen.city.getRuleset())
             it.add(detailsString.toLabel().apply { wrap = true })
                 .width(cityScreen.stage.width / 4 - 2 * pad).row() // when you set wrap, then you need to manually set the size of the label

--- a/core/src/com/unciv/ui/cityscreen/CityReligionInfoTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityReligionInfoTable.kt
@@ -2,6 +2,7 @@ package com.unciv.ui.cityscreen
 
 import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.scenes.scene2d.ui.Table
+import com.unciv.Constants
 import com.unciv.logic.city.CityInfoReligionManager
 import com.unciv.models.Religion
 import com.unciv.ui.utils.*
@@ -65,7 +66,7 @@ class CityReligionInfoTable(
         val (icon, label) = getIconAndLabel(religionManager.getMajorityReligion())
         return ExpanderTab(
                 title = "Majority Religion: [$label]",
-                fontSize = 18,
+                fontSize = Constants.defaultFontSize,
                 icon = ImageGetter.getCircledReligionIcon(icon, 30f),
                 defaultPad = 0f,
                 persistenceID = "CityStatsTable.Religion",

--- a/core/src/com/unciv/ui/cityscreen/SpecialistAllocationTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/SpecialistAllocationTable.kt
@@ -4,6 +4,7 @@ import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.scenes.scene2d.Actor
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.utils.Align
+import com.unciv.Constants
 import com.unciv.UncivGame
 import com.unciv.ui.utils.*
 
@@ -46,7 +47,7 @@ class SpecialistAllocationTable(val cityScreen: CityScreen): Table(BaseScreen.sk
     private fun getAssignButton(assignedSpecialists: Int, maxSpecialists: Int, specialistName: String):Actor {
 
         if (assignedSpecialists >= maxSpecialists || cityInfo.isPuppet) return Table()
-        val assignButton = "+".toLabel(Color.BLACK,24)
+        val assignButton = "+".toLabel(Color.BLACK, Constants.headingFontSize)
                 .apply { this.setAlignment(Align.center) }
                 .surroundWithCircle(30f).apply { circle.color= Color.GREEN.cpy().lerp(Color.BLACK,0.2f) }
         assignButton.onClick {
@@ -60,7 +61,7 @@ class SpecialistAllocationTable(val cityScreen: CityScreen): Table(BaseScreen.sk
     }
 
     private fun getUnassignButton(assignedSpecialists: Int, specialistName: String):Actor {
-        val unassignButton = "-".toLabel(Color.BLACK,24)
+        val unassignButton = "-".toLabel(Color.BLACK,Constants.headingFontSize)
                 .apply { this.setAlignment(Align.center) }
                 .surroundWithCircle(30f).apply { circle.color= Color.RED.cpy().lerp(Color.BLACK,0.1f) }
         unassignButton.onClick {

--- a/core/src/com/unciv/ui/civilopedia/CivilopediaText.kt
+++ b/core/src/com/unciv/ui/civilopedia/CivilopediaText.kt
@@ -6,6 +6,7 @@ import com.badlogic.gdx.scenes.scene2d.Actor
 import com.badlogic.gdx.scenes.scene2d.Group
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.utils.Align
+import com.unciv.Constants
 import com.unciv.UncivGame
 import com.unciv.models.metadata.BaseRuleset
 import com.unciv.models.ruleset.Ruleset
@@ -48,7 +49,7 @@ class FormattedLine (
     val extraImage: String = "",
     /** Width of the [extraImage], height is calculated preserving aspect ratio. Defaults to available width. */
     val imageSize: Float = Float.NaN,
-    /** Text size, defaults to 18. Use [size] or [header] but not both. */
+    /** Text size, defaults to [Constants.defaultFontSize]. Use [size] or [header] but not both. */
     val size: Int = Int.MIN_VALUE,
     /** Header level. 1 means double text size and decreases from there. */
     val header: Int = 0,
@@ -126,10 +127,8 @@ class FormattedLine (
 
     /** Constants used by [FormattedLine] */
     companion object {
-        /** Mirrors default [text] size as used by [toLabel] */
-        const val defaultSize = 18
         /** Array of text sizes to translate the [header] attribute */
-        val headerSizes = arrayOf(defaultSize,36,32,27,24,21,15,12,9)    // pretty arbitrary, yes
+        val headerSizes = arrayOf(Constants.defaultFontSize,36,32,27,24,21,15,12,9)    // pretty arbitrary, yes
         /** Default color for [text] _and_ icons */
         val defaultColor: Color = Color.WHITE
         /** Internal path to the [Link][link] image */
@@ -255,7 +254,7 @@ class FormattedLine (
 
         val fontSize = when {
             header in 1 until headerSizes.size -> headerSizes[header]
-            size == Int.MIN_VALUE -> defaultSize
+            size == Int.MIN_VALUE -> Constants.defaultFontSize
             else -> size
         }
         val labelColor = if(starred) defaultColor else displayColor
@@ -285,7 +284,7 @@ class FormattedLine (
                 else -> (indent-1) * indentPad +
                         indentOneAtNumIcons * (minIconSize + iconPad) + iconPad - usedWidth
             }
-            val label = if (fontSize == defaultSize && labelColor == defaultColor) textToDisplay.toLabel()
+            val label = if (fontSize == Constants.defaultFontSize && labelColor == defaultColor) textToDisplay.toLabel()
             else textToDisplay.toLabel(labelColor,fontSize)
             label.wrap = !centered && labelWidth > 0f
             label.setAlignment(align)

--- a/core/src/com/unciv/ui/mapeditor/MapEditorScreen.kt
+++ b/core/src/com/unciv/ui/mapeditor/MapEditorScreen.kt
@@ -6,6 +6,7 @@ import com.badlogic.gdx.math.Vector2
 import com.badlogic.gdx.scenes.scene2d.InputEvent
 import com.badlogic.gdx.scenes.scene2d.InputListener
 import com.badlogic.gdx.scenes.scene2d.actions.Actions
+import com.unciv.Constants
 import com.unciv.UncivGame
 import com.unciv.logic.HexMath
 import com.unciv.logic.map.MapShape
@@ -75,7 +76,7 @@ class MapEditorScreen(): BaseScreen() {
         val optionsMenuButton = "Menu".toTextButton()
         optionsMenuButton.onClick(openOptionsMenu)
         keyPressDispatcher[KeyCharAndCode.BACK] = openOptionsMenu
-        optionsMenuButton.label.setFontSize(24)
+        optionsMenuButton.label.setFontSize(Constants.headingFontSize)
         optionsMenuButton.labelCell.pad(20f)
         optionsMenuButton.pack()
         optionsMenuButton.x = 30f

--- a/core/src/com/unciv/ui/mapeditor/NewMapScreen.kt
+++ b/core/src/com/unciv/ui/mapeditor/NewMapScreen.kt
@@ -2,6 +2,7 @@ package com.unciv.ui.mapeditor
 
 import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.scenes.scene2d.ui.Table
+import com.unciv.Constants
 import com.unciv.MainMenuScreen
 import com.unciv.UncivGame
 import com.unciv.logic.map.MapParameters
@@ -51,7 +52,7 @@ class NewMapScreen(val mapParameters: MapParameters = getDefaultParameters()) : 
         mapParametersTable = MapParametersTable(mapParameters, isEmptyMapAllowed = true)
         val newMapScreenOptionsTable = Table(skin).apply {
             pad(10f)
-            add("Map Options".toLabel(fontSize = 24)).row()
+            add("Map Options".toLabel(fontSize = Constants.headingFontSize)).row()
             
             // Add the selector for the base ruleset
             val baseRulesetBox = getBaseRulesetSelectBox()

--- a/core/src/com/unciv/ui/newgamescreen/NationTable.kt
+++ b/core/src/com/unciv/ui/newgamescreen/NationTable.kt
@@ -35,7 +35,7 @@ class NationTable(val nation: Nation, width: Float, minHeight: Float, ruleset: R
         val titleText = if (ruleset == null || nation.name == Constants.random || nation.name == Constants.spectator)
             nation.name else nation.getLeaderDisplayName()
         val leaderDisplayNameMaxWidth = internalWidth - 70f // for the nation indicator with padding
-        val leaderDisplayLabel = WrappableLabel(titleText, leaderDisplayNameMaxWidth, innerColor, 24)
+        val leaderDisplayLabel = WrappableLabel(titleText, leaderDisplayNameMaxWidth, innerColor, Constants.headingFontSize)
         if (leaderDisplayLabel.prefWidth > leaderDisplayNameMaxWidth - 2f) {
             leaderDisplayLabel.wrap = true
             titleTable.add(leaderDisplayLabel).width(leaderDisplayNameMaxWidth)

--- a/core/src/com/unciv/ui/newgamescreen/NewGameScreen.kt
+++ b/core/src/com/unciv/ui/newgamescreen/NewGameScreen.kt
@@ -6,6 +6,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.SelectBox
 import com.badlogic.gdx.scenes.scene2d.ui.Skin
 import com.badlogic.gdx.scenes.scene2d.ui.VerticalGroup
 import com.badlogic.gdx.utils.Array
+import com.unciv.Constants
 import com.unciv.UncivGame
 import com.unciv.logic.*
 import com.unciv.logic.civilization.PlayerType
@@ -134,11 +135,11 @@ class NewGameScreen(
     private fun initLandscape() {
         scrollPane.setScrollingDisabled(true,true)
 
-        topTable.add("Game Options".toLabel(fontSize = 24)).pad(20f, 0f)
+        topTable.add("Game Options".toLabel(fontSize = Constants.headingFontSize)).pad(20f, 0f)
         topTable.addSeparatorVertical(Color.BLACK, 1f)
-        topTable.add("Map Options".toLabel(fontSize = 24)).pad(20f,0f)
+        topTable.add("Map Options".toLabel(fontSize = Constants.headingFontSize)).pad(20f,0f)
         topTable.addSeparatorVertical(Color.BLACK, 1f)
-        topTable.add("Civilizations".toLabel(fontSize = 24)).pad(20f,0f)
+        topTable.add("Civilizations".toLabel(fontSize = Constants.headingFontSize)).pad(20f,0f)
         topTable.addSeparator(Color.CLEAR, height = 1f)
 
         topTable.add(ScrollPane(newGameOptionsTable)

--- a/core/src/com/unciv/ui/overviewscreen/CityOverviewTable.kt
+++ b/core/src/com/unciv/ui/overviewscreen/CityOverviewTable.kt
@@ -6,6 +6,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.Cell
 import com.badlogic.gdx.scenes.scene2d.ui.Label
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.utils.Align
+import com.unciv.Constants
 import com.unciv.logic.city.CityInfo
 import com.unciv.logic.civilization.CivilizationInfo
 import com.unciv.models.stats.Stat
@@ -54,7 +55,7 @@ class CityOverviewTable(private val viewingPlayer: CivilizationInfo, private val
         cityInfoTableIcons.defaults()
             .pad(paddingVert, paddingHorz)
             .align(Align.center)
-        cityInfoTableIcons.add("Cities".toLabel(fontSize = 24)).colspan(numHeaderCells).align(Align.center).row()
+        cityInfoTableIcons.add("Cities".toLabel(fontSize = Constants.headingFontSize)).colspan(numHeaderCells).align(Align.center).row()
         val citySortIcon: IconCircleGroup = ImageGetter.getUnitIcon("Settler").surroundWithCircle(iconSize)
         addSortIcon("City", citySortIcon)
         val headerFillerCell = cityInfoTableIcons.add(Table())  // will push the first icon to left-align

--- a/core/src/com/unciv/ui/overviewscreen/ReligionOverviewTable.kt
+++ b/core/src/com/unciv/ui/overviewscreen/ReligionOverviewTable.kt
@@ -2,6 +2,7 @@ package com.unciv.ui.overviewscreen
 
 import com.badlogic.gdx.scenes.scene2d.ui.Button
 import com.badlogic.gdx.scenes.scene2d.ui.Table
+import com.unciv.Constants
 import com.unciv.UncivGame
 import com.unciv.logic.civilization.CivilizationInfo
 import com.unciv.logic.civilization.ReligionState
@@ -138,7 +139,7 @@ class ReligionOverviewTable(
     private fun createBeliefDescription(belief: Belief) =
         MarkupRenderer.render(
             belief.run { sequence {
-                yield(FormattedLine(name, size = 24, centered = true))
+                yield(FormattedLine(name, size = Constants.headingFontSize, centered = true))
                 yield(FormattedLine())
                 yieldAll(getCivilopediaTextLines(gameInfo.ruleSet, true))
             } }.toList()

--- a/core/src/com/unciv/ui/overviewscreen/StatsOverviewTable.kt
+++ b/core/src/com/unciv/ui/overviewscreen/StatsOverviewTable.kt
@@ -3,6 +3,7 @@ package com.unciv.ui.overviewscreen
 import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.scenes.scene2d.ui.Slider
 import com.badlogic.gdx.scenes.scene2d.ui.Table
+import com.unciv.Constants
 import com.unciv.logic.civilization.CivilizationInfo
 import com.unciv.models.ruleset.ModOptionsConstants
 import com.unciv.ui.utils.*
@@ -25,7 +26,7 @@ class StatsOverviewTable (
     private fun getHappinessTable(): Table {
         val happinessTable = Table(BaseScreen.skin)
         happinessTable.defaults().pad(5f)
-        happinessTable.add("Happiness".toLabel(fontSize = 24)).colspan(2).row()
+        happinessTable.add("Happiness".toLabel(fontSize = Constants.headingFontSize)).colspan(2).row()
         happinessTable.addSeparator()
 
         val happinessBreakdown = viewingPlayer.stats().getHappinessBreakdown()
@@ -43,7 +44,7 @@ class StatsOverviewTable (
     private fun getGoldTable(): Table {
         val goldTable = Table(BaseScreen.skin)
         goldTable.defaults().pad(5f)
-        goldTable.add("Gold".toLabel(fontSize = 24)).colspan(2).row()
+        goldTable.add("Gold".toLabel(fontSize = Constants.headingFontSize)).colspan(2).row()
         goldTable.addSeparator()
         var total = 0f
         for (entry in viewingPlayer.stats().getStatMapForNextTurn()) {
@@ -78,7 +79,7 @@ class StatsOverviewTable (
     private fun getScienceTable(): Table {
         val scienceTable = Table(BaseScreen.skin)
         scienceTable.defaults().pad(5f)
-        scienceTable.add("Science".toLabel(fontSize = 24)).colspan(2).row()
+        scienceTable.add("Science".toLabel(fontSize = Constants.headingFontSize)).colspan(2).row()
         scienceTable.addSeparator()
         val scienceStats = viewingPlayer.stats().getStatMapForNextTurn()
             .filter { it.value.science != 0f }
@@ -100,7 +101,7 @@ class StatsOverviewTable (
         val greatPeopleIcon = ImageGetter.getStatIcon("Specialist")
         greatPeopleIcon.color = Color.ROYAL
         greatPeopleHeader.add(greatPeopleIcon).padRight(12f).size(30f)
-        greatPeopleHeader.add("Great person points".toLabel(fontSize = 24)).padTop(5f)
+        greatPeopleHeader.add("Great person points".toLabel(fontSize = Constants.headingFontSize)).padTop(5f)
         greatPeopleTable.add(greatPeopleHeader).colspan(3).row()
         greatPeopleTable.addSeparator()
         greatPeopleTable.add()
@@ -126,7 +127,7 @@ class StatsOverviewTable (
     
     private fun getScoreTable(): Table {
         val scoreTableHeader = Table(BaseScreen.skin)
-        scoreTableHeader.add("Score".toLabel(fontSize = 24)).padBottom(6f)
+        scoreTableHeader.add("Score".toLabel(fontSize = Constants.headingFontSize)).padBottom(6f)
         
         val scoreTable = Table(BaseScreen.skin)
         scoreTable.defaults().pad(5f)

--- a/core/src/com/unciv/ui/pickerscreens/ModManagementOptions.kt
+++ b/core/src/com/unciv/ui/pickerscreens/ModManagementOptions.kt
@@ -4,6 +4,7 @@ import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.scenes.scene2d.Touchable
 import com.badlogic.gdx.scenes.scene2d.ui.*
 import com.badlogic.gdx.utils.Align
+import com.unciv.Constants
 import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.translations.tr
 import com.unciv.ui.newgamescreen.TranslatedSelectBox
@@ -101,7 +102,7 @@ class ModManagementOptions(private val modManagementScreen: ModManagementScreen)
 
         expander = ExpanderTab(
             "Sort and Filter",
-            fontSize = 18,
+            fontSize = Constants.defaultFontSize,
             startsOutOpened = false,
             defaultPad = 2.5f,
             headerPad = 5f,

--- a/core/src/com/unciv/ui/pickerscreens/PantheonPickerScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/PantheonPickerScreen.kt
@@ -2,6 +2,7 @@ package com.unciv.ui.pickerscreens
 
 import com.badlogic.gdx.scenes.scene2d.Touchable
 import com.badlogic.gdx.scenes.scene2d.ui.Table
+import com.unciv.Constants
 import com.unciv.UncivGame
 import com.unciv.logic.GameInfo
 import com.unciv.logic.civilization.CivilizationInfo
@@ -31,7 +32,7 @@ class PantheonPickerScreen(choosingCiv: CivilizationInfo, gameInfo: GameInfo) : 
                     else ImageGetter.getBackground(ImageGetter.getBlue()) 
             }
             beliefTable.pad(10f)
-            beliefTable.add(belief.name.toLabel(fontSize = 24)).row()
+            beliefTable.add(belief.name.toLabel(fontSize = Constants.headingFontSize)).row()
             beliefTable.add(belief.uniques.joinToString().toLabel())
             beliefTable.onClick { 
                 chosenPantheon = belief

--- a/core/src/com/unciv/ui/pickerscreens/ReligiousBeliefsPickerScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/ReligiousBeliefsPickerScreen.kt
@@ -215,7 +215,7 @@ class ReligiousBeliefsPickerScreen (
     private fun convertBeliefToButton(belief: Belief): Button {
         val contentsTable = Table()
         contentsTable.add(belief.type.name.toLabel(fontColor = Color.valueOf(belief.type.color))).row()
-        contentsTable.add(belief.name.toLabel(fontSize = 24)).row()
+        contentsTable.add(belief.name.toLabel(fontSize = Constants.headingFontSize)).row()
         contentsTable.add(belief.uniques.joinToString("\n") { it.tr() }.toLabel())
         return Button(contentsTable, skin)
     }

--- a/core/src/com/unciv/ui/trade/DiplomacyScreen.kt
+++ b/core/src/com/unciv/ui/trade/DiplomacyScreen.kt
@@ -52,7 +52,7 @@ class DiplomacyScreen(val viewingCiv:CivilizationInfo): BaseScreen() {
 
         val closeButton = Constants.close.toTextButton()
         closeButton.onClick { UncivGame.Current.setWorldScreen() }
-        closeButton.label.setFontSize(24)
+        closeButton.label.setFontSize(Constants.headingFontSize)
         closeButton.labelCell.pad(10f)
         closeButton.pack()
         closeButton.y = stage.height - closeButton.height - 10
@@ -227,7 +227,7 @@ class DiplomacyScreen(val viewingCiv:CivilizationInfo): BaseScreen() {
         if (otherCiv.cityStateUniqueUnit != null) {
             val unitName = otherCiv.cityStateUniqueUnit
             val techName = viewingCiv.gameInfo.ruleSet.units[otherCiv.cityStateUniqueUnit]!!.requiredTech
-            diplomacyTable.add("[${otherCiv.civName}] is able to provide [${unitName}] once [${techName}] is researched.".toLabel(fontSize = 18)).row()
+            diplomacyTable.add("[${otherCiv.civName}] is able to provide [${unitName}] once [${techName}] is researched.".toLabel(fontSize = Constants.defaultFontSize)).row()
         }
 
         return diplomacyTable
@@ -556,7 +556,7 @@ class DiplomacyScreen(val viewingCiv:CivilizationInfo): BaseScreen() {
             quest.name
         val description = assignedQuest.getDescription()
 
-        questTable.add(title.toLabel(fontSize = 24)).row()
+        questTable.add(title.toLabel(fontSize = Constants.headingFontSize)).row()
         questTable.add(description.toLabel().apply { wrap = true; setAlignment(Align.center) })
             .width(stage.width / 2).row()
         if (quest.duration > 0)
@@ -582,7 +582,7 @@ class DiplomacyScreen(val viewingCiv:CivilizationInfo): BaseScreen() {
         val progress = if (viewingCiv.knows(target)) "Currently you have killed [${otherCiv.questManager.unitsKilledSoFar(target, viewingCiv)}] of their military units."
             else "You need to find them first!"
 
-        warTable.add(title.toLabel(fontSize = 24)).row()
+        warTable.add(title.toLabel(fontSize = Constants.headingFontSize)).row()
         warTable.add(description.toLabel().apply { wrap = true; setAlignment(Align.center) })
             .width(stage.width / 2).row()
         warTable.add(progress.toLabel().apply { wrap = true; setAlignment(Align.center) })

--- a/core/src/com/unciv/ui/trade/LeaderIntroTable.kt
+++ b/core/src/com/unciv/ui/trade/LeaderIntroTable.kt
@@ -2,6 +2,7 @@ package com.unciv.ui.trade
 
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.utils.Align
+import com.unciv.Constants
 import com.unciv.logic.civilization.CivilizationInfo
 import com.unciv.ui.utils.BaseScreen
 import com.unciv.ui.utils.ImageGetter
@@ -28,7 +29,7 @@ class LeaderIntroTable (
         defaults().align(Align.center)
         val nation = civInfo.nation
         val leaderPortraitFile = "LeaderIcons/" + nation.leaderName
-        val leaderLabel = civInfo.getLeaderDisplayName().toLabel(fontSize = 24)
+        val leaderLabel = civInfo.getLeaderDisplayName().toLabel(fontSize = Constants.headingFontSize)
         val nationIndicator = ImageGetter.getNationIndicator(nation, 24f)
         if (nation.leaderName.isNotEmpty() && ImageGetter.imageExists(leaderPortraitFile)) {
             val nameTable = Table()

--- a/core/src/com/unciv/ui/utils/BaseScreen.kt
+++ b/core/src/com/unciv/ui/utils/BaseScreen.kt
@@ -93,14 +93,20 @@ open class BaseScreen : Screen {
                 add("Checkbox-pressed", ImageGetter.getCheckBoxPressed(), Drawable::class.java)
                 load(Gdx.files.internal("Skin.json"))
             }
-            skin.get(TextButton.TextButtonStyle::class.java).font = Fonts.font.apply { data.setScale(20 / Fonts.ORIGINAL_FONT_SIZE) }
-            skin.get(CheckBox.CheckBoxStyle::class.java).font = Fonts.font.apply { data.setScale(20 / Fonts.ORIGINAL_FONT_SIZE) }
-            skin.get(CheckBox.CheckBoxStyle::class.java).fontColor = Color.WHITE
-            skin.get(Label.LabelStyle::class.java).font = Fonts.font.apply { data.setScale(18 / Fonts.ORIGINAL_FONT_SIZE) }
-            skin.get(Label.LabelStyle::class.java).fontColor = Color.WHITE
-            skin.get(TextField.TextFieldStyle::class.java).font = Fonts.font.apply { data.setScale(18 / Fonts.ORIGINAL_FONT_SIZE) }
-            skin.get(SelectBox.SelectBoxStyle::class.java).font = Fonts.font.apply { data.setScale(20 / Fonts.ORIGINAL_FONT_SIZE) }
-            skin.get(SelectBox.SelectBoxStyle::class.java).listStyle.font = Fonts.font.apply { data.setScale(20 / Fonts.ORIGINAL_FONT_SIZE) }
+            skin.get(TextButton.TextButtonStyle::class.java).font = Fonts.font
+            skin.get(CheckBox.CheckBoxStyle::class.java).apply {
+                font = Fonts.font
+                fontColor = Color.WHITE
+            }
+            skin.get(Label.LabelStyle::class.java).apply {
+                font = Fonts.font
+                fontColor = Color.WHITE
+            }
+            skin.get(TextField.TextFieldStyle::class.java).font = Fonts.font
+            skin.get(SelectBox.SelectBoxStyle::class.java).apply {
+                font = Fonts.font
+                listStyle.font = Fonts.font
+            }
         }
         /** Colour to use for empty sections of the screen. */
         val clearColor = Color(0f, 0f, 0.2f, 1f)

--- a/core/src/com/unciv/ui/utils/ExpanderTab.kt
+++ b/core/src/com/unciv/ui/utils/ExpanderTab.kt
@@ -7,6 +7,7 @@ import com.badlogic.gdx.scenes.scene2d.Touchable
 import com.badlogic.gdx.scenes.scene2d.actions.FloatAction
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.utils.Align
+import com.unciv.Constants
 import com.unciv.UncivGame
 
 /**
@@ -24,7 +25,7 @@ import com.unciv.UncivGame
  */
 class ExpanderTab(
     title: String,
-    fontSize: Int = 24,
+    fontSize: Int = Constants.headingFontSize,
     icon: Actor? = null,
     startsOutOpened: Boolean = true,
     defaultPad: Float = 10f,

--- a/core/src/com/unciv/ui/utils/ExtensionFunctions.kt
+++ b/core/src/com/unciv/ui/utils/ExtensionFunctions.kt
@@ -6,6 +6,7 @@ import com.badlogic.gdx.scenes.scene2d.*
 import com.badlogic.gdx.scenes.scene2d.ui.*
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener
 import com.badlogic.gdx.scenes.scene2d.utils.ClickListener
+import com.unciv.Constants
 import com.unciv.CrashScreen
 import com.unciv.UncivGame
 import com.unciv.models.UncivSound
@@ -190,14 +191,14 @@ fun String.toLabel() = Label(this.tr(), BaseScreen.skin)
 fun Int.toLabel() = this.toString().toLabel()
 
 /** Translate a [String] and make a [Label] widget from it with a specified font color and size */
-fun String.toLabel(fontColor: Color = Color.WHITE, fontSize: Int = 18): Label {
+fun String.toLabel(fontColor: Color = Color.WHITE, fontSize: Int = Constants.defaultFontSize): Label {
     // We don't want to use setFontSize and setFontColor because they set the font,
     //  which means we need to rebuild the font cache which means more memory allocation.
     var labelStyle = BaseScreen.skin.get(Label.LabelStyle::class.java)
-    if (fontColor != Color.WHITE || fontSize != 18) { // if we want the default we don't need to create another style
+    if (fontColor != Color.WHITE || fontSize != Constants.defaultFontSize) { // if we want the default we don't need to create another style
         labelStyle = Label.LabelStyle(labelStyle) // clone this to another
         labelStyle.fontColor = fontColor
-        if (fontSize != 18) labelStyle.font = Fonts.font
+        if (fontSize != Constants.defaultFontSize) labelStyle.font = Fonts.font
     }
     return Label(this.tr(), labelStyle).apply { setFontScale(fontSize / Fonts.ORIGINAL_FONT_SIZE) }
 }

--- a/core/src/com/unciv/ui/utils/Fonts.kt
+++ b/core/src/com/unciv/ui/utils/Fonts.kt
@@ -11,6 +11,7 @@ import com.badlogic.gdx.graphics.g2d.PixmapPacker
 import com.badlogic.gdx.graphics.g2d.TextureRegion
 import com.badlogic.gdx.utils.Array
 import com.badlogic.gdx.utils.Disposable
+import com.unciv.Constants
 import com.unciv.UncivGame
 import com.unciv.models.stats.Stat
 
@@ -133,6 +134,7 @@ object Fonts {
         val fontData = NativeBitmapFontData(UncivGame.Current.fontImplementation!!)
         font = BitmapFont(fontData, fontData.regions, false)
         font.setOwnsTexture(true)
+        font.data.setScale(Constants.defaultFontSize / ORIGINAL_FONT_SIZE)
     }
 
     /**

--- a/core/src/com/unciv/ui/utils/IconTextButton.kt
+++ b/core/src/com/unciv/ui/utils/IconTextButton.kt
@@ -5,6 +5,7 @@ import com.badlogic.gdx.scenes.scene2d.Actor
 import com.badlogic.gdx.scenes.scene2d.ui.Button
 import com.badlogic.gdx.scenes.scene2d.ui.Cell
 import com.badlogic.gdx.scenes.scene2d.ui.Label
+import com.unciv.Constants
 
 /**
  * Translate a [String] and make a [Button] widget from it, with control over font size, font colour, an optional icon, and custom formatting.
@@ -14,7 +15,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.Label
  * @param fontSize Text size for [String.toLabel].
  * @param fontColor Text colour for [String.toLabel].
  */
-class IconTextButton(text: String, val icon: Actor? = null, fontSize: Int = 18, fontColor: Color = Color.WHITE): Button(BaseScreen.skin) {
+class IconTextButton(text: String, val icon: Actor? = null, fontSize: Int = Constants.defaultFontSize, fontColor: Color = Color.WHITE): Button(BaseScreen.skin) {
     val button = Button(BaseScreen.skin)
     /** [Label] instance produced by and with content and formatting as specified to [String.toLabel]. */
     val label = text.toLabel(fontColor, fontSize)

--- a/core/src/com/unciv/ui/utils/MayaCalendar.kt
+++ b/core/src/com/unciv/ui/utils/MayaCalendar.kt
@@ -1,6 +1,7 @@
 package com.unciv.ui.utils
 
 import com.badlogic.gdx.graphics.Color
+import com.unciv.Constants
 import com.unciv.logic.civilization.CivilizationInfo
 import com.unciv.models.ruleset.unique.UniqueTriggerActivation
 import com.unciv.models.ruleset.unique.UniqueType
@@ -70,7 +71,7 @@ object MayaCalendar {
     fun openPopup(previousScreen: BaseScreen, civInfo: CivilizationInfo, year: Int) {
         Popup(previousScreen).apply {
             name = "MayaCalendar"
-            addGoodSizedLabel("The Mayan Long Count", 24).apply {
+            addGoodSizedLabel("The Mayan Long Count", Constants.headingFontSize).apply {
                 actor.color = civInfo.nation.getOuterColor()
             }.row()
             addSeparator(color = Color.DARK_GRAY)

--- a/core/src/com/unciv/ui/utils/Popup.kt
+++ b/core/src/com/unciv/ui/utils/Popup.kt
@@ -78,11 +78,11 @@ open class Popup(val screen: BaseScreen): Table(BaseScreen.skin) {
 
     /**
      * Adds a [caption][text] label: A label with word wrap enabled over half the stage width.
-     * Will be larger than normal text if the [size] parameter is set to >18.
+     * Will be larger than normal text if the [size] parameter is set to > [Constants.defaultFontSize].
      * @param text The caption text.
      * @param size The font size for the label.
      */
-    fun addGoodSizedLabel(text: String, size:Int=18): Cell<Label> {
+    fun addGoodSizedLabel(text: String, size:Int=Constants.defaultFontSize): Cell<Label> {
         val label = text.toLabel(fontSize = size)
         label.wrap = true
         label.setAlignment(Align.center)

--- a/core/src/com/unciv/ui/utils/TabbedPager.kt
+++ b/core/src/com/unciv/ui/utils/TabbedPager.kt
@@ -4,6 +4,7 @@ import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.scenes.scene2d.Actor
 import com.badlogic.gdx.scenes.scene2d.Group
 import com.badlogic.gdx.scenes.scene2d.ui.*
+import com.unciv.Constants
 import com.unciv.UncivGame
 import kotlin.math.min
 
@@ -37,7 +38,7 @@ class TabbedPager(
     private var maximumWidth: Float = Float.MAX_VALUE,
     private val minimumHeight: Float = 0f,
     private var maximumHeight: Float = Float.MAX_VALUE,
-    private val headerFontSize: Int = 18,
+    private val headerFontSize: Int = Constants.defaultFontSize,
     private val headerFontColor: Color = Color.WHITE,
     private val highlightColor: Color = Color.BLUE,
     backgroundColor: Color = ImageGetter.getBlue().lerp(Color.BLACK, 0.5f),

--- a/core/src/com/unciv/ui/utils/UncivSlider.kt
+++ b/core/src/com/unciv/ui/utils/UncivSlider.kt
@@ -9,6 +9,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.*
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener
 import com.badlogic.gdx.utils.Align
 import com.badlogic.gdx.utils.Timer
+import com.unciv.Constants
 import com.unciv.models.UncivSound
 
 /**
@@ -41,7 +42,7 @@ class UncivSlider (
 ): Table(BaseScreen.skin) {
     // constants for geometry tuning
     companion object {
-        const val plusMinusFontSize = 18
+        const val plusMinusFontSize = Constants.defaultFontSize
         const val plusMinusCircleSize = 20f
         const val padding = 5f                  // padding around the Slider, doubled between it and +/- buttons
         const val hideDelay = 3f                // delay in s to hide tooltip

--- a/core/src/com/unciv/ui/utils/WrappableLabel.kt
+++ b/core/src/com/unciv/ui/utils/WrappableLabel.kt
@@ -2,6 +2,7 @@ package com.unciv.ui.utils
 
 import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.scenes.scene2d.ui.Label
+import com.unciv.Constants
 import com.unciv.models.translations.tr
 import kotlin.math.min
 
@@ -15,15 +16,15 @@ class WrappableLabel(
     text: String,
     private val expectedWidth: Float,
     fontColor: Color = Color.WHITE,
-    fontSize: Int = 18
+    fontSize: Int = Constants.defaultFontSize
 ) : Label(text.tr(), BaseScreen.skin) {
     private var _measuredWidth = 0f
 
     init {
-        if (fontColor != Color.WHITE || fontSize!=18) {
+        if (fontColor != Color.WHITE || fontSize!=Constants.defaultFontSize) {
             val style = LabelStyle(this.style)
             style.fontColor = fontColor
-            if (fontSize != 18) {
+            if (fontSize != Constants.defaultFontSize) {
                 style.font = Fonts.font
                 setFontScale(fontSize / Fonts.ORIGINAL_FONT_SIZE)
             }

--- a/core/src/com/unciv/ui/worldscreen/AlertPopup.kt
+++ b/core/src/com/unciv/ui/worldscreen/AlertPopup.kt
@@ -90,7 +90,7 @@ class AlertPopup(val worldScreen: WorldScreen, val popupAlert: PopupAlert): Popu
             }
             AlertType.CityConquered -> {
                 val city = worldScreen.gameInfo.getCities().first { it.id == popupAlert.value }
-                addGoodSizedLabel("What would you like to do with the city?", 24)
+                addGoodSizedLabel("What would you like to do with the city?", Constants.headingFontSize)
                         .padBottom(20f).row()
                 val conqueringCiv = worldScreen.gameInfo.currentPlayerCiv
 
@@ -231,7 +231,7 @@ class AlertPopup(val worldScreen: WorldScreen, val popupAlert: PopupAlert): Popu
             }
             AlertType.DiplomaticMarriage -> {
                 val city = worldScreen.gameInfo.getCities().first { it.id == popupAlert.value }
-                addGoodSizedLabel(city.name.tr() + ": " + "What would you like to do with the city?".tr(), 24) // Add name because there might be several cities
+                addGoodSizedLabel(city.name.tr() + ": " + "What would you like to do with the city?".tr(), Constants.headingFontSize) // Add name because there might be several cities
                     .padBottom(20f).row()
                 val marryingCiv = worldScreen.gameInfo.currentPlayerCiv
 

--- a/core/src/com/unciv/ui/worldscreen/PlayerReadyScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/PlayerReadyScreen.kt
@@ -3,6 +3,7 @@ package com.unciv.ui.worldscreen
 import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.scenes.scene2d.Touchable
 import com.badlogic.gdx.scenes.scene2d.ui.Table
+import com.unciv.Constants
 import com.unciv.logic.GameInfo
 import com.unciv.logic.civilization.CivilizationInfo
 import com.unciv.ui.utils.*
@@ -13,7 +14,7 @@ class PlayerReadyScreen(gameInfo: GameInfo, currentPlayerCiv: CivilizationInfo) 
         table.touchable= Touchable.enabled
         table.background= ImageGetter.getBackground(currentPlayerCiv.nation.getOuterColor())
 
-        table.add("[$currentPlayerCiv] ready?".toLabel(currentPlayerCiv.nation.getInnerColor(),24))
+        table.add("[$currentPlayerCiv] ready?".toLabel(currentPlayerCiv.nation.getInnerColor(),  Constants.headingFontSize))
 
         table.onClick {
             postCrashHandlingRunnable { // To avoid ANRs on Android when the creation of the worldscreen takes more than 500ms


### PR DESCRIPTION
Does two things:
* Fixes uneven font sizes, as in #5996.
* Moves the 13 occurrences of `18` and 11 occurrences of `24` to Constants, to make future consistency easier.

May also be easier to review by commit. First one actually changes logic; Second one just swaps out a lot of integer literals for a constant.