### PR TITLE
Fixed the display of political relations 

### DIFF
--- a/core/src/com/unciv/logic/civilization/Civilization.kt
+++ b/core/src/com/unciv/logic/civilization/Civilization.kt
@@ -317,7 +317,7 @@ class Civilization : IsPartOfGameInfoSerialization {
 
     /** Returns only undefeated civs, aka the ones we care about */
     fun getKnownCivs() = diplomacy.values.map { it.otherCiv() }.filter { !it.isDefeated() }
-    fun knows(otherCivName: String) = diplomacy.containsKey(otherCivName)
+    fun knows(otherCivName: String) = (civName == otherCivName || diplomacy.containsKey(otherCivName))
     fun knows(otherCiv: Civilization) = knows(otherCiv.civName)
 
     fun getCapital() = cities.firstOrNull { it.isCapital() }

--- a/core/src/com/unciv/ui/overviewscreen/GlobalPoliticsOverviewTable.kt
+++ b/core/src/com/unciv/ui/overviewscreen/GlobalPoliticsOverviewTable.kt
@@ -168,7 +168,7 @@ class GlobalPoliticsOverviewTable (
     }
 
     private fun getCivName(otherciv: Civilization): String {
-        if (viewingPlayer.knows(otherciv) || otherciv.civName != viewingPlayer.civName) {
+        if (viewingPlayer.knows(otherciv)){
             return otherciv.civName
         }
         return "an unknown civilization"
@@ -179,7 +179,7 @@ class GlobalPoliticsOverviewTable (
 
         // wars
         for (otherCiv in civ.getKnownCivs()) {
-            if (!viewingPlayer.knows(otherCiv))
+            if (!viewingPlayer.knows(civ))
                 continue
 
             if(civ.isAtWarWith(otherCiv)) {

--- a/core/src/com/unciv/ui/overviewscreen/ReligionOverviewTable.kt
+++ b/core/src/com/unciv/ui/overviewscreen/ReligionOverviewTable.kt
@@ -89,7 +89,7 @@ class ReligionOverviewTab(
         val existingReligions: List<Religion> = gameInfo.civilizations.mapNotNull { it.religionManager.religion }
         for (religion in existingReligions) {
             val image = if (religion.isPantheon()) {
-                if (viewingPlayer.knows(religion.foundingCivName) || viewingPlayer.civName == religion.foundingCivName)
+                if (viewingPlayer.knows(religion.foundingCivName))
                     ImageGetter.getNationPortrait(religion.getFounder().nation, 60f)
                 else
                     ImageGetter.getRandomNationPortrait(60f)
@@ -136,7 +136,7 @@ class ReligionOverviewTab(
         statsTable.add(religion.getReligionDisplayName().toLabel()).right().row()
         statsTable.add("Founding Civ:".toLabel())
         val foundingCivName =
-            if (viewingPlayer.knows(religion.foundingCivName) || viewingPlayer.civName == religion.foundingCivName)
+            if (viewingPlayer.knows(religion.foundingCivName))
                 religion.foundingCivName
             else Constants.unknownNationName
         statsTable.add(foundingCivName.toLabel()).right().row()

--- a/core/src/com/unciv/ui/trade/DiplomacyScreen.kt
+++ b/core/src/com/unciv/ui/trade/DiplomacyScreen.kt
@@ -217,7 +217,7 @@ class DiplomacyScreen(
         var ally = otherCiv.getAllyCiv()
         if (ally != null) {
             val allyInfluence = otherCiv.getDiplomacyManager(ally).getInfluence().toInt()
-            if (!viewingCiv.knows(ally) && ally != viewingCiv.civName)
+            if (!viewingCiv.knows(ally))
                 ally = "Unknown civilization"
             diplomacyTable
                 .add("Ally: [$ally] with [$allyInfluence] Influence".toLabel())


### PR DESCRIPTION
Closes #8182
Civs did not know about themselves
Now the political relationship is shown 2-sided and is shown when a known civ is in a relation with an unknown civ
<details><summary>screens</summary>

![16_1](https://user-images.githubusercontent.com/1225948/217258017-df72c0f0-8f20-4033-bbb2-46eb6833b838.jpg)
![16_2](https://user-images.githubusercontent.com/1225948/217258030-c840c255-68bd-4835-82b1-14f84652be41.jpg)
</details>