### PR TITLE
Block temperatureShift adjustment unless Easter Egg date

### DIFF
--- a/core/src/com/unciv/ui/tutorials/EasterEggRulesets.kt
+++ b/core/src/com/unciv/ui/tutorials/EasterEggRulesets.kt
@@ -11,14 +11,16 @@ import java.time.Month
 
 object EasterEggRulesets {
     fun MapParameters.modifyForEasterEgg() {
-        temperatureShift = when(HolidayDates.getMonth()) {
-            Month.JANUARY -> -1.4f
-            Month.FEBRUARY -> -1.3f
-            Month.MARCH -> -0.4f
-            Month.AUGUST -> 0.4f
-            Month.NOVEMBER -> -0.7f
-            Month.DECEMBER -> -1.3f
-            else -> 0f
+        if(getTodayEasterEggRuleset() != null) {
+            temperatureShift = when (HolidayDates.getMonth()) {
+                Month.JANUARY -> -1.4f
+                Month.FEBRUARY -> -1.3f
+                Month.MARCH -> -0.4f
+                Month.AUGUST -> 0.4f
+                Month.NOVEMBER -> -0.7f
+                Month.DECEMBER -> -1.3f
+                else -> 0f
+            }
         }
         rareFeaturesRichness = 0.15f
     }


### PR DESCRIPTION
THIS IS OPTIONAL

I noticed the temperature adjustment doesn't have a qualifier to check that it's actually an Easter Egg date, so we are actually always applying the temp shift for each month of the year.

It's kinda a neat Easter Egg some have noticed. But if we want to hide it away... there's this PR.

I didn't qualify the extra Richness since the Main Menu map should probably have some more exotic features anyways