### PR TITLE
fixed multiplayer status button not being able to be toggled in settings

### DIFF
--- a/core/src/com/unciv/ui/options/MultiplayerTab.kt
+++ b/core/src/com/unciv/ui/options/MultiplayerTab.kt
@@ -42,7 +42,9 @@ fun multiplayerTab(
     optionsPopup.addCheckbox(
         tab, "Enable multiplayer status button in singleplayer games",
         settings.multiplayer::statusButtonInSinglePlayer, updateWorld = true
-    )
+    ) {
+        settings.multiplayer.statusButtonInSinglePlayer = it
+    }
 
     addSeparator(tab)
 


### PR DESCRIPTION
resolves #7213
