### PR TITLE
Fixed `provides [amount] [resource]` on buildings not accepting conditionals

### DIFF
--- a/core/src/com/unciv/logic/city/CityInfo.kt
+++ b/core/src/com/unciv/logic/city/CityInfo.kt
@@ -351,24 +351,21 @@ class CityInfo {
         for (tileInfo in getTiles()) {
             if (tileInfo.improvement == null) continue
             val tileImprovement = tileInfo.getTileImprovement()
-            for (unique in tileImprovement!!.uniqueObjects) {
-                if (unique.isOfType(UniqueType.ProvidesResources)) {
-                    if (!unique.conditionalsApply(civInfo, this)) continue
-                    val resource = getRuleset().tileResources[unique.params[1]] ?: continue
-                    cityResources.add(
-                        resource,
-                        unique.params[0].toInt() * civInfo.getResourceModifier(resource),
-                        "Improvements"
-                    )
-                }
-                if (unique.isOfType(UniqueType.ConsumesResources)) {
-                    val resource = getRuleset().tileResources[unique.params[1]] ?: continue
-                    cityResources.add(
-                        resource,
-                        -1 * unique.params[0].toInt(),
-                        "Improvements"
-                    )
-                }
+            for (unique in tileImprovement!!.getMatchingUniques(UniqueType.ProvidesResources, StateForConditionals(civInfo, this))) {
+                val resource = getRuleset().tileResources[unique.params[1]] ?: continue
+                cityResources.add(
+                    resource,
+                    unique.params[0].toInt() * civInfo.getResourceModifier(resource),
+                    "Improvements"
+                )
+            }
+            for (unique in tileImprovement.getMatchingUniques(UniqueType.ConsumesResources, StateForConditionals(civInfo, this))) {
+                val resource = getRuleset().tileResources[unique.params[1]] ?: continue
+                cityResources.add(
+                    resource,
+                    -1 * unique.params[0].toInt(),
+                    "Improvements"
+                )
             }
         }
 
@@ -383,8 +380,7 @@ class CityInfo {
             }
         }
 
-        for (unique in getLocalMatchingUniques(UniqueType.ProvidesResources)) { // E.G "Provides [1] [Iron]"
-            if (!unique.conditionalsApply(civInfo, this)) continue
+        for (unique in getLocalMatchingUniques(UniqueType.ProvidesResources, StateForConditionals(civInfo, this))) { // E.G "Provides [1] [Iron]"
             val resource = getRuleset().tileResources[unique.params[1]]
             if (resource != null) {
                 cityResources.add(

--- a/core/src/com/unciv/logic/city/CityInfo.kt
+++ b/core/src/com/unciv/logic/city/CityInfo.kt
@@ -348,9 +348,10 @@ class CityInfo {
             if (amount > 0) cityResources.add(resource, amount, "Tiles")
         }
         
-        val stateForConditionals = StateForConditionals(civInfo, this);
+        
         
         for (tileInfo in getTiles()) {
+            val stateForConditionals = StateForConditionals(civInfo, this, tile = tileInfo)
             if (tileInfo.improvement == null) continue
             val tileImprovement = tileInfo.getTileImprovement()
             for (unique in tileImprovement!!.getMatchingUniques(UniqueType.ProvidesResources, stateForConditionals)) {
@@ -382,7 +383,7 @@ class CityInfo {
             }
         }
 
-        for (unique in getLocalMatchingUniques(UniqueType.ProvidesResources, stateForConditionals)) { // E.G "Provides [1] [Iron]"
+        for (unique in getLocalMatchingUniques(UniqueType.ProvidesResources, StateForConditionals(civInfo, this))) { // E.G "Provides [1] [Iron]"
             val resource = getRuleset().tileResources[unique.params[1]]
             if (resource != null) {
                 cityResources.add(

--- a/core/src/com/unciv/logic/city/CityInfo.kt
+++ b/core/src/com/unciv/logic/city/CityInfo.kt
@@ -348,10 +348,12 @@ class CityInfo {
             if (amount > 0) cityResources.add(resource, amount, "Tiles")
         }
         
+        val stateForConditionals = StateForConditionals(civInfo, this);
+        
         for (tileInfo in getTiles()) {
             if (tileInfo.improvement == null) continue
             val tileImprovement = tileInfo.getTileImprovement()
-            for (unique in tileImprovement!!.getMatchingUniques(UniqueType.ProvidesResources, StateForConditionals(civInfo, this))) {
+            for (unique in tileImprovement!!.getMatchingUniques(UniqueType.ProvidesResources, stateForConditionals)) {
                 val resource = getRuleset().tileResources[unique.params[1]] ?: continue
                 cityResources.add(
                     resource,
@@ -359,7 +361,7 @@ class CityInfo {
                     "Improvements"
                 )
             }
-            for (unique in tileImprovement.getMatchingUniques(UniqueType.ConsumesResources, StateForConditionals(civInfo, this))) {
+            for (unique in tileImprovement.getMatchingUniques(UniqueType.ConsumesResources, stateForConditionals)) {
                 val resource = getRuleset().tileResources[unique.params[1]] ?: continue
                 cityResources.add(
                     resource,
@@ -380,7 +382,7 @@ class CityInfo {
             }
         }
 
-        for (unique in getLocalMatchingUniques(UniqueType.ProvidesResources, StateForConditionals(civInfo, this))) { // E.G "Provides [1] [Iron]"
+        for (unique in getLocalMatchingUniques(UniqueType.ProvidesResources, stateForConditionals)) { // E.G "Provides [1] [Iron]"
             val resource = getRuleset().tileResources[unique.params[1]]
             if (resource != null) {
                 cityResources.add(

--- a/core/src/com/unciv/models/ruleset/unique/StateForConditionals.kt
+++ b/core/src/com/unciv/models/ruleset/unique/StateForConditionals.kt
@@ -21,7 +21,7 @@ data class StateForConditionals(
 
     val region: Region? = null,
 
-    val ignoreConditionals:Boolean = false,
+    val ignoreConditionals: Boolean = false,
 ) {
 
     companion object {


### PR DESCRIPTION
This was due to it still using `getLocalMatchingUniques` without providing a `StateForConditionals`, and then manually filtering them if they didn't provide conditionals. This of course doesn't work anymore, as `getLocalMatchingUniques` then assumes that all conditionals aren't satisfied.
Also refactored a loop over `uniqueObjects` with `isOfType()` to just use `getMatchingUniques()`.