### PR TITLE
ExpanderTab layout fixes 1

### DIFF
--- a/core/src/com/unciv/ui/screens/cityscreen/CitizenManagementTable.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/CitizenManagementTable.kt
@@ -85,7 +85,7 @@ class CitizenManagementTable(val cityScreen: CityScreen) : Table(BaseScreen.skin
     fun asExpander(onChange: (() -> Unit)?): ExpanderTab {
         update()
         return ExpanderTab(
-            title = "{Citizen Management}",
+            title = "Citizen Management",
             fontSize = Constants.defaultFontSize,
             persistenceID = "CityStatsTable.CitizenManagement",
             startsOutOpened = false,

--- a/core/src/com/unciv/ui/screens/cityscreen/CityConstructionsTable.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/CityConstructionsTable.kt
@@ -710,14 +710,14 @@ class CityConstructionsTable(private val cityScreen: CityScreen) {
         lowerTable.pack()
     }
 
-    private fun Table.addCategory(title: String, list: ArrayList<Table>, prefWidth: Float) {
+    private fun Table.addCategory(title: String, list: ArrayList<Table>, desiredWidth: Float) {
         if (list.isEmpty()) return
 
         if (rows > 0) addSeparator()
         val expander = ExpanderTab(
             title,
             defaultPad = 0f,
-            expanderWidth = prefWidth,
+            expanderWidth = desiredWidth,
             persistenceID = "CityConstruction.$title",
             onChange = { resizeAvailableConstructionsScrollPane() }
         ) {

--- a/core/src/com/unciv/ui/screens/cityscreen/SpecialistAllocationTable.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/SpecialistAllocationTable.kt
@@ -138,7 +138,7 @@ class SpecialistAllocationTable(private val cityScreen: CityScreen) : Table(Base
     fun asExpander(onChange: (() -> Unit)?): ExpanderTab {
         update()
         return ExpanderTab(
-            title = "{Specialists}:",
+            title = "Specialists",
             fontSize = Constants.defaultFontSize,
             persistenceID = "CityStatsTable.Specialists",
             startsOutOpened = true,


### PR DESCRIPTION
Fixes the expanders in CityStatsTable as already mentioned - four out of five have 20f unintentional padding below them, this moves the padding where it belongs inside the wrapped, collapsing/expanding area.

Commit 2 is very ephemeral - why have 4 expanders without colon after the title, one with? Curlies around an *entire* string are pretty much ignored by tr(). And a potential name shadowing I wanted to test and avert suspicion during the hunt for the other bug