### PR TITLE
Improvement to MusicController

### DIFF
--- a/core/src/com/unciv/ui/audio/MusicController.kt
+++ b/core/src/com/unciv/ui/audio/MusicController.kt
@@ -213,8 +213,8 @@ class MusicController {
 					val worldScreen = UncivGame.Current.getWorldScreenIfActive()
                     if (worldScreen == null ||
                             !chooseTrack(
-                                MusicMood.peaceOrWar(!worldScreen.viewingCiv.isAtWar()), 
-                                MusicMood.Ambient, 
+                                prefix = MusicMood.peaceOrWar(!worldScreen.viewingCiv.isAtWar()), 
+                                suffix = MusicMood.Ambient, 
                                 EnumSet.of(MusicTrackChooserFlags.NoMatchingPrefix, MusicTrackChooserFlags.SuffixMustMatch)
                             )
                     ) {

--- a/core/src/com/unciv/ui/audio/MusicController.kt
+++ b/core/src/com/unciv/ui/audio/MusicController.kt
@@ -209,7 +209,17 @@ class MusicController {
             ControllerState.Silence ->
                 if (++ticksOfSilence > silenceLengthInTicks) {
                     ticksOfSilence = 0
-                    chooseTrack()
+                    
+					val worldScreen = UncivGame.Current.getWorldScreenIfActive()
+                    if (worldScreen == null ||
+                            !chooseTrack(
+                                MusicMood.peaceOrWar(!worldScreen.viewingCiv.isAtWar()), 
+                                MusicMood.Ambient, 
+                                EnumSet.of(MusicTrackChooserFlags.PrefixMustNotMatch, MusicTrackChooserFlags.SuffixMustMatch)
+                            )
+                    ) {
+                        chooseTrack()
+                    }
                 }
             ControllerState.Shutdown -> {
                 // Fade out first, when all queue entries are idle set up for real shutdown
@@ -284,7 +294,8 @@ class MusicController {
         // get a path list (as strings) of music folder candidates - existence unchecked
         return getAllMusicFiles()
             .filter {
-                (!flags.contains(MusicTrackChooserFlags.PrefixMustMatch) || it.nameWithoutExtension().startsWith(prefix))
+                (!flags.contains(MusicTrackChooserFlags.PrefixMustNotMatch) || !it.nameWithoutExtension().startsWith(prefix))
+                        && (!flags.contains(MusicTrackChooserFlags.PrefixMustMatch) || it.nameWithoutExtension().startsWith(prefix))
                         && (!flags.contains(MusicTrackChooserFlags.SuffixMustMatch) || it.nameWithoutExtension().endsWith(suffix))
             }
             // randomize

--- a/core/src/com/unciv/ui/audio/MusicController.kt
+++ b/core/src/com/unciv/ui/audio/MusicController.kt
@@ -215,7 +215,7 @@ class MusicController {
                             !chooseTrack(
                                 MusicMood.peaceOrWar(!worldScreen.viewingCiv.isAtWar()), 
                                 MusicMood.Ambient, 
-                                EnumSet.of(MusicTrackChooserFlags.PrefixMustNotMatch, MusicTrackChooserFlags.SuffixMustMatch)
+                                EnumSet.of(MusicTrackChooserFlags.NoMatchingPrefix, MusicTrackChooserFlags.SuffixMustMatch)
                             )
                     ) {
                         chooseTrack()
@@ -294,7 +294,7 @@ class MusicController {
         // get a path list (as strings) of music folder candidates - existence unchecked
         return getAllMusicFiles()
             .filter {
-                (!flags.contains(MusicTrackChooserFlags.PrefixMustNotMatch) || !it.nameWithoutExtension().startsWith(prefix))
+                (!flags.contains(MusicTrackChooserFlags.NoMatchingPrefix) || !it.nameWithoutExtension().startsWith(prefix))
                         && (!flags.contains(MusicTrackChooserFlags.PrefixMustMatch) || it.nameWithoutExtension().startsWith(prefix))
                         && (!flags.contains(MusicTrackChooserFlags.SuffixMustMatch) || it.nameWithoutExtension().endsWith(suffix))
             }

--- a/core/src/com/unciv/ui/audio/MusicTrackChooserFlags.kt
+++ b/core/src/com/unciv/ui/audio/MusicTrackChooserFlags.kt
@@ -8,7 +8,7 @@ enum class MusicTrackChooserFlags {
     /** Makes suffix parameter a mandatory match */
     SuffixMustMatch,
     /** Signalizes that prefix parameter must not match */
-    PrefixMustNotMatch,
+    NoMatchingPrefix,
     /** Extends fade duration by factor 5 */
     SlowFade,
     /** Lets music controller shut down after track ends instead of choosing a random next track */

--- a/core/src/com/unciv/ui/audio/MusicTrackChooserFlags.kt
+++ b/core/src/com/unciv/ui/audio/MusicTrackChooserFlags.kt
@@ -7,6 +7,8 @@ enum class MusicTrackChooserFlags {
     PrefixMustMatch,
     /** Makes suffix parameter a mandatory match */
     SuffixMustMatch,
+    /** Signalizes that prefix parameter must not match */
+    PrefixMustNotMatch,
     /** Extends fade duration by factor 5 */
     SlowFade,
     /** Lets music controller shut down after track ends instead of choosing a random next track */

--- a/docs/Modders/Images-and-Audio.md
+++ b/docs/Modders/Images-and-Audio.md
@@ -85,7 +85,7 @@ The current list of triggers is as follows:
 
 | Description | Prefix | [^M] | Suffix | [^X] | Flags |
 | ----------- |:------ |:----:| ------:|:----:|:-----:|
-| Automatic next-track[^0] | | | Ambient | | |
+| Automatic next-track[^0] | (Optional) Peace or War[^7] | | Ambient | [^X] | |
 | Launch game[^1] | | | Menu | | |
 | Every 10th turn | (player civ name) | [^M] | Peace or War[^2] | | [^F] |
 | New game: Select a mod | (mod name) | [^M] | Theme | | [^S] |
@@ -109,10 +109,11 @@ Legend:
 -   [^S]: Stop after playback. No automatic next choice.
 -   [^F]: Slow fadeout of replaced track.
 -   [^D]: Always plays the default file.
--   [^0]: Whenever a track finishes and the configured silence has elapsed, an 'Ambient' track without any context is chosen. Also triggered by 'resume' (e.g. switching to another app and back on Android)
+-   [^0]: Whenever a track finishes and the configured silence has elapsed, an 'Ambient' track is chosen. Also triggered by 'resume' (e.g. switching to another app and back on Android)
 -   [^1]: First opening of the Main Menu (or the initial language picker).
 -   [^2]: Whether the active player is at war with anybody.
 -   [^3]: According to your relation to the picked player.
 -   [^4]: Excluding City States.
 -   [^5]: Both in the alert when another player declares War on you and declaring War yourself in Diplomacy screen.
 -   [^6]: Yes these flags are not optimal.
+-   [^7]: Prefix is optional. Tracks with any of these prefixes will play based on whether the player is at war with anybody. Tracks with no prefix will play independent of that.

--- a/docs/Modders/Images-and-Audio.md
+++ b/docs/Modders/Images-and-Audio.md
@@ -116,4 +116,4 @@ Legend:
 -   [^4]: Excluding City States.
 -   [^5]: Both in the alert when another player declares War on you and declaring War yourself in Diplomacy screen.
 -   [^6]: Yes these flags are not optimal.
--   [^7]: Prefix is optional. Tracks with any of these prefixes will play based on whether the player is at war with anybody. Tracks with no prefix will play independent of that.
+-   [^7]: This prefix is optional. Tracks with and without prefix have the same chance to play, the only difference is that tracks with prefix will play based on whether the player is at war with anybody, while tracks with no prefix are unaffected by that.


### PR DESCRIPTION
Currently there are only one music trigger (Every 10th turn) that plays music based on whether the player is at war with anybody, but it requires you to specify the civ name in prefix. This pr allows optional 'Peace' or 'War' prefix for 'Automatic next-track' music trigger. When player is at war it will choose from tracks without 'Peace' prefix and vice versa, allowing modders to add ambient music that should play only during the war/peace, as well as music that can play independent of that. Existing music mods should work as usual.