### PR TITLE
Little documentation cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,15 +126,11 @@ Thumbs.db
 !/ios-moe/xcode/*.xcodeproj/xcshareddata
 !/ios-moe/xcode/*.xcodeproj/project.pbxproj
 /ios-moe/xcode/native/
-SaveFiles/
 android/android-release.apk
-android/assets/GameSettings.json
 android/release/output.json
 android/release/android-release.apk
 android/release/release/android.aab
-android/assets/fonts/
 android/release/android.aab
-android/assets/maps/
 android/release/android.aab.sig
 android/release/android-release.aab
 tests/build/
@@ -145,11 +141,17 @@ server/packrCache/
 deploy/
 android/release/
 
+# Transient Unciv files
+android/assets/GameSettings.json
+android/assets/lasterror.txt
+android/assets/fonts/
+android/assets/maps/
 android/assets/mods/
-android/assets/SaveFiles/
-android/assets/scenarios/
 android/assets/MultiplayerGames/
 android/assets/music/
+android/assets/SaveFiles/
+android/assets/scenarios/
+SaveFiles/
 
 # Visual Studio Code
 .vscode/
@@ -159,4 +161,5 @@ android/assets/music/
 node_modules/
 package-lock.json
 package.json
-/android/assets/lasterror.txt
+
+# Unsorted additions

--- a/docs/Developers/Building-Locally.md
+++ b/docs/Developers/Building-Locally.md
@@ -38,8 +38,10 @@ So first things first - the initial "No assumptions" setup to have Unciv run fro
     ![image](https://user-images.githubusercontent.com/44038014/169315352-9ba0c4cf-307c-44d1-b3bc-2a58752c6854.png)
     - Settings > Editor > General > On Save > Uncheck Remove trailing spaces on: [...] to prevent it from removing necessary trailing whitespace in template.properties for translation files
     ![image](https://user-images.githubusercontent.com/44038014/169316243-07e36b8e-4c9e-44c4-941c-47e634c68b4c.png)
-    - Right-click the `android/assets/SaveFiles` folder, "Mark directory as" > Excluded, to [disable indexing on mods](https://www.jetbrains.com/help/idea/indexing.html#exclude) for performance.
-      - If you download mods do the same for the `android/assets/mods` folder,
+    - Right-click the `android/assets/SaveFiles` folder, "Mark directory as" > Excluded
+      - If you download mods do the same for the `android/assets/mods` folder and any other files you may create while testing that do not belong in the public project.
+      - This [disables indexing](https://www.jetbrains.com/help/idea/indexing.html#exclude) for performance.
+
 Unciv uses Gradle to specify dependencies and how to run. In the background, the Gradle gnomes will be off fetching the packages (a one-time effort) and, once that's done, will build the project!
 
 Unciv uses Gradle 7.5 and the Android Gradle Plugin 7.3.1. Can check in File > Project Structure > Project


### PR DESCRIPTION
The latest update forgot that markup needs an empty line to end a bulleted list, which tripped my triggers. Also sounded like "exclude SaveGames to skip indexing mods"...
gitignore just a little reordered

Question: Some of the recommendations - shouldn't our editorconfig already cover these, like continuation indent and trailing spaces, and shouldn't we document that support for project-level editorconfig must be (or stay, dunno the default) turned on?