### PR TITLE
Zoom in/out of the history charts

### DIFF
--- a/core/src/com/unciv/ui/components/LineChart.kt
+++ b/core/src/com/unciv/ui/components/LineChart.kt
@@ -3,6 +3,7 @@ package com.unciv.ui.components
 import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.graphics.g2d.Batch
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer
+import com.badlogic.gdx.math.MathUtils.lerp
 import com.badlogic.gdx.math.Matrix4
 import com.badlogic.gdx.math.Vector2
 import com.badlogic.gdx.scenes.scene2d.ui.Label
@@ -53,6 +54,16 @@ class LineChart(
 
 
 
+    fun getTurnAt(x: Float): Int {
+        if (xLabels.isEmpty() || xLabelsAsLabels.isEmpty()) return -1
+        val startPoint = xLabelsAsLabels.first().x
+        val endPoint = xLabelsAsLabels.last().x
+        if (startPoint.compareTo(endPoint) == 0) return xLabels.last()
+        val ratio = (x - startPoint) / (endPoint - startPoint)
+        val turn = lerp(xLabels.first().toFloat(), xLabels.last().toFloat(), ratio)
+        return ceil(turn).toInt()
+    }
+
     fun update(newData: List<DataPoint<Int>>, newSelectedCiv: Civilization) {
         selectedCiv = newSelectedCiv
 
@@ -71,6 +82,7 @@ class LineChart(
     }
 
     private fun generateLabels(value: List<DataPoint<Int>>, yAxis: Boolean): List<Int> {
+        if (value.isEmpty()) return listOf(0)
         val minLabelValue = getPrevNumberDivisibleByPowOfTen(value.minOf { if (yAxis) it.y else it.x })
         val maxLabelValue = getNextNumberDivisibleByPowOfTen(value.maxOf { if (yAxis) it.y else it.x })
         var stepSizePositive = ceil(maxLabelValue.toFloat() / maxLabels).toInt()

--- a/core/src/com/unciv/ui/components/LineChart.kt
+++ b/core/src/com/unciv/ui/components/LineChart.kt
@@ -82,7 +82,7 @@ class LineChart(
             yLabels.map { Label(it.toString(), Label.LabelStyle(Fonts.font, axisLabelColor)) }
     }
 
-    private fun generateLabels(value: List<DataPoint<Int>>, yAxis: Boolean): List<Int> {
+    fun generateLabels(value: List<DataPoint<Int>>, yAxis: Boolean): List<Int> {
         if (value.isEmpty()) return listOf(0)
         val minLabelValue = getPrevNumberDivisibleByPowOfTen(value.minOf { if (yAxis) it.y else it.x })
         val maxLabelValue = getNextNumberDivisibleByPowOfTen(value.maxOf { if (yAxis) it.y else it.x })

--- a/core/src/com/unciv/ui/components/LineChart.kt
+++ b/core/src/com/unciv/ui/components/LineChart.kt
@@ -23,9 +23,7 @@ import kotlin.math.sqrt
 data class DataPoint<T>(val x: T, val y: T, val civ: Civilization)
 
 class LineChart(
-    private var dataPoints: List<DataPoint<Int>>,
     private val viewingCiv: Civilization,
-    private var selectedCiv: Civilization,
     private val chartWidth: Float,
     private val chartHeight: Float
 ) : Widget() {
@@ -45,28 +43,29 @@ class LineChart(
      * as `0` is not counted. */
     private val maxLabels = 10
 
-    private var xLabels: List<Int>
-    private var yLabels: List<Int>
+    private var xLabels = emptyList<Int>()
+    private var yLabels = emptyList<Int>()
 
-    private var hasNegativeYValues: Boolean
-    private var negativeYLabel: Int
+    private var hasNegativeYValues: Boolean = false
+    private var negativeYLabel: Int = 0
 
-    init {
-        hasNegativeYValues = dataPoints.any { it.y < 0 }
-        xLabels = generateLabels(dataPoints.maxOf { it.x })
-        yLabels = generateLabels(dataPoints.maxOf { it.y })
-        val lowestValue = dataPoints.minOf { it.y }
-        negativeYLabel = if (hasNegativeYValues) -getNextNumberDivisibleByPowOfTen(-lowestValue) else 0
-    }
+    private var dataPoints = emptyList<DataPoint<Int>>()
+    private var selectedCiv = Civilization()
+
+
 
     fun update(newData: List<DataPoint<Int>>, newSelectedCiv: Civilization) {
-        dataPoints = newData
         selectedCiv = newSelectedCiv
 
-        hasNegativeYValues = dataPoints.any { it.y < 0 }
-        xLabels = generateLabels(dataPoints.maxOf { it.x })
-        yLabels = generateLabels(dataPoints.maxOf { it.y })
-        val lowestValue = dataPoints.minOf { it.y }
+        dataPoints = newData
+        updateLabels(dataPoints)
+    }
+
+    private fun updateLabels(newData: List<DataPoint<Int>>) {
+        hasNegativeYValues = newData.any { it.y < 0 }
+        xLabels = generateLabels(newData.maxOf { it.x })
+        yLabels = generateLabels(newData.maxOf { it.y })
+        val lowestValue = newData.minOf { it.y }
         negativeYLabel = if (hasNegativeYValues) -getNextNumberDivisibleByPowOfTen(-lowestValue) else 0
     }
 
@@ -93,6 +92,7 @@ class LineChart(
 
     override fun draw(batch: Batch, parentAlpha: Float) {
         super.draw(batch, parentAlpha)
+        if (xLabels.isEmpty() || yLabels.isEmpty()) return
 
         // Save the current batch transformation matrix
         val oldTransformMatrix = batch.transformMatrix.cpy()

--- a/core/src/com/unciv/ui/components/LineChart.kt
+++ b/core/src/com/unciv/ui/components/LineChart.kt
@@ -46,9 +46,14 @@ class LineChart(
 
     private var xLabels = emptyList<Int>()
     private var yLabels = emptyList<Int>()
+    private var xLabelsAsLabels = emptyList<Label>()
+    private var yLabelsAsLabels = emptyList<Label>()
+
 
     private var hasNegativeYValues: Boolean = false
     private var negativeYLabel: Int = 0
+    private var negativeYLabelAsLabel = Label("0", Label.LabelStyle(Fonts.font, axisLabelColor))
+
 
     private var dataPoints = emptyList<DataPoint<Int>>()
     private var selectedCiv = Civilization()
@@ -66,8 +71,16 @@ class LineChart(
         hasNegativeYValues = newData.any { it.y < 0 }
         xLabels = generateLabels(newData.maxOf { it.x })
         yLabels = generateLabels(newData.maxOf { it.y })
+
+        xLabelsAsLabels =
+            xLabels.map { Label(it.toString(), Label.LabelStyle(Fonts.font, axisLabelColor)) }
+        yLabelsAsLabels =
+            yLabels.map { Label(it.toString(), Label.LabelStyle(Fonts.font, axisLabelColor)) }
+
         val lowestValue = newData.minOf { it.y }
         negativeYLabel = if (hasNegativeYValues) -getNextNumberDivisibleByPowOfTen(-lowestValue) else 0
+        negativeYLabelAsLabel =
+            Label(negativeYLabel.toString(), Label.LabelStyle(Fonts.font, axisLabelColor))
     }
 
     private fun generateLabels(maxValue: Int): List<Int> {
@@ -103,11 +116,7 @@ class LineChart(
 
         val lastTurnDataPoints = getLastTurnDataPoints()
 
-        val labelHeight = Label("123", Label.LabelStyle(Fonts.font, axisLabelColor)).height
-        val yLabelsAsLabels =
-                yLabels.map { Label(it.toString(), Label.LabelStyle(Fonts.font, axisLabelColor)) }
-        val negativeYLabelAsLabel =
-                Label(negativeYLabel.toString(), Label.LabelStyle(Fonts.font, axisLabelColor))
+        val labelHeight = yLabelsAsLabels.first().height
         val widestYLabelWidth = max(yLabelsAsLabels.maxOf { it.width }, negativeYLabelAsLabel.width)
         // We assume here that all labels have the same height. We need to deduct the height of
         // a label from the available height, because otherwise the label on the top would
@@ -148,15 +157,12 @@ class LineChart(
         }
 
         // Draw x-axis labels
-        val xLabelsAsLabels =
-                xLabels.map { Label(it.toString(), Label.LabelStyle(Fonts.font, axisLabelColor)) }
         val lastXAxisLabelWidth = xLabelsAsLabels[xLabelsAsLabels.size - 1].width
         val xAxisLabelMinX =
                 widestYLabelWidth + axisToLabelPadding + axisLineWidth / 2
         val xAxisLabelMaxX = chartWidth - lastXAxisLabelWidth / 2
         val xAxisLabelXRange = xAxisLabelMaxX - xAxisLabelMinX
-        xLabels.forEachIndexed { index, labelAsInt ->
-            val label = Label(labelAsInt.toString(), Label.LabelStyle(Fonts.font, axisLabelColor))
+        xLabelsAsLabels.forEachIndexed { index, label ->
             val xPos = xAxisLabelMinX + index * (xAxisLabelXRange / (xLabels.size - 1))
             label.setPosition(xPos - label.width / 2, 0f)
             label.draw(batch, 1f)

--- a/core/src/com/unciv/ui/components/LineChart.kt
+++ b/core/src/com/unciv/ui/components/LineChart.kt
@@ -11,6 +11,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.Widget
 import com.badlogic.gdx.utils.Align
 import com.unciv.logic.civilization.Civilization
 import com.unciv.ui.components.extensions.surroundWithCircle
+import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.screens.victoryscreen.VictoryScreenCivGroup
 import com.unciv.ui.screens.victoryscreen.VictoryScreenCivGroup.DefeatedPlayerStyle
 import kotlin.math.min
@@ -223,16 +224,7 @@ class LineChart(
 
                 // Draw the selected Civ icon on its last datapoint
                 if (i == simplifiedScaledPoints.size - 1 && selectedCiv == civ && selectedCiv in lastTurnDataPoints) {
-                    val selectedCivIcon =
-                            VictoryScreenCivGroup(
-                                selectedCiv,
-                                "",
-                                viewingCiv,
-                                DefeatedPlayerStyle.REGULAR
-                            ).children[0].run {
-                                (this as? Image)?.surroundWithCircle(30f, color = Color.LIGHT_GRAY)
-                                    ?: this
-                            }
+                    val selectedCivIcon = VictoryScreenCivGroup.getCivImageAndColors(selectedCiv, viewingCiv, DefeatedPlayerStyle.REGULAR).first
                     selectedCivIcon.run {
                         setPosition(b.x, b.y, Align.center)
                         setSize(33f, 33f) // Dead Civs need this

--- a/core/src/com/unciv/ui/components/LineChart.kt
+++ b/core/src/com/unciv/ui/components/LineChart.kt
@@ -138,25 +138,24 @@ class LineChart(
         // We draw the y-axis labels first. They will take away some space on the left of the
         // widget which we need to consider when drawing the rest of the graph.
         var yAxisYPosition = 0f
-        val negativeOrientationLineYPosition = yAxisLabelMinY + labelHeight / 2
-        val yLabelsToDraw = yLabelsAsLabels
-        yLabelsToDraw.forEachIndexed { index, label ->
-            val yPos = yAxisLabelMinY + index * (yAxisLabelYRange / (yLabelsToDraw.size - 1))
+        yLabels.forEachIndexed { index, value ->
+            val label = yLabelsAsLabels[index] // we assume yLabels.size == yLabelsAsLabels.size
+            val yPos = yAxisLabelMinY + index * (yAxisLabelYRange / (yLabels.size - 1))
             label.setPosition((widestYLabelWidth - label.width) / 2, yPos)
             label.draw(batch, 1f)
 
             // Draw y-axis orientation lines and x-axis
-            val zeroIndex = 0
+            val zeroIndex = value == 0
             drawLine(
                 batch,
                 widestYLabelWidth + axisToLabelPadding + axisLineWidth,
                 yPos + labelHeight / 2,
                 chartWidth,
                 yPos + labelHeight / 2,
-                if (index != zeroIndex) orientationLineColor else axisColor,
-                if (index != zeroIndex) orientationLineWidth else axisLineWidth
+                if (zeroIndex) axisColor else orientationLineColor,
+                if (zeroIndex) axisLineWidth else orientationLineWidth
             )
-            if (index == zeroIndex) {
+            if (zeroIndex) {
                 yAxisYPosition = yPos + labelHeight / 2
             }
         }
@@ -180,7 +179,7 @@ class LineChart(
                 xPos,
                 chartHeight,
                 if (index > 0) orientationLineColor else axisColor,
-                if (index >0) orientationLineWidth else axisLineWidth
+                if (index > 0) orientationLineWidth else axisLineWidth
             )
         }
 

--- a/core/src/com/unciv/ui/components/LineChart.kt
+++ b/core/src/com/unciv/ui/components/LineChart.kt
@@ -20,12 +20,12 @@ import kotlin.math.max
 import kotlin.math.pow
 import kotlin.math.sqrt
 
-private data class DataPoint<T>(val x: T, val y: T, val civ: Civilization)
+data class DataPoint<T>(val x: T, val y: T, val civ: Civilization)
 
 class LineChart(
-    data: Map<Int, Map<Civilization, Int>>,
+    private var dataPoints: List<DataPoint<Int>>,
     private val viewingCiv: Civilization,
-    private val selectedCiv: Civilization,
+    private var selectedCiv: Civilization,
     private val chartWidth: Float,
     private val chartHeight: Float
 ) : Widget() {
@@ -45,19 +45,24 @@ class LineChart(
      * as `0` is not counted. */
     private val maxLabels = 10
 
-    private val xLabels: List<Int>
-    private val yLabels: List<Int>
+    private var xLabels: List<Int>
+    private var yLabels: List<Int>
 
-    private val hasNegativeYValues: Boolean
-    private val negativeYLabel: Int
-
-    private val dataPoints: List<DataPoint<Int>> = data.flatMap { turn ->
-        turn.value.map { (civ, value) ->
-            DataPoint(turn.key, value, civ)
-        }
-    }
+    private var hasNegativeYValues: Boolean
+    private var negativeYLabel: Int
 
     init {
+        hasNegativeYValues = dataPoints.any { it.y < 0 }
+        xLabels = generateLabels(dataPoints.maxOf { it.x })
+        yLabels = generateLabels(dataPoints.maxOf { it.y })
+        val lowestValue = dataPoints.minOf { it.y }
+        negativeYLabel = if (hasNegativeYValues) -getNextNumberDivisibleByPowOfTen(-lowestValue) else 0
+    }
+
+    fun update(newData: List<DataPoint<Int>>, newSelectedCiv: Civilization) {
+        dataPoints = newData
+        selectedCiv = newSelectedCiv
+
         hasNegativeYValues = dataPoints.any { it.y < 0 }
         xLabels = generateLabels(dataPoints.maxOf { it.x })
         yLabels = generateLabels(dataPoints.maxOf { it.y })

--- a/core/src/com/unciv/ui/screens/victoryscreen/VictoryScreenCharts.kt
+++ b/core/src/com/unciv/ui/screens/victoryscreen/VictoryScreenCharts.kt
@@ -41,7 +41,7 @@ class VictoryScreenCharts(
     private var lineChart : LineChart? = null
     private val chartHolder = Container(lineChart)
     // if it is negative - no zoom, if positive - zoom at turn X
-    private var zoomAtX : Int = -1
+    private var zoomAtX : IntRange? = null
     private val zoomSize = 10
 
     init {
@@ -103,7 +103,7 @@ class VictoryScreenCharts(
             )
             chartHolder.actor = lineChart
             val onChartClick = OnClickListener(function = { _ , x, _ ->
-                zoomAtX = if (zoomAtX < 0) lineChart!!.getTurnAt(x) else -1
+                zoomAtX = if (zoomAtX == null) lineChart!!.getTurnAt(x) else null
                 updateChart()
             })
             lineChart?.addListener(onChartClick)
@@ -117,7 +117,7 @@ class VictoryScreenCharts(
             .filter { it.isMajorCiv() }
             .flatMap { civ ->
                 civ.statsHistory
-                    .filterKeys { zoomAtX < 0 || abs(it - zoomAtX) <= zoomSize  }
+                    .filterKeys { zoomAtX == null || it in zoomAtX!!  }
                     .filterValues { it.containsKey(rankingType) }
                     .map { (turn, data) -> Pair(turn, Pair(civ, data.getValue(rankingType))) }
             }

--- a/core/src/com/unciv/ui/screens/victoryscreen/VictoryScreenCharts.kt
+++ b/core/src/com/unciv/ui/screens/victoryscreen/VictoryScreenCharts.kt
@@ -92,15 +92,13 @@ class VictoryScreenCharts(
         if (lineChart == null)
         {
             lineChart = LineChart(
-                getLineChartData(rankingType),
                 viewingCiv,
-                selectedCiv,
                 parent.width - getColumnWidth(0) - 60f,
                 parent.height - 60f
             )
             chartHolder.actor = lineChart
-        } else
-            lineChart?.update(getLineChartData(rankingType), selectedCiv)
+        }
+        lineChart?.update(getLineChartData(rankingType), selectedCiv)
         chartHolder.invalidateHierarchy()
     }
 

--- a/tests/src/com/unciv/ui/components/LineChartTests.kt
+++ b/tests/src/com/unciv/ui/components/LineChartTests.kt
@@ -7,7 +7,7 @@ import org.junit.Test
 class LineChartTests {
 
     private val civ = Civilization("My civ")
-    private val lineChart = LineChart(Civilization(civ.civName), 200f, 100f)
+    private val lineChart = LineChart(Civilization(civ.civName))
 
     @Test
     fun `labels for an empty list are just 0 label`() {

--- a/tests/src/com/unciv/ui/components/LineChartTests.kt
+++ b/tests/src/com/unciv/ui/components/LineChartTests.kt
@@ -1,0 +1,140 @@
+package com.unciv.ui.components
+
+import com.unciv.logic.civilization.Civilization
+import org.junit.Assert
+import org.junit.Test
+
+class LineChartTests {
+
+    private val civ = Civilization("My civ")
+    private val lineChart = LineChart(Civilization(civ.civName), 200f, 100f)
+
+    @Test
+    fun `labels for an empty list are just 0 label`() {
+        val data = mutableListOf <DataPoint<Int>>()
+        val result = lineChart.generateLabels(data, true)
+        Assert.assertTrue(result.size == 1 && result[0] == 0)
+    }
+
+    @Test
+    fun `chart goes along 0 line`() {
+        val data = mutableListOf <DataPoint<Int>>()
+        data.add(DataPoint(0,0, civ))
+        data.add(DataPoint(1,0, civ))
+        data.add(DataPoint(2,0, civ))
+        val result = lineChart.generateLabels(data, true)
+        Assert.assertTrue(result.size == 2 && result[0] == 0 && result[1] == 1)
+    }
+
+    @Test
+    fun `chart is from 0 to the positive value`() {
+        val data = mutableListOf <DataPoint<Int>>()
+        data.add(DataPoint(0,-100, civ))
+        data.add(DataPoint(1,200, civ))
+        data.add(DataPoint(2,1600, civ))
+        val result = lineChart.generateLabels(data, false) // testing the X axis
+        Assert.assertTrue(result.size == 11 && result.first() == 0 && result[1] == 1 && result.last() == 10)
+    }
+
+    @Test
+    fun `chart is from 0 to the negative value`() {
+        val data = mutableListOf <DataPoint<Int>>()
+        data.add(DataPoint(0,0, civ))
+        data.add(DataPoint(1,-2, civ))
+        data.add(DataPoint(2,-6, civ))
+        val result = lineChart.generateLabels(data, true) // testing the Y axis
+        Assert.assertTrue(result.size == 11 && result.first() == -10 && result[1] == -9 && result.last() == 0)
+    }
+
+    @Test
+    fun `chart goes from the negative to the positive value near 0`() {
+        val data = mutableListOf <DataPoint<Int>>()
+        data.add(DataPoint(0,-5, civ))
+        data.add(DataPoint(1,2, civ))
+        data.add(DataPoint(2,6, civ))
+        val result = lineChart.generateLabels(data, true)
+        Assert.assertTrue(result.size == 21 && result.first() == -10 && result[1] == -9 && result.last() == 10)
+    }
+
+    @Test
+    fun `chart goes from the negative to the positive far from 0`() {
+        val data = mutableListOf <DataPoint<Int>>()
+        data.add(DataPoint(0,-59, civ))
+        data.add(DataPoint(1,191, civ))
+        data.add(DataPoint(2,160, civ))
+        val result = lineChart.generateLabels(data, true)
+        Assert.assertTrue(result.size == 14 && result.first() == -60 && result[1] == -40 && result[3] == 0 && result.last() == 200)
+    }
+
+    @Test
+    fun `chart goes from the positive to the negative far from 0`() {
+        val data = mutableListOf <DataPoint<Int>>()
+        data.add(DataPoint(0,-485, civ))
+        data.add(DataPoint(1,191, civ))
+        data.add(DataPoint(2,160, civ))
+        val result = lineChart.generateLabels(data, true)
+        Assert.assertTrue(result.size == 15 && result.first() == -500 && result[1] == -450 && result[10] == 0 && result.last() == 200)
+    }
+
+    @Test
+    fun `chart is within the positive values far from 0`() {
+        val data = mutableListOf <DataPoint<Int>>()
+        data.add(DataPoint(0,290, civ))
+        data.add(DataPoint(1,1159, civ))
+        data.add(DataPoint(2,280, civ))
+        val result = lineChart.generateLabels(data, true)
+        Assert.assertTrue(result.size == 11 && result.first() == 200 && result[1] == 300 && result.last() == 1200)
+    }
+
+    @Test
+    fun `chart is within the negative values far from 0`() {
+        val data = mutableListOf <DataPoint<Int>>()
+        data.add(DataPoint(0,-290, civ))
+        data.add(DataPoint(1,-1160, civ))
+        data.add(DataPoint(2,-280, civ))
+        val result = lineChart.generateLabels(data, true)
+        Assert.assertTrue(result.size == 10 && result.first() == -1200 && result[1] == -1080 && result.last() == -120)
+    }
+
+
+    @Test
+    fun `chart is within the positive values near 0`() {
+        val data = mutableListOf <DataPoint<Int>>()
+        data.add(DataPoint(0,180, civ))
+        data.add(DataPoint(1,1101, civ))
+        data.add(DataPoint(2,980, civ))
+        val result = lineChart.generateLabels(data, true)
+        Assert.assertTrue(result.size == 11 && result.first() == 0 && result[1] == 120 && result.last() == 1200)
+    }
+
+    @Test
+    fun `chart is within the negative values near 0`() {
+        val data = mutableListOf <DataPoint<Int>>()
+        data.add(DataPoint(0,-180, civ))
+        data.add(DataPoint(1,-1101, civ))
+        data.add(DataPoint(2,-980, civ))
+        val result = lineChart.generateLabels(data, true)
+        Assert.assertTrue(result.size == 11 && result.first() == -1200 && result[1] == -1080 && result.last() == 0)
+    }
+
+    @Test
+    fun `chart is mostly in the positive values but not only`() {
+        val data = mutableListOf <DataPoint<Int>>()
+        data.add(DataPoint(0,210, civ))
+        data.add(DataPoint(1,1101, civ))
+        data.add(DataPoint(2,-89, civ))
+        val result = lineChart.generateLabels(data, true)
+        Assert.assertTrue(result.size == 12 && result.first() == -90 && result[1] == 0 && result.last() == 1200)
+    }
+
+    @Test
+    fun `chart is mostly in the negative values but not only`() {
+        val data = mutableListOf <DataPoint<Int>>()
+        data.add(DataPoint(0,111, civ))
+        data.add(DataPoint(1,-2101, civ))
+        data.add(DataPoint(2,-345, civ))
+        val result = lineChart.generateLabels(data, true)
+        Assert.assertTrue(result.size == 12 && result.first() == -2200 && result[10] == 0 && result.last() == 200)
+    }
+
+}


### PR DESCRIPTION
The `LineChart` control has been totally rewritten.
The key improvements are:
* No objects are created during the `draw()` - less memory usage
* The drawing happens in the same batch as other controls - improved performance
* The drawing happens by native 2D libGdx controls, not using 3D shape renderer
* There is an autoscaling based on the data to be displayed (e.g. from 100 to 200, not permanently from 0 to X)
* The negative axis is not limited by just 1 step

And of course, the primary change: zoom in and out by click on the certain area of the chart.


https://github.com/yairm210/Unciv/assets/27405436/ba73619c-c88a-4be8-8b03-864c5c42e0d2


