### PR TITLE
Translate "Sell" in city screen

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -1063,6 +1063,7 @@ In resistance for another [numberOfTurns] turns =
 We Love The King Day for another [numberOfTurns] turns = 
 Demanding [resource] = 
 Sell for [sellAmount] gold = 
+Sell = 
 Are you sure you want to sell this [building]? = 
 Free = 
 [greatPerson] points = 

--- a/core/src/com/unciv/ui/cityscreen/ConstructionInfoTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/ConstructionInfoTable.kt
@@ -95,7 +95,7 @@ class ConstructionInfoTable(val cityScreen: CityScreen): Table() {
             if (construction is Building && cityConstructions.isBuilt(construction.name)
                     && construction.isSellable()) {
                 val sellAmount = cityScreen.city.getGoldForSellingBuilding(construction.name)
-                val sellText = "Sell [$sellAmount] " + Fonts.gold
+                val sellText = "{Sell} [$sellAmount] " + Fonts.gold
                 val sellBuildingButton = sellText.toTextButton()
                 row()
                 add(sellBuildingButton).padTop(5f).colspan(2).center()


### PR DESCRIPTION
I have absolutely no idea if the fix is good or not.

I followed Yairm's request: "_Better to change the line in code to put the "sell" in {curly brackets} so only it is translated_".

So here it is.^^