### PR TITLE
Move automated units button was showing when it didn't do anything

### DIFF
--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -791,7 +791,7 @@ class WorldScreen(val gameInfo: GameInfo, val viewingCiv:CivilizationInfo) : Bas
                 }
 
             !viewingCiv.hasMovedAutomatedUnits && viewingCiv.getCivUnits()
-                .any { it.isMoving() || it.isAutomated() || it.isExploring() } ->
+                .any { it.currentMovement >= 0.1f && (it.isMoving() || it.isAutomated() || it.isExploring()) } ->
                 NextTurnAction("Move automated units", Color.LIGHT_GRAY) {
                     viewingCiv.hasMovedAutomatedUnits = true
                     isPlayersTurn = false // Disable state changes


### PR DESCRIPTION
To repro in current master: Give the first Warrior at turn 0 a multi-turn move order, the "Move automated units" appears and does nothing as the unit already did what it could this turn...