### PR TITLE
Fix translation issues caused by nested brackets and braces

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -1175,7 +1175,7 @@ Number of your cities\ndemanding this resource for\n'We Love The King Day' =
 
 [victoryType] Victory = 
 Built [building] = 
-Add all [param] in capital = 
+Add all [comment] in capital = 
 Destroy all players = 
 Capture all capitals = 
 Complete [amount] Policy branches = 

--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -86,7 +86,6 @@ Requires a [buildingName] in all cities =
 [buildingName] required: = 
 Requires a [buildingName] in this city = 
 Cannot be built with [buildingName] = 
-Consumes 1 [resource] = 
 Consumes [amount] [resource] = 
 [amount] available = 
 Required tech: [requiredTech] = 
@@ -1176,7 +1175,7 @@ Number of your cities\ndemanding this resource for\n'We Love The King Day' =
 
 [victoryType] Victory = 
 Built [building] = 
-Add all spaceship parts in capital = 
+Add all [param] in capital = 
 Destroy all players = 
 Capture all capitals = 
 Complete [amount] Policy branches = 

--- a/core/src/com/unciv/models/translations/Translations.kt
+++ b/core/src/com/unciv/models/translations/Translations.kt
@@ -352,12 +352,10 @@ fun String.tr(): String {
 
     // curly and square brackets can be nested inside of each other so find the leftmost curly/square
     // bracket then process that first
-    val indexSquare = this.indexOfFirst { it == '[' }
-    val indexCurly = this.indexOfFirst { it == '{' }
-    val processSquare = if (indexSquare >= 0 && indexCurly >= 0) indexSquare < indexCurly
-        else indexSquare >= 0
-    val processCurly = if (indexSquare >= 0 && indexCurly >= 0) indexCurly < indexSquare
-        else indexCurly >= 0
+    val indexSquare = this.indexOf('[')
+    val indexCurly = this.indexOf('{')
+    val processSquare = indexSquare >= 0 && (indexCurly < 0 || indexSquare < indexCurly)
+    val processCurly =  indexCurly >= 0 && (indexSquare < 0 || indexCurly < indexSquare)
 
     // There might still be optimization potential here!
     if (processSquare) { // Placeholders!

--- a/core/src/com/unciv/models/translations/Translations.kt
+++ b/core/src/com/unciv/models/translations/Translations.kt
@@ -360,7 +360,7 @@ fun String.tr(): String {
         else indexCurly >= 0
 
     // There might still be optimization potential here!
-    if (processSquare) {
+    if (processSquare) { // Placeholders!
         /**
          * I'm SURE there's an easier way to do this but I can't think of it =\
          * So what's all this then?

--- a/core/src/com/unciv/models/translations/Translations.kt
+++ b/core/src/com/unciv/models/translations/Translations.kt
@@ -350,8 +350,17 @@ fun String.tr(): String {
         return fullyTranslatedString
     }
 
+    // curly and square brackets can be nested inside of each other so find the leftmost curly/square
+    // bracket then process that first
+    val indexSquare = this.indexOfFirst { it == '[' }
+    val indexCurly = this.indexOfFirst { it == '{' }
+    val processSquare = if (indexSquare >= 0 && indexCurly >= 0) indexSquare < indexCurly
+        else indexSquare >= 0
+    val processCurly = if (indexSquare >= 0 && indexCurly >= 0) indexCurly < indexSquare
+        else indexCurly >= 0
+
     // There might still be optimization potential here!
-    if (contains('[')) { // Placeholders!
+    if (processSquare) {
         /**
          * I'm SURE there's an easier way to do this but I can't think of it =\
          * So what's all this then?
@@ -399,11 +408,9 @@ fun String.tr(): String {
         return languageSpecificPlaceholder      // every component is already translated
     }
 
-
-    if (contains('{')) { // Translating partial sentences
+    if (processCurly) { // Translating partial sentences
         return curlyBraceRegex.replace(this) { it.groups[1]!!.value.tr() }
     }
-
 
     if (Stats.isStats(this)) return Stats.parse(this).toString()
 

--- a/core/src/com/unciv/ui/utils/extensions/FormattingExtensions.kt
+++ b/core/src/com/unciv/ui/utils/extensions/FormattingExtensions.kt
@@ -15,9 +15,8 @@ fun Int.toPercent() = toFloat().toPercent()
 /** Translate a percentage number - e.g. 25 - to the multiplication value - e.g. 1.25f */
 fun Float.toPercent() = 1 + this/100
 
-/** Convert a [resource name][this] into "Consumes [amount] $resource" string (untranslated, using separate templates for 1 and other amounts) */
-//todo some day... remove and use just one translatable where this is called
-fun String.getConsumesAmountString(amount: Int) = if (amount == 1) "Consumes 1 [$this]" else "Consumes [$amount] [$this]"
+/** Convert a [resource name][this] into "Consumes [amount] $resource" string (untranslated) */
+fun String.getConsumesAmountString(amount: Int) = "Consumes [$amount] [$this]"
 
 /** Formats the [Duration] into a translated string */
 fun Duration.format(): String {


### PR DESCRIPTION
Fixes #7246 and the latest issues in #6131. The issue stems from the fact that braces and brackets within a string can be `"{nested [{inside} {each}] other} {like [this]}".tr()`. Prior to 46b1516159e62840b53abcbe76e3176d0e84e2be, curly braces were processed first then afterwards square brackets first but neither solution is sufficient for the nesting problem. This PR changes it so that the enclosing brackets and braces are processed left to right, `tr()`anslating the contents recursively.

Other changes include a redundant string being removed. "Consumes 1 [resource]" and "Consumes [numberGreaterThan1] [resource]" were coded separately so I merged them into a single string. Testing it reveals no issues that I can tell.

The spaceship victory string was also tweaked.

Images below of previous troublemaking spots (image 3 shows the "Consumes [amount] [resource]" string working for 1 or >1 resources). I checked and all of the open boxes in #6131 ought to be addressed.

<Details>

![1](https://files.catbox.moe/bipolo.png)

![2](https://files.catbox.moe/1rysvs.png)

![3](https://files.catbox.moe/gf22ny.png)

![4](https://files.catbox.moe/aykdwa.png)

</Details>