### PR TITLE
Keyboard bindings - collision check

### DIFF
--- a/android/assets/jsons/Tutorials.json
+++ b/android/assets/jsons/Tutorials.json
@@ -398,7 +398,6 @@
             {"text":"This is a work in progress.","color":"#b22222","starred":true},
             {"text":"For technical reasons, only direct keys or Ctrl-Letter combinations can be used.","starred":true},
             {"text":"The Escape key is intentionally excluded from being reassigned.","starred":true},
-            {"text":"Currently, there are no checks to prevent conflicting assignments.","starred":true},
             {},
             {"text":"Using the Keys page","header":3},
             {"text":"Each binding has a button with an image looking like this:"},
@@ -407,6 +406,7 @@
             {"text":"Double-click the image to reset the binding to default."},
             {},
             {"text":"Bindings mapped to their default keys are displayed in gray, those reassigned by you in white."},
+            {"text":"Conflicting assignments are marked red. Conflicts can exist across categories, like World Screen / Unit Actions. Note that at the moment, the game does not prevent saving conflicting assignments, though the result may be unexpected."},
             {},
             {"text":"For discussion about missing entries, see the linked github issue.","link":"https://github.com/yairm210/Unciv/issues/8862"}
         ]

--- a/core/src/com/unciv/ui/components/KeyCapturingButton.kt
+++ b/core/src/com/unciv/ui/components/KeyCapturingButton.kt
@@ -68,9 +68,16 @@ class KeyCapturingButton(
             updateLabel()
         }
 
+    var markConflict = false
+        set(value) {
+            field = value
+            updateStyle()
+        }
+
     private var savedFocus: Actor? = null
     private val normalStyle: ImageTextButtonStyle
     private val defaultStyle: ImageTextButtonStyle
+    private val conflictStyle: ImageTextButtonStyle
 
     init {
         imageCell.size((style as KeyCapturingButtonStyle).imageSize)
@@ -80,13 +87,23 @@ class KeyCapturingButton(
         normalStyle = style
         defaultStyle = ImageTextButtonStyle(normalStyle)
         defaultStyle.fontColor = Color.GRAY.cpy()
+        conflictStyle = ImageTextButtonStyle(normalStyle)
+        conflictStyle.fontColor = Color.RED.cpy()
         addListener(ButtonListener(this))
     }
 
     private fun updateLabel() {
         label.setText(if (current == KeyCharAndCode.UNKNOWN) "" else current.toString())
-        style = if (current == default) defaultStyle else normalStyle
+        updateStyle()
     }
+    private fun updateStyle() {
+        style = when {
+            markConflict -> conflictStyle
+            current == default -> defaultStyle
+            else -> normalStyle
+        }
+    }
+
     private fun handleKey(code: Int, control: Boolean) {
         current = if (control) KeyCharAndCode.ctrlFromCode(code) else KeyCharAndCode(code)
         onKeyHit?.invoke(current)

--- a/core/src/com/unciv/ui/components/input/KeyboardBinding.kt
+++ b/core/src/com/unciv/ui/components/input/KeyboardBinding.kt
@@ -12,6 +12,8 @@ enum class KeyboardBinding(
     label: String? = null,
     key: KeyCharAndCode? = null
 ) {
+    //region Enum Instances
+
     /** Used by [KeyShortcutDispatcher.KeyShortcut] to mark an old-style shortcut with a hardcoded key */
     None(Category.None, KeyCharAndCode.UNKNOWN),
 
@@ -89,10 +91,22 @@ enum class KeyboardBinding(
     Confirm(Category.Popups, "Confirm Dialog", 'y'),
     Cancel(Category.Popups, "Cancel Dialog", 'n'),
     ;
+    //endregion
 
     enum class Category {
-        None, WorldScreen, UnitActions, Popups;
+        None,
+        WorldScreen {
+            // Conflict checking within group plus keys assigned to UnitActions are a problem
+            override fun checkConflictsIn() = sequenceOf(this, UnitActions)
+        },
+        UnitActions {
+            // Conflict checking within group disabled, but any key assigned on WorldScreen is a problem
+            override fun checkConflictsIn() = sequenceOf(WorldScreen)
+        },
+        Popups
+        ;
         val label = unCamelCase(name)
+        open fun checkConflictsIn() = sequenceOf(this)
     }
 
     val label: String
@@ -104,12 +118,13 @@ enum class KeyboardBinding(
         this.defaultKey = key ?: KeyCharAndCode(name[0])
     }
 
-    // Helpers to make enum instance initializations shorter
+    //region Helper constructors
     constructor(category: Category, label: String, key: Char) : this(category, label, KeyCharAndCode(key))
     constructor(category: Category, label: String, key: Int) : this(category, label, KeyCharAndCode(key))
     constructor(category: Category, key: KeyCharAndCode) : this(category, null, key)
     constructor(category: Category, key: Char) : this(category, KeyCharAndCode(key))
     constructor(category: Category, key: Int) : this(category, KeyCharAndCode(key))
+    //endregion
 
     /** Debug helper */
     override fun toString() = "$category.$name($defaultKey)"


### PR DESCRIPTION
Adds a very simple collision check to the bindings page

<details>

![image](https://github.com/yairm210/Unciv/assets/63000004/a5a33d66-aebd-4de8-83b6-ba2bd481d89b)

Note - the red "G" conflicts with the Unit Actions using G. All G's over there are red too, and all of them go back grey when that worldscreen assignment is reset... Interdependencies are complex, but as simple first version it's quite clever.
</details>