### PR TITLE
Restore unit action shortcuts accidentally dropped in commit 4fb2ad8fa

### DIFF
--- a/core/src/com/unciv/ui/worldscreen/unit/UnitActionsTable.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitActionsTable.kt
@@ -49,6 +49,7 @@ class UnitActionsTable(val worldScreen: WorldScreen) : Table() {
                 // overlay, since the user definitely wants to interact with the new unit.
                 worldScreen.mapHolder.removeUnitActionOverlay()
             }
+            actionButton.keyShortcuts.add(key)
         }
 
         return actionButton


### PR DESCRIPTION
Unit action shortcuts got broken, but this is not a fault of the refactoring: this was accidentally done later when merging shortcut and click callbacks.