### PR TITLE
Improve performance of worldmap panning

### DIFF
--- a/core/src/com/unciv/ui/UncivStage.kt
+++ b/core/src/com/unciv/ui/UncivStage.kt
@@ -1,34 +1,47 @@
-package com.unciv.ui.crashhandling
+package com.unciv.ui
 
 import com.badlogic.gdx.graphics.g2d.Batch
 import com.badlogic.gdx.scenes.scene2d.Stage
 import com.badlogic.gdx.utils.viewport.Viewport
-import com.unciv.ui.utils.*
+import com.unciv.ui.utils.wrapCrashHandling
+import com.unciv.ui.utils.wrapCrashHandlingUnit
 
 
-/** Stage that safely brings the game to a [CrashScreen] if any event handlers throw an exception or an error that doesn't get otherwise handled. */
-class CrashHandlingStage(viewport: Viewport, batch: Batch) : Stage(viewport, batch) {
+/** Main stage for the game. Safely brings the game to a [CrashScreen] if any event handlers throw an exception or an error that doesn't get otherwise handled. */
+class UncivStage(viewport: Viewport, batch: Batch) : Stage(viewport, batch) {
 
-    override fun draw() = { super.draw() }.wrapCrashHandlingUnit()()
-    override fun act() = { super.act() }.wrapCrashHandlingUnit()()
-    override fun act(delta: Float) = { super.act(delta) }.wrapCrashHandlingUnit()()
+    override fun draw() =
+        { super.draw() }.wrapCrashHandlingUnit()()
 
-    override fun touchDown(screenX: Int, screenY: Int, pointer: Int, button: Int)
-        = { super.touchDown(screenX, screenY, pointer, button) }.wrapCrashHandling()() ?: true
-    override fun touchDragged(screenX: Int, screenY: Int, pointer: Int)
-        = { super.touchDragged(screenX, screenY, pointer) }.wrapCrashHandling()() ?: true
-    override fun touchUp(screenX: Int, screenY: Int, pointer: Int, button: Int)
-        = { super.touchUp(screenX, screenY, pointer, button) }.wrapCrashHandling()() ?: true
-    override fun mouseMoved(screenX: Int, screenY: Int)
-        = { super.mouseMoved(screenX, screenY) }.wrapCrashHandling()() ?: true
-    override fun scrolled(amountX: Float, amountY: Float)
-        = { super.scrolled(amountX, amountY) }.wrapCrashHandling()() ?: true
-    override fun keyDown(keyCode: Int)
-        = { super.keyDown(keyCode) }.wrapCrashHandling()() ?: true
-    override fun keyUp(keyCode: Int)
-        = { super.keyUp(keyCode) }.wrapCrashHandling()() ?: true
-    override fun keyTyped(character: Char)
-        = { super.keyTyped(character) }.wrapCrashHandling()() ?: true
+    override fun act() =
+        { super.act() }.wrapCrashHandlingUnit()()
+
+    override fun act(delta: Float) =
+        { super.act(delta) }.wrapCrashHandlingUnit()()
+
+    override fun touchDown(screenX: Int, screenY: Int, pointer: Int, button: Int) =
+        { super.touchDown(screenX, screenY, pointer, button) }.wrapCrashHandling()() ?: true
+
+    override fun touchDragged(screenX: Int, screenY: Int, pointer: Int) =
+        { super.touchDragged(screenX, screenY, pointer) }.wrapCrashHandling()() ?: true
+
+    override fun touchUp(screenX: Int, screenY: Int, pointer: Int, button: Int) =
+        { super.touchUp(screenX, screenY, pointer, button) }.wrapCrashHandling()() ?: true
+
+    override fun mouseMoved(screenX: Int, screenY: Int) =
+        { super.mouseMoved(screenX, screenY) }.wrapCrashHandling()() ?: true
+
+    override fun scrolled(amountX: Float, amountY: Float) =
+        { super.scrolled(amountX, amountY) }.wrapCrashHandling()() ?: true
+
+    override fun keyDown(keyCode: Int) =
+        { super.keyDown(keyCode) }.wrapCrashHandling()() ?: true
+
+    override fun keyUp(keyCode: Int) =
+        { super.keyUp(keyCode) }.wrapCrashHandling()() ?: true
+
+    override fun keyTyped(character: Char) =
+        { super.keyTyped(character) }.wrapCrashHandling()() ?: true
 
 }
 

--- a/core/src/com/unciv/ui/UncivStage.kt
+++ b/core/src/com/unciv/ui/UncivStage.kt
@@ -1,5 +1,6 @@
 package com.unciv.ui
 
+import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.graphics.g2d.Batch
 import com.badlogic.gdx.scenes.scene2d.Stage
 import com.badlogic.gdx.utils.viewport.Viewport
@@ -10,11 +11,23 @@ import com.unciv.ui.utils.wrapCrashHandlingUnit
 /** Main stage for the game. Safely brings the game to a [CrashScreen] if any event handlers throw an exception or an error that doesn't get otherwise handled. */
 class UncivStage(viewport: Viewport, batch: Batch) : Stage(viewport, batch) {
 
+    /**
+     * Enables/disables sending pointer enter/exit events to actors on this stage. May be disabled for performance reasons if enter/exit events are not needed temporarily.
+     */
+    var performPointerEnterExitEvents: Boolean = false
+
     override fun draw() =
         { super.draw() }.wrapCrashHandlingUnit()()
+    override fun act() = {
+        /** We're basically replicating [Stage.act], so this value is simply taken from there. */
+        val delta = Gdx.graphics.deltaTime.coerceAtMost(1 / 30f)
 
-    override fun act() =
-        { super.act() }.wrapCrashHandlingUnit()()
+        if (performPointerEnterExitEvents) {
+            super.act(delta)
+        } else {
+            root.act(delta)
+        }
+    }.wrapCrashHandlingUnit()()
 
     override fun act(delta: Float) =
         { super.act(delta) }.wrapCrashHandlingUnit()()

--- a/core/src/com/unciv/ui/UncivStage.kt
+++ b/core/src/com/unciv/ui/UncivStage.kt
@@ -12,14 +12,18 @@ import com.unciv.ui.utils.wrapCrashHandlingUnit
 class UncivStage(viewport: Viewport, batch: Batch) : Stage(viewport, batch) {
 
     /**
-     * Enables/disables sending pointer enter/exit events to actors on this stage. May be disabled for performance reasons if enter/exit events are not needed temporarily.
+     * Enables/disables sending pointer enter/exit events to actors on this stage.
+     * Checking for the enter/exit bounds is a relatively expensive operation and may thus be disabled temporarily.
      */
     var performPointerEnterExitEvents: Boolean = false
 
     override fun draw() =
         { super.draw() }.wrapCrashHandlingUnit()()
+
+    /** libGDX has no built-in way to disable/enable pointer enter/exit events. It is simply being done in [Stage.act]. So to disable this, we have
+     * to replicate the [Stage.act] method without the code for pointer enter/exit events. This is of course inherently brittle, but the only way. */
     override fun act() = {
-        /** We're basically replicating [Stage.act], so this value is simply taken from there. */
+        /** We're replicating [Stage.act], so this value is simply taken from there */
         val delta = Gdx.graphics.deltaTime.coerceAtMost(1 / 30f)
 
         if (performPointerEnterExitEvents) {

--- a/core/src/com/unciv/ui/cityscreen/CityScreen.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityScreen.kt
@@ -308,11 +308,9 @@ class CityScreen(
             }
         }
 
-        val tileMapGroup = TileGroupMap(tileGroups, stage.width / 2, stage.height / 2, tileGroupsToUnwrap = tilesToUnwrap)
+        val tileMapGroup = TileGroupMap(tileGroups, tileGroupsToUnwrap = tilesToUnwrap)
         mapScrollPane.actor = tileMapGroup
         mapScrollPane.setSize(stage.width, stage.height)
-        mapScrollPane.setOrigin(stage.width / 2, stage.height / 2)
-        mapScrollPane.center(stage)
         stage.addActor(mapScrollPane)
 
         mapScrollPane.layout() // center scrolling

--- a/core/src/com/unciv/ui/crashhandling/CrashScreen.kt
+++ b/core/src/com/unciv/ui/crashhandling/CrashScreen.kt
@@ -21,7 +21,7 @@ import kotlin.concurrent.thread
 
 /*
 Crashes are now handled from:
-- Event listeners, by [CrashHandlingStage].
+- Event listeners, by [UncivStage].
 - The main rendering loop, by [UncivGame.render].
 - Threads, by [crashHandlingThread].
 - Main loop runnables, by [postCrashHandlingRunnable].

--- a/core/src/com/unciv/ui/map/TileGroupMap.kt
+++ b/core/src/com/unciv/ui/map/TileGroupMap.kt
@@ -27,6 +27,11 @@ class TileGroupMap<T: TileGroup>(
     worldWrap: Boolean = false,
     tileGroupsToUnwrap: Set<T>? = null
 ): Group() {
+    /** If the [act] method should be performed. If this is false, every child within this [TileGroupMap] will not get their [act] method called
+     * and thus not perform any [com.badlogic.gdx.scenes.scene2d.Action]s.
+     * Most children here already do not do anything in their [act] methods. However, even iterating through all of them */
+    var shouldAct = true
+
     private var topX = -Float.MAX_VALUE
     private var topY = -Float.MAX_VALUE
     private var bottomX = Float.MAX_VALUE
@@ -166,5 +171,9 @@ class TileGroupMap<T: TileGroup>(
     // For debugging purposes
      override fun draw(batch: Batch?, parentAlpha: Float) { super.draw(batch, parentAlpha) }
      @Suppress("RedundantOverride")
-     override fun act(delta: Float) { super.act(delta) }
+     override fun act(delta: Float) {
+         if(shouldAct) {
+             super.act(delta)
+         }
+     }
 }

--- a/core/src/com/unciv/ui/map/TileGroupMap.kt
+++ b/core/src/com/unciv/ui/map/TileGroupMap.kt
@@ -22,8 +22,6 @@ import kotlin.math.min
  */
 class TileGroupMap<T: TileGroup>(
     tileGroups: Iterable<T>,
-    private val leftAndRightPadding: Float,
-    private val topAndBottomPadding: Float,
     worldWrap: Boolean = false,
     tileGroupsToUnwrap: Set<T>? = null
 ): Group() {
@@ -77,7 +75,7 @@ class TileGroupMap<T: TileGroup>(
         }
 
         for (group in tileGroups) {
-            group.moveBy(-bottomX + leftAndRightPadding, -bottomY + topAndBottomPadding)
+            group.moveBy(-bottomX, -bottomY)
         }
 
         if (worldWrap) {
@@ -86,11 +84,11 @@ class TileGroupMap<T: TileGroup>(
 
                 mirrorTiles.first.setPosition(positionalVector.x * 0.8f * groupSize.toFloat(),
                         positionalVector.y * 0.8f * groupSize.toFloat())
-                mirrorTiles.first.moveBy(-bottomX + leftAndRightPadding - bottomX * 2, -bottomY + topAndBottomPadding)
+                mirrorTiles.first.moveBy(-bottomX - bottomX * 2, -bottomY )
 
                 mirrorTiles.second.setPosition(positionalVector.x * 0.8f * groupSize.toFloat(),
                         positionalVector.y * 0.8f * groupSize.toFloat())
-                mirrorTiles.second.moveBy(-bottomX + leftAndRightPadding + bottomX * 2, -bottomY + topAndBottomPadding)
+                mirrorTiles.second.moveBy(-bottomX + bottomX * 2, -bottomY)
             }
         }
 
@@ -151,8 +149,8 @@ class TileGroupMap<T: TileGroup>(
         // Map's width is reduced by groupSize if it is wrapped, because wrapped map will miss a tile on the right.
         // This ensures that wrapped maps have a smooth transition.
         // If map is not wrapped, Map's width doesn't need to be reduce by groupSize
-        if (worldWrap) setSize(topX - bottomX + leftAndRightPadding * 2 - groupSize, topY - bottomY + topAndBottomPadding * 2)
-        else setSize(topX - bottomX + leftAndRightPadding * 2, topY - bottomY + topAndBottomPadding * 2)
+        if (worldWrap) setSize(topX - bottomX - groupSize, topY - bottomY)
+        else setSize(topX - bottomX, topY - bottomY)
     }
 
     /**
@@ -160,7 +158,7 @@ class TileGroupMap<T: TileGroup>(
      */
     fun getPositionalVector(stageCoords: Vector2): Vector2 {
         val trueGroupSize = 0.8f * groupSize.toFloat()
-        return Vector2(bottomX - leftAndRightPadding, bottomY - topAndBottomPadding)
+        return Vector2(bottomX, bottomY)
                 .add(stageCoords)
                 .sub(groupSize.toFloat() / 2f, groupSize.toFloat() / 2f)
                 .scl(1f / trueGroupSize)

--- a/core/src/com/unciv/ui/mapeditor/EditorMapHolder.kt
+++ b/core/src/com/unciv/ui/mapeditor/EditorMapHolder.kt
@@ -24,7 +24,7 @@ class EditorMapHolder(
     parentScreen: BaseScreen,
     internal val tileMap: TileMap,
     private val onTileClick: (TileInfo) -> Unit
-): ZoomableScrollPane() {
+): ZoomableScrollPane(20f, 20f) {
     val editorScreen = parentScreen as? MapEditorScreen
 
     val tileGroups = HashMap<TileInfo, List<TileGroup>>()
@@ -32,7 +32,6 @@ class EditorMapHolder(
     private val allTileGroups = ArrayList<TileGroup>()
 
     private val maxWorldZoomOut = UncivGame.Current.settings.maxWorldZoomOut
-    private val minZoomScale = 1f / maxWorldZoomOut
 
     private var blinkAction: Action? = null
 
@@ -53,8 +52,6 @@ class EditorMapHolder(
 
         tileGroupMap = TileGroupMap(
             daTileGroups,
-            stage.width * maxWorldZoomOut / 2,
-            stage.height * maxWorldZoomOut / 2,
             continuousScrollingX)
         actor = tileGroupMap
         val mirrorTileGroups = tileGroupMap.getMirrorTiles()
@@ -140,11 +137,6 @@ class EditorMapHolder(
         addAction(blinkAction) // Don't set it on the group because it's an actionless group
     }
 
-    override fun zoom(zoomScale: Float) {
-        if (zoomScale < minZoomScale || zoomScale > 2f) return
-        setScale(zoomScale)
-    }
-
     /*
     The ScrollPane interferes with the dragging listener of MapEditorToolsDrawer.
     Once the ZoomableScrollPane super is initialized, there are 3 listeners + 1 capture listener:
@@ -195,7 +187,7 @@ class EditorMapHolder(
                 if (!isPainting) return
 
                 editorScreen!!.hideSelection()
-                val stageCoords = actor.stageToLocalCoordinates(Vector2(event!!.stageX, event.stageY))
+                val stageCoords = actor?.stageToLocalCoordinates(Vector2(event!!.stageX, event.stageY)) ?: return
                 val centerTileInfo = getClosestTileTo(stageCoords)
                     ?: return
                 editorScreen.tabs.edit.paintTilesWithBrush(centerTileInfo)

--- a/core/src/com/unciv/ui/utils/BaseScreen.kt
+++ b/core/src/com/unciv/ui/utils/BaseScreen.kt
@@ -10,9 +10,9 @@ import com.badlogic.gdx.scenes.scene2d.Stage
 import com.badlogic.gdx.scenes.scene2d.ui.*
 import com.badlogic.gdx.scenes.scene2d.utils.Drawable
 import com.badlogic.gdx.utils.viewport.ExtendViewport
-import com.unciv.ui.crashhandling.CrashHandlingStage
 import com.unciv.UncivGame
 import com.unciv.models.Tutorial
+import com.unciv.ui.UncivStage
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.popup.hasOpenPopups
 import com.unciv.ui.tutorials.TutorialController
@@ -32,7 +32,7 @@ abstract class BaseScreen : Screen {
         val height = resolutions[1]
 
         /** The ExtendViewport sets the _minimum_(!) world size - the actual world size will be larger, fitted to screen/window aspect ratio. */
-        stage = CrashHandlingStage(ExtendViewport(height, height), SpriteBatch())
+        stage = UncivStage(ExtendViewport(height, height), SpriteBatch())
 
         if (enableSceneDebug) {
             stage.setDebugUnderMouse(true)

--- a/core/src/com/unciv/ui/utils/ZoomableScrollPane.kt
+++ b/core/src/com/unciv/ui/utils/ZoomableScrollPane.kt
@@ -1,25 +1,122 @@
 package com.unciv.ui.utils
 
+import com.badlogic.gdx.math.Rectangle
+import com.badlogic.gdx.scenes.scene2d.Actor
+import com.badlogic.gdx.scenes.scene2d.Group
 import com.badlogic.gdx.scenes.scene2d.InputEvent
 import com.badlogic.gdx.scenes.scene2d.InputListener
 import com.badlogic.gdx.scenes.scene2d.ui.ScrollPane
 import com.badlogic.gdx.scenes.scene2d.utils.ActorGestureListener
+import com.badlogic.gdx.scenes.scene2d.utils.Cullable
 import kotlin.math.sqrt
 
 
-open class ZoomableScrollPane : ScrollPane(null) {
+open class ZoomableScrollPane(
+    val extraCullingX: Float = 0f,
+    val extraCullingY: Float = 0f,
+    var minZoom: Float = 0.5f,
+    var maxZoom: Float = 1 / minZoom // if we can halve the size, then by default also allow to double it
+) : ScrollPane(null) {
     var continuousScrollingX = false
 
-    var onPanStop: (() -> Unit)? = null
-    var onPanStart: (() -> Unit)? = null
+    var onViewportChangedListener: ((width: Float, height: Float, viewport: Rectangle) -> Unit)? = null
+    var onPanStopListener: (() -> Unit)? = null
+    var onPanStartListener: (() -> Unit)? = null
+
+    /**
+     * Exists so that we are always able to set the center to the edge of the contained actor.
+     * Otherwise, the [ScrollPane] would always stop at the actor's edge, keeping the center always ([width or height]/2) away from the edge.
+     * This is lateinit because unfortunately [ScrollPane] uses [setActor] in its constructor, and we override [setActor], so paddingGroup has not been
+     * constructed at that moment, throwing a NPE.
+     */
+    @Suppress("UNNECESSARY_LATEINIT")
+    private lateinit var paddingGroup: Group
+
+    private val horizontalPadding get() = width / 2
+    private val verticalPadding get() = height / 2
 
     init {
+        paddingGroup = Group()
+        super.setActor(paddingGroup)
+
         addZoomListeners()
     }
 
+    override fun setActor(actor: Actor?) {
+        if (!this::paddingGroup.isInitialized) return
+        paddingGroup.clearChildren()
+        paddingGroup.addActor(actor)
+    }
+
+    override fun getActor(): Actor? {
+        if (!this::paddingGroup.isInitialized || !paddingGroup.hasChildren()) return null
+        return paddingGroup.children[0]
+    }
+
+    override fun scrollX(pixelsX: Float) {
+        super.scrollX(pixelsX)
+        updateCulling()
+        onViewportChanged()
+    }
+
+    override fun scrollY(pixelsY: Float) {
+        super.scrollY(pixelsY)
+        updateCulling()
+        onViewportChanged()
+    }
+
+    override fun sizeChanged() {
+        updatePadding()
+        super.sizeChanged()
+        updateCulling()
+    }
+
+    private fun updatePadding() {
+        val content = actor
+        if (content == null) return
+        // Padding is always [dimension / 2] because we want to be able to have the center of the scrollPane at the very edge of the content
+        content.x = horizontalPadding
+        paddingGroup.width = content.width + horizontalPadding * 2
+        content.y = verticalPadding
+        paddingGroup.height = content.height + verticalPadding * 2
+    }
+
+    fun updateCulling() {
+        val content = actor
+        if (content !is Cullable) return
+
+        fun Rectangle.addInAllDirections(xDirectionIncrease: Float, yDirectionIncrease: Float): Rectangle {
+            x -= xDirectionIncrease
+            y -= yDirectionIncrease
+            width += xDirectionIncrease * 2
+            height += yDirectionIncrease * 2
+            return this
+        }
+
+        content.setCullingArea(
+            getViewport().addInAllDirections(extraCullingX, extraCullingY)
+        )
+    }
+
     open fun zoom(zoomScale: Float) {
-        if (zoomScale < 0.5f || zoomScale > 2f) return
+        if (zoomScale < minZoom || zoomScale > maxZoom) return
+
+        val previousScaleX = scaleX
+        val previousScaleY = scaleY
+
         setScale(zoomScale)
+
+        // When we scale, the width & height values stay the same. However, after scaling up/down, the width will be rendered wider/narrower than before.
+        // But we want to keep the size of the pane the same, so we do need to adjust the width & height: smaller if the scale increased, larger if it decreased.
+        val newWidth = width * previousScaleX / zoomScale
+        val newHeight = height * previousScaleY / zoomScale
+        setSize(newWidth, newHeight)
+
+        onViewportChanged()
+        // The size increase/decrease kept scrollX and scrollY (i.e. the top edge and left edge) the same - but changing the scale & size should have changed
+        // where the right and bottom edges are. This would mean our visual center moved. To correct this, we theoretically need to update the scroll position
+        // by half (i.e. middle) of what our size changed.
+        // However, we also changed the padding, which is exactly equal to half of our size change, so we actually don't need to move our center at all.
     }
     fun zoomIn() {
         zoom(scaleX / 0.8f)
@@ -64,7 +161,7 @@ open class ZoomableScrollPane : ScrollPane(null) {
             override fun pan(event: InputEvent, x: Float, y: Float, deltaX: Float, deltaY: Float) {
                 if (!wasPanning) {
                     wasPanning = true
-                    onPanStart?.invoke()
+                    onPanStartListener?.invoke()
                 }
                 setScrollbarsVisible(true)
                 scrollX -= deltaX
@@ -87,8 +184,24 @@ open class ZoomableScrollPane : ScrollPane(null) {
 
             override fun panStop(event: InputEvent?, x: Float, y: Float, pointer: Int, button: Int) {
                 wasPanning = false
-                onPanStop?.invoke()
+                onPanStopListener?.invoke()
             }
         }
+    }
+
+    /** @return the currently scrolled-to viewport of the whole scrollable area */
+    fun getViewport(): Rectangle {
+        val viewportFromLeft = scrollX
+        /** In the default coordinate system, the y origin is at the bottom, but scrollY is from the top, so we need to invert. */
+        val viewportFromBottom = maxY - scrollY
+        return Rectangle(
+            viewportFromLeft - horizontalPadding,
+            viewportFromBottom - verticalPadding,
+            width,
+            height)
+    }
+
+    private fun onViewportChanged() {
+        onViewportChangedListener?.invoke(maxX, maxY, getViewport())
     }
 }

--- a/core/src/com/unciv/ui/worldscreen/WorldMapHolder.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldMapHolder.kt
@@ -57,6 +57,28 @@ class WorldMapHolder(internal val worldScreen: WorldScreen, internal val tileMap
         if (Gdx.app.type == Application.ApplicationType.Desktop) this.setFlingTime(0f)
         continuousScrollingX = tileMap.mapParameters.worldWrap
         reloadMaxZoom()
+        disablePointerEventsAndActionsOnPan()
+    }
+
+    /**
+     * When scrolling the world map, there are two unnecessary (at least currently) things happening that take a decent amount of time:
+     *
+     * 1. Checking which [Actor]'s bounds the pointer (mouse/finger) entered+exited and sending appropriate events to these actors
+     * 2. Running all [Actor.act] methods of all child [Actor]s
+     *
+     * Disabling them while panning increases the frame rate while panning by approximately 100%.
+     */
+    private fun disablePointerEventsAndActionsOnPan() {
+        onPanStart = {
+            Log.debug("Disable pointer enter/exit events & TileGroupMap.act()")
+            (stage as UncivStage).performPointerEnterExitEvents = false
+            tileGroupMap.shouldAct = false
+        }
+        onPanStop = {
+            Log.debug("Enable pointer enter/exit events & TileGroupMap.act()")
+            (stage as UncivStage).performPointerEnterExitEvents = true
+            tileGroupMap.shouldAct = true
+        }
     }
 
     internal fun reloadMaxZoom() {

--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -615,10 +615,12 @@ class WorldScreen(val gameInfo: GameInfo, val viewingCiv:CivilizationInfo) : Bas
 
         // This is not the case if you have a multiplayer game where you play as 2 civs
         if (newWorldScreen.viewingCiv.civName == viewingCiv.civName) {
-            newWorldScreen.mapHolder.scrollX = mapHolder.scrollX
-            newWorldScreen.mapHolder.scrollY = mapHolder.scrollY
+            newWorldScreen.mapHolder.width = mapHolder.width
+            newWorldScreen.mapHolder.height = mapHolder.height
             newWorldScreen.mapHolder.scaleX = mapHolder.scaleX
             newWorldScreen.mapHolder.scaleY = mapHolder.scaleY
+            newWorldScreen.mapHolder.scrollX = mapHolder.scrollX
+            newWorldScreen.mapHolder.scrollY = mapHolder.scrollY
             newWorldScreen.mapHolder.updateVisualScroll()
         }
 
@@ -850,7 +852,6 @@ class WorldScreen(val gameInfo: GameInfo, val viewingCiv:CivilizationInfo) : Bas
         }
 //        topBar.selectedCivLabel.setText(Gdx.graphics.framesPerSecond) // for framerate testing
 
-        minimapWrapper.minimap.updateScrollPosition()
 
         super.render(delta)
     }


### PR DESCRIPTION
Again, while reviewing this, I'd suggest going through commit-by-commit.

This improves performance of world map panning on my phone by about 100%, from 12 to 24 fps.

This is mainly achieved by simply disabling two things while panning:

1. Pointer enter + exit events. These are simply completely useless while panning, as we only allow panning via pointer, so the only thing that's happening is that a bunch of pointer enter/exit events are fired on the tiles you move your pointer over while panning.
2. `WorldMapHolder.act()`. This means all `act()` of all the tiles, buttons & whatever within `WorldMapHolder` are not being executed, so no animations playing or anything else. This is currently, as far as I can see, only the city button sliding downward/upward when clicked and the spinning circle around unit icons. Of course, this might change in the future, but I think even then it is fine to have stuff temporarily paused while you're panning. Maybe when we add more animating things, this optimization could then only be done if `continuousRendering` is `true` instead of always like now.

Now a performance improvement PR would be nothing without measurements, so here is the call tree for when only pointer enter/exit events are enabled:

![image](https://user-images.githubusercontent.com/2777158/171306851-70a3d7ca-9b98-400d-8e83-64bfee396baa.png)

36.82% of the time spent on firing useless enter/exit events.

Now the `WorldMapHolder.act()` might be surprising, since we already have `ActionlessGroup` for almost everything within there... but believe it or not, simply iterating over all actors within `WorldMapHolder` for large maps is already a decent chunk:

![image](https://user-images.githubusercontent.com/2777158/171306988-a199ba3b-02ca-4bf0-a4ad-02f5053de1fc.png)

As you can see, 18.2% of the total time is spent solely for iterating over the actors. 31.46% total time for `WorldMapHolder.act`.

Now, there's also a third optimization, which basically had 0 effect that I didn't really expect. Before, the `WorldMapHolder` (which is a `ZoomableScrollPane`) always had the size of the maximum scrolled out state, so no matter how much you scrolled in or out, the size of the `WorldMapHolder` stayed the same. This meant that all tiles on maximal zoom out level were always rendered, even if you normally play zoomed in. On the map I tested with, that were around 1800 tiles rendered when fully zoomed out, and around 200-300 on a zoom level that you usually play at. Only rendering 200 instead of 1800 tiles made no measurable performance difference.

I left it and the refactoring I did of the `ZoomableScrollPane` & `WorldMapHolder` & `TileGroupMap`  in because I think it's a really good refactoring :D it basically moves the code within `TileGroupMap`, that is only responsible for getting the `ZoomableScrollPane` to work, to actually be within `ZoomableScrollPane` instead. Now `TileGroupMap` is simply responsible for putting its tiles on the screen, and `ZoomableScrollPane` is responsible for all things zooming and panning. This also moves a bunch of zoom/panning code from `WorldMapHolder` to `ZoomableScrollPane`.