### PR TITLE
Clear mod action Table when deleting mods; Avoid crashy nulls.

### DIFF
--- a/core/src/com/unciv/ui/pickerscreens/ModManagementScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/ModManagementScreen.kt
@@ -529,6 +529,7 @@ class ModManagementScreen(
                 question = "Are you SURE you want to delete this mod?",
                 action = {
                     deleteMod(mod.name)
+                    modActionTable.clear()
                     rightSideButton.setText("[${mod.name}] was deleted.".tr())
                 },
                 screen = this,


### PR DESCRIPTION
Closes #6025.