### PR TITLE
Resolve #7438 -Can no longer receive negative gold offers from AI

### DIFF
--- a/core/src/com/unciv/logic/automation/NextTurnAutomation.kt
+++ b/core/src/com/unciv/logic/automation/NextTurnAutomation.kt
@@ -220,7 +220,7 @@ object NextTurnAutomation {
             delta = (delta * 2) / 3 // Only compensate some of it though, they're the ones asking us
             // First give some GPT, then lump sum - but only if they're not already offering the same
             for (ourGold in tradeLogic.ourAvailableOffers
-                    .filter { it.isTradable() && it.type == TradeType.Gold || it.type == TradeType.Gold_Per_Turn }
+                    .filter { it.isTradable() && (it.type == TradeType.Gold || it.type == TradeType.Gold_Per_Turn) }
                     .sortedByDescending { it.type.ordinal }) {
                 if (tradeLogic.currentTrade.theirOffers.none { it.type == ourGold.type } &&
                         counterofferAsks.keys.none { it.type == ourGold.type } ) {

--- a/core/src/com/unciv/logic/automation/NextTurnAutomation.kt
+++ b/core/src/com/unciv/logic/automation/NextTurnAutomation.kt
@@ -155,7 +155,7 @@ object NextTurnAutomation {
             if ((offer.type == TradeType.Gold || offer.type == TradeType.Gold_Per_Turn)
                     && tradeRequest.trade.ourOffers.any { it.type == offer.type })
                     continue // Don't want to counteroffer straight gold for gold, that's silly
-            if (!offer.tradable)
+            if (!offer.isTradable())
                 continue // For example resources gained by trade or CS
             if (offer.type == TradeType.City)
                 continue // Players generally don't want to give up their cities, and they might misclick
@@ -220,7 +220,7 @@ object NextTurnAutomation {
             delta = (delta * 2) / 3 // Only compensate some of it though, they're the ones asking us
             // First give some GPT, then lump sum - but only if they're not already offering the same
             for (ourGold in tradeLogic.ourAvailableOffers
-                    .filter { it.tradable && it.type == TradeType.Gold || it.type == TradeType.Gold_Per_Turn }
+                    .filter { it.isTradable() && it.type == TradeType.Gold || it.type == TradeType.Gold_Per_Turn }
                     .sortedByDescending { it.type.ordinal }) {
                 if (tradeLogic.currentTrade.theirOffers.none { it.type == ourGold.type } &&
                         counterofferAsks.keys.none { it.type == ourGold.type } ) {

--- a/core/src/com/unciv/logic/trade/TradeOffer.kt
+++ b/core/src/com/unciv/logic/trade/TradeOffer.kt
@@ -8,14 +8,14 @@ import com.unciv.models.ruleset.Speed
 import com.unciv.models.translations.tr
 import com.unciv.ui.utils.Fonts
 
-data class TradeOffer(val name: String, val type: TradeType, var amount: Int = 1, var duration: Int, val tradable: Boolean=true) : IsPartOfGameInfoSerialization {
+data class TradeOffer(val name: String, val type: TradeType, var amount: Int = 1, var duration: Int) : IsPartOfGameInfoSerialization {
 
     constructor(
         name: String,
         type: TradeType,
         amount: Int = 1,
         speed: Speed = UncivGame.Current.gameInfo!!.speed
-    ) : this(name, type, amount, duration = -1, amount > 0) {
+    ) : this(name, type, amount, duration = -1) {
         duration = when {
             type.isImmediate -> -1 // -1 for offers that are immediate (e.g. gold transfer)
             name == Constants.peaceTreaty -> speed.peaceDealDuration
@@ -31,6 +31,8 @@ data class TradeOffer(val name: String, val type: TradeType, var amount: Int = 1
                 && offer.type == type
                 && offer.amount == amount
     }
+
+    fun isTradable() = amount > 0
 
     fun getOfferText(untradable: Int = 0): String {
         var offerText = when(type){

--- a/core/src/com/unciv/logic/trade/TradeOffer.kt
+++ b/core/src/com/unciv/logic/trade/TradeOffer.kt
@@ -3,19 +3,19 @@ package com.unciv.logic.trade
 import com.unciv.Constants
 import com.unciv.UncivGame
 import com.unciv.logic.IsPartOfGameInfoSerialization
+import com.unciv.logic.trade.TradeType.TradeTypeNumberType
 import com.unciv.models.ruleset.Speed
 import com.unciv.models.translations.tr
 import com.unciv.ui.utils.Fonts
-import com.unciv.logic.trade.TradeType.TradeTypeNumberType
 
-data class TradeOffer(val name: String, val type: TradeType, var amount: Int = 1, var duration: Int) : IsPartOfGameInfoSerialization {
+data class TradeOffer(val name: String, val type: TradeType, var amount: Int = 1, var duration: Int, val tradable: Boolean=true) : IsPartOfGameInfoSerialization {
 
     constructor(
         name: String,
         type: TradeType,
         amount: Int = 1,
         speed: Speed = UncivGame.Current.gameInfo!!.speed
-    ) : this(name, type, amount, duration = -1) {
+    ) : this(name, type, amount, duration = -1, amount > 0) {
         duration = when {
             type.isImmediate -> -1 // -1 for offers that are immediate (e.g. gold transfer)
             name == Constants.peaceTreaty -> speed.peaceDealDuration

--- a/core/src/com/unciv/ui/trade/OffersListScroll.kt
+++ b/core/src/com/unciv/ui/trade/OffersListScroll.kt
@@ -104,7 +104,8 @@ class OffersListScroll(
                 val amountPerClick =
                         if (offer.type == Gold) 50
                         else 1
-                if (offer.amount > 0 && offer.name != Constants.peaceTreaty && // can't disable peace treaty!
+
+                if (offer.tradable && offer.name != Constants.peaceTreaty && // can't disable peace treaty!
                         offer.name != Constants.researchAgreement) {
 
                     // highlight unique suggestions

--- a/core/src/com/unciv/ui/trade/OffersListScroll.kt
+++ b/core/src/com/unciv/ui/trade/OffersListScroll.kt
@@ -105,7 +105,7 @@ class OffersListScroll(
                         if (offer.type == Gold) 50
                         else 1
 
-                if (offer.tradable && offer.name != Constants.peaceTreaty && // can't disable peace treaty!
+                if (offer.isTradable() && offer.name != Constants.peaceTreaty && // can't disable peace treaty!
                         offer.name != Constants.researchAgreement) {
 
                     // highlight unique suggestions


### PR DESCRIPTION
This was due to negative gold and GPT being added to the list of available offers for completeness, and being disabled in UI.
This lead to the AI considering it a valid counteroffer to offer the player.

Solved by adding a 'tradable' field to every offer, and disabling non-tradable (by default: non-positive) offers in both UI and for AI.