### PR TITLE
Fix crash when base ruleset contains no strategic resources

### DIFF
--- a/core/src/com/unciv/ui/worldscreen/WorldScreenTopBar.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreenTopBar.kt
@@ -158,7 +158,7 @@ class WorldScreenTopBar(val worldScreen: WorldScreen) : Table() {
         }
 
         // in case the icons are configured higher than a label, we add a dummy - height will be measured once before it's updated
-        if (resourceActors.isEmpty()) {
+        if (resourceActors.isNotEmpty()) {
             resourcesWrapper.add(resourceActors[0].icon)
             resourceTable.add(resourcesWrapper)
         }


### PR DESCRIPTION
Accidentally did 4 instead of just the one, they all work fine though the latest one is ideal
