### PR TITLE
Fixed softlock forcing you to found a pantheon without available beliefs

### DIFF
--- a/core/src/com/unciv/logic/civilization/ReligionManager.kt
+++ b/core/src/com/unciv/logic/civilization/ReligionManager.kt
@@ -206,7 +206,8 @@ class ReligionManager : IsPartOfGameInfoSerialization {
         val gameInfo = civInfo.gameInfo
         val numberOfBeliefs = if (type == BeliefType.Any) gameInfo.ruleSet.beliefs.values.count()
         else gameInfo.ruleSet.beliefs.values.count { it.type == type }
-        return numberOfBeliefs - gameInfo.religions.flatMap { it.value.getBeliefs(type) }.count()
+        return numberOfBeliefs - gameInfo.religions.flatMap { it.value.getBeliefs(type) }.distinct().count()
+        // We need to do the distinct above, as pantheons and religions founded out of those pantheons might share beliefs
     }
 
     fun getReligionWithBelief(belief: Belief): Religion? {


### PR DESCRIPTION
Savefile to reproduce:
[Invalid Pantheon Found.txt](https://github.com/yairm210/Unciv/files/9692286/Weird.Stuff.txt)

The problem was that when you found a religion, a new `Religion` object is created, that shares a pantheon `Belief` with your previous pantheon religion. Thus, just counting the amount of beliefs in each existing `Religion` over-estimates the amount of `Beliefs` of type `Pantheon` actually used in the game. As we only check if the amount of beliefs left of a certain type equals 0, this check would in the save file above return `true`, as there were -9 `Belief`s of type `Pantheon` left. By using a distinct, we ignore these doubly counted pantheons, and thus get the correct number.