### PR TITLE
Small actor activation patch

### DIFF
--- a/core/src/com/unciv/ui/components/extensions/Scene2dExtensions.kt
+++ b/core/src/com/unciv/ui/components/extensions/Scene2dExtensions.kt
@@ -43,6 +43,7 @@ private class RestorableTextButtonStyle(
 /** Disable a [Button] by setting its [touchable][Button.touchable] and [style][Button.style] properties. */
 fun Button.disable() {
     touchable = Touchable.disabled
+    isDisabled = true
     val oldStyle = style
     if (oldStyle is RestorableTextButtonStyle) return
     val disabledStyle = BaseScreen.skin.get("disabled", TextButtonStyle::class.java)
@@ -54,6 +55,7 @@ fun Button.enable() {
     if (oldStyle is RestorableTextButtonStyle) {
         style = oldStyle.restoreStyle
     }
+    isDisabled = false
     touchable = Touchable.enabled
 }
 /** Enable or disable a [Button] by setting its [touchable][Button.touchable] and [style][Button.style] properties,

--- a/core/src/com/unciv/ui/components/input/ActivationActionMap.kt
+++ b/core/src/com/unciv/ui/components/input/ActivationActionMap.kt
@@ -51,7 +51,8 @@ internal class ActivationActionMap : MutableMap<ActivationTypes, ActivationActio
         if (actions.isEmpty()) return false
         if (actions.sound != UncivSound.Silent)
             Concurrency.runOnGLThread("Sound") { SoundPlayer.play(actions.sound) }
-        for (action in actions)
+        // We can't know an activation handler won't redefine activations, so better iterate over a copy
+        for (action in actions.toList())
             action.invoke()
         return true
     }

--- a/core/src/com/unciv/ui/components/input/ActorAttachments.kt
+++ b/core/src/com/unciv/ui/components/input/ActorAttachments.kt
@@ -1,6 +1,7 @@
 package com.unciv.ui.components.input
 
 import com.badlogic.gdx.scenes.scene2d.Actor
+import com.badlogic.gdx.scenes.scene2d.utils.Disableable
 import com.unciv.models.UncivSound
 
 internal class ActorAttachments private constructor(actor: Actor) {
@@ -37,6 +38,7 @@ internal class ActorAttachments private constructor(actor: Actor) {
 
     fun activate(type: ActivationTypes): Boolean {
         if (!this::activationActions.isInitialized) return false
+        if ((actor as? Disableable)?.isDisabled == true) return false // Skip if disabled - could reach here through key shortcuts
         return activationActions.activate(type)
     }
 


### PR DESCRIPTION
* Prevent activation of disabled actors via key shortcuts
    * Like [this reverted commit](https://github.com/yairm210/Unciv/commit/ee855b8d77de3d9486170f900433c5c6b433d32a) but only for Actors that implement Disableable
    * Opted to track Gdx isDisabled within our isEnabled so the test reads cleaner - invisible since we do not actually supply styles with background/textColor for the disabled state (exception AnimatedMenuPopup.SmallButtonStyle - but that manages disabling just fine the Gdx way and is an example why the test should be on isDisabled)
    * I am actually convinced we could ditch the whole RestorableTextButtonStyle thing and reduce isEnabled to a isDisabled wrapper by properly providing for Gdx's way in the Skin. Skin file even gets shorter not longer. Tested but not included.

* Avoid activation concurrent modification problems
      * Should fix #9711 - forgot to test but the logic is sound

I've been running these changes for a while now while debugging stuff.
