### PR TITLE
TechPickerScreen colors - skinnable and prettier Future Tech

### DIFF
--- a/core/src/com/unciv/models/skins/SkinStrings.kt
+++ b/core/src/com/unciv/models/skins/SkinStrings.kt
@@ -63,4 +63,10 @@ class SkinStrings(skin: String = UncivGame.Current.settings.skin) {
         }
         return ImageGetter.getNinePatch(location, tint)
     }
+
+    fun getUIColor(path: String, default: Color? = null) =
+            skinConfig.skinVariants[path]?.tint
+                ?: default
+                ?: skinConfig.clearColor
+
 }

--- a/core/src/com/unciv/ui/screens/pickerscreens/TechPickerScreen.kt
+++ b/core/src/com/unciv/ui/screens/pickerscreens/TechPickerScreen.kt
@@ -58,11 +58,11 @@ class TechPickerScreen(
     private var researchableTechs = civInfo.gameInfo.ruleset.technologies.keys
             .filter { civTech.canBeResearched(it) }.toHashSet()
 
-    private val currentTechColor = colorFromRGB(72, 147, 175)
-    private val researchedTechColor = colorFromRGB(255, 215, 0)
-    private val researchableTechColor = colorFromRGB(28, 170, 0)
-    private val queuedTechColor = colorFromRGB(7*2, 46*2, 43*2)
-
+    private val currentTechColor = skinStrings.getUIColor("TechPickerScreen/CurrentTechColor", colorFromRGB(72, 147, 175))
+    private val researchedTechColor = skinStrings.getUIColor("TechPickerScreen/ResearchedTechColor", colorFromRGB(255, 215, 0))
+    private val researchableTechColor = skinStrings.getUIColor("TechPickerScreen/ResearchableTechColor", colorFromRGB(28, 170, 0))
+    private val queuedTechColor = skinStrings.getUIColor("TechPickerScreen/QueuedTechColor", colorFromRGB(7*2, 46*2, 43*2))
+    private val researchedFutureTechColor = skinStrings.getUIColor("TechPickerScreen/ResearchedFutureTechColor", colorFromRGB(127, 50, 0))
 
     private val turnsToTech = civInfo.gameInfo.ruleset.technologies.values.associateBy({ it.name }, { civTech.turnsToTech(it.name) })
 
@@ -201,8 +201,10 @@ class TechPickerScreen(
 
     private fun setButtonsInfo() {
         for ((techName, techButton) in techNameToButton) {
+            val isResearched = civTech.isResearched(techName)
             techButton.setButtonColor(when {
-                civTech.isResearched(techName) && techName != Constants.futureTech -> researchedTechColor
+                isResearched && techName != Constants.futureTech -> researchedTechColor
+                isResearched -> researchedFutureTechColor
                 // if we're here to pick a free tech, show the current tech like the rest of the researchables so it'll be obvious what we can pick
                 tempTechsToResearch.firstOrNull() == techName && !freeTechPick -> currentTechColor
                 researchableTechs.contains(techName) -> researchableTechColor
@@ -210,16 +212,11 @@ class TechPickerScreen(
                 else -> Color.BLACK.cpy()
             })
 
-            if (civTech.isResearched(techName) && techName != Constants.futureTech) {
+            if (isResearched && techName != Constants.futureTech) {
                 techButton.text.color = colorFromRGB(154, 98, 16)
-                techButton.color = researchedTechColor.cpy().darken(0.5f)
             }
 
-            if (techName == selectedTech?.name && civTech.isResearched(techName)) {
-                techButton.setButtonColor(colorFromRGB(230, 220, 114))
-            }
-
-            if (!civTech.isResearched(techName) || techName == Constants.futureTech) {
+            if (!isResearched || techName == Constants.futureTech) {
                 techButton.turns.setText(turnsToTech[techName] + "${Fonts.turn}".tr())
             }
 

--- a/desktop/src/com/unciv/app/desktop/UiElementDocsWriter.kt
+++ b/desktop/src/com/unciv/app/desktop/UiElementDocsWriter.kt
@@ -20,17 +20,28 @@ class UiElementDocsWriter {
         val startIndex = originalLines.indexOf(startMarker).takeIf { it != -1 } ?: (endIndex + 1)
 
         val elements = mutableListOf<String>()
+        val backgroundRegex = Regex("""getUiBackground\((\X*?)"(?<path>.*)"[ ,\n\r]*((BaseScreen\.)?skinStrings\.(?<default>.*)Shape)?\X*?\)""")
+        val colorRegex = Regex("""
+            getUIColor\s*\(\s*          # function call, whitespace around opening round bracket optional. All \s also allow line breaks!
+            "(?<path>[^"]*)"\s*         # captures "path", anything between double-quotes, not allowing for embedded quotes
+            (?:,\s*                     # group for optional default parameter
+                (?:default\s*=\s*)?     # allow for named parameter
+                (?:Colors\s*\(|colorFromRGB\s*\(|Color\.)   # recognize only Color constructor, colorFromRGB helper, or Color.* constants as argument
+                (?<default>[^)]*)       # capture "default" up until a closing round bracket
+            )\s*\)                      # ends default parameter group and checks closing round bracket of the getUIColor call
+            """, RegexOption.COMMENTS)
 
         for (file in srcFile.walk()) {
             if (file.path.endsWith(".kt")) {
-                val results = Regex("getUiBackground\\((\\X*?)\"(?<path>.*)\"[ ,\n\r]*((BaseScreen\\.)?skinStrings\\.(?<defaultShape>.*)Shape)?\\X*?\\)")
-                    .findAll(file.readText())
-                for (result in results) {
+                val sourceText = file.readText()
+                val matches: Sequence<MatchResult> =
+                        backgroundRegex.findAll(sourceText) + colorRegex.findAll(sourceText)
+                for (result in matches) {
                     val path = result.groups["path"]?.value
                     val name = path?.takeLastWhile { it != '/' } ?: ""
-                    val defaultShape = result.groups["defaultShape"]?.value
+                    val default = result.groups["default"]?.value
                     if (name.isNotBlank())
-                        elements.add("| ${path!!.dropLast(name.length)} | $name | $defaultShape | |")
+                        elements.add("| ${path!!.dropLast(name.length)} | $name | $default | |")
                 }
             }
         }

--- a/docs/Modders/Creating-a-UI-skin.md
+++ b/docs/Modders/Creating-a-UI-skin.md
@@ -94,6 +94,11 @@ These shapes are used all over Unciv and can be replaced to make a lot of UI ele
 | TechPickerScreen/ | Background | null | |
 | TechPickerScreen/ | Background | null | |
 | TechPickerScreen/ | BottomTable | null | |
+| TechPickerScreen/ | CurrentTechColor | 72, 147, 175 | |
+| TechPickerScreen/ | QueuedTechColor | 7*2, 46*2, 43*2 | |
+| TechPickerScreen/ | ResearchableTechColor | 28, 170, 0 | |
+| TechPickerScreen/ | ResearchedFutureTechColor | 127, 50, 0 | |
+| TechPickerScreen/ | ResearchedTechColor | 255, 215, 0 | |
 | TechPickerScreen/ | TechButtonIconsOutline | roundedEdgeRectangleSmall | |
 | VictoryScreen/ | CivGroup | roundedEdgeRectangle | |
 | WorldScreen/ | AirUnitTable | null | |


### PR DESCRIPTION
<details><summary>Before</summary>

![image](https://user-images.githubusercontent.com/63000004/227723408-61421d54-d7d9-4784-8468-0c45cf1667ee.png)
![image](https://user-images.githubusercontent.com/63000004/227723415-365d01bd-006f-45d9-aea5-e4750e5444a0.png)
</details>

<details><summary>After</summary>

![image](https://user-images.githubusercontent.com/63000004/227723435-1bf37a92-057c-46bf-be28-7f16db96fde6.png)
![image](https://user-images.githubusercontent.com/63000004/227723440-621a15ce-2082-48f9-9388-bf80ca28694c.png)
</details>

* The code I removed without replacement - couldn't find any effect. See second before/after - identical.
* That color was a just wild guess with numbers not from an actual color picker - why not. Plus anyone can mod it now.
* I know that could have stayed just _one_ regex. I think readability/performance balance - are close, and who cares for +/- 10%.

...
* There's still another potential issue with future tech: Getting free techs while it's already the only option will a) reset normal progress and b) increase inflation, so that's not really "free". Will anybody even notice?