### PR TITLE
Update Korean.properties

### DIFF
--- a/android/assets/jsons/translations/Korean.properties
+++ b/android/assets/jsons/translations/Korean.properties
@@ -4450,41 +4450,32 @@ Stele = 스텔레
 
 Shrine = 성소
 
- # Requires translation!
-Pyramid = 
+Pyramid = 피라미드
 
 
- # Requires translation!
-'Regard your soldiers as your children, and they will follow you into the deepest valleys; look on them as your own beloved sons, and they will stand by you even unto death.' - Sun Tzu = 
+'Regard your soldiers as your children, and they will follow you into the deepest valleys; look on them as your own beloved sons, and they will stand by you even unto death.' - Sun Tzu = '병사를 자식처럼 부르면 어디든 따를 것이다. 병사를 사랑하는 자식 대하듯 하면 목숨을 바쳐 충성할 것이다.' - 손자
 Terracotta Army = 병마용
 
 
 Amphitheater = 원형 극장
 
 
- # Requires translation!
-'...who drinks the water I shall give him, says the Lord, will have a spring inside him welling up for eternal life. Let them bring me to your holy mountain in the place where you dwell. Across the desert and through the mountain to the Canyon of the Crescent Moon...' - Indiana Jones = 
+'...who drinks the water I shall give him, says the Lord, will have a spring inside him welling up for eternal life. Let them bring me to your holy mountain in the place where you dwell. Across the desert and through the mountain to the Canyon of the Crescent Moon...' - Indiana Jones = '...내가 주는 물을 마시는 자는 불로장생할 것이니 사람들이 나를 네가 있는 성스러운 산으로 인도하도록 할지어다. 사막을 가로지르고 산을 넘으면 초승달 계곡이 나오는데...' - 인디아나 존스
 Petra = 페트라
 
 
- # Requires translation!
-'With the magnificence of eternity before us, let time, with all its fluctuations, dwindle into its own littleness.' - Thomas Chalmers = 
- # Requires translation!
-Great Mosque of Djenne = 
- # Requires translation!
-[baseUnitFilter] units built [cityFilter] can [action] [amount] extra times = 
+'With the magnificence of eternity before us, let time, with all its fluctuations, dwindle into its own littleness.' - Thomas Chalmers = '무한이라는 장엄한 개념 앞에서 변동이 심한 시간이라는 개념은 작아질 수밖에 없다.' - 토마스 챌머스
+Great Mosque of Djenne = 젠네 모스크
+[baseUnitFilter] units built [cityFilter] can [action] [amount] extra times = [cityFilter]에서 탄생한 [baseUnitFilter] 유닛의 [action] 횟수 [amount]회 증가
 
- # Requires translation!
-Grand Temple = 
+Grand Temple = 대사원
 
 
- # Requires translation!
-'Justice is an unassailable fortress, built on the brow of a mountain which cannot be overthrown by the violence of torrents, nor demolished by the force of armies.' - Joseph Addison = 
+'Justice is an unassailable fortress, built on the brow of a mountain which cannot be overthrown by the violence of torrents, nor demolished by the force of armies.' - Joseph Addison = '정의란 급류나 군대로도 무너트릴 수 없는 산꼭대기에 세운 무적의 요새다.' - 조저프 에디슨
 Alhambra = 알함브라 궁전
 
 
- # Requires translation!
-Ceilidh Hall = 
+Ceilidh Hall = 케일리 홀
 
 
 'Don't clap too hard - it's a very old building.' - John Osbourne = '아주 오래된 건물이니까, 너무 세게 손뼉 치지 마십시오.' - 존 오스본
@@ -4494,15 +4485,12 @@ Leaning Tower of Pisa = 피사의 탑
 Coffee House = 카페
 
 
- # Requires translation!
-'...the location is one of the most beautiful to be found, holy and unapproachable, a worthy temple for the divine friend who has brought salvation and true blessing to the world.' - King Ludwig II of Bavaria = 
+'...the location is one of the most beautiful to be found, holy and unapproachable, a worthy temple for the divine friend who has brought salvation and true blessing to the world.' - King Ludwig II of Bavaria = '…아름답고 성스럽고 범접할 수 없는 곳에 있다. 세상을 구원하고 축복하러 온 신성한 친구에게 어울리는 곳이다.' - 루트비히 2세
 Neuschwanstein = 노이슈반슈타인 성
 
 
- # Requires translation!
-Recycling Center = 
- # Requires translation!
-Limited to [amount] per Civilization = 
+Recycling Center = 재활용 센터
+Limited to [amount] per Civilization = 문명당 [amount]개까지 건설 가능
 
 
 'Nothing travels faster than light with the possible exception of bad news, which obeys its own special rules.' - Douglas Adams = '물리학에서 빛보다 빠른 물체는 없다. 그러나 나쁜 소식은 빛보다 빠를 수 있다. 이는 소식이 퍼지는 데 특별한 법칙이 적용되기 때문이다.' - 더글라스 애덤스
@@ -4510,12 +4498,10 @@ CN Tower = CN 타워
 [amount] population [cityFilter] = [cityFilter]의 인구 [amount]
 
 Bomb Shelter = 방공호
- # Requires translation!
-Population loss from nuclear attacks [amount]% [cityFilter] = 
+Population loss from nuclear attacks [amount]% [cityFilter] = [cityFilter]의 핵 공격으로 인한 인구 손실 [amount]%
 
 
- # Requires translation!
-'The wonder is, not that the field of stars is so vast, but that man has measured it.' - Anatole France = 
+'The wonder is, not that the field of stars is so vast, but that man has measured it.' - Anatole France = '진정한 불가사의는 우주의 방대한 크기가 아니라 인간이 그 크기를 측정했다는 사실이다.' - 아나톨 프랑스
 Hubble Space Telescope = 허블 우주 망원경
 
 
@@ -4533,12 +4519,9 @@ Pagoda = 파고다
 #################### Lines from Eras from Civ V - Gods & Kings ####################
 
 
- # Requires translation!
-May not generate great prophet equivalents naturally = 
- # Requires translation!
-May buy [baseUnitFilter] units for [amount] [stat] [cityFilter] at an increasing price ([amount2]) = 
- # Requires translation!
-Starting in this era disables religion = 
+May not generate great prophet equivalents naturally = 위대한 선지자를 탄생시킬 수 없습니다.
+May buy [baseUnitFilter] units for [amount] [stat] [cityFilter] at an increasing price ([amount2]) = [cityFilter]애서 [baseUnitFilter] 유닛을 [amount] [stat]으로 구매할 수는 있습니다. ([amount2]씩 비용 증가)
+Starting in this era disables religion = 이 시대에서 시작하면 종교가 비활성화됩니다.
 
 
 Marine = 해병대
@@ -4582,10 +4565,8 @@ You are in the presence of Attila, scourge of Rome. Do not let hubris be your do
 This is better than you deserve, but let it not be said that I am an unfair man. = 이정도까지 해줄 이유는 없지만, 나는 그렇게 인색한 사람이 아니다.
 Good day to you. = 안녕하시오.
 Scourge of God = 신의 재앙
- # Requires translation!
-Your men stand proudly to greet you, Great Attila, grand warrior and ruler of the Hunnic empire. Together with your brother Bleda you expanded the boundaries of your empire, becoming the most powerful and frightening force of the 5th century. You bowed the Eastern Roman Emperors to your will and took kingdom after kingdom along the Danube and Nisava Rivers. As the sovereign ruler of the Huns, you marched your army across Europe into Gaul, planning to extend your already impressive lands all the way to the Atlantic Ocean. Your untimely death led to the quick disintegration and downfall of your empire, but your name and deeds have created an everlasting legacy for your people. = 
- # Requires translation!
-Fearsome General, your people call for the recreation of a new Hunnic Empire, one which will make the exploits and histories of the former seem like the faded dreaming of a dying sun. Will you answer their call to regain your rightful prominence and glory? Will you mount your steadfast steed and lead your armies to victory? Will you build a civilization that stands the test of time? = 
+Your men stand proudly to greet you, Great Attila, grand warrior and ruler of the Hunnic empire. Together with your brother Bleda you expanded the boundaries of your empire, becoming the most powerful and frightening force of the 5th century. You bowed the Eastern Roman Emperors to your will and took kingdom after kingdom along the Danube and Nisava Rivers. As the sovereign ruler of the Huns, you marched your army across Europe into Gaul, planning to extend your already impressive lands all the way to the Atlantic Ocean. Your untimely death led to the quick disintegration and downfall of your empire, but your name and deeds have created an everlasting legacy for your people. = 훈 제국의 통치자이자 숭고한 전사인 아틸라여, 그대의 백성이 당당하게 일어나 그대를 맞이합니다. 그대는 형 블레다와 함께 제국의 경계를 확장하여 5세기 최강의 대제국을 건설했습니다. 동로마 제국 황제를 무릎 꿇리고 도나우 강과 니샤바 강을 따라 여러 왕국을 정복했습니다. 훈족의 군주인 그대는 이미 대서양까지 이어지는 영토 확장의 꿈을 품고 유럽을 통과해 갈리아까지 진군했습니다. 그대의 때아닌 죽음으로 제국은 끝내 와해되어 멸망하였으나, 그대의 이름과 업적은 훈족에게 영원한 유산으로 남았습니다.
+Fearsome General, your people call for the recreation of a new Hunnic Empire, one which will make the exploits and histories of the former seem like the faded dreaming of a dying sun. Will you answer their call to regain your rightful prominence and glory? Will you mount your steadfast steed and lead your armies to victory? Will you build a civilization that stands the test of time? = 무시무시한 장군이여, 그대의 백성은 옛 제국의 공적과 역사가 죽어가는 태양의 빛바랜 꿈처럼 보이게 할 만큼 강대한 제국을 새로이 건설하고 싶어합니다. 그들의 부름에 응하여 다시금 그대의 용맹과 영광을 떨치겠습니까? 튼튼한 애마를 타고 군대를 승리로 이끌겠습니까? 세월의 시련을 이겨낼 문명을 건설하겠습니까?
 Atilla's Court = 아틸라 궁정
 The Huns = 훈족
 Cities are razed [amount] times as fast = 도시를 불태우는 속도 [amount]배
