### PR TITLE
units no longer explore on territory without open border agreement

### DIFF
--- a/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
+++ b/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
@@ -583,8 +583,8 @@ class UnitMovementAlgorithms(val unit: MapUnit) {
         if (!assumeCanPassThrough && !canPassThrough(tile))
             return false
 
-        if(tile.getOwner() != null && !unit.civInfo.canEnterBordersOf(tile.getOwner()!!))
-            return false
+//         if(tile.getOwner() != null && !unit.civInfo.canEnterBordersOf(tile.getOwner()!!))
+//             return false
 
         // even if they'll let us pass through, we can't enter their city - unless we just captured it
         if (tile.isCityCenter() && tile.getOwner() != unit.civInfo && !tile.getCity()!!.hasJustBeenConquered)
@@ -604,8 +604,8 @@ class UnitMovementAlgorithms(val unit: MapUnit) {
                 return true // if city is free - no problem, get in
         } // let's check whether it enters city on carrier now...
 
-        if(tile.getOwner() != null && !unit.civInfo.canEnterBordersOf(tile.getOwner()!!))
-            return false
+//         if(tile.getOwner() != null && !unit.civInfo.canEnterBordersOf(tile.getOwner()!!))
+//             return false
 
         if (tile.militaryUnit != null) {
             val unitAtDestination = tile.militaryUnit!!
@@ -645,8 +645,8 @@ class UnitMovementAlgorithms(val unit: MapUnit) {
                 && !tile.isCityCenter())
             return false
 
-        if(tile.getOwner() != null && !unit.civInfo.canEnterBordersOf(tile.getOwner()!!))
-            return false
+//         if(tile.getOwner() != null && !unit.civInfo.canEnterBordersOf(tile.getOwner()!!))
+//             return false
 
         val unitSpecificAllowOcean: Boolean by lazy {
             unit.civInfo.tech.specificUnitsCanEnterOcean &&

--- a/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
+++ b/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
@@ -583,6 +583,9 @@ class UnitMovementAlgorithms(val unit: MapUnit) {
         if (!assumeCanPassThrough && !canPassThrough(tile))
             return false
 
+        if(tile.getOwner() != null && !unit.civInfo.canEnterBordersOf(tile.getOwner()!!))
+            return false
+
         // even if they'll let us pass through, we can't enter their city - unless we just captured it
         if (tile.isCityCenter() && tile.getOwner() != unit.civInfo && !tile.getCity()!!.hasJustBeenConquered)
             return false

--- a/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
+++ b/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
@@ -604,6 +604,9 @@ class UnitMovementAlgorithms(val unit: MapUnit) {
                 return true // if city is free - no problem, get in
         } // let's check whether it enters city on carrier now...
 
+        if(tile.getOwner() != null && !unit.civInfo.canEnterBordersOf(tile.getOwner()!!))
+            return false
+
         if (tile.militaryUnit != null) {
             val unitAtDestination = tile.militaryUnit!!
             return unitAtDestination.canTransport(unit)

--- a/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
+++ b/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
@@ -639,6 +639,9 @@ class UnitMovementAlgorithms(val unit: MapUnit) {
                 && !tile.isCityCenter())
             return false
 
+        if(tile.getOwner() != null && !unit.civInfo.canEnterBordersOf(tile.getOwner()!!))
+            return false
+
         val unitSpecificAllowOcean: Boolean by lazy {
             unit.civInfo.tech.specificUnitsCanEnterOcean &&
                     unit.civInfo.getMatchingUniques(UniqueType.UnitsMayEnterOcean)


### PR DESCRIPTION
resolves #1814

units no longer pass through territory where they don't have an Open Borders agreement

Steps on how I tested:
- Created small world with 1 bot and 18 CS
- skipped 2 turns to let the CS build their cities (They can build their territory on a tile where you have a unit and they consider that as trespassing)
- put every unit on explore
- skipped a bunch of turns until the entire map is explored

