### PR TITLE
Sort game speeds in Civilopedia by how fast they are

### DIFF
--- a/core/src/com/unciv/models/ruleset/Speed.kt
+++ b/core/src/com/unciv/models/ruleset/Speed.kt
@@ -74,6 +74,7 @@ class Speed : RulesetObject(), IsPartOfGameInfoSerialization {
         yield(FormattedLine("Peace deal duration: [$peaceDealDuration] turns${Fonts.turn}"))
         yield(FormattedLine("Start year: [" + ("{[${abs(startYear).toInt()}] " + (if (startYear < 0) "BC" else "AD") + "}]").tr()))
     }.toList()
+    override fun getSortGroup(ruleset: Ruleset): Int = (modifier * 1000).toInt()
 
     fun numTotalTurns(): Int = yearsPerTurn.last().untilTurn
 }


### PR DESCRIPTION
The Civilopedia now sorts game speeds by their `modifier` entry in ascending order (fastest to slowest which for unmodded Unciv means Quick speed at the top of the list to Marathon speed at the bottom of the list). Mods that add new game speeds (or replace all of them) are also handled. Game speeds in the New Game Setup screen are still listed in the order they're defined in `Speeds.json`.