### PR TITLE
exploredTiles deprecation, step 1 - do not check exploredTiles when checking if a tile is explored

### DIFF
--- a/core/src/com/unciv/logic/civilization/Civilization.kt
+++ b/core/src/com/unciv/logic/civilization/Civilization.kt
@@ -186,6 +186,7 @@ class Civilization : IsPartOfGameInfoSerialization {
     // This is basically a way to ensure our lists are immutable.
     var cities = listOf<City>()
     var citiesCreated = 0
+    @Deprecated("4.5.0 - in favor of Tile.exploredBy")
     var exploredTiles = HashSet<Vector2>()
 
     // Limit camera within explored region

--- a/core/src/com/unciv/logic/map/tile/Tile.kt
+++ b/core/src/com/unciv/logic/map/tile/Tile.kt
@@ -243,20 +243,20 @@ open class Tile : IsPartOfGameInfoSerialization {
     fun isExplored(player: Civilization): Boolean {
         if (UncivGame.Current.viewEntireMapForDebug || player.isSpectator())
             return true
-        return exploredBy.contains(player.civName) || player.exploredTiles.contains(position)
+        return exploredBy.contains(player.civName)
     }
 
     fun setExplored(player: Civilization, isExplored: Boolean, explorerPosition: Vector2? = null) {
         if (isExplored) {
-            exploredBy.add(player.civName)
+            player.exploredTiles.add(position)
 
             // Disable the undo button if a new tile has been explored
-            if (player.exploredTiles.add(position) && GUI.isWorldLoaded()) {
+            if (exploredBy.add(player.civName) && GUI.isWorldLoaded()) {
                 val worldScreen = GUI.getWorldScreen()
                 worldScreen.preActionGameInfo = worldScreen.gameInfo
             }
 
-            if(player.playerType == PlayerType.Human)
+            if (player.playerType == PlayerType.Human)
                 player.exploredRegion.checkTilePosition(position, explorerPosition)
         } else {
             exploredBy.remove(player.civName)


### PR DESCRIPTION
exploredTiles continues to remain updated, to allow 'intermediate' players to not ruin the explored tiles of other players
If no negative feedback comes after this release (4.5.1), then full deprecation will enter 4.5.2