### PR TITLE
Fix games not being loadable

### DIFF
--- a/core/src/com/unciv/logic/map/TileInfo.kt
+++ b/core/src/com/unciv/logic/map/TileInfo.kt
@@ -585,7 +585,7 @@ open class TileInfo : IsPartOfGameInfoSerialization {
         if (city != null) {
             // As above, since the conditional is tile-dependant,
             //  we save uniques in the cache without conditional filtering, and use only filtered ones
-            val allStatPercentUniques = cityUniqueCache.get("allSatPercentFromObject",
+            val allStatPercentUniques = cityUniqueCache.get("allStatPercentFromObject",
                 city.getMatchingUniques(UniqueType.AllStatsPercentFromObject, StateForConditionals.IgnoreConditionals))
                     .filter { it.conditionalsApply(conditionalState) }
             for (unique in allStatPercentUniques) {
@@ -596,7 +596,7 @@ open class TileInfo : IsPartOfGameInfoSerialization {
             }
 
             // Same trick different unique - not sure if worth generalizing this 'late apply' of conditions?
-            val statPercentUniques = cityUniqueCache.get("allSatPercentFromObject",
+            val statPercentUniques = cityUniqueCache.get("statPercentFromObject",
                 city.getMatchingUniques(UniqueType.StatPercentFromObject, StateForConditionals.IgnoreConditionals))
                     .filter { it.conditionalsApply(conditionalState) }
 

--- a/core/src/com/unciv/logic/map/TileInfo.kt
+++ b/core/src/com/unciv/logic/map/TileInfo.kt
@@ -536,7 +536,7 @@ open class TileInfo : IsPartOfGameInfoSerialization {
             //  therefore if we want the cache to be useful it needs to hold the pre-filtered uniques,
             //  and then for each improvement we'll filter the uniques locally.
             //  This is still a MASSIVE save of RAM!
-            val tileUniques = cityUniqueCache.get("StatsFromTiles",
+            val tileUniques = cityUniqueCache.get(UniqueType.StatsFromTiles.name,
                 city.getMatchingUniques(UniqueType.StatsFromTiles, StateForConditionals.IgnoreConditionals)
                     .filter { city.matchesFilter(it.params[2]) }) // These are the uniques for all improvements for this city,
                 .filter { it.conditionalsApply(conditionalState) } // ...and this is those with applicable conditions
@@ -555,7 +555,7 @@ open class TileInfo : IsPartOfGameInfoSerialization {
 
         fun statsFromObject() {
             // Same as above - cache holds unfiltered uniques for the city, while we use only the filtered ones
-            val uniques = cityUniqueCache.get("statsFromObjects",
+            val uniques = cityUniqueCache.get(UniqueType.StatsFromObject.name,
                 city.getMatchingUniques(UniqueType.StatsFromObject, StateForConditionals.IgnoreConditionals))
                 .filter { it.conditionalsApply(conditionalState) }
             for (unique in uniques) {
@@ -585,7 +585,7 @@ open class TileInfo : IsPartOfGameInfoSerialization {
         if (city != null) {
             // As above, since the conditional is tile-dependant,
             //  we save uniques in the cache without conditional filtering, and use only filtered ones
-            val allStatPercentUniques = cityUniqueCache.get("allStatPercentFromObject",
+            val allStatPercentUniques = cityUniqueCache.get(UniqueType.AllStatsPercentFromObject.name,
                 city.getMatchingUniques(UniqueType.AllStatsPercentFromObject, StateForConditionals.IgnoreConditionals))
                     .filter { it.conditionalsApply(conditionalState) }
             for (unique in allStatPercentUniques) {
@@ -596,7 +596,7 @@ open class TileInfo : IsPartOfGameInfoSerialization {
             }
 
             // Same trick different unique - not sure if worth generalizing this 'late apply' of conditions?
-            val statPercentUniques = cityUniqueCache.get("statPercentFromObject",
+            val statPercentUniques = cityUniqueCache.get(UniqueType.StatPercentFromObject.name,
                 city.getMatchingUniques(UniqueType.StatPercentFromObject, StateForConditionals.IgnoreConditionals))
                     .filter { it.conditionalsApply(conditionalState) }
 


### PR DESCRIPTION
Fixes https://discord.com/channels/586194543280390151/588357826758574106/999799873383706774

> 4.1.21-patch1 (happens also on 4.1.21)
>
>All my saved games prior to 4.1.21 can not be loaded:
>"Unhandeld problem: IndexOutOfBoundsException Index: 2, Size, 2" (both on Android and PC)

```
java.lang.IndexOutOfBoundsException: Index 2 out of bounds for length 2
	at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:64)
	at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:70)
	at java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:266)
	at java.base/java.util.Objects.checkIndex(Objects.java:359)
	at java.base/java.util.ArrayList.get(ArrayList.java:427)
	at com.unciv.logic.map.TileInfo.getImprovementPercentageStats(TileInfo.kt:604)
	at com.unciv.logic.map.TileInfo.getImprovementStats(TileInfo.kt:519)
	at com.unciv.logic.map.TileInfo.getTileStats(TileInfo.kt:371)
	at com.unciv.logic.city.CityStats.updateTileStats(CityStats.kt:387)
	at com.unciv.logic.city.CityStats.update(CityStats.kt:490)
	at com.unciv.logic.city.CityStats.update$default(CityStats.kt:488)
	at com.unciv.logic.GameInfo.setTransients(GameInfo.kt:522)
	at com.unciv.logic.UncivFiles$Companion.gameInfoFromString(UncivFiles.kt:359)
	at com.unciv.logic.UncivFiles.loadGameFromFile(UncivFiles.kt:231)
	at com.unciv.logic.UncivFiles.loadGameByName(UncivFiles.kt:224)
	at com.unciv.ui.saves.LoadGameScreen$onLoadGame$1.invokeSuspend(LoadGameScreen.kt:120)
	at com.unciv.ui.saves.LoadGameScreen$onLoadGame$1.invoke(LoadGameScreen.kt)
	at com.unciv.ui.saves.LoadGameScreen$onLoadGame$1.invoke(LoadGameScreen.kt)
	at com.unciv.utils.concurrency.ConcurrencyKt$launchCrashHandling$1.invokeSuspend(Concurrency.kt:83)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
	at com.unciv.utils.concurrency.CrashHandlingDispatcher$dispatch$1.invoke(Concurrency.kt:164)
	at com.unciv.utils.concurrency.CrashHandlingDispatcher$dispatch$1.invoke(Concurrency.kt:164)
	at com.unciv.ui.crashhandling.CrashHandlingExtensionsKt$wrapCrashHandling$1.invoke(CrashHandlingExtensions.kt:17)
	at com.unciv.ui.crashhandling.CrashHandlingExtensionsKt$wrapCrashHandlingUnit$1.invoke(CrashHandlingExtensions.kt:33)
	at com.unciv.ui.crashhandling.CrashHandlingExtensionsKt$wrapCrashHandlingUnit$1.invoke(CrashHandlingExtensions.kt:33)
	at com.unciv.utils.concurrency.CrashHandlingDispatcher.dispatch$lambda-0(Concurrency.kt:164)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:833)
```