### PR TITLE
Italian: Add translations for '# Requires translation' lines

### DIFF
--- a/android/assets/jsons/translations/Italian.properties
+++ b/android/assets/jsons/translations/Italian.properties
@@ -7,8 +7,7 @@
 # If the first word in a sentence starts with a capital in your language, 
 # put the english word 'true' behind the '=', otherwise 'false'.
 # Don't translate these words to your language, only put 'true' or 'false'.
- # Requires translation!
-StartWithCapitalLetter = 
+StartWithCapitalLetter = true
 
 
 # Fastlane
@@ -16,13 +15,11 @@ StartWithCapitalLetter =
 
 # Documentation: https://f-droid.org/en/docs/Build_Metadata_Reference/#Summary
 # English to translate: https://github.com/yairm210/Unciv/blob/master/fastlane/metadata/android/en-US/short_description.txt
- # Requires translation!
-Fastlane_short_description = 
+Fastlane_short_description = Gioco 4X - Costruire una civiltà
 
 # Documentation: https://f-droid.org/en/docs/Build_Metadata_Reference/#Description
 # English to translate: https://github.com/yairm210/Unciv/blob/master/fastlane/metadata/android/en-US/full_description.txt
- # Requires translation!
-Fastlane_full_description = 
+Fastlane_full_description = Una reinterpretazione open source del gioco di gestione delle civiltà più famoso di sempre; per di più veloce, leggero, senza pubblicità e gratuito per sempre!\n\nCostruisci il tuo impero, ricerca tecnologie, espandi le tue città ed elimina i tuoi avversari!\n\nSuggerimenti? Bug? L'elenco dei problemi aperti è disponibile nella <a href="https://github.com/yairm210/Unciv/issues">pagina Github - Issues</a>. Qualsiasi aiuto è benvenuto!\n\nQualche domanda? Commenti? O anche solo molto tempo libero da investire? Vieni a chattare con noi sul <a href="https://discord.gg/bjrB4Xw">server Discord Unciv</a>.\n\nVuoi dare una mano a tradurre il gioco nella tua lingua? Segui le istruzioni nell'<a href="https://yairm210.github.io/Unciv/Other/Translating">articolo wiki</a> per i traduttori.\n\nKotlin e/o Java non hanno segreti per te? Sentiti libero di partecipare allo sviluppo sulla <a href="https://github.com/yairm210/Unciv">pagina Github</a>.\n\nIl mondo ti sta aspettando! Costruirai una civiltà in grado di superare la prova del tempo?\n\nL'autorizzazione "abilita l'accesso completo alla rete" è richiesta per le seguenti funzionalità:\n- Elencare e scaricare le mod disponibili\n- Scaricare la musica e i suoni\n- Caricare e scaricare online lo stato delle partite multiplayer\nTutte le altre autorizzazioni elencate sono gestite automaticamente dall'API per la funzione di notifica del turno multiplayer.
 
 
 # Starting from here normal translations start, as described in
@@ -506,8 +503,7 @@ Land or water only = Solo terra o acqua
 Brush ([size]): = Pennello ([size]):
 # The single letter shown in the [size] parameter above for setting "Floodfill".
 # Please do not make this longer, the associated slider will not handle well.
- # Requires translation!
-Floodfill_Abbreviation = 
+Floodfill_Abbreviation = R
 Error loading map! = Errore caricamento mappa!
 Map saved successfully! = Salvataggio mappa riuscito!
 Current map RNG seed: [amount] = Seme RNG mappa attuale: [amount]
