### PR TITLE
Fix Polynesia's Wayfinding

### DIFF
--- a/android/assets/jsons/Civ V - Gods & Kings/Nations.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Nations.json
@@ -488,7 +488,7 @@
 		"innerColor": [255,255,78],
 		"favoredReligion": "Christianity",
 		"uniqueName": "Wayfinding",
-		"uniques": ["Enables embarkation for land units <starting from the [Ancient era]>", "Enables embarked units to enter ocean tiles <starting from the [Ancient era]>", "Normal vision when embarked <for [All] units>", "+[10]% Strength if within [2] tiles of a [Moai]"],
+		"uniques": ["Enables embarkation for land units <starting from the [Ancient era]>", "Enables [All] units to enter ocean tiles <starting from the [Ancient era]>", "Normal vision when embarked <for [All] units>", "+[10]% Strength if within [2] tiles of a [Moai]"],
 		"cities": ["Honolulu","Samoa","Tonga","Nuku Hiva","Raiatea","Aotearoa","Tahiti","Hilo","Te Wai Pounamu","Rapa Nui",
 			"Tuamotu","Rarotonga","Tuvalu","Tubuai","Mangareva","Oahu","Kiritimati","Ontong Java","Niue","Rekohu",
 			"Rakahanga","Bora Bora","Kailua","Uvea","Futuna","Rotuma","Tokelau","Lahaina","Bellona","Mungava","Tikopia",

--- a/android/assets/jsons/Civ V - Gods & Kings/Techs.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Techs.json
@@ -266,7 +266,7 @@
 			{
 				"name": "Astronomy",
 				"row": 2,
-				"uniques": ["[+1] Movement <for [Embarked] units>","Enables embarked units to enter ocean tiles"],
+				"uniques": ["[+1] Movement <for [Embarked] units>","Enables [Embarked] units to enter ocean tiles"],
 				"prerequisites": ["Compass","Education"],
 				"quote": "'Joyfully to the breeze royal Odysseus spread his sail, and with his rudder skillfully he steered.' - Homer"
 			},

--- a/android/assets/jsons/Civ V - Vanilla/Nations.json
+++ b/android/assets/jsons/Civ V - Vanilla/Nations.json
@@ -468,7 +468,7 @@
 		"outerColor": [225,105,0],
 		"innerColor": [255,255,78],
 		"uniqueName": "Wayfinding",
-		"uniques": ["Enables embarkation for land units <starting from the [Ancient era]>", "Enables embarked units to enter ocean tiles <starting from the [Ancient era]>", "Normal vision when embarked <for [All] units>", "+[10]% Strength if within [2] tiles of a [Moai]"],
+		"uniques": ["Enables embarkation for land units <starting from the [Ancient era]>", "Enables [All] units to enter ocean tiles <starting from the [Ancient era]>", "Normal vision when embarked <for [All] units>", "+[10]% Strength if within [2] tiles of a [Moai]"],
 		"cities": ["Honolulu","Samoa","Tonga","Nuku Hiva","Raiatea","Aotearoa","Tahiti","Hilo","Te Wai Pounamu","Rapa Nui",
 			"Tuamotu","Rarotonga","Tuvalu","Tubuai","Mangareva","Oahu","Kiritimati","Ontong Java","Niue","Rekohu",
 			"Rakahanga","Bora Bora","Kailua","Uvea","Futuna","Rotuma","Tokelau","Lahaina","Bellona","Mungava","Tikopia",

--- a/android/assets/jsons/Civ V - Vanilla/Techs.json
+++ b/android/assets/jsons/Civ V - Vanilla/Techs.json
@@ -246,7 +246,7 @@
 			{
 				"name": "Astronomy",
 				"row": 2,
-				"uniques": ["[+1] Movement <for [Embarked] units>","Enables embarked units to enter ocean tiles"],
+				"uniques": ["[+1] Movement <for [Embarked] units>","Enables [Embarked] units to enter ocean tiles"],
 				"prerequisites": ["Compass","Education"],
 				"quote": "'Joyfully to the breeze royal Odysseus spread his sail, and with his rudder skillfully he steered.' - Homer"
 			},

--- a/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
+++ b/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
@@ -610,14 +610,16 @@ class UnitMovementAlgorithms(val unit:MapUnit) {
                 && !tile.isCityCenter())
             return false
 
-
         if (tile.isWater && unit.baseUnit.isLandUnit()) {
             if (!unit.civInfo.tech.unitsCanEmbark) return false
             if (tile.isOcean && !unit.civInfo.tech.embarkedUnitsCanEnterOcean)
                 return false
         }
-        if (tile.isOcean && !unit.civInfo.tech.wayfinding) { // Apparently all Polynesian naval units can enter oceans
-            if (unit.cannotEnterOceanTiles) return false
+        if (tile.isOcean && !unit.civInfo.tech.allUnitsCanEnterOcean) { // Apparently all Polynesian naval units can enter oceans
+            val unitSpecificAllowOcean = unit.civInfo.tech.specificUnitsCanEnterOcean &&
+                        unit.civInfo.getMatchingUniques(UniqueType.UnitsMayEnterOcean)
+                            .any { unit.matchesFilter(it.params[0]) }
+            if (!unitSpecificAllowOcean && unit.cannotEnterOceanTiles) return false
         }
         if (tile.naturalWonder != null) return false
 

--- a/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
+++ b/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
@@ -610,15 +610,17 @@ class UnitMovementAlgorithms(val unit:MapUnit) {
                 && !tile.isCityCenter())
             return false
 
+        val unitSpecificAllowOcean: Boolean by lazy {
+            unit.civInfo.tech.specificUnitsCanEnterOcean &&
+                    unit.civInfo.getMatchingUniques(UniqueType.UnitsMayEnterOcean)
+                        .any { unit.matchesFilter(it.params[0]) }
+        }
         if (tile.isWater && unit.baseUnit.isLandUnit()) {
             if (!unit.civInfo.tech.unitsCanEmbark) return false
-            if (tile.isOcean && !unit.civInfo.tech.embarkedUnitsCanEnterOcean)
+            if (tile.isOcean && !unit.civInfo.tech.embarkedUnitsCanEnterOcean && !unitSpecificAllowOcean)
                 return false
         }
         if (tile.isOcean && !unit.civInfo.tech.allUnitsCanEnterOcean) { // Apparently all Polynesian naval units can enter oceans
-            val unitSpecificAllowOcean = unit.civInfo.tech.specificUnitsCanEnterOcean &&
-                        unit.civInfo.getMatchingUniques(UniqueType.UnitsMayEnterOcean)
-                            .any { unit.matchesFilter(it.params[0]) }
             if (!unitSpecificAllowOcean && unit.cannotEnterOceanTiles) return false
         }
         if (tile.naturalWonder != null) return false

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -262,20 +262,22 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
     CityHealingUnits("[mapUnitFilter] Units adjacent to this city heal [amount] HP per turn when healing", UniqueTarget.Global, UniqueTarget.FollowerBelief),
 
     GoldenAgeLength("[amount]% Golden Age length", UniqueTarget.Global),
-    
+
     StrengthForCities("[amount]% Strength for cities", UniqueTarget.Global, UniqueTarget.FollowerBelief),
     @Deprecated("as of 3.19.1", ReplaceWith("[+amount]% Strength for cities <with a garrison> <when attacking>"))
     StrengthForGarrisonedCitiesAttacking("+[amount]% attacking strength for cities with garrisoned units", UniqueTarget.Global),
-    
+
     UnitStartingExperience("New [baseUnitFilter] units start with [amount] Experience [cityFilter]", UniqueTarget.Global, UniqueTarget.FollowerBelief),
     UnitStartingPromotions("All newly-trained [baseUnitFilter] units [cityFilter] receive the [promotion] promotion", UniqueTarget.Global, UniqueTarget.FollowerBelief),
     UnitStartingActions("[baseUnitFilter] units built [cityFilter] can [action] [amount] extra times", UniqueTarget.Global, UniqueTarget.FollowerBelief),
     // ToDo: make per unit and use unit filters?
     LandUnitEmbarkation("Enables embarkation for land units", UniqueTarget.Global),
+    UnitsMayEnterOcean("Enables [mapUnitFilter] units to enter ocean tiles", UniqueTarget.Global),
+    @Deprecated("as of 3.19.13", ReplaceWith("Enables [Embarked] units to enter ocean tiles <starting from the [Ancient era]>"))
     EmbarkedUnitsMayEnterOcean("Enables embarked units to enter ocean tiles", UniqueTarget.Global),
-    @Deprecated("as of 3.19.9", ReplaceWith("Enables embarkation for land units <starting from the [Ancient era]>\", \"Enables embarked units to enter ocean tiles <starting from the [Ancient era]>"))
+    @Deprecated("as of 3.19.9", ReplaceWith("Enables embarkation for land units <starting from the [Ancient era]>\", \"Enables [All] units to enter ocean tiles <starting from the [Ancient era]>"))
     EmbarkAndEnterOcean("Can embark and move over Coasts and Oceans immediately", UniqueTarget.Global),
-    
+
     PopulationLossFromNukes("Population loss from nuclear attacks [amount]% [cityFilter]", UniqueTarget.Global),
     @Deprecated("as of 3.19.2", ReplaceWith("Population loss from nuclear attacks [-amount]% [in this city]"))
     PopulationLossFromNukesDeprecated("Population loss from nuclear attacks -[amount]%", UniqueTarget.Global),

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -551,7 +551,9 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 ??? example  "Enables embarkation for land units"
 	Applicable to: Global
 
-??? example  "Enables embarked units to enter ocean tiles"
+??? example  "Enables [mapUnitFilter] units to enter ocean tiles"
+	Example: "Enables [Wounded] units to enter ocean tiles"
+
 	Applicable to: Global
 
 ??? example  "Population loss from nuclear attacks [amount]% [cityFilter]"


### PR DESCRIPTION
Fix #6202 by introducing a UnitsMayEnterOcean UniqueType with mapUnitFilter support which Polynesia can use with "All" instead of "Embarked"

Tested:
* [x] Polynesia's embark and trireme can sail ocean immediately
* [x] Non-Polynesia:  Astronomy still as expected
* [x] Modded `UnitsMayEnterOcean` with a unit filter that's neither "All" nor "Embarked"