### PR TITLE
Assist on downloading of the missing mods

### DIFF
--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -19,7 +19,8 @@ import com.unciv.ui.audio.MusicTrackChooserFlags
 import java.util.*
 
 
-class UncivShowableException(missingMods: String) : Exception(missingMods)
+class MissingModsException(val missingMods: String) : UncivShowableException("Missing mods: [$missingMods]")
+open class UncivShowableException(errorText: String) : Exception(errorText)
 
 class GameInfo {
     //region Fields - Serialized
@@ -402,7 +403,7 @@ class GameInfo {
             .filterNot { it in ruleSet.mods }
             .joinToString(limit = 120) { it }
         if (missingMods.isNotEmpty()) {
-            throw UncivShowableException("Missing mods: [$missingMods]")
+            throw MissingModsException(missingMods)
         }
 
         removeMissingModReferences()

--- a/core/src/com/unciv/ui/pickerscreens/GitHub.kt
+++ b/core/src/com/unciv/ui/pickerscreens/GitHub.kt
@@ -219,8 +219,8 @@ object Github {
      * @return              Parsed [RepoSearch] json on success, `null` on failure.
      * @see <a href="https://docs.github.com/en/rest/reference/search#search-repositories">Github API doc</a>
      */
-    fun tryGetGithubReposWithTopic(amountPerPage:Int, page:Int): RepoSearch? {
-        val link = "https://api.github.com/search/repositories?q=topic:unciv-mod&sort:stars&per_page=$amountPerPage&page=$page"
+    fun tryGetGithubReposWithTopic(amountPerPage:Int, page:Int, searchRequest: String = ""): RepoSearch? {
+        val link = "https://api.github.com/search/repositories?q=${searchRequest}topic:unciv-mod&sort:stars&per_page=$amountPerPage&page=$page"
         var retries = 2
         while (retries > 0) {
             retries--

--- a/core/src/com/unciv/ui/pickerscreens/GitHub.kt
+++ b/core/src/com/unciv/ui/pickerscreens/GitHub.kt
@@ -1,4 +1,4 @@
-package com.unciv.ui.worldscreen.mainmenu
+package com.unciv.ui.pickerscreens
 
 import com.badlogic.gdx.Files
 import com.badlogic.gdx.files.FileHandle

--- a/core/src/com/unciv/ui/pickerscreens/GitHub.kt
+++ b/core/src/com/unciv/ui/pickerscreens/GitHub.kt
@@ -2,7 +2,11 @@ package com.unciv.ui.pickerscreens
 
 import com.badlogic.gdx.Files
 import com.badlogic.gdx.files.FileHandle
+import com.badlogic.gdx.utils.Json
+import com.unciv.JsonParser
+import com.unciv.logic.BackwardCompatibility.updateDeprecations
 import com.unciv.logic.GameSaver
+import com.unciv.models.ruleset.ModOptions
 import java.io.*
 import java.net.HttpURLConnection
 import java.net.URL
@@ -303,6 +307,21 @@ object Github {
     class RepoOwner {
         var login = ""
         var avatar_url: String? = null
+    }
+
+    /** Rewrite modOptions file for a mod we just installed to include metadata we got from the GitHub api
+     *
+     *  (called on background thread)
+     */
+    fun rewriteModOptions(repo: Repo, modFolder: FileHandle) {
+        val modOptionsFile = modFolder.child("jsons/ModOptions.json")
+        val modOptions = if (modOptionsFile.exists()) JsonParser().getFromJson(ModOptions::class.java, modOptionsFile) else ModOptions()
+        modOptions.modUrl = repo.html_url
+        modOptions.lastUpdated = repo.pushed_at
+        modOptions.author = repo.owner.login
+        modOptions.modSize = repo.size
+        modOptions.updateDeprecations()
+        Json().toJson(modOptions, modOptionsFile)
     }
 }
 

--- a/core/src/com/unciv/ui/pickerscreens/ModManagementOptions.kt
+++ b/core/src/com/unciv/ui/pickerscreens/ModManagementOptions.kt
@@ -11,7 +11,6 @@ import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.newgamescreen.TranslatedSelectBox
 import com.unciv.ui.utils.*
 import com.unciv.ui.utils.UncivTooltip.Companion.addTooltip
-import com.unciv.ui.worldscreen.mainmenu.Github
 import kotlin.math.sign
 
 /**

--- a/core/src/com/unciv/ui/pickerscreens/ModManagementScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/ModManagementScreen.kt
@@ -25,7 +25,6 @@ import com.unciv.ui.popup.ToastPopup
 import com.unciv.ui.popup.YesNoPopup
 import com.unciv.ui.utils.UncivDateFormat.formatDate
 import com.unciv.ui.utils.UncivDateFormat.parseDate
-import com.unciv.ui.worldscreen.mainmenu.Github
 import java.util.*
 import kotlin.collections.HashMap
 import kotlin.math.max

--- a/core/src/com/unciv/ui/saves/LoadGameScreen.kt
+++ b/core/src/com/unciv/ui/saves/LoadGameScreen.kt
@@ -162,9 +162,10 @@ class LoadGameScreen(previousScreen:BaseScreen) : PickerScreen(disableScroll = t
             try {
                 val mods = missingModsToLoad.replace(' ', '-').lowercase().splitToSequence(",-")
                 for (modName in mods) {
-                    val repos = Github.tryGetGithubReposWithTopic(10, 1, modName)
-                        ?: throw Exception("Could not download mod list")
-                    val repo = repos.items.first { it.name.lowercase() == modName }
+                    val repos = Github.tryGetGithubReposWithTopic(10, 1, "$modName+") // + is important here!
+                        ?: throw UncivShowableException("Could not download mod list")
+                    val repo = repos.items.firstOrNull { it.name.lowercase() == modName }
+                        ?: throw UncivShowableException("The $modName is not found.")
                     val modFolder = Github.downloadAndExtract(
                         repo.html_url, repo.default_branch,
                         Gdx.files.local("mods")

--- a/core/src/com/unciv/ui/saves/LoadGameScreen.kt
+++ b/core/src/com/unciv/ui/saves/LoadGameScreen.kt
@@ -106,7 +106,8 @@ class LoadGameScreen(previousScreen:BaseScreen) : PickerScreen(disableScroll = t
                             game.loadGame(gameInfo)
                         }
                     } else if (exception !is CancellationException) {
-                        errorLabel.setText("Could not load game from custom location!".tr())
+                        val errorText = if (exception is UncivShowableException) "\n${exception.message}" else ""
+                        errorLabel.setText("Could not load game from custom location!".tr() + errorText)
                         exception?.printStackTrace()
                     }
                 }


### PR DESCRIPTION
Let's imagine the story: 
You are eager to fix yet another pesky bug and (what a luck!) you even got the saved file to reproduce it.
You try to load it and... 💥  

| Have you ever seen this screen? | ...or if you lucky enough, you know the reason, at least: |
| - | - |
| ![Screenshot 2022-05-07 19-34-02](https://user-images.githubusercontent.com/27405436/167263816-df9714e7-b792-469a-afd8-39a0c3400fc4.png) |  ![Screenshot 2022-05-07 19-34-28](https://user-images.githubusercontent.com/27405436/167263984-c89f51f9-192b-405f-aa71-841961f551a8.png) |

Previously, you had to go to the mod options, seaching for the given mods (if you are lucky to remember all their names), download them and return back to the load screen to try again. Too looooong and complicated.

Now you are 2 clicks away from loading the game since the magic button "Download missing mods" has appeared.

<img src="https://user-images.githubusercontent.com/27405436/167264254-301b2b2f-3fa7-4748-8a94-dd3948e8fd84.png" width="500px" >

Just click on it and the missing mods will be downloaded for you to try loading the game once again.
P.S. Of course, it appears only if the loading error is caused by missing mods.


