### PR TITLE
Simplified and optimized image attempter use

### DIFF
--- a/core/src/com/unciv/models/ruleset/Nation.kt
+++ b/core/src/com/unciv/models/ruleset/Nation.kt
@@ -21,6 +21,8 @@ class Nation : RulesetObject() {
     else "[$leaderName] of [$name]"
 
     val style = ""
+    fun getStyleOrCivName() = style.ifEmpty { name }
+
     var cityStateType: CityStateType? = null
     var preferredVictoryType: String = Constants.neutralVictoryType
     var declaringWar = ""

--- a/core/src/com/unciv/ui/tilegroups/TileGroup.kt
+++ b/core/src/com/unciv/ui/tilegroups/TileGroup.kt
@@ -683,7 +683,7 @@ open class TileGroup(
 
         val militaryUnit = tileInfo.militaryUnit
         if (militaryUnit != null && showMilitaryUnit && UncivGame.Current.settings.showPixelUnits) {
-            newImageLocation = tileSetStrings.getImageLocation(militaryUnit)
+            newImageLocation = tileSetStrings.getUnitImageLocation(militaryUnit)
         }
 
         val nationName = if (militaryUnit != null) "${militaryUnit.civInfo.civName}-" else ""
@@ -708,7 +708,7 @@ open class TileGroup(
         val civilianUnit = tileInfo.civilianUnit
 
         if (civilianUnit != null && tileIsViewable && UncivGame.Current.settings.showPixelUnits) {
-            newImageLocation = tileSetStrings.getImageLocation(civilianUnit)
+            newImageLocation = tileSetStrings.getUnitImageLocation(civilianUnit)
         }
 
         val nationName = if (civilianUnit != null) "${civilianUnit.civInfo.civName}-" else ""

--- a/core/src/com/unciv/ui/tilegroups/TileSetStrings.kt
+++ b/core/src/com/unciv/ui/tilegroups/TileSetStrings.kt
@@ -1,9 +1,12 @@
 package com.unciv.ui.tilegroups
 
 import com.unciv.UncivGame
+import com.unciv.logic.civilization.CivilizationInfo
+import com.unciv.logic.map.MapUnit
 import com.unciv.logic.map.RoadStatus
 import com.unciv.models.tilesets.TileSetCache
 import com.unciv.models.tilesets.TileSetConfig
+import com.unciv.ui.images.ImageAttempter
 import com.unciv.ui.images.ImageGetter
 
 /**
@@ -35,17 +38,15 @@ class TileSetStrings(tileSet: String = UncivGame.Current.settings.tileSet, fallb
     val bottomRiver by lazy { orFallback { tilesLocation + "River-Bottom"} }
     val bottomLeftRiver  by lazy { orFallback { tilesLocation + "River-BottomLeft"} }
     val unitsLocation = tileSetLocation + "Units/"
-    val landUnit = unitsLocation + "LandUnit"
-    val waterUnit = unitsLocation + "WaterUnit"
-    val civilianLandUnit = unitsLocation + "CivilianLandUnit"
 
     val bordersLocation = tileSetLocation + "Borders/"
+
 
     // There aren't that many tile combinations, and so we end up joining the same strings over and over again.
     // On large maps, this can end up as quite a lot of space, some tens of MB!
     // In order to save on space, we have this function that gets several strings and returns their concat,
     //  but is able to retrieve the existing concat if it exists, letting us essentially save each string exactly once.
-    private val hashmap = HashMap<Pair<String, String>, String>()
+    private val stringConcatHashmap = HashMap<Pair<String, String>, String>()
     fun getString(vararg strings: String): String {
         var currentString = ""
         for (str in strings) {
@@ -54,10 +55,10 @@ class TileSetStrings(tileSet: String = UncivGame.Current.settings.tileSet, fallb
                 continue
             }
             val pair = Pair(currentString, str)
-            if (hashmap.containsKey(pair)) currentString = hashmap[pair]!!
+            if (stringConcatHashmap.containsKey(pair)) currentString = stringConcatHashmap[pair]!!
             else {
                 val newString = currentString + str
-                hashmap[pair] = newString
+                stringConcatHashmap[pair] = newString
                 currentString = newString
             }
         }
@@ -111,5 +112,85 @@ class TileSetStrings(tileSet: String = UncivGame.Current.settings.tileSet, fallb
     /** @see orFallback */
     fun orFallback(image: TileSetStrings.() -> String)
             = orFallback(image, image)
+
+
+
+    /** For caching image locations based on given parameters (era, style, etc)
+     * Based on what the final image would look like if all parameters existed,
+     * like "pikeman-Medieval era-France": "pikeman" */
+    val imageParamsToImageLocation = HashMap<String,String>()
+
+
+    /**
+     * Image fallbacks work by precedence.
+     * So currently, if you're france, it's the modern era, and you have a pikeman:
+     * - If there's an era+style image of any era, take that
+     * - Else, if there's an era-no-style image of any era, take that
+     * - Only then check style-only
+     * This means that if there's a "pikeman-France" and a "pikeman-Medieval era",
+     * The era-based image wins out, even though it's not the current era.
+     */
+
+    private fun tryGetUnitImageLocation(unit:MapUnit): String? {
+        val baseUnitIconLocation = this.unitsLocation + unit.name
+        val civInfo = unit.civInfo
+        val style = civInfo.nation.getStyleOrCivName()
+
+        var imageAttempter = ImageAttempter(baseUnitIconLocation)
+            // Era+style image: looks like  "pikeman-Medieval era-France"
+            // More advanced eras default to older eras
+            .tryEraImage(civInfo, baseUnitIconLocation, style, this)
+            // Era-only image: looks like "pikeman-Medieval era"
+            .tryEraImage(civInfo, baseUnitIconLocation, null, this)
+            // Style era: looks like "pikeman-France" or "pikeman-European"
+            .tryImage { "$baseUnitIconLocation-${civInfo.nation.getStyleOrCivName()}" }
+            .tryImage { baseUnitIconLocation }
+
+        if (unit.baseUnit.replaces != null)
+            imageAttempter = imageAttempter.tryImage { getString(unitsLocation, unit.baseUnit.replaces!!) }
+
+        return imageAttempter.getPathOrNull()
+    }
+
+    /** Only for owned tiles! */
+    private fun tryGetOwnedTileImageLocation(baseLocation:String, owner:CivilizationInfo): String? {
+        val ownersStyle = owner.nation.getStyleOrCivName()
+        return ImageAttempter(baseLocation)
+            .tryEraImage(owner, baseLocation, ownersStyle, this)
+            .tryEraImage(owner, baseLocation, null, this)
+            .tryImage { getString(baseLocation, tag, ownersStyle) }
+            .getPathOrNull()
+    }
+
+    fun getOwnedTileImageLocation(baseLocation:String, owner:CivilizationInfo): String {
+        val imageKey = getString(baseLocation, tag,
+            owner.getEra().name, tag,
+            owner.nation.getStyleOrCivName())
+        val currentImageMapping = imageParamsToImageLocation[imageKey]
+        if (currentImageMapping!=null) return currentImageMapping
+
+        val imageLocation = tryGetOwnedTileImageLocation(baseLocation, owner)
+            ?: baseLocation
+
+        imageParamsToImageLocation[imageKey] = imageLocation
+        return imageLocation
+    }
+
+    fun getImageLocation(unit: MapUnit):String {
+        val imageKey = getString(
+            unit.name, tag,
+            unit.civInfo.getEra().name, tag,
+            unit.civInfo.nation.getStyleOrCivName()
+        )
+        // if in cache return that
+        val currentImageMapping = imageParamsToImageLocation[imageKey]
+        if (currentImageMapping!=null) return currentImageMapping
+
+        val imageLocation = tryGetUnitImageLocation(unit)
+            ?: fallback?.tryGetUnitImageLocation(unit)
+            ?: ""
+        imageParamsToImageLocation[imageKey] = imageLocation
+        return imageLocation
+    }
 
 }


### PR DESCRIPTION
Image fallback logic was in a bad place - confusing, semi-optimized, and spread out over several places

This brings everything into one place, simplifies the logic, adds comments,  optimizes string concats to bring down RAM usage, and adds caching so we don't need to conduct the same searches over and over

Part of #7491