### PR TITLE
Fix policy uniques not being applied after adoption

### DIFF
--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -810,6 +810,7 @@ class CivilizationInfo : IsPartOfGameInfoSerialization {
         policies.civInfo = this
         if (policies.adoptedPolicies.size > 0 && policies.numberOfAdoptedPolicies == 0)
             policies.numberOfAdoptedPolicies = policies.adoptedPolicies.count { !Policy.isBranchCompleteByName(it) }
+        policies.setTransients()
 
         questManager.civInfo = this
         questManager.setTransients()

--- a/core/src/com/unciv/logic/civilization/PolicyManager.kt
+++ b/core/src/com/unciv/logic/civilization/PolicyManager.kt
@@ -78,11 +78,6 @@ class PolicyManager : IsPartOfGameInfoSerialization {
     private val branches: Set<PolicyBranch>
         get() = civInfo.gameInfo.ruleSet.policyBranches.values.toSet()
 
-    // Only instantiate a single value for all policy managers
-    companion object {
-        private val turnCountRegex by lazy { Regex("for \\[[0-9]*\\] turns") }
-    }
-
     fun clone(): PolicyManager {
         val toReturn = PolicyManager()
         toReturn.numberOfAdoptedPolicies = numberOfAdoptedPolicies
@@ -97,6 +92,18 @@ class PolicyManager : IsPartOfGameInfoSerialization {
 
     @Suppress("MemberVisibilityCanBePrivate")
     fun getPolicyByName(name: String): Policy = getRulesetPolicies()[name]!!
+
+    fun setTransients() {
+        for (policyName in adoptedPolicies) addPolicyToTransients(
+            getPolicyByName(policyName)
+        )
+    }
+
+    private fun addPolicyToTransients(policy: Policy) {
+        for (unique in policy.uniqueObjects) {
+            policyUniques.addUnique(unique)
+        }
+    }
 
     fun addCulture(culture: Int) {
         val couldAdoptPolicyBefore = canAdoptPolicy()
@@ -177,6 +184,7 @@ class PolicyManager : IsPartOfGameInfoSerialization {
         }
 
         adoptedPolicies.add(policy.name)
+        addPolicyToTransients(policy)
 
         if (!branchCompletion) {
             val branch = policy.branch


### PR DESCRIPTION
Partially undo commit 3422e161ada01731d1be86ebaf970f124fce6cb1 to fix policy unique objects not being added to the civ's unique list.

Also removes a now-unused `companion object` from `PolicyManager.kt`.