### PR TITLE
Initial Desktop run starts fullscreen

### DIFF
--- a/core/src/com/unciv/logic/UncivFiles.kt
+++ b/core/src/com/unciv/logic/UncivFiles.kt
@@ -311,9 +311,7 @@ class UncivFiles(
             }
         }
 
-        return settings ?: GameSettings().apply {
-            isFreshlyCreated = true
-        }
+        return settings ?: GameSettings().apply { isFreshlyCreated = true }
     }
 
     fun setGeneralSettings(gameSettings: GameSettings) {

--- a/core/src/com/unciv/logic/UncivFiles.kt
+++ b/core/src/com/unciv/logic/UncivFiles.kt
@@ -6,10 +6,8 @@ import com.badlogic.gdx.files.FileHandle
 import com.badlogic.gdx.utils.JsonReader
 import com.badlogic.gdx.utils.SerializationException
 import com.unciv.UncivGame
-import com.unciv.json.fromJsonFile
 import com.unciv.json.json
 import com.unciv.models.metadata.GameSettings
-import com.unciv.models.metadata.WindowState
 import com.unciv.models.metadata.doMigrations
 import com.unciv.models.metadata.isMigrationNecessary
 import com.unciv.ui.saves.Gzip
@@ -18,14 +16,13 @@ import com.unciv.utils.Log
 import com.unciv.utils.concurrency.Concurrency
 import com.unciv.utils.debug
 import kotlinx.coroutines.Job
-import java.awt.Toolkit
 import java.io.File
 import java.io.Writer
 
 private const val SAVE_FILES_FOLDER = "SaveFiles"
 private const val MULTIPLAYER_FILES_FOLDER = "MultiplayerGames"
 private const val AUTOSAVE_FILE_NAME = "Autosave"
-private const val SETTINGS_FILE_NAME = "GameSettings.json"
+const val SETTINGS_FILE_NAME = "GameSettings.json"
 
 class UncivFiles(
     /**
@@ -319,36 +316,7 @@ class UncivFiles(
     }
 
     companion object {
-
         var saveZipped = false
-
-        /** Specialized function to access settings before Gdx is initialized.
-         *
-         * @param base Path to the directory where the file should be - if not set, the OS current directory is used (which is "/" on Android)
-         */
-        fun getSettingsForPlatformLaunchers(base: String = "."): GameSettings {
-            // FileHandle is Gdx, but the class and JsonParser are not dependent on app initialization
-            // In fact, at this point Gdx.app or Gdx.files are null but this still works.
-            val file = FileHandle(base + File.separator + SETTINGS_FILE_NAME)
-
-            return if (file.exists())
-                json().fromJsonFile(
-                    GameSettings::class.java,
-                    file
-                )
-            else GameSettings().apply {
-                isFreshlyCreated = true
-                resolution = "1200x800" // By default Desktops should have a higher resolution
-                // LibGDX not yet configured, use regular java class
-                val screensize = Toolkit.getDefaultToolkit().screenSize
-                windowState = WindowState(
-                    width = screensize.width,
-                    height = screensize.height
-                )
-                file.writeString(json().toJson(this),false)
-            }
-
-        }
 
         /** @throws IncompatibleGameInfoVersionException if the [gameData] was created by a version of this game that is incompatible with the current one. */
         fun gameInfoFromString(gameData: String): GameInfo {

--- a/core/src/com/unciv/logic/UncivFiles.kt
+++ b/core/src/com/unciv/logic/UncivFiles.kt
@@ -336,7 +336,9 @@ class UncivFiles(
                     GameSettings::class.java,
                     file
                 )
-            else GameSettings().apply { isFreshlyCreated = true
+            else GameSettings().apply {
+                isFreshlyCreated = true
+                resolution = "1200x800" // By default Desktops should have a higher resolution
                 // LibGDX not yet configured, use regular java class
                 val screensize = Toolkit.getDefaultToolkit().screenSize
                 windowState = WindowState(

--- a/desktop/src/com/unciv/app/desktop/DesktopLauncher.kt
+++ b/desktop/src/com/unciv/app/desktop/DesktopLauncher.kt
@@ -44,9 +44,7 @@ internal object DesktopLauncher {
         config.disableAudio(true)
 
         val settings = UncivFiles.getSettingsForPlatformLaunchers()
-        if (!settings.isFreshlyCreated) {
-            config.setWindowedMode(settings.windowState.width.coerceAtLeast(120), settings.windowState.height.coerceAtLeast(80))
-        }
+        config.setWindowedMode(settings.windowState.width.coerceAtLeast(120), settings.windowState.height.coerceAtLeast(80))
 
         if (!isRunFromJAR) {
             UniqueDocsWriter().write()

--- a/tests/src/com/unciv/dev/FasterUIDevelopment.kt
+++ b/tests/src/com/unciv/dev/FasterUIDevelopment.kt
@@ -12,6 +12,7 @@ import com.badlogic.gdx.scenes.scene2d.InputEvent
 import com.badlogic.gdx.scenes.scene2d.InputListener
 import com.unciv.UncivGame
 import com.unciv.UncivGameParameters
+import com.unciv.dev.FasterUIDevelopment.DevElement
 import com.unciv.logic.UncivFiles
 import com.unciv.logic.multiplayer.throttle
 import com.unciv.ui.images.ImageGetter
@@ -51,11 +52,6 @@ object FasterUIDevelopment {
         System.setProperty("org.lwjgl.system.stackSize", "384")
 
         val config = Lwjgl3ApplicationConfiguration()
-
-        val settings = UncivFiles.getSettingsForPlatformLaunchers()
-        if (!settings.isFreshlyCreated) {
-            config.setWindowedMode(settings.windowState.width.coerceAtLeast(120), settings.windowState.height.coerceAtLeast(80))
-        }
 
         Lwjgl3Application(UIDevGame(), config)
     }


### PR DESCRIPTION
Current Unciv starts as a tiny screen on Desktop upon initial startup.
This was due to the fact that LibGDX, which is where we usually get our screen size from, is not initialized at the stage where we need to configure how it's going to start, which is where we set the initial screen size.

Solved by using regular ol' Java awt to get the initial screen size, so players have an initial fullscreen experience, which is IMO a much better one.
We also save the settings file so this initial size is 'locked in' for future runs.