### PR TITLE
Fixed wrong implementation of Basic auth

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -614,6 +614,7 @@ File could not be found on the multiplayer server =
 Unhandled problem, [errorMessage] = 
 Please enter your server password = 
 Set password = 
+Password must be at least 6 characters long = 
 Failed to set password! = 
 Password set successfully for server [serverURL] = 
 Password = 

--- a/android/src/com/unciv/app/MultiplayerTurnCheckWorker.kt
+++ b/android/src/com/unciv/app/MultiplayerTurnCheckWorker.kt
@@ -216,7 +216,7 @@ class MultiplayerTurnCheckWorker(appContext: Context, workerParams: WorkerParame
                         Pair(USER_ID, settings.userId), Pair(CONFIGURED_DELAY, settings.turnCheckerDelay.seconds),
                         Pair(PERSISTENT_NOTIFICATION_ENABLED, settings.turnCheckerPersistentNotificationEnabled),
                         Pair(FILE_STORAGE, settings.server),
-                        Pair(AUTH_HEADER, "Basic ${Gzip.zip(settings.userId)}:${Gzip.zip(settings.passwords[settings.server] ?: "")}"))
+                        Pair(AUTH_HEADER, "Basic ${Gzip.zip("${settings.userId}:${settings.passwords[settings.server] ?: ""}")}"))
 
                 if (settings.turnCheckerPersistentNotificationEnabled) {
                     showPersistentNotification(applicationContext, "—", settings.turnCheckerDelay)

--- a/android/src/com/unciv/app/MultiplayerTurnCheckWorker.kt
+++ b/android/src/com/unciv/app/MultiplayerTurnCheckWorker.kt
@@ -24,7 +24,6 @@ import com.unciv.logic.files.UncivFiles
 import com.unciv.logic.multiplayer.storage.FileStorageRateLimitReached
 import com.unciv.logic.multiplayer.storage.OnlineMultiplayerFiles
 import com.unciv.models.metadata.GameSettingsMultiplayer
-import com.unciv.ui.screens.savescreens.Gzip
 import kotlinx.coroutines.runBlocking
 import java.io.FileNotFoundException
 import java.io.PrintWriter
@@ -216,7 +215,7 @@ class MultiplayerTurnCheckWorker(appContext: Context, workerParams: WorkerParame
                         Pair(USER_ID, settings.userId), Pair(CONFIGURED_DELAY, settings.turnCheckerDelay.seconds),
                         Pair(PERSISTENT_NOTIFICATION_ENABLED, settings.turnCheckerPersistentNotificationEnabled),
                         Pair(FILE_STORAGE, settings.server),
-                        Pair(AUTH_HEADER, "Basic ${Gzip.zip("${settings.userId}:${settings.passwords[settings.server] ?: ""}")}"))
+                        Pair(AUTH_HEADER, settings.getAuthHeader()))
 
                 if (settings.turnCheckerPersistentNotificationEnabled) {
                     showPersistentNotification(applicationContext, "—", settings.turnCheckerDelay)

--- a/core/src/com/unciv/logic/multiplayer/storage/OnlineMultiplayerFiles.kt
+++ b/core/src/com/unciv/logic/multiplayer/storage/OnlineMultiplayerFiles.kt
@@ -27,7 +27,7 @@ class OnlineMultiplayerFiles(
         val authHeader = if (authenticationHeader == null) {
             val settings = UncivGame.Current.settings.multiplayer
             mapOf(
-                "Authorization" to "Basic ${Gzip.zip(settings.userId)}:${Gzip.zip(settings.passwords[settings.server] ?: "")}"
+                "Authorization" to "Basic ${Gzip.zip("${settings.userId}:${settings.passwords[settings.server] ?: ""}")}"
             )
         } else {
             authenticationHeader

--- a/core/src/com/unciv/logic/multiplayer/storage/OnlineMultiplayerFiles.kt
+++ b/core/src/com/unciv/logic/multiplayer/storage/OnlineMultiplayerFiles.kt
@@ -5,7 +5,6 @@ import com.unciv.UncivGame
 import com.unciv.logic.GameInfo
 import com.unciv.logic.GameInfoPreview
 import com.unciv.logic.files.UncivFiles
-import com.unciv.ui.screens.savescreens.Gzip
 
 /**
  * Allows access to games stored on a server for multiplayer purposes.
@@ -26,9 +25,7 @@ class OnlineMultiplayerFiles(
         val identifier = if (fileStorageIdentifier == null) UncivGame.Current.settings.multiplayer.server else fileStorageIdentifier
         val authHeader = if (authenticationHeader == null) {
             val settings = UncivGame.Current.settings.multiplayer
-            mapOf(
-                "Authorization" to "Basic ${Gzip.zip("${settings.userId}:${settings.passwords[settings.server] ?: ""}")}"
-            )
+            mapOf("Authorization" to settings.getAuthHeader())
         } else {
             authenticationHeader
         }

--- a/core/src/com/unciv/logic/multiplayer/storage/UncivServerFileStorage.kt
+++ b/core/src/com/unciv/logic/multiplayer/storage/UncivServerFileStorage.kt
@@ -1,6 +1,7 @@
 package com.unciv.logic.multiplayer.storage
 
 import com.badlogic.gdx.Net
+import com.badlogic.gdx.utils.Base64Coder
 import com.unciv.ui.screens.savescreens.Gzip
 import com.unciv.utils.debug
 import kotlin.Exception
@@ -58,7 +59,8 @@ object UncivServerFileStorage : FileStorage {
 
     override fun authenticate(userId: String, password: String): Boolean {
         var authenticated = false
-        authHeader = mapOf("Authorization" to "Basic ${Gzip.zip("${userId}:${password}")}")
+        val preEncodedAuthValue = "$userId:$password"
+        authHeader = mapOf("Authorization" to "Basic ${Base64Coder.encodeString(preEncodedAuthValue)}")
         SimpleHttp.sendGetRequest("$serverUrl/auth", timeout=timeout, header=authHeader) {
                 success, result, code ->
             if (!success) {

--- a/core/src/com/unciv/logic/multiplayer/storage/UncivServerFileStorage.kt
+++ b/core/src/com/unciv/logic/multiplayer/storage/UncivServerFileStorage.kt
@@ -58,7 +58,7 @@ object UncivServerFileStorage : FileStorage {
 
     override fun authenticate(userId: String, password: String): Boolean {
         var authenticated = false
-        authHeader = mapOf("Authorization" to "Basic ${Gzip.zip(userId)}:${Gzip.zip(password)}")
+        authHeader = mapOf("Authorization" to "Basic ${Gzip.zip("${userId}:${password}")}")
         SimpleHttp.sendGetRequest("$serverUrl/auth", timeout=timeout, header=authHeader) {
                 success, result, code ->
             if (!success) {

--- a/core/src/com/unciv/models/metadata/GameSettings.kt
+++ b/core/src/com/unciv/models/metadata/GameSettings.kt
@@ -2,6 +2,7 @@ package com.unciv.models.metadata
 
 import com.badlogic.gdx.Application
 import com.badlogic.gdx.Gdx
+import com.badlogic.gdx.utils.Base64Coder
 import com.unciv.Constants
 import com.unciv.UncivGame
 import com.unciv.logic.multiplayer.FriendList
@@ -233,6 +234,12 @@ class GameSettingsMultiplayer {
     var currentGameTurnNotificationSound: UncivSound = UncivSound.Silent
     var otherGameTurnNotificationSound: UncivSound = UncivSound.Silent
     var hideDropboxWarning = false
+
+    fun getAuthHeader(): String {
+        val serverPassword = passwords[server] ?: ""
+        val preEncodedAuthValue = "$userId:$serverPassword"
+        return "Basic ${Base64Coder.encodeString(preEncodedAuthValue)}"
+    }
 }
 
 enum class GameSetting(

--- a/core/src/com/unciv/ui/popups/options/MultiplayerTab.kt
+++ b/core/src/com/unciv/ui/popups/options/MultiplayerTab.kt
@@ -282,12 +282,17 @@ private fun successfullyConnectedToServer(action: (Boolean, Boolean) -> Unit) {
 }
 
 private fun setPassword(password: String, optionsPopup: OptionsPopup) {
-    if (password.isNullOrBlank())
+    if (password.isBlank())
         return
 
     val popup = Popup(optionsPopup.stageToShowOn).apply {
         addGoodSizedLabel("Awaiting response...").row()
         open(true)
+    }
+
+    if (password.length < 6) {
+        popup.reuseWith("Password must be at least 6 characters long", true)
+        return
     }
 
     if (UncivGame.Current.onlineMultiplayer.serverFeatureSet.authVersion == 0) {


### PR DESCRIPTION
+ added min length (6) for passwords

Basic auth is [supposed](https://en.wikipedia.org/wiki/Basic_access_authentication) to base64 encode the whole userId:password string instead of encoding userId and password separately

@touhidurrr and @oynqr since you've already started implementing auth