### PR TITLE
Fix amphibious promotion

### DIFF
--- a/core/src/com/unciv/logic/battle/BattleDamage.kt
+++ b/core/src/com/unciv/logic/battle/BattleDamage.kt
@@ -112,10 +112,8 @@ object BattleDamage {
         if (attacker is MapUnitCombatant) {
             modifiers.add(getTileSpecificModifiers(attacker, defender.getTile()))
 
-            // Depreciated Version
-            if (attacker.unit.isEmbarked() && !attacker.unit.hasUnique(UniqueType.AttackFromSea))
-                modifiers["Landing"] = -50
-            if (attacker.unit.isEmbarked() && !attacker.unit.hasUnique(UniqueType.AttackAcrossCoast))
+            if (attacker.unit.isEmbarked()
+                    && !(attacker.unit.hasUnique(UniqueType.AttackAcrossCoast)) || attacker.unit.hasUnique(UniqueType.AttackFromSea))
                 modifiers["Landing"] = -50
 
             // Land Melee Unit attacking to Water


### PR DESCRIPTION
Fixes marines having an attack penalty when attacking from coast to land. There was an if statement checking for a depreciated unique type so marines, berserkers, and any unit with amphibious would have a landing penalty added due to this if statement.