### PR TITLE
Key bindings Step 3 - Better UI

### DIFF
--- a/android/assets/jsons/Tutorials.json
+++ b/android/assets/jsons/Tutorials.json
@@ -401,16 +401,15 @@
             {"text":"Currently, there are no checks to prevent conflicting assignments.","starred":true},
             {},
             {"text":"Using the Keys page","header":3},
-            {"text":"Each binding has a label, a text field, and a key button looking like this:"},
+            {"text":"Each binding has a label, a dropdown select, and a key button looking like this:"},
             {"extraImage":"OtherIcons/Keyboard","imageSize":36},
             {"text":"While hovering the mouse over the key button, you can press a desired key directly to assign it."},
-            {"text":"Alternatively, you can enter the key's name in the text field."},
-            {"text":"To reset a binding to its default, simply clear the text field."},
+            {"text":"Alternatively, you can select the key in the dropdown."},
             {},
             {"text":"Bindings mapped to their default keys are displayed in gray, those reassigned by you in white."},
             {},
             {"text":"For discussion about missing entries, see the linked github issue.","link":"https://github.com/yairm210/Unciv/issues/8862"}
-        ],
+        ]
         // "uniques": ["Will not be displayed in Civilopedia"] // would prevent use for help link
     }
 ]

--- a/core/src/com/unciv/ui/components/KeyCapturingButton.kt
+++ b/core/src/com/unciv/ui/components/KeyCapturingButton.kt
@@ -1,0 +1,69 @@
+package com.unciv.ui.components
+
+import com.badlogic.gdx.Input
+import com.badlogic.gdx.graphics.Color
+import com.badlogic.gdx.scenes.scene2d.Actor
+import com.badlogic.gdx.scenes.scene2d.InputEvent
+import com.badlogic.gdx.scenes.scene2d.ui.ImageButton
+import com.badlogic.gdx.scenes.scene2d.utils.ClickListener
+import com.badlogic.gdx.utils.Align
+import com.unciv.ui.components.UncivTooltip.Companion.addTooltip
+import com.unciv.ui.images.ImageGetter
+
+/** A button that captures keyboard keys and reports them through [onKeyHit] */
+class KeyCapturingButton(
+    private val onKeyHit: (keyCode: Int, control: Boolean) -> Unit
+) : ImageButton(getStyle()) {
+    companion object {
+        private const val buttonSize = 36f
+        private const val buttonImage = "OtherIcons/Keyboard"
+        private val controlKeys = setOf(Input.Keys.CONTROL_LEFT, Input.Keys.CONTROL_RIGHT)
+
+        private fun getStyle() = ImageButtonStyle().apply {
+            val image = ImageGetter.getDrawable(buttonImage)
+            imageUp = image
+            imageOver = image.tint(Color.LIME)
+        }
+    }
+
+    private var savedFocus: Actor? = null
+
+    init {
+        setSize(buttonSize, buttonSize)
+        addTooltip("Hit the desired key now", 18f, targetAlign = Align.bottomRight)
+        addListener(ButtonListener(this))
+    }
+
+    private class ButtonListener(private val myButton: KeyCapturingButton) : ClickListener() {
+        private var controlDown = false
+
+        override fun enter(event: InputEvent?, x: Float, y: Float, pointer: Int, fromActor: Actor?) {
+            if (myButton.stage == null) return
+            myButton.savedFocus = myButton.stage.keyboardFocus
+            myButton.stage.keyboardFocus = myButton
+        }
+
+        override fun exit(event: InputEvent?, x: Float, y: Float, pointer: Int, toActor: Actor?) {
+            if (myButton.stage == null) return
+            myButton.stage.keyboardFocus = myButton.savedFocus
+            myButton.savedFocus = null
+        }
+
+        override fun keyDown(event: InputEvent?, keycode: Int): Boolean {
+            if (keycode == Input.Keys.ESCAPE) return false
+            if (keycode in controlKeys) {
+                controlDown = true
+            } else {
+                myButton.onKeyHit(keycode, controlDown)
+            }
+            return true
+        }
+
+        override fun keyUp(event: InputEvent?, keycode: Int): Boolean {
+            if (keycode == Input.Keys.ESCAPE) return false
+            if (keycode in controlKeys)
+                controlDown = false
+            return true
+        }
+    }
+}

