### PR TITLE
Bigger header on policy and mod screens

### DIFF
--- a/core/src/com/unciv/ui/pickerscreens/ModManagementOptions.kt
+++ b/core/src/com/unciv/ui/pickerscreens/ModManagementOptions.kt
@@ -156,7 +156,7 @@ class ModManagementOptions(private val modManagementScreen: ModManagementScreen)
             fontSize = Constants.defaultFontSize,
             startsOutOpened = false,
             defaultPad = 2.5f,
-            headerPad = 5f,
+            headerPad = 15f,
             expanderWidth = 360f,
             onChange = { expanderChangeEvent?.invoke() }
         ) {

--- a/core/src/com/unciv/ui/pickerscreens/ModManagementScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/ModManagementScreen.kt
@@ -169,13 +169,13 @@ class ModManagementScreen(
         installedHeaderLabel!!.onClick {
             optionsManager.installedHeaderClicked()
         }
-        topTable.add(installedHeaderLabel).pad(5f).minWidth(200f).padLeft(25f)
+        topTable.add(installedHeaderLabel).pad(15f).minWidth(200f).padLeft(25f)
             // 30 = 5 default pad + 20 to compensate for 'permanent visual mod' decoration icon
         onlineHeaderLabel = optionsManager.getOnlineHeader().toLabel()
         onlineHeaderLabel!!.onClick {
             optionsManager.onlineHeaderClicked()
         }
-        topTable.add(onlineHeaderLabel).pad(5f)
+        topTable.add(onlineHeaderLabel).pad(15f)
         topTable.add("".toLabel()).minWidth(200f)  // placeholder for "Mod actions"
         topTable.add().expandX()
         topTable.row()

--- a/core/src/com/unciv/ui/pickerscreens/PolicyPickerScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/PolicyPickerScreen.kt
@@ -547,7 +547,7 @@ class PolicyPickerScreen(val worldScreen: WorldScreen, val viewingCiv: Civilizat
         val header = BorderedTable(path="PolicyScreen/PolicyBranchHeader")
         header.bgColor = colorFromRGB(47,90,92)
         header.borderSize = 5f
-        header.pad(5f)
+        header.pad(10f)
 
         val table = Table()
 
@@ -562,7 +562,7 @@ class PolicyPickerScreen(val worldScreen: WorldScreen, val viewingCiv: Civilizat
         table.add(branch.name.tr().uppercase().toLabel(fontSize = 14).apply { setAlignment(Align.center) }).center()
         table.add(icon).expandX().left().padLeft(5f)
 
-        table.setTouchable(Touchable.enabled)
+        header.setTouchable(Touchable.enabled)
 
         header.add(table).minWidth(150f).growX()
         header.pack()


### PR DESCRIPTION
After playing a while on the phone I realized that the #8552 was not enough and the headers are small, hard to click, especially near the edge of the screen. Therefore, I increased their height a little. 
On my 6" 1080x2160 screen with medium screen size, the hit/miss ratio is much better.
Also, made a bigger header on the mod screen(#8582)

Screenshots:
<details><summary>was</summary>

![14_2](https://user-images.githubusercontent.com/1225948/216833194-cad9f017-c9c8-4bcf-8dc1-61a3e9ebcd3e.jpg)

![14_3](https://user-images.githubusercontent.com/1225948/216833208-fb1a740e-5781-4830-8f57-d1e87f656218.jpg)
</details>
<details><summary>became</summary>

![14_1](https://user-images.githubusercontent.com/1225948/216833245-a21951ad-67eb-49f1-8080-dc74133ca442.jpg)

![14_5](https://user-images.githubusercontent.com/1225948/216833254-b69ccb8d-4209-4b6e-8e1b-eba1612c6d31.jpg)
</details>