### PR TITLE
Main menu background map changes infrequently

### DIFF
--- a/docs/Modders/Creating-a-UI-skin.md
+++ b/docs/Modders/Creating-a-UI-skin.md
@@ -117,7 +117,7 @@ These shapes are used all over Unciv and can be replaced to make a lot of UI ele
 
 The skinConfig is similar to the [tilesetConfig](Creating-a-custom-tileset.md#tileset-config) and can be used to define different colors and shapes for unciv to use.
 
-To create a config for your skin you just need to create a new .json file under `Jsons/Skins/`. Just create a .txt file and rename it to MyCoolSkinExample.json. You only have to add things if you want to change them. Else the default values will be used.
+To create a config for your skin you just need to create a new .json file under `jsons/Skins/`. Just create a .txt file and rename it to MyCoolSkinExample.json. You only have to add things if you want to change them. Else the default values will be used.
 
 This is an example of such a config file that will be explain below:
 

--- a/docs/Modders/Creating-a-custom-tileset.md
+++ b/docs/Modders/Creating-a-custom-tileset.md
@@ -25,7 +25,7 @@ BaseTerrain, TerrainFeatures, Resource, Improvement.
 
 This is where tileset configs shine. You can use these to alter the way Unicv renders tiles.
 
-To create a config for your tileset you just need to create a new .json file under Jsons/Tilesets/. Just create a .txt file and rename it to MyCoolTilesetExample.json. You only have to add things if you want to change them. Else the default values will be used.
+To create a config for your tileset you just need to create a new .json file under jsons/Tilesets/. Just create a .txt file and rename it to MyCoolTilesetExample.json. You only have to add things if you want to change them. Else the default values will be used.
 
 This is an example of such a config file that will be explain below:
 


### PR DESCRIPTION
.. also fixes the bugged MainMenuScreen/Background skin hook. That one - a centered Table having no dimensions at draw time, and defaulting to whitedot tinted white. Minimal fix would be to setFillParent the Table and use clearColor tint (tested) but I opted for a more lightweight Stack anyway, as that makes blending over to another map easier. Also, using a Table with children.size > cells.size is... a misunderstanding. Sorry it took me so long to see that detail.

Oh, and the docs saying the jsons folder needs to be named Jsons for skins and tilesets - someone actually took that seriously. We got a skin mod potentially looking different on Windows vs Linux through no fault of the author.

Will likely conflict with xEyes - no biggie.