### PR TITLE
fix no victoryTypes for the first time gaming with "quick game" opion.

### DIFF
--- a/core/src/com/unciv/MainMenuScreen.kt
+++ b/core/src/com/unciv/MainMenuScreen.kt
@@ -227,7 +227,13 @@ class MainMenuScreen: BaseScreen(), RecreateOnResize {
             val newGame: GameInfo
             // Can fail when starting the game...
             try {
-                newGame = GameStarter.startNewGame(GameSetupInfo.fromSettings("Chieftain"))
+                val gameInfo = GameSetupInfo.fromSettings("Chieftain")
+                if (gameInfo.gameParameters.victoryTypes.isEmpty()) {
+                    val ruleSet = RulesetCache.getComplexRuleset(gameInfo.gameParameters)
+                    gameInfo.gameParameters.victoryTypes.addAll(ruleSet.victories.keys)
+                }
+                newGame = GameStarter.startNewGame(gameInfo)
+
             } catch (notAPlayer: UncivShowableException) {
                 val (message) = LoadGameScreen.getLoadExceptionMessage(notAPlayer)
                 launchOnGLThread { ToastPopup(message, this@MainMenuScreen) }


### PR DESCRIPTION
fix #7775


## Reproduce:
1. remove "assets/GameSettings.json"
2. build APP
3. click quick start

(Or clear app file on android device, and click "quick game" immediately after opening the app)

## Reason

`GameSetupInfo.kt` line 26
```
        fun fromSettings(defaultDifficulty: String? = null) = UncivGame.Current.settings.run {
            if (lastGameSetup == null) GameSetupInfo().apply {  
                ...
            }...

```
For the first time, there is no "GameSettings.json" file, `lastGameSetup` must be null.
Thus, `gameInfo.gameParameters.victoryTypes` is an empty `arrayList`. (GameParameters.kt:line34)