### PR TITLE
More Spectator/Barbarians fixes related to income

### DIFF
--- a/core/src/com/unciv/logic/civilization/Civilization.kt
+++ b/core/src/com/unciv/logic/civilization/Civilization.kt
@@ -505,7 +505,7 @@ class Civilization : IsPartOfGameInfoSerialization {
      */
     fun isDefeated() = when {
         isBarbarian() || isSpectator() -> false     // Barbarians and voyeurs can't lose
-        hasEverOwnedOriginalCapital == true -> cities.isEmpty()
+        hasEverOwnedOriginalCapital -> cities.isEmpty()
         else -> units.getCivUnits().none()
     }
 

--- a/core/src/com/unciv/logic/civilization/diplomacy/CityStateFunctions.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/CityStateFunctions.kt
@@ -222,7 +222,7 @@ class CityStateFunctions(val civInfo: Civilization) {
         var newAllyName: String? = null
         if (!civInfo.isCityState()) return
         val maxInfluence = civInfo.diplomacy
-            .filter { !it.value.otherCiv().isCityState() && !it.value.otherCiv().isDefeated() }
+            .filter { it.value.otherCiv().isMajorCiv() && !it.value.otherCiv().isDefeated() }
             .maxByOrNull { it.value.getInfluence() }
         if (maxInfluence != null && maxInfluence.value.getInfluence() >= 60) {
             newAllyName = maxInfluence.key

--- a/core/src/com/unciv/logic/civilization/managers/TurnManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/TurnManager.kt
@@ -17,6 +17,7 @@ import com.unciv.logic.trade.TradeEvaluation
 import com.unciv.models.ruleset.ModOptionsConstants
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.ruleset.unique.endTurn
+import com.unciv.models.stats.Stats
 import com.unciv.ui.components.MayaCalendar
 import java.util.*
 import kotlin.math.max
@@ -213,8 +214,6 @@ class TurnManager(val civInfo: Civilization) {
 
 
     fun endTurn() {
-        if (civInfo.isSpectator()) return
-
         val notificationsLog = civInfo.notificationsLog
         val notificationsThisTurn = Civilization.NotificationsLog(civInfo.gameInfo.turns)
         notificationsThisTurn.notifications.addAll(civInfo.notifications)
@@ -228,9 +227,15 @@ class TurnManager(val civInfo: Civilization) {
 
         civInfo.notifications.clear()
 
-        civInfo.updateStatsForNextTurn()
+        if (civInfo.isDefeated() || civInfo.isSpectator()) return  // yes they do call this, best not update any further stuff
 
-        val nextTurnStats = civInfo.stats.statsForNextTurn
+        var nextTurnStats =
+            if (civInfo.isBarbarian())
+                Stats()
+            else {
+                civInfo.updateStatsForNextTurn()
+                civInfo.stats.statsForNextTurn
+            }
 
         civInfo.policies.endTurn(nextTurnStats.culture.toInt())
         civInfo.totalCultureForContests += nextTurnStats.culture.toInt()
@@ -239,17 +244,18 @@ class TurnManager(val civInfo: Civilization) {
             civInfo.questManager.endTurn()
 
         // disband units until there are none left OR the gold values are normal
-        if (!civInfo.isBarbarian() && civInfo.gold < -100 && nextTurnStats.gold.toInt() < 0) {
-            for (i in 1 until (civInfo.gold / -100)) {
-                var civMilitaryUnits = civInfo.units.getCivUnits().filter { it.baseUnit.isMilitary() }
-                if (civMilitaryUnits.any()) {
-                    val unitToDisband = civMilitaryUnits.first()
-                    unitToDisband.disband()
-                    civMilitaryUnits -= unitToDisband
-                    val unitName = unitToDisband.shortDisplayName()
-                    civInfo.addNotification("Cannot provide unit upkeep for $unitName - unit has been disbanded!", NotificationCategory.Units, unitName, NotificationIcon.Death)
-                }
-            }
+        if (!civInfo.isBarbarian() && civInfo.gold <= -200 && nextTurnStats.gold.toInt() < 0) {
+            val militaryUnits = civInfo.units.getCivUnits().filter { it.isMilitary() }
+            do {
+                val unitToDisband = militaryUnits.minByOrNull { it.baseUnit.cost }
+                    // or .firstOrNull()?
+                    ?: break
+                unitToDisband.disband()
+                val unitName = unitToDisband.shortDisplayName()
+                civInfo.addNotification("Cannot provide unit upkeep for $unitName - unit has been disbanded!", NotificationCategory.Units, unitName, NotificationIcon.Death)
+                civInfo.updateStatsForNextTurn()  // recalculate unit upkeep
+                nextTurnStats = civInfo.stats.statsForNextTurn
+            } while (civInfo.gold <= -200 && nextTurnStats.gold.toInt() < 0)
         }
 
         civInfo.addGold( nextTurnStats.gold.toInt() )
@@ -265,13 +271,10 @@ class TurnManager(val civInfo: Civilization) {
         if (civInfo.isMajorCiv()) // City-states don't get great people!
             civInfo.greatPeople.addGreatPersonPoints()
 
-        // To handle tile's owner issue (#8246), we need to run being razed city first.
-        for (city in sequence {
-            yieldAll(civInfo.cities.filter { it.isBeingRazed })
-            yieldAll(civInfo.cities.filterNot { it.isBeingRazed })
-        }.toList()) { // a city can be removed while iterating (if it's being razed) so we need to iterate over a copy
+        // To handle tile's owner issue (#8246), we need to run cities being razed first.
+        // a city can be removed while iterating (if it's being razed) so we need to iterate over a copy - sorting does one
+        for (city in civInfo.cities.sortedByDescending { it.isBeingRazed })
             CityTurnManager(city).endTurn()
-        }
 
         civInfo.temporaryUniques.endTurn()
 

--- a/core/src/com/unciv/ui/screens/overviewscreen/EmpireOverviewCategories.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/EmpireOverviewCategories.kt
@@ -25,6 +25,7 @@ enum class EmpireOverviewCategories(
     Stats("StatIcons/Gold", 'S', Align.top) {
         override fun createTab(viewingPlayer: Civilization, overviewScreen: EmpireOverviewScreen, persistedData: EmpireOverviewTabPersistableData?) =
                 StatsOverviewTab(viewingPlayer, overviewScreen)
+        override fun showDisabled(viewingPlayer: Civilization) = viewingPlayer.isSpectator()
     },
     Trades("StatIcons/Acquire", 'T', Align.top) {
         override fun createTab(viewingPlayer: Civilization, overviewScreen: EmpireOverviewScreen, persistedData: EmpireOverviewTabPersistableData?) =

--- a/tests/src/com/unciv/uniques/TriggeredUniquesTests.kt
+++ b/tests/src/com/unciv/uniques/TriggeredUniquesTests.kt
@@ -39,6 +39,9 @@ class TriggeredUniquesTests {
     @Test
     fun testConditionalTimedUniqueExpires() {
         civInfo.policies.adopt(policy, true)
+        // For endTurn to do the part we need, the civ must be alive - have a city or unit,
+        // and right now that attacker is not in the civ's unit list
+        civInfo.units.addUnit(attacker.unit, false)
         TurnManager(civInfo).endTurn()
         val modifiers = BattleDamage.getAttackModifiers(attacker, defender)
         Assert.assertTrue("Timed Strength should no longer work after endTurn", modifiers.sumValues() == 0)


### PR DESCRIPTION
OK, here my branch where I analyzed that "Spectator" game. Inspect and take apart at your leisure.

- Spectator gets relevant notifications -> better let the normal code for notif log history turnaround run before the early exit
- Defated Civs still _do_ run endTurn. I'll leave the startTurn - obviously should go there too, but that's an ass-umption, I didn't test.
- Barbarians now get 0 income - no --gold, no golden ages. Likely un-noticeable unless you read the saved json, so more defense-in-depth kind of thing.
- That CityStateFunctions test - no-brainer. !isCityState includes major, barbs, and speccie... Unnecessary.
- The spectator doesn't need to see his own stats in overview - like +N happiness for seeing all natural wonders
- The razing-first: Before had two filters, both materializing as list 'cuz source not a seq, then yieldall into a seq builder, then tolist - one simple sort is enough, and does only the one copy we need.
- The disband for debt code had a few flaws, and one 'I'm not sure about' - open to discussion.
    - The for loop never took into account any change due to disband - `1 until N` is a range constructor, so N is never re-evaluated.
    - `1 until (gold/-100)` executes its first iteration when gold falls to -200 or below - upper end exclusive. So the guarding `if` should also test <= -200
    - maintenance should be recalculated
    - the sequence is built, then used, then that `-=` operator... Someone was thinking in Set's, or the seq was patched in later - this wraps the seq into another one avoiding the entry - sequences! To take an element out, you need to complicate the instructions it represents. Another malloc.
    - ..and then it was discarded anyway
    - Now something very debatable: That `first()` was as good as nondeterministic - if playing without reloads, order of creation, more or less, probably. Load - rebuilt from tilemap, tile enumeration order. Disbanding the cheapest first - or better the GDR that is more likely to cancel the debt??? Or plonk the original back in as in that comment?

- ~~I'll check that failing test soon~~ - it tested an incomplete situation conflicting with the isDefeated test now in there