@@ -4698,321 +4679,181 @@ Gain [amount] Influence with a [param] gift to a City-State = 도시 국가에 [
 When declaring friendship, both parties gain a [amount]% boost to great person generation = 다른 문명과 우호 관계 선언시 양국의 위인 출현율 +[amount]%
 
 Maria Theresa = 마리아 테레지아
- # Requires translation!
-Shame that it has come this far. But ye wished it so. Next time, be so good, choose your words more wisely. = 
-What a fool ye are! Ye will end swiftly and miserably. = 어리석군요! 당신은 곧 비참하게 될 것입니다.
-The world is pitiful! There's no beauty in it, no wisdom. I am almost glad to go. = 가엾은 세상이여! 이곳에는 아름다움도, 현명함도 없군요. 내가 떠나는 것이 기쁩니다.
-The archduchess of Austria welcomes your Eminence to... Oh let's get this over with! I have a luncheon at four o'clock. = 오스트리아의 대공비가 당신의 방문을 환영... 환영 인사는 끝내야겠군요! 4시에 오찬이 있어서요.
-I see you admire my new damask. Nobody should say that I am an unjust woman. Let's reach an agreement! = 당신이 제 새 다마스크를 감탄스럽게 보고 있는 것 같군요. 아무도 제가 불공평한 여자라고 할 수는 없습니다. 합의를 보죠!
+Shame that it has come this far. But ye wished it so. Next time, be so good, choose your words more wisely. = 여기까지 와버린 것이 안타깝습니다. 그러나 당신네들이 바란 일이죠. 다음부터는 꼭 말을 가려가면서 하세요.
+What a fool ye are! Ye will end swiftly and miserably. = 어리석군요! 당신은 곧 비참해질 것입니다.
+The world is pitiful! There's no beauty in it, no wisdom. I am almost glad to go. = 참으로 끔찍한 세상이로군요! 아름다움도, 현명함도 없는 이런 세상이라면 떠나도 아쉬울 게 없어요.
+The archduchess of Austria welcomes your Eminence to... Oh let's get this over with! I have a luncheon at four o'clock. = 오스트리아의 대공비가 공의 방문을... 오, 인사치레는 이쯤에서 끝내지요. 4시에 오찬이 있어서요.
+I see you admire my new damask. Nobody should say that I am an unjust woman. Let's reach an agreement! = 내 다마스크를 자꾸 쳐다보더군요. 나는 치사한 여자가 아니에요. 거래합시다!
 Oh, it's ye! = 오, 당신이군요!
 Diplomatic Marriage = 외교혼
- # Requires translation!
-Noble and virtuous Queen Maria Theresa, Holy Roman Empress and sovereign of Austria, the people bow to your gracious will. Following the death of your father King Charles VI, you ascended the thone of Austria during a time of great instability, but the empty coffers and diminished military did litle to dissuade your ambitions. Faced with war almost immediately upon your succession to the thron, you managed to fend off your foes, and in naming your husband Francis Stephen co-ruler, assured your place as Empress of the Holy Roman Empire. During your reigh, you guided Austria on a new path of reform - strengthening the military, replenishing the treasury, and improving the educational system of the kingdom. = 
- # Requires translation!
-Oh great queen, bold and dignified, the time has come for you to rise and guide the kingdom once again. Can you return your people to the height of prosperity and splendor? Will you build a civilization that stands the test of time? = 
+Noble and virtuous Queen Maria Theresa, Holy Roman Empress and sovereign of Austria, the people bow to your gracious will. Following the death of your father King Charles VI, you ascended the thone of Austria during a time of great instability, but the empty coffers and diminished military did litle to dissuade your ambitions. Faced with war almost immediately upon your succession to the thron, you managed to fend off your foes, and in naming your husband Francis Stephen co-ruler, assured your place as Empress of the Holy Roman Empire. During your reigh, you guided Austria on a new path of reform - strengthening the military, replenishing the treasury, and improving the educational system of the kingdom. = 신성로마제국의 여황이자 오스트리아의 군주이신 고귀하고 고결한 마리아 테레지아 여왕이시여. 모든 백성이 당신의 자애로운 명령에 순종하나이다. 부왕 카를 6세께서 서거하신 후 시국이 매우 불안정한 와중에 왕위에 오르셨으나, 텅 빈 국고와 줄어든 군사력은 당신의 야망을 꺾기엔 너무나도 작은 문제에 지나지 않습니다. 명목상의 공동 통치자이자 부군이신 프란츠 슈테판을 내세워 신성로마제국의 여황 자리를 확립하시고, 즉위 후 바로 전쟁에 임하시어 적들을 물리치셨습니다. 당신의 통치 아래서 오스트리아는 군사력 증강, 국고 보충, 교육 체계 개선 등을 이루며 재건의 길을 걸어갑니다.
+Oh great queen, bold and dignified, the time has come for you to rise and guide the kingdom once again. Can you return your people to the height of prosperity and splendor? Will you build a civilization that stands the test of time? = 용기와 위엄을 한데 갖추신 위대한 여황이시여. 왕국을 다시 되살릴 때가 왔습니다. 당신의 백성을 번영과 영광으로 이끌어 주시겠습니까? 세월의 시련을 이겨낼 문명을 건설하겠습니까?
 Vienna = 비엔나
 Salzburg = 잘츠부르크
 Graz = 그라츠
 Linz = 린츠
 Klagenfurt = 클라겐푸르트
- # Requires translation!
-Bregenz = 
- # Requires translation!
-Innsbruck = 
- # Requires translation!
-Kitzbühel = 
- # Requires translation!
-St. Pölten = 
- # Requires translation!
-Eisenstadt = 
- # Requires translation!
-Villach = 
- # Requires translation!
-Zwettl = 
- # Requires translation!
-Traun = 
- # Requires translation!
-Wels = 
- # Requires translation!
-Dornbirn = 
- # Requires translation!
-Feldkirch = 
- # Requires translation!
-Amstetten = 
- # Requires translation!
-Bad Ischl = 
- # Requires translation!
-Wolfsberg = 
- # Requires translation!
-Kufstein = 
- # Requires translation!
-Leoben = 
- # Requires translation!
-Klosterneuburg = 
- # Requires translation!
-Leonding = 
- # Requires translation!
-Kapfenberg = 
- # Requires translation!
-Hallein = 
- # Requires translation!
-Bischofshofen = 
- # Requires translation!
-Waidhofen = 
- # Requires translation!
-Saalbach = 
- # Requires translation!
-Lienz = 
- # Requires translation!
-Steyr = 
+Bregenz = 브레겐츠
+Innsbruck = 인스브룩
+Kitzbühel = 키츠뷔엘
+St. Pölten = 장크트픨텐
+Eisenstadt = 아이젠슈타트
+Villach = 필라흐
+Zwettl = 츠베틀
+Traun = 트라운
+Wels = 벨스
+Dornbirn = 도른비른
+Feldkirch = 펠트키르히
+Amstetten = 암슈테텐
+Bad Ischl = 바트이슐
+Wolfsberg = 볼프스부르크
+Kufstein = 쿠프슈타인
+Leoben = 레오벤
+Klosterneuburg = 클로스터노이부르크
+Leonding = 레온딩
+Kapfenberg = 카펜베르트
+Hallein = 할라인
+Bischofshofen = 비쇼프스호펜
+Waidhofen = 바이트호펜
+Saalbach = 잘아흐
+Lienz = 린츠
+Steyr = 슈타이아
 Austria = 오스트리아
 Can spend Gold to annex or puppet a City-State that has been your ally for [amount] turns. = 골드를 사용하여 [amount]턴 동안 동맹이 유지된 도시 국가를 합병하거나 괴뢰 정부를 세울 수 있습니다.
 
 Dido = 디도
- # Requires translation!
-Tell me, do you all know how numerous my armies, elephants and the gdadons are? No? Today, you shall find out! = 
-Fate is against you. You earned the animosity of Carthage in your exploration. Your days are numbered. = 운명은 당신의 편이 아닙니다. 당신은 당신의 정복에 대한 카르타고의 반감을 샀습니다. 당신이 살 날도 이제 얼마 안 남았군요.
+Tell me, do you all know how numerous my armies, elephants and the gdadons are? No? Today, you shall find out! = 카르타고의 군세나 코끼리 군단의 위용, 전선의 수 정도는 파악하고 전쟁을 시작했습니까? 모른다고요? 곧 알게 될 겁니다!
+Fate is against you. You earned the animosity of Carthage in your exploration. Your days are numbered. = 당신의 운이 다했습니다. 위대한 카르타고는 더이상 당신의 조롱과 협박을 참지 않을 겁니다. 죽을 준비나 하시지요.
 The fates became to hate me. This is it? You wouldn't destroy us so without their help. = 운명이 저를 싫어하게 되었다, 이건가요? 운명의 도움 없이는 저희를 정복할 수 없었을 겁니다.
 The Phoenicians welcome you to this most pleasant kingdom. I am Dido, the queen of Carthage and all that belongs to it. = 페니키아인들은 가장 즐거운 왕국으로의 당신의 방문을 환영합니다. 저는 카르타고와 그곳에 속한 모든 것의 여왕입니다.
-I just had the marvelous idea, and I think you'll appreciate it too. = 놀라운 생각을 해냈습니다, 당신도 그렇게 생각할 것 같네요.
+I just had the marvelous idea, and I think you'll appreciate it too. = 아주 멋진 생각이 떠올랐습니다. 그대도 기뻐할 게 분명합니다.
 What is it now? = 또 뭡니까?
 Phoenician Heritage = 페니키아의 계승자
- # Requires translation!
-Blessings and salutations to you, revered Queen Dido, founder of the legendary kingdom of Carthage. Chronicled by the words of the great poet Virgil, your husband Acerbas was murdered at the hands of your own brother, King Pygmalion of Tyre, who subsequently claimed the treasures of Acerbas that were now rightfully yours. Fearing the lengths from which your brother would pursue this vast wealth, you and your compatriots sailed for new lands. Arriving on the shores of North Africa, you tricked the local king with the simple manipulation of an ox hide, laying out a vast expanse of territory for your new home, the future kingdom of Carthage. = 
- # Requires translation!
-Clever and inquisitive Dido, the world longs for a leader who can provide a shelter from the coming storm, guided by brilliant intuition and cunning. Can you lead the people in the creation of a new kingdom to rival that of once mighty Carthage? Can you build a civilization that will stand the test of time? = 
+Blessings and salutations to you, revered Queen Dido, founder of the legendary kingdom of Carthage. Chronicled by the words of the great poet Virgil, your husband Acerbas was murdered at the hands of your own brother, King Pygmalion of Tyre, who subsequently claimed the treasures of Acerbas that were now rightfully yours. Fearing the lengths from which your brother would pursue this vast wealth, you and your compatriots sailed for new lands. Arriving on the shores of North Africa, you tricked the local king with the simple manipulation of an ox hide, laying out a vast expanse of territory for your new home, the future kingdom of Carthage. = 전설적인 왕국 카르타고를 건국하신 존경받는 여왕 디도께 축복과 찬사가 있기를. 위대한 시인 베르길리우스의 서사시에 따르면 당신의 부군 아케르바스는 그의 재산을 탐내는 티레의 왕 피그말리온, 즉 당신 오라버니의 손에 목숨을 잃었다 합니다. 그의 막대한 재산을 얻기 위해 오라버니가 벌인 만행을 두려워한 당신은 동료를 모아 새로운 땅으로 떠나셨습니다. 북아프리카 해안에 도착한 당신은 그 지역의 통치자를 소가죽을 사용한 지혜로 압도하여 넓은 토지를 획득하시고 미래의 카르타고 왕국을 세울 기반을 마련하셨습니다.
+Clever and inquisitive Dido, the world longs for a leader who can provide a shelter from the coming storm, guided by brilliant intuition and cunning. Can you lead the people in the creation of a new kingdom to rival that of once mighty Carthage? Can you build a civilization that will stand the test of time? = 지혜롭고 호기심 많은 디도시여. 뛰어난 직감과 지혜로 앞으로 다가올 폭풍우를 막아낼 수 있는 지도자가 필요하옵니다. 과거의 강력한 카르타고와 견줄 만한 새로운 왕국을 만드시겠습니까? 세월의 시련을 이겨낼 문명을 건설하겠습니까?
 Carthage = 카르타고
- # Requires translation!
-Utique = 
- # Requires translation!
-Hippo Regius = 
- # Requires translation!
-Gades = 
- # Requires translation!
-Saguntum = 
- # Requires translation!
-Carthago Nova = 
- # Requires translation!
-Panormus = 
- # Requires translation!
-Lilybaeum = 
- # Requires translation!
-Hadrumetum = 
- # Requires translation!
-Zama Regia = 
- # Requires translation!
-Karalis = 
- # Requires translation!
-Malaca = 
- # Requires translation!
-Leptis Magna = 
- # Requires translation!
-Hippo Diarrhytus = 
- # Requires translation!
-Motya = 
- # Requires translation!
-Sulci = 
- # Requires translation!
-Leptis Parva = 
- # Requires translation!
-Tharros = 
- # Requires translation!
-Soluntum = 
- # Requires translation!
-Lixus = 
- # Requires translation!
-Oea = 
- # Requires translation!
-Theveste = 
- # Requires translation!
-Ibossim = 
- # Requires translation!
-Thapsus = 
- # Requires translation!
-Aleria = 
- # Requires translation!
-Tingis = 
- # Requires translation!
-Abyla = 
- # Requires translation!
-Sabratha = 
- # Requires translation!
-Rusadir = 
- # Requires translation!
-Baecula = 
- # Requires translation!
-Saldae = 
+Utique = 우티쿠
+Hippo Regius = 히포레기우스
+Gades = 가데스
+Saguntum = 사군툼
+Carthago Nova = 카르타고노바
+Panormus = 파노르무스
+Lilybaeum = 릴리바이움
+Hadrumetum = 하드루메툼
+Zama Regia = 자마레기아
+Karalis = 카랄리스
+Malaca = 말라카
+Leptis Magna = 렙티스마그나
+Hippo Diarrhytus = 히포다이리투스
+Motya = 모티아
+Sulci = 술키
+Leptis Parva = 렙티스파바
+Tharros = 타로스
+Soluntum = 소룬툼
+Lixus = 릭서스
+Oea = 오에아
+Theveste = 테베스테
+Ibossim = 이보심
+Thapsus = 탑수스
+Aleria = 알레리아
+Tingis = 틴기스
+Abyla = 아빌라
+Sabratha = 사브라타
+Rusadir = 루사디르
+Baecula = 베쿨라
+Saldae = 살대
 Land units may cross [tileFilter] tiles after the first [unit] is earned = [unit]을(를) 처음 얻고 나서 지상 유닛들은 [tileFilter]을(를) 통행할 수 있음
 Units ending their turn on [tileFilter] tiles take [amount] damage = [tileFilter]에서 턴을 마친 유닛들은 [amount] 데미지를 받음
 
 Theodora = 테오도라
-It is always a shame to destroy a thing of beauty. Happily, you are not one. = 아름다운 것을 파괴하는 것은 언제나 부끄러운 일이죠. 기쁘게도, 당신은 아닙니다.
-Now darling, tantrums are most unbecoming. I shall have to teach you a lesson. = 화를 내는 건 가장 부적절한 것이에요. 제가 당신을 가르쳐주어야겠군요.
-Like a child playing with toys you are. My people will never love you, nor suffer this indignation gracefully. = 저희를 아주 갖고 놀았군요. 백성들은 당신을 좋아하지 않을 것이고, 그렇다고 이 분함에 시달리지도 않을 것입니다.
-My, isn't this a pleasant surprise - what may I call you, oh mysterious stranger? I am Theodora, beloved of Byzantium. = 뜻밖의 기쁨이군요! 제가 당신을 뭐라고 불러야 할까요, 미스터리한 낯선이가 좋을까요? 저는 비잔티움의 총애받는 여왕, 테오도라입니다.
-I have heard that you adept at certain kinds of ... interactions. Show me. = 당신이 교류에 능숙하다고 들었습니다. 보여주세요.
+It is always a shame to destroy a thing of beauty. Happily, you are not one. = 아름다운 사람을 죽여야 할 때면 내 마음이 안타깝지만, 당신은 아름답지 않아서 다행이야.
+Now darling, tantrums are most unbecoming. I shall have to teach you a lesson. = 우리 자기, 더는 짜증을 못 받아 주겠네요. 따끔한 맛을 보여 드릴게요.
+Like a child playing with toys you are. My people will never love you, nor suffer this indignation gracefully. = 당신은 장난감을 가지고 노는 아이나 다름없네요. 우리는 절대로 당신을 반기지 않을 것이고, 분노를 쉽게 누그러뜨리지도 않을 거예요.
+My, isn't this a pleasant surprise - what may I call you, oh mysterious stranger? I am Theodora, beloved of Byzantium. = 뜻밖의 기쁨이군요! 당신을 뭐라고 불러야 하나요, 잘생긴 이방인? 저는 비잔티움의 총애받는 여왕, 테오도라라고 해요.
+I have heard that you adept at certain kinds of ... interactions. Show me. = 당신이... 어떤 일에 아주 능숙하다는 소릴 들었어요. 보여주세요.
 Hello again. = 안녕하세요.
 Patriarchate of Constantinople = 콘스탄티노플 총대주교
- # Requires translation!
-All hail the most magnificent and magnanimous Empress Theodora, beloved of Byzantium and of Rome! From the lowly ranks of actress and courtesan you became the most powerful woman in the Roman Empire, consort to Justinian I. Starting in the late 520's AD, you joined your husband in a series of important spiritual and legal reforms, creating many laws which elevated the status of and promoted equal treatment of women in the empire. You also aided in the restoration and construction of many aqueducts, bridges, and churches across Constantinople, culminating in the creation of the Hagia Sophia, one of the most splendid architectural wonders of the world. = 
- # Requires translation!
-Beautiful Empress, Byzantium is in need of your wisdom and strength - her people are lost without your light to lead them. The Byzantine Empire may have fallen once, but its spirit is still intact waiting to be reborn anew. Can you return Byzantium to the heights of glory it once enjoyed? Can you create a civilization to stand the test of time? = 
- # Requires translation!
-Constantinople = 
- # Requires translation!
-Adrianople = 
- # Requires translation!
-Nicaea = 
- # Requires translation!
-Antioch = 
- # Requires translation!
-Varna = 
- # Requires translation!
-Ohrid = 
- # Requires translation!
-Nicomedia = 
- # Requires translation!
-Trebizond = 
- # Requires translation!
-Cherson = 
- # Requires translation!
-Sardica = 
- # Requires translation!
-Ani = 
- # Requires translation!
-Dyrrachium = 
- # Requires translation!
-Edessa = 
- # Requires translation!
-Chalcedon = 
- # Requires translation!
-Naissus = 
- # Requires translation!
-Bari = 
- # Requires translation!
-Iconium = 
- # Requires translation!
-Prilep = 
- # Requires translation!
-Samosata = 
- # Requires translation!
-Kars = 
- # Requires translation!
-Theodosiopolis = 
- # Requires translation!
-Tyana = 
- # Requires translation!
-Gaza = 
- # Requires translation!
-Kerkyra = 
- # Requires translation!
-Phoenice = 
- # Requires translation!
-Selymbria = 
- # Requires translation!
-Sillyon = 
- # Requires translation!
-Chrysopolis = 
- # Requires translation!
-Vodena = 
- # Requires translation!
-Traianoupoli = 
- # Requires translation!
-Constantia = 
- # Requires translation!
-Patra = 
- # Requires translation!
-Korinthos = 
- # Requires translation!
-Byzantium = 
- # Requires translation!
-May choose [amount] additional belief(s) of any type when [foundingOrEnhancing] a religion = 
+All hail the most magnificent and magnanimous Empress Theodora, beloved of Byzantium and of Rome! From the lowly ranks of actress and courtesan you became the most powerful woman in the Roman Empire, consort to Justinian I. Starting in the late 520's AD, you joined your husband in a series of important spiritual and legal reforms, creating many laws which elevated the status of and promoted equal treatment of women in the empire. You also aided in the restoration and construction of many aqueducts, bridges, and churches across Constantinople, culminating in the creation of the Hagia Sophia, one of the most splendid architectural wonders of the world. = 비잔티움과 로마의 연인, 위대하고 자비로운 테오도라 여제께 경배를! 그대는 배우와 매춘부들로 이루어진 틈바구니에서 일어나, 유스티니아누스 1세 폐하의 아내가 되어 로마 제국 최고의 여인으로 우뚝 섰습니다. 520년대 후반부터 그대는 황제와 함께 정신적, 법적 개혁을 추진하여 제국 내 여성의 지위를 높이고 여성의 평등한 대우를 장려하는 법을 제정했습니다. 또한 콘스탄티노플 전역의 수로와 다리, 교회를 복구하고 건설하는 데 일조하여 마침내 세계에서 가장 아름다운 건축물 중 하나인 성 소피아 대성당이 태어났습니다.
+Beautiful Empress, Byzantium is in need of your wisdom and strength - her people are lost without your light to lead them. The Byzantine Empire may have fallen once, but its spirit is still intact waiting to be reborn anew. Can you return Byzantium to the heights of glory it once enjoyed? Can you create a civilization to stand the test of time? = 아름다운 여제여. 비잔티움에는 그대의 지혜와 힘이 필요합니다. 백성은 그대를 잃고서 어둠 속을 방황하고 있습니다. 비잔틴 제국은 몰락하였으나 그 정신은 아직도 온전히 남아 다시 태어나기를 기다리고 있습니다. 비잔티움을 다시금 한때 누렸던 영광의 정점으로 되돌리고, 세월의 시련을 이겨낼 문명을 건설해 주시겠습니까?
+Constantinople = 콘스탄티노플
+Adrianople = 아드리아노플
+Nicaea = 니케아
+Antioch = 안티오크
+Varna = 바르나
+Ohrid = 오흐리드
+Nicomedia = 니코메디아
+Trebizond = 트레비존스
+Cherson = 케르손
+Sardica = 사르디카
+Ani = 아니
+Dyrrachium = 디라키움
+Edessa = 에데사
+Chalcedon = 칼케돈
+Naissus = 나이수스
+Bari = 바리
+Iconium = 이코늄
+Prilep = 프릴레프
+Samosata = 사모사타
+Kars = 카르스
+Theodosiopoli = 테오도시오폴리스
+Tyana = 타이아나
+Gaza = 가자
+Kerkyra = 케르키라
+Phoenice = 포에니케
+Selymbria = 셀림브리아
+Sillyon = 실리욘
+Chrysopolis = 크리소폴리스
+Vodena = 보데나
+Traianoupoli = 트라야누폴리
+Constantia = 콘스탄티아
+Patra = 파트라
+Korinthos = 코린트
+Byzantium = 비잔티움
+May choose [amount] additional belief(s) of any type when [foundingOrEnhancing] a religion = 종교 [foundingOrEnhancing] 시 추가 교리 [amount]개 선택 가능
 
- # Requires translation!
-Boudicca = 
- # Requires translation!
-You shall stain this land no longer with your vileness! To arms, my countrymen. We ride to war! = 
- # Requires translation!
-Traitorous man! The Celtic peoples will not stand for such wanton abuse and slander - I shall have your balls! = 
- # Requires translation!
-Vile ruler, know you have won this war in name alone. Your cities lie buried and your troops defeated. I have my own victory. = 
- # Requires translation!
-I am Boudicca, Queen of the Celts. Let no-one underestimate me! = 
- # Requires translation!
-Let us join our forces together and reap the rewards. = 
- # Requires translation!
-God has given good to you. = 
- # Requires translation!
-Druidic Lore = 
- # Requires translation!
-Eternal glory and praise for you, fierce and vengeful Warrior Queen! In a time dominated by men, you not only secured your throne and sovereign rule, but also successfully defied the power of the Roman Empire. After suffering terrible punishment and humiliation at the hand of the Roman invaders, you rallied your people in a bloody and terrifying revolt. Legions fell under your chariot wheels and the city of London burned. While in the end the Romans retained ownership of the isles, you alone made Nero consider withdrawing all troops and leaving Britain forever. = 
- # Requires translation!
-Oh sleeping lioness, your people desire that you rise and lead them again in the calling that is your namesake. Will you meet their challenge on the open field and lead the Celts to everlasting victory? Will you restore your lands and build an empire to stand the test of time? = 
- # Requires translation!
-Cardiff = 
- # Requires translation!
-Truro = 
- # Requires translation!
-Douglas = 
- # Requires translation!
-Glasgow = 
- # Requires translation!
-Cork = 
- # Requires translation!
-Aberystwyth = 
- # Requires translation!
-Penzance = 
- # Requires translation!
-Ramsey = 
- # Requires translation!
-Inverness = 
- # Requires translation!
-Limerick = 
- # Requires translation!
-Swansea = 
- # Requires translation!
-St. Ives = 
- # Requires translation!
-Peel = 
- # Requires translation!
-Aberdeen = 
- # Requires translation!
-Belfast = 
- # Requires translation!
-Caernarfon = 
- # Requires translation!
-Newquay = 
- # Requires translation!
-Saint-Nazaire = 
- # Requires translation!
-Castletown = 
- # Requires translation!
-Stirling = 
- # Requires translation!
-Galway = 
- # Requires translation!
-Conwy = 
- # Requires translation!
-St. Austell = 
- # Requires translation!
-Saint-Malo = 
- # Requires translation!
-Onchan = 
- # Requires translation!
-Dundee = 
- # Requires translation!
-Londonderry = 
- # Requires translation!
-Llanfairpwllgwyngyll = 
- # Requires translation!
-Falmouth = 
- # Requires translation!
-Lorient = 
- # Requires translation!
-Celts = 
+Boudicca = 부디카
+You shall stain this land no longer with your vileness! To arms, my countrymen. We ride to war! = 우리 땅에서 당신들이 저지르는 악행을 더이상 참을 수 없습니다! 형제들이여, 무기를 들어라! 전쟁이다!
+Traitorous man! The Celtic peoples will not stand for such wanton abuse and slander - I shall have your balls! = 배신자! 우리 켈트족을 농락하고 모욕하다니, 멱을 따주지!
+Vile ruler, know you have won this war in name alone. Your cities lie buried and your troops defeated. I have my own victory. = 비열한 작자야, 껍데기뿐인 승리가 어떠냐. 네 도시는 폐허가 됐고 네 군대의 시체가 널려있으니 나는 나대로 승리를 거둔 것이다.
+I am Boudicca, Queen of the Celts. Let no-one underestimate me! = 나는 켈트족의 선택된 여왕 부디카입니다. 여자라고 얕보지 마십시오!
+Let us join our forces together and reap the rewards. = 우리가 힘을 합치면 서로에게 유익할 것 같습니다.
+God has given good to you. = 신께서 그대에게 선을 행하십니다.
+Druidic Lore = 드루이드교 전승
+Eternal glory and praise for you, fierce and vengeful Warrior Queen! In a time dominated by men, you not only secured your throne and sovereign rule, but also successfully defied the power of the Roman Empire. After suffering terrible punishment and humiliation at the hand of the Roman invaders, you rallied your people in a bloody and terrifying revolt. Legions fell under your chariot wheels and the city of London burned. While in the end the Romans retained ownership of the isles, you alone made Nero consider withdrawing all troops and leaving Britain forever. = 용맹하고 강인한 여왕께 영원한 영광과 찬미를! 그대는 남자가 지배하는 세상에서 왕좌와 통치권을 손에 넣었을 뿐 아니라 로마 제국의 위세에 도전하였습니다. 또한 로마 침략군의 손에 끔찍한 고통과 모욕을 당하고도 백성을 규합하여 무시무시한 혁명을 일으켰습니다. 로마 군단병이 그대의 전차 바퀴 아래 스러지고 런던 시는 불타올랐습니다. 끝내 로마군을 브리튼 섬에서 몰아내지는 못하였으나 네로 황제가 철군하여 영영 브리튼을 떠날까 고민한 것은 순전히 그대 때문이었습니다.
+Oh sleeping lioness, your people desire that you rise and lead them again in the calling that is your namesake. Will you meet their challenge on the open field and lead the Celts to everlasting victory? Will you restore your lands and build an empire to stand the test of time? = 잠자는 암사자여. 켈트족은 그대가 돌아와 다시금 켈트족을 이끌어주시기를 바라고 있습니다. 이 시련을 받아들여 켈트족을 영원한 승리로 이끌겠습니까? 잃어버린 영토를 되찾아 세월의 시련을 이겨낼 문명을 건설하겠습니까?
+Cardiff = 카디프
+Truro = 트루로
+Douglas = 더글라스
+Glasgow = 글래스고
+Cork = 코크
+Aberystwyth = 에버리스트위스
+Penzance = 펜잔스
+Ramsey = 램지
+Inverness = 인버네스
+Limerick = 리머릭
+Swansea = 스완지
+St. Ives = 세인트아이브
+Peel = 필
+Aberdeen = 애버딘
+Belfast = 벨파스트
+Caernarfon = 카나폰
+Newquay = 뉴키
+Saint-Nazaire = 세인트나제흐
+Castletown = 캐슬타운
+Stirling = 스털링
+Galway = 골웨이
+Conwy = 콘위
+St. Austell = 세인트오스틀
+Saint-Malo = 세인트말로
+Onchan = 온찬
+Dundee = 던디
+Londonderry = 런던데리
+Llanfairpwllgwyngyll = 랜바이어푸흘귄기흘
+Falmouth = 팔머스
+Lorient = 로리앙
+Celts = 켈트
 
- # Requires translation!
-Haile Selassie = 
+Haile Selassie = 하일레 셀라시에
  # Requires translation!
 I have tried all other avenues, but yet you persist in this madness. I hope, for your sake, your end is swift. = 
  # Requires translation!
@@ -5023,83 +4864,45 @@ God and history will remember your actions this day. I hope you are ready for yo
 A thousand welcomes to our fair nation. I am Selassie, the Ras Tafari Makonnen and Emperor of Ethiopia, your humble servant. = 
  # Requires translation!
 I request that you consider this offer between our two peoples. I believe it will do us both good. = 
- # Requires translation!
-Spirit of Adwa = 
- # Requires translation!
-Blessings be upon you, honorable and righteous Emperor of Ethiopia, Haile Selassie. Your legacy as one of Ethiopia's greatest rulers, and as the spiritual leader to the Rastafarian movement, is outshone only by the influence you had on diplomacy and political cooperation throughout the world. In introducing Ethiopia's first written constitution, you planted the seeds of democracy that would take root over the coming years, and your infinitely wise grasp of global affairs secured Ethiopia's place as a charter member of the United Nations. Spearheading efforts to reform and modernize the nation during your reign, you changed the course of Ethiopian history forever = 
- # Requires translation!
-Revered king, your composed demeanor once protected the people from the many conflicts that plague the nations of men, and the kingdom looks to you to assure peace once again. Will you lead the people with courage and authority, moving forward into a new age? Will you build a civilization that stands the test of time? = 
- # Requires translation!
-Addis Ababa = 
- # Requires translation!
-Harar = 
- # Requires translation!
-Adwa = 
- # Requires translation!
-Lalibela = 
- # Requires translation!
-Gondar = 
- # Requires translation!
-Axum = 
- # Requires translation!
-Dire Dawa = 
- # Requires translation!
-Bahir Dar = 
- # Requires translation!
-Adama = 
- # Requires translation!
-Mek'ele = 
- # Requires translation!
-Awasa = 
- # Requires translation!
-Jimma = 
- # Requires translation!
-Jijiga = 
- # Requires translation!
-Dessie = 
- # Requires translation!
-Debre Berhan = 
- # Requires translation!
-Shashamane = 
- # Requires translation!
-Debre Zeyit = 
- # Requires translation!
-Sodo = 
- # Requires translation!
-Hosaena = 
- # Requires translation!
-Nekemte = 
- # Requires translation!
-Asella = 
- # Requires translation!
-Dila = 
- # Requires translation!
-Adigrat = 
- # Requires translation!
-Debre Markos = 
- # Requires translation!
-Kombolcha = 
- # Requires translation!
-Debre Tabor = 
- # Requires translation!
-Sebeta = 
- # Requires translation!
-Shire = 
- # Requires translation!
-Ambo = 
- # Requires translation!
-Negele Arsi = 
- # Requires translation!
-Gambela = 
- # Requires translation!
-Ziway = 
- # Requires translation!
-Weldiya = 
- # Requires translation!
-Ethiopia = 
+Spirit of Adwa = 아드와 전투의 정신
+Blessings be upon you, honorable and righteous Emperor of Ethiopia, Haile Selassie. Your legacy as one of Ethiopia's greatest rulers, and as the spiritual leader to the Rastafarian movement, is outshone only by the influence you had on diplomacy and political cooperation throughout the world. In introducing Ethiopia's first written constitution, you planted the seeds of democracy that would take root over the coming years, and your infinitely wise grasp of global affairs secured Ethiopia's place as a charter member of the United Nations. Spearheading efforts to reform and modernize the nation during your reign, you changed the course of Ethiopian history forever = 에티오피아의 명예롭고 공정한 황제 하일레 셀라시에께 축복이 있기를. 에티오피아에서 제일 위대한 지도자이자 래스터패리 운동의 영적 지도자인 당신은 전 세계적인 외교와 정치 협력을 이끌어내셨습니다. 에티오피아의 첫 성문 헌법을 제정함으로써 에티오피아에 민주주의의 씨앗을 심었고 지혜롭게 국제 문제에 대처하여 에티오피아를 국제연합 창설 회원국 위치에 올려놓으셨습니다. 국가 재건과 근대화의 최전선에서 노력한 당신은 에티오피아의 역사가 나갈 방향을 영원히 바꾸어 놓으셨습니다.
+Revered king, your composed demeanor once protected the people from the many conflicts that plague the nations of men, and the kingdom looks to you to assure peace once again. Will you lead the people with courage and authority, moving forward into a new age? Will you build a civilization that stands the test of time? = 존경받는 황제시여. 당신은 침착하게 대처하여 국민을 괴롭히는 수많은 투쟁을 막아내셨습니다. 이제 왕국은 당신이 다시 한 번 평화를 지켜 주기를 바라옵니다. 용기와 권위를 가지고 국민을 이끌어 새로운 시대를 향해 전진하시겠습니까? 세월의 시련을 이겨낼 문명을 건설하겠습니까?
+Addis Ababa = 아디스아바바
+Harar = 하라르
+Adwa = 아드와
+Lalibela = 랄리벨라
+Gondar = 곤다르
+Axum = 악숨
+Dire Dawa = 디레다와
+Bahir Dar = 바히르다르
+Adama = 아다마
+Mek'ele = 맥엘레
+Awasa = 아와사
+Jimma = 짐마
+Jijiga = 지지가
+Dessie = 데시
+Debre Berhan = 데브레버한
+Shashamane = 샤샤메인
+Debre Zeyit = 데브레제이트
+Sodo = 소도
+Hosaena = 호사이나
+Nekemte = 네켐테
+Asella = 아셀라
+Dila = 딜라
+Adigrat = 아디그라트
+Debre Markos = 데브레마코스
+Kombolcha = 콘볼차
+Debre Tabor = 데브레타보르
+Sebeta = 세베타
+Shire = 샤이어
+Ambo = 암보
+Negele Arsi = 네겔레아르시
+Gambela = 감벨라
+Ziway = 지웨이
+Weldiya = 웰디아
+Ethiopia = 에티오피아
 
- # Requires translation!
-Pacal = 
+Pacal = 파칼
  # Requires translation!
 A sacrifice unlike all others must be made! = 
  # Requires translation!
@@ -5114,82 +4917,45 @@ Friend, I believe I may have found a way to save us all! Look, look and accept m
 A fine day, it helps you. = 
  # Requires translation!
 The Long Count = 
- # Requires translation!
-Your people kneel before you, exalted King Pacal the Great, favored son of the gods and shield to the citizens of the Palenque domain. After years of strife at the hands of your neighboring rivals, you struck back at the enemies of your people, sacrificing their leaders in retribution for the insults dealt to your predecessors. The glory of Palenque was restored only by the guidance afforded by your wisdom, as you orchestrated vast reconstruction efforts within the city, creating some of the greatest monuments and architecture your people - and the world - have ever known. = 
- # Requires translation!
-Illustrious King, your people once again look to you for leadership and counsel in the coming days. Will you channel the will of the gods and restore your once proud kingdom to its greatest heights? Will you build new monuments to forever enshrine the memories of your people? Can you build a civilization that will stand the test of time? = 
- # Requires translation!
-Palenque = 
- # Requires translation!
-Tikal = 
- # Requires translation!
-Uxmal = 
- # Requires translation!
-Tulum = 
- # Requires translation!
-Copan = 
- # Requires translation!
-Coba = 
- # Requires translation!
-El Mirador = 
- # Requires translation!
-Calakmul = 
- # Requires translation!
-Edzna = 
- # Requires translation!
-Lamanai = 
- # Requires translation!
-Izapa = 
- # Requires translation!
-Uaxactun = 
- # Requires translation!
-Comalcalco = 
- # Requires translation!
+Your people kneel before you, exalted King Pacal the Great, favored son of the gods and shield to the citizens of the Palenque domain. After years of strife at the hands of your neighboring rivals, you struck back at the enemies of your people, sacrificing their leaders in retribution for the insults dealt to your predecessors. The glory of Palenque was restored only by the guidance afforded by your wisdom, as you orchestrated vast reconstruction efforts within the city, creating some of the greatest monuments and architecture your people - and the world - have ever known. = 신들의 총애받는 자손이시며 팔렝케 시민의 수호자인 파칼 대왕이시여, 그대 앞에 백성 모두 무릎 꿇나이다. 당신은 적들에 맞서 싸워 이웃 경쟁자들과의 분쟁을 종결시켰으며 그들의 지도자를 제물로 바쳐 선조를 모욕한 죄에 응징을 가하셨습니다. 도시의 대규모 재건을 통하여 전 세계를 통틀어서도 그 위대함을 견줄 데 없는 유적들을 세우신 당신의 지혜가 없었다면 팔렝케의 영광도 없었을 겁니다.
+Illustrious King, your people once again look to you for leadership and counsel in the coming days. Will you channel the will of the gods and restore your once proud kingdom to its greatest heights? Will you build new monuments to forever enshrine the memories of your people? Can you build a civilization that will stand the test of time? = 걸출한 왕이시여. 백성은 당신의 미래를 향한 충고와 지도를 다시금 바라나이다. 신들의 뜻을 받들어 위대한 왕국을 재건하시겠습니까? 왕국의 존재를 영원히 역사에 남길 만한 새 유적을 지으시겠습니까? 세월의 시련을 이겨낼 문명을 건설하겠습니까?
+Palenque = 팔렌케
+Tikal = 티칼
+Uxmal = 우쉬말
+Tulum = 툴룸
+Copan = 코판
+Coba = 코바
+El Mirador = 엘 미라도르
+Calakmul = 칼라크물
+Edzna = 에즈나
+Lamanai = 라마나이
+Izapa = 이사파
+Uaxactun = 우악삭툰
+Comalcalco = 코말칼코
 Piedras Negras = 
  # Requires translation!
 Cancuen = 
- # Requires translation!
-Yaxha = 
- # Requires translation!
-Quirigua = 
- # Requires translation!
-Q'umarkaj = 
- # Requires translation!
-Nakbe = 
- # Requires translation!
-Cerros = 
- # Requires translation!
-Xunantunich = 
- # Requires translation!
-Takalik Abaj = 
- # Requires translation!
-Cival = 
- # Requires translation!
-San Bartolo = 
- # Requires translation!
-Altar de Sacrificios = 
- # Requires translation!
-Seibal = 
- # Requires translation!
-Caracol = 
- # Requires translation!
-Naranjo = 
- # Requires translation!
-Dos Pilas = 
- # Requires translation!
-Mayapan = 
- # Requires translation!
-Ixinche = 
- # Requires translation!
-Zaculeu = 
- # Requires translation!
-Kabah = 
- # Requires translation!
-The Maya = 
- # Requires translation!
-Receive a free Great Person at the end of every [comment] (every 394 years), after researching [tech]. Each bonus person can only be chosen once. = 
- # Requires translation!
-Once The Long Count activates, the year on the world screen displays as the traditional Mayan Long Count. = 
+Yaxha = 약사
+Quirigua = 키리구아
+Q'umarkaj = 우말카하
+Nakbe = 나크비
+Cerros = 세로스
+Xunantunich = 주난투니치
+Takalik Abaj = 타칼릭 아바
+Cival = 시발
+San Bartolo = 산 바르톨로
+Altar de Sacrificios = 희생의 제단
+Seibal = 세이발
+Caracol = 카라콜
+Naranjo = 나란호
+Dos Pilas = 도스 필라스
+Mayapan = 마야판
+Ixinche = 이신테
+Zaculeu = 자쿨레우
+Kabah = 카바
+The Maya = 마야
+Receive a free Great Person at the end of every [comment] (every 394 years), after researching [tech]. Each bonus person can only be chosen once. = [tech] 연구 후 [comment](394년)가 끝날 때마다 위인이 무료로 출현, 한번 선택한 위인 선택 불가
+Once The Long Count activates, the year on the world screen displays as the traditional Mayan Long Count. = 장기력이 해금되면 세계 화면의 연도 표시가 마야 장기력 표시로 바뀜
 
 
 I didn't want to do this. We declare war. = 이걸 하는 걸 원치 않소. 전젱을 선포한다.

--- a/android/assets/jsons/translations/Korean.properties
+++ b/android/assets/jsons/translations/Korean.properties
@@ -4976,12 +4976,10 @@ Jerusalem = 예루살렘
 
 #################### Lines from Policies from Civ V - Gods & Kings ####################
 
- # Requires translation!
-Provides a [buildingName] in your first [amount] cities for free = 
+Provides a [buildingName] in your first [amount] cities for free = 최초 [amount]개 도시에 [buildingName] 무료로 제공
 
 
- # Requires translation!
-[amount]% Gold from Great Merchant trade missions = 
+[amount]% Gold from Great Merchant trade missions = 위대한 상인이 무역 임무에서 얻는 골드 [amount]%
 
 
 #################### Lines from Quests from Civ V - Gods & Kings ####################
@@ -5001,15 +4999,11 @@ Taoism = 도교
 #################### Lines from Ruins from Civ V - Gods & Kings ####################
 
 
- # Requires translation!
-We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[param] Faith) = 
- # Requires translation!
-discover holy symbols = 
+We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[param] Faith) = 고대 유적에서 성물을 발견하여 종교에 대한 이해가 깊어졌습니다! (+[param] 신앙)
+discover holy symbols = 성물 발견
 
