### PR TITLE
Volley only for Siege in G&K

### DIFF
--- a/android/assets/jsons/Civ V - Gods & Kings/UnitPromotions.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/UnitPromotions.json
@@ -61,7 +61,7 @@
 		"name": "Volley",
 		"prerequisites": ["Accuracy I","Barrage I"],
 		"uniques": ["[+50]% Strength <vs cities>"],
-		"unitTypes": ["Archery","Ranged Gunpowder","Siege"],
+		"unitTypes": ["Siege"],
         "column": 3,
         "row": 1
 	},


### PR DESCRIPTION
Double checking, Volley Promotion is only for Siege units in G&K (same for BNW).

In Vanilla it's available for Ranged.