### PR TITLE
Resources can now again provide uniques applying to the entire civ

### DIFF
--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -403,6 +403,11 @@ class CivilizationInfo {
         if (religionManager.religion != null)
             yieldAll(religionManager.religion!!.getFounderUniques().filter { it.isOfType(uniqueType) })
         
+        yieldAll(getCivResources().asSequence()
+            .filter { it.amount > 0 }
+            .flatMap { it.resource.getMatchingUniques(uniqueType, stateForConditionals) }
+        )
+        
         yieldAll(gameInfo.ruleSet.globalUniques.getMatchingUniques(uniqueType, stateForConditionals))
         
     }.filter {

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -32,6 +32,7 @@ enum class UniqueTarget(val inheritsFrom: UniqueTarget? = null) {
     // These are a bit of a lie. There's no "Promotion only" or "UnitType only" uniques,
     //  they're all just Unit uniques in different places.
     //  So there should be no uniqueType that has a Promotion or UnitType target.
+    //  Except meta-level uniques, such as 'incompatible with [promotion]', of course
     Unit,
     UnitType(Unit),
     Promotion(Unit),
@@ -39,7 +40,7 @@ enum class UniqueTarget(val inheritsFrom: UniqueTarget? = null) {
     // Tile-specific
     Terrain,
     Improvement,
-    Resource,
+    Resource(Global),
     Ruins,
 
     // Other
@@ -99,7 +100,7 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
     NullifiesStat("Nullifies [stat] [cityFilter]", UniqueTarget.Global),
     NullifiesGrowth("Nullifies Growth [cityFilter]", UniqueTarget.Global),
 
-    PercentProductionWonders("[amount]% Production when constructing [buildingFilter] wonders [cityFilter]", UniqueTarget.Global, UniqueTarget.Resource, UniqueTarget.FollowerBelief),
+    PercentProductionWonders("[amount]% Production when constructing [buildingFilter] wonders [cityFilter]", UniqueTarget.Global, UniqueTarget.FollowerBelief),
     PercentProductionBuildings("[amount]% Production when constructing [buildingFilter] buildings [cityFilter]", UniqueTarget.Global, UniqueTarget.FollowerBelief),
     PercentProductionUnits("[amount]% Production when constructing [baseUnitFilter] units [cityFilter]", UniqueTarget.Global, UniqueTarget.FollowerBelief),
 


### PR DESCRIPTION
This fixes Marble not providing the 15% Production bonus.
One downside of this implementation, is that Marble must provide bonuses that are anti-local.
For example, even if it has "[+15]% Production [in this city]" as a unique, that will still apply to all cities. What logical way could you define 'in this city' if you received this resource via trading otherwise?