### PR TITLE
add a new row for error label

### DIFF
--- a/core/src/com/unciv/ui/popup/AskNumberPopup.kt
+++ b/core/src/com/unciv/ui/popup/AskNumberPopup.kt
@@ -126,7 +126,7 @@ class AskNumberPopup(
             }
         ) {
             actionOnOk(nameField.text.toInt())
-        }
+        }.row()
         equalizeLastTwoButtonWidths()
 
         keyboardFocus = nameField

--- a/core/src/com/unciv/ui/popup/AskTextPopup.kt
+++ b/core/src/com/unciv/ui/popup/AskTextPopup.kt
@@ -58,7 +58,7 @@ class AskTextPopup(
             }
         ) {
             actionOnOk(nameField.text)
-        }
+        }.row()
         equalizeLastTwoButtonWidths()
         keyboardFocus = nameField
     }


### PR DESCRIPTION
Closes #7678. This pull request adds a new row for error label in `AskTextPopup` and `AskNumberPopup`.

**Screenshots for fixed version**
![Screenshot_20220819_185412_com unciv clone](https://user-images.githubusercontent.com/64761703/185604001-8126239a-8c15-477e-aa19-73d8eec80ddc.jpg)
![Screenshot_20220819_185508_com unciv clone](https://user-images.githubusercontent.com/64761703/185604016-35f8b0cc-17c5-4a21-9399-0185711ba200.jpg)
