### PR TITLE
Show CrashScreen instead of quit when crash on Android

### DIFF
--- a/android/src/com/unciv/app/PlatformSpecificHelpersAndroid.kt
+++ b/android/src/com/unciv/app/PlatformSpecificHelpersAndroid.kt
@@ -62,11 +62,6 @@ Sources for Info about current orientation in case need:
      */
     override fun shouldPreferExternalStorage(): Boolean = true
 
-    override fun handleUncaughtThrowable(ex: Throwable): Boolean {
-        thread { throw ex } // this will kill the app but report the exception to the Google Play Console if the user allows it
-        return true
-    }
-
     override fun addImprovements(textField: TextField): TextField {
         return TextfieldImprovements.add(textField)
     }


### PR DESCRIPTION
Since [Google has removed the "crash feedback" in the latest update](https://stackoverflow.com/questions/48527229/where-can-i-find-crash-feedback-from-users-in-the-google-play-console), throwing the exception directly when crashing on Android does not make sense. Not everybody has Play Console installed on their Android phone. We need to open Crash Screen. It provides detailed information about the crash, including stack trace. So that we can easily locate the problem without `adb logcat`.