### PR TITLE
Minor Constants.minimumMovementEpsilon cleanup

### DIFF
--- a/core/src/com/unciv/Constants.kt
+++ b/core/src/com/unciv/Constants.kt
@@ -58,10 +58,15 @@ object Constants {
     const val rising = "Rising"
     const val lowering = "Lowering"
     const val remove = "Remove "
-    
+
     const val uniqueOrDelimiter = "\" OR \""
-    
-    const val minimumMovementEpsilon = 0.05
+
+    /**
+     * Use this to determine whether a [MapUnit][com.unciv.logic.map.MapUnit]'s movement is exhausted
+     * (currentMovement <= this) if and only if a fuzzy comparison is needed to account for Float rounding errors.
+     * _Most_ checks do compare to 0!
+     */
+    const val minimumMovementEpsilon = 0.05f  // 0.1f was used previously, too - here for global searches
     const val defaultFontSize = 18
     const val headingFontSize = 24
 }

--- a/core/src/com/unciv/logic/automation/BattleHelper.kt
+++ b/core/src/com/unciv/logic/automation/BattleHelper.kt
@@ -1,5 +1,6 @@
 package com.unciv.logic.automation
 
+import com.unciv.Constants
 import com.unciv.logic.battle.Battle
 import com.unciv.logic.battle.BattleDamage
 import com.unciv.logic.battle.ICombatant
@@ -54,11 +55,6 @@ object BattleHelper {
         val rangeOfAttack = unit.getRange()
 
         val attackableTiles = ArrayList<AttackableTile>()
-        // The >0.1 (instead of >0) solves a bug where you've moved 2/3 road tiles,
-        // you come to move a third (distance is less that remaining movements),
-        // and then later we round it off to a whole.
-        // So the poor unit thought it could attack from the tile, but when it comes to do so it has no movement points!
-        // Silly floats, basically
 
         val unitMustBeSetUp = unit.hasUnique(UniqueType.MustSetUp)
         val tilesToAttackFrom = if (stayOnTile || unit.baseUnit.movesLikeAirUnits())
@@ -75,8 +71,8 @@ object BattleHelper {
                         unit.currentMovement - distance.totalDistance - movementPointsToExpendBeforeAttack
                     Pair(tile, movementLeft)
                 }
-                // still got leftover movement points after all that, to attack (0.1 is because of Float nonsense, see MapUnit.moveToTile(...)
-                .filter { it.second > 0.1f }
+                // still got leftover movement points after all that, to attack
+                .filter { it.second > Constants.minimumMovementEpsilon }
                 .filter {
                     it.first == unit.getTile() || unit.movement.canMoveTo(it.first)
                 }

--- a/core/src/com/unciv/ui/overviewscreen/UnitOverviewTable.kt
+++ b/core/src/com/unciv/ui/overviewscreen/UnitOverviewTable.kt
@@ -2,6 +2,7 @@ package com.unciv.ui.overviewscreen
 
 import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.scenes.scene2d.ui.Table
+import com.unciv.Constants
 import com.unciv.logic.civilization.CivilizationInfo
 import com.unciv.models.translations.tr
 import com.unciv.ui.pickerscreens.PromotionPickerScreen
@@ -77,7 +78,7 @@ class UnitOverviewTable(
             for (unit in viewingPlayer.getCivUnits().sortedWith(
                 compareBy({ it.displayName() },
                     { !it.due },
-                    { it.currentMovement < 0.1f },
+                    { it.currentMovement <= Constants.minimumMovementEpsilon },
                     { abs(it.currentTile.position.x) + abs(it.currentTile.position.y) })
             )) {
                 val baseUnit = unit.baseUnit()

--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -13,6 +13,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.Button
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton
 import com.badlogic.gdx.utils.Align
+import com.unciv.Constants
 import com.unciv.UncivGame
 import com.unciv.logic.GameInfo
 import com.unciv.logic.GameSaver
@@ -791,7 +792,7 @@ class WorldScreen(val gameInfo: GameInfo, val viewingCiv:CivilizationInfo) : Bas
                 }
 
             !viewingCiv.hasMovedAutomatedUnits && viewingCiv.getCivUnits()
-                .any { it.currentMovement >= 0.1f && (it.isMoving() || it.isAutomated() || it.isExploring()) } ->
+                .any { it.currentMovement > Constants.minimumMovementEpsilon && (it.isMoving() || it.isAutomated() || it.isExploring()) } ->
                 NextTurnAction("Move automated units", Color.LIGHT_GRAY) {
                     viewingCiv.hasMovedAutomatedUnits = true
                     isPlayersTurn = false // Disable state changes


### PR DESCRIPTION
Since the const was there it should cover _all_ cases where MapUnit.currentMovement is compared with some Epsilon. To be moved to ModConstants as soon as RoadStatus is moddable... :grinning: 