### PR TITLE
Fix tooltips on Android with physical keyboard detected

### DIFF
--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsTable.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsTable.kt
@@ -30,7 +30,7 @@ class UnitActionsTable(val worldScreen: WorldScreen) : Table() {
         if (!worldScreen.canChangeState) return // No actions when it's not your turn or spectator!
         for (unitAction in UnitActions.getUnitActions(unit)) {
             val button = getUnitActionButton(unit, unitAction)
-            if (unitAction is UpgradeUnitAction) {
+            if (unitAction is UpgradeUnitAction && GUI.keyboardAvailable) {
                 val tipTitle = "«RED»${unitAction.type.key}«»: {Upgrade}"
                 val tipActor = BaseUnitDescriptions.getUpgradeTooltipActor(tipTitle, unit.baseUnit, unitAction.unitToUpgradeTo)
                 button.addListener(UncivTooltip(button, tipActor


### PR DESCRIPTION
Fixes issues mentioned after #9485 was merged - see screenshots by @WhoIsJohannes there.

The basic issue affected all Android AVD's and probably physical devices with an actual physical keyboard connected as well.
The new tip exposed the issue for all Android devices, for the Upgrade button only - because I (:face_with_head_bandage:) forgot that the guard is in the addTooltip extension, not the class itself...