### PR TITLE
Not enter the city while performing an air strikes sequence

### DIFF
--- a/core/src/com/unciv/ui/tilegroups/CityButton.kt
+++ b/core/src/com/unciv/ui/tilegroups/CityButton.kt
@@ -163,9 +163,10 @@ class CityButton(val city: CityInfo, private val tileGroup: WorldTileGroup): Tab
             if (isButtonMoved) {
                 val viewingCiv = worldScreen.viewingCiv
                 // second tap on the button will go to the city screen
-                // if this city belongs to you
-                if (uncivGame.viewEntireMapForDebug || belongsToViewingCiv() || viewingCiv.isSpectator()) {
-                    uncivGame.setScreen(CityScreen(city))
+                // if this city belongs to you and you are not iterating though the air units
+                if (uncivGame.viewEntireMapForDebug || viewingCiv.isSpectator()
+                    || (belongsToViewingCiv() && !tileGroup.tileInfo.airUnits.contains(unitTable.selectedUnit))) {
+                        uncivGame.setScreen(CityScreen(city))
                 } else if (viewingCiv.knows(city.civInfo)) {
                     foreignCityInfoPopup()
                 }


### PR DESCRIPTION
Fixes #5604.

I agree with the reporter, the behaviour is really annoying and the suggested workaround by Xander is not intuitive as well as difficult for small mobile screens.
Now the behaviour is consistent with the air carriers and is more intuitive: the 2nd, 3rd, N-th air unit can be selected in the same way as the 1st one - via the city button.

P.S> For those who may ask "what if `selectedUnit == null`", the `contains()` has special handling for this case, so there will be no problems since `airUnits` contains a non-nullable `MapUnit` type.

P.P.S> The `&&` has higher precedence than `||`, so the braces are not needed there, but I keep them in the name of readability.