### PR TITLE
Fixed automated workers not replacing forts for AI civ.

### DIFF
--- a/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
@@ -162,13 +162,6 @@ class WorkerAutomation(
             return
         }
 
-        //If we have reached a fort tile that is in progress and shouldn't be there, cancel it.
-        if (currentTile.improvementInProgress == Constants.fort
-                && !evaluateFortSuroundings(currentTile, false)) {
-            debug("Replacing fort in progress with new improvement")
-            currentTile.stopWorkingOnImprovement()
-        }
-
         if (currentTile.improvementInProgress == null && tileCanBeImproved(unit, currentTile)) {
             debug("WorkerAutomation: ${unit.label()} -> start improving $currentTile")
             return currentTile.startWorkingOnImprovement(chooseImprovement(unit, currentTile)!!, civInfo, unit)

--- a/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
@@ -556,8 +556,8 @@ class WorkerAutomation(
      * @return Yes the location is good for a Fort here
      */
     fun evaluateFortPlacement(tile: Tile, isCitadel: Boolean): Boolean {
-        return evaluateFortSuroundings(tile,isCitadel)
-            && tile.improvement != Constants.fort // don't build fort if it is already here
+        return tile.improvement != Constants.fort // don't build fort if it is already here
+            && evaluateFortSuroundings(tile,isCitadel)
     }
 
     private fun hasWorkableSeaResource(tile: Tile, civInfo: Civilization): Boolean =

--- a/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
@@ -131,7 +131,7 @@ class WorkerAutomation(
             if (reachedTile != currentTile) unit.doAction() // otherwise, we get a situation where the worker is automated, so it tries to move but doesn't, then tries to automate, then move, etc, forever. Stack overflow exception!
 
             //If we have reached a fort tile that is in progress and shouldn't be there, cancel it.
-            if (reachedTile == tileToWork && (reachedTile.improvementInProgress == Constants.fort && !evaluateFortSuroundings(currentTile, false))) {
+            if (reachedTile == tileToWork && reachedTile.improvementInProgress == Constants.fort && !evaluateFortSuroundings(currentTile, false)) {
                 debug("Replacing fort in progress with new improvement")
                 reachedTile.stopWorkingOnImprovement()
             }
@@ -163,8 +163,8 @@ class WorkerAutomation(
         }
 
         //If we have reached a fort tile that is in progress and shouldn't be there, cancel it.
-        if ((currentTile.improvementInProgress == Constants.fort
-                && !evaluateFortSuroundings(currentTile, false))) {
+        if (currentTile.improvementInProgress == Constants.fort
+                && !evaluateFortSuroundings(currentTile, false)) {
             debug("Replacing fort in progress with new improvement")
             currentTile.stopWorkingOnImprovement()
         }

--- a/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
@@ -129,20 +129,27 @@ class WorkerAutomation(
             debug("WorkerAutomation: %s -> head towards %s", unit.label(), tileToWork)
             val reachedTile = unit.movement.headTowards(tileToWork)
             if (reachedTile != currentTile) unit.doAction() // otherwise, we get a situation where the worker is automated, so it tries to move but doesn't, then tries to automate, then move, etc, forever. Stack overflow exception!
+
+            //If we have reached a fort tile that is in progress and shouldn't be there, cancel it.
+            if (reachedTile == tileToWork && (reachedTile.improvementInProgress == Constants.fort && !evaluateFortSuroundings(currentTile, false))) {
+                debug("Replacing fort in progress with new improvement")
+                reachedTile.stopWorkingOnImprovement()
+            }
+
             // If there's move still left, perform action
             // Unit may stop due to Enemy Unit within walking range during doAction() call
             if (unit.currentMovement > 0 && reachedTile == tileToWork) {
                 if (reachedTile.isPillaged()) {
-                    debug("WorkerAutomation: ${unit.label()} -> repairs $currentTile")
+                    debug("WorkerAutomation: ${unit.label()} -> repairs $reachedTile")
                     UnitActions.getRepairAction(unit).invoke()
                     return
                 }
-                if (currentTile.improvementInProgress == null && currentTile.isLand
-                        && tileCanBeImproved(unit, currentTile)
+                if (reachedTile.improvementInProgress == null && reachedTile.isLand
+                        && tileCanBeImproved(unit, reachedTile)
                 ) {
-                    debug("WorkerAutomation: ${unit.label()} -> start improving $currentTile")
-                    return currentTile.startWorkingOnImprovement(
-                        chooseImprovement(unit, currentTile)!!, civInfo, unit
+                    debug("WorkerAutomation: ${unit.label()} -> start improving $reachedTile")
+                    return reachedTile.startWorkingOnImprovement(
+                        chooseImprovement(unit, reachedTile)!!, civInfo, unit
                     )
                 }
             }
@@ -153,6 +160,13 @@ class WorkerAutomation(
             debug("WorkerAutomation: ${unit.label()} -> repairs $currentTile")
             UnitActions.getRepairAction(unit).invoke()
             return
+        }
+
+        //If we have reached a fort tile that is in progress and shouldn't be there, cancel it.
+        if ((currentTile.improvementInProgress == Constants.fort
+                && !evaluateFortSuroundings(currentTile, false))) {
+            debug("Replacing fort in progress with new improvement")
+            currentTile.stopWorkingOnImprovement()
         }
 
         if (currentTile.improvementInProgress == null && tileCanBeImproved(unit, currentTile)) {
@@ -331,7 +345,10 @@ class WorkerAutomation(
                 && civInfo.cities.none { it.getCenterTile().aerialDistanceTo(tile) <= 3 })
             return false // unworkable tile
 
-        val junkImprovement = tile.getTileImprovement()?.hasUnique(UniqueType.AutomatedWorkersWillReplace)
+        //If the tile is a junk improvement or a fort placed in a bad location.
+        val junkImprovement = tile.getTileImprovement()?.hasUnique(UniqueType.AutomatedWorkersWillReplace) == true
+            || (tile.improvement == Constants.fort && !evaluateFortSuroundings(tile, false) && !civInfo.isHuman())
+
         if (tile.improvement != null && junkImprovement == false
                 && !UncivGame.Current.settings.automatedWorkersReplaceImprovements
                 && unit.civ.isHuman())
@@ -451,7 +468,7 @@ class WorkerAutomation(
     }
 
     /**
-     * Checks whether a given tile allows a Fort and whether a Fort may be undesirable (without checking surroundings).
+     * Checks whether a given tile allows a Fort and whether a Fort may be undesirable (without checking surroundings or if there is a fort already on the tile).
      *
      * -> Checks: city, already built, resource, great improvements.
      * Used only in [evaluateFortPlacement].
@@ -460,7 +477,6 @@ class WorkerAutomation(
         //todo Should this not also check impassable and the fort improvement's terrainsCanBeBuiltOn/uniques?
         if (tile.isCityCenter() // don't build fort in the city
             || !tile.isLand // don't build fort in the water
-            || tile.improvement == Constants.fort // don't build fort if it is already here
             || tile.hasViewableResource(civInfo) // don't build on resource tiles
             || tile.containsGreatImprovement() // don't build on great improvements (including citadel)
         ) return false
@@ -470,10 +486,12 @@ class WorkerAutomation(
 
     /**
      * Do we want a Fort [here][tile] considering surroundings?
+     * (but does not check if if there is already a fort here)
+     *
      * @param  isCitadel Controls within borders check - true also allows 1 tile outside borders
-     * @return Yes please build a Fort here
+     * @return Yes the location is good for a Fort here
      */
-    fun evaluateFortPlacement(tile: Tile, isCitadel: Boolean): Boolean {
+    private fun evaluateFortSuroundings(tile: Tile, isCitadel: Boolean): Boolean {
         //todo Is the Citadel code dead anyway? If not - why does the nearestTiles check not respect the param?
 
         // build on our land only
@@ -536,6 +554,17 @@ class WorkerAutomation(
         // let's build fort on the front line, not behind the city
         // +2 is a acceptable deviation from the straight line between cities
         return distanceBetweenCities + 2 > distanceToEnemy + distanceToOurCity
+    }
+
+    /**
+     * Do we want to build a Fort [here][tile] considering surroundings?
+     *
+     * @param  isCitadel Controls within borders check - true also allows 1 tile outside borders
+     * @return Yes the location is good for a Fort here
+     */
+    fun evaluateFortPlacement(tile: Tile, isCitadel: Boolean): Boolean {
+        return evaluateFortSuroundings(tile,isCitadel)
+            && tile.improvement != Constants.fort // don't build fort if it is already here
     }
 
     private fun hasWorkableSeaResource(tile: Tile, civInfo: Civilization): Boolean =


### PR DESCRIPTION
This fixes the issues described in #9836. Workers will now replace forts on their land. They will also immediately cancel in-progress forts (although it needs a little more testing to confirm that the new improvement did not lose a turn of construction).

To prevent automated workers from removing player Civ forts, automated workers don't replace forts for the player Civ.

Note: From what I have seen, the AI does not seem to build forts before this change. I doubt this changed it in any way, but it could reduce future commits to improving new fort placement by the AI.

Also Note: There were a few lines in WorkerAutomation.kt from lines 136-152 that referenced the old tile (currentTile) instead of the new tile (reachedTile) the worker moved to that I changed. Logically the previous version didn't make sense to me. This does change non-fort-related behaviors.