- # Requires translation!
-We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[param] Faith) = 
- # Requires translation!
-an ancient prophecy = 
+We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[param] Faith) = 고대 유적에서 예언자를 발견하여 우리의 정신적인 유대가 강해졌습니다! (+[param] 신앙)
+an ancient prophecy = 고대 예언자
 
 
 #################### Lines from Specialists from Civ V - Gods & Kings ####################
@@ -5052,8 +5046,7 @@ Mount Kailash = 카일라스 산
 
 Mount Sinai = 시나이 산
 
- # Requires translation!
-Sri Pada = 
+Sri Pada = 스리파다
 
 Uluru = 울루루
 
@@ -5079,15 +5072,12 @@ Salt = 소금
 #################### Lines from Units from Civ V - Gods & Kings ####################
 
 
- # Requires translation!
-Atlatlist = 
+Atlatlist = 아틀라틀 투창병
 
 
- # Requires translation!
-Quinquereme = 
+Quinquereme = 오단노선
 
- # Requires translation!
-Dromon = 
+Dromon = 드로몬
 
 
 Horse Archer = 궁기병
@@ -5096,15 +5086,12 @@ Horse Archer = 궁기병
 Battering Ram = 공성추
 Can only attack [combatantFilter] units = [combatantFilter]만 공격 가능
 
- # Requires translation!
-Pictish Warrior = 
+Pictish Warrior = 픽트족 전사
 
 
- # Requires translation!
-African Forest Elephant = 
+African Forest Elephant = 아프리카 숲 코끼리
 
- # Requires translation!
-Cataphract = 
+Cataphract = 카타프락토이
 
 
 Composite Bowman = 합성궁병
@@ -5129,14 +5116,11 @@ Gatling Gun = 개틀링 기관총
 
 Carolean = 캐롤리언
 
- # Requires translation!
-Mehal Sefari = 
+Mehal Sefari = 메할 사파리
 
 
- # Requires translation!
-Hussar = 
- # Requires translation!
-[amount]% to Flank Attack bonuses = 
+Hussar = 후사르
+[amount]% to Flank Attack bonuses = 측면 공격 보너스 [amount]%
 
 
 Great War Infantry = 1차 세계대전 보병
@@ -5178,8 +5162,7 @@ Although your city will keep expanding forever, your citizens can only work 3 ti
 
 As cities grow in size and influence, you have to deal with a happiness mechanic that is no longer tied to each individual city.\nInstead, your entire empire shares the same level of satisfaction.\nAs your cities grow in population you’ll find that it is more and more difficult to keep your empire happy. = 도시의 영역과 인구가 증가하면 문명 전체의 행복도를 신경써야 합니다.\n행복도는 과학, 골드처럼 문명 전체에서 공유되는 값입니다.\n도시의 수와 총인구수가 증가할수록 국가를 행복한 상태로 유지하는 것이 어려워집니다.
 In addition, you can’t even build any city improvements that increase happiness until you’ve done the appropriate research.\nIf your empire’s happiness ever goes below zero the growth rate of your cities will be hurt.\nIf your empire becomes severely unhappy (as indicated by the smiley-face icon at the top of the interface)\n  your armies will have a big penalty slapped on to their overall combat effectiveness. = 상단의 웃는 아이콘이 행복도를 나타냅니다.\n행복도를 올려주는 건물을 지으려면 해당 기술을 연구해야 합니다.\n행복도가 마이너스로 떨어지면 불행 상태가 되어 모든 도시의 성장률이 크게 감소합니다.\n불행 상태가 심해지면 군사 유닛들의 전투력도 크게 감소합니다.
- # Requires translation!
-This means that it is very difficult to expand quickly in Unciv.\nIt isn’t impossible, but as a new player you probably shouldn't do it.\nSo what should you do? Chill out, scout, and improve the land that you do have by building Workers.\nOnly build new cities once you have found a spot that you believe is appropriate. = 
+This means that it is very difficult to expand quickly in Unciv.\nIt isn’t impossible, but as a new player you probably shouldn't do it.\nSo what should you do? Chill out, scout, and improve the land that you do have by building Workers.\nOnly build new cities once you have found a spot that you believe is appropriate. = 이는 곧 Unciv에서는 빠른 확장이 매우 어렵다는 것을 의미합니다.\n할 수는 있지만 초심자라면 그렇게 하지 않는 게 좋을 겁니다.\n그럼 어떡해야 할까요? 느긋하게 정찰하고 노동자를 건설해서 지금 가진 땅에 시설을 지으세요.\n새로운 도시는 적당하다고 생각되는 자리에만 펴는 것이 좋습니다.
 
 Unhappiness = 불행
  # Requires translation!

--- a/android/assets/jsons/translations/Korean.properties
+++ b/android/assets/jsons/translations/Korean.properties
@@ -3329,7 +3329,7 @@ Free Speech = 표현의 자유
 Democracy = 민주주의
 [amount]% unhappiness from specialists [cityFilter] = [cityFilter]의 전문가가 생성하는 불행 [amount]%
 Freedom Complete = 평등 완성
-[amount]% Yield from every [tileFilter] = [tileImprovement]의 해당 분야 산출량 [amount]%
+[amount]% Yield from every [tileFilter] = [tileFilter]의 해당 분야 산출량 [amount]%
 
 Populism = 포퓰리즘
 Militarism = 군국주의

--- a/android/assets/jsons/translations/Korean.properties
+++ b/android/assets/jsons/translations/Korean.properties
@@ -3629,7 +3629,7 @@ Lakes = 호수
 
 Mountain = 산
 Has an elevation of [amount] for visibility calculations = 시야 계산에서 높이 [amount]에 해당
-Units ending their turn on this terrain take [amount] damage = 이 지형에서 턴을 마친 유닛은 고정 피해 [amount]HP를 입음
+Units ending their turn on this terrain take [amount] damage = 이 지형에서 턴을 마친 유닛이 [amount] 피해를 입음
 
 Snow = 설원
 
@@ -3688,8 +3688,7 @@ Barringer Crater = 베린저 크레이터
 
 Farm = 농장
 Can also be built on tiles adjacent to fresh water = 담수 옆에도 건설 가능
- # Requires translation!
-[stats] from [tileFilter] tiles = 
+[stats] from [tileFilter] tiles = [tileFilter]에서 [stats]
 
 Lumber mill = 제재소
 
@@ -3748,10 +3747,9 @@ Customs house = 세관
 Holy site = 성지
 
 Citadel = 성채
- # Requires translation!
-Adjacent enemy units ending their turn take [amount] damage = 
+Adjacent enemy units ending their turn take [amount] damage = 주변에서 턴을 마친 적 유닛이 [amount] 피해를 입음
 Can be built just outside your borders = 국경 바로 바깥까지만 건설 가능
-Constructing it will take over the tiles around it and assign them to your closest city = 해당 시설 건설 시, 주위 타일을 점령하고, 가장 가까운 아군 도시에 할당됨
+Constructing it will take over the tiles around it and assign them to your closest city = 시설 건설 시 주위 타일을 점령하여 가장 가까운 아군 도시에 할당함
 
 Moai = 모아이
 
@@ -3790,16 +3788,14 @@ Stone = 석재
 Fish = 생선
 
 Horses = 말
- # Requires translation!
-Guaranteed with Strategic Balance resource option = 
+Guaranteed with Strategic Balance resource option = 자원 설정이 전략적 균형으로 보장됨
 
 Iron = 철
 
 Coal = 석탄
 
 Oil = 석유
- # Requires translation!
-Deposits in [tileFilter] tiles always provide [amount] resources = 
+Deposits in [tileFilter] tiles always provide [amount] resources = [tileFilter]에서 [amount]개의 자원을 보장함
 
 Aluminum = 알루미늄
 
@@ -3896,8 +3892,7 @@ Blitz = 전격전
 [amount] additional attacks per turn = 턴당 공격 횟수 [amount]
 
 Woodsman = 벌목꾼
- # Requires translation!
-Double movement in [terrainFilter] = 
+Double movement in [terrainFilter] = [terrainFilter]에서 행동력 소모 절반
 
 Amphibious = 수륙 양용
 Eliminates combat penalty for attacking over a river = 공격시 도하 페널티 없음
@@ -4039,8 +4034,7 @@ All healing effects doubled = 모든 회복 효과 두 배
 
 Slinger Withdraw = 투석병 철수
 
- # Requires translation!
-Ignore terrain cost = 
+Ignore terrain cost = 지형 무시
 Ignores terrain cost = 지형에 의한 이동력 감소 무시
 
  # Requires translation!
@@ -4048,8 +4042,7 @@ Pictish Courage =
 
  # Requires translation!
 Home Sweet Home = 
- # Requires translation!
-[amount]% Strength decreasing with distance from the capital = 
+[amount]% Strength decreasing with distance from the capital = 수도 근처에서 전투력 [amount]%, 수도와 멀어질수록 감소함
 
 
 #################### Lines from UnitTypes from Civ V - Vanilla ####################
@@ -4060,10 +4053,8 @@ Civilian Water =
 
 
 Can enter ice tiles = 빙하 지형에 통행 가능
- # Requires translation!
-Invisible to non-adjacent units = 
- # Requires translation!
-Can see invisible [mapUnitFilter] units = 
+Invisible to non-adjacent units = 인접한 유닛이 없으면 보이지 않음
+Can see invisible [mapUnitFilter] units = 보이지 않는 [mapUnitFilter]을 볼 수 있음
 
 
 Aircraft = 항공 유닛
@@ -4086,11 +4077,9 @@ Founds a new city = 새로운 도시를 건설함
 Excess Food converted to Production when under construction = 생산시 잉여 식량이 생산력으로 전환됨
 Requires at least [amount] population = 인구 [amount] 이상부터 생산 가능
 
- # Requires translation!
-May upgrade to [baseUnitFilter] through ruins-like effects = 
+May upgrade to [baseUnitFilter] through ruins-like effects = 고대 유적 등을 통해서 [baseUnitFilter]으로 업그레이드 가능
 
- # Requires translation!
-This is your basic, club-swinging fighter. = 
+This is your basic, club-swinging fighter. = 이것은 방망이를 휘두르는 가장 기초적인 전투 유닛입니다.
 
 Maori Warrior = 마오리 전사
 
@@ -4105,19 +4094,16 @@ Bowman = 궁병
 
 Slinger = 투석병
 
- # Requires translation!
-Skirmisher = 
+Skirmisher = 척후병
 
 Work Boats = 작업선
 Cannot enter ocean tiles = 대양 항해 불가능
 May create improvements on water resources = 해양 자원에 시설 건설 가능
- # Requires translation!
-Uncapturable = 
+Uncapturable = 포획 불가능
 
 Trireme = 삼단노선
 
- # Requires translation!
-Galley = 
+Galley = 갤리
 
 Chariot Archer = 궁전차
 No defensive terrain bonus = 지형에 의한 방어 보너스 없음
@@ -4132,8 +4118,7 @@ Hoplite = 호플리테스
 
 Persian Immortal = 이모탈
 
- # Requires translation!
-Marauder = 
+Marauder = 약탈자
 
 Horseman = 기마병
 Can move after attacking = 공격 후 이동 가능
@@ -4293,19 +4278,14 @@ Great Merchant = 위대한 상인
 Can undertake a trade mission with City-State, giving a large sum of gold and [amount] Influence = 도시 국가에서 무역 임무를 통해 많은 양의 일시불 골드와 영향력 [amount]을(를) 얻을 수 있음
 
 Great Engineer = 위대한 기술자
- # Requires translation!
-Can speed up construction of a building = 
+Can speed up construction of a building = 건설 가속 가능
 
 Great Prophet = 위대한 선지자
- # Requires translation!
-Can construct [tileImprovement] if it hasn't used other actions yet = 
- # Requires translation!
-Can [param] [amount] times = 
- # Requires translation!
-Removes other religions when spreading religion = 
+Can construct [tileImprovement] if it hasn't used other actions yet = 다른 활동을 하지 않았다면 [tileImprovement] 시설 건설 가능
+Can [param] [amount] times = [param] [amount]회 가능
+Removes other religions when spreading religion = 종교 전파 시 타 종교를 제거함
 May found a religion = 종교 창시 가능
- # Requires translation!
-May enhance a religion = 
+May enhance a religion = 종교 강화 가능
 May enter foreign tiles without open borders = 개방되지 않은 국경 출입 가능
 Religious Unit = 종교 유닛
  # Requires translation!
@@ -4320,10 +4300,8 @@ Missionary = 선교사
 May enter foreign tiles without open borders, but loses [amount] religious strength each turn it ends there = 개방되지 않은 국경을 통과할 수 있으나, 해당 턴을 타국 영토에서 마칠 경우, [amount] 신앙력을 잃습니다.
 Can be purchased with [stat] [cityFilter] = [cityFilter] 도시에서 [stat]으로 구매 가능
 
- # Requires translation!
-Inquisitor = 
- # Requires translation!
-Prevents spreading of religion to the city it is next to = 
+Inquisitor = 이단심문관
+Prevents spreading of religion to the city it is next to = 도시에 인접해 있으면 타 종교를 전파할 수 없음
 
 
 #################### Lines from Beliefs from Civ V - Gods & Kings ####################
@@ -4379,15 +4357,12 @@ Sacred Waters = 신성한 물
 Stone Circles = 환상열석
 
 Follower = 신자
- # Requires translation!
-Asceticism = 
+Asceticism = 금욕주의
 
 Cathedrals = 대성당
- # Requires translation!
-May buy [buildingFilter] buildings with [stat] [cityFilter] = 
+May buy [buildingFilter] buildings with [stat] [cityFilter] = [cityFilter]에서 [stat](으)로 [buildingFilter] 구매 가능
 
- # Requires translation!
-Choral Music = 
+Choral Music = 합창곡
 
 Divine inspiration = 신의 계시
 
@@ -4395,13 +4370,10 @@ Feed the World = 기아 대책
 
 Guruship = 구루
 
- # Requires translation!
-Holy Warriors = 
- # Requires translation!
-May buy [baseUnitFilter] units with [stat] for [amount] times their normal Production cost = 
+Holy Warriors = 성전사
+May buy [baseUnitFilter] units with [stat] for [amount] times their normal Production cost = 필요 생산력의 [amount]배에 해당하는 [stat](으)로 [baseUnitFilter] 구매 가능
 
- # Requires translation!
-Liturgical Drama = 
+Liturgical Drama = 전례극
 
 Monasteries = 수도원
 
@@ -4413,13 +4385,10 @@ Peace Gardens = 평화로운 정원
 
 Religious Art = 종교 예술
 
- # Requires translation!
-Religious Center = 
+Religious Center = 종교 중심지
 
- # Requires translation!
-Religious Community = 
- # Requires translation!
-[amount]% [stat] from every follower, up to [amount2]% = 
+Religious Community = 종교 공동체
+[amount]% [stat] from every follower, up to [amount2]% = 신자 하나당 [stat] [amount]%, 최대 [amount2]%
 
 Swords into Ploughshares = 칼을 쟁기로
 
@@ -4432,75 +4401,51 @@ Church Property = 교회 재산권
 Initiation Rites = 통과 의례
 [stats] when a city adopts this religion for the first time (modified by game speed) = 처음으로 종교를 전파한 도시 하나마다 [stats] (게임 속도에 따라 조정됨)
 
- # Requires translation!
-Interfaith Dialogue = 
- # Requires translation!
-When spreading religion to a city, gain [amount] times the amount of followers of other religions as [stat] = 
+Interfaith Dialogue = 종교 회담
+When spreading religion to a city, gain [amount] times the amount of followers of other religions as [stat] = 종교 전파 시 타 종교 신도 수의 [amount] 배에 해당하는 [stat] 획득
 
 Papal Primacy = 교황직
- # Requires translation!
-Resting point for Influence with City-States following this religion [amount] = 
+Resting point for Influence with City-States following this religion [amount] = 이 종교를 따르는 도시 국가와의 최저 우호도 [amount]
 
- # Requires translation!
-Peace Loving = 
- # Requires translation!
-[stats] for every [amount] global followers [cityFilter] = 
+Peace Loving = 평화주의
+[stats] for every [amount] global followers [cityFilter] = [cityFilter]에서 이 종교를 믿는 신자 [amount]명마다 [stats]
 
 Pilgrimage = 성지 순례
 
- # Requires translation!
-Tithe = 
+Tithe = 십일조
 
- # Requires translation!
-World Church = 
+World Church = 초교파교회
 
- # Requires translation!
-Enhancer = 
- # Requires translation!
-Defender of the Faith = 
+Enhancer = 강화 교리
+Defender of the Faith = 신앙의 수호자
 
- # Requires translation!
-Holy Order = 
+Holy Order = 종교 단체
 
- # Requires translation!
-Itinerant Preachers = 
- # Requires translation!
-Religion naturally spreads to cities [amount] tiles away = 
+Itinerant Preachers = 순회 전도사
+Religion naturally spreads to cities [amount] tiles away = 종교 전파 거리 [amount] 증가
 
- # Requires translation!
-Just War = 
+Just War = 정의로운 전쟁
 
- # Requires translation!
-Messiah = 
- # Requires translation!
-[amount]% Spread Religion Strength = 
- # Requires translation!
-[amount]% Faith cost of generating Great Prophet equivalents = 
- # Requires translation!
-[stat] cost for [unit] units [amount]% = 
+Messiah = 메시아
+[amount]% Spread Religion Strength = 종교 전파의 효과 [amount]%
+[amount]% Faith cost of generating Great Prophet equivalents = 위대한 선지자 탄생에 필요한 신앙 [amount]%
+[stat] cost for [unit] units [amount]% = [unit] 구매에 필요한 [stat] [amount]%
 
- # Requires translation!
-Missionary Zeal = 
+Missionary Zeal = 선교 열정
 
- # Requires translation!
-Religious Texts = 
- # Requires translation!
-[amount]% Natural religion spread [cityFilter] = 
+Religious Texts = 종교 문서
+[amount]% Natural religion spread [cityFilter] = [cityFilter]에서 종교 전파 속도 [amount]%
 
- # Requires translation!
-Religious Unity = 
+Religious Unity = 단일 종교
 
- # Requires translation!
-Reliquary = 
- # Requires translation!
-[stats] whenever a Great Person is expended = 
+Reliquary = 유골함
+[stats] whenever a Great Person is expended = 위인 소모시 [stats]
 
 
 #################### Lines from Buildings from Civ V - Gods & Kings ####################
 
 
- # Requires translation!
-Stele = 
+Stele = 스텔레
 
 
 Shrine = 성소

--- a/android/assets/jsons/translations/Korean.properties
+++ b/android/assets/jsons/translations/Korean.properties
@@ -2,13 +2,11 @@
 
 # Equivalent of a space in your language
 # If your language doesn't use spaces, just add "" as a translation, otherwise " "
- # Requires translation!
 " " = " "
 
 # If the first word in a sentence starts with a capital in your language, 
 # put the english word 'true' behind the '=', otherwise 'false'.
 # Don't translate these words to your language, only put 'true' or 'false'.
- # Requires translation!
 StartWithCapitalLetter = false
 
 
@@ -266,20 +264,16 @@ Demanding a Worker from small City-State =
 Very recently paid tribute = 
  # Requires translation!
 Recently paid tribute = 
- # Requires translation!
-Influence below -30 = 
- # Requires translation!
-Military Rank = 
- # Requires translation!
-Military near City-State = 
+Influence below -30 = -30 이하 영향력
+Military Rank = 군사력 순위
+Military near City-State = 도시 국가 근처 군대
  # Requires translation!
 Sum: = 
  # Requires translation!
 Take [amount] gold (-15 Influence) = 
  # Requires translation!
 Take worker (-50 Influence) = 
- # Requires translation!
-[civName] is afraid of your military power! = 
+[civName] is afraid of your military power! = [civName]이(가) 우리의 군사력을 두려워합니다!
 
 
 # Trades
@@ -367,8 +361,7 @@ Time = 시간
 
 # Used for random nation indicator in empire selector and unknown nation icons in various overview screens.
 # Should be a single character, or at least visually square.
- # Requires translation!
-? = 
+? = ?
 
 Map Shape = 지도 모양
 Hexagonal = 육각형
@@ -540,8 +533,7 @@ Debug = 디버그
 
 Version = 버전
 See online Readme = 온라인 README 보기
- # Requires translation!
-Visit repository = 
+Visit repository = Repository 방문
 Turns between autosaves = 자동저장 간격
 Sound effects volume = 효과음 음량
 Music volume = 음악 음량
@@ -772,8 +764,7 @@ Science = 과학
 Faith = 신앙
 
 Crop Yield = 식량 생산량
- # Requires translation!
-Growth = 
+Growth = 성장
 Territory = 영토
 Force = 군사력
 GOLDEN AGE = 황금기
@@ -785,8 +776,7 @@ Global Effect =
 [year] AD = 기원후 [year]년
 Civilopedia = 문명 백과사전
 # Display name of unknown nations.
- # Requires translation!
-??? = 
+??? = ???
 
 Start new game = 새 게임
 Save game = 저장하기
@@ -920,8 +910,7 @@ defence vs [unitType] = [unitType] 대항 방어력
 Defensive Bonus = 방어 보너스
 Stacked with [unitType] = [unitType]과 중첩됨
 
- # Requires translation!
-Unit ability = 
+Unit ability = 유닛 능력
 
 The following improvements [stats]: = 다음 시설에 [stats] : 
 The following improvements on [tileType] tiles [stats]: = [tileType] 시설에 [stats] : 
@@ -1078,8 +1067,7 @@ Cost = 비용
 May contain [listOfResources] = 발견되는 자원: [listOfResources]
 May contain: = 발견되는 자원:
 Can upgrade from [unit] = [unit]에서 업그레이드 가능
- # Requires translation!
-Can upgrade from: = 
+Can upgrade from: = 이 유닛으로 업그레이드 가능함:
 Upgrades to [upgradedUnit] = [upgradedUnit](으)로 업그레이드 가능
 Obsolete with [obsoleteTech] = [obsoleteTech] 연구 후 생산 불가
 Occurs on [listOfTerrains] = 발생하는 지형: [listOfTerrains]
@@ -1425,8 +1413,7 @@ Invisible to others = 다른 유닛에게 보이지 않음
 # Example: In the unique "+20% Strength <for [unitFilter] units>", should the <for [unitFilter] units>
 # be translated before or after the "+20% Strength"?
 
- # Requires translation!
-ConditionalsPlacement = 
+ConditionalsPlacement = before
 
 # The second determines the exact ordering of all conditionals that are to be translated.
 # ALL conditionals that exist will be part of this line, and they may be moved around and rearranged as you please.
@@ -1626,8 +1613,7 @@ Notre Dame = 노트르담 대성당
 Castle = 성
 
 Mughal Fort = 무굴 요새
- # Requires translation!
-[stats] = 
+[stats] = [stats]
 
 'Bushido is realized in the presence of death. This means choosing death whenever there is a choice between life and death. There is no other reasoning.' - Yamamoto Tsunetomo = '무사도는 죽음을 마주했을 때 실현된다. 즉, 삶과 죽음의 기로에서 죽음을 택한다는 뜻이다. 다른 생각의 여지는 없다.' - 야마모토 츠네모토
 Himeji Castle = 히메지 성
@@ -3406,38 +3392,29 @@ We have heard the tenets of [param] and are most curious. Will you send missiona
 
 #################### Lines from Ruins from Civ V - Vanilla ####################
 
-We have discovered cultural artifacts in the ruins! (+20 culture) = 유적에서 문화 유산을 발견하였습니다! (+20 문화)
+We have discovered cultural artifacts in the ruins! (+20 culture) = 고대 유적에서 문화 유산을 발견하였습니다! (+20 문화)
 discover cultural artifacts = 문화 유산 발견
 
- # Requires translation!
-squatters willing to work for you = 
+squatters willing to work for you = 거주자들이 우리 문명에 노동자로 합류함
 
- # Requires translation!
-squatters wishing to settle under your rule = 
+squatters wishing to settle under your rule = 거주자들이 우리 문명에 개척자로 합류함
 
- # Requires translation!
-An ancient tribe trained us in their ways of combat! = 
-your exploring unit receives training = 해당 유닛을 업그레이드
+An ancient tribe trained us in their ways of combat! = 고대 부족으로부터 전투 훈련을 받았습니다!
+your exploring unit receives training = 유닛 경험치 획득
 
- # Requires translation!
-We have found survivors in the ruins! Population added to [param]. = 
-survivors (adds population to a city) = 생존자 (도시에 인구 추가 제공)
+We have found survivors in the ruins! Population added to [param]. = 고대 유적의 생존자가 [param]에 정착하여 인구가 증가했습니다
+survivors (adds population to a city) = 생존자 (도시에 인구 추가)
 
- # Requires translation!
-We have found a stash of [param] Gold in the ruins! = 
+We have found a stash of [param] Gold in the ruins! = 고대 유적에서 [param] 골드를 얻었습니다!
 a stash of gold = 골드 발견
 
 discover a lost technology = 기술 발견
 
- # Requires translation!
-Our unit finds advanced weaponry hidden in the ruins! = 
- # Requires translation!
-advanced weaponry for your explorer = 
+Our unit finds advanced weaponry hidden in the ruins! = 아군이 고대 유적에서 더 나은 무기를 찾았습니다!
+advanced weaponry for your explorer = 유닛 업그레이드
 
- # Requires translation!
-You find evidence of Barbarian activity. Nearby Barbarian camps are revealed! = 
- # Requires translation!
-reveal nearby Barbarian camps = 
+You find evidence of Barbarian activity. Nearby Barbarian camps are revealed! = 야만인이 활동한 흔적을 발견했습니다. 인근의 야만인 캠프가 표시됩니다!
+reveal nearby Barbarian camps = 야만인 주둔지 밝히기
 
 find a crudely-drawn map = 대략 그려진 지도 발견
 
@@ -3575,10 +3552,8 @@ Railroads = 철도
 
 'And homeless near a thousand homes I stood, and near a thousand tables pined and wanted food.' - William Wordsworth = '집이 없는 나는 천 채의 집 근처에 서서, 천 개의 식탁 옆에서 음식을 애타게 구했다.' - 윌리엄 워즈워드
 Refrigeration = 냉각기술
