### PR TITLE
Fix foreign units flags fading

### DIFF
--- a/core/src/com/unciv/ui/tilegroups/TileGroupIcons.kt
+++ b/core/src/com/unciv/ui/tilegroups/TileGroupIcons.kt
@@ -100,11 +100,11 @@ class TileGroupIcons(val tileGroup: TileGroup) {
 
             // Instead of fading out the entire unit with its background, we just fade out its central icon,
             // that way it remains much more visible on the map
-            if (!unit.isIdle() && unit.civInfo == viewingCiv) {
+            if (unit.civInfo == viewingCiv && !unit.isIdle()) {
                 newImage.actionGroup?.color?.a = 0.5f * UncivGame.Current.settings.unitIconOpacity
             }
 
-            if (unit.currentMovement == 0f) {
+            if (unit.civInfo == viewingCiv && unit.currentMovement == 0f) {
                 newImage.flagSelection.color?.apply { a *= 0.5f }
                 newImage.flagBg.children?.forEach { it.color.apply { a *= 0.5f } }
                 newImage.unitBaseImage.color.a *= 0.5f

--- a/core/src/com/unciv/ui/utils/UnitGroup.kt
+++ b/core/src/com/unciv/ui/utils/UnitGroup.kt
@@ -145,7 +145,10 @@ class UnitGroup(val unit: MapUnit, val size: Float): Group() {
         }
 
         // Unit base icon is faded out only if out of moves
-        val alpha = if (unit.currentMovement == 0f) 0.5f else 1f
+        // Foreign unit icons are never faded!
+        val shouldBeFaded = (unit.owner == UncivGame.Current.worldScreen?.viewingCiv?.civName
+                && unit.currentMovement == 0f)
+        val alpha = if (shouldBeFaded) 0.5f else 1f
         unitBaseImage.color.a = alpha
         flagBg.children.forEach { it.color.a = alpha }
 


### PR DESCRIPTION
Foreign units icons should always remain unfaded, even if out of moves. 