### PR TITLE
Nicer NotificationScroll

### DIFF
--- a/core/src/com/unciv/ui/worldscreen/NotificationsScroll.kt
+++ b/core/src/com/unciv/ui/worldscreen/NotificationsScroll.kt
@@ -24,7 +24,7 @@ class NotificationsScroll(
         const val inverseScaleFactor = 1f / scaleFactor
         /** Limit width by wrapping labels to this percentage of the stage */
         const val maxWidthOfStage = 0.333f
-        /** Logical size of the notification icons - note fontsize is coded separately */
+        /** Logical size of the notification icons - note font size is coded separately */
         const val iconSize = 30f
     }
 
@@ -110,5 +110,9 @@ class NotificationsScroll(
         notificationsTable.invalidate() // looks redundant but isn't
         // (the flags it sets are already on when inspected in debugger, but when omitting it the
         // ScrollPane will not properly scroll down to the new maxY when TileInfoTable changes to a smaller height)
+    }
+
+    fun setTopRight (right: Float, top: Float) {
+        setPosition(right - width * scaleFactor, top - height * scaleFactor)
     }
 }

--- a/core/src/com/unciv/ui/worldscreen/NotificationsScroll.kt
+++ b/core/src/com/unciv/ui/worldscreen/NotificationsScroll.kt
@@ -3,43 +3,69 @@ package com.unciv.ui.worldscreen
 import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.scenes.scene2d.Actor
 import com.badlogic.gdx.scenes.scene2d.Touchable
+import com.badlogic.gdx.scenes.scene2d.ui.Cell
 import com.badlogic.gdx.scenes.scene2d.ui.Table
+import com.badlogic.gdx.utils.Align
 import com.unciv.logic.civilization.Notification
+import com.unciv.ui.utils.WrappableLabel
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.utils.onClick
-import com.unciv.ui.utils.toLabel
 import kotlin.math.min
 import com.unciv.ui.utils.AutoScrollPane as ScrollPane
 
