### PR TITLE
Fix missing icons and translations in civilopedia accessed from main menu

### DIFF
--- a/core/src/com/unciv/MainMenuScreen.kt
+++ b/core/src/com/unciv/MainMenuScreen.kt
@@ -231,13 +231,11 @@ class MainMenuScreen: BaseScreen() {
     }
 
     private fun openCivilopedia() {
-        var ruleset: Ruleset? = RulesetCache[BaseRuleset.Civ_V_GnK.fullName]
         val rulesetParameters = game.settings.lastGameSetup?.gameParameters
-        if (rulesetParameters != null) {
-            ruleset = RulesetCache.getComplexRuleset(rulesetParameters)
-            UncivGame.Current.translations.translationActiveMods = LinkedHashSet(rulesetParameters.getModsAndBaseRuleset())
-        }
-        if (ruleset == null) return
+        val ruleset = if (rulesetParameters == null)
+                RulesetCache[BaseRuleset.Civ_V_GnK.fullName] ?: return
+                else RulesetCache.getComplexRuleset(rulesetParameters)
+        UncivGame.Current.translations.translationActiveMods = ruleset.mods
         ImageGetter.setNewRuleset(ruleset)
         setSkin()
         game.setScreen(CivilopediaScreen(ruleset, this))

--- a/core/src/com/unciv/MainMenuScreen.kt
+++ b/core/src/com/unciv/MainMenuScreen.kt
@@ -19,7 +19,6 @@ import com.unciv.ui.multiplayer.MultiplayerScreen
 import com.unciv.ui.mapeditor.*
 import com.unciv.models.metadata.GameSetupInfo
 import com.unciv.models.ruleset.Ruleset
-import com.unciv.models.translations.Translations
 import com.unciv.ui.civilopedia.CivilopediaScreen
 import com.unciv.ui.crashhandling.launchCrashHandling
 import com.unciv.ui.crashhandling.postCrashHandlingRunnable

--- a/core/src/com/unciv/MainMenuScreen.kt
+++ b/core/src/com/unciv/MainMenuScreen.kt
@@ -233,6 +233,7 @@ class MainMenuScreen: BaseScreen() {
         val ruleset =RulesetCache[game.settings.lastGameSetup?.gameParameters?.baseRuleset]
             ?: RulesetCache[BaseRuleset.Civ_V_GnK.fullName]
             ?: return
+        ImageGetter.setNewRuleset(ruleset)
         game.setScreen(CivilopediaScreen(ruleset, this))
     }
 

--- a/core/src/com/unciv/MainMenuScreen.kt
+++ b/core/src/com/unciv/MainMenuScreen.kt
@@ -18,6 +18,8 @@ import com.unciv.models.ruleset.RulesetCache
 import com.unciv.ui.multiplayer.MultiplayerScreen
 import com.unciv.ui.mapeditor.*
 import com.unciv.models.metadata.GameSetupInfo
+import com.unciv.models.ruleset.Ruleset
+import com.unciv.models.translations.Translations
 import com.unciv.ui.civilopedia.CivilopediaScreen
 import com.unciv.ui.crashhandling.launchCrashHandling
 import com.unciv.ui.crashhandling.postCrashHandlingRunnable
@@ -230,10 +232,15 @@ class MainMenuScreen: BaseScreen() {
     }
 
     private fun openCivilopedia() {
-        val ruleset =RulesetCache[game.settings.lastGameSetup?.gameParameters?.baseRuleset]
-            ?: RulesetCache[BaseRuleset.Civ_V_GnK.fullName]
-            ?: return
+        var ruleset: Ruleset? = RulesetCache[BaseRuleset.Civ_V_GnK.fullName]
+        val rulesetParamters = game.settings.lastGameSetup?.gameParameters
+        if (rulesetParamters != null) {
+            ruleset = RulesetCache.getComplexRuleset(rulesetParamters)
+            UncivGame.Current.translations.translationActiveMods = LinkedHashSet(rulesetParamters.getModsAndBaseRuleset())
+        }
+        if (ruleset == null) return
         ImageGetter.setNewRuleset(ruleset)
+        setSkin()
         game.setScreen(CivilopediaScreen(ruleset, this))
     }
 

--- a/core/src/com/unciv/MainMenuScreen.kt
+++ b/core/src/com/unciv/MainMenuScreen.kt
@@ -232,10 +232,10 @@ class MainMenuScreen: BaseScreen() {
 
     private fun openCivilopedia() {
         var ruleset: Ruleset? = RulesetCache[BaseRuleset.Civ_V_GnK.fullName]
-        val rulesetParamters = game.settings.lastGameSetup?.gameParameters
-        if (rulesetParamters != null) {
-            ruleset = RulesetCache.getComplexRuleset(rulesetParamters)
-            UncivGame.Current.translations.translationActiveMods = LinkedHashSet(rulesetParamters.getModsAndBaseRuleset())
+        val rulesetParameters = game.settings.lastGameSetup?.gameParameters
+        if (rulesetParameters != null) {
+            ruleset = RulesetCache.getComplexRuleset(rulesetParameters)
+            UncivGame.Current.translations.translationActiveMods = LinkedHashSet(rulesetParameters.getModsAndBaseRuleset())
         }
         if (ruleset == null) return
         ImageGetter.setNewRuleset(ruleset)


### PR DESCRIPTION
Fixes #6913. Seems like the game wasn't loading G&K icons. Credit to @SomeTroglodyte who wrote the one-line fix in the issue thread then provided help in this thread. Also ensures that the correct translation is applied to the civilopedia for mods including base ruleset mods.