### PR TITLE
Check for trigger uniques when starting and recaluating population

### DIFF
--- a/core/src/com/unciv/UncivGame.kt
+++ b/core/src/com/unciv/UncivGame.kt
@@ -79,6 +79,7 @@ object GUI {
     }
 
     fun isMyTurn(): Boolean {
+        if (!UncivGame.isCurrentInitialized() || !isWorldLoaded()) return false
         return UncivGame.Current.worldScreen!!.isPlayersTurn
     }
 

--- a/core/src/com/unciv/logic/GameStarter.kt
+++ b/core/src/com/unciv/logic/GameStarter.kt
@@ -19,6 +19,8 @@ import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.ruleset.RulesetCache
 import com.unciv.models.ruleset.unique.StateForConditionals
 import com.unciv.models.ruleset.unique.UniqueType
+import com.unciv.models.ruleset.unique.UniqueType.UniqueTarget
+import com.unciv.models.ruleset.unique.UniqueTriggerActivation
 import com.unciv.models.ruleset.unit.BaseUnit
 import com.unciv.models.stats.Stats
 import com.unciv.models.translations.equalsPlaceholderText

--- a/core/src/com/unciv/logic/GameStarter.kt
+++ b/core/src/com/unciv/logic/GameStarter.kt
@@ -19,7 +19,7 @@ import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.ruleset.RulesetCache
 import com.unciv.models.ruleset.unique.StateForConditionals
 import com.unciv.models.ruleset.unique.UniqueType
-import com.unciv.models.ruleset.unique.UniqueType.UniqueTarget
+import com.unciv.models.ruleset.unique.UniqueTarget
 import com.unciv.models.ruleset.unique.UniqueTriggerActivation
 import com.unciv.models.ruleset.unit.BaseUnit
 import com.unciv.models.stats.Stats

