### PR TITLE
Policy images in red text, policy branch icons in pedia

### DIFF
--- a/core/src/com/unciv/ui/screens/civilopediascreen/CivilopediaCategories.kt
+++ b/core/src/com/unciv/ui/screens/civilopediascreen/CivilopediaCategories.kt
@@ -16,12 +16,13 @@ import com.unciv.ui.components.tilegroups.TileSetStrings
 import com.unciv.ui.components.KeyCharAndCode
 import com.unciv.ui.components.extensions.setSize
 import com.unciv.ui.components.extensions.surroundWithCircle
-import java.io.File
+import com.unciv.ui.images.IconCircleGroup
 
 
 /** Encapsulates the knowledge on how to get an icon for each of the Civilopedia categories */
 object CivilopediaImageGetters {
     private const val policyIconFolder = "PolicyIcons"
+    private const val policyBranchIconFolder = "PolicyBranchIcons"
     private const val policyInnerSize = 0.25f
 
     // Todo: potential synergy with map editor
@@ -64,17 +65,17 @@ object CivilopediaImageGetters {
         if (nation == null) null
         else ImageGetter.getNationPortrait(nation, size)
     }
-    val policy = { name: String, size: Float ->
-        // policy branch start and complete have no icons but are linked -> nonexistence must be passed down
-        val fileName = policyIconFolder + File.separator + name
-        if (ImageGetter.imageExists(fileName))
-            ImageGetter.getImage(fileName)
-                .apply {
-                    setSize(size * policyInnerSize,size * policyInnerSize)
-                    color = Color.BROWN
-                }
-                .surroundWithCircle(size)
-        else null
+    val policy = fun(name: String, size: Float): IconCircleGroup? {
+        // result is nullable: policy branch complete have no icons but are linked -> nonexistence must be passed down
+        fun tryImage(path: String, color: Color): IconCircleGroup? {
+            if (ImageGetter.imageExists(path)) return ImageGetter.getImage(path).apply {
+                setSize(size * policyInnerSize,size * policyInnerSize)
+                this.color = color
+            }.surroundWithCircle(size)
+            return null
+        }
+        return tryImage("$policyBranchIconFolder/$name", Color.BLACK)
+            ?: tryImage("$policyIconFolder/$name", Color.BROWN)
     }
     val resource = { name: String, size: Float ->
         ImageGetter.getResourcePortrait(name, size)

--- a/core/src/com/unciv/ui/screens/pickerscreens/PolicyPickerScreen.kt
+++ b/core/src/com/unciv/ui/screens/pickerscreens/PolicyPickerScreen.kt
@@ -18,6 +18,7 @@ import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.translations.fillPlaceholders
 import com.unciv.models.translations.tr
 import com.unciv.ui.components.BorderedTable
+import com.unciv.ui.components.ColorMarkupLabel
 import com.unciv.ui.components.extensions.addSeparator
 import com.unciv.ui.components.extensions.center
 import com.unciv.ui.components.extensions.colorFromRGB
@@ -69,8 +70,8 @@ class PolicyButton(viewingCiv: Civilization, canChangeState: Boolean, val policy
 
     val icon = ImageGetter.getImage("PolicyIcons/" + policy.name)
 
-    val isPickable = policy.isPickable(viewingCiv, canChangeState)
-    val isAdopted = viewingCiv.policies.isAdopted(policy.name)
+    private val isPickable = policy.isPickable(viewingCiv, canChangeState)
+    private val isAdopted = viewingCiv.policies.isAdopted(policy.name)
 
     var isSelected = false
         set(value) {
@@ -130,11 +131,11 @@ class PolicyPickerScreen(val viewingCiv: Civilization, val canChangeState: Boole
     : PickerScreen(), RecreateOnResize {
 
     object Sizes {
-        val paddingVertical = 10f
-        val paddingHorizontal = 20f
-        val paddingBetweenHor = 10f
-        val paddingBetweenVer = 20f
-        val iconSize = 50f
+        const val paddingVertical = 10f
+        const val paddingHorizontal = 20f
+        const val paddingBetweenHor = 10f
+        const val paddingBetweenVer = 20f
+        const val iconSize = 50f
     }
 
     private var policyNameToButton = HashMap<String, PolicyButton>()
@@ -280,7 +281,8 @@ class PolicyPickerScreen(val viewingCiv: Civilization, val canChangeState: Boole
         val conditionals = LinkedHashMap<UniqueType, ArrayList<String>>()
 
         branch.uniqueMap[UniqueType.OnlyAvailableWhen.text]?.forEach {
-            it.conditionals.forEach {
+            unique ->
+            unique.conditionals.forEach {
                 if (it.type != null) {
                     if (conditionals[it.type] == null)
                         conditionals[it.type] = ArrayList()
@@ -294,8 +296,7 @@ class PolicyPickerScreen(val viewingCiv: Civilization, val canChangeState: Boole
             for ((k, v) in conditionals) {
                 warning += "• " + k.text.fillPlaceholders(v.joinToString()).tr() + "\n"
             }
-            val warningLabel = warning.toLabel(Color.RED.cpy(), 13)
-            warningLabel.setFillParent(false)
+            val warningLabel = ColorMarkupLabel(warning, Color.RED, fontSize = 13)
             warningLabel.setAlignment(Align.topLeft)
             warningLabel.wrap = true
             labelTable.add(warningLabel).pad(0f, 20f, 17f, 20f).grow()
@@ -520,7 +521,9 @@ class PolicyPickerScreen(val viewingCiv: Civilization, val canChangeState: Boole
         }.toGroup(15f) else null
         val expandIcon = ImageGetter.getImage("OtherIcons/BackArrow").apply { rotation = 90f }.toGroup(10f)
         table.add(expandIcon).minWidth(15f).expandX().left()
-        table.add(branch.name.tr(hideIcons = true).uppercase().toLabel(fontSize = 14).apply { setAlignment(Align.center) }).center()
+        table.add(
+            branch.name.tr(hideIcons = true).uppercase().toLabel(fontSize = 14, alignment = Align.center)
+        ).center()
         table.add(icon).expandX().left().padLeft(5f)
 
         header.touchable = Touchable.enabled
@@ -624,7 +627,7 @@ class PolicyPickerScreen(val viewingCiv: Civilization, val canChangeState: Boole
         return table
     }
 
-    private fun getPolicyButton(policy: Policy, size: Float = 30f): PolicyButton {
+    private fun getPolicyButton(policy: Policy, size: Float): PolicyButton {
         val button = PolicyButton(viewingCiv, canChangeState, policy, size = size)
         button.onClick { pickPolicy(button = button) }
         if (policy.isPickable(viewingCiv, canChangeState))


### PR DESCRIPTION
Screenshots in #9304 mostly apply (except for those I had reused the Pedia getter for the font, thus pixely edges on SurroundWithCircle'd glyphs).

As for that `CivilopediaImageGetters` helper being out of date - wishing for an intrepid fearless coder to attack the mighty task of creating a common RulesetObject.getImage kind of interface... right?