### PR TITLE
Fix cities getting the resource list of other cities

### DIFF
--- a/core/src/com/unciv/logic/city/City.kt
+++ b/core/src/com/unciv/logic/city/City.kt
@@ -264,7 +264,7 @@ class City : IsPartOfGameInfoSerialization {
     }
 
     private fun getCityResourcesFromUniqueBuildings(cityResources: ResourceSupplyList, resourceModifer: HashMap<String, Float>) {
-        for (unique in getMatchingUniques(UniqueType.ProvidesResources, StateForConditionals(civ, this))) { // E.G "Provides [1] [Iron]"
+        for (unique in cityConstructions.builtBuildingUniqueMap.getMatchingUniques(UniqueType.ProvidesResources, StateForConditionals(civ, this))) { // E.G "Provides [1] [Iron]"
             val resource = getRuleset().tileResources[unique.params[1]]
                 ?: continue
             cityResources.add(


### PR DESCRIPTION
Fixes #10038
Note: Because of this change, local-style beliefs can no longer provide resources at all. On one hand, this is fine as it would erroneously claim it came from a building and resources from follower beliefs applying to the cities themselves may or may not be confusing (there was a whole discussion on discord wondering how it actually worked). On the other, maybe beliefs should be counted separately as well