### PR TITLE
Render resource icons above border

### DIFF
--- a/core/src/com/unciv/ui/map/TileGroupMap.kt
+++ b/core/src/com/unciv/ui/map/TileGroupMap.kt
@@ -108,6 +108,7 @@ class TileGroupMap<T: TileGroup>(
 
         val baseLayers = ArrayList<ActionlessGroup>()
         val featureLayers = ArrayList<ActionlessGroup>()
+        val borderLayers = ArrayList<ActionlessGroup>()
         val miscLayers = ArrayList<ActionlessGroup>()
         val pixelUnitLayers = ArrayList<ActionlessGroup>()
         val circleFogCrosshairLayers = ArrayList<ActionlessGroup>()
@@ -120,6 +121,7 @@ class TileGroupMap<T: TileGroup>(
             // now, we steal the subgroups from all the tilegroups, that's how we form layers!
             baseLayers.add(group.baseLayerGroup.apply { setPosition(group.x,group.y) })
             featureLayers.add(group.terrainFeatureLayerGroup.apply { setPosition(group.x,group.y) })
+            borderLayers.add(group.borderLayerGroup.apply { setPosition(group.x,group.y) })
             miscLayers.add(group.miscLayerGroup.apply { setPosition(group.x,group.y) })
             pixelUnitLayers.add(group.pixelMilitaryUnitGroup.apply { setPosition(group.x,group.y) })
             pixelUnitLayers.add(group.pixelCivilianUnitGroup.apply { setPosition(group.x,group.y) })
@@ -132,6 +134,7 @@ class TileGroupMap<T: TileGroup>(
                 for (mirrorTile in mirrorTileGroups[group.tileInfo]!!.toList()) {
                     baseLayers.add(mirrorTile.baseLayerGroup.apply { setPosition(mirrorTile.x,mirrorTile.y) })
                     featureLayers.add(mirrorTile.terrainFeatureLayerGroup.apply { setPosition(mirrorTile.x,mirrorTile.y) })
+                    borderLayers.add(mirrorTile.borderLayerGroup.apply { setPosition(mirrorTile.x,mirrorTile.y) })
                     miscLayers.add(mirrorTile.miscLayerGroup.apply { setPosition(mirrorTile.x,mirrorTile.y) })
                     pixelUnitLayers.add(mirrorTile.pixelMilitaryUnitGroup.apply { setPosition(mirrorTile.x,mirrorTile.y) })
                     pixelUnitLayers.add(mirrorTile.pixelCivilianUnitGroup.apply { setPosition(mirrorTile.x,mirrorTile.y) })
@@ -144,6 +147,7 @@ class TileGroupMap<T: TileGroup>(
         }
         for (group in baseLayers) addActor(group)
         for (group in featureLayers) addActor(group)
+        for (group in borderLayers) addActor(group)
         for (group in miscLayers) addActor(group)
         for (group in pixelUnitLayers) addActor(group)
         for (group in circleFogCrosshairLayers) addActor(group)

--- a/core/src/com/unciv/ui/tilegroups/TileGroup.kt
+++ b/core/src/com/unciv/ui/tilegroups/TileGroup.kt
@@ -85,6 +85,7 @@ open class TileGroup(
     class MiscLayerGroupClass(groupSize: Float) : ActionlessGroup(groupSize) {
         override fun draw(batch: Batch?, parentAlpha: Float) = super.draw(batch, parentAlpha)
     }
+    val borderLayerGroup = MiscLayerGroupClass(groupSize)
     val miscLayerGroup = MiscLayerGroupClass(groupSize)
 
     var tileYieldGroupInitialized = false
@@ -195,6 +196,7 @@ open class TileGroup(
         this.setSize(groupSize, groupSize)
         this.addActor(baseLayerGroup)
         this.addActor(terrainFeatureLayerGroup)
+        this.addActor(borderLayerGroup)
         this.addActor(miscLayerGroup)
         this.addActor(pixelMilitaryUnitGroup)
         this.addActor(pixelCivilianUnitGroup)
@@ -562,7 +564,7 @@ open class TileGroup(
                 val innerBorderImage = ImageGetter.getImage(
                         tileSetStrings.orFallback { getBorder(borderShapeString,"Inner") }
                 )
-                miscLayerGroup.addActor(innerBorderImage)
+                borderLayerGroup.addActor(innerBorderImage)
                 images.add(innerBorderImage)
                 setHexagonImageSize(innerBorderImage)
                 innerBorderImage.rotateBy(angle)
@@ -571,7 +573,7 @@ open class TileGroup(
                 val outerBorderImage = ImageGetter.getImage(
                         tileSetStrings.orFallback { getBorder(borderShapeString, "Outer") }
                 )
-                miscLayerGroup.addActor(outerBorderImage)
+                borderLayerGroup.addActor(outerBorderImage)
                 images.add(outerBorderImage)
                 setHexagonImageSize(outerBorderImage)
                 outerBorderImage.rotateBy(angle)


### PR DESCRIPTION
Closes #7096 by creating a separate group for the borders then is rendered below map icons but still above terrain.

![Borders](https://user-images.githubusercontent.com/105244635/179099131-9550eca8-519a-4abd-9bb9-b12f77becc75.png)