### PR TITLE
Added deep linked multiplayer games

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -29,8 +29,17 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <intent-filter android:autoVerify="true" >
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data
+                    android:scheme="https"
+                    android:host="unciv.app"
+                    android:path="/multiplayer"
+                />
+            </intent-filter>
         </activity>
-
 
         <activity
             android:name="com.unciv.app.AndroidTvLauncher"

--- a/android/src/com/unciv/app/MultiplayerTurnCheckWorker.kt
+++ b/android/src/com/unciv/app/MultiplayerTurnCheckWorker.kt
@@ -6,6 +6,7 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.graphics.Color
+import android.net.Uri
 import android.os.Build
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationCompat.DEFAULT_VIBRATE
@@ -138,17 +139,18 @@ class MultiplayerTurnCheckWorker(appContext: Context, workerParams: WorkerParame
             }
         }
 
-        fun notifyUserAboutTurn(applicationContext: Context, gameName: String) {
-            val pendingIntent: PendingIntent =
-                    Intent(applicationContext, AndroidLauncher::class.java).let { notificationIntent ->
-                        PendingIntent.getActivity(applicationContext, 0, notificationIntent, 0)
-                    }
+        fun notifyUserAboutTurn(applicationContext: Context, game: Pair<String, String>) {
+            val intent = Intent(applicationContext, AndroidLauncher::class.java).apply {
+                action = Intent.ACTION_VIEW
+                data = Uri.parse("https://unciv.app/multiplayer?id=${game.second}")
+            }
+            val pendingIntent = PendingIntent.getActivity(applicationContext, 0, intent, 0)
 
             val contentTitle = applicationContext.resources.getString(R.string.Notify_YourTurn_Short)
             val notification: NotificationCompat.Builder = NotificationCompat.Builder(applicationContext, NOTIFICATION_CHANNEL_ID_INFO)
                     .setPriority(NotificationManagerCompat.IMPORTANCE_HIGH) // people are waiting!
                     .setContentTitle(contentTitle)
-                    .setContentText(applicationContext.resources.getString(R.string.Notify_YourTurn_Long).replace("[gameName]", gameName))
+                    .setContentText(applicationContext.resources.getString(R.string.Notify_YourTurn_Long).replace("[gameName]", game.first))
                     .setTicker(contentTitle)
                     // without at least vibrate, some Android versions don't show a heads-up notification
                     .setDefaults(DEFAULT_VIBRATE)
@@ -190,7 +192,7 @@ class MultiplayerTurnCheckWorker(appContext: Context, workerParams: WorkerParame
                 // Of the turnNotification is OFF, this will be -1 since we never saved this game in the array
                 // Or possibly reading the preview file returned an exception
                 if (gameIndex!=-1)
-                    notifyUserAboutTurn(applicationContext, gameNames[gameIndex])
+                    notifyUserAboutTurn(applicationContext, Pair(gameNames[gameIndex], gameIds[gameIndex]))
             } else {
                 val inputData = workDataOf(Pair(FAIL_COUNT, 0), Pair(GAME_ID, gameIds), Pair(GAME_NAME, gameNames),
                         Pair(USER_ID, settings.userId), Pair(CONFIGURED_DELAY, settings.multiplayerTurnCheckerDelayInMinutes),
@@ -238,8 +240,8 @@ class MultiplayerTurnCheckWorker(appContext: Context, workerParams: WorkerParame
             val gameNames = inputData.getStringArray(GAME_NAME)!!
             var arrayIndex = 0
             // We only want to notify the user or update persisted notification once but still want
-            // to download all games to update the files hence this bool
-            var foundGame = ""
+            // to download all games to update the files so we save the first one we find
+            var foundGame: Pair<String, String>? = null
 
             for (gameId in gameIds){
                 //gameId could be an empty string if startTurnChecker fails to load all files
@@ -260,10 +262,8 @@ class MultiplayerTurnCheckWorker(appContext: Context, workerParams: WorkerParame
                      */
                     GameSaver.saveGame(gamePreview, gameNames[arrayIndex])
 
-                    if (currentTurnPlayer.playerId == inputData.getString(USER_ID)!! && foundGame.isEmpty()) {
-                        // We only save the first found game as the player will go into the
-                        // multiplayer screen anyway to join the game and see the other ones
-                        foundGame = gameNames[arrayIndex]
+                    if (currentTurnPlayer.playerId == inputData.getString(USER_ID)!! && foundGame == null) {
+                        foundGame = Pair(gameNames[arrayIndex], gameIds[arrayIndex])
                     }
                     arrayIndex++
                 } catch (ex: FileNotFoundException){
@@ -276,7 +276,7 @@ class MultiplayerTurnCheckWorker(appContext: Context, workerParams: WorkerParame
                 }
             }
 
-            if (foundGame.isNotEmpty()){
+            if (foundGame != null){
                 notifyUserAboutTurn(applicationContext, foundGame)
                 with(NotificationManagerCompat.from(applicationContext)) {
                     cancel(NOTIFICATION_ID_SERVICE)


### PR DESCRIPTION
This allows the turn notification to open a multiplayer game directly without having to go through Main Menu->Multiplayer->Multiplayer Game->Join Game.
It also allows the app to open links like https://unciv.app/multiplayer?id=c7b4a08c-1420-4fc3-bfcb-8bc27b0d8d1d to download the specified game and open it. This could be used to make sharing games between players easier. To make it safer for everyone using it I will probably buy the unciv.app domain to redirect it to Github before implementing the share feature in case someone opens such a link in the browser instead of with the app. It's quite cheap (around 1€ per month) so that's not a problem.

[Unciv.com](https://unciv.com/) however :upside_down_face: