### PR TITLE
Workaround for Mod previews not showing on default Windows distribution

### DIFF
--- a/core/src/com/unciv/ui/screens/pickerscreens/GitHub.kt
+++ b/core/src/com/unciv/ui/screens/pickerscreens/GitHub.kt
@@ -21,6 +21,7 @@ import java.io.InputStream
 import java.io.InputStreamReader
 import java.net.HttpURLConnection
 import java.net.URL
+import java.nio.Buffer
 import java.nio.ByteBuffer
 import java.util.zip.ZipEntry
 import java.util.zip.ZipFile
@@ -260,7 +261,9 @@ object Github {
                 ?: download("$fileLocation.png")
                 ?: return null
             val byteArray = file.readBytes()
-            val buffer = ByteBuffer.allocateDirect(byteArray.size).put(byteArray).position(0)
+            val buffer = ByteBuffer.allocateDirect(byteArray.size).put(byteArray)
+            // This works around a Java 8 bug. With Java 11+, you can chain the rewind directly on the previous line.
+            (buffer as Buffer).position(0)
             return Pixmap(buffer)
         } catch (_: Throwable) {
             return null


### PR DESCRIPTION
Fixes #9854

# But

... do we really want to? Alternatively we could bundle a better jre, a Java 11-LTS one works fine??? Also, that source - ojdkbuild - is by now archived and stale.

# Alternative
<details>

```patch
Index: .github/workflows/buildAndDeploy.yml
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/.github/workflows/buildAndDeploy.yml b/.github/workflows/buildAndDeploy.yml
--- a/.github/workflows/buildAndDeploy.yml	(revision 26549da2688a6206023d138d3c55e3778f812d50)
+++ b/.github/workflows/buildAndDeploy.yml	(date 1690805806611)
@@ -196,7 +196,7 @@
           wget -q -O jre-linux-64.tar.gz https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.19%2B7/OpenJDK11U-jre_x64_linux_hotspot_11.0.19_7.tar.gz
           ./gradlew desktop:packrLinux64
 
-          wget -q -O jdk-windows-64.zip https://github.com/ojdkbuild/ojdkbuild/releases/download/java-1.8.0-openjdk-1.8.0.232-1.b09/java-1.8.0-openjdk-1.8.0.232-1.b09.ojdkbuild.windows.x86_64.zip
+          wget -q -O jdk-windows-64.zip https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.20%2B8/OpenJDK11U-jre_x64_windows_hotspot_11.0.20_8.zip
           ./gradlew desktop:packrWindows64
 
       - name: Upload packed zips
```
</details>