### PR TITLE
Fix after-pillage display

### DIFF
--- a/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
@@ -287,6 +287,7 @@ object UnitActions {
                         tile.turnsToImprovement = 2
                     }
                     tile.improvement = null
+                    unit.civInfo.lastSeenImprovement.remove(tile.position)
                     if (tile.resource != null) tile.getOwner()?.updateDetailedCivResources()    // this might take away a resource
 
                     val freePillage = unit.hasUnique(UniqueType.NoMovementToPillage, checkCivInfoUniques = true)


### PR DESCRIPTION
Fix for: Immediately after pillaging an improvement, both improvement and improvement-in-progress are shown on TileInfoTable and map. !!! Not sure this is the best approach !!!