### PR TITLE
Added uniques related to improvements

### DIFF
--- a/android/assets/jsons/Civ V - Gods & Kings/TileImprovements.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/TileImprovements.json
@@ -250,7 +250,7 @@
 	},
 	{ 
 		"name": "City center", 
-		"uniques": ["Unpillagable", "Indestructible"],
+		"uniques": ["Unpillagable", "Irremovable"],
         "civilopediaText": [
 			{"text":"Marks the center of a city"},
 			{"text":"Appearance changes with the technological era of the owning civilization"}

--- a/android/assets/jsons/Civ V - Gods & Kings/TileImprovements.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/TileImprovements.json
@@ -82,7 +82,7 @@
 		"terrainsCanBeBuiltOn": ["Coast"],
 		"food": 1,
 		"techRequired": "Sailing",
-		"uniques": ["[+1 Gold] <after discovering [Compass]>"]
+		"uniques": ["[+1 Gold] <after discovering [Compass]>", "Consumes builder when build"]
 	},
 
 	// Military improvement
@@ -174,31 +174,34 @@
 	{
 		"name": "Academy",
 		"science": 8,
-		"uniques": ["Great Improvement", "[+2 Science] <after discovering [Scientific Theory]>", "[+2 Science] <after discovering [Atomic Theory]>"]
+		"uniques": ["Great Improvement", "[+2 Science] <after discovering [Scientific Theory]>", "[+2 Science] <after discovering [Atomic Theory]>", "Consumes builder when build"]
 	},
 	{
 		"name": "Landmark",
 		"culture": 6,
-		"uniques": ["Great Improvement"]
+		"uniques": ["Great Improvement", "Consumes builder when build"]
 	},
 	{
 		"name": "Manufactory",
 		"production": 4,
-		"uniques": ["Great Improvement", "[+1 Production] <after discovering [Chemistry]>"]
+		"uniques": ["Great Improvement", "[+1 Production] <after discovering [Chemistry]>", "Consumes builder when build"]
 	},
 	{
 		"name": "Customs house",
 		"gold": 4,
-		"uniques": ["Great Improvement", "[+1 Gold] <after discovering [Economics]>"]
+		"uniques": ["Great Improvement", "[+1 Gold] <after discovering [Economics]>", "Consumes builder when build"]
 	},
 	{
 		"name": "Holy site",
 		"faith": 6,
-		"uniques": ["Great Improvement"]
+		"uniques": ["Great Improvement", "Consumes builder when build"]
 	},
 	{
 		"name": "Citadel",
-		"uniques": ["Great Improvement", "Gives a defensive bonus of [100]%", "Adjacent enemy units ending their turn take [30] damage", "Can be built just outside your borders"],
+		"uniques": [
+			"Great Improvement", "Gives a defensive bonus of [100]%", "Adjacent enemy units ending their turn take [30] damage", 
+			"Can be built just outside your borders", "Adds adjacent tiles to your closest city", "Consumes builder when build"
+		],
         "civilopediaText": [{"text":"Constructing it will take over the tiles around it and assign them to your closest city"}]
 	},
 

--- a/android/assets/jsons/Civ V - Gods & Kings/TileImprovements.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/TileImprovements.json
@@ -82,7 +82,7 @@
 		"terrainsCanBeBuiltOn": ["Coast"],
 		"food": 1,
 		"techRequired": "Sailing",
-		"uniques": ["[+1 Gold] <after discovering [Compass]>", "Consumes builder when build"]
+		"uniques": ["[+1 Gold] <after discovering [Compass]>", "Consumes builder when built"]
 	},
 
 	// Military improvement
