### PR TITLE
Combat java.util.star-import

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -37,9 +37,10 @@ ij_kotlin_keep_blank_lines_in_code = 2
 ij_kotlin_keep_blank_lines_in_declarations = 2
 ij_kotlin_block_comment_at_first_column = true
 ij_kotlin_line_comment_add_space = true
-ij_kotlin_name_count_to_use_star_import = 999
-ij_kotlin_name_count_to_use_star_import_for_members = 999
-ij_kotlin_continuation_indent_size = 8
+ij_kotlin_name_count_to_use_star_import = 100
+ij_kotlin_name_count_to_use_star_import_for_members = 100
+ij_kotlin_packages_to_use_import_on_demand = kotlinx.android.synthetic.**,io.ktor.**
+ij_kotlin_continuation_indent_size = 4
 ij_kotlin_continuation_indent_for_chained_calls = false
 ij_kotlin_continuation_indent_for_expression_bodies = true
 ij_kotlin_continuation_indent_in_argument_lists = false
@@ -47,6 +48,9 @@ ij_kotlin_continuation_indent_in_elvis = false
 ij_kotlin_continuation_indent_in_if_conditions = true
 ij_kotlin_continuation_indent_in_parameter_lists = false
 ij_kotlin_continuation_indent_in_supertype_lists = false
+ij_java_class_count_to_use_import_on_demand = 100
+ij_java_names_count_to_use_import_on_demand = 100
+ij_java_use_single_class_imports = true
 
 [*.json]
 ij_json_keep_blank_lines_in_code = 0

--- a/android/src/com/unciv/app/AndroidFont.kt
+++ b/android/src/com/unciv/app/AndroidFont.kt
@@ -16,7 +16,7 @@ import com.unciv.ui.components.FontFamilyData
 import com.unciv.ui.components.FontImplementation
 import com.unciv.ui.components.Fonts
 import com.unciv.utils.Log
