### PR TITLE
Optimize String to Stat and Translation mod list somewhat

### DIFF
--- a/core/src/com/unciv/models/ruleset/Building.kt
+++ b/core/src/com/unciv/models/ruleset/Building.kt
@@ -718,7 +718,7 @@ class Building : RulesetStatsObject(), INonPerpetualConstruction {
             replaces -> true
             else -> {
                 if (uniques.contains(filter)) return true
-                val stat = Stat.values().firstOrNull { it.name == filter }
+                val stat = Stat.safeValueOf(filter)
                 if (stat != null && isStatRelated(stat)) return true
                 return false
             }

--- a/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
@@ -155,14 +155,14 @@ enum class UniqueParameterType(
     StatName("stat", "Culture", "This is one of the 7 major stats in the game - `Gold`, `Science`, `Production`, `Food`, `Happiness`, `Culture` and `Faith`. Note that the stat names need to be capitalized!") {
         override fun getErrorSeverity(parameterText: String, ruleset: Ruleset):
                 UniqueType.UniqueComplianceErrorSeverity? {
-            if (Stat.values().any { it.name == parameterText }) return null
+            if (Stat.isStat(parameterText)) return null
             return UniqueType.UniqueComplianceErrorSeverity.RulesetInvariant
         }
     },
 
     /** [UniqueType.DamageUnitsPlunder] and others near that one */
     PlunderableStatName("plunderableStat", "Gold", "All the following stats can be plundered: `Gold`, `Science`, `Culture`, `Faith`") {
-        private val knownValues = setOf(Stat.Gold.name, Stat.Science.name, Stat.Culture.name, Stat.Faith.name)
+        private val knownValues = Stat.statsWithCivWideField.map { it.name }.toSet()
         override fun getErrorSeverity(
             parameterText: String,
             ruleset: Ruleset
@@ -216,7 +216,7 @@ enum class UniqueParameterType(
     /** Implemented by [Building.matchesFilter][com.unciv.models.ruleset.Building.matchesFilter] */
     BuildingFilter("buildingFilter", "Culture") {
         private val knownValues = mutableSetOf("All","Building","Buildings","Wonder","Wonders","National Wonder","World Wonder")
-            .apply { addAll(Stat.values().map { it.name }) }
+            .apply { addAll(Stat.names()) }
         override fun getErrorSeverity(
             parameterText: String,
             ruleset: Ruleset

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -319,10 +319,9 @@ object UniqueTriggerActivation {
             // I could parametrize the [Allied], but eh.
 
             OneTimeGainStat -> {
-                if (Stat.values().none { it.name == unique.params[1] }) return false
-                val stat = Stat.valueOf(unique.params[1])
+                val stat = Stat.safeValueOf(unique.params[1]) ?: return false
 
-                if (stat !in listOf(Stat.Gold, Stat.Faith, Stat.Science, Stat.Culture)
+                if (stat !in Stat.statsWithCivWideField
                     || unique.params[0].toIntOrNull() == null
                 ) return false
 
@@ -332,10 +331,9 @@ object UniqueTriggerActivation {
                 return true
             }
             OneTimeGainStatRange -> {
-                if (Stat.values().none { it.name == unique.params[2] }) return false
-                val stat = Stat.valueOf(unique.params[2])
+                val stat = Stat.safeValueOf(unique.params[2]) ?: return false
 
-                if (stat !in listOf(Stat.Gold, Stat.Faith, Stat.Science, Stat.Culture)
+                if (stat !in Stat.statsWithCivWideField
                     || unique.params[0].toIntOrNull() == null
                     || unique.params[1].toIntOrNull() == null
                 ) return false

--- a/core/src/com/unciv/models/stats/Stat.kt
+++ b/core/src/com/unciv/models/stats/Stat.kt
@@ -18,9 +18,12 @@ enum class Stat(
     Faith(NotificationIcon.Faith, UncivSound.Choir, Fonts.faith);
 
     companion object {
-        val statsUsableToBuy = listOf(Gold, Food, Science, Culture, Faith)
+        val statsUsableToBuy = setOf(Gold, Food, Science, Culture, Faith)
         private val valuesAsMap = values().associateBy { it.name }
         fun safeValueOf(name: String) = valuesAsMap[name]
+        fun isStat(name: String) = name in valuesAsMap
+        fun names() = valuesAsMap.keys
+        val statsWithCivWideField = setOf(Gold, Science, Culture, Faith)
     }
 }
 

--- a/core/src/com/unciv/models/stats/Stat.kt
+++ b/core/src/com/unciv/models/stats/Stat.kt
@@ -19,6 +19,8 @@ enum class Stat(
 
     companion object {
         val statsUsableToBuy = listOf(Gold, Food, Science, Culture, Faith)
+        private val valuesAsMap = values().associateBy { it.name }
+        fun safeValueOf(name: String) = valuesAsMap[name]
     }
 }
 

--- a/core/src/com/unciv/ui/overviewscreen/CityOverviewTable.kt
+++ b/core/src/com/unciv/ui/overviewscreen/CityOverviewTable.kt
@@ -57,7 +57,7 @@ class CityOverviewTab(
             .apply { addTooltip("Current construction", 18f, tipAlign = Align.center) }
 
         // Readability helpers
-        private fun String.isStat() = Stat.values().any { it.name == this }
+        private fun String.isStat() = Stat.isStat(this)
 
         private fun CityInfo.getStat(stat: Stat) =
             if (stat == Stat.Happiness)
@@ -115,7 +115,7 @@ class CityOverviewTab(
             "Population" -> city2.population.population - city1.population.population
             WLTK -> city2.isWeLoveTheKingDayActive().compareTo(city1.isWeLoveTheKingDayActive())
             else -> {
-                val stat = Stat.valueOf(persistableData.sortedBy)
+                val stat = Stat.safeValueOf(persistableData.sortedBy)!!
                 city2.getStat(stat) - city1.getStat(stat)
             }
         }
@@ -199,8 +199,8 @@ class CityOverviewTab(
             cityInfoTableDetails.add(city.population.population.toCenteredLabel())
 
             for (column in columnsNames) {
-                if (!column.isStat()) continue
-                cityInfoTableDetails.add(city.getStat(Stat.valueOf(column)).toCenteredLabel())
+                val stat = Stat.safeValueOf(column) ?: continue
+                cityInfoTableDetails.add(city.getStat(stat).toCenteredLabel())
             }
 
             when {


### PR DESCRIPTION
- I believe a map is faster on average than an iteration even with only 7 items - not measured though. Motivation: each and every tr() call uses `Stat.values().firstOrNull` - might shave of a few ns.
- Some cleanup to use that new Stat capability elsewhere (2nd commit)
- Made a cached variant of tr()'s `val activeMods` - old code would allocate a new LinkedHashSet and copy ruleset names into it _twice_[^1] each call. My bad I think... I hope the hashCode calculation comes cheaper. Tested ba loading G&K / Deciv games back and forth and looking at Gold/Water.

[^1]: Set.plus does one then casts the LinkedHashSet down to Set, and our code then cast it back up to HashSet - by cloning.