-class NotificationsScroll(internal val worldScreen: WorldScreen) : ScrollPane(null) {
+class NotificationsScroll(
+    private val worldScreen: WorldScreen,
+    private val maxNotificationsHeight: Float
+) : ScrollPane(null) {
+    private companion object {
+        /** Scale the entire ScrollPane by this factor */
+        const val scaleFactor = 0.5f
+        /** Complement of [scaleFactor] because multiplication is cheaper */
+        const val inverseScaleFactor = 1f / scaleFactor
+        /** Limit width by wrapping labels to this percentage of the stage */
+        const val maxWidthOfStage = 0.333f
+        /** Logical size of the notification icons - note fontsize is coded separately */
+        const val iconSize = 30f
+    }
 
-    var notificationsHash: Int = 0
+    private var notificationsHash: Int = 0
 
     private var notificationsTable = Table()
+    private var endOfTableSpacerCell: Cell<*>? = null
+
+    private val maxEntryWidth = worldScreen.stage.width * maxWidthOfStage * inverseScaleFactor
 
     init {
         actor = notificationsTable.right()
         touchable = Touchable.childrenOnly
-        setScale(.5f)
+        setScale(scaleFactor)
     }
 
-    internal fun update(notifications: MutableList<Notification>) {
+    internal fun update(notifications: MutableList<Notification>, tileInfoTableHeight: Float) {
 
         // no news? - keep our list as it is, especially don't reset scroll position
-        if (notificationsHash == notifications.hashCode())
+        if (notificationsHash == notifications.hashCode()) {
+            sizeScrollingSpacer(tileInfoTableHeight)
+            layout()
             return
+        }
         notificationsHash = notifications.hashCode()
 
         notificationsTable.clearChildren()
-        for (notification in notifications.toList().reversed()) { // toList to avoid concurrency problems
-            val label = notification.text.toLabel(Color.BLACK, 30)
+        for (notification in notifications.asReversed().toList()) { // toList to avoid concurrency problems
             val listItem = Table()
-
             listItem.background = ImageGetter.getRoundedEdgeRectangle()
-            listItem.add(label)
 
+            val labelWidth = maxEntryWidth - iconSize * notification.icons.size - 10f
+            val label = WrappableLabel(notification.text, labelWidth, Color.BLACK, 30)
+            label.setAlignment(Align.center)
+            if (label.prefWidth > labelWidth * scaleFactor) {  // can't explain why the comparison needs scaleFactor
+                label.wrap = true
+                listItem.add(label).maxWidth(label.optimizePrefWidth()).padRight(10f)
+            } else {
+                listItem.add(label).padRight(10f)
+            }
 
-            val iconSize = 30f
             if (notification.icons.isNotEmpty()) {
                 val ruleset = worldScreen.gameInfo.ruleSet
                 for (icon in notification.icons.reversed()) {
@@ -63,9 +89,26 @@ class NotificationsScroll(internal val worldScreen: WorldScreen) : ScrollPane(nu
 
             notificationsTable.add(clickArea).right().row()
         }
-        notificationsTable.pack()
+
+        notificationsTable.pack()  // needed to get height - prefHeight is set and close but not quite the same value
+        val filledHeight = notificationsTable.height
+
+        sizeScrollingSpacer(tileInfoTableHeight)
+
         pack()
-        height = min(notificationsTable.height, worldScreen.stage.height * 2 / 3 - 15f)
+        height = min(filledHeight, maxNotificationsHeight * inverseScaleFactor)  // after this, maxY is still incorrect until layout()
     }
 
+    /** Add some empty space that can be scrolled under the TileInfoTable which is covering our lower part */
+    private fun sizeScrollingSpacer(tileInfoTableHeight: Float) {
+        if (endOfTableSpacerCell == null) {
+            endOfTableSpacerCell = notificationsTable.add().pad(5f)
+            notificationsTable.row()
+        }
+        val scaledHeight = tileInfoTableHeight * inverseScaleFactor
+        endOfTableSpacerCell!!.height(scaledHeight)
+        notificationsTable.invalidate() // looks redundant but isn't
+        // (the flags it sets are already on when inspected in debugger, but when omitting it the
+        // ScrollPane will not properly scroll down to the new maxY when TileInfoTable changes to a smaller height)
+    }
 }

--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -467,8 +467,7 @@ class WorldScreen(val gameInfo: GameInfo, val viewingCiv:CivilizationInfo) : Bas
         }
         updateNextTurnButton(hasOpenPopups()) // This must be before the notifications update, since its position is based on it
         notificationsScroll.update(viewingCiv.notifications, bottomTileInfoTable.height)
-        notificationsScroll.setPosition(stage.width - notificationsScroll.width * 0.5f - 10f,
-                nextTurnButton.y - notificationsScroll.height * 0.5f - 5f)
+        notificationsScroll.setTopRight(stage.width - 10f, nextTurnButton.y - 5f)
     }
 
     private fun getCurrentTutorialTask(): String {

--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -72,7 +72,7 @@ class WorldScreen(val gameInfo: GameInfo, val viewingCiv:CivilizationInfo) : Bas
     val canChangeState
         get() = isPlayersTurn && !viewingCiv.isSpectator()
     private var waitingForAutosave = false
-    val mapVisualization = MapVisualization(gameInfo, viewingCiv)
+    private val mapVisualization = MapVisualization(gameInfo, viewingCiv)
 
     val mapHolder = WorldMapHolder(this, gameInfo.tileMap)
     private val minimapWrapper = MinimapHolder(mapHolder)
@@ -107,7 +107,9 @@ class WorldScreen(val gameInfo: GameInfo, val viewingCiv:CivilizationInfo) : Bas
         topBar.setPosition(0f, stage.height - topBar.height)
         topBar.width = stage.width
 
-        notificationsScroll = NotificationsScroll(this)
+        val maxNotificationsHeight = topBar.y - nextTurnButton.height -
+                (if (game.settings.showMinimap) minimapWrapper.height else 0f) - 25f
+        notificationsScroll = NotificationsScroll(this, maxNotificationsHeight)
         // notifications are right-aligned, they take up only as much space as necessary.
         notificationsScroll.width = stage.width / 2
 
@@ -142,11 +144,11 @@ class WorldScreen(val gameInfo: GameInfo, val viewingCiv:CivilizationInfo) : Bas
 
         stage.addActor(mapHolder)
         stage.scrollFocus = mapHolder
+        stage.addActor(notificationsScroll)  // very low in z-order, so we're free to let it extend _below_ tile info and minimap if we want 
         stage.addActor(minimapWrapper)
         stage.addActor(topBar)
         stage.addActor(nextTurnButton)
         stage.addActor(techPolicyAndVictoryHolder)
-        stage.addActor(notificationsScroll)
         stage.addActor(tutorialTaskTable)
 
 
@@ -464,7 +466,7 @@ class WorldScreen(val gameInfo: GameInfo, val viewingCiv:CivilizationInfo) : Bas
             }
         }
         updateNextTurnButton(hasOpenPopups()) // This must be before the notifications update, since its position is based on it
-        notificationsScroll.update(viewingCiv.notifications)
+        notificationsScroll.update(viewingCiv.notifications, bottomTileInfoTable.height)
         notificationsScroll.setPosition(stage.width - notificationsScroll.width * 0.5f - 10f,
                 nextTurnButton.y - notificationsScroll.height * 0.5f - 5f)
     }


### PR DESCRIPTION
Such a small thing, and took so much fiddling... Very good for phones in portrait too. Also, the scale factor and maximum "intrusion" are local const's and thus easily configurable (or even convertible to gamesettings).

#### Done:
* [x] Test on Android AVD
* [x] Test effect of tweaking the const factors

<details><summary>Example as it is now</summary>

![image](https://user-images.githubusercontent.com/63000004/162534528-9fbe665f-0af3-4a2c-bd87-93e947b0dd6d.png)

</details>

<details><summary>This PR, same data</summary>

![image](https://user-images.githubusercontent.com/63000004/162534792-d4606eeb-a983-4302-b7b9-af081a4c385e.png)

</details>

<details><summary>Clip showing the 'easter egg'-y way it now scrolls _under_ the Tile info box</summary>

https://user-images.githubusercontent.com/63000004/162533863-9a5743d3-0c8a-4401-b00c-8f58fbbf46bc.mp4

Note - at 0:09 I just clicked on a coast tile outside the peek box showing reaction to a 2-line tile info box - closing the empty space, then around 0:15 it gets larger again, and allows scrolling back up to show the last notification..
</details>