### PR TITLE
Translation writer conditionals

### DIFF
--- a/android/assets/jsons/Civ V - Gods & Kings/Nations.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Nations.json
@@ -211,7 +211,8 @@
 
 		"startIntroPart1": "The blessings of the gods be upon you, Caesar Augustus, emperor of Rome and all her holdings. Your empire was the greatest and longest lived of all in Western civilization. And your people single-handedly shaped its culture, law, art, and warfare like none other, before or since. Through years of glorious conquest, Rome came to dominate all the lands of the Mediterranean from Spain in the west to Syria in the east. And her dominion would eventually expand to cover much of England and northern Germany. Roman art and architecture still awe and inspire the world. And she remains the envy of all lesser civilizations who have followed.",
 		"startIntroPart2": "O mighty emperor, your people turn to you to once more reclaim the glory of Rome! Will you see to it that your empire rises again, bringing peace and order to all? Will you make Rome once again center of the world? Can you build a civilization that will stand the test of time?",
-		"declaringWar": "My treasury contains little and my soldiers are getting impatient... <sigh> ...therefore you must die.",
+		// The original <sigh> causes translation problems
+		"declaringWar": "My treasury contains little and my soldiers are getting impatient... (sigh) ...therefore you must die.",
 		"attacked": "So brave, yet so stupid! If only you had a brain similar to your courage.",
 		"defeated": "The gods have deprived Rome of their favour. We have been defeated.",
 		"introduction": "I greet you. I am Augustus, Imperator and Pontifex Maximus of Rome. If you are a friend of Rome, you are welcome.",
@@ -317,7 +318,7 @@
 		"startIntroPart2": "Gandhi, your people look to you to lead them to even greater heights of glory! Can you help your people realize their great potential, to once again become the world's center of arts, culture and religion? Can you build a civilization that will stand the test of time?",
 		"declaringWar": "I have just received a report that large numbers of my troops have crossed your borders.",
 		"attacked": "My attempts to avoid violence have failed. An eye for an eye only makes the world blind.",
-		"defeated": "You can chain me, you can torture me, you can even destroy this body, but you will never imprison my mind. ",
+		"defeated": "You can chain me, you can torture me, you can even destroy this body, but you will never imprison my mind.",
 		"introduction": "Hello, I am Mohandas Gandhi. My people call me Bapu, but please, call me friend.",
 		"neutralHello": "I wish you peace.",
 		"hateHello": "What do you want?",
@@ -782,7 +783,7 @@
 		"startIntroPart1": "Noble and virtuous Queen Maria Theresa, Holy Roman Empress and sovereign of Austria, the people bow to your gracious will. Following the death of your father King Charles VI, you ascended the thone of Austria during a time of great instability, but the empty coffers and diminished military did litle to dissuade your ambitions. Faced with war almost immediately upon your succession to the thron, you managed to fend off your foes, and in naming your husband Francis Stephen co-ruler, assured your place as Empress of the Holy Roman Empire. During your reigh, you guided Austria on a new path of reform - strengthening the military, replenishing the treasury, and improving the educational system of the kingdom.",
 		"startIntroPart2": "Oh great queen, bold and dignified, the time has come for you to rise and guide the kingdom once again. Can you return your people to the height of prosperity and splendor? Will you build a civilization that stands the test of time?",
 
-		"declaringWar": "Shame that it has come this far. But ye wished it so. Next time, be so good, choose your words more wisely. ",
+		"declaringWar": "Shame that it has come this far. But ye wished it so. Next time, be so good, choose your words more wisely.",
 		"attacked": "What a fool ye are! Ye will end swiftly and miserably.",
 		"defeated": "The world is pitiful! There's no beauty in it, no wisdom. I am almost glad to go.",
 		"introduction": "The archduchess of Austria welcomes your Eminence to... Oh let's get this over with! I have a luncheon at four o'clock.",

--- a/android/assets/jsons/Civ V - Vanilla/Nations.json
+++ b/android/assets/jsons/Civ V - Vanilla/Nations.json
@@ -204,7 +204,8 @@
 
 		"startIntroPart1": "The blessings of the gods be upon you, Caesar Augustus, emperor of Rome and all her holdings. Your empire was the greatest and longest lived of all in Western civilization. And your people single-handedly shaped its culture, law, art, and warfare like none other, before or since. Through years of glorious conquest, Rome came to dominate all the lands of the Mediterranean from Spain in the west to Syria in the east. And her dominion would eventually expand to cover much of England and northern Germany. Roman art and architecture still awe and inspire the world. And she remains the envy of all lesser civilizations who have followed.",
 		"startIntroPart2": "O mighty emperor, your people turn to you to once more reclaim the glory of Rome! Will you see to it that your empire rises again, bringing peace and order to all? Will you make Rome once again center of the world? Can you build a civilization that will stand the test of time?",
-		"declaringWar": "My treasury contains little and my soldiers are getting impatient... <sigh> ...therefore you must die.",
+		// The original <sigh> causes translation problems
+		"declaringWar": "My treasury contains little and my soldiers are getting impatient... (sigh) ...therefore you must die.",
 		"attacked": "So brave, yet so stupid! If only you had a brain similar to your courage.",
 		"defeated": "The gods have deprived Rome of their favour. We have been defeated.",
 		"introduction": "I greet you. I am Augustus, Imperator and Pontifex Maximus of Rome. If you are a friend of Rome, you are welcome.",
@@ -304,7 +305,7 @@
 
 		"declaringWar": "I have just received a report that large numbers of my troops have crossed your borders.",
 		"attacked": "My attempts to avoid violence have failed. An eye for an eye only makes the world blind.",
-		"defeated": "You can chain me, you can torture me, you can even destroy this body, but you will never imprison my mind. ",
+		"defeated": "You can chain me, you can torture me, you can even destroy this body, but you will never imprison my mind.",
 		"introduction": "Hello, I am Mohandas Gandhi. My people call me Bapu, but please, call me friend.",
 		"neutralHello": "I wish you peace.",
 		"hateHello": "What do you want?",

--- a/android/assets/jsons/translations/Brazilian_Portuguese.properties
+++ b/android/assets/jsons/translations/Brazilian_Portuguese.properties
@@ -1217,8 +1217,6 @@ or [terrainType] = ou [terrainType]
 Can be constructed by = Pode ser construído por
 Defence bonus = Bônus de defesa
 Movement cost = Custo de movimento
-Open terrain = Abrir terreno
-Rough Terrain = Terreno Bruto
 for = Por
 Missing translations: = Traduções faltando:
 Resolution = Resolução
@@ -1397,125 +1395,6 @@ Enhancing religion =
  # Requires translation!
 Enhanced religion = 
 
-# Terrains
-
-Impassable = Inacessível
-Rare feature = Característica rara
-
-# terrainFilters (so for uniques like: "[stats] from [terrainFilter] tiles")
-
- # Requires translation!
-All = 
-Water = Água
-Land = Terreno
- # Requires translation!
-Coastal = 
-River = Rio
- # Requires translation!
-Rough terrain = 
-Foreign Land = Terra Estrangeira
- # Requires translation!
-Foreign = 
-Friendly Land = Território Amigável
-Water resource = Recurso marinho
- # Requires translation!
-Bonus resource = 
- # Requires translation!
-Luxury resource = 
- # Requires translation!
-Strategic resource = 
-Fresh water = Água doce
-non-fresh water = água salgada
- # Requires translation!
-Natural Wonder = 
- # Requires translation!
-Hybrid = 
- # Requires translation!
-Undesirable = 
- # Requires translation!
-Desirable = 
- # Requires translation!
-Featureless = 
- # Requires translation!
-Fresh Water = 
-
-# improvementFilters
-
- # Requires translation!
-All Road = 
-Great Improvement = Grande Melhoria
- # Requires translation!
-Great = 
-
-# Resources
-
-Bison = Bisões
-Copper = Cobre
-Cocoa = Cacau
-Crab = Caranguejos
-Citrus = Cítricos
-Truffles = Trufas
-Strategic = Estratégicos
-Bonus = Bônus
-Luxury = Luxúria
-
-# Unit types
-
-City = Cidade
-Civilian = Cidadão
-Melee = Corpo a corpo
-Ranged = Ataque à distância
-Scout = Batedor
-Mounted = Montado(a)
-Armor = Blindado
- # Requires translation!
-Siege = 
-
-WaterCivilian = Cidadão marítimo
-WaterMelee = Corpo a corpo marítimo
-WaterRanged = Ataque à distância marítimo
-WaterSubmarine = Submarino
-WaterAircraftCarrier = Porta-Aviões Marítimo
-
-Fighter = Avião de combate
-Bomber = Bombardeiro
- # Requires translation!
-AtomicBomber = 
-Missile = Míssil
-
-
-# Unit filters and other unit related things
-
-Air = Aéreo
-air units = Unidades aéreas
-Barbarian = Bárbaro
-Barbarians = Bárbaros
- # Requires translation!
-Embarked = 
-land units = Unidades terrestres
-Military = Militar
-# Deprecated since 3.15.2, but should still be translated until it is officially removed
- # Requires translation!
-military water = 
-non-air = não-aérea
- # Requires translation!
-Nuclear Weapon = 
-Submarine = Submarino
- # Requires translation!
-submarine units = 
-Unbuildable = Não construível
-water units = Unidades marítimas
-wounded units = unidades feridas
-Wounded = Ferida
-
-# For the "All newly-trained [relevant] units in this city receive the [] promotion" translation. Relevant as in 'units that can receive'
-relevant = aplicável
-
-# For "May choose [amount] additional [beliefType] beliefs when [founding/enhancing] a religion"
- # Requires translation!
-founding = 
- # Requires translation!
-enhancing = 
 
 # Promotions
 
@@ -1523,6 +1402,7 @@ Pick promotion = Escolher promoção
  OR  = Ou 
 units in open terrain = unidades em terreno aberto
 units in rough terrain = unidades em terreno acidentado
+wounded units = unidades feridas
 Targeting II (air) = Alvejamento Aéreo II
 Targeting III (air) = Alvejamento Aéreo III
 Bonus when performing air sweep [bonusAmount]% = [bonusAmount]% de bônus enquanto executa varredura áerea
@@ -1667,6 +1547,11 @@ This Unit upgrades for free =
 Never destroyed when the city is captured = 
 Invisible to others = Invisível para outros
 
+# Unused Resources
+
+Bison = Bisões
+Cocoa = Cacau
+
 
 # In English we just paste all these conditionals at the end of each unique, but in your language that
 # may not turn into valid sentences. Therefore we have the following two translations to determine
@@ -1696,6 +1581,36 @@ ConditionalsPlacement =
 
 ########################### AUTOMATICALLY GENERATED TRANSLATABLE STRINGS ########################### 
 
+
+######### Map Unit Filters ###########
+
+Wounded = Ferida
+Barbarians = Bárbaros
+ # Requires translation!
+City-State = 
+ # Requires translation!
+Embarked = 
+ # Requires translation!
+Non-City = 
+
+######### Unit Type Filters ###########
+
+Military = Militar
+Civilian = Cidadão
+non-air = não-aérea
+relevant = aplicável
+ # Requires translation!
+Nuclear Weapon = 
+City = Cidade
+Air = Aéreo
+land units = Unidades terrestres
+water units = Unidades marítimas
+air units = Unidades aéreas
+ # Requires translation!
+military units = 
+ # Requires translation!
+submarine units = 
+Barbarian = Bárbaro
 
 ######### City filters ###########
 
@@ -1727,6 +1642,81 @@ in holy cities =
 in City-State cities = 
  # Requires translation!
 in cities following this religion = 
+
+######### Population Filters ###########
+
+ # Requires translation!
+Unemployed = 
+ # Requires translation!
+Followers of the Majority Religion = 
+ # Requires translation!
+Followers of this Religion = 
+
+######### Terrain Filters ###########
+
+ # Requires translation!
+All = 
+ # Requires translation!
+Coastal = 
+River = Rio
+Open terrain = Abrir terreno
+ # Requires translation!
+Rough terrain = 
+Water resource = Recurso marinho
+Foreign Land = Terra Estrangeira
+ # Requires translation!
+Foreign = 
+Friendly Land = Território Amigável
+ # Requires translation!
+Enemy Land = 
+ # Requires translation!
+Featureless = 
+ # Requires translation!
+Fresh Water = 
+non-fresh water = água salgada
+ # Requires translation!
+Natural Wonder = 
+Impassable = Inacessível
+Land = Terreno
+Water = Água
+ # Requires translation!
+Luxury resource = 
+ # Requires translation!
+Strategic resource = 
+ # Requires translation!
+Bonus resource = 
+
+######### Tile Filters ###########
+
+ # Requires translation!
+unimproved = 
+ # Requires translation!
+All Road = 
+Great Improvement = Grande Melhoria
+
+######### Region Types ###########
+
+ # Requires translation!
+Hybrid = 
+
+######### Terrain Quality ###########
+
+ # Requires translation!
+Undesirable = 
+ # Requires translation!
+Desirable = 
+
+######### Improvement Filters ###########
+
+ # Requires translation!
+Great = 
+
+######### Prophet Action Filters ###########
+
+ # Requires translation!
+founding = 
+ # Requires translation!
+enhancing = 
 
 ######### Unique Specials ###########
 
@@ -1760,6 +1750,8 @@ Temple of Artemis = Templo de Artemis
 
 The Great Lighthouse = O Grande Farol
 'They that go down to the sea in ships, that do business in great waters; these see the works of the Lord, and his wonders in the deep.' - The Bible, Psalms 107:23-24 = 'Os navios que descem no mar, negociam em grandes águas; estes vêem as obras do Senhor, e suas maravilhas nas profundezas.' - A Bíblia, Salmos 107:23-24
+ # Requires translation!
+for [mapUnitFilter] units = 
  # Requires translation!
 [amount] Movement = 
  # Requires translation!
@@ -1814,6 +1806,10 @@ Krepost = Fortaleza
 
 Statue of Zeus = Estátua de Zeus
 'He spoke, the son of Kronos, and nodded his head with the dark brows, and the immortally anointed hair of the great god swept from his divine head, and all Olympos was shaken' - The Iliad = 'Ele falou, filho de Cronos, e acenou com a cabeça com as sobrancelhas escuras, e os cabelos imortalmente ungidos do grande deus varreram de sua cabeça divina, e todo o Olimpo foi abalado' - A Ilíada
+ # Requires translation!
+vs cities = 
+ # Requires translation!
+when attacking = 
  # Requires translation!
 [amount]% Strength = 
 
@@ -1927,11 +1923,15 @@ Castle = Castelo
 
 Mughal Fort = Forte de Mughal
  # Requires translation!
+after discovering [tech] = 
+ # Requires translation!
 [stats] [cityFilter] = 
 
 Himeji Castle = Castelo Himeji
  # Requires translation!
 'Bushido is realized in the presence of death. This means choosing death whenever there is a choice between life and death. There is no other reasoning.' - Yamamoto Tsunetomo = 
+ # Requires translation!
+when fighting in [tileFilter] tiles = 
 
 Ironworks = Siderurgia
 
@@ -2051,6 +2051,8 @@ Pentagon = Pentágono
 [amount]% Gold cost of upgrading = [amount]% Custo de Ouro da melhoria
 
 Solar Plant = Planta Solar
+ # Requires translation!
+in cities without a [buildingFilter] = 
 Only available = Disponível apenas
 
 Nuclear Plant = Planta Nuclear
@@ -2090,6 +2092,7 @@ King = Rei
 Era Starting Unit = 
 
 Emperor = Imperador
+Scout = Batedor
 
 Immortal = Imortal
 Worker = Trabalhador
@@ -2122,9 +2125,6 @@ Atomic era = Era Atômica
 Information era = Era da Informação
 
 Future era = Era futurista
-
-
-#################### Lines from GlobalUniques from Civ V - Vanilla ####################
 
 
 #################### Lines from Nations from Civ V - Vanilla ####################
@@ -2545,6 +2545,8 @@ Bourges =
  # Requires translation!
 Calais = 
 France = França
+ # Requires translation!
+before discovering [tech] = 
 
 Catherine = Catarina
 You've behaved yourself very badly, you know it. Now it's payback time. = Você se comportou muito mal, e você sabe disso. É hora da vingança.
@@ -2640,7 +2642,7 @@ Double quantity of [resource] produced =
 
 Augustus Caesar = Augusto César
  # Requires translation!
-My treasury contains little and my soldiers are getting impatient... ...therefore you must die. = 
+My treasury contains little and my soldiers are getting impatient... (sigh) ...therefore you must die. = 
 So brave, yet so stupid! If only you had a brain similar to your courage. = Tão bravo, porém tão estupido! Ao menos se você tivesse um cérebro similar a sua coragen.
 The gods have deprived Rome of their favour. We have been defeated. = Os deuses privaram Roma de seu favor. Nós fomos derrotados.
 I greet you. I am Augustus, Imperator and Pontifex Maximus of Rome. If you are a friend of Rome, you are welcome. = Prazer. Sou César Augusto, imperador e Papa de Roma. Se você é amigo de Roma, você é bem vindo.
@@ -3500,6 +3502,8 @@ Patigrbana =
  # Requires translation!
 Phrada = 
 Persia = Pérsia
+ # Requires translation!
+during a Golden Age = 
 
 Kamehameha I = Kamehameha I
 The ancient fire flashing across the sky is what proclaimed that this day would come, though I had foolishly hoped for a different outcome. = O fogo antigo brilhando no céu é o que proclamava que esse dia chegaria, apesar de eu tolamente ter esperado um resultado diferente.
@@ -3592,6 +3596,8 @@ Pileni =
  # Requires translation!
 Nukumanu = 
 Polynesia = Polinésia
+ # Requires translation!
+starting from the [era] = 
 Enables embarkation for land units = Permite o embarque de unidades terrestres
  # Requires translation!
 Enables [mapUnitFilter] units to enter ocean tiles = 
@@ -4254,6 +4260,8 @@ Provides the cheapest [stat] building in your first [amount] cities for free =
 Oligarchy = Oligarquia
 Units in cities cost no Maintenance = Unidades em cidades não cobram custo de Manutenção
  # Requires translation!
+with a garrison = 
+ # Requires translation!
 [amount]% Strength for cities = 
 Landed Elite = Elite aterrisada
  # Requires translation!
@@ -4278,6 +4286,8 @@ Liberty =
 
 Warrior Code = Código de Honra
 Discipline = Disciplina
+ # Requires translation!
+when adjacent to a [mapUnitFilter] unit = 
 Military Tradition = Tradição militar
  # Requires translation!
 [amount]% XP gained from combat = 
@@ -4286,6 +4296,8 @@ Professional Army = Exército Profissional
 Honor Complete = Honra Completa
  # Requires translation!
 Honor = 
+ # Requires translation!
+vs [mapUnitFilter] units = 
  # Requires translation!
 Notified of new Barbarian encampments = 
 
@@ -4301,6 +4313,8 @@ Free Religion = Liberdade de Religião
 Piety Complete = Piedade Completa
  # Requires translation!
 Piety = 
+ # Requires translation!
+before adopting [policy] = 
 
  # Requires translation!
 Philantropy = 
@@ -4362,10 +4376,14 @@ Rationalism Complete = Racionalismo Completo
  # Requires translation!
 Rationalism = 
  # Requires translation!
+while the empire is happy = 
+ # Requires translation!
 [amount]% [stat] = 
 
 Constitution = Constituição
 Universal Suffrage = Sufrágio Universal
+ # Requires translation!
+when defending = 
 Civil Society = Sociedade Civil
  # Requires translation!
 [amount]% Food consumption by specialists [cityFilter] = 
@@ -4389,6 +4407,8 @@ Quantity of strategic resources produced by the empire +[amount]% =
 Police State = Estado de Polícia
 Total War = Guerra Total
 Autocracy Complete = Autocracia Completa
+ # Requires translation!
+for [amount] turns = 
  # Requires translation!
 Autocracy = 
  # Requires translation!
@@ -4423,34 +4443,34 @@ Clear Barbarian Camp = Limpar o acampamento bárbaro
 We feel threatened by a Barbarian Camp near our city. Please take care of it. = Estamos nos sentindo ameaçados com este acampamento bárbaro perto de nossa cidade.Cuide dele por favor
 
 Connect Resource = Conectar recurso
-In order to make our civilizations stronger, connect [param] to your trade network. = Para fazer nossas civilizações mais fortes,conecte [param] para suas estradas
+In order to make our civilizations stronger, connect [tileResource] to your trade network. = Para fazer nossas civilizações mais fortes,conecte [tileResource] para suas estradas
 
 Construct Wonder = Construir uma Maravilha
-We recommend you to start building [param] to show the whole world your civilization strength. = Eu recomendo que você começe á construir [param] para mostrar ao mundo como sua civilização é forte
+We recommend you to start building [wonder] to show the whole world your civilization strength. = Eu recomendo que você começe á construir [wonder] para mostrar ao mundo como sua civilização é forte
 
 Acquire Great Person = Adquirir uma Grande Personalidade
-Great People can change the course of a Civilization! You will be rewarded for acquiring a new [param]. = Grandes Personalidades podem mudar o rumo de sua civilização.Você vai ser tecompensado por adquirir [param]
+Great People can change the course of a Civilization! You will be rewarded for acquiring a new [greatPerson]. = Grandes Personalidades podem mudar o rumo de sua civilização.Você vai ser tecompensado por adquirir [greatPerson]
 
  # Requires translation!
 Conquer City State = 
  # Requires translation!
-It's time to erase the City-State of [param] from the map. You will be greatly rewarded for conquering them! = 
+It's time to erase the City-State of [cityState] from the map. You will be greatly rewarded for conquering them! = 
 
 Find Player = Procurar Jogador
-You have yet to discover where [param] set up their cities. You will be rewarded for finding their territories. = Você ainda nâo descobriu onde ainda [param] onde eles podem ter fundado suas cidades,você vai ser recompensado por achar os territórios
+You have yet to discover where [civName] set up their cities. You will be rewarded for finding their territories. = Você ainda nâo descobriu onde ainda [civName] onde eles podem ter fundado suas cidades,você vai ser recompensado por achar os territórios
 
 Find Natural Wonder = Achar uma Maravilha Natural
-Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [param] yet. = Mande seus melhores exploradores em uma missão para achar as Maravilhas Naturais.Ninguém sabe a localização das [param] ainda
+Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [naturalWonder] yet. = Mande seus melhores exploradores em uma missão para achar as Maravilhas Naturais.Ninguém sabe a localização das [naturalWonder] ainda
 
  # Requires translation!
 Give Gold = 
  # Requires translation!
-We are suffering great poverty after being robbed by [param], and unless we receive a sum of Gold, it's only a matter of time before we collapse. = 
+We are suffering great poverty after being robbed by [civName], and unless we receive a sum of Gold, it's only a matter of time before we collapse. = 
 
  # Requires translation!
 Pledge to Protect = 
  # Requires translation!
-We need your protection to stop the aggressions of [param]. By signing a Pledge of Protection, you'll confirm the bond that ties us. = 
+We need your protection to stop the aggressions of [civName]. By signing a Pledge of Protection, you'll confirm the bond that ties us. = 
 
  # Requires translation!
 Contest Culture = 
@@ -4470,20 +4490,20 @@ The civilization with the largest number of new Technologies researched will gai
  # Requires translation!
 Invest = 
  # Requires translation!
-Our people are rejoicing thanks to a tourism boom. For a certain amount of time, any Gold donation will yield [amount]% extra Influence. = 
+Our people are rejoicing thanks to a tourism boom. For a certain amount of time, any Gold donation will yield [50]% extra Influence. = 
 
  # Requires translation!
 Bully City State = 
  # Requires translation!
-We are tired of the pretensions of [param]. If someone were to put them in their place by Demanding Tribute from them, they would be rewarded. = 
+We are tired of the pretensions of [cityState]. If someone were to put them in their place by Demanding Tribute from them, they would be rewarded. = 
 
  # Requires translation!
 Denounce Civilization = 
  # Requires translation!
-We have been forced to pay tribute to [param]! We need you to tell the world of their ill deeds. = 
+We have been forced to pay tribute to [civName]! We need you to tell the world of their ill deeds. = 
 
  # Requires translation!
-We have heard the tenets of [param] and are most curious. Will you send missionaries to teach us about your religion? = 
+We have heard the tenets of [religionName] and are most curious. Will you send missionaries to teach us about your religion? = 
 
 
 #################### Lines from Ruins from Civ V - Vanilla ####################
@@ -4505,12 +4525,12 @@ An ancient tribe trained us in their ways of combat! =
 your exploring unit receives training = 
 
  # Requires translation!
-We have found survivors in the ruins! Population added to [param]. = 
+We have found survivors in the ruins! Population added to [cityName]. = 
  # Requires translation!
 survivors (adds population to a city) = 
 
  # Requires translation!
-We have found a stash of [param] Gold in the ruins! = 
+We have found a stash of [goldAmount] Gold in the ruins! = 
  # Requires translation!
 a stash of gold = 
 
@@ -4749,6 +4769,7 @@ Tundra = Tundra
 Desert = Deserto
 
 Lakes = Lagos
+Fresh water = Água doce
 
 Mountain = Montanhas
  # Requires translation!
@@ -4774,6 +4795,7 @@ A Camp can be built here without cutting it down =
 Jungle = Selva
 
 Marsh = Pântano
+Rare feature = Característica rara
  # Requires translation!
 Only Polders can be built here = 
 
@@ -5000,6 +5022,9 @@ Porcelain =
 
  # Requires translation!
 Sword = 
+Mounted = Montado(a)
+ # Requires translation!
+Siege = 
  # Requires translation!
 Ranged Gunpowder = 
  # Requires translation!
@@ -5008,6 +5033,7 @@ Armored =
 Melee Water = 
  # Requires translation!
 Ranged Water = 
+Submarine = Submarino
 Heal Instantly = Cura Instantânea
  # Requires translation!
 Heal this unit by [amount] HP = 
@@ -5075,6 +5101,8 @@ Medic = Médico I
 All adjacent units heal [amount] HP when healing = 
 
 Medic II = Médico II
+ # Requires translation!
+in [tileFilter] tiles = 
  # Requires translation!
 [amount] HP when healing = 
 
@@ -5145,6 +5173,7 @@ Supply =
  # Requires translation!
 May heal outside of friendly territory = 
 
+Bomber = Bombardeiro
 Siege I = Cerco Aéreo I
 
 Siege II = Cerco Aéreo II
@@ -5155,6 +5184,7 @@ Evasion = Evasão
  # Requires translation!
 Damage taken from interception reduced by [amount]% = 
 
+Fighter = Avião de combate
 Interception I = Interceptação I
  # Requires translation!
 [amount]% Damage when intercepting = 
@@ -5271,12 +5301,32 @@ Can see over obstacles =
  # Requires translation!
 Atomic Bomber = 
 
+Missile = Míssil
  # Requires translation!
 Self-destructs when attacking = 
  # Requires translation!
 Cannot be intercepted = 
 
 Can pass through impassable tiles = Pode passar por hexágonos impossíveis de passar
+
+Melee = Corpo a corpo
+
+Ranged = Ataque à distância
+
+Armor = Blindado
+
+WaterCivilian = Cidadão marítimo
+
+WaterMelee = Corpo a corpo marítimo
+
+WaterRanged = Ataque à distância marítimo
+
+WaterSubmarine = Submarino
+
+WaterAircraftCarrier = Porta-Aviões Marítimo
+
+ # Requires translation!
+AtomicBomber = 
 
 
 #################### Lines from Units from Civ V - Vanilla ####################
@@ -5361,6 +5411,8 @@ Knight = Cavaleiro
 Camel Archer = Arqueiro de camelo
 
 Conquistador = Conquistador
+ # Requires translation!
+on foreign continents = 
 
 Naresuan's Elephant = Elefante de Naresuan
 
@@ -5457,6 +5509,8 @@ Atomic Bomb = Bomba Atômica
  # Requires translation!
 Nuclear weapon of Strength [amount] = 
  # Requires translation!
+if [buildingName] is constructed = 
+ # Requires translation!
 Blast radius [amount] = 
 
 Rocket Artillery = Artilharia de foguetes
@@ -5499,6 +5553,7 @@ Great Artist = Grande Artista
 Can start an [amount]-turn golden age = Pode começar uma Era Dourada de [amount]-turnos
 Can construct [improvementName] = Pode construir [improvementName]
 Great Person - [stat] = Grande Pessoa - [stat] 
+Unbuildable = Não construível
 
 Great Scientist = Grande Cientista
 Can hurry technology research = Pode apressar pesquisa tecnológica
@@ -5581,6 +5636,8 @@ Fertility Rites =
 
  # Requires translation!
 God of Craftsman = 
+ # Requires translation!
+in cities with at least [amount] [populationFilter] = 
 
  # Requires translation!
 God of the Open Sky = 
@@ -5661,6 +5718,8 @@ Guruship =
  # Requires translation!
 Holy Warriors = 
  # Requires translation!
+before the [era] = 
+ # Requires translation!
 May buy [baseUnitFilter] units with [stat] for [amount] times their normal Production cost = 
 
  # Requires translation!
@@ -5691,6 +5750,8 @@ Religious Community =
 
  # Requires translation!
 Swords into Ploughshares = 
+ # Requires translation!
+when not at war = 
 
  # Requires translation!
 Founder = 
@@ -5882,9 +5943,6 @@ Starting in this era disables religion =
 
 
 Marine = Náutico
-
-
-#################### Lines from GlobalUniques from Civ V - Gods & Kings ####################
 
 
 #################### Lines from Nations from Civ V - Gods & Kings ####################
@@ -6508,6 +6566,8 @@ Falmouth =
 Lorient = 
  # Requires translation!
 Celts = 
+ # Requires translation!
+with [amount] to [amount2] neighboring [tileFilter] [tileFilter2] tiles = 
 
  # Requires translation!
 Haile Selassie = 
@@ -6595,6 +6655,8 @@ Ziway =
 Weldiya = 
  # Requires translation!
 Ethiopia = 
+ # Requires translation!
+when fighting units from a Civilization with more Cities than you = 
 
  # Requires translation!
 Pacal = 
@@ -6740,12 +6802,12 @@ Taoism = Taoísmo
 
 
  # Requires translation!
-We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[param] Faith) = 
+We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[faithAmount] Faith) = 
  # Requires translation!
 discover holy symbols = 
 
  # Requires translation!
-We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[param] Faith) = 
+We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[faithAmount] Faith) = 
 an ancient prophecy = uma profecia antiga
 
 
@@ -6812,7 +6874,15 @@ Polder =
 #################### Lines from TileResources from Civ V - Gods & Kings ####################
 
 
+Citrus = Cítricos
+
+Copper = Cobre
+
+Crab = Caranguejos
+
 Salt = Sal
+
+Truffles = Trufas
 
 
 #################### Lines from UnitPromotions from Civ V - Gods & Kings ####################
@@ -7290,13 +7360,7 @@ Irremovable =
  # Requires translation!
 when at war = 
  # Requires translation!
-when not at war = 
- # Requires translation!
-during a Golden Age = 
- # Requires translation!
 with [resource] = 
- # Requires translation!
-while the empire is happy = 
  # Requires translation!
 when between [amount] and [amount2] Happiness = 
  # Requires translation!
@@ -7304,67 +7368,25 @@ when below [amount] Happiness =
  # Requires translation!
 during the [era] = 
  # Requires translation!
-before the [era] = 
- # Requires translation!
-starting from the [era] = 
- # Requires translation!
 if no other Civilization has researched this = 
- # Requires translation!
-after discovering [tech] = 
- # Requires translation!
-before discovering [tech] = 
  # Requires translation!
 upon discovering [tech] = 
  # Requires translation!
 after adopting [policy] = 
  # Requires translation!
-before adopting [policy] = 
- # Requires translation!
-if [buildingName] is constructed = 
- # Requires translation!
-for [amount] turns = 
- # Requires translation!
 by consuming this unit = 
  # Requires translation!
 in cities with a [buildingFilter] = 
  # Requires translation!
-in cities without a [buildingFilter] = 
- # Requires translation!
-in cities with at least [amount] [populationFilter] = 
- # Requires translation!
-with a garrison = 
- # Requires translation!
-for [mapUnitFilter] units = 
- # Requires translation!
 for units with [promotion] = 
  # Requires translation!
 for units without [promotion] = 
- # Requires translation!
-vs cities = 
- # Requires translation!
-vs [mapUnitFilter] units = 
- # Requires translation!
-when fighting units from a Civilization with more Cities than you = 
- # Requires translation!
-when attacking = 
- # Requires translation!
-when defending = 
- # Requires translation!
-when fighting in [tileFilter] tiles = 
- # Requires translation!
-on foreign continents = 
- # Requires translation!
-when adjacent to a [mapUnitFilter] unit = 
  # Requires translation!
 when above [amount] HP = 
  # Requires translation!
 when below [amount] HP = 
  # Requires translation!
 with [amount] to [amount2] neighboring [tileFilter] tiles = 
- # Requires translation!
-with [amount] to [amount2] neighboring [tileFilter] [tileFilter2] tiles = 
- # Requires translation!
-in [tileFilter] tiles = 
  # Requires translation!
 in [tileFilter] [tileFilter2] tiles = 
  # Requires translation!
@@ -7428,3 +7450,10 @@ Ruins = Ruínas
 CityState = Cidade-Estado
 ModOptions = Opções de Mod
 Conditional = Condicional
+
+#################### Removed Lines ####################
+
+#~~Rough Terrain = Terreno Bruto
+#~~Strategic = Estratégicos
+#~~Bonus = Bônus
+#~~Luxury = Luxúria

--- a/android/assets/jsons/translations/Bulgarian.properties
+++ b/android/assets/jsons/translations/Bulgarian.properties
@@ -1390,9 +1390,6 @@ or [terrainType] =
 Can be constructed by = 
 Defence bonus = Защитен бонус
 Movement cost = Струва (движение)
- # Requires translation!
-Open terrain = 
-Rough Terrain = Пресечен терен
 for = за
 Missing translations: = Липса на превод:
 Resolution = Резолюция
@@ -1583,139 +1580,6 @@ Enhancing religion =
  # Requires translation!
 Enhanced religion = 
 
-# Terrains
-
-Impassable = Непроходим
- # Requires translation!
-Rare feature = 
-
-# terrainFilters (so for uniques like: "[stats] from [terrainFilter] tiles")
-
- # Requires translation!
-All = 
-Water = Вода
-Land = Земя
- # Requires translation!
-Coastal = 
-River = Река
- # Requires translation!
-Rough terrain = 
-Foreign Land = Вража Територия
- # Requires translation!
-Foreign = 
- # Requires translation!
-Friendly Land = 
-Water resource = Воден ресурс
- # Requires translation!
-Bonus resource = 
- # Requires translation!
-Luxury resource = 
- # Requires translation!
-Strategic resource = 
-Fresh water = Прясна вода
-non-fresh water = застояла вода
- # Requires translation!
-Natural Wonder = 
- # Requires translation!
-Hybrid = 
- # Requires translation!
-Undesirable = 
- # Requires translation!
-Desirable = 
- # Requires translation!
-Featureless = 
- # Requires translation!
-Fresh Water = 
-
-# improvementFilters
-
- # Requires translation!
-All Road = 
- # Requires translation!
-Great Improvement = 
- # Requires translation!
-Great = 
-
-# Resources
-
-Bison = Бизон
-Copper = Мед
-Cocoa = Какао
-Crab = Рак
-Citrus = Цитрус
-Truffles = Трюфели
- # Requires translation!
-Strategic = 
- # Requires translation!
-Bonus = 
- # Requires translation!
-Luxury = 
-
-# Unit types
-
-City = Градски
-Civilian = Гражданин
-Melee = Близкобоен
-Ranged = Стрелец
- # Requires translation!
-Scout = 
-Mounted = Ездач
-Armor = Брониран
- # Requires translation!
-Siege = 
-
-WaterCivilian = Граждани във вода
-WaterMelee = Близкобоен във водата
-WaterRanged = Воден стрелец
-WaterSubmarine = Подводница
-WaterAircraftCarrier = Самолетоносач
-
- # Requires translation!
-Fighter = 
- # Requires translation!
-Bomber = 
- # Requires translation!
-AtomicBomber = 
-Missile = Ракетен
-
-
-# Unit filters and other unit related things
-
- # Requires translation!
-Air = 
-air units = въздушни единици
- # Requires translation!
-Barbarian = 
- # Requires translation!
-Barbarians = 
- # Requires translation!
-Embarked = 
-land units = земни единици
-Military = военни
-# Deprecated since 3.15.2, but should still be translated until it is officially removed
- # Requires translation!
-military water = 
-non-air = наземни
- # Requires translation!
-Nuclear Weapon = 
- # Requires translation!
-Submarine = 
- # Requires translation!
-submarine units = 
-Unbuildable = Непостроим
-water units = водни единици
-wounded units = ранени единици
- # Requires translation!
-Wounded = 
-
-# For the "All newly-trained [relevant] units in this city receive the [] promotion" translation. Relevant as in 'units that can receive'
-relevant = свързани
-
-# For "May choose [amount] additional [beliefType] beliefs when [founding/enhancing] a religion"
- # Requires translation!
-founding = 
- # Requires translation!
-enhancing = 
 
 # Promotions
 
@@ -1723,6 +1587,7 @@ Pick promotion = Избери Повишение
  OR  = ИЛИ
 units in open terrain = единици на открит терен
 units in rough terrain = единици на пресечен терен
+wounded units = ранени единици
 Targeting II (air) = Целене II (въздух)
 Targeting III (air) = Целене III (въздух)
 Bonus when performing air sweep [bonusAmount]% = Бонус [bonusAmount]% при извършване на въздушен обзор
@@ -1888,6 +1753,11 @@ Never destroyed when the city is captured =
  # Requires translation!
 Invisible to others = 
 
+# Unused Resources
+
+Bison = Бизон
+Cocoa = Какао
+
 
 # In English we just paste all these conditionals at the end of each unique, but in your language that
 # may not turn into valid sentences. Therefore we have the following two translations to determine
@@ -1917,6 +1787,40 @@ ConditionalsPlacement =
 
 ########################### AUTOMATICALLY GENERATED TRANSLATABLE STRINGS ########################### 
 
+
+######### Map Unit Filters ###########
+
+ # Requires translation!
+Wounded = 
+ # Requires translation!
+Barbarians = 
+ # Requires translation!
+City-State = 
+ # Requires translation!
+Embarked = 
+ # Requires translation!
+Non-City = 
+
+######### Unit Type Filters ###########
+
+Military = военни
+Civilian = Гражданин
+non-air = наземни
+relevant = свързани
+ # Requires translation!
+Nuclear Weapon = 
+City = Градски
+ # Requires translation!
+Air = 
+land units = земни единици
+water units = водни единици
+air units = въздушни единици
+ # Requires translation!
+military units = 
+ # Requires translation!
+submarine units = 
+ # Requires translation!
+Barbarian = 
 
 ######### City filters ###########
 
@@ -1952,6 +1856,84 @@ in holy cities =
 in City-State cities = 
  # Requires translation!
 in cities following this religion = 
+
+######### Population Filters ###########
+
+ # Requires translation!
+Unemployed = 
+ # Requires translation!
+Followers of the Majority Religion = 
+ # Requires translation!
+Followers of this Religion = 
+
+######### Terrain Filters ###########
+
+ # Requires translation!
+All = 
+ # Requires translation!
+Coastal = 
+River = Река
+ # Requires translation!
+Open terrain = 
+ # Requires translation!
+Rough terrain = 
+Water resource = Воден ресурс
+Foreign Land = Вража Територия
+ # Requires translation!
+Foreign = 
+ # Requires translation!
+Friendly Land = 
+ # Requires translation!
+Enemy Land = 
+ # Requires translation!
+Featureless = 
+ # Requires translation!
+Fresh Water = 
+non-fresh water = застояла вода
+ # Requires translation!
+Natural Wonder = 
+Impassable = Непроходим
+Land = Земя
+Water = Вода
+ # Requires translation!
+Luxury resource = 
+ # Requires translation!
+Strategic resource = 
+ # Requires translation!
+Bonus resource = 
+
+######### Tile Filters ###########
+
+ # Requires translation!
+unimproved = 
+ # Requires translation!
+All Road = 
+ # Requires translation!
+Great Improvement = 
+
+######### Region Types ###########
+
+ # Requires translation!
+Hybrid = 
+
+######### Terrain Quality ###########
+
+ # Requires translation!
+Undesirable = 
+ # Requires translation!
+Desirable = 
+
+######### Improvement Filters ###########
+
+ # Requires translation!
+Great = 
+
+######### Prophet Action Filters ###########
+
+ # Requires translation!
+founding = 
+ # Requires translation!
+enhancing = 
 
 ######### Unique Specials ###########
 
@@ -1992,6 +1974,8 @@ Temple of Artemis =
 The Great Lighthouse = 
  # Requires translation!
 'They that go down to the sea in ships, that do business in great waters; these see the works of the Lord, and his wonders in the deep.' - The Bible, Psalms 107:23-24 = 
+ # Requires translation!
+for [mapUnitFilter] units = 
  # Requires translation!
 [amount] Movement = 
  # Requires translation!
@@ -2069,6 +2053,10 @@ Krepost =
 Statue of Zeus = 
  # Requires translation!
 'He spoke, the son of Kronos, and nodded his head with the dark brows, and the immortally anointed hair of the great god swept from his divine head, and all Olympos was shaken' - The Iliad = 
+ # Requires translation!
+vs cities = 
+ # Requires translation!
+when attacking = 
  # Requires translation!
 [amount]% Strength = 
 
@@ -2226,12 +2214,16 @@ Castle =
  # Requires translation!
 Mughal Fort = 
  # Requires translation!
+after discovering [tech] = 
+ # Requires translation!
 [stats] [cityFilter] = 
 
  # Requires translation!
 Himeji Castle = 
  # Requires translation!
 'Bushido is realized in the presence of death. This means choosing death whenever there is a choice between life and death. There is no other reasoning.' - Yamamoto Tsunetomo = 
+ # Requires translation!
+when fighting in [tileFilter] tiles = 
 
  # Requires translation!
 Ironworks = 
@@ -2397,6 +2389,8 @@ Pentagon =
  # Requires translation!
 Solar Plant = 
  # Requires translation!
+in cities without a [buildingFilter] = 
+ # Requires translation!
 Only available = 
 
  # Requires translation!
@@ -2448,6 +2442,8 @@ Era Starting Unit =
 
  # Requires translation!
 Emperor = 
+ # Requires translation!
+Scout = 
 
  # Requires translation!
 Immortal = 
@@ -2490,9 +2486,6 @@ Atomic era =
 Information era = Информационна ера
 
 Future era = Бъдеще
-
-
-#################### Lines from GlobalUniques from Civ V - Vanilla ####################
 
 
 #################### Lines from Nations from Civ V - Vanilla ####################
@@ -3147,6 +3140,8 @@ Bourges =
 Calais = 
  # Requires translation!
 France = 
+ # Requires translation!
+before discovering [tech] = 
 
  # Requires translation!
 Catherine = 
@@ -3253,7 +3248,7 @@ Double quantity of [resource] produced =
  # Requires translation!
 Augustus Caesar = 
  # Requires translation!
-My treasury contains little and my soldiers are getting impatient... ...therefore you must die. = 
+My treasury contains little and my soldiers are getting impatient... (sigh) ...therefore you must die. = 
  # Requires translation!
 So brave, yet so stupid! If only you had a brain similar to your courage. = 
  # Requires translation!
@@ -4297,6 +4292,8 @@ Patigrbana =
 Phrada = 
  # Requires translation!
 Persia = 
+ # Requires translation!
+during a Golden Age = 
 
  # Requires translation!
 Kamehameha I = 
@@ -4399,6 +4396,8 @@ Pileni =
 Nukumanu = 
  # Requires translation!
 Polynesia = 
+ # Requires translation!
+starting from the [era] = 
  # Requires translation!
 Enables embarkation for land units = 
  # Requires translation!
@@ -5301,6 +5300,8 @@ Oligarchy =
  # Requires translation!
 Units in cities cost no Maintenance = 
  # Requires translation!
+with a garrison = 
+ # Requires translation!
 [amount]% Strength for cities = 
  # Requires translation!
 Landed Elite = 
@@ -5339,6 +5340,8 @@ Warrior Code =
  # Requires translation!
 Discipline = 
  # Requires translation!
+when adjacent to a [mapUnitFilter] unit = 
+ # Requires translation!
 Military Tradition = 
  # Requires translation!
 [amount]% XP gained from combat = 
@@ -5350,6 +5353,8 @@ Professional Army =
 Honor Complete = 
  # Requires translation!
 Honor = 
+ # Requires translation!
+vs [mapUnitFilter] units = 
  # Requires translation!
 Notified of new Barbarian encampments = 
 
@@ -5371,6 +5376,8 @@ Free Religion =
 Piety Complete = 
  # Requires translation!
 Piety = 
+ # Requires translation!
+before adopting [policy] = 
 
  # Requires translation!
 Philantropy = 
@@ -5443,12 +5450,16 @@ Rationalism Complete =
  # Requires translation!
 Rationalism = 
  # Requires translation!
+while the empire is happy = 
+ # Requires translation!
 [amount]% [stat] = 
 
  # Requires translation!
 Constitution = 
  # Requires translation!
 Universal Suffrage = 
+ # Requires translation!
+when defending = 
  # Requires translation!
 Civil Society = 
  # Requires translation!
@@ -5482,6 +5493,8 @@ Police State =
 Total War = 
  # Requires translation!
 Autocracy Complete = 
+ # Requires translation!
+for [amount] turns = 
  # Requires translation!
 Autocracy = 
  # Requires translation!
@@ -5522,42 +5535,42 @@ We feel threatened by a Barbarian Camp near our city. Please take care of it. =
  # Requires translation!
 Connect Resource = 
  # Requires translation!
-In order to make our civilizations stronger, connect [param] to your trade network. = 
+In order to make our civilizations stronger, connect [tileResource] to your trade network. = 
 
  # Requires translation!
 Construct Wonder = 
  # Requires translation!
-We recommend you to start building [param] to show the whole world your civilization strength. = 
+We recommend you to start building [wonder] to show the whole world your civilization strength. = 
 
  # Requires translation!
 Acquire Great Person = 
  # Requires translation!
-Great People can change the course of a Civilization! You will be rewarded for acquiring a new [param]. = 
+Great People can change the course of a Civilization! You will be rewarded for acquiring a new [greatPerson]. = 
 
  # Requires translation!
 Conquer City State = 
  # Requires translation!
-It's time to erase the City-State of [param] from the map. You will be greatly rewarded for conquering them! = 
+It's time to erase the City-State of [cityState] from the map. You will be greatly rewarded for conquering them! = 
 
  # Requires translation!
 Find Player = 
  # Requires translation!
-You have yet to discover where [param] set up their cities. You will be rewarded for finding their territories. = 
+You have yet to discover where [civName] set up their cities. You will be rewarded for finding their territories. = 
 
  # Requires translation!
 Find Natural Wonder = 
  # Requires translation!
-Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [param] yet. = 
+Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [naturalWonder] yet. = 
 
  # Requires translation!
 Give Gold = 
  # Requires translation!
-We are suffering great poverty after being robbed by [param], and unless we receive a sum of Gold, it's only a matter of time before we collapse. = 
+We are suffering great poverty after being robbed by [civName], and unless we receive a sum of Gold, it's only a matter of time before we collapse. = 
 
  # Requires translation!
 Pledge to Protect = 
  # Requires translation!
-We need your protection to stop the aggressions of [param]. By signing a Pledge of Protection, you'll confirm the bond that ties us. = 
+We need your protection to stop the aggressions of [civName]. By signing a Pledge of Protection, you'll confirm the bond that ties us. = 
 
  # Requires translation!
 Contest Culture = 
@@ -5577,20 +5590,20 @@ The civilization with the largest number of new Technologies researched will gai
  # Requires translation!
 Invest = 
  # Requires translation!
-Our people are rejoicing thanks to a tourism boom. For a certain amount of time, any Gold donation will yield [amount]% extra Influence. = 
+Our people are rejoicing thanks to a tourism boom. For a certain amount of time, any Gold donation will yield [50]% extra Influence. = 
 
  # Requires translation!
 Bully City State = 
  # Requires translation!
-We are tired of the pretensions of [param]. If someone were to put them in their place by Demanding Tribute from them, they would be rewarded. = 
+We are tired of the pretensions of [cityState]. If someone were to put them in their place by Demanding Tribute from them, they would be rewarded. = 
 
  # Requires translation!
 Denounce Civilization = 
  # Requires translation!
-We have been forced to pay tribute to [param]! We need you to tell the world of their ill deeds. = 
+We have been forced to pay tribute to [civName]! We need you to tell the world of their ill deeds. = 
 
  # Requires translation!
-We have heard the tenets of [param] and are most curious. Will you send missionaries to teach us about your religion? = 
+We have heard the tenets of [religionName] and are most curious. Will you send missionaries to teach us about your religion? = 
 
 
 #################### Lines from Ruins from Civ V - Vanilla ####################
@@ -5612,12 +5625,12 @@ An ancient tribe trained us in their ways of combat! =
 your exploring unit receives training = 
 
  # Requires translation!
-We have found survivors in the ruins! Population added to [param]. = 
+We have found survivors in the ruins! Population added to [cityName]. = 
  # Requires translation!
 survivors (adds population to a city) = 
 
  # Requires translation!
-We have found a stash of [param] Gold in the ruins! = 
+We have found a stash of [goldAmount] Gold in the ruins! = 
  # Requires translation!
 a stash of gold = 
 
@@ -6012,6 +6025,7 @@ Desert =
 
  # Requires translation!
 Lakes = 
+Fresh water = Прясна вода
 
  # Requires translation!
 Mountain = 
@@ -6044,6 +6058,8 @@ Jungle =
 
  # Requires translation!
 Marsh = 
+ # Requires translation!
+Rare feature = 
  # Requires translation!
 Only Polders can be built here = 
 
@@ -6346,6 +6362,9 @@ Porcelain =
 
  # Requires translation!
 Sword = 
+Mounted = Ездач
+ # Requires translation!
+Siege = 
  # Requires translation!
 Ranged Gunpowder = 
  # Requires translation!
@@ -6354,6 +6373,8 @@ Armored =
 Melee Water = 
  # Requires translation!
 Ranged Water = 
+ # Requires translation!
+Submarine = 
  # Requires translation!
 Heal Instantly = 
  # Requires translation!
@@ -6446,6 +6467,8 @@ All adjacent units heal [amount] HP when healing =
 
  # Requires translation!
 Medic II = 
+ # Requires translation!
+in [tileFilter] tiles = 
  # Requires translation!
 [amount] HP when healing = 
 
@@ -6540,6 +6563,8 @@ Supply =
 May heal outside of friendly territory = 
 
  # Requires translation!
+Bomber = 
+ # Requires translation!
 Siege I = 
 
  # Requires translation!
@@ -6553,6 +6578,8 @@ Evasion =
  # Requires translation!
 Damage taken from interception reduced by [amount]% = 
 
+ # Requires translation!
+Fighter = 
  # Requires translation!
 Interception I = 
  # Requires translation!
@@ -6697,6 +6724,7 @@ Can see over obstacles =
  # Requires translation!
 Atomic Bomber = 
 
+Missile = Ракетен
  # Requires translation!
 Self-destructs when attacking = 
  # Requires translation!
@@ -6704,6 +6732,25 @@ Cannot be intercepted =
 
  # Requires translation!
 Can pass through impassable tiles = 
+
+Melee = Близкобоен
+
+Ranged = Стрелец
+
+Armor = Брониран
+
+WaterCivilian = Граждани във вода
+
+WaterMelee = Близкобоен във водата
+
+WaterRanged = Воден стрелец
+
+WaterSubmarine = Подводница
+
+WaterAircraftCarrier = Самолетоносач
+
+ # Requires translation!
+AtomicBomber = 
 
 
 #################### Lines from Units from Civ V - Vanilla ####################
@@ -6822,6 +6869,8 @@ Camel Archer =
 
  # Requires translation!
 Conquistador = 
+ # Requires translation!
+on foreign continents = 
 
  # Requires translation!
 Naresuan's Elephant = 
@@ -6956,6 +7005,8 @@ Atomic Bomb = Атомна Бомба
  # Requires translation!
 Nuclear weapon of Strength [amount] = 
  # Requires translation!
+if [buildingName] is constructed = 
+ # Requires translation!
 Blast radius [amount] = 
 
  # Requires translation!
@@ -7008,6 +7059,7 @@ Can start an [amount]-turn golden age =
 Can construct [improvementName] = 
  # Requires translation!
 Great Person - [stat] = 
+Unbuildable = Непостроим
 
  # Requires translation!
 Great Scientist = 
@@ -7103,6 +7155,8 @@ Fertility Rites =
 
  # Requires translation!
 God of Craftsman = 
+ # Requires translation!
+in cities with at least [amount] [populationFilter] = 
 
  # Requires translation!
 God of the Open Sky = 
@@ -7183,6 +7237,8 @@ Guruship =
  # Requires translation!
 Holy Warriors = 
  # Requires translation!
+before the [era] = 
+ # Requires translation!
 May buy [baseUnitFilter] units with [stat] for [amount] times their normal Production cost = 
 
  # Requires translation!
@@ -7213,6 +7269,8 @@ Religious Community =
 
  # Requires translation!
 Swords into Ploughshares = 
+ # Requires translation!
+when not at war = 
 
  # Requires translation!
 Founder = 
@@ -7410,9 +7468,6 @@ Starting in this era disables religion =
 
 
 Marine = Морска Пехота
-
-
-#################### Lines from GlobalUniques from Civ V - Gods & Kings ####################
 
 
 #################### Lines from Nations from Civ V - Gods & Kings ####################
@@ -8036,6 +8091,8 @@ Falmouth =
 Lorient = 
  # Requires translation!
 Celts = 
+ # Requires translation!
+with [amount] to [amount2] neighboring [tileFilter] [tileFilter2] tiles = 
 
  # Requires translation!
 Haile Selassie = 
@@ -8123,6 +8180,8 @@ Ziway =
 Weldiya = 
  # Requires translation!
 Ethiopia = 
+ # Requires translation!
+when fighting units from a Civilization with more Cities than you = 
 
  # Requires translation!
 Pacal = 
@@ -8270,12 +8329,12 @@ Taoism =
 
 
  # Requires translation!
-We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[param] Faith) = 
+We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[faithAmount] Faith) = 
  # Requires translation!
 discover holy symbols = 
 
  # Requires translation!
-We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[param] Faith) = 
+We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[faithAmount] Faith) = 
  # Requires translation!
 an ancient prophecy = 
 
@@ -8355,8 +8414,16 @@ Polder =
 #################### Lines from TileResources from Civ V - Gods & Kings ####################
 
 
+Citrus = Цитрус
+
+Copper = Мед
+
+Crab = Рак
+
  # Requires translation!
 Salt = 
+
+Truffles = Трюфели
 
 
 #################### Lines from UnitPromotions from Civ V - Gods & Kings ####################
@@ -8901,13 +8968,7 @@ Irremovable =
  # Requires translation!
 when at war = 
  # Requires translation!
-when not at war = 
- # Requires translation!
-during a Golden Age = 
- # Requires translation!
 with [resource] = 
- # Requires translation!
-while the empire is happy = 
  # Requires translation!
 when between [amount] and [amount2] Happiness = 
  # Requires translation!
@@ -8915,67 +8976,25 @@ when below [amount] Happiness =
  # Requires translation!
 during the [era] = 
  # Requires translation!
-before the [era] = 
- # Requires translation!
-starting from the [era] = 
- # Requires translation!
 if no other Civilization has researched this = 
- # Requires translation!
-after discovering [tech] = 
- # Requires translation!
-before discovering [tech] = 
  # Requires translation!
 upon discovering [tech] = 
  # Requires translation!
 after adopting [policy] = 
  # Requires translation!
-before adopting [policy] = 
- # Requires translation!
-if [buildingName] is constructed = 
- # Requires translation!
-for [amount] turns = 
- # Requires translation!
 by consuming this unit = 
  # Requires translation!
 in cities with a [buildingFilter] = 
  # Requires translation!
-in cities without a [buildingFilter] = 
- # Requires translation!
-in cities with at least [amount] [populationFilter] = 
- # Requires translation!
-with a garrison = 
- # Requires translation!
-for [mapUnitFilter] units = 
- # Requires translation!
 for units with [promotion] = 
  # Requires translation!
 for units without [promotion] = 
- # Requires translation!
-vs cities = 
- # Requires translation!
-vs [mapUnitFilter] units = 
- # Requires translation!
-when fighting units from a Civilization with more Cities than you = 
- # Requires translation!
-when attacking = 
- # Requires translation!
-when defending = 
- # Requires translation!
-when fighting in [tileFilter] tiles = 
- # Requires translation!
-on foreign continents = 
- # Requires translation!
-when adjacent to a [mapUnitFilter] unit = 
  # Requires translation!
 when above [amount] HP = 
  # Requires translation!
 when below [amount] HP = 
  # Requires translation!
 with [amount] to [amount2] neighboring [tileFilter] tiles = 
- # Requires translation!
-with [amount] to [amount2] neighboring [tileFilter] [tileFilter2] tiles = 
- # Requires translation!
-in [tileFilter] tiles = 
  # Requires translation!
 in [tileFilter] [tileFilter2] tiles = 
  # Requires translation!
@@ -9054,3 +9073,7 @@ CityState =
 ModOptions = 
  # Requires translation!
 Conditional = 
+
+#################### Removed Lines ####################
+
+#~~Rough Terrain = Пресечен терен

--- a/android/assets/jsons/translations/Czech.properties
+++ b/android/assets/jsons/translations/Czech.properties
@@ -1085,8 +1085,6 @@ or [terrainType] = nebo [terrainType]
 Can be constructed by = Může být postaven jednotkou
 Defence bonus = Obranný bonus
 Movement cost = Náročnost pohybu
-Open terrain = Otevřený terén
-Rough Terrain = Obtížný terén
 for = za
 Missing translations: = Chybějící překlady:
 Resolution = Rozlišení
@@ -1217,102 +1215,6 @@ Religion = Náboženství
 Enhancing religion = Vylepšuje náboženství
 Enhanced religion = Vylepšené náboženství
 
-# Terrains
-
-Impassable = Nepřístupné
-Rare feature = Vzácný prvek
-
-# terrainFilters (so for uniques like: "[stats] from [terrainFilter] tiles")
-
-All = Všechna
-Water = Vodní
-Land = Pozemní
-Coastal = Pobřežní
-River = Řeka
-Rough terrain = Obtížný terén
-Foreign Land = Cizí území
-Foreign = Cizí 
-Friendly Land = Přátelské území
-Water resource = Voda se surovinami
-Bonus resource = Bonusová surovina
-Luxury resource = Luxusní surovina
-Strategic resource = Strategická surovina
-Fresh water = Sladká voda
-non-fresh water = bez sladké vody
-Natural Wonder = Přírodní Div
-Hybrid = Hybridní
-Undesirable = Nežádoucí
-Desirable = Žádoucí
-Featureless = Bez prvků
-Fresh Water = Sladká voda
-
-# improvementFilters
-
-All Road = Všechy cesty
-Great Improvement = Velké vylepšení
-Great = Velké 
-
-# Resources
-
-Bison = Bizoni
-Copper = Měď
-Cocoa = Kakao
-Crab = Krabi
-Citrus = Citrusy
-Truffles = Lanýže
-Strategic = Strategický
-Bonus = Bonus
-Luxury = Luxusní
-
-# Unit types
-
-City = Město
-Civilian = Civilista
-Melee = Boj zblízka
-Ranged = Boj na dálku
-Scout = Zvěd
-Mounted = Jízdní
-Armor = Obrněná vozidla
-Siege = Obléhací
-
-WaterCivilian = Námořní civilista
-WaterMelee = Námořní boj zblízka
-WaterRanged = Námořní boj na dálku
-WaterSubmarine = Námořní ponorka
-WaterAircraftCarrier = Letadlová loď
-
-Fighter = Stíhač
-Bomber = Bombardér
-AtomicBomber = Jaderný Bombardér
-Missile = Střela
-
-
-# Unit filters and other unit related things
-
-Air = Vzdušné
-air units = vzdušné jednotky
-Barbarian = Barbar
-Barbarians = Barbaři
-Embarked = Naloděné
-land units = pozemní jednotky
-Military = Vojenské
-# Deprecated since 3.15.2, but should still be translated until it is officially removed
-military water = vojenské námořní
-non-air = nelétací
-Nuclear Weapon = Jaderná zbraň
-Submarine = Ponorka
-submarine units = ponorky
-Unbuildable = Nelze vybudovat
-water units = námořní jednotky
-wounded units = zraněné jednotky
-Wounded = Zraněné
-
-# For the "All newly-trained [relevant] units in this city receive the [] promotion" translation. Relevant as in 'units that can receive'
-relevant = relevantní
-
-# For "May choose [amount] additional [beliefType] beliefs when [founding/enhancing] a religion"
-founding = zakladání
-enhancing = vylepšování
 
 # Promotions
 
@@ -1320,6 +1222,7 @@ Pick promotion = Vybrat povýšení
  OR  =  NEBO 
 units in open terrain = jednotky v otevřeném terénu
 units in rough terrain = jednotky v obtížném terénu
+wounded units = zraněné jednotky
 Targeting II (air) = Míření II (vzduch)
 Targeting III (air) = Míření III (vzduch)
 Bonus when performing air sweep [bonusAmount]% = Bonus při provádění leteckého čištění [bonusAmount]%
@@ -1423,6 +1326,11 @@ This Unit upgrades for free = Jednotka se vylepšuje zdarma
 Never destroyed when the city is captured = Nikdy se nezničí při obsazení města
 Invisible to others = Neviditelná pro ostatní
 
+# Unused Resources
+
+Bison = Bizoni
+Cocoa = Kakao
+
 
 # In English we just paste all these conditionals at the end of each unique, but in your language that
 # may not turn into valid sentences. Therefore we have the following two translations to determine
@@ -1452,6 +1360,33 @@ ConditionalsPlacement = after
 ########################### AUTOMATICALLY GENERATED TRANSLATABLE STRINGS ########################### 
 
 
+######### Map Unit Filters ###########
+
+Wounded = Zraněné
+Barbarians = Barbaři
+ # Requires translation!
+City-State = 
+Embarked = Naloděné
+ # Requires translation!
+Non-City = 
+
+######### Unit Type Filters ###########
+
+Military = Vojenské
+Civilian = Civilista
+non-air = nelétací
+relevant = relevantní
+Nuclear Weapon = Jaderná zbraň
+City = Město
+Air = Vzdušné
+land units = pozemní jednotky
+water units = námořní jednotky
+air units = vzdušné jednotky
+ # Requires translation!
+military units = 
+submarine units = ponorky
+Barbarian = Barbar
+
 ######### City filters ###########
 
 in this city = v tomto městě
@@ -1470,6 +1405,64 @@ in annexed cities = v anektovaných městech
 in holy cities = ve svatých městech
 in City-State cities = v městských státech
 in cities following this religion = ve městech následujícíh toto náboženství
+
+######### Population Filters ###########
+
+ # Requires translation!
+Unemployed = 
+ # Requires translation!
+Followers of the Majority Religion = 
+ # Requires translation!
+Followers of this Religion = 
+
+######### Terrain Filters ###########
+
+All = Všechna
+Coastal = Pobřežní
+River = Řeka
+Open terrain = Otevřený terén
+Rough terrain = Obtížný terén
+Water resource = Voda se surovinami
+Foreign Land = Cizí území
+Foreign = Cizí 
+Friendly Land = Přátelské území
+ # Requires translation!
+Enemy Land = 
+Featureless = Bez prvků
+Fresh Water = Sladká voda
+non-fresh water = bez sladké vody
+Natural Wonder = Přírodní Div
+Impassable = Nepřístupné
+Land = Pozemní
+Water = Vodní
+Luxury resource = Luxusní surovina
+Strategic resource = Strategická surovina
+Bonus resource = Bonusová surovina
+
+######### Tile Filters ###########
+
+ # Requires translation!
+unimproved = 
+All Road = Všechy cesty
+Great Improvement = Velké vylepšení
+
+######### Region Types ###########
+
+Hybrid = Hybridní
+
+######### Terrain Quality ###########
+
+Undesirable = Nežádoucí
+Desirable = Žádoucí
+
+######### Improvement Filters ###########
+
+Great = Velké 
+
+######### Prophet Action Filters ###########
+
+founding = zakladání
+enhancing = vylepšování
 
 ######### Unique Specials ###########
 
@@ -1497,6 +1490,7 @@ Temple of Artemis = Artemidin chrám
 
 The Great Lighthouse = Maják na ostrově Faru
 'They that go down to the sea in ships, that do business in great waters; these see the works of the Lord, and his wonders in the deep.' - The Bible, Psalms 107:23-24 = 'Ti, kteří se vydávají na lodích na moře, kdo konají dílo na nesmírných vodách, spatřili Hospodinovy skutky, jeho divy na hlubině.' - Bible, Žalm 107: 23-24
+for [mapUnitFilter] units = pro [mapUnitFilter] jednotky
 [amount] Movement = [amount] pohyb
 [amount] Sight = [amount] dohled
 
@@ -1543,6 +1537,8 @@ Krepost = Krepost
 
 Statue of Zeus = Socha Dia
 'He spoke, the son of Kronos, and nodded his head with the dark brows, and the immortally anointed hair of the great god swept from his divine head, and all Olympos was shaken' - The Iliad = 'Domluviv Kronův syn, svým tmavým obočím kývl. Ihned kadeře božské se hrnuly do čela vládci z božské nesmrtelné hlavy - a velký Olymp se zachvěl.' - Ilias
+vs cities = proti městům
+when attacking = při útoku
 [amount]% Strength = [amount]% síly
 
 Lighthouse = Maják
@@ -1641,10 +1637,12 @@ Notre Dame = Katedrála Notre-Dame
 Castle = Hrad
 
 Mughal Fort = Mughalská pevnost
+after discovering [tech] = po objevu technologie [tech]
 [stats] [cityFilter] = [stats] [cityFilter]
 
 Himeji Castle = Hrad Himedži
 'Bushido is realized in the presence of death. This means choosing death whenever there is a choice between life and death. There is no other reasoning.' - Yamamoto Tsunetomo = 'Bušidó se děje v přítomnosti smrti. To znamená vybrat si smrt, kdykoli je na výběr mezi životem a smrtí. Neexistuje žádné jiné zdůvodnění.' - Jamamoto Cunetomo
+when fighting in [tileFilter] tiles = při boji na políčku [tileFilter]
 
 Ironworks = Železárny
 
@@ -1747,6 +1745,8 @@ Pentagon = Pentagon
 [amount]% Gold cost of upgrading = [amount]% zlata za vylepšení
 
 Solar Plant = Solární elektrárna
+ # Requires translation!
+in cities without a [buildingFilter] = 
 Only available = Dostupné pouze
 
 Nuclear Plant = Jaderná elektrárna
@@ -1780,6 +1780,7 @@ King = Král
 Era Starting Unit = Startovní jednotka éry
 
 Emperor = Císař
+Scout = Zvěd
 
 Immortal = Polobůh
 Worker = Dělník
@@ -1812,9 +1813,6 @@ Atomic era = Atomová éra
 Information era = Informační éra
 
 Future era = Budoucí éra
-
-
-#################### Lines from GlobalUniques from Civ V - Vanilla ####################
 
 
 #################### Lines from Nations from Civ V - Vanilla ####################
@@ -2150,6 +2148,7 @@ La Rochelle = La Rochelle
 Bourges = Bourges
 Calais = Calais
 France = Francie
+before discovering [tech] = před objevem technologie [tech]
 
 Catherine = Kateřina II. Veliká
 You've behaved yourself very badly, you know it. Now it's payback time. = Choval jste se velmi zle, však víte. Teď je čas za to zaplatit.
@@ -2204,7 +2203,8 @@ Russia = Rusko
 Double quantity of [resource] produced = Dvojnásobné množství suroviny [resource]
 
 Augustus Caesar = Augustus Caesar
-My treasury contains little and my soldiers are getting impatient... ...therefore you must die. = Má pokladna je již téměř prázdná a vojáci začínají být netrpěliví... ...takže musíte zemřít.
+ # Requires translation!
+My treasury contains little and my soldiers are getting impatient... (sigh) ...therefore you must die. = 
 So brave, yet so stupid! If only you had a brain similar to your courage. = Tak odvážné a přitom tak hloupé! Kdybyste tak měl mozek odpovídající Vaší odvaze.
 The gods have deprived Rome of their favour. We have been defeated. = Bohové odepřeli Římu svou přízeň. Byli jsme poraženi.
 I greet you. I am Augustus, Imperator and Pontifex Maximus of Rome. If you are a friend of Rome, you are welcome. = Zdravím vás. Jsem Augustus, císař a nejvyšší kněz Říma. Jste-li přáteli Říma, jste vítáni.
@@ -2737,6 +2737,7 @@ Paishiyauvada = Paishiyauvada
 Patigrbana = Patigrbana
 Phrada = Phrada
 Persia = Persie
+during a Golden Age = během Zlatého věku
 
 Kamehameha I = Kamehameha I.
 The ancient fire flashing across the sky is what proclaimed that this day would come, though I had foolishly hoped for a different outcome. = Starověký oheň blikající po obloze je to, co hlásalo, že tento den přijde, i když jsem pošetile doufal v jiný výsledek.
@@ -2789,6 +2790,7 @@ Nuguria = Nuguria
 Pileni = Pileni
 Nukumanu = Nukumanu
 Polynesia = Polynésie
+starting from the [era] = počínaje érou [era]
 Enables embarkation for land units = Zpřístupní možnost nalodění se pozemním jednotkám
 Enables [mapUnitFilter] units to enter ocean tiles = Umožňuje jednotkám typu [mapUnitFilter] vstoupit na pole oceán
 Normal vision when embarked = Normální dohled při nalodění
@@ -3263,6 +3265,7 @@ Legalism = Legalismus
 Provides the cheapest [stat] building in your first [amount] cities for free = Zdarma poskytne nejlevnější [stat] budovu v našich prvních [amount] městech
 Oligarchy = Oligarchie
 Units in cities cost no Maintenance = Jednotky ve městech nestojí žádný udržovací poplatek
+with a garrison = s posádkou
 [amount]% Strength for cities = [amount]% síly pro města
 Landed Elite = Pozemkové vlastnictví
 [amount]% growth [cityFilter] = [amount]% růst [cityFilter]
@@ -3285,6 +3288,7 @@ Liberty =
 
 Warrior Code = Kodex válečníka
 Discipline = Disciplína
+when adjacent to a [mapUnitFilter] unit = sousedící s [mapUnitFilter] jednotkou
 Military Tradition = Vojenská tradice
 [amount]% XP gained from combat = [amount]% zkušeností z boje
 Military Caste = Vojenská třída
@@ -3292,6 +3296,7 @@ Professional Army = Profesionální armáda
 Honor Complete = Kompletní Čest
  # Requires translation!
 Honor = 
+vs [mapUnitFilter] units = proti [mapUnitFilter] jednotky
  # Requires translation!
 Notified of new Barbarian encampments = 
 
@@ -3305,6 +3310,7 @@ Free Religion = Svoboda vyznání
 Piety Complete = Kompletní Zbožnost
  # Requires translation!
 Piety = 
+before adopting [policy] = před přijetím politiky [policy]
 
 Philantropy = Dobročinnost
 Gifts of Gold to City-States generate [amount]% more Influence = Dary zlata městským státům vytváří [amount]% více vlivu
@@ -3345,10 +3351,12 @@ Rationalism Complete = Kompletní Racionalismus
 [amount] Free Technologies = [amount] technologie zdarma
  # Requires translation!
 Rationalism = 
+while the empire is happy = je-li říše spokojená
 [amount]% [stat] = [amount]% [stat]
 
 Constitution = Ústavní systém
 Universal Suffrage = Všeobecné volební právo
+when defending = při obraně
 Civil Society = Občanská společnost
 [amount]% Food consumption by specialists [cityFilter] = [amount]% spotřeby jídla specialisty [cityFilter]
 Free Speech = Svoboda projevu
@@ -3367,6 +3375,8 @@ Quantity of strategic resources produced by the empire +[amount]% = +[amount]% s
 Police State = Policejní stát
 Total War = Totální válka
 Autocracy Complete = Kompletní Autokracie
+ # Requires translation!
+for [amount] turns = 
  # Requires translation!
 Autocracy = 
 Upon capturing a city, receive [amount] times its [stat] production as [plunderableStat] immediately = Ihned po obsazení města získá [amount] krát jeho [stat] produkci jako [plunderableStat]
@@ -3392,28 +3402,28 @@ Clear Barbarian Camp = Vyčistit tábor Barbarů
 We feel threatened by a Barbarian Camp near our city. Please take care of it. = Cítíme se ohroženi táborem Barbarů poblíž města.
 
 Connect Resource = Zajištění suroviny
-In order to make our civilizations stronger, connect [param] to your trade network. = Abyste učinili nasi civilizaci silnější, připojte do své obchodní sítě surovinu [param].
+In order to make our civilizations stronger, connect [tileResource] to your trade network. = Abyste učinili nasi civilizaci silnější, připojte do své obchodní sítě surovinu [tileResource].
 
 Construct Wonder = Stavba divu
-We recommend you to start building [param] to show the whole world your civilization strength. = Doporučujeme vám postavit div [param], abyste ukázali svou sílu světu.
+We recommend you to start building [wonder] to show the whole world your civilization strength. = Doporučujeme vám postavit div [wonder], abyste ukázali svou sílu světu.
 
 Acquire Great Person = Zisk velké osobnosti
-Great People can change the course of a Civilization! You will be rewarded for acquiring a new [param]. = Velké osobnosti mohou změnit vývoj civilizace! Odměnu získáte až budete mít novou velkou osobnost [param].
+Great People can change the course of a Civilization! You will be rewarded for acquiring a new [greatPerson]. = Velké osobnosti mohou změnit vývoj civilizace! Odměnu získáte až budete mít novou velkou osobnost [greatPerson].
 
 Conquer City State = Dobýt městský stát
-It's time to erase the City-State of [param] from the map. You will be greatly rewarded for conquering them! = Je na čase vymazat městský stát [param] z mapy. Za jejich dobytí budete dobře odměněni!
+It's time to erase the City-State of [cityState] from the map. You will be greatly rewarded for conquering them! = Je na čase vymazat městský stát [cityState] z mapy. Za jejich dobytí budete dobře odměněni!
 
 Find Player = Nalezení civilizace
-You have yet to discover where [param] set up their cities. You will be rewarded for finding their territories. = Stále jestě musíte objevit, kde si civilizace [param] postavila města. Odměna bude za objevení jejich území.
+You have yet to discover where [civName] set up their cities. You will be rewarded for finding their territories. = Stále jestě musíte objevit, kde si civilizace [civName] postavila města. Odměna bude za objevení jejich území.
 
 Find Natural Wonder = Nalezeni divu přírody
-Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [param] yet. = Vyšlete nejlepší zvědy na objevem přírodního divu. Nikdo zatím nevi, kde je [param].
+Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [naturalWonder] yet. = Vyšlete nejlepší zvědy na objevem přírodního divu. Nikdo zatím nevi, kde je [naturalWonder].
 
 Give Gold = Věnovat zlato
-We are suffering great poverty after being robbed by [param], and unless we receive a sum of Gold, it's only a matter of time before we collapse. = Po okradení civilizací [param] trpíme velkou chudobou, a pokud nezískáme dost zlata, je jen otázkou času, kdy se zhroutíme.
+We are suffering great poverty after being robbed by [civName], and unless we receive a sum of Gold, it's only a matter of time before we collapse. = Po okradení civilizací [civName] trpíme velkou chudobou, a pokud nezískáme dost zlata, je jen otázkou času, kdy se zhroutíme.
 
 Pledge to Protect = Slib chránit
-We need your protection to stop the aggressions of [param]. By signing a Pledge of Protection, you'll confirm the bond that ties us. = Potřebujeme vaši ochranu, abychom zastavili agresi civilizace [param]. Podpisem slibu ochrany potvrdíte pouto, které nás spojuje.
+We need your protection to stop the aggressions of [civName]. By signing a Pledge of Protection, you'll confirm the bond that ties us. = Potřebujeme vaši ochranu, abychom zastavili agresi civilizace [civName]. Podpisem slibu ochrany potvrdíte pouto, které nás spojuje.
 
 Contest Culture = Soutěž kultury
 The civilization with the largest Culture growth will gain a reward. = Civilizace s největším růstem kultury získá odměnu.
@@ -3425,15 +3435,15 @@ Contest Technologies = Soutěž technologie
 The civilization with the largest number of new Technologies researched will gain a reward. = Civilizace s největším počtem nových vyzkoumaných technologií získá odměnu.
 
 Invest = Investice
-Our people are rejoicing thanks to a tourism boom. For a certain amount of time, any Gold donation will yield [amount]% extra Influence. = Naši lidé se z rozmachu cestovního ruchu radují. Po určitou dobu jakýkoli dar zlata přinese [amount]% dalšího vlivu.
+Our people are rejoicing thanks to a tourism boom. For a certain amount of time, any Gold donation will yield [50]% extra Influence. = Naši lidé se z rozmachu cestovního ruchu radují. Po určitou dobu jakýkoli dar zlata přinese [50]% dalšího vlivu.
 
 Bully City State = Šikanující městský stát
-We are tired of the pretensions of [param]. If someone were to put them in their place by Demanding Tribute from them, they would be rewarded. = Jsme unaveni útoky státu [param]. Pokud by je někdo postavil na jejich místo (požadavkem), byl by odměněn.
+We are tired of the pretensions of [cityState]. If someone were to put them in their place by Demanding Tribute from them, they would be rewarded. = Jsme unaveni útoky státu [cityState]. Pokud by je někdo postavil na jejich místo (požadavkem), byl by odměněn.
 
 Denounce Civilization = Odsouzení civilizace
-We have been forced to pay tribute to [param]! We need you to tell the world of their ill deeds. = Byli jsme donuceni zaplatit poplatky civilizaci [param]! Potřebujeme, abyste světu ukázali jejich zlé skutky.
+We have been forced to pay tribute to [civName]! We need you to tell the world of their ill deeds. = Byli jsme donuceni zaplatit poplatky civilizaci [civName]! Potřebujeme, abyste světu ukázali jejich zlé skutky.
 
-We have heard the tenets of [param] and are most curious. Will you send missionaries to teach us about your religion? = Slyšeli jsme zásady náboženství [param] a jsme velmi zvědaví. Pošlete nám misionáře, aby nás poučili o vašem náboženství?
+We have heard the tenets of [religionName] and are most curious. Will you send missionaries to teach us about your religion? = Slyšeli jsme zásady náboženství [religionName] a jsme velmi zvědaví. Pošlete nám misionáře, aby nás poučili o vašem náboženství?
 
 
 #################### Lines from Ruins from Civ V - Vanilla ####################
@@ -3448,10 +3458,10 @@ squatters wishing to settle under your rule = squateři, kteří se chtějí usa
 An ancient tribe trained us in their ways of combat! = Starověký kmen nás vycvičil ve způsobech boje!
 your exploring unit receives training = průzkumník byl vytrénován
 
-We have found survivors in the ruins! Population added to [param]. = Našli jsme v ruinách přeživší! Populace přidána do [param].
+We have found survivors in the ruins! Population added to [cityName]. = Našli jsme v ruinách přeživší! Populace přidána do [cityName].
 survivors (adds population to a city) = přeživší (zvýší populaci města)
 
-We have found a stash of [param] Gold in the ruins! = V ruinách jsme našli skrýš [param] zlata!
+We have found a stash of [goldAmount] Gold in the ruins! = V ruinách jsme našli skrýš [goldAmount] zlata!
 a stash of gold = truhla zlata
 
 discover a lost technology = objev ztracené technologie
@@ -3670,6 +3680,7 @@ Tundra = Tundra
 Desert = Poušť
 
 Lakes = Jezera
+Fresh water = Sladká voda
 
 Mountain = Hory
 Has an elevation of [amount] for visibility calculations = Má výšku [amount] pro výpočty viditelnosti
@@ -3690,6 +3701,7 @@ A Camp can be built here without cutting it down = Tábor zde může být postav
 Jungle = Džungle
 
 Marsh = Bažina
+Rare feature = Vzácný prvek
 Only Polders can be built here = Zde může být postaven pouze Polder
 
 Fallout = Atomový spad
@@ -3885,10 +3897,13 @@ Porcelain = Porcelán
 #################### Lines from UnitPromotions from Civ V - Vanilla ####################
 
 Sword = Meče
+Mounted = Jízdní
+Siege = Obléhací
 Ranged Gunpowder = Střelné Střelecké
 Armored = Obrněné
 Melee Water = Námořní Bojové
 Ranged Water = Námořní Střelecké
+Submarine = Ponorka
 Heal Instantly = Okamžité léčení
 Heal this unit by [amount] HP = Vyléčí tuto jednotku o [amount] zdraví
 Doing so will consume this opportunity to choose a Promotion = Přijde tím ale o možnost povýšení
@@ -3947,6 +3962,7 @@ Medic = Zdravotník I
 All adjacent units heal [amount] HP when healing = Všechny sousední jednotky vyléčí [amount] zdraví při léčení
 
 Medic II = Zdravotník II
+in [tileFilter] tiles = na políčkách [tileFilter]
 [amount] HP when healing = [amount] zdraví při léčení
 
 Scouting I = Průzkum I
@@ -4007,6 +4023,7 @@ Flight Deck III = Letová paluba III
 Supply = Zásobování
 May heal outside of friendly territory = Může se léčit mimo přátelské území.
 
+Bomber = Bombardér
 Siege I = Nálet I
 
 Siege II = Nálet II
@@ -4016,6 +4033,7 @@ Siege III = Nálet III
 Evasion = Únik
 Damage taken from interception reduced by [amount]% = Škody způsobené stíháním nižší o [amount]%
 
+Fighter = Stíhač
 Interception I = Stíhání I
 [amount]% Damage when intercepting = [amount]% poškození při stíhání
 
@@ -4113,10 +4131,29 @@ Can see over obstacles =
 
 Atomic Bomber = Jaderný bombardér
 
+Missile = Střela
 Self-destructs when attacking = Zničí sebe sama při útoku
 Cannot be intercepted = Nelze stíhat
 
 Can pass through impassable tiles = Může přes neprůchozí políčka
+
+Melee = Boj zblízka
+
+Ranged = Boj na dálku
+
+Armor = Obrněná vozidla
+
+WaterCivilian = Námořní civilista
+
+WaterMelee = Námořní boj zblízka
+
+WaterRanged = Námořní boj na dálku
+
+WaterSubmarine = Námořní ponorka
+
+WaterAircraftCarrier = Letadlová loď
+
+AtomicBomber = Jaderný Bombardér
 
 
 #################### Lines from Units from Civ V - Vanilla ####################
@@ -4194,6 +4231,7 @@ Knight = Rytíř
 Camel Archer = Lučištník na velbloudu
 
 Conquistador = Konkistador
+on foreign continents = na cizím kontinentu
 
 Naresuan's Elephant = Naresuanův slon
 
@@ -4284,6 +4322,8 @@ Anti-Tank Gun = Protitanková zbraň
 
 Atomic Bomb = Atomová bomba
 Nuclear weapon of Strength [amount] = Jaderná zbraň síly [amount]
+ # Requires translation!
+if [buildingName] is constructed = 
 Blast radius [amount] = Poloměr výbuchu [amount]
 
 Rocket Artillery = Raketové dělostřelectvo
@@ -4318,6 +4358,7 @@ Great Artist = Velký umělec
 Can start an [amount]-turn golden age = Může spustit [amount]-tahový zlatý věk
 Can construct [improvementName] = Může postavit [improvementName]
 Great Person - [stat] = Velká osobnost - [stat]
+Unbuildable = Nelze vybudovat
 
 Great Scientist = Velký vědec
 Can hurry technology research = Může uspíšit výzkum
@@ -4376,6 +4417,8 @@ Faith Healers = Léčitelé
 Fertility Rites = Rituály plodnosti
 
 God of Craftsman = Bůh řemeslníků
+ # Requires translation!
+in cities with at least [amount] [populationFilter] = 
 
 God of the Open Sky = Bůh oblohy
 
@@ -4427,6 +4470,7 @@ Feed the World = Nakrmit svět
 Guruship = Duchovní otec
 
 Holy Warriors = Svatí válečníci
+before the [era] = před érou [era]
 May buy [baseUnitFilter] units with [stat] for [amount] times their normal Production cost = Může koupit [baseUnitFilter] jednotky za [stat] za [amount] krát cenu normální produkce
 
 Liturgical Drama = Liturgické drama
@@ -4447,6 +4491,7 @@ Religious Community = Náboženská komunita
 [amount]% [stat] from every follower, up to [amount2]% = [amount]% [stat] za každého stoupence, až do [amount2]%
 
 Swords into Ploughshares = Meče na radlice
+when not at war = není-li ve válce
 
 Founder = Zakladatel
 Ceremonial Burial = Slavnostní pohřeb
@@ -4579,9 +4624,6 @@ Starting in this era disables religion = Počátek v této éře zakáže nábo�
 
 
 Marine = Námořní pěchota
-
-
-#################### Lines from GlobalUniques from Civ V - Gods & Kings ####################
 
 
 #################### Lines from Nations from Civ V - Gods & Kings ####################
@@ -4907,6 +4949,7 @@ Llanfairpwllgwyngyll = Llanfairpwllgwyngyll
 Falmouth = Falmouth
 Lorient = Lorient
 Celts = Keltové
+with [amount] to [amount2] neighboring [tileFilter] [tileFilter2] tiles = s [amount] až [amount2] sousedními políčky [tileFilter] [tileFilter2]
 
 Haile Selassie = Haile Selassie
 I have tried all other avenues, but yet you persist in this madness. I hope, for your sake, your end is swift. = Zkoušel jsem všechny ostatní cesty, ale přesto v tomto šílenství setrváváte. Doufám, ve vašem zájmu, že váš konec bude rychlý.
@@ -4951,6 +4994,7 @@ Gambela = Gambela
 Ziway = Ziway
 Weldiya = Weldiya
 Ethiopia = Etiopie
+when fighting units from a Civilization with more Cities than you = při boji s jednotkami civilizace, která má více měst
 
 Pacal = Pakal
 A sacrifice unlike all others must be made! = Musí být učiněna oběť jako žádná jiná!
@@ -5036,10 +5080,10 @@ Taoism = Taoismus
 #################### Lines from Ruins from Civ V - Gods & Kings ####################
 
 
-We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[param] Faith) = Našli jsme v ruinách svaté symboly, což nám dalo hlubší porozumění náboženství! (+[param] Víry)
+We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[faithAmount] Faith) = Našli jsme v ruinách svaté symboly, což nám dalo hlubší porozumění náboženství! (+[faithAmount] Víry)
 discover holy symbols = objev svatých symbolů
 
-We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[param] Faith) = Našli jsme v ruinách prastaré proroctví, což výrazně zvýšilo naše duchovní spojení! (+[param] Víry)
+We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[faithAmount] Faith) = Našli jsme v ruinách prastaré proroctví, což výrazně zvýšilo naše duchovní spojení! (+[faithAmount] Víry)
 an ancient prophecy = prastaré proroctví
 
 
@@ -5097,7 +5141,15 @@ Polder = Polder
 #################### Lines from TileResources from Civ V - Gods & Kings ####################
 
 
+Citrus = Citrusy
+
+Copper = Měď
+
+Crab = Krabi
+
 Salt = Sůl
+
+Truffles = Lanýže
 
 
 #################### Lines from UnitPromotions from Civ V - Gods & Kings ####################
@@ -5483,55 +5535,27 @@ No Sight =
  # Requires translation!
 Irremovable = 
 when at war = je-li ve válce
-when not at war = není-li ve válce
-during a Golden Age = během Zlatého věku
  # Requires translation!
 with [resource] = 
-while the empire is happy = je-li říše spokojená
 when between [amount] and [amount2] Happiness = při spokojenosti mezi [amount] a [amount2]
 when below [amount] Happiness = při menší spokojenosti než [amount]
 during the [era] = během éry [era]
-before the [era] = před érou [era]
-starting from the [era] = počínaje érou [era]
  # Requires translation!
 if no other Civilization has researched this = 
-after discovering [tech] = po objevu technologie [tech]
-before discovering [tech] = před objevem technologie [tech]
  # Requires translation!
 upon discovering [tech] = 
 after adopting [policy] = po přijetí politiky [policy]
-before adopting [policy] = před přijetím politiky [policy]
- # Requires translation!
-if [buildingName] is constructed = 
- # Requires translation!
-for [amount] turns = 
  # Requires translation!
 by consuming this unit = 
  # Requires translation!
 in cities with a [buildingFilter] = 
  # Requires translation!
-in cities without a [buildingFilter] = 
- # Requires translation!
-in cities with at least [amount] [populationFilter] = 
-with a garrison = s posádkou
-for [mapUnitFilter] units = pro [mapUnitFilter] jednotky
- # Requires translation!
 for units with [promotion] = 
  # Requires translation!
 for units without [promotion] = 
-vs cities = proti městům
-vs [mapUnitFilter] units = proti [mapUnitFilter] jednotky
-when fighting units from a Civilization with more Cities than you = při boji s jednotkami civilizace, která má více měst
-when attacking = při útoku
-when defending = při obraně
-when fighting in [tileFilter] tiles = při boji na políčku [tileFilter]
-on foreign continents = na cizím kontinentu
-when adjacent to a [mapUnitFilter] unit = sousedící s [mapUnitFilter] jednotkou
 when above [amount] HP = při více než [amount] zdraví
 when below [amount] HP = při méně než [amount] zdraví 
 with [amount] to [amount2] neighboring [tileFilter] tiles = s [amount] až [amount2] sousedními políčky [tileFilter]
-with [amount] to [amount2] neighboring [tileFilter] [tileFilter2] tiles = s [amount] až [amount2] sousedními políčky [tileFilter] [tileFilter2]
-in [tileFilter] tiles = na políčkách [tileFilter]
 in [tileFilter] [tileFilter2] tiles = na políčkách [tileFilter] [tileFilter2]
 in tiles without [tileFilter] = na políčkách bez [tileFilter]
 on water maps = na vodních mapách
@@ -5591,3 +5615,12 @@ CityState =
 ModOptions = 
  # Requires translation!
 Conditional = 
+
+#################### Removed Lines ####################
+
+#~~Rough Terrain = Obtížný terén
+#~~Strategic = Strategický
+#~~Bonus = Bonus
+#~~Luxury = Luxusní
+#~~military water = vojenské námořní
+#~~My treasury contains little and my soldiers are getting impatient... ...therefore you must die. = Má pokladna je již téměř prázdná a vojáci začínají být netrpěliví... ...takže musíte zemřít.

--- a/android/assets/jsons/translations/Dutch.properties
+++ b/android/assets/jsons/translations/Dutch.properties
@@ -1095,8 +1095,6 @@ or [terrainType] = of  [terrainType]
 Can be constructed by = Kan gebouwd worden door
 Defence bonus = Verdedigingsbonus
 Movement cost = Bewegingskosten
-Open terrain = Open terrein
-Rough Terrain = Ruw terrein
 for = voor
 Missing translations: = Ontbrekende vertalingen: 
 Resolution = Resolutie
@@ -1228,102 +1226,6 @@ Religion = Religie
 Enhancing religion = Verbeteren van de religie 
 Enhanced religion = Verbeterde religie
 
-# Terrains
-
-Impassable = Onbegaanbaar
-Rare feature = Uitzonderlijke eigenschap
-
-# terrainFilters (so for uniques like: "[stats] from [terrainFilter] tiles")
-
-All = Alle
-Water = Water
-Land = Land
-Coastal = Kust
-River = Rivier
-Rough terrain = Ruig terrein
-Foreign Land = Vreemd land
-Foreign = Vreemd
-Friendly Land = Bevriend land
-Water resource = Water grondstof
-Bonus resource = Bonus grondstof 
-Luxury resource = Luxe grondstof
-Strategic resource = Strategische grondstof
-Fresh water = Zoet water
-non-fresh water = Niet-zoet water
-Natural Wonder = Natuurlijk wonder
-Hybrid = Hybride
-Undesirable = Onwenselijk
-Desirable = Wenselijk
-Featureless = Zonder kenmerken
-Fresh Water = Zoet water
-
-# improvementFilters
-
-All Road = Alle weg
-Great Improvement =  Grote verbetering
-Great = Groot
-
-# Resources
-
-Bison = Bisons
-Copper = Koperen
-Cocoa = Cacao
-Crab = Krabben
-Citrus = Citrus
-Truffles = Truffles
-Strategic = Strategisch
-Bonus = Bonus
-Luxury = Luxegoed
-
-# Unit types
-
-City = Stad
-Civilian = Burger
-Melee = Melee
-Ranged = Afstands
-Scout = Verkenner
-Mounted = Bereden
-Armor = Pantser
-Siege = Belegering
-
-WaterCivilian = WaterBurger
-WaterMelee = WaterSlag
-WaterRanged = WaterAfstand
-WaterSubmarine = WaterDuikboot
-WaterAircraftCarrier = WaterVliegdekschip
-
-Fighter = Jachtvliegtuig
-Bomber = Bommenwerper
-AtomicBomber = Atoombommenwerper
-Missile = Raket
-
-
-# Unit filters and other unit related things
-
-Air = Lucht
-air units = Luchteenheden
-Barbarian = Barbaren
-Barbarians = Barbaren
-Embarked = ingescheept
-land units = Landeenheden
-Military = militair
-# Deprecated since 3.15.2, but should still be translated until it is officially removed
-military water = militair water
-non-air = niet-lucht
-Nuclear Weapon = Kernwapen
-Submarine = Onderzeeër
-submarine units = onderzee eenheid
-Unbuildable = Onbouwbaar
-water units = Watereenheden
-wounded units = gewonde eenheden
-Wounded = Gewond
-
-# For the "All newly-trained [relevant] units in this city receive the [] promotion" translation. Relevant as in 'units that can receive'
-relevant = relevante
-
-# For "May choose [amount] additional [beliefType] beliefs when [founding/enhancing] a religion"
-founding = stichten
-enhancing = verbeteren
 
 # Promotions
 
@@ -1331,6 +1233,7 @@ Pick promotion = Kies een promotie
  OR  = OF 
 units in open terrain = eenheden in open terrein
 units in rough terrain = eenheden in ruw terrein
+wounded units = gewonde eenheden
 Targeting II (air) = Gerichtheid II (lucht)
 Targeting III (air) = Gerichtheid III (lucht)
 Bonus when performing air sweep [bonusAmount]% = Bonus bij het uitvoeren van een luchtsleep [bonusAmount]%
@@ -1434,6 +1337,11 @@ This Unit upgrades for free = Deze eenheid kan gratis opwaarderen
 Never destroyed when the city is captured = Nooit vernield bij verovering van de stad
 Invisible to others = Onzichtbaar voor anderen
 
+# Unused Resources
+
+Bison = Bisons
+Cocoa = Cacao
+
 
 # In English we just paste all these conditionals at the end of each unique, but in your language that
 # may not turn into valid sentences. Therefore we have the following two translations to determine
@@ -1463,6 +1371,33 @@ ConditionalsPlacement = after
 ########################### AUTOMATICALLY GENERATED TRANSLATABLE STRINGS ########################### 
 
 
+######### Map Unit Filters ###########
+
+Wounded = Gewond
+Barbarians = Barbaren
+ # Requires translation!
+City-State = 
+Embarked = ingescheept
+ # Requires translation!
+Non-City = 
+
+######### Unit Type Filters ###########
+
+Military = militair
+Civilian = Burger
+non-air = niet-lucht
+relevant = relevante
+Nuclear Weapon = Kernwapen
+City = Stad
+Air = Lucht
+land units = Landeenheden
+water units = Watereenheden
+air units = Luchteenheden
+ # Requires translation!
+military units = 
+submarine units = onderzee eenheid
+Barbarian = Barbaren
+
 ######### City filters ###########
 
 in this city = in deze stad
@@ -1481,6 +1416,64 @@ in annexed cities = in ge-annexeerde steden
 in holy cities = in heilige steden
 in City-State cities = in stadstaat steden
 in cities following this religion = in steden die deze religie volgen
+
+######### Population Filters ###########
+
+ # Requires translation!
+Unemployed = 
+ # Requires translation!
+Followers of the Majority Religion = 
+ # Requires translation!
+Followers of this Religion = 
+
+######### Terrain Filters ###########
+
+All = Alle
+Coastal = Kust
+River = Rivier
+Open terrain = Open terrein
+Rough terrain = Ruig terrein
+Water resource = Water grondstof
+Foreign Land = Vreemd land
+Foreign = Vreemd
+Friendly Land = Bevriend land
+ # Requires translation!
+Enemy Land = 
+Featureless = Zonder kenmerken
+Fresh Water = Zoet water
+non-fresh water = Niet-zoet water
+Natural Wonder = Natuurlijk wonder
+Impassable = Onbegaanbaar
+Land = Land
+Water = Water
+Luxury resource = Luxe grondstof
+Strategic resource = Strategische grondstof
+Bonus resource = Bonus grondstof 
+
+######### Tile Filters ###########
+
+ # Requires translation!
+unimproved = 
+All Road = Alle weg
+Great Improvement =  Grote verbetering
+
+######### Region Types ###########
+
+Hybrid = Hybride
+
+######### Terrain Quality ###########
+
+Undesirable = Onwenselijk
+Desirable = Wenselijk
+
+######### Improvement Filters ###########
+
+Great = Groot
+
+######### Prophet Action Filters ###########
+
+founding = stichten
+enhancing = verbeteren
 
 ######### Unique Specials ###########
 
@@ -1511,6 +1504,8 @@ Temple of Artemis = Tempel van Artemis
 The Great Lighthouse = De Grote Vuurtoren
  # Requires translation!
 'They that go down to the sea in ships, that do business in great waters; these see the works of the Lord, and his wonders in the deep.' - The Bible, Psalms 107:23-24 = 
+ # Requires translation!
+for [mapUnitFilter] units = 
 [amount] Movement = [amount] Actie
 [amount] Sight = [amount] zicht
 
@@ -1560,6 +1555,10 @@ Krepost = Krepost
 Statue of Zeus = Standbeeld van Zeus
  # Requires translation!
 'He spoke, the son of Kronos, and nodded his head with the dark brows, and the immortally anointed hair of the great god swept from his divine head, and all Olympos was shaken' - The Iliad = 
+ # Requires translation!
+vs cities = 
+ # Requires translation!
+when attacking = 
 [amount]% Strength = [amount]% Kract
 
 Lighthouse = Vuurtoren
@@ -1668,11 +1667,15 @@ Notre Dame = Notre Dame
 Castle = Kasteel
 
 Mughal Fort = Mogol fort
+ # Requires translation!
+after discovering [tech] = 
 [stats] [cityFilter] = [stats] [cityFilter]
 
 Himeji Castle = Kasteel Himeji
  # Requires translation!
 'Bushido is realized in the presence of death. This means choosing death whenever there is a choice between life and death. There is no other reasoning.' - Yamamoto Tsunetomo = 
+ # Requires translation!
+when fighting in [tileFilter] tiles = 
 
 Ironworks = IJzergieterij
 
@@ -1779,6 +1782,8 @@ Pentagon = Pentagon
 
 Solar Plant = Zonne-energiecentrale
  # Requires translation!
+in cities without a [buildingFilter] = 
+ # Requires translation!
 Only available = 
 
 Nuclear Plant = Kerncentrale
@@ -1813,6 +1818,7 @@ King = Koning
 Era Starting Unit = starteenheid Era
 
 Emperor = Keizer
+Scout = Verkenner
 
 Immortal = Onsterfelijk
 Worker = Werker
@@ -1845,9 +1851,6 @@ Atomic era = Atoomtijdperk
 Information era = Informaticatijdperk
 
 Future era = Toekomst
-
-
-#################### Lines from GlobalUniques from Civ V - Vanilla ####################
 
 
 #################### Lines from Nations from Civ V - Vanilla ####################
@@ -2185,6 +2188,8 @@ La Rochelle = La Rochelle
 Bourges = Bourges
 Calais = Calais
 France = Frankrijk
+ # Requires translation!
+before discovering [tech] = 
 
 Catherine = Catharina
 You've behaved yourself very badly, you know it. Now it's payback time. = Je hebt jezelf slecht gedragen, en dat weet je. Het is tijd voor wraak.
@@ -2241,7 +2246,8 @@ Russia = Rusland
 Double quantity of [resource] produced = Dubbele hoeveelheid van [resource] geproduceerd
 
 Augustus Caesar = Augustus Caesar
-My treasury contains little and my soldiers are getting impatient... ...therefore you must die. = De bodem van mijn schatkist is in zicht en mijn soldaten worden ongeduldig... ...daarom moet je vernietigd worden.
+ # Requires translation!
+My treasury contains little and my soldiers are getting impatient... (sigh) ...therefore you must die. = 
 So brave, yet so stupid! If only you had a brain similar to your courage. = Zo dapper, maar zo dom! Had je maar zoveel hersenen als je dapperheid had. 
 The gods have deprived Rome of their favour. We have been defeated. = De goden hebben Rome verlaten. We zijn verslagen.
 I greet you. I am Augustus, Imperator and Pontifex Maximus of Rome. If you are a friend of Rome, you are welcome. = Ik groet je, ik ben Augustus, Imperator en Pontifex Maximus van Rome. Als je een vriend van Rome bent, heet ik je welkom.
@@ -2893,6 +2899,8 @@ Patigrbana =
  # Requires translation!
 Phrada = 
 Persia = Perzië
+ # Requires translation!
+during a Golden Age = 
 
  # Requires translation!
 Kamehameha I = 
@@ -2992,6 +3000,8 @@ Pileni =
  # Requires translation!
 Nukumanu = 
 Polynesia = Polynesië
+ # Requires translation!
+starting from the [era] = 
  # Requires translation!
 Enables embarkation for land units = 
  # Requires translation!
@@ -3865,6 +3875,8 @@ Oligarchy = Oligarchie
  # Requires translation!
 Units in cities cost no Maintenance = 
  # Requires translation!
+with a garrison = 
+ # Requires translation!
 [amount]% Strength for cities = 
  # Requires translation!
 Landed Elite = 
@@ -3896,6 +3908,8 @@ Liberty =
  # Requires translation!
 Warrior Code = 
 Discipline = Discipline
+ # Requires translation!
+when adjacent to a [mapUnitFilter] unit = 
 Military Tradition = Militaire Traditie
  # Requires translation!
 [amount]% XP gained from combat = 
@@ -3906,6 +3920,8 @@ Professional Army = Professioneel Leger
 Honor Complete = 
  # Requires translation!
 Honor = 
+ # Requires translation!
+vs [mapUnitFilter] units = 
  # Requires translation!
 Notified of new Barbarian encampments = 
 
@@ -3922,6 +3938,8 @@ Free Religion = Vrije Religie
 Piety Complete = 
  # Requires translation!
 Piety = 
+ # Requires translation!
+before adopting [policy] = 
 
  # Requires translation!
 Philantropy = 
@@ -3992,11 +4010,15 @@ Rationalism Complete =
  # Requires translation!
 Rationalism = 
  # Requires translation!
+while the empire is happy = 
+ # Requires translation!
 [amount]% [stat] = 
 
 Constitution = Grondwet
  # Requires translation!
 Universal Suffrage = 
+ # Requires translation!
+when defending = 
  # Requires translation!
 Civil Society = 
  # Requires translation!
@@ -4026,6 +4048,8 @@ Police State =
 Total War = 
  # Requires translation!
 Autocracy Complete = 
+ # Requires translation!
+for [amount] turns = 
  # Requires translation!
 Autocracy = 
  # Requires translation!
@@ -4064,39 +4088,39 @@ We feel threatened by a Barbarian Camp near our city. Please take care of it. =
 
 Connect Resource = Verbind Grondstof
  # Requires translation!
-In order to make our civilizations stronger, connect [param] to your trade network. = 
+In order to make our civilizations stronger, connect [tileResource] to your trade network. = 
 
 Construct Wonder = Bouw Wonder
  # Requires translation!
-We recommend you to start building [param] to show the whole world your civilization strength. = 
+We recommend you to start building [wonder] to show the whole world your civilization strength. = 
 
  # Requires translation!
 Acquire Great Person = 
  # Requires translation!
-Great People can change the course of a Civilization! You will be rewarded for acquiring a new [param]. = 
+Great People can change the course of a Civilization! You will be rewarded for acquiring a new [greatPerson]. = 
 
  # Requires translation!
 Conquer City State = 
  # Requires translation!
-It's time to erase the City-State of [param] from the map. You will be greatly rewarded for conquering them! = 
+It's time to erase the City-State of [cityState] from the map. You will be greatly rewarded for conquering them! = 
 
 Find Player = Vind Speler
  # Requires translation!
-You have yet to discover where [param] set up their cities. You will be rewarded for finding their territories. = 
+You have yet to discover where [civName] set up their cities. You will be rewarded for finding their territories. = 
 
 Find Natural Wonder = Vind Natuurlijk Wonder
  # Requires translation!
-Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [param] yet. = 
+Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [naturalWonder] yet. = 
 
  # Requires translation!
 Give Gold = 
  # Requires translation!
-We are suffering great poverty after being robbed by [param], and unless we receive a sum of Gold, it's only a matter of time before we collapse. = 
+We are suffering great poverty after being robbed by [civName], and unless we receive a sum of Gold, it's only a matter of time before we collapse. = 
 
  # Requires translation!
 Pledge to Protect = 
  # Requires translation!
-We need your protection to stop the aggressions of [param]. By signing a Pledge of Protection, you'll confirm the bond that ties us. = 
+We need your protection to stop the aggressions of [civName]. By signing a Pledge of Protection, you'll confirm the bond that ties us. = 
 
  # Requires translation!
 Contest Culture = 
@@ -4116,20 +4140,20 @@ The civilization with the largest number of new Technologies researched will gai
  # Requires translation!
 Invest = 
  # Requires translation!
-Our people are rejoicing thanks to a tourism boom. For a certain amount of time, any Gold donation will yield [amount]% extra Influence. = 
+Our people are rejoicing thanks to a tourism boom. For a certain amount of time, any Gold donation will yield [50]% extra Influence. = 
 
  # Requires translation!
 Bully City State = 
  # Requires translation!
-We are tired of the pretensions of [param]. If someone were to put them in their place by Demanding Tribute from them, they would be rewarded. = 
+We are tired of the pretensions of [cityState]. If someone were to put them in their place by Demanding Tribute from them, they would be rewarded. = 
 
  # Requires translation!
 Denounce Civilization = 
  # Requires translation!
-We have been forced to pay tribute to [param]! We need you to tell the world of their ill deeds. = 
+We have been forced to pay tribute to [civName]! We need you to tell the world of their ill deeds. = 
 
  # Requires translation!
-We have heard the tenets of [param] and are most curious. Will you send missionaries to teach us about your religion? = 
+We have heard the tenets of [religionName] and are most curious. Will you send missionaries to teach us about your religion? = 
 
 
 #################### Lines from Ruins from Civ V - Vanilla ####################
@@ -4151,12 +4175,12 @@ An ancient tribe trained us in their ways of combat! =
 your exploring unit receives training = 
 
  # Requires translation!
-We have found survivors in the ruins! Population added to [param]. = 
+We have found survivors in the ruins! Population added to [cityName]. = 
  # Requires translation!
 survivors (adds population to a city) = 
 
  # Requires translation!
-We have found a stash of [param] Gold in the ruins! = 
+We have found a stash of [goldAmount] Gold in the ruins! = 
  # Requires translation!
 a stash of gold = 
 
@@ -4471,6 +4495,7 @@ Tundra = Toendra
 Desert = Woestijn
 
 Lakes = Meren
+Fresh water = Zoet water
 
 Mountain = Berg
  # Requires translation!
@@ -4496,6 +4521,7 @@ A Camp can be built here without cutting it down =
 Jungle = Oerwoud
 
 Marsh = Moeras
+Rare feature = Uitzonderlijke eigenschap
  # Requires translation!
 Only Polders can be built here = 
 
@@ -4728,6 +4754,8 @@ Porcelain =
 
  # Requires translation!
 Sword = 
+Mounted = Bereden
+Siege = Belegering
  # Requires translation!
 Ranged Gunpowder = 
  # Requires translation!
@@ -4736,6 +4764,7 @@ Armored =
 Melee Water = 
  # Requires translation!
 Ranged Water = 
+Submarine = Onderzeeër
 Heal Instantly = Genees instantaan
  # Requires translation!
 Heal this unit by [amount] HP = 
@@ -4803,6 +4832,8 @@ Medic = Dokter
 All adjacent units heal [amount] HP when healing = 
 
 Medic II = Dokter II
+ # Requires translation!
+in [tileFilter] tiles = 
  # Requires translation!
 [amount] HP when healing = 
 
@@ -4893,6 +4924,7 @@ Supply =
  # Requires translation!
 May heal outside of friendly territory = 
 
+Bomber = Bommenwerper
 Siege I = Belegering I
 
 Siege II = Belegering II
@@ -4903,6 +4935,7 @@ Evasion = Ontwijking
  # Requires translation!
 Damage taken from interception reduced by [amount]% = 
 
+Fighter = Jachtvliegtuig
 Interception I = Interceptie I
  # Requires translation!
 [amount]% Damage when intercepting = 
@@ -5039,6 +5072,7 @@ Can see over obstacles =
  # Requires translation!
 Atomic Bomber = 
 
+Missile = Raket
  # Requires translation!
 Self-destructs when attacking = 
  # Requires translation!
@@ -5046,6 +5080,24 @@ Cannot be intercepted =
 
  # Requires translation!
 Can pass through impassable tiles = 
+
+Melee = Melee
+
+Ranged = Afstands
+
+Armor = Pantser
+
+WaterCivilian = WaterBurger
+
+WaterMelee = WaterSlag
+
+WaterRanged = WaterAfstand
+
+WaterSubmarine = WaterDuikboot
+
+WaterAircraftCarrier = WaterVliegdekschip
+
+AtomicBomber = Atoombommenwerper
 
 
 #################### Lines from Units from Civ V - Vanilla ####################
@@ -5148,6 +5200,8 @@ Camel Archer =
 
  # Requires translation!
 Conquistador = 
+ # Requires translation!
+on foreign continents = 
 
  # Requires translation!
 Naresuan's Elephant = 
@@ -5273,6 +5327,8 @@ Atomic Bomb = Atoombom
  # Requires translation!
 Nuclear weapon of Strength [amount] = 
  # Requires translation!
+if [buildingName] is constructed = 
+ # Requires translation!
 Blast radius [amount] = 
 
  # Requires translation!
@@ -5325,6 +5381,7 @@ Can start an [amount]-turn golden age =
 Can construct [improvementName] = 
  # Requires translation!
 Great Person - [stat] = 
+Unbuildable = Onbouwbaar
 
  # Requires translation!
 Great Scientist = 
@@ -5406,6 +5463,8 @@ Faith Healers = Gebedsgenezers
 Fertility Rites = Vruchtbaarheidsritueel
 
 God of Craftsman = God van de Ambachtslieden
+ # Requires translation!
+in cities with at least [amount] [populationFilter] = 
 
 God of the Open Sky = God van de Open Lucht
 
@@ -5460,6 +5519,8 @@ Guruship = Guruschap
  # Requires translation!
 Holy Warriors = 
  # Requires translation!
+before the [era] = 
+ # Requires translation!
 May buy [baseUnitFilter] units with [stat] for [amount] times their normal Production cost = 
 
 Liturgical Drama = Liturgies drama
@@ -5480,6 +5541,8 @@ Religious Community = Religieuze gemeenschap
 [amount]% [stat] from every follower, up to [amount2]% = [amount]% [stat] voor elke volger, tot [amount2]%
 
 Swords into Ploughshares = Zwaarden naar ploegscharen
+ # Requires translation!
+when not at war = 
 
 Founder = Stichter
 Ceremonial Burial = Ceremoniele begravenis
@@ -5633,9 +5696,6 @@ Starting in this era disables religion =
 
 
 Marine = Marinier
-
-
-#################### Lines from GlobalUniques from Civ V - Gods & Kings ####################
 
 
 #################### Lines from Nations from Civ V - Gods & Kings ####################
@@ -6258,6 +6318,8 @@ Falmouth =
 Lorient = 
  # Requires translation!
 Celts = 
+ # Requires translation!
+with [amount] to [amount2] neighboring [tileFilter] [tileFilter2] tiles = 
 
  # Requires translation!
 Haile Selassie = 
@@ -6345,6 +6407,8 @@ Ziway =
 Weldiya = 
  # Requires translation!
 Ethiopia = 
+ # Requires translation!
+when fighting units from a Civilization with more Cities than you = 
 
  # Requires translation!
 Pacal = 
@@ -6492,12 +6556,12 @@ Taoism =
 
 
  # Requires translation!
-We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[param] Faith) = 
+We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[faithAmount] Faith) = 
  # Requires translation!
 discover holy symbols = 
 
  # Requires translation!
-We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[param] Faith) = 
+We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[faithAmount] Faith) = 
  # Requires translation!
 an ancient prophecy = 
 
@@ -6573,8 +6637,16 @@ Polder =
 #################### Lines from TileResources from Civ V - Gods & Kings ####################
 
 
+Citrus = Citrus
+
+Copper = Koperen
+
+Crab = Krabben
+
  # Requires translation!
 Salt = 
+
+Truffles = Truffles
 
 
 #################### Lines from UnitPromotions from Civ V - Gods & Kings ####################
@@ -7129,13 +7201,7 @@ Irremovable =
  # Requires translation!
 when at war = 
  # Requires translation!
-when not at war = 
- # Requires translation!
-during a Golden Age = 
- # Requires translation!
 with [resource] = 
- # Requires translation!
-while the empire is happy = 
  # Requires translation!
 when between [amount] and [amount2] Happiness = 
  # Requires translation!
@@ -7143,67 +7209,25 @@ when below [amount] Happiness =
  # Requires translation!
 during the [era] = 
  # Requires translation!
-before the [era] = 
- # Requires translation!
-starting from the [era] = 
- # Requires translation!
 if no other Civilization has researched this = 
- # Requires translation!
-after discovering [tech] = 
- # Requires translation!
-before discovering [tech] = 
  # Requires translation!
 upon discovering [tech] = 
  # Requires translation!
 after adopting [policy] = 
  # Requires translation!
-before adopting [policy] = 
- # Requires translation!
-if [buildingName] is constructed = 
- # Requires translation!
-for [amount] turns = 
- # Requires translation!
 by consuming this unit = 
  # Requires translation!
 in cities with a [buildingFilter] = 
  # Requires translation!
-in cities without a [buildingFilter] = 
- # Requires translation!
-in cities with at least [amount] [populationFilter] = 
- # Requires translation!
-with a garrison = 
- # Requires translation!
-for [mapUnitFilter] units = 
- # Requires translation!
 for units with [promotion] = 
  # Requires translation!
 for units without [promotion] = 
- # Requires translation!
-vs cities = 
- # Requires translation!
-vs [mapUnitFilter] units = 
- # Requires translation!
-when fighting units from a Civilization with more Cities than you = 
- # Requires translation!
-when attacking = 
- # Requires translation!
-when defending = 
- # Requires translation!
-when fighting in [tileFilter] tiles = 
- # Requires translation!
-on foreign continents = 
- # Requires translation!
-when adjacent to a [mapUnitFilter] unit = 
  # Requires translation!
 when above [amount] HP = 
  # Requires translation!
 when below [amount] HP = 
  # Requires translation!
 with [amount] to [amount2] neighboring [tileFilter] tiles = 
- # Requires translation!
-with [amount] to [amount2] neighboring [tileFilter] [tileFilter2] tiles = 
- # Requires translation!
-in [tileFilter] tiles = 
  # Requires translation!
 in [tileFilter] [tileFilter2] tiles = 
  # Requires translation!
@@ -7282,3 +7306,12 @@ CityState =
 ModOptions = 
  # Requires translation!
 Conditional = 
+
+#################### Removed Lines ####################
+
+#~~Rough Terrain = Ruw terrein
+#~~Strategic = Strategisch
+#~~Bonus = Bonus
+#~~Luxury = Luxegoed
+#~~military water = militair water
+#~~My treasury contains little and my soldiers are getting impatient... ...therefore you must die. = De bodem van mijn schatkist is in zicht en mijn soldaten worden ongeduldig... ...daarom moet je vernietigd worden.

--- a/android/assets/jsons/translations/English.properties
+++ b/android/assets/jsons/translations/English.properties
@@ -2032,10 +2032,6 @@ Defence bonus =
  # Requires translation!
 Movement cost = 
  # Requires translation!
-Open terrain = 
- # Requires translation!
-Rough Terrain = 
- # Requires translation!
 for = 
  # Requires translation!
 Missing translations: = 
@@ -2276,169 +2272,6 @@ Enhancing religion =
  # Requires translation!
 Enhanced religion = 
 
-# Terrains
-
- # Requires translation!
-Impassable = 
- # Requires translation!
-Rare feature = 
-
-# terrainFilters (so for uniques like: "[stats] from [terrainFilter] tiles")
-
- # Requires translation!
-All = 
- # Requires translation!
-Water = 
- # Requires translation!
-Land = 
- # Requires translation!
-Coastal = 
- # Requires translation!
-River = 
- # Requires translation!
-Rough terrain = 
- # Requires translation!
-Foreign Land = 
- # Requires translation!
-Foreign = 
- # Requires translation!
-Friendly Land = 
- # Requires translation!
-Water resource = 
- # Requires translation!
-Bonus resource = 
- # Requires translation!
-Luxury resource = 
- # Requires translation!
-Strategic resource = 
- # Requires translation!
-Fresh water = 
- # Requires translation!
-non-fresh water = 
- # Requires translation!
-Natural Wonder = 
- # Requires translation!
-Hybrid = 
- # Requires translation!
-Undesirable = 
- # Requires translation!
-Desirable = 
- # Requires translation!
-Featureless = 
- # Requires translation!
-Fresh Water = 
-
-# improvementFilters
-
- # Requires translation!
-All Road = 
- # Requires translation!
-Great Improvement = 
- # Requires translation!
-Great = 
-
-# Resources
-
- # Requires translation!
-Bison = 
- # Requires translation!
-Copper = 
- # Requires translation!
-Cocoa = 
- # Requires translation!
-Crab = 
- # Requires translation!
-Citrus = 
- # Requires translation!
-Truffles = 
- # Requires translation!
-Strategic = 
- # Requires translation!
-Bonus = 
- # Requires translation!
-Luxury = 
-
-# Unit types
-
- # Requires translation!
-City = 
- # Requires translation!
-Civilian = 
- # Requires translation!
-Melee = 
- # Requires translation!
-Ranged = 
- # Requires translation!
-Scout = 
- # Requires translation!
-Mounted = 
- # Requires translation!
-Armor = 
- # Requires translation!
-Siege = 
-
-WaterCivilian = Water Civilian
-WaterMelee = Water Melee
-WaterRanged = Water Ranged
-WaterSubmarine = Submarine
- # Requires translation!
-WaterAircraftCarrier = 
-
- # Requires translation!
-Fighter = 
- # Requires translation!
-Bomber = 
- # Requires translation!
-AtomicBomber = 
- # Requires translation!
-Missile = 
-
-
-# Unit filters and other unit related things
-
- # Requires translation!
-Air = 
- # Requires translation!
-air units = 
- # Requires translation!
-Barbarian = 
- # Requires translation!
-Barbarians = 
- # Requires translation!
-Embarked = 
- # Requires translation!
-land units = 
- # Requires translation!
-Military = 
-# Deprecated since 3.15.2, but should still be translated until it is officially removed
- # Requires translation!
-military water = 
- # Requires translation!
-non-air = 
- # Requires translation!
-Nuclear Weapon = 
- # Requires translation!
-Submarine = 
- # Requires translation!
-submarine units = 
- # Requires translation!
-Unbuildable = 
- # Requires translation!
-water units = 
- # Requires translation!
-wounded units = 
- # Requires translation!
-Wounded = 
-
-# For the "All newly-trained [relevant] units in this city receive the [] promotion" translation. Relevant as in 'units that can receive'
- # Requires translation!
-relevant = 
-
-# For "May choose [amount] additional [beliefType] beliefs when [founding/enhancing] a religion"
- # Requires translation!
-founding = 
- # Requires translation!
-enhancing = 
 
 # Promotions
 
@@ -2450,6 +2283,8 @@ Pick promotion =
 units in open terrain = 
  # Requires translation!
 units in rough terrain = 
+ # Requires translation!
+wounded units = 
  # Requires translation!
 Targeting II (air) = 
  # Requires translation!
@@ -2624,6 +2459,13 @@ Never destroyed when the city is captured =
  # Requires translation!
 Invisible to others = 
 
+# Unused Resources
+
+ # Requires translation!
+Bison = 
+ # Requires translation!
+Cocoa = 
+
 
 # In English we just paste all these conditionals at the end of each unique, but in your language that
 # may not turn into valid sentences. Therefore we have the following two translations to determine
@@ -2653,6 +2495,48 @@ ConditionalsPlacement =
 
 ########################### AUTOMATICALLY GENERATED TRANSLATABLE STRINGS ########################### 
 
+
+######### Map Unit Filters ###########
+
+ # Requires translation!
+Wounded = 
+ # Requires translation!
+Barbarians = 
+ # Requires translation!
+City-State = 
+ # Requires translation!
+Embarked = 
+ # Requires translation!
+Non-City = 
+
+######### Unit Type Filters ###########
+
+ # Requires translation!
+Military = 
+ # Requires translation!
+Civilian = 
+ # Requires translation!
+non-air = 
+ # Requires translation!
+relevant = 
+ # Requires translation!
+Nuclear Weapon = 
+ # Requires translation!
+City = 
+ # Requires translation!
+Air = 
+ # Requires translation!
+land units = 
+ # Requires translation!
+water units = 
+ # Requires translation!
+air units = 
+ # Requires translation!
+military units = 
+ # Requires translation!
+submarine units = 
+ # Requires translation!
+Barbarian = 
 
 ######### City filters ###########
 
@@ -2688,6 +2572,91 @@ in holy cities =
 in City-State cities = 
  # Requires translation!
 in cities following this religion = 
+
+######### Population Filters ###########
+
+ # Requires translation!
+Unemployed = 
+ # Requires translation!
+Followers of the Majority Religion = 
+ # Requires translation!
+Followers of this Religion = 
+
+######### Terrain Filters ###########
+
+ # Requires translation!
+All = 
+ # Requires translation!
+Coastal = 
+ # Requires translation!
+River = 
+ # Requires translation!
+Open terrain = 
+ # Requires translation!
+Rough terrain = 
+ # Requires translation!
+Water resource = 
+ # Requires translation!
+Foreign Land = 
+ # Requires translation!
+Foreign = 
+ # Requires translation!
+Friendly Land = 
+ # Requires translation!
+Enemy Land = 
+ # Requires translation!
+Featureless = 
+ # Requires translation!
+Fresh Water = 
+ # Requires translation!
+non-fresh water = 
+ # Requires translation!
+Natural Wonder = 
+ # Requires translation!
+Impassable = 
+ # Requires translation!
+Land = 
+ # Requires translation!
+Water = 
+ # Requires translation!
+Luxury resource = 
+ # Requires translation!
+Strategic resource = 
+ # Requires translation!
+Bonus resource = 
+
+######### Tile Filters ###########
+
+ # Requires translation!
+unimproved = 
+ # Requires translation!
+All Road = 
+ # Requires translation!
+Great Improvement = 
+
+######### Region Types ###########
+
+ # Requires translation!
+Hybrid = 
+
+######### Terrain Quality ###########
+
+ # Requires translation!
+Undesirable = 
+ # Requires translation!
+Desirable = 
+
+######### Improvement Filters ###########
+
+ # Requires translation!
+Great = 
+
+######### Prophet Action Filters ###########
+
+ # Requires translation!
+founding = 
+ # Requires translation!
+enhancing = 
 
 ######### Unique Specials ###########
 
@@ -2728,6 +2697,8 @@ Temple of Artemis =
 The Great Lighthouse = 
  # Requires translation!
 'They that go down to the sea in ships, that do business in great waters; these see the works of the Lord, and his wonders in the deep.' - The Bible, Psalms 107:23-24 = 
+ # Requires translation!
+for [mapUnitFilter] units = 
  # Requires translation!
 [amount] Movement = 
  # Requires translation!
@@ -2805,6 +2776,10 @@ Krepost =
 Statue of Zeus = 
  # Requires translation!
 'He spoke, the son of Kronos, and nodded his head with the dark brows, and the immortally anointed hair of the great god swept from his divine head, and all Olympos was shaken' - The Iliad = 
+ # Requires translation!
+vs cities = 
+ # Requires translation!
+when attacking = 
  # Requires translation!
 [amount]% Strength = 
 
@@ -2962,12 +2937,16 @@ Castle =
  # Requires translation!
 Mughal Fort = 
  # Requires translation!
+after discovering [tech] = 
+ # Requires translation!
 [stats] [cityFilter] = 
 
  # Requires translation!
 Himeji Castle = 
  # Requires translation!
 'Bushido is realized in the presence of death. This means choosing death whenever there is a choice between life and death. There is no other reasoning.' - Yamamoto Tsunetomo = 
+ # Requires translation!
+when fighting in [tileFilter] tiles = 
 
  # Requires translation!
 Ironworks = 
@@ -3133,6 +3112,8 @@ Pentagon =
  # Requires translation!
 Solar Plant = 
  # Requires translation!
+in cities without a [buildingFilter] = 
+ # Requires translation!
 Only available = 
 
  # Requires translation!
@@ -3184,6 +3165,8 @@ Era Starting Unit =
 
  # Requires translation!
 Emperor = 
+ # Requires translation!
+Scout = 
 
  # Requires translation!
 Immortal = 
@@ -3234,9 +3217,6 @@ Information era =
 
  # Requires translation!
 Future era = 
-
-
-#################### Lines from GlobalUniques from Civ V - Vanilla ####################
 
 
 #################### Lines from Nations from Civ V - Vanilla ####################
@@ -3897,6 +3877,8 @@ Bourges =
 Calais = 
  # Requires translation!
 France = 
+ # Requires translation!
+before discovering [tech] = 
 
  # Requires translation!
 Catherine = 
@@ -4004,7 +3986,7 @@ Double quantity of [resource] produced =
  # Requires translation!
 Augustus Caesar = 
  # Requires translation!
-My treasury contains little and my soldiers are getting impatient... ...therefore you must die. = 
+My treasury contains little and my soldiers are getting impatient... (sigh) ...therefore you must die. = 
  # Requires translation!
 So brave, yet so stupid! If only you had a brain similar to your courage. = 
  # Requires translation!
@@ -5060,6 +5042,8 @@ Patigrbana =
 Phrada = 
  # Requires translation!
 Persia = 
+ # Requires translation!
+during a Golden Age = 
 
  # Requires translation!
 Kamehameha I = 
@@ -5163,6 +5147,8 @@ Pileni =
 Nukumanu = 
  # Requires translation!
 Polynesia = 
+ # Requires translation!
+starting from the [era] = 
  # Requires translation!
 Enables embarkation for land units = 
  # Requires translation!
@@ -6070,6 +6056,8 @@ Oligarchy =
  # Requires translation!
 Units in cities cost no Maintenance = 
  # Requires translation!
+with a garrison = 
+ # Requires translation!
 [amount]% Strength for cities = 
  # Requires translation!
 Landed Elite = 
@@ -6108,6 +6096,8 @@ Warrior Code =
  # Requires translation!
 Discipline = 
  # Requires translation!
+when adjacent to a [mapUnitFilter] unit = 
+ # Requires translation!
 Military Tradition = 
  # Requires translation!
 [amount]% XP gained from combat = 
@@ -6119,6 +6109,8 @@ Professional Army =
 Honor Complete = 
  # Requires translation!
 Honor = 
+ # Requires translation!
+vs [mapUnitFilter] units = 
  # Requires translation!
 Notified of new Barbarian encampments = 
 
@@ -6140,6 +6132,8 @@ Free Religion =
 Piety Complete = 
  # Requires translation!
 Piety = 
+ # Requires translation!
+before adopting [policy] = 
 
  # Requires translation!
 Philantropy = 
@@ -6212,12 +6206,16 @@ Rationalism Complete =
  # Requires translation!
 Rationalism = 
  # Requires translation!
+while the empire is happy = 
+ # Requires translation!
 [amount]% [stat] = 
 
  # Requires translation!
 Constitution = 
  # Requires translation!
 Universal Suffrage = 
+ # Requires translation!
+when defending = 
  # Requires translation!
 Civil Society = 
  # Requires translation!
@@ -6251,6 +6249,8 @@ Police State =
 Total War = 
  # Requires translation!
 Autocracy Complete = 
+ # Requires translation!
+for [amount] turns = 
  # Requires translation!
 Autocracy = 
  # Requires translation!
@@ -6291,42 +6291,42 @@ We feel threatened by a Barbarian Camp near our city. Please take care of it. =
  # Requires translation!
 Connect Resource = 
  # Requires translation!
-In order to make our civilizations stronger, connect [param] to your trade network. = 
+In order to make our civilizations stronger, connect [tileResource] to your trade network. = 
 
  # Requires translation!
 Construct Wonder = 
  # Requires translation!
-We recommend you to start building [param] to show the whole world your civilization strength. = 
+We recommend you to start building [wonder] to show the whole world your civilization strength. = 
 
  # Requires translation!
 Acquire Great Person = 
  # Requires translation!
-Great People can change the course of a Civilization! You will be rewarded for acquiring a new [param]. = 
+Great People can change the course of a Civilization! You will be rewarded for acquiring a new [greatPerson]. = 
 
  # Requires translation!
 Conquer City State = 
  # Requires translation!
-It's time to erase the City-State of [param] from the map. You will be greatly rewarded for conquering them! = 
+It's time to erase the City-State of [cityState] from the map. You will be greatly rewarded for conquering them! = 
 
  # Requires translation!
 Find Player = 
  # Requires translation!
-You have yet to discover where [param] set up their cities. You will be rewarded for finding their territories. = 
+You have yet to discover where [civName] set up their cities. You will be rewarded for finding their territories. = 
 
  # Requires translation!
 Find Natural Wonder = 
  # Requires translation!
-Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [param] yet. = 
+Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [naturalWonder] yet. = 
 
  # Requires translation!
 Give Gold = 
  # Requires translation!
-We are suffering great poverty after being robbed by [param], and unless we receive a sum of Gold, it's only a matter of time before we collapse. = 
+We are suffering great poverty after being robbed by [civName], and unless we receive a sum of Gold, it's only a matter of time before we collapse. = 
 
  # Requires translation!
 Pledge to Protect = 
  # Requires translation!
-We need your protection to stop the aggressions of [param]. By signing a Pledge of Protection, you'll confirm the bond that ties us. = 
+We need your protection to stop the aggressions of [civName]. By signing a Pledge of Protection, you'll confirm the bond that ties us. = 
 
  # Requires translation!
 Contest Culture = 
@@ -6346,20 +6346,20 @@ The civilization with the largest number of new Technologies researched will gai
  # Requires translation!
 Invest = 
  # Requires translation!
-Our people are rejoicing thanks to a tourism boom. For a certain amount of time, any Gold donation will yield [amount]% extra Influence. = 
+Our people are rejoicing thanks to a tourism boom. For a certain amount of time, any Gold donation will yield [50]% extra Influence. = 
 
  # Requires translation!
 Bully City State = 
  # Requires translation!
-We are tired of the pretensions of [param]. If someone were to put them in their place by Demanding Tribute from them, they would be rewarded. = 
+We are tired of the pretensions of [cityState]. If someone were to put them in their place by Demanding Tribute from them, they would be rewarded. = 
 
  # Requires translation!
 Denounce Civilization = 
  # Requires translation!
-We have been forced to pay tribute to [param]! We need you to tell the world of their ill deeds. = 
+We have been forced to pay tribute to [civName]! We need you to tell the world of their ill deeds. = 
 
  # Requires translation!
-We have heard the tenets of [param] and are most curious. Will you send missionaries to teach us about your religion? = 
+We have heard the tenets of [religionName] and are most curious. Will you send missionaries to teach us about your religion? = 
 
 
 #################### Lines from Ruins from Civ V - Vanilla ####################
@@ -6381,12 +6381,12 @@ An ancient tribe trained us in their ways of combat! =
 your exploring unit receives training = 
 
  # Requires translation!
-We have found survivors in the ruins! Population added to [param]. = 
+We have found survivors in the ruins! Population added to [cityName]. = 
  # Requires translation!
 survivors (adds population to a city) = 
 
  # Requires translation!
-We have found a stash of [param] Gold in the ruins! = 
+We have found a stash of [goldAmount] Gold in the ruins! = 
  # Requires translation!
 a stash of gold = 
 
@@ -6781,6 +6781,8 @@ Desert =
 
  # Requires translation!
 Lakes = 
+ # Requires translation!
+Fresh water = 
 
  # Requires translation!
 Mountain = 
@@ -6813,6 +6815,8 @@ Jungle =
 
  # Requires translation!
 Marsh = 
+ # Requires translation!
+Rare feature = 
  # Requires translation!
 Only Polders can be built here = 
 
@@ -7117,6 +7121,10 @@ Porcelain =
  # Requires translation!
 Sword = 
  # Requires translation!
+Mounted = 
+ # Requires translation!
+Siege = 
+ # Requires translation!
 Ranged Gunpowder = 
  # Requires translation!
 Armored = 
@@ -7124,6 +7132,8 @@ Armored =
 Melee Water = 
  # Requires translation!
 Ranged Water = 
+ # Requires translation!
+Submarine = 
  # Requires translation!
 Heal Instantly = 
  # Requires translation!
@@ -7216,6 +7226,8 @@ All adjacent units heal [amount] HP when healing =
 
  # Requires translation!
 Medic II = 
+ # Requires translation!
+in [tileFilter] tiles = 
  # Requires translation!
 [amount] HP when healing = 
 
@@ -7310,6 +7322,8 @@ Supply =
 May heal outside of friendly territory = 
 
  # Requires translation!
+Bomber = 
+ # Requires translation!
 Siege I = 
 
  # Requires translation!
@@ -7323,6 +7337,8 @@ Evasion =
  # Requires translation!
 Damage taken from interception reduced by [amount]% = 
 
+ # Requires translation!
+Fighter = 
  # Requires translation!
 Interception I = 
  # Requires translation!
@@ -7468,12 +7484,37 @@ Can see over obstacles =
 Atomic Bomber = 
 
  # Requires translation!
+Missile = 
+ # Requires translation!
 Self-destructs when attacking = 
  # Requires translation!
 Cannot be intercepted = 
 
  # Requires translation!
 Can pass through impassable tiles = 
+
+ # Requires translation!
+Melee = 
+
+ # Requires translation!
+Ranged = 
+
+ # Requires translation!
+Armor = 
+
+WaterCivilian = Water Civilian
+
+WaterMelee = Water Melee
+
+WaterRanged = Water Ranged
+
+WaterSubmarine = Submarine
+
+ # Requires translation!
+WaterAircraftCarrier = 
+
+ # Requires translation!
+AtomicBomber = 
 
 
 #################### Lines from Units from Civ V - Vanilla ####################
@@ -7592,6 +7633,8 @@ Camel Archer =
 
  # Requires translation!
 Conquistador = 
+ # Requires translation!
+on foreign continents = 
 
  # Requires translation!
 Naresuan's Elephant = 
@@ -7728,6 +7771,8 @@ Atomic Bomb =
  # Requires translation!
 Nuclear weapon of Strength [amount] = 
  # Requires translation!
+if [buildingName] is constructed = 
+ # Requires translation!
 Blast radius [amount] = 
 
  # Requires translation!
@@ -7782,6 +7827,8 @@ Can start an [amount]-turn golden age =
 Can construct [improvementName] = 
  # Requires translation!
 Great Person - [stat] = 
+ # Requires translation!
+Unbuildable = 
 
  # Requires translation!
 Great Scientist = 
@@ -7877,6 +7924,8 @@ Fertility Rites =
 
  # Requires translation!
 God of Craftsman = 
+ # Requires translation!
+in cities with at least [amount] [populationFilter] = 
 
  # Requires translation!
 God of the Open Sky = 
@@ -7957,6 +8006,8 @@ Guruship =
  # Requires translation!
 Holy Warriors = 
  # Requires translation!
+before the [era] = 
+ # Requires translation!
 May buy [baseUnitFilter] units with [stat] for [amount] times their normal Production cost = 
 
  # Requires translation!
@@ -7987,6 +8038,8 @@ Religious Community =
 
  # Requires translation!
 Swords into Ploughshares = 
+ # Requires translation!
+when not at war = 
 
  # Requires translation!
 Founder = 
@@ -8185,9 +8238,6 @@ Starting in this era disables religion =
 
  # Requires translation!
 Marine = 
-
-
-#################### Lines from GlobalUniques from Civ V - Gods & Kings ####################
 
 
 #################### Lines from Nations from Civ V - Gods & Kings ####################
@@ -8811,6 +8861,8 @@ Falmouth =
 Lorient = 
  # Requires translation!
 Celts = 
+ # Requires translation!
+with [amount] to [amount2] neighboring [tileFilter] [tileFilter2] tiles = 
 
  # Requires translation!
 Haile Selassie = 
@@ -8898,6 +8950,8 @@ Ziway =
 Weldiya = 
  # Requires translation!
 Ethiopia = 
+ # Requires translation!
+when fighting units from a Civilization with more Cities than you = 
 
  # Requires translation!
 Pacal = 
@@ -9045,12 +9099,12 @@ Taoism =
 
 
  # Requires translation!
-We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[param] Faith) = 
+We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[faithAmount] Faith) = 
  # Requires translation!
 discover holy symbols = 
 
  # Requires translation!
-We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[param] Faith) = 
+We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[faithAmount] Faith) = 
  # Requires translation!
 an ancient prophecy = 
 
@@ -9131,7 +9185,19 @@ Polder =
 
 
  # Requires translation!
+Citrus = 
+
+ # Requires translation!
+Copper = 
+
+ # Requires translation!
+Crab = 
+
+ # Requires translation!
 Salt = 
+
+ # Requires translation!
+Truffles = 
 
 
 #################### Lines from UnitPromotions from Civ V - Gods & Kings ####################
@@ -9693,13 +9759,7 @@ Irremovable =
  # Requires translation!
 when at war = 
  # Requires translation!
-when not at war = 
- # Requires translation!
-during a Golden Age = 
- # Requires translation!
 with [resource] = 
- # Requires translation!
-while the empire is happy = 
  # Requires translation!
 when between [amount] and [amount2] Happiness = 
  # Requires translation!
@@ -9707,67 +9767,25 @@ when below [amount] Happiness =
  # Requires translation!
 during the [era] = 
  # Requires translation!
-before the [era] = 
- # Requires translation!
-starting from the [era] = 
- # Requires translation!
 if no other Civilization has researched this = 
- # Requires translation!
-after discovering [tech] = 
- # Requires translation!
-before discovering [tech] = 
  # Requires translation!
 upon discovering [tech] = 
  # Requires translation!
 after adopting [policy] = 
  # Requires translation!
-before adopting [policy] = 
- # Requires translation!
-if [buildingName] is constructed = 
- # Requires translation!
-for [amount] turns = 
- # Requires translation!
 by consuming this unit = 
  # Requires translation!
 in cities with a [buildingFilter] = 
  # Requires translation!
-in cities without a [buildingFilter] = 
- # Requires translation!
-in cities with at least [amount] [populationFilter] = 
- # Requires translation!
-with a garrison = 
- # Requires translation!
-for [mapUnitFilter] units = 
- # Requires translation!
 for units with [promotion] = 
  # Requires translation!
 for units without [promotion] = 
- # Requires translation!
-vs cities = 
- # Requires translation!
-vs [mapUnitFilter] units = 
- # Requires translation!
-when fighting units from a Civilization with more Cities than you = 
- # Requires translation!
-when attacking = 
- # Requires translation!
-when defending = 
- # Requires translation!
-when fighting in [tileFilter] tiles = 
- # Requires translation!
-on foreign continents = 
- # Requires translation!
-when adjacent to a [mapUnitFilter] unit = 
  # Requires translation!
 when above [amount] HP = 
  # Requires translation!
 when below [amount] HP = 
  # Requires translation!
 with [amount] to [amount2] neighboring [tileFilter] tiles = 
- # Requires translation!
-with [amount] to [amount2] neighboring [tileFilter] [tileFilter2] tiles = 
- # Requires translation!
-in [tileFilter] tiles = 
  # Requires translation!
 in [tileFilter] [tileFilter2] tiles = 
  # Requires translation!

--- a/android/assets/jsons/translations/Filipino.properties
+++ b/android/assets/jsons/translations/Filipino.properties
@@ -1802,10 +1802,6 @@ Defence bonus =
  # Requires translation!
 Movement cost = 
  # Requires translation!
-Open terrain = 
- # Requires translation!
-Rough Terrain = 
- # Requires translation!
 for = 
  # Requires translation!
 Missing translations: = 
@@ -2045,169 +2041,6 @@ Enhancing religion =
  # Requires translation!
 Enhanced religion = 
 
-# Terrains
-
- # Requires translation!
-Impassable = 
- # Requires translation!
-Rare feature = 
-
-# terrainFilters (so for uniques like: "[stats] from [terrainFilter] tiles")
-
- # Requires translation!
-All = 
- # Requires translation!
-Water = 
- # Requires translation!
-Land = 
- # Requires translation!
-Coastal = 
- # Requires translation!
-River = 
- # Requires translation!
-Rough terrain = 
- # Requires translation!
-Foreign Land = 
- # Requires translation!
-Foreign = 
- # Requires translation!
-Friendly Land = 
- # Requires translation!
-Water resource = 
- # Requires translation!
-Bonus resource = 
- # Requires translation!
-Luxury resource = 
- # Requires translation!
-Strategic resource = 
- # Requires translation!
-Fresh water = 
- # Requires translation!
-non-fresh water = 
- # Requires translation!
-Natural Wonder = 
- # Requires translation!
-Hybrid = 
- # Requires translation!
-Undesirable = 
- # Requires translation!
-Desirable = 
- # Requires translation!
-Featureless = 
- # Requires translation!
-Fresh Water = 
-
-# improvementFilters
-
- # Requires translation!
-All Road = 
- # Requires translation!
-Great Improvement = 
- # Requires translation!
-Great = 
-
-# Resources
-
- # Requires translation!
-Bison = 
- # Requires translation!
-Copper = 
- # Requires translation!
-Cocoa = 
- # Requires translation!
-Crab = 
- # Requires translation!
-Citrus = 
- # Requires translation!
-Truffles = 
- # Requires translation!
-Strategic = 
- # Requires translation!
-Bonus = 
- # Requires translation!
-Luxury = 
-
-# Unit types
-
-City = Lungsod
-Civilian = Sibilyan
- # Requires translation!
-Melee = 
-Ranged = Ranged
-Scout = Scout
- # Requires translation!
-Mounted = 
- # Requires translation!
-Armor = 
- # Requires translation!
-Siege = 
-
- # Requires translation!
-WaterCivilian = 
- # Requires translation!
-WaterMelee = 
- # Requires translation!
-WaterRanged = 
- # Requires translation!
-WaterSubmarine = 
- # Requires translation!
-WaterAircraftCarrier = 
-
- # Requires translation!
-Fighter = 
- # Requires translation!
-Bomber = 
- # Requires translation!
-AtomicBomber = 
- # Requires translation!
-Missile = 
-
-
-# Unit filters and other unit related things
-
- # Requires translation!
-Air = 
- # Requires translation!
-air units = 
- # Requires translation!
-Barbarian = 
- # Requires translation!
-Barbarians = 
- # Requires translation!
-Embarked = 
- # Requires translation!
-land units = 
- # Requires translation!
-Military = 
-# Deprecated since 3.15.2, but should still be translated until it is officially removed
- # Requires translation!
-military water = 
- # Requires translation!
-non-air = 
- # Requires translation!
-Nuclear Weapon = 
- # Requires translation!
-Submarine = 
- # Requires translation!
-submarine units = 
- # Requires translation!
-Unbuildable = 
- # Requires translation!
-water units = 
- # Requires translation!
-wounded units = 
- # Requires translation!
-Wounded = 
-
-# For the "All newly-trained [relevant] units in this city receive the [] promotion" translation. Relevant as in 'units that can receive'
- # Requires translation!
-relevant = 
-
-# For "May choose [amount] additional [beliefType] beliefs when [founding/enhancing] a religion"
- # Requires translation!
-founding = 
- # Requires translation!
-enhancing = 
 
 # Promotions
 
@@ -2219,6 +2052,8 @@ Pick promotion =
 units in open terrain = 
  # Requires translation!
 units in rough terrain = 
+ # Requires translation!
+wounded units = 
  # Requires translation!
 Targeting II (air) = 
  # Requires translation!
@@ -2393,6 +2228,13 @@ Never destroyed when the city is captured =
  # Requires translation!
 Invisible to others = 
 
+# Unused Resources
+
+ # Requires translation!
+Bison = 
+ # Requires translation!
+Cocoa = 
+
 
 # In English we just paste all these conditionals at the end of each unique, but in your language that
 # may not turn into valid sentences. Therefore we have the following two translations to determine
@@ -2422,6 +2264,46 @@ ConditionalsPlacement =
 
 ########################### AUTOMATICALLY GENERATED TRANSLATABLE STRINGS ########################### 
 
+
+######### Map Unit Filters ###########
+
+ # Requires translation!
+Wounded = 
+ # Requires translation!
+Barbarians = 
+ # Requires translation!
+City-State = 
+ # Requires translation!
+Embarked = 
+ # Requires translation!
+Non-City = 
+
+######### Unit Type Filters ###########
+
+ # Requires translation!
+Military = 
+Civilian = Sibilyan
+ # Requires translation!
+non-air = 
+ # Requires translation!
+relevant = 
+ # Requires translation!
+Nuclear Weapon = 
+City = Lungsod
+ # Requires translation!
+Air = 
+ # Requires translation!
+land units = 
+ # Requires translation!
+water units = 
+ # Requires translation!
+air units = 
+ # Requires translation!
+military units = 
+ # Requires translation!
+submarine units = 
+ # Requires translation!
+Barbarian = 
 
 ######### City filters ###########
 
@@ -2457,6 +2339,91 @@ in holy cities =
 in City-State cities = 
  # Requires translation!
 in cities following this religion = 
+
+######### Population Filters ###########
+
+ # Requires translation!
+Unemployed = 
+ # Requires translation!
+Followers of the Majority Religion = 
+ # Requires translation!
+Followers of this Religion = 
+
+######### Terrain Filters ###########
+
+ # Requires translation!
+All = 
+ # Requires translation!
+Coastal = 
+ # Requires translation!
+River = 
+ # Requires translation!
+Open terrain = 
+ # Requires translation!
+Rough terrain = 
+ # Requires translation!
+Water resource = 
+ # Requires translation!
+Foreign Land = 
+ # Requires translation!
+Foreign = 
+ # Requires translation!
+Friendly Land = 
+ # Requires translation!
+Enemy Land = 
+ # Requires translation!
+Featureless = 
+ # Requires translation!
+Fresh Water = 
+ # Requires translation!
+non-fresh water = 
+ # Requires translation!
+Natural Wonder = 
+ # Requires translation!
+Impassable = 
+ # Requires translation!
+Land = 
+ # Requires translation!
+Water = 
+ # Requires translation!
+Luxury resource = 
+ # Requires translation!
+Strategic resource = 
+ # Requires translation!
+Bonus resource = 
+
+######### Tile Filters ###########
+
+ # Requires translation!
+unimproved = 
+ # Requires translation!
+All Road = 
+ # Requires translation!
+Great Improvement = 
+
+######### Region Types ###########
+
+ # Requires translation!
+Hybrid = 
+
+######### Terrain Quality ###########
+
+ # Requires translation!
+Undesirable = 
+ # Requires translation!
+Desirable = 
+
+######### Improvement Filters ###########
+
+ # Requires translation!
+Great = 
+
+######### Prophet Action Filters ###########
+
+ # Requires translation!
+founding = 
+ # Requires translation!
+enhancing = 
 
 ######### Unique Specials ###########
 
@@ -2497,6 +2464,8 @@ Temple of Artemis =
 The Great Lighthouse = 
  # Requires translation!
 'They that go down to the sea in ships, that do business in great waters; these see the works of the Lord, and his wonders in the deep.' - The Bible, Psalms 107:23-24 = 
+ # Requires translation!
+for [mapUnitFilter] units = 
  # Requires translation!
 [amount] Movement = 
  # Requires translation!
@@ -2574,6 +2543,10 @@ Krepost =
 Statue of Zeus = 
  # Requires translation!
 'He spoke, the son of Kronos, and nodded his head with the dark brows, and the immortally anointed hair of the great god swept from his divine head, and all Olympos was shaken' - The Iliad = 
+ # Requires translation!
+vs cities = 
+ # Requires translation!
+when attacking = 
  # Requires translation!
 [amount]% Strength = 
 
@@ -2731,12 +2704,16 @@ Castle =
  # Requires translation!
 Mughal Fort = 
  # Requires translation!
+after discovering [tech] = 
+ # Requires translation!
 [stats] [cityFilter] = 
 
  # Requires translation!
 Himeji Castle = 
  # Requires translation!
 'Bushido is realized in the presence of death. This means choosing death whenever there is a choice between life and death. There is no other reasoning.' - Yamamoto Tsunetomo = 
+ # Requires translation!
+when fighting in [tileFilter] tiles = 
 
  # Requires translation!
 Ironworks = 
@@ -2902,6 +2879,8 @@ Pentagon =
  # Requires translation!
 Solar Plant = 
  # Requires translation!
+in cities without a [buildingFilter] = 
+ # Requires translation!
 Only available = 
 
  # Requires translation!
@@ -2953,6 +2932,7 @@ Era Starting Unit =
 
  # Requires translation!
 Emperor = 
+Scout = Scout
 
  # Requires translation!
 Immortal = 
@@ -3003,9 +2983,6 @@ Information era =
 
  # Requires translation!
 Future era = 
-
-
-#################### Lines from GlobalUniques from Civ V - Vanilla ####################
 
 
 #################### Lines from Nations from Civ V - Vanilla ####################
@@ -3666,6 +3643,8 @@ Bourges =
 Calais = 
  # Requires translation!
 France = 
+ # Requires translation!
+before discovering [tech] = 
 
  # Requires translation!
 Catherine = 
@@ -3773,7 +3752,7 @@ Double quantity of [resource] produced =
  # Requires translation!
 Augustus Caesar = 
  # Requires translation!
-My treasury contains little and my soldiers are getting impatient... ...therefore you must die. = 
+My treasury contains little and my soldiers are getting impatient... (sigh) ...therefore you must die. = 
  # Requires translation!
 So brave, yet so stupid! If only you had a brain similar to your courage. = 
  # Requires translation!
@@ -4829,6 +4808,8 @@ Patigrbana =
 Phrada = 
  # Requires translation!
 Persia = 
+ # Requires translation!
+during a Golden Age = 
 
  # Requires translation!
 Kamehameha I = 
@@ -4932,6 +4913,8 @@ Pileni =
 Nukumanu = 
  # Requires translation!
 Polynesia = 
+ # Requires translation!
+starting from the [era] = 
  # Requires translation!
 Enables embarkation for land units = 
  # Requires translation!
@@ -5839,6 +5822,8 @@ Oligarchy =
  # Requires translation!
 Units in cities cost no Maintenance = 
  # Requires translation!
+with a garrison = 
+ # Requires translation!
 [amount]% Strength for cities = 
  # Requires translation!
 Landed Elite = 
@@ -5877,6 +5862,8 @@ Warrior Code =
  # Requires translation!
 Discipline = 
  # Requires translation!
+when adjacent to a [mapUnitFilter] unit = 
+ # Requires translation!
 Military Tradition = 
  # Requires translation!
 [amount]% XP gained from combat = 
@@ -5888,6 +5875,8 @@ Professional Army =
 Honor Complete = 
  # Requires translation!
 Honor = 
+ # Requires translation!
+vs [mapUnitFilter] units = 
  # Requires translation!
 Notified of new Barbarian encampments = 
 
@@ -5909,6 +5898,8 @@ Free Religion =
 Piety Complete = 
  # Requires translation!
 Piety = 
+ # Requires translation!
+before adopting [policy] = 
 
  # Requires translation!
 Philantropy = 
@@ -5981,12 +5972,16 @@ Rationalism Complete =
  # Requires translation!
 Rationalism = 
  # Requires translation!
+while the empire is happy = 
+ # Requires translation!
 [amount]% [stat] = 
 
  # Requires translation!
 Constitution = 
  # Requires translation!
 Universal Suffrage = 
+ # Requires translation!
+when defending = 
  # Requires translation!
 Civil Society = 
  # Requires translation!
@@ -6020,6 +6015,8 @@ Police State =
 Total War = 
  # Requires translation!
 Autocracy Complete = 
+ # Requires translation!
+for [amount] turns = 
  # Requires translation!
 Autocracy = 
  # Requires translation!
@@ -6060,42 +6057,42 @@ We feel threatened by a Barbarian Camp near our city. Please take care of it. =
  # Requires translation!
 Connect Resource = 
  # Requires translation!
-In order to make our civilizations stronger, connect [param] to your trade network. = 
+In order to make our civilizations stronger, connect [tileResource] to your trade network. = 
 
  # Requires translation!
 Construct Wonder = 
  # Requires translation!
-We recommend you to start building [param] to show the whole world your civilization strength. = 
+We recommend you to start building [wonder] to show the whole world your civilization strength. = 
 
  # Requires translation!
 Acquire Great Person = 
  # Requires translation!
-Great People can change the course of a Civilization! You will be rewarded for acquiring a new [param]. = 
+Great People can change the course of a Civilization! You will be rewarded for acquiring a new [greatPerson]. = 
 
  # Requires translation!
 Conquer City State = 
  # Requires translation!
-It's time to erase the City-State of [param] from the map. You will be greatly rewarded for conquering them! = 
+It's time to erase the City-State of [cityState] from the map. You will be greatly rewarded for conquering them! = 
 
  # Requires translation!
 Find Player = 
  # Requires translation!
-You have yet to discover where [param] set up their cities. You will be rewarded for finding their territories. = 
+You have yet to discover where [civName] set up their cities. You will be rewarded for finding their territories. = 
 
  # Requires translation!
 Find Natural Wonder = 
  # Requires translation!
-Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [param] yet. = 
+Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [naturalWonder] yet. = 
 
  # Requires translation!
 Give Gold = 
  # Requires translation!
-We are suffering great poverty after being robbed by [param], and unless we receive a sum of Gold, it's only a matter of time before we collapse. = 
+We are suffering great poverty after being robbed by [civName], and unless we receive a sum of Gold, it's only a matter of time before we collapse. = 
 
  # Requires translation!
 Pledge to Protect = 
  # Requires translation!
-We need your protection to stop the aggressions of [param]. By signing a Pledge of Protection, you'll confirm the bond that ties us. = 
+We need your protection to stop the aggressions of [civName]. By signing a Pledge of Protection, you'll confirm the bond that ties us. = 
 
  # Requires translation!
 Contest Culture = 
@@ -6115,20 +6112,20 @@ The civilization with the largest number of new Technologies researched will gai
  # Requires translation!
 Invest = 
  # Requires translation!
-Our people are rejoicing thanks to a tourism boom. For a certain amount of time, any Gold donation will yield [amount]% extra Influence. = 
+Our people are rejoicing thanks to a tourism boom. For a certain amount of time, any Gold donation will yield [50]% extra Influence. = 
 
  # Requires translation!
 Bully City State = 
  # Requires translation!
-We are tired of the pretensions of [param]. If someone were to put them in their place by Demanding Tribute from them, they would be rewarded. = 
+We are tired of the pretensions of [cityState]. If someone were to put them in their place by Demanding Tribute from them, they would be rewarded. = 
 
  # Requires translation!
 Denounce Civilization = 
  # Requires translation!
-We have been forced to pay tribute to [param]! We need you to tell the world of their ill deeds. = 
+We have been forced to pay tribute to [civName]! We need you to tell the world of their ill deeds. = 
 
  # Requires translation!
-We have heard the tenets of [param] and are most curious. Will you send missionaries to teach us about your religion? = 
+We have heard the tenets of [religionName] and are most curious. Will you send missionaries to teach us about your religion? = 
 
 
 #################### Lines from Ruins from Civ V - Vanilla ####################
@@ -6150,12 +6147,12 @@ An ancient tribe trained us in their ways of combat! =
 your exploring unit receives training = 
 
  # Requires translation!
-We have found survivors in the ruins! Population added to [param]. = 
+We have found survivors in the ruins! Population added to [cityName]. = 
  # Requires translation!
 survivors (adds population to a city) = 
 
  # Requires translation!
-We have found a stash of [param] Gold in the ruins! = 
+We have found a stash of [goldAmount] Gold in the ruins! = 
  # Requires translation!
 a stash of gold = 
 
@@ -6550,6 +6547,8 @@ Desert =
 
  # Requires translation!
 Lakes = 
+ # Requires translation!
+Fresh water = 
 
  # Requires translation!
 Mountain = 
@@ -6582,6 +6581,8 @@ Jungle =
 
  # Requires translation!
 Marsh = 
+ # Requires translation!
+Rare feature = 
  # Requires translation!
 Only Polders can be built here = 
 
@@ -6886,6 +6887,10 @@ Porcelain =
  # Requires translation!
 Sword = 
  # Requires translation!
+Mounted = 
+ # Requires translation!
+Siege = 
+ # Requires translation!
 Ranged Gunpowder = 
  # Requires translation!
 Armored = 
@@ -6893,6 +6898,8 @@ Armored =
 Melee Water = 
  # Requires translation!
 Ranged Water = 
+ # Requires translation!
+Submarine = 
  # Requires translation!
 Heal Instantly = 
  # Requires translation!
@@ -6985,6 +6992,8 @@ All adjacent units heal [amount] HP when healing =
 
  # Requires translation!
 Medic II = 
+ # Requires translation!
+in [tileFilter] tiles = 
  # Requires translation!
 [amount] HP when healing = 
 
@@ -7079,6 +7088,8 @@ Supply =
 May heal outside of friendly territory = 
 
  # Requires translation!
+Bomber = 
+ # Requires translation!
 Siege I = 
 
  # Requires translation!
@@ -7092,6 +7103,8 @@ Evasion =
  # Requires translation!
 Damage taken from interception reduced by [amount]% = 
 
+ # Requires translation!
+Fighter = 
  # Requires translation!
 Interception I = 
  # Requires translation!
@@ -7237,12 +7250,40 @@ Can see over obstacles =
 Atomic Bomber = 
 
  # Requires translation!
+Missile = 
+ # Requires translation!
 Self-destructs when attacking = 
  # Requires translation!
 Cannot be intercepted = 
 
  # Requires translation!
 Can pass through impassable tiles = 
+
+ # Requires translation!
+Melee = 
+
+Ranged = Ranged
+
+ # Requires translation!
+Armor = 
+
+ # Requires translation!
+WaterCivilian = 
+
+ # Requires translation!
+WaterMelee = 
+
+ # Requires translation!
+WaterRanged = 
+
+ # Requires translation!
+WaterSubmarine = 
+
+ # Requires translation!
+WaterAircraftCarrier = 
+
+ # Requires translation!
+AtomicBomber = 
 
 
 #################### Lines from Units from Civ V - Vanilla ####################
@@ -7361,6 +7402,8 @@ Camel Archer =
 
  # Requires translation!
 Conquistador = 
+ # Requires translation!
+on foreign continents = 
 
  # Requires translation!
 Naresuan's Elephant = 
@@ -7497,6 +7540,8 @@ Atomic Bomb =
  # Requires translation!
 Nuclear weapon of Strength [amount] = 
  # Requires translation!
+if [buildingName] is constructed = 
+ # Requires translation!
 Blast radius [amount] = 
 
  # Requires translation!
@@ -7551,6 +7596,8 @@ Can start an [amount]-turn golden age =
 Can construct [improvementName] = 
  # Requires translation!
 Great Person - [stat] = 
+ # Requires translation!
+Unbuildable = 
 
  # Requires translation!
 Great Scientist = 
@@ -7646,6 +7693,8 @@ Fertility Rites =
 
  # Requires translation!
 God of Craftsman = 
+ # Requires translation!
+in cities with at least [amount] [populationFilter] = 
 
  # Requires translation!
 God of the Open Sky = 
@@ -7726,6 +7775,8 @@ Guruship =
  # Requires translation!
 Holy Warriors = 
  # Requires translation!
+before the [era] = 
+ # Requires translation!
 May buy [baseUnitFilter] units with [stat] for [amount] times their normal Production cost = 
 
  # Requires translation!
@@ -7756,6 +7807,8 @@ Religious Community =
 
  # Requires translation!
 Swords into Ploughshares = 
+ # Requires translation!
+when not at war = 
 
  # Requires translation!
 Founder = 
@@ -7954,9 +8007,6 @@ Starting in this era disables religion =
 
  # Requires translation!
 Marine = 
-
-
-#################### Lines from GlobalUniques from Civ V - Gods & Kings ####################
 
 
 #################### Lines from Nations from Civ V - Gods & Kings ####################
@@ -8580,6 +8630,8 @@ Falmouth =
 Lorient = 
  # Requires translation!
 Celts = 
+ # Requires translation!
+with [amount] to [amount2] neighboring [tileFilter] [tileFilter2] tiles = 
 
  # Requires translation!
 Haile Selassie = 
@@ -8667,6 +8719,8 @@ Ziway =
 Weldiya = 
  # Requires translation!
 Ethiopia = 
+ # Requires translation!
+when fighting units from a Civilization with more Cities than you = 
 
  # Requires translation!
 Pacal = 
@@ -8814,12 +8868,12 @@ Taoism =
 
 
  # Requires translation!
-We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[param] Faith) = 
+We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[faithAmount] Faith) = 
  # Requires translation!
 discover holy symbols = 
 
  # Requires translation!
-We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[param] Faith) = 
+We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[faithAmount] Faith) = 
  # Requires translation!
 an ancient prophecy = 
 
@@ -8900,7 +8954,19 @@ Polder =
 
 
  # Requires translation!
+Citrus = 
+
+ # Requires translation!
+Copper = 
+
+ # Requires translation!
+Crab = 
+
+ # Requires translation!
 Salt = 
+
+ # Requires translation!
+Truffles = 
 
 
 #################### Lines from UnitPromotions from Civ V - Gods & Kings ####################
@@ -9462,13 +9528,7 @@ Irremovable =
  # Requires translation!
 when at war = 
  # Requires translation!
-when not at war = 
- # Requires translation!
-during a Golden Age = 
- # Requires translation!
 with [resource] = 
- # Requires translation!
-while the empire is happy = 
  # Requires translation!
 when between [amount] and [amount2] Happiness = 
  # Requires translation!
@@ -9476,67 +9536,25 @@ when below [amount] Happiness =
  # Requires translation!
 during the [era] = 
  # Requires translation!
-before the [era] = 
- # Requires translation!
-starting from the [era] = 
- # Requires translation!
 if no other Civilization has researched this = 
- # Requires translation!
-after discovering [tech] = 
- # Requires translation!
-before discovering [tech] = 
  # Requires translation!
 upon discovering [tech] = 
  # Requires translation!
 after adopting [policy] = 
  # Requires translation!
-before adopting [policy] = 
- # Requires translation!
-if [buildingName] is constructed = 
- # Requires translation!
-for [amount] turns = 
- # Requires translation!
 by consuming this unit = 
  # Requires translation!
 in cities with a [buildingFilter] = 
  # Requires translation!
-in cities without a [buildingFilter] = 
- # Requires translation!
-in cities with at least [amount] [populationFilter] = 
- # Requires translation!
-with a garrison = 
- # Requires translation!
-for [mapUnitFilter] units = 
- # Requires translation!
 for units with [promotion] = 
  # Requires translation!
 for units without [promotion] = 
- # Requires translation!
-vs cities = 
- # Requires translation!
-vs [mapUnitFilter] units = 
- # Requires translation!
-when fighting units from a Civilization with more Cities than you = 
- # Requires translation!
-when attacking = 
- # Requires translation!
-when defending = 
- # Requires translation!
-when fighting in [tileFilter] tiles = 
- # Requires translation!
-on foreign continents = 
- # Requires translation!
-when adjacent to a [mapUnitFilter] unit = 
  # Requires translation!
 when above [amount] HP = 
  # Requires translation!
 when below [amount] HP = 
  # Requires translation!
 with [amount] to [amount2] neighboring [tileFilter] tiles = 
- # Requires translation!
-with [amount] to [amount2] neighboring [tileFilter] [tileFilter2] tiles = 
- # Requires translation!
-in [tileFilter] tiles = 
  # Requires translation!
 in [tileFilter] [tileFilter2] tiles = 
  # Requires translation!

--- a/android/assets/jsons/translations/Finnish.properties
+++ b/android/assets/jsons/translations/Finnish.properties
@@ -1333,8 +1333,6 @@ or [terrainType] =
 Can be constructed by = 
 Defence bonus = Puolustusbonus
 Movement cost = Liikkumisen hinta
-Open terrain = Avoin maasto
-Rough Terrain = Vaikea Maasto
  # Requires translation!
 for = 
 Missing translations: = Puuttuvat käännökset
@@ -1514,125 +1512,6 @@ Enhancing religion =
  # Requires translation!
 Enhanced religion = 
 
-# Terrains
-
-Impassable = Läpikulkematon
- # Requires translation!
-Rare feature = 
-
-# terrainFilters (so for uniques like: "[stats] from [terrainFilter] tiles")
-
-All = Kaikki
-Water = Vesi
-Land = Maa
-Coastal = Rannikko
-River = Joki
- # Requires translation!
-Rough terrain = 
-Foreign Land = Vierailla Mailla
- # Requires translation!
-Foreign = 
-Friendly Land = Omilla mailla
-Water resource = Vesiresurssi
-Bonus resource = Bonusresurssi
- # Requires translation!
-Luxury resource = 
-Strategic resource = Strateginen resurssi
-Fresh water = Makeavesi
-non-fresh water = suolavesi
-Natural Wonder = Kansallisihme
- # Requires translation!
-Hybrid = 
- # Requires translation!
-Undesirable = 
- # Requires translation!
-Desirable = 
- # Requires translation!
-Featureless = 
- # Requires translation!
-Fresh Water = 
-
-# improvementFilters
-
- # Requires translation!
-All Road = 
-Great Improvement = Merkittävä parannus
-Great = Suuri
-
-# Resources
-
-Bison = Biisoni
-Copper = Kupari
-Cocoa = Kaakao
-Crab = Ravut
-Citrus = Sitrukset
-Truffles = Tryffelit
-Strategic = Strateginen
-Bonus = Bonus
- # Requires translation!
-Luxury = 
-
-# Unit types
-
-City = Kaupungit
-Civilian = Siviilit
-Melee = Lähitaistelu
-Ranged = Pitkän kantaman yksiköt
-Scout = Tiedustelija
-Mounted = Ratsailla olevat
-Armor = Panssaroidut
-Siege = Piirityskone
-
-WaterCivilian = Siviililaivat
-WaterMelee = Vesilähitaistelu
-WaterRanged = Laivaston pitkän kantaman yksiköt
-WaterSubmarine = Laivaston sukellusveneet
-WaterAircraftCarrier = Lentotukialukset
-
-Fighter = Hävittäjä
-Bomber = Pommikone
-AtomicBomber = Ydinpommittaja
-Missile = Ohjukset
-
-
-# Unit filters and other unit related things
-
- # Requires translation!
-Air = 
-air units = lentoyksiköt
- # Requires translation!
-Barbarian = 
-Barbarians = Barbaarit
- # Requires translation!
-Embarked = 
-land units = maayksiköt
- # Requires translation!
-Military = 
-# Deprecated since 3.15.2, but should still be translated until it is officially removed
- # Requires translation!
-military water = 
- # Requires translation!
-non-air = 
- # Requires translation!
-Nuclear Weapon = 
-Submarine = Sukellusvene
- # Requires translation!
-submarine units = 
-Unbuildable = Ei rakennettavissa
-water units = laivaston yksiköt
-wounded units = haavoittuneet yksiköt
- # Requires translation!
-Wounded = 
-
-# For the "All newly-trained [relevant] units in this city receive the [] promotion" translation. Relevant as in 'units that can receive'
- # Requires translation!
-relevant = 
-
-# For "May choose [amount] additional [beliefType] beliefs when [founding/enhancing] a religion"
- # Requires translation!
-founding = 
- # Requires translation!
-enhancing = 
 
 # Promotions
 
@@ -1640,6 +1519,7 @@ Pick promotion = Valitse ylennys
  OR  = TAI
 units in open terrain = yksiköt avoimessa maastossa
 units in rough terrain = yksiköt vaikeassa maastossa
+wounded units = haavoittuneet yksiköt
 Targeting II (air) = Kohdennus II (ilma)
 Targeting III (air) = Kohdennus III (ilma)
 Bonus when performing air sweep [bonusAmount]% = Bonus tiedustelulennolla [bonusAmount]%
@@ -1798,6 +1678,11 @@ Never destroyed when the city is captured =
  # Requires translation!
 Invisible to others = 
 
+# Unused Resources
+
+Bison = Biisoni
+Cocoa = Kaakao
+
 
 # In English we just paste all these conditionals at the end of each unique, but in your language that
 # may not turn into valid sentences. Therefore we have the following two translations to determine
@@ -1827,6 +1712,42 @@ ConditionalsPlacement =
 
 ########################### AUTOMATICALLY GENERATED TRANSLATABLE STRINGS ########################### 
 
+
+######### Map Unit Filters ###########
+
+ # Requires translation!
+Wounded = 
+Barbarians = Barbaarit
+ # Requires translation!
+City-State = 
+ # Requires translation!
+Embarked = 
+ # Requires translation!
+Non-City = 
+
+######### Unit Type Filters ###########
+
+ # Requires translation!
+Military = 
+Civilian = Siviilit
+ # Requires translation!
+non-air = 
+ # Requires translation!
+relevant = 
+ # Requires translation!
+Nuclear Weapon = 
+City = Kaupungit
+ # Requires translation!
+Air = 
+land units = maayksiköt
+water units = laivaston yksiköt
+air units = lentoyksiköt
+ # Requires translation!
+military units = 
+ # Requires translation!
+submarine units = 
+ # Requires translation!
+Barbarian = 
 
 ######### City filters ###########
 
@@ -1863,6 +1784,75 @@ in City-State cities =
  # Requires translation!
 in cities following this religion = 
 
+######### Population Filters ###########
+
+ # Requires translation!
+Unemployed = 
+ # Requires translation!
+Followers of the Majority Religion = 
+ # Requires translation!
+Followers of this Religion = 
+
+######### Terrain Filters ###########
+
+All = Kaikki
+Coastal = Rannikko
+River = Joki
+Open terrain = Avoin maasto
+ # Requires translation!
+Rough terrain = 
+Water resource = Vesiresurssi
+Foreign Land = Vierailla Mailla
+ # Requires translation!
+Foreign = 
+Friendly Land = Omilla mailla
+ # Requires translation!
+Enemy Land = 
+ # Requires translation!
+Featureless = 
+ # Requires translation!
+Fresh Water = 
+non-fresh water = suolavesi
+Natural Wonder = Kansallisihme
+Impassable = Läpikulkematon
+Land = Maa
+Water = Vesi
+ # Requires translation!
+Luxury resource = 
+Strategic resource = Strateginen resurssi
+Bonus resource = Bonusresurssi
+
+######### Tile Filters ###########
+
+ # Requires translation!
+unimproved = 
+ # Requires translation!
+All Road = 
+Great Improvement = Merkittävä parannus
+
+######### Region Types ###########
+
+ # Requires translation!
+Hybrid = 
+
+######### Terrain Quality ###########
+
+ # Requires translation!
+Undesirable = 
+ # Requires translation!
+Desirable = 
+
+######### Improvement Filters ###########
+
+Great = Suuri
+
+######### Prophet Action Filters ###########
+
+ # Requires translation!
+founding = 
+ # Requires translation!
+enhancing = 
+
 ######### Unique Specials ###########
 
  # Requires translation!
@@ -1897,6 +1887,8 @@ Temple of Artemis =
 The Great Lighthouse = Faroksen majakka
  # Requires translation!
 'They that go down to the sea in ships, that do business in great waters; these see the works of the Lord, and his wonders in the deep.' - The Bible, Psalms 107:23-24 = 
+ # Requires translation!
+for [mapUnitFilter] units = 
  # Requires translation!
 [amount] Movement = 
  # Requires translation!
@@ -1958,6 +1950,10 @@ Krepost = Krepost
 Statue of Zeus = Zeuksen Patsas
  # Requires translation!
 'He spoke, the son of Kronos, and nodded his head with the dark brows, and the immortally anointed hair of the great god swept from his divine head, and all Olympos was shaken' - The Iliad = 
+ # Requires translation!
+vs cities = 
+ # Requires translation!
+when attacking = 
  # Requires translation!
 [amount]% Strength = 
 
@@ -2091,11 +2087,15 @@ Castle = Linna
  # Requires translation!
 Mughal Fort = 
  # Requires translation!
+after discovering [tech] = 
+ # Requires translation!
 [stats] [cityFilter] = 
 
 Himeji Castle = Himejin Linna
  # Requires translation!
 'Bushido is realized in the presence of death. This means choosing death whenever there is a choice between life and death. There is no other reasoning.' - Yamamoto Tsunetomo = 
+ # Requires translation!
+when fighting in [tileFilter] tiles = 
 
 Ironworks = Rautaruukki
 
@@ -2228,6 +2228,8 @@ Pentagon = Pentagon
 
 Solar Plant = Aurinkovoimala
  # Requires translation!
+in cities without a [buildingFilter] = 
+ # Requires translation!
 Only available = 
 
 Nuclear Plant = Ydinvoimala
@@ -2269,6 +2271,7 @@ King = Kuningas
 Era Starting Unit = 
 
 Emperor = Keisari
+Scout = Tiedustelija
 
 Immortal = Kuolematon
 Worker = Työmies
@@ -2311,9 +2314,6 @@ Information era =
 
  # Requires translation!
 Future era = 
-
-
-#################### Lines from GlobalUniques from Civ V - Vanilla ####################
 
 
 #################### Lines from Nations from Civ V - Vanilla ####################
@@ -2664,6 +2664,8 @@ La Rochelle = La Rochelle
 Bourges = Bourges
 Calais = Calais
 France = Ranska
+ # Requires translation!
+before discovering [tech] = 
 
 Catherine = Katariina
 You've behaved yourself very badly, you know it. Now it's payback time. = Olet käyttäytynyt todella huonosti. Nyt on takaisinmaksun aika.
@@ -2721,7 +2723,7 @@ Double quantity of [resource] produced = [resource] tuottavat resurssit tuplana
 
 Augustus Caesar = Augustus Caesar
  # Requires translation!
-My treasury contains little and my soldiers are getting impatient... ...therefore you must die. = 
+My treasury contains little and my soldiers are getting impatient... (sigh) ...therefore you must die. = 
 So brave, yet so stupid! If only you had a brain similar to your courage. = Niin uhrea mutta niin tyhmä! Voi kunpa aivosi vetäisivät vertoja rohkeudellesi.
 The gods have deprived Rome of their favour. We have been defeated. = Jumalat ovat hyljänneet Rooman. Meidät on kukistettu.
 I greet you. I am Augustus, Imperator and Pontifex Maximus of Rome. If you are a friend of Rome, you are welcome. = Tervehdin teitä. Olen Augustus, Rooman Imperaattori ja Pontifex Maximus. Jos olette Rooman ystävä, olette tervetulleet.
@@ -3378,6 +3380,8 @@ Patigrbana =
  # Requires translation!
 Phrada = 
 Persia = Persia
+ # Requires translation!
+during a Golden Age = 
 
 Kamehameha I = Kamehameha I
 The ancient fire flashing across the sky is what proclaimed that this day would come, though I had foolishly hoped for a different outcome. = Muinainen liekki taivalla ennusti että tämä päivä tulisi, mutta typeryydessäni toivoin eri lopputulosta.
@@ -3471,6 +3475,8 @@ Pileni =
  # Requires translation!
 Nukumanu = 
 Polynesia = Polynesia
+ # Requires translation!
+starting from the [era] = 
 Enables embarkation for land units = Sallii kuivan maan yksiköiden vesille siirtymisen
  # Requires translation!
 Enables [mapUnitFilter] units to enter ocean tiles = 
@@ -4339,6 +4345,8 @@ Provides the cheapest [stat] building in your first [amount] cities for free =
 Oligarchy = 
 Units in cities cost no Maintenance = Yksiköt eivät maksa Ylläpitoa kaupungeissa.
  # Requires translation!
+with a garrison = 
+ # Requires translation!
 [amount]% Strength for cities = 
 Landed Elite = Maanomistajien Eliitti
  # Requires translation!
@@ -4371,6 +4379,8 @@ Liberty =
 Warrior Code = Soturin Säännöstö
  # Requires translation!
 Discipline = 
+ # Requires translation!
+when adjacent to a [mapUnitFilter] unit = 
 Military Tradition = Sodankäynnin Perinteet
  # Requires translation!
 [amount]% XP gained from combat = 
@@ -4380,6 +4390,8 @@ Professional Army =
 Honor Complete = Kunnia valmis
  # Requires translation!
 Honor = 
+ # Requires translation!
+vs [mapUnitFilter] units = 
  # Requires translation!
 Notified of new Barbarian encampments = 
 
@@ -4397,6 +4409,8 @@ Free Religion = Uskonvapaus
 Piety Complete = Hartaus valmis
  # Requires translation!
 Piety = 
+ # Requires translation!
+before adopting [policy] = 
 
  # Requires translation!
 Philantropy = 
@@ -4467,11 +4481,15 @@ Rationalism Complete =
  # Requires translation!
 Rationalism = 
  # Requires translation!
+while the empire is happy = 
+ # Requires translation!
 [amount]% [stat] = 
 
 Constitution = Perustuslaki
  # Requires translation!
 Universal Suffrage = 
+ # Requires translation!
+when defending = 
 Civil Society = Kansalaisyhteiskunta
  # Requires translation!
 [amount]% Food consumption by specialists [cityFilter] = 
@@ -4500,6 +4518,8 @@ Police State =
 Total War = 
  # Requires translation!
 Autocracy Complete = 
+ # Requires translation!
+for [amount] turns = 
  # Requires translation!
 Autocracy = 
  # Requires translation!
@@ -4540,42 +4560,42 @@ We feel threatened by a Barbarian Camp near our city. Please take care of it. =
  # Requires translation!
 Connect Resource = 
  # Requires translation!
-In order to make our civilizations stronger, connect [param] to your trade network. = 
+In order to make our civilizations stronger, connect [tileResource] to your trade network. = 
 
  # Requires translation!
 Construct Wonder = 
  # Requires translation!
-We recommend you to start building [param] to show the whole world your civilization strength. = 
+We recommend you to start building [wonder] to show the whole world your civilization strength. = 
 
  # Requires translation!
 Acquire Great Person = 
  # Requires translation!
-Great People can change the course of a Civilization! You will be rewarded for acquiring a new [param]. = 
+Great People can change the course of a Civilization! You will be rewarded for acquiring a new [greatPerson]. = 
 
  # Requires translation!
 Conquer City State = 
  # Requires translation!
-It's time to erase the City-State of [param] from the map. You will be greatly rewarded for conquering them! = 
+It's time to erase the City-State of [cityState] from the map. You will be greatly rewarded for conquering them! = 
 
  # Requires translation!
 Find Player = 
  # Requires translation!
-You have yet to discover where [param] set up their cities. You will be rewarded for finding their territories. = 
+You have yet to discover where [civName] set up their cities. You will be rewarded for finding their territories. = 
 
  # Requires translation!
 Find Natural Wonder = 
  # Requires translation!
-Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [param] yet. = 
+Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [naturalWonder] yet. = 
 
  # Requires translation!
 Give Gold = 
  # Requires translation!
-We are suffering great poverty after being robbed by [param], and unless we receive a sum of Gold, it's only a matter of time before we collapse. = 
+We are suffering great poverty after being robbed by [civName], and unless we receive a sum of Gold, it's only a matter of time before we collapse. = 
 
  # Requires translation!
 Pledge to Protect = 
  # Requires translation!
-We need your protection to stop the aggressions of [param]. By signing a Pledge of Protection, you'll confirm the bond that ties us. = 
+We need your protection to stop the aggressions of [civName]. By signing a Pledge of Protection, you'll confirm the bond that ties us. = 
 
  # Requires translation!
 Contest Culture = 
@@ -4595,20 +4615,20 @@ The civilization with the largest number of new Technologies researched will gai
  # Requires translation!
 Invest = 
  # Requires translation!
-Our people are rejoicing thanks to a tourism boom. For a certain amount of time, any Gold donation will yield [amount]% extra Influence. = 
+Our people are rejoicing thanks to a tourism boom. For a certain amount of time, any Gold donation will yield [50]% extra Influence. = 
 
  # Requires translation!
 Bully City State = 
  # Requires translation!
-We are tired of the pretensions of [param]. If someone were to put them in their place by Demanding Tribute from them, they would be rewarded. = 
+We are tired of the pretensions of [cityState]. If someone were to put them in their place by Demanding Tribute from them, they would be rewarded. = 
 
  # Requires translation!
 Denounce Civilization = 
  # Requires translation!
-We have been forced to pay tribute to [param]! We need you to tell the world of their ill deeds. = 
+We have been forced to pay tribute to [civName]! We need you to tell the world of their ill deeds. = 
 
  # Requires translation!
-We have heard the tenets of [param] and are most curious. Will you send missionaries to teach us about your religion? = 
+We have heard the tenets of [religionName] and are most curious. Will you send missionaries to teach us about your religion? = 
 
 
 #################### Lines from Ruins from Civ V - Vanilla ####################
@@ -4630,12 +4650,12 @@ An ancient tribe trained us in their ways of combat! =
 your exploring unit receives training = 
 
  # Requires translation!
-We have found survivors in the ruins! Population added to [param]. = 
+We have found survivors in the ruins! Population added to [cityName]. = 
  # Requires translation!
 survivors (adds population to a city) = 
 
  # Requires translation!
-We have found a stash of [param] Gold in the ruins! = 
+We have found a stash of [goldAmount] Gold in the ruins! = 
  # Requires translation!
 a stash of gold = 
 
@@ -5009,6 +5029,7 @@ Desert =
 
  # Requires translation!
 Lakes = 
+Fresh water = Makeavesi
 
  # Requires translation!
 Mountain = 
@@ -5040,6 +5061,8 @@ A Camp can be built here without cutting it down =
 Jungle = 
 
 Marsh = Suo
+ # Requires translation!
+Rare feature = 
  # Requires translation!
 Only Polders can be built here = 
 
@@ -5281,6 +5304,8 @@ Porcelain =
 
  # Requires translation!
 Sword = 
+Mounted = Ratsailla olevat
+Siege = Piirityskone
  # Requires translation!
 Ranged Gunpowder = 
  # Requires translation!
@@ -5289,6 +5314,7 @@ Armored =
 Melee Water = 
  # Requires translation!
 Ranged Water = 
+Submarine = Sukellusvene
 Heal Instantly = Palaudu välittömästi
  # Requires translation!
 Heal this unit by [amount] HP = 
@@ -5377,6 +5403,8 @@ All adjacent units heal [amount] HP when healing =
  # Requires translation!
 Medic II = 
  # Requires translation!
+in [tileFilter] tiles = 
+ # Requires translation!
 [amount] HP when healing = 
 
 Scouting I = Tiedustelu I
@@ -5464,6 +5492,7 @@ Supply =
  # Requires translation!
 May heal outside of friendly territory = 
 
+Bomber = Pommikone
  # Requires translation!
 Siege I = 
 
@@ -5478,6 +5507,7 @@ Evasion =
  # Requires translation!
 Damage taken from interception reduced by [amount]% = 
 
+Fighter = Hävittäjä
  # Requires translation!
 Interception I = 
  # Requires translation!
@@ -5619,6 +5649,7 @@ Can see over obstacles =
  # Requires translation!
 Atomic Bomber = 
 
+Missile = Ohjukset
  # Requires translation!
 Self-destructs when attacking = 
  # Requires translation!
@@ -5626,6 +5657,24 @@ Cannot be intercepted =
 
  # Requires translation!
 Can pass through impassable tiles = 
+
+Melee = Lähitaistelu
+
+Ranged = Pitkän kantaman yksiköt
+
+Armor = Panssaroidut
+
+WaterCivilian = Siviililaivat
+
+WaterMelee = Vesilähitaistelu
+
+WaterRanged = Laivaston pitkän kantaman yksiköt
+
+WaterSubmarine = Laivaston sukellusveneet
+
+WaterAircraftCarrier = Lentotukialukset
+
+AtomicBomber = Ydinpommittaja
 
 
 #################### Lines from Units from Civ V - Vanilla ####################
@@ -5739,6 +5788,8 @@ Camel Archer =
 
  # Requires translation!
 Conquistador = 
+ # Requires translation!
+on foreign continents = 
 
  # Requires translation!
 Naresuan's Elephant = 
@@ -5867,6 +5918,8 @@ Atomic Bomb = Atomipommi
  # Requires translation!
 Nuclear weapon of Strength [amount] = 
  # Requires translation!
+if [buildingName] is constructed = 
+ # Requires translation!
 Blast radius [amount] = 
 
  # Requires translation!
@@ -5919,6 +5972,7 @@ Can start an [amount]-turn golden age =
 Can construct [improvementName] = 
  # Requires translation!
 Great Person - [stat] = 
+Unbuildable = Ei rakennettavissa
 
  # Requires translation!
 Great Scientist = 
@@ -6008,6 +6062,8 @@ Fertility Rites =
 
  # Requires translation!
 God of Craftsman = 
+ # Requires translation!
+in cities with at least [amount] [populationFilter] = 
 
  # Requires translation!
 God of the Open Sky = 
@@ -6088,6 +6144,8 @@ Guruship =
  # Requires translation!
 Holy Warriors = 
  # Requires translation!
+before the [era] = 
+ # Requires translation!
 May buy [baseUnitFilter] units with [stat] for [amount] times their normal Production cost = 
 
  # Requires translation!
@@ -6118,6 +6176,8 @@ Religious Community =
 
  # Requires translation!
 Swords into Ploughshares = 
+ # Requires translation!
+when not at war = 
 
  # Requires translation!
 Founder = 
@@ -6312,9 +6372,6 @@ Starting in this era disables religion =
 
 
 Marine = Rannikkojääkäri
-
-
-#################### Lines from GlobalUniques from Civ V - Gods & Kings ####################
 
 
 #################### Lines from Nations from Civ V - Gods & Kings ####################
@@ -6938,6 +6995,8 @@ Falmouth =
 Lorient = 
  # Requires translation!
 Celts = 
+ # Requires translation!
+with [amount] to [amount2] neighboring [tileFilter] [tileFilter2] tiles = 
 
  # Requires translation!
 Haile Selassie = 
@@ -7025,6 +7084,8 @@ Ziway =
 Weldiya = 
  # Requires translation!
 Ethiopia = 
+ # Requires translation!
+when fighting units from a Civilization with more Cities than you = 
 
  # Requires translation!
 Pacal = 
@@ -7172,12 +7233,12 @@ Taoism =
 
 
  # Requires translation!
-We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[param] Faith) = 
+We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[faithAmount] Faith) = 
  # Requires translation!
 discover holy symbols = 
 
  # Requires translation!
-We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[param] Faith) = 
+We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[faithAmount] Faith) = 
  # Requires translation!
 an ancient prophecy = 
 
@@ -7257,8 +7318,16 @@ Polder =
 #################### Lines from TileResources from Civ V - Gods & Kings ####################
 
 
+Citrus = Sitrukset
+
+Copper = Kupari
+
+Crab = Ravut
+
  # Requires translation!
 Salt = 
+
+Truffles = Tryffelit
 
 
 #################### Lines from UnitPromotions from Civ V - Gods & Kings ####################
@@ -7814,13 +7883,7 @@ Irremovable =
  # Requires translation!
 when at war = 
  # Requires translation!
-when not at war = 
- # Requires translation!
-during a Golden Age = 
- # Requires translation!
 with [resource] = 
- # Requires translation!
-while the empire is happy = 
  # Requires translation!
 when between [amount] and [amount2] Happiness = 
  # Requires translation!
@@ -7828,67 +7891,25 @@ when below [amount] Happiness =
  # Requires translation!
 during the [era] = 
  # Requires translation!
-before the [era] = 
- # Requires translation!
-starting from the [era] = 
- # Requires translation!
 if no other Civilization has researched this = 
- # Requires translation!
-after discovering [tech] = 
- # Requires translation!
-before discovering [tech] = 
  # Requires translation!
 upon discovering [tech] = 
  # Requires translation!
 after adopting [policy] = 
  # Requires translation!
-before adopting [policy] = 
- # Requires translation!
-if [buildingName] is constructed = 
- # Requires translation!
-for [amount] turns = 
- # Requires translation!
 by consuming this unit = 
  # Requires translation!
 in cities with a [buildingFilter] = 
  # Requires translation!
-in cities without a [buildingFilter] = 
- # Requires translation!
-in cities with at least [amount] [populationFilter] = 
- # Requires translation!
-with a garrison = 
- # Requires translation!
-for [mapUnitFilter] units = 
- # Requires translation!
 for units with [promotion] = 
  # Requires translation!
 for units without [promotion] = 
- # Requires translation!
-vs cities = 
- # Requires translation!
-vs [mapUnitFilter] units = 
- # Requires translation!
-when fighting units from a Civilization with more Cities than you = 
- # Requires translation!
-when attacking = 
- # Requires translation!
-when defending = 
- # Requires translation!
-when fighting in [tileFilter] tiles = 
- # Requires translation!
-on foreign continents = 
- # Requires translation!
-when adjacent to a [mapUnitFilter] unit = 
  # Requires translation!
 when above [amount] HP = 
  # Requires translation!
 when below [amount] HP = 
  # Requires translation!
 with [amount] to [amount2] neighboring [tileFilter] tiles = 
- # Requires translation!
-with [amount] to [amount2] neighboring [tileFilter] [tileFilter2] tiles = 
- # Requires translation!
-in [tileFilter] tiles = 
  # Requires translation!
 in [tileFilter] [tileFilter2] tiles = 
  # Requires translation!
@@ -7967,3 +7988,9 @@ CityState =
 ModOptions = 
  # Requires translation!
 Conditional = 
+
+#################### Removed Lines ####################
+
+#~~Rough Terrain = Vaikea Maasto
+#~~Strategic = Strateginen
+#~~Bonus = Bonus

--- a/android/assets/jsons/translations/French.properties
+++ b/android/assets/jsons/translations/French.properties
@@ -1082,8 +1082,6 @@ or [terrainType] = ou [terrainType]
 Can be constructed by = Peut être construit par
 Defence bonus = Bonus de défense
 Movement cost = Coût de mouvement
-Open terrain = Terrain dégagé
-Rough Terrain = Terrain accidenté
 for = pour
 Missing translations: = Traductions manquantes :
 Resolution = Résolution
@@ -1213,102 +1211,6 @@ Religion = Religion
 Enhancing religion = Renforce une religion
 Enhanced religion = Religion renforcée
 
-# Terrains
-
-Impassable = Infranchissable
-Rare feature = Caractéristique rare
-
-# terrainFilters (so for uniques like: "[stats] from [terrainFilter] tiles")
-
-All = Tout Type
-Water = Navale(s)
-Land = Terrestre(s)
-Coastal = Côtière(s)
-River = Rivière
-Rough terrain = Terrain accidenté
-Foreign Land = Territoire Étranger
-Foreign = Étrangère(s)
-Friendly Land = Territoire Allié
-Water resource = Ressource aquatique
-Bonus resource = Ressource bonus
-Luxury resource = Ressource de luxe
-Strategic resource = Ressource stratégique
-Fresh water = Eau douce
-non-fresh water = Eau salée
-Natural Wonder = Merveille Naturelle
-Hybrid = Hybride
-Undesirable = Indésirable
-Desirable = Attrayant
-Featureless = Sans caractéristique
-Fresh Water = Eau douce
-
-# improvementFilters
-
-All Road = Toute Route
-Great Improvement = Grand Aménagement
-Great = Grand
-
-# Resources
-
-Bison = Bison
-Copper = Cuivre
-Cocoa = Cacao
-Crab = Crabe
-Citrus = Agrumes
-Truffles = Truffes
-Strategic = Stratégique
-Bonus = Bonus
-Luxury = Luxe
-
-# Unit types
-
-City = Ville
-Civilian = Civile(s)
-Melee = Combat rapproché
-Ranged = Combat à distance
-Scout = Éclaireur
-Mounted = Montée(s)
-Armor = Blindée(s)
-Siege = Siège
-
-WaterCivilian = Civil naval
-WaterMelee = Combat naval rapproché
-WaterRanged = Combat naval à distance
-WaterSubmarine = Combat sous-marin
-WaterAircraftCarrier = Porte-avions
-
-Fighter = Chasseur
-Bomber = Bombardier
-AtomicBomber = Bombardier atomique
-Missile = Missile
-
-
-# Unit filters and other unit related things
-
-Air = Aérienne(s)
-air units = unités aériennes
-Barbarian = Barbare
-Barbarians = Barbares
-Embarked = Embarquée(s)
-land units = unités terrestres
-Military = Militaire(s)
-# Deprecated since 3.15.2, but should still be translated until it is officially removed
-military water = militaire(s) navale(s)
-non-air = non-aérienne(s)
-Nuclear Weapon = Arme nucléaire
-Submarine = Sous-Marin
-submarine units = unités sous-marines
-Unbuildable = Non-constructible
-water units = unités navales
-wounded units = unités blessées
-Wounded = Blessée(s)
-
-# For the "All newly-trained [relevant] units in this city receive the [] promotion" translation. Relevant as in 'units that can receive'
-relevant = appropriée(s)
-
-# For "May choose [amount] additional [beliefType] beliefs when [founding/enhancing] a religion"
-founding = fondant
-enhancing = renforçant
 
 # Promotions
 
@@ -1316,6 +1218,7 @@ Pick promotion = Choisissez une promotion
  OR  =  OU 
 units in open terrain = unités en terrain dégagé
 units in rough terrain = unités en terrain accidenté
+wounded units = unités blessées
 Targeting II (air) = Visée II (air)
 Targeting III (air) = Visée III (air)
 Bonus when performing air sweep [bonusAmount]% = Bonus en effectuant un balayage aérien [bonusAmount]%
@@ -1419,6 +1322,11 @@ This Unit upgrades for free = Cette unité peut être améliorée gratuitement
 Never destroyed when the city is captured = Jamais détruit(e) quand la ville est capturée
 Invisible to others = Invisible aux autres
 
+# Unused Resources
+
+Bison = Bison
+Cocoa = Cacao
+
 
 # In English we just paste all these conditionals at the end of each unique, but in your language that
 # may not turn into valid sentences. Therefore we have the following two translations to determine
@@ -1448,6 +1356,33 @@ ConditionalsPlacement = after
 ########################### AUTOMATICALLY GENERATED TRANSLATABLE STRINGS ########################### 
 
 
+######### Map Unit Filters ###########
+
+Wounded = Blessée(s)
+Barbarians = Barbares
+ # Requires translation!
+City-State = 
+Embarked = Embarquée(s)
+ # Requires translation!
+Non-City = 
+
+######### Unit Type Filters ###########
+
+Military = Militaire(s)
+Civilian = Civile(s)
+non-air = non-aérienne(s)
+relevant = appropriée(s)
+Nuclear Weapon = Arme nucléaire
+City = Ville
+Air = Aérienne(s)
+land units = unités terrestres
+water units = unités navales
+air units = unités aériennes
+ # Requires translation!
+military units = 
+submarine units = unités sous-marines
+Barbarian = Barbare
+
 ######### City filters ###########
 
 in this city = dans cette ville
@@ -1466,6 +1401,64 @@ in annexed cities = dans les villes annexées
 in holy cities = dans les villes saintes
 in City-State cities = dans les villes Cité-État
 in cities following this religion = dans les villes pratiquant cette religion
+
+######### Population Filters ###########
+
+ # Requires translation!
+Unemployed = 
+ # Requires translation!
+Followers of the Majority Religion = 
+ # Requires translation!
+Followers of this Religion = 
+
+######### Terrain Filters ###########
+
+All = Tout Type
+Coastal = Côtière(s)
+River = Rivière
+Open terrain = Terrain dégagé
+Rough terrain = Terrain accidenté
+Water resource = Ressource aquatique
+Foreign Land = Territoire Étranger
+Foreign = Étrangère(s)
+Friendly Land = Territoire Allié
+ # Requires translation!
+Enemy Land = 
+Featureless = Sans caractéristique
+Fresh Water = Eau douce
+non-fresh water = Eau salée
+Natural Wonder = Merveille Naturelle
+Impassable = Infranchissable
+Land = Terrestre(s)
+Water = Navale(s)
+Luxury resource = Ressource de luxe
+Strategic resource = Ressource stratégique
+Bonus resource = Ressource bonus
+
+######### Tile Filters ###########
+
+ # Requires translation!
+unimproved = 
+All Road = Toute Route
+Great Improvement = Grand Aménagement
+
+######### Region Types ###########
+
+Hybrid = Hybride
+
+######### Terrain Quality ###########
+
+Undesirable = Indésirable
+Desirable = Attrayant
+
+######### Improvement Filters ###########
+
+Great = Grand
+
+######### Prophet Action Filters ###########
+
+founding = fondant
+enhancing = renforçant
 
 ######### Unique Specials ###########
 
@@ -1493,6 +1486,7 @@ Temple of Artemis = Temple d'Artémis
 
 The Great Lighthouse = Le Grand Phare
 'They that go down to the sea in ships, that do business in great waters; these see the works of the Lord, and his wonders in the deep.' - The Bible, Psalms 107:23-24 = 'Ceux qui étaient descendus sur la mer dans des navires, et qui travaillaient sur les grandes eaux ; ceux-là virent les œuvres de l'Éternel et ses merveilles au milieu de l'abîme.' - La Bible, Psaumes 107:23-24
+for [mapUnitFilter] units = pour les unités [mapUnitFilter]
 [amount] Movement = [amount] Mouvement
 [amount] Sight = [amount] Vision
 
@@ -1539,6 +1533,8 @@ Krepost = Krepost
 
 Statue of Zeus = Statue de Zeus
 'He spoke, the son of Kronos, and nodded his head with the dark brows, and the immortally anointed hair of the great god swept from his divine head, and all Olympos was shaken' - The Iliad = 'Lorsque le fils de Chronos s’exprima et acquiesça, le front sombre, la chevelure consacrée et immortelle du grand dieu se balança sur son crâne divin, et toute l’Olympe fut secouée.' - L'Illiade
+vs cities = contre les villes
+when attacking = en phase offensive
 [amount]% Strength = [amount]% Puissance
 
 Lighthouse = Phare
@@ -1636,10 +1632,12 @@ Notre Dame = Notre-Dame
 Castle = Château
 
 Mughal Fort = Fort Moghol
+after discovering [tech] = après avoir découvert [tech]
 [stats] [cityFilter] = [stats] [cityFilter]
 
 Himeji Castle = Château de Himeji
 'Bushido is realized in the presence of death. This means choosing death whenever there is a choice between life and death. There is no other reasoning.' - Yamamoto Tsunetomo = 'J'ai découvert que mourir est au coeur du bushido. Lorsque, confronté à deux alternatives, vivre ou mourir, sans hésitation, il nous faut choisir la mort.' - Yamamoto Tsunetomo
+when fighting in [tileFilter] tiles = en combat sur les cases [tileFilter]
 
 Ironworks = Usine Sidérurgique
 
@@ -1742,6 +1740,7 @@ Pentagon = Pentagone
 [amount]% Gold cost of upgrading = [amount]% coût en Or de l'amélioration
 
 Solar Plant = Centrale Solaire
+in cities without a [buildingFilter] = dans les villes sans un(e) [buildingFilter]
 Only available = Uniquement disponible
 
 Nuclear Plant = Centrale Nucléaire
@@ -1775,6 +1774,7 @@ King = Roi
 Era Starting Unit = Unité(s) au début de l'Ère
 
 Emperor = Empereur
+Scout = Éclaireur
 
 Immortal = Immortel
 Worker = Ouvrier
@@ -1807,9 +1807,6 @@ Atomic era = Ère atomique
 Information era = Ère de l'information
 
 Future era = Ère future
-
-
-#################### Lines from GlobalUniques from Civ V - Vanilla ####################
 
 
 #################### Lines from Nations from Civ V - Vanilla ####################
@@ -2147,6 +2144,7 @@ La Rochelle = La Rochelle
 Bourges = Bourges
 Calais = Calais
 France = France
+before discovering [tech] = avant de découvrir [tech]
 
 Catherine = Catherine II
 You've behaved yourself very badly, you know it. Now it's payback time. = Vous vous êtes très mal comporté, et vous le savez. À présent, sonne l'heure de la vengeance.
@@ -2201,7 +2199,8 @@ Russia = Russie
 Double quantity of [resource] produced = Double la quantité de [resource] produit(s)
 
 Augustus Caesar = Auguste César
-My treasury contains little and my soldiers are getting impatient... ...therefore you must die. = Mes coffres sont peu remplis et mes soldats s'impatientent... vous devez par conséquent périr.
+ # Requires translation!
+My treasury contains little and my soldiers are getting impatient... (sigh) ...therefore you must die. = 
 So brave, yet so stupid! If only you had a brain similar to your courage. = Si brave et pourtant si stupide ! Si seulement vous aviez une intelligence équivalente à votre courage.
 The gods have deprived Rome of their favour. We have been defeated. = Les Dieux n'accordent plus leurs faveurs à Rome. Nous avons été vaincus.
 I greet you. I am Augustus, Imperator and Pontifex Maximus of Rome. If you are a friend of Rome, you are welcome. = Avé ! Je suis Auguste, Imperator et Pontifex Maximus de Rome. Vous êtes le bienvenu, si vous êtes l'ami de Rome.
@@ -2734,6 +2733,7 @@ Paishiyauvada = Paishiyauvada
 Patigrbana = Patigrbana
 Phrada = Phrada
 Persia = Perse
+during a Golden Age = durant un Âge d'Or
 
 Kamehameha I = Kamehameha Ier
 The ancient fire flashing across the sky is what proclaimed that this day would come, though I had foolishly hoped for a different outcome. = Les anciens feux transversant le ciel avaient annoncé que ce jour viendrait, même si j'ai naïvement espéré une autre issue...
@@ -2786,6 +2786,7 @@ Nuguria = Nuguria
 Pileni = Pileni
 Nukumanu = Nukumanu
 Polynesia = Polynésie
+starting from the [era] = à partir de [era]
 Enables embarkation for land units = Permet d'embarquer les unités terrestres
 Enables [mapUnitFilter] units to enter ocean tiles = Permet aux unités [mapUnitFilter] de traverser les cases Océan
 Normal vision when embarked = Vision normale quand embarqué
@@ -3260,6 +3261,7 @@ Legalism = Légalisme
 Provides the cheapest [stat] building in your first [amount] cities for free = Fournit gratuitement le bâtiment [stat] le moins cher dans vos [amount] premières villes
 Oligarchy = Oligarchie
 Units in cities cost no Maintenance = Les unités dans les villes ne coûtent aucune maintenance
+with a garrison = avec une garnison
 [amount]% Strength for cities = [amount]% Puissance pour les villes
 Landed Elite = Élite Terrienne
 [amount]% growth [cityFilter] = [amount]% croissance [cityFilter]
@@ -3282,6 +3284,7 @@ Liberty =
 
 Warrior Code = Code du Guerrier
 Discipline = Discipline
+when adjacent to a [mapUnitFilter] unit = adjacente(s) à une unité [mapUnitFilter]
 Military Tradition = Tradition Militaire
 [amount]% XP gained from combat = [amount]% XP gagné après combat
 Military Caste = Caste Militaire
@@ -3289,6 +3292,7 @@ Professional Army = Armée de Métier
 Honor Complete = Honneur Complet
  # Requires translation!
 Honor = 
+vs [mapUnitFilter] units = contre les unités [mapUnitFilter]
 Notified of new Barbarian encampments = Notification pour les nouveaux campements Barbares
 
 Organized Religion = Religion Organisée
@@ -3301,6 +3305,7 @@ Free Religion = Tolérance Religieuse
 Piety Complete = Piété Complète
  # Requires translation!
 Piety = 
+before adopting [policy] = avant d'adopter [policy]
 
 Philantropy = Philantropie
 Gifts of Gold to City-States generate [amount]% more Influence = Les présents en Or aux Cités-États génèrent [amount]% plus d'Influence
@@ -3341,10 +3346,12 @@ Rationalism Complete = Rationalisme Complet
 [amount] Free Technologies = [amount] technologie(s) gratuite(s)
  # Requires translation!
 Rationalism = 
+while the empire is happy = quand l'empire est heureux
 [amount]% [stat] = [amount]% [stat]
 
 Constitution = Constitution
 Universal Suffrage = Suffrage Universel
+when defending = en phase défensive
 Civil Society = Société Civile
 [amount]% Food consumption by specialists [cityFilter] = [amount]% consommation de nourriture par les spécialistes [cityFilter]
 Free Speech = Liberté d'Expression
@@ -3363,6 +3370,7 @@ Quantity of strategic resources produced by the empire +[amount]% = Quantité de
 Police State = État Policier
 Total War = Guerre Totale
 Autocracy Complete = Autocratie Complète
+for [amount] turns = pour [amount] tours
  # Requires translation!
 Autocracy = 
 Upon capturing a city, receive [amount] times its [stat] production as [plunderableStat] immediately = En capturant une ville, recevez [amount] fois sa création de [stat] en [plunderableStat] immédiatement
@@ -3388,28 +3396,28 @@ Clear Barbarian Camp = Nettoyer le Campement Barbare
 We feel threatened by a Barbarian Camp near our city. Please take care of it. = Nous nous sentons menacés par un campement barbare près de notre ville. S'il vous plaît, agissez.
 
 Connect Resource = Connecter une Ressource
-In order to make our civilizations stronger, connect [param] to your trade network. = Afin de rendre nos civilisations plus fortes, connectez [param] à votre réseau commercial.
+In order to make our civilizations stronger, connect [tileResource] to your trade network. = Afin de rendre nos civilisations plus fortes, connectez [tileResource] à votre réseau commercial.
 
 Construct Wonder = Construire une Merveille
-We recommend you to start building [param] to show the whole world your civilization strength. = Nous vous recommandons de commencer à construire [param] pour montrer au monde entier la puissance de votre civilisation.
+We recommend you to start building [wonder] to show the whole world your civilization strength. = Nous vous recommandons de commencer à construire [wonder] pour montrer au monde entier la puissance de votre civilisation.
 
 Acquire Great Person = Acquérir un Personnage Illustre
-Great People can change the course of a Civilization! You will be rewarded for acquiring a new [param]. = Les Personnages Illustres peuvent modifier le cours d'une civilisation ! Vous serez récompensé pour l'acquisition d'un nouveau [param].
+Great People can change the course of a Civilization! You will be rewarded for acquiring a new [greatPerson]. = Les Personnages Illustres peuvent modifier le cours d'une civilisation ! Vous serez récompensé pour l'acquisition d'un nouveau [greatPerson].
 
 Conquer City State = Conquérir une Cité-État
-It's time to erase the City-State of [param] from the map. You will be greatly rewarded for conquering them! = Le temps est venu d'éradiquer la Cité-État de [param]. Vous serez grandement récompensé pour cette conquête !
+It's time to erase the City-State of [cityState] from the map. You will be greatly rewarded for conquering them! = Le temps est venu d'éradiquer la Cité-État de [cityState]. Vous serez grandement récompensé pour cette conquête !
 
 Find Player = Trouver un Joueur
-You have yet to discover where [param] set up their cities. You will be rewarded for finding their territories. = Il vous reste encore à découvrir où [param] a fondé ses villes. Vous serez récompensé pour la découverte de leurs territoires.
+You have yet to discover where [civName] set up their cities. You will be rewarded for finding their territories. = Il vous reste encore à découvrir où [civName] a fondé ses villes. Vous serez récompensé pour la découverte de leurs territoires.
 
 Find Natural Wonder = Trouver une Merveille Naturelle
-Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [param] yet. = Envoyez vos meilleurs explorateurs à la recherche de Merveilles Naturelles. Personne n'a encore découvert l'emplacement de [param].
+Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [naturalWonder] yet. = Envoyez vos meilleurs explorateurs à la recherche de Merveilles Naturelles. Personne n'a encore découvert l'emplacement de [naturalWonder].
 
 Give Gold = Donner de l'Or
-We are suffering great poverty after being robbed by [param], and unless we receive a sum of Gold, it's only a matter of time before we collapse. = Nous souffrons d'une grande pauvreté après avoir été dépouillé par [param]. À moins que nous recevions un don d'Or, il reste peu de temps avant notre effondrement.
+We are suffering great poverty after being robbed by [civName], and unless we receive a sum of Gold, it's only a matter of time before we collapse. = Nous souffrons d'une grande pauvreté après avoir été dépouillé par [civName]. À moins que nous recevions un don d'Or, il reste peu de temps avant notre effondrement.
 
 Pledge to Protect = S'engager à Protéger
-We need your protection to stop the aggressions of [param]. By signing a Pledge of Protection, you'll confirm the bond that ties us. = Nous avons besoin de votre protection pour stopper l'agression de [param]. En signant une Promesse de Protection, vous allez confortez le lien qui nous unit.
+We need your protection to stop the aggressions of [civName]. By signing a Pledge of Protection, you'll confirm the bond that ties us. = Nous avons besoin de votre protection pour stopper l'agression de [civName]. En signant une Promesse de Protection, vous allez confortez le lien qui nous unit.
 
 Contest Culture = Compétition Culturelle
 The civilization with the largest Culture growth will gain a reward. = La civilisation ayant le plus de Culture gagnera une récompense.
@@ -3421,15 +3429,15 @@ Contest Technologies = Compétition Technologique
 The civilization with the largest number of new Technologies researched will gain a reward. = La civilisation ayant le plus grand nombre de nouvelles Technologies recherchées gagnera une récompense.
 
 Invest = Investir
-Our people are rejoicing thanks to a tourism boom. For a certain amount of time, any Gold donation will yield [amount]% extra Influence. = Notre peuple se réjouit d'un tourisme en forte hausse. Pour un temps limité, toute donation d'Or rapportera [amount]% d'Influence supplémentaire.
+Our people are rejoicing thanks to a tourism boom. For a certain amount of time, any Gold donation will yield [50]% extra Influence. = Notre peuple se réjouit d'un tourisme en forte hausse. Pour un temps limité, toute donation d'Or rapportera [50]% d'Influence supplémentaire.
 
 Bully City State = Intimider une Cité-État
-We are tired of the pretensions of [param]. If someone were to put them in their place by Demanding Tribute from them, they would be rewarded. = Nous sommes las des prétentions de [param]. Si quelqu'un pouvait les remettre à leur place en leur réclamant un Tribut, cela mériterait une récompense.
+We are tired of the pretensions of [cityState]. If someone were to put them in their place by Demanding Tribute from them, they would be rewarded. = Nous sommes las des prétentions de [cityState]. Si quelqu'un pouvait les remettre à leur place en leur réclamant un Tribut, cela mériterait une récompense.
 
 Denounce Civilization = Dénoncer une Civilisation
-We have been forced to pay tribute to [param]! We need you to tell the world of their ill deeds. = Nous avons été forcé de payer un Tribut à [param]! De grâce, nous vous demandons de révéler au monde leurs odieux agissements !
+We have been forced to pay tribute to [civName]! We need you to tell the world of their ill deeds. = Nous avons été forcé de payer un Tribut à [civName]! De grâce, nous vous demandons de révéler au monde leurs odieux agissements !
 
-We have heard the tenets of [param] and are most curious. Will you send missionaries to teach us about your religion? = Nous avons eu vent des dogmes de [param] et sommes désireux d'en savoir davantage. Voudriez-vous envoyer des missionnaires pour nous enseigner votre religion ?
+We have heard the tenets of [religionName] and are most curious. Will you send missionaries to teach us about your religion? = Nous avons eu vent des dogmes de [religionName] et sommes désireux d'en savoir davantage. Voudriez-vous envoyer des missionnaires pour nous enseigner votre religion ?
 
 
 #################### Lines from Ruins from Civ V - Vanilla ####################
@@ -3444,10 +3452,10 @@ squatters wishing to settle under your rule = indigènes désirant vivre sous vo
 An ancient tribe trained us in their ways of combat! = Une tribu ancienne nous a entraîné à leur art du combat !
 your exploring unit receives training = votre unité d'exploration reçoit un entraînement
 
-We have found survivors in the ruins! Population added to [param]. = Nous avons trouvé des survivants dans les ruines ! Population ajoutée à [param].
+We have found survivors in the ruins! Population added to [cityName]. = Nous avons trouvé des survivants dans les ruines ! Population ajoutée à [cityName].
 survivors (adds population to a city) = survivants (ajoute de la population à une cité)
 
-We have found a stash of [param] Gold in the ruins! = Nous avons trouvé une cache secrète de [param] Or dans les ruines !
+We have found a stash of [goldAmount] Gold in the ruins! = Nous avons trouvé une cache secrète de [goldAmount] Or dans les ruines !
 a stash of gold = une cache secrète d'or
 
 discover a lost technology = découvrir une technologie oubliée
@@ -3666,6 +3674,7 @@ Tundra = Toundra
 Desert = Désert
 
 Lakes = Lacs
+Fresh water = Eau douce
 
 Mountain = Montagne
 Has an elevation of [amount] for visibility calculations = A une élévation de [amount] pour le calcul de la vision
@@ -3686,6 +3695,7 @@ A Camp can be built here without cutting it down = Un Campement peut être const
 Jungle = Jungle
 
 Marsh = Marais
+Rare feature = Caractéristique rare
 Only Polders can be built here = Seuls des Polders peuvent être construits ici
 
 Fallout = Retombées radioactives
@@ -3881,10 +3891,13 @@ Porcelain = Porcelaine
 #################### Lines from UnitPromotions from Civ V - Vanilla ####################
 
 Sword = Arme blanche
+Mounted = Montée(s)
+Siege = Siège
 Ranged Gunpowder = Poudre d'artillerie
 Armored = Blindée(s)
 Melee Water = Combat naval rapproché
 Ranged Water = Combat naval à distance
+Submarine = Sous-Marin
 Heal Instantly = Soin Instantané
 Heal this unit by [amount] HP = Soigne cette unité de [amount] PV
 Doing so will consume this opportunity to choose a Promotion = Se soigner ainsi remplacera la possibilité actuelle de choisir une Promotion
@@ -3943,6 +3956,7 @@ Medic = Médecin
 All adjacent units heal [amount] HP when healing = Toutes les unités adjacentes récupèrent [amount] PV en phase de soin
 
 Medic II = Médecin II
+in [tileFilter] tiles = sur les cases [tileFilter]
 [amount] HP when healing = [amount] PV en phase de soin
 
 Scouting I = Éclaireur I
@@ -4003,6 +4017,7 @@ Flight Deck III = Pont d'Envol III
 Supply = Ravitaillement
 May heal outside of friendly territory = Peut se soigner en dehors d'un territoire allié
 
+Bomber = Bombardier
 Siege I = Siège I
 
 Siege II = Siège II
@@ -4012,6 +4027,7 @@ Siege III = Siège III
 Evasion = Esquive
 Damage taken from interception reduced by [amount]% = Les dégâts subis suite à une interception sont réduits de [amount]%
 
+Fighter = Chasseur
 Interception I = Interception I
 [amount]% Damage when intercepting = [amount]% Dégâts en phase d'interception
 
@@ -4108,10 +4124,29 @@ Can see over obstacles =
 
 Atomic Bomber = Bombardier Atomique
 
+Missile = Missile
 Self-destructs when attacking = S'autodétruit lors de l'attaque
 Cannot be intercepted = Ne peut pas être intercepté
 
 Can pass through impassable tiles = Peut passer les cases infranchissables
+
+Melee = Combat rapproché
+
+Ranged = Combat à distance
+
+Armor = Blindée(s)
+
+WaterCivilian = Civil naval
+
+WaterMelee = Combat naval rapproché
+
+WaterRanged = Combat naval à distance
+
+WaterSubmarine = Combat sous-marin
+
+WaterAircraftCarrier = Porte-avions
+
+AtomicBomber = Bombardier atomique
 
 
 #################### Lines from Units from Civ V - Vanilla ####################
@@ -4189,6 +4224,7 @@ Knight = Chevalier
 Camel Archer = Archer Méhariste
 
 Conquistador = Conquistador
+on foreign continents = sur les continents étrangers
 
 Naresuan's Elephant = Éléphant de Naresuan
 
@@ -4279,6 +4315,7 @@ Anti-Tank Gun = Canon Antichar
 
 Atomic Bomb = Bombe Atomique
 Nuclear weapon of Strength [amount] = Arme nucléaire de Puissance [amount]
+if [buildingName] is constructed = si [buildingName] est construit(e)
 Blast radius [amount] = Rayon de déflagration [amount]
 
 Rocket Artillery = Lance-Roquettes
@@ -4313,6 +4350,7 @@ Great Artist = Grand Artiste
 Can start an [amount]-turn golden age = Peut démarrer un âge d'or de [amount] tours
 Can construct [improvementName] = Peut construire [improvementName]
 Great Person - [stat] = Personnage Illustre - [stat]
+Unbuildable = Non-constructible
 
 Great Scientist = Grand Savant
 Can hurry technology research = Peut accélerer une recherche technologique
@@ -4371,6 +4409,8 @@ Faith Healers = Guérison par la Foi
 Fertility Rites = Rites de Fertilité
 
 God of Craftsman = Dieu des Artisans
+ # Requires translation!
+in cities with at least [amount] [populationFilter] = 
 
 God of the Open Sky = Dieu du Ciel Ouvert
 
@@ -4422,6 +4462,7 @@ Feed the World = Nourrir le Monde
 Guruship = Leader Spirituel
 
 Holy Warriors = Guerriers Saints
+before the [era] = avant [era]
 May buy [baseUnitFilter] units with [stat] for [amount] times their normal Production cost = Peut acheter des unités [baseUnitFilter] avec [stat] pour [amount] fois leur coût normal en Production
 
 Liturgical Drama = Pièces Liturgiques
@@ -4442,6 +4483,7 @@ Religious Community = Communauté Religieuse
 [amount]% [stat] from every follower, up to [amount2]% = [amount]% [stat] pour chaque fidèle, jusqu'à [amount2]%
 
 Swords into Ploughshares = Épées aux Fourreaux
+when not at war = quand en paix
 
 Founder = Fondateur
 Ceremonial Burial = Inhumation Cérémonielle
@@ -4574,9 +4616,6 @@ Starting in this era disables religion = Démarrer durant cette ère désactive 
 
 
 Marine = Fusilier Marin
-
-
-#################### Lines from GlobalUniques from Civ V - Gods & Kings ####################
 
 
 #################### Lines from Nations from Civ V - Gods & Kings ####################
@@ -4901,6 +4940,7 @@ Llanfairpwllgwyngyll = Llanfair Pwllgwyngyll
 Falmouth = Falmouth
 Lorient = Lorient
 Celts = Celtes
+with [amount] to [amount2] neighboring [tileFilter] [tileFilter2] tiles = avec [amount] à [amount2] cases [tileFilter2] [tileFilter] adjacentes
 
 Haile Selassie = Hailé Sélassié
 I have tried all other avenues, but yet you persist in this madness. I hope, for your sake, your end is swift. = J'ai tenté tous les autres chemins, mais pourtant, vous persistez dans cette folie. J'espère, pour votre salut, que votre fin sera rapide.
@@ -4947,6 +4987,7 @@ Gambela = Gambela
 Ziway = Ziway
 Weldiya = Weldiya
 Ethiopia = Éthiopie
+when fighting units from a Civilization with more Cities than you = en combat contre les unités d'une Civilisation ayant plus de Villes que vous
 
 Pacal = Pacal
 A sacrifice unlike all others must be made! = Un sacrifice comme nul autre doit être accompli !
@@ -5032,10 +5073,10 @@ Taoism = Taoïsme
 #################### Lines from Ruins from Civ V - Gods & Kings ####################
 
 
-We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[param] Faith) = Nous avons trouvé des écritures saintes dans les ruines, permettant d'approfondir notre compréhension de la religion ! (+[param] Foi)
+We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[faithAmount] Faith) = Nous avons trouvé des écritures saintes dans les ruines, permettant d'approfondir notre compréhension de la religion ! (+[faithAmount] Foi)
 discover holy symbols = découvrir des écritures saintes
 
-We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[param] Faith) = Nous avons trouvé une prophétie antique dans les ruines, améliorant grandement notre cohésion spirituelle ! (+[param] Foi)
+We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[faithAmount] Faith) = Nous avons trouvé une prophétie antique dans les ruines, améliorant grandement notre cohésion spirituelle ! (+[faithAmount] Foi)
 an ancient prophecy = une prophétie antique
 
 
@@ -5093,7 +5134,15 @@ Polder = Polder
 #################### Lines from TileResources from Civ V - Gods & Kings ####################
 
 
+Citrus = Agrumes
+
+Copper = Cuivre
+
+Crab = Crabe
+
 Salt = Sel
+
+Truffles = Truffes
 
 
 #################### Lines from UnitPromotions from Civ V - Gods & Kings ####################
@@ -5425,45 +5474,20 @@ No Sight =
 [amount] XP gained from combat = [amount] XP gagné après combat
 Irremovable = Insupprimable
 when at war = quand en guerre
-when not at war = quand en paix
-during a Golden Age = durant un Âge d'Or
 with [resource] = avec [resource]
-while the empire is happy = quand l'empire est heureux
 when between [amount] and [amount2] Happiness = quand entre [amount] et [amount2] Bonheur
 when below [amount] Happiness = quand en dessous de [amount] Bonheur
 during the [era] = pendant [era]
-before the [era] = avant [era]
-starting from the [era] = à partir de [era]
 if no other Civilization has researched this = si aucune autre Civilisation n'a recherché ceci
-after discovering [tech] = après avoir découvert [tech]
-before discovering [tech] = avant de découvrir [tech]
 upon discovering [tech] = en découvrant [tech]
 after adopting [policy] = après avoir adopté [policy]
-before adopting [policy] = avant d'adopter [policy]
-if [buildingName] is constructed = si [buildingName] est construit(e)
-for [amount] turns = pour [amount] tours
 by consuming this unit = en consommant cette unité
 in cities with a [buildingFilter] = dans les villes avec un(e) [buildingFilter]
-in cities without a [buildingFilter] = dans les villes sans un(e) [buildingFilter]
- # Requires translation!
-in cities with at least [amount] [populationFilter] = 
-with a garrison = avec une garnison
-for [mapUnitFilter] units = pour les unités [mapUnitFilter]
 for units with [promotion] = pour les unités avec [promotion]
 for units without [promotion] = pour les unités sans [promotion]
-vs cities = contre les villes
-vs [mapUnitFilter] units = contre les unités [mapUnitFilter]
-when fighting units from a Civilization with more Cities than you = en combat contre les unités d'une Civilisation ayant plus de Villes que vous
-when attacking = en phase offensive
-when defending = en phase défensive
-when fighting in [tileFilter] tiles = en combat sur les cases [tileFilter]
-on foreign continents = sur les continents étrangers
-when adjacent to a [mapUnitFilter] unit = adjacente(s) à une unité [mapUnitFilter]
 when above [amount] HP = quand au dessus de [amount] PV
 when below [amount] HP = quand en dessous de [amount] PV
 with [amount] to [amount2] neighboring [tileFilter] tiles = avec [amount] à [amount2] cases [tileFilter] adjacentes
-with [amount] to [amount2] neighboring [tileFilter] [tileFilter2] tiles = avec [amount] à [amount2] cases [tileFilter2] [tileFilter] adjacentes
-in [tileFilter] tiles = sur les cases [tileFilter]
 in [tileFilter] [tileFilter2] tiles = sur les cases [tileFilter2] [tileFilter]
 in tiles without [tileFilter] = sur les cases sans [tileFilter]
 on water maps = sur les cartes maritimes
@@ -5503,3 +5527,12 @@ Ruins = Ruines
 CityState = Cité-État
 ModOptions = Options Mod
 Conditional = Conditionnel
+
+#################### Removed Lines ####################
+
+#~~Rough Terrain = Terrain accidenté
+#~~Strategic = Stratégique
+#~~Bonus = Bonus
+#~~Luxury = Luxe
+#~~military water = militaire(s) navale(s)
+#~~My treasury contains little and my soldiers are getting impatient... ...therefore you must die. = Mes coffres sont peu remplis et mes soldats s'impatientent... vous devez par conséquent périr.

--- a/android/assets/jsons/translations/German.properties
+++ b/android/assets/jsons/translations/German.properties
@@ -1366,6 +1366,7 @@ water units = Wassereinheiten
 air units = Lufteinheiten
 military units = militärische
 submarine units = U-Boot Einheiten
+Barbarian = Barbaren
 
 ######### City filters ###########
 
@@ -3311,6 +3312,7 @@ Scientific Revolution = Wissenschaftsrevolution
 Rationalism Complete = Rationalismus vollständig
 [amount] Free Technologies = [amount] freie Technologien
 Rationalism = Rationalismus
+while the empire is happy = solange die Bevölkerung glücklich ist
 [amount]% [stat] = [amount]% [stat]
 
 Constitution = Verfassung

--- a/android/assets/jsons/translations/German.properties
+++ b/android/assets/jsons/translations/German.properties
@@ -1078,8 +1078,6 @@ or [terrainType] = oder [terrainType]
 Can be constructed by = Kann erbaut werden von
 Defence bonus = Verteidigungsbonus
 Movement cost = Bewegungskosten
-Open terrain = Offenes Gelände
-Rough Terrain = Unwegsames Gelände
 for = für
 Missing translations: = Fehlende Übersetzungen:
 Resolution = Auflösung
@@ -1208,102 +1206,6 @@ Religion = Religion
 Enhancing religion = Religionsverbesserung
 Enhanced religion = Verbesserte Religion
 
-# Terrains
-
-Impassable = Unpassierbar
-Rare feature = Seltene Geländeform
-
-# terrainFilters (so for uniques like: "[stats] from [terrainFilter] tiles")
-
-All = alle
-Water = Wasser
-Land = Land
-Coastal = Küsten
-River = Fluss
-Rough terrain = Unwegsames Gelände
-Foreign Land = Fremdes Land
-Foreign = Fremdes
-Friendly Land = Befreundetes Land
-Water resource = Wasser-Ressource
-Bonus resource = Bonus-ressource
-Luxury resource = Luxus-ressource
-Strategic resource = Strategische Ressource
-Fresh water = Frischwasser
-non-fresh water = nicht frisches Wasser
-Natural Wonder = Naturwunder
-Hybrid = Gemischt
-Undesirable = Unerwünscht
-Desirable = Erwünscht
-Featureless = Eigenschaftslos
-Fresh Water = Frischwasser
-
-# improvementFilters
-
-All Road = Alle Straßen
-Great Improvement = Große Verbesserung
-Great = Große
-
-# Resources
-
-Bison = Bisons
-Copper = Kupfer
-Cocoa = Kakao
-Crab = Krabben
-Citrus = Zitrusfrüchte
-Truffles = Trüffel
-Strategic = Strategisch
-Bonus = Bonus
-Luxury = Luxus
-
-# Unit types
-
-City = Stadt
-Civilian = Zivilist
-Melee = Nahkampf
-Ranged = Fernkampf
-Scout = Späher
-Mounted = Beritten
-Armor = Panzerung
-Siege = Belagerung
-
-WaterCivilian = Wasser-Zivilist
-WaterMelee = Wassernahkampf
-WaterRanged = Wasserfernkampf
-WaterSubmarine = U-Boote
-WaterAircraftCarrier = Flugzeugträger
-
-Fighter = Jagdflugzeug
-Bomber = Bomber
-AtomicBomber = Atombomber
-Missile = Rakete
-
-
-# Unit filters and other unit related things
-
-Air = Luft
-air units = Lufteinheiten
-Barbarian = Barbar
-Barbarians = Barbaren
-Embarked = Eingeschifft
-land units = Landeinheiten
-Military = militärisch
-# Deprecated since 3.15.2, but should still be translated until it is officially removed
-military water = militärisches Wasser
-non-air = nicht-fliegend
-Nuclear Weapon = Atomwaffe
-Submarine = U-Boot
-submarine units = U-Boot Einheiten
-Unbuildable = nicht baubar
-water units = Wassereinheiten
-wounded units = verwundete Einheiten
-Wounded = Verwundet
-
-# For the "All newly-trained [relevant] units in this city receive the [] promotion" translation. Relevant as in 'units that can receive'
-relevant = relevante
-
-# For "May choose [amount] additional [beliefType] beliefs when [founding/enhancing] a religion"
-founding = gründen
-enhancing = verbessern
 
 # Promotions
 
@@ -1311,6 +1213,7 @@ Pick promotion = Wähle eine Beförderung
  OR  =  ODER 
 units in open terrain = Einheiten im offenen Gelände
 units in rough terrain = Einheiten in unwegsamem Gelände
+wounded units = verwundete Einheiten
 Targeting II (air) = Luftzielerfassung II
 Targeting III (air) = Luftzielerfassung III
 Bonus when performing air sweep [bonusAmount]% = [bonusAmount]% Bonus bei Luftraumsäuberungen
@@ -1407,6 +1310,11 @@ This Unit upgrades for free = Diese Einheit kann kostenlos aufgerüstet werden
 Never destroyed when the city is captured = Wird niemals bei einer Annektierung der Stadt zerstört
 Invisible to others = Unsichtbar für andere
 
+# Unused Resources
+
+Bison = Bison
+Cocoa = Kakao
+
 
 # In English we just paste all these conditionals at the end of each unique, but in your language that
 # may not turn into valid sentences. Therefore we have the following two translations to determine
@@ -1436,6 +1344,29 @@ ConditionalsPlacement = after
 ########################### AUTOMATICALLY GENERATED TRANSLATABLE STRINGS ########################### 
 
 
+######### Map Unit Filters ###########
+
+Wounded = Verwundet
+Barbarians = Barbaren
+City-State = Stadtstaat
+Embarked = Eingeschifft
+Non-City = Nicht-Stadt
+
+######### Unit Type Filters ###########
+
+Military = militärisch
+Civilian = Zivilist
+non-air = nicht-fliegend
+relevant = relevante
+Nuclear Weapon = Atomwaffe
+City = Stadt
+Air = Luft
+land units = Landeinheiten
+water units = Wassereinheiten
+air units = Lufteinheiten
+military units = militärische
+submarine units = U-Boot Einheiten
+
 ######### City filters ###########
 
 in this city = in dieser Stadt
@@ -1454,6 +1385,59 @@ in annexed cities = in annektierten Städten
 in holy cities = in heiligen Städten
 in City-State cities = in Stadtstaat-Städten
 in cities following this religion = in Städten, die dieser Religion folgen
+
+######### Population Filters ###########
+
+Unemployed = Unbeschäftigt
+Followers of the Majority Religion = Anhänger der Hauptreligion
+Followers of this Religion = Anhänger dieser Religion
+
+######### Terrain Filters ###########
+
+All = alle
+Coastal = Küsten
+River = Fluss
+Open terrain = Offenes Gelände
+Rough terrain = Unwegsames Gelände
+Water resource = Wasser-Ressource
+Foreign Land = Fremdes Land
+Foreign = Fremdes
+Friendly Land = Befreundetes Land
+Enemy Land = Feindliches Land
+Featureless = Eigenschaftslos
+Fresh Water = Frischwasser
+non-fresh water = nicht frisches Wasser
+Natural Wonder = Naturwunder
+Impassable = Unpassierbar
+Land = Land
+Water = Wasser
+Luxury resource = Luxus-ressource
+Strategic resource = Strategische Ressource
+Bonus resource = Bonus-ressource
+
+######### Tile Filters ###########
+
+unimproved = unverbessert
+All Road = Alle Straßen
+Great Improvement = Große Verbesserung
+
+######### Region Types ###########
+
+Hybrid = Gemischt
+
+######### Terrain Quality ###########
+
+Undesirable = Unerwünscht
+Desirable = Erwünscht
+
+######### Improvement Filters ###########
+
+Great = Große
+
+######### Prophet Action Filters ###########
+
+founding = gründen
+enhancing = verbessern
 
 ######### Unique Specials ###########
 
@@ -1479,6 +1463,7 @@ Temple of Artemis = Tempel der Artemis
 
 The Great Lighthouse = Der Große Leuchtturm
 'They that go down to the sea in ships, that do business in great waters; these see the works of the Lord, and his wonders in the deep.' - The Bible, Psalms 107:23-24 = 'Die mit Schiffen auf dem Meere fuhren und trieben ihren Handel auf großen Wassern, die des HERRN Werke erfahren haben und seine Wunder im Meer.' - Die Bibel, Psalm 107,23-25
+for [mapUnitFilter] units = für [mapUnitFilter] Einheiten
 [amount] Movement = [amount] Bewegungsrate
 [amount] Sight = [amount] Sicht
 
@@ -1525,6 +1510,8 @@ Krepost = Krepost
 
 Statue of Zeus = Statue des Zeus
 'He spoke, the son of Kronos, and nodded his head with the dark brows, and the immortally anointed hair of the great god swept from his divine head, and all Olympos was shaken' - The Iliad = 'Er sprach, der Sohn des Kronos, und neigte sein Haupt mit den dunklen Brauen, sodass sein unsterblich gesalbtes Haar von seinem göttlichen Schädel herunterschweifte, und der ganze Olymp ward erschüttert' - Ilias
+vs cities = vs Städte
+when attacking = beim Angriff
 [amount]% Strength = [amount]% Stärke
 
 Lighthouse = Leuchtturm
@@ -1621,10 +1608,12 @@ Notre Dame = Notre-Dame
 Castle = Burg
 
 Mughal Fort = Mogul Festung
+after discovering [tech] = nach dem Entdecken von [tech]
 [stats] [cityFilter] = [stats] [cityFilter]
 
 Himeji Castle = Schloss Himeji
 'Bushido is realized in the presence of death. This means choosing death whenever there is a choice between life and death. There is no other reasoning.' - Yamamoto Tsunetomo = 'Bushido wird in der Gegenwart des Todes verwirklicht. Das bedeutet, den Tod zu wählen, wann immer die Wahl zwischen Leben und Tod besteht. Es gibt keine andere Argumentation.' - Yamamoto Tsunetomo
+when fighting in [tileFilter] tiles = wenn auf [tileFilter] gekämpft wird
 
 Ironworks = Eisenhüttenwerk
 
@@ -1726,6 +1715,7 @@ Pentagon = Pentagon
 [amount]% Gold cost of upgrading = [amount]% Goldkosten für Aufrüstung
 
 Solar Plant = Solarkraftwerk
+in cities without a [buildingFilter] = in Städten ohne [buildingFilter]
 Only available = Nur verfügbar
 
 Nuclear Plant = Atomkraftwerk
@@ -1759,6 +1749,7 @@ King = König
 Era Starting Unit = Start-Einheit des Zeitalters
 
 Emperor = Kaiser
+Scout = Späher
 
 Immortal = Unsterbliche(r)
 Worker = Arbeiter
@@ -1791,9 +1782,6 @@ Atomic era = Atomzeitalter
 Information era = Informationszeitalter
 
 Future era = Ära der Zukunft
-
-
-#################### Lines from GlobalUniques from Civ V - Vanilla ####################
 
 
 #################### Lines from Nations from Civ V - Vanilla ####################
@@ -2129,6 +2117,7 @@ La Rochelle = La Rochelle
 Bourges = Bourges
 Calais = Calais
 France = Frankreich
+before discovering [tech] = vor dem Entdecken von [tech]
 
 Catherine = Katharina
 You've behaved yourself very badly, you know it. Now it's payback time. = Ihr habt Euch sehr schlecht benommen, Ihr wisst es. Nun zahle ich es Euch zurück.
@@ -2183,7 +2172,7 @@ Russia = Russland
 Double quantity of [resource] produced = Doppelte Menge von [resource] produziert
 
 Augustus Caesar = Julius Cäsar
-My treasury contains little and my soldiers are getting impatient... ...therefore you must die. = Meine Schatzkammer enthält wenig, und meine Soldaten werden ungeduldig... ...deshalb müsst ihr sterben.
+My treasury contains little and my soldiers are getting impatient... (sigh) ...therefore you must die. = Meine Schatzkammer enthält wenig, und meine Soldaten werden ungeduldig... (Seufz) ...deshalb müsst ihr sterben.
 So brave, yet so stupid! If only you had a brain similar to your courage. = So mutig, so dumm! Wenn Ihr nur einen Verstand wie Eure Tapferkeit hättest.
 The gods have deprived Rome of their favour. We have been defeated. = Die Götter haben Rom verlassen. Wir haben verloren.
 I greet you. I am Augustus, Imperator and Pontifex Maximus of Rome. If you are a friend of Rome, you are welcome. = Ich grüße dich. Ich bin Julius, Imperator und Pontifex Maximus von Rom. Bist Du ein Freund Roms, so sei willkommen.
@@ -2716,6 +2705,7 @@ Paishiyauvada = Paishiyauvada
 Patigrbana = Patigrbana
 Phrada = Phrada
 Persia = Persien
+during a Golden Age = während eines Goldenen Zeitalters
 
 Kamehameha I = Kamehameha I
 The ancient fire flashing across the sky is what proclaimed that this day would come, though I had foolishly hoped for a different outcome. = Von alters her hat ein über den Himmel blitzendes Feuer verkündet, dieser Tag werde kommen. Leichtsinnig hatte ich einen anderen Ausgang erhofft.
@@ -2768,6 +2758,7 @@ Nuguria = Nuguria
 Pileni = Pileni
 Nukumanu = Nukumanu
 Polynesia = Polynesien
+starting from the [era] = beginnend mit [era]
 Enables embarkation for land units = Ermöglicht das Einschiffen von Landeinheiten
 Enables [mapUnitFilter] units to enter ocean tiles = Erlaubt [mapUnitFilter] Einheiten Ozeanfelder zu betreten
 Normal vision when embarked = Normale Sichtweite wenn eingeschifft
@@ -3242,6 +3233,7 @@ Legalism = Legalismus
 Provides the cheapest [stat] building in your first [amount] cities for free = Stellt das günstigste [stat] Gebäude in deinen ersten [amount] Städten kostenlos zur Verfügung
 Oligarchy = Oligarchie
 Units in cities cost no Maintenance = Einheiten in Städten kosten keinen Unterhalt
+with a garrison = mit einer Garnison
 [amount]% Strength for cities = [amount]% Stärke für Städte
 Landed Elite = Landjunkerschaft
 [amount]% growth [cityFilter] = [amount]% Wachstum [cityFilter]
@@ -3262,12 +3254,14 @@ Liberty = Unabhängigkeit
 
 Warrior Code = Kriegerkodex
 Discipline = Disziplin
+when adjacent to a [mapUnitFilter] unit = wenn benachbart zu einer [mapUnitFilter] Einheit
 Military Tradition = Militärtradition
 [amount]% XP gained from combat = [amount]% EP im Kampf gewonnen
 Military Caste = Militarisierte Burg
 Professional Army = Berufsarmee
 Honor Complete = Ehre vollständig
 Honor = Ehre
+vs [mapUnitFilter] units = vs [mapUnitFilter] Einheiten
 Notified of new Barbarian encampments = Benachrichtigt über neue Barbarenlager
 
 Organized Religion = Organisierte Religion
@@ -3279,6 +3273,7 @@ Reformation = Reformation
 Free Religion = Religionsfreiheit
 Piety Complete = Frömmigkeit vollständig
 Piety = Frömmigkeit
+before adopting [policy] = vor dem Verabschieden von [policy]
 
 Philantropy = Philantropie
 Gifts of Gold to City-States generate [amount]% more Influence = Goldgeschenke an Stadtstaaten erzeugen [amount]% mehr Einfluss
@@ -3320,6 +3315,7 @@ Rationalism = Rationalismus
 
 Constitution = Verfassung
 Universal Suffrage = Allgemeines Wahlrecht
+when defending = beim Verteidigen
 Civil Society = Zivilgesellschaft
 [amount]% Food consumption by specialists [cityFilter] = [amount]% Nahrungsverbrauch von Spezialisten [cityFilter]
 Free Speech = Meinungsfreiheit
@@ -3337,6 +3333,7 @@ Quantity of strategic resources produced by the empire +[amount]% = Menge der vo
 Police State = Polizeistaat
 Total War = Totaler Krieg
 Autocracy Complete = Autokratie vollständig
+for [amount] turns = für [amount] Runden
 Autocracy = Autokratie
 Upon capturing a city, receive [amount] times its [stat] production as [plunderableStat] immediately = Erhalte beim Erobern einer Stadt sofort [amount]-mal ihre [stat] Produktion als [plunderableStat]
 
@@ -3360,28 +3357,28 @@ Clear Barbarian Camp = Säubert das Barbarenlager
 We feel threatened by a Barbarian Camp near our city. Please take care of it. = Wir fühlen uns von einem Barbarenlager in der Nähe unserer Stadt bedroht. Bitte kümmert Euch um sie.
 
 Connect Resource = Ressource anschließen
-In order to make our civilizations stronger, connect [param] to your trade network. = Um unsere Zivilisationen zu stärken, verbindet [param] mit Eurem Handelsnetzwerk.
+In order to make our civilizations stronger, connect [tileResource] to your trade network. = Um unsere Zivilisationen zu stärken, verbindet [tileResource] mit Eurem Handelsnetzwerk.
 
 Construct Wonder = Weltwunder bauen
-We recommend you to start building [param] to show the whole world your civilization strength. = Wir empfehlen Euch, mit dem Bau von [param] zu beginnen, um der ganzen Welt Eure Zivilisationsstärke zu zeigen.
+We recommend you to start building [wonder] to show the whole world your civilization strength. = Wir empfehlen Euch, mit dem Bau von [wonder] zu beginnen, um der ganzen Welt Eure Zivilisationsstärke zu zeigen.
 
 Acquire Great Person = Erschafft eine Große Persönlichkeit
-Great People can change the course of a Civilization! You will be rewarded for acquiring a new [param]. = Große Persönlichkeiten können den Kurs einer Zivilisation verändern! Sie werden für den Erwerb eines neuen [param] belohnt.
+Great People can change the course of a Civilization! You will be rewarded for acquiring a new [greatPerson]. = Große Persönlichkeiten können den Kurs einer Zivilisation verändern! Sie werden für den Erwerb eines neuen [greatPerson] belohnt.
 
 Conquer City State = Stadtstaat erobern
-It's time to erase the City-State of [param] from the map. You will be greatly rewarded for conquering them! = Es ist an der Zeit, den Stadtstaat [param] von der Karte zu tilgen. Ihr werdet für diese Eroberung reichlich belohnt werden!
+It's time to erase the City-State of [cityState] from the map. You will be greatly rewarded for conquering them! = Es ist an der Zeit, den Stadtstaat [cityState] von der Karte zu tilgen. Ihr werdet für diese Eroberung reichlich belohnt werden!
 
 Find Player = Findet Spieler
-You have yet to discover where [param] set up their cities. You will be rewarded for finding their territories. = Sie müssen noch herausfinden, wo [param] die Städte eingerichtet hat. Ihr werdet belohnt, wenn Ihr sie findet.
+You have yet to discover where [civName] set up their cities. You will be rewarded for finding their territories. = Sie müssen noch herausfinden, wo [civName] die Städte eingerichtet hat. Ihr werdet belohnt, wenn Ihr sie findet.
 
 Find Natural Wonder = Findet Naturwunder
-Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [param] yet. = Sendet Eure besten Entdecker auf die Suche nach Naturwundern. Noch kennt niemand den Standort von [param].
+Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [naturalWonder] yet. = Sendet Eure besten Entdecker auf die Suche nach Naturwundern. Noch kennt niemand den Standort von [naturalWonder].
 
 Give Gold = Gold überreichen
-We are suffering great poverty after being robbed by [param], and unless we receive a sum of Gold, it's only a matter of time before we collapse. = Wir leiden unter großer Armut, nachdem wir von [param] beraubt wurden, und wenn wir nicht eine Summe Gold erhalten, ist es nur eine Frage der Zeit, bis wir zusammenbrechen.
+We are suffering great poverty after being robbed by [civName], and unless we receive a sum of Gold, it's only a matter of time before we collapse. = Wir leiden unter großer Armut, nachdem wir von [civName] beraubt wurden, und wenn wir nicht eine Summe Gold erhalten, ist es nur eine Frage der Zeit, bis wir zusammenbrechen.
 
 Pledge to Protect = Schutzversprechens
-We need your protection to stop the aggressions of [param]. By signing a Pledge of Protection, you'll confirm the bond that ties us. = Wir brauchen euren Schutz, um die Aggressionen von [param] zu stoppen. Mit der Unterzeichnung eines Schutzversprechens bestätigt ihr das Band, das uns verbindet.
+We need your protection to stop the aggressions of [civName]. By signing a Pledge of Protection, you'll confirm the bond that ties us. = Wir brauchen euren Schutz, um die Aggressionen von [civName] zu stoppen. Mit der Unterzeichnung eines Schutzversprechens bestätigt ihr das Band, das uns verbindet.
 
 Contest Culture = Wettbewerb Kultur
 The civilization with the largest Culture growth will gain a reward. = Die Zivilisation mit dem größten Kulturwachstum gewinnt eine Belohnung.
@@ -3393,15 +3390,15 @@ Contest Technologies = Wettbewerb Technologien
 The civilization with the largest number of new Technologies researched will gain a reward. = Die Zivilisation, die die meisten neuen Technologien erforscht hat, gewinnt eine Belohnung.
 
 Invest = Investieren
-Our people are rejoicing thanks to a tourism boom. For a certain amount of time, any Gold donation will yield [amount]% extra Influence. = Unser Volk freut sich über einen Tourismusboom. Für eine bestimmte Zeit bringt jede Goldspende [amount]% zusätzlichen Einfluss.
+Our people are rejoicing thanks to a tourism boom. For a certain amount of time, any Gold donation will yield [50]% extra Influence. = Unser Volk freut sich über einen Tourismusboom. Für eine bestimmte Zeit bringt jede Goldspende [50]% zusätzlichen Einfluss.
 
 Bully City State = Stadtstaat schikanieren
-We are tired of the pretensions of [param]. If someone were to put them in their place by Demanding Tribute from them, they would be rewarded. = Wir sind die Anmaßungen von [param] leid. Wenn jemand sie in ihre Schranken weisen würde, indem er von ihnen Tribut fordert, würde er belohnt werden.
+We are tired of the pretensions of [cityState]. If someone were to put them in their place by Demanding Tribute from them, they would be rewarded. = Wir sind die Anmaßungen von [cityState] leid. Wenn jemand sie in ihre Schranken weisen würde, indem er von ihnen Tribut fordert, würde er belohnt werden.
 
 Denounce Civilization = Zivilisation anprangern
-We have been forced to pay tribute to [param]! We need you to tell the world of their ill deeds. = Wir sind gezwungen, [param] Tribut zu zollen! Wir brauchen dich, um der Welt von ihren schlechten Taten zu berichten.
+We have been forced to pay tribute to [civName]! We need you to tell the world of their ill deeds. = Wir sind gezwungen, [civName] Tribut zu zollen! Wir brauchen dich, um der Welt von ihren schlechten Taten zu berichten.
 
-We have heard the tenets of [param] and are most curious. Will you send missionaries to teach us about your religion? = Wir haben die Lehren von [param] gehört und sind sehr neugierig. Werdet ihr Missionare aussenden, um uns eure Religion zu lehren?
+We have heard the tenets of [religionName] and are most curious. Will you send missionaries to teach us about your religion? = Wir haben die Lehren von [religionName] gehört und sind sehr neugierig. Werdet ihr Missionare aussenden, um uns eure Religion zu lehren?
 
 
 #################### Lines from Ruins from Civ V - Vanilla ####################
@@ -3416,10 +3413,10 @@ squatters wishing to settle under your rule = Wilde Siedler, die sich unter dein
 An ancient tribe trained us in their ways of combat! = Ein uralter Stamm hat uns in seinen Kampfkünsten ausgebildet!
 your exploring unit receives training = deine erkundende Einheit erhält eine Beförderung
 
-We have found survivors in the ruins! Population added to [param]. = Wir haben Überlebende in den Ruinen gefunden! Bevölkerung zu [param] hinzugefügt.
+We have found survivors in the ruins! Population added to [cityName]. = Wir haben Überlebende in den Ruinen gefunden! Bevölkerung zu [cityName] hinzugefügt.
 survivors (adds population to a city) = Überlebende (fügt Bevökerung einer Stadt hinzu)
 
-We have found a stash of [param] Gold in the ruins! = Wir haben einen Haufen von [param] Gold in den Ruinen gefunden!
+We have found a stash of [goldAmount] Gold in the ruins! = Wir haben einen Haufen von [goldAmount] Gold in den Ruinen gefunden!
 a stash of gold = erhalte einen Haufen Gold
 
 discover a lost technology = entdecke eine verlorene Technologie
@@ -3638,6 +3635,7 @@ Tundra = Tundra
 Desert = Wüste
 
 Lakes = Seen
+Fresh water = Frischwasser
 
 Mountain = Berge
 Has an elevation of [amount] for visibility calculations = Hat eine Erhebung von [amount] für die Berechnung der Sichtweite
@@ -3657,6 +3655,7 @@ A Camp can be built here without cutting it down = Hier kann ein Lager gebaut we
 Jungle = Dschungel
 
 Marsh = Sumpf
+Rare feature = Seltene Geländeform
 Only Polders can be built here = Hier können nur Polder gebaut werden
 
 Fallout = Verseucht
@@ -3852,10 +3851,13 @@ Porcelain = Porzellan
 #################### Lines from UnitPromotions from Civ V - Vanilla ####################
 
 Sword = Schwert
+Mounted = Beritten
+Siege = Belagerung
 Ranged Gunpowder = Schießpulver-Fernkampf
 Armored = Gepanzert
 Melee Water = Wasser-Nahkampf
 Ranged Water = Wasser-Fernkampf
+Submarine = U-Boot
 Heal Instantly = Sofortige Heilung
 Heal this unit by [amount] HP = Heile diese Einheit um [amount] LP
 Doing so will consume this opportunity to choose a Promotion = Dadurch wird die Möglichkeit, eine Beförderung zu wählen, verbraucht.
@@ -3914,6 +3916,7 @@ Medic = Sanitäter I
 All adjacent units heal [amount] HP when healing = Beim Heilen werden alle benachbarten Einheiten um [amount] LP geheilt
 
 Medic II = Sanitäter II
+in [tileFilter] tiles = auf [tileFilter] Feldern
 [amount] HP when healing = [amount] LP bei Heilung
 
 Scouting I = Spähen I
@@ -3974,6 +3977,7 @@ Flight Deck III = Flugdeck III
 Supply = Versorgung
 May heal outside of friendly territory = Darf auch außerhalb von befreundetem Territorium heilen
 
+Bomber = Bomber
 Siege I = Belagerung I
 
 Siege II = Belagerung II
@@ -3983,6 +3987,7 @@ Siege III = Belagerung III
 Evasion = Ausweichen
 Damage taken from interception reduced by [amount]% = Durch Abfangen verursachter Schaden um [amount]% reduziert
 
+Fighter = Jagdflugzeug
 Interception I = Abfangen I
 [amount]% Damage when intercepting = [amount]% Schaden beim Abfangen
 
@@ -4078,10 +4083,29 @@ Can see over obstacles = Kann über Hindernisse hinweg sehen
 
 Atomic Bomber = Atombomber
 
+Missile = Rakete
 Self-destructs when attacking = Selbstzerstörung beim Angriff
 Cannot be intercepted = Kann nicht abgefangen werden
 
 Can pass through impassable tiles = Kann sich über unpassierbare Felder bewegen
+
+Melee = Nahkampf
+
+Ranged = Fernkampf
+
+Armor = Panzerung
+
+WaterCivilian = Wasser-Zivilist
+
+WaterMelee = Wassernahkampf
+
+WaterRanged = Wasserfernkampf
+
+WaterSubmarine = U-Boote
+
+WaterAircraftCarrier = Flugzeugträger
+
+AtomicBomber = Atombomber
 
 
 #################### Lines from Units from Civ V - Vanilla ####################
@@ -4159,6 +4183,7 @@ Knight = Ritter
 Camel Archer = Kamel-Bogenschütze
 
 Conquistador = Konquistador
+on foreign continents = auf fremden Kontinenten
 
 Naresuan's Elephant = Naresuans Elefant
 
@@ -4249,6 +4274,7 @@ Anti-Tank Gun = Panzerabwehr-Kanone
 
 Atomic Bomb = Atombombe
 Nuclear weapon of Strength [amount] = Atomwaffe der Stärke [amount]
+if [buildingName] is constructed = wenn [buildingName] gebaut wurde
 Blast radius [amount] = Explosionsradius [amount]
 
 Rocket Artillery = Raketenartillerie
@@ -4283,6 +4309,7 @@ Great Artist = Großer Künstler
 Can start an [amount]-turn golden age = Kann [amount]-Runden goldenes Zeitalter starten
 Can construct [improvementName] = Kann [improvementName] erbauen
 Great Person - [stat] = Große Persönlichkeit - [stat]
+Unbuildable = nicht baubar
 
 Great Scientist = Großer Wissenschaftler
 Can hurry technology research = Kann Erforschung von Technologien beschleunigen
@@ -4341,6 +4368,7 @@ Faith Healers = Glaubensheiler
 Fertility Rites = Fruchtbarkeitsraten
 
 God of Craftsman = Gott der Handwerker
+in cities with at least [amount] [populationFilter] = in Städten mit mindestens [amount] [populationFilter]
 
 God of the Open Sky = Gott des offenen Himmels
 
@@ -4392,6 +4420,7 @@ Feed the World = Die Welt ernähren
 Guruship = Guruschaft
 
 Holy Warriors = Heilige Krieger
+before the [era] = vor [era]
 May buy [baseUnitFilter] units with [stat] for [amount] times their normal Production cost = Kann [baseUnitFilter] Einheiten mit [stat] kaufen für das [amount]-fache der normalen Produktionskosten
 
 Liturgical Drama = Liturgisches Drama
@@ -4412,6 +4441,7 @@ Religious Community = Religiöses Gemeinschaft
 [amount]% [stat] from every follower, up to [amount2]% = [amount]% [stat] von jedem Anhänger, bis zu [amount2]%
 
 Swords into Ploughshares = Schwerter zu Pflugscharen
+when not at war = wenn nicht im Krieg
 
 Founder = Gründer
 Ceremonial Burial = Rituelle Grabstädte
@@ -4544,9 +4574,6 @@ Starting in this era disables religion = Wenn in dieser Ära begonnen wird, wird
 
 
 Marine = Marine
-
-
-#################### Lines from GlobalUniques from Civ V - Gods & Kings ####################
 
 
 #################### Lines from Nations from Civ V - Gods & Kings ####################
@@ -4871,6 +4898,7 @@ Llanfairpwllgwyngyll = Llanfairpwllgwyngyll
 Falmouth = Falmouth
 Lorient = Lorient
 Celts = Kelten
+with [amount] to [amount2] neighboring [tileFilter] [tileFilter2] tiles = mit [amount] bis [amount2] benachbarten [tileFilter] [tileFilter2] Feldern
 
 Haile Selassie = Haile Selassie
 I have tried all other avenues, but yet you persist in this madness. I hope, for your sake, your end is swift. = Ich habe alle anderen Möglichkeiten ausprobiert, aber ihr beharrt immer noch auf diesem Wahnsinn. Ich hoffe für Euch, dass Ihr ein schnelles Ende findet.
@@ -4915,6 +4943,7 @@ Gambela = Gambela
 Ziway = Ziway
 Weldiya = Weldiya
 Ethiopia = Äthiopien
+when fighting units from a Civilization with more Cities than you = beim Kampf gegen Einheiten einer Zivilisation mit mehr Städten als du
 
 Pacal = Pacal
 A sacrifice unlike all others must be made! = Es muss ein Opfer gebracht werden, das es so noch nie gegeben hat!
@@ -5000,10 +5029,10 @@ Taoism = Taoismus
 #################### Lines from Ruins from Civ V - Gods & Kings ####################
 
 
-We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[param] Faith) = Wir haben in den Ruinen heilige Symbole gefunden, die uns ein tieferes Verständnis der Religion vermitteln! (+[param] Glaube)
+We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[faithAmount] Faith) = Wir haben in den Ruinen heilige Symbole gefunden, die uns ein tieferes Verständnis der Religion vermitteln! (+[faithAmount] Glaube)
 discover holy symbols = entdecke heilige Symbole
 
-We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[param] Faith) = Wir haben in den Ruinen eine uralte Prophezeiung gefunden, die unsere spirituelle Verbindung erheblich verstärkt! (+[param] Glaube)
+We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[faithAmount] Faith) = Wir haben in den Ruinen eine uralte Prophezeiung gefunden, die unsere spirituelle Verbindung erheblich verstärkt! (+[faithAmount] Glaube)
 an ancient prophecy = eine uralte Prophezeiung
 
 
@@ -5061,7 +5090,15 @@ Polder = Polder
 #################### Lines from TileResources from Civ V - Gods & Kings ####################
 
 
+Citrus = Zitrusfrüchte
+
+Copper = Kupfer
+
+Crab = Krabben
+
 Salt = Salz
+
+Truffles = Trüffel
 
 
 #################### Lines from UnitPromotions from Civ V - Gods & Kings ####################
@@ -5392,44 +5429,20 @@ No Sight = Keine Sicht
 [amount] XP gained from combat = [amount] EP im Kampf gewonnen
 Irremovable = Nicht entfernbar
 when at war = wenn im Krieg
-when not at war = wenn nicht im Krieg
-during a Golden Age = während eines Goldenen Zeitalters
 with [resource] = mit [resource]
-while the empire is happy = solange das Reich glücklich ist
 when between [amount] and [amount2] Happiness = wenn zwischen [amount] und [amount2] Zufriedenheit
 when below [amount] Happiness = wenn unterhalb [amount] Zufriedenheit
 during the [era] = während [era]
-before the [era] = vor [era]
-starting from the [era] = beginnend mit [era]
 if no other Civilization has researched this = wenn keine andere Zivilisation dies bereits erforscht hat
-after discovering [tech] = nach dem Entdecken von [tech]
-before discovering [tech] = vor dem Entdecken von [tech]
 upon discovering [tech] = beim Entdecken von [tech]
 after adopting [policy] = nach dem Verabschieden von [policy]
-before adopting [policy] = vor dem Verabschieden von [policy]
-if [buildingName] is constructed = wenn [buildingName] gebaut wurde
-for [amount] turns = für [amount] Runden
 by consuming this unit = durch Verbrauch dieser Einheit
 in cities with a [buildingFilter] = in Städten mit [buildingFilter]
-in cities without a [buildingFilter] = in Städten ohne [buildingFilter]
-in cities with at least [amount] [populationFilter] = in Städten mit mindestens [amount] [populationFilter]
-with a garrison = mit einer Garnison
-for [mapUnitFilter] units = für [mapUnitFilter] Einheiten
 for units with [promotion] = für Einheiten mit [promotion]
 for units without [promotion] = für Einheiten ohne [promotion]
-vs cities = vs Städte
-vs [mapUnitFilter] units = vs [mapUnitFilter] Einheiten
-when fighting units from a Civilization with more Cities than you = beim Kampf gegen Einheiten einer Zivilisation mit mehr Städten als du
-when attacking = beim Angriff
-when defending = beim Verteidigen
-when fighting in [tileFilter] tiles = wenn auf [tileFilter] gekämpft wird
-on foreign continents = auf fremden Kontinenten
-when adjacent to a [mapUnitFilter] unit = wenn benachbart zu einer [mapUnitFilter] Einheit
 when above [amount] HP = wenn mehr als [amount] LP
 when below [amount] HP = wenn weniger als [amount] LP
 with [amount] to [amount2] neighboring [tileFilter] tiles = mit [amount] bis [amount2] benachbarten [tileFilter] Feldern
-with [amount] to [amount2] neighboring [tileFilter] [tileFilter2] tiles = mit [amount] bis [amount2] benachbarten [tileFilter] [tileFilter2] Feldern
-in [tileFilter] tiles = auf [tileFilter] Feldern
 in [tileFilter] [tileFilter2] tiles = auf [tileFilter] [tileFilter2] Feldern
 in tiles without [tileFilter] = auf Felder ohne [tileFilter]
 on water maps = auf Wasserkarten

--- a/android/assets/jsons/translations/Greek.properties
+++ b/android/assets/jsons/translations/Greek.properties
@@ -1684,10 +1684,6 @@ Can be constructed by =
 Defence bonus = 
  # Requires translation!
 Movement cost = 
- # Requires translation!
-Open terrain = 
- # Requires translation!
-Rough Terrain = 
 for = γιά
  # Requires translation!
 Missing translations: = 
@@ -1907,153 +1903,6 @@ Enhancing religion =
  # Requires translation!
 Enhanced religion = 
 
-# Terrains
-
-Impassable = Απροσπέραστο
- # Requires translation!
-Rare feature = 
-
-# terrainFilters (so for uniques like: "[stats] from [terrainFilter] tiles")
-
-All = όλοι  
-Water = Νερό
-Land = Γη
-Coastal = Παραλιακός
-River = Ποταμός
- # Requires translation!
-Rough terrain = 
-Foreign Land = Ξένη γη
- # Requires translation!
-Foreign = 
- # Requires translation!
-Friendly Land = 
- # Requires translation!
-Water resource = 
- # Requires translation!
-Bonus resource = 
- # Requires translation!
-Luxury resource = 
- # Requires translation!
-Strategic resource = 
- # Requires translation!
-Fresh water = 
- # Requires translation!
-non-fresh water = 
- # Requires translation!
-Natural Wonder = 
- # Requires translation!
-Hybrid = 
- # Requires translation!
-Undesirable = 
- # Requires translation!
-Desirable = 
- # Requires translation!
-Featureless = 
- # Requires translation!
-Fresh Water = 
-
-# improvementFilters
-
- # Requires translation!
-All Road = 
-Great Improvement = Τέλεια βελτίωση 
-Great = Τέλειος/α/ο
-
-# Resources
-
- # Requires translation!
-Bison = 
- # Requires translation!
-Copper = 
- # Requires translation!
-Cocoa = 
-Crab = Καβούρι
- # Requires translation!
-Citrus = 
- # Requires translation!
-Truffles = 
- # Requires translation!
-Strategic = 
- # Requires translation!
-Bonus = 
- # Requires translation!
-Luxury = 
-
-# Unit types
-
-City = Πόλη
-Civilian = Πολίτης
- # Requires translation!
-Melee = 
- # Requires translation!
-Ranged = 
-Scout = Κατάσκοπος
- # Requires translation!
-Mounted = 
- # Requires translation!
-Armor = 
- # Requires translation!
-Siege = 
-
- # Requires translation!
-WaterCivilian = 
- # Requires translation!
-WaterMelee = 
- # Requires translation!
-WaterRanged = 
- # Requires translation!
-WaterSubmarine = 
- # Requires translation!
-WaterAircraftCarrier = 
-
- # Requires translation!
-Fighter = 
- # Requires translation!
-Bomber = 
-AtomicBomber = Ατομική βόμβα
- # Requires translation!
-Missile = 
-
-
-# Unit filters and other unit related things
-
- # Requires translation!
-Air = 
- # Requires translation!
-air units = 
-Barbarian = Βάρβαρος
-Barbarians = Βάρβαροι
-Embarked = Επιβιβασμένος/η/ο
- # Requires translation!
-land units = 
- # Requires translation!
-Military = 
-# Deprecated since 3.15.2, but should still be translated until it is officially removed
- # Requires translation!
-military water = 
- # Requires translation!
-non-air = 
-Nuclear Weapon = Πυρηνικό όπλο
- # Requires translation!
-Submarine = 
- # Requires translation!
-submarine units = 
- # Requires translation!
-Unbuildable = 
- # Requires translation!
-water units = 
-wounded units = Τραυματισμένες μονάδες
-Wounded = Τραυματισμένος/η/ο
-
-# For the "All newly-trained [relevant] units in this city receive the [] promotion" translation. Relevant as in 'units that can receive'
- # Requires translation!
-relevant = 
-
-# For "May choose [amount] additional [beliefType] beliefs when [founding/enhancing] a religion"
- # Requires translation!
-founding = 
- # Requires translation!
-enhancing = 
 
 # Promotions
 
@@ -2064,6 +1913,7 @@ Pick promotion =
 units in open terrain = 
  # Requires translation!
 units in rough terrain = 
+wounded units = Τραυματισμένες μονάδες
  # Requires translation!
 Targeting II (air) = 
  # Requires translation!
@@ -2225,6 +2075,13 @@ Never destroyed when the city is captured =
  # Requires translation!
 Invisible to others = 
 
+# Unused Resources
+
+ # Requires translation!
+Bison = 
+ # Requires translation!
+Cocoa = 
+
 
 # In English we just paste all these conditionals at the end of each unique, but in your language that
 # may not turn into valid sentences. Therefore we have the following two translations to determine
@@ -2255,6 +2112,41 @@ ConditionalsPlacement =
 ########################### AUTOMATICALLY GENERATED TRANSLATABLE STRINGS ########################### 
 
 
+######### Map Unit Filters ###########
+
+Wounded = Τραυματισμένος/η/ο
+Barbarians = Βάρβαροι
+ # Requires translation!
+City-State = 
+Embarked = Επιβιβασμένος/η/ο
+ # Requires translation!
+Non-City = 
+
+######### Unit Type Filters ###########
+
+ # Requires translation!
+Military = 
+Civilian = Πολίτης
+ # Requires translation!
+non-air = 
+ # Requires translation!
+relevant = 
+Nuclear Weapon = Πυρηνικό όπλο
+City = Πόλη
+ # Requires translation!
+Air = 
+ # Requires translation!
+land units = 
+ # Requires translation!
+water units = 
+ # Requires translation!
+air units = 
+ # Requires translation!
+military units = 
+ # Requires translation!
+submarine units = 
+Barbarian = Βάρβαρος
+
 ######### City filters ###########
 
 in this city = Σε αυτήν την πόλη
@@ -2282,6 +2174,82 @@ in holy cities =
 in City-State cities = 
  # Requires translation!
 in cities following this religion = 
+
+######### Population Filters ###########
+
+ # Requires translation!
+Unemployed = 
+ # Requires translation!
+Followers of the Majority Religion = 
+ # Requires translation!
+Followers of this Religion = 
+
+######### Terrain Filters ###########
+
+All = όλοι  
+Coastal = Παραλιακός
+River = Ποταμός
+ # Requires translation!
+Open terrain = 
+ # Requires translation!
+Rough terrain = 
+ # Requires translation!
+Water resource = 
+Foreign Land = Ξένη γη
+ # Requires translation!
+Foreign = 
+ # Requires translation!
+Friendly Land = 
+ # Requires translation!
+Enemy Land = 
+ # Requires translation!
+Featureless = 
+ # Requires translation!
+Fresh Water = 
+ # Requires translation!
+non-fresh water = 
+ # Requires translation!
+Natural Wonder = 
+Impassable = Απροσπέραστο
+Land = Γη
+Water = Νερό
+ # Requires translation!
+Luxury resource = 
+ # Requires translation!
+Strategic resource = 
+ # Requires translation!
+Bonus resource = 
+
+######### Tile Filters ###########
+
+ # Requires translation!
+unimproved = 
+ # Requires translation!
+All Road = 
+Great Improvement = Τέλεια βελτίωση 
+
+######### Region Types ###########
+
+ # Requires translation!
+Hybrid = 
+
+######### Terrain Quality ###########
+
+ # Requires translation!
+Undesirable = 
+ # Requires translation!
+Desirable = 
+
+######### Improvement Filters ###########
+
+Great = Τέλειος/α/ο
+
+######### Prophet Action Filters ###########
+
+ # Requires translation!
+founding = 
+ # Requires translation!
+enhancing = 
 
 ######### Unique Specials ###########
 
@@ -2319,6 +2287,8 @@ Temple of Artemis = Ἀρτεμίσιον
 The Great Lighthouse = 
  # Requires translation!
 'They that go down to the sea in ships, that do business in great waters; these see the works of the Lord, and his wonders in the deep.' - The Bible, Psalms 107:23-24 = 
+ # Requires translation!
+for [mapUnitFilter] units = 
  # Requires translation!
 [amount] Movement = 
  # Requires translation!
@@ -2386,6 +2356,10 @@ Krepost =
 Statue of Zeus = Τὸ Ἄγαλμα τοῦ Διὸς 
  # Requires translation!
 'He spoke, the son of Kronos, and nodded his head with the dark brows, and the immortally anointed hair of the great god swept from his divine head, and all Olympos was shaken' - The Iliad = 
+ # Requires translation!
+vs cities = 
+ # Requires translation!
+when attacking = 
  # Requires translation!
 [amount]% Strength = 
 
@@ -2527,12 +2501,16 @@ Castle = Κάστρο
  # Requires translation!
 Mughal Fort = 
  # Requires translation!
+after discovering [tech] = 
+ # Requires translation!
 [stats] [cityFilter] = 
 
  # Requires translation!
 Himeji Castle = 
  # Requires translation!
 'Bushido is realized in the presence of death. This means choosing death whenever there is a choice between life and death. There is no other reasoning.' - Yamamoto Tsunetomo = 
+ # Requires translation!
+when fighting in [tileFilter] tiles = 
 
  # Requires translation!
 Ironworks = 
@@ -2683,6 +2661,8 @@ Pentagon = Πεντάγωνο
  # Requires translation!
 Solar Plant = 
  # Requires translation!
+in cities without a [buildingFilter] = 
+ # Requires translation!
 Only available = 
 
  # Requires translation!
@@ -2729,6 +2709,7 @@ King = Βασιλέας
 Era Starting Unit = 
 
 Emperor = Αυτοκράτορας
+Scout = Κατάσκοπος
 
  # Requires translation!
 Immortal = 
@@ -2771,9 +2752,6 @@ Information era = Εποχή της πληροφορίας
 
  # Requires translation!
 Future era = 
-
-
-#################### Lines from GlobalUniques from Civ V - Vanilla ####################
 
 
 #################### Lines from Nations from Civ V - Vanilla ####################
@@ -3381,6 +3359,8 @@ Bourges =
 Calais = 
  # Requires translation!
 France = 
+ # Requires translation!
+before discovering [tech] = 
 
  # Requires translation!
 Catherine = 
@@ -3488,7 +3468,7 @@ Double quantity of [resource] produced =
  # Requires translation!
 Augustus Caesar = 
  # Requires translation!
-My treasury contains little and my soldiers are getting impatient... ...therefore you must die. = 
+My treasury contains little and my soldiers are getting impatient... (sigh) ...therefore you must die. = 
  # Requires translation!
 So brave, yet so stupid! If only you had a brain similar to your courage. = 
  # Requires translation!
@@ -4528,6 +4508,8 @@ Patigrbana =
  # Requires translation!
 Phrada = 
 Persia = Περσία
+ # Requires translation!
+during a Golden Age = 
 
  # Requires translation!
 Kamehameha I = 
@@ -4630,6 +4612,8 @@ Pileni =
 Nukumanu = 
  # Requires translation!
 Polynesia = 
+ # Requires translation!
+starting from the [era] = 
  # Requires translation!
 Enables embarkation for land units = 
  # Requires translation!
@@ -5532,6 +5516,8 @@ Oligarchy =
  # Requires translation!
 Units in cities cost no Maintenance = 
  # Requires translation!
+with a garrison = 
+ # Requires translation!
 [amount]% Strength for cities = 
  # Requires translation!
 Landed Elite = 
@@ -5570,6 +5556,8 @@ Warrior Code =
  # Requires translation!
 Discipline = 
  # Requires translation!
+when adjacent to a [mapUnitFilter] unit = 
+ # Requires translation!
 Military Tradition = 
  # Requires translation!
 [amount]% XP gained from combat = 
@@ -5581,6 +5569,8 @@ Professional Army =
 Honor Complete = 
  # Requires translation!
 Honor = 
+ # Requires translation!
+vs [mapUnitFilter] units = 
  # Requires translation!
 Notified of new Barbarian encampments = 
 
@@ -5602,6 +5592,8 @@ Free Religion =
 Piety Complete = 
  # Requires translation!
 Piety = 
+ # Requires translation!
+before adopting [policy] = 
 
  # Requires translation!
 Philantropy = 
@@ -5674,12 +5666,16 @@ Rationalism Complete =
  # Requires translation!
 Rationalism = 
  # Requires translation!
+while the empire is happy = 
+ # Requires translation!
 [amount]% [stat] = 
 
  # Requires translation!
 Constitution = 
  # Requires translation!
 Universal Suffrage = 
+ # Requires translation!
+when defending = 
  # Requires translation!
 Civil Society = 
  # Requires translation!
@@ -5713,6 +5709,8 @@ Police State =
 Total War = 
  # Requires translation!
 Autocracy Complete = 
+ # Requires translation!
+for [amount] turns = 
  # Requires translation!
 Autocracy = 
  # Requires translation!
@@ -5753,42 +5751,42 @@ We feel threatened by a Barbarian Camp near our city. Please take care of it. =
  # Requires translation!
 Connect Resource = 
  # Requires translation!
-In order to make our civilizations stronger, connect [param] to your trade network. = 
+In order to make our civilizations stronger, connect [tileResource] to your trade network. = 
 
  # Requires translation!
 Construct Wonder = 
  # Requires translation!
-We recommend you to start building [param] to show the whole world your civilization strength. = 
+We recommend you to start building [wonder] to show the whole world your civilization strength. = 
 
  # Requires translation!
 Acquire Great Person = 
  # Requires translation!
-Great People can change the course of a Civilization! You will be rewarded for acquiring a new [param]. = 
+Great People can change the course of a Civilization! You will be rewarded for acquiring a new [greatPerson]. = 
 
  # Requires translation!
 Conquer City State = 
  # Requires translation!
-It's time to erase the City-State of [param] from the map. You will be greatly rewarded for conquering them! = 
+It's time to erase the City-State of [cityState] from the map. You will be greatly rewarded for conquering them! = 
 
  # Requires translation!
 Find Player = 
  # Requires translation!
-You have yet to discover where [param] set up their cities. You will be rewarded for finding their territories. = 
+You have yet to discover where [civName] set up their cities. You will be rewarded for finding their territories. = 
 
  # Requires translation!
 Find Natural Wonder = 
  # Requires translation!
-Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [param] yet. = 
+Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [naturalWonder] yet. = 
 
  # Requires translation!
 Give Gold = 
  # Requires translation!
-We are suffering great poverty after being robbed by [param], and unless we receive a sum of Gold, it's only a matter of time before we collapse. = 
+We are suffering great poverty after being robbed by [civName], and unless we receive a sum of Gold, it's only a matter of time before we collapse. = 
 
  # Requires translation!
 Pledge to Protect = 
  # Requires translation!
-We need your protection to stop the aggressions of [param]. By signing a Pledge of Protection, you'll confirm the bond that ties us. = 
+We need your protection to stop the aggressions of [civName]. By signing a Pledge of Protection, you'll confirm the bond that ties us. = 
 
  # Requires translation!
 Contest Culture = 
@@ -5808,20 +5806,20 @@ The civilization with the largest number of new Technologies researched will gai
  # Requires translation!
 Invest = 
  # Requires translation!
-Our people are rejoicing thanks to a tourism boom. For a certain amount of time, any Gold donation will yield [amount]% extra Influence. = 
+Our people are rejoicing thanks to a tourism boom. For a certain amount of time, any Gold donation will yield [50]% extra Influence. = 
 
  # Requires translation!
 Bully City State = 
  # Requires translation!
-We are tired of the pretensions of [param]. If someone were to put them in their place by Demanding Tribute from them, they would be rewarded. = 
+We are tired of the pretensions of [cityState]. If someone were to put them in their place by Demanding Tribute from them, they would be rewarded. = 
 
  # Requires translation!
 Denounce Civilization = 
  # Requires translation!
-We have been forced to pay tribute to [param]! We need you to tell the world of their ill deeds. = 
+We have been forced to pay tribute to [civName]! We need you to tell the world of their ill deeds. = 
 
  # Requires translation!
-We have heard the tenets of [param] and are most curious. Will you send missionaries to teach us about your religion? = 
+We have heard the tenets of [religionName] and are most curious. Will you send missionaries to teach us about your religion? = 
 
 
 #################### Lines from Ruins from Civ V - Vanilla ####################
@@ -5843,12 +5841,12 @@ An ancient tribe trained us in their ways of combat! =
 your exploring unit receives training = 
 
  # Requires translation!
-We have found survivors in the ruins! Population added to [param]. = 
+We have found survivors in the ruins! Population added to [cityName]. = 
  # Requires translation!
 survivors (adds population to a city) = 
 
  # Requires translation!
-We have found a stash of [param] Gold in the ruins! = 
+We have found a stash of [goldAmount] Gold in the ruins! = 
  # Requires translation!
 a stash of gold = 
 
@@ -6233,6 +6231,8 @@ Tundra =
 Desert = έρημος
 
 Lakes = Λίμνη
+ # Requires translation!
+Fresh water = 
 
  # Requires translation!
 Mountain = 
@@ -6261,6 +6261,8 @@ Jungle = Ζούγκλα
 
  # Requires translation!
 Marsh = 
+ # Requires translation!
+Rare feature = 
  # Requires translation!
 Only Polders can be built here = 
 
@@ -6542,6 +6544,10 @@ Porcelain =
  # Requires translation!
 Sword = 
  # Requires translation!
+Mounted = 
+ # Requires translation!
+Siege = 
+ # Requires translation!
 Ranged Gunpowder = 
  # Requires translation!
 Armored = 
@@ -6549,6 +6555,8 @@ Armored =
 Melee Water = 
  # Requires translation!
 Ranged Water = 
+ # Requires translation!
+Submarine = 
  # Requires translation!
 Heal Instantly = 
  # Requires translation!
@@ -6641,6 +6649,8 @@ All adjacent units heal [amount] HP when healing =
 
  # Requires translation!
 Medic II = 
+ # Requires translation!
+in [tileFilter] tiles = 
  # Requires translation!
 [amount] HP when healing = 
 
@@ -6735,6 +6745,8 @@ Supply =
 May heal outside of friendly territory = 
 
  # Requires translation!
+Bomber = 
+ # Requires translation!
 Siege I = 
 
  # Requires translation!
@@ -6748,6 +6760,8 @@ Evasion =
  # Requires translation!
 Damage taken from interception reduced by [amount]% = 
 
+ # Requires translation!
+Fighter = 
  # Requires translation!
 Interception I = 
  # Requires translation!
@@ -6893,12 +6907,40 @@ Can see over obstacles =
 Atomic Bomber = 
 
  # Requires translation!
+Missile = 
+ # Requires translation!
 Self-destructs when attacking = 
  # Requires translation!
 Cannot be intercepted = 
 
  # Requires translation!
 Can pass through impassable tiles = 
+
+ # Requires translation!
+Melee = 
+
+ # Requires translation!
+Ranged = 
+
+ # Requires translation!
+Armor = 
+
+ # Requires translation!
+WaterCivilian = 
+
+ # Requires translation!
+WaterMelee = 
+
+ # Requires translation!
+WaterRanged = 
+
+ # Requires translation!
+WaterSubmarine = 
+
+ # Requires translation!
+WaterAircraftCarrier = 
+
+AtomicBomber = Ατομική βόμβα
 
 
 #################### Lines from Units from Civ V - Vanilla ####################
@@ -7014,6 +7056,8 @@ Camel Archer =
 
  # Requires translation!
 Conquistador = 
+ # Requires translation!
+on foreign continents = 
 
  # Requires translation!
 Naresuan's Elephant = 
@@ -7147,6 +7191,8 @@ Atomic Bomb =
  # Requires translation!
 Nuclear weapon of Strength [amount] = 
  # Requires translation!
+if [buildingName] is constructed = 
+ # Requires translation!
 Blast radius [amount] = 
 
  # Requires translation!
@@ -7201,6 +7247,8 @@ Can start an [amount]-turn golden age =
 Can construct [improvementName] = 
  # Requires translation!
 Great Person - [stat] = 
+ # Requires translation!
+Unbuildable = 
 
  # Requires translation!
 Great Scientist = 
@@ -7296,6 +7344,8 @@ Fertility Rites =
 
  # Requires translation!
 God of Craftsman = 
+ # Requires translation!
+in cities with at least [amount] [populationFilter] = 
 
 God of the Open Sky = Θεός του ανοικτού ουρανού
 
@@ -7368,6 +7418,8 @@ Guruship =
  # Requires translation!
 Holy Warriors = 
  # Requires translation!
+before the [era] = 
+ # Requires translation!
 May buy [baseUnitFilter] units with [stat] for [amount] times their normal Production cost = 
 
  # Requires translation!
@@ -7396,6 +7448,8 @@ Religious Community =
 
  # Requires translation!
 Swords into Ploughshares = 
+ # Requires translation!
+when not at war = 
 
 Founder = Ιδρυτής 
  # Requires translation!
@@ -7586,9 +7640,6 @@ Starting in this era disables religion =
 
  # Requires translation!
 Marine = 
-
-
-#################### Lines from GlobalUniques from Civ V - Gods & Kings ####################
 
 
 #################### Lines from Nations from Civ V - Gods & Kings ####################
@@ -8210,6 +8261,8 @@ Falmouth =
 Lorient = 
  # Requires translation!
 Celts = 
+ # Requires translation!
+with [amount] to [amount2] neighboring [tileFilter] [tileFilter2] tiles = 
 
  # Requires translation!
 Haile Selassie = 
@@ -8297,6 +8350,8 @@ Ziway =
 Weldiya = 
  # Requires translation!
 Ethiopia = 
+ # Requires translation!
+when fighting units from a Civilization with more Cities than you = 
 
  # Requires translation!
 Pacal = 
@@ -8444,12 +8499,12 @@ Taoism =
 
 
  # Requires translation!
-We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[param] Faith) = 
+We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[faithAmount] Faith) = 
  # Requires translation!
 discover holy symbols = 
 
  # Requires translation!
-We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[param] Faith) = 
+We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[faithAmount] Faith) = 
  # Requires translation!
 an ancient prophecy = 
 
@@ -8530,7 +8585,18 @@ Polder =
 
 
  # Requires translation!
+Citrus = 
+
+ # Requires translation!
+Copper = 
+
+Crab = Καβούρι
+
+ # Requires translation!
 Salt = 
+
+ # Requires translation!
+Truffles = 
 
 
 #################### Lines from UnitPromotions from Civ V - Gods & Kings ####################
@@ -9092,13 +9158,7 @@ Irremovable =
  # Requires translation!
 when at war = 
  # Requires translation!
-when not at war = 
- # Requires translation!
-during a Golden Age = 
- # Requires translation!
 with [resource] = 
- # Requires translation!
-while the empire is happy = 
  # Requires translation!
 when between [amount] and [amount2] Happiness = 
  # Requires translation!
@@ -9106,67 +9166,25 @@ when below [amount] Happiness =
  # Requires translation!
 during the [era] = 
  # Requires translation!
-before the [era] = 
- # Requires translation!
-starting from the [era] = 
- # Requires translation!
 if no other Civilization has researched this = 
- # Requires translation!
-after discovering [tech] = 
- # Requires translation!
-before discovering [tech] = 
  # Requires translation!
 upon discovering [tech] = 
  # Requires translation!
 after adopting [policy] = 
  # Requires translation!
-before adopting [policy] = 
- # Requires translation!
-if [buildingName] is constructed = 
- # Requires translation!
-for [amount] turns = 
- # Requires translation!
 by consuming this unit = 
  # Requires translation!
 in cities with a [buildingFilter] = 
  # Requires translation!
-in cities without a [buildingFilter] = 
- # Requires translation!
-in cities with at least [amount] [populationFilter] = 
- # Requires translation!
-with a garrison = 
- # Requires translation!
-for [mapUnitFilter] units = 
- # Requires translation!
 for units with [promotion] = 
  # Requires translation!
 for units without [promotion] = 
- # Requires translation!
-vs cities = 
- # Requires translation!
-vs [mapUnitFilter] units = 
- # Requires translation!
-when fighting units from a Civilization with more Cities than you = 
- # Requires translation!
-when attacking = 
- # Requires translation!
-when defending = 
- # Requires translation!
-when fighting in [tileFilter] tiles = 
- # Requires translation!
-on foreign continents = 
- # Requires translation!
-when adjacent to a [mapUnitFilter] unit = 
  # Requires translation!
 when above [amount] HP = 
  # Requires translation!
 when below [amount] HP = 
  # Requires translation!
 with [amount] to [amount2] neighboring [tileFilter] tiles = 
- # Requires translation!
-with [amount] to [amount2] neighboring [tileFilter] [tileFilter2] tiles = 
- # Requires translation!
-in [tileFilter] tiles = 
  # Requires translation!
 in [tileFilter] [tileFilter2] tiles = 
  # Requires translation!

--- a/android/assets/jsons/translations/Hungarian.properties
+++ b/android/assets/jsons/translations/Hungarian.properties
@@ -1369,8 +1369,6 @@ or [terrainType] =
 Can be constructed by = 
 Defence bonus = Védelmi bónusz
 Movement cost = Mozgási költség
-Open terrain = Nyílt terep
-Rough Terrain = Nehéz terep
 for = számára
 Missing translations: = Hiányzó fordítások:
 Resolution = Felbontás
@@ -1549,117 +1547,6 @@ Enhancing religion =
  # Requires translation!
 Enhanced religion = 
 
-# Terrains
-
-Impassable = Járhatatlan
-Rare feature = Ritka tereptárgy
-
-# terrainFilters (so for uniques like: "[stats] from [terrainFilter] tiles")
-
-All = Összes
-Water = Vízi
-Land = Föld
-Coastal = Parti
-River = Folyó
- # Requires translation!
-Rough terrain = 
-Foreign Land = Idegen föld
- # Requires translation!
-Foreign = 
-Friendly Land = Barátságos föld
-Water resource = Vízi alapanyag
-Bonus resource = Bónusz alapanyag
-Luxury resource = Luxus alapanyag
-Strategic resource = Stratégiai alapanyag
-Fresh water = Édesvíz
-non-fresh water = Sósvíz
-Natural Wonder = Természeti Csoda
- # Requires translation!
-Hybrid = 
- # Requires translation!
-Undesirable = 
- # Requires translation!
-Desirable = 
- # Requires translation!
-Featureless = 
- # Requires translation!
-Fresh Water = 
-
-# improvementFilters
-
- # Requires translation!
-All Road = 
- # Requires translation!
-Great Improvement = 
- # Requires translation!
-Great = 
-
-# Resources
-
-Bison = Bivaly
-Copper = Réz
-Cocoa = Kakaó
-Crab = Rák
-Citrus = Citrus
-Truffles = Szarvasgomba
-Strategic = Stratégiai
-Bonus = Bónusz
-Luxury = Luxus
-
-# Unit types
-
-City = Város
-Civilian = Polgár
-Melee = Közelharci
-Ranged = Távolsági
-Scout = Felderítő
-Mounted = Lovas
-Armor = Páncélozott
-Siege = Ostrom
-
-WaterCivilian = Vízi polgár
-WaterMelee = Vízi közelharci
-WaterRanged = Vízi távolsági
-WaterSubmarine = Tengeralatjáró
-WaterAircraftCarrier = Repülőgép hordozó
-
-Fighter = Vadászgép
-Bomber = Bombázó
-AtomicBomber = AtomBombázó
-Missile = Rakéta
-
-
-# Unit filters and other unit related things
-
-Air = Légi
-air units = légi egységek
-Barbarian = Barbár
-Barbarians = Barbárok
- # Requires translation!
-Embarked = 
-land units = földi egységek
-Military = hadsereg
-# Deprecated since 3.15.2, but should still be translated until it is officially removed
- # Requires translation!
-military water = 
-non-air = nem légi
-Nuclear Weapon = Nukleáris fegyver
-Submarine = Tengeralattjáró
- # Requires translation!
-submarine units = 
-Unbuildable = Megépíthetetlen
-water units = vízi egységek
-wounded units = sérült egységek
-Wounded = Sérült
-
-# For the "All newly-trained [relevant] units in this city receive the [] promotion" translation. Relevant as in 'units that can receive'
-relevant = megfelelő
-
-# For "May choose [amount] additional [beliefType] beliefs when [founding/enhancing] a religion"
- # Requires translation!
-founding = 
- # Requires translation!
-enhancing = 
 
 # Promotions
 
@@ -1667,6 +1554,7 @@ Pick promotion = Előléptetés választása
  OR  = VAGY
 units in open terrain = egységek nyílt terepen
 units in rough terrain = egységek nehéz terepen
+wounded units = sérült egységek
 Targeting II (air) = Célbemérés II (légi)
 Targeting III (air) = Célbemérés III (légi)
 Bonus when performing air sweep [bonusAmount]% = Bónusz légsöprés végrehajtásakor [bonusAmount]%
@@ -1798,6 +1686,11 @@ This Unit upgrades for free =
 Never destroyed when the city is captured = 
 Invisible to others = Láthatatlan mások számára
 
+# Unused Resources
+
+Bison = Bivaly
+Cocoa = Kakaó
+
 
 # In English we just paste all these conditionals at the end of each unique, but in your language that
 # may not turn into valid sentences. Therefore we have the following two translations to determine
@@ -1828,6 +1721,35 @@ ConditionalsPlacement =
 ########################### AUTOMATICALLY GENERATED TRANSLATABLE STRINGS ########################### 
 
 
+######### Map Unit Filters ###########
+
+Wounded = Sérült
+Barbarians = Barbárok
+ # Requires translation!
+City-State = 
+ # Requires translation!
+Embarked = 
+ # Requires translation!
+Non-City = 
+
+######### Unit Type Filters ###########
+
+Military = hadsereg
+Civilian = Polgár
+non-air = nem légi
+relevant = megfelelő
+Nuclear Weapon = Nukleáris fegyver
+City = Város
+Air = Légi
+land units = földi egységek
+water units = vízi egységek
+air units = légi egységek
+ # Requires translation!
+military units = 
+ # Requires translation!
+submarine units = 
+Barbarian = Barbár
+
 ######### City filters ###########
 
 in this city = ebben a városban
@@ -1857,6 +1779,76 @@ in holy cities =
 in City-State cities = 
  # Requires translation!
 in cities following this religion = 
+
+######### Population Filters ###########
+
+ # Requires translation!
+Unemployed = 
+ # Requires translation!
+Followers of the Majority Religion = 
+ # Requires translation!
+Followers of this Religion = 
+
+######### Terrain Filters ###########
+
+All = Összes
+Coastal = Parti
+River = Folyó
+Open terrain = Nyílt terep
+ # Requires translation!
+Rough terrain = 
+Water resource = Vízi alapanyag
+Foreign Land = Idegen föld
+ # Requires translation!
+Foreign = 
+Friendly Land = Barátságos föld
+ # Requires translation!
+Enemy Land = 
+ # Requires translation!
+Featureless = 
+ # Requires translation!
+Fresh Water = 
+non-fresh water = Sósvíz
+Natural Wonder = Természeti Csoda
+Impassable = Járhatatlan
+Land = Föld
+Water = Vízi
+Luxury resource = Luxus alapanyag
+Strategic resource = Stratégiai alapanyag
+Bonus resource = Bónusz alapanyag
+
+######### Tile Filters ###########
+
+ # Requires translation!
+unimproved = 
+ # Requires translation!
+All Road = 
+ # Requires translation!
+Great Improvement = 
+
+######### Region Types ###########
+
+ # Requires translation!
+Hybrid = 
+
+######### Terrain Quality ###########
+
+ # Requires translation!
+Undesirable = 
+ # Requires translation!
+Desirable = 
+
+######### Improvement Filters ###########
+
+ # Requires translation!
+Great = 
+
+######### Prophet Action Filters ###########
+
+ # Requires translation!
+founding = 
+ # Requires translation!
+enhancing = 
 
 ######### Unique Specials ###########
 
@@ -1890,6 +1882,8 @@ Temple of Artemis = Artemisz temploma
 
 The Great Lighthouse = Alexandriai világítótorony
 'They that go down to the sea in ships, that do business in great waters; these see the works of the Lord, and his wonders in the deep.' - The Bible, Psalms 107:23-24 = 'A kik hajókon tengerre szállnak, és a nagy vizeken kalmárkodnak, Azok látták az Úrnak dolgait, és az ő csodáit a mélységben.' - A Biblia, Zsoltárok 107:23-24
+ # Requires translation!
+for [mapUnitFilter] units = 
  # Requires translation!
 [amount] Movement = 
  # Requires translation!
@@ -1946,6 +1940,10 @@ Krepost = Krepost Erőd
 Statue of Zeus = Zeusz-szobor
  # Requires translation!
 'He spoke, the son of Kronos, and nodded his head with the dark brows, and the immortally anointed hair of the great god swept from his divine head, and all Olympos was shaken' - The Iliad = 
+ # Requires translation!
+vs cities = 
+ # Requires translation!
+when attacking = 
  # Requires translation!
 [amount]% Strength = 
 
@@ -2062,11 +2060,15 @@ Castle = Kastély
 
 Mughal Fort = Mogul erőd
  # Requires translation!
+after discovering [tech] = 
+ # Requires translation!
 [stats] [cityFilter] = 
 
 Himeji Castle = Himedzsi várkastély
  # Requires translation!
 'Bushido is realized in the presence of death. This means choosing death whenever there is a choice between life and death. There is no other reasoning.' - Yamamoto Tsunetomo = 
+ # Requires translation!
+when fighting in [tileFilter] tiles = 
 
 Ironworks = Vasművek
 
@@ -2190,6 +2192,8 @@ Pentagon = Pentagon
 
 Solar Plant = Naperőmű
  # Requires translation!
+in cities without a [buildingFilter] = 
+ # Requires translation!
 Only available = 
 
 Nuclear Plant = Atomerőmű
@@ -2231,6 +2235,7 @@ King = Király
 Era Starting Unit = Kor kezdő egysége
 
 Emperor = Császár
+Scout = Felderítő
 
 Immortal = Halhatatlan
 Worker = Munkás
@@ -2263,9 +2268,6 @@ Atomic era = Atom kor
 Information era = Információs kor
 
 Future era = Jövő kor
-
-
-#################### Lines from GlobalUniques from Civ V - Vanilla ####################
 
 
 #################### Lines from Nations from Civ V - Vanilla ####################
@@ -2702,6 +2704,8 @@ La Rochelle = La Rochelle
 Bourges = Bourges
 Calais = Calais
 France = Francia Birodalom
+ # Requires translation!
+before discovering [tech] = 
 
 Catherine = II. (Nagy) Katalin
  # Requires translation!
@@ -2768,7 +2772,7 @@ Double quantity of [resource] produced =
 
 Augustus Caesar = Augustus császár
  # Requires translation!
-My treasury contains little and my soldiers are getting impatient... ...therefore you must die. = 
+My treasury contains little and my soldiers are getting impatient... (sigh) ...therefore you must die. = 
  # Requires translation!
 So brave, yet so stupid! If only you had a brain similar to your courage. = 
  # Requires translation!
@@ -3483,6 +3487,8 @@ Patigrbana =
  # Requires translation!
 Phrada = 
 Persia = Perzsa Birodalom
+ # Requires translation!
+during a Golden Age = 
 
 Kamehameha I = Nagy Kamehameha
  # Requires translation!
@@ -3577,6 +3583,8 @@ Pileni =
  # Requires translation!
 Nukumanu = 
 Polynesia = Polinéz Birodalom
+ # Requires translation!
+starting from the [era] = 
 Enables embarkation for land units = Engedélyezi a földi egységeknek a vízre szállást
  # Requires translation!
 Enables [mapUnitFilter] units to enter ocean tiles = 
@@ -4312,6 +4320,8 @@ Oligarchy = Oligarchia
  # Requires translation!
 Units in cities cost no Maintenance = 
  # Requires translation!
+with a garrison = 
+ # Requires translation!
 [amount]% Strength for cities = 
 Landed Elite = Birtokos elit
  # Requires translation!
@@ -4337,6 +4347,8 @@ Liberty =
 
 Warrior Code = Harcosok törvénykönyve
 Discipline = Fegyelem
+ # Requires translation!
+when adjacent to a [mapUnitFilter] unit = 
 Military Tradition = Katonai hagyomány
  # Requires translation!
 [amount]% XP gained from combat = 
@@ -4345,6 +4357,8 @@ Professional Army = Hivatásos hadsereg
 Honor Complete = Becsület befejezve
  # Requires translation!
 Honor = 
+ # Requires translation!
+vs [mapUnitFilter] units = 
  # Requires translation!
 Notified of new Barbarian encampments = 
 
@@ -4361,6 +4375,8 @@ Free Religion =
 Piety Complete = Jámborság befejezve
  # Requires translation!
 Piety = 
+ # Requires translation!
+before adopting [policy] = 
 
 Philantropy = Emberbarátság
  # Requires translation!
@@ -4416,10 +4432,14 @@ Rationalism Complete = Racionalizmus befejezve
  # Requires translation!
 Rationalism = 
  # Requires translation!
+while the empire is happy = 
+ # Requires translation!
 [amount]% [stat] = 
 
 Constitution = Alkotmány
 Universal Suffrage = Általános választójog
+ # Requires translation!
+when defending = 
 Civil Society = Polgári társadalom
  # Requires translation!
 [amount]% Food consumption by specialists [cityFilter] = 
@@ -4443,6 +4463,8 @@ Quantity of strategic resources produced by the empire +[amount]% =
 Police State = Rendőrállam
 Total War = Totális háború
 Autocracy Complete = Autokrácia befejezve
+ # Requires translation!
+for [amount] turns = 
  # Requires translation!
 Autocracy = 
  # Requires translation!
@@ -4479,39 +4501,39 @@ We feel threatened by a Barbarian Camp near our city. Please take care of it. =
  # Requires translation!
 Connect Resource = 
  # Requires translation!
-In order to make our civilizations stronger, connect [param] to your trade network. = 
+In order to make our civilizations stronger, connect [tileResource] to your trade network. = 
 
 Construct Wonder = Csoda építése
  # Requires translation!
-We recommend you to start building [param] to show the whole world your civilization strength. = 
+We recommend you to start building [wonder] to show the whole world your civilization strength. = 
 
  # Requires translation!
 Acquire Great Person = 
  # Requires translation!
-Great People can change the course of a Civilization! You will be rewarded for acquiring a new [param]. = 
+Great People can change the course of a Civilization! You will be rewarded for acquiring a new [greatPerson]. = 
 
  # Requires translation!
 Conquer City State = 
  # Requires translation!
-It's time to erase the City-State of [param] from the map. You will be greatly rewarded for conquering them! = 
+It's time to erase the City-State of [cityState] from the map. You will be greatly rewarded for conquering them! = 
 
 Find Player = Játékos Megtalálása
  # Requires translation!
-You have yet to discover where [param] set up their cities. You will be rewarded for finding their territories. = 
+You have yet to discover where [civName] set up their cities. You will be rewarded for finding their territories. = 
 
 Find Natural Wonder = Természeti Csoda Megtalálása
  # Requires translation!
-Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [param] yet. = 
+Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [naturalWonder] yet. = 
 
  # Requires translation!
 Give Gold = 
  # Requires translation!
-We are suffering great poverty after being robbed by [param], and unless we receive a sum of Gold, it's only a matter of time before we collapse. = 
+We are suffering great poverty after being robbed by [civName], and unless we receive a sum of Gold, it's only a matter of time before we collapse. = 
 
  # Requires translation!
 Pledge to Protect = 
  # Requires translation!
-We need your protection to stop the aggressions of [param]. By signing a Pledge of Protection, you'll confirm the bond that ties us. = 
+We need your protection to stop the aggressions of [civName]. By signing a Pledge of Protection, you'll confirm the bond that ties us. = 
 
  # Requires translation!
 Contest Culture = 
@@ -4531,20 +4553,20 @@ The civilization with the largest number of new Technologies researched will gai
  # Requires translation!
 Invest = 
  # Requires translation!
-Our people are rejoicing thanks to a tourism boom. For a certain amount of time, any Gold donation will yield [amount]% extra Influence. = 
+Our people are rejoicing thanks to a tourism boom. For a certain amount of time, any Gold donation will yield [50]% extra Influence. = 
 
  # Requires translation!
 Bully City State = 
  # Requires translation!
-We are tired of the pretensions of [param]. If someone were to put them in their place by Demanding Tribute from them, they would be rewarded. = 
+We are tired of the pretensions of [cityState]. If someone were to put them in their place by Demanding Tribute from them, they would be rewarded. = 
 
  # Requires translation!
 Denounce Civilization = 
  # Requires translation!
-We have been forced to pay tribute to [param]! We need you to tell the world of their ill deeds. = 
+We have been forced to pay tribute to [civName]! We need you to tell the world of their ill deeds. = 
 
  # Requires translation!
-We have heard the tenets of [param] and are most curious. Will you send missionaries to teach us about your religion? = 
+We have heard the tenets of [religionName] and are most curious. Will you send missionaries to teach us about your religion? = 
 
 
 #################### Lines from Ruins from Civ V - Vanilla ####################
@@ -4566,12 +4588,12 @@ An ancient tribe trained us in their ways of combat! =
 your exploring unit receives training = 
 
  # Requires translation!
-We have found survivors in the ruins! Population added to [param]. = 
+We have found survivors in the ruins! Population added to [cityName]. = 
  # Requires translation!
 survivors (adds population to a city) = 
 
  # Requires translation!
-We have found a stash of [param] Gold in the ruins! = 
+We have found a stash of [goldAmount] Gold in the ruins! = 
  # Requires translation!
 a stash of gold = 
 
@@ -4808,6 +4830,7 @@ Tundra = Tundra
 Desert = Sivatag
 
 Lakes = Tavas
+Fresh water = Édesvíz
 
 Mountain = Hegyek
  # Requires translation!
@@ -4834,6 +4857,7 @@ A Camp can be built here without cutting it down =
 Jungle = Dzsungel
 
 Marsh = Mocsár
+Rare feature = Ritka tereptárgy
  # Requires translation!
 Only Polders can be built here = 
 
@@ -5060,6 +5084,8 @@ Porcelain = Porcelán
 
  # Requires translation!
 Sword = 
+Mounted = Lovas
+Siege = Ostrom
  # Requires translation!
 Ranged Gunpowder = 
  # Requires translation!
@@ -5068,6 +5094,7 @@ Armored =
 Melee Water = 
  # Requires translation!
 Ranged Water = 
+Submarine = Tengeralattjáró
 Heal Instantly = Azonnali gyógyulás
  # Requires translation!
 Heal this unit by [amount] HP = 
@@ -5136,6 +5163,8 @@ Medic = Orvos
 All adjacent units heal [amount] HP when healing = 
 
 Medic II = Orvos II
+ # Requires translation!
+in [tileFilter] tiles = 
  # Requires translation!
 [amount] HP when healing = 
 
@@ -5221,6 +5250,7 @@ Supply =
  # Requires translation!
 May heal outside of friendly territory = 
 
+Bomber = Bombázó
 Siege I = Ostrom I
 
 Siege II = Ostrom II
@@ -5231,6 +5261,7 @@ Evasion = Kitérés
  # Requires translation!
 Damage taken from interception reduced by [amount]% = 
 
+Fighter = Vadászgép
 Interception I = Elfogás I
  # Requires translation!
 [amount]% Damage when intercepting = 
@@ -5348,6 +5379,7 @@ Can see over obstacles =
  # Requires translation!
 Atomic Bomber = 
 
+Missile = Rakéta
  # Requires translation!
 Self-destructs when attacking = 
  # Requires translation!
@@ -5355,6 +5387,24 @@ Cannot be intercepted =
 
  # Requires translation!
 Can pass through impassable tiles = 
+
+Melee = Közelharci
+
+Ranged = Távolsági
+
+Armor = Páncélozott
+
+WaterCivilian = Vízi polgár
+
+WaterMelee = Vízi közelharci
+
+WaterRanged = Vízi távolsági
+
+WaterSubmarine = Tengeralatjáró
+
+WaterAircraftCarrier = Repülőgép hordozó
+
+AtomicBomber = AtomBombázó
 
 
 #################### Lines from Units from Civ V - Vanilla ####################
@@ -5441,6 +5491,8 @@ Knight = Lovag
 Camel Archer = Tevés íjász
 
 Conquistador = Konkvisztádor
+ # Requires translation!
+on foreign continents = 
 
 Naresuan's Elephant = Naresuan elefántja
 
@@ -5537,6 +5589,8 @@ Atomic Bomb = Atombomba
  # Requires translation!
 Nuclear weapon of Strength [amount] = 
  # Requires translation!
+if [buildingName] is constructed = 
+ # Requires translation!
 Blast radius [amount] = 
 
 Rocket Artillery = Rakétatüzérség
@@ -5580,6 +5634,7 @@ Great Artist = Híres Művész
 Can start an [amount]-turn golden age = [amount] körös Aranykort indíthat
 Can construct [improvementName] = [improvementName] építése
 Great Person - [stat] = Híres ember - [stat]
+Unbuildable = Megépíthetetlen
 
 Great Scientist = Híres Tudós
 Can hurry technology research = Meggyorsítja a technológiák kutatását
@@ -5661,6 +5716,8 @@ Fertility Rites =
 
  # Requires translation!
 God of Craftsman = 
+ # Requires translation!
+in cities with at least [amount] [populationFilter] = 
 
  # Requires translation!
 God of the Open Sky = 
@@ -5737,6 +5794,8 @@ Guruship =
  # Requires translation!
 Holy Warriors = 
  # Requires translation!
+before the [era] = 
+ # Requires translation!
 May buy [baseUnitFilter] units with [stat] for [amount] times their normal Production cost = 
 
  # Requires translation!
@@ -5766,6 +5825,8 @@ Religious Community =
 
  # Requires translation!
 Swords into Ploughshares = 
+ # Requires translation!
+when not at war = 
 
  # Requires translation!
 Founder = 
@@ -5956,9 +6017,6 @@ Starting in this era disables religion =
 
 
 Marine = Tengerészgyalogos
-
-
-#################### Lines from GlobalUniques from Civ V - Gods & Kings ####################
 
 
 #################### Lines from Nations from Civ V - Gods & Kings ####################
@@ -6570,6 +6628,8 @@ Falmouth =
 Lorient = 
  # Requires translation!
 Celts = 
+ # Requires translation!
+with [amount] to [amount2] neighboring [tileFilter] [tileFilter2] tiles = 
 
  # Requires translation!
 Haile Selassie = 
@@ -6657,6 +6717,8 @@ Ziway =
 Weldiya = 
  # Requires translation!
 Ethiopia = 
+ # Requires translation!
+when fighting units from a Civilization with more Cities than you = 
 
  # Requires translation!
 Pacal = 
@@ -6801,12 +6863,12 @@ Taoism = taoizmus
 
 
  # Requires translation!
-We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[param] Faith) = 
+We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[faithAmount] Faith) = 
  # Requires translation!
 discover holy symbols = 
 
  # Requires translation!
-We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[param] Faith) = 
+We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[faithAmount] Faith) = 
  # Requires translation!
 an ancient prophecy = 
 
@@ -6878,7 +6940,15 @@ Polder =
 #################### Lines from TileResources from Civ V - Gods & Kings ####################
 
 
+Citrus = Citrus
+
+Copper = Réz
+
+Crab = Rák
+
 Salt = Só
+
+Truffles = Szarvasgomba
 
 
 #################### Lines from UnitPromotions from Civ V - Gods & Kings ####################
@@ -7389,13 +7459,7 @@ Irremovable =
  # Requires translation!
 when at war = 
  # Requires translation!
-when not at war = 
- # Requires translation!
-during a Golden Age = 
- # Requires translation!
 with [resource] = 
- # Requires translation!
-while the empire is happy = 
  # Requires translation!
 when between [amount] and [amount2] Happiness = 
  # Requires translation!
@@ -7403,67 +7467,25 @@ when below [amount] Happiness =
  # Requires translation!
 during the [era] = 
  # Requires translation!
-before the [era] = 
- # Requires translation!
-starting from the [era] = 
- # Requires translation!
 if no other Civilization has researched this = 
- # Requires translation!
-after discovering [tech] = 
- # Requires translation!
-before discovering [tech] = 
  # Requires translation!
 upon discovering [tech] = 
  # Requires translation!
 after adopting [policy] = 
  # Requires translation!
-before adopting [policy] = 
- # Requires translation!
-if [buildingName] is constructed = 
- # Requires translation!
-for [amount] turns = 
- # Requires translation!
 by consuming this unit = 
  # Requires translation!
 in cities with a [buildingFilter] = 
  # Requires translation!
-in cities without a [buildingFilter] = 
- # Requires translation!
-in cities with at least [amount] [populationFilter] = 
- # Requires translation!
-with a garrison = 
- # Requires translation!
-for [mapUnitFilter] units = 
- # Requires translation!
 for units with [promotion] = 
  # Requires translation!
 for units without [promotion] = 
- # Requires translation!
-vs cities = 
- # Requires translation!
-vs [mapUnitFilter] units = 
- # Requires translation!
-when fighting units from a Civilization with more Cities than you = 
- # Requires translation!
-when attacking = 
- # Requires translation!
-when defending = 
- # Requires translation!
-when fighting in [tileFilter] tiles = 
- # Requires translation!
-on foreign continents = 
- # Requires translation!
-when adjacent to a [mapUnitFilter] unit = 
  # Requires translation!
 when above [amount] HP = 
  # Requires translation!
 when below [amount] HP = 
  # Requires translation!
 with [amount] to [amount2] neighboring [tileFilter] tiles = 
- # Requires translation!
-with [amount] to [amount2] neighboring [tileFilter] [tileFilter2] tiles = 
- # Requires translation!
-in [tileFilter] tiles = 
  # Requires translation!
 in [tileFilter] [tileFilter2] tiles = 
  # Requires translation!
@@ -7542,3 +7564,10 @@ CityState =
 ModOptions = 
  # Requires translation!
 Conditional = 
+
+#################### Removed Lines ####################
+
+#~~Rough Terrain = Nehéz terep
+#~~Strategic = Stratégiai
+#~~Bonus = Bónusz
+#~~Luxury = Luxus

--- a/android/assets/jsons/translations/Indonesian.properties
+++ b/android/assets/jsons/translations/Indonesian.properties
@@ -1082,8 +1082,6 @@ or [terrainType] = atau [terrainType]
 Can be constructed by = Dapat dibangun oleh
 Defence bonus = Bonus pertahanan
 Movement cost = Biaya pergerakan
-Open terrain = Medan terbuka
-Rough Terrain = Medan Kasar
 for = untuk
 Missing translations: = Terjemahan belum ada:
 Resolution = Resolusi
@@ -1213,102 +1211,6 @@ Religion = Agama
 Enhancing religion = Agama penguat
 Enhanced religion = Agama diperkuat
 
-# Terrains
-
-Impassable = Tidak Dapat Dilewati
-Rare feature = Fitur langka
-
-# terrainFilters (so for uniques like: "[stats] from [terrainFilter] tiles")
-
-All = Semua
-Water = Air
-Land = Darat
-Coastal = Pesisir
-River = Sungai
-Rough terrain = Medan kasar
-Foreign Land = Tanah Asing
-Foreign = Asing
-Friendly Land = Tanah Sekutu
-Water resource = Sumber daya air
-Bonus resource = Sumber daya bonus
-Luxury resource = Barang mewah
-Strategic resource = Sumber daya strategis
-Fresh water = Air tawar
-non-fresh water = air asin
-Natural Wonder = Keajaiban Alam
-Hybrid = Hibrida
-Undesirable = Tidak diinginkan
-Desirable = Diinginkan
-Featureless = Tidak Berfitur
-Fresh Water = Air Tawar
-
-# improvementFilters
-
-All Road = Semua Jalan
-Great Improvement = Peningkatan Hebat
-Great = Besar
-
-# Resources
-
-Bison = Bison
-Copper = Tembaga
-Cocoa = Biji Cokelat
-Crab = Kepiting
-Citrus = Jeruk
-Truffles = Jamur Truffle
-Strategic = Strategis
-Bonus = Bonus
-Luxury = Mewah
-
-# Unit types
-
-City = Kota
-Civilian = Penduduk
-Melee = Jarak dekat
-Ranged = Jarak Jauh
-Scout = Pengintai
-Mounted = Pasukan Berkuda
-Armor = Lapis Baja
-Siege = Pengepung
-
-WaterCivilian = PendudukAir
-WaterMelee = JarakDekatAir
-WaterRanged = JarakJauhAir
-WaterSubmarine = KapalSelamAir
-WaterAircraftCarrier = KapalIndukAir
-
-Fighter = Pesawat Tempur
-Bomber = Pengebom
-AtomicBomber = PengebomAtom
-Missile = Rudal
-
-
-# Unit filters and other unit related things
-
-Air = Udara
-air units = unit udara
-Barbarian = Orang Barbar
-Barbarians = Orang Barbar
-Embarked = Sedang Berlayar
-land units = unit darat
-Military = militer
-# Deprecated since 3.15.2, but should still be translated until it is officially removed
-military water = air militer
-non-air = non-udara
-Nuclear Weapon = Senjata Nuklir
-Submarine = Kapal Selam
-submarine units = unit kapal selam
-Unbuildable = Tidak dapat dibuat
-water units = unit laut
-wounded units = unit terluka
-Wounded = Terluka
-
-# For the "All newly-trained [relevant] units in this city receive the [] promotion" translation. Relevant as in 'units that can receive'
-relevant = relevan
-
-# For "May choose [amount] additional [beliefType] beliefs when [founding/enhancing] a religion"
-founding = mendirikan
-enhancing = memperkuat
 
 # Promotions
 
@@ -1316,6 +1218,7 @@ Pick promotion = Pilih promosi
  OR  =  ATAU 
 units in open terrain = unit di medan terbuka
 units in rough terrain = unit di medan berat
+wounded units = unit terluka
 Targeting II (air) = Bidikan II (udara)
 Targeting III (air) = Bidikan III (udara)
 Bonus when performing air sweep [bonusAmount]% = Bonus ketika melakukan sweeping di udara [bonusAmount]%
@@ -1419,6 +1322,11 @@ This Unit upgrades for free = Unit ini dapat ditingkatkan secara gratis
 Never destroyed when the city is captured = Tidak akan hancur jika kota direbut
 Invisible to others = Tidak terlihat bangsa lain
 
+# Unused Resources
+
+Bison = Bison
+Cocoa = Biji Cokelat
+
 
 # In English we just paste all these conditionals at the end of each unique, but in your language that
 # may not turn into valid sentences. Therefore we have the following two translations to determine
@@ -1448,6 +1356,33 @@ ConditionalsPlacement = after
 ########################### AUTOMATICALLY GENERATED TRANSLATABLE STRINGS ########################### 
 
 
+######### Map Unit Filters ###########
+
+Wounded = Terluka
+Barbarians = Orang Barbar
+ # Requires translation!
+City-State = 
+Embarked = Sedang Berlayar
+ # Requires translation!
+Non-City = 
+
+######### Unit Type Filters ###########
+
+Military = militer
+Civilian = Penduduk
+non-air = non-udara
+relevant = relevan
+Nuclear Weapon = Senjata Nuklir
+City = Kota
+Air = Udara
+land units = unit darat
+water units = unit laut
+air units = unit udara
+ # Requires translation!
+military units = 
+submarine units = unit kapal selam
+Barbarian = Orang Barbar
+
 ######### City filters ###########
 
 in this city = di kota ini
@@ -1466,6 +1401,64 @@ in annexed cities = di kota-kota yang dicaplok
 in holy cities = di kota-kota suci
 in City-State cities = di kota-kota Negara-Kota
 in cities following this religion = di kota-kota yang mengikuti agama ini
+
+######### Population Filters ###########
+
+ # Requires translation!
+Unemployed = 
+ # Requires translation!
+Followers of the Majority Religion = 
+ # Requires translation!
+Followers of this Religion = 
+
+######### Terrain Filters ###########
+
+All = Semua
+Coastal = Pesisir
+River = Sungai
+Open terrain = Medan terbuka
+Rough terrain = Medan kasar
+Water resource = Sumber daya air
+Foreign Land = Tanah Asing
+Foreign = Asing
+Friendly Land = Tanah Sekutu
+ # Requires translation!
+Enemy Land = 
+Featureless = Tidak Berfitur
+Fresh Water = Air Tawar
+non-fresh water = air asin
+Natural Wonder = Keajaiban Alam
+Impassable = Tidak Dapat Dilewati
+Land = Darat
+Water = Air
+Luxury resource = Barang mewah
+Strategic resource = Sumber daya strategis
+Bonus resource = Sumber daya bonus
+
+######### Tile Filters ###########
+
+ # Requires translation!
+unimproved = 
+All Road = Semua Jalan
+Great Improvement = Peningkatan Hebat
+
+######### Region Types ###########
+
+Hybrid = Hibrida
+
+######### Terrain Quality ###########
+
+Undesirable = Tidak diinginkan
+Desirable = Diinginkan
+
+######### Improvement Filters ###########
+
+Great = Besar
+
+######### Prophet Action Filters ###########
+
+founding = mendirikan
+enhancing = memperkuat
 
 ######### Unique Specials ###########
 
@@ -1493,6 +1486,7 @@ Temple of Artemis = Kuil Artemis
 
 The Great Lighthouse = Mercusuar Agung
 'They that go down to the sea in ships, that do business in great waters; these see the works of the Lord, and his wonders in the deep.' - The Bible, Psalms 107:23-24 = 'Ada orang-orang yang mengarungi laut dengan kapal-kapal, yang melakukan perdagangan di lautan luas; mereka melihat pekerjaan-pekerjaan Tuhan,  dan perbuatan-perbuatan-Nya yang ajaib di tempat yang dalam.' - Alkitab, Mazmur 107:23-24
+for [mapUnitFilter] units = untuk unit [mapUnitFilter]
 [amount] Movement = [amount] Pergerakan
 [amount] Sight = [amount] Penglihatan
 
@@ -1539,6 +1533,8 @@ Krepost = Krepost
 
 Statue of Zeus = Patung Zeus
 'He spoke, the son of Kronos, and nodded his head with the dark brows, and the immortally anointed hair of the great god swept from his divine head, and all Olympos was shaken' - The Iliad = 'Ia berfirman, anak sang Kronos, dan menganggukan kepalanya dengan keningnya yang gelap, kemudian rambut dewa agung abadi yang diurapi tertiup dari kepala ilahinya, dan seluruh Olympos kaget' - The Iliad
+vs cities = vs kota
+when attacking = saat menyerang
 [amount]% Strength = [amount]% Kekuatan
 
 Lighthouse = Mercusuar
@@ -1636,10 +1632,12 @@ Notre Dame = Notre Dame
 Castle = Kastil
 
 Mughal Fort = Benteng Mughal
+after discovering [tech] = setelah menemukan [tech]
 [stats] [cityFilter] = [stats] [cityFilter]
 
 Himeji Castle = Kastil Himeji
 'Bushido is realized in the presence of death. This means choosing death whenever there is a choice between life and death. There is no other reasoning.' - Yamamoto Tsunetomo = 'Bushido diwujudkan di hadapan kematian. Hal ini berarti memilih kematian setiap kali ada pilihan antara hidup dan mati. Tidak perlu pertimbangan lain.' - Yamamoto Tsunetomo
+when fighting in [tileFilter] tiles = saat bertempur di [tileFilter]
 
 Ironworks = Pertukangan Besi
 
@@ -1742,6 +1740,7 @@ Pentagon = Pentagon
 [amount]% Gold cost of upgrading = [amount]% biaya Emas untuk peningkatan
 
 Solar Plant = Panel Surya
+in cities without a [buildingFilter] = untuk kota-kota tanpa [buildingFilter]
 Only available = Hanya tersedia
 
 Nuclear Plant = PLTN
@@ -1775,6 +1774,7 @@ King = Raja
 Era Starting Unit = Unit Awal Era
 
 Emperor = Kaisar
+Scout = Pengintai
 
 Immortal = Abadi
 Worker = Pekerja
@@ -1807,9 +1807,6 @@ Atomic era = Era Atomik
 Information era = Era Informasi
 
 Future era = Masa Depan
-
-
-#################### Lines from GlobalUniques from Civ V - Vanilla ####################
 
 
 #################### Lines from Nations from Civ V - Vanilla ####################
@@ -2145,6 +2142,7 @@ La Rochelle = La Rochelle
 Bourges = Bourges
 Calais = Calais
 France = Prancis
+before discovering [tech] = sebelum menemukan [tech]
 
 Catherine = Katerina
 You've behaved yourself very badly, you know it. Now it's payback time. = Kau telah berperilaku buruk dan engkau tahu itu. Sekarang waktunya pembalasan.
@@ -2199,7 +2197,8 @@ Russia = Rusia
 Double quantity of [resource] produced = [resource] dihasilkan 2 kali lebih banyak
 
 Augustus Caesar = Augustus Caesar
-My treasury contains little and my soldiers are getting impatient... ...therefore you must die. = Perbendaharaanku tinggal sedikit dan para pasukanku semakin tidak sabar... <desah> ...maka kamu harus mati.
+ # Requires translation!
+My treasury contains little and my soldiers are getting impatient... (sigh) ...therefore you must die. = 
 So brave, yet so stupid! If only you had a brain similar to your courage. = Sangat berani, tapi bodoh sekali! Kalau saja kau punya otak sebesar keberanianmu.
 The gods have deprived Rome of their favour. We have been defeated. = Para dewa telah menarik naungannya atas Roma. Kami telah dikalahkan.
 I greet you. I am Augustus, Imperator and Pontifex Maximus of Rome. If you are a friend of Rome, you are welcome. = Salam. Aku Augustus, Imperator dan Pontifex Maximus Roma. Jika engkau teman Roma, kau disambut.
@@ -2732,6 +2731,7 @@ Paishiyauvada = Paishiyauvada
 Patigrbana = Patigrbana
 Phrada = Frada
 Persia = Persia
+during a Golden Age = di saat Masa Kejayaan
 
 Kamehameha I = Kamehameha I
 The ancient fire flashing across the sky is what proclaimed that this day would come, though I had foolishly hoped for a different outcome. = Api purba yang bersinar melintasi langit menyatakan bahwa hari ini akan datang, walaupun aku ini bodoh dengan mengharapkan hasil yang lain.
@@ -2784,6 +2784,7 @@ Nuguria = Nuguria
 Pileni = Pileni
 Nukumanu = Nukumanu
 Polynesia = Polinesia
+starting from the [era] = mulai dari [era]
 Enables embarkation for land units = Memampukan unit darat untuk melaut
 Enables [mapUnitFilter] units to enter ocean tiles = Memampukan unit [mapUnitFilter] memasuki daerah samudra
 Normal vision when embarked = Penglihatan normal saat melaut
@@ -3258,6 +3259,7 @@ Legalism = Legalisme
 Provides the cheapest [stat] building in your first [amount] cities for free = Menyediakan bangunan [stat] yang paling murah di [amount] kota pertamamu secara gratis
 Oligarchy = Oligarki
 Units in cities cost no Maintenance = Unit di kota tidak perlu biaya pemeliharaan
+with a garrison = dengan garnisun
 [amount]% Strength for cities = [amount]% Kekuatan untuk kota
 Landed Elite = Tuan Tanah
 [amount]% growth [cityFilter] = [amount]% pertumbuhan [cityFilter]
@@ -3280,6 +3282,7 @@ Liberty =
 
 Warrior Code = Kode Pejuang
 Discipline = Disiplin
+when adjacent to a [mapUnitFilter] unit = saat di samping unit [mapUnitFilter]
 Military Tradition = Tradisi Militer 
 [amount]% XP gained from combat = [amount]% XP dari pertarungan
 Military Caste = Kasta Militer
@@ -3287,6 +3290,7 @@ Professional Army = Prajurit Profesional
 Honor Complete = Kehormatan Lengkap
  # Requires translation!
 Honor = 
+vs [mapUnitFilter] units = vs unit [mapUnitFilter]
 Notified of new Barbarian encampments = Diberitahu tentang perkemahan orang Barbar baru
 
 Organized Religion = Agama Terorganisasi
@@ -3299,6 +3303,7 @@ Free Religion = Agama Gratis
 Piety Complete = Kesalehan Lengkap
  # Requires translation!
 Piety = 
+before adopting [policy] = sebelum menerapkan [policy]
 
 Philantropy = Filantropi
 Gifts of Gold to City-States generate [amount]% more Influence = Pemberian Emas ke Negara-Kota menghasilkan [amount]% lebih banyak Pengaruh
@@ -3339,10 +3344,12 @@ Rationalism Complete = Rasionalisme Lengkap
 [amount] Free Technologies = [amount] Teknologi Gratis
  # Requires translation!
 Rationalism = 
+while the empire is happy = selama kerajaan sedang bahagia
 [amount]% [stat] = [amount]% [stat]
 
 Constitution = Konstitusi
 Universal Suffrage = Hak Suara Universal
+when defending = saat bertahan
 Civil Society = Masyarakat Sipil
 [amount]% Food consumption by specialists [cityFilter] = [amount]% konsumsi Makanan oleh spesialis [cityFilter]
 Free Speech = Kebebasan Berbicara
@@ -3361,6 +3368,7 @@ Quantity of strategic resources produced by the empire +[amount]% = Jumlah sumbe
 Police State = Negara Kepolisian
 Total War = Perang Total
 Autocracy Complete = Otokrasi Lengkap
+for [amount] turns = untuk [amount] giliran
  # Requires translation!
 Autocracy = 
 Upon capturing a city, receive [amount] times its [stat] production as [plunderableStat] immediately = Saat menaklukkan sebuah kota, langsung menerima [amount] kali produksi [stat]nya sebagai [plunderableStat]
@@ -3386,28 +3394,28 @@ Clear Barbarian Camp = Hancurkan Kemah orang Barbar
 We feel threatened by a Barbarian Camp near our city. Please take care of it. = Kami merasa terancam dengan kemah orang Barbar di dekat kota kami. Tolong bereskan.
 
 Connect Resource = Sediakan sumber daya
-In order to make our civilizations stronger, connect [param] to your trade network. = Agar peradaban kita semakin kuat, masukkan [param] ke dalam jaringan perdaganganmu.
+In order to make our civilizations stronger, connect [tileResource] to your trade network. = Agar peradaban kita semakin kuat, masukkan [tileResource] ke dalam jaringan perdaganganmu.
 
 Construct Wonder = Bangun Keajaiban Dunia
-We recommend you to start building [param] to show the whole world your civilization strength. = Kami menganjurkanmu untuk mulai membangun [param] untuk menunjukkan seluruh dunia akan kekuatan peradabanmu.
+We recommend you to start building [wonder] to show the whole world your civilization strength. = Kami menganjurkanmu untuk mulai membangun [wonder] untuk menunjukkan seluruh dunia akan kekuatan peradabanmu.
 
 Acquire Great Person = Dapatkan Orang Hebat
-Great People can change the course of a Civilization! You will be rewarded for acquiring a new [param]. = Orang Hebat bisa mengubah masa depan sebuah peradaban! Kamu akan diberi hadiah jika kamu mendapatkan [param].
+Great People can change the course of a Civilization! You will be rewarded for acquiring a new [greatPerson]. = Orang Hebat bisa mengubah masa depan sebuah peradaban! Kamu akan diberi hadiah jika kamu mendapatkan [greatPerson].
 
 Conquer City State = Taklukkan Negara Kota
-It's time to erase the City-State of [param] from the map. You will be greatly rewarded for conquering them! = Waktunya menghapus Negara Kota [param] dari peta. Engkau akan diberikan hadiah besar kalau menaklukkan mereka!
+It's time to erase the City-State of [cityState] from the map. You will be greatly rewarded for conquering them! = Waktunya menghapus Negara Kota [cityState] dari peta. Engkau akan diberikan hadiah besar kalau menaklukkan mereka!
 
 Find Player = Cari Peradaban
-You have yet to discover where [param] set up their cities. You will be rewarded for finding their territories. = Kamu masih harus menemukan di mana [param] membangun kota-kotanya. Kamu akan diberi hadiah jika kamu menemukan teritori mereka.
+You have yet to discover where [civName] set up their cities. You will be rewarded for finding their territories. = Kamu masih harus menemukan di mana [civName] membangun kota-kotanya. Kamu akan diberi hadiah jika kamu menemukan teritori mereka.
 
 Find Natural Wonder = Temukan Keajaiban Alam
-Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [param] yet. = Kirimkan penjelajah terbaikmu dalam sebuah misi untuk menemukan Keajaiban Alam. Belum ada yang tahu di mana [param] berada.
+Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [naturalWonder] yet. = Kirimkan penjelajah terbaikmu dalam sebuah misi untuk menemukan Keajaiban Alam. Belum ada yang tahu di mana [naturalWonder] berada.
 
 Give Gold = Berikan Emas
-We are suffering great poverty after being robbed by [param], and unless we receive a sum of Gold, it's only a matter of time before we collapse. = Kami sedang mengalami kelaparan hebat setelah dirampok [param], kecuali kami mendapatkan sejumlah Emas, hanya tinggal menunggu waktu sebelum kami kolaps.
+We are suffering great poverty after being robbed by [civName], and unless we receive a sum of Gold, it's only a matter of time before we collapse. = Kami sedang mengalami kelaparan hebat setelah dirampok [civName], kecuali kami mendapatkan sejumlah Emas, hanya tinggal menunggu waktu sebelum kami kolaps.
 
 Pledge to Protect = Janji untuk Melindungi
-We need your protection to stop the aggressions of [param]. By signing a Pledge of Protection, you'll confirm the bond that ties us. = Kami memerlukan perlindunganmu untuk menghentikan agresi [param]. Dengan menandatangani Perjanjian Perlindungan, kamu meneguhkan ikatan yang mengikat kita.
+We need your protection to stop the aggressions of [civName]. By signing a Pledge of Protection, you'll confirm the bond that ties us. = Kami memerlukan perlindunganmu untuk menghentikan agresi [civName]. Dengan menandatangani Perjanjian Perlindungan, kamu meneguhkan ikatan yang mengikat kita.
 
 Contest Culture = Adakan Lomba Budaya
 The civilization with the largest Culture growth will gain a reward. = Peradaban dengan pertumbuhan Budaya terbesar akan mendapatkan hadiah.
@@ -3419,15 +3427,15 @@ Contest Technologies = Adakan Lomba Teknologi
 The civilization with the largest number of new Technologies researched will gain a reward. = Peradaban dengan pertumbuhan Teknologi terbesar akan mendapatkan hadiah.
 
 Invest = Investasi
-Our people are rejoicing thanks to a tourism boom. For a certain amount of time, any Gold donation will yield [amount]% extra Influence. = Rakyat kami bersukacita karena adanya lonjakan pariwisata. Untuk sementara ini, setiap donasi Emas akan menghasilkan [amount]% Pengaruh tambahan.
+Our people are rejoicing thanks to a tourism boom. For a certain amount of time, any Gold donation will yield [50]% extra Influence. = Rakyat kami bersukacita karena adanya lonjakan pariwisata. Untuk sementara ini, setiap donasi Emas akan menghasilkan [50]% Pengaruh tambahan.
 
 Bully City State = Rundung Negara Kota
-We are tired of the pretensions of [param]. If someone were to put them in their place by Demanding Tribute from them, they would be rewarded. = Kami muak dengan dalihan [param]. Jika ada orang yang bisa merendahkan mereka dengan Menagih Upeti kepada mereka, orang itu akan diberi hadiah.
+We are tired of the pretensions of [cityState]. If someone were to put them in their place by Demanding Tribute from them, they would be rewarded. = Kami muak dengan dalihan [cityState]. Jika ada orang yang bisa merendahkan mereka dengan Menagih Upeti kepada mereka, orang itu akan diberi hadiah.
 
 Denounce Civilization = Hina Peradaban
-We have been forced to pay tribute to [param]! We need you to tell the world of their ill deeds. = Kami telah dipaksa untuk membayar upeti kepada [param]! Kami memerlukanmu untuk memberitahu kepada dunia tentang perbuatan-perbuatan buruk mereka.
+We have been forced to pay tribute to [civName]! We need you to tell the world of their ill deeds. = Kami telah dipaksa untuk membayar upeti kepada [civName]! Kami memerlukanmu untuk memberitahu kepada dunia tentang perbuatan-perbuatan buruk mereka.
 
-We have heard the tenets of [param] and are most curious. Will you send missionaries to teach us about your religion? = Kami telah mendengarkan prinsip-prinsip [param] dan ingin memahaminya lebih dalam lagi. Dapatkah kamu mengirim misionaris untuk mengajarkan kami tentang agamamu?
+We have heard the tenets of [religionName] and are most curious. Will you send missionaries to teach us about your religion? = Kami telah mendengarkan prinsip-prinsip [religionName] dan ingin memahaminya lebih dalam lagi. Dapatkah kamu mengirim misionaris untuk mengajarkan kami tentang agamamu?
 
 
 #################### Lines from Ruins from Civ V - Vanilla ####################
@@ -3442,10 +3450,10 @@ squatters wishing to settle under your rule = penghuni liar yang ingin tinggal d
 An ancient tribe trained us in their ways of combat! = Sebuah suku kuno telah melatih kita cara bertarung mereka!
 your exploring unit receives training = pelatihan kepada unit yang menjelajahinya
 
-We have found survivors in the ruins! Population added to [param]. = Kita telah menemukan penyintas di reruntuhan! Populasi ditambahkan ke [param].
+We have found survivors in the ruins! Population added to [cityName]. = Kita telah menemukan penyintas di reruntuhan! Populasi ditambahkan ke [cityName].
 survivors (adds population to a city) = penduduk (menambah populasi di salah satu kota)
 
-We have found a stash of [param] Gold in the ruins! = Kita telah menemukan timbunan emas sebanyak [param] di reruntuhan!
+We have found a stash of [goldAmount] Gold in the ruins! = Kita telah menemukan timbunan emas sebanyak [goldAmount] di reruntuhan!
 a stash of gold = emas
 
 discover a lost technology = teknologi yang hilang
@@ -3664,6 +3672,7 @@ Tundra = Tundra
 Desert = Padang Pasir
 
 Lakes = Danau
+Fresh water = Air tawar
 
 Mountain = Gunung
 Has an elevation of [amount] for visibility calculations = Memiliki ketinggian [amount] sebagai perhitungan untuk jangkauan penglihatan
@@ -3684,6 +3693,7 @@ A Camp can be built here without cutting it down = Perkemahan dapat dibangun di 
 Jungle = Hutan Belantara
 
 Marsh = Rawa
+Rare feature = Fitur langka
 Only Polders can be built here = Hanya Polder yang bisa dibangun di sini
 
 Fallout = Daerah Radioaktif Nuklir
@@ -3879,10 +3889,13 @@ Porcelain = Keramik
 #################### Lines from UnitPromotions from Civ V - Vanilla ####################
 
 Sword = Pedang
+Mounted = Pasukan Berkuda
+Siege = Pengepung
 Ranged Gunpowder = Bubuk Mesiu Berjarak
 Armored = Lapis Baja
 Melee Water = Air Jarak Dekat
 Ranged Water = Air Jarak Jauh
+Submarine = Kapal Selam
 Heal Instantly = Sembuhkan seketika
 Heal this unit by [amount] HP = Sembuhkan unit ini sebesar [amount] darah
 Doing so will consume this opportunity to choose a Promotion = Tindakan ini akan memakai kesempatan untuk memilih sebuah Promosi
@@ -3941,6 +3954,7 @@ Medic = Medis
 All adjacent units heal [amount] HP when healing = Semua unit bersebelahan mendapatkan [amount] darah tambahan saat penyembuhan
 
 Medic II = Medis II
+in [tileFilter] tiles = di daerah [tileFilter]
 [amount] HP when healing = [amount] darah saat penyembuhan
 
 Scouting I = Pengintaian I
@@ -4001,6 +4015,7 @@ Flight Deck III = Dek Penerbangan III
 Supply = Pasokan
 May heal outside of friendly territory = Dapat menyembuhkan diri di luar daerah kekuasaan/sekutu
 
+Bomber = Pengebom
 Siege I = Kepungan I
 
 Siege II = Kepungan II
@@ -4010,6 +4025,7 @@ Siege III = Kepungan III
 Evasion = Penghindaran
 Damage taken from interception reduced by [amount]% = Kerusakan dari pencegatan berkurang sebesar [amount]%
 
+Fighter = Pesawat Tempur
 Interception I = Pencegatan I
 [amount]% Damage when intercepting = [amount]% Kerusakan ketika melakukan pencegatan
 
@@ -4106,10 +4122,29 @@ Can see over obstacles =
 
 Atomic Bomber = Pengebom Atom
 
+Missile = Rudal
 Self-destructs when attacking = Menghancurkan diri ketika menyerang
 Cannot be intercepted = Tidak dapat dicegat
 
 Can pass through impassable tiles = Dapat bergerak melalui daerah yang tidak dapat dilalui unit lain
+
+Melee = Jarak dekat
+
+Ranged = Jarak Jauh
+
+Armor = Lapis Baja
+
+WaterCivilian = PendudukAir
+
+WaterMelee = JarakDekatAir
+
+WaterRanged = JarakJauhAir
+
+WaterSubmarine = KapalSelamAir
+
+WaterAircraftCarrier = KapalIndukAir
+
+AtomicBomber = PengebomAtom
 
 
 #################### Lines from Units from Civ V - Vanilla ####################
@@ -4187,6 +4222,7 @@ Knight = Ksatria
 Camel Archer = Pemanah Berunta
 
 Conquistador = Conquistador
+on foreign continents = di benua asing
 
 Naresuan's Elephant = Gajah Naresuan
 
@@ -4277,6 +4313,7 @@ Anti-Tank Gun = Senjata Anti-Tank
 
 Atomic Bomb = Bom Atom
 Nuclear weapon of Strength [amount] = Kekuatan nuklir [amount]
+if [buildingName] is constructed = jika [buildingName] telah dibangun
 Blast radius [amount] = Jarak ledakan [amount]
 
 Rocket Artillery = Artileri Roket
@@ -4311,6 +4348,7 @@ Great Artist = Seniman Hebat
 Can start an [amount]-turn golden age = Dapat memulai masa kejayaan [amount]-giliran
 Can construct [improvementName] = Dapat membangun [improvementName]
 Great Person - [stat] = Orang Hebat - [stat]
+Unbuildable = Tidak dapat dibuat
 
 Great Scientist = Ilmuwan Hebat
 Can hurry technology research = Dapat mempercepat riset teknologi
@@ -4369,6 +4407,8 @@ Faith Healers = Dukun Penyembuh
 Fertility Rites = Ritual Kesuburan
 
 God of Craftsman = Dewa Pertukangan
+ # Requires translation!
+in cities with at least [amount] [populationFilter] = 
 
 God of the Open Sky = Dewa Langit
 
@@ -4420,6 +4460,7 @@ Feed the World = Beri Makan Dunia
 Guruship = Keguruan
 
 Holy Warriors = Prajurit Suci
+before the [era] = sebelum [era]
 May buy [baseUnitFilter] units with [stat] for [amount] times their normal Production cost = Dapat membeli unit [baseUnitFilter] dengan [stat] seharga [amount] kali biaya Produksi normalnya
 
 Liturgical Drama = Drama Liturgi
@@ -4440,6 +4481,7 @@ Religious Community = Komunitas Keagamaan
 [amount]% [stat] from every follower, up to [amount2]% = [amount]% [stat] untuk setiap pengikut, hingga [amount2]%
 
 Swords into Ploughshares = Pedang Menjadi Mata Bajak
+when not at war = saat tidak sedang berperang
 
 Founder = Pendiri
 Ceremonial Burial = Upacara Penguburan
@@ -4572,9 +4614,6 @@ Starting in this era disables religion = Memulai di era ini akan meniadakan agam
 
 
 Marine = Marinir
-
-
-#################### Lines from GlobalUniques from Civ V - Gods & Kings ####################
 
 
 #################### Lines from Nations from Civ V - Gods & Kings ####################
@@ -4899,6 +4938,7 @@ Llanfairpwllgwyngyll = Llanfairpwllgwyngyll
 Falmouth = Falmouth
 Lorient = Lorient
 Celts = Celts
+with [amount] to [amount2] neighboring [tileFilter] [tileFilter2] tiles = dari [amount] ke [amount2] daerah [tileFilter] [tileFilter2] bersebelahan 
 
 Haile Selassie = Haile Selassie
 I have tried all other avenues, but yet you persist in this madness. I hope, for your sake, your end is swift. = Aku telah mencoba semua jalan lain, tetapi engkau tetap bersikeras pada kegilaan ini. Aku harap, untuk kebaikanmu, ajalmu cepat datang.
@@ -4943,6 +4983,7 @@ Gambela = Gambela
 Ziway = Ziway
 Weldiya = Weldiya
 Ethiopia = Etiopia
+when fighting units from a Civilization with more Cities than you = saat bertempur dengan unit dari peradaban dengan jumlah kota lebih dari kamu
 
 Pacal = Pakal
 A sacrifice unlike all others must be made! = Pengorbanan yang lain daripada yang lain harus dilakukan!
@@ -5028,10 +5069,10 @@ Taoism = Taoisme
 #################### Lines from Ruins from Civ V - Gods & Kings ####################
 
 
-We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[param] Faith) = Kita telah menemukan simbol-simbol suci di reruntuhan, yang memberikan kepada kita pemahaman yang lebih dalam tentang agama! (+[param] Iman)
+We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[faithAmount] Faith) = Kita telah menemukan simbol-simbol suci di reruntuhan, yang memberikan kepada kita pemahaman yang lebih dalam tentang agama! (+[faithAmount] Iman)
 discover holy symbols = menemukan simbol-simbol suci
 
-We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[param] Faith) = Kita telah menemukan nubuat kuno di reruntuhan, yang semakin menguatkan koneksi spiritual kita! (+[param] Iman)
+We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[faithAmount] Faith) = Kita telah menemukan nubuat kuno di reruntuhan, yang semakin menguatkan koneksi spiritual kita! (+[faithAmount] Iman)
 an ancient prophecy = nubuat kuno
 
 
@@ -5089,7 +5130,15 @@ Polder = Polder
 #################### Lines from TileResources from Civ V - Gods & Kings ####################
 
 
+Citrus = Jeruk
+
+Copper = Tembaga
+
+Crab = Kepiting
+
 Salt = Garam
+
+Truffles = Jamur Truffle
 
 
 #################### Lines from UnitPromotions from Civ V - Gods & Kings ####################
@@ -5421,45 +5470,20 @@ No Sight =
 [amount] XP gained from combat = [amount] XP dari pertarungan
 Irremovable = Tidak dapat disingkirkan
 when at war = saat sedang berperang
-when not at war = saat tidak sedang berperang
-during a Golden Age = di saat Masa Kejayaan
 with [resource] = dengan [resource]
-while the empire is happy = selama kerajaan sedang bahagia
 when between [amount] and [amount2] Happiness = saat memiliki antara [amount] dan [amount2] Kebahagiaan
 when below [amount] Happiness = saat memiliki kurang dari [amount] Kebahagiaan
 during the [era] = selama [era] 
-before the [era] = sebelum [era]
-starting from the [era] = mulai dari [era]
 if no other Civilization has researched this = jika tidak ada Peradaban lain yang telah meriset ini
-after discovering [tech] = setelah menemukan [tech]
-before discovering [tech] = sebelum menemukan [tech]
 upon discovering [tech] = saat menemukan [tech]
 after adopting [policy] = setelah menerapkan [policy]
-before adopting [policy] = sebelum menerapkan [policy]
-if [buildingName] is constructed = jika [buildingName] telah dibangun
-for [amount] turns = untuk [amount] giliran
 by consuming this unit = dengan mengonsumsi unit ini
 in cities with a [buildingFilter] = untuk kota-kota dengan [buildingFilter]
-in cities without a [buildingFilter] = untuk kota-kota tanpa [buildingFilter]
- # Requires translation!
-in cities with at least [amount] [populationFilter] = 
-with a garrison = dengan garnisun
-for [mapUnitFilter] units = untuk unit [mapUnitFilter]
 for units with [promotion] = untuk unit dengan [promotion]
 for units without [promotion] = untuk unit tanpa [promotion]
-vs cities = vs kota
-vs [mapUnitFilter] units = vs unit [mapUnitFilter]
-when fighting units from a Civilization with more Cities than you = saat bertempur dengan unit dari peradaban dengan jumlah kota lebih dari kamu
-when attacking = saat menyerang
-when defending = saat bertahan
-when fighting in [tileFilter] tiles = saat bertempur di [tileFilter]
-on foreign continents = di benua asing
-when adjacent to a [mapUnitFilter] unit = saat di samping unit [mapUnitFilter]
 when above [amount] HP = saat di atas [amount] HP
 when below [amount] HP = saat di bawah [amount] HP
 with [amount] to [amount2] neighboring [tileFilter] tiles = dari [amount] ke [amount2] daerah [tileFilter] bersebelahan
-with [amount] to [amount2] neighboring [tileFilter] [tileFilter2] tiles = dari [amount] ke [amount2] daerah [tileFilter] [tileFilter2] bersebelahan 
-in [tileFilter] tiles = di daerah [tileFilter]
 in [tileFilter] [tileFilter2] tiles = di daerah [tileFilter] [tileFilter2]
 in tiles without [tileFilter] = di daerah tanpa [tileFilter]
 on water maps = di peta air
@@ -5499,3 +5523,12 @@ Ruins = Reruntuhan
 CityState = NegaraKota
 ModOptions = PilihanMod
 Conditional = Kondisional
+
+#################### Removed Lines ####################
+
+#~~Rough Terrain = Medan Kasar
+#~~Strategic = Strategis
+#~~Bonus = Bonus
+#~~Luxury = Mewah
+#~~military water = air militer
+#~~My treasury contains little and my soldiers are getting impatient... ...therefore you must die. = Perbendaharaanku tinggal sedikit dan para pasukanku semakin tidak sabar... <desah> ...maka kamu harus mati.

--- a/android/assets/jsons/translations/Italian.properties
+++ b/android/assets/jsons/translations/Italian.properties
@@ -1085,8 +1085,6 @@ or [terrainType] = o [terrainType]
 Can be constructed by = Costruibile da
 Defence bonus = Bonus di Difesa
 Movement cost = Costi di movimento
-Open terrain = Terreno aperto
-Rough Terrain = Terreno accidentato
 for = per
 Missing translations: = Traduzioni mancanti: 
 Resolution = Risoluzione
@@ -1216,102 +1214,6 @@ Religion = Religione
 Enhancing religion = Religione in miglioramento
 Enhanced religion = Religione potenziata
 
-# Terrains
-
-Impassable = Inaccessibile
-Rare feature = Caratteristica rara
-
-# terrainFilters (so for uniques like: "[stats] from [terrainFilter] tiles")
-
-All = tutte
-Water = anfibia
-Land = terrestre
-Coastal = Costiera
-River = Fiume
-Rough terrain = Terreno accidentato
-Foreign Land = Terra Straniera
-Foreign = straniero
-Friendly Land = territorio amico
-Water resource = risorsa anfibia
-Bonus resource = Risorsa bonus
-Luxury resource = Risorsa di lusso
-Strategic resource = Risorsa strategica
-Fresh water = acqua fresca
-non-fresh water = acqua non potabile
-Natural Wonder = Meraviglia Naturale
-Hybrid = Ibrido
-Undesirable = Indesiderabile
-Desirable = Desiderabile
-Featureless = Nessuna caratteristica
-Fresh Water = acqua fresca
-
-# improvementFilters
-
-All Road = Tutte le strade
-Great Improvement = Grande Miglioramento
-Great = Grande
-
-# Resources
-
-Bison = Bisonti
-Copper = Rame
-Cocoa = Cacao
-Crab = Granchi
-Citrus = Agrumi
-Truffles = Tartufi
-Strategic = strategica
-Bonus = bonus
-Luxury = di lusso
-
-# Unit types
-
-City = Città
-Civilian = unità civile
-Melee = unità da mischia
-Ranged = unità da tiro
-Scout = Scout
-Mounted = unità a cavallo
-Armor = unità corazzata
-Siege = unità d'assedio
-
-WaterCivilian = unità marittima civile
-WaterMelee = marittima da mischia
-WaterRanged = marittima a distanza
-WaterSubmarine = sottomarina
-WaterAircraftCarrier = portaerei anfibio
-
-Fighter = Caccia
-Bomber = Bombardiere
-AtomicBomber = Bombardiere atomico
-Missile = da tiro
-
-
-# Unit filters and other unit related things
-
-Air = aerea
-air units = unità aeree
-Barbarian = barbaro
-Barbarians = Barbari
-Embarked = sbarcate
-land units = unità terrestri
-Military = militari
-# Deprecated since 3.15.2, but should still be translated until it is officially removed
-military water = anfibie militari
-non-air = non aeree
-Nuclear Weapon = Arma nucleare
-Submarine = Sottomarino
-submarine units = unità sottomarine
-Unbuildable = Non costruibile
-water units = unità anfibie
-wounded units = unità ferite
-Wounded = ferite
-
-# For the "All newly-trained [relevant] units in this city receive the [] promotion" translation. Relevant as in 'units that can receive'
-relevant = rilevante
-
-# For "May choose [amount] additional [beliefType] beliefs when [founding/enhancing] a religion"
-founding = fondi
-enhancing = potenzi
 
 # Promotions
 
@@ -1319,6 +1221,7 @@ Pick promotion = Scegli promozione
  OR  =  O 
 units in open terrain = unità su terreno aperto
 units in rough terrain = unità su terreno accidentato
+wounded units = unità ferite
 Targeting II (air) = Puntamento aereo II
 Targeting III (air) = Puntamento aereo III
 Bonus when performing air sweep [bonusAmount]% = +[bonusAmount]% Forza nella distruzione delle difese aeree
@@ -1422,6 +1325,11 @@ This Unit upgrades for free = L'Unità è aggiornabile grauitamente
 Never destroyed when the city is captured = Mai distrutto quando la città viene catturata
 Invisible to others = Invisibile per le altre unità
 
+# Unused Resources
+
+Bison = Bisonti
+Cocoa = Cacao
+
 
 # In English we just paste all these conditionals at the end of each unique, but in your language that
 # may not turn into valid sentences. Therefore we have the following two translations to determine
@@ -1452,6 +1360,33 @@ ConditionalsPlacement =
 ########################### AUTOMATICALLY GENERATED TRANSLATABLE STRINGS ########################### 
 
 
+######### Map Unit Filters ###########
+
+Wounded = ferite
+Barbarians = Barbari
+ # Requires translation!
+City-State = 
+Embarked = sbarcate
+ # Requires translation!
+Non-City = 
+
+######### Unit Type Filters ###########
+
+Military = militari
+Civilian = unità civile
+non-air = non aeree
+relevant = rilevante
+Nuclear Weapon = Arma nucleare
+City = Città
+Air = aerea
+land units = unità terrestri
+water units = unità anfibie
+air units = unità aeree
+ # Requires translation!
+military units = 
+submarine units = unità sottomarine
+Barbarian = barbaro
+
 ######### City filters ###########
 
 in this city = in questa città
@@ -1470,6 +1405,64 @@ in annexed cities = nelle città annesse
 in holy cities = nelle città sante
 in City-State cities = nelle Città-stato
 in cities following this religion = nelle città che seguono questa religione
+
+######### Population Filters ###########
+
+ # Requires translation!
+Unemployed = 
+ # Requires translation!
+Followers of the Majority Religion = 
+ # Requires translation!
+Followers of this Religion = 
+
+######### Terrain Filters ###########
+
+All = tutte
+Coastal = Costiera
+River = Fiume
+Open terrain = Terreno aperto
+Rough terrain = Terreno accidentato
+Water resource = risorsa anfibia
+Foreign Land = Terra Straniera
+Foreign = straniero
+Friendly Land = territorio amico
+ # Requires translation!
+Enemy Land = 
+Featureless = Nessuna caratteristica
+Fresh Water = acqua fresca
+non-fresh water = acqua non potabile
+Natural Wonder = Meraviglia Naturale
+Impassable = Inaccessibile
+Land = terrestre
+Water = anfibia
+Luxury resource = Risorsa di lusso
+Strategic resource = Risorsa strategica
+Bonus resource = Risorsa bonus
+
+######### Tile Filters ###########
+
+ # Requires translation!
+unimproved = 
+All Road = Tutte le strade
+Great Improvement = Grande Miglioramento
+
+######### Region Types ###########
+
+Hybrid = Ibrido
+
+######### Terrain Quality ###########
+
+Undesirable = Indesiderabile
+Desirable = Desiderabile
+
+######### Improvement Filters ###########
+
+Great = Grande
+
+######### Prophet Action Filters ###########
+
+founding = fondi
+enhancing = potenzi
 
 ######### Unique Specials ###########
 
@@ -1497,6 +1490,7 @@ Temple of Artemis = Tempio di Artemide
 
 The Great Lighthouse = Grande Faro
 'They that go down to the sea in ships, that do business in great waters; these see the works of the Lord, and his wonders in the deep.' - The Bible, Psalms 107:23-24 = 'Ecco quelli che scendon nel mare su navi, che trafficano sulle grandi acque; essi veggono le opere dell'Eterno e le sue meraviglie nell'abisso.' - Salmi 107:23-24
+for [mapUnitFilter] units = per le unità [mapUnitFilter]
 [amount] Movement = [amount] Movimento
 [amount] Sight = [amount] Visione
 
@@ -1543,6 +1537,8 @@ Krepost = Krepost
 
 Statue of Zeus = Statua di Zeus
 'He spoke, the son of Kronos, and nodded his head with the dark brows, and the immortally anointed hair of the great god swept from his divine head, and all Olympos was shaken' - The Iliad = 'Così parlò, il figlio di Crono, e con le nere sopracciglia accennò; le chiome immortali del sire si scompigliarono sul capo divino: scosse tutto l'Olimpo.' - L'Iliade
+vs cities = contro le città
+when attacking = in attacco
 [amount]% Strength = [amount]% Forza
 
 Lighthouse = Faro
@@ -1640,10 +1636,12 @@ Notre Dame = Notre Dame
 Castle = Castello
 
 Mughal Fort = Forte Mughal
+after discovering [tech] = quando scopri [tech]
 [stats] [cityFilter] = [stats] [cityFilter]
 
 Himeji Castle = Castello di Himeji
 'Bushido is realized in the presence of death. This means choosing death whenever there is a choice between life and death. There is no other reasoning.' - Yamamoto Tsunetomo = 'Il Bushido si realizza in presenza della morte. Significa, ogni volta che c'è una scelta tra la vita e la morte, scegliere la seconda. Non c'è alcun altro ragionamento.' - Yamamoto Tsunetomo
+when fighting in [tileFilter] tiles = quando combatti nelle caselle [tileFilter]
 
 Ironworks = Ferriera
 
@@ -1746,6 +1744,7 @@ Pentagon = Pentagono
 [amount]% Gold cost of upgrading = [amount]% costi in oro per gli aggiornamenti
 
 Solar Plant = Centrale ad energia solare
+in cities without a [buildingFilter] = nelle città senza edifici [buildingFilter]
 Only available = Disponibile solo
 
 Nuclear Plant = Centrale nucleare
@@ -1779,6 +1778,7 @@ King = Re
 Era Starting Unit = Unità iniziale d'epoca
 
 Emperor = Imperatore
+Scout = Scout
 
 Immortal = Immortale
 Worker = Lavoratore
@@ -1811,9 +1811,6 @@ Atomic era = Atomica
 Information era = Informatica
 
 Future era = Futura
-
-
-#################### Lines from GlobalUniques from Civ V - Vanilla ####################
 
 
 #################### Lines from Nations from Civ V - Vanilla ####################
@@ -2149,6 +2146,7 @@ La Rochelle = La Rochelle
 Bourges = Bourges
 Calais = Calais
 France = Francia
+before discovering [tech] = finché non scopri [tech]
 
 Catherine = Caterina II
 You've behaved yourself very badly, you know it. Now it's payback time. = Ti sei comportato molto male, lo sai? Credo che adesso dovrò insegnarti l'umiltà.
@@ -2203,7 +2201,8 @@ Russia = Russia
 Double quantity of [resource] produced = Doppia quantità da [resource]
 
 Augustus Caesar = Cesare Augusto
-My treasury contains little and my soldiers are getting impatient... ...therefore you must die. = Il mio tesoro è così magro e i miei soldati hanno fame di conquista. Mi dispiace dirti che sei tu il bersaglio. Alea Jacta Est!
+ # Requires translation!
+My treasury contains little and my soldiers are getting impatient... (sigh) ...therefore you must die. = 
 So brave, yet so stupid! If only you had a brain similar to your courage. = La tua arroganza sarà la tua rovina! Nessun potere, per quanto prode o forte, può sconfiggere Roma!
 The gods have deprived Rome of their favour. We have been defeated. = Gli dei hanno privato Roma del loro favore. Siamo stati sconfitti. Per noi è la fine.
 I greet you. I am Augustus, Imperator and Pontifex Maximus of Rome. If you are a friend of Rome, you are welcome. = Ave. Sono Augusto, Princeps, Imperator e Pontifex Maximus di Roma. Se sei amico di Roma, sei il benvenuto, ma sappi che Roma è mortale contro i suoi nemici.
@@ -2736,6 +2735,7 @@ Paishiyauvada = Paishiyauvada
 Patigrbana = Patigrbana
 Phrada = Phrada
 Persia = Persia
+during a Golden Age = durante un'Età dell'Oro
 
 Kamehameha I = Kamehameha I
 The ancient fire flashing across the sky is what proclaimed that this day would come, though I had foolishly hoped for a different outcome. = L'antico fuoco che s'illumina nel cielo ha proclamato l'arrivo di questo giorno... anche se, scioccamente, speravo in un altro esito.
@@ -2788,6 +2788,7 @@ Nuguria = Nuguria
 Pileni = Pileni
 Nukumanu = Nukumanu
 Polynesia = Polinesia
+starting from the [era] = a partire dall'[era]
 Enables embarkation for land units = Permette alle unità terrestri di imbarcarsi e attraversare le caselle acquatiche.
 Enables [mapUnitFilter] units to enter ocean tiles = Permette alle unità [mapUnitFilter] di attraversare l'oceano
 Normal vision when embarked = Visione normale quando imbarcata
@@ -3262,6 +3263,7 @@ Legalism = Legalismo
 Provides the cheapest [stat] building in your first [amount] cities for free = Le tue prime [amount] città ricevono un edificio gratuito [stat]
 Oligarchy = Oligarchia
 Units in cities cost no Maintenance = Nessun mantenimento per le unità nelle Città
+with a garrison = con una guarnigione
 [amount]% Strength for cities = [amount]% Forza per le Città
 Landed Elite = Nobiltà terriera
 [amount]% growth [cityFilter] = [amount]% crescita [cityFilter]
@@ -3284,6 +3286,7 @@ Liberty =
 
 Warrior Code = Codice guerriero
 Discipline = Disciplina
+when adjacent to a [mapUnitFilter] unit = quando si trova nei pressi di un'unità [mapUnitFilter]
 Military Tradition = Tradizione militare
 [amount]% XP gained from combat = [amount] XP dal combattimento
 Military Caste = Casta Militare
@@ -3291,6 +3294,7 @@ Professional Army = Esercito professionale
 Honor Complete = Onore Completo
  # Requires translation!
 Honor = 
+vs [mapUnitFilter] units = contro le unità [mapUnitFilter]
 Notified of new Barbarian encampments = Riceverai notifiche su nuovi accampamenti barbari
 
 Organized Religion = Religione Organizzata
@@ -3303,6 +3307,7 @@ Free Religion = Tolleranza Religiosa
 Piety Complete = Devozione Completa
  # Requires translation!
 Piety = 
+before adopting [policy] = prima di adottare [policy]
 
 Philantropy = Filantropia
 Gifts of Gold to City-States generate [amount]% more Influence = +[amount]% Influenza dai doni in Oro alle Città-Stato
@@ -3343,10 +3348,12 @@ Rationalism Complete = Razionalismo Completo
 [amount] Free Technologies = [amount] Tecnologie gratuite
  # Requires translation!
 Rationalism = 
+while the empire is happy = mentre l'impero è felice
 [amount]% [stat] = [amount]% [stat]
 
 Constitution = Costituzione
 Universal Suffrage = Suffragio Universale
+when defending = in difesa
 Civil Society = Società civile
 [amount]% Food consumption by specialists [cityFilter] = [amount]% consumo di cibo dagli specialisti [cityFilter]
 Free Speech = Libertà di parola
@@ -3365,6 +3372,7 @@ Quantity of strategic resources produced by the empire +[amount]% = +[amount]% q
 Police State = Stato di polizia
 Total War = Guerra Totale
 Autocracy Complete = Autocrazia Completa
+for [amount] turns = per [amount] turni
  # Requires translation!
 Autocracy = 
 Upon capturing a city, receive [amount] times its [stat] production as [plunderableStat] immediately = Quando conquisti una città, ne ricevi immediatamente [amount] volte la produzione in [stat] pari a [plunderableStat]
@@ -3390,28 +3398,28 @@ Clear Barbarian Camp = Ripulisci accampamento barbaro
 We feel threatened by a Barbarian Camp near our city. Please take care of it. = Un gruppo di barbari ha costruito un accampamento vicino a noi. Ti preghiamo, occupatene tu.
 
 Connect Resource = Collega risorsa
-In order to make our civilizations stronger, connect [param] to your trade network. = Ti chiediamo di collegare la nostra risorsa di [param] alla tua rete commerciale. In questo modo, i nostri legami e i nostri commerci diverranno più forti.
+In order to make our civilizations stronger, connect [tileResource] to your trade network. = Ti chiediamo di collegare la nostra risorsa di [tileResource] alla tua rete commerciale. In questo modo, i nostri legami e i nostri commerci diverranno più forti.
 
 Construct Wonder = Costruisci Meraviglia
-We recommend you to start building [param] to show the whole world your civilization strength. = Se riuscissi a costruire la Meraviglia Mondiale chiamata [param], ci mostreresti la tua magnificenza.
+We recommend you to start building [wonder] to show the whole world your civilization strength. = Se riuscissi a costruire la Meraviglia Mondiale chiamata [wonder], ci mostreresti la tua magnificenza.
 
 Acquire Great Person = Ottieni Grande Personaggio
-Great People can change the course of a Civilization! You will be rewarded for acquiring a new [param]. = I Grandi Personaggi possono cambiare la storia di una civiltà! Sarebbe grandioso se riuscissi a trovare un [param].
+Great People can change the course of a Civilization! You will be rewarded for acquiring a new [greatPerson]. = I Grandi Personaggi possono cambiare la storia di una civiltà! Sarebbe grandioso se riuscissi a trovare un [greatPerson].
 
 Conquer City State = Conquista Città-Stato
-It's time to erase the City-State of [param] from the map. You will be greatly rewarded for conquering them! = Abbiamo un conto in sospeso con la Città-Stato di [param]. Se riesci a cancellarla dalla mappa, ti ricompenseremo lautamente.
+It's time to erase the City-State of [cityState] from the map. You will be greatly rewarded for conquering them! = Abbiamo un conto in sospeso con la Città-Stato di [cityState]. Se riesci a cancellarla dalla mappa, ti ricompenseremo lautamente.
 
 Find Player = Trova giocatore
-You have yet to discover where [param] set up their cities. You will be rewarded for finding their territories. = Abbiamo udito di un popolo che si fa chiamare [param]. Trova i suoi territori e noi ti ricompenseremo.
+You have yet to discover where [civName] set up their cities. You will be rewarded for finding their territories. = Abbiamo udito di un popolo che si fa chiamare [civName]. Trova i suoi territori e noi ti ricompenseremo.
 
 Find Natural Wonder = Trova Meraviglia Naturale
-Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [param] yet. = Nessuno di noi è mai riuscito a trovare [param]. Ti preghiamo di mandare i tuoi migliori esploratori a scoprire questa Meraviglia naturale.
+Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [naturalWonder] yet. = Nessuno di noi è mai riuscito a trovare [naturalWonder]. Ti preghiamo di mandare i tuoi migliori esploratori a scoprire questa Meraviglia naturale.
 
 Give Gold = Elargisci Oro
-We are suffering great poverty after being robbed by [param], and unless we receive a sum of Gold, it's only a matter of time before we collapse. = La nostra gente soffre la povertà a seguito di uno sgarro per mano di [param], e se non riceviamo una somma d'Oro al più presto, il nostro governo crollerà.
+We are suffering great poverty after being robbed by [civName], and unless we receive a sum of Gold, it's only a matter of time before we collapse. = La nostra gente soffre la povertà a seguito di uno sgarro per mano di [civName], e se non riceviamo una somma d'Oro al più presto, il nostro governo crollerà.
 
 Pledge to Protect = Impegnati a proteggere
-We need your protection to stop the aggressions of [param]. By signing a Pledge of Protection, you'll confirm the bond that ties us. = Essendo preoccupati dalle aggressioni di [param], abbiamo bisogno di un protettore. Se riesci a impegnarti a proteggerci, confermerai il legame che ci unisce.
+We need your protection to stop the aggressions of [civName]. By signing a Pledge of Protection, you'll confirm the bond that ties us. = Essendo preoccupati dalle aggressioni di [civName], abbiamo bisogno di un protettore. Se riesci a impegnarti a proteggerci, confermerai il legame che ci unisce.
 
 Contest Culture = Gara di Cultura
 The civilization with the largest Culture growth will gain a reward. = Questa Città-stato è alla ricerca della cultura più forte e influente. La civiltà che accumulerà più Cultura verrà ricompensata.
@@ -3423,15 +3431,15 @@ Contest Technologies = Gara tecnologica
 The civilization with the largest number of new Technologies researched will gain a reward. = Una Città-stato ha indetto una fiera tecnologica! La civiltà che scoprirà il maggior numero di tecnologie verrà ricompensata.
 
 Invest = Investimento
-Our people are rejoicing thanks to a tourism boom. For a certain amount of time, any Gold donation will yield [amount]% extra Influence. = Il nostro popolo gioisce a causa di un boom turistico. Per un certo lasso di tempo, le donazioni in Oro frutteranno il [amount]% in più di Influenza.
+Our people are rejoicing thanks to a tourism boom. For a certain amount of time, any Gold donation will yield [50]% extra Influence. = Il nostro popolo gioisce a causa di un boom turistico. Per un certo lasso di tempo, le donazioni in Oro frutteranno il [50]% in più di Influenza.
 
 Bully City State = Minaccia Città-Stato
-We are tired of the pretensions of [param]. If someone were to put them in their place by Demanding Tribute from them, they would be rewarded. = Le pretese di [param] ci hanno sfiancato. Se qualcuno desse a quella Città-Stato una lezione in forma di richiesta di tributo, noi li ricompenseremmo.
+We are tired of the pretensions of [cityState]. If someone were to put them in their place by Demanding Tribute from them, they would be rewarded. = Le pretese di [cityState] ci hanno sfiancato. Se qualcuno desse a quella Città-Stato una lezione in forma di richiesta di tributo, noi li ricompenseremmo.
 
 Denounce Civilization = Denuncia Civiltà
-We have been forced to pay tribute to [param]! We need you to tell the world of their ill deeds. = Siamo stati costretti a pagre un tributo a [param]! Ti prego, svela al mondo la sua arroganza e denuncia il suo popolo!
+We have been forced to pay tribute to [civName]! We need you to tell the world of their ill deeds. = Siamo stati costretti a pagre un tributo a [civName]! Ti prego, svela al mondo la sua arroganza e denuncia il suo popolo!
 
-We have heard the tenets of [param] and are most curious. Will you send missionaries to teach us about your religion? = Gli insegnamenti della religione chiamata [param] ci hanno molto incuriosito. Perché non ci mandi dei missionari per insegnarci la tua fede?
+We have heard the tenets of [religionName] and are most curious. Will you send missionaries to teach us about your religion? = Gli insegnamenti della religione chiamata [religionName] ci hanno molto incuriosito. Perché non ci mandi dei missionari per insegnarci la tua fede?
 
 
 #################### Lines from Ruins from Civ V - Vanilla ####################
@@ -3446,10 +3454,10 @@ squatters wishing to settle under your rule = sopravvissuti in cerca di un luogo
 An ancient tribe trained us in their ways of combat! = Un'antica tribù ci ha addestrati nelle arti della guerra!
 your exploring unit receives training = punti esperienza per l'unità esploratrice
 
-We have found survivors in the ruins! Population added to [param]. = Abbiamo trovato dei superstiti, che si sono aggiunti a [param]!
+We have found survivors in the ruins! Population added to [cityName]. = Abbiamo trovato dei superstiti, che si sono aggiunti a [cityName]!
 survivors (adds population to a city) = superstiti che si aggiungono alla popolazione di una città
 
-We have found a stash of [param] Gold in the ruins! = Abbiamo trovato un tesoro di [param] Oro!
+We have found a stash of [goldAmount] Gold in the ruins! = Abbiamo trovato un tesoro di [goldAmount] Oro!
 a stash of gold = una manciata d'oro
 
 discover a lost technology = i segreti di una tecnologia perduta
@@ -3668,6 +3676,7 @@ Tundra = Tundra
 Desert = Deserto
 
 Lakes = Laghi
+Fresh water = acqua fresca
 
 Mountain = Montagna
 Has an elevation of [amount] for visibility calculations = Ha un'elevazione di [amount] per calcoli visibilità
@@ -3688,6 +3697,7 @@ A Camp can be built here without cutting it down = Puoi costruirvi un Campo senz
 Jungle = Giungla
 
 Marsh = Palude
+Rare feature = Caratteristica rara
 Only Polders can be built here = Può ospitare solo Polder
 
 Fallout = Scorie Radioattive
@@ -3883,10 +3893,13 @@ Porcelain = Porcellana
 #################### Lines from UnitPromotions from Civ V - Vanilla ####################
 
 Sword = Spada
+Mounted = unità a cavallo
+Siege = unità d'assedio
 Ranged Gunpowder = Polvere da sparo a distanza
 Armored = Corazzata
 Melee Water = Anfibia da mischia
 Ranged Water = Anfibia a distanza
+Submarine = Sottomarino
 Heal Instantly = Cura istantanea.
 Heal this unit by [amount] HP = Guarisci l'unità di [amount] HP
 Doing so will consume this opportunity to choose a Promotion = Rinuncia però all'opportunità di scegliere una Promozione
@@ -3945,6 +3958,7 @@ Medic = Medico I
 All adjacent units heal [amount] HP when healing = Tutte le unità adiacenti guariscono [amount] HP
 
 Medic II = Medico II
+in [tileFilter] tiles = nelle caselle [tileFilter]
 [amount] HP when healing = [amount] Salute quando guarisce
 
 Scouting I = Esplorazione I
@@ -4005,6 +4019,7 @@ Flight Deck III = Ponte di volo III
 Supply = Rifornimento
 May heal outside of friendly territory = Può guarire fuori dal territorio amico
 
+Bomber = Bombardiere
 Siege I = Assedio I
 
 Siege II = Assedio II
@@ -4014,6 +4029,7 @@ Siege III = Assedio III
 Evasion = Manovre evasive
 Damage taken from interception reduced by [amount]% = -[amount]% danni subiti dall'intercettazione
 
+Fighter = Caccia
 Interception I = Intercettazione I
 [amount]% Damage when intercepting = [amount]% danno quando intercetti
 
@@ -4110,10 +4126,29 @@ Can see over obstacles =
 
 Atomic Bomber = Bombardiere atomico
 
+Missile = da tiro
 Self-destructs when attacking = Si autodistrugge quando attacca
 Cannot be intercepted = Non può essere intercettato
 
 Can pass through impassable tiles = Può oltrepassare le caselle impenetrabili
+
+Melee = unità da mischia
+
+Ranged = unità da tiro
+
+Armor = unità corazzata
+
+WaterCivilian = unità marittima civile
+
+WaterMelee = marittima da mischia
+
+WaterRanged = marittima a distanza
+
+WaterSubmarine = sottomarina
+
+WaterAircraftCarrier = portaerei anfibio
+
+AtomicBomber = Bombardiere atomico
 
 
 #################### Lines from Units from Civ V - Vanilla ####################
@@ -4191,6 +4226,7 @@ Knight = Cavaliere
 Camel Archer = Arciere su cammello
 
 Conquistador = Conquistador
+on foreign continents = sui continenti stranieri
 
 Naresuan's Elephant = Elefante di Naresuan
 
@@ -4281,6 +4317,7 @@ Anti-Tank Gun = Cannone anticarro
 
 Atomic Bomb = Bomba atomica
 Nuclear weapon of Strength [amount] = Arma nucleare di Forza [amount]
+if [buildingName] is constructed = se [buildingName] è presente
 Blast radius [amount] = Raggio esplosivo [amount]
 
 Rocket Artillery = Artiglieria lanciarazzi
@@ -4315,6 +4352,7 @@ Great Artist = Grande Artista
 Can start an [amount]-turn golden age = Può avviare un'Età dell'Oro ([amount] turni)
 Can construct [improvementName] = Può costruire [improvementName]
 Great Person - [stat] = Grande Personaggio - [stat]
+Unbuildable = Non costruibile
 
 Great Scientist = Grande Scienziato
 Can hurry technology research = Può accelerare la ricerca tecnologica
@@ -4373,6 +4411,8 @@ Faith Healers = Guaritori della fede
 Fertility Rites = Riti di fertilità
 
 God of Craftsman = Dio dell'Artigianato
+ # Requires translation!
+in cities with at least [amount] [populationFilter] = 
 
 God of the Open Sky = Dio del Cielo Aperto
 
@@ -4424,6 +4464,7 @@ Feed the World = Nutrire il mondo
 Guruship = Guru
 
 Holy Warriors = Guerrieri Santi
+before the [era] = prima dell'[era]
 May buy [baseUnitFilter] units with [stat] for [amount] times their normal Production cost = Puoi costruire unità [baseUnitFilter] spendendo [stat] pari a [amount] volte il loro costo Produzione normale
 
 Liturgical Drama = Drammaturgia liturgica
@@ -4444,6 +4485,7 @@ Religious Community = Comunità religiosa
 [amount]% [stat] from every follower, up to [amount2]% = [amount]% [stat] per ogni seguace, fino a [amount2]%
 
 Swords into Ploughshares = Le spade diventano aratri
+when not at war = quando non sei in guerra
 
 Founder = Fondatore
 Ceremonial Burial = Sepoltura cerimoniale
@@ -4576,9 +4618,6 @@ Starting in this era disables religion = Cominciare in quest'epoca disabilita la
 
 
 Marine = Marine
-
-
-#################### Lines from GlobalUniques from Civ V - Gods & Kings ####################
 
 
 #################### Lines from Nations from Civ V - Gods & Kings ####################
@@ -4903,6 +4942,7 @@ Llanfairpwllgwyngyll = Llanfairpwllgwyngyll
 Falmouth = Falmouth
 Lorient = Lorient
 Celts = Celti
+with [amount] to [amount2] neighboring [tileFilter] [tileFilter2] tiles = con [amount]-[amount2] caselle [tileFilter] [tileFilter2] nei pressi
 
 Haile Selassie = Hailé Selassié
 I have tried all other avenues, but yet you persist in this madness. I hope, for your sake, your end is swift. = Ho provato ogni altra via, eppure persisti nella tua malvagità. Spero, per il tuo bene, che quanto sto per fare ti basti per cambiare.
@@ -4947,6 +4987,7 @@ Gambela = Gambela
 Ziway = Ziway
 Weldiya = Weldiya
 Ethiopia = Etiopia
+when fighting units from a Civilization with more Cities than you = quando combatti contro unità di una Civiltà con più Città di te
 
 Pacal = Pacal
 A sacrifice unlike all others must be made! = Un sacrificio come nessun altro va fatto oggi stesso! Vieni, e rendi onore agli dei!
@@ -5032,10 +5073,10 @@ Taoism = Taoismo
 #################### Lines from Ruins from Civ V - Gods & Kings ####################
 
 
-We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[param] Faith) = Abbiamo trovato dei simboli sacri, che ci hanno donato una miglior conoscenza della religione! (+[param] Fede)
+We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[faithAmount] Faith) = Abbiamo trovato dei simboli sacri, che ci hanno donato una miglior conoscenza della religione! (+[faithAmount] Fede)
 discover holy symbols = dei simboli sacri
 
-We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[param] Faith) = Un'antica profezia ha enormemente incrementato la nostra connessione spirituale! (+[param] Fede)
+We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[faithAmount] Faith) = Un'antica profezia ha enormemente incrementato la nostra connessione spirituale! (+[faithAmount] Fede)
 an ancient prophecy = un'antica profezia
 
 
@@ -5093,7 +5134,15 @@ Polder = Polder
 #################### Lines from TileResources from Civ V - Gods & Kings ####################
 
 
+Citrus = Agrumi
+
+Copper = Rame
+
+Crab = Granchi
+
 Salt = Sale
+
+Truffles = Tartufi
 
 
 #################### Lines from UnitPromotions from Civ V - Gods & Kings ####################
@@ -5425,45 +5474,20 @@ No Sight =
 [amount] XP gained from combat = [amount] XP dal combattimento
 Irremovable = Irremovibile
 when at war = quando sei in guerra
-when not at war = quando non sei in guerra
-during a Golden Age = durante un'Età dell'Oro
 with [resource] = con [resource]
-while the empire is happy = mentre l'impero è felice
 when between [amount] and [amount2] Happiness = se la Felicità è tra [amount] e [amount2]
 when below [amount] Happiness = quando la Felicità è sotto di [amount]
 during the [era] = durante l'[era]
-before the [era] = prima dell'[era]
-starting from the [era] = a partire dall'[era]
 if no other Civilization has researched this = se nessun'altra civiltà l'ha scoperta
-after discovering [tech] = quando scopri [tech]
-before discovering [tech] = finché non scopri [tech]
 upon discovering [tech] = quando scopri [tech]
 after adopting [policy] = quando adotti [policy]
-before adopting [policy] = prima di adottare [policy]
-if [buildingName] is constructed = se [buildingName] è presente
-for [amount] turns = per [amount] turni
 by consuming this unit = consumando questa unità
 in cities with a [buildingFilter] = nelle città che possiedono edifici [buildingFilter]
-in cities without a [buildingFilter] = nelle città senza edifici [buildingFilter]
- # Requires translation!
-in cities with at least [amount] [populationFilter] = 
-with a garrison = con una guarnigione
-for [mapUnitFilter] units = per le unità [mapUnitFilter]
 for units with [promotion] = per le unità con la promozione [promotion]
 for units without [promotion] = per le unità senza la promozione [promotion]
-vs cities = contro le città
-vs [mapUnitFilter] units = contro le unità [mapUnitFilter]
-when fighting units from a Civilization with more Cities than you = quando combatti contro unità di una Civiltà con più Città di te
-when attacking = in attacco
-when defending = in difesa
-when fighting in [tileFilter] tiles = quando combatti nelle caselle [tileFilter]
-on foreign continents = sui continenti stranieri
-when adjacent to a [mapUnitFilter] unit = quando si trova nei pressi di un'unità [mapUnitFilter]
 when above [amount] HP = se la salute è almeno [amount]
 when below [amount] HP = se la salute è meno di [amount]
 with [amount] to [amount2] neighboring [tileFilter] tiles = con [amount]-[amount2] caselle [tileFilter] nei pressi
-with [amount] to [amount2] neighboring [tileFilter] [tileFilter2] tiles = con [amount]-[amount2] caselle [tileFilter] [tileFilter2] nei pressi
-in [tileFilter] tiles = nelle caselle [tileFilter]
 in [tileFilter] [tileFilter2] tiles = nelle caselle [tileFilter] [tileFilter2]
 in tiles without [tileFilter] = nelle caselle senza [tileFilter]
 on water maps = sulle mappe acquatiche
@@ -5521,3 +5545,12 @@ CityState =
 ModOptions = 
  # Requires translation!
 Conditional = 
+
+#################### Removed Lines ####################
+
+#~~Rough Terrain = Terreno accidentato
+#~~Strategic = strategica
+#~~Bonus = bonus
+#~~Luxury = di lusso
+#~~military water = anfibie militari
+#~~My treasury contains little and my soldiers are getting impatient... ...therefore you must die. = Il mio tesoro è così magro e i miei soldati hanno fame di conquista. Mi dispiace dirti che sei tu il bersaglio. Alea Jacta Est!

--- a/android/assets/jsons/translations/Japanese.properties
+++ b/android/assets/jsons/translations/Japanese.properties
@@ -1114,8 +1114,6 @@ or [terrainType] =
 Can be constructed by = 
 Defence bonus = 防衛ボーナス
 Movement cost = 移動コスト
-Open terrain = 平坦な地形
-Rough Terrain = 起伏に富んだ地形
  # Requires translation!
 for = 
 Missing translations: = 欠落している翻訳:
@@ -1269,111 +1267,6 @@ Enhancing religion =
  # Requires translation!
 Enhanced religion = 
 
-# Terrains
-
-Impassable = 進行不可
-Rare feature = レア機能
-
-# terrainFilters (so for uniques like: "[stats] from [terrainFilter] tiles")
-
-All = すべて
-Water = 水
-Land = 領土
-Coastal = 海岸
-River = 川
-Rough terrain = 起伏に富んだ地形
-Foreign Land = 異国の地
-Foreign = 異国
-Friendly Land = 友好国
-Water resource = 水資源
-Bonus resource = ボーナス資源
-Luxury resource = 高級資源
-Strategic resource = 戦略資源
-Fresh water = 淡水源
-non-fresh water = 非淡水源
-Natural Wonder = 自然遺産
- # Requires translation!
-Hybrid = 
- # Requires translation!
-Undesirable = 
- # Requires translation!
-Desirable = 
- # Requires translation!
-Featureless = 
- # Requires translation!
-Fresh Water = 
-
-# improvementFilters
-
-All Road = すべての道
-Great Improvement = 偉人のタイル整備
- # Requires translation!
-Great = 
-
-# Resources
-
-Bison = バイソン
-Copper = 銅
-Cocoa = ココア
-Crab = カニ
-Citrus = 柑橘果物
-Truffles = トリュフ
-Strategic = 戦略資源
-Bonus = ボーナス資源
-Luxury = 高級資源
-
-# Unit types
-
-City = 都市
-Civilian = 市民
-Melee = 白兵
-Ranged = 遠隔攻撃
-Scout = 斥候
-Mounted = 騎乗
-Armor = 機甲
-Siege = 攻城
-
-WaterCivilian = 民間船
-WaterMelee = 海軍
-WaterRanged = 海軍遠隔
-WaterSubmarine = 潜水
-WaterAircraftCarrier = 水上航空母艦
-
-Fighter = 戦闘機
-Bomber = 爆撃機
-AtomicBomber = 原子爆弾
-Missile = ミサイル
-
-
-# Unit filters and other unit related things
-
-Air = 空軍
-air units = 航空ユニット
-Barbarian = 野蛮人
-Barbarians = 蛮族
-Embarked = 乗船中
-land units = 陸上ユニット
-Military = 軍事
-# Deprecated since 3.15.2, but should still be translated until it is officially removed
- # Requires translation!
-military water = 
-non-air = 非航空
-Nuclear Weapon = 核兵器
-Submarine = 潜水艦
-submarine units = 潜水艦ユニット
-Unbuildable = 建設不可
-water units = 海上ユニット
-wounded units = 負傷ユニット
-Wounded = 損傷
-
-# For the "All newly-trained [relevant] units in this city receive the [] promotion" translation. Relevant as in 'units that can receive'
-relevant = 関連
-
-# For "May choose [amount] additional [beliefType] beliefs when [founding/enhancing] a religion"
- # Requires translation!
-founding = 
- # Requires translation!
-enhancing = 
 
 # Promotions
 
@@ -1381,6 +1274,7 @@ Pick promotion = 昇進を選択
  OR  = または
 units in open terrain = 平坦な地形のユニット
 units in rough terrain = 起伏に富んだ地形のユニット
+wounded units = 負傷ユニット
 Targeting II (air) = 標的捕捉 II（航空）
 Targeting III (air) = 標的捕捉 III（航空）
 Bonus when performing air sweep [bonusAmount]% = 掃射時のボーナス[bonusAmount]%
@@ -1491,6 +1385,11 @@ This Unit upgrades for free =
 Never destroyed when the city is captured = 都市が確保されても破壊されない
 Invisible to others = 他文明には表示されない
 
+# Unused Resources
+
+Bison = バイソン
+Cocoa = ココア
+
 
 # In English we just paste all these conditionals at the end of each unique, but in your language that
 # may not turn into valid sentences. Therefore we have the following two translations to determine
@@ -1520,6 +1419,33 @@ ConditionalsPlacement = before
 ########################### AUTOMATICALLY GENERATED TRANSLATABLE STRINGS ########################### 
 
 
+######### Map Unit Filters ###########
+
+Wounded = 損傷
+Barbarians = 蛮族
+ # Requires translation!
+City-State = 
+Embarked = 乗船中
+ # Requires translation!
+Non-City = 
+
+######### Unit Type Filters ###########
+
+Military = 軍事
+Civilian = 市民
+non-air = 非航空
+relevant = 関連
+Nuclear Weapon = 核兵器
+City = 都市
+Air = 空軍
+land units = 陸上ユニット
+water units = 海上ユニット
+air units = 航空ユニット
+ # Requires translation!
+military units = 
+submarine units = 潜水艦ユニット
+Barbarian = 野蛮人
+
 ######### City filters ###########
 
 in this city = この都市で
@@ -1540,6 +1466,72 @@ in annexed cities = 併合された都市で
 in holy cities = 聖地で
 in City-State cities = 都市国家の都市で
 in cities following this religion = この宗教が主流の都市で
+
+######### Population Filters ###########
+
+ # Requires translation!
+Unemployed = 
+ # Requires translation!
+Followers of the Majority Religion = 
+ # Requires translation!
+Followers of this Religion = 
+
+######### Terrain Filters ###########
+
+All = すべて
+Coastal = 海岸
+River = 川
+Open terrain = 平坦な地形
+Rough terrain = 起伏に富んだ地形
+Water resource = 水資源
+Foreign Land = 異国の地
+Foreign = 異国
+Friendly Land = 友好国
+ # Requires translation!
+Enemy Land = 
+ # Requires translation!
+Featureless = 
+ # Requires translation!
+Fresh Water = 
+non-fresh water = 非淡水源
+Natural Wonder = 自然遺産
+Impassable = 進行不可
+Land = 領土
+Water = 水
+Luxury resource = 高級資源
+Strategic resource = 戦略資源
+Bonus resource = ボーナス資源
+
+######### Tile Filters ###########
+
+ # Requires translation!
+unimproved = 
+All Road = すべての道
+Great Improvement = 偉人のタイル整備
+
+######### Region Types ###########
+
+ # Requires translation!
+Hybrid = 
+
+######### Terrain Quality ###########
+
+ # Requires translation!
+Undesirable = 
+ # Requires translation!
+Desirable = 
+
+######### Improvement Filters ###########
+
+ # Requires translation!
+Great = 
+
+######### Prophet Action Filters ###########
+
+ # Requires translation!
+founding = 
+ # Requires translation!
+enhancing = 
 
 ######### Unique Specials ###########
 
@@ -1569,6 +1561,7 @@ Temple of Artemis = アルテミス神殿
 
 The Great Lighthouse = ファロス灯台
 'They that go down to the sea in ships, that do business in great waters; these see the works of the Lord, and his wonders in the deep.' - The Bible, Psalms 107:23-24 = 「彼らは船に乗り海に出て、大海原で事業をなす者となった。彼らは深き海で主の御業を見た。驚くべき主の美業を。」 - 旧約聖書詩編 107:23-24
+for [mapUnitFilter] units = [mapUnitFilter]のユニットに
 [amount] Movement = 移動[amount]
 [amount] Sight = 視界[amount]
 
@@ -1616,6 +1609,8 @@ Krepost = クレポスト
 
 Statue of Zeus = ゼウス像
 'He spoke, the son of Kronos, and nodded his head with the dark brows, and the immortally anointed hair of the great god swept from his divine head, and all Olympos was shaken' - The Iliad = 「暗褐色の眉を持つクロノスの息子はそう言うとうなずき、油によって永遠に清められた偉大なる髪を神聖なる頭部よりなびかせ、オリンポス全土を震撼させた」 - イリアス
+vs cities = 都市に対して
+when attacking = 攻撃時
 [amount]% Strength = 戦闘力[amount]%
 
 Lighthouse = 灯台
@@ -1721,11 +1716,13 @@ Notre Dame = ノートルダム大聖堂
 Castle = 城
 
 Mughal Fort = ムガル要塞
+after discovering [tech] = [tech]を研究してから
 [stats] [cityFilter] = [cityFilter][stats]
 
 Himeji Castle = 姫路城
  # Requires translation!
 'Bushido is realized in the presence of death. This means choosing death whenever there is a choice between life and death. There is no other reasoning.' - Yamamoto Tsunetomo = 
+when fighting in [tileFilter] tiles = [tileFilter]のタイルで戦闘時
 
 Ironworks = 製鉄所
 
@@ -1841,6 +1838,8 @@ Pentagon = ペンタゴン
 [amount]% Gold cost of upgrading = アップグレードにかかるゴールド[amount]%
 
 Solar Plant = 太陽熱発電
+ # Requires translation!
+in cities without a [buildingFilter] = 
 Only available = だけできる
 
 Nuclear Plant = 原子力発電所
@@ -1875,6 +1874,7 @@ King = 国王
 Era Starting Unit = 時代の始まりのユニット
 
 Emperor = 皇帝
+Scout = 斥候
 
 Immortal = 不死者
 Worker = 労働者
@@ -1907,9 +1907,6 @@ Atomic era = 原子力時代
 Information era = 情報時代
 
 Future era = 未来
-
-
-#################### Lines from GlobalUniques from Civ V - Vanilla ####################
 
 
 #################### Lines from Nations from Civ V - Vanilla ####################
@@ -2247,6 +2244,7 @@ La Rochelle = ラ・ロシェル
 Bourges = ブールジュ
 Calais = カレー
 France = フランス
+before discovering [tech] = [tech]を研究するまで
 
 Catherine = エカテリーナ
 You've behaved yourself very badly, you know it. Now it's payback time. = 身に覚えがない訳ではなかろう。償う時がきたのだ。
@@ -2302,7 +2300,7 @@ Double quantity of [resource] produced = [resource]の生産量が2倍
 
 Augustus Caesar = アウグストゥス
  # Requires translation!
-My treasury contains little and my soldiers are getting impatient... ...therefore you must die. = 
+My treasury contains little and my soldiers are getting impatient... (sigh) ...therefore you must die. = 
 So brave, yet so stupid! If only you had a brain similar to your courage. = そなたは強いが、それでいて愚かなようだ。そなたの頭脳がその軍隊のように強ければよかったのだがな。
 The gods have deprived Rome of their favour. We have been defeated. = 神々はローマを見放した。我等は敗れたのだ。
 I greet you. I am Augustus, Imperator and Pontifex Maximus of Rome. If you are a friend of Rome, you are welcome. = ようこそ。私はアウグストゥス、ローマ皇帝であり最高神祇官だ。もしあなたがローマの友であるならば、私はあなたを歓迎する。
@@ -2855,6 +2853,7 @@ Paishiyauvada = パイシヤウヴァダ
 Patigrbana = パティグルバナ
 Phrada = フラダ
 Persia = ペルシア
+during a Golden Age = 黄金時代の間
 
 Kamehameha I = カメハメハ
 The ancient fire flashing across the sky is what proclaimed that this day would come, though I had foolishly hoped for a different outcome. = 天空にきらめくいにしえの炎はこの日の訪れを示している。私としては愚かにも違う結末を期待していたのだがな。
@@ -2909,6 +2908,8 @@ Nuguria = ニューギニア
 Pileni = ピレニ
 Nukumanu = ヌクマヌ
 Polynesia = ポリネシア
+ # Requires translation!
+starting from the [era] = 
 Enables embarkation for land units = 地上ユニットの乗船が可能になる
  # Requires translation!
 Enables [mapUnitFilter] units to enter ocean tiles = 
@@ -3411,6 +3412,8 @@ Provides the cheapest [stat] building in your first [amount] cities for free = �
 Oligarchy = 寡頭制
 Units in cities cost no Maintenance = 都市に駐留しているユニットには維持費がかからなくなる
  # Requires translation!
+with a garrison = 
+ # Requires translation!
 [amount]% Strength for cities = 
 Landed Elite = 地主エリート
 [amount]% growth [cityFilter] = [cityFilter]成長[amount]%
@@ -3434,6 +3437,8 @@ Liberty =
 
 Warrior Code = 戦士の掟
 Discipline = 規律
+ # Requires translation!
+when adjacent to a [mapUnitFilter] unit = 
 Military Tradition = 軍の栄誉
  # Requires translation!
 [amount]% XP gained from combat = 
@@ -3442,6 +3447,7 @@ Professional Army = 軍隊の常備
 Honor Complete = 名誉コンプリート
  # Requires translation!
 Honor = 
+vs [mapUnitFilter] units = [mapUnitFilter]ユニットに対して
  # Requires translation!
 Notified of new Barbarian encampments = 
 
@@ -3455,6 +3461,7 @@ Free Religion = 宗教的寛容
 Piety Complete = 敬虔コンプリート
  # Requires translation!
 Piety = 
+before adopting [policy] = [policy]を採用するまで
 
 Philantropy = 博愛主義
 Gifts of Gold to City-States generate [amount]% more Influence = ゴールドの寄付によって都市国家へ与える影響力が[amount]%増加
@@ -3497,10 +3504,12 @@ Rationalism Complete = 合理主義コンプリート
 [amount] Free Technologies = テクノロジーを無償で[amount]つ獲得
  # Requires translation!
 Rationalism = 
+while the empire is happy = 国家が幸福である間
 [amount]% [stat] = [stat][amount]%
 
 Constitution = 憲法
 Universal Suffrage = 普通選挙
+when defending = 防衛時
 Civil Society = 市民社会
 [amount]% Food consumption by specialists [cityFilter] = [cityFilter]専門家の食料の消費[amount]%
 Free Speech = 表現の自由
@@ -3519,6 +3528,8 @@ Quantity of strategic resources produced by the empire +[amount]% = 戦略資源
 Police State = 警察国家
 Total War = 総力戦
 Autocracy Complete = 独裁コンプリート
+ # Requires translation!
+for [amount] turns = 
  # Requires translation!
 Autocracy = 
  # Requires translation!
@@ -3545,29 +3556,29 @@ Clear Barbarian Camp = 野営地の制圧
 We feel threatened by a Barbarian Camp near our city. Please take care of it. = 我々の都市は近くにある蛮族の野営地に脅かされています。気をつけてください。
 
 Connect Resource = 資源の接続
-In order to make our civilizations stronger, connect [param] to your trade network. = 我々の文明をより強固なものにするために、\n[param]をあなたの交易路に接続してください。
+In order to make our civilizations stronger, connect [tileResource] to your trade network. = 我々の文明をより強固なものにするために、\n[tileResource]をあなたの交易路に接続してください。
 
 Construct Wonder = 遺産の建設
-We recommend you to start building [param] to show the whole world your civilization strength. = 文明の強さを世界に見せつけるために、\n[param]を建設することをおすすめします。
+We recommend you to start building [wonder] to show the whole world your civilization strength. = 文明の強さを世界に見せつけるために、\n[wonder]を建設することをおすすめします。
 
 Acquire Great Person = 偉人の取得
-Great People can change the course of a Civilization! You will be rewarded for acquiring a new [param]. = 偉人は文明の行き先を変えられます。\n新たに[param]を取得すれば報酬を得られます。
+Great People can change the course of a Civilization! You will be rewarded for acquiring a new [greatPerson]. = 偉人は文明の行き先を変えられます。\n新たに[greatPerson]を取得すれば報酬を得られます。
 
 Conquer City State = 都市国家の征服
-It's time to erase the City-State of [param] from the map. You will be greatly rewarded for conquering them! = 都市国家の[param]を世界地図から取り除くときです。\n都市国家を征服すれば報酬を得られます。
+It's time to erase the City-State of [cityState] from the map. You will be greatly rewarded for conquering them! = 都市国家の[cityState]を世界地図から取り除くときです。\n都市国家を征服すれば報酬を得られます。
 
 Find Player = プレイヤーの探索
-You have yet to discover where [param] set up their cities. You will be rewarded for finding their territories. = 我々は[param]がどこに都市を置いたのかわかっていません。\n領土を発見すれば報酬を得られます。
+You have yet to discover where [civName] set up their cities. You will be rewarded for finding their territories. = 我々は[civName]がどこに都市を置いたのかわかっていません。\n領土を発見すれば報酬を得られます。
 
 Find Natural Wonder = 自然遺産の探索
-Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [param] yet. = 自然遺産を発見するために探索者を行かせてください。\n[param]はまだ誰にも発見されていません。
+Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [naturalWonder] yet. = 自然遺産を発見するために探索者を行かせてください。\n[naturalWonder]はまだ誰にも発見されていません。
 
 Give Gold = ゴールドの提供
-We are suffering great poverty after being robbed by [param], and unless we receive a sum of Gold, it's only a matter of time before we collapse. = 我々は[param]からの強奪被害に遭った後、貧困に悩まされており、\nゴールドが提供されなければ、我々の崩壊まではあとわずかです。
+We are suffering great poverty after being robbed by [civName], and unless we receive a sum of Gold, it's only a matter of time before we collapse. = 我々は[civName]からの強奪被害に遭った後、貧困に悩まされており、\nゴールドが提供されなければ、我々の崩壊まではあとわずかです。
 
 Pledge to Protect = 保護の誓約
  # Requires translation!
-We need your protection to stop the aggressions of [param]. By signing a Pledge of Protection, you'll confirm the bond that ties us. = 
+We need your protection to stop the aggressions of [civName]. By signing a Pledge of Protection, you'll confirm the bond that ties us. = 
 
 Contest Culture = 文化力の競争
 The civilization with the largest Culture growth will gain a reward. = 最も多く文化が成長した文明が報酬を得られます。
@@ -3579,20 +3590,20 @@ Contest Technologies = テクノロジーの競争
 The civilization with the largest number of new Technologies researched will gain a reward. = 最も多く新しいテクノロジーを研究した文明が報酬を得られます。
 
 Invest = 投資
-Our people are rejoicing thanks to a tourism boom. For a certain amount of time, any Gold donation will yield [amount]% extra Influence. = 我々は観光ブームに喜んでいます。\n期間中にゴールドを寄付すれば[amount]%追加で影響力を得られます。
+Our people are rejoicing thanks to a tourism boom. For a certain amount of time, any Gold donation will yield [50]% extra Influence. = 我々は観光ブームに喜んでいます。\n期間中にゴールドを寄付すれば[50]%追加で影響力を得られます。
 
  # Requires translation!
 Bully City State = 
  # Requires translation!
-We are tired of the pretensions of [param]. If someone were to put them in their place by Demanding Tribute from them, they would be rewarded. = 
+We are tired of the pretensions of [cityState]. If someone were to put them in their place by Demanding Tribute from them, they would be rewarded. = 
 
  # Requires translation!
 Denounce Civilization = 
  # Requires translation!
-We have been forced to pay tribute to [param]! We need you to tell the world of their ill deeds. = 
+We have been forced to pay tribute to [civName]! We need you to tell the world of their ill deeds. = 
 
  # Requires translation!
-We have heard the tenets of [param] and are most curious. Will you send missionaries to teach us about your religion? = 
+We have heard the tenets of [religionName] and are most curious. Will you send missionaries to teach us about your religion? = 
 
 
 #################### Lines from Ruins from Civ V - Vanilla ####################
@@ -3614,12 +3625,12 @@ An ancient tribe trained us in their ways of combat! =
 your exploring unit receives training = 
 
  # Requires translation!
-We have found survivors in the ruins! Population added to [param]. = 
+We have found survivors in the ruins! Population added to [cityName]. = 
  # Requires translation!
 survivors (adds population to a city) = 
 
  # Requires translation!
-We have found a stash of [param] Gold in the ruins! = 
+We have found a stash of [goldAmount] Gold in the ruins! = 
  # Requires translation!
 a stash of gold = 
 
@@ -3847,6 +3858,7 @@ Tundra = ツンドラ
 Desert = 砂漠
 
 Lakes = 湖
+Fresh water = 淡水源
 
 Mountain = 山岳
  # Requires translation!
@@ -3872,6 +3884,7 @@ A Camp can be built here without cutting it down =
 Jungle = ジャングル
 
 Marsh = 湿原
+Rare feature = レア機能
  # Requires translation!
 Only Polders can be built here = 
 
@@ -4090,6 +4103,8 @@ Porcelain = 磁器
 
  # Requires translation!
 Sword = 
+Mounted = 騎乗
+Siege = 攻城
  # Requires translation!
 Ranged Gunpowder = 
  # Requires translation!
@@ -4098,6 +4113,7 @@ Armored =
 Melee Water = 
  # Requires translation!
 Ranged Water = 
+Submarine = 潜水艦
 Heal Instantly = 瞬時回復
 Heal this unit by [amount] HP = このユニットのHPを[amount]回復する
 Doing so will consume this opportunity to choose a Promotion = 昇進する機会を失うことになる
@@ -4161,6 +4177,7 @@ Medic = 衛生兵
 All adjacent units heal [amount] HP when healing = 
 
 Medic II = 衛生兵 II
+in [tileFilter] tiles = [tileFilter]のタイルで
 [amount] HP when healing = 回復時にHP[amount]
 
 Scouting I = 斥候 I
@@ -4230,6 +4247,7 @@ Supply =
  # Requires translation!
 May heal outside of friendly territory = 
 
+Bomber = 爆撃機
 Siege I = 攻城攻撃
 
 Siege II = 攻城攻撃II
@@ -4240,6 +4258,7 @@ Evasion = 回避
  # Requires translation!
 Damage taken from interception reduced by [amount]% = 
 
+Fighter = 戦闘機
 Interception I = 迎撃 I
  # Requires translation!
 [amount]% Damage when intercepting = 
@@ -4354,10 +4373,29 @@ Can see over obstacles =
  # Requires translation!
 Atomic Bomber = 
 
+Missile = ミサイル
 Self-destructs when attacking = 攻撃時消滅する
 Cannot be intercepted = 迎撃されない
 
 Can pass through impassable tiles = 通行不可なタイルを通過できる
+
+Melee = 白兵
+
+Ranged = 遠隔攻撃
+
+Armor = 機甲
+
+WaterCivilian = 民間船
+
+WaterMelee = 海軍
+
+WaterRanged = 海軍遠隔
+
+WaterSubmarine = 潜水
+
+WaterAircraftCarrier = 水上航空母艦
+
+AtomicBomber = 原子爆弾
 
 
 #################### Lines from Units from Civ V - Vanilla ####################
@@ -4438,6 +4476,8 @@ Knight = 騎士
 Camel Archer = ラクダ弓兵
 
 Conquistador = コンキスタドール
+ # Requires translation!
+on foreign continents = 
 
 Naresuan's Elephant = ナレースワンの象
 
@@ -4528,6 +4568,8 @@ Anti-Tank Gun = 対戦車砲
 
 Atomic Bomb = 原子爆弾
 Nuclear weapon of Strength [amount] = 威力[amount]の核兵器
+ # Requires translation!
+if [buildingName] is constructed = 
 Blast radius [amount] = 爆破半径 [amount]
 
 Rocket Artillery = ロケット砲
@@ -4562,6 +4604,7 @@ Great Artist = 大芸術家
 Can start an [amount]-turn golden age = 黄金時代を[amount]ターン始められる
 Can construct [improvementName] = [improvementName]を構築可能
 Great Person - [stat] = 偉人 - [stat]
+Unbuildable = 建設不可
 
 Great Scientist = 大科学者
 Can hurry technology research = テクノロジーの研究を早める
@@ -4633,6 +4676,8 @@ Fertility Rites =
 
  # Requires translation!
 God of Craftsman = 
+ # Requires translation!
+in cities with at least [amount] [populationFilter] = 
 
  # Requires translation!
 God of the Open Sky = 
@@ -4711,6 +4756,7 @@ Guruship =
 
  # Requires translation!
 Holy Warriors = 
+before the [era] = [era]の前
  # Requires translation!
 May buy [baseUnitFilter] units with [stat] for [amount] times their normal Production cost = 
 
@@ -4742,6 +4788,7 @@ Religious Community =
 
  # Requires translation!
 Swords into Ploughshares = 
+when not at war = 非戦時
 
  # Requires translation!
 Founder = 
@@ -4923,9 +4970,6 @@ Starting in this era disables religion =
 
 
 Marine = 海兵隊
-
-
-#################### Lines from GlobalUniques from Civ V - Gods & Kings ####################
 
 
 #################### Lines from Nations from Civ V - Gods & Kings ####################
@@ -5524,6 +5568,8 @@ Falmouth =
  # Requires translation!
 Lorient = 
 Celts = ケルト
+ # Requires translation!
+with [amount] to [amount2] neighboring [tileFilter] [tileFilter2] tiles = 
 
 Haile Selassie = ハイレ・セラシエ
  # Requires translation!
@@ -5609,6 +5655,8 @@ Ziway =
  # Requires translation!
 Weldiya = 
 Ethiopia = エチオピア
+ # Requires translation!
+when fighting units from a Civilization with more Cities than you = 
 
 Pacal = パカル
  # Requires translation!
@@ -5748,12 +5796,12 @@ Taoism = 道教
 
 
  # Requires translation!
-We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[param] Faith) = 
+We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[faithAmount] Faith) = 
  # Requires translation!
 discover holy symbols = 
 
  # Requires translation!
-We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[param] Faith) = 
+We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[faithAmount] Faith) = 
  # Requires translation!
 an ancient prophecy = 
 
@@ -5817,7 +5865,15 @@ Polder =
 #################### Lines from TileResources from Civ V - Gods & Kings ####################
 
 
+Citrus = 柑橘果物
+
+Copper = 銅
+
+Crab = カニ
+
 Salt = 塩
+
+Truffles = トリュフ
 
 
 #################### Lines from UnitPromotions from Civ V - Gods & Kings ####################
@@ -6255,62 +6311,28 @@ No Sight =
  # Requires translation!
 Irremovable = 
 when at war = 戦時
-when not at war = 非戦時
-during a Golden Age = 黄金時代の間
  # Requires translation!
 with [resource] = 
-while the empire is happy = 国家が幸福である間
 when between [amount] and [amount2] Happiness = 幸福度が[amount]から[amount2]までのとき
 when below [amount] Happiness = 幸福度が[amount]より低いとき
 during the [era] = [era]の間
-before the [era] = [era]の前
- # Requires translation!
-starting from the [era] = 
  # Requires translation!
 if no other Civilization has researched this = 
-after discovering [tech] = [tech]を研究してから
-before discovering [tech] = [tech]を研究するまで
  # Requires translation!
 upon discovering [tech] = 
 after adopting [policy] = [policy]を採用してから
-before adopting [policy] = [policy]を採用するまで
- # Requires translation!
-if [buildingName] is constructed = 
- # Requires translation!
-for [amount] turns = 
  # Requires translation!
 by consuming this unit = 
  # Requires translation!
 in cities with a [buildingFilter] = 
  # Requires translation!
-in cities without a [buildingFilter] = 
- # Requires translation!
-in cities with at least [amount] [populationFilter] = 
- # Requires translation!
-with a garrison = 
-for [mapUnitFilter] units = [mapUnitFilter]のユニットに
- # Requires translation!
 for units with [promotion] = 
  # Requires translation!
 for units without [promotion] = 
-vs cities = 都市に対して
-vs [mapUnitFilter] units = [mapUnitFilter]ユニットに対して
- # Requires translation!
-when fighting units from a Civilization with more Cities than you = 
-when attacking = 攻撃時
-when defending = 防衛時
-when fighting in [tileFilter] tiles = [tileFilter]のタイルで戦闘時
- # Requires translation!
-on foreign continents = 
- # Requires translation!
-when adjacent to a [mapUnitFilter] unit = 
 when above [amount] HP = [amount]HPより高いとき
 when below [amount] HP = [amount]HPより低いとき
  # Requires translation!
 with [amount] to [amount2] neighboring [tileFilter] tiles = 
- # Requires translation!
-with [amount] to [amount2] neighboring [tileFilter] [tileFilter2] tiles = 
-in [tileFilter] tiles = [tileFilter]のタイルで
  # Requires translation!
 in [tileFilter] [tileFilter2] tiles = 
 in tiles without [tileFilter] = [tileFilter]以外のタイルで
@@ -6378,3 +6400,10 @@ CityState = 都市国家
 ModOptions = 
  # Requires translation!
 Conditional = 
+
+#################### Removed Lines ####################
+
+#~~Rough Terrain = 起伏に富んだ地形
+#~~Strategic = 戦略資源
+#~~Bonus = ボーナス資源
+#~~Luxury = 高級資源

--- a/android/assets/jsons/translations/Korean.properties
+++ b/android/assets/jsons/translations/Korean.properties
@@ -1106,8 +1106,6 @@ or [terrainType] = 또는 [terrainType] 지형
 Can be constructed by = 건설가능 유닛
 Defence bonus = 방어 보너스
 Movement cost = 소모 행동력
-Open terrain = 개활지
-Rough Terrain = 험지
 for = 이(가) 다음 자원에 추가됨:
 Missing translations: = 미완성 번역 목록:
 Resolution = 해상도
@@ -1238,106 +1236,6 @@ Religion = 종교
 Enhancing religion = 종교 강화
 Enhanced religion = 강화된 종교
 
-# Terrains
-
-Impassable = 통행 불가
-Rare feature = 희귀지형
-
-# terrainFilters (so for uniques like: "[stats] from [terrainFilter] tiles")
-
-All = 모든
-Water = 해상
-Land = 지상
-Coastal = 해안
-River = 강
-Rough terrain = 험지
-Foreign Land = 우호 지역 밖
-Foreign = 우호 지역 밖
-Friendly Land = 우호 지역
-Water resource = 해양 자원
-Bonus resource = 보너스 자원
-Luxury resource = 사치 자원
-Strategic resource = 전략 자원
-Fresh water = 담수
-non-fresh water = 담수가 아닌 물
-Natural Wonder = 자연 불가사의
- # Requires translation!
-Hybrid = 
- # Requires translation!
-Undesirable = 
- # Requires translation!
-Desirable = 
- # Requires translation!
-Featureless = 
-Fresh Water = 담수
-
-# improvementFilters
-
-All Road = 모든 도로
-Great Improvement = 위인 시설
-Great = 위인
-
-# Resources
-
-Bison = 들소
-Copper = 구리
-Cocoa = 코코아
-Crab = 게
-Citrus = 감귤
-Truffles = 송로버섯
-Strategic = 전략 자원
-Bonus = 보너스 자원
-Luxury = 사치 자원
-
-# Unit types
-
-City = 도시
-Civilian = 민간
-Melee = 근접
-Ranged = 원거리
-Scout = 정찰병
-Mounted = 기마
-Armor = 중갑
-Siege = 공성
-
-WaterCivilian = 해상 민간
-WaterMelee = 해상 근접
-WaterRanged = 해상 원거리
-WaterSubmarine = 수중
-WaterAircraftCarrier = 항공모함
-
-Fighter = 전투기
-Bomber = 폭격기
-AtomicBomber = 핵무기
-Missile = 미사일
-
-
-# Unit filters and other unit related things
-
-Air = 공중
-air units = 공중
-Barbarian = 야만인
-Barbarians = 야만인
-Embarked = 승선한
-land units = 지상
-Military = 군사
-# Deprecated since 3.15.2, but should still be translated until it is officially removed
-military water = 해상 군사
-non-air = 공중 유닛이 아닌
-Nuclear Weapon = 핵폭탄
-Submarine = 잠수함
-submarine units = 잠수함
-Unbuildable = 도시에서 직접 생산 불가
-water units = 해상 유닛
-wounded units = 부상당한 유닛
-Wounded = 피해를 입은
-
-# For the "All newly-trained [relevant] units in this city receive the [] promotion" translation. Relevant as in 'units that can receive'
-relevant = 해당되는 모든
-
-# For "May choose [amount] additional [beliefType] beliefs when [founding/enhancing] a religion"
-founding = 창시
-enhancing = 강화
 
 # Promotions
 
@@ -1345,6 +1243,7 @@ Pick promotion = 승급 선택
  OR  =  또는 
 units in open terrain = 개활지에서 싸우는 유닛
 units in rough terrain = 험지에서 싸우는 유닛
+wounded units = 부상당한 유닛
 Targeting II (air) = 공중 목표 설정 II
 Targeting III (air) = 공중 목표 설정 III
 Bonus when performing air sweep [bonusAmount]% = 대공 무력화시 전투력 +[bonusAmount]%
@@ -1448,6 +1347,11 @@ This Unit upgrades for free = 유닛이 무료로 업그레이드됨
 Never destroyed when the city is captured = 도시가 점령당해도 파괴되지 않음
 Invisible to others = 탐지 불가
 
+# Unused Resources
+
+Bison = 들소
+Cocoa = 코코아
+
 
 # In English we just paste all these conditionals at the end of each unique, but in your language that
 # may not turn into valid sentences. Therefore we have the following two translations to determine
@@ -1477,6 +1381,33 @@ ConditionalsPlacement = before
 ########################### AUTOMATICALLY GENERATED TRANSLATABLE STRINGS ########################### 
 
 
+######### Map Unit Filters ###########
+
+Wounded = 피해를 입은
+Barbarians = 야만인
+ # Requires translation!
+City-State = 
+Embarked = 승선한
+ # Requires translation!
+Non-City = 
+
+######### Unit Type Filters ###########
+
+Military = 군사
+Civilian = 민간
+non-air = 공중 유닛이 아닌
+relevant = 해당되는 모든
+Nuclear Weapon = 핵폭탄
+City = 도시
+Air = 공중
+land units = 지상
+water units = 해상 유닛
+air units = 공중
+ # Requires translation!
+military units = 
+submarine units = 잠수함
+Barbarian = 야만인
+
 ######### City filters ###########
 
 in this city = 이 도시
@@ -1495,6 +1426,68 @@ in annexed cities = 합병된 도시
 in holy cities = 성도
 in City-State cities = 도시 국가의 도시
 in cities following this religion = 이 종교를 믿는 도시
+
+######### Population Filters ###########
+
+ # Requires translation!
+Unemployed = 
+ # Requires translation!
+Followers of the Majority Religion = 
+ # Requires translation!
+Followers of this Religion = 
+
+######### Terrain Filters ###########
+
+All = 모든
+Coastal = 해안
+River = 강
+Open terrain = 개활지
+Rough terrain = 험지
+Water resource = 해양 자원
+Foreign Land = 우호 지역 밖
+Foreign = 우호 지역 밖
+Friendly Land = 우호 지역
+ # Requires translation!
+Enemy Land = 
+ # Requires translation!
+Featureless = 
+Fresh Water = 담수
+non-fresh water = 담수가 아닌 물
+Natural Wonder = 자연 불가사의
+Impassable = 통행 불가
+Land = 지상
+Water = 해상
+Luxury resource = 사치 자원
+Strategic resource = 전략 자원
+Bonus resource = 보너스 자원
+
+######### Tile Filters ###########
+
+ # Requires translation!
+unimproved = 
+All Road = 모든 도로
+Great Improvement = 위인 시설
+
+######### Region Types ###########
+
+ # Requires translation!
+Hybrid = 
+
+######### Terrain Quality ###########
+
+ # Requires translation!
+Undesirable = 
+ # Requires translation!
+Desirable = 
+
+######### Improvement Filters ###########
+
+Great = 위인
+
+######### Prophet Action Filters ###########
+
+founding = 창시
+enhancing = 강화
 
 ######### Unique Specials ###########
 
@@ -1522,6 +1515,7 @@ Temple of Artemis = 아르테미스 사원
 
 The Great Lighthouse = 알렉산드리아 등대
 'They that go down to the sea in ships, that do business in great waters; these see the works of the Lord, and his wonders in the deep.' - The Bible, Psalms 107:23-24 = '배들을 바다에 띄우며 큰 물에서 일을 하는 자는 여호와께서 행하신 일들과 그의 기이한 일들을 깊은 바다에서 보나니.' - 성경, 시편 107:23-24
+for [mapUnitFilter] units = [mapUnitFilter] 유닛에
 [amount] Movement = 행동력 [amount]
 [amount] Sight = 시야 [amount]
 
@@ -1568,6 +1562,8 @@ Krepost = 크리아포스츠
 
 Statue of Zeus = 제우스 동상
 'He spoke, the son of Kronos, and nodded his head with the dark brows, and the immortally anointed hair of the great god swept from his divine head, and all Olympos was shaken' - The Iliad = '크로노스의 아들인 그가 말하고, 어두운 눈썹을 찡그리며 고개를 끄덕였고, 불멸의 기름이 발라진 위대한 신의 머리카락이 신의 머리에서 쓸려나갔고, 모든 올림포스가 흔들렸다.' - 일리아드
+vs cities = 도시 대항
+when attacking = 공격시
 [amount]% Strength = 전투력 [amount]%
 
 Lighthouse = 등대
@@ -1665,10 +1661,12 @@ Notre Dame = 노트르담 대성당
 Castle = 성
 
 Mughal Fort = 무굴 요새
+after discovering [tech] = [tech] 연구 후
 [stats] [cityFilter] = [cityFilter]에 [stats]
 
 Himeji Castle = 히메지 성
 'Bushido is realized in the presence of death. This means choosing death whenever there is a choice between life and death. There is no other reasoning.' - Yamamoto Tsunetomo = '무사도는 죽음을 마주했을 때 실현된다. 즉, 삶과 죽음의 기로에서 죽음을 택한다는 뜻이다. 다른 생각의 여지는 없다.' - 야마모토 츠네모토
+when fighting in [tileFilter] tiles = [tileFilter] 
 
 Ironworks = 제철소
 
@@ -1771,6 +1769,7 @@ Pentagon = 펜타곤
 [amount]% Gold cost of upgrading = 업그레이드에 필요한 골드 [amount]%
 
 Solar Plant = 태양열 발전소
+in cities without a [buildingFilter] = [buildingFilter]이(가) 건설되지 않은 도시
 Only available = 에만 가능
 
 Nuclear Plant = 원자력 발전소
@@ -1804,6 +1803,7 @@ King = 왕
 Era Starting Unit = 시작 유닛
 
 Emperor = 황제
+Scout = 정찰병
 
 Immortal = 불멸자
 Worker = 노동자
@@ -1836,9 +1836,6 @@ Atomic era = 원자력 시대
 Information era = 정보화 시대
 
 Future era = 미래 시대
-
-
-#################### Lines from GlobalUniques from Civ V - Vanilla ####################
 
 
 #################### Lines from Nations from Civ V - Vanilla ####################
@@ -2174,6 +2171,7 @@ La Rochelle = 라 로셸
 Bourges = 부르쥬
 Calais = 칼레
 France = 프랑스
+before discovering [tech] = [tech] 연구 전
 
 Catherine = 예카테리나
 You've behaved yourself very badly, you know it. Now it's payback time. = 당신이 아주 불쾌하게 굴었다는 것을 스스로도 잘 알겠죠. 이제 보복할 시간입니다.
@@ -2228,7 +2226,8 @@ Russia = 러시아
 Double quantity of [resource] produced = [resource] 획득량 두 배
 
 Augustus Caesar = 아우구스투스 카이사르
-My treasury contains little and my soldiers are getting impatient... ...therefore you must die. = 내 국고가 바닥나고 군사들은 동요하고 있네... 그러니 자네가 죽어줘야겠군.
+ # Requires translation!
+My treasury contains little and my soldiers are getting impatient... (sigh) ...therefore you must die. = 
 So brave, yet so stupid! If only you had a brain similar to your courage. = 참으로 용감하나, 참으로 멍청하구나! 그 용기만큼의 두뇌를 가졌더라면 좋았을 텐데.
 The gods have deprived Rome of their favour. We have been defeated. = 신들이 로마로부터 은총을 거두는구나. 우리가 정복당했다.
 I greet you. I am Augustus, Imperator and Pontifex Maximus of Rome. If you are a friend of Rome, you are welcome. = 그대에게 인사하지. 나는 로마의 황제이자 대제사장인 아우구스투스다. 그대를 로마의 친구로서 환영한다.
@@ -2761,6 +2760,7 @@ Paishiyauvada = 파이시야우바다
 Patigrbana = 파티그르바나
 Phrada = 프라다
 Persia = 페르시아
+during a Golden Age = 황금기 동안
 
 Kamehameha I = 카메하메하
 The ancient fire flashing across the sky is what proclaimed that this day would come, though I had foolishly hoped for a different outcome. = 나는 어리석게도 다른 결과를 바랬건만, 하늘에 빛나는 고대의 불빛들은 이 날이 올 것을 알려주었소.
@@ -2813,6 +2813,7 @@ Nuguria = 누구리아
 Pileni = 피레니
 Nukumanu = 누쿠마누
 Polynesia = 폴리네시아
+starting from the [era] = [era]부터
 Enables embarkation for land units = 지상 유닛이 승선할 수 있음
  # Requires translation!
 Enables [mapUnitFilter] units to enter ocean tiles = 
@@ -3288,6 +3289,7 @@ Legalism = 율법 정치
 Provides the cheapest [stat] building in your first [amount] cities for free = 최초 [amount]개 도시에 가장 저렴한 [stat] 건물 무료로 제공
 Oligarchy = 과두제
 Units in cities cost no Maintenance = 도시에 주둔한 유닛의 유지비 없음
+with a garrison = 유닛 주둔중
 [amount]% Strength for cities = 도시 전투력 [amount]%
 Landed Elite = 대지주
 [amount]% growth [cityFilter] = [cityFilter]의 성장률 [amount]%
@@ -3310,6 +3312,7 @@ Liberty =
 
 Warrior Code = 전사규범
 Discipline = 규율
+when adjacent to a [mapUnitFilter] unit = [mapUnitFilter] 유닛에 인접시
 Military Tradition = 군사 전통
 [amount]% XP gained from combat = 전투로 얻는 XP [amount]%
 Military Caste = 군사신분제
@@ -3317,6 +3320,7 @@ Professional Army = 직업 군대
 Honor Complete = 명예 완성
  # Requires translation!
 Honor = 
+vs [mapUnitFilter] units = [mapUnitFilter] 유닛 대항
 Notified of new Barbarian encampments = 야만인 주둔지 생성시 알림
 
 Organized Religion = 종교 체제
@@ -3329,6 +3333,7 @@ Free Religion = 종교적 관용
 Piety Complete = 신앙 완성
  # Requires translation!
 Piety = 
+before adopting [policy] = [policy] 채택 전
 
 Philantropy = 박애주의
 Gifts of Gold to City-States generate [amount]% more Influence = 도시 국가에 금을 선물하여 얻는 영향력 +[amount]%
@@ -3369,10 +3374,12 @@ Rationalism Complete = 합리주의 완성
 [amount] Free Technologies = 무료 기술 [amount]개 획득
  # Requires translation!
 Rationalism = 
+while the empire is happy = 행복 상태일 때
 [amount]% [stat] = [stat] [amount]%
 
 Constitution = 헌법
 Universal Suffrage = 보통선거제도
+when defending = 방어시
 Civil Society = 시민 사회
 [amount]% Food consumption by specialists [cityFilter] = [cityFilter]의 전문가가 소비하는 식량 [amount]%
 Free Speech = 표현의 자유
@@ -3391,6 +3398,7 @@ Quantity of strategic resources produced by the empire +[amount]% = 모든 전�
 Police State = 경찰국가
 Total War = 총력전
 Autocracy Complete = 독재 완성
+for [amount] turns = [amount] 턴 동안
  # Requires translation!
 Autocracy = 
 Upon capturing a city, receive [amount] times its [stat] production as [plunderableStat] immediately = 도시 점령시 도시가 생산하던 [stat]의 [amount]배에 해당하는 [plunderableStat] 획득
@@ -3416,28 +3424,28 @@ Clear Barbarian Camp = 야만인 주둔지 토벌
 We feel threatened by a Barbarian Camp near our city. Please take care of it. = 근처의 야만인 주둔지로 인해 위협받고 있소. 저 야만인 주둔지를 없애주시오.
 
 Connect Resource = 자원 연결
-In order to make our civilizations stronger, connect [param] to your trade network. = 우리 문명을 강성하게 하기 위해, 교역로로 [param] 자원을 연결해 주시오.
+In order to make our civilizations stronger, connect [tileResource] to your trade network. = 우리 문명을 강성하게 하기 위해, 교역로로 [tileResource] 자원을 연결해 주시오.
 
 Construct Wonder = 불가사의 건설
-We recommend you to start building [param] to show the whole world your civilization strength. = 당신 문명의 위엄을 전 세계에 보이기 위해 [param] 불가사의를 건설하는 것이 좋을 것 같소.
+We recommend you to start building [wonder] to show the whole world your civilization strength. = 당신 문명의 위엄을 전 세계에 보이기 위해 [wonder] 불가사의를 건설하는 것이 좋을 것 같소.
 
 Acquire Great Person = 위인 배출
-Great People can change the course of a Civilization! You will be rewarded for acquiring a new [param]. = 위인들은 문명의 흐름을 바꿀 수 있소! 새로운 [param]을 배출함으로써 보상 받을 것이오.
+Great People can change the course of a Civilization! You will be rewarded for acquiring a new [greatPerson]. = 위인들은 문명의 흐름을 바꿀 수 있소! 새로운 [greatPerson]을 배출함으로써 보상 받을 것이오.
 
 Conquer City State = 도시 국가 정벌
-It's time to erase the City-State of [param] from the map. You will be greatly rewarded for conquering them! = [param] 도시 국가를 지도에서 지워버릴 때가 왔습니다. 그들을 정벌하면 큰 보상이 있을 것입니다!
+It's time to erase the City-State of [cityState] from the map. You will be greatly rewarded for conquering them! = [cityState] 도시 국가를 지도에서 지워버릴 때가 왔습니다. 그들을 정벌하면 큰 보상이 있을 것입니다!
 
 Find Player = 다른 문명의 영토 발견하기
-You have yet to discover where [param] set up their cities. You will be rewarded for finding their territories. = 당신들은 [param]이 어디에 도시를 세웠는지를 찾지 못했소. 그들의 영토를 찾으면 보상을 받을 것이오.
+You have yet to discover where [civName] set up their cities. You will be rewarded for finding their territories. = 당신들은 [civName]이 어디에 도시를 세웠는지를 찾지 못했소. 그들의 영토를 찾으면 보상을 받을 것이오.
 
 Find Natural Wonder = 자연 불가사의 발견하기
-Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [param] yet. = 자연 불가사의를 찾기 위한 모험에 당신 문명의 최고의 탐험가를 보내시오. 아직 그 누구도 [param]의 위치를 알지 못하오.
+Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [naturalWonder] yet. = 자연 불가사의를 찾기 위한 모험에 당신 문명의 최고의 탐험가를 보내시오. 아직 그 누구도 [naturalWonder]의 위치를 알지 못하오.
 
 Give Gold = 원조 요청
-We are suffering great poverty after being robbed by [param], and unless we receive a sum of Gold, it's only a matter of time before we collapse. = 우리는 [param]의 약탈로 인한 가난에 시달리고 있습니다. 골드 지원이 없으면 파산하는 것은 시간문제입니다.
+We are suffering great poverty after being robbed by [civName], and unless we receive a sum of Gold, it's only a matter of time before we collapse. = 우리는 [civName]의 약탈로 인한 가난에 시달리고 있습니다. 골드 지원이 없으면 파산하는 것은 시간문제입니다.
 
 Pledge to Protect = 보호 요청
-We need your protection to stop the aggressions of [param]. By signing a Pledge of Protection, you'll confirm the bond that ties us. = [param]의 공세를 멈추기 위해 보호가 필요합니다. 보호 선언을 체결하면 서로 간의 유대를 확인할 수 있을 것입니다.
+We need your protection to stop the aggressions of [civName]. By signing a Pledge of Protection, you'll confirm the bond that ties us. = [civName]의 공세를 멈추기 위해 보호가 필요합니다. 보호 선언을 체결하면 서로 간의 유대를 확인할 수 있을 것입니다.
 
 Contest Culture = 문화 생성
 The civilization with the largest Culture growth will gain a reward. = 문화를 가장 많이 생성한 문명에게 보상이 주어질 것입니다.
@@ -3449,15 +3457,15 @@ Contest Technologies = 기술
 The civilization with the largest number of new Technologies researched will gain a reward. = 기술을 가장 많이 연구한 문명에게 보상이 주어질 것입니다.
 
 Invest = 투자 요청
-Our people are rejoicing thanks to a tourism boom. For a certain amount of time, any Gold donation will yield [amount]% extra Influence. = 우리 시민들이 관광 열풍으로 인해 크게 기뻐하고 있습니다. 일정 기간 동안 모든 골드 선물에 [amount]%의 영향력이 추가로 제공될 것입니다.
+Our people are rejoicing thanks to a tourism boom. For a certain amount of time, any Gold donation will yield [50]% extra Influence. = 우리 시민들이 관광 열풍으로 인해 크게 기뻐하고 있습니다. 일정 기간 동안 모든 골드 선물에 [50]%의 영향력이 추가로 제공될 것입니다.
 
 Bully City State = 도시 국가 괴롭히기
-We are tired of the pretensions of [param]. If someone were to put them in their place by Demanding Tribute from them, they would be rewarded. = [param]과의 신경전에 지쳤습니다. 누군가 그들에게 공물을 요구하여 주제를 파악하게 해준다면 보상이 주어질 것입니다.
+We are tired of the pretensions of [cityState]. If someone were to put them in their place by Demanding Tribute from them, they would be rewarded. = [cityState]과의 신경전에 지쳤습니다. 누군가 그들에게 공물을 요구하여 주제를 파악하게 해준다면 보상이 주어질 것입니다.
 
 Denounce Civilization = 다른 문명 비난하기
-We have been forced to pay tribute to [param]! We need you to tell the world of their ill deeds. = [param]에서 강제로 공물을 뜯어갔습니다! 그들의 만행을 전 세계에 알려주시기 바랍니다.
+We have been forced to pay tribute to [civName]! We need you to tell the world of their ill deeds. = [civName]에서 강제로 공물을 뜯어갔습니다! 그들의 만행을 전 세계에 알려주시기 바랍니다.
 
-We have heard the tenets of [param] and are most curious. Will you send missionaries to teach us about your religion? = [param]의 교리를 우리는 익히 들었고 매우 관심이 많습니다. 당신의 종교를 가르쳐줄 사절단을 파견해주시겠습니까?
+We have heard the tenets of [religionName] and are most curious. Will you send missionaries to teach us about your religion? = [religionName]의 교리를 우리는 익히 들었고 매우 관심이 많습니다. 당신의 종교를 가르쳐줄 사절단을 파견해주시겠습니까?
 
 
 #################### Lines from Ruins from Civ V - Vanilla ####################
@@ -3472,10 +3480,10 @@ squatters wishing to settle under your rule = 거주자들이 우리 문명에 �
 An ancient tribe trained us in their ways of combat! = 고대 부족으로부터 전투 훈련을 받았습니다!
 your exploring unit receives training = 유닛 XP 획득
 
-We have found survivors in the ruins! Population added to [param]. = 고대 유적의 생존자가 [param]에 정착하여 인구가 증가했습니다
+We have found survivors in the ruins! Population added to [cityName]. = 고대 유적의 생존자가 [cityName]에 정착하여 인구가 증가했습니다
 survivors (adds population to a city) = 생존자 (도시에 인구 추가)
 
-We have found a stash of [param] Gold in the ruins! = 고대 유적에서 [param] 골드를 얻었습니다!
+We have found a stash of [goldAmount] Gold in the ruins! = 고대 유적에서 [goldAmount] 골드를 얻었습니다!
 a stash of gold = 골드 발견
 
 discover a lost technology = 기술 발견
@@ -3694,6 +3702,7 @@ Tundra = 툰드라
 Desert = 사막
 
 Lakes = 호수
+Fresh water = 담수
 
 Mountain = 산
 Has an elevation of [amount] for visibility calculations = 시야 계산에서 높이 [amount]에 해당
@@ -3714,6 +3723,7 @@ A Camp can be built here without cutting it down = 벌목하지 않고도 야영
 Jungle = 정글
 
 Marsh = 습지
+Rare feature = 희귀지형
 Only Polders can be built here = 현재 타일에 간척지 시설만 건설 가능
 
 Fallout = 낙진
@@ -3909,10 +3919,13 @@ Porcelain = 도자기
 #################### Lines from UnitPromotions from Civ V - Vanilla ####################
 
 Sword = 근접 냉병기
+Mounted = 기마
+Siege = 공성
 Ranged Gunpowder = 원거리 화약
 Armored = 기갑
 Melee Water = 해상 근접
 Ranged Water = 해상 원거리
+Submarine = 잠수함
 Heal Instantly = 즉시 회복
 Heal this unit by [amount] HP = 유닛 [amount] HP 회복
 Doing so will consume this opportunity to choose a Promotion = 선택시 이번 승급 기회를 잃어버림
@@ -3971,6 +3984,7 @@ Medic = 의무병 I
 All adjacent units heal [amount] HP when healing = 인접한 유닛이 회복시 추가로 [amount] HP 회복
 
 Medic II = 의무병 II
+in [tileFilter] tiles = [tileFilter] 타일
 [amount] HP when healing = 회복시 추가로 [amount] HP 회복
 
 Scouting I = 정찰 I
@@ -4031,6 +4045,7 @@ Flight Deck III = 비행 갑판 III
 Supply = 보급
 May heal outside of friendly territory = 우호 지역 밖에서 회복 가능
 
+Bomber = 폭격기
 Siege I = 공성 I
 
 Siege II = 공성 II
@@ -4040,6 +4055,7 @@ Siege III = 공성 III
 Evasion = 회피
 Damage taken from interception reduced by [amount]% = 요격당할 때 피해 -[amount]%
 
+Fighter = 전투기
 Interception I = 요격 I
 [amount]% Damage when intercepting = 요격할 때 피해 [amount]%
 
@@ -4137,10 +4153,29 @@ Can see over obstacles =
 
 Atomic Bomber = 원자 폭탄
 
+Missile = 미사일
 Self-destructs when attacking = 공격시 자폭함
 Cannot be intercepted = 요격되지 않음
 
 Can pass through impassable tiles = 통행 불가 지형에 출입 가능
+
+Melee = 근접
+
+Ranged = 원거리
+
+Armor = 중갑
+
+WaterCivilian = 해상 민간
+
+WaterMelee = 해상 근접
+
+WaterRanged = 해상 원거리
+
+WaterSubmarine = 수중
+
+WaterAircraftCarrier = 항공모함
+
+AtomicBomber = 핵무기
 
 
 #################### Lines from Units from Civ V - Vanilla ####################
@@ -4218,6 +4253,7 @@ Knight = 기사
 Camel Archer = 낙타궁병
 
 Conquistador = 콩키스타도르
+on foreign continents = 본토가 아닌 다른 대륙에서
 
 Naresuan's Elephant = 나레수안 코끼리
 
@@ -4308,6 +4344,8 @@ Anti-Tank Gun = 대전차포
 
 Atomic Bomb = 원자폭탄
 Nuclear weapon of Strength [amount] = 핵무기 위력 [amount]
+ # Requires translation!
+if [buildingName] is constructed = 
 Blast radius [amount] = 폭발 반경 [amount]타일
 
 Rocket Artillery = 다연장 로켓포
@@ -4342,6 +4380,7 @@ Great Artist = 위대한 예술가
 Can start an [amount]-turn golden age = [amount]턴의 황금기 시작 가능
 Can construct [improvementName] = [improvementName] 건설 가능
 Great Person - [stat] = [stat] 위인
+Unbuildable = 도시에서 직접 생산 불가
 
 Great Scientist = 위대한 과학자
 Can hurry technology research = 연구 가속 가능
@@ -4401,6 +4440,8 @@ Faith Healers = 신앙 치료사
 Fertility Rites = 풍년 기원제
 
 God of Craftsman = 장인의 신
+ # Requires translation!
+in cities with at least [amount] [populationFilter] = 
 
 God of the Open Sky = 창공의 신
 
@@ -4452,6 +4493,7 @@ Feed the World = 기아 대책
 Guruship = 구루
 
 Holy Warriors = 성전사
+before the [era] = [era] 전까지
 May buy [baseUnitFilter] units with [stat] for [amount] times their normal Production cost = 필요 생산력의 [amount]배에 해당하는 [stat](으)로 [baseUnitFilter] 구매 가능
 
 Liturgical Drama = 전례극
@@ -4472,6 +4514,7 @@ Religious Community = 종교 공동체
 [amount]% [stat] from every follower, up to [amount2]% = 신도 하나당 [stat] [amount]%, 최대 [amount2]%
 
 Swords into Ploughshares = 칼을 쟁기로
+when not at war = 전쟁이 없을 때
 
 Founder = 창시자
 Ceremonial Burial = 매장 의식
@@ -4604,9 +4647,6 @@ Starting in this era disables religion = 이 시대에서 시작하면 종교가
 
 
 Marine = 해병대
-
-
-#################### Lines from GlobalUniques from Civ V - Gods & Kings ####################
 
 
 #################### Lines from Nations from Civ V - Gods & Kings ####################
@@ -4931,6 +4971,7 @@ Llanfairpwllgwyngyll = 랜바이어푸흘귄기흘
 Falmouth = 팔머스
 Lorient = 로리앙
 Celts = 켈트
+with [amount] to [amount2] neighboring [tileFilter] [tileFilter2] tiles = 인접한 [tileFilter] [tileFilter2] 타일이 [amount]~[amount2]개 있는
 
 Haile Selassie = 하일레 셀라시에
 I have tried all other avenues, but yet you persist in this madness. I hope, for your sake, your end is swift. = 대안을 두루 찾아보았지만, 당신은 미친 소리만 계속하시는군요. 이렇게 된 이상 당신을 빨리 없애는 게 모두를 위하는 길입니다.
@@ -4975,6 +5016,7 @@ Gambela = 감벨라
 Ziway = 지웨이
 Weldiya = 웰디아
 Ethiopia = 에티오피아
+when fighting units from a Civilization with more Cities than you = 자신보다 도시를 많이 가진 문명과 전투시
 
 Pacal = 파칼
 A sacrifice unlike all others must be made! = 다른 문명과는 다른 제물을 바쳐야만 해!
@@ -5062,10 +5104,10 @@ Taoism = 도교
 #################### Lines from Ruins from Civ V - Gods & Kings ####################
 
 
-We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[param] Faith) = 고대 유적에서 성물을 발견하여 종교에 대한 이해가 깊어졌습니다! (+[param] 신앙)
+We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[faithAmount] Faith) = 고대 유적에서 성물을 발견하여 종교에 대한 이해가 깊어졌습니다! (+[faithAmount] 신앙)
 discover holy symbols = 성물 발견
 
-We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[param] Faith) = 고대 유적에서 예언자를 발견하여 우리의 정신적인 유대가 강해졌습니다! (+[param] 신앙)
+We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[faithAmount] Faith) = 고대 유적에서 예언자를 발견하여 우리의 정신적인 유대가 강해졌습니다! (+[faithAmount] 신앙)
 an ancient prophecy = 고대 예언자
 
 
@@ -5123,7 +5165,15 @@ Polder = 간척지
 #################### Lines from TileResources from Civ V - Gods & Kings ####################
 
 
+Citrus = 감귤
+
+Copper = 구리
+
+Crab = 게
+
 Salt = 소금
+
+Truffles = 송로버섯
 
 
 #################### Lines from UnitPromotions from Civ V - Gods & Kings ####################
@@ -5460,49 +5510,23 @@ No Sight =
  # Requires translation!
 Irremovable = 
 when at war = 전쟁 중에
-when not at war = 전쟁이 없을 때
-during a Golden Age = 황금기 동안
  # Requires translation!
 with [resource] = 
-while the empire is happy = 행복 상태일 때
 when between [amount] and [amount2] Happiness = 행복도 [amount] ~ [amount2] 사이일 때
 when below [amount] Happiness = 행복도 [amount] 이하일 때
 during the [era] = [era] 동안
-before the [era] = [era] 전까지
-starting from the [era] = [era]부터
 if no other Civilization has researched this = 이 기술을 연구한 다른 문명이 없을 때
-after discovering [tech] = [tech] 연구 후
-before discovering [tech] = [tech] 연구 전
  # Requires translation!
 upon discovering [tech] = 
 after adopting [policy] = [policy] 채택 후
-before adopting [policy] = [policy] 채택 전
- # Requires translation!
-if [buildingName] is constructed = 
-for [amount] turns = [amount] 턴 동안
  # Requires translation!
 by consuming this unit = 
 in cities with a [buildingFilter] = [buildingFilter]이(가) 건설된 도시
-in cities without a [buildingFilter] = [buildingFilter]이(가) 건설되지 않은 도시
- # Requires translation!
-in cities with at least [amount] [populationFilter] = 
-with a garrison = 유닛 주둔중
-for [mapUnitFilter] units = [mapUnitFilter] 유닛에
 for units with [promotion] = [promotion] 승급이 있는 유닛에
 for units without [promotion] = [promotion] 승급이 없는 유닛에
-vs cities = 도시 대항
-vs [mapUnitFilter] units = [mapUnitFilter] 유닛 대항
-when fighting units from a Civilization with more Cities than you = 자신보다 도시를 많이 가진 문명과 전투시
-when attacking = 공격시
-when defending = 방어시
-when fighting in [tileFilter] tiles = [tileFilter] 
-on foreign continents = 본토가 아닌 다른 대륙에서
-when adjacent to a [mapUnitFilter] unit = [mapUnitFilter] 유닛에 인접시
 when above [amount] HP = [amount] HP 이상일 때
 when below [amount] HP = [amount] HP 이하일 때
 with [amount] to [amount2] neighboring [tileFilter] tiles = 인접한 [tileFilter] 타일이 [amount]~[amount2]개 있는
-with [amount] to [amount2] neighboring [tileFilter] [tileFilter2] tiles = 인접한 [tileFilter] [tileFilter2] 타일이 [amount]~[amount2]개 있는
-in [tileFilter] tiles = [tileFilter] 타일
 in [tileFilter] [tileFilter2] tiles = [tileFilter] [tileFilter2] 타일
 in tiles without [tileFilter] = [tileFilter]이 없는 타일
  # Requires translation!
@@ -5547,3 +5571,12 @@ CityState = 도시 국가
 ModOptions = 모드 설정
  # Requires translation!
 Conditional = 
+
+#################### Removed Lines ####################
+
+#~~Rough Terrain = 험지
+#~~Strategic = 전략 자원
+#~~Bonus = 보너스 자원
+#~~Luxury = 사치 자원
+#~~military water = 해상 군사
+#~~My treasury contains little and my soldiers are getting impatient... ...therefore you must die. = 내 국고가 바닥나고 군사들은 동요하고 있네... 그러니 자네가 죽어줘야겠군.

--- a/android/assets/jsons/translations/Lithuanian.properties
+++ b/android/assets/jsons/translations/Lithuanian.properties
@@ -1413,9 +1413,6 @@ or [terrainType] =
 Can be constructed by = 
 Defence bonus = Gynybos premija
 Movement cost = Judėjimo kaina
- # Requires translation!
-Open terrain = 
-Rough Terrain = Grubus reljefas
 for = dėl
 Missing translations: = Trūksta vertimų:
 Resolution = Rezoliucija
@@ -1625,147 +1622,6 @@ Enhancing religion =
  # Requires translation!
 Enhanced religion = 
 
-# Terrains
-
-Impassable = Neįveikiama 
- # Requires translation!
-Rare feature = 
-
-# terrainFilters (so for uniques like: "[stats] from [terrainFilter] tiles")
-
- # Requires translation!
-All = 
- # Requires translation!
-Water = 
-Land = Pasėlių derlius
- # Requires translation!
-Coastal = 
- # Requires translation!
-River = 
- # Requires translation!
-Rough terrain = 
-Foreign Land = Svetima žemė
- # Requires translation!
-Foreign = 
- # Requires translation!
-Friendly Land = 
- # Requires translation!
-Water resource = 
- # Requires translation!
-Bonus resource = 
- # Requires translation!
-Luxury resource = 
- # Requires translation!
-Strategic resource = 
- # Requires translation!
-Fresh water = 
- # Requires translation!
-non-fresh water = 
- # Requires translation!
-Natural Wonder = 
- # Requires translation!
-Hybrid = 
- # Requires translation!
-Undesirable = 
- # Requires translation!
-Desirable = 
- # Requires translation!
-Featureless = 
- # Requires translation!
-Fresh Water = 
-
-# improvementFilters
-
- # Requires translation!
-All Road = 
- # Requires translation!
-Great Improvement = 
- # Requires translation!
-Great = 
-
-# Resources
-
-Bison = Bizonas
-Copper = Varis
-Cocoa = Kakava
-Crab = Krabas
-Citrus = Citrusiniai
-Truffles = Triufeliai
- # Requires translation!
-Strategic = 
- # Requires translation!
-Bonus = 
- # Requires translation!
-Luxury = 
-
-# Unit types
-
-City = Miestas
-Civilian = Civilis
-Melee = Melee
-Ranged = Svyravo
- # Requires translation!
-Scout = 
-Mounted = Pakabinta
-Armor = Šarvai
- # Requires translation!
-Siege = 
-
-WaterCivilian = WaterCivilian
-WaterMelee = WaterMelee
-WaterRanged = Vandeniu
-WaterSubmarine = WaterSubmarine
-WaterAircraftCarrier = Vandens lėktuvas
-
- # Requires translation!
-Fighter = 
- # Requires translation!
-Bomber = 
- # Requires translation!
-AtomicBomber = 
-Missile = Raketa
-
-
-# Unit filters and other unit related things
-
- # Requires translation!
-Air = 
-air units = oro vienetai
- # Requires translation!
-Barbarian = 
- # Requires translation!
-Barbarians = 
- # Requires translation!
-Embarked = 
-land units = žemės vienetų
- # Requires translation!
-Military = 
-# Deprecated since 3.15.2, but should still be translated until it is officially removed
- # Requires translation!
-military water = 
- # Requires translation!
-non-air = 
- # Requires translation!
-Nuclear Weapon = 
- # Requires translation!
-Submarine = 
- # Requires translation!
-submarine units = 
-Unbuildable = Neatnaujinamas
-water units = vandens vienetai
-wounded units = sužeistų vienetų
- # Requires translation!
-Wounded = 
-
-# For the "All newly-trained [relevant] units in this city receive the [] promotion" translation. Relevant as in 'units that can receive'
- # Requires translation!
-relevant = 
-
-# For "May choose [amount] additional [beliefType] beliefs when [founding/enhancing] a religion"
- # Requires translation!
-founding = 
- # Requires translation!
-enhancing = 
 
 # Promotions
 
@@ -1773,6 +1629,7 @@ Pick promotion = Pasirinkite reklama
  OR  = ARBA
 units in open terrain = vienetai atviroje vietovėje
 units in rough terrain = vienetai nelygiame reljefe
+wounded units = sužeistų vienetų
 Targeting II (air) = Taikymas II (air)
 Targeting III (air) = Taikymas III (air)
 Bonus when performing air sweep [bonusAmount]% = Premija atliekant oro valymą [bonusAmount]%
@@ -1934,6 +1791,11 @@ Never destroyed when the city is captured =
  # Requires translation!
 Invisible to others = 
 
+# Unused Resources
+
+Bison = Bizonas
+Cocoa = Kakava
+
 
 # In English we just paste all these conditionals at the end of each unique, but in your language that
 # may not turn into valid sentences. Therefore we have the following two translations to determine
@@ -1963,6 +1825,43 @@ ConditionalsPlacement =
 
 ########################### AUTOMATICALLY GENERATED TRANSLATABLE STRINGS ########################### 
 
+
+######### Map Unit Filters ###########
+
+ # Requires translation!
+Wounded = 
+ # Requires translation!
+Barbarians = 
+ # Requires translation!
+City-State = 
+ # Requires translation!
+Embarked = 
+ # Requires translation!
+Non-City = 
+
+######### Unit Type Filters ###########
+
+ # Requires translation!
+Military = 
+Civilian = Civilis
+ # Requires translation!
+non-air = 
+ # Requires translation!
+relevant = 
+ # Requires translation!
+Nuclear Weapon = 
+City = Miestas
+ # Requires translation!
+Air = 
+land units = žemės vienetų
+water units = vandens vienetai
+air units = oro vienetai
+ # Requires translation!
+military units = 
+ # Requires translation!
+submarine units = 
+ # Requires translation!
+Barbarian = 
 
 ######### City filters ###########
 
@@ -1998,6 +1897,88 @@ in holy cities =
 in City-State cities = 
  # Requires translation!
 in cities following this religion = 
+
+######### Population Filters ###########
+
+ # Requires translation!
+Unemployed = 
+ # Requires translation!
+Followers of the Majority Religion = 
+ # Requires translation!
+Followers of this Religion = 
+
+######### Terrain Filters ###########
+
+ # Requires translation!
+All = 
+ # Requires translation!
+Coastal = 
+ # Requires translation!
+River = 
+ # Requires translation!
+Open terrain = 
+ # Requires translation!
+Rough terrain = 
+ # Requires translation!
+Water resource = 
+Foreign Land = Svetima žemė
+ # Requires translation!
+Foreign = 
+ # Requires translation!
+Friendly Land = 
+ # Requires translation!
+Enemy Land = 
+ # Requires translation!
+Featureless = 
+ # Requires translation!
+Fresh Water = 
+ # Requires translation!
+non-fresh water = 
+ # Requires translation!
+Natural Wonder = 
+Impassable = Neįveikiama 
+Land = Pasėlių derlius
+ # Requires translation!
+Water = 
+ # Requires translation!
+Luxury resource = 
+ # Requires translation!
+Strategic resource = 
+ # Requires translation!
+Bonus resource = 
+
+######### Tile Filters ###########
+
+ # Requires translation!
+unimproved = 
+ # Requires translation!
+All Road = 
+ # Requires translation!
+Great Improvement = 
+
+######### Region Types ###########
+
+ # Requires translation!
+Hybrid = 
+
+######### Terrain Quality ###########
+
+ # Requires translation!
+Undesirable = 
+ # Requires translation!
+Desirable = 
+
+######### Improvement Filters ###########
+
+ # Requires translation!
+Great = 
+
+######### Prophet Action Filters ###########
+
+ # Requires translation!
+founding = 
+ # Requires translation!
+enhancing = 
 
 ######### Unique Specials ###########
 
@@ -2038,6 +2019,8 @@ Temple of Artemis =
 The Great Lighthouse = 
  # Requires translation!
 'They that go down to the sea in ships, that do business in great waters; these see the works of the Lord, and his wonders in the deep.' - The Bible, Psalms 107:23-24 = 
+ # Requires translation!
+for [mapUnitFilter] units = 
  # Requires translation!
 [amount] Movement = 
  # Requires translation!
@@ -2115,6 +2098,10 @@ Krepost =
 Statue of Zeus = 
  # Requires translation!
 'He spoke, the son of Kronos, and nodded his head with the dark brows, and the immortally anointed hair of the great god swept from his divine head, and all Olympos was shaken' - The Iliad = 
+ # Requires translation!
+vs cities = 
+ # Requires translation!
+when attacking = 
  # Requires translation!
 [amount]% Strength = 
 
@@ -2272,12 +2259,16 @@ Castle =
  # Requires translation!
 Mughal Fort = 
  # Requires translation!
+after discovering [tech] = 
+ # Requires translation!
 [stats] [cityFilter] = 
 
  # Requires translation!
 Himeji Castle = 
  # Requires translation!
 'Bushido is realized in the presence of death. This means choosing death whenever there is a choice between life and death. There is no other reasoning.' - Yamamoto Tsunetomo = 
+ # Requires translation!
+when fighting in [tileFilter] tiles = 
 
  # Requires translation!
 Ironworks = 
@@ -2443,6 +2434,8 @@ Pentagon =
  # Requires translation!
 Solar Plant = 
  # Requires translation!
+in cities without a [buildingFilter] = 
+ # Requires translation!
 Only available = 
 
  # Requires translation!
@@ -2494,6 +2487,8 @@ Era Starting Unit =
 
  # Requires translation!
 Emperor = 
+ # Requires translation!
+Scout = 
 
  # Requires translation!
 Immortal = 
@@ -2544,9 +2539,6 @@ Information era =
 
  # Requires translation!
 Future era = 
-
-
-#################### Lines from GlobalUniques from Civ V - Vanilla ####################
 
 
 #################### Lines from Nations from Civ V - Vanilla ####################
@@ -3201,6 +3193,8 @@ Bourges =
 Calais = 
  # Requires translation!
 France = 
+ # Requires translation!
+before discovering [tech] = 
 
  # Requires translation!
 Catherine = 
@@ -3288,7 +3282,7 @@ Double quantity of [resource] produced =
  # Requires translation!
 Augustus Caesar = 
  # Requires translation!
-My treasury contains little and my soldiers are getting impatient... ...therefore you must die. = 
+My treasury contains little and my soldiers are getting impatient... (sigh) ...therefore you must die. = 
  # Requires translation!
 So brave, yet so stupid! If only you had a brain similar to your courage. = 
  # Requires translation!
@@ -4333,6 +4327,8 @@ Patigrbana =
 Phrada = 
  # Requires translation!
 Persia = 
+ # Requires translation!
+during a Golden Age = 
 
  # Requires translation!
 Kamehameha I = 
@@ -4435,6 +4431,8 @@ Pileni =
 Nukumanu = 
  # Requires translation!
 Polynesia = 
+ # Requires translation!
+starting from the [era] = 
  # Requires translation!
 Enables embarkation for land units = 
  # Requires translation!
@@ -5337,6 +5335,8 @@ Oligarchy =
  # Requires translation!
 Units in cities cost no Maintenance = 
  # Requires translation!
+with a garrison = 
+ # Requires translation!
 [amount]% Strength for cities = 
  # Requires translation!
 Landed Elite = 
@@ -5375,6 +5375,8 @@ Warrior Code =
  # Requires translation!
 Discipline = 
  # Requires translation!
+when adjacent to a [mapUnitFilter] unit = 
+ # Requires translation!
 Military Tradition = 
  # Requires translation!
 [amount]% XP gained from combat = 
@@ -5386,6 +5388,8 @@ Professional Army =
 Honor Complete = 
  # Requires translation!
 Honor = 
+ # Requires translation!
+vs [mapUnitFilter] units = 
  # Requires translation!
 Notified of new Barbarian encampments = 
 
@@ -5407,6 +5411,8 @@ Free Religion =
 Piety Complete = 
  # Requires translation!
 Piety = 
+ # Requires translation!
+before adopting [policy] = 
 
  # Requires translation!
 Philantropy = 
@@ -5479,12 +5485,16 @@ Rationalism Complete =
  # Requires translation!
 Rationalism = 
  # Requires translation!
+while the empire is happy = 
+ # Requires translation!
 [amount]% [stat] = 
 
  # Requires translation!
 Constitution = 
  # Requires translation!
 Universal Suffrage = 
+ # Requires translation!
+when defending = 
  # Requires translation!
 Civil Society = 
  # Requires translation!
@@ -5518,6 +5528,8 @@ Police State =
 Total War = 
  # Requires translation!
 Autocracy Complete = 
+ # Requires translation!
+for [amount] turns = 
  # Requires translation!
 Autocracy = 
  # Requires translation!
@@ -5558,42 +5570,42 @@ We feel threatened by a Barbarian Camp near our city. Please take care of it. =
  # Requires translation!
 Connect Resource = 
  # Requires translation!
-In order to make our civilizations stronger, connect [param] to your trade network. = 
+In order to make our civilizations stronger, connect [tileResource] to your trade network. = 
 
  # Requires translation!
 Construct Wonder = 
  # Requires translation!
-We recommend you to start building [param] to show the whole world your civilization strength. = 
+We recommend you to start building [wonder] to show the whole world your civilization strength. = 
 
  # Requires translation!
 Acquire Great Person = 
  # Requires translation!
-Great People can change the course of a Civilization! You will be rewarded for acquiring a new [param]. = 
+Great People can change the course of a Civilization! You will be rewarded for acquiring a new [greatPerson]. = 
 
  # Requires translation!
 Conquer City State = 
  # Requires translation!
-It's time to erase the City-State of [param] from the map. You will be greatly rewarded for conquering them! = 
+It's time to erase the City-State of [cityState] from the map. You will be greatly rewarded for conquering them! = 
 
  # Requires translation!
 Find Player = 
  # Requires translation!
-You have yet to discover where [param] set up their cities. You will be rewarded for finding their territories. = 
+You have yet to discover where [civName] set up their cities. You will be rewarded for finding their territories. = 
 
  # Requires translation!
 Find Natural Wonder = 
  # Requires translation!
-Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [param] yet. = 
+Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [naturalWonder] yet. = 
 
  # Requires translation!
 Give Gold = 
  # Requires translation!
-We are suffering great poverty after being robbed by [param], and unless we receive a sum of Gold, it's only a matter of time before we collapse. = 
+We are suffering great poverty after being robbed by [civName], and unless we receive a sum of Gold, it's only a matter of time before we collapse. = 
 
  # Requires translation!
 Pledge to Protect = 
  # Requires translation!
-We need your protection to stop the aggressions of [param]. By signing a Pledge of Protection, you'll confirm the bond that ties us. = 
+We need your protection to stop the aggressions of [civName]. By signing a Pledge of Protection, you'll confirm the bond that ties us. = 
 
  # Requires translation!
 Contest Culture = 
@@ -5613,20 +5625,20 @@ The civilization with the largest number of new Technologies researched will gai
  # Requires translation!
 Invest = 
  # Requires translation!
-Our people are rejoicing thanks to a tourism boom. For a certain amount of time, any Gold donation will yield [amount]% extra Influence. = 
+Our people are rejoicing thanks to a tourism boom. For a certain amount of time, any Gold donation will yield [50]% extra Influence. = 
 
  # Requires translation!
 Bully City State = 
  # Requires translation!
-We are tired of the pretensions of [param]. If someone were to put them in their place by Demanding Tribute from them, they would be rewarded. = 
+We are tired of the pretensions of [cityState]. If someone were to put them in their place by Demanding Tribute from them, they would be rewarded. = 
 
  # Requires translation!
 Denounce Civilization = 
  # Requires translation!
-We have been forced to pay tribute to [param]! We need you to tell the world of their ill deeds. = 
+We have been forced to pay tribute to [civName]! We need you to tell the world of their ill deeds. = 
 
  # Requires translation!
-We have heard the tenets of [param] and are most curious. Will you send missionaries to teach us about your religion? = 
+We have heard the tenets of [religionName] and are most curious. Will you send missionaries to teach us about your religion? = 
 
 
 #################### Lines from Ruins from Civ V - Vanilla ####################
@@ -5648,12 +5660,12 @@ An ancient tribe trained us in their ways of combat! =
 your exploring unit receives training = 
 
  # Requires translation!
-We have found survivors in the ruins! Population added to [param]. = 
+We have found survivors in the ruins! Population added to [cityName]. = 
  # Requires translation!
 survivors (adds population to a city) = 
 
  # Requires translation!
-We have found a stash of [param] Gold in the ruins! = 
+We have found a stash of [goldAmount] Gold in the ruins! = 
  # Requires translation!
 a stash of gold = 
 
@@ -6048,6 +6060,8 @@ Desert =
 
  # Requires translation!
 Lakes = 
+ # Requires translation!
+Fresh water = 
 
  # Requires translation!
 Mountain = 
@@ -6080,6 +6094,8 @@ Jungle =
 
  # Requires translation!
 Marsh = 
+ # Requires translation!
+Rare feature = 
  # Requires translation!
 Only Polders can be built here = 
 
@@ -6380,6 +6396,9 @@ Porcelain =
 
  # Requires translation!
 Sword = 
+Mounted = Pakabinta
+ # Requires translation!
+Siege = 
  # Requires translation!
 Ranged Gunpowder = 
  # Requires translation!
@@ -6388,6 +6407,8 @@ Armored =
 Melee Water = 
  # Requires translation!
 Ranged Water = 
+ # Requires translation!
+Submarine = 
  # Requires translation!
 Heal Instantly = 
  # Requires translation!
@@ -6480,6 +6501,8 @@ All adjacent units heal [amount] HP when healing =
 
  # Requires translation!
 Medic II = 
+ # Requires translation!
+in [tileFilter] tiles = 
  # Requires translation!
 [amount] HP when healing = 
 
@@ -6574,6 +6597,8 @@ Supply =
 May heal outside of friendly territory = 
 
  # Requires translation!
+Bomber = 
+ # Requires translation!
 Siege I = 
 
  # Requires translation!
@@ -6587,6 +6612,8 @@ Evasion =
  # Requires translation!
 Damage taken from interception reduced by [amount]% = 
 
+ # Requires translation!
+Fighter = 
  # Requires translation!
 Interception I = 
  # Requires translation!
@@ -6731,6 +6758,7 @@ Can see over obstacles =
  # Requires translation!
 Atomic Bomber = 
 
+Missile = Raketa
  # Requires translation!
 Self-destructs when attacking = 
  # Requires translation!
@@ -6738,6 +6766,25 @@ Cannot be intercepted =
 
  # Requires translation!
 Can pass through impassable tiles = 
+
+Melee = Melee
+
+Ranged = Svyravo
+
+Armor = Šarvai
+
+WaterCivilian = WaterCivilian
+
+WaterMelee = WaterMelee
+
+WaterRanged = Vandeniu
+
+WaterSubmarine = WaterSubmarine
+
+WaterAircraftCarrier = Vandens lėktuvas
+
+ # Requires translation!
+AtomicBomber = 
 
 
 #################### Lines from Units from Civ V - Vanilla ####################
@@ -6856,6 +6903,8 @@ Camel Archer =
 
  # Requires translation!
 Conquistador = 
+ # Requires translation!
+on foreign continents = 
 
  # Requires translation!
 Naresuan's Elephant = 
@@ -6990,6 +7039,8 @@ Atomic Bomb = Atominė bomba
  # Requires translation!
 Nuclear weapon of Strength [amount] = 
  # Requires translation!
+if [buildingName] is constructed = 
+ # Requires translation!
 Blast radius [amount] = 
 
  # Requires translation!
@@ -7042,6 +7093,7 @@ Can start an [amount]-turn golden age =
 Can construct [improvementName] = 
  # Requires translation!
 Great Person - [stat] = 
+Unbuildable = Neatnaujinamas
 
  # Requires translation!
 Great Scientist = 
@@ -7137,6 +7189,8 @@ Fertility Rites =
 
  # Requires translation!
 God of Craftsman = 
+ # Requires translation!
+in cities with at least [amount] [populationFilter] = 
 
  # Requires translation!
 God of the Open Sky = 
@@ -7217,6 +7271,8 @@ Guruship =
  # Requires translation!
 Holy Warriors = 
  # Requires translation!
+before the [era] = 
+ # Requires translation!
 May buy [baseUnitFilter] units with [stat] for [amount] times their normal Production cost = 
 
  # Requires translation!
@@ -7247,6 +7303,8 @@ Religious Community =
 
  # Requires translation!
 Swords into Ploughshares = 
+ # Requires translation!
+when not at war = 
 
  # Requires translation!
 Founder = 
@@ -7444,9 +7502,6 @@ Starting in this era disables religion =
 
 
 Marine = Jūrų
-
-
-#################### Lines from GlobalUniques from Civ V - Gods & Kings ####################
 
 
 #################### Lines from Nations from Civ V - Gods & Kings ####################
@@ -8070,6 +8125,8 @@ Falmouth =
 Lorient = 
  # Requires translation!
 Celts = 
+ # Requires translation!
+with [amount] to [amount2] neighboring [tileFilter] [tileFilter2] tiles = 
 
  # Requires translation!
 Haile Selassie = 
@@ -8157,6 +8214,8 @@ Ziway =
 Weldiya = 
  # Requires translation!
 Ethiopia = 
+ # Requires translation!
+when fighting units from a Civilization with more Cities than you = 
 
  # Requires translation!
 Pacal = 
@@ -8304,12 +8363,12 @@ Taoism =
 
 
  # Requires translation!
-We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[param] Faith) = 
+We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[faithAmount] Faith) = 
  # Requires translation!
 discover holy symbols = 
 
  # Requires translation!
-We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[param] Faith) = 
+We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[faithAmount] Faith) = 
  # Requires translation!
 an ancient prophecy = 
 
@@ -8389,8 +8448,16 @@ Polder =
 #################### Lines from TileResources from Civ V - Gods & Kings ####################
 
 
+Citrus = Citrusiniai
+
+Copper = Varis
+
+Crab = Krabas
+
  # Requires translation!
 Salt = 
+
+Truffles = Triufeliai
 
 
 #################### Lines from UnitPromotions from Civ V - Gods & Kings ####################
@@ -8930,13 +8997,7 @@ Irremovable =
  # Requires translation!
 when at war = 
  # Requires translation!
-when not at war = 
- # Requires translation!
-during a Golden Age = 
- # Requires translation!
 with [resource] = 
- # Requires translation!
-while the empire is happy = 
  # Requires translation!
 when between [amount] and [amount2] Happiness = 
  # Requires translation!
@@ -8944,67 +9005,25 @@ when below [amount] Happiness =
  # Requires translation!
 during the [era] = 
  # Requires translation!
-before the [era] = 
- # Requires translation!
-starting from the [era] = 
- # Requires translation!
 if no other Civilization has researched this = 
- # Requires translation!
-after discovering [tech] = 
- # Requires translation!
-before discovering [tech] = 
  # Requires translation!
 upon discovering [tech] = 
  # Requires translation!
 after adopting [policy] = 
  # Requires translation!
-before adopting [policy] = 
- # Requires translation!
-if [buildingName] is constructed = 
- # Requires translation!
-for [amount] turns = 
- # Requires translation!
 by consuming this unit = 
  # Requires translation!
 in cities with a [buildingFilter] = 
  # Requires translation!
-in cities without a [buildingFilter] = 
- # Requires translation!
-in cities with at least [amount] [populationFilter] = 
- # Requires translation!
-with a garrison = 
- # Requires translation!
-for [mapUnitFilter] units = 
- # Requires translation!
 for units with [promotion] = 
  # Requires translation!
 for units without [promotion] = 
- # Requires translation!
-vs cities = 
- # Requires translation!
-vs [mapUnitFilter] units = 
- # Requires translation!
-when fighting units from a Civilization with more Cities than you = 
- # Requires translation!
-when attacking = 
- # Requires translation!
-when defending = 
- # Requires translation!
-when fighting in [tileFilter] tiles = 
- # Requires translation!
-on foreign continents = 
- # Requires translation!
-when adjacent to a [mapUnitFilter] unit = 
  # Requires translation!
 when above [amount] HP = 
  # Requires translation!
 when below [amount] HP = 
  # Requires translation!
 with [amount] to [amount2] neighboring [tileFilter] tiles = 
- # Requires translation!
-with [amount] to [amount2] neighboring [tileFilter] [tileFilter2] tiles = 
- # Requires translation!
-in [tileFilter] tiles = 
  # Requires translation!
 in [tileFilter] [tileFilter2] tiles = 
  # Requires translation!
@@ -9083,3 +9102,7 @@ CityState =
 ModOptions = 
  # Requires translation!
 Conditional = 
+
+#################### Removed Lines ####################
+
+#~~Rough Terrain = Grubus reljefas

--- a/android/assets/jsons/translations/Malay.properties
+++ b/android/assets/jsons/translations/Malay.properties
@@ -1274,8 +1274,6 @@ or [terrainType] = atau [terrainType]
 Can be constructed by = Boleh dibina oleh
 Defence bonus = Bonus pertahanan
 Movement cost = Kos pergerakan
-Open terrain = Medan terbuka
-Rough Terrain = Medan kasar
 for = untuk
 Missing translations: = Terjemahan hilang:
 Resolution = Resolusi
@@ -1436,109 +1434,6 @@ Enhancing religion =
  # Requires translation!
 Enhanced religion = 
 
-# Terrains
-
-Impassable = Tidak dapat dilalui
-Rare feature = Ciri jarang
-
-# terrainFilters (so for uniques like: "[stats] from [terrainFilter] tiles")
-
-All = Semua
-Water = Air
-Land = Tanah
-Coastal = Pantai
-River = Sungai
-Rough terrain = Medan kasar
-Foreign Land = Tanah Asing
-Foreign = Asing
-Friendly Land = Tanah Sahabat
-Water resource = Sumber air
-Bonus resource = Sumber bonus
-Luxury resource = Sumber mewah
-Strategic resource = Sumber strategik
-Fresh water = Air tawar
-non-fresh water = Air tidak tawar
-Natural Wonder = Keajaiban Semula Jadi
- # Requires translation!
-Hybrid = 
- # Requires translation!
-Undesirable = 
- # Requires translation!
-Desirable = 
- # Requires translation!
-Featureless = 
- # Requires translation!
-Fresh Water = 
-
-# improvementFilters
-
-All Road = Semua Jalan
-Great Improvement = Peningkatan Hebat
-Great = Hebat
-
-# Resources
-
-Bison = Bison
-Copper = Tembaga
-Cocoa = Koko
-Crab = Ketam
-Citrus = Sitrus
-Truffles = Truffle
-Strategic = Strategik
-Bonus = Bonus
-Luxury = Kemewahan
-
-# Unit types
-
-City = Bandar
-Civilian = Orang Awam
-Melee = Unit Tempur Jarak Dekat
-Ranged = Unit Jarak Jauh
-Scout = Peninjau
-Mounted = Terpasang
-Armor = Perisai
-Siege = Pengepungan
-
-WaterCivilian = Orang Awam Air
-WaterMelee = Unit Tempur Jarak Dekat Air
-WaterRanged = Unit Jarak Jauh Air
-WaterSubmarine = Kapal Selam Air
-WaterAircraftCarrier = Kapal Induk Pesawat Udara Air
-
-Fighter = Pesawat Pejuang
-Bomber = Pesawat Pengebom
-AtomicBomber = Pesawat Pengebom Atom
-Missile = Peluru Berpandu
-
-
-# Unit filters and other unit related things
-
-Air = Udara
-air units = unit udara
-Barbarian = Orang Barbar
-Barbarians = Orang barbar
-Embarked = Mulakan
-land units = unit darat
-Military = Tentera
-# Deprecated since 3.15.2, but should still be translated until it is officially removed
-military water = Tentera air
-non-air = bukan udara
-Nuclear Weapon = Senjata Nuklear
-Submarine = Kapal Selam
-submarine units = unit kapal selam
-Unbuildable = Tidak dapat dibina
-water units = unit air
-wounded units = unit tercedera
-Wounded = Tercedera
-
-# For the "All newly-trained [relevant] units in this city receive the [] promotion" translation. Relevant as in 'units that can receive'
-relevant = relevan
-
-# For "May choose [amount] additional [beliefType] beliefs when [founding/enhancing] a religion"
- # Requires translation!
-founding = 
- # Requires translation!
-enhancing = 
 
 # Promotions
 
@@ -1546,6 +1441,7 @@ Pick promotion = Pilih pangkat
  OR  = ATAU
 units in open terrain = unit di medan terbuka
 units in rough terrain = unit di medan kasar
+wounded units = unit tercedera
 Targeting II (air) = Sasaran II (udara)
 Targeting III (air) = Sasaran III (udara)
 Bonus when performing air sweep [bonusAmount]% = Bonus ketika sapuan udara [bonusAmount]&
@@ -1663,6 +1559,11 @@ Never destroyed when the city is captured =
  # Requires translation!
 Invisible to others = 
 
+# Unused Resources
+
+Bison = Bison
+Cocoa = Koko
+
 
 # In English we just paste all these conditionals at the end of each unique, but in your language that
 # may not turn into valid sentences. Therefore we have the following two translations to determine
@@ -1693,6 +1594,33 @@ ConditionalsPlacement =
 ########################### AUTOMATICALLY GENERATED TRANSLATABLE STRINGS ########################### 
 
 
+######### Map Unit Filters ###########
+
+Wounded = Tercedera
+Barbarians = Orang barbar
+ # Requires translation!
+City-State = 
+Embarked = Mulakan
+ # Requires translation!
+Non-City = 
+
+######### Unit Type Filters ###########
+
+Military = Tentera
+Civilian = Orang Awam
+non-air = bukan udara
+relevant = relevan
+Nuclear Weapon = Senjata Nuklear
+City = Bandar
+Air = Udara
+land units = unit darat
+water units = unit air
+air units = unit udara
+ # Requires translation!
+military units = 
+submarine units = unit kapal selam
+Barbarian = Orang Barbar
+
 ######### City filters ###########
 
 in this city = di bandar ini
@@ -1719,6 +1647,71 @@ in holy cities =
 in City-State cities = 
  # Requires translation!
 in cities following this religion = 
+
+######### Population Filters ###########
+
+ # Requires translation!
+Unemployed = 
+ # Requires translation!
+Followers of the Majority Religion = 
+ # Requires translation!
+Followers of this Religion = 
+
+######### Terrain Filters ###########
+
+All = Semua
+Coastal = Pantai
+River = Sungai
+Open terrain = Medan terbuka
+Rough terrain = Medan kasar
+Water resource = Sumber air
+Foreign Land = Tanah Asing
+Foreign = Asing
+Friendly Land = Tanah Sahabat
+ # Requires translation!
+Enemy Land = 
+ # Requires translation!
+Featureless = 
+ # Requires translation!
+Fresh Water = 
+non-fresh water = Air tidak tawar
+Natural Wonder = Keajaiban Semula Jadi
+Impassable = Tidak dapat dilalui
+Land = Tanah
+Water = Air
+Luxury resource = Sumber mewah
+Strategic resource = Sumber strategik
+Bonus resource = Sumber bonus
+
+######### Tile Filters ###########
+
+ # Requires translation!
+unimproved = 
+All Road = Semua Jalan
+Great Improvement = Peningkatan Hebat
+
+######### Region Types ###########
+
+ # Requires translation!
+Hybrid = 
+
+######### Terrain Quality ###########
+
+ # Requires translation!
+Undesirable = 
+ # Requires translation!
+Desirable = 
+
+######### Improvement Filters ###########
+
+Great = Hebat
+
+######### Prophet Action Filters ###########
+
+ # Requires translation!
+founding = 
+ # Requires translation!
+enhancing = 
 
 ######### Unique Specials ###########
 
@@ -1756,6 +1749,8 @@ Temple of Artemis = Temple of Artemis
 The Great Lighthouse = 
  # Requires translation!
 'They that go down to the sea in ships, that do business in great waters; these see the works of the Lord, and his wonders in the deep.' - The Bible, Psalms 107:23-24 = 
+ # Requires translation!
+for [mapUnitFilter] units = 
  # Requires translation!
 [amount] Movement = 
  # Requires translation!
@@ -1825,6 +1820,10 @@ Krepost =
 Statue of Zeus = 
  # Requires translation!
 'He spoke, the son of Kronos, and nodded his head with the dark brows, and the immortally anointed hair of the great god swept from his divine head, and all Olympos was shaken' - The Iliad = 
+ # Requires translation!
+vs cities = 
+ # Requires translation!
+when attacking = 
  # Requires translation!
 [amount]% Strength = 
 
@@ -1965,12 +1964,16 @@ Castle = Istana
  # Requires translation!
 Mughal Fort = 
  # Requires translation!
+after discovering [tech] = 
+ # Requires translation!
 [stats] [cityFilter] = 
 
  # Requires translation!
 Himeji Castle = 
  # Requires translation!
 'Bushido is realized in the presence of death. This means choosing death whenever there is a choice between life and death. There is no other reasoning.' - Yamamoto Tsunetomo = 
+ # Requires translation!
+when fighting in [tileFilter] tiles = 
 
  # Requires translation!
 Ironworks = 
@@ -2113,6 +2116,8 @@ Pentagon = Pentagon
 
 Solar Plant = Ladang Solar
  # Requires translation!
+in cities without a [buildingFilter] = 
+ # Requires translation!
 Only available = 
 
 Nuclear Plant = Penjana Nuklear
@@ -2159,6 +2164,7 @@ Era Starting Unit =
 
  # Requires translation!
 Emperor = 
+Scout = Peninjau
 
  # Requires translation!
 Immortal = 
@@ -2198,9 +2204,6 @@ Atomic era =
 Information era = Era Informasi
 
 Future era = Era Masa Hadapan
-
-
-#################### Lines from GlobalUniques from Civ V - Vanilla ####################
 
 
 #################### Lines from Nations from Civ V - Vanilla ####################
@@ -2855,6 +2858,8 @@ Bourges =
  # Requires translation!
 Calais = 
 France = Perancis
+ # Requires translation!
+before discovering [tech] = 
 
  # Requires translation!
 Catherine = 
@@ -2961,7 +2966,7 @@ Double quantity of [resource] produced =
  # Requires translation!
 Augustus Caesar = 
  # Requires translation!
-My treasury contains little and my soldiers are getting impatient... ...therefore you must die. = 
+My treasury contains little and my soldiers are getting impatient... (sigh) ...therefore you must die. = 
  # Requires translation!
 So brave, yet so stupid! If only you had a brain similar to your courage. = 
  # Requires translation!
@@ -4005,6 +4010,8 @@ Patigrbana =
  # Requires translation!
 Phrada = 
 Persia = Parsi
+ # Requires translation!
+during a Golden Age = 
 
  # Requires translation!
 Kamehameha I = 
@@ -4107,6 +4114,8 @@ Pileni =
  # Requires translation!
 Nukumanu = 
 Polynesia = Polinesia
+ # Requires translation!
+starting from the [era] = 
  # Requires translation!
 Enables embarkation for land units = 
  # Requires translation!
@@ -4983,6 +4992,8 @@ Oligarchy = Oilgarki
  # Requires translation!
 Units in cities cost no Maintenance = 
  # Requires translation!
+with a garrison = 
+ # Requires translation!
 [amount]% Strength for cities = 
  # Requires translation!
 Landed Elite = 
@@ -5015,6 +5026,8 @@ Liberty =
  # Requires translation!
 Warrior Code = 
 Discipline = Disipin
+ # Requires translation!
+when adjacent to a [mapUnitFilter] unit = 
 Military Tradition = Tradisi Tentera
  # Requires translation!
 [amount]% XP gained from combat = 
@@ -5026,6 +5039,8 @@ Professional Army =
 Honor Complete = 
  # Requires translation!
 Honor = 
+ # Requires translation!
+vs [mapUnitFilter] units = 
  # Requires translation!
 Notified of new Barbarian encampments = 
 
@@ -5045,6 +5060,8 @@ Free Religion = Kebebasan Agama
 Piety Complete = 
  # Requires translation!
 Piety = 
+ # Requires translation!
+before adopting [policy] = 
 
  # Requires translation!
 Philantropy = 
@@ -5116,10 +5133,14 @@ Rationalism Complete =
  # Requires translation!
 Rationalism = 
  # Requires translation!
+while the empire is happy = 
+ # Requires translation!
 [amount]% [stat] = 
 
 Constitution = Perlembagaan
 Universal Suffrage = Hak Pilih Sejagat
+ # Requires translation!
+when defending = 
 Civil Society = Masyarakat Sivil
  # Requires translation!
 [amount]% Food consumption by specialists [cityFilter] = 
@@ -5148,6 +5169,8 @@ Police State =
 Total War = 
  # Requires translation!
 Autocracy Complete = 
+ # Requires translation!
+for [amount] turns = 
  # Requires translation!
 Autocracy = 
  # Requires translation!
@@ -5183,40 +5206,40 @@ We feel threatened by a Barbarian Camp near our city. Please take care of it. =
  # Requires translation!
 Connect Resource = 
  # Requires translation!
-In order to make our civilizations stronger, connect [param] to your trade network. = 
+In order to make our civilizations stronger, connect [tileResource] to your trade network. = 
 
  # Requires translation!
 Construct Wonder = 
  # Requires translation!
-We recommend you to start building [param] to show the whole world your civilization strength. = 
+We recommend you to start building [wonder] to show the whole world your civilization strength. = 
 
  # Requires translation!
 Acquire Great Person = 
  # Requires translation!
-Great People can change the course of a Civilization! You will be rewarded for acquiring a new [param]. = 
+Great People can change the course of a Civilization! You will be rewarded for acquiring a new [greatPerson]. = 
 
  # Requires translation!
 Conquer City State = 
  # Requires translation!
-It's time to erase the City-State of [param] from the map. You will be greatly rewarded for conquering them! = 
+It's time to erase the City-State of [cityState] from the map. You will be greatly rewarded for conquering them! = 
 
 Find Player = Cari Pemain
  # Requires translation!
-You have yet to discover where [param] set up their cities. You will be rewarded for finding their territories. = 
+You have yet to discover where [civName] set up their cities. You will be rewarded for finding their territories. = 
 
  # Requires translation!
 Find Natural Wonder = 
  # Requires translation!
-Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [param] yet. = 
+Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [naturalWonder] yet. = 
 
 Give Gold = Bagi Emas
  # Requires translation!
-We are suffering great poverty after being robbed by [param], and unless we receive a sum of Gold, it's only a matter of time before we collapse. = 
+We are suffering great poverty after being robbed by [civName], and unless we receive a sum of Gold, it's only a matter of time before we collapse. = 
 
  # Requires translation!
 Pledge to Protect = 
  # Requires translation!
-We need your protection to stop the aggressions of [param]. By signing a Pledge of Protection, you'll confirm the bond that ties us. = 
+We need your protection to stop the aggressions of [civName]. By signing a Pledge of Protection, you'll confirm the bond that ties us. = 
 
  # Requires translation!
 Contest Culture = 
@@ -5235,20 +5258,20 @@ The civilization with the largest number of new Technologies researched will gai
 
 Invest = Labur
  # Requires translation!
-Our people are rejoicing thanks to a tourism boom. For a certain amount of time, any Gold donation will yield [amount]% extra Influence. = 
+Our people are rejoicing thanks to a tourism boom. For a certain amount of time, any Gold donation will yield [50]% extra Influence. = 
 
  # Requires translation!
 Bully City State = 
  # Requires translation!
-We are tired of the pretensions of [param]. If someone were to put them in their place by Demanding Tribute from them, they would be rewarded. = 
+We are tired of the pretensions of [cityState]. If someone were to put them in their place by Demanding Tribute from them, they would be rewarded. = 
 
  # Requires translation!
 Denounce Civilization = 
  # Requires translation!
-We have been forced to pay tribute to [param]! We need you to tell the world of their ill deeds. = 
+We have been forced to pay tribute to [civName]! We need you to tell the world of their ill deeds. = 
 
  # Requires translation!
-We have heard the tenets of [param] and are most curious. Will you send missionaries to teach us about your religion? = 
+We have heard the tenets of [religionName] and are most curious. Will you send missionaries to teach us about your religion? = 
 
 
 #################### Lines from Ruins from Civ V - Vanilla ####################
@@ -5270,12 +5293,12 @@ An ancient tribe trained us in their ways of combat! =
 your exploring unit receives training = 
 
  # Requires translation!
-We have found survivors in the ruins! Population added to [param]. = 
+We have found survivors in the ruins! Population added to [cityName]. = 
  # Requires translation!
 survivors (adds population to a city) = 
 
  # Requires translation!
-We have found a stash of [param] Gold in the ruins! = 
+We have found a stash of [goldAmount] Gold in the ruins! = 
  # Requires translation!
 a stash of gold = 
 
@@ -5591,6 +5614,7 @@ Tundra = Tundra
 Desert = Gurun
 
 Lakes = Tasik
+Fresh water = Air tawar
 
 Mountain = Gunung
  # Requires translation!
@@ -5619,6 +5643,7 @@ Jungle =
 
  # Requires translation!
 Marsh = 
+Rare feature = Ciri jarang
  # Requires translation!
 Only Polders can be built here = 
 
@@ -5878,6 +5903,8 @@ Porcelain =
 
  # Requires translation!
 Sword = 
+Mounted = Terpasang
+Siege = Pengepungan
  # Requires translation!
 Ranged Gunpowder = 
  # Requires translation!
@@ -5886,6 +5913,7 @@ Armored =
 Melee Water = 
  # Requires translation!
 Ranged Water = 
+Submarine = Kapal Selam
  # Requires translation!
 Heal Instantly = 
  # Requires translation!
@@ -5979,6 +6007,8 @@ All adjacent units heal [amount] HP when healing =
  # Requires translation!
 Medic II = 
  # Requires translation!
+in [tileFilter] tiles = 
+ # Requires translation!
 [amount] HP when healing = 
 
  # Requires translation!
@@ -6071,6 +6101,7 @@ Supply =
  # Requires translation!
 May heal outside of friendly territory = 
 
+Bomber = Pesawat Pengebom
  # Requires translation!
 Siege I = 
 
@@ -6085,6 +6116,7 @@ Evasion =
  # Requires translation!
 Damage taken from interception reduced by [amount]% = 
 
+Fighter = Pesawat Pejuang
  # Requires translation!
 Interception I = 
  # Requires translation!
@@ -6227,6 +6259,7 @@ Can see over obstacles =
 
 Atomic Bomber = Pengebom Atomik
 
+Missile = Peluru Berpandu
  # Requires translation!
 Self-destructs when attacking = 
  # Requires translation!
@@ -6234,6 +6267,24 @@ Cannot be intercepted =
 
  # Requires translation!
 Can pass through impassable tiles = 
+
+Melee = Unit Tempur Jarak Dekat
+
+Ranged = Unit Jarak Jauh
+
+Armor = Perisai
+
+WaterCivilian = Orang Awam Air
+
+WaterMelee = Unit Tempur Jarak Dekat Air
+
+WaterRanged = Unit Jarak Jauh Air
+
+WaterSubmarine = Kapal Selam Air
+
+WaterAircraftCarrier = Kapal Induk Pesawat Udara Air
+
+AtomicBomber = Pesawat Pengebom Atom
 
 
 #################### Lines from Units from Civ V - Vanilla ####################
@@ -6351,6 +6402,8 @@ Camel Archer =
 
  # Requires translation!
 Conquistador = 
+ # Requires translation!
+on foreign continents = 
 
  # Requires translation!
 Naresuan's Elephant = 
@@ -6478,6 +6531,8 @@ Atomic Bomb = Bom Atom
  # Requires translation!
 Nuclear weapon of Strength [amount] = 
  # Requires translation!
+if [buildingName] is constructed = 
+ # Requires translation!
 Blast radius [amount] = 
 
  # Requires translation!
@@ -6530,6 +6585,7 @@ Can start an [amount]-turn golden age =
 Can construct [improvementName] = 
  # Requires translation!
 Great Person - [stat] = 
+Unbuildable = Tidak dapat dibina
 
  # Requires translation!
 Great Scientist = 
@@ -6625,6 +6681,8 @@ Fertility Rites =
 
  # Requires translation!
 God of Craftsman = 
+ # Requires translation!
+in cities with at least [amount] [populationFilter] = 
 
  # Requires translation!
 God of the Open Sky = 
@@ -6705,6 +6763,8 @@ Guruship =
  # Requires translation!
 Holy Warriors = 
  # Requires translation!
+before the [era] = 
+ # Requires translation!
 May buy [baseUnitFilter] units with [stat] for [amount] times their normal Production cost = 
 
  # Requires translation!
@@ -6735,6 +6795,8 @@ Religious Community =
 
  # Requires translation!
 Swords into Ploughshares = 
+ # Requires translation!
+when not at war = 
 
  # Requires translation!
 Founder = 
@@ -6931,9 +6993,6 @@ Starting in this era disables religion =
 
 
 Marine = Marin
-
-
-#################### Lines from GlobalUniques from Civ V - Gods & Kings ####################
 
 
 #################### Lines from Nations from Civ V - Gods & Kings ####################
@@ -7557,6 +7616,8 @@ Falmouth =
 Lorient = 
  # Requires translation!
 Celts = 
+ # Requires translation!
+with [amount] to [amount2] neighboring [tileFilter] [tileFilter2] tiles = 
 
  # Requires translation!
 Haile Selassie = 
@@ -7644,6 +7705,8 @@ Ziway =
 Weldiya = 
  # Requires translation!
 Ethiopia = 
+ # Requires translation!
+when fighting units from a Civilization with more Cities than you = 
 
  # Requires translation!
 Pacal = 
@@ -7791,12 +7854,12 @@ Taoism =
 
 
  # Requires translation!
-We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[param] Faith) = 
+We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[faithAmount] Faith) = 
  # Requires translation!
 discover holy symbols = 
 
  # Requires translation!
-We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[param] Faith) = 
+We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[faithAmount] Faith) = 
  # Requires translation!
 an ancient prophecy = 
 
@@ -7868,7 +7931,15 @@ Polder =
 #################### Lines from TileResources from Civ V - Gods & Kings ####################
 
 
+Citrus = Sitrus
+
+Copper = Tembaga
+
+Crab = Ketam
+
 Salt = Garam
+
+Truffles = Truffle
 
 
 #################### Lines from UnitPromotions from Civ V - Gods & Kings ####################
@@ -8429,13 +8500,7 @@ Irremovable =
  # Requires translation!
 when at war = 
  # Requires translation!
-when not at war = 
- # Requires translation!
-during a Golden Age = 
- # Requires translation!
 with [resource] = 
- # Requires translation!
-while the empire is happy = 
  # Requires translation!
 when between [amount] and [amount2] Happiness = 
  # Requires translation!
@@ -8443,67 +8508,25 @@ when below [amount] Happiness =
  # Requires translation!
 during the [era] = 
  # Requires translation!
-before the [era] = 
- # Requires translation!
-starting from the [era] = 
- # Requires translation!
 if no other Civilization has researched this = 
- # Requires translation!
-after discovering [tech] = 
- # Requires translation!
-before discovering [tech] = 
  # Requires translation!
 upon discovering [tech] = 
  # Requires translation!
 after adopting [policy] = 
  # Requires translation!
-before adopting [policy] = 
- # Requires translation!
-if [buildingName] is constructed = 
- # Requires translation!
-for [amount] turns = 
- # Requires translation!
 by consuming this unit = 
  # Requires translation!
 in cities with a [buildingFilter] = 
  # Requires translation!
-in cities without a [buildingFilter] = 
- # Requires translation!
-in cities with at least [amount] [populationFilter] = 
- # Requires translation!
-with a garrison = 
- # Requires translation!
-for [mapUnitFilter] units = 
- # Requires translation!
 for units with [promotion] = 
  # Requires translation!
 for units without [promotion] = 
- # Requires translation!
-vs cities = 
- # Requires translation!
-vs [mapUnitFilter] units = 
- # Requires translation!
-when fighting units from a Civilization with more Cities than you = 
- # Requires translation!
-when attacking = 
- # Requires translation!
-when defending = 
- # Requires translation!
-when fighting in [tileFilter] tiles = 
- # Requires translation!
-on foreign continents = 
- # Requires translation!
-when adjacent to a [mapUnitFilter] unit = 
  # Requires translation!
 when above [amount] HP = 
  # Requires translation!
 when below [amount] HP = 
  # Requires translation!
 with [amount] to [amount2] neighboring [tileFilter] tiles = 
- # Requires translation!
-with [amount] to [amount2] neighboring [tileFilter] [tileFilter2] tiles = 
- # Requires translation!
-in [tileFilter] tiles = 
  # Requires translation!
 in [tileFilter] [tileFilter2] tiles = 
  # Requires translation!
@@ -8582,3 +8605,11 @@ CityState =
 ModOptions = 
  # Requires translation!
 Conditional = 
+
+#################### Removed Lines ####################
+
+#~~Rough Terrain = Medan kasar
+#~~Strategic = Strategik
+#~~Bonus = Bonus
+#~~Luxury = Kemewahan
+#~~military water = Tentera air

--- a/android/assets/jsons/translations/Persian_(Pinglish-DIN).properties
+++ b/android/assets/jsons/translations/Persian_(Pinglish-DIN).properties
@@ -1435,9 +1435,6 @@ or [terrainType] =
 Can be constructed by = 
 Defence bonus = Emtiāz e defāi
 Movement cost = Hazine ye harekat
- # Requires translation!
-Open terrain = 
-Rough Terrain = Zamin e nāhamvār
 for = barāye
 Missing translations: = Tarjome hāye nāmojood:
 Resolution = Vozooh e tasvir 
@@ -1625,147 +1622,6 @@ Enhancing religion =
  # Requires translation!
 Enhanced religion = 
 
-# Terrains
-
-Impassable = Ğeyr e ğābel e oboor
- # Requires translation!
-Rare feature = 
-
-# terrainFilters (so for uniques like: "[stats] from [terrainFilter] tiles")
-
- # Requires translation!
-All = 
- # Requires translation!
-Water = 
-Land = Zamin
- # Requires translation!
-Coastal = 
- # Requires translation!
-River = 
- # Requires translation!
-Rough terrain = 
-Foreign Land = Zamin e ḵāreji
- # Requires translation!
-Foreign = 
- # Requires translation!
-Friendly Land = 
- # Requires translation!
-Water resource = 
- # Requires translation!
-Bonus resource = 
- # Requires translation!
-Luxury resource = 
- # Requires translation!
-Strategic resource = 
- # Requires translation!
-Fresh water = 
- # Requires translation!
-non-fresh water = 
- # Requires translation!
-Natural Wonder = 
- # Requires translation!
-Hybrid = 
- # Requires translation!
-Undesirable = 
- # Requires translation!
-Desirable = 
- # Requires translation!
-Featureless = 
- # Requires translation!
-Fresh Water = 
-
-# improvementFilters
-
- # Requires translation!
-All Road = 
- # Requires translation!
-Great Improvement = 
- # Requires translation!
-Great = 
-
-# Resources
-
-Bison = Ğāv
-Copper = Mes
-Cocoa = Kākāoo
-Crab = Ḵarčang
-Citrus = Morakkabāt
-Truffles = Ğārč
- # Requires translation!
-Strategic = 
- # Requires translation!
-Bonus = 
- # Requires translation!
-Luxury = 
-
-# Unit types
-
-City = Šahr
-Civilian = Šahrvand
-Melee = Nazdik-bord
-Ranged = Door-bord
- # Requires translation!
-Scout = 
-Mounted = Savāre
-Armor = Zereh
- # Requires translation!
-Siege = 
-
-WaterCivilian = Šahrvand
-WaterMelee = Nazdik-bord
-WaterRanged = Door-bord
-WaterSubmarine = Zirdaryāi
-WaterAircraftCarrier = Nāv e havāpeymā bar
-
- # Requires translation!
-Fighter = 
- # Requires translation!
-Bomber = 
- # Requires translation!
-AtomicBomber = 
-Missile = Moošak
-
-
-# Unit filters and other unit related things
-
- # Requires translation!
-Air = 
-air units = Niroo hāye havāi 
- # Requires translation!
-Barbarian = 
- # Requires translation!
-Barbarians = 
- # Requires translation!
-Embarked = 
-land units = Niroo hāye zamini
- # Requires translation!
-Military = 
-# Deprecated since 3.15.2, but should still be translated until it is officially removed
- # Requires translation!
-military water = 
- # Requires translation!
-non-air = 
- # Requires translation!
-Nuclear Weapon = 
- # Requires translation!
-Submarine = 
- # Requires translation!
-submarine units = 
-Unbuildable = Ğeyr e ğābel e sāḵt
-water units = Niroo hāye daryāi
-wounded units = Niroo hā majrooh
- # Requires translation!
-Wounded = 
-
-# For the "All newly-trained [relevant] units in this city receive the [] promotion" translation. Relevant as in 'units that can receive'
- # Requires translation!
-relevant = 
-
-# For "May choose [amount] additional [beliefType] beliefs when [founding/enhancing] a religion"
- # Requires translation!
-founding = 
- # Requires translation!
-enhancing = 
 
 # Promotions
 
@@ -1773,6 +1629,7 @@ Pick promotion = Enteḵāb e behsāzi
  OR  =  YĀ 
 units in open terrain = Niroo hā dar zamin e hamvār
 units in rough terrain = Niroo hā dar zamin e nāhamvār
+wounded units = Niroo hā majrooh
 Targeting II (air) = Nešāne giri 2
 Targeting III (air) = Nešāne giri 3
 Bonus when performing air sweep [bonusAmount]% = [bonusAmount]% komak hendām defā’e havāi
@@ -1934,6 +1791,11 @@ Never destroyed when the city is captured =
  # Requires translation!
 Invisible to others = 
 
+# Unused Resources
+
+Bison = Ğāv
+Cocoa = Kākāoo
+
 
 # In English we just paste all these conditionals at the end of each unique, but in your language that
 # may not turn into valid sentences. Therefore we have the following two translations to determine
@@ -1963,6 +1825,43 @@ ConditionalsPlacement =
 
 ########################### AUTOMATICALLY GENERATED TRANSLATABLE STRINGS ########################### 
 
+
+######### Map Unit Filters ###########
+
+ # Requires translation!
+Wounded = 
+ # Requires translation!
+Barbarians = 
+ # Requires translation!
+City-State = 
+ # Requires translation!
+Embarked = 
+ # Requires translation!
+Non-City = 
+
+######### Unit Type Filters ###########
+
+ # Requires translation!
+Military = 
+Civilian = Šahrvand
+ # Requires translation!
+non-air = 
+ # Requires translation!
+relevant = 
+ # Requires translation!
+Nuclear Weapon = 
+City = Šahr
+ # Requires translation!
+Air = 
+land units = Niroo hāye zamini
+water units = Niroo hāye daryāi
+air units = Niroo hāye havāi 
+ # Requires translation!
+military units = 
+ # Requires translation!
+submarine units = 
+ # Requires translation!
+Barbarian = 
 
 ######### City filters ###########
 
@@ -1999,6 +1898,88 @@ in City-State cities =
  # Requires translation!
 in cities following this religion = 
 
+######### Population Filters ###########
+
+ # Requires translation!
+Unemployed = 
+ # Requires translation!
+Followers of the Majority Religion = 
+ # Requires translation!
+Followers of this Religion = 
+
+######### Terrain Filters ###########
+
+ # Requires translation!
+All = 
+ # Requires translation!
+Coastal = 
+ # Requires translation!
+River = 
+ # Requires translation!
+Open terrain = 
+ # Requires translation!
+Rough terrain = 
+ # Requires translation!
+Water resource = 
+Foreign Land = Zamin e ḵāreji
+ # Requires translation!
+Foreign = 
+ # Requires translation!
+Friendly Land = 
+ # Requires translation!
+Enemy Land = 
+ # Requires translation!
+Featureless = 
+ # Requires translation!
+Fresh Water = 
+ # Requires translation!
+non-fresh water = 
+ # Requires translation!
+Natural Wonder = 
+Impassable = Ğeyr e ğābel e oboor
+Land = Zamin
+ # Requires translation!
+Water = 
+ # Requires translation!
+Luxury resource = 
+ # Requires translation!
+Strategic resource = 
+ # Requires translation!
+Bonus resource = 
+
+######### Tile Filters ###########
+
+ # Requires translation!
+unimproved = 
+ # Requires translation!
+All Road = 
+ # Requires translation!
+Great Improvement = 
+
+######### Region Types ###########
+
+ # Requires translation!
+Hybrid = 
+
+######### Terrain Quality ###########
+
+ # Requires translation!
+Undesirable = 
+ # Requires translation!
+Desirable = 
+
+######### Improvement Filters ###########
+
+ # Requires translation!
+Great = 
+
+######### Prophet Action Filters ###########
+
+ # Requires translation!
+founding = 
+ # Requires translation!
+enhancing = 
+
 ######### Unique Specials ###########
 
  # Requires translation!
@@ -2034,6 +2015,8 @@ Temple of Artemis =
 The Great Lighthouse = 
  # Requires translation!
 'They that go down to the sea in ships, that do business in great waters; these see the works of the Lord, and his wonders in the deep.' - The Bible, Psalms 107:23-24 = 
+ # Requires translation!
+for [mapUnitFilter] units = 
  # Requires translation!
 [amount] Movement = 
  # Requires translation!
@@ -2093,6 +2076,10 @@ Krepost = Gal’e
 Statue of Zeus = Mojasame ye Zeoos
  # Requires translation!
 'He spoke, the son of Kronos, and nodded his head with the dark brows, and the immortally anointed hair of the great god swept from his divine head, and all Olympos was shaken' - The Iliad = 
+ # Requires translation!
+vs cities = 
+ # Requires translation!
+when attacking = 
  # Requires translation!
 [amount]% Strength = 
 
@@ -2248,12 +2235,16 @@ Castle =
  # Requires translation!
 Mughal Fort = 
  # Requires translation!
+after discovering [tech] = 
+ # Requires translation!
 [stats] [cityFilter] = 
 
  # Requires translation!
 Himeji Castle = 
  # Requires translation!
 'Bushido is realized in the presence of death. This means choosing death whenever there is a choice between life and death. There is no other reasoning.' - Yamamoto Tsunetomo = 
+ # Requires translation!
+when fighting in [tileFilter] tiles = 
 
  # Requires translation!
 Ironworks = 
@@ -2419,6 +2410,8 @@ Pentagon =
  # Requires translation!
 Solar Plant = 
  # Requires translation!
+in cities without a [buildingFilter] = 
+ # Requires translation!
 Only available = 
 
  # Requires translation!
@@ -2470,6 +2463,8 @@ Era Starting Unit =
 
  # Requires translation!
 Emperor = 
+ # Requires translation!
+Scout = 
 
  # Requires translation!
 Immortal = 
@@ -2520,9 +2515,6 @@ Information era =
 
  # Requires translation!
 Future era = 
-
-
-#################### Lines from GlobalUniques from Civ V - Vanilla ####################
 
 
 #################### Lines from Nations from Civ V - Vanilla ####################
@@ -3177,6 +3169,8 @@ Bourges =
 Calais = 
  # Requires translation!
 France = 
+ # Requires translation!
+before discovering [tech] = 
 
  # Requires translation!
 Catherine = 
@@ -3283,7 +3277,7 @@ Double quantity of [resource] produced =
  # Requires translation!
 Augustus Caesar = 
  # Requires translation!
-My treasury contains little and my soldiers are getting impatient... ...therefore you must die. = 
+My treasury contains little and my soldiers are getting impatient... (sigh) ...therefore you must die. = 
  # Requires translation!
 So brave, yet so stupid! If only you had a brain similar to your courage. = 
  # Requires translation!
@@ -4327,6 +4321,8 @@ Patigrbana =
 Phrada = 
  # Requires translation!
 Persia = 
+ # Requires translation!
+during a Golden Age = 
 
  # Requires translation!
 Kamehameha I = 
@@ -4429,6 +4425,8 @@ Pileni =
 Nukumanu = 
  # Requires translation!
 Polynesia = 
+ # Requires translation!
+starting from the [era] = 
  # Requires translation!
 Enables embarkation for land units = 
  # Requires translation!
@@ -5330,6 +5328,8 @@ Oligarchy =
  # Requires translation!
 Units in cities cost no Maintenance = 
  # Requires translation!
+with a garrison = 
+ # Requires translation!
 [amount]% Strength for cities = 
  # Requires translation!
 Landed Elite = 
@@ -5368,6 +5368,8 @@ Warrior Code =
  # Requires translation!
 Discipline = 
  # Requires translation!
+when adjacent to a [mapUnitFilter] unit = 
+ # Requires translation!
 Military Tradition = 
  # Requires translation!
 [amount]% XP gained from combat = 
@@ -5379,6 +5381,8 @@ Professional Army =
 Honor Complete = 
  # Requires translation!
 Honor = 
+ # Requires translation!
+vs [mapUnitFilter] units = 
  # Requires translation!
 Notified of new Barbarian encampments = 
 
@@ -5400,6 +5404,8 @@ Free Religion =
 Piety Complete = 
  # Requires translation!
 Piety = 
+ # Requires translation!
+before adopting [policy] = 
 
  # Requires translation!
 Philantropy = 
@@ -5472,12 +5478,16 @@ Rationalism Complete =
  # Requires translation!
 Rationalism = 
  # Requires translation!
+while the empire is happy = 
+ # Requires translation!
 [amount]% [stat] = 
 
  # Requires translation!
 Constitution = 
  # Requires translation!
 Universal Suffrage = 
+ # Requires translation!
+when defending = 
  # Requires translation!
 Civil Society = 
  # Requires translation!
@@ -5511,6 +5521,8 @@ Police State =
 Total War = 
  # Requires translation!
 Autocracy Complete = 
+ # Requires translation!
+for [amount] turns = 
  # Requires translation!
 Autocracy = 
  # Requires translation!
@@ -5551,42 +5563,42 @@ We feel threatened by a Barbarian Camp near our city. Please take care of it. =
  # Requires translation!
 Connect Resource = 
  # Requires translation!
-In order to make our civilizations stronger, connect [param] to your trade network. = 
+In order to make our civilizations stronger, connect [tileResource] to your trade network. = 
 
  # Requires translation!
 Construct Wonder = 
  # Requires translation!
-We recommend you to start building [param] to show the whole world your civilization strength. = 
+We recommend you to start building [wonder] to show the whole world your civilization strength. = 
 
  # Requires translation!
 Acquire Great Person = 
  # Requires translation!
-Great People can change the course of a Civilization! You will be rewarded for acquiring a new [param]. = 
+Great People can change the course of a Civilization! You will be rewarded for acquiring a new [greatPerson]. = 
 
  # Requires translation!
 Conquer City State = 
  # Requires translation!
-It's time to erase the City-State of [param] from the map. You will be greatly rewarded for conquering them! = 
+It's time to erase the City-State of [cityState] from the map. You will be greatly rewarded for conquering them! = 
 
  # Requires translation!
 Find Player = 
  # Requires translation!
-You have yet to discover where [param] set up their cities. You will be rewarded for finding their territories. = 
+You have yet to discover where [civName] set up their cities. You will be rewarded for finding their territories. = 
 
  # Requires translation!
 Find Natural Wonder = 
  # Requires translation!
-Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [param] yet. = 
+Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [naturalWonder] yet. = 
 
  # Requires translation!
 Give Gold = 
  # Requires translation!
-We are suffering great poverty after being robbed by [param], and unless we receive a sum of Gold, it's only a matter of time before we collapse. = 
+We are suffering great poverty after being robbed by [civName], and unless we receive a sum of Gold, it's only a matter of time before we collapse. = 
 
  # Requires translation!
 Pledge to Protect = 
  # Requires translation!
-We need your protection to stop the aggressions of [param]. By signing a Pledge of Protection, you'll confirm the bond that ties us. = 
+We need your protection to stop the aggressions of [civName]. By signing a Pledge of Protection, you'll confirm the bond that ties us. = 
 
  # Requires translation!
 Contest Culture = 
@@ -5606,20 +5618,20 @@ The civilization with the largest number of new Technologies researched will gai
  # Requires translation!
 Invest = 
  # Requires translation!
-Our people are rejoicing thanks to a tourism boom. For a certain amount of time, any Gold donation will yield [amount]% extra Influence. = 
+Our people are rejoicing thanks to a tourism boom. For a certain amount of time, any Gold donation will yield [50]% extra Influence. = 
 
  # Requires translation!
 Bully City State = 
  # Requires translation!
-We are tired of the pretensions of [param]. If someone were to put them in their place by Demanding Tribute from them, they would be rewarded. = 
+We are tired of the pretensions of [cityState]. If someone were to put them in their place by Demanding Tribute from them, they would be rewarded. = 
 
  # Requires translation!
 Denounce Civilization = 
  # Requires translation!
-We have been forced to pay tribute to [param]! We need you to tell the world of their ill deeds. = 
+We have been forced to pay tribute to [civName]! We need you to tell the world of their ill deeds. = 
 
  # Requires translation!
-We have heard the tenets of [param] and are most curious. Will you send missionaries to teach us about your religion? = 
+We have heard the tenets of [religionName] and are most curious. Will you send missionaries to teach us about your religion? = 
 
 
 #################### Lines from Ruins from Civ V - Vanilla ####################
@@ -5641,12 +5653,12 @@ An ancient tribe trained us in their ways of combat! =
 your exploring unit receives training = 
 
  # Requires translation!
-We have found survivors in the ruins! Population added to [param]. = 
+We have found survivors in the ruins! Population added to [cityName]. = 
  # Requires translation!
 survivors (adds population to a city) = 
 
  # Requires translation!
-We have found a stash of [param] Gold in the ruins! = 
+We have found a stash of [goldAmount] Gold in the ruins! = 
  # Requires translation!
 a stash of gold = 
 
@@ -6041,6 +6053,8 @@ Desert =
 
  # Requires translation!
 Lakes = 
+ # Requires translation!
+Fresh water = 
 
  # Requires translation!
 Mountain = 
@@ -6073,6 +6087,8 @@ Jungle =
 
  # Requires translation!
 Marsh = 
+ # Requires translation!
+Rare feature = 
  # Requires translation!
 Only Polders can be built here = 
 
@@ -6376,6 +6392,9 @@ Porcelain =
 
  # Requires translation!
 Sword = 
+Mounted = Savāre
+ # Requires translation!
+Siege = 
  # Requires translation!
 Ranged Gunpowder = 
  # Requires translation!
@@ -6384,6 +6403,8 @@ Armored =
 Melee Water = 
  # Requires translation!
 Ranged Water = 
+ # Requires translation!
+Submarine = 
  # Requires translation!
 Heal Instantly = 
  # Requires translation!
@@ -6476,6 +6497,8 @@ All adjacent units heal [amount] HP when healing =
 
  # Requires translation!
 Medic II = 
+ # Requires translation!
+in [tileFilter] tiles = 
  # Requires translation!
 [amount] HP when healing = 
 
@@ -6570,6 +6593,8 @@ Supply =
 May heal outside of friendly territory = 
 
  # Requires translation!
+Bomber = 
+ # Requires translation!
 Siege I = 
 
  # Requires translation!
@@ -6583,6 +6608,8 @@ Evasion =
  # Requires translation!
 Damage taken from interception reduced by [amount]% = 
 
+ # Requires translation!
+Fighter = 
  # Requires translation!
 Interception I = 
  # Requires translation!
@@ -6727,6 +6754,7 @@ Can see over obstacles =
  # Requires translation!
 Atomic Bomber = 
 
+Missile = Moošak
  # Requires translation!
 Self-destructs when attacking = 
  # Requires translation!
@@ -6734,6 +6762,25 @@ Cannot be intercepted =
 
  # Requires translation!
 Can pass through impassable tiles = 
+
+Melee = Nazdik-bord
+
+Ranged = Door-bord
+
+Armor = Zereh
+
+WaterCivilian = Šahrvand
+
+WaterMelee = Nazdik-bord
+
+WaterRanged = Door-bord
+
+WaterSubmarine = Zirdaryāi
+
+WaterAircraftCarrier = Nāv e havāpeymā bar
+
+ # Requires translation!
+AtomicBomber = 
 
 
 #################### Lines from Units from Civ V - Vanilla ####################
@@ -6852,6 +6899,8 @@ Camel Archer =
 
  # Requires translation!
 Conquistador = 
+ # Requires translation!
+on foreign continents = 
 
  # Requires translation!
 Naresuan's Elephant = 
@@ -6986,6 +7035,8 @@ Atomic Bomb = Bomb e haste i
  # Requires translation!
 Nuclear weapon of Strength [amount] = 
  # Requires translation!
+if [buildingName] is constructed = 
+ # Requires translation!
 Blast radius [amount] = 
 
  # Requires translation!
@@ -7038,6 +7089,7 @@ Can start an [amount]-turn golden age =
 Can construct [improvementName] = 
  # Requires translation!
 Great Person - [stat] = 
+Unbuildable = Ğeyr e ğābel e sāḵt
 
  # Requires translation!
 Great Scientist = 
@@ -7133,6 +7185,8 @@ Fertility Rites =
 
  # Requires translation!
 God of Craftsman = 
+ # Requires translation!
+in cities with at least [amount] [populationFilter] = 
 
  # Requires translation!
 God of the Open Sky = 
@@ -7213,6 +7267,8 @@ Guruship =
  # Requires translation!
 Holy Warriors = 
  # Requires translation!
+before the [era] = 
+ # Requires translation!
 May buy [baseUnitFilter] units with [stat] for [amount] times their normal Production cost = 
 
  # Requires translation!
@@ -7243,6 +7299,8 @@ Religious Community =
 
  # Requires translation!
 Swords into Ploughshares = 
+ # Requires translation!
+when not at war = 
 
  # Requires translation!
 Founder = 
@@ -7440,9 +7498,6 @@ Starting in this era disables religion =
 
 
 Marine = Daryāi
-
-
-#################### Lines from GlobalUniques from Civ V - Gods & Kings ####################
 
 
 #################### Lines from Nations from Civ V - Gods & Kings ####################
@@ -8066,6 +8121,8 @@ Falmouth =
 Lorient = 
  # Requires translation!
 Celts = 
+ # Requires translation!
+with [amount] to [amount2] neighboring [tileFilter] [tileFilter2] tiles = 
 
  # Requires translation!
 Haile Selassie = 
@@ -8153,6 +8210,8 @@ Ziway =
 Weldiya = 
  # Requires translation!
 Ethiopia = 
+ # Requires translation!
+when fighting units from a Civilization with more Cities than you = 
 
  # Requires translation!
 Pacal = 
@@ -8300,12 +8359,12 @@ Taoism =
 
 
  # Requires translation!
-We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[param] Faith) = 
+We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[faithAmount] Faith) = 
  # Requires translation!
 discover holy symbols = 
 
  # Requires translation!
-We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[param] Faith) = 
+We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[faithAmount] Faith) = 
  # Requires translation!
 an ancient prophecy = 
 
@@ -8385,8 +8444,16 @@ Polder =
 #################### Lines from TileResources from Civ V - Gods & Kings ####################
 
 
+Citrus = Morakkabāt
+
+Copper = Mes
+
+Crab = Ḵarčang
+
  # Requires translation!
 Salt = 
+
+Truffles = Ğārč
 
 
 #################### Lines from UnitPromotions from Civ V - Gods & Kings ####################
@@ -8947,13 +9014,7 @@ Irremovable =
  # Requires translation!
 when at war = 
  # Requires translation!
-when not at war = 
- # Requires translation!
-during a Golden Age = 
- # Requires translation!
 with [resource] = 
- # Requires translation!
-while the empire is happy = 
  # Requires translation!
 when between [amount] and [amount2] Happiness = 
  # Requires translation!
@@ -8961,67 +9022,25 @@ when below [amount] Happiness =
  # Requires translation!
 during the [era] = 
  # Requires translation!
-before the [era] = 
- # Requires translation!
-starting from the [era] = 
- # Requires translation!
 if no other Civilization has researched this = 
- # Requires translation!
-after discovering [tech] = 
- # Requires translation!
-before discovering [tech] = 
  # Requires translation!
 upon discovering [tech] = 
  # Requires translation!
 after adopting [policy] = 
  # Requires translation!
-before adopting [policy] = 
- # Requires translation!
-if [buildingName] is constructed = 
- # Requires translation!
-for [amount] turns = 
- # Requires translation!
 by consuming this unit = 
  # Requires translation!
 in cities with a [buildingFilter] = 
  # Requires translation!
-in cities without a [buildingFilter] = 
- # Requires translation!
-in cities with at least [amount] [populationFilter] = 
- # Requires translation!
-with a garrison = 
- # Requires translation!
-for [mapUnitFilter] units = 
- # Requires translation!
 for units with [promotion] = 
  # Requires translation!
 for units without [promotion] = 
- # Requires translation!
-vs cities = 
- # Requires translation!
-vs [mapUnitFilter] units = 
- # Requires translation!
-when fighting units from a Civilization with more Cities than you = 
- # Requires translation!
-when attacking = 
- # Requires translation!
-when defending = 
- # Requires translation!
-when fighting in [tileFilter] tiles = 
- # Requires translation!
-on foreign continents = 
- # Requires translation!
-when adjacent to a [mapUnitFilter] unit = 
  # Requires translation!
 when above [amount] HP = 
  # Requires translation!
 when below [amount] HP = 
  # Requires translation!
 with [amount] to [amount2] neighboring [tileFilter] tiles = 
- # Requires translation!
-with [amount] to [amount2] neighboring [tileFilter] [tileFilter2] tiles = 
- # Requires translation!
-in [tileFilter] tiles = 
  # Requires translation!
 in [tileFilter] [tileFilter2] tiles = 
  # Requires translation!
@@ -9100,3 +9119,7 @@ CityState =
 ModOptions = 
  # Requires translation!
 Conditional = 
+
+#################### Removed Lines ####################
+
+#~~Rough Terrain = Zamin e nāhamvār

--- a/android/assets/jsons/translations/Persian_(Pinglish-UN).properties
+++ b/android/assets/jsons/translations/Persian_(Pinglish-UN).properties
@@ -1432,9 +1432,6 @@ or [terrainType] =
 Can be constructed by = 
 Defence bonus = Emtiaaz e defaai
 Movement cost = Hazine ye harekat
- # Requires translation!
-Open terrain = 
-Rough Terrain = Zamin e naahamvaar
 for = baraaye
 Missing translations: = Tarjome haaye naamojood:
 Resolution = Vozooh e tasvir 
@@ -1622,147 +1619,6 @@ Enhancing religion =
  # Requires translation!
 Enhanced religion = 
 
-# Terrains
-
-Impassable = Gheyr e ghaabel e oboor
- # Requires translation!
-Rare feature = 
-
-# terrainFilters (so for uniques like: "[stats] from [terrainFilter] tiles")
-
- # Requires translation!
-All = 
- # Requires translation!
-Water = 
-Land = Zamin
- # Requires translation!
-Coastal = 
- # Requires translation!
-River = 
- # Requires translation!
-Rough terrain = 
-Foreign Land = Zamin e khaareji
- # Requires translation!
-Foreign = 
- # Requires translation!
-Friendly Land = 
- # Requires translation!
-Water resource = 
- # Requires translation!
-Bonus resource = 
- # Requires translation!
-Luxury resource = 
- # Requires translation!
-Strategic resource = 
- # Requires translation!
-Fresh water = 
- # Requires translation!
-non-fresh water = 
- # Requires translation!
-Natural Wonder = 
- # Requires translation!
-Hybrid = 
- # Requires translation!
-Undesirable = 
- # Requires translation!
-Desirable = 
- # Requires translation!
-Featureless = 
- # Requires translation!
-Fresh Water = 
-
-# improvementFilters
-
- # Requires translation!
-All Road = 
- # Requires translation!
-Great Improvement = 
- # Requires translation!
-Great = 
-
-# Resources
-
-Bison = Ghaav
-Copper = Mes
-Cocoa = Kaakaaoo
-Crab = Kharchang
-Citrus = Morakkabaat
-Truffles = Ghaarch
- # Requires translation!
-Strategic = 
- # Requires translation!
-Bonus = 
- # Requires translation!
-Luxury = 
-
-# Unit types
-
-City = Shahr
-Civilian = Shahrvand
-Melee = Nazdik-bord
-Ranged = Door-bord
- # Requires translation!
-Scout = 
-Mounted = Savaare
-Armor = Zereh
- # Requires translation!
-Siege = 
-
-WaterCivilian = Shahrvand
-WaterMelee = Nazdik-bord
-WaterRanged = Door-bord
-WaterSubmarine = Zirdaryaai
-WaterAircraftCarrier = Naav e havaapeymaa bar
-
- # Requires translation!
-Fighter = 
- # Requires translation!
-Bomber = 
- # Requires translation!
-AtomicBomber = 
-Missile = Mooshak
-
-
-# Unit filters and other unit related things
-
- # Requires translation!
-Air = 
-air units = Niroo haaye havaai 
- # Requires translation!
-Barbarian = 
- # Requires translation!
-Barbarians = 
- # Requires translation!
-Embarked = 
-land units = Niroo haaye zamini
- # Requires translation!
-Military = 
-# Deprecated since 3.15.2, but should still be translated until it is officially removed
- # Requires translation!
-military water = 
- # Requires translation!
-non-air = 
- # Requires translation!
-Nuclear Weapon = 
- # Requires translation!
-Submarine = 
- # Requires translation!
-submarine units = 
-Unbuildable = Gheyr e ghaabel e saakht
-water units = Niroo haaye daryaai
-wounded units = Niroo haa majrooh
- # Requires translation!
-Wounded = 
-
-# For the "All newly-trained [relevant] units in this city receive the [] promotion" translation. Relevant as in 'units that can receive'
- # Requires translation!
-relevant = 
-
-# For "May choose [amount] additional [beliefType] beliefs when [founding/enhancing] a religion"
- # Requires translation!
-founding = 
- # Requires translation!
-enhancing = 
 
 # Promotions
 
@@ -1770,6 +1626,7 @@ Pick promotion = Entekhaab e behsaazi
  OR  =  YAa 
 units in open terrain = Niroo haa dar zamin e hamvaar
 units in rough terrain = Niroo haa dar zamin e naahamvaar
+wounded units = Niroo haa majrooh
 Targeting II (air) = Neshaane giri 2
 Targeting III (air) = Neshaane giri 3
 Bonus when performing air sweep [bonusAmount]% = [bonusAmount]% komak hendaam defaa’e havaai
@@ -1931,6 +1788,11 @@ Never destroyed when the city is captured =
  # Requires translation!
 Invisible to others = 
 
+# Unused Resources
+
+Bison = Ghaav
+Cocoa = Kaakaaoo
+
 
 # In English we just paste all these conditionals at the end of each unique, but in your language that
 # may not turn into valid sentences. Therefore we have the following two translations to determine
@@ -1960,6 +1822,43 @@ ConditionalsPlacement =
 
 ########################### AUTOMATICALLY GENERATED TRANSLATABLE STRINGS ########################### 
 
+
+######### Map Unit Filters ###########
+
+ # Requires translation!
+Wounded = 
+ # Requires translation!
+Barbarians = 
+ # Requires translation!
+City-State = 
+ # Requires translation!
+Embarked = 
+ # Requires translation!
+Non-City = 
+
+######### Unit Type Filters ###########
+
+ # Requires translation!
+Military = 
+Civilian = Shahrvand
+ # Requires translation!
+non-air = 
+ # Requires translation!
+relevant = 
+ # Requires translation!
+Nuclear Weapon = 
+City = Shahr
+ # Requires translation!
+Air = 
+land units = Niroo haaye zamini
+water units = Niroo haaye daryaai
+air units = Niroo haaye havaai 
+ # Requires translation!
+military units = 
+ # Requires translation!
+submarine units = 
+ # Requires translation!
+Barbarian = 
 
 ######### City filters ###########
 
@@ -1996,6 +1895,88 @@ in City-State cities =
  # Requires translation!
 in cities following this religion = 
 
+######### Population Filters ###########
+
+ # Requires translation!
+Unemployed = 
+ # Requires translation!
+Followers of the Majority Religion = 
+ # Requires translation!
+Followers of this Religion = 
+
+######### Terrain Filters ###########
+
+ # Requires translation!
+All = 
+ # Requires translation!
+Coastal = 
+ # Requires translation!
+River = 
+ # Requires translation!
+Open terrain = 
+ # Requires translation!
+Rough terrain = 
+ # Requires translation!
+Water resource = 
+Foreign Land = Zamin e khaareji
+ # Requires translation!
+Foreign = 
+ # Requires translation!
+Friendly Land = 
+ # Requires translation!
+Enemy Land = 
+ # Requires translation!
+Featureless = 
+ # Requires translation!
+Fresh Water = 
+ # Requires translation!
+non-fresh water = 
+ # Requires translation!
+Natural Wonder = 
+Impassable = Gheyr e ghaabel e oboor
+Land = Zamin
+ # Requires translation!
+Water = 
+ # Requires translation!
+Luxury resource = 
+ # Requires translation!
+Strategic resource = 
+ # Requires translation!
+Bonus resource = 
+
+######### Tile Filters ###########
+
+ # Requires translation!
+unimproved = 
+ # Requires translation!
+All Road = 
+ # Requires translation!
+Great Improvement = 
+
+######### Region Types ###########
+
+ # Requires translation!
+Hybrid = 
+
+######### Terrain Quality ###########
+
+ # Requires translation!
+Undesirable = 
+ # Requires translation!
+Desirable = 
+
+######### Improvement Filters ###########
+
+ # Requires translation!
+Great = 
+
+######### Prophet Action Filters ###########
+
+ # Requires translation!
+founding = 
+ # Requires translation!
+enhancing = 
+
 ######### Unique Specials ###########
 
  # Requires translation!
@@ -2031,6 +2012,8 @@ Temple of Artemis =
 The Great Lighthouse = 
  # Requires translation!
 'They that go down to the sea in ships, that do business in great waters; these see the works of the Lord, and his wonders in the deep.' - The Bible, Psalms 107:23-24 = 
+ # Requires translation!
+for [mapUnitFilter] units = 
  # Requires translation!
 [amount] Movement = 
  # Requires translation!
@@ -2090,6 +2073,10 @@ Krepost = Gal’e
 Statue of Zeus = Mojasame ye Zeoos
  # Requires translation!
 'He spoke, the son of Kronos, and nodded his head with the dark brows, and the immortally anointed hair of the great god swept from his divine head, and all Olympos was shaken' - The Iliad = 
+ # Requires translation!
+vs cities = 
+ # Requires translation!
+when attacking = 
  # Requires translation!
 [amount]% Strength = 
 
@@ -2245,12 +2232,16 @@ Castle =
  # Requires translation!
 Mughal Fort = 
  # Requires translation!
+after discovering [tech] = 
+ # Requires translation!
 [stats] [cityFilter] = 
 
  # Requires translation!
 Himeji Castle = 
  # Requires translation!
 'Bushido is realized in the presence of death. This means choosing death whenever there is a choice between life and death. There is no other reasoning.' - Yamamoto Tsunetomo = 
+ # Requires translation!
+when fighting in [tileFilter] tiles = 
 
  # Requires translation!
 Ironworks = 
@@ -2416,6 +2407,8 @@ Pentagon =
  # Requires translation!
 Solar Plant = 
  # Requires translation!
+in cities without a [buildingFilter] = 
+ # Requires translation!
 Only available = 
 
  # Requires translation!
@@ -2467,6 +2460,8 @@ Era Starting Unit =
 
  # Requires translation!
 Emperor = 
+ # Requires translation!
+Scout = 
 
  # Requires translation!
 Immortal = 
@@ -2517,9 +2512,6 @@ Information era =
 
  # Requires translation!
 Future era = 
-
-
-#################### Lines from GlobalUniques from Civ V - Vanilla ####################
 
 
 #################### Lines from Nations from Civ V - Vanilla ####################
@@ -3174,6 +3166,8 @@ Bourges =
 Calais = 
  # Requires translation!
 France = 
+ # Requires translation!
+before discovering [tech] = 
 
  # Requires translation!
 Catherine = 
@@ -3280,7 +3274,7 @@ Double quantity of [resource] produced =
  # Requires translation!
 Augustus Caesar = 
  # Requires translation!
-My treasury contains little and my soldiers are getting impatient... ...therefore you must die. = 
+My treasury contains little and my soldiers are getting impatient... (sigh) ...therefore you must die. = 
  # Requires translation!
 So brave, yet so stupid! If only you had a brain similar to your courage. = 
  # Requires translation!
@@ -4324,6 +4318,8 @@ Patigrbana =
 Phrada = 
  # Requires translation!
 Persia = 
+ # Requires translation!
+during a Golden Age = 
 
  # Requires translation!
 Kamehameha I = 
@@ -4426,6 +4422,8 @@ Pileni =
 Nukumanu = 
  # Requires translation!
 Polynesia = 
+ # Requires translation!
+starting from the [era] = 
  # Requires translation!
 Enables embarkation for land units = 
  # Requires translation!
@@ -5327,6 +5325,8 @@ Oligarchy =
  # Requires translation!
 Units in cities cost no Maintenance = 
  # Requires translation!
+with a garrison = 
+ # Requires translation!
 [amount]% Strength for cities = 
  # Requires translation!
 Landed Elite = 
@@ -5365,6 +5365,8 @@ Warrior Code =
  # Requires translation!
 Discipline = 
  # Requires translation!
+when adjacent to a [mapUnitFilter] unit = 
+ # Requires translation!
 Military Tradition = 
  # Requires translation!
 [amount]% XP gained from combat = 
@@ -5376,6 +5378,8 @@ Professional Army =
 Honor Complete = 
  # Requires translation!
 Honor = 
+ # Requires translation!
+vs [mapUnitFilter] units = 
  # Requires translation!
 Notified of new Barbarian encampments = 
 
@@ -5397,6 +5401,8 @@ Free Religion =
 Piety Complete = 
  # Requires translation!
 Piety = 
+ # Requires translation!
+before adopting [policy] = 
 
  # Requires translation!
 Philantropy = 
@@ -5469,12 +5475,16 @@ Rationalism Complete =
  # Requires translation!
 Rationalism = 
  # Requires translation!
+while the empire is happy = 
+ # Requires translation!
 [amount]% [stat] = 
 
  # Requires translation!
 Constitution = 
  # Requires translation!
 Universal Suffrage = 
+ # Requires translation!
+when defending = 
  # Requires translation!
 Civil Society = 
  # Requires translation!
@@ -5508,6 +5518,8 @@ Police State =
 Total War = 
  # Requires translation!
 Autocracy Complete = 
+ # Requires translation!
+for [amount] turns = 
  # Requires translation!
 Autocracy = 
  # Requires translation!
@@ -5548,42 +5560,42 @@ We feel threatened by a Barbarian Camp near our city. Please take care of it. =
  # Requires translation!
 Connect Resource = 
  # Requires translation!
-In order to make our civilizations stronger, connect [param] to your trade network. = 
+In order to make our civilizations stronger, connect [tileResource] to your trade network. = 
 
  # Requires translation!
 Construct Wonder = 
  # Requires translation!
-We recommend you to start building [param] to show the whole world your civilization strength. = 
+We recommend you to start building [wonder] to show the whole world your civilization strength. = 
 
  # Requires translation!
 Acquire Great Person = 
  # Requires translation!
-Great People can change the course of a Civilization! You will be rewarded for acquiring a new [param]. = 
+Great People can change the course of a Civilization! You will be rewarded for acquiring a new [greatPerson]. = 
 
  # Requires translation!
 Conquer City State = 
  # Requires translation!
-It's time to erase the City-State of [param] from the map. You will be greatly rewarded for conquering them! = 
+It's time to erase the City-State of [cityState] from the map. You will be greatly rewarded for conquering them! = 
 
  # Requires translation!
 Find Player = 
  # Requires translation!
-You have yet to discover where [param] set up their cities. You will be rewarded for finding their territories. = 
+You have yet to discover where [civName] set up their cities. You will be rewarded for finding their territories. = 
 
  # Requires translation!
 Find Natural Wonder = 
  # Requires translation!
-Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [param] yet. = 
+Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [naturalWonder] yet. = 
 
  # Requires translation!
 Give Gold = 
  # Requires translation!
-We are suffering great poverty after being robbed by [param], and unless we receive a sum of Gold, it's only a matter of time before we collapse. = 
+We are suffering great poverty after being robbed by [civName], and unless we receive a sum of Gold, it's only a matter of time before we collapse. = 
 
  # Requires translation!
 Pledge to Protect = 
  # Requires translation!
-We need your protection to stop the aggressions of [param]. By signing a Pledge of Protection, you'll confirm the bond that ties us. = 
+We need your protection to stop the aggressions of [civName]. By signing a Pledge of Protection, you'll confirm the bond that ties us. = 
 
  # Requires translation!
 Contest Culture = 
@@ -5603,20 +5615,20 @@ The civilization with the largest number of new Technologies researched will gai
  # Requires translation!
 Invest = 
  # Requires translation!
-Our people are rejoicing thanks to a tourism boom. For a certain amount of time, any Gold donation will yield [amount]% extra Influence. = 
+Our people are rejoicing thanks to a tourism boom. For a certain amount of time, any Gold donation will yield [50]% extra Influence. = 
 
  # Requires translation!
 Bully City State = 
  # Requires translation!
-We are tired of the pretensions of [param]. If someone were to put them in their place by Demanding Tribute from them, they would be rewarded. = 
+We are tired of the pretensions of [cityState]. If someone were to put them in their place by Demanding Tribute from them, they would be rewarded. = 
 
  # Requires translation!
 Denounce Civilization = 
  # Requires translation!
-We have been forced to pay tribute to [param]! We need you to tell the world of their ill deeds. = 
+We have been forced to pay tribute to [civName]! We need you to tell the world of their ill deeds. = 
 
  # Requires translation!
-We have heard the tenets of [param] and are most curious. Will you send missionaries to teach us about your religion? = 
+We have heard the tenets of [religionName] and are most curious. Will you send missionaries to teach us about your religion? = 
 
 
 #################### Lines from Ruins from Civ V - Vanilla ####################
@@ -5638,12 +5650,12 @@ An ancient tribe trained us in their ways of combat! =
 your exploring unit receives training = 
 
  # Requires translation!
-We have found survivors in the ruins! Population added to [param]. = 
+We have found survivors in the ruins! Population added to [cityName]. = 
  # Requires translation!
 survivors (adds population to a city) = 
 
  # Requires translation!
-We have found a stash of [param] Gold in the ruins! = 
+We have found a stash of [goldAmount] Gold in the ruins! = 
  # Requires translation!
 a stash of gold = 
 
@@ -6038,6 +6050,8 @@ Desert =
 
  # Requires translation!
 Lakes = 
+ # Requires translation!
+Fresh water = 
 
  # Requires translation!
 Mountain = 
@@ -6070,6 +6084,8 @@ Jungle =
 
  # Requires translation!
 Marsh = 
+ # Requires translation!
+Rare feature = 
  # Requires translation!
 Only Polders can be built here = 
 
@@ -6373,6 +6389,9 @@ Porcelain =
 
  # Requires translation!
 Sword = 
+Mounted = Savaare
+ # Requires translation!
+Siege = 
  # Requires translation!
 Ranged Gunpowder = 
  # Requires translation!
@@ -6381,6 +6400,8 @@ Armored =
 Melee Water = 
  # Requires translation!
 Ranged Water = 
+ # Requires translation!
+Submarine = 
  # Requires translation!
 Heal Instantly = 
  # Requires translation!
@@ -6473,6 +6494,8 @@ All adjacent units heal [amount] HP when healing =
 
  # Requires translation!
 Medic II = 
+ # Requires translation!
+in [tileFilter] tiles = 
  # Requires translation!
 [amount] HP when healing = 
 
@@ -6567,6 +6590,8 @@ Supply =
 May heal outside of friendly territory = 
 
  # Requires translation!
+Bomber = 
+ # Requires translation!
 Siege I = 
 
  # Requires translation!
@@ -6580,6 +6605,8 @@ Evasion =
  # Requires translation!
 Damage taken from interception reduced by [amount]% = 
 
+ # Requires translation!
+Fighter = 
  # Requires translation!
 Interception I = 
  # Requires translation!
@@ -6724,6 +6751,7 @@ Can see over obstacles =
  # Requires translation!
 Atomic Bomber = 
 
+Missile = Mooshak
  # Requires translation!
 Self-destructs when attacking = 
  # Requires translation!
@@ -6731,6 +6759,25 @@ Cannot be intercepted =
 
  # Requires translation!
 Can pass through impassable tiles = 
+
+Melee = Nazdik-bord
+
+Ranged = Door-bord
+
+Armor = Zereh
+
+WaterCivilian = Shahrvand
+
+WaterMelee = Nazdik-bord
+
+WaterRanged = Door-bord
+
+WaterSubmarine = Zirdaryaai
+
+WaterAircraftCarrier = Naav e havaapeymaa bar
+
+ # Requires translation!
+AtomicBomber = 
 
 
 #################### Lines from Units from Civ V - Vanilla ####################
@@ -6849,6 +6896,8 @@ Camel Archer =
 
  # Requires translation!
 Conquistador = 
+ # Requires translation!
+on foreign continents = 
 
  # Requires translation!
 Naresuan's Elephant = 
@@ -6983,6 +7032,8 @@ Atomic Bomb = Bomb e haste i
  # Requires translation!
 Nuclear weapon of Strength [amount] = 
  # Requires translation!
+if [buildingName] is constructed = 
+ # Requires translation!
 Blast radius [amount] = 
 
  # Requires translation!
@@ -7035,6 +7086,7 @@ Can start an [amount]-turn golden age =
 Can construct [improvementName] = 
  # Requires translation!
 Great Person - [stat] = 
+Unbuildable = Gheyr e ghaabel e saakht
 
  # Requires translation!
 Great Scientist = 
@@ -7130,6 +7182,8 @@ Fertility Rites =
 
  # Requires translation!
 God of Craftsman = 
+ # Requires translation!
+in cities with at least [amount] [populationFilter] = 
 
  # Requires translation!
 God of the Open Sky = 
@@ -7210,6 +7264,8 @@ Guruship =
  # Requires translation!
 Holy Warriors = 
  # Requires translation!
+before the [era] = 
+ # Requires translation!
 May buy [baseUnitFilter] units with [stat] for [amount] times their normal Production cost = 
 
  # Requires translation!
@@ -7240,6 +7296,8 @@ Religious Community =
 
  # Requires translation!
 Swords into Ploughshares = 
+ # Requires translation!
+when not at war = 
 
  # Requires translation!
 Founder = 
@@ -7437,9 +7495,6 @@ Starting in this era disables religion =
 
 
 Marine = Daryaai
-
-
-#################### Lines from GlobalUniques from Civ V - Gods & Kings ####################
 
 
 #################### Lines from Nations from Civ V - Gods & Kings ####################
@@ -8063,6 +8118,8 @@ Falmouth =
 Lorient = 
  # Requires translation!
 Celts = 
+ # Requires translation!
+with [amount] to [amount2] neighboring [tileFilter] [tileFilter2] tiles = 
 
  # Requires translation!
 Haile Selassie = 
@@ -8150,6 +8207,8 @@ Ziway =
 Weldiya = 
  # Requires translation!
 Ethiopia = 
+ # Requires translation!
+when fighting units from a Civilization with more Cities than you = 
 
  # Requires translation!
 Pacal = 
@@ -8297,12 +8356,12 @@ Taoism =
 
 
  # Requires translation!
-We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[param] Faith) = 
+We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[faithAmount] Faith) = 
  # Requires translation!
 discover holy symbols = 
 
  # Requires translation!
-We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[param] Faith) = 
+We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[faithAmount] Faith) = 
  # Requires translation!
 an ancient prophecy = 
 
@@ -8382,8 +8441,16 @@ Polder =
 #################### Lines from TileResources from Civ V - Gods & Kings ####################
 
 
+Citrus = Morakkabaat
+
+Copper = Mes
+
+Crab = Kharchang
+
  # Requires translation!
 Salt = 
+
+Truffles = Ghaarch
 
 
 #################### Lines from UnitPromotions from Civ V - Gods & Kings ####################
@@ -8944,13 +9011,7 @@ Irremovable =
  # Requires translation!
 when at war = 
  # Requires translation!
-when not at war = 
- # Requires translation!
-during a Golden Age = 
- # Requires translation!
 with [resource] = 
- # Requires translation!
-while the empire is happy = 
  # Requires translation!
 when between [amount] and [amount2] Happiness = 
  # Requires translation!
@@ -8958,67 +9019,25 @@ when below [amount] Happiness =
  # Requires translation!
 during the [era] = 
  # Requires translation!
-before the [era] = 
- # Requires translation!
-starting from the [era] = 
- # Requires translation!
 if no other Civilization has researched this = 
- # Requires translation!
-after discovering [tech] = 
- # Requires translation!
-before discovering [tech] = 
  # Requires translation!
 upon discovering [tech] = 
  # Requires translation!
 after adopting [policy] = 
  # Requires translation!
-before adopting [policy] = 
- # Requires translation!
-if [buildingName] is constructed = 
- # Requires translation!
-for [amount] turns = 
- # Requires translation!
 by consuming this unit = 
  # Requires translation!
 in cities with a [buildingFilter] = 
  # Requires translation!
-in cities without a [buildingFilter] = 
- # Requires translation!
-in cities with at least [amount] [populationFilter] = 
- # Requires translation!
-with a garrison = 
- # Requires translation!
-for [mapUnitFilter] units = 
- # Requires translation!
 for units with [promotion] = 
  # Requires translation!
 for units without [promotion] = 
- # Requires translation!
-vs cities = 
- # Requires translation!
-vs [mapUnitFilter] units = 
- # Requires translation!
-when fighting units from a Civilization with more Cities than you = 
- # Requires translation!
-when attacking = 
- # Requires translation!
-when defending = 
- # Requires translation!
-when fighting in [tileFilter] tiles = 
- # Requires translation!
-on foreign continents = 
- # Requires translation!
-when adjacent to a [mapUnitFilter] unit = 
  # Requires translation!
 when above [amount] HP = 
  # Requires translation!
 when below [amount] HP = 
  # Requires translation!
 with [amount] to [amount2] neighboring [tileFilter] tiles = 
- # Requires translation!
-with [amount] to [amount2] neighboring [tileFilter] [tileFilter2] tiles = 
- # Requires translation!
-in [tileFilter] tiles = 
  # Requires translation!
 in [tileFilter] [tileFilter2] tiles = 
  # Requires translation!
@@ -9097,3 +9116,7 @@ CityState =
 ModOptions = 
  # Requires translation!
 Conditional = 
+
+#################### Removed Lines ####################
+
+#~~Rough Terrain = Zamin e naahamvaar

--- a/android/assets/jsons/translations/Polish.properties
+++ b/android/assets/jsons/translations/Polish.properties
@@ -1121,8 +1121,6 @@ or [terrainType] = lub [terrainType]
 Can be constructed by = Może być skonstruowane przez
 Defence bonus = Premia do obrony
 Movement cost = Koszt ruchu
-Open terrain = Otwarty Teren
-Rough Terrain = Trudny Teren
 for = dla
 Missing translations: = Brakujące tłumaczenia:
 Resolution = Rozdzielczość
@@ -1275,121 +1273,6 @@ Enhancing religion =
  # Requires translation!
 Enhanced religion = 
 
-# Terrains
-
-Impassable = Nie do przejścia
-Rare feature = Rzadka cecha
-
-# terrainFilters (so for uniques like: "[stats] from [terrainFilter] tiles")
-
- # Requires translation!
-All = 
-Water = Wodnych
-Land = Ląd
- # Requires translation!
-Coastal = 
-River = Rzeczne
-Rough terrain = Trudny teren
-Foreign Land = Obce Terytorium
- # Requires translation!
-Foreign = 
-Friendly Land = Przyjacielskie Terytorium
-Water resource = Źródła wody
- # Requires translation!
-Bonus resource = 
- # Requires translation!
-Luxury resource = 
- # Requires translation!
-Strategic resource = 
-Fresh water = Świeżej wody
-non-fresh water = Nieświeżej wody
- # Requires translation!
-Natural Wonder = 
- # Requires translation!
-Hybrid = 
- # Requires translation!
-Undesirable = 
- # Requires translation!
-Desirable = 
- # Requires translation!
-Featureless = 
- # Requires translation!
-Fresh Water = 
-
-# improvementFilters
-
- # Requires translation!
-All Road = 
-Great Improvement = Ulepszenie wielkiego człowieka
- # Requires translation!
-Great = 
-
-# Resources
-
-Bison = Bizony
-Copper = Miedź
-Cocoa = Kakao
-Crab = Kraby
-Citrus = Cytrusy
-Truffles = Trufle
-Strategic = Strategiczne
-Bonus = Bonusowe
-Luxury = Luksusowe
-
-# Unit types
-
-City = Miasto
-Civilian = cywilna
-Melee = Walcząca w zwarciu
-Ranged = Dystansowa
-Scout = Zwiadowca
-Mounted = Konna
-Armor = Pancerna
-Siege = Oblężenie
-
-WaterCivilian = wodna cywilna
-WaterMelee = Wodna walcząca w zwarciu
-WaterRanged = Wodna dystansowa
-WaterSubmarine = Okręt podwodny
-WaterAircraftCarrier = Lotniskowiec
-
-Fighter = Myśliwiec
-Bomber = Bombowiec
-AtomicBomber = Bombowiec Atomowy
-Missile = Pocisk
-
-
-# Unit filters and other unit related things
-
-Air = Powietrze
-air units = jednostka powietrzna
-Barbarian = Barbarzyńca
-Barbarians = Barbarzyńcy
-Embarked = Zaokrętowane
-land units = jednostka lądowa
-Military = wojsko
-# Deprecated since 3.15.2, but should still be translated until it is officially removed
- # Requires translation!
-military water = 
-non-air = lądowe
- # Requires translation!
-Nuclear Weapon = 
-Submarine = Okręt Podwodny
- # Requires translation!
-submarine units = 
-Unbuildable = Nie można zbudować
-water units = jednostka wodna
-wounded units = uszkodzone jednostki
-Wounded = Ranny
-
-# For the "All newly-trained [relevant] units in this city receive the [] promotion" translation. Relevant as in 'units that can receive'
-relevant = odpowiednie
-
-# For "May choose [amount] additional [beliefType] beliefs when [founding/enhancing] a religion"
- # Requires translation!
-founding = 
- # Requires translation!
-enhancing = 
 
 # Promotions
 
@@ -1397,6 +1280,7 @@ Pick promotion = Wybierz Awans
  OR  =  LUB  
 units in open terrain = jednostki w otwartym terenie
 units in rough terrain = jednostki w trudnym terenie
+wounded units = uszkodzone jednostki
 Targeting II (air) = Celowanie Lotnicze II
 Targeting III (air) = Celowanie Lotnicze III
 Bonus when performing air sweep [bonusAmount]% = Premia podczas czyszczenia niebia [bonusAmount]%
@@ -1531,6 +1415,11 @@ This Unit upgrades for free =
 Never destroyed when the city is captured = 
 Invisible to others = Niewidoczny dla innych
 
+# Unused Resources
+
+Bison = Bizony
+Cocoa = Kakao
+
 
 # In English we just paste all these conditionals at the end of each unique, but in your language that
 # may not turn into valid sentences. Therefore we have the following two translations to determine
@@ -1561,6 +1450,35 @@ ConditionalsPlacement =
 ########################### AUTOMATICALLY GENERATED TRANSLATABLE STRINGS ########################### 
 
 
+######### Map Unit Filters ###########
+
+Wounded = Ranny
+Barbarians = Barbarzyńcy
+ # Requires translation!
+City-State = 
+Embarked = Zaokrętowane
+ # Requires translation!
+Non-City = 
+
+######### Unit Type Filters ###########
+
+Military = wojsko
+Civilian = cywilna
+non-air = lądowe
+relevant = odpowiednie
+ # Requires translation!
+Nuclear Weapon = 
+City = Miasto
+Air = Powietrze
+land units = jednostka lądowa
+water units = jednostka wodna
+air units = jednostka powietrzna
+ # Requires translation!
+military units = 
+ # Requires translation!
+submarine units = 
+Barbarian = Barbarzyńca
+
 ######### City filters ###########
 
 in this city = w tym mieście
@@ -1580,6 +1498,80 @@ in annexed cities = w zaanektowanych miastach
 in holy cities = w świętych miastach
 in City-State cities = w miastach-państwach
 in cities following this religion = w miastach wyznających tą religię
+
+######### Population Filters ###########
+
+ # Requires translation!
+Unemployed = 
+ # Requires translation!
+Followers of the Majority Religion = 
+ # Requires translation!
+Followers of this Religion = 
+
+######### Terrain Filters ###########
+
+ # Requires translation!
+All = 
+ # Requires translation!
+Coastal = 
+River = Rzeczne
+Open terrain = Otwarty Teren
+Rough terrain = Trudny teren
+Water resource = Źródła wody
+Foreign Land = Obce Terytorium
+ # Requires translation!
+Foreign = 
+Friendly Land = Przyjacielskie Terytorium
+ # Requires translation!
+Enemy Land = 
+ # Requires translation!
+Featureless = 
+ # Requires translation!
+Fresh Water = 
+non-fresh water = Nieświeżej wody
+ # Requires translation!
+Natural Wonder = 
+Impassable = Nie do przejścia
+Land = Ląd
+Water = Wodnych
+ # Requires translation!
+Luxury resource = 
+ # Requires translation!
+Strategic resource = 
+ # Requires translation!
+Bonus resource = 
+
+######### Tile Filters ###########
+
+ # Requires translation!
+unimproved = 
+ # Requires translation!
+All Road = 
+Great Improvement = Ulepszenie wielkiego człowieka
+
+######### Region Types ###########
+
+ # Requires translation!
+Hybrid = 
+
+######### Terrain Quality ###########
+
+ # Requires translation!
+Undesirable = 
+ # Requires translation!
+Desirable = 
+
+######### Improvement Filters ###########
+
+ # Requires translation!
+Great = 
+
+######### Prophet Action Filters ###########
+
+ # Requires translation!
+founding = 
+ # Requires translation!
+enhancing = 
 
 ######### Unique Specials ###########
 
@@ -1611,6 +1603,7 @@ Temple of Artemis = Świątyna Artemisa
 
 The Great Lighthouse = Latarnia z Faros
 'They that go down to the sea in ships, that do business in great waters; these see the works of the Lord, and his wonders in the deep.' - The Bible, Psalms 107:23-24 = 'Ci, którzy na statkach ruszyli na morze, aby uprawiać handel na ogromnych wodach, ci widzieli dzieła Pana i jego cuda wśród głębiny.'– Biblia, Księga Psalmów 107,23-24
+for [mapUnitFilter] units = dla jednostek [mapUnitFilter]
  # Requires translation!
 [amount] Movement = 
  # Requires translation!
@@ -1664,6 +1657,8 @@ Krepost = Twierdza
 
 Statue of Zeus = Posąg Zeusa
 'He spoke, the son of Kronos, and nodded his head with the dark brows, and the immortally anointed hair of the great god swept from his divine head, and all Olympos was shaken' - The Iliad = 'Syn Kronosa przemówił i skinął głową z ciemnymi brwiami i na wieki namaszczone włosy wielkiego boga spłynęły z boskiej głowy, a cały Olimp zatrząsł się w posadach' - Iliada
+vs cities = przeciwko miastom
+when attacking = gdy atakuje
  # Requires translation!
 [amount]% Strength = 
 
@@ -1775,11 +1770,13 @@ Notre Dame = Notre Dame
 Castle = Zamek
 
 Mughal Fort = Fort Mogolski
+after discovering [tech] = po odkryciu [tech]
 [stats] [cityFilter] = [stats] [cityFilter]
 
 Himeji Castle = Zamek Himeji
  # Requires translation!
 'Bushido is realized in the presence of death. This means choosing death whenever there is a choice between life and death. There is no other reasoning.' - Yamamoto Tsunetomo = 
+when fighting in [tileFilter] tiles = gdy walczy na polach [tileFilter]
 
 Ironworks = Huta
 
@@ -1902,6 +1899,7 @@ Pentagon = Pentagon
 [amount]% Gold cost of upgrading = 
 
 Solar Plant = Elektrownia Słoneczna
+in cities without a [buildingFilter] = w miastach bez [buildingFilter]
  # Requires translation!
 Only available = 
 
@@ -1944,6 +1942,7 @@ King = Król
 Era Starting Unit = 
 
 Emperor = Imperator
+Scout = Zwiadowca
 
 Immortal = Nieśmiertelny
 Worker = Robotnik
@@ -1976,9 +1975,6 @@ Atomic era = Epoka atomu
 Information era = Epoka Informacyjna
 
 Future era = Przyszłość
-
-
-#################### Lines from GlobalUniques from Civ V - Vanilla ####################
 
 
 #################### Lines from Nations from Civ V - Vanilla ####################
@@ -2329,6 +2325,7 @@ La Rochelle = La Rochelle
 Bourges = Bourges
 Calais = Calais
 France = Francja
+before discovering [tech] = przed odkryciem [tech]
 
 Catherine = Katarzyna II
 You've behaved yourself very badly, you know it. Now it's payback time. = Zachowałeś się bardzo źle, wiesz o tym. Teraz jest czas na zemstę.
@@ -2386,7 +2383,7 @@ Double quantity of [resource] produced = Podwójna ilość surowca: [resource]
 
 Augustus Caesar = Oktawian August
  # Requires translation!
-My treasury contains little and my soldiers are getting impatient... ...therefore you must die. = 
+My treasury contains little and my soldiers are getting impatient... (sigh) ...therefore you must die. = 
 So brave, yet so stupid! If only you had a brain similar to your courage. = Taki odważny, ale taki głupi! Gdybyś tylko miał mózg podobny do twojej odwagi.
 The gods have deprived Rome of their favour. We have been defeated. = Bogowie pozbawili Rzym ich łaski. Zostaliśmy pokonani..
 I greet you. I am Augustus, Imperator and Pontifex Maximus of Rome. If you are a friend of Rome, you are welcome. = Witam was. Jestem Juliusz, Imperatorem i Pontyfikatem Maximusa z Rzymu. Jeśli jesteście przyjaciółmi Rzymu, jesteście mile widziani.
@@ -2941,6 +2938,7 @@ Paishiyauvada = Paishiyauvada
 Patigrbana = Patigrbana
 Phrada = Phrada
 Persia = Persja
+during a Golden Age = podczas Złotej Ery
 
 Kamehameha I = Kamehameha I
 The ancient fire flashing across the sky is what proclaimed that this day would come, though I had foolishly hoped for a different outcome. = Starożytny ogień podróżujący po niebie zapowiedział ten dzień, ale w swej głupocie wierzyłem, że będzie inaczej. Przygotuj się na zniszczenie, choć żyliśmy w przyjaźni.Starożytny ogień podróżujący po niebie zapowiedział ten dzień, ale w swej głupocie wierzyłem, że będzie inaczej. Przygotuj się na zniszczenie, choć żyliśmy w przyjaźni.
@@ -2995,6 +2993,7 @@ Nuguria = Nuguria
 Pileni = Pileni
 Nukumanu = Nukumanu
 Polynesia = Polinezja
+starting from the [era] = startując od [era]
 Enables embarkation for land units = Umożliwia jednostkom lądowym zaokrętowanie
  # Requires translation!
 Enables [mapUnitFilter] units to enter ocean tiles = 
@@ -3535,6 +3534,7 @@ Legalism = Legalizm
 Provides the cheapest [stat] building in your first [amount] cities for free = 
 Oligarchy = Oligarchia
 Units in cities cost no Maintenance = Utrzymanie garnizonów nic nie kosztuje
+with a garrison = z garnizonem
  # Requires translation!
 [amount]% Strength for cities = 
 Landed Elite = Właściciele Ziemscy
@@ -3560,6 +3560,7 @@ Liberty =
 
 Warrior Code = Kodeks Wojownika
 Discipline = Dyscyplina
+when adjacent to a [mapUnitFilter] unit = gdy przylega do jednostki [mapUnitFilter]
 Military Tradition = Tradycja Wojskowa
  # Requires translation!
 [amount]% XP gained from combat = 
@@ -3568,6 +3569,7 @@ Professional Army = Armia Zawodowa
 Honor Complete = Ukończony Honor
  # Requires translation!
 Honor = 
+vs [mapUnitFilter] units = przeciwko jednostkom [mapUnitFilter]
  # Requires translation!
 Notified of new Barbarian encampments = 
 
@@ -3583,6 +3585,7 @@ Free Religion = Tolerancja Religijna
 Piety Complete = Ukończona Pobożność
  # Requires translation!
 Piety = 
+before adopting [policy] = przed zaadaptowaniem [policy]
 
 Philantropy = Filantropia
  # Requires translation!
@@ -3639,11 +3642,13 @@ Rationalism Complete = Ukończony Racjonalizm
 [amount] Free Technologies = [amount] Darmowych technologii
  # Requires translation!
 Rationalism = 
+while the empire is happy = kiedy imperium jest szczęśliwe
  # Requires translation!
 [amount]% [stat] = 
 
 Constitution = Konstytucja
 Universal Suffrage = Powszechne Prawo Wyborcze
+when defending = gdy broni
 Civil Society = Społeczeństwo Obywatelskie
  # Requires translation!
 [amount]% Food consumption by specialists [cityFilter] = 
@@ -3667,6 +3672,7 @@ Quantity of strategic resources produced by the empire +[amount]% =
 Police State = Państwo Policyjne
 Total War = Wojna Absolutna
 Autocracy Complete = Ukończona Autokracja
+for [amount] turns = na [amount] tur
  # Requires translation!
 Autocracy = 
  # Requires translation!
@@ -3698,34 +3704,34 @@ Clear Barbarian Camp = Zniszcz Obóz Barbarzyńców
 We feel threatened by a Barbarian Camp near our city. Please take care of it. = Czujemy się zagrożeni przez Obóz Barbarzyńców niedaleko naszego miasta. Prosimy zajmij się tym.
 
 Connect Resource = Połącz Zasób
-In order to make our civilizations stronger, connect [param] to your trade network. = Aby cywilizacja rosła w siłę, dołącz [param] do twojej sieci handlowej.
+In order to make our civilizations stronger, connect [tileResource] to your trade network. = Aby cywilizacja rosła w siłę, dołącz [tileResource] do twojej sieci handlowej.
 
 Construct Wonder = Zbuduj Cud
-We recommend you to start building [param] to show the whole world your civilization strength. = Rekomendujemy zaczęcie budowania [param] aby pokazać całemu światu potęgę Twojej cywilizacji.
+We recommend you to start building [wonder] to show the whole world your civilization strength. = Rekomendujemy zaczęcie budowania [wonder] aby pokazać całemu światu potęgę Twojej cywilizacji.
 
 Acquire Great Person = Zdobądź Wspaniałą Osobę
-Great People can change the course of a Civilization! You will be rewarded for acquiring a new [param]. = Wspaniałe Osoby mogą zmienic kurs Cywilizacji! Będziesz wynagrodzony za zdobycie nowej [param]
+Great People can change the course of a Civilization! You will be rewarded for acquiring a new [greatPerson]. = Wspaniałe Osoby mogą zmienic kurs Cywilizacji! Będziesz wynagrodzony za zdobycie nowej [greatPerson]
 
  # Requires translation!
 Conquer City State = 
  # Requires translation!
-It's time to erase the City-State of [param] from the map. You will be greatly rewarded for conquering them! = 
+It's time to erase the City-State of [cityState] from the map. You will be greatly rewarded for conquering them! = 
 
 Find Player = Znajdź Gracza
-You have yet to discover where [param] set up their cities. You will be rewarded for finding their territories. = Musisz odkryć gdzie [param] zbudował swoje miasta. Będziesz wynagrodzony za zdobycie jego terytoriów.
+You have yet to discover where [civName] set up their cities. You will be rewarded for finding their territories. = Musisz odkryć gdzie [civName] zbudował swoje miasta. Będziesz wynagrodzony za zdobycie jego terytoriów.
 
 Find Natural Wonder = Znajdź Cud Natury
-Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [param] yet. = Wyślij swoich najlepszych odkrywców na misję odkrywania Cudów Natury. Nikt jeszcze nie zna lokalizacji [param].
+Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [naturalWonder] yet. = Wyślij swoich najlepszych odkrywców na misję odkrywania Cudów Natury. Nikt jeszcze nie zna lokalizacji [naturalWonder].
 
  # Requires translation!
 Give Gold = 
  # Requires translation!
-We are suffering great poverty after being robbed by [param], and unless we receive a sum of Gold, it's only a matter of time before we collapse. = 
+We are suffering great poverty after being robbed by [civName], and unless we receive a sum of Gold, it's only a matter of time before we collapse. = 
 
  # Requires translation!
 Pledge to Protect = 
  # Requires translation!
-We need your protection to stop the aggressions of [param]. By signing a Pledge of Protection, you'll confirm the bond that ties us. = 
+We need your protection to stop the aggressions of [civName]. By signing a Pledge of Protection, you'll confirm the bond that ties us. = 
 
  # Requires translation!
 Contest Culture = 
@@ -3745,20 +3751,20 @@ The civilization with the largest number of new Technologies researched will gai
  # Requires translation!
 Invest = 
  # Requires translation!
-Our people are rejoicing thanks to a tourism boom. For a certain amount of time, any Gold donation will yield [amount]% extra Influence. = 
+Our people are rejoicing thanks to a tourism boom. For a certain amount of time, any Gold donation will yield [50]% extra Influence. = 
 
  # Requires translation!
 Bully City State = 
  # Requires translation!
-We are tired of the pretensions of [param]. If someone were to put them in their place by Demanding Tribute from them, they would be rewarded. = 
+We are tired of the pretensions of [cityState]. If someone were to put them in their place by Demanding Tribute from them, they would be rewarded. = 
 
  # Requires translation!
 Denounce Civilization = 
  # Requires translation!
-We have been forced to pay tribute to [param]! We need you to tell the world of their ill deeds. = 
+We have been forced to pay tribute to [civName]! We need you to tell the world of their ill deeds. = 
 
  # Requires translation!
-We have heard the tenets of [param] and are most curious. Will you send missionaries to teach us about your religion? = 
+We have heard the tenets of [religionName] and are most curious. Will you send missionaries to teach us about your religion? = 
 
 
 #################### Lines from Ruins from Civ V - Vanilla ####################
@@ -3780,12 +3786,12 @@ An ancient tribe trained us in their ways of combat! =
 your exploring unit receives training = 
 
  # Requires translation!
-We have found survivors in the ruins! Population added to [param]. = 
+We have found survivors in the ruins! Population added to [cityName]. = 
  # Requires translation!
 survivors (adds population to a city) = 
 
  # Requires translation!
-We have found a stash of [param] Gold in the ruins! = 
+We have found a stash of [goldAmount] Gold in the ruins! = 
  # Requires translation!
 a stash of gold = 
 
@@ -4020,6 +4026,7 @@ Tundra = Tundra
 Desert = Pustynia
 
 Lakes = Jeziora
+Fresh water = Świeżej wody
 
 Mountain = Góra
  # Requires translation!
@@ -4045,6 +4052,7 @@ A Camp can be built here without cutting it down =
 Jungle = Dżungla
 
 Marsh = Mokradła
+Rare feature = Rzadka cecha
  # Requires translation!
 Only Polders can be built here = 
 
@@ -4260,6 +4268,8 @@ Porcelain = Porcelana
 
  # Requires translation!
 Sword = 
+Mounted = Konna
+Siege = Oblężenie
  # Requires translation!
 Ranged Gunpowder = 
  # Requires translation!
@@ -4268,6 +4278,7 @@ Armored =
 Melee Water = 
  # Requires translation!
 Ranged Water = 
+Submarine = Okręt Podwodny
 Heal Instantly = Natychmiastowe leczenie
  # Requires translation!
 Heal this unit by [amount] HP = 
@@ -4334,6 +4345,7 @@ Medic = Medyk I
 All adjacent units heal [amount] HP when healing = 
 
 Medic II = Medyk II
+in [tileFilter] tiles = na polach [tileFilter]
  # Requires translation!
 [amount] HP when healing = 
 
@@ -4404,6 +4416,7 @@ Supply =
  # Requires translation!
 May heal outside of friendly territory = 
 
+Bomber = Bombowiec
 Siege I = Oblężenie I
 
 Siege II = Oblężenie II
@@ -4414,6 +4427,7 @@ Evasion = Unik
  # Requires translation!
 Damage taken from interception reduced by [amount]% = 
 
+Fighter = Myśliwiec
 Interception I = Przechwytywanie I
  # Requires translation!
 [amount]% Damage when intercepting = 
@@ -4528,10 +4542,29 @@ Can see over obstacles =
 
 Atomic Bomber = Bombowiec Nuklearny
 
+Missile = Pocisk
 Self-destructs when attacking = Samozniszczenie podczas ataku
 Cannot be intercepted = Nie może zostać przechwycony
 
 Can pass through impassable tiles = Może przechodzić przez pola nie do przejścia
+
+Melee = Walcząca w zwarciu
+
+Ranged = Dystansowa
+
+Armor = Pancerna
+
+WaterCivilian = wodna cywilna
+
+WaterMelee = Wodna walcząca w zwarciu
+
+WaterRanged = Wodna dystansowa
+
+WaterSubmarine = Okręt podwodny
+
+WaterAircraftCarrier = Lotniskowiec
+
+AtomicBomber = Bombowiec Atomowy
 
 
 #################### Lines from Units from Civ V - Vanilla ####################
@@ -4613,6 +4646,7 @@ Knight = Rycerz
 Camel Archer = Łucznik Arabski
 
 Conquistador = Konkwistador
+on foreign continents = na obcych kontynentach
 
 Naresuan's Elephant = Słoń Naresuan
 
@@ -4705,6 +4739,7 @@ Anti-Tank Gun = Działo Przeciwpancerne
 Atomic Bomb = Bomba Atomowa
  # Requires translation!
 Nuclear weapon of Strength [amount] = 
+if [buildingName] is constructed = jeśli [buildingName] jest budowane
 Blast radius [amount] = Zasięg wybuchu [amount]
 
 Rocket Artillery = Artyleria Rakietowa
@@ -4742,6 +4777,7 @@ Great Artist = Wielki Artysta
 Can start an [amount]-turn golden age = Może rozpocząć [amount]-turowy Złoty Wiek
 Can construct [improvementName] = Może utworzyć [improvementName]
 Great Person - [stat] = Wielki Człowiek - [stat]
+Unbuildable = Nie można zbudować
 
 Great Scientist = Wielki Naukowiec
 Can hurry technology research = Może przyspieszyć badanie techologii
@@ -4816,6 +4852,8 @@ Fertility Rites =
 
  # Requires translation!
 God of Craftsman = 
+ # Requires translation!
+in cities with at least [amount] [populationFilter] = 
 
  # Requires translation!
 God of the Open Sky = 
@@ -4881,6 +4919,7 @@ Feed the World =
 Guruship = 
 
 Holy Warriors = Święci Wojownicy
+before the [era] = przed [era]
  # Requires translation!
 May buy [baseUnitFilter] units with [stat] for [amount] times their normal Production cost = 
 
@@ -4904,6 +4943,7 @@ Religious Community = Społeczność Religijna
 
  # Requires translation!
 Swords into Ploughshares = 
+when not at war = poza wojną
 
 Founder = Założyciel
  # Requires translation!
@@ -5083,9 +5123,6 @@ Starting in this era disables religion =
 
 
 Marine = Piechota Morska
-
-
-#################### Lines from GlobalUniques from Civ V - Gods & Kings ####################
 
 
 #################### Lines from Nations from Civ V - Gods & Kings ####################
@@ -5687,6 +5724,8 @@ Falmouth =
 Lorient = 
  # Requires translation!
 Celts = 
+ # Requires translation!
+with [amount] to [amount2] neighboring [tileFilter] [tileFilter2] tiles = 
 
  # Requires translation!
 Haile Selassie = 
@@ -5772,6 +5811,7 @@ Ziway =
  # Requires translation!
 Weldiya = 
 Ethiopia = Etiopia
+when fighting units from a Civilization with more Cities than you = gdy walczy z jednostkami Cywilizacji, która ma więcej miast niż ty
 
  # Requires translation!
 Pacal = 
@@ -5913,12 +5953,12 @@ Taoism = Taoizm
 
 
  # Requires translation!
-We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[param] Faith) = 
+We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[faithAmount] Faith) = 
  # Requires translation!
 discover holy symbols = 
 
  # Requires translation!
-We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[param] Faith) = 
+We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[faithAmount] Faith) = 
  # Requires translation!
 an ancient prophecy = 
 
@@ -5983,7 +6023,15 @@ Polder = Polder
 #################### Lines from TileResources from Civ V - Gods & Kings ####################
 
 
+Citrus = Cytrusy
+
+Copper = Miedź
+
+Crab = Kraby
+
 Salt = Sól
+
+Truffles = Trufle
 
 
 #################### Lines from UnitPromotions from Civ V - Gods & Kings ####################
@@ -6430,47 +6478,21 @@ No Sight =
 [amount] XP gained from combat = [amount] XP otrzymywanego z walki
 Irremovable = Nieusuwalne
 when at war = podczas wojny
-when not at war = poza wojną
-during a Golden Age = podczas Złotej Ery
 with [resource] = z [resource]
-while the empire is happy = kiedy imperium jest szczęśliwe
 when between [amount] and [amount2] Happiness = kiedy pomiędzy [amount] a [amount2] Szczęścia
 when below [amount] Happiness = kiedy poniżej [amount] Szczęścia
 during the [era] = podczas [era]
-before the [era] = przed [era]
-starting from the [era] = startując od [era]
 if no other Civilization has researched this = kiedy żadna inna Cywilizacja nie odkryła tego
-after discovering [tech] = po odkryciu [tech]
-before discovering [tech] = przed odkryciem [tech]
 upon discovering [tech] = po odkryciu [tech]
 after adopting [policy] = po zaadaptowaniu [policy]
-before adopting [policy] = przed zaadaptowaniem [policy]
-if [buildingName] is constructed = jeśli [buildingName] jest budowane
-for [amount] turns = na [amount] tur
 by consuming this unit = przez wykorzystanie tej jednostki
 in cities with a [buildingFilter] = w miastach z [buildingFilter]
-in cities without a [buildingFilter] = w miastach bez [buildingFilter]
- # Requires translation!
-in cities with at least [amount] [populationFilter] = 
-with a garrison = z garnizonem
-for [mapUnitFilter] units = dla jednostek [mapUnitFilter]
 for units with [promotion] = dla jednostek z [promotion]
 for units without [promotion] = dla jednostek bez [promotion]
-vs cities = przeciwko miastom
-vs [mapUnitFilter] units = przeciwko jednostkom [mapUnitFilter]
-when fighting units from a Civilization with more Cities than you = gdy walczy z jednostkami Cywilizacji, która ma więcej miast niż ty
-when attacking = gdy atakuje
-when defending = gdy broni
-when fighting in [tileFilter] tiles = gdy walczy na polach [tileFilter]
-on foreign continents = na obcych kontynentach
-when adjacent to a [mapUnitFilter] unit = gdy przylega do jednostki [mapUnitFilter]
 when above [amount] HP = gdy powyżej [amount] HP
 when below [amount] HP = gdy poniżej [amount] HP
  # Requires translation!
 with [amount] to [amount2] neighboring [tileFilter] tiles = 
- # Requires translation!
-with [amount] to [amount2] neighboring [tileFilter] [tileFilter2] tiles = 
-in [tileFilter] tiles = na polach [tileFilter]
 in [tileFilter] [tileFilter2] tiles = na polach [tileFilter] [tileFilter2]
 in tiles without [tileFilter] = na polach bez [tileFilter]
 on water maps = na mapach wodnych
@@ -6527,3 +6549,10 @@ Ruins = Ruiny
 CityState = Miasto-Państwo
 ModOptions = Ustawienia modyfikacji
 Conditional = Warunkowy
+
+#################### Removed Lines ####################
+
+#~~Rough Terrain = Trudny Teren
+#~~Strategic = Strategiczne
+#~~Bonus = Bonusowe
+#~~Luxury = Luksusowe

--- a/android/assets/jsons/translations/Portuguese.properties
+++ b/android/assets/jsons/translations/Portuguese.properties
@@ -1234,8 +1234,6 @@ or [terrainType] = ou [terrainType]
 Can be constructed by = Pode ser construído por
 Defence bonus = Bonus de defesa
 Movement cost = Custo de movimento
-Open terrain = Terreno aberto
-Rough Terrain = Terreno acidentado
 for = para
 Missing translations: = Traduções a faltar:
 Resolution = Resolução
@@ -1383,109 +1381,6 @@ Enhancing religion =
  # Requires translation!
 Enhanced religion = 
 
-# Terrains
-
-Impassable = Inacessível
-Rare feature = Característica rara
-
-# terrainFilters (so for uniques like: "[stats] from [terrainFilter] tiles")
-
-All = Tudo
-Water = Água
-Land = Terra
-Coastal = Litoral
-River = Rio
-Rough terrain = Terreno acidentado
-Foreign Land = Terra estrangeira
-Foreign = Estrangeiro
-Friendly Land = Terra Amigável 
-Water resource = Recursos hídricos
-Bonus resource = Recurso bónus
-Luxury resource = Recurso de luxo
-Strategic resource = Recurso estratégico
-Fresh water = Água fresca
-non-fresh water = Água não fresca
-Natural Wonder = Maravilha natural
- # Requires translation!
-Hybrid = 
- # Requires translation!
-Undesirable = 
- # Requires translation!
-Desirable = 
- # Requires translation!
-Featureless = 
- # Requires translation!
-Fresh Water = 
-
-# improvementFilters
-
-All Road = Toda a estrada
-Great Improvement = Boa melhoria
-Great = Bom
-
-# Resources
-
-Bison = Bisões
-Copper = Cobre
-Cocoa = Cacau
-Crab = Caranguejos
-Citrus = Cítrico
-Truffles = Trufas
-Strategic = Estratégico
-Bonus = Bónus
-Luxury = Luxo 
-
-# Unit types
-
-City = Cidade
-Civilian = Cidadão
-Melee = Corpo a corpo
-Ranged = Ataque a distância
-Scout = Explorador
-Mounted = Montado(a)
-Armor = Blindado
-Siege = Cerco
-
-WaterCivilian = Cidadão marítimo
-WaterMelee = Corpo a corpo marítimo
-WaterRanged = Ataque a distância marítima
-WaterSubmarine = Submarino
-WaterAircraftCarrier = Porta-aviões aquáticos
-
-Fighter = Avião de combate
-Bomber = Bombardeiro
-AtomicBomber = Bomba Atómica
-Missile = Míssel
-
-
-# Unit filters and other unit related things
-
-Air = Ar
-air units = Unidades aéreas
-Barbarian = Bárbaro
-Barbarians = Bárbaros
-Embarked = Embarcou
-land units = Unidades terrestres
-Military = militar
-# Deprecated since 3.15.2, but should still be translated until it is officially removed
-military water = água militar
-non-air = não aéreas
-Nuclear Weapon = Arma Núclear
-Submarine = Submarino
-submarine units = Submarinos
-Unbuildable = Não construível
-water units = Unidades marinhas
-wounded units = unidades feridas
-Wounded = Ferido
-
-# For the "All newly-trained [relevant] units in this city receive the [] promotion" translation. Relevant as in 'units that can receive'
-relevant = relevantes
-
-# For "May choose [amount] additional [beliefType] beliefs when [founding/enhancing] a religion"
- # Requires translation!
-founding = 
- # Requires translation!
-enhancing = 
 
 # Promotions
 
@@ -1493,6 +1388,7 @@ Pick promotion = Pegue uma promoção
  OR  =  OU 
 units in open terrain = unidades em terreno aberto
 units in rough terrain = unidades em terreno bruto
+wounded units = unidades feridas
 Targeting II (air) = Alvejamento Aéreo II
 Targeting III (air) = Alvejamento Aéreo III
 Bonus when performing air sweep [bonusAmount]% = [bonusAmount]% de bônus enquanto executa varredura áerea
@@ -1608,6 +1504,11 @@ This Unit upgrades for free = Esta unidade é atualizada gratuitamente
 Never destroyed when the city is captured = 
 Invisible to others = Invisível para outros
 
+# Unused Resources
+
+Bison = Bisões
+Cocoa = Cacau
+
 
 # In English we just paste all these conditionals at the end of each unique, but in your language that
 # may not turn into valid sentences. Therefore we have the following two translations to determine
@@ -1638,6 +1539,33 @@ ConditionalsPlacement =
 ########################### AUTOMATICALLY GENERATED TRANSLATABLE STRINGS ########################### 
 
 
+######### Map Unit Filters ###########
+
+Wounded = Ferido
+Barbarians = Bárbaros
+ # Requires translation!
+City-State = 
+Embarked = Embarcou
+ # Requires translation!
+Non-City = 
+
+######### Unit Type Filters ###########
+
+Military = militar
+Civilian = Cidadão
+non-air = não aéreas
+relevant = relevantes
+Nuclear Weapon = Arma Núclear
+City = Cidade
+Air = Ar
+land units = Unidades terrestres
+water units = Unidades marinhas
+air units = Unidades aéreas
+ # Requires translation!
+military units = 
+submarine units = Submarinos
+Barbarian = Bárbaro
+
 ######### City filters ###########
 
 in this city = nesta cidade
@@ -1664,6 +1592,71 @@ in holy cities =
 in City-State cities = 
  # Requires translation!
 in cities following this religion = 
+
+######### Population Filters ###########
+
+ # Requires translation!
+Unemployed = 
+ # Requires translation!
+Followers of the Majority Religion = 
+ # Requires translation!
+Followers of this Religion = 
+
+######### Terrain Filters ###########
+
+All = Tudo
+Coastal = Litoral
+River = Rio
+Open terrain = Terreno aberto
+Rough terrain = Terreno acidentado
+Water resource = Recursos hídricos
+Foreign Land = Terra estrangeira
+Foreign = Estrangeiro
+Friendly Land = Terra Amigável 
+ # Requires translation!
+Enemy Land = 
+ # Requires translation!
+Featureless = 
+ # Requires translation!
+Fresh Water = 
+non-fresh water = Água não fresca
+Natural Wonder = Maravilha natural
+Impassable = Inacessível
+Land = Terra
+Water = Água
+Luxury resource = Recurso de luxo
+Strategic resource = Recurso estratégico
+Bonus resource = Recurso bónus
+
+######### Tile Filters ###########
+
+ # Requires translation!
+unimproved = 
+All Road = Toda a estrada
+Great Improvement = Boa melhoria
+
+######### Region Types ###########
+
+ # Requires translation!
+Hybrid = 
+
+######### Terrain Quality ###########
+
+ # Requires translation!
+Undesirable = 
+ # Requires translation!
+Desirable = 
+
+######### Improvement Filters ###########
+
+Great = Bom
+
+######### Prophet Action Filters ###########
+
+ # Requires translation!
+founding = 
+ # Requires translation!
+enhancing = 
 
 ######### Unique Specials ###########
 
@@ -1696,6 +1689,8 @@ Temple of Artemis = Templo de Ártemis
 
 The Great Lighthouse = O Grande Farol
 'They that go down to the sea in ships, that do business in great waters; these see the works of the Lord, and his wonders in the deep.' - The Bible, Psalms 107:23-24 = 'Os navios que descem no mar, negociam em grandes águas; estes vêem as obras do Senhor, e suas maravilhas nas profundezas.' - A Bíblia, Salmos 107:23-24
+ # Requires translation!
+for [mapUnitFilter] units = 
 [amount] Movement = [amount] Movimento
  # Requires translation!
 [amount] Sight = 
@@ -1746,6 +1741,10 @@ Krepost = Fortaleza
 
 Statue of Zeus = Estátua de Zeus
 'He spoke, the son of Kronos, and nodded his head with the dark brows, and the immortally anointed hair of the great god swept from his divine head, and all Olympos was shaken' - The Iliad = 'Ele falou, o filho de Cronos, e acenou com a cabeça com as sobrancelhas escuras, e os cabelos imortalmente ungidos do grande deus foram arrancados da sua cabeça divina, e todo o Olimpo foi abalado' - A Ilíada
+ # Requires translation!
+vs cities = 
+ # Requires translation!
+when attacking = 
  # Requires translation!
 [amount]% Strength = 
 
@@ -1858,11 +1857,15 @@ Notre Dame = Notre Dame
 Castle = Castelo
 
 Mughal Fort = Forte de Mughal
+ # Requires translation!
+after discovering [tech] = 
 [stats] [cityFilter] = [stats] [cityFilter]
 
 Himeji Castle = Castelo Himeji
  # Requires translation!
 'Bushido is realized in the presence of death. This means choosing death whenever there is a choice between life and death. There is no other reasoning.' - Yamamoto Tsunetomo = 
+ # Requires translation!
+when fighting in [tileFilter] tiles = 
 
 Ironworks = Siderurgia
 
@@ -1982,6 +1985,8 @@ Pentagon = Pentágono
 
 Solar Plant = Planta Solar
  # Requires translation!
+in cities without a [buildingFilter] = 
+ # Requires translation!
 Only available = 
 
 Nuclear Plant = Planta Nuclear
@@ -2016,6 +2021,7 @@ King = Rei
 Era Starting Unit = Unidade da Era Inicial
 
 Emperor = Imperador
+Scout = Explorador
 
 Immortal = Imortal
 Worker = Trabalhador
@@ -2048,9 +2054,6 @@ Atomic era = Era atómica
 Information era = Era da Informação
 
 Future era = Era futurista
-
-
-#################### Lines from GlobalUniques from Civ V - Vanilla ####################
 
 
 #################### Lines from Nations from Civ V - Vanilla ####################
@@ -2389,6 +2392,8 @@ La Rochelle = La Rochelle
 Bourges = Burges
 Calais = Calais
 France = França
+ # Requires translation!
+before discovering [tech] = 
 
 Catherine = Catarina
 You've behaved yourself very badly, you know it. Now it's payback time. = Comportaste-te muito mal, sabes disso. Agora é a hora da vingança.
@@ -2444,7 +2449,7 @@ Double quantity of [resource] produced = Quantidade dupla de [resource] produzid
 
 Augustus Caesar = César Augusto
  # Requires translation!
-My treasury contains little and my soldiers are getting impatient... ...therefore you must die. = 
+My treasury contains little and my soldiers are getting impatient... (sigh) ...therefore you must die. = 
 So brave, yet so stupid! If only you had a brain similar to your courage. = Tão corajoso, mas tão estúpido! Se ao menos tivesses um cérebro semelhante à tua coragem.
 The gods have deprived Rome of their favour. We have been defeated. = Os deuses privaram a Roma do seu favor. Fomos derrotados.
 I greet you. I am Augustus, Imperator and Pontifex Maximus of Rome. If you are a friend of Rome, you are welcome. = Eu saúdo-te. Sou Augusto, Imperador e Pontífice Máximo de Roma. Se és amigo de Roma, sê bem-vindo.
@@ -3166,6 +3171,8 @@ Patigrbana =
  # Requires translation!
 Phrada = 
 Persia = Pérsia
+ # Requires translation!
+during a Golden Age = 
 
  # Requires translation!
 Kamehameha I = 
@@ -3267,6 +3274,8 @@ Pileni =
  # Requires translation!
 Nukumanu = 
 Polynesia = Polinésia
+ # Requires translation!
+starting from the [era] = 
 Enables embarkation for land units = Permite o embarque de unidades terrestres
  # Requires translation!
 Enables [mapUnitFilter] units to enter ocean tiles = 
@@ -4084,6 +4093,8 @@ Provides the cheapest [stat] building in your first [amount] cities for free =
 Oligarchy = Oligarquia
 Units in cities cost no Maintenance = As unidades nas cidades não custam manutenção
  # Requires translation!
+with a garrison = 
+ # Requires translation!
 [amount]% Strength for cities = 
 Landed Elite = Elite aterrisada
  # Requires translation!
@@ -4108,6 +4119,8 @@ Liberty =
 
 Warrior Code = Código de Honra
 Discipline = Disciplina
+ # Requires translation!
+when adjacent to a [mapUnitFilter] unit = 
 Military Tradition = Tradição militar
  # Requires translation!
 [amount]% XP gained from combat = 
@@ -4116,6 +4129,8 @@ Professional Army = Exército Profissional
 Honor Complete = Honra Completa
  # Requires translation!
 Honor = 
+ # Requires translation!
+vs [mapUnitFilter] units = 
  # Requires translation!
 Notified of new Barbarian encampments = 
 
@@ -4131,6 +4146,8 @@ Free Religion = Liberdade de Religião
 Piety Complete = Piedade Completa
  # Requires translation!
 Piety = 
+ # Requires translation!
+before adopting [policy] = 
 
 Philantropy = Filantropia
 Gifts of Gold to City-States generate [amount]% more Influence = Presentes de ouro para cidades-estados geram [amount]% mais influência
@@ -4180,10 +4197,14 @@ Rationalism Complete = Racionalismo Completo
  # Requires translation!
 Rationalism = 
  # Requires translation!
+while the empire is happy = 
+ # Requires translation!
 [amount]% [stat] = 
 
 Constitution = Constituição
 Universal Suffrage = Sufrágio Universal
+ # Requires translation!
+when defending = 
 Civil Society = Sociedade Civil
  # Requires translation!
 [amount]% Food consumption by specialists [cityFilter] = 
@@ -4207,6 +4228,8 @@ Quantity of strategic resources produced by the empire +[amount]% =
 Police State = Estado de Polícia
 Total War = Guerra Total
 Autocracy Complete = Autocracia Completa
+ # Requires translation!
+for [amount] turns = 
  # Requires translation!
 Autocracy = 
  # Requires translation!
@@ -4237,34 +4260,34 @@ Clear Barbarian Camp = Limpa um Campo Bárbaro
 We feel threatened by a Barbarian Camp near our city. Please take care of it. = Sentimo-nos ameaçados por um acampamento bárbaro perto da nossa cidade. Por favor, cuida dele.
 
 Connect Resource = Conecta um Recurso
-In order to make our civilizations stronger, connect [param] to your trade network. = Para tornar as nossas civilizações mais fortes, conecta um [param] à tua rede de comércio.
+In order to make our civilizations stronger, connect [tileResource] to your trade network. = Para tornar as nossas civilizações mais fortes, conecta um [tileResource] à tua rede de comércio.
 
 Construct Wonder = Constroi uma Maravilha
-We recommend you to start building [param] to show the whole world your civilization strength. = Recomendamos que comeces a construir uma [param] para mostrar ao mundo inteiro a força da tua civilização.
+We recommend you to start building [wonder] to show the whole world your civilization strength. = Recomendamos que comeces a construir uma [wonder] para mostrar ao mundo inteiro a força da tua civilização.
 
 Acquire Great Person = Consegue uma Pessoa Experiente
-Great People can change the course of a Civilization! You will be rewarded for acquiring a new [param]. = As Pessoas Experientes podem mudar o curso de uma civilização! Serás recompensado por conseguires uma nova [param].
+Great People can change the course of a Civilization! You will be rewarded for acquiring a new [greatPerson]. = As Pessoas Experientes podem mudar o curso de uma civilização! Serás recompensado por conseguires uma nova [greatPerson].
 
  # Requires translation!
 Conquer City State = 
  # Requires translation!
-It's time to erase the City-State of [param] from the map. You will be greatly rewarded for conquering them! = 
+It's time to erase the City-State of [cityState] from the map. You will be greatly rewarded for conquering them! = 
 
 Find Player = Encontrar jogador
-You have yet to discover where [param] set up their cities. You will be rewarded for finding their territories. = Ainda não descobriste onde os [param] estabeleceram as suas cidades. Serás recompensado por encontrar os seus territórios
+You have yet to discover where [civName] set up their cities. You will be rewarded for finding their territories. = Ainda não descobriste onde os [civName] estabeleceram as suas cidades. Serás recompensado por encontrar os seus territórios
 
 Find Natural Wonder = Encontra uma Maravilha Natural
-Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [param] yet. = Envia os teus melhores exploradores numa missão para descobrir as maravilhas naturais. Ninguém sabe a localização de [param] ainda.
+Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [naturalWonder] yet. = Envia os teus melhores exploradores numa missão para descobrir as maravilhas naturais. Ninguém sabe a localização de [naturalWonder] ainda.
 
  # Requires translation!
 Give Gold = 
  # Requires translation!
-We are suffering great poverty after being robbed by [param], and unless we receive a sum of Gold, it's only a matter of time before we collapse. = 
+We are suffering great poverty after being robbed by [civName], and unless we receive a sum of Gold, it's only a matter of time before we collapse. = 
 
  # Requires translation!
 Pledge to Protect = 
  # Requires translation!
-We need your protection to stop the aggressions of [param]. By signing a Pledge of Protection, you'll confirm the bond that ties us. = 
+We need your protection to stop the aggressions of [civName]. By signing a Pledge of Protection, you'll confirm the bond that ties us. = 
 
  # Requires translation!
 Contest Culture = 
@@ -4284,20 +4307,20 @@ The civilization with the largest number of new Technologies researched will gai
  # Requires translation!
 Invest = 
  # Requires translation!
-Our people are rejoicing thanks to a tourism boom. For a certain amount of time, any Gold donation will yield [amount]% extra Influence. = 
+Our people are rejoicing thanks to a tourism boom. For a certain amount of time, any Gold donation will yield [50]% extra Influence. = 
 
  # Requires translation!
 Bully City State = 
  # Requires translation!
-We are tired of the pretensions of [param]. If someone were to put them in their place by Demanding Tribute from them, they would be rewarded. = 
+We are tired of the pretensions of [cityState]. If someone were to put them in their place by Demanding Tribute from them, they would be rewarded. = 
 
  # Requires translation!
 Denounce Civilization = 
  # Requires translation!
-We have been forced to pay tribute to [param]! We need you to tell the world of their ill deeds. = 
+We have been forced to pay tribute to [civName]! We need you to tell the world of their ill deeds. = 
 
  # Requires translation!
-We have heard the tenets of [param] and are most curious. Will you send missionaries to teach us about your religion? = 
+We have heard the tenets of [religionName] and are most curious. Will you send missionaries to teach us about your religion? = 
 
 
 #################### Lines from Ruins from Civ V - Vanilla ####################
@@ -4319,12 +4342,12 @@ An ancient tribe trained us in their ways of combat! =
 your exploring unit receives training = 
 
  # Requires translation!
-We have found survivors in the ruins! Population added to [param]. = 
+We have found survivors in the ruins! Population added to [cityName]. = 
  # Requires translation!
 survivors (adds population to a city) = 
 
  # Requires translation!
-We have found a stash of [param] Gold in the ruins! = 
+We have found a stash of [goldAmount] Gold in the ruins! = 
  # Requires translation!
 a stash of gold = 
 
@@ -4604,6 +4627,7 @@ Tundra = Tundra
 Desert = Deserto
 
 Lakes = Lagos
+Fresh water = Água fresca
 
 Mountain = Montanhas
  # Requires translation!
@@ -4630,6 +4654,7 @@ A Camp can be built here without cutting it down =
 Jungle = Selva
 
 Marsh = Pântano
+Rare feature = Característica rara
  # Requires translation!
 Only Polders can be built here = 
 
@@ -4860,6 +4885,8 @@ Porcelain =
 
  # Requires translation!
 Sword = 
+Mounted = Montado(a)
+Siege = Cerco
  # Requires translation!
 Ranged Gunpowder = 
  # Requires translation!
@@ -4868,6 +4895,7 @@ Armored =
 Melee Water = 
  # Requires translation!
 Ranged Water = 
+Submarine = Submarino
 Heal Instantly = Cura Instantânea
  # Requires translation!
 Heal this unit by [amount] HP = 
@@ -4934,6 +4962,8 @@ Medic = Médico I
 All adjacent units heal [amount] HP when healing = 
 
 Medic II = Médico II
+ # Requires translation!
+in [tileFilter] tiles = 
  # Requires translation!
 [amount] HP when healing = 
 
@@ -5002,6 +5032,7 @@ Supply =
  # Requires translation!
 May heal outside of friendly territory = 
 
+Bomber = Bombardeiro
 Siege I = Cerco Aéreo I
 
 Siege II = Cerco Aéreo II
@@ -5012,6 +5043,7 @@ Evasion = Evasão
  # Requires translation!
 Damage taken from interception reduced by [amount]% = 
 
+Fighter = Avião de combate
 Interception I = Interceptação I
  # Requires translation!
 [amount]% Damage when intercepting = 
@@ -5130,12 +5162,31 @@ Can see over obstacles =
  # Requires translation!
 Atomic Bomber = 
 
+Missile = Míssel
 Self-destructs when attacking = Autodestrói-se ao atacar
  # Requires translation!
 Cannot be intercepted = 
 
  # Requires translation!
 Can pass through impassable tiles = 
+
+Melee = Corpo a corpo
+
+Ranged = Ataque a distância
+
+Armor = Blindado
+
+WaterCivilian = Cidadão marítimo
+
+WaterMelee = Corpo a corpo marítimo
+
+WaterRanged = Ataque a distância marítima
+
+WaterSubmarine = Submarino
+
+WaterAircraftCarrier = Porta-aviões aquáticos
+
+AtomicBomber = Bomba Atómica
 
 
 #################### Lines from Units from Civ V - Vanilla ####################
@@ -5223,6 +5274,8 @@ Knight = Cavaleiro
 Camel Archer = Arqueiro de camelo
 
 Conquistador = Conquistador
+ # Requires translation!
+on foreign continents = 
 
 Naresuan's Elephant = Elefante de Naresuan
 
@@ -5317,6 +5370,8 @@ Anti-Tank Gun = Arma anti-tanque
 
 Atomic Bomb = Bomba Atômica
 Nuclear weapon of Strength [amount] = Arma nuclear de Força [amount]
+ # Requires translation!
+if [buildingName] is constructed = 
 Blast radius [amount] = Raio da explosão [amount]
 
 Rocket Artillery = Artilharia de foguetes
@@ -5354,6 +5409,7 @@ Great Artist = Grande Artista
 Can start an [amount]-turn golden age = Podes começar uma era de ouro de [amount]
 Can construct [improvementName] = Podes construir [improvementName]
 Great Person - [stat] = Pessoa Experiente - [stat]
+Unbuildable = Não construível
 
 Great Scientist = Grande Cientista
 Can hurry technology research = Pode apressar pesquisa tecnológica
@@ -5423,6 +5479,8 @@ Faith Healers = Curandeiros da fé
 Fertility Rites = Ritos de fertilidade
 
 God of Craftsman = Deus do artesão
+ # Requires translation!
+in cities with at least [amount] [populationFilter] = 
 
 God of the Open Sky = Deus do céu aberto
 
@@ -5478,6 +5536,8 @@ Guruship =
  # Requires translation!
 Holy Warriors = 
  # Requires translation!
+before the [era] = 
+ # Requires translation!
 May buy [baseUnitFilter] units with [stat] for [amount] times their normal Production cost = 
 
 Liturgical Drama = Drama Litúrgico
@@ -5498,6 +5558,8 @@ Religious Community = Comunidade Religiosa
 [amount]% [stat] from every follower, up to [amount2]% = [amount]% [stat] de cada seguidor, até [amount2]%
 
 Swords into Ploughshares = Espadas em relhas de arado
+ # Requires translation!
+when not at war = 
 
 Founder = Fundador
 Ceremonial Burial = Enterro Cerimonial
@@ -5671,9 +5733,6 @@ Starting in this era disables religion =
 
 
 Marine = Náutico
-
-
-#################### Lines from GlobalUniques from Civ V - Gods & Kings ####################
 
 
 #################### Lines from Nations from Civ V - Gods & Kings ####################
@@ -6295,6 +6354,8 @@ Falmouth =
 Lorient = 
  # Requires translation!
 Celts = 
+ # Requires translation!
+with [amount] to [amount2] neighboring [tileFilter] [tileFilter2] tiles = 
 
  # Requires translation!
 Haile Selassie = 
@@ -6382,6 +6443,8 @@ Ziway =
 Weldiya = 
  # Requires translation!
 Ethiopia = 
+ # Requires translation!
+when fighting units from a Civilization with more Cities than you = 
 
  # Requires translation!
 Pacal = 
@@ -6529,12 +6592,12 @@ Taoism =
 
 
  # Requires translation!
-We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[param] Faith) = 
+We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[faithAmount] Faith) = 
  # Requires translation!
 discover holy symbols = 
 
  # Requires translation!
-We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[param] Faith) = 
+We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[faithAmount] Faith) = 
  # Requires translation!
 an ancient prophecy = 
 
@@ -6606,8 +6669,16 @@ Polder =
 #################### Lines from TileResources from Civ V - Gods & Kings ####################
 
 
+Citrus = Cítrico
+
+Copper = Cobre
+
+Crab = Caranguejos
+
  # Requires translation!
 Salt = 
+
+Truffles = Trufas
 
 
 #################### Lines from UnitPromotions from Civ V - Gods & Kings ####################
@@ -7056,13 +7127,7 @@ Irremovable =
  # Requires translation!
 when at war = 
  # Requires translation!
-when not at war = 
- # Requires translation!
-during a Golden Age = 
- # Requires translation!
 with [resource] = 
- # Requires translation!
-while the empire is happy = 
  # Requires translation!
 when between [amount] and [amount2] Happiness = 
  # Requires translation!
@@ -7070,67 +7135,25 @@ when below [amount] Happiness =
  # Requires translation!
 during the [era] = 
  # Requires translation!
-before the [era] = 
- # Requires translation!
-starting from the [era] = 
- # Requires translation!
 if no other Civilization has researched this = 
- # Requires translation!
-after discovering [tech] = 
- # Requires translation!
-before discovering [tech] = 
  # Requires translation!
 upon discovering [tech] = 
  # Requires translation!
 after adopting [policy] = 
  # Requires translation!
-before adopting [policy] = 
- # Requires translation!
-if [buildingName] is constructed = 
- # Requires translation!
-for [amount] turns = 
- # Requires translation!
 by consuming this unit = 
  # Requires translation!
 in cities with a [buildingFilter] = 
  # Requires translation!
-in cities without a [buildingFilter] = 
- # Requires translation!
-in cities with at least [amount] [populationFilter] = 
- # Requires translation!
-with a garrison = 
- # Requires translation!
-for [mapUnitFilter] units = 
- # Requires translation!
 for units with [promotion] = 
  # Requires translation!
 for units without [promotion] = 
- # Requires translation!
-vs cities = 
- # Requires translation!
-vs [mapUnitFilter] units = 
- # Requires translation!
-when fighting units from a Civilization with more Cities than you = 
- # Requires translation!
-when attacking = 
- # Requires translation!
-when defending = 
- # Requires translation!
-when fighting in [tileFilter] tiles = 
- # Requires translation!
-on foreign continents = 
- # Requires translation!
-when adjacent to a [mapUnitFilter] unit = 
  # Requires translation!
 when above [amount] HP = 
  # Requires translation!
 when below [amount] HP = 
  # Requires translation!
 with [amount] to [amount2] neighboring [tileFilter] tiles = 
- # Requires translation!
-with [amount] to [amount2] neighboring [tileFilter] [tileFilter2] tiles = 
- # Requires translation!
-in [tileFilter] tiles = 
  # Requires translation!
 in [tileFilter] [tileFilter2] tiles = 
  # Requires translation!
@@ -7209,3 +7232,11 @@ CityState =
 ModOptions = 
  # Requires translation!
 Conditional = 
+
+#################### Removed Lines ####################
+
+#~~Rough Terrain = Terreno acidentado
+#~~Strategic = Estratégico
+#~~Bonus = Bónus
+#~~Luxury = Luxo 
+#~~military water = água militar

--- a/android/assets/jsons/translations/Romanian.properties
+++ b/android/assets/jsons/translations/Romanian.properties
@@ -1274,10 +1274,6 @@ or [terrainType] =
 Can be constructed by = 
 Defence bonus = Bonus de apărare
 Movement cost = Cost de deplasare
- # Requires translation!
-Open terrain = 
- # Requires translation!
-Rough Terrain = 
 for = pentru
 Missing translations: = Traduceri lipsă:
 Resolution = Rezoluție
@@ -1489,149 +1485,6 @@ Enhancing religion =
  # Requires translation!
 Enhanced religion = 
 
-# Terrains
-
-Impassable = Inaccesibil
- # Requires translation!
-Rare feature = 
-
-# terrainFilters (so for uniques like: "[stats] from [terrainFilter] tiles")
-
- # Requires translation!
-All = 
- # Requires translation!
-Water = 
-Land = Teren
- # Requires translation!
-Coastal = 
- # Requires translation!
-River = 
- # Requires translation!
-Rough terrain = 
- # Requires translation!
-Foreign Land = 
- # Requires translation!
-Foreign = 
- # Requires translation!
-Friendly Land = 
- # Requires translation!
-Water resource = 
- # Requires translation!
-Bonus resource = 
- # Requires translation!
-Luxury resource = 
- # Requires translation!
-Strategic resource = 
- # Requires translation!
-Fresh water = 
- # Requires translation!
-non-fresh water = 
- # Requires translation!
-Natural Wonder = 
- # Requires translation!
-Hybrid = 
- # Requires translation!
-Undesirable = 
- # Requires translation!
-Desirable = 
- # Requires translation!
-Featureless = 
- # Requires translation!
-Fresh Water = 
-
-# improvementFilters
-
- # Requires translation!
-All Road = 
- # Requires translation!
-Great Improvement = 
- # Requires translation!
-Great = 
-
-# Resources
-
-Bison = Bizon
-Copper = Cupru
-Cocoa = Cacao
-Crab = Crab
-Citrus = Citrus
-Truffles = Trufe
- # Requires translation!
-Strategic = 
- # Requires translation!
-Bonus = 
- # Requires translation!
-Luxury = 
-
-# Unit types
-
-City = Oraș
-Civilian = Civil
-Melee = Luptător de contact
-Ranged = Luptător la distanță
-Scout = Explorator
-Mounted = Luptător călare
-Armor = Armură
- # Requires translation!
-Siege = 
-
- # Requires translation!
-WaterCivilian = 
- # Requires translation!
-WaterMelee = 
- # Requires translation!
-WaterRanged = 
-WaterSubmarine = Submarin
- # Requires translation!
-WaterAircraftCarrier = 
-
-Fighter = Avion de vânătoare
-Bomber = Bombardier
- # Requires translation!
-AtomicBomber = 
- # Requires translation!
-Missile = 
-
-
-# Unit filters and other unit related things
-
- # Requires translation!
-Air = 
-air units = unități aeriene
- # Requires translation!
-Barbarian = 
-Barbarians = Barbari
- # Requires translation!
-Embarked = 
-land units = unități terestre
- # Requires translation!
-Military = 
-# Deprecated since 3.15.2, but should still be translated until it is officially removed
- # Requires translation!
-military water = 
- # Requires translation!
-non-air = 
- # Requires translation!
-Nuclear Weapon = 
-Submarine = Submarin
- # Requires translation!
-submarine units = 
- # Requires translation!
-Unbuildable = 
-water units = unități acvatice
-wounded units = unități rănite
- # Requires translation!
-Wounded = 
-
-# For the "All newly-trained [relevant] units in this city receive the [] promotion" translation. Relevant as in 'units that can receive'
- # Requires translation!
-relevant = 
-
-# For "May choose [amount] additional [beliefType] beliefs when [founding/enhancing] a religion"
- # Requires translation!
-founding = 
- # Requires translation!
-enhancing = 
 
 # Promotions
 
@@ -1639,6 +1492,7 @@ Pick promotion = Alege o promovare
  OR  =  SAU 
 units in open terrain = unități pe terent deschis
 units in rough terrain = unități pe teren accidentat
+wounded units = unități rănite
  # Requires translation!
 Targeting II (air) = 
  # Requires translation!
@@ -1812,6 +1666,11 @@ This Unit upgrades for free =
 Never destroyed when the city is captured = 
 Invisible to others = Invizibil pentru alții
 
+# Unused Resources
+
+Bison = Bizon
+Cocoa = Cacao
+
 
 # In English we just paste all these conditionals at the end of each unique, but in your language that
 # may not turn into valid sentences. Therefore we have the following two translations to determine
@@ -1841,6 +1700,42 @@ ConditionalsPlacement =
 
 ########################### AUTOMATICALLY GENERATED TRANSLATABLE STRINGS ########################### 
 
+
+######### Map Unit Filters ###########
+
+ # Requires translation!
+Wounded = 
+Barbarians = Barbari
+ # Requires translation!
+City-State = 
+ # Requires translation!
+Embarked = 
+ # Requires translation!
+Non-City = 
+
+######### Unit Type Filters ###########
+
+ # Requires translation!
+Military = 
+Civilian = Civil
+ # Requires translation!
+non-air = 
+ # Requires translation!
+relevant = 
+ # Requires translation!
+Nuclear Weapon = 
+City = Oraș
+ # Requires translation!
+Air = 
+land units = unități terestre
+water units = unități acvatice
+air units = unități aeriene
+ # Requires translation!
+military units = 
+ # Requires translation!
+submarine units = 
+ # Requires translation!
+Barbarian = 
 
 ######### City filters ###########
 
@@ -1877,6 +1772,89 @@ in City-State cities =
  # Requires translation!
 in cities following this religion = 
 
+######### Population Filters ###########
+
+ # Requires translation!
+Unemployed = 
+ # Requires translation!
+Followers of the Majority Religion = 
+ # Requires translation!
+Followers of this Religion = 
+
+######### Terrain Filters ###########
+
+ # Requires translation!
+All = 
+ # Requires translation!
+Coastal = 
+ # Requires translation!
+River = 
+ # Requires translation!
+Open terrain = 
+ # Requires translation!
+Rough terrain = 
+ # Requires translation!
+Water resource = 
+ # Requires translation!
+Foreign Land = 
+ # Requires translation!
+Foreign = 
+ # Requires translation!
+Friendly Land = 
+ # Requires translation!
+Enemy Land = 
+ # Requires translation!
+Featureless = 
+ # Requires translation!
+Fresh Water = 
+ # Requires translation!
+non-fresh water = 
+ # Requires translation!
+Natural Wonder = 
+Impassable = Inaccesibil
+Land = Teren
+ # Requires translation!
+Water = 
+ # Requires translation!
+Luxury resource = 
+ # Requires translation!
+Strategic resource = 
+ # Requires translation!
+Bonus resource = 
+
+######### Tile Filters ###########
+
+ # Requires translation!
+unimproved = 
+ # Requires translation!
+All Road = 
+ # Requires translation!
+Great Improvement = 
+
+######### Region Types ###########
+
+ # Requires translation!
+Hybrid = 
+
+######### Terrain Quality ###########
+
+ # Requires translation!
+Undesirable = 
+ # Requires translation!
+Desirable = 
+
+######### Improvement Filters ###########
+
+ # Requires translation!
+Great = 
+
+######### Prophet Action Filters ###########
+
+ # Requires translation!
+founding = 
+ # Requires translation!
+enhancing = 
+
 ######### Unique Specials ###########
 
  # Requires translation!
@@ -1910,6 +1888,8 @@ Temple of Artemis =
 
 The Great Lighthouse = Marele Far
 'They that go down to the sea in ships, that do business in great waters; these see the works of the Lord, and his wonders in the deep.' - The Bible, Psalms 107:23-24 = 'Cei ce se coborâseră pe mare în corăbii și făceau negoț pe apele cele mari, aceia au văzut lucrările Domnului și minunile Lui în mijlocul adâncului.' - Biblia, Psalmul 107:23-24
+ # Requires translation!
+for [mapUnitFilter] units = 
  # Requires translation!
 [amount] Movement = 
  # Requires translation!
@@ -1972,6 +1952,10 @@ Krepost = Fortăreață
 Statue of Zeus = 
  # Requires translation!
 'He spoke, the son of Kronos, and nodded his head with the dark brows, and the immortally anointed hair of the great god swept from his divine head, and all Olympos was shaken' - The Iliad = 
+ # Requires translation!
+vs cities = 
+ # Requires translation!
+when attacking = 
  # Requires translation!
 [amount]% Strength = 
 
@@ -2094,11 +2078,15 @@ Castle = Castel
 
 Mughal Fort = Fort mogul
  # Requires translation!
+after discovering [tech] = 
+ # Requires translation!
 [stats] [cityFilter] = 
 
 Himeji Castle = Castelul Himeji
  # Requires translation!
 'Bushido is realized in the presence of death. This means choosing death whenever there is a choice between life and death. There is no other reasoning.' - Yamamoto Tsunetomo = 
+ # Requires translation!
+when fighting in [tileFilter] tiles = 
 
 Ironworks = Fierărie
 
@@ -2226,6 +2214,8 @@ Pentagon = Pentagon
 
 Solar Plant = Centrală solară
  # Requires translation!
+in cities without a [buildingFilter] = 
+ # Requires translation!
 Only available = 
 
 Nuclear Plant = Centrală nucleară
@@ -2267,6 +2257,7 @@ King = Rege
 Era Starting Unit = 
 
 Emperor = Împărat
+Scout = Explorator
 
 Immortal = Nemuritor
 Worker = Muncitor
@@ -2300,9 +2291,6 @@ Atomic era =
 Information era = Era informațională
 
 Future era = Era viitorului
-
-
-#################### Lines from GlobalUniques from Civ V - Vanilla ####################
 
 
 #################### Lines from Nations from Civ V - Vanilla ####################
@@ -2949,6 +2937,8 @@ Bourges =
  # Requires translation!
 Calais = 
 France = Franța
+ # Requires translation!
+before discovering [tech] = 
 
 Catherine = Ecaterina
  # Requires translation!
@@ -3053,7 +3043,7 @@ Double quantity of [resource] produced =
  # Requires translation!
 Augustus Caesar = 
  # Requires translation!
-My treasury contains little and my soldiers are getting impatient... ...therefore you must die. = 
+My treasury contains little and my soldiers are getting impatient... (sigh) ...therefore you must die. = 
  # Requires translation!
 So brave, yet so stupid! If only you had a brain similar to your courage. = 
  # Requires translation!
@@ -4091,6 +4081,8 @@ Patigrbana =
 Phrada = 
  # Requires translation!
 Persia = 
+ # Requires translation!
+during a Golden Age = 
 
  # Requires translation!
 Kamehameha I = 
@@ -4192,6 +4184,8 @@ Pileni =
  # Requires translation!
 Nukumanu = 
 Polynesia = Polinezia
+ # Requires translation!
+starting from the [era] = 
 Enables embarkation for land units = Permite îmbarcarea unităților terestre
  # Requires translation!
 Enables [mapUnitFilter] units to enter ocean tiles = 
@@ -5079,6 +5073,8 @@ Oligarchy = Oligarhie
  # Requires translation!
 Units in cities cost no Maintenance = 
  # Requires translation!
+with a garrison = 
+ # Requires translation!
 [amount]% Strength for cities = 
 Landed Elite = Elita terestră
  # Requires translation!
@@ -5104,6 +5100,8 @@ Liberty =
 
 Warrior Code = Cod războinici
 Discipline = Disciplină
+ # Requires translation!
+when adjacent to a [mapUnitFilter] unit = 
 Military Tradition = Tradiție militară
  # Requires translation!
 [amount]% XP gained from combat = 
@@ -5112,6 +5110,8 @@ Professional Army = Armată profesionistă
 Honor Complete = Onoare realizată
  # Requires translation!
 Honor = 
+ # Requires translation!
+vs [mapUnitFilter] units = 
  # Requires translation!
 Notified of new Barbarian encampments = 
 
@@ -5127,6 +5127,8 @@ Free Religion = Religie liberă
 Piety Complete = Credință realizată
  # Requires translation!
 Piety = 
+ # Requires translation!
+before adopting [policy] = 
 
  # Requires translation!
 Philantropy = 
@@ -5189,10 +5191,14 @@ Rationalism Complete = Raționalism realizat
  # Requires translation!
 Rationalism = 
  # Requires translation!
+while the empire is happy = 
+ # Requires translation!
 [amount]% [stat] = 
 
 Constitution = Constituție
 Universal Suffrage = Vot universal
+ # Requires translation!
+when defending = 
 Civil Society = Societate civilă
  # Requires translation!
 [amount]% Food consumption by specialists [cityFilter] = 
@@ -5217,6 +5223,8 @@ Police State = Stat polițienesc
 Total War = Război total
  # Requires translation!
 Autocracy Complete = 
+ # Requires translation!
+for [amount] turns = 
  # Requires translation!
 Autocracy = 
  # Requires translation!
@@ -5257,42 +5265,42 @@ We feel threatened by a Barbarian Camp near our city. Please take care of it. =
  # Requires translation!
 Connect Resource = 
  # Requires translation!
-In order to make our civilizations stronger, connect [param] to your trade network. = 
+In order to make our civilizations stronger, connect [tileResource] to your trade network. = 
 
  # Requires translation!
 Construct Wonder = 
  # Requires translation!
-We recommend you to start building [param] to show the whole world your civilization strength. = 
+We recommend you to start building [wonder] to show the whole world your civilization strength. = 
 
  # Requires translation!
 Acquire Great Person = 
  # Requires translation!
-Great People can change the course of a Civilization! You will be rewarded for acquiring a new [param]. = 
+Great People can change the course of a Civilization! You will be rewarded for acquiring a new [greatPerson]. = 
 
  # Requires translation!
 Conquer City State = 
  # Requires translation!
-It's time to erase the City-State of [param] from the map. You will be greatly rewarded for conquering them! = 
+It's time to erase the City-State of [cityState] from the map. You will be greatly rewarded for conquering them! = 
 
  # Requires translation!
 Find Player = 
  # Requires translation!
-You have yet to discover where [param] set up their cities. You will be rewarded for finding their territories. = 
+You have yet to discover where [civName] set up their cities. You will be rewarded for finding their territories. = 
 
  # Requires translation!
 Find Natural Wonder = 
  # Requires translation!
-Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [param] yet. = 
+Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [naturalWonder] yet. = 
 
  # Requires translation!
 Give Gold = 
  # Requires translation!
-We are suffering great poverty after being robbed by [param], and unless we receive a sum of Gold, it's only a matter of time before we collapse. = 
+We are suffering great poverty after being robbed by [civName], and unless we receive a sum of Gold, it's only a matter of time before we collapse. = 
 
  # Requires translation!
 Pledge to Protect = 
  # Requires translation!
-We need your protection to stop the aggressions of [param]. By signing a Pledge of Protection, you'll confirm the bond that ties us. = 
+We need your protection to stop the aggressions of [civName]. By signing a Pledge of Protection, you'll confirm the bond that ties us. = 
 
  # Requires translation!
 Contest Culture = 
@@ -5312,20 +5320,20 @@ The civilization with the largest number of new Technologies researched will gai
  # Requires translation!
 Invest = 
  # Requires translation!
-Our people are rejoicing thanks to a tourism boom. For a certain amount of time, any Gold donation will yield [amount]% extra Influence. = 
+Our people are rejoicing thanks to a tourism boom. For a certain amount of time, any Gold donation will yield [50]% extra Influence. = 
 
  # Requires translation!
 Bully City State = 
  # Requires translation!
-We are tired of the pretensions of [param]. If someone were to put them in their place by Demanding Tribute from them, they would be rewarded. = 
+We are tired of the pretensions of [cityState]. If someone were to put them in their place by Demanding Tribute from them, they would be rewarded. = 
 
  # Requires translation!
 Denounce Civilization = 
  # Requires translation!
-We have been forced to pay tribute to [param]! We need you to tell the world of their ill deeds. = 
+We have been forced to pay tribute to [civName]! We need you to tell the world of their ill deeds. = 
 
  # Requires translation!
-We have heard the tenets of [param] and are most curious. Will you send missionaries to teach us about your religion? = 
+We have heard the tenets of [religionName] and are most curious. Will you send missionaries to teach us about your religion? = 
 
 
 #################### Lines from Ruins from Civ V - Vanilla ####################
@@ -5347,12 +5355,12 @@ An ancient tribe trained us in their ways of combat! =
 your exploring unit receives training = 
 
  # Requires translation!
-We have found survivors in the ruins! Population added to [param]. = 
+We have found survivors in the ruins! Population added to [cityName]. = 
  # Requires translation!
 survivors (adds population to a city) = 
 
  # Requires translation!
-We have found a stash of [param] Gold in the ruins! = 
+We have found a stash of [goldAmount] Gold in the ruins! = 
  # Requires translation!
 a stash of gold = 
 
@@ -5659,6 +5667,8 @@ Tundra = Tundră
 Desert = Deșert
 
 Lakes = Lacuri
+ # Requires translation!
+Fresh water = 
 
 Mountain = Munte
  # Requires translation!
@@ -5685,6 +5695,8 @@ A Camp can be built here without cutting it down =
 Jungle = Junglă
 
 Marsh = Mlaștină
+ # Requires translation!
+Rare feature = 
  # Requires translation!
 Only Polders can be built here = 
 
@@ -5929,6 +5941,9 @@ Porcelain =
 
  # Requires translation!
 Sword = 
+Mounted = Luptător călare
+ # Requires translation!
+Siege = 
  # Requires translation!
 Ranged Gunpowder = 
  # Requires translation!
@@ -5937,6 +5952,7 @@ Armored =
 Melee Water = 
  # Requires translation!
 Ranged Water = 
+Submarine = Submarin
 Heal Instantly = Vindecare instantanee
  # Requires translation!
 Heal this unit by [amount] HP = 
@@ -6013,6 +6029,8 @@ Medic = Medic I
 All adjacent units heal [amount] HP when healing = 
 
 Medic II = Medic II
+ # Requires translation!
+in [tileFilter] tiles = 
  # Requires translation!
 [amount] HP when healing = 
 
@@ -6103,6 +6121,7 @@ Supply =
  # Requires translation!
 May heal outside of friendly territory = 
 
+Bomber = Bombardier
 Siege I = Asediu I
 
 Siege II = Asediu II
@@ -6113,6 +6132,7 @@ Evasion = Evaziune
  # Requires translation!
 Damage taken from interception reduced by [amount]% = 
 
+Fighter = Avion de vânătoare
 Interception I = Interceptare I
  # Requires translation!
 [amount]% Damage when intercepting = 
@@ -6245,12 +6265,37 @@ Can see over obstacles =
 Atomic Bomber = 
 
  # Requires translation!
+Missile = 
+ # Requires translation!
 Self-destructs when attacking = 
  # Requires translation!
 Cannot be intercepted = 
 
  # Requires translation!
 Can pass through impassable tiles = 
+
+Melee = Luptător de contact
+
+Ranged = Luptător la distanță
+
+Armor = Armură
+
+ # Requires translation!
+WaterCivilian = 
+
+ # Requires translation!
+WaterMelee = 
+
+ # Requires translation!
+WaterRanged = 
+
+WaterSubmarine = Submarin
+
+ # Requires translation!
+WaterAircraftCarrier = 
+
+ # Requires translation!
+AtomicBomber = 
 
 
 #################### Lines from Units from Civ V - Vanilla ####################
@@ -6339,6 +6384,8 @@ Camel Archer = Arcaș pe cămilă
 
  # Requires translation!
 Conquistador = 
+ # Requires translation!
+on foreign continents = 
 
  # Requires translation!
 Naresuan's Elephant = 
@@ -6441,6 +6488,8 @@ Atomic Bomb = Bombă Atomică
  # Requires translation!
 Nuclear weapon of Strength [amount] = 
  # Requires translation!
+if [buildingName] is constructed = 
+ # Requires translation!
 Blast radius [amount] = 
 
 Rocket Artillery = Artilerie de Rachete
@@ -6489,6 +6538,8 @@ Can start an [amount]-turn golden age =
 Can construct [improvementName] = 
  # Requires translation!
 Great Person - [stat] = 
+ # Requires translation!
+Unbuildable = 
 
 Great Scientist = Mare Om de Știință
 Can hurry technology research = Poate grăbi cercetarea tehnologică
@@ -6572,6 +6623,8 @@ Fertility Rites =
 
  # Requires translation!
 God of Craftsman = 
+ # Requires translation!
+in cities with at least [amount] [populationFilter] = 
 
  # Requires translation!
 God of the Open Sky = 
@@ -6652,6 +6705,8 @@ Guruship =
  # Requires translation!
 Holy Warriors = 
  # Requires translation!
+before the [era] = 
+ # Requires translation!
 May buy [baseUnitFilter] units with [stat] for [amount] times their normal Production cost = 
 
  # Requires translation!
@@ -6682,6 +6737,8 @@ Religious Community =
 
  # Requires translation!
 Swords into Ploughshares = 
+ # Requires translation!
+when not at war = 
 
  # Requires translation!
 Founder = 
@@ -6873,9 +6930,6 @@ Starting in this era disables religion =
 
 
 Marine = Pușcaș marin
-
-
-#################### Lines from GlobalUniques from Civ V - Gods & Kings ####################
 
 
 #################### Lines from Nations from Civ V - Gods & Kings ####################
@@ -7499,6 +7553,8 @@ Falmouth =
 Lorient = 
  # Requires translation!
 Celts = 
+ # Requires translation!
+with [amount] to [amount2] neighboring [tileFilter] [tileFilter2] tiles = 
 
  # Requires translation!
 Haile Selassie = 
@@ -7586,6 +7642,8 @@ Ziway =
 Weldiya = 
  # Requires translation!
 Ethiopia = 
+ # Requires translation!
+when fighting units from a Civilization with more Cities than you = 
 
  # Requires translation!
 Pacal = 
@@ -7733,12 +7791,12 @@ Taoism =
 
 
  # Requires translation!
-We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[param] Faith) = 
+We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[faithAmount] Faith) = 
  # Requires translation!
 discover holy symbols = 
 
  # Requires translation!
-We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[param] Faith) = 
+We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[faithAmount] Faith) = 
  # Requires translation!
 an ancient prophecy = 
 
@@ -7813,8 +7871,16 @@ Polder =
 #################### Lines from TileResources from Civ V - Gods & Kings ####################
 
 
+Citrus = Citrus
+
+Copper = Cupru
+
+Crab = Crab
+
  # Requires translation!
 Salt = 
+
+Truffles = Trufe
 
 
 #################### Lines from UnitPromotions from Civ V - Gods & Kings ####################
@@ -8355,13 +8421,7 @@ Irremovable =
  # Requires translation!
 when at war = 
  # Requires translation!
-when not at war = 
- # Requires translation!
-during a Golden Age = 
- # Requires translation!
 with [resource] = 
- # Requires translation!
-while the empire is happy = 
  # Requires translation!
 when between [amount] and [amount2] Happiness = 
  # Requires translation!
@@ -8369,67 +8429,25 @@ when below [amount] Happiness =
  # Requires translation!
 during the [era] = 
  # Requires translation!
-before the [era] = 
- # Requires translation!
-starting from the [era] = 
- # Requires translation!
 if no other Civilization has researched this = 
- # Requires translation!
-after discovering [tech] = 
- # Requires translation!
-before discovering [tech] = 
  # Requires translation!
 upon discovering [tech] = 
  # Requires translation!
 after adopting [policy] = 
  # Requires translation!
-before adopting [policy] = 
- # Requires translation!
-if [buildingName] is constructed = 
- # Requires translation!
-for [amount] turns = 
- # Requires translation!
 by consuming this unit = 
  # Requires translation!
 in cities with a [buildingFilter] = 
  # Requires translation!
-in cities without a [buildingFilter] = 
- # Requires translation!
-in cities with at least [amount] [populationFilter] = 
- # Requires translation!
-with a garrison = 
- # Requires translation!
-for [mapUnitFilter] units = 
- # Requires translation!
 for units with [promotion] = 
  # Requires translation!
 for units without [promotion] = 
- # Requires translation!
-vs cities = 
- # Requires translation!
-vs [mapUnitFilter] units = 
- # Requires translation!
-when fighting units from a Civilization with more Cities than you = 
- # Requires translation!
-when attacking = 
- # Requires translation!
-when defending = 
- # Requires translation!
-when fighting in [tileFilter] tiles = 
- # Requires translation!
-on foreign continents = 
- # Requires translation!
-when adjacent to a [mapUnitFilter] unit = 
  # Requires translation!
 when above [amount] HP = 
  # Requires translation!
 when below [amount] HP = 
  # Requires translation!
 with [amount] to [amount2] neighboring [tileFilter] tiles = 
- # Requires translation!
-with [amount] to [amount2] neighboring [tileFilter] [tileFilter2] tiles = 
- # Requires translation!
-in [tileFilter] tiles = 
  # Requires translation!
 in [tileFilter] [tileFilter2] tiles = 
  # Requires translation!

--- a/android/assets/jsons/translations/Russian.properties
+++ b/android/assets/jsons/translations/Russian.properties
@@ -1090,8 +1090,6 @@ or [terrainType] = или [terrainType]
 Can be constructed by = Можно построить с помощью
 Defence bonus = Бонус к защите
 Movement cost = Стоимость передвижения
-Open terrain = Открытая местность
-Rough Terrain = Пересеченная местность
 for = за
 Missing translations: = Отсутствующие переводы:
 Resolution = Разрешение
@@ -1222,104 +1220,6 @@ Religion = Религия
 Enhancing religion = Религия укрепляется
 Enhanced religion = Религия укреплена
 
-# Terrains
-
-Impassable = Непроходимо
-Rare feature = Редкая особенность
-
-# terrainFilters (so for uniques like: "[stats] from [terrainFilter] tiles")
-
-All = Все
-Water = Морские
-Land = Наземные
-Coastal = Прибрежные
-River = Река
-Rough terrain = Пересечённая местность
-Foreign Land = Чужая территория
-Foreign = Чужие
-Friendly Land = Дружественная территория
-Water resource = Морской ресурс
-Bonus resource = Бонусный ресурс
-Luxury resource = Редкий ресурс
-Strategic resource = Стратегический ресурс
-Fresh water = Пресная вода
-non-fresh water = Солёная вода
-Natural Wonder = Чудо природы
-Hybrid = Гибридные
- # Requires translation!
-Undesirable = 
- # Requires translation!
-Desirable = 
-Featureless = Без особенностей
-Fresh Water = Пресная вода
-
-# improvementFilters
-
-All Road = Дороги
-Great Improvement = Великое улучшение
-Great = Великое
-
-# Resources
-
-Bison = Бизоны
-Copper = Медь
-Cocoa = Какао
-Crab = Крабы
-Citrus = Цитрусы
-Truffles = Трюфели
-Strategic = Стратегический ресурс
-Bonus = Бонусный ресурс
-Luxury = Редкий ресурс
-
-# Unit types
-
-City = Город
-Civilian = Гражданский юнит
-Melee = Юнит ближнего боя
-Ranged = Юнит дальнего боя
-Scout = Разведчик
-Mounted = Конница
-Armor = Бронированный юнит
-Siege = Осадное орудие
-
-WaterCivilian = Гражданское судно
-WaterMelee = Судно ближнего боя
-WaterRanged = Судно дальнего боя
-WaterSubmarine = Подлодка
-WaterAircraftCarrier = Авианосец
-
-Fighter = Истребитель
-Bomber = Бомбардировщик
-AtomicBomber = Атомный бомбардировщик
-Missile = Ракета
-
-
-# Unit filters and other unit related things
-
-Air = Воздушные
-air units = воздушные юниты
-Barbarian = Варварские
-Barbarians = Варвары
-Embarked = Погруженные
-land units = сухопутные юниты
-Military = Военные
-# Deprecated since 3.15.2, but should still be translated until it is officially removed
-military water = военно-морской
-non-air = Не воздушные
-Nuclear Weapon = Ядерное оружие
-Submarine = Подлодка
-submarine units = подводные юниты
-Unbuildable = Нельзя построить
-water units = морские юниты
-wounded units = раненые юниты
-Wounded = Раненые
-
-# For the "All newly-trained [relevant] units in this city receive the [] promotion" translation. Relevant as in 'units that can receive'
-relevant = если доступно
-
-# For "May choose [amount] additional [beliefType] beliefs when [founding/enhancing] a religion"
-founding = основывается
-enhancing = укрепляется
 
 # Promotions
 
@@ -1327,6 +1227,7 @@ Pick promotion = Выбрать повышение
  OR  =  ИЛИ 
 units in open terrain = юнитов на открытой местности
 units in rough terrain = юнитов на пересечённой местности
+wounded units = раненые юниты
 Targeting II (air) = Воздушная наводка II
 Targeting III (air) = Воздушная наводка III
 Bonus when performing air sweep [bonusAmount]% = Бонус +[bonusAmount]% при зачистке неба
@@ -1430,6 +1331,11 @@ This Unit upgrades for free = Модернизация этого юнита - �
 Never destroyed when the city is captured = Никогда не разрушается, если город захвачен
 Invisible to others = Невидим для остальных
 
+# Unused Resources
+
+Bison = Бизоны
+Cocoa = Какао
+
 
 # In English we just paste all these conditionals at the end of each unique, but in your language that
 # may not turn into valid sentences. Therefore we have the following two translations to determine
@@ -1459,6 +1365,33 @@ ConditionalsPlacement = after
 ########################### AUTOMATICALLY GENERATED TRANSLATABLE STRINGS ########################### 
 
 
+######### Map Unit Filters ###########
+
+Wounded = Раненые
+Barbarians = Варвары
+ # Requires translation!
+City-State = 
+Embarked = Погруженные
+ # Requires translation!
+Non-City = 
+
+######### Unit Type Filters ###########
+
+Military = Военные
+Civilian = Гражданский юнит
+non-air = Не воздушные
+relevant = если доступно
+Nuclear Weapon = Ядерное оружие
+City = Город
+Air = Воздушные
+land units = сухопутные юниты
+water units = морские юниты
+air units = воздушные юниты
+ # Requires translation!
+military units = 
+submarine units = подводные юниты
+Barbarian = Варварские
+
 ######### City filters ###########
 
 in this city = в этом городе
@@ -1477,6 +1410,66 @@ in annexed cities = в аннексированных городах
 in holy cities = в священных городах
 in City-State cities = в городах-государствах
 in cities following this religion = в городах, следующих этой религии
+
+######### Population Filters ###########
+
+ # Requires translation!
+Unemployed = 
+ # Requires translation!
+Followers of the Majority Religion = 
+ # Requires translation!
+Followers of this Religion = 
+
+######### Terrain Filters ###########
+
+All = Все
+Coastal = Прибрежные
+River = Река
+Open terrain = Открытая местность
+Rough terrain = Пересечённая местность
+Water resource = Морской ресурс
+Foreign Land = Чужая территория
+Foreign = Чужие
+Friendly Land = Дружественная территория
+ # Requires translation!
+Enemy Land = 
+Featureless = Без особенностей
+Fresh Water = Пресная вода
+non-fresh water = Солёная вода
+Natural Wonder = Чудо природы
+Impassable = Непроходимо
+Land = Наземные
+Water = Морские
+Luxury resource = Редкий ресурс
+Strategic resource = Стратегический ресурс
+Bonus resource = Бонусный ресурс
+
+######### Tile Filters ###########
+
+ # Requires translation!
+unimproved = 
+All Road = Дороги
+Great Improvement = Великое улучшение
+
+######### Region Types ###########
+
+Hybrid = Гибридные
+
+######### Terrain Quality ###########
+
+ # Requires translation!
+Undesirable = 
+ # Requires translation!
+Desirable = 
+
+######### Improvement Filters ###########
+
+Great = Великое
+
+######### Prophet Action Filters ###########
+
+founding = основывается
+enhancing = укрепляется
 
 ######### Unique Specials ###########
 
@@ -1504,6 +1497,7 @@ Temple of Artemis = Храм Артемиды
 
 The Great Lighthouse = Фаросский маяк
 'They that go down to the sea in ships, that do business in great waters; these see the works of the Lord, and his wonders in the deep.' - The Bible, Psalms 107:23-24 = 'Отправляющиеся на кораблях в море, производящие дела на больших водах, видят дела Господа и чудеса Его в пучине...' - Псалтирь, Псалом 106: 23-24
+for [mapUnitFilter] units = для юнитов: [mapUnitFilter]
 [amount] Movement = [amount] к передвижению
 [amount] Sight = [amount] к радиусу обзора
 
@@ -1550,6 +1544,8 @@ Krepost = Острог
 
 Statue of Zeus = Статуя Зевса
 'He spoke, the son of Kronos, and nodded his head with the dark brows, and the immortally anointed hair of the great god swept from his divine head, and all Olympos was shaken' - The Iliad = 'Молвил Кронион и иссиня-черными двинул бровями; волны нетленных волос с головы Громовержца бессмертной на плечи пали его. И Олимп всколебался великий.' - Илиада
+vs cities = против городов
+when attacking = когда атакует
 [amount]% Strength = [amount]% к силе
 
 Lighthouse = Маяк
@@ -1648,10 +1644,12 @@ Notre Dame = Нотр-Дам
 Castle = Замок
 
 Mughal Fort = Красный форт
+after discovering [tech] = после исследования: [tech]
 [stats] [cityFilter] = [stats] [cityFilter]
 
 Himeji Castle = Замок Химэдзи
 'Bushido is realized in the presence of death. This means choosing death whenever there is a choice between life and death. There is no other reasoning.' - Yamamoto Tsunetomo = 'Бусидо - путь воина - означает смерть. Когда для выбора имеются два пути, выбирай тот, который ведет к смерти. Не рассуждай! Направь мысль на путь, который ты предпочел, и иди.' - Ямамото Цунетомо
+when fighting in [tileFilter] tiles = когда сражается на клетках [tileFilter]
 
 Ironworks = Металлургический завод
 
@@ -1756,6 +1754,7 @@ Pentagon = Пентагон
 [amount]% Gold cost of upgrading = [amount]% к затратам золота на модернизацию
 
 Solar Plant = Солнечная ЭС
+in cities without a [buildingFilter] = в городах, не имеющих [buildingFilter]
 Only available = Доступно только
 
 Nuclear Plant = АЭС
@@ -1789,6 +1788,7 @@ King = Король
 Era Starting Unit = Стартовый юнит эпохи
 
 Emperor = Император
+Scout = Разведчик
 
 Immortal = Бессмертный
 Worker = Рабочий
@@ -1821,9 +1821,6 @@ Atomic era = Атомная эра
 Information era = Информационная эра
 
 Future era = Будущее
-
-
-#################### Lines from GlobalUniques from Civ V - Vanilla ####################
 
 
 #################### Lines from Nations from Civ V - Vanilla ####################
@@ -2159,6 +2156,7 @@ La Rochelle = Ла-Рошель
 Bourges = Бурж
 Calais = Кале
 France = Франция
+before discovering [tech] = до исследования: [tech]
 
 Catherine = Екатерина
 You've behaved yourself very badly, you know it. Now it's payback time. = Знаете, вы поступили очень плохо. Пришло время расплаты.
@@ -2213,7 +2211,8 @@ Russia = Россия
 Double quantity of [resource] produced = Удваивается количество [resource]
 
 Augustus Caesar = Август Цезарь
-My treasury contains little and my soldiers are getting impatient... ...therefore you must die. = Моя казна почти пуста, а мои солдаты теряют терпение... ...поэтому вы должны умереть.
+ # Requires translation!
+My treasury contains little and my soldiers are getting impatient... (sigh) ...therefore you must die. = 
 So brave, yet so stupid! If only you had a brain similar to your courage. = Такая отвага, да при такой-то тупости! Если б только твой ум был соразмерен храбрости.
 The gods have deprived Rome of their favour. We have been defeated. = Боги отвернулись от Рима. Мы повержены.
 I greet you. I am Augustus, Imperator and Pontifex Maximus of Rome. If you are a friend of Rome, you are welcome. = Я приветствую вас. Я Август, император и великий понтифик Рима. Если вы друг Рима, то добро пожаловать.
@@ -2746,6 +2745,7 @@ Paishiyauvada = Пайшьяувада
 Patigrbana = Патигрбана
 Phrada = Фрада
 Persia = Персия
+during a Golden Age = во время Золотого века
 
 Kamehameha I = Камеамеа I
 The ancient fire flashing across the sky is what proclaimed that this day would come, though I had foolishly hoped for a different outcome. = Вспышка пламени в небесах предсказала нам наступление этого дня, но я безрассудно надеялся на другой исход.
@@ -2798,6 +2798,7 @@ Nuguria = Нугурия
 Pileni = Пилени
 Nukumanu = Нукуману
 Polynesia = Полинезия
+starting from the [era] = начиная с эпохи: [era]
 Enables embarkation for land units = Позволяет сухопутным юнитам передвигаться по воде
  # Requires translation!
 Enables [mapUnitFilter] units to enter ocean tiles = 
@@ -3273,6 +3274,7 @@ Legalism = Легализм
 Provides the cheapest [stat] building in your first [amount] cities for free = Самое дешёвое здание типа [stat] появляется в ваших первых [amount] городах
 Oligarchy = Олигархия
 Units in cities cost no Maintenance = Гарнизоны в городах содержатся бесплатно
+with a garrison = с гарнизоном
 [amount]% Strength for cities = [amount]% к силе городов
 Landed Elite = Землевладельческая Элита
 [amount]% growth [cityFilter] = [amount]% к росту [cityFilter]
@@ -3295,6 +3297,7 @@ Liberty =
 
 Warrior Code = Военная Присяга
 Discipline = Дисциплина
+when adjacent to a [mapUnitFilter] unit = когда рядом находится юнит: [mapUnitFilter]
 Military Tradition = Военные Традиции
 [amount]% XP gained from combat = На [amount]% больше опыта в бою
 Military Caste = Военная Каста
@@ -3302,6 +3305,7 @@ Professional Army = Профессиональная Армия
 Honor Complete = Честь Завершена
  # Requires translation!
 Honor = 
+vs [mapUnitFilter] units = против юнитов: [mapUnitFilter]
 Notified of new Barbarian encampments = Оповещает о новых лагерях варваров
 
 Organized Religion = Организованная Религия
@@ -3314,6 +3318,7 @@ Free Religion = Веротерпимость
 Piety Complete = Набожность Завершена
  # Requires translation!
 Piety = 
+before adopting [policy] = до принятия: [policy]
 
 Philantropy = Филантропия
 Gifts of Gold to City-States generate [amount]% more Influence = Подарки золотом городам-государствам приносят на [amount]% больше влияния
@@ -3354,10 +3359,12 @@ Rationalism Complete = Рационализм Завершен
 [amount] Free Technologies = [amount] бесплатных технологий
  # Requires translation!
 Rationalism = 
+while the empire is happy = когда цивилизация счастлива
 [amount]% [stat] = [amount]% [stat]
 
 Constitution = Конституция
 Universal Suffrage = Всеобщее Избирательное Право
+when defending = когда защищается
 Civil Society = Гражданское Общество
 [amount]% Food consumption by specialists [cityFilter] = [amount]% к потреблению еды специалистами [cityFilter]
 Free Speech = Свобода Слова
@@ -3376,6 +3383,7 @@ Quantity of strategic resources produced by the empire +[amount]% = Количе
 Police State = Полицейское Государство
 Total War = Тотальная Война
 Autocracy Complete = Автократия Завершена
+for [amount] turns = на [amount] ходов
  # Requires translation!
 Autocracy = 
 Upon capturing a city, receive [amount] times its [stat] production as [plunderableStat] immediately = По взятию города, мгновенно получает его производство [stat] в виде [plunderableStat] в [amount]-кратном размере
@@ -3401,28 +3409,28 @@ Clear Barbarian Camp = Уничтожьте лагерь варваров
 We feel threatened by a Barbarian Camp near our city. Please take care of it. = Мы напуганы варварским лагерем неподалёку от нашего города. Уничтожьте его.
 
 Connect Resource = Включите ресурс в торговую сеть
-In order to make our civilizations stronger, connect [param] to your trade network. = Чтобы сделать наши цивилизации сильнее, включите [param] в вашу торговую сеть.
+In order to make our civilizations stronger, connect [tileResource] to your trade network. = Чтобы сделать наши цивилизации сильнее, включите [tileResource] в вашу торговую сеть.
 
 Construct Wonder = Постройте чудо
-We recommend you to start building [param] to show the whole world your civilization strength. = Рекомендуем построить [param], чтобы показать всему миру силу своей цивилизации.
+We recommend you to start building [wonder] to show the whole world your civilization strength. = Рекомендуем построить [wonder], чтобы показать всему миру силу своей цивилизации.
 
 Acquire Great Person = Создайте Великого человека
-Great People can change the course of a Civilization! You will be rewarded for acquiring a new [param]. = Великие люди могут изменить ход истории! Вы будете вознаграждены за создание нового [param].
+Great People can change the course of a Civilization! You will be rewarded for acquiring a new [greatPerson]. = Великие люди могут изменить ход истории! Вы будете вознаграждены за создание нового [greatPerson].
 
 Conquer City State = Захватите город-государство
-It's time to erase the City-State of [param] from the map. You will be greatly rewarded for conquering them! = Пришло время стереть город-государство [param] с лица земли. Вы будете щедро вознаграждены за их захват.
+It's time to erase the City-State of [cityState] from the map. You will be greatly rewarded for conquering them! = Пришло время стереть город-государство [cityState] с лица земли. Вы будете щедро вознаграждены за их захват.
 
 Find Player = Найдите игрока
-You have yet to discover where [param] set up their cities. You will be rewarded for finding their territories. = Вам нужно узнать, где [param] создали свои города. Вы будете вознаграждены за обнаружение их территорий.
+You have yet to discover where [civName] set up their cities. You will be rewarded for finding their territories. = Вам нужно узнать, где [civName] создали свои города. Вы будете вознаграждены за обнаружение их территорий.
 
 Find Natural Wonder = Найдите чудо природы
-Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [param] yet. = Отправьте своих лучших исследователей на поиски чудес природы. Пока никто не знает, где находится [param].
+Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [naturalWonder] yet. = Отправьте своих лучших исследователей на поиски чудес природы. Пока никто не знает, где находится [naturalWonder].
 
 Give Gold = Подарите золото
-We are suffering great poverty after being robbed by [param], and unless we receive a sum of Gold, it's only a matter of time before we collapse. = Мы страдаем от страшной бедности после того, как [param] ограбили нас, и до тех пор, пока мы не получим золото, наше существование - лишь вопрос времени.
+We are suffering great poverty after being robbed by [civName], and unless we receive a sum of Gold, it's only a matter of time before we collapse. = Мы страдаем от страшной бедности после того, как [civName] ограбили нас, и до тех пор, пока мы не получим золото, наше существование - лишь вопрос времени.
 
 Pledge to Protect = Пообещайте защиту
-We need your protection to stop the aggressions of [param]. By signing a Pledge of Protection, you'll confirm the bond that ties us. = Нам нужна ваша защита, чтобы остановить агрессию державы [param]. Гарантируя нам защиту, вы сильнее скрепите узы, связвающие нас.
+We need your protection to stop the aggressions of [civName]. By signing a Pledge of Protection, you'll confirm the bond that ties us. = Нам нужна ваша защита, чтобы остановить агрессию державы [civName]. Гарантируя нам защиту, вы сильнее скрепите узы, связвающие нас.
 
 Contest Culture = Состязание культуры
 The civilization with the largest Culture growth will gain a reward. = Цивилизация с наибольшим приростом культуры получит вознаграждение.
@@ -3434,15 +3442,15 @@ Contest Technologies = Состязание технологий
 The civilization with the largest number of new Technologies researched will gain a reward. = Цивилизация, которая откроет наибольшее число технологий, получит вознаграждение.
 
 Invest = Инвестируйте
-Our people are rejoicing thanks to a tourism boom. For a certain amount of time, any Gold donation will yield [amount]% extra Influence. = Наш народ радуется в связи с наплывом туристов. В течение некоторого времени любое пожертвование золота будет дополнительно приносить [amount]% влияния. 
+Our people are rejoicing thanks to a tourism boom. For a certain amount of time, any Gold donation will yield [50]% extra Influence. = Наш народ радуется в связи с наплывом туристов. В течение некоторого времени любое пожертвование золота будет дополнительно приносить [50]% влияния. 
 
 Bully City State = Запугните город-государство
-We are tired of the pretensions of [param]. If someone were to put them in their place by Demanding Tribute from them, they would be rewarded. = Мы устали от претензий [param]. Если кто-нибудь сможет поставить их на свое место, потребовав от них дань, он получит вознаграждение.
+We are tired of the pretensions of [cityState]. If someone were to put them in their place by Demanding Tribute from them, they would be rewarded. = Мы устали от претензий [cityState]. Если кто-нибудь сможет поставить их на свое место, потребовав от них дань, он получит вознаграждение.
 
 Denounce Civilization = Осудите державу
-We have been forced to pay tribute to [param]! We need you to tell the world of their ill deeds. = Мы были вынуждены выплатить дань державе [param]! Нам нужно, чтобы вы рассказали об их злодеяниях всему миру.
+We have been forced to pay tribute to [civName]! We need you to tell the world of their ill deeds. = Мы были вынуждены выплатить дань державе [civName]! Нам нужно, чтобы вы рассказали об их злодеяниях всему миру.
 
-We have heard the tenets of [param] and are most curious. Will you send missionaries to teach us about your religion? = Мы были наслышаны о догматах [param] и нам очень любопытно. Пошлете ли вы нам своих миссионеров, чтобы они рассказали нам о вашей вере?
+We have heard the tenets of [religionName] and are most curious. Will you send missionaries to teach us about your religion? = Мы были наслышаны о догматах [religionName] и нам очень любопытно. Пошлете ли вы нам своих миссионеров, чтобы они рассказали нам о вашей вере?
 
 
 #################### Lines from Ruins from Civ V - Vanilla ####################
@@ -3457,10 +3465,10 @@ squatters wishing to settle under your rule = местные жители, же�
 An ancient tribe trained us in their ways of combat! = Древнее племя научило нас новым способам ведения боя!
 your exploring unit receives training = ваш исследовательский юнит проходит обучение
 
-We have found survivors in the ruins! Population added to [param]. = Мы нашли в руинах выживших! В город [param] добавлено население.
+We have found survivors in the ruins! Population added to [cityName]. = Мы нашли в руинах выживших! В город [cityName] добавлено население.
 survivors (adds population to a city) = выжившие (добавляет население в город)
 
-We have found a stash of [param] Gold in the ruins! = Мы нашли в руинах сундук и получили золото: [param]!
+We have found a stash of [goldAmount] Gold in the ruins! = Мы нашли в руинах сундук и получили золото: [goldAmount]!
 a stash of gold = сундук с золотом
 
 discover a lost technology = обнаружить утерянную технологию
@@ -3681,6 +3689,7 @@ Tundra = Тундра
 Desert = Пустыня
 
 Lakes = Озёра
+Fresh water = Пресная вода
 
 Mountain = Гора
 Has an elevation of [amount] for visibility calculations = Имеет высоту [amount] для расчёта видимости
@@ -3701,6 +3710,7 @@ A Camp can be built here without cutting it down = Здесь можно пос�
 Jungle = Джунгли
 
 Marsh = Болото
+Rare feature = Редкая особенность
 Only Polders can be built here = Здесь можно строить только польдеры
 
 Fallout = Пустошь
@@ -3896,10 +3906,13 @@ Porcelain = Фарфор
 #################### Lines from UnitPromotions from Civ V - Vanilla ####################
 
 Sword = Меч
+Mounted = Конница
+Siege = Осадное орудие
 Ranged Gunpowder = Порох (дальний бой)
 Armored = Бронированный юнит
 Melee Water = Судно ближнего боя
 Ranged Water = Судно дальнего боя
+Submarine = Подлодка
 Heal Instantly = Мгновенное исцеление
 Heal this unit by [amount] HP = Восстанавливает этот юнит на [amount] ОЗ
 Doing so will consume this opportunity to choose a Promotion = Забирает возможность выбрать повышение
@@ -3958,6 +3971,7 @@ Medic = Медик
 All adjacent units heal [amount] HP when healing = Все соседние юниты восстанавливают [amount] ОЗ при лечении
 
 Medic II = Медик II
+in [tileFilter] tiles = на клетках [tileFilter]
 [amount] HP when healing = [amount] ОЗ когда лечится
 
 Scouting I = Разведка I
@@ -4018,6 +4032,7 @@ Flight Deck III = Лётная палуба III
 Supply = Снабжение
 May heal outside of friendly territory = Может лечится вне дружественной территории
 
+Bomber = Бомбардировщик
 Siege I = Осада I
 
 Siege II = Осада II
@@ -4027,6 +4042,7 @@ Siege III = Осада III
 Evasion = Уклонение
 Damage taken from interception reduced by [amount]% = Урон от перехвата уменьшен на [amount]%
 
+Fighter = Истребитель
 Interception I = Перехват I
 [amount]% Damage when intercepting = [amount]% к урону при перехвате
 
@@ -4124,10 +4140,29 @@ Can see over obstacles =
 
 Atomic Bomber = Атомный бомбардировщик
 
+Missile = Ракета
 Self-destructs when attacking = Самоуничтожается при атаке
 Cannot be intercepted = Нельзя перехватить
 
 Can pass through impassable tiles = Может проходить через непроходимые клетки
+
+Melee = Юнит ближнего боя
+
+Ranged = Юнит дальнего боя
+
+Armor = Бронированный юнит
+
+WaterCivilian = Гражданское судно
+
+WaterMelee = Судно ближнего боя
+
+WaterRanged = Судно дальнего боя
+
+WaterSubmarine = Подлодка
+
+WaterAircraftCarrier = Авианосец
+
+AtomicBomber = Атомный бомбардировщик
 
 
 #################### Lines from Units from Civ V - Vanilla ####################
@@ -4205,6 +4240,7 @@ Knight = Рыцарь
 Camel Archer = Лучник на верблюде
 
 Conquistador = Конкистадор
+on foreign continents = на внешних континентах
 
 Naresuan's Elephant = Слон Наресуана
 
@@ -4295,6 +4331,8 @@ Anti-Tank Gun = Противотанковое орудие
 
 Atomic Bomb = Атомная бомба
 Nuclear weapon of Strength [amount] = Ядерное оружие с силой [amount]
+ # Requires translation!
+if [buildingName] is constructed = 
 Blast radius [amount] = Радиус взрыва [amount]
 
 Rocket Artillery = Ракетная артиллерия
@@ -4329,6 +4367,7 @@ Great Artist = Великий художник
 Can start an [amount]-turn golden age = Может начать золотой век длительностью [amount] ходов
 Can construct [improvementName] = Может построить [improvementName]
 Great Person - [stat] = Великий человек - [stat]
+Unbuildable = Нельзя построить
 
 Great Scientist = Великий учёный
 Can hurry technology research = Может ускорить изучение технологии
@@ -4388,6 +4427,8 @@ Faith Healers = Целители
 Fertility Rites = Обряды плодородия
 
 God of Craftsman = Бог ремесленников
+ # Requires translation!
+in cities with at least [amount] [populationFilter] = 
 
 God of the Open Sky = Бог открытого неба
 
@@ -4439,6 +4480,7 @@ Feed the World = Накорми мир
 Guruship = Наставничество
 
 Holy Warriors = Священные воины
+before the [era] = до эпохи: [era]
 May buy [baseUnitFilter] units with [stat] for [amount] times their normal Production cost = Можно покупать юниты: [baseUnitFilter] за [stat] по стоимости в [amount] раз(а) большей стоимости их производства
 
 Liturgical Drama = Литургическая драма
@@ -4459,6 +4501,7 @@ Religious Community = Религиозное сообщество
 [amount]% [stat] from every follower, up to [amount2]% = [amount]% [stat] от каждого последователя вплоть до [amount2]%
 
 Swords into Ploughshares = Мечи на орала
+when not at war = в мирное время 
 
 Founder = Основатель
 Ceremonial Burial = Ритуальное погребение
@@ -4597,9 +4640,6 @@ Starting in this era disables religion = Начало в этой эпохе о�
 
 
 Marine = Морской пехотинец
-
-
-#################### Lines from GlobalUniques from Civ V - Gods & Kings ####################
 
 
 #################### Lines from Nations from Civ V - Gods & Kings ####################
@@ -4934,6 +4974,7 @@ Llanfairpwllgwyngyll = Лланвайр Пуллгвингилл
 Falmouth = Фалмут
 Lorient = Лорьян
 Celts = Кельты
+with [amount] to [amount2] neighboring [tileFilter] [tileFilter2] tiles = когда от [amount] до [amount2] соседних клеток [tileFilter] [tileFilter2]
 
 Haile Selassie = Хайле Селассие
 I have tried all other avenues, but yet you persist in this madness. I hope, for your sake, your end is swift. = Я испробовал всевозможные пути, но вы же упорствуете в этом безумии. Надеюсь, для вашего же блага, ваш конец скоро наступит.
@@ -4980,6 +5021,7 @@ Gambela = Гамбела
 Ziway = Звай
 Weldiya = Уольдыя
 Ethiopia = Эфиопия
+when fighting units from a Civilization with more Cities than you = когда сражается с юнитами из цивилизации с большим числом городов чем у вас
 
 Pacal = Пакаль
 A sacrifice unlike all others must be made! = Жертва в отличие от всего остального, должна быть принесена!
@@ -5067,10 +5109,10 @@ Taoism = Даосизм
 #################### Lines from Ruins from Civ V - Gods & Kings ####################
 
 
-We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[param] Faith) = Мы нашли священные символы в руинах, что дало нам более глубокое понимание религии! (+[param] веры)
+We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[faithAmount] Faith) = Мы нашли священные символы в руинах, что дало нам более глубокое понимание религии! (+[faithAmount] веры)
 discover holy symbols = обнаружить священные символы
 
-We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[param] Faith) = Мы нашли древнее пророчество в руинах, что значительно укрепило нашу духовную связь! (+[param] веры)
+We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[faithAmount] Faith) = Мы нашли древнее пророчество в руинах, что значительно укрепило нашу духовную связь! (+[faithAmount] веры)
 an ancient prophecy = древнее пророчество
 
 
@@ -5128,7 +5170,15 @@ Polder = Польдер
 #################### Lines from TileResources from Civ V - Gods & Kings ####################
 
 
+Citrus = Цитрусы
+
+Copper = Медь
+
+Crab = Крабы
+
 Salt = Соль
+
+Truffles = Трюфели
 
 
 #################### Lines from UnitPromotions from Civ V - Gods & Kings ####################
@@ -5465,48 +5515,22 @@ No Sight =
  # Requires translation!
 Irremovable = 
 when at war = во время войны
-when not at war = в мирное время 
-during a Golden Age = во время Золотого века
 with [resource] = вместе с: [resource]
-while the empire is happy = когда цивилизация счастлива
 when between [amount] and [amount2] Happiness = когда счастье между [amount] и [amount2]
 when below [amount] Happiness = когда меньше [amount] счастья
 during the [era] = во время эпохи: [era]
-before the [era] = до эпохи: [era]
-starting from the [era] = начиная с эпохи: [era]
 if no other Civilization has researched this = если никакая другая цивилизация не исследовала
-after discovering [tech] = после исследования: [tech]
-before discovering [tech] = до исследования: [tech]
  # Requires translation!
 upon discovering [tech] = 
 after adopting [policy] = после принятия: [policy]
-before adopting [policy] = до принятия: [policy]
- # Requires translation!
-if [buildingName] is constructed = 
-for [amount] turns = на [amount] ходов
  # Requires translation!
 by consuming this unit = 
 in cities with a [buildingFilter] = в городах, имеющих [buildingFilter]
-in cities without a [buildingFilter] = в городах, не имеющих [buildingFilter]
- # Requires translation!
-in cities with at least [amount] [populationFilter] = 
-with a garrison = с гарнизоном
-for [mapUnitFilter] units = для юнитов: [mapUnitFilter]
 for units with [promotion] = для юнитов с повышением [promotion]
 for units without [promotion] = для юнитов без повышения [promotion]
-vs cities = против городов
-vs [mapUnitFilter] units = против юнитов: [mapUnitFilter]
-when fighting units from a Civilization with more Cities than you = когда сражается с юнитами из цивилизации с большим числом городов чем у вас
-when attacking = когда атакует
-when defending = когда защищается
-when fighting in [tileFilter] tiles = когда сражается на клетках [tileFilter]
-on foreign continents = на внешних континентах
-when adjacent to a [mapUnitFilter] unit = когда рядом находится юнит: [mapUnitFilter]
 when above [amount] HP = когда больше [amount] ОЗ
 when below [amount] HP = когда меньше [amount] ОЗ
 with [amount] to [amount2] neighboring [tileFilter] tiles = когда от [amount] до [amount2] соседних клеток [tileFilter]
-with [amount] to [amount2] neighboring [tileFilter] [tileFilter2] tiles = когда от [amount] до [amount2] соседних клеток [tileFilter] [tileFilter2]
-in [tileFilter] tiles = на клетках [tileFilter]
 in [tileFilter] [tileFilter2] tiles = на клетках [tileFilter] [tileFilter2]
 in tiles without [tileFilter] = на клетках, не имеющих [tileFilter]
 on water maps = на морских участках
@@ -5547,3 +5571,12 @@ Ruins = Руины
 CityState = Город-государство
 ModOptions = Настройки мода
 Conditional = Условие
+
+#################### Removed Lines ####################
+
+#~~Rough Terrain = Пересеченная местность
+#~~Strategic = Стратегический ресурс
+#~~Bonus = Бонусный ресурс
+#~~Luxury = Редкий ресурс
+#~~military water = военно-морской
+#~~My treasury contains little and my soldiers are getting impatient... ...therefore you must die. = Моя казна почти пуста, а мои солдаты теряют терпение... ...поэтому вы должны умереть.

--- a/android/assets/jsons/translations/Simplified_Chinese.properties
+++ b/android/assets/jsons/translations/Simplified_Chinese.properties
@@ -1089,8 +1089,6 @@ or [terrainType] = 或[terrainType]
 Can be constructed by = 可以建造由
 Defence bonus = 防御力加成
 Movement cost = 移动力消耗
-Open terrain = 开阔地形
-Rough Terrain = 崎岖地形
 for = ，当建造在拥有下列资源的地块上时：
 Missing translations: = 未翻译的词条：
 Resolution = 分辨率
@@ -1221,102 +1219,6 @@ Religion = 宗教
 Enhancing religion = 强化宗教中
 Enhanced religion = 强化宗教
 
-# Terrains
-
-Impassable = 不能通行
-Rare feature = 稀有地貌
-
-# terrainFilters (so for uniques like: "[stats] from [terrainFilter] tiles")
-
-All = 所有
-Water = 水上
-Land = 陆军
-Coastal = 沿海
-River = 河流
-Rough terrain = 崎岖地形
-Foreign Land = 异国领土
-Foreign = 异国
-Friendly Land = 友好领土
-Water resource = 水上资源
-Bonus resource = 奖金资源
-Luxury resource = 奢侈品资源
-Strategic resource = 战略资源
-Fresh water = 淡水
-non-fresh water = 非淡水
-Natural Wonder = 自然奇观
-Hybrid = 混合
-Undesirable = 不想要的
-Desirable = 想要的
-Featureless = 无特色的
-Fresh Water = 淡水
-
-# improvementFilters
-
-All Road = 道（铁）路
-Great Improvement = 伟人设施
-Great = 伟人
-
-# Resources
-
-Bison = 野牛
-Copper = 赤铜
-Cocoa = 可可
-Crab = 螃蟹
-Citrus = 柑橘
-Truffles = 松露
-Strategic = 战略资源
-Bonus = 奖励资源
-Luxury = 奢侈资源
-
-# Unit types
-
-City = 城市
-Civilian = 平民
-Melee = 近战
-Ranged = 远程
-Scout = 斥候
-Mounted = 骑乘
-Armor = 装甲
-Siege = 攻城
-
-WaterCivilian = 海上平民
-WaterMelee = 海军近战
-WaterRanged = 海军远程
-WaterSubmarine = 海军潜艇
-WaterAircraftCarrier = 海军航母
-
-Fighter = 战斗机
-Bomber = 轰炸机
-AtomicBomber = 核武器
-Missile = 导弹
-
-
-# Unit filters and other unit related things
-
-Air = 空军
-air units = 空军单位
-Barbarian = 蛮族
-Barbarians = 蛮族
-Embarked = 船运
-land units = 陆军单位
-Military = 军事
-# Deprecated since 3.15.2, but should still be translated until it is officially removed
-military water = 海军军事
-non-air = 非空军
-Nuclear Weapon = 核武器
-Submarine = 潜艇
-submarine units = 潜艇单位
-Unbuildable = 不可组建单位
-water units = 海军单位
-wounded units = 受伤单位
-Wounded = 受伤
-
-# For the "All newly-trained [relevant] units in this city receive the [] promotion" translation. Relevant as in 'units that can receive'
-relevant = 相应
-
-# For "May choose [amount] additional [beliefType] beliefs when [founding/enhancing] a religion"
-founding = 创立
-enhancing = 强化
 
 # Promotions
 
@@ -1324,6 +1226,7 @@ Pick promotion = 选择晋升项
  OR  = 或
 units in open terrain = 位于开阔地形的单位
 units in rough terrain = 位于崎岖地形的单位
+wounded units = 受伤单位
 Targeting II (air) = 空中定位 II 级
 Targeting III (air) = 空中定位 III 级
 Bonus when performing air sweep [bonusAmount]% = 空中游猎时 +[bonusAmount]% 战斗力
@@ -1427,6 +1330,11 @@ This Unit upgrades for free = 单位免费升级
 Never destroyed when the city is captured = 城市被占领时不会被摧毁
 Invisible to others = 对其他单位隐形
 
+# Unused Resources
+
+Bison = 野牛
+Cocoa = 可可
+
 
 # In English we just paste all these conditionals at the end of each unique, but in your language that
 # may not turn into valid sentences. Therefore we have the following two translations to determine
@@ -1456,6 +1364,33 @@ ConditionalsPlacement = before
 ########################### AUTOMATICALLY GENERATED TRANSLATABLE STRINGS ########################### 
 
 
+######### Map Unit Filters ###########
+
+Wounded = 受伤
+Barbarians = 蛮族
+ # Requires translation!
+City-State = 
+Embarked = 船运
+ # Requires translation!
+Non-City = 
+
+######### Unit Type Filters ###########
+
+Military = 军事
+Civilian = 平民
+non-air = 非空军
+relevant = 相应
+Nuclear Weapon = 核武器
+City = 城市
+Air = 空军
+land units = 陆军单位
+water units = 海军单位
+air units = 空军单位
+ # Requires translation!
+military units = 
+submarine units = 潜艇单位
+Barbarian = 蛮族
+
 ######### City filters ###########
 
 in this city = 所在城市
@@ -1474,6 +1409,64 @@ in annexed cities = 在被吞并的城市
 in holy cities = 在圣城
 in City-State cities = 在城邦城市
 in cities following this religion = 在追随此宗教的城市
+
+######### Population Filters ###########
+
+ # Requires translation!
+Unemployed = 
+ # Requires translation!
+Followers of the Majority Religion = 
+ # Requires translation!
+Followers of this Religion = 
+
+######### Terrain Filters ###########
+
+All = 所有
+Coastal = 沿海
+River = 河流
+Open terrain = 开阔地形
+Rough terrain = 崎岖地形
+Water resource = 水上资源
+Foreign Land = 异国领土
+Foreign = 异国
+Friendly Land = 友好领土
+ # Requires translation!
+Enemy Land = 
+Featureless = 无特色的
+Fresh Water = 淡水
+non-fresh water = 非淡水
+Natural Wonder = 自然奇观
+Impassable = 不能通行
+Land = 陆军
+Water = 水上
+Luxury resource = 奢侈品资源
+Strategic resource = 战略资源
+Bonus resource = 奖金资源
+
+######### Tile Filters ###########
+
+ # Requires translation!
+unimproved = 
+All Road = 道（铁）路
+Great Improvement = 伟人设施
+
+######### Region Types ###########
+
+Hybrid = 混合
+
+######### Terrain Quality ###########
+
+Undesirable = 不想要的
+Desirable = 想要的
+
+######### Improvement Filters ###########
+
+Great = 伟人
+
+######### Prophet Action Filters ###########
+
+founding = 创立
+enhancing = 强化
 
 ######### Unique Specials ###########
 
@@ -1501,6 +1494,7 @@ Temple of Artemis = 阿尔忒弥斯神庙
 
 The Great Lighthouse = 大灯塔
 'They that go down to the sea in ships, that do business in great waters; these see the works of the Lord, and his wonders in the deep.' - The Bible, Psalms 107:23-24 = “在大海上坐船，在大水里经理事务的；他们看到耶和华的作为，并他在深水中的奇事。” —— 圣经 · 诗篇 107：23 ～ 24
+for [mapUnitFilter] units = 对与处在[mapUnitFilter]单位
 [amount] Movement = [amount]移动力
 [amount] Sight = [amount]视野
 
@@ -1547,6 +1541,8 @@ Krepost = 俄罗斯营垒
 
 Statue of Zeus = 宙斯神像
 'He spoke, the son of Kronos, and nodded his head with the dark brows, and the immortally anointed hair of the great god swept from his divine head, and all Olympos was shaken' - The Iliad = “克罗诺斯之子言罢，弯颈点动浓黑的眉毛，涂着仙液的发绺从众神之王永生的头颅上顺势泼泻，摇撼着巍峨的奥林匹斯山脉。” —— 荷马：《伊利亚特》
+vs cities = 对战城市
+when attacking = 当攻击时
 [amount]% Strength = [amount]% 战斗力
 
 Lighthouse = 灯塔
@@ -1645,10 +1641,12 @@ Notre Dame = 巴黎圣母院
 Castle = 城堡
 
 Mughal Fort = 莫卧儿城塞
+after discovering [tech] = 当发现[tech]后
 [stats] [cityFilter] = [cityFilter][stats]
 
 Himeji Castle = 姬路城
 'Bushido is realized in the presence of death. This means choosing death whenever there is a choice between life and death. There is no other reasoning.' - Yamamoto Tsunetomo = “武士道是在死亡面前实现的。这意味着在生与死之间做出选择时选择死亡。没有其他理由了。” —— 山本津通
+when fighting in [tileFilter] tiles = 在[tileFilter]地块上作战时
 
 Ironworks = 钢铁厂
 
@@ -1751,6 +1749,7 @@ Pentagon = 五角大楼
 [amount]% Gold cost of upgrading = [amount]%升级金钱花费
 
 Solar Plant = 太阳能电站
+in cities without a [buildingFilter] = 在未建造[buildingFilter]的城市中
  # Requires translation!
 Only available = 
 
@@ -1785,6 +1784,7 @@ King = 国王
 Era Starting Unit = 时代起始单位
 
 Emperor = 皇帝
+Scout = 斥候
 
 Immortal = 仙人
 Worker = 工人
@@ -1817,9 +1817,6 @@ Atomic era = 原子时代
 Information era = 信息时代
 
 Future era = 未来时代
-
-
-#################### Lines from GlobalUniques from Civ V - Vanilla ####################
 
 
 #################### Lines from Nations from Civ V - Vanilla ####################
@@ -2155,6 +2152,7 @@ La Rochelle = 拉罗谢尔
 Bourges = 布尔日
 Calais = 加莱
 France = 法兰西
+before discovering [tech] = 在发现[tech]前
 
 Catherine = 叶卡捷琳娜二世
 You've behaved yourself very badly, you know it. Now it's payback time. = 如果我可以活到两百岁，整个世界都将匍匐在我脚下，现在首先从你开始！
@@ -2209,7 +2207,8 @@ Russia = 俄罗斯
 Double quantity of [resource] produced = [resource]产量加倍
 
 Augustus Caesar = 奥古斯都 · 恺撒
-My treasury contains little and my soldiers are getting impatient... ...therefore you must die. = 我的金库里几乎没有钱，我的士兵们也越来越不耐烦……所以你必须死。
+ # Requires translation!
+My treasury contains little and my soldiers are getting impatient... (sigh) ...therefore you must die. = 
 So brave, yet so stupid! If only you had a brain similar to your courage. = 蠢货，是愚昧给了你挑衅的勇气！厄运如密布的箭弩落下，而你终将无处躲避。
 The gods have deprived Rome of their favour. We have been defeated. = 你即使征服了全世界，如果没有人分享，终将倍感凄凉。罗马荣耀永存！
 I greet you. I am Augustus, Imperator and Pontifex Maximus of Rome. If you are a friend of Rome, you are welcome. = 欢迎你。我是奥古斯都，罗马帝国皇帝兼最高祭司。如果你是罗马的朋友，那么你将受到欢迎。
@@ -2743,6 +2742,7 @@ Paishiyauvada = 帕西亚威达
 Patigrbana = 帕瓦格班纳
 Phrada = 弗拉达
 Persia = 波斯
+during a Golden Age = 在黄金时代期间
 
 Kamehameha I = 卡美哈梅哈一世
 The ancient fire flashing across the sky is what proclaimed that this day would come, though I had foolishly hoped for a different outcome. = 我愚蠢地期盼，希望还有其他可能；但当天火燎原之时，审判之日终将来临。
@@ -2795,6 +2795,7 @@ Nuguria = 努古里亚
 Pileni = 皮莱尼
 Nukumanu = 努库马努
 Polynesia = 波利尼西亚
+starting from the [era] = 从[era]开始
 Enables embarkation for land units = 陆军单位拥有船运能力
 Enables [mapUnitFilter] units to enter ocean tiles = 允许[mapUnitFilter]进入海洋
 Normal vision when embarked = 下海时视野正常
@@ -3269,6 +3270,7 @@ Legalism = 律法统治
 Provides the cheapest [stat] building in your first [amount] cities for free = 前[amount]座城市免费获得最便宜的[stat]建筑
 Oligarchy = 寡头政治
 Units in cities cost no Maintenance = 镇守城市的单位无需维护费
+with a garrison = 如果城市有军队驻扎
 [amount]% Strength for cities = 每个城市[amount]%的防守强度
 Landed Elite = 缙绅阶层
 [amount]% growth [cityFilter] = [cityFilter][amount]%人口增长
@@ -3291,6 +3293,7 @@ Liberty =
 
 Warrior Code = 尚武精神
 Discipline = 军事纪律
+when adjacent to a [mapUnitFilter] unit = 当和[mapUnitFilter]单位相邻时
 Military Tradition = 军事传统
 [amount]% XP gained from combat = 从战斗中获得[amount]%经验
 Military Caste = 军人阶层
@@ -3298,6 +3301,7 @@ Professional Army = 职业军队
 Honor Complete = 完整的荣誉政策
  # Requires translation!
 Honor = 
+vs [mapUnitFilter] units = 对战[mapUnitFilter]单位
 Notified of new Barbarian encampments = 会对新出现蛮族营地提醒
 
 Organized Religion = 教会组织
@@ -3310,6 +3314,7 @@ Free Religion = 信仰自由
 Piety Complete = 完整的虔信政策
  # Requires translation!
 Piety = 
+before adopting [policy] = 在推行[policy]前
 
 Philantropy = 慈善事业
 Gifts of Gold to City-States generate [amount]% more Influence = 赠与城邦金钱提升的影响力+[amount]%
@@ -3350,10 +3355,12 @@ Rationalism Complete = 完整的理性政策
 [amount] Free Technologies = [amount] 项免费科技
  # Requires translation!
 Rationalism = 
+while the empire is happy = 当帝国处于快乐时
 [amount]% [stat] = [amount]% [stat]
 
 Constitution = 宪政主义
 Universal Suffrage = 普选制度
+when defending = 当防御时
 Civil Society = 公民社会
 [amount]% Food consumption by specialists [cityFilter] = [amount]% 的来自[cityFilter]的专业者的食物消耗
 Free Speech = 言论自由
@@ -3372,6 +3379,7 @@ Quantity of strategic resources produced by the empire +[amount]% = 战略资源
 Police State = 极权国家
 Total War = 全面战争
 Autocracy Complete = 完整的独裁政策
+for [amount] turns = 需要[amount]回合
  # Requires translation!
 Autocracy = 
 Upon capturing a city, receive [amount] times its [stat] production as [plunderableStat] immediately = 占领一个城市后，立即以[plunderableStat]形式获得它[stat]生产的[amount]倍
@@ -3397,28 +3405,28 @@ Clear Barbarian Camp = 清除蛮族营地
 We feel threatened by a Barbarian Camp near our city. Please take care of it. = 附近的一个蛮人营地对我们的城市构成了极大威胁，请处理好它。
 
 Connect Resource = 连接资源
-In order to make our civilizations stronger, connect [param] to your trade network. = 开发资源[param]并将其连接到您的贸易网络，我们的商人将会十分高兴。
+In order to make our civilizations stronger, connect [tileResource] to your trade network. = 开发资源[tileResource]并将其连接到您的贸易网络，我们的商人将会十分高兴。
 
 Construct Wonder = 建造奇观
-We recommend you to start building [param] to show the whole world your civilization strength. = 如果您能建造[param]，我们的学者和艺术家将会交口称誉您的成就。
+We recommend you to start building [wonder] to show the whole world your civilization strength. = 如果您能建造[wonder]，我们的学者和艺术家将会交口称誉您的成就。
 
 Acquire Great Person = 获得伟人
-Great People can change the course of a Civilization! You will be rewarded for acquiring a new [param]. = 伟人可以改变文明的进程！您将获得一个新的[param]。
+Great People can change the course of a Civilization! You will be rewarded for acquiring a new [greatPerson]. = 伟人可以改变文明的进程！您将获得一个新的[greatPerson]。
 
 Conquer City State = 征服城邦
-It's time to erase the City-State of [param] from the map. You will be greatly rewarded for conquering them! = 现在是时候从地图上擦除[param]城邦了。你将因战胜他们而获得巨大的回报！
+It's time to erase the City-State of [cityState] from the map. You will be greatly rewarded for conquering them! = 现在是时候从地图上擦除[cityState]城邦了。你将因战胜他们而获得巨大的回报！
 
 Find Player = 寻找文明
-You have yet to discover where [param] set up their cities. You will be rewarded for finding their territories. = 您尚未发现[param]在哪里建立他们的城市。找到他们将会给您奖励。
+You have yet to discover where [civName] set up their cities. You will be rewarded for finding their territories. = 您尚未发现[civName]在哪里建立他们的城市。找到他们将会给您奖励。
 
 Find Natural Wonder = 探索自然奇观
-Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [param] yet. = 派遣你最好的探险家去探索自然奇观。还没有人知道[param]的位置。
+Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [naturalWonder] yet. = 派遣你最好的探险家去探索自然奇观。还没有人知道[naturalWonder]的位置。
 
 Give Gold = 赠送金钱
-We are suffering great poverty after being robbed by [param], and unless we receive a sum of Gold, it's only a matter of time before we collapse. = 在被[param]抢劫后，我们正遭受着巨大的贫困，如果我们无法得到一笔金钱，我们的崩溃将只是时间问题。
+We are suffering great poverty after being robbed by [civName], and unless we receive a sum of Gold, it's only a matter of time before we collapse. = 在被[civName]抢劫后，我们正遭受着巨大的贫困，如果我们无法得到一笔金钱，我们的崩溃将只是时间问题。
 
 Pledge to Protect = 承诺保护
-We need your protection to stop the aggressions of [param]. By signing a Pledge of Protection, you'll confirm the bond that ties us. = 我们需要你的保护来阻止[param]的入侵。通过签署保护承诺，你将确保我们之间的联系。
+We need your protection to stop the aggressions of [civName]. By signing a Pledge of Protection, you'll confirm the bond that ties us. = 我们需要你的保护来阻止[civName]的入侵。通过签署保护承诺，你将确保我们之间的联系。
 
 Contest Culture = 文化竞赛
 The civilization with the largest Culture growth will gain a reward. = 文化增长最多的文明将获得奖励。
@@ -3430,15 +3438,15 @@ Contest Technologies = 科技竞赛
 The civilization with the largest number of new Technologies researched will gain a reward. = 新研发的科技最多的文明将获得奖励。
 
 Invest = 投资
-Our people are rejoicing thanks to a tourism boom. For a certain amount of time, any Gold donation will yield [amount]% extra Influence. = 由于旅游业的繁荣，我们的人民正在欢欣鼓舞。在一定时间内，任何金钱捐赠都会产生[amount]%的额外影响力。
+Our people are rejoicing thanks to a tourism boom. For a certain amount of time, any Gold donation will yield [50]% extra Influence. = 由于旅游业的繁荣，我们的人民正在欢欣鼓舞。在一定时间内，任何金钱捐赠都会产生[50]%的额外影响力。
 
 Bully City State = 恐吓城邦
-We are tired of the pretensions of [param]. If someone were to put them in their place by Demanding Tribute from them, they would be rewarded. = 我们厌倦了[param]的自命不凡。如果有人通过向他们要求贡品，将得到奖励。
+We are tired of the pretensions of [cityState]. If someone were to put them in their place by Demanding Tribute from them, they would be rewarded. = 我们厌倦了[cityState]的自命不凡。如果有人通过向他们要求贡品，将得到奖励。
 
 Denounce Civilization = 谴责文明
-We have been forced to pay tribute to [param]! We need you to tell the world of their ill deeds. = 我们被迫向[param]进贡！我们需要你告诉全世界他们的恶行。
+We have been forced to pay tribute to [civName]! We need you to tell the world of their ill deeds. = 我们被迫向[civName]进贡！我们需要你告诉全世界他们的恶行。
 
-We have heard the tenets of [param] and are most curious. Will you send missionaries to teach us about your religion? = 我们已经听过[param]的信条，并且非常好奇。你会派传教士来教我们你的宗教吗？
+We have heard the tenets of [religionName] and are most curious. Will you send missionaries to teach us about your religion? = 我们已经听过[religionName]的信条，并且非常好奇。你会派传教士来教我们你的宗教吗？
 
 
 #################### Lines from Ruins from Civ V - Vanilla ####################
@@ -3453,10 +3461,10 @@ squatters wishing to settle under your rule = 原住民想加入您麾下
 An ancient tribe trained us in their ways of combat! = 一个古老的部落以他们的战斗方式训练了我们的
 your exploring unit receives training = 你的探索单位接受训练
 
-We have found survivors in the ruins! Population added to [param]. = 我们在废墟中找到了幸存者，[param]人口增加。
+We have found survivors in the ruins! Population added to [cityName]. = 我们在废墟中找到了幸存者，[cityName]人口增加。
 survivors (adds population to a city) = 幸存者（增加城市人口）
 
-We have found a stash of [param] Gold in the ruins! = 我们在废墟找到[param]金
+We have found a stash of [goldAmount] Gold in the ruins! = 我们在废墟找到[goldAmount]金
 a stash of gold = 一笔金钱
 
 discover a lost technology = 发现失传的技术
@@ -3675,6 +3683,7 @@ Tundra = 冻土
 Desert = 沙漠
 
 Lakes = 湖泊
+Fresh water = 淡水
 
 Mountain = 山脉
 Has an elevation of [amount] for visibility calculations = 计算单位的视野范围时按高程[amount]计算
@@ -3695,6 +3704,7 @@ A Camp can be built here without cutting it down = 可以在此建造营地而�
 Jungle = 丛林
 
 Marsh = 沼泽
+Rare feature = 稀有地貌
 Only Polders can be built here = 这里只能建造圩田
 
 Fallout = 核辐射
@@ -3890,10 +3900,13 @@ Porcelain = 瓷器
 #################### Lines from UnitPromotions from Civ V - Vanilla ####################
 
 Sword = 近战
+Mounted = 骑乘
+Siege = 攻城
 Ranged Gunpowder = 远程火器
 Armored = 装甲
 Melee Water = 水面近战
 Ranged Water = 水面远程
+Submarine = 潜艇
 Heal Instantly = 浴火重生！
 Heal this unit by [amount] HP = 恢复该单位 [amount] 生命值
 Doing so will consume this opportunity to choose a Promotion = 这样做将消耗掉这次选择晋升项的机会
@@ -3952,6 +3965,7 @@ Medic = 治疗I级
 All adjacent units heal [amount] HP when healing = 所有相邻单位在治疗时治疗 [amount] 生命值
 
 Medic II = 治疗II级
+in [tileFilter] tiles = 在[tileFilter]地块上
 [amount] HP when healing = [amount] 自愈时恢复的生命值
 
 Scouting I = 侦察I级
@@ -4013,6 +4027,7 @@ Flight Deck III = 飞行甲板III级
 Supply = 海上补给
 May heal outside of friendly territory = 可以在友好领土之外自愈
 
+Bomber = 轰炸机
 Siege I = 攻坚I级
 
 Siege II = 攻坚II级
@@ -4022,6 +4037,7 @@ Siege III = 攻坚III级
 Evasion = 规避能力
 Damage taken from interception reduced by [amount]% = 遭受拦截时的损伤-[amount]%
 
+Fighter = 战斗机
 Interception I = 拦截I级
 [amount]% Damage when intercepting = 拦截敌方飞机时伤害 +[amount]%
 
@@ -4118,10 +4134,29 @@ Can see over obstacles =
 
 Atomic Bomber = 原子弹
 
+Missile = 导弹
 Self-destructs when attacking = 攻击时自我毁灭
 Cannot be intercepted = 不可拦截
 
 Can pass through impassable tiles = 可以穿过无法通行的地块
+
+Melee = 近战
+
+Ranged = 远程
+
+Armor = 装甲
+
+WaterCivilian = 海上平民
+
+WaterMelee = 海军近战
+
+WaterRanged = 海军远程
+
+WaterSubmarine = 海军潜艇
+
+WaterAircraftCarrier = 海军航母
+
+AtomicBomber = 核武器
 
 
 #################### Lines from Units from Civ V - Vanilla ####################
@@ -4199,6 +4234,7 @@ Knight = 骑士
 Camel Archer = 骆驼骑射手
 
 Conquistador = 西班牙征服者
+on foreign continents = 在非本土大陆上作战时
 
 Naresuan's Elephant = 纳黎萱战象
 
@@ -4289,6 +4325,7 @@ Anti-Tank Gun = 反坦克炮
 
 Atomic Bomb = 原子弹
 Nuclear weapon of Strength [amount] = 核武器威力：[amount]
+if [buildingName] is constructed = 如果该城市已建造[buildingName]
 Blast radius [amount] = 爆炸半径：[amount]
 
 Rocket Artillery = 火箭炮
@@ -4323,6 +4360,7 @@ Great Artist = 大艺术家
 Can start an [amount]-turn golden age = 可以开启[amount]回合黄金时代
 Can construct [improvementName] = 能建造[improvementName]
 Great Person - [stat] = 伟人 - [stat]
+Unbuildable = 不可组建单位
 
 Great Scientist = 大科学家
 Can hurry technology research = 可以加速科技研究
@@ -4382,6 +4420,8 @@ Faith Healers = 治疗之神
 Fertility Rites = 入教仪式
 
 God of Craftsman = 工匠之神
+ # Requires translation!
+in cities with at least [amount] [populationFilter] = 
 
 God of the Open Sky = 天空之神
 
@@ -4433,6 +4473,7 @@ Feed the World = 哺育世界
 Guruship = 古鲁导师
 
 Holy Warriors = 神圣战士
+before the [era] = 在[era]前
 May buy [baseUnitFilter] units with [stat] for [amount] times their normal Production cost = 可以用[stat]购买[baseUnitFilter]单位，价格为其正常生产成本的[amount]倍
 
 Liturgical Drama = 礼仪剧
@@ -4453,6 +4494,7 @@ Religious Community = 宗教社区
 [amount]% [stat] from every follower, up to [amount2]% = 对于每个信徒从[amount]%[stat]，增长至[amount2]%
 
 Swords into Ploughshares = 铸剑为犁
+when not at war = 当不处于战争时
 
 Founder = 创始人
 Ceremonial Burial = 葬礼仪式
@@ -4585,9 +4627,6 @@ Starting in this era disables religion = 在此时代开始将会禁用宗教
 
 
 Marine = 海军陆战队
-
-
-#################### Lines from GlobalUniques from Civ V - Gods & Kings ####################
 
 
 #################### Lines from Nations from Civ V - Gods & Kings ####################
@@ -4912,6 +4951,7 @@ Llanfairpwllgwyngyll = 兰韦尔普尔古因吉尔
 Falmouth = 法尔茅斯
 Lorient = 洛里昂
 Celts = 凯尔特
+with [amount] to [amount2] neighboring [tileFilter] [tileFilter2] tiles = 当与[amount]到[amount2][tileFilter][tileFilter2]地块相邻时
 
 Haile Selassie = 海尔·塞拉西
 I have tried all other avenues, but yet you persist in this madness. I hope, for your sake, your end is swift. = 我试过所有其他的方法，但你仍然坚持这种疯狂。我希望，为了你，你的终结会很快。
@@ -4956,6 +4996,7 @@ Gambela = 甘贝拉
 Ziway = 齐韦
 Weldiya = 韦尔迪亚
 Ethiopia = 埃塞俄比亚
+when fighting units from a Civilization with more Cities than you = 当和来自比你拥有更多城市的文明的单位作战时
 
 Pacal = 帕卡尔
 A sacrifice unlike all others must be made! = 必须做出不同于所有其他人的牺牲！
@@ -5041,10 +5082,10 @@ Taoism = 道教
 #################### Lines from Ruins from Civ V - Gods & Kings ####################
 
 
-We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[param] Faith) = 我们在废墟中发现了奇怪的符号，我们对宗教的了解更深刻了（+[param] 信仰）
+We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[faithAmount] Faith) = 我们在废墟中发现了奇怪的符号，我们对宗教的了解更深刻了（+[faithAmount] 信仰）
 discover holy symbols = 发现神圣的符号
 
-We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[param] Faith) = 我们在废墟中发现了古老的预言，极大的强化了我们的精神联系（+[param] 信仰）
+We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[faithAmount] Faith) = 我们在废墟中发现了古老的预言，极大的强化了我们的精神联系（+[faithAmount] 信仰）
 an ancient prophecy = 一个古老的预言
 
 
@@ -5102,7 +5143,15 @@ Polder = 圩田
 #################### Lines from TileResources from Civ V - Gods & Kings ####################
 
 
+Citrus = 柑橘
+
+Copper = 赤铜
+
+Crab = 螃蟹
+
 Salt = 盐
+
+Truffles = 松露
 
 
 #################### Lines from UnitPromotions from Civ V - Gods & Kings ####################
@@ -5440,46 +5489,21 @@ No Sight =
  # Requires translation!
 Irremovable = 
 when at war = 当处于战争时
-when not at war = 当不处于战争时
-during a Golden Age = 在黄金时代期间
 with [resource] = 拥有[resource]的
-while the empire is happy = 当帝国处于快乐时
 when between [amount] and [amount2] Happiness = 当帝国处于[amount]到[amount2]点快乐之间时
 when below [amount] Happiness = 当帝国低于[amount]快乐时
 during the [era] = 在[era]
-before the [era] = 在[era]前
-starting from the [era] = 从[era]开始
 if no other Civilization has researched this = 如果没有其他文明研究这个科技的时候
-after discovering [tech] = 当发现[tech]后
-before discovering [tech] = 在发现[tech]前
  # Requires translation!
 upon discovering [tech] = 
 after adopting [policy] = 在推行[policy]后
-before adopting [policy] = 在推行[policy]前
-if [buildingName] is constructed = 如果该城市已建造[buildingName]
-for [amount] turns = 需要[amount]回合
 by consuming this unit = 在组建这个单位时
 in cities with a [buildingFilter] = 在正在建造[buildingFilter]的城市中
-in cities without a [buildingFilter] = 在未建造[buildingFilter]的城市中
- # Requires translation!
-in cities with at least [amount] [populationFilter] = 
-with a garrison = 如果城市有军队驻扎
-for [mapUnitFilter] units = 对与处在[mapUnitFilter]单位
 for units with [promotion] = 对于拥有[promotion]的单位
 for units without [promotion] = 对于没有[promotion]的单位
-vs cities = 对战城市
-vs [mapUnitFilter] units = 对战[mapUnitFilter]单位
-when fighting units from a Civilization with more Cities than you = 当和来自比你拥有更多城市的文明的单位作战时
-when attacking = 当攻击时
-when defending = 当防御时
-when fighting in [tileFilter] tiles = 在[tileFilter]地块上作战时
-on foreign continents = 在非本土大陆上作战时
-when adjacent to a [mapUnitFilter] unit = 当和[mapUnitFilter]单位相邻时
 when above [amount] HP = 当超过[amount]生命值时
 when below [amount] HP = 当低于[amount]生命值时
 with [amount] to [amount2] neighboring [tileFilter] tiles = 当与[amount]到[amount2][tileFilter]地块相邻时
-with [amount] to [amount2] neighboring [tileFilter] [tileFilter2] tiles = 当与[amount]到[amount2][tileFilter][tileFilter2]地块相邻时
-in [tileFilter] tiles = 在[tileFilter]地块上
 in [tileFilter] [tileFilter2] tiles = 在[tileFilter]或[tileFilter2]地块上
 in tiles without [tileFilter] = 在没有[tileFilter]的地块上
 on water maps = 海洋地图
@@ -5521,3 +5545,12 @@ Ruins = 遗迹
 CityState = 城邦
 ModOptions = 模组选项
 Conditional = 有前提的
+
+#################### Removed Lines ####################
+
+#~~Rough Terrain = 崎岖地形
+#~~Strategic = 战略资源
+#~~Bonus = 奖励资源
+#~~Luxury = 奢侈资源
+#~~military water = 海军军事
+#~~My treasury contains little and my soldiers are getting impatient... ...therefore you must die. = 我的金库里几乎没有钱，我的士兵们也越来越不耐烦……所以你必须死。

--- a/android/assets/jsons/translations/Spanish.properties
+++ b/android/assets/jsons/translations/Spanish.properties
@@ -1083,8 +1083,6 @@ or [terrainType] = o [terrainType]
 Can be constructed by = Puede ser construido por
 Defence bonus = Bonus de defensa
 Movement cost = Coste de movimiento
-Open terrain = Terreno Abierto
-Rough Terrain = Terreno Abrupto
 for = para
 Missing translations: = Traducciones restantes:
 Resolution = Resolución
@@ -1214,102 +1212,6 @@ Religion = Religión
 Enhancing religion = Mejorando Religión
 Enhanced religion = Religión Mejorada
 
-# Terrains
-
-Impassable = Infranqueable
-Rare feature = Característica rara
-
-# terrainFilters (so for uniques like: "[stats] from [terrainFilter] tiles")
-
-All = Cualquiera
-Water = Agua
-Land = Tierra
-Coastal = Costera
-River = Río
-Rough terrain = Terreno Abrupto
-Foreign Land = Tierra Extranjera
-Foreign = Extranjera
-Friendly Land = Tierra Amiga
-Water resource = Recurso de Agua
-Bonus resource = Recurso Bonus
-Luxury resource = Recurso de Lujo
-Strategic resource = Recurso Estrategico
-Fresh water = Agua Dulce
-non-fresh water = agua no dulce
-Natural Wonder = Maravilla Natural
-Hybrid = Híbrido
-Undesirable = Indeseable
-Desirable = Deseable
-Featureless = Monótono
-Fresh Water = Agua Fresca
-
-# improvementFilters
-
-All Road = Todas las Carreteras
-Great Improvement = Gran Mejora
-Great = Gran
-
-# Resources
-
-Bison = Bisonte
-Copper = Cobre
-Cocoa = Cacao
-Crab = Cangrejos
-Citrus = Cítricos
-Truffles = Trufas
-Strategic = Estratégico
-Bonus = bonificación
-Luxury = Lujo
-
-# Unit types
-
-City = Ciudad
-Civilian = Civil
-Melee = Cuerpo a cuerpo
-Ranged = A distancia
-Scout = Explorador
-Mounted = Montado
-Armor = Blindado
-Siege = Asedio
-
-WaterCivilian = Civil Naval
-WaterMelee = Naval cuerpo a cuerpo
-WaterRanged = Naval a distancia
-WaterSubmarine = Submarino Naval
-WaterAircraftCarrier = Portaaviones
-
-Fighter = Caza
-Bomber = Bombardero
-AtomicBomber = Bombardero Atómico
-Missile = Misil
-
-
-# Unit filters and other unit related things
-
-Air = Aérea
-air units = unidades aéreas
-Barbarian = Bárbaras
-Barbarians = Bárbaros
-Embarked = Embarcadas
-land units = unidades terrestres
-Military = Militares
-# Deprecated since 3.15.2, but should still be translated until it is officially removed
-military water = militares marítimas
-non-air = no aéreas
-Nuclear Weapon = Arma Nuclear
-Submarine = Submarino
-submarine units = unidades submarinas
-Unbuildable = Inedificable
-water units = unidades navales
-wounded units = unidades heridas
-Wounded = Heridas
-
-# For the "All newly-trained [relevant] units in this city receive the [] promotion" translation. Relevant as in 'units that can receive'
-relevant = relevantes
-
-# For "May choose [amount] additional [beliefType] beliefs when [founding/enhancing] a religion"
-founding = fundar
-enhancing = mejorar
 
 # Promotions
 
@@ -1317,6 +1219,7 @@ Pick promotion = Elige ascenso
  OR  =  O 
 units in open terrain = unidades en terreno abierto
 units in rough terrain = unidades en terreno abrupto
+wounded units = unidades heridas
 Targeting II (air) = Fijación de objetivos aérea II
 Targeting III (air) = Fijación de objetivos aérea III
 Bonus when performing air sweep [bonusAmount]% = [bonusAmount]% de bonus al realizar un barrido aéreo
@@ -1420,6 +1323,11 @@ This Unit upgrades for free = Esta Unidad se mejora gratis
 Never destroyed when the city is captured = Nunca destruido cuando una ciudad es capturada
 Invisible to others = Invisible para los demás
 
+# Unused Resources
+
+Bison = Bisonte
+Cocoa = Cacao
+
 
 # In English we just paste all these conditionals at the end of each unique, but in your language that
 # may not turn into valid sentences. Therefore we have the following two translations to determine
@@ -1449,6 +1357,33 @@ ConditionalsPlacement = after
 ########################### AUTOMATICALLY GENERATED TRANSLATABLE STRINGS ########################### 
 
 
+######### Map Unit Filters ###########
+
+Wounded = Heridas
+Barbarians = Bárbaros
+ # Requires translation!
+City-State = 
+Embarked = Embarcadas
+ # Requires translation!
+Non-City = 
+
+######### Unit Type Filters ###########
+
+Military = Militares
+Civilian = Civil
+non-air = no aéreas
+relevant = relevantes
+Nuclear Weapon = Arma Nuclear
+City = Ciudad
+Air = Aérea
+land units = unidades terrestres
+water units = unidades navales
+air units = unidades aéreas
+ # Requires translation!
+military units = 
+submarine units = unidades submarinas
+Barbarian = Bárbaras
+
 ######### City filters ###########
 
 in this city = en esta ciudad
@@ -1467,6 +1402,64 @@ in annexed cities = en ciudades anexadas
 in holy cities = en ciudades santas
 in City-State cities = en ciudades de Ciudades-Estado
 in cities following this religion = en ciudades siguiendo esta religión
+
+######### Population Filters ###########
+
+ # Requires translation!
+Unemployed = 
+ # Requires translation!
+Followers of the Majority Religion = 
+ # Requires translation!
+Followers of this Religion = 
+
+######### Terrain Filters ###########
+
+All = Cualquiera
+Coastal = Costera
+River = Río
+Open terrain = Terreno Abierto
+Rough terrain = Terreno Abrupto
+Water resource = Recurso de Agua
+Foreign Land = Tierra Extranjera
+Foreign = Extranjera
+Friendly Land = Tierra Amiga
+ # Requires translation!
+Enemy Land = 
+Featureless = Monótono
+Fresh Water = Agua Fresca
+non-fresh water = agua no dulce
+Natural Wonder = Maravilla Natural
+Impassable = Infranqueable
+Land = Tierra
+Water = Agua
+Luxury resource = Recurso de Lujo
+Strategic resource = Recurso Estrategico
+Bonus resource = Recurso Bonus
+
+######### Tile Filters ###########
+
+ # Requires translation!
+unimproved = 
+All Road = Todas las Carreteras
+Great Improvement = Gran Mejora
+
+######### Region Types ###########
+
+Hybrid = Híbrido
+
+######### Terrain Quality ###########
+
+Undesirable = Indeseable
+Desirable = Deseable
+
+######### Improvement Filters ###########
+
+Great = Gran
+
+######### Prophet Action Filters ###########
+
+founding = fundar
+enhancing = mejorar
 
 ######### Unique Specials ###########
 
@@ -1494,6 +1487,7 @@ Temple of Artemis = Templo de artemisa
 
 The Great Lighthouse = El Gran Faro
 'They that go down to the sea in ships, that do business in great waters; these see the works of the Lord, and his wonders in the deep.' - The Bible, Psalms 107:23-24 = 'Los que surcan el mar en las naves para hacer su negocio en la inmensidad de las aguas también ven la obra de Yavéh y sus maravillas en el piélago.' - La Biblia, Salmos 107: 23-24
+for [mapUnitFilter] units = para unidades [mapUnitFilter]
 [amount] Movement = [amount] Movimiento
 [amount] Sight = [amount] Visión
 
@@ -1540,6 +1534,8 @@ Krepost = Krepost
 
 Statue of Zeus = Estatua de Zeus
 'He spoke, the son of Kronos, and nodded his head with the dark brows, and the immortally anointed hair of the great god swept from his divine head, and all Olympos was shaken' - The Iliad = 'Habló, el hijo del artero Cronos, y asintió con su cabeza de cejas oscuras, y el cabello inmortalmente ungido del gran dios salió de su divina cabeza, y todo el Olimpo se sacudió' - La Ilíada
+vs cities = vs ciudades
+when attacking = al atacar
 [amount]% Strength = [amount]% Fuerza
 
 Lighthouse = Faro
@@ -1637,10 +1633,12 @@ Notre Dame = Notre Dame
 Castle = Castillo
 
 Mughal Fort = Fuerte Rojo
+after discovering [tech] = después de descubrir [tech]
 [stats] [cityFilter] = [stats] [cityFilter] 
 
 Himeji Castle = Castillo Himeji
 'Bushido is realized in the presence of death. This means choosing death whenever there is a choice between life and death. There is no other reasoning.' - Yamamoto Tsunetomo = 'Bushido es realizado en la presencia de la muerte. Esto significa escojer la muerte cuandoquiera que haya opción entre la vida y la muerte. No hay otro razonamiento.' - Yamamoto Tsunetomo
+when fighting in [tileFilter] tiles = al pelear en casillas [tileFilter]
 
 Ironworks = Herrería
 
@@ -1743,6 +1741,7 @@ Pentagon = Pentágono
 [amount]% Gold cost of upgrading = [amount]% Costo de oro de la actualización
 
 Solar Plant = Planta Solar
+in cities without a [buildingFilter] = en ciudades sin un/a [buildingFilter]
 Only available = Solo disponible
 
 Nuclear Plant = Central Nuclear
@@ -1776,6 +1775,7 @@ King = Monarca
 Era Starting Unit = Unidad inicial de era
 
 Emperor = Emperador
+Scout = Explorador
 
 Immortal = Inmortal
 Worker = Trabajador
@@ -1808,9 +1808,6 @@ Atomic era = Edad Atómica
 Information era = Edad informática
 
 Future era = Edad Futurista
-
-
-#################### Lines from GlobalUniques from Civ V - Vanilla ####################
 
 
 #################### Lines from Nations from Civ V - Vanilla ####################
@@ -2146,6 +2143,7 @@ La Rochelle = La Rochelle
 Bourges = Bourges
 Calais = Calais
 France = Francia
+before discovering [tech] = antes de descubrir [tech]
 
 Catherine = Catalina
 You've behaved yourself very badly, you know it. Now it's payback time. = Te has comportado muy mal, lo sabes. Ahora es tiempo de venganza.
@@ -2200,7 +2198,8 @@ Russia = Rusia
 Double quantity of [resource] produced = Cantidad doble de [resource] producida
 
 Augustus Caesar = César Augusto
-My treasury contains little and my soldiers are getting impatient... ...therefore you must die. = Mis arcas se acaban y mis soldados se impacientan... ...por eso debes morir.
+ # Requires translation!
+My treasury contains little and my soldiers are getting impatient... (sigh) ...therefore you must die. = 
 So brave, yet so stupid! If only you had a brain similar to your courage. = ¡Tan valiente, pero tan estúpido! Si tan sólo tuvieras un cerebro similar a tu coraje.
 The gods have deprived Rome of their favour. We have been defeated. = Los dioses han privado a Roma de su favor. Hemos sido derrotados.
 I greet you. I am Augustus, Imperator and Pontifex Maximus of Rome. If you are a friend of Rome, you are welcome. = Te saludo. Soy Augusto, Imperator y Pontífice Máximo de Roma. Si eres amigo de Roma, eres bienvenido.
@@ -2733,6 +2732,7 @@ Paishiyauvada = Paishiyauvada
 Patigrbana = Patigrbana
 Phrada = Phrada
 Persia = Persia
+during a Golden Age = durante una edad de oro
 
 Kamehameha I = Kamehameha I
 The ancient fire flashing across the sky is what proclaimed that this day would come, though I had foolishly hoped for a different outcome. = El fuego antiguo surcando el cielo es lo que proclamó que este día llegaría, pero esperaba que fuera de otra manera.
@@ -2785,6 +2785,7 @@ Nuguria = Nuguria
 Pileni = Pileni
 Nukumanu = Nukumani
 Polynesia = Polinesia
+starting from the [era] = a partir de la [era]
 Enables embarkation for land units = Habilita la embarcación a las unidades de tierra
 Enables [mapUnitFilter] units to enter ocean tiles = Permite a unidades [mapUnitFilter] embarcadas entrar a casillas de Oceano
 Normal vision when embarked = Visión normal al embarcar
@@ -3259,6 +3260,7 @@ Legalism = Legalismo
 Provides the cheapest [stat] building in your first [amount] cities for free = Provee el edificio [stat] más barato en tus primeras [amount] ciudades gratis
 Oligarchy = Oligarquía
 Units in cities cost no Maintenance = Las unidades en las ciudades no cuestan mantenimiento
+with a garrison = con una guarnición
 [amount]% Strength for cities = [amount]% Fuerza para ciudades
 Landed Elite = Élite Terrateniente
 [amount]% growth [cityFilter] = [amount]% crecimiento [cityFilter]
@@ -3281,6 +3283,7 @@ Liberty =
 
 Warrior Code = Código guerrero
 Discipline = Disciplina
+when adjacent to a [mapUnitFilter] unit = cuando está adyacente a una unidad [mapUnitFilter]
 Military Tradition = Tradición militar
 [amount]% XP gained from combat = [amount]% XP ganada del combate
 Military Caste = Casta militar
@@ -3288,6 +3291,7 @@ Professional Army = Ejercito Profesional
 Honor Complete = Honor Completado
  # Requires translation!
 Honor = 
+vs [mapUnitFilter] units = vs unidades [mapUnitFilter]
 Notified of new Barbarian encampments = Serás avisado de nuevos campamentos Bárbaros
 
 Organized Religion = Religión Organizada
@@ -3300,6 +3304,7 @@ Free Religion = Libertad de Culto
 Piety Complete = Piedad Completada
  # Requires translation!
 Piety = 
+before adopting [policy] = antes de adoptar [policy]
 
 Philantropy = Filantropía
 Gifts of Gold to City-States generate [amount]% more Influence = Regalos de Oro a Ciudades-Estado generan [amount]% más Influencia
@@ -3340,10 +3345,12 @@ Rationalism Complete = Racionalismo Completado
 [amount] Free Technologies = [amount] Tecnologias Gratis
  # Requires translation!
 Rationalism = 
+while the empire is happy = mientras el imperio es feliz
 [amount]% [stat] = [amount]% [stat]
 
 Constitution = Constitución
 Universal Suffrage = Sufragio Universal
+when defending = al defender
 Civil Society = Sociedad Civil
 [amount]% Food consumption by specialists [cityFilter] = [amount]% Consumo de alimentos por especialistas [cityFilter]
 Free Speech = Libertad de Expresión
@@ -3362,6 +3369,7 @@ Quantity of strategic resources produced by the empire +[amount]% = Cantidad de 
 Police State = Estado de policías
 Total War = Guerra Total
 Autocracy Complete = Autocracia completada
+for [amount] turns = Por [amount] turnos
  # Requires translation!
 Autocracy = 
 Upon capturing a city, receive [amount] times its [stat] production as [plunderableStat] immediately = Al capturar una ciudad, recibe [amount] veces es [stat] producción como [plunderableStat] inmediatamente
@@ -3387,28 +3395,28 @@ Clear Barbarian Camp = Limpia el campamento bárbaro
 We feel threatened by a Barbarian Camp near our city. Please take care of it. = Nos sentimos amenazados por un Campamento de Bárbaros cerca de nuestra ciudad. Por favor límpialo.
 
 Connect Resource = Conectar recurso
-In order to make our civilizations stronger, connect [param] to your trade network. = Para fortalecer nuestras civilizaciones, conecte [param] a su red comercial.
+In order to make our civilizations stronger, connect [tileResource] to your trade network. = Para fortalecer nuestras civilizaciones, conecte [tileResource] a su red comercial.
 
 Construct Wonder = Construir maravilla
-We recommend you to start building [param] to show the whole world your civilization strength. = Te recomendamos que comiences a construir [param] para mostrar al mundo entero la fuerza de tu civilización.
+We recommend you to start building [wonder] to show the whole world your civilization strength. = Te recomendamos que comiences a construir [wonder] para mostrar al mundo entero la fuerza de tu civilización.
 
 Acquire Great Person = Adquirir gran persona
-Great People can change the course of a Civilization! You will be rewarded for acquiring a new [param]. = ¡Las grandes personas pueden cambiar el curso de una civilización! Serás recompensado por adquirir un nuevo [param].
+Great People can change the course of a Civilization! You will be rewarded for acquiring a new [greatPerson]. = ¡Las grandes personas pueden cambiar el curso de una civilización! Serás recompensado por adquirir un nuevo [greatPerson].
 
 Conquer City State = Conquistar Ciudad-Estado
-It's time to erase the City-State of [param] from the map. You will be greatly rewarded for conquering them! = Es tiempo de borrar la Ciudad-Estado de [param] del mapa. ¡Serás grandiosamente recompensado por conquistarlos!
+It's time to erase the City-State of [cityState] from the map. You will be greatly rewarded for conquering them! = Es tiempo de borrar la Ciudad-Estado de [cityState] del mapa. ¡Serás grandiosamente recompensado por conquistarlos!
 
 Find Player = Encontrar jugador
-You have yet to discover where [param] set up their cities. You will be rewarded for finding their territories. = Todavía tienes que descubrir dónde [param] estableció sus ciudades. Serás recompensado por encontrar sus territorios.
+You have yet to discover where [civName] set up their cities. You will be rewarded for finding their territories. = Todavía tienes que descubrir dónde [civName] estableció sus ciudades. Serás recompensado por encontrar sus territorios.
 
 Find Natural Wonder = Encuentra la maravilla natural
-Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [param] yet. = Envíe a sus mejores exploradores en una búsqueda para descubrir maravillas naturales. Nadie sabe la ubicación de [param] todavía.
+Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [naturalWonder] yet. = Envíe a sus mejores exploradores en una búsqueda para descubrir maravillas naturales. Nadie sabe la ubicación de [naturalWonder] todavía.
 
 Give Gold = Dar Oro
-We are suffering great poverty after being robbed by [param], and unless we receive a sum of Gold, it's only a matter of time before we collapse. = Estamos sufriendo una gran pobreza después de ser robados por [param], y a menos de que recivamos una suma de Oro, nuestro colapso es cuestión de tiempo.
+We are suffering great poverty after being robbed by [civName], and unless we receive a sum of Gold, it's only a matter of time before we collapse. = Estamos sufriendo una gran pobreza después de ser robados por [civName], y a menos de que recivamos una suma de Oro, nuestro colapso es cuestión de tiempo.
 
 Pledge to Protect = Prometer Protección
-We need your protection to stop the aggressions of [param]. By signing a Pledge of Protection, you'll confirm the bond that ties us. = Necesitamos tu protección para parar las agresiones de [param]. Al firmar una Promesa de Protección, confirmarás la relación que nos une.
+We need your protection to stop the aggressions of [civName]. By signing a Pledge of Protection, you'll confirm the bond that ties us. = Necesitamos tu protección para parar las agresiones de [civName]. Al firmar una Promesa de Protección, confirmarás la relación que nos une.
 
 Contest Culture = Torneo de Cultura
 The civilization with the largest Culture growth will gain a reward. = La civilización con más crecimiento en Cultura ganará una recompensa.
@@ -3420,15 +3428,15 @@ Contest Technologies = Torneo de Tecnologías
 The civilization with the largest number of new Technologies researched will gain a reward. = La civilización con el mayor número de tecnologías ganará una recompensa.
 
 Invest = Invertir
-Our people are rejoicing thanks to a tourism boom. For a certain amount of time, any Gold donation will yield [amount]% extra Influence. = Nuestra gente se regocija gracias a una subida en turismo. Por cierto periodo de tiempo, cualquier donación en Oro dará [amount]% Influencia extra.
+Our people are rejoicing thanks to a tourism boom. For a certain amount of time, any Gold donation will yield [50]% extra Influence. = Nuestra gente se regocija gracias a una subida en turismo. Por cierto periodo de tiempo, cualquier donación en Oro dará [50]% Influencia extra.
 
 Bully City State = Intimidar Ciudad-Estado
-We are tired of the pretensions of [param]. If someone were to put them in their place by Demanding Tribute from them, they would be rewarded. = Estamos cansados de loa alardeos de [param]. Si alguien pudiera ponerlos en su lugar Demandando Tributo, ese tal será recompensado.
+We are tired of the pretensions of [cityState]. If someone were to put them in their place by Demanding Tribute from them, they would be rewarded. = Estamos cansados de loa alardeos de [cityState]. Si alguien pudiera ponerlos en su lugar Demandando Tributo, ese tal será recompensado.
 
 Denounce Civilization = Denunciar Civilización
-We have been forced to pay tribute to [param]! We need you to tell the world of their ill deeds. = ¡Hemos sido forzados a pagar tributo a [param]! Necesitamos que le digas al mundo sus malas acciones.
+We have been forced to pay tribute to [civName]! We need you to tell the world of their ill deeds. = ¡Hemos sido forzados a pagar tributo a [civName]! Necesitamos que le digas al mundo sus malas acciones.
 
-We have heard the tenets of [param] and are most curious. Will you send missionaries to teach us about your religion? = Hemos escuchado los dogmas de [param] y son de lo más intrigantes. ¿Enviarás misioneros para enseñarnos de tu religión?
+We have heard the tenets of [religionName] and are most curious. Will you send missionaries to teach us about your religion? = Hemos escuchado los dogmas de [religionName] y son de lo más intrigantes. ¿Enviarás misioneros para enseñarnos de tu religión?
 
 
 #################### Lines from Ruins from Civ V - Vanilla ####################
@@ -3443,10 +3451,10 @@ squatters wishing to settle under your rule = desamparados dispuestos a coloniza
 An ancient tribe trained us in their ways of combat! = ¡Una tribu antigua nos ha entrenado en sus maneras de combate!
 your exploring unit receives training = la unidad exploradora recive entrenamiento
 
-We have found survivors in the ruins! Population added to [param]. = ¡Encontramos sobrevivientes en las ruinas! Población añadida a [param].
+We have found survivors in the ruins! Population added to [cityName]. = ¡Encontramos sobrevivientes en las ruinas! Población añadida a [cityName].
 survivors (adds population to a city) = sobrevivientes (añade población a una ciudad)
 
-We have found a stash of [param] Gold in the ruins! = Encontramos un balijo de [param] Oro en las ruinas
+We have found a stash of [goldAmount] Gold in the ruins! = Encontramos un balijo de [goldAmount] Oro en las ruinas
 a stash of gold = un balijo de oro
 
 discover a lost technology = descubrimiento de una tecnología perdida
@@ -3665,6 +3673,7 @@ Tundra = Tundra
 Desert = Desierto
 
 Lakes = Lagos
+Fresh water = Agua Dulce
 
 Mountain = Montañas
 Has an elevation of [amount] for visibility calculations = Tiene una elevación de [amount] para calculaciones de visibilidad
@@ -3685,6 +3694,7 @@ A Camp can be built here without cutting it down = Un Campamento puede ser const
 Jungle = Selva
 
 Marsh = Pantano
+Rare feature = Característica rara
 Only Polders can be built here = Solo Pólderos pueden ser construídos aquí
 
 Fallout = Terreno radioactivo
@@ -3880,10 +3890,13 @@ Porcelain = Porcelana
 #################### Lines from UnitPromotions from Civ V - Vanilla ####################
 
 Sword = Espada
+Mounted = Montado
+Siege = Asedio
 Ranged Gunpowder = Pólvora de largo alcance
 Armored = Blindado
 Melee Water = Cuerpo a cuerpo Agua
 Ranged Water = Largo Alcance Agua
+Submarine = Submarino
 Heal Instantly = Curar al Instante
 Heal this unit by [amount] HP = Cura esta unidad por [amount] HP
 Doing so will consume this opportunity to choose a Promotion = Hacerlo consumirá esta oportunidad de escojer una promoción
@@ -3942,6 +3955,7 @@ Medic = Médica
 All adjacent units heal [amount] HP when healing = Todas las unidades adyacentes se curan [amount] HP al sanarse
 
 Medic II = Médica II
+in [tileFilter] tiles = en casillas [tileFilter]
 [amount] HP when healing = [amount] HP al curarse
 
 Scouting I = Exploración I
@@ -4002,6 +4016,7 @@ Flight Deck III = Cubierta de Vuelo III
 Supply = Suministros
 May heal outside of friendly territory = Puede curarse fuera de territorio amistoso
 
+Bomber = Bombardero
 Siege I = Asedio I
 
 Siege II = Asedio II
@@ -4011,6 +4026,7 @@ Siege III = Asedio III
 Evasion = Evasión
 Damage taken from interception reduced by [amount]% = Daño recibido por intercepción reducido en [amount]%
 
+Fighter = Caza
 Interception I = Intercepción I
 [amount]% Damage when intercepting = [amount]% Daño al interceptar
 
@@ -4107,10 +4123,29 @@ Can see over obstacles =
 
 Atomic Bomber = Bombardero Atómico
 
+Missile = Misil
 Self-destructs when attacking = Se auto-destruye al atacar
 Cannot be intercepted = No puede ser interceptado
 
 Can pass through impassable tiles = Puede pasar por casillas infranqueables
+
+Melee = Cuerpo a cuerpo
+
+Ranged = A distancia
+
+Armor = Blindado
+
+WaterCivilian = Civil Naval
+
+WaterMelee = Naval cuerpo a cuerpo
+
+WaterRanged = Naval a distancia
+
+WaterSubmarine = Submarino Naval
+
+WaterAircraftCarrier = Portaaviones
+
+AtomicBomber = Bombardero Atómico
 
 
 #################### Lines from Units from Civ V - Vanilla ####################
@@ -4188,6 +4223,7 @@ Knight = Caballero
 Camel Archer = Arquero a Camello
 
 Conquistador = Conquistador
+on foreign continents = en continentes extranjeros
 
 Naresuan's Elephant = Elefante Naresuano
 
@@ -4278,6 +4314,7 @@ Anti-Tank Gun = Cañón Anti-Tanque
 
 Atomic Bomb = Bomba atómica
 Nuclear weapon of Strength [amount] = Arma Nuclear de Fuerza [amount]
+if [buildingName] is constructed = si [buildingName] está construido
 Blast radius [amount] = Radio de efecto [amount]
 
 Rocket Artillery = Artillería de Misiles
@@ -4312,6 +4349,7 @@ Great Artist = Gran Artista
 Can start an [amount]-turn golden age = Puede comenzar una edad de oro de [amount]-turnos 
 Can construct [improvementName] = Puede construir [improvementName]
 Great Person - [stat] = Gran Personaje - [stat]
+Unbuildable = Inedificable
 
 Great Scientist = Gran Científico
 Can hurry technology research = Puede acelerar investigaciones
@@ -4370,6 +4408,8 @@ Faith Healers = Sanadores por Fé
 Fertility Rites = Ritos de Fertilidad
 
 God of Craftsman = Dios de Artesanos
+ # Requires translation!
+in cities with at least [amount] [populationFilter] = 
 
 God of the Open Sky = Dios del Cielo Despejado
 
@@ -4421,6 +4461,7 @@ Feed the World = Alimenta el Mundo
 Guruship = Gurús
 
 Holy Warriors = Guerreros santos
+before the [era] = antes de [era]
 May buy [baseUnitFilter] units with [stat] for [amount] times their normal Production cost = puede comprar unidades [baseUnitFilter] con [stat] por [amount] veces su costo de producción normal
 
 Liturgical Drama = Drama Litúrgico
@@ -4441,6 +4482,7 @@ Religious Community = Comunidad Religiosa
 [amount]% [stat] from every follower, up to [amount2]% = [amount]% [stat] por cada seguidor, hasta [amount2]%
 
 Swords into Ploughshares = De Blandír a Arar
+when not at war = si no está en guerra
 
 Founder = Fundador
 Ceremonial Burial = Entierro Ceremonial
@@ -4573,9 +4615,6 @@ Starting in this era disables religion = Iniciar en esta era desabilita Religió
 
 
 Marine = Marines
-
-
-#################### Lines from GlobalUniques from Civ V - Gods & Kings ####################
 
 
 #################### Lines from Nations from Civ V - Gods & Kings ####################
@@ -4900,6 +4939,7 @@ Llanfairpwllgwyngyll = Llanfairpwllgwyngyll
 Falmouth = Falmouth
 Lorient = Lorient
 Celts = Celts
+with [amount] to [amount2] neighboring [tileFilter] [tileFilter2] tiles = con [amount] a [amount2] casillas [tileFilter] [tileFilter2] adyacentes
 
 Haile Selassie = Haile Selassie
 I have tried all other avenues, but yet you persist in this madness. I hope, for your sake, your end is swift. = He probado todas las otras vías, pero aún persistes en esta locura. Espero, por tu bien, que tu final sea rápido.
@@ -4944,6 +4984,7 @@ Gambela = Gambela
 Ziway = Ziway
 Weldiya = Weldiya
 Ethiopia = Etiopía
+when fighting units from a Civilization with more Cities than you = cuando luches contra unidades de una Civilización con más Ciudades que tú
 
 Pacal = Pacal
 A sacrifice unlike all others must be made! = ¡Se debe hacer un sacrificio diferente a todos los demás!
@@ -5029,10 +5070,10 @@ Taoism = Taoismo
 #################### Lines from Ruins from Civ V - Gods & Kings ####################
 
 
-We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[param] Faith) = Hemos encontrado simbolos religiosos en las ruinas, ¡dandonos un conocimiento más profundo de religión! (+[param] Fé)
+We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[faithAmount] Faith) = Hemos encontrado simbolos religiosos en las ruinas, ¡dandonos un conocimiento más profundo de religión! (+[faithAmount] Fé)
 discover holy symbols = descubriste simbolos religiosos
 
-We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[param] Faith) = Hemos encontrado una antigua profecía, ¡aumentando enormemente nuestra conección espiritual! (+[param] Fé)
+We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[faithAmount] Faith) = Hemos encontrado una antigua profecía, ¡aumentando enormemente nuestra conección espiritual! (+[faithAmount] Fé)
 an ancient prophecy = una profecía antigua
 
 
@@ -5090,7 +5131,15 @@ Polder = Pólder
 #################### Lines from TileResources from Civ V - Gods & Kings ####################
 
 
+Citrus = Cítricos
+
+Copper = Cobre
+
+Crab = Cangrejos
+
 Salt = Sal
+
+Truffles = Trufas
 
 
 #################### Lines from UnitPromotions from Civ V - Gods & Kings ####################
@@ -5422,45 +5471,20 @@ No Sight =
 [amount] XP gained from combat = [amount] XP obtenido del combate
 Irremovable = Inremovible
 when at war = si está en guerra
-when not at war = si no está en guerra
-during a Golden Age = durante una edad de oro
 with [resource] = con [resource]
-while the empire is happy = mientras el imperio es feliz
 when between [amount] and [amount2] Happiness = cuando entre [amount] y [amount2] Felicidad
 when below [amount] Happiness = cuando por debajo de[amount] felicidad
 during the [era] = durante el [era]
-before the [era] = antes de [era]
-starting from the [era] = a partir de la [era]
 if no other Civilization has researched this = si nadie más la ha investigado 
-after discovering [tech] = después de descubrir [tech]
-before discovering [tech] = antes de descubrir [tech]
 upon discovering [tech] = al descubrir [tech]
 after adopting [policy] = después de adoptar [policy]
-before adopting [policy] = antes de adoptar [policy]
-if [buildingName] is constructed = si [buildingName] está construido
-for [amount] turns = Por [amount] turnos
 by consuming this unit = al consumar esta unidad
 in cities with a [buildingFilter] = en ciudades con un/a [buildingFilter]
-in cities without a [buildingFilter] = en ciudades sin un/a [buildingFilter]
- # Requires translation!
-in cities with at least [amount] [populationFilter] = 
-with a garrison = con una guarnición
-for [mapUnitFilter] units = para unidades [mapUnitFilter]
 for units with [promotion] = para unidades con [promotion]
 for units without [promotion] = para unidades sin [promotion]
-vs cities = vs ciudades
-vs [mapUnitFilter] units = vs unidades [mapUnitFilter]
-when fighting units from a Civilization with more Cities than you = cuando luches contra unidades de una Civilización con más Ciudades que tú
-when attacking = al atacar
-when defending = al defender
-when fighting in [tileFilter] tiles = al pelear en casillas [tileFilter]
-on foreign continents = en continentes extranjeros
-when adjacent to a [mapUnitFilter] unit = cuando está adyacente a una unidad [mapUnitFilter]
 when above [amount] HP = cuando está por encima de [amount] HP
 when below [amount] HP = cuando está por debajo de [amount] HP
 with [amount] to [amount2] neighboring [tileFilter] tiles = con [amount] a [amount2] [tileFilter] fichas
-with [amount] to [amount2] neighboring [tileFilter] [tileFilter2] tiles = con [amount] a [amount2] casillas [tileFilter] [tileFilter2] adyacentes
-in [tileFilter] tiles = en casillas [tileFilter]
 in [tileFilter] [tileFilter2] tiles = en casillas [tileFilter] [tileFilter2]
 in tiles without [tileFilter] = en casillas sin [tileFilter]
 on water maps = en mapas de agua
@@ -5500,3 +5524,12 @@ Ruins = Ruinas
 CityState = ciudad-estado
 ModOptions = Opciones de mod
 Conditional = Condicional
+
+#################### Removed Lines ####################
+
+#~~Rough Terrain = Terreno Abrupto
+#~~Strategic = Estratégico
+#~~Bonus = bonificación
+#~~Luxury = Lujo
+#~~military water = militares marítimas
+#~~My treasury contains little and my soldiers are getting impatient... ...therefore you must die. = Mis arcas se acaban y mis soldados se impacientan... ...por eso debes morir.

--- a/android/assets/jsons/translations/Swedish.properties
+++ b/android/assets/jsons/translations/Swedish.properties
@@ -1109,8 +1109,6 @@ or [terrainType] = eller [terrainType]
 Can be constructed by = Kan konstrueras av
 Defence bonus = Försvarsbonus
 Movement cost = Förflyttningskostnad
-Open terrain = Öppen Terräng
-Rough Terrain = Kuperad Terräng
 for = för
 Missing translations: = Saknade översättningar:
 Resolution = Upplösning
@@ -1243,102 +1241,6 @@ Religion = Religion
 Enhancing religion = Förbättra Religion
 Enhanced religion = Förbättrad Religion
 
-# Terrains
-
-Impassable = Oframkomlig
-Rare feature = Ovanligt drag
-
-# terrainFilters (so for uniques like: "[stats] from [terrainFilter] tiles")
-
-All = Alla
-Water = Vatten
-Land = Land
-Coastal = Kustlig
-River = Flod
-Rough terrain = Kuperad terräng
-Foreign Land = Främmande Land
-Foreign = Utländsk
-Friendly Land = Vänliga Land
-Water resource = Vattenresurs
-Bonus resource = Bonusresurs
-Luxury resource = Lyxresurs
-Strategic resource = Strategisk resurs
-Fresh water = Färskvatten
-non-fresh water = icke-Färskvatten
-Natural Wonder = Naturligt Underverk
-Hybrid = Hybrid
-Undesirable = Oönskvärd
-Desirable = Önskvärd
-Featureless = Egenskapslös
-Fresh Water = Färskvatten
-
-# improvementFilters
-
-All Road = Alla Vägar
-Great Improvement = Stor Förbättring
-Great = Stor
-
-# Resources
-
-Bison = Bison
-Copper = Koppar
-Cocoa = Kakao
-Crab = Krabba
-Citrus = Citrus
-Truffles = Tryffel
-Strategic = Strategisk
-Bonus = Bonus
-Luxury = Lyx
-
-# Unit types
-
-City = Stad
-Civilian = Civil
-Melee = Närstrid
-Ranged = Räckvidd
-Scout = Spejare
-Mounted = Beriden
-Armor = Pansar
-Siege = Belägring
-
-WaterCivilian = civila vattenenheter
-WaterMelee = Vattennärstrid
-WaterRanged = Vattenräckvidd
-WaterSubmarine = Ubåt
-WaterAircraftCarrier = Hangarfartyg
-
-Fighter = Jaktplan
-Bomber = Bombplan
-AtomicBomber = Atombombplan
-Missile = Missil
-
-
-# Unit filters and other unit related things
-
-Air = Luft
-air units = luftenheter
-Barbarian = Barbar
-Barbarians = Barbarer
-Embarked = Ombordstigen
-land units = landenheter
-Military = Militär
-# Deprecated since 3.15.2, but should still be translated until it is officially removed
-military water = militära vatten
-non-air = icke-luft
-Nuclear Weapon = Kärnvapen
-Submarine = Ubåt
-submarine units = undervattensenheter
-Unbuildable = Obyggbar
-water units = vattenenheter
-wounded units = skadade enheter
-Wounded = Skadad
-
-# For the "All newly-trained [relevant] units in this city receive the [] promotion" translation. Relevant as in 'units that can receive'
-relevant = tillämpliga
-
-# For "May choose [amount] additional [beliefType] beliefs when [founding/enhancing] a religion"
-founding = grundande
-enhancing = förbättrande
 
 # Promotions
 
@@ -1346,6 +1248,7 @@ Pick promotion = Välj befordring
  OR  =  ELLER 
 units in open terrain = enheter i öppen terräng
 units in rough terrain = enheter i kuperad terräng
+wounded units = skadade enheter
 Targeting II (air) = Målsökning II (luft)
 Targeting III (air) = Målsökning III (luft)
 Bonus when performing air sweep [bonusAmount]% = Bonus vid luftrensning [bonusAmount]%
@@ -1449,6 +1352,11 @@ This Unit upgrades for free = Denna enhet uppgraderas gratis
 Never destroyed when the city is captured = Förstörs aldrig när staden blir erövrad
 Invisible to others = Osynlig för andra
 
+# Unused Resources
+
+Bison = Bison
+Cocoa = Kakao
+
 
 # In English we just paste all these conditionals at the end of each unique, but in your language that
 # may not turn into valid sentences. Therefore we have the following two translations to determine
@@ -1478,6 +1386,33 @@ ConditionalsPlacement = after
 ########################### AUTOMATICALLY GENERATED TRANSLATABLE STRINGS ########################### 
 
 
+######### Map Unit Filters ###########
+
+Wounded = Skadad
+Barbarians = Barbarer
+ # Requires translation!
+City-State = 
+Embarked = Ombordstigen
+ # Requires translation!
+Non-City = 
+
+######### Unit Type Filters ###########
+
+Military = Militär
+Civilian = Civil
+non-air = icke-luft
+relevant = tillämpliga
+Nuclear Weapon = Kärnvapen
+City = Stad
+Air = Luft
+land units = landenheter
+water units = vattenenheter
+air units = luftenheter
+ # Requires translation!
+military units = 
+submarine units = undervattensenheter
+Barbarian = Barbar
+
 ######### City filters ###########
 
 in this city = i denna stad
@@ -1496,6 +1431,64 @@ in annexed cities = i annekterade städer
 in holy cities = i heliga städer
 in City-State cities = i stadsstats städer
 in cities following this religion = i städer som följer denna religion
+
+######### Population Filters ###########
+
+ # Requires translation!
+Unemployed = 
+ # Requires translation!
+Followers of the Majority Religion = 
+ # Requires translation!
+Followers of this Religion = 
+
+######### Terrain Filters ###########
+
+All = Alla
+Coastal = Kustlig
+River = Flod
+Open terrain = Öppen Terräng
+Rough terrain = Kuperad terräng
+Water resource = Vattenresurs
+Foreign Land = Främmande Land
+Foreign = Utländsk
+Friendly Land = Vänliga Land
+ # Requires translation!
+Enemy Land = 
+Featureless = Egenskapslös
+Fresh Water = Färskvatten
+non-fresh water = icke-Färskvatten
+Natural Wonder = Naturligt Underverk
+Impassable = Oframkomlig
+Land = Land
+Water = Vatten
+Luxury resource = Lyxresurs
+Strategic resource = Strategisk resurs
+Bonus resource = Bonusresurs
+
+######### Tile Filters ###########
+
+ # Requires translation!
+unimproved = 
+All Road = Alla Vägar
+Great Improvement = Stor Förbättring
+
+######### Region Types ###########
+
+Hybrid = Hybrid
+
+######### Terrain Quality ###########
+
+Undesirable = Oönskvärd
+Desirable = Önskvärd
+
+######### Improvement Filters ###########
+
+Great = Stor
+
+######### Prophet Action Filters ###########
+
+founding = grundande
+enhancing = förbättrande
 
 ######### Unique Specials ###########
 
@@ -1523,6 +1516,7 @@ Temple of Artemis = Artemistemplet
 
 The Great Lighthouse = Fyrtornet på Faros
 'They that go down to the sea in ships, that do business in great waters; these see the works of the Lord, and his wonders in the deep.' - The Bible, Psalms 107:23-24 = 'Andra for på skepp över havet och drev handel på de stora vattnen. De såg Herrens verk, hans under i havets djup.' - Bibeln, Psaltaren 107:23-24
+for [mapUnitFilter] units = för [mapUnitFilter]-enheter
 [amount] Movement = [amount] Förflyttning
 [amount] Sight = [amount] Sikt
 
@@ -1571,6 +1565,8 @@ Krepost = Krepost
 
 Statue of Zeus = Zeusstatyn
 'He spoke, the son of Kronos, and nodded his head with the dark brows, and the immortally anointed hair of the great god swept from his divine head, and all Olympos was shaken' - The Iliad = 'Sade Kronion, och nu svartbrynade pannan han böjde, och det ambrosiska hår kring den högstes odödliga hufvud svallade böljande fram; då darrade hela Olympen.' - Iliaden
+vs cities = mot städer
+when attacking = vid anfall
 [amount]% Strength = [amount]% Styrka
 
 Lighthouse = Fyr
@@ -1671,10 +1667,12 @@ Notre Dame = Notre Dame
 Castle = Borg
 
 Mughal Fort = Mogulfort
+after discovering [tech] = efter upptäckten av [tech]
 [stats] [cityFilter] = [stats] [cityFilter]
 
 Himeji Castle = Himejislottet
 'Bushido is realized in the presence of death. This means choosing death whenever there is a choice between life and death. There is no other reasoning.' - Yamamoto Tsunetomo = 'Bushido förverkligas i dödens närvaro. Det betyder att välja död varje gång det finns ett val mellan liv och död. Det finns inget annat resonemang.' - Yamamoto Tsunetomo
+when fighting in [tileFilter] tiles = vid strid i [tileFilter]-rutor
 
 Ironworks = Stålverk
 
@@ -1781,6 +1779,8 @@ Pentagon = Pentagon
 
 Solar Plant = Solkraftverk
  # Requires translation!
+in cities without a [buildingFilter] = 
+ # Requires translation!
 Only available = 
 
 Nuclear Plant = Kärnkraftverk
@@ -1814,6 +1814,7 @@ King = Kung
 Era Starting Unit = Startenhet för eran
 
 Emperor = Kejsare
+Scout = Spejare
 
 Immortal = Odödlig
 Worker = Arbetare
@@ -1846,9 +1847,6 @@ Atomic era = Atomeran
 Information era = Informationseran
 
 Future era = Framtidseran
-
-
-#################### Lines from GlobalUniques from Civ V - Vanilla ####################
 
 
 #################### Lines from Nations from Civ V - Vanilla ####################
@@ -2185,6 +2183,7 @@ La Rochelle = La Rochelle
 Bourges = Bourges
 Calais = Calais
 France = Frankrike
+before discovering [tech] = innan upptäckten av [tech]
 
 Catherine = Katarina
 You've behaved yourself very badly, you know it. Now it's payback time. = Du har betett dig mycket illa, som du väl vet. Nu är det dags för bestraffning.
@@ -2239,7 +2238,8 @@ Russia = Ryssland
 Double quantity of [resource] produced = Dubbel mängd av [resource] produceras
 
 Augustus Caesar = Augustus Caesar
-My treasury contains little and my soldiers are getting impatient... ...therefore you must die. = Min skattkammare är nästintill tom och mina soldater otåliga...  ...därför måste du dö.
+ # Requires translation!
+My treasury contains little and my soldiers are getting impatient... (sigh) ...therefore you must die. = 
 So brave, yet so stupid! If only you had a brain similar to your courage. = Så modig, men ändå så korkad! Om du ändå hade hjärna i proportion till din ryggrad.
 The gods have deprived Rome of their favour. We have been defeated. = Gudarna har berövat Rom sin favör. Vi är besegrade.
 I greet you. I am Augustus, Imperator and Pontifex Maximus of Rome. If you are a friend of Rome, you are welcome. = Jag hälsar dig. Jag är Augustus, Kejsare och Pontifex Maximus av Rom. Om du är en vän till Rom, är du välkommen.
@@ -2773,6 +2773,7 @@ Paishiyauvada = Paishiyauvada
 Patigrbana = Patigrbana
 Phrada = Phrada
 Persia = Persien
+during a Golden Age = under en Guldålder
 
 Kamehameha I = Kamehameha I
 The ancient fire flashing across the sky is what proclaimed that this day would come, though I had foolishly hoped for a different outcome. = Den uråldriga elden som svepte över skyn förutspådde att denna dag skulle komme, fast jag hade i min dårskap hoppats på ett annorlunda utfall.
@@ -2825,6 +2826,7 @@ Nuguria = Nuguria
 Pileni = Pileni
 Nukumanu = Nukumanu
 Polynesia = Polynesien
+starting from the [era] = med början i [era]
 Enables embarkation for land units = Möjliggör ombordstigning för landenheter
  # Requires translation!
 Enables [mapUnitFilter] units to enter ocean tiles = 
@@ -3302,6 +3304,8 @@ Provides the cheapest [stat] building in your first [amount] cities for free = G
 Oligarchy = Oligarki
 Units in cities cost no Maintenance = Enheter i städer har ingen Driftkostnad
  # Requires translation!
+with a garrison = 
+ # Requires translation!
 [amount]% Strength for cities = 
 Landed Elite = Jordägande Elit
 [amount]% growth [cityFilter] = [amount]% tillväxt [cityFilter]
@@ -3324,6 +3328,8 @@ Liberty =
 
 Warrior Code = Krigaretos
 Discipline = Disciplin
+ # Requires translation!
+when adjacent to a [mapUnitFilter] unit = 
 Military Tradition = Militär Tradition
  # Requires translation!
 [amount]% XP gained from combat = 
@@ -3332,6 +3338,7 @@ Professional Army = Professionell Armé
 Honor Complete = Heder Fullbordat
  # Requires translation!
 Honor = 
+vs [mapUnitFilter] units = mot [mapUnitFilter]-enheter
  # Requires translation!
 Notified of new Barbarian encampments = 
 
@@ -3346,6 +3353,7 @@ Free Religion = Religionsfrihet
 Piety Complete = Tro Fullbordat
  # Requires translation!
 Piety = 
+before adopting [policy] = innan [policy] anammats
 
 Philantropy = Filantropi
 Gifts of Gold to City-States generate [amount]% more Influence = Guldgåvor till Stadsstater genererar [amount]% mer Inflytande
@@ -3390,10 +3398,12 @@ Rationalism Complete = Rationalism Fullbordat
 [amount] Free Technologies = [amount] Gratisteknologier
  # Requires translation!
 Rationalism = 
+while the empire is happy = medan riket är lyckligt
 [amount]% [stat] = [amount]% [stat]
 
 Constitution = Konstitution
 Universal Suffrage = Allmän Rösträtt
+when defending = vid försvar
 Civil Society = Civilsamhälle
  # Requires translation!
 [amount]% Food consumption by specialists [cityFilter] = 
@@ -3414,6 +3424,8 @@ Quantity of strategic resources produced by the empire +[amount]% = Mängd strat
 Police State = Polisstat
 Total War = Totalt Krig
 Autocracy Complete = Autokrati Fullbordat
+ # Requires translation!
+for [amount] turns = 
  # Requires translation!
 Autocracy = 
  # Requires translation!
@@ -3441,28 +3453,28 @@ Clear Barbarian Camp = Töm Barbarläger
 We feel threatened by a Barbarian Camp near our city. Please take care of it. = Vi känner oss hotade av ett Barbarläger nära vår stad. Var vänlig ta hand om det.
 
 Connect Resource = Länka samman resurs
-In order to make our civilizations stronger, connect [param] to your trade network. = Så att vi kan stärka våra civilisationer, koppla samman [param] till ditt handelsnätverk.
+In order to make our civilizations stronger, connect [tileResource] to your trade network. = Så att vi kan stärka våra civilisationer, koppla samman [tileResource] till ditt handelsnätverk.
 
 Construct Wonder = Bygg Underverk
-We recommend you to start building [param] to show the whole world your civilization strength. = Vi föreslår att du börjar bygga [param] för att visa hela världen din civilisations styrka.
+We recommend you to start building [wonder] to show the whole world your civilization strength. = Vi föreslår att du börjar bygga [wonder] för att visa hela världen din civilisations styrka.
 
 Acquire Great Person = Införskaffa Stor Person
-Great People can change the course of a Civilization! You will be rewarded for acquiring a new [param]. = Stora Personen slå in en Civilisation på nytt spår! Du kommer belönas om du skaffar en ny [param].
+Great People can change the course of a Civilization! You will be rewarded for acquiring a new [greatPerson]. = Stora Personen slå in en Civilisation på nytt spår! Du kommer belönas om du skaffar en ny [greatPerson].
 
 Conquer City State = Erövra Stadsstat
-It's time to erase the City-State of [param] from the map. You will be greatly rewarded for conquering them! = Det är dags att avlägsna Stadsstaten [param] från kartan. Du kommer rikeligen belönas om du erövrar dem!
+It's time to erase the City-State of [cityState] from the map. You will be greatly rewarded for conquering them! = Det är dags att avlägsna Stadsstaten [cityState] från kartan. Du kommer rikeligen belönas om du erövrar dem!
 
 Find Player = Hitta Spelare
-You have yet to discover where [param] set up their cities. You will be rewarded for finding their territories. = Du har ännu inte upptäck var [param] byggt sina städer. Du kommer belönas om du hittar deras territorier.
+You have yet to discover where [civName] set up their cities. You will be rewarded for finding their territories. = Du har ännu inte upptäck var [civName] byggt sina städer. Du kommer belönas om du hittar deras territorier.
 
 Find Natural Wonder = Hitta Naturligt Underverk
-Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [param] yet. = Skicka dina bästa utforskare på resa för att hitta Naturliga Underverk. Inget vet ännu var [param] finns.
+Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [naturalWonder] yet. = Skicka dina bästa utforskare på resa för att hitta Naturliga Underverk. Inget vet ännu var [naturalWonder] finns.
 
 Give Gold = Skänk Guld
-We are suffering great poverty after being robbed by [param], and unless we receive a sum of Gold, it's only a matter of time before we collapse. = Vi är hårt drabbade av fattigdom efter att [param] rånat oss, och om vi inte får en summa Guld är det bara en tidsfråga när vi kollapsar.
+We are suffering great poverty after being robbed by [civName], and unless we receive a sum of Gold, it's only a matter of time before we collapse. = Vi är hårt drabbade av fattigdom efter att [civName] rånat oss, och om vi inte får en summa Guld är det bara en tidsfråga när vi kollapsar.
 
 Pledge to Protect = Svär att Skydda
-We need your protection to stop the aggressions of [param]. By signing a Pledge of Protection, you'll confirm the bond that ties us. = Vi behöver ditt skydd för att stoppa hotet från [param]. Genom att skriva under en Ed att Beskydda, skulle du bekräfta banden som knyter oss samman.
+We need your protection to stop the aggressions of [civName]. By signing a Pledge of Protection, you'll confirm the bond that ties us. = Vi behöver ditt skydd för att stoppa hotet från [civName]. Genom att skriva under en Ed att Beskydda, skulle du bekräfta banden som knyter oss samman.
 
 Contest Culture = Kulturtävling
 The civilization with the largest Culture growth will gain a reward. = Civilisationen med mest Kulturtillväxt kommer få en belöning.
@@ -3474,15 +3486,15 @@ Contest Technologies = Teknologitävling
 The civilization with the largest number of new Technologies researched will gain a reward. = Civilisationen som upptäcker störst antal nya teknologier kommer få en belöning.
 
 Invest = Investera
-Our people are rejoicing thanks to a tourism boom. For a certain amount of time, any Gold donation will yield [amount]% extra Influence. = Vårt folk gläds åt en turistboom. För en viss tid kommer alla Guldgåvor ge [amount]% extra Inflytande.
+Our people are rejoicing thanks to a tourism boom. For a certain amount of time, any Gold donation will yield [50]% extra Influence. = Vårt folk gläds åt en turistboom. För en viss tid kommer alla Guldgåvor ge [50]% extra Inflytande.
 
 Bully City State = Mobba Stadsstat
-We are tired of the pretensions of [param]. If someone were to put them in their place by Demanding Tribute from them, they would be rewarded. = Vi är trötta på att [param] tror att de är något. Om någon tryckte ned dem i skorna genom att Kräva Brandskatt från dem, skulle de få en belöning.
+We are tired of the pretensions of [cityState]. If someone were to put them in their place by Demanding Tribute from them, they would be rewarded. = Vi är trötta på att [cityState] tror att de är något. Om någon tryckte ned dem i skorna genom att Kräva Brandskatt från dem, skulle de få en belöning.
 
 Denounce Civilization = Fördöm Civilisation
-We have been forced to pay tribute to [param]! We need you to tell the world of their ill deeds. = Vi har brandskattats av [param]! Du måste berätta om deras illdåd för hela världen.
+We have been forced to pay tribute to [civName]! We need you to tell the world of their ill deeds. = Vi har brandskattats av [civName]! Du måste berätta om deras illdåd för hela världen.
 
-We have heard the tenets of [param] and are most curious. Will you send missionaries to teach us about your religion? = Vi har hört om trossatserna i [param] och är mycket nyfikna. Kan du skicka missionärer för att lära oss om din religion?
+We have heard the tenets of [religionName] and are most curious. Will you send missionaries to teach us about your religion? = Vi har hört om trossatserna i [religionName] och är mycket nyfikna. Kan du skicka missionärer för att lära oss om din religion?
 
 
 #################### Lines from Ruins from Civ V - Vanilla ####################
@@ -3497,10 +3509,10 @@ squatters wishing to settle under your rule = ockupanter som vill bosätta sig u
 An ancient tribe trained us in their ways of combat! = En antik stam tränade oss i deras sätt att strida!
 your exploring unit receives training = din utforskande enhet får träning
 
-We have found survivors in the ruins! Population added to [param]. = Vi har hittat överlevare i ruinerna! Befolkning har lags till [param].
+We have found survivors in the ruins! Population added to [cityName]. = Vi har hittat överlevare i ruinerna! Befolkning har lags till [cityName].
 survivors (adds population to a city) = överlevare (lägger till befolkning i en stad)
 
-We have found a stash of [param] Gold in the ruins! = Vi har hittat en samling med [param] Guld i ruinerna!
+We have found a stash of [goldAmount] Gold in the ruins! = Vi har hittat en samling med [goldAmount] Guld i ruinerna!
 a stash of gold = en samling av guld
 
 discover a lost technology = upptäck en förlorad teknologi
@@ -3719,6 +3731,7 @@ Tundra = Tundra
 Desert = Öken
 
 Lakes = Sjöar
+Fresh water = Färskvatten
 
 Mountain = Berg
 Has an elevation of [amount] for visibility calculations = Har en höjd på [amount] för synlighetsberäkningar
@@ -3739,6 +3752,7 @@ A Camp can be built here without cutting it down = Ett Läger kan byggas här ut
 Jungle = Djungel
 
 Marsh = Träsk
+Rare feature = Ovanligt drag
 Only Polders can be built here = Endast Poldrar kan byggas här
 
 Fallout = Nedfall
@@ -3934,10 +3948,13 @@ Porcelain = Porslin
 #################### Lines from UnitPromotions from Civ V - Vanilla ####################
 
 Sword = Svärd
+Mounted = Beriden
+Siege = Belägring
 Ranged Gunpowder = Distans Krut
 Armored = Bepansrad
 Melee Water = Närstrids Vatten
 Ranged Water = Distans Vatten
+Submarine = Ubåt
 Heal Instantly = Läk Omedelbart
 Heal this unit by [amount] HP = Läk denna enhet med [amount] KP
 Doing so will consume this opportunity to choose a Promotion = Genom att göra detta förbrukas detta tillfälle att välja en Befordring
@@ -3997,6 +4014,7 @@ Medic = Sjukvårdare
 All adjacent units heal [amount] HP when healing = Alla intilliggande enheter läker [amount] KP då de läker
 
 Medic II = Sjukvårdare II
+in [tileFilter] tiles = i [tileFilter]-rutor
 [amount] HP when healing = [amount] KP vid läkning
 
 Scouting I = Spaning I
@@ -4058,6 +4076,7 @@ Flight Deck III = Flygdäck III
 Supply = Förnödenheter
 May heal outside of friendly territory = Kan läka utanför vänligt territorium
 
+Bomber = Bombplan
 Siege I = Belägring I
 
 Siege II = Belägring II
@@ -4067,6 +4086,7 @@ Siege III = Belägring III
 Evasion = Undanflykt
 Damage taken from interception reduced by [amount]% = Skada från genskjutningar minskas med [amount]%
 
+Fighter = Jaktplan
 Interception I = Genskjutning I
 [amount]% Damage when intercepting = [amount]% skada vid genskjutning
 
@@ -4164,10 +4184,29 @@ Can see over obstacles =
 
 Atomic Bomber = Atombombare
 
+Missile = Missil
 Self-destructs when attacking = Självdestruerar vid anfall
 Cannot be intercepted = Kan inte bli stoppad
 
 Can pass through impassable tiles = Kan gå igenom opasserbara rutor
+
+Melee = Närstrid
+
+Ranged = Räckvidd
+
+Armor = Pansar
+
+WaterCivilian = civila vattenenheter
+
+WaterMelee = Vattennärstrid
+
+WaterRanged = Vattenräckvidd
+
+WaterSubmarine = Ubåt
+
+WaterAircraftCarrier = Hangarfartyg
+
+AtomicBomber = Atombombplan
 
 
 #################### Lines from Units from Civ V - Vanilla ####################
@@ -4245,6 +4284,7 @@ Knight = Riddare
 Camel Archer = Kamelskytt
 
 Conquistador = Conquistador
+on foreign continents = på främmande kontinenter
 
 Naresuan's Elephant = Naresuans Elefant
 
@@ -4335,6 +4375,8 @@ Anti-Tank Gun = Pansarvärnskanon
 
 Atomic Bomb = Atombomb
 Nuclear weapon of Strength [amount] = Kärnvapen av Styrka [amount]
+ # Requires translation!
+if [buildingName] is constructed = 
 Blast radius [amount] = Sprängradie [amount]
 
 Rocket Artillery = Raketartilleri
@@ -4369,6 +4411,7 @@ Great Artist = Stor Konstnär
 Can start an [amount]-turn golden age = Kan påbörja en [amount]-drags guldålder
 Can construct [improvementName] = Kan bygga [improvementName]
 Great Person - [stat] = Stor Person - [stat]
+Unbuildable = Obyggbar
 
 Great Scientist = Stor Forskare
 Can hurry technology research = Kan påskynda forskning
@@ -4428,6 +4471,8 @@ Faith Healers = Helbrägdagörare
 Fertility Rites = Fruktbarhetsriter
 
 God of Craftsman = Hantverkarnas Gud
+ # Requires translation!
+in cities with at least [amount] [populationFilter] = 
 
 God of the Open Sky = Den Öppna Himlens Gud
 
@@ -4479,6 +4524,7 @@ Feed the World = Mata Världen
 Guruship = Guruskap
 
 Holy Warriors = Heliga Krigare
+before the [era] = innan [era]
 May buy [baseUnitFilter] units with [stat] for [amount] times their normal Production cost = Kan köpa [baseUnitFilter]-enheter med [stat] för [amount] gånger deras normala Produktionskostnad
 
 Liturgical Drama = Liturgiskt Drama
@@ -4499,6 +4545,7 @@ Religious Community = Religiös Gemenskap
 [amount]% [stat] from every follower, up to [amount2]% = [amount]% [stat] från varje anhängare, upp till [amount2]%
 
 Swords into Ploughshares = Svärd till Plogbillar
+when not at war = medan ej i krig
 
 Founder = Grundare
 Ceremonial Burial = Ceremoniell Begravning
@@ -4631,9 +4678,6 @@ Starting in this era disables religion = Att starta i denna era kommer att stän
 
 
 Marine = Marinsoldat
-
-
-#################### Lines from GlobalUniques from Civ V - Gods & Kings ####################
 
 
 #################### Lines from Nations from Civ V - Gods & Kings ####################
@@ -4958,6 +5002,7 @@ Llanfairpwllgwyngyll = Llanfairpwllgwyngyll
 Falmouth = Falmouth
 Lorient = Lorient
 Celts = Kelterna
+with [amount] to [amount2] neighboring [tileFilter] [tileFilter2] tiles = med [amount] till [amount2] angränsande [tileFilter] [tileFilter2]-rutor
 
 Haile Selassie = Haile Selassie
 I have tried all other avenues, but yet you persist in this madness. I hope, for your sake, your end is swift. = Jag har provat alla andra vägar, men du envisas i denna galenskap. Jag hoppas för din skull att ditt slut blir kort.
@@ -5002,6 +5047,7 @@ Gambela = Gambela
 Ziway = Ziway
 Weldiya = Weldiya
 Ethiopia = Etiopien
+when fighting units from a Civilization with more Cities than you = vid strid mot enheter från en Civilisation med fler Städer än du
 
 Pacal = Pakal
 A sacrifice unlike all others must be made! = Nu krävs ett offer utan dess like!
@@ -5087,10 +5133,10 @@ Taoism = Daoism
 #################### Lines from Ruins from Civ V - Gods & Kings ####################
 
 
-We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[param] Faith) = Vi har hittat heliga symboler i ruinerna, vilket ger oss en djupare förståelse för religion! (+[param] Tro)
+We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[faithAmount] Faith) = Vi har hittat heliga symboler i ruinerna, vilket ger oss en djupare förståelse för religion! (+[faithAmount] Tro)
 discover holy symbols = upptäck heliga symboler
 
-We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[param] Faith) = Vi har hittat en antik profetia i ruinerna, vilket kraftigt ökar vår andliga anslutning! (+[param] Tro)
+We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[faithAmount] Faith) = Vi har hittat en antik profetia i ruinerna, vilket kraftigt ökar vår andliga anslutning! (+[faithAmount] Tro)
 an ancient prophecy = en antik profetia
 
 
@@ -5148,7 +5194,15 @@ Polder = Polder
 #################### Lines from TileResources from Civ V - Gods & Kings ####################
 
 
+Citrus = Citrus
+
+Copper = Koppar
+
+Crab = Krabba
+
 Salt = Salt
+
+Truffles = Tryffel
 
 
 #################### Lines from UnitPromotions from Civ V - Gods & Kings ####################
@@ -5497,59 +5551,29 @@ No Sight =
  # Requires translation!
 Irremovable = 
 when at war = medan i krig
-when not at war = medan ej i krig
-during a Golden Age = under en Guldålder
  # Requires translation!
 with [resource] = 
-while the empire is happy = medan riket är lyckligt
  # Requires translation!
 when between [amount] and [amount2] Happiness = 
  # Requires translation!
 when below [amount] Happiness = 
 during the [era] = under [era]
-before the [era] = innan [era]
-starting from the [era] = med början i [era]
  # Requires translation!
 if no other Civilization has researched this = 
-after discovering [tech] = efter upptäckten av [tech]
-before discovering [tech] = innan upptäckten av [tech]
  # Requires translation!
 upon discovering [tech] = 
 after adopting [policy] = efter att [policy] anammats
-before adopting [policy] = innan [policy] anammats
- # Requires translation!
-if [buildingName] is constructed = 
- # Requires translation!
-for [amount] turns = 
  # Requires translation!
 by consuming this unit = 
  # Requires translation!
 in cities with a [buildingFilter] = 
  # Requires translation!
-in cities without a [buildingFilter] = 
- # Requires translation!
-in cities with at least [amount] [populationFilter] = 
- # Requires translation!
-with a garrison = 
-for [mapUnitFilter] units = för [mapUnitFilter]-enheter
- # Requires translation!
 for units with [promotion] = 
  # Requires translation!
 for units without [promotion] = 
-vs cities = mot städer
-vs [mapUnitFilter] units = mot [mapUnitFilter]-enheter
-when fighting units from a Civilization with more Cities than you = vid strid mot enheter från en Civilisation med fler Städer än du
-when attacking = vid anfall
-when defending = vid försvar
-when fighting in [tileFilter] tiles = vid strid i [tileFilter]-rutor
-on foreign continents = på främmande kontinenter
- # Requires translation!
-when adjacent to a [mapUnitFilter] unit = 
 when above [amount] HP = medan över [amount] KP
 when below [amount] HP = medan under [amount] KP
 with [amount] to [amount2] neighboring [tileFilter] tiles = med [amount] till [amount2] angränsande [tileFilter]-rutor
-with [amount] to [amount2] neighboring [tileFilter] [tileFilter2] tiles = med [amount] till [amount2] angränsande [tileFilter] [tileFilter2]-rutor
-in [tileFilter] tiles = i [tileFilter]-rutor
 in [tileFilter] [tileFilter2] tiles = i [tileFilter] [tileFilter2]-rutor
 in tiles without [tileFilter] = i rutor utan [tileFilter]
 on water maps = på vattenkartor
@@ -5607,3 +5631,12 @@ CityState =
 ModOptions = 
  # Requires translation!
 Conditional = 
+
+#################### Removed Lines ####################
+
+#~~Rough Terrain = Kuperad Terräng
+#~~Strategic = Strategisk
+#~~Bonus = Bonus
+#~~Luxury = Lyx
+#~~military water = militära vatten
+#~~My treasury contains little and my soldiers are getting impatient... ...therefore you must die. = Min skattkammare är nästintill tom och mina soldater otåliga...  ...därför måste du dö.

--- a/android/assets/jsons/translations/Traditional_Chinese.properties
+++ b/android/assets/jsons/translations/Traditional_Chinese.properties
@@ -1367,9 +1367,6 @@ or [terrainType] =
 Can be constructed by = 
 Defence bonus = 防禦力加成
 Movement cost = 移動力消耗
- # Requires translation!
-Open terrain = 
-Rough Terrain = 崎嶇地形
 for = ，當建造在擁有下列資源的地區上時：
 Missing translations: = 未翻譯的字串:
 Resolution = 解析度
@@ -1548,123 +1545,6 @@ Enhancing religion =
  # Requires translation!
 Enhanced religion = 
 
-# Terrains
-
-Impassable = 不能通行
-Rare feature = 稀有地貌
-
-# terrainFilters (so for uniques like: "[stats] from [terrainFilter] tiles")
-
- # Requires translation!
-All = 
-Water = 水上
-Land = 陸軍
- # Requires translation!
-Coastal = 
-River = 河流
-Rough terrain = 崎嶇地形
-Foreign Land = 異國領土
- # Requires translation!
-Foreign = 
-Friendly Land = 友好領土
-Water resource = 水上資源
- # Requires translation!
-Bonus resource = 
- # Requires translation!
-Luxury resource = 
- # Requires translation!
-Strategic resource = 
-Fresh water = 淡水
-non-fresh water = 非淡水
- # Requires translation!
-Natural Wonder = 
- # Requires translation!
-Hybrid = 
- # Requires translation!
-Undesirable = 
- # Requires translation!
-Desirable = 
- # Requires translation!
-Featureless = 
- # Requires translation!
-Fresh Water = 
-
-# improvementFilters
-
- # Requires translation!
-All Road = 
-Great Improvement = 偉人設施
- # Requires translation!
-Great = 
-
-# Resources
-
-Bison = 野牛
-Copper = 赤銅
-Cocoa = 可可
-Crab = 螃蟹
-Citrus = 柑橘
-Truffles = 松露
-Strategic = 戰略資源
-Bonus = 獎勵資源
-Luxury = 奢侈資源
-
-# Unit types
-
-City = 城市
-Civilian = 平民
-Melee = 近戰單位
-Ranged = 遠程單位
-Scout = 斥候
-Mounted = 騎乘
-Armor = 裝甲
-Siege = 攻城
-
-WaterCivilian = 海上平民
-WaterMelee = 海軍近戰
-WaterRanged = 海軍遠程
-WaterSubmarine = 海軍潛艇
-WaterAircraftCarrier = 海軍航母單位
-
-Fighter = 戰鬥機
-Bomber = 轟炸機
- # Requires translation!
-AtomicBomber = 
-Missile = 導彈單位
-
-
-# Unit filters and other unit related things
-
-Air = 空軍
-air units = 空軍單位
-Barbarian = 蠻族
-Barbarians = 蠻族
- # Requires translation!
-Embarked = 
-land units = 陸軍單位
-Military = 軍事
-# Deprecated since 3.15.2, but should still be translated until it is officially removed
- # Requires translation!
-military water = 
-non-air = 非空軍
- # Requires translation!
-Nuclear Weapon = 
-Submarine = 潛艇
- # Requires translation!
-submarine units = 
-Unbuildable = 不可训练單位
-water units = 海軍單位
-wounded units = 受傷單位
-Wounded = 受傷
-
-# For the "All newly-trained [relevant] units in this city receive the [] promotion" translation. Relevant as in 'units that can receive'
-relevant = 相應的
-
-# For "May choose [amount] additional [beliefType] beliefs when [founding/enhancing] a religion"
- # Requires translation!
-founding = 
- # Requires translation!
-enhancing = 
 
 # Promotions
 
@@ -1672,6 +1552,7 @@ Pick promotion = 選擇升級項目
  OR  = 或
 units in open terrain = 位於開闊地形的單位
 units in rough terrain = 位於崎嶇地形的單位
+wounded units = 受傷單位
 Targeting II (air) = 空中定位II級
 Targeting III (air) = 空中定位III級
 Bonus when performing air sweep [bonusAmount]% = 空中遊獵時+[bonusAmount]%戰鬥力
@@ -1814,6 +1695,11 @@ This Unit upgrades for free =
 Never destroyed when the city is captured = 
 Invisible to others = 對其他單位隱形
 
+# Unused Resources
+
+Bison = 野牛
+Cocoa = 可可
+
 
 # In English we just paste all these conditionals at the end of each unique, but in your language that
 # may not turn into valid sentences. Therefore we have the following two translations to determine
@@ -1844,6 +1730,36 @@ ConditionalsPlacement =
 ########################### AUTOMATICALLY GENERATED TRANSLATABLE STRINGS ########################### 
 
 
+######### Map Unit Filters ###########
+
+Wounded = 受傷
+Barbarians = 蠻族
+ # Requires translation!
+City-State = 
+ # Requires translation!
+Embarked = 
+ # Requires translation!
+Non-City = 
+
+######### Unit Type Filters ###########
+
+Military = 軍事
+Civilian = 平民
+non-air = 非空軍
+relevant = 相應的
+ # Requires translation!
+Nuclear Weapon = 
+City = 城市
+Air = 空軍
+land units = 陸軍單位
+water units = 海軍單位
+air units = 空軍單位
+ # Requires translation!
+military units = 
+ # Requires translation!
+submarine units = 
+Barbarian = 蠻族
+
 ######### City filters ###########
 
 in this city = 所在城市
@@ -1871,6 +1787,81 @@ in holy cities =
 in City-State cities = 
  # Requires translation!
 in cities following this religion = 
+
+######### Population Filters ###########
+
+ # Requires translation!
+Unemployed = 
+ # Requires translation!
+Followers of the Majority Religion = 
+ # Requires translation!
+Followers of this Religion = 
+
+######### Terrain Filters ###########
+
+ # Requires translation!
+All = 
+ # Requires translation!
+Coastal = 
+River = 河流
+ # Requires translation!
+Open terrain = 
+Rough terrain = 崎嶇地形
+Water resource = 水上資源
+Foreign Land = 異國領土
+ # Requires translation!
+Foreign = 
+Friendly Land = 友好領土
+ # Requires translation!
+Enemy Land = 
+ # Requires translation!
+Featureless = 
+ # Requires translation!
+Fresh Water = 
+non-fresh water = 非淡水
+ # Requires translation!
+Natural Wonder = 
+Impassable = 不能通行
+Land = 陸軍
+Water = 水上
+ # Requires translation!
+Luxury resource = 
+ # Requires translation!
+Strategic resource = 
+ # Requires translation!
+Bonus resource = 
+
+######### Tile Filters ###########
+
+ # Requires translation!
+unimproved = 
+ # Requires translation!
+All Road = 
+Great Improvement = 偉人設施
+
+######### Region Types ###########
+
+ # Requires translation!
+Hybrid = 
+
+######### Terrain Quality ###########
+
+ # Requires translation!
+Undesirable = 
+ # Requires translation!
+Desirable = 
+
+######### Improvement Filters ###########
+
+ # Requires translation!
+Great = 
+
+######### Prophet Action Filters ###########
+
+ # Requires translation!
+founding = 
+ # Requires translation!
+enhancing = 
 
 ######### Unique Specials ###########
 
@@ -1904,6 +1895,8 @@ Temple of Artemis = 阿爾忒彌斯神廟
 
 The Great Lighthouse = 大燈塔
 'They that go down to the sea in ships, that do business in great waters; these see the works of the Lord, and his wonders in the deep.' - The Bible, Psalms 107:23-24 = “在大海上坐船，在大水裡處理事物的；他們看到耶和華的作為，並他在深水中的奇事。”——聖經·詩篇 107:23-24
+ # Requires translation!
+for [mapUnitFilter] units = 
  # Requires translation!
 [amount] Movement = 
  # Requires translation!
@@ -1957,6 +1950,10 @@ Krepost = 俄羅斯營壘
 
 Statue of Zeus = 宙斯神像
 'He spoke, the son of Kronos, and nodded his head with the dark brows, and the immortally anointed hair of the great god swept from his divine head, and all Olympos was shaken' - The Iliad = “克羅諾斯之子言罷，彎頸點動濃黑的眉毛，塗著仙液的發綹從眾神之王永生的頭顱上順勢潑瀉，搖撼著巍峨的奧林匹斯山脈。” —— 荷馬：《伊利亞特》
+ # Requires translation!
+vs cities = 
+ # Requires translation!
+when attacking = 
  # Requires translation!
 [amount]% Strength = 
 
@@ -2069,11 +2066,15 @@ Notre Dame = 巴黎聖母院
 Castle = 城堡
 
 Mughal Fort = 莫臥兒城塞
+ # Requires translation!
+after discovering [tech] = 
 [stats] [cityFilter] = [cityFilter][stats]
 
 Himeji Castle = 姬路城
  # Requires translation!
 'Bushido is realized in the presence of death. This means choosing death whenever there is a choice between life and death. There is no other reasoning.' - Yamamoto Tsunetomo = 
+ # Requires translation!
+when fighting in [tileFilter] tiles = 
 
 Ironworks = 鋼鐵廠
 
@@ -2198,6 +2199,8 @@ Pentagon = 五角大廈
 
 Solar Plant = 太陽能電廠
  # Requires translation!
+in cities without a [buildingFilter] = 
+ # Requires translation!
 Only available = 
 
 Nuclear Plant = 核電廠
@@ -2239,6 +2242,7 @@ King = 國王
 Era Starting Unit = 
 
 Emperor = 皇帝
+Scout = 斥候
 
 Immortal = 仙人
 Worker = 工人
@@ -2272,9 +2276,6 @@ Atomic era =
 Information era = 資訊時代
 
 Future era = 未來時代
-
-
-#################### Lines from GlobalUniques from Civ V - Vanilla ####################
 
 
 #################### Lines from Nations from Civ V - Vanilla ####################
@@ -2625,6 +2626,8 @@ La Rochelle = 拉羅謝爾
 Bourges = 布日
 Calais = 加萊
 France = 法蘭西
+ # Requires translation!
+before discovering [tech] = 
 
 Catherine = 葉卡捷琳娜二世
 You've behaved yourself very badly, you know it. Now it's payback time. = 如果我可以活到兩百歲，整個世界都將匍匐在我腳下，現在首先從你開始！
@@ -2682,7 +2685,7 @@ Double quantity of [resource] produced = [resource]產量加倍
 
 Augustus Caesar = 奧古斯都·愷撒
  # Requires translation!
-My treasury contains little and my soldiers are getting impatient... ...therefore you must die. = 
+My treasury contains little and my soldiers are getting impatient... (sigh) ...therefore you must die. = 
 So brave, yet so stupid! If only you had a brain similar to your courage. = 蠢貨，是愚昧給了你挑釁的勇氣！厄運如密佈的箭弩落下，而你終將無處躲避。
 The gods have deprived Rome of their favour. We have been defeated. = 你即使征服了全世界，如果沒有人分享，終將倍感淒涼。羅馬榮耀永存！
 I greet you. I am Augustus, Imperator and Pontifex Maximus of Rome. If you are a friend of Rome, you are welcome. = 歡迎你。我是奧古斯都，羅馬帝國皇帝兼最高祭司。如果你是羅馬的朋友，那麼你將受到歡迎。
@@ -3238,6 +3241,8 @@ Paishiyauvada = 帕西亞威達
 Patigrbana = 帕瓦格班納
 Phrada = 弗拉達
 Persia = 波斯
+ # Requires translation!
+during a Golden Age = 
 
 Kamehameha I = 卡美哈梅哈一世
 The ancient fire flashing across the sky is what proclaimed that this day would come, though I had foolishly hoped for a different outcome. = 我曾愚蠢的期盼有其他結果，但當大火在天上閃過，這一天將會到來。
@@ -3292,6 +3297,8 @@ Nuguria = 努古裡亞
 Pileni = 皮萊尼
 Nukumanu = 努庫馬努
 Polynesia = 波利尼西亞
+ # Requires translation!
+starting from the [era] = 
 Enables embarkation for land units = 陸軍單位擁有船運能力
  # Requires translation!
 Enables [mapUnitFilter] units to enter ocean tiles = 
@@ -3799,6 +3806,8 @@ Provides the cheapest [stat] building in your first [amount] cities for free =
 Oligarchy = 寡頭政治
 Units in cities cost no Maintenance = 鎮守城市的單位無需維護費
  # Requires translation!
+with a garrison = 
+ # Requires translation!
 [amount]% Strength for cities = 
 Landed Elite = 縉紳階層
  # Requires translation!
@@ -3823,6 +3832,8 @@ Liberty =
 
 Warrior Code = 尚武精神
 Discipline = 軍事紀律
+ # Requires translation!
+when adjacent to a [mapUnitFilter] unit = 
 Military Tradition = 軍事傳統
  # Requires translation!
 [amount]% XP gained from combat = 
@@ -3831,6 +3842,8 @@ Professional Army = 職業軍隊
 Honor Complete = 完整的榮譽政策
  # Requires translation!
 Honor = 
+ # Requires translation!
+vs [mapUnitFilter] units = 
  # Requires translation!
 Notified of new Barbarian encampments = 
 
@@ -3846,6 +3859,8 @@ Free Religion = 信仰自由
 Piety Complete = 完整的虔信政策
  # Requires translation!
 Piety = 
+ # Requires translation!
+before adopting [policy] = 
 
  # Requires translation!
 Philantropy = 
@@ -3907,10 +3922,14 @@ Rationalism Complete = 完整的理性政策
  # Requires translation!
 Rationalism = 
  # Requires translation!
+while the empire is happy = 
+ # Requires translation!
 [amount]% [stat] = 
 
 Constitution = 憲政主義
 Universal Suffrage = 普選制度
+ # Requires translation!
+when defending = 
 Civil Society = 公民社會
  # Requires translation!
 [amount]% Food consumption by specialists [cityFilter] = 
@@ -3934,6 +3953,8 @@ Quantity of strategic resources produced by the empire +[amount]% =
 Police State = 員警國家
 Total War = 全面戰爭
 Autocracy Complete = 完整的獨裁政策
+ # Requires translation!
+for [amount] turns = 
  # Requires translation!
 Autocracy = 
  # Requires translation!
@@ -3968,34 +3989,34 @@ Clear Barbarian Camp = 清除蠻族營地
 We feel threatened by a Barbarian Camp near our city. Please take care of it. = 附近的一個蠻人營地對我們的都市構成了極大威脅，請處理好它。
 
 Connect Resource = 連接資源
-In order to make our civilizations stronger, connect [param] to your trade network. = 開發資源[param]並將其連接到您的貿易網絡，我們的商人將會十分高興。
+In order to make our civilizations stronger, connect [tileResource] to your trade network. = 開發資源[tileResource]並將其連接到您的貿易網絡，我們的商人將會十分高興。
 
 Construct Wonder = 建造奇觀
-We recommend you to start building [param] to show the whole world your civilization strength. = 如果您能建造[param]，我們的學者和藝術家將會交口稱譽您的成就。
+We recommend you to start building [wonder] to show the whole world your civilization strength. = 如果您能建造[wonder]，我們的學者和藝術家將會交口稱譽您的成就。
 
 Acquire Great Person = 獲得偉人
-Great People can change the course of a Civilization! You will be rewarded for acquiring a new [param]. = 偉人可以改變文明的進程！您將獲得一個新的[param]。
+Great People can change the course of a Civilization! You will be rewarded for acquiring a new [greatPerson]. = 偉人可以改變文明的進程！您將獲得一個新的[greatPerson]。
 
  # Requires translation!
 Conquer City State = 
  # Requires translation!
-It's time to erase the City-State of [param] from the map. You will be greatly rewarded for conquering them! = 
+It's time to erase the City-State of [cityState] from the map. You will be greatly rewarded for conquering them! = 
 
 Find Player = 尋找文明
-You have yet to discover where [param] set up their cities. You will be rewarded for finding their territories. = 您尚未發現[param]在哪裡建立他們的城市。找到他們將會給您獎勵。
+You have yet to discover where [civName] set up their cities. You will be rewarded for finding their territories. = 您尚未發現[civName]在哪裡建立他們的城市。找到他們將會給您獎勵。
 
 Find Natural Wonder = 探索自然奇觀
-Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [param] yet. = 派遣你最好的探險家去探索自然奇觀。還沒有人知道[param]的位置。
+Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [naturalWonder] yet. = 派遣你最好的探險家去探索自然奇觀。還沒有人知道[naturalWonder]的位置。
 
  # Requires translation!
 Give Gold = 
  # Requires translation!
-We are suffering great poverty after being robbed by [param], and unless we receive a sum of Gold, it's only a matter of time before we collapse. = 
+We are suffering great poverty after being robbed by [civName], and unless we receive a sum of Gold, it's only a matter of time before we collapse. = 
 
  # Requires translation!
 Pledge to Protect = 
  # Requires translation!
-We need your protection to stop the aggressions of [param]. By signing a Pledge of Protection, you'll confirm the bond that ties us. = 
+We need your protection to stop the aggressions of [civName]. By signing a Pledge of Protection, you'll confirm the bond that ties us. = 
 
  # Requires translation!
 Contest Culture = 
@@ -4015,20 +4036,20 @@ The civilization with the largest number of new Technologies researched will gai
  # Requires translation!
 Invest = 
  # Requires translation!
-Our people are rejoicing thanks to a tourism boom. For a certain amount of time, any Gold donation will yield [amount]% extra Influence. = 
+Our people are rejoicing thanks to a tourism boom. For a certain amount of time, any Gold donation will yield [50]% extra Influence. = 
 
  # Requires translation!
 Bully City State = 
  # Requires translation!
-We are tired of the pretensions of [param]. If someone were to put them in their place by Demanding Tribute from them, they would be rewarded. = 
+We are tired of the pretensions of [cityState]. If someone were to put them in their place by Demanding Tribute from them, they would be rewarded. = 
 
  # Requires translation!
 Denounce Civilization = 
  # Requires translation!
-We have been forced to pay tribute to [param]! We need you to tell the world of their ill deeds. = 
+We have been forced to pay tribute to [civName]! We need you to tell the world of their ill deeds. = 
 
  # Requires translation!
-We have heard the tenets of [param] and are most curious. Will you send missionaries to teach us about your religion? = 
+We have heard the tenets of [religionName] and are most curious. Will you send missionaries to teach us about your religion? = 
 
 
 #################### Lines from Ruins from Civ V - Vanilla ####################
@@ -4050,12 +4071,12 @@ An ancient tribe trained us in their ways of combat! =
 your exploring unit receives training = 
 
  # Requires translation!
-We have found survivors in the ruins! Population added to [param]. = 
+We have found survivors in the ruins! Population added to [cityName]. = 
  # Requires translation!
 survivors (adds population to a city) = 
 
  # Requires translation!
-We have found a stash of [param] Gold in the ruins! = 
+We have found a stash of [goldAmount] Gold in the ruins! = 
  # Requires translation!
 a stash of gold = 
 
@@ -4294,6 +4315,7 @@ Tundra = 凍土
 Desert = 沙漠
 
 Lakes = 湖泊
+Fresh water = 淡水
 
 Mountain = 山脈
  # Requires translation!
@@ -4319,6 +4341,7 @@ A Camp can be built here without cutting it down =
 Jungle = 叢林
 
 Marsh = 沼澤
+Rare feature = 稀有地貌
  # Requires translation!
 Only Polders can be built here = 
 
@@ -4542,6 +4565,8 @@ Porcelain =
 
  # Requires translation!
 Sword = 
+Mounted = 騎乘
+Siege = 攻城
  # Requires translation!
 Ranged Gunpowder = 
  # Requires translation!
@@ -4550,6 +4575,7 @@ Armored =
 Melee Water = 
  # Requires translation!
 Ranged Water = 
+Submarine = 潛艇
 Heal Instantly = 浴火重生
  # Requires translation!
 Heal this unit by [amount] HP = 
@@ -4616,6 +4642,8 @@ Medic = 治療I級
 All adjacent units heal [amount] HP when healing = 
 
 Medic II = 治療II級
+ # Requires translation!
+in [tileFilter] tiles = 
  # Requires translation!
 [amount] HP when healing = 
 
@@ -4686,6 +4714,7 @@ Supply =
  # Requires translation!
 May heal outside of friendly territory = 
 
+Bomber = 轟炸機
 Siege I = 攻堅I級
 
 Siege II = 攻堅II級
@@ -4696,6 +4725,7 @@ Evasion = 規避能力
  # Requires translation!
 Damage taken from interception reduced by [amount]% = 
 
+Fighter = 戰鬥機
 Interception I = 攔截I級
  # Requires translation!
 [amount]% Damage when intercepting = 
@@ -4812,12 +4842,32 @@ Can see over obstacles =
  # Requires translation!
 Atomic Bomber = 
 
+Missile = 導彈單位
  # Requires translation!
 Self-destructs when attacking = 
  # Requires translation!
 Cannot be intercepted = 
 
 Can pass through impassable tiles = 可以穿過無法通行的地塊
+
+Melee = 近戰單位
+
+Ranged = 遠程單位
+
+Armor = 裝甲
+
+WaterCivilian = 海上平民
+
+WaterMelee = 海軍近戰
+
+WaterRanged = 海軍遠程
+
+WaterSubmarine = 海軍潛艇
+
+WaterAircraftCarrier = 海軍航母單位
+
+ # Requires translation!
+AtomicBomber = 
 
 
 #################### Lines from Units from Civ V - Vanilla ####################
@@ -4902,6 +4952,8 @@ Knight = 騎士
 Camel Archer = 駱駝騎射手
 
 Conquistador = 西班牙征服者
+ # Requires translation!
+on foreign continents = 
 
 Naresuan's Elephant = 納黎萱戰象
 
@@ -4997,6 +5049,8 @@ Atomic Bomb = 原子彈
  # Requires translation!
 Nuclear weapon of Strength [amount] = 
  # Requires translation!
+if [buildingName] is constructed = 
+ # Requires translation!
 Blast radius [amount] = 
 
 Rocket Artillery = 火箭炮
@@ -5039,6 +5093,7 @@ Great Artist = 大藝術家
 Can start an [amount]-turn golden age = 可以開啟[amount]回合黃金時代
 Can construct [improvementName] = 能建造[improvementName]
 Great Person - [stat] = 偉人 - [stat]
+Unbuildable = 不可训练單位
 
 Great Scientist = 大科學家
 Can hurry technology research = 可以加速科技研究
@@ -5121,6 +5176,8 @@ Fertility Rites =
 
  # Requires translation!
 God of Craftsman = 
+ # Requires translation!
+in cities with at least [amount] [populationFilter] = 
 
  # Requires translation!
 God of the Open Sky = 
@@ -5201,6 +5258,8 @@ Guruship =
  # Requires translation!
 Holy Warriors = 
  # Requires translation!
+before the [era] = 
+ # Requires translation!
 May buy [baseUnitFilter] units with [stat] for [amount] times their normal Production cost = 
 
  # Requires translation!
@@ -5231,6 +5290,8 @@ Religious Community =
 
  # Requires translation!
 Swords into Ploughshares = 
+ # Requires translation!
+when not at war = 
 
  # Requires translation!
 Founder = 
@@ -5422,9 +5483,6 @@ Starting in this era disables religion =
 
 
 Marine = 海軍陸戰隊
-
-
-#################### Lines from GlobalUniques from Civ V - Gods & Kings ####################
 
 
 #################### Lines from Nations from Civ V - Gods & Kings ####################
@@ -6048,6 +6106,8 @@ Falmouth =
 Lorient = 
  # Requires translation!
 Celts = 
+ # Requires translation!
+with [amount] to [amount2] neighboring [tileFilter] [tileFilter2] tiles = 
 
  # Requires translation!
 Haile Selassie = 
@@ -6135,6 +6195,8 @@ Ziway =
 Weldiya = 
  # Requires translation!
 Ethiopia = 
+ # Requires translation!
+when fighting units from a Civilization with more Cities than you = 
 
  # Requires translation!
 Pacal = 
@@ -6282,12 +6344,12 @@ Taoism =
 
 
  # Requires translation!
-We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[param] Faith) = 
+We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[faithAmount] Faith) = 
  # Requires translation!
 discover holy symbols = 
 
  # Requires translation!
-We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[param] Faith) = 
+We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[faithAmount] Faith) = 
  # Requires translation!
 an ancient prophecy = 
 
@@ -6355,8 +6417,16 @@ Polder =
 #################### Lines from TileResources from Civ V - Gods & Kings ####################
 
 
+Citrus = 柑橘
+
+Copper = 赤銅
+
+Crab = 螃蟹
+
  # Requires translation!
 Salt = 
+
+Truffles = 松露
 
 
 #################### Lines from UnitPromotions from Civ V - Gods & Kings ####################
@@ -6837,13 +6907,7 @@ Irremovable =
  # Requires translation!
 when at war = 
  # Requires translation!
-when not at war = 
- # Requires translation!
-during a Golden Age = 
- # Requires translation!
 with [resource] = 
- # Requires translation!
-while the empire is happy = 
  # Requires translation!
 when between [amount] and [amount2] Happiness = 
  # Requires translation!
@@ -6851,67 +6915,25 @@ when below [amount] Happiness =
  # Requires translation!
 during the [era] = 
  # Requires translation!
-before the [era] = 
- # Requires translation!
-starting from the [era] = 
- # Requires translation!
 if no other Civilization has researched this = 
- # Requires translation!
-after discovering [tech] = 
- # Requires translation!
-before discovering [tech] = 
  # Requires translation!
 upon discovering [tech] = 
  # Requires translation!
 after adopting [policy] = 
  # Requires translation!
-before adopting [policy] = 
- # Requires translation!
-if [buildingName] is constructed = 
- # Requires translation!
-for [amount] turns = 
- # Requires translation!
 by consuming this unit = 
  # Requires translation!
 in cities with a [buildingFilter] = 
  # Requires translation!
-in cities without a [buildingFilter] = 
- # Requires translation!
-in cities with at least [amount] [populationFilter] = 
- # Requires translation!
-with a garrison = 
- # Requires translation!
-for [mapUnitFilter] units = 
- # Requires translation!
 for units with [promotion] = 
  # Requires translation!
 for units without [promotion] = 
- # Requires translation!
-vs cities = 
- # Requires translation!
-vs [mapUnitFilter] units = 
- # Requires translation!
-when fighting units from a Civilization with more Cities than you = 
- # Requires translation!
-when attacking = 
- # Requires translation!
-when defending = 
- # Requires translation!
-when fighting in [tileFilter] tiles = 
- # Requires translation!
-on foreign continents = 
- # Requires translation!
-when adjacent to a [mapUnitFilter] unit = 
  # Requires translation!
 when above [amount] HP = 
  # Requires translation!
 when below [amount] HP = 
  # Requires translation!
 with [amount] to [amount2] neighboring [tileFilter] tiles = 
- # Requires translation!
-with [amount] to [amount2] neighboring [tileFilter] [tileFilter2] tiles = 
- # Requires translation!
-in [tileFilter] tiles = 
  # Requires translation!
 in [tileFilter] [tileFilter2] tiles = 
  # Requires translation!
@@ -6990,3 +7012,10 @@ CityState =
 ModOptions = 
  # Requires translation!
 Conditional = 
+
+#################### Removed Lines ####################
+
+#~~Rough Terrain = 崎嶇地形
+#~~Strategic = 戰略資源
+#~~Bonus = 獎勵資源
+#~~Luxury = 奢侈資源

--- a/android/assets/jsons/translations/Turkish.properties
+++ b/android/assets/jsons/translations/Turkish.properties
@@ -1217,8 +1217,6 @@ or [terrainType] = veya [terrainType]
 Can be constructed by = Tarafından inşa edilebilir
 Defence bonus = Savunma bonusu
 Movement cost = Hareket maliyeti
-Open terrain = Açık Arazi
-Rough Terrain = Engebeli Arazi
 for = için
 Missing translations: = Eksik çeviriler:
 Resolution = Çözünürlük
@@ -1368,110 +1366,6 @@ Enhancing religion =
  # Requires translation!
 Enhanced religion = 
 
-# Terrains
-
-Impassable = Geçilemez
-Rare feature = Nadir özellik
-
-# terrainFilters (so for uniques like: "[stats] from [terrainFilter] tiles")
-
-All = Hepsi
-Water = Su
-Land = Arazi
-Coastal = Kıyısal
-River = Irmak
-Rough terrain = Engebeli arazi
-Foreign Land = Yabancı Toprakları
-Foreign = Yabancı
-Friendly Land = Dost Toprakları
-Water resource = Su kaynağı
-Bonus resource = Bonus kaynak
-Luxury resource = Lüks kaynak
-Strategic resource = Stratejik kaynak
-Fresh water = Tatlı su
-non-fresh water = Tuzlu su
-Natural Wonder = Doğal Harika
-Hybrid = Melez
- # Requires translation!
-Undesirable = 
- # Requires translation!
-Desirable = 
- # Requires translation!
-Featureless = 
- # Requires translation!
-Fresh Water = 
-
-# improvementFilters
-
- # Requires translation!
-All Road = 
-Great Improvement = Büyük Geliştirme
- # Requires translation!
-Great = 
-
-# Resources
-
-Bison = Bizon
-Copper = Bakır
-Cocoa = Kakao
-Crab = Yengeç
-Citrus = Narenciye
-Truffles = Domalan
-Strategic = Stratejik
-Bonus = Bonus
-Luxury = Lüks
-
-# Unit types
-
-City = Şehir
-Civilian = Sivil
-Melee = Yakın dövüş
-Ranged = Menzilli
-Scout = İzci
-Mounted = Binekli
-Armor = Zırh
-Siege = Kuşatma
-
-WaterCivilian = DenizSivil
-WaterMelee = Deniz YakınDövüş
-WaterRanged = DenizMenzilli
-WaterSubmarine = Su Denizaltısı
-WaterAircraftCarrier = Uçak gemisi
-
-Fighter = Savaş Uçağı
-Bomber = Bombardıman Uçağı
-AtomicBomber = AtomBombası
-Missile = Roket
-
-
-# Unit filters and other unit related things
-
-Air = Hava
-air units = hava birlikleri
-Barbarian = Barbar
-Barbarians = Barbarlar
-Embarked = Denizde
-land units = kara birlikleri
-Military = Askeri birlikleri
-# Deprecated since 3.15.2, but should still be translated until it is officially removed
-military water = askeri deniz
-non-air = hava olmayan
-Nuclear Weapon = Nükleer Silah
-Submarine = Denizaltı
-submarine units = Denizaltı birlikleri
-Unbuildable = İnşa edilemez
-water units = deniz birlikleri
-wounded units = yaralı birimler
-Wounded = Yaralı
-
-# For the "All newly-trained [relevant] units in this city receive the [] promotion" translation. Relevant as in 'units that can receive'
-relevant = ilgili
-
-# For "May choose [amount] additional [beliefType] beliefs when [founding/enhancing] a religion"
- # Requires translation!
-founding = 
- # Requires translation!
-enhancing = 
 
 # Promotions
 
@@ -1479,6 +1373,7 @@ Pick promotion = Terfi seçin
  OR  =   VEYA 
 units in open terrain = açık alandaki birimler
 units in rough terrain = engebeli alandaki birimler
+wounded units = yaralı birimler
 Targeting II (air) = Hedefleme 2 (Hava)
 Targeting III (air) = Hedefleme 3 (Hava)
 Bonus when performing air sweep [bonusAmount]% = Hava taraması yaparken bonus [bonusAmount]%
@@ -1587,6 +1482,11 @@ This Unit upgrades for free = Birlik bedavaya yükselir
 Never destroyed when the city is captured = 
 Invisible to others = Başkalarına görünmez
 
+# Unused Resources
+
+Bison = Bizon
+Cocoa = Kakao
+
 
 # In English we just paste all these conditionals at the end of each unique, but in your language that
 # may not turn into valid sentences. Therefore we have the following two translations to determine
@@ -1616,6 +1516,33 @@ ConditionalsPlacement = before
 ########################### AUTOMATICALLY GENERATED TRANSLATABLE STRINGS ########################### 
 
 
+######### Map Unit Filters ###########
+
+Wounded = Yaralı
+Barbarians = Barbarlar
+ # Requires translation!
+City-State = 
+Embarked = Denizde
+ # Requires translation!
+Non-City = 
+
+######### Unit Type Filters ###########
+
+Military = Askeri birlikleri
+Civilian = Sivil
+non-air = hava olmayan
+relevant = ilgili
+Nuclear Weapon = Nükleer Silah
+City = Şehir
+Air = Hava
+land units = kara birlikleri
+water units = deniz birlikleri
+air units = hava birlikleri
+ # Requires translation!
+military units = 
+submarine units = Denizaltı birlikleri
+Barbarian = Barbar
+
 ######### City filters ###########
 
 in this city = bu şehirde
@@ -1638,6 +1565,72 @@ in holy cities = mukaddes şehirlerde
 in City-State cities = Şehir Devleti şehirlerinde
  # Requires translation!
 in cities following this religion = 
+
+######### Population Filters ###########
+
+ # Requires translation!
+Unemployed = 
+ # Requires translation!
+Followers of the Majority Religion = 
+ # Requires translation!
+Followers of this Religion = 
+
+######### Terrain Filters ###########
+
+All = Hepsi
+Coastal = Kıyısal
+River = Irmak
+Open terrain = Açık Arazi
+Rough terrain = Engebeli arazi
+Water resource = Su kaynağı
+Foreign Land = Yabancı Toprakları
+Foreign = Yabancı
+Friendly Land = Dost Toprakları
+ # Requires translation!
+Enemy Land = 
+ # Requires translation!
+Featureless = 
+ # Requires translation!
+Fresh Water = 
+non-fresh water = Tuzlu su
+Natural Wonder = Doğal Harika
+Impassable = Geçilemez
+Land = Arazi
+Water = Su
+Luxury resource = Lüks kaynak
+Strategic resource = Stratejik kaynak
+Bonus resource = Bonus kaynak
+
+######### Tile Filters ###########
+
+ # Requires translation!
+unimproved = 
+ # Requires translation!
+All Road = 
+Great Improvement = Büyük Geliştirme
+
+######### Region Types ###########
+
+Hybrid = Melez
+
+######### Terrain Quality ###########
+
+ # Requires translation!
+Undesirable = 
+ # Requires translation!
+Desirable = 
+
+######### Improvement Filters ###########
+
+ # Requires translation!
+Great = 
+
+######### Prophet Action Filters ###########
+
+ # Requires translation!
+founding = 
+ # Requires translation!
+enhancing = 
 
 ######### Unique Specials ###########
 
@@ -1669,6 +1662,8 @@ Temple of Artemis = Artemis Tapınağı
 
 The Great Lighthouse = Büyük Deniz Feneri
 'They that go down to the sea in ships, that do business in great waters; these see the works of the Lord, and his wonders in the deep.' - The Bible, Psalms 107:23-24 = 'Gemilerle denize açılanlar, okyanuslarda iş yapanlar; RAB'bin işlerini, derinliklerde yaptığı harikaları görürler' - Kitabı Mukaddes, Mezmurlar 107:23-24
+ # Requires translation!
+for [mapUnitFilter] units = 
 [amount] Movement = [amount] Hareket
 [amount] Sight = [amount] Görüş
 
@@ -1717,6 +1712,9 @@ Krepost = Krepost
 
 Statue of Zeus = Zeus Heykeli
 'He spoke, the son of Kronos, and nodded his head with the dark brows, and the immortally anointed hair of the great god swept from his divine head, and all Olympos was shaken' - The Iliad = 'Konuştu, Kronos'un oğlu ve koyu kaşlarla başını salladı ve büyük tanrının ölümsüzce meshedilmiş saçları ilahi kafasından süpürüldü ve bütün Olimpos sarsıldı. '- İlyada
+ # Requires translation!
+vs cities = 
+when attacking = saldırırken
 [amount]% Strength = %[amount] Güç
 
 Lighthouse = Deniz feneri
@@ -1822,11 +1820,15 @@ Notre Dame = Notre Dame
 Castle = Kale
 
 Mughal Fort = Babür Kalesi
+ # Requires translation!
+after discovering [tech] = 
 [stats] [cityFilter] = [stats] [cityFilter]
 
 Himeji Castle = Himeci Kalesi
  # Requires translation!
 'Bushido is realized in the presence of death. This means choosing death whenever there is a choice between life and death. There is no other reasoning.' - Yamamoto Tsunetomo = 
+ # Requires translation!
+when fighting in [tileFilter] tiles = 
 
 Ironworks = Demirhane
 
@@ -1943,6 +1945,8 @@ Pentagon = Pentagon
 
 Solar Plant = Güneş Paneli
  # Requires translation!
+in cities without a [buildingFilter] = 
+ # Requires translation!
 Only available = 
 
 Nuclear Plant = Nükleer Santral
@@ -1977,6 +1981,7 @@ King = Kral
 Era Starting Unit = Çağda Başlarken edinilen Birlik
 
 Emperor = İmparator
+Scout = İzci
 
 Immortal = Ölümsüz
 Worker = İşçi
@@ -2009,9 +2014,6 @@ Atomic era = Atom çağı
 Information era = Bilgi Çağı
 
 Future era = Gelecek Çağı
-
-
-#################### Lines from GlobalUniques from Civ V - Vanilla ####################
 
 
 #################### Lines from Nations from Civ V - Vanilla ####################
@@ -2356,6 +2358,8 @@ La Rochelle = La Rochelle
 Bourges = Bourges
 Calais = Calais
 France = Fransa
+ # Requires translation!
+before discovering [tech] = 
 
 Catherine = Katerina
 You've behaved yourself very badly, you know it. Now it's payback time. = Çok kötü hareketlerde bulundun, biliyorsun. Şimdi ödeşme zamanı.
@@ -2410,7 +2414,8 @@ Russia = Rusya
 Double quantity of [resource] produced = [resource] kaynağının iki katı üretildi
 
 Augustus Caesar = Augustus Sezar
-My treasury contains little and my soldiers are getting impatient... ...therefore you must die. = Hazinem pek dolu değil askerlerimse sabırsızlanıyor... ...öyleyse ölmen gerek.
+ # Requires translation!
+My treasury contains little and my soldiers are getting impatient... (sigh) ...therefore you must die. = 
 So brave, yet so stupid! If only you had a brain similar to your courage. = Çok cesurca, bi o kadar da aptalca! Keşke cesaretin kadar aklın da olsaydı.
 The gods have deprived Rome of their favour. We have been defeated. = Tanrılar Roma'yı beğenisinden mahrum bıraktı. Yenildik.
 I greet you. I am Augustus, Imperator and Pontifex Maximus of Rome. If you are a friend of Rome, you are welcome. = Seni selamlıyorum. Ben Augustus, Roma'nın İmparatoru ve Pontifex Maximus'u. Eğer Roma'nın bir dostuysan, hoşgeldin.
@@ -2966,6 +2971,7 @@ Paishiyauvada = Paishiyauvada
 Patigrbana = Patigrabana
 Phrada = Ferah
 Persia = İran
+during a Golden Age = Altın Çağdayken
 
 Kamehameha I = I. Kamehameha
 The ancient fire flashing across the sky is what proclaimed that this day would come, though I had foolishly hoped for a different outcome. = Ben akılsızca farklı bir sonucu olacağını zannetsem de gökyüzünde parıldayan kadim ateş bu günün geleceğini ilan ediyordu.
@@ -3020,6 +3026,8 @@ Nuguria = Nuguria
 Pileni = Pileni
 Nukumanu = Nukumanu
 Polynesia = Polinezya
+ # Requires translation!
+starting from the [era] = 
 Enables embarkation for land units = Kara birimleri için denize girmeyi mümkün kılar
  # Requires translation!
 Enables [mapUnitFilter] units to enter ocean tiles = 
@@ -3538,6 +3546,8 @@ Provides the cheapest [stat] building in your first [amount] cities for free =
 Oligarchy = Oligarşi
 Units in cities cost no Maintenance = Şehirlerdeki birliklere Bakım ücreti ödenmez
  # Requires translation!
+with a garrison = 
+ # Requires translation!
 [amount]% Strength for cities = 
 Landed Elite = Toprak Ağalığı
  # Requires translation!
@@ -3562,6 +3572,8 @@ Liberty =
 
 Warrior Code = Savaşçı Yasası
 Discipline = Disiplin
+ # Requires translation!
+when adjacent to a [mapUnitFilter] unit = 
 Military Tradition = Askeri Gelenek
  # Requires translation!
 [amount]% XP gained from combat = 
@@ -3570,6 +3582,8 @@ Professional Army = Düzenli Ordu
 Honor Complete = Şeref Tamamlandı
  # Requires translation!
 Honor = 
+ # Requires translation!
+vs [mapUnitFilter] units = 
  # Requires translation!
 Notified of new Barbarian encampments = 
 
@@ -3585,6 +3599,8 @@ Free Religion = Özgür Din
 Piety Complete = Dindarlık Tamamlandı
  # Requires translation!
 Piety = 
+ # Requires translation!
+before adopting [policy] = 
 
 Philantropy = Hayırseverlik
 Gifts of Gold to City-States generate [amount]% more Influence =  Şehir Devletlerine hediye edilen Altınlar %[amount] daha fazla etki sağlar
@@ -3631,10 +3647,12 @@ Rationalism Complete = Akılcılık Tamamlandı
 [amount] Free Technologies = [amount] Bedava Teknoloji
  # Requires translation!
 Rationalism = 
+while the empire is happy = imparatorluk mutluyken
 [amount]% [stat] = %[amount] [stat]
 
 Constitution = Anayasa
 Universal Suffrage = Evrensel Oy Hakkı
+when defending = savunurken
 Civil Society = Sivil Toplum
  # Requires translation!
 [amount]% Food consumption by specialists [cityFilter] = 
@@ -3656,6 +3674,8 @@ Quantity of strategic resources produced by the empire +[amount]% = İmparatorlu
 Police State = Polis Devleti
 Total War = Topyekün Savaş
 Autocracy Complete = Otokrasi Tamamlandı
+ # Requires translation!
+for [amount] turns = 
  # Requires translation!
 Autocracy = 
  # Requires translation!
@@ -3683,31 +3703,31 @@ Clear Barbarian Camp = Barbar Kamplarını Yok Et
 We feel threatened by a Barbarian Camp near our city. Please take care of it. = Yakınımızdaki bir Barbar Kampından korkuyoruz. Lütfen onlarla ilgilenin.
 
 Connect Resource = Kaynağı ticaret ağına bağla
-In order to make our civilizations stronger, connect [param] to your trade network. = Uygarlıklarımızı güçlendirmek adına [param]'ı ticaret ağına bağla.
+In order to make our civilizations stronger, connect [tileResource] to your trade network. = Uygarlıklarımızı güçlendirmek adına [tileResource]'ı ticaret ağına bağla.
 
 Construct Wonder = Eseri inşa et
-We recommend you to start building [param] to show the whole world your civilization strength. = Uygarlığınızın gücünü tüm dünyaya göstermek için [param]'ı inşa etmeye başlamanızı tavsiye ediyoruz.
+We recommend you to start building [wonder] to show the whole world your civilization strength. = Uygarlığınızın gücünü tüm dünyaya göstermek için [wonder]'ı inşa etmeye başlamanızı tavsiye ediyoruz.
 
 Acquire Great Person = Büyük Şahsiyet Edin
-Great People can change the course of a Civilization! You will be rewarded for acquiring a new [param]. = Büyük Şahsiyetler bir uygarlığın geleceğini değiştirebilir! Yeni bir [param] edinmeniz ödüllendirilmenizle sonuçlanacaktır.
+Great People can change the course of a Civilization! You will be rewarded for acquiring a new [greatPerson]. = Büyük Şahsiyetler bir uygarlığın geleceğini değiştirebilir! Yeni bir [greatPerson] edinmeniz ödüllendirilmenizle sonuçlanacaktır.
 
 Conquer City State = Şehir Devleti Fethet
-It's time to erase the City-State of [param] from the map. You will be greatly rewarded for conquering them! = [param] Şehir Devletini haritadan silmenin vakti geldi. Onları fethederseniz ödüllendileceksiniz!
+It's time to erase the City-State of [cityState] from the map. You will be greatly rewarded for conquering them! = [cityState] Şehir Devletini haritadan silmenin vakti geldi. Onları fethederseniz ödüllendileceksiniz!
 
 Find Player = Oyuncuyu Bul
-You have yet to discover where [param] set up their cities. You will be rewarded for finding their territories. = [param]'ın Şehirlerini nereye kurduğunu bulamamışsınız. Onların topraklarını bulmanız durumda ödüllendirileceksiniz.
+You have yet to discover where [civName] set up their cities. You will be rewarded for finding their territories. = [civName]'ın Şehirlerini nereye kurduğunu bulamamışsınız. Onların topraklarını bulmanız durumda ödüllendirileceksiniz.
 
 Find Natural Wonder = Doğal Harika Bul
-Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [param] yet. = En iyi gezginlerinizi bir Doğa harikası bulması için gönderiniz. Henüz kimse [param]'ın nerede olduğunu bilmiyor.
+Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [naturalWonder] yet. = En iyi gezginlerinizi bir Doğa harikası bulması için gönderiniz. Henüz kimse [naturalWonder]'ın nerede olduğunu bilmiyor.
 
 Give Gold = Altın Ver
  # Requires translation!
-We are suffering great poverty after being robbed by [param], and unless we receive a sum of Gold, it's only a matter of time before we collapse. = 
+We are suffering great poverty after being robbed by [civName], and unless we receive a sum of Gold, it's only a matter of time before we collapse. = 
 
  # Requires translation!
 Pledge to Protect = 
  # Requires translation!
-We need your protection to stop the aggressions of [param]. By signing a Pledge of Protection, you'll confirm the bond that ties us. = 
+We need your protection to stop the aggressions of [civName]. By signing a Pledge of Protection, you'll confirm the bond that ties us. = 
 
  # Requires translation!
 Contest Culture = 
@@ -3727,20 +3747,20 @@ The civilization with the largest number of new Technologies researched will gai
  # Requires translation!
 Invest = 
  # Requires translation!
-Our people are rejoicing thanks to a tourism boom. For a certain amount of time, any Gold donation will yield [amount]% extra Influence. = 
+Our people are rejoicing thanks to a tourism boom. For a certain amount of time, any Gold donation will yield [50]% extra Influence. = 
 
  # Requires translation!
 Bully City State = 
  # Requires translation!
-We are tired of the pretensions of [param]. If someone were to put them in their place by Demanding Tribute from them, they would be rewarded. = 
+We are tired of the pretensions of [cityState]. If someone were to put them in their place by Demanding Tribute from them, they would be rewarded. = 
 
  # Requires translation!
 Denounce Civilization = 
  # Requires translation!
-We have been forced to pay tribute to [param]! We need you to tell the world of their ill deeds. = 
+We have been forced to pay tribute to [civName]! We need you to tell the world of their ill deeds. = 
 
  # Requires translation!
-We have heard the tenets of [param] and are most curious. Will you send missionaries to teach us about your religion? = 
+We have heard the tenets of [religionName] and are most curious. Will you send missionaries to teach us about your religion? = 
 
 
 #################### Lines from Ruins from Civ V - Vanilla ####################
@@ -3759,11 +3779,11 @@ An ancient tribe trained us in their ways of combat! =
 your exploring unit receives training = gezgin birliğiniz eğitim alır
 
  # Requires translation!
-We have found survivors in the ruins! Population added to [param]. = 
+We have found survivors in the ruins! Population added to [cityName]. = 
 survivors (adds population to a city) =  sağ kalanları bir grup insan bulursunuz (bir şehre nüfus sağlar)
 
  # Requires translation!
-We have found a stash of [param] Gold in the ruins! = 
+We have found a stash of [goldAmount] Gold in the ruins! = 
 a stash of gold = altın zulası bulursunuz
 
 discover a lost technology = kayıp bir teknolojiyi bulursunuz
@@ -3992,6 +4012,7 @@ Tundra = Tundra
 Desert = Çöl
 
 Lakes = Göl
+Fresh water = Tatlı su
 
 Mountain = Dağ
 Has an elevation of [amount] for visibility calculations =  Görünürlük hesaplamaları için [amount] yükseltisi vardır
@@ -4013,6 +4034,7 @@ A Camp can be built here without cutting it down = Buraya buradaki ağaçların 
 Jungle = Cengel
 
 Marsh = Bataklık
+Rare feature = Nadir özellik
  # Requires translation!
 Only Polders can be built here = 
 
@@ -4220,10 +4242,13 @@ Porcelain = Porselen
 #################### Lines from UnitPromotions from Civ V - Vanilla ####################
 
 Sword = Kılıçlı
+Mounted = Binekli
+Siege = Kuşatma
 Ranged Gunpowder = Menzilli Barut
 Armored = Zırhlı
 Melee Water = Deniz Yakın Dövüş
 Ranged Water = Menzilli Deniz
+Submarine = Denizaltı
 Heal Instantly = Anında iyileştir
 Heal this unit by [amount] HP = Bu birliği [amount] can iyileştirir.
 Doing so will consume this opportunity to choose a Promotion = Bunu seçerseniz terfi edemezsiniz
@@ -4284,6 +4309,8 @@ Medic = Doktor 1
 All adjacent units heal [amount] HP when healing = Bitişikteki birlikler iyileşirken [amount] HP iyileşir
 
 Medic II = Doktor 2
+ # Requires translation!
+in [tileFilter] tiles = 
 [amount] HP when healing = İyileşirken [amount] HP
 
 Scouting I = Keşif 1
@@ -4346,6 +4373,7 @@ Flight Deck III = Uçuş Güvertesi 3
 Supply = 
 May heal outside of friendly territory = Arkadaş canlısı arazi dışında iyileşebilir
 
+Bomber = Bombardıman Uçağı
 Siege I = Kuşatma 1 
 
 Siege II = Kuşatma 2
@@ -4355,6 +4383,7 @@ Siege III = Kuşatma 3
 Evasion = Kaçınma
 Damage taken from interception reduced by [amount]% = Engellemelerden alınan hasar %[amount] azalır
 
+Fighter = Savaş Uçağı
 Interception I = Engelleme 1
 [amount]% Damage when intercepting = Engellenirken %[amount] hasar
 
@@ -4462,10 +4491,29 @@ Can see over obstacles =
 
 Atomic Bomber = Atom Bombası
 
+Missile = Roket
 Self-destructs when attacking = Saldırırken kendini imha eder
 Cannot be intercepted = Saldırısı engellenemez
 
 Can pass through impassable tiles = Geçilemez bölgelerden geçebilir
+
+Melee = Yakın dövüş
+
+Ranged = Menzilli
+
+Armor = Zırh
+
+WaterCivilian = DenizSivil
+
+WaterMelee = Deniz YakınDövüş
+
+WaterRanged = DenizMenzilli
+
+WaterSubmarine = Su Denizaltısı
+
+WaterAircraftCarrier = Uçak gemisi
+
+AtomicBomber = AtomBombası
 
 
 #################### Lines from Units from Civ V - Vanilla ####################
@@ -4545,6 +4593,8 @@ Knight = Şövalye
 Camel Archer = Deve Okçusu
 
 Conquistador = Conquistador
+ # Requires translation!
+on foreign continents = 
 
 Naresuan's Elephant = Naresuan'ın Fili
 
@@ -4635,6 +4685,8 @@ Anti-Tank Gun = Tanksavar Silahı
 
 Atomic Bomb = Atom Bombası
 Nuclear weapon of Strength [amount] = [amount] Gücünde nükleer silah
+ # Requires translation!
+if [buildingName] is constructed = 
 Blast radius [amount] = [amount] Patlama çapı
 
 Rocket Artillery = Roket Topçuları
@@ -4672,6 +4724,7 @@ Great Artist = Harika Sanatçı
 Can start an [amount]-turn golden age = [amount] turluk altın çağ başlatabilir
 Can construct [improvementName] = [improvementName] inşa edebilir
 Great Person - [stat] = Büyük Şahsiyet - [stat]
+Unbuildable = İnşa edilemez
 
 Great Scientist = Harika Bilim İnsanı
 Can hurry technology research = Teknoloji araştırmaları daha hızlı yapılabilir
@@ -4749,6 +4802,8 @@ Fertility Rites =
 
  # Requires translation!
 God of Craftsman = 
+ # Requires translation!
+in cities with at least [amount] [populationFilter] = 
 
 God of the Open Sky = Gök Tanrısı
 
@@ -4816,6 +4871,8 @@ Guruship =
  # Requires translation!
 Holy Warriors = 
  # Requires translation!
+before the [era] = 
+ # Requires translation!
 May buy [baseUnitFilter] units with [stat] for [amount] times their normal Production cost = 
 
  # Requires translation!
@@ -4844,6 +4901,7 @@ Religious Community =
 
  # Requires translation!
 Swords into Ploughshares = 
+when not at war = savaşta değilken
 
 Founder = Kurucu
  # Requires translation!
@@ -5014,9 +5072,6 @@ Starting in this era disables religion =
 
 
 Marine = Bahriyeler
-
-
-#################### Lines from GlobalUniques from Civ V - Gods & Kings ####################
 
 
 #################### Lines from Nations from Civ V - Gods & Kings ####################
@@ -5513,6 +5568,8 @@ Falmouth =
  # Requires translation!
 Lorient = 
 Celts = Keltler
+ # Requires translation!
+with [amount] to [amount2] neighboring [tileFilter] [tileFilter2] tiles = 
 
  # Requires translation!
 Haile Selassie = 
@@ -5599,6 +5656,8 @@ Ziway =
  # Requires translation!
 Weldiya = 
 Ethiopia = Habeşistan
+ # Requires translation!
+when fighting units from a Civilization with more Cities than you = 
 
  # Requires translation!
 Pacal = 
@@ -5739,12 +5798,12 @@ Taoism = Taoizm
 
 
  # Requires translation!
-We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[param] Faith) = 
+We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[faithAmount] Faith) = 
  # Requires translation!
 discover holy symbols = 
 
  # Requires translation!
-We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[param] Faith) = 
+We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[faithAmount] Faith) = 
  # Requires translation!
 an ancient prophecy = 
 
@@ -5807,7 +5866,15 @@ Polder = Polder
 #################### Lines from TileResources from Civ V - Gods & Kings ####################
 
 
+Citrus = Narenciye
+
+Copper = Bakır
+
+Crab = Yengeç
+
 Salt = Tuz
+
+Truffles = Domalan
 
 
 #################### Lines from UnitPromotions from Civ V - Gods & Kings ####################
@@ -6294,11 +6361,8 @@ No Sight =
  # Requires translation!
 Irremovable = 
 when at war = savaştayken
-when not at war = savaşta değilken
-during a Golden Age = Altın Çağdayken
  # Requires translation!
 with [resource] = 
-while the empire is happy = imparatorluk mutluyken
  # Requires translation!
 when between [amount] and [amount2] Happiness = 
  # Requires translation!
@@ -6306,65 +6370,25 @@ when below [amount] Happiness =
  # Requires translation!
 during the [era] = 
  # Requires translation!
-before the [era] = 
- # Requires translation!
-starting from the [era] = 
- # Requires translation!
 if no other Civilization has researched this = 
- # Requires translation!
-after discovering [tech] = 
- # Requires translation!
-before discovering [tech] = 
  # Requires translation!
 upon discovering [tech] = 
  # Requires translation!
 after adopting [policy] = 
  # Requires translation!
-before adopting [policy] = 
- # Requires translation!
-if [buildingName] is constructed = 
- # Requires translation!
-for [amount] turns = 
- # Requires translation!
 by consuming this unit = 
  # Requires translation!
 in cities with a [buildingFilter] = 
  # Requires translation!
-in cities without a [buildingFilter] = 
- # Requires translation!
-in cities with at least [amount] [populationFilter] = 
- # Requires translation!
-with a garrison = 
- # Requires translation!
-for [mapUnitFilter] units = 
- # Requires translation!
 for units with [promotion] = 
  # Requires translation!
 for units without [promotion] = 
- # Requires translation!
-vs cities = 
- # Requires translation!
-vs [mapUnitFilter] units = 
- # Requires translation!
-when fighting units from a Civilization with more Cities than you = 
-when attacking = saldırırken
-when defending = savunurken
- # Requires translation!
-when fighting in [tileFilter] tiles = 
- # Requires translation!
-on foreign continents = 
- # Requires translation!
-when adjacent to a [mapUnitFilter] unit = 
  # Requires translation!
 when above [amount] HP = 
  # Requires translation!
 when below [amount] HP = 
  # Requires translation!
 with [amount] to [amount2] neighboring [tileFilter] tiles = 
- # Requires translation!
-with [amount] to [amount2] neighboring [tileFilter] [tileFilter2] tiles = 
- # Requires translation!
-in [tileFilter] tiles = 
  # Requires translation!
 in [tileFilter] [tileFilter2] tiles = 
  # Requires translation!
@@ -6443,3 +6467,12 @@ CityState =
 ModOptions = 
  # Requires translation!
 Conditional = 
+
+#################### Removed Lines ####################
+
+#~~Rough Terrain = Engebeli Arazi
+#~~Strategic = Stratejik
+#~~Bonus = Bonus
+#~~Luxury = Lüks
+#~~military water = askeri deniz
+#~~My treasury contains little and my soldiers are getting impatient... ...therefore you must die. = Hazinem pek dolu değil askerlerimse sabırsızlanıyor... ...öyleyse ölmen gerek.

--- a/android/assets/jsons/translations/Ukrainian.properties
+++ b/android/assets/jsons/translations/Ukrainian.properties
@@ -1133,8 +1133,6 @@ or [terrainType] = або [terrainType]
 Can be constructed by = Можуть побудувати:
 Defence bonus = Бонус до захисту
 Movement cost = Вартість руху
-Open terrain = Відкрита місцевість
-Rough Terrain = Нерівна місцевість
 for = за
 Missing translations: = Відсутні переклади:
 Resolution = Роздільність
@@ -1272,104 +1270,6 @@ Religion = Релігія
 Enhancing religion = Релігія покращується
 Enhanced religion = Покращена релігія
 
-# Terrains
-
-Impassable = Непрохідні
-Rare feature = Рідкісна риса
-
-# terrainFilters (so for uniques like: "[stats] from [terrainFilter] tiles")
-
-All = Усі
-Water = Вода
-Land = Земля
-Coastal = прибережні
-River = річкові
-Rough terrain = пересічні
-Foreign Land = ворожі
-Foreign = іноземні
-Friendly Land = дружні землі
-Water resource = Морський ресурс
-Bonus resource = Бонусний ресурс
-Luxury resource = Дорогоцінний ресурс
-Strategic resource = Сратегічний ресурс
-Fresh water = прісноводні
-non-fresh water = «без доступу до прісної води»
-Natural Wonder = Природне диво
-Hybrid = Гібрид
-Undesirable = Недосяжне
-Desirable = Досяжне
- # Requires translation!
-Featureless = 
- # Requires translation!
-Fresh Water = 
-
-# improvementFilters
-
-All Road = Уся дорога
-Great Improvement = Велике покращення
-Great = Великий 
-
-# Resources
-
-Bison = Бізони
-Copper = Мідь
-Cocoa = Какао
-Crab = Краб
-Citrus = Цитрус
-Truffles = Трюфелі
-Strategic = Стратегічний ресурс
-Bonus = Бонусний ресурс
-Luxury = Ресурс розкоші
-
-# Unit types
-
-City = Місто
-Civilian = Цивільний
-Melee = Ближній бій
-Ranged = Дальній бій
-Scout = Розвідник
-Mounted = Кіннота
-Armor = Бронетехніка
-Siege = Облоговий
-
-WaterCivilian = Морський цивільний
-WaterMelee = Морський ближній бій
-WaterRanged = Морський дальній бій
-WaterSubmarine = Підводний
-WaterAircraftCarrier = Морський авіаносець
-
-Fighter = Винищувач
-Bomber = Бомбардувальник
-AtomicBomber = Атомний Бомбардувальник
-Missile = Ракета
-
-
-# Unit filters and other unit related things
-
-Air = Повітря
-air units = Повітряні підрозділи
-Barbarian = Варварський
-Barbarians = Варвари
-Embarked = Спущений на воду
-land units = Наземні підрозділи
-Military = військові
-# Deprecated since 3.15.2, but should still be translated until it is officially removed
-military water = військові морські
-non-air = не-повітряні
-Nuclear Weapon = Ядерна зброя
-Submarine = Субмарина
-submarine units = підводні підрозділи
-Unbuildable = Неможливо створити
-water units = Водні підрозділи
-wounded units = пошкоджені підрозділи
-Wounded = Поранений
-
-# For the "All newly-trained [relevant] units in this city receive the [] promotion" translation. Relevant as in 'units that can receive'
-relevant = придатні
-
-# For "May choose [amount] additional [beliefType] beliefs when [founding/enhancing] a religion"
-founding = заснування
-enhancing = покращення
 
 # Promotions
 
@@ -1377,6 +1277,7 @@ Pick promotion = Вибрати підвищення
  OR  =  Або 
 units in open terrain = підрозділи на відкритій території
 units in rough terrain = підрозділи на пересіченій території
+wounded units = пошкоджені підрозділи
 Targeting II (air) = Повітряна ціль II
 Targeting III (air) = Повітряна ціль III
 Bonus when performing air sweep [bonusAmount]% = Чисте повітря отримує силу +[bonusAmount]%
@@ -1481,6 +1382,11 @@ This Unit upgrades for free = Цей підрозділ покращується
 Never destroyed when the city is captured = Ніколи не знищується під час захоплення міста
 Invisible to others = Інші не бачать
 
+# Unused Resources
+
+Bison = Бізони
+Cocoa = Какао
+
 
 # In English we just paste all these conditionals at the end of each unique, but in your language that
 # may not turn into valid sentences. Therefore we have the following two translations to determine
@@ -1511,6 +1417,33 @@ ConditionalsPlacement =
 ########################### AUTOMATICALLY GENERATED TRANSLATABLE STRINGS ########################### 
 
 
+######### Map Unit Filters ###########
+
+Wounded = Поранений
+Barbarians = Варвари
+ # Requires translation!
+City-State = 
+Embarked = Спущений на воду
+ # Requires translation!
+Non-City = 
+
+######### Unit Type Filters ###########
+
+Military = військові
+Civilian = Цивільний
+non-air = не-повітряні
+relevant = придатні
+Nuclear Weapon = Ядерна зброя
+City = Місто
+Air = Повітря
+land units = Наземні підрозділи
+water units = Водні підрозділи
+air units = Повітряні підрозділи
+ # Requires translation!
+military units = 
+submarine units = підводні підрозділи
+Barbarian = Варварський
+
 ######### City filters ###########
 
 in this city = у цьому місті
@@ -1531,6 +1464,66 @@ in annexed cities = у анексованих містах
 in holy cities = у св'ятих містах
 in City-State cities = у містах-державах
 in cities following this religion = у містах, що сповідують цю релігію
+
+######### Population Filters ###########
+
+ # Requires translation!
+Unemployed = 
+ # Requires translation!
+Followers of the Majority Religion = 
+ # Requires translation!
+Followers of this Religion = 
+
+######### Terrain Filters ###########
+
+All = Усі
+Coastal = прибережні
+River = річкові
+Open terrain = Відкрита місцевість
+Rough terrain = пересічні
+Water resource = Морський ресурс
+Foreign Land = ворожі
+Foreign = іноземні
+Friendly Land = дружні землі
+ # Requires translation!
+Enemy Land = 
+ # Requires translation!
+Featureless = 
+ # Requires translation!
+Fresh Water = 
+non-fresh water = «без доступу до прісної води»
+Natural Wonder = Природне диво
+Impassable = Непрохідні
+Land = Земля
+Water = Вода
+Luxury resource = Дорогоцінний ресурс
+Strategic resource = Сратегічний ресурс
+Bonus resource = Бонусний ресурс
+
+######### Tile Filters ###########
+
+ # Requires translation!
+unimproved = 
+All Road = Уся дорога
+Great Improvement = Велике покращення
+
+######### Region Types ###########
+
+Hybrid = Гібрид
+
+######### Terrain Quality ###########
+
+Undesirable = Недосяжне
+Desirable = Досяжне
+
+######### Improvement Filters ###########
+
+Great = Великий 
+
+######### Prophet Action Filters ###########
+
+founding = заснування
+enhancing = покращення
 
 ######### Unique Specials ###########
 
@@ -1560,6 +1553,8 @@ Temple of Artemis = Храм Артеміди
 
 The Great Lighthouse = Александрійський маяк
 'They that go down to the sea in ships, that do business in great waters; these see the works of the Lord, and his wonders in the deep.' - The Bible, Psalms 107:23-24 = «Ті, хто по морю пливе кораблями, хто чинить зайняття своє на великій воді; вони бачили чини Господні та чуда Його в глибині!» — Біблія, Псалом 107:23-34.
+ # Requires translation!
+for [mapUnitFilter] units = 
 [amount] Movement = [amount] переміщення
 [amount] Sight = [amount] бачення
 
@@ -1609,6 +1604,8 @@ Krepost = Фортеця
 
 Statue of Zeus = Статуя Зевса
 'He spoke, the son of Kronos, and nodded his head with the dark brows, and the immortally anointed hair of the great god swept from his divine head, and all Olympos was shaken' - The Iliad = «Він, син Кроноса, мовив та похитав головою з-під темних бров, та волосся помазане бессмертям величного бога впало з його святої голови, та весь Олімп здригнувся» — Ілліада.
+vs cities = у битвах з містом
+when attacking = коли у нападі
 [amount]% Strength = [amount]% до сили
 
 Lighthouse = Маяк
@@ -1717,11 +1714,15 @@ Notre Dame = Собор Паризької Богоматері
 Castle = Замок
 
 Mughal Fort = Червоний форт
+ # Requires translation!
+after discovering [tech] = 
 [stats] [cityFilter] = [stats] [cityFilter]
 
 Himeji Castle = Замок Хімедзі
  # Requires translation!
 'Bushido is realized in the presence of death. This means choosing death whenever there is a choice between life and death. There is no other reasoning.' - Yamamoto Tsunetomo = 
+ # Requires translation!
+when fighting in [tileFilter] tiles = 
 
 Ironworks = Чавуноливарня
 
@@ -1839,6 +1840,8 @@ Pentagon = Пентагон
 
 Solar Plant = Сонячна електростанція
  # Requires translation!
+in cities without a [buildingFilter] = 
+ # Requires translation!
 Only available = 
 
 Nuclear Plant = Ядерна електростанція
@@ -1873,6 +1876,7 @@ King = Король
 Era Starting Unit = початкові підрозділи цієї епохи
 
 Emperor = Імператор
+Scout = Розвідник
 
 Immortal = Безсмертний
 Worker = Робітник
@@ -1905,9 +1909,6 @@ Atomic era = Холодна війна
 Information era = Інформаційна ера
 
 Future era = Майбутнє
-
-
-#################### Lines from GlobalUniques from Civ V - Vanilla ####################
 
 
 #################### Lines from Nations from Civ V - Vanilla ####################
@@ -2256,6 +2257,8 @@ La Rochelle = Ля Рошель
 Bourges = Бурже
 Calais = Кале
 France = Франція
+ # Requires translation!
+before discovering [tech] = 
 
 Catherine = Катерина
 You've behaved yourself very badly, you know it. Now it's payback time. = Ви поводили себе дуже погано, вам це відомо. Тепер настав час відповідати за свої гріхи.
@@ -2313,7 +2316,7 @@ Double quantity of [resource] produced = Удвічі збільшується �
 
 Augustus Caesar = Октавіан Август
  # Requires translation!
-My treasury contains little and my soldiers are getting impatient... ...therefore you must die. = 
+My treasury contains little and my soldiers are getting impatient... (sigh) ...therefore you must die. = 
 So brave, yet so stupid! If only you had a brain similar to your courage. = Такий сміливий поступок, але такий дурний! Якби ж ваш мозок був таким же великим як і ваша мужність.
 The gods have deprived Rome of their favour. We have been defeated. = Боги покинули нас. Ми програли.
 I greet you. I am Augustus, Imperator and Pontifex Maximus of Rome. If you are a friend of Rome, you are welcome. = Вітаю тебе. Я Август, імператор та великий понтифік Риму. Якщо ви друг Риму, ми готові дружити з вами.
@@ -2867,6 +2870,7 @@ Paishiyauvada = Пєйшіяувада
 Patigrbana = Патіґорбана
 Phrada = Фарах
 Persia = Персія
+during a Golden Age = під час Золотої Доби
 
 Kamehameha I = Камегамега I
 The ancient fire flashing across the sky is what proclaimed that this day would come, though I had foolishly hoped for a different outcome. = Древній вогонь запалав через все небо - це було знамення, що цей день прийде, хоча я нерозумно сподівався на іншу розв’язку.
@@ -2921,6 +2925,8 @@ Nuguria = Нукурія
 Pileni = Пілені
 Nukumanu = Нукуману
 Polynesia = Полінезія
+ # Requires translation!
+starting from the [era] = 
 Enables embarkation for land units = Дозволяє посадку на судно наземним підрозділам
  # Requires translation!
 Enables [mapUnitFilter] units to enter ocean tiles = 
@@ -3421,6 +3427,8 @@ Provides the cheapest [stat] building in your first [amount] cities for free = �
 Oligarchy = Олігархія
 Units in cities cost no Maintenance = Підрозділи у містах не потребують обслуговування
  # Requires translation!
+with a garrison = 
+ # Requires translation!
 [amount]% Strength for cities = 
 Landed Elite = Землевласники
 [amount]% growth [cityFilter] = [amount]% до росту [cityFilter]
@@ -3443,6 +3451,8 @@ Liberty =
 
 Warrior Code = Кодекс воїна
 Discipline = Дисципліна
+ # Requires translation!
+when adjacent to a [mapUnitFilter] unit = 
 Military Tradition = Військові традиції
  # Requires translation!
 [amount]% XP gained from combat = 
@@ -3451,6 +3461,7 @@ Professional Army = Професійна армія
 Honor Complete = Честь завершена
  # Requires translation!
 Honor = 
+vs [mapUnitFilter] units = у битвах з [mapUnitFilter] підрозділами
  # Requires translation!
 Notified of new Barbarian encampments = 
 
@@ -3465,6 +3476,8 @@ Free Religion = Свобода віросповідання
 Piety Complete = Побожність завершена
  # Requires translation!
 Piety = 
+ # Requires translation!
+before adopting [policy] = 
 
 Philantropy = Філантропія
 Gifts of Gold to City-States generate [amount]% more Influence = Подарунки містам-державам дають на [amount]% більше впливу
@@ -3510,11 +3523,13 @@ Rationalism Complete = Раціоналізм завершено
 [amount] Free Technologies = [amount] безкоштовних технологій
  # Requires translation!
 Rationalism = 
+while the empire is happy = поки імперія щаслива
  # Requires translation!
 [amount]% [stat] = 
 
 Constitution = Конституція
 Universal Suffrage = Загальне виборче право
+when defending = коли у захисті
 Civil Society = Громадянське суспільство
  # Requires translation!
 [amount]% Food consumption by specialists [cityFilter] = 
@@ -3535,6 +3550,8 @@ Quantity of strategic resources produced by the empire +[amount]% = Імпері
 Police State = Поліційна держава
 Total War = Тотальна війна
 Autocracy Complete = Автократія завершена
+ # Requires translation!
+for [amount] turns = 
  # Requires translation!
 Autocracy = 
  # Requires translation!
@@ -3562,30 +3579,30 @@ Clear Barbarian Camp = Знищення варварського табору
 We feel threatened by a Barbarian Camp near our city. Please take care of it. = Ми відчуваємо загрозу від варварського табору біля нашого міста.
 
 Connect Resource = Приєднання ресурсів
-In order to make our civilizations stronger, connect [param] to your trade network. = Щоб зробити наші цивілізації сильнійшими, приєднайте [param] до вашої торгівельної мережі.
+In order to make our civilizations stronger, connect [tileResource] to your trade network. = Щоб зробити наші цивілізації сильнійшими, приєднайте [tileResource] до вашої торгівельної мережі.
 
 Construct Wonder = Побудувати Диво
-We recommend you to start building [param] to show the whole world your civilization strength. = Ми рекомендуємо вам розпочати будівництво [param], щоб засвідчити всьому світові міць вашої цивілізації.
+We recommend you to start building [wonder] to show the whole world your civilization strength. = Ми рекомендуємо вам розпочати будівництво [wonder], щоб засвідчити всьому світові міць вашої цивілізації.
 
 Acquire Great Person = Отримати Видатну Особу
-Great People can change the course of a Civilization! You will be rewarded for acquiring a new [param]. = Видатна особа може змінити шлях цивілізації! Вас буде винагороджено за здобуття нової особи: [param].
+Great People can change the course of a Civilization! You will be rewarded for acquiring a new [greatPerson]. = Видатна особа може змінити шлях цивілізації! Вас буде винагороджено за здобуття нової особи: [greatPerson].
 
 Conquer City State = Завоювати місто-державу
-It's time to erase the City-State of [param] from the map. You will be greatly rewarded for conquering them! = Настав час стерти місто-державу [param] з мапи. Ви будете щедро нагороджені!
+It's time to erase the City-State of [cityState] from the map. You will be greatly rewarded for conquering them! = Настав час стерти місто-державу [cityState] з мапи. Ви будете щедро нагороджені!
 
 Find Player = Знайти гравця
-You have yet to discover where [param] set up their cities. You will be rewarded for finding their territories. = Ви ще не знайшли, де [param] розташовує свої міста. Вас буде винагороджено за знаходження їх територій.
+You have yet to discover where [civName] set up their cities. You will be rewarded for finding their territories. = Ви ще не знайшли, де [civName] розташовує свої міста. Вас буде винагороджено за знаходження їх територій.
 
 Find Natural Wonder = Знайти Природнє Диво
-Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [param] yet. = Відправте ваших найкращих дослідників на пошуки природних Див. Ніхто досі не знає, де знаходиться [param].
+Send your best explorers on a quest to discover Natural Wonders. Nobody knows the location of [naturalWonder] yet. = Відправте ваших найкращих дослідників на пошуки природних Див. Ніхто досі не знає, де знаходиться [naturalWonder].
 
 Give Gold = Подаруйте золото
  # Requires translation!
-We are suffering great poverty after being robbed by [param], and unless we receive a sum of Gold, it's only a matter of time before we collapse. = 
+We are suffering great poverty after being robbed by [civName], and unless we receive a sum of Gold, it's only a matter of time before we collapse. = 
 
 Pledge to Protect = Обіцянка захищати
  # Requires translation!
-We need your protection to stop the aggressions of [param]. By signing a Pledge of Protection, you'll confirm the bond that ties us. = 
+We need your protection to stop the aggressions of [civName]. By signing a Pledge of Protection, you'll confirm the bond that ties us. = 
 
 Contest Culture = Культурне змагання
  # Requires translation!
@@ -3601,18 +3618,18 @@ The civilization with the largest number of new Technologies researched will gai
 
 Invest = Інвестуйте
  # Requires translation!
-Our people are rejoicing thanks to a tourism boom. For a certain amount of time, any Gold donation will yield [amount]% extra Influence. = 
+Our people are rejoicing thanks to a tourism boom. For a certain amount of time, any Gold donation will yield [50]% extra Influence. = 
 
 Bully City State = Принизьте місто-державу
  # Requires translation!
-We are tired of the pretensions of [param]. If someone were to put them in their place by Demanding Tribute from them, they would be rewarded. = 
+We are tired of the pretensions of [cityState]. If someone were to put them in their place by Demanding Tribute from them, they would be rewarded. = 
 
 Denounce Civilization = Засудіть цивілізацію
  # Requires translation!
-We have been forced to pay tribute to [param]! We need you to tell the world of their ill deeds. = 
+We have been forced to pay tribute to [civName]! We need you to tell the world of their ill deeds. = 
 
  # Requires translation!
-We have heard the tenets of [param] and are most curious. Will you send missionaries to teach us about your religion? = 
+We have heard the tenets of [religionName] and are most curious. Will you send missionaries to teach us about your religion? = 
 
 
 #################### Lines from Ruins from Civ V - Vanilla ####################
@@ -3633,12 +3650,12 @@ An ancient tribe trained us in their ways of combat! =
 your exploring unit receives training = 
 
  # Requires translation!
-We have found survivors in the ruins! Population added to [param]. = 
+We have found survivors in the ruins! Population added to [cityName]. = 
  # Requires translation!
 survivors (adds population to a city) = 
 
  # Requires translation!
-We have found a stash of [param] Gold in the ruins! = 
+We have found a stash of [goldAmount] Gold in the ruins! = 
  # Requires translation!
 a stash of gold = 
 
@@ -3870,6 +3887,7 @@ Tundra = Тундра
 Desert = Пустеля
 
 Lakes = Озера
+Fresh water = прісноводні
 
 Mountain = Гори
 Has an elevation of [amount] for visibility calculations = Має висоту [amount] видимости
@@ -3892,6 +3910,7 @@ A Camp can be built here without cutting it down =
 Jungle = Джунглі
 
 Marsh = Болото
+Rare feature = Рідкісна риса
  # Requires translation!
 Only Polders can be built here = 
 
@@ -4103,11 +4122,14 @@ Porcelain = Фарфор
 #################### Lines from UnitPromotions from Civ V - Vanilla ####################
 
 Sword = Меч
+Mounted = Кіннота
+Siege = Облоговий
 Ranged Gunpowder = Дальнобійний вогнепальний
  # Requires translation!
 Armored = 
 Melee Water = Ближньобійний морський
 Ranged Water = Дальнобійний морський
+Submarine = Субмарина
 Heal Instantly = Миттєве лікування
  # Requires translation!
 Heal this unit by [amount] HP = 
@@ -4172,6 +4194,8 @@ Medic = Медик I
 All adjacent units heal [amount] HP when healing = 
 
 Medic II = Медик II
+ # Requires translation!
+in [tileFilter] tiles = 
 [amount] HP when healing = [amount] здоров'я під час лікування
 
 Scouting I = Розвідка I
@@ -4234,6 +4258,7 @@ Flight Deck III = Льотна палуба III
 Supply = Конвої
 May heal outside of friendly territory = Може лікуватись за межами дружньої території
 
+Bomber = Бомбардувальник
 Siege I = Наліт I
 
 Siege II = Наліт II
@@ -4243,6 +4268,7 @@ Siege III = Наліт III
 Evasion = Ухилення
 Damage taken from interception reduced by [amount]% = На [amount]% менше пошкоджень від перехоплення
 
+Fighter = Винищувач
 Interception I = Перехоплення I
 [amount]% Damage when intercepting = [amount]% пошкоджень під час перехоплення
 
@@ -4345,11 +4371,30 @@ Can see over obstacles =
 
 Atomic Bomber = Ядерний бомбардувальний
 
+Missile = Ракета
 Self-destructs when attacking = Само-знищується при атаці
  # Requires translation!
 Cannot be intercepted = 
 
 Can pass through impassable tiles = Можна проходити через непроходимі клітинки
+
+Melee = Ближній бій
+
+Ranged = Дальній бій
+
+Armor = Бронетехніка
+
+WaterCivilian = Морський цивільний
+
+WaterMelee = Морський ближній бій
+
+WaterRanged = Морський дальній бій
+
+WaterSubmarine = Підводний
+
+WaterAircraftCarrier = Морський авіаносець
+
+AtomicBomber = Атомний Бомбардувальник
 
 
 #################### Lines from Units from Civ V - Vanilla ####################
@@ -4430,6 +4475,8 @@ Knight = Лицар
 Camel Archer = Лучник на верблюді
 
 Conquistador = Конкістадор
+ # Requires translation!
+on foreign continents = 
 
 Naresuan's Elephant = Слон Наресуана
 
@@ -4520,6 +4567,8 @@ Anti-Tank Gun = Протитанкова гармата
 
 Atomic Bomb = Ядерна бомба
 Nuclear weapon of Strength [amount] = Ядерна зброя потужністю [amount]
+ # Requires translation!
+if [buildingName] is constructed = 
 Blast radius [amount] = Радіус ураження [amount]
 
 Rocket Artillery = Ракетна артилерія
@@ -4555,6 +4604,7 @@ Great Artist = Видатний митець
 Can start an [amount]-turn golden age = Може розпочати Золоту добу на [amount] ходів
 Can construct [improvementName] = Може спорудити [improvementName]
 Great Person - [stat] = Велика людина — [stat]
+Unbuildable = Неможливо створити
 
 Great Scientist = Видатний науковець
 Can hurry technology research = Може пришвидшити технологічне дослідження
@@ -4616,6 +4666,8 @@ Faith Healers = Релігійні цілителі
 Fertility Rites = Обряди родючості
 
 God of Craftsman = Бог ремісників
+ # Requires translation!
+in cities with at least [amount] [populationFilter] = 
 
 God of the Open Sky = Бог неба
 
@@ -4669,6 +4721,8 @@ Guruship = Гуру
 
 Holy Warriors = Релігійні воїни
  # Requires translation!
+before the [era] = 
+ # Requires translation!
 May buy [baseUnitFilter] units with [stat] for [amount] times their normal Production cost = 
 
 Liturgical Drama = Літургійна драма
@@ -4689,6 +4743,7 @@ Religious Community = Релігійна спільнота
 [amount]% [stat] from every follower, up to [amount2]% = [amount]% [stat] за кожного послідовника, поки не досягне [amount2]%
 
 Swords into Ploughshares = Мечі у плуги
+when not at war = у мирний час
 
 Founder = Засновник
 Ceremonial Burial = Урочисте поховання
@@ -4838,9 +4893,6 @@ Starting in this era disables religion = Старт у цій епосі вим�
 
 
 Marine = Морська піхота
-
-
-#################### Lines from GlobalUniques from Civ V - Gods & Kings ####################
 
 
 #################### Lines from Nations from Civ V - Gods & Kings ####################
@@ -5238,6 +5290,8 @@ Falmouth =
  # Requires translation!
 Lorient = 
 Celts = Кельти
+ # Requires translation!
+with [amount] to [amount2] neighboring [tileFilter] [tileFilter2] tiles = 
 
 Haile Selassie = Хайле Селассіє
  # Requires translation!
@@ -5317,6 +5371,8 @@ Ziway =
  # Requires translation!
 Weldiya = 
 Ethiopia = Ефіопія
+ # Requires translation!
+when fighting units from a Civilization with more Cities than you = 
 
 Pacal = Пакаль
  # Requires translation!
@@ -5409,12 +5465,12 @@ Taoism = Таоізм
 
 
  # Requires translation!
-We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[param] Faith) = 
+We have found holy symbols in the ruins, giving us a deeper understanding of religion! (+[faithAmount] Faith) = 
  # Requires translation!
 discover holy symbols = 
 
  # Requires translation!
-We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[param] Faith) = 
+We have found an ancient prophecy in the ruins, greatly increasing our spiritual connection! (+[faithAmount] Faith) = 
  # Requires translation!
 an ancient prophecy = 
 
@@ -5475,7 +5531,15 @@ Polder = Польдер
 #################### Lines from TileResources from Civ V - Gods & Kings ####################
 
 
+Citrus = Цитрус
+
+Copper = Мідь
+
+Crab = Краб
+
 Salt = Сіль
+
+Truffles = Трюфелі
 
 
 #################### Lines from UnitPromotions from Civ V - Gods & Kings ####################
@@ -5881,11 +5945,8 @@ No Sight =
  # Requires translation!
 Irremovable = 
 when at war = коли воює
-when not at war = у мирний час
-during a Golden Age = під час Золотої Доби
  # Requires translation!
 with [resource] = 
-while the empire is happy = поки імперія щаслива
  # Requires translation!
 when between [amount] and [amount2] Happiness = 
  # Requires translation!
@@ -5893,63 +5954,25 @@ when below [amount] Happiness =
  # Requires translation!
 during the [era] = 
  # Requires translation!
-before the [era] = 
- # Requires translation!
-starting from the [era] = 
- # Requires translation!
 if no other Civilization has researched this = 
- # Requires translation!
-after discovering [tech] = 
- # Requires translation!
-before discovering [tech] = 
  # Requires translation!
 upon discovering [tech] = 
  # Requires translation!
 after adopting [policy] = 
  # Requires translation!
-before adopting [policy] = 
- # Requires translation!
-if [buildingName] is constructed = 
- # Requires translation!
-for [amount] turns = 
- # Requires translation!
 by consuming this unit = 
  # Requires translation!
 in cities with a [buildingFilter] = 
  # Requires translation!
-in cities without a [buildingFilter] = 
- # Requires translation!
-in cities with at least [amount] [populationFilter] = 
- # Requires translation!
-with a garrison = 
- # Requires translation!
-for [mapUnitFilter] units = 
- # Requires translation!
 for units with [promotion] = 
  # Requires translation!
 for units without [promotion] = 
-vs cities = у битвах з містом
-vs [mapUnitFilter] units = у битвах з [mapUnitFilter] підрозділами
- # Requires translation!
-when fighting units from a Civilization with more Cities than you = 
-when attacking = коли у нападі
-when defending = коли у захисті
- # Requires translation!
-when fighting in [tileFilter] tiles = 
- # Requires translation!
-on foreign continents = 
- # Requires translation!
-when adjacent to a [mapUnitFilter] unit = 
  # Requires translation!
 when above [amount] HP = 
  # Requires translation!
 when below [amount] HP = 
  # Requires translation!
 with [amount] to [amount2] neighboring [tileFilter] tiles = 
- # Requires translation!
-with [amount] to [amount2] neighboring [tileFilter] [tileFilter2] tiles = 
- # Requires translation!
-in [tileFilter] tiles = 
  # Requires translation!
 in [tileFilter] [tileFilter2] tiles = 
  # Requires translation!
@@ -6028,3 +6051,11 @@ CityState =
 ModOptions = 
  # Requires translation!
 Conditional = 
+
+#################### Removed Lines ####################
+
+#~~Rough Terrain = Нерівна місцевість
+#~~Strategic = Стратегічний ресурс
+#~~Bonus = Бонусний ресурс
+#~~Luxury = Ресурс розкоші
+#~~military water = військові морські

--- a/android/assets/jsons/translations/completionPercentages.properties
+++ b/android/assets/jsons/translations/completionPercentages.properties
@@ -1,7 +1,7 @@
 Persian_(Pinglish-UN) = 17
 Italian = 98
 Russian = 98
-German = 100
+German = 99
 Swedish = 96
 Turkish = 77
 Ukrainian = 87

--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -1085,8 +1085,6 @@ or [terrainType] =
 Can be constructed by = 
 Defence bonus = 
 Movement cost = 
-Open terrain = 
-Rough Terrain = 
 for = 
 Missing translations: = 
 Version = 
@@ -1216,108 +1214,6 @@ Religion =
 Enhancing religion = 
 Enhanced religion = 
 
-# Terrains
-
-Impassable = 
-Rare feature = 
-
-# terrainFilters (so for uniques like: "[stats] from [terrainFilter] tiles")
-
-All = 
-Water = 
-Land = 
-Coastal = 
-River = 
-Open terrain = 
-Rough terrain = 
-Foreign Land = 
-Foreign = 
-Friendly Land = 
-Friendly = 
-Water resource = 
-Bonus resource = 
-Luxury resource = 
-Strategic resource = 
-Fresh water = 
-non-fresh water = 
-Natural Wonder = 
-Hybrid = 
-Undesirable = 
-Desirable = 
-Featureless = 
-Fresh Water = 
-
-# improvementFilters
-
-All = 
-All Road = 
-Great Improvement = 
-Great = 
-
-# Resources
-
-Bison = 
-Copper = 
-Cocoa = 
-Crab = 
-Citrus = 
-Truffles = 
-Strategic = 
-Bonus = 
-Luxury = 
-
-# Unit types
-
-City = 
-Civilian = 
-Melee = 
-Ranged = 
-Scout = 
-Mounted = 
-Armor = 
-Siege = 
-
-WaterCivilian = 
-WaterMelee = 
-WaterRanged = 
-WaterSubmarine = 
-WaterAircraftCarrier = 
-
-Fighter = 
-Bomber = 
-AtomicBomber = 
-Missile = 
-
-
-# Unit filters and other unit related things
-
-Air = 
-air units = 
-All = 
-Barbarian = 
-Barbarians = 
-Embarked = 
-Land = 
-land units = 
-Military = 
-# Deprecated since 3.15.2, but should still be translated until it is officially removed
-military water = 
-non-air = 
-Nuclear Weapon = 
-Submarine = 
-submarine units = 
-Unbuildable = 
-Water = 
-water units = 
-wounded units = 
-Wounded = 
-
-# For the "All newly-trained [relevant] units in this city receive the [] promotion" translation. Relevant as in 'units that can receive'
-relevant = 
-
-# For "May choose [amount] additional [beliefType] beliefs when [founding/enhancing] a religion"
-founding = 
-enhancing = 
 
 # Promotions
 
@@ -1423,6 +1319,11 @@ This Unit upgrades for free =
 [stats] when a city adopts this religion for the first time = 
 Never destroyed when the city is captured = 
 Invisible to others = 
+
+# Unused Resources
+
+Bison = 
+Cocoa = 
 
 
 # In English we just paste all these conditionals at the end of each unique, but in your language that

--- a/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
@@ -13,7 +13,7 @@ import com.unciv.models.translations.TranslationFileWriter  // for  Kdoc only
 
 
 /**
- * These manage validation of parameters in [Unique]s and 
+ * These manage validation of parameters in [Unique]s and
  * placeholder guessing for untyped uniques in [TranslationFileWriter].
  *
  * [UniqueType] will build a map of valid [UniqueParameterType]s per parameter by matching
@@ -38,11 +38,13 @@ enum class UniqueParameterType(
             else null
         }
     },
+
     // todo potentially remove if OneTimeRevealSpecificMapTiles changes
     KeywordAll("'all'") {
         override fun getErrorSeverity(parameterText: String, ruleset: Ruleset) =
             if (parameterText == "All") null else UniqueType.UniqueComplianceErrorSeverity.RulesetInvariant
     },
+
     CombatantFilter("combatantFilter") {
         override fun getErrorSeverity(parameterText: String, ruleset: Ruleset):
                 UniqueType.UniqueComplianceErrorSeverity? {
@@ -51,7 +53,8 @@ enum class UniqueParameterType(
         }
 
     },
-    MapUnitFilter("mapUnitFilter") {
+
+    MapUnitFilter("mapUnitFilter", "Map Unit Filters") {
         private val knownValues = setOf("Wounded", Constants.barbarians, "City-State", "Embarked", "Non-City")
         override fun getErrorSeverity(parameterText: String, ruleset: Ruleset):
                 UniqueType.UniqueComplianceErrorSeverity? {
@@ -62,7 +65,9 @@ enum class UniqueParameterType(
             if (parameterText in knownValues) return null
             return BaseUnitFilter.getErrorSeverity(parameterText, ruleset)
         }
+        override fun getTranslationWriterStringsForOutput() = knownValues
     },
+
     BaseUnitFilter("baseUnitFilter") {
         override fun getErrorSeverity(parameterText: String, ruleset: Ruleset):
                 UniqueType.UniqueComplianceErrorSeverity? {
@@ -70,12 +75,14 @@ enum class UniqueParameterType(
             return UnitTypeFilter.getErrorSeverity(parameterText, ruleset)
         }
     },
-    UnitTypeFilter("unitType") {
+
+    UnitTypeFilter("unitType", "Unit Type Filters") {
         // As you can see there is a difference between these and what's in unitTypeStrings (for translation) -
         // the goal is to unify, but for now this is the "real" list
         private val knownValues = setOf("All", "Melee", "Ranged", "Civilian", "Military", "Land", "Water", "Air",
-            "non-air", "Nuclear Weapon", "Great Person", "Religious")
-        private val unitTypeStrings = hashSetOf(
+            "non-air", "Nuclear Weapon", "Great Person", "Religious", "Barbarian")
+        // TODO make this obsolete
+        private val unitTypeStrings = setOf(
             "Military",
             "Civilian",
             "non-air",
@@ -89,6 +96,7 @@ enum class UniqueParameterType(
             "air units",
             "military units",
             "submarine units",
+            "Barbarian"
             // Note: this can't handle combinations of parameters (e.g. [{Military} {Water}])
         )
 
@@ -101,7 +109,9 @@ enum class UniqueParameterType(
 
         override fun isTranslationWriterGuess(parameterText: String, ruleset: Ruleset) =
             parameterText in ruleset.unitTypes.keys || parameterText in unitTypeStrings
+        override fun getTranslationWriterStringsForOutput() = unitTypeStrings
     },
+
     UnitName("unit") {
         override fun getErrorSeverity(parameterText: String, ruleset: Ruleset):
                 UniqueType.UniqueComplianceErrorSeverity? {
@@ -109,6 +119,7 @@ enum class UniqueParameterType(
             return UniqueType.UniqueComplianceErrorSeverity.WarningOnly
         }
     },
+
     GreatPerson("greatPerson") {
         override fun getErrorSeverity(
             parameterText: String,
@@ -118,6 +129,7 @@ enum class UniqueParameterType(
             return UniqueType.UniqueComplianceErrorSeverity.RulesetSpecific
         }
     },
+
     Stats("stats") {
         override fun getErrorSeverity(parameterText: String, ruleset: Ruleset):
                 UniqueType.UniqueComplianceErrorSeverity? {
@@ -125,6 +137,7 @@ enum class UniqueParameterType(
             return UniqueType.UniqueComplianceErrorSeverity.RulesetInvariant
         }
     },
+
     StatName("stat") {
         override fun getErrorSeverity(parameterText: String, ruleset: Ruleset):
                 UniqueType.UniqueComplianceErrorSeverity? {
@@ -132,6 +145,7 @@ enum class UniqueParameterType(
             return UniqueType.UniqueComplianceErrorSeverity.RulesetInvariant
         }
     },
+
     PlunderableStatName("plunderableStat") {
         private val knownValues = setOf(Stat.Gold.name, Stat.Science.name, Stat.Culture.name, Stat.Faith.name)
         override fun getErrorSeverity(
@@ -142,6 +156,7 @@ enum class UniqueParameterType(
             return UniqueType.UniqueComplianceErrorSeverity.RulesetInvariant
         }
     },
+
     CityFilter("cityFilter", "City filters") {
         private val cityFilterStrings = setOf(
             "in this city",
@@ -170,6 +185,7 @@ enum class UniqueParameterType(
 
         override fun getTranslationWriterStringsForOutput() = cityFilterStrings
     },
+
     BuildingName("buildingName") {
         override fun getErrorSeverity(
             parameterText: String,
@@ -179,6 +195,7 @@ enum class UniqueParameterType(
             return UniqueType.UniqueComplianceErrorSeverity.RulesetSpecific
         }
     },
+
     BuildingFilter("buildingFilter") {
         private val knownValues = setOf("All","Building","Buildings","Wonder","Wonders","National Wonder","World Wonder")
         override fun getErrorSeverity(
@@ -194,6 +211,7 @@ enum class UniqueParameterType(
         override fun isTranslationWriterGuess(parameterText: String, ruleset: Ruleset) =
             parameterText != "All" && getErrorSeverity(parameterText, ruleset) == null
     },
+
     // Only used in values deprecated in 3.17.10
         ConstructionFilter("constructionFilter") {
             override fun getErrorSeverity(
@@ -206,7 +224,8 @@ enum class UniqueParameterType(
             }
         },
     //
-    PopulationFilter("populationFilter") {
+
+    PopulationFilter("populationFilter", "Population Filters") {
         private val knownValues = setOf("Population", "Specialists", "Unemployed", "Followers of the Majority Religion", "Followers of this Religion")
         override fun getErrorSeverity(
             parameterText: String,
@@ -214,26 +233,29 @@ enum class UniqueParameterType(
         ): UniqueType.UniqueComplianceErrorSeverity? {
             if (parameterText in knownValues) return null
             return UniqueType.UniqueComplianceErrorSeverity.RulesetSpecific
-        }  
+        }
+        override fun getTranslationWriterStringsForOutput() = knownValues
     },
-    TerrainFilter("terrainFilter") {
+
+    TerrainFilter("terrainFilter", "Terrain Filters") {
         private val knownValues = setOf("All",
-            Constants.coastal, "River", "Open terrain", "Rough terrain", "Water resource",
-            "Foreign Land", "Foreign", "Friendly Land", "Friendly", "Enemy Land", "Enemy",
-            "Featureless", Constants.freshWaterFilter, "Natural Wonder")
-        override fun getErrorSeverity(parameterText: String, ruleset: Ruleset):
-                UniqueType.UniqueComplianceErrorSeverity? {
-            if (parameterText in knownValues) return null
-            if (ruleset.terrains.containsKey(parameterText)) return null
-            if (TerrainType.values().any { parameterText == it.name }) return null
-            if (ruleset.tileResources.containsKey(parameterText)) return null
-            if (ResourceType.values().any { parameterText == it.name + " resource" }) return null
-            return UniqueType.UniqueComplianceErrorSeverity.WarningOnly
+                Constants.coastal, "River", "Open terrain", "Rough terrain", "Water resource",
+                "Foreign Land", "Foreign", "Friendly Land", "Friendly", "Enemy Land", "Enemy",
+                "Featureless", Constants.freshWaterFilter, "non-fresh water", "Natural Wonder",
+                "Impassable", "Land", "Water") +
+            ResourceType.values().map { it.name + " resource" }
+        override fun getErrorSeverity(parameterText: String, ruleset: Ruleset) = when(parameterText) {
+            in knownValues -> null
+            in ruleset.terrains -> null
+            in ruleset.tileResources -> null
+            else -> UniqueType.UniqueComplianceErrorSeverity.WarningOnly
         }
         override fun isTranslationWriterGuess(parameterText: String, ruleset: Ruleset) =
-            parameterText in ruleset.terrains.keys || parameterText != "All" && parameterText in knownValues
+            parameterText in ruleset.terrains || parameterText != "All" && parameterText in knownValues
+        override fun getTranslationWriterStringsForOutput() = knownValues
     },
-    TileFilter("tileFilter") {
+
+    TileFilter("tileFilter", "Tile Filters") {
         private val knownValues = setOf("unimproved", "All Road", "Great Improvement")
         override fun getErrorSeverity(parameterText: String, ruleset: Ruleset):
                 UniqueType.UniqueComplianceErrorSeverity? {
@@ -241,7 +263,9 @@ enum class UniqueParameterType(
             if (ruleset.tileImprovements.containsKey(parameterText)) return null
             return TerrainFilter.getErrorSeverity(parameterText, ruleset)
         }
+        override fun getTranslationWriterStringsForOutput() = knownValues
     },
+
     /** Used by NaturalWonderGenerator, only tests base terrain or a feature */
     SimpleTerrain("simpleTerrain") {
         private val knownValues = setOf("Elevated", "Water", "Land")
@@ -252,6 +276,7 @@ enum class UniqueParameterType(
             return UniqueType.UniqueComplianceErrorSeverity.RulesetSpecific
         }
     },
+
     /** Used by NaturalWonderGenerator, only tests base terrain */
     BaseTerrain("baseTerrain") {
         override fun getErrorSeverity(parameterText: String, ruleset: Ruleset):
@@ -260,6 +285,7 @@ enum class UniqueParameterType(
             return UniqueType.UniqueComplianceErrorSeverity.RulesetSpecific
         }
     },
+
     TerrainName("terrainName") {
         override fun getErrorSeverity(parameterText: String, ruleset: Ruleset):
                 UniqueType.UniqueComplianceErrorSeverity? {
@@ -267,8 +293,9 @@ enum class UniqueParameterType(
             return UniqueType.UniqueComplianceErrorSeverity.RulesetSpecific
         }
     },
+
     /** Used for region definitions, can be a terrain type with region unique, or "Hybrid" */
-    RegionType("regionType") {
+    RegionType("regionType", "Region Types") {
         private val knownValues = setOf("Hybrid")
         override fun getErrorSeverity(parameterText: String, ruleset: Ruleset):
                 UniqueType.UniqueComplianceErrorSeverity? {
@@ -278,16 +305,20 @@ enum class UniqueParameterType(
                 return null
             return UniqueType.UniqueComplianceErrorSeverity.RulesetSpecific
         }
+        override fun getTranslationWriterStringsForOutput() = knownValues
     },
+
     /** Used for start placements */
-    TerrainQuality("terrainQuality") {
+    TerrainQuality("terrainQuality", "Terrain Quality") {
         private val knownValues = setOf("Undesirable", "Food", "Desirable", "Production")
         override fun getErrorSeverity(parameterText: String, ruleset: Ruleset):
                 UniqueType.UniqueComplianceErrorSeverity? {
             if (parameterText in knownValues) return null
             return UniqueType.UniqueComplianceErrorSeverity.RulesetInvariant
         }
+        override fun getTranslationWriterStringsForOutput() = knownValues
     },
+
     Promotion("promotion") {
         override fun getErrorSeverity(parameterText: String, ruleset: Ruleset):
             UniqueType.UniqueComplianceErrorSeverity? = when (parameterText) {
@@ -295,6 +326,7 @@ enum class UniqueParameterType(
                 else -> UniqueType.UniqueComplianceErrorSeverity.RulesetSpecific
             }
     },
+
     Era("era") {
         override fun getErrorSeverity(parameterText: String, ruleset: Ruleset):
             UniqueType.UniqueComplianceErrorSeverity? = when (parameterText) {
@@ -302,6 +334,7 @@ enum class UniqueParameterType(
                 else -> UniqueType.UniqueComplianceErrorSeverity.RulesetSpecific
             }
     },
+
     ImprovementName("improvementName"){
         override fun getErrorSeverity(parameterText: String,ruleset: Ruleset):
                 UniqueType.UniqueComplianceErrorSeverity? {
@@ -309,19 +342,20 @@ enum class UniqueParameterType(
             return UniqueType.UniqueComplianceErrorSeverity.RulesetSpecific
         }
     },
+
     /** should mirror TileImprovement.matchesFilter exactly */
-    ImprovementFilter("improvementFilter") {
+    ImprovementFilter("improvementFilter", "Improvement Filters") {
         private val knownValues = setOf("All", "All Road", "Great Improvement", "Great")
         override fun getErrorSeverity(parameterText: String, ruleset: Ruleset):
                 UniqueType.UniqueComplianceErrorSeverity? {
             if (parameterText in knownValues) return null
-            if (ruleset.tileImprovements.containsKey(parameterText)) return null
-            return UniqueType.UniqueComplianceErrorSeverity.RulesetSpecific
+            return ImprovementName.getErrorSeverity(parameterText, ruleset)
         }
-
         override fun isTranslationWriterGuess(parameterText: String, ruleset: Ruleset) =
             parameterText != "All" && getErrorSeverity(parameterText, ruleset) == null
+        override fun getTranslationWriterStringsForOutput() = knownValues
     },
+
     Resource("resource") {
         override fun getErrorSeverity(parameterText: String, ruleset: Ruleset):
             UniqueType.UniqueComplianceErrorSeverity? = when (parameterText) {
@@ -329,6 +363,7 @@ enum class UniqueParameterType(
                 else -> UniqueType.UniqueComplianceErrorSeverity.RulesetSpecific
             }
     },
+
     BeliefTypeName("beliefType") {
         override fun getErrorSeverity(parameterText: String, ruleset: Ruleset):
                 UniqueType.UniqueComplianceErrorSeverity? = when (parameterText) {
@@ -336,6 +371,7 @@ enum class UniqueParameterType(
             else -> UniqueType.UniqueComplianceErrorSeverity.RulesetInvariant
         }
     },
+
     Belief("belief") {
         override fun getErrorSeverity(parameterText: String, ruleset: Ruleset):
                 UniqueType.UniqueComplianceErrorSeverity? = when (parameterText) {
@@ -343,14 +379,17 @@ enum class UniqueParameterType(
             else -> UniqueType.UniqueComplianceErrorSeverity.RulesetSpecific
         }
     },
-    FoundingOrEnhancing("foundingOrEnhancing") {
+
+    FoundingOrEnhancing("foundingOrEnhancing", "Prophet Action Filters") {
         private val knownValues = setOf("founding", "enhancing")
         override fun getErrorSeverity(parameterText: String, ruleset: Ruleset):
                 UniqueType.UniqueComplianceErrorSeverity? = when (parameterText) {
             in knownValues -> null
             else -> UniqueType.UniqueComplianceErrorSeverity.RulesetInvariant
         }
+        override fun getTranslationWriterStringsForOutput() = knownValues
     },
+
     Technology("tech") {
         override fun getErrorSeverity(parameterText: String, ruleset: Ruleset):
                 UniqueType.UniqueComplianceErrorSeverity? = when (parameterText) {
@@ -358,6 +397,7 @@ enum class UniqueParameterType(
             else -> UniqueType.UniqueComplianceErrorSeverity.RulesetSpecific
         }
     },
+
     Specialist("specialist") {
         override fun getErrorSeverity(parameterText: String, ruleset: Ruleset):
                 UniqueType.UniqueComplianceErrorSeverity? = when (parameterText) {
@@ -365,6 +405,7 @@ enum class UniqueParameterType(
             else -> UniqueType.UniqueComplianceErrorSeverity.RulesetSpecific
         }
     },
+
     Policy("policy") {
         override fun getErrorSeverity(
             parameterText: String,
@@ -376,15 +417,17 @@ enum class UniqueParameterType(
             }
         }
     },
+
     VictoryT("victoryType") {
         override fun getErrorSeverity(
             parameterText: String,
             ruleset: Ruleset
         ): UniqueType.UniqueComplianceErrorSeverity? {
-            return if (parameterText in VictoryType.values().map { it.name }) null 
+            return if (parameterText in VictoryType.values().map { it.name }) null
             else UniqueType.UniqueComplianceErrorSeverity.RulesetInvariant
         }
     },
+
     CostOrStrength("costOrStrength") {
         private val knownValues = setOf("Cost", "Strength")
         override fun getErrorSeverity(
@@ -395,6 +438,7 @@ enum class UniqueParameterType(
             else UniqueType.UniqueComplianceErrorSeverity.RulesetInvariant
         }
     },
+
     Action("action") {
         private val knownValues = setOf(Constants.spreadReligionAbilityCount, Constants.removeHeresyAbilityCount)
         override fun getErrorSeverity(
@@ -405,6 +449,7 @@ enum class UniqueParameterType(
             else UniqueType.UniqueComplianceErrorSeverity.RulesetInvariant
         }
     },
+
     /** Behaves like [Unknown], but states explicitly the parameter is OK and its contents are ignored */
     Comment("comment", "Unique Specials") {
         override fun getErrorSeverity(parameterText: String, ruleset: Ruleset):
@@ -412,10 +457,12 @@ enum class UniqueParameterType(
 
         override fun getTranslationWriterStringsForOutput() = scanExistingValues(this)
     },
+
     Unknown("param") {
         override fun getErrorSeverity(parameterText: String, ruleset: Ruleset):
                 UniqueType.UniqueComplianceErrorSeverity? = null
     };
+
 
     /** Validate a [Unique] parameter */
     abstract fun getErrorSeverity(parameterText: String, ruleset: Ruleset): UniqueType.UniqueComplianceErrorSeverity?
@@ -424,9 +471,10 @@ enum class UniqueParameterType(
     open fun isTranslationWriterGuess(parameterText: String, ruleset: Ruleset): Boolean =
         getErrorSeverity(parameterText, ruleset) == null
 
-    /** Get a list of possible values [TranslationFileWriter] should include as translatable string 
+    /** Get a list of possible values [TranslationFileWriter] should include as translatable string
      *  that are not recognized from other json sources */
     open fun getTranslationWriterStringsForOutput(): Set<String> = setOf()
+
 
     companion object {
         private fun scanExistingValues(type: UniqueParameterType): Set<String> {

--- a/core/src/com/unciv/models/translations/TranslationFileWriter.kt
+++ b/core/src/com/unciv/models/translations/TranslationFileWriter.kt
@@ -3,7 +3,6 @@ package com.unciv.models.translations
 import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.files.FileHandle
 import com.badlogic.gdx.utils.Array
-import com.unciv.Constants
 import com.unciv.JsonParser
 import com.unciv.models.metadata.BaseRuleset
 import com.unciv.models.ruleset.*
@@ -15,8 +14,6 @@ import com.unciv.models.ruleset.unique.*
 import com.unciv.models.ruleset.unit.BaseUnit
 import com.unciv.models.ruleset.unit.Promotion
 import com.unciv.models.ruleset.unit.UnitType
-import com.unciv.models.stats.Stat
-import com.unciv.models.stats.Stats
 import java.lang.reflect.Field
 import java.lang.reflect.Modifier
 
@@ -43,7 +40,8 @@ object TranslationFileWriter {
 
             return "Translation files are generated successfully."
         } catch (ex: Throwable) {
-            return ex.localizedMessage
+            ex.printStackTrace()
+            return ex.localizedMessage ?: ex.javaClass.simpleName
         }
     }
 
@@ -79,19 +77,20 @@ object TranslationFileWriter {
 
             for (baseRuleset in BaseRuleset.values()) {
                 val generatedStringsFromBaseRuleset =
-                        generateStringsFromJSONs(Gdx.files.local("jsons/${baseRuleset.fullName}"))
+                        GenerateStringsFromJSONs(Gdx.files.local("jsons/${baseRuleset.fullName}"))
                 for (entry in generatedStringsFromBaseRuleset)
                     fileNameToGeneratedStrings[entry.key + " from " + baseRuleset.fullName] = entry.value
             }
 
             fileNameToGeneratedStrings["Tutorials"] = generateTutorialsStrings()
         } else {
-            fileNameToGeneratedStrings.putAll(generateStringsFromJSONs(modFolder.child("jsons")))
+            fileNameToGeneratedStrings.putAll(GenerateStringsFromJSONs(modFolder.child("jsons")))
         }
 
-        for (key in fileNameToGeneratedStrings.keys) {
+        for ((key, value) in fileNameToGeneratedStrings) {
+            if (value.isEmpty()) continue
             linesToTranslate.add("\n#################### Lines from $key ####################\n")
-            linesToTranslate.addAll(fileNameToGeneratedStrings.getValue(key))
+            linesToTranslate.addAll(value)
         }
 
 
@@ -147,7 +146,7 @@ object TranslationFileWriter {
                 if (languageIndex == 0) countOfTranslatableLines++
 
                 val existingTranslation = translations[hashMapKey]
-                var translationValue = if (existingTranslation != null && language in existingTranslation){
+                var translationValue = if (existingTranslation != null && language in existingTranslation) {
                     translationsOfThisLanguage++
                     existingTranslation[language]!!
                 } else if (baseTranslations?.get(hashMapKey)?.containsKey(language) == true) {
@@ -177,12 +176,23 @@ object TranslationFileWriter {
                         )
                 }
 
-                val lineToWrite = translationKey.replace("\n", "\\n") +
-                        " = " + translationValue.replace("\n", "\\n")
-                stringBuilder.appendLine(lineToWrite)
+                stringBuilder.appendTranslation(translationKey, translationValue)
             }
 
             countOfTranslatedLines[language] = translationsOfThisLanguage
+
+            // As a courtesy to translators, add in any deletions as comments
+            var needHeader = true
+            for ((translationKey, translationEntry) in translations) {
+                if (translationKey in existingTranslationKeys) continue
+                val translationValue = translationEntry[language] ?: continue
+                if (needHeader) {
+                    needHeader = false
+                    stringBuilder.appendLine("\n#################### Removed Lines ####################\n")
+                }
+                val prefix = (if (translationKey.startsWith("#~~")) "" else "#~~")
+                stringBuilder.appendTranslation(prefix + translationKey, translationValue)
+            }
 
             val fileWriter = getFileHandle(modFolder, languageFileLocation.format(language))
             // Any time you have more than 3 line breaks, make it 3
@@ -196,6 +206,11 @@ object TranslationFileWriter {
             entry.setValue(if (countOfTranslatableLines <= 0) 100 else entry.value * 100 / countOfTranslatableLines)
 
         return countOfTranslatedLines
+    }
+
+    private fun StringBuilder.appendTranslation(key: String, value: String) {
+        appendLine(key.replace("\n", "\\n") +
+                " = " + value.replace("\n", "\\n"))
     }
 
     private fun writeLanguagePercentages(percentages: HashMap<String, Int>, modFolder: FileHandle? = null) {
@@ -223,7 +238,8 @@ object TranslationFileWriter {
 
     // used for unit test only
     fun getGeneratedStringsSize(): Int {
-        return generateStringsFromJSONs(Gdx.files.local("jsons/Civ V - Vanilla")).values.sumOf { // exclude empty lines
+        return GenerateStringsFromJSONs(Gdx.files.local("jsons/Civ V - Vanilla")).values.sumOf {
+            // exclude empty lines
             it.count { line: String -> !line.startsWith(specialNewLineCode) }
         }
     }
@@ -237,6 +253,7 @@ object TranslationFileWriter {
         }
         return text.fillPlaceholders(*newPlaceholders.toTypedArray())
     }
+
     private fun ArrayList<String>.addNumberedParameter(name: String) {
         if (name !in this) {
             this += name
@@ -247,12 +264,16 @@ object TranslationFileWriter {
         this += name + i
     }
 
-    private fun generateStringsFromJSONs(jsonsFolder: FileHandle): LinkedHashMap<String, MutableSet<String>> {
+    /** This scans one folder for json files and generates lines ***to translate*** (left side).
+     *  All work is done right on instantiation.
+      */
+    private class GenerateStringsFromJSONs(
+        jsonsFolder: FileHandle
+    ): LinkedHashMap<String, MutableSet<String>>() {
+        // Using LinkedHashMap (instead of HashMap) is important to maintain the order of sections in the translation file
+
         val ruleset = RulesetCache.getVanillaRuleset()
         val startMillis = System.currentTimeMillis()
-
-        // Using LinkedHashMap (instead of HashMap) is important to maintain the order of sections in the translation file
-        val generatedStrings = LinkedHashMap<String, MutableSet<String>>()
 
         var uniqueIndexOfNewLine = 0
         val jsonParser = JsonParser()
@@ -260,171 +281,197 @@ object TranslationFileWriter {
                 .list { file -> file.name.endsWith(".json", true) }
                 .sortedBy { it.name() }       // generatedStrings maintains order, so let's feed it a predictable one
 
-        for (jsonFile in listOfJSONFiles) {
-            val filename = jsonFile.nameWithoutExtension()
+        // One set per json file, secondary loop var. Could be nicer to isolate all per-file
+        // processing into another class, but then we'd have to pass uniqueIndexOfNewLine around. 
+        lateinit var resultStrings: MutableSet<String>
 
-            val javaClass = getJavaClassByName(filename)
-            if (javaClass == this.javaClass)
-                continue // unknown JSON, let's skip it
+        init {
+            for (jsonFile in listOfJSONFiles) {
+                val filename = jsonFile.nameWithoutExtension()
 
-            val array = jsonParser.getFromJson(javaClass, jsonFile.path())
+                val javaClass = getJavaClassByName(filename)
+                if (javaClass == this.javaClass)
+                    continue // unknown JSON, let's skip it
 
-            generatedStrings[filename] = mutableSetOf()
-            val resultStrings = generatedStrings[filename]!!
+                val array = jsonParser.getFromJson(javaClass, jsonFile.path())
 
-            fun submitString(string: String) {
-                val unique = Unique(string)
-                if (unique.hasFlag(UniqueFlag.HiddenToUsers))
-                    return // We don't need to translate this at all, not user-visible
-                var stringToTranslate = string.removeConditionals()
+                resultStrings = mutableSetOf()
+                this[filename] = resultStrings
 
-                if (unique.params.isNotEmpty()) {
-                    val parameterNames = ArrayList<String>()
-                    for ((index, parameter) in unique.params.withIndex()) {
-                        val parameterName =
-                            if (unique.type != null) {
-                                val possibleParameterTypes = unique.type.parameterTypeMap[index]
-                                // for multiple types. will look like "[unitName/buildingName]"
-                                possibleParameterTypes.joinToString("/") { it.parameterName }
-                            } else {
-                                UniqueParameterType.guessTypeForTranslationWriter(parameter, ruleset).parameterName
-                            }
-                        parameterNames.addNumberedParameter(parameterName)
+                if (array is kotlin.Array<*>)
+                    for (element in array) {
+                        serializeElement(element!!) // let's serialize the strings recursively
+                        // This is a small hack to insert multiple /n into the set, which can't contain identical lines
+                        resultStrings.add("$specialNewLineCode ${uniqueIndexOfNewLine++}")
                     }
-                    stringToTranslate = stringToTranslate.fillPlaceholders(*parameterNames.toTypedArray())
-                } else if (string.contains('{')) {
-                    val matches = curlyBraceRegex.findAll(string)
-                    if (matches.any()) {
-                        // Ignore outer string, only translate the parts within `{}`
-                        matches.forEach { submitString(it.groups[1]!!.value) }
-                        return
-                    }
+            }
+            val displayName = if (jsonsFolder.name() != "jsons") jsonsFolder.name()
+                else jsonsFolder.parent().name()  // Show mod name
+            println("Translation writer took ${System.currentTimeMillis() - startMillis}ms for $displayName")
+        }
+
+        fun submitString(string: String) {
+            if ('{' in string) {
+                val matches = curlyBraceRegex.findAll(string)
+                if (matches.any()) {
+                    // Ignore outer string, only translate the parts within `{}`
+                    matches.forEach { submitString(it.groups[1]!!.value) }
+                    return
                 }
-                resultStrings.add("$stringToTranslate = ")
+            }
+            resultStrings.add("$string = ")
+        }
+
+        fun submitString(string: String, unique: Unique) {
+            if (unique.hasFlag(UniqueFlag.HiddenToUsers))
+                return // We don't need to translate this at all, not user-visible
+
+            val stringToTranslate = string.removeConditionals()
+            for (conditional in unique.conditionals) {
+                submitString(conditional.text, conditional)
+            }
+
+            if (unique.params.isEmpty()) {
+                submitString(stringToTranslate)
                 return
             }
 
-            fun serializeElement(element: Any) {
-                if (element is String) {
-                    submitString(element)
-                    return
-                }
-
-                // Example: PolicyBranch inherits from Policy inherits from RulesetObject.
-                // RulesetObject has the name and uniques properties and we wish to include them.
-                // So we need superclass recursion to be sure not to miss stuff in the future.
-                // The superclass != null check is made obsolete in theory by the Object check, but better play safe.
-                fun Class<*>.allSupers(): Sequence<Class<*>> = sequence {
-                    if (this@allSupers == Object::class.java) return@sequence
-                    yield(this@allSupers)
-                    if (superclass != null)
-                        yieldAll(superclass.allSupers())
-                }
-                // Including `fields` is dubious. AFAIK it is an incomplete view of what we're getting via superclass recursion.
-                val allFields = element.javaClass.fields.asSequence() +
-                        element.javaClass.allSupers().flatMap { it.declaredFields.asSequence() }
-                // Filter by classes we can and want to process, avoid Companion fields
-                // Note lazies are not Modifier.TRANSIENT but their type is different and excluded
-                val relevantFields = allFields.filter {
-                        (it.modifiers and (Modifier.STATIC or Modifier.TRANSIENT)) == 0
-                        && (
-                            it.type == String::class.java ||
-                            it.type == java.util.ArrayList::class.java ||
-                            it.type == java.util.List::class.java ||        // CivilopediaText is not an ArrayList
-                            it.type == java.util.HashSet::class.java ||
-                            it.type.isEnum  // allow scanning Enum names
-                        )
-                        && it.type != element.javaClass  // avoid following infinite loops
-                    }.distinct()  // We do get duplicates even without `fields`, no need to do double work, even if submitString operates on a set
-
-                for (field in relevantFields) {
-                    field.isAccessible = true
-                    val fieldValue = field.get(element)
-                    if (isFieldTranslatable(javaClass, field, fieldValue)) { // skip fields which must not be translated
-                        // this field can contain sub-objects, let's serialize them as well
-                        @Suppress("RemoveRedundantQualifierName")  // to clarify List does _not_ inherit from anything in java.util
-                        when (fieldValue) {
-                            is java.util.AbstractCollection<*> ->
-                                for (item in fieldValue)
-                                    if (item is String) submitString(item) else serializeElement(item!!)
-                            is kotlin.collections.List<*> ->
-                                for (item in fieldValue)
-                                    if (item is String) submitString(item) else serializeElement(item!!)
-                            else -> submitString(fieldValue.toString())
-                        }
+            val parameterNames = ArrayList<String>()
+            for ((index, parameter) in unique.params.withIndex()) {
+                val parameterName =
+                    if (unique.type != null) {
+                        val possibleParameterTypes = unique.type.parameterTypeMap[index]
+                        // for multiple types. will look like "[unitName/buildingName]"
+                        possibleParameterTypes.joinToString("/") { it.parameterName }
+                    } else {
+                        UniqueParameterType.guessTypeForTranslationWriter(parameter, ruleset).parameterName
                     }
-                }
+                parameterNames.addNumberedParameter(parameterName)
+            }
+            resultStrings.add("${stringToTranslate.fillPlaceholders(*parameterNames.toTypedArray())} = ")
+        }
+
+        // Example: PolicyBranch inherits from Policy inherits from RulesetObject.
+        // RulesetObject has the name and uniques properties and we wish to include them.
+        // So we need superclass recursion to be sure not to miss stuff in the future.
+        // The superclass != null check is made obsolete in theory by the Object check, but better play safe.
+        fun Class<*>.allSupers(): Sequence<Class<*>> = sequence {
+            if (this@allSupers == Object::class.java) return@sequence
+            yield(this@allSupers)
+            if (superclass != null)
+                yieldAll(superclass.allSupers())
+        }
+
+        fun serializeElement(element: Any) {
+            if (element is String) {
+                submitString(element)
+                return
             }
 
-            if (array is kotlin.Array<*>)
-                for (element in array) {
-                    serializeElement(element!!) // let's serialize the strings recursively
-                    // This is a small hack to insert multiple /n into the set, which can't contain identical lines
-                    resultStrings.add("$specialNewLineCode ${uniqueIndexOfNewLine++}")
+            // Including `fields` is dubious. AFAIK it is an incomplete view of what we're getting
+            // anyway via superclass recursion. But since we now do a distinct() it won't hurt.
+            val allFields = element.javaClass.fields.asSequence() +
+                    element.javaClass.allSupers().flatMap { it.declaredFields.asSequence() }
+            // Filter by classes we can and want to process, avoid Companion fields
+            // Note lazies are Modifier.TRANSIENT and type == kotlin.Lazy
+            val relevantFields = allFields.filter {
+                    (it.modifiers and (Modifier.STATIC or Modifier.TRANSIENT)) == 0 &&
+                    isFieldTypeRelevant(it.type)
+                    // it.type != element.javaClass  // avoid following infinite loops - redundant as isFieldTypeRelevant won't match
+                }.distinct()  // We do get duplicates even without `fields`, no need to do double work, even if submitString operates on a set
+
+            for (field in relevantFields) {
+                field.isAccessible = true
+                val fieldValue = field.get(element)
+                // skip fields which must not be translated
+                if (!isFieldTranslatable(element.javaClass, field, fieldValue)) continue
+                // this field can contain sub-objects, let's serialize them as well
+                @Suppress("RemoveRedundantQualifierName")  // to clarify List does _not_ inherit from anything in java.util
+                when {
+                    // Promotion names are not uniques but since we did the "[unitName] ability"
+                    // they need the "parameters" treatment too
+                    (field.name == "uniques" || field.name == "promotions") && (fieldValue is java.util.AbstractCollection<*>) ->
+                        for (item in fieldValue)
+                            if (item is String) submitString(item, Unique(item)) else serializeElement(item!!)
+                    fieldValue is java.util.AbstractCollection<*> ->
+                        for (item in fieldValue)
+                            if (item is String) submitString(item) else serializeElement(item!!)
+                    fieldValue is kotlin.collections.List<*> ->
+                        for (item in fieldValue)
+                            if (item is String) submitString(item) else serializeElement(item!!)
+                    element is Promotion && field.name == "name" ->  // see above
+                        submitString(fieldValue.toString(), Unique(fieldValue.toString()))
+                    else -> submitString(fieldValue.toString())
                 }
+            }
         }
-        println("Translation writer took ${System.currentTimeMillis()-startMillis}ms for ${jsonsFolder.name()}")
 
-        return generatedStrings
-    }
+        companion object {
+            /** Exclude fields by name that contain references to items defined elsewhere
+             * or are otherwise Strings but not user-displayed.
+             *
+             * An exclusion applies either over _all_ json files and all classes contained in them
+             * or Class-specific by using a "Class.Field" notation.
+             */
+            private val untranslatableFieldSet = setOf(
+                "aiFreeTechs", "aiFreeUnits", "attackSound", "building", "cannotBeBuiltWith",
+                "cultureBuildings", "excludedDifficulties", "improvement", "improvingTech",
+                "obsoleteTech", "occursOn", "prerequisites", "promotions",
+                "providesFreeBuilding", "replaces", "requiredBuilding", "requiredBuildingInAllCities",
+                "requiredNearbyImprovedResources", "requiredResource", "requiredTech", "requires",
+                "revealedBy", "startBias", "techRequired", "terrainsCanBeBuiltOn",
+                "terrainsCanBeFoundOn", "turnsInto", "uniqueTo", "upgradesTo",
+                "link", "icon", "extraImage", "color",  // FormattedLine
+                "RuinReward.uniques", "TerrainType.name"
+            )
 
-    /** Exclude fields by name that contain references to items defined elsewhere
-     * or are otherwise Strings but not user-displayed.
-     *
-     * An exclusion applies either over _all_ json files and all classes contained in them
-     * or Class-specific by using a "Class.Field" notation.
-     */
-    private val untranslatableFieldSet = setOf(
-            "aiFreeTechs", "aiFreeUnits", "attackSound", "building",
-            "cannotBeBuiltWith", "cultureBuildings", "improvement", "improvingTech",
-            "obsoleteTech", "occursOn", "prerequisites", "promotions",
-            "providesFreeBuilding", "replaces", "requiredBuilding", "requiredBuildingInAllCities",
-            "requiredNearbyImprovedResources", "requiredResource", "requiredTech", "requires",
-            "resourceTerrainAllow", "revealedBy", "startBias", "techRequired",
-            "terrainsCanBeBuiltOn", "terrainsCanBeFoundOn", "turnsInto", "uniqueTo", "upgradesTo",
-            "link", "icon", "extraImage", "color",  // FormattedLine
-            "excludedDifficulties", "RuinReward.uniques"      // RuinReward
-    )
-    /** Specifies Enums where the name property _is_ translatable, by Class name */
-    private val translatableEnumsSet = setOf("BeliefType")
+            /** Specifies Enums where the name property _is_ translatable, by Class name */
+            private val translatableEnumsSet = setOf("BeliefType")
 
-    /** Checks whether a field's value should be included in the translation templates.
-     * Applies explicit field exclusions from [untranslatableFieldSet].
-     * The Modifier.STATIC exclusion removes fields from e.g. companion objects.
-     * Fields of enum types need that type explicitly allowed in [translatableEnumsSet]
-     */
-    private fun isFieldTranslatable(clazz: Class<*>, field: Field, fieldValue: Any?): Boolean {
-        return fieldValue != null &&
-                fieldValue != "" &&
-                (field.modifiers and Modifier.STATIC) == 0 &&
-                (!field.type.isEnum || field.type.simpleName in translatableEnumsSet) &&
-                field.name !in untranslatableFieldSet &&
-                (clazz.componentType?.simpleName ?: clazz.simpleName) + "." + field.name !in untranslatableFieldSet
-    }
+            private fun isFieldTypeRelevant(type: Class<*>) =
+                    type == String::class.java ||
+                    type == java.util.ArrayList::class.java ||
+                    type == java.util.List::class.java ||        // CivilopediaText is not an ArrayList
+                    type == java.util.HashSet::class.java ||
+                    type.isEnum  // allow scanning Enum names
 
-    private fun getJavaClassByName(name: String): Class<Any> {
-        return when (name) {
-            "Beliefs" -> emptyArray<Belief>().javaClass
-            "Buildings" -> emptyArray<Building>().javaClass
-            "Difficulties" -> emptyArray<Difficulty>().javaClass
-            "Eras" -> emptyArray<Era>().javaClass
-            "GlobalUniques" -> GlobalUniques().javaClass
-            "Nations" -> emptyArray<Nation>().javaClass
-            "Policies" -> emptyArray<PolicyBranch>().javaClass
-            "Quests" -> emptyArray<Quest>().javaClass
-            "Religions" -> emptyArray<String>().javaClass
-            "Ruins" -> emptyArray<RuinReward>().javaClass
-            "Specialists" -> emptyArray<Specialist>().javaClass
-            "Techs" -> emptyArray<TechColumn>().javaClass
-            "Terrains" -> emptyArray<Terrain>().javaClass
-            "TileImprovements" -> emptyArray<TileImprovement>().javaClass
-            "TileResources" -> emptyArray<TileResource>().javaClass
-            "Tutorials" -> this.javaClass // dummy value
-            "UnitPromotions" -> emptyArray<Promotion>().javaClass
-            "Units" -> emptyArray<BaseUnit>().javaClass
-            "UnitTypes" -> emptyArray<UnitType>().javaClass
-            else -> this.javaClass // dummy value
+            /** Checks whether a field's value should be included in the translation templates.
+             * Applies explicit field exclusions from [untranslatableFieldSet].
+             * The Modifier.STATIC exclusion removes fields from e.g. companion objects.
+             * Fields of enum types need that type explicitly allowed in [translatableEnumsSet]
+             */
+            private fun isFieldTranslatable(clazz: Class<*>, field: Field, fieldValue: Any?): Boolean {
+                return fieldValue != null &&
+                        fieldValue != "" &&
+                        (!field.type.isEnum || field.type.simpleName in translatableEnumsSet) &&
+                        field.name !in untranslatableFieldSet &&
+                        (clazz.componentType?.simpleName ?: clazz.simpleName) + "." + field.name !in untranslatableFieldSet
+            }
+
+            private fun getJavaClassByName(name: String): Class<Any> {
+                return when (name) {
+                    "Beliefs" -> emptyArray<Belief>().javaClass
+                    "Buildings" -> emptyArray<Building>().javaClass
+                    "Difficulties" -> emptyArray<Difficulty>().javaClass
+                    "Eras" -> emptyArray<Era>().javaClass
+                    "GlobalUniques" -> GlobalUniques().javaClass
+                    "Nations" -> emptyArray<Nation>().javaClass
+                    "Policies" -> emptyArray<PolicyBranch>().javaClass
+                    "Quests" -> emptyArray<Quest>().javaClass
+                    "Religions" -> emptyArray<String>().javaClass
+                    "Ruins" -> emptyArray<RuinReward>().javaClass
+                    "Specialists" -> emptyArray<Specialist>().javaClass
+                    "Techs" -> emptyArray<TechColumn>().javaClass
+                    "Terrains" -> emptyArray<Terrain>().javaClass
+                    "TileImprovements" -> emptyArray<TileImprovement>().javaClass
+                    "TileResources" -> emptyArray<TileResource>().javaClass
+                    "Tutorials" -> this.javaClass // dummy value
+                    "UnitPromotions" -> emptyArray<Promotion>().javaClass
+                    "Units" -> emptyArray<BaseUnit>().javaClass
+                    "UnitTypes" -> emptyArray<UnitType>().javaClass
+                    else -> this.javaClass // dummy value
+                }
+            }
         }
     }
-
 }

--- a/docs/Other/Translating.md
+++ b/docs/Other/Translating.md
@@ -50,6 +50,12 @@ Make sure that you make the changes in the 'master' branch in your repo!
 
 Each untranslated phrase will have a "requires translation" line before it, so you can quickly find them. You don't need to remove them yourself if you don't want to - they will be automatically removed the next time we rebuild the file.
 
+Order of lines does not matter, they will be rearranged automatically each release.
+
+When Unciv no longer needs a translation entry, it will be moved to the end and prefixed with `#~~`. Those removed lines will survive automatic processes, so please check them and remove those where you are sure they will indeed no longer be needed. They exist for cases where e.g. a detail in the english source version needed changing - that will invalidate existing translations, but now you can recover previous versions and adapt them to the new template.
+
+You can leave very limited comments to yourself or other translators - prefix comments with `#~~#<number> = ` (assign sequential numbers to that `<number>` placeholder) and place them at the end of the file. The comment style you see in the rest of the file is reserved for internal use, and placing such comments in earlier parts will lead to them being moved to the end by the next release.
+
 Do as much as you're comfortable with - it's a big game with a lot of named objects, so don't feel pressured into doing everything =)
 
 Note that Right-to-Left languages such as Arabic and Hebrew are not supported by the framework :/
@@ -64,10 +70,12 @@ Sometimes, new strings (names, uniques, etc) are added in the json files. In ord
 
 - Goes over the template.properties and copies translation lines
 - For every json file in the jsons folder
-    - Selects all string values - both in objects, and in arrays in objects
+    - Selects all string values - both in objects, and in arrays in objects, to any inheritance or nesting level.
+      (Collections that can be parsed must be derived from List or AbstractCollection)
     - Generates a 'key = value' line
+- Scans knowledge from UniqueType and UniqueParameterType instances and generates 'key = value' lines for them
 
-This means that every text that ISN'T in the jsons needs to be added manually to the template.properties in order to be translated!
+This means that every text that ISN'T in the jsons or the UniqueType system needs to be added manually to the template.properties in order to be translated!
 That also means if you've been adding new json structures you (or someone) should check TranslationFileWriter and see if it is able to cope with them.
 
 ## Rules for templates added manually
@@ -82,3 +90,6 @@ Translation templates can use placeholders, and there's two varieties: `[]` and 
 Square brackets `[]` mean the outer and inner components are both translated individually. The outer template will use alias names inside the brackets - example: Your code outputs "Everyone gains [5000] gold!", then the translation template should be "Everyone gains [amount] gold! = ". The translation engine would translate the "Everyone gains [] gold!" and "5000" individually and reassemble them - of course, the number is simply passed through. But in other cases that could be e.g. a Unit name that would be translated, and you could trust that translations for units are already handled just fine. Note that [uniques](../Modders/Unique-parameter-types.md) often use the feature, but it is in no way limited to them. It it makes life easier for translators, use it.
 
 Curly brackets `{}` are simpler - the contents within the brackets are translated individually, while the outer parts are passed through verbatim. Example: `"+$amount${Fonts.gold} {Gold}".toLabel()` - note the first `${}` is a kotlin template while the second pair becomes part of the string. It tells the translation engine to ignore the numbers and the symbol but to translate the single word "Gold".
+
+## Rules for all sources
+The [], {} and <> bracket types are used internally and cannot be part of a translatable text. Use () instead.


### PR DESCRIPTION
I think that's all for the translation writer I'm gonna do for now.

#### Notes
- Again, since that unit test compares parameter placeholders across languages, all of them are included, and that will break open translation PR's not based on this, and merging will be _quite_ difficult. I recommend merge this and have people start over, _or_ wait for a lull in translation PR's, have them all merged, then fix this by pulling those updates and simply re-running the generator over those.
Merging older translation PR's after this will be tricky because:
- This moves stuff around, since the scanner is more capable, stuff can appear earlier. I think that's good (else I could have switched processing order), uniques appear under the object where they are first used, so the xl'tor has more context, instead of in one long list.
- The Unique() treatment including [] and <> processing is no longer applied to _everything_. This means Caesar's war declaration <sigh> came through in that step, and keys are no longer trimmed. This should fix ` OR `, but a) two flavour texts, on austria and india, were now not-matching since the xlt had the trimmed string but json an extra space. Removed the space in json so the xlt stays valid. b) that <sigh> still falls through when actual xlations are matched, and at that point the context is gone, so I opted to side-step that problem and make it a (sigh).
- The Unique() treatment _is_ applied to uniques collections, obviously, but also to promotion names - a kludge to not make our idea for those `[unit] ability` promotions uglier in the xlt files (still worked, but the lines were all `[Maori Warrior] ability = ...` - almost self-explaining why).
- The Unique() treatment _is not_ applied to Quest description, which will copy the original json [] content to the xlt files (still auto-matching the old translations) - including the one hardcoded [50]%. I think that's just fine, all the others are clearer now.

- **Unmatched translations are no longer lost** - see the wiki changes included.

- Minor tweaks...
- Performance is better between 20 and 50% I guess, fluctuates too much on my box to be more precise.

#### *Not* treated here

- Will fix some of the stuff mentioned in #6131 if not all - I have _not_ checked, sorry.
- Actually fixing the UniqueParameterType knowledge of how the filters work, or UniqueTypes choosing a different filter in the declaration and implementation. See my issue for input on that. I fixed only tiny stuff necessary to get nice and stable translation files (like Rough terrain / Rough Terrain).
- Forgot: I declared Impassable to be a valid TerrainFilter mainly so no template entry is necessary because it could well _be_ one, I should have actually implemented the option.