### PR TITLE
AI now move units closer to enemy first in wartime

### DIFF
--- a/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
@@ -433,6 +433,14 @@ class MapUnit : IsPartOfGameInfoSerialization {
     fun isGreatPerson() = baseUnit.isGreatPerson()
     fun isGreatPersonOfType(type: String) = baseUnit.isGreatPersonOfType(type)
 
+    fun getDistanceToEnemyUnit(maxDist: Int): Int? {
+        for (i in 1..maxDist) {
+            if (currentTile.getTilesAtDistance(i).any {it.militaryUnit != null
+                && it.militaryUnit!!.civ.isAtWarWith(civ) })
+                return i
+        }
+        return null
+    }
     //endregion
 
     //region state-changing functions


### PR DESCRIPTION
Units tend to be clumped up in a large ball when they need to move into enemy territory to attack. This code prioritizes moving the units in front first so the AI can move them quicker to their target with fewer inefficiencies.

If you take a medium or large map with nukes disabled, set yourself as the spectator and add 6 AI civs, then let them play out. Once they get a huge death ball, they are very inefficient with fighting. Therefore I created this first change to help fix this.