### PR TITLE
Reassign workers when resistance ends or improvement created

### DIFF
--- a/core/src/com/unciv/logic/city/managers/CityInfoConquestFunctions.kt
+++ b/core/src/com/unciv/logic/city/managers/CityInfoConquestFunctions.kt
@@ -156,6 +156,7 @@ class CityInfoConquestFunctions(val city: City){
     fun annexCity() {
         city.isPuppet = false
         city.cityConstructions.inProgressConstructions.clear() // undo all progress of the previous civ on units etc.
+        if (!city.isInResistance()) city.updateCitizens = true
         city.cityStats.update()
         GUI.setUpdateWorldOnNextRender()
     }

--- a/core/src/com/unciv/logic/map/mapunit/UnitTurnManager.kt
+++ b/core/src/com/unciv/logic/map/mapunit/UnitTurnManager.kt
@@ -208,9 +208,8 @@ class UnitTurnManager(val unit: MapUnit) {
             tile.improvementInProgress == RoadStatus.Railroad.name -> tile.addRoad(RoadStatus.Railroad, unit.civ)
             tile.improvementInProgress == Constants.repair -> tile.setRepaired()
             else -> {
-                val improvement = unit.civ.gameInfo.ruleset.tileImprovements[tile.improvementInProgress]!!
-                improvement.handleImprovementCompletion(unit)
                 tile.changeImprovement(tile.improvementInProgress)
+                tile.getTileImprovement()!!.handleImprovementCompletion(unit)
             }
         }
 

--- a/core/src/com/unciv/models/ruleset/tile/TileImprovement.kt
+++ b/core/src/com/unciv/models/ruleset/tile/TileImprovement.kt
@@ -80,6 +80,7 @@ class TileImprovement : RulesetStatsObject() {
         if (tile.resource != null) {
             val city = builder.getTile().getCity()
             if (city != null) {
+                city.updateCitizens = true
                 city.cityStats.update()
                 city.civ.cache.updateCivResources()
             }

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActions.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActions.kt
@@ -159,12 +159,8 @@ object UnitActions {
         return UnitAction(UnitActionType.Create, "Create [$improvementName]",
             action = {
                 tile.changeImprovement(improvementName)
-                val city = tile.getCity()
-                if (city != null) {
-                    city.cityStats.update()
-                    city.civ.cache.updateCivResources()
-                }
-                unit.destroy()
+                tile.getTileImprovement()!!.handleImprovementCompletion(unit)
+                unit.destroy()  // Modders may wish for a nondestructive way, but that should be another Unique
             }.takeIf { unit.currentMovement > 0 })
     }
 
@@ -502,7 +498,7 @@ object UnitActions {
                     unitTile.stopWorkingOnImprovement()
                     improvement.handleImprovementCompletion(unit)
 
-                    // without this the world screen won't the improvement because it isn't the 'last seen improvement'
+                    // without this the world screen won't show the improvement because it isn't the 'last seen improvement'
                     unit.civ.cache.updateViewableTiles()
 
                     if (unique.type == UniqueType.ConstructImprovementConsumingUnit) unit.consume()


### PR DESCRIPTION
Fixes #9189
Also kicks the reallocate workers flag for "placed" improvements, so plonking down fishing boats or an academy will reevaluate citizen management focus.

Please review carefully. Tests fine, and the reorder I did to City.startTurn can be explained - cityStats.update is duplicated within reassignPopulation, so you can save one _if_ tryUpdateRoadStatus nor WLTK depend on it. But the order within startTurn _may_ have aspects I didn't see. 