### PR TITLE
Notification manager proof of concept

### DIFF
--- a/core/src/com/unciv/UncivGame.kt
+++ b/core/src/com/unciv/UncivGame.kt
@@ -9,6 +9,7 @@ import com.badlogic.gdx.utils.Align
 import com.unciv.logic.GameInfo
 import com.unciv.logic.GameSaver
 import com.unciv.logic.civilization.PlayerType
+import com.unciv.logic.event.NotificationManager
 import com.unciv.models.metadata.GameSettings
 import com.unciv.models.ruleset.RulesetCache
 import com.unciv.models.tilesets.TileSetCache
@@ -79,6 +80,7 @@ class UncivGame(parameters: UncivGameParameters) : Game() {
 
 
     val translations = Translations()
+    lateinit var notificationManager: NotificationManager
 
     override fun create() {
         isInitialized = false // this could be on reload, therefore we need to keep setting this to false
@@ -146,6 +148,8 @@ class UncivGame(parameters: UncivGameParameters) : Game() {
                 isInitialized = true
             }
         }
+
+        notificationManager = NotificationManager()
     }
 
     fun loadGame(gameInfo: GameInfo) {
@@ -260,6 +264,7 @@ class UncivGame(parameters: UncivGameParameters) : Game() {
 
         // On desktop this should only be this one and "DestroyJavaVM"
         logRunningThreads()
+        notificationManager.cleanup()
     }
 
     private fun logRunningThreads() {

--- a/core/src/com/unciv/logic/event/NotificationManager.kt
+++ b/core/src/com/unciv/logic/event/NotificationManager.kt
@@ -1,0 +1,165 @@
+package com.unciv.logic.event
+
+import com.unciv.logic.city.CityInfo
+import com.unciv.logic.city.IConstruction
+import com.unciv.logic.civilization.AlertType
+import com.unciv.logic.civilization.CivilizationInfo
+import com.unciv.logic.civilization.NotificationIcon
+import com.unciv.logic.civilization.PopupAlert
+import com.unciv.logic.map.MapUnit
+import com.unciv.logic.map.TileInfo
+import com.unciv.models.ruleset.Building
+import com.unciv.models.ruleset.tile.TileImprovement
+import com.unciv.models.ruleset.unique.StateForConditionals
+import com.unciv.models.ruleset.unique.UniqueType
+import com.unciv.models.stats.Stats
+
+class NotificationManager {
+    private val events = EventBus.EventReceiver()
+
+    init {
+        events.receive(INotificationEvent::class) {
+            it.createNotification()
+        }
+        /*events.receive(SomeInheritingClassOfINotificationEvent::class) {
+            it.specialFunction()
+        }*/
+    }
+
+    fun cleanup() {
+        events.stopReceiving()
+    }
+}
+
+/** Interface for notification-generating events */
+interface INotificationEvent : Event {
+    fun createNotification()
+}
+
+/////
+// below definitions temporarily in this file for conciseness
+/////
+/** Interface for unit action events which will have a unit and possibly a location associated with them */
+interface IUnitActionNotification : INotificationEvent {
+    val actingUnit: MapUnit
+    val tile: TileInfo
+    val targetUnit: MapUnit?
+}
+
+class PillageNotification(
+    override val actingUnit: MapUnit,
+    override val tile: TileInfo,
+    val improvement: TileImprovement,
+    val lootedStats: Stats?,
+    override val targetUnit: MapUnit? = null
+) : IUnitActionNotification {
+
+    val victim: CivilizationInfo? = tile.getOwner()
+
+    override fun createNotification() {
+        val pillagerString = "We have pillaged a [${improvement.name}]"
+        if (victim != null) {
+            actingUnit.civInfo.addNotification(pillagerString, tile.position, NotificationIcon.War, victim!!.civName)
+            victim!!.addNotification("[${actingUnit.civInfo.civName}] has pillaged our [${improvement.name}]", tile.position, NotificationIcon.War, actingUnit.civInfo.civName)
+        } else {
+            actingUnit.civInfo.addNotification(pillagerString, tile.position, NotificationIcon.War)
+        }
+    }
+}
+
+interface ICityNotification : INotificationEvent {
+    val city: CityInfo
+}
+
+abstract class CityConstructionNotification : ICityNotification {
+    abstract val construction: IConstruction
+
+    enum class CityAwareness {
+        KNOWS_CITY,
+        KNOWS_CIV,
+        FARAWAY_LAND
+    }
+
+    fun canSeeCity(civ: CivilizationInfo): CityAwareness {
+        return when {
+            civ.exploredTiles.contains(city.location) -> CityAwareness.KNOWS_CITY
+            civ.knows(city.civInfo) -> CityAwareness.KNOWS_CIV
+            else -> CityAwareness.FARAWAY_LAND
+        }
+    }
+}
+
+class ConstructionBegunNotification(
+    override val city: CityInfo,
+    override val construction: IConstruction
+) :
+    CityConstructionNotification() {
+    override fun createNotification() {
+        val buildingIcon = "BuildingIcons/${construction.name}"
+        for (otherCiv in city.civInfo.gameInfo.civilizations) {
+            if (otherCiv == city.civInfo) continue
+            when (canSeeCity(otherCiv)) {
+                CityAwareness.KNOWS_CITY -> otherCiv.addNotification("The city of [${city.name}] has started constructing [${construction.name}]!",
+                    city.location, NotificationIcon.Construction, buildingIcon)
+                CityAwareness.KNOWS_CIV -> otherCiv.addNotification("[${city.civInfo.civName}] has started constructing [${construction.name}]!",
+                    NotificationIcon.Construction, buildingIcon)
+                CityAwareness.FARAWAY_LAND -> otherCiv.addNotification("An unknown civilization has started constructing [${construction.name}]!",
+                    NotificationIcon.Construction, buildingIcon)
+            }
+        }
+    }
+}
+
+class ConstructionCompletedNotification(
+    override val city: CityInfo,
+    override val construction: IConstruction
+) :
+    CityConstructionNotification() {
+    override fun createNotification() {
+        val constructionIcon = if (construction is Building) "BuildingIcons/${construction.name}"
+        else construction.name
+
+        if (construction is Building
+                && construction.isWonder) {
+            city.civInfo.popupAlerts.add(PopupAlert(AlertType.WonderBuilt, construction.name))
+
+            for (civ in city.civInfo.gameInfo.civilizations) {
+                when (canSeeCity(civ)) {
+                    CityAwareness.KNOWS_CITY -> civ.addNotification("[${construction.name}] has been built in [${city.name}]",
+                        city.location, NotificationIcon.Construction, constructionIcon)
+                    else -> civ.addNotification("[${construction.name}] has been built in a faraway land", constructionIcon)
+                }
+            }
+        }
+
+        if (construction is Building && construction.hasUnique(
+                    UniqueType.TriggersAlertOnCompletion,
+                    StateForConditionals(city.civInfo, city)
+                )) {
+            for (otherCiv in city.civInfo.gameInfo.civilizations) {
+                // No need to notify ourself, since we already got the building notification anyway
+                if (otherCiv == city.civInfo) continue
+                val completingCivDescription =
+                        when (canSeeCity(otherCiv)) {
+                            CityAwareness.KNOWS_CIV, CityAwareness.KNOWS_CITY -> "[${city.civInfo.civName}]"
+                            else -> "An unknown civilization"
+                        }
+                otherCiv.addNotification("$completingCivDescription has completed [${construction.name}]!",
+                    NotificationIcon.Construction, constructionIcon)
+            }
+        }
+    }
+}
+
+class ConstructionCancelledNotification(
+    override val city: CityInfo,
+    override val construction: IConstruction,
+    private val workDone: Int
+) : CityConstructionNotification() {
+    override fun createNotification() {
+        city.civInfo.addNotification(
+            "Excess production for [${construction.name}] converted to [$workDone] gold",
+            city.location,
+            NotificationIcon.Gold, "BuildingIcons/${construction.name}")
+    }
+}

--- a/core/src/com/unciv/logic/event/NotificationManager.kt
+++ b/core/src/com/unciv/logic/event/NotificationManager.kt
@@ -71,6 +71,12 @@ interface ICityNotification : INotificationEvent {
     val city: CityInfo
 }
 
+class CapitalMovedNotification(override val city: CityInfo) : ICityNotification {
+    override fun createNotification() {
+        city.civInfo.addNotification("[${city.name}] is now your new capital", city.location, NotificationIcon.City)
+    }
+}
+
 abstract class CityConstructionNotification : ICityNotification {
     abstract val construction: IConstruction
 

--- a/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
@@ -10,6 +10,8 @@ import com.unciv.logic.civilization.NotificationIcon
 import com.unciv.logic.civilization.PlayerType
 import com.unciv.logic.civilization.diplomacy.DiplomacyFlags
 import com.unciv.logic.civilization.diplomacy.DiplomaticModifiers
+import com.unciv.logic.event.EventBus
+import com.unciv.logic.event.PillageNotification
 import com.unciv.logic.map.MapUnit
 import com.unciv.logic.map.TileInfo
 import com.unciv.models.Counter
@@ -41,7 +43,7 @@ object UnitActions {
         val unitTable = worldScreen.bottomUnitTable
         val actionList = ArrayList<UnitAction>()
 
-        if (unit.isMoving()) 
+        if (unit.isMoving())
             actionList += UnitAction(UnitActionType.StopMovement) { unit.action = null }
         if (unit.isExploring())
             actionList += UnitAction(UnitActionType.StopExploration) { unit.action = null }
@@ -284,6 +286,7 @@ object UnitActions {
 
         return UnitAction(UnitActionType.Pillage,
                 action = {
+                    EventBus.send(PillageNotification(unit, tile, tile.getTileImprovement()!!, null))
                     tile.setPillaged()
                     unit.civInfo.lastSeenImprovement.remove(tile.position)
                     if (tile.resource != null) tile.getOwner()?.updateDetailedCivResources()    // this might take away a resource
@@ -396,7 +399,7 @@ object UnitActions {
 
         val couldConstruct = unit.currentMovement > 0
             && !tile.isCityCenter()
-            && unit.civInfo.gameInfo.ruleSet.tileImprovements.values.any { 
+            && unit.civInfo.gameInfo.ruleSet.tileImprovements.values.any {
                 ImprovementPickerScreen.canReport(tile.getImprovementBuildingProblems(it, unit.civInfo).toSet())
                 && unit.canBuildImprovement(it)
             }
@@ -808,7 +811,7 @@ object UnitActions {
 
         return UnitAction(UnitActionType.GiftUnit, action = giftAction)
     }
-    
+
     private fun addTriggerUniqueActions(unit: MapUnit, actionList: ArrayList<UnitAction>){
         for (unique in unit.getUniques()) {
             if (!unique.conditionals.any { it.type == UniqueType.ConditionalConsumeUnit }) continue


### PR DESCRIPTION
This is a quick proof of concept of a notification manager that @Azzurite talked about in #6993 and so what I wrote here is my interpretation of how it _could_ be implemented. This is more of a demonstration than a definitive implementation (especially since I copy and pasted code from #7009 directly into this PR).

The idea is that we can use the new `EventBus` that listens for events and has customizable listeners which can process the events as we need them to in order to handle notifications on the world screen. This `NotificationManager` listens for `Event`s that implement the `INotificationEvent` interface (which has an abstract `createNotification()` function used to created the notifications to all necessary parties). This lets us create dedicated notification-creating code beyond calling `addNotification(...)` that can be reused and inherited in an objected-oriented manner while keeping the gameplay code focuses on gameplay mechanics. Here I've got an example hierarchy of interfaces and classes that help create notifications including supporting code that is reused between notification classes. What do you guys think of this as a way of managing notification code?