### PR TITLE
Allow city- or tile- related conditionals on stat conversion unique

### DIFF
--- a/core/src/com/unciv/models/ruleset/IConstruction.kt
+++ b/core/src/com/unciv/models/ruleset/IConstruction.kt
@@ -231,10 +231,12 @@ open class PerpetualStatConversion(val stat: Stat) :
     fun getConversionRate(city: City) : Int = (1/city.cityStats.getStatConversionRate(stat)).roundToInt()
 
     override fun isBuildable(cityConstructions: CityConstructions): Boolean {
-        if (stat == Stat.Faith && !cityConstructions.city.civ.gameInfo.isReligionEnabled())
+        val city = cityConstructions.city
+        if (stat == Stat.Faith && !city.civ.gameInfo.isReligionEnabled())
             return false
 
-        return cityConstructions.city.civ.getMatchingUniques(UniqueType.EnablesCivWideStatProduction)
+        val stateForConditionals = StateForConditionals(city.civ, city, tile = city.getCenterTile())
+        return city.civ.getMatchingUniques(UniqueType.EnablesCivWideStatProduction, stateForConditionals)
             .any { it.params[0] == stat.name }
     }
 }


### PR DESCRIPTION
Let's close #9134 - that tiny piece of diff is unchanged from #9137, and re-thinking I came to the conclusion the potential loophole is less important. Plus, we should still have construction queue validation which should take care of it - or is that gone? At least two of my c-queue improvements from way back _are_ gone... I'll check another day. Maybe even dig out that queue that could intelligently queue a University after a Library and prevented swapping them... Which could close another still open ticket iirc.