@@ -174,35 +174,35 @@
 	{
 		"name": "Academy",
 		"science": 8,
-		"uniques": ["Great Improvement", "[+2 Science] <after discovering [Scientific Theory]>", "[+2 Science] <after discovering [Atomic Theory]>", "Consumes builder when build"]
+		"uniques": ["Great Improvement", "[+2 Science] <after discovering [Scientific Theory]>", "[+2 Science] <after discovering [Atomic Theory]>", "Consumes builder when built"]
 	},
 	{
 		"name": "Landmark",
 		"culture": 6,
-		"uniques": ["Great Improvement", "Consumes builder when build"]
+		"uniques": ["Great Improvement", "Consumes builder when built"]
 	},
 	{
 		"name": "Manufactory",
 		"production": 4,
-		"uniques": ["Great Improvement", "[+1 Production] <after discovering [Chemistry]>", "Consumes builder when build"]
+		"uniques": ["Great Improvement", "[+1 Production] <after discovering [Chemistry]>", "Consumes builder when built"]
 	},
 	{
 		"name": "Customs house",
 		"gold": 4,
-		"uniques": ["Great Improvement", "[+1 Gold] <after discovering [Economics]>", "Consumes builder when build"]
+		"uniques": ["Great Improvement", "[+1 Gold] <after discovering [Economics]>", "Consumes builder when built"]
 	},
 	{
 		"name": "Holy site",
 		"faith": 6,
-		"uniques": ["Great Improvement", "Consumes builder when build"]
+		"uniques": ["Great Improvement", "Consumes builder when built"]
 	},
 	{
 		"name": "Citadel",
 		"uniques": [
 			"Great Improvement", "Gives a defensive bonus of [100]%", "Adjacent enemy units ending their turn take [30] damage", 
-			"Can be built just outside your borders", "Adds adjacent tiles to your closest city", "Consumes builder when build"
+			"Can be built just outside your borders", "Constructing it will take over the tiles around it and assign them to your closest city", 
+			"Consumes builder when built"
 		],
-        "civilopediaText": [{"text":"Constructing it will take over the tiles around it and assign them to your closest city"}]
 	},
 
 	//Civilization unique improvements

--- a/android/assets/jsons/Civ V - Vanilla/TileImprovements.json
+++ b/android/assets/jsons/Civ V - Vanilla/TileImprovements.json
@@ -82,7 +82,7 @@
 		"terrainsCanBeBuiltOn": ["Coast"],
 		"food": 1,
 		"techRequired": "Sailing",
-		"uniques": ["[+1 Gold] <after discovering [Compass]>", "Consumes builder when build"]
+		"uniques": ["[+1 Gold] <after discovering [Compass]>", "Consumes builder when built"]
 	},
 
 	// Military improvement
@@ -174,35 +174,35 @@
 	{
 		"name": "Academy",
 		"science": 8,
-		"uniques": ["Great Improvement", "[+2 Science] <after discovering [Scientific Theory]>", "Consumes builder when build"]
+		"uniques": ["Great Improvement", "[+2 Science] <after discovering [Scientific Theory]>", "Consumes builder when built"]
 	},
 	{
 		"name": "Landmark",
 		"culture": 6,
-		"uniques": ["Great Improvement", "Consumes builder when build"]
+		"uniques": ["Great Improvement", "Consumes builder when built"]
 	},
 	{
 		"name": "Manufactory",
 		"production": 4,
-		"uniques": ["Great Improvement", "[+1 Production] <after discovering [Chemistry]>", "Consumes builder when build"]
+		"uniques": ["Great Improvement", "[+1 Production] <after discovering [Chemistry]>", "Consumes builder when built"]
 	},
 	{
 		"name": "Customs house",
 		"gold": 4,
-		"uniques": ["Great Improvement", "[+1 Gold] <after discovering [Economics]>", "Consumes builder when build"]
+		"uniques": ["Great Improvement", "[+1 Gold] <after discovering [Economics]>", "Consumes builder when built"]
 	},
 	{
 		"name": "Holy site",
 		"faith": 6,
-		"uniques": ["Great Improvement", "Consumes builder when build"]
+		"uniques": ["Great Improvement", "Consumes builder when built"]
 	},
 	{
 		"name": "Citadel",
 		"uniques": [
 			"Great Improvement", "Gives a defensive bonus of [100]%", "Adjacent enemy units ending their turn take [30] damage", 
-			"Can be built just outside your borders", "Adds adjacent tiles to your closest city", "Consumes builder when build"
+			"Can be built just outside your borders", "Constructing it will take over the tiles around it and assign them to your closest city", 
+			"Consumes builder when built"
 		],
-        "civilopediaText": [{"text":"Constructing it will take over the tiles around it and assign them to your closest city"}]
 	},
 
 	//Civilization unique improvements

