### PR TITLE
Improve connected to / disconnected from Capital handling

### DIFF
--- a/core/src/com/unciv/logic/city/City.kt
+++ b/core/src/com/unciv/logic/city/City.kt
@@ -101,6 +101,13 @@ class City : IsPartOfGameInfoSerialization {
 
     internal var flagsCountdown = HashMap<String, Int>()
 
+    /** Persisted connected-to-capital (by any medium) to allow "disconnected" notifications after loading */
+    // Unknown only exists to support older saves, so those do not generate spurions connected/disconnected messages.
+    // The other names are chosen so serialization is compatible with a Boolean to allow easy replacement in the future.
+    @Suppress("EnumEntryName")
+    enum class ConnectedToCapitalStatus { Unknown, `false`, `true` }
+    var connectedToCapitalStatus = ConnectedToCapitalStatus.Unknown
+
     fun hasDiplomaticMarriage(): Boolean = foundingCiv == ""
 
     //region pure functions
@@ -129,6 +136,7 @@ class City : IsPartOfGameInfoSerialization {
         toReturn.cityAIFocus = cityAIFocus
         toReturn.avoidGrowth = avoidGrowth
         toReturn.manualSpecialists = manualSpecialists
+        toReturn.connectedToCapitalStatus = connectedToCapitalStatus
         return toReturn
     }
 

--- a/core/src/com/unciv/logic/city/City.kt
+++ b/core/src/com/unciv/logic/city/City.kt
@@ -102,7 +102,7 @@ class City : IsPartOfGameInfoSerialization {
     internal var flagsCountdown = HashMap<String, Int>()
 
     /** Persisted connected-to-capital (by any medium) to allow "disconnected" notifications after loading */
-    // Unknown only exists to support older saves, so those do not generate spurions connected/disconnected messages.
+    // Unknown only exists to support older saves, so those do not generate spurious connected/disconnected messages.
     // The other names are chosen so serialization is compatible with a Boolean to allow easy replacement in the future.
     @Suppress("EnumEntryName")
     enum class ConnectedToCapitalStatus { Unknown, `false`, `true` }


### PR DESCRIPTION
Issue #7514 "disconnected" part. I think that could then be closed.

<details><summary>Skrynshutt</summary>

![image](https://github.com/yairm210/Unciv/assets/63000004/f019dd3c-6356-4c50-97ff-5d77f758b695)

</details>

...That screenshot has been made, however, with massive manipulation of the AI: tryPillageImprovement changed to prefer current tile, and an if (enemy territory) tryPillageImprovement call near the start of automateUnitMoves, otherwise I could play 30 turns of that war with 4-6 mongols on that road and they never disconnected me. So...

#### Questions
* That defensive design for backward compatibility - a much simpler approach would re-throw "your city X has been connected to your capital" on the first load after updating for each connected city, once (or one "disconnected" for each unconnected = worse). That would also be what this could migrate to after a grace period - enum to Boolean, and don't differentiate between 'certain' and 'unsure' for the connected last turn tests.
* Would that 'prefer current tile' bit make sense for the general codebase? My code see below
* Non-barbs only ever call tryPillageImprovement from tryHealUnit: Make sense to make those health thresholds moddable? ModOptions/Civilization?
* `UniqueType.NoMovementToPillage` has no influence on AI - should it have? For units with that ability that prefer current tile change would likely make a lot of sense, and maybe they should see if pillaging is an advantage even outside of tryHealUnit?

<details><summary>tryPillageImprovement</summary>

```kotlin
    fun tryPillageImprovement(unit: MapUnit): Boolean {
        if (unit.isCivilian()) return false

        fun Tile.canUnitPillageHere() = (
            canPillageTileImprovement()
                || (canPillageRoad() && getRoadOwner() != null && unit.civ.isAtWarWith(getRoadOwner()!!))
            ) && UnitActions.canPillage(unit, this)

        if (!unit.getTile().canUnitPillageHere()) {
            val unitDistanceToTiles = unit.movement.getDistanceToTiles()
            val tilesThatCanWalkToAndThenPillage = unitDistanceToTiles
                .filter { it.value.totalDistance > 0f && it.value.totalDistance < unit.currentMovement }.keys
                .filter { unit.movement.canMoveTo(it) && it.canUnitPillageHere() }

            if (tilesThatCanWalkToAndThenPillage.isEmpty()) return false
            val tileToPillage = tilesThatCanWalkToAndThenPillage.maxByOrNull { it.getDefensiveBonus() }!!
            if (unit.getTile() != tileToPillage)
                unit.movement.moveToTile(tileToPillage)
        }

        UnitActionsPillage.getPillageAction(unit)?.action?.invoke()
        return unit.currentMovement == 0f
    }
```
</details>
