### PR TITLE
Prevent theme music tracks from randomly playing

### DIFF
--- a/core/src/com/unciv/UncivGame.kt
+++ b/core/src/com/unciv/UncivGame.kt
@@ -146,7 +146,7 @@ class UncivGame(parameters: UncivGameParameters) : Game() {
 
             // This stuff needs to run on the main thread because it needs the GL context
             launchOnGLThread {
-                musicController.chooseTrack(suffixes = listOf(MusicMood.Menu, "Ambient"),
+                musicController.chooseTrack(suffixes = listOf(MusicMood.Menu, MusicMood.Ambient),
                     flags = EnumSet.of(MusicTrackChooserFlags.SuffixMustMatch))
 
                 ImageGetter.ruleset = RulesetCache.getVanillaRuleset() // so that we can enter the map editor without having to load a game first

--- a/core/src/com/unciv/UncivGame.kt
+++ b/core/src/com/unciv/UncivGame.kt
@@ -21,6 +21,7 @@ import com.unciv.ui.LoadingScreen
 import com.unciv.ui.audio.GameSounds
 import com.unciv.ui.audio.MusicController
 import com.unciv.ui.audio.MusicMood
+import com.unciv.ui.audio.MusicTrackChooserFlags
 import com.unciv.ui.audio.SoundPlayer
 import com.unciv.ui.crashhandling.CrashScreen
 import com.unciv.ui.crashhandling.wrapCrashHandlingUnit
@@ -145,10 +146,8 @@ class UncivGame(parameters: UncivGameParameters) : Game() {
 
             // This stuff needs to run on the main thread because it needs the GL context
             launchOnGLThread {
-                musicController.chooseTrack(suffix = MusicMood.Menu)
-                if (!musicController.isPlaying()) {
-                    musicController.chooseTrack() // play any Ambient track as a backup
-                }
+                musicController.chooseTrack(suffixes = listOf(MusicMood.Menu, "Ambient"),
+                    flags = EnumSet.of(MusicTrackChooserFlags.SuffixMustMatch))
 
                 ImageGetter.ruleset = RulesetCache.getVanillaRuleset() // so that we can enter the map editor without having to load a game first
 

--- a/core/src/com/unciv/UncivGame.kt
+++ b/core/src/com/unciv/UncivGame.kt
@@ -146,6 +146,9 @@ class UncivGame(parameters: UncivGameParameters) : Game() {
             // This stuff needs to run on the main thread because it needs the GL context
             launchOnGLThread {
                 musicController.chooseTrack(suffix = MusicMood.Menu)
+                if (!musicController.isPlaying()) {
+                    musicController.chooseTrack() // play any Ambient track as a backup
+                }
 
                 ImageGetter.ruleset = RulesetCache.getVanillaRuleset() // so that we can enter the map editor without having to load a game first
 

--- a/core/src/com/unciv/ui/audio/MusicController.kt
+++ b/core/src/com/unciv/ui/audio/MusicController.kt
@@ -348,7 +348,7 @@ class MusicController {
      */
     fun chooseTrack (
         prefix: String = "",
-        suffix: String = "Ambient",
+        suffix: String = MusicMood.Ambient,
         flags: EnumSet<MusicTrackChooserFlags> = EnumSet.of(MusicTrackChooserFlags.SuffixMustMatch)
     ): Boolean {
         if (baseVolume == 0f) return false

--- a/core/src/com/unciv/ui/audio/MusicController.kt
+++ b/core/src/com/unciv/ui/audio/MusicController.kt
@@ -389,7 +389,7 @@ class MusicController {
                     current?.startFade(MusicTrackController.State.FadeOut, fadingStep)
                 ControllerState.Pause ->
                     if (current?.state == MusicTrackController.State.Idle) clearCurrent()
-                ControllerState.Idle -> {
+                ControllerState.Idle, ControllerState.Silence -> {
                     if (current == null) {
                         // force track to begin now
                         current = next

--- a/core/src/com/unciv/ui/audio/MusicController.kt
+++ b/core/src/com/unciv/ui/audio/MusicController.kt
@@ -349,7 +349,7 @@ class MusicController {
     fun chooseTrack (
         prefix: String = "",
         suffix: String = "Ambient",
-        flags: EnumSet<MusicTrackChooserFlags> = EnumSet.noneOf(MusicTrackChooserFlags::class.java)
+        flags: EnumSet<MusicTrackChooserFlags> = EnumSet.of(MusicTrackChooserFlags.SuffixMustMatch)
     ): Boolean {
         if (baseVolume == 0f) return false
 
@@ -389,6 +389,13 @@ class MusicController {
                     current?.startFade(MusicTrackController.State.FadeOut, fadingStep)
                 ControllerState.Pause ->
                     if (current?.state == MusicTrackController.State.Idle) clearCurrent()
+                ControllerState.Idle -> {
+                    if (current == null) {
+                        // force track to begin now
+                        current = next
+                        next = null
+                    }
+                }
                 else -> Unit
             }
         })

--- a/core/src/com/unciv/ui/audio/MusicController.kt
+++ b/core/src/com/unciv/ui/audio/MusicController.kt
@@ -389,13 +389,6 @@ class MusicController {
                     current?.startFade(MusicTrackController.State.FadeOut, fadingStep)
                 ControllerState.Pause ->
                     if (current?.state == MusicTrackController.State.Idle) clearCurrent()
-                ControllerState.Idle, ControllerState.Silence -> {
-                    if (current == null) {
-                        // force track to begin now
-                        current = next
-                        next = null
-                    }
-                }
                 else -> Unit
             }
         })

--- a/core/src/com/unciv/ui/audio/MusicMood.kt
+++ b/core/src/com/unciv/ui/audio/MusicMood.kt
@@ -6,6 +6,7 @@ object MusicMood {
     const val War = "War"
     const val Defeat = "Defeat"
     const val Menu = "Menu"
+    const val Ambient = "Ambient"
 
     val themeOrPeace = listOf(Theme, Peace)
     fun peaceOrWar(isAtWar: Boolean) = if (isAtWar) War else Peace


### PR DESCRIPTION
Fixes #7392 by preventing `Theme` tracks (and others) from being played randomly. The main fix lies in the default conditions for `MusicController.chooseTrack()` which are

```

fun chooseTrack (
        prefix: String = "",
        suffix: String = "Ambient",
        flags: EnumSet<MusicTrackChooserFlags> = EnumSet.noneOf(MusicTrackChooserFlags::class.java)
    ): Boolean {
        .....
```

`suffix: String = "Ambient"` implies that the default behavior of `chooseTrack()` (no specified arguments) is to choose a track with the suffix "Ambient" but the default `flags` of `EnumSet.noneOf(MusicTrackChooserFlags::class.java)` means that `chooseTrack()` will default to choosing a completely random track regardless of suffix (look at `MusicController.chooseFile()` to see what I mean). This PR fixes it so that the default `flags` argument for `MusicController.chooseTrack()` is `EnumSet.of(MusicTrackChooserFlags.SuffixMustMatch)` which means that the `suffix: String = "Ambient"` will be forced to be satisfied (and will assuming the user hasn't deleted the default music track) when selecting the next track if no other arguments are specified, which happens when the game needs to find a new track to play after the current one is done and no other songs are queued.

Since the default suffix on `chooseTrack()` what changed, the main menu music selection logic has been tweaked to try to load a specific "Menu" suffixed song and fall back to an "Ambient" track if it can't find one.