### PR TITLE
Fix erroneous relationship decay notification

### DIFF
--- a/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
@@ -260,7 +260,7 @@ class DiplomacyManager() : IsPartOfGameInfoSerialization {
     }
 
     private fun getCityStateInfluenceDegrade(): Float {
-        if (getInfluence() < getCityStateInfluenceRestingPoint())
+        if (getInfluence() <= getCityStateInfluenceRestingPoint())
             return 0f
 
         val decrement = when {
@@ -288,7 +288,7 @@ class DiplomacyManager() : IsPartOfGameInfoSerialization {
     }
 
     private fun getCityStateInfluenceRecovery(): Float {
-        if (getInfluence() > getCityStateInfluenceRestingPoint())
+        if (getInfluence() >= getCityStateInfluenceRestingPoint())
             return 0f
 
         val increment = 1f  // sic: personality does not matter here


### PR DESCRIPTION
Whenever your relationship resting point as well as the relationship
score for city states is at the exact value of 30 or 60, a notification
is shown that the relationship is about to degrade, even though it can
and will not. This fixes said issue by adding checks for the resting
points to getTurnsToRelationshipChange().

A recent example where I encountered this was in a game with many city
states where I had the Aesthetics policy and pledged to protect all of
them, which led to a resting relationship value of 30 with them.