### PR TITLE
Fix art for farms on hills

### DIFF
--- a/android/assets/jsons/TileSets/FantasyHex.json
+++ b/android/assets/jsons/TileSets/FantasyHex.json
@@ -35,11 +35,11 @@
         "Plains+Jungle+Ancient ruins": ["Plains","Ancient ruins-Jungle","PlainsJungle"],
 	    
 	// Farms on hills
-	"Grassland+Hill+Farm": ["Grassland","Farm","Hill"],
+	"Grassland+Hill+Farm": ["Grassland+Farm","Hill"],
         "Plains+Hill+Farm": ["Plains+Farm","Hill"],
         "Desert+Hill+Farm": ["Desert+Farm","Hill"],
-        "Tundra+Hill+Farm": ["Tundra","Farm","Hill"],
-        "Snow+Hill+Farm": ["Snow","Farm","Hill"],
+        "Tundra+Hill+Farm": ["Tundra+Farm","Hill"],
+        "Snow+Hill+Farm": ["Snow+Farm","Hill"],
 
         //resources behind forest and jungle
             //TODO all the resources...

--- a/android/assets/jsons/TileSets/FantasyHex.json
+++ b/android/assets/jsons/TileSets/FantasyHex.json
@@ -33,6 +33,13 @@
         //Jungle improvements for Jungle
         "Grassland+Jungle+Ancient ruins": ["Grassland","Ancient ruins-Jungle","Jungle"],
         "Plains+Jungle+Ancient ruins": ["Plains","Ancient ruins-Jungle","PlainsJungle"],
+	    
+	// Farms on hills
+	"Grassland+Hill+Farm": ["Grassland","Farm","Hill"],
+        "Plains+Hill+Farm": ["Plains+Farm","Hill"],
+        "Desert+Hill+Farm": ["Desert+Farm","Hill"],
+        "Tundra+Hill+Farm": ["Tundra","Farm","Hill"],
+        "Snow+Hill+Farm": ["Snow","Farm","Hill"],
 
         //resources behind forest and jungle
             //TODO all the resources...


### PR DESCRIPTION
Currently, if you build a farm on a hill by fresh water, the hill does not change appearance at all. This fixes that, causing the area around the rocks to appear farmed.