### PR TITLE
Unique units abilities that should be inherited by upgrades

### DIFF
--- a/android/assets/jsons/Civ V - Gods & Kings/UnitPromotions.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/UnitPromotions.json
@@ -547,5 +547,54 @@
 	{
 		"name": "Home Sweet Home", // only for Mehal Sefari and subsequent upgrades
 		"uniques": ["[+30]% Strength decreasing with distance from the capital"]
+	},
+	{
+		"name": "Mohawk Warrior ability",
+		"uniques": ["[+33]% Strength <when fighting in [Forest] tiles>", "[+33]% Strength <when fighting in [Jungle] tiles>"]
+	},
+	{
+		"name": "Jaguar ability",
+		"uniques": ["[+33]% Strength <when fighting in [Forest] tiles>", "[+33]% Strength <when fighting in [Jungle] tiles>", "Heals [25] damage if it kills a unit"]
+	},
+	{
+		"name": "Persian Immortal ability",
+		"uniques": ["[+10] HP when healing"]
+	},
+	{
+		"name": "Conquistador ability",
+		"uniques": ["Defense bonus when embarked"]
+	},
+	{
+		"name": "Janissary ability",
+		"uniques": ["Heals [50] damage if it kills a unit", "[+25]% Strength <when attacking>"]
+	},
+	{
+		"name": "Sipahi ability",
+		"uniques": ["No movement cost to pillage"]
+	},
+	{
+		"name": "Cossack ability",
+		"uniques": ["[+50]% Strength <vs [Wounded] units>"]
+	},
+	{
+		"name": "Hussar ability",
+		"uniques": ["[+50]% to Flank Attack bonuses"]
+	},
+	{
+		"name": "Norwegian Ski Infantry ability",
+		"uniques": ["[+25]% Strength <when fighting in [Snow] tiles>",
+			"[+25]% Strength <when fighting in [Tundra] tiles>",
+			"[+25]% Strength <when fighting in [Hill] tiles>",
+			"Double movement in [Snow]",
+			"Double movement in [Tundra]",
+			"Double movement in [Hill]"]
+	},
+	{
+		"name": "Hakkapeliitta ability",
+		"uniques": ["Transfer Movement to [Great General]", "[+15]% Strength when stacked with [Great General]"]
+	},
+	{
+		"name": "Zero ability",
+		"uniques": ["[+33]% Strength <vs [Fighter] units>"]
 	}
 ]

--- a/android/assets/jsons/Civ V - Gods & Kings/UnitPromotions.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/UnitPromotions.json
@@ -549,39 +549,39 @@
 		"uniques": ["[+30]% Strength decreasing with distance from the capital"]
 	},
 	{
-		"name": "Mohawk Warrior ability",
+		"name": "[Mohawk Warrior] ability",
 		"uniques": ["[+33]% Strength <when fighting in [Forest] tiles>", "[+33]% Strength <when fighting in [Jungle] tiles>"]
 	},
 	{
-		"name": "Jaguar ability",
+		"name": "[Jaguar] ability",
 		"uniques": ["[+33]% Strength <when fighting in [Forest] tiles>", "[+33]% Strength <when fighting in [Jungle] tiles>", "Heals [25] damage if it kills a unit"]
 	},
 	{
-		"name": "Persian Immortal ability",
+		"name": "[Persian Immortal] ability",
 		"uniques": ["[+10] HP when healing"]
 	},
 	{
-		"name": "Conquistador ability",
+		"name": "[Conquistador] ability",
 		"uniques": ["Defense bonus when embarked"]
 	},
 	{
-		"name": "Janissary ability",
+		"name": "[Janissary] ability",
 		"uniques": ["Heals [50] damage if it kills a unit", "[+25]% Strength <when attacking>"]
 	},
 	{
-		"name": "Sipahi ability",
+		"name": "[Sipahi] ability",
 		"uniques": ["No movement cost to pillage"]
 	},
 	{
-		"name": "Cossack ability",
+		"name": "[Cossack] ability",
 		"uniques": ["[+50]% Strength <vs [Wounded] units>"]
 	},
 	{
-		"name": "Hussar ability",
+		"name": "[Hussar] ability",
 		"uniques": ["[+50]% to Flank Attack bonuses"]
 	},
 	{
-		"name": "Norwegian Ski Infantry ability",
+		"name": "[Norwegian Ski Infantry] ability",
 		"uniques": ["[+25]% Strength <when fighting in [Snow] tiles>",
 			"[+25]% Strength <when fighting in [Tundra] tiles>",
 			"[+25]% Strength <when fighting in [Hill] tiles>",
@@ -590,11 +590,11 @@
 			"Double movement in [Hill]"]
 	},
 	{
-		"name": "Hakkapeliitta ability",
+		"name": "[Hakkapeliitta] ability",
 		"uniques": ["Transfer Movement to [Great General]", "[+15]% Strength when stacked with [Great General]"]
 	},
 	{
-		"name": "Zero ability",
+		"name": "[Zero] ability",
 		"uniques": ["[+33]% Strength <vs [Fighter] units>"]
 	}
 ]

--- a/android/assets/jsons/Civ V - Gods & Kings/Units.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Units.json
@@ -66,8 +66,7 @@
 		"strength": 8,
 		"cost": 40,
 		"obsoleteTech": "Metal Casting",
-		"uniques": ["[+33]% Strength <when fighting in [Forest] tiles>", "[+33]% Strength <when fighting in [Jungle] tiles>", "Heals [25] damage if it kills a unit"],
-		"promotions": ["Woodsman"],
+		"promotions": ["Jaguar ability","Woodsman"],
 		"upgradesTo": "Swordsman",
 		"attackSound": "nonmetalhit"
 	},
