### PR TITLE
Various UX improvements

### DIFF
--- a/android/assets/Skin.json
+++ b/android/assets/Skin.json
@@ -1,230 +1,225 @@
 {
 com.badlogic.gdx.graphics.g2d.BitmapFont: {
-	button: "Nativefont"
-	font: "Nativefont"
-	title: "Nativefont"
+    button: "Nativefont"
+    font: "Nativefont"
+    title: "Nativefont"
 }
 com.badlogic.gdx.graphics.Color: {
-	black: {
-		r: 0
-		g: 0
-		b: 0
-		a: 1
-	}
-	color: {
-		r: 0.2
-		g: 0.3
-		b: 0.5
-		a: 1
-	}
-	gray: {
-		r: 0.5
-		g: 0.5
-		b: 0.5
-		a: 1
-	}
-	highlight: {
-		r: 0.42156863
-		g: 1
-		b: 0.5552286
-		a: 1
-	}
-	pressed: {
-		r: 0.2529412
-		g: 0.6
-		b: 0.33313715
-		a: 1
-	}
-	selection: {
-		r: 0.22745098
-		g: 0.59607846
-		b: 0.85882354
-		a: 1
-	}
-	white: {
-		r: 1
-		g: 1
-		b: 1
-		a: 1
-	}
+    black: {
+        r: 0
+        g: 0
+        b: 0
+        a: 1
+    }
+    color: {
+        r: 0.2
+        g: 0.3
+        b: 0.5
+        a: 1
+    }
+    gray: {
+        r: 0.5
+        g: 0.5
+        b: 0.5
+        a: 1
+    }
+    highlight: { a: 1.0, b: 0.44705883, g: 0.8627451, r: 0.39607844 }
+    pressed: {
+        r: 0.2529412
+        g: 0.6
+        b: 0.33313715
+        a: 1
+    }
+    selection: {
+        r: 0.22745098
+        g: 0.59607846
+        b: 0.85882354
+        a: 1
+    }
+    white: {
+        r: 1
+        g: 1
+        b: 1
+        a: 1
+    }
 }
 com.badlogic.gdx.scenes.scene2d.ui.Skin$TintedDrawable: {
-	button-c: {
-		name: "RoundedEdgeRectangle"
-		color: color
-	}
-	button-p: {
-		name: "RoundedEdgeRectangle"
-		color: pressed
-	}
-	button-h: {
-		name: "RoundedEdgeRectangle"
-		color: highlight
-	}
-	checkbox-c: {
-		name: "Checkbox"
-		color: color
-	}
-	checkbox-pressed-c: {
-		name: "Checkbox-pressed"
-		color: color
-	}
-	list-c: {
-		name: "RectangleWithOutline"
-		color: color
-	}
-	scrollbar-c: {
-		name: "Scrollbar"
-		color: color
-	}
-	select-box-c: {
-		name: "Select-box"
-		color: color
-	}
-	select-box-pressed-c: {
-		name: "Select-box-pressed"
-		color: color
-	}
-	select-box-h: {
-		name: "Select-box"
-		color: highlight
-	}
-	slider-knob-c: {
-		name: "Circle"
-		color: color
-	}
-	slider-horizontal-s: {
-		name: "Rectangle"
-		color: selection
-	}
-	slider-vertical-s: {
-		name: "Rectangle"
-		color: selection
-	}
-	slider-knob-h: {
-		name: "Circle"
-		color: highlight
-	}
-	slider-horizontal-p: {
-		name: "Rectangle"
-		color: pressed
-	}
-	slider-vertical-p: {
-		name: "Rectangle"
-		color: pressed
-	}
-	splitpane-horizontal-c: {
-		name: "RectangleWithOutline"
-		color: color
-	}
-	splitpane-vertical-c: {
-		name: "RectangleWithOutline"
-		color: color
-	}
-	textfield-c: {
-		name: "RoundedEdgeRectangle"
-		color: color
-	}
-	selection: {
-		name: "Rectangle"
-		color: selection
-	}
-	white: {
-		name: "Rectangle"
-		color: white
-	}
+    button-c: {
+        name: "RoundedEdgeRectangle"
+        color: color
+    }
+    button-p: {
+        name: "RoundedEdgeRectangle"
+        color: pressed
+    }
+    button-h: {
+        name: "RoundedEdgeRectangle"
+        color: highlight
+    }
+    checkbox-c: {
+        name: "Checkbox"
+        color: color
+    }
+    checkbox-pressed-c: {
+        name: "Checkbox-pressed"
+        color: color
+    }
+    list-c: {
+        name: "RectangleWithOutline"
+        color: color
+    }
+    scrollbar-c: {
+        name: "Scrollbar"
+        color: color
+    }
+    select-box-c: {
+        name: "Select-box"
+        color: color
+    }
+    select-box-pressed-c: {
+        name: "Select-box-pressed"
+        color: color
+    }
+    select-box-h: {
+        name: "Select-box"
+        color: highlight
+    }
+    slider-knob-c: {
+        name: "Circle"
+        color: color
+    }
+    slider-horizontal-s: {
+        name: "Rectangle"
+        color: selection
+    }
+    slider-vertical-s: {
+        name: "Rectangle"
+        color: selection
+    }
+    slider-knob-h: {
+        name: "Circle"
+        color: highlight
+    }
+    slider-horizontal-p: {
+        name: "Rectangle"
+        color: pressed
+    }
+    slider-vertical-p: {
+        name: "Rectangle"
+        color: pressed
+    }
+    splitpane-horizontal-c: {
+        name: "RectangleWithOutline"
+        color: color
+    }
+    splitpane-vertical-c: {
+        name: "RectangleWithOutline"
+        color: color
+    }
+    textfield-c: {
+        name: "RoundedEdgeRectangle"
+        color: color
+    }
+    selection: {
+        name: "Rectangle"
+        color: selection
+    }
+    white: {
+        name: "Rectangle"
+        color: white
+    }
 }
 com.badlogic.gdx.scenes.scene2d.ui.Button$ButtonStyle: {
-	default: {
-		up: button-c
-		down: button-p
-		over: button-h
-	}
+    default: {
+        up: button-c
+        down: button-p
+        over: button-h
+    }
 }
 com.badlogic.gdx.scenes.scene2d.ui.CheckBox$CheckBoxStyle: {
-	default: {
-		checkboxOn: checkbox-pressed-c
-		checkboxOff: checkbox-c
-		font: button
-		fontColor: color
-		downFontColor: pressed
-		overFontColor: highlight
-	}
+    default: {
+        checkboxOn: checkbox-pressed-c
+        checkboxOff: checkbox-c
+        font: button
+        fontColor: color
+        downFontColor: pressed
+        overFontColor: highlight
+    }
 }
 com.badlogic.gdx.scenes.scene2d.ui.Label$LabelStyle: {
-	default: {
-		font: font
-		fontColor: color
-	}
+    default: {
+        font: font
+        fontColor: color
+    }
 }
 com.badlogic.gdx.scenes.scene2d.ui.List$ListStyle: {
-	default: {
-		font: font
-		fontColorSelected: white
-		fontColorUnselected: white
-		selection: selection
-		background: list-c
-	}
+    default: {
+        font: font
+        fontColorSelected: white
+        fontColorUnselected: white
+        selection: selection
+        background: list-c
+    }
 }
 com.badlogic.gdx.scenes.scene2d.ui.ScrollPane$ScrollPaneStyle: {
-	default: {
-		hScrollKnob: scrollbar-c
-		vScrollKnob: scrollbar-c
-	}
+    default: {
+        hScrollKnob: scrollbar-c
+        vScrollKnob: scrollbar-c
+    }
 }
 com.badlogic.gdx.scenes.scene2d.ui.SelectBox$SelectBoxStyle: {
-	default: {
-		font: font
-		fontColor: white
-		background: select-box-c
-		scrollStyle: default
-		listStyle: default
-		backgroundOver: select-box-h
-		backgroundOpen: select-box-pressed-c
-	}
+    default: {
+        font: font
+        fontColor: white
+        background: select-box-c
+        scrollStyle: default
+        listStyle: default
+        backgroundOver: select-box-h
+        backgroundOpen: select-box-pressed-c
+    }
 }
 com.badlogic.gdx.scenes.scene2d.ui.Slider$SliderStyle: {
-	default-horizontal: {
-		knobOver: slider-knob-h
-		knobDown: slider-knob-h
-		background: slider-horizontal-p
-		knob: slider-knob-c
-		knobBefore: slider-horizontal-s
-	}
-	default-vertical: {
-		knobOver: slider-knob-h
-		knobDown: slider-knob-h
-		background: slider-vertical-p
-		knob: slider-knob-c
-		knobBefore: slider-vertical-s
-	}
+    default-horizontal: {
+        knobOver: slider-knob-h
+        knobDown: slider-knob-h
+        background: slider-horizontal-p
+        knob: slider-knob-c
+        knobBefore: slider-horizontal-s
+    }
+    default-vertical: {
+        knobOver: slider-knob-h
+        knobDown: slider-knob-h
+        background: slider-vertical-p
+        knob: slider-knob-c
+        knobBefore: slider-vertical-s
+    }
 }
 com.badlogic.gdx.scenes.scene2d.ui.SplitPane$SplitPaneStyle: {
-	default-horizontal: {
-		handle: splitpane-horizontal-c
-	}
-	default-vertical: {
-		handle: splitpane-vertical-c
-	}
+    default-horizontal: {
+        handle: splitpane-horizontal-c
+    }
+    default-vertical: {
+        handle: splitpane-vertical-c
+    }
 }
 com.badlogic.gdx.scenes.scene2d.ui.TextButton$TextButtonStyle: {
-	default: {
-		font: button
-		fontColor: white
-		downFontColor: white
-		overFontColor: gray
-		up: button-c
-		down: button-p
-		over: button-h
-	}
+    default: {
+        font: button
+        fontColor: white
+        downFontColor: white
+        overFontColor: gray
+        up: button-c
+        down: button-p
+        over: button-h
+    }
 }
 com.badlogic.gdx.scenes.scene2d.ui.TextField$TextFieldStyle: {
-	default: {
-		font: font
-		fontColor: white
-		background: textfield-c
-		cursor: white
-		selection: selection
-	}
+    default: {
+        font: font
+        fontColor: white
+        background: textfield-c
+        cursor: white
+        selection: selection
+    }
 }
 }

