### PR TITLE
Buildings json schema

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -7,7 +7,6 @@
     <inspection_tool class="JsonPathEvaluateUnknownKey" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="JsonPathUnknownFunction" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="JsonPathUnknownOperator" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="JsonSchemaCompliance" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="JsonSchemaDeprecation" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
     <inspection_tool class="JsonSchemaRefReference" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="JsonStandardCompliance" enabled="false" level="ERROR" enabled_by_default="false" />

--- a/android/assets/jsons/Civ V - Gods & Kings/Buildings.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Buildings.json
@@ -15,12 +15,16 @@
 	},
 	{
 		"name": "Monument",
+        "fds": 2,
 		"culture": 2,
 		"cost": 40,
 		"hurryCostModifier": 40,
 		"maintenance": 1,
 		"uniques": ["Destroyed when the city is captured"]
 	},
+    {
+
+    },
 	{
 		"name": "Stele",
 		"replaces": "Monument",

--- a/android/assets/jsons/Civ V - Gods & Kings/Buildings.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Buildings.json
@@ -22,9 +22,6 @@
 		"maintenance": 1,
 		"uniques": ["Destroyed when the city is captured"]
 	},
-    {
-
-    },
 	{
 		"name": "Stele",
 		"replaces": "Monument",

--- a/android/assets/jsons/Civ V - Gods & Kings/Buildings.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Buildings.json
@@ -15,7 +15,6 @@
 	},
 	{
 		"name": "Monument",
-        "fds": 2,
 		"culture": 2,
 		"cost": 40,
 		"hurryCostModifier": 40,

--- a/android/assets/jsons/Civ V - Vanilla/Buildings.json
+++ b/android/assets/jsons/Civ V - Vanilla/Buildings.json
@@ -57,6 +57,7 @@
 	{
 		"name": "Stone Works",
 		"happiness": 1,
+        "fds": 1,
 		"production": 1,
 		"requiredNearbyImprovedResources": ["Marble", "Stone"],
 		"maintenance": 1,
@@ -64,7 +65,12 @@
 		"uniques": ["Must not be on [Plains]",
 			"[+1 Production] from [Stone] tiles [in this city]",
 			"[+1 Production] from [Marble] tiles [in this city]"],
-		"requiredTech": "Calendar"
+		"requiredTech": "Calendar",
+        "civilopediaText": [
+            {
+
+            }
+        ]
 	},
 	{
 		"name": "Stonehenge",

--- a/android/assets/jsons/Civ V - Vanilla/Buildings.json
+++ b/android/assets/jsons/Civ V - Vanilla/Buildings.json
@@ -13,9 +13,6 @@
 		"cost": 1,
 		"uniques": ["Indicates the capital city"]
 	},
-    {
-        ""
-    },
 	{
 		"name": "Monument",
 		"culture": 2,

--- a/android/assets/jsons/Civ V - Vanilla/Buildings.json
+++ b/android/assets/jsons/Civ V - Vanilla/Buildings.json
@@ -65,12 +65,7 @@
 		"uniques": ["Must not be on [Plains]",
 			"[+1 Production] from [Stone] tiles [in this city]",
 			"[+1 Production] from [Marble] tiles [in this city]"],
-		"requiredTech": "Calendar",
-        "civilopediaText": [
-            {
-
-            }
-        ]
+		"requiredTech": "Calendar"
 	},
 	{
 		"name": "Stonehenge",

--- a/android/assets/jsons/Civ V - Vanilla/Buildings.json
+++ b/android/assets/jsons/Civ V - Vanilla/Buildings.json
@@ -13,6 +13,9 @@
 		"cost": 1,
 		"uniques": ["Indicates the capital city"]
 	},
+    {
+        ""
+    },
 	{
 		"name": "Monument",
 		"culture": 2,

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -135,6 +135,8 @@ project(":core") {
         "implementation"("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion")
         "implementation"("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
 
+        "implementation"("com.github.Ricky12Awesome:json-schema-serialization:0.6.6")
+
         "implementation"("io.ktor:ktor-client-core:$ktorVersion")
         "implementation"("io.ktor:ktor-client-cio:$ktorVersion")
         "implementation"("io.ktor:ktor-client-websockets:$ktorVersion")

--- a/core/src/com/unciv/models/Counter.kt
+++ b/core/src/com/unciv/models/Counter.kt
@@ -2,14 +2,10 @@ package com.unciv.models
 
 import com.unciv.logic.IsPartOfGameInfoSerialization
 
+
+@kotlinx.serialization.Serializable
 open class Counter<K>(
-    fromMap: Map<K, Int>? = null
-) : LinkedHashMap<K, Int>(fromMap?.size ?: 10), IsPartOfGameInfoSerialization {
-    init {
-        if (fromMap != null)
-            for ((key, value) in fromMap)
-                put(key, value)
-    }
+) : LinkedHashMap<K, Int>(), IsPartOfGameInfoSerialization {
 
     override operator fun get(key: K): Int { // don't return null if empty
         return if (containsKey(key))
@@ -27,7 +23,7 @@ open class Counter<K>(
         put(key, get(key) + value)
     }
 
-    fun add(other: Counter<K>) {
+    fun add(other: Map<K, Int>) {
         for ((key, value) in other) add(key, value)
     }
     operator fun plusAssign(other: Counter<K>) = add(other)
@@ -43,7 +39,7 @@ open class Counter<K>(
         return newCounter
     }
 
-    operator fun plus(other: Counter<K>) = clone().apply { add(other) }
+    operator fun plus(other: Map<K, Int>) = clone().apply { add(other) }
 
     fun sumValues() = values.sum()
 

--- a/core/src/com/unciv/models/ruleset/Building.kt
+++ b/core/src/com/unciv/models/ruleset/Building.kt
@@ -24,6 +24,8 @@ import com.unciv.ui.components.extensions.toPercent
 import com.unciv.ui.screens.civilopediascreen.FormattedLine
 
 
+
+@kotlinx.serialization.Serializable
 class Building : RulesetStatsObject(), INonPerpetualConstruction {
 
     override var requiredTech: String? = null
@@ -691,6 +693,7 @@ class Building : RulesetStatsObject(), INonPerpetualConstruction {
     }
     fun hasCreateOneImprovementUnique() = _hasCreatesOneImprovementUnique
 
+    @kotlinx.serialization.Transient
     private var _getImprovementToCreate: TileImprovement? = null
     fun getImprovementToCreate(ruleset: Ruleset): TileImprovement? {
         if (!hasCreateOneImprovementUnique()) return null

--- a/core/src/com/unciv/models/ruleset/RulesetObject.kt
+++ b/core/src/com/unciv/models/ruleset/RulesetObject.kt
@@ -25,6 +25,8 @@ abstract class RulesetObject: IRulesetObject {
 }
 
 // Same, but inherits from NamedStats - I couldn't find a way to unify the declarations but this is fine
+
+@kotlinx.serialization.Serializable
 abstract class RulesetStatsObject: NamedStats(), IRulesetObject {
     override var originRuleset = ""
     override var uniques = ArrayList<String>() // Can not be a hashset as that would remove doubles

--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -181,7 +181,7 @@ class BaseUnit : RulesetObject(), INonPerpetualConstruction {
             yield(RejectionReasonType.MaxNumberBuildable.toInstance())
 
         if (!civ.isBarbarian()) { // Barbarians don't need resources
-            val civResources = Counter(civ.getCivResourcesByName()) + additionalResources
+            val civResources = Counter<String>() + civ.getCivResourcesByName() + additionalResources
             for ((resource, requiredAmount) in getResourceRequirementsPerTurn()) {
                 val availableAmount = civResources[resource]
                 if (availableAmount < requiredAmount) {

--- a/core/src/com/unciv/models/stats/NamedStats.kt
+++ b/core/src/com/unciv/models/stats/NamedStats.kt
@@ -1,7 +1,11 @@
 package com.unciv.models.stats
 
+import kotlinx.serialization.Required
 
+
+@kotlinx.serialization.Serializable
 open class NamedStats : Stats(), INamed {
+    @Required
     override lateinit var name: String
 
     override fun toString(): String {

--- a/core/src/com/unciv/models/stats/Stats.kt
+++ b/core/src/com/unciv/models/stats/Stats.kt
@@ -11,6 +11,8 @@ import kotlin.reflect.KMutableProperty0
  *
  * Also possible: `<Stats>`.[values].sum() and similar aggregates over a Sequence<Float>.
  */
+
+@kotlinx.serialization.Serializable
 open class Stats(
     var production: Float = 0f,
     var food: Float = 0f,

--- a/core/src/com/unciv/ui/popups/options/AdvancedTab.kt
+++ b/core/src/com/unciv/ui/popups/options/AdvancedTab.kt
@@ -13,37 +13,42 @@ import com.badlogic.gdx.scenes.scene2d.ui.Cell
 import com.badlogic.gdx.scenes.scene2d.ui.SelectBox
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.utils.Array
+import com.github.ricky12awesome.jss.encodeToSchema
+import com.github.ricky12awesome.jss.globalJson
 import com.unciv.Constants
 import com.unciv.GUI
 import com.unciv.UncivGame
 import com.unciv.models.metadata.GameSettings
 import com.unciv.models.metadata.ModCategories
 import com.unciv.models.metadata.ScreenSize
+import com.unciv.models.ruleset.Building
 import com.unciv.models.translations.TranslationFileWriter
 import com.unciv.models.translations.tr
-import com.unciv.ui.popups.ConfirmPopup
-import com.unciv.ui.screens.basescreen.BaseScreen
 import com.unciv.ui.components.FontFamilyData
 import com.unciv.ui.components.Fonts
 import com.unciv.ui.components.UncivSlider
 import com.unciv.ui.components.UncivTooltip.Companion.addTooltip
 import com.unciv.ui.components.extensions.disable
-import com.unciv.ui.components.input.keyShortcuts
-import com.unciv.ui.components.input.onActivation
-import com.unciv.ui.components.input.onChange
-import com.unciv.ui.components.input.onClick
 import com.unciv.ui.components.extensions.setFontColor
 import com.unciv.ui.components.extensions.toCheckBox
 import com.unciv.ui.components.extensions.toLabel
 import com.unciv.ui.components.extensions.toTextButton
 import com.unciv.ui.components.extensions.withoutItem
+import com.unciv.ui.components.input.keyShortcuts
+import com.unciv.ui.components.input.onActivation
+import com.unciv.ui.components.input.onChange
+import com.unciv.ui.components.input.onClick
+import com.unciv.ui.popups.ConfirmPopup
+import com.unciv.ui.screens.basescreen.BaseScreen
+import com.unciv.utils.Concurrency
 import com.unciv.utils.Display
 import com.unciv.utils.ScreenOrientation
-import com.unciv.utils.Concurrency
 import com.unciv.utils.launchOnGLThread
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.builtins.ListSerializer
+import java.io.File
 import java.util.UUID
 import java.util.zip.Deflater
 
@@ -240,6 +245,19 @@ private fun addTranslationGeneration(table: Table, optionsPopup: OptionsPopup) {
         generateTranslationsButton.setText(Constants.working.tr())
         Concurrency.run("WriteTranslations") {
             val result = TranslationFileWriter.writeNewTranslationFiles()
+
+            fun getBuildingsJsonSchema() = globalJson.encodeToSchema(ListSerializer(Building.serializer()), generateDefinitions = false)
+
+            fun compileJsonSchema(){
+
+                val schemaLocation = "../../docs/modding/schemas"
+                File(schemaLocation).mkdirs()
+
+                val schemaString = getBuildingsJsonSchema()
+                File(schemaLocation + File.separator + "buildings.json").writeText(schemaString)
+            }
+            compileJsonSchema()
+
             launchOnGLThread {
                 // notify about completion
                 generateTranslationsButton.setText(result.tr())

--- a/core/src/com/unciv/ui/screens/civilopediascreen/FormattedLine.kt
+++ b/core/src/com/unciv/ui/screens/civilopediascreen/FormattedLine.kt
@@ -38,6 +38,8 @@ import kotlin.math.max
  *  - A separator line ([separator])
  *  - Automatic external links ([link] begins with a URL protocol)
  */
+
+@kotlinx.serialization.Serializable
 class FormattedLine (
     /** Text to display. */
     val text: String = "",

--- a/docs/modding/schemas/buildings.json
+++ b/docs/modding/schemas/buildings.json
@@ -1,0 +1,126 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "requiredTech": {
+        "if": {
+          "type": "string"
+        },
+        "else": {
+          "type": "null"
+        }
+      },
+      "cost": {
+        "type": "number"
+      },
+      "maintenance": {
+        "type": "number"
+      },
+      "percentStatBonus": {
+        "if": {
+          "type": "object"
+        },
+        "else": {
+          "type": "null"
+        },
+        "properties": {
+          "production": {
+            "type": "number"
+          },
+          "food": {
+            "type": "number"
+          },
+          "gold": {
+            "type": "number"
+          },
+          "science": {
+            "type": "number"
+          },
+          "culture": {
+            "type": "number"
+          },
+          "happiness": {
+            "type": "number"
+          },
+          "faith": {
+            "type": "number"
+          }
+        }
+      },
+      "specialistSlots": {
+        "type": "object"
+      },
+      "greatPersonPoints": {
+        "type": "object"
+      },
+      "hurryCostModifier": {
+        "type": "number"
+      },
+      "isWonder": {
+        "type": "boolean"
+      },
+      "isNationalWonder": {
+        "type": "boolean"
+      },
+      "requiredBuilding": {
+        "if": {
+          "type": "string"
+        },
+        "else": {
+          "type": "null"
+        }
+      },
+      "requiredResource": {
+        "if": {
+          "type": "string"
+        },
+        "else": {
+          "type": "null"
+        }
+      },
+      "requiredNearbyImprovedResources": {
+        "if": {
+          "type": "array"
+        },
+        "else": {
+          "type": "null"
+        },
+        "items": {
+          "type": "string"
+        }
+      },
+      "cityStrength": {
+        "type": "number"
+      },
+      "cityHealth": {
+        "type": "number"
+      },
+      "replaces": {
+        "if": {
+          "type": "string"
+        },
+        "else": {
+          "type": "null"
+        }
+      },
+      "uniqueTo": {
+        "if": {
+          "type": "string"
+        },
+        "else": {
+          "type": "null"
+        }
+      },
+      "quote": {
+        "type": "string"
+      },
+      "replacementTextForUniques": {
+        "type": "string"
+      }
+    }
+  },
+  "definitions": {
+  }
+}

--- a/docs/modding/schemas/buildings.json
+++ b/docs/modding/schemas/buildings.json
@@ -4,209 +4,72 @@
   "items": {
     "type": "object",
     "properties": {
-      "production": {
-        "type": "number"
-      },
-      "food": {
-        "type": "number"
-      },
-      "gold": {
-        "type": "number"
-      },
-      "science": {
-        "type": "number"
-      },
-      "culture": {
-        "type": "number"
-      },
-      "happiness": {
-        "type": "number"
-      },
-      "faith": {
-        "type": "number"
-      },
-      "name": {
-        "type": "string"
-      },
-      "originRuleset": {
-        "type": "string"
-      },
+      "name": { "type": "string" },
       "uniques": {
         "type": "array",
-        "items": {
-          "type": "string"
-        }
+        "items": { "type": "string" }
       },
       "civilopediaText": {
         "type": "array",
-        "items": {
-          "type": "object",
-          "properties": {
-            "text": {
-              "type": "string"
-            },
-            "link": {
-              "type": "string"
-            },
-            "icon": {
-              "type": "string"
-            },
-            "extraImage": {
-              "type": "string"
-            },
-            "imageSize": {
-              "type": "number"
-            },
-            "size": {
-              "type": "number"
-            },
-            "header": {
-              "type": "number"
-            },
-            "indent": {
-              "type": "number"
-            },
-            "padding": {
-              "type": "number"
-            },
-            "color": {
-              "type": "string"
-            },
-            "separator": {
-              "type": "boolean"
-            },
-            "starred": {
-              "type": "boolean"
-            },
-            "centered": {
-              "type": "boolean"
-            },
-            "iconCrossed": {
-              "type": "boolean"
-            }
-          }
-        }
+        "items": { "$ref": "#/definitions/civilopediaText"}
       },
-      "requiredTech": {
-        "if": {
-          "type": "string"
-        },
-        "else": {
-          "type": "null"
-        }
-      },
-      "cost": {
-        "type": "number"
-      },
-      "maintenance": {
-        "type": "number"
-      },
-      "percentStatBonus": {
-        "if": {
-          "type": "object"
-        },
-        "else": {
-          "type": "null"
-        },
-        "properties": {
-          "production": {
-            "type": "number"
-          },
-          "food": {
-            "type": "number"
-          },
-          "gold": {
-            "type": "number"
-          },
-          "science": {
-            "type": "number"
-          },
-          "culture": {
-            "type": "number"
-          },
-          "happiness": {
-            "type": "number"
-          },
-          "faith": {
-            "type": "number"
-          }
-        }
-      },
-      "specialistSlots": {
-        "type": "object"
-      },
-      "greatPersonPoints": {
-        "type": "object"
-      },
-      "hurryCostModifier": {
-        "type": "number"
-      },
-      "isWonder": {
-        "type": "boolean"
-      },
-      "isNationalWonder": {
-        "type": "boolean"
-      },
-      "requiredBuilding": {
-        "if": {
-          "type": "string"
-        },
-        "else": {
-          "type": "null"
-        }
-      },
-      "requiredResource": {
-        "if": {
-          "type": "string"
-        },
-        "else": {
-          "type": "null"
-        }
-      },
+      "requiredTech": { "type": "string" },
+      "cost": { "type": "number" },
+      "maintenance": { "type": "number" },
+      "percentStatBonus": { "$ref": "#/definitions/stats" },
+      "specialistSlots": { "type": "object" },
+      "greatPersonPoints": { "type": "object" },
+      "hurryCostModifier": { "type": "number" },
+      "isWonder": { "type": "boolean" },
+      "isNationalWonder": { "type": "boolean" },
+      "requiredBuilding": { "type": "string" },
+      "requiredResource": { "type": "string" },
       "requiredNearbyImprovedResources": {
-        "if": {
-          "type": "array"
-        },
-        "else": {
-          "type": "null"
-        },
-        "items": {
-          "type": "string"
-        }
+        "type": "array",
+        "items": { "type": "string" }
       },
-      "cityStrength": {
-        "type": "number"
-      },
-      "cityHealth": {
-        "type": "number"
-      },
-      "replaces": {
-        "if": {
-          "type": "string"
-        },
-        "else": {
-          "type": "null"
-        }
-      },
-      "uniqueTo": {
-        "if": {
-          "type": "string"
-        },
-        "else": {
-          "type": "null"
-        }
-      },
-      "quote": {
-        "type": "string"
-      },
-      "replacementTextForUniques": {
-        "type": "string"
-      }
+      "cityStrength": { "type": "number" },
+      "cityHealth": { "type": "number" },
+      "replaces": { "type": "string" },
+      "uniqueTo": { "type": "string" },
+      "quote": { "type": "string" },
+      "replacementTextForUniques": { "type": "string" }
     },
     "required": [
       "name"
     ]
   },
   "definitions": {
+      "stats": {
+          "type": "object",
+          "properties": {
+              "production": { "type": "number" },
+              "food": { "type": "number" },
+              "gold": { "type": "number" },
+              "science": { "type": "number" },
+              "culture": { "type": "number" },
+              "happiness": { "type": "number" },
+              "faith": { "type": "number" }
+          }
+      },
+      "civilopediaText": {
+          "type": "object",
+          "properties": {
+              "text": { "type": "string" },
+              "link": { "type": "string" },
+              "icon": { "type": "string" },
+              "extraImage": { "type": "string" },
+              "imageSize": { "type": "number" },
+              "size": { "type": "number" },
+              "header": { "type": "number" },
+              "indent": { "type": "number" },
+              "padding": { "type": "number" },
+              "color": { "type": "string" },
+              "separator": { "type": "boolean" },
+              "starred": { "type": "boolean" },
+              "centered": { "type": "boolean" },
+              "iconCrossed": { "type": "boolean" }
+          }
+      }
   }
 }

--- a/docs/modding/schemas/buildings.json
+++ b/docs/modding/schemas/buildings.json
@@ -4,6 +4,89 @@
   "items": {
     "type": "object",
     "properties": {
+      "production": {
+        "type": "number"
+      },
+      "food": {
+        "type": "number"
+      },
+      "gold": {
+        "type": "number"
+      },
+      "science": {
+        "type": "number"
+      },
+      "culture": {
+        "type": "number"
+      },
+      "happiness": {
+        "type": "number"
+      },
+      "faith": {
+        "type": "number"
+      },
+      "name": {
+        "type": "string"
+      },
+      "originRuleset": {
+        "type": "string"
+      },
+      "uniques": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "civilopediaText": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "text": {
+              "type": "string"
+            },
+            "link": {
+              "type": "string"
+            },
+            "icon": {
+              "type": "string"
+            },
+            "extraImage": {
+              "type": "string"
+            },
+            "imageSize": {
+              "type": "number"
+            },
+            "size": {
+              "type": "number"
+            },
+            "header": {
+              "type": "number"
+            },
+            "indent": {
+              "type": "number"
+            },
+            "padding": {
+              "type": "number"
+            },
+            "color": {
+              "type": "string"
+            },
+            "separator": {
+              "type": "boolean"
+            },
+            "starred": {
+              "type": "boolean"
+            },
+            "centered": {
+              "type": "boolean"
+            },
+            "iconCrossed": {
+              "type": "boolean"
+            }
+          }
+        }
+      },
       "requiredTech": {
         "if": {
           "type": "string"
@@ -119,7 +202,10 @@
       "replacementTextForUniques": {
         "type": "string"
       }
-    }
+    },
+    "required": [
+      "name"
+    ]
   },
   "definitions": {
   }


### PR DESCRIPTION
POC for #10152 

![image](https://github.com/yairm210/Unciv/assets/8366208/5df80ef8-8eef-444c-be34-562e0e95466b)

Example for warning (nested - array of strings):
![image](https://github.com/yairm210/Unciv/assets/8366208/2efa0377-45ef-445a-a54d-82227eb5d1bd)

Honestly though, kind of underwhelming at the moment

Instructions for use:

- Add schema mapping
  - Search "json schema mappings" in doubletap
  - Click '+', direct schema to file at `docs/modding/schemas/buildings.json` for local file, or `https://raw.githubusercontent.com/yairm210/Unciv/9b63b329f112d6edb4280243498cc0e358e61d8d/docs/modding/schemas/buildings.json` for an example external URL (this is what modders will be doing)
  - Add a file path pattern: `*/Buildings.json`
 
![image](https://github.com/yairm210/Unciv/assets/8366208/e4719561-5ca5-4fe7-ab7f-5bcaddb04494)

- You can turn on 'show json schema' setting the same way to see what schema applies to a file, on bottom bar
![image](https://github.com/yairm210/Unciv/assets/8366208/9f55515d-d38b-4e72-94c9-acb45f59baa5)

Still doesn't manage to show me there's a bad field though:
![image](https://github.com/yairm210/Unciv/assets/8366208/2a0f467c-6866-49fb-8a79-8564a51c469c)

even though I manually added `
    "additionalProperties": false` to the json schema, sounded like a jetbrains implementation issue - but then I see [this exists](https://youtrack.jetbrains.com/issue/WEB-51501) so now I don't know what to think.
