### PR TITLE
Suggestion: hide tutorial button

### DIFF
--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -101,6 +101,8 @@ class WorldScreen(
     var fogOfWar = true
         private set
 
+    var isTutorialShown = true
+    
     /** `true` when it's the player's turn unless he is a spectator*/
     val canChangeState
         get() = isPlayersTurn && !viewingCiv.isSpectator()
@@ -395,13 +397,17 @@ class WorldScreen(
             val tutorialTask = getCurrentTutorialTask()
             if (tutorialTask == "" || !game.settings.showTutorials || viewingCiv.isDefeated()) {
                 tutorialTaskTable.isVisible = false
+                minimapWrapper.tutorialHideButton.actor.isVisible = false
             } else {
-                tutorialTaskTable.isVisible = true
-                tutorialTaskTable.add(tutorialTask.toLabel()
-                    .apply { setAlignment(Align.center) }).pad(10f)
-                tutorialTaskTable.pack()
-                tutorialTaskTable.centerX(stage)
-                tutorialTaskTable.y = topBar.y - tutorialTaskTable.height
+                minimapWrapper.tutorialHideButton.actor.isVisible = true
+                if (isTutorialShown) {
+                    tutorialTaskTable.isVisible = true
+                    tutorialTaskTable.add(tutorialTask.toLabel()
+                        .apply { setAlignment(Align.center) }).pad(10f)
+                    tutorialTaskTable.pack()
+                    tutorialTaskTable.centerX(stage)
+                    tutorialTaskTable.y = topBar.y - tutorialTaskTable.height
+                } else tutorialTaskTable.isVisible = false
             }
 
             if (fogOfWar) minimapWrapper.update(selectedCiv)

--- a/core/src/com/unciv/ui/worldscreen/minimap/MinimapHolder.kt
+++ b/core/src/com/unciv/ui/worldscreen/minimap/MinimapHolder.kt
@@ -15,6 +15,13 @@ class MinimapHolder(val mapHolder: WorldMapHolder) : Table() {
     private var minimapSize = Int.MIN_VALUE
     lateinit var minimap: Minimap
 
+    /** Button, next to the minimap, to toggle tutorials. */
+    val tutorialHideButton = MapOverlayToggleButton(
+        ImageGetter.getImage("OtherIcons/Question").apply { setColor(0f, 0f, 0f, 1f) },
+        getter = { worldScreen.isTutorialShown },
+        setter = { worldScreen.isTutorialShown = it },
+        backgroundColor = Color.GREEN
+    )
     /** Button, next to the minimap, to toggle the unit movement map overlay. */
     val movementsImageButton = MapOverlayToggleButton(
         ImageGetter.getImage("StatIcons/Movement").apply { setColor(0f, 0f, 0f, 1f) },
@@ -88,6 +95,7 @@ class MinimapHolder(val mapHolder: WorldMapHolder) : Table() {
     private fun getToggleIcons(): Table {
         val toggleIconTable = Table()
 
+        toggleIconTable.add(tutorialHideButton.actor).row()
         toggleIconTable.add(movementsImageButton.actor).row()
         toggleIconTable.add(yieldImageButton.actor).row()
         toggleIconTable.add(populationImageButton.actor).row()
@@ -101,6 +109,7 @@ class MinimapHolder(val mapHolder: WorldMapHolder) : Table() {
         isVisible = UncivGame.Current.settings.showMinimap
         if (isVisible) {
             minimap.update(civInfo)
+            tutorialHideButton.update()
             movementsImageButton.update()
             yieldImageButton.update()
             populationImageButton.update()


### PR DESCRIPTION
in response to #7143
tutorial titles still take up a lot of space on the screen. 
my suggestion is to add a button next to the minimap when a tutorial is available. 

screenshots:
<details><summary>no tut available - no button</summary>
<img src="https://user-images.githubusercontent.com/1225948/216488294-1e1ddf26-92b8-4d88-9dab-e9472080355e.jpg">
</details>
<details><summary>tut is shown- button is bright green</summary>
<img src="https://user-images.githubusercontent.com/1225948/216488414-fbb97248-c8cd-41ac-9f43-35f2b6dadc06.jpg">
</details>
<details><summary>tut is hidden- button is dimmed</summary>
<img src="https://user-images.githubusercontent.com/1225948/216489064-992f34a6-67bf-4408-ae20-ce707239fbc9.jpg">
</details>
<details><summary>on the tiny screen size, default minimap size</summary>
<img src="https://user-images.githubusercontent.com/1225948/216488806-e6610669-38af-4b8c-85e6-c3d9a278e14a.jpg">
</details>
<details><summary>on the small screen size, default minimap size</summary>
<img src="https://user-images.githubusercontent.com/1225948/216488867-ecd801f1-5087-4a9d-b1c2-e4ed8188dceb.jpg">
</details>