### PR TITLE
More accurate "Religions to be founded" count

### DIFF
--- a/core/src/com/unciv/logic/civilization/ReligionManager.kt
+++ b/core/src/com/unciv/logic/civilization/ReligionManager.kt
@@ -7,6 +7,7 @@ import com.unciv.models.ruleset.Belief
 import com.unciv.models.ruleset.BeliefType
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.ui.utils.extensions.toPercent
+import java.lang.Integer.min
 import kotlin.random.Random
 
 class ReligionManager {
@@ -150,6 +151,26 @@ class ReligionManager {
 
     fun amountOfFoundableReligions() = civInfo.gameInfo.civilizations.count { it.isMajorCiv() } / 2 + 1
 
+    fun remainingFoundableReligions(): Int {
+        val foundedReligionsCount = civInfo.gameInfo.civilizations.count {
+            it.religionManager.religion != null && it.religionManager.religionState >= ReligionState.Religion
+        }
+
+        // count the number of foundable religions left given defined ruleset religions and number of civs in game
+        val maxNumberOfAdditionalReligions = min(civInfo.gameInfo.ruleSet.religions.size,
+            amountOfFoundableReligions()) - foundedReligionsCount
+
+        val availableBeliefsToFound = min(
+            civInfo.gameInfo.ruleSet.beliefs.values.count {
+                it.type == BeliefType.Follower
+                        && civInfo.gameInfo.religions.values.none { religion -> it in religion.getBeliefs(BeliefType.Follower) }
+            },
+            civInfo.gameInfo.ruleSet.beliefs.values.count { it.type == BeliefType.Founder } - foundedReligionsCount
+        )
+
+        return min(maxNumberOfAdditionalReligions, availableBeliefsToFound)
+    }
+
     fun mayFoundReligionAtAll(prophet: MapUnit): Boolean {
         if (!civInfo.gameInfo.isReligionEnabled()) return false // No religion
 
@@ -160,24 +181,8 @@ class ReligionManager {
 
         if (!civInfo.isMajorCiv()) return false // Only major civs may use religion
 
-        val foundedReligionsCount = civInfo.gameInfo.civilizations.count {
-            it.religionManager.religion != null && it.religionManager.religionState >= ReligionState.Religion
-        }
-
-        if (foundedReligionsCount >= amountOfFoundableReligions())
+        if (remainingFoundableReligions() == 0)
             return false // Too bad, too many religions have already been founded
-
-        if (foundedReligionsCount >= civInfo.gameInfo.ruleSet.religions.size)
-            return false // Mod maker did not provide enough religions for the amount of civs present
-
-        if (civInfo.gameInfo.ruleSet.beliefs.values.none {
-            it.type == BeliefType.Follower
-            && civInfo.gameInfo.religions.values.none { religion -> it in religion.getBeliefs(BeliefType.Follower) }
-        }) return false // Mod maker did not provide enough follower beliefs
-
-        // Shortcut as each religion will always have exactly one founder belief
-        if (foundedReligionsCount >= civInfo.gameInfo.ruleSet.beliefs.values.count { it.type == BeliefType.Founder })
-            return false // Mod maker did not provide enough founder beliefs
 
         return true
     }

--- a/core/src/com/unciv/ui/overviewscreen/ReligionOverviewTable.kt
+++ b/core/src/com/unciv/ui/overviewscreen/ReligionOverviewTable.kt
@@ -79,9 +79,7 @@ class ReligionOverviewTab(
         }
 
         add("Religions to be founded:".toLabel())
-
-        val foundedReligions = viewingPlayer.gameInfo.civilizations.count { it.religionManager.religionState >= ReligionState.Religion }
-        add((viewingPlayer.religionManager.amountOfFoundableReligions() - foundedReligions).toLabel()).right().row()
+        add((viewingPlayer.religionManager.remainingFoundableReligions()).toLabel()).right().row()
 
         add("Religious status:".toLabel()).left()
         add(viewingPlayer.religionManager.religionState.toString().toLabel()).right().row()


### PR DESCRIPTION
This was inspired by a Discord user who was trying to figure out why they couldn't found a religion despite the religion overview screen saying there were 2 left religions to be founded. The number displayed is now the minimum value of the following variables:
* usual number of religions that can be founded (half the number of major civs + 1) - # of founded religions
* number of religions defined in the ruleset - # of founded religions
* number of follower beliefs not already a part of existing religions
* number of founding beliefs - # of founded religions

For base UnCiv, this means the maximum number of religions in game is 9, limited by the number of founder beliefs.