### PR TITLE
Fix "1.5x unhappiness" still being mentioned

### DIFF
--- a/core/src/com/unciv/ui/worldscreen/AlertPopup.kt
+++ b/core/src/com/unciv/ui/worldscreen/AlertPopup.kt
@@ -394,7 +394,7 @@ class AlertPopup(val worldScreen: WorldScreen, val popupAlert: PopupAlert): Popu
         button.onActivation { puppetAction() }
         button.keyShortcuts.add('p')
         add(button).row()
-        addGoodSizedLabel("Puppeted cities do not increase your tech or policy cost, but their citizens generate 1.5x the regular unhappiness.").row()
+        addGoodSizedLabel("Puppeted cities do not increase your tech or policy cost.").row()
         addGoodSizedLabel("You have no control over the the production of puppeted cities.").row()
         addGoodSizedLabel("Puppeted cities also generate 25% less Gold and Science.").row()
         addGoodSizedLabel("A puppeted city can be annexed at any time.").row()


### PR DESCRIPTION
Fix "`but their citizens generate 1.5x the regular unhappiness`" still being mentioned when conquering a city, in the pop-up giving the choice to the player to either annex/puppet/raze the city.

![puppet](https://user-images.githubusercontent.com/11946570/184745222-c5c3c758-2173-486c-95bb-83f9b717338f.png)

Follows #7420 , which removed this mention in the stringtables only.

