### PR TITLE
Update Spanish.properties

### DIFF
--- a/android/assets/jsons/translations/Spanish.properties
+++ b/android/assets/jsons/translations/Spanish.properties
@@ -19,7 +19,7 @@ Fastlane_short_description = Juego 4X de crear civilizaciones
 
 # Documentation: https://f-droid.org/en/docs/Build_Metadata_Reference/#Description
 # English to translate: https://github.com/yairm210/Unciv/blob/master/fastlane/metadata/android/en-US/full_description.txt
-Fastlane_full_description = Una reimplementación del juego de construcción de civilizaciones más famoso de la hsitoria - ¡rápido, pequeño, sin anuncios, gratis por siempre!\n\n¡Construye tu civilización, investiga tecnologías, expande tus ciudades y derrota a tus enemingos!\n\n¿Peticiones?¿Errores? La lista de cosas por hacer de la aplicación es https://github.com/yairm210/UnCiv/issues, ¡toda pequeña ayuda es bienvenida!\n\n¿Preguntas?¿Errores?¿Aburrido? Únetenos en https://discord.gg/bjrB4Xw.\n\n¿Quieres ayudar a traducir el juego a tu idioma? Envíame un email a yairm210@hotmail.com.\n\n¿Sabes escribir Java o Kotlin? Únetenos en https://github.com/yairm210/UnCiv.¡El mundo espera!¿Convertirás tu civilización en un imperio que resistirá el paso del tiempo?\n\n Se requiere el permiso de 'tener acceso completo a la red' para descargas iniciadas por el usuario y el modo multijugador. Todos los demás permisos listados son incluidos automáticamente por el API usado para implementar las notificaciones de turnos en el modo multijugador. Los permisos de red son usados para contar mods, descargar mods, descargar música y para cargar/descargar partidas multijugador. Unciv no inicia ninguna otra comunicación por Internet.
+Fastlane_full_description = Una reimplementación del juego de construcción de civilizaciones más famoso de la historia - ¡Rápido, pequeño, sin anuncios, gratis por siempre!\n\n¡Construye tu civilización, investiga tecnologías, expande tus ciudades y derrota a tus enemigos!\n\n¿Peticiones?¿Errores? La lista de cosas por hacer de la aplicación es https://github.com/yairm210/UnCiv/issues, ¡toda pequeña ayuda es bienvenida!\n\n¿Preguntas?¿Errores?¿Aburrido? Únetenos en https://discord.gg/bjrB4Xw.\n\n¿Quieres ayudar a traducir el juego a tu idioma? Envíame un email a yairm210@hotmail.com.\n\n¿Sabes escribir Java o Kotlin? Únetenos en https://github.com/yairm210/UnCiv.¡El mundo espera!¿Convertirás tu civilización en un imperio que resistirá el paso del tiempo?\n\n Se requiere el permiso de "Tener acceso completo a la red" para descargas iniciadas por el usuario y el modo multijugador. Todos los demás permisos listados son incluidos automáticamente por el API usado para implementar las notificaciones de turnos en el modo multijugador. Los permisos de red son usados para contar mods, descargar mods, descargar música y para cargar/descargar partidas multijugador. Unciv no inicia ninguna otra comunicación por Internet.
 
 
 # Starting from here normal translations start, as described in
@@ -392,7 +392,7 @@ Water level = Nivel del agua
 
 Online Multiplayer = Multijugador Online
  # Requires translation!
-You're currently using the default multiplayer server, which is based on a free Dropbox account. Because a lot of people use this, it is uncertain if you'll actually be able to access it consistently. Consider using a custom server instead. = 
+You're currently using the default multiplayer server, which is based on a free Dropbox account. Because a lot of people use this, it is uncertain if you'll actually be able to access it consistently. Consider using a custom server instead. = Actualmente estás usando el servidor multijugador por defecto, el cual está basado en una cuenta gratis de Dropbox. Debido a que mucha gente lo usa, es posible que no puedas acceder al servidor con frecuencia. Considera usar un servidor propio mejor.
 Open Documentation = Abrir documentación
 Don't show again = No mostrar de nuevo
 
