### PR TITLE
Fix more leaks of the actual Player count in random mode

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -1379,6 +1379,8 @@ You have been defeated. Your civilization has been overwhelmed by its many foes.
 One more turn...! = 
 Destroy [civName] = 
 Capture [cityName] = 
+Destroy ? * [civName] = 
+Capture ? * [cityName] = 
 Our status = 
 Global status = 
 Rankings = 
@@ -1603,6 +1605,7 @@ Minimal Faith required for\nthe next [Great Prophet]: =
 Religions to be founded: [amount] = 
 Available religion symbols = 
 Number of civilizations * [amount] + [amount2] = 
+Estimated Number of civilizations * [amount] + [amount2] = 
 Religions already founded = 
 Available founder beliefs = 
 Available follower beliefs = 

--- a/core/src/com/unciv/logic/civilization/Civilization.kt
+++ b/core/src/com/unciv/logic/civilization/Civilization.kt
@@ -32,6 +32,7 @@ import com.unciv.logic.map.mapunit.MapUnit
 import com.unciv.logic.map.tile.Tile
 import com.unciv.logic.trade.TradeRequest
 import com.unciv.models.Counter
+import com.unciv.models.metadata.GameParameters // Kdoc only
 import com.unciv.models.ruleset.Building
 import com.unciv.models.ruleset.Policy
 import com.unciv.models.ruleset.Victory
@@ -53,7 +54,6 @@ import com.unciv.models.stats.Stats
 import com.unciv.models.translations.tr
 import com.unciv.ui.components.extensions.toPercent
 import com.unciv.ui.screens.victoryscreen.RankingType
-import java.util.*
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.roundToInt
@@ -795,8 +795,7 @@ class Civilization : IsPartOfGameInfoSerialization {
             city.cityConstructions.addBuilding(city.capitalCityIndicator())
             city.isBeingRazed = false // stop razing the new capital if it was being razed
         }
-        if (oldCapital != null)
-            oldCapital.cityConstructions.removeBuilding(oldCapital.capitalCityIndicator())
+        oldCapital?.cityConstructions?.removeBuilding(oldCapital.capitalCityIndicator())
     }
 
     fun moveCapitalToNextLargest() {
@@ -813,6 +812,20 @@ class Civilization : IsPartOfGameInfoSerialization {
 
     fun getAllyCiv() = allyCivName
     fun setAllyCiv(newAllyName: String?) { allyCivName = newAllyName }
+
+    /** Determine if this civ (typically as human player) is allowed to know how many major civs there are
+     *
+     *  Can only be `true` if [GameParameters.randomNumberOfPlayers] is `true`, but in that case
+     *  we try to see if the player _could_ be certain with a modicum of cleverness...
+     */
+    fun hideCivCount(): Boolean {
+        if (!gameInfo.gameParameters.randomNumberOfPlayers) return false
+        val knownCivs = 1 + getKnownCivs().count { it.isMajorCiv() }
+        if (knownCivs >= gameInfo.gameParameters.maxNumberOfPlayers) return false
+        if (hasUnique(UniqueType.OneTimeRevealEntireMap)) return false
+        // Other ideas? viewableTiles.size == gameInfo.tileMap.tileList.size seems not quite useful...
+        return true
+    }
 
     fun asPreview() = CivilizationInfoPreview(this)
 }

--- a/core/src/com/unciv/ui/screens/overviewscreen/ReligionOverviewTable.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/ReligionOverviewTable.kt
@@ -68,34 +68,37 @@ class ReligionOverviewTab(
 
     private fun Table.addCivSpecificStats() {
         // This is not Civ-specific, but -oh well- still fits
-        val remaining = viewingPlayer.religionManager.remainingFoundableReligions()
         val minWidth = max(religionButtonLabel.prefWidth, overviewScreen.stage.width / 3)
-        val headerText = "Religions to be founded: [$remaining]"
+        val manager = viewingPlayer.religionManager
+        val headerText =
+            if (viewingPlayer.hideCivCount()) "Religions to be founded: [?]"
+            else "Religions to be founded: [${manager.remainingFoundableReligions()}]"
         val religionCountExpander = ExpanderTab(
             headerText, fontSize = 18, headerPad =  5f,
-            startsOutOpened = false, defaultPad =  0f, expanderWidth = minWidth
+            startsOutOpened = false, defaultPad =  0f, expanderWidth = minWidth,
+            onChange = { overviewScreen.resizePage(this@ReligionOverviewTab) }
         ) {
             it.defaults().padTop(10f)
-            for ((text, num) in viewingPlayer.religionManager.remainingFoundableReligionsBreakdown()) {
+            for ((text, num) in manager.remainingFoundableReligionsBreakdown()) {
                 it.add(text.toLabel())
                 it.add(num.toString().toLabel(alignment = Align.right)).right().row()
             }
         }
         add(religionCountExpander).colspan(2).growX().row()
 
-        if (viewingPlayer.religionManager.canGenerateProphet()) {
+        if (manager.canGenerateProphet()) {
             add("Minimal Faith required for\nthe next [great prophet equivalent]:"
-                .fillPlaceholders(viewingPlayer.religionManager.getGreatProphetEquivalent()!!)
+                .fillPlaceholders(manager.getGreatProphetEquivalent()!!)
                 .toLabel()
             )
             add(
-                (viewingPlayer.religionManager.faithForNextGreatProphet() + 1)
+                (manager.faithForNextGreatProphet() + 1)
                 .toLabel()
             ).right().row()
         }
 
         add("Religious status:".toLabel()).left()
-        add(viewingPlayer.religionManager.religionState.toString().toLabel()).right().row()
+        add(manager.religionState.toString().toLabel()).right().row()
     }
 
     private fun loadReligionButtons() {


### PR DESCRIPTION
Two more places where the random number of players could be seen
* Domination Victory (and CaptureAllCapitals too) part of VictoryScreen
* Remaining Religions to be founded

<details><summary>Pix</summary>

![image](https://user-images.githubusercontent.com/63000004/232251748-b280830e-3a13-4e5e-b1ae-89862629e2d2.png)
![image](https://user-images.githubusercontent.com/63000004/232251755-52b7a533-8a10-4eda-9eb1-d482edfbc4c4.png)

</details>


Also, fix a minor layout problem with the religion count breakdown expander opening.