--- a/android/assets/jsons/Civ V - Vanilla/TileImprovements.json
+++ b/android/assets/jsons/Civ V - Vanilla/TileImprovements.json
@@ -82,7 +82,7 @@
 		"terrainsCanBeBuiltOn": ["Coast"],
 		"food": 1,
 		"techRequired": "Sailing",
-		"uniques": ["[+1 Gold] <after discovering [Compass]>"]
+		"uniques": ["[+1 Gold] <after discovering [Compass]>", "Consumes builder when build"]
 	},
 
 	// Military improvement
@@ -174,31 +174,34 @@
 	{
 		"name": "Academy",
 		"science": 8,
-		"uniques": ["Great Improvement", "[+2 Science] <after discovering [Scientific Theory]>"]
+		"uniques": ["Great Improvement", "[+2 Science] <after discovering [Scientific Theory]>", "Consumes builder when build"]
 	},
 	{
 		"name": "Landmark",
 		"culture": 6,
-		"uniques": ["Great Improvement"]
+		"uniques": ["Great Improvement", "Consumes builder when build"]
 	},
 	{
 		"name": "Manufactory",
 		"production": 4,
-		"uniques": ["Great Improvement", "[+1 Production] <after discovering [Chemistry]>"]
+		"uniques": ["Great Improvement", "[+1 Production] <after discovering [Chemistry]>", "Consumes builder when build"]
 	},
 	{
 		"name": "Customs house",
 		"gold": 4,
-		"uniques": ["Great Improvement", "[+1 Gold] <after discovering [Economics]>"]
+		"uniques": ["Great Improvement", "[+1 Gold] <after discovering [Economics]>", "Consumes builder when build"]
 	},
 	{
 		"name": "Holy site",
 		"faith": 6,
-		"uniques": ["Great Improvement"]
+		"uniques": ["Great Improvement", "Consumes builder when build"]
 	},
 	{
 		"name": "Citadel",
-		"uniques": ["Great Improvement", "Gives a defensive bonus of [100]%", "Adjacent enemy units ending their turn take [30] damage", "Can be built just outside your borders"],
+		"uniques": [
+			"Great Improvement", "Gives a defensive bonus of [100]%", "Adjacent enemy units ending their turn take [30] damage", 
+			"Can be built just outside your borders", "Adds adjacent tiles to your closest city", "Consumes builder when build"
+		],
         "civilopediaText": [{"text":"Constructing it will take over the tiles around it and assign them to your closest city"}]
 	},
 

