### PR TITLE
confirmation when pressing next turn

### DIFF
--- a/core/src/com/unciv/models/metadata/GameSettings.kt
+++ b/core/src/com/unciv/models/metadata/GameSettings.kt
@@ -48,6 +48,7 @@ class GameSettings {
     var multiplayerTurnCheckerPersistentNotificationEnabled = true
     var multiplayerTurnCheckerDelayInMinutes = 5
     var orderTradeOffersByAmount = true
+    var confirmNextTurn = false
     var windowState = WindowState()
     var isFreshlyCreated = false
     var visualMods = HashSet<String>()

--- a/core/src/com/unciv/ui/options/GameplayTab.kt
+++ b/core/src/com/unciv/ui/options/GameplayTab.kt
@@ -33,4 +33,5 @@ fun gameplayTab(
         settings.automatedWorkersReplaceImprovements
     ) { settings.automatedWorkersReplaceImprovements = it }
     optionsPopup.addCheckbox(this, "Order trade offers by amount", settings.orderTradeOffersByAmount) { settings.orderTradeOffersByAmount = it }
+    optionsPopup.addCheckbox(this, "Ask for confirmation when pressing next turn", settings.confirmNextTurn) { settings.confirmNextTurn = it }
 }

--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -39,6 +39,7 @@ import com.unciv.ui.pickerscreens.*
 import com.unciv.ui.popup.ExitGamePopup
 import com.unciv.ui.popup.Popup
 import com.unciv.ui.popup.ToastPopup
+import com.unciv.ui.popup.YesNoPopup
 import com.unciv.ui.popup.hasOpenPopups
 import com.unciv.ui.saves.LoadGameScreen
 import com.unciv.ui.saves.SaveGameScreen
@@ -822,8 +823,15 @@ class WorldScreen(val gameInfo: GameInfo, val viewingCiv:CivilizationInfo) : Bas
 
             else ->
                 NextTurnAction("${Fonts.turn}{Next turn}", Color.WHITE) {
-                    game.settings.addCompletedTutorialTask("Pass a turn")
-                    nextTurn()
+                    if(game.settings.confirmNextTurn) {
+                        YesNoPopup("Confirm next turn", {
+                            game.settings.addCompletedTutorialTask("Pass a turn")
+                            nextTurn()
+                        }, UncivGame.Current.worldScreen).open()
+                    } else {
+                        game.settings.addCompletedTutorialTask("Pass a turn")
+                        nextTurn()
+                    }
                 }
         }
     }


### PR DESCRIPTION
resolves #6880 

Adds an option in settings for getting an YesNoPopup when pressing next turn to avoid accidentally pressing it

By default is off