### PR TITLE
Logistics allows move after attack

### DIFF
--- a/android/assets/jsons/Civ V - Gods & Kings/UnitPromotions.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/UnitPromotions.json
@@ -471,7 +471,7 @@
 		"name": "Logistics",
 		"prerequisites": ["Accuracy III","Barrage III","Targeting III", "Wolfpack III",
 			"Bombardment III", "Coastal Raider III","Boarding Party III","Siege III", "Mobility II", "Anti-Armor II"],
-		"uniques": ["[1] additional attacks per turn"],
+		"uniques": ["[1] additional attacks per turn", "Can move after attacking"],
 		"unitTypes": ["Archery","Ranged Gunpowder","Siege","Melee Water","Ranged Water","Submarine","Fighter","Bomber","Helicopter"]
 	},
 
@@ -596,5 +596,9 @@
 	{
 		"name": "[Zero] ability",
 		"uniques": ["[+33]% Strength <vs [Fighter] units>"]
-	}
+	},
+    {
+        "name": "[Chu-Ko-Nu] ability",
+        "uniques": ["[1] additional attacks per turn", "Can move after attacking"]
+    }
 ]

--- a/android/assets/jsons/Civ V - Gods & Kings/Units.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Units.json
@@ -690,7 +690,7 @@
 		"requiredTech": "Machinery",
 		"upgradesTo": "Gatling Gun",
 		"obsoleteTech": "Industrialization",
-		"promotions": ["Logistics"],
+		"promotions": ["[Chu-Ko-Nu] ability"],
 		"attackSound": "arrow"
 	},
 	{


### PR DESCRIPTION
Resolves #7289 by giving the Logistics promotion a "Can move after attack" unique. Additionally, Chu-Ko-Nu are given a separate promotion that is a copy of Logistics since they're able to receive Logistics in Civ 5 (even though they can't use the third attack unless they somehow get 1 more movement such as upgrading to mech infantry or the Persians receiving one through a city-state).