### PR TITLE
Hide Unmet Civ and Capital Names in the Victory Status Screen

### DIFF
--- a/core/src/com/unciv/Constants.kt
+++ b/core/src/com/unciv/Constants.kt
@@ -42,6 +42,7 @@ object Constants {
     const val openBorders = "Open Borders"
     const val random = "Random"
     const val unknownNationName = "???"
+    const val unknownCityName = "???"
 
     const val fort = "Fort"
 

--- a/core/src/com/unciv/models/ruleset/Victory.kt
+++ b/core/src/com/unciv/models/ruleset/Victory.kt
@@ -213,7 +213,10 @@ class Milestone(val uniqueDescription: String, private val parentVictory: Victor
             MilestoneType.CaptureAllCapitals -> {
                 val originalCapitals = civInfo.gameInfo.getCities().filter { it.isOriginalCapital }
                 for (city in originalCapitals) {
-                    buttons.add(getMilestoneButton("Capture [${city.name}]", city.civInfo == civInfo))
+                    val milestoneText =
+                        if (civInfo.exploredTiles.contains(city.location)) "Capture [${city.name}]"
+                        else "Capture [${Constants.unknownNationName}]"
+                    buttons.add(getMilestoneButton(milestoneText, city.civInfo == civInfo))
                 }
             }
             

--- a/core/src/com/unciv/models/ruleset/Victory.kt
+++ b/core/src/com/unciv/models/ruleset/Victory.kt
@@ -215,7 +215,7 @@ class Milestone(val uniqueDescription: String, private val parentVictory: Victor
                 for (city in originalCapitals) {
                     val milestoneText =
                         if (civInfo.exploredTiles.contains(city.location)) "Capture [${city.name}]"
-                        else "Capture [${Constants.unknownNationName}]"
+                        else "Capture [${Constants.unknownCityName}]"
                     buttons.add(getMilestoneButton(milestoneText, city.civInfo == civInfo))
                 }
             }

--- a/core/src/com/unciv/models/ruleset/Victory.kt
+++ b/core/src/com/unciv/models/ruleset/Victory.kt
@@ -211,7 +211,7 @@ class Milestone(val uniqueDescription: String, private val parentVictory: Victor
             MilestoneType.CaptureAllCapitals -> {
                 val originalCapitals = civInfo.gameInfo.getCities().filter { it.isOriginalCapital }
                 for (city in originalCapitals) {
-                    val milestoneText = if (civInfo.knows(city.civInfo) || !city.civInfo.isAlive()) "Capture [${city.name}]" else "Capture [${Constants.unknownNationName}]"
+                    val milestoneText = if (civInfo.knows(city.civInfo)) "Capture [${city.name}]" else "Capture [${Constants.unknownNationName}]"
                     buttons.add(getMilestoneButton(milestoneText, city.civInfo == civInfo))
                 }
             }

--- a/core/src/com/unciv/models/ruleset/Victory.kt
+++ b/core/src/com/unciv/models/ruleset/Victory.kt
@@ -203,7 +203,9 @@ class Milestone(val uniqueDescription: String, private val parentVictory: Victor
             MilestoneType.DestroyAllPlayers -> {
                 val majorCivs = civInfo.gameInfo.civilizations.filter { it.isMajorCiv() && it != civInfo }
                 for (civ in majorCivs) {
-                    val milestoneText = if (civInfo.knows(civ) || !civ.isAlive()) "Destroy [${civ.civName}]" else "Destroy [${Constants.unknownNationName}]"
+                    val milestoneText =
+                        if (civInfo.knows(civ) || !civ.isAlive()) "Destroy [${civ.civName}]"
+                        else "Destroy [${Constants.unknownNationName}]"
                     buttons.add(getMilestoneButton(milestoneText, !civ.isAlive()))
                 }
             }
@@ -211,8 +213,7 @@ class Milestone(val uniqueDescription: String, private val parentVictory: Victor
             MilestoneType.CaptureAllCapitals -> {
                 val originalCapitals = civInfo.gameInfo.getCities().filter { it.isOriginalCapital }
                 for (city in originalCapitals) {
-                    val milestoneText = if (civInfo.knows(city.civInfo)) "Capture [${city.name}]" else "Capture [${Constants.unknownNationName}]"
-                    buttons.add(getMilestoneButton(milestoneText, city.civInfo == civInfo))
+                    buttons.add(getMilestoneButton("Capture [${city.name}]", city.civInfo == civInfo))
                 }
             }
             
@@ -226,7 +227,9 @@ class Milestone(val uniqueDescription: String, private val parentVictory: Victor
                 val majorCivs = civInfo.gameInfo.civilizations.filter { it.isMajorCiv() }
                 val civReligion = civInfo.religionManager.religion
                 for (civ in majorCivs) {
-                    val milestoneText = if (civInfo.knows(civ) || !civ.isAlive()) "Majority religion of [${civ.civName}]" else "Majority religion of [${Constants.unknownNationName}]"
+                    val milestoneText =
+                        if (civInfo.knows(civ) || !civ.isAlive()) "Majority religion of [${civ.civName}]"
+                        else "Majority religion of [${Constants.unknownNationName}]"
                     if (civReligion == null || (civReligion.isPantheon() && civInfo != civ) || !civ.religionManager.isMajorityReligionForCiv(civReligion))
                         buttons.add(getMilestoneButton(milestoneText, false))
                     else

--- a/core/src/com/unciv/models/ruleset/Victory.kt
+++ b/core/src/com/unciv/models/ruleset/Victory.kt
@@ -2,6 +2,7 @@ package com.unciv.models.ruleset
 
 import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton
+import com.unciv.Constants
 import com.unciv.models.stats.INamed
 import com.unciv.logic.civilization.CivilizationInfo
 import com.unciv.models.Counter
@@ -202,14 +203,16 @@ class Milestone(val uniqueDescription: String, private val parentVictory: Victor
             MilestoneType.DestroyAllPlayers -> {
                 val majorCivs = civInfo.gameInfo.civilizations.filter { it.isMajorCiv() && it != civInfo }
                 for (civ in majorCivs) {
-                    buttons.add(getMilestoneButton("Destroy [${civ.civName}]", !civ.isAlive()))
+                    val milestoneText = if (civInfo.knows(civ) || !civ.isAlive()) "Destroy [${civ.civName}]" else "Destroy [${Constants.unknownNationName}]"
+                    buttons.add(getMilestoneButton(milestoneText, !civ.isAlive()))
                 }
             }
             
             MilestoneType.CaptureAllCapitals -> {
                 val originalCapitals = civInfo.gameInfo.getCities().filter { it.isOriginalCapital }
                 for (city in originalCapitals) {
-                    buttons.add(getMilestoneButton("Capture [${city.name}]", city.civInfo == civInfo))
+                    val milestoneText = if (civInfo.knows(city.civInfo) || !city.civInfo.isAlive()) "Capture [${city.name}]" else "Capture [${Constants.unknownNationName}]"
+                    buttons.add(getMilestoneButton(milestoneText, city.civInfo == civInfo))
                 }
             }
             
@@ -223,10 +226,11 @@ class Milestone(val uniqueDescription: String, private val parentVictory: Victor
                 val majorCivs = civInfo.gameInfo.civilizations.filter { it.isMajorCiv() }
                 val civReligion = civInfo.religionManager.religion
                 for (civ in majorCivs) {
+                    val milestoneText = if (civInfo.knows(civ) || !civ.isAlive()) "Majority religion of [${civ.civName}]" else "Majority religion of [${Constants.unknownNationName}]"
                     if (civReligion == null || (civReligion.isPantheon() && civInfo != civ) || !civ.religionManager.isMajorityReligionForCiv(civReligion))
-                        buttons.add(getMilestoneButton("Majority religion of [${civ.civName}]", false))
+                        buttons.add(getMilestoneButton(milestoneText, false))
                     else
-                        buttons.add(getMilestoneButton("Majority religion of [${civ.civName}]", true))
+                        buttons.add(getMilestoneButton(milestoneText, true))
                 }
             }
         }

--- a/core/src/com/unciv/models/ruleset/Victory.kt
+++ b/core/src/com/unciv/models/ruleset/Victory.kt
@@ -230,10 +230,8 @@ class Milestone(val uniqueDescription: String, private val parentVictory: Victor
                     val milestoneText =
                         if (civInfo.knows(civ) || !civ.isAlive()) "Majority religion of [${civ.civName}]"
                         else "Majority religion of [${Constants.unknownNationName}]"
-                    if (civReligion == null || (civReligion.isPantheon() && civInfo != civ) || !civ.religionManager.isMajorityReligionForCiv(civReligion))
-                        buttons.add(getMilestoneButton(milestoneText, false))
-                    else
-                        buttons.add(getMilestoneButton(milestoneText, true))
+                    val milestoneMet = (civReligion != null && (!civReligion.isPantheon() || civInfo == civ) && civ.religionManager.isMajorityReligionForCiv(civReligion))
+                    buttons.add(getMilestoneButton(milestoneText, milestoneMet))
                 }
             }
         }


### PR DESCRIPTION
Obscures the names of civs the player has not met in the "Our Status" tab of the Victory Status screen by replacing their names with "???" (```Constants.unknownNationName```). In the event that the civ dies before the player meets them, the civ name will be revealed anyways. Since the other Victory Status tabs hide the unmet civ names I don't see any reason why this one tab should spoil them.

Performs the same obscuring with the Religion victory type (which is currently unimplemented in the vanilla game). ~~The same could be done for the take-all-capitals victory condition but since there could be cases where the city name becomes unobscured then reobscured (plus with this victory type being unimplemented) I decided to leave that for a later time.~~ EDIT: Capital names are now replaced with a ```Constants.unknownCityName``` string (currently "???") until the player has seen the capital city tile.