### PR TITLE
Notifications location

### DIFF
--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -303,18 +303,19 @@ class GameInfo {
                 thisPlayer.addNotification("An enemy [$unitName] was spotted $inOrNear our territory", tile.position, NotificationIcon.War, unitName)
             }
         } else {
-            val positions = tiles.map { it.position }
-            thisPlayer.addNotification("[${positions.size}] enemy units were spotted $inOrNear our territory", LocationAction(positions), NotificationIcon.War)
+            val positions = tiles.asSequence().map { it.position }
+            thisPlayer.addNotification("[${tiles.size}] enemy units were spotted $inOrNear our territory", LocationAction(positions), NotificationIcon.War)
         }
     }
 
     private fun addBombardNotification(thisPlayer: CivilizationInfo, cities: List<CityInfo>) {
-        if (cities.count() < 3) {
+        if (cities.size < 3) {
             for (city in cities)
                 thisPlayer.addNotification("Your city [${city.name}] can bombard the enemy!", city.location, NotificationIcon.City, NotificationIcon.Crosshair)
-
-        } else
-            thisPlayer.addNotification("[${cities.count()}] of your cities can bombard the enemy!", LocationAction(cities.map { it.location }), NotificationIcon.City, NotificationIcon.Crosshair)
+        } else {
+            val positions = cities.asSequence().map { it.location }
+            thisPlayer.addNotification("[${cities.size}] of your cities can bombard the enemy!", LocationAction(positions), NotificationIcon.City, NotificationIcon.Crosshair)
+        }
     }
 
     fun notifyExploredResources(civInfo: CivilizationInfo, resourceName: String, maxDistance: Int, showForeign: Boolean) {
@@ -354,12 +355,12 @@ class GameInfo {
             // re-sort to a more pleasant display order
             .sortedWith(compareBy{ it.tile.aerialDistanceTo(chosenCity.getCenterTile()) })
             .map { it.tile.position }
-            .toList()       // explicit materialization of sequence to satisfy addNotification overload
 
-        val text =  if(positions.size==1)
+        val positionsCount = positions.count()
+        val text =  if (positionsCount == 1)
             "[$resourceName] revealed near [${chosenCity.name}]"
         else
-            "[${positions.size}] sources of [$resourceName] revealed, e.g. near [${chosenCity.name}]"
+            "[$positionsCount] sources of [$resourceName] revealed, e.g. near [${chosenCity.name}]"
 
         civInfo.addNotification(
             text,

--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -313,11 +313,7 @@ object Battle {
             val notificationString = attackerString + whatHappenedString + defenderString
             val attackerIcon = if (attacker is CityCombatant) NotificationIcon.City else attacker.getName()
             val defenderIcon = if (defender is CityCombatant) NotificationIcon.City else defender.getName()
-            val locations = LocationAction (
-                if (attackerTile != null && attackerTile.position != attackedTile.position)
-                        listOf(attackedTile.position, attackerTile.position)
-                else listOf(attackedTile.position)
-            )
+            val locations = LocationAction(attackedTile.position, attackerTile?.position)
             defender.getCivInfo().addNotification(notificationString, locations, attackerIcon, whatHappenedIcon, defenderIcon)
         }
     }
@@ -773,38 +769,17 @@ object Battle {
 
             val attackerName = attacker.getName()
             val interceptorName = interceptor.name
-            val locations = LocationAction(
-                listOf(
-                    interceptor.currentTile.position,
-                    attacker.unit.currentTile.position
-                )
-            )
-
-            if (attacker.isDefeated()) {
-                attacker.getCivInfo()
-                    .addNotification(
-                        "Our [$attackerName] was destroyed by an intercepting [$interceptorName]",
-                        interceptor.currentTile.position, attackerName, NotificationIcon.War,
-                        interceptorName
-                    )
-                interceptingCiv
-                    .addNotification(
-                        "Our [$interceptorName] intercepted and destroyed an enemy [$attackerName]",
-                        locations, interceptorName, NotificationIcon.War, attackerName
-                    )
-            } else {
-                attacker.getCivInfo()
-                    .addNotification(
-                        "Our [$attackerName] was attacked by an intercepting [$interceptorName]",
-                        interceptor.currentTile.position, attackerName,NotificationIcon.War,
-                        interceptorName
-                    )
-                interceptingCiv
-                    .addNotification(
-                        "Our [$interceptorName] intercepted and attacked an enemy [$attackerName]",
-                        locations, interceptorName, NotificationIcon.War, attackerName
-                    )
-            }
+            val locations = LocationAction(interceptor.currentTile.position, attacker.unit.currentTile.position)
+            val attackerText = if (attacker.isDefeated())
+                "Our [$attackerName] was destroyed by an intercepting [$interceptorName]"
+                else "Our [$attackerName] was attacked by an intercepting [$interceptorName]"
+            val interceptorText = if (attacker.isDefeated())
+                "Our [$interceptorName] intercepted and destroyed an enemy [$attackerName]"
+                else "Our [$interceptorName] intercepted and attacked an enemy [$attackerName]"
+            attacker.getCivInfo().addNotification(attackerText, interceptor.currentTile.position,
+                attackerName, NotificationIcon.War, interceptorName)
+            interceptingCiv.addNotification(interceptorText, locations,
+                interceptorName, NotificationIcon.War, attackerName)
             return
         }
     }
@@ -859,7 +834,7 @@ object Battle {
 
         val attackingUnit = attackBaseUnit.name; val defendingUnit = defendBaseUnit.name
         val notificationString = "[$defendingUnit] withdrew from a [$attackingUnit]"
-        val locations = LocationAction(listOf(toTile.position, attacker.getTile().position))
+        val locations = LocationAction(toTile.position, attacker.getTile().position)
         defender.getCivInfo().addNotification(notificationString, locations, defendingUnit, NotificationIcon.War, attackingUnit)
         attacker.getCivInfo().addNotification(notificationString, locations, defendingUnit, NotificationIcon.War, attackingUnit)
         return true

--- a/core/src/com/unciv/logic/city/CityConstructions.kt
+++ b/core/src/com/unciv/logic/city/CityConstructions.kt
@@ -366,22 +366,21 @@ class CityConstructions {
                 (construction as INonPerpetualConstruction).getRejectionReasons(this)
 
             if (rejectionReasons.hasAReasonToBeRemovedFromQueue()) {
+                val workDone = getWorkDone(constructionName)
                 if (construction is Building) {
                     // Production put into wonders gets refunded
-                    if (construction.isWonder && getWorkDone(constructionName) != 0) {
-                        cityInfo.civInfo.addGold( getWorkDone(constructionName) )
-                        val buildingIcon = "BuildingIcons/${constructionName}"
-                        cityInfo.civInfo.addNotification("Excess production for [$constructionName] converted to [${getWorkDone(constructionName)}] gold", NotificationIcon.Gold, buildingIcon)
+                    if (construction.isWonder && workDone != 0) {
+                        cityInfo.civInfo.addGold(workDone)
+                        cityInfo.civInfo.addNotification(
+                            "Excess production for [$constructionName] converted to [$workDone] gold",
+                            cityInfo.location,
+                            NotificationIcon.Gold, "BuildingIcons/${constructionName}")
                     }
                 } else if (construction is BaseUnit) {
                     // Production put into upgradable units gets put into upgraded version
                     if (rejectionReasons.all { it == RejectionReason.Obsoleted } && construction.upgradesTo != null) {
-                        // I'd love to use the '+=' operator but since 'inProgressConstructions[...]' can be null, kotlin doesn't allow me to
-                        if (!inProgressConstructions.contains(construction.upgradesTo)) {
-                            inProgressConstructions[construction.upgradesTo!!] = getWorkDone(constructionName)
-                        } else {
-                            inProgressConstructions[construction.upgradesTo!!] = inProgressConstructions[construction.upgradesTo!!]!! + getWorkDone(constructionName)
-                        }
+                        inProgressConstructions[construction.upgradesTo!!] =
+                            (inProgressConstructions[construction.upgradesTo!!] ?: 0) + workDone
                     }
                 }
                 inProgressConstructions.remove(constructionName)

--- a/core/src/com/unciv/logic/city/CityExpansionManager.kt
+++ b/core/src/com/unciv/logic/city/CityExpansionManager.kt
@@ -181,7 +181,7 @@ class CityExpansionManager {
         if (cultureStored >= getCultureToNextTile()) {
             val location = addNewTileWithCulture()
             if (location != null) {
-                val locations = LocationAction(listOf(location, cityInfo.location))
+                val locations = LocationAction(location, cityInfo.location)
                 cityInfo.civInfo.addNotification("[" + cityInfo.name + "] has expanded its borders!", locations, NotificationIcon.Culture)
             }
         }

--- a/core/src/com/unciv/logic/civilization/CityStateFunctions.kt
+++ b/core/src/com/unciv/logic/civilization/CityStateFunctions.kt
@@ -82,7 +82,7 @@ class CityStateFunctions(val civInfo: CivilizationInfo) {
         val cities = NextTurnAutomation.getClosestCities(receivingCiv, civInfo)
         val placedUnit = receivingCiv.placeUnitNearTile(cities.city1.location, giftedUnit.name)
             ?: return
-        val locations = LocationAction(listOf(placedUnit.getTile().position, cities.city2.location))
+        val locations = LocationAction(placedUnit.getTile().position, cities.city2.location)
         receivingCiv.addNotification( "[${civInfo.civName}] gave us a [${giftedUnit.name}] as a gift!", locations, civInfo.civName, giftedUnit.name)
     }
 
@@ -110,7 +110,7 @@ class CityStateFunctions(val civInfo: CivilizationInfo) {
 
         // Point to the places mentioned in the message _in that order_ (debatable)
         val placedLocation = placedUnit.getTile().position
-        val locations = LocationAction(listOf(placedLocation, cities.city2.location, city.location))
+        val locations = LocationAction(placedLocation, cities.city2.location, city.location)
         receivingCiv.addNotification("[${civInfo.civName}] gave us a [${militaryUnit.name}] as gift near [${city.name}]!", locations, civInfo.civName, militaryUnit.name)
     }
 

--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -1091,8 +1091,9 @@ class CivilizationInfo {
 
     fun addNotification(text: String, action: NotificationAction?, vararg notificationIcons: String) {
         if (playerType == PlayerType.AI) return // no point in lengthening the saved game info if no one will read it
-        val arrayList = ArrayList<String>().apply { addAll(notificationIcons) }
-        notifications.add(Notification(text, arrayList, action))
+        val arrayList = notificationIcons.toCollection(ArrayList())
+        notifications.add(Notification(text, arrayList,
+                if (action is LocationAction && action.locations.isEmpty()) null else action))
     }
 
     fun addUnit(unitName: String, city: CityInfo? = null): MapUnit? {

--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -1,7 +1,6 @@
 package com.unciv.logic.civilization
 
 import com.badlogic.gdx.math.Vector2
-import com.unciv.Constants
 import com.unciv.UncivGame
 import com.unciv.logic.GameInfo
 import com.unciv.logic.UncivShowableException
@@ -1084,7 +1083,7 @@ class CivilizationInfo {
 
 
     fun addNotification(text: String, location: Vector2, vararg notificationIcons: String) {
-        addNotification(text, LocationAction(listOf(location)), *notificationIcons)
+        addNotification(text, LocationAction(location), *notificationIcons)
     }
 
     fun addNotification(text: String, vararg notificationIcons: String) = addNotification(text, null, *notificationIcons)

--- a/core/src/com/unciv/logic/civilization/Notification.kt
+++ b/core/src/com/unciv/logic/civilization/Notification.kt
@@ -1,9 +1,7 @@
 package com.unciv.logic.civilization
 
 import com.badlogic.gdx.math.Vector2
-import com.unciv.models.stats.Stat
 import com.unciv.ui.cityscreen.CityScreen
-import com.unciv.ui.pickerscreens.PolicyPickerScreen
 import com.unciv.ui.pickerscreens.TechPickerScreen
 import com.unciv.ui.trade.DiplomacyScreen
 import com.unciv.ui.utils.MayaCalendar
@@ -54,10 +52,15 @@ interface NotificationAction {
     fun execute(worldScreen: WorldScreen)
 }
 
-/** cycle through tiles */
+/** A notification action that cycles through tiles.
+ * 
+ * Constructors accept any kind of [Vector2] collection, including [Iterable], [Sequence], `vararg`.
+ * `varargs` allows nulls which are ignored, a resulting empty list is allowed and equivalent to no [NotificationAction].
+ */
 data class LocationAction(var locations: ArrayList<Vector2> = ArrayList()) : NotificationAction {
-
-    constructor(locations: List<Vector2>) : this(ArrayList(locations))
+    constructor(locations: Iterable<Vector2>) : this(locations.toCollection(ArrayList()))
+    constructor(locations: Sequence<Vector2>) : this(locations.toCollection(ArrayList()))
+    constructor(vararg locations: Vector2?) : this(locations.asSequence().filterNotNull())
 
     override fun execute(worldScreen: WorldScreen) {
         if (locations.isNotEmpty()) {

--- a/core/src/com/unciv/logic/civilization/Notification.kt
+++ b/core/src/com/unciv/logic/civilization/Notification.kt
@@ -27,6 +27,9 @@ object NotificationIcon {
     const val Food = "StatIcons/Food"
     const val Faith = "StatIcons/Faith"
     const val Crosshair = "OtherIcons/CrosshairB"
+    const val Scout = "UnitIcons/Scout"
+    const val Ruins = "ImprovementIcons/Ancient ruins"
+    const val Barbarians = "ImprovementIcons/Barbarian encampment"
 }
 
 /**

--- a/core/src/com/unciv/logic/civilization/QuestManager.kt
+++ b/core/src/com/unciv/logic/civilization/QuestManager.kt
@@ -226,7 +226,7 @@ class QuestManager {
                     && !it.isAtWarWith(civInfo)
                     && it.getProximity(civInfo) <= Proximity.Far }) {
                 otherCiv.addNotification("[${civInfo.civName}] is being invaded by Barbarians! Destroy Barbarians near their territory to earn Influence.",
-                    LocationAction(listOf(civInfo.getCapital().location)), civInfo.civName, NotificationIcon.War)
+                    civInfo.getCapital().location, civInfo.civName, NotificationIcon.War)
             }
             civInfo.addFlag(CivFlags.TurnsTillCallForBarbHelp.name, 30)
         }

--- a/core/src/com/unciv/logic/civilization/TechManager.kt
+++ b/core/src/com/unciv/logic/civilization/TechManager.kt
@@ -313,7 +313,7 @@ class TechManager {
                     civInfo.addNotification(text, city.location, NotificationIcon.Construction)
                 }
             } else {
-                val locationAction = LocationAction(cities.map { it.location })
+                val locationAction = LocationAction(cities.asSequence().map { it.location })
                 if (construction is BaseUnit && construction.upgradesTo != null) {
                     val text = "[${cities.size}] cities changed production from [$unit] to [${construction.upgradesTo!!}]"
                     civInfo.addNotification(text, locationAction, unit, NotificationIcon.Construction, construction.upgradesTo!!)

--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -670,7 +670,7 @@ class MapUnit {
             productionPointsToAdd * 2 / 3
         if (productionPointsToAdd > 0) {
             closestCity.cityConstructions.addProductionPoints(productionPointsToAdd)
-            val locations = LocationAction(listOf(tile.position, closestCity.location))
+            val locations = LocationAction(tile.position, closestCity.location)
             civInfo.addNotification(
                 "Clearing a [$removedTerrainFeature] has created [$productionPointsToAdd] Production for [${closestCity.name}]",
                 locations, NotificationIcon.Construction
@@ -1066,7 +1066,7 @@ class MapUnit {
             ?: return
         if (damage == 0) return
         health -= damage
-        val locations = LocationAction(listOf(citadelTile.position, currentTile.position))
+        val locations = LocationAction(citadelTile.position, currentTile.position)
         if (health <= 0) {
             civInfo.addNotification(
                 "An enemy [Citadel] has destroyed our [$name]",

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -1,6 +1,7 @@
 package com.unciv.models.ruleset.unique
 
 import com.badlogic.gdx.math.Vector2
+import com.unciv.Constants
 import com.unciv.logic.city.CityInfo
 import com.unciv.logic.civilization.*
 import com.unciv.logic.map.MapUnit
@@ -90,7 +91,7 @@ object UniqueTriggerActivation {
                         else notification
                     civInfo.addNotification(
                         notificationText,
-                        placedUnit.getTile().position,
+                        LocationAction(placedUnit.getTile().position, tile?.position),
                         placedUnit.name
                     )
                 }
@@ -191,7 +192,7 @@ object UniqueTriggerActivation {
                         else notification
                     civInfo.addNotification(
                         notificationText,
-                        randomCity.location,
+                        LocationAction(randomCity.location, tile?.position),
                         NotificationIcon.Population
                     )
                 }
@@ -233,7 +234,7 @@ object UniqueTriggerActivation {
                             notification.fillPlaceholders(*(techsToResearch.map { it.name }
                                 .toTypedArray()))
                         else notification
-                    civInfo.addNotification(notificationText, NotificationIcon.Science)
+                    civInfo.addNotification(notificationText, LocationAction(tile?.position), NotificationIcon.Science)
                 }
 
                 return true
@@ -261,7 +262,7 @@ object UniqueTriggerActivation {
 
             OneTimeRevealEntireMap -> {
                 if (notification != null) {
-                    civInfo.addNotification(notification, "UnitIcons/Scout")
+                    civInfo.addNotification(notification, LocationAction(tile?.position), NotificationIcon.Scout)
                 }
                 return civInfo.exploredTiles.addAll(
                     civInfo.gameInfo.tileMap.values.asSequence().map { it.position })
@@ -329,7 +330,7 @@ object UniqueTriggerActivation {
 
                 civInfo.addStat(stat, unique.params[0].toInt())
                 if (notification != null)
-                    civInfo.addNotification(notification, stat.notificationIcon)
+                    civInfo.addNotification(notification, LocationAction(tile?.position), stat.notificationIcon)
                 return true
             }
             OneTimeGainStatRange -> {
@@ -356,7 +357,7 @@ object UniqueTriggerActivation {
                         if (notification.hasPlaceholderParameters()) {
                             notification.fillPlaceholders(foundStatAmount.toString())
                         } else notification
-                    civInfo.addNotification(notificationText, stat.notificationIcon)
+                    civInfo.addNotification(notificationText, LocationAction(tile?.position), stat.notificationIcon)
                 }
 
                 return true
@@ -373,7 +374,7 @@ object UniqueTriggerActivation {
                         if (notification.hasPlaceholderParameters())
                             notification.fillPlaceholders(gainedFaith.toString())
                         else notification
-                    civInfo.addNotification(notificationText, NotificationIcon.Faith)
+                    civInfo.addNotification(notificationText, LocationAction(tile?.position), NotificationIcon.Faith)
                 }
 
                 return true
@@ -391,7 +392,7 @@ object UniqueTriggerActivation {
                         if (notification.hasPlaceholderParameters())
                             notification.fillPlaceholders(gainedFaith.toString())
                         else notification
-                    civInfo.addNotification(notificationText, NotificationIcon.Faith)
+                    civInfo.addNotification(notificationText, LocationAction(tile?.position), NotificationIcon.Faith)
                 }
 
                 return true
@@ -424,8 +425,10 @@ object UniqueTriggerActivation {
                 if (notification != null) {
                     civInfo.addNotification(
                         notification,
-                        LocationAction(nearbyRevealableTiles)
-                    ) // We really need a barbarian icon
+                        LocationAction(nearbyRevealableTiles),
+                        if (unique.params[1] == Constants.barbarianEncampment)
+                            NotificationIcon.Barbarians else NotificationIcon.Scout
+                    )
                 }
 
                 return true
@@ -447,7 +450,7 @@ object UniqueTriggerActivation {
                     civInfo.addNotification(
                         notification,
                         tile.position,
-                        "ImprovementIcons/Ancient ruins"
+                        NotificationIcon.Ruins
                     )
             }
 
@@ -512,7 +515,7 @@ object UniqueTriggerActivation {
                     ?: return false
                 unit.promotions.addPromotion(promotion, true)
                 if (notification != null)
-                    unit.civInfo.addNotification(notification, unit.name)
+                    unit.civInfo.addNotification(notification, unit.getTile().position, unit.name)
                 return true
             }
         }

--- a/core/src/com/unciv/ui/worldscreen/AlertPopup.kt
+++ b/core/src/com/unciv/ui/worldscreen/AlertPopup.kt
@@ -256,55 +256,32 @@ class AlertPopup(val worldScreen: WorldScreen, val popupAlert: PopupAlert): Popu
                     }
                 }
             }
-            AlertType.BulliedProtectedMinor -> {
+            AlertType.BulliedProtectedMinor, AlertType.AttackedProtectedMinor -> {
                 val involvedCivs = popupAlert.value.split('@')
-                val bully = worldScreen.gameInfo.getCivilization(involvedCivs[0])
+                val bullyOrAttacker = worldScreen.gameInfo.getCivilization(involvedCivs[0])
                 val cityState = worldScreen.gameInfo.getCivilization(involvedCivs[1])
                 val player = worldScreen.viewingCiv
-                addLeaderName(bully)
+                addLeaderName(bullyOrAttacker)
 
-                val text = if (bully.getDiplomacyManager(player).relationshipLevel() >= RelationshipLevel.Neutral) // Nice message
-                    "I've been informed that my armies have taken tribute from [${cityState.civName}], a city-state under your protection.\nI assure you, this was quite unintentional, and I hope that this does not serve to drive us apart."
-                else    // Nasty message
-                    "We asked [${cityState.civName}] for a tribute recently and they gave in.\nYou promised to protect them from such things, but we both know you cannot back that up."
+                val relation = bullyOrAttacker.getDiplomacyManager(player).relationshipLevel()
+                val text = when {
+                    popupAlert.type == AlertType.BulliedProtectedMinor && relation >= RelationshipLevel.Neutral ->  // Nice message
+                        "I've been informed that my armies have taken tribute from [${cityState.civName}], a city-state under your protection.\nI assure you, this was quite unintentional, and I hope that this does not serve to drive us apart."
+                    popupAlert.type == AlertType.BulliedProtectedMinor ->  // Nasty message
+                        "We asked [${cityState.civName}] for a tribute recently and they gave in.\nYou promised to protect them from such things, but we both know you cannot back that up."
+                    relation >= RelationshipLevel.Neutral ->  // Nice message
+                        "It's come to my attention that I may have attacked [${cityState.civName}], a city-state under your protection.\nWhile it was not my goal to be at odds with your empire, this was deemed a necessary course of action."
+                    else ->  // Nasty message
+                        "I thought you might like to know that I've launched an invasion of one of your little pet states.\nThe lands of [${cityState.civName}] will make a fine addition to my own."
+                }
                 addGoodSizedLabel(text).row()
 
                 add(getCloseButton("You'll pay for this!", 'y') {
-                    player.getDiplomacyManager(bully).sideWithCityState()
+                    player.getDiplomacyManager(bullyOrAttacker).sideWithCityState()
                 }).row()
                 add(getCloseButton("Very well.", 'n') {
-                    if(cityState.cities.isEmpty())
-                        player.addNotification("You have broken your Pledge to Protect [${cityState.civName}]!", cityState.civName)
-                    else {
-                        val capitalLocation = LocationAction(listOf(cityState.getCapital().location))
-                        player.addNotification("You have broken your Pledge to Protect [${cityState.civName}]!", capitalLocation, cityState.civName)
-                    }
-                    cityState.removeProtectorCiv(player, forced = true)
-                }).row()
-            }
-            AlertType.AttackedProtectedMinor -> {
-                val involvedCivs = popupAlert.value.split('@')
-                val attacker = worldScreen.gameInfo.getCivilization(involvedCivs[0])
-                val cityState = worldScreen.gameInfo.getCivilization(involvedCivs[1])
-                val player = worldScreen.viewingCiv
-                addLeaderName(attacker)
-
-                val text = if (attacker.getDiplomacyManager(player).relationshipLevel() >= RelationshipLevel.Neutral) // Nice message
-                    "It's come to my attention that I may have attacked [${cityState.civName}], a city-state under your protection.\nWhile it was not my goal to be at odds with your empire, this was deemed a necessary course of action."
-                else    // Nasty message
-                    "I thought you might like to know that I've launched an invasion of one of your little pet states.\nThe lands of [${cityState.civName}] will make a fine addition to my own."
-                addGoodSizedLabel(text).row()
-
-                add(getCloseButton("You'll pay for this!", 'y') {
-                    player.getDiplomacyManager(attacker).sideWithCityState()
-                }).row()
-                add(getCloseButton("Very well.", 'n') {
-                    if(cityState.cities.isEmpty())
-                        player.addNotification("You have broken your Pledge to Protect [${cityState.civName}]!", cityState.civName)
-                    else {
-                        val capitalLocation = LocationAction(listOf(cityState.getCapital().location))
-                        player.addNotification("You have broken your Pledge to Protect [${cityState.civName}]!", capitalLocation, cityState.civName)
-                    }
+                    val capitalLocation = LocationAction(cityState.cities.asSequence().map { it.location }) // in practice 0 or 1 entries, that's OK
+                    player.addNotification("You have broken your Pledge to Protect [${cityState.civName}]!", capitalLocation, cityState.civName)
                     cityState.removeProtectorCiv(player, forced = true)
                 }).row()
             }


### PR DESCRIPTION
This came about because some notification reactions to clicks irked me, then I couldn't resist simplifying the caller code for little cost to the class code. Then I ended up reorganizing some of the caller code. Organized into separate commits for the distinct aspects:

- LocationAction now accepts and copes with most anything, including `vararg Vector1?`
- All calls checked and simplified. Some look more complex due to Sequence use to reduce the number of copy allocations to one.
- Most if not all Ruin reward notifications should finger the location where the ruin was (for our rulesets - mods could use triggers I didn't touch). Unit XP and unit upgrade not touched as the unit is already fingered.
- The production refund messages from a lost Wonder race now finger the city