### PR TITLE
Update template.properties

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -732,6 +732,7 @@ Enable portrait orientation =
 Generate translation files = 
 Translation files are generated successfully. = 
 Fastlane files are generated successfully. = 
+Generate screenshots = 
 Please note that translations are a community-based work in progress and are INCOMPLETE! The percentage shown is how much of the language is translated in-game. If you want to help translating the game into your language, click here. = 
 Font family = 
 Font size multiplier = 


### PR DESCRIPTION
Missing line on template
Found on 4.3.10 Window64, Still exists on 4.3.11

<details><summary>details</summary>

Menu - Setting - Advanced setting - Generate screenshot
![win4 3 10 settings](https://user-images.githubusercontent.com/64586749/208911211-e72d9a76-9a28-4288-8b6b-e25e8235b4fa.jpg)
</details>