### PR TITLE
Fix unit icon opacity for idle units

### DIFF
--- a/core/src/com/unciv/ui/utils/UnitGroup.kt
+++ b/core/src/com/unciv/ui/utils/UnitGroup.kt
@@ -71,10 +71,17 @@ class UnitGroup(val unit: MapUnit, val size: Float): Group() {
 
     fun selectUnit() {
 
-        //Make unit icons fully opaque when units are selected
-        unitBaseImage.color.a = 1f
+        //Make unit icon background colors fully opaque when units are selected
         background?.color?.a = 1f
-        actionGroup?.color?.a = 1f
+
+        //If unit is idle, leave unitBaseImage and actionGroup at 50% opacity when selected
+        if (!unit.isIdle()) {
+            unitBaseImage.color.a = 0.5f
+            actionGroup?.color?.a = 0.5f
+        } else { //Else set to 100% opacity when selected
+            unitBaseImage.color.a = 1f
+            actionGroup?.color?.a = 1f
+        }
 
         val whiteHalo = getBackgroundImageForUnit()
         val whiteHaloSize = 30f


### PR DESCRIPTION
This PR handles the unitBaseImage and actionGroup layers of unit icons properly if a unit is idle (out of moves or in a state such as fortified or sleeping), leaving them at 50% opacity when selected. My previous PRs set them to 100% opacity regardless of idle status.

https://user-images.githubusercontent.com/56904240/177252699-39dec492-4ea1-43fc-be05-5400bb077ae2.mp4


