### PR TITLE
Fixed memory- and time-intensive unit maintenance checks

### DIFF
--- a/core/src/com/unciv/models/ruleset/unique/StateForConditionals.kt
+++ b/core/src/com/unciv/models/ruleset/unique/StateForConditionals.kt
@@ -19,4 +19,11 @@ data class StateForConditionals(
     val combatAction: CombatAction? = null,
 
     val region: Region? = null,
-)
+
+    val ignoreConditionals:Boolean = false,
+) {
+
+    companion object {
+        val IgnoreConditionals = StateForConditionals(ignoreConditionals = true)
+    }
+}

--- a/core/src/com/unciv/models/ruleset/unique/Unique.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Unique.kt
@@ -38,7 +38,8 @@ class Unique(val text: String, val sourceObjectType: UniqueTarget? = null, val s
     }
 
     fun conditionalsApply(state: StateForConditionals?): Boolean {
-        if (state == null) return conditionals.isEmpty() 
+        if (state == null) return conditionals.isEmpty()
+        if (state.ignoreConditionals) return true
         for (condition in conditionals) {
             if (!conditionalApplies(condition, state)) return false
         }


### PR DESCRIPTION
Get all civwide unit discount uniques once, and then filter them by-conditional only when checking each specific unit.
This saves a LOT of memory allocation and time.
A result of the investigation at #5919.