### PR TITLE
Fixed world wrap coordinates check

### DIFF
--- a/core/src/com/unciv/ui/components/tilegroups/TileGroupMap.kt
+++ b/core/src/com/unciv/ui/components/tilegroups/TileGroupMap.kt
@@ -58,6 +58,9 @@ class TileGroupMap<T: TileGroup>(
     private var bottomX = Float.MAX_VALUE
     private var bottomY = Float.MAX_VALUE
 
+    private var drawTopX = 0f
+    private var drawBottomX = 0f
+
     init {
 
         for (tileGroup in tileGroups) {
@@ -96,6 +99,9 @@ class TileGroupMap<T: TileGroup>(
 
         topX -= bottomX
         bottomX -= bottomX
+
+        drawTopX = topX - bottomX
+        drawBottomX = bottomX - bottomX
 
         val baseLayers = ArrayList<TileLayerTerrain>()
         val featureLayers = ArrayList<TileLayerFeatures>()
@@ -165,19 +171,17 @@ class TileGroupMap<T: TileGroup>(
     override fun draw(batch: Batch?, parentAlpha: Float) {
 
         if (worldWrap) {
-
             // Prevent flickering when zoomed out so you can see entire map
-            val visibleMapWidth: Float
-            if(mapHolder.width > width) visibleMapWidth = width - groupSize * 1.5f
-            else visibleMapWidth = mapHolder.width
+            val visibleMapWidth = if (mapHolder.width > width) width - groupSize * 1.5f
+                else mapHolder.width
 
             // Where is viewport's boundaries
-            val rightSide = mapHolder.scrollX + visibleMapWidth/2f
-            val leftSide = mapHolder.scrollX - visibleMapWidth/2f
+            val rightSide = mapHolder.scrollX + visibleMapWidth / 2f
+            val leftSide = mapHolder.scrollX - visibleMapWidth / 2f
 
             // Have we looked beyond map?
-            val diffRight = rightSide - topX
-            val diffLeft = leftSide - bottomX
+            val diffRight = rightSide - drawTopX
+            val diffLeft = leftSide - drawBottomX
 
             val beyondRight = diffRight >= 0f
             val beyondLeft = diffLeft <= 0f
@@ -193,23 +197,21 @@ class TileGroupMap<T: TileGroup>(
                 children.forEach {
                     if (beyondRight) {
                         // Move from left to right
-                        if (it.x - bottomX <= diffRight)
+                        if (it.x - drawBottomX <= diffRight)
                             it.x += width
                     } else if (beyondLeft) {
                         // Move from right to left
-                        if (it.x + groupSize >= topX + diffLeft)
+                        if (it.x + groupSize >= drawTopX + diffLeft)
                             it.x -= width
                     }
                     newBottomX = min(newBottomX, it.x)
                     newTopX = max(newTopX, it.x + groupSize)
                 }
 
-                bottomX = newBottomX
-                topX = newTopX
+                drawBottomX = newBottomX
+                drawTopX = newTopX
             }
-
         }
-
         super.draw(batch, parentAlpha)
     }
 

--- a/core/src/com/unciv/ui/components/tilegroups/TileGroupMap.kt
+++ b/core/src/com/unciv/ui/components/tilegroups/TileGroupMap.kt
@@ -97,9 +97,6 @@ class TileGroupMap<T: TileGroup>(
             group.moveBy(-bottomX, -bottomY)
         }
 
-        topX -= bottomX
-        bottomX -= bottomX
-
         drawTopX = topX - bottomX
         drawBottomX = bottomX - bottomX
 

--- a/core/src/com/unciv/ui/components/tilegroups/TileGroupMap.kt
+++ b/core/src/com/unciv/ui/components/tilegroups/TileGroupMap.kt
@@ -134,6 +134,9 @@ class TileGroupMap<T: TileGroup>(
         if (worldWrap) setSize(topX - bottomX - groupSize, topY - bottomY)
         else setSize(topX - bottomX, topY - bottomY)
 
+        topY -= bottomX
+        bottomX -= bottomX
+
         cullingArea = Rectangle(0f, 0f, width, height)
     }
 

--- a/core/src/com/unciv/ui/components/tilegroups/TileGroupMap.kt
+++ b/core/src/com/unciv/ui/components/tilegroups/TileGroupMap.kt
@@ -94,6 +94,9 @@ class TileGroupMap<T: TileGroup>(
             group.moveBy(-bottomX, -bottomY)
         }
 
+        topX -= bottomX
+        bottomX -= bottomX
+
         val baseLayers = ArrayList<TileLayerTerrain>()
         val featureLayers = ArrayList<TileLayerFeatures>()
         val borderLayers = ArrayList<TileLayerBorders>()
@@ -133,9 +136,6 @@ class TileGroupMap<T: TileGroup>(
         // If map is not wrapped, Map's width doesn't need to be reduce by groupSize
         if (worldWrap) setSize(topX - bottomX - groupSize, topY - bottomY)
         else setSize(topX - bottomX, topY - bottomY)
-
-        topY -= bottomX
-        bottomX -= bottomX
 
         cullingArea = Rectangle(0f, 0f, width, height)
     }


### PR DESCRIPTION
Closes #8723.
In init tiles are movedBy -bottomX (line 94), but the topX and bottomX vars used to move the tiles for world wrap remain unchanged. 
And we have tiles.x from 0 to maxX, but bottomX=0-maxX/2 and topX=maxX/2.

So I changed the values of vars topX and bottomX by -bottomX in init.