### PR TITLE
Animate battle damage numbers

### DIFF
--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -40,6 +40,8 @@ object Battle {
     /**
      * Moves [attacker] to [attackableTile], handles siege setup then attacks if still possible
      * (by calling [attack] or [NUKE]). Does _not_ play the attack sound!
+     *
+     * Currently not used by UI, only by automation via [BattleHelper.tryAttackNearbyEnemy][com.unciv.logic.automation.unit.BattleHelper.tryAttackNearbyEnemy]
      */
     fun moveAndAttack(attacker: ICombatant, attackableTile: AttackableTile) {
         if (!movePreparingAttack(attacker, attackableTile)) return
@@ -345,6 +347,10 @@ object Battle {
         return true
     }
 
+    /** Holder for battle result - actual damage.
+     *  @param attackerDealt Damage done by attacker to defender
+     *  @param defenderDealt Damage done by defender to attacker
+     */
     data class DamageDealt(val attackerDealt: Int, val defenderDealt: Int) {
         operator fun plus(other: DamageDealt) =
             DamageDealt(attackerDealt + other.attackerDealt, defenderDealt + other.defenderDealt)
@@ -1088,7 +1094,7 @@ object Battle {
         interceptingCiv.addNotification(interceptorText, locations, NotificationCategory.War,
                 interceptorName, NotificationIcon.War, attackerName)
 
-        return DamageDealt(damage, 0)
+        return DamageDealt(0, damage)
     }
 
     private fun doWithdrawFromMeleeAbility(attacker: ICombatant, defender: ICombatant, baseWithdrawChance: Int): Boolean {

--- a/core/src/com/unciv/logic/battle/BattleDamage.kt
+++ b/core/src/com/unciv/logic/battle/BattleDamage.kt
@@ -261,7 +261,7 @@ object BattleDamage {
         defender: ICombatant,
         tileToAttackFrom: Tile = defender.getTile(),
         /** Between 0 and 1.  Defaults to turn and location-based random to avoid save scumming */
-        randomnessFactor: Float = Random(attacker.getCivInfo().gameInfo.turns * attacker.getTile().position.hashCode().toLong()).nextFloat()
+        randomnessFactor: Float = Random(defender.getCivInfo().gameInfo.turns * defender.getTile().position.hashCode().toLong()).nextFloat()
         ,
     ): Int {
         if (defender.isCivilian()) return 40

--- a/core/src/com/unciv/ui/components/UncivTooltip.kt
+++ b/core/src/com/unciv/ui/components/UncivTooltip.kt
@@ -96,8 +96,8 @@ class UncivTooltip <T: Actor>(
             state = TipState.Showing
             container.addAction(Actions.sequence(
                 Actions.parallel(
-                    Actions.fadeIn(UncivSlider.tipAnimationDuration, Interpolation.fade),
-                    Actions.scaleTo(1f, 1f, 0.2f, Interpolation.fade)
+                    Actions.fadeIn(tipAnimationDuration, Interpolation.fade),
+                    Actions.scaleTo(1f, 1f, tipAnimationDuration, Interpolation.fade)
                 ),
                 Actions.run { if (state == TipState.Showing) state = TipState.Shown }
             ))
@@ -117,8 +117,8 @@ class UncivTooltip <T: Actor>(
             state = TipState.Hiding
             container.addAction(Actions.sequence(
                 Actions.parallel(
-                    Actions.alpha(0.2f, 0.2f, Interpolation.fade),
-                    Actions.scaleTo(0.05f, 0.05f, 0.2f, Interpolation.fade)
+                    Actions.alpha(0.2f, tipAnimationDuration, Interpolation.fade),
+                    Actions.scaleTo(0.05f, 0.05f, tipAnimationDuration, Interpolation.fade)
                 ),
                 Actions.removeActor(),
                 Actions.run { if (state == TipState.Hiding) state = TipState.Hidden }
@@ -164,6 +164,9 @@ class UncivTooltip <T: Actor>(
     //endregion
 
     companion object {
+        /** Duration of the fade/zoom-in/out animations */
+        const val tipAnimationDuration = 0.2f
+
         /**
          * Add a [Label]-based Tooltip with a rounded-corner background to a [Table] or other [Group].
          *

--- a/core/src/com/unciv/ui/screens/worldscreen/WorldMapHolder.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/WorldMapHolder.kt
@@ -53,6 +53,7 @@ import com.unciv.ui.components.tilegroups.WorldTileGroup
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.screens.basescreen.BaseScreen
 import com.unciv.ui.screens.basescreen.UncivStage
+import com.unciv.ui.screens.worldscreen.bottombar.BattleTableHelpers.battleAnimation
 import com.unciv.utils.Log
 import com.unciv.utils.Concurrency
 import com.unciv.utils.launchOnGLThread
@@ -229,6 +230,7 @@ class WorldMapHolder(
             }
             /** If we are in unit-swapping mode and didn't find a swap partner, we don't want to move or attack */
         } else {
+            // This seems inefficient as the tileToAttack is already known - but the method also calculates tileToAttackFrom
             val attackableTile = BattleHelper
                     .getAttackableEnemies(unit, unit.movement.getDistanceToTiles())
                     .firstOrNull { it.tileToAttack == tile }
@@ -237,7 +239,9 @@ class WorldMapHolder(
                 val attacker = MapUnitCombatant(unit)
                 if (!Battle.movePreparingAttack(attacker, attackableTile)) return
                 SoundPlayer.play(attacker.getAttackSound())
-                Battle.attackOrNuke(attacker, attackableTile)
+                val (damageToDefender, damageToAttacker) = Battle.attackOrNuke(attacker, attackableTile)
+                if (attackableTile.combatant != null)
+                    worldScreen.battleAnimation(attacker, damageToAttacker, attackableTile.combatant, damageToDefender)
                 localShouldUpdate = true
             } else if (unit.movement.canReach(tile)) {
                 /** ****** Right-click Move ****** */

--- a/core/src/com/unciv/ui/screens/worldscreen/bottombar/BattleTable.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/bottombar/BattleTable.kt
@@ -288,7 +288,7 @@ class BattleTable(val worldScreen: WorldScreen): Table() {
 
         if (!canStillAttack) return
         SoundPlayer.play(attacker.getAttackSound())
-        val (damageToAttacker, damageToDefender) = Battle.attackOrNuke(attacker, attackableTile)
+        val (damageToDefender, damageToAttacker) = Battle.attackOrNuke(attacker, attackableTile)
 
         worldScreen.battleAnimation(attacker, damageToAttacker, defender, damageToDefender)
     }

--- a/core/src/com/unciv/ui/screens/worldscreen/bottombar/BattleTableHelpers.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/bottombar/BattleTableHelpers.kt
@@ -153,7 +153,7 @@ object BattleTableHelpers {
         if (damage == 0) return
         val animationDuration = 1f
 
-        val label = damage.toString().toLabel(Color.RED, 40, Align.center, true)
+        val label = (-damage).toString().toLabel(Color.RED, 40, Align.center, true)
         label.touchable = Touchable.disabled
         val container = Container(label)
         container.touchable = Touchable.disabled
@@ -166,7 +166,7 @@ object BattleTableHelpers {
             Actions.parallel(
                 Actions.alpha(0.1f, animationDuration, Interpolation.fade),
                 Actions.scaleTo(0.05f, 0.05f, animationDuration),
-                Actions.moveBy(19f, 90f, animationDuration)
+                Actions.moveBy(label.width * 0.95f * 0.5f, 90f, animationDuration)
             ),
             Actions.removeActor()
         ))

--- a/core/src/com/unciv/ui/screens/worldscreen/bottombar/BattleTableHelpers.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/bottombar/BattleTableHelpers.kt
@@ -101,8 +101,7 @@ object BattleTableHelpers {
                     if (combatant.isCity()) {
                         val icon = tileGroup.layerMisc.improvementIcon
                         if (icon != null) yield (icon)
-                    }
-                    else {
+                    } else if (!combatant.isAirUnit()) {
                         val slot = if (combatant.isCivilian()) 0 else 1
                         yieldAll((tileGroup.layerUnitArt.getChild(slot) as Group).children)
                     }
@@ -112,7 +111,7 @@ object BattleTableHelpers {
                 sequence {
                     if (damageToDefender != 0) yieldAll(getMapActorsForCombatant(defender))
                     if (damageToAttacker != 0) yieldAll(getMapActorsForCombatant(attacker))
-                }.mapTo(arrayListOf()) { it to it.color.cpy() }.toMap()
+                }.associateWith { it.color.cpy() }
 
         val actorsToMove = getMapActorsForCombatant(attacker).toList()
 
@@ -154,7 +153,7 @@ object BattleTableHelpers {
         if (damage == 0) return
         val animationDuration = 1f
 
-        val label = damage.toString().toLabel(Color.SCARLET, 50, Align.center, true)
+        val label = damage.toString().toLabel(Color.RED, 40, Align.center, true)
         label.touchable = Touchable.disabled
         val container = Container(label)
         container.touchable = Touchable.disabled
@@ -166,8 +165,8 @@ object BattleTableHelpers {
         container.addAction(Actions.sequence(
             Actions.parallel(
                 Actions.alpha(0.1f, animationDuration, Interpolation.fade),
-                Actions.scaleTo(0.05f, 0.05f, animationDuration, Interpolation.fastSlow),
-                Actions.moveBy(30f, 90f, animationDuration, Interpolation.slowFast)
+                Actions.scaleTo(0.05f, 0.05f, animationDuration),
+                Actions.moveBy(19f, 90f, animationDuration)
             ),
             Actions.removeActor()
         ))


### PR DESCRIPTION
Closes #9353 - <details><summary>clip</summary>

https://github.com/yairm210/Unciv/assets/63000004/fb58fb0c-0e73-4d7d-9340-e1dae78a6efc
</details>

I've left some tasks untouched - unify right-click code with BattleTable attack, or scaling the labels to world zoom. There's unrelated linting and comments, side effects of exploring possible approaches earls on, e.g. inconsistencies between UncivTooltip and UncivSlider - I checked what I did for these to see what's reusable and that constant was just too inconsistent. The attack animation question I've decided by guess, as I still do not know of a mod with images to test. And the issue with both damage numbers playing at the same location I've dealt with the simplest way possible - if that would be the case, the number for the dead defender is omitted.