### PR TITLE
Special images for embarked units

### DIFF
--- a/core/src/com/unciv/ui/tilegroups/TileSetStrings.kt
+++ b/core/src/com/unciv/ui/tilegroups/TileSetStrings.kt
@@ -35,6 +35,7 @@ class TileSetStrings(tileSet: String = UncivGame.Current.settings.tileSet, fallb
     val bottomRightRiver by lazy { orFallback { tilesLocation + "River-BottomRight"} }
     val bottomRiver by lazy { orFallback { tilesLocation + "River-Bottom"} }
     val bottomLeftRiver  by lazy { orFallback { tilesLocation + "River-BottomLeft"} }
+
     val unitsLocation = tileSetLocation + "Units/"
 
     val bordersLocation = tileSetLocation + "Borders/"
@@ -100,6 +101,11 @@ class TileSetStrings(tileSet: String = UncivGame.Current.settings.tileSet, fallb
     val imageParamsToImageLocation = HashMap<String,String>()
 
 
+    val embarkedMilitaryUnitLocation = getString(unitsLocation, "EmbarkedUnit-Military")
+    val hasEmbarkedMilitaryUnitImage = ImageGetter.imageExists(embarkedMilitaryUnitLocation)
+
+    val embarkedCivilianUnitLocation = getString(unitsLocation, "EmbarkedUnit-Civilian")
+    val hasEmbarkedCivilianUnitImage = ImageGetter.imageExists(embarkedCivilianUnitLocation)
     /**
      * Image fallbacks work by precedence.
      * So currently, if you're france, it's the modern era, and you have a pikeman:
@@ -111,7 +117,20 @@ class TileSetStrings(tileSet: String = UncivGame.Current.settings.tileSet, fallb
      */
 
     private fun tryGetUnitImageLocation(unit:MapUnit): String? {
-        val baseUnitIconLocation = this.unitsLocation + unit.name
+
+        var baseUnitIconLocation = getString(this.unitsLocation, unit.name)
+        if (unit.isEmbarked()) {
+            val unitSpecificEmbarkedUnitLocation =
+                    getString(unitsLocation, "EmbarkedUnit-${unit.name}")
+            baseUnitIconLocation = if (ImageGetter.imageExists(unitSpecificEmbarkedUnitLocation))
+                unitSpecificEmbarkedUnitLocation
+            else if (unit.isCivilian() && hasEmbarkedCivilianUnitImage)
+                embarkedCivilianUnitLocation
+            else if (unit.isMilitary() && hasEmbarkedMilitaryUnitImage)
+                embarkedMilitaryUnitLocation
+            else baseUnitIconLocation // no change
+        }
+
         val civInfo = unit.civInfo
         val style = civInfo.nation.getStyleOrCivName()
 
@@ -122,7 +141,7 @@ class TileSetStrings(tileSet: String = UncivGame.Current.settings.tileSet, fallb
             // Era-only image: looks like "pikeman-Medieval era"
             .tryEraImage(civInfo, baseUnitIconLocation, null, this)
             // Style era: looks like "pikeman-France" or "pikeman-European"
-            .tryImage { "$baseUnitIconLocation-${civInfo.nation.getStyleOrCivName()}" }
+            .tryImage { getString(baseUnitIconLocation, tag, civInfo.nation.getStyleOrCivName()) }
             .tryImage { baseUnitIconLocation }
 
         if (unit.baseUnit.replaces != null)
@@ -135,7 +154,8 @@ class TileSetStrings(tileSet: String = UncivGame.Current.settings.tileSet, fallb
         val imageKey = getString(
             unit.name, tag,
             unit.civInfo.getEra().name, tag,
-            unit.civInfo.nation.getStyleOrCivName()
+            unit.civInfo.nation.getStyleOrCivName(), tag,
+            unit.isEmbarked().toString()
         )
         // if in cache return that
         val currentImageMapping = imageParamsToImageLocation[imageKey]


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8366208/190927104-d9bdcec2-af9e-46f3-8575-6b8cd8cf85d1.png)

Top rated suggestion in Discord, by @GeneralWadaling

Seen here - top left corner is civilian embarked, bottom right is military embarked
We can't turn embarked units into civilians when embarked, that will mess up our entire pathfinding system

The way it works is, there are two set images - "EmbarkedUnit-Military" and "EmbarkedUnit-Civilian"
You can override this default, like "EmbarkedUnit-Pikeman", "EmbarkedUnit-Settler"
