### PR TITLE
Stop automate production setting from automating other players' production in MP

### DIFF
--- a/core/src/com/unciv/logic/automation/ConstructionAutomation.kt
+++ b/core/src/com/unciv/logic/automation/ConstructionAutomation.kt
@@ -60,9 +60,6 @@ class ConstructionAutomation(val cityConstructions: CityConstructions){
 
 
     fun chooseNextConstruction() {
-        if (!UncivGame.Current.settings.autoAssignCityProduction
-                && civInfo.playerType == PlayerType.Human && !cityInfo.isPuppet)
-            return
         if (cityConstructions.getCurrentConstruction() !is PerpetualConstruction) return  // don't want to be stuck on these forever
 
         addFoodBuildingChoice()

--- a/core/src/com/unciv/logic/city/CityConstructions.kt
+++ b/core/src/com/unciv/logic/city/CityConstructions.kt
@@ -585,8 +585,9 @@ class CityConstructions : IsPartOfGameInfoSerialization {
                     && (getConstruction(currentConstructionFromQueue) !is PerpetualConstruction || currentConstructionIsUserSet)) return
         }
 
-        val isCurrentPlayersTurn = cityInfo.civInfo.gameInfo.isUsersTurn() || cityInfo.civInfo.playerId == ""
-        if ((UncivGame.Current.settings.autoAssignCityProduction && isCurrentPlayersTurn) // only automate if the active player has the setting to automate production
+        val isCurrentPlayersTurn = cityInfo.civInfo.gameInfo.isUsersTurn()
+                || !cityInfo.civInfo.gameInfo.gameParameters.isOnlineMultiplayer
+        if ((UncivGame.Current.settings.autoAssignCityProduction && isCurrentPlayersTurn) // only automate if the active human player has the setting to automate production
                 || !cityInfo.civInfo.isPlayerCivilization() || cityInfo.isPuppet) {
             ConstructionAutomation(this).chooseNextConstruction()
         }

--- a/core/src/com/unciv/logic/city/CityConstructions.kt
+++ b/core/src/com/unciv/logic/city/CityConstructions.kt
@@ -9,6 +9,7 @@ import com.unciv.logic.civilization.NotificationIcon
 import com.unciv.logic.civilization.PopupAlert
 import com.unciv.logic.map.MapUnit
 import com.unciv.logic.map.TileInfo
+import com.unciv.logic.multiplayer.isUsersTurn
 import com.unciv.models.ruleset.Building
 import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.ruleset.unique.LocalUniqueCache
@@ -584,7 +585,11 @@ class CityConstructions : IsPartOfGameInfoSerialization {
                     && (getConstruction(currentConstructionFromQueue) !is PerpetualConstruction || currentConstructionIsUserSet)) return
         }
 
-        ConstructionAutomation(this).chooseNextConstruction()
+        val isCurrentPlayersTurn = cityInfo.civInfo.gameInfo.isUsersTurn() || cityInfo.civInfo.playerId == ""
+        if ((UncivGame.Current.settings.autoAssignCityProduction && isCurrentPlayersTurn) // only automate if the active player has the setting to automate production
+                || !cityInfo.civInfo.isPlayerCivilization() || cityInfo.isPuppet) {
+            ConstructionAutomation(this).chooseNextConstruction()
+        }
 
         /** Support for [UniqueType.CreatesOneImprovement] - if an Improvement-creating Building was auto-queued, auto-choose a tile: */
         val building = getCurrentConstruction() as? Building ?: return


### PR DESCRIPTION
The automate production setting has strange behavior in multiplayer games where any human player that has the option enabled will cause the next human player's production to be automated even if they have the option disabled. Now that will no longer be the case, thanks to some reordering in `GameInfo.nextTurn()` and some changed conditions in `CityConstructions.chooseNextConstruction()`.