### PR TITLE
Tiny bugfix for NotificationsScroll

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -1261,7 +1261,7 @@ Base unit buy cost: [amount]¤ =
 Research agreement cost: [amount]¤ = 
 
 
-S# Policies
+# Policies
 
 Adopt policy = 
 Adopt free policy = 

--- a/core/src/com/unciv/ui/worldscreen/NotificationsScroll.kt
+++ b/core/src/com/unciv/ui/worldscreen/NotificationsScroll.kt
@@ -52,6 +52,8 @@ class NotificationsScroll(
         notificationsHash = notifications.hashCode()
 
         notificationsTable.clearChildren()
+        endOfTableSpacerCell = null
+
         for (notification in notifications.asReversed().toList()) { // toList to avoid concurrency problems
             val listItem = Table()
             listItem.background = ImageGetter.getRoundedEdgeRectangle()


### PR DESCRIPTION
After getting more notifications during a turn (e.g. buy Harbors), notifications are not scrollable far enough. Silly mistake.