### PR TITLE
Fixed TechButton progress-bar padding, less rounded corners for buttons.

### DIFF
--- a/core/src/com/unciv/ui/pickerscreens/TechButton.kt
+++ b/core/src/com/unciv/ui/pickerscreens/TechButton.kt
@@ -38,11 +38,11 @@ class TechButton(techName:String, private val techManager: TechManager, isWorldS
         setAlignment(Align.right)
     }
     var orderIndicator: IconCircleGroup? = null
-    var bg = Image(BaseScreen.skinStrings.getUiBackground("TechPickerScreen/TechButton", BaseScreen.skinStrings.roundedEdgeRectangleShape))
+    var bg = Image(BaseScreen.skinStrings.getUiBackground("TechPickerScreen/TechButton", BaseScreen.skinStrings.roundedEdgeRectangleMidShape))
 
     init {
         touchable = Touchable.enabled
-        background = BaseScreen.skinStrings.getUiBackground("TechPickerScreen/TechButton", BaseScreen.skinStrings.roundedEdgeRectangleShape,
+        background = BaseScreen.skinStrings.getUiBackground("TechPickerScreen/TechButton", BaseScreen.skinStrings.roundedEdgeRectangleMidShape,
             tintColor = Color.WHITE.darken(0.3f))
 
         bg.toBack()
@@ -51,9 +51,10 @@ class TechButton(techName:String, private val techManager: TechManager, isWorldS
         pad(0f).padBottom(5f).padTop(5f).padLeft(5f).padRight(5f)
 
         if (ImageGetter.techIconExists(techName))
-            add(ImageGetter.getTechIconGroup(techName, 45f)).padRight(5f).left()
+            add(ImageGetter.getTechIconGroup(techName, 46f)).padRight(5f).padLeft(2f).left()
 
         val rightSide = Table()
+
 
         if (isWorldScreen) {
             val techCost = techManager.costOfTech(techName)
@@ -62,12 +63,13 @@ class TechButton(techName:String, private val techManager: TechManager, isWorldS
 
             val percentComplete = (techCost - remainingTech) / techCost.toFloat()
             val percentWillBeComplete = (techCost - (remainingTech-techThisTurn)) / techCost.toFloat()
-            val progressBar = ImageGetter.ProgressBar(2f, 50f, true)
+            val progressBar = ImageGetter.ProgressBar(2f, 48f, true)
                     .setBackground(Color.WHITE)
                     .setSemiProgress(Color.BLUE.brighten(0.3f), percentWillBeComplete)
                     .setProgress(Color.BLUE.darken(0.5f), percentComplete)
-            add(progressBar.addBorder(1f, Color.GRAY)).pad(10f)
+            add(progressBar.addBorder(1f, Color.GRAY)).padLeft(0f).padRight(5f)
         }
+
         rightSide.add(text).width(145f).top().left().padRight(15f)
         rightSide.add(turns).width(40f).top().right().padRight(10f).row()
 
@@ -93,7 +95,7 @@ class TechButton(techName:String, private val techManager: TechManager, isWorldS
         val techEnabledIcons = Table().align(Align.left)
         techEnabledIcons.background = BaseScreen.skinStrings.getUiBackground(
             "TechPickerScreen/TechButtonIconsOutline",
-            BaseScreen.skinStrings.rectangleWithOutlineShape,
+            BaseScreen.skinStrings.roundedEdgeRectangleSmallShape,
             tintColor = Color.BLACK.cpy().apply { a = 0.7f }
         )
         techEnabledIcons.pad(0f).padLeft(10f).padTop(2f).padBottom(2f)

--- a/core/src/com/unciv/ui/pickerscreens/TechButton.kt
+++ b/core/src/com/unciv/ui/pickerscreens/TechButton.kt
@@ -48,13 +48,10 @@ class TechButton(techName:String, private val techManager: TechManager, isWorldS
         bg.toBack()
         addActor(bg)
 
-        pad(0f).padBottom(5f).padTop(5f).padLeft(5f).padRight(5f)
+        pad(0f).padBottom(5f).padTop(5f).padLeft(5f).padRight(0f)
 
         if (ImageGetter.techIconExists(techName))
             add(ImageGetter.getTechIconGroup(techName, 46f)).padRight(5f).padLeft(2f).left()
-
-        val rightSide = Table()
-
 
         if (isWorldScreen) {
             val techCost = techManager.costOfTech(techName)
@@ -70,8 +67,10 @@ class TechButton(techName:String, private val techManager: TechManager, isWorldS
             add(progressBar.addBorder(1f, Color.GRAY)).padLeft(0f).padRight(5f)
         }
 
-        rightSide.add(text).width(145f).top().left().padRight(15f)
-        rightSide.add(turns).width(40f).top().right().padRight(10f).row()
+        val rightSide = Table()
+
+        rightSide.add(text).width(140f).top().left().padRight(15f)
+        rightSide.add(turns).width(40f).top().left().padRight(10f).row()
 
         addTechEnabledIcons(techName, isWorldScreen, rightSide)
 

--- a/docs/Modders/Creating-a-UI-skin.md
+++ b/docs/Modders/Creating-a-UI-skin.md
@@ -92,9 +92,9 @@ These shapes are used all over Unciv and can be replaced to make a lot of UI ele
 | TechPickerScreen/ | Background | null | |
 | TechPickerScreen/ | Background | null | |
 | TechPickerScreen/ | BottomTable | null | |
-| TechPickerScreen/ | TechButton | roundedEdgeRectangle | |
-| TechPickerScreen/ | TechButton | roundedEdgeRectangle | |
-| TechPickerScreen/ | TechButtonIconsOutline | rectangleWithOutline | |
+| TechPickerScreen/ | TechButton | roundedEdgeRectangleMid | |
+| TechPickerScreen/ | TechButton | roundedEdgeRectangleMid | |
+| TechPickerScreen/ | TechButtonIconsOutline | roundedEdgeRectangleSmall | |
 | VictoryScreen/ | CivGroup | roundedEdgeRectangle | |
 | WorldScreen/ | AirUnitTable | null | |
 | WorldScreen/ | BattleTable | null | |


### PR DESCRIPTION
Removed extra vertical padding on TechButton progress bar, now more slim
![image](https://user-images.githubusercontent.com/32207817/209857184-53caa510-59d2-421c-9482-6a0b3a3167e0.png)

Less round corners for tech buttons, more rounded corners for inner icons container:
![image](https://user-images.githubusercontent.com/32207817/209857354-eea49137-9433-4614-9a79-4165651cf5cb.png)

