### PR TITLE
Fixed a bug where stats from uniques would exponentially grow

### DIFF
--- a/core/src/com/unciv/logic/city/CityStats.kt
+++ b/core/src/com/unciv/logic/city/CityStats.kt
@@ -22,7 +22,7 @@ class StatTreeNode {
     private var innerStats: Stats? = null
 
     private fun addInnerStats(stats: Stats) {
-        if (innerStats == null) innerStats = stats
+        if (innerStats == null) innerStats = stats.clone() // Copy the stats instead of referencing them
         else innerStats!!.add(stats) // What happens if we add 2 stats to the same leaf?
     }
 


### PR DESCRIPTION
Instead of cloning stats, we copy the reference to them, and then start adding things. This, of course, can only go wrong, and it did: in the save file below (provided by a discord user), the mughal fort's "[+1 Gold] \<after discovering [Flight]>" starting providing INT_MAX gold/turn. Fixing it is luckily simple, just clone the stats instead of assigning it directly.


[Weird Stuff.txt](https://github.com/yairm210/Unciv/files/7990906/Weird.Stuff.txt)