### PR TITLE
City rename popup

### DIFF
--- a/core/src/com/unciv/ui/cityscreen/CityScreenCityPickerTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityScreenCityPickerTable.kt
@@ -5,7 +5,7 @@ import com.badlogic.gdx.scenes.scene2d.Touchable
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.utils.Align
 import com.unciv.ui.images.ImageGetter
-import com.unciv.ui.popup.AskTextPopup
+import com.unciv.ui.pickerscreens.CityRenamePopup
 import com.unciv.ui.utils.BaseScreen
 import com.unciv.ui.utils.extensions.onClick
 import com.unciv.ui.utils.extensions.toLabel
@@ -54,16 +54,13 @@ class CityScreenCityPickerTable(private val cityScreen: CityScreen) : Table() {
 
         val currentCityLabel = city.name.toLabel(fontSize = 30, fontColor = civInfo.nation.getInnerColor())
         if (cityScreen.canChangeState) currentCityLabel.onClick {
-            AskTextPopup(
-                cityScreen,
-                label = "Please enter a new name for your city",
-                defaultText = city.name,
-                validate = { it != "" },
-                actionOnOk = { text ->
-                    city.name = text
+            CityRenamePopup(
+                screen = cityScreen,
+                city = city,
+                actionOnClose = {
                     cityScreen.game.replaceCurrentScreen(CityScreen(city))
                 }
-            ).open()
+            )
         }
 
         cityNameTable.add(currentCityLabel)

--- a/core/src/com/unciv/ui/pickerscreens/CityRenamePopup.kt
+++ b/core/src/com/unciv/ui/pickerscreens/CityRenamePopup.kt
@@ -1,0 +1,24 @@
+package com.unciv.ui.pickerscreens
+
+import com.unciv.logic.city.City
+import com.unciv.models.translations.tr
+import com.unciv.ui.images.ImageGetter
+import com.unciv.ui.popup.AskTextPopup
+import com.unciv.ui.utils.BaseScreen
+
+class CityRenamePopup(val screen: BaseScreen, val city: City, val actionOnClose: ()->Unit) {
+    init {
+        AskTextPopup(
+            screen,
+            label = "Please enter a new name for your city",
+            defaultText = city.name.tr(),
+            validate = { it != "" },
+            actionOnOk = { text ->
+                city.name = text
+                actionOnClose()
+            }
+        ).open()
+    }
+
+}
+

--- a/core/src/com/unciv/ui/worldscreen/unit/UnitTable.kt
+++ b/core/src/com/unciv/ui/worldscreen/unit/UnitTable.kt
@@ -17,6 +17,7 @@ import com.unciv.models.translations.tr
 import com.unciv.ui.civilopedia.CivilopediaCategories
 import com.unciv.ui.civilopedia.CivilopediaScreen
 import com.unciv.ui.images.ImageGetter
+import com.unciv.ui.pickerscreens.CityRenamePopup
 import com.unciv.ui.pickerscreens.PromotionPickerScreen
 import com.unciv.ui.pickerscreens.UnitRenamePopup
 import com.unciv.ui.utils.BaseScreen
@@ -125,7 +126,7 @@ class UnitTable(val worldScreen: WorldScreen) : Table() {
             if (selectedUnit!!.civInfo != worldScreen.viewingCiv && !worldScreen.viewingCiv.isSpectator()) { // The unit that was selected, was captured. It exists but is no longer ours.
                 selectUnit()
                 selectedUnitHasChanged = true
-            } else if (selectedUnit!! !in selectedUnit!!.getTile().getUnits()) { // The unit that was there no longer exists}
+            } else if (selectedUnit!! !in selectedUnit!!.getTile().getUnits()) { // The unit that was there no longer exists
                 selectUnit()
                 selectedUnitHasChanged = true
             }
@@ -222,12 +223,26 @@ class UnitTable(val worldScreen: WorldScreen) : Table() {
         }
 
         else if (selectedCity != null) {
+            isVisible = true
             separator.isVisible = true
             val city = selectedCity!!
             var nameLabelText = city.name.tr()
             if(city.health<city.getMaxHealth()) nameLabelText+=" ("+city.health+")"
             unitNameLabel.setText(nameLabelText)
 
+            unitNameLabel.clearListeners()
+            unitNameLabel.onClick {
+            if (!worldScreen.canChangeState) return@onClick
+                CityRenamePopup(
+                    screen = worldScreen,
+                    city = city,
+                    actionOnClose = {
+                        unitNameLabel.setText(city.name.tr())
+                        worldScreen.shouldUpdate = true
+                    }
+                )
+            }
+            
             unitDescriptionTable.clear()
             unitDescriptionTable.defaults().pad(2f).padRight(5f)
             unitDescriptionTable.add("Strength".tr())


### PR DESCRIPTION
it is now possible to rename a city by clicking on its name in the UnitTable on the world screen(bottom left)