### PR TITLE
A renamed unit shows that new name in can promote notifications

### DIFF
--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -559,7 +559,7 @@ object Battle {
         }
 
         if (!thisCombatant.isDefeated() && thisCombatant.unit.promotions.canBePromoted())
-            thisCombatant.getCivInfo().addNotification("[${thisCombatant.unit.name}] can be promoted!",thisCombatant.getTile().position, NotificationCategory.Units, thisCombatant.unit.name)
+            thisCombatant.getCivInfo().addNotification("[${thisCombatant.unit.displayName()}] can be promoted!",thisCombatant.getTile().position, NotificationCategory.Units, thisCombatant.unit.name)
     }
 
     private fun conquerCity(city: City, attacker: MapUnitCombatant) {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/63000004/227797822-2554faa6-cee6-46df-accb-a344e1b4c790.png)
..."But I renamed that guy"...
![image](https://user-images.githubusercontent.com/63000004/227798950-6a0955ee-5b18-4b2e-ae51-87925b4b7f56.png)

I hesitated between displayName and shortDisplayname, potential multiple passes through tr() and the tidbit we don't want the chosen name to be translated... Never going to be really safe.
