### PR TITLE
Added conditional for 'first civilization to research a tech'

### DIFF
--- a/core/src/com/unciv/models/ruleset/unique/Unique.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Unique.kt
@@ -42,7 +42,7 @@ class Unique(val text: String, val sourceObjectType: UniqueTarget? = null, val s
         if (state == null) return conditionals.isEmpty()
         if (state.ignoreConditionals) return true
         for (condition in conditionals) {
-            if (!conditionalApplies(condition, state)) return false
+            if (!conditionalApplies(condition, state, this)) return false
         }
         return true
     }
@@ -71,7 +71,8 @@ class Unique(val text: String, val sourceObjectType: UniqueTarget? = null, val s
 
     private fun conditionalApplies(
         condition: Unique,
-        state: StateForConditionals
+        state: StateForConditionals,
+        baseUnique: Unique
     ): Boolean {
 
         fun ruleset() = state.civInfo!!.gameInfo.ruleSet
@@ -174,6 +175,12 @@ class Unique(val text: String, val sourceObjectType: UniqueTarget? = null, val s
             UniqueType.ConditionalOnWaterMaps -> state.region?.continentID == -1
             UniqueType.ConditionalInRegionOfType -> state.region?.type == condition.params[0]
             UniqueType.ConditionalInRegionExceptOfType -> state.region?.type != condition.params[0]
+
+            UniqueType.ConditionalFirstCivToResearch -> baseUnique.sourceObjectType == UniqueTarget.Tech
+                    && state.civInfo != null
+                    && state.civInfo.gameInfo.civilizations.none {
+                it != state.civInfo && it.isMajorCiv() && it.hasTechOrPolicy(baseUnique.sourceObjectName!!)
+            }
 
             else -> false
         }

--- a/core/src/com/unciv/models/ruleset/unique/Unique.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Unique.kt
@@ -42,7 +42,7 @@ class Unique(val text: String, val sourceObjectType: UniqueTarget? = null, val s
         if (state == null) return conditionals.isEmpty()
         if (state.ignoreConditionals) return true
         for (condition in conditionals) {
-            if (!conditionalApplies(condition, state, this)) return false
+            if (!conditionalApplies(condition, state)) return false
         }
         return true
     }
@@ -71,8 +71,7 @@ class Unique(val text: String, val sourceObjectType: UniqueTarget? = null, val s
 
     private fun conditionalApplies(
         condition: Unique,
-        state: StateForConditionals,
-        baseUnique: Unique
+        state: StateForConditionals
     ): Boolean {
 
         fun ruleset() = state.civInfo!!.gameInfo.ruleSet
@@ -176,10 +175,10 @@ class Unique(val text: String, val sourceObjectType: UniqueTarget? = null, val s
             UniqueType.ConditionalInRegionOfType -> state.region?.type == condition.params[0]
             UniqueType.ConditionalInRegionExceptOfType -> state.region?.type != condition.params[0]
 
-            UniqueType.ConditionalFirstCivToResearch -> baseUnique.sourceObjectType == UniqueTarget.Tech
+            UniqueType.ConditionalFirstCivToResearch -> sourceObjectType == UniqueTarget.Tech
                     && state.civInfo != null
                     && state.civInfo.gameInfo.civilizations.none {
-                it != state.civInfo && it.isMajorCiv() && it.hasTechOrPolicy(baseUnique.sourceObjectName!!)
+                it != state.civInfo && it.isMajorCiv() && it.hasTechOrPolicy(sourceObjectName!!)
             }
 
             else -> false

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -29,6 +29,8 @@ object UniqueTriggerActivation {
             if (tile != null) Random(tile.position.toString().hashCode())
             else Random(-550) // Very random indeed
 
+        if (!unique.conditionalsApply(StateForConditionals(civInfo, cityInfo))) return false
+
         @Suppress("NON_EXHAUSTIVE_WHEN")  // Yes we're not treating all types here
         when (unique.type) {
             OneTimeFreeUnit -> {

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -584,7 +584,7 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
     ConditionalOnWaterMaps("on water maps", UniqueTarget.Conditional),
     ConditionalInRegionOfType("in [regionType] Regions", UniqueTarget.Conditional),
     ConditionalInRegionExceptOfType("in all except [regionType] Regions", UniqueTarget.Conditional),
-    ConditionalFirstCivToResearch("for the first Civilization to research this", UniqueTarget.Conditional),
+    ConditionalFirstCivToResearch("if no other civilization has researched this", UniqueTarget.Conditional),
 
     //endregion
 

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -549,7 +549,8 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
     ConditionalDuringEra("during the [era]", UniqueTarget.Conditional),
     ConditionalBeforeEra("before the [era]", UniqueTarget.Conditional),
     ConditionalStartingFromEra("starting from the [era]", UniqueTarget.Conditional),
-    
+
+    ConditionalFirstCivToResearch("if no other Civilization has researched this", UniqueTarget.Conditional),
     ConditionalTech("after discovering [tech]", UniqueTarget.Conditional),
     ConditionalNoTech("before discovering [tech]", UniqueTarget.Conditional),
     ConditionalPolicy("after adopting [policy]", UniqueTarget.Conditional),
@@ -584,7 +585,6 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
     ConditionalOnWaterMaps("on water maps", UniqueTarget.Conditional),
     ConditionalInRegionOfType("in [regionType] Regions", UniqueTarget.Conditional),
     ConditionalInRegionExceptOfType("in all except [regionType] Regions", UniqueTarget.Conditional),
-    ConditionalFirstCivToResearch("if no other Civilization has researched this", UniqueTarget.Conditional),
 
     //endregion
 

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -584,7 +584,7 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
     ConditionalOnWaterMaps("on water maps", UniqueTarget.Conditional),
     ConditionalInRegionOfType("in [regionType] Regions", UniqueTarget.Conditional),
     ConditionalInRegionExceptOfType("in all except [regionType] Regions", UniqueTarget.Conditional),
-    ConditionalFirstCivToResearch("if no other civilization has researched this", UniqueTarget.Conditional),
+    ConditionalFirstCivToResearch("if no other Civilization has researched this", UniqueTarget.Conditional),
 
     //endregion
 

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -584,6 +584,7 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
     ConditionalOnWaterMaps("on water maps", UniqueTarget.Conditional),
     ConditionalInRegionOfType("in [regionType] Regions", UniqueTarget.Conditional),
     ConditionalInRegionExceptOfType("in all except [regionType] Regions", UniqueTarget.Conditional),
+    ConditionalFirstCivToResearch("for the first Civilization to research this", UniqueTarget.Conditional),
 
     //endregion
 

--- a/docs/uniques.md
+++ b/docs/uniques.md
@@ -1323,6 +1323,9 @@ Example: "<starting from the [Ancient era]>"
 
 Applicable to: Conditional
 
+#### <if no other Civilization has researched this>
+Applicable to: Conditional
+
 #### <after discovering [tech]>
 Example: "<after discovering [Agriculture]>"
 
@@ -1437,9 +1440,6 @@ Applicable to: Conditional
 #### <in all except [regionType] Regions>
 Example: "<in all except [Hybrid] Regions>"
 
-Applicable to: Conditional
-
-#### <for the first Civilization to research this>
 Applicable to: Conditional
 
 ## Deprecated uniques

--- a/docs/uniques.md
+++ b/docs/uniques.md
@@ -1439,6 +1439,9 @@ Example: "<in all except [Hybrid] Regions>"
 
 Applicable to: Conditional
 
+#### <for the first Civilization to research this>
+Applicable to: Conditional
+
 ## Deprecated uniques
  - "[stats] per turn from cities before [tech/policy]" - Deprecated as of 3.18.14, replace with "[stats] [in all cities] <before discovering [tech]> OR [stats] [in all cities] <before adopting [policy]>"
  - "[stats] from every Wonder" - Deprecated as of 3.19.1, replace with "[stats] from every [Wonder]"


### PR DESCRIPTION
Techs with these kinds of conditional bonuses exist in Civ IV and VI
Phrasing also allows long-term benefits for techs which no one else has researched, like "[+10%] Strength <if no other Civilization has researched this>"
A nicer sounding but more limiting phrasing is "<for the first civilization to research this>", but since we don't currently hold information on who first researched each tech, that could confuse players that this will continue to work even after others have researched it because we were the first.