### PR TITLE
Fix graphical bug related to resuming games from the main menu

### DIFF
--- a/core/src/com/unciv/MainMenuScreen.kt
+++ b/core/src/com/unciv/MainMenuScreen.kt
@@ -212,6 +212,7 @@ class MainMenuScreen: BaseScreen(), RecreateOnResize {
         val curWorldScreen = game.worldScreen
         if (curWorldScreen != null) {
             game.resetToWorldScreen()
+            ImageGetter.ruleset = game.gameInfo!!.ruleSet
             curWorldScreen.popups.filterIsInstance(WorldScreenMenuPopup::class.java).forEach(Popup::close)
         } else {
             QuickSave.autoLoadGame(this)


### PR DESCRIPTION
Fixes a fairly specific bug where a user exits to the main menu from a game then immediately resumes the game which causes certain icons to no longer appear. This occurs because the main menu loads the vanilla ruleset since it's guaranteed to be present for the generated main menu background.
https://github.com/yairm210/Unciv/blob/a1357414a0584bb2332dd172055c57bf3a77d1c2/core/src/com/unciv/MainMenuScreen.kt#L94-L96
However, if the user was playing with the G&K ruleset, then the icons added by G&K will not be reloaded so they will appear as blank spaces. You can test this out by starting a game as the Celts, selecting Bronze Working as your tech to research, then while researching it in game, selecting the menu and returning to the main menu then immediately resuming the game using the "Resume" button. You'll see that the Bronze Working tech in the top left corner has a blank space which corresponds to the icon of the Pictish Warrior.
