### PR TITLE
Future tech moddable

### DIFF
--- a/android/assets/jsons/Civ V - Gods & Kings/Techs.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Techs.json
@@ -648,8 +648,9 @@
 			{
 				"name": "Future Tech",
 				"row": 5,
-				"prerequisites": ["Globalization","Particle Physics", "Nuclear Fusion", "Nanotechnology", "Stealth"],
-				"uniques": ["Who knows what the future holds?", "Can be continually researched"],
+				"prerequisites": ["Globalization", "Particle Physics", "Nuclear Fusion", "Nanotechnology", "Stealth"],
+				"uniques": ["Who knows what the future holds?", "Can be continually researched",
+                    "Adds [10] points to your score each time it is researched"],
 				"quote": "'I think we agree, the past is over.' - George W. Bush"
 			}
 		]

--- a/android/assets/jsons/Civ V - Gods & Kings/Techs.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Techs.json
@@ -649,9 +649,10 @@
 				"name": "Future Tech",
 				"row": 5,
 				"prerequisites": ["Globalization", "Particle Physics", "Nuclear Fusion", "Nanotechnology", "Stealth"],
-				"uniques": ["Who knows what the future holds?", "Can be continually researched",
+				"uniques": ["Can be continually researched",
                     "Adds [10] points to your score each time it is researched"],
-				"quote": "'I think we agree, the past is over.' - George W. Bush"
+				"quote": "'I think we agree, the past is over.' - George W. Bush",
+                "civilopediaText":[{"text":"Who knows what the future holds?", "color":"#ffc0a0"}]
 			}
 		]
 	}

--- a/android/assets/jsons/Civ V - Vanilla/Techs.json
+++ b/android/assets/jsons/Civ V - Vanilla/Techs.json
@@ -615,9 +615,10 @@
 				"name": "Future Tech",
 				"row": 5,
 				"prerequisites": ["Globalization", "Nuclear Fusion", "Nanotechnology"],
-				"uniques": ["Who knows what the future holds?", "Can be continually researched",
+				"uniques": ["Can be continually researched",
                     "Adds [10] points to your score each time it is researched"],
-				"quote": "'I think we agree, the past is over.' - George W. Bush"
+				"quote": "'I think we agree, the past is over.' - George W. Bush",
+                "civilopediaText":[{"text":"Who knows what the future holds?", "color":"#ffc0a0"}]
 			}
 		]
 	}

--- a/android/assets/jsons/Civ V - Vanilla/Techs.json
+++ b/android/assets/jsons/Civ V - Vanilla/Techs.json
@@ -614,8 +614,9 @@
 			{
 				"name": "Future Tech",
 				"row": 5,
-				"prerequisites": ["Globalization","Nuclear Fusion", "Nanotechnology"],
-				"uniques": ["Who knows what the future holds?", "Can be continually researched"],
+				"prerequisites": ["Globalization", "Nuclear Fusion", "Nanotechnology"],
+				"uniques": ["Who knows what the future holds?", "Can be continually researched",
+                    "Adds [10] points to your score each time it is researched"],
 				"quote": "'I think we agree, the past is over.' - George W. Bush"
 			}
 		]

--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -579,6 +579,8 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
             if (civInfo.hasEverOwnedOriginalCapital == null) {
                 civInfo.hasEverOwnedOriginalCapital = civInfo.cities.any { it.isOriginalCapital }
             }
+
+            civInfo.tech.migrateRepeatableTechsResearched(ruleset)
         }
 
         spaceResources.clear()

--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -65,8 +65,9 @@ data class CompatibilityVersion(
 
 }
 
