### PR TITLE
Air Units take damage in Combat

### DIFF
--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -221,7 +221,7 @@ object Battle {
 
         if (defender is MapUnitCombatant && defender.unit.isCivilian() && attacker.isMelee()) {
             captureCivilianUnit(attacker, defender)
-        } else if (attacker.isRanged()) {
+        } else if (attacker.isRanged() && !attacker.isAirUnit()) {  // Air Units are Ranged, but take damage as well
             defender.takeDamage(potentialDamageToDefender) // straight up
         } else {
             //melee attack is complicated, because either side may defeat the other midway

--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -410,10 +410,7 @@ object Battle {
             addXp(defender, 2, attacker)
         } else if (!defender.isCivilian()) // unit was not captured but actually attacked
         {
-            if(defender.isCity())
-                addXp(attacker, 5, defender)
-            else
-                addXp(attacker, 6, defender)
+            addXp(attacker, 5, defender)
             addXp(defender, 4, attacker)
         }
     }

--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -70,7 +70,7 @@ object Battle {
         }
 
         if (attacker is MapUnitCombatant && attacker.unit.baseUnit.isAirUnit()) {
-            tryInterceptAirAttack(attacker, attackedTile, defender.getCivInfo())
+            tryInterceptAirAttack(attacker, attackedTile, defender)
             if (attacker.isDefeated()) return
         }
 
@@ -792,11 +792,15 @@ object Battle {
         if (targetedCity.population.population < 1) targetedCity.population.setPopulation(1)
     }
 
-    private fun tryInterceptAirAttack(attacker: MapUnitCombatant, attackedTile:TileInfo, interceptingCiv:CivilizationInfo) {
+    // One defender gets to try and Intercept
+    // Can't be unit that being attacked
+    private fun tryInterceptAirAttack(attacker: MapUnitCombatant, attackedTile:TileInfo, defender: ICombatant) {
         if (attacker.unit.hasUnique("Cannot be intercepted")) return
+        val interceptingCiv = defender.getCivInfo()
         // Pick highest chance interceptor
         val interceptor = interceptingCiv.getCivUnits()
-            .filter { it.canIntercept(attackedTile) }
+                .filterNot { defender is MapUnitCombatant && it == defender.unit }  // can't defend and Intercept
+                .filter { it.canIntercept(attackedTile) }
                 .sortedByDescending { it.interceptChance() }.first()
         // Does Intercept happen
         if (Random().nextFloat() > interceptor.interceptChance() / 100f) return
@@ -832,6 +836,50 @@ object Battle {
         interceptingCiv.addNotification(interceptorText, locations,
                 interceptorName, NotificationIcon.War, attackerName)
         return
+    }
+
+    // All of the Civ's units will try to Intercept. But only 1 can succeed
+    private fun tryInterceptAirAttack(attacker: MapUnitCombatant, attackedTile:TileInfo, interceptingCiv: CivilizationInfo) {
+        if (attacker.unit.hasUnique("Cannot be intercepted")) return
+        // Pick highest chance interceptor
+        for (interceptor in interceptingCiv.getCivUnits()
+                .filter { it.canIntercept(attackedTile) }
+                .sortedByDescending { it.interceptChance() }) {
+            // Does Intercept happen
+            if (Random().nextFloat() > interceptor.interceptChance() / 100f) return
+
+            var damage = BattleDamage.calculateDamageToDefender(
+                    MapUnitCombatant(interceptor),
+                    null,
+                    attacker
+            )
+
+            var damageFactor = 1f + interceptor.interceptDamagePercentBonus().toFloat() / 100f
+            damageFactor *= attacker.unit.receivedInterceptDamageFactor()
+
+            damage = (damage.toFloat() * damageFactor).toInt()
+
+            attacker.takeDamage(damage)
+            interceptor.attacksThisTurn++
+
+            if (damage > 0)
+                addXp(MapUnitCombatant(interceptor), 2, attacker)
+
+            val attackerName = attacker.getName()
+            val interceptorName = interceptor.name
+            val locations = LocationAction(interceptor.currentTile.position, attacker.unit.currentTile.position)
+            val attackerText = if (attacker.isDefeated())
+                "Our [$attackerName] was destroyed by an intercepting [$interceptorName]"
+            else "Our [$attackerName] was attacked by an intercepting [$interceptorName]"
+            val interceptorText = if (attacker.isDefeated())
+                "Our [$interceptorName] intercepted and destroyed an enemy [$attackerName]"
+            else "Our [$interceptorName] intercepted and attacked an enemy [$attackerName]"
+            attacker.getCivInfo().addNotification(attackerText, interceptor.currentTile.position,
+                    attackerName, NotificationIcon.War, interceptorName)
+            interceptingCiv.addNotification(interceptorText, locations,
+                    interceptorName, NotificationIcon.War, attackerName)
+            return
+        }
     }
 
     private fun doWithdrawFromMeleeAbility(attacker: ICombatant, defender: ICombatant, baseWithdrawChance: Int): Boolean {

--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -799,7 +799,7 @@ object Battle {
                 .filter { it.canIntercept(attackedTile) }
                 .sortedByDescending { it.interceptChance() }) { 
             // defender can't also intercept
-            if (defender == null && MapUnitCombatant(interceptor) == defender) continue
+            if (defender != null && defender is MapUnitCombatant && interceptor == defender.unit) continue
             // Does Intercept happen? If not, exit
             if (Random().nextFloat() > interceptor.interceptChance() / 100f) return
 

--- a/core/src/com/unciv/logic/battle/BattleDamage.kt
+++ b/core/src/com/unciv/logic/battle/BattleDamage.kt
@@ -292,7 +292,7 @@ object BattleDamage {
     private fun damageModifier(
         attackerToDefenderRatio: Float,
         damageToAttacker: Boolean,
-        attacker: ICombatant,
+        attacker: ICombatant, // for the randomness
         ignoreRandomness: Boolean = false,
     ): Float {
         // https://forums.civfanatics.com/threads/getting-the-combat-damage-math.646582/#post-15468029
@@ -302,12 +302,10 @@ object BattleDamage {
         if (damageToAttacker && attackerToDefenderRatio > 1 || !damageToAttacker && attackerToDefenderRatio < 1) // damage ratio from the weaker party is inverted
             ratioModifier = ratioModifier.pow(-1)
         val randomSeed = attacker.getCivInfo().gameInfo.turns * attacker.getTile().position.hashCode() // so people don't save-scum to get optimal results
-        val baseDamage = if (attacker.isCity()) 20 else 24
-        val addRandomDamage = if (attacker.isCity()) 10f else 12f
-        val randomDamage = baseDamage + 
-            if (ignoreRandomness) addRandomDamage / 2
-            else addRandomDamage * Random(randomSeed.toLong()).nextFloat()
-        return randomDamage * ratioModifier
+        val randomCenteredAround30 = 24 +
+                if (ignoreRandomness) 6f
+                else 12 * Random(randomSeed.toLong()).nextFloat()
+        return randomCenteredAround30 * ratioModifier
     }
 }
 

--- a/core/src/com/unciv/logic/battle/BattleDamage.kt
+++ b/core/src/com/unciv/logic/battle/BattleDamage.kt
@@ -292,7 +292,7 @@ object BattleDamage {
     private fun damageModifier(
         attackerToDefenderRatio: Float,
         damageToAttacker: Boolean,
-        attacker: ICombatant, // for the randomness
+        attacker: ICombatant,
         ignoreRandomness: Boolean = false,
     ): Float {
         // https://forums.civfanatics.com/threads/getting-the-combat-damage-math.646582/#post-15468029
@@ -302,10 +302,12 @@ object BattleDamage {
         if (damageToAttacker && attackerToDefenderRatio > 1 || !damageToAttacker && attackerToDefenderRatio < 1) // damage ratio from the weaker party is inverted
             ratioModifier = ratioModifier.pow(-1)
         val randomSeed = attacker.getCivInfo().gameInfo.turns * attacker.getTile().position.hashCode() // so people don't save-scum to get optimal results
-        val randomCenteredAround30 = 24 + 
-            if (ignoreRandomness) 6f
-            else 12 * Random(randomSeed.toLong()).nextFloat()
-        return randomCenteredAround30 * ratioModifier
+        val baseDamage = if (attacker.isCity()) 20 else 24
+        val addRandomDamage = if (attacker.isCity()) 10f else 12f
+        val randomDamage = baseDamage + 
+            if (ignoreRandomness) addRandomDamage / 2
+            else addRandomDamage * Random(randomSeed.toLong()).nextFloat()
+        return randomDamage * ratioModifier
     }
 }
 

--- a/core/src/com/unciv/logic/battle/BattleDamage.kt
+++ b/core/src/com/unciv/logic/battle/BattleDamage.kt
@@ -264,7 +264,7 @@ object BattleDamage {
         defender: ICombatant,
         ignoreRandomness: Boolean = false,
     ): Int {
-        if (attacker.isRanged()) return 0
+        if (attacker.isRanged() && !attacker.isAirUnit()) return 0
         if (defender.isCivilian()) return 0
         val ratio =
             getAttackingStrength(attacker, defender) / getDefendingStrength(

--- a/core/src/com/unciv/logic/battle/ICombatant.kt
+++ b/core/src/com/unciv/logic/battle/ICombatant.kt
@@ -26,6 +26,10 @@ interface ICombatant {
         if (this is CityCombatant) return true
         return (this as MapUnitCombatant).unit.baseUnit.isRanged()
     }
+    fun isAirUnit(): Boolean {
+        if (this is CityCombatant) return false
+        return (this as MapUnitCombatant).unit.baseUnit.isAirUnit()
+    }
     fun isCity(): Boolean {
         return this is CityCombatant
     }

--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -979,6 +979,8 @@ class MapUnit {
 
     fun canIntercept(): Boolean {
         if (interceptChance() == 0) return false
+        // Air Units can only Intercept if they didn't move this turn
+        if (baseUnit.isAirUnit() && currentMovement == 0f) return false
         val maxAttacksPerTurn = 1 +
             getMatchingUniques("[] extra interceptions may be made per turn").sumOf { it.params[0].toInt() }
         if (attacksThisTurn >= maxAttacksPerTurn) return false


### PR DESCRIPTION
Air Units now take damage during combat.
Edits to both takeDamage() calculation and calculateDamageToAttacker()
![image](https://user-images.githubusercontent.com/44038014/162878236-c138b676-ac6a-4058-99a5-3b728cc6ab8d.png)

Other changes:
- [x] Interception uses highest chance unit to Intercept
- [x] Interception by defending unit not possible
- [x] Interception grants 2 XP
- [x] Air units can't Intercept if they've moved that turn