### PR TITLE
Fixed a bug where units requiring nearby units for bonuses could find themselves

### DIFF
--- a/core/src/com/unciv/models/ruleset/unique/Unique.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Unique.kt
@@ -1,6 +1,7 @@
 package com.unciv.models.ruleset.unique
 
 import com.unciv.logic.battle.CombatAction
+import com.unciv.logic.battle.MapUnitCombatant
 import com.unciv.logic.city.CityInfo
 import com.unciv.models.stats.Stats
 import com.unciv.models.translations.*
@@ -53,6 +54,10 @@ class Unique(val text: String, val sourceObjectType: UniqueTarget? = null, val s
 
         fun ruleset() = state.civInfo!!.gameInfo.ruleSet
         val relevantUnitTile by lazy { state.attackedTile ?: state.unit?.getTile() }
+        val relevantUnit by lazy {
+            if (state.ourCombatant != null && state.ourCombatant is MapUnitCombatant) state.ourCombatant.unit
+            else state.unit
+        }
 
         return when (condition.type) {
             UniqueType.ConditionalWar -> state.civInfo?.isAtWar() == true
@@ -120,7 +125,9 @@ class Unique(val text: String, val sourceObjectType: UniqueTarget? = null, val s
                             != state.unit.getTile().getContinent()
                     )
             UniqueType.ConditionalAdjacentUnit ->
-                state.civInfo != null && relevantUnitTile!!.neighbors.any {
+                state.civInfo != null 
+                && relevantUnit != null
+                && relevantUnit!!.currentTile.neighbors.any {
                     it.militaryUnit != null
                     && it.militaryUnit!!.civInfo == state.civInfo    
                     && it.militaryUnit!!.matchesFilter(condition.params[0])

--- a/core/src/com/unciv/models/ruleset/unique/Unique.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Unique.kt
@@ -127,8 +127,9 @@ class Unique(val text: String, val sourceObjectType: UniqueTarget? = null, val s
             UniqueType.ConditionalAdjacentUnit ->
                 state.civInfo != null 
                 && relevantUnit != null
-                && relevantUnit!!.currentTile.neighbors.any {
+                && relevantUnitTile!!.neighbors.any {
                     it.militaryUnit != null
+                    && it.militaryUnit != relevantUnit
                     && it.militaryUnit!!.civInfo == state.civInfo    
                     && it.militaryUnit!!.matchesFilter(condition.params[0])
                 }


### PR DESCRIPTION
For example the discipline policy wanted 'an adjacent [Melee] unit' for the bonus to take effect. However, the 'adjacent' was determined from the tile where the battle would take place, to which the unit was adjacent. The condition would therefore be satisfied, by having found themselves.

Save file (send in by discord user):
[Greece -  6 turns.txt](https://github.com/yairm210/Unciv/files/7993947/Greece.-.6.turns.txt)
