### PR TITLE
Converted stat list to stat tree

### DIFF
--- a/core/src/com/unciv/logic/city/CityConstructions.kt
+++ b/core/src/com/unciv/logic/city/CityConstructions.kt
@@ -84,10 +84,10 @@ class CityConstructions {
     /**
      * @return [Stats] provided by all built buildings in city plus the bonus from Library
      */
-    fun getStats(): Stats {
-        val stats = Stats()
+    fun getStats(): StatTreeNode {
+        val stats = StatTreeNode()
         for (building in getBuiltBuildings())
-            stats.add(building.getStats(cityInfo))
+            stats.addStats(building.getStats(cityInfo), building.name)
         return stats
     }
 

--- a/core/src/com/unciv/logic/city/CityStats.kt
+++ b/core/src/com/unciv/logic/city/CityStats.kt
@@ -21,9 +21,14 @@ class StatTreeNode {
     val children = LinkedHashMap<String, StatTreeNode>()
     private var innerStats: Stats? = null
 
+    private fun addInnerStats(stats: Stats) {
+        if (innerStats == null) innerStats = stats
+        else innerStats!!.add(stats) // What happens if we add 2 stats to the same leaf?
+    }
+
     fun addStats(newStats: Stats, vararg hierarchyList: String) {
         if (hierarchyList.isEmpty()) {
-            innerStats = newStats
+            addInnerStats(newStats)
             return
         }
         val childName = hierarchyList.first()
@@ -32,14 +37,15 @@ class StatTreeNode {
         children[childName]!!.addStats(newStats, *hierarchyList.drop(1).toTypedArray())
     }
 
-    fun add(otherTree: StatTreeNode){
+    fun add(otherTree: StatTreeNode) {
+        if (otherTree.innerStats != null) addInnerStats(otherTree.innerStats!!)
         for ((key, value) in otherTree.children) {
             if (!children.containsKey(key)) children[key] = value
             else children[key]!!.add(value)
         }
     }
 
-    val totalStats:Stats by lazy {
+    val totalStats: Stats by lazy {
         val toReturn = Stats()
         if (innerStats != null) toReturn.add(innerStats!!)
         for (child in children.values) toReturn.add(child.totalStats)

--- a/core/src/com/unciv/logic/civilization/TechManager.kt
+++ b/core/src/com/unciv/logic/civilization/TechManager.kt
@@ -167,7 +167,7 @@ class TechManager {
         // The Science the Great Scientist generates does not include Science from Policies, Trade routes and City-States.
         var allCitiesScience = 0f
         civInfo.cities.forEach { it ->
-            val totalBaseScience = it.cityStats.baseStatList.values.map { it.science }.sum()
+            val totalBaseScience = it.cityStats.baseStatTree.totalStats.science
             val totalBonusPercents = it.cityStats.statPercentBonusList.filter { it.key != "Policies" }.values.map { it.science }.sum()
             allCitiesScience += totalBaseScience * totalBonusPercents.toPercent()
         }

--- a/core/src/com/unciv/ui/cityscreen/CityInfoTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityInfoTable.kt
@@ -145,7 +145,7 @@ class CityInfoTable(private val cityScreen: CityScreen) : Table(BaseScreen.skin)
 
     private fun addStatsToHashmap(statTreeNode: StatTreeNode, hashMap: HashMap<String, Float>, stat:Stat, indentation:Int=0) {
         for ((name, child) in statTreeNode.children) {
-            hashMap["-".repeat(indentation) + name] = child.totalStats[stat]
+            hashMap["- ".repeat(indentation) + name] = child.totalStats[stat]
             addStatsToHashmap(child, hashMap, stat, indentation + 1)
         }
     }
@@ -172,7 +172,7 @@ class CityInfoTable(private val cityScreen: CityScreen) : Table(BaseScreen.skin)
             for (entry in relevantBaseStats) {
                 val specificStatValue = entry.value
                 sumOfAllBaseValues += specificStatValue
-                statValuesTable.add(entry.key.toLabel())
+                statValuesTable.add(entry.key.toLabel()).left()
                 statValuesTable.add(specificStatValue.toOneDecimalLabel()).row()
             }
             statValuesTable.addSeparator()

--- a/core/src/com/unciv/ui/cityscreen/CityInfoTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityInfoTable.kt
@@ -157,7 +157,7 @@ class CityInfoTable(private val cityScreen: CityScreen) : Table(BaseScreen.skin)
         val cityStats = cityScreen.city.cityStats
 
         for (stat in Stat.values()) {
-            val statValuesTable = Table().apply { defaults().pad(2f) }
+            val statValuesTable = Table()
             statValuesTable.touchable = Touchable.enabled
             addCategory(stat.name, statValuesTable)
 
@@ -172,7 +172,15 @@ class CityInfoTable(private val cityScreen: CityScreen) : Table(BaseScreen.skin)
         showDetails:Boolean = false
     ) {
         statValuesTable.clear()
-        statValuesTable.onClick { updateStatValuesTable(stat, cityStats, statValuesTable, !showDetails) }
+        statValuesTable.defaults().pad(2f)
+        statValuesTable.onClick {
+            updateStatValuesTable(
+                stat,
+                cityStats,
+                statValuesTable,
+                !showDetails
+            )
+        }
 
         val relevantBaseStats = LinkedHashMap<String, Float>()
 
@@ -229,6 +237,14 @@ class CityInfoTable(private val cityScreen: CityScreen) : Table(BaseScreen.skin)
             statValuesTable.add("Total".toLabel())
             statValuesTable.add(finalTotal.toOneDecimalLabel()).row()
         }
+
+        statValuesTable.pack()
+        val toggleButtonChar = if (showDetails) "-" else "+"
+        val toggleButton = toggleButtonChar.toLabel().apply { setAlignment(Align.center) }
+            .surroundWithCircle(25f, color = ImageGetter.getBlue())
+            .surroundWithCircle(27f, false)
+        statValuesTable.addActor(toggleButton)
+        toggleButton.setPosition(0f, statValuesTable.height, Align.topLeft)
 
         statValuesTable.padBottom(4f)
     }

--- a/core/src/com/unciv/ui/cityscreen/CityInfoTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityInfoTable.kt
@@ -5,6 +5,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.utils.Align
 import com.unciv.UncivGame
 import com.unciv.logic.city.CityInfo
+import com.unciv.logic.city.StatTreeNode
 import com.unciv.models.UncivSound
 import com.unciv.models.ruleset.Building
 import com.unciv.models.stats.Stat
@@ -142,16 +143,21 @@ class CityInfoTable(private val cityScreen: CityScreen) : Table(BaseScreen.skin)
         }
     }
 
+    private fun addStatsToHashmap(statTreeNode: StatTreeNode, hashMap: HashMap<String, Float>, stat:Stat, indentation:Int=0) {
+        for ((name, child) in statTreeNode.children) {
+            hashMap["-".repeat(indentation) + name] = child.totalStats[stat]
+            addStatsToHashmap(child, hashMap, stat, indentation + 1)
+        }
+    }
+
     private fun Table.addStatInfo() {
         val cityStats = cityScreen.city.cityStats
-
 
         for (stat in Stat.values()) {
             val relevantBaseStats = LinkedHashMap<String, Float>()
 
             if (stat != Stat.Happiness)
-                for ((key, value) in cityStats.baseStatList)
-                    relevantBaseStats[key] = value[stat]
+                addStatsToHashmap(cityStats.baseStatTree, relevantBaseStats, stat)
             else relevantBaseStats.putAll(cityStats.happinessList)
             for (key in relevantBaseStats.keys.toList())
                 if (relevantBaseStats[key] == 0f) relevantBaseStats.remove(key)


### PR DESCRIPTION
current changes do not affect UI at all, since we're still going by the shallow mapping that existed beforehand

The problem:
![image](https://user-images.githubusercontent.com/8366208/150681948-9a822f03-30d0-42d8-9424-5c661da83ee3.png)

I have no way of knowing which policies, techs, and wonders are contributing to my stat production.
Solution: Turn all lists of stats into trees of stats! This will also help us in the overview screen to dig deeper.