@@ -552,32 +552,32 @@ UserID copied to clipboard = ID de usuario copiada al portapapeles
 Game ID copied to clipboard! = ¡ID de partida copiada al portapapeles!
 Friend name = Nombre de amigo
 Player ID = ID de jugador
-Please input a name for your friend! = ¡Por favor ingrese un nombre para su amigo!
-Please input a player ID for your friend! = ¡Por favor ingrese un ID de jugador para tu amigo!
-Are you sure you want to delete this friend? = ¿Está seguro de que quiere eliminar a este amigo?
+Please input a name for your friend! = ¡Por favor ingresa un nombre para tu amigo!
+Please input a player ID for your friend! = ¡Por favor ingresa un ID de jugador para tu amigo!
+Are you sure you want to delete this friend? = ¿Estás seguro de que quieres eliminar a este amigo?
 Paste player ID from clipboard = Pegar ID de jugador desde el portapapeles
 Player name already used! = ¡Nombre de jugador ya usado!
 Player ID already used! = ¡ID de jugador ya usado!
 Player ID is incorrect = El ID de jugador es incorrecto
  # Requires translation!
-Select friend = 
+Select friend = Escoger amigo
  # Requires translation!
-Select [thingToSelect] = 
+Select [thingToSelect] = Escoger [thingToSelect]
 Friends list = Lista de amigos
 Add friend = Añadir amigo
 Edit friend = Editar amigo
 Friend name is already in your friends list! = ¡El nombre del amigo ya está en tu lista de amigos!
 Player ID is already in your friends list! = ¡El ID de jugador ya está en tu lista de amigos!
-You have to write a name for your friend! = ¡Tiene que escribir un nombre para su amigo!
-You have to write an ID for your friend! = ¡Tiene que escribir un ID para su amigo!
-You cannot add your own player ID in your friend list! = ¡No puede añadir a su propio ID de jugador a su lista de amigos!
-To add a friend, ask him to send you his player ID.\nClick the 'Add friend' button.\nInsert his player ID and a name for him.\nThen click the 'Add friend' button again.\n\nAfter that you will see him in your friends list.\n\nA new button will appear when creating a new\nmultiplayer game, which allows you to select your friend. = Para añadir a un amigo, pídale que le envíe su ID de jugador.\nHaga clic en en el botón 'Añadir amigo'.\nInserte su ID de jugador y un nombre para él.\nEntonces haga clic en el botón 'Añadir amigo' otra vez.\n\nDespués de eso lo verá en su lista de amigos.\n\nUn nuevo botón aparecerá cuando cree un nuevo\njuego multijugador, que le permitirá seleccionar a su amigo.
+You have to write a name for your friend! = ¡Tienes que escribir un nombre para tu amigo!
+You have to write an ID for your friend! = ¡Tienes que escribir un ID para tu amigo!
+You cannot add your own player ID in your friend list! = ¡No puedes añadir tu propio ID de jugador a tu lista de amigos!
+To add a friend, ask him to send you his player ID.\nClick the 'Add friend' button.\nInsert his player ID and a name for him.\nThen click the 'Add friend' button again.\n\nAfter that you will see him in your friends list.\n\nA new button will appear when creating a new\nmultiplayer game, which allows you to select your friend. = Para añadir a un amigo, pídale que le envíe su ID de jugador.\nHaga clic en en el botón 'Añadir amigo'.\nInserta su ID de jugador y un nombre para él.\nEntonces haga clic en el botón 'Añadir amigo' otra vez.\n\nDespués de eso lo verás en su lista de amigos.\n\nUn nuevo botón aparecerá cuando cree un nuevo\njuego multijugador, que le permitirá seleccionar a su amigo.
  # Requires translation!
-Please input Player ID! = 
+Please input Player ID! = ¡Por favor, inserte ID de jugador!
 Set current user = Asignar usuario actual
 Player ID from clipboard = ID de jugador desde el portapapeles
 Player ID from friends list = ID de jugador de lista de amigos
