### PR TITLE
Fix scout not upgrading through ruins

### DIFF
--- a/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
@@ -370,7 +370,7 @@ object UnitActions {
         isFree: Boolean,
         isSpecial: Boolean
     ): UnitAction? {
-        if (unit.baseUnit().upgradesTo == null) return null
+        if (unit.baseUnit().upgradesTo == null && unit.baseUnit().specialUpgradesTo == null) return null // can't upgrade to anything
         val unitTile = unit.getTile()
         val civInfo = unit.civInfo
         if (!isFree && unitTile.getOwner() != civInfo) return null


### PR DESCRIPTION
Fixes #7090. There was a missing check to see if the unit has a special upgrade possible so it was affecting scouts upgrading to archers not just unique units like the issue mentions.