-import java.util.*
+import java.util.Locale
 import kotlin.math.abs
 
 class AndroidFont : FontImplementation {

--- a/android/src/com/unciv/app/MultiplayerTurnCheckWorker.kt
+++ b/android/src/com/unciv/app/MultiplayerTurnCheckWorker.kt
@@ -289,7 +289,7 @@ class MultiplayerTurnCheckWorker(appContext: Context, workerParams: WorkerParame
         try {
             val gameIds = inputData.getStringArray(GAME_ID)!!
             val gameNames = inputData.getStringArray(GAME_NAME)!!
-            Log.d(LOG_TAG, "doWork gameNames: ${Arrays.toString(gameNames)}")
+            Log.d(LOG_TAG, "doWork gameNames: ${gameNames.contentToString()}")
             // We only want to notify the user or update persisted notification once but still want
             // to download all games to update the files so we save the first one we find
             var foundGame: Pair<String, String>? = null

--- a/core/src/com/unciv/UncivGame.kt
+++ b/core/src/com/unciv/UncivGame.kt
@@ -52,7 +52,8 @@ import com.unciv.utils.withGLContext
 import com.unciv.utils.withThreadPoolContext
 import kotlinx.coroutines.CancellationException
 import java.io.PrintWriter
-import java.util.*
+import java.util.EnumSet
+import java.util.UUID
 import kotlin.collections.ArrayDeque
 import kotlin.system.exitProcess
 
@@ -484,7 +485,7 @@ open class UncivGame(val isConsoleMode: Boolean = false) : Game(), PlatformSpeci
 
     private fun logRunningThreads() {
         val numThreads = Thread.activeCount()
-        val threadList = Array(numThreads) { _ -> Thread() }
+        val threadList = Array(numThreads) { Thread() }
         Thread.enumerate(threadList)
         threadList.filter { it !== Thread.currentThread() && it.name != "DestroyJavaVM" }.forEach {
             debug("Thread %s still running in UncivGame.dispose().", it.name)

--- a/core/src/com/unciv/logic/IdHelper.kt
+++ b/core/src/com/unciv/logic/IdHelper.kt
@@ -1,6 +1,6 @@
 package com.unciv.logic
 
-import java.util.*
+import java.util.Locale
 import kotlin.math.abs
 
 /**
@@ -112,5 +112,3 @@ object IdChecker {
             return (10 - (sum % 10)) % 10
         }
 }
-
-

--- a/core/src/com/unciv/logic/automation/ai/TacticalAnalysisMap.kt
+++ b/core/src/com/unciv/logic/automation/ai/TacticalAnalysisMap.kt
@@ -8,7 +8,7 @@ import com.unciv.logic.civilization.Civilization
 import com.unciv.logic.map.tile.Tile
 import com.unciv.logic.map.TileMap
 import com.unciv.utils.Log
-import java.util.*
+import java.util.UUID
 import kotlin.collections.ArrayList
 import kotlin.collections.HashMap
 

--- a/core/src/com/unciv/logic/automation/civilization/BarbarianManager.kt
+++ b/core/src/com/unciv/logic/automation/civilization/BarbarianManager.kt
@@ -11,10 +11,10 @@ import com.unciv.logic.map.TileMap
 import com.unciv.logic.map.tile.Tile
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.ui.components.extensions.randomWeighted
-import java.util.*
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.pow
+import kotlin.random.Random
 
 class BarbarianManager : IsPartOfGameInfoSerialization {
     /** Deprecated  */
@@ -78,7 +78,7 @@ class BarbarianManager : IsPartOfGameInfoSerialization {
 
     fun placeBarbarianEncampment() {
         // Before we do the expensive stuff, do a roll to see if we will place a camp at all
-        if (gameInfo.turns > 1 && Random().nextBoolean())
+        if (gameInfo.turns > 1 && Random.Default.nextBoolean())
             return
 
         // Barbarians will only spawn in places that no one can see
@@ -119,7 +119,7 @@ class BarbarianManager : IsPartOfGameInfoSerialization {
 
         var tile: Tile?
         var addedCamps = 0
-        var biasCoast = Random().nextInt(6) == 0
+        var biasCoast = Random.Default.nextInt(6) == 0
 
         // Add the camps
         while (addedCamps < campsToAdd) {
@@ -146,7 +146,7 @@ class BarbarianManager : IsPartOfGameInfoSerialization {
                 // Remove some newly non-viable tiles
                 viableTiles.removeAll(tile.getTilesInDistance(7).toSet())
                 // Reroll bias
-                biasCoast = Random().nextInt(6) == 0
+                biasCoast = Random.Default.nextInt(6) == 0
             }
         }
     }
@@ -280,7 +280,7 @@ class Encampment() : IsPartOfGameInfoSerialization {
     /** When a barbarian is spawned, seed the counter for next spawn */
     private fun resetCountdown() {
         // Base 8-12 turns
-        countdown = 8 + Random().nextInt(5)
+        countdown = 8 + Random.Default.nextInt(5)
         // Quicker on Raging Barbarians
         if (gameInfo.gameParameters.ragingBarbarians)
             countdown /= 2

--- a/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
@@ -45,7 +45,8 @@ import com.unciv.models.ruleset.unit.BaseUnit
 import com.unciv.models.stats.Stat
 import com.unciv.models.translations.tr
 import com.unciv.ui.screens.victoryscreen.RankingType
-import java.util.*
+import java.util.SortedMap
+import java.util.TreeMap
 import kotlin.math.min
 
 object NextTurnAutomation {
@@ -701,7 +702,7 @@ object NextTurnAutomation {
                 (it.type == beliefType || beliefType == BeliefType.Any)
                 && !additionalBeliefsToExclude.contains(it)
                 && civInfo.religionManager.getReligionWithBelief(it) == null
-                && it.getMatchingUniques(UniqueType.OnlyAvailableWhen).none { !it.conditionalsApply(civInfo) }
+                && it.getMatchingUniques(UniqueType.OnlyAvailableWhen).none { unique -> !unique.conditionalsApply(civInfo) }
             }
             .maxByOrNull { ReligionAutomation.rateBelief(civInfo, it) }
     }
@@ -762,7 +763,6 @@ object NextTurnAutomation {
     @Suppress("unused")  //todo: Work in Progress?
     private fun offerDeclarationOfFriendship(civInfo: Civilization) {
         val civsThatWeCanDeclareFriendshipWith = civInfo.getKnownCivs()
-                .asSequence()
                 .filter {
                     it.isMajorCiv() && !it.isAtWarWith(civInfo)
                             && it.getDiplomacyManager(civInfo).isRelationshipLevelGT(RelationshipLevel.Neutral)
@@ -781,7 +781,6 @@ object NextTurnAutomation {
         if (!civInfo.diplomacyFunctions.canSignResearchAgreement()) return // don't waste your time
 
         val canSignResearchAgreementCiv = civInfo.getKnownCivs()
-                .asSequence()
                 .filter {
                     civInfo.diplomacyFunctions.canSignResearchAgreementsWith(it)
                             && !civInfo.getDiplomacyManager(it).hasFlag(DiplomacyFlags.DeclinedResearchAgreement)

--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -28,9 +28,9 @@ import com.unciv.models.stats.Stat
 import com.unciv.models.stats.Stats
 import com.unciv.ui.components.extensions.toPercent
 import com.unciv.utils.debug
-import java.util.*
 import kotlin.math.max
 import kotlin.math.min
+import kotlin.random.Random
 
 /**
  * Damage calculations according to civ v wiki and https://steamcommunity.com/sharedfiles/filedetails/?id=170194443
@@ -358,7 +358,7 @@ object Battle {
             //so...for each round, we randomize who gets the attack in. Seems to be a good way to work for now.
 
             while (potentialDamageToDefender + potentialDamageToAttacker > 0) {
-                if (Random().nextInt(potentialDamageToDefender + potentialDamageToAttacker) < potentialDamageToDefender) {
+                if (Random.Default.nextInt(potentialDamageToDefender + potentialDamageToAttacker) < potentialDamageToDefender) {
                     potentialDamageToDefender--
                     defender.takeDamage(1)
                     if (defender.isDefeated()) break
@@ -707,7 +707,8 @@ object Battle {
             capturedUnit.civ = capturingCiv
 
             val workerTypeUnit = capturingCiv.gameInfo.ruleset.units.values
-                .firstOrNull { it.isCivilian() && it.getMatchingUniques(UniqueType.BuildImprovements).any { it.params[0] == "Land" } }
+                .firstOrNull { it.isCivilian() && it.getMatchingUniques(UniqueType.BuildImprovements)
+                    .any { unique -> unique.params[0] == "Land" } }
 
             if (workerTypeUnit != null)
                 capturingCiv.units.placeUnitNearTile(capturedUnit.currentTile.position, workerTypeUnit.name)
@@ -843,9 +844,9 @@ object Battle {
             if (defender.unit.isCivilian() || nukeStrength >= 2) {
                 unit.destroy()
             } else if (nukeStrength == 1) {
-                defender.takeDamage(((40 + Random().nextInt(60)) * damageModifierFromMissingResource).toInt())
+                defender.takeDamage(((40 + Random.Default.nextInt(60)) * damageModifierFromMissingResource).toInt())
             } else if (nukeStrength == 0) {
-                defender.takeDamage(((20 + Random().nextInt(30)) * damageModifierFromMissingResource).toInt())
+                defender.takeDamage(((20 + Random.Default.nextInt(30)) * damageModifierFromMissingResource).toInt())
             }
             postBattleNotifications(attacker, defender, defender.getTile())
             destroyIfDefeated(defender.getCivInfo(), attacker.getCivInfo())
@@ -865,13 +866,13 @@ object Battle {
             if (tile.terrainHasUnique(UniqueType.DestroyableByNukesChance)) {
                 for (terrainFeature in tile.terrainFeatureObjects) {
                     for (unique in terrainFeature.getMatchingUniques(UniqueType.DestroyableByNukesChance)) {
-                        if (Random().nextFloat() >= unique.params[0].toFloat() / 100f) continue
+                        if (Random.Default.nextFloat() >= unique.params[0].toFloat() / 100f) continue
                         tile.removeTerrainFeature(terrainFeature.name)
                         if (!tile.terrainFeatures.contains("Fallout"))
                             tile.addTerrainFeature("Fallout")
                     }
                 }
-            } else if (Random().nextFloat() < 0.5f && !tile.terrainFeatures.contains("Fallout")) {
+            } else if (Random.Default.nextFloat() < 0.5f && !tile.terrainFeatures.contains("Fallout")) {
                 tile.addTerrainFeature("Fallout")
             }
         }
@@ -888,8 +889,8 @@ object Battle {
         var populationLoss = targetedCity.population.population *
             when (nukeStrength) {
                 0 -> 0f
-                1 -> (30 + Random().nextInt(40)) / 100f
-                2 -> (60 + Random().nextInt(20)) / 100f
+                1 -> (30 + Random.Default.nextInt(40)) / 100f
+                2 -> (60 + Random.Default.nextInt(20)) / 100f
                 else -> 1f
             }
         for (unique in targetedCity.getMatchingUniques(UniqueType.PopulationLossFromNukes)) {
@@ -1031,7 +1032,7 @@ object Battle {
             if (defender != null && defender is MapUnitCombatant && interceptor == defender.unit) continue
             interceptor.attacksThisTurn++  // even if you miss, you took the shot
             // Does Intercept happen? If not, exit
-            if (Random().nextFloat() > interceptor.interceptChance() / 100f) return
+            if (Random.Default.nextFloat() > interceptor.interceptChance() / 100f) return
 
             var damage = BattleDamage.calculateDamageToDefender(
                 MapUnitCombatant(interceptor),

--- a/core/src/com/unciv/logic/battle/BattleDamage.kt
+++ b/core/src/com/unciv/logic/battle/BattleDamage.kt
@@ -9,11 +9,11 @@ import com.unciv.models.ruleset.unique.UniqueTarget
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.translations.tr
 import com.unciv.ui.components.extensions.toPercent
-import java.util.*
 import kotlin.collections.set
 import kotlin.math.max
 import kotlin.math.pow
 import kotlin.math.roundToInt
+import kotlin.random.Random
 
 object BattleDamage {
 

--- a/core/src/com/unciv/logic/city/City.kt
+++ b/core/src/com/unciv/logic/city/City.kt
@@ -22,7 +22,7 @@ import com.unciv.models.ruleset.unique.Unique
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.ruleset.unit.BaseUnit
 import com.unciv.models.stats.Stat
-import java.util.*
+import java.util.UUID
 import kotlin.math.roundToInt
 
 enum class CityFlags {

--- a/core/src/com/unciv/logic/city/managers/CityTurnManager.kt
+++ b/core/src/com/unciv/logic/city/managers/CityTurnManager.kt
@@ -7,8 +7,8 @@ import com.unciv.logic.civilization.NotificationCategory
 import com.unciv.logic.civilization.NotificationIcon
 import com.unciv.models.ruleset.tile.ResourceType
 import com.unciv.models.ruleset.unique.UniqueType
-import java.util.*
 import kotlin.math.min
+import kotlin.random.Random
 
 class CityTurnManager(val city: City) {
 
@@ -41,7 +41,7 @@ class CityTurnManager(val city: City) {
         if (city.demandedResource == "" && !city.hasFlag(CityFlags.ResourceDemand)) {
             city.setFlag(
                 CityFlags.ResourceDemand,
-                (if (city.isCapital()) 25 else 15) + Random().nextInt(10))
+                (if (city.isCapital()) 25 else 15) + Random.Default.nextInt(10))
         }
     }
 
@@ -103,7 +103,7 @@ class CityTurnManager(val city: City) {
         if (chosenResource != null)
             city.demandedResource = chosenResource.name
         if (city.demandedResource == "") // Failed to get a valid resource, try again some time later
-            city.setFlag(CityFlags.ResourceDemand, 15 + Random().nextInt(10))
+            city.setFlag(CityFlags.ResourceDemand, 15 + Random.Default.nextInt(10))
         else
             city.civ.addNotification("[${city.name}] demands [${city.demandedResource}]!",
                 city.location, NotificationCategory.General, NotificationIcon.City, "ResourceIcons/${city.demandedResource}")

--- a/core/src/com/unciv/logic/civilization/diplomacy/CityStateFunctions.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/CityStateFunctions.kt
@@ -22,9 +22,9 @@ import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.ruleset.unit.BaseUnit
 import com.unciv.models.stats.Stat
 import com.unciv.ui.screens.victoryscreen.RankingType
-import java.util.*
 import kotlin.math.min
 import kotlin.math.pow
+import kotlin.random.Random
 
 /** Class containing city-state-specific functions */
 class CityStateFunctions(val civInfo: Civilization) {
@@ -67,7 +67,7 @@ class CityStateFunctions(val civInfo: Civilization) {
         return true
     }
 
-    fun turnsForGreatPersonFromCityState(): Int = ((37 + Random().nextInt(7)) * civInfo.gameInfo.speed.modifier).toInt()
+    fun turnsForGreatPersonFromCityState(): Int = ((37 + Random.Default.nextInt(7)) * civInfo.gameInfo.speed.modifier).toInt()
 
     /** Gain a random great person from the city state */
     fun giveGreatPersonToPatron(receivingCiv: Civilization) {
@@ -552,7 +552,7 @@ class CityStateFunctions(val civInfo: Civilization) {
             civInfo.getDiplomacyManager(attacker).becomeWary()
         }
         else if (attacker.isMinorCivAggressor()) { // They've attacked a few
-            if (Random().nextBoolean()) { // 50% chance
+            if (Random.Default.nextBoolean()) { // 50% chance
                 civInfo.getDiplomacyManager(attacker).becomeWary()
             }
         }
@@ -591,7 +591,7 @@ class CityStateFunctions(val civInfo: Civilization) {
                 if (cityState.isAtWarWith(attacker))
                     probability += 50
 
-                if (Random().nextInt(100) <= probability) {
+                if (Random.Default.nextInt(100) <= probability) {
                     cityState.getDiplomacyManager(attacker).becomeWary()
                 }
             }
@@ -684,7 +684,7 @@ class CityStateFunctions(val civInfo: Civilization) {
     ):Sequence<Unique> {
         if (civInfo.isCityState()) return emptySequence()
 
-        return civInfo.getKnownCivs().asSequence().filter { it.isCityState() }
+        return civInfo.getKnownCivs().filter { it.isCityState() }
             .flatMap {
                 // We don't use DiplomacyManager.getRelationshipLevel for performance reasons - it tries to calculate getTributeWillingness which is heavy
                 val relationshipLevel =

--- a/core/src/com/unciv/logic/civilization/managers/TurnManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/TurnManager.kt
@@ -20,9 +20,9 @@ import com.unciv.models.ruleset.unique.endTurn
 import com.unciv.models.stats.Stats
 import com.unciv.ui.components.MayaCalendar
 import com.unciv.utils.Log
-import java.util.*
 import kotlin.math.max
 import kotlin.math.min
+import kotlin.random.Random
 
 class TurnManager(val civInfo: Civilization) {
 
@@ -173,7 +173,7 @@ class TurnManager(val civInfo: Civilization) {
             return
         }
 
-        val random = Random()
+        val random = Random.Default
         val rebelCount = 1 + random.nextInt(100 + 20 * (civInfo.cities.size - 1)) / 100
         val spawnCity = civInfo.cities.maxByOrNull { random.nextInt(it.population.population + 10) } ?: return
         val spawnTile = spawnCity.getTiles().maxByOrNull { rateTileForRevoltSpawn(it) } ?: return
@@ -215,7 +215,7 @@ class TurnManager(val civInfo: Civilization) {
     }
 
     private fun getTurnsBeforeRevolt() =
-            ((4 + Random().nextInt(3)) * max(civInfo.gameInfo.speed.modifier, 1f)).toInt()
+            ((4 + Random.Default.nextInt(3)) * max(civInfo.gameInfo.speed.modifier, 1f)).toInt()
 
 
     fun endTurn() {

--- a/core/src/com/unciv/logic/map/tile/TileHistory.kt
+++ b/core/src/com/unciv/logic/map/tile/TileHistory.kt
@@ -4,7 +4,7 @@ import com.badlogic.gdx.utils.Json
 import com.badlogic.gdx.utils.JsonValue
 import com.unciv.logic.IsPartOfGameInfoSerialization
 import com.unciv.logic.map.tile.TileHistory.TileHistoryState.CityCenterType
-import java.util.*
+import java.util.TreeMap
 
 /**
  * Records events throughout the game related to a tile.

--- a/core/src/com/unciv/logic/multiplayer/OnlineMultiplayer.kt
+++ b/core/src/com/unciv/logic/multiplayer/OnlineMultiplayer.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.launchIn
 import java.time.Duration
 import java.time.Instant
-import java.util.*
+import java.util.Collections
 import java.util.concurrent.atomic.AtomicReference
 
 
@@ -139,12 +139,11 @@ class OnlineMultiplayer {
      */
     suspend fun addGame(gameId: String, gameName: String? = null) {
         val saveFileName = if (gameName.isNullOrBlank()) gameId else gameName
-        var gamePreview: GameInfoPreview
-        try {
-            gamePreview = multiplayerFiles.tryDownloadGamePreview(gameId)
+        val gamePreview: GameInfoPreview = try {
+            multiplayerFiles.tryDownloadGamePreview(gameId)
         } catch (ex: MultiplayerFileNotFoundException) {
             // Game is so old that a preview could not be found on dropbox lets try the real gameInfo instead
-            gamePreview = multiplayerFiles.tryDownloadGame(gameId).asPreview()
+            multiplayerFiles.tryDownloadGame(gameId).asPreview()
         }
         addGame(gamePreview, saveFileName)
     }
@@ -459,4 +458,3 @@ suspend fun <T> attemptAction(
 
 fun GameInfoPreview.isUsersTurn() = getCivilization(currentPlayer).playerId == UncivGame.Current.settings.multiplayer.userId
 fun GameInfo.isUsersTurn() = getCivilization(currentPlayer).playerId == UncivGame.Current.settings.multiplayer.userId
-

--- a/core/src/com/unciv/logic/multiplayer/storage/DropBox.kt
+++ b/core/src/com/unciv/logic/multiplayer/storage/DropBox.kt
@@ -11,7 +11,8 @@ import java.io.InputStreamReader
 import java.net.HttpURLConnection
 import java.net.URL
 import java.nio.charset.Charset
-import java.util.*
+import java.util.Date
+import java.util.Timer
 import kotlin.concurrent.timer
 
 
@@ -156,10 +157,10 @@ object DropBox: FileStorage {
 //        var has_more = false
 //    }
 
-    @Suppress("PropertyName")
+    @Suppress("PropertyName")  // and don't make that private or this suppress won't work
     private class MetaData: FileMetaData {
 //        var name = ""
-        private var server_modified = ""
+        var server_modified = ""
 
         override fun getLastModified(): Date {
             return server_modified.parseDate()

--- a/core/src/com/unciv/logic/multiplayer/storage/FileStorage.kt
+++ b/core/src/com/unciv/logic/multiplayer/storage/FileStorage.kt
@@ -1,7 +1,8 @@
 package com.unciv.logic.multiplayer.storage
 
 import com.unciv.logic.UncivShowableException
-import java.util.*
+import java.util.Date
+import java.io.FileNotFoundException  // Kdoc only
 
 class FileStorageConflictException : Exception()
 class FileStorageRateLimitReached(val limitRemainingSeconds: Int) : UncivShowableException("Server limit reached! Please wait for [${limitRemainingSeconds}] seconds")

--- a/core/src/com/unciv/logic/trade/TradeOffersList.kt
+++ b/core/src/com/unciv/logic/trade/TradeOffersList.kt
@@ -1,7 +1,6 @@
 package com.unciv.logic.trade
 
 import com.unciv.logic.IsPartOfGameInfoSerialization
-import java.util.*
 
 class TradeOffersList: ArrayList<TradeOffer>(), IsPartOfGameInfoSerialization {
     override fun add(element: TradeOffer): Boolean {

--- a/core/src/com/unciv/models/metadata/GameSettings.kt
+++ b/core/src/com/unciv/models/metadata/GameSettings.kt
@@ -15,7 +15,7 @@ import com.unciv.utils.Display
 import com.unciv.utils.ScreenOrientation
 import java.text.Collator
 import java.time.Duration
-import java.util.*
+import java.util.Locale
 import kotlin.reflect.KClass
 import kotlin.reflect.KMutableProperty0
 

--- a/core/src/com/unciv/models/ruleset/tech/TechColumn.kt
+++ b/core/src/com/unciv/models/ruleset/tech/TechColumn.kt
@@ -1,7 +1,5 @@
 package com.unciv.models.ruleset.tech
 
-import java.util.*
-
 class TechColumn {
     var columnNumber: Int = 0
     lateinit var era: String
@@ -10,5 +8,3 @@ class TechColumn {
     var buildingCost: Int = 0
     var wonderCost: Int = 0
 }
-
-

--- a/core/src/com/unciv/models/translations/Translations.kt
+++ b/core/src/com/unciv/models/translations/Translations.kt
@@ -10,7 +10,7 @@ import com.unciv.models.stats.Stats
 import com.unciv.ui.components.Fonts
 import com.unciv.utils.Log
 import com.unciv.utils.debug
-import java.util.*
+import java.util.Locale
 
 /**
  *  This collection holds all translations for the game.
@@ -233,12 +233,15 @@ class Translations : LinkedHashMap<String, TranslationEntry>(){
 
 // Expect a literal [ followed by a captured () group and a literal ].
 // The group may contain any number of any character except ] - pattern [^]]
+@Suppress("RegExpRedundantEscape") // Some Android versions need ]}) escaped
 val squareBraceRegex = Regex("""\[([^]]*)\]""")
 
 // Analogous as above: Expect a {} pair with any chars but } in between and capture that
+@Suppress("RegExpRedundantEscape") // Some Android versions need ]}) escaped
 val curlyBraceRegex = Regex("""\{([^}]*)\}""")
 
 // Analogous as above: Expect a <> pair with any chars but > in between and capture that
+@Suppress("RegExpRedundantEscape") // Some Android versions need ]}) escaped
 val pointyBraceRegex = Regex("""\<([^>]*)\>""")
 
 

--- a/core/src/com/unciv/ui/audio/MusicController.kt
+++ b/core/src/com/unciv/ui/audio/MusicController.kt
@@ -9,7 +9,8 @@ import com.unciv.logic.multiplayer.storage.DropBox
 import com.unciv.models.metadata.GameSettings
 import com.unciv.utils.Log
 import com.unciv.utils.debug
-import java.util.*
+import java.util.EnumSet
+import java.util.Timer
 import kotlin.concurrent.thread
 import kotlin.concurrent.timer
 import kotlin.math.roundToInt
@@ -122,7 +123,7 @@ class MusicController {
     /** @return the path of the playing track or null if none playing */
     private fun currentlyPlaying(): String = when(state) {
         ControllerState.Playing, ControllerState.PlaySingle, ControllerState.Pause ->
-            musicHistory.peekLast() ?: ""
+            musicHistory.lastOrNull() ?: ""
         else -> ""
     }
 

--- a/core/src/com/unciv/ui/audio/MusicTrackChooserFlags.kt
+++ b/core/src/com/unciv/ui/audio/MusicTrackChooserFlags.kt
@@ -1,6 +1,6 @@
 package com.unciv.ui.audio
 
-import java.util.*
+import java.util.EnumSet
 
 enum class MusicTrackChooserFlags {
     /** Makes prefix parameter a mandatory match */

--- a/core/src/com/unciv/ui/components/LanguageTable.kt
+++ b/core/src/com/unciv/ui/components/LanguageTable.kt
@@ -10,7 +10,7 @@ import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.components.extensions.darken
 import com.unciv.ui.components.extensions.toLabel
 import com.unciv.ui.screens.basescreen.BaseScreen
-import java.util.*
+import java.util.Locale
 import kotlin.collections.ArrayList
 
 /** Represents a row in the Language picker, used both in OptionsPopup and in LanguagePickerScreen */

--- a/core/src/com/unciv/ui/components/extensions/FormattingExtensions.kt
+++ b/core/src/com/unciv/ui/components/extensions/FormattingExtensions.kt
@@ -6,7 +6,9 @@ import com.unciv.ui.components.Fonts
 import java.text.SimpleDateFormat
 import java.time.Duration
 import java.time.temporal.ChronoUnit
-import java.util.*
+import java.util.Date
+import java.util.Locale
+import java.util.SortedMap
 
 /** Translate a percentage number - e.g. 25 - to the multiplication value - e.g. 1.25f */
 fun String.toPercent() = toFloat().toPercent()
@@ -20,8 +22,7 @@ fun Float.toPercent() = 1 + this/100
 /** Convert a [resource name][this] into "Consumes [amount] $resource" string (untranslated) */
 fun String.getConsumesAmountString(amount: Int, isStockpiled:Boolean): String {
     val uniqueString = "{Consumes [$amount] [$this]}"
-    if (!isStockpiled) return uniqueString
-    else return "$uniqueString /${Fonts.turn}"
+    return if (isStockpiled) "$uniqueString /${Fonts.turn}" else uniqueString
 }
 
 /** Convert a [resource name][this] into "Need [amount] more $resource" string (untranslated) */

--- a/core/src/com/unciv/ui/popups/options/AdvancedTab.kt
+++ b/core/src/com/unciv/ui/popups/options/AdvancedTab.kt
@@ -42,7 +42,7 @@ import com.unciv.utils.launchOnGLThread
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import java.util.*
+import java.util.UUID
 import java.util.zip.Deflater
 
 fun advancedTab(

--- a/core/src/com/unciv/ui/screens/multiplayerscreens/AddFriendScreen.kt
+++ b/core/src/com/unciv/ui/screens/multiplayerscreens/AddFriendScreen.kt
@@ -13,7 +13,7 @@ import com.unciv.ui.components.extensions.enable
 import com.unciv.ui.components.extensions.onClick
 import com.unciv.ui.components.extensions.toLabel
 import com.unciv.ui.components.extensions.toTextButton
-import java.util.*
+import java.util.UUID
 
 class AddFriendScreen : PickerScreen() {
     init {

--- a/core/src/com/unciv/ui/screens/multiplayerscreens/AddMultiplayerGameScreen.kt
+++ b/core/src/com/unciv/ui/screens/multiplayerscreens/AddMultiplayerGameScreen.kt
@@ -15,7 +15,7 @@ import com.unciv.ui.components.extensions.toLabel
 import com.unciv.ui.components.extensions.toTextButton
 import com.unciv.utils.Concurrency
 import com.unciv.utils.launchOnGLThread
-import java.util.*
+import java.util.UUID
 
 class AddMultiplayerGameScreen : PickerScreen() {
     init {

--- a/core/src/com/unciv/ui/screens/multiplayerscreens/EditFriendScreen.kt
+++ b/core/src/com/unciv/ui/screens/multiplayerscreens/EditFriendScreen.kt
@@ -15,7 +15,7 @@ import com.unciv.ui.components.extensions.enable
 import com.unciv.ui.components.extensions.onClick
 import com.unciv.ui.components.extensions.toLabel
 import com.unciv.ui.components.extensions.toTextButton
-import java.util.*
+import java.util.UUID
 
 class EditFriendScreen(selectedFriend: FriendList.Friend) : PickerScreen() {
     init {

--- a/core/src/com/unciv/ui/screens/newgamescreen/PlayerPickerTable.kt
+++ b/core/src/com/unciv/ui/screens/newgamescreen/PlayerPickerTable.kt
@@ -39,7 +39,7 @@ import com.unciv.ui.screens.basescreen.BaseScreen
 import com.unciv.ui.screens.multiplayerscreens.FriendPickerList
 import com.unciv.ui.screens.pickerscreens.PickerPane
 import com.unciv.ui.screens.pickerscreens.PickerScreen
-import java.util.*
+import java.util.UUID
 import com.unciv.ui.components.AutoScrollPane as ScrollPane
 
 /**
@@ -428,7 +428,7 @@ private class NationPickerPopup(
                 yield(spectator)
         } + playerPicker.getAvailablePlayerCivs(player.chosenCiv)
             .sortedWith(compareBy(UncivGame.Current.settings.getCollatorFromLocale()) { it.name.tr() })
-        val nations = nationSequence.toCollection(ArrayList<Nation>(previousScreen.ruleset.nations.size))
+        val nations = nationSequence.toCollection(ArrayList(previousScreen.ruleset.nations.size))
 
         var nationListScrollY = 0f
         var currentY = 0f

--- a/core/src/com/unciv/ui/screens/savescreens/LoadOrSaveScreen.kt
+++ b/core/src/com/unciv/ui/screens/savescreens/LoadOrSaveScreen.kt
@@ -24,7 +24,7 @@ import com.unciv.ui.components.extensions.toLabel
 import com.unciv.ui.components.extensions.toTextButton
 import com.unciv.utils.Concurrency
 import com.unciv.utils.launchOnGLThread
-import java.util.*
+import java.util.Date
 
 
 abstract class LoadOrSaveScreen(

--- a/core/src/com/unciv/ui/screens/worldscreen/AlertPopup.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/AlertPopup.kt
@@ -30,7 +30,7 @@ import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.popups.Popup
 import com.unciv.ui.screens.diplomacyscreen.LeaderIntroTable
 import com.unciv.ui.screens.victoryscreen.VictoryScreen
-import java.util.*
+import java.util.EnumSet
 
 /**
  * [Popup] communicating events other than trade offers to the player.

--- a/desktop/src/com/unciv/app/desktop/DiscordUpdater.kt
+++ b/desktop/src/com/unciv/app/desktop/DiscordUpdater.kt
@@ -5,7 +5,7 @@ import club.minnced.discord.rpc.DiscordRPC
 import club.minnced.discord.rpc.DiscordRichPresence
 import com.sun.jna.Native
 import com.unciv.utils.debug
-import java.util.*
+import java.util.Timer
 import kotlin.concurrent.timer
 
 class DiscordGameInfo(

--- a/server/src/com/unciv/app/server/UncivServer.kt
+++ b/server/src/com/unciv/app/server/UncivServer.kt
@@ -125,7 +125,7 @@ private class UncivServerRunner : CliktCommand() {
                 }
                 put("/files/{fileName}") {
                     val fileName = call.parameters["fileName"] ?: throw Exception("No fileName!")
-                    log.info("Receiving file: ${fileName}")
+                    log.info("Receiving file: $fileName")
                     val file = File(fileFolderName, fileName)
 
                     if (!validateGameAccess(file, call.request.headers["Authorization"])) {


### PR DESCRIPTION
Evil-be-gone. In a way pure linting, but since it replaces quite a few direct java library uses with their kotlin counterparts the result is theoretically not 100% identical. Still, I say if kotlin has a Random we shouldn't bypass it, same for ArrayDeque or the collection typealiases. Additional benefit - we can clearly see and search on which specific java api's we are actually depending on, just in case we ever need to avoid that.