### PR TITLE
Fix SelectBox ScrollPane being transparent

### DIFF
--- a/android/assets/Skin.json
+++ b/android/assets/Skin.json
@@ -1,313 +1,322 @@
 {
-    com.badlogic.gdx.graphics.g2d.BitmapFont: {
-        button: "Nativefont"
-        font: "Nativefont"
-        title: "Nativefont"
-    }
-    com.badlogic.gdx.graphics.Color: {
-        black: {
-            r: 0
-            g: 0
-            b: 0
-            a: 1
+    "com.badlogic.gdx.graphics.g2d.BitmapFont": {
+        "button": "Nativefont",
+        "font": "Nativefont",
+        "title": "Nativefont"
+    },
+    "com.badlogic.gdx.graphics.Color": {
+        "black": {
+            "r": 0,
+            "g": 0,
+            "b": 0,
+            "a": 1
+        },
+        "color": {
+            "r": 0.2,
+            "g": 0.3,
+            "b": 0.5,
+            "a": 1
+        },
+        "gray": {
+            "r": 0.5,
+            "g": 0.5,
+            "b": 0.5,
+            "a": 1
+        },
+        "dark-gray": {
+            "r": 0.25,
+            "g": 0.25,
+            "b": 0.25,
+            "a": 1
+        },
+        "disabled": {
+            "r": 0.14509805,
+            "g": 0.16862746,
+            "b": 0.24313726,
+            "a": 1
+        },
+        "highlight": {
+            "r": 0.39607844,
+            "g": 0.8627451,
+            "b": 0.44705883,
+            "a": 1
+        },
+        "pressed": {
+            "r": 0.2529412,
+            "g": 0.6,
+            "b": 0.33313715,
+            "a": 1
+        },
+        "selection": {
+            "r": 0.22745098,
+            "g": 0.59607846,
+            "b": 0.85882354,
+            "a": 1
+        },
+        "white": {
+            "r": 1,
+            "g": 1,
+            "b": 1,
+            "a": 1
+        },
+        "positive": {
+            "r": 0.12156863,
+            "g": 0.49411765,
+            "b": 0.21960784,
+            "a": 1
+        },
+        "negative": {
+            "r": 0.5529412,
+            "g": 0.03137255,
+            "b": 0.0,
+            "a": 1
+        },
+        "negative-highlight": {
+            "r": 0.8666667,
+            "g": 0.078431375,
+            "b": 0.050980393,
+            "a": 1
+        },
+        "negative-selected": {
+            "r": 0.7764706,
+            "g": 0.0627451,
+            "b": 0.039215688,
+            "a": 1
         }
-        color: {
-            r: 0.2
-            g: 0.3
-            b: 0.5
-            a: 1
+    },
+    "com.badlogic.gdx.scenes.scene2d.ui.Skin$TintedDrawable": {
+        "button-c": {
+            "name": "RoundedEdgeRectangle",
+            "color": "color"
+        },
+        "button-p": {
+            "name": "RoundedEdgeRectangle",
+            "color": "pressed"
+        },
+        "button-h": {
+            "name": "RoundedEdgeRectangle",
+            "color": "highlight"
+        },
+        "button-disabled": {
+            "name": "RoundedEdgeRectangle",
+            "color": "disabled"
+        },
+        "button-positive": {
+            "name": "RoundedEdgeRectangle",
+            "color": "positive"
+        },
+        "button-negative": {
+            "name": "RoundedEdgeRectangle",
+            "color": "negative"
+        },
+        "button-negative-pressed": {
+            "name": "RoundedEdgeRectangle",
+            "color": "negative-selected"
+        },
+        "button-negative-hover": {
+            "name": "RoundedEdgeRectangle",
+            "color": "negative-highlight"
+        },
+        "checkbox-c": {
+            "name": "Checkbox",
+            "color": "color"
+        },
+        "checkbox-pressed-c": {
+            "name": "Checkbox-pressed",
+            "color": "color"
+        },
+        "list-c": {
+            "name": "RectangleWithOutline",
+            "color": "color"
+        },
+        "scrollbar-c": {
+            "name": "Scrollbar",
+            "color": "color"
+        },
+        "select-box-c": {
+            "name": "Select-box",
+            "color": "color"
+        },
+        "select-box-pressed-c": {
+            "name": "Select-box-pressed",
+            "color": "color"
+        },
+        "select-box-h": {
+            "name": "Select-box",
+            "color": "highlight"
+        },
+        "select-box-scroll-bg-c": {
+            "name": "Scrollbar",
+            "color": "default-clear"
+        },
+        "slider-knob-c": {
+            "name": "Circle",
+            "color": "color"
+        },
+        "slider-horizontal-s": {
+            "name": "Rectangle",
+            "color": "selection"
+        },
+        "slider-vertical-s": {
+            "name": "Rectangle",
+            "color": "selection"
+        },
+        "slider-knob-h": {
+            "name": "Circle",
+            "color": "highlight"
+        },
+        "slider-horizontal-p": {
+            "name": "Rectangle",
+            "color": "pressed"
+        },
+        "slider-vertical-p": {
+            "name": "Rectangle",
+            "color": "pressed"
+        },
+        "splitpane-horizontal-c": {
+            "name": "RectangleWithOutline",
+            "color": "color"
+        },
+        "splitpane-vertical-c": {
+            "name": "RectangleWithOutline",
+            "color": "color"
+        },
+        "textfield-c": {
+            "name": "RoundedEdgeRectangle",
+            "color": "color"
+        },
+        "selection": {
+            "name": "Rectangle",
+            "color": "selection"
+        },
+        "white": {
+            "name": "Rectangle",
+            "color": "white"
         }
-        gray: {
-            r: 0.5
-            g: 0.5
-            b: 0.5
-            a: 1
+    },
+    "com.badlogic.gdx.scenes.scene2d.ui.Button$ButtonStyle": {
+        "default": {
+            "up": "button-c",
+            "down": "button-p",
+            "over": "button-h"
         }
-        dark-gray: {
-            a: 1.0,
-            b: 0.25,
-            g: 0.25,
-            r: 0.25
+    },
+    "com.badlogic.gdx.scenes.scene2d.ui.CheckBox$CheckBoxStyle": {
+        "default": {
+            "checkboxOn": "checkbox-pressed-c",
+            "checkboxOff": "checkbox-c",
+            "font": "button",
+            "fontColor": "color",
+            "downFontColor": "pressed",
+            "overFontColor": "highlight"
         }
-        disabled: {
-            a: 1.0,
-            b: 0.24313726,
-            g: 0.16862746,
-            r: 0.14509805
+    },
+    "com.badlogic.gdx.scenes.scene2d.ui.Label$LabelStyle": {
+        "default": {
+            "font": "font",
+            "fontColor": "color"
         }
-        highlight: {
-            a: 1.0,
-            b: 0.44705883,
-            g: 0.8627451,
-            r: 0.39607844
+    },
+    "com.badlogic.gdx.scenes.scene2d.ui.List$ListStyle": {
+        "default": {
+            "font": "font",
+            "fontColorSelected": "white",
+            "fontColorUnselected": "white",
+            "selection": "selection",
+            "background": "list-c"
         }
-        pressed: {
-            r: 0.2529412
-            g: 0.6
-            b: 0.33313715
-            a: 1
+    },
+    "com.badlogic.gdx.scenes.scene2d.ui.ScrollPane$ScrollPaneStyle": {
+        "default": {
+            "hScrollKnob": "scrollbar-c",
+            "vScrollKnob": "scrollbar-c"
+        },
+        "select-box-scroll": {
+            "background": "select-box-scroll-bg-c",
+            "hScrollKnob": "scrollbar-c",
+            "vScrollKnob": "scrollbar-c"
         }
-        selection: {
-            r: 0.22745098
-            g: 0.59607846
-            b: 0.85882354
-            a: 1
+    },
+    "com.badlogic.gdx.scenes.scene2d.ui.SelectBox$SelectBoxStyle": {
+        "default": {
+            "font": "font",
+            "fontColor": "white",
+            "background": "select-box-c",
+            "scrollStyle": "select-box-scroll",
+            "listStyle": "default",
+            "backgroundOver": "select-box-h",
+            "backgroundOpen": "select-box-pressed-c"
         }
-        white: {
-            r: 1
-            g: 1
-            b: 1
-            a: 1
+    },
+    "com.badlogic.gdx.scenes.scene2d.ui.Slider$SliderStyle": {
+        "default-horizontal": {
+            "knobOver": "slider-knob-h",
+            "knobDown": "slider-knob-h",
+            "background": "slider-horizontal-p",
+            "knob": "slider-knob-c",
+            "knobBefore": "slider-horizontal-s"
+        },
+        "default-vertical": {
+            "knobOver": "slider-knob-h",
+            "knobDown": "slider-knob-h",
+            "background": "slider-vertical-p",
+            "knob": "slider-knob-c",
+            "knobBefore": "slider-vertical-s"
         }
-        positive: {
-            a: 1.0,
-            b: 0.21960784,
-            g: 0.49411765,
-            r: 0.12156863
+    },
+    "com.badlogic.gdx.scenes.scene2d.ui.SplitPane$SplitPaneStyle": {
+        "default-horizontal": {
+            "handle": "splitpane-horizontal-c"
+        },
+        "default-vertical": {
+            "handle": "splitpane-vertical-c"
         }
-        negative: {
-            a: 1.0,
-            b: 0.0,
-            g: 0.03137255,
-            r: 0.5529412
+    },
+    "com.badlogic.gdx.scenes.scene2d.ui.TextButton$TextButtonStyle": {
+        "default": {
+            "font": "button",
+            "fontColor": "white",
+            "downFontColor": "white",
+            "overFontColor": "dark-gray",
+            "up": "button-c",
+            "down": "button-p",
+            "over": "button-h"
+        },
+        "positive": {
+            "font": "button",
+            "fontColor": "white",
+            "downFontColor": "white",
+            "overFontColor": "dark-gray",
+            "up": "button-positive",
+            "down": "button-p",
+            "over": "button-h"
+        },
+        "negative": {
+            "font": "button",
+            "fontColor": "white",
+            "downFontColor": "white",
+            "overFontColor": "white",
+            "up": "button-negative",
+            "down": "button-negative-pressed",
+            "over": "button-negative-hover"
+        },
+        "disabled": {
+            "font": "button",
+            "fontColor": "white",
+            "downFontColor": "white",
+            "overFontColor": "white",
+            "up": "button-disabled",
+            "down": "button-disabled",
+            "over": "button-disabled"
         }
-        negative-highlight: {
-            a: 1.0,
-            b: 0.050980393,
-            g: 0.078431375,
-            r: 0.8666667
-        }
-        negative-selected: {
-            a: 1.0,
-            b: 0.039215688,
-            g: 0.0627451,
-            r: 0.7764706
-        }
-    }
-    com.badlogic.gdx.scenes.scene2d.ui.Skin$TintedDrawable: {
-        button-c: {
-            name: "RoundedEdgeRectangle"
-            color: color
-        }
-        button-p: {
-            name: "RoundedEdgeRectangle"
-            color: pressed
-        }
-        button-h: {
-            name: "RoundedEdgeRectangle"
-            color: highlight
-        }
-        button-disabled: {
-            name: "RoundedEdgeRectangle"
-            color: disabled
-        }
-        button-positive: {
-            name: "RoundedEdgeRectangle"
-            color: positive
-        }
-        button-negative: {
-            name: "RoundedEdgeRectangle"
-            color: negative
-        }
-        button-negative-pressed: {
-            name: "RoundedEdgeRectangle"
-            color: negative-selected
-        }
-        button-negative-hover: {
-            name: "RoundedEdgeRectangle"
-            color: negative-highlight
-        }
-        checkbox-c: {
-            name: "Checkbox"
-            color: color
-        }
-        checkbox-pressed-c: {
-            name: "Checkbox-pressed"
-            color: color
-        }
-        list-c: {
-            name: "RectangleWithOutline"
-            color: color
-        }
-        scrollbar-c: {
-            name: "Scrollbar"
-            color: color
-        }
-        select-box-c: {
-            name: "Select-box"
-            color: color
-        }
-        select-box-pressed-c: {
-            name: "Select-box-pressed"
-            color: color
-        }
-        select-box-h: {
-            name: "Select-box"
-            color: highlight
-        }
-        slider-knob-c: {
-            name: "Circle"
-            color: color
-        }
-        slider-horizontal-s: {
-            name: "Rectangle"
-            color: selection
-        }
-        slider-vertical-s: {
-            name: "Rectangle"
-            color: selection
-        }
-        slider-knob-h: {
-            name: "Circle"
-            color: highlight
-        }
-        slider-horizontal-p: {
-            name: "Rectangle"
-            color: pressed
-        }
-        slider-vertical-p: {
-            name: "Rectangle"
-            color: pressed
-        }
-        splitpane-horizontal-c: {
-            name: "RectangleWithOutline"
-            color: color
-        }
-        splitpane-vertical-c: {
-            name: "RectangleWithOutline"
-            color: color
-        }
-        textfield-c: {
-            name: "RoundedEdgeRectangle"
-            color: color
-        }
-        selection: {
-            name: "Rectangle"
-            color: selection
-        }
-        white: {
-            name: "Rectangle"
-            color: white
-        }
-    }
-    com.badlogic.gdx.scenes.scene2d.ui.Button$ButtonStyle: {
-        default: {
-            up: button-c
-            down: button-p
-            over: button-h
-        }
-    }
-    com.badlogic.gdx.scenes.scene2d.ui.CheckBox$CheckBoxStyle: {
-        default: {
-            checkboxOn: checkbox-pressed-c
-            checkboxOff: checkbox-c
-            font: button
-            fontColor: color
-            downFontColor: pressed
-            overFontColor: highlight
-        }
-    }
-    com.badlogic.gdx.scenes.scene2d.ui.Label$LabelStyle: {
-        default: {
-            font: font
-            fontColor: color
-        }
-    }
-    com.badlogic.gdx.scenes.scene2d.ui.List$ListStyle: {
-        default: {
-            font: font
-            fontColorSelected: white
-            fontColorUnselected: white
-            selection: selection
-            background: list-c
-        }
-    }
-    com.badlogic.gdx.scenes.scene2d.ui.ScrollPane$ScrollPaneStyle: {
-        default: {
-            hScrollKnob: scrollbar-c
-            vScrollKnob: scrollbar-c
-        }
-    }
-    com.badlogic.gdx.scenes.scene2d.ui.SelectBox$SelectBoxStyle: {
-        default: {
-            font: font
-            fontColor: white
-            background: select-box-c
-            scrollStyle: default
-            listStyle: default
-            backgroundOver: select-box-h
-            backgroundOpen: select-box-pressed-c
-        }
-    }
-    com.badlogic.gdx.scenes.scene2d.ui.Slider$SliderStyle: {
-        default-horizontal: {
-            knobOver: slider-knob-h
-            knobDown: slider-knob-h
-            background: slider-horizontal-p
-            knob: slider-knob-c
-            knobBefore: slider-horizontal-s
-        }
-        default-vertical: {
-            knobOver: slider-knob-h
-            knobDown: slider-knob-h
-            background: slider-vertical-p
-            knob: slider-knob-c
-            knobBefore: slider-vertical-s
-        }
-    }
-    com.badlogic.gdx.scenes.scene2d.ui.SplitPane$SplitPaneStyle: {
-        default-horizontal: {
-            handle: splitpane-horizontal-c
-        }
-        default-vertical: {
-            handle: splitpane-vertical-c
-        }
-    }
-    com.badlogic.gdx.scenes.scene2d.ui.TextButton$TextButtonStyle: {
-        default: {
-            font: button
-            fontColor: white
-            downFontColor: white
-            overFontColor: dark-gray
-            up: button-c
-            down: button-p
-            over: button-h
-        }
-        positive: {
-            font: button
-            fontColor: white
-            downFontColor: white
-            overFontColor: dark-gray
-            up: button-positive
-            down: button-p
-            over: button-h
-        }
-        negative: {
-            font: button
-            fontColor: white
-            downFontColor: white
-            overFontColor: white
-            up: button-negative
-            down: button-negative-pressed
-            over: button-negative-hover
-        }
-        disabled: {
-            font: button
-            fontColor: white
-            downFontColor: white
-            overFontColor: white
-            up: button-disabled
-            down: button-disabled
-            over: button-disabled
-        }
-    }
-    com.badlogic.gdx.scenes.scene2d.ui.TextField$TextFieldStyle: {
-        default: {
-            font: font
-            fontColor: white
-            background: textfield-c
-            cursor: white
-            selection: selection
+    },
+    "com.badlogic.gdx.scenes.scene2d.ui.TextField$TextFieldStyle": {
+        "default": {
+            "font": "font",
+            "fontColor": "white",
+            "background": "textfield-c",
+            "cursor": "white",
+            "selection": "selection"
         }
     }
 }

--- a/core/src/com/unciv/ui/screens/basescreen/BaseScreen.kt
+++ b/core/src/com/unciv/ui/screens/basescreen/BaseScreen.kt
@@ -117,10 +117,12 @@ abstract class BaseScreen : Screen {
 
         lateinit var skin: Skin
         lateinit var skinStrings: SkinStrings
+
         fun setSkin() {
             Fonts.resetFont()
             skinStrings = SkinStrings()
             skin = Skin().apply {
+                add("default-clear", clearColor, Color::class.java)
                 add("Nativefont", Fonts.font, BitmapFont::class.java)
                 add("RoundedEdgeRectangle", skinStrings.getUiBackground("", skinStrings.roundedEdgeRectangleShape), Drawable::class.java)
                 add("Rectangle", ImageGetter.getDrawable(""), Drawable::class.java)


### PR DESCRIPTION
...and make Skin.json conform to JSON standard

To _see_ how that missing background doesn't look too sexy, at the moment one would need to fetch a s*tload of base ruleset mods, possibly more than exist (know of no other SelectBox of dynamic entry count). With the next KeyBinding UI that's gonna change.

This makes `BaseScreen.clearColor` available for use in `Skin.json` through code, as that looks best as SelectBox scrollbar background IMO. One could just as well do it the other way round and declare the json master and pull the var from it instead of hardcoding that as Color(0,0,0.2)...

Note: Gave in to the temptation to JSON-ify that file partially because of the inconsistencies. No commas at all or standard-conform but not mixed please, and rgba or abgr order but not both in use please...