### PR TITLE
Minor reweight of AI policy selection

### DIFF
--- a/android/assets/jsons/Civ V - Gods & Kings/Policies.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Policies.json
@@ -3,11 +3,11 @@
         "name": "Tradition",
         "era": "Ancient era",
         "priorities": {
-            "Neutral": 30,
-            "Cultural": 30,
+            "Neutral": 0,
+            "Cultural": 10,
             "Diplomatic": 0,
             "Domination": 0,
-            "Scientific": 30
+            "Scientific": 10
         },
         "uniques": [
             "[+3 Culture] [in capital]",
@@ -72,10 +72,10 @@
         "name": "Liberty",
         "era": "Ancient era",
         "priorities": {
-            "Neutral": 30,
+            "Neutral": 0,
             "Cultural": 0,
-            "Diplomatic": 30,
-            "Domination": 30,
+            "Diplomatic": 10,
+            "Domination": 10,
             "Scientific": 0
         },
         "uniques": ["[+1 Culture] [in all cities]"],

--- a/android/assets/jsons/Civ V - Gods & Kings/Policies.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Policies.json
@@ -76,7 +76,7 @@
             "Cultural": 0,
             "Diplomatic": 10,
             "Domination": 10,
-            "Scientific": 0
+            "Scientific": 10
         },
         "uniques": ["[+1 Culture] [in all cities]"],
         "policies": [
@@ -142,7 +142,7 @@
             "Cultural": 0,
             "Diplomatic": 10,
             "Domination": 10,
-            "Scientific": 10
+            "Scientific": 0
         },
         "uniques": [
             "[+33]% Strength <vs [Barbarian] units>",
@@ -414,7 +414,7 @@
             "Cultural": 10,
             "Diplomatic": 10,
             "Domination": 10,
-            "Scientific": 20
+            "Scientific": 60
         },
         "uniques": [
             "[+15]% [Science] <while the empire is happy>",

--- a/android/assets/jsons/Civ V - Vanilla/Policies.json
+++ b/android/assets/jsons/Civ V - Vanilla/Policies.json
@@ -480,9 +480,9 @@
         "priorities": {
             "Neutral": 30,
             "Cultural": 30,
-            "Diplomatic": 20,
+            "Diplomatic": 30,
             "Domination": 0,
-            "Scientific": 20
+            "Scientific": 30
         },
         "uniques": [
             "[+25]% Great Person generation [in all cities]",
@@ -608,7 +608,7 @@
             "Cultural": 0,
             "Diplomatic": 30,
             "Domination": 0,
-            "Scientific": 20
+            "Scientific": 30
         },
         "uniques": [
             "[+1 Happiness] [in all cities]",

--- a/android/assets/jsons/Civ V - Vanilla/Policies.json
+++ b/android/assets/jsons/Civ V - Vanilla/Policies.json
@@ -3,11 +3,11 @@
         "name": "Tradition",
         "era": "Ancient era",
         "priorities": {
-            "Neutral": 40,
-            "Cultural": 40,
+            "Neutral": 0,
+            "Cultural": 10,
             "Diplomatic": 0,
             "Domination": 0,
-            "Scientific": 40
+            "Scientific": 10
         },
         "uniques": [
             "[+3 Culture] [in capital]",
@@ -72,10 +72,10 @@
         "name": "Liberty",
         "era": "Ancient era",
         "priorities": {
-            "Neutral": 40,
+            "Neutral": 0,
             "Cultural": 0,
-            "Diplomatic": 40,
-            "Domination": 40,
+            "Diplomatic": 10,
+            "Domination": 10,
             "Scientific": 0
         },
         "uniques": ["[+1 Culture] [in all cities]"],
@@ -420,7 +420,7 @@
             "Scientific": 20
         },
         "uniques": [
-            "Science gained from research agreements [+50]%"
+            "Science gained from research agreements [+50]%",
             "Only available <before adopting [Piety]>"
         ],
         "policies": [

--- a/android/assets/jsons/Civ V - Vanilla/Policies.json
+++ b/android/assets/jsons/Civ V - Vanilla/Policies.json
@@ -417,7 +417,7 @@
             "Cultural": 10,
             "Diplomatic": 0,
             "Domination": 0,
-            "Scientific": 20
+            "Scientific": 40
         },
         "uniques": [
             "Science gained from research agreements [+50]%",


### PR DESCRIPTION
#7249 made me curious to see how the AI picks policies to see why they didn't pick honor. Each nation has a preferred victory type (which defaults to `neutralVictoryType` if their preferred victory is disabled in the game settings) and each policy branch has a priority assigned to it that is associated with each victory type. When picking a policy to unlock, the AI's prioritization is

* pick highest priority policy branch available, choosing randomly if there is a tie and none are in-progress
* if multiple branches tie for highest priority and one or more is partially complete, pick the one with the highest progress, choosing randomly if two or more are tied for progress

The AI weights for vanilla and G&K rulesets are shown below. The AI weights for Tradition and Liberty were either 30 or 0 and the AI weights for Honor were either 10 or 0 depending on victory type, meaning that the AI would always prioritize Tradition and Liberty over Honor. An AI with a neutral preferred victory type would also always choose finishing Tradition and Liberty before considering another policy branch (except for the ideological ones).

This PR cuts down on the weights of Tradition and Liberty so that some AI may consider picking Honor as their first policy branch. Additionally, the weights for an AI with a neutral preferred victory type have been leveled so they will not have a preference towards any specific policies (other than ideological ones but it will pick randomly among those 3 when it reaches the industrial era). Some of the vanilla values have also been changed in case anyone plays with that ruleset.

![weights](https://files.catbox.moe/7cuwj8.jpg)