### PR TITLE
fixed even more warnings

### DIFF
--- a/core/src/com/unciv/MainMenuScreen.kt
+++ b/core/src/com/unciv/MainMenuScreen.kt
@@ -162,7 +162,7 @@ class MainMenuScreen: BaseScreen(), RecreateOnResize {
 
         if (game.files.getSaves().any()) {
             val loadGameTable = getMenuButton("Load game", "OtherIcons/Load", 'l')
-                { game.pushScreen(LoadGameScreen(this)) }
+                { game.pushScreen(LoadGameScreen()) }
             column1.add(loadGameTable).row()
         }
 

--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -220,7 +220,7 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
     fun isReligionEnabled(): Boolean {
         val religionDisabledByRuleset = (ruleSet.eras[gameParameters.startingEra]!!.hasUnique(UniqueType.DisablesReligion)
                 || ruleSet.modOptions.uniques.contains(ModOptionsConstants.disableReligion))
-        return !religionDisabledByRuleset && gameParameters.religionEnabled
+        return !religionDisabledByRuleset
     }
 
     fun isEspionageEnabled(): Boolean {

--- a/core/src/com/unciv/logic/automation/ai/TacticalAnalysisMap.kt
+++ b/core/src/com/unciv/logic/automation/ai/TacticalAnalysisMap.kt
@@ -60,7 +60,7 @@ class TacticalDominanceZone {
         return id.startsWith('-')
     }
 
-    fun extend(tile: TileInfo) {
+    fun extend() {
         tileCount += 1
     }
 }
@@ -214,7 +214,7 @@ class TacticalAnalysisMap {
                 }
             }
             plotPositionToZoneId[tile.position] = zoneId
-            zone.extend(tile)
+            zone.extend()
         }
 
         // Ensure that continents sizes are calculated
@@ -239,7 +239,7 @@ class TacticalAnalysisMap {
                 val tile = stack.removeLastOrNull() ?: break
                 val tileContinentSize = tile.tileMap.continentSizes[tile.getContinent()] ?: Int.MAX_VALUE
                 plotPositionToZoneId[tile.position] = newId
-                newZone.extend(tile)
+                newZone.extend()
 
                 for (neighbor in tile.neighbors) {
 

--- a/core/src/com/unciv/models/metadata/GameParameters.kt
+++ b/core/src/com/unciv/models/metadata/GameParameters.kt
@@ -64,7 +64,6 @@ class GameParameters : IsPartOfGameInfoSerialization { // Default values are the
         parameters.ragingBarbarians = ragingBarbarians
         parameters.oneCityChallenge = oneCityChallenge
         parameters.nuclearWeaponsEnabled = nuclearWeaponsEnabled
-        parameters.religionEnabled = religionEnabled
         parameters.victoryTypes = ArrayList(victoryTypes)
         parameters.startingEra = startingEra
         parameters.isOnlineMultiplayer = isOnlineMultiplayer

--- a/core/src/com/unciv/models/metadata/GameSettings.kt
+++ b/core/src/com/unciv/models/metadata/GameSettings.kt
@@ -217,6 +217,7 @@ enum class GameSetting(
 
     /** **Warning:** It is the obligation of the caller to select the same type [T] that the [kClass] of this property has */
     fun <T> getProperty(settings: GameSettings): KMutableProperty0<T> {
+        @Suppress("UNCHECKED_CAST")
         return propertyGetter(settings) as KMutableProperty0<T>
     }
 }

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -1130,7 +1130,7 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
         return errorList
     }
 
-    fun getDeprecationAnnotation(): Deprecated? = declaringClass.getField(name)
+    fun getDeprecationAnnotation(): Deprecated? = declaringJavaClass.getField(name)
         .getAnnotation(Deprecated::class.java)
 
 }

--- a/core/src/com/unciv/ui/saves/LoadGameScreen.kt
+++ b/core/src/com/unciv/ui/saves/LoadGameScreen.kt
@@ -15,7 +15,6 @@ import com.unciv.models.translations.tr
 import com.unciv.ui.pickerscreens.Github
 import com.unciv.ui.popup.Popup
 import com.unciv.ui.popup.ToastPopup
-import com.unciv.ui.utils.BaseScreen
 import com.unciv.ui.utils.KeyCharAndCode
 import com.unciv.ui.utils.UncivTooltip.Companion.addTooltip
 import com.unciv.ui.utils.extensions.disable
@@ -31,7 +30,7 @@ import com.unciv.utils.concurrency.Concurrency
 import com.unciv.utils.concurrency.launchOnGLThread
 import java.io.FileNotFoundException
 
-class LoadGameScreen(previousScreen:BaseScreen) : LoadOrSaveScreen() {
+class LoadGameScreen : LoadOrSaveScreen() {
     private val copySavedGameToClipboardButton = getCopyExistingSaveToClipboardButton()
     private val errorLabel = "".toLabel(Color.RED).apply { isVisible = false }
     private val loadMissingModsButton = getLoadMissingModsButton()

--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -251,7 +251,7 @@ class WorldScreen(
             })
         }
         globalShortcuts.add(KeyCharAndCode.ctrl('S')) { game.pushScreen(SaveGameScreen(gameInfo)) }    //   Save
-        globalShortcuts.add(KeyCharAndCode.ctrl('L')) { game.pushScreen(LoadGameScreen(this)) }    //   Load
+        globalShortcuts.add(KeyCharAndCode.ctrl('L')) { game.pushScreen(LoadGameScreen()) }    //   Load
         globalShortcuts.add(KeyCharAndCode.ctrl('Q')) { game.popScreen() }    //   WorldScreen is the last screen, so this quits
         globalShortcuts.add(Input.Keys.NUMPAD_ADD) { this.mapHolder.zoomIn() }    //   '+' Zoom
         globalShortcuts.add(Input.Keys.NUMPAD_SUBTRACT) { this.mapHolder.zoomOut() }    //   '-' Zoom

--- a/core/src/com/unciv/ui/worldscreen/mainmenu/WorldScreenMenuPopup.kt
+++ b/core/src/com/unciv/ui/worldscreen/mainmenu/WorldScreenMenuPopup.kt
@@ -32,7 +32,7 @@ class WorldScreenMenuPopup(val worldScreen: WorldScreen) : Popup(worldScreen) {
         }.row()
         addButton("Load game") {
             close()
-            worldScreen.game.pushScreen(LoadGameScreen(worldScreen))
+            worldScreen.game.pushScreen(LoadGameScreen())
         }.row()
 
         addButton("Start new game") {


### PR DESCRIPTION
Now we only have deprecation warnings left:

`com/unciv/json/NonStringKeyMapSerializer.kt: (44, 13)` - which I think could also be fixed considering this was made in may last year so I'm guessing all users migrated the old properties to the new ones

`Some religion deprecations` - which I believe could be removed in at least one case. I'll do it and you tell me if I should revert the commit

`Resolution deprecations` - I have no clue about this one since it's relatively new so it probably doesn't matter if it stays there for a bit more