### PR TITLE
Fix policies not contributing stats from city-states

### DIFF
--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -913,7 +913,7 @@ class CivilizationInfo {
 
     fun endTurn() {
         notifications.clear()
-
+        updateStatsForNextTurn()
         val nextTurnStats = statsForNextTurn
 
         policies.endTurn(nextTurnStats.culture.toInt())


### PR DESCRIPTION
Fixes #7220. This was fun to debug.

<Details>

Once the player hits the "End turn" button, `GameInfo` is cloned then all transients initialized. At the start, every civ's `statsForNextTurn` is all 0's. `statsForNextTurn` is updated at two points in `GameInfo.setTransients()`

https://github.com/yairm210/Unciv/blob/18b91bba1ed8aa63743d96c2419c6687ed6842ea/core/src/com/unciv/logic/GameInfo.kt#L425

and

https://github.com/yairm210/Unciv/blob/18b91bba1ed8aa63743d96c2419c6687ed6842ea/core/src/com/unciv/logic/GameInfo.kt#L456

At the former point, the `civInfo`s do not have their `cities` field populated so stats contributed by cities are still zeroed. At the latter point, the stats contributed by cities are calculated but `civInfo.statsForNextTurn` is updated _in the order civs appear in `gameInfo.civilizations`_ (major civs then city-states). This means that if `civ1`'s `statsForNextTurn()` is dependent on `cityStates`'s `statsForNextTurn` object, then that `civ1` will not be seeing `cityState`'s most accurate `statsForNextTurn` which is what is causing the bug (the player's interface is updated separately at a later point so the interface reflects the true values).

Once the new `gameInfo` object is set up, `endTurn()` is called for the current player which is where the research/culture/gold is added to the `civilizationInfo` so there is currently no opportunity for the stats to be updated to their most correct values. This fix adds a `updateStatsForNextTurn()` at the top of the `civilizationInfo.endTurn()` to make sure the most accurate stats are added to the various counters. It also mirrors the `updateStatsForNextTurn()` that appears at the beginning of `civilizationInfo.startTurn()` for some pleasing symmetry.

</Details>