### PR TITLE
Remove double XP gain from Intercept

### DIFF
--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -843,9 +843,6 @@ object Battle {
             if (damage > 0)
                 addXp(MapUnitCombatant(interceptor), 2, attacker)
 
-            if (damage > 0)
-                addXp(MapUnitCombatant(interceptor), 2, attacker)
-
             val attackerName = attacker.getName()
             val interceptorName = interceptor.name
             val locations = LocationAction(interceptor.currentTile.position, attacker.unit.currentTile.position)


### PR DESCRIPTION
No idea how this happened considering the previous PR didn't have this, but somehow there's a double XP reward for Interception