### PR TITLE
Fixed missing unimproved resources in the overview table

### DIFF
--- a/core/src/com/unciv/ui/overviewscreen/ResourcesOverviewTable.kt
+++ b/core/src/com/unciv/ui/overviewscreen/ResourcesOverviewTable.kt
@@ -223,12 +223,13 @@ class ResourcesOverviewTab(
     private fun getExtraDrilldown(): ResourceSupplyList {
         val newResourceSupplyList = ResourceSupplyList()
         for (city in viewingPlayer.cities) {
-            if (city.demandedResource.isEmpty()) continue
-            val wltkResource = gameInfo.ruleset.tileResources[city.demandedResource] ?: continue
-            if (city.isWeLoveTheKingDayActive()) {
-                newResourceSupplyList.add(wltkResource, ExtraInfoOrigin.CelebratingWLKT.name)
-            } else {
-                newResourceSupplyList.add(wltkResource, ExtraInfoOrigin.DemandingWLTK.name)
+            if (!city.demandedResource.isEmpty()) {
+                val wltkResource = gameInfo.ruleset.tileResources[city.demandedResource]!!
+                if (city.isWeLoveTheKingDayActive()) {
+                    newResourceSupplyList.add(wltkResource, ExtraInfoOrigin.CelebratingWLKT.name)
+                } else {
+                    newResourceSupplyList.add(wltkResource, ExtraInfoOrigin.DemandingWLTK.name)
+                }
             }
             for (tile in city.getTiles()) {
                 if (tile.isCityCenter()) continue


### PR DESCRIPTION
Closes #8502
Unimproved resource check was skipped for whole city tiles if it didn't require a resource for WLTK