### PR TITLE
spectators can no longer move and attack with units after selecting them

### DIFF
--- a/core/src/com/unciv/ui/worldscreen/WorldMapHolder.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldMapHolder.kt
@@ -216,34 +216,36 @@ class WorldMapHolder(
     }
 
     private fun onTileRightClicked(unit: MapUnit, tile: TileInfo) {
-        removeUnitActionOverlay()
-        selectedTile = tile
-        unitMovementPaths.clear()
-        worldScreen.shouldUpdate = true
-
-        if (worldScreen.bottomUnitTable.selectedUnitIsSwapping) {
-            if (unit.movement.canUnitSwapTo(tile)) {
-                swapMoveUnitToTargetTile(unit, tile)
-            }
-            // If we are in unit-swapping mode, we don't want to move or attack
-            return
-        }
-
-        val attackableTile = BattleHelper.getAttackableEnemies(unit, unit.movement.getDistanceToTiles())
-            .firstOrNull { it.tileToAttack == tile }
-        if (unit.canAttack() && attackableTile != null) {
+        if (!UncivGame.Current.gameInfo.currentPlayerCiv.isSpectator()) {
+            removeUnitActionOverlay()
+            selectedTile = tile
+            unitMovementPaths.clear()
             worldScreen.shouldUpdate = true
-            val attacker = MapUnitCombatant(unit)
-            if (!Battle.movePreparingAttack(attacker, attackableTile)) return
-            Sounds.play(attacker.getAttackSound())
-            Battle.attackOrNuke(attacker, attackableTile)
-            return
-        }
 
-        val canUnitReachTile = unit.movement.canReach(tile)
-        if (canUnitReachTile) {
-            moveUnitToTargetTile(listOf(unit), tile)
-            return
+            if (worldScreen.bottomUnitTable.selectedUnitIsSwapping) {
+                if (unit.movement.canUnitSwapTo(tile)) {
+                    swapMoveUnitToTargetTile(unit, tile)
+                }
+                // If we are in unit-swapping mode, we don't want to move or attack
+                return
+            }
+
+            val attackableTile = BattleHelper.getAttackableEnemies(unit, unit.movement.getDistanceToTiles())
+                .firstOrNull { it.tileToAttack == tile }
+            if (unit.canAttack() && attackableTile != null) {
+                worldScreen.shouldUpdate = true
+                val attacker = MapUnitCombatant(unit)
+                if (!Battle.movePreparingAttack(attacker, attackableTile)) return
+                Sounds.play(attacker.getAttackSound())
+                Battle.attackOrNuke(attacker, attackableTile)
+                return
+            }
+
+            val canUnitReachTile = unit.movement.canReach(tile)
+            if (canUnitReachTile) {
+                moveUnitToTargetTile(listOf(unit), tile)
+                return
+            }
         }
     }
 


### PR DESCRIPTION
No matter what I do Github makes it hard to read so:
I added 
```Kotlin
if (!UncivGame.Current.gameInfo.currentPlayerCiv.isSpectator()) { 
    //code 
}
```
 on the code when you right click after selecting a unit as this caused many issues mentioned in #4460