### PR TITLE
Suggest to adopt policy when the game starts with some culture

### DIFF
--- a/core/src/com/unciv/logic/city/CityInfo.kt
+++ b/core/src/com/unciv/logic/city/CityInfo.kt
@@ -163,7 +163,11 @@ class CityInfo : IsPartOfGameInfoSerialization {
         ) ?: "City Without A Name"
 
         isOriginalCapital = civInfo.citiesCreated == 0
-        if (isOriginalCapital) civInfo.hasEverOwnedOriginalCapital = true
+        if (isOriginalCapital) {
+            civInfo.hasEverOwnedOriginalCapital = true
+            // if you have some culture before the 1st city is found, you may want to adopt the 1st policy
+            civInfo.policies.shouldOpenPolicyPicker = true
+        }
         civInfo.citiesCreated++
 
         civInfo.cities = civInfo.cities.toMutableList().apply { add(this@CityInfo) }


### PR DESCRIPTION
**Problem:**
When you start with Era higher than Ancient, usually you get some culture to adopt the 1st policy.
However, you may notice that you could adopt the policy on the very 1st turn only in several turns later.
**Fix:**
Now you get your regular prompt "Pick a policy" as soon as you found your 1st city and have enough culture to adopt.
If you start the game in the Ancient Era with no cuture, you will not get the prompt because `canAdoptPolicy()` still returns `False`.