### PR TITLE
Check rulesets for potential typos.

### DIFF
--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -311,7 +311,7 @@ class Ruleset {
                 val similarUniques = UniqueType.values().filter { getRelativeTextDistance(it.placeholderText, unique.placeholderText) <= uniqueMisspellingThreshold }
                 val equalUniques = similarUniques.filter { it.placeholderText == unique.placeholderText }
                 if (equalUniques.isNotEmpty()) {
-                    lines.add(
+                    lines.add( // This should only ever happen if a bug is or has been introduced that prevents Unique.type from being set for a valid UniqueType, I think.
                         "$name's unique \"${unique.text}\" looks like it should be fine, but for some reason isn't recognized.",
                         RulesetErrorSeverity.OK
                     )

--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -25,6 +25,7 @@ import com.unciv.models.stats.Stats
 import com.unciv.models.translations.fillPlaceholders
 import com.unciv.models.translations.tr
 import com.unciv.ui.utils.colorFromRGB
+import com.unciv.ui.utils.getRelativeTextDistance
 import kotlin.collections.set
 
 object ModOptionsConstants {
@@ -297,13 +298,39 @@ class Ruleset {
         return stringList.joinToString { it.tr() }
     }
 
+    /** Similarity below which an untyped unique can be considered a potential misspelling.
+     * Roughly corresponds to the fraction of the Unique placeholder text that can be different/misspelled, but with some extra room for [getRelativeTextDistance] idiosyncrasies. */
+    private val uniqueMisspellingThreshold = 0.15 // Tweak as needed. Simple misspellings seem to be around 0.025, so would mostly be caught by 0.05. IMO 0.1 would be good, but raising to 0.15 also seemed to catch what may be an outdated Unique.
 
     fun checkUniques(uniqueContainer:IHasUniques, lines:RulesetErrorList,
                      severityToReport: UniqueType.UniqueComplianceErrorSeverity) {
         val name = if (uniqueContainer is INamed) uniqueContainer.name else ""
 
         for (unique in uniqueContainer.uniqueObjects) {
-            if (unique.type == null) continue
+            if (unique.type == null) {
+                val similarUniques = UniqueType.values().filter { getRelativeTextDistance(it.placeholderText, unique.placeholderText) <= uniqueMisspellingThreshold }
+                val equalUniques = similarUniques.filter { it.placeholderText == unique.placeholderText }
+                if (equalUniques.isNotEmpty()) {
+                    lines.add(
+                        "$name's unique \"${unique.text}\" looks like it should be fine, but for some reason isn't recognized.",
+                        RulesetErrorSeverity.OK
+                    )
+                } else if (similarUniques.isNotEmpty()) {
+                    lines.add("$name's unique \"${unique.text}\" looks like it may be a misspelling of:\n" +
+                        similarUniques.joinToString("\n") { uniqueType ->
+                            val deprecationAnnotation = UniqueType::class.java.getField(uniqueType.name)
+                                    .getAnnotation(Deprecated::class.java)
+                            if (deprecationAnnotation == null)
+                                "\"${uniqueType.text}\""
+                            else
+                                "\"${uniqueType.text}\" (Deprecated)"
+                        }.prependIndent("\t"),
+                        RulesetErrorSeverity.OK
+                    )
+
+                }
+                continue
+            }
             val complianceErrors = unique.type.getComplianceErrors(unique, this)
             for (complianceError in complianceErrors) {
                 if (complianceError.errorSeverity == severityToReport)

--- a/core/src/com/unciv/ui/utils/TextSimilarity.kt
+++ b/core/src/com/unciv/ui/utils/TextSimilarity.kt
@@ -1,0 +1,71 @@
+package com.unciv.ui.utils
+
+/**
+ * Algorithm:
+ *  - Keep an index for each string.
+ *  - Iteratively advance by one character in each string.
+ *      - If the character at the index of each string is not the same, then pause.
+ *          - Try to find the minumum number of characters to skip in the first string to find the current character of the second string.
+ *          - Try to find the minimum number of characters to skip in the second string to find the current character of the first string.
+ *          - If the above condition cannot be satisifed for either string, then skip both by one character and continue advancing them together.
+ *          - Otherwise, skip ahead in either the first string or the second string, depending on which requires the lowest offset, and continue advancing both strings together.
+ *      - Stop when either one of the above steps cannot be completed or the end of either string has been reached.
+ *  - The distance returned is the apprximately total number of characters skipped, plus the total number of characters unaccounted for at the end.
+ *
+ * Meant to run in linear-ish time.
+ * Order of comparands shouldn't matter too much, but does a little.
+ * This seemed simpler than a thorough implementation of other string comparison algorithms, and maybe more performant than a naïve implementation of other string comparisons, as well as sufficient for the fairly simple use case.
+ *
+ * @param text1 String to compare.
+ * @param text2 String to compare.
+ * @return Approximate distance between them.
+ */
+fun getTextDistance(text1: String, text2: String): Int {
+    var dist = 0;
+    var i1 = 0;
+    var i2 = 0;
+
+//    fun String.debugTraversal(index: Int) = println(this.substring(0..index-1)+"["+this[index]+"]"+this.substring(index+1..this.lastIndex))
+//    /** Uncomment this and stick it at the start of the `while` if you want to see what's happening. */
+//    fun debugTraversal() { println(); text1.debugTraversal(i1); text2.debugTraversal(i2); }
+
+    fun inRange() = i1 < text1.length && i2 < text2.length // Length is O(1), apparently.
+    while (inRange()) {
+//        debugTraversal()
+        var char1 = text1[i1] // Indexing may not be, though.
+        var char2 = text2[i2]
+        if (char1 == char2) {
+            i1++
+            i2++
+        } else {
+            val firstMatchIndex1 = (i1..text1.lastIndex).firstOrNull { text1[it] == char2 }
+            val firstMatchIndex2 = (i2..text2.lastIndex).firstOrNull { text2[it] == char1 }
+            if (firstMatchIndex1 == null && firstMatchIndex2 == null) {
+                dist++
+                i1++
+                i2++
+                continue
+            }
+            val firstMatchOffset1 = firstMatchIndex1?.minus(i1)
+            val firstMatchOffset2 = firstMatchIndex2?.minus(i2)
+            when {
+                (firstMatchOffset2 == null || (firstMatchOffset1 != null && firstMatchOffset1 < firstMatchOffset2)) -> { // Preferential behaviour when the offsets are equal does make the operation slightly non-commutative, I think.
+                    dist += firstMatchOffset1!!
+                    i1 = firstMatchIndex1 + 1
+                    i2++
+                }
+                (firstMatchOffset1 == null || firstMatchOffset1 >= firstMatchOffset2) -> {
+                    dist += firstMatchOffset2
+                    i1++
+                    i2 = firstMatchIndex2 + 1
+                }
+                else -> throw IllegalStateException("Can't compare Strings:\n\t${text1}\n\t${text2}")
+            }
+        }
+    }
+    dist += ((text1.length - i1) + (text2.length - i2)) / 2
+    return dist
+}
+
+/** @return the [getTextDistance] of two strings relative to their average length. */
+fun getRelativeTextDistance(text1: String, text2: String) = getTextDistance(text1, text2).toDouble() / (text1.length + text2.length) * 2.0


### PR DESCRIPTION
Follow-up to #6016.

![image](https://user-images.githubusercontent.com/37680486/150697985-30bd887c-a548-4a06-8556-43d86e73d2ea.png)

<details><summary>Some algorithm test code.</summary>

```kotlin
fun testTextDist(text1: String, text2: String) {
    println()
    println(text1)
    println(text2)
    println("Absolute: ${getTextDistance(text1, text2)}\nRelative: ${getRelativeTextDistance(text1, text2)}")
}

testTextDist(
        "The quick brown fox jumps over the lazy dogs.",
        "The quick brown fox jumps over the lazy dogs."
) // This is actually a really bad/atypical example due to lack of repeating characters.
testTextDist(
        "The quick brown fox jumps over the lazy dogs.",
        "The quick Brown fox jumps over the Lazy dogs."
)
testTextDist(
        "The quick brown fox jumps over the lazy dogs.",
        "The quic brwn fox jumpsover the lazy dogs"
)
testTextDist(
        "The wolf had the fox with him, and whatsoever the wolf wished, that the fox was compelled to do, for he was the weaker, and he would gladly have been rid of his master.",
        "Here are not many people—and as it is desirable that a story–teller and a story–reader should establish a mutual understanding as soon as possible, I beg it to be noticed that I confine this observation neither to young people nor to little people, but extend it to all conditions of people: little and big, young and old: yet growing up, or already growing down again—there are not, I say, many people who would care to sleep in a church. I don’t mean at sermon–time in warm weather (when the thing has actually been done, once or twice), but in the night, and alone."
) // Wikisource random.
testTextDist(
        "[]% Culture cost of adopting new Policies",
        "[]% Culture cost of adopting new policies"
) // https://github.com/yairm210/Unciv/pull/6016
testTextDist(
        "[]% maintenance cost for buildings []",

        "[]% maintenance cost for buildings []"
)
testTextDist(
        "[]% maintenance cost for buildings []",

        "[]% maintenance cost forBuildings []"
) // Does poorly because missing space followed by wrong character means it skips all the way to the next space.
testTextDist(
        "[]% maintenance cost for buildings []",

        "[]% maintenance cost forbuildings []"
)
testTextDist(
        "[]% maintenance cost for buildings []",

        "[]% maintenaince cost for buildings []"
)
testTextDist(
        "[]% maintenance cost for buildings []",

        "+[]%maintenaince cost for buildings []"
)
```
</details>

<details><summary>Algorithm test output.</summary>

```
The quick brown fox jumps over the lazy dogs.
The quick brown fox jumps over the lazy dogs.
Absolute: 0
Relative: 0.0

The quick brown fox jumps over the lazy dogs.
The quick Brown fox jumps over the Lazy dogs.
Absolute: 2
Relative: 0.044444444444444446

The quick brown fox jumps over the lazy dogs.
The quic brwn fox jumpsover the lazy dogs
Absolute: 3
Relative: 0.06976744186046512

The wolf had the fox with him, and whatsoever the wolf wished, that the fox was compelled to do, for he was the weaker, and he would gladly have been rid of his master.
Here are not many people—and as it is desirable that a story–teller and a story–reader should establish a mutual understanding as soon as possible, I beg it to be noticed that I confine this observation neither to young people nor to little people, but extend it to all conditions of people: little and big, young and old: yet growing up, or already growing down again—there are not, I say, many people who would care to sleep in a church. I don’t mean at sermon–time in warm weather (when the thing has actually been done, once or twice), but in the night, and alone.
Absolute: 651
Relative: 1.7690217391304348

[]% Culture cost of adopting new Policies
[]% Culture cost of adopting new policies
Absolute: 1
Relative: 0.024390243902439025

[]% maintenance cost for buildings []
[]% maintenance cost for buildings []
Absolute: 0
Relative: 0.0

[]% maintenance cost for buildings []
[]% maintenance cost forBuildings []
Absolute: 19
Relative: 0.5205479452054794

[]% maintenance cost for buildings []
[]% maintenance cost forbuildings []
Absolute: 1
Relative: 0.0273972602739726

[]% maintenance cost for buildings []
[]% maintenaince cost for buildings []
Absolute: 1
Relative: 0.02666666666666667

[]% maintenance cost for buildings []
+[]%maintenaince cost for buildings []
Absolute: 3
Relative: 0.08
```
</details>