### PR TITLE
Translate search help text in Mod filter

### DIFF
--- a/core/src/com/unciv/ui/pickerscreens/ModManagementOptions.kt
+++ b/core/src/com/unciv/ui/pickerscreens/ModManagementOptions.kt
@@ -85,7 +85,7 @@ class ModManagementOptions(private val modManagementScreen: ModManagementScreen)
     val expander: ExpanderTab
 
     init {
-        textField.messageText = "Enter search text"
+        textField.messageText = "Enter search text".tr()
 
         val searchIcon = ImageGetter.getImage("OtherIcons/Search")
             .surroundWithCircle(50f, color = Color.CLEAR)


### PR DESCRIPTION
Currently, all languages show the same help text when trying to filter mods:
Enter search text

The PR is for showing the available translated string.