### PR TITLE
increased kotlin version to latest 1.7.0

### DIFF
--- a/buildSrc/src/main/kotlin/BuildConfig.kt
+++ b/buildSrc/src/main/kotlin/BuildConfig.kt
@@ -1,7 +1,7 @@
 package com.unciv.build
 
 object BuildConfig {
-    const val kotlinVersion = "1.6.21"
+    const val kotlinVersion = "1.7.0"
     const val appName = "Unciv"
     const val appCodeNumber = 723
     const val appVersion = "4.1.9"

--- a/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
@@ -28,6 +28,7 @@ import com.unciv.ui.popup.YesNoPopup
 import com.unciv.ui.popup.hasOpenPopups
 import com.unciv.ui.utils.extensions.toPercent
 import com.unciv.ui.worldscreen.WorldScreen
+import com.unciv.utils.Log.debug
 import kotlin.math.min
 import kotlin.random.Random
 
@@ -573,6 +574,9 @@ object UnitActions {
                         unit.consume()
                     }.takeIf { canConductTradeMission }
                 )
+            }
+            else -> {
+                debug("Fragment ${unique.type} is not applicable to Great Person")
             }
         }
     }


### PR DESCRIPTION
Just saw that 1.7.0 released so I wanted to try this. I don't know how good of an idea it is to update to a x.0 release, so yeah..

After running migration it only wanted an else in a when statement
Run and Debug both work fine, but if I click "Make Project" i get the following:

```
Could not determine the dependencies of task ':ios:compileJava'.
> Could not resolve all task dependencies for configuration ':ios:compileClasspath'.
   > Could not resolve project :core.
     Required by:
         project :ios
      > No matching variant of project :core was found. The consumer was configured to find an API of a library compatible with Java 7, preferably in the form of class files, preferably optimized for standard JVMs, and its dependencies declared externally, as well as attribute 'org.jetbrains.kotlin.platform.type' with value 'jvm' but:
          - Variant 'apiElements' capability Unciv:core:1.0.1 declares an API of a library, packaged as a jar, preferably optimized for standard JVMs, and its dependencies declared externally, as well as attribute 'org.jetbrains.kotlin.platform.type' with value 'jvm':
              - Incompatible because this component declares a component compatible with Java 8 and the consumer needed a component compatible with Java 7
          - Variant 'runtimeElements' capability Unciv:core:1.0.1 declares a runtime of a library, packaged as a jar, preferably optimized for standard JVMs, and its dependencies declared externally, as well as attribute 'org.jetbrains.kotlin.platform.type' with value 'jvm':
              - Incompatible because this component declares a component compatible with Java 8 and the consumer needed a component compatible with Java 7

```