### PR TITLE
fix wrong glyph when switch between different ruleset.

### DIFF
--- a/core/src/com/unciv/ui/newgamescreen/NewGameScreen.kt
+++ b/core/src/com/unciv/ui/newgamescreen/NewGameScreen.kt
@@ -189,6 +189,7 @@ class NewGameScreen(
             rightSideButton.disable()
             rightSideButton.setText("Working...".tr())
 
+            setSkin()
             // Creating a new game can take a while and we don't want ANRs
             Concurrency.runOnNonDaemonThreadPool("NewGame") {
                 startNewGame()


### PR DESCRIPTION
## Bug Description:
Between `DeCiv Redux` and `Civ V God & Kings`, they have different glyph to show the `Gold` (¤). When you start a new game and choose the different ruleset which not the same as the previous one, the `Gold` (¤) glyph will show incorrectly.

<img width="982" alt="截圖 2022-10-28 下午8 43 22" src="https://user-images.githubusercontent.com/17497074/198589647-f9654f2e-05f5-49cf-878c-0b8c2333fb38.png">


## Reproduce:
1. Start a new game with `DeCiv Redux` ruleset 
2. Start a new game with `Civ V God & Kings` ruleset
3. Open city screen and click any item which can be purchased with gold.

## Reason 
`BitmapFont` not reload before start the new game
