### PR TITLE
Great improvements can again be constructed on forest

### DIFF
--- a/android/assets/jsons/Civ V - Gods & Kings/TileImprovements.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/TileImprovements.json
@@ -181,31 +181,31 @@
 		"name": "Academy",
 		"terrainsCanBeBuiltOn": ["Land"],
 		"science": 8,
-		"uniques": ["Great Improvement", "[+2 Science] <after discovering [Scientific Theory]>", "[+2 Science] <after discovering [Atomic Theory]>"]
+		"uniques": ["Great Improvement", "[+2 Science] <after discovering [Scientific Theory]>", "[+2 Science] <after discovering [Atomic Theory]>", "Removes removable features when built"]
 	},
 	{
 		"name": "Landmark",
 		"terrainsCanBeBuiltOn": ["Land"],
 		"culture": 6,
-		"uniques": ["Great Improvement"]
+		"uniques": ["Great Improvement", "Removes removable features when built"]
 	},
 	{
 		"name": "Manufactory",
 		"terrainsCanBeBuiltOn": ["Land"],
 		"production": 4,
-		"uniques": ["Great Improvement", "[+1 Production] <after discovering [Chemistry]>"]
+		"uniques": ["Great Improvement", "[+1 Production] <after discovering [Chemistry]>", "Removes removable features when built"]
 	},
 	{
 		"name": "Customs house",
 		"terrainsCanBeBuiltOn": ["Land"],
 		"gold": 4,
-		"uniques": ["Great Improvement", "[+1 Gold] <after discovering [Economics]>"]
+		"uniques": ["Great Improvement", "[+1 Gold] <after discovering [Economics]>", "Removes removable features when built"]
 	},
 	{
 		"name": "Holy site",
 		"terrainsCanBeBuiltOn": ["Land"],
 		"faith": 6,
-		"uniques": ["Great Improvement"]
+		"uniques": ["Great Improvement", "Removes removable features when built"]
 	},
 	{
 		"name": "Citadel",
@@ -215,7 +215,8 @@
 			"Gives a defensive bonus of [100]%",
 			"Adjacent enemy units ending their turn take [30] damage",
 			"Can be built just outside your borders",
-        	"Constructing it will take over the tiles around it and assign them to your closest city"
+        	"Constructing it will take over the tiles around it and assign them to your closest city",
+			"Removes removable features when built",
 		]
 	},
 

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -619,8 +619,9 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
     CanBuildJustOutsideBorders("Can be built just outside your borders", UniqueTarget.Improvement),
     CanOnlyBeBuiltOnTile("Can only be built on [tileFilter] tiles", UniqueTarget.Improvement),
     CannotBuildOnTile("Cannot be built on [tileFilter] tiles", UniqueTarget.Improvement),
-    NoFeatureRemovalNeeded("Does not need removal of [tileFilter]", UniqueTarget.Improvement),
     CanOnlyImproveResource("Can only be built to improve a resource", UniqueTarget.Improvement),
+    NoFeatureRemovalNeeded("Does not need removal of [tileFilter]", UniqueTarget.Improvement),
+    RemovesFeaturesIfBuilt("Removes removable features when built", UniqueTarget.Improvement),
 
     DefensiveBonus("Gives a defensive bonus of [relativeAmount]%", UniqueTarget.Improvement),
     ImprovementMaintenance("Costs [amount] gold per turn when in your territory", UniqueTarget.Improvement), // Unused

--- a/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
@@ -644,14 +644,6 @@ object UnitActions {
                 title = "Create [$improvementName]",
                 action = {
                     val unitTile = unit.getTile()
-                    unitTile.setTerrainFeatures(
-                        // Remove terrainFeatures that a Worker can remove
-                        // and that aren't explicitly allowed under the improvement
-                        unitTile.terrainFeatures.filter {
-                            "Remove $it" !in unitTile.ruleset.tileImprovements ||
-                            it in improvement.terrainsCanBeBuiltOn
-                        }
-                    )
                     unitTile.removeCreatesOneImprovementMarker()
                     unitTile.improvement = improvementName
                     unitTile.stopWorkingOnImprovement()

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -1430,12 +1430,15 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 	Applicable to: Improvement
 
+??? example  "Can only be built to improve a resource"
+	Applicable to: Improvement
+
 ??? example  "Does not need removal of [tileFilter]"
 	Example: "Does not need removal of [Farm]"
 
 	Applicable to: Improvement
 
-??? example  "Can only be built to improve a resource"
+??? example  "Removes removable features when built"
 	Applicable to: Improvement
 
 ??? example  "Gives a defensive bonus of [relativeAmount]%"


### PR DESCRIPTION
This PR fixes a bug where great improvements couldn't be build on forests/marshes/jungles/etc. It does so by creating a unique which specifically allows for removing features, and checking for that.
Additionally, we only remove these features when we have the tech to remove them. For example, you can no longer plonk an Academy down over a forest without having researched mining.