### PR TITLE
Fix untranslated strings

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -317,6 +317,7 @@ Declare war on [nation] =
 Luxury resources = 
 Strategic resources = 
 Owned by you: [amountOwned] = 
+Non-existent city = 
 
 # Nation picker
 
@@ -906,6 +907,7 @@ Sleep until healed =
 Moving = 
 Set up = 
 Paradrop = 
+Air Sweep = 
 Add in capital = 
 Add to [comment] = 
 Upgrade to [unitType] ([goldCost] gold) = 
@@ -1052,6 +1054,7 @@ Please select a tile for this building's [improvement] =
 # Ask for text or numbers popup UI
 
 Invalid input! Please enter a different string. = 
+Invalid input! Please enter a valid number. = 
 Please enter some text = 
 
 # Technology UI


### PR DESCRIPTION
Fix remaining untranslatable strings from issue #6131 .

```
Air Sweep
Non-existent city
Invalid input! Please enter a valid number.
```

I tested it before submitting the PR: these translated strings work in-game once added to the translation file.
Therefore, the fix requires only to add the missing strings to template.properties... (I can handle that ^^)