### PR TITLE
Fix game crashing when a multiplayer game can not be read

### DIFF
--- a/core/src/com/unciv/logic/UncivFiles.kt
+++ b/core/src/com/unciv/logic/UncivFiles.kt
@@ -245,7 +245,7 @@ class UncivFiles(
     /**
      * GDX JSON deserialization does not throw when the file is empty, it just returns `null`.
      *
-     * Since we work with non-nullable types, we convert this to an actual exception here ot have a nice exception message instead of a NPE.
+     * Since we work with non-nullable types, we convert this to an actual exception here to have a nice exception message instead of a NPE.
      */
     private fun emptyFile(gameFile: FileHandle): SerializationException {
         return SerializationException("The file for the game ${gameFile.name()} is empty")

--- a/core/src/com/unciv/logic/UncivFiles.kt
+++ b/core/src/com/unciv/logic/UncivFiles.kt
@@ -4,6 +4,7 @@ import com.badlogic.gdx.Files
 import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.files.FileHandle
 import com.badlogic.gdx.utils.JsonReader
+import com.badlogic.gdx.utils.SerializationException
 import com.unciv.UncivGame
 import com.unciv.json.fromJsonFile
 import com.unciv.json.json
@@ -223,14 +224,31 @@ class UncivFiles(
             loadGameFromFile(getSave(gameName))
 
     fun loadGameFromFile(gameFile: FileHandle): GameInfo {
-        return gameInfoFromString(gameFile.readString())
+        val gameData = gameFile.readString()
+        if (gameData.isNullOrBlank()) {
+            throw emptyFile(gameFile)
+        }
+        return gameInfoFromString(gameData)
     }
 
     fun loadGamePreviewByName(gameName: String) =
             loadGamePreviewFromFile(getMultiplayerSave(gameName))
 
     fun loadGamePreviewFromFile(gameFile: FileHandle): GameInfoPreview {
-        return json().fromJson(GameInfoPreview::class.java, gameFile)
+        val preview = json().fromJson(GameInfoPreview::class.java, gameFile)
+        if (preview == null) {
+            throw emptyFile(gameFile)
+        }
+        return preview
+    }
+
+    /**
+     * GDX JSON deserialization does not throw when the file is empty, it just returns `null`.
+     *
+     * Since we work with non-nullable types, we convert this to an actual exception here ot have a nice exception message instead of a NPE.
+     */
+    private fun emptyFile(gameFile: FileHandle): SerializationException {
+        return SerializationException("The file for the game ${gameFile.name()} is empty")
     }
 
     class CustomLoadResult<T>(

--- a/core/src/com/unciv/logic/multiplayer/OnlineMultiplayer.kt
+++ b/core/src/com/unciv/logic/multiplayer/OnlineMultiplayer.kt
@@ -21,7 +21,6 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.launchIn
-import java.io.FileNotFoundException
 import java.time.Duration
 import java.time.Instant
 import java.util.*
@@ -155,9 +154,9 @@ class OnlineMultiplayer {
         return addGame(fileHandle, preview)
     }
 
-    private suspend fun addGame(fileHandle: FileHandle, preview: GameInfoPreview = files.loadGamePreviewFromFile(fileHandle)) {
-        debug("Adding game %s", preview.gameId)
-        val game = OnlineMultiplayerGame(fileHandle, preview, Instant.now())
+    private suspend fun addGame(fileHandle: FileHandle, preview: GameInfoPreview? = null) {
+        debug("Adding game %s", fileHandle.name())
+        val game = OnlineMultiplayerGame(fileHandle, preview, if (preview != null) Instant.now() else null)
         savedGames[fileHandle] = game
         withGLContext {
             EventBus.send(MultiplayerGameAdded(game.name))


### PR DESCRIPTION
Fixes #7399

The constructor of `OnlineMultiplayerGame` reads the file handle it gets as an argument if `preview` is `null`. The constructor also catches all exceptions and makes them available as the `error` property.

When I did `preview: GameInfoPreview = files.loadGamePreviewFromFile(fileHandle)` as the default argument for the `addGame` function, I basically circumvented that and the error that happened from `loadGamePreviewFromFile` lead to causing a crash and did not get stored in the `OnlineMultiplayerGame`.

This fixes that by simply removing that default argument code and letting `preview` be `null`, which then gets handled by `OnlineMultiplayerGame` internally.