### PR TITLE
Future tech fix

### DIFF
--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -65,8 +65,9 @@ data class CompatibilityVersion(
 
 }
 
-data class VictoryData(val winningCiv:String, val victoryType:String, val victoryTurn:Int){
-    constructor(): this("","",0) // for serializer
+data class VictoryData(val winningCiv: String, val victoryType: String, val victoryTurn: Int) {
+    @Suppress("unused")  // used by json serialization
+    constructor(): this("","",0)
 }
 
 class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion {
@@ -419,7 +420,7 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
     }
 
     /** Generate a notification pointing out resources.
-     *  Used by [addTechnology][TechManager.addTechnology] and [ResourcesOverviewTab][com.unciv.ui.overviewscreen.ResourcesOverviewTab]
+     *  Used by [addTechnology][TechManager.addTechnology] and [ResourcesOverviewTab][com.unciv.ui.screens.overviewscreen.ResourcesOverviewTab]
      * @param maxDistance from next City, 0 removes distance limitation.
      * @param showForeign Disables filter to exclude foreign territory.
      * @return `false` if no resources were found and no notification was added.
@@ -546,12 +547,11 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
 
         convertFortify()
 
-        for (civInfo in sequence {
+        for (civInfo in civilizations.asSequence()
             // update city-state resource first since the happiness of major civ depends on it.
             // See issue: https://github.com/yairm210/Unciv/issues/7781
-            yieldAll(civilizations.filter { it.isCityState() })
-            yieldAll(civilizations.filter { !it.isCityState() })
-        }) {
+            .sortedByDescending { it.isCityState() }
+        ) {
             for (unit in civInfo.units.getCivUnits())
                 unit.updateVisibleTiles(false) // this needs to be done after all the units are assigned to their civs and all other transients are set
             if(civInfo.playerType == PlayerType.Human)

--- a/core/src/com/unciv/logic/civilization/managers/TechManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/TechManager.kt
@@ -23,7 +23,6 @@ import com.unciv.models.ruleset.unit.BaseUnit
 import com.unciv.ui.components.MayaCalendar
 import com.unciv.ui.components.extensions.toPercent
 import com.unciv.ui.components.extensions.withItem
-import java.util.*
 import kotlin.math.ceil
 import kotlin.math.max
 import kotlin.math.min
@@ -153,13 +152,13 @@ class TechManager : IsPartOfGameInfoSerialization {
     //endregion
 
     fun getRequiredTechsToDestination(destinationTech: Technology): List<Technology> {
-        val prerequisites = Stack<Technology>()
+        val prerequisites = mutableListOf<Technology>()
 
         val checkPrerequisites = ArrayDeque<Technology>()
         checkPrerequisites.add(destinationTech)
 
         while (!checkPrerequisites.isEmpty()) {
-            val techToCheck = checkPrerequisites.pop()
+            val techToCheck = checkPrerequisites.removeFirst()
             // future tech can have been researched even when we're researching it,
             // so...if we skip it we'll end up with 0 techs in the "required techs", which will mean that we don't have anything to research. Yeah.
             if (!techToCheck.isContinuallyResearchable() &&

--- a/core/src/com/unciv/logic/civilization/managers/TechManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/TechManager.kt
@@ -256,6 +256,7 @@ class TechManager : IsPartOfGameInfoSerialization {
             techsToResearch.remove(techName)
         else
             repeatingTechsResearched++
+        techsInProgress.remove(techName)
         researchedTechnologies = researchedTechnologies.withItem(newTech)
         addTechToTransients(newTech)
 


### PR DESCRIPTION
OK, this is the three lightweight commits from #8866 . Still closes #8864 and saves a few bytes in saved games (currently the final beakers once a tech is gained are kept indefinitely, this should clear those too).

On `ArrayDeque` - using the Kotlin proxy still goes to the Java implementation, but leaves the door a bit more open for the kotlin devs to improve in the future. It's just missing the `pop` method - which in the Java version -surprise- also goes directly to `removeFirst`... A `Stack` has no direct kotlin replacement, one would use ArrayDeque as well, but it's overkill for what happens anyway. Whatever kotlin picks for `MutableList` should excel at appending at the end and enumerating sequentially, and no more is asked of it here...