### PR TITLE
Liberate civ open borders fix

### DIFF
--- a/core/src/com/unciv/logic/city/managers/CityConquestFunctions.kt
+++ b/core/src/com/unciv/logic/city/managers/CityConquestFunctions.kt
@@ -236,7 +236,6 @@ class CityConquestFunctions(val city: City){
                     .addModifier(DiplomaticModifiers.CapturedOurCities, respectForLiberatingOurCity)
             val openBordersTrade = TradeLogic(foundingCiv, conqueringCiv)
             openBordersTrade.currentTrade.ourOffers.add(TradeOffer(Constants.openBorders, TradeType.Agreement))
-            openBordersTrade.currentTrade.theirOffers.add(TradeOffer(Constants.openBorders, TradeType.Agreement))
             openBordersTrade.acceptTrade()
         } else {
             //Liberating a city state gives a large amount of influence, and peace

--- a/core/src/com/unciv/logic/city/managers/CityConquestFunctions.kt
+++ b/core/src/com/unciv/logic/city/managers/CityConquestFunctions.kt
@@ -234,6 +234,10 @@ class CityConquestFunctions(val city: City){
         if (foundingCiv.isMajorCiv()) {
             foundingCiv.getDiplomacyManager(conqueringCiv)
                     .addModifier(DiplomaticModifiers.CapturedOurCities, respectForLiberatingOurCity)
+            val openBordersTrade = TradeLogic(foundingCiv, conqueringCiv)
+            openBordersTrade.currentTrade.ourOffers.add(TradeOffer(Constants.openBorders, TradeType.Agreement))
+            openBordersTrade.currentTrade.theirOffers.add(TradeOffer(Constants.openBorders, TradeType.Agreement))
+            openBordersTrade.acceptTrade()
         } else {
             //Liberating a city state gives a large amount of influence, and peace
             foundingCiv.getDiplomacyManager(conqueringCiv).setInfluence(90f)


### PR DESCRIPTION
Solves #7777

This commit adds an open borders trade from the liberated Civ. The liberated Civ does not get open borders from the conquering Civ (to give the conquering civ more choice and power).

This change is not standard Civ V behavior based on online searching. It is, however, a quality-of-life improvement/game refinement.