### PR TITLE
Fix intended Longpress-to-move on Android not working

### DIFF
--- a/core/src/com/unciv/ui/components/input/ActivationExtensions.kt
+++ b/core/src/com/unciv/ui/components/input/ActivationExtensions.kt
@@ -98,14 +98,13 @@ fun Actor.onRightClick(sound: UncivSound = UncivSound.Click, action: ActivationA
  *  A [sound] will be played (concurrently) on activation unless you specify [UncivSound.Silent].
  *  @return `this` to allow chaining
  */
-@Suppress("unused")  // Just in case - for now, only onRightClick is used
+@Suppress("unused")  // Just in case - for now, the Longpress in WorldMapHolder is using onActivation directly
 fun Actor.onLongPress(sound: UncivSound = UncivSound.Click, action: ActivationAction): Actor =
     onActivation(ActivationTypes.Longpress, sound, noEquivalence = true, action)
 
 /** Clears activation actions for a specific [type], and, if [noEquivalence] is `true`,
  *  its [equivalent][ActivationTypes.isEquivalent] types.
  */
-@Suppress("unused")  // Just in case - for now, it's automatic clear via clearListener
 fun Actor.clearActivationActions(type: ActivationTypes, noEquivalence: Boolean = true) {
     ActorAttachments.get(this).clearActivationActions(type, noEquivalence)
 }


### PR DESCRIPTION
When I rerolled the Actor activation system to use ActorGestureListener, it was fully intended the existing desktop right-click would map to long-presses. I was so sure I tested - albeit on an AVD... Nope, the desktop world map right-click to move/attack does _not_ work on Android hardware as long-press. With this PR it does. It also deactivates long-press on desktop (so right-click only), but that is easily changed if someone expresses a preference for it.

That trailing space my Studio autofixed will guarantee conflicts with another open PR, at least I've seen that blank before - no worries, we'll fix when we get there.