### PR TITLE
Better control over debug messages

### DIFF
--- a/core/src/com/unciv/utils/Log.kt
+++ b/core/src/com/unciv/utils/Log.kt
@@ -16,16 +16,26 @@ import java.util.regex.Pattern
  */
 object Log {
 
-    /** Add -DnoLog=<comma-separated-list-of-class-names> to not log these classes. */
-    private val disabledLogsFromProperty = System.getProperty("noLog")?.split(',')?.toMutableSet() ?: mutableSetOf()
+    /**
+     * Add -DnoLog=<comma-separated-list-of-partial-class-names> to not log these classes.
+     * Log tags (= class names) **containing** these Strings will not be logged.
+     * You _can_ disable the default exclusions with an empty `-DnoLog=` argument.
+     */
+    val disableLogsFrom = (
+            System.getProperty("noLog")
+            ?: "Battle,Music,Sounds,Translations,WorkerAutomation"
+        ).split(',').filterNot { it.isEmpty() }.toMutableSet()
 
-    /** Log tags (= class names) **containing** these Strings will not be logged.  */
-    val disableLogsFrom = if (disabledLogsFromProperty.isEmpty()) {
-        "Battle,Music,Sounds,Translations,WorkerAutomation"
-            .split(',').toMutableSet()
-    } else {
-        disabledLogsFromProperty
-    }
+    /**
+     * Add -DonlyLog=<comma-separated-list-of-partial-class-names> to only log specific classes.
+     * Only Log tags (= class names) **containing** these Strings will be logged (Not set means all)
+     * [disableLogsFrom] will still be respected if this is set.
+     * Note you cannot disable all logging with `-DonlyLog=`, use `-DonlyLog=~~~` instead.
+     */
+    val enableLogsFrom = (
+            System.getProperty("onlyLog")
+            ?: ""
+        ).split(',').filterNot { it.isEmpty() }.toMutableSet()
 
     var backend: LogBackend = DefaultLogBackend()
 
@@ -186,7 +196,8 @@ private fun doLog(logger: (Tag, String, String) -> Unit, tag: Tag, msg: String, 
 }
 
 private fun isTagDisabled(tag: Tag): Boolean {
-    return Log.disableLogsFrom.any { it in tag.name }
+    return Log.disableLogsFrom.any { it in tag.name } ||
+            (Log.enableLogsFrom.isNotEmpty() && Log.enableLogsFrom.none { it in tag.name })
 }
 
 private fun buildThrowableMessage(msg: String, throwable: Throwable): String {
@@ -195,7 +206,7 @@ private fun buildThrowableMessage(msg: String, throwable: Throwable): String {
 
 private fun replaceLambdasWithValues(params: Array<out Any?>): Array<out Any?> {
     var out: Array<Any?>? = null
-    for (i in 0 until params.size) {
+    for (i in params.indices) {
         val param = params[i]
         if (param is Function0<*>) {
             if (out == null) out = arrayOf(*params)

--- a/docs/Developers/Building-Locally.md
+++ b/docs/Developers/Building-Locally.md
@@ -26,6 +26,7 @@ So first things first - the initial "No assumptions" setup to have Unciv run fro
     -   Choose "Application"
     -   Give the configuration a name, we recommend "Desktop"
     -   Set the module classpath (the box to the right of the Java selection) to `Unciv.desktop.main` (`Unciv.desktop` for Bumblebee or below), main class to `com.unciv.app.desktop.DesktopLauncher` and `<repo_folder>\android\assets\` as the Working directory, OK to close the window
+        -   It _may_ be useful to set some VM options - activate the field in the run config editor with Alt-V or via the Modify Options menu, then add `-Xmx4096m -Xms256m -XX:MaxMetaspaceSize=256m` to allow a debugged game a little more memory. Or, use the `-DnoLog=` or `-DonlyLog=` options to control console logging. See the [Log.kt](https://github.com/yairm210/Unciv/blob/master/core/src/com/unciv/utils/Log.kt) comments for details.
         -   If you get a `../../docs/uniques.md (No such file or directory)` error that means you forgot to set the working directory!
 -   Select the Desktop configuration (or however you chose to name it) and click the green arrow button to run! Or you can use the next button -the green critter with six legs and two feelers - to start debugging.
 -   A few Android Studio settings that are recommended:
@@ -37,7 +38,7 @@ So first things first - the initial "No assumptions" setup to have Unciv run fro
 
 Unciv uses Gradle to specify dependencies and how to run. In the background, the Gradle gnomes will be off fetching the packages (a one-time effort) and, once that's done, will build the project!
 
-Unciv uses Gradle 7.2 and the Android Gradle Plugin 7.1.3. Can check in File > Project Structure > Project
+Unciv uses Gradle 7.5 and the Android Gradle Plugin 7.3.1. Can check in File > Project Structure > Project
 
 Note advanced build commands as described in the next paragraph, specifically the `gradlew desktop:dist` one to build a jar, run just fine in Android Studio's terminal (Alt+F12), with most dependencies already taken care of.
 


### PR DESCRIPTION
Another entirely optional offer...

After a debug session recently that continued to scroll new messages into the console window of Android Studio several minutes _after the process exit_, I thought I should dig this out of the shelf and show it.

Simple: You work on - say - MapUnit code? Add `-DonlyLog=Unit` to your run config right where you put your `-Xmx4096m`, presto lightweight console output.