### PR TITLE
Making SpecialistAllocationTable an ExpanderTab

### DIFF
--- a/core/src/com/unciv/ui/cityscreen/CityStatsTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityStatsTable.kt
@@ -46,10 +46,8 @@ class CityStatsTable(val cityScreen: CityScreen): Table() {
         innerTable.addSeparator()
         addText()
         if (!cityInfo.population.getMaxSpecialists().isEmpty()) {
-            innerTable.addSeparator()
-            innerTable.add(SpecialistAllocationTable(cityScreen).apply { update() }).row()
+            addSpecialistInfo()
         }
-        
         if (cityInfo.religion.getNumberOfFollowers().isNotEmpty() && cityInfo.civInfo.gameInfo.isReligionEnabled())
             addReligionInfo()
 
@@ -111,6 +109,18 @@ class CityStatsTable(val cityScreen: CityScreen): Table() {
         }
 
         innerTable.add(tableWithIcons).row()
+    }
+
+    private fun addSpecialistInfo() {
+        val expanderTab = SpecialistAllocationTable(cityScreen).asExpander {
+            pack()
+            setPosition(
+                stage.width - CityScreen.posFromEdge,
+                stage.height - CityScreen.posFromEdge,
+                Align.topRight
+            )
+        }
+        innerTable.add(expanderTab).growX().row()
     }
 
     private fun addReligionInfo() {

--- a/core/src/com/unciv/ui/cityscreen/SpecialistAllocationTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/SpecialistAllocationTable.kt
@@ -90,7 +90,7 @@ class SpecialistAllocationTable(val cityScreen: CityScreen): Table(BaseScreen.sk
 
     fun asExpander(onChange: (()->Unit)?): ExpanderTab {
         return ExpanderTab(
-            title = "Specialists:",
+            title = "{Specialists}:",
             fontSize = Constants.defaultFontSize,
             persistenceID = "CityStatsTable.Specialists",
             startsOutOpened = true,

--- a/core/src/com/unciv/ui/cityscreen/SpecialistAllocationTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/SpecialistAllocationTable.kt
@@ -86,4 +86,19 @@ class SpecialistAllocationTable(val cityScreen: CityScreen): Table(BaseScreen.sk
         }
         return specialistStatTable
     }
+
+
+    fun asExpander(onChange: (()->Unit)?): ExpanderTab {
+        return ExpanderTab(
+            title = "Specialists:",
+            fontSize = Constants.defaultFontSize,
+            persistenceID = "CityStatsTable.Specialists",
+            startsOutOpened = true,
+            onChange = onChange
+        ) {
+            it.add(this)
+            update()
+        }
+    }
+
 }

--- a/core/src/com/unciv/ui/overviewscreen/WonderOverviewTable.kt
+++ b/core/src/com/unciv/ui/overviewscreen/WonderOverviewTable.kt
@@ -179,7 +179,7 @@ class WonderOverviewTab(
                 val status = when {
                     viewingPlayer == city.civInfo -> WonderStatus.Owned
                     viewingPlayer.knows(city.civInfo) -> WonderStatus.Known
-                    else -> WonderStatus.Unknown
+                    else -> WonderStatus.NotFound
                 }
                 wonders[index] = WonderInfo(wonderName, CivilopediaCategories.Wonder,
                     wonders[index].groupName, wonders[index].groupColor,


### PR DESCRIPTION
Hi,
I'm new to this project, and really enjoy the game you have created. I found that sometimes the CityStatsTable gets crowded on the right with the SpecialistAllocationTable taking up space like this:
![uncivScreenshot_20220422-153443](https://user-images.githubusercontent.com/14141325/165245537-5c297d6e-ea86-4379-aabc-e3b8a870beca.png)

I made this PR to enable the player to fold up that section to regain a little bit more view of the map. Let me know if you think there are better approaches to this, whether from a UI design or coding viewpoint. This is my first time coding in Kotlin (and libGDX). 