### PR TITLE
Politics overview no longer discloses random number of players

### DIFF
--- a/core/src/com/unciv/logic/civilization/Civilization.kt
+++ b/core/src/com/unciv/logic/civilization/Civilization.kt
@@ -313,7 +313,12 @@ class Civilization : IsPartOfGameInfoSerialization {
     @Suppress("MemberVisibilityCanBePrivate")  // same visibility for overloads
     fun getProximity(civName: String) = proximity[civName] ?: Proximity.None
 
-    /** Returns only undefeated civs, aka the ones we care about */
+    /** Returns only undefeated civs, aka the ones we care about
+     *
+     *  Note: Currently the implementation of `updateAllyCivForCityState` will cause the diplomacy map of
+     *  city-states to contain the barbarians. Therefore, [getKnownCivs] will **not** list the barbarians
+     *  for major civs, but **will** do so for city-states after some gameplay.
+     */
     fun getKnownCivs() = diplomacy.values.asSequence().map { it.otherCiv() }.filter { !it.isDefeated() }
     fun knows(otherCivName: String) = diplomacy.containsKey(otherCivName)
     fun knows(otherCiv: Civilization) = knows(otherCiv.civName)

--- a/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyFunctions.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyFunctions.kt
@@ -13,7 +13,7 @@ import com.unciv.models.stats.Stat
 import com.unciv.models.stats.Stats
 import com.unciv.models.translations.tr
 
-class DiplomacyFunctions(val civInfo:Civilization){
+class DiplomacyFunctions(val civInfo: Civilization){
 
     /** A sorted Sequence of all other civs we know (excluding barbarians and spectators) */
     fun getKnownCivsSorted(includeCityStates: Boolean = true, includeDefeated: Boolean = false) =
@@ -59,7 +59,7 @@ class DiplomacyFunctions(val civInfo:Civilization){
             // For now, it might be overkill though.
             var meetString = "[${civInfo.civName}] has given us [${giftAmount}] as a token of goodwill for meeting us"
             val religionMeetString = "[${civInfo.civName}] has also given us [${faithAmount}]"
-            if (civInfo.diplomacy.filter { it.value.otherCiv().isMajorCiv() }.size == 1) {
+            if (civInfo.diplomacy.count { it.value.otherCiv().isMajorCiv() } == 1) {
                 giftAmount.timesInPlace(2f)
                 meetString = "[${civInfo.civName}] has given us [${giftAmount}] as we are the first major civ to meet them"
             }

--- a/core/src/com/unciv/ui/screens/overviewscreen/EmpireOverviewCategories.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/EmpireOverviewCategories.kt
@@ -44,6 +44,7 @@ enum class EmpireOverviewCategories(
     Politics("OtherIcons/Politics", 'P', Align.top) {
         override fun createTab(viewingPlayer: Civilization, overviewScreen: EmpireOverviewScreen, persistedData: EmpireOverviewTabPersistableData?) =
                 GlobalPoliticsOverviewTable(viewingPlayer, overviewScreen, persistedData)
+        override fun showDisabled(viewingPlayer: Civilization) = viewingPlayer.diplomacy.isEmpty()
     },
     Resources("StatIcons/Happiness", 'R', Align.topLeft) {
         override fun createTab(viewingPlayer: Civilization, overviewScreen: EmpireOverviewScreen, persistedData: EmpireOverviewTabPersistableData?) =

--- a/core/src/com/unciv/ui/screens/overviewscreen/GlobalPoliticsOverviewTable.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/GlobalPoliticsOverviewTable.kt
@@ -69,7 +69,7 @@ class GlobalPoliticsOverviewTable (
 
     private fun updatePoliticsTable() {
         clear()
-        getFixedContent().clear()
+        fixedContent.clear()
 
         val diagramButton = "Show diagram".toTextButton().onClick(::updateDiagram)
 
@@ -85,18 +85,14 @@ class GlobalPoliticsOverviewTable (
             add("Relations".toLabel()).row()
             add(diagramButton).pad(10f)
         })
-        row()
-        addSeparator(Color.GRAY)
 
         createGlobalPoliticsTable()
     }
 
     private fun createGlobalPoliticsTable() {
-        val civilizations = mutableListOf<Civilization>()
-        civilizations.add(viewingPlayer)
-        civilizations.addAll(viewingPlayer.getKnownCivs())
-        civilizations.removeAll(civilizations.filter { it.isBarbarian() || it.isCityState() || it.isSpectator() })
-        for (civ in civilizations) {
+        for (civ in viewingPlayer.diplomacyFunctions.getKnownCivsSorted(includeCityStates = false)) {
+            addSeparator(Color.GRAY)
+
             // civ image
             add(ImageGetter.getNationPortrait(civ.nation, 100f)).pad(20f)
 
@@ -119,9 +115,6 @@ class GlobalPoliticsOverviewTable (
 
             //politics
             add(getPoliticsOfCivTable(civ)).pad(20f)
-
-            if (civilizations.indexOf(civ) != civilizations.lastIndex)
-                addSeparator(Color.GRAY)
         }
     }
 
@@ -325,6 +318,7 @@ class GlobalPoliticsOverviewTable (
             .pad(5f).colspan(columns).row()
         if (count == 0) return
         addSeparator()
+
         var currentColumn = 0
         var lastCivWasMajor = false
         fun advanceCols(delta: Int) {
@@ -335,6 +329,7 @@ class GlobalPoliticsOverviewTable (
             }
             lastCivWasMajor = delta == 2
         }
+
         for (civ in civs) {
             if (lastCivWasMajor && civ.isCityState())
                 advanceCols(columns)


### PR DESCRIPTION
Closes #9463

I did hesitate with the `Civilization.hideCityStateCount` and `Civilization.hideCivCount` methods - one now is local to its single use, as extension function, while the other has a few callers and is a normal method... And using their similarity to do a common parameterized implementation wasn't pretty either. Matter of taste??

Minor changes: The choice list/diagram now persists over repeated Overview opens (or screen resizes), and the page is disabled while you don't know anybody...

Also thought about, but then did nothing: To separate the code for list/diagram, as they have nothing in common. Also, all class fields are used by the diagram portion only - not immediately clear to a new code reader. Regions? If only kotlin had the .net partial classes...