### PR TITLE
Improvements in science display

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -788,6 +788,7 @@ You need to restart the game for this change to take effect. =
 # Notifications
 
 Research of [technologyName] has completed! = 
+We gained [amount] Science from Research Agreement = 
 [construction] has become obsolete and was removed from the queue in [cityName]! = 
 [construction] has become obsolete and was removed from the queue in [amount] cities! = 
 [cityName] changed production from [oldUnit] to [newUnit] = 

--- a/core/src/com/unciv/logic/civilization/managers/TechManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/TechManager.kt
@@ -90,6 +90,8 @@ class TechManager : IsPartOfGameInfoSerialization {
 
     fun getNumberOfTechsResearched(): Int = techsResearched.size
 
+    fun getOverflowScience(): Int = overflowScience
+
     private fun getRuleset() = civInfo.gameInfo.ruleset
 
     fun costOfTech(techName: String): Int {
@@ -131,9 +133,12 @@ class TechManager : IsPartOfGameInfoSerialization {
 
     fun remainingScienceToTech(techName: String) = costOfTech(techName) - researchOfTech(techName)
 
-    fun turnsToTech(techName: String) = when {
-        civInfo.stats.statsForNextTurn.science <= 0f -> "∞"
-        else -> max(1, ceil(remainingScienceToTech(techName).toDouble() / civInfo.stats.statsForNextTurn.science).toInt()).toString()
+    fun turnsToTech(techName: String): String {
+        val spareScience = if (canBeResearched(techName)) overflowScience else 0
+        return when {
+            civInfo.stats.statsForNextTurn.science <= 0f -> "∞"
+            else -> max(1, ceil((remainingScienceToTech(techName).toDouble() - spareScience) / civInfo.stats.statsForNextTurn.science).toInt()).toString()
+        }
     }
 
     fun isResearched(techName: String): Boolean = techsResearched.contains(techName)

--- a/core/src/com/unciv/logic/civilization/managers/TechManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/TechManager.kt
@@ -131,13 +131,17 @@ class TechManager : IsPartOfGameInfoSerialization {
     fun researchOfTech(TechName: String?) = techsInProgress[TechName] ?: 0
     // Was once duplicated as fun scienceSpentOnTech(tech: String): Int
 
-    fun remainingScienceToTech(techName: String) = costOfTech(techName) - researchOfTech(techName)
+    fun remainingScienceToTech(techName: String): Int {
+        val spareScience = if (canBeResearched(techName)) overflowScience else 0
+        return costOfTech(techName) - researchOfTech(techName) - spareScience
+    }
 
     fun turnsToTech(techName: String): String {
-        val spareScience = if (canBeResearched(techName)) overflowScience else 0
+        val remainingCost = remainingScienceToTech(techName).toDouble()
         return when {
+            remainingCost <= 0f -> "1"
             civInfo.stats.statsForNextTurn.science <= 0f -> "∞"
-            else -> max(1, ceil((remainingScienceToTech(techName).toDouble() - spareScience) / civInfo.stats.statsForNextTurn.science).toInt()).toString()
+            else -> max(1, ceil(remainingCost / civInfo.stats.statsForNextTurn.science).toInt()).toString()
         }
     }
 

--- a/core/src/com/unciv/logic/civilization/managers/TechManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/TechManager.kt
@@ -240,7 +240,12 @@ class TechManager : IsPartOfGameInfoSerialization {
     fun addScience(scienceGet: Int) {
         val currentTechnology = currentTechnologyName() ?: return
         techsInProgress[currentTechnology] = researchOfTech(currentTechnology) + scienceGet
-        if (techsInProgress[currentTechnology]!! < costOfTech(currentTechnology))
+
+        checkTech(currentTechnology)
+    }
+
+    fun checkTech(currentTechnology: String?) {
+        if (currentTechnology == null || techsInProgress[currentTechnology]!! < costOfTech(currentTechnology))
             return
 
         // We finished it!

--- a/core/src/com/unciv/logic/civilization/managers/TechManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/TechManager.kt
@@ -218,8 +218,12 @@ class TechManager : IsPartOfGameInfoSerialization {
         var finalScienceToAdd = scienceForNewTurn
 
         if (scienceFromResearchAgreements != 0) {
-            finalScienceToAdd += scienceFromResearchAgreements()
+            val scienceBoost = scienceFromResearchAgreements()
+            finalScienceToAdd += scienceBoost
             scienceFromResearchAgreements = 0
+            civInfo.addNotification("We gained [$scienceBoost] Science from Research Agreement",
+                NotificationCategory.General,
+                NotificationIcon.Science)
         }
         if (overflowScience != 0) { // https://forums.civfanatics.com/threads/the-mechanics-of-overflow-inflation.517970/
             val techsResearchedKnownCivs = civInfo.getKnownCivs()

--- a/core/src/com/unciv/logic/civilization/managers/TechManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/TechManager.kt
@@ -240,12 +240,7 @@ class TechManager : IsPartOfGameInfoSerialization {
     fun addScience(scienceGet: Int) {
         val currentTechnology = currentTechnologyName() ?: return
         techsInProgress[currentTechnology] = researchOfTech(currentTechnology) + scienceGet
-
-        checkTech(currentTechnology)
-    }
-
-    fun checkTech(currentTechnology: String?) {
-        if (currentTechnology == null || techsInProgress[currentTechnology]!! < costOfTech(currentTechnology))
+        if (techsInProgress[currentTechnology]!! < costOfTech(currentTechnology))
             return
 
         // We finished it!

--- a/core/src/com/unciv/logic/civilization/managers/TurnManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/TurnManager.kt
@@ -31,7 +31,7 @@ class TurnManager(val civInfo: Civilization) {
         }
 
         if (civInfo.cities.isNotEmpty() && civInfo.gameInfo.ruleset.technologies.isNotEmpty())
-            civInfo.tech.addScience(0)
+            civInfo.tech.checkResearchProgress()
 
         civInfo.civConstructions.startTurn()
         civInfo.attacksSinceTurnStart.clear()

--- a/core/src/com/unciv/logic/civilization/managers/TurnManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/TurnManager.kt
@@ -31,7 +31,7 @@ class TurnManager(val civInfo: Civilization) {
         }
 
         if (civInfo.cities.isNotEmpty() && civInfo.gameInfo.ruleset.technologies.isNotEmpty())
-            civInfo.tech.checkTech(civInfo.tech.currentTechnologyName())
+            civInfo.tech.addScience(0)
 
         civInfo.civConstructions.startTurn()
         civInfo.attacksSinceTurnStart.clear()

--- a/core/src/com/unciv/logic/civilization/managers/TurnManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/TurnManager.kt
@@ -30,6 +30,9 @@ class TurnManager(val civInfo: Civilization) {
             civInfo.statsHistory.recordRankingStats(civInfo)
         }
 
+        if (civInfo.cities.isNotEmpty() && civInfo.gameInfo.ruleset.technologies.isNotEmpty())
+            civInfo.tech.checkTech(civInfo.tech.currentTechnologyName())
+
         civInfo.civConstructions.startTurn()
         civInfo.attacksSinceTurnStart.clear()
         civInfo.updateStatsForNextTurn() // for things that change when turn passes e.g. golden age, city state influence

--- a/core/src/com/unciv/logic/civilization/managers/TurnManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/TurnManager.kt
@@ -31,7 +31,7 @@ class TurnManager(val civInfo: Civilization) {
         }
 
         if (civInfo.cities.isNotEmpty() && civInfo.gameInfo.ruleset.technologies.isNotEmpty())
-            civInfo.tech.checkResearchProgress()
+            civInfo.tech.updateResearchProgress()
 
         civInfo.civConstructions.startTurn()
         civInfo.attacksSinceTurnStart.clear()

--- a/core/src/com/unciv/ui/screens/pickerscreens/TechPickerScreen.kt
+++ b/core/src/com/unciv/ui/screens/pickerscreens/TechPickerScreen.kt
@@ -115,6 +115,8 @@ class TechPickerScreen(
         }
         else civTech.techsToResearch = tempTechsToResearch
 
+        civTech.checkResearchProgress()
+
         game.settings.addCompletedTutorialTask("Pick technology")
 
         game.popScreen()
@@ -424,7 +426,7 @@ class TechPickerScreen(
     }
 
     private fun getTechProgressLabel(techs: List<String>): String {
-        val progress = techs.sumOf { tech -> civTech.researchOfTech(tech) } + civTech.getOverflowScience()
+        val progress = techs.sumOf { tech -> civTech.researchOfTech(tech) } + civTech.getOverflowScience(techs.first())
         val techCost = techs.sumOf { tech -> civInfo.tech.costOfTech(tech) }
         return "(${progress}/${techCost})"
     }

--- a/core/src/com/unciv/ui/screens/pickerscreens/TechPickerScreen.kt
+++ b/core/src/com/unciv/ui/screens/pickerscreens/TechPickerScreen.kt
@@ -424,7 +424,7 @@ class TechPickerScreen(
     }
 
     private fun getTechProgressLabel(techs: List<String>): String {
-        val progress = techs.sumOf { tech -> civTech.researchOfTech(tech) }
+        val progress = techs.sumOf { tech -> civTech.researchOfTech(tech) } + civTech.getOverflowScience()
         val techCost = techs.sumOf { tech -> civInfo.tech.costOfTech(tech) }
         return "(${progress}/${techCost})"
     }

--- a/core/src/com/unciv/ui/screens/pickerscreens/TechPickerScreen.kt
+++ b/core/src/com/unciv/ui/screens/pickerscreens/TechPickerScreen.kt
@@ -115,7 +115,7 @@ class TechPickerScreen(
         }
         else civTech.techsToResearch = tempTechsToResearch
 
-        civTech.checkResearchProgress()
+        civTech.updateResearchProgress()
 
         game.settings.addCompletedTutorialTask("Pick technology")
 


### PR DESCRIPTION
What is done:
* Science overflow is now displayed when picking new tech and is taken into account when calculating the number of turns for research
* Notification with the amount of science from a research agreement
* Checking for tech completion at the beginnig of a turn(for cases when there are 2 turns left before the end of the research and another civilization is completing research of the same technology on the current turn and research costs decrease)