### PR TITLE
Only consider attackable enemies within visible tiles.

### DIFF
--- a/core/src/com/unciv/logic/automation/unit/SpecificUnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/SpecificUnitAutomation.kt
@@ -577,6 +577,7 @@ object SpecificUnitAutomation {
         for (city in immediatelyReachableCitiesAndCarriers) {
             if (city.getTilesInDistance(unit.getRange())
                             .any {
+                                it.isVisible(unit.civ) &&
                                 BattleHelper.containsAttackableEnemy(
                                     it,
                                     MapUnitCombatant(unit)


### PR DESCRIPTION
I noticed that some planes wouldn't advance towards the enemy and I just debugged it. Turns out there was some barbarians in the fog of war around the city where they were stationed.

This code still doesn't work if the plane needs to fly through another city first to reach the enemy, but I guess that's not a big deal since this will only matter on rather big maps (considering the range of aircraft) and it will only matter for civs that have a lot of cities and planes (which is probably not an AI and also probably not a civ that is doing poorly).

Another shot in the dark: I'm noticing a lot of units are losing their "Automated" status when going to the next turn and I have to keep automating them over and over again. Any idea why?