### PR TITLE
Display wonders built in other civs correctly

### DIFF
--- a/core/src/com/unciv/ui/overviewscreen/WonderOverviewTable.kt
+++ b/core/src/com/unciv/ui/overviewscreen/WonderOverviewTable.kt
@@ -179,7 +179,7 @@ class WonderOverviewTab(
                 val status = when {
                     viewingPlayer == city.civInfo -> WonderStatus.Owned
                     viewingPlayer.knows(city.civInfo) -> WonderStatus.Known
-                    else -> WonderStatus.Unknown
+                    else -> WonderStatus.NotFound
                 }
                 wonders[index] = WonderInfo(wonderName, CivilopediaCategories.Wonder,
                     wonders[index].groupName, wonders[index].groupColor,


### PR DESCRIPTION
When you enter the era (e.g. Ancient), usually you see the whole list of the wonders with "Not built" status.
As soon as the game goes, some civilizations build the Wonders and they get assigned to the civilization that builds them or ... just disappear from the list as "Unknown", if they built by unknown civiliazation.

![Screenshot 2022-04-25 17-32-18](https://user-images.githubusercontent.com/27405436/165120766-ab1a11b7-7015-4088-b59d-74395462602d.png)

That's a bug I am fixing right here.

![Screenshot 2022-04-25 18-24-20](https://user-images.githubusercontent.com/27405436/165121225-7f2e7938-02af-4360-a9db-9e0af46d3c3c.png)

Now we know it is built (in the far far lands) but it is not found where it is yet.