### PR TITLE
Add "UI Skin" in template.properties

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -1322,6 +1322,7 @@ Missing translations: =
 Version = 
 Resolution = 
 Tileset = 
+UI Skin = 
 Create = 
 Language = 
 Improvements = 


### PR DESCRIPTION
"UI Skin" is missing in template.properties, hence not added to translation files.

Before:
![before](https://user-images.githubusercontent.com/11946570/188510164-453ffbe0-533b-4524-9680-c46e852aa61c.png)

After:
![after](https://user-images.githubusercontent.com/11946570/188510180-52945b3c-6c10-4d86-b366-ea28b42941cf.png)

