### PR TITLE
Fixed a few rare mod-specific crashes

### DIFF
--- a/core/src/com/unciv/logic/city/PopulationManager.kt
+++ b/core/src/com/unciv/logic/city/PopulationManager.kt
@@ -63,11 +63,12 @@ class PopulationManager {
         if (foodStored >= getFoodToNextPopulation()) {  // growth!
             foodStored -= getFoodToNextPopulation()
             var percentOfFoodCarriedOver = 
-                (cityInfo.getMatchingUniques(UniqueType.CarryOverFood) 
+                (
+                    (cityInfo.getMatchingUniques(UniqueType.CarryOverFood)
+                        + cityInfo.getMatchingUniques(UniqueType.CarryOverFoodAlsoDeprecated)
+                    ).filter { cityInfo.matchesFilter(it.params[1]) }
                     + cityInfo.getMatchingUniques(UniqueType.CarryOverFoodDeprecated)
-                    + cityInfo.getMatchingUniques(UniqueType.CarryOverFoodAlsoDeprecated)
-                ).filter { cityInfo.matchesFilter(it.params[1]) }
-                .sumOf { it.params[0].toInt() }
+                ).sumOf { it.params[0].toInt() }
             // Try to avoid runaway food gain in mods, just in case 
             if (percentOfFoodCarriedOver > 95) percentOfFoodCarriedOver = 95 
             foodStored += (getFoodToNextPopulation() * percentOfFoodCarriedOver / 100f).toInt()

--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -1,6 +1,7 @@
 package com.unciv.logic.civilization
 
 import com.badlogic.gdx.math.Vector2
+import com.unciv.Constants
 import com.unciv.UncivGame
 import com.unciv.logic.GameInfo
 import com.unciv.logic.UncivShowableException
@@ -988,6 +989,11 @@ class CivilizationInfo {
         shouldShowDiplomaticVotingResults()
 
     private fun updateRevolts() {
+        if (gameInfo.civilizations.none { it.civName == Constants.barbarians }) {
+            // Can't spawn revolts without barbarians ¯\_(ツ)_/¯
+            return
+        }
+        
         if (!hasUnique(UniqueType.SpawnRebels)) {
             removeFlag(CivFlags.RevoltSpawning.name)
             return


### PR DESCRIPTION
-Fixed a crash where having revolts spawn in a game without barbarians crashes the game
-Fixed a crash where mods using an outdated unique for carry-over food could lead to crashes