### PR TITLE
Allow modded harbor-type buildings to connect cities to capital

### DIFF
--- a/core/src/com/unciv/logic/civilization/CapitalConnectionsFinder.kt
+++ b/core/src/com/unciv/logic/civilization/CapitalConnectionsFinder.kt
@@ -4,6 +4,7 @@ import com.unciv.logic.city.CityInfo
 import com.unciv.logic.map.BFS
 import com.unciv.logic.map.RoadStatus
 import com.unciv.logic.map.TileInfo
+import com.unciv.models.ruleset.unique.UniqueType
 import kotlin.collections.set
 
 class CapitalConnectionsFinder(private val civInfo: CivilizationInfo) {
@@ -80,7 +81,7 @@ class CapitalConnectionsFinder(private val civInfo: CivilizationInfo) {
     }
 
     private fun CityInfo.containsHarbor() =
-            this.cityConstructions.containsBuildingOrEquivalent(harbor)
+            this.cityConstructions.builtBuildingUniqueMap.getUniques(UniqueType.ConnectTradeRoutes).any()
 
     private fun check(cityToConnectFrom: CityInfo,
                       transportType: String,

--- a/tests/src/com/unciv/logic/civilization/CapitalConnectionsFinderTests.kt
+++ b/tests/src/com/unciv/logic/civilization/CapitalConnectionsFinderTests.kt
@@ -117,7 +117,7 @@ class CapitalConnectionsFinderTests {
             if (capital)
                 cityConstructions.builtBuildings.add(rules.buildings.values.first { it.hasUnique(UniqueType.IndicatesCapital) }.name)
             if (hasHarbor)
-                cityConstructions.builtBuildings.add(rules.buildings.values.first { it.name == "Harbor" }.name)
+                cityConstructions.builtBuildings.add(rules.buildings.values.first { it.hasUnique(UniqueType.ConnectTradeRoutes) }.name)
             this.name = name
             setTransients()
             tilesMap[location].setOwningCity(this)


### PR DESCRIPTION
Fixes #7244. The capital connections checker was hardcoded to look for buildings named "Harbor" or a unique replacement for the harbor. It now checks the city for a building with `UniqueType.ConnectTradeRoutes`. Tested with vanilla and Alpha Frontier and the buildings with that unique now form a trade route.

The capital connection finder unit test was also updated to look for a building with `UniqueType.ConnectTradeRoutes` instead of looking for a building named "Harbor" for the sake of consistency.