### PR TITLE
Smooth zoom when scrolling + cleanup code for listeners

### DIFF
--- a/core/src/com/unciv/MainMenuScreen.kt
+++ b/core/src/com/unciv/MainMenuScreen.kt
@@ -21,7 +21,7 @@ import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.ruleset.RulesetCache
 import com.unciv.ui.civilopedia.CivilopediaScreen
 import com.unciv.ui.images.ImageGetter
-import com.unciv.ui.map.TileGroupMap
+import com.unciv.ui.tilegroups.TileGroupMap
 import com.unciv.ui.mapeditor.EditorMapHolder
 import com.unciv.ui.mapeditor.MapEditorScreen
 import com.unciv.ui.multiplayer.MultiplayerScreen

--- a/core/src/com/unciv/ui/cityscreen/CityScreen.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityScreen.kt
@@ -19,7 +19,7 @@ import com.unciv.models.stats.Stat
 import com.unciv.ui.audio.CityAmbiencePlayer
 import com.unciv.ui.audio.SoundPlayer
 import com.unciv.ui.images.ImageGetter
-import com.unciv.ui.map.TileGroupMap
+import com.unciv.ui.tilegroups.TileGroupMap
 import com.unciv.ui.popup.ToastPopup
 import com.unciv.ui.tilegroups.CityTileGroup
 import com.unciv.ui.tilegroups.TileSetStrings

--- a/core/src/com/unciv/ui/mapeditor/EditorMapHolder.kt
+++ b/core/src/com/unciv/ui/mapeditor/EditorMapHolder.kt
@@ -8,11 +8,10 @@ import com.badlogic.gdx.scenes.scene2d.InputListener
 import com.badlogic.gdx.scenes.scene2d.Stage
 import com.badlogic.gdx.scenes.scene2d.Touchable
 import com.badlogic.gdx.scenes.scene2d.actions.Actions
-import com.unciv.UncivGame
 import com.unciv.logic.map.HexMath
 import com.unciv.logic.map.tile.Tile
 import com.unciv.logic.map.TileMap
-import com.unciv.ui.map.TileGroupMap
+import com.unciv.ui.tilegroups.TileGroupMap
 import com.unciv.ui.tilegroups.TileGroup
 import com.unciv.ui.tilegroups.TileSetStrings
 import com.unciv.ui.utils.BaseScreen

