### PR TITLE
Enable gradle caching for faster CI runs

### DIFF
--- a/.github/workflows/buildAndDeploy.yml
+++ b/.github/workflows/buildAndDeploy.yml
@@ -30,9 +30,11 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
+          distribution: 'zulu'
           java-version: '11'
+          cache: 'gradle'
 
       - name: Compile kotlin and build classes
         run: ./gradlew classes

--- a/.github/workflows/buildAndDeploy.yml
+++ b/.github/workflows/buildAndDeploy.yml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: actions/setup-java@v3
         with:
-          distribution: 'zulu'
+          distribution: 'temurin'
           java-version: '11'
           cache: 'gradle'
 


### PR DESCRIPTION
Notes:
1. distribution is mandatory in v3
2. zulu is used because it was recommended in [wiki](https://yairm210.github.io/Unciv/Developers/Building-Locally/#without-android-studio)