### PR TITLE
Optimized BorderedTable, refactored CityButton, new air table for units + misc

### DIFF
--- a/core/src/com/unciv/models/tilesets/TileSet.kt
+++ b/core/src/com/unciv/models/tilesets/TileSet.kt
@@ -12,7 +12,8 @@ class TileSet(val name: String) {
     }
 
     fun mergeConfig(id: String) {
-        configs[id]?.let { config.updateConfig(it) }
+        val configToMerge = configs[id] ?: return
+        config.updateConfig(configToMerge)
     }
 
     fun resetConfig() {

--- a/core/src/com/unciv/ui/pickerscreens/PolicyPickerScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/PolicyPickerScreen.kt
@@ -28,6 +28,7 @@ import com.unciv.ui.utils.extensions.colorFromRGB
 import com.unciv.ui.utils.extensions.darken
 import com.unciv.ui.utils.extensions.disable
 import com.unciv.ui.utils.extensions.enable
+import com.unciv.ui.utils.extensions.isEnabled
 import com.unciv.ui.utils.extensions.onClick
 import com.unciv.ui.utils.extensions.pad
 import com.unciv.ui.utils.extensions.toGroup
@@ -37,7 +38,7 @@ import java.lang.Integer.max
 import kotlin.math.abs
 import kotlin.math.min
 
-object PolicyColors {
+private object PolicyColors {
 
     val policyPickable = colorFromRGB(47,67,92).darken(0.3f)
     val policyNotPickable =  colorFromRGB(20, 20, 20)
@@ -58,7 +59,7 @@ fun Policy.isPickable() : Boolean {
     val worldScreen = UncivGame.Current.worldScreen ?: return false
     val viewingCiv = worldScreen.viewingCiv
     if (!worldScreen.isPlayersTurn
-            || worldScreen.viewingCiv.isSpectator() // viewingCiv var points to selectedCiv in case of spectator
+            || viewingCiv.isSpectator() // viewingCiv var points to selectedCiv in case of spectator
             || viewingCiv.isDefeated()
             || viewingCiv.policies.isAdopted(this.name)
             || this.policyBranchType == PolicyBranchType.BranchComplete
@@ -71,13 +72,11 @@ fun Policy.isPickable() : Boolean {
 
 class PolicyButton(val policy: Policy, size: Float = 30f) : BorderedTable(
     path = "PolicyScreen/PolicyButton",
-    defaultBorder = BaseScreen.skinStrings.roundedEdgeRectangleSmallShape,
-    defaultInner = BaseScreen.skinStrings.roundedEdgeRectangleSmallShape,
-    borderSize = 2f
+    defaultBgBorder = BaseScreen.skinStrings.roundedEdgeRectangleSmallShape,
+    defaultBgShape = BaseScreen.skinStrings.roundedEdgeRectangleSmallShape,
 ) {
 
     val icon = ImageGetter.getImage("PolicyIcons/" + policy.name)
-    val highlight = ImageGetter.getImage("UnitFlagIcons/UnitFlagSelection")
 
     var isSelected = false
         set(value) {
@@ -87,11 +86,10 @@ class PolicyButton(val policy: Policy, size: Float = 30f) : BorderedTable(
 
     init {
 
+        borderSize = 2f
         icon.setSize(size*0.7f, size*0.7f)
-        highlight.setSize(size*1.38f, size*1.38f)
 
         addActor(icon)
-        addActor(highlight)
 
         updateState()
         pack()
@@ -100,9 +98,6 @@ class PolicyButton(val policy: Policy, size: Float = 30f) : BorderedTable(
 
         icon.toFront()
         icon.center(this)
-        highlight.toBack()
-        highlight.isVisible = false
-        highlight.center(this)
     }
 
     fun onClick(function: () -> Unit): PolicyButton {
@@ -121,27 +116,24 @@ class PolicyButton(val policy: Policy, size: Float = 30f) : BorderedTable(
         val isPickable = policy.isPickable()
         val isAdopted = viewingCiv.policies.isAdopted(policy.name)
 
-
-        highlight.isVisible = isSelected
-
         when {
 
             isSelected && isPickable -> {
-                setBackgroundColor(PolicyColors.policySelected)
+                bgColor = PolicyColors.policySelected
             }
 
             isPickable -> {
-                setBackgroundColor(PolicyColors.policyPickable)
+                bgColor = PolicyColors.policyPickable
             }
 
             isAdopted -> {
                 icon.color = Color.GOLD.cpy()
-                setBackgroundColor(colorFromRGB(10,90,100).darken(0.8f))
+                bgColor = colorFromRGB(10,90,100).darken(0.8f)
             }
 
             else -> {
                 icon.color.a = 0.2f
-                setBackgroundColor(PolicyColors.policyNotPickable)
+                bgColor = PolicyColors.policyNotPickable
             }
 
         }
@@ -164,7 +156,7 @@ class PolicyPickerScreen(val worldScreen: WorldScreen, civInfo: Civilization = w
 
     internal val viewingCiv: Civilization = civInfo
 
-    private var policyNameToButton = HashMap<String, BorderedTable>()
+    private var policyNameToButton = HashMap<String, PolicyButton>()
     private var selectedPolicyButton: PolicyButton? = null
 
     init {
@@ -301,9 +293,8 @@ class PolicyPickerScreen(val worldScreen: WorldScreen, civInfo: Civilization = w
 
         // Main table
         val colorBg = if (branch.isAdopted()) PolicyColors.branchAdopted else PolicyColors.branchNotAdopted
-        val branchGroup = BorderedTable(
-            path="PolicyScree/PolicyBranchBackground",
-            innerColor = colorBg)
+        val branchGroup = BorderedTable(path="PolicyScree/PolicyBranchBackground")
+            .apply { bgColor = colorBg }
 
         // Header
         val header = getBranchHeader(branch)
@@ -554,9 +545,9 @@ class PolicyPickerScreen(val worldScreen: WorldScreen, civInfo: Civilization = w
     }
 
     private fun getBranchHeader(branch: PolicyBranch): Table {
-        val header = BorderedTable(
-            path="PolicyScreen/PolicyBranchHeader",
-            innerColor = colorFromRGB(47,90,92), borderSize = 5f)
+        val header = BorderedTable(path="PolicyScreen/PolicyBranchHeader")
+        header.bgColor = colorFromRGB(47,90,92)
+        header.borderSize = 5f
         header.pad(5f)
 
         val table = Table()
@@ -614,9 +605,10 @@ class PolicyPickerScreen(val worldScreen: WorldScreen, civInfo: Civilization = w
 
         val table = BorderedTable(
             path="PolicyScreen/PolicyBranchAdoptButton",
-            defaultInner = skinStrings.roundedEdgeRectangleSmallShape,
-            defaultBorder = skinStrings.roundedEdgeRectangleSmallShape,
-            innerColor = color, borderSize = 2f)
+            defaultBgShape = skinStrings.roundedEdgeRectangleSmallShape,
+            defaultBgBorder = skinStrings.roundedEdgeRectangleSmallShape)
+        table.bgColor = color
+        table.borderSize = 2f
 
         table.add(label).minHeight(30f).minWidth(150f).growX()
         table.addActor(lockIcon)
@@ -645,7 +637,7 @@ class PolicyPickerScreen(val worldScreen: WorldScreen, civInfo: Civilization = w
         return table
     }
 
-    private fun getPolicyButton(policy: Policy, size: Float = 30f): BorderedTable {
+    private fun getPolicyButton(policy: Policy, size: Float = 30f): PolicyButton {
         val button = PolicyButton(policy, size = size)
         button.onClick { pickPolicy(button = button) }
         return button

--- a/core/src/com/unciv/ui/pickerscreens/PolicyPickerScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/PolicyPickerScreen.kt
@@ -293,7 +293,7 @@ class PolicyPickerScreen(val worldScreen: WorldScreen, civInfo: Civilization = w
 
         // Main table
         val colorBg = if (branch.isAdopted()) PolicyColors.branchAdopted else PolicyColors.branchNotAdopted
-        val branchGroup = BorderedTable(path="PolicyScree/PolicyBranchBackground")
+        val branchGroup = BorderedTable(path="PolicyScreen/PolicyBranchBackground")
             .apply { bgColor = colorBg }
 
         // Header

--- a/core/src/com/unciv/ui/pickerscreens/PromotionPickerScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/PromotionPickerScreen.kt
@@ -83,12 +83,8 @@ class PromotionButton(
 
 ) : BorderedTable(
     path="PromotionScreen/PromotionButton",
-    defaultInner = BaseScreen.skinStrings.roundedEdgeRectangleMidShape,
-    defaultBorder = BaseScreen.skinStrings.roundedEdgeRectangleMidBorderShape,
-    borderColor = Color.WHITE.cpy(),
-    innerColor = Color.BLACK,
-    borderSize = 5f
-) {
+    defaultBgShape = BaseScreen.skinStrings.roundedEdgeRectangleMidShape,
+    defaultBgBorder = BaseScreen.skinStrings.roundedEdgeRectangleMidBorderShape) {
 
     var isSelected = false
     val label = node.promotion.name.toLabel().apply {
@@ -98,6 +94,8 @@ class PromotionButton(
     }
 
     init {
+
+        borderSize = 5f
 
         pad(5f)
         align(Align.left)
@@ -115,7 +113,8 @@ class PromotionButton(
             isPromoted -> PromotionPickerScreen.Promoted
             else -> PromotionPickerScreen.Default
         }
-        setBackgroundColor(color)
+
+        bgColor = color
 
         val textColor = when {
             isSelected -> Color.WHITE
@@ -360,7 +359,7 @@ class PromotionPickerScreen(val unit: MapUnit) : PickerScreen(), RecreateOnResiz
                 btn.updateColor()
             button.node.promotion.prerequisites.forEach { promotionToButton[it]?.apply {
                 if (!this.isPromoted)
-                    setBackgroundColor(Prerequisite) }}
+                    bgColor = Prerequisite }}
 
             rightSideButton.isEnabled = isPickable
             rightSideButton.setText(node.promotion.name.tr())

--- a/core/src/com/unciv/ui/tilegroups/CityButton.kt
+++ b/core/src/com/unciv/ui/tilegroups/CityButton.kt
@@ -154,35 +154,36 @@ class AirUnitTable(city: City, numberOfUnits: Int, size: Float=14f) : BorderedTa
 
 }
 
-private class StatusTable(city: City) : Table() {
+private class StatusTable(city: City, iconSize: Float = 18f) : Table() {
 
     init {
 
+        val padBetween = 2f
         val viewingCiv = UncivGame.Current.worldScreen!!.viewingCiv
 
         if (city.civInfo == viewingCiv && city.isConnectedToCapital() && !city.isCapital()) {
             val connectionImage = ImageGetter.getStatIcon("CityConnection")
-            add(connectionImage).size(18f)
+            add(connectionImage).size(iconSize)
         }
 
         if (city.isInResistance()) {
             val resistanceImage = ImageGetter.getImage("StatIcons/Resistance")
-            add(resistanceImage).size(18f).padLeft(2f)
+            add(resistanceImage).size(iconSize).padLeft(padBetween)
         }
 
         if (city.isPuppet) {
             val puppetImage = ImageGetter.getImage("OtherIcons/Puppet")
-            add(puppetImage).size(18f).padLeft(2f)
+            add(puppetImage).size(iconSize).padLeft(padBetween)
         }
 
         if (city.isBeingRazed) {
             val fireImage = ImageGetter.getImage("OtherIcons/Fire")
-            add(fireImage).size(18f).padLeft(2f)
+            add(fireImage).size(iconSize).padLeft(padBetween)
         }
 
         if (city.civInfo == viewingCiv && city.isWeLoveTheKingDayActive()) {
             val wltkdImage = ImageGetter.getImage("OtherIcons/WLTKD")
-            add(wltkdImage).size(18f).padLeft(2f)
+            add(wltkdImage).size(iconSize).padLeft(padBetween)
         }
     }
 
@@ -375,6 +376,10 @@ class CityButton(val city: City, private val tileGroup: TileGroup): Table(BaseSc
     private var isButtonMoved = false
     private var isViewable = true
 
+    fun isMoved(): Boolean {
+        return isButtonMoved
+    }
+
     fun update(isCityViewable: Boolean) {
 
         isViewable = isCityViewable
@@ -514,15 +519,16 @@ class CityButton(val city: City, private val tileGroup: TileGroup): Table(BaseSc
         }
 
         // when deselected, move city button to its original position
-        if (isButtonMoved
-                && unitTable.selectedCity != city
+        if (unitTable.selectedCity != city
                 && unitTable.selectedUnit?.currentTile != city.getCenterTile()) {
 
             moveButtonUp()
         }
     }
 
-    private fun moveButtonDown() {
+    fun moveButtonDown() {
+        if (isButtonMoved)
+            return
         val moveButtonAction = Actions.sequence(
                 Actions.moveTo(tileGroup.x, tileGroup.y-height, 0.4f, Interpolation.swingOut),
                 Actions.run {
@@ -533,7 +539,9 @@ class CityButton(val city: City, private val tileGroup: TileGroup): Table(BaseSc
         parent.addAction(moveButtonAction) // Move the whole cityButtonLayerGroup down, so the CityButton remains clickable
     }
 
-    private fun moveButtonUp() {
+    fun moveButtonUp() {
+        if (!isButtonMoved)
+            return
         val floatAction = Actions.sequence(
                 Actions.moveTo(tileGroup.x, tileGroup.y, 0.4f, Interpolation.sine),
                 Actions.run {

--- a/core/src/com/unciv/ui/tilegroups/CityButton.kt
+++ b/core/src/com/unciv/ui/tilegroups/CityButton.kt
@@ -45,6 +45,9 @@ class InfluenceTable(
 
         defaults().pad(1f)
         setSize(width, height)
+        background = BaseScreen.skinStrings.getUiBackground(
+            "WorldScreen/CityButton/InfluenceBar",
+            tintColor = Color.BLACK)
 
         val normalizedInfluence = max(-60f, min(influence, 60f)) / 30f
 

--- a/core/src/com/unciv/ui/tilegroups/CityButton.kt
+++ b/core/src/com/unciv/ui/tilegroups/CityButton.kt
@@ -11,7 +11,6 @@ import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.utils.Align
 import com.unciv.UncivGame
 import com.unciv.logic.battle.CityCombatant
-import com.unciv.logic.city.CityConstructions
 import com.unciv.logic.city.City
 import com.unciv.logic.city.INonPerpetualConstruction
 import com.unciv.logic.city.PerpetualConstruction
@@ -31,25 +30,334 @@ import com.unciv.ui.utils.extensions.colorFromRGB
 import com.unciv.ui.utils.extensions.onClick
 import com.unciv.ui.utils.extensions.toGroup
 import com.unciv.ui.utils.extensions.toLabel
-import javax.swing.Icon
 import kotlin.math.max
 import kotlin.math.min
 
-private object Colors {
-    val construction = colorFromRGB(196,140,62)
-    val growh =  colorFromRGB(130,225,78)
+class InfluenceTable(
+    influence: Float,
+    relationshipLevel: RelationshipLevel,
+    width: Float=100f,
+    height: Float=5f) : Table() {
+
+    override fun draw(batch: Batch?, parentAlpha: Float) { super.draw(batch, parentAlpha) }
+
+    init {
+
+        defaults().pad(1f)
+        setSize(width, height)
+
+        val normalizedInfluence = max(-60f, min(influence, 60f)) / 30f
+
+        val color = when (relationshipLevel) {
+            RelationshipLevel.Unforgivable -> Color.RED
+            RelationshipLevel.Enemy -> Color.ORANGE
+            RelationshipLevel.Afraid -> Color.YELLOW
+            RelationshipLevel.Neutral, RelationshipLevel.Friend -> Color.LIME
+            RelationshipLevel.Ally -> Color.SKY
+            else -> Color.DARK_GRAY
+        }
+
+        val percentages = arrayListOf(0f, 0f, 0f, 0f)
+        when {
+            normalizedInfluence < -1f -> {
+                percentages[0] = -normalizedInfluence - 1f
+                percentages[1] = 1f
+            }
+            normalizedInfluence < 0f -> percentages[1] = -normalizedInfluence
+            normalizedInfluence < 1f -> percentages[2] = normalizedInfluence
+            else -> {
+                percentages[2] = 1f
+                percentages[3] = (normalizedInfluence - 1f)
+            }
+        }
+
+        for (i in 0..3)
+            add(getBarPiece(percentages[i], color, i < 2))
+
+    }
+
+    private fun getBarPiece(percentage: Float, color: Color, negative: Boolean): Table{
+        val barPieceSize = width / 4f
+        val barPiece = Table()
+        val full = ImageGetter.getWhiteDot()
+        val empty = ImageGetter.getWhiteDot()
+
+        full.color = color
+        empty.color = Color.DARK_GRAY
+
+        if (negative) {
+            barPiece.add(empty).size((1f - percentage) * barPieceSize, height)
+            barPiece.add(full).size(percentage * barPieceSize, height)
+        } else {
+            barPiece.add(full).size(percentage * barPieceSize, height)
+            barPiece.add(empty).size((1f - percentage) * barPieceSize, height)
+        }
+
+        return barPiece
+    }
+
 }
 
-class IconTable(borderColor: Color, innerColor: Color, borderSize: Float, borderOnTop:Boolean=true): BorderedTable(
+private class DefenceTable(city: City) : BorderedTable(
+
+    path="WorldScreen/CityButton/DefenceTable",
+    defaultBgShape = BaseScreen.skinStrings.roundedTopEdgeRectangleSmallShape,
+    defaultBgBorder = BaseScreen.skinStrings.roundedTopEdgeRectangleSmallBorderShape) {
+
+    init {
+
+        val viewingCiv = UncivGame.Current.worldScreen!!.viewingCiv
+
+        borderSize = 4f
+        bgColor = Color.BLACK
+        bgBorderColor = when {
+            city.civInfo == viewingCiv -> colorFromRGB(255, 237, 200)
+            city.civInfo.isAtWarWith(viewingCiv) -> Color.RED
+            else -> Color.BLACK
+        }
+
+        pad(2f, 3f, 0f, 3f)
+
+        val cityStrength = CityCombatant(city).getDefendingStrength()
+        val cityStrengthLabel = "${Fonts.strength}$cityStrength"
+            .toLabel(fontSize = 12, alignment = Align.center)
+        add(cityStrengthLabel).colspan(2).grow().center()
+    }
+
+}
+
+class AirUnitTable(city: City, numberOfUnits: Int, size: Float=14f) : BorderedTable(
+    path="WorldScreen/CityButton/AirUnitTable",
+    defaultBgShape = BaseScreen.skinStrings.roundedEdgeRectangleSmallShape,
+    defaultBgBorder = BaseScreen.skinStrings.roundedEdgeRectangleSmallShape) {
+
+    init {
+
+        padTop(2f)
+        padBottom(2f)
+
+        padLeft(10f)
+        padRight(10f)
+
+        val textColor = city.civInfo.nation.getInnerColor()
+
+        bgColor = city.civInfo.nation.getOuterColor()
+        bgBorderColor = city.civInfo.nation.getOuterColor()
+
+        val aircraftImage = ImageGetter.getImage("OtherIcons/Aircraft")
+        aircraftImage.color = textColor
+        aircraftImage.setSize(size, size)
+
+        add(aircraftImage)
+        add(numberOfUnits.toString().toLabel(textColor, size.toInt()))
+    }
+
+}
+
+private class StatusTable(city: City) : Table() {
+
+    init {
+
+        val viewingCiv = UncivGame.Current.worldScreen!!.viewingCiv
+
+        if (city.civInfo == viewingCiv && city.isConnectedToCapital() && !city.isCapital()) {
+            val connectionImage = ImageGetter.getStatIcon("CityConnection")
+            add(connectionImage).size(18f)
+        }
+
+        if (city.isInResistance()) {
+            val resistanceImage = ImageGetter.getImage("StatIcons/Resistance")
+            add(resistanceImage).size(18f).padLeft(2f)
+        }
+
+        if (city.isPuppet) {
+            val puppetImage = ImageGetter.getImage("OtherIcons/Puppet")
+            add(puppetImage).size(18f).padLeft(2f)
+        }
+
+        if (city.isBeingRazed) {
+            val fireImage = ImageGetter.getImage("OtherIcons/Fire")
+            add(fireImage).size(18f).padLeft(2f)
+        }
+
+        if (city.civInfo == viewingCiv && city.isWeLoveTheKingDayActive()) {
+            val wltkdImage = ImageGetter.getImage("OtherIcons/WLTKD")
+            add(wltkdImage).size(18f).padLeft(2f)
+        }
+    }
+
+}
+
+private class CityTable(city: City, forPopup: Boolean = false) : BorderedTable(
     path = "WorldScreen/CityButton/IconTable",
-    defaultInner = BaseScreen.skinStrings.roundedEdgeRectangleMidShape,
-    defaultBorder = BaseScreen.skinStrings.roundedEdgeRectangleMidBorderShape,
-    borderColor = borderColor,
-    innerColor = innerColor,
-    borderSize = borderSize,
-    borderOnTop = borderOnTop
-) {
-    override fun draw(batch: Batch?, parentAlpha: Float) { super.draw(batch, parentAlpha) }
+    defaultBgShape = BaseScreen.skinStrings.roundedEdgeRectangleMidShape,
+    defaultBgBorder = BaseScreen.skinStrings.roundedEdgeRectangleMidBorderShape) {
+
+    init {
+        isTransform = false
+        touchable = Touchable.enabled
+
+        val viewingCiv = UncivGame.Current.worldScreen!!.viewingCiv
+
+        bgBorderColor = when {
+            city.civInfo == viewingCiv -> colorFromRGB(233, 233, 172)
+            city.civInfo.isAtWarWith(viewingCiv) -> colorFromRGB(230, 51, 0)
+            else -> Color.BLACK
+        }
+        borderSize = when {
+            city.civInfo == viewingCiv -> 4f
+            city.civInfo.isAtWarWith(viewingCiv) -> 4f
+            else -> 2f
+        }
+        bgColor = city.civInfo.nation.getOuterColor().cpy().apply { a = 0.9f }
+        borderOnTop = city.civInfo == viewingCiv
+
+        pad(0f)
+        defaults().pad(0f)
+
+        val isShowDetailedInfo = UncivGame.Current.viewEntireMapForDebug
+                || city.civInfo == viewingCiv
+                || viewingCiv.isSpectator()
+
+        addCityPopNumber(city)
+
+        if (isShowDetailedInfo)
+            addCityGrowthBar(city)
+
+        addCityText(city, forPopup)
+
+        if (isShowDetailedInfo)
+            addCityConstruction(city)
+
+        if (city.civInfo != viewingCiv)
+            addCivIcon(city)
+
+        cells.first().padLeft(4f)
+        cells.last().padRight(4f)
+    }
+
+    private fun addCityPopNumber(city: City) {
+        val textColor = city.civInfo.nation.getInnerColor()
+        val popLabel = city.population.population.toString()
+            .toLabel(fontColor = textColor, fontSize = 18, alignment = Align.center)
+        add(popLabel).minWidth(26f)
+    }
+
+    private fun addCityGrowthBar(city: City) {
+
+        val textColor = city.civInfo.nation.getInnerColor()
+
+        val table = Table()
+
+        var growthPercentage = city.population.foodStored / city.population.getFoodToNextPopulation().toFloat()
+        if (growthPercentage < 0) growthPercentage = 0.0f
+        if (growthPercentage > 1) growthPercentage = 1.0f
+
+        val growthBar = ImageGetter.getProgressBarVertical(4f, 30f,
+            if (city.isStarving()) 1.0f else growthPercentage,
+            if (city.isStarving()) Color.RED else CityButton.ColorGrowth, Color.BLACK, 1f)
+        growthBar.color.a = 0.8f
+
+        val turnLabelText = when {
+            city.isGrowing() -> {
+                val turnsToGrowth = city.population.getNumTurnsToNewPopulation()
+                if (turnsToGrowth != null && turnsToGrowth < 100) turnsToGrowth.toString() else "∞"
+            }
+            city.isStarving() -> {
+                val turnsToStarvation = city.population.getNumTurnsToStarvation()
+                if (turnsToStarvation != null && turnsToStarvation < 100) turnsToStarvation.toString() else "∞"
+            }
+            else -> "∞"
+        }
+
+        val turnLabel = turnLabelText.toLabel(fontColor = textColor, fontSize = 13)
+
+        table.add(growthBar).padRight(2f)
+        table.add(turnLabel).expandY().bottom()
+        add(table).minWidth(6f).padLeft(2f)
+    }
+
+    private fun addCityText(city: City, forPopup: Boolean) {
+
+        val textColor = city.civInfo.nation.getInnerColor()
+        val table = Table().apply { isTransform = false }
+
+        if (city.isCapital()) {
+            val capitalIcon = when {
+                city.civInfo.isCityState() -> ImageGetter.getNationIcon("CityState")
+                    .apply { color = textColor }
+                else -> ImageGetter.getImage("OtherIcons/Capital")
+            }
+            table.add(capitalIcon).size(20f).padRight(5f)
+        }
+
+        val cityName = city.name.tr().toLabel(fontColor = textColor, alignment = Align.center)
+        table.add(cityName).growY().center()
+
+        if (!forPopup) {
+            val cityReligion = city.religion.getMajorityReligion()
+            if (cityReligion != null) {
+                val religionImage = ImageGetter.getReligionIcon(cityReligion.getIconName()).apply {
+                    color = textColor }.toGroup(20f)
+                table.add(religionImage).size(20f).padLeft(5f)
+            }
+        }
+
+        table.pack()
+        add(table)
+            .minHeight(34f)
+            .padLeft(10f)
+            .padRight(10f)
+            .expandY().center()
+
+    }
+
+    private fun addCityConstruction(city: City) {
+
+        val textColor = city.civInfo.nation.getInnerColor()
+
+        val cityConstructions = city.cityConstructions
+        val cityCurrentConstruction = cityConstructions.getCurrentConstruction()
+
+        val progressTable = Table()
+
+        var percentage = 0f
+        var turns = "∞"
+        var icon: Group? = null
+
+        if (cityConstructions.currentConstructionFromQueue.isNotEmpty()) {
+            if (cityCurrentConstruction !is PerpetualConstruction) {
+                val turnsToConstruction = cityConstructions.turnsToConstruction(cityCurrentConstruction.name)
+                if (turnsToConstruction < 100)
+                    turns = turnsToConstruction.toString()
+                percentage = cityConstructions.getWorkDone(cityCurrentConstruction.name) /
+                        (cityCurrentConstruction as INonPerpetualConstruction).getProductionCost(cityConstructions.city.civInfo).toFloat()
+            }
+            icon = ImageGetter.getConstructionPortrait(cityCurrentConstruction.name, 24f)
+        }
+
+        val productionBar = ImageGetter.getProgressBarVertical(4f, 30f, percentage,
+            CityButton.ColorConstruction, Color.BLACK, 1f)
+        productionBar.color.a = 0.8f
+
+        progressTable.add(turns.toLabel(textColor, 13)).expandY().bottom()
+        progressTable.add(productionBar).padLeft(2f)
+
+        add(progressTable).minWidth(6f).padRight(2f)
+        add(icon).minWidth(26f)
+
+    }
+
+    private fun addCivIcon(city: City) {
+
+        val icon = when {
+            city.civInfo.isMajorCiv() -> ImageGetter.getNationIcon(city.civInfo.nation.name)
+            else -> ImageGetter.getImage("CityStateIcons/" + city.civInfo.cityStateType.name)
+        }
+        icon.color = city.civInfo.nation.getInnerColor()
+
+        add(icon.toGroup(20f)).minWidth(26f)
+    }
 }
 
 class CityButton(val city: City, private val tileGroup: TileGroup): Table(BaseScreen.skin){
@@ -61,57 +369,68 @@ class CityButton(val city: City, private val tileGroup: TileGroup): Table(BaseSc
         touchable = Touchable.disabled
     }
 
-    private lateinit var iconTable: IconTable
+    private lateinit var cityTable: CityTable
 
     private val listOfHiddenUnitMarkers: MutableList<Actor> = mutableListOf()
     private var isButtonMoved = false
-    private var showAdditionalInfoTags = false
+    private var isViewable = true
 
-    fun update(isCityViewable:Boolean) {
-        showAdditionalInfoTags = isCityViewable
+    fun update(isCityViewable: Boolean) {
+
+        isViewable = isCityViewable
 
         clear()
         setButtonActions()
-        addAirUnitTable()
 
-        add(getDefenceTable()).row()
+        // Top-to-bottom layout
 
-        iconTable = getIconTable()
-        add(iconTable).row()
-
-        if (city.civInfo.isCityState() && city.civInfo.knows(worldScreen.viewingCiv)) {
-            val diplomacyManager = city.civInfo.getDiplomacyManager(worldScreen.viewingCiv)
-            val influenceBar = getInfluenceBar(diplomacyManager.getInfluence(), diplomacyManager.relationshipLevel())
-            add(influenceBar).padTop(1f).row()
+        // If any air units in the city - add number indicator
+        if (isCityViewable && tileGroup.tile.airUnits.isNotEmpty()) {
+            add(AirUnitTable(city, tileGroup.tile.airUnits.size)).padBottom(5f).row()
         }
 
-        add(getStatuses()).padTop(3f)
+        // Add City strength table
+        add(DefenceTable(city)).row()
+
+        // Add City main table: pop, name, religion, construction, nation icon
+        cityTable = CityTable(city)
+        add(cityTable).row()
+
+        // If city state - add influence bar
+        if (city.civInfo.isCityState() && city.civInfo.knows(worldScreen.viewingCiv)) {
+            val diplomacyManager = city.civInfo.getDiplomacyManager(worldScreen.viewingCiv)
+            add(InfluenceTable(diplomacyManager.getInfluence(), diplomacyManager.relationshipLevel())).padTop(1f).row()
+        }
+
+        // Add statuses: connection, resistance, puppet, raze, WLTKD
+        add(StatusTable(city)).padTop(3f)
 
         pack()
 
-        if (showAdditionalInfoTags && city.health < city.getMaxHealth().toFloat()) {
+        // If city damaged - add health bar
+        if (isCityViewable && city.health < city.getMaxHealth().toFloat()) {
             val healthBar = ImageGetter.getHealthBar(city.health.toFloat(),
                 city.getMaxHealth().toFloat(), 100f, 3f)
             addActor(healthBar)
             healthBar.center(this)
-            healthBar.y = iconTable.y + iconTable.height-healthBar.height - 1f
+            healthBar.y = cityTable.y + cityTable.height-healthBar.height - 1f
         }
 
         setOrigin(Align.center)
         centerX(tileGroup)
 
-        updateHiddenUnitMarkers()
+        updateHiddenUnitMarkers(isCityViewable)
     }
 
     private enum class HiddenUnitMarkerPosition {Left, Center, Right}
 
-    private fun updateHiddenUnitMarkers() {
+    private fun updateHiddenUnitMarkers(isCityViewable: Boolean) {
         // remove obsolete markers
         for (marker in listOfHiddenUnitMarkers)
-            iconTable.removeActor(marker)
+            cityTable.removeActor(marker)
         listOfHiddenUnitMarkers.clear()
 
-        if (!showAdditionalInfoTags) return
+        if (!isCityViewable) return
 
         // detect civilian in the city center
         if (!isButtonMoved && (tileGroup.tile.civilianUnit != null))
@@ -149,7 +468,7 @@ class CityButton(val city: City, private val tileGroup: TileGroup): Table(BaseSc
 
     private fun insertHiddenUnitMarker(pos: HiddenUnitMarkerPosition) {
         // center of the city button +/- size of the 1.5 tiles
-        val positionX = iconTable.width / 2 + (pos.ordinal-1)*60f
+        val positionX = cityTable.width / 2 + (pos.ordinal-1)*60f
 
         val indicator = ImageGetter.getTriangle().apply {
             color = city.civInfo.nation.getInnerColor()
@@ -161,25 +480,8 @@ class CityButton(val city: City, private val tileGroup: TileGroup): Table(BaseSc
             } else
                 setPosition(positionX - width/2, -height) // height compensation because of asymmetrical icon
         }
-        iconTable.addActor(indicator)
+        cityTable.addActor(indicator)
         listOfHiddenUnitMarkers.add(indicator)
-    }
-
-    private fun addAirUnitTable() {
-        if (!showAdditionalInfoTags || tileGroup.tile.airUnits.isEmpty()) return
-        val secondaryColor = city.civInfo.nation.getInnerColor()
-        val airUnitTable = BorderedTable(
-            path="WorldScreen/CityButton/AirUnitTable",
-            defaultInner = BaseScreen.skinStrings.roundedEdgeRectangleSmallShape,
-            defaultBorder = BaseScreen.skinStrings.roundedEdgeRectangleSmallShape,
-            innerColor = city.civInfo.nation.getOuterColor(),
-            borderColor = city.civInfo.nation.getOuterColor()
-        )
-        val aircraftImage = ImageGetter.getImage("OtherIcons/Aircraft")
-        aircraftImage.color = secondaryColor
-        airUnitTable.add(aircraftImage).size(15f)
-        airUnitTable.add(tileGroup.tile.airUnits.size.toString().toLabel(secondaryColor,14))
-        add(airUnitTable).padBottom(5f).minWidth(50f).row()
     }
 
     private fun belongsToViewingCiv() = city.civInfo == worldScreen.viewingCiv
@@ -220,152 +522,12 @@ class CityButton(val city: City, private val tileGroup: TileGroup): Table(BaseSc
         }
     }
 
-    private fun getDefenceTable(forPopup: Boolean = false): Group {
-        val borderColor = when {
-            city.civInfo == worldScreen.viewingCiv -> colorFromRGB(255, 237, 200)
-            city.civInfo.isAtWarWith(worldScreen.viewingCiv) -> Color.RED
-            else -> Color.BLACK
-        }
-
-        val table = BorderedTable(
-            path="WorldScreen/CityButton/DefenceTable",
-            innerColor = Color.BLACK,
-            borderColor = borderColor,
-            defaultInner = BaseScreen.skinStrings.roundedTopEdgeRectangleSmallShape,
-            defaultBorder = BaseScreen.skinStrings.roundedTopEdgeRectangleSmallBorderShape,
-            borderSize = 5f)
-        table.pad(2f, 3f, 0f, 3f)
-
-        val cityStrength = CityCombatant(city).getDefendingStrength()
-        val cityStrengthLabel = "${Fonts.strength}$cityStrength".toLabel(fontSize = 12)
-        cityStrengthLabel.setAlignment(Align.center)
-
-        if (!forPopup)
-            table.add(cityStrengthLabel).grow().center()
-        return table
-    }
-
-    private fun getStatuses() : Table {
-
-        val table = Table()
-
-        if (belongsToViewingCiv() && city.isConnectedToCapital() && !city.isCapital()) {
-            val connectionImage = ImageGetter.getStatIcon("CityConnection")
-            table.add(connectionImage).size(18f)
-        }
-
-        if (city.isInResistance()) {
-            val resistanceImage = ImageGetter.getImage("StatIcons/Resistance")
-            table.add(resistanceImage).size(18f).padLeft(2f)
-        }
-
-        if (city.isPuppet) {
-            val puppetImage = ImageGetter.getImage("OtherIcons/Puppet")
-            table.add(puppetImage).size(18f).padLeft(2f)
-        }
-
-        if (city.isBeingRazed) {
-            val fireImage = ImageGetter.getImage("OtherIcons/Fire")
-            table.add(fireImage).size(18f).padLeft(2f)
-        }
-
-        if (belongsToViewingCiv() && city.isWeLoveTheKingDayActive()) {
-            val wtlkdImage = ImageGetter.getImage("OtherIcons/WLTKD")
-            table.add(wtlkdImage).size(18f).padLeft(2f)
-        }
-
-        return table
-
-    }
-
-    private fun getIconTable(forPopup: Boolean = false): IconTable {
-        val secondaryColor = city.civInfo.nation.getInnerColor()
-        val borderColor = when {
-            city.civInfo == worldScreen.viewingCiv -> colorFromRGB(233, 233, 172)
-            city.civInfo.isAtWarWith(worldScreen.viewingCiv) -> Color.RED.apply { r = 0.9f; g= 0.2f }
-            else -> Color.BLACK
-        }
-        val borderSize = when {
-            city.civInfo == worldScreen.viewingCiv -> 4f
-            city.civInfo.isAtWarWith(worldScreen.viewingCiv) -> 4f
-            else -> 2f
-        }
-
-        val iconTable = IconTable(
-            borderColor = borderColor,
-            innerColor = city.civInfo.nation.getOuterColor().cpy().apply { a = 0.9f },
-            borderSize = borderSize
-        ).apply {
-            isTransform = false
-        }
-        iconTable.pad(0f).padLeft(5f)
-        iconTable.touchable = Touchable.enabled
-
-        val popGroup = getPopulationGroup(uncivGame.viewEntireMapForDebug
-                || belongsToViewingCiv()
-                || worldScreen.viewingCiv.isSpectator())
-        val popGroupCell = iconTable.add(popGroup).minHeight(34f)
-
-        val labelTable = Table()
-
-        if (city.isCapital()) {
-            if (city.civInfo.isCityState()) {
-                val cityStateImage = ImageGetter.getNationIcon("CityState")
-                    .apply { color = secondaryColor }
-                labelTable.add(cityStateImage).size(20f).padRight(5f)
-            } else {
-                val starImage = ImageGetter.getImage("OtherIcons/Capital")
-                labelTable.add(starImage).size(20f).padRight(5f)
-            }
-        }
-
-        val cityButtonText = city.name.tr()
-        val label = cityButtonText.toLabel(secondaryColor).apply { setAlignment(Align.center) }
-        labelTable.add(label).growY().center()
-
-        if (!forPopup) {
-            val cityReligion = city.religion.getMajorityReligion()
-            if (cityReligion != null) {
-                val religionImage = ImageGetter.getReligionIcon(cityReligion.getIconName()).apply {
-                    color = secondaryColor }.toGroup(20f)
-                labelTable.add(religionImage).size(20f).padLeft(5f)
-            }
-        }
-
-        labelTable.pack()
-        iconTable.add(labelTable).padLeft(10f).padRight(10f).expandY().minHeight(32f).center()
-        label.toFront()
-
-        if (city.civInfo.isCityState()) {
-            val cityStateImage = ImageGetter.getImage("CityStateIcons/" +city.civInfo.cityStateType.name).apply { color = secondaryColor }
-            iconTable.padLeft(10f)
-            iconTable.add(cityStateImage).size(20f).fillY().padRight(5f)
-        }
-
-        if (uncivGame.viewEntireMapForDebug || belongsToViewingCiv() || worldScreen.viewingCiv.isSpectator()) {
-            val constructionGroup = getConstructionGroup(city.cityConstructions)
-            iconTable.add(constructionGroup)
-        } else if (city.civInfo.isMajorCiv()) {
-            val nationIcon = ImageGetter.getNationIcon(city.civInfo.nation.name)
-            nationIcon.color = secondaryColor
-            iconTable.add(nationIcon).size(20f).padRight(7f)
-            popGroupCell.padLeft(5f)
-        }
-
-        if (city.civInfo == worldScreen.viewingCiv)
-            iconTable.bgBorder.toFront()
-        else
-            iconTable.bgBorder.toBack()
-        iconTable.pack()
-        return iconTable
-    }
-
     private fun moveButtonDown() {
         val moveButtonAction = Actions.sequence(
                 Actions.moveTo(tileGroup.x, tileGroup.y-height, 0.4f, Interpolation.swingOut),
                 Actions.run {
                     isButtonMoved = true
-                    updateHiddenUnitMarkers()
+                    updateHiddenUnitMarkers(isViewable)
                 }
         )
         parent.addAction(moveButtonAction) // Move the whole cityButtonLayerGroup down, so the CityButton remains clickable
@@ -376,94 +538,10 @@ class CityButton(val city: City, private val tileGroup: TileGroup): Table(BaseSc
                 Actions.moveTo(tileGroup.x, tileGroup.y, 0.4f, Interpolation.sine),
                 Actions.run {
                     isButtonMoved = false
-                    updateHiddenUnitMarkers()
+                    updateHiddenUnitMarkers(isViewable)
                 }
         )
         parent.addAction(floatAction)
-    }
-
-    private fun getPopulationGroup(showGrowth: Boolean): Group {
-        val secondaryColor = city.civInfo.nation.getInnerColor()
-        val table = Table().apply { isTransform = false }
-        val popLabel = city.population.population.toString()
-            .toLabel(fontColor = secondaryColor, fontSize = 18).apply {
-            setAlignment(Align.center)
-        }
-        table.add(popLabel).minHeight(30f).apply {
-            if (showGrowth)
-                minWidth(26f)
-            else
-                minWidth(17f)
-        }.pad(0f)
-
-        table.pack()
-
-        if (showGrowth) {
-            var growthPercentage = city.population.foodStored / city.population.getFoodToNextPopulation().toFloat()
-            if (growthPercentage < 0) growthPercentage = 0.0f
-
-            // This can happen if the city was just taken, and there was excess food stored.
-            // Without it, it caused the growth bar's height to exceed that of the group's.
-            if (growthPercentage > 1) growthPercentage = 1.0f
-
-            val growthBar = ImageGetter.getProgressBarVertical(4f, 30f,
-                if (city.isStarving()) 1.0f else growthPercentage,
-                if (city.isStarving()) Color.RED else Colors.growh, Color.BLACK, 1f)
-            growthBar.color.a = 0.8f
-            table.add(growthBar).padTop(1f).padBottom(1f)
-
-            val turnLabelText = when {
-                city.isGrowing() -> {
-                    val turnsToGrowth = city.population.getNumTurnsToNewPopulation()
-                    if (turnsToGrowth != null && turnsToGrowth < 100) turnsToGrowth.toString() else "∞"
-                }
-                city.isStarving() -> {
-                    val turnsToStarvation = city.population.getNumTurnsToStarvation()
-                    if (turnsToStarvation != null && turnsToStarvation < 100) turnsToStarvation.toString() else "∞"
-                }
-                else -> "∞"
-            }
-
-            val turnLabel = turnLabelText.toLabel(fontColor = secondaryColor, fontSize = 13)
-            table.add(turnLabel).expandY().bottom().padLeft(3f)
-            turnLabel.toBack()
-        }
-
-        return table
-    }
-
-    private fun getConstructionGroup(cityConstructions: CityConstructions): Group {
-        val secondaryColor = city.civInfo.nation.getInnerColor()
-        val cityCurrentConstruction = cityConstructions.getCurrentConstruction()
-
-        val table = Table().apply { isTransform = false }
-        val tableHeight = 30f
-
-        if (cityConstructions.currentConstructionFromQueue.isNotEmpty()) {
-
-            if (cityCurrentConstruction !is PerpetualConstruction) {
-                val turnsToConstruction = cityConstructions.turnsToConstruction(cityCurrentConstruction.name)
-                val label = (if (turnsToConstruction < 100) turnsToConstruction.toString() else "∞").toLabel(secondaryColor, 13)
-
-                table.add(label).expandY().bottom().padRight(3f)
-
-                val constructionPercentage = cityConstructions.getWorkDone(cityCurrentConstruction.name) /
-                        (cityCurrentConstruction as INonPerpetualConstruction).getProductionCost(cityConstructions.city.civInfo).toFloat()
-                val productionBar = ImageGetter.getProgressBarVertical(4f, tableHeight, constructionPercentage,
-                    Colors.construction, Color.BLACK, 1f)
-                productionBar.color.a = 0.8f
-
-                table.add(productionBar).padTop(1f).padBottom(1f)
-            }
-
-            val constructionImage = ImageGetter.getConstructionPortrait(cityCurrentConstruction.name, 24f)
-            table.add(constructionImage).minHeight(32f).minWidth(26f)
-                .expand().center().right().pad(0f).padRight(4f).padLeft(3f)
-            table.pack()
-        }
-
-
-        return table
     }
 
     private fun foreignCityInfoPopup() {
@@ -477,7 +555,7 @@ class CityButton(val city: City, private val tileGroup: TileGroup): Table(BaseSc
 
         val popup = Popup(worldScreen).apply {
             name = "ForeignCityInfoPopup"
-            add(getIconTable(true)).fillX().padBottom(5f).colspan(3).row()
+            add(CityTable(city, true)).fillX().padBottom(5f).colspan(3).row()
             add(CityReligionInfoTable(city.religion, true)).colspan(3).row()
             addOKButton("Diplomacy") { openDiplomacy() }
             add().expandX()
@@ -487,69 +565,8 @@ class CityButton(val city: City, private val tileGroup: TileGroup): Table(BaseSc
     }
 
     companion object {
-        fun getInfluenceBar(influence: Float, relationshipLevel: RelationshipLevel, width: Float = 100f, height: Float = 5f): Table {
-            val normalizedInfluence = max(-60f, min(influence, 60f)) / 30f
-
-            val color = when (relationshipLevel) {
-                RelationshipLevel.Unforgivable -> Color.RED
-                RelationshipLevel.Enemy -> Color.ORANGE
-                RelationshipLevel.Afraid -> Color.YELLOW
-                RelationshipLevel.Neutral, RelationshipLevel.Friend -> Color.LIME
-                RelationshipLevel.Ally -> Color.SKY
-                else -> Color.DARK_GRAY
-            }
-
-            val percentages = arrayListOf(0f, 0f, 0f, 0f)
-            when {
-                normalizedInfluence < -1f -> {
-                    percentages[0] = -normalizedInfluence - 1f
-                    percentages[1] = 1f
-                }
-                normalizedInfluence < 0f -> percentages[1] = -normalizedInfluence
-                normalizedInfluence < 1f -> percentages[2] = normalizedInfluence
-                else -> {
-                    percentages[2] = 1f
-                    percentages[3] = (normalizedInfluence - 1f)
-                }
-            }
-
-            fun getBarPiece(percentage: Float, color: Color, negative: Boolean): Table{
-                val barPieceSize = width / 4f
-                val barPiece = Table()
-                val full = ImageGetter.getWhiteDot()
-                val empty = ImageGetter.getWhiteDot()
-
-                full.color = color
-                empty.color = Color.DARK_GRAY
-
-                if (negative) {
-                    barPiece.add(empty).size((1f - percentage) * barPieceSize, height)
-                    barPiece.add(full).size(percentage * barPieceSize, height)
-                } else {
-                    barPiece.add(full).size(percentage * barPieceSize, height)
-                    barPiece.add(empty).size((1f - percentage) * barPieceSize, height)
-                }
-
-                return barPiece
-            }
-
-            class InfluenceTable:Table() { // for recognition in the profiler
-                override fun draw(batch: Batch?, parentAlpha: Float) { super.draw(batch, parentAlpha) }
-            }
-            val influenceBar = InfluenceTable().apply {
-                defaults().pad(1f)
-                setSize(width, height)
-                background = BaseScreen.skinStrings.getUiBackground(
-                    "WorldScreen/CityButton/InfluenceBar",
-                    tintColor = Color.BLACK
-                )
-            }
-
-            for (i in 0..3)
-                influenceBar.add(getBarPiece(percentages[i], color, i < 2))
-
-            return influenceBar
-        }
+        val ColorConstruction = colorFromRGB(196,140,62)
+        val ColorGrowth =  colorFromRGB(130,225,78)
     }
 
     // For debugging purposes

--- a/core/src/com/unciv/ui/tilegroups/layers/TileLayerCityButton.kt
+++ b/core/src/com/unciv/ui/tilegroups/layers/TileLayerCityButton.kt
@@ -34,6 +34,14 @@ class TileLayerCityButton(tileGroup: TileGroup, size: Float) : TileLayer(tileGro
             super.draw(batch, parentAlpha)
     }
 
+    fun moveUp() {
+        cityButton?.moveButtonUp()
+    }
+
+    fun moveDown() {
+        cityButton?.moveButtonDown()
+    }
+
     fun update(city: City?, viewable: Boolean) {
 
         // There used to be a city here but it was razed

--- a/core/src/com/unciv/ui/tilegroups/layers/TileLayerUnitFlag.kt
+++ b/core/src/com/unciv/ui/tilegroups/layers/TileLayerUnitFlag.kt
@@ -11,6 +11,7 @@ import com.unciv.ui.tilegroups.TileGroup
 import com.unciv.ui.utils.BaseScreen
 import com.unciv.ui.utils.UnitGroup
 import com.unciv.ui.utils.extensions.center
+import com.unciv.ui.utils.extensions.centerX
 import com.unciv.ui.utils.extensions.toLabel
 
 class TileLayerUnitFlag(tileGroup: TileGroup, size: Float) : TileLayer(tileGroup, size) {
@@ -60,8 +61,6 @@ class TileLayerUnitFlag(tileGroup: TileGroup, size: Float) : TileLayer(tileGroup
                 val table = getAirUnitTable(unit)
                 addActor(table)
                 table.toBack()
-                table.center(this)
-                //table.y += 40f
                 table.y = newIcon.y + newIcon.height/2 - table.height/2
                 table.x = newIcon.x + newIcon.width - table.width/2
             }
@@ -81,8 +80,8 @@ class TileLayerUnitFlag(tileGroup: TileGroup, size: Float) : TileLayer(tileGroup
 
     private fun getAirUnitTable(unit: MapUnit): Table {
 
-        val iconColor = unit.civInfo.nation.getOuterColor()  //Color.WHITE.cpy().apply { a = 0.9f }
-        val bgColor = unit.civInfo.nation.getInnerColor() //Color.BLACK.cpy().apply { a = 0.9f }
+        val iconColor = unit.civInfo.nation.getOuterColor()
+        val bgColor = unit.civInfo.nation.getInnerColor()
 
         val airUnitTable = Table()
         airUnitTable.background = BaseScreen.skinStrings.getUiBackground(

--- a/core/src/com/unciv/ui/trade/DiplomacyScreen.kt
+++ b/core/src/com/unciv/ui/trade/DiplomacyScreen.kt
@@ -31,7 +31,7 @@ import com.unciv.ui.audio.MusicTrackChooserFlags
 import com.unciv.ui.civilopedia.CivilopediaScreen
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.popup.ConfirmPopup
-import com.unciv.ui.tilegroups.CityButton
+import com.unciv.ui.tilegroups.InfluenceTable
 import com.unciv.ui.utils.BaseScreen
 import com.unciv.ui.utils.Fonts
 import com.unciv.ui.utils.KeyCharAndCode
@@ -904,7 +904,7 @@ class DiplomacyScreen(
         relationshipTable.add(relationshipText.toLabel(relationshipColor)).row()
         if (otherCivDiplomacyManager.civInfo.isCityState())
             relationshipTable.add(
-                CityButton.getInfluenceBar(
+                InfluenceTable(
                     otherCivDiplomacyManager.getInfluence(),
                     relationshipLevel,
                     200f, 10f

--- a/core/src/com/unciv/ui/utils/BorderedTable.kt
+++ b/core/src/com/unciv/ui/utils/BorderedTable.kt
@@ -1,64 +1,52 @@
 package com.unciv.ui.utils
 
 import com.badlogic.gdx.graphics.Color
-import com.badlogic.gdx.scenes.scene2d.Actor
-import com.badlogic.gdx.scenes.scene2d.ui.Cell
-import com.badlogic.gdx.scenes.scene2d.ui.Image
+import com.badlogic.gdx.graphics.g2d.Batch
 import com.badlogic.gdx.scenes.scene2d.ui.Table
-import com.unciv.ui.utils.extensions.center
+import com.badlogic.gdx.scenes.scene2d.utils.Drawable
 
 open class BorderedTable(
     val path: String = "",
-    val defaultInner: String = BaseScreen.skinStrings.rectangleWithOutlineShape,
-    val defaultBorder: String = BaseScreen.skinStrings.rectangleWithOutlineShape,
-    val borderColor: Color = Color.WHITE,
-    val innerColor: Color = Color.BLACK,
-    var borderSize: Float = 5f,
-    val borderOnTop: Boolean = false
-) : Table() {
+    defaultBgShape: String = BaseScreen.skinStrings.rectangleWithOutlineShape,
+    defaultBgBorder: String = BaseScreen.skinStrings.rectangleWithOutlineShape) : Table() {
 
-    var bgInner: Image = Image(BaseScreen.skinStrings.getUiBackground(path, defaultInner,  innerColor.cpy()))
-    var bgBorder: Image = Image(BaseScreen.skinStrings.getUiBackground(path + "Border", defaultBorder,  borderColor.cpy()))
+    var bgColor: Color = Color.BLACK
+    var bgBorderColor: Color = Color.WHITE
 
-    init {
-        if (borderSize != 0f)
-            this.addActor(bgBorder)
-        this.addActor(bgInner)
+    var borderSize: Float = 5f
+    var borderOnTop: Boolean = false
 
+    private var bgInner: Drawable = BaseScreen.skinStrings.getUiBackground(path, defaultBgShape)
+    private var bgBorder: Drawable = BaseScreen.skinStrings.getUiBackground(path + "Border", defaultBgBorder)
 
+    override fun drawBackground(batch: Batch, parentAlpha: Float, x: Float, y: Float) {
         if (borderOnTop) {
-            if (borderSize != 0f)
-                bgBorder.toBack()
-            bgInner.toBack()
+            batch.setColor(
+                bgColor.r*color.r,
+                bgColor.g*color.g,
+                bgColor.b*color.b,
+                bgColor.a*color.a * parentAlpha)
+            bgInner.draw(batch, x, y, width, height)
+            batch.setColor(
+                bgBorderColor.r*color.r,
+                bgBorderColor.g*color.g,
+                bgBorderColor.b*color.b,
+                bgBorderColor.a*color.a * parentAlpha)
+            bgBorder.draw(batch, x-borderSize/2, y-borderSize/2, width+borderSize, height+borderSize)
         } else {
-            bgInner.toBack()
-            if (borderSize != 0f)
-                bgBorder.toBack()
+            batch.setColor(
+                bgBorderColor.r*color.r,
+                bgBorderColor.g*color.g,
+                bgBorderColor.b*color.b,
+                bgBorderColor.a*color.a * parentAlpha)
+            bgBorder.draw(batch, x-borderSize/2, y-borderSize/2, width+borderSize, height+borderSize)
+            batch.setColor(
+                bgColor.r*color.r,
+                bgColor.g*color.g,
+                bgColor.b*color.b,
+                bgColor.a*color.a * parentAlpha)
+            bgInner.draw(batch, x, y, width, height)
         }
-
     }
 
-    fun setBackgroundColor(color: Color) {
-        bgInner.remove()
-        bgInner = Image(BaseScreen.skinStrings.getUiBackground(path, defaultInner, color.cpy()))
-        addActor(bgInner)
-        if (borderSize != 0f) {
-            if (borderOnTop)
-                bgBorder.zIndex = bgInner.zIndex + 1
-            else
-                bgInner.zIndex = bgBorder.zIndex + 1
-        }
-        sizeChanged()
-    }
-
-    override fun sizeChanged() {
-        super.sizeChanged()
-        if (borderSize != 0f)
-            bgBorder.setSize(width + borderSize, height + borderSize)
-        bgInner.setSize(width, height)
-
-        if (borderSize != 0f)
-            bgBorder.center(this)
-        bgInner.center(this)
-    }
 }

--- a/core/src/com/unciv/ui/utils/UnitGroup.kt
+++ b/core/src/com/unciv/ui/utils/UnitGroup.kt
@@ -126,7 +126,6 @@ class UnitGroup(val unit: MapUnit, val size: Float): Group() {
 
     private fun getActionImage(): Image? {
         return when {
-            unit.isFortified() -> ImageGetter.getImage("UnitActionIcons/Fortify")
             unit.isSleeping() -> ImageGetter.getImage("UnitActionIcons/Sleep")
             unit.isMoving() -> ImageGetter.getImage("UnitActionIcons/MoveTo")
             unit.isExploring() -> ImageGetter.getImage("UnitActionIcons/Explore")

--- a/core/src/com/unciv/ui/utils/UnitGroup.kt
+++ b/core/src/com/unciv/ui/utils/UnitGroup.kt
@@ -12,8 +12,7 @@ import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.utils.extensions.center
 import com.unciv.ui.utils.extensions.colorFromRGB
 import com.unciv.ui.utils.extensions.surroundWithCircle
-
-val unitCircleLocation = "UnitIcons/Circle"
+import com.unciv.ui.utils.extensions.surroundWithThinCircle
 
 class UnitGroup(val unit: MapUnit, val size: Float): Group() {
     var actionGroup :Group? = null
@@ -76,8 +75,9 @@ class UnitGroup(val unit: MapUnit, val size: Float): Group() {
 
         val actionImage = getActionImage()
         if (actionImage != null) {
-            val actionCircle = actionImage.surroundWithCircle(size / 2 * 0.9f, circleImageLocation = unitCircleLocation)
-                .surroundWithCircle(size / 2, false, Color.BLACK, circleImageLocation = unitCircleLocation)
+            val actionCircle = actionImage
+                .surroundWithCircle(size / 2 * 0.9f)
+                .surroundWithThinCircle()
             actionCircle.setPosition(size / 2, 0f)
             actionCircle.color.a = UncivGame.Current.settings.unitIconOpacity
             addActor(actionCircle)
@@ -160,7 +160,7 @@ class UnitGroup(val unit: MapUnit, val size: Float): Group() {
                 && unit.currentMovement == 0f)
         val alpha = if (shouldBeFaded) 0.5f else 1f
         flagIcon.color.a = alpha
-        flagBg.children.forEach { it.color.a = alpha }
+        flagBg.color.a = alpha
 
         if (UncivGame.Current.settings.continuousRendering) {
             flagSelection.color.a = 1f

--- a/core/src/com/unciv/ui/worldscreen/WorldMapHolder.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldMapHolder.kt
@@ -425,7 +425,7 @@ class WorldMapHolder(
             }
 
             for (unit in unitList) {
-                val unitGroup = UnitGroup(unit, 60f).surroundWithCircle(80f)
+                val unitGroup = UnitGroup(unit, 60f).surroundWithCircle(85f, resizeActor = false)
                 unitGroup.circle.color = Color.GRAY.cpy().apply { a = 0.5f }
                 if (unit.currentMovement == 0f) unitGroup.color.a = 0.5f
                 unitGroup.touchable = Touchable.enabled

--- a/core/src/com/unciv/ui/worldscreen/WorldMapHolder.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldMapHolder.kt
@@ -187,6 +187,12 @@ class WorldMapHolder(
         unitTable.tileSelected(tile)
         val newSelectedUnit = unitTable.selectedUnit
 
+        if (previousSelectedCity != null && tile != previousSelectedCity.getCenterTile()) {
+            tileGroups[previousSelectedCity.getCenterTile()]?.forEach {
+                it.layerCityButton.moveUp()
+            }
+        }
+
         if (previousSelectedUnits.isNotEmpty() && previousSelectedUnits.any { it.getTile() != tile }
                 && worldScreen.isPlayersTurn
                 && (

--- a/docs/Modders/Creating-a-UI-skin.md
+++ b/docs/Modders/Creating-a-UI-skin.md
@@ -105,7 +105,6 @@ These shapes are used all over Unciv and can be replaced to make a lot of UI ele
 | WorldScreen/ | TutorialTaskTable | null | |
 | WorldScreen/ | UnitTable | roundedEdgeRectangleMid | |
 | WorldScreen/ | UnitTable | roundedEdgeRectangleMid | |
-| WorldScreen/CityButton/ | InfluenceBar | null | |
 | WorldScreen/Minimap/ | Background | null | |
 | WorldScreen/Minimap/ | Border | null | |
 | WorldScreen/TopBar/ | LeftAttachment | roundedEdgeRectangle | |

--- a/docs/Modders/Creating-a-UI-skin.md
+++ b/docs/Modders/Creating-a-UI-skin.md
@@ -105,6 +105,7 @@ These shapes are used all over Unciv and can be replaced to make a lot of UI ele
 | WorldScreen/ | TutorialTaskTable | null | |
 | WorldScreen/ | UnitTable | roundedEdgeRectangleMid | |
 | WorldScreen/ | UnitTable | roundedEdgeRectangleMid | |
+| WorldScreen/CityButton/ | InfluenceBar | null | |
 | WorldScreen/Minimap/ | Background | null | |
 | WorldScreen/Minimap/ | Border | null | |
 | WorldScreen/TopBar/ | LeftAttachment | roundedEdgeRectangle | |


### PR DESCRIPTION
1) Rewritten `BorderedTable` class: removed inner Images, override `draw` instead.
Less objects, less bugs, more speed.

2) Chore: Rearranged `CityButton` class and file, separated each plate component in own class: `InfluenceTable`, `DefenceTable`, `CityTable`, etc. No visual changes.

3) New look for air table for units:
![image](https://user-images.githubusercontent.com/32207817/215292431-1151c8fb-f4bd-4ccf-89a5-97de67715d57.png)![image](https://user-images.githubusercontent.com/32207817/215292438-595b6c60-7897-4091-ab78-dadc2890a682.png)![image](https://user-images.githubusercontent.com/32207817/215292442-eec03645-5bd1-44b6-b78b-b41be2d759f5.png)

4) Fixes:
- removed bugged selection highlight for Policy buttons in Policy Screen
- fixed wrong alignment for circles of city units
![image](https://user-images.githubusercontent.com/32207817/215292556-566b6e53-1f4b-491e-8d57-62d298b0a22c.png)
- removed redundant "Fortified" action indicator (fortified status is visible via flag shape already)
![image](https://user-images.githubusercontent.com/32207817/215292591-a02bb902-2191-42d4-9750-88abb9445955.png) to ![image](https://user-images.githubusercontent.com/32207817/215292619-8ab02aa1-32e7-436e-ae2c-9548a8c4f84f.png)
 

