### PR TITLE
Update Hosting-a-Multiplayer-server.md

### DIFF
--- a/docs/Other/Hosting-a-Multiplayer-server.md
+++ b/docs/Other/Hosting-a-Multiplayer-server.md
@@ -30,4 +30,6 @@ For other devices, you'll need an external IP, which is out of scope for this do
 
 On the other device, do the same - enter the URL, click 'check connection' from the new device, and if you got the same result - congratulations, you're both connected to the same server and can start a multiplayer game on the server!
 
+Android has some restrictions and does not allow unencrypted HTTP traffic from the Unciv app to a server. So you need to have a reverse proxy that sits between your (Android) client(s) and the Unciv server. The reverse proxy then needs to have a valid certificate and handles the TLS sessions for your Unciv server.
+
 Please note that devices NOT connected to the same server will NOT be able to participate in multiplayer games together!

--- a/docs/Other/Hosting-a-Multiplayer-server.md
+++ b/docs/Other/Hosting-a-Multiplayer-server.md
@@ -6,7 +6,7 @@ Therefore, you can now host your own Unciv server, when not on Android.
 
 To do so, you must have a JDK installed.
 
-From the directory where the Unciv.jar file is located, open a terminal and run the following line:
+From the directory where the Unciv.jar file is located, create a folder named "MultiplayerFiles", open a terminal and run the following line:
 `java -cp Unciv.jar com.unciv.app.desktop.UncivServer`
 
 Don't forget to use 'cd' to switch to the correct dictionary. Here's an example in Windows.
@@ -15,6 +15,7 @@ Don't forget to use 'cd' to switch to the correct dictionary. Here's an example 
 D:
 cd Games
 cd unciv
+mkdir MultiplayerFiles
 java -cp Unciv.jar com.unciv.app.desktop.UncivServer
 ```
 


### PR DESCRIPTION
Added a section for explaining that Android does not like unencrypted traffic to a self-hosted server and that you need to setup a reverse proxy to do that.