### PR TITLE
Fix uniques.md being generated with wrong line endings

### DIFF
--- a/desktop/src/com/unciv/app/desktop/UniqueDocsWriter.kt
+++ b/desktop/src/com/unciv/app/desktop/UniqueDocsWriter.kt
@@ -71,7 +71,7 @@ class UniqueDocsWriter {
                     // `val paramExamples = uniqueType.parameterTypeMap.map { it.joinToString("/") { pt -> pt.docExample } }.toTypedArray()`
                     // Might confuse modders to think "/" can go into the _actual_ unique and mean "or", so better show just one ("Farm" in the example above):
                     val paramExamples = uniqueType.parameterTypeMap.map { it.first().docExample }.toTypedArray()
-                    lines += "\tExample: \"${uniqueText.fillPlaceholders(*paramExamples)}\"\r\n"
+                    lines += "\tExample: \"${uniqueText.fillPlaceholders(*paramExamples)}\"\n"
                 }
                 lines += "\tApplicable to: " + uniqueType.allTargets().sorted().joinToString()
                 lines += ""
@@ -87,7 +87,6 @@ class UniqueDocsWriter {
             lines += "*[${paramType.parameterName}]: ${paramType.docDescription}$punctuation"
         }
 
-        // Let's use CRLF ending same as in all other files
-        File("../../docs/Modders/uniques.md").writeText(lines.joinToString("\r\n"))
+        File("../../docs/Modders/uniques.md").writeText(lines.joinToString("\n"))
     }
 }


### PR DESCRIPTION
In the repository, this file definitely has Unix line endings (\n). So generating it with \r\n causes it to always show changes, even though there aren't any.

@JackRainy you added that, maybe you have [autocrlf = true](https://stackoverflow.com/questions/2332349/best-practices-for-cross-platform-git-config/2361321#2361321), that's why you thought all files use \r\n?