### PR TITLE
Unit Overview as SortableGrid - first draft

### DIFF
--- a/core/src/com/unciv/ui/screens/overviewscreen/CityOverviewTab.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/CityOverviewTab.kt
@@ -11,8 +11,7 @@ class CityOverviewTab(
     persistedData: EmpireOverviewTabPersistableData? = null
 ) : EmpireOverviewTab(viewingPlayer, overviewScreen) {
     class CityTabPersistableData(
-        override var sortedBy: CityOverviewTabColumn = CityOverviewTabColumn.CityColumn,
-
+        override var sortedBy: CityOverviewTabColumn = CityOverviewTabColumn.CityColumn
     ) : EmpireOverviewTabPersistableData(), SortableGrid.ISortState<CityOverviewTabColumn> {
         override fun isEmpty() = sortedBy == CityOverviewTabColumn.CityColumn
         override var direction = SortableGrid.SortDirection.None
@@ -26,17 +25,17 @@ class CityOverviewTab(
         actionContext = overviewScreen,
         sortState = persistableData,
         iconSize = 50f,  //if you set this too low, there is a chance that the tables will be misaligned
-        paddingVert = 5f,
-        paddingHorz = 8f,
-        separateHeader = false
+        separateHeader = true
     ) {
         header, details, totals ->
-        this.name
         equalizeColumns(details, header, totals)
         this.layout()
     }
 
+    override fun getFixedContent() = grid.getHeader()
+
     init {
+        top()
         add(grid)
     }
 }

--- a/core/src/com/unciv/ui/screens/overviewscreen/EmpireOverviewScreen.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/EmpireOverviewScreen.kt
@@ -14,7 +14,7 @@ import com.unciv.ui.screens.overviewscreen.EmpireOverviewCategories.EmpireOvervi
 import com.unciv.ui.screens.overviewscreen.EmpireOverviewTab.EmpireOverviewTabPersistableData
 
 class EmpireOverviewScreen(
-    private var viewingPlayer: Civilization,
+    private val viewingPlayer: Civilization,
     defaultCategory: EmpireOverviewCategories? = null,
     selection: String = ""
 ) : BaseScreen(), RecreateOnResize {

--- a/core/src/com/unciv/ui/screens/overviewscreen/UnitOverviewPromotionTable.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/UnitOverviewPromotionTable.kt
@@ -1,0 +1,57 @@
+package com.unciv.ui.screens.overviewscreen
+
+import com.badlogic.gdx.graphics.Color
+import com.badlogic.gdx.scenes.scene2d.ui.Table
+import com.unciv.GUI
+import com.unciv.logic.map.mapunit.MapUnit
+import com.unciv.ui.components.extensions.darken
+import com.unciv.ui.components.input.onClick
+import com.unciv.ui.images.ImageGetter
+import com.unciv.ui.screens.pickerscreens.PromotionPickerScreen
+
+/** Supplies one "cell" actor to [UnitOverviewTabColumn.Promotions], encapsulated for readability */
+class UnitOverviewPromotionTable(
+    unit: MapUnit,
+    actionContext: UnitOverviewTab
+) : Table() {
+    init {
+        onClick {
+            if (unit.promotions.canBePromoted() || unit.promotions.promotions.isNotEmpty()) {
+                val game = actionContext.overviewScreen.game
+                game.pushScreen(PromotionPickerScreen(unit) {
+                    update(unit)
+                })
+            }
+        }
+    }
+
+    private fun update(unit: MapUnit) {
+        clearChildren()
+
+        // getPromotions goes by json order on demand - so this is the same sorting as on UnitTable,
+        // but not same as on PromotionPickerScreen (which e.g. tries to respect prerequisite proximity)
+        val promotions = unit.promotions.getPromotions(true)
+        val showPromoteStar = unit.promotions.canBePromoted()
+
+        if (promotions.any()) {
+            val iconCount = promotions.count() + (if (showPromoteStar) 1 else 0)
+            val numberOfLines = (iconCount - 1) / 8 + 1  // Int math: -1,/,+1 means divide rounding *up*
+            val promotionsPerLine = (iconCount - 1) / numberOfLines + 1
+            for (linePromotions in promotions.chunked(promotionsPerLine)) {
+                for (promotion in linePromotions) {
+                    add(ImageGetter.getPromotionPortrait(promotion.name))
+                }
+                if (linePromotions.size == promotionsPerLine) row()
+            }
+        }
+
+        if (!showPromoteStar) return
+        add(
+            ImageGetter.getImage("OtherIcons/Star").apply {
+                color = if (GUI.isAllowedChangeState() && unit.currentMovement > 0f && unit.attacksThisTurn == 0)
+                    Color.GOLDENROD
+                else Color.GOLDENROD.darken(0.25f)
+            }
+        ).size(24f).padLeft(8f)
+    }
+}

--- a/core/src/com/unciv/ui/screens/overviewscreen/UnitOverviewTab.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/UnitOverviewTab.kt
@@ -1,44 +1,20 @@
 package com.unciv.ui.screens.overviewscreen
 
-import com.badlogic.gdx.graphics.Color
-import com.badlogic.gdx.math.Vector2
 import com.badlogic.gdx.scenes.scene2d.Action
 import com.badlogic.gdx.scenes.scene2d.Actor
-import com.badlogic.gdx.scenes.scene2d.Group
 import com.badlogic.gdx.scenes.scene2d.actions.Actions
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.utils.Align
-import com.unciv.Constants
-import com.unciv.GUI
 import com.unciv.logic.civilization.Civilization
 import com.unciv.logic.map.mapunit.MapUnit
-import com.unciv.logic.map.tile.Tile
-import com.unciv.models.UnitActionType
-import com.unciv.models.UpgradeUnitAction
 import com.unciv.models.ruleset.unit.BaseUnit
-import com.unciv.ui.components.ExpanderTab
-import com.unciv.ui.components.Fonts
+import com.unciv.ui.components.SortableGrid
 import com.unciv.ui.components.TabbedPager
-import com.unciv.ui.components.UnitGroup
-import com.unciv.ui.components.extensions.addSeparator
-import com.unciv.ui.components.extensions.brighten
-import com.unciv.ui.components.extensions.center
-import com.unciv.ui.components.extensions.darken
 import com.unciv.ui.components.extensions.equalizeColumns
-import com.unciv.ui.components.extensions.surroundWithCircle
-import com.unciv.ui.components.extensions.toLabel
 import com.unciv.ui.components.extensions.toPrettyString
-import com.unciv.ui.components.input.onClick
 import com.unciv.ui.images.IconTextButton
-import com.unciv.ui.images.ImageGetter
-import com.unciv.ui.popups.UnitUpgradeMenu
-import com.unciv.ui.screens.basescreen.BaseScreen
-import com.unciv.ui.screens.pickerscreens.PromotionPickerScreen
-import com.unciv.ui.screens.pickerscreens.UnitRenamePopup
-import com.unciv.ui.screens.worldscreen.unit.actions.UnitActionsUpgrade
-import kotlin.math.abs
+import com.unciv.ui.screens.overviewscreen.UnitSupplyTable.getUnitSupplyTable
 
-//TODO use SortableGrid
 /**
  * Supplies the Unit sub-table for the Empire Overview
  */
@@ -48,9 +24,11 @@ class UnitOverviewTab(
     persistedData: EmpireOverviewTabPersistableData? = null
 ) : EmpireOverviewTab(viewingPlayer, overviewScreen) {
     class UnitTabPersistableData(
-        var scrollY: Float? = null
-    ) : EmpireOverviewTabPersistableData() {
-        override fun isEmpty() = scrollY == null
+        var scrollY: Float? = null,
+        override var sortedBy: UnitOverviewTabColumn = UnitOverviewTabColumn.Name
+    ) : EmpireOverviewTabPersistableData(), SortableGrid.ISortState<UnitOverviewTabColumn> {
+        override fun isEmpty() = scrollY == null && sortedBy == UnitOverviewTabColumn.Name
+        override var direction = SortableGrid.SortDirection.None
     }
     override val persistableData = (persistedData as? UnitTabPersistableData) ?: UnitTabPersistableData()
 
@@ -64,9 +42,6 @@ class UnitOverviewTab(
         removeBlinkAction()
     }
 
-    private val supplyTableWidth = (overviewScreen.stage.width * 0.25f).coerceAtLeast(240f)
-    private val unitListTable = Table() // could be `this` instead, extra nesting helps readability a little
-    private val unitHeaderTable = Table()
     private val fixedContent = Table()
 
     // used for select()
@@ -81,251 +56,54 @@ class UnitOverviewTab(
 
     override fun getFixedContent() = fixedContent
 
+    private val grid = SortableGrid(
+        columns = UnitOverviewTabColumn.values().asIterable(),
+        data = viewingPlayer.units.getCivUnits().asIterable(),
+        actionContext = this,
+        sortState = persistableData,
+        iconSize = 25f
+    ) { header, details, totals ->
+        equalizeColumns(details, header, totals)
+        this.layout()
+    }
+
     init {
-        fixedContent.add(getUnitSupplyTable()).align(Align.top).padBottom(10f).row()
-        fixedContent.add(unitHeaderTable.updateUnitHeaderTable())
+        fixedContent.add(getUnitSupplyTable(this)).align(Align.top).padBottom(10f).row()
+        //fixedContent.add(grid.getHeader())
         top()
-        add(unitListTable.updateUnitListTable())
-        equalizeColumns(unitListTable, unitHeaderTable)
-    }
-
-    // Here overloads are simpler than a generic:
-    private fun Table.addLabeledValue (label: String, value: Int) {
-        add(label.toLabel()).left()
-        add(value.toLabel()).right().row()
-    }
-    private fun Table.addLabeledValue (label: String, value: String) {
-        add(label.toLabel()).left()
-        add(value.toLabel()).right().row()
-    }
-
-    private fun showWorldScreenAt(position: Vector2, unit: MapUnit?) {
-        GUI.resetToWorldScreen()
-        GUI.getMap().setCenterPosition(position, forceSelectUnit = unit)
-    }
-    private fun showWorldScreenAt(unit: MapUnit) = showWorldScreenAt(unit.currentTile.position, unit)
-    private fun showWorldScreenAt(tile: Tile) = showWorldScreenAt(tile.position, null)
-
-    private fun getUnitSupplyTable(): ExpanderTab {
-        val stats = viewingPlayer.stats
-        val deficit = stats.getUnitSupplyDeficit()
-        val icon = if (deficit <= 0) null else Group().apply {
-            isTransform = false
-            setSize(36f, 36f)
-            val image = ImageGetter.getImage("OtherIcons/ExclamationMark")
-            image.color = Color.FIREBRICK
-            image.setSize(36f, 36f)
-            image.center(this)
-            image.setOrigin(Align.center)
-            addActor(image)
-        }
-        return ExpanderTab(
-            title = "Unit Supply",
-            fontSize = Constants.defaultFontSize,
-            icon = icon,
-            startsOutOpened = deficit > 0,
-            defaultPad = 0f,
-            expanderWidth = supplyTableWidth,
-            onChange = {
-                overviewScreen.resizePage(this)
-            }
-        ) {
-            it.defaults().pad(5f).fill(false)
-            it.background = BaseScreen.skinStrings.getUiBackground(
-                "OverviewScreen/UnitOverviewTab/UnitSupplyTable",
-                tintColor = BaseScreen.skinStrings.skinConfig.baseColor.darken(0.6f)
-            )
-            it.addLabeledValue("Base Supply", stats.getBaseUnitSupply())
-            it.addLabeledValue("Cities", stats.getUnitSupplyFromCities())
-            it.addLabeledValue("Population", stats.getUnitSupplyFromPop())
-            it.addSeparator()
-            it.addLabeledValue("Total Supply", stats.getUnitSupply())
-            it.addLabeledValue("In Use", viewingPlayer.units.getCivUnitsSize())
-            it.addSeparator()
-            it.addLabeledValue("Supply Deficit", deficit)
-            it.addLabeledValue("Production Penalty", "${stats.getUnitSupplyProductionPenalty().toInt()}%")
-            if (deficit > 0) {
-                val penaltyLabel = "Increase your supply or reduce the amount of units to remove the production penalty"
-                    .toLabel(Color.FIREBRICK)
-                penaltyLabel.wrap = true
-                it.add(penaltyLabel).colspan(2).left()
-                    .width(supplyTableWidth).row()
-            }
-        }
-    }
-
-    private fun Table.updateUnitHeaderTable(): Table {
-        defaults().pad(5f)
-        add("Name".toLabel())
-        add()  // Column: edit-name
-        add("Action".toLabel())
-        add(Fonts.strength.toString().toLabel())
-        add(Fonts.rangedStrength.toString().toLabel())
-        add(Fonts.movement.toString().toLabel())
-        add("Closest city".toLabel())
-        add("Promotions".toLabel())
-        add("Upgrade".toLabel())
-        add("Health".toLabel())
-        addSeparator().padBottom(0f)
-        return this
-    }
-
-    private fun Table.updateUnitListTable(): Table {
-        clear()
-        val game = overviewScreen.game
-        defaults().pad(5f)
-
-        for (unit in viewingPlayer.units.getCivUnits().sortedWith(
-            compareBy({ it.displayName() },
-                { !it.due },
-                { it.currentMovement <= Constants.minimumMovementEpsilon },
-                { abs(it.currentTile.position.x) + abs(it.currentTile.position.y) })
-        )) {
-            val baseUnit = unit.baseUnit()
-
-            // Unit button column - name, health, fortified, sleeping, embarked are visible here
-            val button = IconTextButton(
-                    unit.displayName(),
-                    UnitGroup(unit, 20f).apply { if (!unit.isIdle()) color.a = 0.5f },
-                    fontColor = if (unit.isIdle()) Color.WHITE else Color.LIGHT_GRAY
-                )
-            button.name = getUnitIdentifier(unit)  // Marker to find a unit in select()
-            button.onClick {
-                showWorldScreenAt(unit)
-            }
-            add(button).fillX()
-
-            // Column: edit-name
-            val editIcon = ImageGetter.getImage("OtherIcons/Pencil").apply { this.color = Color.WHITE }.surroundWithCircle(30f, true, Color.valueOf("000c31"))
-            editIcon.onClick {
-                UnitRenamePopup(
-                    screen = overviewScreen,
-                    unit = unit,
-                    actionOnClose = {
-                        overviewScreen.game.replaceCurrentScreen(
-                            EmpireOverviewScreen(viewingPlayer, selection = getUnitIdentifier(unit))
-                        )
-                    })
-            }
-            add(editIcon)
-
-            // Column: action
-            fun getWorkerActionText(unit: MapUnit): String? = when {
-                // See UnitTurnManager.endTurn, if..workOnImprovement or UnitGroup.getActionImage: similar logic
-                !unit.cache.hasUniqueToBuildImprovements -> null
-                unit.currentMovement == 0f -> null
-                unit.currentTile.improvementInProgress == null -> null
-                !unit.canBuildImprovement(unit.getTile().getTileImprovementInProgress()!!) -> null
-                else -> unit.currentTile.improvementInProgress
-            }
-            fun getActionText(unit: MapUnit): String? {
-                val workerText by lazy { getWorkerActionText(unit) }
-                return when {
-                    unit.action == null -> workerText
-                    unit.isFortified() -> UnitActionType.Fortify.value
-                    unit.isMoving() -> "Moving"
-                    unit.isAutomated() && workerText != null -> "[$workerText] ${Fonts.automate}"
-                    else -> unit.action
-                }
-            }
-            add(getActionText(unit)?.toLabel())
-
-            // Columns: strength, ranged
-            if (baseUnit.strength > 0) add(baseUnit.strength.toLabel()) else add()
-            if (baseUnit.rangedStrength > 0) add(baseUnit.rangedStrength.toLabel()) else add()
-            add(unit.getMovementString().toLabel())
-
-            // Closest city column
-            val closestCity =
-                unit.getTile().getTilesInDistance(3).firstOrNull { it.isCityCenter() }
-            val cityColor = if (unit.getTile() == closestCity) Color.FOREST.brighten(0.5f) else Color.WHITE
-            if (closestCity != null)
-                add(closestCity.getCity()!!.name.toLabel(cityColor).apply {
-                    onClick { showWorldScreenAt(closestCity) }
-                })
-            else add()
-
-            // Promotions column
-            val promotionsTable = Table()
-            updatePromotionsTable(promotionsTable, unit)
-            promotionsTable.onClick {
-                if (unit.promotions.canBePromoted() || unit.promotions.promotions.isNotEmpty()) {
-                    game.pushScreen(PromotionPickerScreen(unit) {
-                        updatePromotionsTable(promotionsTable, unit)
-                    })
-                }
-            }
-            add(promotionsTable)
-
-            // Upgrade column
-            val unitAction = UnitActionsUpgrade.getUpgradeActionAnywhere(unit)
-            if (unitAction != null) {
-                val enable = unitAction.action != null && viewingPlayer.isCurrentPlayer() &&
-                    GUI.isAllowedChangeState()
-                val unitToUpgradeTo = (unitAction as UpgradeUnitAction).unitToUpgradeTo
-                val selectKey = getUnitIdentifier(unit, unitToUpgradeTo)
-                val upgradeIcon = ImageGetter.getUnitIcon(unitToUpgradeTo.name,
-                    if (enable) Color.GREEN else Color.GREEN.darken(0.5f))
-                if (enable) upgradeIcon.onClick {
-                    UnitUpgradeMenu(overviewScreen.stage, upgradeIcon, unit, unitAction) {
-                        unitListTable.updateUnitListTable()
-                        select(selectKey)
-                    }
-                }
-                add(upgradeIcon).size(28f)
-            } else add()
-
-            // Numeric health column - there's already a health bar on the button, but...?
-            if (unit.health < 100) add(unit.health.toLabel()) else add()
-            row()
-        }
-        return this
-    }
-
-    private fun updatePromotionsTable(table: Table, unit: MapUnit) {
-        table.clearChildren()
-
-        // getPromotions goes by json order on demand - so this is the same sorting as on UnitTable,
-        // but not same as on PromotionPickerScreen (which e.g. tries to respect prerequisite proximity)
-        val promotions = unit.promotions.getPromotions(true)
-        val showPromoteStar = unit.promotions.canBePromoted()
-        if (promotions.any()) {
-            val iconCount = promotions.count() + (if (showPromoteStar) 1 else 0)
-            val numberOfLines = (iconCount - 1) / 8 + 1  // Int math: -1,/,+1 means divide rounding *up*
-            val promotionsPerLine = (iconCount - 1) / numberOfLines + 1
-            for (linePromotions in promotions.chunked(promotionsPerLine)) {
-                for (promotion in linePromotions) {
-                    table.add(ImageGetter.getPromotionPortrait(promotion.name))
-                }
-                if (linePromotions.size == promotionsPerLine) table.row()
-            }
-        }
-
-        if (!showPromoteStar) return
-        table.add(
-            ImageGetter.getImage("OtherIcons/Star").apply {
-                color = if (GUI.isAllowedChangeState() && unit.currentMovement > 0f && unit.attacksThisTurn == 0)
-                    Color.GOLDENROD
-                else Color.GOLDENROD.darken(0.25f)
-            }
-        ).size(24f).padLeft(8f)
+        add(grid)
     }
 
     companion object {
+        /** Constructs an ID that allows recognizing a specific MapUnit without resorting to instance identity.
+         *
+         *  This allows for changes affecting the unit that choose to implement via re-creation,
+         *  or recognizing an upgrade via the [unitToUpgradeTo] parameter.
+         *  It uses name (ignoring user renames) and tile position, and therefore it is not valid across
+         *  any user interaction involving movement or next-turn - internal UnitOverview use is fine.
+         *
+         *  * Example: `Bomber@(2,9).a3` means the Bomber unit in the (2,9) tile, 4th air unit slot
+         */
         fun getUnitIdentifier(unit: MapUnit, unitToUpgradeTo: BaseUnit? = null): String {
             val name = unitToUpgradeTo?.name ?: unit.name
-            return "$name@${unit.getTile().position.toPrettyString()}"
+            val tile = unit.getTile()
+            val posInTile = when (unit) {
+                tile.militaryUnit -> "m"
+                tile.civilianUnit -> "c"
+                else -> "a${tile.airUnits.indexOf(unit)}"
+            }
+            return "$name@${tile.position.toPrettyString()}.$posInTile"
         }
     }
 
     override fun select(selection: String): Float? {
-        val cell = unitListTable.cells.asSequence()
+        val cell = grid.cells.asSequence()
                 .filter { it.actor is IconTextButton && it.actor.name == selection }
                 .firstOrNull() ?: return null
         val button = cell.actor as IconTextButton
         val scrollY = (0 until cell.row)
-            .map { unitListTable.getRowHeight(it) }.sum() -
-                (parent.height - unitListTable.getRowHeight(cell.row)) / 2
+            .map { grid.getRowHeight(it) }.sum() -
+                (parent.height - grid.getRowHeight(cell.row)) / 2
 
         removeBlinkAction()
         blinkAction = Actions.repeat(3, Actions.sequence(
@@ -337,4 +115,8 @@ class UnitOverviewTab(
         return scrollY
     }
 
+    internal fun updateAndSelect(selection: String) {
+        grid.updateDetails()
+        select(selection)
+    }
 }

--- a/core/src/com/unciv/ui/screens/overviewscreen/UnitOverviewTabColumn.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/UnitOverviewTabColumn.kt
@@ -1,0 +1,196 @@
+package com.unciv.ui.screens.overviewscreen
+
+import com.badlogic.gdx.graphics.Color
+import com.badlogic.gdx.math.Vector2
+import com.badlogic.gdx.scenes.scene2d.Actor
+import com.badlogic.gdx.utils.Align
+import com.unciv.Constants
+import com.unciv.GUI
+import com.unciv.UncivGame
+import com.unciv.logic.map.mapunit.MapUnit
+import com.unciv.logic.map.tile.Tile
+import com.unciv.models.UnitActionType
+import com.unciv.models.UpgradeUnitAction
+import com.unciv.models.translations.tr
+import com.unciv.ui.components.Fonts
+import com.unciv.ui.components.ISortableGridContentProvider
+import com.unciv.ui.components.UnitGroup
+import com.unciv.ui.components.extensions.brighten
+import com.unciv.ui.components.extensions.darken
+import com.unciv.ui.components.extensions.surroundWithCircle
+import com.unciv.ui.components.extensions.toLabel
+import com.unciv.ui.components.input.onClick
+import com.unciv.ui.images.IconTextButton
+import com.unciv.ui.images.ImageGetter
+import com.unciv.ui.popups.UnitUpgradeMenu
+import com.unciv.ui.screens.pickerscreens.UnitRenamePopup
+import com.unciv.ui.screens.worldscreen.unit.actions.UnitActionsUpgrade
+import kotlin.math.abs
+
+//todo Grid Framework does not respect header actor widths well
+//todo Grid Framework has header-body column alignment issues when separateHeader is on
+//todo Grid Framework has header-body column alignment issues when separateHeader is off, too!
+//todo Grid Framework use of iconSize feels off here
+//todo Grid Framework could learn string cells, and cache them for faster sort
+
+/**
+ * This defines all behaviour of the [UnitOverviewTab] columns
+ */
+enum class UnitOverviewTabColumn : ISortableGridContentProvider<MapUnit, UnitOverviewTab> {
+    //region Enum Instances
+    Name {
+        // Unit button column - name, health, fortified, sleeping, embarked are visible here
+        override val fillX = true
+        override fun getEntryActor(item: MapUnit, iconSize: Float, actionContext: UnitOverviewTab) =
+            IconTextButton(
+                item.displayName(),
+                UnitGroup(item, 20f).apply { if (!item.isIdle()) color.a = 0.5f },
+                fontColor = if (item.isIdle()) Color.WHITE else Color.LIGHT_GRAY
+            ).apply {
+                name = UnitOverviewTab.getUnitIdentifier(item)
+                onClick { showWorldScreenAt(item) }
+            }
+        override fun getComparator() =
+            compareBy<MapUnit, String>(collator) { it.displayName().tr(hideIcons = true) }
+            .thenByDescending { it.due }
+            .thenBy { it.currentMovement <= Constants.minimumMovementEpsilon }
+            .thenBy { abs(it.currentTile.position.x) + abs(it.currentTile.position.y) }
+    },
+
+    EditName {
+        override val headerTip = "Edit name"
+        override fun getEntryActor(item: MapUnit, iconSize: Float, actionContext: UnitOverviewTab) =
+            ImageGetter.getImage("OtherIcons/Pencil")
+                .apply { this.color = Color.WHITE }
+                .surroundWithCircle(30f, true, Color.valueOf("000c31"))
+                .onClick { UnitRenamePopup(actionContext.overviewScreen, item) {
+                    actionContext.updateAndSelect(UnitOverviewTab.getUnitIdentifier(item))
+                }}
+        override fun getComparator() =
+            compareBy<MapUnit, String>(collator) { it.instanceName.orEmpty() }
+                .thenBy(collator) { it.name.tr(hideIcons = true) }
+    },
+
+    Action {
+        private fun getWorkerActionText(unit: MapUnit): String? = when {
+            // See UnitTurnManager.endTurn, if..workOnImprovement or UnitGroup.getActionImage: similar logic
+            !unit.cache.hasUniqueToBuildImprovements -> null
+            unit.currentMovement == 0f -> null
+            unit.currentTile.improvementInProgress == null -> null
+            !unit.canBuildImprovement(unit.getTile().getTileImprovementInProgress()!!) -> null
+            else -> unit.currentTile.improvementInProgress
+        }
+        private fun getActionText(unit: MapUnit): String? {
+            val workerText by lazy { getWorkerActionText(unit) }
+            return when {
+                unit.action == null -> workerText
+                unit.isFortified() -> UnitActionType.Fortify.value
+                unit.isMoving() -> "Moving"
+                unit.isAutomated() && workerText != null -> "[$workerText] ${Fonts.automate}"
+                else -> unit.action
+            }
+        }
+        override fun getEntryActor(item: MapUnit, iconSize: Float, actionContext: UnitOverviewTab) =
+            getActionText(item)?.toLabel()
+        override fun getComparator() =
+            compareBy<MapUnit, String>(collator) { getActionText(it).orEmpty() }
+    },
+
+    Strength {
+        override fun getHeaderIcon(iconSize: Float) = Fonts.strength.toString().toLabel()
+        override fun getEntryValue(item: MapUnit) = item.baseUnit.strength
+    },
+
+    RangedStrength {
+        override val headerTip = "Ranged strength"
+        override fun getHeaderIcon(iconSize: Float) = Fonts.rangedStrength.toString().toLabel()
+        override fun getEntryValue(item: MapUnit) = item.baseUnit.rangedStrength
+    },
+
+    Movement {
+        override fun getHeaderIcon(iconSize: Float) = Fonts.movement.toString().toLabel()
+        override fun getEntryActor(item: MapUnit, iconSize: Float, actionContext: UnitOverviewTab) =
+            item.getMovementString().toLabel()
+        override fun getComparator() = compareBy<MapUnit> { it.getMaxMovement() }
+            .thenBy { it.currentMovement }
+    },
+
+    ClosestCity {
+        override val headerTip = "Closest city"
+        private fun getClosestCity(unit: MapUnit) =
+            unit.getTile().getTilesInDistance(3).firstOrNull { it.isCityCenter() }
+        override fun getEntryActor(item: MapUnit, iconSize: Float, actionContext: UnitOverviewTab): Actor? {
+            val cityTile = getClosestCity(item) ?: return null
+            val cityColor = if (item.getTile() == cityTile) Color.FOREST.brighten(0.5f) else Color.WHITE
+            return cityTile.getCity()!!.name
+                .toLabel(cityColor, hideIcons = true)
+                .onClick { showWorldScreenAt(cityTile) }
+        }
+        override fun getComparator() = compareBy<MapUnit, String>(collator) {
+            getClosestCity(it)?.getCity()?.name?.tr(hideIcons = true).orEmpty()
+        }
+    },
+
+    Promotions {
+        override val defaultDescending = true
+        override fun getEntryValue(item: MapUnit) = item.promotions.totalXpProduced()
+        override fun getEntryActor(item: MapUnit, iconSize: Float, actionContext: UnitOverviewTab) =
+            UnitOverviewPromotionTable(item, actionContext)
+    },
+
+    Upgrade {
+        override fun getEntryActor(item: MapUnit, iconSize: Float, actionContext: UnitOverviewTab): Actor? {
+            val unitAction = UnitActionsUpgrade.getUpgradeActionAnywhere(item)
+                ?: return null
+            val enable = unitAction.action != null && actionContext.viewingPlayer.isCurrentPlayer() &&
+                GUI.isAllowedChangeState()
+            val unitToUpgradeTo = (unitAction as UpgradeUnitAction).unitToUpgradeTo
+            val selectKey = UnitOverviewTab.getUnitIdentifier(item, unitToUpgradeTo)
+            val upgradeIcon = ImageGetter.getUnitIcon(unitToUpgradeTo.name,
+                if (enable) Color.GREEN else Color.GREEN.darken(0.5f))
+            if (enable) upgradeIcon.onClick {
+                UnitUpgradeMenu(actionContext.stage, upgradeIcon, item, unitAction) {
+                    actionContext.updateAndSelect(selectKey)
+                }
+            }
+            return upgradeIcon
+        }
+    },
+
+    Health {
+        //override fun isVisible(gameInfo: GameInfo): Boolean = false
+        override fun getEntryValue(item: MapUnit) = item.health
+        override fun getEntryActor(item: MapUnit, iconSize: Float, actionContext: UnitOverviewTab): Actor? =
+            item.health.takeIf { it < 100 }?.toLabel()
+    }
+    ;
+    //endregion
+
+    //region Overridable fields
+    override val headerTip get() = name
+    override val align = Align.center
+    override val fillX = false
+    override val expandX = false
+    override val equalizeHeight = false
+    override val defaultDescending = false
+    //endregion
+
+    //region Overridable methods
+    override fun getHeaderIcon(iconSize: Float) = headerTip.toLabel()
+    override fun getEntryValue(item: MapUnit) = 0
+    override fun getEntryActor(item: MapUnit, iconSize: Float, actionContext: UnitOverviewTab): Actor? =
+        getEntryValue(item).takeIf { it > 0 }?.toLabel()
+    override fun getTotalsActor(items: Iterable<MapUnit>): Actor? = null
+    //endregion
+
+    companion object {
+        private val collator = UncivGame.Current.settings.getCollatorFromLocale()
+
+        private fun showWorldScreenAt(position: Vector2, unit: MapUnit?) {
+            GUI.resetToWorldScreen()
+            GUI.getMap().setCenterPosition(position, forceSelectUnit = unit)
+        }
+        private fun showWorldScreenAt(unit: MapUnit) = showWorldScreenAt(unit.currentTile.position, unit)
+        private fun showWorldScreenAt(tile: Tile) = showWorldScreenAt(tile.position, null)
+    }
+}

--- a/core/src/com/unciv/ui/screens/overviewscreen/UnitSupplyTable.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/UnitSupplyTable.kt
@@ -1,0 +1,78 @@
+package com.unciv.ui.screens.overviewscreen
+
+import com.badlogic.gdx.graphics.Color
+import com.badlogic.gdx.scenes.scene2d.Group
+import com.badlogic.gdx.scenes.scene2d.ui.Table
+import com.unciv.Constants
+import com.unciv.ui.components.ExpanderTab
+import com.unciv.ui.components.extensions.addSeparator
+import com.unciv.ui.components.extensions.center
+import com.unciv.ui.components.extensions.darken
+import com.unciv.ui.components.extensions.toLabel
+import com.unciv.ui.images.ImageGetter
+import com.unciv.ui.screens.basescreen.BaseScreen
+
+/** A factory to create the "Unit Supply Breakdown" ExpanderTab */
+object UnitSupplyTable {
+    internal fun getUnitSupplyTable(parent: UnitOverviewTab): ExpanderTab {
+        val overviewScreen = parent.overviewScreen
+        val viewingPlayer = parent.viewingPlayer
+        val stats = viewingPlayer.stats
+        val supplyTableWidth = (overviewScreen.stage.width * 0.25f).coerceAtLeast(240f)
+
+        val deficit = stats.getUnitSupplyDeficit()
+        val icon = if (deficit <= 0) null else Group().apply {
+            isTransform = false
+            setSize(36f, 36f)
+            val image = ImageGetter.getImage("OtherIcons/ExclamationMark")
+            image.color = Color.FIREBRICK
+            image.setSize(36f, 36f)
+            image.center(this)
+            addActor(image)
+        }
+
+        return ExpanderTab(
+            title = "Unit Supply",
+            fontSize = Constants.defaultFontSize,
+            icon = icon,
+            startsOutOpened = deficit > 0,
+            defaultPad = 0f,
+            expanderWidth = supplyTableWidth,
+            onChange = {
+                overviewScreen.resizePage(parent)
+            }
+        ) {
+            it.defaults().pad(5f).fill(false)
+            it.background = BaseScreen.skinStrings.getUiBackground(
+                "OverviewScreen/UnitOverviewTab/UnitSupplyTable",
+                tintColor = BaseScreen.skinStrings.skinConfig.baseColor.darken(0.6f)
+            )
+            it.addLabeledValue("Base Supply", stats.getBaseUnitSupply())
+            it.addLabeledValue("Cities", stats.getUnitSupplyFromCities())
+            it.addLabeledValue("Population", stats.getUnitSupplyFromPop())
+            it.addSeparator()
+            it.addLabeledValue("Total Supply", stats.getUnitSupply())
+            it.addLabeledValue("In Use", viewingPlayer.units.getCivUnitsSize())
+            it.addSeparator()
+            it.addLabeledValue("Supply Deficit", deficit)
+            it.addLabeledValue("Production Penalty", "${stats.getUnitSupplyProductionPenalty().toInt()}%")
+            if (deficit > 0) {
+                val penaltyLabel = "Increase your supply or reduce the amount of units to remove the production penalty"
+                    .toLabel(Color.FIREBRICK)
+                penaltyLabel.wrap = true
+                it.add(penaltyLabel).colspan(2).left()
+                    .width(supplyTableWidth).row()
+            }
+        }
+    }
+
+    // Here overloads are simpler than a generic:
+    private fun Table.addLabeledValue (label: String, value: Int) {
+        add(label.toLabel()).left()
+        add(value.toLabel()).right().row()
+    }
+    private fun Table.addLabeledValue (label: String, value: String) {
+        add(label.toLabel()).left()
+        add(value.toLabel()).right().row()
+    }
+}


### PR DESCRIPTION
In case someone wants to review, comment or ridicule...

The now SortableGrid-based City overview has a few -to me- surprising geometry quirks I'll try to iron out while working on this. The way I remember it wasn't that bad when I originally developed it, so I must assume merge mistakes and a simple, but maybe hard to see, solution.

This so far is just a refactoring of the existing UnitOverviewTab to the Grid framework, which auto-enables resorting by header click. Opens interesting possibilities. Would be almost release-ready if I were to replace all header cells with icons. And with the exception of that ugly header, it worked on the first run. Noice. I just never tested SortableGrid with headers wider than content...