### PR TITLE
Fix MayWithdraw modifier calculation

### DIFF
--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -77,7 +77,7 @@ object Battle {
         // Withdraw from melee ability
         if (attacker is MapUnitCombatant && attacker.isMelee() && defender is MapUnitCombatant) {
             val withdrawUniques = defender.unit.getMatchingUniques(UniqueType.MayWithdraw)
-            val baseWithdrawChance = 100-withdrawUniques.fold(100) { probability, unique -> probability * (100-unique.params[0].toInt()) }
+            val baseWithdrawChance = 100-withdrawUniques.fold(100) { probability, unique -> probability * (100-unique.params[0].toInt()) / 100 }
             // If a mod allows multiple withdraw properties, they stack multiplicatively
             if (baseWithdrawChance != 0 && doWithdrawFromMeleeAbility(attacker, defender, baseWithdrawChance)) return
         }

--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -77,7 +77,8 @@ object Battle {
         // Withdraw from melee ability
         if (attacker is MapUnitCombatant && attacker.isMelee() && defender is MapUnitCombatant) {
             val withdrawUniques = defender.unit.getMatchingUniques(UniqueType.MayWithdraw)
-            val baseWithdrawChance = 100-withdrawUniques.fold(100) { probability, unique -> probability * (100-unique.params[0].toInt()) / 100 }
+            val combinedProbabilityToStayPut = withdrawUniques.fold(100) { probabilityToStayPut, unique -> probabilityToStayPut * (100-unique.params[0].toInt()) / 100 }
+            val baseWithdrawChance = 100 - combinedProbabilityToStayPut
             // If a mod allows multiple withdraw properties, they stack multiplicatively
             if (baseWithdrawChance != 0 && doWithdrawFromMeleeAbility(attacker, defender, baseWithdrawChance)) return
         }


### PR DESCRIPTION
Resolves #6828. Part of the calculation was off by a factor of 100 so a slinger with an 80% chance of withdrawal would have its base withdrawal chance calculated at -1900% so it would always fail to withdraw. All promotions or units which use ```UniqueType.MayWithdraw``` should be corrected (tested with slinger and survivalism III at least and those units will mostly withdraw with the occasional failure to withdraw).