### PR TITLE
City screen displays "free" tile yields undimmed

### DIFF
--- a/core/src/com/unciv/ui/components/tilegroups/CityTileGroup.kt
+++ b/core/src/com/unciv/ui/components/tilegroups/CityTileGroup.kt
@@ -111,6 +111,11 @@ class CityTileGroup(val city: City, tile: Tile, tileSetStrings: TileSetStrings) 
                 layerMisc.dimYields(false)
             }
 
+            // Provides yield without worker assigned (isWorked already tested above)
+            tile.providesYield() -> {
+                // defaults are OK
+            }
+
             // Not-worked
             else -> {
                 icon = ImageGetter.getImage("TileIcons/NotWorked")


### PR DESCRIPTION
<details><summary>Tiny thing...</summary>

Bfre:
![image](https://user-images.githubusercontent.com/63000004/221416006-1375f691-41b9-45a5-a62d-5c596b801604.png)

Arftr:
![image](https://user-images.githubusercontent.com/63000004/221416137-d211ecc2-adbd-4c9e-b403-554c60798eb8.png)

Also tested for a modded `TileProvidesYieldWithoutPopulation` on an improvement.
</details>
