### PR TITLE
Fix mouse wheel on NotificationsScroll

### DIFF
--- a/core/src/com/unciv/ui/screens/worldscreen/NotificationsScroll.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/NotificationsScroll.kt
@@ -110,6 +110,14 @@ class NotificationsScroll(
         height = worldScreen.stage.height * inverseScaleFactor
     }
 
+    /**
+     * If a Gdx ScrollPane has content larger than its size on both dimensions (if only one axis is
+     * scrollable, the wheel will always scroll that axis), it will prefer mapping the mouse wheel
+     * to *horizontal* scrolling, which is not quite the best choice for our notifications.
+     *
+     * The intuitive approach might be to change the listener (by overriding [addScrollListener]),
+     * but luckily this works too.
+     */
     override fun getMouseWheelX() = 0f
 
     /** Access to hidden "state" - writing it will ensure this is fully visible or hidden and the

--- a/core/src/com/unciv/ui/screens/worldscreen/NotificationsScroll.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/NotificationsScroll.kt
@@ -110,6 +110,8 @@ class NotificationsScroll(
         height = worldScreen.stage.height * inverseScaleFactor
     }
 
+    override fun getMouseWheelX() = 0f
+
     /** Access to hidden "state" - writing it will ensure this is fully visible or hidden and the
      *  restore button shown as needed - with animation. */
     @Suppress("MemberVisibilityCanBePrivate")  // API for future use


### PR DESCRIPTION
Mostly a test whether I could recover from a bad experiment: Android Studio Hedgehog preview. Rollback success - I can push again.

The NotificationsScroll since a few versions ago can be dragged/flicked in all 4 directions - and I forgot the mouse wheel, where libGdx has such a moronic default. I mean, a look at the hardware should tell you, if there's a choice, scroll vertically not horizontally... But Gdx chose to prefer horizontal if content exceeds ScrollPane area on both axes.