### PR TITLE
fix: double unit while load game from customFile.

### DIFF
--- a/core/src/com/unciv/logic/UncivFiles.kt
+++ b/core/src/com/unciv/logic/UncivFiles.kt
@@ -276,7 +276,6 @@ class UncivFiles(
             try {
                 val gameInfo = gameInfoFromString(gameData)
                 gameInfo.customSaveLocation = location
-                gameInfo.setTransients()
                 loadCompletionCallback(CustomLoadResult(location to gameInfo))
             } catch (ex: Exception) {
                 loadCompletionCallback(CustomLoadResult(exception = ex))


### PR DESCRIPTION
### Issue:

  ALL unit will display double after load game form costum location.  (loading from autosave / clipboard are fine)

<img width="1552" alt="截圖 2022-09-09 下午6 02 36" src="https://user-images.githubusercontent.com/17497074/189328595-bf16cd5e-0a87-4551-8919-1b072cc2fee2.png">

<img width="1552" alt="截圖 2022-09-09 下午6 26 49" src="https://user-images.githubusercontent.com/17497074/189329988-afcedc6f-0900-423c-a436-58c079d2cdeb.png">


### steps:
1. Start a new game and build a city, there is only one unit exit on the map.
2. Save game to custom location.
3. load game from custom location.

### save data:
[Russia - 1turn.txt](https://github.com/yairm210/Unciv/files/9534474/Aztecs.-.1turn.txt)

### Solution:

In `UncivFiles.gameInfoFromString(gameData: String)`, line 359, will invoke function `gameInfo.setTransients()`
But, the func `loadGameFromCustomLocation` will trigger `gameInfo.setTransients()` again at line 279.
So, just remove it.