### PR TITLE
MapEditor: allow to retract generated steps

### DIFF
--- a/core/src/com/unciv/logic/map/mapgenerator/MapRegression.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/MapRegression.kt
@@ -1,0 +1,252 @@
+package com.unciv.logic.map.mapgenerator
+
+import com.unciv.Constants
+import com.unciv.logic.map.TileMap
+import com.unciv.logic.map.tile.Tile
+import com.unciv.models.ruleset.Ruleset
+import com.unciv.models.ruleset.tile.TerrainType
+import com.unciv.models.ruleset.unique.UniqueType
+import com.unciv.ui.screens.mapeditorscreen.MapGeneratorSteps
+import com.unciv.ui.screens.mapeditorscreen.MapGeneratorSteps.Elevation
+import com.unciv.ui.screens.mapeditorscreen.MapGeneratorSteps.HumidityAndTemperature
+import com.unciv.ui.screens.mapeditorscreen.MapGeneratorSteps.LakesAndCoast
+import com.unciv.ui.screens.mapeditorscreen.MapGeneratorSteps.Vegetation
+import com.unciv.ui.screens.mapeditorscreen.MapGeneratorSteps.RareFeatures
+import com.unciv.ui.screens.mapeditorscreen.MapGeneratorSteps.Ice
+import com.unciv.ui.screens.mapeditorscreen.MapGeneratorSteps.NaturalWonders
+import com.unciv.ui.screens.mapeditorscreen.MapGeneratorSteps.Rivers
+import com.unciv.ui.screens.mapeditorscreen.MapGeneratorSteps.Resources
+import com.unciv.ui.screens.mapeditorscreen.MapGeneratorSteps.AncientRuins
+
+
+// todo: unify tile Equivalents with MapGenerator
+
+/**
+ * This is a helpful tool to retract some steps in Map Generation
+ */
+class MapRegression(private val ruleset: Ruleset) {
+
+    companion object {
+
+        fun retractStep(step: MapGeneratorSteps, map: TileMap, ruleset: Ruleset) {
+            val regression = MapRegression(ruleset)
+            when (step) {
+                Elevation -> regression.retractElevation(map)
+                HumidityAndTemperature -> regression.retractHumidityAndTemperature(map)
+                LakesAndCoast -> regression.retractLakesAndCoast(map)
+                Vegetation -> regression.retractVegetation(map)
+                RareFeatures -> regression.retractRareFeatures(map)
+                Ice -> regression.retractIce(map)
+                NaturalWonders -> regression.retractNaturalWonders(map)
+                Rivers -> regression.retractRivers(map)
+                Resources -> regression.retractResources(map)
+                AncientRuins -> regression.retractAncientRuins(map)
+                else -> {}
+            }
+        }
+    }
+
+    fun retractElevation(map: TileMap) {
+        // mountain
+        val mountain = ruleset.terrains.values.filter { it.hasUnique(UniqueType.OccursInChains) }
+        map.values
+            .filterBaseTerrain(mountain.map { it.name })
+            .forEach { tile ->
+                tile.baseTerrain = Constants.grassland // retract to grassland
+                tile.setTerrainTransients()
+            }
+        // hill
+        val hill = ruleset.terrains.values.filter { it.hasUnique(UniqueType.RoughTerrain) }
+        map.values
+            .filter { it.isLand }
+            .filterFeatures(hill.map { it.name })
+            .forEach { tile ->
+                tile.retractTerrainFeatures(hill.map { it.name })
+                tile.setTerrainTransients()
+            }
+    }
+
+    /**
+     * _this can not fully retract_
+     */
+    fun retractHumidityAndTemperature(map: TileMap) {
+        val elevationTerrains = ruleset.terrains.values.asSequence()
+            .filter {
+                it.hasUnique(UniqueType.OccursInChains)
+            }.mapTo(mutableSetOf()) { it.name }
+        map.values
+            .filter { tile -> tile.isLand && tile.baseTerrain !in elevationTerrains }
+            .forEach { tile ->
+                tile.baseTerrain = Constants.grassland // retract to grassland
+                tile.temperature = 0.0
+                tile.humidity = 0.5
+                tile.setTerrainTransients()
+            }
+    }
+
+    /**
+     * _this can not fully retract_
+     */
+    fun retractLakes(map: TileMap) {
+        map.values.filter { it.baseTerrain == Constants.lakes }
+            .forEach { tile ->
+                tile.baseTerrain = Constants.grassland // todo: better guess, maybe not grassland
+                tile.setTerrainTransients()
+            }
+    }
+
+    fun retractCoast(map: TileMap) {
+        map.values.filter { it.baseTerrain == Constants.coast }
+            .forEach { tile ->
+
+                tile.baseTerrain = Constants.ocean
+                tile.setTerrainTransients()
+            }
+    }
+
+    fun retractLakesAndCoast(map: TileMap) {
+        retractCoast(map)
+        retractLakes(map)
+    }
+
+
+    fun retractVegetation(map: TileMap) {
+        val vegetationEquivalents =
+                ruleset.terrains.values.filter { it.hasUnique(UniqueType.Vegetation) }.map { it.name }
+        map.values.filterFeatures(vegetationEquivalents)
+            .forEach { tile ->
+                tile.retractTerrainFeatures(vegetationEquivalents)
+            }
+    }
+
+    fun retractRareFeatures(map: TileMap) {
+        val rareFeatures = ruleset.terrains.values.filter {
+            it.type == TerrainType.TerrainFeature && it.hasUnique(UniqueType.RareFeature)
+        }.map { it.name }
+
+        map.values
+            .filterFeatures(rareFeatures)
+            .forEach { tile ->
+                tile.retractTerrainFeatures(rareFeatures)
+            }
+    }
+
+
+    fun retractIce(map: TileMap) {
+        val waterTerrain: Set<String> =
+                ruleset.terrains.values.asSequence()
+                    .filter { it.type == TerrainType.Water }
+                    .map { it.name }.toSet()
+
+        val iceEquivalents = ruleset.terrains.values.asSequence()
+            .filter { terrain ->
+                terrain.type == TerrainType.TerrainFeature &&
+                        terrain.impassable &&
+                        terrain.occursOn.all { it in waterTerrain }
+            }.map { it.name }.toList()
+
+        map.values
+            .filterFeatures(iceEquivalents)
+            .forEach { tile ->
+                tile.retractTerrainFeatures(iceEquivalents)
+            }
+    }
+
+    /**
+     * _this can not fully retract_, but we try to do the best
+     */
+    fun retractNaturalWonders(map: TileMap) {
+
+        map.values
+            .filter { it.isNaturalWonder() }
+            .forEach { tile ->
+                removeNatureWonder(ruleset, tile)
+            }
+    }
+
+
+    // todo: better guess on previous tile
+    private fun removeNatureWonder(ruleset: Ruleset, tile: Tile) {
+
+        val naturalWonder = tile.getNaturalWonder()
+        val wonderCandidateTiles = naturalWonder.occursOn.mapNotNull { ruleset.terrains[it] }
+
+        val onWater = wonderCandidateTiles.any { it.type == TerrainType.Water }
+        val onLand = wonderCandidateTiles.any { it.type == TerrainType.Land }
+
+        val nearBy = tile.getTilesAtDistance(1)
+
+        val retractedTile = when {
+            onWater -> {
+                if (nearBy.filter { it.isOcean }.count() >= nearBy.count() * 2 / 3) {
+                    // more than 2/3 nearby are ocean
+                    Constants.ocean
+                } else {
+                    Constants.coast
+                }
+            }
+
+            onLand -> {
+                if (nearBy.filter { it.isHill() }.count() >= nearBy.count() * 2 / 3) {
+                    // more than 2/3 nearby are hill
+                    Constants.hill
+                } else {
+                    Constants.grassland
+                }
+            }
+
+            else -> { // what?
+                wonderCandidateTiles.first().name
+            }
+        }
+
+        tile.naturalWonder = null
+        tile.baseTerrain = retractedTile
+        tile.setTerrainTransients()
+    }
+
+
+    fun retractRivers(map: TileMap) {
+        map.values.forEach { tile ->
+            tile.hasBottomRightRiver = false
+            tile.hasBottomRiver = false
+            tile.hasBottomLeftRiver = false
+        }
+    }
+
+    fun retractResources(map: TileMap) {
+        map.values.forEach { tile -> tile.resource = null }
+    }
+
+    fun retractAncientRuins(map: TileMap) {
+        val ruinsEquivalents = ruleset.tileImprovements.filter { it.value.isAncientRuinsEquivalent() }
+        if (ruinsEquivalents.isEmpty()) return
+
+        map.values
+            .filter { tile -> tile.improvement in ruinsEquivalents.keys }
+            .forEach { tile ->
+                tile.changeImprovement(null)
+            }
+    }
+
+    // fun retract(map: TileMap) {}
+
+    private fun Tile.retractTerrainFeatures(features: List<String>) =
+            setTerrainFeatures(
+                terrainFeatures.toMutableList().also { it.removeAny(features) }
+            )
+
+    private fun Collection<Tile>.filterFeatures(terrainFeature: List<String>) =
+            filter {
+                it.terrainFeatures.containsAny(terrainFeature)
+            }
+
+    private fun Collection<Tile>.filterBaseTerrain(terrain: List<String>) =
+            filter { it.baseTerrain in terrain }
+
+    private fun <E> Collection<E>.containsAny(list: List<E>): Boolean =
+            list.map { contains(it) }.reduce { a, b -> a || b }
+
+    private fun <E> MutableCollection<E>.removeAny(list: List<E>): Boolean =
+            list.map { remove(it) }.reduce { a, b -> a || b }
+}

