### PR TITLE
Unit overview force column, close promote exploit

### DIFF
--- a/core/src/com/unciv/ui/screens/pickerscreens/PromotionPickerScreen.kt
+++ b/core/src/com/unciv/ui/screens/pickerscreens/PromotionPickerScreen.kt
@@ -62,7 +62,7 @@ class PromotionNode(val promotion: Promotion) {
     }
 
     class CustomComparator(
-        val baseNode: PromotionNode
+        private val baseNode: PromotionNode
     ) : Comparator<PromotionNode> {
         override fun compare(a: PromotionNode, b: PromotionNode): Int {
             val baseName = baseNode.baseName
@@ -78,15 +78,15 @@ class PromotionNode(val promotion: Promotion) {
 
 }
 
-class PromotionButton(
+private class PromotionButton(
     val node: PromotionNode,
     val isPickable: Boolean = true,
     val isPromoted: Boolean = false
-
 ) : BorderedTable(
     path="PromotionScreen/PromotionButton",
     defaultBgShape = BaseScreen.skinStrings.roundedEdgeRectangleMidShape,
-    defaultBgBorder = BaseScreen.skinStrings.roundedEdgeRectangleMidBorderShape) {
+    defaultBgBorder = BaseScreen.skinStrings.roundedEdgeRectangleMidBorderShape
+) {
 
     var isSelected = false
     val label = node.promotion.name.toLabel().apply {
@@ -132,11 +132,11 @@ class PromotionButton(
 class PromotionPickerScreen(val unit: MapUnit) : PickerScreen(), RecreateOnResize {
 
     companion object Colors {
-        val Default:Color = Color.BLACK
-        val Selected:Color = colorFromRGB(72, 147, 175)
-        val Promoted:Color = colorFromRGB(255, 215, 0).darken(0.2f)
-        val Pickable:Color = colorFromRGB(28, 80, 0)
-        val Prerequisite:Color = colorFromRGB(14, 92, 86)
+        val Default: Color = Color.BLACK
+        val Selected: Color = colorFromRGB(72, 147, 175)
+        val Promoted: Color = colorFromRGB(255, 215, 0).darken(0.2f)
+        val Pickable: Color = colorFromRGB(28, 80, 0)
+        val Prerequisite: Color = colorFromRGB(14, 92, 86)
     }
 
     private val promotionsTable = Table()
@@ -250,10 +250,8 @@ class PromotionPickerScreen(val unit: MapUnit) : PickerScreen(), RecreateOnResiz
             // Choose best predecessor - the one with less depth
             var best: PromotionNode? = null
             for (predecessor in node.predecessors) {
-                if (best == null)
+                if (best == null || predecessor.maxDepth < best.maxDepth)
                     best = predecessor
-                else
-                    best = if (predecessor.maxDepth < best.maxDepth) predecessor else best
             }
 
             // Remove everything else, leave only best


### PR DESCRIPTION
Individual commits:
* [Close exploit allowing promotion with 0 movement](https://github.com/yairm210/Unciv/commit/565bd002dd65f49913932eb37cc42f3c09533b24)
        Caused by the picker first doing the right check and disabling the right side button, but soon after on the actual selection of a promotion - poof. So, one could promote after attacking or with zero movement via unit overview or via unittable click, even if blocked as unit action...

* [Replace Unit Overview health column with Force](https://github.com/yairm210/Unciv/commit/2ffde754db46e1fca577084d2a2ce4606a79610b)
        I think ages ago we hinted that health is redundant since there is already the health _bar_ on the  left
        Force was readily available and may be useful if/once we make that grid sortable
        I would prefer some abstraction instead of a raw number - get max over all units on the map, percentage to color gradient, map to a list of icons (wet towel to gorilla 🐁🐀🐍🐈🐒🐐🐅🦏🦍🐘) - potentially expensive and far more work than this. Not doing such a thing without some guidance what would be attractive/useful here.

* [Linting](https://github.com/yairm210/Unciv/commit/10f5dbd82bed117b6fee2b8a8c9f5306f4f1cada)
        May actually improve promotion column in rare cases - trigger "hey why detour over floats when ints do" -> I noticed it wasn't including the promote star in the layout formula...

For laughs: Every single emoji up there is completely different in edit mode from here.
![image](https://user-images.githubusercontent.com/63000004/227737754-6079fc9a-5e7f-4083-a983-6f722a4e9574.png)

* Note: **AI can still promote with 0 movement points** if I read that code correctly (`UnitAutomation.tryUpgradeUnit` doesn't check, but perhaps the check is upsstream)