### PR TITLE
fix `UncivServer.xyz` not working on new Installation

### DIFF
--- a/core/src/com/unciv/Constants.kt
+++ b/core/src/com/unciv/Constants.kt
@@ -80,7 +80,7 @@ object Constants {
     const val uniqueOrDelimiter = "\" OR \""
 
     const val dropboxMultiplayerServer = "Dropbox"
-    const val uncivXyzServer = "https://uncivserver.xyz/"
+    const val uncivXyzServer = "https://uncivserver.xyz"
 
     const val defaultTileset = "HexaRealm"
     const val defaultUnitset = "AbsoluteUnits"


### PR DESCRIPTION
Normally this is auto-fixed but a `/` at the end of the URL does not work. Because in API you do requests like `GET /file/:filename` and if you also put a `/` at the end of the server URL, it becomes something like this `https://example.com//files/filename`. Since the auto-fix happens only when typing a new URL from `Options` > `Multiplayer`, the default value doesn't get auto-fixed and shows errors. I tested on a new installation and as expected it shows the `Couldn't upload game` error. This pr fixes this.