### PR TITLE
Converted TileInfo.isCityCenter to use a transient var

### DIFF
--- a/core/src/com/unciv/logic/city/CityExpansionManager.kt
+++ b/core/src/com/unciv/logic/city/CityExpansionManager.kt
@@ -144,7 +144,7 @@ class CityExpansionManager {
                 city.lockedTiles.remove(tileInfo.position)
         }
 
-        tileInfo.owningCity = null
+        tileInfo.setOwningCity(null)
 
         cityInfo.civInfo.updateDetailedCivResources()
         cityInfo.cityStats.update()
@@ -164,7 +164,7 @@ class CityExpansionManager {
             tileInfo.getCity()!!.expansion.relinquishOwnership(tileInfo)
 
         cityInfo.tiles = cityInfo.tiles.withItem(tileInfo.position)
-        tileInfo.owningCity = cityInfo
+        tileInfo.setOwningCity(cityInfo)
         cityInfo.population.autoAssignPopulation()
         cityInfo.civInfo.updateDetailedCivResources()
         cityInfo.cityStats.update()
@@ -190,7 +190,7 @@ class CityExpansionManager {
     fun setTransients() {
         val tiles = cityInfo.getTiles()
         for (tile in tiles)
-            tile.owningCity = cityInfo
+            tile.setOwningCity(cityInfo)
     }
     //endregion
 }

--- a/core/src/com/unciv/logic/map/TileInfo.kt
+++ b/core/src/com/unciv/logic/map/TileInfo.kt
@@ -27,7 +27,16 @@ open class TileInfo {
     lateinit var ruleset: Ruleset  // a tile can be a tile with a ruleset, even without a map.
 
     @Transient
+    private var isCityCenterInternal = false
+
+    @Transient
     var owningCity: CityInfo? = null
+        private set
+
+    fun setOwningCity(city:CityInfo?){
+        owningCity = city
+        isCityCenterInternal = getCity()?.location == position
+    }
 
     @Transient
     private lateinit var baseTerrainObject: Terrain
@@ -156,7 +165,7 @@ open class TileInfo {
             if (naturalWonder == null) throw Exception("No natural wonder exists for this tile!")
             else ruleset.terrains[naturalWonder!!]!!
 
-    fun isCityCenter(): Boolean = getCity()?.location == position
+    fun isCityCenter(): Boolean = isCityCenterInternal
     fun isNaturalWonder(): Boolean = naturalWonder != null
     fun isImpassible() = getLastTerrain().impassable
 

--- a/tests/src/com/unciv/logic/map/TileImprovementConstructionTests.kt
+++ b/tests/src/com/unciv/logic/map/TileImprovementConstructionTests.kt
@@ -23,8 +23,8 @@ class TileImprovementConstructionTests {
     private fun getTile() = TileInfo().apply {
         baseTerrain = "Plains"
         ruleset = ruleSet
-        owningCity = city
         position = Vector2(1f, 1f) // so that it's not on the same position as the city
+        setOwningCity(city)
         this@apply.tileMap = this@TileImprovementConstructionTests.tileMap
     }
 

--- a/tests/src/com/unciv/logic/map/UnitMovementAlgorithmsTests.kt
+++ b/tests/src/com/unciv/logic/map/UnitMovementAlgorithmsTests.kt
@@ -82,7 +82,7 @@ class UnitMovementAlgorithmsTests {
         val city = CityInfo()
         city.location = cityTile.position
         city.civInfo = civInfo
-        cityTile.owningCity = city
+        cityTile.setOwningCity(city)
 
         for (type in ruleSet.unitTypes)
         {
@@ -248,7 +248,7 @@ class UnitMovementAlgorithmsTests {
         val city = CityInfo()
         city.location = tile.position.cpy().add(1f,1f)
         city.civInfo = otherCiv
-        tile.owningCity = city
+        tile.setOwningCity(city)
 
         unit.baseUnit = BaseUnit().apply { unitType = ruleSet.unitTypes.keys.first(); ruleset = ruleSet }
         unit.owner = civInfo.civName


### PR DESCRIPTION
I can't believe this is a thing but there you have it.

![image](https://user-images.githubusercontent.com/8366208/151248763-972e5f99-612a-4c1d-934f-b79a7ca9d5bb.png)

![image](https://user-images.githubusercontent.com/8366208/151248805-5a600fab-4632-436c-984d-2538844becb9.png)

![image](https://user-images.githubusercontent.com/8366208/151248909-78c9855f-3d87-4b0d-844a-a67d6f150f69.png)


Out of 100 seconds, the isCityCenter function occupies nearly *8 seconds*, or in other words *8% of nextTurn runtime*.

I assumed this to be an efficient function, since what does it do, it just takes 2 existing values and compares them, right?

Apparently that's not good enough, at the amount of function calls we're talking about.

Result:

![image](https://user-images.githubusercontent.com/8366208/151249540-a4c68a62-fe05-489b-8274-223fca81fba4.png)

The fun part of performance is that it never ends. Each closed bottleneck reveals new ones.

Things to watch out for:

- updateViewableTiles (this is 30% of nextTurn)
- BaseUnit.canBePurchasedWithStat (around 18%)
- MapUnit.hasUnique (seems to iterate on an array? instead of map access?)
- getUnitMaintenance