### PR TITLE
land melee units can't attack naval units, unless Optics is researched 

### DIFF
--- a/core/src/com/unciv/logic/automation/BattleHelper.kt
+++ b/core/src/com/unciv/logic/automation/BattleHelper.kt
@@ -102,6 +102,13 @@ object BattleHelper {
         if (tileCombatant.getCivInfo() == combatant.getCivInfo()) return false
         if (!combatant.getCivInfo().isAtWarWith(tileCombatant.getCivInfo())) return false
 
+        if (combatant is MapUnitCombatant && combatant.unit.baseUnit.unitType.contains("Water") &&
+                combatant.unit.baseUnit.isMelee() && !combatant.unit.civInfo.hasUnique(UniqueType.LandUnitEmbarkation)){
+            if (tileCombatant is MapUnitCombatant && tileCombatant.unit.baseUnit.unitType.contains("Water")) {
+                return false
+            }
+        }
+
         if (combatant is MapUnitCombatant &&
             combatant.unit.hasUnique(UniqueType.CanOnlyAttackUnits) &&
             combatant.unit.getMatchingUniques(UniqueType.CanOnlyAttackUnits).none { tileCombatant.matchesCategory(it.params[0]) }


### PR DESCRIPTION
resolves #6948 

before attacking a water unit, the attacker needs to have 'Optics' tech unlocked (gives access to embarking)

I redid the PR to remove the unnecessary commits 