### PR TITLE
land melee units can no longer attack water units, unless they have Optics tech

### DIFF
--- a/core/src/com/unciv/logic/automation/BattleHelper.kt
+++ b/core/src/com/unciv/logic/automation/BattleHelper.kt
@@ -104,9 +104,17 @@ object BattleHelper {
 
         //don't let non-embarked melee units attack water units, unless they have Optics tech
         if (combatant is MapUnitCombatant && combatant.unit.baseUnit.unitType.contains("Water") &&
-            combatant.unit.baseUnit.isMelee() && !combatant.unit.civInfo.hasUnique(UniqueType.LandUnitEmbarkation) &&
-            tileCombatant is MapUnitCombatant && tileCombatant.unit.baseUnit.unitType.contains("Water"))
+            combatant.unit.baseUnit.isMelee() && !combatant.unit.civInfo.hasUnique(UniqueType.LandUnitEmbarkation)){
+                if (tileCombatant is MapUnitCombatant && tileCombatant.unit.baseUnit.unitType.contains("Water")) {
+                    return false
+                }
+        }
+
+        if (combatant is MapUnitCombatant && combatant.unit.isEmbarked()) {
+            if (tileCombatant is MapUnitCombatant && tile.isWater) {
                 return false
+            }
+        }
 
         if (combatant is MapUnitCombatant &&
             combatant.unit.hasUnique(UniqueType.CanOnlyAttackUnits) &&

--- a/core/src/com/unciv/logic/automation/BattleHelper.kt
+++ b/core/src/com/unciv/logic/automation/BattleHelper.kt
@@ -102,8 +102,9 @@ object BattleHelper {
         if (tileCombatant.getCivInfo() == combatant.getCivInfo()) return false
         if (!combatant.getCivInfo().isAtWarWith(tileCombatant.getCivInfo())) return false
 
-        //don't let non-embarked melee units attack water units
-        if (combatant is MapUnitCombatant && !combatant.unit.baseUnit.unitType.contains("Water") && combatant.unit.baseUnit.isMelee() && !combatant.unit.isEmbarked() &&
+        //don't let non-embarked melee units attack water units, unless they have Optics tech
+        if (combatant is MapUnitCombatant && !combatant.unit.baseUnit.unitType.contains("Water") &&
+            combatant.unit.baseUnit.isMelee() && !combatant.unit.isEmbarked() && !combatant.getCivInfo().hasTechOrPolicy("Optics") &&
             tileCombatant is MapUnitCombatant && tileCombatant.unit.baseUnit.unitType.contains("Water"))
                 return false
 

--- a/core/src/com/unciv/logic/automation/BattleHelper.kt
+++ b/core/src/com/unciv/logic/automation/BattleHelper.kt
@@ -103,8 +103,8 @@ object BattleHelper {
         if (!combatant.getCivInfo().isAtWarWith(tileCombatant.getCivInfo())) return false
 
         //don't let non-embarked melee units attack water units, unless they have Optics tech
-        if (combatant is MapUnitCombatant && !combatant.unit.baseUnit.unitType.contains("Water") &&
-            combatant.unit.baseUnit.isMelee() && !combatant.unit.isEmbarked() && !combatant.getCivInfo().hasTechOrPolicy("Optics") &&
+        if (combatant is MapUnitCombatant && combatant.unit.baseUnit.isMelee() &&
+            !combatant.unit.civInfo.hasUnique(UniqueType.LandUnitEmbarkation) &&
             tileCombatant is MapUnitCombatant && tileCombatant.unit.baseUnit.unitType.contains("Water"))
                 return false
 

--- a/core/src/com/unciv/logic/automation/BattleHelper.kt
+++ b/core/src/com/unciv/logic/automation/BattleHelper.kt
@@ -103,8 +103,8 @@ object BattleHelper {
         if (!combatant.getCivInfo().isAtWarWith(tileCombatant.getCivInfo())) return false
 
         //don't let non-embarked melee units attack water units, unless they have Optics tech
-        if (combatant is MapUnitCombatant && combatant.unit.baseUnit.isMelee() &&
-            !combatant.unit.civInfo.hasUnique(UniqueType.LandUnitEmbarkation) &&
+        if (combatant is MapUnitCombatant && combatant.unit.baseUnit.unitType.contains("Water") &&
+            combatant.unit.baseUnit.isMelee() && !combatant.unit.civInfo.hasUnique(UniqueType.LandUnitEmbarkation) &&
             tileCombatant is MapUnitCombatant && tileCombatant.unit.baseUnit.unitType.contains("Water"))
                 return false
 

--- a/core/src/com/unciv/logic/automation/BattleHelper.kt
+++ b/core/src/com/unciv/logic/automation/BattleHelper.kt
@@ -102,6 +102,12 @@ object BattleHelper {
         if (tileCombatant.getCivInfo() == combatant.getCivInfo()) return false
         if (!combatant.getCivInfo().isAtWarWith(tileCombatant.getCivInfo())) return false
 
+        //don't let melee units attack water units
+        if (combatant is MapUnitCombatant && (!combatant.unit.baseUnit.unitType.contains("Water") && combatant.unit.baseUnit.isRanged())
+            && tileCombatant is MapUnitCombatant && tileCombatant.unit.baseUnit.unitType.contains("Water")) {
+                return false
+        }
+
         if (combatant is MapUnitCombatant &&
             combatant.unit.hasUnique(UniqueType.CanOnlyAttackUnits) &&
             combatant.unit.getMatchingUniques(UniqueType.CanOnlyAttackUnits).none { tileCombatant.matchesCategory(it.params[0]) }

--- a/core/src/com/unciv/logic/automation/BattleHelper.kt
+++ b/core/src/com/unciv/logic/automation/BattleHelper.kt
@@ -110,12 +110,6 @@ object BattleHelper {
                 }
         }
 
-        if (combatant is MapUnitCombatant && combatant.unit.isEmbarked()) {
-            if (tileCombatant is MapUnitCombatant && tile.isWater) {
-                return false
-            }
-        }
-
         if (combatant is MapUnitCombatant &&
             combatant.unit.hasUnique(UniqueType.CanOnlyAttackUnits) &&
             combatant.unit.getMatchingUniques(UniqueType.CanOnlyAttackUnits).none { tileCombatant.matchesCategory(it.params[0]) }

--- a/core/src/com/unciv/logic/automation/BattleHelper.kt
+++ b/core/src/com/unciv/logic/automation/BattleHelper.kt
@@ -102,11 +102,10 @@ object BattleHelper {
         if (tileCombatant.getCivInfo() == combatant.getCivInfo()) return false
         if (!combatant.getCivInfo().isAtWarWith(tileCombatant.getCivInfo())) return false
 
-        //don't let melee units attack water units
-        if (combatant is MapUnitCombatant && (!combatant.unit.baseUnit.unitType.contains("Water") && combatant.unit.baseUnit.isRanged())
-            && tileCombatant is MapUnitCombatant && tileCombatant.unit.baseUnit.unitType.contains("Water")) {
+        //don't let non-embarked melee units attack water units
+        if (combatant is MapUnitCombatant && !combatant.unit.baseUnit.unitType.contains("Water") && combatant.unit.baseUnit.isMelee() && !combatant.unit.isEmbarked() &&
+            tileCombatant is MapUnitCombatant && tileCombatant.unit.baseUnit.unitType.contains("Water"))
                 return false
-        }
 
         if (combatant is MapUnitCombatant &&
             combatant.unit.hasUnique(UniqueType.CanOnlyAttackUnits) &&


### PR DESCRIPTION
resolves #6948

before attacking a water unit, the attacker needs to have 'Optics' tech unlocked (gives access to embarking)

