### PR TITLE
Fix when units can be purchased

### DIFF
--- a/core/src/com/unciv/models/ruleset/IConstruction.kt
+++ b/core/src/com/unciv/models/ruleset/IConstruction.kt
@@ -41,7 +41,6 @@ interface INonPerpetualConstruction : IConstruction, INamed, IHasUniques {
     fun canBePurchasedWithStat(city: City?, stat: Stat): Boolean {
         if (stat == Stat.Production || stat == Stat.Happiness) return false
         if (hasUnique(UniqueType.CannotBePurchased)) return false
-        if (stat == Stat.Gold) return !hasUnique(UniqueType.Unbuildable)
         // Can be purchased with [Stat] [cityFilter]
         if (city != null && getMatchingUniques(UniqueType.CanBePurchasedWithStat)
             .any { it.params[0] == stat.name && city.matchesFilter(it.params[1]) }
@@ -50,6 +49,7 @@ interface INonPerpetualConstruction : IConstruction, INamed, IHasUniques {
         if (city != null && getMatchingUniques(UniqueType.CanBePurchasedForAmountStat)
             .any { it.params[1] == stat.name && city.matchesFilter(it.params[2]) }
         ) return true
+        if (stat == Stat.Gold) return !hasUnique(UniqueType.Unbuildable)
         return false
     }
 

--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -89,7 +89,7 @@ class BaseUnit : RulesetObject(), INonPerpetualConstruction {
     override fun canBePurchasedWithStat(city: City?, stat: Stat): Boolean {
         if (city == null) return super.canBePurchasedWithStat(null, stat)
         if (hasUnique(UniqueType.CannotBePurchased)) return false
-        if (getRejectionReasons(city.civ, city).any { it.type != RejectionReasonType.Unbuildable  })
+        if (getRejectionReasons(city.cityConstructions).any { it.type != RejectionReasonType.Unbuildable  })
             return false
         if (costFunctions.canBePurchasedWithStat(city, stat)) return true
         return super.canBePurchasedWithStat(city, stat)


### PR DESCRIPTION
- Allows units to be purchased with gold if they have the unique for it
- Fixes cases that allowed purchasing a unit that shouldn't be available