### PR TITLE
Don't wake sleeping civilians when an enemy is nearby if they're in a city

### DIFF
--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -908,7 +908,7 @@ class MapUnit {
 
         // Wake sleeping units if there's an enemy in vision range:
         // Military units always but civilians only if not protected.
-        if (isSleeping() && (isMilitary() || currentTile.militaryUnit == null) &&
+        if (isSleeping() && (isMilitary() || (currentTile.militaryUnit == null && !currentTile.isCityCenter())) &&
             this.viewableTiles.any {
                 it.militaryUnit != null && it.militaryUnit!!.civInfo.isAtWarWith(civInfo)
             }


### PR DESCRIPTION
Tweaks the condition to wake units so that civilians that are sleeping inside cities won't get woken if there isn't a military unit in the city center too. It's quite annoying having to make them skip their turn when I know they're safe inside the city.