### PR TITLE
Fixed turn checker crashes 

### DIFF
--- a/android/src/com/unciv/app/MultiplayerTurnCheckWorker.kt
+++ b/android/src/com/unciv/app/MultiplayerTurnCheckWorker.kt
@@ -13,7 +13,6 @@ import androidx.core.app.NotificationCompat.DEFAULT_VIBRATE
 import androidx.core.app.NotificationManagerCompat
 import androidx.work.*
 import com.badlogic.gdx.backends.android.AndroidApplication
-import com.unciv.Constants
 import com.unciv.logic.GameInfo
 import com.unciv.logic.GameSaver
 import com.unciv.models.metadata.GameSettings
@@ -49,7 +48,7 @@ class MultiplayerTurnCheckWorker(appContext: Context, workerParams: WorkerParame
         private const val USER_ID = "USER_ID"
         private const val CONFIGURED_DELAY = "CONFIGURED_DELAY"
         private const val PERSISTENT_NOTIFICATION_ENABLED = "PERSISTENT_NOTIFICATION_ENABLED"
-        private const val FILE_STORAGE = Constants.dropboxMultiplayerServer
+        private const val FILE_STORAGE = "FILE_STORAGE"
 
         fun enqueue(appContext: Context,
                     delayInMinutes: Int, inputData: Data) {

--- a/core/src/com/unciv/logic/multiplayer/Multiplayer.kt
+++ b/core/src/com/unciv/logic/multiplayer/Multiplayer.kt
@@ -61,6 +61,14 @@ class UncivServerFileStorage(val serverUrl:String):IFileStorage {
 
 class FileStorageConflictException: Exception()
 
+/**
+ * Allows access to games stored on a server for multiplayer purposes.
+ * Defaults to using UncivGame.Current.settings.multiplayerServer if fileStorageIdentifier is not given.
+ *
+ * @param fileStorageIdentifier must be given if UncivGame.Current might not be initialized
+ * @see IFileStorage
+ * @see UncivGame.Current.settings.multiplayerServer
+ */
 class OnlineMultiplayer(var fileStorageIdentifier: String? = null) {
     val fileStorage: IFileStorage
     init {

--- a/core/src/com/unciv/logic/multiplayer/Multiplayer.kt
+++ b/core/src/com/unciv/logic/multiplayer/Multiplayer.kt
@@ -66,9 +66,10 @@ class OnlineMultiplayer(var fileStorageIdentifier: String? = null) {
     init {
         if (fileStorageIdentifier == null)
             fileStorageIdentifier = UncivGame.Current.settings.multiplayerServer
-        if (fileStorageIdentifier == Constants.dropboxMultiplayerServer)
-            fileStorage = DropboxFileStorage()
-        else fileStorage = UncivServerFileStorage(fileStorageIdentifier!!)
+        fileStorage = if (fileStorageIdentifier == Constants.dropboxMultiplayerServer)
+            DropboxFileStorage()
+        else
+            UncivServerFileStorage(fileStorageIdentifier!!)
     }
 
     fun tryUploadGame(gameInfo: GameInfo, withPreview: Boolean) {

--- a/core/src/com/unciv/logic/multiplayer/Multiplayer.kt
+++ b/core/src/com/unciv/logic/multiplayer/Multiplayer.kt
@@ -68,8 +68,7 @@ class OnlineMultiplayer(var fileStorageIdentifier: String? = null) {
             fileStorageIdentifier = UncivGame.Current.settings.multiplayerServer
         fileStorage = if (fileStorageIdentifier == Constants.dropboxMultiplayerServer)
             DropboxFileStorage()
-        else
-            UncivServerFileStorage(fileStorageIdentifier!!)
+        else UncivServerFileStorage(fileStorageIdentifier!!)
     }
 
     fun tryUploadGame(gameInfo: GameInfo, withPreview: Boolean) {

--- a/core/src/com/unciv/logic/multiplayer/Multiplayer.kt
+++ b/core/src/com/unciv/logic/multiplayer/Multiplayer.kt
@@ -62,13 +62,14 @@ class UncivServerFileStorage(val serverUrl:String):IFileStorage {
 
 class FileStorageConflictException: Exception()
 
-class OnlineMultiplayer {
+class OnlineMultiplayer(var fileStorageIdentifier: String? = null) {
     val fileStorage: IFileStorage
     init {
-        val settings = UncivGame.Current.settings
-        if (settings.multiplayerServer == Constants.dropboxMultiplayerServer)
+        if (fileStorageIdentifier == null)
+            fileStorageIdentifier = UncivGame.Current.settings.multiplayerServer
+        if (fileStorageIdentifier == Constants.dropboxMultiplayerServer)
             fileStorage = DropboxFileStorage()
-        else fileStorage = UncivServerFileStorage(settings.multiplayerServer)
+        else fileStorage = UncivServerFileStorage(fileStorageIdentifier!!)
     }
 
     fun tryUploadGame(gameInfo: GameInfo, withPreview: Boolean) {


### PR DESCRIPTION
Fixes #6502
Passing the desired server from MultiplayerTurnCheckWorker to OnlineMultiplayer guarantees that UncivGame.current will not be called.