--- a/android/assets/Skin.json
+++ b/android/assets/Skin.json
@@ -24,7 +24,7 @@ com.badlogic.gdx.graphics.Color: {
         a: 1
     }
     dark-gray: { a: 1.0, b: 0.25, g: 0.25, r: 0.25 }
-    disabled: { a: 1.0, b: 0.25882354, g: 0.14117648, r: 0.105882354 }
+    disabled: { a: 1.0, b: 0.24313726, g: 0.16862746, r: 0.14509805 }
     highlight: { a: 1.0, b: 0.44705883, g: 0.8627451, r: 0.39607844 }
     pressed: {
         r: 0.2529412

--- a/android/assets/Skin.json
+++ b/android/assets/Skin.json
@@ -44,6 +44,10 @@ com.badlogic.gdx.graphics.Color: {
         b: 1
         a: 1
     }
+    positive: { a: 1.0, b: 0.21960784, g: 0.49411765, r: 0.12156863 }
+    negative: { a: 1.0, b: 0.0, g: 0.03137255, r: 0.5529412 }
+    negative-highlight: { a: 1.0, b: 0.050980393, g: 0.078431375, r: 0.8666667 }
+    negative-selected: { a: 1.0, b: 0.039215688, g: 0.0627451, r: 0.7764706 }
 }
 com.badlogic.gdx.scenes.scene2d.ui.Skin$TintedDrawable: {
     button-c: {
@@ -61,6 +65,22 @@ com.badlogic.gdx.scenes.scene2d.ui.Skin$TintedDrawable: {
     button-disabled: {
         name: "RoundedEdgeRectangle"
         color: disabled
+    }
+    button-positive: {
+        name: "RoundedEdgeRectangle"
+        color: positive
+    }
+    button-negative: {
+        name: "RoundedEdgeRectangle"
+        color: negative
+    }
+    button-negative-pressed: {
+        name: "RoundedEdgeRectangle"
+        color: negative-selected
+    }
+    button-negative-hover: {
+        name: "RoundedEdgeRectangle"
+        color: negative-highlight
     }
     checkbox-c: {
         name: "Checkbox"
@@ -217,6 +237,24 @@ com.badlogic.gdx.scenes.scene2d.ui.TextButton$TextButtonStyle: {
         up: button-c
         down: button-p
         over: button-h
+    }
+    positive: {
+        font: button
+        fontColor: white
+        downFontColor: white
+        overFontColor: dark-gray
+        up: button-positive
+        down: button-p
+        over: button-h
+    }
+    negative: {
+        font: button
+        fontColor: white
+        downFontColor: white
+        overFontColor: white
+        up: button-negative
+        down: button-negative-pressed
+        over: button-negative-hover
     }
     disabled: {
         font: button

--- a/android/assets/Skin.json
+++ b/android/assets/Skin.json
@@ -23,6 +23,7 @@ com.badlogic.gdx.graphics.Color: {
         b: 0.5
         a: 1
     }
+    dark-gray: { a: 1.0, b: 0.25, g: 0.25, r: 0.25 }
     highlight: { a: 1.0, b: 0.44705883, g: 0.8627451, r: 0.39607844 }
     pressed: {
         r: 0.2529412
@@ -207,7 +208,7 @@ com.badlogic.gdx.scenes.scene2d.ui.TextButton$TextButtonStyle: {
         font: button
         fontColor: white
         downFontColor: white
-        overFontColor: gray
+        overFontColor: dark-gray
         up: button-c
         down: button-p
         over: button-h

--- a/android/assets/Skin.json
+++ b/android/assets/Skin.json
@@ -24,6 +24,7 @@ com.badlogic.gdx.graphics.Color: {
         a: 1
     }
     dark-gray: { a: 1.0, b: 0.25, g: 0.25, r: 0.25 }
+    disabled: { a: 1.0, b: 0.25882354, g: 0.14117648, r: 0.105882354 }
     highlight: { a: 1.0, b: 0.44705883, g: 0.8627451, r: 0.39607844 }
     pressed: {
         r: 0.2529412
@@ -56,6 +57,10 @@ com.badlogic.gdx.scenes.scene2d.ui.Skin$TintedDrawable: {
     button-h: {
         name: "RoundedEdgeRectangle"
         color: highlight
+    }
+    button-disabled: {
+        name: "RoundedEdgeRectangle"
+        color: disabled
     }
     checkbox-c: {
         name: "Checkbox"
@@ -212,6 +217,15 @@ com.badlogic.gdx.scenes.scene2d.ui.TextButton$TextButtonStyle: {
         up: button-c
         down: button-p
         over: button-h
+    }
+    disabled: {
+        font: button
+        fontColor: white
+        downFontColor: white
+        overFontColor: white
+        up: button-disabled
+        down: button-disabled
+        over: button-disabled
     }
 }
 com.badlogic.gdx.scenes.scene2d.ui.TextField$TextFieldStyle: {

--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -25,6 +25,9 @@ Fastlane_full_description =
 # Starting from here normal translations start, as described in
 # https://yairm210.github.io/Unciv/Other/Translating/
 
+# General
+Delete = 
+
 # Base ruleset names
 Civ V - Vanilla = 
 Civ V - Gods & Kings = 
@@ -141,6 +144,7 @@ We will remember this. =
 [civName] and [targetCivName] have signed the Declaration of Friendship! = 
 [civName] has denounced [targetCivName]! = 
 Do you want to break your promise to [leaderName]? = 
+Break promise = 
 We promised not to settle near them ([count] turns remaining) = 
 They promised not to settle near us ([count] turns remaining) = 
 
@@ -505,6 +509,7 @@ Change map to fit selected ruleset? =
 Area: [amount] tiles, [amount2] continents/islands = 
 Area: [amount] tiles, [amount2]% water, [amount3] continents/islands = 
 Do you want to leave without saving the recent changes? = 
+Leave = 
 Do you want to load another map without saving the recent changes? = 
 Invalid map: Area ([area]) does not match saved dimensions ([dimensions]). = 
 The dimensions have now been fixed for you. = 
@@ -627,6 +632,7 @@ Copy to clipboard =
 Copy saved game to clipboard = 
 Could not load game = 
 Load [saveFileName] = 
+Are you sure you want to delete this save? = 
 Delete save = 
 [saveFileName] deleted successfully. = 
 Insufficient permissions to delete [saveFileName]. = 
@@ -634,6 +640,7 @@ Failed to delete [saveFileName]. =
 Saved at = 
 Saving... = 
 Overwrite existing file? = 
+Overwrite = 
 It looks like your saved game can't be loaded! = 
 If you could copy your game data ("Copy saved game to clipboard" -  = 
   paste into an email to yairm210@hotmail.com) = 
@@ -942,6 +949,7 @@ Social policies =
 Community = 
 Close = 
 Do you want to exit the game? = 
+Exit = 
 Start bias: = 
 Avoid [terrain] = 
 
@@ -961,6 +969,7 @@ Buy for [amount] gold =
 Buy = 
 Currently you have [amount] [stat]. = 
 Would you like to purchase [constructionName] for [buildingGoldCost] [stat]? = 
+Purchase = 
 No space available to place [unit] near [city] = 
 Maintenance cost = 
 Pick construction = 

--- a/core/src/com/unciv/ui/UncivStage.kt
+++ b/core/src/com/unciv/ui/UncivStage.kt
@@ -15,7 +15,7 @@ class UncivStage(viewport: Viewport, batch: Batch) : Stage(viewport, batch) {
      * Enables/disables sending pointer enter/exit events to actors on this stage.
      * Checking for the enter/exit bounds is a relatively expensive operation and may thus be disabled temporarily.
      */
-    var performPointerEnterExitEvents: Boolean = false
+    var performPointerEnterExitEvents: Boolean = true
 
     override fun draw() =
         { super.draw() }.wrapCrashHandlingUnit()()

--- a/core/src/com/unciv/ui/cityscreen/CityConstructionsTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityConstructionsTable.kt
@@ -23,7 +23,7 @@ import com.unciv.models.translations.tr
 import com.unciv.ui.audio.SoundPlayer
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.popup.Popup
-import com.unciv.ui.popup.YesNoPopup
+import com.unciv.ui.popup.ConfirmPopup
 import com.unciv.ui.popup.closeAllPopups
 import com.unciv.ui.utils.BaseScreen
 import com.unciv.ui.utils.ExpanderTab
@@ -517,9 +517,11 @@ class CityConstructionsTable(private val cityScreen: CityScreen) {
 
         val purchasePrompt = "Currently you have [${city.getStatReserve(stat)}] [${stat.name}].".tr() + "\n\n" +
                 "Would you like to purchase [${construction.name}] for [$constructionBuyCost] [${stat.character}]?".tr()
-        YesNoPopup(
+        ConfirmPopup(
+            cityScreen,
             purchasePrompt,
-            screen = cityScreen,
+            "Purchase",
+            true,
             restoreDefault = { cityScreen.update() }
         ) { purchaseConstruction(construction, stat, tile) }.open()
     }

--- a/core/src/com/unciv/ui/cityscreen/CityInfoTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityInfoTable.kt
@@ -17,7 +17,7 @@ import com.unciv.models.stats.Stat
 import com.unciv.models.translations.tr
 import com.unciv.ui.images.IconCircleGroup
 import com.unciv.ui.images.ImageGetter
-import com.unciv.ui.popup.YesNoPopup
+import com.unciv.ui.popup.ConfirmPopup
 import com.unciv.ui.popup.closeAllPopups
 import com.unciv.ui.utils.BaseScreen
 import com.unciv.ui.utils.ExpanderTab
@@ -130,15 +130,19 @@ class CityInfoTable(private val cityScreen: CityScreen) : Table(BaseScreen.skin)
                 .width(cityScreen.stage.width / 4 - 2 * pad).row() // when you set wrap, then you need to manually set the size of the label
             if (building.isSellable() && !isFree) {
                 val sellAmount = cityScreen.city.getGoldForSellingBuilding(building.name)
-                val sellBuildingButton = "Sell for [$sellAmount] gold".toTextButton()
+                val sellText = "Sell for [$sellAmount] gold"
+                val sellBuildingButton = sellText.toTextButton()
                 it.add(sellBuildingButton).pad(5f).row()
 
                 sellBuildingButton.onClick(UncivSound.Coin) {
                     sellBuildingButton.disable()
                     cityScreen.closeAllPopups()
 
-                    YesNoPopup("Are you sure you want to sell this [${building.name}]?".tr(),
-                        cityScreen, {
+                    ConfirmPopup(
+                        cityScreen,
+                        "Are you sure you want to sell this [${building.name}]?",
+                        sellText,
+                        restoreDefault = {
                             cityScreen.update()
                         }
                     ) {

--- a/core/src/com/unciv/ui/cityscreen/CityScreenTileTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityScreenTileTable.kt
@@ -13,7 +13,7 @@ import com.unciv.ui.civilopedia.CivilopediaScreen
 import com.unciv.ui.civilopedia.FormattedLine.IconDisplay
 import com.unciv.ui.civilopedia.MarkupRenderer
 import com.unciv.ui.images.ImageGetter
-import com.unciv.ui.popup.YesNoPopup
+import com.unciv.ui.popup.ConfirmPopup
 import com.unciv.ui.popup.closeAllPopups
 import com.unciv.ui.utils.UncivTooltip.Companion.addTooltip
 import com.unciv.ui.utils.extensions.darken
@@ -113,9 +113,11 @@ class CityScreenTileTable(private val cityScreen: CityScreen): Table() {
 
         val purchasePrompt = "Currently you have [${city.civInfo.gold}] [Gold].".tr() + "\n\n" +
                 "Would you like to purchase [Tile] for [$goldCostOfTile] [${Stat.Gold.character}]?".tr()
-        YesNoPopup(
+        ConfirmPopup(
+            cityScreen,
             purchasePrompt,
-            screen = cityScreen,
+            "Purchase",
+            true,
             restoreDefault = { cityScreen.update() }
         ) {
             SoundPlayer.play(UncivSound.Coin)

--- a/core/src/com/unciv/ui/mapeditor/MapEditorLoadTab.kt
+++ b/core/src/com/unciv/ui/mapeditor/MapEditorLoadTab.kt
@@ -11,7 +11,7 @@ import com.unciv.models.ruleset.RulesetCache
 import com.unciv.models.translations.tr
 import com.unciv.ui.popup.Popup
 import com.unciv.ui.popup.ToastPopup
-import com.unciv.ui.popup.YesNoPopup
+import com.unciv.ui.popup.ConfirmPopup
 import com.unciv.ui.utils.AutoScrollPane
 import com.unciv.ui.utils.BaseScreen
 import com.unciv.ui.utils.KeyCharAndCode
@@ -57,14 +57,21 @@ class MapEditorLoadTab(
 
     private fun loadHandler() {
         if (chosenMap == null) return
-        editorScreen.askIfDirty("Do you want to load another map without saving the recent changes?") {
+        editorScreen.askIfDirty(
+            "Do you want to load another map without saving the recent changes?",
+            "Load map"
+        ) {
             thread(name = "MapLoader", isDaemon = true, block = this::loaderThread)
         }
     }
 
     private fun deleteHandler() {
         if (chosenMap == null) return
-        YesNoPopup("Are you sure you want to delete this map?", editorScreen) {
+        ConfirmPopup(
+            editorScreen,
+            "Are you sure you want to delete this map?",
+            "Delete map",
+        ) {
             chosenMap!!.delete()
             mapFiles.update()
         }.open()

--- a/core/src/com/unciv/ui/mapeditor/MapEditorModsTab.kt
+++ b/core/src/com/unciv/ui/mapeditor/MapEditorModsTab.kt
@@ -133,11 +133,11 @@ class MapEditorModsTab(
             add(ScrollPane(incompatibilityTable)).colspan(2)
                 .maxHeight(stageToShowOn.height * 0.8f).row()
             addGoodSizedLabel("Change map to fit selected ruleset?", 24).colspan(2).row()
-            addButtonInRow(Constants.yes, 'y') {
+            addButton(Constants.yes, 'y') {
                 onOK()
                 close()
             }
-            addButtonInRow(Constants.no, 'n') { close() }
+            addButton(Constants.no, 'n') { close() }
             equalizeLastTwoButtonWidths()
             open(true)
         }

--- a/core/src/com/unciv/ui/mapeditor/MapEditorSaveTab.kt
+++ b/core/src/com/unciv/ui/mapeditor/MapEditorSaveTab.kt
@@ -11,7 +11,7 @@ import com.unciv.logic.map.TileMap
 import com.unciv.models.translations.tr
 import com.unciv.ui.popup.Popup
 import com.unciv.ui.popup.ToastPopup
-import com.unciv.ui.popup.YesNoPopup
+import com.unciv.ui.popup.ConfirmPopup
 import com.unciv.ui.utils.AutoScrollPane
 import com.unciv.ui.utils.BaseScreen
 import com.unciv.ui.utils.KeyCharAndCode
@@ -81,7 +81,11 @@ class MapEditorSaveTab(
 
     private fun deleteHandler() {
         if (chosenMap == null) return
-        YesNoPopup("Are you sure you want to delete this map?", editorScreen) {
+        ConfirmPopup(
+            editorScreen,
+            "Are you sure you want to delete this map?",
+            "Delete map",
+        ) {
             chosenMap!!.delete()
             mapFiles.update()
         }.open()

--- a/core/src/com/unciv/ui/mapeditor/MapEditorScreen.kt
+++ b/core/src/com/unciv/ui/mapeditor/MapEditorScreen.kt
@@ -18,7 +18,7 @@ import com.unciv.models.ruleset.RulesetCache
 import com.unciv.models.translations.tr
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.popup.ToastPopup
-import com.unciv.ui.popup.YesNoPopup
+import com.unciv.ui.popup.ConfirmPopup
 import com.unciv.ui.tilegroups.TileGroup
 import com.unciv.ui.utils.BaseScreen
 import com.unciv.ui.utils.KeyCharAndCode
@@ -183,14 +183,17 @@ class MapEditorScreen(map: TileMap? = null): BaseScreen() {
     }
 
     internal fun closeEditor() {
-        askIfDirty("Do you want to leave without saving the recent changes?") {
+        askIfDirty(
+            "Do you want to leave without saving the recent changes?",
+            "Leave"
+        ) {
             game.setScreen(MainMenuScreen())
         }
     }
 
-    fun askIfDirty(question: String, action: ()->Unit) {
+    fun askIfDirty(question: String, confirmText: String, isConfirmPositive: Boolean = false, action: ()->Unit) {
         if (!isDirty) return action()
-        YesNoPopup(question, screen = this, action = action).open()
+        ConfirmPopup(screen = this, question, confirmText, isConfirmPositive, action = action).open()
     }
 
     fun hideSelection() {

--- a/core/src/com/unciv/ui/multiplayer/EditFriendScreen.kt
+++ b/core/src/com/unciv/ui/multiplayer/EditFriendScreen.kt
@@ -8,8 +8,8 @@ import com.unciv.logic.IdChecker
 import com.unciv.logic.multiplayer.FriendList
 import com.unciv.models.translations.tr
 import com.unciv.ui.pickerscreens.PickerScreen
+import com.unciv.ui.popup.ConfirmPopup
 import com.unciv.ui.popup.ToastPopup
-import com.unciv.ui.popup.YesNoPopup
 import com.unciv.ui.utils.extensions.enable
 import com.unciv.ui.utils.extensions.onClick
 import com.unciv.ui.utils.extensions.toLabel
@@ -40,7 +40,11 @@ class EditFriendScreen(selectedFriend: FriendList.Friend, backScreen: ViewFriend
         topTable.add(gameIDTable).padBottom(30f).row()
 
         deleteFriendButton.onClick {
-            val askPopup = YesNoPopup("Are you sure you want to delete this friend?", this) {
+            val askPopup = ConfirmPopup(
+                this,
+                "Are you sure you want to delete this friend?",
+                "Delete"
+            ) {
                 friendlist.delete(selectedFriend)
                 backScreen.game.setScreen(backScreen)
                 backScreen.refreshFriendsList()

--- a/core/src/com/unciv/ui/multiplayer/EditMultiplayerGameInfoScreen.kt
+++ b/core/src/com/unciv/ui/multiplayer/EditMultiplayerGameInfoScreen.kt
@@ -1,13 +1,14 @@
 package com.unciv.ui.multiplayer
 
 import com.badlogic.gdx.graphics.Color
+import com.badlogic.gdx.scenes.scene2d.ui.TextButton.TextButtonStyle
 import com.badlogic.gdx.scenes.scene2d.ui.TextField
 import com.unciv.logic.multiplayer.OnlineMultiplayerGame
 import com.unciv.models.translations.tr
 import com.unciv.ui.pickerscreens.PickerScreen
+import com.unciv.ui.popup.ConfirmPopup
 import com.unciv.ui.popup.Popup
 import com.unciv.ui.popup.ToastPopup
-import com.unciv.ui.popup.YesNoPopup
 import com.unciv.ui.utils.extensions.disable
 import com.unciv.ui.utils.extensions.enable
 import com.unciv.ui.utils.extensions.onClick
@@ -25,9 +26,14 @@ class EditMultiplayerGameInfoScreen(val multiplayerGame: OnlineMultiplayerGame, 
         topTable.add("Rename".toLabel()).row()
         topTable.add(textField).pad(10f).padBottom(30f).width(stage.width / 2).row()
 
-        val deleteButton = "Delete save".toTextButton()
+        val negativeButtonStyle = skin.get("negative", TextButtonStyle::class.java)
+        val deleteButton = "Delete save".toTextButton(negativeButtonStyle)
         deleteButton.onClick {
-            val askPopup = YesNoPopup("Are you sure you want to delete this map?", this) {
+            val askPopup = ConfirmPopup(
+                this,
+                "Are you sure you want to delete this map?",
+                "Delete map",
+            ) {
                 try {
                     game.onlineMultiplayer.deleteGame(multiplayerGame)
                     game.setScreen(backScreen)
@@ -36,16 +42,19 @@ class EditMultiplayerGameInfoScreen(val multiplayerGame: OnlineMultiplayerGame, 
                 }
             }
             askPopup.open()
-        }.apply { color = Color.RED }
+        }
 
-        val giveUpButton = "Resign".toTextButton()
+        val giveUpButton = "Resign".toTextButton(negativeButtonStyle)
         giveUpButton.onClick {
-            val askPopup = YesNoPopup("Are you sure you want to resign?", this) {
+            val askPopup = ConfirmPopup(
+                this,
+                "Are you sure you want to resign?",
+                "Resign",
+            ) {
                 resign(multiplayerGame, backScreen)
             }
             askPopup.open()
         }
-        giveUpButton.apply { color = Color.RED }
 
         topTable.add(deleteButton).pad(10f).row()
         topTable.add(giveUpButton)

--- a/core/src/com/unciv/ui/newgamescreen/NewGameScreen.kt
+++ b/core/src/com/unciv/ui/newgamescreen/NewGameScreen.kt
@@ -21,9 +21,9 @@ import com.unciv.models.ruleset.RulesetCache
 import com.unciv.models.translations.tr
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.pickerscreens.PickerScreen
+import com.unciv.ui.popup.ConfirmPopup
 import com.unciv.ui.popup.Popup
 import com.unciv.ui.popup.ToastPopup
-import com.unciv.ui.popup.YesNoPopup
 import com.unciv.ui.utils.BaseScreen
 import com.unciv.ui.utils.ExpanderTab
 import com.unciv.ui.utils.extensions.addSeparator
@@ -76,7 +76,11 @@ class NewGameScreen(
             val resetToDefaultsButton = "Reset to defaults".toTextButton()
             rightSideGroup.addActorAt(0, resetToDefaultsButton)
             resetToDefaultsButton.onClick {
-                YesNoPopup("Are you sure you want to reset all game options to defaults?", this) {
+                ConfirmPopup(
+                    this,
+                    "Are you sure you want to reset all game options to defaults?",
+                    "Reset to defaults",
+                ) {
                     game.setScreen(NewGameScreen(previousScreen, GameSetupInfo()))
                 }.open(true)
             }

--- a/core/src/com/unciv/ui/options/AdvancedTab.kt
+++ b/core/src/com/unciv/ui/options/AdvancedTab.kt
@@ -13,11 +13,10 @@ import com.unciv.UncivGame
 import com.unciv.models.metadata.GameSettings
 import com.unciv.models.translations.TranslationFileWriter
 import com.unciv.models.translations.tr
-import com.unciv.ui.popup.YesNoPopup
+import com.unciv.ui.popup.ConfirmPopup
 import com.unciv.ui.utils.BaseScreen
 import com.unciv.ui.utils.FontFamilyData
 import com.unciv.ui.utils.Fonts
-import com.unciv.ui.utils.KeyCharAndCode
 import com.unciv.ui.utils.UncivSlider
 import com.unciv.ui.utils.UncivTooltip.Companion.addTooltip
 import com.unciv.ui.utils.extensions.disable
@@ -174,7 +173,11 @@ private fun addSetUserId(table: Table, settings: GameSettings) {
             try {
                 val clipboardContents = Gdx.app.clipboard.contents.trim()
                 UUID.fromString(clipboardContents)
-                YesNoPopup("Doing this will reset your current user ID to the clipboard contents - are you sure?",table.stage) {
+                ConfirmPopup(
+                    table.stage,
+                    "Doing this will reset your current user ID to the clipboard contents - are you sure?",
+                    "Take user ID from clipboard"
+                ) {
                     settings.multiplayer.userId = clipboardContents
                     settings.save()
                     idSetLabel.setFontColor(Color.WHITE).setText("ID successfully set!".tr())

--- a/core/src/com/unciv/ui/overviewscreen/DiplomacyOverviewTable.kt
+++ b/core/src/com/unciv/ui/overviewscreen/DiplomacyOverviewTable.kt
@@ -6,6 +6,7 @@ import com.badlogic.gdx.scenes.scene2d.Group
 import com.badlogic.gdx.scenes.scene2d.Touchable
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton
+import com.badlogic.gdx.scenes.scene2d.ui.TextButton.TextButtonStyle
 import com.badlogic.gdx.utils.Align
 import com.unciv.Constants
 import com.unciv.UncivGame
@@ -15,6 +16,7 @@ import com.unciv.logic.civilization.diplomacy.DiplomaticStatus
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.trade.DiplomacyScreen
 import com.unciv.ui.utils.AutoScrollPane
+import com.unciv.ui.utils.BaseScreen
 import com.unciv.ui.utils.UncivTooltip.Companion.addTooltip
 import com.unciv.ui.utils.extensions.addBorder
 import com.unciv.ui.utils.extensions.addSeparator
@@ -108,7 +110,11 @@ class DiplomacyOverviewTab (
         }
 
         table.add(floatingTable)
-        toggleCityStatesButton.color = if (persistableData.includeCityStates) Color.RED else Color.GREEN
+        toggleCityStatesButton.style = if (persistableData.includeCityStates) {
+            BaseScreen.skin.get("negative", TextButtonStyle::class.java)
+        } else {
+            BaseScreen.skin.get("positive", TextButtonStyle::class.java)
+        }
         civTableScroll.setScrollingDisabled(portraitMode, portraitMode)
     }
 

--- a/core/src/com/unciv/ui/pickerscreens/ModManagementScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/ModManagementScreen.kt
@@ -22,7 +22,7 @@ import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.pickerscreens.ModManagementOptions.SortType
 import com.unciv.ui.popup.Popup
 import com.unciv.ui.popup.ToastPopup
-import com.unciv.ui.popup.YesNoPopup
+import com.unciv.ui.popup.ConfirmPopup
 import com.unciv.ui.utils.AutoScrollPane
 import com.unciv.ui.utils.ExpanderTab
 import com.unciv.ui.utils.KeyCharAndCode
@@ -527,21 +527,23 @@ class ModManagementScreen(
     private fun installedButtonAction(mod: ModUIData) {
         syncInstalledSelected(mod.name, mod.button)
         refreshInstalledModActions(mod.ruleset!!)
-        rightSideButton.setText("Delete [${mod.name}]".tr())
+        val deleteText = "Delete [${mod.name}]"
+        rightSideButton.setText(deleteText.tr())
         // Don't let the player think he can delete Vanilla and G&K rulesets
         rightSideButton.isEnabled = mod.ruleset.folderLocation!=null
         showModDescription(mod.name)
         rightSideButton.clearListeners()
         rightSideButton.onClick {
             rightSideButton.isEnabled = false
-            YesNoPopup(
+            ConfirmPopup(
+                screen = this,
                 question = "Are you SURE you want to delete this mod?",
+                confirmText = deleteText,
                 action = {
                     deleteMod(mod.ruleset)
                     modActionTable.clear()
                     rightSideButton.setText("[${mod.name}] was deleted.".tr())
                 },
-                screen = this,
                 restoreDefault = { rightSideButton.isEnabled = true }
             ).open()
         }

--- a/core/src/com/unciv/ui/popup/AskNumberPopup.kt
+++ b/core/src/com/unciv/ui/popup/AskNumberPopup.kt
@@ -116,6 +116,7 @@ class AskNumberPopup(
         val errorLabel = errorText.toLabel()
         errorLabel.color = Color.RED
 
+        addCloseButton()
         addOKButton(
             validate = {
                 val errorFound = !isValidInt(nameField.text) || !validate(nameField.text.toInt())
@@ -125,7 +126,6 @@ class AskNumberPopup(
         ) {
             actionOnOk(nameField.text.toInt())
         }
-        addCloseButton()
         equalizeLastTwoButtonWidths()
 
         keyboardFocus = nameField

--- a/core/src/com/unciv/ui/popup/AskTextPopup.kt
+++ b/core/src/com/unciv/ui/popup/AskTextPopup.kt
@@ -48,6 +48,7 @@ class AskTextPopup(
         val errorLabel = errorText.toLabel()
         errorLabel.color = Color.RED
 
+        addCloseButton()
         addOKButton(
             validate = {
                 val errorFound = nameField.text == "" || !validate(nameField.text)
@@ -57,7 +58,6 @@ class AskTextPopup(
         ) {
             actionOnOk(nameField.text)
         }
-        addCloseButton()
         equalizeLastTwoButtonWidths()
         keyboardFocus = nameField
     }

--- a/core/src/com/unciv/ui/popup/ConfirmPopup.kt
+++ b/core/src/com/unciv/ui/popup/ConfirmPopup.kt
@@ -2,32 +2,37 @@ package com.unciv.ui.popup
 
 import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.scenes.scene2d.Stage
+import com.badlogic.gdx.scenes.scene2d.ui.TextButton.TextButtonStyle
 import com.badlogic.gdx.utils.Align
-import com.unciv.Constants
-import com.unciv.UncivGame
 import com.unciv.ui.utils.BaseScreen
 import com.unciv.ui.utils.KeyCharAndCode
 import com.unciv.ui.utils.extensions.toLabel
 
-/** Variant of [Popup] pre-populated with one label, plus yes and no buttons
+/** Variant of [Popup] pre-populated with one label, plus confirm and cancel buttons
  * @param question The text for the label
+ * @param confirmText The text for the "Confirm" button
+ * @param isConfirmPositive If the action to be performed is positive or not (i.e. buy = positive, delete = negative), default false
  * @param action A lambda to execute when "Yes" is chosen
  * @param screen The parent screen - see [Popup.screen]. Optional, defaults to the current [WorldScreen][com.unciv.ui.worldscreen.WorldScreen]
  * @param restoreDefault A lambda to execute when "No" is chosen
  */
-open class YesNoPopup(
-    question: String,
+open class ConfirmPopup(
     stageToShowOn: Stage,
+    question: String,
+    confirmText: String,
+    isConfirmPositive: Boolean = false,
     restoreDefault: () -> Unit = {},
     action: () -> Unit
 ) : Popup(stageToShowOn) {
 
     constructor(
-        question: String,
         screen: BaseScreen,
+        question: String,
+        confirmText: String,
+        isConfirmPositive: Boolean = false,
         restoreDefault: () -> Unit = {},
         action: () -> Unit
-    ) : this(question, screen.stage, restoreDefault, action)
+    ) : this(screen.stage, question, confirmText, isConfirmPositive, restoreDefault, action)
 
     /** The [Label][com.badlogic.gdx.scenes.scene2d.ui.Label] created for parameter `question` for optional layout tweaking */
     private val promptLabel = question.toLabel()
@@ -35,16 +40,19 @@ open class YesNoPopup(
     init {
         promptLabel.setAlignment(Align.center)
         add(promptLabel).colspan(2).row()
-        addCloseButton(Constants.no, KeyCharAndCode('n'), action = restoreDefault)
-        addOKButton(Constants.yes, KeyCharAndCode('y'), action = action)
+        addCloseButton("Cancel", KeyCharAndCode('n'), action = restoreDefault)
+        val confirmStyleName = if (isConfirmPositive) "positive" else "negative"
+        val confirmStyle = BaseScreen.skin.get(confirmStyleName, TextButtonStyle::class.java)
+        addOKButton(confirmText, KeyCharAndCode('y'), confirmStyle, action = action)
         equalizeLastTwoButtonWidths()
     }
 }
 
-/** Shortcut to open a [YesNoPopup] with the exit game question */
-class ExitGamePopup(screen: BaseScreen, force: Boolean = false) : YesNoPopup(
-    question = "Do you want to exit the game?",
+/** Shortcut to open a [ConfirmPopup] with the exit game question */
+class ExitGamePopup(screen: BaseScreen, force: Boolean = false) : ConfirmPopup(
     screen = screen,
+    question = "Do you want to exit the game?",
+    confirmText = "Exit",
     restoreDefault = { screen.game.musicController.resume() },
     action = { Gdx.app.exit() }
 ) {

--- a/core/src/com/unciv/ui/popup/Popup.kt
+++ b/core/src/com/unciv/ui/popup/Popup.kt
@@ -9,6 +9,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.Cell
 import com.badlogic.gdx.scenes.scene2d.ui.Label
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton
+import com.badlogic.gdx.scenes.scene2d.ui.TextButton.TextButtonStyle
 import com.badlogic.gdx.scenes.scene2d.ui.TextField
 import com.badlogic.gdx.utils.Align
 import com.unciv.Constants
@@ -109,37 +110,23 @@ open class Popup(
     }
 
     /**
-     * Adds an inline [TextButton].
-     * @param text The button's caption.
-     * @param key Associate a key with this button's action.
-     * @param action A lambda to be executed when the button is clicked.
-     * @return The new [Cell]
-     */
-    fun addButtonInRow(text: String, key: KeyCharAndCode? = null, action: () -> Unit): Cell<TextButton> {
-        val button = text.toTextButton()
-        button.onActivation { action() }
-        button.keyShortcuts.add(key)
-        return add(button)
-    }
-    fun addButtonInRow(text: String, key: Char, action: () -> Unit)
-        = addButtonInRow(text, KeyCharAndCode(key), action)
-    fun addButtonInRow(text: String, key: Int, action: () -> Unit)
-        = addButtonInRow(text, KeyCharAndCode(key), action)
-
-    /**
      * Adds a [TextButton] and ends the current row.
      * @param text The button's caption.
      * @param key Associate a key with this button's action.
      * @param action A lambda to be executed when the button is clicked.
      * @return The new [Cell]
      */
-    fun addButton(text: String, key: KeyCharAndCode? = null, action: () -> Unit)
-        = addButtonInRow(text, key, action).apply { row() }
+    fun addButton(text: String, key: KeyCharAndCode? = null, style: TextButtonStyle? = null, action: () -> Unit): Cell<TextButton> {
+        val button = text.toTextButton(style)
+        button.onActivation { action() }
+        button.keyShortcuts.add(key)
+        return add(button)
+    }
     /** @link [addButton] */
-    fun addButton(text: String, key: Char, action: () -> Unit)
-        = addButtonInRow(text, key, action).apply { row() }
-    fun addButton(text: String, key: Int, action: () -> Unit)
-        = addButtonInRow(text, key, action).apply { row() }
+    fun addButton(text: String, key: Char, style: TextButtonStyle? = null, action: () -> Unit)
+        = addButton(text, KeyCharAndCode(key), style, action).apply { row() }
+    fun addButton(text: String, key: Int, style: TextButtonStyle? = null, action: () -> Unit)
+        = addButton(text, KeyCharAndCode(key), style, action).apply { row() }
 
     /**
      * Adds a [TextButton] that closes the popup, with [BACK][KeyCharAndCode.BACK] already mapped.
@@ -151,9 +138,10 @@ open class Popup(
     fun addCloseButton(
         text: String = Constants.close,
         additionalKey: KeyCharAndCode? = null,
+        style: TextButtonStyle? = null,
         action: (()->Unit)? = null
     ): Cell<TextButton> {
-        val cell = addButtonInRow(text, additionalKey) { close(); if(action!=null) action() }
+        val cell = addButton(text, additionalKey, style) { close(); if(action!=null) action() }
         cell.getActor().keyShortcuts.add(KeyCharAndCode.BACK)
         return cell
     }
@@ -170,10 +158,11 @@ open class Popup(
     fun addOKButton(
         text: String = Constants.OK,
         additionalKey: KeyCharAndCode? = null,
+        style: TextButtonStyle? = null,
         validate: (() -> Boolean) = { true },
         action: (() -> Unit),
     ): Cell<TextButton> {
-        val cell = addButtonInRow(text, additionalKey) {
+        val cell = addButton(text, additionalKey, style) {
             if (validate()) {
                 close()
                 action()

--- a/core/src/com/unciv/ui/popup/Popup.kt
+++ b/core/src/com/unciv/ui/popup/Popup.kt
@@ -146,14 +146,14 @@ open class Popup(
      * @param text The button's caption, defaults to "Close".
      * @param additionalKey An additional key that should act like a click.
      * @param action A lambda to be executed after closing the popup when the button is clicked.
-     * @return The new [Cell], marked as end of row.
+     * @return The new [Cell]
      */
     fun addCloseButton(
         text: String = Constants.close,
         additionalKey: KeyCharAndCode? = null,
         action: (()->Unit)? = null
     ): Cell<TextButton> {
-        val cell = addButton(text, additionalKey) { close(); if(action!=null) action() }
+        val cell = addButtonInRow(text, additionalKey) { close(); if(action!=null) action() }
         cell.getActor().keyShortcuts.add(KeyCharAndCode.BACK)
         return cell
     }
@@ -165,7 +165,7 @@ open class Popup(
      * @param validate Function that should return true when the popup can be closed and `action` can be run.
      * When this function returns false, nothing happens.
      * @param action A lambda to be executed after closing the popup when the button is clicked.
-     * @return The new [Cell], NOT marked as end of row.
+     * @return The new [Cell]
      */
     fun addOKButton(
         text: String = Constants.OK,

--- a/core/src/com/unciv/ui/popup/Popup.kt
+++ b/core/src/com/unciv/ui/popup/Popup.kt
@@ -182,8 +182,8 @@ open class Popup(
         val cell1 = innerTable.cells[n-2]
         val cell2 = innerTable.cells[n-1]
         if (cell1.actor !is Button || cell2.actor !is Button) throw UnsupportedOperationException()
-        cell1.minWidth(cell2.actor.width)
-        cell2.minWidth(cell1.actor.width)
+        cell1.minWidth(cell2.actor.width).uniformX()
+        cell2.minWidth(cell1.actor.width).uniformX()
     }
 
     /**

--- a/core/src/com/unciv/ui/popup/YesNoPopup.kt
+++ b/core/src/com/unciv/ui/popup/YesNoPopup.kt
@@ -36,7 +36,7 @@ open class YesNoPopup(
         promptLabel.setAlignment(Align.center)
         add(promptLabel).colspan(2).row()
         addOKButton(Constants.yes, KeyCharAndCode('y'), action = action)
-        addCloseButton(Constants.no, KeyCharAndCode('n'), restoreDefault)
+        addCloseButton(Constants.no, KeyCharAndCode('n'), action = restoreDefault)
         equalizeLastTwoButtonWidths()
     }
 }

--- a/core/src/com/unciv/ui/popup/YesNoPopup.kt
+++ b/core/src/com/unciv/ui/popup/YesNoPopup.kt
@@ -35,8 +35,8 @@ open class YesNoPopup(
     init {
         promptLabel.setAlignment(Align.center)
         add(promptLabel).colspan(2).row()
-        addOKButton(Constants.yes, KeyCharAndCode('y'), action = action)
         addCloseButton(Constants.no, KeyCharAndCode('n'), action = restoreDefault)
+        addOKButton(Constants.yes, KeyCharAndCode('y'), action = action)
         equalizeLastTwoButtonWidths()
     }
 }

--- a/core/src/com/unciv/ui/saves/LoadOrSaveScreen.kt
+++ b/core/src/com/unciv/ui/saves/LoadOrSaveScreen.kt
@@ -1,9 +1,9 @@
 package com.unciv.ui.saves
 
 import com.badlogic.gdx.files.FileHandle
-import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.scenes.scene2d.ui.CheckBox
 import com.badlogic.gdx.scenes.scene2d.ui.Table
+import com.badlogic.gdx.scenes.scene2d.ui.TextButton
 import com.unciv.Constants
 import com.unciv.models.translations.tr
 import com.unciv.ui.pickerscreens.PickerScreen
@@ -14,8 +14,8 @@ import com.unciv.ui.utils.extensions.UncivDateFormat.formatDate
 import com.unciv.ui.utils.extensions.disable
 import com.unciv.ui.utils.extensions.enable
 import com.unciv.ui.utils.extensions.keyShortcuts
-import com.unciv.ui.utils.extensions.onChange
 import com.unciv.ui.utils.extensions.onActivation
+import com.unciv.ui.utils.extensions.onChange
 import com.unciv.ui.utils.extensions.pad
 import com.unciv.ui.utils.extensions.toLabel
 import com.unciv.ui.utils.extensions.toTextButton
@@ -35,7 +35,7 @@ abstract class LoadOrSaveScreen(
 
     private val savesScrollPane = VerticalFileListScrollPane()
     protected val rightSideTable = Table()
-    protected val deleteSaveButton = "Delete save".toTextButton()
+    protected val deleteSaveButton = "Delete save".toTextButton(skin.get("negative", TextButton.TextButtonStyle::class.java))
     protected val showAutosavesCheckbox = CheckBox("Show autosaves".tr(), skin)
 
     init {
@@ -93,7 +93,6 @@ abstract class LoadOrSaveScreen(
 
     private fun selectExistingSave(saveGameFile: FileHandle) {
         deleteSaveButton.enable()
-        deleteSaveButton.color = Color.RED
 
         selectedSave = saveGameFile.name()
         showSaveInfo(saveGameFile)

--- a/core/src/com/unciv/ui/saves/LoadOrSaveScreen.kt
+++ b/core/src/com/unciv/ui/saves/LoadOrSaveScreen.kt
@@ -7,6 +7,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.TextButton
 import com.unciv.Constants
 import com.unciv.models.translations.tr
 import com.unciv.ui.pickerscreens.PickerScreen
+import com.unciv.ui.popup.ConfirmPopup
 import com.unciv.ui.utils.Fonts
 import com.unciv.ui.utils.KeyCharAndCode
 import com.unciv.ui.utils.UncivTooltip.Companion.addTooltip
@@ -74,17 +75,21 @@ abstract class LoadOrSaveScreen(
 
     private fun onDeleteClicked() {
         if (selectedSave.isEmpty()) return
-        val result = try {
-            if (game.gameSaver.deleteSave(selectedSave)) {
-                resetWindowState()
-                "[$selectedSave] deleted successfully."
-            } else "Failed to delete [$selectedSave]."
-        } catch (ex: SecurityException) {
-            "Insufficient permissions to delete [$selectedSave]."
-        } catch (ex: Throwable) {
-            "Failed to delete [$selectedSave]."
-        }
-        descriptionLabel.setText(result.tr())
+        ConfirmPopup(this, "Are you sure you want to delete this save?", "Delete save") {
+            val result = try {
+                if (game.gameSaver.deleteSave(selectedSave)) {
+                    resetWindowState()
+                    "[$selectedSave] deleted successfully."
+                } else {
+                    "Failed to delete [$selectedSave]."
+                }
+            } catch (ex: SecurityException) {
+                "Insufficient permissions to delete [$selectedSave]."
+            } catch (ex: Throwable) {
+                "Failed to delete [$selectedSave]."
+            }
+            descriptionLabel.setText(result.tr())
+        }.open()
     }
 
     private fun updateShownSaves(showAutosaves: Boolean) {

--- a/core/src/com/unciv/ui/saves/SaveGameScreen.kt
+++ b/core/src/com/unciv/ui/saves/SaveGameScreen.kt
@@ -10,7 +10,7 @@ import com.unciv.logic.GameInfo
 import com.unciv.logic.GameSaver
 import com.unciv.models.translations.tr
 import com.unciv.ui.popup.ToastPopup
-import com.unciv.ui.popup.YesNoPopup
+import com.unciv.ui.popup.ConfirmPopup
 import com.unciv.ui.utils.KeyCharAndCode
 import com.unciv.ui.utils.UncivTooltip.Companion.addTooltip
 import com.unciv.ui.utils.extensions.disable
@@ -35,7 +35,11 @@ class SaveGameScreen(val gameInfo: GameInfo) : LoadOrSaveScreen("Current saves")
         rightSideButton.setText("Save game".tr())
         rightSideButton.onActivation {
             if (game.gameSaver.getSave(gameNameTextField.text).exists())
-                YesNoPopup("Overwrite existing file?", this) { saveGame() }.open()
+                ConfirmPopup(
+                    this,
+                    "Overwrite existing file?",
+                    "Overwrite",
+                ) { saveGame() }.open()
             else saveGame()
         }
         rightSideButton.keyShortcuts.add(KeyCharAndCode.RETURN)

--- a/core/src/com/unciv/ui/trade/DiplomacyScreen.kt
+++ b/core/src/com/unciv/ui/trade/DiplomacyScreen.kt
@@ -33,7 +33,7 @@ import com.unciv.ui.audio.MusicMood
 import com.unciv.ui.audio.MusicTrackChooserFlags
 import com.unciv.ui.civilopedia.CivilopediaScreen
 import com.unciv.ui.images.ImageGetter
-import com.unciv.ui.popup.YesNoPopup
+import com.unciv.ui.popup.ConfirmPopup
 import com.unciv.ui.tilegroups.CityButton
 import com.unciv.ui.utils.BaseScreen
 import com.unciv.ui.utils.Fonts
@@ -391,7 +391,7 @@ class DiplomacyScreen(
     private fun getRevokeProtectionButton(otherCiv: CivilizationInfo): TextButton {
         val revokeProtectionButton = "Revoke Protection".toTextButton()
         revokeProtectionButton.onClick {
-            YesNoPopup("Revoke protection for [${otherCiv.civName}]?", this) {
+            ConfirmPopup(this, "Revoke protection for [${otherCiv.civName}]?", "Revoke Protection") {
                 otherCiv.removeProtectorCiv(viewingCiv)
                 updateLeftSideTable(otherCiv)
                 updateRightSide(otherCiv)
@@ -404,7 +404,12 @@ class DiplomacyScreen(
     private fun getPledgeToProtectButton(otherCiv: CivilizationInfo): TextButton {
         val protectionButton = "Pledge to protect".toTextButton()
         protectionButton.onClick {
-            YesNoPopup("Declare Protection of [${otherCiv.civName}]?", this) {
+            ConfirmPopup(
+                this,
+                "Declare Protection of [${otherCiv.civName}]?",
+                "Pledge to protect",
+                true
+            ) {
                 otherCiv.addProtectorCiv(viewingCiv)
                 updateLeftSideTable(otherCiv)
                 updateRightSide(otherCiv)
@@ -420,7 +425,12 @@ class DiplomacyScreen(
     ): TextButton {
         val peaceButton = "Negotiate Peace".toTextButton()
         peaceButton.onClick {
-            YesNoPopup("Peace with [${otherCiv.civName}]?", this) {
+            ConfirmPopup(
+                this,
+                "Peace with [${otherCiv.civName}]?",
+                "Negotiate Peace",
+                true
+            ) {
                 val tradeLogic = TradeLogic(viewingCiv, otherCiv)
                 tradeLogic.currentTrade.ourOffers.add(
                     TradeOffer(
@@ -763,7 +773,7 @@ class DiplomacyScreen(
     ): TextButton {
         val denounceButton = "Denounce ([30] turns)".toTextButton()
         denounceButton.onClick {
-            YesNoPopup("Denounce [${otherCiv.civName}]?", this) {
+            ConfirmPopup(this, "Denounce [${otherCiv.civName}]?", "Denounce ([30] turns)") {
                 diplomacyManager.denounce()
                 updateLeftSideTable(otherCiv)
                 setRightSideFlavorText(otherCiv, "We will remember this.", "Very well.")
@@ -950,15 +960,14 @@ class DiplomacyScreen(
         diplomacyManager: DiplomacyManager,
         otherCiv: CivilizationInfo
     ): TextButton {
-        val declareWarButton = "Declare war".toTextButton()
-        declareWarButton.color = Color.RED
+        val declareWarButton = "Declare war".toTextButton(skin.get("negative", TextButton.TextButtonStyle::class.java))
         val turnsToPeaceTreaty = diplomacyManager.turnsToPeaceTreaty()
         if (turnsToPeaceTreaty > 0) {
             declareWarButton.disable()
             declareWarButton.setText(declareWarButton.text.toString() + " ($turnsToPeaceTreaty${Fonts.turn})")
         }
         declareWarButton.onClick {
-            YesNoPopup("Declare war on [${otherCiv.civName}]?", this) {
+            ConfirmPopup(this, "Declare war on [${otherCiv.civName}]?", "Declare war") {
                 diplomacyManager.declareWar()
                 setRightSideFlavorText(otherCiv, otherCiv.nation.attacked, "Very well.")
                 updateLeftSideTable(otherCiv)

--- a/core/src/com/unciv/ui/utils/extensions/Scene2dExtensions.kt
+++ b/core/src/com/unciv/ui/utils/extensions/Scene2dExtensions.kt
@@ -10,12 +10,14 @@ import com.badlogic.gdx.scenes.scene2d.InputListener
 import com.badlogic.gdx.scenes.scene2d.Stage
 import com.badlogic.gdx.scenes.scene2d.Touchable
 import com.badlogic.gdx.scenes.scene2d.ui.Button
+import com.badlogic.gdx.scenes.scene2d.ui.Button.ButtonStyle
 import com.badlogic.gdx.scenes.scene2d.ui.Cell
 import com.badlogic.gdx.scenes.scene2d.ui.CheckBox
 import com.badlogic.gdx.scenes.scene2d.ui.Image
 import com.badlogic.gdx.scenes.scene2d.ui.Label
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton
+import com.badlogic.gdx.scenes.scene2d.ui.TextButton.TextButtonStyle
 import com.badlogic.gdx.scenes.scene2d.ui.WidgetGroup
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener
 import com.badlogic.gdx.scenes.scene2d.utils.ClickListener
@@ -38,14 +40,23 @@ import com.unciv.ui.utils.KeyShortcutDispatcher
  * Collection of extension functions mostly for libGdx widgets
  */
 
+private class RestorableTextButtonStyle(
+    baseStyle: TextButtonStyle,
+    val restoreStyle: ButtonStyle
+) : TextButtonStyle(baseStyle)
 /** Disable a [Button] by setting its [touchable][Button.touchable] and [color][Button.color] properties. */
 fun Button.disable() {
     touchable= Touchable.disabled
-    color = Color.GRAY
+    val oldStyle = style
+    val disabledStyle = BaseScreen.skin.get("disabled", TextButtonStyle::class.java)
+    style = RestorableTextButtonStyle(disabledStyle, oldStyle)
 }
 /** Enable a [Button] by setting its [touchable][Button.touchable] and [color][Button.color] properties. */
 fun Button.enable() {
-    color = Color.WHITE
+    val oldStyle = style
+    if (oldStyle is RestorableTextButtonStyle) {
+        style = oldStyle.restoreStyle
+    }
     touchable = Touchable.enabled
 }
 /** Enable or disable a [Button] by setting its [touchable][Button.touchable] and [color][Button.color] properties,

--- a/core/src/com/unciv/ui/utils/extensions/Scene2dExtensions.kt
+++ b/core/src/com/unciv/ui/utils/extensions/Scene2dExtensions.kt
@@ -366,7 +366,10 @@ fun Image.setSize(size: Float) {
 }
 
 /** Translate a [String] and make a [TextButton] widget from it */
-fun String.toTextButton() = TextButton(this.tr(), BaseScreen.skin)
+fun String.toTextButton(style: TextButtonStyle? = null): TextButton {
+    val text = this.tr()
+    return if (style == null) TextButton(text, BaseScreen.skin) else TextButton(text, style)
+}
 
 /** Translate a [String] and make a [Label] widget from it */
 fun String.toLabel() = Label(this.tr(), BaseScreen.skin)

--- a/core/src/com/unciv/ui/worldscreen/TradePopup.kt
+++ b/core/src/com/unciv/ui/worldscreen/TradePopup.kt
@@ -85,20 +85,20 @@ class TradePopup(worldScreen: WorldScreen): Popup(worldScreen){
             close()
             TradeThanksPopup(leaderIntroTable, worldScreen)
             requestingCiv.addNotification("[${viewingCiv.civName}] has accepted your trade request", viewingCiv.civName, NotificationIcon.Trade)
-        }
+        }.row()
 
         addButton("Not this time.", 'n') {
             tradeRequest.decline(viewingCiv)
             close()
             requestingCiv.addNotification("[${viewingCiv.civName}] has denied your trade request", viewingCiv.civName, NotificationIcon.Trade)
             worldScreen.shouldUpdate = true
-        }
+        }.row()
 
         addButton("How about something else...", 'e') {
             close()
             worldScreen.game.setScreen(DiplomacyScreen(viewingCiv, requestingCiv, trade))
             worldScreen.shouldUpdate = true
-        }
+        }.row()
     }
 
     override fun close() {

--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -46,7 +46,7 @@ import com.unciv.ui.pickerscreens.TechPickerScreen
 import com.unciv.ui.popup.ExitGamePopup
 import com.unciv.ui.popup.Popup
 import com.unciv.ui.popup.ToastPopup
-import com.unciv.ui.popup.YesNoPopup
+import com.unciv.ui.popup.ConfirmPopup
 import com.unciv.ui.popup.hasOpenPopups
 import com.unciv.ui.saves.LoadGameScreen
 import com.unciv.ui.saves.QuickSave
@@ -812,7 +812,7 @@ class WorldScreen(
                         nextTurn()
                     }
                     if (game.settings.confirmNextTurn) {
-                        YesNoPopup("Confirm next turn", this, action = action).open()
+                        ConfirmPopup(this, "Confirm next turn", "Next turn", true, action = action).open()
                     } else {
                         action()
                     }

--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -369,12 +369,12 @@ class WorldScreen(
                 loadingGamePopup.innerTable.clear()
                 loadingGamePopup.addGoodSizedLabel("Couldn't download the latest game state!").colspan(2).row()
                 loadingGamePopup.addGoodSizedLabel(message).colspan(2).row()
-                loadingGamePopup.addButtonInRow("Retry") {
+                loadingGamePopup.addButton("Retry") {
                     launchOnThreadPool("Load latest multiplayer state after error") {
                         loadLatestMultiplayerState()
                     }
                 }.right()
-                loadingGamePopup.addButtonInRow("Main menu") {
+                loadingGamePopup.addButton("Main menu") {
                     game.setScreen(MainMenuScreen())
                 }.left()
             }

--- a/core/src/com/unciv/ui/worldscreen/mainmenu/WorldScreenMenuPopup.kt
+++ b/core/src/com/unciv/ui/worldscreen/mainmenu/WorldScreenMenuPopup.kt
@@ -1,7 +1,6 @@
 package com.unciv.ui.worldscreen.mainmenu
 
 import com.badlogic.gdx.Gdx
-import com.unciv.MainMenuScreen
 import com.unciv.ui.civilopedia.CivilopediaScreen
 import com.unciv.models.metadata.GameSetupInfo
 import com.unciv.ui.newgamescreen.NewGameScreen
@@ -17,19 +16,19 @@ class WorldScreenMenuPopup(val worldScreen: WorldScreen) : Popup(worldScreen) {
 
         addButton("Main menu") {
             worldScreen.game.goToMainMenu()
-        }
+        }.row()
         addButton("Civilopedia") {
             close()
             worldScreen.game.setScreen(CivilopediaScreen(worldScreen.gameInfo.ruleSet, worldScreen))
-        }
+        }.row()
         addButton("Save game") {
             close()
             worldScreen.game.setScreen(SaveGameScreen(worldScreen.gameInfo))
-        }
+        }.row()
         addButton("Load game") {
             close()
             worldScreen.game.setScreen(LoadGameScreen(worldScreen))
-        }
+        }.row()
 
         addButton("Start new game") {
             close()
@@ -37,20 +36,20 @@ class WorldScreenMenuPopup(val worldScreen: WorldScreen) : Popup(worldScreen) {
             newGameSetupInfo.mapParameters.reseed()
             val newGameScreen = NewGameScreen(worldScreen, newGameSetupInfo)
             worldScreen.game.setScreen(newGameScreen)
-        }
+        }.row()
 
         addButton("Victory status") {
             close()
             worldScreen.game.setScreen(VictoryScreen(worldScreen))
-        }
+        }.row()
         addButton("Options") {
             close()
             worldScreen.openOptionsPopup()
-        }
+        }.row()
         addButton("Community") {
             close()
             WorldScreenCommunityPopup(worldScreen).open(force = true)
-        }
+        }.row()
         addCloseButton()
         pack()
     }
@@ -62,17 +61,17 @@ class WorldScreenCommunityPopup(val worldScreen: WorldScreen) : Popup(worldScree
         addButton("Discord") {
             Gdx.net.openURI("https://discord.gg/bjrB4Xw")
             close()
-        }
+        }.row()
 
         addButton("Github") {
             Gdx.net.openURI("https://github.com/yairm210/UnCiv")
             close()
-        }
+        }.row()
 
         addButton("Reddit") {
             Gdx.net.openURI("https://www.reddit.com/r/Unciv/")
             close()
-        }
+        }.row()
 
         addCloseButton()
     }

--- a/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
@@ -24,7 +24,7 @@ import com.unciv.models.stats.Stats
 import com.unciv.models.translations.tr
 import com.unciv.ui.pickerscreens.ImprovementPickerScreen
 import com.unciv.ui.pickerscreens.PromotionPickerScreen
-import com.unciv.ui.popup.YesNoPopup
+import com.unciv.ui.popup.ConfirmPopup
 import com.unciv.ui.popup.hasOpenPopups
 import com.unciv.ui.utils.extensions.toPercent
 import com.unciv.ui.worldscreen.WorldScreen
@@ -127,7 +127,7 @@ object UnitActions {
                 val disbandText = if (unit.currentTile.getOwner() == unit.civInfo)
                     "Disband this unit for [${unit.baseUnit.getDisbandGold(unit.civInfo)}] gold?".tr()
                 else "Do you really want to disband this unit?".tr()
-                YesNoPopup(disbandText, UncivGame.Current.worldScreen!!) { unit.disband(); worldScreen.shouldUpdate = true }.open()
+                ConfirmPopup(UncivGame.Current.worldScreen!!, disbandText, "Disband unit") { unit.disband(); worldScreen.shouldUpdate = true }.open()
             }
         }.takeIf { unit.currentMovement > 0 })
     }
@@ -204,7 +204,7 @@ object UnitActions {
                     else {
                         // ask if we would be breaking a promise
                         val text = "Do you want to break your promise to [$leaders]?"
-                        YesNoPopup(text, UncivGame.Current.worldScreen!!, action = foundAction).open(force = true)
+                        ConfirmPopup(UncivGame.Current.worldScreen!!, text, "Break promise", action = foundAction).open(force = true)
                     }
                 }
             )
@@ -275,7 +275,15 @@ object UnitActions {
         else actionList += UnitAction(type = UnitActionType.Pillage) {
             if (!worldScreen.hasOpenPopups()) {
                 val pillageText = "Are you sure you want to pillage this [${unit.currentTile.improvement}]?"
-                YesNoPopup(pillageText, UncivGame.Current.worldScreen!!) { (pillageAction.action)(); worldScreen.shouldUpdate = true }.open()
+                ConfirmPopup(
+                    UncivGame.Current.worldScreen!!,
+                    pillageText,
+                    "Pillage",
+                    true
+                ) {
+                    (pillageAction.action)()
+                    worldScreen.shouldUpdate = true
+                }.open()
             }
         }
     }


### PR DESCRIPTION
I separated all of them by commit:

* [Refactor: Format JSON](https://github.com/yairm210/Unciv/pull/7207/commits/a45b68beedc83aff5d9cdc586402688d5bb1d0ac)
   All our other JSONs use 4 spaces
* [Change button hover color to be darker](https://github.com/yairm210/Unciv/pull/7207/commits/35504f04d1e5ccd20a7f4d7a283b3f84dc8e81b4) 
   Previous:
   ![image](https://user-images.githubusercontent.com/2777158/174439740-6f9fbfd4-2352-4130-ba71-a2bc925684b5.png)
   After, intention is to have better contrast:
   ![image](https://user-images.githubusercontent.com/2777158/174439502-3bcef47e-f00c-4197-8bd7-960cb01da5e6.png)
* [Refactor: Change disabled buttons to always look disabled, even if they don't have the default style](https://github.com/yairm210/Unciv/pull/7207/commits/e41cd57b42b26d0817864b1b0b1d84684b538e17)
   In preparation for the usage of `TextButtonStyle` instead of `button.color = ...`
* [Make disabled style a little grayer](https://github.com/yairm210/Unciv/pull/7207/commits/cc976ac9af194ef7545f785e8343f14924059006)
   Previous:
   ![image](https://user-images.githubusercontent.com/2777158/174439818-cbdc22e5-917a-4450-b565-e9c29b42d7b5.png)
   After, intention is to convey being "disabled" a little better:
   ![image](https://user-images.githubusercontent.com/2777158/174439837-1c74970a-507a-4950-a0c6-c96df73ec0fd.png)
* [Refactor: Make addCloseButton not start a new row](https://github.com/yairm210/Unciv/pull/7207/commits/9b1df8ed3d9b54523ac8845a0ce6775f00dda730)
   This basically doesn't matter anyway since `addCloseButton` is the last addition to the popup in all places, so an implicit row will be created.
* [Refactor: Remove "...inRow" popup button methods & add button style parameter](https://github.com/yairm210/Unciv/pull/7207/commits/5c37cc268428b4f55882ae23018f43855b5be473)
   `addButton` always adding a row is confusing, since `add` doesn't add a row. So I simply removed all `...inRow` functions and let the users add `.row()` manually. It's only 1 character more, no idea why this helper method was ever necessary.
* [Reorder "ok/cancel" popups to have "ok" on the right side](https://github.com/yairm210/Unciv/pull/7207/commits/f702d8d4158fd18d81bc39c72714df6f7b575219)
   Just look at this [web image search](https://duckduckgo.com/?q=android+dialog&t=ffsb&iar=images&iax=images&ia=images) - all dialogs on Android have the "Yes/Confirm/OK" on the right side.
* [Fix pointer enter/exit events being disabled by default](https://github.com/yairm210/Unciv/pull/7207/commits/d90a13de054f684cbce6271e109c34bdc3059b6a)
   When I implemented this, I initially started with `disablePointerEnterExitEvents` and  then later refactored to `performPointerEnterExitEvents`, but I forgot to change the default value.
* [Fix equalizeLastTwoButtonWidths not setting the cells to be equal size](https://github.com/yairm210/Unciv/pull/7207/commits/225d5b4d8b9832be56cd44ad1d56c3319d68a3a1)
   Previous (buttons weren't centered):
   ![image](https://user-images.githubusercontent.com/2777158/174441732-4a403cc8-66e7-4f64-85d5-10d3d122881d.png)
   After (buttons are centered):
   ![image](https://user-images.githubusercontent.com/2777158/174441745-a9565b8c-0a56-4a95-ab6c-4713636701e1.png)
* [Change YesNoPopup to ConfirmPopup](https://github.com/yairm210/Unciv/pull/7207/commits/72c8447e41adc8250556bdd6710ecfbca10b49b2)
   Previous:
   ![image](https://user-images.githubusercontent.com/2777158/174443719-9928123c-d2c1-4980-b71f-2829620c8ea8.png)
   After:
   ![image](https://user-images.githubusercontent.com/2777158/174441516-3116ab7c-6cb1-4a78-b810-f4dbc34705df.png)
* [Add ConfirmPopup to deletion of save files](https://github.com/yairm210/Unciv/pull/7207/commits/7db0a7a797c5c920f04e68b244e6f55013a9d1a9)
   Previously you weren't asked when deleting a save, now you are.