### PR TITLE
Allow removing Fallout from the city tiles

### DIFF
--- a/core/src/com/unciv/logic/map/TileInfo.kt
+++ b/core/src/com/unciv/logic/map/TileInfo.kt
@@ -229,7 +229,7 @@ open class TileInfo {
         }
     }
 
-    fun isEnemyTerritory(civInfo: CivilizationInfo): Boolean {
+    private fun isEnemyTerritory(civInfo: CivilizationInfo): Boolean {
         val tileOwner = getOwner() ?: return false
         return civInfo.isAtWarWith(tileOwner)
     }

--- a/core/src/com/unciv/logic/map/TileInfo.kt
+++ b/core/src/com/unciv/logic/map/TileInfo.kt
@@ -507,7 +507,9 @@ open class TileInfo {
 
         return when {
             improvement.name == this.improvement -> false
-            isCityCenter() -> false
+            // We do an exception for "Remove Fallout" here
+            //   since Fallout is the only "improvement" can be "built" in the city.
+            isCityCenter() && (improvement.name != "Remove Fallout") -> false
             improvement.getMatchingUniques(UniqueType.CannotBuildOnTile, StateForConditionals(tile = this)).any {
                 unique -> matchesTerrainFilter(unique.params[0])
             } -> false

--- a/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
@@ -102,7 +102,7 @@ object UnitActions {
         // have the visual bug that the tile overlays for the eligible swap locations are drawn for
         // /all/ selected units instead of only the first one. This could be fixed, but again,
         // swapping makes little sense for multiselect anyway.
-        if (worldScreen.bottomUnitTable.selectedUnits.count() > 1) return
+        if (worldScreen.bottomUnitTable.selectedUnits.size > 1) return
         // Only show the swap action if there is at least one possible swap movement
         if (unit.movement.getUnitSwappableTiles().none()) return
         actionList += UnitAction(
@@ -653,7 +653,7 @@ object UnitActions {
 
             var resourcesAvailable = true
             if (improvement.uniqueObjects.any {
-                    it.isOfType(UniqueType.ConsumesResources) && civResources[unique.params[1]] ?: 0 < unique.params[0].toInt()
+                    it.isOfType(UniqueType.ConsumesResources) && (civResources[unique.params[1]] ?: 0) < unique.params[0].toInt()
             })
                 resourcesAvailable = false
 

--- a/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
@@ -402,7 +402,6 @@ object UnitActions {
         if (unit.isEmbarked()) return
 
         val canConstruct = unit.currentMovement > 0
-            && !tile.isCityCenter()
             && unit.civInfo.gameInfo.ruleSet.tileImprovements.values.any { 
                 tile.canBuildImprovement(it, unit.civInfo) 
                 && unit.canBuildImprovement(it)


### PR DESCRIPTION
I have faced the issue that the Fallout is the only "improvement" that can be "built" in the city but then there is no way to remove it. This PR fixes this problem.

P.S> During creation of the PR, I decide to look through the issues and found that #6355 was not fixed but just closed without proper testing. Now it is fixed-fixed.