### PR TITLE
Remove "Experimental" warning text

### DIFF
--- a/core/src/com/unciv/ui/options/AdvancedTab.kt
+++ b/core/src/com/unciv/ui/options/AdvancedTab.kt
@@ -53,7 +53,7 @@ fun advancedTab(
     addAutosaveTurnsSelectBox(this, settings)
 
     optionsPopup.addCheckbox(
-        this, "{Show experimental world wrap for maps}\n{HIGHLY EXPERIMENTAL - YOU HAVE BEEN WARNED!}",
+        this, "{Show world wrap for maps}",
         settings.showExperimentalWorldWrap
     ) {
         settings.showExperimentalWorldWrap = it

--- a/core/src/com/unciv/ui/options/DisplayTab.kt
+++ b/core/src/com/unciv/ui/options/DisplayTab.kt
@@ -36,7 +36,7 @@ fun displayTab(
     optionsPopup.addCheckbox(this, "Show resources and improvements", settings.showResourcesAndImprovements, true) { settings.showResourcesAndImprovements = it }
     optionsPopup.addCheckbox(this, "Show tutorials", settings.showTutorials, true) { settings.showTutorials = it }
     optionsPopup.addCheckbox(this, "Show pixel improvements", settings.showPixelImprovements, true) { settings.showPixelImprovements = it }
-    optionsPopup.addCheckbox(this, "Experimental Demographics scoreboard", settings.useDemographics, true) { settings.useDemographics = it }
+    optionsPopup.addCheckbox(this, "Show Demographics scoreboard", settings.useDemographics, true) { settings.useDemographics = it }
     optionsPopup.addCheckbox(this, "Show zoom buttons in world screen", settings.showZoomButtons, true) { settings.showZoomButtons = it }
 
     addMinimapSizeSlider(this, settings, optionsPopup.selectBoxMinWidth)


### PR DESCRIPTION
The "Experimental" warning text, especially for world wrap, can be removed. They are unnecessary at this point after the features have been working well for many months.

![Experimental](https://user-images.githubusercontent.com/56904240/209393364-456d4c98-fba6-4cd0-82f4-56abf090c596.png)
