### PR TITLE
City detailed stats popup - fixed header

### DIFF
--- a/core/src/com/unciv/ui/screens/cityscreen/CityConstructionsTable.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/CityConstructionsTable.kt
@@ -59,7 +59,7 @@ private class ConstructionButtonDTO(
 
 /**
  * Manager to hold and coordinate two widgets for the city screen left side:
- * - Construction queue with switch to [ConstructionInfoTable] button and the enqueue / buy buttons.
+ * - Construction queue with the enqueue / buy buttons.
  *   The queue is scrollable, limited to one third of the stage height.
  * - Available constructions display, scrolling, grouped with expanders and therefore of dynamic height.
  */

--- a/core/src/com/unciv/ui/screens/cityscreen/CityScreen.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/CityScreen.kt
@@ -59,15 +59,15 @@ class CityScreen(
     // Clockwise from the top-left
 
     /** Displays current production, production queue and available productions list
-     *  Not a widget, but manages two: construction queue, info toggle button, buy buttons
-     *  in a Table holder on upper LEFT, and available constructions in a ScrollPane lower LEFT.
+     *  Not a widget, but manages two: construction queue + buy buttons
+     *  in a Table holder on TOP LEFT, and available constructions in a ScrollPane BOTTOM LEFT.
      */
     private var constructionsTable = CityConstructionsTable(this)
 
     /** Displays raze city button - sits on TOP CENTER */
     private var razeCityButtonHolder = Table()
 
-    /** Displays city stats info */
+    /** Displays city stats, population management, religion, built buildings info - TOP RIGHT */
     private var cityStatsTable = CityStatsTable(this)
 
     /** Displays tile info, alternate with selectedConstructionTable - sits on BOTTOM RIGHT */

--- a/core/src/com/unciv/ui/screens/cityscreen/DetailedStatsPopup.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/DetailedStatsPopup.kt
@@ -1,5 +1,6 @@
 package com.unciv.ui.screens.cityscreen
 
+import com.badlogic.gdx.Input
 import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.scenes.scene2d.ui.Label
 import com.badlogic.gdx.scenes.scene2d.ui.Table
@@ -13,6 +14,8 @@ import com.unciv.ui.components.KeyCharAndCode
 import com.unciv.ui.components.extensions.addSeparator
 import com.unciv.ui.components.extensions.brighten
 import com.unciv.ui.components.extensions.darken
+import com.unciv.ui.components.extensions.keyShortcuts
+import com.unciv.ui.components.extensions.onActivation
 import com.unciv.ui.components.extensions.onClick
 import com.unciv.ui.components.extensions.packIfNeeded
 import com.unciv.ui.components.extensions.pad
@@ -52,7 +55,7 @@ class DetailedStatsPopup(
         scrollPaneCell.maxHeight(cityScreen.stage.height *3 / 4)
 
         row()
-        addCloseButton("Cancel", KeyCharAndCode('n'))
+        addCloseButton(additionalKey = KeyCharAndCode.SPACE)
         update()
     }
 
@@ -71,10 +74,7 @@ class DetailedStatsPopup(
         val columnCount = stats.size + 1
         val statColMinWidth = if (onlyWithStat != null) 150f else 110f
 
-        headerTable.add(getToggleButton(isDetailed).onClick {
-            isDetailed = !isDetailed
-            update()
-        }).minWidth(150f).grow()
+        headerTable.add(getToggleButton(isDetailed)).minWidth(150f).grow()
 
         for (stat in stats) {
             val label = stat.name.toLabel()
@@ -173,9 +173,18 @@ class DetailedStatsPopup(
     private fun getToggleButton(showDetails: Boolean): IconCircleGroup {
         val label = (if (showDetails) "-" else "+").toLabel()
         label.setAlignment(Align.center)
-        return label
+        val button = label
             .surroundWithCircle(25f, color = BaseScreen.skinStrings.skinConfig.baseColor)
             .surroundWithCircle(27f, false)
+        button.keyShortcuts.run {
+            add(Input.Keys.PLUS)
+            add(Input.Keys.NUMPAD_ADD)
+        }
+        button.onActivation {
+            isDetailed = !isDetailed
+            update()
+        }
+        return button
     }
 
     private fun traverseTree(

--- a/core/src/com/unciv/ui/screens/cityscreen/DetailedStatsPopup.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/DetailedStatsPopup.kt
@@ -37,6 +37,9 @@ class DetailedStatsPopup(
     private val colorTotal: Color = Color.BLUE.brighten(0.5f)
     private val colorSelector: Color = Color.GREEN.darken(0.5f)
 
+    private val percentFormatter = DecimalFormat("0.#%").apply { positivePrefix = "+"; multiplier = 1 }
+    private val decimalFormatter = DecimalFormat("0.#")
+
     init {
         headerTable.defaults().pad(3f, 0f)
         add(headerTable).padBottom(0f).row()
@@ -273,10 +276,6 @@ class DetailedStatsPopup(
         return tbl
     }
 
-    companion object {
-        private fun Float.toPercentLabel() =
-                "${if (this > 0f) "+" else ""}${DecimalFormat("0.#").format(this)}%".toLabel()
-        private fun Float.toOneDecimalLabel() =
-                DecimalFormat("0.#").format(this).toLabel()
-    }
+    private fun Float.toPercentLabel() = percentFormatter.format(this).toLabel()
+    private fun Float.toOneDecimalLabel() = decimalFormatter.format(this).toLabel()
 }


### PR DESCRIPTION
I think #8190 already mentioned this
- a large expanded city stats breakdown scrolled the header up up and away, now no longer.
- "Cancel" sounded wrong, there's no action to cancel.
- Key 'n' to close - nah, space. Key Plus for the toggle, done.
- Why `if() "+" else "-"` when the library code can do that (I think _all_ those could, String.format has the '+' flag too)

No key _binding_ as that currently would force conflicts. City screen will get a keyboard overhaul some time anyway. Rest is comment linting only.