### PR TITLE
Make Locked Tiles Clickable on entry to CityScreen

### DIFF
--- a/core/src/com/unciv/ui/cityscreen/CityTileGroup.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityTileGroup.kt
@@ -61,6 +61,7 @@ class CityTileGroup(private val city: CityInfo, tileInfo: TileInfo, tileSetStrin
 
             tileInfo.isLocked() -> {
                 icons.addPopulationIcon(ImageGetter.getImage("OtherIcons/Lock"))
+                isWorkable = true
             }
 
             tileInfo.isWorked() || !tileInfo.providesYield() -> { // workable


### PR DESCRIPTION
Fixes #6963