### PR TITLE
Map exploring disables undo button + ExploredRegion smallfixes

### DIFF
--- a/core/src/com/unciv/logic/civilization/ExploredRegion.kt
+++ b/core/src/com/unciv/logic/civilization/ExploredRegion.kt
@@ -115,13 +115,12 @@ class ExploredRegion () : IsPartOfGameInfoSerialization {
                 }
 
                 // Expand region from the nearest edge
-                if (rightSideDistance > leftSideDistance) {
+                if (rightSideDistance > leftSideDistance)
                     topLeft.x = longitude
-                    shouldRecalculateCoords = true
-                } else {
+                else
                     bottomRight.x = longitude
-                    shouldRecalculateCoords = true
-                }
+
+                shouldRecalculateCoords = true
             }
         }
 
@@ -146,7 +145,7 @@ class ExploredRegion () : IsPartOfGameInfoSerialization {
         val bottomRightWorld = worldFromLatLong(bottomRight, tileRadius)
 
         // Convert X to the stage coords
-        val mapCenterX = mapMaxX * 0.5f + tileRadius
+        val mapCenterX = if (isWorldWrap) mapMaxX * 0.5f + tileRadius else mapMaxX * 0.5f
         var left = mapCenterX + topLeftWorld.x
         var right = mapCenterX + bottomRightWorld.x
 

--- a/core/src/com/unciv/logic/map/tile/Tile.kt
+++ b/core/src/com/unciv/logic/map/tile/Tile.kt
@@ -2,6 +2,7 @@
 
 import com.badlogic.gdx.math.Vector2
 import com.unciv.Constants
+import com.unciv.GUI
 import com.unciv.UncivGame
 import com.unciv.logic.IsPartOfGameInfoSerialization
 import com.unciv.logic.city.City
@@ -248,7 +249,13 @@ open class Tile : IsPartOfGameInfoSerialization {
     fun setExplored(player: Civilization, isExplored: Boolean, explorerPosition: Vector2? = null) {
         if (isExplored) {
             exploredBy.add(player.civName)
-            player.exploredTiles.add(position)
+
+            // Disable the undo button if a new tile has been explored
+            if (player.exploredTiles.add(position) && GUI.isWorldLoaded()) {
+                val worldScreen = GUI.getWorldScreen()
+                worldScreen.preActionGameInfo = worldScreen.gameInfo
+            }
+
             if(player.playerType == PlayerType.Human)
                 player.exploredRegion.checkTilePosition(position, explorerPosition)
         } else {

--- a/core/src/com/unciv/ui/screens/worldscreen/TechPolicyDiplomacyButtons.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/TechPolicyDiplomacyButtons.kt
@@ -118,7 +118,7 @@ class TechPolicyDiplomacyButtons(val worldScreen: WorldScreen) : Table(BaseScree
     }
 
     private fun updateUndoButton() {
-        // Don't show policies until they become relevant
+        // Don't show the undo button if there is no action to undo
         if (worldScreen.gameInfo != worldScreen.preActionGameInfo) {
             undoButtonHolder.touchable = Touchable.enabled
             undoButtonHolder.actor = undoButton

--- a/core/src/com/unciv/ui/screens/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/WorldScreen.kt
@@ -305,10 +305,10 @@ class WorldScreen(
                     fun whileKeyPressedLoop() {
                         for (keycode in pressedKeys) {
                             when (keycode) {
-                                Input.Keys.W, Input.Keys.UP -> mapHolder.scrollY -= amountToMove
-                                Input.Keys.S, Input.Keys.DOWN -> mapHolder.scrollY += amountToMove
-                                Input.Keys.A, Input.Keys.LEFT -> mapHolder.scrollX -= amountToMove
-                                Input.Keys.D, Input.Keys.RIGHT -> mapHolder.scrollX += amountToMove
+                                Input.Keys.W, Input.Keys.UP -> mapHolder.scrollY = mapHolder.restrictY(-amountToMove)
+                                Input.Keys.S, Input.Keys.DOWN -> mapHolder.scrollY = mapHolder.restrictY(amountToMove)
+                                Input.Keys.A, Input.Keys.LEFT -> mapHolder.scrollX = mapHolder.restrictX(amountToMove)
+                                Input.Keys.D, Input.Keys.RIGHT -> mapHolder.scrollX = mapHolder.restrictX(-amountToMove)
                             }
                         }
                         mapHolder.updateVisualScroll()


### PR DESCRIPTION
Undo button:
- prevent the undo action if a new tile is explored
- fixed comment

Expored region:
- removed redundant boolean assignment
- fixed region x padding for non world wrap maps
- no longer can you go beyond the explored region using the buttons on the keyboard