### PR TITLE
Fix wrong Duration short formatting

### DIFF
--- a/core/src/com/unciv/ui/utils/extensions/FormattingExtensions.kt
+++ b/core/src/com/unciv/ui/utils/extensions/FormattingExtensions.kt
@@ -51,7 +51,7 @@ private fun Duration.toParts(): SortedMap<ChronoUnit, Long> {
 fun Duration.formatShort(): String {
     val parts = toParts()
     for ((unit, part) in parts) {
-        if (part > 2) return "[${part}] $unit".tr()
+        if (part > 0) return "[${part}] $unit".tr()
     }
     return "[${parts[ChronoUnit.SECONDS]}] ${ChronoUnit.SECONDS}".tr()
 }


### PR DESCRIPTION
This was a remnant from how the formatting worked before.

If you want to show the most significant part, you should not exclude that part when it has a value of 1 or 2...