--- a/core/src/com/unciv/ui/options/AdvancedTab.kt
+++ b/core/src/com/unciv/ui/options/AdvancedTab.kt
@@ -241,7 +241,7 @@ private fun CoroutineScope.generateScreenshots(configs:ArrayList<ScreenshotConfi
         newScreen.mapHolder.onTileClicked(newScreen.mapHolder.tileMap[-2, 3]) // Then click on Keshik
         if (currentConfig.attackCity)
             newScreen.mapHolder.onTileClicked(newScreen.mapHolder.tileMap[-2, 2]) // Then click city again for attack table
-        newScreen.mapHolder.zoomIn()
+        newScreen.mapHolder.zoomIn(true)
         withContext(Dispatchers.IO) {
             Thread.sleep(300)
             launchOnGLThread {

--- a/core/src/com/unciv/ui/tilegroups/TileGroup.kt
+++ b/core/src/com/unciv/ui/tilegroups/TileGroup.kt
@@ -5,7 +5,6 @@ import com.badlogic.gdx.scenes.scene2d.Group
 import com.unciv.UncivGame
 import com.unciv.logic.civilization.Civilization
 import com.unciv.logic.map.tile.Tile
-import com.unciv.ui.map.TileGroupMap
 import com.unciv.ui.tilegroups.layers.TileLayerBorders
 import com.unciv.ui.tilegroups.layers.TileLayerCityButton
 import com.unciv.ui.tilegroups.layers.TileLayerFeatures

--- a/core/src/com/unciv/ui/tilegroups/TileGroupMap.kt
+++ b/core/src/com/unciv/ui/tilegroups/TileGroupMap.kt
@@ -1,13 +1,12 @@
-package com.unciv.ui.map
+package com.unciv.ui.tilegroups
 
 import com.badlogic.gdx.graphics.g2d.Batch
+import com.badlogic.gdx.math.Rectangle
 import com.badlogic.gdx.math.Vector2
+import com.badlogic.gdx.scenes.scene2d.Actor
 import com.badlogic.gdx.scenes.scene2d.Group
 import com.unciv.logic.map.HexMath
 import com.unciv.logic.map.TileMap
-import com.unciv.ui.tilegroups.CityTileGroup
-import com.unciv.ui.tilegroups.TileGroup
-import com.unciv.ui.tilegroups.WorldTileGroup
 import com.unciv.ui.tilegroups.layers.TileLayerBorders
 import com.unciv.ui.tilegroups.layers.TileLayerCityButton
 import com.unciv.ui.tilegroups.layers.TileLayerFeatures
@@ -52,6 +51,7 @@ class TileGroupMap<T: TileGroup>(
      * and thus not perform any [com.badlogic.gdx.scenes.scene2d.Action]s.
      * Most children here already do not do anything in their [act] methods. However, even iterating through all of them */
     var shouldAct = true
+    var shouldHit = true
 
     private var topX = -Float.MAX_VALUE
     private var topY = -Float.MAX_VALUE
@@ -132,6 +132,8 @@ class TileGroupMap<T: TileGroup>(
         // If map is not wrapped, Map's width doesn't need to be reduce by groupSize
         if (worldWrap) setSize(topX - bottomX - groupSize, topY - bottomY)
         else setSize(topX - bottomX, topY - bottomY)
+
+        cullingArea = Rectangle(0f, 0f, width, height)
     }
 
     /**
@@ -146,9 +148,14 @@ class TileGroupMap<T: TileGroup>(
     }
 
     override fun act(delta: Float) {
-        if(shouldAct) {
+        if (shouldAct)
             super.act(delta)
-        }
+    }
+
+    override fun hit(x: Float, y: Float, touchable: Boolean): Actor? {
+        if (shouldHit)
+            return super.hit(x, y, touchable)
+        return null
     }
 
     override fun draw(batch: Batch?, parentAlpha: Float) {

--- a/core/src/com/unciv/ui/utils/ZoomGestureListener.kt
+++ b/core/src/com/unciv/ui/utils/ZoomGestureListener.kt
@@ -9,8 +9,6 @@ import com.badlogic.gdx.scenes.scene2d.InputEvent
 open class ZoomGestureListener(
     halfTapSquareSize: Float, tapCountInterval: Float, longPressDuration: Float, maxFlingDelay: Float
 ) : EventListener {
-
-    var isPinching = false
     val detector: GestureDetector
     var event: InputEvent? = null
 

--- a/core/src/com/unciv/ui/utils/ZoomGestureListener.kt
+++ b/core/src/com/unciv/ui/utils/ZoomGestureListener.kt
@@ -10,13 +10,14 @@ open class ZoomGestureListener(
     halfTapSquareSize: Float, tapCountInterval: Float, longPressDuration: Float, maxFlingDelay: Float
 ) : EventListener {
 
+    var isPinching = false
     val detector: GestureDetector
     var event: InputEvent? = null
 
     constructor() : this(20f, 0.4f, 1.1f, Int.MAX_VALUE.toFloat())
 
     init {
-        detector = GestureDetector(
+        detector = object : GestureDetector(
             halfTapSquareSize,
             tapCountInterval,
             longPressDuration,
@@ -24,7 +25,7 @@ open class ZoomGestureListener(
             object : GestureDetector.GestureAdapter() {
 
                 override fun zoom(initialDistance: Float, distance: Float): Boolean {
-                    this@ZoomGestureListener.zoom(event, initialDistance, distance)
+                    this@ZoomGestureListener.zoom(initialDistance, distance)
                     return true
                 }
 
@@ -34,14 +35,17 @@ open class ZoomGestureListener(
                     stagePointer1: Vector2,
                     stagePointer2: Vector2
                 ): Boolean {
+                    isPinching = true
                     this@ZoomGestureListener.pinch()
                     return true
                 }
 
                 override fun pinchStop() {
+                    isPinching = false
                     this@ZoomGestureListener.pinchStop()
                 }
-            })
+            }) {
+        }
     }
 
 
@@ -71,10 +75,15 @@ open class ZoomGestureListener(
                 detector.touchDragged(event.stageX, event.stageY, event.pointer)
                 return true
             }
+            InputEvent.Type.scrolled -> {
+                return scrolled(event.scrollAmountX, event.scrollAmountY)
+            }
             else -> return false
         }
     }
-    open fun zoom(event: InputEvent?, initialDistance: Float, distance: Float) {}
+
+    open fun scrolled(amountX: Float, amountY: Float): Boolean { return false }
+    open fun zoom(initialDistance: Float, distance: Float) {}
     open fun pinch() {}
     open fun pinchStop() {}
 }

--- a/core/src/com/unciv/ui/utils/ZoomGestureListener.kt
+++ b/core/src/com/unciv/ui/utils/ZoomGestureListener.kt
@@ -17,7 +17,7 @@ open class ZoomGestureListener(
     constructor() : this(20f, 0.4f, 1.1f, Int.MAX_VALUE.toFloat())
 
     init {
-        detector = object : GestureDetector(
+        detector = GestureDetector(
             halfTapSquareSize,
             tapCountInterval,
             longPressDuration,
@@ -35,17 +35,14 @@ open class ZoomGestureListener(
                     stagePointer1: Vector2,
                     stagePointer2: Vector2
                 ): Boolean {
-                    isPinching = true
                     this@ZoomGestureListener.pinch()
                     return true
                 }
 
                 override fun pinchStop() {
-                    isPinching = false
                     this@ZoomGestureListener.pinchStop()
                 }
-            }) {
-        }
+            })
     }
 
 


### PR DESCRIPTION
1) Now zooming by mouse scroll (or by worldscreen zoom buttons) is smooth with `fast-slow` interpolation, instead of just zoom jumps.

2) `TileGroupMap.kt` was moved to `.../ui/tilegroups/`

3) Small cleanups here and there:
- unification of zoom-by-touch listener and zoom-by-scroll listener into single one
- making listener classes inner instead of passing scrollpane as variable