### PR TITLE
Stop city health bar from appearing if city finishes certain buildings while at full health

### DIFF
--- a/core/src/com/unciv/logic/city/CityConstructions.kt
+++ b/core/src/com/unciv/logic/city/CityConstructions.kt
@@ -400,7 +400,13 @@ class CityConstructions {
     }
 
     private fun constructionComplete(construction: INonPerpetualConstruction) {
+        val setFullHealth = (construction is Building && construction.cityHealth > 0 && cityInfo.health == cityInfo.getMaxHealth())
         construction.postBuildEvent(this)
+        if (setFullHealth) {
+            // city built a building that increases health and city was previously at full health
+            // so set health to max to prevent the health bar from popping up
+            cityInfo.health = cityInfo.getMaxHealth()
+        }
         if (construction.name in inProgressConstructions)
             inProgressConstructions.remove(construction.name)
         if (construction.name == currentConstructionFromQueue)


### PR DESCRIPTION
If a building that increases a city's health is completed, the health bar pops up as if it got damaged when in reality it's just because the current health value doesn't get updated but the max health value does. With this PR, if the city is at full health when it finishes a health increasing building, the city's health will automatically be set to the new max health to prevent the health bar from appearing.