### PR TITLE
Fix MapEditor world-wrap flickering

### DIFF
--- a/core/src/com/unciv/ui/mapeditor/MapEditorScreen.kt
+++ b/core/src/com/unciv/ui/mapeditor/MapEditorScreen.kt
@@ -134,6 +134,11 @@ class MapEditorScreen(map: TileMap? = null): BaseScreen(), RecreateOnResize {
             tileClickHandler?.invoke(it)
         }
 
+        if (tileMap.mapParameters.worldWrap) {
+            result.sizeChanged()
+            result.zoom(result.minZoom)
+        }
+
         stage.root.addActorAt(0, result)
         stage.scrollFocus = result
 

--- a/core/src/com/unciv/ui/utils/ZoomableScrollPane.kt
+++ b/core/src/com/unciv/ui/utils/ZoomableScrollPane.kt
@@ -82,7 +82,7 @@ open class ZoomableScrollPane(
         onViewportChanged()
     }
 
-    override fun sizeChanged() {
+    public override fun sizeChanged() {
         updatePadding()
         super.sizeChanged()
         updateCulling()


### PR DESCRIPTION
Fixes flickering because of too much world-wrap zoom out in MapEditor.