### PR TITLE
AI Open Borders Offer fix

### DIFF
--- a/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
@@ -859,7 +859,7 @@ object NextTurnAutomation {
         // Don't accept if they are at war with our friends, they might use our land to attack them
         if (civInfo.diplomacy.values.any { it.isRelationshipLevelGE(RelationshipLevel.Friend) && it.otherCiv().isAtWarWith(otherCiv)})
             return false
-        if (hasAtLeastMotivationToAttack(civInfo, otherCiv, civInfo.getDiplomacyManager(otherCiv).opinionOfOtherCiv().toInt()) > 0)
+        if (hasAtLeastMotivationToAttack(civInfo, otherCiv, (civInfo.getDiplomacyManager(otherCiv).opinionOfOtherCiv()/ 2 - 10).toInt()) >= 0)
             return false
         return true
     }

--- a/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
@@ -835,12 +835,14 @@ object NextTurnAutomation {
     }
     
     private fun offerOpenBorders(civInfo: Civilization) {
-        val civsThatWeCanDeclareFriendshipWith = civInfo.getKnownCivs()
+        if (!civInfo.hasUnique(UniqueType.EnablesOpenBorders)) return
+        val civsThatWeCanOpenBordersWith = civInfo.getKnownCivs()
             .filter { it.isMajorCiv() && !civInfo.isAtWarWith(it) 
+                && it.hasUnique(UniqueType.EnablesOpenBorders)
                 && !civInfo.getDiplomacyManager(it).hasOpenBorders
                 && !civInfo.getDiplomacyManager(it).hasFlag(DiplomacyFlags.DeclinedOpenBorders) }
             .sortedByDescending { it.getDiplomacyManager(civInfo).relationshipLevel() }.toList()
-        for (otherCiv in civsThatWeCanDeclareFriendshipWith) {
+        for (otherCiv in civsThatWeCanOpenBordersWith) {
             // Default setting is 3, this will be changed according to different civ.
             if ((1..10).random() <= 3 && wantsToOpenBorders(civInfo, otherCiv)) {
                 val tradeLogic = TradeLogic(civInfo, otherCiv)

--- a/core/src/com/unciv/logic/trade/Trade.kt
+++ b/core/src/com/unciv/logic/trade/Trade.kt
@@ -61,9 +61,9 @@ class TradeRequest : IsPartOfGameInfoSerialization {
         if (trade.ourOffers.any { it.name == Constants.researchAgreement })
             diplomacyManager.setFlag(DiplomacyFlags.DeclinedResearchAgreement,20)
         if (trade.ourOffers.any { it.name == Constants.defensivePact })
-            diplomacyManager.setFlag(DiplomacyFlags.DeclinedDefensivePact,10)
+            diplomacyManager.setFlag(DiplomacyFlags.DeclinedDefensivePact,20)
         if (trade.ourOffers.any { it.name == Constants.openBorders })
-            diplomacyManager.setFlag(DiplomacyFlags.DeclinedOpenBorders, 10)
+            diplomacyManager.setFlag(DiplomacyFlags.DeclinedOpenBorders, if (decliningCiv.isAI()) 10 else 20)
 
         if (trade.isPeaceTreaty()) diplomacyManager.setFlag(DiplomacyFlags.DeclinedPeace, 5)
 

--- a/core/src/com/unciv/ui/screens/worldscreen/AlertPopup.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/AlertPopup.kt
@@ -199,7 +199,7 @@ class AlertPopup(
         addLeaderName(otherciv)
         addGoodSizedLabel("My friend, shall we declare our friendship to the world?").row()
         addCloseButton("We are not interested.", KeyboardBinding.Cancel) {
-            playerDiploManager.otherCivDiplomacy().setFlag(DiplomacyFlags.DeclinedDeclarationOfFriendship, 10)
+            playerDiploManager.otherCivDiplomacy().setFlag(DiplomacyFlags.DeclinedDeclarationOfFriendship, 20)
         }.row()
         addCloseButton("Declare Friendship ([30] turns)", KeyboardBinding.Confirm) {
             playerDiploManager.signDeclarationOfFriendship()


### PR DESCRIPTION
Fixes  #10177

This commit does a few things.

1. Adds a technology requirement for the AI to offer open borders
2. Increases multiple Declined- flags from 10 to 20. AIs can process these offers without a problem, so reducing their Declined flags times relative to players might be helpful since it is partly a quality-of-life feature.
3. Increased the AI valuing not offering/accepting open borders if it is a suitable war target