### PR TITLE
Fix broken random nations pool

### DIFF
--- a/core/src/com/unciv/logic/GameStarter.kt
+++ b/core/src/com/unciv/logic/GameStarter.kt
@@ -221,11 +221,10 @@ object GameStarter {
 
     private fun addCivilizations(newGameParameters: GameParameters, gameInfo: GameInfo, ruleset: Ruleset, existingMap: Boolean) {
         val availableCivNames = Stack<String>()
-        // CityState or Spectator civs are not available for Random pick
         if (gameSetupInfo.gameParameters.enableRandomNationsPool) {
-            for (nation in gameSetupInfo.gameParameters.randomNations)
-                availableCivNames.add(nation.name)
+            availableCivNames.addAll(gameSetupInfo.gameParameters.randomNations.shuffled())
         } else
+            // CityState or Spectator civs are not available for Random pick
             availableCivNames.addAll(ruleset.nations.filter { it.value.isMajorCiv() }.keys.shuffled())
 
         availableCivNames.removeAll(newGameParameters.players.map { it.chosenCiv }.toSet())
@@ -237,7 +236,7 @@ object GameStarter {
             gameInfo.civilizations.add(barbarianCivilization)
         }
 
-        val civNamesWithStartingLocations = if(existingMap) gameInfo.tileMap.startingLocationsByNation.keys
+        val civNamesWithStartingLocations = if (existingMap) gameInfo.tileMap.startingLocationsByNation.keys
             else emptySet()
         val presetMajors = Stack<String>()
         presetMajors.addAll(availableCivNames.filter { it in civNamesWithStartingLocations })
@@ -248,12 +247,12 @@ object GameStarter {
             val max = newGameParameters.maxNumberOfPlayers.coerceAtLeast(newGameParameters.minNumberOfPlayers)
             var playerCount = (min..max).random()
 
-            val humanPlayerCount = newGameParameters.players.filter {
+            val humanPlayerCount = newGameParameters.players.count {
                 it.playerType === PlayerType.Human
-            }.count()
-            val spectatorCount = newGameParameters.players.filter {
+            }
+            val spectatorCount = newGameParameters.players.count {
                 it.chosenCiv === Constants.spectator
-            }.count()
+            }
             playerCount = playerCount.coerceAtLeast(humanPlayerCount + spectatorCount)
 
             if (newGameParameters.players.size < playerCount) {
@@ -265,6 +264,7 @@ object GameStarter {
                     it.playerType === PlayerType.AI
                 }.shuffled().subList(0, extraPlayers)
 
+                @Suppress("ConvertArgumentToSet")  // Not worth it for a handful entries
                 newGameParameters.players.removeAll(playersToRemove)
             }
         }

--- a/core/src/com/unciv/models/metadata/GameParameters.kt
+++ b/core/src/com/unciv/models/metadata/GameParameters.kt
@@ -3,8 +3,9 @@ package com.unciv.models.metadata
 import com.unciv.logic.IsPartOfGameInfoSerialization
 import com.unciv.logic.civilization.PlayerType
 import com.unciv.models.ruleset.Speed
-import com.unciv.models.ruleset.nation.Nation
 
+
+@Suppress("EnumEntryName")  // These merit unusual names
 enum class BaseRuleset(val fullName:String){
     Civ_V_Vanilla("Civ V - Vanilla"),
     Civ_V_GnK("Civ V - Gods & Kings"),
@@ -29,7 +30,7 @@ class GameParameters : IsPartOfGameInfoSerialization { // Default values are the
     var numberOfCityStates = 6
 
     var enableRandomNationsPool = false
-    var randomNations = arrayListOf<Nation>()
+    var randomNations = arrayListOf<String>()
 
     var noCityRazing = false
     var noBarbarians = false
@@ -54,21 +55,28 @@ class GameParameters : IsPartOfGameInfoSerialization { // Default values are the
         val parameters = GameParameters()
         parameters.difficulty = difficulty
         parameters.speed = speed
-        parameters.players = ArrayList(players)
         parameters.randomNumberOfPlayers = randomNumberOfPlayers
         parameters.minNumberOfPlayers = minNumberOfPlayers
         parameters.maxNumberOfPlayers = maxNumberOfPlayers
+        parameters.players = ArrayList(players)
         parameters.randomNumberOfCityStates = randomNumberOfCityStates
         parameters.minNumberOfCityStates = minNumberOfCityStates
         parameters.maxNumberOfCityStates = maxNumberOfCityStates
         parameters.numberOfCityStates = numberOfCityStates
+        parameters.enableRandomNationsPool = enableRandomNationsPool
+        parameters.randomNations = ArrayList(randomNations)
+        parameters.noCityRazing = noCityRazing
         parameters.noBarbarians = noBarbarians
         parameters.ragingBarbarians = ragingBarbarians
         parameters.oneCityChallenge = oneCityChallenge
+        // godMode intentionally reset on clone
         parameters.nuclearWeaponsEnabled = nuclearWeaponsEnabled
+        parameters.espionageEnabled = espionageEnabled
+        parameters.noStartBias = noStartBias
         parameters.victoryTypes = ArrayList(victoryTypes)
         parameters.startingEra = startingEra
         parameters.isOnlineMultiplayer = isOnlineMultiplayer
+        parameters.anyoneCanSpectate = anyoneCanSpectate
         parameters.baseRuleset = baseRuleset
         parameters.mods = LinkedHashSet(mods)
         parameters.maxTurns = maxTurns

--- a/core/src/com/unciv/ui/screens/newgamescreen/ModCheckboxTable.kt
+++ b/core/src/com/unciv/ui/screens/newgamescreen/ModCheckboxTable.kt
@@ -30,7 +30,7 @@ class ModCheckboxTable(
     private val screen: BaseScreen,
     isPortrait: Boolean = false,
     onUpdate: (String) -> Unit
-): Table(){
+): Table() {
     private val modRulesets = RulesetCache.values.filter { it.name != "" && !it.modOptions.isBaseRuleset}
     private var lastToast: ToastPopup? = null
     private val extensionRulesetModButtons = ArrayList<CheckBox>()


### PR DESCRIPTION
I believe this resolves #8625 and resolves #8465.

Changes:
- Persistence of randomNations as collection of fully serialized Nations was a bad idea, now Strings. No compat code necessary as it was never working, and an emptyList<Nation>() serializes the same as an emptyList<String>().
- Fixed: Random from pool wasn't random at all
- Fixed: Incomplete clone led to options resetting (clone code reordered to field order for easier checking)
- Removed: Unnecessary keepOpen vars
- No reason not to let Advanced Expander state persist (better fix for the problem those keepOpen were afaicg introduced for)
- startsOpen is now "only" a suggestion for the first run of NewGameScreen once per game launch - no longer open by default for rnd #CS or rnd #players as the use of these two can readily be seen with the xpander closed.
- The Advanced and Mods Expanders had different widths - aesthetically imperfect - growX() vs growX() one nesting level deeper. Went the easier way - no growX(), else would have had to review center column -adv map params- too. Also looks better for portrait.
- Made vertical spacing between advanced checkboxes equal to between the mods
- Tweaked vertical spacing between adv and mods slightly - was fine in portrait but a little big in landscape

Fly-by observations, code untouched:
- NewGameScreen.unlockTables and lockTables can probably be removed, likely remainder from removed scenario maps?
- MapParameters clone could benefit from above-mentioned ordering
- MapParameters.numberOfTiles vs MapParameters.getArea - the latter (I did that though I barely remember) makes a distinction for worldwrapped rectangular with odd width - which is problematic anyway as these _must_ drop a column that would otherwise not mesh up with the other side. Should the UI maybe _prevent_ odd width for ww-rect? Otherwise, numberOfTiles only affects scoring while getArea is unused...
- Scrolling of a worldwrapped medium flat earth map is broken. Maybe ww makes no sense for fe anyway?
