### PR TITLE
Resolved #7474 - Disabled packing base images when running from JAR

### DIFF
--- a/desktop/src/com/unciv/app/desktop/DesktopLauncher.kt
+++ b/desktop/src/com/unciv/app/desktop/DesktopLauncher.kt
@@ -30,7 +30,8 @@ internal object DesktopLauncher {
         // There must be a reason for lwjgl3 being so stingy, which for me meant to stay conservative.
         System.setProperty("org.lwjgl.system.stackSize", "384")
 
-        ImagePacker.packImages()
+        val isRunFromJAR = DesktopLauncher.javaClass.`package`.specificationVersion != null
+        ImagePacker.packImages(isRunFromJAR)
 
         val config = Lwjgl3ApplicationConfiguration()
         config.setWindowIcon("ExtraImages/Icon.png")
@@ -47,8 +48,7 @@ internal object DesktopLauncher {
             config.setWindowedMode(settings.windowState.width.coerceAtLeast(120), settings.windowState.height.coerceAtLeast(80))
         }
 
-        val isRunFromIDE = DesktopLauncher.javaClass.`package`.specificationVersion == null
-        if (isRunFromIDE) {
+        if (!isRunFromJAR) {
             UniqueDocsWriter().write()
         }
 

--- a/desktop/src/com/unciv/app/desktop/ImagePacker.kt
+++ b/desktop/src/com/unciv/app/desktop/ImagePacker.kt
@@ -3,6 +3,7 @@ package com.unciv.app.desktop
 import com.badlogic.gdx.graphics.Texture
 import com.badlogic.gdx.tools.texturepacker.TexturePacker
 import com.badlogic.gdx.utils.Json
+import com.unciv.app.desktop.ImagePacker.packImages
 import com.unciv.utils.Log
 import com.unciv.utils.debug
 import java.io.File
@@ -54,15 +55,16 @@ internal object ImagePacker {
         filterMag = Texture.TextureFilter.MipMapLinearLinear // I'm pretty sure this doesn't make sense for magnification, but setting it to Linear gives strange results
     }
 
-    fun packImages() {
+    fun packImages(isRunFromJAR:Boolean) {
         val startTime = System.currentTimeMillis()
 
         val defaultSettings = getDefaultSettings()
 
         // Scan for Image folders and build one atlas each
-        packImagesPerMod("..", ".", defaultSettings)
+        if (!isRunFromJAR)
+            packImagesPerMod("..", ".", defaultSettings)
 
-        // pack for mods as well
+        // pack for mods
         val modDirectory = File("mods")
         if (modDirectory.exists()) {
             for (mod in modDirectory.listFiles()!!) {


### PR DESCRIPTION
We want mod creators to be able to pack their own images, and they should be able to do when running from a distributed version - or in other words, a JAR.
But unless someone is working on the repo, meaning - not from a JAR, they shouldn't attempt to pack the base images.