--- a/android/assets/jsons/Civ V - Vanilla/TileImprovements.json
+++ b/android/assets/jsons/Civ V - Vanilla/TileImprovements.json
@@ -240,7 +240,7 @@
 	},
 	{ 
 		"name": "City center", 
-		"uniques": ["Unpillagable", "Indestructible"],
+		"uniques": ["Unpillagable", "Irremovable"],
         "civilopediaText": [
 			{"text":"Marks the center of a city"},
 			{"text":"Appearance changes with the technological era of the owning civilization"}

--- a/core/src/com/unciv/logic/BarbarianManager.kt
+++ b/core/src/com/unciv/logic/BarbarianManager.kt
@@ -234,7 +234,7 @@ class Encampment() {
                     || it.isCityCenter()
                     || it.getFirstUnit() != null
                     || (it.isWater && !canSpawnBoats)
-                    || (it.hasUnique(UniqueType.FreshWater) && it.isWater) // No Lakes
+                    || (it.terrainHasUnique(UniqueType.FreshWater) && it.isWater) // No Lakes
         }
         if (validTiles.isEmpty()) return false
 

--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -732,7 +732,7 @@ object Battle {
         }
 
         // Pillage improvements, remove roads, add fallout
-        if (tile.improvement != null && !tile.getTileImprovement()!!.hasUnique(UniqueType.Indestructible)) {
+        if (tile.improvement != null && !tile.getTileImprovement()!!.hasUnique(UniqueType.Irremovable)) {
             if (tile.getTileImprovement()!!.hasUnique(UniqueType.Unpillagable)) {
                 tile.improvement = null
             } else {
@@ -743,29 +743,28 @@ object Battle {
         }
         tile.roadStatus = RoadStatus.None
         if (tile.isLand && !tile.isImpassible() && !tile.isCityCenter()) {
-            if (tile.hasUnique(UniqueType.DestroyableByNukesChance)) {
+            if (tile.terrainHasUnique(UniqueType.DestroyableByNukesChance)) {
                 for (terrainFeature in tile.terrainFeatureObjects) {
                     for (unique in terrainFeature.getMatchingUniques(UniqueType.DestroyableByNukesChance)) {
                         if (Random().nextFloat() >= unique.params[0].toFloat() / 100f) continue
                         tile.removeTerrainFeature(terrainFeature.name)
-                        if (!tile.terrainFeatures.contains("Fallout") && !tile.hasUnique(UniqueType.Indestructible))
+                        if (!tile.terrainFeatures.contains("Fallout"))
                             tile.addTerrainFeature("Fallout")
                     }
                 }
-            } else if (Random().nextFloat() < 0.5f && !tile.terrainFeatures.contains("Fallout") && !tile.hasUnique(UniqueType.Indestructible)) {
+            } else if (Random().nextFloat() < 0.5f && !tile.terrainFeatures.contains("Fallout")) {
                 tile.addTerrainFeature("Fallout")
             }
-            if (!tile.hasUnique(UniqueType.DestroyableByNukes)) return
+            if (!tile.terrainHasUnique(UniqueType.DestroyableByNukes)) return
             
             // Deprecated as of 3.19.19 -- If removed, the two successive `if`s above should be merged
-                val destructionChance = if (tile.hasUnique(UniqueType.ResistsNukes)) 0.25f
+                val destructionChance = if (tile.terrainHasUnique(UniqueType.ResistsNukes)) 0.25f
                 else 0.5f
                 if (Random().nextFloat() < destructionChance) {
                     for (terrainFeature in tile.terrainFeatureObjects)
                         if (terrainFeature.hasUnique(UniqueType.DestroyableByNukes))
                             tile.removeTerrainFeature(terrainFeature.name)
-                    if (!tile.hasUnique(UniqueType.Indestructible))
-                        tile.addTerrainFeature("Fallout")
+                    tile.addTerrainFeature("Fallout")
                 }
             //
         }

--- a/core/src/com/unciv/logic/city/CityStats.kt
+++ b/core/src/com/unciv/logic/city/CityStats.kt
@@ -376,7 +376,7 @@ class CityStats(val cityInfo: CityInfo) {
                         || cityInfo.isWorked(it)
                         || it.owningCity == cityInfo && (it.getTileImprovement()
                     ?.hasUnique(UniqueType.TileProvidesYieldWithoutPopulation) == true
-                        || it.hasUnique(UniqueType.TileProvidesYieldWithoutPopulation))
+                        || it.terrainHasUnique(UniqueType.TileProvidesYieldWithoutPopulation))
             })
             stats.add(cell.getTileStats(cityInfo, cityInfo.civInfo))
         statsFromTiles = stats

--- a/core/src/com/unciv/logic/civilization/CivInfoTransientUpdater.kt
+++ b/core/src/com/unciv/logic/civilization/CivInfoTransientUpdater.kt
@@ -121,7 +121,7 @@ class CivInfoTransientUpdater(val civInfo: CivilizationInfo) {
             var goldGained = 0
             val discoveredNaturalWonders = civInfo.gameInfo.civilizations.filter { it != civInfo && it.isMajorCiv() }
                     .flatMap { it.naturalWonders }
-            if (tile.hasUnique(UniqueType.GrantsGoldToFirstToDiscover)
+            if (tile.terrainHasUnique(UniqueType.GrantsGoldToFirstToDiscover)
                     && !discoveredNaturalWonders.contains(tile.naturalWonder!!)) {
                 goldGained += 500
             }

--- a/core/src/com/unciv/logic/map/TileMap.kt
+++ b/core/src/com/unciv/logic/map/TileMap.kt
@@ -360,7 +360,7 @@ class TileMap {
                         || cTileHeight > bNeighborHeight // c>b
                         || (
                             currentTileHeight == bNeighborHeight // a==b
-                            && !bNeighbor.hasUnique(UniqueType.BlocksLineOfSightAtSameElevation)
+                            && !bNeighbor.terrainHasUnique(UniqueType.BlocksLineOfSightAtSameElevation)
                         )
                     )
                 }

--- a/core/src/com/unciv/models/ruleset/tile/TileImprovement.kt
+++ b/core/src/com/unciv/models/ruleset/tile/TileImprovement.kt
@@ -77,12 +77,14 @@ class TileImprovement : RulesetStatsObject() {
     }
     
     fun handleImprovementCompletion(builder: MapUnit) {
+        val tile = builder.getTile()
+        tile.improvement = name
         if (hasUnique(UniqueType.TakesOverAdjacentTiles))
             UnitActions.takeOverTilesAround(builder)
         if (hasUnique(UniqueType.ConsumesBuilder))
             builder.consume()
-        if (builder.getTile().resource != null) {
-            val city = builder.getTile().getCity()
+        if (tile.resource != null) {
+            val city = tile.getCity()
             if (city != null) {
                 city.cityStats.update()
                 city.civInfo.updateDetailedCivResources()

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -583,6 +583,7 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
     ImprovementStatsOnTile("[stats] from [tileFilter] tiles", UniqueTarget.Improvement),
     ImprovementStatsForAdjacencies("[stats] for each adjacent [tileFilter]", UniqueTarget.Improvement),
 
+    ConsumesBuilder("Consumes builder when build", UniqueTarget.Improvement),
     CanBuildOutsideBorders("Can be built outside your borders", UniqueTarget.Improvement),
     CanBuildJustOutsideBorders("Can be built just outside your borders", UniqueTarget.Improvement),
     CanOnlyBeBuiltOnTile("Can only be built on [tileFilter] tiles", UniqueTarget.Improvement),
@@ -595,6 +596,7 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
   
     GreatImprovement("Great Improvement", UniqueTarget.Improvement),
     IsAncientRuinsEquivalent("Provides a random bonus when entered", UniqueTarget.Improvement),
+    TakesOverAdjacentTiles("Adds adjacent tiles to your closest city", UniqueTarget.Improvement),
 
     Unpillagable("Unpillagable", UniqueTarget.Improvement),
     Indestructible("Indestructible", UniqueTarget.Improvement),

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -583,7 +583,7 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
     ImprovementStatsOnTile("[stats] from [tileFilter] tiles", UniqueTarget.Improvement),
     ImprovementStatsForAdjacencies("[stats] for each adjacent [tileFilter]", UniqueTarget.Improvement),
 
-    ConsumesBuilder("Consumes builder when build", UniqueTarget.Improvement),
+    ConsumesBuilder("Consumes builder when built", UniqueTarget.Improvement),
     CanBuildOutsideBorders("Can be built outside your borders", UniqueTarget.Improvement),
     CanBuildJustOutsideBorders("Can be built just outside your borders", UniqueTarget.Improvement),
     CanOnlyBeBuiltOnTile("Can only be built on [tileFilter] tiles", UniqueTarget.Improvement),
@@ -596,7 +596,7 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
   
     GreatImprovement("Great Improvement", UniqueTarget.Improvement),
     IsAncientRuinsEquivalent("Provides a random bonus when entered", UniqueTarget.Improvement),
-    TakesOverAdjacentTiles("Adds adjacent tiles to your closest city", UniqueTarget.Improvement),
+    TakesOverAdjacentTiles("Constructing it will take over the tiles around it and assign them to your closest city", UniqueTarget.Improvement),
 
     Unpillagable("Unpillagable", UniqueTarget.Improvement),
     Irremovable("Irremovable", UniqueTarget.Improvement),
@@ -726,7 +726,7 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
     // region DEPRECATED AND REMOVED
 
     @Deprecated("as of 4.0.12", ReplaceWith("Irremovable"), DeprecationLevel.ERROR)
-    Indestructable("Indestructable", UniqueTarget.Improvement),
+    Indestructible("Indestructible", UniqueTarget.Improvement),
     
     @Deprecated("as of 3.19.1", ReplaceWith("[stats] from every [Wonder]"), DeprecationLevel.ERROR)
     StatsFromWondersDeprecated("[stats] from every Wonder", UniqueTarget.Global, UniqueTarget.FollowerBelief),

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -599,7 +599,6 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
     TakesOverAdjacentTiles("Adds adjacent tiles to your closest city", UniqueTarget.Improvement),
 
     Unpillagable("Unpillagable", UniqueTarget.Improvement),
-    Indestructible("Indestructible", UniqueTarget.Improvement),
     Irremovable("Irremovable", UniqueTarget.Improvement),
     //endregion
 
@@ -726,6 +725,9 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
 
     // region DEPRECATED AND REMOVED
 
+    @Deprecated("as of 4.0.12", ReplaceWith("Irremovable"), DeprecationLevel.ERROR)
+    Indestructable("Indestructable", UniqueTarget.Improvement),
+    
     @Deprecated("as of 3.19.1", ReplaceWith("[stats] from every [Wonder]"), DeprecationLevel.ERROR)
     StatsFromWondersDeprecated("[stats] from every Wonder", UniqueTarget.Global, UniqueTarget.FollowerBelief),
     @Deprecated("as of 3.19.3", ReplaceWith("[stats] from every [buildingFilter] <in cities where this religion has at least [amount] followers>"), DeprecationLevel.ERROR)

--- a/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
@@ -662,8 +662,7 @@ object UnitActions {
                             "Remove $it" !in unitTile.ruleset.tileImprovements ||
                             it in improvement.terrainsCanBeBuiltOn
                         }
-                    ) 
-                    unitTile.improvement = improvementName
+                    )
                     unitTile.improvementInProgress = null
                     unitTile.turnsToImprovement = 0
                     improvement.handleImprovementCompletion(unit)

--- a/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
@@ -16,6 +16,7 @@ import com.unciv.models.UncivSound
 import com.unciv.models.UnitAction
 import com.unciv.models.UnitActionType
 import com.unciv.models.ruleset.Building
+import com.unciv.models.ruleset.unique.StateForConditionals
 import com.unciv.models.ruleset.unique.UniqueTriggerActivation
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.stats.Stat
@@ -454,8 +455,7 @@ object UnitActions {
                 actionList += UnitAction(UnitActionType.HurryResearch,
                     action = {
                         unit.civInfo.tech.addScience(unit.civInfo.tech.getScienceFromGreatScientist())
-                        addStatsPerGreatPersonUsage(unit)
-                        unit.destroy()
+                        unit.consume()
                     }.takeIf { unit.civInfo.tech.currentTechnologyName() != null }
                 )
             }
@@ -464,8 +464,7 @@ object UnitActions {
                 actionList += UnitAction(UnitActionType.StartGoldenAge,
                     action = {
                         unit.civInfo.goldenAges.enterGoldenAge(turnsToGoldenAge)
-                        addStatsPerGreatPersonUsage(unit)
-                        unit.destroy()
+                        unit.consume()
                     }.takeIf { unit.currentTile.getOwner() != null && unit.currentTile.getOwner() == unit.civInfo }
                 )
             }
@@ -483,8 +482,7 @@ object UnitActions {
                             constructIfEnough()
                         }
 
-                        addStatsPerGreatPersonUsage(unit)
-                        unit.destroy()
+                        unit.consume()
                     }.takeIf { canHurryWonder }
                 )
             }
@@ -514,8 +512,7 @@ object UnitActions {
                             constructIfEnough()
                         }
 
-                        addStatsPerGreatPersonUsage(unit)
-                        unit.destroy()
+                        unit.consume()
                     }.takeIf { canHurryConstruction }
                 )
             }
@@ -533,8 +530,7 @@ object UnitActions {
                         tile.owningCity!!.civInfo.getDiplomacyManager(unit.civInfo).addInfluence(influenceEarned)
                         unit.civInfo.addNotification("Your trade mission to [${tile.owningCity!!.civInfo}] has earned you [${goldEarned}] gold and [$influenceEarned] influence!",
                             tile.owningCity!!.civInfo.civName, NotificationIcon.Gold, NotificationIcon.Culture)
-                        addStatsPerGreatPersonUsage(unit)
-                        unit.destroy()
+                        unit.consume()
                     }.takeIf { canConductTradeMission }
                 )
             }
