### PR TITLE
Fix next turn button disabled after leaving sub-screens from menu

### DIFF
--- a/core/src/com/unciv/ui/worldscreen/mainmenu/WorldScreenMenuPopup.kt
+++ b/core/src/com/unciv/ui/worldscreen/mainmenu/WorldScreenMenuPopup.kt
@@ -15,20 +15,38 @@ class WorldScreenMenuPopup(val worldScreen: WorldScreen) : Popup(worldScreen) {
     init {
         defaults().fillX()
 
-        addButton("Main menu") { worldScreen.game.setScreen(MainMenuScreen()) }
-        addButton("Civilopedia") { worldScreen.game.setScreen(CivilopediaScreen(worldScreen.gameInfo.ruleSet, worldScreen)) }
-        addButton("Save game") { worldScreen.game.setScreen(SaveGameScreen(worldScreen.gameInfo)) }
-        addButton("Load game") { worldScreen.game.setScreen(LoadGameScreen(worldScreen)) }
+        addButton("Main menu") {
+            worldScreen.game.setScreen(MainMenuScreen())
+        }
+        addButton("Civilopedia") {
+            close()
+            worldScreen.game.setScreen(CivilopediaScreen(worldScreen.gameInfo.ruleSet, worldScreen))
+        }
+        addButton("Save game") {
+            close()
+            worldScreen.game.setScreen(SaveGameScreen(worldScreen.gameInfo))
+        }
+        addButton("Load game") {
+            close()
+            worldScreen.game.setScreen(LoadGameScreen(worldScreen))
+        }
 
         addButton("Start new game") {
+            close()
             val newGameSetupInfo = GameSetupInfo(worldScreen.gameInfo)
             newGameSetupInfo.mapParameters.reseed()
             val newGameScreen = NewGameScreen(worldScreen, newGameSetupInfo)
             worldScreen.game.setScreen(newGameScreen)
         }
 
-        addButton("Victory status") { worldScreen.game.setScreen(VictoryScreen(worldScreen)) }
-        addButton("Options") { worldScreen.openOptionsPopup() }
+        addButton("Victory status") {
+            close()
+            worldScreen.game.setScreen(VictoryScreen(worldScreen))
+        }
+        addButton("Options") {
+            close()
+            worldScreen.openOptionsPopup()
+        }
         addButton("Community") {
             close()
             WorldScreenCommunityPopup(worldScreen).open(force = true)


### PR DESCRIPTION
Steps to reproduce:
- enter any game
- open WorldScreenMenuPopup
- click Save game
- click Close
- observe Next Turn is disabled, clicking it re-enables

Cause: `WorldScreen.updateNextTurnButton(isSomethingOpen = true)` runs after closing the SaveGameScreen, from UncivGame.render - before the Popup actually closes.

Solutions:
- close the popup right after/before instantiating SaveGameScreen etc.
- override close and call `WorldScreen.enableNextTurnButtonAfterOptions`

Alternative 1 changes the flow, and I actually prefer it. From the save screen I prefer to return to world, not menu. The PR implements a conservative approach to this.

<details><summary>The <i>daring</i> style would be:</summary>

```kotlin
package com.unciv.ui.worldscreen.mainmenu

import com.badlogic.gdx.Gdx
import com.unciv.MainMenuScreen
import com.unciv.ui.civilopedia.CivilopediaScreen
import com.unciv.models.metadata.GameSetupInfo
import com.unciv.ui.newgamescreen.NewGameScreen
import com.unciv.ui.saves.LoadGameScreen
import com.unciv.ui.saves.SaveGameScreen
import com.unciv.ui.utils.BaseScreen
import com.unciv.ui.utils.Popup
import com.unciv.ui.victoryscreen.VictoryScreen
import com.unciv.ui.worldscreen.WorldScreen

class WorldScreenMenuPopup(val worldScreen: WorldScreen) : Popup(worldScreen) {
    companion object {
        private val entries: List<Pair<String, WorldScreen.() -> BaseScreen?>> =
            listOf (
                "Main menu" to {
                    MainMenuScreen()
                },
                "Civilopedia" to {
                    CivilopediaScreen(gameInfo.ruleSet, this)
                },
                "Save game" to {
                    SaveGameScreen(gameInfo)
                },
                "Load game" to {
                    LoadGameScreen(this)
                },
                "Start new game" to {
                    NewGameScreen(this, GameSetupInfo(gameInfo).apply { mapParameters.reseed() })
                },
                "Victory status" to {
                    VictoryScreen(this)
                },
                "Options" to {
                    openOptionsPopup()
                    null
                },
                "Community" to {
                    WorldScreenCommunityPopup(this).open(force = true)
                    null
                },
            )
    }

    init {
        defaults().fillX()

        for ((text, action) in entries) {
            addButton(text) {
                close()
                val screen = worldScreen.action()
                if (screen != null) worldScreen.game.setScreen(screen)
            }
        }
        addCloseButton()
        pack()
    }
}

class WorldScreenCommunityPopup(val worldScreen: WorldScreen) : Popup(worldScreen) {
    init {
        defaults().fillX()
        addButton("Discord") {
            Gdx.net.openURI("https://discord.gg/bjrB4Xw")
            close()
        }

        addButton("Github") {
            Gdx.net.openURI("https://github.com/yairm210/UnCiv")
            close()
        }

        addButton("Reddit") {
            Gdx.net.openURI("https://www.reddit.com/r/Unciv/")
            close()
        }

        addCloseButton()
    }
}
```
</details>

Alternative 2 would be to simply add this to the WorldScreenMenuPopup class:
```kotlin
    override fun close() {
        super.close()
        worldScreen.enableNextTurnButtonAfterOptions()
    }
```

All variants are tested and work as intended.
