### PR TITLE
Allow to reveal explored resources from a city's demanding resources in `CityOverviewTab`

### DIFF
--- a/core/src/com/unciv/ui/screens/overviewscreen/CityOverviewTable.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/CityOverviewTable.kt
@@ -231,6 +231,12 @@ class CityOverviewTab(
                 city.demandedResource.isNotEmpty() -> {
                     val image = ImageGetter.getResourcePortrait(city.demandedResource, iconSize *0.7f)
                     image.addTooltip("Demanding [${city.demandedResource}]", 18f, tipAlign = Align.topLeft)
+                    image.onClick {
+                        if (viewingPlayer.gameInfo
+                                .notifyExploredResources(viewingPlayer, city.demandedResource, 0, true)) {
+                            overviewScreen.game.popScreen()
+                        }
+                    }
                     cityInfoTableDetails.add(image)
                 }
                 else -> cityInfoTableDetails.add()

--- a/core/src/com/unciv/ui/screens/overviewscreen/CityOverviewTable.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/CityOverviewTable.kt
@@ -229,12 +229,12 @@ class CityOverviewTab(
                     cityInfoTableDetails.add(image)
                 }
                 city.demandedResource.isNotEmpty() -> {
-                    val image = ImageGetter.getResourcePortrait(city.demandedResource, iconSize *0.7f)
-                    image.addTooltip("Demanding [${city.demandedResource}]", 18f, tipAlign = Align.topLeft)
-                    image.onClick {
-                        if (viewingPlayer.gameInfo
-                                .notifyExploredResources(viewingPlayer, city.demandedResource, 0, true)) {
-                            overviewScreen.game.popScreen()
+                    val image = ImageGetter.getResourcePortrait(city.demandedResource, iconSize *0.7f).apply {
+                        addTooltip("Demanding [${city.demandedResource}]", 18f, tipAlign = Align.topLeft)
+                        onClick {
+                            if (gameInfo.notifyExploredResources(viewingPlayer, city.demandedResource, 0, true)) {
+                                overviewScreen.game.popScreen()
+                            }
                         }
                     }
                     cityInfoTableDetails.add(image)


### PR DESCRIPTION
## Summary
Allow to reveal explored resources from a city's demanding resources in `CityOverviewTab`.

## Description
Sometimes, A city you owned demands a new Luxury Resource. You want to reveal this resource in map (The notification like `[n] sources of [resourceName] revealed, e.g. near [cityName]`). And, you can make this notification showed by two ways currently: A new Technology has researched with a new resource that can be discovered and showed in map; Or clicking the icon image in `ResourcesOverviewTab`.
Now, I hope to display this notification directly, without jumping to `ResourcesOverviewTab`.
So, I added the callback of demanding resource image to show the notification directly.
