### PR TITLE
fixed minimap showing fog of war everywhere when you joined a mp game without being a player

### DIFF
--- a/core/src/com/unciv/ui/worldscreen/minimap/Minimap.kt
+++ b/core/src/com/unciv/ui/worldscreen/minimap/Minimap.kt
@@ -131,11 +131,8 @@ class Minimap(val mapHolder: WorldMapHolder, minimapSize: Int) : Group() {
                 minimapTile.owningCiv = tileInfo.getOwner()
             }
 
-            val shouldBeUnrevealed = if (viewingCiv.isSpectator()) {
-                false
-            } else {
-                tileInfo.position !in viewingCiv.exploredTiles
-            }
+            val shouldBeUnrevealed = tileInfo.position !in viewingCiv.exploredTiles && !viewingCiv.isSpectator()
+
             val revealStatusChanged = minimapTile.isUnrevealed != shouldBeUnrevealed
             if (revealStatusChanged || ownerChanged) {
                 minimapTile.updateColor(shouldBeUnrevealed)

--- a/core/src/com/unciv/ui/worldscreen/minimap/Minimap.kt
+++ b/core/src/com/unciv/ui/worldscreen/minimap/Minimap.kt
@@ -131,10 +131,10 @@ class Minimap(val mapHolder: WorldMapHolder, minimapSize: Int) : Group() {
                 minimapTile.owningCiv = tileInfo.getOwner()
             }
 
-            val shouldBeUnrevealed = if(!viewingCiv.isSpectator()) {
-                tileInfo.position !in viewingCiv.exploredTiles
-            } else {
+            val shouldBeUnrevealed = if (viewingCiv.isSpectator()) {
                 false
+            } else {
+                tileInfo.position !in viewingCiv.exploredTiles
             }
             val revealStatusChanged = minimapTile.isUnrevealed != shouldBeUnrevealed
             if (revealStatusChanged || ownerChanged) {

--- a/core/src/com/unciv/ui/worldscreen/minimap/Minimap.kt
+++ b/core/src/com/unciv/ui/worldscreen/minimap/Minimap.kt
@@ -131,7 +131,11 @@ class Minimap(val mapHolder: WorldMapHolder, minimapSize: Int) : Group() {
                 minimapTile.owningCiv = tileInfo.getOwner()
             }
 
-            val shouldBeUnrevealed = tileInfo.position !in viewingCiv.exploredTiles
+            val shouldBeUnrevealed = if(!viewingCiv.isSpectator()) {
+                tileInfo.position !in viewingCiv.exploredTiles
+            } else {
+                false
+            }
             val revealStatusChanged = minimapTile.isUnrevealed != shouldBeUnrevealed
             if (revealStatusChanged || ownerChanged) {
                 minimapTile.updateColor(shouldBeUnrevealed)

--- a/core/src/com/unciv/ui/worldscreen/minimap/Minimap.kt
+++ b/core/src/com/unciv/ui/worldscreen/minimap/Minimap.kt
@@ -132,7 +132,6 @@ class Minimap(val mapHolder: WorldMapHolder, minimapSize: Int) : Group() {
             }
 
             val shouldBeUnrevealed = tileInfo.position !in viewingCiv.exploredTiles && !viewingCiv.isSpectator()
-
             val revealStatusChanged = minimapTile.isUnrevealed != shouldBeUnrevealed
             if (revealStatusChanged || ownerChanged) {
                 minimapTile.updateColor(shouldBeUnrevealed)


### PR DESCRIPTION
Spectator has 0 explored tiles if you join a mp game without being invited (without having your user id in the list of players).
This caused the minimap to show the fog of war everywhere

resolves  #7088