### PR TITLE
Reviewed version of the unit's teleportation

### DIFF
--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -868,8 +868,12 @@ class MapUnit {
         }
         if (tile.improvement == Constants.barbarianEncampment && !civInfo.isBarbarian())
             clearEncampment(tile)
+        // Check whether any civilians without military units are there.
+        // Keep in mind that putInTile(), which calls this method,
+        // might has already placed your military unit in this tile.
+        val unguardedCivilian = tile.getUnguardedCivilian(this)
         // Capture Enemy Civilian Unit if you move on top of it
-        if (isMilitary() && tile.getUnguardedCivilian() != null && civInfo.isAtWarWith(tile.getUnguardedCivilian()!!.civInfo)) {
+        if (isMilitary() && unguardedCivilian != null && civInfo.isAtWarWith(unguardedCivilian.civInfo)) {
             Battle.captureCivilianUnit(MapUnitCombatant(this), MapUnitCombatant(tile.civilianUnit!!))
         }
 

--- a/core/src/com/unciv/logic/map/TileInfo.kt
+++ b/core/src/com/unciv/logic/map/TileInfo.kt
@@ -145,8 +145,8 @@ open class TileInfo {
     }
 
     /** Return null if military/air units on tile, or no civilian */
-    fun getUnguardedCivilian(): MapUnit? {
-        if (militaryUnit != null) return null
+    fun getUnguardedCivilian(attacker: MapUnit): MapUnit? {
+        if (militaryUnit != null && militaryUnit != attacker) return null
         if (airUnits.isNotEmpty()) return null
         if (civilianUnit != null) return civilianUnit!!
         return null

--- a/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
+++ b/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
@@ -381,7 +381,10 @@ class UnitMovementAlgorithms(val unit: MapUnit) {
         while (allowedTile == null && distance < 5) {
             distance++
             allowedTile = unit.getTile().getTilesAtDistance(distance)
-                    .firstOrNull { canMoveTo(it) }
+                // can the unit be placed safely there?
+                .filter { canMoveTo(it) }
+                // out of those where it can be placed, can it reach them in any meaningful way?
+                .firstOrNull { getPathBetweenTiles(unit.currentTile, it).size > 1 }
         }
 
         // No tile within 4 spaces? move him to a city.
@@ -713,6 +716,21 @@ class UnitMovementAlgorithms(val unit: MapUnit) {
         pathsToCities.remove(startingTile)
         return pathsToCities
     }
+
+    /**
+     * @returns the set of [TileInfo] between [from] and [to] tiles.
+     * It takes into account the terrain and units possibilities of entering the terrain,
+     * however ignores the diplomatic aspects of such movement like crossing closed borders.
+     */
+    private fun getPathBetweenTiles(from: TileInfo, to: TileInfo): MutableSet<TileInfo> {
+        val tmp = unit.canEnterForeignTerrain
+        unit.canEnterForeignTerrain = true // the trick to ignore tiles owners
+        val bfs = BFS(from) { canMoveTo(it) }
+        bfs.stepUntilDestination(to)
+        unit.canEnterForeignTerrain = tmp
+        return bfs.getReachedTiles()
+    }
+
 }
 
 class PathsToTilesWithinTurn : LinkedHashMap<TileInfo, UnitMovementAlgorithms.ParentTileAndTotalDistance>() {

--- a/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
+++ b/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
@@ -657,13 +657,17 @@ class UnitMovementAlgorithms(val unit: MapUnit) {
 
         if (!unit.canEnterForeignTerrain && !tile.canCivPassThrough(unit.civInfo)) return false
 
+        // The first unit is:
+        //   1. Either military unit
+        //   2. or unprotected civilian
+        //   3. or unprotected air unit while no civilians on tile
         val firstUnit = tile.getFirstUnit()
         // Moving to non-empty tile
         if (firstUnit != null && unit.civInfo != firstUnit.civInfo) {
             // Allow movement through unguarded, at-war Civilian Unit. Capture on the way 
             // But not for Embarked Units capturing on Water
             if (!(unit.isEmbarked() && tile.isWater)
-                    && tile.getUnguardedCivilian() != null && unit.civInfo.isAtWarWith(tile.civilianUnit!!.civInfo))
+                    && firstUnit.isCivilian() && unit.civInfo.isAtWarWith(firstUnit.civInfo))
                 return true
             // Cannot enter hostile tile with any unit in there
             if (unit.civInfo.isAtWarWith(firstUnit.civInfo))


### PR DESCRIPTION
Fixes #4923 and resolves issue mentioned in https://github.com/yairm210/Unciv/issues/5798#issuecomment-1094220756 

Here we solve 2 problems:
1) When the military unit was teleported onto the enemy civilian, the latest was not captured.
Now it is.
2) When the unit was teleported it might appear in the place of no return, where it could not reach technically, e.g. in trap between mountains or a ship into the lake, etc.
Now the path to the destination point is something real which could be made by a unit being "escorted" from the expelled territory.