### PR TITLE
Add next-turn-progress bar for growth/production on CityButtons

### DIFF
--- a/core/src/com/unciv/ui/images/ImageGetter.kt
+++ b/core/src/com/unciv/ui/images/ImageGetter.kt
@@ -304,7 +304,7 @@ object ImageGetter {
         percentComplete: Float,
         progressColor: Color,
         backgroundColor: Color,
-        progressPadding: Float = 0f): Group {
+        progressPadding: Float = 0f): ProgressBar {
         return ProgressBar(width, height, true)
                 .setBackground(backgroundColor)
                 .setProgress(progressColor, percentComplete, padding = progressPadding)
@@ -363,6 +363,7 @@ object ImageGetter {
                 else
                     secondaryProgress?.centerY(this)
             }
+            primaryProgress?.toFront()
             return this
         }
 

--- a/core/src/com/unciv/ui/tilegroups/CityButton.kt
+++ b/core/src/com/unciv/ui/tilegroups/CityButton.kt
@@ -27,11 +27,13 @@ import com.unciv.ui.utils.Fonts
 import com.unciv.ui.utils.extensions.center
 import com.unciv.ui.utils.extensions.centerX
 import com.unciv.ui.utils.extensions.colorFromRGB
+import com.unciv.ui.utils.extensions.darken
 import com.unciv.ui.utils.extensions.onClick
 import com.unciv.ui.utils.extensions.toGroup
 import com.unciv.ui.utils.extensions.toLabel
 import kotlin.math.max
 import kotlin.math.min
+import kotlin.math.roundToInt
 
 class InfluenceTable(
     influence: Float,
@@ -274,6 +276,14 @@ private class CityTable(city: City, forPopup: Boolean = false) : BorderedTable(
             else -> "∞"
         }
 
+        if (city.isGrowing()) {
+            var nextTurnPercentage = (city.foodForNextTurn() + city.population.foodStored) / city.population.getFoodToNextPopulation().toFloat()
+            if (nextTurnPercentage < 0) nextTurnPercentage = 0.0f
+            if (nextTurnPercentage > 1) nextTurnPercentage = 1.0f
+
+            growthBar.setSemiProgress(CityButton.ColorGrowth.cpy().darken(0.4f), nextTurnPercentage, 1f)
+        }
+
         val turnLabel = turnLabelText.toLabel(fontColor = textColor, fontSize = 13)
 
         table.add(growthBar).padRight(2f)
@@ -325,6 +335,7 @@ private class CityTable(city: City, forPopup: Boolean = false) : BorderedTable(
 
         val progressTable = Table()
 
+        var nextTurnPercentage = 0f
         var percentage = 0f
         var turns = "∞"
         var icon: Group? = null
@@ -336,12 +347,20 @@ private class CityTable(city: City, forPopup: Boolean = false) : BorderedTable(
                     turns = turnsToConstruction.toString()
                 percentage = cityConstructions.getWorkDone(cityCurrentConstruction.name) /
                         (cityCurrentConstruction as INonPerpetualConstruction).getProductionCost(cityConstructions.city.civInfo).toFloat()
+                nextTurnPercentage = (cityConstructions.getWorkDone(cityCurrentConstruction.name) + city.cityStats.currentCityStats.production) /
+                        cityCurrentConstruction.getProductionCost(cityConstructions.city.civInfo).toFloat()
+
+                if (nextTurnPercentage > 1f) nextTurnPercentage = 1f
+                if (nextTurnPercentage < 0f) nextTurnPercentage = 0f
+            } else {
+                turns = "-"
             }
             icon = ImageGetter.getConstructionPortrait(cityCurrentConstruction.name, 24f)
         }
 
         val productionBar = ImageGetter.getProgressBarVertical(4f, 30f, percentage,
             CityButton.ColorConstruction, Color.BLACK, 1f)
+        productionBar.setSemiProgress(CityButton.ColorConstruction.cpy().darken(0.4f), nextTurnPercentage, 1f)
         productionBar.color.a = 0.8f
 
         progressTable.add(turns.toLabel(textColor, 13)).expandY().bottom()

--- a/core/src/com/unciv/ui/tilegroups/CityButton.kt
+++ b/core/src/com/unciv/ui/tilegroups/CityButton.kt
@@ -273,7 +273,7 @@ private class CityTable(city: City, forPopup: Boolean = false) : BorderedTable(
                 val turnsToStarvation = city.population.getNumTurnsToStarvation()
                 if (turnsToStarvation != null && turnsToStarvation < 100) turnsToStarvation.toString() else "∞"
             }
-            else -> "∞"
+            else -> "-"
         }
 
         if (city.isGrowing()) {
@@ -337,7 +337,7 @@ private class CityTable(city: City, forPopup: Boolean = false) : BorderedTable(
 
         var nextTurnPercentage = 0f
         var percentage = 0f
-        var turns = "∞"
+        var turns = "-"
         var icon: Group? = null
 
         if (cityConstructions.currentConstructionFromQueue.isNotEmpty()) {
@@ -353,7 +353,7 @@ private class CityTable(city: City, forPopup: Boolean = false) : BorderedTable(
                 if (nextTurnPercentage > 1f) nextTurnPercentage = 1f
                 if (nextTurnPercentage < 0f) nextTurnPercentage = 0f
             } else {
-                turns = "-"
+                turns = "∞"
             }
             icon = ImageGetter.getConstructionPortrait(cityCurrentConstruction.name, 24f)
         }


### PR DESCRIPTION
Add additional coloring to CityButton's growth/construction bars, which denote the percentage of completion on the next turn:
![image](https://user-images.githubusercontent.com/32207817/215610435-71e74cb8-2c2f-4ba2-967d-7351d1ed02a9.png)
![image](https://user-images.githubusercontent.com/32207817/215610547-a6e57006-9cb2-4ccf-90f4-982ce3b3de19.png)
![image](https://user-images.githubusercontent.com/32207817/215610670-d1023ed7-bbf8-490b-b896-b541a2b39754.png)

Solid color - current, darkened color - on next turn.