### PR TITLE
Sea Unit can't capture Land Civilian (and vice versa)

### DIFF
--- a/core/src/com/unciv/logic/automation/BattleHelper.kt
+++ b/core/src/com/unciv/logic/automation/BattleHelper.kt
@@ -48,7 +48,7 @@ object BattleHelper {
                         // capture enemy units since we can't move through them!
                         && !it.canCivPassThrough(unit.civInfo)
                         // Land Unit can't capture Naval and vice versa
-                        && (unit.type.isLandUnit() && it.isWater || unit.type.isWaterUnit() && it.isLand)
+                        && !(unit.type.isLandUnit() && it.isWater || unit.type.isWaterUnit() && it.isLand)
             }
 
         val rangeOfAttack = unit.getRange()

--- a/core/src/com/unciv/logic/automation/BattleHelper.kt
+++ b/core/src/com/unciv/logic/automation/BattleHelper.kt
@@ -47,6 +47,8 @@ object BattleHelper {
                         // DO NOT use "!unit.movement.canPassThrough(it)" since then we won't be able to
                         // capture enemy units since we can't move through them!
                         && !it.canCivPassThrough(unit.civInfo)
+                        // Land Unit can't capture Naval and vice versa
+                        && (unit.type.isLandUnit() && it.isWater || unit.type.isWaterUnit() && it.isLand)
             }
 
         val rangeOfAttack = unit.getRange()


### PR DESCRIPTION
Fix #6111 without changing all the combat rules.
Add in a check to prevent capturing Civilians you can't reach
Note if they were defended, still won't capture since won't move on to tile