### PR TITLE
Fix missing translatables again

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -654,6 +654,7 @@ No problems found. =
 Autoupdate mod uniques = 
 Uniques updated! = 
 
+Max zoom out = 
 Show experimental world wrap for maps = 
 HIGHLY EXPERIMENTAL - YOU HAVE BEEN WARNED! = 
 Enable portrait orientation = 
@@ -781,7 +782,6 @@ Our [name] took [tileDamage] tile damage and was destroyed =
 Our [name] took [tileDamage] tile damage = 
 [civName] has adopted the [policyName] policy = 
 An unknown civilization has adopted the [policyName] policy = 
-Our influence with City-States has started dropping faster! = 
 You gained [Stats] as your religion was spread to [cityName] = 
 You gained [Stats] as your religion was spread to an unknown city = 
 Your city [cityName] was converted to [religionName]! = 

--- a/core/src/com/unciv/models/ruleset/Building.kt
+++ b/core/src/com/unciv/models/ruleset/Building.kt
@@ -12,6 +12,7 @@ import com.unciv.models.translations.fillPlaceholders
 import com.unciv.models.translations.tr
 import com.unciv.ui.civilopedia.FormattedLine
 import com.unciv.ui.utils.Fonts
+import com.unciv.ui.utils.getConsumesAmountString
 import com.unciv.ui.utils.toPercent
 import kotlin.math.pow
 
