### PR TITLE
Keyboard Bindings Step 5: Late resolving

### DIFF
--- a/core/src/com/unciv/ui/components/KeyShortcutDispatcher.kt
+++ b/core/src/com/unciv/ui/components/KeyShortcutDispatcher.kt
@@ -1,7 +1,15 @@
 package com.unciv.ui.components
 
 open class KeyShortcutDispatcher {
-    data class KeyShortcut(val key: KeyCharAndCode, val priority: Int = 0)
+    /**
+     * @param key       The hardcoded key that will be bound to an action through the [add] methods -OR-
+     * @param binding   The abstract [KeyboardBinding] that will be bound to an action through the [add] methods
+     * @param priority  Used by the [Resolver] - only the actions bound to the incoming key with the _highest priority_ will run
+     */
+    data class KeyShortcut(val binding: KeyboardBinding, val key: KeyCharAndCode, val priority: Int = 0) {
+        /** Debug helper */
+        override fun toString() = if (binding.hidden) "$key@$priority" else "$binding@$priority"
+    }
 
     private data class ShortcutAction(val shortcut: KeyShortcut, val action: () -> Unit)
     private val shortcuts: MutableList<ShortcutAction> = mutableListOf()
@@ -12,13 +20,13 @@ open class KeyShortcutDispatcher {
         shortcuts.add(ShortcutAction(shortcut, action))
     }
 
-    fun add(binding: KeyboardBinding, action: (() -> Unit)?) {
-        add(KeyboardBindings[binding], action)
+    fun add(binding: KeyboardBinding, priority: Int = 1, action: (() -> Unit)?) {
+        add(KeyShortcut(binding, KeyCharAndCode.UNKNOWN, priority), action)
     }
 
     fun add(key: KeyCharAndCode?, action: (() -> Unit)?) {
         if (key != null)
-            add(KeyShortcut(key), action)
+            add(KeyShortcut(KeyboardBinding.None, key), action)
     }
 
     fun add(char: Char?, action: (() -> Unit)?) {
@@ -36,7 +44,7 @@ open class KeyShortcutDispatcher {
     }
 
     fun remove(binding: KeyboardBinding) {
-        remove(KeyboardBindings[binding])
+        shortcuts.removeIf { it.shortcut.binding == binding }
     }
 
     fun remove(key: KeyCharAndCode?) {
@@ -62,15 +70,17 @@ open class KeyShortcutDispatcher {
             if (!dispatcher.isActive()) return
 
             for ((shortcut, action) in dispatcher.shortcuts) {
-                if (shortcut.key == key) {
-                    if (shortcut.priority == priority)
-                        triggeredActions.add(action)
-                    else if (shortcut.priority > priority) {
-                        priority = shortcut.priority
-                        triggeredActions.clear()
-                        triggeredActions.add(action)
-                    }
+                var (binding, shortcutKey, shortcutPriority) = shortcut
+                if (binding != KeyboardBinding.None) {
+                    shortcutKey = KeyboardBindings[binding]
+                    if (shortcutKey == binding.defaultKey) shortcutPriority--
                 }
+                if (shortcutKey != key || shortcutPriority < priority) continue
+                if (shortcutPriority > priority) {
+                    priority = shortcutPriority
+                    triggeredActions.clear()
+                }
+                triggeredActions.add(action)
             }
         }
     }

--- a/core/src/com/unciv/ui/components/KeyboardBinding.kt
+++ b/core/src/com/unciv/ui/components/KeyboardBinding.kt
@@ -2,28 +2,48 @@ package com.unciv.ui.components
 
 import com.badlogic.gdx.Input
 
+
 private val unCamelCaseRegex = Regex("([A-Z])([A-Z])([a-z])|([a-z])([A-Z])")
 private fun unCamelCase(name: String) = unCamelCaseRegex.replace(name, """$1$4 $2$3$5""")
 
 enum class KeyboardBinding(
+    val category: Category,
     label: String? = null,
     key: KeyCharAndCode? = null
 ) {
+    // Used by [KeyShortcutDispatcher.KeyShortcut] to mark an old-style shortcut with a hardcoded key
+    None(Category.None, KeyCharAndCode.UNKNOWN),
     // Worldscreen
-    NextTurn,
-    NextTurnAlternate(key = KeyCharAndCode.SPACE),
-    Civilopedia(key = KeyCharAndCode(Input.Keys.F1)),
-    EmpireOverview,
+    NextTurn(Category.WorldScreen),
+    NextTurnAlternate(Category.WorldScreen, KeyCharAndCode.SPACE),
+    Civilopedia(Category.WorldScreen, Input.Keys.F1),
+    EmpireOverview(Category.WorldScreen),
+    Wait(Category.None, 'z'),  // Used but excluded from UI because UnitActionType.Wait needs to be done too
     // Popups
-    Confirm("Confirm Dialog", KeyCharAndCode('y')),
-    Cancel("Cancel Dialog", KeyCharAndCode('n')),
+    Confirm(Category.Popups, "Confirm Dialog", 'y'),
+    Cancel(Category.Popups, "Cancel Dialog", 'n'),
     ;
+
+    enum class Category {
+        None, WorldScreen, Popups
+    }
 
     val label: String
     val defaultKey: KeyCharAndCode
+    val hidden: Boolean get() = category == Category.None
 
     init {
         this.label = label ?: unCamelCase(name)
         this.defaultKey = key ?: KeyCharAndCode(name[0])
     }
+
+    // Helpers to make enum instance initializations shorter
+    constructor(category: Category, label: String, key: Char) : this(category, label, KeyCharAndCode(key))
+    constructor(category: Category, label: String, key: Int) : this(category, label, KeyCharAndCode(key))
+    constructor(category: Category, key: KeyCharAndCode) : this(category, null, key)
+    constructor(category: Category, key: Char) : this(category, null, KeyCharAndCode(key))
+    constructor(category: Category, key: Int) : this(category, null, KeyCharAndCode(key))
+
+    /** Debug helper */
+    override fun toString() = "$category.$name($defaultKey)"
 }

--- a/core/src/com/unciv/ui/components/extensions/Scene2dExtensions.kt
+++ b/core/src/com/unciv/ui/components/extensions/Scene2dExtensions.kt
@@ -99,7 +99,7 @@ fun Color.brighten(t: Float): Color = Color(this).lerp(Color.WHITE, t)
  */
 class ActorKeyShortcutDispatcher internal constructor(val actor: Actor): KeyShortcutDispatcher() {
     fun add(shortcut: KeyShortcut?) = add(shortcut) { actor.activate() }
-    fun add(binding: KeyboardBinding) = add(binding) { actor.activate() }
+    fun add(binding: KeyboardBinding, priority: Int = 1) = add(binding, priority) { actor.activate() }
     fun add(key: KeyCharAndCode?) = add(key) { actor.activate() }
     fun add(char: Char?) = add(char) { actor.activate() }
     fun add(keyCode: Int?) = add(keyCode) { actor.activate() }

--- a/core/src/com/unciv/ui/popups/options/KeyBindingsTab.kt
+++ b/core/src/com/unciv/ui/popups/options/KeyBindingsTab.kt
@@ -39,6 +39,7 @@ class KeyBindingsTab(
         defaults().pad(5f)
 
         for (binding in KeyboardBinding.values()) {
+            if (binding.hidden) continue
             keyFields[binding] = KeyboardBindingWidget(binding)
         }
     }
@@ -48,6 +49,7 @@ class KeyBindingsTab(
         add(disclaimer).colspan(2).center().row()
 
         for (binding in KeyboardBinding.values()) {
+            if (binding.hidden) continue
             add(binding.label.toLabel())
             add(keyFields[binding]).row()
             keyFields[binding]!!.update(keyBindings)
@@ -56,6 +58,7 @@ class KeyBindingsTab(
 
     fun save () {
         for (binding in KeyboardBinding.values()) {
+            if (binding.hidden) continue
             keyBindings.put(binding, keyFields[binding]!!.text)
         }
     }

--- a/core/src/com/unciv/ui/screens/worldscreen/status/NextTurnButton.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/status/NextTurnButton.kt
@@ -5,8 +5,6 @@ import com.unciv.Constants
 import com.unciv.logic.civilization.managers.ReligionState
 import com.unciv.models.ruleset.BeliefType
 import com.unciv.models.translations.tr
-import com.unciv.ui.components.KeyCharAndCode
-import com.unciv.ui.components.KeyShortcutDispatcher.KeyShortcut
 import com.unciv.ui.components.KeyboardBinding
 import com.unciv.ui.components.extensions.disable
 import com.unciv.ui.components.extensions.enable
@@ -38,7 +36,7 @@ class NextTurnButton : IconTextButton("", null, 30) {
         keyShortcuts.add(KeyboardBinding.NextTurn)
         keyShortcuts.add(KeyboardBinding.NextTurnAlternate)
         // Let unit actions override this for command "Wait".
-        keyShortcuts.add(KeyShortcut(KeyCharAndCode('z'), -100))
+        keyShortcuts.add(KeyboardBinding.Wait, -99)
     }
 
     fun update(worldScreen: WorldScreen) {


### PR DESCRIPTION
This should fix the "hey it's still only reacting to the old key" observations.
I still have a bug to hunt, but I haven't yet learned to repro reliably - it seems something can trigger _all_ bindings to suddenly reset to default...

Before, I consciouly kept my fingers out of @Pogonyshev's `KeyShortcutDispatcher` stuff, and thus did the KeyboardBinding to KeyCharAndCode resolution early, when the UI registers the key. I had the suspicion changes in Options might need some rebuild - like a Font change - and tested too sloppily. I saw one success I thought was WorldScreen level binding working right after changing it and didn't look further. Must have been a fluke. Late resolution is a better alternative I had planned looking into anyway, and it comes with this PR.

Also gives Userdefined key bindings a priority +1 thus they'll take precedence over defaults, 

There's still a need to redo tooltips, I haven't even tried to think about that yet - later. Maybe EventBus, or UncivTooltip learns late resolution too? That might be a lot of architectural change...

Introduces Categories as the UI will need them sooner or later, but so far they only serve to hide bindings from the UI, triggered by the need to have some marker in KeyShortcut whether it's a hardcoded key or a latebound binding-based shortcut - and I decided against a nullable field. I'm convinced the existence of both `None` entries will prove useful.

Bindings for UnitActions are done, but I postponed that code for some next PR.

Food for thought: As for conflict detection - grouping by Category helps, but isn't enough - we currently already have duplicate keys that simply cycle through the alternatives; or all the UnitActions mapped to 'g'... I'd instincitvely offer separate bindings for every UnitAction so the user has maximum freedom - for conflict detection that needs a second grouping system where keys undergo a 'distinct' operator for all members of a group before dupe detection is done over 'category' - AND/OR simply using just 1 binding for all 'g' UnitActions, but then a clear _label_ for such a binding might get hard to put into short words.