### PR TITLE
New Demographics Scoreboard

### DIFF
--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -712,7 +712,7 @@ class MapUnit {
         val isFriendlyTerritory = tileInfo.isFriendlyTerritory(civInfo)
 
         var healing = when {
-            tileInfo.isCityCenter() -> 25 // Increased from 20 for CV parity
+            tileInfo.isCityCenter() -> 25
             tileInfo.isWater && isFriendlyTerritory && (baseUnit.isWaterUnit() || isTransported) -> 20 // Water unit on friendly water
             tileInfo.isWater -> 0 // All other water cases
             isFriendlyTerritory -> 20 // Allied territory

--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -713,11 +713,11 @@ class MapUnit {
 
         var healing = when {
             tileInfo.isCityCenter() -> 25 // Increased from 20 for CV parity
-            tileInfo.isWater && isFriendlyTerritory && (baseUnit.isWaterUnit() || isTransported) -> 20 // Water unit on friendly water, increased from 15 for CV parity
+            tileInfo.isWater && isFriendlyTerritory && (baseUnit.isWaterUnit() || isTransported) -> 20 // Water unit on friendly water
             tileInfo.isWater -> 0 // All other water cases
-            isFriendlyTerritory -> 20 // Allied territory, increased from 15 for CV parity
+            isFriendlyTerritory -> 20 // Allied territory
             tileInfo.getOwner() == null -> 10 // Neutral territory
-            else -> 10 // Enemy territory, increased from 5 for CV  parity
+            else -> 10 // Enemy territory
         }
 
         val mayHeal = healing > 0 || (tileInfo.isWater && hasUnique(UniqueType.HealsOutsideFriendlyTerritory, checkCivInfoUniques = true))

--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -712,12 +712,12 @@ class MapUnit {
         val isFriendlyTerritory = tileInfo.isFriendlyTerritory(civInfo)
 
         var healing = when {
-            tileInfo.isCityCenter() -> 20
-            tileInfo.isWater && isFriendlyTerritory && (baseUnit.isWaterUnit() || isTransported) -> 15 // Water unit on friendly water
+            tileInfo.isCityCenter() -> 25 // Increased from 20 for CV parity
+            tileInfo.isWater && isFriendlyTerritory && (baseUnit.isWaterUnit() || isTransported) -> 20 // Water unit on friendly water, increased from 15 for CV parity
             tileInfo.isWater -> 0 // All other water cases
-            isFriendlyTerritory -> 15 // Allied territory
+            isFriendlyTerritory -> 20 // Allied territory, increased from 15 for CV parity
             tileInfo.getOwner() == null -> 10 // Neutral territory
-            else -> 5 // Enemy territory
+            else -> 10 // Enemy territory, increased from 5 for CV  parity
         }
 
         val mayHeal = healing > 0 || (tileInfo.isWater && hasUnique(UniqueType.HealsOutsideFriendlyTerritory, checkCivInfoUniques = true))

--- a/core/src/com/unciv/models/metadata/GameParameters.kt
+++ b/core/src/com/unciv/models/metadata/GameParameters.kt
@@ -22,6 +22,7 @@ class GameParameters { // Default values are the default new game
     var godMode = false
     var nuclearWeaponsEnabled = true
     var religionEnabled = false
+    var demographicsEnabled = false
     
     var victoryTypes: ArrayList<String> = arrayListOf()  
     var startingEra = "Ancient era"
@@ -43,6 +44,7 @@ class GameParameters { // Default values are the default new game
         parameters.oneCityChallenge = oneCityChallenge
         parameters.nuclearWeaponsEnabled = nuclearWeaponsEnabled
         parameters.religionEnabled = religionEnabled
+        parameters.demographicsEnabled = demographicsEnabled
         parameters.victoryTypes = ArrayList(victoryTypes)
         parameters.startingEra = startingEra
         parameters.isOnlineMultiplayer = isOnlineMultiplayer

--- a/core/src/com/unciv/ui/newgamescreen/GameOptionsTable.kt
+++ b/core/src/com/unciv/ui/newgamescreen/GameOptionsTable.kt
@@ -96,11 +96,11 @@ class GameOptionsTable(
             { gameParameters.oneCityChallenge = it }
 
     private fun Table.addNuclearWeaponsCheckbox() =
-            addCheckbox("Enable nuclear weapons", gameParameters.nuclearWeaponsEnabled)
+            addCheckbox("Enable Nuclear Weapons", gameParameters.nuclearWeaponsEnabled)
             { gameParameters.nuclearWeaponsEnabled = it }
 
     private fun Table.addDemographicsCheckbox() =
-        addCheckbox("Demographics-style ranking", gameParameters.demographicsEnabled)
+        addCheckbox("Demographics Scoreboard", gameParameters.demographicsEnabled)
         { gameParameters.demographicsEnabled = it }
 
 

--- a/core/src/com/unciv/ui/newgamescreen/GameOptionsTable.kt
+++ b/core/src/com/unciv/ui/newgamescreen/GameOptionsTable.kt
@@ -68,6 +68,7 @@ class GameOptionsTable(
         checkboxTable.addNuclearWeaponsCheckbox()
         checkboxTable.addIsOnlineMultiplayerCheckbox()
         checkboxTable.addReligionCheckbox(cityStateSlider)
+        checkboxTable.addDemographicsCheckbox()
         add(checkboxTable).center().row()
 
         if (!isPortrait)
@@ -97,6 +98,10 @@ class GameOptionsTable(
     private fun Table.addNuclearWeaponsCheckbox() =
             addCheckbox("Enable nuclear weapons", gameParameters.nuclearWeaponsEnabled)
             { gameParameters.nuclearWeaponsEnabled = it }
+
+    private fun Table.addDemographicsCheckbox() =
+        addCheckbox("Demographics-style ranking", gameParameters.demographicsEnabled)
+        { gameParameters.demographicsEnabled = it }
 
 
     private fun Table.addIsOnlineMultiplayerCheckbox() =

--- a/core/src/com/unciv/ui/victoryscreen/VictoryScreen.kt
+++ b/core/src/com/unciv/ui/victoryscreen/VictoryScreen.kt
@@ -174,6 +174,12 @@ class VictoryScreen(val worldScreen: WorldScreen) : PickerScreen() {
     }
 
     private fun setCivRankingsTable() {
+        if (gameInfo.gameParameters.demographicsEnabled ) {
+            // use new demographics table
+        } else {
+            // use old rankings table
+        }
+
         val majorCivs = gameInfo.civilizations.filter { it.isMajorCiv() }
         val civRankingsTable = Table().apply { defaults().pad(5f) }
 

--- a/core/src/com/unciv/ui/victoryscreen/VictoryScreen.kt
+++ b/core/src/com/unciv/ui/victoryscreen/VictoryScreen.kt
@@ -174,29 +174,34 @@ class VictoryScreen(val worldScreen: WorldScreen) : PickerScreen() {
     }
 
     private fun setCivRankingsTable() {
-        if (gameInfo.gameParameters.demographicsEnabled ) {
-            // use new demographics table
-        } else {
-            // use old rankings table
-        }
+        val majorCivs = gameInfo.civilizations.filter { it.isMajorCiv() } //creates element of only major civs from gameInfo
+        val civRankingsTable = Table().apply { defaults().pad(5f) } //creates table with padding of 5f
 
-        val majorCivs = gameInfo.civilizations.filter { it.isMajorCiv() }
-        val civRankingsTable = Table().apply { defaults().pad(5f) }
+        if (gameInfo.gameParameters.demographicsEnabled ) { //if demographics option is enabled...
+            val demographicsHeaders = arrayOf("Demographic","Rank","Value","Best","Average","Worst")
 
-        for (category in RankingType.values()) {
-            val column = Table().apply { defaults().pad(5f) }
-            column.add(category.name.replace('_',' ').toLabel()).row()
-            column.addSeparator()
-
-            for (civ in majorCivs.sortedByDescending { it.getStatForRanking(category) }) {
-                column.add(getCivGroup(civ, ": " + civ.getStatForRanking(category).toString(), playerCivInfo)).fillX().row()
+            for (i in demographicsHeaders.indices) { //for every index in DemographicsHeaders array...
+                val column = Table().apply { defaults().pad(5f) } //create a column with padding of 5f
+                column.add(demographicsHeaders[i].replace('_',' ').toLabel()).row() //pulls name of category and creates label with it
+                column.addSeparator() //adds a separator line
+                civRankingsTable.add(column) //add resulting column to table
             }
+        } else { //if demographics option is disabled...
+            for (category in RankingType.values()) { //for every category in RankingType class (Score, Population, etc.)...
+                val column = Table().apply { defaults().pad(5f) } //create a column with padding of 5f
+                column.add(category.name.replace('_',' ').toLabel()).row() //pulls name of category and creates label with it
+                column.addSeparator() //adds a separator line
 
-            civRankingsTable.add(column)
+                for (civ in majorCivs.sortedByDescending { it.getStatForRanking(category) }) { //for every civ in majorCivs element, get ranking for this category and sort descending
+                    column.add(getCivGroup(civ, ": " + civ.getStatForRanking(category).toString(), playerCivInfo)).fillX().row() //add the civ name, background, and rank value to a row in the column
+                }
+
+                civRankingsTable.add(column) //add resulting column to table
+            }
         }
 
-        contentsTable.clear()
-        contentsTable.add(civRankingsTable)
+        contentsTable.clear() //clear previous contents of table
+        contentsTable.add(civRankingsTable) //add civRankingsTable to table
     }
 
     private fun getCivGroup(civ: CivilizationInfo, afterCivNameText: String, currentPlayer: CivilizationInfo): Table {

--- a/core/src/com/unciv/ui/victoryscreen/VictoryScreen.kt
+++ b/core/src/com/unciv/ui/victoryscreen/VictoryScreen.kt
@@ -176,42 +176,40 @@ class VictoryScreen(val worldScreen: WorldScreen) : PickerScreen() {
     private fun setCivRankingsTable() {
         val majorCivs = gameInfo.civilizations.filter { it.isMajorCiv() }
         val civRankingsTable = Table().apply { defaults().pad(5f) }
+        val rankLabels = arrayOf("Demographic","Rank","Value","Best","Average","Worst")
 
         if (gameInfo.gameParameters.demographicsEnabled ) {
-            val demographicsHeaders = arrayOf("Demographic","Rank","Value","Best","Average","Worst")
+            for (i in rankLabels.indices) {
+                if (i == 0) {
+                    val demoColumn = Table().apply { defaults().pad(5f) }
+                    demoColumn.add(rankLabels[i].toLabel()).row()
+                    demoColumn.addSeparator()
+                    civRankingsTable.add(demoColumn)
+                    for (category in RankingType.values()) {
+                        val headers = Table().apply { defaults().pad(5f) }
+                        headers.add(category.name.replace('_',' ').toLabel()).row()
+                        headers.addSeparator()
+                        civRankingsTable.add(headers)
+                    }
+                } else {
+                    civRankingsTable.row()
+                    val demoRow = Table().apply {defaults().pad(5f)}
+                    demoRow.add(rankLabels[i].toLabel()).row()
 
-            for (i in demographicsHeaders.indices) {
-                val demoColumn = Table().apply { defaults().pad(5f) }
-                demoColumn.add(demographicsHeaders[i].toLabel()).row()
-                demoColumn.addSeparator()
-                civRankingsTable.add(demoColumn)
+                    //add rank and other info here
+
+                    civRankingsTable.add(demoRow)
+                }
             }
-
-            /*
-            val catColumn = Table().apply { defaults().pad(5f) }
-            for (category in RankingType.values()) {
-                catColumn.add(category.name.replace('_',' ')).fillX().row()
-            }
-            civRankingsTable.add(catColumn)*/
-
-                //pull categories and add to col. 0 of civRankingsTable: Score, Population, Yield, etc.
-                //determine player's civ
-                //determine player's rank in all categories, add to col. 1
-                //show player's value in all categories, add to col. 2
-                //determine best civ in all categories, show in col. 3 (hide civ if unmet)
-                //calculate average score in all categories, show in col. 4
-                //calculate worst civ in all categories, show in col. 5
 
         } else {
             for (category in RankingType.values()) {
                 val column = Table().apply { defaults().pad(5f) }
                 column.add(category.name.replace('_',' ').toLabel()).row()
                 column.addSeparator()
-
                 for (civ in majorCivs.sortedByDescending { it.getStatForRanking(category) }) {
                     column.add(getCivGroup(civ, ": " + civ.getStatForRanking(category).toString(), playerCivInfo)).fillX().row()
                 }
-
                 civRankingsTable.add(column)
             }
         }

--- a/core/src/com/unciv/ui/victoryscreen/VictoryScreen.kt
+++ b/core/src/com/unciv/ui/victoryscreen/VictoryScreen.kt
@@ -174,34 +174,50 @@ class VictoryScreen(val worldScreen: WorldScreen) : PickerScreen() {
     }
 
     private fun setCivRankingsTable() {
-        val majorCivs = gameInfo.civilizations.filter { it.isMajorCiv() } //creates element of only major civs from gameInfo
-        val civRankingsTable = Table().apply { defaults().pad(5f) } //creates table with padding of 5f
+        val majorCivs = gameInfo.civilizations.filter { it.isMajorCiv() }
+        val civRankingsTable = Table().apply { defaults().pad(5f) }
 
-        if (gameInfo.gameParameters.demographicsEnabled ) { //if demographics option is enabled...
+        if (gameInfo.gameParameters.demographicsEnabled ) {
             val demographicsHeaders = arrayOf("Demographic","Rank","Value","Best","Average","Worst")
 
-            for (i in demographicsHeaders.indices) { //for every index in DemographicsHeaders array...
-                val column = Table().apply { defaults().pad(5f) } //create a column with padding of 5f
-                column.add(demographicsHeaders[i].replace('_',' ').toLabel()).row() //pulls name of category and creates label with it
-                column.addSeparator() //adds a separator line
-                civRankingsTable.add(column) //add resulting column to table
+            for (i in demographicsHeaders.indices) {
+                val demoColumn = Table().apply { defaults().pad(5f) }
+                demoColumn.add(demographicsHeaders[i].toLabel()).row()
+                demoColumn.addSeparator()
+                civRankingsTable.add(demoColumn)
             }
-        } else { //if demographics option is disabled...
-            for (category in RankingType.values()) { //for every category in RankingType class (Score, Population, etc.)...
-                val column = Table().apply { defaults().pad(5f) } //create a column with padding of 5f
-                column.add(category.name.replace('_',' ').toLabel()).row() //pulls name of category and creates label with it
-                column.addSeparator() //adds a separator line
 
-                for (civ in majorCivs.sortedByDescending { it.getStatForRanking(category) }) { //for every civ in majorCivs element, get ranking for this category and sort descending
-                    column.add(getCivGroup(civ, ": " + civ.getStatForRanking(category).toString(), playerCivInfo)).fillX().row() //add the civ name, background, and rank value to a row in the column
+            /*
+            val catColumn = Table().apply { defaults().pad(5f) }
+            for (category in RankingType.values()) {
+                catColumn.add(category.name.replace('_',' ')).fillX().row()
+            }
+            civRankingsTable.add(catColumn)*/
+
+                //pull categories and add to col. 0 of civRankingsTable: Score, Population, Yield, etc.
+                //determine player's civ
+                //determine player's rank in all categories, add to col. 1
+                //show player's value in all categories, add to col. 2
+                //determine best civ in all categories, show in col. 3 (hide civ if unmet)
+                //calculate average score in all categories, show in col. 4
+                //calculate worst civ in all categories, show in col. 5
+
+        } else {
+            for (category in RankingType.values()) {
+                val column = Table().apply { defaults().pad(5f) }
+                column.add(category.name.replace('_',' ').toLabel()).row()
+                column.addSeparator()
+
+                for (civ in majorCivs.sortedByDescending { it.getStatForRanking(category) }) {
+                    column.add(getCivGroup(civ, ": " + civ.getStatForRanking(category).toString(), playerCivInfo)).fillX().row()
                 }
 
-                civRankingsTable.add(column) //add resulting column to table
+                civRankingsTable.add(column)
             }
         }
 
-        contentsTable.clear() //clear previous contents of table
-        contentsTable.add(civRankingsTable) //add civRankingsTable to table
+        contentsTable.clear()
+        contentsTable.add(civRankingsTable)
     }
 
     private fun getCivGroup(civ: CivilizationInfo, afterCivNameText: String, currentPlayer: CivilizationInfo): Table {

--- a/core/src/com/unciv/ui/victoryscreen/VictoryScreen.kt
+++ b/core/src/com/unciv/ui/victoryscreen/VictoryScreen.kt
@@ -32,7 +32,13 @@ class VictoryScreen(val worldScreen: WorldScreen) : PickerScreen() {
         if (!playerCivInfo.isSpectator()) tabsTable.add(setMyVictoryButton)
         val setGlobalVictoryButton = "Global status".toTextButton().onClick { setGlobalVictoryTable() }
         tabsTable.add(setGlobalVictoryButton)
-        val setCivRankingsButton = "Rankings".toTextButton().onClick { setCivRankingsTable() }
+
+        val rankingLabel = if (gameInfo.gameParameters.demographicsEnabled ) {
+            "Demographics"
+        } else {
+            "Rankings"
+        }
+        val setCivRankingsButton = rankingLabel.toTextButton().onClick { setCivRankingsTable() }
         tabsTable.add(setCivRankingsButton)
         topTable.add(tabsTable)
         topTable.addSeparator()
@@ -175,33 +181,69 @@ class VictoryScreen(val worldScreen: WorldScreen) : PickerScreen() {
 
     private fun setCivRankingsTable() {
         val majorCivs = gameInfo.civilizations.filter { it.isMajorCiv() }
+        val playerCiv = gameInfo.civilizations.filter { it.isCurrentPlayer() }
         val civRankingsTable = Table().apply { defaults().pad(5f) }
         val rankLabels = arrayOf("Demographic","Rank","Value","Best","Average","Worst")
 
-        if (gameInfo.gameParameters.demographicsEnabled ) {
-            for (i in rankLabels.indices) {
-                if (i == 0) {
-                    val demoColumn = Table().apply { defaults().pad(5f) }
-                    demoColumn.add(rankLabels[i].toLabel()).row()
-                    demoColumn.addSeparator()
-                    civRankingsTable.add(demoColumn)
+        if (gameInfo.gameParameters.demographicsEnabled ) { //uses Demographics ranking screen if selected at game setup
+            for (n in rankLabels.indices) {
+                if (n==0) {
+                    val demoLabel = Table().apply { defaults().pad(5f) }
+                    demoLabel.add(rankLabels[n].toLabel()).row()
+                    demoLabel.addSeparator().fillX()
+                    civRankingsTable.add(demoLabel)
                     for (category in RankingType.values()) {
                         val headers = Table().apply { defaults().pad(5f) }
                         headers.add(category.name.replace('_',' ').toLabel()).row()
-                        headers.addSeparator()
+                        headers.addSeparator().fillX()
                         civRankingsTable.add(headers)
                     }
                 } else {
                     civRankingsTable.row()
-                    val demoRow = Table().apply {defaults().pad(5f)}
-                    demoRow.add(rankLabels[i].toLabel()).row()
+                    civRankingsTable.add(rankLabels[n].toLabel())
+                    for (category in RankingType.values()) {
+                        when (n) {
+                            1 -> { //finds the current player's rank in each category
+                                for ((rankCount, civ) in majorCivs.sortedByDescending { it.getStatForRanking(category) }.withIndex()){
+                                    if(civ.isCurrentPlayer()){
+                                        val rank = (rankCount+1).toLabel()
+                                        civRankingsTable.add(rank)
+                                    }
+                                }
+                            }
+                            2 -> { //finds the current player's value in each category
+                                for (civ in playerCiv) civRankingsTable.add(getCivGroup(civ, ": " + civ.getStatForRanking(category).toString(), playerCivInfo)).fillX()
+                            }
+                            3 -> { //finds civ with the best value in each category
+                                for ((rankCount, civ) in majorCivs.sortedByDescending { it.getStatForRanking(category) }.withIndex()) {
+                                    if(rankCount == majorCivs.indices.first){
+                                        civRankingsTable.add(getCivGroup(civ, ": " + civ.getStatForRanking(category).toString(), playerCivInfo)).fillX()
+                                    }
+                                }
+                            }
+                            4 -> {
+                                //calculates the average value in each category
+                                var totalScore: Int=0
+                                for (civ in majorCivs) {
+                                    totalScore+=civ.getStatForRanking(category)
+                                }
 
-                    //add rank and other info here
-
-                    civRankingsTable.add(demoRow)
+                                val averageScore = totalScore / (majorCivs.lastIndex+1)
+                                civRankingsTable.add(averageScore.toLabel())
+                            }
+                            5-> {
+                                //finds civ with the worst value in each category
+                                for ((rankCount, civ) in majorCivs.sortedByDescending { it.getStatForRanking(category) }.withIndex()) {
+                                    if(rankCount == majorCivs.lastIndex){
+                                        civRankingsTable.add(getCivGroup(civ, ": " + civ.getStatForRanking(category).toString(), playerCivInfo)).fillX()
+                                    }
+                                }
+                            }
+                            else -> {}
+                        }
+                    }
                 }
             }
-
         } else {
             for (category in RankingType.values()) {
                 val column = Table().apply { defaults().pad(5f) }

--- a/core/src/com/unciv/ui/victoryscreen/VictoryScreen.kt
+++ b/core/src/com/unciv/ui/victoryscreen/VictoryScreen.kt
@@ -185,7 +185,7 @@ class VictoryScreen(val worldScreen: WorldScreen) : PickerScreen() {
         val civRankingsTable = Table().apply { defaults().pad(5f) }
         val rankLabels = arrayOf("Demographic","Rank","Value","Best","Average","Worst")
 
-        if (gameInfo.gameParameters.demographicsEnabled ) { //uses Demographics ranking screen if selected at game setup
+        if (gameInfo.gameParameters.demographicsEnabled ) { //uses Demographics Scoreboard if selected at new game setup
             for (n in rankLabels.indices) {
                 if (n==0) {
                     val demoLabel = Table().apply { defaults().pad(5f) }


### PR DESCRIPTION
I've implemented a Demographics Scoreboard similar to the one from Civ V seen below:

<img width="734" alt="Demographics" src="https://user-images.githubusercontent.com/56904240/165886141-1506e928-7bc2-4a55-bc2b-b2f2a27f6bcc.png">

I feel that this view which only shows the current player's rank, value, and overall best/average/worst in the game metrics is more competitive than what's currently shown in the rankings of the victory screen in Unciv, which gives you detailed information for all civilizations in the game. 

To use, enable the checkbox in the new game setup screen. The placement here is intentional so that it can't be changed during a game. By default it is deselected, which uses the old ranking screen.

<img width="421" alt="Game Options" src="https://user-images.githubusercontent.com/56904240/165887043-33611449-58c4-4f75-8faa-050c62391226.png">

In my implementation, the table is transposed compared to Civ V in order to stay more consistent with the other screens in Unciv. Note that the button on the top of the screen changes from "Rankings" to "Demographics" when this scoreboard is used. The formatting is basic and I'm not sure the current order of rows is optimal. Please let me know any feedback on the UI or code, as I'm not very experienced and more than happy to make any changes.

<img width="1252" alt="Scoreboard" src="https://user-images.githubusercontent.com/56904240/165887161-cbcad6b8-524b-46b1-bd29-3265f9d9d23a.png">

