### PR TITLE
City-level resources

### DIFF
--- a/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
@@ -362,16 +362,17 @@ object NextTurnAutomation {
             val highlyDesirableTilesInCity = city.tilesInRange.filter {
                 val hasNaturalWonder = it.naturalWonder != null
                 val hasLuxuryCivDoesntOwn =
-                        it.hasViewableResource(civInfo) &&
-                                it.tileResource.resourceType == ResourceType.Luxury &&
-                                !civInfo.hasResource(it.resource!!)
+                    it.hasViewableResource(civInfo)
+                        && it.tileResource.resourceType == ResourceType.Luxury
+                        && !civInfo.hasResource(it.resource!!)
                 val hasResourceCivHasNoneOrLittle =
-                        (it.hasViewableResource(civInfo)
-                                && it.tileResource.resourceType == ResourceType.Strategic &&
-                                (civInfo.getCivResourcesByName()[it.resource!!] ?: 0) <= 3)
+                    it.hasViewableResource(civInfo)
+                        && it.tileResource.resourceType == ResourceType.Strategic
+                        && civInfo.getResourceAmount(it.resource!!) <= 3
+
                 it.isVisible(civInfo) && it.getOwner() == null
-                        && it.neighbors.any { neighbor -> neighbor.getCity() == city }
-                        (hasNaturalWonder || hasLuxuryCivDoesntOwn || hasResourceCivHasNoneOrLittle)
+                    && it.neighbors.any { neighbor -> neighbor.getCity() == city }
+                (hasNaturalWonder || hasLuxuryCivDoesntOwn || hasResourceCivHasNoneOrLittle)
             }
             for (highlyDesirableTileInCity in highlyDesirableTilesInCity) {
                 highlyDesirableTiles.getOrPut(highlyDesirableTileInCity) { mutableSetOf() }

--- a/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
@@ -603,8 +603,7 @@ object NextTurnAutomation {
 
         for (resource in civInfo.gameInfo.spaceResources) {
             // Have enough resources already
-            val resourceCount = civInfo.getCivResourcesByName()[resource] ?: 0
-            if (resourceCount >= Automation.getReservedSpaceResourceAmount(civInfo))
+            if (civInfo.getResourceAmount(resource) >= Automation.getReservedSpaceResourceAmount(civInfo))
                 continue
 
             val unitToDisband = civInfo.units.getCivUnits()

--- a/core/src/com/unciv/logic/city/City.kt
+++ b/core/src/com/unciv/logic/city/City.kt
@@ -254,6 +254,14 @@ class City : IsPartOfGameInfoSerialization {
         return cityResources
     }
 
+    fun getResourceAmount(resourceName:String): Int {
+        val resource = getRuleset().tileResources[resourceName] ?: return 0
+
+        if (resource.hasUnique(UniqueType.CityResource))
+            return getCityResources().firstOrNull { it.resource == resource }?.amount ?: 0
+        return civ.getCivResourcesByName()[resourceName]!!
+    }
+
     private fun getTileResourceAmount(tile: Tile): Int {
         if (tile.resource == null) return 0
         if (!tile.providesResources(civ)) return 0

--- a/core/src/com/unciv/logic/city/City.kt
+++ b/core/src/com/unciv/logic/city/City.kt
@@ -258,7 +258,7 @@ class City : IsPartOfGameInfoSerialization {
         val resource = getRuleset().tileResources[resourceName] ?: return 0
 
         if (resource.hasUnique(UniqueType.CityResource))
-            return getCityResources().firstOrNull { it.resource == resource }?.amount ?: 0
+            return getCityResources().filter { it.resource == resource }.sumOf { it.amount }
         return civ.getCivResourcesByName()[resourceName]!!
     }
 

--- a/core/src/com/unciv/logic/city/City.kt
+++ b/core/src/com/unciv/logic/city/City.kt
@@ -254,12 +254,14 @@ class City : IsPartOfGameInfoSerialization {
         return cityResources
     }
 
-    fun getResourceAmount(resourceName:String): Int {
+    /** Gets the number of resources available to this city
+     * Accommodates both city-wide and civ-wide resources */
+    fun getResourceAmount(resourceName: String): Int {
         val resource = getRuleset().tileResources[resourceName] ?: return 0
 
         if (resource.hasUnique(UniqueType.CityResource))
-            return getCityResources().filter { it.resource == resource }.sumOf { it.amount }
-        return civ.getCivResourcesByName()[resourceName]!!
+            return getCityResources().asSequence().filter { it.resource == resource }.sumOf { it.amount }
+        return civ.getResourceAmount(resourceName)
     }
 
     private fun getTileResourceAmount(tile: Tile): Int {

--- a/core/src/com/unciv/logic/city/managers/CityTurnManager.kt
+++ b/core/src/com/unciv/logic/city/managers/CityTurnManager.kt
@@ -1,8 +1,8 @@
 package com.unciv.logic.city.managers
 
+import com.unciv.logic.city.City
 import com.unciv.logic.city.CityFlags
 import com.unciv.logic.city.CityFocus
-import com.unciv.logic.city.City
 import com.unciv.logic.civilization.NotificationCategory
 import com.unciv.logic.civilization.NotificationIcon
 import com.unciv.models.ruleset.tile.ResourceType
@@ -46,7 +46,7 @@ class CityTurnManager(val city: City) {
 
     private fun tryWeLoveTheKing() {
         if (city.demandedResource == "") return
-        if (city.civ.getCivResourcesByName()[city.demandedResource]!! > 0) {
+        if (city.getResourceAmount(city.demandedResource) > 0) {
             city.setFlag(CityFlags.WeLoveTheKing, 20 + 1) // +1 because it will be decremented by 1 in the same startTurn()
             city.civ.addNotification(
                 "Because they have [${city.demandedResource}], the citizens of [${city.name}] are celebrating We Love The King Day!",

--- a/core/src/com/unciv/logic/civilization/Civilization.kt
+++ b/core/src/com/unciv/logic/civilization/Civilization.kt
@@ -424,6 +424,12 @@ class Civilization : IsPartOfGameInfoSerialization {
         return hashMap
     }
 
+    /** Gets the number of resources available to this city
+     * Does not include city-wide resources */
+    fun getResourceAmount(resourceName:String): Int {
+        return getCivResourcesByName()[resourceName] ?: 0
+    }
+
     fun getResourceModifier(resource: TileResource): Float {
         var resourceModifier = 1f
         for (unique in getMatchingUniques(UniqueType.DoubleResourceProduced))

--- a/core/src/com/unciv/logic/civilization/Civilization.kt
+++ b/core/src/com/unciv/logic/civilization/Civilization.kt
@@ -425,7 +425,8 @@ class Civilization : IsPartOfGameInfoSerialization {
     }
 
     /** Gets the number of resources available to this city
-     * Does not include city-wide resources */
+     * Does not include city-wide resources
+     * Returns 0 for undefined resources */
     fun getResourceAmount(resourceName:String): Int {
         return getCivResourcesByName()[resourceName] ?: 0
     }
@@ -443,7 +444,7 @@ class Civilization : IsPartOfGameInfoSerialization {
         return resourceModifier
     }
 
-    fun hasResource(resourceName: String): Boolean = getCivResourcesByName()[resourceName]!! > 0
+    fun hasResource(resourceName: String): Boolean = getResourceAmount(resourceName) > 0
 
     fun hasUnique(uniqueType: UniqueType, stateForConditionals: StateForConditionals =
         StateForConditionals(this)) = getMatchingUniques(uniqueType, stateForConditionals).any()

--- a/core/src/com/unciv/logic/civilization/transients/CivInfoTransientCache.kt
+++ b/core/src/com/unciv/logic/civilization/transients/CivInfoTransientCache.kt
@@ -320,6 +320,8 @@ class CivInfoTransientCache(val civInfo: Civilization) {
             newDetailedCivResources.subtractResourceRequirements(
                 unit.baseUnit.getResourceRequirementsPerTurn(), civInfo.gameInfo.ruleset, "Units")
 
+        newDetailedCivResources.removeAll { it.resource.hasUnique(UniqueType.CityResource) }
+
         // Check if anything has actually changed so we don't update stats for no reason - this uses List equality which means it checks the elements
         if (civInfo.detailedCivResources == newDetailedCivResources) return
 

--- a/core/src/com/unciv/logic/map/tile/TileInfoImprovementFunctions.kt
+++ b/core/src/com/unciv/logic/map/tile/TileInfoImprovementFunctions.kt
@@ -45,11 +45,11 @@ class TileInfoImprovementFunctions(val tile: Tile) {
             yield(ImprovementBuildingProblem.Obsolete)
 
         if (improvement.getMatchingUniques(UniqueType.ConsumesResources, stateForConditionals)
-                    .any { civInfo.getCivResourcesByName()[it.params[1]]!! < it.params[0].toInt() })
+                    .any { civInfo.getResourceAmount(it.params[1]) < it.params[0].toInt() })
             yield(ImprovementBuildingProblem.MissingResources)
 
         if (improvement.getMatchingUniques(UniqueType.CostsResources)
-                    .any { civInfo.getCivResourcesByName()[it.params[1]]!! < it.params[0].toInt() })
+                    .any { civInfo.getResourceAmount(it.params[1]) < it.params[0].toInt() })
             yield(ImprovementBuildingProblem.MissingResources)
 
         val knownFeatureRemovals = tile.ruleset.tileImprovements.values

--- a/core/src/com/unciv/logic/trade/TradeEvaluation.kt
+++ b/core/src/com/unciv/logic/trade/TradeEvaluation.kt
@@ -112,8 +112,7 @@ class TradeEvaluation {
             }
 
             TradeType.Strategic_Resource -> {
-                val resources = civInfo.getCivResourcesByName()
-                val amountWillingToBuy = 2 - resources[offer.name]!!
+                val amountWillingToBuy = 2 - civInfo.getResourceAmount(offer.name)
                 if (amountWillingToBuy <= 0) return 0 // we already have enough.
                 val amountToBuyInOffer = min(amountWillingToBuy, offer.amount)
 
@@ -200,7 +199,7 @@ class TradeEvaluation {
             }
             TradeType.Luxury_Resource -> {
                 return when {
-                    civInfo.getCivResourcesByName()[offer.name]!! > 1 -> 250 // fair price
+                    civInfo.getResourceAmount(offer.name) > 1 -> 250 // fair price
                     civInfo.hasUnique(UniqueType.RetainHappinessFromLuxury) -> // If we retain 50% happiness, value at 375
                         750 - (civInfo.getMatchingUniques(UniqueType.RetainHappinessFromLuxury)
                             .first().params[0].toPercent() * 250).toInt()
@@ -221,8 +220,7 @@ class TradeEvaluation {
                             && it.isBuildable(civInfo) }
                 if (!canUseForUnits) return 50 * offer.amount
 
-                val amountLeft = civInfo.getCivResourcesByName()[offer.name]
-                    ?: throw Exception("Got a strategic resource offer but the the resource doesn't exist in this ruleset!")
+                val amountLeft = civInfo.getResourceAmount(offer.name)
 
                 // Each strategic resource starts costing 100 more when we ass the 5 resources baseline
                 // That is to say, if I have 4 and you take one away, that's 200

--- a/core/src/com/unciv/models/ruleset/unique/Unique.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Unique.kt
@@ -45,7 +45,7 @@ class Unique(val text: String, val sourceObjectType: UniqueTarget? = null, val s
     fun hasTriggerConditional(): Boolean {
         if(conditionals.none()) return false
         return conditionals.any{ conditional -> conditional.type?.targetTypes
-            ?.any{ it.canAcceptUniqueTarget(UniqueTarget.TriggerCondition) || it.canAcceptUniqueTarget(UniqueTarget.UnitActionModifier) } 
+            ?.any{ it.canAcceptUniqueTarget(UniqueTarget.TriggerCondition) || it.canAcceptUniqueTarget(UniqueTarget.UnitActionModifier) }
                 ?: false
         }
     }
@@ -153,6 +153,12 @@ class Unique(val text: String, val sourceObjectType: UniqueTarget? = null, val s
 
         val stateBasedRandom by lazy { Random(state.hashCode()) }
 
+        fun getResourceAmount(resourceName:String):Int {
+            if (state.city != null) return state.city.getResourceAmount(resourceName)
+            if (state.civInfo != null) return state.civInfo.getCivResourcesByName()[resourceName]!!
+            return 0
+        }
+
         return when (condition.type) {
             // These are 'what to do' and not 'when to do' conditionals
             UniqueType.ConditionalTimedUnique -> true
@@ -165,12 +171,10 @@ class Unique(val text: String, val sourceObjectType: UniqueTarget? = null, val s
             UniqueType.ConditionalNationFilter -> state.civInfo?.nation?.matchesFilter(condition.params[0]) == true
             UniqueType.ConditionalWar -> state.civInfo?.isAtWar() == true
             UniqueType.ConditionalNotWar -> state.civInfo?.isAtWar() == false
-            UniqueType.ConditionalWithResource -> state.civInfo?.hasResource(condition.params[0]) == true
-            UniqueType.ConditionalWithoutResource -> state.civInfo?.hasResource(condition.params[0]) == false
-            UniqueType.ConditionalWhenAboveAmountResource -> state.civInfo != null
-                    && state.civInfo.getCivResourcesByName()[condition.params[1]]!! > condition.params[0].toInt()
-            UniqueType.ConditionalWhenBelowAmountResource -> state.civInfo != null
-                    && state.civInfo.getCivResourcesByName()[condition.params[1]]!! < condition.params[0].toInt()
+            UniqueType.ConditionalWithResource -> getResourceAmount(condition.params[0]) > 0
+            UniqueType.ConditionalWithoutResource -> getResourceAmount(condition.params[0]) <= 0
+            UniqueType.ConditionalWhenAboveAmountResource -> getResourceAmount(condition.params[1]) > condition.params[0].toInt()
+            UniqueType.ConditionalWhenBelowAmountResource -> getResourceAmount(condition.params[1]) < condition.params[0].toInt()
             UniqueType.ConditionalHappy ->
                 state.civInfo != null && state.civInfo.stats.happiness >= 0
             UniqueType.ConditionalBetweenHappiness ->

--- a/core/src/com/unciv/models/ruleset/unique/Unique.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Unique.kt
@@ -153,9 +153,9 @@ class Unique(val text: String, val sourceObjectType: UniqueTarget? = null, val s
 
         val stateBasedRandom by lazy { Random(state.hashCode()) }
 
-        fun getResourceAmount(resourceName:String):Int {
+        fun getResourceAmount(resourceName: String): Int {
             if (state.city != null) return state.city.getResourceAmount(resourceName)
-            if (state.civInfo != null) return state.civInfo.getCivResourcesByName()[resourceName]!!
+            if (state.civInfo != null) return state.civInfo.getResourceAmount(resourceName)
             return 0
         }
 
@@ -163,10 +163,10 @@ class Unique(val text: String, val sourceObjectType: UniqueTarget? = null, val s
             // These are 'what to do' and not 'when to do' conditionals
             UniqueType.ConditionalTimedUnique -> true
 
+            UniqueType.ConditionalChance -> stateBasedRandom.nextFloat() < condition.params[0].toFloat() / 100f
             UniqueType.ConditionalBeforeTurns -> state.civInfo != null && state.civInfo.gameInfo.turns < condition.params[0].toInt()
             UniqueType.ConditionalAfterTurns -> state.civInfo != null && state.civInfo.gameInfo.turns >= condition.params[0].toInt()
 
-            UniqueType.ConditionalChance -> stateBasedRandom.nextFloat() < condition.params[0].toFloat() / 100f
 
             UniqueType.ConditionalNationFilter -> state.civInfo?.nation?.matchesFilter(condition.params[0]) == true
             UniqueType.ConditionalWar -> state.civInfo?.isAtWar() == true

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -609,6 +609,7 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
     ResourceAmountOnTiles("Deposits in [tileFilter] tiles always provide [amount] resources", UniqueTarget.Resource),
     CityStateOnlyResource("Can only be created by Mercantile City-States", UniqueTarget.Resource),
     Stockpiled("Stockpiled", UniqueTarget.Resource),
+    CityResource("City-level resource", UniqueTarget.Resource),
     CannotBeTraded("Cannot be traded", UniqueTarget.Resource),
     NotShownOnWorldScreen("Not shown on world screen", UniqueTarget.Resource, flags = UniqueFlag.setOfHiddenToUsers),
 

--- a/core/src/com/unciv/ui/screens/cityscreen/CityStatsTable.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/CityStatsTable.kt
@@ -190,7 +190,8 @@ class CityStatsTable(private val cityScreen: CityScreen): Table() {
                 resourceTable.add(ImageGetter.getResourcePortrait(resource.name, 20f))
                     .padRight(5f)
                 }
-        tableWithIcons.add(resourceTable)
+        if (resourceTable.cells.notEmpty())
+            tableWithIcons.add(resourceTable)
 
         val (wltkIcon: Actor?, wltkLabel: Label?) = when {
             city.isWeLoveTheKingDayActive() ->

--- a/core/src/com/unciv/ui/screens/cityscreen/CityStatsTable.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/CityStatsTable.kt
@@ -11,7 +11,9 @@ import com.unciv.UncivGame
 import com.unciv.logic.city.City
 import com.unciv.logic.city.CityFlags
 import com.unciv.logic.city.CityFocus
+import com.unciv.models.Counter
 import com.unciv.models.ruleset.Building
+import com.unciv.models.ruleset.tile.TileResource
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.stats.Stat
 import com.unciv.models.translations.tr
@@ -179,10 +181,13 @@ class CityStatsTable(private val cityScreen: CityScreen): Table() {
         }
 
         val resourceTable = Table()
-        for (resourceSupply in city.getCityResources())
-            if (resourceSupply.resource.hasUnique(UniqueType.CityResource)){
-                resourceTable.add(resourceSupply.amount.toLabel())
-                resourceTable.add(ImageGetter.getResourcePortrait(resourceSupply.resource.name, 20f))
+
+        val resourceCounter = Counter<TileResource>()
+        for (resourceSupply in city.getCityResources()) resourceCounter.add(resourceSupply.resource, resourceSupply.amount)
+        for ((resource, amount) in resourceCounter)
+            if (resource.hasUnique(UniqueType.CityResource)){
+                resourceTable.add(amount.toLabel())
+                resourceTable.add(ImageGetter.getResourcePortrait(resource.name, 20f))
                     .padRight(5f)
                 }
         tableWithIcons.add(resourceTable)

--- a/core/src/com/unciv/ui/screens/cityscreen/CityStatsTable.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/CityStatsTable.kt
@@ -178,6 +178,15 @@ class CityStatsTable(private val cityScreen: CityScreen): Table() {
             tableWithIcons.add("In resistance for another [${city.getFlag(CityFlags.Resistance)}] turns".toLabel()).row()
         }
 
+        val resourceTable = Table()
+        for (resourceSupply in city.getCityResources())
+            if (resourceSupply.resource.hasUnique(UniqueType.CityResource)){
+                resourceTable.add(resourceSupply.amount.toLabel())
+                resourceTable.add(ImageGetter.getResourcePortrait(resourceSupply.resource.name, 20f))
+                    .padRight(5f)
+                }
+        tableWithIcons.add(resourceTable)
+
         val (wltkIcon: Actor?, wltkLabel: Label?) = when {
             city.isWeLoveTheKingDayActive() ->
                 ImageGetter.getStatIcon("Food") to

--- a/core/src/com/unciv/ui/screens/pickerscreens/ImprovementPickerScreen.kt
+++ b/core/src/com/unciv/ui/screens/pickerscreens/ImprovementPickerScreen.kt
@@ -15,10 +15,10 @@ import com.unciv.models.translations.tr
 import com.unciv.ui.components.Fonts
 import com.unciv.ui.components.UncivTooltip.Companion.addTooltip
 import com.unciv.ui.components.extensions.disable
+import com.unciv.ui.components.extensions.toLabel
 import com.unciv.ui.components.input.keyShortcuts
 import com.unciv.ui.components.input.onClick
 import com.unciv.ui.components.input.onDoubleClick
-import com.unciv.ui.components.extensions.toLabel
 import com.unciv.ui.images.ImageGetter
 import kotlin.math.roundToInt
 
@@ -143,7 +143,7 @@ class ImprovementPickerScreen(
                 proposedSolutions.add("Have this tile inside your empire")
             if (ImprovementBuildingProblem.MissingResources in unbuildableBecause) {
                 proposedSolutions.addAll(improvement.getMatchingUniques(UniqueType.ConsumesResources).filter {
-                    currentPlayerCiv.getCivResourcesByName()[it.params[1]]!! < it.params[0].toInt()
+                    currentPlayerCiv.getResourceAmount(it.params[1]) < it.params[0].toInt()
                 }.map { "Acquire more [$it]" })
             }
 

--- a/core/src/com/unciv/ui/screens/worldscreen/WorldScreenTopBar.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/WorldScreenTopBar.kt
@@ -151,7 +151,7 @@ class WorldScreenTopBar(val worldScreen: WorldScreen) : Table() {
         }
 
         val strategicResources = worldScreen.gameInfo.ruleset.tileResources.values
-            .filter { it.resourceType == ResourceType.Strategic }
+            .filter { it.resourceType == ResourceType.Strategic && !it.hasUnique(UniqueType.CityResource) }
         for (resource in strategicResources) {
             val resourceImage = ImageGetter.getResourcePortrait(resource.name, 20f)
             val resourceLabel = "0".toLabel()

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -1656,6 +1656,9 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 ??? example  "Stockpiled"
 	Applicable to: Resource
 
+??? example  "City-level resource"
+	Applicable to: Resource
+
 ??? example  "Cannot be traded"
 	Applicable to: Resource
 

--- a/tests/src/com/unciv/uniques/UnitUniquesTests.kt
+++ b/tests/src/com/unciv/uniques/UnitUniquesTests.kt
@@ -1,7 +1,6 @@
 package com.unciv.uniques
 
 import com.badlogic.gdx.math.Vector2
-import com.sun.source.tree.AssertTree
 import com.unciv.logic.map.mapunit.UnitTurnManager
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.translations.fillPlaceholders
@@ -83,7 +82,7 @@ class UnitUniquesTests {
         civ.tech.addTechnology("Iron Working")
         // capital already owns tile, but this relinquishes first - shouldn't require manual setTerrainTransients, updateCivResources called automatically
         capital.expansion.takeOwnership(ironTile)
-        val ironAvailable = civ.getCivResourcesByName()["Iron"] ?: 0
+        val ironAvailable = civ.getResourceAmount("Iron")
         Assert.assertTrue("Test preparation failed to add Iron to Civ resources", ironAvailable >= 3)
 
         // See if that same Engineer could create a Manufactory NOW


### PR DESCRIPTION
Allows designating resources as city-level resources (think: Civ VI artifact slots/power, Civ IV 'health', etc)

What's really cool is that resources from tiles work as expected, which means you can make city-specific resource chains all the way from base tiles :D

City-level resources are...
- Not displayed in civ top bar
- Not considered civ-level resources (for trade, non-city conditionals, etc)
- Are explicitly treated in city conditionals
- ARE considered for constructing buildings requiring resource
- ARE NOT considered for construction units requiring resource

Example (Civ6 mod, Districts):
![image](https://github.com/yairm210/Unciv/assets/8366208/d0aa8db9-8e84-4dcd-b931-5072831bf977)

@SeventhM Since you're the primary "modder and dev" I would like your feedback on this 