### PR TITLE
Fixed selected civ update

### DIFF
--- a/core/src/com/unciv/ui/screens/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/WorldScreen.kt
@@ -323,15 +323,17 @@ class WorldScreen(
         if(uiEnabled){
             displayTutorialsOnUpdate()
 
+            bottomUnitTable.update()
+
             updateSelectedCiv()
 
             if (fogOfWar) minimapWrapper.update(selectedCiv)
             else minimapWrapper.update(viewingCiv)
 
-            bottomUnitTable.update()
             bottomTileInfoTable.updateTileTable(mapHolder.selectedTile)
             bottomTileInfoTable.x = stage.width - bottomTileInfoTable.width
             bottomTileInfoTable.y = if (game.settings.showMinimap) minimapWrapper.height else 0f
+
             battleTable.update()
 
             displayTutorialTaskOnUpdate()
@@ -502,11 +504,11 @@ class WorldScreen(
     }
 
     private fun updateSelectedCiv() {
-        selectedCiv = when {
-            bottomUnitTable.selectedUnit != null -> bottomUnitTable.selectedUnit!!.civ
-            bottomUnitTable.selectedCity != null -> bottomUnitTable.selectedCity!!.civ
-            else -> viewingCiv
-        }
+            selectedCiv = when {
+                bottomUnitTable.selectedUnit != null -> bottomUnitTable.selectedUnit!!.civ
+                bottomUnitTable.selectedCity != null -> bottomUnitTable.selectedCity!!.civ
+                else -> viewingCiv
+            }
     }
 
     private fun createFogOfWarButton(): TextButton {

--- a/core/src/com/unciv/ui/screens/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/WorldScreen.kt
@@ -504,11 +504,11 @@ class WorldScreen(
     }
 
     private fun updateSelectedCiv() {
-            selectedCiv = when {
-                bottomUnitTable.selectedUnit != null -> bottomUnitTable.selectedUnit!!.civ
-                bottomUnitTable.selectedCity != null -> bottomUnitTable.selectedCity!!.civ
-                else -> viewingCiv
-            }
+        selectedCiv = when {
+            bottomUnitTable.selectedUnit != null -> bottomUnitTable.selectedUnit!!.civ
+            bottomUnitTable.selectedCity != null -> bottomUnitTable.selectedCity!!.civ
+            else -> viewingCiv
+        }
     }
 
     private fun createFogOfWarButton(): TextButton {


### PR DESCRIPTION
`updateSelectedCiv()` depends on `bottomUnitTable`, so `bottomUnitTable.update()` must be called before `updateSelectedCiv()`
My bad, messed it up when implemented the dynamic minimap. I double-checked the order of `worldScreen.Update()`, it looks like everything is correct now