### PR TITLE
Update NextTurnButton to prevent lateinit crash

### DIFF
--- a/core/src/com/unciv/ui/worldscreen/status/NextTurnButton.kt
+++ b/core/src/com/unciv/ui/worldscreen/status/NextTurnButton.kt
@@ -9,7 +9,8 @@ import com.unciv.ui.utils.*
 class NextTurnButton(
     keyPressDispatcher: KeyPressDispatcher
 ) : TextButton("", BaseScreen.skin) {
-    private lateinit var nextTurnAction: NextTurnAction
+    private var nextTurnAction = NextTurnAction("", Color.BLACK) {}
+
     init {
         label.setFontSize(30)
         labelCell.pad(10f)


### PR DESCRIPTION
I would prevent / close #6968 like this. Note I didn't touch the call that leaves the null in the parameter, seems intentional and expecting that returning from options will find an action set earlier...