### PR TITLE
Removed a function that is no longer used and should not be used imo

### DIFF
--- a/core/src/com/unciv/logic/city/CityInfo.kt
+++ b/core/src/com/unciv/logic/city/CityInfo.kt
@@ -839,11 +839,6 @@ class CityInfo {
         }
     }
 
-    // Get all uniques that originate from this city
-    fun getAllLocalUniques(): Sequence<Unique> {
-        return cityConstructions.builtBuildingUniqueMap.getAllUniques() + religion.getUniques()
-    }
-
     // Get all matching uniques that don't apply to only this city
     fun getMatchingUniquesWithNonLocalEffects(placeholderText: String): Sequence<Unique> {
         return cityConstructions.builtBuildingUniqueMap.getUniques(placeholderText)


### PR DESCRIPTION
I feel like all queries for uniques should either go through `getMatchingLocalUniques` instead of manually querying the uniques and then filtering through those