### PR TITLE
Fix longpress triggering when an onClick discards its actor

### DIFF
--- a/core/src/com/unciv/ui/components/input/ActivationListener.kt
+++ b/core/src/com/unciv/ui/components/input/ActivationListener.kt
@@ -17,6 +17,8 @@ class ActivationListener : ActorGestureListener(20f, 0.25f, 1.1f, Int.MAX_VALUE.
 
     override fun longPress(actor: Actor?, x: Float, y: Float): Boolean {
         if (actor == null) return false
+        // See #10050 - when a tap discards its actor or ascendants, Gdx can't cancel the longpress timer
+        if (actor.stage == null) return false
         return actor.activate(ActivationTypes.Longpress)
     }
 }


### PR DESCRIPTION
Closes #10050 

This is a valid workaround, but does not address a related issue: Why is that `actor` at that point even still in memory?

In `updateConstructionQueue` there's a `constructionsQueueTable.clear()` which should have freed it for collection... But no, Table.clear kills listeners on itself, but NOT on children. And `ActorGestureListener` is the only listener in Gdx that keeps a reference to an actor. Is that a Gdx bug? Not sure. What can we do? No idea. Is this a serious memory leak, as in - will discarded actors stay in memory forever or is this a race condition? No idea.