### PR TITLE
fix: lateinit property cityInfo has not been initialized issue.

### DIFF
--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -491,7 +491,12 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
 
         for (religion in religions.values) religion.setTransients(this)
 
-        for (civInfo in civilizations) civInfo.setTransients()
+        civilizations.forEach { civInfo ->
+            civInfo.setTransients()
+        }
+        civilizations.forEach { civInfo ->
+            civInfo.thingsToFocusOnForVictory = civInfo.getPreferredVictoryTypeObject()?.getThingsToFocus(civInfo) ?: setOf()
+        }
 
         convertFortify()
 

--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -491,11 +491,10 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
 
         for (religion in religions.values) religion.setTransients(this)
 
-        civilizations.forEach { civInfo ->
-            civInfo.setTransients()
-        }
-        civilizations.forEach { civInfo ->
-            civInfo.thingsToFocusOnForVictory = civInfo.getPreferredVictoryTypeObject()?.getThingsToFocus(civInfo) ?: setOf()
+        for (civInfo in civilizations) civInfo.setTransients()
+        for (civInfo in civilizations) {
+            civInfo.thingsToFocusOnForVictory =
+                    civInfo.getPreferredVictoryTypeObject()?.getThingsToFocus(civInfo) ?: setOf()
         }
 
         convertFortify()

--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -839,8 +839,6 @@ class CivilizationInfo : IsPartOfGameInfoSerialization {
 
         victoryManager.civInfo = this
 
-        thingsToFocusOnForVictory = getPreferredVictoryTypeObject()?.getThingsToFocus(this) ?: setOf()
-
         for (cityInfo in cities) {
             cityInfo.civInfo = this // must be before the city's setTransients because it depends on the tilemap, that comes from the currentPlayerCivInfo
             cityInfo.setTransients()


### PR DESCRIPTION
solve issue: #7717 

1. 
The var `cityInfo` is not initial properly in `CityReligionManager` class. Here is Exception stack:
<img width="1394" alt="截圖 2022-09-03 下午6 40 16" src="https://user-images.githubusercontent.com/17497074/188267780-8351bba5-26ab-4aca-bc9e-a87b77ef147b.png">



And I go to file `CivilizationInfo.kt:847`, we can found that `cityInfo.civInfo = this`(line 485) should be executed before `thingsToFocusOnForVictory = civInfo.getPreferredVictoryTypeObject()?.get...`. Thus, i exchanged the order.
<img width="1376" alt="截圖 2022-09-03 下午6 46 06" src="https://user-images.githubusercontent.com/17497074/188267528-1a277f8b-8d10-40e1-aff5-85a026c7e0d0.png">


2. After I finished step 1, it occurred a new exception: The var `cityInfo` is not initial properly in `ReligionManager` class.
<img width="1389" alt="截圖 2022-09-03 下午6 50 34" src="https://user-images.githubusercontent.com/17497074/188267865-5b558041-fe48-4606-acb1-6eb5478b6ce1.png">

`ReligionManager.isMajorityReligionForCiv(ReligionManager.kt:83)` will use **ALL** `civInfo`

But, `GameInfo.setTransients(GameInfo.kt:494)` will trigger `CivilizationInfo.setTransients` **iteratively**, in this function will init `ReligionManager.cityInfo`


<img width="1392" alt="截圖 2022-09-03 下午6 55 29" src="https://user-images.githubusercontent.com/17497074/188268319-5852429a-2209-48dd-8692-abe4ae814a6e.png">

<img width="1402" alt="截圖 2022-09-03 下午6 54 11" src="https://user-images.githubusercontent.com/17497074/188268128-376ff45f-776e-476f-8430-72f5d0b0b28d.png">

Hence, i initialize var `thingsToFocusOnForVictory` after ALL `CivilizationInfo.setTransients` has been invoke. 

Anyone is welcome to suggest prettier approach to solve this issue. 