### PR TITLE
removed notificationLog from the game file

### DIFF
--- a/core/src/com/unciv/models/metadata/GameSettings.kt
+++ b/core/src/com/unciv/models/metadata/GameSettings.kt
@@ -70,7 +70,7 @@ class GameSettings {
     var useDemographics: Boolean = false
     var showZoomButtons: Boolean = false
 
-    var notificationsLogMaxTurns = 5
+    var notificationsLogMaxTurns = 15
 
     var androidCutout: Boolean = false
 

--- a/core/src/com/unciv/ui/options/GameplayTab.kt
+++ b/core/src/com/unciv/ui/options/GameplayTab.kt
@@ -52,7 +52,7 @@ private fun addNotificationLogMaxTurnsSlider(table: Table, settings: GameSetting
     table.add("Notifications log max turns".toLabel()).left().fillX()
 
     val minimapSlider = UncivSlider(
-        3f, 15f, 1f,
+        3f, 90f, 1f,
         initial = settings.notificationsLogMaxTurns.toFloat()
     ) {
         val turns = it.toInt()


### PR DESCRIPTION
resolves  #8363

I also increased the max turns to 90 now that it won't clutter save files and the default max number of turns to 15

This deletes the notification log for current saves. 

Should I increase the serialization version? Personally I don't think losing the notif log is that critical, but if people use different versions of the game the notification log will break at every turn.