### PR TITLE
Update Copper Mine to add only 1 production (match Civ 5)

### DIFF
--- a/android/assets/jsons/Civ V - Gods & Kings/TileResources.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/TileResources.json
@@ -453,7 +453,7 @@
 		"terrainsCanBeFoundOn": ["Hill","Forest","Jungle","Grassland","Tundra"],
 		"gold": 2,
 		"improvement": "Mine",
-		"improvementStats": {"production": 2},
+		"improvementStats": {"production": 1},
 		"uniques": ["Generated with weight [15] <in [Tundra] Regions>",
 					"Generated with weight [5] <in [Jungle] Regions>",
 					"Generated with weight [5] <in [Forest] Regions>",


### PR DESCRIPTION
As noted in #6032, updating Copper Mine to only provide +1 Production instead of +2 to match Civ5