### PR TITLE
IHasUniques redesign, UnitType uniques, PerpetualStatConversion conditionals

### DIFF
--- a/core/src/com/unciv/models/ruleset/IConstruction.kt
+++ b/core/src/com/unciv/models/ruleset/IConstruction.kt
@@ -224,10 +224,12 @@ open class PerpetualStatConversion(val stat: Stat) :
     fun getConversionRate(city: City) : Int = (1/city.cityStats.getStatConversionRate(stat)).roundToInt()
 
     override fun isBuildable(cityConstructions: CityConstructions): Boolean {
-        if (stat == Stat.Faith && !cityConstructions.city.civ.gameInfo.isReligionEnabled())
+        val city = cityConstructions.city
+        if (stat == Stat.Faith && !city.civ.gameInfo.isReligionEnabled())
             return false
 
-        return cityConstructions.city.civ.getMatchingUniques(UniqueType.EnablesCivWideStatProduction)
+        val stateForConditionals = StateForConditionals(city.civ, city, tile = city.getCenterTile())
+        return city.civ.getMatchingUniques(UniqueType.EnablesCivWideStatProduction, stateForConditionals)
             .any { it.params[0] == stat.name }
     }
 }

--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -22,6 +22,7 @@ import com.unciv.models.ruleset.tile.TileImprovement
 import com.unciv.models.ruleset.tile.TileResource
 import com.unciv.models.ruleset.unique.IHasUniques
 import com.unciv.models.ruleset.unique.Unique
+import com.unciv.models.ruleset.unique.UniqueMap
 import com.unciv.models.ruleset.unique.UniqueTarget
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.ruleset.unit.BaseUnit
@@ -61,10 +62,10 @@ class ModOptions : IHasUniques {
 
     override var uniques = ArrayList<String>()
 
-    // If these two are delegated with "by lazy", the mod download process crashes and burns
-    // Instead, Ruleset.load sets them, which is preferable in this case anyway
-    override var uniqueObjects: List<Unique> = listOf()
-    override var uniqueMap: Map<String, List<Unique>> = mapOf()
+    @Transient
+    override var uniqueObjectsInternal: List<Unique>? = null
+    @Transient
+    override var uniqueMapInternal: UniqueMap? = null
 
     override fun getUniqueTarget() = UniqueTarget.ModOptions
 
@@ -252,9 +253,7 @@ class Ruleset {
             try {
                 modOptions = json().fromJsonFile(ModOptions::class.java, modOptionsFile)
                 modOptions.updateDeprecations()
-            } catch (ex: Exception) {}
-            modOptions.uniqueObjects = modOptions.uniques.map { Unique(it, UniqueTarget.ModOptions) }
-            modOptions.uniqueMap = modOptions.uniqueObjects.groupBy { it.placeholderText }
+            } catch (_: Exception) {}
         }
 
         val techFile = folderHandle.child("Techs.json")

