### PR TITLE
Accelerate custom map selection a tiny bit

### DIFF
--- a/core/src/com/unciv/logic/MapSaver.kt
+++ b/core/src/com/unciv/logic/MapSaver.kt
@@ -3,6 +3,7 @@ package com.unciv.logic
 import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.files.FileHandle
 import com.unciv.json.json
+import com.unciv.logic.map.MapParameters
 import com.unciv.logic.map.TileMap
 import com.unciv.ui.saves.Gzip
 
@@ -41,11 +42,27 @@ object MapSaver {
         getMap(mapName).writeString(mapToSavedString(tileMap), false)
     }
 
-    fun loadMap(mapFile:FileHandle, checkSizeErrors: Boolean = true):TileMap {
+    fun loadMap(mapFile: FileHandle, checkSizeErrors: Boolean = true): TileMap {
         return mapFromSavedString(mapFile.readString(), checkSizeErrors)
     }
 
     fun getMaps(): Array<FileHandle> = Gdx.files.local(mapsFolder).list()
 
-    private fun mapFromJson(json:String): TileMap = json().fromJson(TileMap::class.java, json)
+    private fun mapFromJson(json: String): TileMap = json().fromJson(TileMap::class.java, json)
+
+    /** Class to parse only the parameters out of a map file */
+    private class TileMapPreview {
+        val mapParameters = MapParameters()
+    }
+    fun loadMapParameters(mapFile: FileHandle): MapParameters {
+        return mapParametersFromSavedString(mapFile.readString())
+    }
+    fun mapParametersFromSavedString(mapString: String): MapParameters {
+        val unzippedJson = try {
+            Gzip.unzip(mapString.trim())
+        } catch (ex: Exception) {
+            mapString
+        }
+        return json().fromJson(TileMapPreview::class.java, unzippedJson).mapParameters
+    }
 }

--- a/core/src/com/unciv/ui/newgamescreen/MapOptionsTable.kt
+++ b/core/src/com/unciv/ui/newgamescreen/MapOptionsTable.kt
@@ -91,9 +91,8 @@ class MapOptionsTable(private val newGameScreen: NewGameScreen): Table() {
         val mapFileSelectBox = SelectBox<FileHandleWrapper>(BaseScreen.skin)
         mapFileSelectBox.onChange {
             val mapFile = mapFileSelectBox.selected.fileHandle
-            val map: TileMap
-            try {
-                map = MapSaver.loadMap(mapFile)
+            val mapParams = try {
+                MapSaver.loadMapParameters(mapFile)
             } catch (ex:Exception){
                 ex.printStackTrace()
                 Popup(newGameScreen).apply {
@@ -107,9 +106,9 @@ class MapOptionsTable(private val newGameScreen: NewGameScreen): Table() {
             }
             mapParameters.name = mapFile.name()
             newGameScreen.gameSetupInfo.mapFile = mapFile
-            val mapMods = map.mapParameters.mods.partition { RulesetCache[it]?.modOptions?.isBaseRuleset == true }
+            val mapMods = mapParams.mods.partition { RulesetCache[it]?.modOptions?.isBaseRuleset == true }
             newGameScreen.gameSetupInfo.gameParameters.mods = LinkedHashSet(mapMods.second)
-            newGameScreen.gameSetupInfo.gameParameters.baseRuleset = mapMods.first.firstOrNull() ?: map.mapParameters.baseRuleset
+            newGameScreen.gameSetupInfo.gameParameters.baseRuleset = mapMods.first.firstOrNull() ?: mapParams.baseRuleset
             newGameScreen.updateRuleset()
             newGameScreen.updateTables()
         }


### PR DESCRIPTION
With a 280x120 Deciv Redux map, this shaves off... 633 of 1031 milliseconds! Woot!

I'd say not worth the trouble, right? Dwarfed by the atlas loading and getComplexRuleset that follow. Still, *feels* a bit more responsive, you see a reaction before those loads. Then again, that map size is probably virtually unplayable.