### PR TITLE
More reapply CityFocus on yield changes

### DIFF
--- a/core/src/com/unciv/logic/city/City.kt
+++ b/core/src/com/unciv/logic/city/City.kt
@@ -1,6 +1,7 @@
 package com.unciv.logic.city
 
 import com.badlogic.gdx.math.Vector2
+import com.unciv.GUI
 import com.unciv.logic.IsPartOfGameInfoSerialization
 import com.unciv.logic.city.managers.CityEspionageManager
 import com.unciv.logic.city.managers.CityExpansionManager
@@ -403,6 +404,10 @@ class City : IsPartOfGameInfoSerialization {
         reassignPopulation(resetLocked = true)
     }
 
+    /** Apply worked tiles optimization (aka CityFocus) - Expensive!
+     *
+     *  If the next City.startTurn is soon enough, then use [reassignPopulationDeferred] instead.
+     */
     fun reassignPopulation(resetLocked: Boolean = false) {
         if (resetLocked) {
             workedTiles = hashSetOf()
@@ -412,9 +417,20 @@ class City : IsPartOfGameInfoSerialization {
         }
         if (!manualSpecialists)
             population.specialistAllocations.clear()
+        updateCitizens = false
         population.autoAssignPopulation()
     }
 
+    /** Apply worked tiles optimization (aka CityFocus) -
+     *  immediately for a human player whoes turn it is (interactive),
+     *  or deferred to the next startTurn while nextTurn is running (for AI)
+     *  @see reassignPopulation
+     */
+    fun reassignPopulationDeferred() {
+        // TODO - is this the best (or even correct) way to detect "interactive" UI calls?
+        if (GUI.isMyTurn() && GUI.getViewingPlayer() == civ) reassignPopulation()
+        else updateCitizens = true
+    }
 
     fun destroyCity(overrideSafeties: Boolean = false) {
         // Original capitals and holy cities cannot be destroyed,

--- a/core/src/com/unciv/logic/city/managers/CityExpansionManager.kt
+++ b/core/src/com/unciv/logic/city/managers/CityExpansionManager.kt
@@ -73,6 +73,9 @@ class CityExpansionManager : IsPartOfGameInfoSerialization {
             throw NotEnoughGoldToBuyTileException()
         city.civ.addGold(-goldCost)
         takeOwnership(tile)
+
+        // Reapply worked tiles optimization (aka CityFocus) - doing it here means AI profits too
+        city.reassignPopulationDeferred()
     }
 
     fun getGoldCostOfTile(tile: Tile): Int {

--- a/core/src/com/unciv/logic/city/managers/CityTurnManager.kt
+++ b/core/src/com/unciv/logic/city/managers/CityTurnManager.kt
@@ -33,7 +33,6 @@ class CityTurnManager(val city: City) {
             city.reassignAllPopulation()
         } else if (city.updateCitizens) {
             city.reassignPopulation()  // includes cityStats.update
-            city.updateCitizens = false
         } else
             city.cityStats.update()
 

--- a/core/src/com/unciv/logic/map/tile/Tile.kt
+++ b/core/src/com/unciv/logic/map/tile/Tile.kt
@@ -881,7 +881,11 @@ open class Tile : IsPartOfGameInfoSerialization {
             return
         // http://well-of-souls.com/civ/civ5_improvements.html says that naval improvements are destroyed upon pillage
         //    and I can't find any other sources so I'll go with that
-        if (!isLand) { changeImprovement(null); return }
+        if (!isLand) {
+            changeImprovement(null)
+            owningCity?.reassignPopulationDeferred()
+            return
+        }
 
         // Setting turnsToImprovement might interfere with UniqueType.CreatesOneImprovement
         improvementFunctions.removeCreatesOneImprovementMarker()
@@ -900,6 +904,8 @@ open class Tile : IsPartOfGameInfoSerialization {
             else
                 roadIsPillaged = true
         }
+
+        owningCity?.reassignPopulationDeferred()
     }
 
     fun isPillaged(): Boolean {
@@ -913,6 +919,8 @@ open class Tile : IsPartOfGameInfoSerialization {
             improvementIsPillaged = false
         else
             roadIsPillaged = false
+
+        owningCity?.reassignPopulationDeferred()
     }
 
 

--- a/core/src/com/unciv/models/ruleset/tile/TileImprovement.kt
+++ b/core/src/com/unciv/models/ruleset/tile/TileImprovement.kt
@@ -75,8 +75,10 @@ class TileImprovement : RulesetStatsObject() {
 
     fun handleImprovementCompletion(builder: MapUnit) {
         val tile = builder.getTile()
+
         if (hasUnique(UniqueType.TakesOverAdjacentTiles))
             UnitActions.takeOverTilesAround(builder)
+
         if (tile.resource != null) {
             val city = builder.getTile().getCity()
             if (city != null) {
@@ -85,6 +87,7 @@ class TileImprovement : RulesetStatsObject() {
                 city.civ.cache.updateCivResources()
             }
         }
+
         if (hasUnique(UniqueType.RemovesFeaturesIfBuilt)) {
             // Remove terrainFeatures that a Worker can remove
             // and that aren't explicitly allowed under the improvement
@@ -100,6 +103,8 @@ class TileImprovement : RulesetStatsObject() {
 
             tile.setTerrainFeatures(tile.terrainFeatures.filterNot { it in removableTerrainFeatures })
         }
+
+        tile.owningCity?.reassignPopulationDeferred()
     }
 
     /**

--- a/core/src/com/unciv/ui/screens/cityscreen/CityScreenTileTable.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/CityScreenTileTable.kt
@@ -5,18 +5,8 @@ import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.unciv.UncivGame
 import com.unciv.logic.map.tile.Tile
 import com.unciv.logic.map.tile.TileDescription
-import com.unciv.models.UncivSound
 import com.unciv.models.stats.Stat
 import com.unciv.models.stats.Stats
-import com.unciv.models.translations.tr
-import com.unciv.ui.audio.SoundPlayer
-import com.unciv.ui.screens.civilopediascreen.CivilopediaScreen
-import com.unciv.ui.screens.civilopediascreen.FormattedLine.IconDisplay
-import com.unciv.ui.screens.civilopediascreen.MarkupRenderer
-import com.unciv.ui.images.ImageGetter
-import com.unciv.ui.popups.ConfirmPopup
-import com.unciv.ui.popups.closeAllPopups
-import com.unciv.ui.screens.basescreen.BaseScreen
 import com.unciv.ui.components.UncivTooltip.Companion.addTooltip
 import com.unciv.ui.components.extensions.darken
 import com.unciv.ui.components.extensions.disable
@@ -26,6 +16,11 @@ import com.unciv.ui.components.extensions.onActivation
 import com.unciv.ui.components.extensions.onClick
 import com.unciv.ui.components.extensions.toLabel
 import com.unciv.ui.components.extensions.toTextButton
+import com.unciv.ui.images.ImageGetter
+import com.unciv.ui.screens.basescreen.BaseScreen
+import com.unciv.ui.screens.civilopediascreen.CivilopediaScreen
+import com.unciv.ui.screens.civilopediascreen.FormattedLine.IconDisplay
+import com.unciv.ui.screens.civilopediascreen.MarkupRenderer
 import kotlin.math.roundToInt
 
 class CityScreenTileTable(private val cityScreen: CityScreen): Table() {
@@ -64,7 +59,7 @@ class CityScreenTileTable(private val cityScreen: CityScreen): Table() {
             val buyTileButton = "Buy for [$goldCostOfTile] gold".toTextButton()
             buyTileButton.onActivation {
                 buyTileButton.disable()
-                askToBuyTile(selectedTile)
+                cityScreen.askToBuyTile(selectedTile)
             }
             buyTileButton.keyShortcuts.add('T')
             buyTileButton.isEnabled =  cityScreen.canChangeState && city.civ.hasStatToBuy(Stat.Gold, goldCostOfTile)
@@ -108,34 +103,6 @@ class CityScreenTileTable(private val cityScreen: CityScreen): Table() {
         pack()
     }
 
-    /** Ask whether user wants to buy [selectedTile] for gold.
-     *
-     * Used from onClick and keyboard dispatch, thus only minimal parameters are passed,
-     * and it needs to do all checks and the sound as appropriate.
-     */
-    private fun askToBuyTile(selectedTile: Tile) {
-        // These checks are redundant for the onClick action, but not for the keyboard binding
-        if (!cityScreen.canChangeState || !city.expansion.canBuyTile(selectedTile)) return
-        val goldCostOfTile = city.expansion.getGoldCostOfTile(selectedTile)
-        if (!city.civ.hasStatToBuy(Stat.Gold, goldCostOfTile)) return
-
-        cityScreen.closeAllPopups()
-
-        val purchasePrompt = "Currently you have [${city.civ.gold}] [Gold].".tr() + "\n\n" +
-                "Would you like to purchase [Tile] for [$goldCostOfTile] [${Stat.Gold.character}]?".tr()
-        ConfirmPopup(
-            cityScreen,
-            purchasePrompt,
-            "Purchase",
-            true,
-            restoreDefault = { cityScreen.update() }
-        ) {
-            SoundPlayer.play(UncivSound.Coin)
-            city.expansion.buyTile(selectedTile)
-            // preselect the next tile on city screen rebuild so bulk buying can go faster
-            UncivGame.Current.replaceCurrentScreen(CityScreen(city, initSelectedTile = city.expansion.chooseNewTileToOwn()))
-        }.open()
-    }
 
     private fun getTileStatsTable(stats: Stats): Table {
         val statsTable = Table()

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsPillage.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsPillage.kt
@@ -59,9 +59,8 @@ object UnitActionsPillage {
                 )
 
                 pillageLooting(tile, unit)
-                tile.setPillaged()
+                tile.setPillaged()  // Also triggers reassignPopulation
                 if (tile.resource != null) tile.getOwner()?.cache?.updateCivResources()    // this might take away a resource
-                tile.getCity()?.updateCitizens = true
 
                 val freePillage = unit.hasUnique(UniqueType.NoMovementToPillage, checkCivInfoUniques = true)
                 if (!freePillage) unit.useMovementPoints(1f)


### PR DESCRIPTION
I've played a whole game with this code, and noticed no evil things... So, please evaluate carefully and tell me what you think

However, _strictly_ testing for correctness isn't trivial.

Key decision was to wrap the "Hey we need to reevaluate CitizenFocus" method such that it first determines whether a player is actually triggering the change and is watching, or if it's maybe next-turn automation; and based on that chooses the expensive actual evaluation or to simply sets the flag to do it on the next startTurn. So AI buying tiles _will_ pass through the method, but it'll be cheap... However, its name could be clearer, as the "Deferred" part comes potentially after the decision, but I didn't want to give it a monster name like "reassignPopulationImmediatelyOrDeferredBasedOnUIState"... It's right on top of the diff in logic/city/City.

Closes #9425, see discussion there. It's a nice surprise the easy solution to that "Courthouse in A means B needs to go back to farming" thing, the coroutine wrapper, works neatly and just fine, and I couldn't break it by continuing gameplay without giving it time...