### PR TITLE
Great General typed uniques - remastered

### DIFF
--- a/android/assets/jsons/Civ V - Gods & Kings/Units.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Units.json
@@ -1634,8 +1634,8 @@
 	{
 		"name": "Great General",
 		"unitType": "Civilian",
-		"uniques": ["Can start an [8]-turn golden age", "Bonus for units in 2 tile radius 15%", "Can construct [Citadel]",
-			"Great Person - [War]", "Unbuildable", "Uncapturable"],
+		"uniques": ["Can start an [8]-turn golden age", "[15]% Strength bonus for [Military] units in a [2] tile radius",
+			"Can construct [Citadel]", "Great Person - [War]", "Unbuildable", "Uncapturable"],
 		"movement": 2
 	},
 	{
@@ -1643,8 +1643,9 @@
 		"unitType": "Civilian",
 		"uniqueTo": "Mongolia",
 		"replaces": "Great General",
-		"uniques": ["Can start an [8]-turn golden age","Bonus for units in 2 tile radius 15%",
-			"All adjacent units heal [+15] HP when healing", "[+15] HP when healing", "Can construct [Citadel]", "Great Person - [War]", "Unbuildable", "Uncapturable"],
+		"uniques": ["Can start an [8]-turn golden age","[15]% Strength bonus for [Military] units in a [2] tile radius",
+			"All adjacent units heal [+15] HP when healing", "[+15] HP when healing",
+			"Can construct [Citadel]", "Great Person - [War]", "Unbuildable", "Uncapturable"],
 		"movement": 5
 	},
 

--- a/android/assets/jsons/Civ V - Gods & Kings/Units.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Units.json
@@ -1634,8 +1634,8 @@
 	{
 		"name": "Great General",
 		"unitType": "Civilian",
-		"uniques": ["Can start an [8]-turn golden age", "[15]% Strength for [Military] units in a [2] tile radius",
-			"Can construct [Citadel]", "Great Person - [War]", "Unbuildable", "Uncapturable"],
+		"uniques": ["Can start an [8]-turn golden age", "[+15]% Strength bonus for [Military] units in [2] tiles", "Can construct [Citadel]",
+			"Great Person - [War]", "Unbuildable", "Uncapturable"],
 		"movement": 2
 	},
 	{
@@ -1643,9 +1643,8 @@
 		"unitType": "Civilian",
 		"uniqueTo": "Mongolia",
 		"replaces": "Great General",
-		"uniques": ["Can start an [8]-turn golden age","[15]% Strength for [Military] units in a [2] tile radius",
-			"All adjacent units heal [+15] HP when healing", "[+15] HP when healing",
-			"Can construct [Citadel]", "Great Person - [War]", "Unbuildable", "Uncapturable"],
+		"uniques": ["Can start an [8]-turn golden age","[+15]% Strength bonus for [Military] units in [2] tiles",
+			"All adjacent units heal [+15] HP when healing", "[+15] HP when healing", "Can construct [Citadel]", "Great Person - [War]", "Unbuildable", "Uncapturable"],
 		"movement": 5
 	},
 

