### PR TITLE
puppet city can no longer become capital

### DIFF
--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -1377,7 +1377,7 @@ class CivilizationInfo : IsPartOfGameInfoSerialization {
 
     fun moveCapitalToNextLargest() {
         moveCapitalTo(cities
-            .filterNot { it.isCapital() }
+            .filterNot { it.isCapital() || it.isPuppet }
             .maxByOrNull { it.population.population})
     }
 


### PR DESCRIPTION
resolves  #7357
resolves  #7339

This caused a NPE when a civ has only 1 city which is also a puppet. 