### PR TITLE
Show required resource for upgrades, rework upgrade logic

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -839,6 +839,7 @@ Paradrop =
 Add in capital = 
 Add to [comment] = 
 Upgrade to [unitType] ([goldCost] gold) = 
+Upgrade to [unitType]\n([goldCost] gold, [resources]) = 
 Found city = 
 Promote = 
 Health = 

--- a/core/src/com/unciv/logic/city/IConstruction.kt
+++ b/core/src/com/unciv/logic/city/IConstruction.kt
@@ -84,13 +84,24 @@ interface INonPerpetualConstruction : IConstruction, INamed, IHasUniques {
 
 
 class RejectionReasons: HashSet<RejectionReasonInstance>() {
-    
+
     fun add(rejectionReason: RejectionReason) = add(RejectionReasonInstance(rejectionReason))
-    
+
     fun contains(rejectionReason: RejectionReason) = any { it.rejectionReason == rejectionReason }
 
-    fun filterTechPolicyEraWonderRequirements(): List<RejectionReasonInstance> {
-        return filterNot { it.rejectionReason in techPolicyEraWonderRequirements }
+    fun isOKIgnoringRequirements(
+        ignoreTechPolicyEraWonderRequirements: Boolean = false,
+        ignoreResources: Boolean = false
+    ): Boolean {
+        if (!ignoreTechPolicyEraWonderRequirements && !ignoreResources) return isEmpty()
+        if (!ignoreTechPolicyEraWonderRequirements)
+            return none { it.rejectionReason != RejectionReason.ConsumesResources }
+        if (!ignoreResources)
+            return none { it.rejectionReason !in techPolicyEraWonderRequirements }
+        return none {
+            it.rejectionReason != RejectionReason.ConsumesResources &&
+            it.rejectionReason !in techPolicyEraWonderRequirements
+        }
     }
 
     fun hasAReasonToBeRemovedFromQueue(): Boolean {

--- a/core/src/com/unciv/logic/city/IConstruction.kt
+++ b/core/src/com/unciv/logic/city/IConstruction.kt
@@ -95,12 +95,12 @@ class RejectionReasons: HashSet<RejectionReasonInstance>() {
     ): Boolean {
         if (!ignoreTechPolicyEraWonderRequirements && !ignoreResources) return isEmpty()
         if (!ignoreTechPolicyEraWonderRequirements)
-            return none { it.rejectionReason != RejectionReason.ConsumesResources }
+            return all { it.rejectionReason == RejectionReason.ConsumesResources }
         if (!ignoreResources)
-            return none { it.rejectionReason !in techPolicyEraWonderRequirements }
-        return none {
-            it.rejectionReason != RejectionReason.ConsumesResources &&
-            it.rejectionReason !in techPolicyEraWonderRequirements
+            return all { it.rejectionReason in techPolicyEraWonderRequirements }
+        return all {
+            it.rejectionReason == RejectionReason.ConsumesResources ||
+            it.rejectionReason in techPolicyEraWonderRequirements
         }
     }
 

--- a/core/src/com/unciv/models/ModConstants.kt
+++ b/core/src/com/unciv/models/ModConstants.kt
@@ -34,6 +34,16 @@ class ModConstants {
     var minimalCityDistance = 3
     var minimalCityDistanceOnDifferentContinents = 2
 
+    // Constants used to calculate Unit Upgrade gold Cost (can only be modded all-or-nothing)
+    class UnitUpgradeCost {
+        val base = 10f
+        val perProduction = 2f
+        val eraMultiplier = 0f  // 0.3 in Civ5 cpp sources but 0 in xml 
+        val exponent = 1f
+        val roundTo = 5
+    }
+    var unitUpgradeCost = UnitUpgradeCost()
+
     // NaturalWonderGenerator uses these to determine the number of Natural Wonders to spawn for a given map size.
     // With these values, radius * mul + add gives a 1-2-3-4-5 progression for Unciv predefined map sizes and a 2-3-4-5-6-7 progression for the original Civ5 map sizes.
     // 0.124 = (Civ5.Huge.getHexagonalRadiusForArea(w*h) - Civ5.Duel.getHexagonalRadiusForArea(w*h)) / 5 (if you do not round in the radius function)
@@ -63,6 +73,7 @@ class ModConstants {
         if (other.unitSupplyPerPopulation != defaults.unitSupplyPerPopulation) unitSupplyPerPopulation = other.unitSupplyPerPopulation
         if (other.minimalCityDistance != defaults.minimalCityDistance) minimalCityDistance = other.minimalCityDistance
         if (other.minimalCityDistanceOnDifferentContinents != defaults.minimalCityDistanceOnDifferentContinents) minimalCityDistanceOnDifferentContinents = other.minimalCityDistanceOnDifferentContinents
+        if (other.unitUpgradeCost != defaults.unitUpgradeCost) unitUpgradeCost = other.unitUpgradeCost
         if (other.naturalWonderCountMultiplier != defaults.naturalWonderCountMultiplier) naturalWonderCountMultiplier = other.naturalWonderCountMultiplier
         if (other.naturalWonderCountAddedConstant != defaults.naturalWonderCountAddedConstant) naturalWonderCountAddedConstant = other.naturalWonderCountAddedConstant
         if (other.ancientRuinCountMultiplier != defaults.ancientRuinCountMultiplier) ancientRuinCountMultiplier = other.ancientRuinCountMultiplier

--- a/core/src/com/unciv/models/UnitAction.kt
+++ b/core/src/com/unciv/models/UnitAction.kt
@@ -7,7 +7,6 @@ import com.badlogic.gdx.utils.Align
 import com.unciv.ui.utils.KeyCharAndCode
 import com.unciv.ui.images.ImageGetter
 import com.unciv.Constants
-import com.unciv.models.translations.equalsPlaceholderText
 import com.unciv.models.translations.getPlaceholderParameters
 import com.unciv.ui.utils.darken
 
@@ -25,31 +24,28 @@ data class UnitAction(
 ) {
     fun getIcon(): Actor {
         if (type.imageGetter != null) return type.imageGetter.invoke()
-        return when {
-            type == UnitActionType.Upgrade 
-                    && title.equalsPlaceholderText("Upgrade to [] ([] gold)") -> {
+        return when (type) {
+            UnitActionType.Upgrade -> {
                 ImageGetter.getUnitIcon(title.getPlaceholderParameters()[0])
             }
-            type == UnitActionType.Create
-                    && title.equalsPlaceholderText("Create []") -> {
+            UnitActionType.Create -> {
                 ImageGetter.getImprovementIcon(title.getPlaceholderParameters()[0])
             }
-            type == UnitActionType.SpreadReligion
-                    && title.equalsPlaceholderText("Spread []") -> {
+            UnitActionType.SpreadReligion -> {
                 val religionName = title.getPlaceholderParameters()[0]
                 ImageGetter.getReligionImage(
-                    if (ImageGetter.religionIconExists(religionName)) religionName 
+                    if (ImageGetter.religionIconExists(religionName)) religionName
                     else "Pantheon"
                 ).apply { color = Color.BLACK }
             }
-            type == UnitActionType.Fortify || type == UnitActionType.FortifyUntilHealed -> {
+            UnitActionType.Fortify, UnitActionType.FortifyUntilHealed -> {
                 val match = fortificationRegex.matchEntire(title)
                 val percentFortified = match?.groups?.get(1)?.value?.toInt() ?: 0
-                ImageGetter.getImage("OtherIcons/Shield").apply { 
+                ImageGetter.getImage("OtherIcons/Shield").apply {
                     color = Color.GREEN.darken(1f - percentFortified / 80f)
                 }
             }
-            else -> ImageGetter.getImage("OtherIcons/Star")
+            else -> ImageGetter.getImage("OtherIcons/Star").apply { color = Color.BLACK }
         }
     }
     companion object {

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -17,7 +17,7 @@ import kotlin.random.Random
 
 // Buildings, techs, policies, ancient ruins and promotions can have 'triggered' effects
 object UniqueTriggerActivation {
-    /** @return boolean whether an action was successfully preformed */
+    /** @return boolean whether an action was successfully performed */
     fun triggerCivwideUnique(
         unique: Unique,
         civInfo: CivilizationInfo,
@@ -43,7 +43,7 @@ object UniqueTriggerActivation {
             OneTimeFreeUnit -> {
                 val unitName = unique.params[0]
                 val unit = ruleSet.units[unitName]
-                if (chosenCity == null || unit == null || (unit.hasUnique(UniqueType.FoundCity) && civInfo.isOneCityChallenger()))
+                if (chosenCity == null || unit == null || (unit.hasUnique(FoundCity) && civInfo.isOneCityChallenger()))
                     return false
 
                 val placedUnit = civInfo.addUnit(unitName, chosenCity)
@@ -59,7 +59,7 @@ object UniqueTriggerActivation {
             OneTimeAmountFreeUnits -> {
                 val unitName = unique.params[1]
                 val unit = ruleSet.units[unitName]
-                if (chosenCity == null || unit == null || (unit.hasUnique(UniqueType.FoundCity) && civInfo.isOneCityChallenger()))
+                if (chosenCity == null || unit == null || (unit.hasUnique(FoundCity) && civInfo.isOneCityChallenger()))
                     return false
 
                 val tilesUnitsWerePlacedOn: MutableList<Vector2> = mutableListOf()
@@ -470,7 +470,7 @@ object UniqueTriggerActivation {
         return false
     }
 
-    /** @return boolean whether an action was successfully preformed */
+    /** @return boolean whether an action was successfully performed */
     fun triggerUnitwideUnique(
         unique: Unique,
         unit: MapUnit,

--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -467,7 +467,7 @@ class BaseUnit : RulesetObject(), INonPerpetualConstruction {
 
     fun isBuildableIgnoringTechs(civInfo: CivilizationInfo): Boolean {
         val rejectionReasons = getRejectionReasons(civInfo)
-        return rejectionReasons.filterTechPolicyEraWonderRequirements().isEmpty()
+        return rejectionReasons.isOKIgnoringRequirements(ignoreTechPolicyEraWonderRequirements = true)
     }
 
     override fun postBuildEvent(cityConstructions: CityConstructions, boughtWith: Stat?): Boolean {

--- a/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
@@ -336,18 +336,22 @@ object UnitActions {
 
         // Check _new_ resource requirements (display only - yes even for free or special upgrades)
         // Using Counter to aggregate is a bit exaggerated, but - respect the mad modder.
-        val delta = Counter<String>()
+        val resourceRequirementsDelta = Counter<String>()
+        for ((resource, amount) in unit.baseUnit().getResourceRequirements())
+            resourceRequirementsDelta.add(resource, -amount)
         for ((resource, amount) in upgradedUnit.getResourceRequirements())
-            delta.add(resource, amount)
-        val deltaStr = if (delta.all { it.value == 0 }) ""
-        else delta.map { "${it.value} {${it.key}}" }.joinToString { it.tr() }
+            resourceRequirementsDelta.add(resource, amount)
+        val newResourceRequirementsString = resourceRequirementsDelta.entries
+            .filter { it.value > 0 }
+            .joinToString { "${it.value} {${it.key}}".tr() }
 
         val goldCostOfUpgrade = if (isFree) 0 else unit.getCostOfUpgrade(upgradedUnit)
 
         // No string for "FREE" variants, these are never shown to the user.
         // The free actions are only triggered via OneTimeUnitUpgrade or OneTimeUnitSpecialUpgrade in UniqueTriggerActivation.
-        val title = if (deltaStr.isEmpty()) "Upgrade to [${upgradedUnit.name}] ([$goldCostOfUpgrade] gold)"
-            else "Upgrade to [${upgradedUnit.name}]\n([$goldCostOfUpgrade] gold, [$deltaStr])"
+        val title = if (newResourceRequirementsString.isEmpty())
+                 "Upgrade to [${upgradedUnit.name}] ([$goldCostOfUpgrade] gold)"
+            else "Upgrade to [${upgradedUnit.name}]\n([$goldCostOfUpgrade] gold, [$newResourceRequirementsString])"
 
         return UnitAction(UnitActionType.Upgrade,
             title = title,

--- a/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
@@ -12,6 +12,7 @@ import com.unciv.logic.civilization.diplomacy.DiplomacyFlags
 import com.unciv.logic.civilization.diplomacy.DiplomaticModifiers
 import com.unciv.logic.map.MapUnit
 import com.unciv.logic.map.TileInfo
+import com.unciv.models.Counter
 import com.unciv.models.UncivSound
 import com.unciv.models.UnitAction
 import com.unciv.models.UnitActionType
@@ -81,6 +82,9 @@ object UnitActions {
 
         addSleepActions(actionList, unit, true)
         addFortifyActions(actionList, unit, true)
+
+        if (unit.canUpgradeMultipleSteps())
+            addUnitUpgradeAction(unit, actionList, 1)
 
         addSwapAction(unit, actionList, worldScreen)
         addDisbandAction(actionList, unit, worldScreen)
@@ -299,96 +303,86 @@ object UnitActions {
         }
     }
 
-    private fun addUnitUpgradeAction(unit: MapUnit, actionList: ArrayList<UnitAction>) {
-        val upgradeAction = getUpgradeAction(unit)
+    private fun addUnitUpgradeAction(
+        unit: MapUnit,
+        actionList: ArrayList<UnitAction>,
+        maxSteps: Int = Int.MAX_VALUE
+    ) {
+        val upgradeAction = getUpgradeAction(unit, maxSteps)
         if (upgradeAction != null) actionList += upgradeAction
     }
 
-    fun getUpgradeAction(unit: MapUnit): UnitAction? {
-        val tile = unit.currentTile
+    /**  Common implementation for [getUpgradeAction], [getFreeUpgradeAction] and [getAncientRuinsUpgradeAction] */
+    private fun getUpgradeAction(
+        unit: MapUnit,
+        maxSteps: Int,
+        isFree: Boolean,
+        isSpecial: Boolean
+    ): UnitAction? {
         if (unit.baseUnit().upgradesTo == null) return null
-        if (!unit.canUpgrade()) return null
-        if (tile.getOwner() != unit.civInfo) return null
-        
-        val upgradedUnit = unit.getUnitToUpgradeTo()
-        val goldCostOfUpgrade = unit.getCostOfUpgrade()
+        val unitTile = unit.getTile()
+        val civInfo = unit.civInfo
+        if (!isFree && unitTile.getOwner() != civInfo) return null
+
+        val upgradesTo = unit.baseUnit().upgradesTo
+        val specialUpgradesTo = unit.baseUnit().specialUpgradesTo
+        val upgradedUnit = when {
+            isSpecial && specialUpgradesTo != null -> civInfo.getEquivalentUnit (specialUpgradesTo)
+            isFree && upgradesTo != null -> civInfo.getEquivalentUnit(upgradesTo)  // getUnitToUpgradeTo can't ignore tech
+            else -> unit.getUnitToUpgradeTo(maxSteps)
+        }
+        if (!unit.canUpgrade(unitToUpgradeTo = upgradedUnit, ignoreRequirements = isFree, ignoreResources = true))
+            return null
+
+        // Check _new_ resource requirements (display only - yes even for free or special upgrades)
+        // Using Counter to aggregate is a bit exaggerated, but - respect the mad modder.
+        val delta = Counter<String>()
+        for ((resource, amount) in upgradedUnit.getResourceRequirements())
+            delta.add(resource, amount)
+        val deltaStr = if (delta.all { it.value == 0 }) ""
+        else delta.map { "${it.value} {${it.key}}" }.joinToString { it.tr() }
+
+        val goldCostOfUpgrade = if (isFree) 0 else unit.getCostOfUpgrade(upgradedUnit)
+
+        // No string for "FREE" variants, these are never shown to the user.
+        // The free actions are only triggered via OneTimeUnitUpgrade or OneTimeUnitSpecialUpgrade in UniqueTriggerActivation.
+        val title = if (deltaStr.isEmpty()) "Upgrade to [${upgradedUnit.name}] ([$goldCostOfUpgrade] gold)"
+            else "Upgrade to [${upgradedUnit.name}]\n([$goldCostOfUpgrade] gold, [$deltaStr])"
 
         return UnitAction(UnitActionType.Upgrade,
-            title = "Upgrade to [${upgradedUnit.name}] ([$goldCostOfUpgrade] gold)",
+            title = title,
             action = {
-                val unitTile = unit.getTile()
                 unit.destroy()
-                val newUnit = unit.civInfo.placeUnitNearTile(unitTile.position, upgradedUnit.name)
+                val newUnit = civInfo.placeUnitNearTile(unitTile.position, upgradedUnit.name)
 
                 /** We were UNABLE to place the new unit, which means that the unit failed to upgrade!
                  * The only known cause of this currently is "land units upgrading to water units" which fail to be placed.
                  */
                 if (newUnit == null) {
-                    val readdedUnit = unit.civInfo.placeUnitNearTile(unitTile.position, unit.name)
-                    unit.copyStatisticsTo(readdedUnit!!)
+                    val resurrectedUnit = civInfo.placeUnitNearTile(unitTile.position, unit.name)!!
+                    unit.copyStatisticsTo(resurrectedUnit)
                 } else { // Managed to upgrade
-                    unit.civInfo.addGold(-goldCostOfUpgrade)
+                    if (!isFree) civInfo.addGold(-goldCostOfUpgrade)
                     unit.copyStatisticsTo(newUnit)
                     newUnit.currentMovement = 0f
                 }
             }.takeIf {
-                unit.civInfo.gold >= goldCostOfUpgrade
-                && unit.currentMovement > 0
-                && !unit.isEmbarked()
-            }
-        )
-    }
-    
-    fun getFreeUpgradeAction(unit: MapUnit): UnitAction? {
-        if (unit.baseUnit().upgradesTo == null) return null
-        val upgradedUnit = unit.civInfo.getEquivalentUnit(unit.baseUnit().upgradesTo!!)
-        if (!unit.canUpgrade(upgradedUnit, true)) return null
-
-        return UnitAction(UnitActionType.Upgrade,
-            title = "Upgrade to [${upgradedUnit.name}] (FREE)",
-            action = {
-                val unitTile = unit.getTile()
-                unit.destroy()
-                val newUnit = unit.civInfo.placeUnitNearTile(unitTile.position, upgradedUnit.name)
-
-                /** We were UNABLE to place the new unit, which means that the unit failed to upgrade!
-                 * The only known cause of this currently is "land units upgrading to water units" which fail to be placed.
-                 */
-                if (newUnit == null) {
-                    val readdedUnit = unit.civInfo.placeUnitNearTile(unitTile.position, unit.name)
-                    unit.copyStatisticsTo(readdedUnit!!)
-                } else { // Managed to upgrade
-                    unit.copyStatisticsTo(newUnit)
-                    newUnit.currentMovement = 0f
-                }
+                isFree || (
+                    unit.civInfo.gold >= goldCostOfUpgrade
+                    && unit.currentMovement > 0
+                    && !unit.isEmbarked()
+                    && unit.canUpgrade(unitToUpgradeTo = upgradedUnit)
+                )
             }
         )
     }
 
-    fun getAncientRuinsUpgradeAction(unit: MapUnit): UnitAction? {
-        val upgradedUnitName =
-            when {
-                unit.baseUnit.specialUpgradesTo != null -> unit.baseUnit.specialUpgradesTo
-                unit.baseUnit.upgradesTo != null -> unit.baseUnit.upgradesTo
-                else -> return null
-            }
-        val upgradedUnit =
-            unit.civInfo.getEquivalentUnit(unit.civInfo.gameInfo.ruleSet.units[upgradedUnitName]!!)
-        
-        if (!unit.canUpgrade(upgradedUnit,true)) return null
-
-        return UnitAction(UnitActionType.Upgrade,
-            title = "Upgrade to [${upgradedUnit.name}] (free)",
-            action = {
-                val unitTile = unit.getTile()
-                unit.destroy()
-                val newUnit = unit.civInfo.placeUnitNearTile(unitTile.position, upgradedUnit.name)!!
-                unit.copyStatisticsTo(newUnit)
-
-                newUnit.currentMovement = 0f
-            }
-        )
-    }
+    fun getUpgradeAction(unit: MapUnit, maxSteps: Int = Int.MAX_VALUE) =
+        getUpgradeAction(unit, maxSteps, isFree = false, isSpecial = false)
+    fun getFreeUpgradeAction(unit: MapUnit) =
+        getUpgradeAction(unit, 1, isFree = true, isSpecial = false)
+    fun getAncientRuinsUpgradeAction(unit: MapUnit) =
+        getUpgradeAction(unit, 1, isFree = true, isSpecial = true)
 
     private fun addBuildingImprovementsAction(unit: MapUnit, actionList: ArrayList<UnitAction>, tile: TileInfo, worldScreen: WorldScreen, unitTable: UnitTable) {
         if (!unit.hasUniqueToBuildImprovements) return

--- a/docs/Other/Miscellaneous-JSON-files.md
+++ b/docs/Other/Miscellaneous-JSON-files.md
@@ -92,7 +92,7 @@ Stored in ModOptions.constants, this is a collection of constants used internall
 This is the only structure that is _merged_ field by field from mods, not overwritten, so you can change XP from Barbarians in one mod
 and city distance in another. In case of conflicts, there is no guarantee which mod wins, only that _default_ values are ignored.
 
-| Attribute | Type | Optional | Notes |
+| Attribute | Type | Default | Notes |
 | --------- | ---- | -------- | ----- |
 | maxXPfromBarbarians | Int | 30 | [^A] |
 | cityStrengthBase| Float | 8.0 | [^B] |
@@ -143,7 +143,7 @@ Legend:
 
 These values are not merged individually, only the entire sub-structure is.
 
-| Attribute | Type | Optional | Notes |
+| Attribute | Type | Default | Notes |
 | --------- | ---- | -------- | ----- |
 | base | Float | 10 |  |
 | perProduction | Float | 2 |  |

--- a/docs/Other/Miscellaneous-JSON-files.md
+++ b/docs/Other/Miscellaneous-JSON-files.md
@@ -89,6 +89,8 @@ The file can have the following attributes, including the values Unciv sets (no 
 ### ModConstants
 
 Stored in ModOptions.constants, this is a collection of constants used internally in Unciv.
+This is the only structure that is _merged_ field by field from mods, not overwritten, so you can change XP from Barbarians in one mod
+and city distance in another. In case of conflicts, there is no guarantee which mod wins, only that _default_ values are ignored.
 
 | Attribute | Type | Optional | Notes |
 | --------- | ---- | -------- | ----- |
@@ -102,6 +104,7 @@ Stored in ModOptions.constants, this is a collection of constants used internall
 | unitSupplyPerPopulation| Float | 0.5 | [^C] |
 | minimalCityDistance| Int | 3 | [^D] |
 | minimalCityDistanceOnDifferentContinents| Int | 2 | [^D] |
+| unitUpgradeCost | Object | see below | [^J] |
 | naturalWonderCountMultiplier| Float | 0.124 | [^E] |
 | naturalWonderCountAddedConstant| Float | 0.1 | [^E] |
 | ancientRuinCountMultiplier| Float | 0.02 | [^F] |
@@ -134,6 +137,26 @@ Legend:
 -   [^F]: MapGenerator.spreadAncientRuins: number of ruins = suitable tile count * this
 -   [^H]: MapGenerator.spawnLakesAndCoasts: Water bodies up to this tile count become Lakes
 -   [^I]: RiverGenerator: river frequency and length bounds
+-   [^J]: A [UnitUpgradeCost](#UnitUpgradeCost) sub-structure.
+
+#### UnitUpgradeCost
+
+These values are not merged individually, only the entire sub-structure is.
+
+| Attribute | Type | Optional | Notes |
+| --------- | ---- | -------- | ----- |
+| base | Float | 10 |  |
+| perProduction | Float | 2 |  |
+| eraMultiplier | Float | 0 |  |
+| exponent | Float | 1 |  |
+| roundTo | Int | 5 |  |
+
+The formula for the gold cost of a unit upgrade is (rounded down to a multiple of `roundTo`):
+        ( max((`base` + `perProduction` * (new_unit_cost - old_unit_cost)), 0)
+            * (1 + eraNumber * `eraMultiplier`) * `civModifier`
+        ) ^ `exponent`
+With `civModifier` being the multiplicative aggregate of ["\[relativeAmount\]% Gold cost of upgrading"](../uniques.md#global_uniques) uniques that apply.
+
 
 ## VictoryTypes.json
 


### PR DESCRIPTION
Closes #6802 - see discussion there.
- Displays additional resource requirements. Code originally also displayed resources being freed as negative numbers, but that went out for simplicity. Could redo if desired.
- Unit upgrade gold cost will change marginally, I mistrusted the "old" results enough to question the formula.
     - The code now has the same abilities and defaults as Civ5, with those factors C5 has in xml backed by ModConstants.
     - Difference: Formula and therefore rounding and clamping done per single upgrade step, not Horseman->GDR in one.
     - The Pentagon/Professional Army Unique should be calculated per upgrade step, but isn't as we'd have to create and discard a MapUnit per intermediate step. Doable but out of scope said my dice.
     - Civ5 rounds to int in _each_ term of the entire formula. Seemed silly, I went with Float right up to the rounding.
- If our main Upgrade action is doing several steps in one, then the single step is offered under additional actions.

Extra credits to @xlenstra for the research!