### PR TITLE
Disabled religion when there is a disableReligion unique 

### DIFF
--- a/core/src/com/unciv/ui/newgamescreen/GameOptionsTable.kt
+++ b/core/src/com/unciv/ui/newgamescreen/GameOptionsTable.kt
@@ -3,7 +3,6 @@ package com.unciv.ui.newgamescreen
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.unciv.UncivGame
 import com.unciv.logic.civilization.CityStateType
-import com.unciv.models.metadata.BaseRuleset
 import com.unciv.models.ruleset.ModOptionsConstants
 import com.unciv.models.ruleset.RulesetCache
 import com.unciv.models.ruleset.unique.UniqueType
@@ -65,17 +64,13 @@ class GameOptionsTable(
             }).colspan(2).fillX().row()
         }).row()
         addVictoryTypeCheckboxes()
-
-        val religionDisabledByRuleset = (ruleset.eras[gameParameters.startingEra]!!.hasUnique(UniqueType.DisablesReligion)
-                || ruleset.modOptions.uniques.contains(ModOptionsConstants.disableReligion))
-
         val checkboxTable = Table().apply { defaults().left().pad(2.5f) }
         checkboxTable.addNoBarbariansCheckbox()
         checkboxTable.addRagingBarbariansCheckbox()
         checkboxTable.addOneCityChallengeCheckbox()
         checkboxTable.addNuclearWeaponsCheckbox()
         checkboxTable.addIsOnlineMultiplayerCheckbox()
-        checkboxTable.addReligionCheckbox(cityStateSlider, religionDisabledByRuleset)
+        checkboxTable.addReligionCheckbox(cityStateSlider)
         checkboxTable.addNoStartBiasCheckbox()
         add(checkboxTable).center().row()
 
@@ -123,7 +118,9 @@ class GameOptionsTable(
                 && !it.hasUnique(UniqueType.CityStateDeprecated)
             }
 
