### PR TITLE
Correct calculation of the production for the Settlers

### DIFF
--- a/core/src/com/unciv/logic/city/CityStats.kt
+++ b/core/src/com/unciv/logic/city/CityStats.kt
@@ -64,8 +64,6 @@ class CityStats(val cityInfo: CityInfo) {
 
     var baseStatTree = StatTreeNode()
 
-    var statPercentBonusList = LinkedHashMap<String, Stats>()
-
     var statPercentBonusTree = StatTreeNode()
 
     // Computed from baseStatList and statPercentBonusList - this is so the players can see a breakdown
@@ -74,8 +72,6 @@ class CityStats(val cityInfo: CityInfo) {
     var happinessList = LinkedHashMap<String, Float>()
 
     var statsFromTiles = Stats()
-
-    var foodEaten = 0f
 
     var currentCityStats: Stats = Stats()  // This is so we won't have to calculate this multiple times - takes a lot of time, especially on phones
 
@@ -96,7 +92,7 @@ class CityStats(val cityInfo: CityInfo) {
             // Deprecated as of 3.19.19
                 if (civInfo.hasUnique(UniqueType.GoldBonusFromTradeRoutesDeprecated)) percentageStats[Stat.Gold] += 25f // Machu Picchu speciality
             //
-            for ((stat, value) in stats) {
+            for ((stat) in stats) {
                 stats[stat] *= percentageStats[stat].toPercent()
             }
         }
@@ -344,7 +340,7 @@ class CityStats(val cityInfo: CityInfo) {
     }
 
     fun isConnectedToCapital(roadType: RoadStatus): Boolean {
-        if (cityInfo.civInfo.cities.count() < 2) return false// first city!
+        if (cityInfo.civInfo.cities.size < 2) return false// first city!
 
         // Railroad, or harbor from railroad
         return if (roadType == RoadStatus.Railroad)
@@ -573,7 +569,7 @@ class CityStats(val cityInfo: CityInfo) {
         Now we have the excess food, to which "growth" modifiers apply
         Some policies have bonuses for growth only, not general food production. */
 
-        updateFoodEaten()
+        val foodEaten = calcFoodEaten()
         newFinalStatList["Population"]!!.food -= foodEaten
 
         var totalFood = newFinalStatList.values.map { it.food }.sum()
@@ -631,8 +627,8 @@ class CityStats(val cityInfo: CityInfo) {
         else 0.0f
     }
 
-    private fun updateFoodEaten() {
-        foodEaten = cityInfo.population.population.toFloat() * 2
+    private fun calcFoodEaten(): Float {
+        var foodEaten = cityInfo.population.population.toFloat() * 2
         var foodEatenBySpecialists = 2f * cityInfo.population.getNumberOfSpecialists()
 
         for (unique in cityInfo.getMatchingUniques(UniqueType.FoodConsumptionBySpecialists))
@@ -640,6 +636,7 @@ class CityStats(val cityInfo: CityInfo) {
                 foodEatenBySpecialists *= unique.params[0].toPercent()
 
         foodEaten -= 2f * cityInfo.population.getNumberOfSpecialists() - foodEatenBySpecialists
+        return foodEaten
     }
 
     //endregion

--- a/core/src/com/unciv/logic/city/CityStats.kt
+++ b/core/src/com/unciv/logic/city/CityStats.kt
@@ -624,11 +624,9 @@ class CityStats(val cityInfo: CityInfo) {
     }
 
     // calculate the conversion of the excessive food to the production
-    // See for details: https://www.youtube.com/watch?v=n5vSKAahXT4
+    // See for details: https://civilization.fandom.com/wiki/Settler_(Civ5)
     private fun getProductionFromExcessiveFood(food : Float): Float {
-        return if (food >= 12.0f ) 5.0f
-          else if (food >= 8.0f ) 4.0f
-          else if (food >= 4.0f ) 3.0f
+        return if (food >= 4.0f ) 2.0f + (food / 4.0f).toInt()
           else if (food >= 2.0f ) 2.0f
           else if (food >= 1.0f ) 1.0f
         else 0.0f

--- a/core/src/com/unciv/logic/city/CityStats.kt
+++ b/core/src/com/unciv/logic/city/CityStats.kt
@@ -599,13 +599,12 @@ class CityStats(val cityInfo: CityInfo) {
         val buildingsMaintenance = getBuildingMaintenanceCosts() // this is AFTER the bonus calculation!
         newFinalStatList["Maintenance"] = Stats(gold = -buildingsMaintenance.toInt().toFloat())
 
-        if (currentConstruction is INonPerpetualConstruction
+        if (totalFood > 0
+            && currentConstruction is INonPerpetualConstruction
             && currentConstruction.hasUnique(UniqueType.ConvertFoodToProductionWhenConstructed)
         ) {
-            if (totalFood > 0)
-                newFinalStatList["Excess food to production"] = Stats(production = getProductionFromExcessiveFood(totalFood), food = -totalFood)
-            else // prevent starvation but no bonus from excess food
-                newFinalStatList["Excess food to production"] = Stats(food = -totalFood)
+            newFinalStatList["Excess food to production"] =
+                Stats(production = getProductionFromExcessiveFood(totalFood), food = -totalFood)
         }
         
         val growthNullifyingUnique = cityInfo.getMatchingUniques(UniqueType.NullifiesGrowth).firstOrNull()

--- a/core/src/com/unciv/ui/cityscreen/CityStatsTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityStatsTable.kt
@@ -73,11 +73,11 @@ class CityStatsTable(val cityScreen: CityScreen): Table() {
 
         var turnsToPopString =
                 when {
+                    cityInfo.getRuleset().units[cityInfo.cityConstructions.currentConstructionFromQueue]
+                        .let { it != null && it.hasUnique(UniqueType.ConvertFoodToProductionWhenConstructed) }
+                    -> "Food converts to production"
                     cityInfo.isGrowing() -> "[${cityInfo.getNumTurnsToNewPopulation()}] turns to new population"
                     cityInfo.isStarving() -> "[${cityInfo.getNumTurnsToStarvation()}] turns to lose population"
-                    cityInfo.getRuleset().units[cityInfo.cityConstructions.currentConstructionFromQueue]
-                            .let { it != null && it.hasUnique(UniqueType.ConvertFoodToProductionWhenConstructed) }
-                    -> "Food converts to production"
                     else -> "Stopped population growth"
                 }.tr()
         turnsToPopString += " (${cityInfo.population.foodStored}${Fonts.food}/${cityInfo.population.getFoodToNextPopulation()}${Fonts.food})"

--- a/core/src/com/unciv/ui/cityscreen/CityStatsTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityStatsTable.kt
@@ -73,11 +73,11 @@ class CityStatsTable(val cityScreen: CityScreen): Table() {
 
         var turnsToPopString =
                 when {
+                    cityInfo.isStarving() -> "[${cityInfo.getNumTurnsToStarvation()}] turns to lose population"
                     cityInfo.getRuleset().units[cityInfo.cityConstructions.currentConstructionFromQueue]
                         .let { it != null && it.hasUnique(UniqueType.ConvertFoodToProductionWhenConstructed) }
                     -> "Food converts to production"
                     cityInfo.isGrowing() -> "[${cityInfo.getNumTurnsToNewPopulation()}] turns to new population"
-                    cityInfo.isStarving() -> "[${cityInfo.getNumTurnsToStarvation()}] turns to lose population"
                     else -> "Stopped population growth"
                 }.tr()
         turnsToPopString += " (${cityInfo.population.foodStored}${Fonts.food}/${cityInfo.population.getFoodToNextPopulation()}${Fonts.food})"


### PR DESCRIPTION
The fix for #6588 

First of all, it fixes the calculation of the excessive food conversion to the production for the Settlers.
~Secondly, it avoids the city of starvation during the Settlers production:~ https://civilization.fandom.com/wiki/Settler_(Civ5)

Also, a minor fix for the caption in the city: when it produces the Settler there was no message about conversion of food since it was overridden by starvation/growing checks.