### PR TITLE
Fix bug, where units do not reveal tiles (#8161)

### DIFF
--- a/core/src/com/unciv/ui/cityscreen/CityTileGroup.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityTileGroup.kt
@@ -71,6 +71,7 @@ class CityTileGroup(private val city: CityInfo, tileInfo: TileInfo, tileSetStrin
             }
         }
 
+        unitLayerGroup.isVisible = false
         terrainFeatureLayerGroup.color.a = 0.5f
         icons.improvementIcon?.setColor(1f, 1f, 1f, 0.5f)
         resourceImage?.setColor(1f, 1f, 1f, 0.5f)

--- a/core/src/com/unciv/ui/tilegroups/TileGroup.kt
+++ b/core/src/com/unciv/ui/tilegroups/TileGroup.kt
@@ -370,6 +370,7 @@ open class TileGroup(
             terrainFeatureLayerGroup, borderLayerGroup, miscLayerGroup,
             pixelMilitaryUnitGroup, pixelCivilianUnitGroup, unitLayerGroup,
             cityButtonLayerGroup, highlightFogCrosshairLayerGroup)
+        for (group in allGroups) group.isVisible = true
 
         if (viewingCiv != null && !isExplored(viewingCiv)) {
             if (tileInfo.neighbors.any { viewingCiv.hasExplored(it) })


### PR DESCRIPTION
This should solve [#8161](https://github.com/yairm210/Unciv/pull/8150) as well as keep flags off in CityScreen.