### PR TITLE
update score icon.

### DIFF
--- a/core/src/com/unciv/ui/overviewscreen/StatsOverviewTable.kt
+++ b/core/src/com/unciv/ui/overviewscreen/StatsOverviewTable.kt
@@ -176,7 +176,7 @@ class StatsOverviewTab(
     private fun updateScoreTable() = scoreTable.apply {
         clear()
         val scoreHeader = Table()
-        val scoreIcon = ImageGetter.getImage("OtherIcons/Cultured")
+        val scoreIcon = ImageGetter.getImage("CityStateIcons/Cultured")
         scoreIcon.color = Color.FIREBRICK
         scoreHeader.add(scoreIcon).padRight(1f).size(Constants.headingFontSize.toFloat())
         scoreHeader.add("Score".toLabel(fontSize = Constants.headingFontSize))

--- a/core/src/com/unciv/ui/victoryscreen/RankingType.kt
+++ b/core/src/com/unciv/ui/victoryscreen/RankingType.kt
@@ -6,7 +6,7 @@ import com.unciv.ui.images.ImageGetter
 
 enum class RankingType(val getImage: ()->Image?) {
     // production, gold, happiness, and culture already have icons added when the line is `tr()`anslated
-        Score({ ImageGetter.getImage("OtherIcons/Cultured").apply { color = Color.FIREBRICK } }),
+        Score({ ImageGetter.getImage("CityStateIcons/Cultured").apply { color = Color.FIREBRICK } }),
         Population({ ImageGetter.getStatIcon("Population") }),
         Crop_Yield({ ImageGetter.getStatIcon("Food") }),
         Production({ null }),


### PR DESCRIPTION
fix #8114 

Replace `OtherIcons/Cultured` with `CityStateIcons/Cultured` .

Refer commit: [Moved city state icons to separate folder](https://github.com/yairm210/Unciv/commit/c5bde45c5dc6c781f63ca2f32f16a02c38798823#diff-b1b3f1dea539497644a040230f99799cac788a0ad467b5351514b84ba05adc48)