### PR TITLE
Prevent mod conflicts better

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -449,6 +449,7 @@ You can play it, but don't expect everything to work! =
 The mod combination you selected «GOLD»has problems«». = 
 You can play it, but «GOLDENROD»don't expect everything to work!«» = 
 This base ruleset is not compatible with the previously selected\nextension mods. They have been disabled. = 
+Are you really sure you want to play with the following known problems? = 
 Base Ruleset = 
 [amount] Techs = 
 [amount] Nations = 

--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -439,10 +439,15 @@ No victory conditions were selected! =
 Mods: = 
 Extension mods = 
 Base ruleset: = 
+# Note - do not translate the colour names between «». Changing them works if you know what you're doing.
 The mod you selected is incorrectly defined! = 
+The mod you selected is «RED»incorrectly defined!«» = 
 The mod combination you selected is incorrectly defined! = 
+The mod combination you selected is «RED»incorrectly defined!«» = 
 The mod combination you selected has problems. = 
 You can play it, but don't expect everything to work! = 
+The mod combination you selected «GOLD»has problems«». = 
+You can play it, but «GOLDENROD»don't expect everything to work!«» = 
 This base ruleset is not compatible with the previously selected\nextension mods. They have been disabled. = 
 Base Ruleset = 
 [amount] Techs = 

