### PR TITLE
Minimal support for Alpha Frontier-like Workers

### DIFF
--- a/core/src/com/unciv/logic/automation/unit/SpecificUnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/SpecificUnitAutomation.kt
@@ -6,7 +6,6 @@ import com.unciv.logic.battle.Battle
 import com.unciv.logic.battle.GreatGeneralImplementation
 import com.unciv.logic.battle.MapUnitCombatant
 import com.unciv.logic.city.City
-import com.unciv.logic.civilization.Civilization
 import com.unciv.logic.civilization.diplomacy.DiplomaticModifiers
 import com.unciv.logic.map.mapunit.MapUnit
 import com.unciv.logic.map.tile.Tile
@@ -19,32 +18,6 @@ import com.unciv.ui.screens.worldscreen.unit.actions.UnitActions
 import com.unciv.ui.screens.worldscreen.unit.actions.UnitActionsReligion
 
 object SpecificUnitAutomation {
-
-    private fun hasWorkableSeaResource(tile: Tile, civInfo: Civilization): Boolean =
-            tile.isWater && tile.improvement == null && tile.hasViewableResource(civInfo)
-
-    fun automateWorkBoats(unit: MapUnit) {
-        val closestReachableResource = unit.civ.cities.asSequence()
-                .flatMap { city -> city.getWorkableTiles() }
-                .filter {
-                    hasWorkableSeaResource(it, unit.civ)
-                            && (unit.currentTile == it || unit.movement.canMoveTo(it))
-                }
-                .sortedBy { it.aerialDistanceTo(unit.currentTile) }
-                .firstOrNull { unit.movement.canReach(it) }
-
-        when (closestReachableResource) {
-            null -> UnitAutomation.tryExplore(unit)
-            else -> {
-                unit.movement.headTowards(closestReachableResource)
-
-                // could be either fishing boats or oil well
-                val isImprovable = closestReachableResource.tileResource.getImprovements().any()
-                if (isImprovable && unit.currentTile == closestReachableResource)
-                    UnitActions.getWaterImprovementAction(unit)?.action?.invoke()
-            }
-        }
-    }
 
     fun automateGreatGeneral(unit: MapUnit): Boolean {
         //try to follow nearby units. Do not garrison in city if possible

--- a/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
@@ -251,6 +251,9 @@ object UnitAutomation {
         if (unit.cache.hasUniqueToBuildImprovements)
             return unit.civ.getWorkerAutomation().automateWorkerAction(unit, tilesWhereWeWillBeCaptured)
 
+        if (unit.cache.hasUniqueToCreateWaterImprovements)
+            return SpecificUnitAutomation.automateWorkBoats(unit)
+
         if (unit.hasUnique(UniqueType.MayFoundReligion)
                 && unit.civ.religionManager.religionState < ReligionState.Religion
                 && unit.civ.religionManager.mayFoundReligionAtAll(unit)
@@ -262,9 +265,6 @@ object UnitAutomation {
                 && unit.civ.religionManager.mayEnhanceReligionAtAll(unit)
         )
             return SpecificUnitAutomation.enhanceReligion(unit)
-
-        if (unit.hasUnique(UniqueType.CreateWaterImprovements))
-            return SpecificUnitAutomation.automateWorkBoats(unit)
 
         // We try to add any unit in the capital we can, though that might not always be desirable
         // For now its a simple option to allow AI to win a science victory again

--- a/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
@@ -693,7 +693,7 @@ object UnitAutomation {
     }
 
     private fun tryTakeBackCapturedCity(unit: MapUnit): Boolean {
-        var capturedCities = unit.civ.getKnownCivs().asSequence()
+        var capturedCities = unit.civ.getKnownCivs() // This is a Sequence
                 .flatMap { it.cities.asSequence() }
                 .filter {
                     unit.civ.isAtWarWith(it.civ) &&

--- a/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
@@ -251,8 +251,11 @@ object UnitAutomation {
         if (unit.cache.hasUniqueToBuildImprovements)
             return unit.civ.getWorkerAutomation().automateWorkerAction(unit, tilesWhereWeWillBeCaptured)
 
-        if (unit.cache.hasUniqueToCreateWaterImprovements)
-            return SpecificUnitAutomation.automateWorkBoats(unit)
+        if (unit.cache.hasUniqueToCreateWaterImprovements){
+            if (!unit.civ.getWorkerAutomation().automateWorkBoats(unit))
+                tryExplore(unit)
+            return
+        }
 
         if (unit.hasUnique(UniqueType.MayFoundReligion)
                 && unit.civ.religionManager.religionState < ReligionState.Religion

--- a/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
@@ -120,7 +120,7 @@ class WorkerAutomation(
         val currentTile = unit.getTile()
         val tileToWork = findTileToWork(unit, tilesWhereWeWillBeCaptured)
 
-        if (civInfo.getWorkerAutomation().getPriority(tileToWork) < 3) { // building roads is more important
+        if (getPriority(tileToWork) < 3) { // building roads is more important
             if (tryConnectingCities(unit)) return
         }
 

--- a/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
@@ -161,6 +161,12 @@ class WorkerAutomation(
         }
 
         if (currentTile.improvementInProgress != null) return // we're working!
+
+        if (unit.cache.hasUniqueToCreateWaterImprovements) {
+            // Support Alpha Frontier-Style Workers that _also_ have the "May create improvements on water resources" unique
+            if (automateWorkBoats(unit)) return
+        }
+
         if (tryConnectingCities(unit)) return //nothing to do, try again to connect cities
 
         val citiesToNumberOfUnimprovedTiles = HashMap<String, Int>()

--- a/core/src/com/unciv/logic/map/mapunit/MapUnitCache.kt
+++ b/core/src/com/unciv/logic/map/mapunit/MapUnitCache.kt
@@ -65,6 +65,7 @@ class MapUnitCache(private val mapUnit: MapUnit) {
     var paradropRange = 0
 
     var hasUniqueToBuildImprovements = false    // not canBuildImprovements to avoid confusion
+    var hasUniqueToCreateWaterImprovements = false
 
     var hasStrengthBonusInRadiusUnique = false
 
@@ -113,6 +114,8 @@ class MapUnitCache(private val mapUnit: MapUnit) {
         )
 
         hasUniqueToBuildImprovements = mapUnit.hasUnique(UniqueType.BuildImprovements)
+        hasUniqueToCreateWaterImprovements = mapUnit.hasUnique(UniqueType.CreateWaterImprovements)
+
         canEnterForeignTerrain = mapUnit.hasUnique(UniqueType.CanEnterForeignTiles)
                 || mapUnit.hasUnique(UniqueType.CanEnterForeignTilesButLosesReligiousStrength)
 

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActions.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActions.kt
@@ -180,11 +180,11 @@ object UnitActions {
       */
     fun getFoundCityAction(unit: MapUnit, tile: Tile): UnitAction? {
         val unique = unit.getMatchingUniques(UniqueType.FoundCity)
-            .filter { it.conditionals.none { it.type == UniqueType.UnitActionExtraLimitedTimes } }
+            .filter { unique -> unique.conditionals.none { it.type == UniqueType.UnitActionExtraLimitedTimes } }
             .firstOrNull()
         if (unique == null || tile.isWater || tile.isImpassible()) return null
         // Spain should still be able to build Conquistadors in a one city challenge - but can't settle them
-        if (unit.civ.isOneCityChallenger() && unit.civ.hasEverOwnedOriginalCapital == true) return null
+        if (unit.civ.isOneCityChallenger() && unit.civ.hasEverOwnedOriginalCapital) return null
         if (usagesLeft(unit, unique)==0) return null
 
         if (unit.currentMovement <= 0 || !tile.canBeSettled())
@@ -745,7 +745,7 @@ object UnitActions {
     fun getMaxUsages(unit: MapUnit, actionUnique: Unique): Int? {
         val extraTimes = unit.getMatchingUniques(actionUnique.type!!)
             .filter { it.text.removeConditionals() == actionUnique.text.removeConditionals() }
-            .flatMap { it.conditionals.filter { it.type == UniqueType.UnitActionExtraLimitedTimes } }
+            .flatMap { unique -> unique.conditionals.filter { it.type == UniqueType.UnitActionExtraLimitedTimes } }
             .map { it.params[0].toInt() }
             .sum()
 


### PR DESCRIPTION
Commit messages tell a lot.

* The "[Add a chance](https://github.com/yairm210/Unciv/commit/ed2afa4b1c8a7db89ca647fe3f03b494073031fd)" one is half of the point of this. It's minimal as it only tries the water AI when land AI reached a medium level fail. Affects only the "workboats" unique.
* The second "half" just removes blockers that kept findTileToWork from working on water when a Worker has "Can build [Water] improvements on tiles" - [later commit](https://github.com/yairm210/Unciv/pull/9690/commits/04ca43deba1764a6524b8da0397fe10fe6dd3e33).

What would really help would be a fuzzy logic so improve land could return a best "quality" and create by sacrifice on water could do the same, both are compared the better ones win. Better result for more CPU. Concept could be extended to large parts of automation...

~~UNTESTED so far~~

Tests were done, by issue OP as well. See below. Looks like sizable improvement for little work (and little risk for G&K players).
 