### PR TITLE
Fix mod translation file generation

### DIFF
--- a/core/src/com/unciv/models/translations/TranslationFileWriter.kt
+++ b/core/src/com/unciv/models/translations/TranslationFileWriter.kt
@@ -38,8 +38,14 @@ object TranslationFileWriter {
             val translations = Translations()
             translations.readAllLanguagesTranslation()
 
-            val percentages = generateTranslationFiles(translations)
-            writeLanguagePercentages(percentages)
+            var fastlaneOutput = ""
+            // check to make sure we're not running from a jar since these users shouldn't need to
+            // regenerate base game translation and fastlane files
+            if (TranslationFileWriter.javaClass.`package`.specificationVersion == null) {
+                val percentages = generateTranslationFiles(translations)
+                writeLanguagePercentages(percentages)
+                fastlaneOutput = "\n" + writeTranslatedFastlaneFiles(translations)
+            }
 
             // See #5168 for some background on this
             for ((modName, modTranslations) in translations.modsWithTranslations) {
@@ -48,8 +54,7 @@ object TranslationFileWriter {
                 writeLanguagePercentages(modPercentages, modFolder)  // unused by the game but maybe helpful for the mod developer
             }
 
-            return "Translation files are generated successfully.".tr() + "\n" +
-                    writeTranslatedFastlaneFiles(translations)
+            return "Translation files are generated successfully.".tr() + fastlaneOutput
         } catch (ex: Throwable) {
             ex.printStackTrace()
             return ex.localizedMessage ?: ex.javaClass.simpleName


### PR DESCRIPTION
Trying to generate translation files from the .jar throws a (caught) exception that prints a cryptic "Collection is empty" when the user presses the button to generate translation files. I tracked down why this was happening and it's due to the base game translation files not being where Unciv expects them to be. I've changed the translation file generation to check if the user is running from the .jar and if so to skip generating base game translation files and fastlane files since these users shouldn't be editing these files (use Android Studio for that if necessary). This change stops the exception from occurring and allows desktop users to generate translation files for their mods.