### PR TITLE
Slider tooltip permanent by default

### DIFF
--- a/core/src/com/unciv/ui/components/UncivSlider.kt
+++ b/core/src/com/unciv/ui/components/UncivSlider.kt
@@ -54,6 +54,7 @@ class UncivSlider (
     plusMinus: Boolean = true,
     initial: Float,
     sound: UncivSound = UncivSound.Slider,
+    private var permanentTip: Boolean = true,
     private val getTipText: ((Float) -> String)? = null,
     onChange: ((Float) -> Unit)? = null
 ): Table(BaseScreen.skin) {
@@ -76,7 +77,11 @@ class UncivSlider (
     private val plusButton: IconCircleGroup?
     private val tipLabel = "".toLabel(Color.LIGHT_GRAY)
     private val tipContainer: Container<Label> = Container(tipLabel)
-    private val tipHideTask: Timer.Task
+    private val tipHideTask = object : Timer.Task() {
+        override fun run() {
+            hideTip()
+        }
+    }
 
     // copies of maliciously protected Slider members
     private var snapToValues: FloatArray? = null
@@ -126,20 +131,17 @@ class UncivSlider (
     // java format string for the value tip, set by changing stepSize
     private var tipFormat = "%.1f"
 
-    /** Prevents hiding the value tooltip over the slider knob */
-    var permanentTip = false
-
     // Detect changes in isDragging
     private var hasFocus = false
 
     init {
         tipLabel.setOrigin(Align.center)
         tipContainer.touchable = Touchable.disabled
-        tipHideTask = object : Timer.Task() {
-            override fun run() {
-                hideTip()
-            }
-        }
+
+        /** Prevents hiding the value tooltip over the slider knob */
+        if(permanentTip)
+            tipHideTask.cancel()
+
 
         stepChanged()   // Initialize tip formatting
 

--- a/core/src/com/unciv/ui/screens/mapeditorscreen/tabs/MapEditorEditTab.kt
+++ b/core/src/com/unciv/ui/screens/mapeditorscreen/tabs/MapEditorEditTab.kt
@@ -90,7 +90,7 @@ class MapEditorEditTab(
             defaults().pad(10f).left()
             add(brushLabel)
             brushCell = add().padLeft(0f)
-            brushSlider = UncivSlider(1f,6f,1f, initial = 1f, getTipText = { getBrushTip(it).tr() }) {
+            brushSlider = UncivSlider(1f,6f,1f, initial = 1f, getTipText = { getBrushTip(it).tr() }, permanentTip = false) {
                 brushSize = if (it > 5f) -1 else it.toInt()
                 brushLabel.setText("Brush ([${getBrushTip(it, true)}]):".tr())
             }

--- a/core/src/com/unciv/ui/screens/newgamescreen/GameOptionsTable.kt
+++ b/core/src/com/unciv/ui/screens/newgamescreen/GameOptionsTable.kt
@@ -229,7 +229,6 @@ class GameOptionsTable(
         val slider = UncivSlider(2f, playableAvailable.toFloat(), 1f, initial = gameParameters.minNumberOfPlayers.toFloat()) {
             gameParameters.minNumberOfPlayers = it.toInt()
         }
-        slider.permanentTip = true
         slider.isDisabled = locked
         add(slider).padTop(10f).row()
     }
@@ -242,7 +241,6 @@ class GameOptionsTable(
         val slider = UncivSlider(2f, playableAvailable.toFloat(), 1f, initial = gameParameters.maxNumberOfPlayers.toFloat()) {
             gameParameters.maxNumberOfPlayers = it.toInt()
         }
-        slider.permanentTip = true
         slider.isDisabled = locked
         add(slider).padTop(10f).row()
     }
@@ -255,7 +253,6 @@ class GameOptionsTable(
         val slider = UncivSlider(0f, cityStatesAvailable.toFloat(), 1f, initial = gameParameters.minNumberOfCityStates.toFloat()) {
             gameParameters.minNumberOfCityStates = it.toInt()
         }
-        slider.permanentTip = true
         slider.isDisabled = locked
         add(slider).padTop(10f).row()
     }
@@ -268,7 +265,6 @@ class GameOptionsTable(
         val slider = UncivSlider(0f, cityStatesAvailable.toFloat(), 1f, initial = gameParameters.maxNumberOfCityStates.toFloat()) {
             gameParameters.maxNumberOfCityStates = it.toInt()
         }
-        slider.permanentTip = true
         slider.isDisabled = locked
         add(slider).padTop(10f).row()
     }
@@ -281,7 +277,6 @@ class GameOptionsTable(
         val slider = UncivSlider(0f, cityStatesAvailable.toFloat(), 1f, initial = gameParameters.numberOfCityStates.toFloat()) {
             gameParameters.numberOfCityStates = it.toInt()
         }
-        slider.permanentTip = true
         slider.isDisabled = locked
         add(slider).padTop(10f).row()
     }
@@ -294,7 +289,6 @@ class GameOptionsTable(
         val slider = UncivSlider(250f, 1500f, 50f, initial = gameParameters.maxTurns.toFloat()) {
             gameParameters.maxTurns = it.toInt()
         }
-        slider.permanentTip = true
         slider.isDisabled = locked
         val snapValues = floatArrayOf(250f,300f,350f,400f,450f,500f,550f,600f,650f,700f,750f,800f,900f,1000f,1250f,1500f)
         slider.setSnapToValues(snapValues, 250f)


### PR DESCRIPTION
In most cases (actually, except for one: "Brush ([size]):" in the map editor), the value of the slider is not obvious and you need to change it to display a tooltip with the current value.
That's why I made the tooltip permanent by default, but you can change it in the slider's constructor parameters.