### PR TITLE
Reduce a few memory allocations

### DIFF
--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -34,7 +34,9 @@ import com.unciv.ui.audio.MusicMood
 import com.unciv.ui.audio.MusicTrackChooserFlags
 import com.unciv.utils.DebugUtils
 import com.unciv.utils.debug
-import java.util.*
+import java.util.UUID
+import kotlin.collections.ArrayList
+import kotlin.collections.HashMap
 
 
 /**
@@ -163,9 +165,11 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
     fun clone(): GameInfo {
         val toReturn = GameInfo()
         toReturn.tileMap = tileMap.clone()
-        toReturn.civilizations.addAll(civilizations.map { it.clone() })
+        toReturn.civilizations = civilizations.asSequence()
+            .map { it.clone() }
+            .toCollection(ArrayList(civilizations.size))
         toReturn.barbarians = barbarians.clone()
-        toReturn.religions.putAll(religions.map { Pair(it.key, it.value.clone()) })
+        toReturn.religions.putAll(religions.asSequence().map { it.key to it.value.clone() })
         toReturn.currentPlayer = currentPlayer
         toReturn.currentTurnStartTime = currentTurnStartTime
         toReturn.turns = turns
@@ -175,7 +179,7 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
         toReturn.diplomaticVictoryVotesCast.putAll(diplomaticVictoryVotesCast)
         toReturn.oneMoreTurnMode = oneMoreTurnMode
         toReturn.customSaveLocation = customSaveLocation
-        toReturn.victoryData = victoryData
+        toReturn.victoryData = victoryData?.copy()
         toReturn.historyStartTurn = historyStartTurn
 
         return toReturn

--- a/core/src/com/unciv/logic/map/TileMap.kt
+++ b/core/src/com/unciv/logic/map/TileMap.kt
@@ -20,8 +20,10 @@ import kotlin.math.abs
  * or [MapGenerator][com.unciv.logic.map.mapgenerator.MapGenerator]; or as part of a running [game][GameInfo].
  *
  * Note: Will be Serialized -> Take special care with lateinit and lazy!
+ *
+ * @param initialCapacity Passed to constructor of [tileList]
  */
-class TileMap : IsPartOfGameInfoSerialization {
+class TileMap(initialCapacity: Int = 10) : IsPartOfGameInfoSerialization {
     companion object {
         /** Legacy way to store starting locations - now this is used only in [translateStartingLocationsFromMap] */
         const val startingLocationPrefix = "StartingLocation "
@@ -38,7 +40,7 @@ class TileMap : IsPartOfGameInfoSerialization {
 
     var mapParameters = MapParameters()
 
-    var tileList = ArrayList<Tile>()
+    var tileList = ArrayList<Tile>(initialCapacity)
 
     /** Structure geared for simple serialization by Gdx.Json (which is a little blind to kotlin collections, especially HashSet)
      * @param position [Vector2] of the location
@@ -93,11 +95,9 @@ class TileMap : IsPartOfGameInfoSerialization {
     //endregion
     //region Constructors
 
-    /** for json parsing, we need to have a default constructor */
-    constructor()
-
     /** creates a hexagonal map of given radius (filled with grassland) */
-    constructor(radius: Int, ruleset: Ruleset, worldWrap: Boolean = false) {
+    constructor(radius: Int, ruleset: Ruleset, worldWrap: Boolean = false)
+            : this (HexMath.getNumberOfTilesInHexagon(radius)) {
         startingLocations.clear()
         val firstAvailableLandTerrain = MapLandmassGenerator.getInitializationTerrain(ruleset, TerrainType.Land)
         for (vector in HexMath.getVectorsInDistance(Vector2.Zero, radius, worldWrap))
@@ -106,7 +106,8 @@ class TileMap : IsPartOfGameInfoSerialization {
     }
 
     /** creates a rectangular map of given width and height (filled with grassland) */
-    constructor(width: Int, height: Int, ruleset: Ruleset, worldWrap: Boolean = false) {
+    constructor(width: Int, height: Int, ruleset: Ruleset, worldWrap: Boolean = false)
+            : this(width * height) {
         startingLocations.clear()
         val firstAvailableLandTerrain = MapLandmassGenerator.getInitializationTerrain(ruleset, TerrainType.Land)
 
@@ -130,13 +131,16 @@ class TileMap : IsPartOfGameInfoSerialization {
 
     /** @return a deep-copy clone of the serializable fields, no transients initialized */
     fun clone(): TileMap {
-        val toReturn = TileMap()
-        toReturn.tileList.addAll(tileList.map { it.clone() })
+        val toReturn = TileMap(tileList.size)
+        toReturn.tileList.addAll(tileList.asSequence().map { it.clone() })
         toReturn.mapParameters = mapParameters
         toReturn.ruleset = ruleset
+
+        // Note during normal play this is empty. Supported for MapEditorScreen.getMapCloneForSave.
         toReturn.startingLocations.clear()
         toReturn.startingLocations.ensureCapacity(startingLocations.size)
         toReturn.startingLocations.addAll(startingLocations)
+
         return toReturn
     }
 

--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -109,7 +109,7 @@ class Ruleset {
     }
 
     private fun <T : INamed> createHashmap(items: Array<T>): LinkedHashMap<String, T> {
-        val hashMap = LinkedHashMap<String, T>()
+        val hashMap = LinkedHashMap<String, T>(items.size)
         for (item in items)
             hashMap[item.name] = item
         return hashMap


### PR DESCRIPTION
Just an observation on the side, level 'can't hurt'. My crude measurements say GameInfo.clone goes from a 44ms average to 35ms, but that's not reliable. I still haven't learned the proper profiling techniques. Note I looked for more similar places and found none that both moves significant data and offers a path to less allocations, next best was Tile.exploredBy and for a HashSet the java lib clone should be faster than addAll - but it wasn't, not measurably, went back up to 38ms, but as said my technique is crude.