### PR TITLE
Fix any civ being able to capture barbarian units

### DIFF
--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -279,7 +279,7 @@ object Battle {
             unitCapturedPrizeShipsUnique(),
             unitGainFromEncampment(),
             unitGainFromDefeatingUnit()
-        ).any()
+        ).any { it }
 
         if (!wasUnitCaptured) return false
 


### PR DESCRIPTION
The current master branch has a bug where any civ can capture barbarian units. The cause is `listOf(false, false, false).any()` always returns true since `any()` on a list is only checking if the list is non-empty so the `.any()` was changed to `.any { it }` which returns true if any element is true.