### PR TITLE
Small File Chooser and Separator fixes

### DIFF
--- a/core/src/com/unciv/logic/files/FileChooser.kt
+++ b/core/src/com/unciv/logic/files/FileChooser.kt
@@ -123,6 +123,7 @@ open class FileChooser(
 
     init {
         innerTable.top().left()
+        innerTable.touchable = Touchable.enabled
 
         fileList.selection.setProgrammaticChangeEvents(false)
         fileNameInput.setTextFieldListener { textField, _ -> result = textField.text }

--- a/core/src/com/unciv/ui/components/extensions/Scene2dExtensions.kt
+++ b/core/src/com/unciv/ui/components/extensions/Scene2dExtensions.kt
@@ -428,9 +428,9 @@ fun Group.addBorderAllowOpacity(size:Float, color: Color): Group {
 
 
 /** get background Image for a new separator */
-private fun getSeparatorImage(color: Color) = ImageGetter.getDot(
+private fun getSeparatorImage(color: Color) = Image(ImageGetter.getWhiteDotDrawable().tint(
     if (color.a != 0f) color else BaseScreen.skin.getColor("color") //0x334d80
-)
+))
 
 /**
  * Create a horizontal separator as an empty Container with a colored background.
@@ -441,7 +441,7 @@ fun Table.addSeparator(color: Color = Color.WHITE, colSpan: Int = 0, height: Flo
     val separator = getSeparatorImage(color)
     val cell = add(separator)
         .colspan(if (colSpan == 0) columns else colSpan)
-        .minHeight(height).fillX()
+        .height(height).fillX()
     row()
     return cell
 }

--- a/core/src/com/unciv/ui/images/ImageGetter.kt
+++ b/core/src/com/unciv/ui/images/ImageGetter.kt
@@ -172,6 +172,7 @@ object ImageGetter {
     }
 
     fun getWhiteDot() = getImage(whiteDotLocation).apply { setSize(1f) }
+    fun getWhiteDotDrawable() = textureRegionDrawables[whiteDotLocation]!!
     fun getDot(dotColor: Color) = getWhiteDot().apply { color = dotColor }
 
     fun getExternalImage(fileName: String): Image {


### PR DESCRIPTION
First commit is pretty obvious - in FileChooser, clicks/taps anywhere not on an actual active element close the dialog. Even on "Load" when the button is disabled - the clicks are caught by the "click-behind" listener.

Second - effectively reverts an old change, to fix effects that must have annoyed us for a long time, but I just now found and understood them - after hours of trying to hammer a Table into submission, including crass reflection hacks, but in vain. Any Table with separators and Actors changing in size dynamically on the same axis, where the Table can grow visibly with the changing Actors (discounting UI that scraps and rebuilds entirely on user interaction) will show it. An Actor grows, so grows the Table, it shrinks back again, the Table won't shrink. Because the separators now insist on the last size they had...