### PR TITLE
Fixed special case to allow the winning player to continue the MP game

### DIFF
--- a/core/src/com/unciv/ui/screens/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/WorldScreen.kt
@@ -617,8 +617,8 @@ class WorldScreen(
 
             debug("Next turn took %sms", System.currentTimeMillis() - startTime)
 
-            // Special case: when you are the only human player, the game will always be up to date
-            if (gameInfo.gameParameters.isOnlineMultiplayer && gameInfoClone.civilizations.filter { it.playerType == PlayerType.Human }.size == 1) {
+            // Special case: when you are the only alive human player, the game will always be up to date
+            if (gameInfo.gameParameters.isOnlineMultiplayer && gameInfoClone.civilizations.filter { it.isAlive() && it.playerType == PlayerType.Human }.size == 1) {
                 gameInfoClone.isUpToDate = true
             }
 


### PR DESCRIPTION
Before this change, it wasn't possible for the winning player to continue the game after winning it (even though there's the "one more turn" button) - so that you had to manually reload the game to continue after every turn.