### PR TITLE
Update Bulgarian.properties

### DIFF
--- a/android/assets/jsons/translations/Bulgarian.properties
+++ b/android/assets/jsons/translations/Bulgarian.properties
@@ -34,17 +34,17 @@ Civ V - Gods & Kings = Civ V - Богове и царе
 
 # Tutorial tasks
 
-Move a unit!\nClick on a unit > Click on a destination > Click the arrow popup = Придвижване на единица!\nКликнете на единица > Кликнете на дестинация > Кликнете на изкачащата стрелка
-Found a city!\nSelect the Settler (flag unit) > Click on 'Found city' (bottom-left corner) = Намерен нов град!\nИзберете Заселник (с флаг) > Кликнете на 'Намерен град' (долен ляв ъгъл)
-Enter the city screen!\nClick the city button twice = Влизане в екран на града!\nКликнете два пъти върху бутона на града
-Pick a technology to research!\nClick on the tech button (greenish, top left) > \n select technology > click 'Research' (bottom right) = Избор на технология за изследване!\nКликнете на бутона за технологии (зелен, горе вляво) > \n Изберете технология > Кликнете на 'Изследване' (долу вдясно)
-Pick a construction!\nEnter city screen > Click on a unit or building (bottom left side) > \n click 'add to queue' = Избор на нов строеж!\nВлезте в екрана на града > Кликнете на единица или сграда (долу вляво) > \n Кликнете 'добавяне'
-Pass a turn!\nCycle through units with 'Next unit' > Click 'Next turn' = Завършване на ход!\nПреминете през всички единици със 'Следваща единица' > Кликнете 'Следващ ход'
-Reassign worked tiles!\nEnter city screen > click the assigned (green) tile to unassign > \n click an unassigned tile to assign population = Преназначаване на плочки!\nВлезте в екрана на града > Кликнете на назначената (зелена) плочка за отмяна > \n Кликнете на отменената плочка за назначаване на популация
-Meet another civilization!\nExplore the map until you encounter another civilization! = Среща с нова цивилизация!\nИзследвайте картата, докато не срещнете нова цивилизация!
-Open the options table!\nClick the menu button (top left) > click 'Options' = Промяна на опциите!\nКликнете на бутона меню (горе вляво) > Изберете 'Опции'
-Construct an improvement!\nConstruct a Worker unit > Move to a Plains or Grassland tile > \n Click 'Construct improvement' (above the unit table, bottom left)\n > Choose the farm > \n Leave the worker there until it's finished = Подобрения!\nОбучете Работник > Изберете плочка Равнина или Трева > \n Кликнете на 'Подобрения' (над таблицата с единиците, долу вляво)\n > Изберете фермата > \n Оставете работника там, докато не завърши
-Create a trade route!\nConstruct roads between your capital and another city\nOr, automate your worker and let him get to that eventually = Създаване на търговски път!\nПостройте пътища между столицата и друг град\nИли оставете работника си да го завърши
+Move a unit!\nClick on a unit > Click on a destination > Click the arrow popup = Придвижете единица!\nКликнете на единица > Кликнете на дестинация > Кликнете на изскачащата стрелка
+Found a city!\nSelect the Settler (flag unit) > Click on 'Found city' (bottom-left corner) = Основете нов град!\nИзберете Заселник (с флаг) > Кликнете на 'Основете град' (долен ляв ъгъл)
+Enter the city screen!\nClick the city button twice = Влезте в екрана на града!\nКликнете два пъти върху бутона на града
+Pick a technology to research!\nClick on the tech button (greenish, top left) > \n select technology > click 'Research' (bottom right) = Изберете технология за изобретяване!\nКликнете на бутона за технологии (зеленикав, горе вляво) > \n Изберете технология > Кликнете на 'Изобретяване' (долу вдясно)
+Pick a construction!\nEnter city screen > Click on a unit or building (bottom left side) > \n click 'add to queue' = Постройте нещо!\nВлезте в екрана на града > Кликнете върху единица или сграда (долу вляво) > \n Кликнете върху 'добавяне'
+Pass a turn!\nCycle through units with 'Next unit' > Click 'Next turn' = Завършете ход!\nПреминете през всички единици със 'Следваща единица' > Кликнете 'Следващ ход'
+Reassign worked tiles!\nEnter city screen > click the assigned (green) tile to unassign > \n click an unassigned tile to assign population = Преназначете полета!\nВлезте в екрана на града > Кликнете на назначеното (зелено) поле за отмяна > \n Кликнете на отмененото поле за назначаване на население
+Meet another civilization!\nExplore the map until you encounter another civilization! = Срещнете се с чужда цивилизация!\nИзследвайте картата, докато не срещнете друга цивилизация!
+Open the options table!\nClick the menu button (top left) > click 'Options' = Отворете прозореца с опции!\nКликнете на бутона меню (горе вляво) > Изберете 'Опции'
+Construct an improvement!\nConstruct a Worker unit > Move to a Plains or Grassland tile > \n Click 'Construct improvement' (above the unit table, bottom left)\n > Choose the farm > \n Leave the worker there until it's finished = Оползотворете поле!\nОбучете Работник > Изберете поле с Равнина или Трева > \n Кликнете на 'Подобрения' (над таблицата с единиците, долу вляво)\n > Изберете фермата > \n Оставете работника там, докато не завърши
+Create a trade route!\nConstruct roads between your capital and another city\nOr, automate your worker and let him get to that eventually = Създайте търговски път!\nПостройте пътища между столицата и друг град\nИли оставете работника си да го завърши
 Conquer a city!\nBring an enemy city down to low health > \nEnter the city with a melee unit = Завладяване на град!\nНамалете защитата на вражеския град > \nВлезте в града с бойна единица
 Move an air unit!\nSelect an air unit > select another city within range > \nMove the unit to the other city = Придвижване на въздушна единица!\nИзберете въздушна единица > Изберете друг град в обсег > \nПреместете единицата в другия град
 See your stats breakdown!\nEnter the Overview screen (top right corner) >\nClick on 'Stats' = Вижте своята статистика!\nВлезте в екрана Преглед (горен десен ъгъл) >\nКликнете на 'Статистика'


### PR DESCRIPTION
Според мен е по-добре ''tile" да се преведе като "поле", а не като "плочка". Също предлагам някои изрази в упътванията, които съдържат отглаголни съществителни (като "Придвижване на единица") да се заменят с заповедни форми на глагола - като "Придвижете единица".