### PR TITLE
Fix piety complete faith discount

### DIFF
--- a/android/assets/jsons/Civ V - Gods & Kings/Policies.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Policies.json
@@ -264,7 +264,7 @@
             {
                 "name": "Piety Complete",
                 "uniques": [
-                    "[Faith] cost of purchasing items in cities [-20]% ",
+                    "[Faith] cost of purchasing items in cities [-20]%",
                     "[+3 Gold, +3 Culture] from every [Holy site]"
                 ]
             }


### PR DESCRIPTION
Fixes a bug mentioned in the discord by Vsynk and Ravignir where there was an extra space in the bonus string for completing the piety policy tree.