--- a/core/src/com/unciv/models/metadata/GameParameters.kt
+++ b/core/src/com/unciv/models/metadata/GameParameters.kt
@@ -50,6 +50,8 @@ class GameParameters : IsPartOfGameInfoSerialization { // Default values are the
 
     var maxTurns = 500
 
+    var acceptedModCheckErrors = ""
+
     fun clone(): GameParameters {
         val parameters = GameParameters()
         parameters.difficulty = difficulty
@@ -80,6 +82,7 @@ class GameParameters : IsPartOfGameInfoSerialization { // Default values are the
         parameters.baseRuleset = baseRuleset
         parameters.mods = LinkedHashSet(mods)
         parameters.maxTurns = maxTurns
+        parameters.acceptedModCheckErrors = acceptedModCheckErrors
         return parameters
     }
 

--- a/core/src/com/unciv/models/ruleset/RulesetValidator.kt
+++ b/core/src/com/unciv/models/ruleset/RulesetValidator.kt
@@ -31,6 +31,7 @@ class RulesetValidator(val ruleset: Ruleset) {
 
         val lines = RulesetErrorList()
 
+        /********************** Ruleset Invariant Part **********************/
         // Checks for all mods - only those that can succeed without loading a base ruleset
         // When not checking the entire ruleset, we can only really detect ruleset-invariant errors in uniques
 
@@ -127,6 +128,8 @@ class RulesetValidator(val ruleset: Ruleset) {
 
         // Quit here when no base ruleset is loaded - references cannot be checked
         if (!ruleset.modOptions.isBaseRuleset) return lines
+
+        /********************** Ruleset Specific Part **********************/
 
         val vanillaRuleset = RulesetCache.getVanillaRuleset()  // for UnitTypes fallback
 
@@ -485,12 +488,11 @@ class RulesetValidator(val ruleset: Ruleset) {
 
         val typeComplianceErrors = unique.type.getComplianceErrors(unique, ruleset)
         for (complianceError in typeComplianceErrors) {
-            // TODO: Make this Error eventually, this is Not Good
             if (complianceError.errorSeverity <= severityToReport)
                 rulesetErrors.add(RulesetError("$name's unique \"${unique.text}\" contains parameter ${complianceError.parameterName}," +
                         " which does not fit parameter type" +
                         " ${complianceError.acceptableParameterTypes.joinToString(" or ") { it.parameterName }} !",
-                    RulesetErrorSeverity.Warning
+                    complianceError.errorSeverity.correspondingRulesetErrorSeverity
                 ))
         }
 

--- a/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
@@ -125,12 +125,12 @@ enum class UniqueParameterType(
         override fun getTranslationWriterStringsForOutput() = knownValues
     },
 
-    /** Only used by [BaseUnitFilter] */
+    /** Used by [BaseUnitFilter] and e.g. [UniqueType.OneTimeFreeUnit] */
     UnitName("unit", "Musketman") {
         override fun getErrorSeverity(parameterText: String, ruleset: Ruleset):
                 UniqueType.UniqueComplianceErrorSeverity? {
             if (ruleset.units.containsKey(parameterText)) return null
-            return UniqueType.UniqueComplianceErrorSeverity.WarningOnly
+            return UniqueType.UniqueComplianceErrorSeverity.RulesetSpecific  // OneTimeFreeUnitRuins crashes with a bad parameter
         }
     },
 
@@ -250,7 +250,7 @@ enum class UniqueParameterType(
             parameterText != "All" && getErrorSeverity(parameterText, ruleset) == null
     },
 
-    /** Implemented by [PopulationManager.getPopulationFilterAmount][com.unciv.logic.city.CityPopulationManager.getPopulationFilterAmount] */
+    /** Implemented by [PopulationManager.getPopulationFilterAmount][com.unciv.logic.city.managers.CityPopulationManager.getPopulationFilterAmount] */
     PopulationFilter("populationFilter", "Followers of this Religion", null, "Population Filters") {
         private val knownValues = setOf("Population", "Specialists", "Unemployed", "Followers of the Majority Religion", "Followers of this Religion")
         override fun getErrorSeverity(

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -2,6 +2,7 @@ package com.unciv.models.ruleset.unique
 
 import com.unciv.Constants
 import com.unciv.models.ruleset.Ruleset
+import com.unciv.models.ruleset.RulesetErrorSeverity
 import com.unciv.models.translations.getPlaceholderParameters
 import com.unciv.models.translations.getPlaceholderText
 
@@ -715,9 +716,9 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
     ///////////////////////////////////////// region TRIGGERED ONE-TIME /////////////////////////////////////////
 
 
-    OneTimeFreeUnit("Free [baseUnitFilter] appears", UniqueTarget.Triggerable),  // used in Policies, Buildings
-    OneTimeAmountFreeUnits("[amount] free [baseUnitFilter] units appear", UniqueTarget.Triggerable), // used in Buildings
-    OneTimeFreeUnitRuins("Free [baseUnitFilter] found in the ruins", UniqueTarget.Ruins), // Differs from "Free [] appears" in that it spawns near the ruins instead of in a city
+    OneTimeFreeUnit("Free [unit] appears", UniqueTarget.Triggerable),  // used in Policies, Buildings
+    OneTimeAmountFreeUnits("[amount] free [unit] units appear", UniqueTarget.Triggerable), // used in Buildings
+    OneTimeFreeUnitRuins("Free [unit] found in the ruins", UniqueTarget.Ruins), // Differs from "Free [] appears" in that it spawns near the ruins instead of in a city
     OneTimeFreePolicy("Free Social Policy", UniqueTarget.Triggerable), // used in Buildings
     OneTimeAmountFreePolicies("[amount] Free Social Policies", UniqueTarget.Triggerable),  // Not used in Vanilla
     OneTimeEnterGoldenAge("Empire enters golden age", UniqueTarget.Triggerable),  // used in Policies, Buildings
@@ -1181,17 +1182,17 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
     val placeholderText = text.getPlaceholderText()
 
     /** Ordinal determines severity - ordered from least to most severe, so we can use Severity >=  */
-    enum class UniqueComplianceErrorSeverity {
+    enum class UniqueComplianceErrorSeverity(val correspondingRulesetErrorSeverity: RulesetErrorSeverity) {
 
         /** This is for filters that can also potentially accept free text, like UnitFilter and TileFilter */
-        WarningOnly,
+        WarningOnly(RulesetErrorSeverity.Warning),
 
         /** This is a problem like "unit/resource/tech name doesn't exist in ruleset" - definite bug */
-        RulesetSpecific,
+        RulesetSpecific(RulesetErrorSeverity.Error),
 
 
         /** This is a problem like "numbers don't parse", "stat isn't stat", "city filter not applicable" */
-        RulesetInvariant
+        RulesetInvariant(RulesetErrorSeverity.Error)
 
     }
 

--- a/core/src/com/unciv/ui/popups/ToastPopup.kt
+++ b/core/src/com/unciv/ui/popups/ToastPopup.kt
@@ -1,6 +1,8 @@
 package com.unciv.ui.popups
 
 import com.badlogic.gdx.scenes.scene2d.Stage
+import com.badlogic.gdx.utils.Align
+import com.unciv.ui.components.ColorMarkupLabel
 import com.unciv.ui.components.input.onClick
 import com.unciv.ui.screens.basescreen.BaseScreen
 import com.unciv.utils.Concurrency
@@ -10,6 +12,8 @@ import kotlinx.coroutines.delay
 /**
  * This is an unobtrusive popup which will close itself after a given amount of time.
  * Default time is two seconds (in milliseconds)
+ *
+ * Note: Supports color markup via [ColorMarkupLabel], using «» instead of Gdx's [].
  */
 class ToastPopup (message: String, stageToShowOn: Stage, val time: Long = 2000) : Popup(stageToShowOn){
 
@@ -20,7 +24,11 @@ class ToastPopup (message: String, stageToShowOn: Stage, val time: Long = 2000) 
         setFillParent(false)
         onClick { close() }  // or `touchable = Touchable.disabled` so you can operate what's behind
 
-        addGoodSizedLabel(message)
+        add(ColorMarkupLabel(message).apply {
+            wrap = true
+            setAlignment(Align.center)
+        }).width(stageToShowOn.width / 2)
+
         open()
         //move it to the top so its not in the middle of the screen
         //have to be done after open() because open() centers the popup

--- a/core/src/com/unciv/ui/screens/newgamescreen/AcceptModErrorsPopup.kt
+++ b/core/src/com/unciv/ui/screens/newgamescreen/AcceptModErrorsPopup.kt
@@ -1,0 +1,45 @@
+package com.unciv.ui.screens.newgamescreen
+
+import com.unciv.Constants
+import com.unciv.ui.components.ColorMarkupLabel
+import com.unciv.ui.popups.ConfirmPopup
+import com.unciv.ui.popups.closeAllPopups
+import com.unciv.ui.screens.basescreen.BaseScreen
+
+internal class AcceptModErrorsPopup(
+    screen: BaseScreen,
+    modCheckResult: String,
+    restoreDefault: () -> Unit,
+    action: () -> Unit
+) : ConfirmPopup(
+    screen,
+    question = "",  // do coloured label instead
+    confirmText = "Accept",
+    isConfirmPositive = false,
+    restoreDefault = restoreDefault,
+    action = action
+) {
+    init {
+        clickBehindToClose = false
+        row()  // skip the empty question label
+        val maxRowWidth = screen.stage.width * 0.9f - 50f  // total padding is 2*(20+5)
+        getScrollPane()?.setScrollingDisabled(true, false)
+
+        val question = "Are you «LIME»really sure«» you want to play with the following «GOLDENROD»known problems«»?"
+        val label1 = ColorMarkupLabel(question, Constants.headingFontSize)
+        val wrapWidth = label1.prefWidth.coerceIn(maxRowWidth / 2, maxRowWidth)
+        if (label1.prefWidth > wrapWidth) {
+            label1.wrap = true
+            add(label1).width(wrapWidth).padBottom(15f).row()
+        } else add(label1).padBottom(15f).row()
+
+        val warnings = modCheckResult.replace("Error:", "«RED»Error«»:")
+            .replace("Warning:","«GOLD»Warning«»:")
+        val label2 = ColorMarkupLabel(warnings)
+        label2.wrap = true
+        add(label2).width(wrapWidth)
+
+        screen.closeAllPopups()  // Toasts too
+        open(true)
+    }
+}

--- a/core/src/com/unciv/ui/screens/newgamescreen/AcceptModErrorsPopup.kt
+++ b/core/src/com/unciv/ui/screens/newgamescreen/AcceptModErrorsPopup.kt
@@ -1,5 +1,6 @@
 package com.unciv.ui.screens.newgamescreen
 
+import com.badlogic.gdx.utils.Align
 import com.unciv.Constants
 import com.unciv.ui.components.ColorMarkupLabel
 import com.unciv.ui.popups.ConfirmPopup
@@ -25,9 +26,11 @@ internal class AcceptModErrorsPopup(
         val maxRowWidth = screen.stage.width * 0.9f - 50f  // total padding is 2*(20+5)
         getScrollPane()?.setScrollingDisabled(true, false)
 
-        val question = "Are you «LIME»really sure«» you want to play with the following «GOLDENROD»known problems«»?"
+        // Note - using the version of ColorMarkupLabel that supports «color» but it was too garish.
+        val question = "Are you really sure you want to play with the following known problems?"
         val label1 = ColorMarkupLabel(question, Constants.headingFontSize)
         val wrapWidth = label1.prefWidth.coerceIn(maxRowWidth / 2, maxRowWidth)
+        label1.setAlignment(Align.center)
         if (label1.prefWidth > wrapWidth) {
             label1.wrap = true
             add(label1).width(wrapWidth).padBottom(15f).row()

--- a/core/src/com/unciv/ui/screens/newgamescreen/ModCheckboxTable.kt
+++ b/core/src/com/unciv/ui/screens/newgamescreen/ModCheckboxTable.kt
@@ -5,21 +5,20 @@ import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener
 import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.ruleset.RulesetCache
-import com.unciv.models.ruleset.RulesetErrorList
 import com.unciv.models.translations.tr
-import com.unciv.ui.popups.ToastPopup
-import com.unciv.ui.screens.basescreen.BaseScreen
 import com.unciv.ui.components.ExpanderTab
-import com.unciv.ui.components.input.onChange
 import com.unciv.ui.components.extensions.pad
 import com.unciv.ui.components.extensions.toCheckBox
+import com.unciv.ui.components.input.onChange
+import com.unciv.ui.popups.ToastPopup
+import com.unciv.ui.screens.basescreen.BaseScreen
 
 /**
  * A widget containing one expander for extension mods.
  * Manages compatibility checks, warns or prevents incompatibilities.
  *
  * @param mods In/out set of active mods, modified in place
- * @param baseRuleset The selected base Ruleset //todo clarify
+ * @param baseRuleset The selected base Ruleset, only for running mod checks against. Use [setBaseRuleset] to change on the fly.
  * @param screen Parent screen, used only to show [ToastPopup]s
  * @param isPortrait Used only for minor layout tweaks, arrangement is always vertical
  * @param onUpdate Callback, parameter is the mod name, called after any checks that may prevent mod selection succeed.
@@ -29,11 +28,13 @@ class ModCheckboxTable(
     private var baseRuleset: String,
     private val screen: BaseScreen,
     isPortrait: Boolean = false,
-    onUpdate: (String) -> Unit
+    private val onUpdate: (String) -> Unit
 ): Table() {
     private val modRulesets = RulesetCache.values.filter { it.name != "" && !it.modOptions.isBaseRuleset}
     private var lastToast: ToastPopup? = null
     private val extensionRulesetModButtons = ArrayList<CheckBox>()
+    var savedModcheckResult: String? = null
+    private var disableChangeEvents = false
 
     init {
 
@@ -57,25 +58,37 @@ class ModCheckboxTable(
                     it.add(checkbox).row()
                 }
             }).pad(10f).padTop(padTop).growX().row()
+
+            runComplexModCheck()
         }
     }
 
     fun setBaseRuleset(newBaseRuleset: String) { baseRuleset = newBaseRuleset }
     fun disableAllCheckboxes() {
+        disableChangeEvents = true
         for (checkBox in extensionRulesetModButtons) {
             checkBox.isChecked = false
         }
+        mods.clear()
+        disableChangeEvents = false
+        onUpdate("-")  // should match no mod
     }
 
+    private fun runComplexModCheck(): Boolean {
+        // Check over complete combination of selected mods
+        val complexModLinkCheck = RulesetCache.checkCombinedModLinks(mods, baseRuleset)
+        if (!complexModLinkCheck.isWarnUser()) return false
+        savedModcheckResult = complexModLinkCheck.getErrorText()
 
-    private fun popupToastError(rulesetErrorList: RulesetErrorList) {
         val initialText =
-            if (rulesetErrorList.isError()) "The mod combination you selected is incorrectly defined!".tr()
-            else "{The mod combination you selected has problems.}\n{You can play it, but don't expect everything to work!}".tr()
-        val toastMessage =  "$initialText\n\n${rulesetErrorList.getErrorText()}"
+            if (complexModLinkCheck.isError()) "The mod combination you selected is «RED»incorrectly defined!«»".tr()
+            else "{The mod combination you selected «GOLD»has problems«».}\n{You can play it, but «GOLDENROD»don't expect everything to work!«»}".tr()
+        val toastMessage =  "$initialText\n\n$savedModcheckResult"
 
         lastToast?.close()
         lastToast = ToastPopup(toastMessage, screen, 5000L)
+
+        return complexModLinkCheck.isError()
     }
 
     private fun checkBoxChanged(
@@ -83,13 +96,15 @@ class ModCheckboxTable(
         changeEvent: ChangeListener.ChangeEvent,
         mod: Ruleset
     ): Boolean {
+        if (disableChangeEvents) return false
+
         if (checkBox.isChecked) {
             // First the quick standalone check
             val modLinkErrors = mod.checkModLinks()
             if (modLinkErrors.isError()) {
                 lastToast?.close()
                 val toastMessage =
-                    "The mod you selected is incorrectly defined!".tr() + "\n\n${modLinkErrors.getErrorText()}"
+                    "The mod you selected is «RED»incorrectly defined!«»".tr() + "\n\n${modLinkErrors.getErrorText()}"
                 lastToast = ToastPopup(toastMessage, screen, 5000L)
                 changeEvent.cancel() // Cancel event to reset to previous state - see Button.setChecked()
                 return false
@@ -98,14 +113,10 @@ class ModCheckboxTable(
             mods.add(mod.name)
 
             // Check over complete combination of selected mods
-            val complexModLinkCheck = RulesetCache.checkCombinedModLinks(mods, baseRuleset)
-            if (complexModLinkCheck.isWarnUser()) {
-                popupToastError(complexModLinkCheck)
-                if (complexModLinkCheck.isError()) {
-                    changeEvent.cancel() // Cancel event to reset to previous state - see Button.setChecked()
-                    mods.remove(mod.name)
-                    return false
-                }
+            if (runComplexModCheck()) {
+                changeEvent.cancel() // Cancel event to reset to previous state - see Button.setChecked()
+                mods.remove(mod.name)
+                return false
             }
 
         } else {
@@ -115,14 +126,11 @@ class ModCheckboxTable(
              */
 
             mods.remove(mod.name)
-            val complexModLinkCheck = RulesetCache.checkCombinedModLinks(mods, baseRuleset)
-            if (complexModLinkCheck.isWarnUser()) {
-                popupToastError(complexModLinkCheck)
-                if (complexModLinkCheck.isError()) {
-                    changeEvent.cancel() // Cancel event to reset to previous state - see Button.setChecked()
-                    mods.add(mod.name)
-                    return false
-                }
+
+            if (runComplexModCheck()) {
+                changeEvent.cancel() // Cancel event to reset to previous state - see Button.setChecked()
+                mods.add(mod.name)
+                return false
             }
 
         }

--- a/core/src/com/unciv/ui/screens/newgamescreen/NewGameModCheckHelpers.kt
+++ b/core/src/com/unciv/ui/screens/newgamescreen/NewGameModCheckHelpers.kt
@@ -1,0 +1,23 @@
+package com.unciv.ui.screens.newgamescreen
+
+import com.unciv.models.ruleset.RulesetErrorList
+import com.unciv.models.translations.tr
+import com.unciv.ui.popups.ToastPopup
+import com.unciv.ui.popups.popups
+import com.unciv.ui.screens.basescreen.BaseScreen
+
+/**
+ * Show a [ToastPopup] for this if severity is at least [isWarnUser][RulesetErrorList.isWarnUser].
+ *
+ * Adds an appropriate header to [getErrorText][RulesetErrorList.getErrorText],
+ * exists mainly to centralize those strings.
+ */
+fun RulesetErrorList.showWarnOrErrorToast(screen: BaseScreen) {
+    if (!isWarnUser()) return
+    val headerText =
+        if (isError()) "The mod combination you selected is «RED»incorrectly defined!«»"
+        else "{The mod combination you selected «GOLD»has problems«».}\n{You can play it, but «GOLDENROD»don't expect everything to work!«»}"
+    val toastMessage = headerText.tr() + "\n\n{" + getErrorText() + "}"
+    for (oldToast in screen.popups.filterIsInstance<ToastPopup>()) { oldToast.close() }
+    ToastPopup(toastMessage, screen, 5000L)
+}

--- a/core/src/com/unciv/ui/screens/newgamescreen/NewGameScreen.kt
+++ b/core/src/com/unciv/ui/screens/newgamescreen/NewGameScreen.kt
@@ -20,17 +20,17 @@ import com.unciv.models.metadata.GameSetupInfo
 import com.unciv.models.ruleset.RulesetCache
 import com.unciv.models.translations.tr
 import com.unciv.ui.components.ExpanderTab
-import com.unciv.ui.components.input.KeyCharAndCode
 import com.unciv.ui.components.extensions.addSeparator
 import com.unciv.ui.components.extensions.addSeparatorVertical
 import com.unciv.ui.components.extensions.disable
 import com.unciv.ui.components.extensions.enable
-import com.unciv.ui.components.input.keyShortcuts
-import com.unciv.ui.components.input.onActivation
-import com.unciv.ui.components.input.onClick
 import com.unciv.ui.components.extensions.pad
 import com.unciv.ui.components.extensions.toLabel
 import com.unciv.ui.components.extensions.toTextButton
+import com.unciv.ui.components.input.KeyCharAndCode
+import com.unciv.ui.components.input.keyShortcuts
+import com.unciv.ui.components.input.onActivation
+import com.unciv.ui.components.input.onClick
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.popups.ConfirmPopup
 import com.unciv.ui.popups.Popup
@@ -38,8 +38,8 @@ import com.unciv.ui.popups.ToastPopup
 import com.unciv.ui.screens.basescreen.BaseScreen
 import com.unciv.ui.screens.basescreen.RecreateOnResize
 import com.unciv.ui.screens.pickerscreens.PickerScreen
-import com.unciv.utils.Log
 import com.unciv.utils.Concurrency
+import com.unciv.utils.Log
 import com.unciv.utils.launchOnGLThread
 import kotlinx.coroutines.coroutineScope
 import java.net.URL
@@ -163,6 +163,20 @@ class NewGameScreen(
             noVictoryTypesPopup.addGoodSizedLabel("No victory conditions were selected!".tr()).row()
             noVictoryTypesPopup.addCloseButton()
             noVictoryTypesPopup.open()
+            return
+        }
+
+        val modCheckResult = newGameOptionsTable.modCheckboxes?.savedModcheckResult
+        newGameOptionsTable.modCheckboxes?.savedModcheckResult = null
+        if (modCheckResult != null) {
+            AcceptModErrorsPopup(
+                this, modCheckResult,
+                restoreDefault = { newGameOptionsTable.resetRuleset() },
+                action = {
+                    gameSetupInfo.gameParameters.acceptedModCheckErrors = modCheckResult
+                    onStartGameClicked()
+                }
+            )
             return
         }
 

--- a/core/src/com/unciv/ui/screens/newgamescreen/NewGameScreen.kt
+++ b/core/src/com/unciv/ui/screens/newgamescreen/NewGameScreen.kt
@@ -79,17 +79,17 @@ class NewGameScreen(
             updatePlayerPickerRandomLabel = { playerPickerTable.updateRandomNumberLabel() }
         )
         mapOptionsTable = MapOptionsTable(this)
-        pickerPane.closeButton.onActivation {
+        closeButton.onActivation {
             mapOptionsTable.cancelBackgroundJobs()
             game.popScreen()
         }
-        pickerPane.closeButton.keyShortcuts.add(KeyCharAndCode.BACK)
+        closeButton.keyShortcuts.add(KeyCharAndCode.BACK)
 
         if (isPortrait) initPortrait()
         else initLandscape()
 
-        pickerPane.bottomTable.background = skinStrings.getUiBackground("NewGameScreen/BottomTable", tintColor = skinStrings.skinConfig.clearColor)
-        pickerPane.topTable.background = skinStrings.getUiBackground("NewGameScreen/TopTable", tintColor = skinStrings.skinConfig.clearColor)
+        bottomTable.background = skinStrings.getUiBackground("NewGameScreen/BottomTable", tintColor = skinStrings.skinConfig.clearColor)
+        topTable.background = skinStrings.getUiBackground("NewGameScreen/TopTable", tintColor = skinStrings.skinConfig.clearColor)
 
         if (UncivGame.Current.settings.lastGameSetup != null) {
             rightSideGroup.addActorAt(0, VerticalGroup().padBottom(5f))
@@ -166,8 +166,8 @@ class NewGameScreen(
             return
         }
 
-        val modCheckResult = newGameOptionsTable.modCheckboxes?.savedModcheckResult
-        newGameOptionsTable.modCheckboxes?.savedModcheckResult = null
+        val modCheckResult = newGameOptionsTable.modCheckboxes.savedModcheckResult
+        newGameOptionsTable.modCheckboxes.savedModcheckResult = null
         if (modCheckResult != null) {
             AcceptModErrorsPopup(
                 this, modCheckResult,

--- a/core/src/com/unciv/ui/screens/pickerscreens/PickerPane.kt
+++ b/core/src/com/unciv/ui/screens/pickerscreens/PickerPane.kt
@@ -20,7 +20,8 @@ import com.unciv.ui.components.extensions.toTextButton
 class PickerPane(
     disableScroll: Boolean = false,
 ) : Table() {
-    /** The close button on the lower left of [bottomTable], see [setDefaultCloseAction] */
+    /** The close button on the lower left of [bottomTable], see [PickerScreen.setDefaultCloseAction].
+     *  Note if you don't use that helper, you'll need to do both click and keyboard support yourself. */
     val closeButton = Constants.close.toTextButton()
     /** A scrollable wrapped Label you can use to show descriptions in the [bottomTable], starts empty */
     val descriptionLabel = "".toLabel()

--- a/core/src/com/unciv/ui/screens/pickerscreens/PickerScreen.kt
+++ b/core/src/com/unciv/ui/screens/pickerscreens/PickerScreen.kt
@@ -20,6 +20,8 @@ open class PickerScreen(disableScroll: Boolean = false) : BaseScreen() {
 
     /** @see PickerPane.topTable */
     val topTable by pickerPane::topTable
+    /** @see PickerPane.bottomTable */
+    val bottomTable by pickerPane::bottomTable
     /** @see PickerPane.scrollPane */
     val scrollPane by pickerPane::scrollPane
     /** @see PickerPane.splitPane */

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -1,13 +1,13 @@
 # Uniques
 Simple unique parameters are explained by mouseover. Complex parameters are explained in [Unique parameter types](../Unique-parameters)
 ## Triggerable uniques
-??? example  "Free [baseUnitFilter] appears"
-	Example: "Free [Melee] appears"
+??? example  "Free [unit] appears"
+	Example: "Free [Musketman] appears"
 
 	Applicable to: Triggerable
 
-??? example  "[amount] free [baseUnitFilter] units appear"
-	Example: "[3] free [Melee] units appear"
+??? example  "[amount] free [unit] units appear"
+	Example: "[3] free [Musketman] units appear"
 
 	Applicable to: Triggerable
 
@@ -1652,8 +1652,8 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 	Applicable to: Resource
 
 ## Ruins uniques
-??? example  "Free [baseUnitFilter] found in the ruins"
-	Example: "Free [Melee] found in the ruins"
+??? example  "Free [unit] found in the ruins"
+	Example: "Free [Musketman] found in the ruins"
 
 	Applicable to: Ruins
 


### PR DESCRIPTION
My interpretation of that "Buy a Wat" in mod A torpedoed by "remove Wat" in mod B - tighten the screws considerably. Probably a repeat performance that whining wins over crashing. Please consider the code anyway, maybe play "pick and choose".

Would close #9583, because that situation is unfixable after the fact (except via savegame hacking), this prevents it in the first place.

What is treated here - see the comment with checkboxes in the issue and commits.

![image](https://github.com/yairm210/Unciv/assets/63000004/c717dd3b-8595-4703-8e78-fbd8dbe3187e)
