### PR TITLE
Bug fix in Demographics scoreboard

### DIFF
--- a/core/src/com/unciv/ui/victoryscreen/VictoryScreen.kt
+++ b/core/src/com/unciv/ui/victoryscreen/VictoryScreen.kt
@@ -202,8 +202,8 @@ class VictoryScreen(val worldScreen: WorldScreen) : PickerScreen() {
 
                 @Suppress("NON_EXHAUSTIVE_WHEN") // RankLabels.Demographic treated above
                 when (rankLabel) {
-                    RankLabels.Rank -> demographicsTable.add((aliveMajorCivsSorted.indexOfFirst { it == gameInfo.currentPlayerCiv } + 1).toLabel())
-                    RankLabels.Value -> addRankCivGroup(gameInfo.currentPlayerCiv)
+                    RankLabels.Rank -> demographicsTable.add((aliveMajorCivsSorted.indexOfFirst { it == worldScreen.viewingCiv } + 1).toLabel())
+                    RankLabels.Value -> addRankCivGroup(worldScreen.viewingCiv)
                     RankLabels.Best -> addRankCivGroup(aliveMajorCivsSorted.firstOrNull()!!)
                     RankLabels.Average -> demographicsTable.add((aliveMajorCivsSorted.sumOf { it.getStatForRanking(category) } / aliveMajorCivsSorted.count()).toLabel())
                     RankLabels.Worst -> addRankCivGroup(aliveMajorCivsSorted.lastOrNull()!!)


### PR DESCRIPTION
Corrected bug in Demographics scoreboard which displayed current player stats based on turn order, not viewing civ. The bug would lead to players seeing other players' rank or value instead of their own while waiting for a turn in a multiplayer game.