### PR TITLE
Add option to Enable/Disable unit upgrades for automated units

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -767,6 +767,7 @@ Auto-assign city production =
 Auto-build roads = 
 Automated workers replace improvements = 
 Automated units move on turn start = 
+Automated units can upgrade = 
 Order trade offers by amount = 
 Ask for confirmation when pressing next turn = 
 Notifications log max turns = 

--- a/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
@@ -1,6 +1,7 @@
 package com.unciv.logic.automation.unit
 
 import com.unciv.Constants
+import com.unciv.UncivGame
 import com.unciv.logic.automation.Automation
 import com.unciv.logic.automation.civilization.NextTurnAutomation
 import com.unciv.logic.battle.Battle
@@ -16,6 +17,7 @@ import com.unciv.logic.civilization.managers.ReligionState
 import com.unciv.logic.map.mapunit.MapUnit
 import com.unciv.logic.map.tile.Tile
 import com.unciv.models.UnitActionType
+import com.unciv.models.metadata.GameSettings
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.ui.screens.worldscreen.unit.actions.UnitActions
 import com.unciv.ui.screens.worldscreen.unit.actions.UnitActionsPillage
@@ -127,6 +129,8 @@ object UnitAutomation {
     }
 
     internal fun tryUpgradeUnit(unit: MapUnit): Boolean {
+        val isPlayer = unit.civ.isCurrentPlayer()
+        if (!UncivGame.Current.settings.automatedUnitsCanUpgrade && isPlayer) return false
         if (unit.baseUnit.upgradesTo == null) return false
         val upgradedUnit = unit.upgrade.getUnitToUpgradeTo()
         if (!upgradedUnit.isBuildable(unit.civ)) return false // for resource reasons, usually

--- a/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
@@ -129,8 +129,8 @@ object UnitAutomation {
     }
 
     internal fun tryUpgradeUnit(unit: MapUnit): Boolean {
-        val isPlayer = unit.civ.isCurrentPlayer()
-        if (!UncivGame.Current.settings.automatedUnitsCanUpgrade && isPlayer) return false
+        val isHuman = unit.civ.isHuman()
+        if (!UncivGame.Current.settings.automatedUnitsCanUpgrade && isHuman) return false
         if (unit.baseUnit.upgradesTo == null) return false
         val upgradedUnit = unit.upgrade.getUnitToUpgradeTo()
         if (!upgradedUnit.isBuildable(unit.civ)) return false // for resource reasons, usually

--- a/core/src/com/unciv/models/metadata/GameSettings.kt
+++ b/core/src/com/unciv/models/metadata/GameSettings.kt
@@ -71,6 +71,7 @@ class GameSettings {
     var autoBuildingRoads: Boolean = true
     var automatedWorkersReplaceImprovements = true
     var automatedUnitsMoveOnTurnStart: Boolean = false
+    var automatedUnitsCanUpgrade: Boolean = true
 
     var showMinimap: Boolean = true
     var minimapSize: Int = 6    // default corresponds to 15% screen space

--- a/core/src/com/unciv/ui/popups/options/GameplayTab.kt
+++ b/core/src/com/unciv/ui/popups/options/GameplayTab.kt
@@ -42,6 +42,11 @@ fun gameplayTab(
         "Automated units move on turn start",
         settings.automatedUnitsMoveOnTurnStart, true
     ) { settings.automatedUnitsMoveOnTurnStart = it }
+    optionsPopup.addCheckbox(
+        this,
+        "Automated units can upgrade",
+        settings.automatedUnitsCanUpgrade, true
+    ) { settings.automatedUnitsCanUpgrade = it }
     optionsPopup.addCheckbox(this, "Order trade offers by amount", settings.orderTradeOffersByAmount) { settings.orderTradeOffersByAmount = it }
     optionsPopup.addCheckbox(this, "Ask for confirmation when pressing next turn", settings.confirmNextTurn) { settings.confirmNextTurn = it }
 


### PR DESCRIPTION
This PR adds an option to enable or disable unit upgrades for player units that are automated. The default state is enabled, to maintain the existing game behavior.

### Rationale
When units that are automated have the ability to upgrade, they will attempt to do so given that the resources requirements are satisfied. This may not be desirable to players who had intended to use those resources for other purposes.