### PR TITLE
Make UncivGame.isInitialized inaccessible outside of the class hierarchy

### DIFF
--- a/android/src/com/unciv/app/AndroidGame.kt
+++ b/android/src/com/unciv/app/AndroidGame.kt
@@ -78,5 +78,5 @@ class AndroidGame(private val activity: Activity) : UncivGame() {
         }
     }
 
-    fun isInitialized() = super.isInitialized
+    fun isInitializedProxy() = super.isInitialized
 }

--- a/android/src/com/unciv/app/AndroidGame.kt
+++ b/android/src/com/unciv/app/AndroidGame.kt
@@ -78,4 +78,5 @@ class AndroidGame(private val activity: Activity) : UncivGame() {
         }
     }
 
+    fun isInitialized() = super.isInitialized
 }

--- a/android/src/com/unciv/app/AndroidLauncher.kt
+++ b/android/src/com/unciv/app/AndroidLauncher.kt
@@ -70,7 +70,7 @@ open class AndroidLauncher : AndroidApplication() {
 
     override fun onPause() {
         val game = this.game!!
-        if (game.isInitialized
+        if (game.isInitialized()
                 && game.gameInfo != null
                 && game.settings.multiplayer.turnCheckerEnabled
                 && game.files.getMultiplayerSaves().any()

--- a/android/src/com/unciv/app/AndroidLauncher.kt
+++ b/android/src/com/unciv/app/AndroidLauncher.kt
@@ -70,7 +70,7 @@ open class AndroidLauncher : AndroidApplication() {
 
     override fun onPause() {
         val game = this.game!!
-        if (game.isInitialized()
+        if (game.isInitializedProxy()
                 && game.gameInfo != null
                 && game.settings.multiplayer.turnCheckerEnabled
                 && game.files.getMultiplayerSaves().any()

--- a/core/src/com/unciv/UncivGame.kt
+++ b/core/src/com/unciv/UncivGame.kt
@@ -137,7 +137,9 @@ open class UncivGame(val isConsoleMode: Boolean = false) : Game(), PlatformSpeci
     var worldScreen: WorldScreen? = null
         private set
 
-    var isInitialized = false
+    /** Flag used only during initialization until the end of [create] */
+    protected var isInitialized = false
+        private set
 
     /** A wrapped render() method that crashes to [CrashScreen] on a unhandled exception or error. */
     private val wrappedCrashHandlingRender = { super.render() }.wrapCrashHandlingUnit()


### PR DESCRIPTION
Tiny thing, the "other half" of what I meant with #9641. Now coders can't be tempted to use isInitialized for something it wasn't introduced for.