### PR TITLE
fix memory leak due to Pixmap don't be released.

### DIFF
--- a/core/src/com/unciv/ui/LoadingScreen.kt
+++ b/core/src/com/unciv/ui/LoadingScreen.kt
@@ -36,7 +36,10 @@ class LoadingScreen(
             for (popup in previousScreen.popups) popup.isVisible = false
             previousScreen.render(Gdx.graphics.getDeltaTime())
         }
-        val screenshot = ScreenshotTexture(Pixmap.createFromFrameBuffer(0, 0, Gdx.graphics.backBufferWidth, Gdx.graphics.backBufferHeight))
+        val pixmap = Pixmap.createFromFrameBuffer(0, 0, Gdx.graphics.backBufferWidth, Gdx.graphics.backBufferHeight)
+        val screenshot = Texture(pixmap)
+        pixmap.dispose()
+
         if (previousScreen != null) {
             for (popup in previousScreen.popups) popup.isVisible = true
         }
@@ -46,16 +49,6 @@ class LoadingScreen(
 
     override fun dispose() {
         screenshot.dispose()
-        super.dispose()
-    }
-}
-
-private class ScreenshotTexture(
-    private val pixmap: Pixmap,
-): Texture(pixmap) {
-
-    override fun dispose() {
-        pixmap.dispose()
         super.dispose()
     }
 }

--- a/core/src/com/unciv/ui/LoadingScreen.kt
+++ b/core/src/com/unciv/ui/LoadingScreen.kt
@@ -36,7 +36,7 @@ class LoadingScreen(
             for (popup in previousScreen.popups) popup.isVisible = false
             previousScreen.render(Gdx.graphics.getDeltaTime())
         }
-        val screenshot = Texture(Pixmap.createFromFrameBuffer(0, 0, Gdx.graphics.backBufferWidth, Gdx.graphics.backBufferHeight))
+        val screenshot = ScreenshotTexture(Pixmap.createFromFrameBuffer(0, 0, Gdx.graphics.backBufferWidth, Gdx.graphics.backBufferHeight))
         if (previousScreen != null) {
             for (popup in previousScreen.popups) popup.isVisible = true
         }
@@ -46,6 +46,16 @@ class LoadingScreen(
 
     override fun dispose() {
         screenshot.dispose()
+        super.dispose()
+    }
+}
+
+private class ScreenshotTexture(
+    private val pixmap: Pixmap,
+): Texture(pixmap) {
+
+    override fun dispose() {
+        pixmap.dispose()
         super.dispose()
     }
 }


### PR DESCRIPTION
Ref: https://libgdx.com/wiki/graphics/taking-a-screenshot

All we need to do is to dispose `Pixmap`