### PR TITLE
Possibly fixed a crash accessing gameInfo before it is initialized

### DIFF
--- a/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
@@ -395,10 +395,10 @@ class DiplomacyManager() {
     private fun remakePeaceTreaty(durationLeft: Int) {
         val treaty = Trade()
         treaty.ourOffers.add(
-            TradeOffer(Constants.peaceTreaty, TradeType.Treaty, _duration = durationLeft)
+            TradeOffer(Constants.peaceTreaty, TradeType.Treaty, duration = durationLeft)
         )
         treaty.theirOffers.add(
-            TradeOffer(Constants.peaceTreaty, TradeType.Treaty, _duration = durationLeft)
+            TradeOffer(Constants.peaceTreaty, TradeType.Treaty, duration = durationLeft)
         )
         trades.add(treaty)
         otherCiv().getDiplomacyManager(civInfo).trades.add(treaty)

--- a/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
@@ -395,10 +395,10 @@ class DiplomacyManager() {
     private fun remakePeaceTreaty(durationLeft: Int) {
         val treaty = Trade()
         treaty.ourOffers.add(
-            TradeOffer(Constants.peaceTreaty, TradeType.Treaty, duration = durationLeft)
+            TradeOffer(Constants.peaceTreaty, TradeType.Treaty, _duration = durationLeft)
         )
         treaty.theirOffers.add(
-            TradeOffer(Constants.peaceTreaty, TradeType.Treaty, duration = durationLeft)
+            TradeOffer(Constants.peaceTreaty, TradeType.Treaty, _duration = durationLeft)
         )
         trades.add(treaty)
         otherCiv().getDiplomacyManager(civInfo).trades.add(treaty)

--- a/core/src/com/unciv/logic/map/mapgenerator/MapRegions.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/MapRegions.kt
@@ -1360,7 +1360,7 @@ class MapRegions (val ruleset: Ruleset){
         // Third add some minor deposits to land tiles
         // Note: In G&K there is a bug where minor deposits are never placed on hills. We're not replicating that.
         val frequency = (baseMinorDepositFrequency * bonusMultiplier).toInt()
-        val minorDepositsToAdd = (landList.count() / frequency) + 1
+        val minorDepositsToAdd = (landList.count() / frequency) + 1 // I sometimes have division by zero errors on this line
         var minorDepositsAdded = 0
         for (tile in landList) {
             if (tile.resource != null || tileData[tile.position]!!.impacts.containsKey(ImpactType.Strategic))

--- a/core/src/com/unciv/logic/trade/TradeEvaluation.kt
+++ b/core/src/com/unciv/logic/trade/TradeEvaluation.kt
@@ -8,7 +8,6 @@ import com.unciv.logic.civilization.CivilizationInfo
 import com.unciv.logic.civilization.diplomacy.RelationshipLevel
 import com.unciv.models.ruleset.ModOptionsConstants
 import com.unciv.models.ruleset.Ruleset
-import com.unciv.models.ruleset.tile.ResourceType
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.ui.utils.toPercent
 import com.unciv.ui.victoryscreen.RankingType

--- a/core/src/com/unciv/logic/trade/TradeLogic.kt
+++ b/core/src/com/unciv/logic/trade/TradeLogic.kt
@@ -28,8 +28,9 @@ class TradeLogic(val ourCivilization:CivilizationInfo, val otherCivilization: Ci
         }
 
         for (entry in civInfo.getCivResourcesWithOriginsForTrade()
-                .filterNot { it.resource.resourceType == ResourceType.Bonus }
-                .filter { it.origin == "Tradable" } ) {
+            .filterNot { it.resource.resourceType == ResourceType.Bonus }
+            .filter { it.origin == "Tradable" }
+        ) {
             val resourceTradeType = if (entry.resource.resourceType == ResourceType.Luxury) TradeType.Luxury_Resource
             else TradeType.Strategic_Resource
             offers.add(TradeOffer(entry.resource.name, resourceTradeType, entry.amount))

--- a/core/src/com/unciv/logic/trade/TradeOffer.kt
+++ b/core/src/com/unciv/logic/trade/TradeOffer.kt
@@ -23,13 +23,12 @@ data class TradeOffer(val name:String, val type:TradeType, var amount:Int = 1, p
             if (_duration == null) {
                 // Do *not* access UncivGame.Current.gameInfo in the default constructor!
                 val gameSpeed = UncivGame.Current.gameInfo.gameParameters.gameSpeed
-                val correctDuration = when {
+                _duration = when {
                     type.isImmediate -> -1 // -1 for offers that are immediate (e.g. gold transfer)
                     name == Constants.peaceTreaty -> 10
                     gameSpeed == GameSpeed.Quick -> 25
                     else -> (30 * gameSpeed.modifier).toInt()
                 }
-                _duration = correctDuration
             }
             return _duration!!
         }

--- a/core/src/com/unciv/logic/trade/TradeOffer.kt
+++ b/core/src/com/unciv/logic/trade/TradeOffer.kt
@@ -6,28 +6,38 @@ import com.unciv.models.metadata.GameSpeed
 import com.unciv.models.translations.tr
 import com.unciv.ui.utils.Fonts
 import com.unciv.logic.trade.TradeType.TradeTypeNumberType
-import com.unciv.models.ruleset.tile.ResourceSupply
 
-data class TradeOffer(val name:String, val type:TradeType, var amount:Int = 1, var duration: Int = -1) {
+data class TradeOffer(val name:String, val type:TradeType, var amount:Int = 1, private var _duration: Int? = null) {
 
-    init {
-        // Duration needs to be part of the variables defined in the primary constructor, 
-        // so that it will be copied over with the automatically generated copy()
-        
-        duration =
-            if (type.isImmediate) -1 // -1 for offers that are immediate (e.g. gold transfer)
-            else {
+    /**
+     * It could be that UncivGame.Current is not initialized when unzipping saves, leading to crashes
+     * The easiest way around this, is to only access the UncivGame.Current whenever the data is needed
+     * instead of when the object is created. The obvious way to do that would be to use a lazy.
+     * Those are, sadly, immutable, and as duration also contains the amount of turns left for a trade,
+     * it needs to be mutable. So the next logical solution would be to use a function for accessing
+     * the value, which is basically what is done here. The duration variable is used in the API,
+     * while internally values are saved in the _duration variable.
+    */
+    var duration: Int
+        get() {
+            if (_duration == null) {
                 // Do *not* access UncivGame.Current.gameInfo in the default constructor!
                 val gameSpeed = UncivGame.Current.gameInfo.gameParameters.gameSpeed
-                when {
+                val correctDuration = when {
+                    type.isImmediate -> -1 // -1 for offers that are immediate (e.g. gold transfer)
                     name == Constants.peaceTreaty -> 10
                     gameSpeed == GameSpeed.Quick -> 25
                     else -> (30 * gameSpeed.modifier).toInt()
                 }
+                _duration = correctDuration
             }
-    }
-
-    constructor() : this("", TradeType.Gold) // so that the json deserializer can work
+            return _duration!!
+        }
+        set (newValue: Int) {
+            _duration = newValue
+        }
+    
+    constructor() : this("", TradeType.Gold, _duration = null) // so that the json deserializer can work
 
     @Suppress("CovariantEquals")    // This is an overload, not an override of the built-in equals(Any?)
     fun equals(offer: TradeOffer): Boolean {


### PR DESCRIPTION
From the crash logs of Google play:
```
kotlin.UninitializedPropertyAccessException: 
  at com.unciv.UncivGame.getGameInfo (UncivGame.kt:37)
  at com.unciv.logic.trade.TradeOffer.<init> (TradeOffer.kt:21)
  at com.unciv.logic.trade.TradeOffer.<init> (TradeOffer.kt:11)
  at com.unciv.logic.trade.TradeLogic.getAvailableOffers (TradeLogic.kt:35)
  at com.unciv.logic.trade.TradeLogic.<init> (TradeLogic.kt:13)
  at com.unciv.logic.automation.NextTurnAutomation.potentialLuxuryTrades (NextTurnAutomation.kt:518)
  at com.unciv.logic.automation.NextTurnAutomation.exchangeLuxuries (NextTurnAutomation.kt:562)
  at com.unciv.logic.automation.NextTurnAutomation.automateCivMoves (NextTurnAutomation.kt:46)
  at com.unciv.logic.GameInfo.nextTurn (GameInfo.kt:228)
  at com.unciv.ui.worldscreen.WorldScreen$nextTurn$1.invoke (WorldScreen.kt:642)
  at com.unciv.ui.worldscreen.WorldScreen$nextTurn$1.invoke (WorldScreen.kt:635)
  at com.unciv.ui.utils.ExtensionFunctionsKt$wrapCrashHandling$1.invoke (ExtensionFunctions.kt:306)
  at com.unciv.ui.utils.ExtensionFunctionsKt$wrapCrashHandlingUnit$1.invoke (ExtensionFunctions.kt:333)
  at com.unciv.ui.utils.ExtensionFunctionsKt$wrapCrashHandlingUnit$1.invoke (ExtensionFunctions.kt:333)
  at kotlin.concurrent.ThreadsKt$thread$thread$1.run (Thread.kt:30)
```
The line `tradeOffer.kt:21` is:
```kotlin
val gameSpeed = UncivGame.Current.gameInfo.gameParameters.gameSpeed
```

This seems to indicate that `UncivGame.Current` is not yet initalized when this object is created. A comment direclty above the line of the crash warns for exactly this:
```
// Do *not* access UncivGame.Current.gameInfo in the default constructor!
```
yet it is still done.

This PR moves this dependency from object creation time to property access time (not sure if those are official names), when `UncivGame.Current` should always be initialized.
When testing I was unable to see any differences in behaviour with before this PR.