### PR TITLE
Removed zoom limit for world-wrap maps

### DIFF
--- a/core/src/com/unciv/ui/components/ZoomableScrollPane.kt
+++ b/core/src/com/unciv/ui/components/ZoomableScrollPane.kt
@@ -45,7 +45,7 @@ open class ZoomableScrollPane(
         this.addListener(zoomListener)
     }
 
-    fun reloadMaxZoom() {
+    open fun reloadMaxZoom() {
 
         maxZoom = UncivGame.Current.settings.maxWorldZoomOut
         minZoom = 1f / maxZoom

--- a/core/src/com/unciv/ui/components/ZoomableScrollPane.kt
+++ b/core/src/com/unciv/ui/components/ZoomableScrollPane.kt
@@ -90,17 +90,6 @@ open class ZoomableScrollPane(
         updatePadding()
         super.sizeChanged()
         updateCulling()
-
-        if (continuousScrollingX) {
-            // For world-wrap we do not allow viewport to become bigger than the map size,
-            // because we don't want to render the same tiles multiple times (they will be
-            // flickering because of movement).
-            // Hence we limit minimal possible zoom to content width + some extra offset.
-            val content = actor
-            if (content != null)
-                minZoom = max((width + 80f) * scaleX / content.width, 1f / UncivGame.Current.settings.maxWorldZoomOut)// add some extra padding offset
-        }
-
     }
 
     private fun updatePadding() {

--- a/core/src/com/unciv/ui/components/tilegroups/TileGroupMap.kt
+++ b/core/src/com/unciv/ui/components/tilegroups/TileGroupMap.kt
@@ -163,9 +163,14 @@ class TileGroupMap<T: TileGroup>(
 
         if (worldWrap) {
 
+            // Prevent flickering when zoomed out so you can see entire map
+            val visibleMapWidth: Float
+            if(mapHolder.width > width) visibleMapWidth = width - groupSize * 1.5f
+            else visibleMapWidth = mapHolder.width
+
             // Where is viewport's boundaries
-            val rightSide = mapHolder.scrollX + mapHolder.width/2f
-            val leftSide = mapHolder.scrollX - mapHolder.width/2f
+            val rightSide = mapHolder.scrollX + visibleMapWidth/2f
+            val leftSide = mapHolder.scrollX - visibleMapWidth/2f
 
             // Have we looked beyond map?
             val diffRight = rightSide - topX

--- a/core/src/com/unciv/ui/popups/options/AdvancedTab.kt
+++ b/core/src/com/unciv/ui/popups/options/AdvancedTab.kt
@@ -169,6 +169,7 @@ private fun addMaxZoomSlider(table: Table, settings: GameSettings) {
     ) {
         settings.maxWorldZoomOut = it
         settings.save()
+        UncivGame.Current.worldScreen?.mapHolder?.reloadMaxZoom()
     }
     table.add(maxZoomSlider).pad(5f).row()
 }

--- a/core/src/com/unciv/ui/screens/worldscreen/WorldMapHolder.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/WorldMapHolder.kt
@@ -71,7 +71,6 @@ class WorldMapHolder(
     init {
         if (Gdx.app.type == Application.ApplicationType.Desktop) this.setFlingTime(0f)
         continuousScrollingX = tileMap.mapParameters.worldWrap
-        reloadMaxZoom()
         setupZoomPanListeners()
     }
 

--- a/core/src/com/unciv/ui/screens/worldscreen/WorldMapHolder.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/WorldMapHolder.kt
@@ -53,6 +53,7 @@ import com.unciv.ui.screens.basescreen.UncivStage
 import com.unciv.utils.Log
 import com.unciv.utils.concurrency.Concurrency
 import com.unciv.utils.concurrency.launchOnGLThread
+import java.lang.Float.max
 
 
 class WorldMapHolder(
@@ -751,6 +752,28 @@ class WorldMapHolder(
             overlay.remove()
         unitActionOverlays.clear()
     }
+
+    override fun reloadMaxZoom()
+    {
+        if (continuousScrollingX) {
+            // For world-wrap we do not allow viewport to become bigger than the map size,
+            // because we don't want to render the same tiles multiple times (they will be
+            // flickering because of movement).
+            // Hence we limit minimal possible zoom to content width + some extra offset.
+
+            val pad = width / tileMap.mapParameters.mapSize.radius * 0.7f
+            minZoom = max(
+                (width + pad) * scaleX / maxX,
+                1f / UncivGame.Current.settings.maxWorldZoomOut
+            )// add some extra padding offset
+
+            // If the window becomes too wide and minZoom > maxZoom, we cannot zoom
+            maxZoom = max(2f * minZoom, UncivGame.Current.settings.maxWorldZoomOut)
+        }
+        else
+            super.reloadMaxZoom()
+    }
+
 
     // For debugging purposes
     override fun draw(batch: Batch?, parentAlpha: Float) = super.draw(batch, parentAlpha)

--- a/core/src/com/unciv/ui/screens/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/WorldScreen.kt
@@ -137,6 +137,7 @@ class WorldScreen(
 
         // This is the most memory-intensive operation we have currently, most OutOfMemory errors will occur here
         mapHolder.addTiles()
+        mapHolder.reloadMaxZoom()
 
         // resume music (in case choices from the menu lead to instantiation of a new WorldScreen)
         UncivGame.Current.musicController.resume()
@@ -242,7 +243,6 @@ class WorldScreen(
         }
         globalShortcuts.add(KeyCharAndCode.ctrl('O')) { // Game Options
             this.openOptionsPopup(onClose = {
-                mapHolder.reloadMaxZoom()
                 nextTurnButton.update(this)
             })
         }


### PR DESCRIPTION
You can now zoom out on world-wrap maps without flickering and with working continuous scrolling
![20_1](https://user-images.githubusercontent.com/1225948/219490420-b1af1cd8-8322-4d8c-ba06-dcff90058243.jpg)
