### PR TITLE
Fix ConcurrentModificationException when puppeting a city

### DIFF
--- a/core/src/com/unciv/logic/city/managers/CityPopulationManager.kt
+++ b/core/src/com/unciv/logic/city/managers/CityPopulationManager.kt
@@ -203,11 +203,9 @@ class CityPopulationManager : IsPartOfGameInfoSerialization {
         }
 
         // unassign specialists that cannot be (e.g. the city was captured and one of the specialist buildings was destroyed)
-        val maxSpecialists = getMaxSpecialists()
-        val specialistsHashmap = specialistAllocations
-        for ((specialistName, amount) in specialistsHashmap)
-            if (amount > maxSpecialists[specialistName])
-                specialistAllocations[specialistName] = maxSpecialists[specialistName]
+        for ((specialistName, maxAmount) in getMaxSpecialists())
+            if (specialistAllocations[specialistName] > maxAmount)
+                specialistAllocations[specialistName] = maxAmount
 
         val localUniqueCache = LocalUniqueCache()
 


### PR DESCRIPTION
Smallest possible fix for #9429, tested just once from a reliable repro save.

How do you feel about Counter.coerceAtMost or the chances to find similar Counter uses using code inspection alone?