### PR TITLE
Mark Unciv as an application that may use more memory than usual on Android

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:roundIcon="@mipmap/uncivicon_round"
         android:label="@string/app_name"
         android:isGame="true"
+        android:largeHeap="true"
         android:appCategory="game"
         android:banner="@drawable/banner"
         android:theme="@style/GdxTheme" >


### PR DESCRIPTION
I brought this in and it was denied, but I think this is so fundamental and important that I'm going to try again.

What it actually does:

By setting `largeHeap=true` you tell Android that your application is an application that uses a lot of memory, so it gives your application more heap. 

For example, on my phone, it increases the memory available from 192MB to 512MB on my 4GB of RAM. I regularly have more than 320MB free on my phone anyway, so setting `largeHeap=true` for me is basically free memory.

Arguments against `largeHeap=true`:

* The game is meant for potato phones, so it should use as little memory as possible to be as performant as possible. If we use `largeHeap=true`, we might get lazy and not do that as much
* Please add more if you have, this is literally the only one I could find

Arguments for `largeHeap=true`:

* Performance is important for all of us devs, setting a variable in a file is not going to change that. Performance/memory optimization focus by devs will stay exactly the same as before
* `largeHeap=true` is meant for potato phones because potato phones are the ones with lower memory. The only negativ thing using more memory does for the user is that their background applications will get killed more often, since more memory is available to the active application. But this is exactly what a potato phone user wants! They want their active application to have the best performance possible, because their performance is already shit. They'll gladly take any gains they can, screw slightly faster task switching.
* `largeHeap=true` actually increases performance by itself. Having a lower heap space available means that the garbage collector (GC) needs to run more often. If we can have longer periods without the GC, it can schedule it's GCing better when nothing is happening, and it can work more efficiently when it actually has to run, since doing many small GCs are slightly less performant than doing one bigger one.
* For what reason does the `largeHeap=true` flag exist? It exists because some applications, by their nature, are more memory-hungry than others. A calculator, alarm or to-do-list application does not need hundreds of megabytes of memory to run. However, a game (just as a simple example) very often uses a lot of memory, does a lot of things, so it makes sense for games to be able to request more memory available.
* Setting `largeHeap=true` doesn't massively impact performance, but it massively impacts what people can do. A game of Unciv simply uses X amounts of memory, more the larger you make your map and the more players you add. So if you have less memory available, you are simply not able to use a larger map at one point. So if `largeHeap=true`, people simply get access to a whole lot more map sizes they previously did not have, basically without drawbacks, since if their performance is bad with these larger maps, they can just go back to playing smaller maps, like before.
* Our map sizes in Unciv are **not** equal to Civ 5. Our current map sizes compared to official Civ 5 map sizes:

   |Game|Label|Hexagon Radius|Rectangle|
   |---|---|---|---|
   |Unciv|Tiny|10|23x15
   |Unciv|Small|15|33x21
   |Civ 5|Duel|17|40x24
   |Unciv|Medium|20|44x29
   |Civ 5|Tiny|25|56x36
   |Civ 5|Small|30|66x42
   |Unciv|Large|30|66x43
   |Civ 5|Medium|37|80x52
   |Unciv|Huge|40|87x57
   |Civ 5|Large|47|104x64
   |Civ 5|Huge|58|128x80

   As you can see, we basically use one size category smaller and even that is smaller than in Civ 5. I know many people don't like playing on larger maps, but I imagine many people do (including myself). Our goal is eventual Civ 5 parity. We can get closer to that right now with one configuration change.

My personal stance is: simply because our use case is exactly why this flag exists should it be used. Yes, we can probably do a whole bunch of memory improvements and be able to eventually get the game working fine with large maps even on smaller available heap. But not using it is just limiting us artificially: even if we do these improvements, we still don't use "free" memory that we could have, and even with these memory improvements, still, just by setting this flag to true, we could have even more things.

And just as a personal anecdote: I use a custom build for me and my friends that have `largeHeap=true`, because otherwise we can't use the larger maps that we like to play. I'm literally unable to join our multiplayer game without `largeHeap=true`, but I can easily do it with it on, and the performance is really good. I haven't noticed any impact on other applications.

So, pretty please with cherries, can we get this merged? :D