### PR TITLE
Linting of unused new function shouldOpenPolicyPicker()

### DIFF
--- a/core/src/com/unciv/logic/city/managers/CityFounder.kt
+++ b/core/src/com/unciv/logic/city/managers/CityFounder.kt
@@ -29,7 +29,7 @@ class CityFounder {
         city.isOriginalCapital = civInfo.citiesCreated == 0
         if (city.isOriginalCapital) {
             civInfo.hasEverOwnedOriginalCapital = true
-            // if you have some culture before the 1st city is found, you may want to adopt the 1st policy
+            // if you have some culture before the 1st city is founded, you may want to adopt the 1st policy
             civInfo.policies.shouldOpenPolicyPicker = true
         }
         civInfo.citiesCreated++

--- a/core/src/com/unciv/logic/civilization/managers/PolicyManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/PolicyManager.kt
@@ -31,10 +31,11 @@ class PolicyManager : IsPartOfGameInfoSerialization {
     internal val adoptedPolicies = HashSet<String>()
     var numberOfAdoptedPolicies = 0
 
-    /** Indicates whether we shoudl *check* if policy is adoptible, and if so open */
+    /** Indicates whether we should *check* if policy is adoptible, and if so open */
     var shouldOpenPolicyPicker = false
 
-    fun shouldOpenPolicyPicker() = shouldOpenPolicyPicker && canAdoptPolicy()
+    /** Used by NextTurnAction.PickPolicy.isChoice */
+    fun shouldShowPolicyPicker() = (shouldOpenPolicyPicker || freePolicies > 0) && canAdoptPolicy()
 
     /** A [Map] pairing each [PolicyBranch] to its priority ([Int]). */
     val priorityMap: Map<PolicyBranch, Int>

--- a/core/src/com/unciv/ui/screens/worldscreen/status/NextTurnAction.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/status/NextTurnAction.kt
@@ -54,9 +54,7 @@ enum class NextTurnAction(protected val text: String, val color: Color) {
     },
     PickPolicy("Pick a policy", Color.VIOLET) {
         override fun isChoice(worldScreen: WorldScreen) =
-            (worldScreen.viewingCiv.policies.shouldOpenPolicyPicker ||
-                    worldScreen.viewingCiv.policies.freePolicies > 0)
-                && worldScreen.viewingCiv.policies.canAdoptPolicy()
+            worldScreen.viewingCiv.policies.shouldShowPolicyPicker()
         override fun action(worldScreen: WorldScreen) {
             worldScreen.game.pushScreen(PolicyPickerScreen(worldScreen.selectedCiv, worldScreen.canChangeState))
             worldScreen.viewingCiv.policies.shouldOpenPolicyPicker = false


### PR DESCRIPTION
Just a little cleanup for _[this good catch](https://github.com/yairm210/Unciv/commit/2028c0569b827a89478c97c09d76c2d82485b771)_

Rename to avoid confusion, pretty arbitrary. Pity renaming the var would be a breaking change...

Remember to remove this from the changelog, nothing to see here.