### PR TITLE
Fix Desktop multiplayer options showing a double separator

### DIFF
--- a/core/src/com/unciv/ui/options/MultiplayerTab.kt
+++ b/core/src/com/unciv/ui/options/MultiplayerTab.kt
@@ -66,9 +66,14 @@ fun multiplayerTab(
 
     addSeparator(tab)
 
-    val turnCheckerSelect = addTurnCheckerOptions(tab, optionsPopup)
-
-    addSeparator(tab)
+    // at the moment the notification service only exists on Android
+    val turnCheckerSelect: RefreshSelect?
+    if (Gdx.app.type != Application.ApplicationType.Android) {
+        turnCheckerSelect = addTurnCheckerOptions(tab, optionsPopup)
+        addSeparator(tab)
+    } else {
+        turnCheckerSelect = null
+    }
 
     addSelectAsSeparateTable(tab, SettingsSelect("Sound notification for when it's your turn in your currently open game:",
         createNotificationSoundOptions(),
@@ -182,9 +187,6 @@ private fun addTurnCheckerOptions(
     tab: Table,
     optionsPopup: OptionsPopup
 ): RefreshSelect? {
-    // at the moment the notification service only exists on Android
-    if (Gdx.app.type != Application.ApplicationType.Android) return null
-
     val settings = optionsPopup.settings
 
     optionsPopup.addCheckbox(tab, "Enable out-of-game turn notifications", settings.multiplayer::turnCheckerEnabled)


### PR DESCRIPTION
This just removes this double separator:

![image](https://user-images.githubusercontent.com/2777158/178119864-39ba7457-ce1b-43ed-b91e-c58d0568390c.png)
