### PR TITLE
Fix UnitTable layout

### DIFF
--- a/core/src/com/unciv/ui/screens/worldscreen/unit/UnitTable.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/UnitTable.kt
@@ -106,10 +106,10 @@ class UnitTable(val worldScreen: WorldScreen) : Table() {
                 add(unitIconNameGroup)
                 add(nextIdleUnitButton)
             }
-            add(moveBetweenUnitsTable).colspan(2).fill().row()
+            add(moveBetweenUnitsTable).fill().row()
 
-            separator = addSeparator().actor!!
-            add(promotionsTable).colspan(2).row()
+            separator = addSeparator().padBottom(5f).actor!!
+            add(promotionsTable).row()
             add(unitDescriptionTable)
             touchable = Touchable.enabled
             onClick {
@@ -262,13 +262,14 @@ class UnitTable(val worldScreen: WorldScreen) : Table() {
         unitIconHolder.clear()
         promotionsTable.clear()
         unitDescriptionTable.clearListeners()
+        separator.width = 0f  // ImageWithCustomSize remembers width and returns if when Table asks for prefWidth
 
         if (selectedUnit != null) {
             if (selectedUnits.size == 1) { // single selected unit
                 unitIconHolder.add(UnitGroup(selectedUnit!!, 30f)).pad(5f)
 
                 for (promotion in selectedUnit!!.promotions.getPromotions(true))
-                    promotionsTable.add(ImageGetter.getPromotionPortrait(promotion.name))
+                    promotionsTable.add(ImageGetter.getPromotionPortrait(promotion.name)).padBottom(2f)
 
                 // Since Clear also clears the listeners, we need to re-add them every time
                 promotionsTable.onClick {


### PR DESCRIPTION
Currently, the UnitTable has a few quirks
- Separator touches promotions
- Width never shrinks until worldscreen is rebuilt
- Centering

Before:
![image](https://github.com/yairm210/Unciv/assets/63000004/cd957a6b-062d-4930-aeda-088b6750175a)
![image](https://github.com/yairm210/Unciv/assets/63000004/2815bba1-b87b-40f6-b2f7-cf120078bd92)

After:
![image](https://github.com/yairm210/Unciv/assets/63000004/5753a5b3-525f-4e02-b88b-25c95d0ecb45)
![image](https://github.com/yairm210/Unciv/assets/63000004/3a823bf5-74d5-410a-99d4-8d6d26ad4e24)

:zany_face: To get that first Worker screenshot like that you need some unit with _tons_ of promotions and have selected it anytime before...

An alternative solution to the width never going down is to revert the addSeparator Actor from being an ImageWithCustomSize to a normal Image (tested). Please help me think of the ramifications - would that be the better approach and what other UI could be affected?