### PR TITLE
Current map generation is extremely dependant on specific terrains existing in the ruleset.

### DIFF
--- a/core/src/com/unciv/logic/map/TileInfo.kt
+++ b/core/src/com/unciv/logic/map/TileInfo.kt
@@ -793,7 +793,7 @@ open class TileInfo {
         // Uninitialized tilemap - when you're displaying a tile in the civilopedia or map editor
         if (::tileMap.isInitialized) convertHillToTerrainFeature()
         if (!ruleset.terrains.containsKey(baseTerrain))
-            throw Exception()
+            throw Exception("Terrain $baseTerrain does not exist in ruleset!")
         baseTerrainObject = ruleset.terrains[baseTerrain]!!
         isWater = getBaseTerrain().type == TerrainType.Water
         isLand = getBaseTerrain().type == TerrainType.Land

--- a/core/src/com/unciv/logic/map/mapgenerator/MapGenerator.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/MapGenerator.kt
@@ -400,15 +400,16 @@ class MapGenerator(val ruleset: Ruleset) {
 
             // Old, static map generation rules - necessary for existing base ruleset mods to continue to function
             if (noTerrainUniques) {
-                tile.baseTerrain = when {
-                    temperature < -0.4 -> if (humidity < 0.5) Constants.snow   else Constants.tundra
-                    temperature < 0.8  -> if (humidity < 0.5) Constants.plains else Constants.grassland
+                val autoTerrain = when {
+                    temperature < -0.4 -> if (humidity < 0.5) Constants.snow else Constants.tundra
+                    temperature < 0.8 -> if (humidity < 0.5) Constants.plains else Constants.grassland
                     temperature <= 1.0 -> if (humidity < 0.7) Constants.desert else Constants.plains
                     else -> {
                         println("applyHumidityAndTemperature: Invalid temperature $temperature")
                         Constants.grassland
                     }
                 }
+                if (ruleset.terrains.containsKey(autoTerrain)) tile.baseTerrain = autoTerrain
                 tile.setTerrainTransients()
                 continue
             }
@@ -432,7 +433,7 @@ class MapGenerator(val ruleset: Ruleset) {
      */
     private fun spawnVegetation(tileMap: TileMap) {
         val vegetationSeed = randomness.RNG.nextInt().toDouble()
-        val candidateTerrains = Constants.vegetation.flatMap{ ruleset.terrains[it]!!.occursOn }
+        val candidateTerrains = Constants.vegetation.mapNotNull { ruleset.terrains[it] }.flatMap{ it.occursOn }
         //Checking it.baseTerrain in candidateTerrains to make sure forest does not spawn on desert hill
         for (tile in tileMap.values.asSequence().filter { it.baseTerrain in candidateTerrains
                 && it.getLastTerrain().name in candidateTerrains }) {

--- a/core/src/com/unciv/logic/map/mapgenerator/RiverGenerator.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/RiverGenerator.kt
@@ -16,17 +16,21 @@ class RiverGenerator(
     }
 
     fun spawnRivers() {
+        if (tileMap.values.none { it.isWater }) return
         val numberOfRivers = tileMap.values.count { it.isLand } / MAP_TILES_PER_RIVER
 
         var optionalTiles = tileMap.values.asSequence()
-                .filter { it.baseTerrain == Constants.mountain && it.isFarEnoughFromWater() }.toMutableList()
+            .filter { it.baseTerrain == Constants.mountain && it.isFarEnoughFromWater() }
+            .toMutableList()
         if (optionalTiles.size < numberOfRivers)
             optionalTiles.addAll(tileMap.values.filter { it.isHill() && it.isFarEnoughFromWater() })
         if (optionalTiles.size < numberOfRivers)
-            optionalTiles = tileMap.values.filter { it.isLand && it.isFarEnoughFromWater() }.toMutableList()
+            optionalTiles =
+                tileMap.values.filter { it.isLand && it.isFarEnoughFromWater() }.toMutableList()
 
         val mapRadius = tileMap.mapParameters.mapSize.radius
-        val riverStarts = randomness.chooseSpreadOutLocations(numberOfRivers, optionalTiles, mapRadius)
+        val riverStarts =
+            randomness.chooseSpreadOutLocations(numberOfRivers, optionalTiles, mapRadius)
         for (tile in riverStarts) spawnRiver(tile)
 
         for (tile in tileMap.values) {


### PR DESCRIPTION
This attempts to eliminate those dependencies.
All changes indicate areas where a crash occured before the change.

I still encounter problems in generateRegions when trying to generate a map with no water tiles - @SimorCedar I think the splitRegion doesn't like the fact that there are land tiles on edges of the map?