### PR TITLE
List which city owns each tile in the city screen UI

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -1053,6 +1053,7 @@ Convert production to science at a rate of [rate] to 1 =
 Convert production to [stat] at a rate of [rate] to 1 = 
 Production to [stat] conversion in cities changed by [relativeAmount]% = 
 The city will not produce anything. = 
+Owned by [cityName] = 
 Worked by [cityName] = 
 Lock = 
 Unlock = 

--- a/core/src/com/unciv/ui/cityscreen/CityScreenTileTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityScreenTileTable.kt
@@ -67,6 +67,9 @@ class CityScreenTileTable(private val cityScreen: CityScreen): Table() {
             innerTable.add(buyTileButton).padTop(5f).row()
         }
 
+        if (selectedTile.owningCity != null)
+            innerTable.add("Owned by [${selectedTile.owningCity!!.name}]".toLabel()).row()
+
         if (city.civInfo.cities.filterNot { it == city }.any { it.isWorked(selectedTile) })
             innerTable.add("Worked by [${selectedTile.getWorkingCity()!!.name}]".toLabel()).row()
 


### PR DESCRIPTION
Adds a way for players to know which city owns each tile. This appears in the bottom right corner of the city screen when a player selects a tile that has an owning city.
![TileOwner](https://user-images.githubusercontent.com/105244635/183265923-a2e5e0dc-6a96-42d8-8f75-1a1c4b0e1550.png)
