### PR TITLE
Gray out city state friend bonus when allied

### DIFF
--- a/core/src/com/unciv/ui/trade/DiplomacyScreen.kt
+++ b/core/src/com/unciv/ui/trade/DiplomacyScreen.kt
@@ -267,7 +267,7 @@ class DiplomacyScreen(
                     .row()
         }
 
-        val friendBonusLabelColor = if (relationLevel >= RelationshipLevel.Friend) Color.GREEN else Color.GRAY
+        val friendBonusLabelColor = if (relationLevel == RelationshipLevel.Friend) Color.GREEN else Color.GRAY
         val friendBonusLabel = friendBonusText.toLabel(friendBonusLabelColor)
             .apply { setAlignment(Align.center) }
         diplomacyTable.add(friendBonusLabel).row()


### PR DESCRIPTION
Since friend and ally bonus are exclusive, it makes sense to gray out the friend bonus when allied since you're not receiving it.