### PR TITLE
Make tileInfo.terrainFeatures immutable

### DIFF
--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -712,14 +712,14 @@ object Battle {
         }
         tile.roadStatus = RoadStatus.None
         if (tile.isLand && !tile.isImpassible() && !tile.terrainFeatures.contains("Fallout")) {
-            if (tile.terrainFeatures.any { attacker.getCivInfo().gameInfo.ruleSet.terrains[it]!!.hasUnique(UniqueType.ResistsNukes) }) {
-                if (Random().nextFloat() < 0.25f) {
-                    tile.terrainFeatures.removeAll { attacker.getCivInfo().gameInfo.ruleSet.terrains[it]!!.hasUnique(UniqueType.DestroyableByNukes) }
-                    tile.terrainFeatures.add("Fallout")
-                }
-            } else if (Random().nextFloat() < 0.5f) {
-                tile.terrainFeatures.removeAll { attacker.getCivInfo().gameInfo.ruleSet.terrains[it]!!.hasUnique(UniqueType.DestroyableByNukes) }
-                tile.terrainFeatures.add("Fallout")
+            val ruleset = tile.ruleset
+            val destructionChance = if (tile.hasUnique(UniqueType.ResistsNukes)) 0.25f
+            else 0.5f
+            if (Random().nextFloat() < destructionChance) {
+                for (terrainFeature in tile.terrainFeatures)
+                    if (ruleset.terrains[terrainFeature]!!.hasUnique(UniqueType.DestroyableByNukes))
+                        tile.removeTerrainFeature(terrainFeature)
+                tile.addTerrainFeature("Fallout")
             }
         }
     }

--- a/core/src/com/unciv/logic/city/CityInfo.kt
+++ b/core/src/com/unciv/logic/city/CityInfo.kt
@@ -124,7 +124,7 @@ class CityInfo {
                 "Remove $it"
             )
         })
-            tile.terrainFeatures.remove(terrainFeature)
+            tile.removeTerrainFeature(terrainFeature)
 
         tile.improvement = null
         tile.improvementInProgress = null

--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -650,7 +650,7 @@ class MapUnit {
                     if (removedFeatureObject != null && removedFeatureObject.hasUnique(UniqueType.ProductionBonusWhenRemoved)) {
                         tryProvideProductionToClosestCity(removedFeatureName)
                     }
-                    tile.terrainFeatures.remove(removedFeatureName)
+                    tile.removeTerrainFeature(removedFeatureName)
                 }
             }
             tile.improvementInProgress == RoadStatus.Road.name -> tile.roadStatus = RoadStatus.Road

