### PR TITLE
Disallow buying tiles in annexed cities in resistance

### DIFF
--- a/core/src/com/unciv/logic/city/managers/CityExpansionManager.kt
+++ b/core/src/com/unciv/logic/city/managers/CityExpansionManager.kt
@@ -57,8 +57,9 @@ class CityExpansionManager : IsPartOfGameInfoSerialization {
 
     fun canBuyTile(tile: Tile): Boolean {
         return when {
-            city.isPuppet -> false
+            city.isPuppet || city.isBeingRazed -> false
             tile.getOwner() != null -> false
+            city.isInResistance() -> false
             tile !in city.tilesInRange -> false
             else -> tile.neighbors.any { it.getCity() == city }
         }


### PR DESCRIPTION
I'm 99% sure the rules here should be "No!".

But say - wasn't there some discussion months ago that the price progression for _cultural_ expansion and _bought_ expansion should be independent? Buying X tiles shouldn't increase next culture cost and vice versa? I can't find the discussion. Would be one extra counter like free promotions or free policies are working right now, and would be fine for a migration phase to just start it at 0 for updating mid-game...