### PR TITLE
Fix unit not giftable in one-sided open borders agreement

### DIFF
--- a/core/src/com/unciv/logic/map/TileInfo.kt
+++ b/core/src/com/unciv/logic/map/TileInfo.kt
@@ -253,7 +253,7 @@ open class TileInfo : IsPartOfGameInfoSerialization {
             tileOwner == null -> false
             tileOwner == civInfo -> true
             !civInfo.knows(tileOwner) -> false
-            else -> tileOwner.getDiplomacyManager(civInfo).isConsideredFriendlyTerritory()
+            else -> civInfo.getDiplomacyManager(tileOwner).isConsideredFriendlyTerritory()
         }
     }
 


### PR DESCRIPTION
Changed isFriendlyTerritory(CivilizationInfo) function to check the active civ's DiplomacyManager against the tileOwner civ, instead of the other way around. This makes sense because we want to see if the tileOwner has opened their borders, not if the requesting civ has opened borders with the tileOwner. This appears to resolve the issue where a unit can't be gifted to the TileOwner if only the tile owner has opened their borders. Issue #7673

I have tested all other calls of the isFriendlyTerritory function, and everything is functioning as expected.