### PR TITLE
Units/Buildings can now be given optional Portraits to be displayed instead of flags.

### DIFF
--- a/core/src/com/unciv/ui/cityscreen/CityConstructionsTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityConstructionsTable.kt
@@ -309,7 +309,7 @@ class CityConstructionsTable(private val cityScreen: CityScreen) {
         table.defaults().pad(2f).minWidth(40f)
         if (isFirstConstructionOfItsKind) table.add(getProgressBar(constructionName)).minWidth(5f)
         else table.add().minWidth(5f)
-        table.add(ImageGetter.getConstructionImage(constructionName).surroundWithCircle(40f)).padRight(10f)
+        table.add(ImageGetter.getPortraitImage(constructionName, 40f)).padRight(10f)
         table.add(text.toLabel()).expandX().fillX().left()
 
         if (constructionQueueIndex > 0) table.add(getRaisePriorityButton(constructionQueueIndex, constructionName, city)).right()
@@ -362,7 +362,7 @@ class CityConstructionsTable(private val cityScreen: CityScreen) {
         }
 
         pickConstructionButton.add(getProgressBar(construction.name)).padRight(5f)
-        pickConstructionButton.add(ImageGetter.getConstructionImage(construction.name).surroundWithCircle(40f)).padRight(10f)
+        pickConstructionButton.add(ImageGetter.getPortraitImage(construction.name, 40f)).padRight(10f)
         pickConstructionButton.add(constructionButtonDTO.buttonText.toLabel()).expandX().fillX()
 
         if (!cannotAddConstructionToQueue(construction, cityScreen.city, cityScreen.city.cityConstructions)) {

--- a/core/src/com/unciv/ui/cityscreen/CityInfoTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityInfoTable.kt
@@ -120,7 +120,7 @@ class CityInfoTable(private val cityScreen: CityScreen) : Table(BaseScreen.skin)
     }
 
     private fun addBuildingInfo(building: Building, destinationTable: Table) {
-        val icon = ImageGetter.getConstructionImage(building.name).surroundWithCircle(30f)
+        val icon = ImageGetter.getPortraitImage(building.name, 30f)
         val isFree = building.name in cityScreen.city.civInfo.civConstructions.getFreeBuildings(cityScreen.city.id)
         val displayName = if (isFree) "{${building.name}} ({Free})" else building.name
         val buildingNameAndIconTable = ExpanderTab(

--- a/core/src/com/unciv/ui/cityscreen/ConstructionInfoTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/ConstructionInfoTable.kt
@@ -56,7 +56,7 @@ class ConstructionInfoTable(val cityScreen: CityScreen): Table() {
         selectedConstructionTable.run {
             pad(10f)
 
-            add(ImageGetter.getConstructionImage(construction.name).surroundWithCircle(50f))
+            add(ImageGetter.getPortraitImage(construction.name, 50f))
                 .pad(5f)
 
             var buildingText = construction.name.tr()

--- a/core/src/com/unciv/ui/civilopedia/CivilopediaCategories.kt
+++ b/core/src/com/unciv/ui/civilopedia/CivilopediaCategories.kt
@@ -52,8 +52,7 @@ object CivilopediaImageGetters {
     }
 
     val construction = { name: String, size: Float ->
-        ImageGetter.getConstructionImage(name)
-            .surroundWithCircle(size)
+        ImageGetter.getPortraitImage(name, size)
     }
     val improvement = { name: String, size: Float ->
         ImageGetter.getImprovementIcon(name, size)

--- a/core/src/com/unciv/ui/images/ImageGetter.kt
+++ b/core/src/com/unciv/ui/images/ImageGetter.kt
@@ -258,7 +258,7 @@ object ImageGetter {
             return if (imageExists(buildingPortraitLocation)) {
                 getImage(buildingPortraitLocation).toGroup(size)
             } else
-                getImage("BuildingIcons/$construction").surroundWithCircle(size)
+                getImage(buildingPortraitLocation).surroundWithCircle(size)
         }
         if (ruleset.units.containsKey(construction)) {
             val unitPortraitLocation = "UnitPortraits/$construction"

--- a/core/src/com/unciv/ui/images/ImageGetter.kt
+++ b/core/src/com/unciv/ui/images/ImageGetter.kt
@@ -252,12 +252,40 @@ object ImageGetter {
         return iconGroup
     }
 
-    fun getConstructionImage(construction: String): Image {
-        if (ruleset.buildings.containsKey(construction)) return getImage("BuildingIcons/$construction")
-        if (ruleset.units.containsKey(construction)) return getUnitIcon(construction)
-        if (construction == "Nothing") return getImage("OtherIcons/Sleep")
-        return getStatIcon(construction)
+    fun getPortraitImage(construction: String, size: Float): Group {
+        if (ruleset.buildings.containsKey(construction)) {
+            return if (buildingPortraitExists(construction)) {
+                val image = getImage("BuildingPortraits/$construction")
+                val group = Group().apply {
+                    setSize(size, size)
+                    image.setSize(size, size)
+                    image.center(this)
+                    image.setOrigin(Align.center)
+                    addActor(image) }
+                group
+            } else
+                getImage("BuildingIcons/$construction").surroundWithCircle(size)
+        }
+        if (ruleset.units.containsKey(construction)) {
+            return if (unitPortraitExists(construction)) {
+                val image = getImage("UnitPortraits/$construction")
+                val group = Group().apply {
+                    setSize(size, size)
+                    image.setSize(size, size)
+                    image.center(this)
+                    image.setOrigin(Align.center)
+                    addActor(image) }
+                group
+            } else
+                getUnitIcon(construction).surroundWithCircle(size)
+        }
+        if (construction == "Nothing")
+            return getImage("OtherIcons/Sleep").surroundWithCircle(size)
+        return getStatIcon(construction).surroundWithCircle(size)
     }
+
+    private fun unitPortraitExists(unitName: String) = imageExists("UnitPortraits/$unitName")
+    private fun buildingPortraitExists(buildingName: String) = imageExists("BuildingPortraits/$buildingName")
 
     fun getPromotionIcon(promotionName: String, size: Float = 30f): Actor {
         val nameWithoutBrackets = promotionName.replace("[", "").replace("]", "")

--- a/core/src/com/unciv/ui/images/ImageGetter.kt
+++ b/core/src/com/unciv/ui/images/ImageGetter.kt
@@ -254,28 +254,16 @@ object ImageGetter {
 
     fun getPortraitImage(construction: String, size: Float): Group {
         if (ruleset.buildings.containsKey(construction)) {
-            return if (buildingPortraitExists(construction)) {
-                val image = getImage("BuildingPortraits/$construction")
-                val group = Group().apply {
-                    setSize(size, size)
-                    image.setSize(size, size)
-                    image.center(this)
-                    image.setOrigin(Align.center)
-                    addActor(image) }
-                group
+            val buildingPortraitLocation = "BuildingPortraits/$construction"
+            return if (imageExists(buildingPortraitLocation)) {
+                getImage(buildingPortraitLocation).toGroup(size)
             } else
                 getImage("BuildingIcons/$construction").surroundWithCircle(size)
         }
         if (ruleset.units.containsKey(construction)) {
-            return if (unitPortraitExists(construction)) {
-                val image = getImage("UnitPortraits/$construction")
-                val group = Group().apply {
-                    setSize(size, size)
-                    image.setSize(size, size)
-                    image.center(this)
-                    image.setOrigin(Align.center)
-                    addActor(image) }
-                group
+            val unitPortraitLocation = "UnitPortraits/$construction"
+            return if (imageExists(unitPortraitLocation)) {
+                getImage(unitPortraitLocation).toGroup(size)
             } else
                 getUnitIcon(construction).surroundWithCircle(size)
         }
@@ -283,9 +271,6 @@ object ImageGetter {
             return getImage("OtherIcons/Sleep").surroundWithCircle(size)
         return getStatIcon(construction).surroundWithCircle(size)
     }
-
-    private fun unitPortraitExists(unitName: String) = imageExists("UnitPortraits/$unitName")
-    private fun buildingPortraitExists(buildingName: String) = imageExists("BuildingPortraits/$buildingName")
 
     fun getPromotionIcon(promotionName: String, size: Float = 30f): Actor {
         val nameWithoutBrackets = promotionName.replace("[", "").replace("]", "")

--- a/core/src/com/unciv/ui/images/ImageGetter.kt
+++ b/core/src/com/unciv/ui/images/ImageGetter.kt
@@ -258,7 +258,7 @@ object ImageGetter {
             return if (imageExists(buildingPortraitLocation)) {
                 getImage(buildingPortraitLocation).toGroup(size)
             } else
-                getImage(buildingPortraitLocation).surroundWithCircle(size)
+                getImage("BuildingIcons/$construction").surroundWithCircle(size)
         }
         if (ruleset.units.containsKey(construction)) {
             val unitPortraitLocation = "UnitPortraits/$construction"

--- a/core/src/com/unciv/ui/overviewscreen/CityOverviewTable.kt
+++ b/core/src/com/unciv/ui/overviewscreen/CityOverviewTable.kt
@@ -194,7 +194,7 @@ class CityOverviewTab(
 
             val construction = city.cityConstructions.currentConstructionFromQueue
             if (construction.isNotEmpty()) {
-                cityInfoTableDetails.add(ImageGetter.getConstructionImage(construction).surroundWithCircle(iconSize*0.8f)).padRight(paddingHorz)
+                cityInfoTableDetails.add(ImageGetter.getPortraitImage(construction, iconSize*0.8f)).padRight(paddingHorz)
             } else {
                 cityInfoTableDetails.add()
             }

--- a/core/src/com/unciv/ui/pickerscreens/TechButton.kt
+++ b/core/src/com/unciv/ui/pickerscreens/TechButton.kt
@@ -64,15 +64,14 @@ class TechButton(techName:String, private val techManager: TechManager, isWorldS
         val tech = ruleset.technologies[techName]!!
 
         for (unit in tech.getEnabledUnits(ruleset, techManager.civInfo))
-            techEnabledIcons.add(ImageGetter.getConstructionImage(unit.name).surroundWithCircle(techIconSize))
+            techEnabledIcons.add(ImageGetter.getPortraitImage(unit.name, techIconSize))
 
         for (building in tech.getEnabledBuildings(ruleset, techManager.civInfo))
-            techEnabledIcons.add(ImageGetter.getConstructionImage(building.name).surroundWithCircle(techIconSize))
+            techEnabledIcons.add(ImageGetter.getPortraitImage(building.name, techIconSize))
 
         for (obj in tech.getObsoletedObjects(ruleset, techManager.civInfo)) {
             val obsoletedIcon = when (obj) {
-                is Building -> ImageGetter.getConstructionImage(obj.name)
-                    .surroundWithCircle(techIconSize)
+                is Building -> ImageGetter.getPortraitImage(obj.name, techIconSize)
                 is TileResource -> ImageGetter.getResourceImage(obj.name, techIconSize)
                 is TileImprovement -> ImageGetter.getImprovementIcon(obj.name, techIconSize)
                 else -> continue

--- a/core/src/com/unciv/ui/tilegroups/CityButton.kt
+++ b/core/src/com/unciv/ui/tilegroups/CityButton.kt
@@ -383,19 +383,9 @@ class CityButton(val city: CityInfo, private val tileGroup: WorldTileGroup): Tab
         val groupHeight = 25f
         val groupWidth = if (cityCurrentConstruction is PerpetualConstruction) 15f else 40f
         group.setSize(groupWidth, groupHeight)
-
-        val circle = ImageGetter.getCircle()
-        circle.setSize(25f, 25f)
-        val constructionImage = ImageGetter.getConstructionImage(cityConstructions.currentConstructionFromQueue)
-        constructionImage.setSize(18f, 18f)
+        val constructionImage = ImageGetter.getPortraitImage(cityConstructions.currentConstructionFromQueue, 25f)
         constructionImage.centerY(group)
         constructionImage.x = group.width - constructionImage.width
-
-        // center the circle on the production image
-        circle.x = constructionImage.x + (constructionImage.width - circle.width) / 2
-        circle.y = constructionImage.y + (constructionImage.height - circle.height) / 2
-
-        group.addActor(circle)
         group.addActor(constructionImage)
 
         val secondaryColor = cityConstructions.cityInfo.civInfo.nation.getInnerColor()

--- a/core/src/com/unciv/ui/utils/extensions/Scene2dExtensions.kt
+++ b/core/src/com/unciv/ui/utils/extensions/Scene2dExtensions.kt
@@ -494,3 +494,13 @@ fun WidgetGroup.packIfNeeded(): WidgetGroup {
 
 /** @return `true` if the screen is narrower than 4:3 landscape */
 fun Stage.isNarrowerThan4to3() = viewport.screenHeight * 4 > viewport.screenWidth * 3
+
+/** Wraps and returns an image in a [Group] of a given size*/
+fun Image.toGroup(size: Float): Group {
+    return Group().apply {
+        setSize(size, size)
+        this@toGroup.setSize(size, size)
+        this@toGroup.center(this)
+        this@toGroup.setOrigin(Align.center)
+        addActor(this@toGroup) }
+}

--- a/core/src/com/unciv/ui/worldscreen/AlertPopup.kt
+++ b/core/src/com/unciv/ui/worldscreen/AlertPopup.kt
@@ -207,7 +207,7 @@ class AlertPopup(val worldScreen: WorldScreen, val popupAlert: PopupAlert): Popu
                             .row()
                     }
                 } else {    // Fallback
-                    add(ImageGetter.getConstructionImage(wonder.name).surroundWithCircle(100f)).pad(20f).row()
+                    add(ImageGetter.getPortraitImage(wonder.name, 100f)).pad(20f).row()
                 }
 
                 val centerTable = Table()

--- a/docs/Modders/Images-and-Audio.md
+++ b/docs/Modders/Images-and-Audio.md
@@ -43,9 +43,7 @@ For example, [here](https://github.com/yairm210/Unciv-leader-portrait-mod-exampl
 
 ### Adding Unit and Building Portraits
 
-These work best if they are full RGB square, between 100x100 and 256x256 pixels, and include some transparent border within that area.
-The base game uses flat icons, colored to fit the civilization's flag colors, to denote units both on the map and in other UI elements.
-A mod can supply "Portraits" - static images that will remain uncolored - by adding their images to `/Images/UnitPortraits/` and `/Images/BuildingPortraits/`, which will be used in all UI elements except for the world map. The file name must correspond exactly with the unit/building name as defined in Units.json and Buildings.json, or they will be ignored.
+The base game uses flat icons, colored to fit the civilization's flag colors, to denote units both on the map and in other UI elements. A mod can supply "Portraits" - static images that will remain uncolored - by adding their images to `/Images/UnitPortraits/` and `/Images/BuildingPortraits/`, which will be used in all UI elements except for the world map. The file name must correspond exactly with the unit/building name as defined in Units.json and Buildings.json, or they will be ignored.
 
 These work best if they are full RGB square, between 100x100 and 256x256 pixels, and include some transparent border within that area.
 

--- a/docs/Modders/Images-and-Audio.md
+++ b/docs/Modders/Images-and-Audio.md
@@ -43,7 +43,9 @@ For example, [here](https://github.com/yairm210/Unciv-leader-portrait-mod-exampl
 
 ### Adding Unit and Building Portraits
 
-The base game comes without Unit/Building Portraits (display flags instead by default), but is able to display them in City Screen, Overview Screen, Tech Tree, Civilopedia, etc. A mod can supply these, by adding their images to `/Images/UnitPortraits/` and `/Images/BuildingPortraits/`. The file name must correspond exactly with the unit/building name as defined in Units.json and Buildings.json, or they will be ignored.
+These work best if they are full RGB square, between 100x100 and 256x256 pixels, and include some transparent border within that area.
+The base game uses flat icons, colored to fit the civilization's flag colors, to denote units both on the map and in other UI elements.
+A mod can supply "Portraits" - static images that will remain uncolored - by adding their images to `/Images/UnitPortraits/` and `/Images/BuildingPortraits/`, which will be used in all UI elements except for the world map. The file name must correspond exactly with the unit/building name as defined in Units.json and Buildings.json, or they will be ignored.
 
 These work best if they are full RGB square, between 100x100 and 256x256 pixels, and include some transparent border within that area.
 

--- a/docs/Modders/Images-and-Audio.md
+++ b/docs/Modders/Images-and-Audio.md
@@ -43,7 +43,7 @@ For example, [here](https://github.com/yairm210/Unciv-leader-portrait-mod-exampl
 
 ### Adding Unit and Building Portraits
 
-The base game comes without Unit/Building Portraits (display flags instead by default), but is able to display them in City Screen, Overview Screen, Tech Tree, Civilopedia, etc. A mod can supply these, by adding their images to `/Images/UnitPortraits/` and `/Images/BuildingPortraits`. The file name must correspond exactly with the unit/building name as defined in Units.json and Buildings.json, or they will be ignored.
+The base game comes without Unit/Building Portraits (display flags instead by default), but is able to display them in City Screen, Overview Screen, Tech Tree, Civilopedia, etc. A mod can supply these, by adding their images to `/Images/UnitPortraits/` and `/Images/BuildingPortraits/`. The file name must correspond exactly with the unit/building name as defined in Units.json and Buildings.json, or they will be ignored.
 
 These work best if they are full RGB square, between 100x100 and 256x256 pixels, and include some transparent border within that area.
 

--- a/docs/Modders/Images-and-Audio.md
+++ b/docs/Modders/Images-and-Audio.md
@@ -41,6 +41,14 @@ These work best if they are square, between 100x100 and 256x256 pixels, and incl
 
 For example, [here](https://github.com/yairm210/Unciv-leader-portrait-mod-example) is mod showing how to add leader portraits, which can complement the base game.
 
+### Adding Unit and Building Portraits
+
+The base game comes without Unit/Building Portraits (display flags instead by default), but is able to display them in City Screen, Overview Screen, Tech Tree, Civilopedia, etc. A mod can supply these, by adding their images to `/Images/UnitPortraits/` and `/Images/BuildingPortraits`. The file name must correspond exactly with the unit/building name as defined in Units.json and Buildings.json, or they will be ignored.
+
+These work best if they are full RGB square, between 100x100 and 256x256 pixels, and include some transparent border within that area.
+
+For example, [here](https://github.com/vegeta1k95/Civ-5-Icons) is mod showing how to add unit portraits, which can complement the base game.
+
 ## Sounds
 
 Standard values are below. The sounds themselves can be found [here](/sounds).

--- a/site/wiki/Audiovisual-Mods/index.html
+++ b/site/wiki/Audiovisual-Mods/index.html
@@ -2,79 +2,79 @@
 <!doctype html>
 <html lang="en" class="no-js">
   <head>
-    
+
       <meta charset="utf-8">
       <meta name="viewport" content="width=device-width,initial-scale=1">
-      
-      
-      
+
+
+
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.3, mkdocs-material-8.2.1">
-    
-    
-      
+
+
+
         <title>Audiovisual Mods - My Docs</title>
-      
-    
-    
+
+
+
       <link rel="stylesheet" href="../../assets/stylesheets/main.e8d9bf0c.min.css">
-      
-        
+
+
         <link rel="stylesheet" href="../../assets/stylesheets/palette.e6a45f82.min.css">
-        
-      
-    
-    
-    
-      
-        
+
+
+
+
+
+
+
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
         <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,400i,700%7CRoboto+Mono&display=fallback">
         <style>:root{--md-text-font:"Roboto";--md-code-font:"Roboto Mono"}</style>
-      
-    
-    
-    <script>__md_scope=new URL("../..",location),__md_get=(e,_=localStorage,t=__md_scope)=>JSON.parse(_.getItem(t.pathname+"."+e)),__md_set=(e,_,t=localStorage,a=__md_scope)=>{try{t.setItem(a.pathname+"."+e,JSON.stringify(_))}catch(e){}}</script>
-    
-      
 
-    
-    
+
+
+    <script>__md_scope=new URL("../..",location),__md_get=(e,_=localStorage,t=__md_scope)=>JSON.parse(_.getItem(t.pathname+"."+e)),__md_set=(e,_,t=localStorage,a=__md_scope)=>{try{t.setItem(a.pathname+"."+e,JSON.stringify(_))}catch(e){}}</script>
+
+
+
+
+
   </head>
-  
-  
-    
-    
-    
-    
-    
+
+
+
+
+
+
+
     <body dir="ltr" data-md-color-scheme="" data-md-color-primary="none" data-md-color-accent="none">
-  
-    
-    
+
+
+
     <input class="md-toggle" data-md-toggle="drawer" type="checkbox" id="__drawer" autocomplete="off">
     <input class="md-toggle" data-md-toggle="search" type="checkbox" id="__search" autocomplete="off">
     <label class="md-overlay" for="__drawer"></label>
     <div data-md-component="skip">
-      
-        
+
+
         <a href="#audiovisual-mods" class="md-skip">
           Skip to content
         </a>
-      
+
     </div>
     <div data-md-component="announce">
-      
+
     </div>
-    
-    
-      
+
+
+
 
 <header class="md-header" data-md-component="header">
   <nav class="md-header__inner md-grid" aria-label="Header">
     <a href="../.." title="My Docs" class="md-header__button md-logo" aria-label="My Docs" data-md-component="logo">
-      
-  
+
+
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 8a3 3 0 0 0 3-3 3 3 0 0 0-3-3 3 3 0 0 0-3 3 3 3 0 0 0 3 3m0 3.54C9.64 9.35 6.5 8 3 8v11c3.5 0 6.64 1.35 9 3.54 2.36-2.19 5.5-3.54 9-3.54V8c-3.5 0-6.64 1.35-9 3.54z"/></svg>
 
     </a>
@@ -90,16 +90,16 @@
         </div>
         <div class="md-header__topic" data-md-component="header-topic">
           <span class="md-ellipsis">
-            
+
               Audiovisual Mods
-            
+
           </span>
         </div>
       </div>
     </div>
-    
-    
-    
+
+
+
       <label class="md-header__button md-icon" for="__search">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M9.5 3A6.5 6.5 0 0 1 16 9.5c0 1.61-.59 3.09-1.56 4.23l.27.27h.79l5 5-1.5 1.5-5-5v-.79l-.27-.27A6.516 6.516 0 0 1 9.5 16 6.5 6.5 0 0 1 3 9.5 6.5 6.5 0 0 1 9.5 3m0 2C7 5 5 7 5 9.5S7 14 9.5 14 14 12 14 9.5 12 5 9.5 5z"/></svg>
       </label>
@@ -113,12 +113,12 @@
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M20 11v2H8l5.5 5.5-1.42 1.42L4.16 12l7.92-7.92L13.5 5.5 8 11h12z"/></svg>
       </label>
       <nav class="md-search__options" aria-label="Search">
-        
+
         <button type="reset" class="md-search__icon md-icon" aria-label="Clear" tabindex="-1">
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z"/></svg>
         </button>
       </nav>
-      
+
     </form>
     <div class="md-search__output">
       <div class="md-search__scrollwrap" data-md-scrollfix>
@@ -132,712 +132,698 @@
     </div>
   </div>
 </div>
-    
-    
+
+
   </nav>
-  
+
 </header>
-    
+
     <div class="md-container" data-md-component="container">
-      
-      
-        
-          
-        
-      
+
+
+
+
+
+
       <main class="md-main" data-md-component="main">
         <div class="md-main__inner md-grid">
-          
-            
-              
+
+
+
               <div class="md-sidebar md-sidebar--primary" data-md-component="sidebar" data-md-type="navigation" >
                 <div class="md-sidebar__scrollwrap">
                   <div class="md-sidebar__inner">
-                    
+
 
 
 <nav class="md-nav md-nav--primary" aria-label="Navigation" data-md-level="0">
   <label class="md-nav__title" for="__drawer">
     <a href="../.." title="My Docs" class="md-nav__button md-logo" aria-label="My Docs" data-md-component="logo">
-      
-  
+
+
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 8a3 3 0 0 0 3-3 3 3 0 0 0-3-3 3 3 0 0 0-3 3 3 3 0 0 0 3 3m0 3.54C9.64 9.35 6.5 8 3 8v11c3.5 0 6.64 1.35 9 3.54 2.36-2.19 5.5-3.54 9-3.54V8c-3.5 0-6.64 1.35-9 3.54z"/></svg>
 
     </a>
     My Docs
   </label>
-  
-  <ul class="md-nav__list" data-md-scrollfix>
-    
-      
-      
-      
 
-  
-  
-  
+  <ul class="md-nav__list" data-md-scrollfix>
+
+
+
+
+
+
+
+
     <li class="md-nav__item">
       <a href="../.." class="md-nav__link">
         Welcome to MkDocs
       </a>
     </li>
-  
 
-    
-      
-      
-      
 
-  
-  
-  
+
+
+
+
+
+
+
+
     <li class="md-nav__item">
       <a href="../../Credits/" class="md-nav__link">
         Icon Credits
       </a>
     </li>
-  
 
-    
-      
-      
-      
 
-  
-  
-  
+
+
+
+
+
+
+
+
     <li class="md-nav__item">
       <a href="../../Game%20Making%20Tips/" class="md-nav__link">
         Tips and tricks for making a LibGDX game
       </a>
     </li>
-  
 
-    
-      
-      
-      
 
-  
-  
-  
+
+
+
+
+
+
+
+
     <li class="md-nav__item">
       <a href="../../unique%20parameters/" class="md-nav__link">
         Unique parameters
       </a>
     </li>
-  
 
-    
-      
-      
-      
 
-  
-  
-  
+
+
+
+
+
+
+
+
     <li class="md-nav__item">
       <a href="../../uniques/" class="md-nav__link">
         Uniques
       </a>
     </li>
-  
 
-    
-      
-      
-      
 
-  
-  
-    
-  
-  
-    
+
+
+
+
+
+
+
+
+
+
+
     <li class="md-nav__item md-nav__item--active md-nav__item--nested">
-      
-      
+
+
         <input class="md-nav__toggle md-toggle" data-md-toggle="__nav_6" type="checkbox" id="__nav_6" checked>
-      
-      
-      
-      
+
+
+
+
         <label class="md-nav__link" for="__nav_6">
           Wiki
           <span class="md-nav__icon md-icon"></span>
         </label>
-      
+
       <nav class="md-nav" aria-label="Wiki" data-md-level="1">
         <label class="md-nav__title" for="__nav_6">
           <span class="md-nav__icon md-icon"></span>
           Wiki
         </label>
         <ul class="md-nav__list" data-md-scrollfix>
-          
-            
-              
-  
-  
-    
-  
-  
+
+
+
+
+
+
+
+
     <li class="md-nav__item md-nav__item--active">
-      
+
       <input class="md-nav__toggle md-toggle" data-md-toggle="toc" type="checkbox" id="__toc">
-      
-      
-        
-      
-      
+
+
+
+
+
         <label class="md-nav__link md-nav__link--active" for="__toc">
           Audiovisual Mods
           <span class="md-nav__icon md-icon"></span>
         </label>
-      
+
       <a href="./" class="md-nav__link md-nav__link--active">
         Audiovisual Mods
       </a>
-      
-        
+
+
 
 <nav class="md-nav md-nav--secondary" aria-label="Table of contents">
-  
-  
-  
-    
-  
-  
+
+
+
+
+
+
     <label class="md-nav__title" for="__toc">
       <span class="md-nav__icon md-icon"></span>
       Table of contents
     </label>
     <ul class="md-nav__list" data-md-component="toc" data-md-scrollfix>
-      
+
         <li class="md-nav__item">
   <a href="#permanent-audiovisual-mods" class="md-nav__link">
     Permanent audiovisual mods
   </a>
-  
+
 </li>
-      
+
         <li class="md-nav__item">
   <a href="#override-built-in-graphics" class="md-nav__link">
     Override built-in graphics
   </a>
-  
+
 </li>
-      
+
         <li class="md-nav__item">
   <a href="#supply-additional-graphics" class="md-nav__link">
     Supply additional graphics
   </a>
-  
+
     <nav class="md-nav" aria-label="Supply additional graphics">
       <ul class="md-nav__list">
-        
+
           <li class="md-nav__item">
   <a href="#adding-wonder-splash-screens" class="md-nav__link">
     Adding Wonder Splash Screens
   </a>
-  
+
 </li>
-        
+
           <li class="md-nav__item">
   <a href="#adding-leader-portraits" class="md-nav__link">
     Adding Leader Portraits
   </a>
-  
+
 </li>
 
-    <li class="md-nav__item">
-  <a href="#adding-unit-portraits" class="md-nav__link">
-    Adding Unit and Building Portraits
-  </a>
-  
-</li>
-        
       </ul>
     </nav>
-  
+
 </li>
-      
+
         <li class="md-nav__item">
   <a href="#override-built-in-sounds" class="md-nav__link">
     Override built-in sounds
   </a>
-  
+
 </li>
-      
+
         <li class="md-nav__item">
   <a href="#supply-additional-music" class="md-nav__link">
     Supply additional music
   </a>
-  
+
     <nav class="md-nav" aria-label="Supply additional music">
       <ul class="md-nav__list">
-        
+
           <li class="md-nav__item">
   <a href="#context-sensitive-music-overview" class="md-nav__link">
     Context-sensitive music: Overview
   </a>
-  
+
 </li>
-        
+
           <li class="md-nav__item">
   <a href="#context-sensitive-music-list-of-triggers" class="md-nav__link">
     Context-sensitive music: List of Triggers
   </a>
-  
+
 </li>
-        
+
       </ul>
     </nav>
-  
-</li>
-      
-    </ul>
-  
-</nav>
-      
-    </li>
-  
 
-            
-          
-            
-              
-  
-  
-  
+</li>
+
+    </ul>
+
+</nav>
+
+    </li>
+
+
+
+
+
+
+
+
+
     <li class="md-nav__item">
       <a href="../Building-locally-without-Android-Studio/" class="md-nav__link">
         Building locally without Android Studio
       </a>
     </li>
-  
 
-            
-          
-            
-              
-  
-  
-  
+
+
+
+
+
+
+
+
     <li class="md-nav__item">
       <a href="../Civilization-related-JSON-files/" class="md-nav__link">
         Civilization related JSON files
       </a>
     </li>
-  
 
-            
-          
-            
-              
-  
-  
-  
+
+
+
+
+
+
+
+
     <li class="md-nav__item">
       <a href="../Coding-standards/" class="md-nav__link">
         Coding standards
       </a>
     </li>
-  
 
-            
-          
-            
-              
-  
-  
-  
+
+
+
+
+
+
+
+
     <li class="md-nav__item">
       <a href="../Creating-a-custom-tileset/" class="md-nav__link">
         How to make Unciv use your custom tileset
       </a>
     </li>
-  
 
-            
-          
-            
-              
-  
-  
-  
+
+
+
+
+
+
+
+
     <li class="md-nav__item">
       <a href="../Force-rating-calculation/" class="md-nav__link">
         Force rating
       </a>
     </li>
-  
 
-            
-          
-            
-              
-  
-  
-  
+
+
+
+
+
+
+
+
     <li class="md-nav__item">
       <a href="../From-code-to-deployment/" class="md-nav__link">
         From code to deployment
       </a>
     </li>
-  
 
-            
-          
-            
-              
-  
-  
-  
+
+
+
+
+
+
+
+
     <li class="md-nav__item">
       <a href="../Getting-Started/" class="md-nav__link">
         Getting Started
       </a>
     </li>
-  
 
-            
-          
-            
-              
-  
-  
-  
+
+
+
+
+
+
+
+
     <li class="md-nav__item">
       <a href="../Home/" class="md-nav__link">
         Home
       </a>
     </li>
-  
 
-            
-          
-            
-              
-  
-  
-  
+
+
+
+
+
+
+
+
     <li class="md-nav__item">
       <a href="../Installing-on-macOS/" class="md-nav__link">
         Installing on macOS
       </a>
     </li>
-  
 
-            
-          
-            
-              
-  
-  
-  
+
+
+
+
+
+
+
+
     <li class="md-nav__item">
       <a href="../JSON-files-for-mods/" class="md-nav__link">
         JSON files for mods
       </a>
     </li>
-  
 
-            
-          
-            
-              
-  
-  
-  
+
+
+
+
+
+
+
+
     <li class="md-nav__item">
       <a href="../Making-a-new-Civilization/" class="md-nav__link">
         Making a new Civilization
       </a>
     </li>
-  
 
-            
-          
-            
-              
-  
-  
-  
+
+
+
+
+
+
+
+
     <li class="md-nav__item">
       <a href="../Map-related-JSON-files/" class="md-nav__link">
         Map related JSON files
       </a>
     </li>
-  
 
-            
-          
-            
-              
-  
-  
-  
+
+
+
+
+
+
+
+
     <li class="md-nav__item">
       <a href="../Miscellaneous-JSON-files/" class="md-nav__link">
         Miscellaneous JSON files
       </a>
     </li>
-  
 
-            
-          
-            
-              
-  
-  
-  
+
+
+
+
+
+
+
+
     <li class="md-nav__item">
       <a href="../Mods/" class="md-nav__link">
         Mods
       </a>
     </li>
-  
 
-            
-          
-            
-              
-  
-  
-  
+
+
+
+
+
+
+
+
     <li class="md-nav__item">
       <a href="../Project-structure-and-major-classes/" class="md-nav__link">
         Project structure
       </a>
     </li>
-  
 
-            
-          
-            
-              
-  
-  
-  
+
+
+
+
+
+
+
+
     <li class="md-nav__item">
       <a href="../Regions/" class="md-nav__link">
         Regions
       </a>
     </li>
-  
 
-            
-          
-            
-              
-  
-  
-  
+
+
+
+
+
+
+
+
     <li class="md-nav__item">
       <a href="../Translating/" class="md-nav__link">
         Translating
       </a>
     </li>
-  
 
-            
-          
-            
-              
-  
-  
-  
+
+
+
+
+
+
+
+
     <li class="md-nav__item">
       <a href="../Translations%2C-mods%2C-and-modding-freedom-in-Open-Source/" class="md-nav__link">
         Translations, mods, and modding freedom in Open Source
       </a>
     </li>
-  
 
-            
-          
-            
-              
-  
-  
-  
+
+
+
+
+
+
+
+
     <li class="md-nav__item">
       <a href="../Uniques/" class="md-nav__link">
         Uniques
       </a>
     </li>
-  
 
-            
-          
-            
-              
-  
-  
-  
+
+
+
+
+
+
+
+
     <li class="md-nav__item">
       <a href="../Unit-related-JSON-files/" class="md-nav__link">
         Unit related JSON files
       </a>
     </li>
-  
 
-            
-          
-            
-              
-  
-  
-  
+
+
+
+
+
+
+
+
     <li class="md-nav__item">
       <a href="../_Footer/" class="md-nav__link">
          Footer
       </a>
     </li>
-  
 
-            
-          
-            
-              
-  
-  
-  
+
+
+
+
+
+
+
+
     <li class="md-nav__item">
       <a href="../_Sidebar/" class="md-nav__link">
         [Home](.)
       </a>
     </li>
-  
 
-            
-          
+
+
+
         </ul>
       </nav>
     </li>
-  
 
-    
+
+
   </ul>
 </nav>
                   </div>
                 </div>
               </div>
-            
-            
-              
+
+
+
               <div class="md-sidebar md-sidebar--secondary" data-md-component="sidebar" data-md-type="toc" >
                 <div class="md-sidebar__scrollwrap">
                   <div class="md-sidebar__inner">
-                    
+
 
 <nav class="md-nav md-nav--secondary" aria-label="Table of contents">
-  
-  
-  
-    
-  
-  
+
+
+
+
+
+
     <label class="md-nav__title" for="__toc">
       <span class="md-nav__icon md-icon"></span>
       Table of contents
     </label>
     <ul class="md-nav__list" data-md-component="toc" data-md-scrollfix>
-      
+
         <li class="md-nav__item">
   <a href="#permanent-audiovisual-mods" class="md-nav__link">
     Permanent audiovisual mods
   </a>
-  
+
 </li>
-      
+
         <li class="md-nav__item">
   <a href="#override-built-in-graphics" class="md-nav__link">
     Override built-in graphics
   </a>
-  
+
 </li>
-      
+
         <li class="md-nav__item">
   <a href="#supply-additional-graphics" class="md-nav__link">
     Supply additional graphics
   </a>
-  
+
     <nav class="md-nav" aria-label="Supply additional graphics">
       <ul class="md-nav__list">
-        
+
           <li class="md-nav__item">
   <a href="#adding-wonder-splash-screens" class="md-nav__link">
     Adding Wonder Splash Screens
   </a>
-  
+
 </li>
-        
+
           <li class="md-nav__item">
   <a href="#adding-leader-portraits" class="md-nav__link">
     Adding Leader Portraits
   </a>
-  
+
 </li>
 
-         <li class="md-nav__item">
-  <a href="#adding-unit-portraits" class="md-nav__link">
-    Adding Unit and Building Portraits
-  </a>
-  
-</li>
-        
       </ul>
     </nav>
-  
+
 </li>
-      
+
         <li class="md-nav__item">
   <a href="#override-built-in-sounds" class="md-nav__link">
     Override built-in sounds
   </a>
-  
+
 </li>
-      
+
         <li class="md-nav__item">
   <a href="#supply-additional-music" class="md-nav__link">
     Supply additional music
   </a>
-  
+
     <nav class="md-nav" aria-label="Supply additional music">
       <ul class="md-nav__list">
-        
+
           <li class="md-nav__item">
   <a href="#context-sensitive-music-overview" class="md-nav__link">
     Context-sensitive music: Overview
   </a>
-  
+
 </li>
-        
+
           <li class="md-nav__item">
   <a href="#context-sensitive-music-list-of-triggers" class="md-nav__link">
     Context-sensitive music: List of Triggers
   </a>
-  
+
 </li>
-        
+
       </ul>
     </nav>
-  
+
 </li>
-      
+
     </ul>
-  
+
 </nav>
                   </div>
                 </div>
               </div>
-            
-          
+
+
           <div class="md-content" data-md-component="content">
             <article class="md-content__inner md-typeset">
-              
-                
+
+
 
 
 <h1 id="audiovisual-mods">Audiovisual Mods</h1>
@@ -865,10 +851,6 @@
 <p>The base game comes without Leader Portraits, but is able to display them in greetings, Civilopedia, diplomacy screens, or the nation picker. A mod can supply these, by adding their images to <code>/Images/LeaderIcons/</code>. The file name must correspond exactly with the leader name of a nation as defined in Nations.json, or they will be ignored.</p>
 <p>These work best if they are square, between 100x100 and 256x256 pixels, and include some transparent border within that area.</p>
 <p>For example, <a href="https://github.com/yairm210/Unciv-leader-portrait-mod-example">here</a> is mod showing how to add leader portraits, which can complement the base game.</p>
-<h3 id="adding-unit-portraits">Adding Unit and Building Portraits</h3>
-<p>The base game comes without Unit and Building portraits (only flags are displayed) but is able to display them in city screen, overview screen, Civilopedia, tech tree, etc. A mod can supply these, by adding their images to <code>/Images/UnitPortraits/</code> and <code>/Images/BuildingPortraits/</code>. The file name must correspond exactly with the Unit/Building name as defined in Units.json and Buildings.json, or they will be ignored.</p>
-<p>These work best if they are full RGB square, between 100x100 and 256x256 pixels, and include some transparent border within that area.</p>
-<p>For example, <a href="https://github.com/vegeta1k95/Civ-5-Icons">here</a> is mod showing how to add units portraits, which can complement the base game.</p>
 <h2 id="override-built-in-sounds">Override built-in sounds</h2>
 <p>This works like graphics, except no atlas is involved. E.g. you include a sounds/Click.mp3, it will play instead of the normal click sound. These files must stay short and small. A sound larger than 1MB when uncompressed may break or not play at all on mobile devices. Unciv tries to standardize on 24kHz sample rate, joint stereo, low-bitrate VBR (-128kbps) mp3. Only mp3 and ogg formats will be recognized (but an existing mp3 can be overridden with an ogg file).</p>
 <h2 id="supply-additional-music">Supply additional music</h2>
@@ -1030,18 +1012,18 @@
 [^5]: Both in the alert when another player declares War on you and declaring War yourself in Diplomacy screen.
 [^6]: Yes these flags are not optimal.</p>
 
-              
+
             </article>
           </div>
         </div>
-        
+
       </main>
-      
+
         <footer class="md-footer">
-  
+
     <nav class="md-footer__inner md-grid" aria-label="Footer">
-      
-        
+
+
         <a href="../../uniques/" class="md-footer__link md-footer__link--prev" aria-label="Previous: Uniques" rel="prev">
           <div class="md-footer__button md-icon">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M20 11v2H8l5.5 5.5-1.42 1.42L4.16 12l7.92-7.92L13.5 5.5 8 11h12z"/></svg>
@@ -1055,9 +1037,9 @@
             </div>
           </div>
         </a>
-      
-      
-        
+
+
+
         <a href="../Building-locally-without-Android-Studio/" class="md-footer__link md-footer__link--next" aria-label="Next: Building locally without Android Studio" rel="next">
           <div class="md-footer__title">
             <div class="md-ellipsis">
@@ -1071,34 +1053,34 @@
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M4 11v2h12l-5.5 5.5 1.42 1.42L19.84 12l-7.92-7.92L10.5 5.5 16 11H4z"/></svg>
           </div>
         </a>
-      
+
     </nav>
-  
+
   <div class="md-footer-meta md-typeset">
     <div class="md-footer-meta__inner md-grid">
       <div class="md-copyright">
-  
-  
+
+
     Made with
     <a href="https://squidfunk.github.io/mkdocs-material/" target="_blank" rel="noopener">
       Material for MkDocs
     </a>
-  
+
 </div>
-      
+
     </div>
   </div>
 </footer>
-      
+
     </div>
     <div class="md-dialog" data-md-component="dialog">
       <div class="md-dialog__inner md-typeset"></div>
     </div>
     <script id="__config" type="application/json">{"base": "../..", "features": [], "translations": {"clipboard.copy": "Copy to clipboard", "clipboard.copied": "Copied to clipboard", "search.config.lang": "en", "search.config.pipeline": "trimmer, stopWordFilter", "search.config.separator": "[\\s\\-]+", "search.placeholder": "Search", "search.result.placeholder": "Type to start searching", "search.result.none": "No matching documents", "search.result.one": "1 matching document", "search.result.other": "# matching documents", "search.result.more.one": "1 more on this page", "search.result.more.other": "# more on this page", "search.result.term.missing": "Missing", "select.version.title": "Select version"}, "search": "../../assets/javascripts/workers/search.bd0b6b67.min.js"}</script>
-    
-    
+
+
       <script src="../../assets/javascripts/bundle.8aa65030.min.js"></script>
-      
-    
+
+
   </body>
 </html>

--- a/site/wiki/Audiovisual-Mods/index.html
+++ b/site/wiki/Audiovisual-Mods/index.html
@@ -348,6 +348,13 @@
   </a>
   
 </li>
+
+    <li class="md-nav__item">
+  <a href="#adding-unit-portraits" class="md-nav__link">
+    Adding Unit and Building Portraits
+  </a>
+  
+</li>
         
       </ul>
     </nav>
@@ -772,6 +779,13 @@
   </a>
   
 </li>
+
+         <li class="md-nav__item">
+  <a href="#adding-unit-portraits" class="md-nav__link">
+    Adding Unit and Building Portraits
+  </a>
+  
+</li>
         
       </ul>
     </nav>
@@ -851,6 +865,10 @@
 <p>The base game comes without Leader Portraits, but is able to display them in greetings, Civilopedia, diplomacy screens, or the nation picker. A mod can supply these, by adding their images to <code>/Images/LeaderIcons/</code>. The file name must correspond exactly with the leader name of a nation as defined in Nations.json, or they will be ignored.</p>
 <p>These work best if they are square, between 100x100 and 256x256 pixels, and include some transparent border within that area.</p>
 <p>For example, <a href="https://github.com/yairm210/Unciv-leader-portrait-mod-example">here</a> is mod showing how to add leader portraits, which can complement the base game.</p>
+<h3 id="adding-unit-portraits">Adding Unit and Building Portraits</h3>
+<p>The base game comes without Unit and Building portraits (only flags are displayed) but is able to display them in city screen, overview screen, Civilopedia, tech tree, etc. A mod can supply these, by adding their images to <code>/Images/UnitPortraits/</code> and <code>/Images/BuildingPortraits/</code>. The file name must correspond exactly with the Unit/Building name as defined in Units.json and Buildings.json, or they will be ignored.</p>
+<p>These work best if they are full RGB square, between 100x100 and 256x256 pixels, and include some transparent border within that area.</p>
+<p>For example, <a href="https://github.com/vegeta1k95/Civ-5-Icons">here</a> is mod showing how to add units portraits, which can complement the base game.</p>
 <h2 id="override-built-in-sounds">Override built-in sounds</h2>
 <p>This works like graphics, except no atlas is involved. E.g. you include a sounds/Click.mp3, it will play instead of the normal click sound. These files must stay short and small. A sound larger than 1MB when uncompressed may break or not play at all on mobile devices. Unciv tries to standardize on 24kHz sample rate, joint stereo, low-bitrate VBR (-128kbps) mp3. Only mp3 and ogg formats will be recognized (but an existing mp3 can be overridden with an ogg file).</p>
 <h2 id="supply-additional-music">Supply additional music</h2>


### PR DESCRIPTION
If mod provides an atlas with entries:

`UnitPortraits/*unit name*`
`BuildingPortraits/*building name*`

these portraits will be displayed everywhere (CityView, TechButtons, Civilopedia, etc) instead of flags, except the map itself - on the map units still use flags, as in Civ 5.

Example: my [Civ-5-Icons mod](https://github.com/vegeta1k95/Civ-5-Icons), some unit are given portraits, some don't (so they remain with flag only).
![image](https://user-images.githubusercontent.com/32207817/206813959-522fc260-9e6a-48f7-9fd0-7519c964c4cb.png)
![image](https://user-images.githubusercontent.com/32207817/206813968-3dd1ee97-62cd-4ff6-ba97-61e9f62f7f90.png)
![image](https://user-images.githubusercontent.com/32207817/206813976-bb2e56b0-5e12-452d-b0cd-782cc94206a3.png)
