### PR TITLE
Slight optimization for AI finding attackable enemy units

### DIFF
--- a/core/src/com/unciv/logic/automation/BattleHelper.kt
+++ b/core/src/com/unciv/logic/automation/BattleHelper.kt
@@ -33,27 +33,12 @@ object BattleHelper {
     }
 
     fun getAttackableEnemies(
-            unit: MapUnit,
-            unitDistanceToTiles: PathsToTilesWithinTurn,
-            tilesToCheck: List<TileInfo>? = null,
-            stayOnTile: Boolean = false
+        unit: MapUnit,
+        unitDistanceToTiles: PathsToTilesWithinTurn,
+        tilesToCheck: List<TileInfo>? = null,
+        stayOnTile: Boolean = false
     ): ArrayList<AttackableTile> {
-        val tilesWithEnemies = (tilesToCheck ?: unit.civInfo.viewableTiles)
-            .filter { containsAttackableEnemy(it, MapUnitCombatant(unit)) }
-            // Filter out invalid Civilian Captures
-            .filterNot {
-                val mapCombatant = Battle.getMapCombatantOfTile(it)
-                // IF all of these are true, THEN the action we'll be taking is in fact CAPTURING the civilian.
-                unit.baseUnit.isMelee() && mapCombatant is MapUnitCombatant && mapCombatant.unit.isCivilian()
-                        // If we can't pass though that tile, we can't capture the civilian "remotely"
-                        // Can use "unit.movement.canPassThrough(it)" now that we can move through
-                        // unguarded Civilian tiles. And this catches Naval trying to capture Land
-                        // Civilians or Land attacking Water Civilians it can't Embark on
-                        && !unit.movement.canPassThrough(it)
-            }
-
         val rangeOfAttack = unit.getRange()
-
         val attackableTiles = ArrayList<AttackableTile>()
 
         val unitMustBeSetUp = unit.hasUnique(UniqueType.MustSetUp)
@@ -77,6 +62,8 @@ object BattleHelper {
                     it.first == unit.getTile() || unit.movement.canMoveTo(it.first)
                 }
 
+        val tilesWithEnemies: HashSet<TileInfo> = HashSet()
+        val tilesWithoutEnemies: HashSet<TileInfo> = HashSet()
         for ((reachableTile, movementLeft) in tilesToAttackFrom) {  // tiles we'll still have energy after we reach there
             val tilesInAttackRange =
                 if (unit.hasUnique(UniqueType.IndirectFire) || unit.baseUnit.movesLikeAirUnits())
@@ -84,10 +71,25 @@ object BattleHelper {
                 else reachableTile.getViewableTilesList(rangeOfAttack)
                     .asSequence()
 
-            attackableTiles += tilesInAttackRange.filter { it in tilesWithEnemies }
-                .map { AttackableTile(reachableTile, it, movementLeft) }
+            for (tile in tilesInAttackRange) {
+                if (tile in tilesWithEnemies) attackableTiles += AttackableTile(reachableTile, tile, movementLeft)
+                else if (tile in tilesWithoutEnemies) continue // avoid checking the same empty tile multiple times
+                else if (checkTile(unit, tile, tilesToCheck)) {
+                    tilesWithEnemies += tile
+                    attackableTiles += AttackableTile(reachableTile, tile, movementLeft)
+                } else {
+                    tilesWithoutEnemies += tile
+                }
+            }
         }
         return attackableTiles
+    }
+
+    private fun checkTile(unit: MapUnit, tile: TileInfo, tilesToCheck: List<TileInfo>?): Boolean {
+        if (!containsAttackableEnemy(tile, MapUnitCombatant(unit))) return false
+        if (tile !in (tilesToCheck ?: unit.civInfo.viewableTiles)) return false
+        val mapCombatant = Battle.getMapCombatantOfTile(tile)
+        return (!unit.baseUnit.isMelee() || mapCombatant !is MapUnitCombatant || !mapCombatant.unit.isCivilian() || unit.movement.canPassThrough(tile))
     }
 
     fun containsAttackableEnemy(tile: TileInfo, combatant: ICombatant): Boolean {


### PR DESCRIPTION
When an AI unit wants to try to attack something (which is potentially every turn for each military unit), it calls `getAttackableEnemies(...)` to get the tiles containing enemy units that it can attack this turn. This function begins with a section of code

```
        val tilesWithEnemies = (tilesToCheck ?: unit.civInfo.viewableTiles)
            .filter { containsAttackableEnemy(it, MapUnitCombatant(unit)) }
            // Filter out invalid Civilian Captures
            .filterNot {
                val mapCombatant = Battle.getMapCombatantOfTile(it)
                // IF all of these are true, THEN the action we'll be taking is in fact CAPTURING the civilian.
                unit.baseUnit.isMelee() && mapCombatant is MapUnitCombatant && mapCombatant.unit.isCivilian()
                        // If we can't pass though that tile, we can't capture the civilian "remotely"
                        // Can use "unit.movement.canPassThrough(it)" now that we can move through
                        // unguarded Civilian tiles. And this catches Naval trying to capture Land
                        // Civilians or Land attacking Water Civilians it can't Embark on
                        && !unit.movement.canPassThrough(it)
            }

```
Since `tilesToCheck` is never specified across all of the function calls to `getAttackableEnemies()`, it defaults to `null` which means every time an AI unit wants to attack something, Unciv iterates over ALL of the civ's visible tiles trying to find attackable enemies even for melee units. This is a needless calculation since after this the code then checks over tiles the unit can actually attack, so this PR extracts the `filter` and `filterNot` predicates and puts them into a function that is called on demand as Unciv iterates over the tiles that the unit can actually attack.

I timed this function alongside the old `getAttackableEnemies` function and found a reduction in computational time of around 33% for a quick speed, large size, 10 major civ, 16 city-state, diety pangaea map (went from around 9.5 cumulative seconds spent calculating `getAttackableEnemies` for all civs over 350 simulated turns to around 6.25 seconds for my modest PC). The histogram of percent difference in time spent calculating this function for this same sample game below for the curious. There are some cases where the new function takes longer to calculate compared to the old one, but these are very small in number. Defeated civs/city-states will always take 0 seconds to calculate `getAttackableEnemies` each turn which is why that bin is so tall. Obviously this won't solve the late-game slowdown for high difficulty games where the AI has so many units since only 3 seconds are saved, but it's a pretty straightforward optimization.

In the plot, an x-axis value of < 0 means that the new `getAttackableEnemies` was faster than the current repo version of the function. The exact equation used to calculate the x-axis value is `(100 * (newTime - oldTime) / (oldTime + 1))` and the times are measured in nanoseconds using the built-in Kotlin timing function.
![getAttackableEnemies](https://user-images.githubusercontent.com/105244635/176973866-5a1cd821-0923-42b5-beea-9c35bcb07d1f.png)


