### PR TITLE
Fixed slider sound playing when opening NewGameScreen and MapEditor

### DIFF
--- a/core/src/com/unciv/ui/mapeditor/MapEditorEditTab.kt
+++ b/core/src/com/unciv/ui/mapeditor/MapEditorEditTab.kt
@@ -73,7 +73,7 @@ class MapEditorEditTab(
             defaults().pad(10f).left()
             add(brushLabel)
             brushCell = add().padLeft(0f)
-            brushSlider = UncivSlider(1f,6f,1f, getTipText = { getBrushTip(it).tr() }) {
+            brushSlider = UncivSlider(1f,6f,1f, initial = 1f, getTipText = { getBrushTip(it).tr() }) {
                 brushSize = if (it > 5f) -1 else it.toInt()
                 brushLabel.setText("Brush ([${getBrushTip(it).take(1)}]):".tr())
             }
@@ -237,7 +237,7 @@ class MapEditorEditTab(
         }
     }
 
-    /** Used for starting locations - no temp tile as brushAction needs to access tile.tileMap */ 
+    /** Used for starting locations - no temp tile as brushAction needs to access tile.tileMap */
     private fun directPaintTile(tile: TileInfo) {
         brushAction(tile)
         editorScreen.isDirty = true

--- a/core/src/com/unciv/ui/newgamescreen/GameOptionsTable.kt
+++ b/core/src/com/unciv/ui/newgamescreen/GameOptionsTable.kt
@@ -122,13 +122,12 @@ class GameOptionsTable(
         if (maxCityStates == 0) return null
 
         add("{Number of City-States}:".toLabel()).left().expandX()
-        val slider = UncivSlider(0f, maxCityStates.toFloat(), 1f, initial = 6f) {
+        val slider = UncivSlider(0f, maxCityStates.toFloat(), 1f, initial = gameParameters.numberOfCityStates.toFloat()) {
             gameParameters.numberOfCityStates = it.toInt()
         }
         slider.permanentTip = true
         slider.isDisabled = locked
         add(slider).padTop(10f).row()
-        slider.value = gameParameters.numberOfCityStates.toFloat()
         return slider
     }
 
@@ -137,14 +136,13 @@ class GameOptionsTable(
             return null
 
         add("{Max Turns}:".toLabel()).left().expandX()
-        val slider = UncivSlider(250f, 1500f, 50f, initial = 500f) {
+        val slider = UncivSlider(250f, 1500f, 50f, initial = gameParameters.maxTurns.toFloat()) {
             gameParameters.maxTurns = it.toInt()
         }
         slider.permanentTip = true
         slider.isDisabled = locked
         val snapValues = floatArrayOf(250f,300f,350f,400f,450f,500f,550f,600f,650f,700f,750f,800f,900f,1000f,1250f,1500f)
         slider.setSnapToValues(snapValues, 250f)
-        slider.value = gameParameters.maxTurns.toFloat()
         return slider
     }
 

--- a/core/src/com/unciv/ui/newgamescreen/GameOptionsTable.kt
+++ b/core/src/com/unciv/ui/newgamescreen/GameOptionsTable.kt
@@ -39,8 +39,8 @@ class GameOptionsTable(
         defaults().pad(5f)
 
         // We assign this first to make sure addBaseRulesetSelectBox doesn't reference a null object
-        modCheckboxes = 
-            if (isPortrait) 
+        modCheckboxes =
+            if (isPortrait)
                 getModCheckboxes(isPortrait = true)
             else getModCheckboxes()
 
@@ -53,13 +53,13 @@ class GameOptionsTable(
             // align left and right edges with other SelectBoxes but allow independent dropdown width
             add(Table().apply {
                 val turnSlider = addMaxTurnsSlider()
-                if (turnSlider != null) 
+                if (turnSlider != null)
                     add(turnSlider).padTop(10f).row()
                 cityStateSlider = addCityStatesSlider()
             }).colspan(2).fillX().row()
         }).row()
         addVictoryTypeCheckboxes()
-        
+
 
         val checkboxTable = Table().apply { defaults().left().pad(2.5f) }
         checkboxTable.addNoBarbariansCheckbox()
@@ -97,7 +97,7 @@ class GameOptionsTable(
     private fun Table.addNuclearWeaponsCheckbox() =
             addCheckbox("Enable Nuclear Weapons", gameParameters.nuclearWeaponsEnabled)
             { gameParameters.nuclearWeaponsEnabled = it }
-    
+
     private fun Table.addIsOnlineMultiplayerCheckbox() =
             addCheckbox("Online Multiplayer", gameParameters.isOnlineMultiplayer)
             {
@@ -122,7 +122,7 @@ class GameOptionsTable(
         if (maxCityStates == 0) return null
 
         add("{Number of City-States}:".toLabel()).left().expandX()
-        val slider = UncivSlider(0f, maxCityStates.toFloat(), 1f) {
+        val slider = UncivSlider(0f, maxCityStates.toFloat(), 1f, initial = 6f) {
             gameParameters.numberOfCityStates = it.toInt()
         }
         slider.permanentTip = true
@@ -137,7 +137,7 @@ class GameOptionsTable(
             return null
 
         add("{Max Turns}:".toLabel()).left().expandX()
-        val slider = UncivSlider(250f, 1500f, 50f) {
+        val slider = UncivSlider(250f, 1500f, 50f, initial = 500f) {
             gameParameters.maxTurns = it.toInt()
         }
         slider.permanentTip = true
@@ -152,8 +152,8 @@ class GameOptionsTable(
         add(text.toLabel()).left()
         val selectBox = TranslatedSelectBox(values, initialState, BaseScreen.skin)
         selectBox.isDisabled = locked
-        selectBox.onChange { 
-            val changedValue = onChange(selectBox.selected.value) 
+        selectBox.onChange {
+            val changedValue = onChange(selectBox.selected.value)
             if (changedValue != null) selectBox.setSelected(changedValue)
         }
         onChange(selectBox.selected.value)
@@ -168,7 +168,7 @@ class GameOptionsTable(
     private fun Table.addBaseRulesetSelectBox() {
         val sortedBaseRulesets = RulesetCache.getSortedBaseRulesets()
         if (sortedBaseRulesets.size < 2) return
-        
+
         addSelectBox(
             "{Base Ruleset}:",
             sortedBaseRulesets,
@@ -176,7 +176,7 @@ class GameOptionsTable(
         ) { newBaseRuleset ->
             val previousSelection = gameParameters.baseRuleset
             if (newBaseRuleset == gameParameters.baseRuleset) return@addSelectBox null
-            
+
             // Check if this mod is well-defined
             val baseRulesetErrors = RulesetCache[newBaseRuleset]!!.checkModLinks()
             if (baseRulesetErrors.isError()) {
@@ -184,7 +184,7 @@ class GameOptionsTable(
                 ToastPopup(toastMessage, previousScreen as BaseScreen, 5000L)
                 return@addSelectBox previousSelection
             }
-            
+
             // If so, add it to the current ruleset
             gameParameters.baseRuleset = newBaseRuleset
             onChooseMod(newBaseRuleset)
@@ -201,13 +201,13 @@ class GameOptionsTable(
                 modCheckboxes!!.disableAllCheckboxes()
             } else if (modLinkErrors.isWarnUser()) {
                 val toastMessage =
-                    "{The mod combination you selected has problems.}\n{You can play it, but don't expect everything to work!}".tr() + 
+                    "{The mod combination you selected has problems.}\n{You can play it, but don't expect everything to work!}".tr() +
                     "\n\n${modLinkErrors.getErrorText()}"
                 ToastPopup(toastMessage, previousScreen as BaseScreen, 5000L)
             }
-            
+
             modCheckboxes!!.setBaseRuleset(newBaseRuleset)
-            
+
             null
         }
     }
@@ -223,7 +223,7 @@ class GameOptionsTable(
         addSelectBox("{Starting Era}:", eras, gameParameters.startingEra)
         { gameParameters.startingEra = it; null }
     }
-    
+
     private fun addVictoryTypeCheckboxes() {
         add("{Victory Conditions}:".toLabel()).colspan(2).row()
 

--- a/core/src/com/unciv/ui/newgamescreen/MapParametersTable.kt
+++ b/core/src/com/unciv/ui/newgamescreen/MapParametersTable.kt
@@ -261,13 +261,13 @@ class MapParametersTable(
             return slider
         }
 
-        addSlider("Map Elevation", {mapParameters.elevationExponent}, 0.6f,0.8f)
+        addSlider("Map Elevation", {mapParameters.elevationExponent}, 0.6f, 0.8f)
         { mapParameters.elevationExponent = it }
 
-        addSlider("Temperature extremeness", {mapParameters.temperatureExtremeness}, 0.4f,0.8f)
+        addSlider("Temperature extremeness", {mapParameters.temperatureExtremeness}, 0.4f, 0.8f)
         { mapParameters.temperatureExtremeness = it }
 
-        addSlider("Resource richness", {mapParameters.resourceRichness},0f,0.5f)
+        addSlider("Resource richness", {mapParameters.resourceRichness},0f, 0.5f)
         { mapParameters.resourceRichness = it }
 
         addSlider("Vegetation richness", {mapParameters.vegetationRichness}, 0f, 1f)

--- a/core/src/com/unciv/ui/newgamescreen/MapParametersTable.kt
+++ b/core/src/com/unciv/ui/newgamescreen/MapParametersTable.kt
@@ -253,8 +253,8 @@ class MapParametersTable(
         table.add("RNG Seed".toLabel()).left()
         table.add(seedTextField).fillX().padBottom(10f).row()
 
-        fun addSlider(text: String, getValue:()->Float, min:Float, max:Float, onChange: (value:Float)->Unit): UncivSlider {
-            val slider = UncivSlider(min, max, (max - min) / 20, onChange = onChange)
+        fun addSlider(text: String, getValue:()->Float, min:Float, max:Float, initial:Float, onChange: (value:Float)->Unit): UncivSlider {
+            val slider = UncivSlider(min, max, (max - min) / 20, onChange = onChange, initial = initial)
             slider.value = getValue()
             table.add(text.toLabel()).left()
             table.add(slider).fillX().row()
@@ -262,28 +262,28 @@ class MapParametersTable(
             return slider
         }
 
-        addSlider("Map Elevation", {mapParameters.elevationExponent}, 0.6f,0.8f)
+        addSlider("Map Elevation", {mapParameters.elevationExponent}, 0.6f,0.8f, 0.70f)
         { mapParameters.elevationExponent = it }
 
-        addSlider("Temperature extremeness", {mapParameters.temperatureExtremeness}, 0.4f,0.8f)
+        addSlider("Temperature extremeness", {mapParameters.temperatureExtremeness}, 0.4f,0.8f, 0.60f)
         { mapParameters.temperatureExtremeness = it }
 
-        addSlider("Resource richness", {mapParameters.resourceRichness},0f,0.5f)
+        addSlider("Resource richness", {mapParameters.resourceRichness},0f,0.5f, 0.1f)
         { mapParameters.resourceRichness = it }
 
-        addSlider("Vegetation richness", {mapParameters.vegetationRichness}, 0f, 1f)
+        addSlider("Vegetation richness", {mapParameters.vegetationRichness}, 0f, 1f, 0.4f)
         { mapParameters.vegetationRichness = it }
 
-        addSlider("Rare features richness", {mapParameters.rareFeaturesRichness}, 0f, 0.5f)
+        addSlider("Rare features richness", {mapParameters.rareFeaturesRichness}, 0f, 0.5f, 0.05f)
         { mapParameters.rareFeaturesRichness = it }
 
-        addSlider("Max Coast extension", {mapParameters.maxCoastExtension.toFloat()}, 0f, 5f)
+        addSlider("Max Coast extension", {mapParameters.maxCoastExtension.toFloat()}, 0f, 5f, 2f)
         { mapParameters.maxCoastExtension = it.toInt() }.apply { stepSize = 1f }
 
-        addSlider("Biome areas extension", {mapParameters.tilesPerBiomeArea.toFloat()}, 1f, 15f)
+        addSlider("Biome areas extension", {mapParameters.tilesPerBiomeArea.toFloat()}, 1f, 15f, 6f)
         { mapParameters.tilesPerBiomeArea = it.toInt() }.apply { stepSize = 1f }
 
-        addSlider("Water level", {mapParameters.waterThreshold}, -0.1f, 0.1f)
+        addSlider("Water level", {mapParameters.waterThreshold}, -0.1f, 0.1f, 0f)
         { mapParameters.waterThreshold = it }
 
         val resetToDefaultButton = "Reset to defaults".toTextButton()

--- a/core/src/com/unciv/ui/newgamescreen/MapParametersTable.kt
+++ b/core/src/com/unciv/ui/newgamescreen/MapParametersTable.kt
@@ -253,37 +253,36 @@ class MapParametersTable(
         table.add("RNG Seed".toLabel()).left()
         table.add(seedTextField).fillX().padBottom(10f).row()
 
-        fun addSlider(text: String, getValue:()->Float, min:Float, max:Float, initial:Float, onChange: (value:Float)->Unit): UncivSlider {
-            val slider = UncivSlider(min, max, (max - min) / 20, onChange = onChange, initial = initial)
-            slider.value = getValue()
+        fun addSlider(text: String, getValue:()->Float, min: Float, max: Float, onChange: (value: Float)->Unit): UncivSlider {
+            val slider = UncivSlider(min, max, (max - min) / 20, onChange = onChange, initial = getValue())
             table.add(text.toLabel()).left()
             table.add(slider).fillX().row()
             advancedSliders[slider] = getValue
             return slider
         }
 
-        addSlider("Map Elevation", {mapParameters.elevationExponent}, 0.6f,0.8f, 0.70f)
+        addSlider("Map Elevation", {mapParameters.elevationExponent}, 0.6f,0.8f)
         { mapParameters.elevationExponent = it }
 
-        addSlider("Temperature extremeness", {mapParameters.temperatureExtremeness}, 0.4f,0.8f, 0.60f)
+        addSlider("Temperature extremeness", {mapParameters.temperatureExtremeness}, 0.4f,0.8f)
         { mapParameters.temperatureExtremeness = it }
 
-        addSlider("Resource richness", {mapParameters.resourceRichness},0f,0.5f, 0.1f)
+        addSlider("Resource richness", {mapParameters.resourceRichness},0f,0.5f)
         { mapParameters.resourceRichness = it }
 
-        addSlider("Vegetation richness", {mapParameters.vegetationRichness}, 0f, 1f, 0.4f)
+        addSlider("Vegetation richness", {mapParameters.vegetationRichness}, 0f, 1f)
         { mapParameters.vegetationRichness = it }
 
-        addSlider("Rare features richness", {mapParameters.rareFeaturesRichness}, 0f, 0.5f, 0.05f)
+        addSlider("Rare features richness", {mapParameters.rareFeaturesRichness}, 0f, 0.5f)
         { mapParameters.rareFeaturesRichness = it }
 
-        addSlider("Max Coast extension", {mapParameters.maxCoastExtension.toFloat()}, 0f, 5f, 2f)
+        addSlider("Max Coast extension", {mapParameters.maxCoastExtension.toFloat()}, 0f, 5f)
         { mapParameters.maxCoastExtension = it.toInt() }.apply { stepSize = 1f }
 
-        addSlider("Biome areas extension", {mapParameters.tilesPerBiomeArea.toFloat()}, 1f, 15f, 6f)
+        addSlider("Biome areas extension", {mapParameters.tilesPerBiomeArea.toFloat()}, 1f, 15f)
         { mapParameters.tilesPerBiomeArea = it.toInt() }.apply { stepSize = 1f }
 
-        addSlider("Water level", {mapParameters.waterThreshold}, -0.1f, 0.1f, 0f)
+        addSlider("Water level", {mapParameters.waterThreshold}, -0.1f, 0.1f)
         { mapParameters.waterThreshold = it }
 
         val resetToDefaultButton = "Reset to defaults".toTextButton()

--- a/core/src/com/unciv/ui/utils/UncivSlider.kt
+++ b/core/src/com/unciv/ui/utils/UncivSlider.kt
@@ -20,14 +20,14 @@ import kotlin.math.sign
 
 /**
  * Modified Gdx [Slider]
- * 
+ *
  * Has +/- buttons at the end for easier single steps
  * Shows a timed tip with the actual value every time it changes
  * Disables listeners of any ScrollPanes this is nested in while dragging
- * 
+ *
  * Note: No attempt is made to distinguish sources of value changes, so the initial setting
  * of the value when a screen is initialized will also trigger the 'tip'. This is intentional.
- * 
+ *
  * @param min           Initializes [Slider.min]
  * @param max           Initializes [Slider.max]
  * @param step          Initializes [Slider.stepSize]
@@ -41,7 +41,7 @@ class UncivSlider (
     step: Float,
     vertical: Boolean = false,
     plusMinus: Boolean = true,
-    initial: Float = min,
+    initial: Float,
     sound: UncivSound = UncivSound.Slider,
     private val getTipText: ((Float) -> String)? = null,
     onChange: ((Float) -> Unit)? = null
@@ -112,7 +112,7 @@ class UncivSlider (
         slider.setSnapToValues(values, threshold)
     }
 
-    // java format string for the value tip, set by changing stepSize 
+    // java format string for the value tip, set by changing stepSize
     private var tipFormat = "%.1f"
 
     /** Prevents hiding the value tooltip over the slider knob */
@@ -139,9 +139,9 @@ class UncivSlider (
             minusButton.onClick {
                 addToValue(-stepSize)
             }
-            add(minusButton).apply { 
+            add(minusButton).apply {
                 if (vertical) padBottom(padding) else padLeft(padding)
-            } 
+            }
             if (vertical) row()
         } else minusButton = null
 
@@ -161,7 +161,7 @@ class UncivSlider (
         } else plusButton = null
 
         row()
-        value = initial  // set initial value late so the tooltip can work with the layout 
+        value = initial  // set initial value late so the tooltip can work with the layout
 
         // Add the listener late so the setting of the initial value is silent
         slider.addListener(object : ChangeListener() {


### PR DESCRIPTION
Fixes #6927

First commit adds the initial values for the sliders in:
-NewGameScreen: Game Options & Map Options>Advanced Settings
-MapEditor: This one was importing the advanced settings from above so that fixed both, turns out you didn't broke the rule too much, just for the brush @SomeTroglodyte :)

Second commit makes the initial value a mandatory parameter for the slider to avoid having the same issue in the future in case we use the slider again in some other menus.