### PR TITLE
Update trade UI.

### DIFF
--- a/core/src/com/unciv/ui/trade/OfferColumnsTable.kt
+++ b/core/src/com/unciv/ui/trade/OfferColumnsTable.kt
@@ -59,8 +59,8 @@ class OfferColumnsTable(private val tradeLogic: TradeLogic, val screen: Diplomac
         add("Our items".tr())
         add("[${tradeLogic.otherCivilization.civName}]'s items".tr()).row()
 
-        add(ourAvailableOffersTable).size(columnWidth, screen.stage.height / 2)
-        add(theirAvailableOffersTable).size(columnWidth, screen.stage.height / 2).row()
+        add(ourAvailableOffersTable).prefSize(columnWidth, screen.stage.height / 2)
+        add(theirAvailableOffersTable).prefSize(columnWidth, screen.stage.height / 2).row()
 
         addSeparator().height(2f)
 

--- a/core/src/com/unciv/ui/trade/OffersListScroll.kt
+++ b/core/src/com/unciv/ui/trade/OffersListScroll.kt
@@ -96,7 +96,8 @@ class OffersListScroll(
                     else -> null
                 }
                 val tradeButton = IconTextButton(tradeLabel, tradeIcon).apply {
-                    iconCell?.size(30f)
+                    if (tradeIcon != null)
+                        iconCell.size(30f)
                     label.setAlignment(Align.center)
                     labelCell.pad(5f).grow()
                 }


### PR DESCRIPTION
# Some UI Issue

<img width="1372" alt="截圖 2022-12-19 下午7 06 57" src="https://user-images.githubusercontent.com/17497074/208430334-aa13357e-9dcf-42d1-9042-fe0d4d2dc158.png">

1. On the top area, the text is being cut off by the boundaries of the screen.
2. For every trade item button, text is being pushed to the right side of button. It should align in the center.

----

After: 
<img width="1353" alt="截圖 2022-12-19 下午8 50 48" src="https://user-images.githubusercontent.com/17497074/208432183-303e80ab-d77c-47ec-8b39-9cbafdb064c9.png">

