### PR TITLE
Repair Civilopedia link from city construction info

### DIFF
--- a/core/src/com/unciv/ui/cityscreen/ConstructionInfoTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/ConstructionInfoTable.kt
@@ -8,7 +8,7 @@ import com.unciv.UncivGame
 import com.unciv.logic.city.IConstruction
 import com.unciv.logic.city.PerpetualConstruction
 import com.unciv.models.ruleset.Building
-import com.unciv.models.ruleset.RulesetObject
+import com.unciv.models.ruleset.IRulesetObject
 import com.unciv.models.ruleset.unit.BaseUnit
 import com.unciv.models.translations.tr
 import com.unciv.ui.civilopedia.CivilopediaScreen
@@ -17,7 +17,6 @@ import com.unciv.ui.utils.*
 
 class ConstructionInfoTable(val cityScreen: CityScreen): Table() {
     private val selectedConstructionTable = Table()
-    val city = cityScreen.city
 
     init {
         selectedConstructionTable.background = ImageGetter.getBackground(ImageGetter.getBlue().darken(0.5f))
@@ -26,7 +25,7 @@ class ConstructionInfoTable(val cityScreen: CityScreen): Table() {
     }
 
     fun update(selectedConstruction: IConstruction?) {
-        selectedConstructionTable.clear()
+        selectedConstructionTable.clear()  // clears content and listeners
 
         if (selectedConstruction == null) {
             isVisible = false
@@ -40,6 +39,7 @@ class ConstructionInfoTable(val cityScreen: CityScreen): Table() {
     }
 
     private fun updateSelectedConstructionTable(construction: IConstruction) {
+        val city = cityScreen.city
         val cityConstructions = city.cityConstructions
 
         //val selectedConstructionTable = Table()
@@ -68,8 +68,7 @@ class ConstructionInfoTable(val cityScreen: CityScreen): Table() {
             descriptionLabel.wrap = true
             add(descriptionLabel).colspan(2).width(stage.width / 4)
 
-            clearListeners()
-            val link = (construction as? RulesetObject)?.makeLink() ?: return
+            val link = (construction as? IRulesetObject)?.makeLink() ?: return
             if (link.isEmpty()) return
             touchable = Touchable.enabled
             onClick {


### PR DESCRIPTION
Small fix - the Civilopedia link for buildings from CityScreen lower right had regressed