### PR TITLE
AI missionaries avoid cities protected by inquisitors

### DIFF
--- a/core/src/com/unciv/logic/automation/SpecificUnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/SpecificUnitAutomation.kt
@@ -299,9 +299,9 @@ object SpecificUnitAutomation {
 
         val city = unit.civInfo.gameInfo.getCities().asSequence()
             .filter { it.religion.getMajorityReligion()?.name != unit.getReligionDisplayName() }
-            .filterNot { it.civInfo.isAtWarWith(unit.civInfo) }
+            .filter { it.civInfo.knows(unit.civInfo) && !it.civInfo.isAtWarWith(unit.civInfo) }
+            .filterNot { it.religion.isProtectedByInquisitor() }
             .minByOrNull { it.getCenterTile().aerialDistanceTo(unit.currentTile) } ?: return
-
 
         val destination = city.getTiles().asSequence()
             .filter { unit.movement.canMoveTo(it) || it == unit.getTile() }

--- a/core/src/com/unciv/logic/city/CityReligion.kt
+++ b/core/src/com/unciv/logic/city/CityReligion.kt
@@ -283,10 +283,9 @@ class CityInfoReligionManager {
     }
 
     fun isProtectedByInquisitor(): Boolean {
-        for (tile in cityInfo.getCenterTile().neighbors)
+        for (tile in cityInfo.getCenterTile().getTilesInDistance(1))
             if (tile.civilianUnit?.hasUnique(UniqueType.PreventSpreadingReligion) == true)
                 return true
-        if (cityInfo.getCenterTile().civilianUnit?.name == "Inquisitor") return true
         return false
     }
 

--- a/core/src/com/unciv/logic/civilization/ReligionManager.kt
+++ b/core/src/com/unciv/logic/civilization/ReligionManager.kt
@@ -333,6 +333,7 @@ class ReligionManager {
         if (missionary.getTile().getOwner() == null) return false
         if (missionary.currentTile.owningCity?.religion?.getMajorityReligion()?.name == missionary.religion)
             return false
+        if (missionary.getTile().getCity()!!.religion.isProtectedByInquisitor()) return false
         return true
     }
 


### PR DESCRIPTION
Addresses some points brought up in #7206 then some other changes I felt were appropriate.
* `SpecificUnitAutomation.automateMissionary()` changed so that AI missionaries avoid cities with inquisitors; AI missionaries no longer given divinely-inspired knowledge of the location of cities belonging to civs they haven't met
* `CityInfoReligionManager.isProtectedByInquisitor()` cleaned up
* `ReligionManager.maySpreadReligionNow()` updated to return false if the unit is in a tile belonging to a city protected by an inquisitor