### PR TITLE
Allow clearing the multiplayer server text field with the "Backspace" key

### DIFF
--- a/core/src/com/unciv/ui/options/MultiplayerTab.kt
+++ b/core/src/com/unciv/ui/options/MultiplayerTab.kt
@@ -238,28 +238,14 @@ private fun fixTextFieldUrlOnType(TextField: TextField) {
     var text: String = TextField.text
     var cursor: Int = minOf(TextField.cursorPosition, text.length)
 
-    // if text is 'http:' or 'https:' auto append '//'
-    if (Regex("^https?:$").containsMatchIn(text)) {
-        TextField.appendText("//")
-        return
-    }
-
     val textBeforeCursor: String = text.substring(0, cursor)
 
-    // replace multiple slash with a single one
-    val multipleSlashes = Regex("/{2,}")
+    // replace multiple slash with a single one, except when it's a ://
+    val multipleSlashes = Regex("(?<!:)/{2,}")
     text = multipleSlashes.replace(text, "/")
 
     // calculate updated cursor
     cursor = multipleSlashes.replace(textBeforeCursor, "/").length
-
-    // operations above makes 'https://' -> 'https:/'
-    // fix that if available and update cursor
-    val i: Int = text.indexOf(":/")
-    if (i > -1) {
-        text = text.replaceRange(i..i + 1, "://")
-        if (cursor > i + 1) ++cursor
-    }
 
     // update TextField
     if (text != TextField.text) {


### PR DESCRIPTION
Fixes #7046

This gets rid of the automatic entering of `//` after putting in a `:`, but I think that's a small price to pay to be able to properly interact with the text field.