### PR TITLE
New "Unitset" option translatable

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -1334,6 +1334,7 @@ Missing translations: =
 Version = 
 Resolution = 
 Tileset = 
+Unitset = 
 UI Skin = 
 Create = 
 Language = 


### PR DESCRIPTION
Makes "Unitset" translatable (related to #7980).
Just required to add the string to the translation file (therefore in template.properties).

Before:
![before](https://user-images.githubusercontent.com/11946570/201503447-0ceca8fa-214e-4168-bebc-3fd6bc9f95c6.png)

After:
![after](https://user-images.githubusercontent.com/11946570/201503460-9d0e2415-0273-44b6-b591-747e3b2e79f7.png)
