### PR TITLE
Fixed a crash when a plane tried to enter a full city

### DIFF
--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -889,7 +889,7 @@ class MapUnit {
     fun putInTile(tile: TileInfo) {
         when {
             !movement.canMoveTo(tile) ->
-                throw Exception("I can't go there!")
+                throw Exception("Unit $name at $currentTile can't be put in tile ${tile.position}!")
             baseUnit.movesLikeAirUnits() -> tile.airUnits.add(this)
             isCivilian() -> tile.civilianUnit = this
             else -> tile.militaryUnit = this

--- a/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
+++ b/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
@@ -261,7 +261,7 @@ class UnitMovementAlgorithms(val unit: MapUnit) {
         if (currentTile == finalDestination) return currentTile
 
         // If we can fly, head there directly
-        if (unit.baseUnit.movesLikeAirUnits() || unit.isPreparingParadrop()) return finalDestination
+        if ((unit.baseUnit.movesLikeAirUnits() || unit.isPreparingParadrop()) && canMoveTo(finalDestination)) return finalDestination
 
         val distanceToTiles = getDistanceToTiles()
 


### PR DESCRIPTION
This would only occur if the plane was damaged and looking for a spot to heal, and had no tile to go to with >0 healing. It would then try to head towards the nearest city, regardless of whether it could enter that. As it's an air unit, 'head towards' means 'fly there directly this 
turn', which obviously caused crashes if the unit couldn't enter that tile.

On a glance it looks like this entire function is not designed to handle air units, as these don't have to care about ranged or bombarding units at all anyway and also doesn't use the normal movement rules. I've only patched this crash, but realistically, this entire function should be redesigned to also handle air units.