### PR TITLE
Fix Right-Click attacks made no sound

### DIFF
--- a/core/src/com/unciv/logic/automation/BattleHelper.kt
+++ b/core/src/com/unciv/logic/automation/BattleHelper.kt
@@ -27,7 +27,7 @@ object BattleHelper {
         val enemyTileToAttack = chooseAttackTarget(unit, attackableEnemies)
 
         if (enemyTileToAttack != null) {
-            Battle.moveAndAttack(MapUnitCombatant(unit), enemyTileToAttack)
+            Battle.moveAndAttack(MapUnitCombatant(unit), enemyTileToAttack, silent = true)
             return true
         }
         return false
@@ -94,7 +94,7 @@ object BattleHelper {
     fun containsAttackableEnemy(tile: TileInfo, combatant: ICombatant): Boolean {
         if (combatant is MapUnitCombatant && combatant.unit.isEmbarked() && !combatant.hasUnique(UniqueType.AttackOnSea)) {
             // Can't attack water units while embarked, only land
-            if (tile.isWater || combatant.isRanged()) 
+            if (tile.isWater || combatant.isRanged())
                 return false
         }
 
@@ -102,7 +102,7 @@ object BattleHelper {
         if (tileCombatant.getCivInfo() == combatant.getCivInfo()) return false
         if (!combatant.getCivInfo().isAtWarWith(tileCombatant.getCivInfo())) return false
 
-        if (combatant is MapUnitCombatant && 
+        if (combatant is MapUnitCombatant &&
             combatant.unit.hasUnique(UniqueType.CanOnlyAttackUnits) &&
             combatant.unit.getMatchingUniques(UniqueType.CanOnlyAttackUnits).none { tileCombatant.matchesCategory(it.params[0]) }
         )
@@ -117,7 +117,7 @@ object BattleHelper {
         // Only units with the right unique can view submarines (or other invisible units) from more then one tile away.
         // Garrisoned invisible units can be attacked by anyone, as else the city will be in invincible.
         if (tileCombatant.isInvisible(combatant.getCivInfo()) && !tile.isCityCenter()) {
-            return combatant is MapUnitCombatant 
+            return combatant is MapUnitCombatant
                 && combatant.getCivInfo().viewableInvisibleUnitsTiles.map { it.position }.contains(tile.position)
         }
         return true

--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -17,6 +17,7 @@ import com.unciv.models.ruleset.unique.Unique
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.stats.Stat
 import com.unciv.models.stats.Stats
+import com.unciv.ui.audio.Sounds
 import com.unciv.ui.utils.toPercent
 import java.util.*
 import kotlin.math.max
@@ -27,7 +28,13 @@ import kotlin.math.min
  */
 object Battle {
 
-    fun moveAndAttack(attacker: ICombatant, attackableTile: AttackableTile) {
+    /**
+     *
+     * Used by [com.unciv.ui.worldscreen.bottombar.BattleTable.simulateBattle] (in the attackButton.onClick handler),
+     * [com.unciv.ui.worldscreen.WorldMapHolder.onTileRightClicked]
+     * and [com.unciv.logic.automation.BattleHelper.tryAttackNearbyEnemy]
+     */
+    fun moveAndAttack(attacker: ICombatant, attackableTile: AttackableTile, silent: Boolean = false) {
         if (attacker is MapUnitCombatant) {
             attacker.unit.movement.moveToTile(attackableTile.tileToAttackFrom)
             /**
@@ -40,13 +47,19 @@ object Battle {
             /** Alternatively, maybe we DID reach that tile, but it turned out to be a hill or something,
              * so we expended all of our movement points!
              */
-            if (attacker.unit.currentMovement == 0f)
-                return
-            if (attacker.hasUnique(UniqueType.MustSetUp) && !attacker.unit.isSetUpForSiege()) {
+            if (attacker.hasUnique(UniqueType.MustSetUp)
+                    && !attacker.unit.isSetUpForSiege()
+                    && attacker.unit.currentMovement > 0f
+            ) {
                 attacker.unit.action = UnitActionType.SetUp.value
                 attacker.unit.useMovementPoints(1f)
             }
+            if (attacker.unit.currentMovement == 0f)
+                return
         }
+
+        if (!silent)
+            Sounds.play(attacker.getAttackSound())
 
         if (attacker is MapUnitCombatant && attacker.unit.baseUnit.isNuclearWeapon())
             return NUKE(attacker, attackableTile.tileToAttack)
@@ -98,9 +111,9 @@ object Battle {
 
         if (defender.getCivInfo().isBarbarian() && attackedTile.improvement == Constants.barbarianEncampment)
             defender.getCivInfo().gameInfo.barbarians.campAttacked(attackedTile.position)
-            
+
         postBattleNationUniques(defender, attackedTile, attacker)
-        
+
         // This needs to come BEFORE the move-to-tile, because if we haven't conquered it we can't move there =)
         if (defender.isDefeated() && defender is CityCombatant && attacker is MapUnitCombatant
                 && attacker.isMelee() && !attacker.unit.hasUnique(UniqueType.CannotCaptureCities)) {
@@ -316,7 +329,7 @@ object Battle {
                 attacker.unit.healBy(amountToHeal)
             }
     }
-    
+
     /** Places a [unitName] unit near [tile] after being attacked by [attacker].
      * Adds a notification to [attacker]'s civInfo and returns whether the captured unit could be placed */
     private fun spawnCapturedUnit(unitName: String, attacker: ICombatant, tile: TileInfo, notification: String): Boolean {
@@ -332,19 +345,19 @@ object Battle {
 
     private fun postBattleNationUniques(defender: ICombatant, attackedTile: TileInfo, attacker: ICombatant) {
         if (!defender.isDefeated()) return
-        
+
         // Barbarians reduce spawn countdown after their camp was attacked "kicking the hornet's nest"
         if (defender.getCivInfo().isBarbarian() && attackedTile.improvement == Constants.barbarianEncampment) {
             var unitPlaced = false
             // German unique - needs to be checked before we try to move to the enemy tile, since the encampment disappears after we move in
             // Deprecated as of 4.0.3
-                if (attacker.getCivInfo().hasUnique(UniqueType.ChanceToRecruitBarbarianFromEncampment) 
+                if (attacker.getCivInfo().hasUnique(UniqueType.ChanceToRecruitBarbarianFromEncampment)
                     && Random().nextDouble() < 0.67
                 ) {
                     attacker.getCivInfo().addGold(25)
                     unitPlaced = spawnCapturedUnit(defender.getName(), attacker, attackedTile,"A barbarian [${defender.getName()}] has joined us!")
                 }
-            
+
                 // New version of unique
             //
             for (unique in attacker.getCivInfo().getMatchingUniques(UniqueType.GainFromEncampment)) {
@@ -353,7 +366,7 @@ object Battle {
                 unitPlaced = spawnCapturedUnit(defender.getName(), attacker, attackedTile,"A barbarian [${defender.getName()}] has joined us!")
             }
         }
-        
+
         // Similarly, Ottoman unique
         // Deprecated as of 4.0.3
             if (attacker.getCivInfo().hasUnique(UniqueType.ChanceToRecruitNavalBarbarian)
@@ -449,7 +462,7 @@ object Battle {
         ) {
             return
         }
-        
+
         val stateForConditionals = StateForConditionals(civInfo = thisCombatant.getCivInfo(), ourCombatant = thisCombatant, theirCombatant = otherCombatant)
 
         for (unique in thisCombatant.getMatchingUniques(UniqueType.FlatXPGain, stateForConditionals, true))
@@ -459,7 +472,7 @@ object Battle {
 
         for (unique in thisCombatant.getMatchingUniques(UniqueType.PercentageXPGain, stateForConditionals, true))
             xpModifier += unique.params[0].toFloat() / 100
-        
+
         val xpGained = (baseXP * xpModifier).toInt()
         thisCombatant.unit.promotions.XP += xpGained
 
@@ -481,8 +494,8 @@ object Battle {
 
     private fun conquerCity(city: CityInfo, attacker: MapUnitCombatant) {
         val attackerCiv = attacker.getCivInfo()
-        
-        
+
+
         attackerCiv.addNotification("We have conquered the city of [${city.name}]!", city.location, NotificationIcon.War)
 
         city.hasJustBeenConquered = true
@@ -610,13 +623,13 @@ object Battle {
             attacker.popupAlerts.add(PopupAlert(AlertType.Defeated, attackedCiv.civName))
         }
     }
-    
+
     fun mayUseNuke(nuke: MapUnitCombatant, targetTile: TileInfo): Boolean {
         val blastRadius =
             if (!nuke.hasUnique(UniqueType.BlastRadius)) 2
             // Don't check conditionals as these are not supported
             else nuke.unit.getMatchingUniques(UniqueType.BlastRadius).first().params[0].toInt()
-        
+
         var canNuke = true
         val attackerCiv = nuke.getCivInfo()
         for (tile in targetTile.getTilesInDistance(blastRadius)) {
@@ -761,7 +774,7 @@ object Battle {
                 tile.addTerrainFeature("Fallout")
             }
             if (!tile.terrainHasUnique(UniqueType.DestroyableByNukes)) return
-        
+
             // Deprecated as of 3.19.19 -- If removed, the two successive `if`s above should be merged
                 val destructionChance = if (tile.terrainHasUnique(UniqueType.ResistsNukes)) 0.25f
                 else 0.5f
@@ -797,13 +810,13 @@ object Battle {
         targetedCity.population.addPopulation(-populationLoss.toInt())
         if (targetedCity.population.population < 1) targetedCity.population.setPopulation(1)
     }
-    
+
     private fun tryInterceptAirAttack(attacker: MapUnitCombatant, attackedTile: TileInfo, interceptingCiv: CivilizationInfo, defender: ICombatant?) {
         if (attacker.unit.hasUnique(UniqueType.CannotBeIntercepted)) return
         // Pick highest chance interceptor
         for (interceptor in interceptingCiv.getCivUnits()
                 .filter { it.canIntercept(attackedTile) }
-                .sortedByDescending { it.interceptChance() }) { 
+                .sortedByDescending { it.interceptChance() }) {
             // defender can't also intercept
             if (defender != null && defender is MapUnitCombatant && interceptor == defender.unit) continue
             // Does Intercept happen? If not, exit

--- a/core/src/com/unciv/ui/audio/Sounds.kt
+++ b/core/src/com/unciv/ui/audio/Sounds.kt
@@ -12,7 +12,7 @@ import java.io.File
 
 /*
  * Problems on Android
- * 
+ *
  * Essentially the freshly created Gdx Sound object from newSound() is not immediately usable, it
  * needs some preparation time - buffering, decoding, whatever. Calling play() immediately will result
  * in no sound, a logcat warning (not ready), and nothing else - specifically no exceptions. Also,
@@ -20,14 +20,14 @@ import java.io.File
  * (resource failed to clean up). Also, Gdx will attempt fast track, which will cause logcat entries,
  * and these will be warnings if the sound file's sample rate (not bitrate) does not match the device's
  * hardware preferred bitrate. On a Xiaomi Mi8 that is 48kHz, not 44.1kHz. Channel count also must match.
- * 
+ *
  * @see "https://github.com/libgdx/libgdx/issues/1775"
  * logcat entry "W/System: A resource failed to call end.":
  *  unavoidable as long as we cache Gdx Sound objects loaded from assets
  * logcat entry "W/SoundPool: sample X not READY":
  *  could be avoided by preloading the 'cache' or otherwise ensuring a minimum delay between
  *  newSound() and play() - there's no test function that does not trigger logcat warnings.
- * 
+ *
  * Current approach: Cache on demand as before, catch stream not ready and retry. This maximizes
  * logcat messages but user experience is acceptable. Empiric delay needed was measured a 40ms
  * so that is the minimum wait before attempting play when we know the sound is freshly cached
@@ -47,11 +47,11 @@ object Sounds {
 
     @Suppress("EnumEntryName")
     private enum class SupportedExtensions { mp3, ogg, wav }    // Per Gdx docs, no aac/m4a
-    
+
     private val soundMap = HashMap<UncivSound, Sound?>()
-    
+
     private val separator = File.separator      // just a shorthand for readability
-    
+
     private var modListHash = Int.MIN_VALUE
 
     /** Ensure cache is not outdated */
@@ -101,7 +101,7 @@ object Sounds {
         return modList.asSequence()
             .map { "mods$separator$it$separator" } +
             sequenceOf("")
-    } 
+    }
 
     /** Holds a Gdx Sound and a flag indicating the sound is freshly loaded and not from cache */
     private data class GetSoundResult(val resource: Sound, val isFresh: Boolean)
@@ -113,7 +113,7 @@ object Sounds {
     private fun get(sound: UncivSound): GetSoundResult? {
         checkCache()
         // Look for cached sound
-        if (sound in soundMap) 
+        if (sound in soundMap)
             return if(soundMap[sound] == null) null
             else GetSoundResult(soundMap[sound]!!, false)
 
@@ -124,7 +124,7 @@ object Sounds {
             // This is essentially a cross join. To operate on all combinations, we pack both lambda
             // parameters into a Pair (using `to`) and unwrap that in the loop using automatic data
             // class deconstruction `(,)`. All this avoids a double break when a match is found.
-            folder -> SupportedExtensions.values().asSequence().map { folder to it } 
+            folder -> SupportedExtensions.values().asSequence().map { folder to it }
         } ) {
             val path = "${modFolder}sounds$separator$fileName.${extension.name}"
             file = Gdx.files.local(path)
@@ -152,10 +152,10 @@ object Sounds {
      *
      * Sources are mods from a loaded game, then mods marked as permanent audiovisual,
      * and lastly Unciv's own assets/sounds. Will fail silently if the sound file cannot be found.
-     * 
+     *
      * This will wait for the Stream to become ready (Android issue) if necessary, and do so on a
      * separate thread. No new thread is created if the sound can be played immediately.
-     * 
+     *
      * @param sound The sound to play
      */
     fun play(sound: UncivSound) {

--- a/core/src/com/unciv/ui/worldscreen/WorldMapHolder.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldMapHolder.kt
@@ -116,29 +116,7 @@ class WorldMapHolder(internal val worldScreen: WorldScreen, internal val tileMap
                     val unit = worldScreen.bottomUnitTable.selectedUnit
                         ?: return
                     launchCrashHandling("WorldScreenClick") {
-                        val tile = tileGroup.tileInfo
-
-                        if (worldScreen.bottomUnitTable.selectedUnitIsSwapping) {
-                            if (unit.movement.canUnitSwapTo(tile)) {
-                                swapMoveUnitToTargetTile(unit, tile)
-                            }
-                            // If we are in unit-swapping mode, we don't want to move or attack
-                            return@launchCrashHandling
-                        }
-
-                        val attackableTile = BattleHelper.getAttackableEnemies(unit, unit.movement.getDistanceToTiles())
-                                .firstOrNull { it.tileToAttack == tileGroup.tileInfo }
-                        if (unit.canAttack() && attackableTile != null) {
-                            Battle.moveAndAttack(MapUnitCombatant(unit), attackableTile)
-                            worldScreen.shouldUpdate = true
-                            return@launchCrashHandling
-                        }
-
-                        val canUnitReachTile = unit.movement.canReach(tile)
-                        if (canUnitReachTile) {
-                            moveUnitToTargetTile(listOf(unit), tile)
-                            return@launchCrashHandling
-                        }
+                        onTileRightClicked(unit, tileGroup.tileInfo)
                     }
                 }
             })
@@ -202,6 +180,29 @@ class WorldMapHolder(internal val worldScreen: WorldScreen, internal val tileMap
         worldScreen.shouldUpdate = true
     }
 
+    private fun onTileRightClicked(unit: MapUnit, tile: TileInfo) {
+        if (worldScreen.bottomUnitTable.selectedUnitIsSwapping) {
+            if (unit.movement.canUnitSwapTo(tile)) {
+                swapMoveUnitToTargetTile(unit, tile)
+            }
+            // If we are in unit-swapping mode, we don't want to move or attack
+            return
+        }
+
+        val attackableTile = BattleHelper.getAttackableEnemies(unit, unit.movement.getDistanceToTiles())
+            .firstOrNull { it.tileToAttack == tile }
+        if (unit.canAttack() && attackableTile != null) {
+            Battle.moveAndAttack(MapUnitCombatant(unit), attackableTile)
+            worldScreen.shouldUpdate = true
+            return
+        }
+
+        val canUnitReachTile = unit.movement.canReach(tile)
+        if (canUnitReachTile) {
+            moveUnitToTargetTile(listOf(unit), tile)
+            return
+        }
+    }
 
     private fun moveUnitToTargetTile(selectedUnits: List<MapUnit>, targetTile: TileInfo) {
         // this can take a long time, because of the unit-to-tile calculation needed, so we put it in a different thread

--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -155,7 +155,7 @@ class WorldScreen(val gameInfo: GameInfo, val viewingCiv:CivilizationInfo) : Bas
 
         stage.addActor(mapHolder)
         stage.scrollFocus = mapHolder
-        stage.addActor(notificationsScroll)  // very low in z-order, so we're free to let it extend _below_ tile info and minimap if we want 
+        stage.addActor(notificationsScroll)  // very low in z-order, so we're free to let it extend _below_ tile info and minimap if we want
         stage.addActor(minimapWrapper)
         stage.addActor(topBar)
         stage.addActor(nextTurnButton)
@@ -408,7 +408,7 @@ class WorldScreen(val gameInfo: GameInfo, val viewingCiv:CivilizationInfo) : Bas
     // This is private so that we will set the shouldUpdate to true instead.
     // That way, not only do we save a lot of unnecessary updates, we also ensure that all updates are called from the main GL thread
     // and we don't get any silly concurrency problems!
-    internal fun update() {
+    private fun update() {
 
         displayTutorialsOnUpdate()
 

--- a/core/src/com/unciv/ui/worldscreen/bottombar/BattleTable.kt
+++ b/core/src/com/unciv/ui/worldscreen/bottombar/BattleTable.kt
@@ -1,5 +1,6 @@
 package com.unciv.ui.worldscreen.bottombar
 
+import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.math.Interpolation
 import com.badlogic.gdx.scenes.scene2d.Actor
@@ -16,6 +17,7 @@ import com.unciv.logic.automation.UnitAutomation
 import com.unciv.logic.battle.*
 import com.unciv.logic.map.TileInfo
 import com.unciv.models.AttackableTile
+import com.unciv.models.UncivSound
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.translations.tr
 import com.unciv.ui.images.ImageGetter
@@ -84,7 +86,7 @@ class BattleTable(val worldScreen: WorldScreen): Table() {
         if (defender == null || (!includeFriendly && defender.getCivInfo() == attackerCiv))
             return null  // no enemy combatant in tile
 
-        val canSeeDefender = 
+        val canSeeDefender =
             if (UncivGame.Current.viewEntireMapForDebug) true
             else {
                 when {
@@ -251,29 +253,8 @@ class BattleTable(val worldScreen: WorldScreen): Table() {
         }
 
         else {
-            attackButton.onClick(attacker.getAttackSound()) {
-                Battle.moveAndAttack(attacker, attackableTile)
-                worldScreen.mapHolder.removeUnitActionOverlay() // the overlay was one of attacking
-                worldScreen.update()
-
-                val actorsToFlashRed = arrayListOf<Actor>()
-
-                if (damageToDefender != 0)
-                    actorsToFlashRed.addAll(getMapActorsForCombatant(defender))
-                if (damageToAttacker != 0)
-                    actorsToFlashRed.addAll(getMapActorsForCombatant(attacker))
-                fun updateRedPercent(percent: Float) {
-                    for (actor in actorsToFlashRed)
-                        actor.color = Color.WHITE.cpy().lerp(Color.RED, percent)
-                }
-                worldScreen.stage.addAction(Actions.sequence(
-                    object : FloatAction(0f, 1f, 0.3f, Interpolation.sine) {
-                        override fun update(percent: Float) = updateRedPercent(percent)
-                    },
-                    object : FloatAction(0f, 1f, 0.3f, Interpolation.sine) {
-                        override fun update(percent: Float) = updateRedPercent(1 - percent)
-                    }
-                ))
+            attackButton.onClick(UncivSound.Silent) {  // moveAndAttack will do the sound
+                onAttackButtonClicked(attacker, defender, attackableTile, damageToAttacker, damageToDefender)
             }
         }
 
@@ -284,6 +265,39 @@ class BattleTable(val worldScreen: WorldScreen): Table() {
         setPosition(worldScreen.stage.width/2-width/2, 5f)
     }
 
+    private fun onAttackButtonClicked(
+        attacker: ICombatant,
+        defender: ICombatant,
+        attackableTile: AttackableTile,
+        damageToAttacker: Int,
+        damageToDefender: Int
+    ) {
+        Battle.moveAndAttack(attacker, attackableTile)
+        worldScreen.mapHolder.removeUnitActionOverlay() // the overlay was one of attacking
+        // There was a direct worldScreen.update() call here, removing its 'private' but not the comment justifying the modifier.
+        // My tests (desktop only) show the red-flash animations look just fine without.
+        worldScreen.shouldUpdate = true
+        //Gdx.graphics.requestRendering()  // Use this if immediate rendering is required
+
+        val actorsToFlashRed = arrayListOf<Actor>()
+
+        if (damageToDefender != 0)
+            actorsToFlashRed.addAll(getMapActorsForCombatant(defender))
+        if (damageToAttacker != 0)
+            actorsToFlashRed.addAll(getMapActorsForCombatant(attacker))
+        fun updateRedPercent(percent: Float) {
+            for (actor in actorsToFlashRed)
+                actor.color = Color.WHITE.cpy().lerp(Color.RED, percent)
+        }
+        worldScreen.stage.addAction(Actions.sequence(
+            object : FloatAction(0f, 1f, 0.3f, Interpolation.sine) {
+                override fun update(percent: Float) = updateRedPercent(percent)
+            },
+            object : FloatAction(0f, 1f, 0.3f, Interpolation.sine) {
+                override fun update(percent: Float) = updateRedPercent(1 - percent)
+            }
+        ))
+    }
 
     fun getMapActorsForCombatant(combatant: ICombatant):Sequence<Actor> =
         sequence {
@@ -314,17 +328,17 @@ class BattleTable(val worldScreen: WorldScreen): Table() {
         attackerNameWrapper.add(getIcon(attacker)).padRight(5f)
         attackerNameWrapper.add(attackerLabel)
         add(attackerNameWrapper)
-        
+
         val canNuke = Battle.mayUseNuke(attacker, targetTile)
 
         val blastRadius =
             if (!attacker.unit.hasUnique(UniqueType.BlastRadius)) 2
             else attacker.unit.getMatchingUniques(UniqueType.BlastRadius).first().params[0].toInt()
-        
+
         val defenderNameWrapper = Table()
         for (tile in targetTile.getTilesInDistance(blastRadius)) {
             val defender = tryGetDefenderAtTile(tile, true) ?: continue
-            
+
             val defenderLabel = Label(defender.getName().tr(), skin)
             defenderNameWrapper.add(getIcon(defender)).padRight(5f)
             defenderNameWrapper.add(defenderLabel).row()


### PR DESCRIPTION
Fixes #6895, but **_I don't like it_**. Problems I see remaining:
- Why was the update being private broken in the first place - maybe there's circumstances I didn't test where the red flashing breaks?
- Right-click attacking also omits said red-flashing for the units being wounded
- Cities can't right-click bombard
- Units can't right-click move into cities (both of these just breaking user expectations, but)
- As you said unclean logic/ui code separation