### PR TITLE
Fix trade routes not working through open borders

### DIFF
--- a/core/src/com/unciv/logic/civilization/CapitalConnectionsFinder.kt
+++ b/core/src/com/unciv/logic/civilization/CapitalConnectionsFinder.kt
@@ -11,7 +11,7 @@ class CapitalConnectionsFinder(private val civInfo: CivilizationInfo) {
     private var citiesToCheck = mutableListOf(civInfo.getCapital())
     private lateinit var newCitiesToCheck: MutableList<CityInfo>
 
-    private val openBordersCivCities = civInfo.gameInfo.getCities().filter { civInfo.hasOpenBordersTo(it.civInfo) }
+    private val openBordersCivCities = civInfo.gameInfo.getCities().filter { it.civInfo.hasOpenBordersTo(civInfo) }
 
     private val harbor = "Harbor"   // hardcoding at least centralized for this class for now
     private val road = RoadStatus.Road.name
@@ -94,7 +94,7 @@ class CapitalConnectionsFinder(private val civInfo: CivilizationInfo) {
 
         val bfs = BFS(cityToConnectFrom.getCenterTile()) {
               val owner = it.getOwner()
-              (it.isCityCenter() || tileFilter(it)) && (owner == null || civInfo.hasOpenBordersTo(owner))
+              (it.isCityCenter() || tileFilter(it)) && (owner == null || owner.hasOpenBordersTo(civInfo))
         }
         bfs.stepToEnd()
         val reachedCities = openBordersCivCities.filter {

--- a/tests/src/com/unciv/logic/civilization/CapitalConnectionsFinderTests.kt
+++ b/tests/src/com/unciv/logic/civilization/CapitalConnectionsFinderTests.kt
@@ -123,9 +123,10 @@ class CapitalConnectionsFinderTests {
     }
 
     private fun meetCivAndSetBorders(name: String, areBordersOpen: Boolean) {
-        ourCiv.diplomacy[name] = DiplomacyManager(ourCiv, name)
+        val otherCiv = civilizations[name]!!
+        otherCiv.diplomacy[ourCiv.civName] = DiplomacyManager(otherCiv, ourCiv.civName)
             .apply { diplomaticStatus = DiplomaticStatus.Peace }
-        ourCiv.diplomacy[name]!!.hasOpenBorders = areBordersOpen
+        otherCiv.diplomacy[ourCiv.civName]!!.hasOpenBorders = areBordersOpen
     }
 
     @Test


### PR DESCRIPTION
Fixes #6683

Of course, when we check for open borders, we have to check if *the other civ* has open borders towards *us*, not the other way around.

Save game to check/reproduce is in the issue.