### PR TITLE
Resolve #7817 - don't show unexplored tiles at all

### DIFF
--- a/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
@@ -256,6 +256,7 @@ class WorkerAutomation(
         val workableTiles = currentTile.getTilesInDistance(4)
                 .filter {
                     (it.civilianUnit == null || it == currentTile)
+                            && (it.owningCity == null || it.getOwner()==civInfo)
                             && tileCanBeImproved(unit, it)
                             && it.getTilesInDistance(2)
                             .none { tile -> tile.isCityCenter() && tile.getCity()!!.civInfo.isAtWarWith(civInfo) }

--- a/core/src/com/unciv/logic/multiplayer/storage/SimpleHttp.kt
+++ b/core/src/com/unciv/logic/multiplayer/storage/SimpleHttp.kt
@@ -7,7 +7,11 @@ import com.unciv.utils.debug
 import java.io.BufferedReader
 import java.io.DataOutputStream
 import java.io.InputStreamReader
-import java.net.*
+import java.net.DatagramSocket
+import java.net.HttpURLConnection
+import java.net.InetAddress
+import java.net.URI
+import java.net.URL
 import java.nio.charset.Charset
 
 private typealias SendRequestCallback = (success: Boolean, result: String, code: Int?)->Unit
@@ -37,6 +41,7 @@ object SimpleHttp {
                 setRequestProperty("User-Agent", "Unciv/${UncivGame.VERSION.toNiceString()}-GNU-Terry-Pratchett")
             else
                 setRequestProperty("User-Agent", "Unciv/Turn-Checker-GNU-Terry-Pratchett")
+            setRequestProperty("Content-Type", "text/plain")
 
             try {
                 if (content.isNotEmpty()) {

--- a/core/src/com/unciv/ui/images/ImageGetter.kt
+++ b/core/src/com/unciv/ui/images/ImageGetter.kt
@@ -159,7 +159,7 @@ object ImageGetter {
         return layerList
     }
 
-    fun getWhiteDot() = getImage(whiteDotLocation)
+    fun getWhiteDot() = getImage(whiteDotLocation).apply { setSize(1f) }
     fun getDot(dotColor: Color) = getWhiteDot().apply { color = dotColor }
 
     fun getExternalImage(fileName: String): Image {

--- a/core/src/com/unciv/ui/tilegroups/TileGroup.kt
+++ b/core/src/com/unciv/ui/tilegroups/TileGroup.kt
@@ -351,7 +351,7 @@ open class TileGroup(
 
         @Suppress("BooleanLiteralArgument")  // readable enough as is
         fun clearUnexploredTiles() {
-            updateTileImage(null)
+            baseLayerGroup.isVisible = false
             updateRivers(false,false, false)
 
             updatePixelMilitaryUnit(false)
@@ -365,9 +365,17 @@ open class TileGroup(
         }
 
         hideHighlight()
+
+        val allGroups = listOf(baseLayerGroup,
+            terrainFeatureLayerGroup, borderLayerGroup, miscLayerGroup,
+            pixelMilitaryUnitGroup, pixelCivilianUnitGroup, unitLayerGroup,
+            cityButtonLayerGroup, highlightFogCrosshairLayerGroup)
+        for (group in allGroups) group.isVisible = true
+
         if (viewingCiv != null && !isExplored(viewingCiv)) {
-            clearUnexploredTiles()
-            for(image in tileBaseImages) image.color = tileSetStrings.tileSetConfig.unexploredTileColor
+            if (tileInfo.neighbors.any { it.position in viewingCiv.exploredTiles })
+                clearUnexploredTiles()
+            else for (group in allGroups) group.isVisible = false
             return
         }
 

--- a/core/src/com/unciv/ui/worldscreen/WorldMapHolder.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldMapHolder.kt
@@ -30,7 +30,6 @@ import com.unciv.models.AttackableTile
 import com.unciv.models.UncivSound
 import com.unciv.models.helpers.MapArrowType
 import com.unciv.models.helpers.MiscArrowTypes
-import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.ui.UncivStage
 import com.unciv.ui.audio.SoundPlayer
 import com.unciv.ui.images.ImageGetter
@@ -171,6 +170,11 @@ class WorldMapHolder(
     }
 
     private fun onTileClicked(tileInfo: TileInfo) {
+
+        if (tileInfo.position !in worldScreen.viewingCiv.exploredTiles
+                && tileInfo.neighbors.all { it.position !in worldScreen.viewingCiv.exploredTiles })
+            return // This tile doesn't exist for you
+
         removeUnitActionOverlay()
         selectedTile = tileInfo
         unitMovementPaths.clear()


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8366208/201496139-952ad37b-878b-496f-9371-6f0caf7655d6.png)

Unexplored tiles do not appear in minimap or main map
Does not include resizing the minimap to what's visible because that is crazy talk and would involve a lot of math and reconstructing the minimap every time the borders expand, maybe later