### PR TITLE
Show replay after 50 turns, but only the discovered part of it.

### DIFF
--- a/core/src/com/unciv/ui/screens/victoryscreen/ReplayMap.kt
+++ b/core/src/com/unciv/ui/screens/victoryscreen/ReplayMap.kt
@@ -3,6 +3,7 @@ package com.unciv.ui.screens.victoryscreen
 import com.badlogic.gdx.graphics.g2d.Batch
 import com.badlogic.gdx.scenes.scene2d.Group
 import com.unciv.UncivGame
+import com.unciv.logic.civilization.Civilization
 import com.unciv.logic.map.TileMap
 import com.unciv.ui.screens.worldscreen.minimap.MinimapTile
 import com.unciv.ui.screens.worldscreen.minimap.MinimapTileUtil
@@ -59,11 +60,15 @@ class ReplayMap(val tileMap: TileMap) : Group() {
     }
 
 
-    fun update(turn: Int) {
+    fun update(turn: Int, viewingCiv: Civilization) {
+        val viewingCivIsDefeated = viewingCiv.gameInfo.victoryData != null || !viewingCiv.isAlive()
         for (minimapTile in minimapTiles) {
-            minimapTile.updateColor(false, turn)
-            minimapTile.updateBorders(turn).updateActorsIn(this)
-            minimapTile.updateCityCircle(turn).updateActorsIn(this)
+            val isVisible = viewingCivIsDefeated || viewingCiv.hasExplored(minimapTile.tile)
+            minimapTile.updateColor(!isVisible, turn)
+            if (isVisible) {
+                minimapTile.updateBorders(turn).updateActorsIn(this)
+                minimapTile.updateCityCircle(turn).updateActorsIn(this)
+            }
         }
     }
 

--- a/core/src/com/unciv/ui/screens/victoryscreen/VictoryScreen.kt
+++ b/core/src/com/unciv/ui/screens/victoryscreen/VictoryScreen.kt
@@ -68,7 +68,16 @@ class VictoryScreen(
         Replay('P', "OtherIcons/Load", allowAsSecret = true) {
             override fun getContent(worldScreen: WorldScreen) = VictoryScreenReplay(worldScreen)
             override fun isHidden(playerCiv: Civilization) =
-                !playerCiv.isSpectator() && playerCiv.gameInfo.victoryData == null && playerCiv.isAlive()
+                !playerCiv.isSpectator()
+                        && playerCiv.gameInfo.victoryData == null
+                        && playerCiv.isAlive()
+                        // We show the replay after 50 turns. This is quite an arbitrary number, but
+                        // we don't want to leak the starting position right away (assuming we don't
+                        // condense the replay map in a similar way to the minimap (ie. it fills
+                        // to only the discovered area) and probably before 50 turns not much
+                        // interesting would happen anyway in the replay and the slider might feel
+                        // weird, too.
+                        && playerCiv.gameInfo.turns < 50
         };
         abstract fun getContent(worldScreen: WorldScreen): Table
         open fun isHidden(playerCiv: Civilization) = false

--- a/core/src/com/unciv/ui/screens/victoryscreen/VictoryScreenReplay.kt
+++ b/core/src/com/unciv/ui/screens/victoryscreen/VictoryScreenReplay.kt
@@ -19,6 +19,7 @@ class VictoryScreenReplay(
     worldScreen: WorldScreen
 ) : Table(BaseScreen.skin), TabbedPager.IPageExtensions {
     private val gameInfo = worldScreen.gameInfo
+    private val viewingCiv = worldScreen.viewingCiv
 
     private val finalTurn = gameInfo.turns
     private var replayTimer : Timer.Task? = null
@@ -110,7 +111,7 @@ class VictoryScreenReplay(
             )
         )
         slider.value = turn.toFloat()
-        replayMap.update(turn)
+        replayMap.update(turn, viewingCiv)
         if (turn == finalTurn) resetTimer()
     }
 


### PR DESCRIPTION
We don't really need to wait until the end of the game to show the replay if we just show the discovered portion of the map.
![Screenshot from 2023-04-11 21-44-13](https://user-images.githubusercontent.com/126110113/231274343-a05c8818-99bd-47c9-aee7-c254e4914c8f.png)
![Screenshot from 2023-04-11 21-53-09](https://user-images.githubusercontent.com/126110113/231274349-ae962a90-3660-4b3e-bd5c-032513f3b607.png)

