### PR TITLE
Allow modded passable natural wonders

### DIFF
--- a/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
+++ b/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
@@ -666,7 +666,6 @@ class UnitMovementAlgorithms(val unit: MapUnit) {
         if (tile.isOcean && !unit.civInfo.tech.allUnitsCanEnterOcean) { // Apparently all Polynesian naval units can enter oceans
             if (!unitSpecificAllowOcean && unit.cannotEnterOceanTiles) return false
         }
-        if (tile.naturalWonder != null) return false
 
         if (!unit.canEnterForeignTerrain && !tile.canCivPassThrough(unit.civInfo)) return false
 


### PR DESCRIPTION
Removes the restriction that all tiles containing natural wonders are impassable. All Unciv natural wonders contain the `"impassable": true` line in the `Terrains.json` file so no vanilla Unciv behavior is changed regarding tile passability.