### PR TITLE
Fix aircraft disappearing when their carrier is teleported

### DIFF
--- a/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
@@ -414,8 +414,7 @@ class DiplomacyManager() {
 
         if (bordersWereClosed) { // borders were closed, get out!
             for (unit in civInfo.getCivUnits()
-                .filter { it.currentTile.getOwner()?.civName == otherCivName}
-                .filterNot { it.isTransported }.toList()) { // transported units are moved when their transport is moved
+                .filter { it.currentTile.getOwner()?.civName == otherCivName}.toList()) {
                 unit.movement.teleportToClosestMoveableTile()
             }
         }

--- a/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
@@ -414,7 +414,7 @@ class DiplomacyManager() {
 
         if (bordersWereClosed) { // borders were closed, get out!
             for (unit in civInfo.getCivUnits()
-                .filter { it.currentTile.getOwner()?.civName == otherCivName}.toList()) {
+                .filter { it.currentTile.getOwner()?.civName == otherCivName }.toList()) {
                 unit.movement.teleportToClosestMoveableTile()
             }
         }

--- a/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
@@ -414,7 +414,8 @@ class DiplomacyManager() {
 
         if (bordersWereClosed) { // borders were closed, get out!
             for (unit in civInfo.getCivUnits()
-                .filter { it.currentTile.getOwner()?.civName == otherCivName }.toList()) {
+                .filter { it.currentTile.getOwner()?.civName == otherCivName}
+                .filterNot { it.isTransported }.toList()) { // transported units are moved when their transport is moved
                 unit.movement.teleportToClosestMoveableTile()
             }
         }

--- a/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
+++ b/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
@@ -394,6 +394,7 @@ class UnitMovementAlgorithms(val unit: MapUnit) {
                 if (allowedTile != null) break
             }
         }
+        val origin = unit.getTile()
         if (allowedTile != null) {
             unit.removeFromTile() // we "teleport" them away
             unit.putInTile(allowedTile)
@@ -401,6 +402,15 @@ class UnitMovementAlgorithms(val unit: MapUnit) {
             if (unit.isSleeping() || unit.isFortified())
                 unit.action = null
             unit.mostRecentMoveType = UnitMovementMemoryType.UnitTeleported
+
+            // bring along the payloads
+            val payloadUnits = origin.getUnits().filter { it.isTransported && unit.canTransport(it) }.toList()
+            for (payload in payloadUnits) {
+                payload.removeFromTile()
+                payload.putInTile(unit.getTile())
+                payload.isTransported = true // restore the flag to not leave the payload in the city
+                payload.mostRecentMoveType = UnitMovementMemoryType.UnitTeleported
+            }
         }
         // it's possible that there is no close tile, and all the guy's cities are full.
         // Nothing we can do.

--- a/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
+++ b/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
@@ -370,12 +370,12 @@ class UnitMovementAlgorithms(val unit: MapUnit) {
      * Displace a unit - choose a viable tile close by if possible and 'teleport' the unit there.
      * This will not use movement points or check for a possible route.
      * It is used e.g. if an enemy city expands its borders, or trades or diplomacy change a unit's
-     * allowed position. Does not move transported units by default but setting
-     * [forceMoveTransportedUnit] to true allows them to be moved.
+     * allowed position. Does not teleport transported units on their own, these are teleported when
+     * the transporting unit is moved.
      * CAN DESTROY THE UNIT.
      */
-    fun teleportToClosestMoveableTile(forceMoveTransportedUnit: Boolean = false) {
-        if (unit.isTransported && !forceMoveTransportedUnit) return // handled when carrying unit is teleported
+    fun teleportToClosestMoveableTile() {
+        if (unit.isTransported) return // handled when carrying unit is teleported
         var allowedTile: TileInfo? = null
         var distance = 0
         // When we didn't limit the allowed distance the game would sometimes spend a whole minute looking for a suitable tile.
@@ -409,7 +409,7 @@ class UnitMovementAlgorithms(val unit: MapUnit) {
             val payloadUnits = origin.getUnits().filter { it.isTransported && unit.canTransport(it) }.toList()
             for (payload in payloadUnits) {
                 payload.removeFromTile()
-                payload.putInTile(unit.getTile())
+                payload.putInTile(allowedTile)
                 payload.isTransported = true // restore the flag to not leave the payload in the city
                 payload.mostRecentMoveType = UnitMovementMemoryType.UnitTeleported
             }

--- a/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
+++ b/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
@@ -385,6 +385,7 @@ class UnitMovementAlgorithms(val unit: MapUnit) {
                 // out of those where it can be placed, can it reach them in any meaningful way?
                 .firstOrNull { getPathBetweenTiles(unit.currentTile, it).size > 1 }
         }
+        if (unit.isTransported) return // handled when carrying unit is teleported
 
         // No tile within 4 spaces? move him to a city.
         if (allowedTile == null) {

--- a/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
+++ b/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
@@ -370,10 +370,12 @@ class UnitMovementAlgorithms(val unit: MapUnit) {
      * Displace a unit - choose a viable tile close by if possible and 'teleport' the unit there.
      * This will not use movement points or check for a possible route.
      * It is used e.g. if an enemy city expands its borders, or trades or diplomacy change a unit's
-     * allowed position.
+     * allowed position. Does not teleport transported units which are instead teleported when the
+     * transport is teleported.
      * CAN DESTROY THE UNIT.
      */
     fun teleportToClosestMoveableTile() {
+        if (unit.isTransported) return // handled when carrying unit is teleported
         var allowedTile: TileInfo? = null
         var distance = 0
         // When we didn't limit the allowed distance the game would sometimes spend a whole minute looking for a suitable tile.
@@ -385,7 +387,6 @@ class UnitMovementAlgorithms(val unit: MapUnit) {
                 // out of those where it can be placed, can it reach them in any meaningful way?
                 .firstOrNull { getPathBetweenTiles(unit.currentTile, it).size > 1 }
         }
-        if (unit.isTransported) return // handled when carrying unit is teleported
 
         // No tile within 4 spaces? move him to a city.
         if (allowedTile == null) {

--- a/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
+++ b/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
@@ -370,12 +370,12 @@ class UnitMovementAlgorithms(val unit: MapUnit) {
      * Displace a unit - choose a viable tile close by if possible and 'teleport' the unit there.
      * This will not use movement points or check for a possible route.
      * It is used e.g. if an enemy city expands its borders, or trades or diplomacy change a unit's
-     * allowed position. Does not teleport transported units which are instead teleported when the
-     * transport is teleported.
+     * allowed position. Does not move transported units by default but setting
+     * [forceMoveTransportedUnit] to true allows them to be moved.
      * CAN DESTROY THE UNIT.
      */
-    fun teleportToClosestMoveableTile() {
-        if (unit.isTransported) return // handled when carrying unit is teleported
+    fun teleportToClosestMoveableTile(forceMoveTransportedUnit: Boolean = false) {
+        if (unit.isTransported && !forceMoveTransportedUnit) return // handled when carrying unit is teleported
         var allowedTile: TileInfo? = null
         var distance = 0
         // When we didn't limit the allowed distance the game would sometimes spend a whole minute looking for a suitable tile.

--- a/tests/src/com/unciv/logic/map/UnitMovementAlgorithmsTests.kt
+++ b/tests/src/com/unciv/logic/map/UnitMovementAlgorithmsTests.kt
@@ -484,8 +484,8 @@ class UnitMovementAlgorithmsTests {
 
         // simulate ejecting all units within foreign territory
         for (unit in civInfo.getCivUnits()) unit.movement.teleportToClosestMoveableTile()
-        Assert.assertTrue("Transport and transported unit must be teleported to the same tile",
-            civInfo.getCivUnits().all { it.getTile() == newTiles.last() })
+        Assert.assertTrue("Transport and transported units must be teleported to the same tile",
+            civInfo.getCivUnits().toList().size == 3 && civInfo.getCivUnits().all { it.getTile() == newTiles.last() })
     }
 
 }

--- a/tests/src/com/unciv/logic/map/UnitMovementAlgorithmsTests.kt
+++ b/tests/src/com/unciv/logic/map/UnitMovementAlgorithmsTests.kt
@@ -484,10 +484,8 @@ class UnitMovementAlgorithmsTests {
 
         // simulate ejecting all units within foreign territory
         for (unit in civInfo.getCivUnits()) unit.movement.teleportToClosestMoveableTile()
-        val success = unit.currentTile == newTiles.last()
-                && fighters.all { it.getTile() == unit.getTile() && it.isTransported }
-
-        Assert.assertTrue("Transport and transported unit must be teleported to the same tile", success)
+        Assert.assertTrue("Transport and transported unit must be teleported to the same tile",
+            civInfo.getCivUnits().all { it.getTile() == newTiles.last() })
     }
 
 }

--- a/tests/src/com/unciv/logic/map/UnitMovementAlgorithmsTests.kt
+++ b/tests/src/com/unciv/logic/map/UnitMovementAlgorithmsTests.kt
@@ -466,6 +466,7 @@ class UnitMovementAlgorithmsTests {
         unit.civInfo = civInfo
         unit.baseUnit.uniques.add("Can carry [2] [Aircraft] units")
         unit.updateUniques(ruleSet)
+        civInfo.addUnit(unit, false)
 
         val fighters = ArrayList<MapUnit>()
         for (i in 0..1) {
@@ -477,10 +478,12 @@ class UnitMovementAlgorithmsTests {
             tile.airUnits += newFighter
             newFighter.name = "Fighter"
             newFighter.isTransported = true
+            civInfo.addUnit(newFighter, false)
             fighters += newFighter
         }
 
-        unit.movement.teleportToClosestMoveableTile()
+        // simulate ejecting all units within foreign territory
+        for (unit in civInfo.getCivUnits()) unit.movement.teleportToClosestMoveableTile()
         val success = unit.currentTile == newTiles.last()
                 && fighters.all { it.getTile() == unit.getTile() && it.isTransported }
 

--- a/tests/src/com/unciv/logic/map/UnitMovementAlgorithmsTests.kt
+++ b/tests/src/com/unciv/logic/map/UnitMovementAlgorithmsTests.kt
@@ -100,7 +100,7 @@ class UnitMovementAlgorithmsTests {
             if (terrain.impassable) continue
             tile.baseTerrain = terrain.name
             tile.setTransients()
-            
+
             for (type in ruleSet.unitTypes) {
                 unit.baseUnit = BaseUnit().apply { unitType = type.key; ruleset = ruleSet }
                 Assert.assertTrue("%s cannot be at %s".format(type.key, terrain.name),
@@ -197,7 +197,7 @@ class UnitMovementAlgorithmsTests {
             civInfo.tech.techsResearched.remove("Astronomy")
 
             Assert.assertTrue("$type cannot be in Ocean until Astronomy",
-                    (unit.baseUnit.isMelee() || unit.baseUnit.isRanged()) 
+                    (unit.baseUnit.isMelee() || unit.baseUnit.isRanged())
                                 != unit.movement.canPassThrough(tile))
 
             civInfo.tech.techsResearched.add("Astronomy")
@@ -208,7 +208,7 @@ class UnitMovementAlgorithmsTests {
     fun canNOTPassThroughTileWithEnemyUnits() {
         tile.baseTerrain = Constants.grassland
         tile.setTransients()
-        
+
         unit.currentTile = tile
 
         val otherCiv = CivilizationInfo()
@@ -449,6 +449,42 @@ class UnitMovementAlgorithmsTests {
 
         Assert.assertTrue("Civilian unit must be captured by teleported unit",
             unit.currentTile == newTiles.last() && otherUnit.civInfo == unit.civInfo)
+    }
+
+    @Test
+    fun `can teleport transport and its transported units to the same tile`() {
+        civInfo.nation.name = Constants.spectator
+
+        tile.baseTerrain = Constants.ocean
+        tile.position.set(0f, 0f)
+        tile.setTransients()
+        createOpponentCivAndCity()
+        val newTiles = generateTileCopies(3)
+
+        setupMilitaryUnitInTheCurrentTile("Aircraft Carrier")
+        unit.owner = civInfo.civName
+        unit.civInfo = civInfo
+        unit.baseUnit.uniques.add("Can carry [2] [Aircraft] units")
+        unit.updateUniques(ruleSet)
+
+        val fighters = ArrayList<MapUnit>()
+        for (i in 0..1) {
+            val newFighter = MapUnit()
+            newFighter.baseUnit = BaseUnit().apply { unitType = "Fighter"; ruleset = ruleSet }
+            newFighter.owner = civInfo.civName
+            newFighter.civInfo = civInfo
+            newFighter.currentTile = unit.getTile()
+            tile.airUnits += newFighter
+            newFighter.name = "Fighter"
+            newFighter.isTransported = true
+            fighters += newFighter
+        }
+
+        unit.movement.teleportToClosestMoveableTile()
+        val success = unit.currentTile == newTiles.last()
+                && fighters.all { it.getTile() == unit.getTile() && it.isTransported }
+
+        Assert.assertTrue("Transport and transported unit must be teleported to the same tile", success)
     }
 
 }


### PR DESCRIPTION
Fixes #7032 by ensuring that transports bring their carried units with them when teleported (by open borders closing for example). All cases of `teleportToClosestMoveableTile()` are handled (in theory), and a new unit test was created to make sure that teleported carriers and their cargo are teleported to the same tile. `teleportToClosestMoveableTile()` will immediately return if called on a transported unit but this function has been given an optional boolean argument that allows for transported units to be teleported just like any other units if the boolean is set to true. By default this argument is false. The below image shows the linked save from #7032 but after a successful teleportation with the red dot being the carrier's location before being ejected.

![Successful teleportation](https://files.catbox.moe/36bthg.jpg)