### PR TITLE
Fixed crash when getting a spy and expanding a city simultaneously

### DIFF
--- a/core/src/com/unciv/logic/civilization/EspionageManager.kt
+++ b/core/src/com/unciv/logic/civilization/EspionageManager.kt
@@ -127,7 +127,9 @@ class EspionageManager : IsPartOfGameInfoSerialization {
 
     fun addSpy(): String {
         val spyName = getSpyName()
-        spyList.add(Spy(spyName))
+        val newSpy = Spy(spyName)
+        newSpy.setTransients(civInfo)
+        spyList.add(newSpy)
         ++spyCount
         return spyName
     }


### PR DESCRIPTION
Fixes #7842
Problem was that first a spy was acquired, and then the viewable tiles of the civ where updated due to the city expanding at the end of the turn. This questioned the spy where its location was, as it can see out of the city it is stationed in. However, the transients of the spy where never set, so the spy did not now what its civInfo was, crash ensues.