### PR TITLE
Fixed UI bugs in portrait mode

### DIFF
--- a/core/src/com/unciv/ui/worldscreen/BackgroundActor.kt
+++ b/core/src/com/unciv/ui/worldscreen/BackgroundActor.kt
@@ -1,8 +1,6 @@
 package com.unciv.ui.worldscreen
 
-import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.graphics.g2d.Batch
-import com.badlogic.gdx.graphics.g2d.NinePatch
 import com.badlogic.gdx.scenes.scene2d.Actor
 import com.badlogic.gdx.scenes.scene2d.Touchable
 import com.badlogic.gdx.scenes.scene2d.utils.Drawable
@@ -11,7 +9,7 @@ import com.badlogic.gdx.utils.Align
 import com.unciv.ui.images.ImageGetter
 
 /** An Actor that just draws a Drawable [background], preferably a [NinePatchDrawable] created
- *  by [BackgroundActor.getRoundedEdgeRectangle], meant to work in Table Cells and to be overlaid with other Widgets.
+ *  by [ImageGetter.getRoundedEdgeRectangle], meant to work in Table Cells and to be overlaid with other Widgets.
  *  The drawable's center can be moved to any of the corners or vertex centers using `align`, which will also scale the
  *  drawable up by factor 2 and clip to the original rectangle. This can be used to draw rectangles with one or two rounded corners.
  *  @param align An [Align] constant - In which corner of the [BackgroundActor] rectangle the center of the [background] should be.
@@ -48,14 +46,5 @@ class BackgroundActor(val background: Drawable, align: Int) : Actor() {
         val color = color
         batch.setColor(color.r, color.g, color.b, color.a * parentAlpha)
         background.draw(batch, x, y, w, h)
-    }
-
-    companion object {
-        fun getRoundedEdgeRectangle(tintColor: Color): NinePatchDrawable {
-            val region = ImageGetter.getDrawable("Skin/roundedEdgeRectangle").region
-            val drawable = NinePatchDrawable(NinePatch(region, 25, 25, 24, 24))
-            drawable.setPadding(15f, 15f, 15f, 15f)
-            return drawable.tint(tintColor)
-        }
     }
 }

--- a/core/src/com/unciv/ui/worldscreen/WorldScreenTopBar.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreenTopBar.kt
@@ -81,10 +81,10 @@ class WorldScreenTopBar(val worldScreen: WorldScreen) : Table() {
         resourceTable.background = backgroundDrawable
         add(statsTable).colspan(3).growX().row()
         add(resourceTable).colspan(3).growX().row()
-        val leftFillerBG = BackgroundActor.getRoundedEdgeRectangle(backColor)
+        val leftFillerBG = ImageGetter.getRoundedEdgeRectangle(backColor)
         leftFillerCell = add(BackgroundActor(leftFillerBG, Align.topLeft))
         add().growX()
-        val rightFillerBG = BackgroundActor.getRoundedEdgeRectangle(backColor)
+        val rightFillerBG = ImageGetter.getRoundedEdgeRectangle(backColor)
         rightFillerCell = add(BackgroundActor(rightFillerBG, Align.topRight))
         pack()
     }


### PR DESCRIPTION
In #7714 I did not realize that the BackgroundActor has its own `getRoundedEdgeRectangle` function. 
I've just removed it now as it isn't useful for the moddable UI anyway.

<details>
<summary>Before #7714</summary>
<br>

![before](https://user-images.githubusercontent.com/24532072/188667675-2be00ccf-ad19-4dae-8420-e6ea965aa310.png)
</details>

<details>
<summary>After #7714</summary>
<br>

![after](https://user-images.githubusercontent.com/24532072/188667783-42240a78-7751-441e-86e0-9f60f52706fd.png)
</details>

<details>
<summary>Now</summary>
<br>

![now](https://user-images.githubusercontent.com/24532072/188667821-5f86eb6d-b6ab-4c41-b4ae-15d771f02b74.PNG)
</details>