-To create a multiplayer game, check the 'multiplayer' toggle in the New Game screen, and for each human player insert that player's user ID. = Para crear una partida multijugador, marca "multijugador" en la pantalla de Nueva Partida, e introduce la ID de usuario para cada jugador humano.
+To create a multiplayer game, check the 'multiplayer' toggle in the New Game screen, and for each human player insert that player's user ID. = Para crear una partida multijugador, marca "Multijugador" en la pantalla de "Nueva Partida", e introduce la ID de usuario para cada jugador humano.
 You can assign your own user ID there easily, and other players can copy their user IDs here and send them to you for you to include them in the game. = Allí puedes asignar fácilmente tu propia ID de usuario, y aquí otros jugadores pueden copiar sus IDs de usuario y enviártelas para que les incluyas en la partida.
 Once you've created your game, the Game ID gets automatically copied to your clipboard so you can send it to the other players. = Una vez que hayas creado tu partida, la ID de partida se copia automáticamente en tu portapapeles para que puedas enviarla a los demás jugadores.
 Players can enter your game by copying the game ID to the clipboard, and clicking on the 'Add multiplayer game' button = Los jugadores pueden entrar en tu partida copiando la ID de partida al portapapeles y haciendo clic en el botón "Añadir partida multijugador"
@@ -626,7 +626,7 @@ Load [saveFileName] = Cargar [saveFileName]
 Delete save = Borrar partida
 [saveFileName] deleted successfully. = [saveFileName] eliminada con éxito.
 Insufficient permissions to delete [saveFileName]. = Permisos faltantes para eliminar [saveFileName].
-Failed to delete [saveFileName]. = No se pudo eliminar eliminar [saveFileName].
+Failed to delete [saveFileName]. = No se pudo eliminar [saveFileName].
 Saved at = Guardado en
 Saving... = Guardando...
 Overwrite existing file? = ¿Sobreescribir el archivo existente?
@@ -640,7 +640,7 @@ Could not load game from custom location! = ¡No se pudo cargar la partida desde
 Save to custom location = Guardar en una ubicación personalizada
 Could not save game to custom location! = ¡No se pudo guardar la partida en la ubicación personalizada!
  # Requires translation!
-Download missing mods = 
+Download missing mods = Descargar mods faltantes
 Missing mods are downloaded successfully. = Los Mods faltantes fueron descargados exitosamente.
 Could not load the missing mods! = ¡No se pudieron cargar los mods faltantes!
 Could not download mod list. = No se pudo descargar la lista de mods.
@@ -685,7 +685,7 @@ Show pixel improvements = Mostrar píxeles de mejoras
 Enable Nuclear Weapons = Permitir Armas Nucleares
 Experimental Demographics scoreboard = Tabla de puntaje Demográfica - Experimental
  # Requires translation!
-Show zoom buttons in world screen = 
+Show zoom buttons in world screen = Mostrar botones de zoom en la pantalla del mundo
 Show tile yields = Mostrar rendimientos de casilla
 Show unit movement arrows = Mostrar flechas de movimiento de unidad
 Continuous rendering = Renderizado Continuo
@@ -890,14 +890,14 @@ Explore = Explorar
 Stop exploration = Detener exploración
 Pillage = Saquear
  # Requires translation!
-Wait = 
+Wait = Esperar
 Are you sure you want to pillage this [improvement]? = ¿Seguro que quieres saquear este [improvement]?
  # Requires translation!
-We have looted [amount] from a [improvement] = 
+We have looted [amount] from a [improvement] = Hemos saqueado [amount] de un [improvement]
  # Requires translation!
-We have looted [amount] from a [improvement] which has been sent to [cityName] = 
+We have looted [amount] from a [improvement] which has been sent to [cityName] = Saqueamos [amount] de un [improvement] que fué enviado a [cityName]
  # Requires translation!
-An enemy [unitName] has pillaged our [improvement] = 
+An enemy [unitName] has pillaged our [improvement] = Un/a [unitName] enemigo ha saqueado nuestro [improvement]
 Create [improvement] = Crear [improvement]
 Start Golden Age = Empezar Edad de Oro
 Trigger unique = Activar exclusivo
@@ -971,13 +971,13 @@ Replaces [improvement] = Sustituye [improvement]
 Pick now! = ¡Elige!
 Remove [feature] first = Quita [feature] primero
  # Requires translation!