--- a/core/src/com/unciv/models/ruleset/RulesetObject.kt
+++ b/core/src/com/unciv/models/ruleset/RulesetObject.kt
@@ -13,18 +13,10 @@ interface IRulesetObject: INamed, IHasUniques, ICivilopediaText
 abstract class RulesetObject: IRulesetObject {
     override var name = ""
     override var uniques = ArrayList<String>() // Can not be a hashset as that would remove doubles
-    @delegate:Transient
-    override val uniqueObjects: List<Unique> by lazy {
-        if (uniques.isEmpty()) emptyList()
-        else uniques.map { Unique(it, getUniqueTarget(), name) }
-    }
-    @delegate:Transient
-    override val uniqueMap: UniqueMap by lazy {
-        if (uniques.isEmpty()) UniqueMap()
-        val newUniqueMap = UniqueMap()
-        newUniqueMap.addUniques(uniqueObjects)
-        newUniqueMap
-    }
+    @Transient
+    override var uniqueObjectsInternal: List<Unique>? = null
+    @Transient
+    override var uniqueMapInternal: UniqueMap? = null
 
     override var civilopediaText = listOf<FormattedLine>()
     override fun toString() = name
@@ -33,16 +25,10 @@ abstract class RulesetObject: IRulesetObject {
 // Same, but inherits from NamedStats - I couldn't find a way to unify the declarations but this is fine
 abstract class RulesetStatsObject: NamedStats(), IRulesetObject {
     override var uniques = ArrayList<String>() // Can not be a hashset as that would remove doubles
-    @delegate:Transient
-    override val uniqueObjects: List<Unique> by lazy {
-        if (uniques.isEmpty()) emptyList()
-        else uniques.map { Unique(it, getUniqueTarget(), name) }
-    }
-    @delegate:Transient
-    override val uniqueMap: Map<String, List<Unique>> by lazy {
-        if (uniques.isEmpty()) emptyMap()
-        else uniqueObjects.groupBy { it.placeholderText }
-    }
+    @Transient
+    override var uniqueObjectsInternal: List<Unique>? = null
+    @Transient
+    override var uniqueMapInternal: UniqueMap? = null
 
     override var civilopediaText = listOf<FormattedLine>()
 }

--- a/core/src/com/unciv/models/ruleset/unique/IHasUniques.kt
+++ b/core/src/com/unciv/models/ruleset/unique/IHasUniques.kt
@@ -1,14 +1,38 @@
 package com.unciv.models.ruleset.unique
 
+import com.unciv.models.stats.INamed
+
 /**
  * Common interface for all 'ruleset objects' that have Uniques, like BaseUnit, Nation, etc.
  */
 interface IHasUniques {
+    /** The Uniques as they are read from json */
     var uniques: ArrayList<String> // Can not be a hashset as that would remove doubles
-    // I bet there's a way of initializing these without having to override it everywhere...
-    val uniqueObjects: List<Unique>
 
-    val uniqueMap: Map<String, List<Unique>>
+    /** Do not use except for overriding and initializing to null in [IHasUniques] implementation */
+    var uniqueObjectsInternal: List<Unique>?
+    /** [uniques] as list of [Unique]s. Late-initialized with a twist:
+     *  Accessing [uniqueObjects] while [uniques] is empty will return an emptyList without marking the objects as initialized. */
+    val uniqueObjects: List<Unique> get() {
+        if (uniques.isEmpty()) return emptyList()
+        if (uniqueObjectsInternal == null)
+            uniqueObjectsInternal = uniquesToUniqueObjects(uniques)
+        return uniqueObjectsInternal!!
+    }
+    /** Convert a collection of String [uniques] to [Unique] objects, can be used in [uniqueObjects] overrides. */
+    fun uniquesToUniqueObjects(uniques: Iterable<String>): List<Unique> {
+        if (uniques.none()) return emptyList()
+        return uniques.map { Unique(it, getUniqueTarget(), (this as? INamed)?.name) }
+    }
+
+    /** Do not use except for overriding and initializing to null in [IHasUniques] implementation */
+    var uniqueMapInternal: UniqueMap?
+    /** A map of (lists of) [Unique]s indexed by [UniqueType.placeholderText]. Late-initialized from [uniqueObjects]. */
+    val uniqueMap: UniqueMap get() {
+        if (uniques.isEmpty()) return UniqueMap.empty
+        if (uniqueMapInternal == null) uniqueMapInternal = UniqueMap(uniqueObjects)
+        return uniqueMapInternal!!
+    }
 
     /** Technically not currently needed, since the unique target can be retrieved from every unique in the uniqueObjects,
      * But making this a function is relevant for future "unify Unciv object" plans ;)
@@ -29,4 +53,3 @@ interface IHasUniques {
     fun hasUnique(uniqueType: UniqueType, stateForConditionals: StateForConditionals? = null) =
         getMatchingUniques(uniqueType.placeholderText, stateForConditionals).any()
 }
-

--- a/core/src/com/unciv/models/ruleset/unit/UnitType.kt
+++ b/core/src/com/unciv/models/ruleset/unit/UnitType.kt
@@ -39,12 +39,9 @@ class UnitType() : RulesetObject() {
     /** Implements [UniqueParameterType.UnitTypeFilter][com.unciv.models.ruleset.unique.UniqueParameterType.UnitTypeFilter] */
     fun matchesFilter(filter: String): Boolean {
         return when (filter) {
-            "Land" -> isLandUnit()
-            "Water" -> isWaterUnit()
-            "Air" -> isAirUnit()
-            else -> {
-                uniques.contains(filter)
-            }
+            unitMovementType?.name -> true
+            in uniques -> true
+            else -> false
         }
     }
 


### PR DESCRIPTION
I'm only ~33% convinced these changes (see three commits separately) should go in as they are. Runs and seems to do a few nextTurns correctly, but not in-depth tested.

Key insights
* Due to `HiddenFromCivilopedia` being a UniqueType, any uniqueObjects or uniqueMap initialization "must not" access a ruleset. This hampers the idea to simply let BaseUnit load the uniques of its UnitType.
* One approach to that led to this idea of doing the late-caching without any Lazy-type delegate.
* Those ideas I played with in #9135 are bull, they might work fine in other contexts. But in Unciv, these lazies are fragile, you can get such code to run but produce wrong results due to them tripping in the wrong order.

Decisions
* As mentioned, what I did to PerpetualStatConversion would allow a mod to tie one to a condition that can become unfulfilled during gameplay - like you're allowed to convert prod to gold only if there's a Trading post near - improvement goes, you can still keep that in the queue, just not remove it and put it back... Same for the building conditional and selling the building... Maybe it's preferrable to document that such combos are intentionally unsupported?
* Instead of allowing the can't be a barbarian unique on UnitTypes, we could also opt for documented non-support.

Interesting tidbit: I found a formula to test whether a lazy is initialized without tripping it. Passes inspection and works in Debugger evaluation. Defined as function, however, it trips the compiler so hard you need to invalidate cache + kill all gradle daemons to recover... `fun isTypeInitialized() = ((::type).run { isAccessible = true; getDelegate() } as Lazy<*>).isInitialized()` - Fun for the whole family!