### PR TITLE
World wrap scrolling fix

### DIFF
--- a/core/src/com/unciv/ui/components/ZoomableScrollPane.kt
+++ b/core/src/com/unciv/ui/components/ZoomableScrollPane.kt
@@ -80,6 +80,17 @@ open class ZoomableScrollPane(
         onViewportChanged()
     }
 
+    override fun setScrollX(pixels: Float) {
+        var result = pixels
+
+        if (continuousScrollingX) {
+            if (result < 0f) result += maxX
+            else if (result > maxX) result -= maxX
+        }
+
+        super.setScrollX(result)
+    }
+
     override fun scrollY(pixelsY: Float) {
         super.scrollY(pixelsY)
         updateCulling()
@@ -292,15 +303,6 @@ open class ZoomableScrollPane(
             setScrollbarsVisible(true)
             scrollX = restrictX(deltaX)
             scrollY = restrictY(deltaY)
-
-            when {
-                continuousScrollingX && scrollPercentX >= 1 && deltaX < 0 -> {
-                    scrollPercentX = 0f
-                }
-                continuousScrollingX && scrollPercentX <= 0 && deltaX > 0-> {
-                    scrollPercentX = 1f
-                }
-            }
 
             //clamp() call is missing here but it doesn't seem to make any big difference in this case
 


### PR DESCRIPTION
Fixes the scrolling teleportation problem from PR #8795
Works with panning, keyboard scrolling, scrollTo() and in the map editor.