### PR TITLE
Suggestion: Collapsible tutorial tasks

### DIFF
--- a/core/src/com/unciv/UncivGame.kt
+++ b/core/src/com/unciv/UncivGame.kt
@@ -66,6 +66,8 @@ class UncivGame(parameters: UncivGameParameters) : Game() {
     lateinit var onlineMultiplayer: OnlineMultiplayer
     lateinit var files: UncivFiles
 
+    var isTutorialTaskCollapsed = false
+
     /**
      * This exists so that when debugging we can see the entire map.
      * Remember to turn this to false before commit and upload!

--- a/core/src/com/unciv/models/metadata/GameSettings.kt
+++ b/core/src/com/unciv/models/metadata/GameSettings.kt
@@ -114,6 +114,7 @@ class GameSettings {
 
     fun addCompletedTutorialTask(tutorialTask: String): Boolean {
         if (!tutorialTasksCompleted.add(tutorialTask)) return false
+        UncivGame.Current.isTutorialTaskCollapsed = false
         save()
         return true
     }

--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -543,21 +543,22 @@ class WorldScreen(
         val tutorialTask = getCurrentTutorialTask()
         if (tutorialTask == "" || !game.settings.showTutorials || viewingCiv.isDefeated()) {
             tutorialTaskTable.isVisible = false
+            return
+        }
+
+        tutorialTaskTable.isVisible = true
+        if (!UncivGame.Current.isTutorialTaskCollapsed) {
+            tutorialTaskTable.add(tutorialTask.toLabel()
+                .apply { setAlignment(Align.center) }).pad(10f)
         } else {
-            tutorialTaskTable.isVisible = true
-            if (!UncivGame.Current.isTutorialTaskCollapsed) {
-                tutorialTaskTable.add(tutorialTask.toLabel()
-                    .apply { setAlignment(Align.center) }).pad(10f)
-            } else {
-                tutorialTaskTable.add(ImageGetter.getImage("CityStateIcons/Cultured").apply { setSize(30f,30f) }).pad(5f)
-            }
-            tutorialTaskTable.pack()
-            tutorialTaskTable.centerX(stage)
-            tutorialTaskTable.y = topBar.y - tutorialTaskTable.height
-            tutorialTaskTable.onClick() {
-                UncivGame.Current.isTutorialTaskCollapsed = !UncivGame.Current.isTutorialTaskCollapsed
-                displayTutorialTaskOnUpdate()
-            }
+            tutorialTaskTable.add(ImageGetter.getImage("CityStateIcons/Cultured").apply { setSize(30f,30f) }).pad(5f)
+        }
+        tutorialTaskTable.pack()
+        tutorialTaskTable.centerX(stage)
+        tutorialTaskTable.y = topBar.y - tutorialTaskTable.height
+        tutorialTaskTable.onClick() {
+            UncivGame.Current.isTutorialTaskCollapsed = !UncivGame.Current.isTutorialTaskCollapsed
+            displayTutorialTaskOnUpdate()
         }
     }
 

--- a/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/worldscreen/WorldScreen.kt
@@ -31,6 +31,7 @@ import com.unciv.models.ruleset.tile.ResourceType
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.ui.cityscreen.CityScreen
 import com.unciv.ui.civilopedia.CivilopediaScreen
+import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.overviewscreen.EmpireOverviewScreen
 import com.unciv.ui.pickerscreens.DiplomaticVotePickerScreen
 import com.unciv.ui.pickerscreens.DiplomaticVoteResultScreen
@@ -391,18 +392,7 @@ class WorldScreen(
 
             updateSelectedCiv()
 
-            tutorialTaskTable.clear()
-            val tutorialTask = getCurrentTutorialTask()
-            if (tutorialTask == "" || !game.settings.showTutorials || viewingCiv.isDefeated()) {
-                tutorialTaskTable.isVisible = false
-            } else {
-                tutorialTaskTable.isVisible = true
-                tutorialTaskTable.add(tutorialTask.toLabel()
-                    .apply { setAlignment(Align.center) }).pad(10f)
-                tutorialTaskTable.pack()
-                tutorialTaskTable.centerX(stage)
-                tutorialTaskTable.y = topBar.y - tutorialTaskTable.height
-            }
+            displayTutorialTaskOnUpdate()
 
             if (fogOfWar) minimapWrapper.update(selectedCiv)
             else minimapWrapper.update(viewingCiv)
@@ -544,6 +534,29 @@ class WorldScreen(
         displayTutorial(TutorialTrigger.Workers) {
             gameInfo.getCurrentPlayerCivilization().units.getCivUnits().any {
                 it.cache.hasUniqueToBuildImprovements && it.isCivilian() && !it.isGreatPerson()
+            }
+        }
+    }
+
+    private fun displayTutorialTaskOnUpdate() {
+        tutorialTaskTable.clear()
+        val tutorialTask = getCurrentTutorialTask()
+        if (tutorialTask == "" || !game.settings.showTutorials || viewingCiv.isDefeated()) {
+            tutorialTaskTable.isVisible = false
+        } else {
+            tutorialTaskTable.isVisible = true
+            if (!UncivGame.Current.isTutorialTaskCollapsed) {
+                tutorialTaskTable.add(tutorialTask.toLabel()
+                    .apply { setAlignment(Align.center) }).pad(10f)
+            } else {
+                tutorialTaskTable.add(ImageGetter.getImage("CityStateIcons/Cultured").apply { setSize(30f,30f) }).pad(5f)
+            }
+            tutorialTaskTable.pack()
+            tutorialTaskTable.centerX(stage)
+            tutorialTaskTable.y = topBar.y - tutorialTaskTable.height
+            tutorialTaskTable.onClick() {
+                UncivGame.Current.isTutorialTaskCollapsed = !UncivGame.Current.isTutorialTaskCollapsed
+                displayTutorialTaskOnUpdate()
             }
         }
     }


### PR DESCRIPTION
in continuation #8559 and #7143
when you click on a tutorial task, it collapses to an icon and frees up screen space. Clicking on the icon again wiil return the tutorial.
<details><summary>Screens</summary>

![11_8](https://user-images.githubusercontent.com/1225948/216836853-e3576c9e-a80a-4cca-8462-c871942ac4f3.jpg)
![11_9](https://user-images.githubusercontent.com/1225948/216836859-435db637-791a-47f9-bd59-c0c0772fdec5.jpg)
![11_10](https://user-images.githubusercontent.com/1225948/216836868-6ad5a538-f92e-4076-bb67-422cd4fade71.jpg)
![11_11](https://user-images.githubusercontent.com/1225948/216836873-ac15dc46-882d-44e9-9b5d-b54525fda2cf.jpg)
</details>