### PR TITLE
Updating XP Rewards. Interception now gives XP

### DIFF
--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -410,10 +410,7 @@ object Battle {
             addXp(defender, 2, attacker)
         } else if (!defender.isCivilian()) // unit was not captured but actually attacked
         {
-            if(defender.isCity())
-                addXp(attacker, 5, defender)
-            else
-                addXp(attacker, 6, defender)
+            addXp(attacker, 5, defender)
             addXp(defender, 4, attacker)
         }
     }

--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -399,12 +399,21 @@ object Battle {
     }
 
     private fun postBattleAddXp(attacker: ICombatant, defender: ICombatant) {
-        if (!attacker.isMelee()) { // ranged attack
-            addXp(attacker, 2, defender)
+        if (attacker.isAirUnit()) {
+            addXp(attacker, 4, defender)
+            addXp(defender, 2, attacker)
+        } else if (attacker.isRanged()) { // ranged attack
+            if(defender.isCity())
+                addXp(attacker, 3, defender)
+            else
+                addXp(attacker, 2, defender)
             addXp(defender, 2, attacker)
         } else if (!defender.isCivilian()) // unit was not captured but actually attacked
         {
-            addXp(attacker, 5, defender)
+            if(defender.isCity())
+                addXp(attacker, 5, defender)
+            else
+                addXp(attacker, 6, defender)
             addXp(defender, 4, attacker)
         }
     }
@@ -802,6 +811,8 @@ object Battle {
 
             attacker.takeDamage(damage)
             interceptor.attacksThisTurn++
+            if (damage > 0)
+                addXp(MapUnitCombatant(interceptor), 2, attacker)
 
             val attackerName = attacker.getName()
             val interceptorName = interceptor.name

--- a/core/src/com/unciv/logic/battle/ICombatant.kt
+++ b/core/src/com/unciv/logic/battle/ICombatant.kt
@@ -26,6 +26,10 @@ interface ICombatant {
         if (this is CityCombatant) return true
         return (this as MapUnitCombatant).unit.baseUnit.isRanged()
     }
+    fun isAirUnit(): Boolean {
+        if (this is CityCombatant) return false
+        return (this as MapUnitCombatant).unit.baseUnit.isAirUnit()
+    }
     fun isCity(): Boolean {
         return this is CityCombatant
     }


### PR DESCRIPTION
Add isAirUnit() Boolean for ICombatant
Not including AirSweep (6XP for attacker if draw Air Intercept, 6XP for Air Defending Intercept, No XP for Ground Intercept Defending) yet

Interception gives 2XP if deals dmg
Ranged Attack on City is 3XP (was 2XP)
Air Attacks are 4XP. Defender gets 2XP

Interesting note. Evasion in the Civ5 code is actually chance to not get Intercepted, not a damage reduction. So UnCiv will give out extra Intercept XP