### PR TITLE
Translate the hard-coded notification strings

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -72,6 +72,7 @@ Get [unitName] =
 
 Hydro Plant = 
 [buildingName] obsoleted = 
+due to constructing [buildingName] = 
 
 # Diplomacy,Trade,Nations
 
@@ -910,6 +911,7 @@ A Great Person joins you! =
 [civ1] has liberated [civ2] = 
 [civ] has liberated an unknown civilization = 
 An unknown civilization has liberated [civ] = 
+Gained [amount] [unitName] unit(s) = 
 
 # Trigger notifications
 

--- a/core/src/com/unciv/logic/civilization/managers/PolicyManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/PolicyManager.kt
@@ -12,6 +12,7 @@ import com.unciv.models.ruleset.unique.UniqueMap
 import com.unciv.models.ruleset.unique.UniqueTarget
 import com.unciv.models.ruleset.unique.UniqueTriggerActivation
 import com.unciv.models.ruleset.unique.UniqueType
+import com.unciv.models.translations.tr
 import com.unciv.ui.utils.extensions.toPercent
 import kotlin.math.pow
 import kotlin.math.roundToInt
@@ -230,7 +231,7 @@ class PolicyManager : IsPartOfGameInfoSerialization {
     ) {
         var extraNotificationTextCopy = extraNotificationText
         if (extraNotificationText != "") {
-            extraNotificationTextCopy = " ${extraNotificationText}"
+            extraNotificationTextCopy = " ${extraNotificationText.tr()}"
         }
         for (civ in civInfo.gameInfo.civilizations.filter { it.isMajorCiv() }) {
             if (civ == civInfo) continue
@@ -240,7 +241,7 @@ class PolicyManager : IsPartOfGameInfoSerialization {
                 "An unknown civilization has adopted the [${policy.name}] policy"
             }
             civ.addNotification(
-                "{${defaultNotificationText}}{${extraNotificationTextCopy}}",
+                "{${defaultNotificationText.tr()}}{${extraNotificationTextCopy}}",
                 NotificationCategory.General,
                 NotificationIcon.Culture
             )

--- a/core/src/com/unciv/models/ruleset/Building.kt
+++ b/core/src/com/unciv/models/ruleset/Building.kt
@@ -663,7 +663,7 @@ class Building : RulesetStatsObject(), INonPerpetualConstruction {
         // "Provides a free [buildingName] [cityFilter]"
         cityConstructions.addFreeBuildings()
 
-        val triggerNotificationText ="due to constructing [$name]"
+        val triggerNotificationText ="due to constructing [$name]".tr()
 
         for (unique in uniqueObjects)
             if (unique.conditionals.none { it.type!!.targetTypes.contains(UniqueTarget.TriggerCondition) })

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -19,6 +19,7 @@ import com.unciv.models.stats.Stat
 import com.unciv.models.stats.Stats
 import com.unciv.models.translations.fillPlaceholders
 import com.unciv.models.translations.hasPlaceholderParameters
+import com.unciv.models.translations.tr
 import com.unciv.ui.utils.MayaCalendar
 import com.unciv.ui.worldscreen.unit.actions.UnitActionsUpgrade
 import kotlin.math.roundToInt
@@ -59,7 +60,7 @@ object UniqueTriggerActivation {
                 val placedUnit = civInfo.units.addUnit(unitName, chosenCity) ?: return false
 
                 val notificationText = getNotificationText(notification, triggerNotificationText,
-                    "Gained [1] [$unitName] unit(s)")
+                    "Gained [1] [$unitName] unit(s)".tr())
                     ?: return true
 
                 civInfo.addNotification(


### PR DESCRIPTION
A few hard-coded strings were missing `.tr()` call, thus a few notifications were never translated.
Here is the fix.