### PR TITLE
disable worldWrap map parameter if its disabled in settings

### DIFF
--- a/core/src/com/unciv/ui/newgamescreen/MapParametersTable.kt
+++ b/core/src/com/unciv/ui/newgamescreen/MapParametersTable.kt
@@ -222,6 +222,7 @@ class MapParametersTable(
             addNoRuinsCheckbox()
             addNoNaturalWondersCheckbox()
             if (showWorldWrap) addWorldWrapCheckbox()
+            else mapParameters.worldWrap = false
         }).colspan(2).center().row()
         if (showWorldWrap)
             add("World wrap maps are very memory intensive - creating large world wrap maps on Android can lead to crashes!"


### PR DESCRIPTION
If you created a game with worldWrap and then turned off worldWrap in settings, the map parameter remains turned on and you can't disable it unless you reenable it in settings, create the world with it disabled (in parameters) and then disable it in settings

This fixes that

resolves #7116