### PR TITLE
Fix some graphics issues related to combat

### DIFF
--- a/core/src/com/unciv/ui/tilegroups/TileGroup.kt
+++ b/core/src/com/unciv/ui/tilegroups/TileGroup.kt
@@ -719,10 +719,10 @@ open class TileGroup(
             newImageLocation = tileSetStrings.getThisUnit() ?: tileSetStrings.fallback?.getThisUnit() ?: ""
         }
 
-        val currentUnitName = if (militaryUnit != null) "${militaryUnit}:" else ""
-        if (pixelMilitaryUnitImageLocation != "$currentUnitName$newImageLocation") {
+        val nationName = if (militaryUnit != null) "${militaryUnit.civInfo.civName}-" else ""
+        if (pixelMilitaryUnitImageLocation != "$nationName$newImageLocation") {
             pixelMilitaryUnitGroup.clear()
-            pixelMilitaryUnitImageLocation = "$currentUnitName$newImageLocation"
+            pixelMilitaryUnitImageLocation = "$nationName$newImageLocation"
 
             if (newImageLocation != "" && ImageGetter.imageExists(newImageLocation)) {
                 val nation = militaryUnit!!.civInfo.nation
@@ -754,10 +754,10 @@ open class TileGroup(
             newImageLocation = tileSetStrings.getThisUnit() ?: tileSetStrings.fallback?.getThisUnit() ?: ""
         }
 
-        val currentUnitName = if (civilianUnit != null) "${civilianUnit}:" else ""
-        if (pixelCivilianUnitImageLocation != "$currentUnitName$newImageLocation") {
+        val nationName = if (civilianUnit != null) "${civilianUnit.civInfo.civName}-" else ""
+        if (pixelCivilianUnitImageLocation != "$nationName$newImageLocation") {
             pixelCivilianUnitGroup.clear()
-            pixelCivilianUnitImageLocation = "$currentUnitName$newImageLocation"
+            pixelCivilianUnitImageLocation = "$nationName$newImageLocation"
 
             if (newImageLocation != "" && ImageGetter.imageExists(newImageLocation)) {
                 val nation = civilianUnit!!.civInfo.nation

--- a/core/src/com/unciv/ui/tilegroups/TileGroup.kt
+++ b/core/src/com/unciv/ui/tilegroups/TileGroup.kt
@@ -719,9 +719,10 @@ open class TileGroup(
             newImageLocation = tileSetStrings.getThisUnit() ?: tileSetStrings.fallback?.getThisUnit() ?: ""
         }
 
-        if (pixelMilitaryUnitImageLocation != newImageLocation) {
+        val currentUnitName = if (militaryUnit != null) "${militaryUnit}:" else ""
+        if (pixelMilitaryUnitImageLocation != "$currentUnitName$newImageLocation") {
             pixelMilitaryUnitGroup.clear()
-            pixelMilitaryUnitImageLocation = newImageLocation
+            pixelMilitaryUnitImageLocation = "$currentUnitName$newImageLocation"
 
             if (newImageLocation != "" && ImageGetter.imageExists(newImageLocation)) {
                 val nation = militaryUnit!!.civInfo.nation
@@ -753,9 +754,10 @@ open class TileGroup(
             newImageLocation = tileSetStrings.getThisUnit() ?: tileSetStrings.fallback?.getThisUnit() ?: ""
         }
 
-        if (pixelCivilianUnitImageLocation != newImageLocation) {
+        val currentUnitName = if (civilianUnit != null) "${civilianUnit}:" else ""
+        if (pixelCivilianUnitImageLocation != "$currentUnitName$newImageLocation") {
             pixelCivilianUnitGroup.clear()
-            pixelCivilianUnitImageLocation = newImageLocation
+            pixelCivilianUnitImageLocation = "$currentUnitName$newImageLocation"
 
             if (newImageLocation != "" && ImageGetter.imageExists(newImageLocation)) {
                 val nation = civilianUnit!!.civInfo.nation

--- a/core/src/com/unciv/ui/worldscreen/bottombar/BattleTableHelpers.kt
+++ b/core/src/com/unciv/ui/worldscreen/bottombar/BattleTableHelpers.kt
@@ -27,12 +27,14 @@ object BattleTableHelpers {
                         combatant.isCivilian() -> {
                             for (tileGroup in tilegroups) {
                                 tileGroup.icons.civilianUnitIcon?.let { yield(it) }
+                                tileGroup.update(viewingCiv)
                                 yieldAll(tileGroup.pixelCivilianUnitGroup.children)
                             }
                         }
                         else -> {
                             for (tileGroup in tilegroups) {
                                 tileGroup.icons.militaryUnitIcon?.let { yield(it) }
+                                tileGroup.update(viewingCiv)
                                 yieldAll(tileGroup.pixelMilitaryUnitGroup.children)
                             }
                         }


### PR DESCRIPTION
Closes #7419. The issue lays in
https://github.com/yairm210/Unciv/blob/cdecb3f52d535b4113d60ed0638d5cc509478e7b/core/src/com/unciv/ui/tilegroups/TileGroup.kt#L719-L722
(and equivalent for civilian units). This variable `pixelMilitaryUnitImageLocation` is the image path for the given military unit in the tile which seemingly prevents the game from reloading the tile image if it's unchanged from its new state `newImageLocation`. If a new image is on the tile, the image is loaded and nation colors applied. However in combat, the unit image can change if, for example, a Warrior kills another Warrior and moves onto its tile. Since the new image location is the same as the old (e.g., both are `path/to/images/Warrior` in the image files), the image isn't reloaded which prevents the nation colors from updating. In the linked issue (using Absolute Units as the mod), the Jaguar and Warrior share the same skin which demonstrates the issue. You can test in the same save with killing the Warrior using the Scout and the issue does not occur. This has been fixed by updating `pixelMilitaryUnitImageLocation` as `"${militaryUnit.civInfo.civName}-${newImageLocation}"` which will ensure nation colors update properly.

This fix led to another issue where now the victorious unit would not flash red due to taking damage. I'm not entirely sure of the cause but I think I narrowed it down to an ordering issue where the flashing red was applied to the pre-update `TileGroup` so when the `TileGroup` updated post-combat, it would remove the flashing image `Actor` and replace it with a non-flashing one. This wasn't happening before because before the above fix, the `TileGroup` is not updated so the flashing image is not unloaded. I think the cause is the same as a separate issue where if you select a melee unit 2 tiles away from an enemy and have it move and attack in the same action, your attacking unit will not flash red; you can test this issue by selecting either Jaguar in the linked save and having it attack Tyre starting from 2 tiles away. Both of these cases have been fixed by updating the `TileGroup` before applying the flashing red.