### PR TITLE
Try to fix potential typos in stock rulesets.

### DIFF
--- a/android/assets/jsons/Civ V - Gods & Kings/Buildings.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Buildings.json
@@ -1036,7 +1036,7 @@
 		"isWonder": true,
 		"culture": 3,
 		"greatPersonPoints": {"Great Engineer": 2},
-		"uniques": ["[-33]% Gold cost of upgrading [Military] units"],
+		"uniques": ["[-33]% Gold cost of upgrading <for [Military] units>"],
 		"requiredTech": "Combined Arms",
 		"quote": "'In preparing for battle I have always found that plans are useless, but planning is indispensable.' - Dwight D. Eisenhower"
 	},
@@ -1206,5 +1206,5 @@
 		"faith": 2,
 		"happiness": 2,
 		"uniques": ["Unbuildable", "Hidden when religion is disabled"]
-	},
+	}
 ]

--- a/android/assets/jsons/Civ V - Gods & Kings/Nations.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Nations.json
@@ -661,7 +661,7 @@
 		"favoredReligion": "Christianity",
 		"uniqueName": "Great Andean Road",
 		"uniques": ["Units ignore terrain costs when moving into any tile with Hills",
-			"[-50]% maintenance on roads & railroads",
+			"[-50]% maintenance on road & railroads",
 			"No Maintenance costs for improvements in [Hill] tiles"],
 		"cities": ["Cuzco","Tiwanaku","Machu","Ollantaytambo","Corihuayrachina","Huamanga","Rumicucho","Vilcabamba","Vitcos",
 			"Andahuaylas","Ica","Arequipa","Nasca","Atico","Juli","Chuito","Chuquiapo","Huanuco Pampa","Tamboccocha",

--- a/android/assets/jsons/Civ V - Gods & Kings/Policies.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Policies.json
@@ -239,7 +239,7 @@
 			},
 			{
 				"name": "Trade Unions",
-				"uniques": ["[-33]% maintenance on roads & railroads", "[+1 Gold] from every [Harbor]", "[+1 Gold] from every [Seaport]"],
+				"uniques": ["[-33]% maintenance on road & railroads", "[+1 Gold] from every [Harbor]", "[+1 Gold] from every [Seaport]"],
 				"row": 1,
 				"column": 4
 			},
@@ -260,7 +260,7 @@
 			},
 			{
 				"name": "Protectionism",
-				"uniques": ["[+2] happiness from each type of luxury resource"],
+				"uniques": ["[+2] Happiness from each type of luxury resource"],
 				"requires": ["Mercantilism"],
 				"row": 3,
 				"column": 4
@@ -339,7 +339,7 @@
 			},
 			{
 				"name": "Civil Society",
-				"uniques": ["[-50]% food consumption by specialists [in all cities]"],
+				"uniques": ["[-50]% Food consumption by specialists [in all cities]"],
 				"row": 1,
 				"column": 5
 			},

--- a/android/assets/jsons/Civ V - Vanilla/Buildings.json
+++ b/android/assets/jsons/Civ V - Vanilla/Buildings.json
@@ -690,7 +690,7 @@
 	},
 	{
 		"name": "Kremlin",
-		"cost": 500
+		"cost": 500,
 		"culture": 3,
 		"cityStrength": 12,
 		"isWonder": true,
@@ -905,7 +905,7 @@
 		"isWonder": true,
 		"culture": 3,
 		"greatPersonPoints": {"Great Engineer": 2},
-		"uniques": ["[-33]% Gold cost of upgrading [Military] units"],
+		"uniques": ["[-33]% Gold cost of upgrading <for [Military] units>"],
 		"requiredTech": "Radar",
 		"quote": "'In preparing for battle I have always found that plans are useless, but planning is indispensable.' - Dwight D. Eisenhower"
 	},
@@ -995,6 +995,6 @@
 		"isNationalWonder": true,
 		"uniques": ["Hidden until [5] social policy branches have been completed", "Triggers a global alert upon build start",
 			"Triggers a Cultural Victory upon completion", "Hidden when [Cultural] Victory is disabled"]