--- a/android/assets/jsons/Civ V - Gods & Kings/Units.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Units.json
@@ -1634,7 +1634,7 @@
 	{
 		"name": "Great General",
 		"unitType": "Civilian",
-		"uniques": ["Can start an [8]-turn golden age", "[15]% Strength bonus for [Military] units in a [2] tile radius",
+		"uniques": ["Can start an [8]-turn golden age", "[15]% Strength for [Military] units in a [2] tile radius",
 			"Can construct [Citadel]", "Great Person - [War]", "Unbuildable", "Uncapturable"],
 		"movement": 2
 	},
@@ -1643,7 +1643,7 @@
 		"unitType": "Civilian",
 		"uniqueTo": "Mongolia",
 		"replaces": "Great General",
-		"uniques": ["Can start an [8]-turn golden age","[15]% Strength bonus for [Military] units in a [2] tile radius",
+		"uniques": ["Can start an [8]-turn golden age","[15]% Strength for [Military] units in a [2] tile radius",
 			"All adjacent units heal [+15] HP when healing", "[+15] HP when healing",
 			"Can construct [Citadel]", "Great Person - [War]", "Unbuildable", "Uncapturable"],
 		"movement": 5

--- a/android/assets/jsons/Civ V - Gods & Kings/Units.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Units.json
@@ -1634,7 +1634,7 @@
 	{
 		"name": "Great General",
 		"unitType": "Civilian",
-		"uniques": ["Can start an [8]-turn golden age", "[+15]% Strength bonus for [Military] units in [2] tiles", "Can construct [Citadel]",
+		"uniques": ["Can start an [8]-turn golden age", "[+15]% Strength bonus for [Military] units within [2] tiles", "Can construct [Citadel]",
 			"Great Person - [War]", "Unbuildable", "Uncapturable"],
 		"movement": 2
 	},
@@ -1643,7 +1643,7 @@
 		"unitType": "Civilian",
 		"uniqueTo": "Mongolia",
 		"replaces": "Great General",
-		"uniques": ["Can start an [8]-turn golden age","[+15]% Strength bonus for [Military] units in [2] tiles",
+		"uniques": ["Can start an [8]-turn golden age","[+15]% Strength bonus for [Military] units within [2] tiles",
 			"All adjacent units heal [+15] HP when healing", "[+15] HP when healing", "Can construct [Citadel]", "Great Person - [War]", "Unbuildable", "Uncapturable"],
 		"movement": 5
 	},

--- a/android/assets/jsons/Civ V - Vanilla/Units.json
+++ b/android/assets/jsons/Civ V - Vanilla/Units.json
@@ -1310,7 +1310,7 @@
 	{
 		"name": "Great General",
 		"unitType": "Civilian",
-		"uniques": ["Can start an [8]-turn golden age", "[15]% Strength bonus for [Military] units in a [2] tile radius",
+		"uniques": ["Can start an [8]-turn golden age", "[15]% Strength for [Military] units in a [2] tile radius",
 			"Can construct [Citadel]", "Great Person - [War]", "Unbuildable", "Uncapturable"],
 		"movement": 2
 	},
@@ -1319,7 +1319,7 @@
 		"unitType": "Civilian",
 		"uniqueTo": "Mongolia",
 		"replaces": "Great General",
-		"uniques": ["Can start an [8]-turn golden age","[15]% Strength bonus for [Military] units in a [2] tile radius",
+		"uniques": ["Can start an [8]-turn golden age","[15]% Strength for [Military] units in a [2] tile radius",
 			"All adjacent units heal [+15] HP when healing", "[+15] HP when healing",
 			"Can construct [Citadel]", "Great Person - [War]", "Unbuildable", "Uncapturable"],
 		"movement": 5

--- a/android/assets/jsons/Civ V - Vanilla/Units.json
+++ b/android/assets/jsons/Civ V - Vanilla/Units.json
@@ -1310,8 +1310,8 @@
 	{
 		"name": "Great General",
 		"unitType": "Civilian",
-		"uniques": ["Can start an [8]-turn golden age", "[15]% Strength for [Military] units in a [2] tile radius",
-			"Can construct [Citadel]", "Great Person - [War]", "Unbuildable", "Uncapturable"],
+		"uniques": ["Can start an [8]-turn golden age", "[+15]% Strength bonus for [Military] units in [2] tiles", "Can construct [Citadel]",
+			"Great Person - [War]", "Unbuildable", "Uncapturable"],
 		"movement": 2
 	},
 	{
@@ -1319,9 +1319,8 @@
 		"unitType": "Civilian",
 		"uniqueTo": "Mongolia",
 		"replaces": "Great General",
-		"uniques": ["Can start an [8]-turn golden age","[15]% Strength for [Military] units in a [2] tile radius",
-			"All adjacent units heal [+15] HP when healing", "[+15] HP when healing",
-			"Can construct [Citadel]", "Great Person - [War]", "Unbuildable", "Uncapturable"],
+		"uniques": ["Can start an [8]-turn golden age", "[+15]% Strength bonus for [Military] units in [2] tiles",
+			"All adjacent units heal [+15] HP when healing", "[+15] HP when healing", "Can construct [Citadel]", "Great Person - [War]", "Unbuildable", "Uncapturable"],
 		"movement": 5
 	},
 

--- a/android/assets/jsons/Civ V - Vanilla/Units.json
+++ b/android/assets/jsons/Civ V - Vanilla/Units.json
@@ -1310,8 +1310,8 @@
 	{
 		"name": "Great General",
 		"unitType": "Civilian",
-		"uniques": ["Can start an [8]-turn golden age", "Bonus for units in 2 tile radius 15%", "Can construct [Citadel]",
-			"Great Person - [War]", "Unbuildable", "Uncapturable"],
+		"uniques": ["Can start an [8]-turn golden age", "[15]% Strength bonus for [Military] units in a [2] tile radius",
+			"Can construct [Citadel]", "Great Person - [War]", "Unbuildable", "Uncapturable"],
 		"movement": 2
 	},
 	{
@@ -1319,8 +1319,9 @@
 		"unitType": "Civilian",
 		"uniqueTo": "Mongolia",
 		"replaces": "Great General",
-		"uniques": ["Can start an [8]-turn golden age","Bonus for units in 2 tile radius 15%",
-			"All adjacent units heal [+15] HP when healing", "[+15] HP when healing", "Can construct [Citadel]", "Great Person - [War]", "Unbuildable", "Uncapturable"],
+		"uniques": ["Can start an [8]-turn golden age","[15]% Strength bonus for [Military] units in a [2] tile radius",
+			"All adjacent units heal [+15] HP when healing", "[+15] HP when healing",
+			"Can construct [Citadel]", "Great Person - [War]", "Unbuildable", "Uncapturable"],
 		"movement": 5
 	},
 

--- a/android/assets/jsons/Civ V - Vanilla/Units.json
+++ b/android/assets/jsons/Civ V - Vanilla/Units.json
@@ -1310,7 +1310,7 @@
 	{
 		"name": "Great General",
 		"unitType": "Civilian",
-		"uniques": ["Can start an [8]-turn golden age", "[+15]% Strength bonus for [Military] units in [2] tiles", "Can construct [Citadel]",
+		"uniques": ["Can start an [8]-turn golden age", "[+15]% Strength bonus for [Military] units within [2] tiles", "Can construct [Citadel]",
 			"Great Person - [War]", "Unbuildable", "Uncapturable"],
 		"movement": 2
 	},
@@ -1319,7 +1319,7 @@
 		"unitType": "Civilian",
 		"uniqueTo": "Mongolia",
 		"replaces": "Great General",
-		"uniques": ["Can start an [8]-turn golden age", "[+15]% Strength bonus for [Military] units in [2] tiles",
+		"uniques": ["Can start an [8]-turn golden age", "[+15]% Strength bonus for [Military] units within [2] tiles",
 			"All adjacent units heal [+15] HP when healing", "[+15] HP when healing", "Can construct [Citadel]", "Great Person - [War]", "Unbuildable", "Uncapturable"],
 		"movement": 5
 	},

--- a/core/src/com/unciv/logic/BackwardCompatibility.kt
+++ b/core/src/com/unciv/logic/BackwardCompatibility.kt
@@ -144,6 +144,14 @@ object BackwardCompatibility {
                     unit.promotions.addPromotion(startingPromo, true)
     }
 
+    /** Upgrade the uniques from deprecated format to the new more general one **/
+    fun GameInfo.updateGreatGeneralUniques() {
+        ruleSet.units.values.filter { it.uniques.contains("Bonus for units in 2 tile radius 15%") }.forEach {
+            it.uniques.remove("Bonus for units in 2 tile radius 15%")
+            it.uniques.add("[+15]% Strength bonus for [Military] units in [2] tiles")
+        }
+    }
+
     /** Move max XP from barbarians to new home */
     @Suppress("DEPRECATION")
     fun ModOptions.updateDeprecations() {

--- a/core/src/com/unciv/logic/BackwardCompatibility.kt
+++ b/core/src/com/unciv/logic/BackwardCompatibility.kt
@@ -148,7 +148,7 @@ object BackwardCompatibility {
     fun GameInfo.updateGreatGeneralUniques() {
         ruleSet.units.values.filter { it.uniques.contains("Bonus for units in 2 tile radius 15%") }.forEach {
             it.uniques.remove("Bonus for units in 2 tile radius 15%")
-            it.uniques.add("[+15]% Strength bonus for [Military] units in [2] tiles")
+            it.uniques.add("[+15]% Strength bonus for [Military] units within [2] tiles")
         }
     }
 

--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -82,7 +82,7 @@ class GameInfo {
     @Transient
     var spaceResources = HashSet<String>()
 
-    /** Cache of all promotions granting Great General capabilities, used in [updateMaxGeneralBonusRadius][com.unciv.logic.battle.GreatGeneralImplementation.updateMaxGeneralBonusRadius] */
+    /** Cache of all promotions granting Great General capabilities, used in [updateMaxGreatGeneralBonusRadius][com.unciv.logic.battle.GreatGeneralImplementation.updateMaxGreatGeneralBonusRadius] */
     // Does _not_ support UniqueType.BonusForUnitsInRadius, it's a new option for mods.
     @delegate:Transient
     val promotionsGrantingGeneralBonus by lazy {

--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -83,13 +83,6 @@ class GameInfo {
     @Transient
     var spaceResources = HashSet<String>()
 
-    /** Cache of all promotions granting Great General capabilities, used in [updateMaxGreatGeneralBonusRadius][com.unciv.logic.battle.GreatGeneralImplementation.updateMaxGreatGeneralBonusRadius] */
-    @delegate:Transient
-    val promotionsGrantingGeneralBonus by lazy {
-        ruleSet.unitPromotions.values.asSequence()
-            .filter { it.hasUnique(UniqueType.StrengthBonusInRadius) }.toList()
-    }
-
     //endregion
     //region Pure functions
 

--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -82,6 +82,14 @@ class GameInfo {
     @Transient
     var spaceResources = HashSet<String>()
 
+    /** Cache of all promotions granting Great General capabilities, used in [updateMaxGeneralBonusRadius][com.unciv.logic.battle.GreatGeneralImplementation.updateMaxGeneralBonusRadius] */
+    // Does _not_ support UniqueType.BonusForUnitsInRadius, it's a new option for mods.
+    @delegate:Transient
+    val promotionsGrantingGeneralBonus by lazy {
+        ruleSet.unitPromotions.values.asSequence()
+            .filter { it.hasUnique(UniqueType.GreatGeneralAura) }.toList()
+    }
+
     //endregion
     //region Pure functions
 

--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -84,11 +84,10 @@ class GameInfo {
     var spaceResources = HashSet<String>()
 
     /** Cache of all promotions granting Great General capabilities, used in [updateMaxGreatGeneralBonusRadius][com.unciv.logic.battle.GreatGeneralImplementation.updateMaxGreatGeneralBonusRadius] */
-    // Does _not_ support UniqueType.BonusForUnitsInRadius, it's a new option for mods.
     @delegate:Transient
     val promotionsGrantingGeneralBonus by lazy {
         ruleSet.unitPromotions.values.asSequence()
-            .filter { it.hasUnique(UniqueType.GreatGeneralAura) }.toList()
+            .filter { it.hasUnique(UniqueType.StrengthBonusInRadius) }.toList()
     }
 
     //endregion

--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -6,6 +6,7 @@ import com.unciv.logic.BackwardCompatibility.guaranteeUnitPromotions
 import com.unciv.logic.BackwardCompatibility.migrateBarbarianCamps
 import com.unciv.logic.BackwardCompatibility.migrateSeenImprovements
 import com.unciv.logic.BackwardCompatibility.removeMissingModReferences
+import com.unciv.logic.BackwardCompatibility.updateGreatGeneralUniques
 import com.unciv.logic.automation.NextTurnAutomation
 import com.unciv.logic.civilization.*
 import com.unciv.logic.city.CityInfo
@@ -423,6 +424,7 @@ class GameInfo {
 
         removeMissingModReferences()
 
+        updateGreatGeneralUniques()
 
         for (baseUnit in ruleSet.units.values)
             baseUnit.ruleset = ruleSet

--- a/core/src/com/unciv/logic/automation/NextTurnAutomation.kt
+++ b/core/src/com/unciv/logic/automation/NextTurnAutomation.kt
@@ -163,8 +163,7 @@ object NextTurnAutomation {
         while (delta > 0) {
             // Now remove the best offer valued below delta until the deal is barely acceptable
             val offerToRemove = counterofferAsks.filter { it.value <= delta }.maxByOrNull { it.value }
-            if (offerToRemove == null)
-                break // Nothing more can be removed, at least en bloc
+                ?: break  // Nothing more can be removed, at least en bloc
             delta -= offerToRemove.value
             counterofferAsks.remove(offerToRemove.key)
         }
@@ -831,7 +830,7 @@ object NextTurnAutomation {
             when {
                 unit.baseUnit.isRanged() -> rangedUnits.add(unit)
                 unit.baseUnit.isMelee() -> meleeUnits.add(unit)
-                unit.hasUnique("Bonus for units in 2 tile radius 15%")
+                unit.hasGreatGeneralUnique
                     -> generals.add(unit) // Generals move after military units
                 else -> civilianUnits.add(unit)
             }

--- a/core/src/com/unciv/logic/automation/NextTurnAutomation.kt
+++ b/core/src/com/unciv/logic/automation/NextTurnAutomation.kt
@@ -830,7 +830,7 @@ object NextTurnAutomation {
             when {
                 unit.baseUnit.isRanged() -> rangedUnits.add(unit)
                 unit.baseUnit.isMelee() -> meleeUnits.add(unit)
-                unit.hasGreatGeneralUnique
+                unit.isGreatPersonOfType("War")
                     -> generals.add(unit) // Generals move after military units
                 else -> civilianUnits.add(unit)
             }

--- a/core/src/com/unciv/logic/automation/SpecificUnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/SpecificUnitAutomation.kt
@@ -94,7 +94,7 @@ object SpecificUnitAutomation {
         return false
     }
 
-    fun automateGreatGeneralFallback(unit: MapUnit, isCitadelPlacer: Boolean) {
+    fun automateGreatGeneralFallback(unit: MapUnit) {
         // if no unit to follow, take refuge in city or build citadel there.
         val reachableTest: (TileInfo) -> Boolean = {
             it.civilianUnit == null &&
@@ -105,7 +105,7 @@ object SpecificUnitAutomation {
                 .sortedBy { it.aerialDistanceTo(unit.currentTile) }
                 .firstOrNull { reachableTest(it) }
             ?: return
-        if (!isCitadelPlacer) {
+        if (!unit.hasCitadelPlacementUnique) {
             unit.movement.headTowards(cityToGarrison)
             return
         }

--- a/core/src/com/unciv/logic/automation/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/UnitAutomation.kt
@@ -160,11 +160,11 @@ object UnitAutomation {
 
             //todo this now supports "Great General"-like mod units not combining 'aura' and citadel
             // abilities, but not additional capabilities if automation finds no use for those two
-            if (unit.hasGreatGeneralUnique && SpecificUnitAutomation.automateGreatGeneral(unit))
+            if (unit.hasStrengthBonusInRadiusUnique && SpecificUnitAutomation.automateGreatGeneral(unit))
                 return
             if (unit.hasCitadelPlacementUnique && SpecificUnitAutomation.automateCitadelPlacer(unit))
                 return
-            if (unit.hasCitadelPlacementUnique || unit.hasGreatGeneralUnique)
+            if (unit.hasCitadelPlacementUnique || unit.hasStrengthBonusInRadiusUnique)
                 return SpecificUnitAutomation.automateGreatGeneralFallback(unit)
 
             if (unit.hasUnique(UniqueType.ConstructImprovementConsumingUnit))

--- a/core/src/com/unciv/logic/automation/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/UnitAutomation.kt
@@ -157,9 +157,16 @@ object UnitAutomation {
             // For now its a simple option to allow AI to win a science victory again
             if (unit.hasUnique(UniqueType.AddInCapital))
                 return SpecificUnitAutomation.automateAddInCapital(unit)
-            
-            if (unit.hasUnique("Bonus for units in 2 tile radius 15%"))
-                return SpecificUnitAutomation.automateGreatGeneral(unit)
+
+            //todo this now supports "Great General"-like mod units not combining 'aura' and citadel
+            // abilities, but not additional capabilities if automation finds no use for those two
+            if (unit.hasGreatGeneralUnique && SpecificUnitAutomation.automateGreatGeneral(unit))
+                return
+            val isCitadelPlacer = unit.hasUnique(UniqueType.TakeOverTilesAroundWhenBuilt)
+            if (isCitadelPlacer && SpecificUnitAutomation.automateCitadelPlacer(unit))
+                return
+            if (isCitadelPlacer || unit.hasGreatGeneralUnique)
+                return SpecificUnitAutomation.automateGreatGeneralFallback(unit, isCitadelPlacer)
 
             if (unit.hasUnique(UniqueType.ConstructImprovementConsumingUnit))
                 return SpecificUnitAutomation.automateImprovementPlacer(unit) // includes great people plus moddable units

--- a/core/src/com/unciv/logic/automation/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/UnitAutomation.kt
@@ -162,13 +162,10 @@ object UnitAutomation {
             // abilities, but not additional capabilities if automation finds no use for those two
             if (unit.hasGreatGeneralUnique && SpecificUnitAutomation.automateGreatGeneral(unit))
                 return
-            val isCitadelPlacer = unit.getMatchingUniques(UniqueType.ConstructImprovementConsumingUnit)
-                .mapNotNull { unit.civInfo.gameInfo.ruleSet.tileImprovements[it.params[0]] }
-                .any { it.hasUnique(UniqueType.TakeOverTilesAroundWhenBuilt) }
-            if (isCitadelPlacer && SpecificUnitAutomation.automateCitadelPlacer(unit))
+            if (unit.hasCitadelPlacementUnique && SpecificUnitAutomation.automateCitadelPlacer(unit))
                 return
-            if (isCitadelPlacer || unit.hasGreatGeneralUnique)
-                return SpecificUnitAutomation.automateGreatGeneralFallback(unit, isCitadelPlacer)
+            if (unit.hasCitadelPlacementUnique || unit.hasGreatGeneralUnique)
+                return SpecificUnitAutomation.automateGreatGeneralFallback(unit)
 
             if (unit.hasUnique(UniqueType.ConstructImprovementConsumingUnit))
                 return SpecificUnitAutomation.automateImprovementPlacer(unit) // includes great people plus moddable units

--- a/core/src/com/unciv/logic/automation/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/UnitAutomation.kt
@@ -162,7 +162,9 @@ object UnitAutomation {
             // abilities, but not additional capabilities if automation finds no use for those two
             if (unit.hasGreatGeneralUnique && SpecificUnitAutomation.automateGreatGeneral(unit))
                 return
-            val isCitadelPlacer = unit.hasUnique(UniqueType.TakeOverTilesAroundWhenBuilt)
+            val isCitadelPlacer = unit.getMatchingUniques(UniqueType.ConstructImprovementConsumingUnit)
+                .mapNotNull { unit.civInfo.gameInfo.ruleSet.tileImprovements[it.params[0]] }
+                .any { it.hasUnique(UniqueType.TakeOverTilesAroundWhenBuilt) }
             if (isCitadelPlacer && SpecificUnitAutomation.automateCitadelPlacer(unit))
                 return
             if (isCitadelPlacer || unit.hasGreatGeneralUnique)

--- a/core/src/com/unciv/logic/battle/BattleDamage.kt
+++ b/core/src/com/unciv/logic/battle/BattleDamage.kt
@@ -73,8 +73,8 @@ object BattleDamage {
                     modifiers["Missing resource"] = -25  //todo ModConstants
 
             val greatGeneralModifier = GreatGeneralImplementation.getGreatGeneralBonus(combatant.unit)
-            if (greatGeneralModifier != 0)
-                modifiers["Great General"] = greatGeneralModifier
+            if (greatGeneralModifier.second != 0)
+                modifiers[greatGeneralModifier.first] = greatGeneralModifier.second
 
             for (unique in combatant.unit.getMatchingUniques(UniqueType.StrengthWhenStacked)) {
                 var stackedUnitsBonus = 0

--- a/core/src/com/unciv/logic/battle/BattleDamage.kt
+++ b/core/src/com/unciv/logic/battle/BattleDamage.kt
@@ -72,9 +72,9 @@ object BattleDamage {
                 if (civResources[resource]!! < 0 && !civInfo.isBarbarian())
                     modifiers["Missing resource"] = -25  //todo ModConstants
 
-            val greatGeneralModifier = GreatGeneralImplementation.getGreatGeneralBonus(combatant.unit)
-            if (greatGeneralModifier.second != 0)
-                modifiers[greatGeneralModifier.first] = greatGeneralModifier.second
+            val (greatGeneralName, greatGeneralBonus) = GreatGeneralImplementation.getGreatGeneralBonus(combatant.unit)
+            if (greatGeneralBonus != 0)
+                modifiers[greatGeneralName] = greatGeneralBonus
 
             for (unique in combatant.unit.getMatchingUniques(UniqueType.StrengthWhenStacked)) {
                 var stackedUnitsBonus = 0

--- a/core/src/com/unciv/logic/battle/GreatGeneralImplementation.kt
+++ b/core/src/com/unciv/logic/battle/GreatGeneralImplementation.kt
@@ -5,7 +5,6 @@ import com.unciv.logic.map.TileInfo
 import com.unciv.models.ruleset.unique.Unique
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.logic.automation.SpecificUnitAutomation  // for Kdoc
-import com.unciv.logic.civilization.CivilizationInfo
 
 
 object GreatGeneralImplementation {
@@ -29,7 +28,7 @@ object GreatGeneralImplementation {
     fun getGreatGeneralBonus(unit: MapUnit): Pair<String, Int> {
         val civInfo = unit.civInfo
         val allGenerals = civInfo.getCivUnits()
-            .filter { it.hasGreatGeneralUnique }
+            .filter { it.hasStrengthBonusInRadiusUnique }
         if (allGenerals.none()) return Pair("", 0)
 
         val greatGeneral = allGenerals

--- a/core/src/com/unciv/logic/battle/GreatGeneralImplementation.kt
+++ b/core/src/com/unciv/logic/battle/GreatGeneralImplementation.kt
@@ -2,7 +2,6 @@ package com.unciv.logic.battle
 
 import com.unciv.logic.map.MapUnit
 import com.unciv.logic.map.TileInfo
-import com.unciv.models.ruleset.unique.StateForConditionals
 import com.unciv.models.ruleset.unique.Unique
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.logic.automation.SpecificUnitAutomation  // for Kdoc
@@ -18,7 +17,7 @@ object GreatGeneralImplementation {
             bonus = unique.params[0].toIntOrNull() ?: 0
         )
         @Deprecated("Remove with UniqueType.BonusForUnitsInRadius")
-        constructor(general: MapUnit) : this(general, 2, "All", 15)
+        constructor(general: MapUnit) : this(general, 2, "Military", 15)
     }
 
     /**
@@ -31,7 +30,7 @@ object GreatGeneralImplementation {
     fun getGreatGeneralBonus(unit: MapUnit): Int {
         val civInfo = unit.civInfo
         val nearbyGenerals = unit.getTile()
-            .getTilesInDistance(civInfo.maxGeneralBonusRadius)
+            .getTilesInDistance(civInfo.maxGreatGeneralBonusRadius)
             .flatMap { it.getUnits() }
             .filter { it.civInfo == civInfo && it.hasGreatGeneralUnique }
         if (nearbyGenerals.none()) return 0
@@ -40,13 +39,15 @@ object GreatGeneralImplementation {
             .flatMap { general ->
                 general.getMatchingUniques(UniqueType.GreatGeneralAura)
                     .map { GeneralBonusData(general, it) } +
-                        general.getMatchingUniques(UniqueType.BonusForUnitsInRadius)
-                            .map { GeneralBonusData(general) }
+                general.getMatchingUniques(UniqueType.BonusForUnitsInRadius)
+                    .map { GeneralBonusData(general) }
             }.filter {
                 // Support the border case when a mod unit has several
                 // GreatGeneralAura uniques (e.g. +50% as radius 1, +25% at radius 2, +5% at radius 3)
+                // The "Military" test is also supported deep down in unit.matchesFilter, a small
+                // optimization for the most common case, as this function is only called for `MapUnitCombatant`s
                 it.general.currentTile.aerialDistanceTo(unit.getTile()) <= it.radius
-                        && (it.filter == "All" || unit.matchesFilter(it.filter))
+                        && (it.filter == "Military" || unit.matchesFilter(it.filter))
             }.maxOfOrNull { it.bonus } ?: 0
         if (unit.hasUnique(UniqueType.GreatGeneralProvidesDoubleCombatBonus, checkCivInfoUniques = true))
             return greatGeneralModifier * 2
@@ -91,36 +92,40 @@ object GreatGeneralImplementation {
                     val militaryUnit = auraTile.militaryUnit
                     if (militaryUnit == null || militaryUnit.civInfo != general.civInfo) 0
                     else generalBonusData.firstOrNull {
+                        // "Military" as commented above only a small optimization
                         auraTile.aerialDistanceTo(unitTile) <= it.radius
-                                && (it.filter == "All" || militaryUnit.matchesFilter(it.filter))
+                                && (it.filter == "Military" || militaryUnit.matchesFilter(it.filter))
                     }?.bonus ?: 0
                 }
             }
     }
 
     /** Find and cache the maximum Great General _Radius_ for a [civInfo]'s _BaseUnits_ */
-    fun setMaxGeneralBonusRadiusBase(civInfo: CivilizationInfo) {
-        civInfo.maxGeneralBonusRadiusBase = civInfo.gameInfo.ruleSet.units.values.asSequence()
-            .filter { it.isGreatGeneral() &&
-                    (it.uniqueTo == civInfo.civName || it.uniqueTo == null && civInfo.getEquivalentUnit(it) == it)
-            }.flatMap {
+    fun setMaxGreatGeneralBonusRadiusBase(civInfo: CivilizationInfo) {
+        val civBaseUnits = civInfo.gameInfo.ruleSet.units.values.asSequence()
+            .filter {
+                    it.uniqueTo == civInfo.civName || it.uniqueTo == null && civInfo.getEquivalentUnit(it) == it
+            }
+        val unitTypes = civInfo.gameInfo.ruleSet.unitTypes.values.asSequence()
+        civInfo.maxGreatGeneralBonusRadiusBase = (civBaseUnits + unitTypes)
+            .flatMap {
                 it.getMatchingUniques(UniqueType.GreatGeneralAura) +
-                        it.getMatchingUniques(UniqueType.BonusForUnitsInRadius)
+                it.getMatchingUniques(UniqueType.BonusForUnitsInRadius)
             }.maxOfOrNull {
                 if (it.type == UniqueType.BonusForUnitsInRadius) 2
                 else it.params[2].toIntOrNull() ?: 0
             } ?: 0
-        updateMaxGeneralBonusRadius(civInfo)
+        updateMaxGreatGeneralBonusRadius(civInfo)
     }
 
-    /** Update [CivilizationInfo.maxGeneralBonusRadius] from [CivilizationInfo.maxGeneralBonusRadiusBase]
+    /** Update [CivilizationInfo.maxGreatGeneralBonusRadius] from [CivilizationInfo.maxGreatGeneralBonusRadiusBase]
      *  and all units having a promotion granting Great General abilities. Should be called whenever
      *  a unit is destroyed or otherwise removed from the civ, or a unit gains a promotion. */
-    fun updateMaxGeneralBonusRadius(civInfo: CivilizationInfo) {
+    fun updateMaxGreatGeneralBonusRadius(civInfo: CivilizationInfo) {
         // If there are no promotions granting a Great General power, then we don't need to scan the actual MapUnits
         val promotionsGrantingGeneralBonus = civInfo.gameInfo.promotionsGrantingGeneralBonus
         if (promotionsGrantingGeneralBonus.isEmpty()) {
-            civInfo.maxGeneralBonusRadius = civInfo.maxGeneralBonusRadiusBase
+            civInfo.maxGreatGeneralBonusRadius = civInfo.maxGreatGeneralBonusRadiusBase
             return
         }
 
@@ -135,7 +140,7 @@ object GreatGeneralImplementation {
             }.maxOfOrNull {
                 it.params[2].toIntOrNull() ?: 0
             } ?: 0
-        civInfo.maxGeneralBonusRadius = civInfo.maxGeneralBonusRadiusBase
+        civInfo.maxGreatGeneralBonusRadius = civInfo.maxGreatGeneralBonusRadiusBase
             .coerceAtLeast(maxPromotionGeneralBonusRadius)
     }
 }

--- a/core/src/com/unciv/logic/battle/GreatGeneralImplementation.kt
+++ b/core/src/com/unciv/logic/battle/GreatGeneralImplementation.kt
@@ -1,0 +1,141 @@
+package com.unciv.logic.battle
+
+import com.unciv.logic.map.MapUnit
+import com.unciv.logic.map.TileInfo
+import com.unciv.models.ruleset.unique.StateForConditionals
+import com.unciv.models.ruleset.unique.Unique
+import com.unciv.models.ruleset.unique.UniqueType
+import com.unciv.logic.automation.SpecificUnitAutomation  // for Kdoc
+import com.unciv.logic.civilization.CivilizationInfo
+
+
+object GreatGeneralImplementation {
+    private data class GeneralBonusData(val general: MapUnit, val radius: Int, val filter: String, val bonus: Int) {
+        constructor(general: MapUnit, unique: Unique) : this(
+            general,
+            radius = unique.params[2].toIntOrNull() ?: 0,
+            filter = unique.params[1],
+            bonus = unique.params[0].toIntOrNull() ?: 0
+        )
+        @Deprecated("Remove with UniqueType.BonusForUnitsInRadius")
+        constructor(general: MapUnit) : this(general, 2, "All", 15)
+    }
+
+    /**
+     * Determine the "Great General" bonus for [unit] by searching for units carrying the [UniqueType.GreatGeneralAura] in the vicinity.
+     *
+     * Used by [BattleDamage.getGeneralModifiers].
+     *
+     * @return Percentage bonus as Int (typically 15), or 0 if no applicable Great General equivalents found 
+     */
+    fun getGreatGeneralBonus(unit: MapUnit): Int {
+        val civInfo = unit.civInfo
+        val nearbyGenerals = unit.getTile()
+            .getTilesInDistance(civInfo.maxGeneralBonusRadius)
+            .flatMap { it.getUnits() }
+            .filter { it.civInfo == civInfo && it.hasGreatGeneralUnique }
+        if (nearbyGenerals.none()) return 0
+
+        val greatGeneralModifier = nearbyGenerals
+            .flatMap { general ->
+                general.getMatchingUniques(UniqueType.GreatGeneralAura)
+                    .map { GeneralBonusData(general, it) } +
+                        general.getMatchingUniques(UniqueType.BonusForUnitsInRadius)
+                            .map { GeneralBonusData(general) }
+            }.filter {
+                // Support the border case when a mod unit has several
+                // GreatGeneralAura uniques (e.g. +50% as radius 1, +25% at radius 2, +5% at radius 3)
+                it.general.currentTile.aerialDistanceTo(unit.getTile()) <= it.radius
+                        && (it.filter == "All" || unit.matchesFilter(it.filter))
+            }.maxOfOrNull { it.bonus } ?: 0
+        if (unit.hasUnique(UniqueType.GreatGeneralProvidesDoubleCombatBonus, checkCivInfoUniques = true))
+            return greatGeneralModifier * 2
+        return greatGeneralModifier
+    }
+
+    /**
+     * Find a tile for accompanying a military unit where the total bonus for all affected units is maximized.
+     *
+     * Used by [SpecificUnitAutomation.automateGreatGeneral].
+     */
+    fun getBestAffectedTroopsTile(general: MapUnit): TileInfo? {
+        // Normally we have only one Unique here. But a mix is not forbidden, so let's try to support mad modders.
+        // (imagine several GreatGeneralAura uniques - +50% at radius 1, +25% at radius 2, +5% at radius 3 - possibly learnable from promotions via buildings or natural wonders?)
+
+        // Map out the uniques sorted by bonus, as later only the best bonus will apply.
+        val generalBonusData = (
+                general.getMatchingUniques(UniqueType.GreatGeneralAura).map { GeneralBonusData(general, it) } +
+                general.getMatchingUniques(UniqueType.BonusForUnitsInRadius).map { GeneralBonusData(general) }
+            ).sortedWith(compareByDescending<GeneralBonusData> { it.bonus }.thenBy { it.radius })
+            .toList()
+
+        // Get candidate units to 'follow', coarsely.
+        // The mapUnitFilter of the unique won't apply here but in the ranking of the "Aura" effectiveness.
+        val unitMaxMovement = general.getMaxMovement()
+        val militaryUnitTilesInDistance = general.movement.getDistanceToTiles().asSequence()
+            .map { it.key }
+            .filter { tile ->
+                val militaryUnit = tile.militaryUnit
+                militaryUnit != null && militaryUnit.civInfo == general.civInfo
+                        && (tile.civilianUnit == null || tile.civilianUnit == general)
+                        && militaryUnit.getMaxMovement() <= unitMaxMovement
+                        && !tile.isCityCenter()
+            }
+
+        // rank tiles and find best 
+        val unitBonusRadius = generalBonusData.maxOfOrNull { it.radius }
+            ?: return null
+        return militaryUnitTilesInDistance
+            .maxByOrNull { unitTile ->
+                unitTile.getTilesInDistance(unitBonusRadius).sumOf { auraTile ->
+                    val militaryUnit = auraTile.militaryUnit
+                    if (militaryUnit == null || militaryUnit.civInfo != general.civInfo) 0
+                    else generalBonusData.firstOrNull {
+                        auraTile.aerialDistanceTo(unitTile) <= it.radius
+                                && (it.filter == "All" || militaryUnit.matchesFilter(it.filter))
+                    }?.bonus ?: 0
+                }
+            }
+    }
+
+    /** Find and cache the maximum Great General _Radius_ for a [civInfo]'s _BaseUnits_ */
+    fun setMaxGeneralBonusRadiusBase(civInfo: CivilizationInfo) {
+        civInfo.maxGeneralBonusRadiusBase = civInfo.gameInfo.ruleSet.units.values.asSequence()
+            .filter { it.isGreatGeneral() &&
+                    (it.uniqueTo == civInfo.civName || it.uniqueTo == null && civInfo.getEquivalentUnit(it) == it)
+            }.flatMap {
+                it.getMatchingUniques(UniqueType.GreatGeneralAura) +
+                        it.getMatchingUniques(UniqueType.BonusForUnitsInRadius)
+            }.maxOfOrNull {
+                if (it.type == UniqueType.BonusForUnitsInRadius) 2
+                else it.params[2].toIntOrNull() ?: 0
+            } ?: 0
+        updateMaxGeneralBonusRadius(civInfo)
+    }
+
+    /** Update [CivilizationInfo.maxGeneralBonusRadius] from [CivilizationInfo.maxGeneralBonusRadiusBase]
+     *  and all units having a promotion granting Great General abilities. Should be called whenever
+     *  a unit is destroyed or otherwise removed from the civ, or a unit gains a promotion. */
+    fun updateMaxGeneralBonusRadius(civInfo: CivilizationInfo) {
+        // If there are no promotions granting a Great General power, then we don't need to scan the actual MapUnits
+        val promotionsGrantingGeneralBonus = civInfo.gameInfo.promotionsGrantingGeneralBonus
+        if (promotionsGrantingGeneralBonus.isEmpty()) {
+            civInfo.maxGeneralBonusRadius = civInfo.maxGeneralBonusRadiusBase
+            return
+        }
+
+        // Need to scan the units - might be faster looping getCivUnits only once, but far less readable
+        val maxPromotionGeneralBonusRadius = promotionsGrantingGeneralBonus.asSequence()
+            .filter { promotion ->
+                civInfo.getCivUnits().any { unit->
+                    promotion.name in unit.promotions.promotions
+                }
+            }.flatMap {
+                it.getMatchingUniques(UniqueType.GreatGeneralAura)
+            }.maxOfOrNull {
+                it.params[2].toIntOrNull() ?: 0
+            } ?: 0
+        civInfo.maxGeneralBonusRadius = civInfo.maxGeneralBonusRadiusBase
+            .coerceAtLeast(maxPromotionGeneralBonusRadius)
+    }
+}

--- a/core/src/com/unciv/logic/battle/GreatGeneralImplementation.kt
+++ b/core/src/com/unciv/logic/battle/GreatGeneralImplementation.kt
@@ -23,7 +23,7 @@ object GreatGeneralImplementation {
      *
      * Used by [BattleDamage.getGeneralModifiers].
      *
-     * @return Percentage a pair of unit's name and bonus as Int (typically 15), or 0 if no applicable Great General equivalents found
+     * @return A pair of unit's name and bonus (percentage) as Int (typically 15), or 0 if no applicable Great General equivalents found
      */
     fun getGreatGeneralBonus(unit: MapUnit): Pair<String, Int> {
         val civInfo = unit.civInfo

--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -122,13 +122,6 @@ class CivilizationInfo {
     @Transient
     var thingsToFocusOnForVictory = setOf<Victory.Focus>()
 
-    @Transient
-    /** Maximum radius of Great General or equivalent effect, from BaseUnit Uniques _only_. */
-    var maxGreatGeneralBonusRadiusBase = 0
-    @Transient
-    /** Maximum radius of Great General or equivalent effect, from BaseUnit Uniques _or_ Promotion Uniques. 0 if none found!! */
-    var maxGreatGeneralBonusRadius = 0
-
     var playerType = PlayerType.AI
 
     /** Used in online multiplayer for human players */
@@ -810,7 +803,6 @@ class CivilizationInfo {
 
         hasLongCountDisplayUnique = hasUnique(UniqueType.MayanCalendarDisplay)
 
-        GreatGeneralImplementation.setMaxGreatGeneralBonusRadiusBase(this)
     }
 
     fun updateSightAndResources() {
@@ -828,7 +820,6 @@ class CivilizationInfo {
     fun updateHasActiveGreatWall() = transients().updateHasActiveGreatWall()
     fun updateViewableTiles() = transients().updateViewableTiles()
     fun updateDetailedCivResources() = transients().updateCivResources()
-    fun updateMaxGreatGeneralBonusRadius() = GreatGeneralImplementation.updateMaxGreatGeneralBonusRadius(this)
 
     fun startTurn() {
         civConstructions.startTurn()

--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -124,10 +124,10 @@ class CivilizationInfo {
 
     @Transient
     /** Maximum radius of Great General or equivalent effect, from BaseUnit Uniques _only_. */
-    var maxGeneralBonusRadiusBase = 0
+    var maxGreatGeneralBonusRadiusBase = 0
     @Transient
     /** Maximum radius of Great General or equivalent effect, from BaseUnit Uniques _or_ Promotion Uniques. 0 if none found!! */
-    var maxGeneralBonusRadius = 0
+    var maxGreatGeneralBonusRadius = 0
 
     var playerType = PlayerType.AI
 
@@ -810,7 +810,7 @@ class CivilizationInfo {
 
         hasLongCountDisplayUnique = hasUnique(UniqueType.MayanCalendarDisplay)
 
-        GreatGeneralImplementation.setMaxGeneralBonusRadiusBase(this)
+        GreatGeneralImplementation.setMaxGreatGeneralBonusRadiusBase(this)
     }
 
     fun updateSightAndResources() {
@@ -828,7 +828,7 @@ class CivilizationInfo {
     fun updateHasActiveGreatWall() = transients().updateHasActiveGreatWall()
     fun updateViewableTiles() = transients().updateViewableTiles()
     fun updateDetailedCivResources() = transients().updateCivResources()
-    fun updateMaxGeneralBonusRadius() = GreatGeneralImplementation.updateMaxGeneralBonusRadius(this)
+    fun updateMaxGreatGeneralBonusRadius() = GreatGeneralImplementation.updateMaxGreatGeneralBonusRadius(this)
 
     fun startTurn() {
         civConstructions.startTurn()

--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -8,7 +8,6 @@ import com.unciv.logic.GameInfo
 import com.unciv.logic.UncivShowableException
 import com.unciv.logic.automation.NextTurnAutomation
 import com.unciv.logic.automation.WorkerAutomation
-import com.unciv.logic.battle.GreatGeneralImplementation
 import com.unciv.logic.city.CityInfo
 import com.unciv.logic.civilization.RuinsManager.RuinsManager
 import com.unciv.logic.civilization.diplomacy.DiplomacyFlags

--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -345,8 +345,7 @@ class MapUnit {
         canEnterForeignTerrain = hasUnique(UniqueType.CanEnterForeignTiles)
             || hasUnique(UniqueType.CanEnterForeignTilesButLosesReligiousStrength)
 
-        hasGreatGeneralUnique = hasUnique(UniqueType.GreatGeneralAura) ||
-                hasUnique(UniqueType.BonusForUnitsInRadius)
+        hasGreatGeneralUnique = hasUnique(UniqueType.StrengthBonusInRadius)
         hasCitadelPlacementUnique = getMatchingUniques(UniqueType.ConstructImprovementConsumingUnit)
             .mapNotNull { civInfo.gameInfo.ruleSet.tileImprovements[it.params[0]] }
             .any { it.hasUnique(UniqueType.TakeOverTilesAroundWhenBuilt) }

--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -121,6 +121,8 @@ class MapUnit {
 
     @Transient
     var hasGreatGeneralUnique = false
+    @Transient
+    var hasCitadelPlacementUnique = false
 
     /** civName owning the unit */
     lateinit var owner: String
@@ -345,6 +347,9 @@ class MapUnit {
 
         hasGreatGeneralUnique = hasUnique(UniqueType.GreatGeneralAura) ||
                 hasUnique(UniqueType.BonusForUnitsInRadius)
+        hasCitadelPlacementUnique = getMatchingUniques(UniqueType.ConstructImprovementConsumingUnit)
+            .mapNotNull { civInfo.gameInfo.ruleSet.tileImprovements[it.params[0]] }
+            .any { it.hasUnique(UniqueType.TakeOverTilesAroundWhenBuilt) }
     }
 
     fun copyStatisticsTo(newUnit: MapUnit) {

--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -120,7 +120,7 @@ class MapUnit {
     var hasUniqueToBuildImprovements = false    // not canBuildImprovements to avoid confusion
 
     @Transient
-    var hasGreatGeneralUnique = false
+    var hasStrengthBonusInRadiusUnique = false
     @Transient
     var hasCitadelPlacementUnique = false
 
@@ -345,7 +345,7 @@ class MapUnit {
         canEnterForeignTerrain = hasUnique(UniqueType.CanEnterForeignTiles)
             || hasUnique(UniqueType.CanEnterForeignTilesButLosesReligiousStrength)
 
-        hasGreatGeneralUnique = hasUnique(UniqueType.StrengthBonusInRadius)
+        hasStrengthBonusInRadiusUnique = hasUnique(UniqueType.StrengthBonusInRadius)
         hasCitadelPlacementUnique = getMatchingUniques(UniqueType.ConstructImprovementConsumingUnit)
             .mapNotNull { civInfo.gameInfo.ruleSet.tileImprovements[it.params[0]] }
             .any { it.hasUnique(UniqueType.TakeOverTilesAroundWhenBuilt) }

--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -847,7 +847,6 @@ class MapUnit {
         removeFromTile()
         civInfo.removeUnit(this)
         civInfo.updateViewableTiles()
-        civInfo.updateMaxGreatGeneralBonusRadius()
         // all transported units should be destroyed as well
         currentTile.getUnits().filter { it.isTransported && isTransportTypeOf(it) }
             .toList() // because we're changing the list

--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -120,6 +120,9 @@ class MapUnit {
     @Transient
     var hasUniqueToBuildImprovements = false    // not canBuildImprovements to avoid confusion
 
+    @Transient
+    var hasGreatGeneralUnique = false
+
     /** civName owning the unit */
     lateinit var owner: String
 
@@ -340,6 +343,9 @@ class MapUnit {
         hasUniqueToBuildImprovements = hasUnique(UniqueType.BuildImprovements)
         canEnterForeignTerrain = hasUnique(UniqueType.CanEnterForeignTiles)
             || hasUnique(UniqueType.CanEnterForeignTilesButLosesReligiousStrength)
+
+        hasGreatGeneralUnique = hasUnique(UniqueType.GreatGeneralAura) ||
+                hasUnique(UniqueType.BonusForUnitsInRadius)
     }
 
     fun copyStatisticsTo(newUnit: MapUnit) {
@@ -837,6 +843,7 @@ class MapUnit {
         removeFromTile()
         civInfo.removeUnit(this)
         civInfo.updateViewableTiles()
+        civInfo.updateMaxGeneralBonusRadius()
         // all transported units should be destroyed as well
         currentTile.getUnits().filter { it.isTransported && isTransportTypeOf(it) }
             .toList() // because we're changing the list

--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -578,6 +578,7 @@ class MapUnit {
     fun canGarrison() = isMilitary() && baseUnit.isLandUnit()
 
     fun isGreatPerson() = baseUnit.isGreatPerson()
+    fun isGreatPersonOfType(type: String) = baseUnit.isGreatPersonOfType(type)
 
     //endregion
 

--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -23,7 +23,6 @@ import com.unciv.models.ruleset.unit.UnitType
 import com.unciv.models.stats.Stats
 import com.unciv.ui.utils.filterAndLogic
 import com.unciv.ui.utils.toPercent
-import com.unciv.ui.worldscreen.unit.UnitActions
 import java.text.DecimalFormat
 import kotlin.math.pow
 
@@ -843,7 +842,7 @@ class MapUnit {
         removeFromTile()
         civInfo.removeUnit(this)
         civInfo.updateViewableTiles()
-        civInfo.updateMaxGeneralBonusRadius()
+        civInfo.updateMaxGreatGeneralBonusRadius()
         // all transported units should be destroyed as well
         currentTile.getUnits().filter { it.isTransported && isTransportTypeOf(it) }
             .toList() // because we're changing the list

--- a/core/src/com/unciv/logic/map/UnitPromotions.kt
+++ b/core/src/com/unciv/logic/map/UnitPromotions.kt
@@ -73,8 +73,10 @@ class UnitPromotions {
         // If we upgrade this unit to its new version, we already need to have this promotion added,
         // so this has to go after the `promotions.add(promotionname)` line.
         doDirectPromotionEffects(promotion)
-        
+
         unit.updateUniques(ruleset)
+
+        unit.civInfo.updateMaxGeneralBonusRadius()  // In case a mod has promotions granting GG uniques
 
         // Since some units get promotions upon construction, they will get the addPromotion from the unit.postBuildEvent
         // upon creation, BEFORE they are assigned to a tile, so the updateVisibleTiles() would crash.

--- a/core/src/com/unciv/logic/map/UnitPromotions.kt
+++ b/core/src/com/unciv/logic/map/UnitPromotions.kt
@@ -76,8 +76,6 @@ class UnitPromotions {
 
         unit.updateUniques(ruleset)
 
-        unit.civInfo.updateMaxGreatGeneralBonusRadius()  // In case a mod has promotions granting GG uniques
-
         // Since some units get promotions upon construction, they will get the addPromotion from the unit.postBuildEvent
         // upon creation, BEFORE they are assigned to a tile, so the updateVisibleTiles() would crash.
         // So, if the addPromotion was triggered from there, simply don't update

--- a/core/src/com/unciv/logic/map/UnitPromotions.kt
+++ b/core/src/com/unciv/logic/map/UnitPromotions.kt
@@ -76,7 +76,7 @@ class UnitPromotions {
 
         unit.updateUniques(ruleset)
 
-        unit.civInfo.updateMaxGeneralBonusRadius()  // In case a mod has promotions granting GG uniques
+        unit.civInfo.updateMaxGreatGeneralBonusRadius()  // In case a mod has promotions granting GG uniques
 
         // Since some units get promotions upon construction, they will get the addPromotion from the unit.postBuildEvent
         // upon creation, BEFORE they are assigned to a tile, so the updateVisibleTiles() would crash.

--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -631,7 +631,8 @@ class Ruleset {
                 val improvementName = unique.params[0]
                 if (tileImprovements[improvementName]==null) continue // this will be caught in the checkUniques
                 if ((tileImprovements[improvementName] as Stats).none() &&
-                        unit.isCivilian() && !unit.isGreatGeneral()) {
+                        unit.isCivilian() &&
+                        !unit.isGreatPersonOfType("War")) {
                     lines.add("${unit.name} can place improvement $improvementName which has no stats, preventing unit automation!",
                         RulesetErrorSeverity.Warning)
                 }

--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -631,8 +631,7 @@ class Ruleset {
                 val improvementName = unique.params[0]
                 if (tileImprovements[improvementName]==null) continue // this will be caught in the checkUniques
                 if ((tileImprovements[improvementName] as Stats).none() &&
-                        unit.isCivilian() &&
-                        !unit.hasUnique("Bonus for units in 2 tile radius 15%")) {
+                        unit.isCivilian() && !unit.isGreatGeneral()) {
                     lines.add("${unit.name} can place improvement $improvementName which has no stats, preventing unit automation!",
                         RulesetErrorSeverity.Warning)
                 }

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -412,9 +412,9 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
     StrengthBonusVsCityStates("+30% Strength when fighting City-State units and cities", UniqueTarget.Global),
     StrengthForAdjacentEnemies("[relativeAmount]% Strength for enemy [combatantFilter] units in adjacent [tileFilter] tiles", UniqueTarget.Unit),
     StrengthWhenStacked("[relativeAmount]% Strength when stacked with [mapUnitFilter]", UniqueTarget.Unit),  // candidate for conditional!
-    @Deprecated("as of 4.0.15", ReplaceWith("[15]% Strength bonus for [Military] units in a [2] tile radius"))
+    @Deprecated("as of 4.0.15", ReplaceWith("[15]% Strength for [Military] units in a [2] tile radius"))
     BonusForUnitsInRadius("Bonus for units in 2 tile radius 15%", UniqueTarget.Unit),
-    GreatGeneralAura("[relativeAmount]% Strength bonus for [mapUnitFilter] units in a [amount] tile radius", UniqueTarget.Unit),
+    GreatGeneralAura("[relativeAmount]% Strength for [mapUnitFilter] units in a [amount] tile radius", UniqueTarget.Unit),
 
     AdditionalAttacks("[amount] additional attacks per turn", UniqueTarget.Unit, UniqueTarget.Global),
     Movement("[amount] Movement", UniqueTarget.Unit, UniqueTarget.Global),

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -412,9 +412,7 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
     StrengthBonusVsCityStates("+30% Strength when fighting City-State units and cities", UniqueTarget.Global),
     StrengthForAdjacentEnemies("[relativeAmount]% Strength for enemy [combatantFilter] units in adjacent [tileFilter] tiles", UniqueTarget.Unit),
     StrengthWhenStacked("[relativeAmount]% Strength when stacked with [mapUnitFilter]", UniqueTarget.Unit),  // candidate for conditional!
-    @Deprecated("as of 4.0.15", ReplaceWith("[15]% Strength for [Military] units in a [2] tile radius"))
-    BonusForUnitsInRadius("Bonus for units in 2 tile radius 15%", UniqueTarget.Unit),
-    GreatGeneralAura("[relativeAmount]% Strength for [mapUnitFilter] units in a [amount] tile radius", UniqueTarget.Unit),
+    StrengthBonusInRadius("[relativeAmount]% Strength bonus for [mapUnitFilter] units in [amount] tiles", UniqueTarget.Unit),
 
     AdditionalAttacks("[amount] additional attacks per turn", UniqueTarget.Unit, UniqueTarget.Global),
     Movement("[amount] Movement", UniqueTarget.Unit, UniqueTarget.Global),

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -758,6 +758,8 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
 
     // region DEPRECATED AND REMOVED
 
+    @Deprecated("as of 4.1.0", ReplaceWith("[+15]% Strength bonus for [Military] units in [2] tiles"), DeprecationLevel.ERROR)
+    BonusForUnitsInRadius("Bonus for units in 2 tile radius 15%", UniqueTarget.Unit),
     @Deprecated("as of 4.0.15", ReplaceWith("Irremovable"), DeprecationLevel.ERROR)
     Indestructible("Indestructible", UniqueTarget.Improvement),
     

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -231,7 +231,7 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
     UnitsFightFullStrengthWhenDamaged("Units fight as though they were at full strength even when damaged", UniqueTarget.Global),
     GoldWhenDiscoveringNaturalWonder("100 Gold for discovering a Natural Wonder (bonus enhanced to 500 Gold if first to discover it)", UniqueTarget.Global),
     UnhappinessFromCitiesDoubled("Unhappiness from number of Cities doubled", UniqueTarget.Global),
-    GreatGeneralProvidesDoubleCombatBonus("Great General provides double combat bonus", UniqueTarget.Global),
+    GreatGeneralProvidesDoubleCombatBonus("Great General provides double combat bonus", UniqueTarget.Unit, UniqueTarget.Global),
     TechBoostWhenScientificBuildingsBuiltInCapital("Receive a tech boost when scientific buildings/wonders are built in capital", UniqueTarget.Global),
     MayNotGenerateGreatProphet("May not generate great prophet equivalents naturally", UniqueTarget.Global),
     @Deprecated("as of 4.0.3", ReplaceWith("When conquering an encampment, earn [25] Gold and recruit a Barbarian unit <with [67]% chance>"))
@@ -412,6 +412,9 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
     StrengthBonusVsCityStates("+30% Strength when fighting City-State units and cities", UniqueTarget.Global),
     StrengthForAdjacentEnemies("[relativeAmount]% Strength for enemy [combatantFilter] units in adjacent [tileFilter] tiles", UniqueTarget.Unit),
     StrengthWhenStacked("[relativeAmount]% Strength when stacked with [mapUnitFilter]", UniqueTarget.Unit),  // candidate for conditional!
+    @Deprecated("as of 4.0.15", ReplaceWith("[15]% Strength bonus for [Military] units in a [2] tile radius"))
+    BonusForUnitsInRadius("Bonus for units in 2 tile radius 15%", UniqueTarget.Unit),
+    GreatGeneralAura("[relativeAmount]% Strength bonus for [mapUnitFilter] units in a [amount] tile radius", UniqueTarget.Unit),
 
     AdditionalAttacks("[amount] additional attacks per turn", UniqueTarget.Unit, UniqueTarget.Global),
     Movement("[amount] Movement", UniqueTarget.Unit, UniqueTarget.Global),
@@ -528,8 +531,6 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
     RemoveOtherReligions("Removes other religions when spreading religion", UniqueTarget.Unit),
 
     CanActionSeveralTimes("Can [action] [amount] times", UniqueTarget.Unit),
-    // TODO needs to be more general
-    BonusForUnitsInRadius("Bonus for units in 2 tile radius 15%", UniqueTarget.Unit),
 
     CanSpeedupConstruction("Can speed up construction of a building", UniqueTarget.Unit),
     CanHurryResearch("Can hurry technology research", UniqueTarget.Unit),

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -412,7 +412,7 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
     StrengthBonusVsCityStates("+30% Strength when fighting City-State units and cities", UniqueTarget.Global),
     StrengthForAdjacentEnemies("[relativeAmount]% Strength for enemy [combatantFilter] units in adjacent [tileFilter] tiles", UniqueTarget.Unit),
     StrengthWhenStacked("[relativeAmount]% Strength when stacked with [mapUnitFilter]", UniqueTarget.Unit),  // candidate for conditional!
-    StrengthBonusInRadius("[relativeAmount]% Strength bonus for [mapUnitFilter] units in [amount] tiles", UniqueTarget.Unit),
+    StrengthBonusInRadius("[relativeAmount]% Strength bonus for [mapUnitFilter] units within [amount] tiles", UniqueTarget.Unit),
 
     AdditionalAttacks("[amount] additional attacks per turn", UniqueTarget.Unit, UniqueTarget.Global),
     Movement("[amount] Movement", UniqueTarget.Unit, UniqueTarget.Global),
@@ -758,7 +758,7 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
 
     // region DEPRECATED AND REMOVED
 
-    @Deprecated("as of 4.1.0", ReplaceWith("[+15]% Strength bonus for [Military] units in [2] tiles"), DeprecationLevel.ERROR)
+    @Deprecated("as of 4.1.0", ReplaceWith("[+15]% Strength bonus for [Military] units within [2] tiles"), DeprecationLevel.ERROR)
     BonusForUnitsInRadius("Bonus for units in 2 tile radius 15%", UniqueTarget.Unit),
     @Deprecated("as of 4.0.15", ReplaceWith("Irremovable"), DeprecationLevel.ERROR)
     Indestructible("Indestructible", UniqueTarget.Improvement),

--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -617,11 +617,6 @@ class BaseUnit : RulesetObject(), INonPerpetualConstruction {
                 }
         )
 
-    /** Checks whether this [BaseUnit] is a Great Geenral equivalent - not to be confused with [MapUnit.hasGreatGeneralUnique], which can be gained by modded Promotions */
-    // Only exists for Ruleset.checkModLinks readability, once the deprecated unique is gone consider folding this away
-    fun isGreatGeneral() = hasUnique(UniqueType.GreatGeneralAura) ||
-            hasUnique(UniqueType.BonusForUnitsInRadius)
-
     fun getForceEvaluation(): Int {
         if (cachedForceEvaluation < 0)    evaluateForce()
         return  cachedForceEvaluation

--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -577,7 +577,8 @@ class BaseUnit : RulesetObject(), INonPerpetualConstruction {
         }
     }
 
-    fun isGreatPerson() = hasUnique(UniqueType.GreatPerson)
+    fun isGreatPerson() = getMatchingUniques(UniqueType.GreatPerson).any()
+    fun isGreatPersonOfType(type: String) = getMatchingUniques(UniqueType.GreatPerson).any { it.params[0] == type }
 
     fun isNuclearWeapon() = hasUnique(UniqueType.NuclearWeapon)
 

--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -616,6 +616,11 @@ class BaseUnit : RulesetObject(), INonPerpetualConstruction {
                 }
         )
 
+    /** Checks whether this [BaseUnit] is a Great Geenral equivalent - not to be confused with [MapUnit.hasGreatGeneralUnique], which can be gained by modded Promotions */
+    // Only exists for Ruleset.checkModLinks readabilty, once the deprecated unique is gone consider folding this away
+    fun isGreatGeneral() = hasUnique(UniqueType.GreatGeneralAura) ||
+            hasUnique(UniqueType.BonusForUnitsInRadius)
+
     fun getForceEvaluation(): Int {
         if (cachedForceEvaluation < 0)    evaluateForce()
         return  cachedForceEvaluation

--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -617,7 +617,7 @@ class BaseUnit : RulesetObject(), INonPerpetualConstruction {
         )
 
     /** Checks whether this [BaseUnit] is a Great Geenral equivalent - not to be confused with [MapUnit.hasGreatGeneralUnique], which can be gained by modded Promotions */
-    // Only exists for Ruleset.checkModLinks readabilty, once the deprecated unique is gone consider folding this away
+    // Only exists for Ruleset.checkModLinks readability, once the deprecated unique is gone consider folding this away
     fun isGreatGeneral() = hasUnique(UniqueType.GreatGeneralAura) ||
             hasUnique(UniqueType.BonusForUnitsInRadius)
 

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -458,7 +458,7 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 	Applicable to: Global
 
 ??? example  "Great General provides double combat bonus"
-	Applicable to: Global
+	Applicable to: Global, Unit
 
 ??? example  "Receive a tech boost when scientific buildings/wonders are built in capital"
 	Applicable to: Global
@@ -988,11 +988,6 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 ??? example  "May create improvements on water resources"
 	Applicable to: Unit
 
-??? example  "[relativeAmount]% Strength bonus for [mapUnitFilter] units in [amount] tiles"
-	Example: "[+20]% Strength bonus for [Wounded] units in [3] tiles"
-
-	Applicable to: Unit
-
 ??? example  "[relativeAmount]% Strength for enemy [combatantFilter] units in adjacent [tileFilter] tiles"
 	Example: "[+20]% Strength for enemy [City] units in adjacent [Farm] tiles"
 
@@ -1000,6 +995,11 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 ??? example  "[relativeAmount]% Strength when stacked with [mapUnitFilter]"
 	Example: "[+20]% Strength when stacked with [Wounded]"
+
+	Applicable to: Unit
+
+??? example  "[relativeAmount]% Strength bonus for [mapUnitFilter] units in [amount] tiles"
+	Example: "[+20]% Strength bonus for [Wounded] units in [3] tiles"
 
 	Applicable to: Unit
 

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -988,6 +988,11 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 ??? example  "May create improvements on water resources"
 	Applicable to: Unit
 
+??? example  "[relativeAmount]% Strength bonus for [mapUnitFilter] units in [amount] tiles"
+	Example: "[+20]% Strength bonus for [Wounded] units in [3] tiles"
+
+	Applicable to: Unit
+
 ??? example  "[relativeAmount]% Strength for enemy [combatantFilter] units in adjacent [tileFilter] tiles"
 	Example: "[+20]% Strength for enemy [City] units in adjacent [Farm] tiles"
 
@@ -1212,9 +1217,6 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 ??? example  "Can [action] [amount] times"
 	Example: "Can [Spread Religion] [3] times"
 
-	Applicable to: Unit
-
-??? example  "Bonus for units in 2 tile radius 15%"
 	Applicable to: Unit
 
 ??? example  "Can speed up construction of a building"


### PR DESCRIPTION
This PR is based on 2 previous implementations: #6751 and #6750 .

I have tried to get all the best from 2 versions + made a performance test of the both ways and took the simplest one.
The performance measurement were made in the next way:
```
val executionTime = measureTimeMillis {
    for (i in 0..100000) {
        val greatGeneralModifier =
            GreatGeneralImplementation.getGreatGeneralBonus(combatant.unit)
        if (greatGeneralModifier.second != 0)
            modifiers[greatGeneralModifier.first] = greatGeneralModifier.second + i - i
    }
}
println(executionTime)
```
while changing the function `getGreatGeneralBonus` within `GreatGeneralImplementation` class and that brought me to the next average results for 14 sequencial runs:
| S implementation with 80 units | J implementation with 80 units | J implementation with 200 units |
| --- | --- | --- |
| 502 ms | 410 ms | 530 ms |

Thus, the performance of the function is around 0.005 ms, which is absolutely acceptable in both implementations. I decided to choose mine as it takes less code = easier to maintain = less bugs in the future.

As a result we have here:
**Pros:**
* Minimum of the additional logic
* The calculation is the same fast for different radius of aura since it does not scan the tiles for units
* Citadel building AI logic is some kind of isolated
* Having several units with different bonuses the maximum will be taken
* The name of unit with `StrengthBonusInRadius` is shown to distinct which of those contributed to the battle stats
* No need to keep the old unique since it will be automatically replaced with the new one in the rules
* `GreatGeneralProvidesDoubleCombatBonus` will be triggered only for Great Generals (China has really great Great Generals but not other modded units)

**Cons:**
* The performance decreases linearly with number of units in civ (but it can be ignored since it takes less than 0.01 ms)
* The replacement of deprecated unique needs to be cleaned up anyway at some point

