### PR TITLE
Reorganized the way city states grant resources & rounded a float to an int

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -237,15 +237,20 @@ Hostile =
 Irrational = 
 Personality = 
 Influence = 
+
+Ally: [civilization] with [amount] Influence = 
 Reach 30 for friendship. = 
 Reach highest influence above 60 for alliance. = 
 When Friends: = 
 When Allies: = 
 The unique luxury is one of: = 
-
 Demand Tribute = 
 Tribute Willingness = 
 At least 0 to take gold, at least 30 and size 4 city for worker = 
+Take [amount] gold (-15 Influence) = 
+Take worker (-50 Influence) = 
+[civName] is afraid of your military power! = 
+
 Major Civ = 
 No Cities = 
 Base value = 
@@ -259,9 +264,7 @@ Influence below -30 =
 Military Rank = 
 Military near City-State = 
 Sum: = 
-Take [amount] gold (-15 Influence) = 
-Take worker (-50 Influence) = 
-[civName] is afraid of your military power! = 
+
 
 
 # Trades

--- a/core/src/com/unciv/logic/civilization/CityStateFunctions.kt
+++ b/core/src/com/unciv/logic/civilization/CityStateFunctions.kt
@@ -4,6 +4,7 @@ import com.unciv.logic.automation.NextTurnAutomation
 import com.unciv.logic.civilization.diplomacy.*
 import com.unciv.models.metadata.GameSpeed
 import com.unciv.models.ruleset.Ruleset
+import com.unciv.models.ruleset.tile.ResourceSupplyList
 import com.unciv.models.ruleset.unique.Unique
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.stats.Stat
@@ -650,5 +651,14 @@ class CityStateFunctions(val civInfo: CivilizationInfo) {
             )
         }
     }
-
+    
+    fun getCityStateResourcesForAlly(): ResourceSupplyList {
+        val newDetailedCivResources = ResourceSupplyList()
+        for (city in civInfo.cities) {
+            for (resourceSupply in city.getCityResources())
+                if (resourceSupply.amount > 0) // IGNORE the fact that they consume their own resources - #4769
+                    newDetailedCivResources.add(resourceSupply.resource, resourceSupply.amount, "City-States")
+        }
+        return newDetailedCivResources
+    }
 }

--- a/core/src/com/unciv/logic/civilization/CivInfoTransientUpdater.kt
+++ b/core/src/com/unciv/logic/civilization/CivInfoTransientUpdater.kt
@@ -172,14 +172,12 @@ class CivInfoTransientUpdater(val civInfo: CivilizationInfo) {
             var resourceBonusPercentage = 1f
             for (unique in civInfo.getMatchingUniques(UniqueType.CityStateResources))
                 resourceBonusPercentage += unique.params[0].toFloat() / 100
-            for (city in civInfo.getKnownCivs().filter { it.getAllyCiv() == civInfo.civName }
-                .flatMap { it.cities }) {
-                for (resourceSupply in city.getCityResources())
-                    if (resourceSupply.origin != "Buildings") // IGNORE the fact that they consume their own resources - #4769
-                        newDetailedCivResources.add(
-                            resourceSupply.resource,
-                            (resourceSupply.amount * resourceBonusPercentage).toInt(), "City-States"
-                        )
+            for (cityStateAlly in civInfo.getKnownCivs().filter { it.getAllyCiv() == civInfo.civName }) {
+                for (resource in CityStateFunctions(cityStateAlly).getCityStateResourcesForAlly()) {
+                    newDetailedCivResources.add(
+                        resource.apply { amount = (amount * resourceBonusPercentage).toInt() }
+                    )
+                }
             }
         }
 

--- a/core/src/com/unciv/ui/trade/DiplomacyScreen.kt
+++ b/core/src/com/unciv/ui/trade/DiplomacyScreen.kt
@@ -174,9 +174,10 @@ class DiplomacyScreen(val viewingCiv:CivilizationInfo): BaseScreen() {
         otherCiv.updateAllyCivForCityState()
         val ally = otherCiv.getAllyCiv()
         if (ally != null) {
-            val allyString = "{Ally}: {$ally} {Influence}: ".tr() +
-                    otherCiv.getDiplomacyManager(ally).influence.toInt().toString()
-            diplomacyTable.add(allyString.toLabel()).row()
+            val allyInfluence = otherCiv.getDiplomacyManager(ally).influence.toInt()
+            diplomacyTable
+                .add("Ally: [$ally] with [$allyInfluence] Influence".toLabel())
+                .row()
         }
 
         val protectors = otherCiv.getProtectorCivs()

--- a/core/src/com/unciv/ui/trade/DiplomacyScreen.kt
+++ b/core/src/com/unciv/ui/trade/DiplomacyScreen.kt
@@ -146,7 +146,9 @@ class DiplomacyScreen(val viewingCiv:CivilizationInfo): BaseScreen() {
         if (otherCiv.detailedCivResources.any { it.resource.resourceType != ResourceType.Bonus }) {
             val resourcesTable = Table()
             resourcesTable.add("{Resources}:  ".toLabel()).padRight(10f)
-            for (supplyList in otherCiv.detailedCivResources) {
+            val cityStateResources = CityStateFunctions(otherCiv)
+                .getCityStateResourcesForAlly()
+            for (supplyList in cityStateResources) {
                 if (supplyList.resource.resourceType == ResourceType.Bonus)
                     continue
                 val name = supplyList.resource.name
@@ -173,7 +175,7 @@ class DiplomacyScreen(val viewingCiv:CivilizationInfo): BaseScreen() {
         val ally = otherCiv.getAllyCiv()
         if (ally != null) {
             val allyString = "{Ally}: {$ally} {Influence}: ".tr() +
-                    otherCiv.getDiplomacyManager(ally).influence.toString()
+                    otherCiv.getDiplomacyManager(ally).influence.toInt().toString()
             diplomacyTable.add(allyString.toLabel()).row()
         }
 


### PR DESCRIPTION
Basically fixes #6168 by implementing all its ideas. Also fixes that the resources of the city-state are actually duplicated instead of just ignoring their buildings in the calculation.

<details> <summary> Pics: </summary>

Before:
![image](https://user-images.githubusercontent.com/71121390/154998622-b63bdcd4-9229-4edb-b635-023f6d0bc975.png)


After:
![image](https://user-images.githubusercontent.com/71121390/154999799-c314cfae-a1f8-4a4e-9e7f-6977e86ba054.png)

The -1 has disappeared as this resource was from a horseman.

</details>