### PR TITLE
The tile still has owner after city has been razed.

### DIFF
--- a/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
+++ b/core/src/com/unciv/logic/civilization/CivilizationInfo.kt
@@ -1002,7 +1002,11 @@ class CivilizationInfo : IsPartOfGameInfoSerialization {
 
         if (isMajorCiv()) greatPeople.addGreatPersonPoints(getGreatPersonPointsForNextTurn()) // City-states don't get great people!
 
-        for (city in cities.toList()) { // a city can be removed while iterating (if it's being razed) so we need to iterate over a copy
+        // To handle tile's owner issue (#8246), we need to run being razed city first.
+        for (city in sequence {
+            yieldAll(cities.filter { it.isBeingRazed })
+            yieldAll(cities.filterNot { it.isBeingRazed })
+        }) {
             city.endTurn()
         }
 

--- a/core/src/com/unciv/ui/cityscreen/CityScreenTileTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityScreenTileTable.kt
@@ -74,7 +74,7 @@ class CityScreenTileTable(private val cityScreen: CityScreen): Table() {
         if (selectedTile.owningCity != null)
             innerTable.add("Owned by [${selectedTile.owningCity!!.name}]".toLabel()).row()
 
-        if (city.civInfo.cities.filterNot { it == city }.any { it.isWorked(selectedTile) })
+        if (selectedTile.getWorkingCity() != null)
             innerTable.add("Worked by [${selectedTile.getWorkingCity()!!.name}]".toLabel()).row()
 
         if (city.isWorked(selectedTile)) {


### PR DESCRIPTION
resolve #8246 

For the beginning, the target tile belong to city `Sukhothai`. To the next turn, the city `Phitsanulok` had been razed and the tile should lose the owner, but there still has a city own this title (`CityScreenTileTalbe:kt:77`)

**beginning**
<img width="748" alt="截圖 2022-12-28 下午6 41 06" src="https://user-images.githubusercontent.com/17497074/209803554-54b75825-a983-4ef9-bc54-d950d5c7b686.png">

**Next Turn**
<img width="659" alt="截圖 2022-12-28 下午6 50 01" src="https://user-images.githubusercontent.com/17497074/209803578-054d12ab-3522-45df-a876-eaec8c66cda7.png">
