### PR TITLE
Removed incorrectly translated strings from indonesian translation

### DIFF
--- a/android/assets/jsons/translations/Indonesian.properties
+++ b/android/assets/jsons/translations/Indonesian.properties
@@ -15,11 +15,11 @@ StartWithCapitalLetter = true
 
 # Documentation: https://f-droid.org/en/docs/Build_Metadata_Reference/#Summary
 # English to translate: https://github.com/yairm210/Unciv/blob/master/fastlane/metadata/android/en-US/short_description.txt
-Fastlane_short_description = Fastlane_penjelasan_singkat
+Fastlane_short_description = 
 
 # Documentation: https://f-droid.org/en/docs/Build_Metadata_Reference/#Description
 # English to translate: https://github.com/yairm210/Unciv/blob/master/fastlane/metadata/android/en-US/full_description.txt
-Fastlane_full_description = Fastlane_penjelesan_lengkap
+Fastlane_full_description = 
 
 
 # Starting from here normal translations start, as described in


### PR DESCRIPTION
They should not be translated literally, but the link above should be followed to find what should be translated instead.