### PR TITLE
Made 'go to on map' translatable & fixed crash

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -97,6 +97,7 @@ Peace =
 Research Agreement = 
 Declare war = 
 Declare war on [civName]? = 
+Go to on map = 
 Let's begin! = 
 [civName] has declared war on us! = 
 [leaderName] of [nation] = 

--- a/core/src/com/unciv/ui/trade/DiplomacyScreen.kt
+++ b/core/src/com/unciv/ui/trade/DiplomacyScreen.kt
@@ -748,7 +748,7 @@ class DiplomacyScreen(
         diplomacyTable.add(demandsButton).row()
         if (isNotPlayersTurn()) demandsButton.disable()
 
-        if (otherCiv.getCapital().location in viewingCiv.exploredTiles)
+        if (otherCiv.cities.isNotEmpty() && otherCiv.getCapital().location in viewingCiv.exploredTiles)
             diplomacyTable.add(getGoToOnMapButton(otherCiv)).row()
         
         if (!otherCiv.isPlayerCivilization()) { // human players make their own choices
@@ -932,7 +932,7 @@ class DiplomacyScreen(
     }
     
     private fun getGoToOnMapButton(civilization: CivilizationInfo): TextButton {
-        val goToOnMapButton = TextButton("Go To on Map", skin)
+        val goToOnMapButton = TextButton("Go to on map", skin)
         goToOnMapButton.onClick {
             UncivGame.Current.setWorldScreen()
             UncivGame.Current.worldScreen.mapHolder.setCenterPosition(civilization.getCapital().location, selectUnit = false)


### PR DESCRIPTION
- Closes #6131 (again)
- Fixed a crash when opening the diplomacy screen of a player without cities