### PR TITLE
Fix free units with a build limit not spawning

### DIFF
--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -61,7 +61,7 @@ object UniqueTriggerActivation {
 
                 val limit = unit.getMatchingUniques(UniqueType.MaxNumberBuildable)
                     .map { it.params[0].toInt() }.minOrNull()
-                if (limit!=null && limit <= civInfo.units.getCivUnits().count { it.name==unitName })
+                if (limit!=null && limit <= civInfo.units.getCivUnits().count { it.name == unitName })
                     return false
 
                 val placedUnit = if (city != null || tile == null)
@@ -88,10 +88,13 @@ object UniqueTriggerActivation {
 
                 val limit = unit.getMatchingUniques(UniqueType.MaxNumberBuildable)
                     .map { it.params[0].toInt() }.minOrNull()
+                val unitCount = civInfo.units.getCivUnits().count { it.name == unitName }
                 val amountFromTriggerable = unique.params[0].toInt()
-                val actualAmount =
-                        if (limit==null) amountFromTriggerable
-                        else civInfo.units.getCivUnits().count { it.name==unitName } - limit
+                val actualAmount = when {
+                    limit == null -> amountFromTriggerable
+                    amountFromTriggerable + unitCount > limit -> unitCount - limit
+                    else -> amountFromTriggerable
+                }
 
                 if (actualAmount <= 0) return false
 

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -61,7 +61,7 @@ object UniqueTriggerActivation {
 
                 val limit = unit.getMatchingUniques(UniqueType.MaxNumberBuildable)
                     .map { it.params[0].toInt() }.minOrNull()
-                if (limit!=null && limit <= civInfo.units.getCivUnits().count { it.name == unitName })
+                if (limit != null && limit <= civInfo.units.getCivUnits().count { it.name == unitName })
                     return false
 
                 val placedUnit = if (city != null || tile == null)

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -92,7 +92,7 @@ object UniqueTriggerActivation {
                 val amountFromTriggerable = unique.params[0].toInt()
                 val actualAmount = when {
                     limit == null -> amountFromTriggerable
-                    amountFromTriggerable + unitCount > limit -> unitCount - limit
+                    amountFromTriggerable + unitCount > limit -> limit - unitCount
                     else -> amountFromTriggerable
                 }
 


### PR DESCRIPTION
I feel like this might be handling things incorrectly. Shouldn't we check if we're above a build limit in placeUnitNearTile instead of the unique? It's not like we even need to check in the unique since it can already handle if the unit doesn't spawn