### PR TITLE
Fixed a bug where the resource supply overview would not add up

### DIFF
--- a/core/src/com/unciv/logic/civilization/CityStateFunctions.kt
+++ b/core/src/com/unciv/logic/civilization/CityStateFunctions.kt
@@ -656,7 +656,7 @@ class CityStateFunctions(val civInfo: CivilizationInfo) {
         for (city in civInfo.cities) {
             for (resourceSupply in city.getCityResources())
                 if (resourceSupply.amount > 0) // IGNORE the fact that they consume their own resources - #4769
-                    newDetailedCivResources.add(resourceSupply.resource, resourceSupply.amount, "City-States")
+                    newDetailedCivResources.add(resourceSupply.resource, resourceSupply.amount, "City-State")
         }
         return newDetailedCivResources
     }

--- a/core/src/com/unciv/logic/civilization/CivInfoTransientUpdater.kt
+++ b/core/src/com/unciv/logic/civilization/CivInfoTransientUpdater.kt
@@ -2,6 +2,7 @@ package com.unciv.logic.civilization
 
 import com.unciv.UncivGame
 import com.unciv.logic.map.TileInfo
+import com.unciv.models.ruleset.tile.ResourceSupply
 import com.unciv.models.ruleset.tile.ResourceSupplyList
 import com.unciv.models.ruleset.unique.UniqueType
 
@@ -166,21 +167,29 @@ class CivInfoTransientUpdater(val civInfo: CivilizationInfo) {
     fun updateCivResources() {
         val newDetailedCivResources = ResourceSupplyList()
         for (city in civInfo.cities) newDetailedCivResources.add(city.getCityResources())
-
+        
         if (!civInfo.isCityState()) {
+            // First we get all these resources of each city state separately
+            val cityStateProvidedResources = ResourceSupplyList()
             var resourceBonusPercentage = 1f
             for (unique in civInfo.getMatchingUniques(UniqueType.CityStateResources))
                 resourceBonusPercentage += unique.params[0].toFloat() / 100
             for (cityStateAlly in civInfo.getKnownCivs().filter { it.getAllyCiv() == civInfo.civName }) {
                 for (resource in cityStateAlly.cityStateFunctions.getCityStateResourcesForAlly()) {
-                    newDetailedCivResources.add(
+                    cityStateProvidedResources.add(
                         resource.apply { amount = (amount * resourceBonusPercentage).toInt() }
                     )
                 }
             }
+            // Then we combine these into one
+            for (resourceSupply in cityStateProvidedResources.groupBy { it.resource }) {
+                newDetailedCivResources.add(ResourceSupply(resourceSupply.key, resourceSupply.value.sumOf { it.amount }, "City-States"))
+            }
+
         }
 
-        for (dip in civInfo.diplomacy.values) newDetailedCivResources.add(dip.resourcesFromTrade())
+
+        for (diplomacyManager in civInfo.diplomacy.values) newDetailedCivResources.add(diplomacyManager.resourcesFromTrade())
         for (unit in civInfo.getCivUnits())
             for ((resource, amount) in unit.baseUnit.getResourceRequirements())
                 newDetailedCivResources.add(civInfo.gameInfo.ruleSet.tileResources[resource]!!, -amount, "Units")

--- a/core/src/com/unciv/ui/overviewscreen/ResourcesOverviewTable.kt
+++ b/core/src/com/unciv/ui/overviewscreen/ResourcesOverviewTable.kt
@@ -42,8 +42,7 @@ class ResourcesOverviewTab(
                 overviewScreen.game.setWorldScreen()
             }
             holder.addActor(resourceImage)
-            holder.setSize(resourceImage.width,
-                resourceImage.height + labelPadding)
+            holder.setSize(resourceImage.width, resourceImage.height + labelPadding)
             // Center-align all labels, but right-align the last couple resources' labels
             // because they may get clipped otherwise. The leftmost label should be fine
             // center-aligned (if there are more than 2 resources), because the left side


### PR DESCRIPTION
This was as when multiple city-states provided a resource, only the count of one of them would be used in the overview.