### PR TITLE
Pantheon Mod Constants

### DIFF
--- a/core/src/com/unciv/logic/civilization/managers/ReligionManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/ReligionManager.kt
@@ -106,7 +106,7 @@ class ReligionManager : IsPartOfGameInfoSerialization {
             || (religionState == ReligionState.Religion || religionState == ReligionState.EnhancedReligion) // any belief adding outside of great prophet use
 
     fun faithForPantheon(additionalCivs: Int = 0) =
-        10 + (civInfo.gameInfo.civilizations.count { it.isMajorCiv() && it.religionManager.religion != null } + additionalCivs) * 5
+        civInfo.gameInfo.ruleset.modOptions.constants.pantheonBase + (civInfo.gameInfo.civilizations.count { it.isMajorCiv() && it.religionManager.religion != null } + additionalCivs) * civInfo.gameInfo.ruleset.modOptions.constants.pantheonGrowth
 
     /** Used for founding the pantheon and for each time the player gets additional pantheon beliefs
      * before forming a religion */
@@ -117,7 +117,7 @@ class ReligionManager : IsPartOfGameInfoSerialization {
         if (numberOfBeliefsAvailable(BeliefType.Pantheon) == 0)
             return false // no more available pantheons
         if (civInfo.gameInfo.civilizations.any { it.religionManager.religionState == ReligionState.EnhancedReligion }
-            && civInfo.gameInfo.civilizations.count { it.religionManager.religionState >= ReligionState.Pantheon } < maxNumberOfReligions()
+            && civInfo.gameInfo.civilizations.count { it.religionManager.religionState >= ReligionState.Pantheon } >= maxNumberOfReligions()
         ) {
             return false
         }

--- a/core/src/com/unciv/models/ModConstants.kt
+++ b/core/src/com/unciv/models/ModConstants.kt
@@ -66,6 +66,10 @@ class ModConstants {
     var religionLimitBase = 1
     var religionLimitMultiplier = 0.5f
 
+    //Factors in formula for pantheon cost
+    var pantheonBase = 10
+    var pantheonGrowth = 5
+
     fun merge(other: ModConstants) {
         if (other.maxXPfromBarbarians != defaults.maxXPfromBarbarians) maxXPfromBarbarians = other.maxXPfromBarbarians
         if (other.cityStrengthBase != defaults.cityStrengthBase) cityStrengthBase = other.cityStrengthBase
@@ -88,6 +92,8 @@ class ModConstants {
         if (other.maxRiverLength != defaults.maxRiverLength) maxRiverLength = other.maxRiverLength
         if (other.religionLimitBase != defaults.religionLimitBase) religionLimitBase = other.religionLimitBase
         if (other.religionLimitMultiplier != defaults.religionLimitMultiplier) religionLimitMultiplier = other.religionLimitMultiplier
+        if (other.pantheonBase != defaults.pantheonBase) pantheonBase = other.pantheonBase
+        if (other.pantheonGrowth != defaults.pantheonGrowth) pantheonGrowth = other.pantheonGrowth
     }
 
     companion object {

--- a/docs/Other/Miscellaneous-JSON-files.md
+++ b/docs/Other/Miscellaneous-JSON-files.md
@@ -151,6 +151,8 @@ and city distance in another. In case of conflicts, there is no guarantee which 
 | maxRiverLength                           | Int    | 666       | [^I]  |
 | religionLimitBase                        | Int    | 1         | [^K]  |
 | religionLimitMultiplier                  | Float  | 0.5       | [^K]  |
+| pantheonBase                             | Int    | 10        | [^L]  |
+| pantheonGrowth                           | Int    | 10        | [^L]  |
 
 
 Legend:
@@ -179,6 +181,7 @@ Legend:
 - [^I]: RiverGenerator: river frequency and length bounds
 - [^J]: A [UnitUpgradeCost](#UnitUpgradeCost) sub-structure.
 - [^K]: Maximum foundable Religions = religionLimitBase + floor(MajorCivCount * religionLimitMultiplier)
+- [^L]: Cost of pantheon = pantheonBase + CivsWithReligion * pantheonGrowth
 
 #### UnitUpgradeCost
 

--- a/docs/Other/Miscellaneous-JSON-files.md
+++ b/docs/Other/Miscellaneous-JSON-files.md
@@ -152,7 +152,7 @@ and city distance in another. In case of conflicts, there is no guarantee which 
 | religionLimitBase                        | Int    | 1         | [^K]  |
 | religionLimitMultiplier                  | Float  | 0.5       | [^K]  |
 | pantheonBase                             | Int    | 10        | [^L]  |
-| pantheonGrowth                           | Int    | 10        | [^L]  |
+| pantheonGrowth                           | Int    | 5         | [^L]  |
 
 
 Legend:


### PR DESCRIPTION
This PR does 2 things

- Fixes a bug where players could get a pantheon after a player enhanced a religion and more players had a pantheon than the maximum allowed, but couldn't get a pantheon in the case when less players had a pantheon than the maximum allowed
- Adds Mod Constants to change the cost of a pantheon