-Research [tech] first = 
+Research [tech] first = Investigar primero [tech]
  # Requires translation!
-Have this tile close to your borders = 
+Have this tile close to your borders = Tener esta casilla cerca de tus bordes
  # Requires translation!
-Have this tile inside your empire = 
+Have this tile inside your empire = Tener esta casilla dentro de tu imperio
  # Requires translation!
-Acquire more [resource] = 
+Acquire more [resource] = Adquirir más [resource]
 Build [building] = Construir [building]
 Train [unit] = Entrenar [unit]
 Produce [thingToProduce] = Producir [thingToProduce]
@@ -1323,9 +1323,9 @@ Embarked strength: [amount]† = Fuerza embarcado: [amount]†
 Base unit buy cost: [amount]¤ = Coste base de compra de unidad: [amount]¤
 Research agreement cost: [amount]¤ = Coste de Acuerdo de Investigación: [amount]¤
  # Requires translation!
-Pillaging this improvement yields [stats] = 
+Pillaging this improvement yields [stats] = Saquear esta mejora da [stats]
  # Requires translation!
-Pillaging this improvement yields approximately [stats] = 
+Pillaging this improvement yields approximately [stats] = Saquear esta mejora da aproximadamente [stats]
 
 # Policies
 
@@ -5475,7 +5475,7 @@ What motivates me to keep working on it, \n  besides the fact I think it's amazi
 Every rating and review that I get puts a smile on my face =)\n  So contact me! Send me an email, review, Github issue\n  or mail pigeon, and let's figure out how to make the game \n  even more awesome!\n(Contact info is in the Play Store) = Cada valoración y reseña hace que sonría =)\n ¡Así que contactarme! Enviadme un email, una issue en GitHub\n o una paloma mensajera y averiguaremos como hacer el juego\n incluso más increíble.
 
 Pillaging = Saqueo
-Military units can pillage improvements, which heals them 25 health and ruins the improvement.\nThe tile can still be worked, but advantages from the improvement - stat bonuses and resources - will be lost.\nWorkers can repair these improvements, which takes less time than building the improvement from scratch.\nPillaging certain improvements will result in your units looting gold from the improvement. = Unidades militares pueden saquear mejoras, lo que les cura 25 de salud y destruye la mejora.\nEl título todavía de puede trabajar, pero los beneficios de la mejora - bonificaciones de estadísticas y recursos - se perderán\nTrabajadores pueden arreglar estas mejoras, lo cual les toma menos tiempo que counstruir la mejora desde cero.\nSaquear ciertas mejoras hará que tus unidades saqueen el oro de la mejora.
+Military units can pillage improvements, which heals them 25 health and ruins the improvement.\nThe tile can still be worked, but advantages from the improvement - stat bonuses and resources - will be lost.\nWorkers can repair these improvements, which takes less time than building the improvement from scratch.\nPillaging certain improvements will result in your units looting gold from the improvement. = Las Unidades militares pueden saquear mejoras, lo que les cura 25 de salud y destruye la mejora.\nLa casilla todavía de podrá trabajar, pero los beneficios de la mejora - bonificaciones de estadísticas y recursos - se perderán.\nLos Trabajadores pueden arreglar estas mejoras, lo cual les toma menos tiempo que construir la mejora desde cero.\nSaquear ciertas mejoras hará que tus unidades saqueen el oro de la mejora.
 
 Experience = Experiencia
 Units that enter combat gain experience, which can then be used on promotions for that unit.\nUnits gain more experience when in Melee combat than Ranged, and more when attacking than when defending. = Las unidades que entren en combate ganarán experiencia, la cual podrá ser usada para ascender a esa unidad.\nLas unidades ganan más experiencia cuando luchan cuerpo a cuerpo que cuando lo hacen a distancia, y ganan más cuando atacan que cuando defienden.


### PR DESCRIPTION
Sometimes I wish for a way for other translators to abide to a standart translation. For example, almost everyone translates "tile" to a different thing, while we have standarized it to "casilla", most still translate it to something else. Or for example, it has been standarized to "talk" to the user "tuteando", more personally/friendly.
But I have no idea how that could work.