### PR TITLE
added optional on-screen buttons to zoom in and out

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -651,6 +651,7 @@ Show pixel units =
 Show pixel improvements = 
 Enable Nuclear Weapons = 
 Experimental Demographics scoreboard = 
+Show zoom buttons in world screen = 
 Show tile yields = 
 Show unit movement arrows = 
 Continuous rendering = 

--- a/core/src/com/unciv/models/metadata/GameSettings.kt
+++ b/core/src/com/unciv/models/metadata/GameSettings.kt
@@ -52,6 +52,7 @@ class GameSettings {
     var isFreshlyCreated = false
     var visualMods = HashSet<String>()
     var useDemographics: Boolean = false
+    var showZoomButtons: Boolean = false
 
 
     var multiplayerServer = Constants.dropboxMultiplayerServer

--- a/core/src/com/unciv/ui/options/DisplayTab.kt
+++ b/core/src/com/unciv/ui/options/DisplayTab.kt
@@ -34,6 +34,7 @@ fun displayTab(
     optionsPopup.addCheckbox(this, "Show pixel units", settings.showPixelUnits, true) { settings.showPixelUnits = it }
     optionsPopup.addCheckbox(this, "Show pixel improvements", settings.showPixelImprovements, true) { settings.showPixelImprovements = it }
     optionsPopup.addCheckbox(this, "Experimental Demographics scoreboard", settings.useDemographics, true) { settings.useDemographics = it }
+    optionsPopup.addCheckbox(this, "Show zoom buttons in world screen", settings.showZoomButtons, true) { settings.showZoomButtons = it }
 
     addMinimapSizeSlider(this, settings, optionsPopup.screen, optionsPopup.selectBoxMinWidth)
 

--- a/core/src/com/unciv/ui/worldscreen/minimap/MinimapHolder.kt
+++ b/core/src/com/unciv/ui/worldscreen/minimap/MinimapHolder.kt
@@ -7,6 +7,8 @@ import com.badlogic.gdx.utils.Align
 import com.unciv.UncivGame
 import com.unciv.logic.civilization.CivilizationInfo
 import com.unciv.ui.images.ImageGetter
+import com.unciv.ui.utils.onClick
+import com.unciv.ui.utils.toTextButton
 import com.unciv.ui.worldscreen.WorldMapHolder
 
 class MinimapHolder(val mapHolder: WorldMapHolder) : Table() {
@@ -52,10 +54,30 @@ class MinimapHolder(val mapHolder: WorldMapHolder) : Table() {
         minimapSize = newMinimapSize
         this.clear()
         minimap = Minimap(mapHolder, minimapSize)
+        if (UncivGame.Current.settings.showZoomButtons) {
+            add(getZoomButtons()).align(Align.bottom)
+        }
         add(getToggleIcons()).align(Align.bottom)
         add(getWrappedMinimap())
         pack()
         if (stage != null) x = stage.width - width
+    }
+
+    private fun getZoomButtons(): Table {
+        val zoomInButton = "+".toTextButton()
+        zoomInButton.label.setFontScale(1.3f,1.3f)
+        zoomInButton.labelCell.padTop(15f)
+        zoomInButton.onClick { mapHolder.zoomIn() }
+
+        val zoomOutButton = "-".toTextButton()
+        zoomOutButton.label.setFontScale(1.3f,1.3f)
+        zoomOutButton.labelCell.padTop(2f)
+        zoomOutButton.onClick { mapHolder.zoomOut() }
+
+        val zoomButtonsTable = Table()
+        zoomButtonsTable.add(zoomInButton).size(60f).padBottom(10f).padRight(10f)
+        zoomButtonsTable.add(zoomOutButton).size(60f).padBottom(10f).padRight(10f)
+        return zoomButtonsTable
     }
 
     private fun getWrappedMinimap(): Table {


### PR DESCRIPTION
resolves #4480

Added an option in the display tab of Options (by default off) to show buttons for zooming in and out

![zoomButtons](https://user-images.githubusercontent.com/21990802/170047426-6ba894aa-7ae3-47d0-ae62-ce68a65bd6c1.png)

