### PR TITLE
Enable the "adopt policy" button properly

### DIFF
--- a/core/src/com/unciv/ui/utils/extensions/Scene2dExtensions.kt
+++ b/core/src/com/unciv/ui/utils/extensions/Scene2dExtensions.kt
@@ -46,12 +46,14 @@ private class RestorableTextButtonStyle(
     baseStyle: TextButtonStyle,
     val restoreStyle: ButtonStyle
 ) : TextButtonStyle(baseStyle)
+
 /** Disable a [Button] by setting its [touchable][Button.touchable] and [color][Button.color] properties. */
 fun Button.disable() {
-    touchable= Touchable.disabled
+    touchable = Touchable.disabled
     val oldStyle = style
     val disabledStyle = BaseScreen.skin.get("disabled", TextButtonStyle::class.java)
-    style = RestorableTextButtonStyle(disabledStyle, oldStyle)
+    if (oldStyle !is RestorableTextButtonStyle)
+        style = RestorableTextButtonStyle(disabledStyle, oldStyle)
 }
 /** Enable a [Button] by setting its [touchable][Button.touchable] and [color][Button.color] properties. */
 fun Button.enable() {


### PR DESCRIPTION
**Problem:**
1. Open the policy window to adopt a policy. 
2. Click 5 times on the disabled policies. 

The "Adopt policy" button is disabled - that's expected. However, now you need to click 6 times (!) on the enabled policies to get it enabled back. See the video.

https://user-images.githubusercontent.com/27405436/185746458-97676c84-9a70-4a49-856f-1be4a4baff4b.mp4

**Fix:**
The problem has appeared in PR #7207 (e41cd57b42b26d0817864b1b0b1d84684b538e17) and while I am not sure I understand the problem the author has tried to solve I put a simple check to avoid a reassignment instead of reverting the change as a whole. Seems to be working but need some testing though, probably, it does not fix all corner cases I can imagine.

https://user-images.githubusercontent.com/27405436/185746868-35962fdd-593a-40b9-8ed5-d3e8f35a71a9.mp4


