### PR TITLE
Fix disappearing terrain when switching between mods

### DIFF
--- a/core/src/com/unciv/models/tilesets/TileSetCache.kt
+++ b/core/src/com/unciv/models/tilesets/TileSetCache.kt
@@ -32,7 +32,7 @@ object TileSetCache : HashMap<String, TileSetConfig>() {
             for (entry in allConfigs.entries.filter { it.key.mod == mod } ) { // Built-in tilesets all have empty strings as their `.mod`, so loop through all of them.
                 val tileSet = entry.key.tileSet
                 if (tileSet in this) this[tileSet]!!.updateConfig(entry.value)
-                else this[tileSet] = entry.value
+                else this[tileSet] = entry.value.clone()
             }
         }
     }

--- a/core/src/com/unciv/models/tilesets/TileSetConfig.kt
+++ b/core/src/com/unciv/models/tilesets/TileSetConfig.kt
@@ -12,7 +12,18 @@ class TileSetConfig {
     var tileScale: Float = 1f
     var ruleVariants: HashMap<String, Array<String>> = HashMap()
 
-    fun updateConfig(other: TileSetConfig){
+    fun clone(): TileSetConfig {
+        val toReturn = TileSetConfig()
+        toReturn.useColorAsBaseTerrain = useColorAsBaseTerrain
+        toReturn.unexploredTileColor = unexploredTileColor
+        toReturn.fogOfWarColor = fogOfWarColor
+        toReturn.fallbackTileSet = fallbackTileSet
+        toReturn.tileScale = tileScale
+        toReturn.ruleVariants.putAll(ruleVariants.map { Pair(it.key, it.value.clone()) })
+        return toReturn
+    }
+
+    fun updateConfig(other: TileSetConfig) {
         useColorAsBaseTerrain = other.useColorAsBaseTerrain
         unexploredTileColor = other.unexploredTileColor
         fogOfWarColor = other.fogOfWarColor


### PR DESCRIPTION
Fixes #7256. `allConfigs` holds all of the tilesets but I think its values were being passed to the `TilesetCache` by reference, so when other mods overwrote the FantasyHex tileset, the base game's entry in `allConfigs` was getting modified too. For reference, the base game FantasyHex `TileSetConfig` has like 80 something `ruleVariants` but after loading Alpha Frontier it would end up with over 900 of them that don't get unloaded after you switch back to the base game. Now `TileSetConfig` is cloned to prevent base game files from being overwritten.