### PR TITLE
Added a hidden option for enabling espionage

### DIFF
--- a/core/src/com/unciv/models/metadata/GameParameters.kt
+++ b/core/src/com/unciv/models/metadata/GameParameters.kt
@@ -28,6 +28,7 @@ class GameParameters : IsPartOfGameInfoSerialization { // Default values are the
     var nuclearWeaponsEnabled = true
     @Deprecated("As of 4.2.3")
     var religionEnabled = true
+    var espionageEnabled = false
     var noStartBias = false
 
     var victoryTypes: ArrayList<String> = arrayListOf()

--- a/core/src/com/unciv/models/metadata/GameSettings.kt
+++ b/core/src/com/unciv/models/metadata/GameSettings.kt
@@ -64,6 +64,7 @@ class GameSettings {
     var multiplayer = GameSettingsMultiplayer()
 
     var showExperimentalWorldWrap = false // We're keeping this as a config due to ANR problems on Android phones for people who don't know what they're doing :/
+    var enableEspionageOption = false
 
     var lastOverviewPage: String = "Cities"
 

--- a/core/src/com/unciv/ui/newgamescreen/GameOptionsTable.kt
+++ b/core/src/com/unciv/ui/newgamescreen/GameOptionsTable.kt
@@ -70,6 +70,8 @@ class GameOptionsTable(
         checkboxTable.addOneCityChallengeCheckbox()
         checkboxTable.addNuclearWeaponsCheckbox()
         checkboxTable.addIsOnlineMultiplayerCheckbox()
+        if (UncivGame.Current.settings.enableEspionageOption)
+            checkboxTable.addEnableEspionageCheckbox()
         checkboxTable.addNoStartBiasCheckbox()
         add(checkboxTable).center().row()
 
@@ -110,6 +112,11 @@ class GameOptionsTable(
                     MultiplayerHelpers.showDropboxWarning(previousScreen as BaseScreen)
                 }
             }
+
+    private fun Table.addEnableEspionageCheckbox() =
+        addCheckbox("Enable Espionage", gameParameters.espionageEnabled)
+        { gameParameters.espionageEnabled = it }
+
 
     private fun numberOfCityStates() = ruleset.nations.values.count {
         it.isCityState()

--- a/core/src/com/unciv/ui/options/DebugTab.kt
+++ b/core/src/com/unciv/ui/options/DebugTab.kt
@@ -51,6 +51,9 @@ fun debugTab() = Table(BaseScreen.skin).apply {
             curGameInfo.gameParameters.godMode = it
         }).colspan(2).row()
     }
+    add("Enable espionage option".toCheckBox(game.settings.enableEspionageOption) {
+        game.settings.enableEspionageOption = it
+    }).colspan(2).row()
     add("Save games compressed".toCheckBox(UncivFiles.saveZipped) {
         UncivFiles.saveZipped = it
     }).colspan(2).row()

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -744,11 +744,6 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 	Applicable to: Global, Unit
 
-??? example  "[greatPerson] is earned [relativeAmount]% faster"
-	Example: "[Great General] is earned [+20]% faster"
-
-	Applicable to: Global, Unit
-
 ??? example  "Earn [amount]% of the damage done to [combatantFilter] units as [civWideStat]"
 	Example: "Earn [3]% of the damage done to [City] units as [Gold]"
 
@@ -771,6 +766,11 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 ??? example  "[relativeAmount]% XP gained from combat"
 	Example: "[+20]% XP gained from combat"
+
+	Applicable to: Global, Unit
+
+??? example  "[greatPerson] is earned [relativeAmount]% faster"
+	Example: "[Great General] is earned [+20]% faster"
 
 	Applicable to: Global, Unit
 
@@ -1171,6 +1171,9 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 ??? example  "May upgrade to [baseUnitFilter] through ruins-like effects"
 	Example: "May upgrade to [Melee] through ruins-like effects"
 
+	Applicable to: Unit
+
+??? example  "Destroys tile improvements when attacking"
 	Applicable to: Unit
 
 ??? example  "Double movement in [terrainFilter]"
@@ -1663,11 +1666,6 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 ??? example  "&lt;during a Golden Age&gt;"
 	Applicable to: Conditional
 
-??? example  "&lt;with [resource]&gt;"
-	Example: "&lt;with [Iron]&gt;"
-
-	Applicable to: Conditional
-
 ??? example  "&lt;while the empire is happy&gt;"
 	Applicable to: Conditional
 
@@ -1726,6 +1724,16 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 ??? example  "&lt;if [buildingName] is constructed&gt;"
 	Example: "&lt;if [Library] is constructed&gt;"
+
+	Applicable to: Conditional
+
+??? example  "&lt;with [resource]&gt;"
+	Example: "&lt;with [Iron]&gt;"
+
+	Applicable to: Conditional
+
+??? example  "&lt;without [resource]&gt;"
+	Example: "&lt;without [Iron]&gt;"
 
 	Applicable to: Conditional
 


### PR DESCRIPTION
This PR adds an option in the debug tab which sets whether or not the 'enable espionage' option is shown when starting a new game. This game option currently does nothing, see #7610.