### PR TITLE
Transported units no longer able to pillage tiles

### DIFF
--- a/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
@@ -812,6 +812,7 @@ object UnitActions {
     }
 
     fun canPillage(unit: MapUnit, tile: TileInfo): Boolean {
+        if (unit.isTransported) return false
         val tileImprovement = tile.getTileImprovement()
         // City ruins, Ancient Ruins, Barbarian Camp, City Center marked in json
         if (tileImprovement == null || tileImprovement.hasUnique(UniqueType.Unpillagable)) return false


### PR DESCRIPTION
Prevents transported planes (or other types of units in modded transports) from being able to pillage the tile they're in. If planes can't pillage tiles by bombing them (and therefore exposing themselves to interception), I don't see any reason why they should be allowed to pillage for health and money.