### PR TITLE
Fix option change not reloading main menu properly

### DIFF
--- a/core/src/com/unciv/UncivGame.kt
+++ b/core/src/com/unciv/UncivGame.kt
@@ -204,12 +204,12 @@ class UncivGame(parameters: UncivGameParameters) : Game() {
     }
 
     /** Re-creates the current [worldScreen], if there is any. */
-    fun reloadWorldscreen() {
+    suspend fun reloadWorldscreen() {
         val curWorldScreen = worldScreen
         val curGameInfo = gameInfo
         if (curWorldScreen == null || curGameInfo == null) return
 
-        Concurrency.run { loadGame(curGameInfo) }
+        loadGame(curGameInfo)
     }
 
     private data class NewScreens(val screenToShow: BaseScreen, val worldScreen: WorldScreen) {


### PR DESCRIPTION
Over two of my recent changes I accidentally removed two features in `OptionsPopup.reloadWorldAndOptions`... First the main menu reload in 9008d242a3f7e07d5859f7d1d9adfa884f94d26d and then opening the options again in a5f9623dbec8d6cc39d1961ce38f50f3d99b96bf. I'm not sure how I've managed to do it honestly :D