### PR TITLE
Update Turkish.properties

### DIFF
--- a/android/assets/jsons/translations/Turkish.properties
+++ b/android/assets/jsons/translations/Turkish.properties
@@ -6233,7 +6233,7 @@ Crab = Yengeç
 
 Salt = Tuz
 
-Truffles = Domalan
+Truffles = Yermantarı
 
 
 #################### Lines from UnitPromotions from Civ V - Gods & Kings ####################


### PR DESCRIPTION
`Domalan` is too local a translation and has other meanings. `Yermantarı"` is better.