### PR TITLE
Fix old barbarian camps not being properly loaded after 86d5011

### DIFF
--- a/core/src/com/unciv/json/HashMapVector2.kt
+++ b/core/src/com/unciv/json/HashMapVector2.kt
@@ -9,15 +9,19 @@ import java.util.HashMap
  */
 class HashMapVector2<T> : HashMap<Vector2, T>() {
     companion object {
-        init {
+        fun createSerializer(): NonStringKeyMapSerializer<MutableMap<Vector2, Any>, Vector2> {
             @Suppress("UNCHECKED_CAST") // kotlin can't tell that HashMapVector2 is also a MutableMap within generics
             val mapClass = HashMapVector2::class.java as Class<MutableMap<Vector2, Any>>
-            val serializer = NonStringKeyMapSerializer(
+            return NonStringKeyMapSerializer(
                 mapClass,
                 Vector2::class.java,
-                { HashMapVector2<Any>() }
+                { HashMapVector2() }
             )
-            jsonSerializers.add(Pair(mapClass, serializer))
+        }
+
+        fun getSerializerClass(): Class<MutableMap<Vector2, Any>> {
+            @Suppress("UNCHECKED_CAST") // kotlin can't tell that HashMapVector2 is also a MutableMap within generics
+            return HashMapVector2::class.java as Class<MutableMap<Vector2, Any>>
         }
     }
 }

--- a/core/src/com/unciv/json/NonStringKeyMapSerializer.kt
+++ b/core/src/com/unciv/json/NonStringKeyMapSerializer.kt
@@ -67,7 +67,7 @@ class NonStringKeyMapSerializer<MT: MutableMap<KT, Any>, KT>(
         while (entry != null) {
             val key = json.readValue(keyClass, entry.child)
             val value = json.readValue<Any>(null, entry.child.next)
-            result[key!!] = value!! as Any
+            result[key!!] = value!!
 
             entry = entry.next
         }

--- a/core/src/com/unciv/json/UncivJson.kt
+++ b/core/src/com/unciv/json/UncivJson.kt
@@ -2,10 +2,10 @@ package com.unciv.json
 
 import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.files.FileHandle
+import com.badlogic.gdx.math.Vector2
 import com.badlogic.gdx.utils.Json
 import com.badlogic.gdx.utils.Json.Serializer
 
-internal val jsonSerializers = ArrayList<Pair<Class<*>, Serializer<*>>>()
 
 /**
  * [Json] is not thread-safe. Use a new one for each parse.
@@ -13,10 +13,8 @@ internal val jsonSerializers = ArrayList<Pair<Class<*>, Serializer<*>>>()
 fun json() = Json().apply {
     setIgnoreDeprecated(true)
     ignoreUnknownFields = true
-    for ((clazz, serializer) in jsonSerializers) {
-        @Suppress("UNCHECKED_CAST") // we used * to accept all types, so kotlin can't know if the class & serializer parameters are actually the same
-        setSerializer(clazz as Class<Any>, serializer as Serializer<Any>)
-    }
+
+    setSerializer(HashMapVector2.getSerializerClass(), HashMapVector2.createSerializer())
 }
 
 fun <T> Json.fromJsonFile(tClass: Class<T>, filePath: String): T = fromJsonFile(tClass, Gdx.files.internal(filePath))

--- a/core/src/com/unciv/json/UncivJson.kt
+++ b/core/src/com/unciv/json/UncivJson.kt
@@ -8,7 +8,7 @@ import com.badlogic.gdx.utils.Json.Serializer
 internal val jsonSerializers = ArrayList<Pair<Class<*>, Serializer<*>>>()
 
 /**
- * [Json] is not thread-safe.
+ * [Json] is not thread-safe. Use a new one for each parse.
  */
 fun json() = Json().apply {
     setIgnoreDeprecated(true)

--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -3,6 +3,7 @@ package com.unciv.logic
 import com.unciv.Constants
 import com.unciv.UncivGame
 import com.unciv.logic.BackwardCompatibility.guaranteeUnitPromotions
+import com.unciv.logic.BackwardCompatibility.migrateBarbarianCamps
 import com.unciv.logic.BackwardCompatibility.migrateSeenImprovements
 import com.unciv.logic.BackwardCompatibility.removeMissingModReferences
 import com.unciv.logic.automation.NextTurnAutomation
@@ -398,6 +399,7 @@ class GameInfo {
         }
         // [TEMPORARY] Convert old saves to remove json workaround
         for (civInfo in civilizations) civInfo.migrateSeenImprovements()
+        barbarians.migrateBarbarianCamps()
 
         ruleSet = RulesetCache.getComplexRuleset(gameParameters)
 


### PR DESCRIPTION
In https://github.com/yairm210/Unciv/pull/6720#issuecomment-1120311197, I said that barb migration should not be necessary, but I tested wrongly. The `camps` property actually needs migration from the old data format.

The problem is that when changing the type of the property and supplying this new custom serializer, of course the new serializer is always used. But since the data is still in the old format, the serializer doesn't deserialize correctly since it assumes the new format.

So I had to add a switch in the serializer itself, changing its behavior depending on if there are still `String` keys in the map to use the old deserialization (this is a direct copy of the code in `Json.readValue` for all `instanceof Map` values) or the new one if there are not.