### PR TITLE
Fix city desert tiles with Petra selectable

### DIFF
--- a/core/src/com/unciv/ui/components/tilegroups/CityTileGroup.kt
+++ b/core/src/com/unciv/ui/components/tilegroups/CityTileGroup.kt
@@ -86,7 +86,7 @@ class CityTileGroup(val city: City, tile: Tile, tileSetStrings: TileSetStrings) 
             }
 
             // Does not provide yields
-            tile.stats.getTileStats(city.civ).isEmpty() -> {
+            tile.stats.getTileStats(city, city.civ).isEmpty() -> {
                 // Do nothing
             }
 


### PR DESCRIPTION
In other words, Fix for: cannot manually assign workers to tiles having _only_ yields from Petra or similar

Closes #8850 - The part under "UNRELATED"

