### PR TITLE
Ai nuke improvement

### DIFF
--- a/core/src/com/unciv/logic/automation/unit/SpecificUnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/SpecificUnitAutomation.kt
@@ -494,6 +494,7 @@ object SpecificUnitAutomation {
     }
 
     fun automateNukes(unit: MapUnit) {
+        if (!unit.civ.isAtWar()) return
         // We should *Almost* never want to nuke our own city, so don't consider it
         val tilesInRange = unit.currentTile.getTilesInDistanceRange(2..unit.getRange())
         var highestTileNukeValue = 0
@@ -513,7 +514,7 @@ object SpecificUnitAutomation {
 
     /**
      * Ranks the tile to nuke based off of all tiles in it's blast radius
-     * By default the value is -400 to prevent inefficient nuking.
+     * By default the value is -500 to prevent inefficient nuking.
      */
     fun getNukeLocationValue(nuke: MapUnit, tile: Tile): Int {
         val civ = nuke.civ

--- a/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
@@ -632,8 +632,8 @@ object UnitAutomation {
             .map { BattleDamage.calculateDamageToDefender(MapUnitCombatant(it), cityCombatant) }
             .sum() // City heals 20 per turn
 
-        if (expectedDamagePerTurn < city.health * 4 && // If we can take immediately, go for it
-                (expectedDamagePerTurn <= 5 || city.health / (Math.max(1, expectedDamagePerTurn-20)) > 5)){ // otherwise check if we can take within a couple of turns
+        if (expectedDamagePerTurn < city.health && // If we can take immediately, go for it
+            (expectedDamagePerTurn <= 20 || city.health / (expectedDamagePerTurn-20) > 5)){ // otherwise check if we can take within a couple of turns
 
             // We won't be able to take this even with 5 turns of continuous damage!
             // don't head straight to the city, try to head to landing grounds -

--- a/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
@@ -214,8 +214,6 @@ object UnitAutomation {
         if (tryAdvanceTowardsCloseEnemy(unit)) return
 
         if (tryHeadTowardsEncampment(unit)) return
-        
-        if (tryAttacking(unit)) return
 
         if (unit.health < 100 && tryHealUnit(unit)) return
 

--- a/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
@@ -191,7 +191,7 @@ object UnitAutomation {
 
         if (tryHeadTowardsOurSiegedCity(unit)) return
 
-        if (unit.health < 50 && /*(tryRetreat(unit) ||*/ tryHealUnit(unit)/*)*/) return // do nothing but heal
+        if (unit.health < 50 && tryHealUnit(unit)) return // do nothing but heal
 
         // if a embarked melee unit can land and attack next turn, do not attack from water.
         if (BattleHelper.tryDisembarkUnitToAttackPosition(unit)) return
@@ -381,26 +381,6 @@ object UnitAutomation {
         return true
     }
     
-//    private fun tryRetreat(unit: MapUnit): Boolean {
-//        val distanceToNearestEnemy = unit.distanceToNearestEnemy ?: 0
-//        if (distanceToNearestEnemy > 3)
-//            return false
-//        val shouldSwapWithUnit = fun (militaryUnit: MapUnit): Boolean {
-//            return militaryUnit.civ == unit.civ
-//                && (militaryUnit.distanceToNearestEnemy ?: 0) > distanceToNearestEnemy &&
-//                (!militaryUnit.baseUnit.isProbablySiegeUnit() || distanceToNearestEnemy > 2) // Don't want to swap with siege units that would be endangered
-//                && militaryUnit.health > 80
-//                && unit.movement.canUnitSwapTo(militaryUnit.currentTile)
-//        }
-//        val nearbyOwnedTiles = unit.movement.getReachableTilesInCurrentTurn().filter { tile -> tile.militaryUnit != null && shouldSwapWithUnit(tile.militaryUnit!!) }
-//        val nearbyBestTiles = nearbyOwnedTiles.sortedByDescending { tile -> tile.militaryUnit!!.distanceToNearestEnemy ?: 0 }
-//        if (nearbyBestTiles.any() ) {
-//            unit.movement.swapMoveToTile(nearbyBestTiles.first())
-//            return true;
-//        }
-//        return false
-//    }
-
     private fun tryHealUnit(unit: MapUnit): Boolean {
         if (unit.baseUnit.isRanged() && unit.hasUnique(UniqueType.HealsEvenAfterAction))
             return false // will heal anyway, and attacks don't hurt

--- a/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
@@ -173,7 +173,7 @@ object UnitAutomation {
         if (unit.baseUnit.isAirUnit() && unit.canIntercept())
             return SpecificUnitAutomation.automateFighter(unit)
 
-        if (unit.baseUnit.isAirUnit() && ! unit.baseUnit.isNuclearWeapon())
+        if (unit.baseUnit.isAirUnit() && !unit.baseUnit.isNuclearWeapon())
             return SpecificUnitAutomation.automateBomber(unit)
 
         if (unit.baseUnit.isNuclearWeapon())

--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -754,6 +754,8 @@ object Battle {
      */
     fun mayUseNuke(nuke: MapUnitCombatant, targetTile: Tile): Boolean {
         if (nuke.getTile() == targetTile) return false
+        // Can only nuke visible Tiles
+        if (!targetTile.isVisible(nuke.getCivInfo())) return false
 
         var canNuke = true
         val attackerCiv = nuke.getCivInfo()


### PR DESCRIPTION
This commit completely changes the Nuking AI. Previously, the Nuke AI would only attack using the SpecificUnitAutomation.automateBomber function since it didn't filter out Nukes.
The Nuke AI prioritizes tiles based on cities, units, and tile improvements. By default, the AI does not launch its nuke unless the value of the tiles hit is high.

The AI is not allowed to nuke tiles that are not visible, and it will only account for visible units.