### PR TITLE
Implement a waiting command (#6884)

### DIFF
--- a/core/src/com/unciv/models/UnitAction.kt
+++ b/core/src/com/unciv/models/UnitAction.kt
@@ -137,6 +137,8 @@ enum class UnitActionType(
         { ImageGetter.getImage("OtherIcons/DisbandUnit") }, KeyCharAndCode.DEL),
     GiftUnit("Gift unit",
         { ImageGetter.getImage("OtherIcons/Present") }, UncivSound.Silent),
+    Wait("Wait",
+        null, 'z', UncivSound.Silent),
     ShowAdditionalActions("Show more",
         { imageGetShowMore() }, KeyCharAndCode(Input.Keys.PAGE_DOWN)),
     HideAdditionalActions("Back",

--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -184,11 +184,8 @@ class WorldScreen(val gameInfo: GameInfo, val viewingCiv:CivilizationInfo) : Bas
         // Don't select unit and change selectedCiv when centering as spectator
         if (viewingCiv.isSpectator())
             mapHolder.setCenterPosition(tileToCenterOn, immediately = true, selectUnit = false)
-        else {
+        else
             mapHolder.setCenterPosition(tileToCenterOn, immediately = true, selectUnit = true)
-            if (viewingCiv.getNextDueUnit() == bottomUnitTable.selectedUnit)
-                viewingCiv.cycleThroughDueUnits()
-        }
 
         tutorialController.allTutorialsShowedCallback = { shouldUpdate = true }
 
@@ -730,7 +727,8 @@ class WorldScreen(val gameInfo: GameInfo, val viewingCiv:CivilizationInfo) : Bas
     }
 
     fun switchToNextUnit() {
-        val nextDueUnit = viewingCiv.cycleThroughDueUnits()
+        // Try to select something new if we already have the next pending unit selected.
+        val nextDueUnit = viewingCiv.cycleThroughDueUnits(bottomUnitTable.selectedUnit)
         if (nextDueUnit != null) {
             mapHolder.setCenterPosition(
                 nextDueUnit.currentTile.position,

--- a/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
@@ -68,8 +68,9 @@ object UnitActions {
         addTriggerUniqueActions(unit, actionList)
         addAddInCapitalAction(unit, actionList, tile)
 
-
         addToggleActionsAction(unit, actionList, unitTable)
+
+        addWaitAction(unit, actionList, worldScreen);
 
         return actionList
     }
@@ -832,4 +833,17 @@ object UnitActions {
         )
     }
 
+    private fun addWaitAction(unit: MapUnit, actionList: ArrayList<UnitAction>, worldScreen: WorldScreen) {
+        // This is only for idle units.
+        if (!unit.isIdle()) return
+        // Don't add if there are no idle units we could switch to,
+        if (!worldScreen.viewingCiv.getDueUnits().any()) return
+        actionList += UnitAction(
+            type = UnitActionType.Wait,
+            action = {
+                unit.due = true
+                worldScreen.switchToNextUnit()
+            }
+        )
+    }
 }

--- a/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
@@ -68,9 +68,9 @@ object UnitActions {
         addTriggerUniqueActions(unit, actionList)
         addAddInCapitalAction(unit, actionList, tile)
 
-        addToggleActionsAction(unit, actionList, unitTable)
-
         addWaitAction(unit, actionList, worldScreen);
+
+        addToggleActionsAction(unit, actionList, unitTable)
 
         return actionList
     }
@@ -822,17 +822,6 @@ object UnitActions {
         }
     }
 
-    private fun addToggleActionsAction(unit: MapUnit, actionList: ArrayList<UnitAction>, unitTable: UnitTable) {
-        actionList += UnitAction(
-            type = if (unit.showAdditionalActions) UnitActionType.HideAdditionalActions
-            else UnitActionType.ShowAdditionalActions,
-            action = {
-                unit.showAdditionalActions = !unit.showAdditionalActions
-                unitTable.update()
-            }
-        )
-    }
-
     private fun addWaitAction(unit: MapUnit, actionList: ArrayList<UnitAction>, worldScreen: WorldScreen) {
         if (!unit.isIdle()) return
         if (worldScreen.viewingCiv.getDueUnits().filter { it != unit }.none()) return
@@ -841,6 +830,17 @@ object UnitActions {
             action = {
                 unit.due = true
                 worldScreen.switchToNextUnit()
+            }
+        )
+    }
+
+    private fun addToggleActionsAction(unit: MapUnit, actionList: ArrayList<UnitAction>, unitTable: UnitTable) {
+        actionList += UnitAction(
+            type = if (unit.showAdditionalActions) UnitActionType.HideAdditionalActions
+            else UnitActionType.ShowAdditionalActions,
+            action = {
+                unit.showAdditionalActions = !unit.showAdditionalActions
+                unitTable.update()
             }
         )
     }

--- a/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
@@ -834,10 +834,8 @@ object UnitActions {
     }
 
     private fun addWaitAction(unit: MapUnit, actionList: ArrayList<UnitAction>, worldScreen: WorldScreen) {
-        // This is only for idle units.
         if (!unit.isIdle()) return
-        // Don't add if there are no idle units we could switch to,
-        if (!worldScreen.viewingCiv.getDueUnits().any()) return
+        if (worldScreen.viewingCiv.getDueUnits().filter { it != unit }.none()) return
         actionList += UnitAction(
             type = UnitActionType.Wait,
             action = {


### PR DESCRIPTION
This is for the feature request #6884. It's a proof-of-concept for the first alternative outlined there. You can now "postpone" decisions for the current unit using key `Z` (since `W` is taken, I used `Z` for "zzz..."). Unit for which decisions are postponed this way will reappear on this turn later when you use "Next unit".

Thoughts: maybe better to move it from unit action area to the place just below "Next unit".