### PR TITLE
Make uniques.md more friendly

### DIFF
--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -655,17 +655,17 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 	Applicable to: Global
 
 ??? example  "[amount] Movement"
-	Example: "[20] Movement"
+	Example: "[3] Movement"
 
 	Applicable to: Global, Unit
 
 ??? example  "[amount] Sight"
-	Example: "[20] Sight"
+	Example: "[5] Sight"
 
 	Applicable to: Global, Unit, Terrain
 
 ??? example  "[amount] Range"
-	Example: "[20] Range"
+	Example: "[3] Range"
 
 	Applicable to: Global, Unit
 


### PR DESCRIPTION
I can't understand why all uniques examples with a [number] are filled with 20. It's illogical sometimes. Such as [20] sight. 
And it sometimes confuses modding beginners like '[20]% Strength'. Does it mean +20% strength or -80% strength?

(Still in progress)