### PR TITLE
Defense against Circular upgrade paths in mods

### DIFF
--- a/core/src/com/unciv/logic/map/mapunit/UnitUpgradeManager.kt
+++ b/core/src/com/unciv/logic/map/mapunit/UnitUpgradeManager.kt
@@ -1,5 +1,6 @@
 package com.unciv.logic.map.mapunit
 
+import com.unciv.logic.UncivShowableException
 import com.unciv.models.ruleset.RejectionReasonType
 import com.unciv.models.ruleset.unique.StateForConditionals
 import com.unciv.models.ruleset.unique.UniqueType
@@ -11,11 +12,13 @@ class UnitUpgradeManager(val unit:MapUnit) {
 
     /** Returns FULL upgrade path, without checking what we can or cannot build currently.
      * Does not contain current baseunit, so will be empty if no upgrades. */
-    private fun getUpgradePath(): List<BaseUnit>{
+    private fun getUpgradePath(): Iterable<BaseUnit> {
         var currentUnit = unit.baseUnit
-        val upgradeList = arrayListOf<BaseUnit>()
-        while (currentUnit.upgradesTo != null){
+        val upgradeList = linkedSetOf<BaseUnit>()
+        while (currentUnit.upgradesTo != null) {
             val nextUpgrade = unit.civ.getEquivalentUnit(currentUnit.upgradesTo!!)
+            if (nextUpgrade in upgradeList)
+                throw(UncivShowableException("Circular or self-referencing upgrade path for ${currentUnit.name}"))
             currentUnit = nextUpgrade
             upgradeList.add(currentUnit)
         }


### PR DESCRIPTION
Inspired by Issue #10092 (already closed):
* UnitUpgradeManager.getUpgradePath will crash with a stack or heap overflow without this, with a large potential delay and impeding CrashScreen to function normally, now it will crash immediately with a meaningful message - and healthy memory.
* A check in RulesetValidator catches the situation, Error-leveled, Rulesetspecific. Screenshot in the issue.
* Some readability improvements in RulesetValidator - I hope - `fun getErrorList` is still faaaaaaaaar too long, but at least this shortens it a bit.

Can be tested using this mod: [Test bad upgrades.zip](https://github.com/yairm210/Unciv/files/12594485/Test.bad.upgrades.zip)