- # Requires translation!
-'I once sent a dozen of my friends a telegram saying 'flee at once-all is discovered!' They all left town immediately.' - Mark Twain = 
- # Requires translation!
-Telegraph = 
+'I once sent a dozen of my friends a telegram saying 'flee at once-all is discovered!' They all left town immediately.' - Mark Twain = '한번은 내 친구들에게 메시지를 보냈다. "도망쳐라! 모두 발각됐다." 그들은 모두 즉시 도망쳤다.' - 마크 트웨인
+Telegraph = 전신기술
 'The whole country was tied together by radio. We all experienced the same heroes and comedians and singers. They were giants.' - Woody Allen = '전국이 라디오 덕분에 하나로 연결되었다. 우리는 모두 같은 영웅과 같은 코미디언, 같은 가수를 경험했다. 그 사람들은 거인이었다.' - 우디 앨런
 Radio = 라디오
 'Aeronautics was neither an industry nor a science. It was a miracle.' - Igor Sikorsky = '항공학은 산업도 과학도 아니었다. 그것은 기적이었다.' - 이고르 시코르스키
@@ -3592,10 +3567,8 @@ Pharmaceuticals = 페니실린
 Plastics = 플라스틱
 'There's a basic principle about consumer electronics: it gets more powerful all the time and it gets cheaper all the time.' - Trip Hawkins = '전자 제품에는 한 가지 기본 원칙이 있다. 기능은 계속 강력해지고 가격은 계속 내려간다.' - 트립 호킨스
 Electronics = 전자공학
- # Requires translation!
-'The speed of communications is wondrous to behold, it is also true that speed does multiply the distribution of information that we know to be untrue.' – Edward R. Murrow = 
- # Requires translation!
-Mass Media = 
+'The speed of communications is wondrous to behold, it is also true that speed does multiply the distribution of information that we know to be untrue.' – Edward R. Murrow = '통신의 속도가 퍼져나가는 속도는 놀랍다. 그리고 필연이다. 우리가 잘못된 정보를 들을 것도.' - 에드워드 R. 머로우
+Mass Media = 대중 매체
 'Vision is the art of seeing things invisible.' - Jonathan Swift = '비전이란 보이지 않는 것을 보는 기술이다.' - 조너선 스위프트
 Radar = 레이더
 'The unleashed power of the atom has changed everything save our modes of thinking, and we thus drift toward unparalleled catastrophes.' - Albert Einstein = '자유로워진 원자의 힘이 우리의 사고 방식을 제외하고는 모든 것을 바꾸어 놓았고, 그리하여 우리는 피할 수 없는 파국을 향해 치닫게 되었다.' - 알베르트 아인슈타인'
@@ -3656,8 +3629,7 @@ Lakes = 호수
 
 Mountain = 산
 Has an elevation of [amount] for visibility calculations = 시야 계산에서 높이 [amount]에 해당
- # Requires translation!
-Units ending their turn on this terrain take [amount] damage = 
+Units ending their turn on this terrain take [amount] damage = 이 지형에서 턴을 마친 유닛은 고정 피해 [amount]HP를 입음
 
 Snow = 설원
 
@@ -3665,7 +3637,7 @@ Hill = 언덕
 [amount] Strength for cities built on this terrain = 이 지형에 세워진 도시의 전투력 [amount]
 
 Forest = 숲
-Provides a one-time Production bonus to the closest city when cut down = 제거하면 가장 가까운 도시에 일회성 생산력 제공
+Provides a one-time Production bonus to the closest city when cut down = 제거시 가장 가까운 도시에 일회성 생산력 제공
 Blocks line-of-sight from tiles at same elevation = 같은 높이에서 일직선상의 시야를 제한함
 Resistant to nukes = 핵폭탄으로 제거 불가
 Can be destroyed by nukes = 핵폭탄으로 제거 가능
@@ -3677,12 +3649,10 @@ Marsh = 습지
 Only Polders can be built here = 현재 타일에 간척지 시설만 건설 가능
 
 Fallout = 낙진
- # Requires translation!
-Nullifies all other stats this tile provides = 
+Nullifies all other stats this tile provides = 타일에서 제공하는 모든 산출을 무효화함
 
 Oasis = 오아시스
- # Requires translation!
-Only [improvementFilter] improvements may be built on this tile = 
+Only [improvementFilter] improvements may be built on this tile = [improvementFilter]만 건설할 수 있음
 
 Flood plains = 범람원
 
@@ -3698,10 +3668,8 @@ El Dorado = 엘도라도
 Grants 500 Gold to the first civilization to discover it = 최초로 발견한 문명에게 500골드 제공
 
 Fountain of Youth = 젊음의 샘
- # Requires translation!
-Grants [promotion] ([comment]) to adjacent [mapUnitFilter] units for the rest of the game = 
- # Requires translation!
-Tile provides yield without assigned population = 
+Grants [promotion] ([comment]) to adjacent [mapUnitFilter] units for the rest of the game = 근접한 [mapUnitFilter] 유닛에게 [promotion] ([comment]) 승급이 부여됨
+Tile provides yield without assigned population = 인구를 배치하지 않아도 산출량을 제공함
 
 Grand Mesa = 그랜드 메사
 

--- a/android/assets/jsons/translations/Korean.properties
+++ b/android/assets/jsons/translations/Korean.properties
@@ -3,13 +3,13 @@
 # Equivalent of a space in your language
 # If your language doesn't use spaces, just add "" as a translation, otherwise " "
  # Requires translation!
-" " = 
+" " = " "
 
 # If the first word in a sentence starts with a capital in your language, 
 # put the english word 'true' behind the '=', otherwise 'false'.
 # Don't translate these words to your language, only put 'true' or 'false'.
  # Requires translation!
-StartWithCapitalLetter = 
+StartWithCapitalLetter = false
 
 
 # Starting from here normal translations start, as written on
@@ -34,22 +34,14 @@ See your stats breakdown!\nEnter the Overview screen (top right corner) >\nClick
 
 # Crash screen
 
- # Requires translation!
-An unrecoverable error has occurred in Unciv: = 
- # Requires translation!
-If this keeps happening, you can try disabling mods. = 
- # Requires translation!
-You can also report this on the issue tracker. = 
- # Requires translation!
-Copy = 
- # Requires translation!
-Error report copied. = 
- # Requires translation!
-Open Issue Tracker = 
- # Requires translation!
-Please copy the error report first. = 
- # Requires translation!
-Close Unciv = 
+An unrecoverable error has occurred in Unciv: = 복구 불가능한 문제가 Unciv에서 발생했습니다.
+If this keeps happening, you can try disabling mods. = 문제가 계속 발생한다면 모드를 비활성화해보시기 바랍니다.
+You can also report this on the issue tracker. = 또는 이슈 트래커에서 문제를 보고할 수도 있습니다.
+Copy = 복사
+Error report copied. = 에러 보고서 복사됨
+Open Issue Tracker = 이슈 트래커 열기
+Please copy the error report first. = 에러 보고서를 먼저 복사해 주세요
+Close Unciv = Unciv 종료
 
 # Buildings
 
@@ -73,8 +65,7 @@ Requires at least one of the following resources worked near the city: = 도시 
 Wonder is being built elsewhere = 다른 도시에서 건설중
 National Wonder is being built elsewhere = 다른 도시에서 건설중
 Requires a [buildingName] in all cities = 모든 도시에 [buildingName] 필요
- # Requires translation!
-[buildingName] required: = 
+[buildingName] required: = [buildingName] 필요함:
 Requires a [buildingName] in this city = 도시에 [buildingName] 필요
 Cannot be built with [buildingName] = [buildingName]과 함께 건설 될 수 없음
 Consumes 1 [resource] = 소모하는 자원: [resource]
@@ -143,8 +134,7 @@ They promised not to settle near us ([count] turns remaining) = 우리 근처에
 [civName] has destroyed [cityState], whom you had pledged to protect! = 당신이 보호하기로 했던 [cityState]가 [civName]에 의해 점령당했습니다!
 
 Unforgivable = 원수지간
- # Requires translation!
-Afraid = 
+Afraid = 두려워함
 Enemy = 적대적
 Competitor = 경쟁적
 Neutral = 중립적
@@ -154,10 +144,8 @@ Ally = 동맹
 
 [questName] (+[influenceAmount] influence) = [questName] (영향력 +[influenceAmount])
 [remainingTurns] turns remaining = [remainingTurns] 턴 남음
- # Requires translation!
-Current leader is [civInfo] with [amount] [stat] generated. = 
- # Requires translation!
-Current leader is [civInfo] with [amount] Technologies discovered. = 
+Current leader is [civInfo] with [amount] [stat] generated. = 현재 선두는 [amount] [stat]을 생성한 [civInfo]입니다.
+Current leader is [civInfo] with [amount] Technologies discovered. = 현재 선두는 [amount]개 기술을 연구한 [civInfo]입니다.
 
 ## Diplomatic modifiers
 
@@ -186,10 +174,8 @@ You gave us units! = 우리에게 유닛을 선물했군요!
 You destroyed City-States that were under our protection! = 감히 우리 보호 하에 있던 도시 국가를 점령하다니!
 You attacked City-States that were under our protection! = 당신은 우리 보호 하에 있는 도시 국가를 공격했소!
 You demanded tribute from City-States that were under our protection! = 당신은 우리 보호 하에 있는 도시 국가에게 공물을 요구했소!
- # Requires translation!
-You sided with a City-State over us = 
- # Requires translation!
-You returned captured units to us = 
+You sided with a City-State over us = 우리보다 도시국가를 우선했군요
+You returned captured units to us = 사로잡힌 유닛을 돌려주셨군요
 
 Demands = 요구
 Please don't settle new cities near us. = 내 근처에 새로운 도시를 세우지 마시오.
@@ -201,10 +187,8 @@ We asked [civName] for a tribute recently and they gave in.\nYou promised to pro
 It's come to my attention that I may have attacked [civName], a city-state under your protection.\nWhile it was not my goal to be at odds with your empire, this was deemed a necessary course of action. = 내가 당신의 보호 하의 도시 국가인 [civName]을 공격했을지도 모른다는 것을 알았소.\n당신과 사이가 나빠지는 것이 내 목적은 아니지만, 이는 작전의 필수 단계로 여겨지고 있소.
 I thought you might like to know that I've launched an invasion of one of your little pet states.\nThe lands of [civName] will make a fine addition to my own. = 내가 당신 치하 국가 중 하나를 공격했다는 걸 알려줘야겠군.\n[civName]의 영토는 내게 큰 보탬이 될 것이오.
 
- # Requires translation!
-Return [unitName] to [civName]? = 
- # Requires translation!
-The [unitName] we liberated originally belonged to [civName]. They will be grateful if we return it to them. = 
+Return [unitName] to [civName]? = [unitName]을(를) [civName]에 반환할까요?
+The [unitName] we liberated originally belonged to [civName]. They will be grateful if we return it to them. = 해방시킨 [unitName]은(는) 원래 [civName] 소속입니다. 반환하면 그들이 고마워할 것입니다.
 
 Enter the amount of gold = 골드 양 입력
 
@@ -231,26 +215,16 @@ We have married into the ruling family of [civName], bringing them under our con
 You have broken your Pledge to Protect [civName]! = [civName] 보호 선언을 어겼습니다!
 City-States grow wary of your aggression. The resting point for Influence has decreased by [amount] for [civName]. = 당신의 공격성에 대한 도시 국가의 경계가 커집니다. [civName]에 대한 정지 영향력이 [amount]만큼 줄어들었습니다.
 
- # Requires translation!
-[cityState] is being attacked by [civName] and asks all major civilizations to help them out by gifting them military units. = 
- # Requires translation!
-[cityState] is being invaded by Barbarians! Destroy Barbarians near their territory to earn Influence. = 
- # Requires translation!
-[cityState] is grateful that you killed a Barbarian that was threatening them! = 
- # Requires translation!
-[cityState] is being attacked by [civName]! Kill [amount] of the attacker's military units and they will be immensely grateful. = 
- # Requires translation!
-[cityState] is deeply grateful for your assistance in the war against [civName]! = 
- # Requires translation!
-[cityState] no longer needs your assistance against [civName]. = 
- # Requires translation!
-War against [civName] = 
- # Requires translation!
-We need you to help us defend against [civName]. Killing [amount] of their military units would slow their offensive. = 
- # Requires translation!
-Currently you have killed [amount] of their military units. = 
- # Requires translation!
-You need to find them first! = 
+[cityState] is being attacked by [civName] and asks all major civilizations to help them out by gifting them military units. = [cityState]이(가) [civName]에게 공격받아 모든 주요 문명들에 군사 유닛을 선물해줄 것을 요청했습니다
+[cityState] is being invaded by Barbarians! Destroy Barbarians near their territory to earn Influence. = [cityState]에 야만인이 침략했습니다! 그들의 영토 근처의 야만인을 물리치고 영향력을 얻으십시오
+[cityState] is grateful that you killed a Barbarian that was threatening them! = [cityState]이(가) 그들을 위협하던 야만인을 해치워준 것에 감사합니다!
+[cityState] is being attacked by [civName]! Kill [amount] of the attacker's military units and they will be immensely grateful. = [cityState]이(가) [civName]에게 공격받고 있습니다! 침략자의 유닛 [amount]기를 해치워주면 대단히 감사할 것입니다
+[cityState] is deeply grateful for your assistance in the war against [civName]! = [cityState]이(가) [civName]와의 전쟁을 도와준 것에 깊이 감사합니다!
+[cityState] no longer needs your assistance against [civName]. = [cityState]이(가) [civName]에 대한 도움을 더는 필요로 하지 않습니다
+War against [civName] = [civName]와(과)의 전쟁
+We need you to help us defend against [civName]. Killing [amount] of their military units would slow their offensive. = [civName]를 막아내는데 도움이 필요하오. 그들의 군사 유닛 [amount]기를 해치워주면 공세를 늦출 수 있을 것이오.
+Currently you have killed [amount] of their military units. = 현재 [amount]기의 유닛을 처치했습니다.
+You need to find them first! = 우선 그들을 만나야 합니다!
 
 Cultured = 문화적
 Maritime = 해양적
@@ -318,10 +292,8 @@ Our items = 우리 물품
 Our trade offer = 우리 거래 품목
 [otherCiv]'s trade offer = [otherCiv]의 거래 품목
 [otherCiv]'s items = [otherCiv]의 물품
- # Requires translation!
-+[amount] untradable copy = 
- # Requires translation!
-+[amount] untradable copies = 
++[amount] untradable copy = 거래 불가능 +[amount]개
++[amount] untradable copies = 거래 불가능 +[amount]개
 Pleasure doing business with you! = 당신과의 거래는 언제나 환영입니다!
 I think not. = 그건 안 됩니다.
 That is acceptable. = 이 정도면 적당하군요.
@@ -363,8 +335,7 @@ Game Options = 게임 설정
 Civilizations = 문명
 Map Type = 지도 선택
 Map file = 지도 파일
- # Requires translation!
-Max Turns = 
+Max Turns = 최대 턴수
 Could not load map! = 지도를 불러올 수 없습니다!
  # Requires translation!
 Invalid map: Area ([area]) does not match saved dimensions ([dimensions]). = 
@@ -380,23 +351,19 @@ Perlin = 펄린
 Continents = 대륙
 Four Corners = 사합점
 Archipelago = 군도
- # Requires translation!
-Inner Sea = 
+Inner Sea = 내해
 Number of City-States = 도시 국가 수
 One City Challenge = 단일 도시 도전
 No Barbarians = 야만인 없음
- # Requires translation!
-Raging Barbarians = 
+Raging Barbarians = 야만인 부흥
 No Ancient Ruins = 고대 유적 없음
 No Natural Wonders = 자연 불가사의 없음
 Victory Conditions = 승리 조건
 Scientific = 과학
 Domination = 정복
 Cultural = 문화
- # Requires translation!
-Diplomatic = 
- # Requires translation!
-Time = 
+Diplomatic = 외교
+Time = 시간
 
 # Used for random nation indicator in empire selector and unknown nation icons in various overview screens.
 # Should be a single character, or at least visually square.
@@ -411,16 +378,11 @@ Width = 너비
 Radius = 반경
 Enable Religion = 종교 활성화
 
- # Requires translation!
-Resource Setting = 
- # Requires translation!
-Sparse = 
- # Requires translation!
-Abundant = 
- # Requires translation!
-Strategic Balance = 
- # Requires translation!
-Legendary Start = 
+Resource Setting = 자원 설정
+Sparse = 드묾
+Abundant = 풍족함
+Strategic Balance = 전략적 균형
+Legendary Start = 전설적인 시작
 
 Advanced Settings = 고급 설정
 RNG Seed = 난수 시드값
@@ -469,18 +431,12 @@ Maybe you put too many players into too small a map? = 지도 크기에 비해 �
 No human players selected! = 인간 플레이어가 선택되지 않았습니다
 Mods: = 모드:
 Extension mods: = 단순 확장 모드:
- # Requires translation!
-Base ruleset: = 
- # Requires translation!
-The mod you selected is incorrectly defined! = 
- # Requires translation!
-The mod combination you selected is incorrectly defined! = 
- # Requires translation!
-The mod combination you selected has problems. = 
- # Requires translation!
-You can play it, but don't expect everything to work! = 
- # Requires translation!
-This base ruleset is not compatible with the previously selected\nextension mods. They have been disabled. = 
+Base ruleset: = 기본 룰셋
+The mod you selected is incorrectly defined! = 선택한 모드의 정의가 올바르지 않습니다!
+The mod combination you selected is incorrectly defined! = 선택한 모드들의 정의가 서로 올바르지 않습니다!
+The mod combination you selected has problems. = 선택한 모드들에 문제가 있습니다.
+You can play it, but don't expect everything to work! = 실행할 수는 있지만 문제가 생길수도 있다는걸 유념하십시오!
+This base ruleset is not compatible with the previously selected\nextension mods. They have been disabled. = 기본 룰셋이 앞서 선택한 확장 모드와 호환되지 않습니다. 확장 모드가 비활성화됩니다.
 Base Ruleset = 기본 룰셋
 [amount] Techs = [amount]개의 기술
 [amount] Nations = [amount]개의 국가
@@ -498,8 +454,7 @@ Anything above 40 may work very slowly on Android! = 안드로이드에서 40을
 
 # Multiplayer
 
- # Requires translation!
-Help = 
+Help = 도움말
 Username = 사용자 이름
 Multiplayer = 멀티플레이
 Could not download game! = 게임을 다운로드할 수 없습니다!
@@ -528,10 +483,8 @@ Could not refresh! = 새로고침 할 수 없습니다!
 Last refresh: [time] minutes ago = 최근 새로고침: [time] 분 전
 Current Turn: = 현재 턴:
 Add Currently Running Game = 현재 진행중인 게임 추가
- # Requires translation!
-Paste gameID from clipboard = 
- # Requires translation!
-GameID = 
+Paste gameID from clipboard = 클립보드에서 게임ID 붙여넣기
+GameID = 게임ID
 Game name = 게임 이름
 Loading latest game state... = 새로고침 중...
 Couldn't download the latest game state! = 새로고침할 수 없습니다!
@@ -539,16 +492,11 @@ Resign = 기권
 Are you sure you want to resign? = 정말로 기권하겠습니까?
 You can only resign if it's your turn = 자기 차례일 때에만 기권할 수 있습니다
 [civName] resigned and is now controlled by AI = [civName] 문명이 기권하여 AI에 의해 조작됩니다
- # Requires translation!
-Last refresh: [time] [timeUnit] ago = 
- # Requires translation!
-Current Turn: [civName] since [time] [timeUnit] ago = 
- # Requires translation!
-Minutes = 
- # Requires translation!
-Hours = 
- # Requires translation!
-Days = 
+Last refresh: [time] [timeUnit] ago = 최근 새로고침: [time] [timeUnit] 전
+Current Turn: [civName] since [time] [timeUnit] ago = 현재 차례: [civName], [time] [timeUnit] 전
+Minutes = 분
+Hours = 시간
+Days = 일
 
 # Save game menu
 
@@ -591,16 +539,14 @@ Locate mod errors = 모드 오류 살펴보기
 Debug = 디버그
 
 Version = 버전
-See online Readme = 온라인 리드미 보기
+See online Readme = 온라인 README 보기
  # Requires translation!
 Visit repository = 
 Turns between autosaves = 자동저장 간격
 Sound effects volume = 효과음 음량
 Music volume = 음악 음량
- # Requires translation!
-Pause between tracks = 
- # Requires translation!
-Currently playing: [title] = 
+Pause between tracks = 음악 간격
+Currently playing: [title] = 현재 재생 중: [title]
 Download music = 음악 다운로드
 Downloading... = 다운로드 중...
 Could not download music! = 음악을 다운로드 할 수 없습니다!
@@ -620,24 +566,19 @@ Show pixel units = 유닛 그래픽 보기
 Show pixel improvements = 자원/시설 그래픽 보기
 Enable nuclear weapons = 핵무기 사용
 Show tile yields = 타일 산출량 보기
- # Requires translation!
-Show unit movement arrows = 
+Show unit movement arrows = 유닛 이동표시 보기
 Continuous rendering = 연속 렌더링
 When disabled, saves battery life but certain animations will be suspended = 끄면 배터리가 절약되지만 애니메이션이 지연될 수 있음
 Order trade offers by amount = 거래 품목 갯수순 정렬
- # Requires translation!
-Check extension mods based on vanilla = 
- # Requires translation!
-Checking mods for errors... = 
- # Requires translation!
-No problems found. = 
+Check extension mods based on vanilla = 바닐라를 기반으로 확장 모드 검사
+Checking mods for errors... = 모드 오류 검사중
+No problems found. = 확인된 문제 없음
 Show experimental world wrap for maps = 원통형 보기(world wrap) 활성화
 HIGHLY EXPERIMENTAL - YOU HAVE BEEN WARNED! = 경고: 매우 불안정함.
 Enable portrait orientation = 세로 보기
 Generate translation files = 번역 파일 생성
 Translation files are generated successfully. = 번역 파일 생성 완료
- # Requires translation!
-Please note that translations are a community-based work in progress and are INCOMPLETE! The percentage shown is how much of the language is translated in-game. If you want to help translating the game into your language, click here. = 
+Please note that translations are a community-based work in progress and are INCOMPLETE! The percentage shown is how much of the language is translated in-game. If you want to help translating the game into your language, click here. = 번역은 커뮤니티에서 이루어지고 있으며 불완전하다는 점을 유념해주시기 바랍니다! 아래에 나타난 비율은 게임 내에서 얼마나 번역이 진행되었는지를 나타냅니다. 여러분의 언어로 게임을 번역하는데 도움을 주시려면 여기를 클릭해주세요.
 
 # Notifications
 
@@ -676,8 +617,7 @@ An enemy [unit] has attacked [cityName] = 적 [unit]이(가) [cityName]을(를) 
 An enemy [unit] has attacked our [ourUnit] = 적 [unit]이(가) 아군 [ourUnit]을(를) 공격했습니다
 Enemy city [cityName] has attacked our [ourUnit] = 적 도시 [cityName]이(가) 아군 [ourUnit]을(를) 공격했습니다
 An enemy [unit] has captured [cityName] = 적 [unit]이(가) [cityName]을(를) 점령했습니다
- # Requires translation!
-An enemy [unit] has raided [cityName] = 
+An enemy [unit] has raided [cityName] = 적 [unit]이(가) [cityName]을(를) 습격했습니다
 An enemy [unit] has captured our [ourUnit] = 아군 [ourUnit]이(가) 적 [unit]에게 포로로 잡혔습니다
 An enemy [unit] has destroyed our [ourUnit] = 아군 [ourUnit]이(가) 적 [unit]에게 제거되었습니다
 Your [ourUnit] has destroyed an enemy [unit] = 적 [unit]이(가) 아군 [ourUnit]에게 제거되었습니다
