### PR TITLE
Refactor UncivShowableException

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -1435,6 +1435,12 @@ Invisible to others =
 Bison = 
 Cocoa = 
 
+# Exceptions that _may_ be shown to the user
+
+Building '[buildingName]' is buildable and therefore must either have an explicit cost or reference an existing tech. = 
+Nation [nationName] is not found! = 
+Unit [unitName] doesn't seem to exist! = 
+
 
 # In English we just paste all these conditionals at the end of each unique, but in your language that
 # may not turn into valid sentences. Therefore we have the following two translations to determine
@@ -1465,5 +1471,3 @@ ConditionalsPlacement =
 
 
 ########################### AUTOMATICALLY GENERATED TRANSLATABLE STRINGS ########################### 
-
-

--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -22,9 +22,6 @@ import com.unciv.ui.audio.MusicTrackChooserFlags
 import java.util.*
 
 
-class MissingModsException(val missingMods: String) : UncivShowableException("Missing mods: [$missingMods]")
-open class UncivShowableException(errorText: String) : Exception(errorText)
-
 class GameInfo {
     //region Fields - Serialized
     var civilizations = mutableListOf<CivilizationInfo>()
@@ -139,7 +136,7 @@ class GameInfo {
         civilizations.firstOrNull {
             it.isSpectator() && it.playerId == playerId
         } ?:
-        CivilizationInfo(Constants.spectator).also { 
+        CivilizationInfo(Constants.spectator).also {
             it.playerType = PlayerType.Human
             it.playerId = playerId
             civilizations.add(it)
@@ -179,14 +176,14 @@ class GameInfo {
             }
         }
     }
- 
+
     fun getYear(turnOffset: Int = 0): Int {
         val turn = getEquivalentTurn() + turnOffset
         val yearToTurnList = YearsToTurn.getList(gameParameters.gameSpeed)
         var year: Float = -4000f
         var i = 0
         var yearsPerTurn: Float
- 
+
         // if macros are ever added to kotlin, this is one hell of a place for em'
         while (i < turn) {
             yearsPerTurn = yearToTurnList.firstOrNull { i < it.toTurn }?.yearInterval ?: 0.5f
@@ -292,7 +289,7 @@ class GameInfo {
                 }
         )
     }
-    
+
     fun getEnabledVictories() = ruleSet.victories.filter { !it.value.hiddenInVictoryScreen && gameParameters.victoryTypes.contains(it.key) }
 
     fun processDiplomaticVictory() {
@@ -344,7 +341,7 @@ class GameInfo {
 
         val exploredRevealTiles: Sequence<TileInfo> =
             if (ruleSet.tileResources[resourceName]!!.hasUnique(UniqueType.CityStateOnlyResource)) {
-                // Look for matching mercantile CS centers 
+                // Look for matching mercantile CS centers
                 getAliveCityStates()
                     .asSequence()
                     .filter { it.cityStateResource == resourceName }
@@ -423,7 +420,7 @@ class GameInfo {
         for (baseUnit in ruleSet.units.values)
             baseUnit.ruleset = ruleSet
 
-        // This needs to go before tileMap.setTransients, as units need to access 
+        // This needs to go before tileMap.setTransients, as units need to access
         // the nation of their civilization when setting transients
         for (civInfo in civilizations) civInfo.gameInfo = this
         for (civInfo in civilizations) civInfo.setNationTransient()
@@ -479,7 +476,7 @@ class GameInfo {
         spaceResources.addAll(ruleSet.buildings.values.filter { it.hasUnique(UniqueType.SpaceshipPart) }
             .flatMap { it.getResourceRequirements().keys } )
         spaceResources.addAll(ruleSet.victories.values.flatMap { it.requiredSpaceshipParts })
-        
+
         barbarians.setTransients(this)
 
         guaranteeUnitPromotions()

--- a/core/src/com/unciv/logic/UncivExceptions.kt
+++ b/core/src/com/unciv/logic/UncivExceptions.kt
@@ -1,0 +1,24 @@
+package com.unciv.logic
+
+import com.unciv.models.translations.tr
+
+/**
+ * An [Exception] wrapper marking an Exception as suitable to be shown to the user.
+ *
+ * @param [errorText] should be the _**untranslated**_ error message.
+ * Use [getLocalizedMessage] to get the translated [message], _**or**_ use auto-translating helpers like .toLabel() or FormattedLine().
+ * Usual formatting (`[] or {}`) applies, as does the need to include the text in templates.properties.
+ */
+open class UncivShowableException(
+    errorText: String,
+    override val cause: Throwable? = null
+) : Exception(errorText) {
+    // override because we _definitely_ have a non-null message from [errorText]
+    override val message: String
+        get() = super.message!!
+    override fun getLocalizedMessage() = message.tr()
+}
+
+class MissingModsException(
+    val missingMods: String
+) : UncivShowableException("Missing mods: [$missingMods]")

--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -56,13 +56,13 @@ class ModOptions : IHasUniques {
     var modUrl = ""
     var author = ""
     var modSize = 0
- 
+
     @Deprecated("As of 3.18.15")
     var maxXPfromBarbarians = 30
 
     override var uniques = ArrayList<String>()
 
-    // If these two are delegated with "by lazy", the mod download process crashes and burns 
+    // If these two are delegated with "by lazy", the mod download process crashes and burns
     // Instead, Ruleset.load sets them, which is preferable in this case anyway
     override var uniqueObjects: List<Unique> = listOf()
     override var uniqueMap: Map<String, List<Unique>> = mapOf()
@@ -307,21 +307,21 @@ class Ruleset {
         }
 
         val difficultiesFile = folderHandle.child("Difficulties.json")
-        if (difficultiesFile.exists()) 
+        if (difficultiesFile.exists())
             difficulties += createHashmap(json().fromJsonFile(Array<Difficulty>::class.java, difficultiesFile))
 
         val globalUniquesFile = folderHandle.child("GlobalUniques.json")
         if (globalUniquesFile.exists()) {
             globalUniques = json().fromJsonFile(GlobalUniques::class.java, globalUniquesFile)
         }
-        
+
         val victoryTypesFiles = folderHandle.child("VictoryTypes.json")
         if (victoryTypesFiles.exists()) {
             victories += createHashmap(json().fromJsonFile(Array<Victory>::class.java, victoryTypesFiles))
         }
 
-        
-        
+
+
         // Add objects that might not be present in base ruleset mods, but are required
         if (modOptions.isBaseRuleset) {
             // This one should be temporary
@@ -355,7 +355,7 @@ class Ruleset {
         for (building in buildings.values) {
             if (building.cost == 0 && !building.hasUnique(UniqueType.Unbuildable)) {
                 val column = technologies[building.requiredTech]?.column
-                        ?: throw UncivShowableException("Building (${building.name}) is buildable and therefore must either have an explicit cost or reference an existing tech")
+                        ?: throw UncivShowableException("Building '[${building.name}]' is buildable and therefore must either have an explicit cost or reference an existing tech.")
                 building.cost = if (building.isAnyWonder()) column.wonderCost else column.buildingCost
             }
         }
@@ -389,7 +389,7 @@ class Ruleset {
         forOptionsPopup: Boolean
     ) {
         val name = if (uniqueContainer is INamed) uniqueContainer.name else ""
-        
+
         for (unique in uniqueContainer.uniqueObjects) {
             val errors = checkUnique(
                 unique,
@@ -424,12 +424,12 @@ class Ruleset {
                 unique.text.count { it=='<' } != unique.text.count { it=='>' } ->listOf(
                         RulesetError("$name's unique \"${unique.text}\" contains mismatched conditional braces!",
                             RulesetErrorSeverity.Warning))
-                
+
                 // This should only ever happen if a bug is or has been introduced that prevents Unique.type from being set for a valid UniqueType, I think.\
                 equalUniques.isNotEmpty() -> listOf(RulesetError(
                         "$name's unique \"${unique.text}\" looks like it should be fine, but for some reason isn't recognized.",
                         RulesetErrorSeverity.OK))
-                
+
                 similarUniques.isNotEmpty() -> {
                     val text =
                         "$name's unique \"${unique.text}\" looks like it may be a misspelling of:\n" +
@@ -503,7 +503,7 @@ class Ruleset {
         if (unique.type.targetTypes.none { uniqueTarget.canAcceptUniqueTarget(it) }
             // the 'consume unit' conditional causes a triggerable unique to become a unit action
             && !(uniqueTarget==UniqueTarget.Unit
-                    && unique.isTriggerable 
+                    && unique.isTriggerable
                     && unique.conditionals.any { it.type == UniqueType.ConditionalConsumeUnit }))
             rulesetErrors.add(
                 "$name's unique \"${unique.text}\" cannot be put on this type of object!",
@@ -681,10 +681,10 @@ class Ruleset {
             for (terrain in improvement.terrainsCanBeBuiltOn)
                 if (!terrains.containsKey(terrain) && terrain != "Land" && terrain != "Water")
                     lines += "${improvement.name} can be built on terrain $terrain which does not exist!"
-            if (improvement.terrainsCanBeBuiltOn.isEmpty() 
-                && !improvement.hasUnique(UniqueType.CanOnlyImproveResource) 
-                && !improvement.hasUnique(UniqueType.Unbuildable) 
-                && !improvement.name.startsWith(Constants.remove) 
+            if (improvement.terrainsCanBeBuiltOn.isEmpty()
+                && !improvement.hasUnique(UniqueType.CanOnlyImproveResource)
+                && !improvement.hasUnique(UniqueType.Unbuildable)
+                && !improvement.name.startsWith(Constants.remove)
                 && improvement.name !in RoadStatus.values().map { it.removeAction }
                 && improvement.name != Constants.cancelImprovementOrder
             ) {
@@ -792,7 +792,7 @@ class Ruleset {
                         lines += "${policy.name} requires policy $prereq which does not exist!"
             checkUniques(policy, lines, rulesetSpecific, forOptionsPopup)
         }
-        
+
         for (policy in policyBranches.values.flatMap { it.policies + it })
             if (policy != policies[policy.name])
                 lines += "More than one policy with the name ${policy.name} exists!"
@@ -818,13 +818,13 @@ class Ruleset {
         for (unitType in unitTypes.values) {
             checkUniques(unitType, lines, rulesetSpecific, forOptionsPopup)
         }
-        
+
         for (victoryType in victories.values) {
-            for (requiredUnit in victoryType.requiredSpaceshipParts) 
+            for (requiredUnit in victoryType.requiredSpaceshipParts)
                 if (!units.contains(requiredUnit))
                     lines.add("Victory type ${victoryType.name} requires adding the non-existant unit $requiredUnit to the capital to win!", RulesetErrorSeverity.Warning)
-            for (milestone in victoryType.milestoneObjects) 
-                if (milestone.type == null) 
+            for (milestone in victoryType.milestoneObjects)
+                if (milestone.type == null)
                     lines.add("Victory type ${victoryType.name} has milestone ${milestone.uniqueDescription} that is of an unknown type!", RulesetErrorSeverity.Error)
             for (victory in victories.values)
                 if (victory.name != victoryType.name && victory.milestones == victoryType.milestones)
@@ -863,10 +863,10 @@ object RulesetCache : HashMap<String,Ruleset>() {
         clear()
         for (ruleset in BaseRuleset.values()) {
             val fileName = "jsons/${ruleset.fullName}"
-            val fileHandle = 
+            val fileHandle =
                 if (consoleMode) FileHandle(fileName)
                 else Gdx.files.internal(fileName)
-            this[ruleset.fullName] = Ruleset().apply { 
+            this[ruleset.fullName] = Ruleset().apply {
                 load(fileHandle, printOutput)
                 name = ruleset.fullName
             }
@@ -949,7 +949,7 @@ object RulesetCache : HashMap<String,Ruleset>() {
         val loadedMods = mods.asSequence()
             .filter { containsKey(it) }
             .map { this[it]!! }
-            .filter { !it.modOptions.isBaseRuleset } + 
+            .filter { !it.modOptions.isBaseRuleset } +
             baseRuleset
 
         for (mod in loadedMods.sortedByDescending { it.modOptions.isBaseRuleset }) {
@@ -982,7 +982,7 @@ object RulesetCache : HashMap<String,Ruleset>() {
             // This happens if a building is dependent on a tech not in the base ruleset
             //  because newRuleset.updateBuildingCosts() in getComplexRuleset() throws an error
             Ruleset.RulesetErrorList()
-                .apply { add(ex.message!!.tr(), Ruleset.RulesetErrorSeverity.Error) }
+                .apply { add(ex.message, Ruleset.RulesetErrorSeverity.Error) }
         }
     }
 

--- a/core/src/com/unciv/ui/mapeditor/MapEditorLoadTab.kt
+++ b/core/src/com/unciv/ui/mapeditor/MapEditorLoadTab.kt
@@ -122,7 +122,7 @@ class MapEditorLoadTab(
                     val rulesetIncompatibilities = map.getRulesetIncompatibility(ruleset)
                     if (rulesetIncompatibilities.isNotEmpty()) {
                         map.removeMissingTerrainModReferences(ruleset)
-                        val message = "{This map has errors:}\n\n".tr() +
+                        val message = "{This map has errors:}\n\n" +
                                 rulesetIncompatibilities.sorted().joinToString("\n") { it.tr() } +
                                 "\n\n{The incompatible elements have been removed.}"
                         ToastPopup(message, editorScreen, 4000L)
@@ -134,7 +134,7 @@ class MapEditorLoadTab(
                 } catch (ex: Throwable) {
                     needPopup = false
                     popup?.close()
-                    println("Error displaying map \"$chosenMap\": ${ex.localizedMessage}")
+                    println("Error displaying map \"$chosenMap\": ${ex.message}")
                     Gdx.input.inputProcessor = editorScreen.stage
                     ToastPopup("Error loading map!", editorScreen)
                 }
@@ -143,9 +143,9 @@ class MapEditorLoadTab(
             needPopup = false
             Gdx.app.postRunnable {
                 popup?.close()
-                println("Error loading map \"$chosenMap\": ${ex.localizedMessage}")
-                ToastPopup("Error loading map!".tr() +
-                        (if (ex is UncivShowableException) "\n" + ex.message else ""), editorScreen)
+                println("Error loading map \"$chosenMap\": ${ex.message}")
+                ToastPopup("{Error loading map!}" +
+                        (if (ex is UncivShowableException) "\n{${ex.message}}" else ""), editorScreen)
             }
         }
     }


### PR DESCRIPTION
That little beast has seen little action since its birth, but more than none, and I came across some (yes this is a spin-off of a spin-off). And noticed they're instantiated in some cases with a pre-translated exception message, which is not quite the Exception concept. So I'd like to propose a quick cleanup, and all devs please do remember it and subclass at will - thanks JR for the perfect demo with MissingModsException.

Notes
- Translation is supposed to happen on the client side, not instantiation. I added Kdoc and a proper (but unused) translation overload, the way it's meant to be.
- I fixed the existing uses, most meant removing tr() calls and ensuring {} or [] are properly used so the final tr treats is correctly, some stuff is still double-tr()'ed, but that should be harmless.
- Since the only constructor demands a non-null message, the client-side message and localizedMessage getters can be non-null too, thanks to the language designers for allowing that deviation/improvement in overrides.
- I added templates so all existing uses are covered - **_but_** - I'm not sure it makes sense. I could believe - haven't really dug into the code to check - that they're not actually shown despite being a "UncivShowableException"... That and the entire ruleset check output isn't at the moment translatable, so maybe these templates should go? Help me out here.