### PR TITLE
Fix new "temperature" map setting not translatable

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -395,6 +395,7 @@ Advanced Settings =
 RNG Seed = 
 Map Elevation = 
 Temperature extremeness = 
+Temperature shift = 
 Resource richness = 
 Vegetation richness = 
 Rare features richness = 


### PR DESCRIPTION
New map setting `Temperature shift` is not translatable. It seems coders like to forget to add new translation entries in `template.properties`. :grin:

<details><summary>Before</summary>
<img src="https://user-images.githubusercontent.com/64586749/208280123-feaad5cf-7031-4e9e-8768-61cc3d78987c.jpg">
</details>

<details><summary>After</summary>
<img src="https://user-images.githubusercontent.com/11946570/208314785-82cec26d-8aab-45a0-8898-02b689ecee69.png">
</details>