### PR TITLE
see autofix attempts on real time when inputting multiplayerServer URL

### DIFF
--- a/core/src/com/unciv/ui/worldscreen/mainmenu/OptionsPopup.kt
+++ b/core/src/com/unciv/ui/worldscreen/mainmenu/OptionsPopup.kt
@@ -281,7 +281,8 @@ class OptionsPopup(
             multiplayerServerTextField.text = Gdx.app.clipboard.contents
         }).row()
         multiplayerServerTextField.onChange {
-            settings.multiplayerServer = formatMultiplayerUrlInput(multiplayerServerTextField.text)
+            multiplayerServerTextField.text = formatMultiplayerUrlInput(multiplayerServerTextField.text)
+            settings.multiplayerServer = multiplayerServerTextField.text
             settings.save()
             connectionToServerButton.isEnabled = multiplayerServerTextField.text != Constants.dropboxMultiplayerServer
         }


### PR DESCRIPTION
I didn't know that `multiplayerServerTextField.text` was mutable. Then I saw this line and realized that it was....
https://github.com/yairm210/Unciv/blob/5a78c594053f89f8e8b86a8567d3952eec03b7b9/core/src/com/unciv/ui/worldscreen/mainmenu/OptionsPopup.kt#L281

So, I think
https://github.com/yairm210/Unciv/blob/92d5b45e1bf08f347b350f37fd0e3763106d9bc5/core/src/com/unciv/ui/worldscreen/mainmenu/OptionsPopup.kt#L284-L285
instead of just
https://github.com/yairm210/Unciv/blob/5a78c594053f89f8e8b86a8567d3952eec03b7b9/core/src/com/unciv/ui/worldscreen/mainmenu/OptionsPopup.kt#L284
is a better way to do this cause players can see the autofixing in real time