### PR TITLE
Fixed the display of political relations

### DIFF
--- a/core/src/com/unciv/logic/civilization/Civilization.kt
+++ b/core/src/com/unciv/logic/civilization/Civilization.kt
@@ -317,7 +317,7 @@ class Civilization : IsPartOfGameInfoSerialization {
 
     /** Returns only undefeated civs, aka the ones we care about */
     fun getKnownCivs() = diplomacy.values.map { it.otherCiv() }.filter { !it.isDefeated() }
-    fun knows(otherCivName: String) = diplomacy.containsKey(otherCivName)
+    fun knows(otherCivName: String) = (civName == otherCivName || diplomacy.containsKey(otherCivName))
     fun knows(otherCiv: Civilization) = knows(otherCiv.civName)
 
     fun getCapital() = cities.firstOrNull { it.isCapital() }

--- a/core/src/com/unciv/ui/overviewscreen/GlobalPoliticsOverviewTable.kt
+++ b/core/src/com/unciv/ui/overviewscreen/GlobalPoliticsOverviewTable.kt
@@ -168,7 +168,7 @@ class GlobalPoliticsOverviewTable (
     }
 
     private fun getCivName(otherciv: Civilization): String {
-        if (viewingPlayer.knows(otherciv) || otherciv.civName != viewingPlayer.civName) {
+        if (viewingPlayer.knows(otherciv)){
             return otherciv.civName
         }
         return "an unknown civilization"
@@ -179,7 +179,7 @@ class GlobalPoliticsOverviewTable (
 
         // wars
         for (otherCiv in civ.getKnownCivs()) {
-            if (!viewingPlayer.knows(otherCiv))
+            if (!viewingPlayer.knows(civ))
                 continue
 
             if(civ.isAtWarWith(otherCiv)) {


### PR DESCRIPTION
Closes #8182
Now the political relationship is shown 2-sided and is shown when a known civ is in a relation with an unknown civ
<details><summary>screens</summary>

![16_1](https://user-images.githubusercontent.com/1225948/217258017-df72c0f0-8f20-4033-bbb2-46eb6833b838.jpg)
![16_2](https://user-images.githubusercontent.com/1225948/217258030-c840c255-68bd-4835-82b1-14f84652be41.jpg)
</details>