### PR TITLE
Invalid players removed from global quests

### DIFF
--- a/core/src/com/unciv/logic/civilization/QuestManager.kt
+++ b/core/src/com/unciv/logic/civilization/QuestManager.kt
@@ -234,6 +234,9 @@ class QuestManager : IsPartOfGameInfoSerialization {
     }
 
     private fun handleGlobalQuests() {
+        // Remove any participants that are no longer valid because of being dead or at war with the CS
+        assignedQuests.removeAll { it.isGlobal() &&
+            !canAssignAQuestTo(civInfo.gameInfo.getCivilization(it.assignee)) }
         val globalQuestsExpired = assignedQuests.filter { it.isGlobal() && it.isExpired() }.map { it.questName }.distinct()
         for (globalQuestName in globalQuestsExpired)
             handleGlobalQuest(globalQuestName)


### PR DESCRIPTION
Solves #7526.
Rechecks each global quest at the start of the turn and removes invalid players, either due to them being dead or being at war with the assigning CS.