--- a/core/src/com/unciv/ui/components/KeysSelectBox.kt
+++ b/core/src/com/unciv/ui/components/KeysSelectBox.kt
@@ -1,0 +1,140 @@
+package com.unciv.ui.components
+
+import com.badlogic.gdx.Input
+import com.badlogic.gdx.graphics.Color
+import com.badlogic.gdx.scenes.scene2d.Actor
+import com.badlogic.gdx.scenes.scene2d.ui.SelectBox
+import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener
+import com.unciv.models.translations.tr
+import com.unciv.ui.screens.basescreen.BaseScreen
+import com.badlogic.gdx.utils.Array as GdxArray
+
+
+/**
+ *  A Widget to allow selecting keys from a [SelectBox].
+ *
+ *  Added value:
+ *  *  Easier change callback as direct [changeCallback] parameter
+ *  *  Pulls existing keys from Gdx.[Input.Keys] with an exclusion parameter
+ *  *  Key names made translatable as e.g. `Key-"A"` or `Key-Space`
+ *  *  Supports TranslationFileWriter by providing those translation keys
+ */
+// Note this has similarities with TranslatedSelectBox, but having entries in the translation
+// files that consist only of a punctuation character wouldn't be pretty
+class KeysSelectBox(
+    private val default: String = "",
+    excludeKeys: Set<Int> = defaultExclusions,
+    private val changeCallback: (() -> Unit)? = null
+) : SelectBox<KeysSelectBox.KeysSelectBoxEntry>(BaseScreen.skin) {
+
+    class KeysSelectBoxEntry(val name: String) {
+        val translation = run {
+            val translationKey = getTranslationKey(name)
+            val translation = translationKey.tr()
+            if (translation == translationKey) name else translation
+        }
+
+        override fun toString() = translation
+        override fun equals(other: Any?) = other is KeysSelectBoxEntry && other.name == this.name
+        override fun hashCode() = name.hashCode()
+    }
+
+    companion object {
+        // Gdx.Input.Keys has a keyNames map internally that would serve,
+        // but it's private and only used for valueOf() - So we do the same here...
+        private val keyCodeMap = LinkedHashMap<String, Int>(200).apply {
+            for (code in 0..Input.Keys.MAX_KEYCODE) {
+                val name = Input.Keys.toString(code) ?: continue
+                put(name, code)
+            }
+        }
+
+        val defaultExclusions = setOf(
+            Input.Keys.UNKNOWN,         // Any key GLFW or Gdx fail to translate fire this - and we assign our own meaning
+            Input.Keys.ESCAPE,          // Married to Android Back, we want to keep this closing the Options
+            Input.Keys.CONTROL_LEFT,    // Captured to support control-letter combos
+            Input.Keys.CONTROL_RIGHT,
+            Input.Keys.PICTSYMBOLS,     // Ugly toString and unknown who could have such a key
+            Input.Keys.SWITCH_CHARSET,
+            Input.Keys.SYM,
+            Input.Keys.PRINT_SCREEN,    // Not captured by Gdx by default, these are handled by the OS
+            Input.Keys.VOLUME_UP,
+            Input.Keys.VOLUME_DOWN,
+            Input.Keys.MUTE,
+        )
+
+        fun getKeyNames(excludeKeys: Set<Int>): Sequence<String> {
+            val keyCodeNames = keyCodeMap.asSequence()
+                .filterNot { it.value in excludeKeys }
+                .map { it.key }
+            val controlNames = ('A'..'Z').asSequence()
+                .map { "Ctrl-$it" }
+            return (keyCodeNames + controlNames)
+                .sortedWith(
+                    compareBy<String> {
+                        when {
+                            it.length == 1 -> 0  // Characters first
+                            it.length in 2..3 && it[0] == 'F' && it[1].isDigit() ->
+                                it.drop(1).toInt()  // then F-Keys numerically
+                            it.startsWith("Ctrl-") -> 100  // Then Ctrl-*
+                            else -> 999  // Rest last
+                        }
+                    }.thenBy { it }  // should be by translated, but - later
+                )
+        }
+
+        private fun getTranslationKey(keyName: String): String {
+            val noSpaces = keyName.replace(' ','-')
+            if (noSpaces.last().isLetterOrDigit()) return "Key-$noSpaces"
+            return "Key-${noSpaces.dropLast(1)}\"${noSpaces.last()}\""
+        }
+
+        @Suppress("unused")  // TranslationFileWriter integration will be done later
+        fun getAllTranslationKeys() = getKeyNames(defaultExclusions).map { getTranslationKey(it) }
+    }
+
+    private val normalStyle: SelectBoxStyle
+    private val defaultStyle: SelectBoxStyle
+
+    init {
+        //TODO:
+        // * Dropdown doesn't listen to mouse wheel until after some focus setting click
+        //   (like any other SelectBox, but here it's more noticeable)
+
+        items = GdxArray<KeysSelectBoxEntry>(200).apply {
+            for (name in getKeyNames(excludeKeys))
+                add(KeysSelectBoxEntry(name))
+        }
+        setSelected(default)
+
+        maxListCount = 12  // or else the dropdown will fill as much vertical space as it can, including upwards
+
+        addListener(object : ChangeListener() {
+            override fun changed(event: ChangeEvent?, actor: Actor?) {
+                setColorForDefault()
+                changeCallback?.invoke()
+            }
+        })
+
+        // clone style to prevent bleeding our changes to other Widgets
+        normalStyle = SelectBoxStyle(style)
+        // Another instance of SelectBoxStyle for displaying whether the selection is the default one
+        defaultStyle = SelectBoxStyle(normalStyle)
+        defaultStyle.fontColor = Color.GRAY.cpy()
+
+        setColorForDefault()
+    }
+
+    fun setSelected(name: String) {
+        val newSelection = items.firstOrNull { it.name == name }
+            ?: return
+        selected = newSelection
+    }
+
+    /** Update fontColor to show whether the selection is the default one (as grayed) */
+    private fun setColorForDefault() {
+        // See Javadoc of underlying style - setStyle is needed to update visually
+        @Suppress("UsePropertyAccessSyntax")
+        setStyle(if (selected.name == default) defaultStyle else normalStyle)
+    }
+}

