### PR TITLE
Prevent AI from sending duplicate peace treaties

### DIFF
--- a/core/src/com/unciv/logic/automation/NextTurnAutomation.kt
+++ b/core/src/com/unciv/logic/automation/NextTurnAutomation.kt
@@ -790,6 +790,8 @@ object NextTurnAutomation {
                 .filter { !civInfo.getDiplomacyManager(it).hasFlag(DiplomacyFlags.DeclinedPeace) }
                 // Don't allow AIs to offer peace to city states allied with their enemies
                 .filterNot { it.isCityState() && it.getAllyCiv() != null && civInfo.isAtWarWith(civInfo.gameInfo.getCivilization(it.getAllyCiv()!!)) }
+                // ignore civs that we have already offered peace this turn as a counteroffer to another civ's peace offer
+                .filter { it.tradeRequests.none { tradeRequest -> tradeRequest.requestingCiv == civInfo.civName && tradeRequest.trade.isPeaceTreaty() } }
 
         for (enemy in enemiesCiv) {
             val motivationToAttack = motivationToAttack(civInfo, enemy)


### PR DESCRIPTION
Fixes #7146. The player had sent a peace treaty offer which the AI processed and sent a counteroffer. Then separately it sent a peace treaty to the player. The `offerPeaceTreaty(civInfo)` function has been changed to not send a peace offer to a civ which `civInfo` has already sent this turn as a part of a counteroffer.