### PR TITLE
Try to fix a potentially miscapitalized/broken policy cost unique.

### DIFF
--- a/android/assets/jsons/Civ V - Gods & Kings/Policies.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Policies.json
@@ -166,7 +166,7 @@
 			},
 			{
 				"name": "Free Religion",
-				"uniques": ["[-10]% Culture cost of adopting new policies"],
+				"uniques": ["[-10]% Culture cost of adopting new Policies"],
 				"requires": ["Mandate Of Heaven", "Reformation"],
 				"row": 3,
 				"column": 4

--- a/core/src/com/unciv/logic/civilization/PolicyManager.kt
+++ b/core/src/com/unciv/logic/civilization/PolicyManager.kt
@@ -91,7 +91,7 @@ class PolicyManager {
             for (unique in civInfo.getMatchingUniques(UniqueType.LessPolicyCostDeprecated))
                 policyCultureCost *= 1 - unique.params[0].toFloat() / 100
         //
-        for (unique in civInfo.getMatchingUniques(UniqueType.LessPolicyCost))
+        for (unique in civInfo.getMatchingUniques(UniqueType.LessPolicyCost) + civInfo.getMatchingUniques(UniqueType.LessPolicyCostDeprecated2))
             policyCultureCost *= unique.params[0].toPercent()
         if (civInfo.isPlayerCivilization())
             policyCultureCost *= civInfo.getDifficulty().policyCostModifier

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -203,8 +203,10 @@ enum class UniqueType(val text:String, vararg targets: UniqueTarget, val flags: 
     BonusHappinessFromLuxuryDeprecated("+[amount] happiness from each type of luxury resource", UniqueTarget.Global),
     LessPolicyCostFromCities("Each city founded increases culture cost of policies [amount]% less than normal", UniqueTarget.Global),
     LessPolicyCost("[amount]% Culture cost of adopting new Policies", UniqueTarget.Global),
-    @Deprecated("As of 3.18.17", ReplaceWith("[amount]% Culture cost of adopting new policies"))
+    @Deprecated("As of 3.18.17", ReplaceWith("[amount]% Culture cost of adopting new Policies"))
     LessPolicyCostDeprecated("Culture cost of adopting new Policies reduced by [amount]%", UniqueTarget.Global),
+    @Deprecated("As of 3.19.1", ReplaceWith("[amount]% Culture cost of adopting new Policies"))
+    LessPolicyCostDeprecated2("[amount]% Culture cost of adopting new policies", UniqueTarget.Global),
 
     EnablesOpenBorders("Enables Open Borders agreements", UniqueTarget.Global),
     // Should the 'R' in 'Research agreements' be capitalized?

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -202,7 +202,7 @@ enum class UniqueType(val text:String, vararg targets: UniqueTarget, val flags: 
     @Deprecated("As of 3.18.17", ReplaceWith("[+amount] Happiness from each type of luxury resource"))
     BonusHappinessFromLuxuryDeprecated("+[amount] happiness from each type of luxury resource", UniqueTarget.Global),
     LessPolicyCostFromCities("Each city founded increases culture cost of policies [amount]% less than normal", UniqueTarget.Global),
-    LessPolicyCost("[amount]% Culture cost of adopting new policies", UniqueTarget.Global),
+    LessPolicyCost("[amount]% Culture cost of adopting new Policies", UniqueTarget.Global),
     @Deprecated("As of 3.18.17", ReplaceWith("[amount]% Culture cost of adopting new policies"))
     LessPolicyCostDeprecated("Culture cost of adopting new Policies reduced by [amount]%", UniqueTarget.Global),
 


### PR DESCRIPTION
Oh yeah. This was the other PR that I wanted to submit today.

---

The UniqueType had a lower-case "policies", but its uses in the JSONs mostly had capitals.

I *think* that can cause problems? Not sure. They're case-sensitive, right? I also mentioned this on #5955, but I worded it in a very nitpicky way and mixed it in with a bunch of less consequential things.