### PR TITLE
Cached summarized civ resources

### DIFF
--- a/core/src/com/unciv/logic/civilization/CivInfoTransientUpdater.kt
+++ b/core/src/com/unciv/logic/civilization/CivInfoTransientUpdater.kt
@@ -164,7 +164,7 @@ class CivInfoTransientUpdater(val civInfo: CivilizationInfo) {
         civInfo.citiesConnectedToCapitalToMediums = citiesReachedToMediums
     }
 
-    fun updateDetailedCivResources() {
+    fun updateCivResources() {
         val newDetailedCivResources = ResourceSupplyList()
         for (city in civInfo.cities) newDetailedCivResources.add(city.getCityResources())
 
@@ -192,6 +192,13 @@ class CivInfoTransientUpdater(val civInfo: CivilizationInfo) {
             for ((resource, amount) in unit.baseUnit.getResourceRequirements())
                 newDetailedCivResources.add(civInfo.gameInfo.ruleSet.tileResources[resource]!!, -amount, "Units")
         civInfo.detailedCivResources = newDetailedCivResources
+
+        val newSummarizedCivResources = ResourceSupplyList()
+        for (resourceSupply in newDetailedCivResources) {
+            newSummarizedCivResources.add(resourceSupply.resource, resourceSupply.amount, "All")
+        }
+        civInfo.summarizedCivResources = newSummarizedCivResources
+
         civInfo.updateStatsForNextTurn() // More or less resources = more or less happiness, with potential domino effects
     }
 }

--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -98,6 +98,9 @@ class CivilizationInfo {
     var detailedCivResources = ResourceSupplyList()
 
     @Transient
+    var summarizedCivResources = ResourceSupplyList()
+
+    @Transient
     val cityStateFunctions = CityStateFunctions(this)
 
     @Transient
@@ -324,13 +327,7 @@ class CivilizationInfo {
     fun getHappiness() = happinessForNextTurn
 
 
-    fun getCivResources(): ResourceSupplyList {
-        val newResourceSupplyList = ResourceSupplyList()
-        for (resourceSupply in detailedCivResources) {
-            newResourceSupplyList.add(resourceSupply.resource, resourceSupply.amount, "All")
-        }
-        return newResourceSupplyList
-    }
+    fun getCivResources(): ResourceSupplyList = summarizedCivResources
 
     // Preserves some origins for resources so we can separate them for trades
     fun getCivResourcesWithOriginsForTrade(): ResourceSupplyList {
@@ -799,7 +796,7 @@ class CivilizationInfo {
     fun initialSetCitiesConnectedToCapitalTransients() = transients().updateCitiesConnectedToCapital(true)
     fun updateHasActiveGreatWall() = transients().updateHasActiveGreatWall()
     fun updateViewableTiles() = transients().updateViewableTiles()
-    fun updateDetailedCivResources() = transients().updateDetailedCivResources()
+    fun updateDetailedCivResources() = transients().updateCivResources()
 
     fun startTurn() {
         civConstructions.startTurn()


### PR DESCRIPTION
Summarized civ resources, which were getting accessed all the time, are now cached and updated together with the detailed civ resources.
A result of the investigation at #5919.