### PR TITLE
Fix positioning of the spectator's fog of war button

### DIFF
--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -154,7 +154,6 @@ class WorldScreen(val gameInfo: GameInfo, val viewingCiv:CivilizationInfo) : Bas
         techPolicyAndVictoryHolder.add(techButtonHolder)
 
         fogOfWarButton.isVisible = viewingCiv.isSpectator()
-        fogOfWarButton.setPosition(10f, topBar.y - fogOfWarButton.height - 10f)
 
         // Don't show policies until they become relevant
         if (viewingCiv.policies.adoptedPolicies.isNotEmpty() || viewingCiv.policies.canAdoptPolicy()) {
@@ -187,6 +186,9 @@ class WorldScreen(val gameInfo: GameInfo, val viewingCiv:CivilizationInfo) : Bas
         stage.addActor(battleTable)
 
         stage.addActor(unitActionsTable)
+
+        topBar.update(viewingCiv)
+        fogOfWarButton.setPosition(10f, topBar.y - fogOfWarButton.height - 10f)
 
         val tileToCenterOn: Vector2 =
                 when {


### PR DESCRIPTION
The fog of war toggle disappeared from the screen recently. The cause lies in the `topBar.y` being 0 until the top bar is updated during `update()`, which causes the fog of war button to be placed below the bottom of the screen as it uses `topBar.y` to set vertical position and is placed before `topBar.y` is properly set. This PR changes it so that `topBar.update(viewingCiv)` is called during the world screen's initialization so that the fog of war button can be placed in the correct spot.