### PR TITLE
"Cannot be hurried" unique type for buildings and techs

### DIFF
--- a/android/assets/jsons/Civ V - Gods & Kings/Buildings.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Buildings.json
@@ -385,7 +385,7 @@
 		"uniques": ["[+2 Gold] from [Gold Ore] tiles [in this city]", "[+2 Gold] from [Silver] tiles [in this city]"],
 		"requiredTech": "Currency"
 	},
-	{ 
+	{
 		"name": "Petra",
 		"culture": 1,
 		"isWonder": true,
@@ -1026,7 +1026,7 @@
 		"name": "Manhattan Project",
 		"cost": 750,
 		"isNationalWonder": true,
-		"uniques": ["Enables nuclear weapon", "Triggers a global alert upon completion"],
+		"uniques": ["Enables nuclear weapon", "Triggers a global alert upon completion", "Cannot be hurried"],
 		"requiredTech": "Atomic Theory"
 	},
 	{
@@ -1077,8 +1077,8 @@
 		"name": "Apollo Program",
 		"cost": 750,
 		"isNationalWonder": true,
-		"uniques": ["Enables construction of Spaceship parts", "Triggers a global alert upon completion", 
-			"Hidden when [Scientific] Victory is disabled"],
+		"uniques": ["Enables construction of Spaceship parts", "Triggers a global alert upon completion",
+			"Hidden when [Scientific] Victory is disabled", "Cannot be hurried"],
 		"requiredTech": "Rocketry"
 	},
 
@@ -1138,11 +1138,11 @@
 		"cost": 1500,
 		"isNationalWonder": true,
 		"uniques": ["Hidden until [5] social policy branches have been completed", "Triggers a global alert upon build start",
-			"Triggers a Cultural Victory upon completion", "Hidden when [Cultural] Victory is disabled"]
+			"Triggers a Cultural Victory upon completion", "Hidden when [Cultural] Victory is disabled", "Cannot be hurried"]
 	},
-	
+
 	// Religious buildings
-	
+
 	{
 		"name": "Cathedral",
 		"cost": 0,
@@ -1157,7 +1157,7 @@
 		"cost": 0,
 		"culture": 2,
 		"faith": 2,
-		"uniques": ["[+1 Culture, +1 Faith] from [Wine] tiles [in this city]", 
+		"uniques": ["[+1 Culture, +1 Faith] from [Wine] tiles [in this city]",
 			"[+1 Culture, +1 Faith] from [Incense] tiles [in this city]",
 			"Unbuildable", "Hidden when religion is disabled", "Destroyed when the city is captured"]
 	},

--- a/android/assets/jsons/Civ V - Vanilla/Buildings.json
+++ b/android/assets/jsons/Civ V - Vanilla/Buildings.json
@@ -291,7 +291,7 @@
 		"requiredBuilding": "Monument",
 		"requiredTech": "Philosophy"
 	},
-	
+
 	{
 		"name": "National College",
 		"cost": 125,
@@ -895,7 +895,7 @@
 		"name": "Manhattan Project",
 		"cost": 750,
 		"isNationalWonder": true,
-		"uniques": ["Enables nuclear weapon", "Triggers a global alert upon completion"],
+		"uniques": ["Enables nuclear weapon", "Triggers a global alert upon completion", "Cannot be hurried"],
 		"requiredTech": "Atomic Theory"
 	},
 	{
@@ -931,8 +931,8 @@
 		"name": "Apollo Program",
 		"cost": 750,
 		"isNationalWonder": true,
-		"uniques": ["Enables construction of Spaceship parts", "Triggers a global alert upon completion", 
-			"Hidden when [Scientific] Victory is disabled"],
+		"uniques": ["Enables construction of Spaceship parts", "Triggers a global alert upon completion",
+			"Hidden when [Scientific] Victory is disabled", "Cannot be hurried"],
 		"requiredTech": "Rocketry"
 	},
 
@@ -966,7 +966,7 @@
 		"cost": 1500,
 		"isNationalWonder": true,
 		"uniques": ["Hidden until [5] social policy branches have been completed", "Triggers a global alert upon build start",
-			"Triggers a Cultural Victory upon completion", "Hidden when [Cultural] Victory is disabled"]
+			"Triggers a Cultural Victory upon completion", "Hidden when [Cultural] Victory is disabled", "Cannot be hurried"]
 	}
-	
+
 ]

--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -62,6 +62,7 @@ Close Unciv =
 Unsellable = 
 Not displayed as an available construction unless [building] is built = 
 Not displayed as an available construction without [resource] = 
+Cannot be hurried = 
 
 Choose a free great person = 
 Get [unitName] = 

--- a/core/src/com/unciv/logic/city/CityConstructions.kt
+++ b/core/src/com/unciv/logic/city/CityConstructions.kt
@@ -189,6 +189,11 @@ class CityConstructions {
         return currentConstruction is Building && currentConstruction.isWonder
     }
 
