### PR TITLE
Several pathfinding optimizations

### DIFF
--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -839,6 +839,7 @@ class MapUnit : IsPartOfGameInfoSerialization {
     }
 
     fun endTurn() {
+        movement.clearPathfindingCache()
         if (currentMovement > 0
             && getTile().improvementInProgress != null
             && canBuildImprovement(getTile().getTileImprovementInProgress()!!)
@@ -885,7 +886,7 @@ class MapUnit : IsPartOfGameInfoSerialization {
     }
 
     fun startTurn() {
-        movement.clearTilesWithinTurnCache()
+        movement.clearPathfindingCache()
         currentMovement = getMaxMovement().toFloat()
         attacksThisTurn = 0
         due = true

--- a/core/src/com/unciv/logic/map/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/MapUnit.kt
@@ -885,6 +885,7 @@ class MapUnit : IsPartOfGameInfoSerialization {
     }
 
     fun startTurn() {
+        movement.clearTilesWithinTurnCache()
         currentMovement = getMaxMovement().toFloat()
         attacksThisTurn = 0
         due = true

--- a/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
+++ b/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
@@ -271,7 +271,7 @@ class UnitMovementAlgorithms(val unit: MapUnit) {
             // no need to check tiles that are surrounded by reachable tiles, only need to check the edgemost tiles.
             // Because anything we can reach from intermediate tiles, can be more easily reached by the edgemost tiles,
             // since we'll have to pass through an edgemost tile in order to reach the destination anyway
-            tilesToCheck = newTilesToCheck.filterNot { tile -> tile.neighbors.all { it in newTilesToCheck || it in tilesToCheck } }
+            tilesToCheck = newTilesToCheck.filterNot { tile -> tile.neighbors.all { it in visitedTiles } }
 
             distance++
         }


### PR DESCRIPTION
This PR makes four changes to speed up pathfinding, both by introducing a cache for AI unit pathfinding that stores information that is often recalculated and also by reducing extraneous calculations. The four changes are
1. account for an edge case where ships trying to `getShortestPath()` to a landlocked tile (where all surrounding tiles are explored and known to be land) will quickly return an empty list since we know a priori that this unit can't reach the tile
2. cache the results of `getShortestPath()` since `canReach()` and `headTowards()` both use this function and are often called in succession, meaning that the path calculation is often repeated
3. cache the results of `getDistanceToTiles()` and use this cached value if the unit hasn't moved or done another action
4. have `getShortestPath()` return immediately when it finds a viable path rather than trying to find the optimal path (justification below)

These changes together reduce the cumulative amount of time spent calculating `getShortestPath()` by more than half and significantly reduce AI turn time since pathfinding is the bulk of the AI turn time computation. The changes that introduce caching only affect AI units since the AI only gives commands to one unit at a time and will never revisit a unit with extra movement points left; human commands are far more unpredictable so more complex caching would be necessary but this wouldn't be worth it.

### 1. Edge case

Self-explanatory.

### 2. Caching `UnitMovementAlgorithms.getShortestPath()`

`getShortestPath()` is called in `canReach()` and in other movement functions like `headTowards()`. Often, the AI generates a list of candidates tiles which it then sees if any can be reached then it `headTowards()` the reachable tile. Since these functions call the exact same `getShortestPath()` function, there's no reason why we shouldn't cache this to save on computational time if nothing has changed between calculating `canReach(destination)` and `headTowards(destination)`.

### 3. Caching `UnitMovementAlgorithms.getDistanceToTiles()`

`UnitMovementAlgorithms.getDistanceToTiles()` is a very widely called function for pathfinding and AI spatial awareness, so caching the result can prevent the game from repeating the same calculation over and over again. I profiled the old vs new `getDistanceToTiles()` functions using the below code for reproducibility, then copied the terminal output to a CSV file and summed the columns using Python's Pandas library. For a medium size map with 4 deity AI and 8 city states, the cumulative `newTime` for the last >100,000 calls to `getDistanceToTiles` was over 70% less than `oldTime`, and up to a 90% decrease in cumulative run time in some cases since accessing the cache takes nanoseconds but repeatedly calculating `getDistanceToTilesWithinTurn` takes microseconds. The AI units were also able to use the cache up to a few dozen times per turn per unit, and the cumulative time decrease over the 100,000+ calls was a few seconds so this probably won't be a noticeable change for the players unless they're playing on an older phone (although in some cases, an AI would take a total of a 100+ milliseconds to calculate `getDistanceToTiles` in a single turn using the old method but only a few milliseconds using the new one so in those cases a user on a computer may notice a difference; on average over an entire game, an AI nation would spend 6 milliseconds less per turn).

I also tested a comparison between the outputs of `getDistanceToTilesOld` and `getDistanceToTilesNew` and every time the outputs were identical so the behavior of `getDistanceToTiles` is unchanged.


<Details>

```
fun getDistanceToTiles(considerZoneOfControl: Boolean = true): PathsToTilesWithinTurn {
        val toReturn: PathsToTilesWithinTurn
        val oldTime = measureNanoTime {
            toReturn = getDistanceToTilesOld(considerZoneOfControl)
        }
        val toNotReturn: PathsToTilesWithinTurn
        val newTime = measureNanoTime {
            toNotReturn = getDistanceToTilesNew(considerZoneOfControl)
        }
        println("$oldTime $newTime")
        return toReturn
    }

    private fun getDistanceToTilesOld(considerZoneOfControl: Boolean = true): PathsToTilesWithinTurn = getDistanceToTilesWithinTurn(unit.currentTile.position, unit.currentMovement, considerZoneOfControl)

    private fun getDistanceToTilesNew(considerZoneOfControl: Boolean = true): PathsToTilesWithinTurn {
        val cacheResults = tilesWithinTurnCache.get(considerZoneOfControl)
        if (cacheResults != null) {
            return cacheResults
        }
        val toReturn = getDistanceToTilesWithinTurn(unit.currentTile.position, unit.currentMovement, considerZoneOfControl)
        return tilesWithinTurnCache.set(considerZoneOfControl, toReturn)
    }
```

</Details>

### 4. `UnitMovementAlgorithms.getShortestPath()` change

Currently, Unciv tries to find the most optimal path in terms of both number of turns to reach the destination tile and also in terms of the final movement points left once it reaches the destination. The thing is, Unciv doesn't account for zone of control after the first move so when planning a path that will take more than a turn to reach, any movement point optimization is pointless since the movement point costs won't reflect zone of control (the previous code comment in `getShortestPath()` justifies this since units will have likely moved so we don't want to try to predict the future). Therefore, we shouldn't try to find the most optimal path since the most optimal path found may not actually be optimal once the unit approaches the destination and pathfinding accounts for zone of control (not to mention units moving around in the turns between now and when the unit actually reaches the tile which would potentially mean the "optimal" path is no longer a viable one). This change does not increase the predicted number of turns to reach the destination.