### PR TITLE
Change serializer to make migrateBarbarianCamps unnecessary

### DIFF
--- a/core/src/com/unciv/logic/BackwardCompatibility.kt
+++ b/core/src/com/unciv/logic/BackwardCompatibility.kt
@@ -1,9 +1,5 @@
 package com.unciv.logic
 
-import com.badlogic.gdx.math.Vector2
-import com.badlogic.gdx.utils.JsonValue
-import com.unciv.json.HashMapVector2
-import com.unciv.json.json
 import com.unciv.logic.city.CityConstructions
 import com.unciv.logic.city.PerpetualConstruction
 import com.unciv.logic.civilization.diplomacy.DiplomacyFlags
@@ -79,6 +75,7 @@ object BackwardCompatibility {
      * Replaces all occurrences of [oldBuildingName] in [cityConstructions] with [newBuildingName]
      * if the former is not contained in the ruleset.
      */
+    @Suppress("SameParameterValue")  // This helper will often have only one use with literal names, but supports any
     private fun changeBuildingNameIfNotInRuleset(
         ruleSet: Ruleset,
         cityConstructions: CityConstructions,
@@ -152,28 +149,6 @@ object BackwardCompatibility {
         }
     }
 
-    /**
-     * Fixes barbarian manager camps not being correctly serialized. Previously we had a [HashMap<Vector2, Encampment] but it was being
-     * serialized as [HashMap<String, Encampment>]. We need to fix that each time an old save is loaded.
-     *
-     * When removing this, also remove [com.unciv.json.NonStringKeyMapSerializer.readOldFormat]
-     */
-    @Suppress("DEPRECATION")
-    fun BarbarianManager.migrateBarbarianCamps() {
-        if (isOldFormat(this)) {
-            val newFormat = HashMapVector2<Encampment>()
-            @Suppress("UNCHECKED_CAST") // The old format is deserialized to a <String, JsonValue> map
-            for ((key, value) in camps as MutableMap<String, JsonValue>) {
-                val newKey = Vector2().fromString(key)
-                val newValue = json().readValue(Encampment::class.java, value)
-                newFormat[newKey] = newValue
-            }
-
-            camps.clear()
-            camps.putAll(newFormat)
-        }
-    }
-
     /** Convert from Fortify X to Fortify and save off X */
     fun GameInfo.convertFortify() {
         val reg = Regex("""^Fortify\s+(\d+)([\w\s]*)""")
@@ -186,18 +161,6 @@ object BackwardCompatibility {
                 }
             }
         }
-    }
-
-    private fun isOldFormat(manager: BarbarianManager): Boolean {
-        val keys = manager.camps.keys as Set<Any>
-        val iterator = keys.iterator()
-        while (iterator.hasNext()) {
-            val key = iterator.next()
-            if (key is String) {
-                return true
-            }
-        }
-        return false
     }
 
     @Suppress("DEPRECATION")

--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -6,7 +6,6 @@ import com.unciv.UncivGame.Version
 import com.unciv.logic.BackwardCompatibility.convertFortify
 import com.unciv.logic.BackwardCompatibility.convertOldGameSpeed
 import com.unciv.logic.BackwardCompatibility.guaranteeUnitPromotions
-import com.unciv.logic.BackwardCompatibility.migrateBarbarianCamps
 import com.unciv.logic.BackwardCompatibility.migrateToTileHistory
 import com.unciv.logic.BackwardCompatibility.removeMissingModReferences
 import com.unciv.logic.GameInfo.Companion.CURRENT_COMPATIBILITY_NUMBER
@@ -67,7 +66,8 @@ data class CompatibilityVersion(
 }
 
 data class VictoryData(val winningCiv:String, val victoryType:String, val victoryTurn:Int){
-    constructor(): this("","",0) // for serializer
+    @Suppress("unused") // for serializer
+    constructor(): this("","",0)
 }
 
 class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion {
@@ -420,7 +420,7 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
     }
 
     /** Generate a notification pointing out resources.
-     *  Used by [addTechnology][TechManager.addTechnology] and [ResourcesOverviewTab][com.unciv.ui.overviewscreen.ResourcesOverviewTab]
+     *  Used by [addTechnology][TechManager.addTechnology] and [ResourcesOverviewTab][com.unciv.ui.screens.overviewscreen.ResourcesOverviewTab]
      * @param maxDistance from next City, 0 removes distance limitation.
      * @param showForeign Disables filter to exclude foreign territory.
      * @return `false` if no resources were found and no notification was added.
@@ -494,7 +494,6 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
             gameParameters.baseRuleset = baseRulesetInMods
             gameParameters.mods = LinkedHashSet(gameParameters.mods.filter { it != baseRulesetInMods })
         }
-        barbarians.migrateBarbarianCamps()
 
         ruleset = RulesetCache.getComplexRuleset(gameParameters)
 


### PR DESCRIPTION
I horsed around with NonStringKeyMapSerializer and had a version that still did the job but was _much_ simpler - but it relied on `out` variance and needed one `@UnsafeVariance` - not pretty, so I ditched it.

But one aspect remained: that 'old' code tried to deal with Gdx Json creating invalid objects in memory by - creating the same invalid objects in memory. Just so the conversion String to original key type can be done later... That irked me - why replicate buggy code one on one just so one can graft a check and alternate path onto it?

So - see diff.
Effectively we're exchanging one `@Suppress("UNCHECKED_CAST")` for another - with the difference that before, we _knew_ the cast was illegal, while now we have _checked_ the cast is valid.

Note this _will_ still read "old" saves that would have run the migrateBarbarianCamps loop just fine.