-	},
+	}
 	
 ]

--- a/android/assets/jsons/Civ V - Vanilla/Nations.json
+++ b/android/assets/jsons/Civ V - Vanilla/Nations.json
@@ -635,7 +635,7 @@
 		"innerColor": [3,115,86],
 		"uniqueName": "Great Andean Road",
 		"uniques": ["Units ignore terrain costs when moving into any tile with Hills",
-			"[-50]% maintenance on roads & railroads",
+			"[-50]% maintenance on road & railroads",
 			"No Maintenance costs for improvements in [Hill] tiles"],
 		"cities": ["Cuzco","Tiwanaku","Machu","Ollantaytambo","Corihuayrachina","Huamanga","Rumicucho","Vilcabamba","Vitcos",
 			"Andahuaylas","Ica","Arequipa","Nasca","Atico","Juli","Chuito","Chuquiapo","Huanuco Pampa","Tamboccocha",

--- a/android/assets/jsons/Civ V - Vanilla/Policies.json
+++ b/android/assets/jsons/Civ V - Vanilla/Policies.json
@@ -121,7 +121,7 @@
 			},
 			{
 				"name": "Professional Army",
-				"uniques": ["[-33]% Gold cost of upgrading [Military] units", "[+1 Happiness] from every [Walls]",
+				"uniques": ["[-33]% Gold cost of upgrading <for [Military] units>", "[+1 Happiness] from every [Walls]",
 					"[+1 Happiness] from every [Castle]", "[+1 Happiness] from every [Arsenal]", "[+1 Happiness] from every [Military Base]"
 				],
 				"requires": ["Military Caste"],
@@ -239,7 +239,7 @@
 			},
 			{
 				"name": "Trade Unions",
-				"uniques": ["[-33]% maintenance on roads & railroads", "[+1 Gold] from every [Harbor]", "[+1 Gold] from every [Seaport]"],
+				"uniques": ["[-33]% maintenance on road & railroads", "[+1 Gold] from every [Harbor]", "[+1 Gold] from every [Seaport]"],
 				"row": 1,
 				"column": 4
 			},
@@ -260,7 +260,7 @@
 			},
 			{
 				"name": "Protectionism",
-				"uniques": ["[+1] happiness from each type of luxury resource"],
+				"uniques": ["[+1] Happiness from each type of luxury resource"],
 				"requires": ["Mercantilism"],
 				"row": 3,
 				"column": 4
@@ -335,7 +335,7 @@
 			},
 			{
 				"name": "Civil Society",
-				"uniques": ["[-50]% food consumption by specialists [in all cities]"],
+				"uniques": ["[-50]% Food consumption by specialists [in all cities]"],
 				"row": 1,
 				"column": 5
 			},

--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -551,6 +551,7 @@ When disabled, saves battery life but certain animations will be suspended =
 Order trade offers by amount = 
 Check extension mods based on vanilla = 
 Checking mods for errors... = 
+No problems found. = 
 Show experimental world wrap for maps = 
 HIGHLY EXPERIMENTAL - YOU HAVE BEEN WARNED! = 
 Enable portrait orientation = 

--- a/core/src/com/unciv/ui/worldscreen/mainmenu/OptionsPopup.kt
+++ b/core/src/com/unciv/ui/worldscreen/mainmenu/OptionsPopup.kt
@@ -295,7 +295,7 @@ class OptionsPopup(val previousScreen: BaseScreen) : Popup(previousScreen) {
                 if (modLinks.isNotOK()) noProblem = false
                 lines += FormattedLine()
             }
-            if (noProblem) lines += FormattedLine("{No problems found}.",)
+            if (noProblem) lines += FormattedLine("No problems found.".tr())
 
             postCrashHandlingRunnable {
                 // Don't just render text, since that will make all the conditionals in the mod replacement messages move to the end, which makes it unreadable


### PR DESCRIPTION
Uses information from #6027. Removes all the messages shown on the screenshot over there.

I did notice the happiness thing in a recent game too.

Also makes the "No problems found." Label translatable.