### PR TITLE
Transported units gifting fix

### DIFF
--- a/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
@@ -559,10 +559,9 @@ class MapUnit : IsPartOfGameInfoSerialization {
     fun gift(recipient: Civilization) {
         civ.units.removeUnit(this)
         civ.cache.updateViewableTiles()
-        // all transported units should be destroyed as well
+        // all transported units should be gift as well
         currentTile.getUnits().filter { it.isTransported && isTransportTypeOf(it) }
-            .toList() // because we're changing the list
-            .forEach { unit -> unit.destroy() }
+            .forEach { unit -> unit.gift(recipient) }
         assignOwner(recipient)
         recipient.cache.updateViewableTiles()
     }

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActions.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActions.kt
@@ -634,6 +634,9 @@ object UnitActions {
         // If gifting to major civ they need to be friendly
         else if (!tile.isFriendlyTerritory(unit.civ)) return null
 
+        // Transported units can't be gifted
+        if (unit.isTransported) return null
+
         if (unit.currentMovement <= 0)
             return UnitAction(UnitActionType.GiftUnit, action = null)
 


### PR DESCRIPTION
fixes  #9853

Units that are being gifted gift the transported units as well.

Units that are transported can no longer be gifted.