### PR TITLE
fix: display "null" text on battleTable if the policy branch autocracy adopted completely

### DIFF
--- a/core/src/com/unciv/models/ruleset/unique/Unique.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Unique.kt
@@ -314,13 +314,18 @@ class TemporaryUnique() : IsPartOfGameInfoSerialization {
 
     constructor(uniqueObject: Unique, turns: Int) : this() {
         unique = uniqueObject.text
+        sourceObjectType = uniqueObject.sourceObjectType
+        sourceObjectName = uniqueObject.sourceObjectName
         turnsLeft = turns
     }
 
     var unique: String = ""
 
+    var sourceObjectType: UniqueTarget? = null
+    var sourceObjectName: String? = null
+
     @delegate:Transient
-    val uniqueObject: Unique by lazy { Unique(unique) }
+    val uniqueObject: Unique by lazy { Unique(unique, sourceObjectType, sourceObjectName) }
 
     var turnsLeft: Int = 0
 }


### PR DESCRIPTION
fix #7839

Missing `sourceObjectType` and `sourceObjectName` while creating the class `Unique` (Unique.kt:328)

**Save Data**

- Before adopt all autocracy :
[Autosave-Aztecs-187.txt](https://github.com/yairm210/Unciv/files/9615356/Autosave-Aztecs-187.txt)

- After adopt all autocracy:
[Autosave-Aztecs-187-adoptcomplete.txt](https://github.com/yairm210/Unciv/files/9615364/Autosave-Aztecs-187-adoptcomplete.txt)

