### PR TITLE
Detect and Use Latest Temurin 11 builds for Packr

### DIFF
--- a/.github/workflows/buildAndDeploy.yml
+++ b/.github/workflows/buildAndDeploy.yml
@@ -150,8 +150,8 @@ jobs:
           ./butler push deploy/Unciv-Linux64.zip yairm210/unciv:Linux64 --userversion ${{steps.tag.outputs.tag}}
           ./gradlew desktop:zipLinuxFilesForJar
 
-          wget -q -O jdk-windows-32.zip 
-          ./gradlew desktop:packrWindows32 "$(echo "$JRE_LIST" | grep -m1 'x86-32_windows')"
+          wget -q -O jdk-windows-32.zip "$(echo "$JRE_LIST" | grep -m1 'x86-32_windows')"
+          ./gradlew desktop:packrWindows32
           ./butler push deploy/Unciv-Windows32.zip yairm210/unciv:Windows32 --userversion ${{steps.tag.outputs.tag}}
 
           #  MacOS bundles correctly but does not run as intended, see https://github.com/yairm210/Unciv/issues/4970

--- a/.github/workflows/buildAndDeploy.yml
+++ b/.github/workflows/buildAndDeploy.yml
@@ -139,23 +139,28 @@ jobs:
           unzip butler.zip
           chmod +x butler
 
+          # Get Temurin Latest Realease info from Github API
+          GITHUB_API_URL='https://api.github.com/repos/adoptium/temurin11-binaries/releases/latest'
+          JRE_LIST="$(curl -s "$GITHUB_API_URL" | grep -oP '(?<="browser_download_url": ").+-jre_.+(gz|zip)')"
+          echo "$JRE_LIST"
+
           wget -q -O packr-all-4.0.0.jar https://github.com/libgdx/packr/releases/download/4.0.0/packr-all-4.0.0.jar
-          wget -q -O jre-linux-64.tar.gz https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.11%2B9/OpenJDK11U-jre_x64_linux_hotspot_11.0.11_9.tar.gz
+          wget -q -O jre-linux-64.tar.gz "$(echo "$JRE_LIST" | grep -m1 'x64_linux')"
           ./gradlew desktop:packrLinux64
-          ./butler push deploy/Unciv-Linux64.zip yairm210/unciv:Linux64     --userversion ${{steps.tag.outputs.tag}}
+          ./butler push deploy/Unciv-Linux64.zip yairm210/unciv:Linux64 --userversion ${{steps.tag.outputs.tag}}
           ./gradlew desktop:zipLinuxFilesForJar
 
-          wget -q -O jdk-windows-32.zip https://github.com/ojdkbuild/ojdkbuild/releases/download/java-1.8.0-openjdk-1.8.0.252-2.b09-x86/java-1.8.0-openjdk-1.8.0.252-2.b09.ojdkbuild.windows.x86.zip
-          ./gradlew desktop:packrWindows32
+          wget -q -O jdk-windows-32.zip 
+          ./gradlew desktop:packrWindows32 "$(echo "$JRE_LIST" | grep -m1 'x86-32_windows')"
           ./butler push deploy/Unciv-Windows32.zip yairm210/unciv:Windows32 --userversion ${{steps.tag.outputs.tag}}
 
           #  MacOS bundles correctly but does not run as intended, see https://github.com/yairm210/Unciv/issues/4970
           #  Disabled until this can be checked by sommeone who actually has a Mac computer
-          #  wget -q -O jre-macOS.tar.gz https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.11%2B9/OpenJDK11U-jre_x64_mac_hotspot_11.0.11_9.tar.gz
+          #  wget -q -O jre-macOS.tar.gz "$(echo "$JRE_LIST" | grep -m1 'x64_mac')"
           #  ./gradlew desktop:packrMacOS
           #  ./butler push deploy/Unciv-MacOS.zip yairm210/unciv:MacOS --userversion ${{steps.tag.outputs.tag}}
 
-          wget -q -O jdk-windows-64.zip https://github.com/ojdkbuild/ojdkbuild/releases/download/java-1.8.0-openjdk-1.8.0.232-1.b09/java-1.8.0-openjdk-1.8.0.232-1.b09.ojdkbuild.windows.x86_64.zip
+          wget -q -O jdk-windows-64.zip "$(echo "$JRE_LIST" | grep -m1 'x64_windows')"
           ./gradlew desktop:packrWindows64
           ./butler push deploy/Unciv-Windows64.zip yairm210/unciv:Windows64 --userversion ${{steps.tag.outputs.tag}}
 


### PR DESCRIPTION
This PR uses Github API to detect latest Temurin 11 JRE builds and fetch them to be used with packr
Latest Releases: https://github.com/adoptium/temurin11-binaries/releases/latest
API URL: https://api.github.com/repos/adoptium/temurin11-binaries/releases/latest