### PR TITLE
Simple Originating-Mod display in Civilopedia

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -1592,6 +1592,7 @@ Domain: [param] =
 Toggle UI (World Screen only) = 
 Overrides yields from underlying terrain = 
 No yields = 
+Mod: [modname] = 
 
 # Policies
 

--- a/core/src/com/unciv/ui/screens/civilopediascreen/ICivilopediaText.kt
+++ b/core/src/com/unciv/ui/screens/civilopediascreen/ICivilopediaText.kt
@@ -2,6 +2,7 @@ package com.unciv.ui.screens.civilopediascreen
 
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.unciv.UncivGame
+import com.unciv.models.ruleset.IRulesetObject
 import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.stats.INamed
 
@@ -81,6 +82,10 @@ interface ICivilopediaText {
             if (!middleDone) {
                 if (outerNotEmpty) yield(FormattedLine())
                 yieldAll(getCivilopediaTextLines(ruleset))
+            }
+            if (this@ICivilopediaText is IRulesetObject && ruleset.mods.size > 1) {
+                yield(FormattedLine())
+                yield(FormattedLine("Mod: [$originRuleset]", starred = true, color = "#daa520"))
             }
         }
         return SimpleCivilopediaText(newLines.toList())

--- a/core/src/com/unciv/ui/screens/civilopediascreen/ICivilopediaText.kt
+++ b/core/src/com/unciv/ui/screens/civilopediascreen/ICivilopediaText.kt
@@ -83,7 +83,7 @@ interface ICivilopediaText {
                 if (outerNotEmpty) yield(FormattedLine())
                 yieldAll(getCivilopediaTextLines(ruleset))
             }
-            if (this@ICivilopediaText is IRulesetObject && ruleset.mods.size > 1) {
+            if (this@ICivilopediaText is IRulesetObject && ruleset.mods.size > 1 && originRuleset.isNotEmpty()) {
                 yield(FormattedLine())
                 yield(FormattedLine("Mod: [$originRuleset]", starred = true, color = "#daa520"))
             }


### PR DESCRIPTION
![r](https://github.com/yairm210/Unciv/assets/63000004/6c582815-2323-43c1-9869-ec50de15dbde)

~~Forgot the i10n template. Any suggestions to wording before I add that?~~ Patched. Also patched for easter eggs - they don't have origins, intentionally.