### PR TITLE
Change AI to not pillage roads in neutral territory

### DIFF
--- a/core/src/com/unciv/logic/map/TileInfo.kt
+++ b/core/src/com/unciv/logic/map/TileInfo.kt
@@ -246,7 +246,7 @@ open class TileInfo : IsPartOfGameInfoSerialization {
     fun canPillageTile(): Boolean {
         return canPillageTileImprovement() || canPillageRoad()
     }
-    private fun canPillageTileImprovement(): Boolean {
+    fun canPillageTileImprovement(): Boolean {
         return improvement != null && !improvementIsPillaged
                 && !ruleset.tileImprovements[improvement]!!.hasUnique(UniqueType.Unpillagable)
                 && !ruleset.tileImprovements[improvement]!!.hasUnique(UniqueType.Irremovable)

--- a/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
@@ -896,7 +896,11 @@ object UnitActions {
         if (!tile.canPillageTile()) return false
         val tileOwner = tile.getOwner()
         // Can't pillage friendly tiles, just like you can't attack them - it's an 'act of war' thing
-        return tileOwner == null || unit.civInfo.isAtWarWith(tileOwner)
+        return if (tileOwner == null) {
+            tile.canPillageTileImprovement()
+        } else {
+            unit.civInfo.isAtWarWith(tileOwner)
+        }
     }
 
     private fun addGiftAction(unit: MapUnit, actionList: ArrayList<UnitAction>, tile: TileInfo) {


### PR DESCRIPTION
Quick fix so that the AI doesn't pillage trade route connections in neutral territory. Especially for CS AIs