### PR TITLE
Autoassign the population when the manual assignment fails

### DIFF
--- a/core/src/com/unciv/logic/city/PopulationManager.kt
+++ b/core/src/com/unciv/logic/city/PopulationManager.kt
@@ -77,12 +77,12 @@ class PopulationManager {
         }
         if (foodStored >= getFoodToNextPopulation()) {  // growth!
             foodStored -= getFoodToNextPopulation()
-            var percentOfFoodCarriedOver = 
+            var percentOfFoodCarriedOver =
                 cityInfo.getMatchingUniques(UniqueType.CarryOverFood)
                     .filter { cityInfo.matchesFilter(it.params[1]) }
                     .sumOf { it.params[0].toInt() }
-            // Try to avoid runaway food gain in mods, just in case 
-            if (percentOfFoodCarriedOver > 95) percentOfFoodCarriedOver = 95 
+            // Try to avoid runaway food gain in mods, just in case
+            if (percentOfFoodCarriedOver > 95) percentOfFoodCarriedOver = 95
             foodStored += (getFoodToNextPopulation() * percentOfFoodCarriedOver / 100f).toInt()
             addPopulation(1)
             cityInfo.updateCitizens = true
@@ -93,7 +93,7 @@ class PopulationManager {
     private fun getStatsOfSpecialist(name: String) = cityInfo.cityStats.getStatsOfSpecialist(name)
 
     fun addPopulation(count: Int) {
-        val changedAmount = 
+        val changedAmount =
             if (population + count < 0) -population
             else count
         population += changedAmount
@@ -121,7 +121,7 @@ class PopulationManager {
             if (cityInfo.matchesFilter(unique.params[1]))
                 specialistFoodBonus *= unique.params[0].toPercent()
         specialistFoodBonus = 2f - specialistFoodBonus
-        
+
         for (i in 1..getFreePopulation()) {
             //evaluate tiles
             val (bestTile, valueBestTile) = cityInfo.getTiles()

--- a/core/src/com/unciv/logic/city/PopulationManager.kt
+++ b/core/src/com/unciv/logic/city/PopulationManager.kt
@@ -197,10 +197,18 @@ class PopulationManager {
 
 
             //un-assign population
-            if ((worstWorkedTile != null && valueWorstTile < valueWorstSpecialist)
-                    || worstJob == null) {
-                cityInfo.workedTiles = cityInfo.workedTiles.withoutItem(worstWorkedTile!!.position)
-            } else specialistAllocations.add(worstJob, -1)
+            if (worstWorkedTile != null && valueWorstTile < valueWorstSpecialist) {
+                cityInfo.workedTiles = cityInfo.workedTiles.withoutItem(worstWorkedTile.position)
+            } else if (worstJob != null) specialistAllocations.add(worstJob, -1)
+            else {
+                // It happens when "cityInfo.manualSpecialists == true"
+                //  and population goes below the number of specialists, e.g. city is razing.
+                // Let's give a chance to do the work automatically at least.
+                val worstAutoJob = specialistAllocations.keys.minByOrNull {
+                    Automation.rankSpecialist(it, cityInfo, cityInfo.cityStats.currentCityStats) }
+                    ?: break // sorry, we can do nothing about that
+                specialistAllocations.add(worstAutoJob, -1)
+            }
         }
 
     }


### PR DESCRIPTION
Fixes #7018

The issue reproduces when the city population goes down (raze the city 🔥) but the city specialists are locked by manual setup and become more in numbers than the population itself. One of the specialists must die, for sure, so we need to release one to rest in peace and freedom.

I am curious how we were so lucky 🍀 that this code has been working with no crashes before.
Most probably, introducing `manualSpecialists` has revealed this hidden bomb.

P.S> As a fan of "Elvis" I hate `!!` but for some reason they are quite popular in this project.