### PR TITLE
Fix new game screen not always respecting translations of selected mods

### DIFF
--- a/core/src/com/unciv/models/translations/Translations.kt
+++ b/core/src/com/unciv/models/translations/Translations.kt
@@ -29,8 +29,8 @@ import kotlin.collections.LinkedHashSet
  *
  *  @see    String.tr   for more explanations (below)
  */
-class Translations : LinkedHashMap<String, TranslationEntry>(){
-    
+class Translations : LinkedHashMap<String, TranslationEntry>() {
+
     var percentCompleteOfLanguages = HashMap<String,Int>()
             .apply { put("English",100) } // So even if we don't manage to load the percentages, we can still pass the language screen
 
@@ -38,7 +38,7 @@ class Translations : LinkedHashMap<String, TranslationEntry>(){
 
     // used by tr() whenever GameInfo not initialized (allowing new game screen to use mod translations)
     var translationActiveMods = LinkedHashSet<String>()
-
+    var forceTranslationActiveMods = false
 
     /**
      * Searches for the translation entry of a given [text] for a given [language].
@@ -165,7 +165,7 @@ class Translations : LinkedHashMap<String, TranslationEntry>(){
     }
 
     /** Ensure _all_ languages are loaded, used by [TranslationFileWriter] and `TranslationTests` */
-    fun readAllLanguagesTranslation(printOutput:Boolean=false) {
+    fun readAllLanguagesTranslation(printOutput: Boolean = false) {
         // Apparently you can't iterate over the files in a directory when running out of a .jar...
         // https://www.badlogicgames.com/forum/viewtopic.php?f=11&t=27250
         // which means we need to list everything manually =/
@@ -180,7 +180,7 @@ class Translations : LinkedHashMap<String, TranslationEntry>(){
         if(printOutput) println("Loading translation files - ${translationFilesTime}ms")
     }
 
-    fun loadPercentageCompleteOfLanguages(){
+    fun loadPercentageCompleteOfLanguages() {
         val startTime = System.currentTimeMillis()
 
         percentCompleteOfLanguages = TranslationFileReader.readLanguagePercentages()
@@ -192,7 +192,7 @@ class Translations : LinkedHashMap<String, TranslationEntry>(){
     fun getConditionalOrder(language: String): String {
         return getText(englishConditionalOrderingString, language, null)
     }
-    
+
     fun placeConditionalsAfterUnique(language: String): Boolean {
         if (get(conditionalUniqueOrderString, language, null)?.get(language) == "before")
             return false
@@ -206,11 +206,11 @@ class Translations : LinkedHashMap<String, TranslationEntry>(){
         val translation = getText("\" \"", language, null)
         return translation.substring(1, translation.length-1)
     }
-    
+
     fun shouldCapitalize(language: String): Boolean {
         return get(shouldCapitalizeString, language, null)?.get(language)?.toBoolean() ?: true
     }
-    
+
     companion object {
         // Whenever this string is changed, it should also be changed in the translation files!
         // It is mostly used as the template for translating the order of conditionals   
@@ -256,7 +256,7 @@ val pointyBraceRegex = Regex("""\<([^>]*)\>""")
  */
 fun String.tr(): String {
     val activeMods = with(UncivGame.Current) {
-        if (isGameInfoInitialized())
+        if (!translations.forceTranslationActiveMods && isGameInfoInitialized())
             gameInfo.gameParameters.mods + gameInfo.gameParameters.baseRuleset
         else translations.translationActiveMods
     }.toHashSet()
@@ -388,7 +388,7 @@ fun String.getPlaceholderText() = this
         .removeConditionals()
         .replace(squareBraceRegex, "[]")
 
-fun String.equalsPlaceholderText(str:String): Boolean {
+fun String.equalsPlaceholderText(str: String): Boolean {
     if (first() != str.first()) return false // for quick negative return 95% of the time
     return this.getPlaceholderText() == str
 }

--- a/core/src/com/unciv/ui/newgamescreen/GameOptionsTable.kt
+++ b/core/src/com/unciv/ui/newgamescreen/GameOptionsTable.kt
@@ -15,15 +15,16 @@ import com.unciv.ui.utils.*
 class GameOptionsTable(
     val previousScreen: IPreviousScreen,
     val isPortrait: Boolean = false,
-    val updatePlayerPickerTable:(desiredCiv:String)->Unit
+    val updatePlayerPickerTable: (desiredCiv: String) -> Unit
 ) : Table(BaseScreen.skin) {
     var gameParameters = previousScreen.gameSetupInfo.gameParameters
     val ruleset = previousScreen.ruleset
     var locked = false
     var modCheckboxes: ModCheckboxTable? = null
-    private set;
+        private set
 
     init {
+        setupTranslations()
         getGameOptionsTable()
     }
 
@@ -38,10 +39,7 @@ class GameOptionsTable(
         defaults().pad(5f)
 
         // We assign this first to make sure addBaseRulesetSelectBox doesn't reference a null object
-        modCheckboxes = 
-            if (isPortrait) 
-                getModCheckboxes(isPortrait = true)
-            else getModCheckboxes()
+        modCheckboxes = getModCheckboxes(isPortrait)
 
         add(Table().apply {
             defaults().pad(5f)
@@ -58,7 +56,6 @@ class GameOptionsTable(
             }).colspan(2).fillX().row()
         }).row()
         addVictoryTypeCheckboxes()
-        
 
         val checkboxTable = Table().apply { defaults().left().pad(2.5f) }
         checkboxTable.addNoBarbariansCheckbox()
@@ -86,8 +83,8 @@ class GameOptionsTable(
             { gameParameters.noBarbarians = it }
 
     private fun Table.addRagingBarbariansCheckbox() =
-        addCheckbox("Raging Barbarians", gameParameters.ragingBarbarians)
-        { gameParameters.ragingBarbarians = it }
+            addCheckbox("Raging Barbarians", gameParameters.ragingBarbarians)
+            { gameParameters.ragingBarbarians = it }
 
     private fun Table.addOneCityChallengeCheckbox() =
             addCheckbox("One City Challenge", gameParameters.oneCityChallenge)
@@ -167,7 +164,7 @@ class GameOptionsTable(
     private fun Table.addBaseRulesetSelectBox() {
         val sortedBaseRulesets = RulesetCache.getSortedBaseRulesets()
         if (sortedBaseRulesets.size < 2) return
-        
+
         addSelectBox(
             "{Base Ruleset}:",
             sortedBaseRulesets,
@@ -175,7 +172,7 @@ class GameOptionsTable(
         ) { newBaseRuleset ->
             val previousSelection = gameParameters.baseRuleset
             if (newBaseRuleset == gameParameters.baseRuleset) return@addSelectBox null
-            
+
             // Check if this mod is well-defined
             val baseRulesetErrors = RulesetCache[newBaseRuleset]!!.checkModLinks()
             if (baseRulesetErrors.isError()) {
@@ -183,7 +180,7 @@ class GameOptionsTable(
                 ToastPopup(toastMessage, previousScreen as BaseScreen, 5000L)
                 return@addSelectBox previousSelection
             }
-            
+
             // If so, add it to the current ruleset
             gameParameters.baseRuleset = newBaseRuleset
             onChooseMod(newBaseRuleset)
@@ -204,9 +201,9 @@ class GameOptionsTable(
                     "\n\n${modLinkErrors.getErrorText()}"
                 ToastPopup(toastMessage, previousScreen as BaseScreen, 5000L)
             }
-            
+
             modCheckboxes!!.setBaseRuleset(newBaseRuleset)
-            
+
             null
         }
     }
@@ -222,7 +219,7 @@ class GameOptionsTable(
         addSelectBox("{Starting Era}:", eras, gameParameters.startingEra)
         { gameParameters.startingEra = it; null }
     }
-    
+
     private fun addVictoryTypeCheckboxes() {
         add("{Victory Conditions}:".toLabel()).colspan(2).row()
 
@@ -257,20 +254,24 @@ class GameOptionsTable(
         ruleset.mods += gameParameters.baseRuleset
         ruleset.mods += gameParameters.mods
         ruleset.modOptions = newRuleset.modOptions
-        
+
         ImageGetter.setNewRuleset(ruleset)
         UncivGame.Current.musicController.setModList(gameParameters.getModsAndBaseRuleset())
     }
 
-    fun getModCheckboxes(isPortrait: Boolean = false): ModCheckboxTable {
+    private fun getModCheckboxes(isPortrait: Boolean = false): ModCheckboxTable {
         return ModCheckboxTable(gameParameters.mods, gameParameters.baseRuleset, previousScreen as BaseScreen, isPortrait) {
             onChooseMod(it)
         }
     }
-    
-    private fun onChooseMod(mod: String) {
+
+    private fun setupTranslations() {
         val activeMods: LinkedHashSet<String> = LinkedHashSet(gameParameters.getModsAndBaseRuleset())
         UncivGame.Current.translations.translationActiveMods = activeMods
+    }
+
+    private fun onChooseMod(mod: String) {
+        setupTranslations()
         reloadRuleset()
         update()
 
@@ -287,4 +288,3 @@ class GameOptionsTable(
         updatePlayerPickerTable(desiredCiv)
     }
 }
-

--- a/core/src/com/unciv/ui/newgamescreen/NewGameScreen.kt
+++ b/core/src/com/unciv/ui/newgamescreen/NewGameScreen.kt
@@ -33,6 +33,7 @@ class NewGameScreen(
     private val mapOptionsTable: MapOptionsTable
 
     init {
+        UncivGame.Current.translations.forceTranslationActiveMods = true
         updateRuleset()  // must come before playerPickerTable so mod nations from fromSettings
         // Has to be initialized before the mapOptionsTable, since the mapOptionsTable refers to it on init
         playerPickerTable = PlayerPickerTable(
@@ -153,7 +154,7 @@ class NewGameScreen(
         topTable.add(playerPickerTable)  // No ScrollPane, PlayerPickerTable has its own
                 .width(stage.width / 3).top()
     }
-    
+
     private fun initPortrait() {
         scrollPane.setScrollingDisabled(false,false)
 
@@ -164,7 +165,7 @@ class NewGameScreen(
 
         topTable.add(newGameOptionsTable.modCheckboxes).expandX().fillX().row()
         topTable.addSeparator(Color.DARK_GRAY, height = 1f)
-        
+
         topTable.add(ExpanderTab("Map Options") {
             it.add(mapOptionsTable).row()
         }).expandX().fillX().row()
@@ -228,6 +229,11 @@ class NewGameScreen(
                 ToastPopup("Game ID copied to clipboard!".tr(), game.worldScreen, 2500)
             }
         }
+    }
+
+    override fun dispose() {
+        UncivGame.Current.translations.forceTranslationActiveMods = false
+        super.dispose()
     }
 
     fun updateRuleset() {


### PR DESCRIPTION
Steps to reproduce:
- Load a base mod translating the Barbarians to something else, e.g. the one from #6192 - and run in English
- Create a game with that mod
- (while in New game screen observe how changing the base ruleset changes the barbarians options to their translated form and back - cool!)
- Quit Unciv and relaunch
- Go to New Game
- Observe the mod is pre-selected but its tranlsation isn't active (raging Barbarians instead of raging Luddites)

- Enter any game
- From the world menu go to new game
- Observe the Barbarians or Luddites options no longer change with the base ruleset

Cause for #1: GameOptionsTable has the code to update translationActiveMods in onChooseMod, but that one does not run during init.
Cause for #2: Translations uses translationActiveMods _only_ while there's no game running under the hood.

This solution solves #2 with an override flag - the danger being missing setting it back. That dispose capture works in testing, but I'm not 100% sure this is the best solution. I encourage thought, own testing, or even rejection as "not worth it" ;)
