### PR TITLE
Simplified yields - currently without toggle option

### DIFF
--- a/core/src/com/unciv/ui/cityscreen/YieldGroup.kt
+++ b/core/src/com/unciv/ui/cityscreen/YieldGroup.kt
@@ -3,7 +3,9 @@ package com.unciv.ui.cityscreen
 import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.scenes.scene2d.ui.HorizontalGroup
 import com.badlogic.gdx.scenes.scene2d.ui.Table
+import com.unciv.models.stats.Stat
 import com.unciv.models.stats.Stats
+import com.unciv.ui.images.IconCircleGroup
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.utils.extensions.surroundWithCircle
 
@@ -11,6 +13,8 @@ class YieldGroup : HorizontalGroup() {
     init {
         isTransform = false // performance helper - nothing here is rotated or scaled
     }
+
+    val isSimplified = true
 
     var currentStats = Stats()
 
@@ -20,36 +24,40 @@ class YieldGroup : HorizontalGroup() {
         clearChildren()
         for ((stat, amount) in stats) {
             if (amount > 0f)  // Defense against upstream bugs - negatives would show as "lots"
-                addActor(getStatIconsTable(stat.name, amount.toInt()))
+                addActor(getStatIconsTable(stat, amount.toInt()))
         }
         pack()
     }
 
-    fun getIcon(statName: String) =
-            ImageGetter.getStatIcon(statName).surroundWithCircle(20f)
-                    .apply { circle.color = Color.BLACK;circle.color.a = 0.5f }
+    fun getIcon(stat: Stat): IconCircleGroup {
+        if (isSimplified) return ImageGetter.getCircle().apply { color = stat.color }
+            .surroundWithCircle(15f)
+            .apply { circle.color = Color.BLACK;circle.color.a = 0.5f }
+        return ImageGetter.getStatIcon(stat.name).surroundWithCircle(20f)
+            .apply { circle.color = Color.BLACK;circle.color.a = 0.5f }
+    }
 
-    private fun getStatIconsTable(statName: String, number: Int): Table {
+    private fun getStatIconsTable(stat: Stat, number: Int): Table {
         val table = Table()
         when (number) {
-            1 -> table.add(getIcon(statName))
+            1 -> table.add(getIcon(stat))
             2 -> {
-                table.add(getIcon(statName)).row()
-                table.add(getIcon(statName))
+                table.add(getIcon(stat)).row()
+                table.add(getIcon(stat))
             }
             3 -> {
-                table.add(getIcon(statName)).colspan(2).row()
-                table.add(getIcon(statName))
-                table.add(getIcon(statName))
+                table.add(getIcon(stat)).colspan(2).row()
+                table.add(getIcon(stat))
+                table.add(getIcon(stat))
             }
             4 -> {
-                table.add(getIcon(statName))
-                table.add(getIcon(statName)).row()
-                table.add(getIcon(statName))
-                table.add(getIcon(statName))
+                table.add(getIcon(stat))
+                table.add(getIcon(stat)).row()
+                table.add(getIcon(stat))
+                table.add(getIcon(stat))
             }
             else -> {
-                val largeImage = ImageGetter.getStatIcon(statName)
+                val largeImage = ImageGetter.getStatIcon(stat.name)
                 table.add(largeImage).size(largeImage.width * 1.5f, largeImage.height * 1.5f)
             }
         }

--- a/core/src/com/unciv/ui/cityscreen/YieldGroup.kt
+++ b/core/src/com/unciv/ui/cityscreen/YieldGroup.kt
@@ -14,8 +14,6 @@ class YieldGroup : HorizontalGroup() {
         isTransform = false // performance helper - nothing here is rotated or scaled
     }
 
-    val isSimplified = true
-
     var currentStats = Stats()
 
     fun setStats(stats: Stats) {
@@ -30,10 +28,8 @@ class YieldGroup : HorizontalGroup() {
     }
 
     fun getIcon(stat: Stat): IconCircleGroup {
-        if (isSimplified) return ImageGetter.getCircle().apply { color = stat.color }
+        return ImageGetter.getCircle().apply { color = stat.color }
             .surroundWithCircle(15f)
-            .apply { circle.color = Color.BLACK;circle.color.a = 0.5f }
-        return ImageGetter.getStatIcon(stat.name).surroundWithCircle(20f)
             .apply { circle.color = Color.BLACK;circle.color.a = 0.5f }
     }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8366208/179199319-c91d510f-6452-49ae-8ffc-860bf06d286b.png)

Lategame maps are generally so chock-full of info that the whole thing is very messy.
Showing yields exacerbates this to the point of nonsense.

This PR minimizes the noise by removing the stat icons from yields, only showing the stat colors.