### PR TITLE
Bombard to the north

### DIFF
--- a/core/src/com/unciv/ui/screens/worldscreen/WorldMapHolder.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/WorldMapHolder.kt
@@ -333,12 +333,6 @@ class WorldMapHolder(
              * so that and that alone will be relegated to the concurrent thread.
              */
 
-            /** LibGdx sometimes has these weird errors when you try to edit the UI layout from 2 separate threads.
-             * And so, all UI editing will be done on the main thread.
-             * The only "heavy lifting" that needs to be done is getting the turns to get there,
-             * so that and that alone will be relegated to the concurrent thread.
-             */
-
             val unitToTurnsToTile = HashMap<MapUnit, Int>()
             for (unit in selectedUnits) {
                 val shortestPath = ArrayList<Tile>()
@@ -695,7 +689,7 @@ class WorldMapHolder(
                 if (nukeBlastRadius >= 0)
                     selectedTile!!.getTilesInDistance(nukeBlastRadius)
                         // Should not display invisible submarine units even if the tile is visible.
-                        .filter { targetTile -> (targetTile.isVisible(unit.civ) && targetTile.getUnits().any { !it.isInvisible(unit.civ) }) 
+                        .filter { targetTile -> (targetTile.isVisible(unit.civ) && targetTile.getUnits().any { !it.isInvisible(unit.civ) })
                             || (targetTile.isCityCenter() && unit.civ.hasExplored(targetTile)) }
                         .map { AttackableTile(unit.getTile(), it, 1f, null) }
                         .toList()

--- a/core/src/com/unciv/ui/screens/worldscreen/WorldMapHolder.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/WorldMapHolder.kt
@@ -422,9 +422,9 @@ class WorldMapHolder(
         }
 
         for (unit in unitList) {
-            val unitGroup = UnitGroup(unit, 60f).surroundWithCircle(85f, resizeActor = false)
+            val unitGroup = UnitGroup(unit, 48f).surroundWithCircle(68f, resizeActor = false)
             unitGroup.circle.color = Color.GRAY.cpy().apply { a = 0.5f }
-            if (unit.currentMovement == 0f) unitGroup.color.a = 0.5f
+            if (unit.currentMovement == 0f) unitGroup.color.a = 0.66f
             unitGroup.touchable = Touchable.enabled
             unitGroup.onClick {
                 worldScreen.bottomUnitTable.selectUnit(unit, Gdx.input.isKeyPressed(Input.Keys.SHIFT_LEFT))
@@ -435,7 +435,7 @@ class WorldMapHolder(
         }
 
         addOverlayOnTileGroup(tileGroups[tile]!!, table)
-        table.moveBy(0f, 60f)
+        table.moveBy(0f, 48f)
 
     }
 


### PR DESCRIPTION
~~Sure there's an open issue for this - _at least_ one. Please someone find them for me?~~
Closes #9760 closes #9445

There was a workaround described somewhere, in this testing game I just was unable to find it, *despite* having understood it a while back... so... there's something to the complaints.

This is a "just a little" approach: It tweaks the size and displacement of the culpable unit overlay by -20%. Also, since when the garrisoned unit has no movement left I fould you can barely see _why_ you can't select the victim up there, as it's much clearer than the overlaid garrison, I tweaked one alpha a tiny tad up...

<details><summary>screenies</summary>

***BEFORE***
Selected, garrison has MP // same with debug rects (cover entire north hex) // Selected, garrison has no moves left
![image](https://github.com/yairm210/Unciv/assets/63000004/92155469-7d62-40ea-bff1-bbdefef687c4)
![image](https://github.com/yairm210/Unciv/assets/63000004/d50dd116-2156-4990-bd81-72fe1591de16)
![image](https://github.com/yairm210/Unciv/assets/63000004/8b139a50-1a3f-42a4-8b5c-b26133675a99)

***AFTER***
Selected, garrison has MP // demo I managed to hit the barb up there // Selected, garrison has no moves left
![image](https://github.com/yairm210/Unciv/assets/63000004/0c5d6305-97b9-4abd-b969-19dc561dcc08)
![image](https://github.com/yairm210/Unciv/assets/63000004/b4b3c8f1-2eb8-4705-8d4a-34233c6a08a9)
![image](https://github.com/yairm210/Unciv/assets/63000004/4df9d7cf-ba74-4f07-9d0f-75c7e96a251b)

</details>

I'm sure this is not the only possible approach (like - nothing of that touchable except the immermost unit circle), and maybe it's not even the cleanest for the intended goal. But - Q&D.