### PR TITLE
Happiness change from bought buildings can reapply citizen focus

### DIFF
--- a/core/src/com/unciv/logic/automation/city/ConstructionAutomation.kt
+++ b/core/src/com/unciv/logic/automation/city/ConstructionAutomation.kt
@@ -314,7 +314,7 @@ class ConstructionAutomation(val cityConstructions: CityConstructions){
 
     private fun addHappinessBuildingChoice() {
         val happinessBuilding = nonWonders
-            .filter { (it.isStatRelated(Stat.Happiness)
+            .filter { it.isStatRelated(Stat.Happiness)
                     && Automation.allowAutomatedConstruction(civInfo, cityInfo, it) }
             .filterBuildable()
             .minByOrNull { it.cost }

--- a/core/src/com/unciv/logic/automation/city/ConstructionAutomation.kt
+++ b/core/src/com/unciv/logic/automation/city/ConstructionAutomation.kt
@@ -315,7 +315,6 @@ class ConstructionAutomation(val cityConstructions: CityConstructions){
     private fun addHappinessBuildingChoice() {
         val happinessBuilding = nonWonders
             .filter { (it.isStatRelated(Stat.Happiness)
-                    || it.hasUnique(UniqueType.RemoveAnnexUnhappiness))
                     && Automation.allowAutomatedConstruction(civInfo, cityInfo, it) }
             .filterBuildable()
             .minByOrNull { it.cost }

--- a/core/src/com/unciv/models/ruleset/Building.kt
+++ b/core/src/com/unciv/models/ruleset/Building.kt
@@ -689,6 +689,13 @@ class Building : RulesetStatsObject(), INonPerpetualConstruction {
         if (isStatRelated(Stat.Science) && civInfo.hasUnique(UniqueType.TechBoostWhenScientificBuildingsBuiltInCapital))
             civInfo.tech.addScience(civInfo.tech.scienceOfLast8Turns.sum() / 8)
 
+        // Happiness change _may_ invalidate best worked tiles (#9238), but if the building
+        // isn't bought then reassignPopulation will run later in startTurn anyway
+        if (boughtWith != null && isStatRelated(Stat.Happiness)) {
+            cityConstructions.city.reassignPopulation()
+            cityConstructions.city.updateCitizens = false
+        }
+
         cityConstructions.city.cityStats.update() // new building, new stats
         civInfo.cache.updateCivResources() // this building/unit could be a resource-requiring one
         civInfo.cache.updateCitiesConnectedToCapital(false) // could be a connecting building, like a harbor
@@ -721,6 +728,7 @@ class Building : RulesetStatsObject(), INonPerpetualConstruction {
         if (getMatchingUniques(UniqueType.Stats).any { it.stats[stat] > 0 }) return true
         if (getMatchingUniques(UniqueType.StatsFromTiles).any { it.stats[stat] > 0 }) return true
         if (getMatchingUniques(UniqueType.StatsPerPopulation).any { it.stats[stat] > 0 }) return true
+        if (stat == Stat.Happiness && hasUnique(UniqueType.RemoveAnnexUnhappiness)) return true
         return false
     }
 


### PR DESCRIPTION
Closes #9238 - I cant believe I overlooked this branch sitting around for so long.

I still have the feeling this could/should be optimized to mitigate the extra perfomance cost, but I can't think of a straighforward way.

Also makes the Courthouse match the "Happiness" building filter which it didnt before - for mods a potential breaking change. What do you think?