### PR TITLE
Simplify method `TileMap.getTilesInRectangle`

### DIFF
--- a/core/src/com/unciv/logic/map/TileMap.kt
+++ b/core/src/com/unciv/logic/map/TileMap.kt
@@ -205,29 +205,17 @@ class TileMap : IsPartOfGameInfoSerialization {
                 }.filterNotNull()
 
     /** @return all tiles within [rectangle], respecting world edges and wrap.
-     *  If using row/column coordinates the rectangle will be "straight" ie parallel with rectangular map edges. */
-    fun getTilesInRectangle(rectangle: Rectangle, rowsAndColumns: Boolean = false): Sequence<Tile> =
-            if (rectangle.width <= 0 || rectangle.height <= 0) {
-                val tile = getIfTileExistsOrNull(rectangle.x.toInt(), rectangle.y.toInt())
-                if (tile == null) sequenceOf()
-                else sequenceOf(tile)
+     *  The rectangle will be "straight" ie parallel with rectangular map edges. */
+    fun getTilesInRectangle(rectangle: Rectangle) = sequence {
+            val x = rectangle.x.toInt()
+            val y = rectangle.y.toInt()
+            for (worldColumnNumber in x until x + rectangle.width.toInt()) {
+                for (worldRowNumber in y until y + rectangle.height.toInt()) {
+                    val hexCoords = HexMath.getTileCoordsFromColumnRow(worldColumnNumber, worldRowNumber)
+                    yield(getIfTileExistsOrNull(hexCoords.x.toInt(), hexCoords.y.toInt()))
+                }
             }
-            else
-                sequence {
-                    for (rectColumnNumber in 0 until rectangle.width.toInt()) {
-                        for (rectRowNumber in 0 until rectangle.height.toInt()) {
-                            val worldColumnNumber = rectangle.x.toInt() + rectColumnNumber
-                            val worldRowNumber = rectangle.y.toInt() + rectRowNumber
-
-                            if (rowsAndColumns) {
-                                val hexCoords = HexMath.getTileCoordsFromColumnRow(worldColumnNumber, worldRowNumber)
-                                yield(getIfTileExistsOrNull(hexCoords.x.toInt(), hexCoords.y.toInt()))
-                            }
-                            else
-                                yield(getIfTileExistsOrNull(worldColumnNumber, worldRowNumber))
-                        }
-                    }
-                }.filterNotNull()
+        }.filterNotNull()
 
     /** @return tile at hex coordinates ([x],[y]) or null if they are outside the map. Respects map edges and world wrap. */
     fun getIfTileExistsOrNull(x: Int, y: Int): Tile? {


### PR DESCRIPTION
This is more of a question - I came across said function and scratched my pate... Please don't merge without actually thinking about it.

- Why will that method treat any col/row rectangle with width ***or*** height zero as a one-tile degenerate rect - are 1x3 rects impossible??
- Those will not be col/row to TileMap coords translated no matter the `rowsAndColumns` param
- Said param no longer clearly documented - was better when Simon named it 'evenQ' - now param name and text diverge enough that one doubts
- The param is true in 6 of 7 call sites, and the seventh is clearly a mistake - in `MapRegions.placeLuxuries` when `isWaterOnlyResource`

The draft code does:
- Drop the second parameter and fix Kdoc accordingly
- Drop the 0/0 special case entirely thereby a) fixing `||` instead of `&&` and b) using `getTileCoordsFromColumnRow` even for 1x1 rectangles
- Therefore no longer guard against width < 0 or height < 0 - I don't see how current code could ever reach that
- Rest is readability only

So, this would potentially change behaviour, but demonstrating the difference or indeed a problem caused by the original 'mistakes' would be quite difficult.