### PR TITLE
AI: Recognize when no further techs can be researched, even if some techs are blocked

### DIFF
--- a/core/src/com/unciv/logic/automation/city/ConstructionAutomation.kt
+++ b/core/src/com/unciv/logic/automation/city/ConstructionAutomation.kt
@@ -32,7 +32,8 @@ class ConstructionAutomation(val cityConstructions: CityConstructions){
     private val militaryUnits = civUnits.count { it.baseUnit.isMilitary() }
     private val workers = civUnits.count { it.hasUniqueToBuildImprovements && it.isCivilian() }.toFloat()
     private val cities = civInfo.cities.size
-    private val allTechsAreResearched = civInfo.tech.getNumberOfTechsResearched() >= civInfo.gameInfo.ruleSet.technologies.size
+    private val allTechsAreResearched = civInfo.gameInfo.ruleSet.technologies.values
+        .all { civInfo.tech.isResearched(it.name) || !civInfo.tech.canBeResearched(it.name)}
 
     private val isAtWar = civInfo.isAtWar()
     private val buildingsForVictory = civInfo.gameInfo.getEnabledVictories().values


### PR DESCRIPTION
We allow mods to block techs for certain civs by policies, other techs, or simply restricted to certain civs
Our construction automation takes into account when all techs have been researched to deprioritize science buildings and production. This *was* only affected when *all* techs were researched, and is now affected when the current civ cannot research any new techs, taking the 'tech restriction' into consideration.

Resolves #7530 