### PR TITLE
Modified multiplayer game viewing option when starting a new game 

### DIFF
--- a/core/src/com/unciv/models/metadata/GameParameters.kt
+++ b/core/src/com/unciv/models/metadata/GameParameters.kt
@@ -35,7 +35,7 @@ class GameParameters : IsPartOfGameInfoSerialization { // Default values are the
     var startingEra = "Ancient era"
 
     var isOnlineMultiplayer = false
-    var anyoneCanSpectate = false
+    var anyoneCanSpectate = true
     var baseRuleset: String = BaseRuleset.Civ_V_GnK.fullName
     var mods = LinkedHashSet<String>()
 


### PR DESCRIPTION
 这为解决#7877中所提及的（notanyoneCanSpectate）提供了第二种解决方案
This provides a second solution to the (notanyoneCanSpectate) mentioned in # 7877