### PR TITLE
Fix civilopedia not showing any victory type entries when opening it without any game open

### DIFF
--- a/core/src/com/unciv/ui/civilopedia/CivilopediaScreen.kt
+++ b/core/src/com/unciv/ui/civilopedia/CivilopediaScreen.kt
@@ -185,7 +185,7 @@ class CivilopediaScreen(
 
         val curGameInfo = game.gameInfo
         val religionEnabled = if (curGameInfo != null) curGameInfo.isReligionEnabled() else ruleset.beliefs.isNotEmpty()
-        val victoryTypes = if (curGameInfo != null) curGameInfo.gameParameters.victoryTypes else emptyList()
+        val victoryTypes = if (curGameInfo != null) curGameInfo.gameParameters.victoryTypes else ruleset.victories.keys
 
         fun shouldBeDisplayed(obj: IHasUniques): Boolean {
             return when {


### PR DESCRIPTION
Now it shows all victory types available in the base ruleset.