### PR TITLE
MusicController - Version 5

### DIFF
--- a/core/src/com/unciv/UncivGame.kt
+++ b/core/src/com/unciv/UncivGame.kt
@@ -37,6 +37,7 @@ class UncivGame(parameters: UncivGameParameters) : Game() {
     val consoleMode = parameters.consoleMode
     val customSaveLocationHelper = parameters.customSaveLocationHelper
     val limitOrientationsHelper = parameters.limitOrientationsHelper
+    private val audioExceptionHelper = parameters.audioExceptionHelper
 
     var deepLinkedMultiplayerGame: String? = null
     lateinit var gameInfo: GameInfo
@@ -97,6 +98,10 @@ class UncivGame(parameters: UncivGameParameters) : Game() {
         settings = GameSaver.getGeneralSettings() // needed for the screen
         screen = LoadingScreen()  // NOT dependent on any atlas or skin
         musicController = MusicController()  // early, but at this point does only copy volume from settings
+        audioExceptionHelper?.installHooks(
+            musicController.getAudioLoopCallback(),
+            musicController.getAudioExceptionHandler()
+        )
 
         ImageGetter.resetAtlases()
         ImageGetter.setNewRuleset(ImageGetter.ruleset)  // This needs to come after the settings, since we may have default visual mods

--- a/core/src/com/unciv/UncivGameParameters.kt
+++ b/core/src/com/unciv/UncivGameParameters.kt
@@ -2,6 +2,7 @@ package com.unciv
 
 import com.unciv.logic.CustomSaveLocationHelper
 import com.unciv.ui.crashhandling.CrashReportSysInfo
+import com.unciv.ui.utils.AudioExceptionHelper
 import com.unciv.ui.utils.LimitOrientationsHelper
 import com.unciv.ui.utils.NativeFontImplementation
 
@@ -11,5 +12,6 @@ class UncivGameParameters(val version: String,
                           val fontImplementation: NativeFontImplementation? = null,
                           val consoleMode: Boolean = false,
                           val customSaveLocationHelper: CustomSaveLocationHelper? = null,
-                          val limitOrientationsHelper: LimitOrientationsHelper? = null
-) { }
+                          val limitOrientationsHelper: LimitOrientationsHelper? = null,
+                          val audioExceptionHelper: AudioExceptionHelper? = null
+)

--- a/core/src/com/unciv/ui/audio/MusicTrackChooserFlags.kt
+++ b/core/src/com/unciv/ui/audio/MusicTrackChooserFlags.kt
@@ -25,5 +25,7 @@ enum class MusicTrackChooserFlags {
         val setSpecific: EnumSet<MusicTrackChooserFlags> = EnumSet.of(PrefixMustMatch, SuffixMustMatch)
         /** EnumSet.of([PrefixMustMatch], [SlowFade]) */
         val setNextTurn: EnumSet<MusicTrackChooserFlags> = EnumSet.of(PrefixMustMatch, SlowFade)
+        /** EnumSet.noneOf() */
+        val none: EnumSet<MusicTrackChooserFlags> = EnumSet.noneOf(MusicTrackChooserFlags::class.java)
     }
 }

--- a/core/src/com/unciv/ui/audio/MusicTrackController.kt
+++ b/core/src/com/unciv/ui/audio/MusicTrackController.kt
@@ -3,10 +3,9 @@ package com.unciv.ui.audio
 import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.audio.Music
 import com.badlogic.gdx.files.FileHandle
-import com.unciv.ui.crashhandling.crashHandlingThread
 
