### PR TITLE
Improve UX

### DIFF
--- a/core/src/com/unciv/ui/cityscreen/CityConstructionsTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityConstructionsTable.kt
@@ -370,7 +370,7 @@ class CityConstructionsTable(private val cityScreen: CityScreen) {
             addToQueueButton.onClick(UncivSound.Silent) {
                 // Since the pickConstructionButton.onClick adds the construction if it's selected,
                 // this effectively adds the construction even if it's unselected
-                addConstructionToQueue(construction, cityScreen.city.cityConstructions)
+                cityScreen.selectConstruction(construction)
             }
             pickConstructionButton.add(addToQueueButton)
         }
@@ -383,7 +383,11 @@ class CityConstructionsTable(private val cityScreen: CityScreen) {
                     .colspan(pickConstructionButton.columns).fillX().left().padTop(2f)
         }
         pickConstructionButton.onClick {
-            cityScreen.selectConstruction(construction)
+            if (cityScreen.selectedConstruction == construction) {
+                addConstructionToQueue(construction, cityScreen.city.cityConstructions)
+            } else {
+                cityScreen.selectConstruction(construction)
+            }
             selectedQueueEntry = -1
             cityScreen.update()
         }

--- a/core/src/com/unciv/ui/cityscreen/CityConstructionsTable.kt
+++ b/core/src/com/unciv/ui/cityscreen/CityConstructionsTable.kt
@@ -322,14 +322,8 @@ class CityConstructionsTable(private val cityScreen: CityScreen) {
 
         table.touchable = Touchable.enabled
         table.onClick {
-            if (selectedQueueEntry == constructionQueueIndex) {
-                city.cityConstructions.removeFromQueue(constructionQueueIndex, false)
-                selectedQueueEntry = -1
-                cityScreen.clearSelection()
-            } else {
-                cityScreen.selectConstruction(constructionName)
-                selectedQueueEntry = constructionQueueIndex
-            }
+            cityScreen.selectConstruction(constructionName)
+            selectedQueueEntry = constructionQueueIndex
             cityScreen.update()
         }
         return table
@@ -376,7 +370,7 @@ class CityConstructionsTable(private val cityScreen: CityScreen) {
             addToQueueButton.onClick(UncivSound.Silent) {
                 // Since the pickConstructionButton.onClick adds the construction if it's selected,
                 // this effectively adds the construction even if it's unselected
-                cityScreen.selectConstruction(construction)
+                addConstructionToQueue(construction, cityScreen.city.cityConstructions)
             }
             pickConstructionButton.add(addToQueueButton)
         }
@@ -389,11 +383,7 @@ class CityConstructionsTable(private val cityScreen: CityScreen) {
                     .colspan(pickConstructionButton.columns).fillX().left().padTop(2f)
         }
         pickConstructionButton.onClick {
-            if (cityScreen.selectedConstruction == construction) {
-                addConstructionToQueue(construction, cityScreen.city.cityConstructions)
-            } else {
-                cityScreen.selectConstruction(construction)
-            }
+            cityScreen.selectConstruction(construction)
             selectedQueueEntry = -1
             cityScreen.update()
         }

--- a/core/src/com/unciv/ui/pickerscreens/GreatPersonPickerScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/GreatPersonPickerScreen.kt
@@ -8,6 +8,7 @@ import com.unciv.models.translations.tr
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.utils.extensions.isEnabled
 import com.unciv.ui.utils.extensions.onClick
+import com.unciv.ui.utils.extensions.onDoubleClick
 
 class GreatPersonPickerScreen(val civInfo:Civilization) : PickerScreen() {
     private var theChosenOne: BaseUnit? = null
@@ -23,24 +24,32 @@ class GreatPersonPickerScreen(val civInfo:Civilization) : PickerScreen() {
             val button = PickerPane.getPickerOptionButton(ImageGetter.getUnitIcon(unit.name), unit.name)
             button.pack()
             button.isEnabled = !useMayaLongCount || unit.name in civInfo.greatPeople.longCountGPPool
-            if (button.isEnabled) button.onClick {
-                theChosenOne = unit
-                pick("Get [${unit.name}]".tr())
-                descriptionLabel.setText(unit.getShortDescription())
+            if (button.isEnabled) {
+                button.onClick {
+                    theChosenOne = unit
+                    pick("Get [${unit.name}]".tr())
+                    descriptionLabel.setText(unit.getShortDescription())
+                }
+
+                button.onDoubleClick(UncivSound.Choir) { confirmAction(useMayaLongCount) }
             }
             topTable.add(button).pad(10f).row()
         }
 
         rightSideButton.onClick(UncivSound.Choir) {
-            civInfo.units.addUnit(theChosenOne!!.name, civInfo.getCapital())
-            civInfo.greatPeople.freeGreatPeople--
-            if (useMayaLongCount) {
-                civInfo.greatPeople.mayaLimitedFreeGP--
-                civInfo.greatPeople.longCountGPPool.remove(theChosenOne!!.name)
-            }
-            UncivGame.Current.popScreen()
+            confirmAction(useMayaLongCount)
         }
 
+    }
+
+    private fun confirmAction(useMayaLongCount: Boolean){
+        civInfo.units.addUnit(theChosenOne!!.name, civInfo.getCapital())
+        civInfo.greatPeople.freeGreatPeople--
+        if (useMayaLongCount) {
+            civInfo.greatPeople.mayaLimitedFreeGP--
+            civInfo.greatPeople.longCountGPPool.remove(theChosenOne!!.name)
+        }
+        UncivGame.Current.popScreen()
     }
 }
 

--- a/core/src/com/unciv/ui/pickerscreens/ImprovementPickerScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/ImprovementPickerScreen.kt
@@ -18,6 +18,7 @@ import com.unciv.ui.utils.UncivTooltip.Companion.addTooltip
 import com.unciv.ui.utils.extensions.disable
 import com.unciv.ui.utils.extensions.keyShortcuts
 import com.unciv.ui.utils.extensions.onClick
+import com.unciv.ui.utils.extensions.onDoubleClick
 import com.unciv.ui.utils.extensions.toLabel
 import kotlin.math.roundToInt
 
@@ -184,6 +185,8 @@ class ImprovementPickerScreen(
                 pick(improvement.name.tr())
                 descriptionLabel.setText(improvement.getDescription(ruleSet))
             }
+
+            improvementButton.onDoubleClick { accept(improvement) }
 
             if (improvement.name == tile.improvementInProgress) improvementButton.color = Color.GREEN
             if (proposedSolutions.isNotEmpty() || tileMarkedForCreatesOneImprovement) {

--- a/core/src/com/unciv/ui/pickerscreens/PromotionPickerScreen.kt
+++ b/core/src/com/unciv/ui/pickerscreens/PromotionPickerScreen.kt
@@ -21,6 +21,7 @@ import com.unciv.ui.utils.extensions.colorFromRGB
 import com.unciv.ui.utils.extensions.darken
 import com.unciv.ui.utils.extensions.isEnabled
 import com.unciv.ui.utils.extensions.onClick
+import com.unciv.ui.utils.extensions.onDoubleClick
 import com.unciv.ui.utils.extensions.setFontColor
 import com.unciv.ui.utils.extensions.toLabel
 import com.unciv.ui.utils.extensions.toTextButton
@@ -367,6 +368,11 @@ class PromotionPickerScreen(val unit: MapUnit) : PickerScreen(), RecreateOnResiz
 
             addConnectingLines()
         }
+
+        if (isPickable)
+            button.onDoubleClick(UncivSound.Promote) {
+                acceptPromotion(node)
+            }
 
         return button
     }

