### PR TITLE
Hide cities where wonders are built until city is explored

### DIFF
--- a/core/src/com/unciv/ui/overviewscreen/WonderOverviewTable.kt
+++ b/core/src/com/unciv/ui/overviewscreen/WonderOverviewTable.kt
@@ -178,7 +178,8 @@ class WonderOverviewTab(
                 val index = wonderIndexMap[wonderName]!!
                 val status = when {
                     viewingPlayer == city.civInfo -> WonderStatus.Owned
-                    viewingPlayer.knows(city.civInfo) -> WonderStatus.Known
+                    //viewingPlayer.knows(city.civInfo) -> WonderStatus.Known
+                    viewingPlayer.exploredTiles.contains(city.location) -> WonderStatus.Known
                     else -> WonderStatus.NotFound
                 }
                 wonders[index] = WonderInfo(wonderName, CivilopediaCategories.Wonder,

--- a/core/src/com/unciv/ui/overviewscreen/WonderOverviewTable.kt
+++ b/core/src/com/unciv/ui/overviewscreen/WonderOverviewTable.kt
@@ -178,7 +178,6 @@ class WonderOverviewTab(
                 val index = wonderIndexMap[wonderName]!!
                 val status = when {
                     viewingPlayer == city.civInfo -> WonderStatus.Owned
-                    //viewingPlayer.knows(city.civInfo) -> WonderStatus.Known
                     viewingPlayer.exploredTiles.contains(city.location) -> WonderStatus.Known
                     else -> WonderStatus.NotFound
                 }


### PR DESCRIPTION
A one line UI tweak. The notification when another player builds a wonder displays the city where it was built unless we haven't explored the city tile, in which case the notification says "a faraway land" instead of saying the city name.

https://github.com/yairm210/Unciv/blob/c9dc0bae0655586d8a004b584630e2d2d61b9fd6/core/src/com/unciv/logic/city/CityConstructions.kt#L411-L415

On the other hand, the wonder screen in the overview will list the city where the wonder was built as long as we know the civ who owns the city where the wonder was built. This PR changes modifies the condition for displaying the wonder's location in the wonder screen so that it is the same for the notification's condition (we've seen the city).