### PR TITLE
Automated Civilians don't multi-turn path through Enemy Territory

### DIFF
--- a/core/src/com/unciv/logic/map/mapunit/UnitMovement.kt
+++ b/core/src/com/unciv/logic/map/mapunit/UnitMovement.kt
@@ -237,6 +237,7 @@ class UnitMovement(val unit: MapUnit) {
         val newTilesToCheck = ArrayList<Tile>()
         var considerZoneOfControl = true // only for first distance!
         val visitedTiles: HashSet<Tile> = hashSetOf(currentTile)
+        val civilization = unit.civ
 
         while (true) {
             if (distance == 2) { // only set this once after distance > 1
@@ -260,6 +261,9 @@ class UnitMovement(val unit: MapUnit) {
                 for (reachableTile in distanceToTilesThisTurn.keys) {
                     // Avoid damaging terrain on first pass
                     if (avoidDamagingTerrain && unit.getDamageFromTerrain(reachableTile) > 0)
+                        continue
+                    // Avoid Enemy Territory if Civilian and Automated. For multi-turn pathing
+                    if (unit.isCivilian() && unit.isAutomated() && reachableTile.isEnemyTerritory(civilization))
                         continue
                     if (reachableTile == destination) {
                         val path = mutableListOf(destination)


### PR DESCRIPTION
Should fix #8811 

Notice Automated Worker intentionally skirts Enemy territory
![image](https://user-images.githubusercontent.com/44038014/227756492-d3be9c76-dfac-4e60-abb4-ff283d39ea50.png)

Does make it seem like Workers can't enter Enemy Territory while the Automated Flag is still active. Selected Mine in enemy territory and doesn't allow it.
![image](https://user-images.githubusercontent.com/44038014/227756533-3c9f54fa-2b76-4501-ad64-17cb135df4c0.png)

But Non-Automated Workers can still path
![image](https://user-images.githubusercontent.com/44038014/227756567-76f1616e-0dd4-43bc-93f8-22911c1ac6a1.png)

