### PR TITLE
Fix issue #7792

### DIFF
--- a/core/src/com/unciv/logic/automation/city/ConstructionAutomation.kt
+++ b/core/src/com/unciv/logic/automation/city/ConstructionAutomation.kt
@@ -38,7 +38,7 @@ class ConstructionAutomation(val cityConstructions: CityConstructions){
 
     private val civUnits = civInfo.units.getCivUnits()
     private val militaryUnits = civUnits.count { it.baseUnit.isMilitary() }
-    private val workers = civUnits.count { it.cache.hasUniqueToBuildImprovements && it.isCivilian() }.toFloat()
+    private val workers = civUnits.count { it.cache.hasUniqueToBuildImprovements}.toFloat()
     private val cities = civInfo.cities.size
     private val allTechsAreResearched = civInfo.gameInfo.ruleset.technologies.values
         .all { civInfo.tech.isResearched(it.name) || !civInfo.tech.canBeResearched(it.name)}

--- a/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
@@ -152,6 +152,14 @@ object UnitAutomation {
                 unit.promotions.addPromotion(availablePromotions.toList().random().name)
         }
 
+        //This allows for military units with certain civilian abilities to behave as civilians in peace and soldiers in war
+        if ((unit.hasUnique(UniqueType.BuildImprovements) || unit.hasUnique(UniqueType.FoundCity) ||
+                unit.hasUnique(UniqueType.ReligiousUnit) || unit.hasUnique(UniqueType.CreateWaterImprovements))
+                && !unit.civ.isAtWar()){
+            automateCivilianUnit(unit)
+            return
+        }
+
         if (unit.baseUnit.isAirUnit() && unit.canIntercept())
             return SpecificUnitAutomation.automateFighter(unit)
 


### PR DESCRIPTION
The issue was caused by Latin-Civs Mixed Militias being considered workers in ConstructionAutomation.addWorkerChoice() but not beign counted as one in ConstructionAutomation.workers. Now, any unit that can build improvements counts as a worker in it. In addition, the AI simulates military units that can found city, build improvements or are religious as civilians in peacetime and as soldiers in wartime.