### PR TITLE
Show highlight for settlers where they can found and not found cities.

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -730,6 +730,7 @@ Show resources and improvements =
 Show tile yields = 
 Show unit movement arrows = 
 Show suggested city locations for units that can found cities = 
+Show possible city locations for units that can found cities = 
 Show pixel units = 
 Show pixel improvements = 
 Unit icon opacity = 

--- a/core/src/com/unciv/logic/automation/unit/SpecificUnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/SpecificUnitAutomation.kt
@@ -2,6 +2,7 @@
 
 import com.unciv.Constants
 import com.unciv.logic.automation.Automation
+import com.unciv.logic.automation.unit.CityLocationTileRanker.IntendedUse.AI_CITY_FOUNDING
 import com.unciv.logic.battle.Battle
 import com.unciv.logic.battle.GreatGeneralImplementation
 import com.unciv.logic.battle.MapUnitCombatant
@@ -150,7 +151,7 @@ object SpecificUnitAutomation {
         // It's possible that we'll see a tile "over the sea" that's better than the tiles close by, but that's not a reason to abandon the close tiles!
         // Also this lead to some routing problems, see https://github.com/yairm210/Unciv/issues/3653
         val bestCityLocation: Tile? =
-                CityLocationTileRanker.getBestTilesToFoundCity(unit).firstOrNull {
+                CityLocationTileRanker.getBestTilesToFoundCity(unit, AI_CITY_FOUNDING).firstOrNull {
                     val pathSize = unit.movement.getShortestPath(it.first).size
                     return@firstOrNull pathSize in 1..3
                 }?.first

--- a/core/src/com/unciv/models/metadata/GameSettings.kt
+++ b/core/src/com/unciv/models/metadata/GameSettings.kt
@@ -45,6 +45,7 @@ class GameSettings {
     var showTileYields: Boolean = false
     var showUnitMovements: Boolean = false
     var showSettlersSuggestedCityLocations: Boolean = true
+    var showSettlersPossibleCityLocations: Boolean = true
 
     var checkForDueUnits: Boolean = true
     var autoUnitCycle: Boolean = true

--- a/core/src/com/unciv/ui/popups/options/DisplayTab.kt
+++ b/core/src/com/unciv/ui/popups/options/DisplayTab.kt
@@ -77,6 +77,7 @@ fun displayTab(
 
     optionsPopup.addCheckbox(this, "Show unit movement arrows", settings.showUnitMovements, true) { settings.showUnitMovements = it }
     optionsPopup.addCheckbox(this, "Show suggested city locations for units that can found cities", settings.showSettlersSuggestedCityLocations, true) { settings.showSettlersSuggestedCityLocations = it }
+    optionsPopup.addCheckbox(this, "Show possible city locations for units that can found cities", settings.showSettlersPossibleCityLocations, true) { settings.showSettlersPossibleCityLocations = it }
     optionsPopup.addCheckbox(this, "Show tile yields", settings.showTileYields, true) { settings.showTileYields = it } // JN
     optionsPopup.addCheckbox(this, "Show worked tiles", settings.showWorkedTiles, true) { settings.showWorkedTiles = it }
     optionsPopup.addCheckbox(this, "Show resources and improvements", settings.showResourcesAndImprovements, true) { settings.showResourcesAndImprovements = it }


### PR DESCRIPTION
Playing around following a suggestion on the Discord that I kind of liked. The idea of showing both possible and impossible locations (rather than just possible ones) is that I only show them at a radius of 5 and I think by showing both this becomes obvious. If you only show possible ones, it might be confusing whether that tile 6 away is just not possible or not part of the highlight.

I'm not entirely happy with the UI. It feels a bit too intrusive, maybe someone has a better idea? Also I don't like that it hides the movement range of the settler. Any ideas on that?

I made it configurable at least, but would like to hear some feedback. I'm a bit torn on this change myself.

![Screenshot from 2023-04-13 21-50-11](https://user-images.githubusercontent.com/126110113/231869496-a7d82472-86cb-4473-89ba-ca8fe4389789.png)
![Screenshot from 2023-04-13 21-50-27](https://user-images.githubusercontent.com/126110113/231869511-1d63bc58-efe3-4457-92b9-4b1fc553ef13.png)
