### PR TITLE
EmpireOverviewCategories rework

### DIFF
--- a/core/src/com/unciv/models/metadata/GameSettings.kt
+++ b/core/src/com/unciv/models/metadata/GameSettings.kt
@@ -10,6 +10,7 @@ import com.unciv.models.UncivSound
 import com.unciv.ui.components.FontFamilyData
 import com.unciv.ui.components.Fonts
 import com.unciv.ui.components.KeyboardBindings
+import com.unciv.ui.screens.overviewscreen.EmpireOverviewCategories
 import com.unciv.utils.ScreenOrientation
 import java.text.Collator
 import java.time.Duration
@@ -86,7 +87,7 @@ class GameSettings {
 
     var enableEspionageOption = false
 
-    var lastOverviewPage: String = "Cities"
+    var lastOverviewPage = EmpireOverviewCategories.Cities  // serializes same as the String we had before
 
     /** Orientation for mobile platforms */
     var displayOrientation = ScreenOrientation.Landscape

--- a/core/src/com/unciv/ui/screens/cityscreen/CityReligionInfoTable.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/CityReligionInfoTable.kt
@@ -84,7 +84,7 @@ class CityReligionInfoTable(
         if (religion == null) return icon
         icon.onClick {
             val newScreen = if (religion == iconName) {
-                EmpireOverviewScreen(civInfo, EmpireOverviewCategories.Religion.name, religion)
+                EmpireOverviewScreen(civInfo, EmpireOverviewCategories.Religion, religion)
             } else {
                 CivilopediaScreen(gameInfo.ruleset, CivilopediaCategories.Belief, religion)
             }

--- a/core/src/com/unciv/ui/screens/overviewscreen/EmpireOverviewCategories.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/EmpireOverviewCategories.kt
@@ -1,17 +1,11 @@
 package com.unciv.ui.screens.overviewscreen
 
 import com.badlogic.gdx.utils.Align
-import com.unciv.UncivGame
 import com.unciv.logic.civilization.Civilization
 import com.unciv.models.ruleset.tile.ResourceType
 import com.unciv.ui.screens.overviewscreen.EmpireOverviewTab.EmpireOverviewTabPersistableData
 import com.unciv.ui.components.KeyCharAndCode
 
-private typealias FactoryType = (Civilization, EmpireOverviewScreen, EmpireOverviewTabPersistableData?) -> EmpireOverviewTab
-
-enum class EmpireOverviewTabState { Normal, Disabled, Hidden }
-private typealias StateTesterType = (Civilization) -> EmpireOverviewTabState
-private fun Boolean.toState(): EmpireOverviewTabState = if (this) EmpireOverviewTabState.Disabled else EmpireOverviewTabState.Normal
 
 /** This controls which Tabs for the [EmpireOverviewScreen] exist and their order.
  *
@@ -21,54 +15,69 @@ private fun Boolean.toState(): EmpireOverviewTabState = if (this) EmpireOverview
 enum class EmpireOverviewCategories(
     val iconName: String,
     val shortcutKey: KeyCharAndCode,
-    val scrollAlign: Int,
-    val factory: FactoryType,
-    val stateTester: StateTesterType
+    val scrollAlign: Int
 ) {
-    Cities("OtherIcons/Cities", 'C', Align.topLeft,
-        fun (viewingPlayer: Civilization, overviewScreen: EmpireOverviewScreen, persistedData: EmpireOverviewTabPersistableData?)
-                = CityOverviewTab(viewingPlayer, overviewScreen, persistedData),
-        fun (viewingPlayer: Civilization) = viewingPlayer.cities.isEmpty().toState()),
-    Stats("StatIcons/Gold", 'S', Align.top,
-        fun (viewingPlayer: Civilization, overviewScreen: EmpireOverviewScreen, _: EmpireOverviewTabPersistableData?)
-                = StatsOverviewTab(viewingPlayer, overviewScreen),
-        fun (_: Civilization) = EmpireOverviewTabState.Normal),
-    Trades("StatIcons/Acquire", 'T', Align.top,
-        fun (viewingPlayer: Civilization, overviewScreen: EmpireOverviewScreen, _: EmpireOverviewTabPersistableData?)
-                = TradesOverviewTab(viewingPlayer, overviewScreen),
-        fun (viewingPlayer: Civilization) =
-                (viewingPlayer.diplomacy.values.all { it.trades.isEmpty()} && !viewingPlayer.diplomacy.values.any{it.otherCiv().tradeRequests.any { it.requestingCiv == viewingPlayer.civName }}).toState()),
-    Units("OtherIcons/Shield", 'U', Align.topLeft,
-        fun (viewingPlayer: Civilization, overviewScreen: EmpireOverviewScreen, persistedData: EmpireOverviewTabPersistableData?)
-                = UnitOverviewTab(viewingPlayer, overviewScreen, persistedData),
-        fun (viewingPlayer: Civilization) = viewingPlayer.units.getCivUnits().none().toState()),
-    Politics("OtherIcons/Politics", 'P', Align.top,
-        fun (viewingPlayer: Civilization, overviewScreen: EmpireOverviewScreen, persistedData: EmpireOverviewTabPersistableData?)
-                = GlobalPoliticsOverviewTable(viewingPlayer, overviewScreen, persistedData),
-        fun (_: Civilization) = EmpireOverviewTabState.Normal),
-    Resources("StatIcons/Happiness", 'R', Align.topLeft,
-        fun (viewingPlayer: Civilization, overviewScreen: EmpireOverviewScreen, persistedData: EmpireOverviewTabPersistableData?)
-                = ResourcesOverviewTab(viewingPlayer, overviewScreen, persistedData),
-        fun (viewingPlayer: Civilization) = (!viewingPlayer.detailedCivResources.any { it.resource.resourceType != ResourceType.Bonus }).toState()),
-    Religion("StatIcons/Faith", 'F', Align.top,
-        fun (viewingPlayer: Civilization, overviewScreen: EmpireOverviewScreen, persistedData: EmpireOverviewTabPersistableData?)
-                = ReligionOverviewTab(viewingPlayer, overviewScreen, persistedData),
-        fun (viewingPlayer: Civilization) = when {
+    Cities("OtherIcons/Cities", 'C', Align.topLeft) {
+        override fun createTab(viewingPlayer: Civilization, overviewScreen: EmpireOverviewScreen, persistedData: EmpireOverviewTabPersistableData?) =
+                CityOverviewTab(viewingPlayer, overviewScreen, persistedData)
+        override fun showDisabled(viewingPlayer: Civilization) = viewingPlayer.cities.isEmpty()
+    },
+    Stats("StatIcons/Gold", 'S', Align.top) {
+        override fun createTab(viewingPlayer: Civilization, overviewScreen: EmpireOverviewScreen, persistedData: EmpireOverviewTabPersistableData?) =
+                StatsOverviewTab(viewingPlayer, overviewScreen)
+    },
+    Trades("StatIcons/Acquire", 'T', Align.top) {
+        override fun createTab(viewingPlayer: Civilization, overviewScreen: EmpireOverviewScreen, persistedData: EmpireOverviewTabPersistableData?) =
+                TradesOverviewTab(viewingPlayer, overviewScreen)
+        override fun showDisabled(viewingPlayer: Civilization) =
+                viewingPlayer.diplomacy.values.all { it.trades.isEmpty() } &&
+                viewingPlayer.diplomacy.values.none { diplomacyManager ->
+                        diplomacyManager.otherCiv().tradeRequests.any { it.requestingCiv == viewingPlayer.civName }
+                    }
+    },
+    Units("OtherIcons/Shield", 'U', Align.topLeft) {
+        override fun createTab(viewingPlayer: Civilization, overviewScreen: EmpireOverviewScreen, persistedData: EmpireOverviewTabPersistableData?) =
+                UnitOverviewTab(viewingPlayer, overviewScreen, persistedData)
+        override fun showDisabled(viewingPlayer: Civilization) = viewingPlayer.units.getCivUnits().none()
+    },
+    Politics("OtherIcons/Politics", 'P', Align.top) {
+        override fun createTab(viewingPlayer: Civilization, overviewScreen: EmpireOverviewScreen, persistedData: EmpireOverviewTabPersistableData?) =
+                GlobalPoliticsOverviewTable(viewingPlayer, overviewScreen, persistedData)
+    },
+    Resources("StatIcons/Happiness", 'R', Align.topLeft) {
+        override fun createTab(viewingPlayer: Civilization, overviewScreen: EmpireOverviewScreen, persistedData: EmpireOverviewTabPersistableData?) =
+                ResourcesOverviewTab(viewingPlayer, overviewScreen, persistedData)
+        override fun showDisabled(viewingPlayer: Civilization) = viewingPlayer.detailedCivResources.none { it.resource.resourceType != ResourceType.Bonus }
+    },
+    Religion("StatIcons/Faith", 'F', Align.top) {
+        override fun createTab(viewingPlayer: Civilization, overviewScreen: EmpireOverviewScreen, persistedData: EmpireOverviewTabPersistableData?) =
+                ReligionOverviewTab(viewingPlayer, overviewScreen, persistedData)
+        override fun testState(viewingPlayer: Civilization) = when {
             !viewingPlayer.gameInfo.isReligionEnabled() -> EmpireOverviewTabState.Hidden
             viewingPlayer.gameInfo.religions.isEmpty() -> EmpireOverviewTabState.Disabled
             else -> EmpireOverviewTabState.Normal
-        }),
-    Wonders("OtherIcons/Wonders", 'W', Align.top,
-        fun (viewingPlayer: Civilization, overviewScreen: EmpireOverviewScreen, _: EmpireOverviewTabPersistableData?)
-                = WonderOverviewTab(viewingPlayer, overviewScreen),
-        fun (viewingPlayer: Civilization) = (viewingPlayer.naturalWonders.isEmpty() && viewingPlayer.cities.isEmpty()).toState()),
-    Notifications("OtherIcons/Notifications", 'N', Align.top,
-        fun (viewingPlayer: Civilization, overviewScreen: EmpireOverviewScreen, persistedData: EmpireOverviewTabPersistableData?)
-                = NotificationsOverviewTable(viewingPlayer, overviewScreen, persistedData),
-        fun (_: Civilization) = EmpireOverviewTabState.Normal)
+        }
+    },
+    Wonders("OtherIcons/Wonders", 'W', Align.top) {
+        override fun createTab(viewingPlayer: Civilization, overviewScreen: EmpireOverviewScreen, persistedData: EmpireOverviewTabPersistableData?) =
+                WonderOverviewTab(viewingPlayer, overviewScreen)
+        override fun showDisabled(viewingPlayer: Civilization) = (viewingPlayer.naturalWonders.isEmpty() && viewingPlayer.cities.isEmpty())
+    },
+    Notifications("OtherIcons/Notifications", 'N', Align.top) {
+        override fun createTab(viewingPlayer: Civilization, overviewScreen: EmpireOverviewScreen, persistedData: EmpireOverviewTabPersistableData?) =
+                NotificationsOverviewTable(viewingPlayer, overviewScreen, persistedData)
+    }
 
-    ; //must be here
+    ;
 
-    constructor(iconName: String, shortcutChar: Char, scrollAlign: Int, factory: FactoryType, stateTester: StateTesterType = { _ -> EmpireOverviewTabState.Normal })
-        : this(iconName, KeyCharAndCode(shortcutChar), scrollAlign, factory, stateTester)
+    constructor(iconName: String, shortcutChar: Char, scrollAlign: Int)
+        : this(iconName, KeyCharAndCode(shortcutChar), scrollAlign)
+
+    enum class EmpireOverviewTabState { Normal, Disabled, Hidden }
+
+    abstract fun createTab(viewingPlayer: Civilization, overviewScreen: EmpireOverviewScreen, persistedData: EmpireOverviewTabPersistableData?): EmpireOverviewTab
+    open fun showDisabled(viewingPlayer: Civilization) = false
+    open fun testState(viewingPlayer: Civilization) =
+            if (showDisabled(viewingPlayer)) EmpireOverviewTabState.Disabled
+            else EmpireOverviewTabState.Normal
 }

--- a/core/src/com/unciv/ui/screens/overviewscreen/EmpireOverviewScreen.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/EmpireOverviewScreen.kt
@@ -4,6 +4,7 @@ import com.badlogic.gdx.graphics.Color
 import com.unciv.Constants
 import com.unciv.logic.civilization.Civilization
 import com.unciv.ui.images.ImageGetter
+import com.unciv.ui.screens.overviewscreen.EmpireOverviewCategories.EmpireOverviewTabState
 import com.unciv.ui.screens.overviewscreen.EmpireOverviewTab.EmpireOverviewTabPersistableData
 import com.unciv.ui.screens.basescreen.BaseScreen
 import com.unciv.ui.components.KeyCharAndCode
@@ -12,7 +13,7 @@ import com.unciv.ui.components.TabbedPager
 
 class EmpireOverviewScreen(
     private var viewingPlayer: Civilization,
-    defaultPage: String = "",
+    defaultCategory: EmpireOverviewCategories? = null,
     selection: String = ""
 ) : BaseScreen(), RecreateOnResize {
     // 50 normal button height + 2*10 topTable padding + 2 Separator + 2*5 centerTable padding
@@ -38,12 +39,7 @@ class EmpireOverviewScreen(
     }
 
     init {
-        val page =
-            if (defaultPage != "") {
-                game.settings.lastOverviewPage = defaultPage
-                defaultPage
-            }
-            else game.settings.lastOverviewPage
+        val selectCategory = defaultCategory ?: game.settings.lastOverviewPage
         val iconSize = Constants.defaultFontSize.toFloat()
 
         globalShortcuts.add(KeyCharAndCode.BACK) { game.popScreen() }
@@ -57,10 +53,10 @@ class EmpireOverviewScreen(
         tabbedPager.addClosePage { game.popScreen() }
 
         for (category in EmpireOverviewCategories.values()) {
-            val tabState = category.stateTester(viewingPlayer)
+            val tabState = category.testState(viewingPlayer)
             if (tabState == EmpireOverviewTabState.Hidden) continue
             val icon = if (category.iconName.isEmpty()) null else ImageGetter.getImage(category.iconName)
-            val pageObject = category.factory(viewingPlayer, this, persistState?.get(category))
+            val pageObject = category.createTab(viewingPlayer, this, persistState?.get(category))
             pageObject.pad(10f, 0f, 10f, 0f)
             pageObjects[category] = pageObject
             val index = tabbedPager.addPage(
@@ -71,7 +67,7 @@ class EmpireOverviewScreen(
                 shortcutKey = category.shortcutKey,
                 scrollAlign = category.scrollAlign
             )
-            if (category.name == page) {
+            if (category == selectCategory) {
                 tabbedPager.selectPage(index)
                 select(pageObject, selection)
             }

--- a/core/src/com/unciv/ui/screens/overviewscreen/EmpireOverviewTab.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/EmpireOverviewTab.kt
@@ -20,10 +20,10 @@ abstract class EmpireOverviewTab (
     open val persistableData = persistedData ?: EmpireOverviewTabPersistableData()
 
     override fun activated(index: Int, caption: String, pager: TabbedPager) {
-        val settings = overviewScreen.game.settings
-        if (caption == "Stats")
-            settings.addCompletedTutorialTask("See your stats breakdown")
-        settings.lastOverviewPage = caption
+        overviewScreen.game.settings.lastOverviewPage =
+                // shouldn't throw because EmpireOverviewScreen takes the TabbedPager
+                // captions directly from EmpireOverviewCategories.name
+                EmpireOverviewCategories.valueOf(caption)
     }
 
     /** Override if the tab can _select_ something specific.

--- a/core/src/com/unciv/ui/screens/overviewscreen/StatsOverviewTable.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/StatsOverviewTable.kt
@@ -4,11 +4,11 @@ import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.unciv.Constants
 import com.unciv.GUI
-import com.unciv.UncivGame
 import com.unciv.logic.civilization.Civilization
 import com.unciv.models.ruleset.ModOptionsConstants
 import com.unciv.models.stats.Stat
 import com.unciv.models.stats.StatMap
+import com.unciv.ui.components.TabbedPager
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.components.UncivSlider
 import com.unciv.ui.components.extensions.addSeparator
@@ -28,6 +28,11 @@ class StatsOverviewTab(
     private val greatPeopleTable = Table()
     private val scoreTable = Table()
     private val isReligionEnabled = gameInfo.isReligionEnabled()
+
+    override fun activated(index: Int, caption: String, pager: TabbedPager) {
+        overviewScreen.game.settings.addCompletedTutorialTask("See your stats breakdown")
+        super.activated(index, caption, pager)
+    }
 
     init {
         val tablePadding = 30f  // Padding around each of the stat tables

--- a/core/src/com/unciv/ui/screens/overviewscreen/UnitOverviewTable.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/UnitOverviewTable.kt
@@ -191,25 +191,30 @@ class UnitOverviewTab(
             }
             add(button).fillX()
 
-            // Columns: action, strength, ranged, moves
+            // Column: edit-name
             val editIcon = ImageGetter.getImage("OtherIcons/Pencil").apply { this.color = Color.WHITE }.surroundWithCircle(30f, true, Color.valueOf("000c31"))
             editIcon.onClick {
                 UnitRenamePopup(
                     screen = overviewScreen,
                     unit = unit,
                     actionOnClose = {
-                        overviewScreen.game.replaceCurrentScreen(EmpireOverviewScreen(viewingPlayer, "", "")) })
+                        overviewScreen.game.replaceCurrentScreen(
+                            EmpireOverviewScreen(viewingPlayer, selection = getUnitIdentifier(unit))
+                        )
+                    })
             }
             add(editIcon)
 
+            // Column: action
             fun getActionLabel(unit: MapUnit) = when {
                 unit.action == null -> ""
                 unit.isFortified() -> UnitActionType.Fortify.value
                 unit.isMoving() -> "Moving"
                 else -> unit.action!!
             }
-
             if (unit.action == null) add() else add(getActionLabel(unit).toLabel())
+
+            // Columns: strength, ranged
             if (baseUnit.strength > 0) add(baseUnit.strength.toLabel()) else add()
             if (baseUnit.rangedStrength > 0) add(baseUnit.rangedStrength.toLabel()) else add()
             add(unit.getMovementString().toLabel())

--- a/core/src/com/unciv/ui/screens/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/WorldScreen.kt
@@ -45,6 +45,7 @@ import com.unciv.ui.screens.basescreen.BaseScreen
 import com.unciv.ui.screens.cityscreen.CityScreen
 import com.unciv.ui.screens.civilopediascreen.CivilopediaScreen
 import com.unciv.ui.screens.mainmenuscreen.MainMenuScreen
+import com.unciv.ui.screens.overviewscreen.EmpireOverviewCategories
 import com.unciv.ui.screens.overviewscreen.EmpireOverviewScreen
 import com.unciv.ui.screens.pickerscreens.DiplomaticVoteResultScreen
 import com.unciv.ui.screens.pickerscreens.GreatPersonPickerScreen
@@ -219,24 +220,28 @@ class WorldScreen(
         super.dispose()
     }
 
+    fun openEmpireOverview(category: EmpireOverviewCategories? = null) {
+        game.pushScreen(EmpireOverviewScreen(selectedCiv, category))
+    }
+
     private fun addKeyboardPresses() {
         // Space and N are assigned in NextTurnButton constructor
         globalShortcuts.add(KeyboardBinding.Civilopedia) { game.pushScreen(CivilopediaScreen(gameInfo.ruleset)) }
-        globalShortcuts.add(KeyboardBinding.EmpireOverview) { game.pushScreen(EmpireOverviewScreen(selectedCiv)) }     // Empire overview last used page
+        globalShortcuts.add(KeyboardBinding.EmpireOverview) { openEmpireOverview() }     // Empire overview last used page
         /*
          * These try to be faithful to default Civ5 key bindings as found in several places online
          * Some are a little arbitrary, e.g. Economic info, Military info
          * Some are very much so as Unciv *is* Strategic View and the Notification log is always visible
          */
-        globalShortcuts.add(Input.Keys.F2) { game.pushScreen(EmpireOverviewScreen(selectedCiv, "Trades")) }    // Economic info
-        globalShortcuts.add(Input.Keys.F3) { game.pushScreen(EmpireOverviewScreen(selectedCiv, "Units")) }    // Military info
-        globalShortcuts.add(Input.Keys.F4) { game.pushScreen(EmpireOverviewScreen(selectedCiv, "Politics")) }    // Diplomacy info
+        globalShortcuts.add(Input.Keys.F2) { openEmpireOverview(EmpireOverviewCategories.Trades) }    // Economic info
+        globalShortcuts.add(Input.Keys.F3) { openEmpireOverview(EmpireOverviewCategories.Units) }    // Military info
+        globalShortcuts.add(Input.Keys.F4) { openEmpireOverview(EmpireOverviewCategories.Politics) }    // Diplomacy info
         globalShortcuts.add(Input.Keys.F5) { game.pushScreen(PolicyPickerScreen(selectedCiv, canChangeState)) }    // Social Policies Screen
         globalShortcuts.add(Input.Keys.F6) { game.pushScreen(TechPickerScreen(viewingCiv)) }    // Tech Screen
-        globalShortcuts.add(Input.Keys.F7) { game.pushScreen(EmpireOverviewScreen(selectedCiv, "Cities")) }    // originally Notification Log
+        globalShortcuts.add(Input.Keys.F7) { openEmpireOverview(EmpireOverviewCategories.Notifications) }    // Notification Log
         globalShortcuts.add(Input.Keys.F8) { game.pushScreen(VictoryScreen(this)) }    // Victory Progress
-        globalShortcuts.add(Input.Keys.F9) { game.pushScreen(EmpireOverviewScreen(selectedCiv, "Stats")) }    // Demographics
-        globalShortcuts.add(Input.Keys.F10) { game.pushScreen(EmpireOverviewScreen(selectedCiv, "Resources")) }    // originally Strategic View
+        globalShortcuts.add(Input.Keys.F9) { openEmpireOverview(EmpireOverviewCategories.Stats) }    // Demographics
+        globalShortcuts.add(Input.Keys.F10) { openEmpireOverview(EmpireOverviewCategories.Resources) }    // originally Strategic View
         globalShortcuts.add(Input.Keys.F11) { QuickSave.save(gameInfo, this) }    // Quick Save
         globalShortcuts.add(Input.Keys.F12) { QuickSave.load(this) }    // Quick Load
         globalShortcuts.add(Input.Keys.HOME) {    // Capital City View
@@ -561,10 +566,10 @@ class WorldScreen(
     }
 
     private fun updateSelectedCiv() {
-        when {
-            bottomUnitTable.selectedUnit != null -> selectedCiv = bottomUnitTable.selectedUnit!!.civ
-            bottomUnitTable.selectedCity != null -> selectedCiv = bottomUnitTable.selectedCity!!.civ
-            else -> selectedCiv = viewingCiv
+        selectedCiv = when {
+            bottomUnitTable.selectedUnit != null -> bottomUnitTable.selectedUnit!!.civ
+            bottomUnitTable.selectedCity != null -> bottomUnitTable.selectedCity!!.civ
+            else -> viewingCiv
         }
     }
 

--- a/core/src/com/unciv/ui/screens/worldscreen/WorldScreenTopBar.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/WorldScreenTopBar.kt
@@ -30,6 +30,7 @@ import com.unciv.ui.popups.popups
 import com.unciv.ui.screens.basescreen.BaseScreen
 import com.unciv.ui.screens.civilopediascreen.CivilopediaCategories
 import com.unciv.ui.screens.civilopediascreen.CivilopediaScreen
+import com.unciv.ui.screens.overviewscreen.EmpireOverviewCategories
 import com.unciv.ui.screens.overviewscreen.EmpireOverviewScreen
 import com.unciv.ui.screens.pickerscreens.PolicyPickerScreen
 import com.unciv.ui.screens.pickerscreens.TechPickerScreen
@@ -45,7 +46,7 @@ import kotlin.math.roundToInt
  */
 //region Fields
 class WorldScreenTopBar(val worldScreen: WorldScreen) : Table() {
-
+    //TODO shouldn't most onClick be addActivationAction instead?
     private val turnsLabel = "Turns: 0/400".toLabel()
     private val goldLabel = "0".toLabel(colorFromRGB(225, 217, 71))
     private val scienceLabel = "0".toLabel(colorFromRGB(78, 140, 151))
@@ -104,23 +105,23 @@ class WorldScreenTopBar(val worldScreen: WorldScreen) : Table() {
                 if (!isLast) padRight(20f)
             }
         }
-        fun addStat(label: Label, icon: String, overviewPage: String, isLast: Boolean = false) =
+        fun addStat(label: Label, icon: String, overviewPage: EmpireOverviewCategories, isLast: Boolean = false) =
             addStat(label, icon, isLast) { EmpireOverviewScreen(worldScreen.selectedCiv, overviewPage) }
 
-        addStat(goldLabel, "Gold", "Stats")
+        addStat(goldLabel, "Gold", EmpireOverviewCategories.Stats)
         addStat(scienceLabel, "Science") { TechPickerScreen(worldScreen.selectedCiv) }
 
         statsTable.add(happinessImage).padBottom(6f).size(20f)
         statsTable.add(happinessLabel).padRight(20f)
         val invokeResourcesPage = {
-            worldScreen.game.pushScreen(EmpireOverviewScreen(worldScreen.selectedCiv, "Resources"))
+            worldScreen.openEmpireOverview(EmpireOverviewCategories.Resources)
         }
         happinessImage.onClick(invokeResourcesPage)
         happinessLabel.onClick(invokeResourcesPage)
 
         addStat(cultureLabel, "Culture") { PolicyPickerScreen(worldScreen.selectedCiv, worldScreen.canChangeState) }
         if (worldScreen.gameInfo.isReligionEnabled()) {
-            addStat(faithLabel, "Faith", "Religion", isLast = true)
+            addStat(faithLabel, "Faith", EmpireOverviewCategories.Religion, isLast = true)
         } else {
             statsTable.add("Religion: Off".toLabel())
         }
@@ -145,7 +146,7 @@ class WorldScreenTopBar(val worldScreen: WorldScreen) : Table() {
             }
         }
         resourcesWrapper.onClick {
-            worldScreen.game.pushScreen(EmpireOverviewScreen(worldScreen.selectedCiv, "Resources"))
+            worldScreen.openEmpireOverview(EmpireOverviewCategories.Resources)
         }
 
         val strategicResources = worldScreen.gameInfo.ruleset.tileResources.values
@@ -174,12 +175,12 @@ class WorldScreenTopBar(val worldScreen: WorldScreen) : Table() {
 
         init {
             unitSupplyImage.onClick {
-                worldScreen.game.pushScreen(EmpireOverviewScreen(worldScreen.selectedCiv, "Units"))
+                worldScreen.openEmpireOverview(EmpireOverviewCategories.Units)
             }
 
             val overviewButton = "Overview".toTextButton()
             overviewButton.addTooltip('e')
-            overviewButton.onClick { worldScreen.game.pushScreen(EmpireOverviewScreen(worldScreen.selectedCiv)) }
+            overviewButton.onClick { worldScreen.openEmpireOverview() }
 
             unitSupplyCell = add()
             add(overviewButton).pad(10f)
@@ -225,7 +226,7 @@ class WorldScreenTopBar(val worldScreen: WorldScreen) : Table() {
             }
 
             selectedCivIconHolder.onClick {
-                worldScreen.game.pushScreen(EmpireOverviewScreen(worldScreen.selectedCiv))
+                worldScreen.openEmpireOverview()
             }
 
             add(menuButton).size(50f).padRight(0f)


### PR DESCRIPTION
Pure architectural update with one exception
* Triggered by finding a 'shadowed name' warning while searching for something - in a line wider than my screen
* Empire Overview tabs no longer referred to by String everywhere but by "primary key", better coding pattern imho
* I think it's much clearer with overrides instead of delegates
* Serializes the same in settings
* Renaming a unit from the Empire Overview Units tab scrolls back to the unit when done (since the thing was done the cheap way by rebuilding the whole screen, I just supplied the selector introduced with garrison link)