### PR TITLE
Prevent duplicate lines from UiElementDocsWriter

### DIFF
--- a/desktop/src/com/unciv/app/desktop/UiElementDocsWriter.kt
+++ b/desktop/src/com/unciv/app/desktop/UiElementDocsWriter.kt
@@ -51,7 +51,7 @@ class UiElementDocsWriter {
             yield(startMarker)
             yield("| Directory | Name | Default shape | Image |")
             yield("|---|:---:|:---:|---|")
-            yieldAll(elements.asSequence().sorted())    // FileTreeWalk guarantees no specific order as it uses File.listFiles
+            yieldAll(elements.asSequence().sorted().distinct())    // FileTreeWalk guarantees no specific order as it uses File.listFiles
             yield(endMarker)
             yieldAll(originalLines.subList(endIndex + 1, originalLines.size))
         }


### PR DESCRIPTION
Tiny thing - at the moment, there are no such duplicates, but reusing a getUIElement call somewhere else seems plausible. Of course, if there were a reuse of a element "key" but with a different default, those would still baffle the doc reader..

Or, we could pay attention to dupes appearing in open PR's and in such case demand the PR author remove code duplication, whether via separate element keys or a helper function.