### PR TITLE
Order indicators in TechScreen like original Civ V

### DIFF
--- a/core/src/com/unciv/ui/pickerscreens/TechButton.kt
+++ b/core/src/com/unciv/ui/pickerscreens/TechButton.kt
@@ -11,7 +11,6 @@ import com.unciv.models.ruleset.Building
 import com.unciv.models.ruleset.tile.TileImprovement
 import com.unciv.models.ruleset.tile.TileResource
 import com.unciv.models.ruleset.unique.UniqueType
-import com.unciv.ui.images.IconCircleGroup
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.utils.BaseScreen
 import com.unciv.ui.utils.extensions.addBorder
@@ -20,7 +19,6 @@ import com.unciv.ui.utils.extensions.center
 import com.unciv.ui.utils.extensions.centerY
 import com.unciv.ui.utils.extensions.darken
 import com.unciv.ui.utils.extensions.setFontSize
-import com.unciv.ui.utils.extensions.surroundWithCircle
 import com.unciv.ui.utils.extensions.toLabel
 
 class TechButton(techName:String, private val techManager: TechManager, isWorldScreen: Boolean = true) : Table(BaseScreen.skin) {
@@ -34,7 +32,6 @@ class TechButton(techName:String, private val techManager: TechManager, isWorldS
         setFontSize(14)
         setAlignment(Align.right)
     }
-    var orderIndicator: IconCircleGroup? = null
     var bg = Image(BaseScreen.skinStrings.getUiBackground("TechPickerScreen/TechButton", BaseScreen.skinStrings.roundedEdgeRectangleMidShape))
 
     init {
@@ -169,15 +166,6 @@ class TechButton(techName:String, private val techManager: TechManager, isWorldS
             .prefWidth(195f)
             .maxWidth(195f)
             .expandX().left().row()
-    }
-
-    fun addOrderIndicator(number:Int){
-        orderIndicator = number.toString().toLabel(fontSize = 18)
-            .apply { setAlignment(Align.center) }
-            .surroundWithCircle(28f, color = BaseScreen.skinStrings.skinConfig.baseColor)
-            .surroundWithCircle(30f,false)
-        orderIndicator!!.setPosition(0f, height, Align.topLeft)
-        addActor(orderIndicator)
     }
 
 }

--- a/core/src/com/unciv/ui/trade/TradeTable.kt
+++ b/core/src/com/unciv/ui/trade/TradeTable.kt
@@ -16,7 +16,7 @@ class TradeTable(private val otherCivilization: Civilization, stage: DiplomacySc
     var offerColumnsTable = OfferColumnsTable(tradeLogic, stage) { onChange() }
     // This is so that after a trade has been traded, we can switch out the offersToDisplay to start anew - this is the easiest way
     private var offerColumnsTableWrapper = Table()
-    private val offerButton = "Offer trade".toTextButton().apply{ isEnabled = false }
+    private val offerButton = "Offer trade".toTextButton().apply { isEnabled = false }
 
     private fun isTradeOffered() = otherCivilization.tradeRequests.any { it.requestingCiv == currentPlayerCiv.civName }
 


### PR DESCRIPTION
<img width="960" alt="捕获" src="https://user-images.githubusercontent.com/49801619/217304460-69016821-bf65-41f0-9354-619f800dd33b.PNG">
By the way, if you update Android Studio to lastest branch (Android Studio Electric Eel | 2022.1.1 Patch 1), com.android.tools.build:gradle:7.4.1 does very well.