### PR TITLE
fix civilopedia category bug.

### DIFF
--- a/core/src/com/unciv/ui/civilopedia/CivilopediaScreen.kt
+++ b/core/src/com/unciv/ui/civilopedia/CivilopediaScreen.kt
@@ -297,13 +297,17 @@ class CivilopediaScreen(
         globalShortcuts.add(Input.Keys.LEFT) {
             val categoryKey = categoryToEntries.keys
             val currentIndex = categoryKey.indexOf(currentCategory)
-            val targetCategory = categoryKey.elementAt((currentIndex - 1) % categoryKey.size)
+            val targetCategory = categoryKey.elementAt(
+                (currentIndex + categoryKey.size - 1) % categoryKey.size
+            )
             selectCategory(targetCategory)
         }
         globalShortcuts.add(Input.Keys.RIGHT) {
             val categoryKey = categoryToEntries.keys
             val currentIndex = categoryKey.indexOf(currentCategory)
-            val targetCategory = categoryKey.elementAt((currentIndex + 1) % categoryKey.size)
+            val targetCategory = categoryKey.elementAt(
+                (currentIndex + categoryKey.size + 1) % categoryKey.size
+            )
             selectCategory(targetCategory)
 
         }

--- a/core/src/com/unciv/ui/civilopedia/CivilopediaScreen.kt
+++ b/core/src/com/unciv/ui/civilopedia/CivilopediaScreen.kt
@@ -291,11 +291,22 @@ class CivilopediaScreen(
             else
                 selectEntry(link, noScrollAnimation = true)
 
-        for (categoryKey in CivilopediaCategories.values()) {
+        for (categoryKey in categoryToEntries.keys) {
             globalShortcuts.add(categoryKey.key) { navigateCategories(categoryKey.key) }
         }
-        globalShortcuts.add(Input.Keys.LEFT) { selectCategory(currentCategory.getByOffset(-1)) }
-        globalShortcuts.add(Input.Keys.RIGHT) { selectCategory(currentCategory.getByOffset(1)) }
+        globalShortcuts.add(Input.Keys.LEFT) {
+            val categoryKey = categoryToEntries.keys
+            val currentIndex = categoryKey.indexOf(currentCategory)
+            val targetCategory = categoryKey.elementAt((currentIndex - 1) % categoryKey.size)
+            selectCategory(targetCategory)
+        }
+        globalShortcuts.add(Input.Keys.RIGHT) {
+            val categoryKey = categoryToEntries.keys
+            val currentIndex = categoryKey.indexOf(currentCategory)
+            val targetCategory = categoryKey.elementAt((currentIndex + 1) % categoryKey.size)
+            selectCategory(targetCategory)
+
+        }
         globalShortcuts.add(Input.Keys.UP) { navigateEntries(-1) }
         globalShortcuts.add(Input.Keys.DOWN) { navigateEntries(1) }
         globalShortcuts.add(Input.Keys.PAGE_UP) { navigateEntries(-10) }


### PR DESCRIPTION
fix #8083 

### Reason
If started a new game with base ruleset: **Civ V - Vanilla** , the civilopedia will not display "Religions & Beliefs" category.

<img width="976" alt="截圖 2022-12-04 下午11 14 06" src="https://user-images.githubusercontent.com/17497074/205498793-88164dca-fd52-4456-9544-24115f648d3f.png">

But user still can select "Religions & Beliefs" category via keyboard input (`Input.Keys.RIGHT` or `Input.Keys.LEFT`)
<img width="1045" alt="截圖 2022-12-04 下午11 19 38" src="https://user-images.githubusercontent.com/17497074/205499022-9d07c9d5-d963-4611-a0f5-936314c723e8.png">

And press 'Up' or 'Down' will occur the crash since there is nothing here.

### Approach
Avoid user enter "Religions & Beliefs" via keyboard input.