### PR TITLE
Don't return 401 when auth is disabled

### DIFF
--- a/server/src/com/unciv/app/server/UncivServer.kt
+++ b/server/src/com/unciv/app/server/UncivServer.kt
@@ -78,13 +78,7 @@ private class UncivServerRunner : CliktCommand() {
         if (!file.exists())
             return true
 
-        // Extract the user id and password from the auth string
-        val (userId, password) = extractAuth(authString) ?: return false
-
-        if (authMap[userId] == null || authMap[userId] == password)
-            return true
-
-        return false
+        return validateAuth(authString)
 
         // TODO Check if the user is the current player and validate its password this requires decoding the game file
     }


### PR DESCRIPTION
See https://github.com/yairm210/Unciv/issues/9136
The `extractAuth` function returns null when server auth is disabled, but `validateGameAccess` ought to return true for that case. Fortunately the logic is implemented in the `validateAuth` function so we can call that instead.