### PR TITLE
Double trades fix + Diplomacy screen layout fix

### DIFF
--- a/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
@@ -653,7 +653,7 @@ object NextTurnAutomation {
         }) {
 
             val relationshipLevel = civInfo.getDiplomacyManager(otherCiv).relationshipLevel()
-            if (relationshipLevel <= RelationshipLevel.Enemy)
+            if (relationshipLevel <= RelationshipLevel.Enemy || otherCiv.tradeRequests.any { it.requestingCiv == civInfo.civName })
                 continue
 
             val trades = potentialLuxuryTrades(civInfo, otherCiv)

--- a/core/src/com/unciv/ui/screens/diplomacyscreen/DiplomacyScreen.kt
+++ b/core/src/com/unciv/ui/screens/diplomacyscreen/DiplomacyScreen.kt
@@ -949,7 +949,7 @@ class DiplomacyScreen(
      *  _Caller is responsible to not exceed this **including its own padding**_
      */
     // Note breaking the rule above will squeeze the leftSideScroll to the left - cumulatively.
-    internal fun getTradeColumnsWidth() = (stage.width - leftSideScroll.width - 3f) / 2  // 3 for SplitPane handle
+    internal fun getTradeColumnsWidth() = (stage.width * 0.8f - 3f) / 2  // 3 for SplitPane handle
 
     override fun resize(width: Int, height: Int) {
         super.resize(width, height)


### PR DESCRIPTION
Double trades fix.
Sometimes I received a trade request from the AI, I counteroffered it, and on the next turn I received two requests: counteroffer  for my counteroffer and the original one. Added a check, AI can't offer a proposal if one has already been offered.

Diplomacy screen layout fix.
`leftSideScroll.width` during diplomacy screen init has a default value of 150(did not figure out why). So, when the diplomacy screen was opened using the "How about something else..." button in the trade offer pop-up, the right side columns had the wrong width(one of the consequences is the incorrect location of the close button). 
Since split plane is split 20/80 from the screen width, I used this constant value to calculate the width for the columns.

<details><summary>Before</summary>

![30_1](https://user-images.githubusercontent.com/1225948/225101616-a193f496-7c7d-47ce-a1d9-2e3c609d69fa.jpg)
![30_2](https://user-images.githubusercontent.com/1225948/225101636-13e5b070-94a7-4e9a-8aa5-a46614516ffc.jpg)

</details>

<details><summary>After</summary>

![30_12](https://user-images.githubusercontent.com/1225948/225101660-0c5a663a-a9e5-49f4-8bb1-2ec591dcafb2.jpg)
![30_22](https://user-images.githubusercontent.com/1225948/225101671-8a3dc0fe-daa8-44e9-9fd1-f2bb519334a5.jpg)

</details>