### PR TITLE
Spectator can now see all invisible units 

### DIFF
--- a/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
@@ -383,9 +383,9 @@ class MapUnit : IsPartOfGameInfoSerialization {
     }
 
     fun isInvisible(to: Civilization): Boolean {
-        if (hasUnique(UniqueType.Invisible))
+        if (hasUnique(UniqueType.Invisible) && !to.isSpectator())
             return true
-        if (hasUnique(UniqueType.InvisibleToNonAdjacent))
+        if (hasUnique(UniqueType.InvisibleToNonAdjacent) && !to.isSpectator())
             return getTile().getTilesInDistance(1).none {
                 it.getUnits().any { unit -> unit.owner == to.civName }
             }


### PR DESCRIPTION
Fixes #9851

Submarines are now visible to the spectator without fog of war but are still not visible to the spectator when selecting a civ that shouldn't see the submarine.