--- a/core/src/com/unciv/logic/civilization/diplomacy/CityStateFunctions.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/CityStateFunctions.kt
@@ -31,10 +31,6 @@ class CityStateFunctions(val civInfo: Civilization) {
 
     /** Attempts to initialize the city state, returning true if successful. */
     fun initCityState(ruleset: Ruleset, startingEra: String, unusedMajorCivs: Collection<String>): Boolean {
-        val startingTechs = ruleset.technologies.values.filter { it.hasUnique(UniqueType.StartingTech) }
-        for (tech in startingTechs)
-            civInfo.tech.techsResearched.add(tech.name) // can't be .addTechnology because the civInfo isn't assigned yet
-
         val allMercantileResources = ruleset.tileResources.values.filter { it.hasUnique(UniqueType.CityStateOnlyResource) }.map { it.name }
         val uniqueTypes = HashSet<UniqueType>()    // We look through these to determine what kinds of city states we have
 

--- a/core/src/com/unciv/logic/civilization/managers/PolicyManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/PolicyManager.kt
@@ -195,6 +195,8 @@ class PolicyManager : IsPartOfGameInfoSerialization {
             if (branch.policies.count { isAdopted(it.name) } == branch.policies.size - 1) { // All done apart from branch completion
                 adopt(branch.policies.last(), true) // add branch completion!
             }
+            for(city in civInfo.cities)
+                city.reassignPopulationDeferred()
         }
 
         // Todo make this a triggerable unique for other objects

--- a/core/src/com/unciv/logic/civilization/managers/PolicyManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/PolicyManager.kt
@@ -195,8 +195,6 @@ class PolicyManager : IsPartOfGameInfoSerialization {
             if (branch.policies.count { isAdopted(it.name) } == branch.policies.size - 1) { // All done apart from branch completion
                 adopt(branch.policies.last(), true) // add branch completion!
             }
-            for(city in civInfo.cities)
-                city.reassignPopulationDeferred()
         }
 
         // Todo make this a triggerable unique for other objects
@@ -216,7 +214,10 @@ class PolicyManager : IsPartOfGameInfoSerialization {
         civInfo.cache.updateCivResources()
 
         // This ALSO has the side-effect of updating the CivInfo statForNextTurn so we don't need to call it explicitly
-        for (cityInfo in civInfo.cities) cityInfo.cityStats.update()
+        for (cityInfo in civInfo.cities) {
+            cityInfo.cityStats.update()
+            cityInfo.reassignPopulationDeferred()
+        }
 
         if (!canAdoptPolicy()) shouldOpenPolicyPicker = false
     }

--- a/core/src/com/unciv/logic/civilization/managers/TechManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/TechManager.kt
@@ -276,7 +276,7 @@ class TechManager : IsPartOfGameInfoSerialization {
         addTechnology(techName)
     }
 
-    fun addTechnology(techName: String) {
+    fun addTechnology(techName: String, showNotification: Boolean = true) {
         val isNewTech = techsResearched.add(techName)
 
         // this is to avoid concurrent modification problems
@@ -305,7 +305,7 @@ class TechManager : IsPartOfGameInfoSerialization {
             city.reassignPopulationDeferred()   
         }
 
-        if (!civInfo.isSpectator())
+        if (!civInfo.isSpectator() && showNotification)
             civInfo.addNotification("Research of [$techName] has completed!", TechAction(techName),
                 NotificationCategory.General,
                 NotificationIcon.Science)
@@ -335,7 +335,7 @@ class TechManager : IsPartOfGameInfoSerialization {
                 MayaLongCountAction(), NotificationCategory.General, MayaCalendar.notificationIcon)
         }
 
-        moveToNewEra()
+        moveToNewEra(showNotification)
         updateResearchProgress()
     }
 
@@ -390,34 +390,36 @@ class TechManager : IsPartOfGameInfoSerialization {
         }
     }
 
-    private fun moveToNewEra() {
+    private fun moveToNewEra(showNotification: Boolean = true) {
         val previousEra = civInfo.getEra()
         updateEra()
         val currentEra = civInfo.getEra()
         if (previousEra != currentEra) {
-            if(!civInfo.isSpectator())
-                civInfo.addNotification(
-                    "You have entered the [$currentEra]!",
-                    NotificationCategory.General,
-                    NotificationIcon.Science
-                )
-            if (civInfo.isMajorCiv()) {
-                for (knownCiv in civInfo.getKnownCivs()) {
-                    knownCiv.addNotification(
-                        "[${civInfo.civName}] has entered the [$currentEra]!",
-                        NotificationCategory.General, civInfo.civName, NotificationIcon.Science
-                    )
-                }
-            }
-            for (policyBranch in getRuleset().policyBranches.values.filter {
-                it.era == currentEra.name && civInfo.policies.isAdoptable(it)
-            }) {
-                if (!civInfo.isSpectator())
+            if(showNotification) {
+                if(!civInfo.isSpectator())
                     civInfo.addNotification(
-                        "[${policyBranch.name}] policy branch unlocked!",
+                        "You have entered the [$currentEra]!",
                         NotificationCategory.General,
-                        NotificationIcon.Culture
+                        NotificationIcon.Science
                     )
+                if (civInfo.isMajorCiv()) {
+                    for (knownCiv in civInfo.getKnownCivs()) {
+                        knownCiv.addNotification(
+                            "[${civInfo.civName}] has entered the [$currentEra]!",
+                            NotificationCategory.General, civInfo.civName, NotificationIcon.Science
+                        )
+                    }
+                }
+                for (policyBranch in getRuleset().policyBranches.values.filter {
+                    it.era == currentEra.name && civInfo.policies.isAdoptable(it)
+                }) {
+                    if (!civInfo.isSpectator())
+                        civInfo.addNotification(
+                            "[${policyBranch.name}] policy branch unlocked!",
+                            NotificationCategory.General,
+                            NotificationIcon.Culture
+                        )
+                }
             }
 
             val erasPassed = getRuleset().eras.values


### PR DESCRIPTION
This PR does the following
- Checks tech uniques for starting techs
- Checks nation and global uniques when starting (allows for just having a trigger immediately as a game starts)
- Reassign population upon getting a tech or getting a policy
- Recalculate resources always after getting a tech. Techs can give resources, so it may not be correct to assume that no new visible resources means no need to recalculate

I'm sure there's a better way to add the global checks than adding the checks to `determineStartingUnitsAndLocations` but I'm drawing blanks for now. I'm also sure the uniques that give a free unit should probably allow for placing a unit at a location and not just a city, but I'll leave that for another time