### PR TITLE
Fix: "Only available" not working properly for religions or transforming/upgrading units

### DIFF
--- a/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
@@ -41,6 +41,7 @@ import com.unciv.models.ruleset.PolicyBranch
 import com.unciv.models.ruleset.Victory
 import com.unciv.models.ruleset.tech.Technology
 import com.unciv.models.ruleset.tile.ResourceType
+import com.unciv.models.ruleset.unique.StateForConditionals
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.ruleset.unit.BaseUnit
 import com.unciv.models.stats.Stat
@@ -708,7 +709,8 @@ object NextTurnAutomation {
                 (it.type == beliefType || beliefType == BeliefType.Any)
                 && !additionalBeliefsToExclude.contains(it)
                 && civInfo.religionManager.getReligionWithBelief(it) == null
-                && it.getMatchingUniques(UniqueType.OnlyAvailableWhen).none { unique -> !unique.conditionalsApply(civInfo) }
+                && it.getMatchingUniques(UniqueType.OnlyAvailableWhen, StateForConditionals.IgnoreConditionals)
+                    .none { unique -> !unique.conditionalsApply(civInfo) }
             }
             .maxByOrNull { ReligionAutomation.rateBelief(civInfo, it) }
     }

--- a/core/src/com/unciv/logic/map/mapunit/UnitUpgradeManager.kt
+++ b/core/src/com/unciv/logic/map/mapunit/UnitUpgradeManager.kt
@@ -32,7 +32,7 @@ class UnitUpgradeManager(val unit:MapUnit) {
         fun isInvalidUpgradeDestination(baseUnit: BaseUnit): Boolean{
             if (baseUnit.requiredTech != null && !unit.civ.tech.isResearched(baseUnit.requiredTech!!))
                 return true
-            if (baseUnit.getMatchingUniques(UniqueType.OnlyAvailableWhen).any {
+            if (baseUnit.getMatchingUniques(UniqueType.OnlyAvailableWhen, StateForConditionals.IgnoreConditionals).any {
                         !it.conditionalsApply(StateForConditionals(unit.civ, unit = unit ))
                     }) return true
             return false

--- a/core/src/com/unciv/ui/screens/pickerscreens/PantheonPickerScreen.kt
+++ b/core/src/com/unciv/ui/screens/pickerscreens/PantheonPickerScreen.kt
@@ -3,6 +3,8 @@ package com.unciv.ui.screens.pickerscreens
 import com.unciv.logic.civilization.Civilization
 import com.unciv.models.ruleset.Belief
 import com.unciv.models.ruleset.BeliefType
+import com.unciv.models.ruleset.unique.StateForConditionals
+import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.translations.tr
 
 class PantheonPickerScreen(
@@ -17,7 +19,9 @@ class PantheonPickerScreen(
         for (belief in ruleset.beliefs.values) {
             if (belief.type != BeliefType.Pantheon) continue
             val beliefButton = getBeliefButton(belief, withTypeLabel = false)
-            if (choosingCiv.religionManager.getReligionWithBelief(belief) == null) {
+            if (choosingCiv.religionManager.getReligionWithBelief(belief) == null
+                && belief.getMatchingUniques(UniqueType.OnlyAvailableWhen, StateForConditionals.IgnoreConditionals)
+                    .none { !it.conditionalsApply(choosingCiv) }) {
                 beliefButton.onClickSelect(selection, belief) {
                     selectedPantheon = belief
                     pick("Follow [${belief.name}]".tr())

--- a/core/src/com/unciv/ui/screens/pickerscreens/ReligiousBeliefsPickerScreen.kt
+++ b/core/src/com/unciv/ui/screens/pickerscreens/ReligiousBeliefsPickerScreen.kt
@@ -11,6 +11,7 @@ import com.unciv.models.Counter
 import com.unciv.models.Religion
 import com.unciv.models.ruleset.Belief
 import com.unciv.models.ruleset.BeliefType
+import com.unciv.models.ruleset.unique.StateForConditionals
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.translations.tr
 import com.unciv.ui.components.AutoScrollPane
@@ -219,8 +220,10 @@ class ReligiousBeliefsPickerScreen (
                     // The Belief is not available because someone already has it
                     beliefButton.disable(redDisableColor)
                 }
-                belief.getMatchingUniques(UniqueType.OnlyAvailableWhen).any { !it.conditionalsApply(choosingCiv) } ->
-                    beliefButton.disable(redDisableColor) // Blocked
+                belief.getMatchingUniques(UniqueType.OnlyAvailableWhen, StateForConditionals.IgnoreConditionals)
+                    .any { !it.conditionalsApply(choosingCiv) } ->
+                    // The Belief is blocked
+                    beliefButton.disable(redDisableColor)
 
                 else ->
                     beliefButton.onClickSelect(rightSelection, belief) {

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActions.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActions.kt
@@ -333,7 +333,7 @@ object UnitActions {
         for (unique in unit.baseUnit().getMatchingUniques(UniqueType.CanTransform, stateForConditionals)) {
             val unitToTransformTo = civInfo.getEquivalentUnit(unique.params[0])
 
-            if (unitToTransformTo.getMatchingUniques(UniqueType.OnlyAvailableWhen)
+            if (unitToTransformTo.getMatchingUniques(UniqueType.OnlyAvailableWhen, StateForConditionals.IgnoreConditionals)
                     .any { !it.conditionalsApply(stateForConditionals) })
                 continue
 


### PR DESCRIPTION
Tbh, I'm not as much of a fan of this implementation. "Only available" needs special rules so often that I almost feel like maybe the better solution is to actually address this in `conditionsApplies` rather than everytime it comes up