### PR TITLE
Added return worker notification

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -934,6 +934,7 @@ After being hit by our [nukeType], [civName] has declared war on us! =
 The civilization of [civName] has been destroyed! = 
 The City-State of [name] has been destroyed! = 
 Your [ourUnit] captured an enemy [theirUnit]! = 
+Your captured [unitName] has been returned by [civName] = 
 Your [ourUnit] plundered [amount] [Stat] from [theirUnit] = 
 We have captured a barbarian encampment and recovered [goldAmount] gold! = 
 An enemy [unitType] has joined us! = 

--- a/core/src/com/unciv/ui/screens/worldscreen/AlertPopup.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/AlertPopup.kt
@@ -10,6 +10,7 @@ import com.unciv.logic.city.City
 import com.unciv.logic.civilization.AlertType
 import com.unciv.logic.civilization.Civilization
 import com.unciv.logic.civilization.NotificationCategory
+import com.unciv.logic.civilization.NotificationIcon
 import com.unciv.logic.civilization.PopupAlert
 import com.unciv.logic.civilization.diplomacy.DiplomaticModifiers
 import com.unciv.logic.civilization.diplomacy.RelationshipLevel
@@ -305,6 +306,7 @@ class AlertPopup(
                 originalOwner.getDiplomacyManager(captor)
                     .setModifier(DiplomaticModifiers.ReturnedCapturedUnits, 20f)
             }
+            originalOwner.addNotification("Your captured [${unitName}] has been returned by [${captor.civName}]", tile.position, NotificationCategory.Diplomacy, NotificationIcon.Trade, unitName, captor.civName)
         }
         addCloseButton(Constants.no, KeyboardBinding.Cancel) {
             // Take it for ourselves

--- a/core/src/com/unciv/ui/screens/worldscreen/AlertPopup.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/AlertPopup.kt
@@ -9,6 +9,10 @@ import com.unciv.logic.battle.Battle
 import com.unciv.logic.city.City
 import com.unciv.logic.civilization.AlertType
 import com.unciv.logic.civilization.Civilization
+import com.unciv.logic.civilization.CivilopediaAction
+import com.unciv.logic.civilization.DiplomacyAction
+import com.unciv.logic.civilization.LocationAction
+import com.unciv.logic.civilization.NotificationAction
 import com.unciv.logic.civilization.NotificationCategory
 import com.unciv.logic.civilization.NotificationIcon
 import com.unciv.logic.civilization.PopupAlert
@@ -306,7 +310,14 @@ class AlertPopup(
                 originalOwner.getDiplomacyManager(captor)
                     .setModifier(DiplomaticModifiers.ReturnedCapturedUnits, 20f)
             }
-            originalOwner.addNotification("Your captured [${unitName}] has been returned by [${captor.civName}]", tile.position, NotificationCategory.Diplomacy, NotificationIcon.Trade, unitName, captor.civName)
+            val notificationSequence = sequence {
+                yield(LocationAction(tile.position))
+                if (closestCity != null)
+                    yield(LocationAction(closestCity.location))
+                yield(DiplomacyAction(captor.civName))
+                yield(CivilopediaAction("Tutorial/Barbarians"))
+            }
+            originalOwner.addNotification("Your captured [${unitName}] has been returned by [${captor.civName}]", notificationSequence, NotificationCategory.Diplomacy, NotificationIcon.Trade, unitName, captor.civName)
         }
         addCloseButton(Constants.no, KeyboardBinding.Cancel) {
             // Take it for ourselves


### PR DESCRIPTION
Solves  #10139

This adds a notification to the Civ who receives their captured worker after it was rescued from another civ.
Two things that I would like to note are that the notification shows the tile where the worker was before it was captured. But what if that tile is outside of the viewing constraint of the Civ?
Also, I couldn't find any code for the AI choosing to return the worker.

![Settler return](https://github.com/yairm210/Unciv/assets/7538725/aa45316a-b95a-4e33-87d1-48213e2def99)