### PR TITLE
Add Build Artifacts in `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,11 @@
 *.ear
 hs_err_pid*
 
+## Build Artifacts
+*.jar
+*.zip
+*.tar.gz
+
 ## Robovm
 /ios/robovm-build/
 


### PR DESCRIPTION
Details:
*.jar -> packr-all-4.0.0.jar
*.zip -> jdk-windows-32.zip, jdk-windows-64.zip
*.tar.gz -> jre-linux-64.tar.gz