### PR TITLE
Fixed a bug where improvements could no longer be built by workers

### DIFF
--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -665,6 +665,7 @@ class MapUnit {
             else -> {
                 val improvement = civInfo.gameInfo.ruleSet.tileImprovements[tile.improvementInProgress]!!
                 improvement.handleImprovementCompletion(this)
+                tile.improvement = tile.improvementInProgress
             }
         }
         


### PR DESCRIPTION
Fixes #6779.
I was 99% certain I already added this line at some earlier point, but somehow it got removed again or something.
Anyway, this fixes improvements not being able to be build by workers.
I'd advice on bringing out a patch for this as this is a major problem.