-/** Wraps one Gdx Music instance and manages threaded loading, playback, fading and cleanup */
-class MusicTrackController(private var volume: Float) {
+/** Wraps one Gdx Music instance and manages loading, playback, fading and cleanup */
+internal class MusicTrackController(private var volume: Float) {
 
     /** Internal state of this Music track */
     enum class State(val canPlay: Boolean) {
@@ -23,24 +22,15 @@ class MusicTrackController(private var volume: Float) {
         private set
     var music: Music? = null
         private set
-    private var loaderThread: Thread? = null
     private var fadeStep = MusicController.defaultFadingStep
     private var fadeVolume: Float = 1f
+
+    //region Functions for MusicController
 
     /** Clean up and dispose resources */
     fun clear() {
         state = State.None
-        clearLoader()
-        clearMusic()
-    }
-    private fun clearLoader() {
-        if (loaderThread == null) return
-        loaderThread!!.interrupt()
-        loaderThread = null
-    }
-    private fun clearMusic() {
         if (music == null) return
-        music!!.stop()
         music!!.dispose()
         music = null
     }
@@ -55,28 +45,23 @@ class MusicTrackController(private var volume: Float) {
         onError: ((MusicTrackController)->Unit)? = null,
         onSuccess: ((MusicTrackController)->Unit)? = null
     ) {
-        if (state != State.None || loaderThread != null || music != null)
+        if (state != State.None || music != null)
             throw IllegalStateException("MusicTrackController.load should only be called once")
-        loaderThread = crashHandlingThread(name = "MusicLoader") {
-            state = State.Loading
-            try {
-                music = Gdx.audio.newMusic(file)
-                if (state != State.Loading) {  // in case clear was called in the meantime
-                    clearMusic()
-                } else {
-                    state = State.Idle
-                    if (MusicController.consoleLog)
-                        println("Music loaded: $file")
-                    onSuccess?.invoke(this)
-                }
-            } catch (ex: Exception) {
-                println("Exception loading $file: ${ex.message}")
+        state = State.Loading
+        try {
+            music = Gdx.audio.newMusic(file)
+            if (state != State.Loading) {  // in case clear was called in the meantime
+                clear()
+            } else {
+                state = State.Idle
                 if (MusicController.consoleLog)
-                    ex.printStackTrace()
-                state = State.Error
-                onError?.invoke(this)
+                    println("Music loaded: $file")
+                onSuccess?.invoke(this)
             }
-            loaderThread = null
+        } catch (ex: Exception) {
+            audioExceptionHandler(ex)
+            state = State.Error
+            onError?.invoke(this)
         }
     }
 
@@ -85,32 +70,6 @@ class MusicTrackController(private var volume: Float) {
         if (state == State.FadeIn) fadeInStep()
         if (state == State.FadeOut) fadeOutStep()
         return state
-    }
-    private fun fadeInStep() {
-        // fade-in: linearly ramp fadeVolume to 1.0, then continue playing
-        fadeVolume += fadeStep
-        if (fadeVolume < 1f  && music != null && music!!.isPlaying) {
-            music!!.volume = volume * fadeVolume
-            return
-        }
-        music!!.volume = volume
-        fadeVolume = 1f
-        state = State.Playing
-    }
-    private fun fadeOutStep() {
-        // fade-out: linearly ramp fadeVolume to 0.0, then act according to Status (Playing->Silence/Pause/Shutdown)
-        // This needs to guard against the music backend breaking mid-fade away during game shutdown
-        fadeVolume -= fadeStep
-        try {
-            if (fadeVolume >= 0.001f && music != null && music!!.isPlaying) {
-                music!!.volume = volume * fadeVolume
-                return
-            }
-            fadeVolume = 0f
-            music!!.volume = 0f
-            music!!.pause()
-        } catch (_: Throwable) {}
-        state = State.Idle
     }
 
     /** Starts fadeIn or fadeOut.
@@ -156,6 +115,42 @@ class MusicTrackController(private var volume: Float) {
         return false
     }
 
+    /** Adjust master volume without affecting a fade-in/out */
+    fun setVolume(newVolume: Float) {
+        volume = newVolume
+        music?.volume = volume * fadeVolume
+    }
+
+    //endregion
+    //region Helpers
+
+    private fun fadeInStep() {
+        // fade-in: linearly ramp fadeVolume to 1.0, then continue playing
+        fadeVolume += fadeStep
+        if (fadeVolume < 1f  && music != null && music!!.isPlaying) {
+            music!!.volume = volume * fadeVolume
+            return
+        }
+        music!!.volume = volume
+        fadeVolume = 1f
+        state = State.Playing
+    }
+    private fun fadeOutStep() {
+        // fade-out: linearly ramp fadeVolume to 0.0, then act according to Status (Playing->Silence/Pause/Shutdown)
+        // This needs to guard against the music backend breaking mid-fade away during game shutdown
+        fadeVolume -= fadeStep
+        try {
+            if (fadeVolume >= 0.001f && music != null && music!!.isPlaying) {
+                music!!.volume = volume * fadeVolume
+                return
+            }
+            fadeVolume = 0f
+            music!!.volume = 0f
+            music!!.pause()
+        } catch (_: Throwable) {}
+        state = State.Idle
+    }
+
     private fun tryPlay(music: Music): Boolean {
         return try {
             music.volume = volume
@@ -163,16 +158,20 @@ class MusicTrackController(private var volume: Float) {
                 music.play()
             true
         } catch (ex: Throwable) {
-            println("Exception playing music: ${ex.message}")
-            if (MusicController.consoleLog)
-                ex.printStackTrace()
+            audioExceptionHandler(ex)
             false
         }
     }
 
-    /** Adjust master volume without affecting a fade-in/out */
-    fun setVolume(newVolume: Float) {
-        volume = newVolume
-        music?.volume = volume * fadeVolume
+    private fun audioExceptionHandler(ex: Throwable) {
+        clear()
+        if (MusicController.consoleLog) {
+            println("${ex.javaClass.simpleName} playing music: ${ex.message}")
+            if (ex.stackTrace != null) ex.printStackTrace()
+        } else {
+            println("Error playing music: ${ex.message ?: ""}")
+        }
     }
+
+    //endregion
 }

--- a/core/src/com/unciv/ui/utils/AudioExceptionHelper.kt
+++ b/core/src/com/unciv/ui/utils/AudioExceptionHelper.kt
@@ -1,0 +1,10 @@
+package com.unciv.ui.utils
+
+import com.badlogic.gdx.audio.Music
+
+interface AudioExceptionHelper {
+    fun installHooks(
+        updateCallback: (()->Unit)?,
+        exceptionHandler: ((Throwable, Music)->Unit)?
+    )
+}

--- a/core/src/com/unciv/ui/worldscreen/mainmenu/OptionsPopup.kt
+++ b/core/src/com/unciv/ui/worldscreen/mainmenu/OptionsPopup.kt
@@ -240,9 +240,10 @@ class OptionsPopup(val previousScreen: BaseScreen) : Popup(previousScreen) {
             addMusicVolumeSlider()
             addMusicPauseSlider()
             addMusicCurrentlyPlaying()
-        } else {
-            addDownloadMusic()
         }
+
+        if (!previousScreen.game.musicController.isDefaultFileAvailable())
+            addDownloadMusic()
     }
 
     private fun getMultiplayerTab(): Table = Table(BaseScreen.skin).apply {
@@ -760,7 +761,9 @@ class OptionsPopup(val previousScreen: BaseScreen) : Popup(previousScreen) {
                 label.setText("Currently playing: [$it]".tr())
             }
         }
-        label.onClick { previousScreen.game.musicController.chooseTrack(flags = MusicTrackChooserFlags.setNextTurn) }
+        label.onClick(UncivSound.Silent) {
+            previousScreen.game.musicController.chooseTrack(flags = MusicTrackChooserFlags.none)
+        }
     }
 
     private fun Table.addDownloadMusic() {

--- a/desktop/src/com/unciv/app/desktop/DesktopLauncher.kt
+++ b/desktop/src/com/unciv/app/desktop/DesktopLauncher.kt
@@ -5,13 +5,10 @@ import club.minnced.discord.rpc.DiscordRPC
 import club.minnced.discord.rpc.DiscordRichPresence
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3ApplicationConfiguration
-import com.badlogic.gdx.files.FileHandle
 import com.badlogic.gdx.graphics.glutils.HdpiMode
 import com.sun.jna.Native
-import com.unciv.JsonParser
 import com.unciv.UncivGame
 import com.unciv.UncivGameParameters
-import com.unciv.logic.GameSaver
 import com.unciv.models.metadata.GameSettings
 import com.unciv.ui.utils.Fonts
 import java.util.*
@@ -34,6 +31,10 @@ internal object DesktopLauncher {
         config.setHdpiMode(HdpiMode.Logical)
         config.setWindowSizeLimits(120, 80, -1, -1)
 
+        // We don't need the initial Audio created in Lwjgl3Application, HardenGdxAudio will replace it anyway.
+        // Note that means config.setAudioConfig() would be ignored too, those would need to go into the HardenedGdxAudio constructor.
+        config.disableAudio(true)
+
         val settings = GameSettings.getSettingsForPlatformLaunchers()
         if (!settings.isFreshlyCreated) {
             config.setWindowedMode(settings.windowState.width.coerceAtLeast(120), settings.windowState.height.coerceAtLeast(80))
@@ -50,7 +51,8 @@ internal object DesktopLauncher {
             cancelDiscordEvent = { discordTimer?.cancel() },
             fontImplementation = NativeFontDesktop(Fonts.ORIGINAL_FONT_SIZE.toInt(), settings.fontFamily),
             customSaveLocationHelper = CustomSaveLocationHelperDesktop(),
-            crashReportSysInfo = CrashReportSysInfoDesktop()
+            crashReportSysInfo = CrashReportSysInfoDesktop(),
+            audioExceptionHelper = HardenGdxAudio()
         )
 
         val game = UncivGame(desktopParameters)

--- a/desktop/src/com/unciv/app/desktop/HardenGdxAudio.kt
+++ b/desktop/src/com/unciv/app/desktop/HardenGdxAudio.kt
@@ -1,0 +1,135 @@
+package com.unciv.app.desktop
+
+import com.badlogic.gdx.Gdx
+import com.badlogic.gdx.audio.Music
+import com.badlogic.gdx.backends.lwjgl3.audio.OpenALLwjgl3Audio
+import com.badlogic.gdx.backends.lwjgl3.audio.OpenALMusic
+import com.badlogic.gdx.backends.lwjgl3.audio.mock.MockAudio
+import com.badlogic.gdx.utils.Array
+import com.unciv.ui.utils.AudioExceptionHelper
+
+/**
+ *  Problem: Not all exceptions playing Music can be caught on the desktop platform using a try-catch around the play method.
+ *  Unciv 3.17.13 to 4.0.5 all exacerbated the problem due to using Music from various threads - my current interpretation
+ *  is that OpenALMusic isn't thread-safe on play, load, dispose or any other methods touching any AL10.al*Buffers* call.
+ *  But even with that fixed, music streams can have codec failures _after_ the first buffer's worth of data, so the problem is only mitigated.
+ *
+ *  Sooner or later some Exception will be thrown from the code under `Lwjgl3Application.loop` -> `OpenALLwjgl3Audio.update` ->
+ *  `OpenALMusic.update` -> `OpenALMusic.fill`, where a Gdx app _cannot_ catch them and has no chance to recover gracefully.
+ *
+ *  This catches those Exceptions and reports them through a callback mechanism, and also provides a callback from the app loop
+ *  that allows MusicController to make its Music calls on a thread guaranteed to be safe for OpenALMusic.
+ * #
+ *  ### Approach:
+ *  - Subclass [OpenALLwjgl3Audio] overriding [update][OpenALLwjgl3Audio.update] with equivalent code catching any Exceptions and Errors
+ *  - Replicate original update (a 2-liner) accessing underlying fields through reflection to avoid rewriting the _whole_ thing
+ *  - Not super.update so failed music can be immediately stopped, disposed and removed
+ *  - Replace the object running inside Gdx - Gdx.app.audio - through reflection
+ *  - Replace the object Unciv talks to - overwriting Gdx.audio is surprisingly allowed
+ *
+ *  ### Some exceptions so far seen:
+ *  * Cannot store to object array because "this.mode_param" is null
+ *  * BufferOverflowException from java.nio.DirectByteBuffer.put(DirectByteBuffer.java:409)
+ *  * GdxRuntimeException: Error reading audio data from Mp3$Music.read(Mp3.java:90)
+ *  * Unable to allocate audio buffers. AL Error: 40961 from OpenALMusic.play(OpenALMusic.java:83)
+ *  * Unable to allocate audio buffers. AL Error: 40963 from OpenALMusic.play(OpenALMusic.java:83)
+ *  * Unable to allocate audio buffers. AL Error: 40964 from OpenALMusic.play(OpenALMusic.java:83)
+ *  * ArrayIndexOutOfBoundsException: arraycopy: last destination index 1733 out of bounds for byte[1732] from PushbackInputStream.unread(PushbackInputStream.java:232)
+ *  * ArrayIndexOutOfBoundsException: arraycopy: length -109 is negative from OggInputStream.readPCM(OggInputStream.java:319)
+ *  * IllegalArgumentException: newPosition > limit: (29308 > 4608) from java.nio.Buffer.position(Buffer.java:316)
+ *  * IllegalArgumentException: newPosition < 0: (11520 < 0)
+ *  * java.nio.BufferOverflowException at java.base/java.nio.ByteBuffer.put(ByteBuffer.java:1179)
+ *  * [gdx-audio] Error reading OGG: Corrupt or missing data in bitstream.
+ *  * ArithmeticException in LayerIIIDecoder:904
+ *  * javazoom.jl.decoder.BitstreamException: Bitstream errorcode 102
+ *  * NullPointerException: Cannot invoke "javazoom.jl.decoder.Bitstream.closeFrame()" because "this.bitstream" is null
+ */
+class HardenGdxAudio : AudioExceptionHelper {
+
+    override fun installHooks(
+        updateCallback: (()->Unit)?,
+        exceptionHandler: ((Throwable, Music)->Unit)?
+    ) {
+        // Get already instantiated Audio implementation for cleanup
+        // (may be OpenALLwjgl3Audio or MockAudio at this point)
+        val badAudio = Gdx.audio
+
+        val noAudio = MockAudio()
+
+        Gdx.audio = noAudio  // It's a miracle this is allowed.
+        // If it breaks in a Gdx update, go reflection instead as done below for Gdx.app.audio:
+
+        // Access the reference stored in Gdx.app.audio via reflection
+        val appClass = Gdx.app::class.java
+        val audioField = appClass.declaredFields.firstOrNull { it.name == "audio" }
+        if (audioField != null) {
+            audioField.isAccessible = true
+            audioField.set(Gdx.app, noAudio)  // kill it for a microsecond safely
+        }
+
+        // Clean up allocated resources
+        (badAudio as? OpenALLwjgl3Audio)?.dispose()
+
+        // Create replacement
+        val newAudio = HardenedGdxAudio(updateCallback, exceptionHandler)
+
+        // Store in Gdx fields used throughout the app (Gdx.app.audio by Gdx internally, Gdx.audio by us)
+        audioField?.set(Gdx.app, newAudio)
+        Gdx.audio = newAudio
+    }
+
+    class HardenedGdxAudio(
+        private val updateCallback: (()->Unit)?,
+        private val exceptionHandler: ((Throwable, Music)->Unit)?
+    ) : OpenALLwjgl3Audio() {
+        private val noDevice: Boolean
+        private val music: Array<OpenALMusic>
+
+        init {
+            val myClass = this::class.java
+            val noDeviceField = myClass.superclass.declaredFields.first { it.name == "noDevice" }
+            noDeviceField.isAccessible = true
+            noDevice = noDeviceField.getBoolean(this)
+            val musicField = myClass.superclass.declaredFields.first { it.name == "music" }
+            musicField.isAccessible = true
+            @Suppress("UNCHECKED_CAST")
+            music = musicField.get(this) as Array<OpenALMusic>
+        }
+
+        // This is just a kotlin translation of the original `update` with added try-catch and cleanup
+        override fun update() {
+            if (noDevice) return
+            var i = 0  // No for loop as the array might be changed
+            while (i < music.size) {
+                val item = music[i]
+                try {
+                    item.update()
+                } catch (ex: Throwable) {
+                    item.dispose() // this will call stop which will do audio.music.removeValue
+                    exceptionHandler?.invoke(ex, item)
+                }
+                i++
+            }
+            updateCallback?.invoke()
+        }
+    }
+}
+
+/*
+    Getting Gdx to play other music formats might work along these lines:
+    (Note - this is Lwjgl3 only, one would have to repeat per platform with quite different actual
+     implementations, though DefaultAndroidAudio just calls the SDK's MediaPlayer so it likely
+     already supports m4a, flac, opus and others...)
+
+    class AacMusic(audio: OpenALLwjgl3Audio?, file: FileHandle?) : OpenALMusic(audio, file) {
+        override fun read(buffer: ByteArray?): Int {
+            //...
+        }
+        override fun reset() {
+            //...
+        }
+    }
+    fun registerCodecs(audio: OpenALLwjgl3Audio) {
+        audio.registerMusic("m4a", AacMusic::class.java)
+    }
+*/


### PR DESCRIPTION
This is my latest take on how to fix the problems first mentioned on the lwjgl3 PR (#5614), hopefully fixes #5725, closes #6499.

I called the commit "Can catch exceptions from Gdx.app.loop and replaces Timer on desktop with a callback from OpenALLwjgl3Audio.update" - that's the tech shorthand. In the meantime I coded, heavily tested and rejected three other branches with different concepts - all without the brutal reflection hooks. One did away with all background processing and used `setOnCompletionListener` to chain tracks. Best test result - survived sitting there for over 10 hours before it crashed anyway (with the div/0 in line 904 of javazoom.jl.decoder.LayerIIIDecoder). Also had noticeably more "choppiness" during next turn or changing screens. One tried to move all Music calls to one common background thread with its own postRunnable system - fail. One tried to use Gdx's postRunnable to get the few calls that couldn't be made to run on the main thread by other means over to that safe thread - fail, too.

So I went back to the Big Fat Hammer and polished it.

This has so far run music from a jar (on linux+openjdk11) for hours, and seen extensive Android hardware (LOS16) and AVD (only the Q one as it's so much faster) tests. Runs from the Studio debugger have been much shorter.

Sorry it hasn't become much simpler but more complicated, but it's the nicest _and_ most stable MusicController I have gotten so far.

New details:
- thatched finally renamed so it will have a chance to play even when mods having "Ambient" suffixed tracks are active. Name is also nicer for the 'currently playing' label.
- Thatched can still be downloaded when one installs music mods before using "that button". You can even download while mod music is playing and when it's done it will fade-over nicely. Maybe rename the button in time to something like "Download _default_ music" or "Download classic Unciv theme"?
- Fade-overs where one track fades out at the same time the replacement is fading in are now unblocked and tested. Previously, I had taken out a tiny enabling line which meant fade-in was done after fade-out finished. Fade-over working means I could extend the default fade time a little, sounds cool.
- The manual track change from options now uses default fade speed, not the 3s it did before.

If you really want a far simpler MusicController, the last two commits of #6499 would be a good start, plus disabling mp3 music support (!), then redoing the fade capability as you said with Gdx Actions - hoping setVolume (actually `alSourcef(..AL_GAIN..)`) isn't one of the AL10 functions with thread-safety problems - or Action code always runs on the main thread. This one was easier for me as I already had most elements ready somewhere, and the massive hours invested were mostly testing and monitored runs in the debugger.