### PR TITLE
Use the scrolling for the oversized popups

### DIFF
--- a/core/src/com/unciv/ui/popup/Popup.kt
+++ b/core/src/com/unciv/ui/popup/Popup.kt
@@ -28,12 +28,14 @@ open class Popup(val screen: BaseScreen): Table(BaseScreen.skin) {
         // Set actor name for debugging
         name = javaClass.simpleName
 
+        val scrollPane = AutoScrollPane(innerTable, BaseScreen.skin)
+
         background = ImageGetter.getBackground(Color.GRAY.cpy().apply { a=.5f })
         innerTable.background = ImageGetter.getBackground(ImageGetter.getBlue().darken(0.5f))
 
         innerTable.pad(20f)
         innerTable.defaults().pad(5f)
-        super.add(innerTable)
+        super.add(scrollPane)
 
         this.isVisible = false
         touchable = Touchable.enabled // don't allow clicking behind


### PR DESCRIPTION
Fixes #5811 and, probably, fixes #5046

The fix is simple and elegant, however, I feel it needs more testing than just a few popups.

<details><summary>See video here</summary>

![Screencast 2022-05-01]( https://user-images.githubusercontent.com/27405436/166164703-2fce85a9-6492-4c68-acd9-cd7c2bcacefc.gif )

</details>

As far as you see, the small popups are not affected and behave as usual (no scrolling), however, large oversized ones are able to be scrolled, so the large text on the game's start is not blocker anymore.
