### PR TITLE
Out-of-move units are half-opaque relative to base setting

### DIFF
--- a/core/src/com/unciv/ui/tilegroups/layers/TileLayerUnitFlag.kt
+++ b/core/src/com/unciv/ui/tilegroups/layers/TileLayerUnitFlag.kt
@@ -69,8 +69,8 @@ class TileLayerUnitFlag(tileGroup: TileGroup, size: Float) : TileLayer(tileGroup
                 newIcon.actionGroup?.color?.a = 0.5f
 
             // Fade out flag for own out-of-moves units
-            if (unit.civ == viewingCiv && unit.currentMovement == 0f && UncivGame.Current.settings.unitIconOpacity == 1f)
-                newIcon.color.a = 0.5f
+            if (unit.civ == viewingCiv && unit.currentMovement == 0f)
+                newIcon.color.a = 0.5f * UncivGame.Current.settings.unitIconOpacity
 
         }
 


### PR DESCRIPTION
See #8669