### PR TITLE
Four Uniques typed - Blitz, Haka Dance, Hakkapeliitta, Amphibious

### DIFF
--- a/core/src/com/unciv/logic/battle/BattleDamage.kt
+++ b/core/src/com/unciv/logic/battle/BattleDamage.kt
@@ -64,7 +64,7 @@ object BattleDamage {
 
 
             for (unique in adjacentUnits.filter { it.civInfo.isAtWarWith(combatant.getCivInfo()) }
-                .flatMap { it.getMatchingUniques("[]% Strength for enemy [] units in adjacent [] tiles") })
+                    .flatMap { it.getMatchingUniques(UniqueType.StrengthForAdjacentEnemies) })
                 if (combatant.matchesCategory(unique.params[1]) && combatant.getTile()
                         .matchesFilter(unique.params[2])
                 )
@@ -85,7 +85,7 @@ object BattleDamage {
                 modifiers["Great General"] = greatGeneralModifier
             }
 
-            for (unique in combatant.unit.getMatchingUniques("[]% Strength when stacked with []")) {
+            for (unique in combatant.unit.getMatchingUniques(UniqueType.StrengthWhenStacked)) {
                 var stackedUnitsBonus = 0
                 if (combatant.unit.getTile().getUnits().any { it.matchesFilter(unique.params[1]) })
                     stackedUnitsBonus += unique.params[0].toInt()
@@ -149,10 +149,9 @@ object BattleDamage {
                     modifiers["Flanking"] =
                         (flankingBonus * (numberOfAttackersSurroundingDefender - 1)).toInt()
                 }
-                if (attacker.getTile()
-                        .aerialDistanceTo(defender.getTile()) == 1 && attacker.getTile()
-                        .isConnectedByRiver(defender.getTile())
-                    && !attacker.unit.hasUnique("Eliminates combat penalty for attacking over a river")
+                if (attacker.getTile().aerialDistanceTo(defender.getTile()) == 1 &&
+                        attacker.getTile().isConnectedByRiver(defender.getTile()) &&
+                        !attacker.unit.hasUnique(UniqueType.AttackAcrossRiver)
                 ) {
                     if (!attacker.getTile()
                             .hasConnection(attacker.getCivInfo()) // meaning, the tiles are not road-connected for this civ

--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -245,7 +245,7 @@ class MapUnit {
         DecimalFormat("0.#").format(currentMovement.toDouble()) + "/" + getMaxMovement()
 
     fun getTile(): TileInfo = currentTile
-    
+
 
     // This SHOULD NOT be a HashSet, because if it is, then promotions with the same text (e.g. barrage I, barrage II)
     //  will not get counted twice!
@@ -260,7 +260,7 @@ class MapUnit {
     // TODO typify usages and remove this function
     fun getMatchingUniques(placeholderText: String): Sequence<Unique> =
         tempUniquesMap.getUniques(placeholderText)
-    
+
     fun getMatchingUniques(
         uniqueType: UniqueType,
         stateForConditionals: StateForConditionals = StateForConditionals(civInfo, unit=this),
@@ -458,7 +458,8 @@ class MapUnit {
     }
 
     fun maxAttacksPerTurn(): Int {
-        return 1 + getMatchingUniques("[] additional attacks per turn").sumOf { it.params[0].toInt() }
+        return 1 + getMatchingUniques(UniqueType.AdditionalAttacks, checkCivInfoUniques = true)
+            .sumOf { it.params[0].toInt() }
     }
 
     fun canAttack(): Boolean {
@@ -469,7 +470,8 @@ class MapUnit {
     fun getRange(): Int {
         if (baseUnit.isMelee()) return 1
         var range = baseUnit().range
-        range += getMatchingUniques(UniqueType.Range, checkCivInfoUniques = true).sumOf { it.params[0].toInt() }
+        range += getMatchingUniques(UniqueType.Range, checkCivInfoUniques = true)
+            .sumOf { it.params[0].toInt() }
         return range
     }
 

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -413,7 +413,7 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
     StrengthForAdjacentEnemies("[relativeAmount]% Strength for enemy [combatantFilter] units in adjacent [tileFilter] tiles", UniqueTarget.Unit),
     StrengthWhenStacked("[relativeAmount]% Strength when stacked with [mapUnitFilter]", UniqueTarget.Unit),  // candidate for conditional!
 
-    AdditionalAttacks("[] additional attacks per turn", UniqueTarget.Unit, UniqueTarget.Global),
+    AdditionalAttacks("[amount] additional attacks per turn", UniqueTarget.Unit, UniqueTarget.Global),
     Movement("[amount] Movement", UniqueTarget.Unit, UniqueTarget.Global),
     Sight("[amount] Sight", UniqueTarget.Unit, UniqueTarget.Global, UniqueTarget.Terrain),
     Range("[amount] Range", UniqueTarget.Unit, UniqueTarget.Global),

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -410,13 +410,16 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
     FlankAttackBonus("[relativeAmount]% to Flank Attack bonuses", UniqueTarget.Unit, UniqueTarget.Global),
     // There's currently no conditional that would allow you strength vs city-state *cities* and that's why this isn't deprecated yet
     StrengthBonusVsCityStates("+30% Strength when fighting City-State units and cities", UniqueTarget.Global),
+    StrengthForAdjacentEnemies("[relativeAmount]% Strength for enemy [combatantFilter] units in adjacent [tileFilter] tiles", UniqueTarget.Unit),
+    StrengthWhenStacked("[relativeAmount]% Strength when stacked with [mapUnitFilter]", UniqueTarget.Unit),  // candidate for conditional!
 
+    AdditionalAttacks("[] additional attacks per turn", UniqueTarget.Unit, UniqueTarget.Global),
     Movement("[amount] Movement", UniqueTarget.Unit, UniqueTarget.Global),
     Sight("[amount] Sight", UniqueTarget.Unit, UniqueTarget.Global, UniqueTarget.Terrain),
     Range("[amount] Range", UniqueTarget.Unit, UniqueTarget.Global),
     Heal("[amount] HP when healing", UniqueTarget.Unit, UniqueTarget.Global),
+
     SpreadReligionStrength("[relativeAmount]% Spread Religion Strength", UniqueTarget.Unit, UniqueTarget.Global),
-  
     MayFoundReligion("May found a religion", UniqueTarget.Unit),
     MayEnhanceReligion("May enhance a religion", UniqueTarget.Unit),
     StatsWhenSpreading("When spreading religion to a city, gain [amount] times the amount of followers of other religions as [stat]", UniqueTarget.Unit, UniqueTarget.Global),
@@ -448,7 +451,7 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
     HealOnlyByPillaging("Can only heal by pillaging", UniqueTarget.Unit, UniqueTarget.Global),
     HealsEvenAfterAction("Unit will heal every turn, even if it performs an action", UniqueTarget.Unit),
     HealAdjacentUnits("All adjacent units heal [amount] HP when healing", UniqueTarget.Unit),
-    
+
     NormalVisionWhenEmbarked("Normal vision when embarked", UniqueTarget.Unit, UniqueTarget.Global),
     DefenceBonusWhenEmbarked("Defense bonus when embarked", UniqueTarget.Unit, UniqueTarget.Global),
     @Deprecated("as of 4.0.3", ReplaceWith("Defense bonus when embarked <for [All] units>"))
@@ -457,6 +460,7 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
     AttackFromSea("Eliminates combat penalty for attacking from the sea", UniqueTarget.Unit),
     AttackAcrossCoast("Eliminates combat penalty for attacking across a coast", UniqueTarget.Unit),
     AttackOnSea("May attack when embarked", UniqueTarget.Unit),
+    AttackAcrossRiver("Eliminates combat penalty for attacking over a river", UniqueTarget.Unit),
 
     NoSight("No Sight", UniqueTarget.Unit),
     CanSeeOverObstacles("Can see over obstacles", UniqueTarget.Unit),

--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -671,7 +671,7 @@ class BaseUnit : RulesetObject(), INonPerpetualConstruction {
                     -> power += power / 4
                 unique.isOfType(UniqueType.MustSetUp) // Must set up - 20 % penalty
                     -> power -= power / 5
-                unique.placeholderText == "[] additional attacks per turn" // Extra attacks - 20% bonus per extra attack
+                unique.isOfType(UniqueType.AdditionalAttacks) // Extra attacks - 20% bonus per extra attack
                     -> power += (power * unique.params[0].toInt()) / 5
             }
         }


### PR DESCRIPTION
Another way to fix #6731 - _UniqueType_ some Battle Uniques. Possible **_side effect_**: I enabled `checkCivInfoUniques = true` for the AdditionalAttacks UniqueType to mimic the Range one - seemed plausible, and should be transparent with our stock base rulesets. The others should be left as limited as before. Not very consistent, I know, but expanding moddability scope is more X's domain?

Related to #6739, but works independently, obviously.