### PR TITLE
Fix an untranslated string

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -1324,6 +1324,7 @@ Improvements =
 Loading... = 
 Filter: = 
 OK = 
+Map is incompatible with the chosen ruleset! = 
 Base terrain [terrain] does not exist in ruleset! = 
 Terrain feature [feature] does not exist in ruleset! = 
 Resource [resource] does not exist in ruleset! = 


### PR DESCRIPTION
Fix an untranslated string when trying to launch a new game on a map that is not compatible with the ruleset.

Before:
![incompatible](https://user-images.githubusercontent.com/11946570/184461669-6bb7a075-96fa-46ff-b77c-dc27cb962cbe.png)

After:
![after](https://user-images.githubusercontent.com/11946570/184462154-2c369643-d9b6-4518-8214-f8eb8c594f68.png)

