### PR TITLE
Notification log fix

### DIFF
--- a/core/src/com/unciv/logic/civilization/managers/RuinsManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/RuinsManager.kt
@@ -49,7 +49,7 @@ class RuinsManager : IsPartOfGameInfoSerialization {
                 && (civInfo.civConstructions.boughtItemsWithIncreasingPrice[civInfo.religionManager.getGreatProphetEquivalent()] ?: 0) > 0
             ) continue
 
-            if (possibleReward.getMatchingUniques(UniqueType.OnlyAvailableWhen)
+            if (possibleReward.getMatchingUniques(UniqueType.OnlyAvailableWhen, StateForConditionals.IgnoreConditionals)
                         .any { !it.conditionalsApply(StateForConditionals(civInfo, unit=triggeringUnit, tile = triggeringUnit.getTile()) ) })
                 continue
 

--- a/core/src/com/unciv/ui/cityscreen/ConstructionInfoTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/ConstructionInfoTable.kt
@@ -82,7 +82,7 @@ class ConstructionInfoTable(val cityScreen: CityScreen): Table() {
                 is BaseUnit -> construction.getDescription(city)
                 is Building -> construction.getDescription(city, true)
                 is PerpetualStatConversion -> construction.description.replace("[rate]", "[${construction.getConversionRate(city)}]").tr()
-                is PerpetualConstruction -> construction.description
+                is PerpetualConstruction -> construction.description.tr()
                 else -> ""  // Should never happen
             }
 

--- a/core/src/com/unciv/ui/overviewscreen/NotificationsOverviewTable.kt
+++ b/core/src/com/unciv/ui/overviewscreen/NotificationsOverviewTable.kt
@@ -88,7 +88,7 @@ class NotificationsOverviewTable(
             for (notification in categoryNotifications) {
                 val notificationTable = Table(BaseScreen.skin)
 
-                val labelWidth = maxEntryWidth * notification.icons.size - 10f
+                val labelWidth = maxEntryWidth - iconSize * notification.icons.size - 10f
                 val label = WrappableLabel(notification.text, labelWidth, Color.BLACK, 20)
 
                 notificationTable.add(label)


### PR DESCRIPTION
Closes #8501 by translating the "This city will produce nothing" text as well as fixing the bugged notification bubble. I also found a separate bug where ruin rewards had a faulty check for "Only available <conditional>" uniques that caused the conditional to never be considered properly. This is fixed as well.