### PR TITLE
More compact CrashHandling exception output

### DIFF
--- a/core/src/com/unciv/ui/crashhandling/CrashScreen.kt
+++ b/core/src/com/unciv/ui/crashhandling/CrashScreen.kt
@@ -14,8 +14,6 @@ import com.unciv.ui.images.IconTextButton
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.popup.ToastPopup
 import com.unciv.ui.utils.*
-import java.io.PrintWriter
-import java.io.StringWriter
 import kotlin.concurrent.thread
 
 /*
@@ -33,9 +31,23 @@ class CrashScreen(val exception: Throwable): BaseScreen() {
 
     private companion object {
         fun Throwable.stringify(): String {
-            val out = StringWriter()
-            this.printStackTrace(PrintWriter(out))
-            return out.toString()
+            val sb = StringBuilder()
+            sb.appendLine(this.toString())
+            var inUnciv = false
+            for (element in stackTrace) {
+                if (element.className.startsWith("com.unciv.ui.crashhandling")) break
+                sb.append("\tat ")
+                sb.appendLine(element.toString())
+                if (element.className.startsWith("com.unciv.")) inUnciv = true
+                else if (inUnciv) break
+            }
+            var nextNestedCause = this.cause
+            while (nextNestedCause != null) {
+                sb.append("Caused by: ")
+                sb.appendLine(nextNestedCause.toString())
+                nextNestedCause = nextNestedCause.cause
+            }
+            return sb.toString()
         }
     }
 


### PR DESCRIPTION
<details><summary>Just a dumb idea I wanted to see how it looked.</summary>


**Platform:** Desktop
**Version:** Desktop
**Rulesets:** [Higher quality builtin sounds, Additional Music - Movies, Civ V - Vanilla, Modern Joke Religions, DeCiv Redux, Civ6 mod, Wikia Leader Portraits, Civ V Soundtrack, Civ Army Color Style Sheet, Deciv Redux Leader Portraits, Aliens have crashed on Earth, Test Generals, Ancient Civilizations, Civ V - Gods & Kings, Great Community Maps, 5Hex Tileset, Additional Music - Various, Unciv Europe Map Example (broken), Additional Music - Ambient]
**Last Screen:** `com.unciv.MainMenuScreen`

--------------------------------

OS: Linux (amd64, 5.13.0-41-generic)
	Linux Mint 20.3
Java: Eclipse Adoptium Temurin-11.0.14.1+1
	Max Memory: 2048 MB


--------------------------------


**Message before:**
```
com.unciv.logic.UncivShowableException: Fehler beim Laden der Karte
	at com.unciv.ui.civilopedia.CivilopediaScreen._init_$shouldBeDisplayed(CivilopediaScreen.kt:188)
	at com.unciv.ui.civilopedia.CivilopediaScreen.<init>(CivilopediaScreen.kt:216)
	at com.unciv.ui.civilopedia.CivilopediaScreen.<init>(CivilopediaScreen.kt:28)
	at com.unciv.MainMenuScreen.openCivilopedia(MainMenuScreen.kt:236)
	at com.unciv.MainMenuScreen.access$openCivilopedia(MainMenuScreen.kt:32)
	at com.unciv.MainMenuScreen$4.invoke(MainMenuScreen.kt:161)
	at com.unciv.MainMenuScreen$4.invoke(MainMenuScreen.kt:161)
	at com.unciv.ui.utils.KeyPressDispatcher$install$1.keyDown(KeyPressDispatcher.kt:210)
	at com.badlogic.gdx.scenes.scene2d.InputListener.handle(InputListener.java:53)
	at com.badlogic.gdx.scenes.scene2d.Actor.notify(Actor.java:188)
	at com.badlogic.gdx.scenes.scene2d.Actor.fire(Actor.java:152)
	at com.badlogic.gdx.scenes.scene2d.Stage.keyDown(Stage.java:418)
	at com.unciv.ui.crashhandling.CrashHandlingStage.access$keyDown$s80204510(CrashHandlingStage.kt:10)
	at com.unciv.ui.crashhandling.CrashHandlingStage$keyDown$1.invoke(CrashHandlingStage.kt:27)
	at com.unciv.ui.crashhandling.CrashHandlingStage$keyDown$1.invoke(CrashHandlingStage.kt:27)
	at com.unciv.ui.utils.ExtensionFunctionsKt$wrapCrashHandling$1.invoke(ExtensionFunctions.kt:346)
	at com.unciv.ui.crashhandling.CrashHandlingStage.keyDown(CrashHandlingStage.kt:27)
	at com.badlogic.gdx.InputEventQueue.drain(InputEventQueue.java:58)
	at com.badlogic.gdx.backends.lwjgl3.DefaultLwjgl3Input.update(DefaultLwjgl3Input.java:189)
	at com.badlogic.gdx.backends.lwjgl3.Lwjgl3Window.update(Lwjgl3Window.java:378)
	at com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application.loop(Lwjgl3Application.java:192)
	at com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application.<init>(Lwjgl3Application.java:166)
	at com.unciv.app.desktop.DesktopLauncher.main(DesktopLauncher.kt:64)

```

**Message after:**
```
com.unciv.logic.UncivShowableException: Fehler beim Laden der Karte
	at com.unciv.ui.civilopedia.CivilopediaScreen._init_$shouldBeDisplayed(CivilopediaScreen.kt:188)
	at com.unciv.ui.civilopedia.CivilopediaScreen.<init>(CivilopediaScreen.kt:216)
	at com.unciv.ui.civilopedia.CivilopediaScreen.<init>(CivilopediaScreen.kt:28)
	at com.unciv.MainMenuScreen.openCivilopedia(MainMenuScreen.kt:236)
	at com.unciv.MainMenuScreen.access$openCivilopedia(MainMenuScreen.kt:32)
	at com.unciv.MainMenuScreen$4.invoke(MainMenuScreen.kt:161)
	at com.unciv.MainMenuScreen$4.invoke(MainMenuScreen.kt:161)
	at com.unciv.ui.utils.KeyPressDispatcher$install$1.keyDown(KeyPressDispatcher.kt:210)
	at com.badlogic.gdx.scenes.scene2d.InputListener.handle(InputListener.java:53)

```
</details>

Stops right where it stops being interesting, but... Better keep the simpler code?