### PR TITLE
Fix unit being captured two times

### DIFF
--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -348,9 +348,12 @@ object Battle {
         addedUnit.currentMovement = 0f
         addedUnit.health = 50
         attacker.getCivInfo().addNotification(notification, addedUnit.getTile().position, attacker.getName(), unitName)
-        // Also capture any civilians on the same tile
-        if (tile.civilianUnit != null)
-            captureCivilianUnit(attacker, MapUnitCombatant(tile.civilianUnit!!))
+
+        val civilianUnit = tile.civilianUnit
+        // placeUnitNearTile might not have spawned the unit in exactly this tile, in which case no capture would have happened on this tile. So we need to do that here.
+        if (addedUnit.getTile() != tile && civilianUnit != null) {
+            captureCivilianUnit(attacker, MapUnitCombatant(civilianUnit))
+        }
         return true
     }
 
@@ -559,7 +562,14 @@ object Battle {
         return null
     }
 
+    /**
+     * @throws IllegalArgumentException if the [attacker] and [defender] belong to the same civ.
+     */
     fun captureCivilianUnit(attacker: ICombatant, defender: MapUnitCombatant, checkDefeat: Boolean = true) {
+        if (attacker.getCivInfo() == defender.getCivInfo()) {
+            throw IllegalArgumentException("Can't capture our own unit!")
+        }
+
         // need to save this because if the unit is captured its owner wil be overwritten
         val defenderCiv = defender.getCivInfo()
 


### PR DESCRIPTION
`placeUnitNearTile` already captures any civilian units it places its unit into. But `spawnCapturedUnit` unconditionally tries to capture the unit again. This resulted in capturing a unit that the civ already owned, which shouldn't work. However, `captureCivilianUnit` only checks for the `originalOwner`, not the current owner, and still does the capture anyway. This resulted in the dialog "Do you want to return this captured unit to yourself?" which then finally resulted in an exception. 

Took a while to figure the root cause out. Since `captureCivilianUnit` should not be called for capturing our own unit, I made it throw an `IllegalArgumentException`, which should catch these kind of errors during development, or at least make a bug easier to find.