### PR TITLE
Clean up some differences between units that can move on water and other units

### DIFF
--- a/core/src/com/unciv/logic/automation/unit/BattleHelper.kt
+++ b/core/src/com/unciv/logic/automation/unit/BattleHelper.kt
@@ -121,8 +121,8 @@ object BattleHelper {
         if (tileCombatant is CityCombatant && tileCombatant.city.hasJustBeenConquered) return false
         if (!combatant.getCivInfo().isAtWarWith(tileCombatant.getCivInfo())) return false
 
-        if (combatant is MapUnitCombatant && combatant.isLandUnit() && combatant.isMelee() &&
-            !combatant.hasUnique(UniqueType.LandUnitEmbarkation) && tile.isWater
+        if (combatant is MapUnitCombatant && combatant.isLandUnit() && combatant.isMelee() && tile.isWater &&
+            (!combatant.hasUnique(UniqueType.LandUnitEmbarkation) && !combatant.hasUnique(UniqueType.CanMoveOnWater))
         )
             return false
 

--- a/core/src/com/unciv/logic/automation/unit/BattleHelper.kt
+++ b/core/src/com/unciv/logic/automation/unit/BattleHelper.kt
@@ -122,7 +122,7 @@ object BattleHelper {
         if (!combatant.getCivInfo().isAtWarWith(tileCombatant.getCivInfo())) return false
 
         if (combatant is MapUnitCombatant && combatant.isLandUnit() && combatant.isMelee() && tile.isWater &&
-            (!combatant.hasUnique(UniqueType.LandUnitEmbarkation) && !combatant.hasUnique(UniqueType.CanMoveOnWater))
+            (!combatant.getCivInfo().tech.unitsCanEmbark && !combatant.unit.cache.canMoveOnWater)
         )
             return false
 

--- a/core/src/com/unciv/logic/automation/unit/BattleHelper.kt
+++ b/core/src/com/unciv/logic/automation/unit/BattleHelper.kt
@@ -122,7 +122,7 @@ object BattleHelper {
         if (!combatant.getCivInfo().isAtWarWith(tileCombatant.getCivInfo())) return false
 
         if (combatant is MapUnitCombatant && combatant.isLandUnit() && combatant.isMelee() && tile.isWater &&
-            (!combatant.getCivInfo().tech.unitsCanEmbark && !combatant.unit.cache.canMoveOnWater)
+            !combatant.getCivInfo().tech.unitsCanEmbark && !combatant.unit.cache.canMoveOnWater
         )
             return false
 

--- a/core/src/com/unciv/logic/battle/BattleDamage.kt
+++ b/core/src/com/unciv/logic/battle/BattleDamage.kt
@@ -114,7 +114,7 @@ object BattleDamage {
         val modifiers = getGeneralModifiers(attacker, defender, CombatAction.Attack, tileToAttackFrom)
 
         if (attacker is MapUnitCombatant) {
-            if (attacker.unit.isEmbarked()
+            if (attacker.unit.isEmbarked() && defender.getTile().isLand
                     && !attacker.unit.hasUnique(UniqueType.AttackAcrossCoast))
                 modifiers["Landing"] = -50
 

--- a/core/src/com/unciv/logic/battle/BattleDamage.kt
+++ b/core/src/com/unciv/logic/battle/BattleDamage.kt
@@ -1,5 +1,6 @@
 package com.unciv.logic.battle
 
+import com.unciv.Constants
 import com.unciv.logic.map.tile.Tile
 import com.unciv.models.Counter
 import com.unciv.models.ruleset.GlobalUniques
@@ -116,7 +117,7 @@ object BattleDamage {
         if (attacker is MapUnitCombatant) {
             if (attacker.unit.isEmbarked()
                     && !attacker.unit.hasUnique(UniqueType.AttackAcrossCoast))
-                modifiers["Embarked"] = -50
+                modifiers[Constants.embarked] = -50
 
             // Land Melee Unit attacking to Water
             if (attacker.unit.type.isLandUnit() && !attacker.getTile().isWater && attacker.isMelee() && defender.getTile().isWater

--- a/core/src/com/unciv/logic/battle/BattleDamage.kt
+++ b/core/src/com/unciv/logic/battle/BattleDamage.kt
@@ -1,6 +1,5 @@
 package com.unciv.logic.battle
 
-import com.unciv.Constants
 import com.unciv.logic.map.tile.Tile
 import com.unciv.models.Counter
 import com.unciv.models.ruleset.GlobalUniques
@@ -115,9 +114,9 @@ object BattleDamage {
         val modifiers = getGeneralModifiers(attacker, defender, CombatAction.Attack, tileToAttackFrom)
 
         if (attacker is MapUnitCombatant) {
-            if (attacker.unit.isEmbarked()
+            if (attacker.unit.isEmbarked() && defender.getTile().isLand
                     && !attacker.unit.hasUnique(UniqueType.AttackAcrossCoast))
-                modifiers[Constants.embarked] = -50
+                modifiers["Landing"] = -50
 
             // Land Melee Unit attacking to Water
             if (attacker.unit.type.isLandUnit() && !attacker.getTile().isWater && attacker.isMelee() && defender.getTile().isWater

--- a/core/src/com/unciv/logic/battle/BattleDamage.kt
+++ b/core/src/com/unciv/logic/battle/BattleDamage.kt
@@ -114,9 +114,9 @@ object BattleDamage {
         val modifiers = getGeneralModifiers(attacker, defender, CombatAction.Attack, tileToAttackFrom)
 
         if (attacker is MapUnitCombatant) {
-            if (attacker.unit.isEmbarked() && defender.getTile().isLand
+            if (attacker.unit.isEmbarked()
                     && !attacker.unit.hasUnique(UniqueType.AttackAcrossCoast))
-                modifiers["Landing"] = -50
+                modifiers["Embarked"] = -50
 
             // Land Melee Unit attacking to Water
             if (attacker.unit.type.isLandUnit() && !attacker.getTile().isWater && attacker.isMelee() && defender.getTile().isWater

--- a/core/src/com/unciv/logic/map/TileMap.kt
+++ b/core/src/com/unciv/logic/map/TileMap.kt
@@ -513,7 +513,7 @@ class TileMap(initialCapacity: Int = 10) : IsPartOfGameInfoSerialization {
             var potentialCandidates = getPassableNeighbours(currentTile)
             while (unitToPlaceTile == null && tryCount++ < 10) {
                 unitToPlaceTile = potentialCandidates
-                        .sortedByDescending { if (unit.baseUnit.isLandUnit()) it.isLand else true } // Land units should prefer to go into land tiles
+                        .sortedByDescending { if (unit.baseUnit.isLandUnit() && !unit.cache.canMoveOnWater) it.isLand else true } // Land units should prefer to go into land tiles
                         .firstOrNull { unit.movement.canMoveTo(it) }
                 if (unitToPlaceTile != null) continue
                 // if it's not found yet, let's check their neighbours

--- a/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
@@ -509,7 +509,7 @@ class MapUnit : IsPartOfGameInfoSerialization {
         var healing = when {
             tile.isCityCenter() -> 25
             tile.isWater && isFriendlyTerritory && (baseUnit.isWaterUnit() || isTransported) -> 20 // Water unit on friendly water
-            tile.isWater && isFriendlyTerritory && (baseUnit.hasUnique(UniqueType.CanMoveOnWater)) -> 20 // Treated as a water unit on friendly water
+            tile.isWater && isFriendlyTerritory && cache.canMoveOnWater -> 20 // Treated as a water unit on friendly water
             tile.isWater -> 0 // All other water cases
             isFriendlyTerritory -> 20 // Allied territory
             tile.getOwner() == null -> 10 // Neutral territory

--- a/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
@@ -509,6 +509,7 @@ class MapUnit : IsPartOfGameInfoSerialization {
         var healing = when {
             tile.isCityCenter() -> 25
             tile.isWater && isFriendlyTerritory && (baseUnit.isWaterUnit() || isTransported) -> 20 // Water unit on friendly water
+            tile.isWater && isFriendlyTerritory && (baseUnit.hasUnique(UniqueType.CanMoveOnWater)) -> 20 // Treated as a water unit on friendly water
             tile.isWater -> 0 // All other water cases
             isFriendlyTerritory -> 20 // Allied territory
             tile.getOwner() == null -> 10 // Neutral territory

--- a/core/src/com/unciv/logic/map/mapunit/UnitMovement.kt
+++ b/core/src/com/unciv/logic/map/mapunit/UnitMovement.kt
@@ -769,7 +769,7 @@ class UnitMovement(val unit: MapUnit) {
                     unit.civ.getMatchingUniques(UniqueType.UnitsMayEnterOcean)
                         .any { unit.matchesFilter(it.params[0]) }
         }
-        if (tile.isWater && unit.baseUnit.isLandUnit()) {
+        if (tile.isWater && unit.baseUnit.isLandUnit() && !unit.cache.canMoveOnWater) {
             if (!unit.civ.tech.unitsCanEmbark) return false
             if (tile.isOcean && !unit.civ.tech.embarkedUnitsCanEnterOcean && !unitSpecificAllowOcean)
                 return false
@@ -791,7 +791,7 @@ class UnitMovement(val unit: MapUnit) {
         if (firstUnit != null && unit.civ != firstUnit.civ) {
             // Allow movement through unguarded, at-war Civilian Unit. Capture on the way
             // But not for Embarked Units capturing on Water
-            if (!(unit.baseUnit.isLandUnit() && tile.isWater)
+            if (!(unit.baseUnit.isLandUnit() && tile.isWater && !unit.cache.canMoveOnWater)
                     && firstUnit.isCivilian() && unit.civ.isAtWarWith(firstUnit.civ))
                 return true
             // Cannot enter hostile tile with any unit in there


### PR DESCRIPTION
I'm not sure if units that can move over water should heal on water like a water unit (20 in friendly land, 0 elsewhere) or like a land unit (20 in friendly land, 10 elsewhere)

I also intended to remove the penalty when embarked units attacks other naval/embarked units via UniqueType.AttackOnSea, but I can't find evidence this unique is actually being used correctly