### PR TITLE
Fixed unit upgrade check

### DIFF
--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -138,7 +138,6 @@ class BaseUnit : RulesetObject(), INonPerpetualConstruction {
     }
 
     fun getRejectionReasons(civ: Civilization, city:City?=null): Sequence<RejectionReason> {
-        //var result = sequence<RejectionReason> {}
         val result = mutableListOf<RejectionReason>()
         if (requiredTech != null && !civ.tech.isResearched(requiredTech!!))
             result.add(RejectionReasonType.RequiresTech.toInstance("$requiredTech not researched"))


### PR DESCRIPTION
Fixed bug from [discord](https://discord.com/channels/586194543280390151/588357826758574106/1075505021745111050)
For some reaseon, in the previous form of the _getRejectionReasons_ function, the _civ_ object inside the _sequence_ curly brackets had the number of resources that was before calling unit.civ.units.removeUnit(unit), resulting in insufficient resources.
Now it works correctly:
![21_1](https://user-images.githubusercontent.com/1225948/219520885-d37653ab-81f7-4243-b102-02742a47ea0b.jpg)
