### PR TITLE
Fix bug, where Unit flags backgrounds appear on CityScreen tiles

### DIFF
--- a/core/src/com/unciv/ui/cityscreen/CityTileGroup.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityTileGroup.kt
@@ -1,5 +1,6 @@
 package com.unciv.ui.cityscreen
 
+import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.utils.Align
 import com.unciv.logic.city.CityInfo
@@ -73,8 +74,6 @@ class CityTileGroup(private val city: CityInfo, tileInfo: TileInfo, tileSetStrin
         terrainFeatureLayerGroup.color.a = 0.5f
         icons.improvementIcon?.setColor(1f, 1f, 1f, 0.5f)
         resourceImage?.setColor(1f, 1f, 1f, 0.5f)
-        icons.civilianUnitIcon?.setColor(1f, 1f, 1f, 0.5f)
-        icons.militaryUnitIcon?.setColor(1f, 1f, 1f, 0.5f)
         updatePopulationIcon()
         updateYieldGroup()
     }

--- a/core/src/com/unciv/ui/tilegroups/TileGroup.kt
+++ b/core/src/com/unciv/ui/tilegroups/TileGroup.kt
@@ -370,7 +370,6 @@ open class TileGroup(
             terrainFeatureLayerGroup, borderLayerGroup, miscLayerGroup,
             pixelMilitaryUnitGroup, pixelCivilianUnitGroup, unitLayerGroup,
             cityButtonLayerGroup, highlightFogCrosshairLayerGroup)
-        for (group in allGroups) group.isVisible = true
 
         if (viewingCiv != null && !isExplored(viewingCiv)) {
             if (tileInfo.neighbors.any { viewingCiv.hasExplored(it) })


### PR DESCRIPTION
For some reason, there was a code inside TileGroup, which had been forcefully setting visibility of many layers (including unitLayer) to true. Removed.

Was it for some edge-case?