### PR TITLE
Fix infinite city-state tribute cooldown bug

### DIFF
--- a/core/src/com/unciv/logic/civilization/CityStateFunctions.kt
+++ b/core/src/com/unciv/logic/civilization/CityStateFunctions.kt
@@ -352,7 +352,7 @@ class CityStateFunctions(val civInfo: CivilizationInfo) {
         val recentBullying = civInfo.getRecentBullyingCountdown()
         if (recentBullying != null && recentBullying > 10)
             modifiers["Very recently paid tribute"] = -300
-        else if (recentBullying != null)
+        else if (recentBullying != null && recentBullying > 0)
             modifiers["Recently paid tribute"] = -40
         if (civInfo.getDiplomacyManager(demandingCiv).getInfluence() < -30)
             modifiers["Influence below -30"] = -300


### PR DESCRIPTION
Closes #7645. The condition for adding the "Recently paid tribute" modifier was originally checking if the recent bullying flag was non-null which works if the city state hasn't been bullied before but not once the city-state is bullied and this flag always becomes non-null. Didn't test on the saved file in the issue but stepping through the debugger before and after shows that the condition change successfully prevents the "Recently paid tribute" modifier from appearing if the bully countdown is 0.

While I haven't tested this extensively, this fix may result in more city states being afraid since they won't perpetually have the "Recently paid tribute" modifier which negatively impacts `civInfo.getTributeWillingness(otherCiv())`.
https://github.com/yairm210/Unciv/blob/9898789772d067b19bd3bbd056c6b08e87c89e0e/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt#L180