### PR TITLE
Potentially fix canUnitSwapToReachableTile crash

### DIFF
--- a/core/src/com/unciv/logic/map/mapunit/UnitMovement.kt
+++ b/core/src/com/unciv/logic/map/mapunit/UnitMovement.kt
@@ -463,12 +463,12 @@ class UnitMovement(val unit: MapUnit) {
         // Check if we could enter their tile if they wouldn't be there
         otherUnit.removeFromTile()
         val weCanEnterTheirTile = canMoveTo(reachableTile)
-        otherUnit.putInTile(reachableTile)
+        otherUnit.putInTileUnchecked(reachableTile)
         if (!weCanEnterTheirTile) return false
         // Check if they could enter our tile if we wouldn't be here
         unit.removeFromTile()
         val theyCanEnterOurTile = otherUnit.movement.canMoveTo(ourPosition)
-        unit.putInTile(ourPosition)
+        unit.putInTileUnchecked(ourPosition)
         if (!theyCanEnterOurTile) return false
         // All clear!
         return true


### PR DESCRIPTION
Possibly fixes #10011 - can't test without a save allowing such a liberate city-state. Normal gameplay tests fine.

Not necessarily the correct solution, but one without rules change. The question is, should we ensure city tiles can never ever ever contain other civ's units? In that case, if the liberator were already teleported away as punishment, the issue would likely not arise.