### PR TITLE
Empire Overview City tab redone

### DIFF
--- a/core/src/com/unciv/ui/overviewscreen/CityOverviewTable.kt
+++ b/core/src/com/unciv/ui/overviewscreen/CityOverviewTable.kt
@@ -2,11 +2,13 @@ package com.unciv.ui.overviewscreen
 
 import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.scenes.scene2d.Actor
+import com.badlogic.gdx.scenes.scene2d.Group
 import com.badlogic.gdx.scenes.scene2d.ui.Cell
 import com.badlogic.gdx.scenes.scene2d.ui.Label
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.utils.Align
 import com.unciv.Constants
+import com.unciv.UncivGame
 import com.unciv.logic.city.CityFlags
 import com.unciv.logic.city.CityInfo
 import com.unciv.logic.civilization.CivilizationInfo
@@ -15,8 +17,13 @@ import com.unciv.models.translations.tr
 import com.unciv.ui.cityscreen.CityScreen
 import com.unciv.ui.utils.*
 import com.unciv.ui.utils.UncivTooltip.Companion.addTooltip
-import kotlin.math.max
 import kotlin.math.roundToInt
+
+private fun String.isStat() = Stat.values().any { it.name == this }
+private fun CityInfo.getStat(stat: Stat) =
+    if (stat == Stat.Happiness)
+        cityStats.happinessList.values.sum().roundToInt()
+    else cityStats.currentCityStats[stat].roundToInt()
 
 class CityOverviewTab(
     viewingPlayer: CivilizationInfo,
@@ -24,9 +31,10 @@ class CityOverviewTab(
     persistedData: EmpireOverviewTabPersistableData? = null
 ) : EmpireOverviewTab(viewingPlayer, overviewScreen) {
     class CityTabPersistableData(
-        var sortedBy: String = "City"
+        var sortedBy: String = CITY,
+        var descending: Boolean = false
     ) : EmpireOverviewTabPersistableData() {
-        override fun isEmpty() = sortedBy == "City"
+        override fun isEmpty() = sortedBy == CITY
     }
 
     override val persistableData = (persistedData as? CityTabPersistableData) ?: CityTabPersistableData()
@@ -35,122 +43,132 @@ class CityOverviewTab(
         const val iconSize = 50f  //if you set this too low, there is a chance that the tables will be misaligned
         const val paddingVert = 5f      // vertical padding
         const val paddingHorz = 8f      // horizontal padding
+
+        private const val CITY = "City"
+        private const val WLTK = "WLTK"
+        private const val CONSTRUCTION = "Construction"
+        private val alphabeticColumns = listOf(CITY, CONSTRUCTION, WLTK)
+
+        private val citySortIcon = ImageGetter.getUnitIcon("Settler")
+            .surroundWithCircle(iconSize)
+            .apply { addTooltip("Name", 18f, tipAlign = Align.center) }
+        private val wltkSortIcon = ImageGetter.getImage("OtherIcons/WLTK 2")
+            .apply { color = Color.BLACK }
+            .surroundWithCircle(iconSize, color = Color.TAN)
+            .apply { addTooltip("We Love The King Day", 18f, tipAlign = Align.center) }
+        private val constructionSortIcon = ImageGetter.getImage("OtherIcons/Settings")
+            .apply { color = Color.BLACK }
+            .surroundWithCircle(iconSize, color = Color.LIGHT_GRAY)
+            .apply { addTooltip("Current construction", 18f, tipAlign = Align.center) }
     }
 
     private val columnsNames = arrayListOf("Population", "Food", "Gold", "Science", "Production", "Culture", "Happiness")
-            .apply { if (viewingPlayer.gameInfo.isReligionEnabled()) add("Faith") }
+            .apply { if (gameInfo.isReligionEnabled()) add("Faith") }
+
+    private val cityInfoTableHeader = Table(skin)
+    private val cityInfoTableDetails = Table(skin)
+    private val cityInfoTableTotal = Table(skin)
+
+    private val collator = UncivGame.Current.settings.getCollatorFromLocale()
+
+    override fun getFixedContent() = Table().apply {
+        add("Cities".toLabel(fontSize = Constants.headingFontSize)).padTop(10f).row()
+        add(cityInfoTableHeader).padBottom(paddingVert).row()
+        addSeparator(Color.GRAY)
+    }
 
     init {
-        val numHeaderCells = columnsNames.size + 2      // +1 City +1 Filler
+        cityInfoTableHeader.defaults().pad(paddingVert, paddingHorz).minWidth(iconSize)
+        cityInfoTableDetails.defaults().pad(paddingVert, paddingHorz).minWidth(iconSize)
+        cityInfoTableTotal.defaults().pad(paddingVert, paddingHorz).minWidth(iconSize)
 
-        val cityInfoTableIcons = Table(skin)
-        val cityInfoTableDetails = Table(skin)
-        val cityInfoTableTotal = Table(skin)
+        updateTotal()
+        update()
 
-        fun sortOnClick(iconName: String) {
-            val descending = persistableData.sortedBy == iconName
-            persistableData.sortedBy = iconName
+        add(cityInfoTableDetails).row()
+        addSeparator(Color.GRAY).pad(paddingVert, 0f)
+        add(cityInfoTableTotal)
+    }
+
+    fun toggleSort(sortBy: String) {
+        if (sortBy == persistableData.sortedBy) {
+            persistableData.descending = !persistableData.descending
+        } else {
+            persistableData.sortedBy = sortBy
+            persistableData.descending = sortBy !in alphabeticColumns  // Start numeric columns descending
+        }
+    }
+
+    fun getComparator() = Comparator { city2: CityInfo, city1: CityInfo ->
+        when(persistableData.sortedBy) {
+            CITY -> collator.compare(city2.name.tr(), city1.name.tr())
+            CONSTRUCTION -> collator.compare(
+                city2.cityConstructions.currentConstructionFromQueue.tr(),
+                city1.cityConstructions.currentConstructionFromQueue.tr())
+            "Population" -> city2.population.population - city1.population.population
+            WLTK -> city2.isWeLoveTheKingDayActive().compareTo(city1.isWeLoveTheKingDayActive())
+            else -> {
+                val stat = Stat.valueOf(persistableData.sortedBy)
+                city2.getStat(stat) - city1.getStat(stat)
+            }
+        }
+    }
+
+    private fun getSortSymbol() = if(persistableData.descending) "￬" else "￪"
+
+    private fun update() {
+        updateHeader()
+        updateCities()
+        equalizeColumns(cityInfoTableDetails, cityInfoTableHeader, cityInfoTableTotal)
+        layout()
+    }
+
+    private fun updateHeader() {
+        fun sortOnClick(sortBy: String) {
+            toggleSort(sortBy)
             // sort the table: clear and fill with sorted data
-            cityInfoTableDetails.clear()
-            fillCitiesTable(cityInfoTableDetails, iconName, descending)
-            // reset to return back for ascending next time
-            if (descending) persistableData.sortedBy = ""
+            update()
         }
 
-        fun addSortIcon(iconName: String, iconParam: Actor? = null) {
-            val icon = iconParam ?: ImageGetter.getStatIcon(iconName)
-            icon.onClick { sortOnClick(iconName) }
-            cityInfoTableIcons.add(icon).size(iconSize)
+        fun addSortIcon(iconName: String, iconParam: Actor? = null): Cell<Group> {
+            val image = iconParam ?: ImageGetter.getStatIcon(iconName)
+
+            val icon = Group().apply {
+                isTransform = false
+                setSize(iconSize, iconSize)
+                image.setSize(iconSize, iconSize)
+                image.center(this)
+                image.setOrigin(Align.center)
+                onClick { sortOnClick(iconName) }
+            }
+            if (iconName == persistableData.sortedBy) {
+                val label = getSortSymbol().toLabel()
+                label.setOrigin(Align.bottomRight)
+                label.setPosition(iconSize - 2f, 0f)
+                icon.addActor(label)
+            }
+            icon.addActor(image)
+            return cityInfoTableHeader.add(icon).size(iconSize)
         }
 
-        // Prepare top third: cityInfoTableIcons
-        cityInfoTableIcons.defaults()
-            .pad(paddingVert, paddingHorz)
-            .align(Align.center)
-        cityInfoTableIcons.add("Cities".toLabel(fontSize = Constants.headingFontSize)).colspan(numHeaderCells).align(Align.center).row()
-        val citySortIcon: IconCircleGroup = ImageGetter.getUnitIcon("Settler").surroundWithCircle(iconSize)
-        addSortIcon("City", citySortIcon)
-        val headerFillerCell = cityInfoTableIcons.add(Table())  // will push the first icon to left-align
+        cityInfoTableHeader.clear()
+        addSortIcon(CITY, citySortIcon).left()
+        cityInfoTableHeader.add()  // construction _icon_ column
+        addSortIcon(CONSTRUCTION, constructionSortIcon).left()
         for (name in columnsNames) {
             addSortIcon(name)
         }
-        val wltkSortIcon: IconCircleGroup = ImageGetter.getImage("OtherIcons/WLTK 2")
-            .apply { color = Color.BLACK }
-            .surroundWithCircle(iconSize, color = Color.TAN)
-        wltkSortIcon.addTooltip("We Love The King Day", 18f, tipAlign = Align.center )
-        addSortIcon("WLTK", wltkSortIcon)
-        cityInfoTableIcons.pack()
-
-        // Prepare middle third: cityInfoScrollPane (a ScrollPane containing cityInfoTableDetails)
-        cityInfoTableDetails.defaults()
-            .pad(paddingVert, paddingHorz)
-            .minWidth(iconSize)     //we need the min width so we can align the different tables
-            .align(Align.left)
-
-        fillCitiesTable(cityInfoTableDetails, persistableData.sortedBy, false)
-
-        val cityInfoScrollPane = AutoScrollPane(cityInfoTableDetails)
-        cityInfoScrollPane.pack()
-        cityInfoScrollPane.setOverscroll(false, false) //I think it feels better with no overscroll
-
-        // place the button for sorting by city name on top of the cities names
-        // by sizing the filler to: subtract width of other columns and one cell padding from overall width
-        val headingFillerWidth = max(0f, cityInfoTableDetails.width - (iconSize + 2*paddingHorz) * numHeaderCells - 2*paddingHorz)
-        headerFillerCell.width(headingFillerWidth)
-        cityInfoTableIcons.width = cityInfoTableDetails.width
-
-        // Prepare bottom third: cityInfoTableTotal
-        cityInfoTableTotal.defaults()
-            .pad(paddingVert, paddingHorz)
-            .minWidth(iconSize) //we need the min width so we can align the different tables
-
-        cityInfoTableTotal.add("Total".toLabel())
-        cityInfoTableTotal.add(viewingPlayer.cities.sumOf { it.population.population }.toString().toLabel()).myAlign(Align.center)
-        for (column in columnsNames.filter { it.isStat() }) {
-            val stat = Stat.valueOf(column)
-            if (stat == Stat.Food || stat == Stat.Production) cityInfoTableTotal.add() // an intended empty space
-            else cityInfoTableTotal.add(viewingPlayer.cities.sumOf { getStatOfCity(it, stat) }.toLabel()).myAlign(Align.center)
-        }
-        cityInfoTableTotal.add(viewingPlayer.cities.count { it.isWeLoveTheKingDayActive() }.toLabel()).myAlign(Align.center)
-        cityInfoTableTotal.pack()
-
-        // Stack cityInfoTableIcons, cityInfoScrollPane, and cityInfoTableTotal vertically
-        val table = Table(skin)
-        //since the names of the cities are on the left, and the length of the names varies
-        //we align every row to the right, coz we set the size of the other(number) cells to the image size
-        //and thus, we can guarantee that the tables will be aligned
-        table.defaults().pad(paddingVert).align(Align.right)
-        table.add(cityInfoTableIcons).row()
-        table.add(cityInfoScrollPane).width(cityInfoTableDetails.width).row()
-        table.add(cityInfoTableTotal)
-        table.pack()
-        add(table)
+        addSortIcon(WLTK, wltkSortIcon)
+        cityInfoTableHeader.pack()
     }
 
-    private fun getStatOfCity(cityInfo: CityInfo, stat: Stat): Int {
-        return if (stat == Stat.Happiness)
-             cityInfo.cityStats.happinessList.values.sum().roundToInt()
-        else cityInfo.cityStats.currentCityStats[stat].roundToInt()
-    }
-
-    private fun fillCitiesTable(citiesTable: Table, sortType: String, descending: Boolean) {
+    private fun updateCities() {
+        cityInfoTableDetails.clear()
         if (viewingPlayer.cities.isEmpty()) return
 
-        val sorter = Comparator { city2, city1: CityInfo ->
-            when {
-                sortType == "Population" -> city1.population.population - city2.population.population
-                sortType.isStat() -> {
-                    val stat = Stat.valueOf(sortType)
-                    getStatOfCity(city1, stat) - getStatOfCity(city2, stat)
-                }
-                sortType == "WLTK" -> city1.isWeLoveTheKingDayActive().compareTo(city2.isWeLoveTheKingDayActive())
-                else -> city2.name.tr().compareTo(city1.name.tr())
-            }
-        }
-
+        val sorter = getComparator()
         var cityList = viewingPlayer.cities.sortedWith(sorter)
-
-        if (descending)
+        if (persistableData.descending)
             cityList = cityList.reversed()
 
         val constructionCells: MutableList<Cell<Label>> = mutableListOf()
@@ -159,53 +177,65 @@ class CityOverviewTab(
             button.onClick {
                 overviewScreen.game.setScreen(CityScreen(city))
             }
-            citiesTable.add(button)
+            cityInfoTableDetails.add(button).left().fillX()
 
-            if (city.cityConstructions.currentConstructionFromQueue.isNotEmpty()) {
-                citiesTable.add(ImageGetter.getConstructionImage(city.cityConstructions.currentConstructionFromQueue).surroundWithCircle(iconSize*0.8f)).padRight(paddingHorz)
+            val construction = city.cityConstructions.currentConstructionFromQueue
+            if (construction.isNotEmpty()) {
+                cityInfoTableDetails.add(ImageGetter.getConstructionImage(construction).surroundWithCircle(iconSize*0.8f)).padRight(paddingHorz)
             } else {
-                citiesTable.add()
+                cityInfoTableDetails.add()
             }
 
-            val cell = citiesTable.add(city.cityConstructions.getCityProductionTextForCityButton().toLabel())
+            val cell = cityInfoTableDetails.add(city.cityConstructions.getCityProductionTextForCityButton().toLabel()).left().expandX()
             constructionCells.add(cell)
 
-            citiesTable.add(city.population.population.toLabel()).myAlign(Align.center)
+            cityInfoTableDetails.add(city.population.population.toCenteredLabel())
+
             for (column in columnsNames) {
                 if (!column.isStat()) continue
-                citiesTable.add(getStatOfCity(city, Stat.valueOf(column)).toLabel()).myAlign(Align.center)
+                cityInfoTableDetails.add(city.getStat(Stat.valueOf(column)).toCenteredLabel())
             }
 
             when {
                 city.isWeLoveTheKingDayActive() -> {
                     val image = ImageGetter.getImage("OtherIcons/WLTK 1").surroundWithCircle(iconSize, color = Color.CLEAR)
                     image.addTooltip("[${city.getFlag(CityFlags.WeLoveTheKing)}] turns", 18f, tipAlign = Align.topLeft)
-                    citiesTable.add(image)
+                    cityInfoTableDetails.add(image)
                 }
                 city.demandedResource.isNotEmpty() -> {
                     val image = ImageGetter.getResourceImage(city.demandedResource, iconSize*0.7f)
                     image.addTooltip("Demanding [${city.demandedResource}]", 18f, tipAlign = Align.topLeft)
-                    citiesTable.add(image).padLeft(iconSize*0.3f)
+                    cityInfoTableDetails.add(image).padLeft(iconSize*0.3f)
                 }
-                else -> citiesTable.add()
+                else -> cityInfoTableDetails.add()
             }
 
-            citiesTable.row()
+            cityInfoTableDetails.row()
         }
 
         // row heights may diverge - fix it by setting minHeight to
         // largest actual height (of the construction cell) - !! guarded by isEmpty test above
         val largestLabelHeight = constructionCells.maxByOrNull{ it.prefHeight }!!.prefHeight
-        constructionCells.forEach{ it.minHeight(largestLabelHeight ) }
+        for (cell in constructionCells) cell.minHeight(largestLabelHeight)
 
-        citiesTable.pack()
+        cityInfoTableDetails.pack()
     }
 
-    private fun String.isStat() = Stat.values().any { it.name == this }
-
-    // Helper to prettify converting Cell.align() to the Cell's actor's .align()
-    private fun Cell<Label>.myAlign(align: Int): Cell<Label> {
-        (this.actor as Label).setAlignment(align)
-        return this
+    private fun updateTotal() {
+        cityInfoTableTotal.add("Total".toLabel()).left()
+        cityInfoTableTotal.add()  // construction icon column
+        cityInfoTableTotal.add().expandX()  // construction label column
+        cityInfoTableTotal.add(viewingPlayer.cities.sumOf { it.population.population }.toCenteredLabel())
+        for (column in columnsNames.filter { it.isStat() }) {
+            val stat = Stat.valueOf(column)
+            if (stat == Stat.Food || stat == Stat.Production) cityInfoTableTotal.add() // an intended empty space
+            else cityInfoTableTotal.add(viewingPlayer.cities.sumOf { it.getStat(stat) }.toCenteredLabel())
+        }
+        cityInfoTableTotal.add(viewingPlayer.cities.count { it.isWeLoveTheKingDayActive() }.toCenteredLabel())
+        cityInfoTableTotal.pack()
     }
+
+    private fun Int.toCenteredLabel(): Label =
+        this.toLabel().apply { setAlignment(Align.center) }
+
 }


### PR DESCRIPTION
- Fixed header, back to doesn't participate in scrolling
- show sort direction on header icons
- allow sort on production (a matter of taste, I could easily take that out again or make the feature setting-gated, but I remember doing that in Call To power all the time)
- sort using collation
- persist ascending/descending
- numeric cols start with descending sort after changing sorted column, alpha ones ascending - was a bit hidden in source before as those comparators simply were the wrong way round
- redesigned how vertical alignment is enforced, IMHO a little more robust.