### PR TITLE
Allow filters in the ModOptions "ToRemove" lists

### DIFF
--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -120,10 +120,13 @@ class Ruleset {
 
     fun add(ruleset: Ruleset) {
         beliefs.putAll(ruleset.beliefs)
-        if ("*" in ruleset.modOptions.buildingsToRemove) buildings.clear()
+        ruleset.modOptions.buildingsToRemove
+            .flatMap { buildingToRemove ->
+                buildings.filter { it.value.matchesFilter(buildingToRemove) }.keys
+            }.toSet().forEach {
+                buildings.remove(it)
+            }
         buildings.putAll(ruleset.buildings)
-        for (buildingToRemove in ruleset.modOptions.buildingsToRemove)
-            buildings.remove(buildingToRemove)
         difficulties.putAll(ruleset.difficulties)
         eras.putAll(ruleset.eras)
         speeds.putAll(ruleset.speeds)
@@ -131,30 +134,39 @@ class Ruleset {
             uniques.addAll(globalUniques.uniques)
             uniques.addAll(ruleset.globalUniques.uniques)
         }
-        if ("*" in ruleset.modOptions.nationsToRemove) nations.clear()
+        ruleset.modOptions.nationsToRemove
+            .flatMap { nationToRemove ->
+                nations.filter { it.value.matchesFilter(nationToRemove) }.keys
+            }.toSet().forEach {
+                nations.remove(it)
+            }
         nations.putAll(ruleset.nations)
-        for (nationToRemove in ruleset.modOptions.nationsToRemove)
-            nations.remove(nationToRemove)
         policyBranches.putAll(ruleset.policyBranches)
         policies.putAll(ruleset.policies)
         quests.putAll(ruleset.quests)
         religions.addAll(ruleset.religions)
         ruinRewards.putAll(ruleset.ruinRewards)
         specialists.putAll(ruleset.specialists)
-        if ("*" in ruleset.modOptions.techsToRemove) technologies.clear()
+        ruleset.modOptions.techsToRemove
+            .flatMap { techToRemove ->
+                technologies.filter { it.value.matchesFilter(techToRemove) }.keys
+            }.toSet().forEach {
+                technologies.remove(it)
+            }
         technologies.putAll(ruleset.technologies)
-        for (techToRemove in ruleset.modOptions.techsToRemove)
-            technologies.remove(techToRemove)
         terrains.putAll(ruleset.terrains)
         tileImprovements.putAll(ruleset.tileImprovements)
         tileResources.putAll(ruleset.tileResources)
         unitTypes.putAll(ruleset.unitTypes)
         victories.putAll(ruleset.victories)
         cityStateTypes.putAll(ruleset.cityStateTypes)
-        if ("*" in ruleset.modOptions.unitsToRemove) units.clear()
+        ruleset.modOptions.unitsToRemove
+            .flatMap { unitToRemove ->
+                units.filter { it.value.matchesFilter(unitToRemove) }.keys
+            }.toSet().forEach {
+                units.remove(it)
+            }
         units.putAll(ruleset.units)
-        for (unitToRemove in ruleset.modOptions.unitsToRemove)
-            units.remove(unitToRemove)
         modOptions.uniques.addAll(ruleset.modOptions.uniques)
         modOptions.constants.merge(ruleset.modOptions.constants)
 

--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -120,34 +120,41 @@ class Ruleset {
 
     fun add(ruleset: Ruleset) {
         beliefs.putAll(ruleset.beliefs)
+        if ("*" in ruleset.modOptions.buildingsToRemove) buildings.clear()
         buildings.putAll(ruleset.buildings)
-        for (buildingToRemove in ruleset.modOptions.buildingsToRemove) buildings.remove(
-            buildingToRemove
-        )
+        for (buildingToRemove in ruleset.modOptions.buildingsToRemove)
+            buildings.remove(buildingToRemove)
         difficulties.putAll(ruleset.difficulties)
         eras.putAll(ruleset.eras)
         speeds.putAll(ruleset.speeds)
         globalUniques = GlobalUniques().apply {
-            uniques.addAll(globalUniques.uniques); uniques.addAll(ruleset.globalUniques.uniques)
+            uniques.addAll(globalUniques.uniques)
+            uniques.addAll(ruleset.globalUniques.uniques)
         }
+        if ("*" in ruleset.modOptions.nationsToRemove) nations.clear()
         nations.putAll(ruleset.nations)
-        for (nationToRemove in ruleset.modOptions.nationsToRemove) nations.remove(nationToRemove)
+        for (nationToRemove in ruleset.modOptions.nationsToRemove)
+            nations.remove(nationToRemove)
         policyBranches.putAll(ruleset.policyBranches)
         policies.putAll(ruleset.policies)
         quests.putAll(ruleset.quests)
         religions.addAll(ruleset.religions)
         ruinRewards.putAll(ruleset.ruinRewards)
         specialists.putAll(ruleset.specialists)
+        if ("*" in ruleset.modOptions.techsToRemove) technologies.clear()
         technologies.putAll(ruleset.technologies)
-        for (techToRemove in ruleset.modOptions.techsToRemove) technologies.remove(techToRemove)
+        for (techToRemove in ruleset.modOptions.techsToRemove)
+            technologies.remove(techToRemove)
         terrains.putAll(ruleset.terrains)
         tileImprovements.putAll(ruleset.tileImprovements)
         tileResources.putAll(ruleset.tileResources)
-        units.putAll(ruleset.units)
         unitTypes.putAll(ruleset.unitTypes)
         victories.putAll(ruleset.victories)
         cityStateTypes.putAll(ruleset.cityStateTypes)
-        for (unitToRemove in ruleset.modOptions.unitsToRemove) units.remove(unitToRemove)
+        if ("*" in ruleset.modOptions.unitsToRemove) units.clear()
+        units.putAll(ruleset.units)
+        for (unitToRemove in ruleset.modOptions.unitsToRemove)
+            units.remove(unitToRemove)
         modOptions.uniques.addAll(ruleset.modOptions.uniques)
         modOptions.constants.merge(ruleset.modOptions.constants)
 
@@ -565,7 +572,7 @@ object RulesetCache : HashMap<String,Ruleset>() {
 
         for (mod in loadedMods.sortedByDescending { it.modOptions.isBaseRuleset }) {
             if (mod.modOptions.isBaseRuleset) {
-                // This is so we don't keep using the base ruleset's unqiues *by reference* and add to in ad infinitum
+                // This is so we don't keep using the base ruleset's uniques *by reference* and add to in ad infinitum
                 newRuleset.modOptions.uniques = ArrayList()
                 newRuleset.modOptions.isBaseRuleset = true
             }

--- a/core/src/com/unciv/models/ruleset/nation/Nation.kt
+++ b/core/src/com/unciv/models/ruleset/nation/Nation.kt
@@ -295,7 +295,17 @@ import kotlin.math.pow
     }
 
      fun getContrastRatio() = getContrastRatio(getInnerColor(), getOuterColor())
-}
+
+     fun matchesFilter(filter: String): Boolean {
+         return when (filter) {
+             "All" -> true
+             name -> true
+             "Major" -> isMajorCiv()
+             "CityState" -> isCityState()
+             else -> uniques.contains(filter)
+         }
+     }
+ }
 
 
  /** All defined by https://www.w3.org/TR/WCAG20/#relativeluminancedef */

--- a/core/src/com/unciv/models/ruleset/tech/Technology.kt
+++ b/core/src/com/unciv/models/ruleset/tech/Technology.kt
@@ -1,7 +1,6 @@
 package com.unciv.models.ruleset.tech
 
 import com.unciv.GUI
-import com.unciv.UncivGame
 import com.unciv.logic.civilization.Civilization
 import com.unciv.models.ruleset.Building
 import com.unciv.models.ruleset.Ruleset
@@ -284,5 +283,14 @@ class Technology: RulesetObject() {
         }
 
         return lineList
+    }
+
+    fun matchesFilter(filter: String): Boolean {
+        return when (filter) {
+            "All" -> true
+            name -> true
+            era() -> true
+            else -> uniques.contains(filter)
+        }
     }
 }

--- a/docs/Modders/Unique-parameters.md
+++ b/docs/Modders/Unique-parameters.md
@@ -96,6 +96,18 @@ It can be any value noted in `baseUnitFilter` or one of the following:
 -   `Barbarians`, `Barbarian`
 -   Again, any combination of the above is also allowed, e.g. `[{Wounded} {Water}]` units.
 
+## nationFilter
+
+At the moment only implemented for [ModOptions.nationsToRemove](../Other/Miscellaneous-JSON-files.md#modoptionsjson).
+
+Allowed values are:
+
+- `All`
+- `Major`
+- `CityState`
+- The name of a Nation
+- A unique a Nation has (verbatim, no placeholders)
+
 ## populationFilter
 
 A filter determining a part of the population of a city. It can be any of the following values:
@@ -132,6 +144,17 @@ Each stats is comprised of several stat changes, each in the form of `+{amount} 
 For example: `+1 Science`.
 
 These can be strung together with ", " between them, for example: `+2 Production, +3 Food`.
+
+## technologyFilter
+
+At the moment only implemented for [ModOptions.techsToRemove](../Other/Miscellaneous-JSON-files.md#modoptionsjson).
+
+Allowed values are:
+
+- `All`
+- The name of an Era
+- The name of a Technology
+- A unique a Technology has (verbatim, no placeholders)
 
 ## terrainFilter
 

--- a/docs/Other/Miscellaneous-JSON-files.md
+++ b/docs/Other/Miscellaneous-JSON-files.md
@@ -108,20 +108,20 @@ This file is a little different:
 
 The file can have the following attributes, including the values Unciv sets (no point in a mod author setting those):
 
-| Attribute | Type | Optional | Notes                                                                                                                                   |
-| --------- | ---- | -------- |-----------------------------------------------------------------------------------------------------------------------------------------|
-| isBaseRuleset | Boolean | false | Differentiates mods that change the vanilla ruleset or replace it                                                                       |
-| maxXPfromBarbarians | Integer | 30 | *Deprecated*, see [constants](#ModConstants)                                                                                            |
-| uniques | List | empty | Mod-wide specials, [see here](../Modders/uniques.md#modoptions-uniques)                                                                 |
-| techsToRemove | List | empty | List of [Technologies](Civilization-related-JSON-files.md#techsjson) to remove (isBaseRuleset=false only), "*" removes all              |
-| buildingsToRemove | List | empty | List of [Buildings or Wonders](Civilization-related-JSON-files.md#buildingsjson) to remove (isBaseRuleset=false only), "*" removes all  |
-| unitsToRemove | List | empty | List of [Units](Unit-related-JSON-files.md#unitsjson) to remove (isBaseRuleset=false only), "*" removes all                             |
-| nationsToRemove | List | empty | List of [Nations](Civilization-related-JSON-files.md#nationsjson) to remove (isBaseRuleset=false only), "*" removes all                 |
-| lastUpdated | String | empty | Set automatically after download - Last repository update, not necessarily last content change                                          |
-| modUrl | String | empty | Set automatically after download - URL of repository                                                                                    |
-| author | String | empty | Set automatically after download - Owner of repository                                                                                  |
-| modSize | Integer | empty | Set automatically after download - kB in entire repository, not sum of default branch files                                             |
-| constants | Object | empty | see [ModConstants](#ModConstants)                                                                                                       |
+| Attribute           | Type    | Optional | Notes                                                                                                                                                                               |
+|---------------------|---------|----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| isBaseRuleset       | Boolean | false    | Differentiates mods that change the vanilla ruleset or replace it                                                                                                                   |
+| maxXPfromBarbarians | Integer | 30       | *Deprecated*, see [constants](#ModConstants)                                                                                                                                        |
+| uniques             | List    | empty    | Mod-wide specials, [see here](../Modders/uniques.md#modoptions-uniques)                                                                                                             |
+| techsToRemove       | List    | empty    | List of [Technologies](Civilization-related-JSON-files.md#techsjson) or [-filters](../Modders/Unique-parameters.md#technologyfilter) to remove (isBaseRuleset=false only)           |
+| buildingsToRemove   | List    | empty    | List of [Buildings or Wonders](Civilization-related-JSON-files.md#buildingsjson) or [-filters](../Modders/Unique-parameters.md#buildingfilter) to remove (isBaseRuleset=false only) |
+| unitsToRemove       | List    | empty    | List of [Units](Unit-related-JSON-files.md#unitsjson) or [-filters](../Modders/Unique-parameters.md#baseunitfilter) to remove (isBaseRuleset=false only)                            |
+| nationsToRemove     | List    | empty    | List of [Nations](Civilization-related-JSON-files.md#nationsjson) or [-filters](../Modders/Unique-parameters.md#nationfilter) to remove (isBaseRuleset=false only)                  |
+| lastUpdated         | String  | empty    | Set automatically after download - Last repository update, not necessarily last content change                                                                                      |
+| modUrl              | String  | empty    | Set automatically after download - URL of repository                                                                                                                                |
+| author              | String  | empty    | Set automatically after download - Owner of repository                                                                                                                              |
+| modSize             | Integer | empty    | Set automatically after download - kB in entire repository, not sum of default branch files                                                                                         |
+| constants           | Object  | empty    | see [ModConstants](#ModConstants)                                                                                                                                                   |
 
 ### ModConstants
 

--- a/docs/Other/Miscellaneous-JSON-files.md
+++ b/docs/Other/Miscellaneous-JSON-files.md
@@ -108,20 +108,20 @@ This file is a little different:
 
 The file can have the following attributes, including the values Unciv sets (no point in a mod author setting those):
 
-| Attribute | Type | Optional | Notes |
-| --------- | ---- | -------- | ----- |
-| isBaseRuleset | Boolean | false | Differentiates mods that change the vanilla ruleset or replace it |
-| maxXPfromBarbarians | Integer | 30 | *Deprecated*, see [constants](#ModConstants) |
-| uniques | List | empty | Mod-wide specials, [see here](../Modders/uniques.md#modoptions-uniques) |
-| techsToRemove | List | empty | List of [Technologies](Civilization-related-JSON-files.md#techsjson) to remove (isBaseRuleset=false only) |
-| buildingsToRemove | List | empty | List of [Buildings or Wonders](Civilization-related-JSON-files.md#buildingsjson) to remove (isBaseRuleset=false only) |
-| unitsToRemove | List | empty | List of [Units](Unit-related-JSON-files.md#unitsjson) to remove (isBaseRuleset=false only) |
-| nationsToRemove | List | empty | List of [Nations](Civilization-related-JSON-files.md#nationsjson) to remove (isBaseRuleset=false only) |
-| lastUpdated | String | empty | Set automatically after download - Last repository update, not necessarily last content change |
-| modUrl | String | empty | Set automatically after download - URL of repository |
-| author | String | empty | Set automatically after download - Owner of repository |
-| modSize | Integer | empty | Set automatically after download - kB in entire repository, not sum of default branch files |
-| constants | Object | empty | see [ModConstants](#ModConstants) |
+| Attribute | Type | Optional | Notes                                                                                                                                   |
+| --------- | ---- | -------- |-----------------------------------------------------------------------------------------------------------------------------------------|
+| isBaseRuleset | Boolean | false | Differentiates mods that change the vanilla ruleset or replace it                                                                       |
+| maxXPfromBarbarians | Integer | 30 | *Deprecated*, see [constants](#ModConstants)                                                                                            |
+| uniques | List | empty | Mod-wide specials, [see here](../Modders/uniques.md#modoptions-uniques)                                                                 |
+| techsToRemove | List | empty | List of [Technologies](Civilization-related-JSON-files.md#techsjson) to remove (isBaseRuleset=false only), "*" removes all              |
+| buildingsToRemove | List | empty | List of [Buildings or Wonders](Civilization-related-JSON-files.md#buildingsjson) to remove (isBaseRuleset=false only), "*" removes all  |
+| unitsToRemove | List | empty | List of [Units](Unit-related-JSON-files.md#unitsjson) to remove (isBaseRuleset=false only), "*" removes all                             |
+| nationsToRemove | List | empty | List of [Nations](Civilization-related-JSON-files.md#nationsjson) to remove (isBaseRuleset=false only), "*" removes all                 |
+| lastUpdated | String | empty | Set automatically after download - Last repository update, not necessarily last content change                                          |
+| modUrl | String | empty | Set automatically after download - URL of repository                                                                                    |
+| author | String | empty | Set automatically after download - Owner of repository                                                                                  |
+| modSize | Integer | empty | Set automatically after download - kB in entire repository, not sum of default branch files                                             |
+| constants | Object | empty | see [ModConstants](#ModConstants)                                                                                                       |
 
 ### ModConstants
 
@@ -192,7 +192,7 @@ The formula for the gold cost of a unit upgrade is (rounded down to a multiple o
         ( max((`base` + `perProduction` * (new_unit_cost - old_unit_cost)), 0)
             * (1 + eraNumber * `eraMultiplier`) * `civModifier`
         ) ^ `exponent`
-With `civModifier` being the multiplicative aggregate of ["\[relativeAmount\]% Gold cost of upgrading"](../uniques.md#global_uniques) uniques that apply.
+With `civModifier` being the multiplicative aggregate of ["\[relativeAmount\]% Gold cost of upgrading"](../Modders/uniques.md#global-uniques) uniques that apply.
 
 
 ## VictoryTypes.json


### PR DESCRIPTION
Inspired by #8625 and #8465 mentioning a certain mod which says "not balanced around vanilla civs but around itself" in its readme. Allows the modder to prune those ruleset collections for which a `*ToRemove` already exists with broader filters instead of removing entries individually. 

@AceHank - would that suit you? I tested `nationsToRemove:["Major"]` on your EoF and it works as intended, but it may be a little harsh to preclude mixing your nations with vanilla ones entirely??

Edit: The "*" wildcard idea wasn't that nice, e.g. to clear Nations one would likely be able to leave Spectator and maybe the City States...

Q: Shouldn't matchesFilter by now be an abstract on IRulesetObject or something similar?