### PR TITLE
Fix translation of game speeds entries in civilopedia.

### DIFF
--- a/core/src/com/unciv/models/ruleset/Speed.kt
+++ b/core/src/com/unciv/models/ruleset/Speed.kt
@@ -71,7 +71,7 @@ class Speed : RulesetObject() {
         yield(FormattedLine("Golden age length modifier: [${goldenAgeLengthModifier * 100}]%${Fonts.happiness}"))
         yield(FormattedLine("Adjacent city religious pressure: [$religiousPressureAdjacentCity]${Fonts.faith}"))
         yield(FormattedLine("Peace deal duration: [$peaceDealDuration] turns${Fonts.turn}"))
-        yield(FormattedLine("Start year: " + ("[${abs(startYear).toInt()}] " + (if (startYear < 0) "BC" else "AD")).tr()))
+        yield(FormattedLine("Start year: [" + (("[${abs(startYear).toInt()}] " + (if (startYear < 0) "BC" else "AD")).tr() + "]").tr()))
     }.toList()
 
     fun numTotalTurns(): Int = yearsPerTurn.last().untilTurn

--- a/core/src/com/unciv/ui/civilopedia/CivilopediaCategories.kt
+++ b/core/src/com/unciv/ui/civilopedia/CivilopediaCategories.kt
@@ -190,7 +190,7 @@ enum class CivilopediaCategories (
         KeyCharAndCode('D'),
         "OtherIcons/Tyrannosaurus"
     ),
-    Speed ("Speeds", false,
+    Speed ("Game Speeds", false,
         getImage = null,
         KeyCharAndCode('S'),
         "OtherIcons/Timer"


### PR DESCRIPTION
Two fixes for localisation in civilopedia.

1.- "Speeds" entry is referred as "Game speed" in template.properties for localisation.
2.- For "Start year: [comment]", two calls to .tr() are needed: one for translating the part with "BC/AC" and another for "Start year". Maybe there are more appropriate ways to fix this.