### PR TITLE
Allow buildings to require population, Allow buildings to use condtionals

### DIFF
--- a/core/src/com/unciv/models/ruleset/Building.kt
+++ b/core/src/com/unciv/models/ruleset/Building.kt
@@ -465,9 +465,8 @@ class Building : RulesetStatsObject(), INonPerpetualConstruction {
             yield(RejectionReasonType.AlreadyBuilt.toInstance())
 
         for (unique in uniqueObjects) {
-            for (unique in uniqueObjects) {
-                if (unique.type != UniqueType.OnlyAvailableWhen &&
-                    !unique.conditionalsApply(StateForConditionals(civ, cityConstructions.city))) continue
+            if (unique.type != UniqueType.OnlyAvailableWhen &&
+                !unique.conditionalsApply(StateForConditionals(civ, cityConstructions.city))) continue
                 
             @Suppress("NON_EXHAUSTIVE_WHEN")
             when (unique.type) {

--- a/core/src/com/unciv/models/ruleset/Building.kt
+++ b/core/src/com/unciv/models/ruleset/Building.kt
@@ -463,17 +463,22 @@ class Building : RulesetStatsObject(), INonPerpetualConstruction {
 
         if (cityConstructions.isBuilt(name))
             yield(RejectionReasonType.AlreadyBuilt.toInstance())
-        // for buildings that are created as side effects of other things, and not directly built,
-        // or for buildings that can only be bought
-        if (hasUnique(UniqueType.Unbuildable, StateForConditionals(civ, cityConstructions.city)))
-            yield(RejectionReasonType.Unbuildable.toInstance())
 
         for (unique in uniqueObjects) {
             @Suppress("NON_EXHAUSTIVE_WHEN")
             when (unique.type) {
-                UniqueType.OnlyAvailableWhen->
+                // for buildings that are created as side effects of other things, and not directly built,
+                // or for buildings that can only be bought
+                UniqueType.Unbuildable ->
+                    yield(RejectionReasonType.Unbuildable.toInstance())
+
+                UniqueType.OnlyAvailableWhen ->
                     if (!unique.conditionalsApply(civ, cityConstructions.city))
                         yield(RejectionReasonType.ShouldNotBeDisplayed.toInstance())
+
+                UniqueType.RequiresPopulation ->
+                    if (unique.params[0].toInt() > cityConstructions.city.population.population)
+                        yield(RejectionReasonType.PopulationRequirement.toInstance(unique.text))
 
                 UniqueType.EnablesNuclearWeapons -> if (!cityConstructions.city.civ.gameInfo.gameParameters.nuclearWeaponsEnabled)
                     yield(RejectionReasonType.DisabledBySetting.toInstance())

--- a/core/src/com/unciv/models/ruleset/Building.kt
+++ b/core/src/com/unciv/models/ruleset/Building.kt
@@ -465,6 +465,10 @@ class Building : RulesetStatsObject(), INonPerpetualConstruction {
             yield(RejectionReasonType.AlreadyBuilt.toInstance())
 
         for (unique in uniqueObjects) {
+            for (unique in uniqueObjects) {
+                if (unique.type != UniqueType.OnlyAvailableWhen &&
+                    !unique.conditionalsApply(StateForConditionals(civ, cityConstructions.city))) continue
+                
             @Suppress("NON_EXHAUSTIVE_WHEN")
             when (unique.type) {
                 // for buildings that are created as side effects of other things, and not directly built,


### PR DESCRIPTION
Closes #9977

I do find it a bit weird that the way Units and buildings check their uniques is ever so slightly different. Also, the unit to require population technically does state it works for buildings, so this PR just makes this work as expected