### PR TITLE
Fix Natural Wonder placement

### DIFF
--- a/core/src/com/unciv/logic/map/mapgenerator/MapRegions.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/MapRegions.kt
@@ -829,10 +829,21 @@ class MapRegions (val ruleset: Ruleset){
     }
 
     fun placeResourcesAndMinorCivs(tileMap: TileMap, minorCivs: List<CivilizationInfo>) {
+        placeNaturalWonderImpacts(tileMap)
         assignLuxuries()
         placeMinorCivs(tileMap, minorCivs)
         placeLuxuries(tileMap)
         placeStrategicAndBonuses(tileMap)
+    }
+
+    /** Places impacts from NWs that have been generated just prior to this step. */
+    private fun placeNaturalWonderImpacts(tileMap: TileMap) {
+        for (tile in tileMap.values.filter { it.isNaturalWonder() }) {
+            placeImpact(ImpactType.Bonus, tile, 1)
+            placeImpact(ImpactType.Strategic, tile, 1)
+            placeImpact(ImpactType.Luxury, tile, 1)
+            placeImpact(ImpactType.MinorCiv, tile, 1)
+        }
     }
 
     /** Assigns a luxury to each region. No luxury can be assigned to too many regions.


### PR DESCRIPTION
Resolves #7534.

Addresses a couple of issues with Natural Wonder placements:

- Wonders were spawning too close to each other (#7534). There is now a minimum distance of (map height / 5).
- Wonders were being spawned in incorrect order meaning the ones with more picky requirements were less often able to be placed. The rare ones should be _slightly_ more frequent now.
- Due to an oversight (by me) too many resources were placed next to NWs. This should now be more rare.