### PR TITLE
Strength penalty for adjacent enemy units unique no longer stacks

### DIFF
--- a/core/src/com/unciv/logic/battle/BattleDamage.kt
+++ b/core/src/com/unciv/logic/battle/BattleDamage.kt
@@ -60,12 +60,13 @@ object BattleDamage {
 
             //https://www.carlsguides.com/strategy/civilization5/war/combatbonuses.php
             val adjacentUnits = combatant.getTile().neighbors.flatMap { it.getUnits() }
-            for (unique in adjacentUnits.filter { it.civInfo.isAtWarWith(civInfo) }
-                    .flatMap { it.getMatchingUniques(UniqueType.StrengthForAdjacentEnemies) })
-                if (combatant.matchesCategory(unique.params[1]) && combatant.getTile()
-                        .matchesFilter(unique.params[2])
-                )
-                    modifiers.add("Adjacent enemy units", unique.params[0].toInt())
+            val strengthMalus = adjacentUnits.filter { it.civInfo.isAtWarWith(civInfo) }
+                    .flatMap { it.getMatchingUniques(UniqueType.StrengthForAdjacentEnemies) }
+                    .filter { combatant.matchesCategory(it.params[1]) && combatant.getTile().matchesFilter(it.params[2]) }
+                    .maxByOrNull { it.params[0] }
+            if (strengthMalus != null) {
+                modifiers.add("Adjacent enemy units", strengthMalus.params[0].toInt())
+            }
 
             val civResources = civInfo.getCivResourcesByName()
             for (resource in combatant.unit.baseUnit.getResourceRequirements().keys)


### PR DESCRIPTION
Currently the "[relativeAmount]% Strength for enemy [combatantFilter] units in adjacent [tileFilter] tiles" unique (used in the Maori warrior's Haka War Dance promotion and the African Forest Elephant's unique) stacks with itself, so a unit surrounded by 3 Maori warriors will have a -30% strength penalty (10% from each warrior). This PR changes it so that the behavior is more in line with Civ 5 behavior, instead taking the largest applicable strength malus, so now the unit surrounded by 3 enemy Maori warriors will only have a -10% strength penalty.