### PR TITLE
Reduce warnings

### DIFF
--- a/core/src/com/unciv/logic/BackwardCompatibility.kt
+++ b/core/src/com/unciv/logic/BackwardCompatibility.kt
@@ -143,6 +143,7 @@ object BackwardCompatibility {
     }
 
     /** Move max XP from barbarians to new home */
+    @Suppress("DEPRECATION")
     fun ModOptions.updateDeprecations() {
         if (maxXPfromBarbarians != 30) {
             constants.maxXPfromBarbarians = maxXPfromBarbarians

--- a/core/src/com/unciv/logic/automation/SpecificUnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/SpecificUnitAutomation.kt
@@ -338,7 +338,7 @@ object SpecificUnitAutomation {
         unit.movement.headTowards(destination)
 
 
-        if (cityToConvert != null && unit.currentTile.getCity() == destination!!.getCity()) {
+        if (cityToConvert != null && unit.currentTile.getCity() == destination.getCity()) {
             doReligiousAction(unit, destination)
         }
 

--- a/core/src/com/unciv/logic/city/CityInfoConquestFunctions.kt
+++ b/core/src/com/unciv/logic/city/CityInfoConquestFunctions.kt
@@ -123,7 +123,8 @@ class CityInfoConquestFunctions(val city: CityInfo){
     /** This happens when we either puppet OR annex, basically whenever we conquer a city and don't liberate it */
     fun puppetCity(conqueringCiv: CivilizationInfo) {
         // Gain gold for plundering city
-        val goldPlundered = getGoldForCapturingCity(conqueringCiv)  // todo: use this val
+        @Suppress("UNUSED_VARIABLE")  // todo: use this val
+        val goldPlundered = getGoldForCapturingCity(conqueringCiv)
         city.apply {
 
             val oldCiv = civInfo

--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -731,6 +731,7 @@ class Ruleset {
                     lines += "Difficulty ${difficulty.name} contains starting unit $unitName which does not exist!"
         }
 
+        @Suppress("DEPRECATION")
         if (modOptions.maxXPfromBarbarians != 30) {
             lines.add("maxXPfromBarbarians is moved to the constants object, instead use: \nconstants: {\n    maxXPfromBarbarians: ${modOptions.maxXPfromBarbarians},\n}", RulesetErrorSeverity.Warning)
         }

--- a/core/src/com/unciv/models/ruleset/tech/Technology.kt
+++ b/core/src/com/unciv/models/ruleset/tech/Technology.kt
@@ -203,7 +203,6 @@ class Technology: RulesetObject() {
             }
         }
 
-        var wantEmpty = true
         for (improvement in ruleset.tileImprovements.values)
             for (unique in improvement.uniqueObjects) {
                 if (unique.isOfType(UniqueType.Stats)) {

--- a/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
@@ -369,7 +369,8 @@ enum class UniqueParameterType(var parameterName:String) {
             "in cities following this religion",
         )
 
-        fun safeValueOf(param: String) = values().firstOrNull { it.parameterName == param } ?: Unknown.apply { this.parameterName = param }
+        fun safeValueOf(param: String) = values().firstOrNull { it.parameterName == param }
+            ?: Unknown.apply { this.parameterName = param }  //TODO Danger: There is only one instance of Unknown!
     }
 }
 

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -986,5 +986,5 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
 }
 
 // I didn't put this is a companion object because APPARENTLY doing that means you can't use it in the init function.
-val numberRegex = Regex("\\d") // I really doubt we'll get to double-digit numbers of parameters in a single unique.
+val numberRegex = Regex("\\d+$") // Any number of trailing digits
 

--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -395,6 +395,7 @@ class BaseUnit : RulesetObject(), INonPerpetualConstruction {
             rejectionReasons.add(RejectionReason.DisabledBySetting)
 
         for (unique in uniqueObjects) {
+            @Suppress("NON_EXHAUSTIVE_WHEN")  // Yes we want to implement only a few here
             when (unique.type) {
                 UniqueType.Unbuildable ->
                     rejectionReasons.add(RejectionReason.Unbuildable)
@@ -432,16 +433,15 @@ class BaseUnit : RulesetObject(), INonPerpetualConstruction {
                     rejectionReasons.add(RejectionReason.ConsumesResources.toInstance("Consumes [$amount] [$resource]"))
                 }
         }
-        
+
         for (unique in civInfo.getMatchingUniques(UniqueType.CannotBuildUnits))
             if (this.matchesFilter(unique.params[0])) {
-                val rejectionReason = RejectionReason.CannotBeBuilt.toInstance()
                 if (unique.conditionals.any { it.type == UniqueType.ConditionalBelowHappiness }){
                     rejectionReasons.add(RejectionReason.CannotBeBuilt.toInstance(unique.text, true))
                 }
                 else rejectionReasons.add(RejectionReason.CannotBeBuilt)
             }
-        
+
         return rejectionReasons
     }
 

--- a/core/src/com/unciv/ui/utils/LanguageTable.kt
+++ b/core/src/com/unciv/ui/utils/LanguageTable.kt
@@ -11,7 +11,7 @@ import java.util.ArrayList
 /** Represents a row in the Language picker, used both in OptionsPopup and in LanguagePickerScreen */
 internal class LanguageTable(val language:String, val percentComplete: Int): Table(){
     private val blue = ImageGetter.getBlue()
-    private val darkBlue = blue.darken(0.5f)!!
+    private val darkBlue = blue.darken(0.5f)
 
     init{
         pad(10f)

--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -411,7 +411,7 @@ class WorldScreen(val gameInfo: GameInfo, val viewingCiv:CivilizationInfo) : Bas
             allUnits.filter(mapVisualization::isUnitPastVisible),
             allUnits.filter(mapVisualization::isUnitFutureVisible),
             allAttacks.filter { (attacker, source, target) -> mapVisualization.isAttackVisible(attacker, source, target) }
-                    .map { (attacker, source, target) -> source to target }
+                    .map { (_, source, target) -> source to target }
         )
 
         // if we use the clone, then when we update viewable tiles

--- a/core/src/com/unciv/ui/worldscreen/bottombar/BattleTable.kt
+++ b/core/src/com/unciv/ui/worldscreen/bottombar/BattleTable.kt
@@ -165,7 +165,7 @@ class BattleTable(val worldScreen: WorldScreen): Table() {
 
         // from Battle.addXp(), check for can't gain more XP from Barbarians
         val modConstants = attacker.getCivInfo().gameInfo.ruleSet.modOptions.constants
-        if (attacker is MapUnitCombatant && (attacker as MapUnitCombatant).unit.promotions.totalXpProduced() >= modConstants.maxXPfromBarbarians
+        if (attacker is MapUnitCombatant && attacker.unit.promotions.totalXpProduced() >= modConstants.maxXPfromBarbarians
                 && defender.getCivInfo().isBarbarian()){
             add("Cannot gain more XP from Barbarians".tr().toLabel(fontSize = 16).apply { wrap=true }).width(quarterScreen)
             row()

--- a/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
@@ -54,7 +54,7 @@ object UnitActions {
         addPromoteAction(unit, actionList)
         addUnitUpgradeAction(unit, actionList)
         addPillageAction(unit, actionList, worldScreen)
-        addParadropAction(unit, actionList, worldScreen)
+        addParadropAction(unit, actionList)
         addSetupAction(unit, actionList)
         addFoundCityAction(unit, actionList, tile)
         addBuildingImprovementsAction(unit, actionList, tile, worldScreen, unitTable)
@@ -244,7 +244,7 @@ object UnitActions {
                 }.takeIf { unit.currentMovement > 0 && !isSetUp })
     }
 
-    private fun addParadropAction(unit: MapUnit, actionList: ArrayList<UnitAction>, worldScreen: WorldScreen) {
+    private fun addParadropAction(unit: MapUnit, actionList: ArrayList<UnitAction>) {
         val paradropUniques =
             unit.getMatchingUniques("May Paradrop up to [] tiles from inside friendly territory")
         if (!paradropUniques.any() || unit.isEmbarked()) return


### PR DESCRIPTION
Just treating some compiler warnings. NOT important.
- Not touching _Unique_ deprecations. Pattern is easily scanned. Barb xp however is enough to remove the var when grace period ends.
- ResourceOverview ignored since it's in an upcoming PR
- Battle damage calc unused params - those may have intentions? Unique applicability?
- `Regex("\\d+$")` since the comment was not on the spot - it did remove _all_ digits. Couldn't resist, as the intention was `amount2` -> `amount` right?