### PR TITLE
feat: added auto next turn

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -763,6 +763,7 @@ When disabled, saves battery life but certain animations will be suspended =
 Gameplay = 
 Check for idle units = 
 Auto Unit Cycle = 
+Auto next turn = 
 Move units with a single tap = 
 Auto-assign city production = 
 Auto-build roads = 

--- a/core/src/com/unciv/models/metadata/GameSettings.kt
+++ b/core/src/com/unciv/models/metadata/GameSettings.kt
@@ -47,6 +47,7 @@ class GameSettings {
     var showSettlersSuggestedCityLocations: Boolean = true
 
     var checkForDueUnits: Boolean = true
+    var autoNextTurn: Boolean = false
     var autoUnitCycle: Boolean = true
     var singleTapMove: Boolean = false
     var language: String = Constants.english

--- a/core/src/com/unciv/ui/popups/options/GameplayTab.kt
+++ b/core/src/com/unciv/ui/popups/options/GameplayTab.kt
@@ -18,6 +18,7 @@ fun gameplayTab(
     val settings = optionsPopup.settings
 
     optionsPopup.addCheckbox(this, "Check for idle units", settings.checkForDueUnits, true) { settings.checkForDueUnits = it }
+    optionsPopup.addCheckbox(this, "Auto next turn", settings.autoNextTurn, true) { settings.autoNextTurn = it }
     optionsPopup.addCheckbox(this, "Auto Unit Cycle", settings.autoUnitCycle, true) { settings.autoUnitCycle = it }
     optionsPopup.addCheckbox(this, "Move units with a single tap", settings.singleTapMove) { settings.singleTapMove = it }
     optionsPopup.addCheckbox(this, "Auto-assign city production", settings.autoAssignCityProduction, true) { shouldAutoAssignCityProduction ->

--- a/core/src/com/unciv/ui/screens/worldscreen/status/NextTurnButton.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/status/NextTurnButton.kt
@@ -2,6 +2,7 @@ package com.unciv.ui.screens.worldscreen.status
 
 import com.badlogic.gdx.graphics.Color
 import com.unciv.Constants
+import com.unciv.UncivGame
 import com.unciv.logic.civilization.managers.ReligionState
 import com.unciv.models.ruleset.BeliefType
 import com.unciv.models.translations.tr
@@ -43,6 +44,14 @@ class NextTurnButton : IconTextButton("", null, 30) {
     fun update(worldScreen: WorldScreen) {
         nextTurnAction = getNextTurnAction(worldScreen)
         updateButton(nextTurnAction)
+
+        if (worldScreen.gameInfo.turns != 0) {
+            if (nextTurnAction.text.tr() == "Next turn".tr() &&
+                UncivGame.Current.settings.autoNextTurn
+            ) {
+                worldScreen.nextTurn()
+            }
+        }
 
         isEnabled = !worldScreen.hasOpenPopups() && worldScreen.isPlayersTurn
                 && !worldScreen.waitingForAutosave && !worldScreen.isNextTurnUpdateRunning()


### PR DESCRIPTION
Resolves #9450
Resolves #2375

Currently it requires `check for idle units` to be disabled. Should it automatically ignore those ? Can you think of other instances in which the game shouldn't go to the next turn besides new tech and new policy? 

Plus it should actually check if you have a city placed instead of `turns != 0` and it should also have a limit, as mentioned in #2375 but I'll do that after I get a response for the questions above :)