### PR TITLE
Removed double notifications and processing of treaties when traded

### DIFF
--- a/core/src/com/unciv/logic/trade/TradeLogic.kt
+++ b/core/src/com/unciv/logic/trade/TradeLogic.kt
@@ -157,6 +157,7 @@ class TradeLogic(val ourCivilization:Civilization, val otherCivilization: Civili
         for (offer in currentTrade.ourOffers.filterNot { it.type == TradeType.Treaty })
             transferTrade(ourCivilization, otherCivilization, offer)
 
+        // Transfter of treaties should only be done from one side to avoid double signing and notifying
         for (offer in currentTrade.theirOffers.filter { it.type == TradeType.Treaty })
             transferTrade(otherCivilization, ourCivilization, offer)
 

--- a/core/src/com/unciv/logic/trade/TradeLogic.kt
+++ b/core/src/com/unciv/logic/trade/TradeLogic.kt
@@ -124,13 +124,17 @@ class TradeLogic(val ourCivilization:Civilization, val otherCivilization: Civili
                         to.popupAlerts.add(PopupAlert(AlertType.CityTraded, city.id))
                 }
                 TradeType.Treaty -> {
+                    // Note: Treaties are not transfered from both sides due to notifications and double signing
                     if (offer.name == Constants.peaceTreaty) to.getDiplomacyManager(from).makePeace()
                     if (offer.name == Constants.researchAgreement) {
                         to.addGold(-offer.amount)
+                        from.addGold(-offer.amount)
                         to.getDiplomacyManager(from)
                             .setFlag(DiplomacyFlags.ResearchAgreement, offer.duration)
+                        from.getDiplomacyManager(to)
+                            .setFlag(DiplomacyFlags.ResearchAgreement, offer.duration)
                     }
-                    if (offer.name == Constants.defensivePact) from.getDiplomacyManager(to).signDefensivePact(offer.duration);
+                    if (offer.name == Constants.defensivePact) to.getDiplomacyManager(from).signDefensivePact(offer.duration);
                 }
                 TradeType.Introduction -> to.diplomacyFunctions.makeCivilizationsMeet(to.gameInfo.getCivilization(offer.name))
                 TradeType.WarDeclaration -> {
@@ -155,8 +159,6 @@ class TradeLogic(val ourCivilization:Civilization, val otherCivilization: Civili
 
         for (offer in currentTrade.theirOffers.filter { it.type == TradeType.Treaty })
             transferTrade(otherCivilization, ourCivilization, offer)
-        for (offer in currentTrade.ourOffers.filter { it.type == TradeType.Treaty })
-            transferTrade(ourCivilization, otherCivilization, offer)
 
         ourCivilization.cache.updateCivResources()
         ourCivilization.updateStatsForNextTurn()


### PR DESCRIPTION
Originally a part of #10071

Treaties are now only processed from one side of the trade. 

Due to the nature of a treaty they must be on each side of the trade. The previous code processed the treaties on both sides of the trade. However, DiplomacyManager.makePeace() calls makePeaceOneSide() on both sides, as well as signDefensivePact(). Calling makePeace() and signDefensivePact() twice did not cause any logical problems, but it does cause a double notification to appear, which is redundant and takes up notification space.

![DoubleNotification](https://github.com/yairm210/Unciv/assets/7538725/52c069cd-679c-4671-be52-46f6d0a85dde)

This change processes each treaty from only one side arbitrarily. The only difference with these is which Civ appears first on the notifications. The research agreement was the only thing that needed to be processed from both sides, which I fixed.