### PR TITLE
Exception handleing when loading mod options

### DIFF
--- a/core/src/com/unciv/ui/pickerscreens/GitHub.kt
+++ b/core/src/com/unciv/ui/pickerscreens/GitHub.kt
@@ -320,31 +320,13 @@ object Github {
      */
     fun rewriteModOptions(repo: Repo, modFolder: FileHandle) {
         val modOptionsFile = modFolder.child("jsons/ModOptions.json")
-        var modOptions = ModOptions()
-
-        try {
-            modOptions = if (modOptionsFile.exists()) json().fromJsonFile(ModOptions::class.java, modOptionsFile) else ModOptions()
-        } catch (ex: SerializationException) {
-            Log.error("Mod options were not serialized correctly.")
-        } catch (ex: Exception) {
-            Log.error("Loading mod options caused an unhandled exception.")
-        }
-
+        val modOptions = if (modOptionsFile.exists()) json().fromJsonFile(ModOptions::class.java, modOptionsFile) else ModOptions()
         modOptions.modUrl = repo.html_url
         modOptions.lastUpdated = repo.pushed_at
         modOptions.author = repo.owner.login
         modOptions.modSize = repo.size
         modOptions.updateDeprecations()
-
-        try {
-            json().toJson(modOptions, modOptionsFile)
-        } catch (ex: SerializationException) {
-            Log.error("Mod options were not written correctly")
-        } catch (ex: FileNotFoundException) {
-            Log.error("ModOptionsFile could not be found.")
-        } catch (ex: Exception) {
-            Log.error("Writing mod options caused an unhandled exception.")
-        }
+        json().toJson(modOptions, modOptionsFile)
     }
 }
 

--- a/core/src/com/unciv/ui/pickerscreens/GitHub.kt
+++ b/core/src/com/unciv/ui/pickerscreens/GitHub.kt
@@ -2,6 +2,7 @@ package com.unciv.ui.pickerscreens
 
 import com.badlogic.gdx.Files
 import com.badlogic.gdx.files.FileHandle
+import com.badlogic.gdx.utils.SerializationException
 import com.unciv.json.fromJsonFile
 import com.unciv.json.json
 import com.unciv.logic.BackwardCompatibility.updateDeprecations
@@ -323,8 +324,10 @@ object Github {
 
         try {
             modOptions = if (modOptionsFile.exists()) json().fromJsonFile(ModOptions::class.java, modOptionsFile) else ModOptions()
-        } catch (ex: Throwable) {
-            Log.error("Mod options were not read correctly.")
+        } catch (ex: SerializationException) {
+            Log.error("Mod options were not serialized correctly.")
+        } catch (ex: Exception) {
+            Log.error("Loading mod options caused an unhandled exception.")
         }
 
         modOptions.modUrl = repo.html_url
@@ -335,8 +338,12 @@ object Github {
 
         try {
             json().toJson(modOptions, modOptionsFile)
-        } catch (ex: Throwable) {
+        } catch (ex: SerializationException) {
             Log.error("Mod options were not written correctly")
+        } catch (ex: FileNotFoundException) {
+            Log.error("ModOptionsFile could not be found.")
+        } catch (ex: Exception) {
+            Log.error("Writing mod options caused an unhandled exception.")
         }
     }
 }

--- a/core/src/com/unciv/ui/pickerscreens/GitHub.kt
+++ b/core/src/com/unciv/ui/pickerscreens/GitHub.kt
@@ -319,13 +319,25 @@ object Github {
      */
     fun rewriteModOptions(repo: Repo, modFolder: FileHandle) {
         val modOptionsFile = modFolder.child("jsons/ModOptions.json")
-        val modOptions = if (modOptionsFile.exists()) json().fromJsonFile(ModOptions::class.java, modOptionsFile) else ModOptions()
+        var modOptions = ModOptions()
+
+        try {
+            modOptions = if (modOptionsFile.exists()) json().fromJsonFile(ModOptions::class.java, modOptionsFile) else ModOptions()
+        } catch (ex: Throwable) {
+            Log.error("Mod options were not read correctly.")
+        }
+
         modOptions.modUrl = repo.html_url
         modOptions.lastUpdated = repo.pushed_at
         modOptions.author = repo.owner.login
         modOptions.modSize = repo.size
         modOptions.updateDeprecations()
-        json().toJson(modOptions, modOptionsFile)
+
+        try {
+            json().toJson(modOptions, modOptionsFile)
+        } catch (ex: Throwable) {
+            Log.error("Mod options were not written correctly")
+        }
     }
 }
 

--- a/core/src/com/unciv/ui/pickerscreens/GitHub.kt
+++ b/core/src/com/unciv/ui/pickerscreens/GitHub.kt
@@ -2,7 +2,6 @@ package com.unciv.ui.pickerscreens
 
 import com.badlogic.gdx.Files
 import com.badlogic.gdx.files.FileHandle
-import com.badlogic.gdx.utils.SerializationException
 import com.unciv.json.fromJsonFile
 import com.unciv.json.json
 import com.unciv.logic.BackwardCompatibility.updateDeprecations

--- a/core/src/com/unciv/ui/pickerscreens/ModManagementScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/ModManagementScreen.kt
@@ -10,6 +10,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.ScrollPane
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton
 import com.badlogic.gdx.utils.Align
+import com.badlogic.gdx.utils.SerializationException
 import com.unciv.MainMenuScreen
 import com.unciv.json.fromJsonFile
 import com.unciv.json.json
@@ -41,6 +42,7 @@ import com.unciv.ui.utils.extensions.onClick
 import com.unciv.ui.utils.extensions.toCheckBox
 import com.unciv.ui.utils.extensions.toLabel
 import com.unciv.ui.utils.extensions.toTextButton
+import com.unciv.utils.Log
 import com.unciv.utils.concurrency.Concurrency
 import com.unciv.utils.concurrency.launchOnGLThread
 import kotlinx.coroutines.Job
@@ -258,7 +260,15 @@ class ModManagementScreen(
                 }
 
                 if (installedMod.modOptions.author.isEmpty()) {
-                    Github.rewriteModOptions(repo, installedMod.folderLocation!!)
+                    try {
+                        Github.rewriteModOptions(repo, installedMod.folderLocation!!)
+                    } catch (ex: SerializationException) {
+                        Log.error("Error while adding mod info from repo search:", ex)
+                        return
+                    } catch (ex: Exception) {
+                        Log.error("Error while adding mod info from repo search:", ex)
+                        return
+                    }
                     installedMod.modOptions.author = repo.owner.login
                     installedMod.modOptions.modSize = repo.size
                 }


### PR DESCRIPTION
resolves  #7232

In that issue the mod had `[ ]` and failed to load the mod options. Should we automatically remove these brackets or let the modders fix this themselves ?