### PR TITLE
Fix UniqueType.EnsureMinimumStats

### DIFF
--- a/core/src/com/unciv/logic/map/tile/TileStatFunctions.kt
+++ b/core/src/com/unciv/logic/map/tile/TileStatFunctions.kt
@@ -84,8 +84,11 @@ class TileStatFunctions(val tile: Tile) {
 
     /** Ensures each stat is >= [other].stat - modifies in place */
     private fun Stats.coerceAtLeast(other: Stats) {
-        for ((stat, value) in other)
+        // Note: Not `for ((stat, value) in other)` - that would skip zero values
+        for (stat in Stat.values()) {
+            val value = other[stat]
             if (this[stat] < value) this[stat] = value
+        }
     }
 
     /** Gets basic stats to start off [getTileStats] or [getTileStartYield], independently mutable result */


### PR DESCRIPTION
Mods can lead to negative input that should be clamped to zero if the EnsureMinimumStats has no value for that stat, right? 