### PR TITLE
Capital movement tweaks

### DIFF
--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -504,16 +504,27 @@ object Battle {
             return
         }
 
-        if (attackerCiv.isPlayerCivilization()) {
-            attackerCiv.popupAlerts.add(PopupAlert(AlertType.CityConquered, city.id))
-            UncivGame.Current.settings.addCompletedTutorialTask("Conquer a city")
-        } else {
+        if (city.isOriginalCapital && city.foundingCiv == attackerCiv.civName) {
+            // retaking old capital
             city.puppetCity(attackerCiv)
-            if (city.population.population < 4 && city.canBeDestroyed(justCaptured = true)) {
+            city.annexCity()
+        } else if (attackerCiv.isPlayerCivilization()) {
+            // we're not taking our former capital
+            attackerCiv.popupAlerts.add(PopupAlert(AlertType.CityConquered, city.id))
+        } else {
+            // ideally here we would do some AI thinking for liberation vs. razing
+            // e.g., valueCityStateAlliance() > 0 to determine if we should liberate a city-state
+            city.puppetCity(attackerCiv)
+            if ((city.population.population < 4 || attackerCiv.isCityState())
+                && city.canBeDestroyed(justCaptured = true)) {
+                // raze if attacker is a city state
                 city.annexCity()
                 city.isBeingRazed = true
             }
         }
+
+        if (attackerCiv.isPlayerCivilization())
+            UncivGame.Current.settings.addCompletedTutorialTask("Conquer a city")
     }
 
     fun getMapCombatantOfTile(tile: TileInfo): ICombatant? {

--- a/core/src/com/unciv/logic/city/CityInfo.kt
+++ b/core/src/com/unciv/logic/city/CityInfo.kt
@@ -631,12 +631,16 @@ class CityInfo {
     fun setFlag(flag: CityFlags, amount: Int) {
         flagsCountdown[flag.name] = amount
     }
+
+    fun removeFlag(flag: CityFlags) {
+        flagsCountdown.remove(flag.name)
+    }
     
     fun resetWLTKD() {
         // Removes the flags for we love the king & resource demand
         // The resource demand flag will automatically be readded with 15 turns remaining, see startTurn()
-        flagsCountdown.remove(CityFlags.WeLoveTheKing.name)
-        flagsCountdown.remove(CityFlags.ResourceDemand.name)
+        removeFlag(CityFlags.WeLoveTheKing)
+        removeFlag(CityFlags.ResourceDemand)
         demandedResource = ""
     }
 
@@ -712,7 +716,7 @@ class CityInfo {
         }
 
         if (isCapital() && civInfo.cities.isNotEmpty()) { // Move the capital if destroyed (by a nuke or by razing)
-            civInfo.cities.first().cityConstructions.addBuilding(capitalCityIndicator())
+            civInfo.moveCapitalToNextLargest()
         }
 
         // Update proximity rankings for all civs

--- a/core/src/com/unciv/logic/city/CityInfoConquestFunctions.kt
+++ b/core/src/com/unciv/logic/city/CityInfoConquestFunctions.kt
@@ -12,7 +12,6 @@ import com.unciv.logic.trade.TradeOffer
 import com.unciv.logic.trade.TradeType
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.ui.utils.withoutItem
-import java.util.*
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.roundToInt
@@ -111,10 +110,17 @@ class CityInfoConquestFunctions(val city: CityInfo){
             if (population.population > 1) population.addPopulation(-1 - population.population / 4) // so from 2-4 population, remove 1, from 5-8, remove 2, etc.
             reassignPopulation()
 
-            setFlag(CityFlags.Resistance,
-                if (reconqueredCityWhileStillInResistance || foundingCiv == receivingCiv.civName) 0
-                else population.population // I checked, and even if you puppet there's resistance for conquering
-            )
+            if (!reconqueredCityWhileStillInResistance && foundingCiv != receivingCiv.civName) {
+                // add resistance
+                setFlag(
+                    CityFlags.Resistance,
+                    population.population // I checked, and even if you puppet there's resistance for conquering
+                )
+            } else {
+                // reconquering or liberating city in resistance so eliminate it
+                removeFlag(CityFlags.Resistance)
+            }
+
         }
         conqueringCiv.updateViewableTiles() // Might see new tiles from this city
     }
@@ -196,7 +202,7 @@ class CityInfoConquestFunctions(val city: CityInfo){
 
             conquerCity(conqueringCiv, oldCiv, foundingCiv)
 
-            if (foundingCiv.cities.size == 1) cityConstructions.addBuilding(capitalCityIndicator()) // Resurrection!
+            if (foundingCiv.cities.size == 1 && !city.isOriginalCapital) cityConstructions.addBuilding(capitalCityIndicator()) // Resurrection! (if we haven't already moved the capital)
             isPuppet = false
             cityStats.update()
 
@@ -249,15 +255,7 @@ class CityInfoConquestFunctions(val city: CityInfo){
 
             // Remove/relocate palace for old Civ - need to do this BEFORE we move the cities between
             //  civs so the capitalCityIndicator recognizes the unique buildings of the conquered civ
-            val capitalCityIndicator = capitalCityIndicator()
-            if (cityConstructions.isBuilt(capitalCityIndicator)) {
-                cityConstructions.removeBuilding(capitalCityIndicator)
-                val firstOtherCity = oldCiv.cities.firstOrNull { it != this }
-                if (firstOtherCity != null) {
-                    firstOtherCity.cityConstructions.addBuilding(capitalCityIndicator) // relocate palace
-                    firstOtherCity.isBeingRazed = false // Do not allow it to continue being razed if it was!
-                }
-            }
+            if (oldCiv.getCapital() == city)  oldCiv.moveCapitalToNextLargest()
 
             civInfo.cities = civInfo.cities.toMutableList().apply { remove(city) }
             newCivInfo.cities = newCivInfo.cities.toMutableList().apply { add(city) }
@@ -281,9 +279,11 @@ class CityInfoConquestFunctions(val city: CityInfo){
             // Place palace for newCiv if this is the only city they have
             // This needs to happen _before_ free buildings are added, as somtimes these should 
             // only be placed in the capital, and then there needs to be a capital.
-            if (newCivInfo.cities.count() == 1) {
-                cityConstructions.addBuilding(capitalCityIndicator)
-            }
+            ////if (newCivInfo.cities.count() == 1) {
+            //    cityConstructions.addBuilding(capitalCityIndicator)
+            //}
+            if (city.isOriginalCapital && city.foundingCiv == newCivInfo.civName)
+                newCivInfo.moveCapitalTo(city)
 
             // Add our free buildings to this city and add free buildings provided by the city to other cities
             civInfo.civConstructions.tryAddFreeBuildings()

--- a/core/src/com/unciv/logic/city/CityInfoConquestFunctions.kt
+++ b/core/src/com/unciv/logic/city/CityInfoConquestFunctions.kt
@@ -255,7 +255,7 @@ class CityInfoConquestFunctions(val city: CityInfo){
 
             // Remove/relocate palace for old Civ - need to do this BEFORE we move the cities between
             //  civs so the capitalCityIndicator recognizes the unique buildings of the conquered civ
-            if (oldCiv.getCapital() == city)  oldCiv.moveCapitalToNextLargest()
+            if (oldCiv.getCapital() == this)  oldCiv.moveCapitalToNextLargest()
 
             civInfo.cities = civInfo.cities.toMutableList().apply { remove(city) }
             newCivInfo.cities = newCivInfo.cities.toMutableList().apply { add(city) }

--- a/core/src/com/unciv/logic/city/CityInfoConquestFunctions.kt
+++ b/core/src/com/unciv/logic/city/CityInfoConquestFunctions.kt
@@ -280,7 +280,7 @@ class CityInfoConquestFunctions(val city: CityInfo){
             // This needs to happen _before_ free buildings are added, as somtimes these should 
             // only be placed in the capital, and then there needs to be a capital.
             if (newCivInfo.cities.count() == 1) {
-                newCivInfo.moveCapitalTo(city)
+                newCivInfo.moveCapitalTo(this)
             }
 
             // Add our free buildings to this city and add free buildings provided by the city to other cities

--- a/core/src/com/unciv/logic/city/CityInfoConquestFunctions.kt
+++ b/core/src/com/unciv/logic/city/CityInfoConquestFunctions.kt
@@ -279,9 +279,6 @@ class CityInfoConquestFunctions(val city: CityInfo){
             // Place palace for newCiv if this is the only city they have
             // This needs to happen _before_ free buildings are added, as somtimes these should 
             // only be placed in the capital, and then there needs to be a capital.
-            ////if (newCivInfo.cities.count() == 1) {
-            //    cityConstructions.addBuilding(capitalCityIndicator)
-            //}
             if (city.isOriginalCapital && city.foundingCiv == newCivInfo.civName)
                 newCivInfo.moveCapitalTo(city)
 

--- a/core/src/com/unciv/logic/city/CityInfoConquestFunctions.kt
+++ b/core/src/com/unciv/logic/city/CityInfoConquestFunctions.kt
@@ -202,7 +202,7 @@ class CityInfoConquestFunctions(val city: CityInfo){
 
             conquerCity(conqueringCiv, oldCiv, foundingCiv)
 
-            if (foundingCiv.cities.size == 1 && !city.isOriginalCapital) cityConstructions.addBuilding(capitalCityIndicator()) // Resurrection! (if we haven't already moved the capital)
+            if (foundingCiv.cities.size == 1) cityConstructions.addBuilding(capitalCityIndicator()) // Resurrection! (if we haven't already moved the capital)
             isPuppet = false
             cityStats.update()
 

--- a/core/src/com/unciv/logic/city/CityInfoConquestFunctions.kt
+++ b/core/src/com/unciv/logic/city/CityInfoConquestFunctions.kt
@@ -279,8 +279,9 @@ class CityInfoConquestFunctions(val city: CityInfo){
             // Place palace for newCiv if this is the only city they have
             // This needs to happen _before_ free buildings are added, as somtimes these should 
             // only be placed in the capital, and then there needs to be a capital.
-            if (city.isOriginalCapital && city.foundingCiv == newCivInfo.civName)
+            if (newCivInfo.cities.count() == 1) {
                 newCivInfo.moveCapitalTo(city)
+            }
 
             // Add our free buildings to this city and add free buildings provided by the city to other cities
             civInfo.civConstructions.tryAddFreeBuildings()

--- a/core/src/com/unciv/logic/city/CityInfoConquestFunctions.kt
+++ b/core/src/com/unciv/logic/city/CityInfoConquestFunctions.kt
@@ -202,7 +202,7 @@ class CityInfoConquestFunctions(val city: CityInfo){
 
             conquerCity(conqueringCiv, oldCiv, foundingCiv)
 
-            if (foundingCiv.cities.size == 1) cityConstructions.addBuilding(capitalCityIndicator()) // Resurrection! (if we haven't already moved the capital)
+            if (foundingCiv.cities.size == 1) cityConstructions.addBuilding(capitalCityIndicator()) // Resurrection!
             isPuppet = false
             cityStats.update()
 

--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -1302,6 +1302,24 @@ class CivilizationInfo {
         return proximity
     }
 
+    /**
+     * Removes current capital then moves capital to argument city if not null
+     */
+    fun moveCapitalTo(city: CityInfo?) {
+        if (cities.isNotEmpty()) {
+            getCapital().cityConstructions.removeBuilding(getCapital().capitalCityIndicator())
+        }
+
+        if (city == null) return // can't move a non-existent city but we can always remove our old capital
+        // move new capital
+        city.cityConstructions.addBuilding(city.capitalCityIndicator())
+        city.isBeingRazed = false // stop razing the new capital if it was being razed
+    }
+
+    fun moveCapitalToNextLargest() {
+        moveCapitalTo(cities.maxByOrNull { it.population.population })
+    }
+
     //////////////////////// City State wrapper functions ////////////////////////
 
     fun receiveGoldGift(donorCiv: CivilizationInfo, giftAmount: Int) =

--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -1317,7 +1317,9 @@ class CivilizationInfo {
     }
 
     fun moveCapitalToNextLargest() {
-        moveCapitalTo(cities.maxByOrNull { it.population.population })
+        moveCapitalTo(cities
+            .filterNot { it == getCapital() }
+            .maxByOrNull { it.population.population})
     }
 
     //////////////////////// City State wrapper functions ////////////////////////


### PR DESCRIPTION
Changes regarding capital movement and city transfer.
* When a civ loses its capital, it will move the capital to its next largest city instead of the first city in the civ's list of cities
* Civs will automatically move their capital back to their original capital if they've recaptured it (Civ 5 mechanic). For players this means skipping the annex or puppet option screen and for AI this means they'll annex the city right away
* Liberated or recaptured cities that were originally founded by the recapturing (or receiving) civ will skip resistance (and can bombard the turn they are taken back which addresses a point in #4697)
* City states will always raze cities they capture if they can (again a Civ 5 mechanic)

This also adds a ```moveCapitalTo(newCapitalCity)``` function that can be reused in the future for a moveable capital mechanic like in earlier civ games where capitals can be moved by building palaces.

In the future, I believe that some of the code at the bottom of the conquerCity function in ![Battle.kt](https://github.com/yairm210/Unciv/blob/master/core/src/com/unciv/logic/battle/Battle.kt) could be refactored into a civ AI function. Looking at some of the available civ 5 source code, there is some AI thought to whether a civ liberates a city (liberating a comrade's city, for example) and there are also some existing functions in Unciv that could be used (```valueCityStateAlliance()``` in ![NextTurnAutomation.kt](https://github.com/yairm210/Unciv/blob/master/core/src/com/unciv/logic/automation/NextTurnAutomation.kt) when deciding if a minor civ should be liberated, for example).