### PR TITLE
Fix memory leaks in BaseScreen & gdx.Stage/gdx.TextFields

### DIFF
--- a/core/src/com/unciv/MainMenuScreen.kt
+++ b/core/src/com/unciv/MainMenuScreen.kt
@@ -38,11 +38,11 @@ import com.unciv.ui.tutorials.EasterEggRulesets.modifyForEasterEgg
 import com.unciv.ui.utils.AutoScrollPane
 import com.unciv.ui.utils.BaseScreen
 import com.unciv.ui.utils.KeyCharAndCode
+import com.unciv.ui.utils.RecreateOnResize
 import com.unciv.ui.utils.UncivTooltip.Companion.addTooltip
 import com.unciv.ui.utils.extensions.center
 import com.unciv.ui.utils.extensions.keyShortcuts
 import com.unciv.ui.utils.extensions.onActivation
-import com.unciv.ui.utils.extensions.onClick
 import com.unciv.ui.utils.extensions.setFontSize
 import com.unciv.ui.utils.extensions.surroundWithCircle
 import com.unciv.ui.utils.extensions.toLabel
@@ -52,7 +52,7 @@ import com.unciv.utils.concurrency.launchOnGLThread
 import kotlin.math.min
 
 
-class MainMenuScreen: BaseScreen() {
+class MainMenuScreen: BaseScreen(), RecreateOnResize {
     private val backgroundTable = Table().apply { background= ImageGetter.getBackground(Color.WHITE) }
     private val singleColumn = isCrampedPortrait()
     private var easterEggRuleset: Ruleset? = null  // Cache it so the next 'egg' can be found in Civilopedia
@@ -151,25 +151,25 @@ class MainMenuScreen: BaseScreen() {
         column1.add(quickstartTable).row()
 
         val newGameButton = getMenuButton("Start new game", "OtherIcons/New", 'n')
-            { game.setScreen(NewGameScreen(this)) }
+            { game.pushScreen(NewGameScreen()) }
         column1.add(newGameButton).row()
 
         if (game.gameSaver.getSaves().any()) {
             val loadGameTable = getMenuButton("Load game", "OtherIcons/Load", 'l')
-                { game.setScreen(LoadGameScreen(this)) }
+                { game.pushScreen(LoadGameScreen(this)) }
             column1.add(loadGameTable).row()
         }
 
         val multiplayerTable = getMenuButton("Multiplayer", "OtherIcons/Multiplayer", 'm')
-            { game.setScreen(MultiplayerScreen(this)) }
+            { game.pushScreen(MultiplayerScreen(this)) }
         column2.add(multiplayerTable).row()
 
         val mapEditorScreenTable = getMenuButton("Map editor", "OtherIcons/MapEditor", 'e')
-            { game.setScreen(MapEditorScreen()) }
+            { game.pushScreen(MapEditorScreen()) }
         column2.add(mapEditorScreenTable).row()
 
         val modsTable = getMenuButton("Mods", "OtherIcons/Mods", 'd')
-            { game.setScreen(ModManagementScreen()) }
+            { game.pushScreen(ModManagementScreen()) }
         column2.add(modsTable).row()
 
         val optionsTable = getMenuButton("Options", "OtherIcons/Options", 'o')
@@ -256,12 +256,8 @@ class MainMenuScreen: BaseScreen() {
         UncivGame.Current.translations.translationActiveMods = ruleset.mods
         ImageGetter.setNewRuleset(ruleset)
         setSkin()
-        game.setScreen(CivilopediaScreen(ruleset, this))
+        game.pushScreen(CivilopediaScreen(ruleset))
     }
 
-    override fun resize(width: Int, height: Int) {
-        if (stage.viewport.screenWidth != width || stage.viewport.screenHeight != height) {
-            game.setScreen(MainMenuScreen())
-        }
-    }
+    override fun recreate(): BaseScreen = MainMenuScreen()
 }

--- a/core/src/com/unciv/MainMenuScreen.kt
+++ b/core/src/com/unciv/MainMenuScreen.kt
@@ -25,7 +25,6 @@ import com.unciv.ui.mapeditor.MapEditorScreen
 import com.unciv.ui.multiplayer.MultiplayerScreen
 import com.unciv.ui.newgamescreen.NewGameScreen
 import com.unciv.ui.pickerscreens.ModManagementScreen
-import com.unciv.ui.popup.ExitGamePopup
 import com.unciv.ui.popup.Popup
 import com.unciv.ui.popup.ToastPopup
 import com.unciv.ui.popup.closeAllPopups
@@ -192,7 +191,7 @@ class MainMenuScreen: BaseScreen(), RecreateOnResize {
                 closeAllPopups()
                 return@add
             }
-            ExitGamePopup(this)
+            game.popScreen()
         }
 
         val helpButton = "?".toLabel(fontSize = 32)

--- a/core/src/com/unciv/UncivGame.kt
+++ b/core/src/com/unciv/UncivGame.kt
@@ -37,6 +37,7 @@ import com.unciv.utils.concurrency.withGLContext
 import com.unciv.utils.concurrency.withThreadPoolContext
 import com.unciv.utils.debug
 import java.util.*
+import kotlin.collections.ArrayDeque
 
 class UncivGame(parameters: UncivGameParameters) : Game() {
     // we need this secondary constructor because Java code for iOS can't handle Kotlin lambda parameters
@@ -82,8 +83,9 @@ class UncivGame(parameters: UncivGameParameters) : Game() {
     private val wrappedCrashHandlingRender = { super.render() }.wrapCrashHandlingUnit()
     // Stored here because I imagine that might be slightly faster than allocating for a new lambda every time, and the render loop is possibly one of the only places where that could have a significant impact.
 
-
     val translations = Translations()
+
+    val screenStack = ArrayDeque<BaseScreen>()
 
     override fun create() {
         isInitialized = false // this could be on reload, therefore we need to keep setting this to false
@@ -144,8 +146,8 @@ class UncivGame(parameters: UncivGameParameters) : Game() {
                 ImageGetter.ruleset = RulesetCache.getVanillaRuleset() // so that we can enter the map editor without having to load a game first
 
                 when {
-                    settings.isFreshlyCreated -> setScreen(LanguagePickerScreen())
-                    deepLinkedMultiplayerGame == null -> setScreen(MainMenuScreen())
+                    settings.isFreshlyCreated -> pushScreen(LanguagePickerScreen())
+                    deepLinkedMultiplayerGame == null -> pushScreen(MainMenuScreen())
                     else -> tryLoadDeepLinkedGame()
                 }
 
@@ -154,7 +156,7 @@ class UncivGame(parameters: UncivGameParameters) : Game() {
         }
     }
 
-    /** Loads a game, initializing the state of all important modules. Automatically runs on the appropriate thread. */
+    /** Loads a game, [disposing][BaseScreen.dispose] all other screens. Initializes the state of all important modules. Automatically runs on the appropriate thread. */
     suspend fun loadGame(newGameInfo: GameInfo): WorldScreen = withThreadPoolContext toplevel@{
         val prevGameInfo = gameInfo
         gameInfo = newGameInfo
@@ -164,25 +166,27 @@ class UncivGame(parameters: UncivGameParameters) : Game() {
         val isLoadingSameGame = worldScreen != null && prevGameInfo != null && prevGameInfo.gameId == newGameInfo.gameId
         val worldScreenRestoreState = if (isLoadingSameGame) worldScreen!!.getRestoreState() else null
 
-        withGLContext { setScreen(LoadingScreen(getScreen())) }
-
-        worldScreen?.dispose()
-        worldScreen = null // This allows the GC to collect our old WorldScreen, otherwise we keep two WorldScreens in memory.
-
         return@toplevel withGLContext {
-            val worldScreen = WorldScreen(newGameInfo, newGameInfo.getPlayerToViewAs(), worldScreenRestoreState)
+            setScreen(LoadingScreen(getScreen()))
+            for (screen in screenStack) screen.dispose()
+            screenStack.clear()
+
+            worldScreen = null // This allows the GC to collect our old WorldScreen, otherwise we keep two WorldScreens in memory.
+            val newWorldScreen = WorldScreen(newGameInfo, newGameInfo.getPlayerToViewAs(), worldScreenRestoreState)
+            worldScreen = newWorldScreen
 
             val moreThanOnePlayer = newGameInfo.civilizations.count { it.playerType == PlayerType.Human } > 1
             val isSingleplayer = !newGameInfo.gameParameters.isOnlineMultiplayer
             val screenToShow = if (moreThanOnePlayer && isSingleplayer) {
-                PlayerReadyScreen(worldScreen)
+                PlayerReadyScreen(newWorldScreen)
             } else {
-                worldScreen
+                newWorldScreen
             }
 
+            screenStack.addLast(screenToShow)
             setScreen(screenToShow)
 
-            return@withGLContext worldScreen
+            return@withGLContext newWorldScreen
         }
     }
 
@@ -212,18 +216,13 @@ class UncivGame(parameters: UncivGameParameters) : Game() {
         loadGame(curGameInfo)
     }
 
-    private data class NewScreens(val screenToShow: BaseScreen, val worldScreen: WorldScreen) {
-        constructor(worldScreen: WorldScreen) : this(worldScreen, worldScreen)
-    }
-
     /**
      * Sets the screen of the game and automatically disposes the old screen as long as it isn't the world screen.
      *
      * @param screen must be a subclass of [BaseScreen].
      */
     override fun setScreen(screen: Screen) {
-        if (screen !is BaseScreen) throw IllegalArgumentException("Call to setScreen with screen that does not inherit BaseScreen: " + screen.javaClass.simpleName)
-        setScreen(screen)
+        throw UnsupportedOperationException("Use pushScreen or replaceCurrentScreen instead")
     }
 
     override fun getScreen(): BaseScreen? {
@@ -231,48 +230,70 @@ class UncivGame(parameters: UncivGameParameters) : Game() {
         return if (curScreen == null) { null } else { curScreen as BaseScreen }
     }
 
-    /** Sets the screen of the game and automatically [disposes][Screen.dispose] the old screen as long as it isn't the world screen. */
-    fun setScreen(newScreen: BaseScreen) {
-        if (newScreen is WorldScreen) {
-            debug(
-                "Setting new world screen: gameId: %s, turn: %s, curCiv: %s",
-                newScreen.gameInfo.gameId, newScreen.gameInfo.turns, newScreen.gameInfo.currentPlayer
-            )
-            if (newScreen != worldScreen) worldScreen?.dispose()
-            worldScreen = newScreen
-            newScreen.shouldUpdate = true
-            Gdx.graphics.requestRendering()
-        } else {
-            debug("Setting new screen: %s", newScreen)
-        }
-
-        val oldScreen = screen
+    private fun setScreen(newScreen: BaseScreen) {
+        debug("Setting new screen: %s, screenStack: %s", newScreen, screenStack)
         Gdx.input.inputProcessor = newScreen.stage
         super.setScreen(newScreen) // This can set the screen to the policy picker or tech picker screen, so the input processor must be set before
-        if (oldScreen !is WorldScreen) { // we want to keep the world screen around, because it's expensive to re-create it
-            oldScreen?.dispose()
+        if (newScreen is WorldScreen) {
+            newScreen.shouldUpdate = true
         }
+        Gdx.graphics.requestRendering()
+    }
+
+    /** Adds a screen to be displayed instead of the current screen, with an option to go back to the previous screen by calling [popScreen] */
+    fun pushScreen(newScreen: BaseScreen) {
+        screenStack.addLast(newScreen)
+        setScreen(newScreen)
     }
 
     /**
-     * Resets the game to the stored world screen and automatically [disposes][Screen.dispose] the old screen.
+     * Pops the currently displayed screen off the screen stack and shows the previous screen. If there is no previous screen, will ask the user to quit the game.
+     * Automatically [disposes][BaseScreen.dispose] the old screen as long as it isn't the world screen.
+     *
+     * @return the new screen
      */
-    fun resetToWorldScreen() {
-        setScreen(worldScreen!!)
+    fun popScreen(): BaseScreen? {
+        val oldScreen = screenStack.removeLast()
+        val newScreen = screenStack.lastOrNull()
+        if (newScreen == null) {
+            return null
+        }
+        setScreen(newScreen)
+        if (oldScreen !is WorldScreen) { // we want to keep the world screen around, because it's expensive to re-create it
+            oldScreen.dispose()
+        }
+        return newScreen
+    }
+
+    /** Replaces the current screen with a new one. Automatically [disposes][BaseScreen.dispose] the old screen as long as it isn't the world screen. */
+    fun replaceCurrentScreen(newScreen: BaseScreen) {
+        val oldScreen = screenStack.removeLast()
+        screenStack.addLast(newScreen)
+        setScreen(newScreen)
+        oldScreen.dispose()
+    }
+
+    /** Resets the game to the stored world screen and automatically [disposes][Screen.dispose] all other screens. */
+    fun resetToWorldScreen(): WorldScreen {
+        for (screen in screenStack.filter { it !is WorldScreen}) screen.dispose()
+        screenStack.removeAll { it !is WorldScreen }
+        val worldScreen = screenStack.last()
+        setScreen(worldScreen)
+        return worldScreen as WorldScreen
     }
 
     private fun tryLoadDeepLinkedGame() = Concurrency.run("LoadDeepLinkedGame") {
         if (deepLinkedMultiplayerGame == null) return@run
 
         launchOnGLThread {
-            setScreen(LoadingScreen(getScreen()!!))
+            pushScreen(LoadingScreen(getScreen()!!))
         }
         try {
             onlineMultiplayer.loadGame(deepLinkedMultiplayerGame!!)
         } catch (ex: Exception) {
             launchOnGLThread {
                 val mainMenu = MainMenuScreen()
-                setScreen(mainMenu)
+                replaceCurrentScreen(mainMenu)
                 val popup = Popup(mainMenu)
                 popup.addGoodSizedLabel(MultiplayerHelpers.getLoadExceptionMessage(ex))
                 popup.row()
@@ -365,7 +386,7 @@ class UncivGame(parameters: UncivGameParameters) : Game() {
             gameSaver.requestAutoSaveUnCloned(curGameInfo) // Can save gameInfo directly because the user can't modify it on the MainMenuScreen
         }
         val mainMenuScreen = MainMenuScreen()
-        setScreen(mainMenuScreen)
+        pushScreen(mainMenuScreen)
         return mainMenuScreen
     }
 

--- a/core/src/com/unciv/UncivGame.kt
+++ b/core/src/com/unciv/UncivGame.kt
@@ -166,8 +166,13 @@ class UncivGame(parameters: UncivGameParameters) : Game() {
         val isLoadingSameGame = worldScreen != null && prevGameInfo != null && prevGameInfo.gameId == newGameInfo.gameId
         val worldScreenRestoreState = if (isLoadingSameGame) worldScreen!!.getRestoreState() else null
 
-        return@toplevel withGLContext {
+        withGLContext {
+            // this is not merged with the below GL context block so that our loading screen gets a chance to show - otherwise
+            // we do it all in one swoop on the same thread and the application just "freezes" without loading screen for the duration.
             setScreen(LoadingScreen(getScreen()))
+        }
+
+        return@toplevel withGLContext {
             for (screen in screenStack) screen.dispose()
             screenStack.clear()
 

--- a/core/src/com/unciv/logic/civilization/Notification.kt
+++ b/core/src/com/unciv/logic/civilization/Notification.kt
@@ -78,7 +78,7 @@ data class LocationAction(var locations: ArrayList<Vector2> = ArrayList()) : Not
 class TechAction(val techName: String = "") : NotificationAction {
     override fun execute(worldScreen: WorldScreen) {
         val tech = worldScreen.gameInfo.ruleSet.technologies[techName]
-        worldScreen.game.setScreen(TechPickerScreen(worldScreen.viewingCiv, tech))
+        worldScreen.game.pushScreen(TechPickerScreen(worldScreen.viewingCiv, tech))
     }
 }
 
@@ -87,7 +87,7 @@ data class CityAction(val city: Vector2 = Vector2.Zero): NotificationAction {
     override fun execute(worldScreen: WorldScreen) {
         worldScreen.mapHolder.tileMap[city].getCity()?.let {
             if (it.civInfo == worldScreen.viewingCiv)
-                worldScreen.game.setScreen(CityScreen(it))
+                worldScreen.game.pushScreen(CityScreen(it))
         }
     }
 }
@@ -96,7 +96,7 @@ data class CityAction(val city: Vector2 = Vector2.Zero): NotificationAction {
 data class DiplomacyAction(val otherCivName: String = ""): NotificationAction {
     override fun execute(worldScreen: WorldScreen) {
         val otherCiv = worldScreen.gameInfo.getCivilization(otherCivName)
-        worldScreen.game.setScreen(DiplomacyScreen(worldScreen.viewingCiv, otherCiv))
+        worldScreen.game.pushScreen(DiplomacyScreen(worldScreen.viewingCiv, otherCiv))
     }
 }
 

--- a/core/src/com/unciv/ui/LanguagePickerScreen.kt
+++ b/core/src/com/unciv/ui/LanguagePickerScreen.kt
@@ -48,6 +48,6 @@ class LanguagePickerScreen : PickerScreen() {
         game.settings.save()
 
         game.translations.tryReadTranslationForCurrentLanguage()
-        game.setScreen(MainMenuScreen())
+        game.replaceCurrentScreen(MainMenuScreen())
     }
 }

--- a/core/src/com/unciv/ui/UncivStage.kt
+++ b/core/src/com/unciv/ui/UncivStage.kt
@@ -9,7 +9,7 @@ import com.unciv.ui.crashhandling.wrapCrashHandlingUnit
 
 
 /** Main stage for the game. Catches all exceptions or errors thrown by event handlers, calling [com.unciv.UncivGame.handleUncaughtThrowable] with the thrown exception or error. */
-class UncivStage(viewport: Viewport, batch: Batch) : Stage(viewport, batch) {
+class UncivStage(viewport: Viewport) : Stage(viewport) {
 
     /**
      * Enables/disables sending pointer enter/exit events to actors on this stage.

--- a/core/src/com/unciv/ui/cityscreen/CityReligionInfoTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityReligionInfoTable.kt
@@ -79,10 +79,12 @@ class CityReligionInfoTable(
         val icon = ImageGetter.getCircledReligionIcon(iconName, 30f)
         if (religion == null) return icon
         icon.onClick {
-            val newScreen = if (religion == iconName)
+            val newScreen = if (religion == iconName) {
                 EmpireOverviewScreen(civInfo, EmpireOverviewCategories.Religion.name, religion)
-            else CivilopediaScreen(gameInfo.ruleSet, UncivGame.Current.screen!!, CivilopediaCategories.Belief, religion )
-            UncivGame.Current.setScreen(newScreen)
+            } else {
+                CivilopediaScreen(gameInfo.ruleSet, CivilopediaCategories.Belief, religion)
+            }
+            UncivGame.Current.pushScreen(newScreen)
         }
         return icon
     }

--- a/core/src/com/unciv/ui/cityscreen/CityScreen.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityScreen.kt
@@ -21,18 +21,20 @@ import com.unciv.ui.popup.ToastPopup
 import com.unciv.ui.tilegroups.TileSetStrings
 import com.unciv.ui.utils.BaseScreen
 import com.unciv.ui.utils.KeyCharAndCode
+import com.unciv.ui.utils.RecreateOnResize
 import com.unciv.ui.utils.ZoomableScrollPane
 import com.unciv.ui.utils.extensions.center
 import com.unciv.ui.utils.extensions.disable
 import com.unciv.ui.utils.extensions.onClick
 import com.unciv.ui.utils.extensions.packIfNeeded
 import com.unciv.ui.utils.extensions.toTextButton
+import com.unciv.ui.worldscreen.WorldScreen
 
 class CityScreen(
     internal val city: CityInfo,
     initSelectedConstruction: IConstruction? = null,
     initSelectedTile: TileInfo? = null
-): BaseScreen() {
+): BaseScreen(), RecreateOnResize {
     companion object {
         /** Distance from stage edges to floating widgets */
         const val posFromEdge = 5f
@@ -107,7 +109,7 @@ class CityScreen(
     private val nextTileToOwn = city.expansion.chooseNewTileToOwn()
 
     init {
-        globalShortcuts.add(KeyCharAndCode.BACK) { game.resetToWorldScreen() }
+        globalShortcuts.add(KeyCharAndCode.BACK) { game.popScreen() }
         UncivGame.Current.settings.addCompletedTutorialTask("Enter city screen")
 
         addTiles()
@@ -394,9 +396,11 @@ class CityScreen(
     }
 
     fun exit() {
-        game.resetToWorldScreen()
-        game.worldScreen!!.mapHolder.setCenterPosition(city.location)
-        game.worldScreen!!.bottomUnitTable.selectUnit()
+        val newScreen = game.popScreen()
+        if (newScreen is WorldScreen) {
+            newScreen.mapHolder.setCenterPosition(city.location)
+            newScreen.bottomUnitTable.selectUnit()
+        }
     }
 
     fun page(delta: Int) {
@@ -408,12 +412,8 @@ class CityScreen(
         val newCityScreen = CityScreen(civInfo.cities[indexOfNextCity])
         newCityScreen.showConstructionsTable = showConstructionsTable // stay on stats drilldown between cities
         newCityScreen.update()
-        game.setScreen(newCityScreen)
+        game.replaceCurrentScreen(newCityScreen)
     }
 
-    override fun resize(width: Int, height: Int) {
-        if (stage.viewport.screenWidth != width || stage.viewport.screenHeight != height) {
-            game.setScreen(CityScreen(city))
-        }
-    }
+    override fun recreate(): BaseScreen = CityScreen(city)
 }

--- a/core/src/com/unciv/ui/cityscreen/CityScreenCityPickerTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityScreenCityPickerTable.kt
@@ -59,7 +59,7 @@ class CityScreenCityPickerTable(private val cityScreen: CityScreen) : Table() {
                 defaultText = city.name,
                 actionOnOk = { text ->
                     city.name = text
-                    cityScreen.game.setScreen(CityScreen(city))
+                    cityScreen.game.replaceCurrentScreen(CityScreen(city))
                 }
             ).open()
         }

--- a/core/src/com/unciv/ui/cityscreen/CityScreenTileTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityScreenTileTable.kt
@@ -49,7 +49,7 @@ class CityScreenTileTable(private val cityScreen: CityScreen): Table() {
         innerTable.pad(5f)
 
         innerTable.add( MarkupRenderer.render(selectedTile.toMarkup(city.civInfo), iconDisplay = IconDisplay.None) {
-            UncivGame.Current.setScreen(CivilopediaScreen(city.getRuleset(), cityScreen, link = it))
+            UncivGame.Current.pushScreen(CivilopediaScreen(city.getRuleset(), link = it))
         } )
         innerTable.row()
         innerTable.add(getTileStatsTable(stats)).row()
@@ -92,7 +92,7 @@ class CityScreenTileTable(private val cityScreen: CityScreen): Table() {
             }
         }
         if (selectedTile.isCityCenter() && selectedTile.getCity() != city && selectedTile.getCity()!!.civInfo == city.civInfo)
-            innerTable.add("Move to city".toTextButton().onClick { cityScreen.game.setScreen(CityScreen(selectedTile.getCity()!!)) })
+            innerTable.add("Move to city".toTextButton().onClick { cityScreen.game.replaceCurrentScreen(CityScreen(selectedTile.getCity()!!)) })
 
         innerTable.pack()
         pack()
@@ -121,7 +121,7 @@ class CityScreenTileTable(private val cityScreen: CityScreen): Table() {
             SoundPlayer.play(UncivSound.Coin)
             city.expansion.buyTile(selectedTile)
             // preselect the next tile on city screen rebuild so bulk buying can go faster
-            UncivGame.Current.setScreen(CityScreen(city, initSelectedTile = city.expansion.chooseNewTileToOwn()))
+            UncivGame.Current.replaceCurrentScreen(CityScreen(city, initSelectedTile = city.expansion.chooseNewTileToOwn()))
         }.open()
     }
 

--- a/core/src/com/unciv/ui/cityscreen/CityStatsTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityStatsTable.kt
@@ -156,7 +156,7 @@ class CityStatsTable(val cityScreen: CityScreen): Table() {
         if (wltkLabel != null) {
             tableWithIcons.add(wltkIcon!!).size(20f).padRight(5f)
             wltkLabel.onClick {
-                UncivGame.Current.setScreen(CivilopediaScreen(cityInfo.getRuleset(), cityScreen, link = "We Love The King Day"))
+                UncivGame.Current.pushScreen(CivilopediaScreen(cityInfo.getRuleset(), link = "We Love The King Day"))
             }
             tableWithIcons.add(wltkLabel).row()
         }

--- a/core/src/com/unciv/ui/cityscreen/ConstructionInfoTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/ConstructionInfoTable.kt
@@ -75,7 +75,7 @@ class ConstructionInfoTable(val cityScreen: CityScreen): Table() {
             if (link.isEmpty()) return
             touchable = Touchable.enabled
             onClick {
-                UncivGame.Current.setScreen(CivilopediaScreen(city.getRuleset(), cityScreen, link = link))
+                UncivGame.Current.pushScreen(CivilopediaScreen(city.getRuleset(), link = link))
             }
         }
     }

--- a/core/src/com/unciv/ui/civilopedia/CivilopediaScreen.kt
+++ b/core/src/com/unciv/ui/civilopedia/CivilopediaScreen.kt
@@ -20,6 +20,7 @@ import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.utils.BaseScreen
 import com.unciv.ui.utils.Fonts
 import com.unciv.ui.utils.KeyCharAndCode
+import com.unciv.ui.utils.RecreateOnResize
 import com.unciv.ui.utils.UncivTooltip.Companion.addTooltip
 import com.unciv.ui.utils.extensions.colorFromRGB
 import com.unciv.ui.utils.extensions.onClick
@@ -35,10 +36,9 @@ import com.unciv.ui.utils.AutoScrollPane as ScrollPane
  */
 class CivilopediaScreen(
     val ruleset: Ruleset,
-    val previousScreen: BaseScreen,
     category: CivilopediaCategories = CivilopediaCategories.Tutorial,
     link: String = ""
-) : BaseScreen() {
+) : BaseScreen(), RecreateOnResize {
 
     /** Container collecting data per Civilopedia entry
      * @param name From [Ruleset] object [INamed.name]
@@ -181,7 +181,7 @@ class CivilopediaScreen(
 
     init {
         val imageSize = 50f
-        globalShortcuts.add(KeyCharAndCode.BACK) { game.setScreen(previousScreen) }
+        globalShortcuts.add(KeyCharAndCode.BACK) { game.popScreen() }
 
         val curGameInfo = game.gameInfo
         val religionEnabled = if (curGameInfo != null) curGameInfo.isReligionEnabled() else ruleset.beliefs.isNotEmpty()
@@ -252,7 +252,7 @@ class CivilopediaScreen(
 
         val goToGameButton = Constants.close.toTextButton()
         goToGameButton.onClick {
-            game.setScreen(previousScreen)
+            game.popScreen()
         }
 
         val topTable = Table()
@@ -317,9 +317,5 @@ class CivilopediaScreen(
         selectEntry(entryIndex.keys.drop(newIndex).first())
     }
 
-    override fun resize(width: Int, height: Int) {
-        if (stage.viewport.screenWidth != width || stage.viewport.screenHeight != height) {
-            game.setScreen(CivilopediaScreen(ruleset, previousScreen, currentCategory, currentEntry))
-        }
-    }
+    override fun recreate(): BaseScreen = CivilopediaScreen(ruleset, currentCategory, currentEntry)
 }

--- a/core/src/com/unciv/ui/mapeditor/MapEditorScreen.kt
+++ b/core/src/com/unciv/ui/mapeditor/MapEditorScreen.kt
@@ -22,6 +22,7 @@ import com.unciv.ui.popup.YesNoPopup
 import com.unciv.ui.tilegroups.TileGroup
 import com.unciv.ui.utils.BaseScreen
 import com.unciv.ui.utils.KeyCharAndCode
+import com.unciv.ui.utils.RecreateOnResize
 import com.unciv.ui.worldscreen.ZoomButtonPair
 
 
@@ -47,7 +48,7 @@ import com.unciv.ui.worldscreen.ZoomButtonPair
 //todo See #6694 - allow adding tiles to a map (1 cell all around on hex? world-wrapped hex?? all around on rectangular? top bottom only on world-wrapped??)
 //todo move map copy&paste to save/load??
 
-class MapEditorScreen(map: TileMap? = null): BaseScreen() {
+class MapEditorScreen(map: TileMap? = null): BaseScreen(), RecreateOnResize {
     /** The map being edited, with mod list for that map */
     var tileMap: TileMap
     /** Flag indicating the map should be saved */
@@ -184,7 +185,7 @@ class MapEditorScreen(map: TileMap? = null): BaseScreen() {
 
     internal fun closeEditor() {
         askIfDirty("Do you want to leave without saving the recent changes?") {
-            game.setScreen(MainMenuScreen())
+            game.popScreen()
         }
     }
 
@@ -240,9 +241,5 @@ class MapEditorScreen(map: TileMap? = null): BaseScreen() {
         params.mapSize = MapSizeNew((maxLongitude - minLongitude + 1), (maxLatitude - minLatitude + 1) / 2)
     }
 
-    override fun resize(width: Int, height: Int) {
-        if (stage.viewport.screenWidth != width || stage.viewport.screenHeight != height) {
-            game.setScreen(MapEditorScreen(tileMap))
-        }
-    }
+    override fun recreate(): BaseScreen = MapEditorScreen(tileMap)
 }

--- a/core/src/com/unciv/ui/mapeditor/MapEditorViewTab.kt
+++ b/core/src/com/unciv/ui/mapeditor/MapEditorViewTab.kt
@@ -205,7 +205,7 @@ class MapEditorViewTab(
                 }
             } else {
                 // This needs CivilopediaScreen to be able to work without a GameInfo!
-                UncivGame.Current.setScreen(CivilopediaScreen(tile.ruleset, editorScreen, link = it))
+                UncivGame.Current.pushScreen(CivilopediaScreen(tile.ruleset, link = it))
             }
         })
 

--- a/core/src/com/unciv/ui/multiplayer/AddFriendScreen.kt
+++ b/core/src/com/unciv/ui/multiplayer/AddFriendScreen.kt
@@ -3,6 +3,7 @@ package com.unciv.ui.multiplayer
 import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.scenes.scene2d.ui.TextField
+import com.unciv.UncivGame
 import com.unciv.logic.IdChecker
 import com.unciv.logic.multiplayer.FriendList
 import com.unciv.models.translations.tr
@@ -14,7 +15,7 @@ import com.unciv.ui.utils.extensions.toLabel
 import com.unciv.ui.utils.extensions.toTextButton
 import java.util.*
 
-class AddFriendScreen(backScreen: ViewFriendsListScreen) : PickerScreen() {
+class AddFriendScreen : PickerScreen() {
     init {
         val friendNameTextField = TextField("", skin)
         val pastePlayerIDButton = "Paste player ID from clipboard".toTextButton()
@@ -39,7 +40,7 @@ class AddFriendScreen(backScreen: ViewFriendsListScreen) : PickerScreen() {
         //CloseButton Setup
         closeButton.setText("Back".tr())
         closeButton.onClick {
-            backScreen.game.setScreen(backScreen)
+            UncivGame.Current.popScreen()
         }
 
         //RightSideButton Setup
@@ -65,8 +66,10 @@ class AddFriendScreen(backScreen: ViewFriendsListScreen) : PickerScreen() {
                 FriendList.ErrorType.YOURSELF -> ToastPopup("You cannot add your own player ID in your friend list!", this)
 
                 else -> {
-                    backScreen.game.setScreen(backScreen)
-                    backScreen.refreshFriendsList()
+                    val newScreen = UncivGame.Current.popScreen()
+                    if (newScreen is ViewFriendsListScreen) {
+                        newScreen.refreshFriendsList()
+                    }
                 }
             }
         }

--- a/core/src/com/unciv/ui/multiplayer/AddMultiplayerGameScreen.kt
+++ b/core/src/com/unciv/ui/multiplayer/AddMultiplayerGameScreen.kt
@@ -16,7 +16,7 @@ import com.unciv.utils.concurrency.Concurrency
 import com.unciv.utils.concurrency.launchOnGLThread
 import java.util.*
 
-class AddMultiplayerGameScreen(backScreen: MultiplayerScreen) : PickerScreen() {
+class AddMultiplayerGameScreen : PickerScreen() {
     init {
         val gameNameTextField = TextField("", skin)
         val gameIDTextField = TextField("", skin)
@@ -37,7 +37,7 @@ class AddMultiplayerGameScreen(backScreen: MultiplayerScreen) : PickerScreen() {
         //CloseButton Setup
         closeButton.setText("Back".tr())
         closeButton.onClick {
-            backScreen.game.setScreen(backScreen)
+            game.popScreen()
         }
 
         //RightSideButton Setup
@@ -60,7 +60,7 @@ class AddMultiplayerGameScreen(backScreen: MultiplayerScreen) : PickerScreen() {
                     game.onlineMultiplayer.addGame(gameIDTextField.text.trim(), gameNameTextField.text.trim())
                     launchOnGLThread {
                         popup.close()
-                        game.setScreen(backScreen)
+                        game.popScreen()
                     }
                 } catch (ex: Exception) {
                     val message = MultiplayerHelpers.getLoadExceptionMessage(ex)

--- a/core/src/com/unciv/ui/multiplayer/EditFriendScreen.kt
+++ b/core/src/com/unciv/ui/multiplayer/EditFriendScreen.kt
@@ -4,6 +4,7 @@ import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.scenes.scene2d.ui.TextField
+import com.unciv.UncivGame
 import com.unciv.logic.IdChecker
 import com.unciv.logic.multiplayer.FriendList
 import com.unciv.models.translations.tr
@@ -16,7 +17,7 @@ import com.unciv.ui.utils.extensions.toLabel
 import com.unciv.ui.utils.extensions.toTextButton
 import java.util.*
 
-class EditFriendScreen(selectedFriend: FriendList.Friend, backScreen: ViewFriendsListScreen) : PickerScreen() {
+class EditFriendScreen(selectedFriend: FriendList.Friend) : PickerScreen() {
     init {
         val friendNameTextField = TextField(selectedFriend.name, skin)
         val pastePlayerIDButton = "Player ID from clipboard".toTextButton()
@@ -42,8 +43,7 @@ class EditFriendScreen(selectedFriend: FriendList.Friend, backScreen: ViewFriend
         deleteFriendButton.onClick {
             val askPopup = YesNoPopup("Are you sure you want to delete this friend?", this) {
                 friendlist.delete(selectedFriend)
-                backScreen.game.setScreen(backScreen)
-                backScreen.refreshFriendsList()
+                goBack()
             }
             askPopup.open()
         }.apply { color = Color.RED }
@@ -52,7 +52,7 @@ class EditFriendScreen(selectedFriend: FriendList.Friend, backScreen: ViewFriend
         //CloseButton Setup
         closeButton.setText("Back".tr())
         closeButton.onClick {
-            backScreen.game.setScreen(backScreen)
+            goBack()
         }
 
         //RightSideButton Setup
@@ -61,8 +61,7 @@ class EditFriendScreen(selectedFriend: FriendList.Friend, backScreen: ViewFriend
         rightSideButton.onClick {
             // if no edits have been made, go back to friends list
             if (selectedFriend.name == friendNameTextField.text && selectedFriend.playerID == playerIDTextField.text) {
-                backScreen.game.setScreen(backScreen)
-                backScreen.refreshFriendsList()
+                goBack()
             }
             if (friendlist.isFriendNameInFriendList(friendNameTextField.text) == FriendList.ErrorType.ALREADYINLIST
                     && friendlist.isFriendIDInFriendList(playerIDTextField.text) == FriendList.ErrorType.ALREADYINLIST) {
@@ -81,8 +80,14 @@ class EditFriendScreen(selectedFriend: FriendList.Friend, backScreen: ViewFriend
                 return@onClick
             }
             friendlist.edit(selectedFriend, friendNameTextField.text, playerIDTextField.text)
-            backScreen.game.setScreen(backScreen)
-            backScreen.refreshFriendsList()
+            goBack()
         }
+    }
+}
+
+fun goBack() {
+    val newScreen = UncivGame.Current.popScreen()
+    if (newScreen is ViewFriendsListScreen) {
+        newScreen.refreshFriendsList()
     }
 }

--- a/core/src/com/unciv/ui/multiplayer/EditMultiplayerGameInfoScreen.kt
+++ b/core/src/com/unciv/ui/multiplayer/EditMultiplayerGameInfoScreen.kt
@@ -18,7 +18,7 @@ import com.unciv.utils.concurrency.launchOnGLThread
 
 /** Subscreen of MultiplayerScreen to edit and delete saves
  * backScreen is used for getting back to the MultiplayerScreen so it doesn't have to be created over and over again */
-class EditMultiplayerGameInfoScreen(val multiplayerGame: OnlineMultiplayerGame, backScreen: MultiplayerScreen) : PickerScreen() {
+class EditMultiplayerGameInfoScreen(val multiplayerGame: OnlineMultiplayerGame) : PickerScreen() {
     init {
         val textField = TextField(multiplayerGame.name, skin)
 
@@ -30,7 +30,7 @@ class EditMultiplayerGameInfoScreen(val multiplayerGame: OnlineMultiplayerGame, 
             val askPopup = YesNoPopup("Are you sure you want to delete this map?", this) {
                 try {
                     game.onlineMultiplayer.deleteGame(multiplayerGame)
-                    game.setScreen(backScreen)
+                    game.popScreen()
                 } catch (ex: Exception) {
                     ToastPopup("Could not delete game!", this)
                 }
@@ -41,7 +41,7 @@ class EditMultiplayerGameInfoScreen(val multiplayerGame: OnlineMultiplayerGame, 
         val giveUpButton = "Resign".toTextButton()
         giveUpButton.onClick {
             val askPopup = YesNoPopup("Are you sure you want to resign?", this) {
-                resign(multiplayerGame, backScreen)
+                resign(multiplayerGame)
             }
             askPopup.open()
         }
@@ -53,7 +53,7 @@ class EditMultiplayerGameInfoScreen(val multiplayerGame: OnlineMultiplayerGame, 
         //CloseButton Setup
         closeButton.setText("Back".tr())
         closeButton.onClick {
-            backScreen.game.setScreen(backScreen)
+            game.popScreen()
         }
 
         //RightSideButton Setup
@@ -63,8 +63,10 @@ class EditMultiplayerGameInfoScreen(val multiplayerGame: OnlineMultiplayerGame, 
             rightSideButton.setText("Saving...".tr())
             val newName = textField.text.trim()
             game.onlineMultiplayer.changeGameName(multiplayerGame, newName)
-            backScreen.selectGame(newName)
-            backScreen.game.setScreen(backScreen)
+            val newScreen = game.popScreen()
+            if (newScreen is MultiplayerScreen) {
+                newScreen.selectGame(newName)
+            }
         }
 
         if (multiplayerGame.preview == null) {
@@ -79,7 +81,7 @@ class EditMultiplayerGameInfoScreen(val multiplayerGame: OnlineMultiplayerGame, 
      * Helper function to decrease indentation
      * Turns the current playerCiv into an AI civ and uploads the game afterwards.
      */
-    private fun resign(multiplayerGame: OnlineMultiplayerGame, backScreen: MultiplayerScreen) {
+    private fun resign(multiplayerGame: OnlineMultiplayerGame) {
         //Create a popup
         val popup = Popup(this)
         popup.addGoodSizedLabel("Working...").row()
@@ -91,8 +93,7 @@ class EditMultiplayerGameInfoScreen(val multiplayerGame: OnlineMultiplayerGame, 
                 if (resignSuccess) {
                     launchOnGLThread {
                         popup.close()
-                        //go back to the MultiplayerScreen
-                        game.setScreen(backScreen)
+                        game.popScreen()
                     }
                 } else {
                     launchOnGLThread {

--- a/core/src/com/unciv/ui/multiplayer/MultiplayerScreen.kt
+++ b/core/src/com/unciv/ui/multiplayer/MultiplayerScreen.kt
@@ -44,7 +44,7 @@ class MultiplayerScreen(previousScreen: BaseScreen) : PickerScreen() {
     private val events = EventBus.EventReceiver()
 
     init {
-        setDefaultCloseAction(previousScreen)
+        setDefaultCloseAction()
 
         scrollPane.setScrollingDisabled(false, true)
 
@@ -89,7 +89,7 @@ class MultiplayerScreen(previousScreen: BaseScreen) : PickerScreen() {
     fun createAddGameButton(): TextButton {
         val btn = addGameText.toTextButton()
         btn.onClick {
-            game.setScreen(AddMultiplayerGameScreen(this))
+            game.pushScreen(AddMultiplayerGameScreen())
         }
         return btn
     }
@@ -97,7 +97,7 @@ class MultiplayerScreen(previousScreen: BaseScreen) : PickerScreen() {
     fun createEditButton(): TextButton {
         val btn = editButtonText.toTextButton().apply { disable() }
         btn.onClick {
-            game.setScreen(EditMultiplayerGameInfoScreen(selectedGame!!, this))
+            game.pushScreen(EditMultiplayerGameInfoScreen(selectedGame!!))
         }
         return btn
     }
@@ -117,7 +117,7 @@ class MultiplayerScreen(previousScreen: BaseScreen) : PickerScreen() {
     fun createFriendsListButton(): TextButton {
         val btn = friendsListText.toTextButton()
         btn.onClick {
-            game.setScreen(ViewFriendsListScreen(this))
+            game.pushScreen(ViewFriendsListScreen())
         }
         return btn
     }

--- a/core/src/com/unciv/ui/multiplayer/ViewFriendsListScreen.kt
+++ b/core/src/com/unciv/ui/multiplayer/ViewFriendsListScreen.kt
@@ -11,7 +11,7 @@ import com.unciv.ui.utils.extensions.onClick
 import com.unciv.ui.utils.extensions.toTextButton
 import com.unciv.ui.utils.AutoScrollPane as ScrollPane
 
-class ViewFriendsListScreen(previousScreen: BaseScreen) : PickerScreen() {
+class ViewFriendsListScreen : PickerScreen() {
     private val rightSideTable = Table()
     private val leftSideTable = Table()
     private var friendsTable = Table()
@@ -25,7 +25,7 @@ class ViewFriendsListScreen(previousScreen: BaseScreen) : PickerScreen() {
     private lateinit var selectedFriend: FriendList.Friend
 
     init {
-        setDefaultCloseAction(previousScreen)
+        setDefaultCloseAction()
         rightSideButton.remove()
 
         //Help Button Setup
@@ -53,12 +53,12 @@ class ViewFriendsListScreen(previousScreen: BaseScreen) : PickerScreen() {
         rightSideTable.defaults().pad(20.0f)
 
         addFriendButton.onClick {
-            game.setScreen(AddFriendScreen(this))
+            game.pushScreen(AddFriendScreen())
         }
         rightSideTable.add(addFriendButton).padBottom(10f).row()
 
         editFriendButton.onClick {
-            game.setScreen(EditFriendScreen(selectedFriend,this))
+            game.pushScreen(EditFriendScreen(selectedFriend))
             editFriendButton.disable()
         }
         rightSideTable.add(editFriendButton).padBottom(30f).row()

--- a/core/src/com/unciv/ui/options/OptionsPopup.kt
+++ b/core/src/com/unciv/ui/options/OptionsPopup.kt
@@ -142,7 +142,7 @@ class OptionsPopup(
                 UncivGame.Current.reloadWorldscreen()
             } else if (screen is MainMenuScreen) {
                 withGLContext {
-                    UncivGame.Current.setScreen(MainMenuScreen())
+                    UncivGame.Current.replaceCurrentScreen(MainMenuScreen())
                 }
             }
             withGLContext {

--- a/core/src/com/unciv/ui/overviewscreen/CityOverviewTable.kt
+++ b/core/src/com/unciv/ui/overviewscreen/CityOverviewTable.kt
@@ -188,7 +188,7 @@ class CityOverviewTab(
         for (city in cityList) {
             val button = city.name.toTextButton()
             button.onClick {
-                overviewScreen.game.setScreen(CityScreen(city))
+                overviewScreen.game.pushScreen(CityScreen(city))
             }
             cityInfoTableDetails.add(button).left().fillX()
 

--- a/core/src/com/unciv/ui/overviewscreen/DiplomacyOverviewTable.kt
+++ b/core/src/com/unciv/ui/overviewscreen/DiplomacyOverviewTable.kt
@@ -127,7 +127,7 @@ class DiplomacyOverviewTab (
         table.touchable = Touchable.enabled
         table.onClick {
             if (civInfo.isDefeated() || viewingPlayer.isSpectator() || civInfo == viewingPlayer) return@onClick
-            UncivGame.Current.setScreen(DiplomacyScreen(viewingPlayer, civInfo))
+            UncivGame.Current.pushScreen(DiplomacyScreen(viewingPlayer, civInfo))
         }
         return table
     }

--- a/core/src/com/unciv/ui/overviewscreen/EmpireOverviewScreen.kt
+++ b/core/src/com/unciv/ui/overviewscreen/EmpireOverviewScreen.kt
@@ -7,13 +7,14 @@ import com.unciv.ui.overviewscreen.EmpireOverviewTab.EmpireOverviewTabPersistabl
 import com.unciv.ui.utils.BaseScreen
 import com.unciv.ui.utils.KeyCharAndCode
 import com.unciv.ui.images.ImageGetter
+import com.unciv.ui.utils.RecreateOnResize
 import com.unciv.ui.utils.TabbedPager
 
 class EmpireOverviewScreen(
     private var viewingPlayer: CivilizationInfo,
     defaultPage: String = "",
     selection: String = ""
-) : BaseScreen() {
+) : BaseScreen(), RecreateOnResize {
     // 50 normal button height + 2*10 topTable padding + 2 Separator + 2*5 centerTable padding
     // Since a resize recreates this screen this should be fine as a val
     internal val centerAreaHeight = stage.height - 82f
@@ -45,7 +46,7 @@ class EmpireOverviewScreen(
             else game.settings.lastOverviewPage
         val iconSize = Constants.defaultFontSize.toFloat()
 
-        globalShortcuts.add(KeyCharAndCode.BACK) { game.resetToWorldScreen() }
+        globalShortcuts.add(KeyCharAndCode.BACK) { game.popScreen() }
 
         tabbedPager = TabbedPager(
             stage.width, stage.width,
@@ -53,7 +54,7 @@ class EmpireOverviewScreen(
             separatorColor = Color.WHITE,
             capacity = EmpireOverviewCategories.values().size)
 
-        tabbedPager.addClosePage { game.resetToWorldScreen() }
+        tabbedPager.addClosePage { game.popScreen() }
 
         for (category in EmpireOverviewCategories.values()) {
             val tabState = category.stateTester(viewingPlayer)
@@ -80,12 +81,9 @@ class EmpireOverviewScreen(
         stage.addActor(tabbedPager)
    }
 
-    override fun resize(width: Int, height: Int) {
-        if (stage.viewport.screenWidth != width || stage.viewport.screenHeight != height) {
-            updatePersistState(pageObjects)
-            game.setScreen(EmpireOverviewScreen(viewingPlayer, game.settings.lastOverviewPage))
-            dispose()
-        }
+    override fun recreate(): BaseScreen {
+        updatePersistState(pageObjects)
+        return EmpireOverviewScreen(viewingPlayer, game.settings.lastOverviewPage)
     }
 
     fun resizePage(tab: EmpireOverviewTab) {

--- a/core/src/com/unciv/ui/overviewscreen/ReligionOverviewTable.kt
+++ b/core/src/com/unciv/ui/overviewscreen/ReligionOverviewTable.kt
@@ -179,7 +179,7 @@ class ReligionOverviewTab(
         MarkupRenderer.render(
             belief.getCivilopediaTextLines(withHeader = true)
         ) {
-            UncivGame.Current.setScreen(CivilopediaScreen(gameInfo.ruleSet, overviewScreen, link = it))
+            UncivGame.Current.pushScreen(CivilopediaScreen(gameInfo.ruleSet, link = it))
         }.apply {
             background = ImageGetter.getBackground(ImageGetter.getBlue())
         }

--- a/core/src/com/unciv/ui/overviewscreen/ResourcesOverviewTable.kt
+++ b/core/src/com/unciv/ui/overviewscreen/ResourcesOverviewTable.kt
@@ -79,12 +79,12 @@ class ResourcesOverviewTab(
         ImageGetter.getResourceImage(name, iconSize).apply {
             onClick {
                 if (viewingPlayer.gameInfo.notifyExploredResources(viewingPlayer, name, 0, true))
-                    overviewScreen.game.resetToWorldScreen()
+                    overviewScreen.game.popScreen()
             }
         }
     private fun TileResource.getLabel() = name.toLabel().apply {
         onClick {
-            overviewScreen.game.setScreen(CivilopediaScreen(gameInfo.ruleSet, overviewScreen, CivilopediaCategories.Resource, this@getLabel.name))
+            overviewScreen.game.pushScreen(CivilopediaScreen(gameInfo.ruleSet, CivilopediaCategories.Resource, this@getLabel.name))
         }
     }
 

--- a/core/src/com/unciv/ui/overviewscreen/UnitOverviewTable.kt
+++ b/core/src/com/unciv/ui/overviewscreen/UnitOverviewTable.kt
@@ -197,7 +197,7 @@ class UnitOverviewTab(
                 ).size(24f).padLeft(8f)
             promotionsTable.onClick {
                 if (unit.promotions.canBePromoted() || unit.promotions.promotions.isNotEmpty()) {
-                    game.setScreen(PromotionPickerScreen(unit))
+                    game.pushScreen(PromotionPickerScreen(unit))
                 }
             }
             add(promotionsTable)

--- a/core/src/com/unciv/ui/overviewscreen/WonderOverviewTable.kt
+++ b/core/src/com/unciv/ui/overviewscreen/WonderOverviewTable.kt
@@ -226,7 +226,7 @@ class WonderOverviewTab(
 
             val image = wonder.getImage()
             image?.onClick {
-                UncivGame.Current.setScreen(CivilopediaScreen(ruleSet, overviewScreen, wonder.category, wonder.name))
+                UncivGame.Current.pushScreen(CivilopediaScreen(ruleSet, wonder.category, wonder.name))
             }
             // Terrain image padding is a bit unpredictable, they need ~5f more. Ensure equal line spacing on name, not image:
             add(image).pad(0f, 10f, 0f, 10f)
@@ -238,11 +238,8 @@ class WonderOverviewTab(
                 val locationLabel = locationText.toLabel()
                 if (wonder.location != null)
                     locationLabel.onClick{
-                        val worldScreen = UncivGame.Current.worldScreen
-                        if (worldScreen != null) {
-                            UncivGame.Current.resetToWorldScreen()
-                            worldScreen.mapHolder.setCenterPosition(wonder.location.position)
-                        }
+                        val worldScreen = UncivGame.Current.resetToWorldScreen()
+                        worldScreen.mapHolder.setCenterPosition(wonder.location.position)
                     }
                 add(locationLabel).fillY()
             }

--- a/core/src/com/unciv/ui/pickerscreens/DiplomaticVotePickerScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/DiplomaticVotePickerScreen.kt
@@ -30,7 +30,7 @@ class DiplomaticVotePickerScreen(private val votingCiv: CivilizationInfo) : Pick
 
         rightSideButton.onClick(UncivSound.Chimes) {
             votingCiv.diplomaticVoteForCiv(chosenCiv!!)
-            UncivGame.Current.resetToWorldScreen()
+            UncivGame.Current.popScreen()
         }
 
     }

--- a/core/src/com/unciv/ui/pickerscreens/DiplomaticVoteResultScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/DiplomaticVoteResultScreen.kt
@@ -25,7 +25,7 @@ class DiplomaticVoteResultScreen(val votesCast: HashMap<String, String>, val vie
 
         rightSideButton.onClick(UncivSound.Click) {
             viewingCiv.addFlag(CivFlags.ShowDiplomaticVotingResults.name, -1)
-            UncivGame.Current.resetToWorldScreen()
+            UncivGame.Current.popScreen()
         }
         rightSideButton.enable()
         rightSideButton.setText("Continue".tr())

--- a/core/src/com/unciv/ui/pickerscreens/GreatPersonPickerScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/GreatPersonPickerScreen.kt
@@ -38,7 +38,7 @@ class GreatPersonPickerScreen(val civInfo:CivilizationInfo) : PickerScreen() {
                 civInfo.greatPeople.mayaLimitedFreeGP--
                 civInfo.greatPeople.longCountGPPool.remove(theChosenOne!!.name)
             }
-            UncivGame.Current.resetToWorldScreen()
+            UncivGame.Current.popScreen()
         }
 
     }

--- a/core/src/com/unciv/ui/pickerscreens/ImprovementPickerScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/ImprovementPickerScreen.kt
@@ -60,12 +60,11 @@ class ImprovementPickerScreen(
             unit.action = null // this is to "wake up" the worker if it's sleeping
             onAccept()
         }
-        game.resetToWorldScreen()
+        game.popScreen()
     }
 
     init {
         setDefaultCloseAction()
-        globalShortcuts.add(KeyCharAndCode.BACK) { UncivGame.Current.resetToWorldScreen() }
 
         rightSideButton.setText("Pick improvement".tr())
         rightSideButton.onClick {

--- a/core/src/com/unciv/ui/pickerscreens/ModManagementScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/ModManagementScreen.kt
@@ -24,8 +24,10 @@ import com.unciv.ui.popup.Popup
 import com.unciv.ui.popup.ToastPopup
 import com.unciv.ui.popup.YesNoPopup
 import com.unciv.ui.utils.AutoScrollPane
+import com.unciv.ui.utils.BaseScreen
 import com.unciv.ui.utils.ExpanderTab
 import com.unciv.ui.utils.KeyCharAndCode
+import com.unciv.ui.utils.RecreateOnResize
 import com.unciv.ui.utils.WrappableLabel
 import com.unciv.ui.utils.extensions.UncivDateFormat.formatDate
 import com.unciv.ui.utils.extensions.UncivDateFormat.parseDate
@@ -54,7 +56,7 @@ import kotlin.math.max
 class ModManagementScreen(
     previousInstalledMods: HashMap<String, ModUIData>? = null,
     previousOnlineMods: HashMap<String, ModUIData>? = null
-): PickerScreen(disableScroll = true) {
+): PickerScreen(disableScroll = true), RecreateOnResize {
 
     private val modTable = Table().apply { defaults().pad(10f) }
     private val scrollInstalledMods = AutoScrollPane(modTable)
@@ -102,7 +104,7 @@ class ModManagementScreen(
             if (game.settings.tileSet !in tileSets) {
                 game.settings.tileSet = tileSets.first()
             }
-            game.setScreen(MainMenuScreen())
+            game.popScreen()
         }
         closeButton.keyShortcuts.add(KeyCharAndCode.BACK)
 
@@ -590,11 +592,7 @@ class ModManagementScreen(
         modDescriptionLabel.setText(onlineModDescription + separator + installedModDescription)
     }
 
-    override fun resize(width: Int, height: Int) {
-        if (stage.viewport.screenWidth != width || stage.viewport.screenHeight != height) {
-            game.setScreen(ModManagementScreen(installedModInfo, onlineModInfo))
-        }
-    }
+    override fun recreate(): BaseScreen = ModManagementScreen(installedModInfo, onlineModInfo)
 
     companion object {
         val modsToHideAsUrl by lazy {

--- a/core/src/com/unciv/ui/pickerscreens/PickerScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/PickerScreen.kt
@@ -41,10 +41,9 @@ open class PickerScreen(disableScroll: Boolean = false) : BaseScreen() {
      * Initializes the [Close button][closeButton]'s action (and the Back/ESC handler)
      * to return to the [previousScreen] if specified, or else to the world screen.
      */
-    fun setDefaultCloseAction(previousScreen: BaseScreen? = null) {
+    fun setDefaultCloseAction() {
         pickerPane.closeButton.onActivation {
-            if (previousScreen != null) game.setScreen(previousScreen)
-            else game.resetToWorldScreen()
+            game.popScreen()
         }
         pickerPane.closeButton.keyShortcuts.add(KeyCharAndCode.BACK)
     }

--- a/core/src/com/unciv/ui/pickerscreens/PolicyPickerScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/PolicyPickerScreen.kt
@@ -12,7 +12,9 @@ import com.unciv.models.ruleset.Policy.PolicyBranchType
 import com.unciv.models.ruleset.PolicyBranch
 import com.unciv.models.translations.tr
 import com.unciv.ui.images.ImageGetter
+import com.unciv.ui.utils.BaseScreen
 import com.unciv.ui.utils.KeyCharAndCode
+import com.unciv.ui.utils.RecreateOnResize
 import com.unciv.ui.utils.extensions.addSeparator
 import com.unciv.ui.utils.extensions.disable
 import com.unciv.ui.utils.extensions.enable
@@ -24,7 +26,7 @@ import kotlin.math.min
 
 
 class PolicyPickerScreen(val worldScreen: WorldScreen, civInfo: CivilizationInfo = worldScreen.viewingCiv)
-    : PickerScreen() {
+    : PickerScreen(), RecreateOnResize {
     internal val viewingCiv: CivilizationInfo = civInfo
     private var pickedPolicy: Policy? = null
 
@@ -45,8 +47,6 @@ class PolicyPickerScreen(val worldScreen: WorldScreen, civInfo: CivilizationInfo
 
         if (policies.freePolicies > 0 && policies.canAdoptPolicy())
             closeButton.disable()
-        else
-            globalShortcuts.add(KeyCharAndCode.BACK) { UncivGame.Current.resetToWorldScreen() }
 
         rightSideButton.onClick(UncivSound.Policy) {
             val policy = pickedPolicy!!
@@ -58,13 +58,13 @@ class PolicyPickerScreen(val worldScreen: WorldScreen, civInfo: CivilizationInfo
 
             // If we've moved to another screen in the meantime (great person pick, victory screen) ignore this
             if (game.screen !is PolicyPickerScreen || !policies.canAdoptPolicy()) {
-                game.resetToWorldScreen()
+                game.popScreen()
             } else {
                 val policyScreen = PolicyPickerScreen(worldScreen)
                 policyScreen.scrollPane.scrollPercentX = scrollPane.scrollPercentX
                 policyScreen.scrollPane.scrollPercentY = scrollPane.scrollPercentY
                 policyScreen.scrollPane.updateVisualScroll()
-                game.setScreen(policyScreen)  // update policies
+                game.replaceCurrentScreen(policyScreen)  // update policies
             }
         }
 
@@ -148,7 +148,7 @@ class PolicyPickerScreen(val worldScreen: WorldScreen, civInfo: CivilizationInfo
         if (viewingCiv.gameInfo.gameParameters.godMode && pickedPolicy == policy
                 && viewingCiv.policies.isAdoptable(policy)) {
             viewingCiv.policies.adopt(policy)
-            game.setScreen(PolicyPickerScreen(worldScreen))
+            game.replaceCurrentScreen(PolicyPickerScreen(worldScreen))
         }
         pickedPolicy = policy
 
@@ -211,9 +211,5 @@ class PolicyPickerScreen(val worldScreen: WorldScreen, civInfo: CivilizationInfo
         return policyButton
     }
 
-    override fun resize(width: Int, height: Int) {
-        if (stage.viewport.screenWidth != width || stage.viewport.screenHeight != height) {
-            game.setScreen(PolicyPickerScreen(worldScreen,viewingCiv))
-        }
-    }
+    override fun recreate(): BaseScreen = PolicyPickerScreen(worldScreen, viewingCiv)
 }

--- a/core/src/com/unciv/ui/pickerscreens/PromotionPickerScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/PromotionPickerScreen.kt
@@ -12,14 +12,16 @@ import com.unciv.models.ruleset.unit.Promotion
 import com.unciv.models.translations.tr
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.popup.AskTextPopup
+import com.unciv.ui.utils.BaseScreen
 import com.unciv.ui.utils.KeyCharAndCode
+import com.unciv.ui.utils.RecreateOnResize
 import com.unciv.ui.utils.extensions.isEnabled
 import com.unciv.ui.utils.extensions.onClick
 import com.unciv.ui.utils.extensions.surroundWithCircle
 import com.unciv.ui.utils.extensions.toLabel
 import com.unciv.ui.utils.extensions.toTextButton
 
-class PromotionPickerScreen(val unit: MapUnit) : PickerScreen() {
+class PromotionPickerScreen(val unit: MapUnit) : PickerScreen(), RecreateOnResize {
     private var selectedPromotion: Promotion? = null
 
     private fun acceptPromotion(promotion: Promotion?) {
@@ -28,13 +30,12 @@ class PromotionPickerScreen(val unit: MapUnit) : PickerScreen() {
 
         unit.promotions.addPromotion(promotion.name)
         if (unit.promotions.canBePromoted())
-            game.setScreen(PromotionPickerScreen(unit).setScrollY(scrollPane.scrollY))
+            game.replaceCurrentScreen(recreate())
         else
-            game.resetToWorldScreen()
+            game.popScreen()
     }
 
     init {
-        globalShortcuts.add(KeyCharAndCode.BACK) { UncivGame.Current.resetToWorldScreen() }
         setDefaultCloseAction()
 
         rightSideButton.setText("Pick promotion".tr())
@@ -68,7 +69,7 @@ class PromotionPickerScreen(val unit: MapUnit) : PickerScreen() {
                     validate = { it != unit.name},
                     actionOnOk = { userInput ->
                         unit.instanceName = userInput
-                        this.game.setScreen(PromotionPickerScreen(unit))
+                        this.game.replaceCurrentScreen(PromotionPickerScreen(unit))
                     }
                 ).open()
             }
@@ -112,16 +113,15 @@ class PromotionPickerScreen(val unit: MapUnit) : PickerScreen() {
         displayTutorial(Tutorial.Experience)
     }
 
-    private fun setScrollY(scrollY: Float): PromotionPickerScreen {
+    private fun setScrollY(scrollY: Float) {
         splitPane.pack()    // otherwise scrollPane.maxY == 0
         scrollPane.scrollY = scrollY
         scrollPane.updateVisualScroll()
-        return this
     }
 
-    override fun resize(width: Int, height: Int) {
-        if (stage.viewport.screenWidth != width || stage.viewport.screenHeight != height) {
-            game.setScreen(PromotionPickerScreen(unit).setScrollY(scrollPane.scrollY))
-        }
+    override fun recreate(): BaseScreen {
+        val newScreen = PromotionPickerScreen(unit)
+        newScreen.setScrollY(scrollPane.scrollY)
+        return newScreen
     }
 }

--- a/core/src/com/unciv/ui/pickerscreens/ReligionPickerScreenCommon.kt
+++ b/core/src/com/unciv/ui/pickerscreens/ReligionPickerScreenCommon.kt
@@ -66,7 +66,7 @@ abstract class ReligionPickerScreenCommon(
         rightSideButton.setText(buttonText.tr())
         rightSideButton.onClick(UncivSound.Choir) {
             choosingCiv.religionManager.action()
-            UncivGame.Current.resetToWorldScreen()
+            UncivGame.Current.popScreen()
         }
     }
 
@@ -107,7 +107,7 @@ abstract class ReligionPickerScreenCommon(
                 add(MarkupRenderer.render(
                     belief.getCivilopediaTextLines(withHeader = true), width - 20f
                 ) {
-                    UncivGame.Current.setScreen(CivilopediaScreen(ruleset, this@ReligionPickerScreenCommon, link = it))
+                    UncivGame.Current.pushScreen(CivilopediaScreen(ruleset,  link = it))
                 }).growX()
                 // Icon should it be needed:  CivilopediaImageGetters.belief(belief.getIconName(), 50f)
             }

--- a/core/src/com/unciv/ui/pickerscreens/TechPickerScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/TechPickerScreen.kt
@@ -62,12 +62,11 @@ class TechPickerScreen(
 
     init {
         setDefaultCloseAction()
-        globalShortcuts.add(KeyCharAndCode.BACK) { UncivGame.Current.resetToWorldScreen() }
         scrollPane.setOverscroll(false, false)
 
         descriptionLabel.onClick {
             if (selectedTech != null)
-                game.setScreen(CivilopediaScreen(civInfo.gameInfo.ruleSet, this, CivilopediaCategories.Technology, selectedTech!!.name))
+                game.pushScreen(CivilopediaScreen(civInfo.gameInfo.ruleSet, CivilopediaCategories.Technology, selectedTech!!.name))
         }
 
         tempTechsToResearch = ArrayList(civTech.techsToResearch)
@@ -88,7 +87,7 @@ class TechPickerScreen(
 
             game.settings.addCompletedTutorialTask("Pick technology")
 
-            game.resetToWorldScreen()
+            game.popScreen()
         }
 
         // per default show current/recent technology,

--- a/core/src/com/unciv/ui/popup/YesNoPopup.kt
+++ b/core/src/com/unciv/ui/popup/YesNoPopup.kt
@@ -40,16 +40,3 @@ open class YesNoPopup(
         equalizeLastTwoButtonWidths()
     }
 }
-
-/** Shortcut to open a [YesNoPopup] with the exit game question */
-class ExitGamePopup(screen: BaseScreen, force: Boolean = false) : YesNoPopup(
-    question = "Do you want to exit the game?",
-    screen = screen,
-    restoreDefault = { screen.game.musicController.resume() },
-    action = { Gdx.app.exit() }
-) {
-    init {
-        screen.game.musicController.pause()
-        open(force)
-    }
-}

--- a/core/src/com/unciv/ui/saves/LoadGameScreen.kt
+++ b/core/src/com/unciv/ui/saves/LoadGameScreen.kt
@@ -45,7 +45,7 @@ class LoadGameScreen(previousScreen:BaseScreen) : LoadOrSaveScreen() {
     }
 
     init {
-        setDefaultCloseAction(previousScreen)
+        setDefaultCloseAction()
         rightSideTable.initRightSideTable()
         rightSideButton.onActivation { onLoadGame() }
         rightSideButton.keyShortcuts.add(KeyCharAndCode.RETURN)

--- a/core/src/com/unciv/ui/saves/SaveGameScreen.kt
+++ b/core/src/com/unciv/ui/saves/SaveGameScreen.kt
@@ -98,7 +98,7 @@ class SaveGameScreen(val gameInfo: GameInfo) : LoadOrSaveScreen("Current saves")
                         errorLabel.setText("Could not save game to custom location!".tr())
                         result.exception?.printStackTrace()
                     } else if (result.isSuccessful()) {
-                        game.resetToWorldScreen()
+                        game.popScreen()
                     }
                     saveToCustomLocation.enable()
                 }
@@ -114,7 +114,7 @@ class SaveGameScreen(val gameInfo: GameInfo) : LoadOrSaveScreen("Current saves")
             game.gameSaver.saveGame(gameInfo, gameNameTextField.text) {
                 launchOnGLThread {
                     if (it != null) ToastPopup("Could not save game!", this@SaveGameScreen)
-                    else UncivGame.Current.resetToWorldScreen()
+                    else UncivGame.Current.popScreen()
                 }
             }
         }

--- a/core/src/com/unciv/ui/tilegroups/CityButton.kt
+++ b/core/src/com/unciv/ui/tilegroups/CityButton.kt
@@ -166,7 +166,7 @@ class CityButton(val city: CityInfo, private val tileGroup: WorldTileGroup): Tab
                 // if this city belongs to you and you are not iterating though the air units
                 if (uncivGame.viewEntireMapForDebug || viewingCiv.isSpectator()
                     || (belongsToViewingCiv() && !tileGroup.tileInfo.airUnits.contains(unitTable.selectedUnit))) {
-                        uncivGame.setScreen(CityScreen(city))
+                        uncivGame.pushScreen(CityScreen(city))
                 } else if (viewingCiv.knows(city.civInfo)) {
                     foreignCityInfoPopup()
                 }
@@ -425,7 +425,7 @@ class CityButton(val city: CityInfo, private val tileGroup: WorldTileGroup): Tab
     private fun foreignCityInfoPopup() {
         fun openDiplomacy() {
             // If city doesn't belong to you, go directly to its owner's diplomacy screen.
-            worldScreen.game.setScreen(DiplomacyScreen(worldScreen.viewingCiv, city.civInfo))
+            worldScreen.game.pushScreen(DiplomacyScreen(worldScreen.viewingCiv, city.civInfo))
         }
 
         // If there's nothing to display cuz no Religion - skip popup

--- a/core/src/com/unciv/ui/trade/DiplomacyScreen.kt
+++ b/core/src/com/unciv/ui/trade/DiplomacyScreen.kt
@@ -86,7 +86,7 @@ class DiplomacyScreen(
         splitPane.setFillParent(true)
         stage.addActor(splitPane)
 
-        closeButton.onActivation { UncivGame.Current.resetToWorldScreen() }
+        closeButton.onActivation { UncivGame.Current.popScreen() }
         closeButton.keyShortcuts.add(KeyCharAndCode.BACK)
         closeButton.label.setFontSize(Constants.headingFontSize)
         closeButton.labelCell.pad(10f)
@@ -206,12 +206,7 @@ class DiplomacyScreen(
                 resourcesTable.add(wrapper).padRight(20f)
                 wrapper.addTooltip(name, 18f)
                 wrapper.onClick {
-                    val pedia = CivilopediaScreen(
-                        UncivGame.Current.gameInfo!!.ruleSet,
-                        this,
-                        link = "Resource/$name"
-                    )
-                    UncivGame.Current.setScreen(pedia)
+                    UncivGame.Current.pushScreen(CivilopediaScreen(UncivGame.Current.gameInfo!!.ruleSet, link = "Resource/$name"))
                 }
             }
             diplomacyTable.add(resourcesTable).row()
@@ -494,7 +489,7 @@ class DiplomacyScreen(
         diplomaticMarriageButton.onClick {
             val newCities = otherCiv.cities
             otherCiv.cityStateFunctions.diplomaticMarriage(viewingCiv)
-            UncivGame.Current.resetToWorldScreen() // The other civ will no longer exist
+            UncivGame.Current.popScreen() // The other civ will no longer exist
             for (city in newCities)
                 viewingCiv.popupAlerts.add(PopupAlert(AlertType.DiplomaticMarriage, city.id))   // Player gets to choose between annex and puppet
         }
@@ -994,11 +989,8 @@ class DiplomacyScreen(
     private fun getGoToOnMapButton(civilization: CivilizationInfo): TextButton {
         val goToOnMapButton = "Go to on map".toTextButton()
         goToOnMapButton.onClick {
-            val worldScreen = UncivGame.Current.worldScreen
-            if (worldScreen != null) {
-                UncivGame.Current.resetToWorldScreen()
-                worldScreen.mapHolder.setCenterPosition(civilization.getCapital()!!.location, selectUnit = false)
-            }
+            val worldScreen = UncivGame.Current.resetToWorldScreen()
+            worldScreen.mapHolder.setCenterPosition(civilization.getCapital()!!.location, selectUnit = false)
         }
         return goToOnMapButton
     }

--- a/core/src/com/unciv/ui/utils/BaseScreen.kt
+++ b/core/src/com/unciv/ui/utils/BaseScreen.kt
@@ -5,7 +5,6 @@ import com.badlogic.gdx.Screen
 import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.graphics.GL20
 import com.badlogic.gdx.graphics.g2d.BitmapFont
-import com.badlogic.gdx.graphics.g2d.SpriteBatch
 import com.badlogic.gdx.scenes.scene2d.Actor
 import com.badlogic.gdx.scenes.scene2d.Stage
 import com.badlogic.gdx.scenes.scene2d.ui.CheckBox
@@ -46,7 +45,7 @@ abstract class BaseScreen : Screen {
         val height = resolutions[1]
 
         /** The ExtendViewport sets the _minimum_(!) world size - the actual world size will be larger, fitted to screen/window aspect ratio. */
-        stage = UncivStage(ExtendViewport(height, height), SpriteBatch())
+        stage = UncivStage(ExtendViewport(height, height))
 
         if (enableSceneDebug) {
             stage.setDebugUnderMouse(true)
@@ -83,7 +82,11 @@ abstract class BaseScreen : Screen {
     }
 
     override fun resize(width: Int, height: Int) {
-        stage.viewport.update(width, height, true)
+        if (this !is RecreateOnResize) {
+            stage.viewport.update(width, height, true)
+        } else if (stage.viewport.screenWidth != width || stage.viewport.screenHeight != height) {
+            game.replaceCurrentScreen(recreate())
+        }
     }
 
     override fun pause() {}
@@ -92,7 +95,9 @@ abstract class BaseScreen : Screen {
 
     override fun hide() {}
 
-    override fun dispose() {}
+    override fun dispose() {
+        stage.dispose()
+    }
 
     fun displayTutorial(tutorial: Tutorial, test: (() -> Boolean)? = null) {
         if (!game.settings.showTutorials) return
@@ -150,4 +155,8 @@ abstract class BaseScreen : Screen {
     fun openOptionsPopup(startingPage: Int = OptionsPopup.defaultPage, onClose: () -> Unit = {}) {
         OptionsPopup(this, startingPage, onClose).open(force = true)
     }
+}
+
+interface RecreateOnResize {
+    fun recreate(): BaseScreen
 }

--- a/core/src/com/unciv/ui/victoryscreen/VictoryScreen.kt
+++ b/core/src/com/unciv/ui/victoryscreen/VictoryScreen.kt
@@ -72,7 +72,6 @@ class VictoryScreen(val worldScreen: WorldScreen) : PickerScreen() {
             wonOrLost("", null, false)
         } else if (!someoneHasWon) {
             setDefaultCloseAction()
-            globalShortcuts.add(KeyCharAndCode.BACK) { game.resetToWorldScreen() }
         }
     }
 
@@ -94,13 +93,13 @@ class VictoryScreen(val worldScreen: WorldScreen) : PickerScreen() {
         rightSideButton.onClick {
             val newGameSetupInfo = GameSetupInfo(gameInfo)
             newGameSetupInfo.mapParameters.reseed()
-            game.setScreen(NewGameScreen(this, newGameSetupInfo))
+            game.pushScreen(NewGameScreen(newGameSetupInfo))
         }
 
         closeButton.setText("One more turn...!".tr())
         closeButton.onClick {
             gameInfo.oneMoreTurnMode = true
-            game.resetToWorldScreen()
+            game.popScreen()
         }
     }
 

--- a/core/src/com/unciv/ui/worldscreen/PlayerReadyScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/PlayerReadyScreen.kt
@@ -19,9 +19,7 @@ class PlayerReadyScreen(worldScreen: WorldScreen) : BaseScreen() {
         table.add("[$curCiv] ready?".toLabel(curCiv.nation.getInnerColor(), Constants.headingFontSize))
 
         table.onClick {
-            Concurrency.runOnGLThread { // To avoid ANRs on Android when the creation of the worldscreen takes more than 500ms
-                game.setScreen(worldScreen)
-            }
+            game.replaceCurrentScreen(worldScreen)
         }
         table.setFillParent(true)
         stage.addActor(table)

--- a/core/src/com/unciv/ui/worldscreen/TradePopup.kt
+++ b/core/src/com/unciv/ui/worldscreen/TradePopup.kt
@@ -96,7 +96,7 @@ class TradePopup(worldScreen: WorldScreen): Popup(worldScreen){
 
         addButton("How about something else...", 'e') {
             close()
-            worldScreen.game.setScreen(DiplomacyScreen(viewingCiv, requestingCiv, trade))
+            worldScreen.game.pushScreen(DiplomacyScreen(viewingCiv, requestingCiv, trade))
             worldScreen.shouldUpdate = true
         }
     }

--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -161,7 +161,7 @@ class WorldScreen(
 
         techButtonHolder.touchable = Touchable.enabled
         techButtonHolder.onClick(UncivSound.Paper) {
-            game.setScreen(TechPickerScreen(viewingCiv))
+            game.pushScreen(TechPickerScreen(viewingCiv))
         }
         techPolicyAndVictoryHolder.add(techButtonHolder)
 
@@ -171,7 +171,7 @@ class WorldScreen(
         if (viewingCiv.policies.adoptedPolicies.isNotEmpty() || viewingCiv.policies.canAdoptPolicy()) {
             val policyScreenButton = Button(skin)
             policyScreenButton.add(ImageGetter.getImage("PolicyIcons/Constitution")).size(30f).pad(15f)
-            policyScreenButton.onClick { game.setScreen(PolicyPickerScreen(this)) }
+            policyScreenButton.onClick { game.pushScreen(PolicyPickerScreen(this)) }
             techPolicyAndVictoryHolder.add(policyScreenButton).pad(10f)
         }
 
@@ -252,28 +252,28 @@ class WorldScreen(
 
     private fun addKeyboardPresses() {
         // Space and N are assigned in createNextTurnButton
-        globalShortcuts.add(Input.Keys.F1) { game.setScreen(CivilopediaScreen(gameInfo.ruleSet, this)) }
-        globalShortcuts.add('E') { game.setScreen(EmpireOverviewScreen(selectedCiv)) }     // Empire overview last used page
+        globalShortcuts.add(Input.Keys.F1) { game.pushScreen(CivilopediaScreen(gameInfo.ruleSet)) }
+        globalShortcuts.add('E') { game.pushScreen(EmpireOverviewScreen(selectedCiv)) }     // Empire overview last used page
         /*
          * These try to be faithful to default Civ5 key bindings as found in several places online
          * Some are a little arbitrary, e.g. Economic info, Military info
          * Some are very much so as Unciv *is* Strategic View and the Notification log is always visible
          */
-        globalShortcuts.add(Input.Keys.F2) { game.setScreen(EmpireOverviewScreen(selectedCiv, "Trades")) }    // Economic info
-        globalShortcuts.add(Input.Keys.F3) { game.setScreen(EmpireOverviewScreen(selectedCiv, "Units")) }    // Military info
-        globalShortcuts.add(Input.Keys.F4) { game.setScreen(EmpireOverviewScreen(selectedCiv, "Diplomacy")) }    // Diplomacy info
-        globalShortcuts.add(Input.Keys.F5) { game.setScreen(PolicyPickerScreen(this, selectedCiv)) }    // Social Policies Screen
-        globalShortcuts.add(Input.Keys.F6) { game.setScreen(TechPickerScreen(viewingCiv)) }    // Tech Screen
-        globalShortcuts.add(Input.Keys.F7) { game.setScreen(EmpireOverviewScreen(selectedCiv, "Cities")) }    // originally Notification Log
-        globalShortcuts.add(Input.Keys.F8) { game.setScreen(VictoryScreen(this)) }    // Victory Progress
-        globalShortcuts.add(Input.Keys.F9) { game.setScreen(EmpireOverviewScreen(selectedCiv, "Stats")) }    // Demographics
-        globalShortcuts.add(Input.Keys.F10) { game.setScreen(EmpireOverviewScreen(selectedCiv, "Resources")) }    // originally Strategic View
+        globalShortcuts.add(Input.Keys.F2) { game.pushScreen(EmpireOverviewScreen(selectedCiv, "Trades")) }    // Economic info
+        globalShortcuts.add(Input.Keys.F3) { game.pushScreen(EmpireOverviewScreen(selectedCiv, "Units")) }    // Military info
+        globalShortcuts.add(Input.Keys.F4) { game.pushScreen(EmpireOverviewScreen(selectedCiv, "Diplomacy")) }    // Diplomacy info
+        globalShortcuts.add(Input.Keys.F5) { game.pushScreen(PolicyPickerScreen(this, selectedCiv)) }    // Social Policies Screen
+        globalShortcuts.add(Input.Keys.F6) { game.pushScreen(TechPickerScreen(viewingCiv)) }    // Tech Screen
+        globalShortcuts.add(Input.Keys.F7) { game.pushScreen(EmpireOverviewScreen(selectedCiv, "Cities")) }    // originally Notification Log
+        globalShortcuts.add(Input.Keys.F8) { game.pushScreen(VictoryScreen(this)) }    // Victory Progress
+        globalShortcuts.add(Input.Keys.F9) { game.pushScreen(EmpireOverviewScreen(selectedCiv, "Stats")) }    // Demographics
+        globalShortcuts.add(Input.Keys.F10) { game.pushScreen(EmpireOverviewScreen(selectedCiv, "Resources")) }    // originally Strategic View
         globalShortcuts.add(Input.Keys.F11) { QuickSave.save(gameInfo, this) }    // Quick Save
         globalShortcuts.add(Input.Keys.F12) { QuickSave.load(this) }    // Quick Load
         globalShortcuts.add(Input.Keys.HOME) {    // Capital City View
             val capital = gameInfo.currentPlayerCiv.getCapital()
             if (capital != null && !mapHolder.setCenterPosition(capital.location))
-                game.setScreen(CityScreen(capital))
+                game.pushScreen(CityScreen(capital))
         }
         globalShortcuts.add(KeyCharAndCode.ctrl('O')) { // Game Options
             this.openOptionsPopup(onClose = {
@@ -281,8 +281,8 @@ class WorldScreen(
                 nextTurnButton.update(hasOpenPopups(), isPlayersTurn, waitingForAutosave, isNextTurnUpdateRunning())
             })
         }
-        globalShortcuts.add(KeyCharAndCode.ctrl('S')) { game.setScreen(SaveGameScreen(gameInfo)) }    //   Save
-        globalShortcuts.add(KeyCharAndCode.ctrl('L')) { game.setScreen(LoadGameScreen(this)) }    //   Load
+        globalShortcuts.add(KeyCharAndCode.ctrl('S')) { game.pushScreen(SaveGameScreen(gameInfo)) }    //   Save
+        globalShortcuts.add(KeyCharAndCode.ctrl('L')) { game.pushScreen(LoadGameScreen(this)) }    //   Load
         globalShortcuts.add(KeyCharAndCode.ctrl('Q')) { ExitGamePopup(this, true) }    //   Quit
         globalShortcuts.add(Input.Keys.NUMPAD_ADD) { this.mapHolder.zoomIn() }    //   '+' Zoom
         globalShortcuts.add(Input.Keys.NUMPAD_SUBTRACT) { this.mapHolder.zoomOut() }    //   '-' Zoom
@@ -375,7 +375,7 @@ class WorldScreen(
                     }
                 }.right()
                 loadingGamePopup.addButtonInRow("Main menu") {
-                    game.setScreen(MainMenuScreen())
+                    game.pushScreen(MainMenuScreen())
                 }.left()
             }
         }
@@ -447,10 +447,10 @@ class WorldScreen(
         if (!hasOpenPopups() && isPlayersTurn) {
             when {
                 viewingCiv.shouldShowDiplomaticVotingResults() ->
-                    UncivGame.Current.setScreen(DiplomaticVoteResultScreen(gameInfo.diplomaticVictoryVotesCast, viewingCiv))
+                    UncivGame.Current.pushScreen(DiplomaticVoteResultScreen(gameInfo.diplomaticVictoryVotesCast, viewingCiv))
                 !gameInfo.oneMoreTurnMode && (viewingCiv.isDefeated() || gameInfo.civilizations.any { it.victoryManager.hasWon() }) ->
-                    game.setScreen(VictoryScreen(this))
-                viewingCiv.greatPeople.freeGreatPeople > 0 -> game.setScreen(GreatPersonPickerScreen(viewingCiv))
+                    game.pushScreen(VictoryScreen(this))
+                viewingCiv.greatPeople.freeGreatPeople > 0 -> game.pushScreen(GreatPersonPickerScreen(viewingCiv))
                 viewingCiv.popupAlerts.any() -> AlertPopup(this, viewingCiv.popupAlerts.first()).open()
                 viewingCiv.tradeRequests.isNotEmpty() -> {
                     // In the meantime this became invalid, perhaps because we accepted previous trades
@@ -557,7 +557,7 @@ class WorldScreen(
                         .any()) {
             displayTutorial(Tutorial.OtherCivEncountered)
             val btn = "Diplomacy".toTextButton()
-            btn.onClick { game.setScreen(DiplomacyScreen(viewingCiv)) }
+            btn.onClick { game.pushScreen(DiplomacyScreen(viewingCiv)) }
             btn.label.setFontSize(30)
             btn.labelCell.pad(10f)
             diplomacyButtonHolder.add(btn)
@@ -738,32 +738,32 @@ class WorldScreen(
                 NextTurnAction("Pick construction", Color.CORAL) {
                     val cityWithNoProductionSet = viewingCiv.cities
                         .firstOrNull { it.cityConstructions.currentConstructionFromQueue == "" }
-                    if (cityWithNoProductionSet != null) game.setScreen(
+                    if (cityWithNoProductionSet != null) game.pushScreen(
                         CityScreen(cityWithNoProductionSet)
                     )
                 }
 
             viewingCiv.shouldOpenTechPicker() ->
                 NextTurnAction("Pick a tech", Color.SKY) {
-                    game.setScreen(
+                    game.pushScreen(
                         TechPickerScreen(viewingCiv, null, viewingCiv.tech.freeTechs != 0)
                     )
                 }
 
             viewingCiv.policies.shouldOpenPolicyPicker || (viewingCiv.policies.freePolicies > 0 && viewingCiv.policies.canAdoptPolicy()) ->
                 NextTurnAction("Pick a policy", Color.VIOLET) {
-                    game.setScreen(PolicyPickerScreen(this))
+                    game.pushScreen(PolicyPickerScreen(this))
                     viewingCiv.policies.shouldOpenPolicyPicker = false
                 }
 
             viewingCiv.religionManager.canFoundPantheon() ->
                 NextTurnAction("Found Pantheon", Color.WHITE) {
-                    game.setScreen(PantheonPickerScreen(viewingCiv))
+                    game.pushScreen(PantheonPickerScreen(viewingCiv))
                 }
 
             viewingCiv.religionManager.religionState == ReligionState.FoundingReligion ->
                 NextTurnAction("Found Religion", Color.WHITE) {
-                    game.setScreen(
+                    game.pushScreen(
                         ReligiousBeliefsPickerScreen(
                             viewingCiv,
                             viewingCiv.religionManager.getBeliefsToChooseAtFounding(),
@@ -774,7 +774,7 @@ class WorldScreen(
 
             viewingCiv.religionManager.religionState == ReligionState.EnhancingReligion ->
                 NextTurnAction("Enhance a Religion", Color.ORANGE) {
-                    game.setScreen(
+                    game.pushScreen(
                         ReligiousBeliefsPickerScreen(
                             viewingCiv,
                             viewingCiv.religionManager.getBeliefsToChooseAtEnhancing(),
@@ -785,7 +785,7 @@ class WorldScreen(
 
             viewingCiv.mayVoteForDiplomaticVictory() ->
                 NextTurnAction("Vote for World Leader", Color.MAROON) {
-                    game.setScreen(DiplomaticVotePickerScreen(viewingCiv))
+                    game.pushScreen(DiplomaticVotePickerScreen(viewingCiv))
                 }
 
             !viewingCiv.hasMovedAutomatedUnits && viewingCiv.getCivUnits()

--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -43,7 +43,6 @@ import com.unciv.ui.pickerscreens.PolicyPickerScreen
 import com.unciv.ui.pickerscreens.ReligiousBeliefsPickerScreen
 import com.unciv.ui.pickerscreens.TechButton
 import com.unciv.ui.pickerscreens.TechPickerScreen
-import com.unciv.ui.popup.ExitGamePopup
 import com.unciv.ui.popup.Popup
 import com.unciv.ui.popup.ToastPopup
 import com.unciv.ui.popup.YesNoPopup
@@ -283,7 +282,7 @@ class WorldScreen(
         }
         globalShortcuts.add(KeyCharAndCode.ctrl('S')) { game.pushScreen(SaveGameScreen(gameInfo)) }    //   Save
         globalShortcuts.add(KeyCharAndCode.ctrl('L')) { game.pushScreen(LoadGameScreen(this)) }    //   Load
-        globalShortcuts.add(KeyCharAndCode.ctrl('Q')) { ExitGamePopup(this, true) }    //   Quit
+        globalShortcuts.add(KeyCharAndCode.ctrl('Q')) { game.popScreen() }    //   WorldScreen is the last screen, so this quits
         globalShortcuts.add(Input.Keys.NUMPAD_ADD) { this.mapHolder.zoomIn() }    //   '+' Zoom
         globalShortcuts.add(Input.Keys.NUMPAD_SUBTRACT) { this.mapHolder.zoomOut() }    //   '-' Zoom
     }
@@ -885,8 +884,7 @@ class WorldScreen(
             return
         }
 
-        ExitGamePopup(this, true)
-
+        game.popScreen()
     }
 
     fun autoSave() {

--- a/core/src/com/unciv/ui/worldscreen/WorldScreenTopBar.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreenTopBar.kt
@@ -96,7 +96,7 @@ class WorldScreenTopBar(val worldScreen: WorldScreen) : Table() {
         fun addStat(label: Label, icon: String, isLast: Boolean = false, screenFactory: ()->BaseScreen) {
             val image = ImageGetter.getStatIcon(icon)
             val action = {
-                worldScreen.game.setScreen(screenFactory())
+                worldScreen.game.pushScreen(screenFactory())
             }
             label.onClick(action)
             image.onClick(action)
@@ -114,7 +114,7 @@ class WorldScreenTopBar(val worldScreen: WorldScreen) : Table() {
         statsTable.add(happinessImage).padBottom(6f).size(20f)
         statsTable.add(happinessLabel).padRight(20f)
         val invokeResourcesPage = {
-            worldScreen.game.setScreen(EmpireOverviewScreen(worldScreen.selectedCiv, "Resources"))
+            worldScreen.game.pushScreen(EmpireOverviewScreen(worldScreen.selectedCiv, "Resources"))
         }
         happinessImage.onClick(invokeResourcesPage)
         happinessLabel.onClick(invokeResourcesPage)
@@ -142,11 +142,11 @@ class WorldScreenTopBar(val worldScreen: WorldScreen) : Table() {
                 val gameInfo = worldScreen.selectedCiv.gameInfo
                 MayaCalendar.openPopup(worldScreen, worldScreen.selectedCiv, gameInfo.getYear())
             } else {
-                worldScreen.game.setScreen(VictoryScreen(worldScreen))
+                worldScreen.game.pushScreen(VictoryScreen(worldScreen))
             }
         }
         resourcesWrapper.onClick {
-            worldScreen.game.setScreen(EmpireOverviewScreen(worldScreen.selectedCiv, "Resources"))
+            worldScreen.game.pushScreen(EmpireOverviewScreen(worldScreen.selectedCiv, "Resources"))
         }
 
         val strategicResources = worldScreen.gameInfo.ruleSet.tileResources.values
@@ -171,12 +171,12 @@ class WorldScreenTopBar(val worldScreen: WorldScreen) : Table() {
 
         init {
             unitSupplyImage.onClick {
-                worldScreen.game.setScreen(EmpireOverviewScreen(worldScreen.selectedCiv, "Units"))
+                worldScreen.game.pushScreen(EmpireOverviewScreen(worldScreen.selectedCiv, "Units"))
             }
 
             val overviewButton = "Overview".toTextButton()
             overviewButton.addTooltip('e')
-            overviewButton.onClick { worldScreen.game.setScreen(EmpireOverviewScreen(worldScreen.selectedCiv)) }
+            overviewButton.onClick { worldScreen.game.pushScreen(EmpireOverviewScreen(worldScreen.selectedCiv)) }
 
             unitSupplyCell = add()
             add(overviewButton).pad(10f)
@@ -215,15 +215,14 @@ class WorldScreenTopBar(val worldScreen: WorldScreen) : Table() {
             selectedCivLabel.onClick {
                 val civilopediaScreen = CivilopediaScreen(
                     worldScreen.selectedCiv.gameInfo.ruleSet,
-                    worldScreen,
                     CivilopediaCategories.Nation,
                     worldScreen.selectedCiv.civName
                 )
-                worldScreen.game.setScreen(civilopediaScreen)
+                worldScreen.game.pushScreen(civilopediaScreen)
             }
 
             selectedCivIconHolder.onClick {
-                worldScreen.game.setScreen(EmpireOverviewScreen(worldScreen.selectedCiv))
+                worldScreen.game.pushScreen(EmpireOverviewScreen(worldScreen.selectedCiv))
             }
 
             add(menuButton).size(50f).padRight(0f)

--- a/core/src/com/unciv/ui/worldscreen/bottombar/TileInfoTable.kt
+++ b/core/src/com/unciv/ui/worldscreen/bottombar/TileInfoTable.kt
@@ -26,7 +26,7 @@ class TileInfoTable(private val viewingCiv :CivilizationInfo) : Table(BaseScreen
         if (tile != null && (UncivGame.Current.viewEntireMapForDebug || viewingCiv.exploredTiles.contains(tile.position)) ) {
             add(getStatsTable(tile))
             add( MarkupRenderer.render(tile.toMarkup(viewingCiv), padding = 0f, iconDisplay = IconDisplay.None) {
-                UncivGame.Current.setScreen(CivilopediaScreen(viewingCiv.gameInfo.ruleSet, UncivGame.Current.worldScreen!!, link = it))
+                UncivGame.Current.pushScreen(CivilopediaScreen(viewingCiv.gameInfo.ruleSet, link = it))
             } ).pad(5f).row()
             if (UncivGame.Current.viewEntireMapForDebug)
                 add(tile.position.run { "(${x.toInt()},${y.toInt()})" }.toLabel()).colspan(2).pad(5f)

--- a/core/src/com/unciv/ui/worldscreen/mainmenu/WorldScreenMenuPopup.kt
+++ b/core/src/com/unciv/ui/worldscreen/mainmenu/WorldScreenMenuPopup.kt
@@ -20,28 +20,28 @@ class WorldScreenMenuPopup(val worldScreen: WorldScreen) : Popup(worldScreen) {
         }
         addButton("Civilopedia") {
             close()
-            worldScreen.game.setScreen(CivilopediaScreen(worldScreen.gameInfo.ruleSet, worldScreen))
+            worldScreen.game.pushScreen(CivilopediaScreen(worldScreen.gameInfo.ruleSet))
         }
         addButton("Save game") {
             close()
-            worldScreen.game.setScreen(SaveGameScreen(worldScreen.gameInfo))
+            worldScreen.game.pushScreen(SaveGameScreen(worldScreen.gameInfo))
         }
         addButton("Load game") {
             close()
-            worldScreen.game.setScreen(LoadGameScreen(worldScreen))
+            worldScreen.game.pushScreen(LoadGameScreen(worldScreen))
         }
 
         addButton("Start new game") {
             close()
             val newGameSetupInfo = GameSetupInfo(worldScreen.gameInfo)
             newGameSetupInfo.mapParameters.reseed()
-            val newGameScreen = NewGameScreen(worldScreen, newGameSetupInfo)
-            worldScreen.game.setScreen(newGameScreen)
+            val newGameScreen = NewGameScreen(newGameSetupInfo)
+            worldScreen.game.pushScreen(newGameScreen)
         }
 
         addButton("Victory status") {
             close()
-            worldScreen.game.setScreen(VictoryScreen(worldScreen))
+            worldScreen.game.pushScreen(VictoryScreen(worldScreen))
         }
         addButton("Options") {
             close()

--- a/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
@@ -235,7 +235,7 @@ object UnitActions {
         // promotion does not consume movement points, but is not allowed if a unit has exhausted its movement or has attacked
         actionList += UnitAction(UnitActionType.Promote,
             action = {
-                UncivGame.Current.setScreen(PromotionPickerScreen(unit))
+                UncivGame.Current.pushScreen(PromotionPickerScreen(unit))
             }.takeIf { unit.currentMovement > 0 && unit.attacksThisTurn == 0 })
     }
 
@@ -453,7 +453,7 @@ object UnitActions {
         actionList += UnitAction(UnitActionType.ConstructImprovement,
             isCurrentAction = unit.currentTile.hasImprovementInProgress(),
             action = {
-                worldScreen.game.setScreen(ImprovementPickerScreen(tile, unit) { unitTable.selectUnit() })
+                worldScreen.game.pushScreen(ImprovementPickerScreen(tile, unit) { unitTable.selectUnit() })
             }.takeIf { couldConstruct }
         )
     }

--- a/core/src/com/unciv/ui/worldscreen/unit/UnitTable.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitTable.kt
@@ -135,7 +135,7 @@ class UnitTable(val worldScreen: WorldScreen) : Table(){
                 }
                 unitIconNameGroup.clearListeners()
                 unitIconNameGroup.onClick {
-                    worldScreen.game.setScreen(CivilopediaScreen(worldScreen.gameInfo.ruleSet, worldScreen, CivilopediaCategories.Unit, unit.name))
+                    worldScreen.game.pushScreen(CivilopediaScreen(worldScreen.gameInfo.ruleSet, CivilopediaCategories.Unit, unit.name))
                 }
 
                 unitDescriptionTable.clear()
@@ -227,7 +227,7 @@ class UnitTable(val worldScreen: WorldScreen) : Table(){
                 // Since Clear also clears the listeners, we need to re-add it every time
                 promotionsTable.onClick {
                     if (selectedUnit == null || selectedUnit!!.promotions.promotions.isEmpty()) return@onClick
-                    UncivGame.Current.setScreen(PromotionPickerScreen(selectedUnit!!))
+                    UncivGame.Current.pushScreen(PromotionPickerScreen(selectedUnit!!))
                 }
             } else { // multiple selected units
                 for (unit in selectedUnits)


### PR DESCRIPTION
**BaseScreen memory leak**

Currently, `BaseScreen` leaks graphics memory by not `dispose()`ing the `SpriteBatch` it creates. We previously did this:

https://github.com/yairm210/Unciv/blob/0533c9eabade88adc3c9b65115288c645663af94/core/src/com/unciv/ui/utils/BaseScreen.kt#L49

but the [documentation of that constructor](https://github.com/libgdx/libgdx/blob/bf32f0fbebeab7df0b0f257ea0fd3d9fbc549eff/gdx/src/com/badlogic/gdx/scenes/scene2d/Stage.java#L107) says: "`batch` Will not be disposed if `Stage.dispose()` is called, handle disposal yourself". We neither called `Stage.dispose()` nor did we ever call `SpriteBatch.dispose()` (for which we didn't even keep a reference).

**TextField/Stage memory leak**

The second memory leak that is fixed here is one more subtle but the one that actually caused this refactoring: 

[This little task](https://github.com/libgdx/libgdx/blob/bf32f0fbebeab7df0b0f257ea0fd3d9fbc549eff/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextField.java#L309) in `gdx.TextField` creates a new `Thread` that makes the cursor in `TextField`s blink. The `Thread` is only shut down [a few lines above](https://github.com/libgdx/libgdx/blob/bf32f0fbebeab7df0b0f257ea0fd3d9fbc549eff/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextField.java#L306) - but only when the keyboard focus changes. So if you don't do `Stage.dispose()` (which removes all actors, also clearing keyboard focus), then this little task never gets stopped and the thread holds a reference to the stage indefinitely.

**Solution**

So I thought, why not just remove the `SpriteBatch` parameter (so that the `Stage` creates a `SpriteBatch` itself and `dispose()`s it) and call `stage.dispose()` when the screen is `dispose()`? And that worked nicely... but we previously `dispose()`d screens in `UncivGame.setScreen`. That means this change breaks all screens that hold a reference to a "previous screen" to go back to - the new screen gets set, the old screen (that we want to switch back to) gets `dispose()`d, clearing all actors on it, thus going back to it just shows an empty screen.

On this old system, there was no way to fix this. So I had to remove this old system of screens that hold a reference to previous screens completely. Now, `UncivGame` handles all screens in a `screenStack`. Instead of `setScreen` calls, there are now only `pushScreen` and `popScreen` and `replaceCurrentScreen` calls. All usages of `setScreen` have been replaced with calls to these new methods. 

I also changed some usages of `resetToWorldScreen` to `popScreen` - for example, when you previously went to the empire overview screen to the "Cities" tab, and entered a city with its button, and you then pressed "Exit city", you arrived back at the world screen. Now, you arrive at the empire overview screen again in the "Cities" tab, even keeping your scroll position - majestic.