### PR TITLE
fixed no war relation

### DIFF
--- a/core/src/com/unciv/ui/overviewscreen/GlobalPoliticsOverviewTable.kt
+++ b/core/src/com/unciv/ui/overviewscreen/GlobalPoliticsOverviewTable.kt
@@ -163,7 +163,7 @@ class GlobalPoliticsOverviewTable (
 
         // wars
         for (otherCiv in civ.getKnownCivs()) {
-            if(civ.diplomacy[otherCiv.civName]?.hasFlag(DiplomacyFlags.DeclaredWar) == true) {
+            if(civ.diplomacy[otherCiv.civName]?.diplomaticStatus == DiplomaticStatus.War) {
                 val warText = "At war with ${otherCiv.civName}".toLabel()
                 warText.color = Color.RED
                 politicsTable.add(warText).row()


### PR DESCRIPTION
Fix #7884

The `DiplomacyFlags.DeclaredWar` flag is used to remember the number of turns will expire, and then user can negotiate a peace with enemy. It will be removed from `flagsCountdown` (DiplomacyManager.kt:117) when the time‘s up.