### PR TITLE
Diplomacy trade layout fix

### DIFF
--- a/core/src/com/unciv/ui/screens/diplomacyscreen/DiplomacyScreen.kt
+++ b/core/src/com/unciv/ui/screens/diplomacyscreen/DiplomacyScreen.kt
@@ -944,8 +944,12 @@ class DiplomacyScreen(
         return goToOnMapButton
     }
 
-    /** Calculate a width for [TradeTable] two-column layout, called from [OfferColumnsTable] */
-    internal fun getTradeColumnsWidth() = (stage.width - leftSideScroll.width) / 2
+    /** Calculate a width for [TradeTable] two-column layout, called from [OfferColumnsTable]
+     *
+     *  _Caller is responsible to not exceed this **including its own padding**_
+     */
+    // Note breaking the rule above will squeeze the leftSideScroll to the left - cumulatively.
+    internal fun getTradeColumnsWidth() = (stage.width - leftSideScroll.width - 3f) / 2  // 3 for SplitPane handle
 
     override fun resize(width: Int, height: Int) {
         super.resize(width, height)

--- a/core/src/com/unciv/ui/screens/diplomacyscreen/OfferColumnsTable.kt
+++ b/core/src/com/unciv/ui/screens/diplomacyscreen/OfferColumnsTable.kt
@@ -59,7 +59,7 @@ class OfferColumnsTable(
 
         val isPortraitMode = screen.isNarrowerThan4to3()
 
-        val columnWidth = screen.getTradeColumnsWidth()
+        val columnWidth = screen.getTradeColumnsWidth() - 20f // Subtract padding: ours and OffersListScroll's
 
         if (!isPortraitMode) {
             // In landscape, arrange in 4 panels: ours left / theirs right ; items top / offers bottom.

--- a/core/src/com/unciv/ui/screens/diplomacyscreen/TradeTable.kt
+++ b/core/src/com/unciv/ui/screens/diplomacyscreen/TradeTable.kt
@@ -10,31 +10,33 @@ import com.unciv.ui.components.extensions.isEnabled
 import com.unciv.ui.components.extensions.onClick
 import com.unciv.ui.components.extensions.toTextButton
 
-class TradeTable(private val otherCivilization: Civilization, stage: DiplomacyScreen): Table(
-    BaseScreen.skin) {
-    val currentPlayerCiv = otherCivilization.gameInfo.getCurrentPlayerCivilization()
-    var tradeLogic = TradeLogic(currentPlayerCiv,otherCivilization)
-    var offerColumnsTable = OfferColumnsTable(tradeLogic, stage) { onChange() }
+class TradeTable(
+    private val otherCivilization: Civilization,
+    diplomacyScreen: DiplomacyScreen
+): Table(BaseScreen.skin) {
+    private val currentPlayerCiv = otherCivilization.gameInfo.getCurrentPlayerCivilization()
+    internal val tradeLogic = TradeLogic(currentPlayerCiv, otherCivilization)
+    internal val offerColumnsTable = OfferColumnsTable(tradeLogic, diplomacyScreen) { onChange() }
     // This is so that after a trade has been traded, we can switch out the offersToDisplay to start anew - this is the easiest way
-    private var offerColumnsTableWrapper = Table()
+    private val offerColumnsTableWrapper = Table()
     private val offerButton = "Offer trade".toTextButton()
 
     private fun isTradeOffered() = otherCivilization.tradeRequests.any { it.requestingCiv == currentPlayerCiv.civName }
 
-    private fun retractOffer(){
+    private fun retractOffer() {
         otherCivilization.tradeRequests.removeAll { it.requestingCiv == currentPlayerCiv.civName }
         currentPlayerCiv.cache.updateCivResources()
         offerButton.setText("Offer trade".tr())
     }
 
-    init{
+    init {
         offerColumnsTableWrapper.add(offerColumnsTable)
         add(offerColumnsTableWrapper).row()
 
         val lowerTable = Table().apply { defaults().pad(10f) }
 
         val existingOffer = otherCivilization.tradeRequests.firstOrNull { it.requestingCiv == currentPlayerCiv.civName }
-        if (existingOffer != null){
+        if (existingOffer != null) {
             tradeLogic.currentTrade.set(existingOffer.trade.reverse())
             offerColumnsTable.update()
         }
@@ -43,12 +45,12 @@ class TradeTable(private val otherCivilization: Civilization, stage: DiplomacySc
         else offerButton.apply { isEnabled = false }.setText("Offer trade".tr())
 
         offerButton.onClick {
-            if(isTradeOffered()) {
+            if (isTradeOffered()) {
                 retractOffer()
                 return@onClick
             }
 
-            otherCivilization.tradeRequests.add(TradeRequest(currentPlayerCiv.civName,tradeLogic.currentTrade.reverse()))
+            otherCivilization.tradeRequests.add(TradeRequest(currentPlayerCiv.civName, tradeLogic.currentTrade.reverse()))
             currentPlayerCiv.cache.updateCivResources()
             offerButton.setText("Retract offer".tr())
         }
@@ -61,7 +63,7 @@ class TradeTable(private val otherCivilization: Civilization, stage: DiplomacySc
         pack()
     }
 
-    private fun onChange(){
+    private fun onChange() {
         offerColumnsTable.update()
         retractOffer()
         offerButton.isEnabled = !(tradeLogic.currentTrade.theirOffers.size == 0 && tradeLogic.currentTrade.ourOffers.size == 0)


### PR DESCRIPTION
Fixes #8806

Notes
- Most of the diff is nitpicky linting - separate commits for easier reading
- The delta could have been done in 1 subtraction, but I wanted to keep the components closer to the source
- 3f for SplitPane handle width is hardcoded -
     `handleWidth = skin.get("default-horizontal", SplitPane.SplitPaneStyle::class.java).handle.minWidth`
    works but - complicated. <sub><sup>One day we should clean up Skin use a little (maybe all get's in BaseScreen, cached? Centralize the positive/negative thing which at the moment is chaos?)</sup></sub>