### PR TITLE
Avoid built buildings

### DIFF
--- a/core/src/com/unciv/logic/BackwardCompatibility.kt
+++ b/core/src/com/unciv/logic/BackwardCompatibility.kt
@@ -112,12 +112,12 @@ object BackwardCompatibility {
         if (ruleSet.buildings.containsKey(oldBuildingName))
             return
         // Replace in built buildings
-        if (cityConstructions.builtBuildings.contains(oldBuildingName)) {
-            cityConstructions.builtBuildings.remove(oldBuildingName)
-            cityConstructions.builtBuildings.add(newBuildingName)
+        if (cityConstructions.isBuilt(oldBuildingName)) {
+            cityConstructions.removeBuilding(oldBuildingName)
+            cityConstructions.addBuilding(newBuildingName)
         }
         // Replace in construction queue
-        if (!cityConstructions.builtBuildings.contains(newBuildingName) && !cityConstructions.constructionQueue.contains(newBuildingName))
+        if (!cityConstructions.isBuilt(newBuildingName) && !cityConstructions.constructionQueue.contains(newBuildingName))
             cityConstructions.constructionQueue = cityConstructions.constructionQueue
                 .map { if (it == oldBuildingName) newBuildingName else it }
                 .toMutableList()
@@ -125,7 +125,7 @@ object BackwardCompatibility {
             cityConstructions.constructionQueue.remove(oldBuildingName)
         // Replace in in-progress constructions
         if (cityConstructions.inProgressConstructions.containsKey(oldBuildingName)) {
-            if (!cityConstructions.builtBuildings.contains(newBuildingName) && !cityConstructions.inProgressConstructions.containsKey(newBuildingName))
+            if (!cityConstructions.isBuilt(newBuildingName) && !cityConstructions.inProgressConstructions.containsKey(newBuildingName))
                 cityConstructions.inProgressConstructions[newBuildingName] = cityConstructions.inProgressConstructions[oldBuildingName]!!
             cityConstructions.inProgressConstructions.remove(oldBuildingName)
         }

--- a/core/src/com/unciv/logic/BackwardCompatibility.kt
+++ b/core/src/com/unciv/logic/BackwardCompatibility.kt
@@ -66,12 +66,9 @@ object BackwardCompatibility {
     private fun GameInfo.handleMissingReferencesForEachCity() {
         for (city in civilizations.asSequence().flatMap { it.cities.asSequence() }) {
 
-            changeBuildingNameIfNotInRuleset(ruleset, city.cityConstructions, "Hanse", "Bank")
-
-            for (building in city.cityConstructions.builtBuildings.toHashSet()) {
-
-                if (!ruleset.buildings.containsKey(building))
-                    city.cityConstructions.builtBuildings.remove(building)
+            for (building in city.cityConstructions.getBuiltBuildings()) {
+                if (!ruleset.buildings.containsKey(building.name))
+                    city.cityConstructions.removeBuilding(building.name)
             }
 
             fun isInvalidConstruction(construction: String) =

--- a/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
@@ -616,7 +616,7 @@ object NextTurnAutomation {
                 if (city.hasSoldBuildingThisTurn)
                     continue
                 val buildingToSell = civInfo.gameInfo.ruleset.buildings.values.filter {
-                        it.name in city.cityConstructions.builtBuildings
+                        city.cityConstructions.isBuilt(it.name)
                         && it.requiresResource(resource)
                         && it.isSellable()
                         && it.name !in civInfo.civConstructions.getFreeBuildings(city.id) }
@@ -1072,7 +1072,7 @@ object NextTurnAutomation {
             }
             .maxByOrNull { it.cityStats.currentCityStats.production }
             ?: return
-        if (bestCity.cityConstructions.builtBuildings.size > 1) // 2 buildings or more, otherwise focus on self first
+        if (bestCity.cityConstructions.getBuiltBuildings().count() > 1) // 2 buildings or more, otherwise focus on self first
             bestCity.cityConstructions.currentConstructionFromQueue = settlerUnits.minByOrNull { it.cost }!!.name
     }
 

--- a/core/src/com/unciv/logic/automation/civilization/ReligionAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/ReligionAutomation.kt
@@ -67,7 +67,7 @@ object ReligionAutomation {
         // Buy religious buildings in cities if possible
         val citiesWithMissingReligiousBuildings = civInfo.cities.filter { city ->
             city.religion.getMajorityReligion() != null
-            && !city.cityConstructions.builtBuildings.containsAll(city.religion.getMajorityReligion()!!.buildingsPurchasableByBeliefs)
+            && !city.cityConstructions.isAllBuilt(city.religion.getMajorityReligion()!!.buildingsPurchasableByBeliefs)
         }
         if (citiesWithMissingReligiousBuildings.any()) {
             tryBuyAnyReligiousBuilding(civInfo)

--- a/core/src/com/unciv/logic/city/CityConstructions.kt
+++ b/core/src/com/unciv/logic/city/CityConstructions.kt
@@ -185,7 +185,7 @@ class CityConstructions : IsPartOfGameInfoSerialization {
 
     fun getCurrentConstruction(): IConstruction = getConstruction(currentConstructionFromQueue)
 
-    fun isAllBuilt(builingList: List<String>): Boolean {
+    fun isAllBuilt(buildingList: List<String>): Boolean {
         for(building in buildingList)
         {
             if (getBuiltBuildings().none { it.name == building })
@@ -194,7 +194,7 @@ class CityConstructions : IsPartOfGameInfoSerialization {
         return true
     }
 
-    fun isBuilt(buildingName: String): Boolean = builtBuildings.contains(buildingName)
+    fun isBuilt(buildingName: String): Boolean = builtBuildingObjects.any{ it.name == buildingName }
     @Suppress("MemberVisibilityCanBePrivate")
     fun isBeingConstructed(constructionName: String): Boolean = currentConstructionFromQueue == constructionName
     fun isEnqueued(constructionName: String): Boolean = constructionQueue.contains(constructionName)

--- a/core/src/com/unciv/logic/city/CityConstructions.kt
+++ b/core/src/com/unciv/logic/city/CityConstructions.kt
@@ -185,16 +185,9 @@ class CityConstructions : IsPartOfGameInfoSerialization {
 
     fun getCurrentConstruction(): IConstruction = getConstruction(currentConstructionFromQueue)
 
-    fun isAllBuilt(buildingList: List<String>): Boolean {
-        for(building in buildingList)
-        {
-            if (getBuiltBuildings().none { it.name == building })
-                return false
-        }
-        return true
-    }
+    fun isAllBuilt(buildingList: List<String>): Boolean = buildingList.all { isBuilt(it) }
 
-    fun isBuilt(buildingName: String): Boolean = builtBuildingObjects.any{ it.name == buildingName }
+    fun isBuilt(buildingName: String): Boolean = builtBuildingObjects.any { it.name == buildingName }
     @Suppress("MemberVisibilityCanBePrivate")
     fun isBeingConstructed(constructionName: String): Boolean = currentConstructionFromQueue == constructionName
     fun isEnqueued(constructionName: String): Boolean = constructionQueue.contains(constructionName)

--- a/core/src/com/unciv/logic/city/CityConstructions.kt
+++ b/core/src/com/unciv/logic/city/CityConstructions.kt
@@ -185,6 +185,15 @@ class CityConstructions : IsPartOfGameInfoSerialization {
 
     fun getCurrentConstruction(): IConstruction = getConstruction(currentConstructionFromQueue)
 
+    fun isAllBuilt(builingList: List<String>): Boolean {
+        for(building in buildingList)
+        {
+            if (getBuiltBuildings().none { it.name == building })
+                return false
+        }
+        return true
+    }
+
     fun isBuilt(buildingName: String): Boolean = builtBuildings.contains(buildingName)
     @Suppress("MemberVisibilityCanBePrivate")
     fun isBeingConstructed(constructionName: String): Boolean = currentConstructionFromQueue == constructionName
@@ -544,8 +553,10 @@ class CityConstructions : IsPartOfGameInfoSerialization {
     }
 
     fun removeBuilding(buildingName: String) {
-        val buildingObject = city.getRuleset().buildings[buildingName]!!
-        builtBuildingObjects = builtBuildingObjects.withoutItem(buildingObject)
+        val buildingObject = city.getRuleset().buildings[buildingName]
+        if (buildingObject != null)
+            builtBuildingObjects = builtBuildingObjects.withoutItem(buildingObject)
+        else builtBuildingObjects.removeAll{ it.name == buildingName }
         builtBuildings.remove(buildingName)
         city.civ.cache.updateCivResources() // this building could be a resource-requiring one
         city.civ.cache.updateCitiesConnectedToCapital(false) // could be a connecting building, like a harbor

--- a/core/src/com/unciv/logic/city/CityStats.kt
+++ b/core/src/com/unciv/logic/city/CityStats.kt
@@ -302,7 +302,7 @@ class CityStats(val city: City) {
         if (currentConstruction is Building
             && city.civ.cities.isNotEmpty()
             && city.civ.getCapital() != null
-            && city.civ.getCapital()!!.cityConstructions.builtBuildings.contains(currentConstruction.name)
+            && city.civ.getCapital()!!.cityConstructions.isBuilt(currentConstruction.name)
         ) {
             for (unique in city.getMatchingUniques(UniqueType.PercentProductionBuildingsInCapital))
                 addUniqueStats(unique, Stat.Production, unique.params[0].toFloat())

--- a/core/src/com/unciv/logic/civilization/Civilization.kt
+++ b/core/src/com/unciv/logic/civilization/Civilization.kt
@@ -629,8 +629,8 @@ class Civilization : IsPartOfGameInfoSerialization {
         scoreBreakdown["Population"] = cities.sumOf { it.population.population } * 3 * mapSizeModifier
         scoreBreakdown["Tiles"] = cities.sumOf { city -> city.getTiles().filter { !it.isWater}.count() } * 1 * mapSizeModifier
         scoreBreakdown["Wonders"] = 40 * cities
-            .sumOf { city -> city.cityConstructions.builtBuildings
-                .filter { gameInfo.ruleset.buildings[it]!!.isWonder }.size
+            .sumOf { city -> city.cityConstructions.getBuiltBuildings()
+                .filter { it.isWonder }.count()
             }.toDouble()
         scoreBreakdown["Technologies"] = tech.getNumberOfTechsResearched() * 4.toDouble()
         scoreBreakdown["Future Tech"] = tech.repeatingTechsResearched * 10.toDouble()

--- a/core/src/com/unciv/models/ruleset/Victory.kt
+++ b/core/src/com/unciv/models/ruleset/Victory.kt
@@ -82,7 +82,7 @@ class Milestone(val uniqueDescription: String, private val parentVictory: Victor
     fun hasBeenCompletedBy(civInfo: Civilization): Boolean {
         return when (type!!) {
             MilestoneType.BuiltBuilding ->
-                civInfo.cities.any { it.cityConstructions.builtBuildings.contains(params[0])}
+                civInfo.cities.any { it.cityConstructions.isBuilt(params[0])}
             MilestoneType.AddedSSPartsInCapital -> {
                 getIncompleteSpaceshipParts(civInfo).isEmpty()
             }
@@ -93,7 +93,7 @@ class Milestone(val uniqueDescription: String, private val parentVictory: Victor
             MilestoneType.CompletePolicyBranches ->
                 civInfo.policies.completedBranches.size >= params[0].toInt()
             MilestoneType.BuildingBuiltGlobally -> civInfo.gameInfo.getCities().any {
-                it.cityConstructions.builtBuildings.contains(params[0])
+                it.cityConstructions.isBuilt(params[0])
             }
             MilestoneType.WinDiplomaticVote -> civInfo.victoryManager.hasEverWonDiplomaticVote
             MilestoneType.ScoreAfterTimeOut -> {

--- a/core/src/com/unciv/ui/objectdescriptions/TechnologyDescriptions.kt
+++ b/core/src/com/unciv/ui/objectdescriptions/TechnologyDescriptions.kt
@@ -100,7 +100,7 @@ object TechnologyDescriptions {
                     // doesn't have the tech, so it can't have this built anyways. It should be a
                     // little more performant though to add this filter.
                     .filter{ it.civ != viewingCiv }
-                    .any { it.cityConstructions.builtBuildings.contains(building.name) }
+                    .any { it.cityConstructions.isBuilt(building.name)}
                 val wonderConstructionPortrait =
                         if (isAlreadyBuilt)
                             PortraitUnavailableWonderForTechTree(building.name, techIconSize)

--- a/core/src/com/unciv/ui/screens/overviewscreen/WonderOverviewTab.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/WonderOverviewTab.kt
@@ -230,7 +230,7 @@ class WonderInfo {
         }
 
         for (city in gameInfo.getCities()) {
-            for (wonderName in city.cityConstructions.builtBuildings.intersect(wonderIndexMap.keys)) {
+            for (wonderName in city.cityConstructions.getBuiltBuildings().map { it.name }.toList().intersect(wonderIndexMap.keys)) {
                 val index = wonderIndexMap[wonderName]!!
                 val status = when {
                     viewingPlayer == city.civ -> WonderStatus.Owned

--- a/tests/src/com/unciv/logic/civilization/CapitalConnectionsFinderTests.kt
+++ b/tests/src/com/unciv/logic/civilization/CapitalConnectionsFinderTests.kt
@@ -71,16 +71,17 @@ class CapitalConnectionsFinderTests {
     }
 
     private fun createCity(civInfo: Civilization, position: Vector2, name: String, capital: Boolean = false, hasHarbor: Boolean = false): City {
-        return City().apply {
+        val city =  City().apply {
             location = position
-            if (capital)
-                cityConstructions.builtBuildings.add(rules.buildings.values.first { it.hasUnique(UniqueType.IndicatesCapital) }.name)
-            if (hasHarbor)
-                cityConstructions.builtBuildings.add(rules.buildings.values.first { it.hasUnique(UniqueType.ConnectTradeRoutes) }.name)
             this.name = name
             setTransients(civInfo)
             gameInfo.tileMap[location].setOwningCity(this)
         }
+        if (capital)
+            city.cityConstructions.addBuilding(rules.buildings.values.first { it.hasUnique(UniqueType.IndicatesCapital) }.name)
+        if (hasHarbor)
+            city.cityConstructions.addBuilding(rules.buildings.values.first { it.hasUnique(UniqueType.ConnectTradeRoutes) }.name)
+        return city
     }
 
     private fun meetCivAndSetBorders(name: String, areBordersOpen: Boolean) {


### PR DESCRIPTION
PR attempts to removes almost every call to cityConstructions.builtBuildings. Most other systems does not use it (it uses builtBuildingObjects in some way or form) and it opens the way for possible other bugs. The primary places where it was left was in setTransients, the add/remove functions, the clone function, and any places where the other PR of mine already removed the intraction. The only place where I'm not sure builtBuildingObjects is necessarily better is for the wonder overview tab, but everything else should be consistent with how it looks like it should be used

There's the function for `changeBuildingNameIfNotInRuleset`. From what I can tell, it's currently only used for the Hanse, it was done 2 years ago (past deprecation period likely), and seems imo more likely to cause issues in mods than it is to help (given it was done 2 years ago). This PR removes the call to the function for now