### PR TITLE
Implementation of Teams

### DIFF
--- a/core/src/com/unciv/UncivGame.kt
+++ b/core/src/com/unciv/UncivGame.kt
@@ -62,7 +62,7 @@ class UncivGame(parameters: UncivGameParameters) : Game() {
      */
     var viewEntireMapForDebug = false
     /** For when you need to test something in an advanced game and don't have time to faff around */
-    var superchargedForDebug = false
+    var superchargedForDebug = true
 
     /** Simulate until this turn on the first "Next turn" button press.
      *  Does not update World View changes until finished.

--- a/core/src/com/unciv/UncivGame.kt
+++ b/core/src/com/unciv/UncivGame.kt
@@ -62,7 +62,7 @@ class UncivGame(parameters: UncivGameParameters) : Game() {
      */
     var viewEntireMapForDebug = false
     /** For when you need to test something in an advanced game and don't have time to faff around */
-    var superchargedForDebug = true
+    var superchargedForDebug = false
 
     /** Simulate until this turn on the first "Next turn" button press.
      *  Does not update World View changes until finished.

--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -37,6 +37,17 @@ class GameInfo {
     var currentTurnStartTime = 0L
     var gameId = UUID.randomUUID().toString() // random string
 
+    fun addTechnologyToTeam(team: String, techName: String) {
+        var teammatesCivs = civilizations - civilizations.filter { it.team != team }
+        for (teammate in teammatesCivs) {
+            if (teammate.tech.techsResearched.find { it == techName } == techName)
+                teammatesCivs -= teammate
+        }
+        for (teammate in teammatesCivs) {
+            teammate.techsResearchedByTeam.add(techName)
+        }
+    }
+
     // Maps a civ to the civ they voted for
     var diplomaticVictoryVotesCast = HashMap<String, String>()
     // Set to false whenever the results still need te be processed

--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -62,9 +62,11 @@ class GameInfo {
     fun getTeammatesOfCiv(civInfo: CivilizationInfo): ArrayList<CivilizationInfo> {
         val teammates = ArrayList<CivilizationInfo>()
 
-        for (civ in civilizations) {
-            if (civ.team == civInfo.team) {
-                teammates.add(civ)
+        if (!civInfo.isBarbarian() && !civInfo.isSpectator() && !civInfo.isCityState()) {
+            for (civ in civilizations) {
+                if (civ.team == civInfo.team && civ != civInfo) {
+                    teammates.add(civ)
+                }
             }
         }
 

--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -48,6 +48,16 @@ class GameInfo {
         }
     }
 
+    fun countPlayersInTeam(team: String): Int {
+        var playerCount = 0
+        for (civ in civilizations) {
+            if (civ.team == team) {
+                playerCount++
+            }
+        }
+        return playerCount
+    }
+
     // Maps a civ to the civ they voted for
     var diplomaticVictoryVotesCast = HashMap<String, String>()
     // Set to false whenever the results still need te be processed

--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -21,6 +21,7 @@ import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.ui.audio.MusicMood
 import com.unciv.ui.audio.MusicTrackChooserFlags
 import java.util.*
+import kotlin.collections.ArrayList
 
 
 class GameInfo {
@@ -56,6 +57,18 @@ class GameInfo {
             }
         }
         return playerCount
+    }
+
+    fun getTeammatesOfCiv(civInfo: CivilizationInfo): ArrayList<CivilizationInfo> {
+        val teammates = ArrayList<CivilizationInfo>()
+
+        for (civ in civilizations) {
+            if (civ.team == civInfo.team) {
+                teammates.add(civ)
+            }
+        }
+
+        return teammates
     }
 
     // Maps a civ to the civ they voted for

--- a/core/src/com/unciv/logic/GameStarter.kt
+++ b/core/src/com/unciv/logic/GameStarter.kt
@@ -239,6 +239,7 @@ object GameStarter {
                 playerCiv.tech.techsResearched.add(tech.name) // can't be .addTechnology because the civInfo isn't assigned yet
             playerCiv.playerType = player.playerType
             playerCiv.playerId = player.playerId
+            playerCiv.team = player.team
             gameInfo.civilizations.add(playerCiv)
         }
 

--- a/core/src/com/unciv/logic/civilization/CivInfoTransientUpdater.kt
+++ b/core/src/com/unciv/logic/civilization/CivInfoTransientUpdater.kt
@@ -91,6 +91,10 @@ class CivInfoTransientUpdater(val civInfo: CivilizationInfo) {
             }
         }
 
+        for (teammate in civInfo.getTeammates()) {
+            newViewableTiles.addAll(teammate.viewableTiles)
+        }
+
         civInfo.viewableTiles = newViewableTiles // to avoid concurrent modification problems
     }
 

--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -876,11 +876,20 @@ class CivilizationInfo {
     fun updateViewableTiles() = transients().updateViewableTiles()
     fun updateDetailedCivResources() = transients().updateCivResources()
 
-    fun startTurn() {
+    // TODO: change this name to something better
+    fun teamStuff() {
         for (techName in techsResearchedByTeam) {
             tech.addTechnology(techName)
         }
         techsResearchedByTeam.clear()
+
+        for (teammate in gameInfo.getTeammatesOfCiv(this)) {
+            exploredTiles.addAll(teammate.exploredTiles)
+        }
+    }
+
+    fun startTurn() {
+        teamStuff()
         civConstructions.startTurn()
         attacksSinceTurnStart.clear()
         updateStatsForNextTurn() // for things that change when turn passes e.g. golden age, city state influence

--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -292,6 +292,10 @@ class CivilizationInfo {
     }
 
     //region pure functions
+    fun getTeammates(): ArrayList<CivilizationInfo> {
+        return gameInfo.getTeammatesOfCiv(this)
+    }
+
     fun getDifficulty(): Difficulty {
         if (isPlayerCivilization()) return gameInfo.getDifficulty()
         // TODO We should be able to mark a difficulty as 'default AI difficulty' somehow
@@ -882,10 +886,6 @@ class CivilizationInfo {
             tech.addTechnology(techName)
         }
         techsResearchedByTeam.clear()
-
-        for (teammate in gameInfo.getTeammatesOfCiv(this)) {
-            exploredTiles.addAll(teammate.exploredTiles)
-        }
     }
 
     fun startTurn() {

--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -80,7 +80,7 @@ class CivilizationInfo {
     @Transient
     lateinit var nation: Nation
 
-    var team = ""
+    var team = (Math.random()*100).toInt()
     var techsResearchedByTeam = ArrayList<String>()
 
     /**

--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -78,6 +78,8 @@ class CivilizationInfo {
     @Transient
     lateinit var nation: Nation
 
+    var team = ""
+
     /**
      * We never add or remove from here directly, could cause comodification problems.
      * Instead, we create a copy list with the change, and replace this list.
@@ -244,6 +246,7 @@ class CivilizationInfo {
         val toReturn = CivilizationInfo()
         toReturn.gold = gold
         toReturn.playerType = playerType
+        toReturn.team = team
         toReturn.playerId = playerId
         toReturn.civName = civName
         toReturn.tech = tech.clone()
@@ -912,6 +915,7 @@ class CivilizationInfo {
     }
 
     fun endTurn() {
+        println(team)
         notifications.clear()
 
         val nextTurnStats = statsForNextTurn

--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -144,6 +144,8 @@ class CivilizationInfo {
     @Transient
     var thingsToFocusOnForVictory = setOf<Victory.Focus>()
 
+    var friendshipWithTeamDeclared = false
+
     var playerType = PlayerType.AI
 
     /** Used in online multiplayer for human players */
@@ -883,15 +885,17 @@ class CivilizationInfo {
 
     // TODO: change this name to something better
     fun teamStuff() {
+        if (!friendshipWithTeamDeclared) {
+            for (teammate in getTeammates()) {
+                getDiplomacyManager(teammate.civName).setModifier(DiplomaticModifiers.DeclarationOfFriendship, 35f)
+            }
+            friendshipWithTeamDeclared = true
+        }
         // don't mind this, it will be removed when do the tech stuff
         for (techName in techsResearchedByTeam) {
             tech.addTechnology(techName)
         }
         techsResearchedByTeam.clear()
-
-        for (teammate in getTeammates()) {
-            getDiplomacyManager(teammate.civName).setModifier(DiplomaticModifiers.DeclarationOfFriendship, 35f)
-        }
     }
 
     fun startTurn() {

--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -12,6 +12,7 @@ import com.unciv.logic.city.CityInfo
 import com.unciv.logic.civilization.RuinsManager.RuinsManager
 import com.unciv.logic.civilization.diplomacy.DiplomacyFlags
 import com.unciv.logic.civilization.diplomacy.DiplomacyManager
+import com.unciv.logic.civilization.diplomacy.DiplomaticModifiers
 import com.unciv.logic.civilization.diplomacy.DiplomaticStatus
 import com.unciv.logic.map.MapShape
 import com.unciv.logic.map.MapUnit
@@ -882,10 +883,15 @@ class CivilizationInfo {
 
     // TODO: change this name to something better
     fun teamStuff() {
+        // don't mind this, it will be removed when do the tech stuff
         for (techName in techsResearchedByTeam) {
             tech.addTechnology(techName)
         }
         techsResearchedByTeam.clear()
+
+        for (teammate in getTeammates()) {
+            getDiplomacyManager(teammate.civName).setModifier(DiplomaticModifiers.DeclarationOfFriendship, 35f)
+        }
     }
 
     fun startTurn() {

--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -80,7 +80,7 @@ class CivilizationInfo {
     @Transient
     lateinit var nation: Nation
 
-    var team = (Math.random()*100).toInt()
+    var team = (Math.random()*100).toInt().toString()
     var techsResearchedByTeam = ArrayList<String>()
 
     /**

--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -42,6 +42,7 @@ import com.unciv.ui.utils.extensions.toPercent
 import com.unciv.ui.utils.extensions.withItem
 import com.unciv.ui.victoryscreen.RankingType
 import java.util.*
+import kotlin.collections.ArrayList
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.roundToInt
@@ -79,6 +80,7 @@ class CivilizationInfo {
     lateinit var nation: Nation
 
     var team = ""
+    var techsResearchedByTeam = ArrayList<String>()
 
     /**
      * We never add or remove from here directly, could cause comodification problems.
@@ -875,6 +877,10 @@ class CivilizationInfo {
     fun updateDetailedCivResources() = transients().updateCivResources()
 
     fun startTurn() {
+        for (techName in techsResearchedByTeam) {
+            tech.addTechnology(techName)
+        }
+        techsResearchedByTeam.clear()
         civConstructions.startTurn()
         attacksSinceTurnStart.clear()
         updateStatsForNextTurn() // for things that change when turn passes e.g. golden age, city state influence

--- a/core/src/com/unciv/logic/civilization/TechManager.kt
+++ b/core/src/com/unciv/logic/civilization/TechManager.kt
@@ -104,6 +104,10 @@ class TechManager {
         }
         techCost *= worldSizeModifier[0]
         techCost *= 1 + (civInfo.cities.size - 1) * worldSizeModifier[1]
+
+        //add 50% of techCost for each additional team member, like in Civ 5
+        techCost += (civInfo.gameInfo.countPlayersInTeam(civInfo.team) - 1) * (techCost * 0.5f)
+
         return techCost.toInt()
     }
 

--- a/core/src/com/unciv/logic/civilization/TechManager.kt
+++ b/core/src/com/unciv/logic/civilization/TechManager.kt
@@ -132,13 +132,13 @@ class TechManager {
         val tech = getRuleset().technologies[techName]!!
         if (tech.uniqueObjects.any { it.type == UniqueType.OnlyAvailableWhen && !it.conditionalsApply(civInfo) })
             return false
-        
+
         if (tech.getMatchingUniques(UniqueType.IncompatibleWith).any { isResearched(it.params[0]) })
             return false
-        
+
         if (isResearched(tech.name) && !tech.isContinuallyResearchable())
             return false
-        
+
         return tech.prerequisites.all { isResearched(it) }
     }
 
@@ -335,6 +335,8 @@ class TechManager {
             if (unique.params[1] != techName) continue
             civInfo.addNotification("You have unlocked [The Long Count]!", MayaLongCountAction(), MayaCalendar.notificationIcon)
         }
+
+        civInfo.gameInfo.addTechnologyToTeam(civInfo.team, techName)
 
         updateEra()
     }

--- a/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
@@ -615,7 +615,8 @@ class DiplomacyManager() {
         setFriendshipBasedModifier()
 
         if (!hasFlag(DiplomacyFlags.DeclarationOfFriendship))
-            revertToZero(DiplomaticModifiers.DeclarationOfFriendship, 1 / 2f) //decreases slowly and will revert to full if it is declared later
+            if (otherCiv().team != civInfo.team)
+                revertToZero(DiplomaticModifiers.DeclarationOfFriendship, 1 / 2f) //decreases slowly and will revert to full if it is declared later
 
         if (!otherCiv().isCityState()) return
 

--- a/core/src/com/unciv/models/metadata/GameParameters.kt
+++ b/core/src/com/unciv/models/metadata/GameParameters.kt
@@ -15,9 +15,6 @@ class GameParameters { // Default values are the default new game
             playerType = PlayerType.Human
             team = "1"
         })
-        add(Player().apply {
-            team = "1"
-        })
         for (i in 2..4) add(Player().apply { team = "$i" })
     }
     var numberOfCityStates = 6

--- a/core/src/com/unciv/models/metadata/GameParameters.kt
+++ b/core/src/com/unciv/models/metadata/GameParameters.kt
@@ -11,8 +11,14 @@ class GameParameters { // Default values are the default new game
     var difficulty = "Prince"
     var gameSpeed = GameSpeed.Standard
     var players = ArrayList<Player>().apply {
-        add(Player().apply { playerType = PlayerType.Human })
-        for (i in 1..3) add(Player())
+        add(Player().apply {
+            playerType = PlayerType.Human
+            team = "1"
+        })
+        add(Player().apply {
+            team = "1"
+        })
+        for (i in 2..4) add(Player().apply { team = "$i" })
     }
     var numberOfCityStates = 6
 
@@ -22,14 +28,14 @@ class GameParameters { // Default values are the default new game
     var godMode = false
     var nuclearWeaponsEnabled = true
     var religionEnabled = false
-    
-    var victoryTypes: ArrayList<String> = arrayListOf()  
+
+    var victoryTypes: ArrayList<String> = arrayListOf()
     var startingEra = "Ancient era"
 
     var isOnlineMultiplayer = false
     var baseRuleset: String = BaseRuleset.Civ_V_GnK.fullName
     var mods = LinkedHashSet<String>()
-    
+
     var maxTurns = 500
 
     fun clone(): GameParameters {
@@ -69,7 +75,7 @@ class GameParameters { // Default values are the default new game
             yield(baseRuleset)
             yield(if (mods.isEmpty()) "no mods" else mods.joinToString(",", "mods=(", ")", 6) )
         }.joinToString(prefix = "(", postfix = ")")
-    
+
     fun getModsAndBaseRuleset(): HashSet<String> {
         return mods.toHashSet().apply { add(baseRuleset) }
     }

--- a/core/src/com/unciv/models/metadata/Player.kt
+++ b/core/src/com/unciv/models/metadata/Player.kt
@@ -6,4 +6,5 @@ import com.unciv.logic.civilization.PlayerType
 class Player(var chosenCiv: String = Constants.random) {
     var playerType: PlayerType = PlayerType.AI
     var playerId=""
+    var team = "0"
 }

--- a/core/src/com/unciv/ui/newgamescreen/PlayerPickerTable.kt
+++ b/core/src/com/unciv/ui/newgamescreen/PlayerPickerTable.kt
@@ -164,6 +164,12 @@ class PlayerPickerTable(
                         update()
                     }).pad(5f).right().row()
         }
+        val playerTeamTextField = TextField(player.playerId, BaseScreen.skin)
+        playerTeamTextField.messageText = player.team.tr()
+        playerTeamTextField.text = player.team
+        playerTable.add(playerTeamTextField).colspan(2).fillX().pad(5f)
+        playerTeamTextField.addListener { player.team = playerTeamTextField.text; true }
+
         if (gameParameters.isOnlineMultiplayer && player.playerType == PlayerType.Human) {
 
             val playerIdTextField = TextField(player.playerId, BaseScreen.skin)


### PR DESCRIPTION
Before continuing I thought it might be a good idea to show what I have so far to avoid working on something which won't be implemented. I started by creating team classes for the `Player` objects and then wanted to create `Team` classes for the `CivilizationInfo`s from `GameInfo`, but since the teams only affect so little of the actual gameplay (time and domination victory only) I though the refactoring hell would not be worth it, although I still have this branch but didn't do the refactoring for civTeams. So I ditched that idea and went for this.

<a href="https://gaming.stackexchange.com/questions/251475/full-effects-of-being-in-the-same-team-in-civilization-v">Here is how teams work in Civ 5</a>

Roadmap:
- [ ] When any player on the team researches the tech tree all of the teammates get the technology. If you both research the same tech at the same time, the time for completing it will be halved.
- [x] Tech cost increases by 50% for each additional team member
- [x] You also see the map under fog of war which is cleared by the other player on the team.
- [ ] If any player on the team declares war on someone, the whole team goes into the war.
- [ ] The the points of everyone in the team will be counted together and it shows a team score at the list on the right.
- [ ] You can gift units (both combat & civilian) to your teammates just like you can for city-states normally.
- [x] You have permanent Declaration of Friendship with each other
- [ ] You'll still feel ideological pressure (reduced happiness for adopting different ideologies) from team mates
- [ ] Autocracy tenet Futurism doesn't work against team mates.

So far I have a rough UI which lets you assign teams to players and whenever you research something your teammates also get that tech.

~~I will also add a toggle for the teams at some point~~ looks like civ 5 always has teams enabled so I guess there's no point in doing this
