### PR TITLE
Fix resources subtracting in an incorrect manner when they have the same source

### DIFF
--- a/core/src/com/unciv/logic/city/City.kt
+++ b/core/src/com/unciv/logic/city/City.kt
@@ -202,10 +202,14 @@ class City : IsPartOfGameInfoSerialization {
     fun getCityResources(): ResourceSupplyList {
         val cityResources = ResourceSupplyList()
 
+        val resourceModifer = HashMap<String,Float>()
+        for (resource in civ.gameInfo.ruleset.tileResources.values)
+            resourceModifer[resource.name] = civ.getResourceModifier(resource)
+
         for (tileInfo in getTiles().filter { it.resource != null }) {
             val resource = tileInfo.tileResource
-            val amount = getTileResourceAmount(tileInfo)
-            if (amount > 0) cityResources.add(resource, "Tiles", amount)
+            val amount = getTileResourceAmount(tileInfo) * resourceModifer[resource.name]!!
+            if (amount > 0) cityResources.add(resource, "Tiles", amount.toInt())
         }
 
         for (tileInfo in getTiles()) {
@@ -216,7 +220,7 @@ class City : IsPartOfGameInfoSerialization {
                 val resource = getRuleset().tileResources[unique.params[1]] ?: continue
                 cityResources.add(
                     resource, "Improvements",
-                    unique.params[0].toInt()
+                    (unique.params[0].toFloat() * resourceModifer[resource.name]!!).toInt()
                 )
             }
             for (unique in tileImprovement.getMatchingUniques(UniqueType.ConsumesResources, stateForConditionals)) {
@@ -240,7 +244,7 @@ class City : IsPartOfGameInfoSerialization {
                 ?: continue
             cityResources.add(
                 resource, "Buildings",
-                unique.params[0].toInt()
+                (unique.params[0].toFloat() * resourceModifer[resource.name]!!).toInt()
             )
         }
 

--- a/core/src/com/unciv/logic/civilization/transients/CivInfoTransientCache.kt
+++ b/core/src/com/unciv/logic/civilization/transients/CivInfoTransientCache.kt
@@ -284,10 +284,6 @@ class CivInfoTransientCache(val civInfo: Civilization) {
         val newDetailedCivResources = ResourceSupplyList()
         for (city in civInfo.cities) newDetailedCivResources.add(city.getCityResources())
 
-        for (resourceSupply in newDetailedCivResources)
-            if (resourceSupply.amount > 0)
-                resourceSupply.amount = (resourceSupply.amount * civInfo.getResourceModifier(resourceSupply.resource)).toInt()
-
         if (!civInfo.isCityState()) {
             // First we get all these resources of each city state separately
             val cityStateProvidedResources = ResourceSupplyList()
@@ -306,10 +302,11 @@ class CivInfoTransientCache(val civInfo: Civilization) {
 
         for (unique in civInfo.getMatchingUniques(UniqueType.ProvidesResources)) {
             if (unique.sourceObjectType == UniqueTarget.Building || unique.sourceObjectType == UniqueTarget.Wonder) continue // already calculated in city
+            val resource = civInfo.gameInfo.ruleset.tileResources[unique.params[1]]!!
             newDetailedCivResources.add(
-                civInfo.gameInfo.ruleset.tileResources[unique.params[1]]!!,
+                resource,
                 unique.sourceObjectType?.name ?: "",
-                unique.params[0].toInt()
+                (unique.params[0].toFloat() * civInfo.getResourceModifier(resource)).toInt()
             )
         }
 


### PR DESCRIPTION
Not done here, but if we move where `getResourceModifier` is, we can maybe also have it work for city resources and have it limited to just that target/city