### PR TITLE
Prevent deserialization problem with Espionage

### DIFF
--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -56,6 +56,13 @@ import java.util.UUID
  * When you change the structure of any class with this interface in a way which makes it impossible
  * to load the new saves from an older game version, increment [CURRENT_COMPATIBILITY_NUMBER]! And don't forget
  * to add backwards compatibility for the previous format.
+ *
+ * Reminder: In all subclasse, do use only actual Collection types, not abstractions like
+ * `= mutableSetOf<Something>()`. That would make the reflection type of the field an interface, which
+ * hides the actual implementation from Gdx Json, so it will not try to call a no-args constructor but
+ * will instead deserialize a List in the jsonData.isArray() -> isAssignableFrom(Collection) branch of readValue:
+ * https://github.com/libgdx/libgdx/blob/75612dae1eeddc9611ed62366858ff1d0ac7898b/gdx/src/com/badlogic/gdx/utils/Json.java#L1111
+ * .. which will crash later (when readFields actually assigns it) unless empty.
  */
 interface IsPartOfGameInfoSerialization
 

--- a/core/src/com/unciv/logic/civilization/managers/EspionageManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/EspionageManager.kt
@@ -8,15 +8,19 @@ import com.unciv.models.Spy
 
 class EspionageManager : IsPartOfGameInfoSerialization {
 
-    var spyList = mutableListOf<Spy>()
-    val erasSpyEarnedFor = mutableSetOf<String>()
+    var spyList = ArrayList<Spy>()
+    val erasSpyEarnedFor = LinkedHashSet<String>()
+        // mutableSetOf makes the reflection type an interface and that hides the set from Gdx Json,
+        // it will deserialize a List in the jsonData.isArray() -> isAssignableFrom(Collection) branch of readValue:
+        // https://github.com/libgdx/libgdx/blob/75612dae1eeddc9611ed62366858ff1d0ac7898b/gdx/src/com/badlogic/gdx/utils/Json.java#L1111
+        // .. which will crash later (when readFields actually assigns it) unless empty.
 
     @Transient
     lateinit var civInfo: Civilization
 
     fun clone(): EspionageManager {
         val toReturn = EspionageManager()
-        toReturn.spyList.addAll(spyList.map { it.clone() })
+        spyList.mapTo(toReturn.spyList) { it.clone() }
         toReturn.erasSpyEarnedFor.addAll(erasSpyEarnedFor)
         return toReturn
     }

--- a/core/src/com/unciv/logic/civilization/managers/EspionageManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/EspionageManager.kt
@@ -10,10 +10,6 @@ class EspionageManager : IsPartOfGameInfoSerialization {
 
     var spyList = ArrayList<Spy>()
     val erasSpyEarnedFor = LinkedHashSet<String>()
-        // mutableSetOf makes the reflection type an interface and that hides the set from Gdx Json,
-        // it will deserialize a List in the jsonData.isArray() -> isAssignableFrom(Collection) branch of readValue:
-        // https://github.com/libgdx/libgdx/blob/75612dae1eeddc9611ed62366858ff1d0ac7898b/gdx/src/com/badlogic/gdx/utils/Json.java#L1111
-        // .. which will crash later (when readFields actually assigns it) unless empty.
 
     @Transient
     lateinit var civInfo: Civilization


### PR DESCRIPTION
There was an issue where I commented on this, but can't find it.
With current master, no save can be reloaded that has a non-empty erasSpyEarnedFor.

* Too much comment?
* Sniffing into Espionage - I would be tempted to allow unique quotes and portraits per individual Spy, at least as Mod. Imagine a mugshot taken from wikipedia plus the quote "A harlot? Yes, but a traitoress, never! - Phrase attributed to margaretha Zelle during the trial" for "Mata Hari"...
    Civ5 itself seem not to have such a feature... Yes/No, and if Yes - data schema? Extra Json, mapping decorations per Spy name / deprecate spyNames in favour of an array of SpyMetadata objects / custom deserializer that reads both? Display on-click in Espionage screen or on getting a Spy as AlertPopup like the Tech/Wonder quotes?
