### PR TITLE
Added more unit tests for uniques

### DIFF
--- a/android/assets/jsons/Civ V - Gods & Kings/Nations.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Nations.json
@@ -542,7 +542,7 @@
 		"favoredReligion": "Christianity",
 		"uniqueName": "Seven Cities of Gold",
 		"uniques": ["100 Gold for discovering a Natural Wonder (bonus enhanced to 500 Gold if first to discover it)",
-			"Double Happiness from Natural Wonders", "Tile yields from Natural Wonders doubled"],
+			"Double Happiness from Natural Wonders", "[+100]% Yield from every [Natural Wonder]"],
 		"cities": ["Madrid","Barcelona","Seville","Cordoba","Toledo","Santiago","Salamanca","Murcia","Valencia","Zaragoza","Pamplona",
 			"Vitoria","Santander","Oviedo","Jaen","Logroño","Valladolid","Palma","Teruel","Almeria","Leon","Zamora","Mida",
 			"Lugo","Alicante","Càdiz","Eiche","Alcorcon","Burgos","Vigo","Badajoz","La Coruña","Guadalquivir","Bilbao",
@@ -852,9 +852,9 @@
 		"uniqueName": "Patriarchate of Constantinople",
 		"uniques": ["May choose [1] additional belief(s) of any type when [founding] a religion"],
 
-		"cities": ["Constantinople", "Adrianople", "Nicaea", "Antioch", "Varna", "Ohrid", "Nicomedia", "Trebizond", "Cherson", "Sardica", 
-			"Ani", "Dyrrachium", "Edessa", "Chalcedon", "Naissus", "Bari", "Iconium", "Prilep", "Samosata", "Kars", "Nicopolis", "Theodosiopolis", 
-			"Tyana", "Gaza", "Kerkyra", "Phoenice", "Selymbria", "Sillyon", "Chrysopolis", "Vodena", "Caesarea", "Traianoupoli", "Constantia", "Athens", 
+		"cities": ["Constantinople", "Adrianople", "Nicaea", "Antioch", "Varna", "Ohrid", "Nicomedia", "Trebizond", "Cherson", "Sardica",
+			"Ani", "Dyrrachium", "Edessa", "Chalcedon", "Naissus", "Bari", "Iconium", "Prilep", "Samosata", "Kars", "Nicopolis", "Theodosiopolis",
+			"Tyana", "Gaza", "Kerkyra", "Phoenice", "Selymbria", "Sillyon", "Chrysopolis", "Vodena", "Caesarea", "Traianoupoli", "Constantia", "Athens",
 			"Patra", "Korinthos"]
 	},
 	{

--- a/android/assets/jsons/Civ V - Vanilla/Nations.json
+++ b/android/assets/jsons/Civ V - Vanilla/Nations.json
@@ -520,7 +520,7 @@
 		"innerColor": [255,102,102],
 		"uniqueName": "Seven Cities of Gold",
 		"uniques": ["100 Gold for discovering a Natural Wonder (bonus enhanced to 500 Gold if first to discover it)",
-			"Double Happiness from Natural Wonders", "Tile yields from Natural Wonders doubled"],
+			"Double Happiness from Natural Wonders", "[+100]% Yield from every [Natural Wonder]"],
 		"cities": ["Madrid","Barcelona","Seville","Cordoba","Toledo","Santiago","Salamanca","Murcia","Valencia","Zaragoza","Pamplona",
 			"Vitoria","Santander","Oviedo","Jaen","Logroño","Valladolid","Palma","Teruel","Almeria","Leon","Zamora","Mida",
 			"Lugo","Alicante","Càdiz","Eiche","Alcorcon","Burgos","Vigo","Badajoz","La Coruña","Guadalquivir","Bilbao",
@@ -1045,7 +1045,7 @@
 		"innerColor": [0,102,102],
 		"cities": ["Valletta"]
 	},
-	
+
 
 	//Barbarian
 	{

--- a/core/src/com/unciv/logic/city/CityStats.kt
+++ b/core/src/com/unciv/logic/city/CityStats.kt
@@ -599,9 +599,12 @@ class CityStats(val cityInfo: CityInfo) {
 
         val growthNullifyingUnique = cityInfo.getMatchingUniques(UniqueType.NullifiesGrowth).firstOrNull()
         if (growthNullifyingUnique != null) {
+            // Note that negative food will also be nullified. Pretty sure that's conform civ V, but haven't checked.
             val amountToRemove = -newFinalStatList.values.sumOf { it[Stat.Food].toDouble() }
-            newFinalStatList[getSourceNameForUnique(growthNullifyingUnique)] =
+            newFinalStatList.add(
+                getSourceNameForUnique(growthNullifyingUnique),
                 Stats().apply { this[Stat.Food] = amountToRemove.toFloat() }
+            )
         }
 
         if (cityInfo.isInResistance())

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -102,11 +102,12 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
     NullifiesStat("Nullifies [stat] [cityFilter]", UniqueTarget.Global),
     NullifiesGrowth("Nullifies Growth [cityFilter]", UniqueTarget.Global),
 
-    PercentProductionWonders("[relativeAmount]% Production when constructing [buildingFilter] wonders [cityFilter]", UniqueTarget.Global, UniqueTarget.FollowerBelief),
     PercentProductionBuildings("[relativeAmount]% Production when constructing [buildingFilter] buildings [cityFilter]", UniqueTarget.Global, UniqueTarget.FollowerBelief),
     PercentProductionUnits("[relativeAmount]% Production when constructing [baseUnitFilter] units [cityFilter]", UniqueTarget.Global, UniqueTarget.FollowerBelief),
+    PercentProductionWonders("[relativeAmount]% Production when constructing [buildingFilter] wonders [cityFilter]", UniqueTarget.Global, UniqueTarget.FollowerBelief),
     PercentProductionBuildingsInCapital("[relativeAmount]% Production towards any buildings that already exist in the Capital", UniqueTarget.Global, UniqueTarget.FollowerBelief),
     // todo: maybe should be converted to "[+100]% Yield from every [Natural Wonder]"?
+    @Deprecated("As of 4.1.19", ReplaceWith("[+100]% Yield from every [Natural Wonder]"))
     DoubleStatsFromNaturalWonders("Tile yields from Natural Wonders doubled", UniqueTarget.Global),
 
     //endregion Stat providing uniques

--- a/tests/src/com/unciv/uniques/TestGame.kt
+++ b/tests/src/com/unciv/uniques/TestGame.kt
@@ -18,6 +18,8 @@ import com.unciv.models.metadata.GameSettings
 import com.unciv.models.ruleset.*
 import com.unciv.models.ruleset.tile.TileImprovement
 import com.unciv.models.ruleset.unique.UniqueType
+import com.unciv.models.ruleset.unit.BaseUnit
+import com.unciv.models.ruleset.unit.UnitType
 
 class TestGame {
 
@@ -145,7 +147,7 @@ class TestGame {
         return mapUnit
     }
 
-    fun addEmptySpecialist(): String {
+    fun createSpecialist(): String {
         val name = "specialist-${objectsCreated++}"
         ruleset.specialists[name] = Specialist()
         return name
@@ -172,12 +174,21 @@ class TestGame {
         return obj
     }
 
+    fun createBaseUnit(unitType: String = createUnitType().name, vararg uniques: String) =
+        createRulesetObject(ruleset.units, *uniques) {
+            val baseUnit = BaseUnit()
+            baseUnit.ruleset = gameInfo.ruleSet
+            baseUnit.unitType = unitType
+            baseUnit
+        }
     fun createBelief(type: BeliefType = BeliefType.Any, vararg uniques: String) =
-            createRulesetObject(ruleset.beliefs, *uniques) { Belief(type) }
+        createRulesetObject(ruleset.beliefs, *uniques) { Belief(type) }
     fun createBuilding(vararg uniques: String) =
-            createRulesetObject(ruleset.buildings, *uniques) { Building() }
+        createRulesetObject(ruleset.buildings, *uniques) { Building() }
     fun createPolicy(vararg uniques: String) =
-            createRulesetObject(ruleset.policies, *uniques) { Policy() }
+        createRulesetObject(ruleset.policies, *uniques) { Policy() }
     fun createTileImprovement(vararg uniques: String) =
-            createRulesetObject(ruleset.tileImprovements, *uniques) { TileImprovement() }
+        createRulesetObject(ruleset.tileImprovements, *uniques) { TileImprovement() }
+    fun createUnitType(vararg uniques: String) =
+        createRulesetObject(ruleset.unitTypes, *uniques) { UnitType() }
 }


### PR DESCRIPTION
Added a few more unit tests for uniques.

Also deprecated Spain's unique for doubling natural wonder output, and replaced it with "[+100]% Yield from every [Natural Wonder]", which already existed. This results in a slight change in behaviour, as this percentage bonus now also applies to gold gained from being next to a river or from golden ages. Not sure if this is how it is in civ V and if it isn't, if we want a special unique just for this case.

Fixed a small bug with the nullifying growth unique, where it would override all stats from the same source with its negative (or positive) food debuff.