### PR TITLE
Readability helpers for Maps of Sets: add, contains

### DIFF
--- a/core/src/com/unciv/logic/city/CityConstructions.kt
+++ b/core/src/com/unciv/logic/city/CityConstructions.kt
@@ -31,6 +31,7 @@ import com.unciv.models.stats.Stat
 import com.unciv.models.stats.Stats
 import com.unciv.models.translations.tr
 import com.unciv.ui.components.Fonts
+import com.unciv.ui.components.extensions.addToMapOfSets
 import com.unciv.ui.components.extensions.withItem
 import com.unciv.ui.components.extensions.withoutItem
 import com.unciv.ui.screens.civilopediascreen.CivilopediaCategories
@@ -38,7 +39,6 @@ import com.unciv.ui.screens.civilopediascreen.FormattedLine
 import kotlin.math.ceil
 import kotlin.math.min
 import kotlin.math.roundToInt
-
 
 /**
  * City constructions manager.
@@ -604,7 +604,7 @@ class CityConstructions : IsPartOfGameInfoSerialization {
             for (city in citiesThatApply) {
                 if (city.cityConstructions.containsBuildingOrEquivalent(freeBuilding.name)) continue
                 city.cityConstructions.addBuilding(freeBuilding)
-                freeBuildingsProvidedFromThisCity.getOrPut(city.id) { hashSetOf() }.add(freeBuilding.name)
+                freeBuildingsProvidedFromThisCity.addToMapOfSets(city.id, freeBuilding.name)
             }
         }
 
@@ -612,7 +612,7 @@ class CityConstructions : IsPartOfGameInfoSerialization {
         for (unique in city.civ.getMatchingUniques(UniqueType.GainFreeBuildings, stateForConditionals = StateForConditionals(city.civ, city))) {
             val freeBuilding = city.civ.getEquivalentBuilding(unique.params[0])
             if (city.matchesFilter(unique.params[1])) {
-                freeBuildingsProvidedFromThisCity.getOrPut(city.id) { hashSetOf() }.add(freeBuilding.name)
+                freeBuildingsProvidedFromThisCity.addToMapOfSets(city.id, freeBuilding.name)
                 if (!isBuilt(freeBuilding.name))
                     addBuilding(freeBuilding)
             }

--- a/core/src/com/unciv/logic/civilization/CivConstructions.kt
+++ b/core/src/com/unciv/logic/civilization/CivConstructions.kt
@@ -8,6 +8,8 @@ import com.unciv.models.ruleset.INonPerpetualConstruction
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.ruleset.unit.BaseUnit
 import com.unciv.models.stats.Stat
+import com.unciv.ui.components.extensions.addToMapOfSets
+import com.unciv.ui.components.extensions.contains
 import com.unciv.ui.components.extensions.yieldAllNotNull
 
 class CivConstructions : IsPartOfGameInfoSerialization {
@@ -88,8 +90,7 @@ class CivConstructions : IsPartOfGameInfoSerialization {
         getFreeBuildingNamesSequence(cityId).contains(buildingName)
 
     private fun addFreeBuilding(cityId: String, building: String) {
-        freeBuildings.getOrPut(cityId) { hashSetOf() }
-            .add(civInfo.getEquivalentBuilding(building).name)
+        freeBuildings.addToMapOfSets(cityId, civInfo.getEquivalentBuilding(building).name)
     }
 
     private fun addFreeStatsBuildings() {
@@ -105,12 +106,12 @@ class CivConstructions : IsPartOfGameInfoSerialization {
 
     private fun addFreeStatBuildings(stat: Stat, amount: Int) {
         for (city in civInfo.cities.take(amount)) {
-            if (freeStatBuildingsProvided[stat.name]?.contains(city.id) == true) continue
+            if (freeStatBuildingsProvided.contains(stat.name, city.id)) continue
             if (!city.cityConstructions.hasBuildableStatBuildings(stat)) continue
 
             val builtBuilding = city.cityConstructions.addCheapestBuildableStatBuilding(stat)
             if (builtBuilding != null) {
-                freeStatBuildingsProvided.getOrPut(stat.name) { hashSetOf() }.add(city.id)
+                freeStatBuildingsProvided.addToMapOfSets(stat.name, city.id)
                 addFreeBuilding(city.id, builtBuilding)
             }
         }
@@ -130,12 +131,12 @@ class CivConstructions : IsPartOfGameInfoSerialization {
     private fun addFreeBuildings(building: Building, amount: Int) {
 
         for (city in civInfo.cities.take(amount)) {
-            if (freeSpecificBuildingsProvided[building.name]?.contains(city.id) == true
+            if (freeSpecificBuildingsProvided.contains(building.name, city.id)
                 || city.cityConstructions.containsBuildingOrEquivalent(building.name)) continue
 
             building.postBuildEvent(city.cityConstructions)
 
-            freeSpecificBuildingsProvided.getOrPut(building.name) { hashSetOf() }.add(city.id)
+            freeSpecificBuildingsProvided.addToMapOfSets(building.name, city.id)
             addFreeBuilding(city.id, building.name)
         }
     }

--- a/core/src/com/unciv/ui/components/extensions/CollectionExtensions.kt
+++ b/core/src/com/unciv/ui/components/extensions/CollectionExtensions.kt
@@ -83,3 +83,18 @@ suspend fun <T> SequenceScope<T>.yieldAllNotNull(elements: Iterable<T?>?) {
     if (elements == null) return
     for (element in elements) yieldIfNotNull(element)
 }
+
+/**
+ *  Simplifies adding to a map of sets where the map entry where the new element belongs is not
+ *  guaranteed to be already present in the map (sparse map).
+ *
+ *  @param key The key identifying the Set to add [element] to
+ *  @param element The new element to be added to the Set for [key]
+ *  @return `false` if the element was already present, `true` if it was new (same as `Set.add()`)
+ */
+fun <KT, ET> HashMap<KT, HashSet<ET>>.addToMapOfSets(key: KT, element: ET) =
+    getOrPut(key) { hashSetOf() }.add(element)
+
+/** Simplifies testing whether in a sparse map of sets the [element] exists for [key]. */
+fun <KT, ET> HashMap<KT, HashSet<ET>>.contains(key: KT, element: ET) =
+    get(key)?.contains(element) == true


### PR DESCRIPTION
Follow-up on #10094 , [readability discussion](https://github.com/yairm210/Unciv/pull/10094#discussion_r1324120270)

Notes:
* CollectionExtensions.kt is under `ui` but does not really belong there - to be mulled over some time
* A generic applicable both to `HashMap<KT,HashSet<ET>>` and `MutableMap<KT,MutableSet<ET>>` - I failed to grasp how. Should be possible, the inheritance connections are there... :puzzled: