### PR TITLE
Stop AI puppets from building settlers and military

### DIFF
--- a/core/src/com/unciv/logic/automation/Automation.kt
+++ b/core/src/com/unciv/logic/automation/Automation.kt
@@ -106,6 +106,7 @@ object Automation {
     }
 
     fun tryTrainMilitaryUnit(city: CityInfo) {
+        if (city.isPuppet) return
         val chosenUnitName = chooseMilitaryUnit(city)
         if (chosenUnitName != null)
             city.cityConstructions.currentConstructionFromQueue = chosenUnitName

--- a/core/src/com/unciv/logic/automation/NextTurnAutomation.kt
+++ b/core/src/com/unciv/logic/automation/NextTurnAutomation.kt
@@ -858,7 +858,7 @@ object NextTurnAutomation {
             city.reassignAllPopulation()
 
             city.cityConstructions.chooseNextConstruction()
-            if (city.health < city.getMaxHealth() && !city.isPuppet)
+            if (city.health < city.getMaxHealth())
                 Automation.tryTrainMilitaryUnit(city) // override previous decision if city is under attack
         }
     }

--- a/core/src/com/unciv/logic/automation/NextTurnAutomation.kt
+++ b/core/src/com/unciv/logic/automation/NextTurnAutomation.kt
@@ -858,7 +858,7 @@ object NextTurnAutomation {
             city.reassignAllPopulation()
 
             city.cityConstructions.chooseNextConstruction()
-            if (city.health < city.getMaxHealth())
+            if (city.health < city.getMaxHealth() && !city.isPuppet)
                 Automation.tryTrainMilitaryUnit(city) // override previous decision if city is under attack
         }
     }
@@ -878,7 +878,7 @@ object NextTurnAutomation {
                     currentConstruction is BaseUnit && currentConstruction.hasUnique(UniqueType.FoundCity)
                 }) {
 
-            val bestCity = civInfo.cities.maxByOrNull { it.cityStats.currentCityStats.production }!!
+            val bestCity = civInfo.cities.filterNot { it.isPuppet }.maxByOrNull { it.cityStats.currentCityStats.production }!!
             if (bestCity.cityConstructions.builtBuildings.size > 1) // 2 buildings or more, otherwise focus on self first
                 bestCity.cityConstructions.currentConstructionFromQueue = settlerUnits.minByOrNull { it.cost }!!.name
         }


### PR DESCRIPTION
Puppeted cities should not be able to build units and their normal construction logic obeys this directive, but there are two spots I found that would change the production of an AI city to a military unit or settler without checking if the city is a puppet.