### PR TITLE
Block repairs in Hostile Tiles

### DIFF
--- a/core/src/com/unciv/ui/worldscreen/unit/actions/UnitActions.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/actions/UnitActions.kt
@@ -395,6 +395,7 @@ object UnitActions {
         val tile = unit.getTile()
         if (tile.isCityCenter()) return
         if (!tile.isPillaged()) return
+        if (tile.getOwner() != null && unit.civInfo.isAtWarWith(tile.getOwner()!!)) return
 
         val couldConstruct = unit.currentMovement > 0
                 && !tile.isCityCenter() && tile.improvementInProgress != Constants.repair


### PR DESCRIPTION
So you can't spam Repair and Pillage while besieging foreign lands