### PR TITLE
Converted era parameter to a transient var

### DIFF
--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -572,30 +572,7 @@ class CivilizationInfo {
         else -> getCivUnits().none()
     }
 
-    fun getEra(): Era {
-        if (gameInfo.ruleSet.technologies.isEmpty() || tech.researchedTechnologies.isEmpty())
-            return Era()
-        val maxEraOfResearchedTechs = tech.researchedTechnologies
-            .asSequence()
-            .map { it.column!! }
-            .maxByOrNull { it.columnNumber }!!
-            .era
-        val maxEra = gameInfo.ruleSet.eras[maxEraOfResearchedTechs]!!
-
-        val researchedTechsHashset = tech.researchedTechnologies.toHashSet()
-        val minEraOfNonResearchedTechs = gameInfo.ruleSet.technologies.values
-            .asSequence()
-            .filter { it !in researchedTechsHashset }
-            .map { it.column!! }
-            .minByOrNull { it.columnNumber }
-            ?.era
-            ?: return maxEra
-        
-        val minEra = gameInfo.ruleSet.eras[minEraOfNonResearchedTechs]!!
-
-        return if (minEra.eraNumber > maxEra.eraNumber) minEra
-            else maxEra
-    }
+    fun getEra(): Era = tech.era
 
     fun getEraNumber(): Int = getEra().eraNumber
 

--- a/core/src/com/unciv/logic/civilization/TechManager.kt
+++ b/core/src/com/unciv/logic/civilization/TechManager.kt
@@ -4,6 +4,7 @@ import com.unciv.logic.city.CityInfo
 import com.unciv.logic.map.MapSize
 import com.unciv.logic.map.RoadStatus
 import com.unciv.logic.map.TileInfo
+import com.unciv.models.ruleset.Era
 import com.unciv.models.ruleset.unique.UniqueMap
 import com.unciv.models.ruleset.unique.UniqueTriggerActivation
 import com.unciv.models.ruleset.tech.Technology
@@ -20,6 +21,9 @@ import kotlin.math.max
 import kotlin.math.min
 
 class TechManager {
+    @Transient
+    var era: Era = Era()
+
     @Transient
     lateinit var civInfo: CivilizationInfo
     /** This is the Transient list of Technologies */
@@ -326,6 +330,37 @@ class TechManager {
             if (unique.params[1] != techName) continue
             civInfo.addNotification("You have unlocked [The Long Count]!", MayaLongCountAction(), MayaCalendar.notificationIcon)
         }
+
+        updateEra()
+    }
+
+    fun updateEra() {
+        val ruleset = civInfo.gameInfo.ruleSet
+        if (ruleset.technologies.isEmpty() || researchedTechnologies.isEmpty())
+            return
+
+        val maxEraOfResearchedTechs = researchedTechnologies
+            .asSequence()
+            .map { it.column!! }
+            .maxByOrNull { it.columnNumber }!!
+            .era
+        val maxEra = ruleset.eras[maxEraOfResearchedTechs]!!
+
+        val minEraOfNonResearchedTechs = ruleset.technologies.values
+            .asSequence()
+            .filter { it !in researchedTechnologies }
+            .map { it.column!! }
+            .minByOrNull { it.columnNumber }
+            ?.era
+        if (minEraOfNonResearchedTechs == null) {
+            era = maxEra
+            return
+        }
+
+        val minEra = ruleset.eras[minEraOfNonResearchedTechs]!!
+
+        era = if (minEra.eraNumber <= maxEra.eraNumber) maxEra
+        else minEra
     }
 
     fun addTechToTransients(tech: Technology) {
@@ -337,6 +372,7 @@ class TechManager {
         researchedTechnologies.addAll(techsResearched.map { getRuleset().technologies[it]!! })
         researchedTechnologies.forEach { addTechToTransients(it) }
         updateTransientBooleans()
+        updateEra()
     }
 
     private fun updateTransientBooleans() {


### PR DESCRIPTION
The cost of casting getEra() constantly is definitely non-trivial, and why do we even generate the era every time? It only changes when we add a new tech! So we can save it as a transient in the civInfo.tech and be done with it!

Before:
![image](https://user-images.githubusercontent.com/8366208/151358199-38732062-f74a-4478-8112-17b450ef6852.png)

After:
![image](https://user-images.githubusercontent.com/8366208/151357839-713da77e-7b90-4eb5-bb4b-8641bdf8a066.png)

As a reminder, yesterday this same save took about 40s to setTransients, and now we're down to 8s! All the little microimprovements compound on each other :)