### PR TITLE
Show terrain overriding yields in Civilopedia

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -1468,6 +1468,8 @@ Units: =
 Unit types = 
 Domain: [param] = 
 Toggle UI (World Screen only) = 
+Overrides yields from underlying terrain = 
+No yields = 
 
 # Policies
 

--- a/core/src/com/unciv/models/ruleset/tile/Terrain.kt
+++ b/core/src/com/unciv/models/ruleset/tile/Terrain.kt
@@ -74,9 +74,11 @@ class Terrain : RulesetStatsObject() {
         }
 
         val stats = cloneStats()
-        if (!stats.isEmpty()) {
+        if (!stats.isEmpty() || overrideStats) {
             textList += FormattedLine()
-            textList += FormattedLine("$stats")
+            textList += FormattedLine(if (stats.isEmpty()) "No yields" else "$stats")
+            if (overrideStats)
+                textList += FormattedLine("Overrides yields from underlying terrain")
         }
 
         if (occursOn.isNotEmpty() && !hasUnique(UniqueType.NoNaturalGeneration)) {


### PR DESCRIPTION
Resolves #8793, but _only_ the display portion - leaving TileStatFunctions cleanup for another PR (or, yes pelase, another author), as that requires much more thorough testing.

Note the extra for Ice - looked imo not satisfying with _only_ the "overrides" line - like this it's clearer ice cancels any underlying yields - might benefit some mods too.