--- a/core/src/com/unciv/logic/map/TileMap.kt
+++ b/core/src/com/unciv/logic/map/TileMap.kt
@@ -447,7 +447,7 @@ class TileMap {
     fun removeMissingTerrainModReferences(ruleSet: Ruleset) {
         for (tile in this.values) {
             for (terrainFeature in tile.terrainFeatures.filter { !ruleSet.terrains.containsKey(it) })
-                tile.terrainFeatures.remove(terrainFeature)
+                tile.removeTerrainFeature(terrainFeature)
             if (tile.resource != null && !ruleSet.tileResources.containsKey(tile.resource!!))
                 tile.resource = null
             if (tile.improvement != null && !ruleSet.tileImprovements.containsKey(tile.improvement!!))

--- a/core/src/com/unciv/logic/map/mapgenerator/NaturalWonderGenerator.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/NaturalWonderGenerator.kt
@@ -167,7 +167,7 @@ class NaturalWonderGenerator(val ruleset: Ruleset, val randomness: MapGeneration
     }
 
     private fun clearTile(tile: TileInfo){
-        tile.terrainFeatures.clear()
+        tile.terrainFeatures = listOf()
         tile.resource = null
         tile.improvement = null
         tile.setTerrainTransients()

--- a/core/src/com/unciv/ui/civilopedia/CivilopediaCategories.kt
+++ b/core/src/com/unciv/ui/civilopedia/CivilopediaCategories.kt
@@ -31,7 +31,7 @@ object CivilopediaImageGetters {
                 tileInfo.baseTerrain = terrain.turnsInto ?: Constants.grassland
             }
             TerrainType.TerrainFeature -> {
-                tileInfo.terrainFeatures.add(terrain.name)
+                tileInfo.addTerrainFeature(terrain.name)
                 tileInfo.baseTerrain =
                     if (terrain.occursOn.isEmpty() || terrain.occursOn.contains(Constants.grassland))
                         Constants.grassland

--- a/core/src/com/unciv/ui/mapeditor/MapEditorOptionsTable.kt
+++ b/core/src/com/unciv/ui/mapeditor/MapEditorOptionsTable.kt
@@ -83,7 +83,7 @@ class MapEditorOptionsTable(val mapEditorScreen: MapEditorScreen): Table(BaseScr
         terrainFeaturesTable.add(getHex(ImageGetter.getRedCross(50f, 0.6f)).apply {
             onClick {
                 tileAction = {
-                    it.terrainFeatures.clear()
+                    it.terrainFeatures = listOf()
                     it.naturalWonder = null
                     it.hasBottomRiver = false
                     it.hasBottomLeftRiver = false
@@ -305,7 +305,7 @@ class MapEditorOptionsTable(val mapEditorScreen: MapEditorScreen): Table(BaseScr
                     tileInfo.baseTerrain =
                         if (terrainObject.occursOn.isNotEmpty()) terrainObject.occursOn.first()
                         else ruleset.terrains.values.first { it.type == TerrainType.Land }.name
-                    tileInfo.terrainFeatures.add(terrain)
+                    tileInfo.addTerrainFeature(terrain)
                 }
 
                 tileInfo.resource = resource.name
@@ -326,7 +326,7 @@ class MapEditorOptionsTable(val mapEditorScreen: MapEditorScreen): Table(BaseScr
                     terrain.occursOn.isNotEmpty() -> terrain.occursOn.first()
                     else -> "Grassland"
                 }
-                tileInfo.terrainFeatures.add(terrain.name)
+                tileInfo.addTerrainFeature(terrain.name)
             } else tileInfo.baseTerrain = terrain.name
             val group = makeTileGroup(tileInfo)
 
@@ -336,7 +336,7 @@ class MapEditorOptionsTable(val mapEditorScreen: MapEditorScreen): Table(BaseScr
                     when (terrain.type) {
                         TerrainType.TerrainFeature -> {
                             if (terrain.occursOn.contains(it.getLastTerrain().name))
-                                it.terrainFeatures.add(terrain.name)
+                                it.addTerrainFeature(terrain.name)
                         }
                         TerrainType.NaturalWonder -> it.naturalWonder = terrain.name
                         else -> it.baseTerrain = terrain.name

--- a/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
@@ -626,7 +626,7 @@ object UnitActions {
                 action = {
                     val unitTile = unit.getTile()
                     for (terrainFeature in tile.terrainFeatures.filter { unitTile.ruleset.tileImprovements.containsKey("Remove $it") })
-                        unitTile.terrainFeatures.remove(terrainFeature)// remove forest/jungle/marsh
+                        unitTile.removeTerrainFeature(terrainFeature)// remove forest/jungle/marsh
                     unitTile.improvement = improvementName
                     unitTile.improvementInProgress = null
                     unitTile.turnsToImprovement = 0

--- a/tests/src/com/unciv/logic/map/TileImprovementConstructionTests.kt
+++ b/tests/src/com/unciv/logic/map/TileImprovementConstructionTests.kt
@@ -134,7 +134,7 @@ class TileImprovementConstructionTests {
     @Test
     fun terraceFarmCanNOTBeBuiltOnBonus() {
         val tile = getTile()
-        tile.terrainFeatures.add("Hill")
+        tile.addTerrainFeature("Hill")
         tile.resource = "Sheep"
         tile.setTransients()
         civInfo.civName = "Inca"

--- a/tests/src/com/unciv/logic/map/TileMapTests.kt
+++ b/tests/src/com/unciv/logic/map/TileMapTests.kt
@@ -87,8 +87,7 @@ class TileMapTests {
         tile1.baseTerrain = Constants.hill
         tile1.setTerrainTransients()
         tile2.baseTerrain = Constants.grassland
-        tile2.terrainFeatures.clear()
-        tile2.terrainFeatures.add(Constants.forest)
+        tile2.terrainFeatures = listOf(Constants.forest)
         tile2.setTerrainTransients()
         tile3.baseTerrain = Constants.coast
         tile3.setTerrainTransients()
@@ -115,8 +114,7 @@ class TileMapTests {
     @Test
     fun canSeeMountainFromForestOverHills() {
         tile1.baseTerrain = Constants.grassland
-        tile1.terrainFeatures.clear()
-        tile1.terrainFeatures.add(Constants.forest)
+        tile1.terrainFeatures = listOf(Constants.forest)
         tile1.setTerrainTransients()
         tile2.baseTerrain = Constants.hill
         tile2.setTerrainTransients()
@@ -133,8 +131,7 @@ class TileMapTests {
         tile1.baseTerrain = Constants.hill
         tile1.setTerrainTransients()
         tile2.baseTerrain = Constants.grassland
-        tile2.terrainFeatures.clear()
-        tile2.terrainFeatures.add(Constants.forest)
+        tile2.terrainFeatures = listOf(Constants.forest)
         tile2.setTerrainTransients()
         tile3.baseTerrain = Constants.hill
         tile3.setTerrainTransients()
@@ -175,12 +172,10 @@ class TileMapTests {
     @Test
     fun canNOTSeeOutThroughForest() {
         tile1.baseTerrain = Constants.grassland
-        tile1.terrainFeatures.clear()
-        tile1.terrainFeatures.add(Constants.forest)
+        tile1.terrainFeatures = listOf(Constants.forest)
         tile1.setTerrainTransients()
         tile2.baseTerrain = Constants.grassland
-        tile2.terrainFeatures.clear()
-        tile2.terrainFeatures.add(Constants.forest)
+        tile2.terrainFeatures = listOf(Constants.forest)
         tile2.setTerrainTransients()
         tile3.baseTerrain = Constants.grassland
         tile3.setTerrainTransients()
@@ -195,8 +190,7 @@ class TileMapTests {
         tile1.baseTerrain = Constants.coast
         tile1.setTerrainTransients()
         tile2.baseTerrain = Constants.grassland
-        tile2.terrainFeatures.clear()
-        tile2.terrainFeatures.add(Constants.jungle)
+        tile2.terrainFeatures = listOf(Constants.jungle)
         tile2.setTerrainTransients()
         tile3.baseTerrain = Constants.coast
         tile3.setTerrainTransients()

--- a/tests/src/com/unciv/logic/map/UnitMovementAlgorithmsTests.kt
+++ b/tests/src/com/unciv/logic/map/UnitMovementAlgorithmsTests.kt
@@ -54,7 +54,7 @@ class UnitMovementAlgorithmsTests {
     fun canPassThroughPassableTerrains() {
         for (terrain in ruleSet.terrains.values) {
             tile.baseTerrain = terrain.name
-            tile.terrainFeatures.clear()
+            tile.terrainFeatures = listOf()
             tile.setTransients()
 
             unit.baseUnit = BaseUnit().apply { unitType = "Sword"; ruleset = ruleSet }
@@ -112,8 +112,7 @@ class UnitMovementAlgorithmsTests {
     @Test
     fun canNOTEnterIce() {
         tile.baseTerrain = Constants.ocean
-        tile.terrainFeatures.clear()
-        tile.terrainFeatures.add(Constants.ice)
+        tile.terrainFeatures = listOf(Constants.ice)
         tile.setTransients()
 
         for (type in ruleSet.unitTypes) {

--- a/tests/src/com/unciv/uniques/GlobalUniquesTests.kt
+++ b/tests/src/com/unciv/uniques/GlobalUniquesTests.kt
@@ -54,7 +54,7 @@ class GlobalUniquesTests {
         tile.ruleset = ruleSet
         tile.baseTerrain = terrain
         for (feature in features) {
-            tile.terrainFeatures.add(feature)
+            tile.addTerrainFeature(feature)
         }
         tile.tileMap = tileMap
         tile.position = position


### PR DESCRIPTION
Step 1 of saving terrain features as a transient - move all terrainFeature changes to new 'addTerrainFeature' and 'removeTerrainFeature' functions

This also included slight rewriting of functions for clarity, but NO functional changes.
Even though there's some logic that I would definitely change, this PR isn't the place for that.