### PR TITLE
increased mod search results_per_page

### DIFF
--- a/core/src/com/unciv/ui/pickerscreens/ModManagementScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/ModManagementScreen.kt
@@ -67,7 +67,7 @@ class ModManagementScreen(
     private val modActionTable = Table().apply { defaults().pad(10f) }
     private val optionsManager = ModManagementOptions(this)
 
-    val amountPerPage = 30
+    val amountPerPage = 100
 
     private var lastSelectedButton: Button? = null
     private var lastSyncMarkedButton: Button? = null


### PR DESCRIPTION
resolves #7321

When making the mod categories I kept running into rate-limits and the mods load extremely slow because of this. Sorting and searching don't work until all mods have been loaded and as a side effect this makes the search/sort feature feel like it doesn't work all the time. 

The only indication the user gets are 3 dots but those can only be seen if the user scrolls all the way down...

Technically the limit seems to be 1000 but I don't know if that's really necessary, especially now when we only have less than a third of that