@@ -551,9 +547,8 @@ object UnitActions {
 
     fun getFoundReligionAction(unit: MapUnit): () -> Unit {
         return {
-            addStatsPerGreatPersonUsage(unit)
             unit.civInfo.religionManager.useProphetForFoundingReligion(unit)
-            unit.destroy()
+            unit.consume()
         }
     }
 
@@ -568,9 +563,8 @@ object UnitActions {
 
     fun getEnhanceReligionAction(unit: MapUnit): () -> Unit {
         return {
-            addStatsPerGreatPersonUsage(unit)
             unit.civInfo.religionManager.useProphetForEnhancingReligion(unit)
-            unit.destroy()
+            unit.consume()
         }
     }
 
@@ -593,8 +587,7 @@ object UnitActions {
     private fun useActionWithLimitedUses(unit: MapUnit, action: String) {
         unit.abilityUsesLeft[action] = unit.abilityUsesLeft[action]!! - 1
         if (unit.abilityUsesLeft[action]!! <= 0) {
-            addStatsPerGreatPersonUsage(unit)
-            unit.destroy()
+            unit.consume()
         }
     }
 
@@ -673,16 +666,7 @@ object UnitActions {
                     unitTile.improvement = improvementName
                     unitTile.improvementInProgress = null
                     unitTile.turnsToImprovement = 0
-                    if (improvementName == Constants.citadel)
-                        takeOverTilesAround(unit)
-                    val city = unitTile.getCity()
-                    if (city != null) {
-                        city.cityStats.update()
-                        city.civInfo.updateDetailedCivResources()
-                    }
-                    if (unit.isGreatPerson())
-                        addStatsPerGreatPersonUsage(unit)
-                    unit.destroy()
+                    improvement.handleImprovementCompletion(unit)
                 }.takeIf {
                     resourcesAvailable
                     && unit.currentMovement > 0f
@@ -693,7 +677,7 @@ object UnitActions {
         return finalActions
     }
 
-    private fun takeOverTilesAround(unit: MapUnit) {
+    fun takeOverTilesAround(unit: MapUnit) {
         // This method should only be called for a citadel - therefore one of the neighbour tile
         // must belong to unit's civ, so minByOrNull in the nearestCity formula should be never `null`.
         // That is, unless a mod does not specify the proper unique - then fallbackNearestCity will take over.
@@ -735,26 +719,6 @@ object UnitActions {
 
         for (otherCiv in civsToNotify)
             otherCiv.addNotification("[${unit.civInfo}] has stolen your territory!", unit.currentTile.position, unit.civInfo.civName, NotificationIcon.War)
-    }
-
-    private fun addStatsPerGreatPersonUsage(unit: MapUnit) {
-        if (!unit.isGreatPerson()) return
-
-        val civInfo = unit.civInfo
-
-        val gainedStats = Stats()
-        for (unique in civInfo.getMatchingUniques(UniqueType.ProvidesGoldWheneverGreatPersonExpended)) {
-            gainedStats.gold += (100 * civInfo.gameInfo.gameParameters.gameSpeed.modifier).toInt()
-        }
-        for (unique in civInfo.getMatchingUniques(UniqueType.ProvidesStatsWheneverGreatPersonExpended)) {
-            gainedStats.add(unique.stats)
-        }
-
-        if (gainedStats.isEmpty()) return
-
-        for (stat in gainedStats)
-            civInfo.addStat(stat.key, stat.value.toInt())
-        civInfo.addNotification("By expending your [${unit.name}] you gained [${gainedStats}]!", unit.getTile().position, unit.name)
     }
 
     private fun addFortifyActions(actionList: ArrayList<UnitAction>, unit: MapUnit, showingAdditionalActions: Boolean) {
@@ -864,8 +828,7 @@ object UnitActions {
             if (!unique.conditionals.any { it.type == UniqueType.ConditionalConsumeUnit }) continue
             val unitAction = UnitAction(type = UnitActionType.TriggerUnique, unique.text){
                 UniqueTriggerActivation.triggerCivwideUnique(unique, unit.civInfo)
-                addStatsPerGreatPersonUsage(unit)
-                unit.destroy()
+                unit.consume()
             }
             actionList += unitAction
         }

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -1304,7 +1304,7 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 	Applicable to: Improvement
 
-??? example  "Consumes builder when build"
+??? example  "Consumes builder when built"
 	Applicable to: Improvement
 
 ??? example  "Can be built outside your borders"
@@ -1349,7 +1349,7 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 ??? example  "Provides a random bonus when entered"
 	Applicable to: Improvement
 
-??? example  "Adds adjacent tiles to your closest city"
+??? example  "Constructing it will take over the tiles around it and assign them to your closest city"
 	Applicable to: Improvement
 
 ??? example  "Unpillagable"

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -1304,6 +1304,9 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 	Applicable to: Improvement
 
+??? example  "Consumes builder when build"
+	Applicable to: Improvement
+
 ??? example  "Can be built outside your borders"
 	Applicable to: Improvement
 
@@ -1346,10 +1349,10 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 ??? example  "Provides a random bonus when entered"
 	Applicable to: Improvement
 
-??? example  "Unpillagable"
+??? example  "Adds adjacent tiles to your closest city"
 	Applicable to: Improvement
 
-??? example  "Indestructible"
+??? example  "Unpillagable"
 	Applicable to: Improvement
 
 ??? example  "Irremovable"


### PR DESCRIPTION
More specifically, adds a unique for consuming the builder when finishing building something and for the 'take over adjacent tiles' ability of citadels.
Might have conflicts with whatever @SomeTroglodyte is doing with #6576. I'm fine with waiting for that PR to be merged and changing around it (should only be a renaming of a unique).

Part 1 of me going over the way improvements are build and fixing a few simple things (with the end goal of making it more intuitive and moddable, so that for example https://github.com/yairm210/Unciv/pull/4889#issuecomment-900612942 doesn't happen anymore. Additionally, I want to make it finally possible for multiple improvements to improve the same resource, allowing both oil wells and offshore platforms to improve oil). I'm planning on adding these other changes to this same PR, but this is technically fine to be merged as-is.