### PR TITLE
Generalize Great Wall unique

### DIFF
--- a/android/assets/jsons/Civ V - Gods & Kings/Buildings.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Buildings.json
@@ -406,7 +406,7 @@
 		"culture": 3,
 		"greatPersonPoints": {"Great Engineer": 1},
 		"isWonder": true,
-		"uniques": ["Enemy land units must spend 1 extra movement point when inside your territory (obsolete upon Dynamite)",
+		"uniques": ["Enemy [Land] units must spend [1] extra movement points when inside your territory <before discovering [Dynamite]>",
 			"Gain a free [Walls] [in this city]"],
 		"requiredTech": "Engineering",
 		"quote": "'The art of war teaches us to rely not on the likelihood of the enemy's not attacking, but rather on the fact that we have made our position unassailable.' - Sun Tzu"

--- a/android/assets/jsons/Civ V - Vanilla/Buildings.json
+++ b/android/assets/jsons/Civ V - Vanilla/Buildings.json
@@ -253,7 +253,7 @@
 		"culture": 3,
 		"greatPersonPoints": {"Great Engineer": 1},
 		"isWonder": true,
-		"uniques": ["Enemy land units must spend 1 extra movement point when inside your territory (obsolete upon Dynamite)",
+		"uniques": ["Enemy [Land] units must spend [1] extra movement points when inside your territory <before discovering [Dynamite]>",
 			"Gain a free [Walls] [in this city]"],
 		"requiredTech": "Construction",
 		"quote": "'The art of war teaches us to rely not on the likelihood of the enemy's not attacking, but rather on the fact that we have made our position unassailable.' - Sun Tzu"

--- a/core/src/com/unciv/logic/civilization/CivInfoTransientUpdater.kt
+++ b/core/src/com/unciv/logic/civilization/CivInfoTransientUpdater.kt
@@ -139,7 +139,7 @@ class CivInfoTransientUpdater(val civInfo: CivilizationInfo) {
         }
     }
 
-    fun updateHasActiveGreatWall() {
+    fun updateHasActiveEnemyMovementPenalty() {
         civInfo.hasActiveEnemyMovementPenalty = (!civInfo.tech.isResearched("Dynamite") && civInfo.hasUnique(UniqueType.EnemyLandUnitsSpendExtraMovementDepreciated))
                 || civInfo.hasUnique(UniqueType.EnemyLandUnitsSpendExtraMovement)
     }

--- a/core/src/com/unciv/logic/civilization/CivInfoTransientUpdater.kt
+++ b/core/src/com/unciv/logic/civilization/CivInfoTransientUpdater.kt
@@ -140,8 +140,8 @@ class CivInfoTransientUpdater(val civInfo: CivilizationInfo) {
     }
 
     fun updateHasActiveGreatWall() {
-        civInfo.hasActiveGreatWall = !civInfo.tech.isResearched("Dynamite") &&
-                civInfo.hasUnique(UniqueType.EnemyLandUnitsSpendExtraMovement)
+        civInfo.hasActiveEnemyMovementPenalty = (!civInfo.tech.isResearched("Dynamite") && civInfo.hasUnique(UniqueType.EnemyLandUnitsSpendExtraMovementDepreciated))
+                || civInfo.hasUnique(UniqueType.EnemyLandUnitsSpendExtraMovement)
     }
 
     fun updateCitiesConnectedToCapital(initialSetup: Boolean = false) {

--- a/core/src/com/unciv/logic/civilization/CivInfoTransientUpdater.kt
+++ b/core/src/com/unciv/logic/civilization/CivInfoTransientUpdater.kt
@@ -142,6 +142,9 @@ class CivInfoTransientUpdater(val civInfo: CivilizationInfo) {
     fun updateHasActiveEnemyMovementPenalty() {
         civInfo.hasActiveEnemyMovementPenalty = (!civInfo.tech.isResearched("Dynamite") && civInfo.hasUnique(UniqueType.EnemyLandUnitsSpendExtraMovementDepreciated))
                 || civInfo.hasUnique(UniqueType.EnemyLandUnitsSpendExtraMovement)
+        civInfo.enemyMovementPenaltyUniques =
+                civInfo.getMatchingUniques(UniqueType.EnemyLandUnitsSpendExtraMovement) +
+                        civInfo.getMatchingUniques(UniqueType.EnemyLandUnitsSpendExtraMovementDepreciated)
     }
 
     fun updateCitiesConnectedToCapital(initialSetup: Boolean = false) {

--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -879,7 +879,7 @@ class CivilizationInfo : IsPartOfGameInfoSerialization {
 
     fun updateSightAndResources() {
         updateViewableTiles()
-        updateHasActiveGreatWall()
+        updateHasActiveEnemyMovementPenalty()
         updateDetailedCivResources()
     }
 
@@ -889,7 +889,7 @@ class CivilizationInfo : IsPartOfGameInfoSerialization {
 
     // implementation in a separate class, to not clog up CivInfo
     fun initialSetCitiesConnectedToCapitalTransients() = transients().updateCitiesConnectedToCapital(true)
-    fun updateHasActiveGreatWall() = transients().updateHasActiveGreatWall()
+    fun updateHasActiveEnemyMovementPenalty() = transients().updateHasActiveEnemyMovementPenalty()
     fun updateViewableTiles() = transients().updateViewableTiles()
     fun updateDetailedCivResources() = transients().updateCivResources()
 
@@ -992,7 +992,7 @@ class CivilizationInfo : IsPartOfGameInfoSerialization {
         goldenAges.endTurn(getHappiness())
         getCivUnits().forEach { it.endTurn() }  // This is the most expensive part of endTurn
         diplomacy.values.toList().forEach { it.nextTurn() } // we copy the diplomacy values so if it changes in-loop we won't crash
-        updateHasActiveGreatWall()
+        updateHasActiveEnemyMovementPenalty()
 
         cachedMilitaryMight = -1    // Reset so we don't use a value from a previous turn
     }

--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -105,7 +105,7 @@ class CivilizationInfo : IsPartOfGameInfoSerialization {
 
     /** This is for performance since every movement calculation depends on this, see MapUnit comment */
     @Transient
-    var hasActiveGreatWall = false
+    var hasActiveEnemyMovementPenalty = false
 
     @Transient
     var statsForNextTurn = Stats()
@@ -669,6 +669,18 @@ class CivilizationInfo : IsPartOfGameInfoSerialization {
             ?: return false // not encountered yet
         if (otherCiv.isCityState() && diplomacyManager.diplomaticStatus != DiplomaticStatus.War) return true
         return diplomacyManager.hasOpenBorders
+    }
+
+    fun getEnemyMovementPenalty(enemyUnit: MapUnit): Float {
+        val greatWallUnique = getMatchingUniques(UniqueType.EnemyLandUnitsSpendExtraMovement)
+        if (greatWallUnique.any())
+            return greatWallUnique.filter { enemyUnit.matchesFilter(it.params[0]) }
+                .sumOf { it.params[1].toInt() }.toFloat()
+
+        val depreciatedGreatWall = getMatchingUniques(UniqueType.EnemyLandUnitsSpendExtraMovementDepreciated)
+        if (depreciatedGreatWall.any() && enemyUnit.matchesFilter("Land"))
+            return depreciatedGreatWall.count().toFloat() // always 1 per entry
+        return 0f // should not reach this point
     }
 
     /**

--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -676,7 +676,7 @@ class CivilizationInfo : IsPartOfGameInfoSerialization {
         return diplomacyManager.hasOpenBorders
     }
 
-    fun getEnemyMovementPenalty(enemyUnit: MapUnit): Float {
+    fun getEnemyMovementPenalty(enemyUnit: MapUnit, toMoveTo: TileInfo): Float {
         if (enemyMovementPenaltyUniques != null && enemyMovementPenaltyUniques!!.any()) {
             return enemyMovementPenaltyUniques!!.sumOf {
                 when (it.type!!) {
@@ -686,8 +686,8 @@ class CivilizationInfo : IsPartOfGameInfoSerialization {
                         else 0 // doesn't match
                     }
                     UniqueType.EnemyLandUnitsSpendExtraMovementDepreciated -> {
-                        if (enemyUnit.baseUnit.isLandUnit()) {
-                            1 // depreciated unique only works on land units
+                        if (toMoveTo.isLand) {
+                            1 // depreciated unique only works on land tiles
                         } else 0
                     }
                     else -> 0

--- a/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
+++ b/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
@@ -36,7 +36,7 @@ class UnitMovementAlgorithms(val unit: MapUnit) {
             toOwner != null &&
             toOwner.hasActiveEnemyMovementPenalty &&
             civInfo.isAtWarWith(toOwner)
-        ) toOwner.getEnemyMovementPenalty(unit) else 0f
+        ) toOwner.getEnemyMovementPenalty(unit, to) else 0f
 
         if (from.roadStatus == RoadStatus.Railroad && to.roadStatus == RoadStatus.Railroad)
             return RoadStatus.Railroad.movement + extraCost

--- a/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
+++ b/core/src/com/unciv/logic/map/UnitMovementAlgorithms.kt
@@ -34,10 +34,9 @@ class UnitMovementAlgorithms(val unit: MapUnit) {
         val toOwner = to.getOwner()
         val extraCost = if (
             toOwner != null &&
-            to.isLand &&
-            toOwner.hasActiveGreatWall &&
+            toOwner.hasActiveEnemyMovementPenalty &&
             civInfo.isAtWarWith(toOwner)
-        ) 1f else 0f
+        ) toOwner.getEnemyMovementPenalty(unit) else 0f
 
         if (from.roadStatus == RoadStatus.Railroad && to.roadStatus == RoadStatus.Railroad)
             return RoadStatus.Railroad.movement + extraCost

--- a/core/src/com/unciv/models/ruleset/Building.kt
+++ b/core/src/com/unciv/models/ruleset/Building.kt
@@ -666,7 +666,8 @@ class Building : RulesetStatsObject(), INonPerpetualConstruction {
         for (unique in uniqueObjects)
             UniqueTriggerActivation.triggerCivwideUnique(unique, civInfo, cityConstructions.cityInfo)
 
-        if ("Enemy land units must spend 1 extra movement point when inside your territory (obsolete upon Dynamite)" in uniques)
+        if (hasUnique(UniqueType.EnemyLandUnitsSpendExtraMovement)
+                || hasUnique(UniqueType.EnemyLandUnitsSpendExtraMovementDepreciated))
             civInfo.updateHasActiveGreatWall()
 
         // Korean unique - apparently gives the same as the research agreement

--- a/core/src/com/unciv/models/ruleset/Building.kt
+++ b/core/src/com/unciv/models/ruleset/Building.kt
@@ -668,7 +668,7 @@ class Building : RulesetStatsObject(), INonPerpetualConstruction {
 
         if (hasUnique(UniqueType.EnemyLandUnitsSpendExtraMovement)
                 || hasUnique(UniqueType.EnemyLandUnitsSpendExtraMovementDepreciated))
-            civInfo.updateHasActiveGreatWall()
+            civInfo.updateHasActiveEnemyMovementPenalty()
 
         // Korean unique - apparently gives the same as the research agreement
         if (science > 0 && civInfo.hasUnique(UniqueType.TechBoostWhenScientificBuildingsBuiltInCapital))

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -215,7 +215,9 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
     DoubleHappinessFromNaturalWonders("Double Happiness from Natural Wonders", UniqueTarget.Global),
 
     EnablesConstructionOfSpaceshipParts("Enables construction of Spaceship parts", UniqueTarget.Global),
-    EnemyLandUnitsSpendExtraMovement("Enemy land units must spend 1 extra movement point when inside your territory (obsolete upon Dynamite)", UniqueTarget.Global),
+    EnemyLandUnitsSpendExtraMovement("Enemy [mapUnitFilter] units must spend [amount] extra movement points when inside your territory", UniqueTarget.Global),
+    @Deprecated("As of 4.2.4", ReplaceWith("Enemy [Land] units must spend [1] extra movement points when inside your territory <before discovering [Dynamite]>"))
+    EnemyLandUnitsSpendExtraMovementDepreciated("Enemy land units must spend 1 extra movement point when inside your territory (obsolete upon Dynamite)", UniqueTarget.Global),
 
     @Deprecated("s of 4.1.14", ReplaceWith("Production to [Science] conversion in cities changed by [33]%"))
     ProductionToScienceConversionBonus("Production to science conversion in cities increased by 33%", UniqueTarget.Global),


### PR DESCRIPTION
Greatly increases flexibility of this unique since even the obsolete tech was hardcoded.
* Change Great Wall unique from `Enemy land units must spend 1 extra movement point when inside your territory (obsolete upon Dynamite)` to `Enemy [Land] units must spend [1] extra movement points when inside your territory <before discovering [Dynamite]>`
* Rename `CivilizationInfo.hasActiveGreatWall` to a more general `CivilizationInfo.hasActiveEnemyMovementPenalty` to help accommodate any future uniques with similar effects
* Rename a few other functions accordingly