@@ -109,13 +110,13 @@ class Building : RulesetStatsObject(), INonPerpetualConstruction {
         if (isWonder) lines += "Wonder"
         if (isNationalWonder) lines += "National Wonder"
         if (!isFree) {
-            val availableResources = if(!showAdditionalInfo) emptyMap()
+            val availableResources = if (!showAdditionalInfo) emptyMap()
                 else cityInfo.civInfo.getCivResources().associate { it.resource.name to it.amount }
             for ((resource, amount) in getResourceRequirements()) {
                 val available = availableResources[resource] ?: 0
                 lines += if (showAdditionalInfo)
-                    "{Consumes [$amount] [$resource]} ({[$available] available})"
-                else "Consumes [$amount] [$resource]"
+                        "{${resource.getConsumesAmountString(amount)}} ({[$available] available})"
+                    else resource.getConsumesAmountString(amount)
             }
         }
 
@@ -244,7 +245,7 @@ class Building : RulesetStatsObject(), INonPerpetualConstruction {
             for ((resource, amount) in resourceRequirements) {
                 textList += FormattedLine(
                     // the 1 variant should deprecate some time
-                    if (amount == 1) "Consumes 1 [$resource]" else "Consumes [$amount] [$resource]",
+                    resource.getConsumesAmountString(amount),
                     link="Resources/$resource", color="#F42" )
             }
         }
@@ -650,7 +651,7 @@ class Building : RulesetStatsObject(), INonPerpetualConstruction {
 
         for ((resource, amount) in getResourceRequirements())
             if (civInfo.getCivResourcesByName()[resource]!! < amount) {
-                rejectionReasons.add(RejectionReason.ConsumesResources.toInstance("Consumes [$amount] [$resource]" ))
+                rejectionReasons.add(RejectionReason.ConsumesResources.toInstance(resource.getConsumesAmountString(amount)))
             }
 
         if (requiredNearbyImprovedResources != null) {

--- a/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
@@ -502,6 +502,8 @@ enum class UniqueParameterType(
         override fun getTranslationWriterStringsForOutput() = scanExistingValues(this)
     },
 
+    /** We don't know anything about this parameter - this needs to return
+     *  [isTranslationWriterGuess]() == `true` for all inputs or TranslationFileWriter will have a problem! */
     Unknown("param", "Unknown") {
         override fun getErrorSeverity(parameterText: String, ruleset: Ruleset):
                 UniqueType.UniqueComplianceErrorSeverity? = null

--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -14,6 +14,7 @@ import com.unciv.models.translations.tr
 import com.unciv.ui.civilopedia.FormattedLine
 import com.unciv.ui.utils.Fonts
 import com.unciv.ui.utils.filterAndLogic
+import com.unciv.ui.utils.getConsumesAmountString
 import com.unciv.ui.utils.toPercent
 import kotlin.collections.ArrayList
 import kotlin.collections.HashMap
@@ -78,7 +79,7 @@ class BaseUnit : RulesetObject(), INonPerpetualConstruction {
         val availableResources = cityInfo.civInfo.getCivResources().associate { it.resource.name to it.amount }
         for ((resource, amount) in getResourceRequirements()) {
             val available = availableResources[resource] ?: 0
-            lines += "Consumes ${if (amount == 1) "1" else "[$amount]"} [$resource] ({[$available] available})".tr()
+            lines += "{${resource.getConsumesAmountString(amount)}} ({[$available] available})".tr()
         }
         var strengthLine = ""
         if (strength != 0) {
@@ -147,7 +148,7 @@ class BaseUnit : RulesetObject(), INonPerpetualConstruction {
             textList += FormattedLine()
             for ((resource, amount) in resourceRequirements) {
                 textList += FormattedLine(
-                    if (amount == 1) "Consumes 1 [$resource]" else "Consumes [$amount] [$resource]",
+                    resource.getConsumesAmountString(amount),
                     link = "Resource/$resource", color = "#F42"
                 )
             }
@@ -441,7 +442,7 @@ class BaseUnit : RulesetObject(), INonPerpetualConstruction {
         if (!civInfo.isBarbarian()) { // Barbarians don't need resources
             for ((resource, amount) in getResourceRequirements())
                 if (civInfo.getCivResourcesByName()[resource]!! < amount) {
-                    rejectionReasons.add(RejectionReason.ConsumesResources.toInstance("Consumes [$amount] [$resource]"))
+                    rejectionReasons.add(RejectionReason.ConsumesResources.toInstance(resource.getConsumesAmountString(amount)))
                 }
         }
 

--- a/core/src/com/unciv/models/translations/TranslationFileWriter.kt
+++ b/core/src/com/unciv/models/translations/TranslationFileWriter.kt
@@ -344,6 +344,8 @@ object TranslationFileWriter {
                         UniqueParameterType.guessTypeForTranslationWriter(parameter, ruleset).parameterName
                     }
                 parameterNames.addNumberedParameter(parameterName)
+                if (parameterName == UniqueParameterType.Unknown.parameterName)
+                    resultStrings.add("$parameter = ")  // Unknown parameter contents better be offered to translators too
             }
             resultStrings.add("${stringToTranslate.fillPlaceholders(*parameterNames.toTypedArray())} = ")
         }

--- a/core/src/com/unciv/ui/cityscreen/CityConstructionsTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityConstructionsTable.kt
@@ -173,10 +173,7 @@ class CityConstructionsTable(private val cityScreen: CityScreen) {
             val useStoredProduction = entry is Building || !cityConstructions.isBeingConstructedOrEnqueued(entry.name)
             var buttonText = entry.name.tr() + cityConstructions.getTurnsToConstructionString(entry.name, useStoredProduction)
             for ((resource, amount) in entry.getResourceRequirements()) {
-                buttonText += "\n" + (
-                    if (amount == 1) "Consumes 1 [$resource]"
-                    else "Consumes [$amount] [$resource]"
-                ).tr()
+                buttonText += "\n" + resource.getConsumesAmountString(amount).tr()
             }
 
             constructionButtonDTOList.add(
@@ -277,8 +274,7 @@ class CityConstructionsTable(private val cityScreen: CityScreen) {
 
         val constructionResource = cityConstructions.getConstruction(constructionName).getResourceRequirements()
         for ((resource, amount) in constructionResource)
-            text += if (amount == 1) "\n" + "Consumes 1 [$resource]".tr()
-                else "\n" + "Consumes [$amount] [$resource]".tr()
+            text += "\n" + resource.getConsumesAmountString(amount).tr()
 
         table.defaults().pad(2f).minWidth(40f)
         if (isFirstConstructionOfItsKind) table.add(getProgressBar(constructionName)).minWidth(5f)

--- a/core/src/com/unciv/ui/overviewscreen/ReligionOverviewTable.kt
+++ b/core/src/com/unciv/ui/overviewscreen/ReligionOverviewTable.kt
@@ -152,7 +152,7 @@ class ReligionOverviewTab(
         val manager = religion.getFounder().religionManager
         statsTable.add("Cities following this religion:".toLabel())
         statsTable.add(manager.numberOfCitiesFollowingThisReligion().toLabel()).right().row()
-        statsTable.add("{Followers of this religion}:".toLabel())
+        statsTable.add("Followers of this religion:".toLabel())
         statsTable.add(manager.numberOfFollowersFollowingThisReligion("in all cities").toLabel()).right().row()
 
         val minWidth = max(statsTable.minWidth, beliefsTable.minWidth) + 5

--- a/core/src/com/unciv/ui/trade/DiplomacyScreen.kt
+++ b/core/src/com/unciv/ui/trade/DiplomacyScreen.kt
@@ -930,9 +930,9 @@ class DiplomacyScreen(
         rightSideTable.clear()
         rightSideTable.add(diplomacyTable)
     }
-    
+
     private fun getGoToOnMapButton(civilization: CivilizationInfo): TextButton {
-        val goToOnMapButton = TextButton("Go to on map", skin)
+        val goToOnMapButton = "Go to on map".toTextButton()
         goToOnMapButton.onClick {
             UncivGame.Current.setWorldScreen()
             UncivGame.Current.worldScreen.mapHolder.setCenterPosition(civilization.getCapital().location, selectUnit = false)

--- a/core/src/com/unciv/ui/utils/ExtensionFunctions.kt
+++ b/core/src/com/unciv/ui/utils/ExtensionFunctions.kt
@@ -372,3 +372,11 @@ fun <T> String.filterCompositeLogic(predicate: (String) -> T?, operation: (T, T)
  *  otherwise return `null` for Elvis chaining of the individual filter. */
 fun String.filterAndLogic(predicate: (String) -> Boolean): Boolean? =
     if (contains('{')) filterCompositeLogic(predicate) { a, b -> a && b } else null
+
+
+/** Convert a [resource name][this] into "Consumes [amount] $resource" string (untranslated, using separate templates for 1 and other amounts) */
+//todo some day... remove and use just one translatable where this is called
+fun String.getConsumesAmountString(amount: Int) = (
+            if (amount == 1) "Consumes 1 [$this]"
+            else "Consumes [$amount] [$this]"
+        )


### PR DESCRIPTION
Fixes #6131 again - but please read the question in my [last comment](https://github.com/yairm210/Unciv/issues/6131#issuecomment-1119092403) over there - this PR opts for the "slightly more complex with meatballs" answer to that question.

That getConsumesAmountString is a global extension function only so I could find a nice place for it (to respect the _filename_, not a kotlin constraint). The comments "this could be just [amount] [resource]" still apply (though there may be languages having a use for the distinction), but at least _all_ places are now referencing that function and can be found with Alt-F7. tr() not folded in on purpose, some uses could otherwise not avoid a double tr.