### PR TITLE
Destroy Arsenal when city is captured

### DIFF
--- a/android/assets/jsons/Civ V - Gods & Kings/Buildings.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Buildings.json
@@ -824,7 +824,8 @@
 		"cityHealth": 25,
 		"hurryCostModifier": 25,
 		"requiredBuilding": "Castle",
-		"requiredTech": "Metallurgy"
+		"requiredTech": "Metallurgy",
+		"uniques": ["Destroyed when the city is captured"]
 	},
 	{
 		"name": "Kremlin",

--- a/android/assets/jsons/Civ V - Vanilla/Buildings.json
+++ b/android/assets/jsons/Civ V - Vanilla/Buildings.json
@@ -777,7 +777,8 @@
 		"cityHealth": 25,
 		"hurryCostModifier": 25,
 		"requiredBuilding": "Castle",
-		"requiredTech": "Rifling"
+		"requiredTech": "Rifling",
+		"uniques": ["Destroyed when the city is captured"]
 	},
 	// Column 10
 	{


### PR DESCRIPTION
Like all defensive buildings, the Arsenal should be destroyed when the city is captured.