--- a/core/src/com/unciv/ui/popups/options/OptionsPopup.kt
+++ b/core/src/com/unciv/ui/popups/options/OptionsPopup.kt
@@ -16,7 +16,6 @@ import com.unciv.ui.popups.Popup
 import com.unciv.ui.screens.basescreen.BaseScreen
 import com.unciv.ui.screens.mainmenuscreen.MainMenuScreen
 import com.unciv.ui.screens.worldscreen.WorldScreen
-import com.unciv.utils.DebugUtils
 import com.unciv.utils.concurrency.Concurrency
 import com.unciv.utils.concurrency.withGLContext
 import kotlin.reflect.KMutableProperty0


### PR DESCRIPTION
This is my currently almost-best shot at good usability.

I lost the easy ability to reset a specific binding to default, but I had no good idea where to attach that.

Next - bug hunt or translations work. Some lines from my notepad:
- "Please see the Tutorial. = " -> template
- Sort SelectBox by translation
- Sort of Function feeding TranslationFileWriter stays culture-agnostic
- Deal with missing "Del" key - likely Gdx bug or that misnomer KeyCharAndCode fixes?
- How to clarify _these_ translations are optional? Or don't auto-write most but keep any Key-*?
- "Reset all bindings" button

This is how a functional part of a translation file matching this code would look like - but Chermanz are mad, other Languages are likely to need less, e.g. if they keep "Ctrl" - this is 55 of 182 possible keys:
<details><summary>German.properties</summary>

```
Key-Y = Z
Key-Z = Y
Key-"-" = ß
Key-"=" = `
Key-"`" = ^
Key-"/" = -
Key-"\" = #
Key-"[" = Ü
Key-"]" = +
Key-";" = Ö
Key-"'" = Ä
Key-Space = Leertaste
Key-Enter = Eingabe
Key-Menu = Menü
Key-Scroll-Lock = Rollen
Key-Num-"." = Num ,
Key-Num-Enter = Num Eingabe
Key-L-Alt = Alt
Key-R-Alt = Alt-Gr
Key-Up = ￪
Key-Left = ￩
Key-Right = ￫
Key-Down = ￬
Key-Insert = Einfg
Key-Home = Pos1
Key-Page-Up = Bild￪
Key-Page-Down = Bild￬
Key-End = Ende
Key-Ctrl-A = Strg-A
Key-Ctrl-B = Strg-B
Key-Ctrl-C = Strg-C
Key-Ctrl-D = Strg-D
Key-Ctrl-E = Strg-E
Key-Ctrl-F = Strg-F
Key-Ctrl-G = Strg-G
Key-Ctrl-H = Strg-H
Key-Ctrl-I = Strg-I
Key-Ctrl-J = Strg-J
Key-Ctrl-K = Strg-K
Key-Ctrl-L = Strg-L
Key-Ctrl-M = Strg-M
Key-Ctrl-N = Strg-N
Key-Ctrl-O = Strg-O
Key-Ctrl-P = Strg-P
Key-Ctrl-Q = Strg-Q
Key-Ctrl-R = Strg-R
Key-Ctrl-S = Strg-S
Key-Ctrl-T = Strg-T
Key-Ctrl-U = Strg-U
Key-Ctrl-V = Strg-V
Key-Ctrl-W = Strg-W
Key-Ctrl-X = Strg-X
Key-Ctrl-Y = Strg-Z
Key-Ctrl-Z = Strg-Y
```
</details>
(Yup, that works)