### PR TITLE
fix a translation problem in policy screen

### DIFF
--- a/core/src/com/unciv/models/ruleset/Policy.kt
+++ b/core/src/com/unciv/models/ruleset/Policy.kt
@@ -35,10 +35,10 @@ open class Policy : RulesetObject() {
     fun getDescription(): String {
         var text = uniques
             .filter { !it.contains(UniqueType.OnlyAvailableWhen.text) }
-            .joinToString("\n", transform = { "• $it".tr() })
+            .joinToString("\n", transform = { "• ${it.tr()}" })
         if (policyBranchType != PolicyBranchType.BranchStart
                 && policyBranchType != PolicyBranchType.BranchComplete)
-            text = name + "\n" + text
+            text = name.tr() + "\n" + text
         return text
     }
 


### PR DESCRIPTION
As the screenshot shown below, the name of the policy is not translated; the dot is placed after the conditionals in some languages. Apply this commit will solve this problem.

![Screenshot_20221225_165744](https://user-images.githubusercontent.com/64761703/209462566-fbd7667b-f1d1-4504-9e10-377fa621934f.jpg)
