### PR TITLE
UI Double/Multi Click Functionality and Double Click on Tech to Exit Tech Screen

### DIFF
--- a/core/src/com/unciv/ui/pickerscreens/TechPickerScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/TechPickerScreen.kt
@@ -23,6 +23,7 @@ import com.unciv.ui.utils.extensions.colorFromRGB
 import com.unciv.ui.utils.extensions.darken
 import com.unciv.ui.utils.extensions.disable
 import com.unciv.ui.utils.extensions.onClick
+import com.unciv.ui.utils.extensions.onDoubleClick
 import com.unciv.ui.utils.extensions.toLabel
 import com.unciv.utils.concurrency.Concurrency
 import kotlin.math.abs
@@ -80,19 +81,7 @@ class TechPickerScreen(
         pickerPane.bottomTable.background = skinStrings.getUiBackground("TechPickerScreen/BottomTable", tintColor = skinStrings.skinConfig.clearColor)
 
         rightSideButton.setText("Pick a tech".tr())
-        rightSideButton.onClick(UncivSound.Paper) {
-            if (freeTechPick) {
-                val freeTech = selectedTech!!.name
-                // More evil people fast-clicking to cheat - #4977
-                if (!researchableTechs.contains(freeTech)) return@onClick
-                civTech.getFreeTechnology(selectedTech!!.name)
-            }
-            else civTech.techsToResearch = tempTechsToResearch
-
-            game.settings.addCompletedTutorialTask("Pick technology")
-
-            game.popScreen()
-        }
+        rightSideButton.onClick(UncivSound.Paper) { tryExit() }
 
         // per default show current/recent technology,
         // and possibly select it to show description,
@@ -110,6 +99,20 @@ class TechPickerScreen(
             if (firstAvailableTech != null)
                 centerOnTechnology(firstAvailableTech)
         }
+    }
+
+    private fun tryExit() {
+        if (freeTechPick) {
+            val freeTech = selectedTech!!.name
+            // More evil people fast-clicking to cheat - #4977
+            if (!researchableTechs.contains(freeTech)) return
+            civTech.getFreeTechnology(selectedTech!!.name)
+        }
+        else civTech.techsToResearch = tempTechsToResearch
+
+        game.settings.addCompletedTutorialTask("Pick technology")
+
+        game.popScreen()
     }
 
     private fun createTechTable() {
@@ -182,6 +185,7 @@ class TechPickerScreen(
                     table.add(techButton)
                     techNameToButton[tech.name] = techButton
                     techButton.onClick { selectTechnology(tech, false) }
+                    techButton.onDoubleClick { tryExit() }
                     techTable.add(table).fillX()
                 }
             }

--- a/core/src/com/unciv/ui/pickerscreens/TechPickerScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/TechPickerScreen.kt
@@ -185,7 +185,7 @@ class TechPickerScreen(
                     table.add(techButton)
                     techNameToButton[tech.name] = techButton
                     techButton.onClick { selectTechnology(tech, false) }
-                    techButton.onDoubleClick { tryExit() }
+                    techButton.onDoubleClick(UncivSound.Paper) { tryExit() }
                     techTable.add(table).fillX()
                 }
             }

--- a/core/src/com/unciv/ui/utils/extensions/Scene2dExtensions.kt
+++ b/core/src/com/unciv/ui/utils/extensions/Scene2dExtensions.kt
@@ -297,7 +297,7 @@ class OnClickListener(val sound: UncivSound = UncivSound.Click,
     override fun clicked(event: InputEvent?, x: Float, y: Float) {
         var effectiveTapCount = tapCount
         if (clickFunctions[effectiveTapCount] == null) {
-            effectiveTapCount = clickFunctions.keys.maxOrNull() ?: return
+            effectiveTapCount = clickFunctions.keys.filter { it < tapCount }.maxOrNull() ?: return // happens if there's a double (or more) click function but no single click
         }
         val clickInstance = clickFunctions[effectiveTapCount]!!
         Concurrency.run("Sound") { SoundPlayer.play(clickInstance.sound) }

--- a/core/src/com/unciv/ui/utils/extensions/Scene2dExtensions.kt
+++ b/core/src/com/unciv/ui/utils/extensions/Scene2dExtensions.kt
@@ -311,7 +311,7 @@ fun Actor.onClickEvent(sound: UncivSound = UncivSound.Click,
                        tapCount: Int = 1,
                        tapInterval: Float = 0.0f,
                        function: (event: InputEvent?, x: Float, y: Float) -> Unit) {
-    val previousListener = this.listeners.firstOrNull()
+    val previousListener = this.listeners.firstOrNull { it is OnClickListener }
     if (previousListener != null && previousListener is OnClickListener) {
         previousListener.addClickFunction(sound, tapCount, function)
         previousListener.setTapCountInterval(tapInterval)


### PR DESCRIPTION
Extends existing Unciv functionality to allow for double or multiple clicks to trigger functions separate from single click `onClick()` instances. A premade function `Actor.onDoubleClick()` was added so devs can easily add double click functionality the same way you use `onClick()`. By default, clicking twice within a 250 millisecond window triggers a double click although this can be changed as default and on a button-by-button basis. Additional clicks (with the option for separate sounds) are set up to use an existing `ClickListener` object to prevent multiple click listeners from firing at the same time, and the ability to specify a multi click without a single click is also provided. In the event that many clicks happen within one `tapInterval`, the highest available listener instance with a `tapCount` below the actor's current tap count will be used, and if none exist then nothing will happen.

As a demonstration case, double clicking on a tech button in the tech tree will trigger the existing tech selection function as well as the existing exit screen functionality on the second click which makes it convenient for veteran players to select techs, and this has been tested on both Linux and Android.

Demonstration of double click to change the tech being researched as well as a single click vs double click in the tech screen

https://user-images.githubusercontent.com/105244635/216510528-114bd3a4-c472-4f39-ae8c-a61dde8b1226.mp4

