### PR TITLE
Fix Spaceship production boni (and key binding)

### DIFF
--- a/android/assets/jsons/Civ V - Gods & Kings/Buildings.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Buildings.json
@@ -527,9 +527,7 @@
 		"hurryCostModifier": 25,
 		"requiredNearbyImprovedResources": ["Iron"],
 		"requiredTech": "Metal Casting",
-		// If spaceship parts are changed into units, the spaceship part unique should be changed to
-		// "[+15]% Production when constructing [Spaceship part] units [in this city]"
-		"uniques": ["[+15]% Production when constructing [Spaceship part] buildings [in this city]",
+		"uniques": ["[+15]% Production when constructing [Spaceship part] units [in this city]",
 			"[+15]% Production when constructing [Land] units [in this city]",
 			"[+1 Production] from [Iron] tiles [in this city]"]
 	},
@@ -1107,10 +1105,8 @@
 		"name": "Hubble Space Telescope",
 		"isWonder": true,
 		"greatPersonPoints": {"Great Scientist": 1},
-		// If spaceship parts are changed into units, the spaceship part unique should be changed to
-		// "[+25]% Production when constructing [Spaceship part] units [in this city]"
 		"uniques": ["[2] free [Great Scientist] units appear",
-			"[+25]% Production when constructing [Spaceship part] buildings [in this city]",
+			"[+25]% Production when constructing [Spaceship part] units [in this city]",
 			"Gain a free [Spaceship Factory] [in this city]"],
 		"requiredTech": "Satellites",
 		"quote": "'The wonder is, not that the field of stars is so vast, but that man has measured it.' - Anatole France"
@@ -1121,9 +1117,7 @@
 		"requiredResource": "Aluminum",
 		"cost": 360,
 		"requiredBuilding": "Factory",
-		// If spaceship parts are changed into units, this unique should be changed to
-		// "[+50]% Production when constructing [Spaceship part] units [in this city]"
-		"uniques": ["[+50]% Production when constructing [Spaceship part] buildings [in this city]"],
+		"uniques": ["[+50]% Production when constructing [Spaceship part] units [in this city]"],
 		"requiredTech": "Robotics"
 	},
 	// Column 16

--- a/android/assets/jsons/Civ V - Vanilla/Buildings.json
+++ b/android/assets/jsons/Civ V - Vanilla/Buildings.json
@@ -465,9 +465,7 @@
 		"hurryCostModifier": 25,
 		"requiredNearbyImprovedResources": ["Iron"],
 		"requiredTech": "Metal Casting",
-		// If spaceship parts are changed into units, the spaceship part unique should be changed to
-		// "[+15]% Production when constructing [Spaceship part] units [in this city]"
-		"uniques": ["[+15]% Production when constructing [Spaceship part] buildings [in this city]",
+		"uniques": ["[+15]% Production when constructing [Spaceship part] units [in this city]",
 			"[+15]% Production when constructing [Land] units [in this city]",
 			"[+1 Production] from [Iron] tiles [in this city]"]
 	},
@@ -947,9 +945,7 @@
 		"requiredResource": "Aluminum",
 		"cost": 360,
 		"requiredBuilding": "Factory",
-		// If spaceship parts are changed into units, this unique should be changed to
-		// "[+50]% Production when constructing [Spaceship part] units [in this city]"
-		"uniques": ["[+50]% Production when constructing [Spaceship part] buildings [in this city]"],
+		"uniques": ["[+50]% Production when constructing [Spaceship part] units [in this city]"],
 		"requiredTech": "Robotics"
 	},
 	// Column 16

--- a/core/src/com/unciv/models/UnitAction.kt
+++ b/core/src/com/unciv/models/UnitAction.kt
@@ -141,7 +141,7 @@ enum class UnitActionType(
     HideAdditionalActions("Back",
         { imageGetHideMore() }, KeyCharAndCode(Input.Keys.PAGE_UP)),
     AddInCapital( "Add in capital",
-        { ImageGetter.getUnitIcon("SS Cockpit")}, UncivSound.Chimes),
+        { ImageGetter.getUnitIcon("SS Cockpit")}, 'g', UncivSound.Chimes),
     ;
 
     // Allow shorter initializations


### PR DESCRIPTION
While testing a 4-char patch to allow adding spaceship parts via keyboard I noticed certain outdated comments and the recommendations therein not implemented...

Key is "G" as in the Great Person actions - not Persons but probably close to what a player may be used to, and it conflicts not. My first idea "+" was torpedoed by the known keyboard layout being ignored problem.

P.S.: Yes, confirmed by testing that the boni are broken in master and fixed by this. Kudos for the improved stats breakdown.