### PR TITLE
Visual clue a load game from clipboard is underway

### DIFF
--- a/core/src/com/unciv/ui/screens/savescreens/LoadGameScreen.kt
+++ b/core/src/com/unciv/ui/screens/savescreens/LoadGameScreen.kt
@@ -142,6 +142,8 @@ class LoadGameScreen : LoadOrSaveScreen() {
     private fun getLoadFromClipboardButton(): TextButton {
         val pasteButton = loadFromClipboard.toTextButton()
         pasteButton.onActivation {
+            pasteButton.setText("Working...".tr())
+            pasteButton.disable()
             Concurrency.run(loadFromClipboard) {
                 try {
                     val clipboardContentsString = Gdx.app.clipboard.contents.trim()
@@ -149,6 +151,11 @@ class LoadGameScreen : LoadOrSaveScreen() {
                     game.loadGame(loadedGame, true)
                 } catch (ex: Exception) {
                     launchOnGLThread { handleLoadGameException(ex, "Could not load game from clipboard!") }
+                } finally {
+                    launchOnGLThread {
+                        pasteButton.setText(loadFromClipboard.tr())
+                        pasteButton.enable()
+                    }
                 }
             }
         }


### PR DESCRIPTION
I keep wondering, while loading saves from issues, whether I did even hit the button or not - hence this.

Reusing the "Working..." string (now an 11th time - should we move it to Constants?), and like elsewhere showing it on the button itself. There's more places that could use more feedback like this in save/load, but I limited this to what actually irks me.