### PR TITLE
Fix actionGroup Opacity

### DIFF
--- a/core/src/com/unciv/ui/utils/UnitGroup.kt
+++ b/core/src/com/unciv/ui/utils/UnitGroup.kt
@@ -74,6 +74,7 @@ class UnitGroup(val unit: MapUnit, val size: Float): Group() {
         //Make unit icons fully opaque when units are selected
         unitBaseImage.color.a = 1f
         background?.color?.a = 1f
+        actionGroup?.color?.a = 1f
 
         val whiteHalo = getBackgroundImageForUnit()
         val whiteHaloSize = 30f


### PR DESCRIPTION
Makes actionGroup layer of unit icon 100% opaque when selected, in order to match the rest of the unit icon layers. I forgot about this element in my previous PR #7343. See the example below with the Warrior being Fortified.

https://user-images.githubusercontent.com/56904240/177206041-6c46d658-40bc-4e20-8449-e562e49bf570.mp4


