### PR TITLE
Added unitset selection to options menu

### DIFF
--- a/core/src/com/unciv/Constants.kt
+++ b/core/src/com/unciv/Constants.kt
@@ -81,6 +81,7 @@ object Constants {
     const val dropboxMultiplayerServer = "Dropbox"
 
     const val defaultTileset = "HexaRealm"
+    const val defaultUnitset = "FantasyHex"
     const val defaultSkin = "Minimal"
 
     /**

--- a/core/src/com/unciv/Constants.kt
+++ b/core/src/com/unciv/Constants.kt
@@ -81,7 +81,7 @@ object Constants {
     const val dropboxMultiplayerServer = "Dropbox"
 
     const val defaultTileset = "HexaRealm"
-    const val defaultUnitset = "FantasyHex"
+    const val defaultUnitset = "HexaRealm"
     const val defaultSkin = "Minimal"
 
     /**

--- a/core/src/com/unciv/models/metadata/GameSettings.kt
+++ b/core/src/com/unciv/models/metadata/GameSettings.kt
@@ -38,6 +38,7 @@ class GameSettings {
 
     var turnsBetweenAutosaves = 1
     var tileSet: String = Constants.defaultTileset
+    var unitSet: String = Constants.defaultUnitset
     var skin: String = Constants.defaultSkin
     var showTutorials: Boolean = true
     var autoAssignCityProduction: Boolean = true

--- a/core/src/com/unciv/models/metadata/GameSettings.kt
+++ b/core/src/com/unciv/models/metadata/GameSettings.kt
@@ -38,7 +38,7 @@ class GameSettings {
 
     var turnsBetweenAutosaves = 1
     var tileSet: String = Constants.defaultTileset
-    var unitSet: String = Constants.defaultUnitset
+    var unitSet: String? = Constants.defaultUnitset
     var skin: String = Constants.defaultSkin
     var showTutorials: Boolean = true
     var autoAssignCityProduction: Boolean = true
@@ -48,7 +48,7 @@ class GameSettings {
     var showMinimap: Boolean = true
     var minimapSize: Int = 6    // default corresponds to 15% screen space
     var unitIconOpacity = 1f // default corresponds to fully opaque
-    var showPixelUnits: Boolean = true
+    val showPixelUnits: Boolean get() = unitSet != null
     var showPixelImprovements: Boolean = true
     var continuousRendering = false
     var orderTradeOffersByAmount = true

--- a/core/src/com/unciv/ui/images/ImageGetter.kt
+++ b/core/src/com/unciv/ui/images/ImageGetter.kt
@@ -481,6 +481,9 @@ object ImageGetter {
 
     fun getAvailableSkins() = ninePatchDrawables.keys.asSequence().map { it.split("/")[1] }.distinct()
 
-    fun getAvailableTilesets() = textureRegionDrawables.keys.asSequence().filter { it.startsWith("TileSets") }
+    fun getAvailableTilesets() = textureRegionDrawables.keys.asSequence().filter { it.startsWith("TileSets") && !it.contains("/Units/") }
             .map { it.split("/")[1] }.distinct()
+
+    fun getAvailableUnitsets() = textureRegionDrawables.keys.asSequence().filter { it.contains("/Units/") }
+        .map { it.split("/")[1] }.distinct()
 }

--- a/core/src/com/unciv/ui/options/DisplayTab.kt
+++ b/core/src/com/unciv/ui/options/DisplayTab.kt
@@ -47,6 +47,8 @@ fun displayTab(
 
     addTileSetSelectBox(this, settings, optionsPopup.selectBoxMinWidth, onChange)
 
+    addUnitSetSelectBox(this, settings, optionsPopup.selectBoxMinWidth, onChange)
+
     addSkinSelectBox(this, settings, optionsPopup.selectBoxMinWidth, onChange)
 
     optionsPopup.addCheckbox(this, "Continuous rendering", settings.continuousRendering) {
@@ -146,6 +148,25 @@ private fun addTileSetSelectBox(table: Table, settings: GameSettings, selectBoxM
         // ImageGetter ruleset should be correct no matter what screen we're on
         TileSetCache.assembleTileSetConfigs(ImageGetter.ruleset.mods)
         onTilesetChange()
+    }
+}
+
+private fun addUnitSetSelectBox(table: Table, settings: GameSettings, selectBoxMinWidth: Float, onUnitsetChange: () -> Unit) {
+    table.add("Unitset".toLabel()).left().fillX()
+
+    val unitSetSelectBox = SelectBox<String>(table.skin)
+    val unitSetArray = Array<String>()
+    val unitSets = ImageGetter.getAvailableUnitsets()
+    for (unitset in unitSets) unitSetArray.add(unitset)
+    unitSetSelectBox.items = unitSetArray
+    unitSetSelectBox.selected = settings.unitSet
+    table.add(unitSetSelectBox).minWidth(selectBoxMinWidth).pad(10f).row()
+
+    unitSetSelectBox.onChange {
+        settings.unitSet = unitSetSelectBox.selected
+        // ImageGetter ruleset should be correct no matter what screen we're on
+        TileSetCache.assembleTileSetConfigs(ImageGetter.ruleset.mods)
+        onUnitsetChange()
     }
 }
 

--- a/core/src/com/unciv/ui/options/DisplayTab.kt
+++ b/core/src/com/unciv/ui/options/DisplayTab.kt
@@ -34,7 +34,6 @@ fun displayTab(
     optionsPopup.addCheckbox(this, "Show worked tiles", settings.showWorkedTiles, true) { settings.showWorkedTiles = it }
     optionsPopup.addCheckbox(this, "Show resources and improvements", settings.showResourcesAndImprovements, true) { settings.showResourcesAndImprovements = it }
     optionsPopup.addCheckbox(this, "Show tutorials", settings.showTutorials, true) { settings.showTutorials = it }
-    optionsPopup.addCheckbox(this, "Show pixel units", settings.showPixelUnits, true) { settings.showPixelUnits = it }
     optionsPopup.addCheckbox(this, "Show pixel improvements", settings.showPixelImprovements, true) { settings.showPixelImprovements = it }
     optionsPopup.addCheckbox(this, "Experimental Demographics scoreboard", settings.useDemographics, true) { settings.useDemographics = it }
     optionsPopup.addCheckbox(this, "Show zoom buttons in world screen", settings.showZoomButtons, true) { settings.showZoomButtons = it }
@@ -143,7 +142,13 @@ private fun addTileSetSelectBox(table: Table, settings: GameSettings, selectBoxM
     tileSetSelectBox.selected = settings.tileSet
     table.add(tileSetSelectBox).minWidth(selectBoxMinWidth).pad(10f).row()
 
+    val unitSets = ImageGetter.getAvailableUnitsets()
+
     tileSetSelectBox.onChange {
+        // Switch unitSet together with tileSet as long as one with the same name exists and both are selected
+        if (settings.tileSet == settings.unitSet && unitSets.contains(tileSetSelectBox.selected)) {
+            settings.unitSet = tileSetSelectBox.selected
+        }
         settings.tileSet = tileSetSelectBox.selected
         // ImageGetter ruleset should be correct no matter what screen we're on
         TileSetCache.assembleTileSetConfigs(ImageGetter.ruleset.mods)
@@ -156,14 +161,16 @@ private fun addUnitSetSelectBox(table: Table, settings: GameSettings, selectBoxM
 
     val unitSetSelectBox = SelectBox<String>(table.skin)
     val unitSetArray = Array<String>()
+    val nullValue = "None".tr()
+    unitSetArray.add(nullValue)
     val unitSets = ImageGetter.getAvailableUnitsets()
     for (unitset in unitSets) unitSetArray.add(unitset)
     unitSetSelectBox.items = unitSetArray
-    unitSetSelectBox.selected = settings.unitSet
+    unitSetSelectBox.selected = settings.unitSet ?: nullValue
     table.add(unitSetSelectBox).minWidth(selectBoxMinWidth).pad(10f).row()
 
     unitSetSelectBox.onChange {
-        settings.unitSet = unitSetSelectBox.selected
+        settings.unitSet = if (unitSetSelectBox.selected != nullValue) unitSetSelectBox.selected else null
         // ImageGetter ruleset should be correct no matter what screen we're on
         TileSetCache.assembleTileSetConfigs(ImageGetter.ruleset.mods)
         onUnitsetChange()

--- a/core/src/com/unciv/ui/tilegroups/TileSetStrings.kt
+++ b/core/src/com/unciv/ui/tilegroups/TileSetStrings.kt
@@ -13,7 +13,7 @@ import com.unciv.ui.images.ImageGetter
  * @param tileSet Name of the tileset. Defaults to active at time of instantiation.
  * @param fallbackDepth Maximum number of fallback tilesets to try. Used to prevent infinite recursion.
  * */
-class TileSetStrings(tileSet: String = UncivGame.Current.settings.tileSet, unitSet: String = UncivGame.Current.settings.unitSet, fallbackDepth: Int = 1) {
+class TileSetStrings(tileSet: String = UncivGame.Current.settings.tileSet, unitSet: String? = UncivGame.Current.settings.unitSet, fallbackDepth: Int = 1) {
 
     // this is so that when we have 100s of TileGroups, they won't all individually come up with all these strings themselves,
     // it gets pretty memory-intensive (10s of MBs which is a lot for lower-end phones)

--- a/core/src/com/unciv/ui/tilegroups/TileSetStrings.kt
+++ b/core/src/com/unciv/ui/tilegroups/TileSetStrings.kt
@@ -13,11 +13,12 @@ import com.unciv.ui.images.ImageGetter
  * @param tileSet Name of the tileset. Defaults to active at time of instantiation.
  * @param fallbackDepth Maximum number of fallback tilesets to try. Used to prevent infinite recursion.
  * */
-class TileSetStrings(tileSet: String = UncivGame.Current.settings.tileSet, fallbackDepth: Int = 1) {
+class TileSetStrings(tileSet: String = UncivGame.Current.settings.tileSet, unitSet: String = UncivGame.Current.settings.unitSet, fallbackDepth: Int = 1) {
 
     // this is so that when we have 100s of TileGroups, they won't all individually come up with all these strings themselves,
     // it gets pretty memory-intensive (10s of MBs which is a lot for lower-end phones)
     val tileSetLocation = "TileSets/$tileSet/"
+    val unitSetLocation = "TileSets/$unitSet/"
     val tileSetConfig = TileSetCache[tileSet] ?: TileSetConfig()
 
     // These need to be by lazy since the orFallback expects a tileset, which it may not get.
@@ -36,7 +37,7 @@ class TileSetStrings(tileSet: String = UncivGame.Current.settings.tileSet, fallb
     val bottomRiver by lazy { orFallback { tilesLocation + "River-Bottom"} }
     val bottomLeftRiver  by lazy { orFallback { tilesLocation + "River-BottomLeft"} }
 
-    val unitsLocation = tileSetLocation + "Units/"
+    val unitsLocation = unitSetLocation + "Units/"
 
     val bordersLocation = tileSetLocation + "Borders/"
 
@@ -74,7 +75,7 @@ class TileSetStrings(tileSet: String = UncivGame.Current.settings.tileSet, fallb
         if (fallbackDepth <= 0 || tileSetConfig.fallbackTileSet == null)
             null
         else
-            TileSetStrings(tileSetConfig.fallbackTileSet!!, fallbackDepth-1)
+            TileSetStrings(tileSetConfig.fallbackTileSet!!, tileSetConfig.fallbackTileSet!!, fallbackDepth-1)
     }
 
     @Suppress("MemberVisibilityCanBePrivate")


### PR DESCRIPTION
This is a minimal implementation to allow unit images to be selected separately from the tile images.
It raises a question for me, however. Do units need their own config file (only thing I can think of right now would be fallbackUnitSet) or should we at least add a `fallbackUnitSet` variable to the `TilesetConfig`? And in general, would it be wise to split units from tilesets completely (like skins)? That would probably make some mods incompatible.