### PR TITLE
Bugfixes to the units' teleportation

### DIFF
--- a/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
+++ b/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
@@ -385,7 +385,7 @@ class UnitMovementAlgorithms(val unit: MapUnit) {
                 // can the unit be placed safely there?
                 .filter { canMoveTo(it) }
                 // out of those where it can be placed, can it reach them in any meaningful way?
-                .firstOrNull { getPathBetweenTiles(unit.currentTile, it).size > 1 }
+                .firstOrNull { getPathBetweenTiles(unit.currentTile, it).contains(it) }
         }
 
         // No tile within 4 spaces? move him to a city.
@@ -740,7 +740,7 @@ class UnitMovementAlgorithms(val unit: MapUnit) {
     private fun getPathBetweenTiles(from: TileInfo, to: TileInfo): MutableSet<TileInfo> {
         val tmp = unit.canEnterForeignTerrain
         unit.canEnterForeignTerrain = true // the trick to ignore tiles owners
-        val bfs = BFS(from) { canMoveTo(it) }
+        val bfs = BFS(from) { canPassThrough(it) }
         bfs.stepUntilDestination(to)
         unit.canEnterForeignTerrain = tmp
         return bfs.getReachedTiles()

--- a/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
+++ b/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
@@ -389,14 +389,11 @@ class UnitMovementAlgorithms(val unit: MapUnit) {
         }
 
         // No tile within 4 spaces? move him to a city.
-        if (allowedTile == null) {
-            for (city in unit.civInfo.cities) {
-                allowedTile = city.getTiles()
-                        .firstOrNull { canMoveTo(it) }
-                if (allowedTile != null) break
-            }
-        }
         val origin = unit.getTile()
+        if (allowedTile == null)
+            allowedTile = unit.civInfo.cities.flatMap { it.getTiles() }
+                .sortedBy { it.aerialDistanceTo(origin) }.firstOrNull{ canMoveTo(it) }
+
         if (allowedTile != null) {
             unit.removeFromTile() // we "teleport" them away
             unit.putInTile(allowedTile)

--- a/tests/src/com/unciv/logic/map/UnitMovementAlgorithmsTests.kt
+++ b/tests/src/com/unciv/logic/map/UnitMovementAlgorithmsTests.kt
@@ -354,6 +354,33 @@ class UnitMovementAlgorithmsTests {
     }
 
     @Test
+    fun `can teleport water unit over other unit`() {
+        // this is needed for unit.putInTile(), unit.moveThroughTile() to avoid using Uncivgame.Current.viewEntireMapForDebug
+        civInfo.nation.name = Constants.spectator
+
+        tile.baseTerrain = Constants.ocean
+        tile.position.set(0f, 0f)
+        tile.setTransients()
+        createOpponentCivAndCity()
+        val newTiles = generateTileCopies(3)
+
+        // Other unit on the way
+        val otherUnit = MapUnit()
+        otherUnit.civInfo = civInfo
+        otherUnit.owner = civInfo.civName
+        otherUnit.baseUnit = BaseUnit().apply { unitType = "Melee Water"; strength = 1; ruleset = ruleSet }
+        otherUnit.currentTile = newTiles[0]
+        newTiles[0].militaryUnit = otherUnit
+        otherUnit.name = "Friend Unit"
+
+        setupMilitaryUnitInTheCurrentTile("Melee Water")
+
+        unit.movement.teleportToClosestMoveableTile()
+
+        Assert.assertTrue("Unit must be teleported to new location", unit.currentTile == newTiles.last())
+    }
+
+    @Test
     fun `can teleport air unit`() {
         // this is needed for unit.putInTile(), unit.moveThroughTile() to avoid using Uncivgame.Current.viewEntireMapForDebug
         civInfo.nation.name = Constants.spectator
@@ -380,17 +407,19 @@ class UnitMovementAlgorithmsTests {
         tile.position.set(0f, 0f)
         tile.setTransients()
         createOpponentCivAndCity()
-        val newTiles = generateTileCopies(6)
+        val newTiles = generateTileCopies(7)
         // create obstacle
-        newTiles[4].baseTerrain = "Grand Mesa"
-        newTiles[4].setTransients()
+        newTiles[3].baseTerrain = "Grand Mesa"
+        newTiles[3].setTransients()
         // create our city
         CityInfo().apply {
             this.civInfo = this@UnitMovementAlgorithmsTests.civInfo
             location = newTiles.last().position.cpy()
             tiles.add(location)
+            tiles.add(newTiles[5].position)
             tileMap = tile.tileMap
             civInfo.cities = listOf(this)
+            newTiles[5].setOwningCity(this)
             newTiles.last().setOwningCity(this)
         }
 
@@ -398,7 +427,7 @@ class UnitMovementAlgorithmsTests {
 
         unit.movement.teleportToClosestMoveableTile()
 
-        Assert.assertTrue("Unit must be teleported to the city", unit.currentTile == newTiles.last())
+        Assert.assertTrue("Unit must be teleported to the city", unit.currentTile == newTiles[5])
     }
 
     @Test
@@ -412,8 +441,8 @@ class UnitMovementAlgorithmsTests {
         createOpponentCivAndCity()
         val newTiles = generateTileCopies(3)
         // create obstacle
-        newTiles[0].baseTerrain = Constants.grassland
-        newTiles[0].setTransients()
+        newTiles[1].baseTerrain = Constants.grassland
+        newTiles[1].setTransients()
 
         setupMilitaryUnitInTheCurrentTile("Melee Water")
 


### PR DESCRIPTION
Let's imagine the next situation:
The russia begs for the peace treaty and is ready to give away Irkutsk to ~Ukraine~ the Huns for that.
![Screenshot 2022-06-05 00-52-53](https://user-images.githubusercontent.com/27405436/172028306-8d6c4c7e-12a2-4a72-b6b0-f6377ad7166d.png)

What goes wrong here?
1. The colors of the Germany and the Huns - are almost identical, and you can hardly distinct two Huns' Destroyers among German troops. (I am not going to fix that right now).
2. After signing the peace treaty all the units must leave the opponent's territory. I expect the Destroyers will be moved to one of the tiles indicated by red arrows.
- (You may say: "why should they be moved at all, if Irkutsk becomes the Huns' territory?" I believe no peace treaty negotiations can be possible while the troops are still occuping the territory in question. So they must be moved out and then the peace treaty is signed).
- BUT after signing the peace treaty I have found them in the lake near the capital ! 😮 
Wait, didn't I fix exactly that problem in #6698 ?
![Screenshot 2022-06-05 02-23-02](https://user-images.githubusercontent.com/27405436/172028607-868bf90c-f4d7-4f5e-9a21-c34cabb29c30.png)

The algorithm has been intended to search for 5 tiles around, and if there is no suitable reachable tile, to move the unit to the closest city. In this bug you can see it has failed twice moving to neither the closest tile in radius 5, nor to the nearest city.

There were at least three mistakes in the code and two errorful unit tests consealed them. Run these new tests on `master` before the changes from this PR to see the issues. All of them are fixed now.