@@ -691,10 +631,8 @@ Our [attackerName] was attacked by an intercepting [interceptorName] = 아군 [a
 Our [interceptorName] intercepted and attacked an enemy [attackerName] = 아군 [interceptorName]이(가) 적 [attackerName]을(를) 요격해 피해를 입혔습니다
 An enemy [unit] was spotted near our territory = 적 [unit]이(가) 아군 영토 근처에서 발견되었습니다
 An enemy [unit] was spotted in our territory = 적 [unit]이(가) 아군 영토 내에서 발견되었습니다
- # Requires translation!
-Your city [cityName] can bombard the enemy! = 
- # Requires translation!
-[amount] of your cities can bombard the enemy! = 
+Your city [cityName] can bombard the enemy! = [cityName] 도시가 적을 공격할 수 있습니다!
+[amount] of your cities can bombard the enemy! = [amount]개 도시가 적을 공격할 수 있습니다!
 [amount] enemy units were spotted near our territory = [amount]명의 적이 아군 영토 근처에서 발견되었습니다
 [amount] enemy units were spotted in our territory = [amount]명의 적이 아군 영토 내에서 발견되었습니다
 A(n) [nukeType] exploded in our territory! = 아군 영토에 [nukeType] 폭탄이 떨어졌습니다!
@@ -723,8 +661,7 @@ You and [name] are no longer allies! = [name] 도시국가와 이제 동맹 관�
 [cityName] has been connected to your capital! = [cityName]이(가) 수도와 연결되었습니다!
 [cityName] has been disconnected from your capital! = [cityName]와(과) 수도의 연결이 끊겼습니다!
 [civName] has accepted your trade request = [civName]이(가) 거래를 받아들였습니다
- # Requires translation!
-[civName] has made a counteroffer to your trade request = 
+[civName] has made a counteroffer to your trade request = [civName]이(가) 거래의 수정안을 제시했습니다
 [civName] has denied your trade request = [civName]이(가) 거래를 거절했습니다
 [tradeOffer] from [otherCivName] has ended = [otherCivName]이(가) 제시한 [tradeOffer]이(가) 만료되었습니다
 [tradeOffer] to [otherCivName] has ended = [otherCivName]에게 제시한 [tradeOffer]이(가) 만료되었습니다
@@ -739,29 +676,22 @@ We have received [goldAmount] Gold for discovering [naturalWonder] = [naturalWon
 Your relationship with [cityStateName] is about to degrade = [cityStateName] 도시국가와의 관계가 곧 악화됩니다
 Your relationship with [cityStateName] degraded = [cityStateName] 도시국가와의 관계가 악화되었습니다
 A new barbarian encampment has spawned! = 새 야만인 주둔지가 만들어졌습니다!
- # Requires translation!
-Barbarians raided [cityName] and stole [amount] Gold from your treasury! = 
+Barbarians raided [cityName] and stole [amount] Gold from your treasury! = 야만인이 [cityName]을(를) 습격하여 [amount] 골드를 훔쳐갔습니다!
 Received [goldAmount] Gold for capturing [cityName] = [cityName]을(를) 점령하여 [goldAmount]골드를 얻었습니다
 Our proposed trade is no longer relevant! = 우리가 제안한 거래가 유효하지 않습니다!
 [defender] could not withdraw from a [attacker] - blocked. = [defender]이(가) [attacker]에게서 철수하지 못했습니다!
 [defender] withdrew from a [attacker] = [defender]이(가) [attacker]에게서 철수했습니다
- # Requires translation!
-By expending your [unit] you gained [Stats]! = 
+By expending your [unit] you gained [Stats]! = [unit]을(를) 소모하여 [Stats]을(를) 얻었습니다!
 [civName] has stolen your territory! = [civName]에게 영토를 빼앗겼습니다!
 Clearing a [forest] has created [amount] Production for [cityName] = [forest]을 제거하여 [cityName]에 [amount]생산력이 추가되었습니다
 [civName] assigned you a new quest: [questName]. = [civName]이(가) [questName] 퀘스트를 제시했습니다
 [civName] rewarded you with [influence] influence for completing the [questName] quest. = [questName] 퀘스트를 완료하여 [civName]에 대한 영향력이 [influence] 증가했습니다
- # Requires translation!
-[civName] no longer needs your help with the [questName] quest. = 
- # Requires translation!
-The [questName] quest for [civName] has ended. It was won by [civNames]. = 
+[civName] no longer needs your help with the [questName] quest. = [civName]이(가) [questName]에 대한 도움을 더는 필요로 하지 않습니다
+The [questName] quest for [civName] has ended. It was won by [civNames]. = [civName]의 [questName]에서 [civNames]이(가) 우승했습니다.
 The resistance in [cityName] has ended! = [cityName]의 저항이 끝났습니다
- # Requires translation!
-[cityName] demands [resource]! = 
- # Requires translation!
-Because they have [resource], the citizens of [cityName] are celebrating We Love The King Day! = 
- # Requires translation!
-We Love The King Day in [cityName] has ended. = 
+[cityName] demands [resource]! = [cityName]이(가) [resource]을(를) 요구합니다!
+Because they have [resource], the citizens of [cityName] are celebrating We Love The King Day! = [cityName]이(가) [resource]을(를) 획득하여 국왕 기념일을 축하합니다!
+We Love The King Day in [cityName] has ended. = [cityName]의 국왕 기념일이 끝났습니다
 Our [name] took [tileDamage] tile damage and was destroyed = 아군 [name]이(가) [tileDamage]의 피해를 입어 제거되었습니다
 Our [name] took [tileDamage] tile damage = 아군 [name]이(가) [tileDamage]의 피해를 입었습니다
 [civName] has adopted the [policyName] policy = [civName]이(가) [policyName] 정책을 채택했습니다
@@ -771,24 +701,19 @@ You gained [Stats] as your religion was spread to [cityName] = 당신의 종교�
 You gained [Stats] as your religion was spread to an unknown city = 당신의 종교가 미지의 도시에 전파됨에 따라, [Stats]을 얻었습니다.
 Your city [cityName] was converted to [religionName]! = 당신의 [cityName] 도시는 [religionName] 종교로 개종했습니다!
 Your [unitName] lost its faith after spending too long inside enemy territory! = 아군 [unitName] 유닛이 적 영토에 너무 오래 머물러, 신앙심을 잃었습니다.
- # Requires translation!
-You have unlocked [ability] = 
- # Requires translation!
-A new b'ak'tun has just begun! = 
- # Requires translation!
-A Great Person joins you! = 
+You have unlocked [ability] = [ability]이(가) 해금되었습니다
+A new b'ak'tun has just begun! = 새로운 박툰이 시작되었습니다!
+A Great Person joins you! = 우리 문명에 위인이 합류합니다!
 
 
 # World Screen UI
 
 Working... = 로딩 중...
 Waiting for other players... = 다른 플레이어를 기다리는 중...
- # Requires translation!
-Waiting for [civName]... = 
+Waiting for [civName]... = [civName]을(를) 기다리는 중...
 in = 의 완성까지
 Next turn = 다음 턴
- # Requires translation!
-Move automated units = 
+Move automated units = 자동화한 유닛 이동
 [currentPlayerCiv] ready? = [currentPlayerCiv] 준비되었습니까?
 1 turn = 1 턴
 [numberOfTurns] turns = [numberOfTurns] 턴
@@ -853,8 +778,7 @@ Territory = 영토
 Force = 군사력
 GOLDEN AGE = 황금기
 Golden Age = 황금기
- # Requires translation!
-We Love The King Day = 
+We Love The King Day = 국왕 기념일
  # Requires translation!
 Global Effect = 
 [year] BC = 기원전 [year]년
@@ -884,14 +808,10 @@ Avoid [terrain] = [terrain] 제외
 
 # Maya calendar popup
 
- # Requires translation!
-The Mayan Long Count = 
- # Requires translation!
-Your scientists and theologians have devised a systematic approach to measuring long time spans - the Long Count. During the festivities whenever the current b'ak'tun ends, a Great Person will join you. = 
- # Requires translation!
-While the rest of the world calls the current year [year], in the Maya Calendar that is: = 
- # Requires translation!
-[amount] b'ak'tun, [amount2] k'atun, [amount3] tun = 
+The Mayan Long Count = 마야 장기력
+Your scientists and theologians have devised a systematic approach to measuring long time spans - the Long Count. During the festivities whenever the current b'ak'tun ends, a Great Person will join you. = 과학자들과 신학자들이 긴 기간을 측정하는 체계적인 방법인 장기력을 고안했습니다. 박툰이 끝날 때마다 축제가 열리고 이때 위인이 합류합니다.
+While the rest of the world calls the current year [year], in the Maya Calendar that is: = 세계의 다른 나라들은 올해를 [year]으로 부르지만, 마야 장기력에서는 다음과 같습니다:
+[amount] b'ak'tun, [amount2] k'atun, [amount3] tun = [amount] 박툰, [amount2] 카툰, [amount3] 툰
 
 # City screen
 
@@ -900,10 +820,8 @@ Raze city = 도시 파괴
 Stop razing city = 파괴 중단
 Buy for [amount] gold = [amount]골드로 구매
 Buy = 구매
- # Requires translation!
-Currently you have [amount] [stat]. = 
- # Requires translation!
-Would you like to purchase [constructionName] for [buildingGoldCost] [stat]? = 
+Currently you have [amount] [stat]. = 현재 [amount] [stat] 보유중입니다.
+Would you like to purchase [constructionName] for [buildingGoldCost] [stat]? = [constructionName]을(를) [buildingGoldCost] [stat](으)로 구매하시겠습니까?
 No space available to place [unit] near [city] = [city]에 [unit]을(를) 놓을 공간이 없습니다
 Maintenance cost = 유지비
 Pick construction = 생산 선택
@@ -930,14 +848,11 @@ Food converts to production = 식량이 생산력으로 전환됨
 [turnsToStarvation] turns to lose population = [turnsToStarvation]턴 후 인구 감소
 Stopped population growth = 인구 성장이 멈춤
 In resistance for another [numberOfTurns] turns = [numberOfTurns]턴 동안 저항 상태
- # Requires translation!
-We Love The King Day for another [numberOfTurns] turns = 
- # Requires translation!
-Demanding [resource] = 
+We Love The King Day for another [numberOfTurns] turns = [numberOfTurns]턴 동안 국왕 기념일
+Demanding [resource] = [resource] 요구
 Sell for [sellAmount] gold = [sellAmount]골드에 판매
 Are you sure you want to sell this [building]? = [building]을(를) 판매하겠습니까?
- # Requires translation!
-Free = 
+Free = 무료
 [greatPerson] points = [greatPerson] 위인 점수
 Great person points = 위인 점수
 Current points = 현재 점수
@@ -1018,15 +933,12 @@ Conduct Trade Mission = 무역 임무 수행
 Your trade mission to [civName] has earned you [goldAmount] gold and [influenceAmount] influence! = [civName]에 무역 임무를 수행하여 [goldAmount]골드와 [influenceAmount]영향력을 얻었습니다!
 Hurry Wonder = 불가사의 건축 가속
 Hurry Construction = 건축 가속
- # Requires translation!
-Hurry Construction (+[productionAmount]) = 
+Hurry Construction (+[productionAmount]) = 건축 가속 (+[productionAmount])
 Spread Religion = 종교 전파
 Spread [religionName] = [religionName] 전파
- # Requires translation!
-Remove Heresy = 
+Remove Heresy = 이단 색출
 Found a Religion = 종교 창시
- # Requires translation!
-Enhance a Religion = 
+Enhance a Religion = 종교 강화
 Your citizens have been happy with your rule for so long that the empire enters a Golden Age! = 시민들이 당신의 통치에 행복해하여 국가에 황금기가 시작됩니다!
 You have entered the [newEra]! = [newEra]에 온 것을 환영합니다!
 [civName] has entered the [eraName]! = [civName]이(가) [eraName]에 들어갔습니다.
@@ -1055,20 +967,13 @@ Transportation upkeep = 교통 유지비
 Unit upkeep = 유닛 유지비
 Trades = 거래
 Units = 유닛
- # Requires translation!
-Unit Supply = 
- # Requires translation!
-Base Supply = 
- # Requires translation!
-Total Supply = 
- # Requires translation!
-In Use = 
- # Requires translation!
-Supply Deficit = 
- # Requires translation!
-Production Penalty = 
- # Requires translation!
-Increase your supply or reduce the amount of units to remove the production penalty = 
+Unit Supply = 유닛 보급품
+Base Supply = 기초 보급품
+Total Supply = 총 보급품
+In Use = 사용중
+Supply Deficit = 보급품 부족
+Production Penalty = 생산력 페널티
+Increase your supply or reduce the amount of units to remove the production penalty = 생산력 페널티를 제거하려면 보급품을 늘리거나 유닛 수를 줄이십시오
 Name = 명칭
 Closest city = 가장 가까운 도시
 Action = 상태
@@ -1080,26 +985,16 @@ Known and defeated ([numberOfCivs]) = 멸망한 문명: [numberOfCivs]개
 Tiles = 타일
 Natural Wonders = 자연 불가사의
 Treasury deficit = 재무 적자
- # Requires translation!
-Unknown = 
- # Requires translation!
-Not built = 
- # Requires translation!
-Not found = 
- # Requires translation!
-Known = 
- # Requires translation!
-Owned = 
- # Requires translation!
-Near [city] = 
- # Requires translation!
-Somewhere around [city] = 
- # Requires translation!
-Far away = 
- # Requires translation!
-Status = 
- # Requires translation!
-Location = 
+Unknown = 알려지지 않음
+Not built = 지어지지 않음
+Not found = 발견되지 않음
+Known = 알려짐
+Owned = 보유중
+Near [city] = [city] 근처
+Somewhere around [city] = [city] 근처 어딘가
+Far away = 먼 곳
+Status = 상태
+Location = 위치
 
 # Victory
 
@@ -1158,8 +1053,7 @@ Liberating a city returns it to its original owner, giving you a massive relatio
 Raze = 불태우기
 Razing the city annexes it, and starts burning the city to the ground. = 도시를 합병한 후 서서히 불태웁니다.
 The population will gradually dwindle until the city is destroyed. = 도시가 완전히 파괴될 때까지 인구가 천천히 줄어듭니다.
- # Requires translation!
-Original capitals and holy cities cannot be razed. = 
+Original capitals and holy cities cannot be razed. = 원래 수도였던 도시와 성도는 파괴할 수 없습니다.
 Destroy = 파괴하기
 Destroying the city instantly razes the city to the ground. = 도시를 파괴하면 도시가 즉시 폐허가 됩니다.
 Remove your troops in our border immediately! = 우리 영토에서 군대를 치워 주십시오!
@@ -1183,8 +1077,7 @@ Tutorials = 튜토리얼
 Cost = 비용
 May contain [listOfResources] = 발견되는 자원: [listOfResources]
 May contain: = 발견되는 자원:
- # Requires translation!
-Can upgrade from [unit] = 
+Can upgrade from [unit] = [unit]에서 업그레이드 가능
  # Requires translation!
 Can upgrade from: = 
 Upgrades to [upgradedUnit] = [upgradedUnit](으)로 업그레이드 가능
@@ -1255,8 +1148,7 @@ Building cost modifier = 건물 생산력 보정
 Policy cost modifier = 정책 문화량 보정
 Unhappiness modifier = 불행 보정
 Bonus vs. Barbarians = 야만인 대항 보정
- # Requires translation!
-Barbarian spawning delay = 
+Barbarian spawning delay = 야만인 생성 대기시간
 Bonus starting units = 시작 유닛 보너스
 
 AI settings = AI 설정
@@ -1281,10 +1173,8 @@ Free promotion: = 기본 승급:
 Free promotions: = 기본 승급:
 Free for [units] = [units] 기본 적용
 Free for: = 기본 적용:
- # Requires translation!
-Granted by [param] = 
- # Requires translation!
-Granted by: = 
+Granted by [param] = [param]에서 획득
+Granted by: = 획득 방법:
 [bonus] with [tech] = [tech] 연구 시 [bonus]
 Difficulty levels = 난이도
 
@@ -1295,60 +1185,43 @@ Adopt free policy = 무료 정책 채택
 Unlocked at = 등장 시대:
 Gain 2 free technologies = 무료 기술 2개 획득
 All policies adopted = 모든 정책 채택됨
- # Requires translation!
-Policy branch: [branchName] = 
+Policy branch: [branchName] = 정책 트리: [branchName]
 
 # Religions
 
 Choose an Icon and name for your Religion = 종교의 이름과 아이콘을 선택하세요
- # Requires translation!
-Choose a name for your religion = 
+Choose a name for your religion = 종교의 이름을 선택하세요
 Choose a [beliefType] belief! = [beliefType] 교리 선택
- # Requires translation!
-Choose any belief! = 
+Choose any belief! = 교리를 선택하세요!
 Found [religionName] = [religionName] 창시
- # Requires translation!
-Enhance [religionName] = 
+Enhance [religionName] = [religionName] 강화
 Choose a pantheon = 종교관 선택
 Found Religion = 종교 창시
 Found Pantheon = 종교관 세우기
 Follow [belief] = [belief] 교리 채택
 Religions and Beliefs = 종교와 교리
 Majority Religion: [name] = 주류 종교 : [name]
- # Requires translation!
-+ [amount] pressure = 
- # Requires translation!
-Holy city of: [religionName] = 
- # Requires translation!
-Pressure = 
++ [amount] pressure = 압력 + [amount]
+Holy city of: [religionName] = 다음 종교의 성도: [religionName]
+Pressure = 압력
 
 # Religion overview screen
 Religion Name: = 종교 이름:
-Founding Civ: = 창시된 도시:
- # Requires translation!
-Holy City: = 
+Founding Civ: = 창시자:
+Holy City: = 성도
 Cities following this religion: = 해당 종교를 따르는 도시:
 Click an icon to see the stats of this religion = 해당 종교에 대한 정보를 보려면 아이콘 클릭:
- # Requires translation!
-Religion: Off = 
- # Requires translation!
-Minimal Faith required for\nthe next [Great Prophet]: = 
- # Requires translation!
-Religions to be founded: = 
- # Requires translation!
-Religious status: = 
+Religion: Off = 종교: 비활성화됨
+Minimal Faith required for\nthe next [Great Prophet]: = 다음 [Great Prophet] 탄생에 필요한 최소 신앙:
+Religions to be founded: = 창시 가능한 종교:
+Religious status: = 종교 상태:
 
- # Requires translation!
-None = 
+None = 없음
 Pantheon = 종교관
- # Requires translation!
-Founding religion = 
- # Requires translation!
-Religion = 
- # Requires translation!
-Enhancing religion = 
- # Requires translation!
-Enhanced religion = 
+Founding religion = 종교 창시
+Religion = 종교
+Enhancing religion = 종교 강화
+Enhanced religion = 강화된 종교
 
 # Terrains
 
@@ -1381,8 +1254,7 @@ Undesirable =
 Desirable = 
  # Requires translation!
 Featureless = 
- # Requires translation!
-Fresh Water = 
+Fresh Water = 담수
 
 # improvementFilters
 
@@ -1449,10 +1321,8 @@ Wounded = 피해를 입은 유닛
 relevant = 해당되는 모든
 
 # For "May choose [amount] additional [beliefType] beliefs when [founding/enhancing] a religion"
- # Requires translation!
-founding = 
- # Requires translation!
-enhancing = 
+founding = 창시
+enhancing = 강화
 
 # Promotions
 
@@ -1496,8 +1366,7 @@ Are you SURE you want to delete this mod? = 이 모드를 정말로 삭제하겠
 Updated = 업데이트 있음
 Current mods = 현재 모드
 Downloadable mods = 다운로드 가능한 모드
- # Requires translation!
-Mod info and options = 
+Mod info and options = 모드 정보 및 설정
 Next page = 다음 페이지
 Open Github page = 깃허브 페이지 열기
 Permanent audiovisual mod = 시청각모드 항상 적용
@@ -1511,26 +1380,16 @@ No description provided = 설명 없음
 Author: [author] = 제작: [author]
 Size: [size] kB = 크기: [size] kB
 The mod you selected is incompatible with the defined ruleset! = 선택한 모드가 현재 룰셋과 맞지 않습니다
- # Requires translation!
-Sort and Filter = 
- # Requires translation!
-Enter search text = 
- # Requires translation!
-Sort Current: = 
- # Requires translation!
-Sort Downloadable: = 
- # Requires translation!
-Name ￪ = 
- # Requires translation!
-Name ￬ = 
- # Requires translation!
-Date ￪ = 
- # Requires translation!
-Date ￬ = 
- # Requires translation!
-Stars ￬ = 
- # Requires translation!
-Status ￬ = 
+Sort and Filter = 정렬 및 필터
+Enter search text = 검색어를 입력하세요
+Sort Current: = 보유 중인 모드 정렬:
+Sort Downloadable: = 다운로드 가능한 모드 정렬:
+Name ￪ = 이름 ￪
+Name ￬ = 이름 ￬
+Date ￪ = 최근순
+Date ￬ = 오래된순
+Stars ￬ = 별점 ￬
+Status ￬ = 상태 ￬
 
 
 # Uniques that are relevant to more than one type of game object
@@ -1551,7 +1410,7 @@ Gain a free [building] [cityFilter] = [cityFilter]에 [building] 무료로 제�
 
 # Uniques not found in JSON files
 
-Only available after [] turns = [] 턴동안만 이용 가능
+Only available after [] turns = []턴 동안만 이용 가능
 This Unit upgrades for free = 해당 유닛은 무료 업그레이드 가능
 [stats] when a city adopts this religion for the first time = 처음으로 이 종교를 받아들일 때, [stats]
 Never destroyed when the city is captured = 도시가 점령되었을 때에도 파괴되지 않음
@@ -1597,22 +1456,14 @@ in all non-occupied cities = 점령되지 않은 도시
 in all cities with a world wonder = 세계 불가사의가 건설된 도시
 in all cities connected to capital = 수도와 연결된 도시
 in all cities with a garrison = 유닛이 주둔한 도시
- # Requires translation!
-in all cities in which the majority religion is a major religion = 
- # Requires translation!
-in all cities in which the majority religion is an enhanced religion = 
- # Requires translation!
-in non-enemy foreign cities = 
- # Requires translation!
-in foreign cities = 
- # Requires translation!
-in annexed cities = 
- # Requires translation!
-in holy cities = 
- # Requires translation!
-in City-State cities = 
- # Requires translation!
-in cities following this religion = 
+in all cities in which the majority religion is a major religion = 대중 종교가 주요 종교인 도시
+in all cities in which the majority religion is an enhanced religion = 대중 종교가 강화 종교인 도시
+in non-enemy foreign cities = 적이 아닌 외국 도시
+in foreign cities = 외국 도시
+in annexed cities = 합병된 도시
+in holy cities = 성도
+in City-State cities = 도시 국가의 도시
+in cities following this religion = 이 종교를 따르는 도시
 
 #################### Lines from Buildings from Civ V - Vanilla ####################
 
@@ -1620,25 +1471,20 @@ Palace = 궁전
 Indicates the capital city = 수도를 나타내는 건물
 
 Monument = 기념비
- # Requires translation!
-Destroyed when the city is captured = 
+Destroyed when the city is captured = 도시가 점령당하면 파괴됨
 
 Granary = 곡창
 [stats] from [tileFilter] tiles [cityFilter] = [cityFilter]의 [tileFilter]에 [stats]
 
- # Requires translation!
-'It is not so much for its beauty that the forest makes a claim upon men's hearts, as for that subtle something, that quality of air, that emanation from old trees, that so wonderfully changes and renews a weary spirit.' - Robert Louis Stevenson = 
+'It is not so much for its beauty that the forest makes a claim upon men's hearts, as for that subtle something, that quality of air, that emanation from old trees, that so wonderfully changes and renews a weary spirit.' - Robert Louis Stevenson = '인간이 숲을 동경하는 이유는 그저 숲이 아름다워서가 아니라 오래된 숲의 고목에서 뿜어져 나오는 공기에 존재하는 미묘한 무엇인가가 사람의 지친 영혼에 활기를 불어넣어 주고 회복시켜 주기 때문이다.' - 로버트 루이스 스티븐슨
 Temple of Artemis = 아르테미스 사원
- # Requires translation!
-[amount]% [stat] [cityFilter] = 
- # Requires translation!
-[amount]% Production when constructing [baseUnitFilter] units [cityFilter] = 
+[amount]% [stat] [cityFilter] = [cityFilter]의 [stat] [amount]%
+[amount]% Production when constructing [baseUnitFilter] units [cityFilter] = [cityFilter]에서 [baseUnitFilter] 건설시 생산력 [amount]%
 
 'They that go down to the sea in ships, that do business in great waters; these see the works of the Lord, and his wonders in the deep.' - The Bible, Psalms 107:23-24 = '배들을 바다에 띄우며 큰 물에서 일을 하는 자는 여호와께서 행하신 일들과 그의 기이한 일들을 깊은 바다에서 보나니.' - 성경, 시편 107:23-24
 The Great Lighthouse = 알렉산드리아 등대
 [amount] Movement = 행동력 [amount]
- # Requires translation!
-[amount] Sight = 
+[amount] Sight = 시야 [amount]
 
 Stone Works = 석재 공장
 Must not be on [terrainFilter] = [terrainFilter]에 건설 불가
@@ -1665,8 +1511,7 @@ Walls = 성벽
 
 Walls of Babylon = 바빌론 성벽
 
- # Requires translation!
-'O, let not the pains of death which come upon thee enter into my body. I am the god Tem, and I am the foremost part of the sky, and the power which protecteth me is that which is with all the gods forever.' - The Book of the Dead, translated by Sir Ernest Alfred Wallis Budge = 
+'O, let not the pains of death which come upon thee enter into my body. I am the god Tem, and I am the foremost part of the sky, and the power which protecteth me is that which is with all the gods forever.' - The Book of the Dead, translated by Sir Ernest Alfred Wallis Budge = '오, 그대에게 찾아온 죽음의 고통이 나의 육체에 들지 않기를. 나는 템 신으로서, 하늘 꼭대기에 거하며, 영원히 모든 신과 함께 하는 힘이 나를 보호할지니.' - 사자의 서, E.A. 월리스 버지 경 역
 The Pyramids = 피라미드
 [amount]% tile improvement construction time = 시설 건설 시간 [amount]%
 [amount] free [baseUnitFilter] units appear = 무료 [baseUnitFilter] [amount]기 출현
@@ -1679,15 +1524,12 @@ Barracks = 병영
 New [baseUnitFilter] units start with [amount] Experience [cityFilter] = [cityFilter]에서 새로 생산되는 [baseUnitFilter]의 경험치 +[amount]
 
 Krepost = 크리아포스츠
- # Requires translation!
-[amount]% Culture cost of natural border growth [cityFilter] = 
- # Requires translation!
-[amount]% Gold cost of acquiring tiles [cityFilter] = 
+[amount]% Culture cost of natural border growth [cityFilter] = [cityFilter]에서 타일 확장에 필요한 문화량 [amount]%
+[amount]% Gold cost of acquiring tiles [cityFilter] = [cityFilter]에서 타일 구매에 필요한 골드 [amount]%
 
 'He spoke, the son of Kronos, and nodded his head with the dark brows, and the immortally anointed hair of the great god swept from his divine head, and all Olympos was shaken' - The Iliad = '크로노스의 아들인 그가 말하고, 어두운 눈썹을 찡그리며 고개를 끄덕였고, 불멸의 기름이 발라진 위대한 신의 머리카락이 신의 머리에서 쓸려나갔고, 모든 올림포스가 흔들렸다.' - 일리아드
 Statue of Zeus = 제우스 동상
- # Requires translation!
-[amount]% Strength = 
+[amount]% Strength = 전투력 [amount]%
 
 Lighthouse = 등대
 
@@ -1695,11 +1537,9 @@ Stable = 마구간
 
 Courthouse = 법원
 Remove extra unhappiness from annexed cities = 합병된 도시에서 발생하는 추가 불행 제거
- # Requires translation!
-Can only be built [cityFilter] = 
+Can only be built [cityFilter] = [cityFilter]에만 건설 가능
 
- # Requires translation!
-'I think that if ever a mortal heard the word of God it would be in a garden at the cool of the day.' - F. Frankfort Moore = 
+'I think that if ever a mortal heard the word of God it would be in a garden at the cool of the day.' - F. Frankfort Moore = '만에 하나 인간이 신의 말씀을 듣게 된다면, 그것은 서늘한 아침 정원에서일 것이다.' - F. 프랭크포트 무어
 Hanging Gardens = 공중 정원
 
 Colosseum = 콜로세움
@@ -1707,8 +1547,7 @@ Colosseum = 콜로세움
 Circus Maximus = 원형 경기장
 Cost increases by [amount] per owned city = 도시 하나당 비용 +[amount]
 
- # Requires translation!
-'The art of war teaches us to rely not on the likelihood of the enemy's not attacking, but rather on the fact that we have made our position unassailable.' - Sun Tzu = 
+'The art of war teaches us to rely not on the likelihood of the enemy's not attacking, but rather on the fact that we have made our position unassailable.' - Sun Tzu = '병법은 적군이 쳐들어오지 않기를 바라는 것이 아니라, 적군이 우리를 공격할 엄두가 나지 않을 방비 태세에 의지해야 하는 것이다.' - 손자
 Great Wall = 만리장성
 Enemy land units must spend 1 extra movement point when inside your territory (obsolete upon Dynamite) = 적 지상 유닛이 아군 영토에서 이동시 1 행동력을 추가로 소모함\n만리장성을 가진 문명이 다이너마이트를 연구하면 효과가 사라짐
 
@@ -1721,8 +1560,7 @@ Mud Pyramid Mosque = 진흙 피라미드 모스크
 
 National College = 국립대학
 
- # Requires translation!
-'The ancient Oracle said that I was the wisest of all the Greeks. It is because I alone, of all the Greeks, know that I know nothing' - Socrates = 
+'The ancient Oracle said that I was the wisest of all the Greeks. It is because I alone, of all the Greeks, know that I know nothing' - Socrates = '고대 오라클은 내가 그리스에서 가장 현명하다 하였다. 그것은, 모든 그리스인 중 나만이, 내가 아무것도 모른다는 사실을 알기 때문이다.' - 소크라테스
 The Oracle = 오라클
 Free Social Policy = 무료 정책 획득
 
@@ -1737,8 +1575,7 @@ Provides 1 extra copy of each improved luxury resource near this City = 도시 �
 Mint = 조폐국
 
 Aqueduct = 송수로
- # Requires translation!
-[amount]% Food is carried over after population increases [cityFilter] = 
+[amount]% Food is carried over after population increases [cityFilter] = 새로운 시민이 증가한 이후 [cityFilter]의 식량 [amount]% 가 이월됨
 
 Heroic Epic = 영웅적 서사시
 All newly-trained [baseUnitFilter] units [cityFilter] receive the [promotion] promotion = [cityFilter]에서 새로 생산된 [baseUnitFilter]이 [promotion] 승급을 얻음
@@ -1750,24 +1587,19 @@ Garden = 정원
 
 Monastery = 수도원
 
- # Requires translation!
-'For it soars to a height to match the sky, and as if surging up from among the other buildings it stands on high and looks down upon the remainder of the city, adorning it, because it is a part of it, but glorying in its own beauty' - Procopius, De Aedificis = 
+'For it soars to a height to match the sky, and as if surging up from among the other buildings it stands on high and looks down upon the remainder of the city, adorning it, because it is a part of it, but glorying in its own beauty' - Procopius, De Aedificis = '하늘에 닿을 만큼 높이 솟아, 마치 다른 건물들의 복판에서 바로 솟아난 듯 높은 곳에 서서 도시를 내려다보며, 도시의 일부로서 도시를 장식하는 한편으로 그 자체의 아름다움으로 찬연히 빛나고 있다.' - 프로코피오스
 Hagia Sophia = 아야 소피아
 
- # Requires translation!
-'The temple is like no other building in the world. It has towers and decoration and all the refinements which the human genius can conceive of.' - Antonio da Magdalena = 
+'The temple is like no other building in the world. It has towers and decoration and all the refinements which the human genius can conceive of.' - Antonio da Magdalena = '세상에 또 이런 건물은 없을 것이다. 탑이 있고 장식이 있으며 인간의 재주로 생각할 수 있는 기교란 기교는 다 있다.' - 안토니오 데 막달레나
 Angkor Wat = 앙코르와트
 
- # Requires translation!
-'The katun is established at Chichen Itza. The settlement of the Itza shall take place there. The quetzal shall come, the green bird shall come. Ah Kantenal shall come. It is the word of God. The Itza shall come.' - The Books of Chilam Balam = 
+'The katun is established at Chichen Itza. The settlement of the Itza shall take place there. The quetzal shall come, the green bird shall come. Ah Kantenal shall come. It is the word of God. The Itza shall come.' - The Books of Chilam Balam = '치첸 이사에 카툰이 서리라. 이사가 그곳에 정착하리라. 케살이 오리라, 푸른 새가 오리라. 아 칸테날이 오리라. 이는 신의 말씀이라. 이사가 오리라.' - 칠람 발람의 서
 Chichen Itza = 치첸 이트사
- # Requires translation!
-[amount]% Golden Age length = 
+[amount]% Golden Age length = 황금기 지속 시간 [amount]%
 
 National Treasury = 국고
 
- # Requires translation!
-'Few romances can ever surpass that of the granite citadel on top of the beetling precipices of Machu Picchu, the crown of Inca Land.' - Hiram Bingham = 
+'Few romances can ever surpass that of the granite citadel on top of the beetling precipices of Machu Picchu, the crown of Inca Land.' - Hiram Bingham = '잉카 땅의 정수 마추픽추의 들쭉날쭉한 벼랑 위에 우뚝 선 화강암 도시의 낭만보다 더한 낭만은 잘 없을 것이다.' - 하이람 빙엄
 Machu Picchu = 마추픽추
 Gold from all trade routes +25% = 무역로에서 얻는 골드 +25%
 Must have an owned [tileFilter] within [amount] tiles = [tileFilter]에서 [amount]타일 내에 도시가 있어야 함
@@ -1777,8 +1609,7 @@ Workshop = 작업장
 Longhouse = 롱하우스
 
 Forge = 대장간
- # Requires translation!
-[amount]% Production when constructing [buildingFilter] buildings [cityFilter] = 
+[amount]% Production when constructing [buildingFilter] buildings [cityFilter] = [cityFilter]에서 [buildingFilter] 건설시 생산력 [amount]%
 
 Harbor = 항만
 Connects trade routes over water = 바다를 통해 도시 연결
@@ -1789,8 +1620,7 @@ Wat = 와트
 
 Oxford University = 옥스퍼드 대학
 
- # Requires translation!
-'Architecture has recorded the great ideas of the human race. Not only every religious symbol, but every human thought has its page in that vast book.' - Victor Hugo = 
+'Architecture has recorded the great ideas of the human race. Not only every religious symbol, but every human thought has its page in that vast book.' - Victor Hugo = '건축은 항상 인류의 뛰어난 발상을 기록으로 남겼다. 종교적 상징 하나하나가, 그뿐 아니라 인간의 생각 하나하나가 그 방대한 책의 한 페이지를 차지하고 있다.' - 빅토르 위고
 Notre Dame = 노트르담 대성당
 
 Castle = 성
@@ -1799,8 +1629,7 @@ Mughal Fort = 무굴 요새
  # Requires translation!
 [stats] = 
 
- # Requires translation!
-'Bushido is realized in the presence of death. This means choosing death whenever there is a choice between life and death. There is no other reasoning.' - Yamamoto Tsunetomo = 
+'Bushido is realized in the presence of death. This means choosing death whenever there is a choice between life and death. There is no other reasoning.' - Yamamoto Tsunetomo = '무사도는 죽음을 마주했을 때 실현된다. 즉, 삶과 죽음의 기로에서 죽음을 택한다는 뜻이다. 다른 생각의 여지는 없다.' - 야마모토 츠네모토
 Himeji Castle = 히메지 성
 
 Ironworks = 제철소
@@ -1820,8 +1649,7 @@ Satrap's Court = 사트레프 관청
 
 'Most of us can, as we choose, make of this world either a palace or a prison' - John Lubbock = '우리 대부분은 마음 먹기에 따라 세상을 궁궐로 만들 수도 있고 감옥으로 만들 수도 있다.' - 존 러벅
 Forbidden Palace = 자금성
- # Requires translation!
-[amount]% unhappiness from population [cityFilter] = 
+[amount]% unhappiness from population [cityFilter] = [cityFilter]의 시민이 생성하는 불행 [amount]%
 
 Theatre = 극장
 
@@ -1829,44 +1657,37 @@ Seaport = 항구
 
 Hermitage = 에르미타주 박물관
 
- # Requires translation!
-'The Taj Mahal rises above the banks of the river like a solitary tear suspended on the cheek of time.' - Rabindranath Tagore = 
+'The Taj Mahal rises above the banks of the river like a solitary tear suspended on the cheek of time.' - Rabindranath Tagore = '타지마할은, 시간의 뺨에 흐르는 눈물 한 방울과도 같이 강둑 위로 솟아있다.' - 라빈드라나트 타고르
 Taj Mahal = 타지마할
 Empire enters golden age = 황금기를 시작시킴
 
- # Requires translation!
-'Things always seem fairer when we look back at them, and it is out of that inaccessible tower of the past that Longing leans and beckons.' - James Russell Lowell = 
+'Things always seem fairer when we look back at them, and it is out of that inaccessible tower of the past that Longing leans and beckons.' - James Russell Lowell = '만사는 지나고 나서 돌아보면 더 좋아보이며, 바로 그 다가갈 수 없는 과거의 탑으로부터 동경은 몸을 내밀어 우리를 부른다.' - 제임스 러셀 로웰
 Porcelain Tower = 대보은사
 Free [baseUnitFilter] appears = 무료 [baseUnitFilter] 출현
 Science gained from research agreements [amount]% = 연구 협정으로 얻는 과학 [amount]%
 
 Windmill = 풍차
 
- # Requires translation!
-'The Law is a fortress on a hill that armies cannot take or floods wash away.' - The Prophet Muhammed = 
+'The Law is a fortress on a hill that armies cannot take or floods wash away.' - The Prophet Muhammed = '법이란 군대에 빼앗기지도 않고 홍수에 휩쓸리지도 않는 언덕 위의 요새다.' - 선지자 무함마드
 Kremlin = 크렘린 궁전
- # Requires translation!
-[amount]% City Strength from defensive buildings = 
+[amount]% City Strength from defensive buildings = 방어 건물 효과 [amount]%
 
 Museum = 박물관
 
- # Requires translation!
-'Every genuine work of art has as much reason for being as the earth and the sun' - Ralph Waldo Emerson = 
+'Every genuine work of art has as much reason for being as the earth and the sun' - Ralph Waldo Emerson = '진실한 예술품의 존재 가치는 지구와 태양의 존재 가치와 같다.' - 랄프 왈도 에머슨
 The Louvre = 루브르 박물관
 
 Public School = 공립학교
 
 Factory = 공장
 
- # Requires translation!
-'To achieve great things, two things are needed: a plan, and not quite enough time.' - Leonard Bernstein = 
+'To achieve great things, two things are needed: a plan, and not quite enough time.' - Leonard Bernstein = '위대한 업적을 이루려면 두 가지가 필요하다. 하나는 계획이고, 하나는 적당히 빠듯한 시간이다.' - 레너드 번스타인
 Big Ben = 빅 벤
 [stat] cost of purchasing items in cities [amount]% = 모든 도시에서 구입에 소모되는 금이 [amount]% [stat]
 
 Military Academy = 사관 학교
 
- # Requires translation!
-'Pale Death beats equally at the poor man's gate and at the palaces of kings.' - Horace = 
+'Pale Death beats equally at the poor man's gate and at the palaces of kings.' - Horace = '창백한 죽음은 가난한 자의 문과 왕의 궁전을 똑같이 두드린다.' - 호라티우스
 Brandenburg Gate = 브란덴부르크 문
 
 Arsenal = 병기창
@@ -1877,24 +1698,19 @@ Stock Exchange = 증권 거래소
 
 Broadcast Tower = 방송탑
 
- # Requires translation!
-'We live only to discover beauty, all else is a form of waiting' - Kahlil Gibran = 
+'We live only to discover beauty, all else is a form of waiting' - Kahlil Gibran = '우리 삶의 유일한 목적은 아름다움을 발견하는 것이다. 다른 모든 것은 일종의 기다림이다.' - 칼릴 지브란
 Eiffel Tower = 에펠탑
 Provides 1 happiness per 2 additional social policies adopted = 채택한 사회 정책 2개당 행복 +1
 
- # Requires translation!
-'Give me your tired, your poor, your huddled masses yearning to breathe free, the wretched refuse of your teeming shore. Send these, the homeless, tempest-tossed to me, I lift my lamp beside the golden door!' - Emma Lazarus = 
+'Give me your tired, your poor, your huddled masses yearning to breathe free, the wretched refuse of your teeming shore. Send these, the homeless, tempest-tossed to me, I lift my lamp beside the golden door!' - Emma Lazarus = '고단한 자여, 가난한 자여, 자유로이 숨 쉬고자 하는 군중이여, 내게로 오라. 너희 들끓는 해변의 초라한 자여, 갈 곳이 없는 자여, 폭풍에 휩쓸린 자여, 내게로 오라. 내가 황금 문 옆에 등불을 높이 쳐들리라!' - 엠마 라자루스
 Statue of Liberty = 자유의 여신상
- # Requires translation!
-[stats] from every specialist [cityFilter] = 
+[stats] from every specialist [cityFilter] = [cityFilter]의 전문가에서 [stats]
 
 Military Base = 군사 기지
 
- # Requires translation!
-'Come to me, all who labor and are heavy burdened, and I will give you rest.' - New Testament, Matthew 11:28 = 
+'Come to me, all who labor and are heavy burdened, and I will give you rest.' - New Testament, Matthew 11:28 = '고생하며 무거운 짐을 진 너희는 모두 나에게 오너라. 내가 너희에게 안식을 주겠다.' - 성경, 마태복음 11:28
 Cristo Redentor = 구세주 그리스도상
- # Requires translation!
-[amount]% Culture cost of adopting new Policies = 
+[amount]% Culture cost of adopting new Policies = 정책 채택에 필요한 문화량 [amount]%
 
 Research Lab = 연구소
 
@@ -1903,19 +1719,16 @@ Medical Lab = 의학 연구소
 
 Stadium = 경기장
 
- # Requires translation!
-'Those who lose dreaming are lost.' - Australian Aboriginal saying = 
+'Those who lose dreaming are lost.' - Australian Aboriginal saying = '꿈을 잃어버리면 길도 잃는다.' - 호주 원주민 속담
 Sydney Opera House = 시드니 오페라 하우스
 
 Manhattan Project = 맨해튼 프로젝트
 Enables nuclear weapon = 원자 폭탄과 핵미사일 생산 가능
 Triggers a global alert upon completion = 건설 완료시 전 세계에 알림
 
- # Requires translation!
-'In preparing for battle I have always found that plans are useless, but planning is indispensable.' - Dwight D. Eisenhower = 
+'In preparing for battle I have always found that plans are useless, but planning is indispensable.' - Dwight D. Eisenhower = '나는 전투 준비에 있어서, 계획은 아무 쓸모가 없지만 계획을 세우는 일은 꼭 필요하다는 사실을 늘 깨닫게 된다.' - 드와이트 D. 아이젠하워
 Pentagon = 펜타곤
- # Requires translation!
-[amount]% Gold cost of upgrading = 
+[amount]% Gold cost of upgrading = 업그레이드에 필요한 골드 [amount]%
 
 Solar Plant = 태양열 발전소
 
@@ -2107,11 +1920,9 @@ Lamia = 라미아
 Nafplion = 나브폴리온
 Apolyton = 아폴리톤
 Greece = 그리스
- # Requires translation!
-[amount]% City-State Influence degradation = 
+[amount]% City-State Influence degradation = 도시 국가에 대한 영향력 감소 속도 [amount]%
 City-State Influence recovers at twice the normal rate = 도시 국가에 대한 영향력 회복 속도 두 배
- # Requires translation!
-City-State territory always counts as friendly territory = 
+City-State territory always counts as friendly territory = 도시 국가의 영토가 항상 우호적 영토로 취급됨
 
 Wu Zetian = 측천무후
 You won't ever be able to bother me again. Go meet Yama. = 다시는 귀찮게 못하도록 해주지. 염라대왕한테나 가라.
@@ -2228,8 +2039,7 @@ Naqada = 나카다
 Semna = 셈나
 Soleb = 솔룹
 Egypt = 이집트
- # Requires translation!
-[amount]% Production when constructing [buildingFilter] wonders [cityFilter] = 
+[amount]% Production when constructing [buildingFilter] wonders [cityFilter] = [cityFilter]에서 [buildingFilter] 건설시 생산력 [amount]%
 
 Elizabeth = 엘리자베스 1세
 By the grace of God, your days are numbered. = 신의 은총으로 너를 처단하겠다.
@@ -2387,8 +2197,7 @@ Russia = 러시아
 Double quantity of [resource] produced = [resource] 획득량 두 배
 
 Augustus Caesar = 아우구스투스 카이사르
- # Requires translation!
-My treasury contains little and my soldiers are getting impatient... ...therefore you must die. = 
+My treasury contains little and my soldiers are getting impatient... ...therefore you must die. = 내 국고가 바닥나고 군사들은 동요하고 있네... 그러니 자네가 죽어줘야겠군.
 So brave, yet so stupid! If only you had a brain similar to your courage. = 참으로 용감하나, 참으로 멍청하구나! 그 용기만큼의 두뇌를 가졌더라면 좋았을 텐데.
 The gods have deprived Rome of their favour. We have been defeated. = 신들이 로마로부터 은총을 거두는구나. 우리가 정복당했다.
 I greet you. I am Augustus, Imperator and Pontifex Maximus of Rome. If you are a friend of Rome, you are welcome. = 그대에게 인사하지. 나는 로마의 황제이자 대제사장인 아우구스투스다. 그대를 로마의 친구로서 환영한다.
@@ -2437,8 +2246,7 @@ Augustadorum = 아우구스타도룸
 Curia = 큐리아
 Interrama = 인터라마
 Adria = 아드리아
- # Requires translation!
-[amount]% Production towards any buildings that already exist in the Capital = 
+[amount]% Production towards any buildings that already exist in the Capital = 수도에 건설된 건물을 다른 도시에서 건설시 생산력 [amount]%
 
 Harun al-Rashid = 하룬 알 라시드
 The world will be more beautiful without you. Prepare for war. = 그대만 사라진다면 이 세계는 더 아름다워질 것이오. 전쟁을 준비하시오.
@@ -2605,8 +2413,7 @@ Units fight as though they were at full strength even when damaged = 유닛이 �
 Gandhi = 간디
 I have just received a report that large numbers of my troops have crossed your borders. = 방금 많은 수의 군대가 당신의 국경에 들어갔다는 보고를 받았습니다.
 My attempts to avoid violence have failed. An eye for an eye only makes the world blind. = 안타깝게도 우리 나라의 모두가 저처럼 비폭력주의에 전념하는 것은 아닙니다.
- # Requires translation!
-You can chain me, you can torture me, you can even destroy this body, but you will never imprison my mind. = 
+You can chain me, you can torture me, you can even destroy this body, but you will never imprison my mind. = 당신으로 인해 죄없고 무력한 사람들이 희생되었습니다.
 Hello, I am Mohandas Gandhi. My people call me Bapu, but please, call me friend. = 인도 사람들을 대표하여, 저는 당신에게 친선의 손을 뻗습니다.
 My friend, are you interested in this arrangement? = 나의 벗이여, 이 제안에 관심이 있습니까?
 I wish you peace. = 당신에게 평화가 있기를.
@@ -2713,8 +2520,7 @@ Hildesheim = 힐데스하임
 Erlangen = 에어랑엔
 Germany = 독일
 67% chance to earn 25 Gold and recruit a Barbarian unit from a conquered encampment = 야만인 주둔지 점령시 67% 확률로 25골드와 야만인 유닛 획득
- # Requires translation!
-[amount]% maintenance costs = 
+[amount]% maintenance costs = 유지비 [amount]%
 
 Suleiman I = 술레이만
 Your continued insolence and failure to recognize and preeminence leads us to war. = 자넨 내 백성들에게 큰 근심거리가 되고 있군. 자네를 제거해야만 하겠어.
@@ -2977,8 +2783,7 @@ Pileni = 피레니
 Nukumanu = 누쿠마누
 Polynesia = 폴리네시아
 Can embark and move over Coasts and Oceans immediately = 시작 직후 물 타일로 승선, 이동 가능
- # Requires translation!
-Normal vision when embarked = 
+Normal vision when embarked = 승선시 시야 감소 없음
 +[amount]% Strength if within [amount2] tiles of a [tileImprovement] = [tileImprovement] 주변 [amount2]타일 내에서 전투력 +[amount]%
 
 Ramkhamhaeng = 람캄행
@@ -3022,10 +2827,8 @@ Loci = 로치
 Khon Kaen = 칸 카엔
 Surin = 수린
 Siam = 시암
- # Requires translation!
-[amount]% [stat] from City-States = 
- # Requires translation!
-Military Units gifted from City-States start with [amount] XP = 
+[amount]% [stat] from City-States = 도시 국가로부터 받는 [stat] [amount]%
+Military Units gifted from City-States start with [amount] XP = 군사적 도시 국가로부터 받는 군사 유닛의 경험치 [amount] XP
 
 Isabella = 이사벨
 God will probably forgive you... but I shall not. Prepare for war. = 주님께서 너를 용서하실지언정... 나는 그럴 수 없다. 전쟁을 준비해라!
@@ -3265,8 +3068,7 @@ Chucuito = 추퀴토
 Choquequirao = 초퀘퀴라오
 Inca = 잉카
 Units ignore terrain costs when moving into any tile with Hills = 언덕을 포함한 지형으로 진입할 때 행동력 페널티 없음
- # Requires translation!
-[amount]% maintenance on road & railroads = 
+[amount]% maintenance on road & railroads = 도로와 철도의 유지비 [amount]%
 No Maintenance costs for improvements in [tileFilter] tiles = [tileFilter]에 건설된 시설 유지비 없음
 
 Harald Bluetooth = 하랄 블로탄
@@ -3414,21 +3216,16 @@ Zanzibar = 잔지바르
 How could we fall to the likes of you?! = 어쩌다 당신같은 인간에게 패배했단 말인가?!
 Almaty = 알마티
 
- # Requires translation!
-Let's have a nice little War, shall we? = 
- # Requires translation!
-If you need your nose bloodied, we'll happily serve. = 
- # Requires translation!
-The serbian guerilla will never stop haunting you! = 
- # Requires translation!
-Belgrade = 
+Let's have a nice little War, shall we? = 우리 전쟁 잘 한번 해볼까요?
+If you need your nose bloodied, we'll happily serve. = 코피가 나고 싶으시다면, 기꺼이 도와드리겠습니다.
+The serbian guerilla will never stop haunting you! = 세르비아 게릴라가 너를 계속 쫓을 것이다!
+Belgrade = 베오그라드
 
 War lingers in our hearts. Why carry on with a false peace? = 전쟁이 가슴 속에 맴돈다. 거짓된 평화를 지킬 이유가 없구나!
 You gormless radger! You'll dine on your own teeth before you set foot in Ireland! = 멍청한 걸레같으니! 아일랜드에 발도 들이기 전에 쳐부숴주지!
 A lonely wind blows through the highlands today. A dirge for Ireland. Can you hear it? = 오늘도 고지대에 쓸쓸한 바람이 부는구나. 아일랜드를 위한 장송곡이 들리나?
 Dublin = 더블린
- # Requires translation!
-Will not be chosen for new games = 
+Will not be chosen for new games = 새 게임에서 선택되지 않음
 
 You shall stain this land no longer with your vileness! To arms, my countrymen - we ride to war! = 그대는 더이상 이 땅을 악행으로 물들일 수 없다! 전투 준비, 전진하라!
 Traitorous man! The Celtic peoples will not stand for such wanton abuse and slander - I shall have your head! = 배은망덕한 자여! 방자한 중상모략을 더는 용인하지 않겠다. 목을 내놓아라!
@@ -3443,14 +3240,10 @@ M'Banza-Kongo = 음반자 콩구
 What a fine battle! Sidon is willing to serve you! = 훌륭한 전투였습니다! 시돈은 이제 그대를 섬깁니다!
 Sidon = 시돈
 
- # Requires translation!
-We don't like your face. To arms! = 
- # Requires translation!
-You will see you have just bitten off more than you can chew. = 
- # Requires translation!
-This ship may sink, but our spirits will linger. = 
- # Requires translation!
-Valletta = 
+We don't like your face. To arms! = 당신 면상이 맘에 들지 않는군. 전쟁이다!
+You will see you have just bitten off more than you can chew. = 그대가 씹을 수 있는 것보다 많이 물었다는 걸 알게 될 것이오.
+This ship may sink, but our spirits will linger. = 이 배는 가라앉지만, 우리의 영혼은 살아남을 것이다. 
+Valletta = 발레타
 
 Can only heal by pillaging = 약탈 이외에는 회복 불가능
 
@@ -3459,15 +3252,12 @@ Can only heal by pillaging = 약탈 이외에는 회복 불가능
 
 Aristocracy = 관료제
 Legalism = 율법 정치
- # Requires translation!
-Provides the cheapest [stat] building in your first [amount] cities for free = 
+Provides the cheapest [stat] building in your first [amount] cities for free = 최초 [amount]개 도시에 가장 저렴한 [stat] 건물 무료로 제공
 Oligarchy = 과두제
 Units in cities cost no Maintenance = 도시에 주둔한 유닛의 유지비 없음
- # Requires translation!
-[amount]% Strength for cities = 
+[amount]% Strength for cities = 도시 전투력 [amount]%
 Landed Elite = 대지주
- # Requires translation!
-[amount]% growth [cityFilter] = 
+[amount]% growth [cityFilter] = [cityFilter]의 성장률 [amount]%
 Monarchy = 군주제
 Tradition Complete = 전통 완성
 
@@ -3483,19 +3273,16 @@ Free Great Person = 원하는 위인 1명이 무료로 출현
 Warrior Code = 전사규범
 Discipline = 규율
 Military Tradition = 군사 전통
- # Requires translation!
-[amount]% XP gained from combat = 
+[amount]% XP gained from combat = 전투로 얻는 경험치 [amount]%
 Military Caste = 군사신분제
 Professional Army = 직업 군대
 Honor Complete = 명예 완성
 
 Organized Religion = 종교 체제
 Mandate Of Heaven = 천명
- # Requires translation!
-[amount]% of excess happiness converted to [stat] = 
+[amount]% of excess happiness converted to [stat] = 잉여 행복의 [amount]%가 [stat]에 추가됨
 Theocracy = 신권 정치
- # Requires translation!
-[amount]% [stat] from every [tileFilter/specialist/buildingName] = 
+[amount]% [stat] from every [tileFilter/specialist/buildingName] = [tileFilter/specialist/buildingName]에서 [stat] [amount]%
 Reformation = 종교 개혁
 Free Religion = 종교적 관용
 Piety Complete = 신앙 완성
@@ -3507,14 +3294,11 @@ Resting point for Influence with City-States is increased by [amount] = 모든 �
 Scholasticism = 스콜라 철학
 Allied City-States provide [stat] equal to [amount]% of what they produce for themselves = 동맹 관계인 도시 국가로부터 그들이 생산하는 [stat]의 [amount]%를 획득
 Cultural Diplomacy = 문화 외교
- # Requires translation!
-[amount]% resources gifted by City-States = 
- # Requires translation!
-[amount]% Happiness from luxury resources gifted by City-States = 
+[amount]% resources gifted by City-States = 도시 국가로부터 받는 자원 [amount]%
+[amount]% Happiness from luxury resources gifted by City-States = 도시 국가가 제공한 사치 자원에서 얻는 행복 [amount]%
 Educated Elite = 지식인
 Allied City-States will occasionally gift Great People = 동맹 관계인 도시 국가에서 가끔 위인을 선물함
- # Requires translation!
-Patronage Complete = 
+Patronage Complete = 후원 완성
 Influence of all other civilizations with all city-states degrades [amount]% faster = 도시국가에 대한 다른 모든 문명의 영향력 감소 속도 +[amount]%
 Triggers the following global alert: [param] = 다음의 내용을 전 세계에 알림: [param]
 
@@ -3523,16 +3307,14 @@ Trade Unions = 노동 조합
 Merchant Navy = 상선대
 Mercantilism = 중상주의
 Protectionism = 보호무역주의
- # Requires translation!
-[amount] Happiness from each type of luxury resource = 
+[amount] Happiness from each type of luxury resource = 사치 자원 한 종류당 행복 [amount]
 Commerce Complete = 상업 완성
 
 Secularism = 세속주의
 Humanism = 인본주의
 Free Thought = 자유사상
 Sovereignty = 국민주권
- # Requires translation!
-[amount]% [stat] = 
+[amount]% [stat] = [stat] [amount]%
 Scientific Revolution = 과학 혁명
 [amount] Free Technologies = 무료 기술 [amount]개 획득
 Rationalism Complete = 합리주의 완성
@@ -3541,21 +3323,17 @@ Rationalism Complete = 합리주의 완성
 Constitution = 헌법
 Universal Suffrage = 보통선거제도
 Civil Society = 시민 사회
- # Requires translation!
-[amount]% Food consumption by specialists [cityFilter] = 
+[amount]% Food consumption by specialists [cityFilter] = [cityFilter]의 전문가가 소비하는 식량 [amount]%
 Free Speech = 표현의 자유
 [amount] units cost no maintenance = 유닛 [amount]기의 유지비 무료
 Democracy = 민주주의
- # Requires translation!
-[amount]% unhappiness from specialists [cityFilter] = 
+[amount]% unhappiness from specialists [cityFilter] = [cityFilter]의 전문가가 생성하는 불행 [amount]%
 Freedom Complete = 평등 완성
- # Requires translation!
-[amount]% Yield from every [tileFilter] = 
+[amount]% Yield from every [tileFilter] = [tileImprovement]의 해당 분야 산출량 [amount]%
 
 Populism = 포퓰리즘
 Militarism = 군국주의
- # Requires translation!
-[stat] cost of purchasing [baseUnitFilter] units [amount]% = 
+[stat] cost of purchasing [baseUnitFilter] units [amount]% = [baseUnitFilter] 유닛을 구매하는 [stat] [amount]%
 Fascism = 파시즘
 Quantity of strategic resources produced by the empire +[amount]% = 모든 전략자원의 획득량 +[amount]%
 Police State = 경찰국가
@@ -3568,8 +3346,7 @@ Militaristic City-States grant units [amount] times as fast when you are at war 
 Planned Economy = 계획 경제
 Nationalism = 민족주의
 Socialism = 사회주의
- # Requires translation!
-[amount]% maintenance cost for buildings [cityFilter] = 
+[amount]% maintenance cost for buildings [cityFilter] = [cityFilter]의 건물 유지비 [amount]%
 Communism = 공산주의
 Order Complete = 질서 완성
 
@@ -3591,10 +3368,8 @@ We recommend you to start building [param] to show the whole world your civiliza
 Acquire Great Person = 위인 배출
 Great People can change the course of a Civilization! You will be rewarded for acquiring a new [param]. = 위인들은 문명의 흐름을 바꿀 수 있소! 새로운 [param]을 배출함으로써 보상 받을 것이오.
 
- # Requires translation!
-Conquer City State = 
- # Requires translation!
-It's time to erase the City-State of [param] from the map. You will be greatly rewarded for conquering them! = 
+Conquer City State = 도시 국가 정벌
+It's time to erase the City-State of [param] from the map. You will be greatly rewarded for conquering them! = [param] 도시 국가를 지도상에서 지워버릴 때가 왔습니다. 그들을 정벌하면 큰 보상이 있을 것입니다!
 
 Find Player = 다른 문명의 영토 발견하기
 You have yet to discover where [param] set up their cities. You will be rewarded for finding their territories. = 당신들은 [param]이 어디에 도시를 세웠는지를 찾지 못했소. 그들의 영토를 찾으면 보상을 받을 것이오.
@@ -3602,48 +3377,31 @@ You have yet to discover where [param] set up their cities. You will be rewarded
 Find Natural Wonder = 자연 불가사의 발견하기
 Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [param] yet. = 자연 불가사의를 찾기 위한 모험에 당신 문명의 최고의 탐험가를 보내시오. 아직 그 누구도 [param]의 위치를 알지 못하오.
 
- # Requires translation!
-Give Gold = 
- # Requires translation!
-We are suffering great poverty after being robbed by [param], and unless we receive a sum of Gold, it's only a matter of time before we collapse. = 
+Give Gold = 원조 요청
+We are suffering great poverty after being robbed by [param], and unless we receive a sum of Gold, it's only a matter of time before we collapse. = 우리는 [param]의 약탈로 인한 가난에 시달리고 있습니다. 골드 지원이 없으면 파산하는 것은 시간문제입니다.
 
- # Requires translation!
-Pledge to Protect = 
- # Requires translation!
-We need your protection to stop the aggressions of [param]. By signing a Pledge of Protection, you'll confirm the bond that ties us. = 
+Pledge to Protect = 보호 요청
+We need your protection to stop the aggressions of [param]. By signing a Pledge of Protection, you'll confirm the bond that ties us. = [param]의 공세를 멈추기 위해 보호가 필요합니다. 보호 선언을 체결하면 서로 간의 유대를 확인할 수 있을 것입니다.
 
- # Requires translation!
-Contest Culture = 
- # Requires translation!
-The civilization with the largest Culture growth will gain a reward. = 
+Contest Culture = 문화 생성
+The civilization with the largest Culture growth will gain a reward. = 문화를 가장 많이 생성한 문명에게 보상이 주어질 것입니다.
 
- # Requires translation!
-Contest Faith = 
- # Requires translation!
-The civilization with the largest Faith growth will gain a reward. = 
+Contest Faith = 신앙 생성
+The civilization with the largest Faith growth will gain a reward. = 신앙을 가장 많이 생성한 문명에게 보상이 주어질 것입니다.
 
- # Requires translation!
-Contest Technologies = 
- # Requires translation!
-The civilization with the largest number of new Technologies researched will gain a reward. = 
+Contest Technologies = 기술 
+The civilization with the largest number of new Technologies researched will gain a reward. = 기술을 가장 많이 연구한 문명에게 보상이 주어질 것입니다.
 
- # Requires translation!
-Invest = 
- # Requires translation!
-Our people are rejoicing thanks to a tourism boom. For a certain amount of time, any Gold donation will yield [amount]% extra Influence. = 
+Invest = 투자 요청
+Our people are rejoicing thanks to a tourism boom. For a certain amount of time, any Gold donation will yield [amount]% extra Influence. = 우리 시민들이 관광 열풍으로 인해 크게 기뻐하고 있습니다. 일정 기간 동안 모든 골드 선물에 [amount]%의 영향력이 추가로 제공될 것입니다.
 
- # Requires translation!
-Bully City State = 
- # Requires translation!
-We are tired of the pretensions of [param]. If someone were to put them in their place by Demanding Tribute from them, they would be rewarded. = 
+Bully City State = 도시 국가 괴롭히기
+We are tired of the pretensions of [param]. If someone were to put them in their place by Demanding Tribute from them, they would be rewarded. = [param]과의 신경전에 지쳤습니다. 누군가 그들에게 공물을 요구하여 주제를 파악하게 해준다면 보상이 주어질 것입니다.
 
- # Requires translation!
-Denounce Civilization = 
- # Requires translation!
-We have been forced to pay tribute to [param]! We need you to tell the world of their ill deeds. = 
+Denounce Civilization = 다른 문명 비난하기
+We have been forced to pay tribute to [param]! We need you to tell the world of their ill deeds. = [param]에서 강제로 공물을 뜯어갔습니다! 그들의 만행을 전 세계에 알려주시기 바랍니다.
 
- # Requires translation!
-We have heard the tenets of [param] and are most curious. Will you send missionaries to teach us about your religion? = 
+We have heard the tenets of [param] and are most curious. Will you send missionaries to teach us about your religion? = [param]의 교리를 우리는 익히 들었고 매우 관심이 많습니다. 당신의 종교를 가르쳐줄 사절단을 파견해주시겠습니까?
 
 
 #################### Lines from Ruins from Civ V - Vanilla ####################

--- a/android/assets/jsons/translations/Korean.properties
+++ b/android/assets/jsons/translations/Korean.properties
@@ -1287,16 +1287,16 @@ Missile = 미사일
 
 # Unit filters and other unit related things
 
-Air = 공중 유닛
-air units = 공중 유닛
+Air = 공중
+air units = 공중
 Barbarian = 야만인
 Barbarians = 야만인
-Embarked = 승선한 유닛
-land units = 지상 유닛
-Military = 군사 유닛
+Embarked = 승선한
+land units = 지상
+Military = 군사
 # Deprecated since 3.15.2, but should still be translated until it is officially removed
-military water = 해상 군사 유닛
-non-air = 공중 유닛을 제외한 유닛
+military water = 해상 군사
+non-air = 공중 유닛을 제외한
 Nuclear Weapon = 핵폭탄
 Submarine = 잠수함
 submarine units = 잠수함
@@ -4037,19 +4037,16 @@ Slinger Withdraw = 투석병 철수
 Ignore terrain cost = 지형 무시
 Ignores terrain cost = 지형에 의한 이동력 감소 무시
 
- # Requires translation!
-Pictish Courage = 
+Pictish Courage = 용맹한 픽트족
 
- # Requires translation!
-Home Sweet Home = 
+Home Sweet Home = 즐거운 우리집
 [amount]% Strength decreasing with distance from the capital = 수도 근처에서 전투력 [amount]%, 수도와 멀어질수록 감소함
 
 
 #################### Lines from UnitTypes from Civ V - Vanilla ####################
 
 
- # Requires translation!
-Civilian Water = 
+Civilian Water = 해상 비전투
 
 
 Can enter ice tiles = 빙하 지형에 통행 가능
@@ -4854,16 +4851,11 @@ Lorient = 로리앙
 Celts = 켈트
 
 Haile Selassie = 하일레 셀라시에
- # Requires translation!
-I have tried all other avenues, but yet you persist in this madness. I hope, for your sake, your end is swift. = 
- # Requires translation!
-It is silence that allows evil to triumph. We will not stand mute and allow you to continue on this mad quest unchecked. = 
- # Requires translation!
-God and history will remember your actions this day. I hope you are ready for your impending judgment. = 
- # Requires translation!
-A thousand welcomes to our fair nation. I am Selassie, the Ras Tafari Makonnen and Emperor of Ethiopia, your humble servant. = 
- # Requires translation!
-I request that you consider this offer between our two peoples. I believe it will do us both good. = 
+I have tried all other avenues, but yet you persist in this madness. I hope, for your sake, your end is swift. = 대안을 두루 찾아보았지만, 당신은 미친 소리만 계속하시는군요. 이렇게 된 이상 당신을 빨리 없애는 게 모두를 위하는 길입니다.
+It is silence that allows evil to triumph. We will not stand mute and allow you to continue on this mad quest unchecked. = 악행을 보고도 잠자코 있으면 안 됩니다. 당신의 미친 짓을 그냥 두고 보지는 않겠습니다.
+God and history will remember your actions this day. I hope you are ready for your impending judgment. = 오늘 당신이 한 행동은 하늘과 땅이 기억할 것입니다. 심판받을 준비가 되었기를 바랍니다.
+A thousand welcomes to our fair nation. I am Selassie, the Ras Tafari Makonnen and Emperor of Ethiopia, your humble servant. = 어서 오십시오. 소생은 라스 타파리 마코넨이자 에티오피아의 황제인 하일레 셀라시에라고 합니다.
+I request that you consider this offer between our two peoples. I believe it will do us both good. = 이 제안을 고려해 보십시오. 내 생각에는 이 거래가 양 문명에 이익이 될 것입니다.
 Spirit of Adwa = 아드와 전투의 정신
 Blessings be upon you, honorable and righteous Emperor of Ethiopia, Haile Selassie. Your legacy as one of Ethiopia's greatest rulers, and as the spiritual leader to the Rastafarian movement, is outshone only by the influence you had on diplomacy and political cooperation throughout the world. In introducing Ethiopia's first written constitution, you planted the seeds of democracy that would take root over the coming years, and your infinitely wise grasp of global affairs secured Ethiopia's place as a charter member of the United Nations. Spearheading efforts to reform and modernize the nation during your reign, you changed the course of Ethiopian history forever = 에티오피아의 명예롭고 공정한 황제 하일레 셀라시에께 축복이 있기를. 에티오피아에서 제일 위대한 지도자이자 래스터패리 운동의 영적 지도자인 당신은 전 세계적인 외교와 정치 협력을 이끌어내셨습니다. 에티오피아의 첫 성문 헌법을 제정함으로써 에티오피아에 민주주의의 씨앗을 심었고 지혜롭게 국제 문제에 대처하여 에티오피아를 국제연합 창설 회원국 위치에 올려놓으셨습니다. 국가 재건과 근대화의 최전선에서 노력한 당신은 에티오피아의 역사가 나갈 방향을 영원히 바꾸어 놓으셨습니다.
 Revered king, your composed demeanor once protected the people from the many conflicts that plague the nations of men, and the kingdom looks to you to assure peace once again. Will you lead the people with courage and authority, moving forward into a new age? Will you build a civilization that stands the test of time? = 존경받는 황제시여. 당신은 침착하게 대처하여 국민을 괴롭히는 수많은 투쟁을 막아내셨습니다. 이제 왕국은 당신이 다시 한 번 평화를 지켜 주기를 바라옵니다. 용기와 권위를 가지고 국민을 이끌어 새로운 시대를 향해 전진하시겠습니까? 세월의 시련을 이겨낼 문명을 건설하겠습니까?
@@ -4903,20 +4895,14 @@ Weldiya = 웰디아
 Ethiopia = 에티오피아
 
 Pacal = 파칼
- # Requires translation!
-A sacrifice unlike all others must be made! = 
- # Requires translation!
-Muahahahahahaha! = 
- # Requires translation!
+A sacrifice unlike all others must be made! = 다른 문명과는 다른 제물을 바쳐야만 해!
+Muahahahahahaha! = 으흐하하하하하하하!
 Today comes a great searing pain. With you comes the path to the black storm. = 
- # Requires translation!
-Greetings, wayward one. I am known as Pacal. = 
- # Requires translation!
-Friend, I believe I may have found a way to save us all! Look, look and accept my offering! = 
+Greetings, wayward one. I am known as Pacal. = 어서 오게나. 처음 보는군. 나는 파칼 대왕이다.
+Friend, I believe I may have found a way to save us all! Look, look and accept my offering! = 어쩌면 인류를 구원할 방법을 찾은 건지 모르겠어! 어서 내 제안을 받아들여!
  # Requires translation!
 A fine day, it helps you. = 
- # Requires translation!
-The Long Count = 
+The Long Count = 장기력
 Your people kneel before you, exalted King Pacal the Great, favored son of the gods and shield to the citizens of the Palenque domain. After years of strife at the hands of your neighboring rivals, you struck back at the enemies of your people, sacrificing their leaders in retribution for the insults dealt to your predecessors. The glory of Palenque was restored only by the guidance afforded by your wisdom, as you orchestrated vast reconstruction efforts within the city, creating some of the greatest monuments and architecture your people - and the world - have ever known. = 신들의 총애받는 자손이시며 팔렝케 시민의 수호자인 파칼 대왕이시여, 그대 앞에 백성 모두 무릎 꿇나이다. 당신은 적들에 맞서 싸워 이웃 경쟁자들과의 분쟁을 종결시켰으며 그들의 지도자를 제물로 바쳐 선조를 모욕한 죄에 응징을 가하셨습니다. 도시의 대규모 재건을 통하여 전 세계를 통틀어서도 그 위대함을 견줄 데 없는 유적들을 세우신 당신의 지혜가 없었다면 팔렝케의 영광도 없었을 겁니다.
 Illustrious King, your people once again look to you for leadership and counsel in the coming days. Will you channel the will of the gods and restore your once proud kingdom to its greatest heights? Will you build new monuments to forever enshrine the memories of your people? Can you build a civilization that will stand the test of time? = 걸출한 왕이시여. 백성은 당신의 미래를 향한 충고와 지도를 다시금 바라나이다. 신들의 뜻을 받들어 위대한 왕국을 재건하시겠습니까? 왕국의 존재를 영원히 역사에 남길 만한 새 유적을 지으시겠습니까? 세월의 시련을 이겨낼 문명을 건설하겠습니까?
 Palenque = 팔렌케
@@ -4932,9 +4918,8 @@ Lamanai = 라마나이
 Izapa = 이사파
 Uaxactun = 우악삭툰
 Comalcalco = 코말칼코
-Piedras Negras = 
- # Requires translation!
-Cancuen = 
+Piedras Negras = 피에드라스네그라스
+Cancuen = 칸쿠엔
 Yaxha = 약사
 Quirigua = 키리구아
 Q'umarkaj = 우말카하
@@ -5165,11 +5150,9 @@ In addition, you can’t even build any city improvements that increase happines
 This means that it is very difficult to expand quickly in Unciv.\nIt isn’t impossible, but as a new player you probably shouldn't do it.\nSo what should you do? Chill out, scout, and improve the land that you do have by building Workers.\nOnly build new cities once you have found a spot that you believe is appropriate. = 이는 곧 Unciv에서는 빠른 확장이 매우 어렵다는 것을 의미합니다.\n할 수는 있지만 초심자라면 그렇게 하지 않는 게 좋을 겁니다.\n그럼 어떡해야 할까요? 느긋하게 정찰하고 노동자를 건설해서 지금 가진 땅에 시설을 지으세요.\n새로운 도시는 적당하다고 생각되는 자리에만 펴는 것이 좋습니다.
 
 Unhappiness = 불행
- # Requires translation!
-It seems that your citizens are unhappy!\nWhile unhappy, your civilization will suffer many detrimental effects, increasing in severity as unhappiness gets higher. = 
+It seems that your citizens are unhappy!\nWhile unhappy, your civilization will suffer many detrimental effects, increasing in severity as unhappiness gets higher. = 시민들이 행복하지 않은 것 같습니다!\n불행 상태에서 문명은 다양한 악영향을 겪게 되며, 불행이 심해질수록 악영향도 심해집니다.
 Unhappiness has two main causes: Population and cities.\n  Each city causes 3 unhappiness, and each population, 1 = 도시와 인구가 증가하면 행복도가 감소합니다.\n도시 하나당 -3, 인구 하나당 -1만큼 행복도가 감소합니다.
- # Requires translation!
-There are 2 main ways to combat unhappiness:\n  by building happiness buildings for your population\n  or by having improved luxury resources within your borders. = 
+There are 2 main ways to combat unhappiness:\n  by building happiness buildings for your population\n  or by having improved luxury resources within your borders. = 불행을 제거하려면 행복도를 제공하는 건물을 건설하거나\n\n사치자원을 얻으려면 영토 내의 사치자원에 시설을 건설하여 개발하거나, 다른 문명과 거래하거나,\n해당 사치자원을 가진 도시국가와 동맹을 맺으면 됩니다.\n장기적으로는 행복도를 제공하는 정책을 채택하는 것이 도움이 됩니다.
 
 You have entered a Golden Age!\nGolden age points are accumulated each turn by the total happiness \n  of your civilization\nWhen in a golden age, culture and production generation increases +20%,\n  and every tile already providing at least one gold will provide an extra gold. = 문명이 황금기에 진입했습니다!\n매 턴 행복도가 문명의 황금기 점수에 누적됩니다.\n황금기 점수가 일정치에 달하면 황금기가 시작됩니다.\n황금기에는 모든 도시의 문화와 생산력이 20% 증가하고\n1골드 이상 생산하던 모든 타일에서 산출량이 1골드 증가합니다.
 
@@ -5178,10 +5161,8 @@ Connecting your cities to the capital by roads\n  will generate gold via the tra
 
 Victory Types = 승리 방식
 Once you’ve settled your first two or three cities you’re probably 100 to 150 turns into the game.\nNow is a good time to start thinking about how, exactly, you want to win – if you haven’t already. = 도시를 2~3개 세웠다면 아마 100~150턴 정도가 지나 있을 것입니다.\n이때부터는 승리방식을 대략적으로 생각해보는 것이 좋습니다.
- # Requires translation!
-There are four ways to win in Unciv. They are:\n - Cultural Victory: Complete 5 Social Policy Trees and build the Utopia Project\n - Domination Victory: Survive as the last civilization\n - Science Victory: Be the first to construct a spaceship to Alpha Centauri\n - Diplomatic Victory: Build the United Nations and win the vote = 
- # Requires translation!
-So to sum it up, these are the basics of Unciv – Found a prosperous first city, expand slowly to manage happiness, and set yourself up for the victory condition you wish to pursue.\nObviously, there is much more to it than that, but it is important not to jump into the deep end before you know how to swim. = 
+There are four ways to win in Unciv. They are:\n - Cultural Victory: Complete 5 Social Policy Trees and build the Utopia Project\n - Domination Victory: Survive as the last civilization\n - Science Victory: Be the first to construct a spaceship to Alpha Centauri\n - Diplomatic Victory: Build the United Nations and win the vote = Unciv에는 4가지 승리 조건이 있습니다.\n - '문화 승리'는 사회 정책 트리를 다섯 개 완성해야 합니다.\n - '정복 승리'는 가장 마지막으로 살아남는 문명이 되어야 합니다.\n - '과학 승리'는 알파 센타우리로 가는 우주선을 가장 먼저 건설해야 합니다.\n - '외교 승리'는 세계 기구를 건설하고 선거에서 승리해야 합니다.
+So to sum it up, these are the basics of Unciv – Found a prosperous first city, expand slowly to manage happiness, and set yourself up for the victory condition you wish to pursue.\nObviously, there is much more to it than that, but it is important not to jump into the deep end before you know how to swim. = 정리하자면 Unciv의 플레이는 이런 식입니다.\n'수도를 세워 성장 - 행복도를 관리하면서 확장 - 원하는 승리 조건에 다가감'\n자세한 내용은 아직 많이 있지만 그건 차츰 알아가면 됩니다.
 
 Enemy City = 도시 점령
 Cities can be conquered by reducing their health to 1, and entering the city with a melee unit.\nSince cities heal each turn, it is best to attack with ranged units and use your melee units to defend them until the city has been defeated! = 적 도시를 점령하려면 근접 유닛이 도시에 진입해야만 합니다.\n도시는 유닛보다 공격력이 높고 매 턴 체력을 회복하므로 준비가 필요합니다.\n원거리 유닛이 도시를 공격하고, 근접 유닛은 원거리 유닛을 보호하다가\n도시 체력을 다 깎고나서 근접유닛이 막타를 넣어 진입하는 것이 일반적입니다.
@@ -5251,8 +5232,7 @@ Once enough points have been accumulated, a Great Person of that type will be cr
 Great Improvements also provide any strategic resources that are under them, so you don't need to worry if resources are revealed underneath your improvements! = 전략 자원 위에 위인 시설을 건설해도 해당 자원을 획득할 수 있습니다.\n이미 건설한 위인시설 밑에서 나중에 전략 자원이 발견되더라도\n자원을 얻기 위해서 시설을 없애거나 바꿀 필요는 없는 것입니다.
 
 Removing Terrain Features = 추가 지형
- # Requires translation!
-Certain tiles have terrain features - like Flood plains or Forests -  on top of them. Some of these layers, like Jungle, Marsh and Forest, can be removed by workers.\nRemoving the terrain feature does not remove any resources in the tile, and is usually required in order to add improvements exploiting those resources. = 
+Certain tiles have terrain features - like Flood plains or Forests -  on top of them. Some of these layers, like Jungle, Marsh and Forest, can be removed by workers.\nRemoving the terrain feature does not remove any resources in the tile, and is usually required in order to add improvements exploiting those resources. = 어떤 타일은 그 위에 추가지형을 가지고 있습니다.\n몇몇 추가지형(숲, 정글, 습지)은 노동자로 제거할 수 있습니다.\n추가지형을 제거해도 해당 타일의 자원은 사라지지 않습니다.\n자원을 개발하려면 추가지형을 제거해야하는 경우가 더 많습니다.
 
 Natural Wonders, such as the Mt. Fuji, the Rock of Gibraltar and the Great Barrier Reef, are unique, impassable terrain features, masterpieces of mother Nature, which possess exceptional qualities that make them very different from the average terrain.\nThey benefit by giving you large sums of Culture, Science, Gold or Production if worked by your Cities, which is why you might need to bring them under your empire as soon as possible. = 후지 산, 지브롤터 암벽, 대보초 등의 자연 불가사의(자연 경관)는 어느 지형과도 다른 독특한 특성을 지닙니다.\n자연 불가사의는 맵에 하나씩밖에 없고, 유닛이 지나갈 수 없으며\n해당 타일에 인구를 배치하면 많은 양의 문화, 과학, 골드 등을 얻을 수 있으므로\n자연 불가사의를 최대한 빨리 확보하는 것이 중요하다고 할 수 있습니다.
 
@@ -5278,8 +5258,7 @@ This is where you spend most of your time playing Unciv. See the world, control 
 ⑪: Remaining/per turn movement points, strength and experience / XP needed for promotion. For cities, you get its combat strength. = 남은행동력/최대행동력, 전투력/원거리공격력, 현재경험치/승급경험치가 나타나고, 도시는 전투력이 나타납니다.
 ⑫: This button closes the selected unit/city info pane. = ⑫ 유닛 또는 도시 정보창을 닫습니다.
 ⑬: This pane appears when you order a unit to attack an enemy. On top are attacker and defender with their respective base strengths. = ⑬ 아군 유닛 또는 도시를 선택한 다음에 적 유닛을 선택하면 전투력 상세정보 창을 볼 수 있습니다. 최상단에는 공격측의 공격력과 방어측의 전투력이 표시됩니다.
- # Requires translation!
-⑭: Below that are strength bonuses or penalties and health bars projecting before / after the attack. = 
+⑭: Below that are strength bonuses or penalties and health bars projecting before / after the attack. = ⑭ 그 밑으로 공격 전후의 HP와 전투력 보너스/페널티 요인이 표시됩니다.
 ⑮: The Attack Button - let blood flow! = ⑮ 공격 버튼입니다. 피를 보게 하십시오!
 ⑯: The minimap shows an overview over the world, with known cities, terrain and fog of war. Clicking will position the main map. = ⑯ 미니맵에는 전체적인 세계의 모습, 이미 조우한 도시와 이미 탐색한 지형, 미탐색 구역 등이 나타납니다. 미니맵을 클릭하여 세계 화면을 이동할 수 있습니다.
 ⑰: To the side of the minimap are display feature toggling buttons - tile yield, worked indicator, show/hide resources. These mirror setting on the options screen and are hidden if you deactivate the minimap. = ⑰ 미니맵 측면에는 타일 산출량 보기, 시민 배치 보기, 자원/시설 보기 버튼이 있습니다. 이는 설정의 토글과 대응되며 미니맵을 보기 설정을 끄면 같이 숨겨집니다.
@@ -5298,45 +5277,27 @@ This is where you spend most of your time playing Unciv. See the world, control 
 ⓩ: And this is the red targeting circle that led to the attack pane back under ⑬. = ⓩ 붉은색 원은 적을 의미하며 ⑬에서 언급된 전투력 정보창을 볼 수 있습니다.
 What you don't see: The phone/tablet's back button will pop the question whether you wish to leave Unciv and go back to Real Life. On desktop versions, you can use the ESC key. = 게임 종료 버튼: 화면에 표시되지는 않지만, 모바일에서 뒤로가기 또는 PC에서 Esc를 눌러서 게임을 종료하고 현생으로 되돌아갈 수 있습니다.
 
- # Requires translation!
-After building a shrine, your civilization will start generating ☮Faith. = 
- # Requires translation!
-When enough ☮Faith has been generated, you will be able to found a pantheon. = 
- # Requires translation!
-A pantheon will provide a small bonus for your civilization that will apply to all your cities. = 
- # Requires translation!
-Each civilization can only choose a single pantheon belief, and each pantheon can only be chosen once. = 
- # Requires translation!
-Generating more ☮Faith will allow you to found a religion. = 
+After building a shrine, your civilization will start generating ☮Faith. = 성소를 지으면 ☮신앙을 얻을 수 있습니다.
+When enough ☮Faith has been generated, you will be able to found a pantheon. = ☮신앙이 충분히 모이면 종교관을 선택할 수 있습니다.
+A pantheon will provide a small bonus for your civilization that will apply to all your cities. = 종교관은 우리 문명의 모든 도시에 조금의 보너스를 제공합니다.
+Each civilization can only choose a single pantheon belief, and each pantheon can only be chosen once. = 모든 문명은 하나의 종교관만 선택할 수 있고, 모든 종교관은 한 번만 선택할 수 있습니다.
+Generating more ☮Faith will allow you to found a religion. = ☮신앙을 더 생산하면 종교를 창시할 수 있습니다.
 
- # Requires translation!
-Keep generating ☮Faith, and eventually a great prophet will be born in one of your cities. = 
- # Requires translation!
-This great prophet can be used for multiple things: Constructing a holy site, founding a religion and spreading your religion. = 
- # Requires translation!
-When founding your religion, you may choose another two beliefs. The founder belief will only apply to you, while the follower belief will apply to all cities following your religion. = 
- # Requires translation!
-Additionally, the city where you used your great prophet will become the holy city of that religion. = 
- # Requires translation!
-Once you have founded a religion, great prophets will keep being born every so often, though the amount of Faith☮ you have to save up will be higher. = 
- # Requires translation!
-One of these great prophets can then be used to enhance your religion. = 
- # Requires translation!
-This will allow you to choose another follower belief, as well as an enhancer belief, that only applies to you. = 
- # Requires translation!
-Do take care founding a religion soon, only about half the players in the game are able to found a religion! = 
+Keep generating ☮Faith, and eventually a great prophet will be born in one of your cities. = ☮신앙을 계속 모으다 보면 도시에서 위대한 선지자가 탄생합니다.
+This great prophet can be used for multiple things: Constructing a holy site, founding a religion and spreading your religion. = 위대한 선지자는 성지 건설, 종교 창시, 종교 전파 등에 사용됩니다.
+When founding your religion, you may choose another two beliefs. The founder belief will only apply to you, while the follower belief will apply to all cities following your religion. = 종교를 창설할 때에는 서로 다른 두 가지 교리를 선택할 수 있습니다. 창시자 교리는 당신(종교를 창시한 사람)에게만 적용되고, 신도 교리는 종교를 따르는 도시에 적용됩니다.
+Additionally, the city where you used your great prophet will become the holy city of that religion. = 위대한 선지자를 소모하여 종교를 창시한 도시는 해당 종교의 성도가 됩니다.
+Once you have founded a religion, great prophets will keep being born every so often, though the amount of Faith☮ you have to save up will be higher. = 종교를 창시한 뒤에도 위대한 선지자는 계속 탄생하지만, 위인에 필요한 ☮신앙은 점점 증가합니다.
+One of these great prophets can then be used to enhance your religion. = 이러한 선지자들 중 하나는 종교를 강화하는데 쓰일 수 있습니다.
+This will allow you to choose another follower belief, as well as an enhancer belief, that only applies to you. = 종교를 강화하면 추가 신도 교리 1개와 종교를 창시한 문명에게만 적용되는 강화 교리를 선택할 수 있습니다.
+Do take care founding a religion soon, only about half the players in the game are able to found a religion! = 종교는 전체 플레이어 중 절반만이 창시할 수 있으므로 서두르지 않으면 내 종교를 창시할 수 없습니다!
 
- # Requires translation!
-Beliefs = 
- # Requires translation!
-There are four types of beliefs: Pantheon, Founder, Follower and Enhancer beliefs. = 
- # Requires translation!
-Pantheon and Follower beliefs apply to each city following your religion, while Founder and Enhancer beliefs only apply to the founder of a religion. = 
+Beliefs = 교리
+There are four types of beliefs: Pantheon, Founder, Follower and Enhancer beliefs. = 교리는 종교관, 창시자 교리, 신도 교리, 강화 교리로 나뉩니다.
+Pantheon and Follower beliefs apply to each city following your religion, while Founder and Enhancer beliefs only apply to the founder of a religion. = 종교관과 신도 교리는 해당 종교를 따르는 도시에 모두 적용되고, 창시자 교리와 강화 교리는 종교를 창시한 문명에 적용됩니다.
 
- # Requires translation!
-Religion inside cities = 
- # Requires translation!
-When founding a city, it won't follow a religion immediately. = 
+Religion inside cities = 도시 내의 종교
+When founding a city, it won't follow a religion immediately. = 도시를 새로 세워도 종교를 즉시 따르는 것은 아닙니다.
  # Requires translation!
 The religion a city follows depends on the total pressure each religion has within the city. = 
  # Requires translation!
@@ -5553,15 +5514,9 @@ Gain enough Faith for [amount]% of a Great Prophet =
 Reveal up to [amount/'all'] [tileFilter] within a [amount] tile radius = 
  # Requires translation!
 From a randomly chosen tile [amount] tiles away from the ruins, reveal tiles up to [amount2] tiles away with [amount3]% chance = 
- # Requires translation!
-This Unit gains [amount] XP = 
- # Requires translation!
-This Unit upgrades for free including special upgrades = 
- # Requires translation!
-This Unit gains the [promotion] promotion = 
- # Requires translation!
-Hidden before founding a Pantheon = 
- # Requires translation!
-Hidden after founding a Pantheon = 
- # Requires translation!
-Hidden after generating a Great Prophet = 
+This Unit gains [amount] XP = 이 유닛이 경험치 [amount]을 얻음
+This Unit upgrades for free including special upgrades = 이 유닛이 무료로 업그레이드됨
+This Unit gains the [promotion] promotion = 이 유닛이 [promotion] 승급을 얻음
+Hidden before founding a Pantheon = 종교관을 얻기 전에는 숨겨짐
+Hidden after founding a Pantheon = 종교관을 세운 후에는 숨겨짐
+Hidden after generating a Great Prophet = 위대한 선지자를 얻은 후에는 숨겨짐

--- a/android/assets/jsons/translations/Korean.properties
+++ b/android/assets/jsons/translations/Korean.properties
@@ -5376,147 +5376,83 @@ This means exploration and trade is important to grow your cities! =
 
 #################### Lines from Unique Types #######################
 
- # Requires translation!
-Nullifies [stat] [cityFilter] = 
- # Requires translation!
-Nullifies Growth [cityFilter] = 
- # Requires translation!
-Provides [stats] per turn = 
- # Requires translation!
-Provides [stats] [cityFilter] per turn = 
- # Requires translation!
-Provides [amount] Happiness = 
- # Requires translation!
-Provides military units every ≈[amount] turns = 
- # Requires translation!
-Provides a unique luxury = 
- # Requires translation!
-Cannot build [baseUnitFilter] units = 
- # Requires translation!
-[amount]% Great Person generation [cityFilter] = 
- # Requires translation!
-May choose [amount] additional [beliefType] beliefs when [foundingOrEnhancing] a religion = 
- # Requires translation!
-May buy [buildingFilter] buildings for [amount] [stat] [cityFilter] at an increasing price ([amount2]) = 
- # Requires translation!
-May buy [baseUnitFilter] units for [amount] [stat] [cityFilter] = 
- # Requires translation!
-May buy [buildingFilter] buildings for [amount] [stat] [cityFilter] = 
- # Requires translation!
-May buy [baseUnitFilter] units with [stat] [cityFilter] = 
- # Requires translation!
-May buy [buildingFilter] buildings with [stat] for [amount] times their normal Production cost = 
+Nullifies [stat] [cityFilter] = [cityFilter]의 [stat]을 0으로 함
+Nullifies Growth [cityFilter] = [cityFilter]의 성장을 0으로 함
+Provides [stats] per turn = 매 턴 [stats] 제공
+Provides [stats] [cityFilter] per turn = 매 턴 [cityFilter]에 [stats] 제공
+Provides [amount] Happiness = 행복도 [amount] 제공
+Provides military units every ≈[amount] turns = 약 [amount] 턴마다 군사 유닛 제공
+Provides a unique luxury = 고유 사치 자원 제공
+Cannot build [baseUnitFilter] units = [baseUnitFilter] 유닛 생산 불가
+[amount]% Great Person generation [cityFilter] = [cityFilter]에서 위인 출현 속도 [amount]%
+May choose [amount] additional [beliefType] beliefs when [foundingOrEnhancing] a religion = 종교 [foundingOrEnhancing] 시 [amount]개의 추가 [beliefType] 교리 선택 가능
+May buy [buildingFilter] buildings for [amount] [stat] [cityFilter] at an increasing price ([amount2]) = [cityFilter]에서 [amount] [stat]으로 [buildingFilter] 구매 가능, 비용은 [amount2]씩 상승함
+May buy [baseUnitFilter] units for [amount] [stat] [cityFilter] = [cityFilter]에서 [amount] [stat]으로 [baseUnitFilter] 구매 가능
+May buy [buildingFilter] buildings for [amount] [stat] [cityFilter] = [cityFilter]에서 [amount] [stat]으로 [buildingFilter] 구매 가능
+May buy [baseUnitFilter] units with [stat] [cityFilter] = [cityFilter]에서 [stat]으로 [baseUnitFilter] 구매 가능
+May buy [buildingFilter] buildings with [stat] for [amount] times their normal Production cost = 필요 생산력의 [amount]배에 해당하는 [stat]으로 [buildingFilter] 구매 가능
  # Requires translation!
 [stat] cost of purchasing [buildingFilter] buildings [amount]% = 
- # Requires translation!
-Triggers victory = 
- # Requires translation!
-Incompatible with [policy/tech/promotion] = 
- # Requires translation!
-Rebel units may spawn = 
- # Requires translation!
-Can be purchased for [amount] [stat] [cityFilter] = 
- # Requires translation!
-Must not be next to [terrainFilter] = 
- # Requires translation!
-No defensive terrain penalty = 
- # Requires translation!
-Upon capturing a city, receive [amount] times its [stat] production as [plunderableStat] immediately = 
- # Requires translation!
-[amount] XP gained from combat = 
- # Requires translation!
-when at war = 
- # Requires translation!
-when not at war = 
- # Requires translation!
-during a Golden Age = 
- # Requires translation!
-while the empire is happy = 
- # Requires translation!
-when between [amount] and [amount2] Happiness = 
- # Requires translation!
-when below [amount] Happiness = 
- # Requires translation!
-during the [era] = 
- # Requires translation!
-before the [era] = 
- # Requires translation!
-starting from the [era] = 
- # Requires translation!
-after discovering [tech] = 
- # Requires translation!
-before discovering [tech] = 
- # Requires translation!
-after adopting [policy] = 
- # Requires translation!
-before adopting [policy] = 
- # Requires translation!
-if this city has at least [amount] specialists = 
- # Requires translation!
-in cities where this religion has at least [amount] followers = 
- # Requires translation!
-with a garrison = 
- # Requires translation!
-for [mapUnitFilter] units = 
- # Requires translation!
-vs cities = 
- # Requires translation!
-vs [mapUnitFilter] units = 
- # Requires translation!
-when fighting units from a Civilization with more Cities than you = 
- # Requires translation!
-when attacking = 
- # Requires translation!
-when defending = 
- # Requires translation!
-when fighting in [tileFilter] tiles = 
- # Requires translation!
-on foreign continents = 
- # Requires translation!
-when adjacent to a [mapUnitFilter] unit = 
- # Requires translation!
-when above [amount] HP = 
- # Requires translation!
-when below [amount] HP = 
+Triggers victory = 승리를 유발함
+Incompatible with [policy/tech/promotion] = [policy/tech/promotion]과 동시 채택 불가
+Rebel units may spawn = 저항군이 출몰할 수 있음
+Can be purchased for [amount] [stat] [cityFilter] = [cityFilter]에서 [amount] [stat]으로 구매 가능
+Must not be next to [terrainFilter] = [terrainFilter] 옆에 있으면 안됨
+No defensive terrain penalty = 지형 방어 페널티 없음
+Upon capturing a city, receive [amount] times its [stat] production as [plunderableStat] immediately = 도시 점령시 도시가 생산하던 [stat]의 [amount]배에 해당하는 [plunderableStat] 획득
+[amount] XP gained from combat = 전투로 [amount] 경험치 획득
+when at war = 전쟁 중에
+when not at war = 전쟁 중이 아닐 때
+during a Golden Age = 황금기 동안
+while the empire is happy = 행복 상태일 때
+when between [amount] and [amount2] Happiness = 행복도 [amount] ~ [amount2] 사이일 때
+when below [amount] Happiness = 행복도 [amount] 이하일 때
+during the [era] = [era] 동안
+before the [era] = [era] 이전
+starting from the [era] = [era]부터 시작
+after discovering [tech] = [tech] 연구 이후
+before discovering [tech] = [tech] 연구 이전
+after adopting [policy] = [policy] 채택 이후
+before adopting [policy] = [policy] 채택 이전
+if this city has at least [amount] specialists = [amount]명 이상의 전문가가 있는 도시
+in cities where this religion has at least [amount] followers = 이 종교의 신도가 최고 [amount]명 이상인 도시
+with a garrison = 유닛 주둔중
+for [mapUnitFilter] units = [mapUnitFilter] 유닛
+vs cities = 도시 대항
+vs [mapUnitFilter] units = [mapUnitFilter] 대항
+when fighting units from a Civilization with more Cities than you = 자신보다 도시를 많이 가진 문명의 유닛과 싸울 때
+when attacking = 공격시
+when defending = 방어시
+when fighting in [tileFilter] tiles = [tileFilter]에서 전투시
+on foreign continents = 본토와 다른 대륙에서
+when adjacent to a [mapUnitFilter] unit = [mapUnitFilter]과 근접시
+when above [amount] HP = [amount]HP 이상일 때
+when below [amount] HP = [amount]HP 이하일 때
  # Requires translation!
 with [amount] to [amount2] neighboring [tileFilter] tiles = 
  # Requires translation!
 with [amount] to [amount2] neighboring [tileFilter] [tileFilter2] tiles = 
- # Requires translation!
-in [tileFilter] tiles = 
- # Requires translation!
-in [tileFilter] [tileFilter2] tiles = 
- # Requires translation!
-in tiles without [tileFilter] = 
+in [tileFilter] tiles = [tileFilter] 타일
+in [tileFilter] [tileFilter2] tiles = [tileFilter] [tileFilter2] 타일
+in tiles without [tileFilter] = [tileFilter]이 없는 타일
  # Requires translation!
 on water maps = 
- # Requires translation!
-in [regionType] Regions = 
- # Requires translation!
-in all except [regionType] Regions = 
- # Requires translation!
-Free [baseUnitFilter] found in the ruins = 
- # Requires translation!
-[amount] Free Social Policies = 
- # Requires translation!
-[amount] population in a random city = 
- # Requires translation!
-[amount] free random researchable Tech(s) from the [era] = 
- # Requires translation!
-Gain [amount] [stat] = 
+in [regionType] Regions = [regionType] 지역
+in all except [regionType] Regions = [regionType] 지형이 아닌 모든 타일
+Free [baseUnitFilter] found in the ruins = 고대 유적에서 [baseUnitFilter] 획득
+[amount] Free Social Policies = 무료 사회 정책 [amount]개
+[amount] population in a random city = 임의의 도시에 인구 [amount] 추가
+[amount] free random researchable Tech(s) from the [era] = [era]의 연구 가능한 임의의 기술 중 [amount]개 무료
+Gain [amount] [stat] = [amount] [stat] 획득
  # Requires translation!
 Gain [amount]-[amount2] [stat] = 
- # Requires translation!
-Gain enough Faith for a Pantheon = 
- # Requires translation!
-Gain enough Faith for [amount]% of a Great Prophet = 
- # Requires translation!
-Reveal up to [amount/'all'] [tileFilter] within a [amount] tile radius = 
- # Requires translation!
-From a randomly chosen tile [amount] tiles away from the ruins, reveal tiles up to [amount2] tiles away with [amount3]% chance = 
-This Unit gains [amount] XP = 이 유닛이 경험치 [amount]을 얻음
-This Unit upgrades for free including special upgrades = 이 유닛이 무료로 업그레이드됨
-This Unit gains the [promotion] promotion = 이 유닛이 [promotion] 승급을 얻음
-Hidden before founding a Pantheon = 종교관을 얻기 전에는 숨겨짐
-Hidden after founding a Pantheon = 종교관을 세운 후에는 숨겨짐
+Gain enough Faith for a Pantheon = 종교관 선택에 필요한 신앙 획득
+Gain enough Faith for [amount]% of a Great Prophet = 위대한 선지자 획득에 필요한 신앙의 [amount]% 획득
+Reveal up to [amount/'all'] [tileFilter] within a [amount] tile radius = [amount]타일 반경 내에 있는 [amount/'all'] [tileFilter] 시야 확보
+From a randomly chosen tile [amount] tiles away from the ruins, reveal tiles up to [amount2] tiles away with [amount3]% chance = 고대 유적에서 [amount]타일 떨어진 랜덤한 지점을 기준으로 [amount2]타일 반경 영역의 시야를 [amount3]% 확률로 확보
+This Unit gains [amount] XP = 유닛이 경험치 [amount]을 얻음
+This Unit upgrades for free including special upgrades = 유닛이 무료로 업그레이드됨
+This Unit gains the [promotion] promotion = 유닛이 [promotion] 승급을 얻음
+Hidden before founding a Pantheon = 종교관을 선택하기 전에는 숨겨짐
+Hidden after founding a Pantheon = 종교관을 선택한 후에는 숨겨짐
 Hidden after generating a Great Prophet = 위대한 선지자를 얻은 후에는 숨겨짐


### PR DESCRIPTION
### 한국어 역자분들께:
　안녕하세요, 저는 2020년부터 비정기적으로 Unciv 번역에 참여했습니다. 개발도 언어도 역사도 문명 시리즈에도 문외한인 완전 일반인인 제가 번역을 잡아서 항상 불안한 마음이 있었습니다. 
　_**Unciv 번역은, 설령 무근본 창작이라도 Unciv를 기준으로 해야한다는게 제 입장입니다.**_ 좋은(=온전한, 개발 속도와 맞춰가는 꾸준한) 번역을 누구보다 제가 원하는데도 나서는 사람은 극소수였고 그나마도 내킬때 뿐이었죠. 문명 팬덤의 규모나 Unciv의 위치를 생각하면 극히 자연스러운 일이니 "해줘" 할수도 없어서 직접 하면서 느낀 결론입니다. 번역으로 직접 항의 들어본건 아즈텍 몬테수마때 딱 한번 있는데 그건 제 뇌피셜로 성격반영한거라 지금까지도 반성하고 있습니다.
　현재 Unciv 대사는 원어가 아니고 음성도 없고 상황별 바리에이션도 없습니다. 개발에서 시스템을 만들어줘야하는 영역이라 번역 혼자서는 아무것도 할수없는 상황입니다. 이러한 기능 특히 음성을 넣지않는 이유로 아직까지도 높은 RAM 점유율을 추측해볼수 있고, 문5 음성은 2K에 저작권이 있어 막 가져다쓸수 없으며, 설령 팬메이드로 음성을 만들어도 바빌론 마야 등 고대 국가들은 확보 자체가 불가능하다는 점이 문제입니다. 또 Unciv 대사는 전부 Civ wiki의 영어해석을 그대로 긁어옵니다. 그게 영어정발인지는 모르겠지만 여튼 몇 가지 바리에이션 중에 하필 이걸 긁어왔냐 싶은게 꽤 많습니다. 문제는 마이너한 문명은 위 두가지가 시너지를 일으켜 대응되는 원작 대사 및 그 정발 번역을 아예 찾을수 없다는 겁니다. 애초에 원작인 문명 시리즈부터가 재미를 위해 고증을 언제나 희생합니다. 번역에 있어서 원어와 정발(번역)이 일치한다는 보장이 없고 고증이나 인기는 또 별개문제라는걸 문메폴한패가 증명하죠. [설마 조선 초기 세종의 한국어가 정말 현대 한국어였다고 생각하시진 않겠죠?](https://www.youtube.com/watch?v=uGDDyMWHJtg)
　얘기가 새버렸는데 Unciv에 비전문가가 적고 번역에 무관심하다는걸 말씀드리고 싶었고, 그 이유는 문5라는 대안이 있는 그들만의 리그이기 때문이라고 생각합니다. 모딩 안되던 시절에는 카페에 apk 수정하는 능력자도 있던데 중등교육을 이수한 한국인이라면 누구나 시간 들이면 99% 찍는 "번역"을 안하는건 작업이 재미가 없고 영어가 아쉽지 않아서죠. 저는 제 기억으론 한글번역 6~70% 시점부터 참여했는데, 거기까지 작업해주신 분들한텐 참 감사하다고 느꼈지만 작업하면서 솔직히 아무것도 아닌 일반인인 제가 봐도 이건 왜 놔뒀지 싶은 또는 눈뜨고 봐주기 힘든 부분 많았습니다. 그러다보니 결국 전체를 갈아엎는 식으로 작업했고 그 과정에서 제 주관이 반영된 부분도 있었습니다. 물론 누군가에게는 제 번역이 그렇겠지요. 근데 꼬우면 본인이 하세요. 저는 저만큼 번역에 마음써주시는 분이면 어떤 욕을 하든 얼마나 작업물을 갈아엎든 괜찮습니다.
　PR은 개인 블로그나 모임장소가 아닌 것을 알고 있습니다. 그러나 혹시라도 한국어를 번역하기 위해서 깃허브에 오시는 분들에게 긴 말씀을 남길 곳이 없어 적게 되었습니다. 저는 이번을 기점으로 번역에서 정말로 손을 뗍니다. Unciv 개발이 앞으로 순조롭게 진행되고 번역도 활발해지기를 바랍니다.

지도자 대사
- (이번에 손댄곳 전부) : 돈 안드는 범위에서 퀄높은 번역을 찾다가 문메폴 번역을 처음 참고함. 내가 전문가가 아니니 당연하지만 문메폴꺼가 문장력이 월등해서 작업이 즐거웠고, 사람들이 정발을 찾는 이유도 이해가 됐음.

하일레 셀라시에
- your humble servant=소생 : 네이버영어사전에는 경구(敬具)(옛날 편지의 끝맺음말); 소생, 우생(愚生)이라고 되어있음. I'm ~ 식으로 아무것도 아닌 개인이 단일 문장으로 말하는게 아니라 지도자 소개이니 짐/과인 등의 1인칭으로 보아야할것.

행복도 튜토리얼
- there are 2 main ways=(무시) : 알다시피 행복 수급방법은 지금만 해도 2가지보다 훨씬 많은데 Unciv wiki는 언제나 겉핥기였고 앞으로도 그럴테니 번역이 멋대로 추가하기보단 2 ways 만 덜어내면 딱 깔끔해지는 부분.

Lines from unique types
- when.. = ..할 때, / in.. = ..("에서" 는 생략) : in은 cityfilter 변수에 많이 쓰이는데 ~한 도시에서/도시의 이렇게 조사?가 달라짐. 반면에 when은 "때"로 끝내더라도 그대로 연결하든 어떤 조사를 붙이든 자유로움.