### PR TITLE
Notifications scroll pane position fix

### DIFF
--- a/core/src/com/unciv/ui/screens/worldscreen/NotificationsScroll.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/NotificationsScroll.kt
@@ -32,7 +32,6 @@ class NotificationsScroll(
     private var notificationsHash: Int = 0
 
     private var notificationsTable = Table()
-    private var endOfTableSpacerCell: Cell<*>? = null
 
     private val maxEntryWidth = worldScreen.stage.width * maxWidthOfStage * inverseScaleFactor
 
@@ -68,7 +67,6 @@ class NotificationsScroll(
         notificationsHash = newHash
 
         notificationsTable.clearChildren()
-        endOfTableSpacerCell = null
 
         val reversedNotifications = notifications.asReversed().toList() // toList to avoid concurrency problems
         for (category in NotificationCategory.values()){

--- a/core/src/com/unciv/ui/screens/worldscreen/NotificationsScroll.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/NotificationsScroll.kt
@@ -50,13 +50,12 @@ class NotificationsScroll(
      */
     internal fun update(
         notifications: MutableList<Notification>,
-        maxNotificationsHeight: Float,
-        tileInfoTableHeight: Float
+        maxNotificationsHeight: Float
     ) {
         val previousScrollY = scrollY
 
         updateContent(notifications)
-        updateLayout(maxNotificationsHeight, tileInfoTableHeight)
+        updateLayout(maxNotificationsHeight)
 
         scrollY = previousScrollY
         updateVisualScroll()
@@ -120,27 +119,12 @@ class NotificationsScroll(
         notificationsTable.pack()  // needed to get height - prefHeight is set and close but not quite the same value
     }
 
-    private fun updateLayout(maxNotificationsHeight: Float, tileInfoTableHeight: Float) {
+    private fun updateLayout(maxNotificationsHeight: Float) {
         val newHeight = min(notificationsTable.height, maxNotificationsHeight * inverseScaleFactor)
-
-        sizeScrollingSpacer(tileInfoTableHeight)
 
         pack()
         height = newHeight  // after this, maxY is still incorrect until layout()
         layout()
-    }
-
-    /** Add some empty space that can be scrolled under the TileInfoTable which is covering our lower part */
-    private fun sizeScrollingSpacer(tileInfoTableHeight: Float) {
-        if (endOfTableSpacerCell == null) {
-            endOfTableSpacerCell = notificationsTable.add().pad(5f)
-            notificationsTable.row()
-        }
-        val scaledHeight = tileInfoTableHeight * inverseScaleFactor
-        endOfTableSpacerCell!!.height(scaledHeight)
-        notificationsTable.invalidate() // looks redundant but isn't
-        // (the flags it sets are already on when inspected in debugger, but when omitting it the
-        // ScrollPane will not properly scroll down to the new maxY when TileInfoTable changes to a smaller height)
     }
 
     fun setTopRight (right: Float, top: Float) {

--- a/core/src/com/unciv/ui/screens/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/WorldScreen.kt
@@ -454,8 +454,8 @@ class WorldScreen(
         updateGameplayButtons()
 
         val maxNotificationsHeight = statusButtons.y -
-                (if (game.settings.showMinimap) minimapWrapper.height else 0f) - 5f
-        notificationsScroll.update(viewingCiv.notifications, maxNotificationsHeight, bottomTileInfoTable.height)
+                (if (game.settings.showMinimap) minimapWrapper.height else 0f) - bottomTileInfoTable.height - 5f
+        notificationsScroll.update(viewingCiv.notifications, maxNotificationsHeight)
         notificationsScroll.setTopRight(stage.width - 10f, statusButtons.y - 5f)
 
         val posZoomFromRight = if (game.settings.showMinimap) minimapWrapper.width


### PR DESCRIPTION
The Y position of the notifications pane changed according to the info table height of the selected tile. This is related to the `endOfTableSpacerCell`. I did not go into details, because when the selected tile changes (and the size of the info tile table changes), `worldScreen.update()` is called. Then why bother with empty spaces if you can just subtract the info table height from `maxNotificationsHeight`?

<details><summary>Before</summary>

![31_2](https://user-images.githubusercontent.com/1225948/225123894-5ff82e8a-c873-4a17-84f0-3e6b85fbf237.jpg)
![31_3](https://user-images.githubusercontent.com/1225948/225123927-f0505e5e-3bd1-4291-8106-4e5c83ee118d.jpg)
</details>

<details><summary>After</summary>

![31_10](https://user-images.githubusercontent.com/1225948/225123962-a49b3932-50f8-4d99-bf87-9a4a2bdd5e4b.jpg)
![31_11](https://user-images.githubusercontent.com/1225948/225123977-d0490a1f-72ff-4f4f-adb6-abd11acd66aa.jpg)
</details>

<details><summary>Long list test</summary>

![31_12](https://user-images.githubusercontent.com/1225948/225123998-d4863cf2-ae07-4f98-baad-866c6621de2c.jpg)
![31_13](https://user-images.githubusercontent.com/1225948/225124014-9e35731a-6e40-4cee-b677-78738191a8b7.jpg)
</details>