@@ -812,8 +808,7 @@ Enable display cutout (requires restart) = Abilita ritaglio diplay (richiede ria
 
 Max zoom out = Zoom out al massimo
 
- # Requires translation!
-Font family = 
+Font family = Tipo font
 Font size multiplier = Grandezza font
 Default Font = Font default
 
@@ -1013,8 +1008,7 @@ An unknown civilization has liberated [civ] = Una civiltà ignota ha liberato [c
 # If your language puts the effect before the cause - like {Gained [2] [Worker] unit(s)} {due to constructing [The Pyramids]} -
 # put the english word 'true' behind the '=', otherwise 'false'.
 # Don't translate these words to your language, only put 'true' or 'false'. Defaults to 'true'.
- # Requires translation!
-EffectBeforeCause = 
+EffectBeforeCause = true
 
 ## Trigger effects
 
@@ -1793,8 +1787,8 @@ Status ￬ = Stato ￬
 [stats] from [param] tiles in this city = [stats] da ogni fonte di [param] nella Città
 [stats] from every [param] on [tileFilter] tiles = [stats] per ogni [param] sulle caselle [tileFilter]
 [stats] for each adjacent [param] = [stats] per ogni [param] adiacente
-Must be next to [terrain] = La città deve rasentare [terrain]
-Must be on [terrain] = Deve ritrovarsi su [terrain]
+Must be next to [terrain] = Deve confinare con [terrain]
+Must be on [terrain] = Deve stare su [terrain]
 +[amount]% vs [unitType] = +[amount]% contro [unitType]
 +[amount] Movement for all [unitType] units = +[amount] Movimento per tutte le unità [unitType]
 +[amount]% Production when constructing [param] = +[amount]% Produzione quando costruisci [param]
@@ -1831,8 +1825,7 @@ Unit [unitName] doesn't seem to exist! = L'unità [unitName] non sembra esistere
 # Example: In the unique "+20% Strength <for [unitFilter] units>", should the <for [unitFilter] units>
 # be translated before or after the "+20% Strength"?
 
- # Requires translation!
-ConditionalsPlacement = 
+ConditionalsPlacement = after
 
 # The second determines the exact ordering of all conditionals that are to be translated.
 # ALL conditionals that exist will be part of this line, and they may be moved around and rearranged as you please.
@@ -2383,8 +2376,7 @@ all healing effects doubled = effetti curativi raddoppiati
 The Spaceship = L'Astronave
 Maya Long Count calendar cycle = Ciclo del Conto Lungo del calendario maya
 Triggerable = Attivabile
- # Requires translation!
-UnitTriggerable = 
+UnitTriggerable = Unità Attivabile
 Global = Globale
 Nation = Civiltà
 Era = Epoca
@@ -2403,13 +2395,10 @@ Speed = Velocità
 Tutorial = Tutorial
 CityState = Città-Stato
 ModOptions = Opzioni Mod
-Conditional = condizionale
- # Requires translation!
-TriggerCondition = 
- # Requires translation!
-UnitTriggerCondition = 
- # Requires translation!
-UnitActionModifier = 
+Conditional = Condizionale
+TriggerCondition = Condizione di Attivazione
+UnitTriggerCondition = Condizione di Attivazione Unità
+UnitActionModifier = Modificatore Azione Unità
 
 
 #################### Lines from spy actions #######################

--- a/android/assets/jsons/translations/completionPercentages.properties
+++ b/android/assets/jsons/translations/completionPercentages.properties
@@ -1,5 +1,5 @@
 Persian_(Pinglish-UN) = 28
-Italian = 99
+Italian = 100
 Russian = 100
 Belarusian = 2
 Afrikaans = 7
@@ -20,8 +20,8 @@ Traditional_Chinese = 98
 Polish = 100
 Lithuanian = 93
 Romanian = 71
-Simplified_Chinese = 100
 Bulgarian = 42
+Simplified_Chinese = 100
 Korean = 94
 Persian_(Pinglish-DIN) = 13
 Japanese = 80

--- a/fastlane/metadata/android/it/full_description.txt
+++ b/fastlane/metadata/android/it/full_description.txt
@@ -1,0 +1,19 @@
+Una reinterpretazione open source del gioco di gestione delle civiltà più famoso di sempre; per di più veloce, leggero, senza pubblicità e gratuito per sempre!
+
+Costruisci il tuo impero, ricerca tecnologie, espandi le tue città ed elimina i tuoi avversari!
+
+Suggerimenti? Bug? L'elenco dei problemi aperti è disponibile nella <a href="https://github.com/yairm210/Unciv/issues">pagina Github - Issues</a>. Qualsiasi aiuto è benvenuto!
+
+Qualche domanda? Commenti? O anche solo molto tempo libero da investire? Vieni a chattare con noi sul <a href="https://discord.gg/bjrB4Xw">server Discord Unciv</a>.
+
+Vuoi dare una mano a tradurre il gioco nella tua lingua? Segui le istruzioni nell'<a href="https://yairm210.github.io/Unciv/Other/Translating">articolo wiki</a> per i traduttori.
+
+Kotlin e/o Java non hanno segreti per te? Sentiti libero di partecipare allo sviluppo sulla <a href="https://github.com/yairm210/Unciv">pagina Github</a>.
+
+Il mondo ti sta aspettando! Costruirai una civiltà in grado di superare la prova del tempo?
+
+L'autorizzazione "abilita l'accesso completo alla rete" è richiesta per le seguenti funzionalità:
+- Elencare e scaricare le mod disponibili
+- Scaricare la musica e i suoni
+- Caricare e scaricare online lo stato delle partite multiplayer
+Tutte le altre autorizzazioni elencate sono gestite automaticamente dall'API per la funzione di notifica del turno multiplayer.

--- a/fastlane/metadata/android/it/short_description.txt
+++ b/fastlane/metadata/android/it/short_description.txt
@@ -1,0 +1,1 @@
+Gioco 4X - Costruire una civiltà

--- a/fastlane/metadata/android/pt/short_description.txt
+++ b/fastlane/metadata/android/pt/short_description.txt
@@ -1,1 +1,1 @@
-ViaRápida_descrição_curta
+Jogo 4X de construção de civilizações


### PR DESCRIPTION
### List of edits on file `android/assets/jsons/translations/Italian.properties`

- **Line 10**: `StartWithCapitalLetter = true` _## in Italian, just like English, Spanish, French, sentences start with a capital letter_
- **Line 19 --> 18**: `Fastlane_short_description = Gioco 4X - Costruire una civiltà` _## this translation takes inspiration from French one, that approached the issue behind the super compact wording in an elegant way (in Italian, just like in French, using the noun for "building"/"costruzione" would not have worked as good as this solution)_
- **Line 24 --> 22**: `Fastlane_full_description = Una reinterpretazione open source del gioco di gestione delle civiltà più famoso di sempre; per di più veloce, leggero, senza pubblicità e gratuito per sempre!\n\nCostruisci il tuo impero, ricerca tecnologie, espandi le tue città ed elimina i tuoi avversari!\n\nSuggerimenti? Bug? L'elenco dei problemi aperti è disponibile nella <a href="https://github.com/yairm210/Unciv/issues">pagina Github - Issues</a>. Qualsiasi aiuto è benvenuto!\n\nQualche domanda? Commenti? O anche solo molto tempo libero da investire? Vieni a chattare con noi sul <a href="https://discord.gg/bjrB4Xw">server Discord Unciv</a>.\n\nVuoi dare una mano a tradurre il gioco nella tua lingua? Segui le istruzioni nell'<a href="https://yairm210.github.io/Unciv/Other/Translating">articolo wiki</a> per i traduttori.\n\nKotlin e/o Java non hanno segreti per te? Sentiti libero di partecipare allo sviluppo sulla <a href="https://github.com/yairm210/Unciv">pagina Github</a>.\n\nIl mondo ti sta aspettando! Costruirai una civiltà in grado di superare la prova del tempo?\n\nL'autorizzazione "abilita l'accesso completo alla rete" è richiesta per le seguenti funzionalità:\n- Elencare e scaricare le mod disponibili\n- Scaricare la musica e i suoni\n- Caricare e scaricare online lo stato delle partite multiplayer\nTutte le altre autorizzazioni elencate sono gestite automaticamente dall'API per la funzione di notifica del turno multiplayer.` _## this translation is quite direct (not too much creative), and follows more or less the same approach used by French translation_
- **Line 509 --> 506**: `Floodfill_Abbreviation = R` ## _this is not a translation: I put R due to the Floodfill value at Line 551 --> 548 that is: "Riempi". Comparing the approach used in Spanish and French solutions (respectively C for "Cubeta" in Spanish and R for "Remplir" in French) it seams like the starting capital letter is used as Abbreviation, I might be wrong so if this is not the expected behavior/approach please just fill free to add more information about this point_
- **Line 815--> 811**: `Font family = Tipo font` _## this translation is similar to the Spanish one and means "Font Type". In Italian we don't use the "family" equivalent "famiglia" in this context so "tipo" (meaning "type") is more generic but works well. In Italian, compared to Spanish and French even just leaving "Font Family" or just "Font" in English might work well because Informatics/digital editing concepts are often expressed directly in English._
- **Line 1016 --> 1011**: `EffectBeforeCause = true` _## after reading the detailed explanation in the code-comments above this line, I can just simply say that in Italian, with the current version of the translations, this EffectBeforeCause = true makes sense as well as in English and other languages_
- **Line 1796 --> 1791**:  
OLD LINES
    `- Must be next to [terrain] = La città deve rasentare [terrain] `
    `- Must be on [terrain] = Deve ritrovarsi su [terrain] `
NEW LINES
    `+ Must be next to [terrain] = Deve confinare con [terrain] `
    `+ Must be on [terrain] = Deve stare su [terrain] `
   _## just minor changes following the Spanish approach for global consistency and avoiding references that were not present in the original English text. E.g. "città" ("city") is not present in the original text and, depending on the final context, using it inside this sentence might result in a redundant unwanted repetition of this word_
- **Line 1834 --> 1828**: `ConditionalsPlacement = after` _## this makes sense with Italian as well, with the current version of translations_
- **Lines 2379 and following ones**: I have found inconsistency and confusion about this part, also attempting to compare with Spanish or French approach (I had to check because I'm not really sure where these texts will be shown in the final context) I have not found any clear unambiguous way to approach these. These portions of text look like variable names and even follow a strict **CamelCase** formatting. It is not clear if also their translations should follow this CamelCase format or not. In Spanish and French there is no consistency, some are CamelCase and some are not. In this code-change proposal for Italian I always put separated words using white spaces instead of using CamelCase formatting, but if I got it wrong, please let me know and add any useful information about this point @yairm210 (not sure if tagging you makes sense, sorry if this is not the expected process, this is my first PR in this project and yet I am not confident about which Discord server sub channels are the correct places to discuss or point out this kind of topics).

Other changes, including new files and folders, are just the result of generating the language files (now there is an `it/` folder inside `fastlane/metadata/android/`) `full_description.txt` and `short_description.txt` have been created and the translation percentage for Italian rose up from 99% to 100% inside `android/assets/jsons/translations/completionPercentages.properties`, while I'm not sure why generating the language files moved Simplified Chinese in a different line number (from 23 to 24 switching with the line of Bulgarian) but the information kept identical as before.

For some reasons also `fastlane/metadata/android/pt/short_description.txt` got updated with the Portuguese Short Description that anyway makes sense to me.

I'm not sure if these generated language metadata files should be tracked under GIT or not (if we don't want them to be tracked maybe we can just add some exceptions inside the `.gitignore` file).

Thank you very much in advance for any feedback you can provide!