### PR TITLE
Fix Navies capturing Land Civilians

### DIFF
--- a/core/src/com/unciv/logic/automation/BattleHelper.kt
+++ b/core/src/com/unciv/logic/automation/BattleHelper.kt
@@ -39,16 +39,16 @@ object BattleHelper {
     ): ArrayList<AttackableTile> {
         val tilesWithEnemies = (tilesToCheck ?: unit.civInfo.viewableTiles)
             .filter { containsAttackableEnemy(it, MapUnitCombatant(unit)) }
+            // Filter out invalid Civilian Captures
             .filterNot {
                 val mapCombatant = Battle.getMapCombatantOfTile(it)
                 // IF all of these are true, THEN the action we'll be taking is in fact CAPTURING the civilian.
                 unit.baseUnit.isMelee() && mapCombatant is MapUnitCombatant && mapCombatant.unit.isCivilian()
                         // If we can't pass though that tile, we can't capture the civilian "remotely"
-                        // DO NOT use "!unit.movement.canPassThrough(it)" since then we won't be able to
-                        // capture enemy units since we can't move through them!
-                        && (!it.canCivPassThrough(unit.civInfo)
-                        // Naval Melee Unit can't capture Land Civilian
-                        || unit.type.isWaterUnit() && it.isLand)
+                        // Can use "unit.movement.canPassThrough(it)" now that we can move through
+                        // unguarded Civilian tiles. And this catches Naval trying to capture Land
+                        // Civilians or Land attacking Water Civilians it can't Embark on
+                        && !unit.movement.canPassThrough(it)
             }
 
         val rangeOfAttack = unit.getRange()

--- a/core/src/com/unciv/logic/automation/BattleHelper.kt
+++ b/core/src/com/unciv/logic/automation/BattleHelper.kt
@@ -46,9 +46,9 @@ object BattleHelper {
                         // If we can't pass though that tile, we can't capture the civilian "remotely"
                         // DO NOT use "!unit.movement.canPassThrough(it)" since then we won't be able to
                         // capture enemy units since we can't move through them!
-                        && !it.canCivPassThrough(unit.civInfo)
-                        // Land Unit can't capture Naval and vice versa
-                        && !(unit.type.isLandUnit() && it.isWater || unit.type.isWaterUnit() && it.isLand)
+                        && (!it.canCivPassThrough(unit.civInfo)
+                        // Naval Melee Unit can't capture Land Civilian
+                        || unit.type.isWaterUnit() && it.isLand)
             }
 
         val rangeOfAttack = unit.getRange()


### PR DESCRIPTION
Logic fix. Change the check to use !unit.movement.canPassThrough(it) since that respects where the unit can actually go.
For now remove all logic about Land Units trying to capture Naval Civilians since potentially they can be Embarked and just Move onto the Civilian tile, thus capturing them. Thinking through proper consistent rule