### PR TITLE
Prevent senseless BattleTable display and fix right-click issues

### DIFF
--- a/core/src/com/unciv/logic/battle/ICombatant.kt
+++ b/core/src/com/unciv/logic/battle/ICombatant.kt
@@ -43,4 +43,13 @@ interface ICombatant {
         return this is CityCombatant
     }
     fun isCivilian() = this is MapUnitCombatant && this.unit.isCivilian()
+    fun getMaxMovement(): Int {
+        if (this is MapUnitCombatant) return unit.getMaxMovement()
+        return 0
+    }
+    fun getRange(): Int {
+        if (this is MapUnitCombatant) return unit.getRange()
+        if (this is CityCombatant) return city.range
+        return 0
+    }
 }

--- a/core/src/com/unciv/ui/worldscreen/WorldMapHolder.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldMapHolder.kt
@@ -182,6 +182,11 @@ class WorldMapHolder(internal val worldScreen: WorldScreen, internal val tileMap
     }
 
     private fun onTileRightClicked(unit: MapUnit, tile: TileInfo) {
+        removeUnitActionOverlay()
+        selectedTile = tile
+        unitMovementPaths.clear()
+        worldScreen.shouldUpdate = true
+
         if (worldScreen.bottomUnitTable.selectedUnitIsSwapping) {
             if (unit.movement.canUnitSwapTo(tile)) {
                 swapMoveUnitToTargetTile(unit, tile)

--- a/core/src/com/unciv/ui/worldscreen/bottombar/BattleTable.kt
+++ b/core/src/com/unciv/ui/worldscreen/bottombar/BattleTable.kt
@@ -37,28 +37,30 @@ class BattleTable(val worldScreen: WorldScreen): Table() {
         touchable = Touchable.enabled
     }
 
-    fun hide(){
+    private fun hide() {
         isVisible = false
         clear()
         pack()
     }
 
     fun update() {
-        isVisible = true
-        if (!worldScreen.canChangeState) { hide(); return }
+        if (!worldScreen.canChangeState) return hide()
 
-        val attacker = tryGetAttacker()
-        if (attacker == null) { hide(); return }
+        val attacker = tryGetAttacker() ?: return hide()
 
         if (attacker is MapUnitCombatant && attacker.unit.baseUnit.isNuclearWeapon()) {
             val selectedTile = worldScreen.mapHolder.selectedTile
-            if (selectedTile == null) { hide(); return } // no selected tile
+                ?: return hide() // no selected tile
             simulateNuke(attacker, selectedTile)
         } else {
-            val defender = tryGetDefender()
-            if (defender == null) { hide(); return }
+            val defender = tryGetDefender() ?: return hide()
+            val aerialDistance = defender.getTile().aerialDistanceTo(attacker.getTile())
+            val threatDistance = attacker.getRange() + attacker.getMaxMovement() + defender.getMaxMovement()
+            if (aerialDistance > threatDistance) return hide()
             simulateBattle(attacker, defender)
         }
+
+        isVisible = true
         pack()
         addBorderAllowOpacity(1f, Color.WHITE)
     }


### PR DESCRIPTION
Select a city, then select a city from another nation. You get the BattleTable "what-if I could bombard that city". Even if half the world away. Pretty senseless. I thought - OK, try to limit, but don't just prevent display if no attack possible. Maybe display if the battle could _conceivably happen next turn_. This is only on approximation so far, but it already feels better.

Thing is, getMaxMovement returns 1 for air units. No relation to reality. But, with this code, I could "compare strengths" with a Bomber and a City one tile outside its range, but not one two tiles too far. Should I fix this in the original Unit getMaxMovement code, or in the ICombatant proxy I added because it makes sense and things easier, or correct in the threatRange calculation? Once that is done, should I "predict" increased range ("could happen next turn") for: -Operational Range promotion? -Relocation to another City? Simplify potential relocation as a guesstimate by not checking cities one could relocate to but simply doubling range?

The right-click issues part - after a RC move currently TileInfoTable is wrong, and after a RC attack the unit info too. Or - select an Artillery, then a city on another continent 30 tiles away. You get the BattleTable. Now RC-move it one tile - the BattleTable is still there. With the above fix this could look even more ridiculous, with the BT _appearing_ after a RC move because the selectedTile still remembered an ages old selection... I _think_ these lines a left click would do but were missing in RC should do it. Please comment if anybody knows counter arguments.