### PR TITLE
Solve CS placement clustering

### DIFF
--- a/core/src/com/unciv/logic/map/mapgenerator/MapRegions.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/MapRegions.kt
@@ -987,7 +987,7 @@ class MapRegions (val ruleset: Ruleset){
                 if (!canPlaceMinorCiv(tile)) continue
                 val continent = tile.getContinent()
                 if (continent in uninhabitedContinents) {
-                    if(tile.isCoastalTile())
+                    if (tile.isCoastalTile())
                         uninhabitedCoastal.add(tile)
                     else
                         uninhabitedHinterland.add(tile)
@@ -1031,17 +1031,17 @@ class MapRegions (val ruleset: Ruleset){
                     it.assignedMinorCivs.add(civToAssign)
                 }
             }
+        }
 
-            // STILL unassigned civs??
-            if (unassignedCivs.isNotEmpty()) {
-                // At this point there is at least for sure less remaining city states than regions
-                // Sort regions by fertility and put extra city states in the worst ones.
-                val worstRegions = regions.sortedBy { it.totalFertility }.take(unassignedCivs.size)
-                worstRegions.forEach {
-                    val civToAssign = unassignedCivs.first()
-                    unassignedCivs.remove(civToAssign)
-                    it.assignedMinorCivs.add(civToAssign)
-                }
+        // STILL unassigned civs??
+        if (unassignedCivs.isNotEmpty()) {
+            // At this point there is at least for sure less remaining city states than regions
+            // Sort regions by fertility and put extra city states in the worst ones.
+            val worstRegions = regions.sortedBy { it.totalFertility }.take(unassignedCivs.size)
+            worstRegions.forEach {
+                val civToAssign = unassignedCivs.first()
+                unassignedCivs.remove(civToAssign)
+                it.assignedMinorCivs.add(civToAssign)
             }
         }
 
@@ -1053,86 +1053,10 @@ class MapRegions (val ruleset: Ruleset){
         for (unplacedCiv in civAssignedToUninhabited) {
             regions.random().assignedMinorCivs.add(unplacedCiv)
         }
-        // Fallback lists for minor civs that can't be placed with any other method
-        val fallbackTiles = ArrayList<TileInfo>()
-        val fallbackMinors = ArrayList<CivilizationInfo>()
 
         // Now place the ones assigned to specific regions.
         for (region in regions) {
-            // Check the outer edges of the region, working inwards
-            val section = Rectangle(region.rect)
-            val unprocessedTiles = ArrayList<TileInfo>()
-            val regionCoastal = ArrayList<TileInfo>()
-            val regionHinterland = ArrayList<TileInfo>()
-            while (section.width >= 4 && section.height >= 4 && region.assignedMinorCivs.isNotEmpty()) {
-                // Clear the tile lists
-                unprocessedTiles.clear()
-                regionCoastal.clear()
-                regionHinterland.clear()
-                if (section.height > section.width) {
-                    // Check top and bottom
-                    unprocessedTiles.addAll(
-                            tileMap.getTilesInRectangle(
-                                    Rectangle(section.x, section.y, section.width, 1f),
-                                    evenQ = true)
-                    )
-                    unprocessedTiles.addAll(
-                            tileMap.getTilesInRectangle(
-                                    Rectangle(section.x, section.y + section.height - 1, section.width, 1f),
-                                    evenQ = true)
-                    )
-                    // Narrow the remaining section
-                    section.y += 1
-                    section.height -= 2
-                } else {
-                    // Check left and right
-                    unprocessedTiles.addAll(
-                            tileMap.getTilesInRectangle(
-                                    Rectangle(section.x, section.y, 1f, section.height),
-                                    evenQ = true)
-                    )
-                    unprocessedTiles.addAll(
-                            tileMap.getTilesInRectangle(
-                                    Rectangle(section.x + section.width - 1, section.y, 1f, section.height),
-                                    evenQ = true)
-                    )
-                    // Narrow the remaining section
-                    section.x += 1
-                    section.width -= 2
-                }
-                // Now process the tiles
-                for (tile in unprocessedTiles) {
-                    if (!canPlaceMinorCiv(tile)) continue
-                    if (!usingArchipelagoRegions && tile.getContinent() != region.continentID) continue
-                    if(tile.isCoastalTile())
-                        regionCoastal.add(tile)
-                    else
-                        regionHinterland.add(tile)
-                }
-                // Now attempt to place as many minor civs as possible, trying coastal tiles first
-                tryPlaceMinorCivsInTiles(region.assignedMinorCivs, tileMap, regionCoastal)
-                tryPlaceMinorCivsInTiles(region.assignedMinorCivs, tileMap, regionHinterland)
-            }
-            // In case we went through the entire region without finding spots for all assigned civs
-            if(region.assignedMinorCivs.isNotEmpty()) {
-                fallbackMinors.addAll(region.assignedMinorCivs)
-            } else {
-                // If we did find spots for all civs, there might be more eligible tiles left in the region
-                // Add them to the fallback list
-                fallbackTiles.addAll(regionCoastal)
-                fallbackTiles.addAll(regionHinterland)
-                fallbackTiles.addAll(tileMap.getTilesInRectangle(section, evenQ = true)
-                        .filter { canPlaceMinorCiv(it) }
-                )
-            }
-        }
-
-        // Finally attempt to place the fallback lists - the rest will be silently discarded
-        if (fallbackMinors.isNotEmpty()) {
-            // Throw in the uninhabited lists as well
-            fallbackTiles.addAll(uninhabitedCoastal)
-            fallbackTiles.addAll(uninhabitedHinterland)
-            tryPlaceMinorCivsInTiles(fallbackMinors, tileMap, fallbackTiles)
+            tryPlaceMinorCivsInTiles(region.assignedMinorCivs, tileMap, region.tiles.toMutableList())
         }
     }
 


### PR DESCRIPTION
Current code places major civs in the center of regions, and CS states on the edges of regions,
This leads to the unfortunate effect of having large swathes of CS-lands, as far away from the major civs as possible, with ring patterns if the number of Civs is small and the number of CSs is large.

Examples:
![image](https://user-images.githubusercontent.com/8366208/189518133-227094b6-be33-4224-98a0-d209c25c9cf1.png)
![image](https://user-images.githubusercontent.com/8366208/189517901-ca98caf7-3eb4-4396-838f-5102ac5b31f1.png)
![image](https://user-images.githubusercontent.com/8366208/189517910-9d6ccafc-73b1-4b73-a48e-7a8c6ce44f37.png)
![image](https://user-images.githubusercontent.com/8366208/189517924-ccd79e50-b64c-4ff7-876a-303aa1c0a59a.png)
![image](https://user-images.githubusercontent.com/8366208/189517937-f03f0c81-24d1-44f8-a214-82e7456e3982.png)
![image](https://user-images.githubusercontent.com/8366208/189517942-401c0baa-d1a9-48ef-9918-d0cfc6b4faf9.png)

ETC

This PR simplifies the CS placement logic to have them scattered randomly across regions, after they have been sorted into regions (that part is untouched), leading to major civs being relatively equidistant from each other, with CSs scattered in later to leave cities scattered in a relatively spaced-out manner, like so (same generation parameters as first of the above images).

2 major civs, 12 CSs:
![image](https://user-images.githubusercontent.com/8366208/189518028-9eff783e-cd3e-4569-9c7f-0eb5a1482360.png)
![image](https://user-images.githubusercontent.com/8366208/189518043-e9182830-7fd4-42de-9602-63c86b8ee458.png)

And with 4 major civs:
![image](https://user-images.githubusercontent.com/8366208/189518062-fa0124f2-68fe-4a34-8a3d-51861cb46a77.png)
![image](https://user-images.githubusercontent.com/8366208/189518071-00dac6b5-6d9a-477c-8ce1-57df61faa98a.png)
