### PR TITLE
Moddable prettier Tutorials - Step 1

### DIFF
--- a/android/assets/jsons/Tutorials.json
+++ b/android/assets/jsons/Tutorials.json
@@ -1,140 +1,243 @@
-{
-  // Each entry s a tutorial, but the tutorial may be spread over separate paragraphs.
-  // Entries starting with a _ will NOT be shown in Civilopedia.
-  //
+[
+  // Each entry is a tutorial, but the tutorial may be spread over separate paragraphs.
 
-  Introduction: [
+  {
+    "name": "Introduction",
+    "steps": [
       "Welcome to Unciv!\nBecause this is a complex game, there are basic tasks to help familiarize you with the game.\nThese are completely optional, and you're welcome to explore the game on your own!"
-  ],
+    ]
+  },
 
   // Civilopedia only, because players said this was too wall-of-text
-  New_Game: [
+  {
+    "name": "New Game",
+    "steps": [
       "Your first mission is to found your capital city.\nThis is actually an important task because your capital city will probably be your most prosperous.\nMany game bonuses apply only to your capital city and it will probably be the center of your empire.",
       "How do you know a spot is appropriate?\nThat’s not an easy question to answer, but looking for and building next to luxury resources is a good rule of thumb.\nLuxury resources are tiles that have things like gems, cotton, or silk (indicated by a smiley next to the resource icon)\nThese resources make your civilization happy. You should also keep an eye out for resources needed to build units, such as iron. Cities cannot be built within 3 tiles of existing cities, which is another thing to watch out for!",
       "However, cities don’t have a set area that they can work - more on that later!\nThis means you don’t have to settle cities right next to resources.\nLet’s say, for example, that you want access to some iron – but the resource is right next to a desert.\nYou don’t have to settle your city next to the desert. You can settle a few tiles away in more prosperous lands.\nYour city will grow and eventually gain access to the resource.\nYou only need to settle right next to resources if you need them immediately – \n   which might be the case now and then, but you’ll usually have the luxury of time."    ,
       "The first thing coming out of your city should be either a Scout or Warrior.\nI generally prefer the Warrior because it can be used for defense and because it can be upgraded\n  to the Swordsman unit later in the game for a relatively modest sum of gold.\nScouts can be effective, however, if you seem to be located in an area of dense forest and hills.\nScouts don’t suffer a movement penalty in this terrain.\nIf you’re a veteran of the 4x strategy genre your first Warrior or Scout will be followed by a Settler.\nFast expanding is absolutely critical in most games of this type."
-  ],
-  _Slow_Start: [
+    ]
+  },
+  {
+    "name": "Slow Start",
+    "steps": [
       "In your first couple of turns, you will have very little options, but as your civilization grows, so do the number of things requiring your attention."
-  ],
-  Culture_and_Policies: [
+    ],
+    "uniques": ["Will not be displayed in Civilopedia"]
+  },
+  {
+    "name": "Culture and Policies",
+    "steps": [
       "Each turn, the culture you gain from all your cities is added to your Civilization's culture.\nWhen you have enough culture, you may pick a Social Policy, each one giving you a certain bonus."	,
       "The policies are organized into branches, with each branch providing a bonus ability when all policies in the branch have been adopted."    ,
       "With each policy adopted, and with each city built,\n  the cost of adopting another policy rises - so choose wisely!"
-  ],
-  City_Expansion: [
+    ]
+  },
+  {
+    "name": "City Expansion",
+    "steps": [
 	"Once a city has gathered enough Culture, it will expand into a neighboring tile.\nYou have no control over the tile it will expand into, but tiles with resources and higher yields are prioritized.",
 	"Each additional tile will require more culture, but generally your first cities will eventually expand to a wide tile range.",
 	"Although your city will keep expanding forever, your citizens can only work 3 tiles away from city center.\nThis should be taken into account when placing new cities."
-  ],
-  Happiness: [
+    ]
+  },
+  {
+    "name": "Happiness",
+    "steps": [
       "As cities grow in size and influence, you have to deal with a happiness mechanic that is no longer tied to each individual city.\nInstead, your entire empire shares the same level of satisfaction.\nAs your cities grow in population you’ll find that it is more and more difficult to keep your empire happy."    ,
       "In addition, you can’t even build any city improvements that increase happiness until you’ve done the appropriate research.\nIf your empire’s happiness ever goes below zero the growth rate of your cities will be hurt.\nIf your empire becomes severely unhappy (as indicated by the smiley-face icon at the top of the interface)\n  your armies will have a big penalty slapped on to their overall combat effectiveness."    ,
       "This means that it is very difficult to expand quickly in Unciv.\nIt isn’t impossible, but as a new player you probably shouldn't do it.\nSo what should you do? Chill out, scout, and improve the land that you do have by building Workers.\nOnly build new cities once you have found a spot that you believe is appropriate."
-  ],
-  Unhappiness: [
+    ]
+  },
+  {
+    "name": "Unhappiness",
+    "steps": [
       "It seems that your citizens are unhappy!\nWhile unhappy, your civilization will suffer many detrimental effects, increasing in severity as unhappiness gets higher.",
       "Unhappiness has two main causes: Population and cities.\n  Each city causes 3 unhappiness, and each population, 1",
       "There are 2 main ways to combat unhappiness:\n  by building happiness buildings for your population\n  or by having improved luxury resources within your borders."
-  ],
-  Golden_Age: [
+    ]
+  },
+  {
+    "name": "Golden Age",
+    "steps": [
       "You have entered a Golden Age!\nGolden age points are accumulated each turn by the total happiness \n  of your civilization\nWhen in a golden age, culture and production generation increases +20%,\n  and every tile already providing at least one gold will provide an extra gold."
-  ],
+    ]
+  },
 
-  Roads_and_Railroads: [
+  {
+    "name": "Roads and Railroads",
+    "steps": [
       "Connecting your cities to the capital by roads\n  will generate gold via the trade route.\nNote that each road costs 1 gold Maintenance per turn, and each Railroad costs 2 gold,\n  so it may be more economical to wait until the cities grow!"
-  ],
-  Victory_Types: [
+    ]
+  },
+  {
+    "name": "Victory Types",
+    "steps": [
       "Once you’ve settled your first two or three cities you’re probably 100 to 150 turns into the game.\nNow is a good time to start thinking about how, exactly, you want to win – if you haven’t already.",
       "There are four ways to win in Unciv. They are:\n - Cultural Victory: Complete 5 Social Policy Trees and build the Utopia Project\n - Domination Victory: Survive as the last civilization\n - Science Victory: Be the first to construct a spaceship to Alpha Centauri\n - Diplomatic Victory: Build the United Nations and win the vote",
       "So to sum it up, these are the basics of Unciv – Found a prosperous first city, expand slowly to manage happiness, and set yourself up for the victory condition you wish to pursue.\nObviously, there is much more to it than that, but it is important not to jump into the deep end before you know how to swim."
-  ],
-  Enemy_City: [
+    ]
+  },
+  {
+    "name": "Enemy City",
+    "steps": [
       "Cities can be conquered by reducing their health to 1, and entering the city with a melee unit.\nSince cities heal each turn, it is best to attack with ranged units and use your melee units to defend them until the city has been defeated!"
-  ],
-  Luxury_Resource: [
+    ]
+  },
+  {
+    "name": "Luxury Resource",
+    "steps": [
       "Luxury resources within your domain and with their specific improvement are connected to your trade network.\nEach unique Luxury resource you have adds 5 happiness to your civilization, but extra resources of the same type don't add anything, so use them for trading with other civilizations!"
-  ],
-  Strategic_Resource: [
+    ]
+  },
+  {
+    "name": "Strategic Resource",
+    "steps": [
       "Strategic resources within your domain and with their specific improvement are connected to your trade network.\nStrategic resources allow you to train units and construct buildings that require those specific resources, for example the Horseman requires Horses.",
 	  "Unlike Luxury Resources, each Strategic Resource on the map provides more than one of that resource.\nThe top bar keeps count of how many unused strategic resources you own.\nA full drilldown of resources is available in the Resources tab in the Overview screen."
-  ],
-  _EnemyCityNeedsConqueringWithMeleeUnit: [
+    ]
+  },
+  {
+    "name": "EnemyCityNeedsConqueringWithMeleeUnit",
+    "steps": [
       "The city can no longer put up any resistance!\nHowever, to conquer it, you must enter the city with a melee unit"
-  ],
-  After_Conquering: [
+    ],
+    "uniques": ["Will not be displayed in Civilopedia"]
+  },
+  {
+    "name": "After Conquering",
+    "steps": [
       "When conquering a city, you can choose to liberate, annex, puppet, or raze the city.",
       "\nLiberating the city will return it to its original owner, giving you a massive diplomatic boost with them!\n\nAnnexing the city will give you full control over it, but also increase the citizens' unhappiness to 2x!\nThis can be mitigated by building a courthouse in the city, returning the citizen's unhappiness to normal.\n\nPuppeting the city will mean that you have no control on the city's production.\nThe city will not increase your tech or policy cost, but its citizens will generate 1.5x the regular unhappiness.\nA puppeted city can be annexed at any time, but annexed cities cannot be returned to a puppeted state!\n\nRazing the city will lower its population by 1 each turn until the city is destroyed!\nYou cannot raze a city that is either the starting capital of a civilization or the holy city of a religion."
-  ],
-  _BarbarianEncountered: [
+    ]
+  },
+  {
+    "name": "BarbarianEncountered",
+    "steps": [
       "You have encountered a barbarian unit!\nBarbarians attack everyone indiscriminately, so don't let your \n  civilian units go near them, and be careful of your scout!"
-  ],
-  _OtherCivEncountered: [
+    ],
+    "uniques": ["Will not be displayed in Civilopedia"]
+  },
+  {
+    "name": "OtherCivEncountered",
+    "steps": [
       "You have encountered another civilization!\nOther civilizations start out peaceful, and you can trade with them,\n  but they may choose to declare war on you later on"
-  ],
-  Apollo_Program: [
+    ],
+    "uniques": ["Will not be displayed in Civilopedia"]
+  },
+  {
+    "name": "Apollo Program",
+    "steps": [
       "Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities\n (with the relevant technologies) to win a Scientific Victory!"
-  ],
-  Injured_Units: [
+    ]
+  },
+  {
+    "name": "Injured Units",
+    "steps": [
       "Injured units deal less damage, but recover after turns that they have been inactive.\nUnits heal 10 health per turn in enemy territory or neutral land,\n  20 inside your territory and 25 in your cities."
-  ],
-  Workers: [
+    ]
+  },
+  {
+    "name": "Workers",
+    "steps": [
       "Workers are vital to your cities' growth, since only they can construct improvements on tiles.\nImprovements raise the yield of your tiles, allowing your city to produce more and grow faster while working the same amount of tiles!"
-  ],
-  Siege_Units: [
+    ]
+  },
+  {
+    "name": "Siege Units",
+    "steps": [
       "Siege units are extremely powerful against cities, but need to be Set Up before they can attack.\nOnce your siege unit is set up, it can attack from the current tile,\n  but once moved to another tile, it will need to be set up again."
-  ],
-  Embarking: [
+    ]
+  },
+  {
+    "name": "Embarking",
+    "steps": [
       "Once a certain tech is researched, your land units can embark, allowing them to traverse water tiles.\nEntering or leaving water takes the entire turn.",
       "Units are defenseless while embarked (cannot use modifiers), and have a fixed Defending Strength based on your tech Era, so be careful!\nRanged Units can't attack, Melee Units have a Strength penalty, and all have limited vision."
-  ],
-  Idle_Units: [
+    ]
+  },
+  {
+    "name": "Idle Units",
+    "steps": [
       "If you don't want to move a unit this turn, you can skip it by clicking 'Next unit' again.\nIf you won't be moving it for a while, you can have the unit enter Fortify or Sleep mode - \n  units in Fortify or Sleep are not considered idle units.\nIf you want to disable the 'Next unit' feature entirely, you can toggle it in Menu -> Check for idle units."
-  ],
-  Contact_Me: [
+    ]
+  },
+  {
+    "name": "Contact Me",
+    "steps": [
       "Hi there! If you've played this far, you've probably seen that the game is currently incomplete.\n UnCiv is meant to be open-source and free, forever.\n That means no ads or any other nonsense.",
       "What motivates me to keep working on it, \n  besides the fact I think it's amazingly cool that I can,\n  is the support from the players - you guys are the best!",
       "Every rating and review that I get puts a smile on my face =)\n  So contact me! Send me an email, review, Github issue\n  or mail pigeon, and let's figure out how to make the game \n  even more awesome!\n(Contact info is in the Play Store)"
-  ],
-  Pillaging: [
+    ]
+  },
+  {
+    "name": "Pillaging",
+    "steps": [
       "Military units can pillage improvements, which heals them 25 health and ruins the improvement.\nThe tile can still be worked, but advantages from the improvement - stat bonuses and resources - will be lost.\nWorkers can repair these improvements, which takes less time than building the improvement from scratch.\nPillaging certain improvements will result in your units looting gold from the improvement."
-  ],
-  Experience: [
+    ]
+  },
+  {
+    "name": "Experience",
+    "steps": [
 	"Units that enter combat gain experience, which can then be used on promotions for that unit.\nUnits gain more experience when in Melee combat than Ranged, and more when attacking than when defending.",
 	"Units can only gain up to 30 XP from Barbarian units - meaning up to 2 promotions. After that, Barbarian units will provide no experience."
-  ],
-  Combat: [
+    ]
+  },
+  {
+    "name": "Combat",
+    "steps": [
 	"Unit and cities are worn down by combat, which is affected by a number of different values.\nEach unit has a certain 'base' combat value, which can be improved by certain conditions, promotions and locations.",
 	"Units use the 'Strength' value as the base combat value when melee attacking and when defending.\nWhen using a ranged attack, they will the use the 'Ranged Strength' value instead.",
 	"Ranged attacks can be done from a distance, dependent on the 'Range' value of the unit.\nWhile melee attacks allow the defender to damage the attacker in retaliation, ranged attacks do not."
-  ],
-  Research_Agreements: [
+    ]
+  },
+  {
+    "name": "Research Agreements",
+    "steps": [
 	"In research agreements, you and another civilization decide to jointly research technology.\nAt the end of the agreement, you will both receive a 'lump sum' of Science, which will go towards one of your unresearched technologies.",
 	"The amount of ⍾Science you receive at the end is dependent on the ⍾Science generated by your cities and the other civilization's cities during the agreement - the more, the better!"
-  ],
-  City-States: [
+    ]
+  },
+  {
+    "name": "City-States",
+    "steps": [
 	"Not all nations are contending with you for victory.\nCity-States are nations that can't win, don't conquer other cities and can't be traded with.",
 	"Instead, diplomatic relations with City-States are determined by Influence - a meter of 'how much the City-State likes you'.\nInfluence can be increased by attacking their enemies, liberating their city, and giving them sums of gold.",
 	"Certain bonuses are given when you are at above 30 influence.\nWhen you have above 60 Influence, and you have the highest influence with them of all civilizations, you are considered their 'Ally', and gain further bonuses and access to the Luxury and Strategic resources in their lands."
-  ],
-  Great_People: [
+    ]
+  },
+  {
+    "name": "Great People",
+    "steps": [
 	"Certain buildings, and specialists in cities, generate Great Person points per turn.\nThere are several types of Great People, and their points accumulate separately.\nThe number of points per turn and accumulated points can be viewed in the Overview screen.",
 	"Once enough points have been accumulated, a Great Person of that type will be created!\nEach Great Person can construct a certain Great Improvement which gives large yields over time, or immediately consumed to provide a certain bonus now.",
 	"Great Improvements also provide any strategic resources that are under them, so you don't need to worry if resources are revealed underneath your improvements!"
-  ],
-  Removing_Terrain_Features: [
+    ]
+  },
+  {
+    "name": "Removing Terrain Features",
+    "steps": [
 	"Certain tiles have terrain features - like Flood plains or Forests -  on top of them. Some of these layers, like Jungle, Marsh and Forest, can be removed by workers.\nRemoving the terrain feature does not remove any resources in the tile, and is usually required in order to add improvements exploiting those resources."
-  ],
-  Natural_Wonders: [
+    ]
+  },
+  {
+    "name": "Natural Wonders",
+    "steps": [
     "Natural Wonders, such as the Mt. Fuji, the Rock of Gibraltar and the Great Barrier Reef, are unique, impassable terrain features, masterpieces of mother Nature, which possess exceptional qualities that make them very different from the average terrain.\nThey benefit by giving you large sums of Culture, Science, Gold or Production if worked by your Cities, which is why you might need to bring them under your empire as soon as possible."
-  ],
-  "Keyboard": [
+    ]
+  },
+  {
+    "name": "Keyboard",
+    "steps": [
     "If you have a keyboard, some shortcut keys become available. Unit command or improvement picker keys, for example, are shown directly in their corresponding buttons.",
     "On the world screen the hotkeys are as follows:", "Space or 'N' - Next unit or turn\n'E' - Empire overview (last viewed page)\n'+', '-' - Zoom in / out\nHome - center on capital or open its city screen if already centered",
     "F1 - Open Civilopedia\nF2 - Empire overview Trades\nF3 - Empire overview Units\nF4 - Empire overview Diplomacy\nF5 - Social policies\nF6 - Technologies\nF7 - Empire overview Cities\nF8 - Victory Progress\nF9 - Empire overview Stats\nF10 - Empire overview Resources\nF11 - Quicksave\nF12 - Quickload",
     "Ctrl-R - Toggle tile resource display\nCtrl-Y - Toggle tile yield display\nCtrl-O - Game options\nCtrl-S - Save game\nCtrl-L - Load game"
-  ],
-  "World_Screen": [
+    ]
+  },
+  {
+    "name": "World Screen",
+    "steps": [
     "",
     "This is where you spend most of your time playing Unciv. See the world, control your units, access other screens from here.",
     "",
@@ -169,15 +272,21 @@
     "ⓨ: By the way, here's how an empire border looks like - it's in the national colours of the nation owning the territory.",
     "ⓩ: And this is the red targeting circle that led to the attack pane back under ⑬.",
     "What you don't see: The phone/tablet's back button will pop the question whether you wish to leave Unciv and go back to Real Life. On desktop versions, you can use the ESC key."
-  ],
-    "Faith": [
+    ]
+  },
+  {
+    "name": "Faith",
+    "steps": [
         "After building a shrine, your civilization will start generating ☮Faith.",
         "When enough ☮Faith has been generated, you will be able to found a pantheon.",
         "A pantheon will provide a small bonus for your civilization that will apply to all your cities.",
         "Each civilization can only choose a single pantheon belief, and each pantheon can only be chosen once.",
         "Generating more ☮Faith will allow you to found a religion."
-    ],
-    "Religion": [
+      ]
+  },
+  {
+    "name": "Religion",
+    "steps": [
         "Keep generating ☮Faith, and eventually a great prophet will be born in one of your cities.",
         "This great prophet can be used for multiple things: Constructing a holy site, founding a religion and spreading your religion.",
         "When founding your religion, you may choose another two beliefs. The founder belief will only apply to you, while the follower belief will apply to all cities following your religion.",
@@ -186,12 +295,18 @@
         "One of these great prophets can then be used to enhance your religion.",
         "This will allow you to choose another follower belief, as well as an enhancer belief, that only applies to you.",
         "Do take care founding a religion soon, only about half the players in the game are able to found a religion!"
-    ],
-    "Beliefs": [
+      ]
+  },
+  {
+    "name": "Beliefs",
+    "steps": [
         "There are four types of beliefs: Pantheon, Founder, Follower and Enhancer beliefs.",
         "Pantheon and Follower beliefs apply to each city following your religion, while Founder and Enhancer beliefs only apply to the founder of a religion."
-    ],
-    "Religion_inside_cities": [
+      ]
+  },
+  {
+    "name": "Religion inside cities",
+    "steps": [
         "When founding a city, it won't follow a religion immediately.",
         "The religion a city follows depends on the total pressure each religion has within the city.",
         "Followers are allocated in the same proportions as these pressures, and these followers can be viewed in the city screen.",
@@ -199,8 +314,11 @@
         "In both places, a tap/click on the icon of a religion will show detailed information with its effects.",
         "Based on this, you can get a feel for which religions have a lot of pressure built up in the city, and which have almost none.",
         "The city follows a religion if a majority of its population follows that religion, and will only then receive the effects of Follower and Pantheon beliefs of that religion."
-    ],
-    "Spreading_Religion": [
+      ]
+  },
+  {
+    "name": "Spreading Religion",
+    "steps": [
         "Spreading religion happens naturally, but can be sped up using missionaries or great prophets.",
         "Missionaries can be bought in cities following a major religion, and will take the religion of that city.",
         "So do take care where you are buying them! If another civilization has converted one of your cities to their religion, missionaries bought there will follow their religion.",
@@ -217,25 +335,35 @@
         "Holy cities also provide +30 pressure of the religion founded there to themselves, making it very difficult to effectively convert a holy city.",
         "Lastly, before founding a religion, new cities you settle will start with 200 pressure for your pantheon.",
         "This way, all your cities will starting following your pantheon as long as you haven't founded a religion yet."
-    ],
-    "Inquisitors": [
+      ]
+  },
+  {
+    "name": "Inquisitors",
+    "steps": [
         "Inquisitors are the last religious unit, and their strength is removing other religions.",
         "They can remove all other religions from one of your own cities, removing any pressures built up.",
         "Great prophets also have this ability, and remove all other religions in the city when spreading their religion.",
         "Often this results in the city immediately converting to their religion",
         "Additionally, when an inquisitor is stationed in or directly next to a city center, units of other religions cannot spread their faith there, though natural spread is uneffected."
-    ],
-    "Maya_Long_Count_calendar_cycle": [
+      ]
+  },
+  {
+    "name": "Maya Long Count calendar cycle",
+    "steps": [
       "The Mayan unique ability, 'The Long Count', comes with a side effect:",
       "Once active, the game's year display will use mayan notation.",
       "",
       "The Maya measured time in days from what we would call 11th of August, 3114 BCE. A day is called K'in, 20 days are a Winal, 18 Winals are a Tun, 20 Tuns are a K'atun, 20 K'atuns are a B'ak'tun, 20 B'ak'tuns a Piktun, and so on.",
       "Unciv only displays ය B'ak'tuns, ඹ K'atuns and ම Tuns (from left to right) since that is enough to approximate gregorian calendar years. The Maya numerals are pretty obvious to understand. Have fun deciphering them!"
-    ],
-  "We_Love_The_King_Day": [
+      ]
+  },
+  {
+    "name": "We Love The King Day",
+    "steps": [
         "Your cities will periodically demand different luxury goods to satisfy their desire for new things in life.",
         "If you manage to acquire the demanded luxury by trade, expansion, or conquest, the city will celebrate We Love The King Day for 20 turns.",
         "During the We Love The King Day, the city will grow 25% faster.",
         "This means exploration and trade is important to grow your cities!"
     ]
-}
+  }
+]

--- a/core/src/com/unciv/models/TutorialTrigger.kt
+++ b/core/src/com/unciv/models/TutorialTrigger.kt
@@ -1,6 +1,7 @@
 package com.unciv.models
 
-enum class Tutorial(val value: String, val isCivilopedia: Boolean = !value.startsWith("_")) {
+
+enum class TutorialTrigger(val value: String, val isCivilopedia: Boolean = !value.startsWith("_")) {
 
     Introduction("Introduction"),
     NewGame("New_Game"),
@@ -44,9 +45,4 @@ enum class Tutorial(val value: String, val isCivilopedia: Boolean = !value.start
     Inquisitors("Inquisitors"),
     MayanCalendar("Maya_Long_Count_calendar_cycle"),
     WeLoveTheKingDay("We_Love_The_King_Day"),
-    ;
-
-    companion object {
-        fun findByName(name: String): Tutorial? = values().find { it.value == name }
-    }
 }

--- a/core/src/com/unciv/models/ruleset/Era.kt
+++ b/core/src/com/unciv/models/ruleset/Era.kt
@@ -8,7 +8,7 @@ import com.unciv.ui.civilopedia.FormattedLine
 import com.unciv.ui.utils.Fonts
 import com.unciv.ui.utils.colorFromRGB
 
-class Era : RulesetObject(), IHasUniques {
+class Era : RulesetObject() {
     var eraNumber: Int = -1
     var researchAgreementCost = 300
     var startingSettlerCount = 1

--- a/core/src/com/unciv/models/ruleset/Tutorial.kt
+++ b/core/src/com/unciv/models/ruleset/Tutorial.kt
@@ -1,0 +1,10 @@
+package com.unciv.models.ruleset
+
+import com.unciv.models.ruleset.unique.UniqueTarget
+
+class Tutorial : RulesetObject() {
+    //todo migrate to civilopediaText then remove or deprecate
+    val steps: Array<String>? = null
+    override fun getUniqueTarget() = UniqueTarget.Tutorial
+    override fun makeLink() = "Tutorial/$name"
+}

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -47,6 +47,7 @@ enum class UniqueTarget(val inheritsFrom: UniqueTarget? = null) {
     Ruins(Triggerable),
 
     // Other
+    Tutorial,
     CityState,
     ModOptions,
     Conditional,
@@ -1072,4 +1073,3 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
 
 // I didn't put this is a companion object because APPARENTLY doing that means you can't use it in the init function.
 val numberRegex = Regex("\\d+$") // Any number of trailing digits
-

--- a/core/src/com/unciv/ui/pickerscreens/PolicyPickerScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/PolicyPickerScreen.kt
@@ -5,7 +5,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.Button
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.unciv.UncivGame
 import com.unciv.logic.civilization.CivilizationInfo
-import com.unciv.models.Tutorial
+import com.unciv.models.TutorialTrigger
 import com.unciv.models.UncivSound
 import com.unciv.models.ruleset.Policy
 import com.unciv.models.ruleset.PolicyBranch
@@ -24,7 +24,7 @@ class PolicyPickerScreen(val worldScreen: WorldScreen, civInfo: CivilizationInfo
 
     init {
         val policies = viewingCiv.policies
-        displayTutorial(Tutorial.CultureAndPolicies)
+        displayTutorial(TutorialTrigger.CultureAndPolicies)
 
         rightSideButton.setText(when {
             policies.allPoliciesAdopted(checkEra = false) ->

--- a/core/src/com/unciv/ui/pickerscreens/PromotionPickerScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/PromotionPickerScreen.kt
@@ -5,7 +5,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.utils.Align
 import com.unciv.UncivGame
 import com.unciv.logic.map.MapUnit
-import com.unciv.models.Tutorial
+import com.unciv.models.TutorialTrigger
 import com.unciv.models.UncivSound
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.ruleset.unit.Promotion
@@ -49,7 +49,7 @@ class PromotionPickerScreen(val unit: MapUnit) : PickerScreen() {
 
         val unitType = unit.type
         val promotionsForUnitType = unit.civInfo.gameInfo.ruleSet.unitPromotions.values.filter {
-            it.unitTypes.contains(unitType.name) || unit.promotions.promotions.contains(it.name) 
+            it.unitTypes.contains(unitType.name) || unit.promotions.promotions.contains(it.name)
         }
         val unitAvailablePromotions = unit.promotions.getAvailablePromotions()
 
@@ -63,7 +63,7 @@ class PromotionPickerScreen(val unit: MapUnit) : PickerScreen() {
                     icon = ImageGetter.getUnitIcon(unit.name).surroundWithCircle(80f),
                     defaultText = unit.name,
                     validate = { it != unit.name},
-                    actionOnOk = { userInput -> 
+                    actionOnOk = { userInput ->
                         unit.instanceName = userInput
                         this.game.setScreen(PromotionPickerScreen(unit))
                     }
@@ -106,7 +106,7 @@ class PromotionPickerScreen(val unit: MapUnit) : PickerScreen() {
         }
         topTable.add(availablePromotionsGroup)
 
-        displayTutorial(Tutorial.Experience)
+        displayTutorial(TutorialTrigger.Experience)
     }
 
     private fun setScrollY(scrollY: Float): PromotionPickerScreen {

--- a/core/src/com/unciv/ui/tutorials/TutorialController.kt
+++ b/core/src/com/unciv/ui/tutorials/TutorialController.kt
@@ -1,29 +1,35 @@
 package com.unciv.ui.tutorials
 
-import com.badlogic.gdx.utils.Array
 import com.unciv.UncivGame
 import com.unciv.json.fromJsonFile
 import com.unciv.json.json
-import com.unciv.models.Tutorial
+import com.unciv.models.TutorialTrigger
+import com.unciv.models.ruleset.Tutorial
+import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.stats.INamed
 import com.unciv.ui.civilopedia.FormattedLine
 import com.unciv.ui.civilopedia.SimpleCivilopediaText
 import com.unciv.ui.utils.BaseScreen
 
+
 class TutorialController(screen: BaseScreen) {
 
-    private val tutorialQueue = mutableSetOf<Tutorial>()
+    private val tutorialQueue = mutableSetOf<TutorialTrigger>()
     private var isTutorialShowing = false
     var allTutorialsShowedCallback: (() -> Unit)? = null
     private val tutorialRender = TutorialRender(screen)
-    private val tutorials = json().fromJsonFile(LinkedHashMap<String, Array<String>>().javaClass, "jsons/Tutorials.json")
 
-    fun showTutorial(tutorial: Tutorial) {
+    //todo These should live in a ruleset allowing moddability
+    private val tutorials: LinkedHashMap<String, Tutorial> =
+            json().fromJsonFile(Array<Tutorial>::class.java, "jsons/Tutorials.json")
+                .associateByTo(linkedMapOf()) { it.name }
+
+    fun showTutorial(tutorial: TutorialTrigger) {
         tutorialQueue.add(tutorial)
         showTutorialIfNeeded()
     }
 
-    private fun removeTutorial(tutorial: Tutorial) {
+    private fun removeTutorial(tutorial: TutorialTrigger) {
         isTutorialShowing = false
         tutorialQueue.remove(tutorial)
         with(UncivGame.Current.settings) {
@@ -49,32 +55,32 @@ class TutorialController(screen: BaseScreen) {
         }
     }
 
-    private fun getTutorial(tutorial: Tutorial): Array<String> {
-        return tutorials[tutorial.value] ?: Array()
+    private fun getTutorial(tutorial: TutorialTrigger): Array<String> {
+        val name = tutorial.value.replace('_', ' ').trimStart()
+        return tutorials[name]?.steps ?: emptyArray()
     }
 
     /** Wrapper for a Tutorial, supports INamed and ICivilopediaText,
      *  and already provisions for the display of an ExtraImage on top.
-     *  @param rawName from Tutorial.value, with underscores (this wrapper replaces them with spaces)
-     *  @param lines   Array of lines exactly as stored in a TutorialController.tutorials MapEntry
+     *  @param name from Tutorial.name, also used for ExtraImage (with spaces replaced by underscores)
+     *  @param tutorial provides [Tutorial.civilopediaText] and [Tutorial.steps] for display
      */
+    //todo Replace - Civilopedia should display Tutorials directly as the RulesetObjects they are
     class CivilopediaTutorial(
-        rawName: String,
-        lines: Array<String>
+        override var name: String,
+        tutorial: Tutorial
     ) : INamed, SimpleCivilopediaText(
-        sequenceOf(FormattedLine(extraImage = rawName)),
-        lines.asSequence()
-    ) {
-        override var name = rawName.replace("_", " ")
-    }
+        sequenceOf(FormattedLine(extraImage = name.replace(' ', '_'))) + tutorial.civilopediaText.asSequence(),
+        tutorial.steps?.asSequence() ?: emptySequence()
+    )
 
     /** Get all Tutorials intended to be displayed in the Civilopedia
      *  as a List of wrappers supporting INamed and ICivilopediaText
      */
     fun getCivilopediaTutorials(): List<CivilopediaTutorial> {
         val civilopediaTutorials = tutorials.filter {
-            Tutorial.findByName(it.key)!!.isCivilopedia
-        }.map { 
+            !it.value.hasUnique(UniqueType.HiddenFromCivilopedia)
+        }.map {
             tutorial -> CivilopediaTutorial(tutorial.key, tutorial.value)
         }
         return civilopediaTutorials

--- a/core/src/com/unciv/ui/tutorials/TutorialRender.kt
+++ b/core/src/com/unciv/ui/tutorials/TutorialRender.kt
@@ -1,14 +1,14 @@
 package com.unciv.ui.tutorials
 
 import com.badlogic.gdx.Gdx
-import com.badlogic.gdx.utils.Array
 import com.unciv.Constants
-import com.unciv.models.Tutorial
+import com.unciv.models.TutorialTrigger
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.popup.Popup
 import com.unciv.ui.utils.*
 
-data class TutorialForRender(val tutorial: Tutorial, val texts: Array<String>)
+@Suppress("ArrayInDataClass")
+data class TutorialForRender(val tutorial: TutorialTrigger, val texts: Array<String>)
 
 class TutorialRender(private val screen: BaseScreen) {
 
@@ -17,25 +17,21 @@ class TutorialRender(private val screen: BaseScreen) {
     }
 
     private fun showDialog(tutorialName: String, texts: Array<String>, closeAction: () -> Unit) {
-        val text = texts.firstOrNull()
-        if (text == null) {
-            closeAction()
-        } else {
-            val tutorialPopup = Popup(screen)
-            tutorialPopup.name = Constants.tutorialPopupNamePrefix + tutorialName
+        if (texts.isEmpty()) return closeAction()
 
-            if (Gdx.files.internal("ExtraImages/$tutorialName").exists()) {
-                tutorialPopup.add(ImageGetter.getExternalImage(tutorialName)).row()
-            }
+        val tutorialPopup = Popup(screen)
+        tutorialPopup.name = Constants.tutorialPopupNamePrefix + tutorialName
 
-            tutorialPopup.addGoodSizedLabel(texts[0]).row()
-
-            tutorialPopup.addCloseButton(additionalKey = KeyCharAndCode.SPACE) {
-                tutorialPopup.remove()
-                texts.removeIndex(0)
-                showDialog(tutorialName, texts, closeAction)
-            }
-            tutorialPopup.open()
+        if (Gdx.files.internal("ExtraImages/$tutorialName").exists()) {
+            tutorialPopup.add(ImageGetter.getExternalImage(tutorialName)).row()
         }
+
+        tutorialPopup.addGoodSizedLabel(texts[0]).row()
+
+        tutorialPopup.addCloseButton(additionalKey = KeyCharAndCode.SPACE) {
+            tutorialPopup.remove()
+            showDialog(tutorialName, texts.sliceArray(1 until texts.size), closeAction)
+        }
+        tutorialPopup.open()
     }
 }

--- a/core/src/com/unciv/ui/utils/BaseScreen.kt
+++ b/core/src/com/unciv/ui/utils/BaseScreen.kt
@@ -11,7 +11,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.*
 import com.badlogic.gdx.scenes.scene2d.utils.Drawable
 import com.badlogic.gdx.utils.viewport.ExtendViewport
 import com.unciv.UncivGame
-import com.unciv.models.Tutorial
+import com.unciv.models.TutorialTrigger
 import com.unciv.ui.UncivStage
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.popup.hasOpenPopups
@@ -67,7 +67,7 @@ abstract class BaseScreen : Screen {
         keyPressDispatcher.uninstall()
     }
 
-    fun displayTutorial(tutorial: Tutorial, test: (() -> Boolean)? = null) {
+    fun displayTutorial(tutorial: TutorialTrigger, test: (() -> Boolean)? = null) {
         if (!game.settings.showTutorials) return
         if (game.settings.tutorialsShown.contains(tutorial.name)) return
         if (test != null && !test()) return

--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -26,7 +26,7 @@ import com.unciv.logic.map.MapVisualization
 import com.unciv.logic.multiplayer.MultiplayerGameUpdated
 import com.unciv.logic.multiplayer.storage.FileStorageRateLimitReached
 import com.unciv.logic.trade.TradeEvaluation
-import com.unciv.models.Tutorial
+import com.unciv.models.TutorialTrigger
 import com.unciv.models.UncivSound
 import com.unciv.models.ruleset.tile.ResourceType
 import com.unciv.models.ruleset.unique.UniqueType
@@ -58,7 +58,6 @@ import com.unciv.ui.trade.DiplomacyScreen
 import com.unciv.ui.utils.BaseScreen
 import com.unciv.ui.utils.Fonts
 import com.unciv.ui.utils.KeyCharAndCode
-import com.unciv.ui.utils.UncivDateFormat.formatDate
 import com.unciv.ui.utils.centerX
 import com.unciv.ui.utils.colorFromRGB
 import com.unciv.ui.utils.darken
@@ -80,7 +79,6 @@ import com.unciv.ui.worldscreen.status.StatusButtons
 import com.unciv.ui.worldscreen.unit.UnitActionsTable
 import com.unciv.ui.worldscreen.unit.UnitTable
 import kotlinx.coroutines.Job
-import java.util.*
 
 /**
  * Unciv's world screen
@@ -522,9 +520,9 @@ class WorldScreen(val gameInfo: GameInfo, val viewingCiv:CivilizationInfo) : Bas
 
     private fun displayTutorialsOnUpdate() {
 
-        displayTutorial(Tutorial.Introduction)
+        displayTutorial(TutorialTrigger.Introduction)
 
-        displayTutorial(Tutorial.EnemyCityNeedsConqueringWithMeleeUnit) {
+        displayTutorial(TutorialTrigger.EnemyCityNeedsConqueringWithMeleeUnit) {
             viewingCiv.diplomacy.values.asSequence()
                     .filter { it.diplomaticStatus == DiplomaticStatus.War }
                     .map { it.otherCiv() } // we're now lazily enumerating over CivilizationInfo's we're at war with
@@ -536,11 +534,11 @@ class WorldScreen(val gameInfo: GameInfo, val viewingCiv:CivilizationInfo) : Bas
                     //    no matter whether civilian, air or ranged, tell user he needs melee
                     .any { it.getUnits().any { unit -> unit.civInfo == viewingCiv } }
         }
-        displayTutorial(Tutorial.AfterConquering) { viewingCiv.cities.any { it.hasJustBeenConquered } }
+        displayTutorial(TutorialTrigger.AfterConquering) { viewingCiv.cities.any { it.hasJustBeenConquered } }
 
-        displayTutorial(Tutorial.InjuredUnits) { gameInfo.getCurrentPlayerCivilization().getCivUnits().any { it.health < 100 } }
+        displayTutorial(TutorialTrigger.InjuredUnits) { gameInfo.getCurrentPlayerCivilization().getCivUnits().any { it.health < 100 } }
 
-        displayTutorial(Tutorial.Workers) {
+        displayTutorial(TutorialTrigger.Workers) {
             gameInfo.getCurrentPlayerCivilization().getCivUnits().any {
                 it.hasUniqueToBuildImprovements && it.isCivilian() && !it.isGreatPerson()
             }
@@ -552,7 +550,7 @@ class WorldScreen(val gameInfo: GameInfo, val viewingCiv:CivilizationInfo) : Bas
         if (!civInfo.isDefeated() && !civInfo.isSpectator() && civInfo.getKnownCivs()
                         .filterNot { it == viewingCiv || it.isBarbarian() }
                         .any()) {
-            displayTutorial(Tutorial.OtherCivEncountered)
+            displayTutorial(TutorialTrigger.OtherCivEncountered)
             val btn = "Diplomacy".toTextButton()
             btn.onClick { game.setScreen(DiplomacyScreen(viewingCiv)) }
             btn.label.setFontSize(30)
@@ -858,27 +856,27 @@ class WorldScreen(val gameInfo: GameInfo, val viewingCiv:CivilizationInfo) : Bas
 
     private fun showTutorialsOnNextTurn() {
         if (!game.settings.showTutorials) return
-        displayTutorial(Tutorial.SlowStart)
-        displayTutorial(Tutorial.CityExpansion) { viewingCiv.cities.any { it.expansion.tilesClaimed() > 0 } }
-        displayTutorial(Tutorial.BarbarianEncountered) { viewingCiv.viewableTiles.any { it.getUnits().any { unit -> unit.civInfo.isBarbarian() } } }
-        displayTutorial(Tutorial.RoadsAndRailroads) { viewingCiv.cities.size > 2 }
-        displayTutorial(Tutorial.Happiness) { viewingCiv.getHappiness() < 5 }
-        displayTutorial(Tutorial.Unhappiness) { viewingCiv.getHappiness() < 0 }
-        displayTutorial(Tutorial.GoldenAge) { viewingCiv.goldenAges.isGoldenAge() }
-        displayTutorial(Tutorial.IdleUnits) { gameInfo.turns >= 50 && game.settings.checkForDueUnits }
-        displayTutorial(Tutorial.ContactMe) { gameInfo.turns >= 100 }
+        displayTutorial(TutorialTrigger.SlowStart)
+        displayTutorial(TutorialTrigger.CityExpansion) { viewingCiv.cities.any { it.expansion.tilesClaimed() > 0 } }
+        displayTutorial(TutorialTrigger.BarbarianEncountered) { viewingCiv.viewableTiles.any { it.getUnits().any { unit -> unit.civInfo.isBarbarian() } } }
+        displayTutorial(TutorialTrigger.RoadsAndRailroads) { viewingCiv.cities.size > 2 }
+        displayTutorial(TutorialTrigger.Happiness) { viewingCiv.getHappiness() < 5 }
+        displayTutorial(TutorialTrigger.Unhappiness) { viewingCiv.getHappiness() < 0 }
+        displayTutorial(TutorialTrigger.GoldenAge) { viewingCiv.goldenAges.isGoldenAge() }
+        displayTutorial(TutorialTrigger.IdleUnits) { gameInfo.turns >= 50 && game.settings.checkForDueUnits }
+        displayTutorial(TutorialTrigger.ContactMe) { gameInfo.turns >= 100 }
         val resources = viewingCiv.detailedCivResources.asSequence().filter { it.origin == "All" }  // Avoid full list copy
-        displayTutorial(Tutorial.LuxuryResource) { resources.any { it.resource.resourceType == ResourceType.Luxury } }
-        displayTutorial(Tutorial.StrategicResource) { resources.any { it.resource.resourceType == ResourceType.Strategic } }
-        displayTutorial(Tutorial.EnemyCity) {
+        displayTutorial(TutorialTrigger.LuxuryResource) { resources.any { it.resource.resourceType == ResourceType.Luxury } }
+        displayTutorial(TutorialTrigger.StrategicResource) { resources.any { it.resource.resourceType == ResourceType.Strategic } }
+        displayTutorial(TutorialTrigger.EnemyCity) {
             viewingCiv.getKnownCivs().asSequence().filter { viewingCiv.isAtWarWith(it) }
                     .flatMap { it.cities.asSequence() }.any { viewingCiv.exploredTiles.contains(it.location) }
         }
-        displayTutorial(Tutorial.ApolloProgram) { viewingCiv.hasUnique(UniqueType.EnablesConstructionOfSpaceshipParts) }
-        displayTutorial(Tutorial.SiegeUnits) { viewingCiv.getCivUnits().any { it.baseUnit.isProbablySiegeUnit() } }
-        displayTutorial(Tutorial.Embarking) { viewingCiv.hasUnique(UniqueType.LandUnitEmbarkation) }
-        displayTutorial(Tutorial.NaturalWonders) { viewingCiv.naturalWonders.size > 0 }
-        displayTutorial(Tutorial.WeLoveTheKingDay) { viewingCiv.cities.any { it.demandedResource != "" } }
+        displayTutorial(TutorialTrigger.ApolloProgram) { viewingCiv.hasUnique(UniqueType.EnablesConstructionOfSpaceshipParts) }
+        displayTutorial(TutorialTrigger.SiegeUnits) { viewingCiv.getCivUnits().any { it.baseUnit.isProbablySiegeUnit() } }
+        displayTutorial(TutorialTrigger.Embarking) { viewingCiv.hasUnique(UniqueType.LandUnitEmbarkation) }
+        displayTutorial(TutorialTrigger.NaturalWonders) { viewingCiv.naturalWonders.size > 0 }
+        displayTutorial(TutorialTrigger.WeLoveTheKingDay) { viewingCiv.cities.any { it.demandedResource != "" } }
     }
 
     private fun backButtonAndESCHandler() {

--- a/tests/src/com/unciv/testing/TutorialTranslationTests.kt
+++ b/tests/src/com/unciv/testing/TutorialTranslationTests.kt
@@ -1,28 +1,48 @@
 package com.unciv.testing
 
-import com.badlogic.gdx.utils.Array
 import com.unciv.json.fromJsonFile
 import com.unciv.json.json
-import com.unciv.models.Tutorial
-import org.junit.Assert.assertTrue
+import com.unciv.models.TutorialTrigger
+import com.unciv.models.ruleset.Tutorial
+import org.junit.Assert.fail
 import org.junit.Test
 import org.junit.runner.RunWith
-import java.util.LinkedHashMap
 
 @RunWith(GdxTestRunner::class)
 class TutorialTranslationTests {
+    private var tutorials: LinkedHashMap<String, Tutorial>? = null
+    private var exception: Throwable? = null
 
-    private var tutorialCount = Tutorial.values().size
-    private var tutorialKeyNames = Tutorial.values().map { it.value }
+    init {
+         try {
+             tutorials = json().fromJsonFile(Array<Tutorial>::class.java, "jsons/Tutorials.json")
+                 .associateByTo(linkedMapOf()) { it.name }
+         } catch (ex: Throwable) {
+             exception = ex
+         }
+    }
 
     @Test
-    fun tutorialsFileIsSerializable() {
-        val map = json().fromJsonFile(LinkedHashMap<String, Array<String>>().javaClass, "jsons/Tutorials.json")
+    fun tutorialsFileIsDeSerializable() {
+        if (exception != null)
+            fail("Loading Tutorials.json fails with ${exception?.javaClass?.simpleName} \"${exception?.message}\"")
+    }
 
-        assertTrue("The number of items from Tutorials.json must match to the enum Tutorial",
-                map.size == tutorialCount)
-
-        assertTrue("The items from Tutorials.json must match to the enum Tutorial values",
-                tutorialKeyNames.containsAll(map.keys))
+    @Test
+    fun tutorialsFileCoversAllTriggers() {
+        if (tutorials == null) return
+        for (trigger in TutorialTrigger.values()) {
+            val name = trigger.value.replace('_', ' ').trimStart()
+            if (name in tutorials!!) continue
+            fail("TutorialTrigger $trigger has no matching entry in Tutorials.json")
+        }
+    }
+    @Test
+    fun tutorialsAllHaveText() {
+        if (tutorials == null) return
+        for (tutorial in tutorials!!.values) {
+            if (tutorial.steps?.isNotEmpty() != true && tutorial.civilopediaText.isEmpty())
+                fail("Tutorial \"$tutorial\" contains no text")
+        }
     }
 }


### PR DESCRIPTION
Concept:
- The "Tutorial" as in object displayable in Civilopedia becomes a RulesetObject. This is overdue and will allow a few simplifications while allowing nicer presentation. And, soon, makes transformation into an actual part of rulesets easy, too. Tutorials could _know_ about the difference between vanilla and g&k, and become moddable.
- The enum actually concerns itself with the tests when such a text should be spammed. Thus it is renamed to [Totoro](https://en.wikipedia.org/wiki/My_Neighbor_Totoro)ialTrigger (sorry, not quite) - _much_ clearer IMHO, and may lead to some day replacing the triggers with uniques bound to python scripts - think scenarios. All that tutorial detection code in WorldScreen needs to find a better home outside UI anyway.

This PR is the bare minimum first step which _still works as before_. Only difference - adding a Tutorial without a corresponding TutorialTrigger is now explicitly allowed.

Side notes:
- dropping "steps" would require to either decide the annoying "1 line, need OK, another line, need OK" goes, or some idea on how to group civilopediaText. Some FormattedLine instance that triggers 'stop rendering here and ask for OK'?
- Interesting how instead of Ruleset.createHashmap the standard library is enough - and more flexible, the ruleset loader could probably save an interim copy or two where it does +=.
- Gdx Array shadowing standard Array - mega annoying, I'm going to `as GdxArray` _all_ unavoidable uses in the future. And where it was - probably unsuspectingly - used in that soon-to-be-redundant Tutorial to Civilopedia code looks cleaner with normal kotlin Arrays too.
- I'll not be listening for at least a week, so - patience.
- That Era change: I was surprised the compiler even allows inheriting the same interface repeatedly. (Would `class Era : RulesetObject(), IHasUniques, IHasUniques, IHasUniques, IHasUniques, IHasUniques` compile too?????) :smile_cat: 