### PR TITLE
Fix multiplayer turn checker option not showing up on Android

### DIFF
--- a/core/src/com/unciv/ui/options/MultiplayerTab.kt
+++ b/core/src/com/unciv/ui/options/MultiplayerTab.kt
@@ -68,7 +68,7 @@ fun multiplayerTab(
 
     // at the moment the notification service only exists on Android
     val turnCheckerSelect: RefreshSelect?
-    if (Gdx.app.type != Application.ApplicationType.Android) {
+    if (Gdx.app.type == Application.ApplicationType.Android) {
         turnCheckerSelect = addTurnCheckerOptions(tab, optionsPopup)
         addSeparator(tab)
     } else {


### PR DESCRIPTION
Fixes #7573 

It should *only* show up on Android, this was caused by a logic fail in a refactoring.