### PR TITLE
Fix issues when transferring capitals

### DIFF
--- a/core/src/com/unciv/logic/city/City.kt
+++ b/core/src/com/unciv/logic/city/City.kt
@@ -467,7 +467,7 @@ class City : IsPartOfGameInfoSerialization {
 
         // Move the capital if destroyed (by a nuke or by razing)
         // Must be before removing existing capital because we may be annexing a puppet which means city stats update - see #8337
-        if (isCapital()) civ.moveCapitalToNextLargest()
+        if (isCapital()) civ.moveCapitalToNextLargest(null)
 
         civ.cities = civ.cities.toMutableList().apply { remove(this@City) }
         getCenterTile().changeImprovement("City ruins")

--- a/core/src/com/unciv/logic/city/managers/CityConquestFunctions.kt
+++ b/core/src/com/unciv/logic/city/managers/CityConquestFunctions.kt
@@ -66,9 +66,7 @@ class CityConquestFunctions(val city: City){
 
         for (building in city.cityConstructions.getBuiltBuildings()) {
             // Remove national wonders
-            if (building.isNationalWonder && !building.hasUnique(UniqueType.NotDestroyedWhenCityCaptured)
-                && building.name != city.capitalCityIndicator()
-            ) // If we have just made this city the capital, don't remove that
+            if (building.isNationalWonder && !building.hasUnique(UniqueType.NotDestroyedWhenCityCaptured))
                 city.cityConstructions.removeBuilding(building.name)
 
             // Check if we exceed MaxNumberBuildable for any buildings
@@ -260,7 +258,7 @@ class CityConquestFunctions(val city: City){
 
         // Remove/relocate palace for old Civ - need to do this BEFORE we move the cities between
         //  civs so the capitalCityIndicator recognizes the unique buildings of the conquered civ
-        if (city.isCapital())  oldCiv.moveCapitalToNextLargest()
+        if (city.isCapital())  oldCiv.moveCapitalToNextLargest(city)
 
         oldCiv.cities = oldCiv.cities.toMutableList().apply { remove(city) }
         newCiv.cities = newCiv.cities.toMutableList().apply { add(city) }
@@ -278,13 +276,11 @@ class CityConquestFunctions(val city: City){
         // Stop WLTKD if it's still going
         city.resetWLTKD()
 
-        // Place palace for newCiv if this is the only city they have.
-        // This needs to happen _before_ buildings are added or removed,
-        // as any building change triggers a reevaluation of stats which assumes there to be a capital
-        if (newCiv.cities.size == 1) newCiv.moveCapitalTo(city)
-
         // Remove their free buildings from this city and remove free buildings provided by the city from their cities
         removeBuildingsOnMoveToCiv(oldCiv)
+
+        // Place palace for newCiv if this is the only city they have.
+        if (newCiv.cities.size == 1) newCiv.moveCapitalTo(city, null)
 
         // Add our free buildings to this city and add free buildings provided by the city to other cities
         city.civ.civConstructions.tryAddFreeBuildings()

--- a/core/src/com/unciv/logic/civilization/Civilization.kt
+++ b/core/src/com/unciv/logic/civilization/Civilization.kt
@@ -813,25 +813,20 @@ class Civilization : IsPartOfGameInfoSerialization {
     /**
      * Removes current capital then moves capital to argument city if not null
      */
-    fun moveCapitalTo(city: City?) {
-
-        val oldCapital = getCapital()
-
+    fun moveCapitalTo(city: City?, oldCapital: City?) {
         // Add new capital first so the civ doesn't get stuck in a state where it has cities but no capital
         if (city != null) {
             // move new capital
             city.cityConstructions.addBuilding(city.capitalCityIndicator())
             city.isBeingRazed = false // stop razing the new capital if it was being razed
         }
-        // Don't use removeBuilding, since that rebuilds uniques and can generate errors when we have no capital
-        // We're going to recalc the uniques anyway once we move it to the new civ
-        oldCapital?.cityConstructions?.builtBuildings?.remove(oldCapital.capitalCityIndicator())
+        oldCapital?.cityConstructions?.removeBuilding(oldCapital.capitalCityIndicator())
     }
 
-    fun moveCapitalToNextLargest() {
+    fun moveCapitalToNextLargest(oldCapital: City?) {
         val availableCities = cities.filterNot { it.isCapital() }
         if (availableCities.none()) {
-            moveCapitalTo(null)
+            moveCapitalTo(null, oldCapital)
             return
         }
 
@@ -841,7 +836,7 @@ class Civilization : IsPartOfGameInfoSerialization {
             newCapital = availableCities.maxByOrNull { it.population.population }!!
             newCapital.annexCity()
         }
-        moveCapitalTo(newCapital)
+        moveCapitalTo(newCapital, oldCapital)
     }
 
     fun getAllyCiv() = allyCivName

--- a/tests/src/com/unciv/logic/civilization/CityMovingTests.kt
+++ b/tests/src/com/unciv/logic/civilization/CityMovingTests.kt
@@ -54,7 +54,7 @@ class CityMovingTests {
 
         theirCapital.moveToCiv(civInfo)
         Assert.assertTrue(theirOtherCity.isCapital())
-        Assert.assertTrue(theirCapital.isCapital())
+        Assert.assertTrue(!theirCapital.isCapital())
         Assert.assertTrue(theirCapital.civ == civInfo)
     }
 


### PR DESCRIPTION
- Reverts 06377fe
- Reverts and reimplements 42a9c3a
- Fixes issues where you could move a different capital than the intended one if a mod allows you to have more than one capital
___
Admittedly, this PR is a complete shot in the dark, and I have no clue if anything in it actually fixes anything. The only fix I'm certain of is the fix for potentially moving the wrong capital. Currently I have no clue why 4.7.6 kept incorrectly moving the capital when this seems to not have been an issue beforehand, but addressing these previous commits seems like the first step, as this seems to have been when things started going wrong

Still, this should be a better and safer attempt to fix #9679. #9709 and #9731 should make any calls to `removeBuilding` safe if the player is lacking a capital. In fact, thanks to how recalculating city connections works, `removeBuilding` is actually better and safer for this despite us updating stats later anyways because there are potienal checks that rely on the city connections to be up to date. `addBuilding` has also been made safe when having no capital, so it's entirely viable to add the capital if they have only 1 city after everything else is done.

As for the fix regarding potentially moving the wrong capital: `getCapital` only returns the first capital, but this movement checks `isCapital` which doesn't matter if it's the first or the 5th. If that's not the capital being moved, it will end up removing a completely irrelevant capital. This has the bonus issue of not deleting the old capital properly. Whoops!