### PR TITLE
User option to control NotificationScroll behaviour

### DIFF
--- a/core/src/com/unciv/models/metadata/GameSettings.kt
+++ b/core/src/com/unciv/models/metadata/GameSettings.kt
@@ -21,7 +21,11 @@ import kotlin.reflect.KMutableProperty0
 
 data class WindowState (val width: Int = 900, val height: Int = 600)
 
-enum class ScreenSize(val virtualWidth:Float, val virtualHeight:Float){
+enum class ScreenSize(
+    @Suppress("unused")  // Actual width determined by screen aspect ratio, this as comment only
+    val virtualWidth: Float,
+    val virtualHeight: Float
+) {
     Tiny(750f,500f),
     Small(900f,600f),
     Medium(1050f,700f),
@@ -111,6 +115,9 @@ class GameSettings {
 
     var keyBindings = KeyboardBindings()
 
+    /** NotificationScroll on Word Screen visibility control - mapped to NotificationsScroll.UserSetting enum */
+    var notificationScroll: String = ""
+
     /** used to migrate from older versions of the settings */
     var version: Int? = null
 
@@ -153,7 +160,7 @@ class GameSettings {
         return (Fonts.ORIGINAL_FONT_SIZE * fontSizeMultiplier).toInt()
     }
 
-    fun getCurrentLocale(): Locale {
+    private fun getCurrentLocale(): Locale {
         if (locale == null)
             updateLocaleFromLanguage()
         return locale!!
@@ -213,15 +220,16 @@ enum class LocaleCode(var language: String, var country: String) {
 class GameSettingsMultiplayer {
     var userId = ""
     var passwords = mutableMapOf<String, String>()
+    @Suppress("unused")  // @GGuenni knows what he intended with this field
     var userName: String = ""
     var server = Constants.uncivXyzServer
     var friendList: MutableList<FriendList.Friend> = mutableListOf()
     var turnCheckerEnabled = true
     var turnCheckerPersistentNotificationEnabled = true
-    var turnCheckerDelay = Duration.ofMinutes(5)
+    var turnCheckerDelay: Duration = Duration.ofMinutes(5)
     var statusButtonInSinglePlayer = false
-    var currentGameRefreshDelay = Duration.ofSeconds(10)
-    var allGameRefreshDelay = Duration.ofMinutes(5)
+    var currentGameRefreshDelay: Duration = Duration.ofSeconds(10)
+    var allGameRefreshDelay: Duration = Duration.ofMinutes(5)
     var currentGameTurnNotificationSound: UncivSound = UncivSound.Silent
     var otherGameTurnNotificationSound: UncivSound = UncivSound.Silent
     var hideDropboxWarning = false
@@ -233,6 +241,7 @@ class GameSettingsMultiplayer {
     }
 }
 
+@Suppress("SuspiciousCallableReferenceInLambda")  // By @Azzurite, safe as long as that warning below is followed
 enum class GameSetting(
     val kClass: KClass<*>,
     private val propertyGetter: (GameSettings) -> KMutableProperty0<*>

--- a/core/src/com/unciv/ui/screens/overviewscreen/GlobalPoliticsOverviewTable.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/GlobalPoliticsOverviewTable.kt
@@ -182,8 +182,7 @@ class GlobalPoliticsOverviewTable (
 
         // wars
         for (otherCiv in civ.getKnownCivs()) {
-            if(civ.isAtWarWith(otherCiv)) {
-                println(getCivName(otherCiv))
+            if (civ.isAtWarWith(otherCiv)) {
                 val warText = "At war with [${getCivName(otherCiv)}]".toLabel()
                 warText.color = Color.RED
                 politicsTable.add(warText).row()
@@ -193,7 +192,7 @@ class GlobalPoliticsOverviewTable (
 
         // declaration of friendships
         for (otherCiv in civ.getKnownCivs()) {
-            if(civ.diplomacy[otherCiv.civName]?.hasFlag(DiplomacyFlags.DeclarationOfFriendship) == true) {
+            if (civ.diplomacy[otherCiv.civName]?.hasFlag(DiplomacyFlags.DeclarationOfFriendship) == true) {
                 val friendText = "Friends with [${getCivName(otherCiv)}]".toLabel()
                 friendText.color = Color.GREEN
                 val turnsLeftText = " (${civ.diplomacy[otherCiv.civName]?.getFlag(DiplomacyFlags.DeclarationOfFriendship)} ${Fonts.turn})".toLabel()
@@ -205,7 +204,7 @@ class GlobalPoliticsOverviewTable (
 
         // denounced civs
         for (otherCiv in civ.getKnownCivs()) {
-            if(civ.diplomacy[otherCiv.civName]?.hasFlag(DiplomacyFlags.Denunciation) == true) {
+            if (civ.diplomacy[otherCiv.civName]?.hasFlag(DiplomacyFlags.Denunciation) == true) {
                 val denouncedText = "Denounced [${getCivName(otherCiv)}]".toLabel()
                 denouncedText.color = Color.RED
                 val turnsLeftText = "(${civ.diplomacy[otherCiv.civName]?.getFlag(DiplomacyFlags.Denunciation)} ${Fonts.turn})".toLabel()


### PR DESCRIPTION
<details><summary>Demo</summary>

https://user-images.githubusercontent.com/63000004/230769575-3591bbba-b765-4d72-b1ed-f8a82f682595.mp4

</details>

TODO left on top of the main file:
```
 *  Un-hiding the notifications when new ones arrive is a little pointless due to Categories:
 *      * try to scroll new into view? Very complicated as the "old" state is only "available" in the Widgets
 *      * Don't unless a new user option disables categories, then scroll to top?
 *  Idea: Blink or tint the button when new notifications while Hidden
 *  Idea: The little "1" on the bell - remove and draw actual count
```
I just might remove that shortly without any code change - but any input on how to tackle the problems named welcome.

Plus some linting - is there a reliable way to block `println()` and demand `Log.debug` instead? Maybe...