### PR TITLE
Post-Wiki-Migration cleanup.

### DIFF
--- a/.github/workflows/uncivbot.yml
+++ b/.github/workflows/uncivbot.yml
@@ -84,7 +84,7 @@ jobs:
               # Convert AS/GH code browser inter-page links to GH Wiki links by stripping `.md` extensions.
               sed -ie 's|\(](\./[^)]*\)\.md|\1|g' "$f"
               # Convert AS/GH code browser repo file links to GH Wiki links by prepending repo browser to absolute links.
-              sed -ie 's|](/|](https://github.com/${GITHUB_REPOSITORY}/tree/master/|g' "$f"
+              sed -ie 's|](/|](https://github.com/'"${GITHUB_REPOSITORY}"'/tree/master/|g' "$f"
             else # When glob produces no matches, you just get the glob pattern instead.
               ghStatus "Skipping non-existent file $f."
             fi

--- a/docs/wiki/From-code-to-deployment.md
+++ b/docs/wiki/From-code-to-deployment.md
@@ -18,7 +18,7 @@ The process has two major parts, one is "Getting your code in the main repositor
 
 When I'm ready to release a new version I:
 * Comment "merge translations" in one of the open PRs tagged as 'mergeable translation' to trigger the translation branch creation, add a "summary" comment to trigger summary generation, merge the PR and delete the branch (so next version translation branch starts fresh)
-* From my workstation - pull the latest changes and run the [translation generation](./Translating#translation-generation---for-developers)
+* From my workstation - pull the latest changes and run the [translation generation](./Translating.md#translation-generation---for-developers)
 * Change the versionCode and versionName in the Android build.gradle so that Google Play and F-droid can recognize that it's a different release
 * Add an entry in the changelog.md done, WITHOUT hashtags, and less than 500 characters (that's the limit for Google play entries). The formatting needs to be exact or the text sent to Discord, the Github release etc. won't be complete.
 * Add a tag to the commit of the version. When the [Github action](https://github.com/yairm210/Unciv/actions/workflows/buildAndDeploy.yml) sees that we've added a tag, it will run a build, and this time (because of the configuration we put in the [yml file](/.github/workflows/buildAndDeploy.yml) file), it will:

--- a/docs/wiki/Translating.md
+++ b/docs/wiki/Translating.md
@@ -1,6 +1,6 @@
 ## Starting out
 
-The translation files are at https://github.com/yairm210/Unciv/tree/master/android/assets/jsons/translations
+The translation files are at [/android/assets/jsons/translations](/android/assets/jsons/translations)
 
 If you're adding a new language, you'll need to create a new file ('Create a new file' to the right of the folder name in the UI), and copy into it the contents of template.properties
 


### PR DESCRIPTION
- Skimmed through the diffs for `7f8447c3b433f296542bf5bccf198b1907410e6e`, the first automated commit on the Wiki that overwrote existing content with `/docs/wiki`, to make sure that no substanstantive material was lost in the migration.

- Fixed translation of absolute links to GH source paths in UncivBot. It appears I had broken Bash substitution in the original PR at some point. E.G.: https://github.com/yairm210/Unciv/wiki/Project-structure-and-major-classes/_compare/7f8447c3b433f296542bf5bccf198b1907410e6e...d2d1af27e039c74632136928af29cbdb72e7e6bf

- Searched in project for link-like patterns to harmonize everything to resolve in file-system space, as used by Android Studio and GitHub.com/XXX/tree, and translated into web URLs where needed by the wiki update bot.

- Let Android Studio lint all the `/docs/wiki` files for broken links; Fixed them.

- Ran everything changed on my fork, and checked it again.

