### PR TITLE
Fixed the positioning of popups after changing the screen orientation on Android

### DIFF
--- a/android/src/com/unciv/app/AndroidGame.kt
+++ b/android/src/com/unciv/app/AndroidGame.kt
@@ -1,5 +1,6 @@
 package com.unciv.app
 
+import android.app.Activity
 import android.content.Intent
 import android.graphics.Rect
 import android.net.Uri
@@ -14,7 +15,9 @@ import com.unciv.ui.screens.basescreen.BaseScreen
 import com.unciv.ui.screens.basescreen.UncivStage
 import com.unciv.utils.concurrency.Concurrency
 
-class AndroidGame : UncivGame() {
+class AndroidGame(private val activity: Activity) : UncivGame() {
+
+    private var lastOrientation = activity.resources.configuration.orientation
 
     fun addScreenObscuredListener() {
         val contentView = (Gdx.graphics as AndroidGraphics).view
@@ -52,6 +55,12 @@ class AndroidGame : UncivGame() {
                     return
                 lastFrame = currentFrame
                 lastVisibleStage = visibleStage
+
+                val currentOrientation = activity.resources.configuration.orientation
+                if (lastOrientation != currentOrientation) {
+                    lastOrientation = currentOrientation
+                    return
+                }
 
                 Concurrency.runOnGLThread {
                     EventBus.send(UncivStage.VisibleAreaChanged(visibleStage))

--- a/android/src/com/unciv/app/AndroidLauncher.kt
+++ b/android/src/com/unciv/app/AndroidLauncher.kt
@@ -44,7 +44,7 @@ open class AndroidLauncher : AndroidApplication() {
         Display.setOrientation(settings.displayOrientation)
         Display.setCutout(settings.androidCutout)
 
-        game = AndroidGame()
+        game = AndroidGame(this)
         initialize(game, config)
 
         game!!.setDeepLinkedGame(intent)


### PR DESCRIPTION
Resolves #8443
I'm not very good with android stuff, but no one has paid attention to this problem for a long time, so here we are...
After changing the orientation, `UncivStage()` is reinitialized and has the correct `lastKnownVisibleArea`, but `onGlobalLayout()` call messes up the `lastKnownVisibleArea` because it operates on the old `stage` dimensions from the previous screen orientation.