### PR TITLE
Fix crash when melee unit captures civilian then tries to attack it

### DIFF
--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -58,6 +58,10 @@ object Battle {
          * but the hidden tile is actually IMPASSIBLE so you stop halfway!
          */
         if (attacker.getTile() != attackableTile.tileToAttackFrom) return false
+        /** Rarely, a melee unit will target a civilian then move through the civilian to get
+         * to attackableTile.tileToAttackFrom, meaning that they take the civilian. This check stops
+         * the melee unit from trying to capture their own unit if this happens */
+        if (getMapCombatantOfTile(attackableTile.tileToAttack)!!.getCivInfo() == attacker.getCivInfo()) return false
         /** Alternatively, maybe we DID reach that tile, but it turned out to be a hill or something,
          * so we expended all of our movement points!
          */


### PR DESCRIPTION
A melee unit can target a civilian then move through the civilian to get to the tile it plans to attack from, meaning that they take the unit but won't stop trying to attack it, which causes a crash. This fix adds a check to prevent this crash from happening.

The save to test this is posted in the Discord bugs channel and is too big to be pasted here.