### PR TITLE
Allow untyped Uniques in MapUnit UniqueMap

### DIFF
--- a/core/src/com/unciv/logic/city/CityConstructions.kt
+++ b/core/src/com/unciv/logic/city/CityConstructions.kt
@@ -451,9 +451,7 @@ class CityConstructions {
     fun updateUniques() {
         builtBuildingUniqueMap.clear()
         for (building in getBuiltBuildings())
-            for (unique in building.uniqueObjects)
-                if (unique.conditionals.none { it.type == UniqueType.ConditionalTimedUnique })
-                    builtBuildingUniqueMap.addUnique(unique)
+            builtBuildingUniqueMap.addUniques(building.uniqueObjects)
     }
 
     fun addFreeBuildings() {

--- a/core/src/com/unciv/logic/civilization/PolicyManager.kt
+++ b/core/src/com/unciv/logic/civilization/PolicyManager.kt
@@ -112,9 +112,8 @@ class PolicyManager {
             // Should be deprecated together with TimedAttackStrength so
             // I'm putting this here so the compiler will complain if we don't
             val rememberToDeprecate = UniqueType.TimedAttackStrength
-            if (!unique.text.contains(turnCountRegex) && unique.conditionals.none { it.type == UniqueType.ConditionalTimedUnique }) policyUniques.addUnique(
-                unique
-            )
+            if (!unique.text.contains(turnCountRegex)) 
+                policyUniques.addUnique(unique)
         }
     }
 

--- a/core/src/com/unciv/logic/civilization/TechManager.kt
+++ b/core/src/com/unciv/logic/civilization/TechManager.kt
@@ -366,9 +366,7 @@ class TechManager {
     }
 
     fun addTechToTransients(tech: Technology) {
-        for (unique in tech.uniqueObjects)
-            if (unique.conditionals.none { it.type == UniqueType.ConditionalTimedUnique })
-                techUniques.addUnique(unique)
+        techUniques.addUniques(tech.uniqueObjects)
     }
 
     fun setTransients() {

--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -296,11 +296,9 @@ class MapUnit {
         }
 
         tempUniques = uniques
-        val newUniquesMap = UniqueMap()
-        for (unique in uniques)
-            if (unique.type != null)
-                newUniquesMap.addUnique(unique)
-        tempUniquesMap = newUniquesMap
+        tempUniquesMap = UniqueMap().apply {
+            addUniques(uniques)
+        }
 
         allTilesCosts1 = hasUnique(UniqueType.AllTilesCost1Move)
         canPassThroughImpassableTiles = hasUnique(UniqueType.CanPassImpassable)

--- a/core/src/com/unciv/models/ruleset/unique/Unique.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Unique.kt
@@ -283,9 +283,17 @@ class UniqueMap: HashMap<String, ArrayList<Unique>>() {
     //todo Once all untyped Uniques are converted, this should be  HashMap<UniqueType, *>
     // For now, we can have both map types "side by side" each serving their own purpose,
     // and gradually this one will be deprecated in favor of the other
+
+    /** Adds one [unique] unless it has a ConditionalTimedUnique conditional */
     fun addUnique(unique: Unique) {
+        if (unique.conditionals.any { it.type == UniqueType.ConditionalTimedUnique }) return
         if (!containsKey(unique.placeholderText)) this[unique.placeholderText] = ArrayList()
         this[unique.placeholderText]!!.add(unique)
+    }
+
+    /** Calls [addUnique] on each item from [uniques] */
+    fun addUniques(uniques: Iterable<Unique>) {
+        for (unique in uniques) addUnique(unique)
     }
 
     fun getUniques(placeholderText: String): Sequence<Unique> {


### PR DESCRIPTION
One way to fix #6731 - re-enable untyped Uniques to participate in UniqueMap. Also refactors some very common code into UniqueMap - with the **_side effect_** that now Unit/Promotion Uniques with a ConditionalTimedUnique conditional are excluded from the map just as they are from all other sources.