### PR TITLE
Re-enable clean unit tests by fixing Japanese placeholders

### DIFF
--- a/android/assets/jsons/translations/Japanese.properties
+++ b/android/assets/jsons/translations/Japanese.properties
@@ -2307,7 +2307,7 @@ when above [amount] [resource] = [resource][amount]より多く
 when below [amount] [resource] = [resource][amount]未満で
 in this city = この都市で
 in cities with a [buildingFilter] = [buildingFilter]を持つ都市で
-in cities without a [buildingFilter] = [buindingFilter]が無い都市で
+in cities without a [buildingFilter] = [buildingFilter]が無い都市で
 in cities with at least [amount] [populationFilter] = [populationFilter]が[amount]以上いる都市で
 with a garrison = 駐屯地がある
 for [mapUnitFilter] units = [mapUnitFilter]のユニットに
@@ -2354,7 +2354,7 @@ Gain a free [beliefType] belief = 無償の[beliefType]信念を手に入れる
 Triggers voting for the Diplomatic Victory = 外交勝利のための投票が行なわれる
 Instantly consumes [amount] [stockpiledResource] = 即座に[amount]の[stockpiledResource]を消費する
 Instantly provides [amount] [stockpiledResource] = 即座に[amount]の[stockpiledResource]を供給する
-Gain [amount] [stat/resource] = [amount]の[stat/resouce]を手に入れる
+Gain [amount] [stat/resource] = [amount]の[stat/resource]を手に入れる
 Gain [amount]-[amount2] [stat] = [amount]-[amount2]の[stat]を手に入れる
 Gain enough Faith for a Pantheon = パンテオンに必要な信念を手に入れる
 Gain enough Faith for [amount]% of a Great Prophet = 偉大な預言者に必要な信念の[amount]%を手に入れる
@@ -7380,4 +7380,3 @@ If you opened the Civilopedia from the main menu, the "Ruleset" will be that of 
 Letters can select categories, and when there are multiple categories matching the same letter, you can press that repeatedly to cycle between these. = 
  # Requires translation!
 The arrow keys allow navigation as well - left/right for categories, up/down for entries. = 
-


### PR DESCRIPTION
Curious: Why did other new PR's not fail checks?