### PR TITLE
Use both icon and roundIcon properties

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -13,6 +13,7 @@
     <application
         android:allowBackup="true"
         android:icon="@drawable/uncivicon2"
+        android:roundIcon="@drawable/uncivicon2"
         android:label="@string/app_name"
         android:isGame="true"
         android:appCategory="game"


### PR DESCRIPTION
Here is my assumption how to fix #6587

See also: https://developer.android.com/about/versions/nougat/android-7.1.html#circular-icons

> When a launcher requests an app icon, the framework returns either android:icon or android:roundIcon, depending on the device build configuration. Because of this, apps should make sure to define both android:icon and android:roundIcon resources when responding to launcher intents.