### PR TITLE
Update incorrect attribution in changelog

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,8 +15,9 @@ Fix piety complete faith discount - By OptimizedForDensity
 
 ## 4.1.3
 
+Implement 'wait' command - by doublep
+
 By SomeTroglodyte:
-- Implement 'wait' command
 - Re-hide Enable Portrait option on desktop
 - Show required resource for upgrades
 - Fix Right-Click attacks made no sound

--- a/fastlane/metadata/android/en-US/changelogs/716.txt
+++ b/fastlane/metadata/android/en-US/changelogs/716.txt
@@ -1,5 +1,6 @@
+Implement 'wait' command - by doublep
+
 By SomeTroglodyte:
-- Implement 'wait' command
 - Re-hide Enable Portrait option on desktop
 - Show required resource for upgrades
 - Fix Right-Click attacks made no sound


### PR DESCRIPTION
I Noticed a bit late: The original author of #6896 went 'ghost', but I'm pretty sure @doublep is the replacement account.