### PR TITLE
Omit irrelevant warnings from startup console log

### DIFF
--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -506,8 +506,13 @@ object RulesetCache : HashMap<String,Ruleset>() {
                 debug("Mod loaded successfully: %s", modRuleset.name)
                 if (Log.shouldLog()) {
                     val modLinksErrors = modRuleset.checkModLinks()
-                    if (modLinksErrors.any()) {
-                        debug("checkModLinks errors: %s", modLinksErrors.getErrorText())
+                    // For extension mods which use references to base ruleset objects, the parameter type
+                    // errors are irrelevant - the checker ran without a base ruleset
+                    val logFilter: (RulesetError) -> Boolean =
+                        if (modRuleset.modOptions.isBaseRuleset) { { it.errorSeverityToReport > RulesetErrorSeverity.WarningOptionsOnly } }
+                        else { { it.errorSeverityToReport > RulesetErrorSeverity.WarningOptionsOnly && !it.text.contains("does not fit parameter type") } }
+                    if (modLinksErrors.any(logFilter)) {
+                        debug("checkModLinks errors: %s", modLinksErrors.getErrorText(logFilter))
                     }
                 }
             } catch (ex: Exception) {

--- a/core/src/com/unciv/models/ruleset/RulesetValidator.kt
+++ b/core/src/com/unciv/models/ruleset/RulesetValidator.kt
@@ -572,7 +572,9 @@ class RulesetErrorList : ArrayList<RulesetError>() {
     fun isWarnUser() = getFinalSeverity() >= RulesetErrorSeverity.Warning
 
     fun getErrorText(unfiltered: Boolean = false) =
-            filter { unfiltered || it.errorSeverityToReport != RulesetErrorSeverity.WarningOptionsOnly }
+            getErrorText { unfiltered || it.errorSeverityToReport != RulesetErrorSeverity.WarningOptionsOnly }
+    fun getErrorText(filter: (RulesetError)->Boolean) =
+            filter(filter)
                 .sortedByDescending { it.errorSeverityToReport }
                 .joinToString("\n") { it.errorSeverityToReport.name + ": " + it.text }
 }


### PR DESCRIPTION
Tiny thing, likely not worth it, affects us coders only:
![image](https://user-images.githubusercontent.com/63000004/227717793-e5bc3f2e-d8de-4ab3-99a3-c40a9194c082.png)
 (That's the _before_ result, after it's quiet until you actually _got_ problems)