### PR TITLE
(UX, minor change) Allow Space Key to close PlayerReadyScreen

### DIFF
--- a/core/src/com/unciv/ui/screens/worldscreen/PlayerReadyScreen.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/PlayerReadyScreen.kt
@@ -3,9 +3,11 @@ package com.unciv.ui.screens.worldscreen
 import com.badlogic.gdx.scenes.scene2d.Touchable
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.unciv.Constants
-import com.unciv.ui.screens.basescreen.BaseScreen
-import com.unciv.ui.components.input.onClick
 import com.unciv.ui.components.extensions.toLabel
+import com.unciv.ui.components.input.KeyboardBinding
+import com.unciv.ui.components.input.keyShortcuts
+import com.unciv.ui.components.input.onActivation
+import com.unciv.ui.screens.basescreen.BaseScreen
 
 class PlayerReadyScreen(worldScreen: WorldScreen) : BaseScreen() {
     init {
@@ -19,9 +21,11 @@ class PlayerReadyScreen(worldScreen: WorldScreen) : BaseScreen() {
 
         table.add("[$curCiv] ready?".toLabel(curCiv.nation.getInnerColor(), Constants.headingFontSize))
 
-        table.onClick {
+        table.onActivation {
             game.replaceCurrentScreen(worldScreen)
         }
+        // Doing this separately instead of passing the binding to onActivation avoids the tooltip
+        table.keyShortcuts.add(KeyboardBinding.NextTurnAlternate)
         table.setFillParent(true)
         stage.addActor(table)
     }


### PR DESCRIPTION
Random had it that I had a hotseat game as autosave to test the other PR...
Same as the Alert thing - re-using the "Next Turn Alternate" key binding to make it "move on" in as many places as reasonable