### PR TITLE
Fix control-key bindings

### DIFF
--- a/core/src/com/unciv/ui/utils/YesNoPopup.kt
+++ b/core/src/com/unciv/ui/utils/YesNoPopup.kt
@@ -12,11 +12,11 @@ import com.unciv.UncivGame
  * @param restoreDefault A lambda to execute when "No" is chosen
  */
 open class YesNoPopup (
-    question: String,
-    action: ()->Unit,
-    screen: BaseScreen = UncivGame.Current.worldScreen,
-    restoreDefault: ()->Unit = {}
-        ) : Popup(screen) {
+        question: String,
+        action: ()->Unit,
+        screen: BaseScreen = UncivGame.Current.worldScreen,
+        restoreDefault: ()->Unit = {}
+    ) : Popup(screen) {
 
     /** The [Label][com.badlogic.gdx.scenes.scene2d.ui.Label] created for parameter `question` for optional layout tweaking */
     val promptLabel = question.toLabel()


### PR DESCRIPTION
#5614 seems to have regressed several documented key bindings.
This offers a way to reactivate the Ctrl combos.

This is also a _request for ideas/help_ to solve the issue that all keys are now treated as if the user had a !/&"%§/!&"%§ yankee QWERTY keyboard, which is the reason many of us can't answer a yes/no popup with "Y" anymore. It seems neither Gdx nor ljwrgl3 handle layout translation, that seems left to GLFW, and I can't find either an interface to query the layout not one to do the translation. Interestingly, the GLFW sources (as seen by following call stacks down) contain Jdoc that says layout mapping has already happened at the keycode level before key events are queued... Though I can't find the specific comment at the moment.

AFAIK it has still not been decided whether we want e.g. a yes/no box translated to oui/non to react to "O" instead of "Y" to match the translated button, and how to achieve that. Several ideas offer themselves - first letter of button text, entries in the translation files...