### PR TITLE
Allowed adding arbitrary global uniques to city state bonuses

### DIFF
--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -491,6 +491,13 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
 
         for (religion in religions.values) religion.setTransients(this)
 
+        // must be done before updating tech manager bools, since that depends on allied city-states
+        for (civInfo in civilizations)
+            for (diplomacyManager in civInfo.diplomacy.values) {
+                diplomacyManager.civInfo = civInfo
+                diplomacyManager.updateHasOpenBorders()
+            }
+
         for (civInfo in civilizations) civInfo.setTransients()
         for (civInfo in civilizations) {
             civInfo.thingsToFocusOnForVictory =

--- a/core/src/com/unciv/logic/city/CityStats.kt
+++ b/core/src/com/unciv/logic/city/CityStats.kt
@@ -156,9 +156,8 @@ class CityStats(val cityInfo: CityInfo) {
                     if (otherCiv.cityStateType == CityStateType.Maritime && cityInfo.isCapital())
                         stats.food += 2
                 } else {
-                    for (bonus in eraInfo.getCityStateBonuses(otherCiv.cityStateType, relationshipLevel)) {
-                        if (bonus.isOfType(UniqueType.CityStateStatsPerCity)
-                            && cityInfo.matchesFilter(bonus.params[1])
+                    for (bonus in eraInfo.getCityStateBonuses(otherCiv.cityStateType, relationshipLevel, UniqueType.CityStateStatsPerCity)) {
+                        if (cityInfo.matchesFilter(bonus.params[1])
                             && bonus.conditionalsApply(otherCiv, cityInfo)
                         ) stats.add(bonus.stats)
                     }

--- a/core/src/com/unciv/logic/civilization/CityStateFunctions.kt
+++ b/core/src/com/unciv/logic/civilization/CityStateFunctions.kt
@@ -8,6 +8,7 @@ import com.unciv.logic.civilization.diplomacy.DiplomaticStatus
 import com.unciv.logic.civilization.diplomacy.RelationshipLevel
 import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.ruleset.tile.ResourceSupplyList
+import com.unciv.models.ruleset.unique.StateForConditionals
 import com.unciv.models.ruleset.unique.Unique
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.ruleset.unit.BaseUnit
@@ -650,13 +651,17 @@ class CityStateFunctions(val civInfo: CivilizationInfo) {
     }
 
     // TODO: Optimize, update whenever status changes, otherwise retain the same list
-    fun getUniquesProvidedByCityStates(uniqueType: UniqueType):Sequence<Unique>{
+    fun getUniquesProvidedByCityStates(
+        uniqueType: UniqueType,
+        stateForConditionals: StateForConditionals
+    ):Sequence<Unique> {
         if (civInfo.isCityState()) return emptySequence()
         val era = civInfo.getEra()
 
         if (era.undefinedCityStateBonuses()) return emptySequence()
 
         return civInfo.getKnownCivs().asSequence().filter { it.isCityState() }
-            .flatMap { era.getCityStateBonuses(it.cityStateType, civInfo.getDiplomacyManager(it).relationshipLevel(), uniqueType).asSequence() }
+            .flatMap { era.getCityStateBonuses(it.cityStateType, civInfo.getDiplomacyManager(it).relationshipLevel(), uniqueType) }
+            .filter { it.conditionalsApply(stateForConditionals) }
     }
 }

--- a/core/src/com/unciv/logic/civilization/CivInfoStats.kt
+++ b/core/src/com/unciv/logic/civilization/CivInfoStats.kt
@@ -147,21 +147,8 @@ class CivInfoStats(val civInfo: CivilizationInfo) {
                 val eraInfo = civInfo.getEra()
 
                 if (!eraInfo.undefinedCityStateBonuses()) {
-                    for (bonus in eraInfo.getCityStateBonuses(otherCiv.cityStateType, relationshipLevel)) {
-                        if (bonus.isOfType(UniqueType.CityStateStatsPerTurn) && bonus.conditionalsApply(otherCiv))
-                            cityStateBonus.add(bonus.stats)
-                    }
-                } else {
-                    // Deprecated, assume Civ V values for compatibility
-                    if (otherCiv.cityStateType == CityStateType.Cultured) {
-                        cityStateBonus.culture =
-                            when {
-                                civInfo.getEraNumber() in 0..1 -> 3f
-                                civInfo.getEraNumber() in 2..3 -> 6f
-                                else -> 13f
-                            }
-                        if (relationshipLevel == RelationshipLevel.Ally)
-                            cityStateBonus.culture *= 2f
+                    for (bonus in eraInfo.getCityStateBonuses(otherCiv.cityStateType, relationshipLevel, UniqueType.CityStateStatsPerTurn)) {
+                        cityStateBonus.add(bonus.stats)
                     }
                 }
 

--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -463,6 +463,7 @@ class CivilizationInfo : IsPartOfGameInfoSerialization {
                 .filter { it.isOfType(uniqueType) && it.conditionalsApply(stateForConditionals) }
             )
         yieldAll(getEra().getMatchingUniques(uniqueType, stateForConditionals))
+        yieldAll(cityStateFunctions.getUniquesProvidedByCityStates(uniqueType))
         if (religionManager.religion != null)
             yieldAll(religionManager.religion!!.getFounderUniques()
                 .filter { it.isOfType(uniqueType) && it.conditionalsApply(stateForConditionals) })

--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -463,7 +463,7 @@ class CivilizationInfo : IsPartOfGameInfoSerialization {
                 .filter { it.isOfType(uniqueType) && it.conditionalsApply(stateForConditionals) }
             )
         yieldAll(getEra().getMatchingUniques(uniqueType, stateForConditionals))
-        yieldAll(cityStateFunctions.getUniquesProvidedByCityStates(uniqueType))
+        yieldAll(cityStateFunctions.getUniquesProvidedByCityStates(uniqueType, stateForConditionals))
         if (religionManager.religion != null)
             yieldAll(religionManager.religion!!.getFounderUniques()
                 .filter { it.isOfType(uniqueType) && it.conditionalsApply(stateForConditionals) })

--- a/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
@@ -646,11 +646,9 @@ class DiplomacyManager() : IsPartOfGameInfoSerialization {
 
         if (eraInfo.undefinedCityStateBonuses()) return
 
-        for (bonus in eraInfo.getCityStateBonuses(otherCiv().cityStateType, relationshipLevel())) {
+        for (bonus in eraInfo.getCityStateBonuses(otherCiv().cityStateType, relationshipLevel(), UniqueType.CityStateMilitaryUnits)) {
             // Reset the countdown if it has ended, or if we have longer to go than the current maximum (can happen when going from friend to ally)
-            if (bonus.isOfType(UniqueType.CityStateMilitaryUnits) &&
-               (!hasFlag(DiplomacyFlags.ProvideMilitaryUnit) || getFlag(DiplomacyFlags.ProvideMilitaryUnit) > bonus.params[0].toInt())
-            ) {
+            if (!hasFlag(DiplomacyFlags.ProvideMilitaryUnit) || getFlag(DiplomacyFlags.ProvideMilitaryUnit) > bonus.params[0].toInt()) {
                 setFlag(DiplomacyFlags.ProvideMilitaryUnit, bonus.params[0].toInt() + variance)
             }
         }

--- a/core/src/com/unciv/ui/trade/DiplomacyScreen.kt
+++ b/core/src/com/unciv/ui/trade/DiplomacyScreen.kt
@@ -288,7 +288,7 @@ class DiplomacyScreen(
 
     /** Given a list of [bonuses], returns a list of pretty strings with updated values for Siam-like uniques
      *  Assumes that each bonus contains only one stat type */
-    private fun getAdjustedBonuses(bonuses: List<Unique>): List<String> {
+    private fun getAdjustedBonuses(bonuses: Sequence<Unique>): List<String> {
         val bonusStrings = ArrayList<String>()
         for (bonus in bonuses) {
             var improved = false


### PR DESCRIPTION
Steps 1 and 2 of city-state overhaul

- Got rid of fallback for unconfigured city state uniques
- Allowed arbitrary global uniques as city state bonuses

Further steps are:
- Allowing arbitrary city-state types (not just Military, Religious, etc)
- "city-state specializations" - `<to Allied Civilizations>`, `<to Friendly Civilizations>`  conditionals to add to _specific_ city-states so they will provide unique bonuses