### PR TITLE
Removes the option for disabling religion

### DIFF
--- a/core/src/com/unciv/logic/GameStarter.kt
+++ b/core/src/com/unciv/logic/GameStarter.kt
@@ -255,7 +255,6 @@ object GameStarter {
         availableCityStatesNames.addAll( ruleset.nations
             .filter {
                 it.value.isCityState() &&
-                (it.value.cityStateType != CityStateType.Religious || newGameParameters.religionEnabled) &&
                 !it.value.hasUnique(UniqueType.CityStateDeprecated)
             }.keys
             .shuffled()

--- a/core/src/com/unciv/logic/civilization/QuestManager.kt
+++ b/core/src/com/unciv/logic/civilization/QuestManager.kt
@@ -804,7 +804,7 @@ class QuestManager : IsPartOfGameInfoSerialization {
                             && civInfo.gameInfo.getCities().none { it.cityConstructions.isBuilt(building.name) }
                             // Can't be disabled
                             && building.name !in startingEra.startingObsoleteWonders
-                            && (civInfo.gameInfo.gameParameters.religionEnabled || !building.hasUnique(UniqueType.HiddenWithoutReligion))
+                            && (civInfo.gameInfo.isReligionEnabled() || !building.hasUnique(UniqueType.HiddenWithoutReligion))
                             // Can't be more than 25% built anywhere
                             && civInfo.gameInfo.getCities().none {
                         it.cityConstructions.getWorkDone(building.name) * 3 > it.cityConstructions.getRemainingWork(building.name) }

--- a/core/src/com/unciv/models/metadata/GameParameters.kt
+++ b/core/src/com/unciv/models/metadata/GameParameters.kt
@@ -26,7 +26,8 @@ class GameParameters : IsPartOfGameInfoSerialization { // Default values are the
     var oneCityChallenge = false
     var godMode = false
     var nuclearWeaponsEnabled = true
-    var religionEnabled = false
+    @Deprecated("As of 4.2.3")
+    var religionEnabled = true
     var noStartBias = false
 
     var victoryTypes: ArrayList<String> = arrayListOf()
@@ -69,7 +70,6 @@ class GameParameters : IsPartOfGameInfoSerialization { // Default values are the
             if (ragingBarbarians) yield("Raging barbs")
             if (oneCityChallenge) yield("OCC")
             if (!nuclearWeaponsEnabled) yield("No nukes")
-            if (religionEnabled) yield("Religion")
             if (godMode) yield("God mode")
             yield("Enabled Victories: " + victoryTypes.joinToString())
             yield(baseRuleset)

--- a/core/src/com/unciv/ui/newgamescreen/GameOptionsTable.kt
+++ b/core/src/com/unciv/ui/newgamescreen/GameOptionsTable.kt
@@ -38,7 +38,6 @@ class GameOptionsTable(
     }
 
     private fun getGameOptionsTable() {
-        val cityStateSlider: UncivSlider?
         top()
         defaults().pad(5f)
 
@@ -59,7 +58,7 @@ class GameOptionsTable(
                 val turnSlider = addMaxTurnsSlider()
                 if (turnSlider != null)
                     add(turnSlider).padTop(10f).row()
-                cityStateSlider = addCityStatesSlider()
+                addCityStatesSlider()
             }).colspan(2).fillX().row()
         }).row()
         addVictoryTypeCheckboxes()
@@ -71,7 +70,6 @@ class GameOptionsTable(
         checkboxTable.addOneCityChallengeCheckbox()
         checkboxTable.addNuclearWeaponsCheckbox()
         checkboxTable.addIsOnlineMultiplayerCheckbox()
-        checkboxTable.addReligionCheckbox(cityStateSlider)
         checkboxTable.addNoStartBiasCheckbox()
         add(checkboxTable).center().row()
 
@@ -119,19 +117,13 @@ class GameOptionsTable(
         && !it.hasUnique(UniqueType.CityStateDeprecated)
     }
 
-    private fun Table.addReligionCheckbox(cityStateSlider: UncivSlider?) =
-        addCheckbox("Enable Religion", gameParameters.religionEnabled) {
-            gameParameters.religionEnabled = it
-            cityStateSlider?.run { setRange(0f, numberOfCityStates().toFloat()) }
-        }
-
     private fun Table.addNoStartBiasCheckbox() =
             addCheckbox("Disable starting bias", gameParameters.noStartBias)
             { gameParameters.noStartBias = it }
 
-    private fun Table.addCityStatesSlider(): UncivSlider? {
+    private fun Table.addCityStatesSlider() {
         val maxCityStates = numberOfCityStates()
-        if (maxCityStates == 0) return null
+        if (maxCityStates == 0) return
 
         add("{Number of City-States}:".toLabel()).left().expandX()
         val slider = UncivSlider(0f, maxCityStates.toFloat(), 1f, initial = gameParameters.numberOfCityStates.toFloat()) {
@@ -140,7 +132,6 @@ class GameOptionsTable(
         slider.permanentTip = true
         slider.isDisabled = locked
         add(slider).padTop(10f).row()
-        return slider
     }
 
     private fun Table.addMaxTurnsSlider(): UncivSlider? {

--- a/core/src/com/unciv/ui/newgamescreen/GameOptionsTable.kt
+++ b/core/src/com/unciv/ui/newgamescreen/GameOptionsTable.kt
@@ -113,7 +113,6 @@ class GameOptionsTable(
 
     private fun numberOfCityStates() = ruleset.nations.values.count {
         it.isCityState()
-        && (it.cityStateType != CityStateType.Religious || gameParameters.religionEnabled)
         && !it.hasUnique(UniqueType.CityStateDeprecated)
     }
 

--- a/tests/src/com/unciv/testing/SerializationTests.kt
+++ b/tests/src/com/unciv/testing/SerializationTests.kt
@@ -53,7 +53,6 @@ class SerializationTests {
             players.clear()
             players.add(Player("Rome").apply { playerType = PlayerType.Human })
             players.add(Player("Greece"))
-            religionEnabled = true
         }
         val mapParameters = MapParameters().apply {
             mapSize = MapSizeNew(MapSize.Tiny)

--- a/tests/src/com/unciv/uniques/TestGame.kt
+++ b/tests/src/com/unciv/uniques/TestGame.kt
@@ -154,7 +154,6 @@ class TestGame {
     }
 
     fun addReligion(foundingCiv: CivilizationInfo): Religion {
-        gameInfo.gameParameters.religionEnabled = true
         val religion = Religion("Religion-${objectsCreated++}", gameInfo, foundingCiv.civName)
         foundingCiv.religionManager.religion = religion
         gameInfo.religions[religion.name] = religion


### PR DESCRIPTION
This PR removes the option in the new game screen to disable religion, but doesn't remove the underlying variable, so games started with this option disabled can still be played without religion.

This is a bit of a controversial change. For me personally the plan was always to remove this option once religion was fully implemented, but due to that having taking over a year, this option might now have become expected for most users.

Reasons for removing this button:
- Civ V also does this.
- When religion is disabled, the special ability of some civilizations just doesn't apply any more. For example, the Celts can't get Faith from forests any more, and Byzantium doesn't have any use for the extra belief when founding a religion. This makes the civilization weaker, and, if they're an AI player, might unexpectedly lower the difficulty of the game.
- It was never meant to be an option. It was first implemented as such when religion was in a very early state to only allow beta tests and warn players that the feature was in heavy development. Later the button marking it as beta was removed, but the option was kept, as it still wasn't fully finished. With #4290 now closed, religion is fully finished, and from this point of view the option is no longer necessary.