### PR TITLE
Refactor BattleDamage object and test it

### DIFF
--- a/core/src/com/unciv/logic/battle/BattleConstants.kt
+++ b/core/src/com/unciv/logic/battle/BattleConstants.kt
@@ -1,0 +1,15 @@
+package com.unciv.logic.battle
+
+object BattleConstants {
+    //https://www.carlsguides.com/strategy/civilization5/war/combatbonuses.php
+    const val LANDING_MALUS = -50
+    const val BOARDING_MALUS = -50
+    const val ATTACKING_ACROSS_RIVER_MALUS = -20
+    const val BASE_FLANKING_BONUS = 10f
+    const val MISSING_RESOURCES_MALUS = -25
+    const val EMBARKED_DEFENCE_BONUS = 100
+    const val FORTIFICATION_BONUS = 20
+    const val DAMAGE_REDUCTION_WOUNDED_UNIT_RATIO_PERCENTAGE = 300f
+    const val DAMAGE_TO_CIVILIAN_UNIT = 40
+
+}

--- a/core/src/com/unciv/logic/battle/BattleDamage.kt
+++ b/core/src/com/unciv/logic/battle/BattleDamage.kt
@@ -122,7 +122,7 @@ object BattleDamage {
         val civResources = civInfo.getCivResourcesByName()
         for (resource in combatant.unit.baseUnit.getResourceRequirementsPerTurn().keys)
             if (civResources[resource]!! < 0 && !civInfo.isBarbarian())
-                modifiers["Missing resource"] = -25  //todo ModConstants
+                modifiers["Missing resource"] = BattleConstants.MISSING_RESOURCES_MALUS
     }
 
     fun getAttackModifiers(
@@ -146,7 +146,7 @@ object BattleDamage {
                             && MapUnitCombatant(it.militaryUnit!!).isMelee()
                 }
                 if (numberOfOtherAttackersSurroundingDefender > 0) {
-                    var flankingBonus = 10f //https://www.carlsguides.com/strategy/civilization5/war/combatbonuses.php
+                    var flankingBonus = BattleConstants.BASE_FLANKING_BONUS
 
                     // e.g., Discipline policy - https://civilization.fandom.com/wiki/Discipline_(Civ5)
                     for (unique in attacker.unit.getMatchingUniques(UniqueType.FlankAttackBonus, checkCivInfoUniques = true))
@@ -166,22 +166,22 @@ object BattleDamage {
         if (attacker.unit.isEmbarked() && defender.getTile().isLand
             && !attacker.unit.hasUnique(UniqueType.AttackAcrossCoast)
         )
-            modifiers["Landing"] = -50
+            modifiers["Landing"] = BattleConstants.LANDING_MALUS
 
         // Land Melee Unit attacking to Water
         if (attacker.unit.type.isLandUnit() && !attacker.getTile().isWater && attacker.isMelee() && defender.getTile().isWater
             && !attacker.unit.hasUnique(UniqueType.AttackAcrossCoast)
         )
-            modifiers["Boarding"] = -50
+            modifiers["Boarding"] = BattleConstants.BOARDING_MALUS
 
         // Melee Unit on water attacking to Land (not City) unit
         if (!attacker.unit.type.isAirUnit() && attacker.isMelee() && attacker.getTile().isWater && !defender.getTile().isWater
             && !attacker.unit.hasUnique(UniqueType.AttackAcrossCoast) && !defender.isCity()
         )
-            modifiers["Landing"] = -50
+            modifiers["Landing"] = BattleConstants.LANDING_MALUS
 
         if (isMeleeAttackingAcrossRiverWithNoBridge(attacker, tileToAttackFrom, defender))
-            modifiers["Across river"] = -20
+            modifiers["Across river"] = BattleConstants.ATTACKING_ACROSS_RIVER_MALUS
     }
 
     private fun isMeleeAttackingAcrossRiverWithNoBridge(attacker: MapUnitCombatant, tileToAttackFrom: Tile, defender: ICombatant) = (
@@ -220,7 +220,7 @@ object BattleDamage {
                 // embarked units get no defensive modifiers apart from this unique
                 if (defender.unit.hasUnique(UniqueType.DefenceBonusWhenEmbarked, checkCivInfoUniques = true)
                 )
-                    modifiers["Embarked"] = 100
+                    modifiers["Embarked"] = BattleConstants.EMBARKED_DEFENCE_BONUS
 
                 return modifiers
             }
@@ -233,7 +233,7 @@ object BattleDamage {
 
 
             if (defender.unit.isFortified())
-                modifiers["Fortification"] = 20 * defender.unit.getFortificationTurns()
+                modifiers["Fortification"] = BattleConstants.FORTIFICATION_BONUS * defender.unit.getFortificationTurns()
         }
 
         return modifiers
@@ -251,7 +251,7 @@ object BattleDamage {
             || combatant.unit.hasUnique(UniqueType.NoDamagePenalty, checkCivInfoUniques = true)
         ) 1f
         // Each 3 points of health reduces damage dealt by 1%
-        else 1 - (100 - combatant.getHealth()) / 300f
+        else 1 - (100 - combatant.getHealth()) / BattleConstants.DAMAGE_REDUCTION_WOUNDED_UNIT_RATIO_PERCENTAGE
     }
 
 
@@ -298,7 +298,7 @@ object BattleDamage {
         randomnessFactor: Float = Random(defender.getCivInfo().gameInfo.turns * defender.getTile().position.hashCode().toLong()).nextFloat()
         ,
     ): Int {
-        if (defender.isCivilian()) return 40
+        if (defender.isCivilian()) return BattleConstants.DAMAGE_TO_CIVILIAN_UNIT
         val ratio = getAttackingStrength(attacker, defender, tileToAttackFrom) /
                 getDefendingStrength(attacker, defender, tileToAttackFrom)
         return (damageModifier(ratio, false, randomnessFactor) * getHealthDependantDamageRatio(attacker)).roundToInt()

--- a/core/src/com/unciv/logic/battle/BattleDamage.kt
+++ b/core/src/com/unciv/logic/battle/BattleDamage.kt
@@ -90,8 +90,8 @@ object BattleDamage {
                 combatant.getTile().aerialDistanceTo(civInfo.getCapital()!!.getCenterTile())
             // https://steamcommunity.com/sharedfiles/filedetails/?id=326411722#464287
             val effect = unique.params[0].toInt() - 3 * distance
-            if (effect <= 0) continue
-            modifiers.add("${unique.sourceObjectName} (${unique.sourceObjectType})", effect)
+            if (effect > 0)
+                modifiers.add("${unique.sourceObjectName} (${unique.sourceObjectType})", effect)
         }
 
         //https://www.carlsguides.com/strategy/civilization5/war/combatbonuses.php

--- a/core/src/com/unciv/logic/battle/BattleDamage.kt
+++ b/core/src/com/unciv/logic/battle/BattleDamage.kt
@@ -46,6 +46,8 @@ object BattleDamage {
             for (unique in combatant.getMatchingUniques(UniqueType.Strength, conditionalState, true)) {
                 modifiers.add(getModifierStringFromUnique(unique), unique.params[0].toInt())
             }
+
+            // e.g., Mehal Sefari https://civilization.fandom.com/wiki/Mehal_Sefari_(Civ5)
             for (unique in combatant.getMatchingUniques(
                 UniqueType.StrengthNearCapital, conditionalState, true
             )) {
@@ -63,6 +65,8 @@ object BattleDamage {
             if (enemy.getTile() !in combatant.getTile().neighbors && tileToAttackFrom in combatant.getTile().neighbors
                     && enemy is MapUnitCombatant)
                 adjacentUnits += sequenceOf(enemy.unit)
+
+            // e.g., Maori Warrior - https://civilization.fandom.com/wiki/Maori_Warrior_(Civ5)
             val strengthMalus = adjacentUnits.filter { it.civ.isAtWarWith(civInfo) }
                     .flatMap { it.getMatchingUniques(UniqueType.StrengthForAdjacentEnemies) }
                     .filter { combatant.matchesCategory(it.params[1]) && combatant.getTile().matchesFilter(it.params[2]) }
@@ -89,6 +93,7 @@ object BattleDamage {
                     modifiers["Stacked with [${unique.params[1]}]"] = stackedUnitsBonus
             }
 
+            // e.g., Mongolia - https://civilization.fandom.com/wiki/Mongolian_(Civ5)
             if (enemy.getCivInfo().isCityState()
                 && civInfo.hasUnique(UniqueType.StrengthBonusVsCityStates)
             )

--- a/tests/src/com/unciv/logic/battle/BattleDamageTest.kt
+++ b/tests/src/com/unciv/logic/battle/BattleDamageTest.kt
@@ -1,0 +1,158 @@
+package com.unciv.logic.battle
+
+import com.badlogic.gdx.math.Vector2
+import com.unciv.logic.civilization.Civilization
+import com.unciv.logic.civilization.managers.TurnManager
+import com.unciv.logic.map.mapunit.MapUnit
+import com.unciv.logic.map.tile.Tile
+import com.unciv.testing.GdxTestRunner
+import com.unciv.uniques.TestGame
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(GdxTestRunner::class)
+class BattleDamageTest {
+    private lateinit var attackerCiv: Civilization
+    private lateinit var defenderCiv: Civilization
+
+    private lateinit var defaultAttackerTile: Tile
+    private lateinit var defaultDefenderTile: Tile
+
+    private lateinit var defaultAttackerUnit: MapUnit
+    private lateinit var defaultDefenderUnit: MapUnit
+
+    private val testGame = TestGame()
+
+    @Before
+    fun setUp() {
+        testGame.makeHexagonalMap(4)
+        attackerCiv = testGame.addCiv()
+        defenderCiv = testGame.addCiv()
+
+        defaultAttackerTile = testGame.getTile(Vector2(1f, 1f))
+        defaultAttackerUnit = testGame.addUnit("Warrior", attackerCiv, defaultAttackerTile)
+        defaultDefenderTile = testGame.getTile(Vector2(0f, 1f))
+        defaultDefenderUnit = testGame.addUnit("Warrior", defenderCiv, defaultDefenderTile)
+    }
+
+    @Test
+    fun `should retrieve modifiers from policies`() {
+        // given
+        val policy = testGame.createPolicy("[+25]% Strength <when attacking> <for [Military] units>")
+        attackerCiv.policies.adopt(policy, true)
+
+        // when
+        val attackModifiers = BattleDamage.getAttackModifiers(MapUnitCombatant(defaultAttackerUnit), MapUnitCombatant(defaultDefenderUnit), defaultAttackerTile)
+
+        // then
+        assertEquals(1, attackModifiers.size)
+        assertEquals(25, attackModifiers.sumValues())
+    }
+
+    @Test
+    fun `should retrieve modifiers from buldings`() {
+        // given
+        val building = testGame.createBuilding("[+15]% Strength <for [Military] units>")
+        val attackerCity = testGame.addCity(attackerCiv, testGame.getTile(Vector2.Zero))
+        attackerCity.cityConstructions.addBuilding(building.name)
+
+        // when
+        val attackModifiers = BattleDamage.getAttackModifiers(MapUnitCombatant(defaultAttackerUnit), MapUnitCombatant(defaultDefenderUnit), defaultAttackerTile)
+
+        // then
+        assertEquals(1, attackModifiers.size)
+        assertEquals(15, attackModifiers.sumValues())
+    }
+
+    @Test
+    fun `should retrieve modifiers from national abilities`() {
+        // given
+        val civ = testGame.addCiv("[+10]% Strength <for [All] units> <during a Golden Age>") // i.e., Persia national ability
+        civ.goldenAges.enterGoldenAge(2)
+        val attackerTile = testGame.getTile(Vector2.Zero)
+        val attackerUnit = testGame.addUnit("Warrior", civ, attackerTile)
+
+        // when
+        val attackModifiers = BattleDamage.getAttackModifiers(MapUnitCombatant(attackerUnit), MapUnitCombatant(defaultDefenderUnit), attackerTile)
+
+        // then
+        assertEquals(1, attackModifiers.size)
+        assertEquals(10, attackModifiers.sumValues())
+    }
+
+    @Test
+    fun `should retrieve modifiers from lack of strategic resource`() {
+        // given
+        defaultAttackerTile.militaryUnit = null // otherwise we'll also get a flanking bonus
+        val attackerTile = testGame.getTile(Vector2.Zero)
+        val attackerUnit = testGame.addUnit("Horseman", attackerCiv, attackerTile)
+
+        // when
+        val attackModifiers = BattleDamage.getAttackModifiers(MapUnitCombatant(attackerUnit), MapUnitCombatant(defaultDefenderUnit), attackerTile)
+
+        // then
+        assertEquals(1, attackModifiers.size)
+        assertEquals(BattleConstants.MISSING_RESOURCES_MALUS, attackModifiers.sumValues())
+    }
+
+    @Test
+    fun `should retrieve attacking flank bonus modifiers`() {
+        // given
+        val flankingAttackerTile = testGame.getTile(Vector2.Zero)
+        testGame.addUnit("Warrior", attackerCiv, flankingAttackerTile)
+
+        // when
+        val attackModifiers = BattleDamage.getAttackModifiers(MapUnitCombatant(defaultAttackerUnit), MapUnitCombatant(defaultDefenderUnit), defaultAttackerTile)
+
+        // then
+        assertEquals(1, attackModifiers.size)
+        assertEquals(BattleConstants.BASE_FLANKING_BONUS.toInt(), attackModifiers.sumValues())
+    }
+
+    @Test
+    fun `should retrieve defence fortification modifiers`() {
+        // given
+        defaultDefenderUnit.currentMovement = 2f // base warrior max movement points
+        defaultDefenderUnit.fortify()
+        TurnManager(defenderCiv).endTurn()
+
+        // when
+        val defenceModifiers = BattleDamage.getDefenceModifiers(MapUnitCombatant(defaultAttackerUnit), MapUnitCombatant(defaultDefenderUnit), defaultAttackerTile)
+
+        // then
+        assertEquals(1, defenceModifiers.size)
+        assertEquals(BattleConstants.FORTIFICATION_BONUS, defenceModifiers.sumValues())
+    }
+
+    @Test
+    fun `should retrieve defence terrain modifiers`() {
+        // given
+        testGame.setTileFeatures(defaultDefenderTile.position, "Hill")
+
+        // when
+        val defenceModifiers = BattleDamage.getDefenceModifiers(MapUnitCombatant(defaultAttackerUnit), MapUnitCombatant(defaultDefenderUnit), defaultAttackerTile)
+
+        // then
+        assertEquals(1, defenceModifiers.size)
+        assertEquals(25, defenceModifiers.sumValues())
+    }
+
+    @Test
+    fun `should not retrieve defence terrain modifiers when unit doesn't get them`() {
+        // given
+        val defenderTile = testGame.getTile(Vector2.Zero)
+        testGame.setTileFeatures(defenderTile.position, "Hill")
+        defenderCiv.resourceStockpiles.add("Horses", 1) // no resource penalty
+        val defenderUnit = testGame.addUnit("Horseman", defenderCiv, defenderTile)
+
+        // when
+        val defenceModifiers = BattleDamage.getDefenceModifiers(MapUnitCombatant(defaultAttackerUnit), MapUnitCombatant(defenderUnit), defaultAttackerTile)
+
+        // then
+        assertTrue(defenceModifiers.isEmpty())
+        assertEquals(0, defenceModifiers.sumValues())
+    }
+}


### PR DESCRIPTION
This PR is not affiliated with any GitHub issue

* Small refactors for object BattleDamage by introducing helper functions and moving magic constant numbers to dedicated file
* Introduce tests covering most common damage modifiers cases

I suggest looking at the PR commit-by-commit