### PR TITLE
Implement a rudimentary CrashReportSysInfoDesktop

### DIFF
--- a/desktop/src/com/unciv/app/desktop/CrashReportSysInfoDesktop.kt
+++ b/desktop/src/com/unciv/app/desktop/CrashReportSysInfoDesktop.kt
@@ -2,6 +2,7 @@ package com.unciv.app.desktop
 
 import com.badlogic.gdx.files.FileHandle
 import com.unciv.ui.utils.CrashReportSysInfo
+import java.nio.charset.Charset
 
 class CrashReportSysInfoDesktop : CrashReportSysInfo {
 
@@ -9,26 +10,19 @@ class CrashReportSysInfoDesktop : CrashReportSysInfo {
         val builder = StringBuilder()
 
         // Operating system
-        builder.append("OS: " + (System.getProperty("os.name") ?: "Unknown"))
-        val osInfo = listOfNotNull(System.getProperty("os.arch"), System.getProperty("os.version")).joinToString()
-        if (osInfo.isNotEmpty()) builder.append(" ($osInfo)")
+        val osName = System.getProperty("os.name") ?: "Unknown"
+        val isWindows = osName.startsWith("Windows", ignoreCase = true)
+        builder.append("OS: $osName")
+        if (!isWindows) {
+            val osInfo = listOfNotNull(System.getProperty("os.arch"), System.getProperty("os.version")).joinToString()
+            if (osInfo.isNotEmpty()) builder.append(" ($osInfo)")
+        }
         builder.appendLine()
 
-        // Linux distro
-        val osRelease: Map<String,String> = try {
-            FileHandle("/etc/os-release")
-                .readString()
-                .split('\n')
-                .map { it.split('=') }
-                .filter { it.size == 2 }
-                .associate { it[0] to it[1].removeSuffix("\"").removePrefix("\"") }
-        } catch (ex: Throwable) { mapOf() }
-        if ("NAME" in osRelease) {
-            builder.append('\t')
-            builder.appendLine(
-                osRelease["PRETTY_NAME"] ?: "${osRelease["NAME"]} ${osRelease["VERSION"]}"
-            )
-        }
+        // Specific release info
+        val osRelease = if (isWindows) getWinVer() else getLinuxDistro()
+        if (osRelease.isNotEmpty())
+            builder.appendLine("\t$osRelease")
 
         // Java runtime version
         val javaVendor: String? = System.getProperty("java.vendor")
@@ -47,5 +41,60 @@ class CrashReportSysInfoDesktop : CrashReportSysInfo {
         }
 
         return builder.toString()
+    }
+
+    companion object {
+        @Suppress("SpellCheckingInspection")
+        private val winVerCommand = """
+        cmd /c
+        reg query "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion" /v ProductName &&
+        reg query "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion" /v ReleaseId &&
+        reg query "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion" /v CurrentBuild &&
+        reg query "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion" /v DisplayVersion
+        """.trimIndent().replace('\n', ' ')
+
+        /** Kludge to get the important Windows version info (no easier way than the registry AFAIK)
+         *  using a subprocess running reg query. Other methods would involve nasty reflection
+         *  to break java.util.prefs.Preferences out of its Sandbox, or JNA requiring new bindings.
+         */
+        fun getWinVer(): String {
+            val entries: Map<String,String> = try {
+                val process = Runtime.getRuntime().exec(winVerCommand)
+                process.waitFor()
+                val output = process.inputStream.readAllBytes().toString(Charset.defaultCharset())
+
+                val goodLines = output.split('\n').mapNotNull {
+                    it.removeSuffix("\r").run {
+                        if (startsWith("    ") || startsWith("\t")) trim() else null
+                    }
+                }
+
+                goodLines.map { it.split("REG_SZ") }
+                    .filter { it.size == 2 }
+                    .associate { it[0].trim() to it[1].trim() }
+            } catch (ex: Throwable) { mapOf() }
+
+            if ("ProductName" !in entries) return ""
+
+            return entries["ProductName"]!! +
+                    ((entries["DisplayVersion"] ?: entries["ReleaseId"])?.run { " Version $this" } ?: "") +
+                    (entries["CurrentBuild"]?.run { " (Build $this)" } ?: "")
+        }
+
+        /** Get linux Distribution out of the /etc/os-release file (ini-style)
+         *  Should be safely silent on systems not supporting that file.
+         */
+        fun getLinuxDistro(): String {
+            val osRelease: Map<String,String> = try {
+                FileHandle("/etc/os-release")
+                    .readString()
+                    .split('\n')
+                    .map { it.split('=') }
+                    .filter { it.size == 2 }
+                    .associate { it[0] to it[1].removeSuffix("\"").removePrefix("\"") }
+            } catch (ex: Throwable) { mapOf() }
+            if ("NAME" !in osRelease) return ""
+            return osRelease["PRETTY_NAME"] ?: "${osRelease["NAME"]} ${osRelease["VERSION"]}"
+        }
     }
 }