--- a/core/src/com/unciv/ui/saves/LoadGameScreen.kt
+++ b/core/src/com/unciv/ui/saves/LoadGameScreen.kt
@@ -23,6 +23,7 @@ import com.unciv.ui.utils.extensions.isEnabled
 import com.unciv.ui.utils.extensions.keyShortcuts
 import com.unciv.ui.utils.extensions.onActivation
 import com.unciv.ui.utils.extensions.onClick
+import com.unciv.ui.utils.extensions.onDoubleClick
 import com.unciv.ui.utils.extensions.toLabel
 import com.unciv.ui.utils.extensions.toTextButton
 import com.unciv.utils.Log
@@ -98,6 +99,10 @@ class LoadGameScreen : LoadOrSaveScreen() {
         rightSideButton.isVisible = true
         rightSideButton.setText("Load [$selectedSave]".tr())
         rightSideButton.enable()
+    }
+
+    override fun doubleClickAction() {
+        onLoadGame()
     }
 
     private fun Table.initRightSideTable() {

--- a/core/src/com/unciv/ui/saves/LoadOrSaveScreen.kt
+++ b/core/src/com/unciv/ui/saves/LoadOrSaveScreen.kt
@@ -18,6 +18,7 @@ import com.unciv.ui.utils.extensions.enable
 import com.unciv.ui.utils.extensions.keyShortcuts
 import com.unciv.ui.utils.extensions.onActivation
 import com.unciv.ui.utils.extensions.onChange
+import com.unciv.ui.utils.extensions.onDoubleClick
 import com.unciv.ui.utils.extensions.pad
 import com.unciv.ui.utils.extensions.toLabel
 import com.unciv.ui.utils.extensions.toTextButton
@@ -31,6 +32,7 @@ abstract class LoadOrSaveScreen(
 ) : PickerScreen(disableScroll = true) {
 
     abstract fun onExistingSaveSelected(saveGameFile: FileHandle)
+    abstract fun doubleClickAction()
 
     protected var selectedSave = ""
         private set
@@ -42,6 +44,7 @@ abstract class LoadOrSaveScreen(
 
     init {
         savesScrollPane.onChange(::selectExistingSave)
+        savesScrollPane.onDoubleClick { doubleClickAction() }
 
         rightSideTable.defaults().pad(5f, 10f)
 

--- a/core/src/com/unciv/ui/saves/SaveGameScreen.kt
+++ b/core/src/com/unciv/ui/saves/SaveGameScreen.kt
@@ -40,8 +40,6 @@ class SaveGameScreen(val gameInfo: GameInfo) : LoadOrSaveScreen("Current saves")
         }
         rightSideButton.keyShortcuts.add(KeyCharAndCode.RETURN)
         rightSideButton.enable()
-
-        stage.keyboardFocus = gameNameTextField
     }
 
     private fun Table.initRightSideTable() {
@@ -67,7 +65,6 @@ class SaveGameScreen(val gameInfo: GameInfo) : LoadOrSaveScreen("Current saves")
 
         add("Saved game name".toLabel()).row()
         add(gameNameTextField).width(300f).row()
-        stage.keyboardFocus = gameNameTextField
     }
 
     private fun copyToClipboardHandler() {

--- a/core/src/com/unciv/ui/saves/SaveGameScreen.kt
+++ b/core/src/com/unciv/ui/saves/SaveGameScreen.kt
@@ -35,11 +35,7 @@ class SaveGameScreen(val gameInfo: GameInfo) : LoadOrSaveScreen("Current saves")
         rightSideButton.setText("Save game".tr())
         rightSideButton.onActivation {
             if (game.files.getSave(gameNameTextField.text).exists())
-                ConfirmPopup(
-                    this,
-                    "Overwrite existing file?",
-                    "Overwrite",
-                ) { saveGame() }.open()
+                doubleClickAction()
             else saveGame()
         }
         rightSideButton.keyShortcuts.add(KeyCharAndCode.RETURN)
@@ -126,6 +122,14 @@ class SaveGameScreen(val gameInfo: GameInfo) : LoadOrSaveScreen("Current saves")
 
     override fun onExistingSaveSelected(saveGameFile: FileHandle) {
         gameNameTextField.text = saveGameFile.name()
+    }
+
+    override fun doubleClickAction() {
+        ConfirmPopup(
+            this,
+            "Overwrite existing file?",
+            "Overwrite",
+        ) { saveGame() }.open()
     }
 
 }


### PR DESCRIPTION
Added double click actions to:
Great person picker screen;
Improvement picker screen;
Policy picker screen;
Promotion picker screen;
Load/Save game screen.

Removed adding to/removing from construction queue on second click.
On phones it's quite annoying, and it's very easy to miss a button. Closes #8327

Removed default keyboard focus on load/save screen.
Because of keyboard focus on phones, the keyboard appears on the save screen and takes up half the space. In most cases, the standard name is enough or you need to copy the game to the clipboard.
<details><summary>Keyboard screenshot</summary>

![17_1](https://user-images.githubusercontent.com/1225948/217813438-2fab5a36-d6a1-4e38-853c-a5503513b514.jpeg)
</details>
