### PR TITLE
Civ 5: unit selection and cycling behaviour, "Wait" action

### DIFF
--- a/core/src/com/unciv/ui/tilegroups/CityButton.kt
+++ b/core/src/com/unciv/ui/tilegroups/CityButton.kt
@@ -383,10 +383,12 @@ class CityButton(val city: CityInfo, private val tileGroup: WorldTileGroup): Tab
         val groupHeight = 25f
         val groupWidth = if (cityCurrentConstruction is PerpetualConstruction) 15f else 40f
         group.setSize(groupWidth, groupHeight)
-        val constructionImage = ImageGetter.getPortraitImage(cityConstructions.currentConstructionFromQueue, 25f)
-        constructionImage.centerY(group)
-        constructionImage.x = group.width - constructionImage.width
-        group.addActor(constructionImage)
+        if (cityConstructions.currentConstructionFromQueue.isNotEmpty()) {
+            val constructionImage = ImageGetter.getPortraitImage(cityCurrentConstruction.name, 25f)
+            constructionImage.centerY(group)
+            constructionImage.x = group.width - constructionImage.width
+            group.addActor(constructionImage)
+        }
 
         val secondaryColor = cityConstructions.cityInfo.civInfo.nation.getInnerColor()
         if (cityCurrentConstruction !is PerpetualConstruction) {

--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -630,10 +630,12 @@ class WorldScreen(
                 selectUnit = false
             )
             bottomUnitTable.selectUnit(nextDueUnit)
-            shouldUpdate = true
-            // Unless 'wait' action is chosen, the unit will not be considered due anymore.
-            nextDueUnit.due = false
+        } else {
+            mapHolder.removeAction(mapHolder.blinkAction)
+            mapHolder.selectedTile = null
+            bottomUnitTable.selectUnit()
         }
+        shouldUpdate = true
     }
 
     private fun isNextTurnUpdateRunning(): Boolean {

--- a/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
@@ -945,12 +945,10 @@ object UnitActions {
     }
 
     private fun addWaitAction(unit: MapUnit, actionList: ArrayList<UnitAction>, worldScreen: WorldScreen) {
-        if (!unit.isIdle()) return
-        if (worldScreen.viewingCiv.getDueUnits().filter { it != unit }.none()) return
         actionList += UnitAction(
             type = UnitActionType.Wait,
             action = {
-                unit.due = true
+                unit.due = false
                 worldScreen.switchToNextUnit()
             }
         )


### PR DESCRIPTION
1) Changed priority of selection of units when clicked on a tile to (Civ 5 behaviour):
GP + Settlers -> Military -> Civilian other (workers) -> None (deselection)

This particulary means that when starting a new game, your settler will be automatically focused first (I hated that game has been starting with a warrior in focus)

2) Selecting units manually (click) does not un-due them.

2) "Wait" action now is always present and behaves accordingly to Civ 5: it un-due unit until the next turn (unit does not require any action this turn)

3) After last due unit has been given order, we deselect (defocus) unit and tile on which it is standing.

4) (Misc.) WorldScreen CityButton construction portrait now is invisible (instead of weird white circle) if city has nothing in queue (e.g. was just founded)