### PR TITLE
Fix images not being able to have their size set

### DIFF
--- a/core/src/com/unciv/ui/images/ImageGetter.kt
+++ b/core/src/com/unciv/ui/images/ImageGetter.kt
@@ -163,11 +163,11 @@ object ImageGetter {
         // loading screen and Tutorial.WorldScreen quite a bit. More anisotropy barely helps.
         val texture = Texture("ExtraImages/$fileName")
         texture.setFilter(TextureFilter.Linear, TextureFilter.Linear)
-        return Image(TextureRegion(texture))
+        return ImageWithCustomSize(TextureRegion(texture))
     }
 
     fun getImage(fileName: String?): Image {
-        return Image(getDrawable(fileName))
+        return ImageWithCustomSize(getDrawable(fileName))
     }
 
     fun getDrawable(fileName: String?): TextureRegionDrawable {

--- a/core/src/com/unciv/ui/images/ImageWithCustomSize.kt
+++ b/core/src/com/unciv/ui/images/ImageWithCustomSize.kt
@@ -6,18 +6,18 @@ import com.badlogic.gdx.scenes.scene2d.utils.Drawable
 import com.badlogic.gdx.scenes.scene2d.utils.TextureRegionDrawable
 
 /**
- * Either [Image] or [com.badlogic.gdx.scenes.scene2d.utils.Drawable] is badly written, as the [Image.drawable] always has its texture width/height 
+ * Either [Image] or [com.badlogic.gdx.scenes.scene2d.utils.Drawable] is badly written, as the [Image.drawable] always has its texture width/height
  * as min width/height, and [Image.getPrefWidth]/Height is always equal to its [Image.drawable]'s minWidth/Height.
- * 
+ *
  * This results in an [Image.getPrefWidth]/Height call to completely ignore the width/height that was set by [setSize]. To fix this, this class provides a
- * custom implemetnation of [getPrefWidth] and [getPrefHeight].
+ * custom implementation of [getPrefWidth] and [getPrefHeight].
  */
 class ImageWithCustomSize(drawable: Drawable) : Image(drawable) {
-    
+
     constructor(region: TextureRegion) : this(TextureRegionDrawable(region))
 
     override fun getPrefWidth(): Float {
-        return if (width != 0f) {
+        return if (width > 0f) {
             width
         } else if (drawable != null) {
             drawable.minWidth
@@ -25,9 +25,9 @@ class ImageWithCustomSize(drawable: Drawable) : Image(drawable) {
             0f
         }
     }
-    
+
     override fun getPrefHeight(): Float {
-        return if (height != 0f) {
+        return if (height > 0f) {
             height
         } else if (drawable != null) {
             drawable.minHeight

--- a/core/src/com/unciv/ui/images/ImageWithCustomSize.kt
+++ b/core/src/com/unciv/ui/images/ImageWithCustomSize.kt
@@ -1,0 +1,38 @@
+package com.unciv.ui.images
+
+import com.badlogic.gdx.graphics.g2d.TextureRegion
+import com.badlogic.gdx.scenes.scene2d.ui.Image
+import com.badlogic.gdx.scenes.scene2d.utils.Drawable
+import com.badlogic.gdx.scenes.scene2d.utils.TextureRegionDrawable
+
+/**
+ * Either [Image] or [com.badlogic.gdx.scenes.scene2d.utils.Drawable] is badly written, as the [Image.drawable] always has its texture width/height 
+ * as min width/height, and [Image.getPrefWidth]/Height is always equal to its [Image.drawable]'s minWidth/Height.
+ * 
+ * This results in an [Image.getPrefWidth]/Height call to completely ignore the width/height that was set by [setSize]. To fix this, this class provides a
+ * custom implemetnation of [getPrefWidth] and [getPrefHeight].
+ */
+class ImageWithCustomSize(drawable: Drawable) : Image(drawable) {
+    
+    constructor(region: TextureRegion) : this(TextureRegionDrawable(region))
+
+    override fun getPrefWidth(): Float {
+        return if (width != 0f) {
+            width
+        } else if (drawable != null) {
+            drawable.minWidth
+        } else {
+            0f
+        }
+    }
+    
+    override fun getPrefHeight(): Float {
+        return if (height != 0f) {
+            height
+        } else if (drawable != null) {
+            drawable.minHeight
+        } else {
+            0f
+        }
+    }
+}


### PR DESCRIPTION
This fixes images not being able to have their size set by themselves. 

Currently, they're always wrapped inside a `Table` `Cell` somewhere, and then the cell is being given a size, which completely ignores the child's preferences, so it doesn't matter what size the `Image` actually has.

But that basically makes `Image`s only be usable within `Table` `Cells`, which is not nice, as sometimes that's simply an unnecessary overhead.