### PR TITLE
Fix AI great people getting stuck trying to build great improvements

### DIFF
--- a/core/src/com/unciv/logic/automation/SpecificUnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/SpecificUnitAutomation.kt
@@ -257,14 +257,14 @@ object SpecificUnitAutomation {
             val applicableTiles = city.getWorkableTiles().filter {
                 it.isLand && it.resource == null && !it.isCityCenter()
                         && (unit.currentTile == it || unit.movement.canMoveTo(it))
-                        && !it.containsGreatImprovement()
+                        && !it.containsGreatImprovement() && it.canBuildImprovement(improvement, unit.civInfo)
             }
             if (applicableTiles.none()) continue
 
             val pathToCity = unit.movement.getShortestPath(city.getCenterTile())
 
             if (pathToCity.isEmpty()) continue
-            if (pathToCity.size > 2) {
+            if (pathToCity.size > 2 && unit.getTile().getCity() != city) {
                 if (unit.getTile().militaryUnit == null) return // Don't move until you're accompanied by a military unit
                 unit.movement.headTowards(city.getCenterTile())
                 return


### PR DESCRIPTION
This PR fixes two cases where AI great people get stuck trying to build great improvements.

The first case happens because the AI doesn't check if they can actually build an improvement on a destination tile, usually because there's an oasis there. This is fixed by only considering tiles where the AI can build the improvement.

The second case occurs because the great person paths to the selected city until it is within 2 turns worth of movement from the city center. After that, the AI paths to the tile to build the improvement. In some cases, usually very large cities that have rough terrain, the AI chooses a tile that is 3 turns worth of movement away from the city center. This causes the great person to get stuck in an endless loop of trying to get to the selected tile then trying to path back to within 2 turns of movement of the city center. This is fixed by adding a condition to skip the path-to-city-center operation if they're already on a tile owned by the chosen city.