### PR TITLE
Save all tile terrains and terrain uniques in transients, for better performance

### DIFF
--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -488,14 +488,13 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
         for (religion in religions.values) religion.setTransients(this)
 
         for (civInfo in civilizations) civInfo.setTransients()
-        for (civInfo in civilizations) civInfo.updateSightAndResources()
 
         convertFortify()
 
         for (civInfo in civilizations) {
             for (unit in civInfo.getCivUnits())
                 unit.updateVisibleTiles(false) // this needs to be done after all the units are assigned to their civs and all other transients are set
-            civInfo.updateViewableTiles() // only run ONCE and not for each unit - this is a huge performance saver!
+            civInfo.updateSightAndResources() // only run ONCE and not for each unit - this is a huge performance saver!
 
             // Since this depends on the cities of ALL civilizations,
             // we need to wait until we've set the transients of all the cities before we can run this.


### PR DESCRIPTION
getTerrains was a noticeable part in memory consumption, surprisingly.

Also minor changes in other places for performance reasons.

Adding an empty sequence to an existing sequence does have a performance overhead, since in the background what's happening is a new sequence is being created and flattened, I dealt with the simple cases of 'no improvement' and 'no resource' but not with the cases of 'has improvement with no matching unique', if we see that in late-game maps this is considerable we can check if the improvement uniques === emptySequence() and if so don't add them.