### PR TITLE
Fixed AI not removing fallout

### DIFF
--- a/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
@@ -138,12 +138,13 @@ class WorkerAutomation(
 
             // If there's move still left, perform action
             // Unit may stop due to Enemy Unit within walking range during doAction() call
-            if (unit.currentMovement > 0 && reachedTile == tileToWork) {
+            if (reachedTile == tileToWork) {
                 if (reachedTile.isPillaged()) {
                     debug("WorkerAutomation: ${unit.label()} -> repairs $reachedTile")
                     UnitActions.getRepairAction(unit).invoke()
                     return
-                } else if (reachedTile.terrainFeatures.contains("Fallout")) {
+                }
+                if (reachedTile.terrainFeatures.contains("Fallout")) {
                     debug("WorkerAutomation: ${unit.label()} -> removes fallout $reachedTile")
                     reachedTile.improvementInProgress = Constants.remove + "Fallout"
                     reachedTile.turnsToImprovement = reachedTile.ruleset.tileImprovements["Remove Fallout"]!!.getTurnsToBuild(unit.civ, unit)


### PR DESCRIPTION
Fixes  #9871

Workers now treat fallout just like repairing an improvement. There might also be an option to alter the chooseImprovement() function  on line 384 to clear the fallout as well. Although I think the bug is not coming from the WorkerAutomation file because I reverted the file to the one in 4.7.0 and commented out unrelated errors and it still didn't work.

Note: I deleted unit.currentMovement > 0 on line 141, this makes the worker show it's improvement once it arrives even if it doesn't have enough movement points to work on it this turn. This is so that the worker shows it's action even when the improvement only takes one turn to complete.