### PR TITLE
fix wrong happiness point on resume game if adopt 'Cultural Diplomacy' policy.

### DIFF
--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -499,7 +499,12 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
 
         convertFortify()
 
-        for (civInfo in civilizations) {
+        sequence {
+            // update city-state resource first since the happiness of major civ depends on it.
+            // See issue: https://github.com/yairm210/Unciv/issues/7781
+            yieldAll(civilizations.filter { it.isCityState() })
+            yieldAll(civilizations.filter { !it.isCityState(); it.isMajorCiv() })
+        }.forEach { civInfo ->
             for (unit in civInfo.getCivUnits())
                 unit.updateVisibleTiles(false) // this needs to be done after all the units are assigned to their civs and all other transients are set
             civInfo.updateSightAndResources() // only run ONCE and not for each unit - this is a huge performance saver!

--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -499,12 +499,12 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
 
         convertFortify()
 
-        sequence {
+        for (civInfo in sequence {
             // update city-state resource first since the happiness of major civ depends on it.
             // See issue: https://github.com/yairm210/Unciv/issues/7781
             yieldAll(civilizations.filter { it.isCityState() })
-            yieldAll(civilizations.filter { !it.isCityState(); it.isMajorCiv() })
-        }.forEach { civInfo ->
+            yieldAll(civilizations.filter { it.isMajorCiv() })
+        }) {
             for (unit in civInfo.getCivUnits())
                 unit.updateVisibleTiles(false) // this needs to be done after all the units are assigned to their civs and all other transients are set
             civInfo.updateSightAndResources() // only run ONCE and not for each unit - this is a huge performance saver!


### PR DESCRIPTION
As https://github.com/yairm210/Unciv/issues/7781#issuecomment-1243043600 mentioned, just an order problem.
the resources of all city-state must be updated (`GameInfo.kt:line 510 -> civInfo.updateSightAndResources()`) before calculate the happiness of major civ.