### PR TITLE
Fixed diplomacy exception

### DIFF
--- a/core/src/com/unciv/logic/civilization/Civilization.kt
+++ b/core/src/com/unciv/logic/civilization/Civilization.kt
@@ -317,7 +317,7 @@ class Civilization : IsPartOfGameInfoSerialization {
 
     /** Returns only undefeated civs, aka the ones we care about */
     fun getKnownCivs() = diplomacy.values.map { it.otherCiv() }.filter { !it.isDefeated() }
-    fun knows(otherCivName: String) = (civName == otherCivName || diplomacy.containsKey(otherCivName))
+    fun knows(otherCivName: String) = diplomacy.containsKey(otherCivName)
     fun knows(otherCiv: Civilization) = knows(otherCiv.civName)
 
     fun getCapital() = cities.firstOrNull { it.isCapital() }

--- a/core/src/com/unciv/ui/overviewscreen/GlobalPoliticsOverviewTable.kt
+++ b/core/src/com/unciv/ui/overviewscreen/GlobalPoliticsOverviewTable.kt
@@ -168,7 +168,7 @@ class GlobalPoliticsOverviewTable (
     }
 
     private fun getCivName(otherciv: Civilization): String {
-        if (viewingPlayer.knows(otherciv)){
+        if (viewingPlayer.knows(otherciv) || otherciv.civName != viewingPlayer.civName) {
             return otherciv.civName
         }
         return "an unknown civilization"
@@ -179,7 +179,7 @@ class GlobalPoliticsOverviewTable (
 
         // wars
         for (otherCiv in civ.getKnownCivs()) {
-            if (!viewingPlayer.knows(civ))
+            if (!viewingPlayer.knows(otherCiv))
                 continue
 
             if(civ.isAtWarWith(otherCiv)) {

--- a/core/src/com/unciv/ui/overviewscreen/GlobalPoliticsOverviewTable.kt
+++ b/core/src/com/unciv/ui/overviewscreen/GlobalPoliticsOverviewTable.kt
@@ -168,7 +168,7 @@ class GlobalPoliticsOverviewTable (
     }
 
     private fun getCivName(otherciv: Civilization): String {
-        if (viewingPlayer.knows(otherciv) || otherciv.civName != viewingPlayer.civName) {
+        if (viewingPlayer.knows(otherciv) || otherciv.civName == viewingPlayer.civName) {
             return otherciv.civName
         }
         return "an unknown civilization"
@@ -177,11 +177,11 @@ class GlobalPoliticsOverviewTable (
     private fun getPoliticsOfCivTable(civ: Civilization): Table {
         val politicsTable = Table(skin)
 
+        if (!viewingPlayer.knows(civ) && civ.civName != viewingPlayer.civName)
+            return politicsTable
+
         // wars
         for (otherCiv in civ.getKnownCivs()) {
-            if (!viewingPlayer.knows(otherCiv))
-                continue
-
             if(civ.isAtWarWith(otherCiv)) {
                 println(getCivName(otherCiv))
                 val warText = "At war with [${getCivName(otherCiv)}]".toLabel()
@@ -193,9 +193,6 @@ class GlobalPoliticsOverviewTable (
 
         // declaration of friendships
         for (otherCiv in civ.getKnownCivs()) {
-            if (!viewingPlayer.knows(otherCiv))
-                continue
-
             if(civ.diplomacy[otherCiv.civName]?.hasFlag(DiplomacyFlags.DeclarationOfFriendship) == true) {
                 val friendText = "Friends with [${getCivName(otherCiv)}]".toLabel()
                 friendText.color = Color.GREEN
@@ -208,9 +205,6 @@ class GlobalPoliticsOverviewTable (
 
         // denounced civs
         for (otherCiv in civ.getKnownCivs()) {
-            if (!viewingPlayer.knows(otherCiv))
-                continue
-
             if(civ.diplomacy[otherCiv.civName]?.hasFlag(DiplomacyFlags.Denunciation) == true) {
                 val denouncedText = "Denounced [${getCivName(otherCiv)}]".toLabel()
                 denouncedText.color = Color.RED
@@ -223,9 +217,6 @@ class GlobalPoliticsOverviewTable (
 
         //allied CS
         for (cityState in gameInfo.getAliveCityStates()) {
-            if (!viewingPlayer.knows(cityState))
-                continue
-
             if (cityState.diplomacy[civ.civName]?.relationshipLevel() == RelationshipLevel.Ally) {
                 val alliedText = "Allied with [${getCivName(cityState)}]".toLabel()
                 alliedText.color = Color.GREEN

--- a/core/src/com/unciv/ui/overviewscreen/ReligionOverviewTable.kt
+++ b/core/src/com/unciv/ui/overviewscreen/ReligionOverviewTable.kt
@@ -89,7 +89,7 @@ class ReligionOverviewTab(
         val existingReligions: List<Religion> = gameInfo.civilizations.mapNotNull { it.religionManager.religion }
         for (religion in existingReligions) {
             val image = if (religion.isPantheon()) {
-                if (viewingPlayer.knows(religion.foundingCivName))
+                if (viewingPlayer.knows(religion.foundingCivName) || viewingPlayer.civName == religion.foundingCivName)
                     ImageGetter.getNationPortrait(religion.getFounder().nation, 60f)
                 else
                     ImageGetter.getRandomNationPortrait(60f)
@@ -136,7 +136,7 @@ class ReligionOverviewTab(
         statsTable.add(religion.getReligionDisplayName().toLabel()).right().row()
         statsTable.add("Founding Civ:".toLabel())
         val foundingCivName =
-            if (viewingPlayer.knows(religion.foundingCivName))
+            if (viewingPlayer.knows(religion.foundingCivName) || viewingPlayer.civName == religion.foundingCivName)
                 religion.foundingCivName
             else Constants.unknownNationName
         statsTable.add(foundingCivName.toLabel()).right().row()

--- a/core/src/com/unciv/ui/trade/DiplomacyScreen.kt
+++ b/core/src/com/unciv/ui/trade/DiplomacyScreen.kt
@@ -217,7 +217,7 @@ class DiplomacyScreen(
         var ally = otherCiv.getAllyCiv()
         if (ally != null) {
             val allyInfluence = otherCiv.getDiplomacyManager(ally).getInfluence().toInt()
-            if (!viewingCiv.knows(ally))
+            if (!viewingCiv.knows(ally) && ally != viewingCiv.civName)
                 ally = "Unknown civilization"
             diplomacyTable
                 .add("Ally: [$ally] with [$allyInfluence] Influence".toLabel())


### PR DESCRIPTION
In continuation #8613
I didn't fully understand the purpose of the knows() function, it basically acted as a safeguard before the getDiplomacyManager() call, which returns an item from the list or throws an exception. And civilizations do not have themselves in diplomacy list.
So this caused bugs #8620 and #8621
Reverted commits, changed the check only on the politics screen so we still have 2-sided relations view, but without nullException