### PR TITLE
Prevent a case where ancient ruins would give two rewards

### DIFF
--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -448,6 +448,7 @@ object UniqueTriggerActivation {
                         tile.position,
                         NotificationIcon.Ruins
                     )
+                return true
             }
 
             OneTimeTriggerVoting -> {


### PR DESCRIPTION
When ruins give their reward, they check that `UniqueTriggerActivation.triggerCivwideUnique()` returns true, meaning that the ruin reward was executed correctly, and if it returns false, tries `UniqueTriggerActivation.triggerUnitwideUnique()` for the same reward and if it returns false as well, then the ruin tries another reward. A single ruin reward, the "find a crudely-drawn map" one, was missing a `return true` so it would return false by default even when it executed properly, causing players to receive a second ruin reward. That specific ruin reward has been fixed to return true when it executes correctly, preventing a second reward.