### PR TITLE
Corrected an error in Polish translations

### DIFF
--- a/android/assets/jsons/translations/Polish.properties
+++ b/android/assets/jsons/translations/Polish.properties
@@ -2562,7 +2562,7 @@ Monument = Pomnik
 
 Granary = Spichlerz
 
-Temple of Artemis = Świątyna Artemisa
+Temple of Artemis = Świątynia Artemidy
 'It is not so much for its beauty that the forest makes a claim upon men's hearts, as for that subtle something, that quality of air, that emanation from old trees, that so wonderfully changes and renews a weary spirit.' - Robert Louis Stevenson = „Nie tyle ze względu na swoje piękno las rości sobie prawo do ludzkich serc, ile o to subtelne coś, ta jakość powietrza, ta emanacja ze starych drzew, która tak cudownie zmienia i odnawia znużonego ducha.”\n\n– Robert Louis Stevenson
 
 The Great Lighthouse = Latarnia z Faros


### PR DESCRIPTION
# Source
 ## English name:
https://en.wikipedia.org/wiki/Temple_of_Artemis
## Polish name:
https://pl.wikipedia.org/wiki/%C5%9Awi%C4%85tynia_Artemidy_w_Efezie