### PR TITLE
Improvements to AI military unit usage

### DIFF
--- a/core/src/com/unciv/logic/automation/BattleHelper.kt
+++ b/core/src/com/unciv/logic/automation/BattleHelper.kt
@@ -21,16 +21,15 @@ object BattleHelper {
                 BattleDamage.calculateDamageToAttacker(
                     MapUnitCombatant(unit),
                     Battle.getMapCombatantOfTile(it.tileToAttack)!!
-                ) < unit.health
+                ) + unit.getDamageFromTerrain(it.tileToAttackFrom) < unit.health
             }
 
         val enemyTileToAttack = chooseAttackTarget(unit, attackableEnemies)
 
         if (enemyTileToAttack != null) {
             Battle.moveAndAttack(MapUnitCombatant(unit), enemyTileToAttack)
-            return true
         }
-        return false
+        return unit.currentMovement < Constants.minimumMovementEpsilon
     }
 
     fun getAttackableEnemies(

--- a/core/src/com/unciv/logic/automation/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/UnitAutomation.kt
@@ -474,8 +474,9 @@ object UnitAutomation {
             // move into position far away enough that the bombard doesn't hurt
             if (tileToMoveTo != null) {
                 unit.movement.headTowards(tileToMoveTo)
+                return true
             }
-            return unit.currentMovement < Constants.minimumMovementEpsilon
+            return false
         }
 
         val numberOfUnitsAroundCity = closestReachableEnemyCity.getTilesInDistance(4)
@@ -491,13 +492,13 @@ object UnitAutomation {
 
             if (tileToHeadTo != null) { // no need to worry, keep going as the movement alg. says
                 unit.movement.headTowards(tileToHeadTo)
-                return unit.currentMovement < Constants.minimumMovementEpsilon
             }
+            return true
         }
 
         unit.movement.headTowards(closestReachableEnemyCity) // go for it!
 
-        return unit.currentMovement < Constants.minimumMovementEpsilon
+        return true
     }
 
     fun tryEnterOwnClosestCity(unit: MapUnit): Boolean {

--- a/core/src/com/unciv/logic/automation/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/UnitAutomation.kt
@@ -226,18 +226,12 @@ object UnitAutomation {
         // move towards the closest reasonably attackable enemy unit within 3 turns of movement (and 5 tiles range)
         if (tryAdvanceTowardsCloseEnemy(unit)) return
 
-        // may be able to attack an enemy now
-        if (tryAttacking(unit)) return
-
         if (unit.health < 100 && tryHealUnit(unit)) return
 
         // Focus all units without a specific target on the enemy city closest to one of our cities
         if (tryHeadTowardsEnemyCity(unit)) return
 
         if (tryHeadTowardsEncampment(unit)) return
-
-        // one last attack attempt
-        if (tryAttacking(unit)) return
 
         // else, try to go to unreached tiles
         if (tryExplore(unit)) return

--- a/core/src/com/unciv/logic/automation/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/UnitAutomation.kt
@@ -356,7 +356,7 @@ object UnitAutomation {
             unit.movement.moveToTile(tileToPillage)
 
         UnitActions.getPillageAction(unit)?.action?.invoke()
-        return true
+        return unit.currentMovement < Constants.minimumMovementEpsilon
     }
 
     fun getBombardTargets(city: CityInfo): Sequence<TileInfo> =
@@ -394,9 +394,8 @@ object UnitAutomation {
 
         if (closestEnemy != null) {
             unit.movement.headTowards(closestEnemy.tileToAttackFrom)
-            return true
         }
-        return false
+        return unit.currentMovement < Constants.minimumMovementEpsilon
     }
 
     private fun tryAccompanySettlerOrGreatPerson(unit: MapUnit): Boolean {
@@ -419,6 +418,9 @@ object UnitAutomation {
                             it.health < it.getMaxHealth() * 0.75
                 } //Weird health issues and making sure that not all forces move to good defenses
 
+        if (siegedCities.any { it.getCenterTile().aerialDistanceTo(unit.getTile()) <= 2 })
+            return false
+
         val reachableTileNearSiegedCity = siegedCities
                 .flatMap { it.getCenterTile().getTilesAtDistance(2) }
                 .sortedBy { it.aerialDistanceTo(unit.currentTile) }
@@ -427,9 +429,8 @@ object UnitAutomation {
 
         if (reachableTileNearSiegedCity != null) {
             unit.movement.headTowards(reachableTileNearSiegedCity)
-            return true
         }
-        return false
+        return unit.currentMovement < Constants.minimumMovementEpsilon
     }
 
     fun tryHeadTowardsEnemyCity(unit: MapUnit): Boolean {

--- a/core/src/com/unciv/logic/automation/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/UnitAutomation.kt
@@ -215,7 +215,7 @@ object UnitAutomation {
         if (BattleHelper.tryDisembarkUnitToAttackPosition(unit)) return
 
         // if there is an attackable unit in the vicinity, attack!
-        if (BattleHelper.tryAttackNearbyEnemy(unit)) return
+        if (tryAttacking(unit)) return
 
         if (tryTakeBackCapturedCity(unit)) return
 
@@ -226,12 +226,18 @@ object UnitAutomation {
         // move towards the closest reasonably attackable enemy unit within 3 turns of movement (and 5 tiles range)
         if (tryAdvanceTowardsCloseEnemy(unit)) return
 
+        // may be able to attack an enemy now
+        if (tryAttacking(unit)) return
+
         if (unit.health < 100 && tryHealUnit(unit)) return
 
         // Focus all units without a specific target on the enemy city closest to one of our cities
         if (tryHeadTowardsEnemyCity(unit)) return
 
         if (tryHeadTowardsEncampment(unit)) return
+
+        // one last attack attempt
+        if (tryAttacking(unit)) return
 
         // else, try to go to unreached tiles
         if (tryExplore(unit)) return
@@ -241,6 +247,14 @@ object UnitAutomation {
         // Idle CS units should wander so they don't obstruct players so much
         if (unit.civInfo.isCityState())
             wander(unit, stayInTerritory = true)
+    }
+
+    /** @return true only if the unit has 0 movement left */
+    private fun tryAttacking(unit: MapUnit): Boolean {
+        for (numAttacks in unit.attacksThisTurn until unit.maxAttacksPerTurn()) {
+            if (BattleHelper.tryAttackNearbyEnemy(unit)) return true
+        }
+        return false
     }
 
     private fun tryHeadTowardsEncampment(unit: MapUnit): Boolean {

--- a/core/src/com/unciv/logic/automation/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/UnitAutomation.kt
@@ -385,8 +385,9 @@ object UnitAutomation {
 
         if (closestEnemy != null) {
             unit.movement.headTowards(closestEnemy.tileToAttackFrom)
+            return true
         }
-        return unit.currentMovement < Constants.minimumMovementEpsilon
+        return false
     }
 
     private fun tryAccompanySettlerOrGreatPerson(unit: MapUnit): Boolean {


### PR DESCRIPTION
The AI military action logic has been changed in a few places and the AI able to better perform actions including attacking and rallying for a defense or attack. Most of the changes are in UnitAutomation.kt, where there are a series of lines that look like `if (trySomeAction(unit)) return`. Once the return statement is hit, the AI stops giving orders to the unit for the turn regardless of how many movement points are left. As a result, the AI would never be able to attack more than once per turn or move after attacking or pillaging, which is a huge benefit to certain promotions and units/uniques. Attacking logic has been changed so that the AI will now attempt to attack as many times as it is allow by promotions (e.g., chu-ko-nus or other units with the logistics promotion). Several of the `trySomeAction(unit)` style functions in this file have also have their return statements changed, usually to `return unit.currentMovement < Constants.minimumMovementEpsilon` so that they can do another action if they have movement points left. The functions affected are
* `tryUpgradeUnit`
* `tryHeadTowardsSiegedCity`
* `tryPillageImprovement`
* `BattleHelper.tryAttackNearbyEnemy`
* `headTowardsEnemyCity`

The first two functions were particularly bad since they would always return true whether or not the action was successful, meaning that units would do nothing while trying to upgrade for dozens of turns or units would endlessly try to travel to a city to defend it without even attempting to attack the besieging army. The AI is also much better with cavalry and tanks and is able to chain together actions in a somewhat logical manner (move into enemy territory -> attack enemy -> pillage improvement to gain health -> retreat outside of enemy borders to heal more).