### PR TITLE
Victory screen fixed button position

### DIFF
--- a/core/src/com/unciv/ui/screens/victoryscreen/VictoryScreen.kt
+++ b/core/src/com/unciv/ui/screens/victoryscreen/VictoryScreen.kt
@@ -28,14 +28,13 @@ class VictoryScreen(val worldScreen: WorldScreen) : PickerScreen() {
     private val playerCivInfo = worldScreen.viewingCiv
     private val enabledVictoryTypes = gameInfo.gameParameters.victoryTypes
 
+    private val headerTable = Table()
     private val contentsTable = Table()
 
     private var replayTimer : Timer.Task? = null
 
     init {
         val difficultyLabel = ("{Difficulty}: {${gameInfo.difficulty}}").toLabel()
-        difficultyLabel.setPosition(10f, stage.height - 10, Align.topLeft)
-        stage.addActor(difficultyLabel)
 
         val tabsTable = Table().apply { defaults().pad(10f) }
         val setMyVictoryButton = "Our status".toTextButton().onClick { setOurVictoryTable() }
@@ -81,11 +80,29 @@ class VictoryScreen(val worldScreen: WorldScreen) : PickerScreen() {
             tabsTable.add(replayButton)
         }
 
-        topTable.add(tabsTable)
-        topTable.addSeparator()
+        val headerTableRightCell = Table()
+        val gameSpeedLabel = "{Game Speed}: {${gameInfo.gameParameters.speed}}".toLabel()
+        headerTableRightCell.add(gameSpeedLabel).row()
+        if(enabledVictoryTypes.contains("Time")) {
+            val maxTurnsLabel = "{Max Turns}: ${gameInfo.gameParameters.maxTurns}".toLabel()
+            headerTableRightCell.add(maxTurnsLabel).padTop(5f)
+        }
+
+        val leftCell = headerTable.add(difficultyLabel).padLeft(10f).left()
+        headerTable.add(tabsTable).expandX().center()
+        val rightCell = headerTable.add(headerTableRightCell).padRight(10f).right()
+        headerTable.addSeparator()
+        headerTable.pack()
+        // Make the outer cells the same so that the middle one is properly centered
+        if(leftCell.actorWidth > rightCell.actorWidth) rightCell.width(leftCell.actorWidth)
+        else leftCell.width(rightCell.actorWidth)
+
+        pickerPane.clearChildren()
+        pickerPane.add(headerTable).growX().row()
+        pickerPane.add(splitPane).expand().fill()
+
         topTable.add(contentsTable)
     }
-
 
     private fun wonOrLost(description: String, victoryType: String?, hasWon: Boolean) {
         val endGameMessage =


### PR DESCRIPTION
The buttons on the victory screen were part of a scrollPane, so they were dragged across the screen along with the content.
Another problem was that after the ratings tab, content on other tabs that had previously been fit on the screen in width, started scrolling horizontally.
In addition, after resizing, the difficulty label had the wrong position.

Here's what I did:
* Created a header table with the difficulty label and the buttons
* For easier centering of the buttons, I added a game speed label and a max turns label (only visible in games with a time limit, as it is not displayed anywhere else)

<details><summary>before</summary>

![32_1](https://user-images.githubusercontent.com/1225948/226214712-4111e557-3f5c-43ab-b1ed-a4fe7b234c8b.jpg)
</details>
<details><summary>after</summary>

![32_2](https://user-images.githubusercontent.com/1225948/226214720-a3e4bdeb-8a1b-4910-8897-cd6e2e20e26d.jpg)
</details>
