### PR TITLE
Fresh water unit tests

### DIFF
--- a/core/src/com/unciv/logic/map/TileInfo.kt
+++ b/core/src/com/unciv/logic/map/TileInfo.kt
@@ -821,12 +821,17 @@ open class TileInfo {
         isWater = getBaseTerrain().type == TerrainType.Water
         isLand = getBaseTerrain().type == TerrainType.Land
         isOcean = baseTerrain == Constants.ocean
+        setTerrainFeatureTransients()
 
         // Resource amounts missing - Old save or bad mapgen?
         if (::tileMap.isInitialized && resource != null && tileResource.resourceType == ResourceType.Strategic && resourceAmount == 0) {
             // Let's assume it's a small deposit
             setTileResource(tileResource, majorDeposit = false)
         }
+    }
+
+    private fun setTerrainFeatureTransients() {
+        terrainFeatureObjects = terrainFeatures.mapNotNull { ruleset.terrains[it] }
     }
 
     fun setUnitTransients(unitCivTransients: Boolean) {
@@ -841,7 +846,7 @@ open class TileInfo {
     fun stripUnits() {
         for (unit in this.getUnits()) removeUnit(unit)
     }
-    
+
     fun setTileResource(newResource: TileResource, majorDeposit: Boolean = false) {
         resource = newResource.name
 
@@ -869,15 +874,15 @@ open class TileInfo {
             }
         }
     }
-    
+
     fun setTerrainFeatures(terrainFeatureList:List<String>){
         terrainFeatures = terrainFeatureList
-        terrainFeatureObjects = terrainFeatureList.mapNotNull { ruleset.terrains[it] }
+        setTerrainFeatureTransients()
     }
-    
+
     fun addTerrainFeature(terrainFeature:String) =
         setTerrainFeatures(ArrayList(terrainFeatures).apply { add(terrainFeature) })
-    
+
     fun removeTerrainFeature(terrainFeature: String) =
         setTerrainFeatures(ArrayList(terrainFeatures).apply { remove(terrainFeature) })
 

--- a/core/src/com/unciv/logic/map/TileInfo.kt
+++ b/core/src/com/unciv/logic/map/TileInfo.kt
@@ -493,7 +493,7 @@ open class TileInfo {
         // Rivers are odd, as they aren't technically part of any specific tile but still count towards adjacency
         if (terrainFilter == "River") return isAdjacentToRiver()
         if (terrainFilter == Constants.freshWater && isAdjacentToRiver()) return true
-        return neighbors.any { neighbor -> neighbor.matchesFilter(terrainFilter) }
+        return (neighbors + this).any { neighbor -> neighbor.matchesFilter(terrainFilter) }
     }
 
     /** Without regards to what CivInfo it is, a lot of the checks are just for the improvement on the tile.

--- a/tests/src/com/unciv/logic/map/FreshWaterTests.kt
+++ b/tests/src/com/unciv/logic/map/FreshWaterTests.kt
@@ -1,0 +1,41 @@
+package com.unciv.logic.map
+
+import com.badlogic.gdx.math.Vector2
+import com.unciv.Constants
+import com.unciv.logic.MapSaver
+import com.unciv.models.ruleset.Ruleset
+import com.unciv.models.ruleset.RulesetCache
+import com.unciv.testing.GdxTestRunner
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(GdxTestRunner::class)
+class FreshWaterTests {
+    private var map = TileMap()
+    private var ruleSet = Ruleset()
+
+    companion object {
+        private const val testingMap = "H4sIAAAAAAAA/52Sv07DMBDGXyUP4A4NYrmRQsUQCRRQl6rDoRzkVCeO7EtpsPLuOMqWpMRisWT7d993/3yFzStarEjIOvDSNQRPVSOdCj9v/EPgLRbcOkjVNxdSwr0qib9KgTtVhzjYtU5M1asPdJS3mhwJ7PiSHJJNcsCatcZeCWvK2Akc/cC9k7XINTwG2kqvfGMcC5sa/BU2W9WFY1T8kxzAdS5KLEboGsVEZb5JhxrTJVLJeN0TSmvJwfEFHbvTRGEQmMRneCa32MxIo+cwrKnPdu4TH37LegKtM2Mey61VJboHI2EJM/qUnC9kQWxLS51YEciHxb6pEJNmRL3j7JYzmfV0r40pkkaHx9kKjEv0L6FT/wsygYGG+gMAAA=="
+        private val shouldHaveFreshWater = setOf(Vector2(-1f,-1f),Vector2(1f,1f),Vector2(-2f,-2f),Vector2(2f,2f),Vector2(-1f,-2f),Vector2(1f,2f),Vector2(1f,-1f),Vector2(-1f,1f),Vector2(2f,1f),Vector2(-2f,-1f))
+    }
+
+    @Before
+    fun initTheWorld() {
+        RulesetCache.loadRulesets()
+        ruleSet = RulesetCache.getVanillaRuleset()
+        map = MapSaver.mapFromSavedString(testingMap, false)
+        map.setTransients(ruleSet, false)
+    }
+
+    @Test
+    fun isAdjacentToFreshWater() {
+        for (tile in map.values) {
+            val isFresh = tile.isAdjacentTo(Constants.freshWater)
+            val shouldFresh = tile.position in shouldHaveFreshWater
+            Assert.assertFalse("Tile $tile has fresh water but should not", isFresh && !shouldFresh)
+            Assert.assertFalse("Tile $tile should have fresh water but doesn't", !isFresh && shouldFresh)
+        }
+    }
+}


### PR DESCRIPTION
Follow-up to ideas presented in #6219, solves #6186. Nevertheless, please evaluate carefully (actual play testing welcome) - the PR is meant more as idea to further the discussion. I did playtest just a little setup specifically to check the Petra issue.

To consider:
- the setTerrainFeatureTransients thingy is needed so the isAdjacentTo function actually works in that unit test; I believe the issue is likely to affect regular gameplay too (see linked issues), therefore this approach.
- the actual Petra fix is just "the seventh (day, son, seal, samurai, tile)" -  I see no more reason why isAdjacentTo shouldn't also check the center tile, but I might be wrong.
- The test is meant to be expandable, but I lack ideas. The mini-map it sets up is the one from #6219 with all Wheat removed. e.g. would it be worth it to actually test farm buildable on hill with fresh water?