### PR TITLE
Construction table: ordering change (Civ 5) + add/remove on double-click

### DIFF
--- a/core/src/com/unciv/ui/cityscreen/CityConstructionsTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityConstructionsTable.kt
@@ -264,9 +264,9 @@ class CityConstructionsTable(private val cityScreen: CityScreen) {
                     clear()
                     defaults().left().bottom()
                     addCategory("Units", units, maxButtonWidth)
+                    addCategory("Buildings", buildableBuildings, maxButtonWidth)
                     addCategory("Wonders", buildableWonders, maxButtonWidth)
                     addCategory("National Wonders", buildableNationalWonders, maxButtonWidth)
-                    addCategory("Buildings", buildableBuildings, maxButtonWidth)
                     addCategory("Other", specialConstructions, maxButtonWidth)
                     pack()
                 }
@@ -322,8 +322,14 @@ class CityConstructionsTable(private val cityScreen: CityScreen) {
 
         table.touchable = Touchable.enabled
         table.onClick {
-            cityScreen.selectConstruction(constructionName)
-            selectedQueueEntry = constructionQueueIndex
+            if (selectedQueueEntry == constructionQueueIndex) {
+                city.cityConstructions.removeFromQueue(constructionQueueIndex, false)
+                selectedQueueEntry = -1
+                cityScreen.clearSelection()
+            } else {
+                cityScreen.selectConstruction(constructionName)
+                selectedQueueEntry = constructionQueueIndex
+            }
             cityScreen.update()
         }
         return table
@@ -381,7 +387,11 @@ class CityConstructionsTable(private val cityScreen: CityScreen) {
                     .colspan(pickConstructionButton.columns).fillX().left().padTop(2f)
         }
         pickConstructionButton.onClick {
-            cityScreen.selectConstruction(construction)
+            if (cityScreen.selectedConstruction == construction) {
+                addConstructionToQueue(construction, cityScreen.city.cityConstructions)
+            } else {
+                cityScreen.selectConstruction(construction)
+            }
             selectedQueueEntry = -1
             cityScreen.update()
         }


### PR DESCRIPTION
Few changes:

1) Construction table ordering changed:
From: Units -> Wonder -> National Wonders -> Buildings -> Other 
To:     Units -> Buildings -> Wonders -> National Wonders -> Other (Civ 5 ordering)

2) Now constructions can be added to/removed from a queue by double-click: first click is selection (highlighted green), next click adds/removes item to/from queue. This one is very handy, I hate to stretch my fingers to reach small "+" buttons or "Add to queue" at top.
