### PR TITLE
ImageGetter.getDrawable a few ns faster

### DIFF
--- a/core/src/com/unciv/ui/images/ImageGetter.kt
+++ b/core/src/com/unciv/ui/images/ImageGetter.kt
@@ -170,8 +170,7 @@ object ImageGetter {
     }
 
     fun getDrawable(fileName: String?): TextureRegionDrawable {
-        return if (fileName != null && textureRegionDrawables.containsKey(fileName)) textureRegionDrawables[fileName]!!
-        else textureRegionDrawables[whiteDotLocation]!!
+        return textureRegionDrawables[fileName] ?: textureRegionDrawables[whiteDotLocation]!!
     }
 
     fun getRoundedEdgeRectangle(tintColor: Color? = null): NinePatchDrawable {

--- a/core/src/com/unciv/ui/utils/ExtensionFunctions.kt
+++ b/core/src/com/unciv/ui/utils/ExtensionFunctions.kt
@@ -57,13 +57,13 @@ fun Color.darken(t: Float): Color = Color(this).lerp(Color.BLACK, t)
  * The result is returned as a new instance. */
 fun Color.brighten(t: Float): Color = Color(this).lerp(Color.WHITE, t)
 
-fun Actor.centerX(parent: Actor){ x = parent.width/2 - width/2 }
-fun Actor.centerY(parent: Actor){ y = parent.height/2- height/2}
-fun Actor.center(parent: Actor){ centerX(parent); centerY(parent)}
+fun Actor.centerX(parent: Actor) { x = parent.width / 2 - width / 2 }
+fun Actor.centerY(parent: Actor) { y = parent.height / 2 - height / 2 }
+fun Actor.center(parent: Actor) { centerX(parent); centerY(parent) }
 
-fun Actor.centerX(parent: Stage){ x = parent.width/2 - width/2 }
-fun Actor.centerY(parent: Stage){ y = parent.height/2- height/2}
-fun Actor.center(parent: Stage){ centerX(parent); centerY(parent)}
+fun Actor.centerX(parent: Stage) { x = parent.width / 2 - width / 2 }
+fun Actor.centerY(parent: Stage) { y = parent.height / 2 - height / 2 }
+fun Actor.center(parent: Stage) { centerX(parent); centerY(parent) }
 
 /** same as [onClick], but sends the [InputEvent] and coordinates along */
 fun Actor.onClickEvent(sound: UncivSound = UncivSound.Click, function: (event: InputEvent?, x: Float, y: Float) -> Unit) {


### PR DESCRIPTION
Simply - why call HashMap.getNode twice when once would do?

Note: Of the ~160 uses of getDrawable / getImage only _one_ needs nullability of the fileName parameter - ImageAttempter, and only in its last fallback. Might be nicer to remove two `?` and give ImageAttempter an Elvis to ""?