--- a/core/src/com/unciv/ui/screens/mapeditorscreen/MapEditorMainTabs.kt
+++ b/core/src/com/unciv/ui/screens/mapeditorscreen/MapEditorMainTabs.kt
@@ -8,6 +8,7 @@ import com.unciv.ui.screens.mapeditorscreen.tabs.MapEditorGenerateTab
 import com.unciv.ui.screens.mapeditorscreen.tabs.MapEditorLoadTab
 import com.unciv.ui.screens.mapeditorscreen.tabs.MapEditorModsTab
 import com.unciv.ui.screens.mapeditorscreen.tabs.MapEditorOptionsTab
+import com.unciv.ui.screens.mapeditorscreen.tabs.MapEditorRetractTab
 import com.unciv.ui.screens.mapeditorscreen.tabs.MapEditorSaveTab
 import com.unciv.ui.screens.mapeditorscreen.tabs.MapEditorViewTab
 
@@ -17,10 +18,11 @@ class MapEditorMainTabs(
     minimumHeight = editorScreen.stage.height,
     maximumHeight = editorScreen.stage.height,
     headerFontSize = 24,
-    capacity = 7
+    capacity = 8,
 ) {
     val view = MapEditorViewTab(editorScreen)
     val generate = MapEditorGenerateTab(editorScreen)
+    val retract = MapEditorRetractTab(editorScreen)
     val edit = MapEditorEditTab(editorScreen, headerHeight)
     val load = MapEditorLoadTab(editorScreen, headerHeight)
     val save = MapEditorSaveTab(editorScreen, headerHeight)
@@ -36,6 +38,9 @@ class MapEditorMainTabs(
         addPage("Generate", generate,
             ImageGetter.getImage("OtherIcons/New"), 25f,
             shortcutKey = KeyCharAndCode.ctrl('n'))
+        addPage("Retract", retract,
+            ImageGetter.getImage("OtherIcons/BackArrow"), 25f,
+            shortcutKey = KeyCharAndCode.ctrl('r'))
         addPage("Edit", edit,
             ImageGetter.getImage("OtherIcons/Terrains"), 25f,
             shortcutKey = KeyCharAndCode.ctrl('e'))

--- a/core/src/com/unciv/ui/screens/mapeditorscreen/tabs/MapEditorRetractTab.kt
+++ b/core/src/com/unciv/ui/screens/mapeditorscreen/tabs/MapEditorRetractTab.kt
@@ -1,0 +1,92 @@
+package com.unciv.ui.screens.mapeditorscreen.tabs
+
+import com.badlogic.gdx.Gdx
+import com.badlogic.gdx.scenes.scene2d.ui.Label
+import com.badlogic.gdx.scenes.scene2d.ui.Table
+import com.unciv.logic.map.mapgenerator.MapRegression
+import com.unciv.ui.components.extensions.onClick
+import com.unciv.ui.components.extensions.toLabel
+import com.unciv.ui.components.extensions.toTextButton
+import com.unciv.ui.popups.Popup
+import com.unciv.ui.popups.ToastPopup
+import com.unciv.ui.screens.basescreen.BaseScreen
+import com.unciv.ui.screens.mapeditorscreen.MapEditorScreen
+import com.unciv.ui.screens.mapeditorscreen.MapGeneratorSteps
+import com.unciv.ui.screens.mapeditorscreen.MapGeneratorSteps.Continents
+import com.unciv.ui.screens.mapeditorscreen.MapGeneratorSteps.Landmass
+import com.unciv.ui.screens.mapeditorscreen.MapGeneratorSteps.NaturalWonders
+import com.unciv.utils.Log
+import kotlin.concurrent.thread
+
+class MapEditorRetractTab(
+    private val editorScreen: MapEditorScreen
+) : Table(BaseScreen.skin) {
+
+    private var isProcessing = false
+    private var title: Label
+
+    init {
+        top()
+        pad(4f)
+        defaults().pad(2.5f)
+
+        title = TITLE_NORMAL.toLabel(fontSize = 24)
+        add(title).row()
+        for (steps in MapGeneratorSteps.values()) {
+            if (steps <= Landmass || steps == Continents) continue
+
+            val label = steps.label.toLabel(fontSize = 18)
+            val button = "Retract".toTextButton().onClick {
+                if (isProcessing) {
+                    ToastPopup("please wait", stage)
+                } else {
+                    retract(steps)
+                }
+            }
+
+            add(label)
+            add(button)
+            row()
+        }
+    }
+
+    private fun retract(step: MapGeneratorSteps) {
+        if (step <= Landmass) return
+        Gdx.input.inputProcessor = null // remove input processing - nothing will be clicked!
+        isProcessing = true
+        title.setText(TITLE_PROCESS)
+
+        thread(name = "MapRegression", isDaemon = true) {
+            try {
+                MapRegression.retractStep(step, editorScreen.tileMap, editorScreen.ruleset)
+                Gdx.app.postRunnable {
+                    if (step == NaturalWonders) editorScreen.naturalWondersNeedRefresh = true
+                    editorScreen.mapHolder.updateTileGroups()
+                    editorScreen.isDirty = true
+                }
+
+            } catch (exception: Exception) {
+                Log.error("Exception while regress map", exception)
+                Gdx.app.postRunnable {
+                    Popup(editorScreen).apply {
+                        addGoodSizedLabel("Failed to retract steps!") // todo: translate
+                        row()
+                        addCloseButton()
+                    }.open()
+                }
+            } finally {
+                Gdx.app.postRunnable {
+                    isProcessing = false
+                    Gdx.input.inputProcessor = editorScreen.stage
+                    title.setText(TITLE_NORMAL)
+                }
+            }
+        }
+    }
+
+    companion object {
+        private const val TITLE_NORMAL = "Retract"
+        private const val TITLE_PROCESS = "Processing"
+    }
+
+}


### PR DESCRIPTION
# Summary
Frequently, you want to undo changes in `Partial (Stepped) Map Generation" (or created map)  in Map Editor, or remove all tiles/TileFeature/TileImprovement of a certain type quickly.

Now, this PR provides a way (currently not perfect) to retract some large changes in MapEditor


# Changes

This PR adds:

- `MapRegression`: like `MapGenerator`, but does the opposite — retract changes
- `MapEditorRetractTab`: A tab in Map Editor, which looks like subtab `MapEditorGenerateStepsTab` in `MapEditorGenerateTab`, provides UI of retracting changes.

## ScreenShot
![Screenshotpng](https://user-images.githubusercontent.com/30681738/234865479-76759984-ed3e-4a33-96a2-fab79fe837e4.png)



## Known Bugs

- [ ] If user does not retract steps in order of reverted step in normal Generator Steps, may cause some glitchy tile against Terrain Ruleset.(For example, if retrack coast lines before rare terrains, atolls might be left on oceans)
- [ ] `retractNaturalWonders` may not working perfectly.
- [ ] Can not fully revert changes. Since some steps are unretractable, we can only guess what the previous tile might be.
- [ ] Some strings might need to be "refined" and "improved". (So, not "String.tr()"ed)

## Test

**Almost Good**

- Only Vanilla & K&G, no mod is tested.
- Tested on Desktop, no Android.
- Tests look fine for me excepting bugs mentioned above.


# Other Infomation

**Please review my codes carefully.** 
I am new to GDX, and not familiar with this project's code (My first large PR); ~I don't trust and believe myself as well.~




(This should be a draft.)
