### PR TITLE
Make max Zoom out a setting and fix a merge mistake

### DIFF
--- a/core/src/com/unciv/models/metadata/GameSettings.kt
+++ b/core/src/com/unciv/models/metadata/GameSettings.kt
@@ -54,10 +54,10 @@ class GameSettings {
     var windowState = WindowState()
     var isFreshlyCreated = false
     var visualMods = HashSet<String>()
-    
-    
+
+
     var multiplayerServer = Constants.dropboxMultiplayerServer
-    
+
 
     var showExperimentalWorldWrap = false // We're keeping this as a config due to ANR problems on Android phones for people who don't know what they're doing :/
 
@@ -69,6 +69,9 @@ class GameSettings {
     var lastGameSetup: GameSetupInfo? = null
 
     var fontFamily: String = Fonts.DEFAULT_FONT_FAMILY
+
+    /** Maximum zoom-out of the map - performance heavy */
+    var maxWorldZoomOut = 2f
 
     init {
         // 26 = Android Oreo. Versions below may display permanent icon in notification bar.
@@ -115,9 +118,9 @@ class GameSettings {
          *
          * @param base Path to the directory where the file should be - if not set, the OS current directory is used (which is "/" on Android)
          */
-        fun getSettingsForPlatformLaunchers(base: String = ""): GameSettings {
+        fun getSettingsForPlatformLaunchers(base: String = "."): GameSettings {
             // FileHandle is Gdx, but the class and JsonParser are not dependent on app initialization
-            // If fact, at this point Gdx.app or Gdx.files are null but this still works.
+            // In fact, at this point Gdx.app or Gdx.files are null but this still works.
             val file = FileHandle(base + File.separator + GameSaver.settingsFileName)
             return if (file.exists())
                 JsonParser().getFromJson(

--- a/core/src/com/unciv/ui/utils/ZoomableScrollPane.kt
+++ b/core/src/com/unciv/ui/utils/ZoomableScrollPane.kt
@@ -7,7 +7,7 @@ import com.badlogic.gdx.scenes.scene2d.utils.ActorGestureListener
 import kotlin.math.sqrt
 
 
-open class ZoomableScrollPane: ScrollPane(null) {
+open class ZoomableScrollPane : ScrollPane(null) {
     var continuousScrollingX = false
 
     init{
@@ -15,7 +15,7 @@ open class ZoomableScrollPane: ScrollPane(null) {
     }
 
     open fun zoom(zoomScale: Float) {
-        if (zoomScale < 0.25f || zoomScale > 2f) return
+        if (zoomScale < 0.5f || zoomScale > 2f) return
         setScale(zoomScale)
     }
     fun zoomIn() {

--- a/core/src/com/unciv/ui/worldscreen/WorldMapHolder.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldMapHolder.kt
@@ -30,8 +30,6 @@ import com.unciv.ui.tilegroups.TileGroup
 import com.unciv.ui.tilegroups.TileSetStrings
 import com.unciv.ui.tilegroups.WorldTileGroup
 import com.unciv.ui.utils.*
-//import com.unciv.ui.worldscreen.unit.UnitMovementsOverlayGroup
-import kotlin.concurrent.thread
 
 
 class WorldMapHolder(internal val worldScreen: WorldScreen, internal val tileMap: TileMap): ZoomableScrollPane() {
@@ -47,9 +45,19 @@ class WorldMapHolder(internal val worldScreen: WorldScreen, internal val tileMap
 
     private val unitMovementPaths: HashMap<MapUnit, ArrayList<TileInfo>> = HashMap()
 
+    private var maxWorldZoomOut = 2f
+    private var minZoomScale = 0.5f
+
     init {
         if (Gdx.app.type == Application.ApplicationType.Desktop) this.setFlingTime(0f)
         continuousScrollingX = tileMap.mapParameters.worldWrap
+        reloadMaxZoom()
+    }
+
+    internal fun reloadMaxZoom() {
+        maxWorldZoomOut = UncivGame.Current.settings.maxWorldZoomOut
+        minZoomScale = 1f / maxWorldZoomOut
+        if (scaleX < minZoomScale) zoom(1f)   // since normally min isn't reached exactly, only powers of 0.8
     }
 
     // Interface for classes that contain the data required to draw a button
@@ -62,7 +70,11 @@ class WorldMapHolder(internal val worldScreen: WorldScreen, internal val tileMap
     internal fun addTiles() {
         val tileSetStrings = TileSetStrings()
         val daTileGroups = tileMap.values.map { WorldTileGroup(worldScreen, it, tileSetStrings) }
-        val tileGroupMap = TileGroupMap(daTileGroups, worldScreen.stage.width, worldScreen.stage.height, continuousScrollingX)
+        val tileGroupMap = TileGroupMap(
+            daTileGroups,
+            worldScreen.stage.width * maxWorldZoomOut / 2,
+            worldScreen.stage.height * maxWorldZoomOut / 2,
+            continuousScrollingX)
         val mirrorTileGroups = tileGroupMap.getMirrorTiles()
 
         for (tileGroup in daTileGroups) {
@@ -130,7 +142,7 @@ class WorldMapHolder(internal val worldScreen: WorldScreen, internal val tileMap
 
         actor = tileGroupMap
 
-        setSize(worldScreen.stage.width * 2, worldScreen.stage.height * 2)
+        setSize(worldScreen.stage.width * maxWorldZoomOut, worldScreen.stage.height * maxWorldZoomOut)
         setOrigin(width / 2, height / 2)
         center(worldScreen.stage)
 
@@ -702,12 +714,13 @@ class WorldMapHolder(internal val worldScreen: WorldScreen, internal val tileMap
     }
 
     override fun zoom(zoomScale: Float) {
-        super.zoom(zoomScale)
+        if (zoomScale < minZoomScale || zoomScale > 2f) return
+        setScale(zoomScale)
         val scale = 1 / scaleX  // don't use zoomScale itself, in case it was out of bounds and not applied
         if (scale >= 1)
             for (tileGroup in allWorldTileGroups)
                 tileGroup.cityButtonLayerGroup.isTransform = false // to save on rendering time to improve framerate
-        if (scale < 1 && scale > 0.5f)
+        if (scale < 1 && scale >= minZoomScale)
             for (tileGroup in allWorldTileGroups) {
                 // ONLY set those groups that have active city buttons as transformable!
                 // This is massively framerate-improving!

--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -713,6 +713,7 @@ class WorldScreen(val gameInfo: GameInfo, val viewingCiv:CivilizationInfo) : Bas
      * to re-enable the next turn button within its Close button action
      */
     fun enableNextTurnButtonAfterOptions() {
+        mapHolder.reloadMaxZoom()
         nextTurnButton.isEnabled = isPlayersTurn && !waitingForAutosave
     }
 


### PR DESCRIPTION
So I suspected #6354 to ruin my performance, and when I went to check that suspicion I found I had inadvertently ruined @itanasi 's code in that Overview-Units PR. Sorry! Turns out that was exactly the line I always missed when I tried that idea before, and now even more crass zoom-outs do work. Of course, you get to see the triptychon for world wrapped maps when you set it too high...

Do we need an 'eats memory' warning?

P.S.: Also fixes (my bad) desktop no longer restoring window size.