### PR TITLE
Barbary galleys are little less suicidal

### DIFF
--- a/core/src/com/unciv/logic/automation/unit/BattleHelper.kt
+++ b/core/src/com/unciv/logic/automation/unit/BattleHelper.kt
@@ -20,7 +20,7 @@ object BattleHelper {
                 BattleDamage.calculateDamageToAttacker(
                     MapUnitCombatant(unit),
                     Battle.getMapCombatantOfTile(it.tileToAttack)!!
-                ) + unit.getDamageFromTerrain(it.tileToAttackFrom) < unit.health
+                ) + unit.getDamageFromTerrain(it.tileToAttackFrom) < unit.health - 1
             }
 
         val enemyTileToAttack = chooseAttackTarget(unit, attackableEnemies)


### PR DESCRIPTION
Not sure if this is the right solution, but it fixes the case from my last save in #8551.
In my case `BattleDamage.calculateDamageToAttacker()` always returns 99, unit.getDamageFromTerrain() - 0 and `unit.health` is 100. But the galley actually takes 100 damage and dies.
This PR fixes the case, but now the galley come comes close to the city, where I can bombard it down to 7 HP on my turn. It's not suicide, but it doesn't do any harm to me, so what's the point?