-data class VictoryData(val winningCiv:String, val victoryType:String, val victoryTurn:Int){
-    constructor(): this("","",0) // for serializer
+data class VictoryData(val winningCiv: String, val victoryType: String, val victoryTurn: Int) {
+    @Suppress("unused")  // used by json serialization
+    constructor(): this("","",0)
 }
 
 class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion {
@@ -407,7 +408,7 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
     }
 
     /** Generate a notification pointing out resources.
-     *  Used by [addTechnology][TechManager.addTechnology] and [ResourcesOverviewTab][com.unciv.ui.overviewscreen.ResourcesOverviewTab]
+     *  Used by [addTechnology][TechManager.addTechnology] and [ResourcesOverviewTab][com.unciv.ui.screens.overviewscreen.ResourcesOverviewTab]
      * @param maxDistance from next City, 0 removes distance limitation.
      * @param showForeign Disables filter to exclude foreign territory.
      * @return `false` if no resources were found and no notification was added.
@@ -535,12 +536,11 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
 
         convertFortify()
 
-        for (civInfo in sequence {
+        for (civInfo in civilizations.asSequence()
             // update city-state resource first since the happiness of major civ depends on it.
             // See issue: https://github.com/yairm210/Unciv/issues/7781
-            yieldAll(civilizations.filter { it.isCityState() })
-            yieldAll(civilizations.filter { !it.isCityState() })
-        }) {
+            .sortedByDescending { it.isCityState() }
+        ) {
             for (unit in civInfo.units.getCivUnits())
                 unit.updateVisibleTiles(false) // this needs to be done after all the units are assigned to their civs and all other transients are set
             if(civInfo.playerType == PlayerType.Human)

--- a/core/src/com/unciv/logic/civilization/Civilization.kt
+++ b/core/src/com/unciv/logic/civilization/Civilization.kt
@@ -594,7 +594,7 @@ class Civilization : IsPartOfGameInfoSerialization {
                 .filter { gameInfo.ruleset.buildings[it]!!.isWonder }.size
             }.toDouble()
         scoreBreakdown["Technologies"] = tech.getNumberOfTechsResearched() * 4.toDouble()
-        scoreBreakdown["Future Tech"] = tech.repeatingTechsResearched * 10.toDouble()
+        scoreBreakdown[Constants.futureTech] = tech.getRepeatableTechScore().toDouble()
 
         return scoreBreakdown
     }

--- a/core/src/com/unciv/logic/civilization/managers/RepeatableTechManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/RepeatableTechManager.kt
@@ -1,0 +1,75 @@
+package com.unciv.logic.civilization.managers
+
+import com.unciv.Constants
+import com.unciv.models.ruleset.Ruleset
+import com.unciv.models.ruleset.tech.Technology
+import com.unciv.models.ruleset.unique.UniqueType
+import com.unciv.ui.components.extensions.toPercent
+import kotlin.collections.HashMap
+
+interface RepeatableTechManager {
+    companion object {
+        private const val defaultScorePerTech = 10
+    }
+
+    data class RepeatableTechCounter(
+        val count: Int,
+        val cost: Int,
+        val score: Int
+    ) {
+        @Suppress("unused")  // for serialization
+        constructor() : this(1, 0, 0)
+    }
+    var repeatableTechs: HashMap<String, RepeatableTechCounter>
+
+    private data class RepeatableTechFactors(
+        val baseCost: Int,
+        val costIncrement: Int,
+        val costMultiplier: Float,
+        val scorePerTech: Int
+    )
+
+    private fun getTechFactors(tech: Technology): RepeatableTechFactors {
+        val costIncrement = tech.getMatchingUniques(UniqueType.ResearchableMultipleTimesCost)
+            .map { it.params[0].toInt() }
+            .sum()
+        val costMultiplier = tech.getMatchingUniques(UniqueType.ResearchableMultipleTimesCostPercent)
+            .map { it.params[0].toFloat() }
+            .sum().toPercent()
+        val scorePerTech = tech.getMatchingUniques(UniqueType.ResearchableMultipleTimesScore)
+            .map { it.params[0].toInt() }
+            // Allow fallback for older mods that lack the Unique
+            // At some point when all mods use the Unique - replace that fold() with sum()
+            .fold(null) { acc: Int?, value: Int -> (acc ?: 0) + value }
+            ?: defaultScorePerTech
+        return RepeatableTechFactors(tech.cost, costIncrement, costMultiplier, scorePerTech)
+    }
+
+    private fun calculateCounter(tech: Technology, count: Int): RepeatableTechCounter {
+        val factors = getTechFactors(tech)
+        val cost = (1..count).fold(factors.baseCost) { acc, _ ->
+            acc * factors.costMultiplier.toInt() + factors.costIncrement
+        }
+        return RepeatableTechCounter(count, cost, count * factors.scorePerTech)
+    }
+
+    fun incrementRepeatableTech(tech: Technology) {
+        val oldCount = repeatableTechs[tech.name]?.count ?: 0
+        repeatableTechs[tech.name] = calculateCounter(tech, 1 + oldCount)
+    }
+
+    fun getRepeatableTechScore() = repeatableTechs.values.sumOf { it.score }
+
+    fun costOfRepeatableTech(techName: String): Int? {
+        return repeatableTechs[techName]?.cost
+    }
+
+    @Suppress("DEPRECATION")
+    fun migrateRepeatableTechsResearched(ruleset: Ruleset) {
+        this as TechManager
+        if (repeatingTechsResearched == 0) return
+        val tech = ruleset.technologies[Constants.futureTech] ?: return
+        repeatableTechs[Constants.futureTech] = calculateCounter(tech, repeatingTechsResearched)
+        repeatingTechsResearched = 0
+    }
+}

--- a/core/src/com/unciv/logic/civilization/managers/TechManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/TechManager.kt
@@ -24,7 +24,6 @@ import com.unciv.models.ruleset.unit.BaseUnit
 import com.unciv.ui.components.MayaCalendar
 import com.unciv.ui.components.extensions.toPercent
 import com.unciv.ui.components.extensions.withItem
-import java.util.*
 import kotlin.math.ceil
 import kotlin.math.max
 import kotlin.math.min
@@ -160,13 +159,13 @@ class TechManager : RepeatableTechManager, IsPartOfGameInfoSerialization {
     //endregion
 
     fun getRequiredTechsToDestination(destinationTech: Technology): List<Technology> {
-        val prerequisites = Stack<Technology>()
+        val prerequisites = mutableListOf<Technology>()
 
         val checkPrerequisites = ArrayDeque<Technology>()
         checkPrerequisites.add(destinationTech)
 
         while (!checkPrerequisites.isEmpty()) {
-            val techToCheck = checkPrerequisites.pop()
+            val techToCheck = checkPrerequisites.removeFirst()
             // future tech can have been researched even when we're researching it,
             // so...if we skip it we'll end up with 0 techs in the "required techs", which will mean that we don't have anything to research. Yeah.
             if (!techToCheck.isContinuallyResearchable() &&

--- a/core/src/com/unciv/logic/civilization/managers/TechManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/TechManager.kt
@@ -256,6 +256,7 @@ class TechManager : IsPartOfGameInfoSerialization {
             techsToResearch.remove(techName)
         else
             repeatingTechsResearched++
+        techsInProgress.remove(techName)
         researchedTechnologies = researchedTechnologies.withItem(newTech)
         addTechToTransients(newTech)
 

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -275,7 +275,11 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
     StartingTech("Starting tech", UniqueTarget.Tech),
     StartsWithTech("Starts with [tech]", UniqueTarget.Nation),
     StartsWithPolicy("Starts with [policy] adopted", UniqueTarget.Nation),
-    ResearchableMultipleTimes("Can be continually researched", UniqueTarget.Global),
+
+    ResearchableMultipleTimes("Can be continually researched", UniqueTarget.Tech),
+    ResearchableMultipleTimesScore("Adds [amount] points to your score each time it is researched", UniqueTarget.Tech),
+    ResearchableMultipleTimesCost("Cost increases by [amount] each time it is researched", UniqueTarget.Tech),
+    ResearchableMultipleTimesCostPercent("Cost increases by [amount]% each time it is researched", UniqueTarget.Tech),
 
     BaseUnitSupply("[amount] Unit Supply", UniqueTarget.Global),
     UnitSupplyPerPop("[amount] Unit Supply per [amount] population [cityFilter]", UniqueTarget.Global),

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -685,9 +685,6 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 	Applicable to: Global, FollowerBelief
 
-??? example  "Can be continually researched"
-	Applicable to: Global
-
 ??? example  "[amount] Unit Supply"
 	Example: "[3] Unit Supply"
 
@@ -870,6 +867,24 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 ## Tech uniques
 ??? example  "Starting tech"
+	Applicable to: Tech
+
+??? example  "Can be continually researched"
+	Applicable to: Tech
+
+??? example  "Adds [amount] points to your score each time it is researched"
+	Example: "Adds [3] points to your score each time it is researched"
+
+	Applicable to: Tech
+
+??? example  "Cost increases by [amount] each time it is researched"
+	Example: "Cost increases by [3] each time it is researched"
+
+	Applicable to: Tech
+
+??? example  "Cost increases by [amount]% each time it is researched"
+	Example: "Cost increases by [3]% each time it is researched"
+
 	Applicable to: Tech
 
 ??? example  "Only available"


### PR DESCRIPTION
In case the answer to the second question in #8864 is yes...

If it's no (which I'd fully understand) then the ["fix"](https://github.com/yairm210/Unciv/commit/27833dfb0a2e7ae14959e9a29a2d3e8fdfcdd7fa), ["lint"](https://github.com/yairm210/Unciv/commit/0455e5891e3663d54e11d141b9b45e0c47d8e276) and ["kotlinify"](https://github.com/yairm210/Unciv/commit/66a982a9c68b1d1cd5494dfba9255cb300b7ac81) commits might still be interesting.

The [Move "who knows" decoration](https://github.com/yairm210/Unciv/commit/add3db26a147e8c7017707c5ac82e1a54276aa27)  commit looks like <details><summary>this:</summary>

![image](https://user-images.githubusercontent.com/63000004/224500775-ac7e45bf-d1e4-4106-9762-b3ee579bf0c6.png)
</details>
... and has the side effect Future Tech gets a Star icon less (compensating the additional one for the score unique), and the text won't appear on the picker screen's bottom pane.