### PR TITLE
Make "Borderless" display option translatable

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -1383,6 +1383,7 @@ Screen Size =
 Screen Mode = 
 Windowed = 
 Fullscreen = 
+Borderless = 
 Tileset = 
 Unitset = 
 UI Skin = 


### PR DESCRIPTION
https://github.com/yairm210/Unciv/pull/8785 forgot to add "Borderless" to template.properties.

After:

![borderless_after](https://user-images.githubusercontent.com/11946570/222931951-8a211bfc-b5c2-4e57-b99d-b4313b1364d3.png)
