### PR TITLE
Optimization: tiles "isExplored" property delegated to TileInfo class

### DIFF
--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -431,7 +431,7 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
                 }
 
         val exploredRevealInfo = exploredRevealTiles
-            .filter { civInfo.hasExplored(it.position) }
+            .filter { civInfo.hasExplored(it) }
             .flatMap { tile ->
                 civInfo.cities.asSequence()
                     .map {
@@ -586,6 +586,10 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
         cityDistances.game = this
 
         guaranteeUnitPromotions()
+
+        for (player in civilizations)
+            for (tile in player.exploredTiles)
+                tileMap[tile].setExplored(player, true)
     }
 
     //endregion

--- a/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
@@ -719,7 +719,7 @@ object NextTurnAutomation {
         val enemyCivs = civInfo.getKnownCivs()
                 .filterNot {
                     it == civInfo || it.cities.isEmpty() || !civInfo.getDiplomacyManager(it).canDeclareWar()
-                            || it.cities.none { city -> civInfo.hasExplored(city.location) }
+                            || it.cities.none { city -> civInfo.hasExplored(city.getCenterTile()) }
                 }
         // If the AI declares war on a civ without knowing the location of any cities, it'll just keep amassing an army and not sending it anywhere,
         //   and end up at a massive disadvantage

--- a/core/src/com/unciv/logic/city/CityConstructions.kt
+++ b/core/src/com/unciv/logic/city/CityConstructions.kt
@@ -391,7 +391,7 @@ class CityConstructions : IsPartOfGameInfoSerialization {
         for (otherCiv in city.civInfo.gameInfo.civilizations) {
             if (otherCiv == city.civInfo) continue
             when {
-                otherCiv.hasExplored(city.location) ->
+                otherCiv.hasExplored(city.getCenterTile()) ->
                     otherCiv.addNotification("The city of [${city.name}] has started constructing [${construction.name}]!",
                         city.location, NotificationCategory.General, NotificationIcon.Construction, buildingIcon)
                 otherCiv.knows(city.civInfo) ->
@@ -416,7 +416,7 @@ class CityConstructions : IsPartOfGameInfoSerialization {
         if (construction is Building && construction.isWonder) {
             city.civInfo.popupAlerts.add(PopupAlert(AlertType.WonderBuilt, construction.name))
             for (civ in city.civInfo.gameInfo.civilizations) {
-                if (civ.hasExplored(city.location))
+                if (civ.hasExplored(city.getCenterTile()))
                     civ.addNotification("[${construction.name}] has been built in [${city.name}]", city.location,
                         if (civ == city.civInfo) NotificationCategory.Production else NotificationCategory.General, buildingIcon)
                 else

--- a/core/src/com/unciv/logic/city/managers/CityFounder.kt
+++ b/core/src/com/unciv/logic/city/managers/CityFounder.kt
@@ -222,7 +222,7 @@ class CityFounder {
                 citiesWithin6Tiles
                     .map { it.civInfo }
                     .distinct()
-                    .filter { it.knows(city.civInfo) && it.hasExplored(city.location) }
+                    .filter { it.knows(city.civInfo) && it.hasExplored(city.getCenterTile()) }
         for (otherCiv in civsWithCloseCities)
             otherCiv.getDiplomacyManager(city.civInfo).setFlag(DiplomacyFlags.SettledCitiesNearUs, 30)
     }

--- a/core/src/com/unciv/logic/city/managers/CityReligionManager.kt
+++ b/core/src/com/unciv/logic/city/managers/CityReligionManager.kt
@@ -124,7 +124,7 @@ class CityReligionManager : IsPartOfGameInfoSerialization {
 
             for ((key, value) in statsGranted)
                 religionOwningCiv.addStat(key, value.toInt())
-            if (religionOwningCiv.hasExplored(city.location))
+            if (religionOwningCiv.hasExplored(city.getCenterTile()))
                 religionOwningCiv.addNotification(
                     "You gained [$statsGranted] as your religion was spread to [${city.name}]",
                     city.location,

--- a/core/src/com/unciv/logic/civilization/Civilization.kt
+++ b/core/src/com/unciv/logic/civilization/Civilization.kt
@@ -191,12 +191,7 @@ class Civilization : IsPartOfGameInfoSerialization {
     var citiesCreated = 0
     var exploredTiles = HashSet<Vector2>()
 
-    fun hasExplored(position: Vector2) = exploredTiles.contains(position)
-    fun hasExplored(tile: Tile) = hasExplored(tile.position)
-
-    fun addExploredTiles(tiles:Sequence<Vector2>){
-        exploredTiles.addAll(tiles)
-    }
+    fun hasExplored(tile: Tile) = tile.isExplored(this)
 
     var lastSeenImprovement = HashMapVector2<String>()
 
@@ -344,7 +339,8 @@ class Civilization : IsPartOfGameInfoSerialization {
     var cityStateUniqueUnit: String? = null // Unique unit for militaristic city state. Might still be null if there are no appropriate units
 
 
-    fun hasMetCivTerritory(otherCiv: Civilization): Boolean = otherCiv.getCivTerritory().any { hasExplored(it) }
+    fun hasMetCivTerritory(otherCiv: Civilization): Boolean =
+            otherCiv.getCivTerritory().any { gameInfo.tileMap[it].isExplored(this) }
     fun getCompletedPolicyBranchesCount(): Int = policies.adoptedPolicies.count { Policy.isBranchCompleteByName(it) }
     fun originalMajorCapitalsOwned(): Int = cities.count { it.isOriginalCapital && it.foundingCiv != "" && gameInfo.getCivilization(it.foundingCiv).isMajorCiv() }
     private fun getCivTerritory() = cities.asSequence().flatMap { it.tiles.asSequence() }

--- a/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyFunctions.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyFunctions.kt
@@ -79,7 +79,7 @@ class DiplomacyFunctions(val civInfo:Civilization){
                 otherCiv.addStat(key, value.toInt())
 
             if (civInfo.cities.isNotEmpty())
-                otherCiv.exploredTiles = otherCiv.exploredTiles.withItem(civInfo.getCapital()!!.location)
+                civInfo.getCapital()?.getCenterTile()?.setExplored(otherCiv, true)
 
             civInfo.questManager.justMet(otherCiv) // Include them in war with major pseudo-quest
         }

--- a/core/src/com/unciv/logic/civilization/transients/CivInfoTransientCache.kt
+++ b/core/src/com/unciv/logic/civilization/transients/CivInfoTransientCache.kt
@@ -58,8 +58,9 @@ class CivInfoTransientCache(val civInfo: Civilization) {
         // Well, because it gets REALLY LARGE so it's a lot of memory space,
         // and we never actually iterate on the explored tiles (only check contains()),
         // so there's no fear of concurrency problems.
-        val newlyExploredTiles = civInfo.viewableTiles.asSequence().map { it.position }
-        civInfo.addExploredTiles(newlyExploredTiles)
+        civInfo.viewableTiles.asSequence().forEach { tile ->
+            tile.setExplored(civInfo, true)
+        }
 
 
         val viewedCivs = HashMap<Civilization, Tile>()
@@ -114,7 +115,6 @@ class CivInfoTransientCache(val civInfo: Civilization) {
         if (civInfo.isSpectator() || UncivGame.Current.viewEntireMapForDebug) {
             val allTiles = civInfo.gameInfo.tileMap.values.toSet()
             civInfo.viewableTiles = allTiles
-            civInfo.addExploredTiles(allTiles.asSequence().map { it.position })
             civInfo.viewableInvisibleUnitsTiles = allTiles
             return
         }

--- a/core/src/com/unciv/logic/map/tile/Tile.kt
+++ b/core/src/com/unciv/logic/map/tile/Tile.kt
@@ -87,6 +87,8 @@ open class Tile : IsPartOfGameInfoSerialization {
     var terrainFeatures: List<String> = listOf()
         private set
 
+    var exploredBy = HashSet<String>()
+
     @Transient
     var terrainFeatureObjects: List<Terrain> = listOf()
         private set
@@ -168,6 +170,7 @@ open class Tile : IsPartOfGameInfoSerialization {
         toReturn.hasBottomRightRiver = hasBottomRightRiver
         toReturn.hasBottomRiver = hasBottomRiver
         toReturn.continent = continent
+        toReturn.exploredBy.addAll(exploredBy)
         return toReturn
     }
 
@@ -237,6 +240,22 @@ open class Tile : IsPartOfGameInfoSerialization {
         if (UncivGame.Current.viewEntireMapForDebug)
             return true
         return player.viewableTiles.contains(this)
+    }
+
+    fun isExplored(player: Civilization): Boolean {
+        if (UncivGame.Current.viewEntireMapForDebug || player.isSpectator())
+            return true
+        return exploredBy.contains(player.civName) || player.exploredTiles.contains(position)
+    }
+
+    fun setExplored(player: Civilization, isExplored: Boolean) {
+        if (isExplored) {
+            exploredBy.add(player.civName)
+            player.exploredTiles.add(position)
+        } else {
+            exploredBy.remove(player.civName)
+            player.exploredTiles.remove(position)
+        }
     }
 
     fun isCityCenter(): Boolean = isCityCenterInternal

--- a/core/src/com/unciv/models/ruleset/Victory.kt
+++ b/core/src/com/unciv/models/ruleset/Victory.kt
@@ -217,7 +217,7 @@ class Milestone(val uniqueDescription: String, private val parentVictory: Victor
                 val originalCapitals = civInfo.gameInfo.getCities().filter { it.isOriginalCapital }
                 for (city in originalCapitals) {
                     val milestoneText =
-                        if (civInfo.hasExplored(city.location)) "Capture [${city.name}]"
+                        if (civInfo.hasExplored(city.getCenterTile())) "Capture [${city.name}]"
                         else "Capture [${Constants.unknownCityName}]"
                     buttons.add(getMilestoneButton(milestoneText, city.civInfo == civInfo))
                 }

--- a/core/src/com/unciv/ui/overviewscreen/EspionageOverviewScreen.kt
+++ b/core/src/com/unciv/ui/overviewscreen/EspionageOverviewScreen.kt
@@ -121,7 +121,7 @@ class EspionageOverviewScreen(val civInfo: Civilization) : PickerScreen(true) {
         // Then add all cities
 
         val sortedCities = civInfo.gameInfo.getCities()
-            .filter { civInfo.hasExplored(it.location) }
+            .filter { civInfo.hasExplored(it.getCenterTile()) }
             .sortedWith(
                 compareBy<City> {
                     it.civInfo != civInfo

--- a/core/src/com/unciv/ui/overviewscreen/ReligionOverviewTable.kt
+++ b/core/src/com/unciv/ui/overviewscreen/ReligionOverviewTable.kt
@@ -145,7 +145,7 @@ class ReligionOverviewTab(
             if (holyCity != null) {
                 statsTable.add("Holy City:".toLabel())
                 val cityName =
-                    if (viewingPlayer.hasExplored(holyCity.location))
+                    if (viewingPlayer.hasExplored(holyCity.getCenterTile()))
                         holyCity.name
                     else Constants.unknownNationName
                 statsTable.add(cityName.toLabel()).right().row()

--- a/core/src/com/unciv/ui/overviewscreen/WonderOverviewTable.kt
+++ b/core/src/com/unciv/ui/overviewscreen/WonderOverviewTable.kt
@@ -232,7 +232,7 @@ class WonderInfo {
                 val index = wonderIndexMap[wonderName]!!
                 val status = when {
                     viewingPlayer == city.civInfo -> WonderStatus.Owned
-                    viewingPlayer.hasExplored(city.location) -> WonderStatus.Known
+                    viewingPlayer.hasExplored(city.getCenterTile()) -> WonderStatus.Known
                     else -> WonderStatus.NotFound
                 }
                 wonders[index] = WonderInfo(

--- a/core/src/com/unciv/ui/trade/DiplomacyScreen.kt
+++ b/core/src/com/unciv/ui/trade/DiplomacyScreen.kt
@@ -326,7 +326,7 @@ class DiplomacyScreen(
             else diplomacyTable.add(getDeclareWarButton(diplomacyManager, otherCiv)).row()
         }
 
-        if (otherCiv.cities.isNotEmpty() && otherCiv.getCapital() != null && viewingCiv.hasExplored(otherCiv.getCapital()!!.location))
+        if (otherCiv.cities.isNotEmpty() && otherCiv.getCapital() != null && viewingCiv.hasExplored(otherCiv.getCapital()!!.getCenterTile()))
             diplomacyTable.add(getGoToOnMapButton(otherCiv)).row()
 
         val diplomaticMarriageButton = getDiplomaticMarriageButton(otherCiv)
@@ -685,7 +685,7 @@ class DiplomacyScreen(
         diplomacyTable.add(demandsButton).row()
         if (isNotPlayersTurn()) demandsButton.disable()
 
-        if (otherCiv.cities.isNotEmpty() && otherCiv.getCapital() != null && viewingCiv.hasExplored(otherCiv.getCapital()!!.location))
+        if (otherCiv.cities.isNotEmpty() && otherCiv.getCapital() != null && viewingCiv.hasExplored(otherCiv.getCapital()!!.getCenterTile()))
             diplomacyTable.add(getGoToOnMapButton(otherCiv)).row()
 
         if (!otherCiv.isHuman()) { // human players make their own choices

--- a/core/src/com/unciv/ui/worldscreen/WorldMapHolder.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldMapHolder.kt
@@ -572,9 +572,9 @@ class WorldMapHolder(
 
         if (isMapRevealEnabled(viewingCiv)) {
             // Only needs to be done once - this is so the minimap will also be revealed
-            if (viewingCiv.exploredTiles.size != tileMap.values.size)
-                viewingCiv.exploredTiles = tileMap.values.map { it.position }.toHashSet()
-            allWorldTileGroups.forEach { it.showEntireMap = true } // So we can see all resources, regardless of tech
+            allWorldTileGroups.forEach {
+                it.tile.setExplored(viewingCiv, true)
+                it.showEntireMap = true } // So we can see all resources, regardless of tech
         }
 
         for (tileGroup in allWorldTileGroups) {

--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -856,7 +856,7 @@ class WorldScreen(
         displayTutorial(TutorialTrigger.StrategicResource) { resources.any { it.resource.resourceType == ResourceType.Strategic } }
         displayTutorial(TutorialTrigger.EnemyCity) {
             viewingCiv.getKnownCivs().asSequence().filter { viewingCiv.isAtWarWith(it) }
-                    .flatMap { it.cities.asSequence() }.any { viewingCiv.hasExplored(it.location) }
+                    .flatMap { it.cities.asSequence() }.any { viewingCiv.hasExplored(it.getCenterTile()) }
         }
         displayTutorial(TutorialTrigger.ApolloProgram) { viewingCiv.hasUnique(UniqueType.EnablesConstructionOfSpaceshipParts) }
         displayTutorial(TutorialTrigger.SiegeUnits) { viewingCiv.units.getCivUnits().any { it.baseUnit.isProbablySiegeUnit() } }

--- a/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitActions.kt
@@ -231,7 +231,7 @@ object UnitActions {
             if (diplomacyManager.hasFlag(DiplomacyFlags.AgreedToNotSettleNearUs)) {
                 val citiesWithin6Tiles = otherCiv.cities
                     .filter { it.getCenterTile().aerialDistanceTo(tile) <= 6 }
-                    .filter { otherCiv.hasExplored(it.location) }
+                    .filter { otherCiv.hasExplored(it.getCenterTile()) }
                 if (citiesWithin6Tiles.isNotEmpty()) brokenPromises += otherCiv.getLeaderDisplayName()
             }
         }


### PR DESCRIPTION
The field `exploredTiles: HashSet<Vector2>` of `CivilizationInfo` is redundant for the following reasons:
1) Code uses this field only for containment checks: is explored/not explored. The set is never iterated directly.
2) Every time player explores a new tile the whole set has to be recreated. Hence possible performance impact for large maps later in the game.
3) Explored tiles are persistent: once revealed - stays revealed whole game.

This commit suggests instead of `exploredTiles` field in `CivilizationInfo` to use hashset field `exploredBy` in `TileInfo`. This serializable field stores players ids (civ names, for now) who have revealed this tile. 

Pros: 
1) Operation complexity of `tile.isExplored(civ)` is still constant O(1), but can be made even faster because we can use hashing by `Int` IDs instead of `String` civ names or `Vector2` positions.
2) No need to recreate anything upon new tile exploration - just add civ's id to the set. 
3) No concurrent modification errors etc - simple serialization/deserialization.
4) Save games files should not be corrupted

Cons:
1) I could not come up with a backwards compatibility: previous version saved games would have most tiles "unexplored" on the first load.