### PR TITLE
Add notification on ’F ='

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -486,7 +486,7 @@ Land or water only =
 
 ## Labels/messages
 Brush ([size]): = 
-# The letter shown in the [size] parameter above for setting "Floodfill"
+# The letter shown in the [size] parameter above for setting "Floodfill". It will also affect the shoutcut key which is shown on 'Fortify' and 'Sleep', so better be careful!
 F = 
 Error loading map! = 
 Map saved successfully! = 


### PR DESCRIPTION
Inspired by my own translation fault. When I was translating the map editor, I translated the F into the meaning of ‘floodfill’， but I found I had been wrong because the fortify's shortcut key now says 'floodfill' as well. 
![image](https://user-images.githubusercontent.com/100454479/169698995-06a11d2c-cbca-4cce-be49-d238997ac99e.png)
That's why I made a small pull here to notify other translators.
Edited: Just a little typo.