### PR TITLE
Support building GraalVM native image

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 import com.unciv.build.BuildConfig.gdxVersion
 import com.unciv.build.BuildConfig.roboVMVersion
+import org.jetbrains.kotlin.gradle.utils.IMPLEMENTATION
 
 plugins {
     id("io.gitlab.arturbosch.detekt").version("1.23.0-RC3")
@@ -14,6 +15,7 @@ configurations.all { resolutionStrategy {
 buildscript {
 
     repositories {
+        maven { url = uri("https://jitpack.io") }
         // Chinese mirrors for quicker loading for chinese devs - uncomment if you're chinese
         // maven{ url = uri("https://maven.aliyun.com/repository/central") }
         // maven{ url = uri("https://maven.aliyun.com/repository/google") }
@@ -39,6 +41,7 @@ allprojects {
     version = "1.0.1"
 
     repositories {
+        maven { url = uri("https://jitpack.io") } // for java-discord-rpc
         // Chinese mirrors for quicker loading for chinese devs - uncomment if you're chinese
         // maven{ url = uri("https://maven.aliyun.com/repository/central") }
         // maven{ url = uri("https://maven.aliyun.com/repository/google") }
@@ -46,7 +49,6 @@ allprojects {
         google()
         maven { url = uri("https://oss.sonatype.org/content/repositories/snapshots/") }
         maven { url = uri("https://oss.sonatype.org/content/repositories/releases/") }
-        maven { url = uri("https://jitpack.io") } // for java-discord-rpc
     }
 }
 
@@ -66,6 +68,11 @@ project(":desktop") {
 
         "implementation"("net.java.dev.jna:jna:5.11.0")
         "implementation"("net.java.dev.jna:jna-platform:5.11.0")
+
+        //Add Gradle features supporting projects using libGDX building GraalVM native-image
+        IMPLEMENTATION("com.github.berstanio:gdx-graalhelper:master-SNAPSHOT"){
+            exclude(group = "com.github.berstanio.gdx-graalhelper", module = "gdx-svmhelper-backend-moe")
+        }
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,6 @@ configurations.all { resolutionStrategy {
 buildscript {
 
     repositories {
-        maven { url = uri("https://jitpack.io") }
         // Chinese mirrors for quicker loading for chinese devs - uncomment if you're chinese
         // maven{ url = uri("https://maven.aliyun.com/repository/central") }
         // maven{ url = uri("https://maven.aliyun.com/repository/google") }
@@ -24,6 +23,7 @@ buildscript {
         google()  // needed for com.android.tools.build:gradle
         maven { url = uri("https://oss.sonatype.org/content/repositories/snapshots/") }
         gradlePluginPortal()
+        maven { url = uri("https://jitpack.io") }
     }
     dependencies {
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${com.unciv.build.BuildConfig.kotlinVersion}")
@@ -41,7 +41,6 @@ allprojects {
     version = "1.0.1"
 
     repositories {
-        maven { url = uri("https://jitpack.io") } // for java-discord-rpc
         // Chinese mirrors for quicker loading for chinese devs - uncomment if you're chinese
         // maven{ url = uri("https://maven.aliyun.com/repository/central") }
         // maven{ url = uri("https://maven.aliyun.com/repository/google") }
@@ -49,6 +48,7 @@ allprojects {
         google()
         maven { url = uri("https://oss.sonatype.org/content/repositories/snapshots/") }
         maven { url = uri("https://oss.sonatype.org/content/repositories/releases/") }
+        maven { url = uri("https://jitpack.io") } // for java-discord-rpc
     }
 }
 
@@ -69,7 +69,7 @@ project(":desktop") {
         "implementation"("net.java.dev.jna:jna:5.11.0")
         "implementation"("net.java.dev.jna:jna-platform:5.11.0")
 
-        //Add Gradle features supporting projects using libGDX building GraalVM native-image
+        //Add Gradle features supporting projects using libGDX in building GraalVM native-image
         IMPLEMENTATION("com.github.berstanio:gdx-graalhelper:master-SNAPSHOT"){
             exclude(group = "com.github.berstanio.gdx-graalhelper", module = "gdx-svmhelper-backend-moe")
         }

--- a/buildSrc/src/main/kotlin/BuildConfig.kt
+++ b/buildSrc/src/main/kotlin/BuildConfig.kt
@@ -7,6 +7,6 @@ object BuildConfig {
     const val appCodeNumber = 880
     const val appVersion = "4.7.1"
 
-    const val gdxVersion = "1.11.0"
+    const val gdxVersion = "1.11.1-SNAPSHOT"
     const val roboVMVersion = "2.3.1"
 }

--- a/desktop/src/com/unciv/app/desktop/DesktopLauncher.kt
+++ b/desktop/src/com/unciv/app/desktop/DesktopLauncher.kt
@@ -12,6 +12,8 @@ import com.unciv.models.metadata.WindowState
 import com.unciv.ui.components.Fonts
 import com.unciv.utils.Display
 import com.unciv.utils.Log
+import org.lwjgl.system.Library
+import org.lwjgl.system.ThreadLocalUtil
 import java.awt.GraphicsEnvironment
 import kotlin.math.max
 
@@ -19,6 +21,11 @@ internal object DesktopLauncher {
 
     @JvmStatic
     fun main(arg: Array<String>) {
+        // Solve the problem 'java.home property not set'
+        System.setProperty("java.home",System.getenv("JAVA_HOME"))
+        // To avoid segfault
+        Library.initialize()
+        ThreadLocalUtil.setupEnvData()
 
         // Setup Desktop logging
         Log.backend = DesktopLogBackend()


### PR DESCRIPTION
I've tested it on Windows. In principle, it would also work for Linux or MacOS.
Based on my testing, the native application runs with a significantly smaller memory footprint and possibly with faster startup times.
Given the necessity of GraalVM, I didn't add Gradle tasks to build native image.
I've published a release to my own fork.