### PR TITLE
Fix border case crash with lone AI winning on turn 0

### DIFF
--- a/core/src/com/unciv/ui/screens/victoryscreen/VictoryScreenDemographics.kt
+++ b/core/src/com/unciv/ui/screens/victoryscreen/VictoryScreenDemographics.kt
@@ -22,6 +22,10 @@ class VictoryScreenDemographics(
         buildDemographicsHeaders()
 
         for (rankLabel in RankLabels.values())   {
+            if (rankLabel == RankLabels.Value) {
+                // playerCiv is not necessarily alive nor major, and the `first` below would throw
+                if (playerCiv.isDefeated() || !playerCiv.isMajorCiv()) continue
+            }
             row()
             add(rankLabel.name.toLabel())
 


### PR DESCRIPTION
Fix #9279.

Repro: Start new game, only Human Sectator + any AI, Domination victory enabled. AI immediately wins, demographics screen crashes.