### PR TITLE
Apply Char(Int) and Char.code patch to Maya Calendar

### DIFF
--- a/core/src/com/unciv/ui/utils/KeyPressDispatcher.kt
+++ b/core/src/com/unciv/ui/utils/KeyPressDispatcher.kt
@@ -64,11 +64,11 @@ data class KeyCharAndCode(val char: Char, val code: Int) {
         val UNKNOWN = KeyCharAndCode(Input.Keys.UNKNOWN)
 
         // Kludges because we got crashes: java.lang.NoSuchMethodError: 'int kotlin.CharCodeKt.access$getCode$p(char)'  
-        private fun Char.toCode() =
+        fun Char.toCode() =
             try { code } catch (ex: Throwable) { null }
                 ?: try { @Suppress("DEPRECATION") toInt() } catch (ex: Throwable) { null }
                 ?: 0
-        private fun Int.makeChar() =
+        fun Int.makeChar() =
             try { Char(this) } catch (ex: Throwable) { null }
                 ?: try { toChar() } catch (ex: Throwable) { null }
                 ?: Char.MIN_VALUE

--- a/core/src/com/unciv/ui/utils/MayaCalendar.kt
+++ b/core/src/com/unciv/ui/utils/MayaCalendar.kt
@@ -6,6 +6,8 @@ import com.unciv.logic.civilization.CivilizationInfo
 import com.unciv.models.ruleset.unique.UniqueTriggerActivation
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.translations.tr
+import com.unciv.ui.utils.KeyCharAndCode.Companion.makeChar
+import com.unciv.ui.utils.KeyCharAndCode.Companion.toCode
 import kotlin.math.abs
 
 object MayaCalendar {
@@ -23,7 +25,7 @@ object MayaCalendar {
     const val zero = 'ⅰ' // U+2170
     const val nineteen = 'Ↄ' // U+2183
     val digits = zero..nineteen
-    fun digitIcon(ch: Char) = iconFolder + (ch.code - zero.code).toString()
+    fun digitIcon(ch: Char) = iconFolder + (ch.toCode() - zero.toCode()).toString()
 
     // Calculation
     private const val daysOn30000101BCE = 36000 + 5040 + 240 + 11
@@ -43,9 +45,9 @@ object MayaCalendar {
         }
 
         override fun toString(): String {
-            val baktunDigit = Char(zero.code + baktuns)
-            val katunDigit = Char(zero.code + katuns)
-            val tunDigit = Char(zero.code + tuns)
+            val baktunDigit = (zero.toCode() + baktuns).makeChar()
+            val katunDigit = (zero.toCode() + katuns).makeChar()
+            val tunDigit = (zero.toCode() + tuns).makeChar()
             return "$baktunDigit$baktun$katunDigit$katun$tunDigit$tun"
         }
     }


### PR DESCRIPTION
As suspected but not yet confirmed, the Maya crash the moment they get Theology; same Char<->Int conversion the culprit. This takes the easy way - cross-package calls to the workaround helpers. Now the only use left is IdChecker, and I've no idea how to test that one. It uses Char.code while I suspect the real troublemaker is Char(Int).

Must remember to check whether having those critical calls not living in a static would work...