### PR TITLE
Prevent MapEditor 'pinch zoom' painting tiles

### DIFF
--- a/core/src/com/unciv/ui/screens/mapeditorscreen/EditorMapHolder.kt
+++ b/core/src/com/unciv/ui/screens/mapeditorscreen/EditorMapHolder.kt
@@ -17,6 +17,7 @@ import com.unciv.ui.components.tilegroups.TileSetStrings
 import com.unciv.ui.screens.basescreen.BaseScreen
 import com.unciv.ui.components.ZoomableScrollPane
 import com.unciv.ui.components.extensions.onClick
+import com.unciv.ui.screens.basescreen.UncivStage
 
 
 /**
@@ -43,8 +44,27 @@ class EditorMapHolder(
         if (editorScreen == null) touchable = Touchable.disabled
         continuousScrollingX = tileMap.mapParameters.worldWrap
         addTiles(parentScreen.stage)
-        if (editorScreen != null) addCaptureListener(getDragPaintListener())
+        if (editorScreen != null) {
+            addCaptureListener(getDragPaintListener())
+            setupZoomPanListeners()
+        }
         reloadMaxZoom()
+    }
+
+    /** See also: [WorldMapHolder.setupZoomPanListeners][com.unciv.ui.screens.worldscreen.WorldMapHolder.setupZoomPanListeners] */
+    private fun setupZoomPanListeners() {
+
+        fun setActHit() {
+            val isEnabled = !isZooming() && !isPanning
+            (stage as UncivStage).performPointerEnterExitEvents = isEnabled
+            tileGroupMap.shouldAct = isEnabled
+            tileGroupMap.shouldHit = isEnabled
+        }
+
+        onPanStartListener = { setActHit() }
+        onPanStopListener = { setActHit() }
+        onZoomStartListener = { setActHit() }
+        onZoomStopListener = { setActHit() }
     }
 
     private fun addTiles(stage: Stage) {

--- a/core/src/com/unciv/ui/screens/mapeditorscreen/tabs/MapEditorEditTab.kt
+++ b/core/src/com/unciv/ui/screens/mapeditorscreen/tabs/MapEditorEditTab.kt
@@ -189,6 +189,7 @@ class MapEditorEditTab(
 
     fun tileClickHandler(tile: Tile) {
         if (brushSize < -1 || brushSize > 5 || brushHandlerType == BrushHandlerType.None) return
+        if (editorScreen.mapHolder.isPanning || editorScreen.mapHolder.isZooming()) return
         editorScreen.hideSelection()
 
         when (brushHandlerType) {


### PR DESCRIPTION
Fixes #3435
* The actual fix is just the one line in MapEditorEditTab.
* I tried and _couldn't_ get the other candidate culprit listener (dragpaint) to fire with pinching, so it's unchanged - tests on a hardware phone.
* I also integrated the zoom performance thing the other two mapholders got. As duplicated code. Managing that in a nicer way would pretty much mean an intermediate class `MapHolder` in the hierarchy and a thorough review what other stuff would belong there (as ZoomableScrollPane shouldn't know it contains a map - it shouldn't even specialize in Group imho). So, not here.

Asides:
* Let's think about more package reorg - components should get a 'widgets' subpackage methinks??
* Unit tests - it's lateinit and nullability again. Couldn't we introduce rules like 'All our uses of lateinit require _either_ a good documentation why it's _guaranteed_ to be initialized when the constructor is done _or_ it's private, strictly forbidden to be leaked outside the class, and all accesses are documented why the lateinit must be initialized by then - or guarded with ::field.isInitialized - and then nullability would be a cleaner design..... .... .. . ?? We have Tile that has a TileMap lateinit even though loose tiles not on a map are used both in editor and unit tests, and we have maps not part of a game, perfectly valid, and each map has a GameInfo lateinit - feels like an Anti-Pattern. As it is, several unit tests will need fiddling - and will e.g. show that the roadowner design was just fine - under the __assumption_ every tile is on a map and every map is part of a game......