### PR TITLE
Show number of global followers in Religion Overview

### DIFF
--- a/core/src/com/unciv/ui/overviewscreen/ReligionOverviewTable.kt
+++ b/core/src/com/unciv/ui/overviewscreen/ReligionOverviewTable.kt
@@ -149,8 +149,11 @@ class ReligionOverviewTab(
                 statsTable.add(cityName.toLabel()).right().row()
             }
         }
+        val manager = religion.getFounder().religionManager
         statsTable.add("Cities following this religion:".toLabel())
-        statsTable.add(religion.getFounder().religionManager.numberOfCitiesFollowingThisReligion().toLabel()).right().row()
+        statsTable.add(manager.numberOfCitiesFollowingThisReligion().toLabel()).right().row()
+        statsTable.add("{Followers of this religion}:".toLabel())
+        statsTable.add(manager.numberOfFollowersFollowingThisReligion("in all cities").toLabel()).right().row()
 
         val minWidth = max(statsTable.minWidth, beliefsTable.minWidth) + 5
 


### PR DESCRIPTION
Just one additional line. "Global followers" would be clearer, but then we'd need an additional template line. Opinions?

Didn't want to really take off on this, just a little number to compare those Belief effects to. Thus, no drilldown like the City Stats do.