### PR TITLE
Fix editor zoom in

### DIFF
--- a/core/src/com/unciv/ui/mapeditor/EditorMapHolder.kt
+++ b/core/src/com/unciv/ui/mapeditor/EditorMapHolder.kt
@@ -31,8 +31,6 @@ class EditorMapHolder(
     private lateinit var tileGroupMap: TileGroupMap<TileGroup>
     private val allTileGroups = ArrayList<TileGroup>()
 
-    private val maxWorldZoomOut = UncivGame.Current.settings.maxWorldZoomOut
-
     private var blinkAction: Action? = null
 
     private var savedCaptureListeners = emptyList<EventListener>()
@@ -91,9 +89,7 @@ class EditorMapHolder(
                 tileGroup.onClick { onTileClick(tileGroup.tileInfo) }
         }
 
-        setSize(stage.width * maxWorldZoomOut, stage.height * maxWorldZoomOut)
-        setOrigin(width / 2,height / 2)
-        center(stage)
+        setSize(stage.width, stage.height)
 
         layout()
 


### PR DESCRIPTION
Fix the editor map holder being the wrong size (introduced in #7034), causing the center to be at a wrong place & not the whole map being visible.