### PR TITLE
Better support for lacking a capital

### DIFF
--- a/core/src/com/unciv/logic/automation/Automation.kt
+++ b/core/src/com/unciv/logic/automation/Automation.kt
@@ -213,7 +213,7 @@ object Automation {
 
         // If we have vision of our entire starting continent (ish) we are not afraid
         civInfo.gameInfo.tileMap.assignContinents(TileMap.AssignContinentsMode.Ensure)
-        val startingContinent = civInfo.getCapital()!!.getCenterTile().getContinent()
+        val startingContinent = (civInfo.getCapital() ?: civInfo.cities.firstOrNull())!!.getCenterTile().getContinent()
         val startingContinentSize = civInfo.gameInfo.tileMap.continentSizes[startingContinent]
         if (startingContinentSize != null && startingContinentSize < civInfo.viewableTiles.size * multiplier)
             return false

--- a/core/src/com/unciv/logic/automation/Automation.kt
+++ b/core/src/com/unciv/logic/automation/Automation.kt
@@ -213,7 +213,7 @@ object Automation {
 
         // If we have vision of our entire starting continent (ish) we are not afraid
         civInfo.gameInfo.tileMap.assignContinents(TileMap.AssignContinentsMode.Ensure)
-        val startingContinent = (civInfo.getCapital() ?: civInfo.cities.firstOrNull())!!.getCenterTile().getContinent()
+        val startingContinent = civInfo.getCapital(true)!!.getCenterTile().getContinent()
         val startingContinentSize = civInfo.gameInfo.tileMap.continentSizes[startingContinent]
         if (startingContinentSize != null && startingContinentSize < civInfo.viewableTiles.size * multiplier)
             return false

--- a/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
@@ -838,8 +838,10 @@ object NextTurnAutomation {
         val closestCities = getClosestCities(civInfo, otherCiv) ?: return 0
         val baseForce = 30f
 
-        val ourCombatStrength = civInfo.getStatForRanking(RankingType.Force).toFloat() + baseForce + CityCombatant(civInfo.getCapital()!!).getCityStrength()
-        var theirCombatStrength = otherCiv.getStatForRanking(RankingType.Force).toFloat() + baseForce + CityCombatant(otherCiv.getCapital()!!).getCityStrength()
+        var ourCombatStrength = civInfo.getStatForRanking(RankingType.Force).toFloat() + baseForce
+        if (civInfo.getCapital()!= null) ourCombatStrength += CityCombatant(civInfo.getCapital()!!).getCityStrength()
+        var theirCombatStrength = otherCiv.getStatForRanking(RankingType.Force).toFloat() + baseForce
+        if(otherCiv.getCapital() != null) theirCombatStrength += CityCombatant(otherCiv.getCapital()!!).getCityStrength()
 
         //for city-states, also consider their protectors
         if (otherCiv.isCityState() and otherCiv.cityStateFunctions.getProtectorCivs().isNotEmpty()) {
@@ -942,7 +944,7 @@ object NextTurnAutomation {
             return motivationSoFar
         }
 
-        val reachableEnemyCitiesBfs = BFS(civInfo.getCapital()!!.getCenterTile()) { isTileCanMoveThrough(it) }
+        val reachableEnemyCitiesBfs = BFS((civInfo.getCapital() ?: civInfo.cities.firstOrNull())!!.getCenterTile()) { isTileCanMoveThrough(it) }
         reachableEnemyCitiesBfs.stepToEnd()
         val reachableEnemyCities = otherCiv.cities.filter { reachableEnemyCitiesBfs.hasReachedTile(it.getCenterTile()) }
         if (reachableEnemyCities.isEmpty()) return 0 // Can't even reach the enemy city, no point in war.

--- a/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
@@ -944,7 +944,7 @@ object NextTurnAutomation {
             return motivationSoFar
         }
 
-        val reachableEnemyCitiesBfs = BFS((civInfo.getCapital() ?: civInfo.cities.firstOrNull())!!.getCenterTile()) { isTileCanMoveThrough(it) }
+        val reachableEnemyCitiesBfs = BFS(civInfo.getCapital(true)!!.getCenterTile()) { isTileCanMoveThrough(it) }
         reachableEnemyCitiesBfs.stepToEnd()
         val reachableEnemyCities = otherCiv.cities.filter { reachableEnemyCitiesBfs.hasReachedTile(it.getCenterTile()) }
         if (reachableEnemyCities.isEmpty()) return 0 // Can't even reach the enemy city, no point in war.

--- a/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
@@ -58,7 +58,8 @@ class WorkerAutomation(
     private val citiesThatNeedConnecting: List<City> by lazy {
         val result = civInfo.cities.asSequence()
             .filter {
-                it.population.population > 3
+                civInfo.getCapital() != null
+                    && it.population.population > 3
                         && !it.isCapital() && !it.isBeingRazed // Cities being razed should not be connected.
                         && !it.cityStats.isConnectedToCapital(bestRoadAvailable)
             }.sortedBy {

--- a/core/src/com/unciv/logic/civilization/Civilization.kt
+++ b/core/src/com/unciv/logic/civilization/Civilization.kt
@@ -320,7 +320,8 @@ class Civilization : IsPartOfGameInfoSerialization {
     fun knows(otherCivName: String) = diplomacy.containsKey(otherCivName)
     fun knows(otherCiv: Civilization) = knows(otherCiv.civName)
 
-    fun getCapital() = cities.firstOrNull { it.isCapital() }
+    fun getCapital(firstCityIfNoCapital: Boolean = false) = cities.firstOrNull { it.isCapital() } ?:
+        if (firstCityIfNoCapital) cities.firstOrNull() else null
     fun isHuman() = playerType == PlayerType.Human
     fun isAI() = playerType == PlayerType.AI
     fun isOneCityChallenger() = playerType == PlayerType.Human && gameInfo.gameParameters.oneCityChallenge

--- a/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
@@ -521,7 +521,7 @@ class DiplomacyManager() : IsPartOfGameInfoSerialization {
         }
 
         if (!civInfo.isDefeated()) { // don't display city state relationship notifications when the city state is currently defeated
-            val civCapitalLocation = if (civInfo.cities.isNotEmpty() || civInfo.getCapital() != null) civInfo.getCapital()!!.location else null
+            val civCapitalLocation = if (civInfo.cities.any() && civInfo.getCapital() != null) civInfo.getCapital()!!.location else null
             if (getTurnsToRelationshipChange() == 1) {
                 val text = "Your relationship with [${civInfo.civName}] is about to degrade"
                 if (civCapitalLocation != null) otherCiv().addNotification(text,

--- a/core/src/com/unciv/logic/civilization/transients/CivInfoTransientCache.kt
+++ b/core/src/com/unciv/logic/civilization/transients/CivInfoTransientCache.kt
@@ -380,7 +380,7 @@ class CivInfoTransientCache(val civInfo: Civilization) {
 
         // Check if different continents (unless already max distance, or water map)
         if (connections > 0 && proximity != Proximity.Distant && !civInfo.gameInfo.tileMap.isWaterMap()
-                && (civInfo.getCapital()?:civInfo.cities.firstOrNull())!!.getCenterTile().getContinent() != (otherCiv.getCapital()?:otherCiv.cities.firstOrNull())!!.getCenterTile().getContinent()
+                && civInfo.getCapital(true)!!.getCenterTile().getContinent() != otherCiv.getCapital(true)!!.getCenterTile().getContinent()
         ) {
             // Different continents - increase separation by one step
             proximity = when (proximity) {

--- a/core/src/com/unciv/logic/civilization/transients/CivInfoTransientCache.kt
+++ b/core/src/com/unciv/logic/civilization/transients/CivInfoTransientCache.kt
@@ -248,7 +248,7 @@ class CivInfoTransientCache(val civInfo: Civilization) {
     }
 
     fun updateCitiesConnectedToCapital(initialSetup: Boolean = false) {
-        if (civInfo.cities.isEmpty() || civInfo.getCapital() == null) return // eg barbarians
+        if (civInfo.cities.isEmpty()) return // No cities to connect
 
         val oldConnectedCities = if (initialSetup)
             civInfo.cities.filter { it.connectedToCapitalStatus == City.ConnectedToCapitalStatus.`true` }
@@ -257,12 +257,13 @@ class CivInfoTransientCache(val civInfo: Civilization) {
             civInfo.cities.filter { it.connectedToCapitalStatus != City.ConnectedToCapitalStatus.`false` }
         else citiesConnectedToCapitalToMediums.keys
 
-        citiesConnectedToCapitalToMediums = CapitalConnectionsFinder(civInfo).find()
+        citiesConnectedToCapitalToMediums = if(civInfo.getCapital() == null) mapOf()
+        else CapitalConnectionsFinder(civInfo).find()
 
         val newConnectedCities = citiesConnectedToCapitalToMediums.keys
 
         for (city in newConnectedCities)
-            if (city !in oldMaybeConnectedCities && city.civ == civInfo && city != civInfo.getCapital()!!)
+            if (city !in oldMaybeConnectedCities && city.civ == civInfo && city != civInfo.getCapital())
                 civInfo.addNotification("[${city.name}] has been connected to your capital!",
                     city.location, NotificationCategory.Cities, NotificationIcon.Gold
                 )
@@ -379,7 +380,7 @@ class CivInfoTransientCache(val civInfo: Civilization) {
 
         // Check if different continents (unless already max distance, or water map)
         if (connections > 0 && proximity != Proximity.Distant && !civInfo.gameInfo.tileMap.isWaterMap()
-                && civInfo.getCapital()!!.getCenterTile().getContinent() != otherCiv.getCapital()!!.getCenterTile().getContinent()
+                && (civInfo.getCapital()?:civInfo.cities.firstOrNull())!!.getCenterTile().getContinent() != (otherCiv.getCapital()?:otherCiv.cities.firstOrNull())!!.getCenterTile().getContinent()
         ) {
             // Different continents - increase separation by one step
             proximity = when (proximity) {


### PR DESCRIPTION
This PR aims to better avoid crashes due to players lacking a capital for whatever reason. This is partly to better support scenarios where a player sells their capital, but also to fix a major issue with a large chunk of unit tests. I am aware of the previous arguments made in #9516 and #6889. However upon second glance, the issues are actually much deeper than those previous PRs made it out to be. Any scenario that required a city to do something was changed to instead use that civ's first city, though I'm not sure that's the best way to handle it

________
Full explanation here: Currently, there are many cases where buildings didn't trigger uniques, update connections (for harbors), add free buildings, or update city health. This oversight is good news for the unit tests as these checks are largely unnecessary there. However, it is a problem for mods, especially if a player starts in a later era and would have a building that is supposed to do one of these things. Unfortunately, updating these things, specifically city connections, has unforeseen consequences
Under normal conditions, cities do not check if they are connected to the capital unless a new turn has started or a building has finished being built. Since cities by default do not count as connected to the capital, `CityStats.getStatsFromTradeRoute()` will not crash trying to check the capital's population count (in an effort to update the citystats, line 499 calling line 460 calling line 103 in `logic.city.CityStats`). Fixing the prior issue of buildings not updating cities properly means that it will be treated as connected when you remove a city, and thanks to even more broken capital checks, it wouldn't properly clear itself as connected if you sell your capital, leading to a crash
This is where we have a problem in the unit tests. Many of the unit tests immediately removes the capital in order to use a capital that gives no stats. Previously, this only worked because settler buildings didn't update the city properly. If I attempt to fix that (as I was planning to do) many of the tests breaks. Meaning that whether we allow players to not have a capital or not, it is still required to at the very least fix the city connection code in order to allow settler buildings to update cities properly without breaking the unit tests. And since this has come up so many times by now, and given some mods wants to use this as a feature, it seems far more worthwhile to supports players not having a capital than continue saying that the game assumes there's always a capital

This PR does not fully fix for the AI not having a capital, primarily because that's not possible in any capacity that I can tell. Checking for getCapital checks that primarily affects the AI could be done, I just don't know if that's something we want to support