### PR TITLE
Allow generation of "Default" Deciv redux maps

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -498,6 +498,7 @@ Starting location(s): [param] =
 Continent: [param] ([amount] tiles) = 
 Change map to fit selected ruleset? = 
 Area: [amount] tiles, [amount2] continents/islands = 
+Area: [amount] tiles, [amount2]% water, [amount3] continents/islands = 
 Do you want to leave without saving the recent changes? = 
 Do you want to load another map without saving the recent changes? = 
 Invalid map: Area ([area]) does not match saved dimensions ([dimensions]). = 

--- a/core/src/com/unciv/MainMenuScreen.kt
+++ b/core/src/com/unciv/MainMenuScreen.kt
@@ -75,7 +75,11 @@ class MainMenuScreen: BaseScreen() {
 
         launchCrashHandling("ShowMapBackground") {
             val newMap = MapGenerator(RulesetCache.getVanillaRuleset())
-                    .generateMap(MapParameters().apply { mapSize = MapSizeNew(MapSize.Small); type = MapType.default })
+                    .generateMap(MapParameters().apply {
+                        mapSize = MapSizeNew(MapSize.Small)
+                        type = MapType.default
+                        waterThreshold = -0.055f // Gives the same level as when waterThreshold was unused in MapType.default
+                    })
             postCrashHandlingRunnable { // for GL context
                 ImageGetter.setNewRuleset(RulesetCache.getVanillaRuleset())
                 val mapHolder = EditorMapHolder(this@MainMenuScreen, newMap) {}

--- a/core/src/com/unciv/logic/map/TileMap.kt
+++ b/core/src/com/unciv/logic/map/TileMap.kt
@@ -2,10 +2,10 @@ package com.unciv.logic.map
 
 import com.badlogic.gdx.math.Rectangle
 import com.badlogic.gdx.math.Vector2
-import com.unciv.Constants
 import com.unciv.logic.GameInfo
 import com.unciv.logic.HexMath
 import com.unciv.logic.civilization.CivilizationInfo
+import com.unciv.logic.map.mapgenerator.MapLandmassGenerator
 import com.unciv.models.metadata.Player
 import com.unciv.models.ruleset.Nation
 import com.unciv.models.ruleset.Ruleset
@@ -95,7 +95,7 @@ class TileMap {
     /** creates a hexagonal map of given radius (filled with grassland) */
     constructor(radius: Int, ruleset: Ruleset, worldWrap: Boolean = false) {
         startingLocations.clear()
-        val firstAvailableLandTerrain = getInitializationTerrain(ruleset)
+        val firstAvailableLandTerrain = MapLandmassGenerator.getInitializationTerrain(ruleset, TerrainType.Land)
         for (vector in HexMath.getVectorsInDistance(Vector2.Zero, radius, worldWrap))
             tileList.add(TileInfo().apply { position = vector; baseTerrain = firstAvailableLandTerrain })
         setTransients(ruleset)
@@ -104,7 +104,7 @@ class TileMap {
     /** creates a rectangular map of given width and height (filled with grassland) */
     constructor(width: Int, height: Int, ruleset: Ruleset, worldWrap: Boolean = false) {
         startingLocations.clear()
-        val firstAvailableLandTerrain = getInitializationTerrain(ruleset)
+        val firstAvailableLandTerrain = MapLandmassGenerator.getInitializationTerrain(ruleset, TerrainType.Land)
 
         // world-wrap maps must always have an even width, so round down
         val wrapAdjustedWidth = if (worldWrap && width % 2 != 0) width -1 else width
@@ -120,10 +120,6 @@ class TileMap {
 
         setTransients(ruleset)
     }
-
-    private fun getInitializationTerrain(ruleset: Ruleset) =
-        ruleset.terrains.values.firstOrNull { it.type == TerrainType.Land }?.name
-            ?: throw Exception("Cannot create map - no land terrains found!")
 
     //endregion
     //region Operators and Standards

--- a/core/src/com/unciv/ui/mapeditor/EditorMapHolder.kt
+++ b/core/src/com/unciv/ui/mapeditor/EditorMapHolder.kt
@@ -216,6 +216,11 @@ class EditorMapHolder(
         val positionalCoords = tileGroupMap.getPositionalVector(stageCoords)
         val hexPosition = HexMath.world2HexCoords(positionalCoords)
         val rounded = HexMath.roundHexCoords(hexPosition)
-        return tileMap.getOrNull(rounded)
+
+        if (!tileMap.mapParameters.worldWrap)
+            return tileMap.getOrNull(rounded)
+        val wrapped = HexMath.getUnwrappedNearestTo(rounded, Vector2.Zero, tileMap.maxLongitude)
+        //todo this works, but means getUnwrappedNearestTo fails - on the x-y == maxLongitude vertical
+        return tileMap.getOrNull(wrapped) ?: tileMap.getOrNull(rounded)
     }
 }

--- a/core/src/com/unciv/ui/mapeditor/MapEditorGenerateTab.kt
+++ b/core/src/com/unciv/ui/mapeditor/MapEditorGenerateTab.kt
@@ -109,8 +109,10 @@ class MapEditorGenerateTab(
                 when (step) {
                     MapGeneratorSteps.All -> {
                         val generatedMap = generator!!.generateMap(mapParameters)
+                        val savedScale = editorScreen.mapHolder.scaleX
                         Gdx.app.postRunnable {
                             freshMapCompleted(generatedMap, mapParameters, newRuleset!!, selectPage = 0)
+                            editorScreen.mapHolder.zoom(savedScale)
                         }
                     }
                     MapGeneratorSteps.Landmass -> {

--- a/core/src/com/unciv/ui/mapeditor/MapEditorScreen.kt
+++ b/core/src/com/unciv/ui/mapeditor/MapEditorScreen.kt
@@ -20,6 +20,7 @@ import com.unciv.ui.utils.*
 
 //todo normalize properly
 
+//todo Remove "Area: [amount] tiles, [amount2] continents/islands = " after 2022-07-01
 //todo Direct Strategic Resource abundance control
 //todo functional Tab for Units (empty Tab is prepared but commented out in MapEditorEditTab.AllEditSubTabs)
 //todo copy/paste tile areas? (As tool tab, brush sized, floodfill forbidden, tab displays copied area)

--- a/core/src/com/unciv/ui/mapeditor/MapEditorViewTab.kt
+++ b/core/src/com/unciv/ui/mapeditor/MapEditorViewTab.kt
@@ -76,7 +76,10 @@ class MapEditorViewTab(
             ToastPopup("Error assigning continents: ${ex.message}", editorScreen)
         }
 
-        val statsText = "Area: [${tileMap.values.size}] tiles, [${tileMap.continentSizes.size}] continents/islands"
+        val area = tileMap.values.size
+        val waterPercent = (tileMap.values.count { it.isWater } * 100f / area).toInt()
+        val continents = tileMap.continentSizes.size
+        val statsText = "Area: [$area] tiles, $waterPercent% water, [$continents] continents/islands"
         val statsLabel = WrappableLabel(statsText, labelWidth)
         add(statsLabel.apply { wrap = true }).row()
 


### PR DESCRIPTION
Follow-up to @xlenstra comment on #6816.

This time I couldn't resist: That type ignored waterThreshold from the advanced MapParameters, now it doesn't. Effect of slider mapped to a "nice" looking range, comparing water percentages to other types. For that, I patched Map editor to display said water percentage. Might interest others, too. While there, I fixed a problem with "drag" painting not yet dealing with world wrap - never did.

That in turn shows - @will-ca 's arrow code came with the function I use, and I needed a kludge: The function is not meant to guarantee an actual tile at the returned coordinates, but IMHO with "closest to" target (0,0) it should. Doesn't. As I do not really understand all that HexMath, I left the kludge. Maybe someone can look into it?