### PR TITLE
Starting in later eras triggers era uniques in all previous eras

### DIFF
--- a/core/src/com/unciv/logic/GameStarter.kt
+++ b/core/src/com/unciv/logic/GameStarter.kt
@@ -88,6 +88,11 @@ object GameStarter {
                     }
         }
 
+        if (tileMap.continentSizes.isEmpty())   // Probably saved map without continent data
+            runAndMeasure("assignContinents") {
+                tileMap.assignContinents(TileMap.AssignContinentsMode.Ensure)
+            }
+
         runAndMeasure("setTransients") {
             tileMap.setTransients(ruleset) // if we're starting from a map with pre-placed units, they need the civs to exist first
             tileMap.setStartingLocationsTransients()
@@ -97,24 +102,20 @@ object GameStarter {
             gameInfo.setTransients() // needs to be before placeBarbarianUnit because it depends on the tilemap having its gameInfo set
         }
 
-        runAndMeasure("Techs and Stats") {
-            addCivTechs(gameInfo, ruleset, gameSetupInfo)
-
-            addCivStats(gameInfo)
+        runAndMeasure("addCivStartingUnits") {
+            addCivStartingUnits(gameInfo)
         }
 
         runAndMeasure("Policies") {
             addCivPolicies(gameInfo, ruleset)
         }
 
-        if (tileMap.continentSizes.isEmpty())   // Probably saved map without continent data
-            runAndMeasure("assignContinents") {
-                tileMap.assignContinents(TileMap.AssignContinentsMode.Ensure)
-            }
+        runAndMeasure("Techs and Stats") {
+            addCivTechs(gameInfo, ruleset, gameSetupInfo)
+        }
 
-        runAndMeasure("addCivStartingUnits") {
-            // and only now do we add units for everyone, because otherwise both the gameInfo.setTransients() and the placeUnit will both add the unit to the civ's unit list!
-            addCivStartingUnits(gameInfo)
+        runAndMeasure("Starting stats") {
+            addCivStats(gameInfo)
         }
 
         // remove starting locations once we're done

--- a/core/src/com/unciv/logic/civilization/TechManager.kt
+++ b/core/src/com/unciv/logic/civilization/TechManager.kt
@@ -333,9 +333,12 @@ class TechManager : IsPartOfGameInfoSerialization {
                 civInfo.addNotification("[" + policyBranch.name + "] policy branch unlocked!", NotificationIcon.Culture)
             }
             // Note that if you somehow skip over an era, its uniques aren't triggered
-            for (unique in currentEra.uniqueObjects) {
-                UniqueTriggerActivation.triggerCivwideUnique(unique, civInfo)
-            }
+            val erasPassed = getRuleset().eras.values
+                .filter { it.eraNumber > previousEra.eraNumber && it.eraNumber <= currentEra.eraNumber }
+                .sortedBy { it.eraNumber }
+            for (era in erasPassed)
+                for (unique in era.uniqueObjects)
+                    UniqueTriggerActivation.triggerCivwideUnique(unique, civInfo)
         }
     }
 

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -26,7 +26,7 @@ object UniqueTriggerActivation {
         tile: TileInfo? = null,
         notification: String? = null
     ): Boolean {
-        val timingConditional = unique.conditionals.firstOrNull{it.type == ConditionalTimedUnique}
+        val timingConditional = unique.conditionals.firstOrNull { it.type == ConditionalTimedUnique }
         if (timingConditional != null) {
             civInfo.temporaryUniques.add(TemporaryUnique(unique, timingConditional.params[0].toInt()))
             return true
@@ -486,6 +486,7 @@ object UniqueTriggerActivation {
                         val spyName = otherCiv.espionageManager.addSpy()
                         otherCiv.espionageManager.erasSpyEarnedFor.add(currentEra)
                         if (otherCiv == civInfo || otherCiv.knows(civInfo))
+                            // We don't tell which civilization entered the new era, as that is done in the notification directly above this one
                             otherCiv.addNotification("We have recruited [${spyName}] as a spy!", NotificationIcon.Spy)
                         else
                             otherCiv.addNotification("After an unknown civilization entered the [${currentEra}], we have recruited [${spyName}] as a spy!", NotificationIcon.Spy)


### PR DESCRIPTION
When we trigger the unique to give spies to civilizations, we only give them to major civilizations that are alive. However, at the start of the game civilizations have no cities, so they are only alive if they have any units. As before this PR the tech of civs was initialized before the units were placed, there would be no units while determining the era of a civ and the subsequent triggering of era uniques. As a result, no civ would get spies. This PR changes this, by first adding the units and only then initializing the tech. As far as I can see, this has no negative side-effects.