### PR TITLE
Fix typo in AUR workflow

### DIFF
--- a/.github/workflows/buildAndDeploy.yml
+++ b/.github/workflows/buildAndDeploy.yml
@@ -215,14 +215,14 @@ jobs:
 
 
       - name: Get AUR PKGBUILD
-        if: github.event_name == 'push' && contains(github.ref, 'ref/tags/')
+        if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
         continue-on-error: true
         run: |
           curl --silent --output PKGBUILD 'https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h=unciv-bin'
           sed -E -e "s#(_pkgver=).*#\1${{steps.tag.outputs.tag}}#" -e "s#(pkgrel=).*#\10#" -i PKGBUILD
 
       - name: Publish AUR package
-        if: github.event_name == 'push' && contains(github.ref, 'ref/tags/')
+        if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
         continue-on-error: true
         uses: Thyrum/github-actions-deploy-aur@master
         with:


### PR DESCRIPTION
Due to a small typo in the [AUR](https://wiki.archlinux.org/title/Arch_User_Repository) build-and-deploy workflow it never even activated. This should fix it so that the [AUR version](https://aur.archlinux.org/packages/unciv-bin) of Unciv automatically gets updated whenever a release is published.