### PR TITLE
Disabled CS buttons when at war; CS keep influence when at war with ally

### DIFF
--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -247,6 +247,8 @@ class GameInfo {
             }
             switchTurn()
         }
+        if (turns == UncivGame.Current.simulateUntilTurnForDebug)
+            UncivGame.Current.simulateUntilTurnForDebug = 0
 
         currentTurnStartTime = System.currentTimeMillis()
         currentPlayer = thisPlayer.civName

--- a/core/src/com/unciv/logic/automation/NextTurnAutomation.kt
+++ b/core/src/com/unciv/logic/automation/NextTurnAutomation.kt
@@ -244,7 +244,7 @@ object NextTurnAutomation {
 
     private fun tryGainInfluence(civInfo: CivilizationInfo, cityState: CivilizationInfo) {
         if (civInfo.gold < 250) return // save up
-        if (cityState.getDiplomacyManager(civInfo).influence < 20) {
+        if (cityState.getDiplomacyManager(civInfo).getInfluence() < 20) {
             cityState.receiveGoldGift(civInfo, 250)
             return
         }
@@ -267,7 +267,7 @@ object NextTurnAutomation {
             for (cityState in civInfo.getKnownCivs()
                     .filter { it.isCityState() && it.cityStateType == CityStateType.Cultured }) {
                 val diploManager = cityState.getDiplomacyManager(civInfo)
-                if (diploManager.influence < 40) { // we want to gain influence with them
+                if (diploManager.getInfluence() < 40) { // we want to gain influence with them
                     tryGainInfluence(civInfo, cityState)
                     return
                 }
@@ -329,7 +329,7 @@ object NextTurnAutomation {
         }
         if (cityState.getAllyCiv() != null && cityState.getAllyCiv() != civInfo.civName) {
             // easier not to compete if a third civ has this locked down
-            val thirdCivInfluence = cityState.getDiplomacyManager(cityState.getAllyCiv()!!).influence.toInt()
+            val thirdCivInfluence = cityState.getDiplomacyManager(cityState.getAllyCiv()!!).getInfluence().toInt()
             value -= (thirdCivInfluence - 60) / 10
         }
 

--- a/core/src/com/unciv/logic/civilization/CityStateFunctions.kt
+++ b/core/src/com/unciv/logic/civilization/CityStateFunctions.kt
@@ -177,7 +177,7 @@ class CityStateFunctions(val civInfo: CivilizationInfo) {
     }
 
     fun removeProtectorCiv(otherCiv: CivilizationInfo, forced: Boolean = false) {
-        if(!otherCivCanWithdrawProtection(otherCiv) && !forced)
+        if(!forced && !otherCivCanWithdrawProtection(otherCiv))
             return
 
         val diplomacy = civInfo.getDiplomacyManager(otherCiv)
@@ -195,7 +195,7 @@ class CityStateFunctions(val civInfo: CivilizationInfo) {
         if (diplomacy.hasFlag(DiplomacyFlags.RecentlyWithdrewProtection))
             return false
         // Must have at least 0 influence
-        if (diplomacy.influence < 0)
+        if (diplomacy.getInfluence() < 0)
             return false
         // can't be at war
         if (civInfo.isAtWarWith(otherCiv))
@@ -225,8 +225,8 @@ class CityStateFunctions(val civInfo: CivilizationInfo) {
         if (!civInfo.isCityState()) return
         val maxInfluence = civInfo.diplomacy
             .filter { !it.value.otherCiv().isCityState() && !it.value.otherCiv().isDefeated() }
-            .maxByOrNull { it.value.influence }
-        if (maxInfluence != null && maxInfluence.value.influence >= 60) {
+            .maxByOrNull { it.value.getInfluence() }
+        if (maxInfluence != null && maxInfluence.value.getInfluence() >= 60) {
             newAllyName = maxInfluence.key
         }
 
@@ -350,7 +350,7 @@ class CityStateFunctions(val civInfo: CivilizationInfo) {
             modifiers["Very recently paid tribute"] = -300
         else if (recentBullying != null)
             modifiers["Recently paid tribute"] = -40
-        if (civInfo.getDiplomacyManager(demandingCiv).influence < -30)
+        if (civInfo.getDiplomacyManager(demandingCiv).getInfluence() < -30)
             modifiers["Influence below -30"] = -300
 
         // Slight optimization, we don't do the expensive stuff if we have no chance of getting a >= 0 result

--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -598,11 +598,15 @@ class CivilizationInfo {
     fun getEraNumber(): Int = getEra().eraNumber
 
     fun isAtWarWith(otherCiv: CivilizationInfo): Boolean {
-        if (otherCiv == this) return false // never at war with itself
-        if (otherCiv.isBarbarian() || isBarbarian()) return true
-        val diplomacyManager = diplomacy[otherCiv.civName]
-            ?: return false // not encountered yet
-        return diplomacyManager.diplomaticStatus == DiplomaticStatus.War
+        return when {
+            otherCiv == this -> false
+            otherCiv.isBarbarian() || isBarbarian() -> true
+            else -> {
+                val diplomacyManager = diplomacy[otherCiv.civName]
+                    ?: return false // not encountered yet
+                return diplomacyManager.diplomaticStatus == DiplomaticStatus.War
+            }
+        }
     }
 
     fun isAtWar() = diplomacy.values.any { it.diplomaticStatus == DiplomaticStatus.War && !it.otherCiv().isDefeated() }

--- a/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
@@ -115,7 +115,9 @@ class DiplomacyManager() {
     var diplomaticModifiers = HashMap<String, Float>()
 
     /** For city-states. Influence is saved in the CITY STATE -> major civ Diplomacy, NOT in the major civ -> city state diplomacy.
-     *  Won't go below [MINIMUM_INFLUENCE]. Note this declaration leads to Major Civs getting MINIMUM_INFLUENCE serialized, but that is ignored. */
+     * Access via getInfluence() and setInfluence() unless you know what you're doing.
+     * Note that not using the setter skips recalculating the ally and bounds checks, 
+     * and skipping the getter bypasses the modified value when at war */
     private var influence = 0f
 
     /** Total of each turn Science during Research Agreement */

--- a/core/src/com/unciv/ui/tilegroups/CityButton.kt
+++ b/core/src/com/unciv/ui/tilegroups/CityButton.kt
@@ -54,7 +54,7 @@ class CityButton(val city: CityInfo, private val tileGroup: WorldTileGroup): Tab
 
         if (city.civInfo.isCityState() && city.civInfo.knows(worldScreen.viewingCiv)) {
             val diplomacyManager = city.civInfo.getDiplomacyManager(worldScreen.viewingCiv)
-            val influenceBar = getInfluenceBar(diplomacyManager.influence, diplomacyManager.relationshipLevel())
+            val influenceBar = getInfluenceBar(diplomacyManager.getInfluence(), diplomacyManager.relationshipLevel())
             add(influenceBar).row()
         }
 

--- a/core/src/com/unciv/ui/trade/DiplomacyScreen.kt
+++ b/core/src/com/unciv/ui/trade/DiplomacyScreen.kt
@@ -202,7 +202,7 @@ class DiplomacyScreen(
         otherCiv.updateAllyCivForCityState()
         val ally = otherCiv.getAllyCiv()
         if (ally != null) {
-            val allyInfluence = otherCiv.getDiplomacyManager(ally).influence.toInt()
+            val allyInfluence = otherCiv.getDiplomacyManager(ally).getInfluence().toInt()
             diplomacyTable
                 .add("Ally: [$ally] with [$allyInfluence] Influence".toLabel())
                 .row()
@@ -214,8 +214,11 @@ class DiplomacyScreen(
             diplomacyTable.add(protectorString.toLabel()).row()
         }
 
+        val atWar = otherCiv.isAtWarWith(viewingCiv)
+        
         val nextLevelString = when {
-            otherCivDiplomacyManager.influence.toInt() < 30 -> "Reach 30 for friendship."
+            atWar -> ""
+            otherCivDiplomacyManager.getInfluence().toInt() < 30 -> "Reach 30 for friendship."
             ally == viewingCiv.civName -> ""
             else -> "Reach highest influence above 60 for alliance."
         }
@@ -322,7 +325,7 @@ class DiplomacyScreen(
             rightSideTable.add(ScrollPane(getGoldGiftTable(otherCiv)))
         }
         diplomacyTable.add(giveGiftButton).row()
-        if (isNotPlayersTurn()) giveGiftButton.disable()
+        if (isNotPlayersTurn() || viewingCiv.isAtWarWith(otherCiv)) giveGiftButton.disable()
 
         val improveTileButton = getImproveTilesButton(otherCiv, otherCivDiplomacyManager)
         if (improveTileButton != null) diplomacyTable.add(improveTileButton).row()
@@ -357,7 +360,7 @@ class DiplomacyScreen(
             rightSideTable.add(ScrollPane(getDemandTributeTable(otherCiv)))
         }
         diplomacyTable.add(demandTributeButton).row()
-        if (isNotPlayersTurn()) demandTributeButton.disable()
+        if (isNotPlayersTurn() || viewingCiv.isAtWarWith(otherCiv)) demandTributeButton.disable()
 
         val diplomacyManager = viewingCiv.getDiplomacyManager(otherCiv)
         if (!viewingCiv.gameInfo.ruleSet.modOptions.uniques.contains(ModOptionsConstants.diplomaticRelationshipsCannotChange)) {
@@ -440,7 +443,7 @@ class DiplomacyScreen(
         }
 
 
-        if (isNotPlayersTurn() || otherCivDiplomacyManager.influence < 60 || !needsImprovements)
+        if (isNotPlayersTurn() || otherCivDiplomacyManager.getInfluence() < 60 || !needsImprovements)
             improveTileButton.disable()
         return improveTileButton
     }
@@ -857,7 +860,7 @@ class DiplomacyScreen(
         val relationshipTable = Table()
 
         val opinionOfUs =
-            if (otherCivDiplomacyManager.civInfo.isCityState()) otherCivDiplomacyManager.influence.toInt()
+            if (otherCivDiplomacyManager.civInfo.isCityState()) otherCivDiplomacyManager.getInfluence().toInt()
             else otherCivDiplomacyManager.opinionOfOtherCiv().toInt()
 
         relationshipTable.add("{Our relationship}: ".toLabel())
@@ -875,8 +878,8 @@ class DiplomacyScreen(
         if (otherCivDiplomacyManager.civInfo.isCityState())
             relationshipTable.add(
                 CityButton.getInfluenceBar(
-                    otherCivDiplomacyManager.influence,
-                    otherCivDiplomacyManager.relationshipLevel(),
+                    otherCivDiplomacyManager.getInfluence(),
+                    relationshipLevel,
                     200f, 10f
                 )
             ).colspan(2).pad(5f)


### PR DESCRIPTION
This PR does two things:
- When you are at war with a city state, you can no longer give them money, demand stuff, etc.
- When at war with the ally of a city state, your influence is frozen, and after the end of the conflict set back to its original value.

To implement this last thing, I had to split the getter of `influence` off of the underlying field, as otherwise when copying over the old value in `.clone()`, we would copy over -60 when at war, instead of the original value. Most of the changes in that PR are a result of that.
Also resets the `simulateUntilTurns` variable after completing simulation of the turns.