+    fun canBeHurried(): Boolean {
+        val currentConstruction = getCurrentConstruction()
+        return currentConstruction is INonPerpetualConstruction && !currentConstruction.hasUnique(UniqueType.CannotBeHurried)
+    }
+
     /** If the city is constructing multiple units of the same type, subsequent units will require the full cost  */
     fun isFirstConstructionOfItsKind(constructionQueueIndex: Int, name: String): Boolean {
         // if the construction name is the same as the current construction, it isn't the first

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -533,7 +533,9 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
 
     CanActionSeveralTimes("Can [action] [amount] times", UniqueTarget.Unit),
 
+    CannotBeHurried("Cannot be hurried", UniqueTarget.Building, UniqueTarget.Tech),
     CanSpeedupConstruction("Can speed up construction of a building", UniqueTarget.Unit),
+    CanSpeedupWonderConstruction("Can speed up the construction of a wonder", UniqueTarget.Unit),
     CanHurryResearch("Can hurry technology research", UniqueTarget.Unit),
     CanTradeWithCityStateForGoldAndInfluence("Can undertake a trade mission with City-State, giving a large sum of gold and [amount] Influence", UniqueTarget.Unit),
 

--- a/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
@@ -489,16 +489,17 @@ object UnitActions {
 
     private fun addGreatPersonActions(unit: MapUnit, actionList: ArrayList<UnitAction>, tile: TileInfo) {
 
-        if (unit.currentMovement > 0) for (unique in unit.getUniques()) when (unique.placeholderText) {
-            "Can hurry technology research" -> {
+        if (unit.currentMovement > 0) for (unique in unit.getUniques()) when (unique.type) {
+            UniqueType.CanHurryResearch -> {
                 actionList += UnitAction(UnitActionType.HurryResearch,
                     action = {
                         unit.civInfo.tech.addScience(unit.civInfo.tech.getScienceFromGreatScientist())
                         unit.consume()
-                    }.takeIf { unit.civInfo.tech.currentTechnologyName() != null }
+                    }.takeIf { unit.civInfo.tech.currentTechnologyName() != null
+                            && !unit.civInfo.tech.currentTechnology()!!.hasUnique(UniqueType.CannotBeHurried) }
                 )
             }
-            "Can start an []-turn golden age" -> {
+            UniqueType.StartGoldenAge -> {
                 val turnsToGoldenAge = unique.params[0].toInt()
                 actionList += UnitAction(UnitActionType.StartGoldenAge,
                     action = {
@@ -507,11 +508,11 @@ object UnitActions {
                     }.takeIf { unit.currentTile.getOwner() != null && unit.currentTile.getOwner() == unit.civInfo }
                 )
             }
-            "Can speed up the construction of a wonder" -> {
+            UniqueType.CanSpeedupWonderConstruction -> {
                 val canHurryWonder =
                     if (!tile.isCityCenter()) false
                     else tile.getCity()!!.cityConstructions.isBuildingWonder()
-
+                            && tile.getCity()!!.cityConstructions.canBeHurried()
 
                 actionList += UnitAction(UnitActionType.HurryWonder,
                     action = {
@@ -526,15 +527,15 @@ object UnitActions {
                 )
             }
 
-            "Can speed up construction of a building" -> {
+            UniqueType.CanSpeedupConstruction -> {
                 if (!tile.isCityCenter()) {
                     actionList += UnitAction(UnitActionType.HurryBuilding, action = null)
                     continue
                 }
 
-                val canHurryConstruction = tile.getCity()!!.cityConstructions.getCurrentConstruction() is Building
-
                 val cityConstructions = tile.getCity()!!.cityConstructions
+                val canHurryConstruction = cityConstructions.getCurrentConstruction() is Building
+                        && cityConstructions.canBeHurried()
 
                 //http://civilization.wikia.com/wiki/Great_engineer_(Civ5)
                 val productionPointsToAdd = min(
@@ -555,7 +556,7 @@ object UnitActions {
                     }.takeIf { canHurryConstruction }
                 )
             }
-            "Can undertake a trade mission with City-State, giving a large sum of gold and [] Influence" -> {
+            UniqueType.CanTradeWithCityStateForGoldAndInfluence -> {
                 val canConductTradeMission = tile.owningCity?.civInfo?.isCityState() == true
                         && tile.owningCity?.civInfo?.isAtWarWith(unit.civInfo) == false
                 val influenceEarned = unique.params[0].toFloat()


### PR DESCRIPTION
Implements a unique type called `UniqueType.CannotBeHurried` ("Cannot be hurried") which can be given to a building or technology to prevent it from being rushed by a great scientist/engineer. In Civ 5 vanilla and G&K, this applies to the Manhattan Project, Apollo Program, and Utopia Project.

Also cleaned up a when statement in `UnitActions.kt` to check unique types instead of placeholder text. An additional unique type `CanSpeedupWonderConstruction` was implemented as part of this clean up, but this is currently not used in any vanilla Unciv units.