### PR TITLE
close app completely when clicked 'Exit' button

### DIFF
--- a/android/src/com/unciv/app/AndroidLauncher.kt
+++ b/android/src/com/unciv/app/AndroidLauncher.kt
@@ -147,8 +147,8 @@ open class AndroidLauncher : AndroidApplication() {
     }
 
     override fun onDestroy() {
-        super.onDestroy()
-        finishAndRemoveTask();
+        finishAndRemoveTask()
+        if(false) super.onDestroy() // do not remove
     }
 
     override fun onNewIntent(intent: Intent?) {

--- a/android/src/com/unciv/app/AndroidLauncher.kt
+++ b/android/src/com/unciv/app/AndroidLauncher.kt
@@ -146,6 +146,10 @@ open class AndroidLauncher : AndroidApplication() {
         super.onResume()
     }
 
+    override fun onDestroy() {
+        finishAndRemoveTask();
+    }
+
     override fun onNewIntent(intent: Intent?) {
         super.onNewIntent(intent)
         if (intent == null)

--- a/android/src/com/unciv/app/AndroidLauncher.kt
+++ b/android/src/com/unciv/app/AndroidLauncher.kt
@@ -147,6 +147,7 @@ open class AndroidLauncher : AndroidApplication() {
     }
 
     override fun onDestroy() {
+        super.onDestroy()
         finishAndRemoveTask();
     }
 

--- a/core/src/com/unciv/UncivGame.kt
+++ b/core/src/com/unciv/UncivGame.kt
@@ -294,7 +294,7 @@ class UncivGame(parameters: UncivGameParameters) : Game() {
                 restoreDefault = { musicController.resume() },
                 action = {
                     Gdx.app.exit()
-                    System.exit(0)
+
                 }
             ).open(force = true)
             return null
@@ -399,6 +399,8 @@ class UncivGame(parameters: UncivGameParameters) : Game() {
 
         // On desktop this should only be this one and "DestroyJavaVM"
         logRunningThreads()
+
+        System.exit(0)
     }
 
     private fun logRunningThreads() {


### PR DESCRIPTION
Fixes #7515 . I tested it on my Android phone and the bug recurred. This bug seems to be caused by that the 'Exit' button can not close Unciv completely on Android. call `this.finishAndRemoveTask()` method in overridden `onDetroy()` can fix this problem.

*See also [finishAndRemoveTask()](https://developer.android.com/reference/android/app/Activity.html#finishAndRemoveTask()), [onDestroy()](https://developer.android.com/reference/android/app/Activity#onDestroy())*