### PR TITLE
Fix ExploredRegion rectangular maps support + Zoomout flicker prevention reworked

### DIFF
--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -544,7 +544,7 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
             for (unit in civInfo.units.getCivUnits())
                 unit.updateVisibleTiles(false) // this needs to be done after all the units are assigned to their civs and all other transients are set
             if(civInfo.playerType == PlayerType.Human)
-                civInfo.exploredRegion.setMapParameters(tileMap.mapParameters.worldWrap, tileMap.mapParameters.mapSize.radius) // Required for the correct calculation of the explored region on world wrap maps
+                civInfo.exploredRegion.setMapParameters(tileMap.mapParameters) // Required for the correct calculation of the explored region on world wrap maps
             civInfo.cache.updateSightAndResources() // only run ONCE and not for each unit - this is a huge performance saver!
 
             // Since this depends on the cities of ALL civilizations,

--- a/core/src/com/unciv/logic/civilization/ExploredRegion.kt
+++ b/core/src/com/unciv/logic/civilization/ExploredRegion.kt
@@ -5,6 +5,8 @@ import com.unciv.logic.IsPartOfGameInfoSerialization
 import com.unciv.logic.map.HexMath.getLatitude
 import com.unciv.logic.map.HexMath.getLongitude
 import com.unciv.logic.map.HexMath.worldFromLatLong
+import com.unciv.logic.map.MapParameters
+import com.unciv.logic.map.MapShape
 import com.unciv.ui.components.tilegroups.TileGroupMap
 import kotlin.math.abs
 
@@ -54,10 +56,13 @@ class ExploredRegion () : IsPartOfGameInfoSerialization {
         return toReturn
     }
 
-    fun setMapParameters(worldWrap: Boolean, radius: Int)
-    {
-        isWorldWrap = worldWrap
-        mapRadius = radius.toFloat()
+    fun setMapParameters(mapParameters: MapParameters) {
+        isWorldWrap = mapParameters.worldWrap
+
+        if (mapParameters.shape == MapShape.rectangular)
+            mapRadius = (mapParameters.mapSize.width / 2).toFloat()
+        else
+            mapRadius = mapParameters.mapSize.radius.toFloat()
     }
 
     // Check if tilePosition is beyond explored region

--- a/core/src/com/unciv/ui/components/tilegroups/TileGroupMap.kt
+++ b/core/src/com/unciv/ui/components/tilegroups/TileGroupMap.kt
@@ -61,6 +61,8 @@ class TileGroupMap<T: TileGroup>(
     private var drawTopX = 0f
     private var drawBottomX = 0f
 
+    private var maxVisibleMapWidth = 0f
+
     init {
 
         for (tileGroup in tileGroups) {
@@ -141,6 +143,8 @@ class TileGroupMap<T: TileGroup>(
         else setSize(topX - bottomX, topY - bottomY)
 
         cullingArea = Rectangle(0f, 0f, width, height)
+
+        maxVisibleMapWidth = width - groupSize * 1.5f
     }
 
     /**
@@ -169,7 +173,7 @@ class TileGroupMap<T: TileGroup>(
 
         if (worldWrap) {
             // Prevent flickering when zoomed out so you can see entire map
-            val visibleMapWidth = if (mapHolder.width > width) width - groupSize * 1.75f
+            val visibleMapWidth = if (mapHolder.width > maxVisibleMapWidth) maxVisibleMapWidth
                 else mapHolder.width
 
             // Where is viewport's boundaries

--- a/core/src/com/unciv/ui/components/tilegroups/TileGroupMap.kt
+++ b/core/src/com/unciv/ui/components/tilegroups/TileGroupMap.kt
@@ -169,7 +169,7 @@ class TileGroupMap<T: TileGroup>(
 
         if (worldWrap) {
             // Prevent flickering when zoomed out so you can see entire map
-            val visibleMapWidth = if (mapHolder.width > width) width - groupSize * 1.5f
+            val visibleMapWidth = if (mapHolder.width > width) width - groupSize * 1.75f
                 else mapHolder.width
 
             // Where is viewport's boundaries


### PR DESCRIPTION
- ExploredRegion: Fixed mapRadius value for rectangular maps.
- Zoomout flicker prevention reworked: Sometimes I caught a zoom that was slightly smaller than the width of the map and flickering started. Fixed it + reduced the number of mathematical operations in the draw() loop😄