### PR TITLE
Tested and reworked the 'unit upgrades for free' unique till it worked

### DIFF
--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -513,8 +513,9 @@ class MapUnit {
         if (name == unitToUpgradeTo.name) return false
         val rejectionReasons = unitToUpgradeTo.getRejectionReasons(civInfo)
         if (rejectionReasons.isEmpty()) return true
+        if (ignoreRequired && rejectionReasons.filterTechPolicyEraWonderRequirements().isEmpty()) return true
 
-        if (rejectionReasons.size == 1 && rejectionReasons.contains(RejectionReason.ConsumesResources)) {
+        if (rejectionReasons.contains(RejectionReason.ConsumesResources)) {
             // We need to remove the unit from the civ for this check,
             // because if the unit requires, say, horses, and so does its upgrade,
             // and the civ currently has 0 horses, we need to see if the upgrade will be buildable

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -494,7 +494,7 @@ object UniqueTriggerActivation {
                 return true
             }
             OneTimeUnitUpgrade -> {
-                val upgradeAction = UnitActions.getUpgradeAction(unit, true)
+                val upgradeAction = UnitActions.getFreeUpgradeAction(unit)
                     ?: return false
                 upgradeAction.action!!()
                 if (notification != null)


### PR DESCRIPTION
Partially as requested in #3242, though a promotion with only this as an effect can still be picked even if the unit upgrade is unavailable because the civ doesn't have a required resources, in which case the promotion is lost.