### PR TITLE
Fix Mayan UB not appearing in the Mayan nation Civilopedia page

### DIFF
--- a/core/src/com/unciv/models/ruleset/Nation.kt
+++ b/core/src/com/unciv/models/ruleset/Nation.kt
@@ -188,7 +188,7 @@ class Nation : RulesetObject() {
             when {
                 building.uniqueTo != name -> continue
                 building.hasUnique(UniqueType.HiddenFromCivilopedia) -> continue
-                religionEnabled && building.hasUnique(UniqueType.HiddenWithoutReligion) -> continue
+                !religionEnabled && building.hasUnique(UniqueType.HiddenWithoutReligion) -> continue
             }
             yield(FormattedLine("{${building.name}} -", link=building.makeLink()))
             if (building.replaces != null && ruleset.buildings.containsKey(building.replaces!!)) {


### PR DESCRIPTION
There was a missing `!` that caused any `"Hidden when religion is disabled"` unique buildings to be hidden from the nation's Civilopedia page when religion is enabled (and conversely appear when religion, and the building itself, is disabled). The buildings would still appear in the buildings tab of the Civilopedia screen as intended.