### PR TITLE
Typified some building uniques

### DIFF
--- a/android/assets/jsons/Civ V - Gods & Kings/Beliefs.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Beliefs.json
@@ -138,7 +138,7 @@
     {
         "name": "Divine inspiration",
         "type": "Follower",
-        "uniques": ["[+2 Faith] from every Wonder"]
+        "uniques": ["[+2 Faith] from every [Wonder]"]
     },
     {
         "name": "Feed the World",

--- a/android/assets/jsons/Civ V - Gods & Kings/Policies.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Policies.json
@@ -327,7 +327,7 @@
 		"policies": [
 			{
 				"name": "Constitution",
-				"uniques": ["[+2 Culture] from every Wonder"],
+				"uniques": ["[+2 Culture] from every [Wonder]"],
 				"row": 1,
 				"column": 1
 			},

--- a/android/assets/jsons/Civ V - Vanilla/Policies.json
+++ b/android/assets/jsons/Civ V - Vanilla/Policies.json
@@ -323,7 +323,7 @@
 		"policies": [
 			{
 				"name": "Constitution",
-				"uniques": ["[+2 Culture] from every Wonder"],
+				"uniques": ["[+2 Culture] from every [Wonder]"],
 				"row": 1,
 				"column": 1
 			},

--- a/core/src/com/unciv/models/ruleset/Building.kt
+++ b/core/src/com/unciv/models/ruleset/Building.kt
@@ -180,18 +180,18 @@ class Building : RulesetStatsObject(), INonPerpetualConstruction {
                 stats.add(unique.stats)
 
         @Suppress("RemoveRedundantQualifierName")  // make it clearer Building inherits Stats
-        for (unique in uniqueObjects)
-            if (unique.placeholderText == "[] with []" && civInfo.hasResource(unique.params[1])
+        for (unique in getMatchingUniques(UniqueType.StatsWithResource))
+            if (civInfo.hasResource(unique.params[1])
                     && Stats.isStats(unique.params[0]))
                 stats.add(unique.stats)
 
         if (!isWonder)
-            for (unique in city.getMatchingUniques("[] from all [] buildings")) {
+            for (unique in city.getMatchingUniques(UniqueType.StatsFromBuildings)) {
                 if (matchesFilter(unique.params[1]))
                     stats.add(unique.stats)
             }
         else
-            for (unique in city.getMatchingUniques("[] from every Wonder"))
+            for (unique in city.getMatchingUniques(UniqueType.StatsFromWondersDeprecated))
                 stats.add(unique.stats)
         return stats
     }

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -75,14 +75,18 @@ enum class UniqueType(val text:String, vararg targets: UniqueTarget, val flags: 
     StatsFromCitiesOnSpecificTiles("[stats] in cities on [terrainFilter] tiles", UniqueTarget.Global, UniqueTarget.FollowerBelief),
     @Deprecated("As of 3.18.14", ReplaceWith("[stats] [in all cities] <before discovering [tech]> OR [stats] [in all cities] <before adopting [policy]>"))
     StatsFromCitiesBefore("[stats] per turn from cities before [tech/policy]", UniqueTarget.Global, UniqueTarget.FollowerBelief),
-
-
+    StatsFromBuildings("[stats] from all [buildingFilter] buildings", UniqueTarget.Global, UniqueTarget.FollowerBelief),
+    @Deprecated("As of 3.19.1", ReplaceWith("[stats] from every [Wonder]"))
+    StatsFromWondersDeprecated("[stats] from every Wonder", UniqueTarget.Global, UniqueTarget.FollowerBelief),
+    StatsWithResource("[stats] with [resource]", UniqueTarget.Building),
     StatsSpendingGreatPeople("[stats] whenever a Great Person is expended", UniqueTarget.Global),
     StatsFromTiles("[stats] from [tileFilter] tiles [cityFilter]", UniqueTarget.Global, UniqueTarget.FollowerBelief),
     StatsFromTilesWithout("[stats] from [tileFilter] tiles without [tileFilter] [cityFilter]", UniqueTarget.Global, UniqueTarget.FollowerBelief),
     // This is a doozy
-    StatsFromObject("[stats] from every [tileFilter/specialist/buildingName]", UniqueTarget.Global, UniqueTarget.FollowerBelief),
+    StatsFromObject("[stats] from every [tileFilter/specialist/buildingFilter]", UniqueTarget.Global, UniqueTarget.FollowerBelief),
 
+
+    // Stat percentage boosts
     StatPercentBonus("[amount]% [stat]", UniqueTarget.Global, UniqueTarget.FollowerBelief),
     StatPercentFromObject("[amount]% [stat] from every [tileFilter/specialist/buildingName]", UniqueTarget.Global, UniqueTarget.FollowerBelief),
     @Deprecated("As of 3.18.17", ReplaceWith("[amount]% [stat] from every [tileFilter/specialist/buildingName]"))

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -78,7 +78,6 @@ enum class UniqueType(val text:String, vararg targets: UniqueTarget, val flags: 
     StatsFromBuildings("[stats] from all [buildingFilter] buildings", UniqueTarget.Global, UniqueTarget.FollowerBelief),
     @Deprecated("As of 3.19.1", ReplaceWith("[stats] from every [Wonder]"))
     StatsFromWondersDeprecated("[stats] from every Wonder", UniqueTarget.Global, UniqueTarget.FollowerBelief),
-    StatsWithResource("[stats] with [resource]", UniqueTarget.Building),
     StatsSpendingGreatPeople("[stats] whenever a Great Person is expended", UniqueTarget.Global),
     StatsFromTiles("[stats] from [tileFilter] tiles [cityFilter]", UniqueTarget.Global, UniqueTarget.FollowerBelief),
     StatsFromTilesWithout("[stats] from [tileFilter] tiles without [tileFilter] [cityFilter]", UniqueTarget.Global, UniqueTarget.FollowerBelief),
@@ -281,6 +280,7 @@ enum class UniqueType(val text:String, vararg targets: UniqueTarget, val flags: 
     RequiresAnotherBuilding("Requires a [buildingName] in this city", UniqueTarget.Building),
     RequiresBuildingInAllCities("Requires a [buildingName] in all cities", UniqueTarget.Building),
 
+    StatsWithResource("[stats] with [resource]", UniqueTarget.Building),
     
 
     MustBeOn("Must be on [terrainFilter]", UniqueTarget.Building),

--- a/docs/uniques.md
+++ b/docs/uniques.md
@@ -46,6 +46,11 @@ Example: "[+1 Gold, +2 Production] in cities on [Grassland] tiles"
 
 Applicable to: Global, FollowerBelief
 
+#### [stats] from all [buildingFilter] buildings
+Example: "[+1 Gold, +2 Production] from all [buildingFilter] buildings"
+
+Applicable to: Global, FollowerBelief
+
 #### [stats] whenever a Great Person is expended
 Example: "[+1 Gold, +2 Production] whenever a Great Person is expended"
 


### PR DESCRIPTION
I noticed that the code allows "[stats] from every [buildingFilter]" but the UniqueType was limited to "[stats] from every [buildingName]", so now that that's available we don't actually need the "[stats] from every Wonder" unique :)