### PR TITLE
Modified multiplayer game viewing option when starting a new game

### DIFF
--- a/core/src/com/unciv/UncivGame.kt
+++ b/core/src/com/unciv/UncivGame.kt
@@ -184,7 +184,7 @@ class UncivGame(parameters: UncivGameParameters) : Game() {
         gameInfo = newGameInfo
 
 
-        if (gameInfo?.gameParameters?.isOnlineMultiplayer == true && gameInfo?.gameParameters?.anyoneCantSpectate == false) {
+        if (gameInfo?.gameParameters?.isOnlineMultiplayer == true && gameInfo?.gameParameters?.notanyoneCanSpectate == false) {
             if (gameInfo!!.civilizations.none { it.playerId == settings.multiplayer.userId }) {
                 throw UncivShowableException("You are not allowed to spectate!")
             }

--- a/core/src/com/unciv/UncivGame.kt
+++ b/core/src/com/unciv/UncivGame.kt
@@ -184,7 +184,7 @@ class UncivGame(parameters: UncivGameParameters) : Game() {
         gameInfo = newGameInfo
 
 
-        if (gameInfo?.gameParameters?.isOnlineMultiplayer == true && gameInfo?.gameParameters?.anyoneCanSpectate == false) {
+        if (gameInfo?.gameParameters?.isOnlineMultiplayer == true && gameInfo?.gameParameters?.anyoneCantSpectate == false) {
             if (gameInfo!!.civilizations.none { it.playerId == settings.multiplayer.userId }) {
                 throw UncivShowableException("You are not allowed to spectate!")
             }

--- a/core/src/com/unciv/models/metadata/GameParameters.kt
+++ b/core/src/com/unciv/models/metadata/GameParameters.kt
@@ -35,7 +35,7 @@ class GameParameters : IsPartOfGameInfoSerialization { // Default values are the
     var startingEra = "Ancient era"
 
     var isOnlineMultiplayer = false
-    var anyoneCantSpectate = false
+    var notanyoneCanSpectate = false
     var baseRuleset: String = BaseRuleset.Civ_V_GnK.fullName
     var mods = LinkedHashSet<String>()
 

--- a/core/src/com/unciv/models/metadata/GameParameters.kt
+++ b/core/src/com/unciv/models/metadata/GameParameters.kt
@@ -35,7 +35,7 @@ class GameParameters : IsPartOfGameInfoSerialization { // Default values are the
     var startingEra = "Ancient era"
 
     var isOnlineMultiplayer = false
-    var anyoneCanSpectate = false
+    var anyoneCantSpectate = false
     var baseRuleset: String = BaseRuleset.Civ_V_GnK.fullName
     var mods = LinkedHashSet<String>()
 

--- a/core/src/com/unciv/ui/newgamescreen/GameOptionsTable.kt
+++ b/core/src/com/unciv/ui/newgamescreen/GameOptionsTable.kt
@@ -71,7 +71,7 @@ class GameOptionsTable(
         checkboxTable.addNuclearWeaponsCheckbox()
         checkboxTable.addIsOnlineMultiplayerCheckbox()
         if (gameParameters.isOnlineMultiplayer)
-            checkboxTable.addAnyoneCanSpectateCheckbox()
+            checkboxTable.addAnyoneCantSpectateCheckbox()
         if (UncivGame.Current.settings.enableEspionageOption)
             checkboxTable.addEnableEspionageCheckbox()
         checkboxTable.addNoStartBiasCheckbox()
@@ -116,10 +116,10 @@ class GameOptionsTable(
                 update()
             }
 
-    private fun Table.addAnyoneCanSpectateCheckbox() =
-            addCheckbox("Allow anyone to spectate", gameParameters.anyoneCanSpectate)
+    private fun Table.addAnyoneCantSpectateCheckbox() =
+            addCheckbox("Only designated players can watch", gameParameters.anyoneCantSpectate)
             {
-                gameParameters.anyoneCanSpectate = it
+                gameParameters.anyoneCantSpectate = it
             }
 
     private fun Table.addEnableEspionageCheckbox() =

--- a/core/src/com/unciv/ui/newgamescreen/GameOptionsTable.kt
+++ b/core/src/com/unciv/ui/newgamescreen/GameOptionsTable.kt
@@ -71,7 +71,7 @@ class GameOptionsTable(
         checkboxTable.addNuclearWeaponsCheckbox()
         checkboxTable.addIsOnlineMultiplayerCheckbox()
         if (gameParameters.isOnlineMultiplayer)
-            checkboxTable.addAnyoneCantSpectateCheckbox()
+            checkboxTable.notaddAnyoneCanSpectateCheckbox()
         if (UncivGame.Current.settings.enableEspionageOption)
             checkboxTable.addEnableEspionageCheckbox()
         checkboxTable.addNoStartBiasCheckbox()
@@ -116,10 +116,10 @@ class GameOptionsTable(
                 update()
             }
 
-    private fun Table.addAnyoneCantSpectateCheckbox() =
-            addCheckbox("Only designated players can watch", gameParameters.anyoneCantSpectate)
+    private fun Table.notaddAnyoneCanSpectateCheckbox() =
+            addCheckbox("Only designated players can watch", gameParameters.notanyoneCanSpectate)
             {
-                gameParameters.anyoneCantSpectate = it
+                gameParameters.notanyoneCanSpectate = it
             }
 
     private fun Table.addEnableEspionageCheckbox() =

--- a/core/src/com/unciv/ui/newgamescreen/NewGameScreen.kt
+++ b/core/src/com/unciv/ui/newgamescreen/NewGameScreen.kt
@@ -116,7 +116,7 @@ class NewGameScreen(
                     }
                 }
 
-                if (gameSetupInfo.gameParameters.anyoneCantSpectate) {
+                if (gameSetupInfo.gameParameters.notanyoneCanSpectate) {
                     if (gameSetupInfo.gameParameters.players.none { it.playerId == UncivGame.Current.settings.multiplayer.userId }) {
                         val notAllowedToSpectate = Popup(this)
                         notAllowedToSpectate.addGoodSizedLabel("You are not allowed to spectate!".tr()).row()

--- a/core/src/com/unciv/ui/newgamescreen/NewGameScreen.kt
+++ b/core/src/com/unciv/ui/newgamescreen/NewGameScreen.kt
@@ -116,7 +116,7 @@ class NewGameScreen(
                     }
                 }
 
-                if (!gameSetupInfo.gameParameters.anyoneCanSpectate) {
+                if (gameSetupInfo.gameParameters.anyoneCantSpectate) {
                     if (gameSetupInfo.gameParameters.players.none { it.playerId == UncivGame.Current.settings.multiplayer.userId }) {
                         val notAllowedToSpectate = Popup(this)
                         notAllowedToSpectate.addGoodSizedLabel("You are not allowed to spectate!".tr()).row()


### PR DESCRIPTION
我收到大量玩家反馈说很多人想允许所有人观战但往往忘记去允许它——因此我将这个选项（anyoneCanSpectate）修改为了：不允许所有人观战（notanyoneCanSpectate），这样就顺应玩家们的操作了！当然......我不清楚我这一系列改动是否正确，请各位帮忙检查！谢谢！！！！

I have received a lot of feedback from players that many people want to allow everyone to watch the game, but they often forget to allow it - so I changed this option (anyoneCanSpectate) to not allow everyone to watch the game (notanyoneCanSpectate) , which is in line with the players' operation! Of course... I don't know if my series of changes are correct. Please help me check! thank you!!!!