### PR TITLE
Removing repetition

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -255,7 +255,6 @@ Religious =
 Militaristic = 
 Type = 
 Friendly = 
-Neutral = 
 Hostile = 
 Irrational = 
 Personality = 


### PR DESCRIPTION
All translations have ```Neutral = ``` only at line 161, only template have 2 of it at line 161 and 258.