-    private fun Table.addReligionCheckbox(cityStateSlider: UncivSlider?, religionDisabledByRuleset: Boolean) {
+    private fun Table.addReligionCheckbox(cityStateSlider: UncivSlider?) {
+                val religionDisabledByRuleset = (ruleset.eras[gameParameters.startingEra]!!.hasUnique(UniqueType.DisablesReligion)
+                        || ruleset.modOptions.uniques.contains(ModOptionsConstants.disableReligion))
                 if (!religionDisabledByRuleset) {
                     addCheckbox("Enable Religion", gameParameters.religionEnabled) {
                         gameParameters.religionEnabled = it

--- a/core/src/com/unciv/ui/newgamescreen/GameOptionsTable.kt
+++ b/core/src/com/unciv/ui/newgamescreen/GameOptionsTable.kt
@@ -28,7 +28,8 @@ class GameOptionsTable(
     var locked = false
     var modCheckboxes: ModCheckboxTable? = null
     private set
-
+    var religionDisabledByRuleset = (ruleset.eras[gameParameters.startingEra]!!.hasUnique(UniqueType.DisablesReligion)
+            || ruleset.modOptions.uniques.contains(ModOptionsConstants.disableReligion))
     init {
         getGameOptionsTable()
     }
@@ -119,8 +120,6 @@ class GameOptionsTable(
             }
 
     private fun Table.addReligionCheckbox(cityStateSlider: UncivSlider?) {
-                val religionDisabledByRuleset = (ruleset.eras[gameParameters.startingEra]!!.hasUnique(UniqueType.DisablesReligion)
-                        || ruleset.modOptions.uniques.contains(ModOptionsConstants.disableReligion))
                 if (!religionDisabledByRuleset) {
                     addCheckbox("Enable Religion", gameParameters.religionEnabled) {
                         gameParameters.religionEnabled = it
@@ -239,7 +238,8 @@ class GameOptionsTable(
         val eras = ruleset.eras.keys
         addSelectBox("{Starting Era}:", eras, gameParameters.startingEra) {
             gameParameters.startingEra = it
-            update()
+            religionDisabledByRuleset = (ruleset.eras[gameParameters.startingEra]!!.hasUnique(UniqueType.DisablesReligion)
+                    || ruleset.modOptions.uniques.contains(ModOptionsConstants.disableReligion))
             null
         }
     }

--- a/core/src/com/unciv/ui/newgamescreen/GameOptionsTable.kt
+++ b/core/src/com/unciv/ui/newgamescreen/GameOptionsTable.kt
@@ -91,8 +91,8 @@ class GameOptionsTable(
             { gameParameters.noBarbarians = it }
 
     private fun Table.addRagingBarbariansCheckbox() =
-        addCheckbox("Raging Barbarians", gameParameters.ragingBarbarians)
-        { gameParameters.ragingBarbarians = it }
+            addCheckbox("Raging Barbarians", gameParameters.ragingBarbarians)
+            { gameParameters.ragingBarbarians = it }
 
     private fun Table.addOneCityChallengeCheckbox() =
             addCheckbox("One City Challenge", gameParameters.oneCityChallenge)
@@ -239,6 +239,7 @@ class GameOptionsTable(
         val eras = ruleset.eras.keys
         addSelectBox("{Starting Era}:", eras, gameParameters.startingEra)
         { gameParameters.startingEra = it; null }
+        update()
     }
 
     private fun addVictoryTypeCheckboxes() {

--- a/core/src/com/unciv/ui/newgamescreen/GameOptionsTable.kt
+++ b/core/src/com/unciv/ui/newgamescreen/GameOptionsTable.kt
@@ -237,9 +237,11 @@ class GameOptionsTable(
     private fun Table.addEraSelectBox() {
         if (ruleset.technologies.isEmpty()) return // mod with no techs
         val eras = ruleset.eras.keys
-        addSelectBox("{Starting Era}:", eras, gameParameters.startingEra)
-        { gameParameters.startingEra = it; null }
-        update()
+        addSelectBox("{Starting Era}:", eras, gameParameters.startingEra) {
+            gameParameters.startingEra = it
+            update()
+            null
+        }
     }
 
     private fun addVictoryTypeCheckboxes() {

--- a/core/src/com/unciv/ui/newgamescreen/GameOptionsTable.kt
+++ b/core/src/com/unciv/ui/newgamescreen/GameOptionsTable.kt
@@ -3,6 +3,7 @@ package com.unciv.ui.newgamescreen
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.unciv.UncivGame
 import com.unciv.logic.civilization.CityStateType
+import com.unciv.models.metadata.BaseRuleset
 import com.unciv.models.ruleset.RulesetCache
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.translations.tr
@@ -71,7 +72,10 @@ class GameOptionsTable(
         checkboxTable.addOneCityChallengeCheckbox()
         checkboxTable.addNuclearWeaponsCheckbox()
         checkboxTable.addIsOnlineMultiplayerCheckbox()
-        checkboxTable.addReligionCheckbox(cityStateSlider)
+        if (gameParameters.baseRuleset != BaseRuleset.Civ_V_Vanilla.fullName)
+            checkboxTable.addReligionCheckbox(cityStateSlider)
+        else
+            gameParameters.religionEnabled = false
         checkboxTable.addNoStartBiasCheckbox()
         add(checkboxTable).center().row()
 

--- a/core/src/com/unciv/ui/newgamescreen/GameOptionsTable.kt
+++ b/core/src/com/unciv/ui/newgamescreen/GameOptionsTable.kt
@@ -4,6 +4,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.unciv.UncivGame
 import com.unciv.logic.civilization.CityStateType
 import com.unciv.models.metadata.BaseRuleset
+import com.unciv.models.ruleset.ModOptionsConstants
 import com.unciv.models.ruleset.RulesetCache
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.translations.tr
@@ -65,6 +66,8 @@ class GameOptionsTable(
         }).row()
         addVictoryTypeCheckboxes()
 
+        val religionDisabledByRuleset = (ruleset.eras[gameParameters.startingEra]!!.hasUnique(UniqueType.DisablesReligion)
+                || ruleset.modOptions.uniques.contains(ModOptionsConstants.disableReligion))
 
         val checkboxTable = Table().apply { defaults().left().pad(2.5f) }
         checkboxTable.addNoBarbariansCheckbox()
@@ -72,10 +75,7 @@ class GameOptionsTable(
         checkboxTable.addOneCityChallengeCheckbox()
         checkboxTable.addNuclearWeaponsCheckbox()
         checkboxTable.addIsOnlineMultiplayerCheckbox()
-        if (gameParameters.baseRuleset != BaseRuleset.Civ_V_Vanilla.fullName)
-            checkboxTable.addReligionCheckbox(cityStateSlider)
-        else
-            gameParameters.religionEnabled = false
+        checkboxTable.addReligionCheckbox(cityStateSlider, religionDisabledByRuleset)
         checkboxTable.addNoStartBiasCheckbox()
         add(checkboxTable).center().row()
 
@@ -118,16 +118,22 @@ class GameOptionsTable(
             }
 
     private fun numberOfCityStates() = ruleset.nations.values.count {
-        it.isCityState()
-        && (it.cityStateType != CityStateType.Religious || gameParameters.religionEnabled)
-        && !it.hasUnique(UniqueType.CityStateDeprecated)
-    }
+                it.isCityState()
+                && (it.cityStateType != CityStateType.Religious || gameParameters.religionEnabled)
+                && !it.hasUnique(UniqueType.CityStateDeprecated)
+            }
 
-    private fun Table.addReligionCheckbox(cityStateSlider: UncivSlider?) =
-        addCheckbox("Enable Religion", gameParameters.religionEnabled) {
-            gameParameters.religionEnabled = it
-            cityStateSlider?.run { setRange(0f, numberOfCityStates().toFloat()) }
-        }
+    private fun Table.addReligionCheckbox(cityStateSlider: UncivSlider?, religionDisabledByRuleset: Boolean) {
+                if (!religionDisabledByRuleset) {
+                    addCheckbox("Enable Religion", gameParameters.religionEnabled) {
+                        gameParameters.religionEnabled = it
+                        cityStateSlider?.run { setRange(0f, numberOfCityStates().toFloat()) }
+                    }
+                } else {
+                    gameParameters.religionEnabled = false
+                }
+            }
+
 
     private fun Table.addNoStartBiasCheckbox() =
             addCheckbox("Disable starting bias", gameParameters.noStartBias)


### PR DESCRIPTION
this disables religion and hides the checkbox if the vanilla ruleset is selected. 
In civ 5 religion was only implemented in the G&K expansion so I doubt it'd be a good idea to be able to enable it in vanilla