--- a/desktop/src/com/unciv/app/desktop/CrashReportSysInfoDesktop.kt
+++ b/desktop/src/com/unciv/app/desktop/CrashReportSysInfoDesktop.kt
@@ -1,0 +1,51 @@
+package com.unciv.app.desktop
+
+import com.badlogic.gdx.files.FileHandle
+import com.unciv.ui.utils.CrashReportSysInfo
+
+class CrashReportSysInfoDesktop : CrashReportSysInfo {
+
+    override fun getInfo(): String {
+        val builder = StringBuilder()
+
+        // Operating system
+        builder.append("OS: " + (System.getProperty("os.name") ?: "Unknown"))
+        val osInfo = listOfNotNull(System.getProperty("os.arch"), System.getProperty("os.version")).joinToString()
+        if (osInfo.isNotEmpty()) builder.append(" ($osInfo)")
+        builder.appendLine()
+
+        // Linux distro
+        val osRelease: Map<String,String> = try {
+            FileHandle("/etc/os-release")
+                .readString()
+                .split('\n')
+                .map { it.split('=') }
+                .filter { it.size == 2 }
+                .associate { it[0] to it[1].removeSuffix("\"").removePrefix("\"") }
+        } catch (ex: Throwable) { mapOf() }
+        if ("NAME" in osRelease) {
+            builder.append('\t')
+            builder.appendLine(
+                osRelease["PRETTY_NAME"] ?: "${osRelease["NAME"]} ${osRelease["VERSION"]}"
+            )
+        }
+
+        // Java runtime version
+        val javaVendor: String? = System.getProperty("java.vendor")
+        if (javaVendor != null) {
+            val javaVersion: String = System.getProperty("java.vendor.version") ?: System.getProperty("java.vm.version") ?: ""
+            builder.appendLine("Java: $javaVendor $javaVersion")
+        }
+
+        // Java VM memory limit as set by -Xmx
+        val maxMemory = try {
+            Runtime.getRuntime().maxMemory() / 1024 / 1024
+        } catch (ex: Throwable) { -1L }
+        if (maxMemory > 0) {
+            builder.append('\t')
+            builder.appendLine("Max Memory: $maxMemory MB")
+        }
+
+        return builder.toString()
+    }
+}

--- a/desktop/src/com/unciv/app/desktop/DesktopLauncher.kt
+++ b/desktop/src/com/unciv/app/desktop/DesktopLauncher.kt
@@ -49,7 +49,8 @@ internal object DesktopLauncher {
             versionFromJar,
             cancelDiscordEvent = { discordTimer?.cancel() },
             fontImplementation = NativeFontDesktop(Fonts.ORIGINAL_FONT_SIZE.toInt(), settings.fontFamily),
-            customSaveLocationHelper = CustomSaveLocationHelperDesktop()
+            customSaveLocationHelper = CustomSaveLocationHelperDesktop(),
+            crashReportSysInfo = CrashReportSysInfoDesktop()
         )
 
         val game = UncivGame(desktopParameters)


### PR DESCRIPTION
... why not?

Surprise: a `null!!` compiles (w/ tons of unreachable code warnings of course) and gives:
<details><summary>Screenie</summary>

![image](https://user-images.githubusercontent.com/63000004/159362271-ef62213c-d89e-4ef6-8b18-97ebdf610f27.png)
</details>

... I wiped the Windoze setup I once had to test, so no specific provisions for it. I'd like to ensure the 1804/1909/21H2 version thingy is in, the build number, and at most perhaps the chosen servicing ring or somesuch... Not in this PR. "os.version" should be better than nothing. Volunteers welcome.