### PR TITLE
Fix incorrect relationship level comparison

### DIFF
--- a/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
@@ -18,6 +18,7 @@ import com.unciv.ui.components.extensions.toPercent
 import kotlin.math.ceil
 import kotlin.math.max
 import kotlin.math.min
+import kotlin.math.sign
 
 enum class RelationshipLevel(val color: Color) {
     // War is tested separately for the Diplomacy Screen. Colored RED.
@@ -185,7 +186,7 @@ class DiplomacyManager() : IsPartOfGameInfoSerialization {
      */
     private fun compareRelationshipLevel(level: RelationshipLevel, comparesAs: Int): Boolean {
         if (!civInfo.isCityState())
-            return relationshipLevel().compareTo(level) == comparesAs
+            return relationshipLevel().compareTo(level).sign == comparesAs
         return when(level) {
             RelationshipLevel.Afraid -> when {
                 comparesAs < 0 -> getInfluence() < 0
@@ -199,7 +200,9 @@ class DiplomacyManager() : IsPartOfGameInfoSerialization {
             }
             else ->
                 // Outside the potentially expensive questions, do it the easy way
-                relationshipLevel().compareTo(level) == comparesAs
+                // Except - Enum.compareTo does not behave quite like other compareTo's
+                // or like kotlinlang.org says, thus the `sign`
+                relationshipLevel().compareTo(level).sign == comparesAs
         }
     }
     /** @see compareRelationshipLevel */


### PR DESCRIPTION
Quote from kotlinlang.org:
"
The implementation of kotlin.Comparable. The result of a.compareTo(b) for **enum class instances** a and b is equivalent to a.ordinal.compareTo(b.ordinal).
"
Untrue! They simply return the difference of the ordinals; while Int.compareTo(Int) always returns one of (-1,0,1)...

I broke that in... #9073 maybe?

Oh - visible symptoms - Ships can no longer heal in waters of _allied_ city states. Friends yes, Allies no - bad.