### PR TITLE
Update EditorConfig - keep existing credits lists intact

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -74,3 +74,6 @@ ij_properties_spaces_around_key_value_delimiter = false
 
 [{*.yaml, *.yml}]
 indent_size = 2
+
+[*.md]
+ij_markdown_force_one_space_after_list_bullet = false


### PR DESCRIPTION
Tiny thing - in a recent PR (#6856) autoformat touched a lot of lines, which IMO are fine as they were.

Also - should we keep the continuation indents for if conditions and expression bodies? My impression is in theory I like them in these two cases but continuation still seems to apply in situations where I don't like them - but I haven't kept an example around. Input?