### PR TITLE
Show city size in CityScreenCityPickerTable.kt

### DIFF
--- a/core/src/com/unciv/ui/screens/cityscreen/CityScreenCityPickerTable.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/CityScreenCityPickerTable.kt
@@ -52,7 +52,8 @@ class CityScreenCityPickerTable(private val cityScreen: CityScreen) : Table() {
             cityNameTable.add(starImage).size(20f).padRight(5f)
         }
 
-        val currentCityLabel = city.name.toLabel(fontSize = 30, fontColor = civInfo.nation.getInnerColor())
+        val currentCityLabel = city.run { "{$name} (${population.population})" }
+            .toLabel(fontSize = 30, fontColor = civInfo.nation.getInnerColor())
         if (cityScreen.canChangeState) currentCityLabel.onClick {
             CityRenamePopup(
                 screen = cityScreen,


### PR DESCRIPTION
I need this quite often when deciding whether to build something such as "Library" (get 1 research for each 2 population -> "Oh, wait, what's the population of this city?")

Longer term I want to check how hard it would be to show the effects of something more directly e.g. for the social policy picker screen. E.g. "Gain one happiness for each city with a garrison" or "Empire produces double the amount of resources" or "1 extra happiness for each walls, castle, arsenal etc.", would be nice to see directly to how much happiness, resources that translates to make a better decision.

![Screenshot from 2023-04-04 21-47-44](https://user-images.githubusercontent.com/126110113/229904337-82f21c20-2fc8-422c-824b-c0597b2f74ce.png)
![Screenshot from 2023-04-04 21-47-49](https://user-images.githubusercontent.com/126110113/229904376-1d9c2e26-4208-44a2-afaa-b56bd4432632.png)
