### PR TITLE
Platform specific Internet Connectivity Test

### DIFF
--- a/android/src/com/unciv/app/AndroidLauncher.kt
+++ b/android/src/com/unciv/app/AndroidLauncher.kt
@@ -35,15 +35,15 @@ open class AndroidLauncher : AndroidApplication() {
         val fontFamily = settings.fontFamily
 
         // Manage orientation lock
-        val limitOrientationsHelper = LimitOrientationsHelperAndroid(this)
-        limitOrientationsHelper.allowPortrait(settings.allowAndroidPortrait)
+        val platformSpecificHelper = PlatformSpecificHelpersAndroid(this)
+        platformSpecificHelper.allowPortrait(settings.allowAndroidPortrait)
 
         val androidParameters = UncivGameParameters(
             version = BuildConfig.VERSION_NAME,
             crashReportSysInfo = CrashReportSysInfoAndroid,
             fontImplementation = NativeFontAndroid(Fonts.ORIGINAL_FONT_SIZE.toInt(), fontFamily),
             customSaveLocationHelper = customSaveLocationHelper,
-            limitOrientationsHelper = limitOrientationsHelper
+            platformSpecificHelper = platformSpecificHelper
         )
 
         game = UncivGame(androidParameters)

--- a/android/src/com/unciv/app/PlatformSpecificHelpersAndroid.kt
+++ b/android/src/com/unciv/app/PlatformSpecificHelpersAndroid.kt
@@ -1,15 +1,19 @@
 package com.unciv.app
 
 import android.app.Activity
+import android.content.Context
 import android.content.pm.ActivityInfo
-import com.unciv.ui.utils.LimitOrientationsHelper
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import com.unciv.ui.utils.GeneralPlatformSpecificHelpers
 
-/** See also interface [LimitOrientationsHelper].
+/** See also interface [GeneralPlatformSpecificHelpers].
  *
  *  The Android implementation (currently the only one) effectively ends up doing
  *  [Activity.setRequestedOrientation]
  */
-class LimitOrientationsHelperAndroid(private val activity: Activity) : LimitOrientationsHelper {
+class PlatformSpecificHelpersAndroid(private val activity: Activity) : GeneralPlatformSpecificHelpers {
+
 /*
 Sources for Info about current orientation in case need:
         val windowManager = (activity.getSystemService(Context.WINDOW_SERVICE) as WindowManager)
@@ -27,5 +31,16 @@ Sources for Info about current orientation in case need:
         }
         // Comparison ensures ActivityTaskManager.getService().setRequestedOrientation isn't called unless necessary
         if (activity.requestedOrientation != orientation) activity.requestedOrientation = orientation
+    }
+
+    override fun isInternetConnected(): Boolean {
+        val connectivityManager = activity.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        for (network in connectivityManager.allNetworks) {
+            val networkCapabilities = connectivityManager.getNetworkCapabilities(network) ?: continue
+            val isInternet = networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+            val info = connectivityManager.getNetworkInfo(network) ?: continue
+            if (isInternet && info.isConnected) return true
+        }
+        return false
     }
 }

--- a/core/src/com/unciv/UncivGame.kt
+++ b/core/src/com/unciv/UncivGame.kt
@@ -36,7 +36,7 @@ class UncivGame(parameters: UncivGameParameters) : Game() {
     val fontImplementation = parameters.fontImplementation
     val consoleMode = parameters.consoleMode
     val customSaveLocationHelper = parameters.customSaveLocationHelper
-    val limitOrientationsHelper = parameters.limitOrientationsHelper
+    val platformSpecificHelper = parameters.platformSpecificHelper
     private val audioExceptionHelper = parameters.audioExceptionHelper
 
     var deepLinkedMultiplayerGame: String? = null

--- a/core/src/com/unciv/UncivGameParameters.kt
+++ b/core/src/com/unciv/UncivGameParameters.kt
@@ -3,7 +3,7 @@ package com.unciv
 import com.unciv.logic.CustomSaveLocationHelper
 import com.unciv.ui.crashhandling.CrashReportSysInfo
 import com.unciv.ui.utils.AudioExceptionHelper
-import com.unciv.ui.utils.LimitOrientationsHelper
+import com.unciv.ui.utils.GeneralPlatformSpecificHelpers
 import com.unciv.ui.utils.NativeFontImplementation
 
 class UncivGameParameters(val version: String,
@@ -12,6 +12,6 @@ class UncivGameParameters(val version: String,
                           val fontImplementation: NativeFontImplementation? = null,
                           val consoleMode: Boolean = false,
                           val customSaveLocationHelper: CustomSaveLocationHelper? = null,
-                          val limitOrientationsHelper: LimitOrientationsHelper? = null,
+                          val platformSpecificHelper: GeneralPlatformSpecificHelpers? = null,
                           val audioExceptionHelper: AudioExceptionHelper? = null
 )

--- a/core/src/com/unciv/ui/utils/GeneralPlatformSpecificHelpers.kt
+++ b/core/src/com/unciv/ui/utils/GeneralPlatformSpecificHelpers.kt
@@ -2,15 +2,16 @@ package com.unciv.ui.utils
 
 import com.unciv.models.metadata.GameSettings
 
-/** Interface to support managing orientations
- *
- *  You can turn a mobile device on its side or upside down, and a mobile OS may or may not allow the
- *  position changes to automatically result in App orientation changes. This is about limiting that feature.
- */
-interface LimitOrientationsHelper {
+/** Interface to support various platform-specific tools */
+interface GeneralPlatformSpecificHelpers {
     /** Pass a Boolean setting as used in [allowAndroidPortrait][GameSettings.allowAndroidPortrait] to the OS.
+     *
+     *  You can turn a mobile device on its side or upside down, and a mobile OS may or may not allow the
+     *  position changes to automatically result in App orientation changes. This is about limiting that feature.
      *  @param allow `true`: allow all orientations (follows sensor as limited by OS settings)
      *          `false`: allow only landscape orientations (both if supported, otherwise default landscape only)
      */
     fun allowPortrait(allow: Boolean)
+
+    fun isInternetConnected(): Boolean
 }

--- a/core/src/com/unciv/ui/worldscreen/mainmenu/OptionsPopup.kt
+++ b/core/src/com/unciv/ui/worldscreen/mainmenu/OptionsPopup.kt
@@ -108,7 +108,7 @@ class OptionsPopup(val previousScreen: BaseScreen) : Popup(previousScreen) {
 
         addCloseButton {
             previousScreen.game.musicController.onChange(null)
-            previousScreen.game.limitOrientationsHelper?.allowPortrait(settings.allowAndroidPortrait)
+            previousScreen.game.platformSpecificHelper?.allowPortrait(settings.allowAndroidPortrait)
             if (previousScreen is WorldScreen)
                 previousScreen.enableNextTurnButtonAfterOptions()
         }.padBottom(10f)
@@ -318,11 +318,11 @@ class OptionsPopup(val previousScreen: BaseScreen) : Popup(previousScreen) {
 
         addMaxZoomSlider()
 
-        if (previousScreen.game.limitOrientationsHelper != null) {
+        if (previousScreen.game.platformSpecificHelper != null) {
             addCheckbox("Enable portrait orientation", settings.allowAndroidPortrait) {
                 settings.allowAndroidPortrait = it
                 // Note the following might close the options screen indirectly and delayed
-                previousScreen.game.limitOrientationsHelper.allowPortrait(it)
+                previousScreen.game.platformSpecificHelper.allowPortrait(it)
             }
         }
 

--- a/desktop/src/com/unciv/app/desktop/DesktopLauncher.kt
+++ b/desktop/src/com/unciv/app/desktop/DesktopLauncher.kt
@@ -52,6 +52,7 @@ internal object DesktopLauncher {
             fontImplementation = NativeFontDesktop(Fonts.ORIGINAL_FONT_SIZE.toInt(), settings.fontFamily),
             customSaveLocationHelper = CustomSaveLocationHelperDesktop(),
             crashReportSysInfo = CrashReportSysInfoDesktop(),
+            platformSpecificHelper = PlatformSpecificHelpersDesktop(),
             audioExceptionHelper = HardenGdxAudio()
         )
 

--- a/desktop/src/com/unciv/app/desktop/PlatformSpecificHelpersDesktop.kt
+++ b/desktop/src/com/unciv/app/desktop/PlatformSpecificHelpersDesktop.kt
@@ -1,0 +1,14 @@
+package com.unciv.app.desktop
+
+import com.unciv.ui.utils.GeneralPlatformSpecificHelpers
+import java.net.InetAddress
+
+class PlatformSpecificHelpersDesktop : GeneralPlatformSpecificHelpers {
+    override fun allowPortrait(allow: Boolean) {
+        // No need to do anything
+    }
+
+    override fun isInternetConnected(): Boolean {
+        return InetAddress.getByName("8.8.8.8").isReachable(500)  // Parameter timeout in milliseconds 
+    }
+}


### PR DESCRIPTION
Demo for @alexban011 relating to #6666 - PR only to make diff readable easily.

- Rename orientation stuff to general platform stuff, another one of those seems overkill, and collecting little routines like these in some general container feels right
- Android tests connectivity using the ConnectivityManager system service. Sorry for not replacing the deprecated getNetworkInfo, but doing so requires an API level >= 30 gate.
- Desktop pings instead - to 8.8.8.8 with half a second timeout. Primitive, but tests OK.
- Use in the UI is just a wild guess
- Spurious mod check left in, that was a leftover from too lazy to open a fresh branch

Read, laugh, learn, copy & paste, or ignore however you wish. Permission to copy without attribution granted.