### PR TITLE
Citizen Management as Expandable Tab

### DIFF
--- a/core/src/com/unciv/ui/cityscreen/CitizenManagementTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/CitizenManagementTable.kt
@@ -3,28 +3,16 @@ package com.unciv.ui.cityscreen
 import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.scenes.scene2d.Touchable
 import com.badlogic.gdx.scenes.scene2d.ui.Table
+import com.unciv.Constants
 import com.unciv.logic.city.CityFocus
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.utils.*
 
-class CitizenManagementTable(val cityScreen: CityScreen) : Table() {
-    private val innerTable = Table()
+class CitizenManagementTable(val cityScreen: CityScreen) : Table(BaseScreen.skin) {
     val city = cityScreen.city
 
-    init {
-        innerTable.background = ImageGetter.getBackground(ImageGetter.getBlue().darken(0.5f))
-        add(innerTable).pad(2f).fill()
-        background = ImageGetter.getBackground(Color.WHITE)
-    }
-
-    fun update(visible: Boolean = false) {
-        innerTable.clear()
-
-        if (!visible) {
-            isVisible = false
-            return
-        }
-        isVisible = true
+    fun update() {
+        clear()
 
         val colorSelected = BaseScreen.skin.get("selection", Color::class.java)
         val colorButton = BaseScreen.skin.get("color", Color::class.java)
@@ -32,33 +20,50 @@ class CitizenManagementTable(val cityScreen: CityScreen) : Table() {
         // and much more compact and can control backgrounds easily based on settings
         val avoidLabel = "Avoid Growth".toLabel()
         val avoidCell = Table()
-        avoidCell.touchable = Touchable.enabled
         avoidCell.add(avoidLabel).pad(5f)
-        if (cityScreen.canChangeState)
+        if (cityScreen.canChangeState){
+            avoidCell.touchable = Touchable.enabled
             avoidCell.onClick { city.avoidGrowth = !city.avoidGrowth; city.reassignPopulation(); cityScreen.update() }
+        }
 
         avoidCell.background = ImageGetter.getBackground(if (city.avoidGrowth) colorSelected else colorButton)
-        innerTable.add(avoidCell).colspan(2).growX().pad(3f)
-        innerTable.row()
+        add(avoidCell).colspan(2).growX().pad(3f)
+        row()
 
+        var newRow = false
         for (focus in CityFocus.values()) {
             if (!focus.tableEnabled) continue
             if (focus == CityFocus.FaithFocus && !city.civInfo.gameInfo.isReligionEnabled()) continue
             val label = focus.label.toLabel()
             val cell = Table()
-            cell.touchable = Touchable.enabled
             cell.add(label).pad(5f)
-            if (cityScreen.canChangeState)
-                cell.onClick { city.cityAIFocus = focus; city.reassignPopulation(); cityScreen.update() }
-
+            if (cityScreen.canChangeState) {
+                cell.touchable = Touchable.enabled
+                cell.onClick {
+                    city.cityAIFocus = focus; city.reassignPopulation(); cityScreen.update()
+                }
+            }
             cell.background = ImageGetter.getBackground(if (city.cityAIFocus == focus) colorSelected else colorButton)
-            innerTable.add(cell).growX().pad(3f)
-            if (focus.stat != null)
-                innerTable.add(ImageGetter.getStatIcon(focus.stat.name)).size(20f).padRight(5f)
-            innerTable.row()
+            add(cell).growX().pad(3f)
+            if (newRow)  // every 2 make new row
+                row()
+            newRow = !newRow
         }
 
         pack()
+    }
+
+    fun asExpander(onChange: (() -> Unit)?): ExpanderTab {
+        return ExpanderTab(
+            title = "{Citizen Management}",
+            fontSize = Constants.defaultFontSize,
+            persistenceID = "CityStatsTable.CitizenManagement",
+            startsOutOpened = false,
+            onChange = onChange
+        ) {
+            it.add(this)
+            update()
+        }
     }
 
 }

--- a/core/src/com/unciv/ui/cityscreen/CitizenManagementTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/CitizenManagementTable.kt
@@ -18,6 +18,17 @@ class CitizenManagementTable(val cityScreen: CityScreen) : Table(BaseScreen.skin
         val colorButton = BaseScreen.skin.get("color", Color::class.java)
         // effectively a button, but didn't want to rewrite TextButton style
         // and much more compact and can control backgrounds easily based on settings
+        val resetLabel = "Reset Citizens".toLabel()
+        val resetCell = Table()
+        resetCell.add(resetLabel).pad(5f)
+        if (cityScreen.canChangeState){
+            resetCell.touchable = Touchable.enabled
+            resetCell.onClick { city.reassignPopulation(true); cityScreen.update() }
+        }
+        resetCell.background = ImageGetter.getBackground(colorButton)
+        add(resetCell).colspan(2).growX().pad(3f)
+        row()
+
         val avoidLabel = "Avoid Growth".toLabel()
         val avoidCell = Table()
         avoidCell.add(avoidLabel).pad(5f)
@@ -25,7 +36,6 @@ class CitizenManagementTable(val cityScreen: CityScreen) : Table(BaseScreen.skin
             avoidCell.touchable = Touchable.enabled
             avoidCell.onClick { city.avoidGrowth = !city.avoidGrowth; city.reassignPopulation(); cityScreen.update() }
         }
-
         avoidCell.background = ImageGetter.getBackground(if (city.avoidGrowth) colorSelected else colorButton)
         add(avoidCell).colspan(2).growX().pad(3f)
         row()

--- a/core/src/com/unciv/ui/cityscreen/CitizenManagementTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/CitizenManagementTable.kt
@@ -21,7 +21,7 @@ class CitizenManagementTable(val cityScreen: CityScreen) : Table(BaseScreen.skin
         val resetLabel = "Reset Citizens".toLabel()
         val resetCell = Table()
         resetCell.add(resetLabel).pad(5f)
-        if (cityScreen.canChangeState){
+        if (cityScreen.canChangeState) {
             resetCell.touchable = Touchable.enabled
             resetCell.onClick { city.reassignPopulation(true); cityScreen.update() }
         }
@@ -32,7 +32,7 @@ class CitizenManagementTable(val cityScreen: CityScreen) : Table(BaseScreen.skin
         val avoidLabel = "Avoid Growth".toLabel()
         val avoidCell = Table()
         avoidCell.add(avoidLabel).pad(5f)
-        if (cityScreen.canChangeState){
+        if (cityScreen.canChangeState) {
             avoidCell.touchable = Touchable.enabled
             avoidCell.onClick { city.avoidGrowth = !city.avoidGrowth; city.reassignPopulation(); cityScreen.update() }
         }

--- a/core/src/com/unciv/ui/cityscreen/CityScreen.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityScreen.kt
@@ -55,9 +55,6 @@ class CityScreen(
     /** Displays raze city button - sits on TOP CENTER */
     private var razeCityButtonHolder = Table()
 
-    /** Displays reset locks button - sits on BOT RIGHT */
-    private var resetCitizensButtonHolder = Table()
-
     /** Displays city stats info */
     private var cityStatsTable = CityStatsTable(this)
 
@@ -111,13 +108,6 @@ class CityScreen(
 
         //stage.setDebugTableUnderMouse(true)
         stage.addActor(cityStatsTable)
-        val resetCitizensButton = "Reset Citizens".toTextButton()
-        resetCitizensButton.labelCell.pad(5f)
-        resetCitizensButton.onClick { city.reassignPopulation(resetLocked = true); update() }
-        resetCitizensButtonHolder.add(resetCitizensButton)
-        resetCitizensButtonHolder.pack()
-        if (!canChangeState) resetCitizensButton.disable()
-        stage.addActor(resetCitizensButtonHolder)
         constructionsTable.addActorsToStage()
         stage.addActor(cityInfoTable)
         stage.addActor(selectedConstructionTable)
@@ -159,15 +149,6 @@ class CityScreen(
         tileTable.setPosition(stage.width - posFromEdge, posFromEdge, Align.bottomRight)
         selectedConstructionTable.update(selectedConstruction)
         selectedConstructionTable.setPosition(stage.width - posFromEdge, posFromEdge, Align.bottomRight)
-        if (selectedTile == null && selectedConstruction == null)
-            resetCitizensButtonHolder.setPosition(stage.width - posFromEdge,
-                    posFromEdge, Align.bottomRight)
-        else if (selectedConstruction != null)
-            resetCitizensButtonHolder.setPosition(stage.width - posFromEdge,
-                    posFromEdge + selectedConstructionTable.height + 10f, Align.bottomRight)
-        else
-            resetCitizensButtonHolder.setPosition(stage.width - posFromEdge,
-                    posFromEdge + tileTable.height + 10f, Align.bottomRight)
 
         // In portrait mode only: calculate already occupied horizontal space
         val rightMargin = when {

--- a/core/src/com/unciv/ui/cityscreen/CityScreen.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityScreen.kt
@@ -58,9 +58,6 @@ class CityScreen(
     /** Displays reset locks button - sits on BOT RIGHT */
     private var resetCitizensButtonHolder = Table()
 
-    /** Displays reset locks button - sits on BOT RIGHT */
-    private var citizenManagementButtonHolder = Table()
-
     /** Displays city stats info */
     private var cityStatsTable = CityStatsTable(this)
 
@@ -69,10 +66,6 @@ class CityScreen(
 
     /** Displays selected construction info, alternate with tileTable - sits on BOTTOM RIGHT */
     private var selectedConstructionTable = ConstructionInfoTable(this)
-
-    /** Displays selected construction info, alternate with tileTable - sits on BOTTOM RIGHT */
-    private var citizenManagementTable = CitizenManagementTable(this)
-    var citizenManagementVisible = false
 
     /** Displays city name, allows switching between cities - sits on BOTTOM CENTER */
     private var cityPickerTable = CityScreenCityPickerTable(this)
@@ -125,22 +118,10 @@ class CityScreen(
         resetCitizensButtonHolder.pack()
         if (!canChangeState) resetCitizensButton.disable()
         stage.addActor(resetCitizensButtonHolder)
-        val citizenManagementButton = "Citizen Management".toTextButton()
-        citizenManagementButton.labelCell.pad(5f)
-        citizenManagementButton.onClick {
-            clearSelection()
-            citizenManagementVisible = true
-            update()
-        }
-        if (!canChangeState) citizenManagementButton.disable()
-        citizenManagementButtonHolder.add(citizenManagementButton)
-        citizenManagementButtonHolder.pack()
-        stage.addActor(citizenManagementButtonHolder)
         constructionsTable.addActorsToStage()
         stage.addActor(cityInfoTable)
         stage.addActor(selectedConstructionTable)
         stage.addActor(tileTable)
-        stage.addActor(citizenManagementTable)
         stage.addActor(cityPickerTable)  // add late so it's top in Z-order and doesn't get covered in cramped portrait
         stage.addActor(exitCityButton)
         update()
@@ -178,23 +159,15 @@ class CityScreen(
         tileTable.setPosition(stage.width - posFromEdge, posFromEdge, Align.bottomRight)
         selectedConstructionTable.update(selectedConstruction)
         selectedConstructionTable.setPosition(stage.width - posFromEdge, posFromEdge, Align.bottomRight)
-        citizenManagementTable.update(citizenManagementVisible)
-        citizenManagementTable.setPosition(stage.width - posFromEdge, posFromEdge, Align.bottomRight)
-        if (selectedTile == null && selectedConstruction == null && !citizenManagementVisible)
+        if (selectedTile == null && selectedConstruction == null)
             resetCitizensButtonHolder.setPosition(stage.width - posFromEdge,
                     posFromEdge, Align.bottomRight)
         else if (selectedConstruction != null)
             resetCitizensButtonHolder.setPosition(stage.width - posFromEdge,
                     posFromEdge + selectedConstructionTable.height + 10f, Align.bottomRight)
-        else if (selectedTile != null)
-            resetCitizensButtonHolder.setPosition(stage.width - posFromEdge,
-                    posFromEdge + tileTable.height + 10f, Align.bottomRight)
         else
             resetCitizensButtonHolder.setPosition(stage.width - posFromEdge,
-                    posFromEdge + citizenManagementTable.height + 10f, Align.bottomRight)
-        citizenManagementButtonHolder.isVisible = !citizenManagementVisible
-        citizenManagementButtonHolder.setPosition(stage.width - posFromEdge,
-                posFromEdge + resetCitizensButtonHolder.y + resetCitizensButtonHolder.height + 10f, Align.bottomRight)
+                    posFromEdge + tileTable.height + 10f, Align.bottomRight)
 
         // In portrait mode only: calculate already occupied horizontal space
         val rightMargin = when {
@@ -413,13 +386,11 @@ class CityScreen(
             pickTileData = null
         }
         selectedTile = null
-        citizenManagementVisible = false
     }
     private fun selectTile(newTile: TileInfo?) {
         selectedConstruction = null
         selectedQueueEntryTargetTile = null
         pickTileData = null
-        citizenManagementVisible = false
         selectedTile = newTile
     }
     fun clearSelection() = selectTile(null)

--- a/core/src/com/unciv/ui/cityscreen/CityStatsTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityStatsTable.kt
@@ -2,7 +2,6 @@ package com.unciv.ui.cityscreen
 
 import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.scenes.scene2d.Actor
-import com.badlogic.gdx.scenes.scene2d.ui.Cell
 import com.badlogic.gdx.scenes.scene2d.ui.Label
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.utils.Align
@@ -16,7 +15,6 @@ import com.unciv.ui.civilopedia.CivilopediaScreen
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.utils.*
 import kotlin.math.ceil
-import kotlin.math.min
 import kotlin.math.round
 import com.unciv.ui.utils.AutoScrollPane as ScrollPane
 
@@ -33,11 +31,10 @@ class CityStatsTable(val cityScreen: CityScreen): Table() {
         innerTable.defaults().pad(2f)
         innerTable.background = ImageGetter.getBackground(Color.BLACK.cpy().apply { a = 0.8f })
 
-        //add(innerTable).fill()
         outerPane = ScrollPane(innerTable)
         outerPane.setOverscroll(false, false)
         outerPane.setScrollingDisabled(true, false)
-        add(outerPane).maxHeight(cityScreen.stage.height/2)
+        add(outerPane).maxHeight(cityScreen.stage.height / 2)
     }
 
     fun update() {
@@ -50,18 +47,20 @@ class CityStatsTable(val cityScreen: CityScreen): Table() {
             val icon = Table()
             if (cityInfo.cityAIFocus.stat == stat) {
                 icon.add(ImageGetter.getStatIcon(stat.name).surroundWithCircle(27f, false, color = selected))
-                if (cityScreen.canChangeState)
+                if (cityScreen.canChangeState) {
                     icon.onClick {
                         cityInfo.cityAIFocus = CityFocus.NoFocus
                         cityInfo.reassignPopulation(); cityScreen.update()
                     }
+                }
             } else {
                 icon.add(ImageGetter.getStatIcon(stat.name).surroundWithCircle(27f, false, color = Color.CLEAR))
-                if (cityScreen.canChangeState)
+                if (cityScreen.canChangeState) {
                     icon.onClick {
                         cityInfo.cityAIFocus = cityInfo.cityAIFocus.safeValueOf(stat)
                         cityInfo.reassignPopulation(); cityScreen.update()
                     }
+                }
             }
             miniStatsTable.add(icon).size(27f).padRight(5f)
             val valueToDisplay = if (stat == Stat.Happiness) cityInfo.cityStats.happinessList.values.sum() else amount
@@ -71,6 +70,7 @@ class CityStatsTable(val cityScreen: CityScreen): Table() {
 
         innerTable.addSeparator()
         addText()
+        addCitizenManagement()
         if (!cityInfo.population.getMaxSpecialists().isEmpty()) {
             addSpecialistInfo()
         }
@@ -141,6 +141,18 @@ class CityStatsTable(val cityScreen: CityScreen): Table() {
         }
 
         innerTable.add(tableWithIcons).row()
+    }
+
+    private fun addCitizenManagement() {
+        val expanderTab = CitizenManagementTable(cityScreen).asExpander {
+            pack()
+            setPosition(
+                stage.width - CityScreen.posFromEdge,
+                stage.height - CityScreen.posFromEdge,
+                Align.topRight
+            )
+        }
+        innerTable.add(expanderTab).growX().row()
     }
 
     private fun addSpecialistInfo() {

--- a/core/src/com/unciv/ui/cityscreen/CityStatsTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityStatsTable.kt
@@ -2,6 +2,7 @@ package com.unciv.ui.cityscreen
 
 import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.scenes.scene2d.Actor
+import com.badlogic.gdx.scenes.scene2d.ui.Cell
 import com.badlogic.gdx.scenes.scene2d.ui.Label
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.utils.Align
@@ -15,10 +16,13 @@ import com.unciv.ui.civilopedia.CivilopediaScreen
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.utils.*
 import kotlin.math.ceil
+import kotlin.math.min
 import kotlin.math.round
+import com.unciv.ui.utils.AutoScrollPane as ScrollPane
 
 class CityStatsTable(val cityScreen: CityScreen): Table() {
     private val innerTable = Table()
+    private val outerPane: ScrollPane
     private val cityInfo = cityScreen.city
 
     init {
@@ -29,7 +33,11 @@ class CityStatsTable(val cityScreen: CityScreen): Table() {
         innerTable.defaults().pad(2f)
         innerTable.background = ImageGetter.getBackground(Color.BLACK.cpy().apply { a = 0.8f })
 
-        add(innerTable).fill()
+        //add(innerTable).fill()
+        outerPane = ScrollPane(innerTable)
+        outerPane.setOverscroll(false, false)
+        outerPane.setScrollingDisabled(true, false)
+        add(outerPane).maxHeight(cityScreen.stage.height/2)
     }
 
     fun update() {
@@ -69,6 +77,9 @@ class CityStatsTable(val cityScreen: CityScreen): Table() {
         if (cityInfo.religion.getNumberOfFollowers().isNotEmpty() && cityInfo.civInfo.gameInfo.isReligionEnabled())
             addReligionInfo()
 
+        innerTable.pack()
+        outerPane.layout()
+        outerPane.updateVisualScroll()
         pack()
     }
 

--- a/core/src/com/unciv/ui/cityscreen/SpecialistAllocationTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/SpecialistAllocationTable.kt
@@ -18,7 +18,7 @@ class SpecialistAllocationTable(val cityScreen: CityScreen) : Table(BaseScreen.s
         // Auto/Manual Specialists Toggle
         // Color of "color" coming from Skin.json that's loaded into BaseScreen
         // 5 columns: unassignButton, AllocationTable, assignButton, SeparatorVertical, SpecialistsStatsTabe
-        if (cityScreen.canChangeState)
+        if (cityScreen.canChangeState) {
             if (cityInfo.manualSpecialists) {
                 val manualSpecialists = "Manual Specialists".toLabel()
                     .addBorder(5f, BaseScreen.skin.get("color", Color::class.java))
@@ -33,6 +33,7 @@ class SpecialistAllocationTable(val cityScreen: CityScreen) : Table(BaseScreen.s
                 autoSpecialists.onClick { cityInfo.manualSpecialists = true; update() }
                 add(autoSpecialists).colspan(5).row()
             }
+        }
         for ((specialistName, maxSpecialists) in cityInfo.population.getMaxSpecialists()) {
             if (!cityInfo.getRuleset().specialists.containsKey(specialistName)) // specialist doesn't exist in this ruleset, probably a mod
                 continue


### PR DESCRIPTION
Made StatsTable a ScrollPane and locked to only take up 50% height of screen
Removed old buttons, now compacted into table
![image](https://user-images.githubusercontent.com/44038014/170645005-81871bcf-b4cb-4f22-83dc-15d6b619fd3c.png)
 Partial of #6955