### PR TITLE
More UniqueType unit tests and correct some beliefs

### DIFF
--- a/android/assets/jsons/Civ V - Gods & Kings/Beliefs.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Beliefs.json
@@ -24,8 +24,8 @@
     {
         "name": "Fertility Rites",
         "type": "Pantheon",
-        "uniques": ["[+10]% growth [in this city]"] 
-        // Preferably I would not have a cityFilter here, but doing so requires no additional implementation 
+        "uniques": ["[+10]% growth [in this city]"]
+        // Preferably I would not have a cityFilter here, but doing so requires no additional implementation
     },
     {
         "name": "God of Craftsman",
@@ -201,7 +201,7 @@
         "uniques": ["[+15]% growth [in this city] <when not at war>"]
     },
 ///////////////////////////////////////// Founder beliefs //////////////////////////////////////////
-    
+
     {
         "name": "Ceremonial Burial",
         "type": "Founder",
@@ -230,7 +230,7 @@
     {
         "name": "Peace Loving",
         "type": "Founder",
-        "uniques": ["[+1 Happiness] for every [5] global followers [in non-enemy foreign cities]"]
+        "uniques": ["[+1 Happiness] from every [5] global followers [in non-enemy foreign cities]"]
     },
     {
         "name": "Pilgrimage",
@@ -240,12 +240,12 @@
     {
         "name": "Tithe",
         "type": "Founder",
-        "uniques": ["[+1 Gold] for every [4] global followers [in all cities]"]
+        "uniques": ["[+1 Gold] from every [4] global followers [in all cities]"]
     },
     {
         "name": "World Church",
         "type": "Founder",
-        "uniques": ["[+1 Culture] for every [5] global followers [in foreign cities]"]
+        "uniques": ["[+1 Culture] from every [5] global followers [in foreign cities]"]
     },
 
     ////////////////////////////////////// Enhancer beliefs ///////////////////////////////////////
@@ -275,7 +275,7 @@
     {
         "name": "Messiah",
         "type": "Enhancer",
-        "uniques": ["[+25]% Spread Religion Strength <for [Great Prophet] units>", "[-25]% Faith cost of generating Great Prophet equivalents", "[Faith] cost for [Great Prophet] units [-25]%"]
+        "uniques": ["[+25]% Spread Religion Strength <for [Great Prophet] units>", "[-25]% Faith cost of generating Great Prophet equivalents"]
     },
     {
         "name": "Missionary Zeal",

--- a/android/assets/jsons/Civ V - Gods & Kings/Policies.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Policies.json
@@ -264,7 +264,7 @@
             {
                 "name": "Piety Complete",
                 "uniques": [
-                    "[Faith] cost of purchasing items in cities [-20]% ",
+                    "[Faith] cost of purchasing items in cities [-20]%",
                     "[+3 Gold, +3 Culture] from every [Holy site]"
                 ]
             }

--- a/android/assets/jsons/Civ V - Vanilla/Policies.json
+++ b/android/assets/jsons/Civ V - Vanilla/Policies.json
@@ -654,7 +654,7 @@
                 "requires": ["Socialism"],
                 "uniques": [
                     "[+1 Production] [in all cities]",
-                    "[+10]% [Production] when constructing [All] buildings [in all cities]",
+                    "[+10]% Production when constructing [All] buildings [in all cities]",
                     "[+1 Production] from every [Quarry]"
                 ],
                 "row": 3,

--- a/core/src/com/unciv/logic/civilization/PolicyManager.kt
+++ b/core/src/com/unciv/logic/civilization/PolicyManager.kt
@@ -110,7 +110,7 @@ class PolicyManager {
             // Should be deprecated together with TimedAttackStrength so
             // I'm putting this here so the compiler will complain if we don't
             val rememberToDeprecate = UniqueType.TimedAttackStrength
-            if (!unique.text.contains(turnCountRegex)) 
+            if (!unique.text.contains(turnCountRegex))
                 policyUniques.addUnique(unique)
         }
     }
@@ -206,9 +206,9 @@ class PolicyManager {
             }
         }
 
-        for (unique in policy.uniques) {
-            if (unique.equalsPlaceholderText("Triggers the following global alert: []")) triggerGlobalAlerts(
-                policy, unique.getPlaceholderParameters()[0]
+        for (unique in policy.getMatchingUniques(UniqueType.OneTimeGlobalAlert)) {
+            triggerGlobalAlerts(
+                policy, unique.params[0]
             )
         }
 

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -155,7 +155,7 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
 
     GrowthPercentBonus("[relativeAmount]% growth [cityFilter]", UniqueTarget.Global, UniqueTarget.FollowerBelief),
     CarryOverFood("[relativeAmount]% Food is carried over after population increases [cityFilter]", UniqueTarget.Global, UniqueTarget.FollowerBelief),
-    
+
     GainFreeBuildings("Gain a free [buildingName] [cityFilter]", UniqueTarget.Global),
     GreatPersonPointPercentage("[relativeAmount]% Great Person generation [cityFilter]", UniqueTarget.Global, UniqueTarget.FollowerBelief),
     @Deprecated("As of 3.19.19", ReplaceWith("[relativeAmount]% Great Person generation [cityFilter]"))
@@ -197,7 +197,7 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
     BuyItemsDiscount("[stat] cost of purchasing items in cities [relativeAmount]%", UniqueTarget.Global, UniqueTarget.FollowerBelief),
     BuyBuildingsDiscount("[stat] cost of purchasing [buildingFilter] buildings [relativeAmount]%", UniqueTarget.Global, UniqueTarget.FollowerBelief),
     BuyUnitsDiscount("[stat] cost of purchasing [baseUnitFilter] units [relativeAmount]%", UniqueTarget.Global, UniqueTarget.FollowerBelief),
-    
+
     // Should be replaced with moddable improvements when roads become moddable
     RoadMovementSpeed("Improves movement speed on roads",UniqueTarget.Global),
     RoadsConnectAcrossRivers("Roads connect tiles across rivers", UniqueTarget.Global),
@@ -278,7 +278,7 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
     GoldenAgeLength("[relativeAmount]% Golden Age length", UniqueTarget.Global),
 
     StrengthForCities("[relativeAmount]% Strength for cities", UniqueTarget.Global, UniqueTarget.FollowerBelief),
-    
+
     UnitStartingExperience("New [baseUnitFilter] units start with [amount] Experience [cityFilter]", UniqueTarget.Global, UniqueTarget.FollowerBelief),
     UnitStartingPromotions("All newly-trained [baseUnitFilter] units [cityFilter] receive the [promotion] promotion", UniqueTarget.Global, UniqueTarget.FollowerBelief),
     UnitStartingActions("[baseUnitFilter] units built [cityFilter] can [action] [amount] extra times", UniqueTarget.Global, UniqueTarget.FollowerBelief),
@@ -291,7 +291,7 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
     EmbarkAndEnterOcean("Can embark and move over Coasts and Oceans immediately", UniqueTarget.Global),
 
     PopulationLossFromNukes("Population loss from nuclear attacks [relativeAmount]% [cityFilter]", UniqueTarget.Global),
-  
+
     NaturalReligionSpreadStrength("[relativeAmount]% Natural religion spread [cityFilter]", UniqueTarget.FollowerBelief, UniqueTarget.Global),
     ReligionSpreadDistance("Religion naturally spreads to cities [amount] tiles away", UniqueTarget.Global, UniqueTarget.FollowerBelief),
 
@@ -731,6 +731,7 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
     OneTimeRevealSpecificMapTiles("Reveal up to [amount/'all'] [tileFilter] within a [amount] tile radius", UniqueTarget.Ruins),
     OneTimeRevealCrudeMap("From a randomly chosen tile [amount] tiles away from the ruins, reveal tiles up to [amount] tiles away with [amount]% chance", UniqueTarget.Ruins),
     OneTimeTriggerVoting("Triggers voting for the Diplomatic Victory", UniqueTarget.Triggerable),  // used in Building
+    OneTimeGlobalAlert("Triggers the following global alert: [comment]", UniqueTarget.Triggerable), // used in Policy
 
     OneTimeUnitHeal("Heal this unit by [amount] HP", UniqueTarget.Promotion),
     OneTimeUnitGainXP("This Unit gains [amount] XP", UniqueTarget.Ruins),
@@ -765,7 +766,7 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
     BonusForUnitsInRadius("Bonus for units in 2 tile radius 15%", UniqueTarget.Unit),
     @Deprecated("as of 4.0.15", ReplaceWith("Irremovable"), DeprecationLevel.ERROR)
     Indestructible("Indestructible", UniqueTarget.Improvement),
-    
+
     @Deprecated("as of 3.19.1", ReplaceWith("[stats] from every [Wonder]"), DeprecationLevel.ERROR)
     StatsFromWondersDeprecated("[stats] from every Wonder", UniqueTarget.Global, UniqueTarget.FollowerBelief),
     @Deprecated("as of 3.19.3", ReplaceWith("[stats] from every [buildingFilter] <in cities where this religion has at least [amount] followers>"), DeprecationLevel.ERROR)

--- a/tests/src/com/unciv/testing/BasicTests.kt
+++ b/tests/src/com/unciv/testing/BasicTests.kt
@@ -2,6 +2,7 @@
 package com.unciv.testing
 
 import com.badlogic.gdx.Gdx
+import com.badlogic.gdx.utils.compression.lzma.Base
 import com.unciv.Constants
 import com.unciv.UncivGame
 import com.unciv.UncivGameParameters
@@ -208,6 +209,22 @@ class BasicTests {
             for (unique in policyBranch.uniques) {
                 if (!UniqueType.values().any { it.placeholderText == unique.getPlaceholderText() }) {
                     println("${policyBranch.name}: $unique")
+                    allOK = false
+                }
+            }
+        }
+        Assert.assertTrue("This test succeeds only if all policy and policy branch uniques are presented in UniqueType.values()", allOK)
+    }
+
+    @Test
+    fun allBeliefRelatedUniquesHaveTheirUniqueTypes() {
+        val ruleset = RulesetCache[BaseRuleset.Civ_V_GnK.fullName]!!.clone() // vanilla doesn't have beliefs
+        val beliefs = ruleset.beliefs.values
+        var allOK = true
+        for (belief in beliefs) {
+            for (unique in belief.uniques) {
+                if (!UniqueType.values().any { it.placeholderText == unique.getPlaceholderText() }) {
+                    println("${belief.name}: $unique")
                     allOK = false
                 }
             }

--- a/tests/src/com/unciv/testing/BasicTests.kt
+++ b/tests/src/com/unciv/testing/BasicTests.kt
@@ -2,7 +2,6 @@
 package com.unciv.testing
 
 import com.badlogic.gdx.Gdx
-import com.badlogic.gdx.utils.compression.lzma.Base
 import com.unciv.Constants
 import com.unciv.UncivGame
 import com.unciv.UncivGameParameters

--- a/tests/src/com/unciv/testing/BasicTests.kt
+++ b/tests/src/com/unciv/testing/BasicTests.kt
@@ -191,13 +191,38 @@ class BasicTests {
     }
 
     @Test
+    fun allPolicyRelatedUniquesHaveTheirUniqueTypes() {
+        val policies = ruleset.policies.values
+        val policyBranches = ruleset.policyBranches.values
+        var allOK = true
+        for (policy in policies) {
+            for (unique in policy.uniques) {
+                if (!UniqueType.values().any { it.placeholderText == unique.getPlaceholderText() }) {
+                    println("${policy.name}: $unique")
+                    allOK = false
+                }
+            }
+        }
+
+        for (policyBranch in policyBranches) {
+            for (unique in policyBranch.uniques) {
+                if (!UniqueType.values().any { it.placeholderText == unique.getPlaceholderText() }) {
+                    println("${policyBranch.name}: $unique")
+                    allOK = false
+                }
+            }
+        }
+        Assert.assertTrue("This test succeeds only if all policy and policy branch uniques are presented in UniqueType.values()", allOK)
+    }
+
+    @Test
     fun allDeprecatedUniqueTypesHaveReplacewithThatMatchesOtherType() {
         var allOK = true
         for (uniqueType in UniqueType.values()) {
             val deprecationAnnotation = uniqueType.getDeprecationAnnotation() ?: continue
-            
+
             val uniquesToCheck = deprecationAnnotation.replaceWith.expression.split("\", \"", Constants.uniqueOrDelimiter)
-            
+
             for (uniqueText in uniquesToCheck) {
                 val replacementTextUnique = Unique(uniqueText)
 


### PR DESCRIPTION
Implements ```UniqueType.OneTimeGlobalAlert ("Triggers the following global alert: [comment]")``` unique type, mainly to move a hardcoded unique type into ```UniqueTypes.kt```. I'm definitely open to changing the ```UniqueType``` implementations.

This also fixes 3 beliefs by using the correct ```UniqueType``` and also removes an unused one from another belief.

Accordingly, more unit tests to check in the following areas
* Policies
* Policy branches
* Beliefs

These checks are applied to the Vanilla and G&K rulesets to correct for any mistakes. These sort of unit tests would have caught the typo corrected in #6961.