### PR TITLE
Resolve #7434 - HexaRealm as default tileset

### DIFF
--- a/core/src/com/unciv/models/metadata/GameSettings.kt
+++ b/core/src/com/unciv/models/metadata/GameSettings.kt
@@ -4,8 +4,8 @@ import com.badlogic.gdx.Application
 import com.badlogic.gdx.Gdx
 import com.unciv.Constants
 import com.unciv.UncivGame
-import com.unciv.models.UncivSound
 import com.unciv.logic.multiplayer.FriendList
+import com.unciv.models.UncivSound
 import com.unciv.ui.utils.Fonts
 import java.text.Collator
 import java.time.Duration
@@ -37,7 +37,7 @@ class GameSettings {
     var pauseBetweenTracks = 10
 
     var turnsBetweenAutosaves = 1
-    var tileSet: String = "FantasyHex"
+    var tileSet: String = "HexaRealm"
     var showTutorials: Boolean = true
     var autoAssignCityProduction: Boolean = true
     var autoBuildingRoads: Boolean = true


### PR DESCRIPTION
I see no reason currently to open Discussions, existing issues + Discord serve that purpose well enough, and there's no reason to add a third option to the simple "where do I write a question" dilemma