### PR TITLE
Fix spectator not being able to view tile improvements or city buttons

### DIFF
--- a/core/src/com/unciv/logic/civilization/CivInfoTransientUpdater.kt
+++ b/core/src/com/unciv/logic/civilization/CivInfoTransientUpdater.kt
@@ -71,6 +71,7 @@ class CivInfoTransientUpdater(val civInfo: CivilizationInfo) {
         if (civInfo.isSpectator() || UncivGame.Current.viewEntireMapForDebug) {
             val allTiles = civInfo.gameInfo.tileMap.values.toSet()
             civInfo.viewableTiles = allTiles
+            civInfo.exploredTiles = allTiles.map { it.position }.toHashSet()
             civInfo.viewableInvisibleUnitsTiles = allTiles
             return
         }

--- a/core/src/com/unciv/logic/map/TileInfo.kt
+++ b/core/src/com/unciv/logic/map/TileInfo.kt
@@ -181,7 +181,7 @@ open class TileInfo {
     fun getTileImprovementInProgress(): TileImprovement? = if (improvementInProgress == null) null else ruleset.tileImprovements[improvementInProgress!!]
 
     fun getShownImprovement(viewingCiv: CivilizationInfo?): String? {
-        return if (viewingCiv == null || viewingCiv.playerType == PlayerType.AI)
+        return if (viewingCiv == null || viewingCiv.playerType == PlayerType.AI || viewingCiv.isSpectator())
             improvement
         else
             viewingCiv.lastSeenImprovement[position]

--- a/core/src/com/unciv/ui/tilegroups/WorldTileGroup.kt
+++ b/core/src/com/unciv/ui/tilegroups/WorldTileGroup.kt
@@ -31,11 +31,15 @@ class WorldTileGroup(internal val worldScreen: WorldScreen, tileInfo: TileInfo, 
                 && city!!.civInfo == viewingCiv)
             icons.addPopulationIcon()
         // update city buttons in explored tiles or entire map
-        if (showEntireMap || viewingCiv.exploredTiles.contains(tileInfo.position))
+        if (showEntireMap
+                || viewingCiv.exploredTiles.contains(tileInfo.position)
+                || viewingCiv.isSpectator()
+                || (worldScreen.viewingCiv.isSpectator() && !worldScreen.fogOfWar)) {
             updateCityButton(city, tileIsViewable || showEntireMap) // needs to be before the update so the units will be above the city button
-        else if (worldScreen.viewingCiv.isSpectator())
-            // remove city buttons in unexplored tiles during spectating/fog of war
+        } else if (worldScreen.viewingCiv.isSpectator() && worldScreen.fogOfWar) {
+            // remove city buttons in unexplored tiles during spectating and fog of war enabled
             updateCityButton(null, showEntireMap)
+        }
 
         super.update(viewingCiv, UncivGame.Current.settings.showResourcesAndImprovements, UncivGame.Current.settings.showTileYields)
     }

--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -69,7 +69,8 @@ class WorldScreen(val gameInfo: GameInfo, val viewingCiv:CivilizationInfo) : Bas
     var isPlayersTurn = viewingCiv == gameInfo.currentPlayerCiv
         private set     // only this class is allowed to make changes
     var selectedCiv = viewingCiv
-    private var fogOfWar = true
+    var fogOfWar = true
+        private set
     val canChangeState
         get() = isPlayersTurn && !viewingCiv.isSpectator()
     private var waitingForAutosave = false


### PR DESCRIPTION
I'd really like to refactor vision to a separate file that is solely responsible for vision, and then pulling vision out of all the other classes.

But that's for another time :D This is just to fix the spectator not being able to view improvements or city buttons. Pretty straightforward.