### PR TITLE
Fix division by zero crash in AI unit logic

### DIFF
--- a/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
@@ -526,7 +526,7 @@ object UnitAutomation {
             .sum() // City heals 20 per turn
 
         if (expectedDamagePerTurn < city.health && // If we can take immediately, go for it
-                (expectedDamagePerTurn < 20 || city.health / (expectedDamagePerTurn-20) > 5)){ // otherwise check if we can take within a couple of turns
+                (expectedDamagePerTurn <= 20 || city.health / (expectedDamagePerTurn-20) > 5)){ // otherwise check if we can take within a couple of turns
 
             // We won't be able to take this even with 5 turns of continuous damage!
             // don't head straight to the city, try to head to landing grounds -


### PR DESCRIPTION
This is a crash I was getting when simulating games so I don't have a specific save to test but you can see that in the case that `expectedDamagePerTurn == 20` then there would be a division by zero exception.