@@ -311,7 +310,8 @@
 		"requiredTech": "Bronze Working",
 		"obsoleteTech": "Civil Service",
 		"upgradesTo": "Pikeman",
-		"uniques": ["[+50]% Strength <vs [Mounted] units>", "[+10] HP when healing"],
+		"uniques": ["[+50]% Strength <vs [Mounted] units>"],
+		"promotions":["Persian Immortal ability"],
 		"attackSound": "metalhit"
 	},
 	{
@@ -509,7 +509,7 @@
 		"upgradesTo": "Longswordsman",
 		"obsoleteTech": "Gunpowder",
 		"hurryCostModifier": 20,
-		"uniques": ["[+33]% Strength <when fighting in [Forest] tiles>", "[+33]% Strength <when fighting in [Jungle] tiles>"],
+		"promotions": ["Mohawk Warrior ability"],
 		"attackSound": "metalhit"
 	},
 	/*
@@ -612,7 +612,8 @@
 		"requiredResource": "Horses",
 		"upgradesTo": "Cavalry",
 		"obsoleteTech": "Military Science",
-		"uniques": ["Can move after attacking","No defensive terrain bonus", "Founds a new city <on foreign continents>", "[+2] Sight", "Defense bonus when embarked"],
+		"uniques": ["Can move after attacking","No defensive terrain bonus", "Founds a new city <on foreign continents>", "[+2] Sight"],
+		"promotions": ["Conquistador ability"],
 		"attackSound": "horse"
 		//Conquistador should have no penalty attacking cities
 		//Ability to found new cities can only be used on a foreign continent that does not contain the Spanish capital.
@@ -847,7 +848,7 @@
 		"requiredTech": "Gunpowder",
 		"upgradesTo": "Rifleman",
 		"obsoleteTech": "Rifling",
-		"uniques": ["Heals [50] damage if it kills a unit", "[+25]% Strength <when attacking>"],
+		"promotions": ["Janissary ability"],
 		"attackSound": "shot"
 	},
 	{
@@ -961,8 +962,8 @@
 		"requiredTech": "Metallurgy",
 		"requiredResource": "Horses",
 		"uniques": ["Can move after attacking","No defensive terrain bonus","[-33]% Strength <vs cities>",
-			"[+1] Sight", "No movement cost to pillage"],
-		"promotions": ["Formation I"],
+			"[+1] Sight"],
+		"promotions": ["Sipahi ability","Formation I"],
 		"upgradesTo": "Anti-Tank Gun",
 		"obsoleteTech": "Combined Arms",
 		"attackSound": "horse"
@@ -977,9 +978,8 @@
 		"cost": 185,
 		"requiredTech": "Metallurgy",
 		"requiredResource": "Horses",
-		"uniques": ["Can move after attacking","No defensive terrain bonus","[-33]% Strength <vs cities>",
-			"Transfer Movement to [Great General]", "[+15]% Strength when stacked with [Great General]"],
-		"promotions": ["Formation I"],
+		"uniques": ["Can move after attacking","No defensive terrain bonus","[-33]% Strength <vs cities>"],
+		"promotions": ["Hakkapeliitta ability","Formation I"],
 		"upgradesTo": "Anti-Tank Gun",
 		"obsoleteTech": "Combined Arms",
 		"attackSound": "horse"
@@ -1035,12 +1035,7 @@
 		"requiredTech": "Rifling",
 		"obsoleteTech": "Replaceable Parts",
 		"upgradesTo": "Great War Infantry",
-		"uniques": ["[+25]% Strength <when fighting in [Snow] tiles>",
-			"[+25]% Strength <when fighting in [Tundra] tiles>",
-			"[+25]% Strength <when fighting in [Hill] tiles>",
-			"Double movement in [Snow]",
-			"Double movement in [Tundra]",
-			"Double movement in [Hill]"],
+		"promotions": ["Norwegian Ski Infantry ability"],
 		"attackSound": "shot"
 	},
 	{
@@ -1096,8 +1091,8 @@
 		"obsoleteTech": "Combustion",
 		"requiredResource": "Horses",
 		"upgradesTo": "Landship",
-		"uniques": ["Can move after attacking","No defensive terrain bonus",
-			"[-33]% Strength <vs cities>", "[+50]% Strength <vs [Wounded] units>"],
+		"uniques": ["Can move after attacking","No defensive terrain bonus","[-33]% Strength <vs cities>"],
+		"promotions": ["Cossack ability"],
 		"attackSound": "horse"
 	},
 	{
@@ -1112,8 +1107,9 @@
 		"obsoleteTech": "Combustion",
 		"requiredResource": "Horses",
 		"upgradesTo": "Landship",
-		"uniques": ["Can move after attacking","No defensive terrain bonus","[-33]% Strength <vs cities>" ,
-		"[+1] Sight", "[+50]% to Flank Attack bonuses" ],
+		"uniques": ["Can move after attacking","No defensive terrain bonus","[-33]% Strength <vs cities>",
+			"[+1] Sight"],
+		"promotions": ["Hussar ability"],
 		"attackSound": "horse"
 	},
 	{
@@ -1342,8 +1338,8 @@
 		"cost": 375,
 		"requiredTech": "Radar",
 		"upgradesTo": "Jet Fighter",
-		"uniques": ["[100]% chance to intercept air attacks", "[+150]% Strength <vs [Bomber] units>", "[+150]% Strength <vs [Helicopter] units>",
-			"[+33]% Strength <vs [Fighter] units>"],
+		"uniques": ["[100]% chance to intercept air attacks", "[+150]% Strength <vs [Bomber] units>", "[+150]% Strength <vs [Helicopter] units>"],
+		"promotions": ["Zero ability"],
 		"attackSound": "machinegun"
 	},
 	{

--- a/android/assets/jsons/Civ V - Gods & Kings/Units.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Units.json
@@ -66,7 +66,7 @@
 		"strength": 8,
 		"cost": 40,
 		"obsoleteTech": "Metal Casting",
-		"promotions": ["Jaguar ability","Woodsman"],
+		"promotions": ["[Jaguar] ability","Woodsman"],
 		"upgradesTo": "Swordsman",
 		"attackSound": "nonmetalhit"
 	},
@@ -311,7 +311,7 @@
 		"obsoleteTech": "Civil Service",
 		"upgradesTo": "Pikeman",
 		"uniques": ["[+50]% Strength <vs [Mounted] units>"],
-		"promotions":["Persian Immortal ability"],
+		"promotions":["[Persian Immortal] ability"],
 		"attackSound": "metalhit"
 	},
 	{
@@ -509,7 +509,7 @@
 		"upgradesTo": "Longswordsman",
 		"obsoleteTech": "Gunpowder",
 		"hurryCostModifier": 20,
-		"promotions": ["Mohawk Warrior ability"],
+		"promotions": ["[Mohawk Warrior] ability"],
 		"attackSound": "metalhit"
 	},
 	/*
@@ -613,7 +613,7 @@
 		"upgradesTo": "Cavalry",
 		"obsoleteTech": "Military Science",
 		"uniques": ["Can move after attacking","No defensive terrain bonus", "Founds a new city <on foreign continents>", "[+2] Sight"],
-		"promotions": ["Conquistador ability"],
+		"promotions": ["[Conquistador] ability"],
 		"attackSound": "horse"
 		//Conquistador should have no penalty attacking cities
 		//Ability to found new cities can only be used on a foreign continent that does not contain the Spanish capital.
@@ -848,7 +848,7 @@
 		"requiredTech": "Gunpowder",
 		"upgradesTo": "Rifleman",
 		"obsoleteTech": "Rifling",
-		"promotions": ["Janissary ability"],
+		"promotions": ["[Janissary] ability"],
 		"attackSound": "shot"
 	},
 	{
@@ -963,7 +963,7 @@
 		"requiredResource": "Horses",
 		"uniques": ["Can move after attacking","No defensive terrain bonus","[-33]% Strength <vs cities>",
 			"[+1] Sight"],
-		"promotions": ["Sipahi ability","Formation I"],
+		"promotions": ["[Sipahi] ability","Formation I"],
 		"upgradesTo": "Anti-Tank Gun",
 		"obsoleteTech": "Combined Arms",
 		"attackSound": "horse"
@@ -979,7 +979,7 @@
 		"requiredTech": "Metallurgy",
 		"requiredResource": "Horses",
 		"uniques": ["Can move after attacking","No defensive terrain bonus","[-33]% Strength <vs cities>"],
-		"promotions": ["Hakkapeliitta ability","Formation I"],
+		"promotions": ["[Hakkapeliitta] ability","Formation I"],
 		"upgradesTo": "Anti-Tank Gun",
 		"obsoleteTech": "Combined Arms",
 		"attackSound": "horse"
@@ -1035,7 +1035,7 @@
 		"requiredTech": "Rifling",
 		"obsoleteTech": "Replaceable Parts",
 		"upgradesTo": "Great War Infantry",
-		"promotions": ["Norwegian Ski Infantry ability"],
+		"promotions": ["[Norwegian Ski Infantry] ability"],
 		"attackSound": "shot"
 	},
 	{
@@ -1092,7 +1092,7 @@
 		"requiredResource": "Horses",
 		"upgradesTo": "Landship",
 		"uniques": ["Can move after attacking","No defensive terrain bonus","[-33]% Strength <vs cities>"],
-		"promotions": ["Cossack ability"],
+		"promotions": ["[Cossack] ability"],
 		"attackSound": "horse"
 	},
 	{
@@ -1109,7 +1109,7 @@
 		"upgradesTo": "Landship",
 		"uniques": ["Can move after attacking","No defensive terrain bonus","[-33]% Strength <vs cities>",
 			"[+1] Sight"],
-		"promotions": ["Hussar ability"],
+		"promotions": ["[Hussar] ability"],
 		"attackSound": "horse"
 	},
 	{
@@ -1339,7 +1339,7 @@
 		"requiredTech": "Radar",
 		"upgradesTo": "Jet Fighter",
 		"uniques": ["[100]% chance to intercept air attacks", "[+150]% Strength <vs [Bomber] units>", "[+150]% Strength <vs [Helicopter] units>"],
-		"promotions": ["Zero ability"],
+		"promotions": ["[Zero] ability"],
 		"attackSound": "machinegun"
 	},
 	{

--- a/android/assets/jsons/Civ V - Vanilla/UnitPromotions.json
+++ b/android/assets/jsons/Civ V - Vanilla/UnitPromotions.json
@@ -549,35 +549,35 @@
 		"uniques": ["[+30]% Strength decreasing with distance from the capital"]
 	},
 	{
-		"name": "Mohawk Warrior ability",
+		"name": "[Mohawk Warrior] ability",
 		"uniques": ["[+33]% Strength <when fighting in [Forest] tiles>", "[+33]% Strength <when fighting in [Jungle] tiles>"]
 	},
 	{
-		"name": "Jaguar ability",
+		"name": "[Jaguar] ability",
 		"uniques": ["[+33]% Strength <when fighting in [Forest] tiles>", "[+33]% Strength <when fighting in [Jungle] tiles>", "Heals [25] damage if it kills a unit"]
 	},
 	{
-		"name": "Persian Immortal ability",
+		"name": "[Persian Immortal] ability",
 		"uniques": ["[+10] HP when healing"]
 	},
 	{
-		"name": "Conquistador ability",
+		"name": "[Conquistador] ability",
 		"uniques": ["Defense bonus when embarked"]
 	},
 	{
-		"name": "Janissary ability",
+		"name": "[Janissary] ability",
 		"uniques": ["Heals [50] damage if it kills a unit", "[+25]% Strength <when attacking>"]
 	},
 	{
-		"name": "Sipahi ability",
+		"name": "[Sipahi] ability",
 		"uniques": ["No movement cost to pillage"]
 	},
 	{
-		"name": "Cossack ability",
+		"name": "[Cossack] ability",
 		"uniques": ["[+50]% Strength <vs [Wounded] units>"]
 	},
 	{
-		"name": "Norwegian Ski Infantry ability",
+		"name": "[Norwegian Ski Infantry] ability",
 		"uniques": ["[+25]% Strength <when fighting in [Snow] tiles>",
 			"[+25]% Strength <when fighting in [Tundra] tiles>",
 			"[+25]% Strength <when fighting in [Hill] tiles>",
@@ -586,7 +586,7 @@
 			"Double movement in [Hill]"]
 	},
 	{
-		"name": "Zero ability",
+		"name": "[Zero] ability",
 		"uniques": ["[+33]% Strength <vs [Fighter] units>"]
 	}
 ]

--- a/android/assets/jsons/Civ V - Vanilla/UnitPromotions.json
+++ b/android/assets/jsons/Civ V - Vanilla/UnitPromotions.json
@@ -547,5 +547,46 @@
 	{
 		"name": "Home Sweet Home", // only for Mehal Sefari and subsequent upgrades
 		"uniques": ["[+30]% Strength decreasing with distance from the capital"]
+	},
+	{
+		"name": "Mohawk Warrior ability",
+		"uniques": ["[+33]% Strength <when fighting in [Forest] tiles>", "[+33]% Strength <when fighting in [Jungle] tiles>"]
+	},
+	{
+		"name": "Jaguar ability",
+		"uniques": ["[+33]% Strength <when fighting in [Forest] tiles>", "[+33]% Strength <when fighting in [Jungle] tiles>", "Heals [25] damage if it kills a unit"]
+	},
+	{
+		"name": "Persian Immortal ability",
+		"uniques": ["[+10] HP when healing"]
+	},
+	{
+		"name": "Conquistador ability",
+		"uniques": ["Defense bonus when embarked"]
+	},
+	{
+		"name": "Janissary ability",
+		"uniques": ["Heals [50] damage if it kills a unit", "[+25]% Strength <when attacking>"]
+	},
+	{
+		"name": "Sipahi ability",
+		"uniques": ["No movement cost to pillage"]
+	},
+	{
+		"name": "Cossack ability",
+		"uniques": ["[+50]% Strength <vs [Wounded] units>"]
+	},
+	{
+		"name": "Norwegian Ski Infantry ability",
+		"uniques": ["[+25]% Strength <when fighting in [Snow] tiles>",
+			"[+25]% Strength <when fighting in [Tundra] tiles>",
+			"[+25]% Strength <when fighting in [Hill] tiles>",
+			"Double movement in [Snow]",
+			"Double movement in [Tundra]",
+			"Double movement in [Hill]"]
+	},
+	{
+		"name": "Zero ability",
+		"uniques": ["[+33]% Strength <vs [Fighter] units>"]
 	}
 ]

--- a/android/assets/jsons/Civ V - Vanilla/Units.json
+++ b/android/assets/jsons/Civ V - Vanilla/Units.json
@@ -66,8 +66,7 @@
 		"strength": 8,
 		"cost": 40,
 		"obsoleteTech": "Metal Casting",
-		"uniques": ["[+33]% Strength <when fighting in [Forest] tiles>", "[+33]% Strength <when fighting in [Jungle] tiles>", "Heals [25] damage if it kills a unit"],
-		"promotions": ["Woodsman"],
+		"promotions": ["Jaguar ability","Woodsman"],
 		"upgradesTo": "Swordsman",
 		"attackSound": "nonmetalhit"
 	},
@@ -252,7 +251,8 @@
 		"requiredTech": "Bronze Working",
 		"obsoleteTech": "Civil Service",
 		"upgradesTo": "Pikeman",
-		"uniques": ["[+50]% Strength <vs [Mounted] units>", "[+10] HP when healing"],
+		"uniques": ["[+50]% Strength <vs [Mounted] units>"],
+		"promotions":["Persian Immortal ability"],
 		"attackSound": "metalhit"
 	},
 	{
@@ -377,7 +377,7 @@
 		"upgradesTo": "Longswordsman",
 		"obsoleteTech": "Gunpowder",
 		"hurryCostModifier": 20,
-		"uniques": ["[+33]% Strength <when fighting in [Forest] tiles>", "[+33]% Strength <when fighting in [Jungle] tiles>"],
+		"promotions": ["Mohawk Warrior ability"],
 		"attackSound": "metalhit"
 	},
 	/*
@@ -467,7 +467,8 @@
 		"requiredResource": "Horses",
 		"upgradesTo": "Cavalry",
 		"obsoleteTech": "Military Science",
-		"uniques": ["Can move after attacking","No defensive terrain bonus", "Founds a new city <on foreign continents>", "[+2] Sight", "Defense bonus when embarked"],
+		"uniques": ["Can move after attacking","No defensive terrain bonus", "Founds a new city <on foreign continents>", "[+2] Sight"],
+		"promotions": ["Conquistador ability"],
 		"attackSound": "horse"
 		//Conquistador should have no penalty attacking cities
 		//Ability to found new cities can only be used on a foreign continent that does not contain the Spanish capital.
@@ -703,7 +704,7 @@
 		"requiredTech": "Gunpowder",
 		"upgradesTo": "Rifleman",
 		"obsoleteTech": "Rifling",
-		"uniques": ["Heals [50] damage if it kills a unit", "[+25]% Strength <when attacking>"],
+		"promotions": ["Janissary ability"],
 		"attackSound": "shot"
 	},
 	{
@@ -791,8 +792,8 @@
 		"requiredTech": "Metallurgy",
 		"requiredResource": "Horses",
 		"uniques": ["Can move after attacking","No defensive terrain bonus","[-33]% Strength <vs cities>",
-			"[+1] Sight", "No movement cost to pillage"],
-		"promotions": ["Formation I"],
+			"[+1] Sight"],
+		"promotions": ["Sipahi ability","Formation I"],
 		"upgradesTo": "Anti-Tank Gun",
 		"obsoleteTech": "Combustion",
 		"attackSound": "horse"
@@ -835,12 +836,7 @@
 		"requiredTech": "Rifling",
 		"obsoleteTech": "Replaceable Parts",
 		"upgradesTo": "Infantry",
-		"uniques": ["[+25]% Strength <when fighting in [Snow] tiles>",
-			"[+25]% Strength <when fighting in [Tundra] tiles>",
-			"[+25]% Strength <when fighting in [Hill] tiles>",
-			"Double movement in [Snow]",
-			"Double movement in [Tundra]",
-			"Double movement in [Hill]"],
+		"promotions": ["Norwegian Ski Infantry ability"],
 		"attackSound": "shot"
 	},
 	{
@@ -868,8 +864,8 @@
 		"obsoleteTech": "Combustion",
 		"requiredResource": "Horses",
 		"upgradesTo": "Tank",
-		"uniques": ["Can move after attacking","No defensive terrain bonus",
-			"[-33]% Strength <vs cities>", "[+50]% Strength <vs [Wounded] units>"],
+		"uniques": ["Can move after attacking","No defensive terrain bonus","[-33]% Strength <vs cities>"],
+		"promotions":["Cossack ability"],
 		"attackSound": "horse"
 	},
 	{
@@ -1018,8 +1014,8 @@
 		"cost": 375,
 		"requiredTech": "Radar",
 		"upgradesTo": "Jet Fighter",
-		"uniques": ["[100]% chance to intercept air attacks", "[+150]% Strength <vs [Bomber] units>", "[+150]% Strength <vs [Helicopter] units>",
-			"[+33]% Strength <vs [Fighter] units>"],
+		"uniques": ["[100]% chance to intercept air attacks", "[+150]% Strength <vs [Bomber] units>", "[+150]% Strength <vs [Helicopter] units>"],
+		"promotions": ["Zero ability"],
 		"attackSound": "machinegun"
 	},
 	{

--- a/android/assets/jsons/Civ V - Vanilla/Units.json
+++ b/android/assets/jsons/Civ V - Vanilla/Units.json
@@ -66,7 +66,7 @@
 		"strength": 8,
 		"cost": 40,
 		"obsoleteTech": "Metal Casting",
-		"promotions": ["Jaguar ability","Woodsman"],
+		"promotions": ["[Jaguar] ability","Woodsman"],
 		"upgradesTo": "Swordsman",
 		"attackSound": "nonmetalhit"
 	},
@@ -252,7 +252,7 @@
 		"obsoleteTech": "Civil Service",
 		"upgradesTo": "Pikeman",
 		"uniques": ["[+50]% Strength <vs [Mounted] units>"],
-		"promotions":["Persian Immortal ability"],
+		"promotions":["[Persian Immortal] ability"],
 		"attackSound": "metalhit"
 	},
 	{
@@ -377,7 +377,7 @@
 		"upgradesTo": "Longswordsman",
 		"obsoleteTech": "Gunpowder",
 		"hurryCostModifier": 20,
-		"promotions": ["Mohawk Warrior ability"],
+		"promotions": ["[Mohawk Warrior] ability"],
 		"attackSound": "metalhit"
 	},
 	/*
@@ -468,7 +468,7 @@
 		"upgradesTo": "Cavalry",
 		"obsoleteTech": "Military Science",
 		"uniques": ["Can move after attacking","No defensive terrain bonus", "Founds a new city <on foreign continents>", "[+2] Sight"],
-		"promotions": ["Conquistador ability"],
+		"promotions": ["[Conquistador] ability"],
 		"attackSound": "horse"
 		//Conquistador should have no penalty attacking cities
 		//Ability to found new cities can only be used on a foreign continent that does not contain the Spanish capital.
@@ -704,7 +704,7 @@
 		"requiredTech": "Gunpowder",
 		"upgradesTo": "Rifleman",
 		"obsoleteTech": "Rifling",
-		"promotions": ["Janissary ability"],
+		"promotions": ["[Janissary] ability"],
 		"attackSound": "shot"
 	},
 	{
@@ -793,7 +793,7 @@
 		"requiredResource": "Horses",
 		"uniques": ["Can move after attacking","No defensive terrain bonus","[-33]% Strength <vs cities>",
 			"[+1] Sight"],
-		"promotions": ["Sipahi ability","Formation I"],
+		"promotions": ["[Sipahi] ability","Formation I"],
 		"upgradesTo": "Anti-Tank Gun",
 		"obsoleteTech": "Combustion",
 		"attackSound": "horse"
@@ -836,7 +836,7 @@
 		"requiredTech": "Rifling",
 		"obsoleteTech": "Replaceable Parts",
 		"upgradesTo": "Infantry",
-		"promotions": ["Norwegian Ski Infantry ability"],
+		"promotions": ["[Norwegian Ski Infantry] ability"],
 		"attackSound": "shot"
 	},
 	{
@@ -865,7 +865,7 @@
 		"requiredResource": "Horses",
 		"upgradesTo": "Tank",
 		"uniques": ["Can move after attacking","No defensive terrain bonus","[-33]% Strength <vs cities>"],
-		"promotions":["Cossack ability"],
+		"promotions":["[Cossack] ability"],
 		"attackSound": "horse"
 	},
 	{
@@ -1015,7 +1015,7 @@
 		"requiredTech": "Radar",
 		"upgradesTo": "Jet Fighter",
 		"uniques": ["[100]% chance to intercept air attacks", "[+150]% Strength <vs [Bomber] units>", "[+150]% Strength <vs [Helicopter] units>"],
-		"promotions": ["Zero ability"],
+		"promotions": ["[Zero] ability"],
 		"attackSound": "machinegun"
 	},
 	{

--- a/android/assets/jsons/translations/German.properties
+++ b/android/assets/jsons/translations/German.properties
@@ -4025,6 +4025,13 @@ Pictish Courage = Piktische Tapferkeit
 Home Sweet Home = Trautes Heim
 [amount]% Strength decreasing with distance from the capital = [amount]% Stärke, abnehmend mit der Entfernung von der Hauptstadt
 
+[unit] ability = [unit]-Fähigkeit
+
+Heals [amount] damage if it kills a unit = Heilt [amount] Schaden beim Töten einer Einheit
+
+
+Defense bonus when embarked = Verteidigungsbonus wenn Eingeschifft
+
 
 #################### Lines from UnitTypes from Civ V - Vanilla ####################
 
@@ -4064,7 +4071,6 @@ This is your basic, club-swinging fighter. = Dies ist ein einfacher, keulenschwi
 Maori Warrior = Maori Krieger
 
 Jaguar = Jaguar
-Heals [amount] damage if it kills a unit = Heilt [amount] Schaden beim Töten einer Einheit
 
 Brute = Barbar
 
@@ -4125,7 +4131,6 @@ Knight = Ritter
 Camel Archer = Kamel-Bogenschütze
 
 Conquistador = Konquistador
-Defense bonus when embarked = Verteidigungsbonus wenn Eingeschifft
 
 Naresuan's Elephant = Naresuans Elefant
 
@@ -5041,6 +5046,13 @@ Salt = Salz
 #################### Lines from UnitPromotions from Civ V - Gods & Kings ####################
 
 
+[amount]% to Flank Attack bonuses = [amount]% für Flankenangriffsboni
+
+
+Transfer Movement to [unit] = Bewegung zu [unit] übertragen
+[amount]% Strength when stacked with [unit] = [amount]% Stärke wenn auf einem Feld mit [unit]
+
+
 #################### Lines from UnitTypes from Civ V - Gods & Kings ####################
 
 
@@ -5082,8 +5094,6 @@ Sea Beggar = Seeräuber
 
 
 Hakkapeliitta = Hakkapeliitta
-Transfer Movement to [unit] = Bewegung zu [unit] übertragen
-[amount]% Strength when stacked with [unit] = [amount]% Stärke wenn auf einem Feld mit [unit]
 
 
 Gatling Gun = Gatling Gun
@@ -5095,7 +5105,6 @@ Mehal Sefari = Mehal Sefari
 
 
 Hussar = Hussar
-[amount]% to Flank Attack bonuses = [amount]% für Flankenangriffsboni
 
 
 Great War Infantry = Weltkriegs-Infanterie

--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -201,7 +201,7 @@ class BaseUnit : RulesetObject(), INonPerpetualConstruction {
                         promotions.size == 1 -> "{Free promotion:} "
                         it.index == 0 -> "{Free promotions:} "
                         else -> ""
-                    } + "{${it.value}}" +
+                    } + "{${it.value.tr()}}" +   // tr() not redundant as promotion names now can use []
                             (if (promotions.size == 1 || it.index == promotions.size - 1) "" else ","),
                     link = "Promotions/${it.value}",
                     indent = if (it.index == 0) 0 else 1

--- a/core/src/com/unciv/ui/utils/ImageGetter.kt
+++ b/core/src/com/unciv/ui/utils/ImageGetter.kt
@@ -291,10 +291,14 @@ object ImageGetter {
         val basePromotionName = if (level == 0) promotionName
         else promotionName.substring(0, promotionName.length - level - 1)
 
-        val circle = getImage("UnitPromotionIcons/$basePromotionName")
-                .apply { color = colorFromRGB(255, 226, 0) }
-                .surroundWithCircle(size)
-                .apply { circle.color = colorFromRGB(0, 12, 49) }
+        val circle = ImageAttempter(Unit)
+            .tryImage { "UnitPromotionIcons/$basePromotionName" }
+            .tryImage { "UnitIcons/${basePromotionName.removeSuffix(" ability")}" }
+            .getImage()
+            .apply { color = colorFromRGB(255, 226, 0) }
+            .surroundWithCircle(size)
+            .apply { circle.color = colorFromRGB(0, 12, 49) }
+
         if (level != 0) {
             val padding = if (level == 3) 0.5f else 2f
             val starTable = Table().apply { defaults().pad(padding) }

--- a/core/src/com/unciv/ui/utils/ImageGetter.kt
+++ b/core/src/com/unciv/ui/utils/ImageGetter.kt
@@ -281,20 +281,26 @@ object ImageGetter {
     }
 
     fun getPromotionIcon(promotionName: String, size: Float = 30f): Actor {
-        val level = when {
-            promotionName.endsWith(" I") -> 1
-            promotionName.endsWith(" II") -> 2
-            promotionName.endsWith(" III") -> 3
+        val nameWithoutBrackets = promotionName.replace("[", "").replace("]", "")
+
+        var level = when {
+            nameWithoutBrackets.endsWith(" I") -> 1
+            nameWithoutBrackets.endsWith(" II") -> 2
+            nameWithoutBrackets.endsWith(" III") -> 3
             else -> 0
         }
 
-        val basePromotionName = if (level == 0) promotionName
-        else promotionName.substring(0, promotionName.length - level - 1)
+        val basePromotionName = nameWithoutBrackets.dropLast(if (level == 0) 0 else level + 1)
 
-        val circle = ImageAttempter(Unit)
+        val imageAttempter = ImageAttempter(Unit)
+            .tryImage { "UnitPromotionIcons/$nameWithoutBrackets" }
             .tryImage { "UnitPromotionIcons/$basePromotionName" }
             .tryImage { "UnitIcons/${basePromotionName.removeSuffix(" ability")}" }
-            .getImage()
+
+        if (imageAttempter.getPathOrNull() != null && imageAttempter.getPath()!!.endsWith(nameWithoutBrackets))
+            level = 0
+
+        val circle = imageAttempter.getImage()
             .apply { color = colorFromRGB(255, 226, 0) }
             .surroundWithCircle(size)
             .apply { circle.color = colorFromRGB(0, 12, 49) }

--- a/docs/Modders/Images-and-Audio.md
+++ b/docs/Modders/Images-and-Audio.md
@@ -1,4 +1,4 @@
-# Audiovisual Mods
+# Images and Audio
 - [The 'Permanent audiovisual mod' feature](#permanent-audiovisual-mods)
 - [Mods can override built-in graphics](#override-built-in-graphics)
 - [Mods can supply additional tilesets - see separate page](Creating-a-custom-tileset.md)
@@ -13,13 +13,21 @@ The following chapters describe possibilities that will work while a mod is ***a
 ## Override built-in graphics
 If a mod supplies an image with the same name and path as one included in the base game (and its [atlas](Mods.md#more-on-images-and-the-texture-atlas) is up to date), and the mod is active, the mod's graphics will be used instead of the built-in one.
 
-For example, if you include a file named "Images/OtherIcons/Link.png" in your mod, you will be overriding the little chain links icon denoting linked lines in Civilopedia.
+For example, if you include a file named "Images/OtherIcons/Link.png" in your mod, you will be overriding the little chain links icon denoting linked lines in Civilopedia. The first part of the path is not relevant for overriding, it controls which of a set of atlas files will carry the image, but for selection in the game only the rest of the path is relevant.  So, to override "Images.Tech/TechIcons/Archery.png" you could place your image as "Images/TechIcons/Archery.png" and it would work because the "TechIcons/Archery" part is the key.
 
 Please note, as for adding items, your graphics should keep the size and color choices of the original, or the result may be surprising, e.g. when the game tries to tint such an image.
 
 
 ## Supply additional graphics
-Currently there are two kinds where the game has display capability but does not supply graphics itself, as described in the next paragraphs:
+You will need to supply the graphics for new elements - a new unit needs its icon just as a new nation does. The rules are:
+* The path and name of the image file need to conform to the rule: `Image[.AtlasName]/Type-specific/Objectname.png` (Type-specific means "TechIcons" for a Technology, "NationIcons" for a Nation and so on. See vanilla game folders. Objectname is the exact name as defined in json, before translation.)
+* All path parts are case sensitive.
+* Unit Pixel sprites and [Tilesets](Creating-a-custom-tileset.md) follow special rules.
+* Promotions can be named "`[Unitname] ability`". In such a case, if `UnitIcons/Unitname.png` exists it will fall back to that unit icon when `UnitPromotionIcons/Unitname ability.png` is missing.
+* Promotions can be named "Something I" (or " II" or " III"). The suffix will be removed and painted as little stars, only the base `UnitPromotionIcons/Something.png` will be loaded.
+* The special rules for promotions can be combined, e.g. "`[Warrior] ability III`" will fall back to the Warrior unit icon and paint 3 Stars on it.
+
+Additionally, there there are two kinds of images where the game has display capability but does not supply graphics itself, as described in the next paragraphs:
 
 ### Adding Wonder Splash Screens
 You can add wonder images to mods and they'll be displayed instead of the standard icon when a wonder is finished. The image needs to be a .png and 2:1 ratio so for example 200x100 px.
@@ -36,6 +44,13 @@ These work best if they are square, between 100x100 and 256x256 pixels, and incl
 For example, [here](https://github.com/yairm210/Unciv-leader-portrait-mod-example) is mod showing how to add leader portraits, which can complement the base game.
 
 
+## Sounds
+Standard values are below. The sounds themselves can be found [here](/sounds).
+
+- _arrow, artillery, bombard, bombing, cannon, chimes, choir, click, coin, construction, elephant, fortify, gdrAttack, horse, jetgun, machinegun, metalhit, missile, nonmetalhit, nuke, paper, policy, promote, setup, shipguns, shot, slider, swap, tankshot, throw, torpedo, upgrade, whoosh_.
+
+Mods can add their own sounds, as long as any new value in attackSound has a corresponding sound file in the mod's sound folder, using one of the formats mp3, ogg or wav (file name extension must match codec used). Remember, names are case sensitive. Small sizes strongly recommended, Unciv's own sounds use 24kHz joint stereo 8-bit VBR at about 50-100kBps.
+
 ## Override built-in sounds
 This works like graphics, except no atlas is involved. E.g. you include a sounds/Click.mp3, it will play instead of the normal click sound. These files must stay short and small. A sound larger than 1MB when uncompressed may break or not play at all on mobile devices. Unciv tries to standardize on 24kHz sample rate, joint stereo, low-bitrate VBR (-128kbps) mp3. Only mp3 and ogg formats will be recognized (but an existing mp3 can be overridden with an ogg file).
 
@@ -44,7 +59,7 @@ This works like graphics, except no atlas is involved. E.g. you include a sounds
 Sound files (mp3 or ogg) in a mod /music folder will be recognized and used when the mod is active. Except for context-specific music as described in the following paragraphs, tracks will play randomly from all available tracks (with a little bias to avoid close repetition of tracks). There is no overriding - a "thatched-villagers.mp3" in a mod will play in addition to and with the same likelihood as the file that the base game offers to download for you. There is no hard technical limit on bitrate or length, but large bandwidth requirements may lead to stuttering (The end of a "next turn", right before the world map is updated, and with very large maps, is the most likely to cause this).
 
 ### Context-sensitive music: Overview
-The Music Controller will generally play one track after another, with a pause (can be changed in options) between. Leave-game confirmation dialog is opened playback will fade out and pause and can resume when it is closed.
+The Music Controller will generally play one track after another, with a pause (can be changed in options) between. While the "Leave game?" confirmation dialog is opened playback will fade out and pause and can resume when it is closed.
 
 There are various 'triggers' in the game code initiating a choice for a new track. The new track will, if necessary, fade out the currently playing track quickly before it starts playing. Track choice involves context provided by the trigger and a random factor, and an attempt is made to not repeat any track until at least eight others have played.
 

--- a/docs/Other/Unit-related-JSON-files.md
+++ b/docs/Other/Unit-related-JSON-files.md
@@ -26,7 +26,7 @@ Each unit can have the following attributes:
 | promotions | List of Strings | defaults to none | A list of all the promotions the unit automatically receives upon being built. Each promotion must be in [UnitPromotions.json](#unitpromotionsjson) |
 | uniques | List of Strings | defaults to none | A list of the unique abilities this unit has. A list of almost all uniques can be found [here](../Modders/Unique-parameter-types.md#unit-uniques) |
 | replacementTextForUniques | String | defaults to none | If provided, this will be displayed instead of the list of uniques. Can be used for better formatting. |
-| attackSound | String | defaults to none | The sound that is to be played when this unit attacks. For possible values, see [sounds](#Sounds)
+| attackSound | String | defaults to none | The sound that is to be played when this unit attacks. For possible values, see [Sounds](#../Modders/Images-and-Audio.md#sounds)
 | civilopediaText | List | Default empty | see [civilopediaText chapter](Miscellaneous-JSON-files.md#civilopedia-text) |
 
 
@@ -62,11 +62,3 @@ Civilian, Melee, Ranged, Scout, Mounted, Armor, Siege, WaterCivilian, WaterMelee
 | name | String | required | The name of the unit type |
 | movementType | String | required | The domain through which the unit moves. Allowed values: "Water", "Land", "Air" |
 | uniques | List of String | defaults to none | A list of the unique abilities every unit of this type has. A list of almost all uniques can be found [here](../Modders/Unique-parameter-types.md#unit-uniques) |
-
-
-## Sounds
-Standard values are below. The sounds themselves can be found [here](/sounds).
-
-- _arrow, artillery, bombard, bombing, cannon, chimes, choir, click, coin, construction, elephant, fortify, gdrAttack, horse, jetgun, machinegun, metalhit, missile, nonmetalhit, nuke, paper, policy, promote, setup, shipguns, shot, slider, swap, tankshot, throw, torpedo, upgrade, whoosh_.
-
-Mods can add their own sounds, as long as any new value in attackSound has a corresponding sound file in the mod's sound folder, using one of the formats mp3, ogg or wav (file name extension must match codec used). Remember, names are case sensitive. Small sizes strongly recommended, Unciv's own sounds use 24kHz joint stereo 8-bit VBR at about 50-100kBps.


### PR DESCRIPTION
Fixes #6281

![image](https://user-images.githubusercontent.com/63000004/157153406-ecfccd23-a38c-453f-bc52-154036dce656.png)

To do: 
- ~~Verify BackwardCompatibility guaranteeUnitPromotions catches these~~ tested successfully
- Maintain table in issue, did we catch all correctly (e.g. some +sight boni to Knight alternates sound like they should inherit too)?
- ~~Edit back units that already had their boni inheritable to use the no promotion icon needed ability???? Pictish Warrior, Slinger?~~ No