### PR TITLE
Move Mod Manager to prepare class splits

### DIFF
--- a/core/src/com/unciv/ui/screens/mainmenuscreen/MainMenuScreen.kt
+++ b/core/src/com/unciv/ui/screens/mainmenuscreen/MainMenuScreen.kt
@@ -47,7 +47,7 @@ import com.unciv.ui.screens.mapeditorscreen.EditorMapHolder
 import com.unciv.ui.screens.mapeditorscreen.MapEditorScreen
 import com.unciv.ui.screens.multiplayerscreens.MultiplayerScreen
 import com.unciv.ui.screens.newgamescreen.NewGameScreen
-import com.unciv.ui.screens.pickerscreens.ModManagementScreen
+import com.unciv.ui.screens.modmanager.ModManagementScreen
 import com.unciv.ui.screens.savescreens.LoadGameScreen
 import com.unciv.ui.screens.savescreens.QuickSave
 import com.unciv.ui.screens.worldscreen.BackgroundActor

--- a/core/src/com/unciv/ui/screens/modmanager/ModManagementOptions.kt
+++ b/core/src/com/unciv/ui/screens/modmanager/ModManagementOptions.kt
@@ -1,4 +1,4 @@
-package com.unciv.ui.screens.pickerscreens
+package com.unciv.ui.screens.modmanager
 
 import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.scenes.scene2d.Touchable
@@ -23,6 +23,7 @@ import com.unciv.ui.components.input.onChange
 import com.unciv.ui.components.extensions.surroundWithCircle
 import com.unciv.ui.components.extensions.toLabel
 import com.unciv.ui.components.extensions.toTextButton
+import com.unciv.ui.screens.pickerscreens.Github
 import kotlin.math.sign
 
 /**

--- a/core/src/com/unciv/ui/screens/modmanager/ModManagementScreen.kt
+++ b/core/src/com/unciv/ui/screens/modmanager/ModManagementScreen.kt
@@ -1,4 +1,4 @@
-package com.unciv.ui.screens.pickerscreens
+package com.unciv.ui.screens.modmanager
 
 import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.graphics.Color
@@ -46,7 +46,9 @@ import com.unciv.ui.screens.basescreen.BaseScreen
 import com.unciv.ui.screens.basescreen.RecreateOnResize
 import com.unciv.ui.screens.mainmenuscreen.MainMenuScreen
 import com.unciv.ui.screens.pickerscreens.Github.repoNameToFolderName
-import com.unciv.ui.screens.pickerscreens.ModManagementOptions.SortType
+import com.unciv.ui.screens.modmanager.ModManagementOptions.SortType
+import com.unciv.ui.screens.pickerscreens.Github
+import com.unciv.ui.screens.pickerscreens.PickerScreen
 import com.unciv.utils.Concurrency
 import com.unciv.utils.Log
 import com.unciv.utils.launchOnGLThread


### PR DESCRIPTION
This is a package move only, nothing more. The mod manager main screen file is too big, and the other one contains four only loosely related top-level elements. This is to prepare fixing the "resize" issue mentioned in #9854

I'd later split off the "chaff" from ModManagementOptions, remove "UI" from ModUIData - if a RecreateOnResizewants to keep knowledge it should be pure non-UI (or else a resize shouldn't use the interface but relayout the existing UI elements). The main screen - split off at least the modActionTable, possibly the search job with or without the other github glue logic, possibly the mod columns have more in common than differences...