### PR TITLE
Better layout for trade screen in portrait mode

### DIFF
--- a/core/src/com/unciv/ui/trade/DiplomacyScreen.kt
+++ b/core/src/com/unciv/ui/trade/DiplomacyScreen.kt
@@ -68,7 +68,7 @@ class DiplomacyScreen(
     }
 
     private val leftSideTable = Table().apply { defaults().pad(nationIconPad) }
-    private val leftSideScroll = ScrollPane(leftSideTable)
+    val leftSideScroll = ScrollPane(leftSideTable)
     private val rightSideTable = Table()
     private val closeButton = Constants.close.toTextButton()
 

--- a/core/src/com/unciv/ui/trade/OfferColumnsTable.kt
+++ b/core/src/com/unciv/ui/trade/OfferColumnsTable.kt
@@ -54,20 +54,41 @@ class OfferColumnsTable(private val tradeLogic: TradeLogic, val screen: Diplomac
 
     init {
         defaults().pad(5f)
-        val columnWidth = screen.stage.width / 3
 
-        add("Our items".tr())
-        add("[${tradeLogic.otherCivilization.civName}]'s items".tr()).row()
+        val isPortraitMode = screen.isNarrowerThan4to3()
 
-        add(ourAvailableOffersTable).prefSize(columnWidth, screen.stage.height / 2)
-        add(theirAvailableOffersTable).prefSize(columnWidth, screen.stage.height / 2).row()
+        val columnWidth = (screen.stage.width - screen.leftSideScroll.width) / 2
 
-        addSeparator().height(2f)
+        if (!isPortraitMode) {
+            add("Our items".tr())
+            add("[${tradeLogic.otherCivilization.civName}]'s items".tr()).row()
 
-        add("Our trade offer".tr())
-        add("[${tradeLogic.otherCivilization.civName}]'s trade offer".tr()).row()
-        add(ourOffersTable).size(columnWidth, screen.stage.height / 3)
-        add(theirOffersTable).size(columnWidth, screen.stage.height / 3)
+            add(ourAvailableOffersTable).prefSize(columnWidth, screen.stage.height / 2)
+            add(theirAvailableOffersTable).prefSize(columnWidth, screen.stage.height / 2).row()
+
+            addSeparator().height(2f)
+
+            add("Our trade offer".tr())
+            add("[${tradeLogic.otherCivilization.civName}]'s trade offer".tr()).row()
+            add(ourOffersTable).size(columnWidth, screen.stage.height / 3)
+            add(theirOffersTable).size(columnWidth, screen.stage.height / 3)
+        }
+        else {
+            add("Our items".tr()).colspan(2).row()
+            add(ourAvailableOffersTable).height(screen.stage.height / 4f).colspan(2).row()
+
+            addSeparator().height(2f)
+
+            add("[${tradeLogic.otherCivilization.civName}]'s items".tr()).colspan(2).row()
+            add(theirAvailableOffersTable).height(screen.stage.height / 4f).colspan(2).row()
+
+            addSeparator().height(5f)
+
+            add("Our trade offer".tr())
+            add("[${tradeLogic.otherCivilization.civName}]'s trade offer".tr()).row()
+            add(ourOffersTable).height(screen.stage.height / 4f).width(columnWidth)
+            add(theirOffersTable).height(screen.stage.height / 4f).width(columnWidth)
+        }
         pack()
         update()
     }


### PR DESCRIPTION
New: 
![image](https://user-images.githubusercontent.com/8366208/219900369-47764d65-44eb-41f5-90a1-913f685d075a.png)

Old:
![image](https://user-images.githubusercontent.com/8366208/219900418-f27e778b-9428-474f-8718-ba45ffb2441b.png)

The old one is even worse for screen with very high length/width ratios

This took a lot of tinkering to get to look good