### PR TITLE
Update Turkish.properties

### DIFF
--- a/android/assets/jsons/translations/Turkish.properties
+++ b/android/assets/jsons/translations/Turkish.properties
@@ -121,12 +121,9 @@ Peace = Barış
 Research Agreement = Araştırma Antlaşması
 Declare war = Savaş ilan et
 Declare war on [civName]? = [civName] uygarlığına savaş açılsın mı?
- # Requires translation!
-[civName] will also join them in the war = 
- # Requires translation!
-An unknown civilization will also join them in the war = 
- # Requires translation!
-This will cancel your defensive pact with [civName] = 
+[civName] will also join them in the war = [civName] savaşta onlara katılıyor.
+An unknown civilization will also join them in the war = Bilinmeyen bir uygarlıkta savaşta onlara katılıyor
+This will cancel your defensive pact with [civName] = Bu senin [civName] ile olan yardımlaşma anlaşmanı kaldıracak.
 Go to on map = Haritaya git
 Let's begin! = Hadi Başlayalım!
 [civName] has declared war on us! = [civName] bize savaş açtı!
@@ -134,7 +131,7 @@ Let's begin! = Hadi Başlayalım!
 You'll pay for this! = Bunun bedelini ödeyeceksin!
 Negotiate Peace = Barışı Görüşmeleri Yapın
 Peace with [civName]? = [civName] ile barışılsın mı?
-Very well. = Çok iyi.
+Very well. = Pekala.
 Farewell. = Elveda.
 Sounds good! = Kulağa güzel geliyor!
 Not this time. = Bu kez olmaz.
@@ -175,10 +172,8 @@ Ally =  Müttefik
 
 [questName] (+[influenceAmount] influence) = [questName] (+ [influenceAmount] etkisi)
 [remainingTurns] turns remaining = [remainingTurns] tur kaldı
- # Requires translation!
-Current leader is [civInfo] with [amount] [stat] generated. = 
- # Requires translation!
-Current leader is [civInfo] with [amount] Technologies discovered. = 
+Current leader is [civInfo] with [amount] [stat] generated. = Şu anki lider [amount] [stat] üretimi ile [civInfo].
+Current leader is [civInfo] with [amount] Technologies discovered. = Şu anki lider [amount] keşfedilmiş teknoloji ile [civInfo].
 
 Demands = Talepler
 Please don't settle new cities near us. = Lütfen yakınımıza yeni şehirler kurmayın.
@@ -187,10 +182,8 @@ We shall do as we please. = İstediğimiz gibi yaparız.
 We noticed your new city near our borders, despite your promise. This will have....implications. = Söz vermene rağmen yeni şehrini sınırlarımızın yakınına kurdun. Bunun ... yaptırımları olacak.
 I've been informed that my armies have taken tribute from [civName], a city-state under your protection.\nI assure you, this was quite unintentional, and I hope that this does not serve to drive us apart. = Öğrendiğime göre benim askerlerim sizin himayeniz altındaki [civName] şehir devletinden haraç almış.\nBunun kasıtlı olmadığına dair sizi temin eder, bu tatsız hadisenin ilişkilerimizi bozmamasını umarım.
 We asked [civName] for a tribute recently and they gave in.\nYou promised to protect them from such things, but we both know you cannot back that up. = Geçenlerde [civName]'den haraç istedik ve kabul ettiler.\nOnları bu tür şeylerden koruyacağına söz verdin, ama ikimiz de biliyoruz ki, bunu destekleyemezsin.
- # Requires translation!
-It's come to my attention that I may have attacked [civName], a city-state under your protection.\nWhile it was not my goal to be at odds with your empire, this was deemed a necessary course of action. = 
- # Requires translation!
-I thought you might like to know that I've launched an invasion of one of your little pet states.\nThe lands of [civName] will make a fine addition to my own. = 
+It's come to my attention that I may have attacked [civName], a city-state under your protection.\nWhile it was not my goal to be at odds with your empire, this was deemed a necessary course of action. = Koruman altındaki bir şehir devleti olan [civName] 'a saldırmış olabileceğim dikkatime çarptı.\nHer ne kadar amacım sizinle ters olmak olmasa da, bu gerekli bir hareketti.
+I thought you might like to know that I've launched an invasion of one of your little pet states.\nThe lands of [civName] will make a fine addition to my own. = Evcil minik devletlerinizden birine istila düzenlediğimi bilmenizi isterim.\n [civName] toprakları benimkilere harika bir katkı olacak.
 
 Return [unitName] to [civName]? = [unitName] [civName] medeniyetine geri verilsin mi?
 The [unitName] we liberated originally belonged to [civName]. They will be grateful if we return it to them. = Kurtardığımız [unitName] aslında [civName]'e aitti. Onlara geri verirsek minnettar olacaklar.
@@ -213,15 +206,13 @@ Pledge to protect = Koruma Taahhütü
 Declare Protection of [cityStateName]? = [cityStateName]'e Koruma Taahhüdü ilan etmek istediğine emin misin?
 Build [improvementName] on [resourceName] (200 Gold) = [resourceName] üstüne [improvementName] yap (200 Altın)
 Gift Improvement = Geliştirme Hediye et
- # Requires translation!
-[civName] is able to provide [unitName] once [techName] is researched. = 
+[civName] is able to provide [unitName] once [techName] is researched. = [civName], [techName] araştırıldığı gibi [unitName] sağlayabilecek.
 
 Diplomatic Marriage ([amount] Gold) = Siyasî Evlilik ([amount] Altın)
 We have married into the ruling family of [civName], bringing them under our control. = [civName] medeniyetinin hanedanıyla evlendik ve onları hakimiyetimiz altına aldık.
 [civName] has married into the ruling family of [civName2], bringing them under their control. = [civName] medeniyeti [civName2] medeniyetinin hanedanıyla evlendi ve onları hakimiyet altına aldı.
 You have broken your Pledge to Protect [civName]! = [civName] medeniyetini koruma taahhüdünüzü bozdunuz!
- # Requires translation!
-City-States grow wary of your aggression. The resting point for Influence has decreased by [amount] for [civName]. = 
+City-States grow wary of your aggression. The resting point for Influence has decreased by [amount] for [civName]. = Şehir devletleri agresifliğinizden dolayı temkinli. Nüfuz için dinlenme puanları [civName] için [amount] kadar düştü. 
 
 [cityState] is being attacked by [civName] and asks all major civilizations to help them out by gifting them military units. = [cityState], [civName] tarafından saldırıya uğruyor ve tüm büyük uygarlıklardan kendilerine askeri birlikler hediye ederek onlara yardım etmelerini istiyor.
 [cityState] is being invaded by Barbarians! Destroy Barbarians near their territory to earn Influence. = Barbarlar [cityState] şehir devletine saldırıyorlar! Topraklarının yakınlarındaki barbarları yen ve Nüfuz kazan.
@@ -255,8 +246,7 @@ When Allies: = Müttefikken:
 The unique luxury is one of: = Eşsiz lüks:
 Demand Tribute = Haraca Bağla
 Tribute Willingness = Haraç İstekliliği
- # Requires translation!
-At least 0 to take gold, at least 30 and size 4 city for worker = 
+At least 0 to take gold, at least 30 and size 4 city for worker = Altın almak için en az 0, en az 30 ve işçi için şehir büyüklüğü 4
 Take [amount] gold (-15 Influence) = [amount] altın al (-15 Nüfuz)
 Take worker (-50 Influence) = İşçi al (-50 Nüfuz)
 [civName] is afraid of your military power! = [civName] ordunuzun gücünden korkuyor!
@@ -268,10 +258,8 @@ Has Ally = Müttefiki Var
 Has Protector = Koruyucusu Var
 Demanding a Worker = İşçi talep etmek
 Demanding a Worker from small City-State = Küçük Şehir Devletinden İşçi Talep Etmek
- # Requires translation!
-Very recently paid tribute = 
- # Requires translation!
-Recently paid tribute = 
+Very recently paid tribute = Çok yakın zamanda ödenen haraç
+Recently paid tribute = Yakın zamanda ödenen haraç
 Influence below -30 = -30 altında Nüfuz
 Military Rank = Askeri Rütbe
 Military near City-State = Şehir Devleti yakınında asker
@@ -282,18 +270,15 @@ Sum: = Toplam:
 
 Trade = Ticaret
 Offer trade = Ticaret teklif et
- # Requires translation!
-They'll decide on their turn = 
+They'll decide on their turn = Kendi sıralarında karar verecekler
 Retract offer = Teklifi geri çek 
 What do you have in mind? = Aklında ne var?
 Our items = Elimizdekiler
 Our trade offer = Ticaret teklifimiz
 [otherCiv]'s trade offer = [otherCiv] devletinin ticari teklifi
 [otherCiv]'s items = [otherCiv] devletinin elindekiler
- # Requires translation!
-+[amount] untradable copy = 
- # Requires translation!
-+[amount] untradable copies = 
++[amount] untradable copy = +[amount] ticaret edilemez nüsha
++[amount] untradable copies = +[amount] ticaret edilemez nüshalar
 Pleasure doing business with you! = Seninle iş yapmak büyük bir zevk!
 I think not. = Bence hayır.
 That is acceptable. = Bu kabul edilebilir
@@ -302,8 +287,7 @@ Keep going = Devam et
 There's nothing on the table = Masanın üstünde hiçbir şey yok
 Peace Treaty = Barış Antlaşması
 Agreements = Anlaşmalar
- # Requires translation!
-Defensive Pact = 
+Defensive Pact = Yardımlaşma anlaşması 
 Open Borders = Açık Sınırlar
 Gold per turn = Tur başına altın
 Cities = Şehirler
@@ -314,16 +298,13 @@ Declare war on [nation] = [nation] devletine savaş ilan et
 Luxury resources = Lüks kaynaklar
 Strategic resources = Taktiksel kaynaklar
 Owned by you: [amountOwned] = Sizdeki miktarı: [amountOwned]
- # Requires translation!
-Non-existent city = 
+Non-existent city = Var olmayan şehir
 
 # Unit differences
 
 [resourceName] not required = [resourceName] gerekli değil
- # Requires translation!
-Lost ability (vs [originalUnit]): [ability] = 
- # Requires translation!
-Upgrade all [count] [unit] ([cost] gold) = 
+Lost ability (vs [originalUnit]): [ability] = Kayıp beceri (vs [originalUnit]): [ability]
+Upgrade all [count] [unit] ([cost] gold) = Hepsini geliştir [count] [unit] ([cost] gold)
 National ability = Ulusal yetenek
 [firstValue] vs [secondValue] = [firstValue] - [secondValue]
 Gained = Kazanılmış
@@ -337,8 +318,7 @@ Promotions = Terfiler
 Load copied data = Kopyalanan verileri yükle
 Reset to defaults = Varsayılanlara döndür
 Select nations = Ulusları seçin
- # Requires translation!
-Set available nations for random pool = 
+Set available nations for random pool = Karışık bir şekilde mevcut ülkeleri ayarlayın
 Available nations = Mevcut ülkeler
 Banned nations = Yasaklı ülkeler
 Are you sure you want to reset all game options to defaults? = Bütün oyun ayarlarını varsayılana döndürmek istediğinize emin misiniz?
@@ -352,8 +332,7 @@ Max Turns = Azami Tur
 Could not load map! = Harita yüklenemedi!
 Generated = Oluşturulmuş
 Random Generated = Rastgele Oluşturulmuş
- # Requires translation!
-Which options should be available to the random selection? = 
+Which options should be available to the random selection? = Karışık seçim için hangi özellikler kullanılabilir olsun?
 Existing = Mevcut
 Custom = Özel
 Map Generation Type = Harita oluşturma türü
@@ -366,20 +345,13 @@ Three Continents = Üç kıta
 Four Corners = Dört Kısım
 Archipelago = Takımadalar
 Inner Sea = İç Deniz
- # Requires translation!
-Perlin = 
- # Requires translation!
-Random number of Civilizations = 
- # Requires translation!
-Min number of Civilizations = 
- # Requires translation!
-Max number of Civilizations = 
- # Requires translation!
-Random number of City-States = 
- # Requires translation!
-Min number of City-States = 
- # Requires translation!
-Max number of City-States = 
+Perlin = Perlin
+Random number of Civilizations = Medeniyetlerin rastgele sayısı
+Min number of Civilizations = Medeniyetlerin asgari sayısı
+Max number of Civilizations = Medeniyetlerin azami sayısı
+Random number of City-States = Şehir devletlerinin rastgele sayısı
+Min number of City-States = Şehir devletlerinin asgari sayısı
+Max number of City-States = Şehir devletlerinin azami sayısı
 One City Challenge = Tek Şehir Meydan Okuması
 Enable Nuclear Weapons = Nükleer Silahları Aç
 No City Razing = Şehir Yıkımı Yok
@@ -395,8 +367,7 @@ Domination = Hakimiyet
 Cultural = Kültürel
 Diplomatic = Diplomatik
 Time = Süre
- # Requires translation!
-Your previous options needed to be reset to defaults. = 
+Your previous options needed to be reset to defaults. = Bir önceki ayarlarının standarta resetlenmesi gerekiyor.
 
 # Used for random nation indicator in empire selector and unknown nation icons in various overview screens.
 # Should be a single character, or at least visually square.
@@ -405,8 +376,7 @@ Your previous options needed to be reset to defaults. =
 Map Shape = Harita Şekli
 Enabled Map Shapes = Etkin Harita Şekilleri
 Hexagonal = Altıgen
- # Requires translation!
-Flat Earth Hexagonal = 
+Flat Earth Hexagonal = Düz Dünya Altıgen
 Rectangular = Dikdörtgen
 Height = Uzunluk
 Width = Genişlik
@@ -420,15 +390,13 @@ Sparse = Seyrek
 Abundant = Bol
 Strategic Balance = Stratejik Denge
 Legendary Start = Efsanevi Başlangıç
- # Requires translation!
-This is used for painting resources, not in map generator steps: = 
+This is used for painting resources, not in map generator steps: = Bu kaynakları boyamak için kullanılmakta, harita oluşturucu basamaklarında değil.
 
 Advanced Settings = Gelişmiş Ayarlar
 RNG Seed = RNG Kodu
 Map Elevation = Harita Yüksekliği
 Temperature extremeness = Sıcaklık aşırılığı
- # Requires translation!
-Temperature shift = 
+Temperature shift = Sıcaklık değişimi
 Resource richness = Kaynak zenginliği
 Vegetation richness = Bitki örtüsü
 Rare features richness = Nadir özellikler zenginliği
@@ -481,21 +449,15 @@ Extension mods = Uzantı modları
 Base ruleset: = Temel kurallar:
 # Note - do not translate the colour names between «». Changing them works if you know what you're doing.
 The mod you selected is incorrectly defined! = Seçtiğin mod hatalı tanımlanmış!
- # Requires translation!
-The mod you selected is «RED»incorrectly defined!«» = 
+The mod you selected is «RED»incorrectly defined!«» = Seçtiğin mod «RED»hatalı tanımlanmış!«»
 The mod combination you selected is incorrectly defined! = Seçtiğin mod kombinasyonu hatalı tanımlanmış! 
- # Requires translation!
-The mod combination you selected is «RED»incorrectly defined!«» = 
+The mod combination you selected is «RED»incorrectly defined!«» = Seçtiğin mod kombinasyonu «RED»hatalı tanımlanmış!«»
 The mod combination you selected has problems. = Seçtiğin mod kombinasyonunda problemler var.
 You can play it, but don't expect everything to work! = Oynayabilirsin, fakat her şeyin çalışmasını bekleme!
- # Requires translation!
-The mod combination you selected «GOLD»has problems«». = 
- # Requires translation!
-You can play it, but «GOLDENROD»don't expect everything to work!«» = 
- # Requires translation!
-This base ruleset is not compatible with the previously selected\nextension mods. They have been disabled. = 
- # Requires translation!
-Are you really sure you want to play with the following known problems? = 
+The mod combination you selected «GOLD»has problems«». = Seçtiğin mod kombinasyonu «GOLD»sorun iceriyor«».
+You can play it, but «GOLDENROD»don't expect everything to work!«» = Oynayabilirsin, fakat «GOLDENROD»herşeyin çalışmasını bekleme!«»
+This base ruleset is not compatible with the previously selected\nextension mods. They have been disabled. = Bu Temel Kurallar az önce seçilmiş modlarla uyumlu değil. Bu yüzden etknidışı edildiler.
+Are you really sure you want to play with the following known problems? = Sıralanan bilinen sorunlara rağmen oynamak istiyor musun?
 Base Ruleset = Temel Kurallar
 [amount] Techs = [amount] Teknoloji
 [amount] Nations = [amount] Ulus
@@ -517,10 +479,8 @@ Anything above 40 may work very slowly on Android! = 40'ın üzerine çıkıldı
 Map editor = Harita düzenleyicisi
 View = Görüntüle
 Generate = Oluştur
- # Requires translation!
-Partial = 
- # Requires translation!
-Generator steps = 
+Partial = Kısmi
+Generator steps = Oluşturucu adımları
 Edit = Düzenle
 Rivers = Irmaklar
 Load = Yükle
@@ -534,20 +494,15 @@ Are you sure you want to delete this map? = Bu haritayı silmek istediğinize em
 It looks like your map can't be saved! = Görünüşe göre haritan kaydedilemiyor!
 Exit map editor = Harita düzenleyiciden çık
 Change map ruleset = Harita kurallarını değiş
- # Requires translation!
-Change the map to use the ruleset selected on this page = 
+Change the map to use the ruleset selected on this page = Bu sayfadaki Harita kurallarını kullanmak için Haritayı değiş
 Revert to map ruleset = Harita kurallarını eski haline çevir
- # Requires translation!
-Reset the controls to reflect the current map ruleset = 
+Reset the controls to reflect the current map ruleset = Şu anki Harita Kurallarını yansıtmak için kontrolleri sıfırla.
 Features = Özellikler
 Starting locations = Başlangıç konumları
- # Requires translation!
-Tile Matching Criteria = 
+Tile Matching Criteria = Karo Eşleme Kriteri
 Complete match = Tam eşleşme
- # Requires translation!
-Except improvements = 
- # Requires translation!
-Base and terrain features = 
+Except improvements = Harici geliştirmeler 
+Base and terrain features = Yer ve arazi özellikleri
 Base terrain only = Sadece temel arazi
 Land or water only = Sadece kara ya da su
 
@@ -555,53 +510,32 @@ Land or water only = Sadece kara ya da su
 Brush ([size]): = Fırça ([size])
 # The single letter shown in the [size] parameter above for setting "Floodfill".
 # Please do not make this longer, the associated slider will not handle well.
- # Requires translation!
-Floodfill_Abbreviation = 
+Floodfill_Abbreviation = Doldurma_Kısaltması
 Error loading map! = Harita yüklenirken sorun oluştu!
 Map saved successfully! = Harita başarıyla kaydedildi!
- # Requires translation!
-Current map RNG seed: [amount] = 
- # Requires translation!
-Map copy and paste = 
+Current map RNG seed: [amount] = Şu anki haritadaki RNG seed'i: [amount] 
+Map copy and paste = Harita kopyala ve yapıştır 
 Position: [param] = Konum: [param]
 Starting location(s): [param] = Başlangıç konum(lar)ı: [param]
- # Requires translation!
-Continent: [param] ([amount] tiles) = 
- # Requires translation!
-Resource abundance = 
+Continent: [param] ([amount] tiles) = Kıta: [param] ([amount] tiles)
+Resource abundance = Kaynak Bolluğu
 Change map to fit selected ruleset? = Harita, seçilen kural setine uyacak şekilde değiştirilsin mi?
- # Requires translation!
-Area: [amount] tiles, [amount2]% water, [amount3]% impassable, [amount4] continents/islands = 
- # Requires translation!
-Do you want to leave without saving the recent changes? = 
- # Requires translation!
-Leave = 
- # Requires translation!
-Do you want to load another map without saving the recent changes? = 
- # Requires translation!
-River generation failed! = 
- # Requires translation!
-Please don't use step 'Landmass' with map type 'Empty', create a new empty map instead. = 
- # Requires translation!
-This map has errors: = 
- # Requires translation!
-The incompatible elements have been removed. = 
- # Requires translation!
-Current map: World Wrap = 
- # Requires translation!
-Overlay image = 
- # Requires translation!
-Click to choose a file = 
- # Requires translation!
-Choose an image = 
- # Requires translation!
-Overlay opacity: = 
- # Requires translation!
-Invalid overlay image = 
- # Requires translation!
-World wrap is incompatible with an overlay and was deactivated. = 
- # Requires translation!
-An overlay image is incompatible with world wrap and was deactivated. = 
+Area: [amount] tiles, [amount2]% water, [amount3]% impassable, [amount4] continents/islands = Bölge: [amount] arazi, [amount2]% su, [amount3]% geçilmez, [amount4] kıtalar/adalar
+Do you want to leave without saving the recent changes? = Yeni değişikleri kaydetmeden ayrılmak istiyor musun?
+Leave = Ayrıl
+Do you want to load another map without saving the recent changes? = Yeni değişikleri kaydetmeden yeni bir harita yüklemek istiyor musun?
+River generation failed! = Nehir üretimi başarısız!
+Please don't use step 'Landmass' with map type 'Empty', create a new empty map instead. = Lütfen 'Karakütlesi' adımını 'Boş' harita türüyle kullanmayın, bunun yerine yeni bir harita yaratın.
+This map has errors: = Bu haritada hatalar mevcut.
+The incompatible elements have been removed. = Uyuşmaz elementler kaldırıldı.
+Current map: World Wrap = Güncel Harita: Dünya Görünümü
+Overlay image = Kaplama resim
+Click to choose a file = Dosya seçmek için tıklayın
+Choose an image = Resim seç
+Overlay opacity: = Kaplama Opaklığı
+Invalid overlay image = Geçersiz Kaplama Resmi
+World wrap is incompatible with an overlay and was deactivated. = Dünya Görünümü bir kaplama ile uyumsuzdu ve devredışı bırakıldı.
+An overlay image is incompatible with world wrap and was deactivated. = Kaplama resmi bir dünya görünümü ile uyumsuz ve devredışı bırakıldı.
 
 ## Map/Tool names
 My new map = Yeni haritam
@@ -612,19 +546,15 @@ Lakes and coastline = Göller ve sahil
 Sprout vegetation = Bitki örtüsü filizle
 Spawn rare features = Nadir özellikleri ortaya çıkar
 Distribute ice = Buzu dağıt
- # Requires translation!
-Assign continent IDs = 
+Assign continent IDs = Kıta IDsi ata
 Place Natural Wonders = Doğal Harikalar yerleştir
 Let the rivers flow = Nehirlerin akmasını sağla
 Spread Resources = Kaynakları dağıt
 Create ancient ruins = Antik kalıntılar oluştur
- # Requires translation!
-Floodfill = 
+Floodfill = Doldur
 [nation] starting location = [nation] başlangıç yeri
- # Requires translation!
-Any Civ starting locations = 
- # Requires translation!
-Any Civ = 
+Any Civ starting locations = Herhangi bir Medeniyet başlama yeri
+Any Civ = Herhangi Medeniyet
 Remove features = Özellikleri kaldır
 Remove improvement = Geliştirmeleri kaldır
 Remove resource = Kaynakları kaldır
@@ -642,8 +572,7 @@ Username = Kullanıcı adı
 Multiplayer = Çok oyunculu
 Could not download game! = Oyun indirilemedi!
 Could not upload game! = Oyun yüklenemedi!
- # Requires translation!
-Couldn't connect to Multiplayer Server! = 
+Couldn't connect to Multiplayer Server! = Çoklu oyuncu sunucusuna bağlanamadı!
 Retry = Yeniden dene
 Join game = Oyuna Katıl
 Invalid game ID! = Geçersiz oyun kimliği!
@@ -661,8 +590,7 @@ Player name already used! = Oyuncu ismi zaten kullanıldı!
 Player ID already used! = Oyuncu kimliği zaten kullanıldı!
 Player ID is incorrect = Oyuncu kimliği hatalı
 Select friend = Arkadaş seç
- # Requires translation!
-Select [thingToSelect] = 
+Select [thingToSelect] = Seç [thingToSelect]
 Friends list = Arkadaş listesi
 Add friend = Arkadaş ekle
 Edit friend = Arkadaşı düzenle
@@ -673,12 +601,9 @@ You have to write an ID for your friend! = Arkadaşın için bir kimlik yazman g
 You cannot add your own player ID in your friend list! = Kendi oyuncu kimliğini arkadaş listesine ekleyemezsin!
 To add a friend, ask him to send you his player ID.\nClick the 'Add friend' button.\nInsert his player ID and a name for him.\nThen click the 'Add friend' button again.\n\nAfter that you will see him in your friends list.\n\nA new button will appear when creating a new\nmultiplayer game, which allows you to select your friend. = Arkadaşını eklemek için, sana oyuncu kimliğini göndermesini iste.
 Please input Player ID! = Lütfen Oyuncu Kimliği gir!
- # Requires translation!
-The number of players will be adjusted = 
- # Requires translation!
-These [numberOfPlayers] players will be adjusted = 
- # Requires translation!
-[numberOfExplicitPlayersText] to [playerRange] actual players by adding random AI's or by randomly omitting AI's. = 
+The number of players will be adjusted = Oyuncu sayısı ayarlanacak.
+These [numberOfPlayers] players will be adjusted = Şu [numberOfPlayers] oyuncu ayarlanacak.
+[numberOfExplicitPlayersText] to [playerRange] actual players by adding random AI's or by randomly omitting AI's. = Rastgele yapay zeka ekleyip ya da çıkarıp [numberOfExplicitPlayersText] 'ı [playerRange] gerçek oyunculara aktarın.
 Set current user = Geçerli kullanıcıyı ayarla
 Player ID from clipboard = Panodan oyuncu kimliği
 Player ID from friends list = Arkadaş listesinden oyuncu kimliği
@@ -701,13 +626,12 @@ Paste gameID from clipboard = Panodan oyun kimliği yapıştır
 GameID = Oyun kimliği
 Game name = Oyun adı
 Loading latest game state... = En son oyun durumu yükleniyor...
- # Requires translation!
-You are not allowed to spectate! = 
+You are not allowed to spectate! = Seyirciliğe iznin yok.
 Couldn't download the latest game state! = En son oyun durumu indirilemiyor!
-Resign = İstifa etmek
-Are you sure you want to resign? = İstifa etmek istediğinizden emin misiniz?
-You can only resign if it's your turn = Sadece sıra sende ise istifa edebilirsin
-[civName] resigned and is now controlled by AI = [civName] istifa etti ve artık YZ tarafından kontrol ediliyor
+Resign = Geri çekilmek
+Are you sure you want to resign? = Geri çekilmek istediğinizden emin misiniz?
+You can only resign if it's your turn = Sadece sıra sende ise geri çekilebilirsin
+[civName] resigned and is now controlled by AI = [civName] geri çekildi ve artık YZ tarafından kontrol ediliyor
 Last refresh: [duration] ago = Son yenileme: [duration] önce
 Current Turn: [civName] since [duration] ago = Şu Anki Tur: [duration] süredir [civName]
 Seconds = Saniye
@@ -720,30 +644,18 @@ Days = Gün
 [amount] Days = [amount] Gün
 Server limit reached! Please wait for [time] seconds = Sunucu limiti aşıldı! Lütfen [time] saniye bekleyin
 File could not be found on the multiplayer server = Çevrimiçi sunucuda dosya bulunamadı
- # Requires translation!
-Unhandled problem, [errorMessage] = 
- # Requires translation!
-Please enter your server password = 
- # Requires translation!
-Set password = 
- # Requires translation!
-Password must be at least 6 characters long = 
- # Requires translation!
-Failed to set password! = 
- # Requires translation!
-Password set successfully for server [serverURL] = 
- # Requires translation!
-Password = 
- # Requires translation!
-Your userId is password secured = 
- # Requires translation!
-Set a password to secure your userId = 
- # Requires translation!
-Authenticate = 
- # Requires translation!
-This server does not support authentication = 
- # Requires translation!
-Authentication failed = 
+Unhandled problem, [errorMessage] = İşlenmemiş sıkıntı, [errorMessage]
+Please enter your server password = Lütfen sunucu parolarınızı girin
+Set password = Parola belirle
+Password must be at least 6 characters long = Parola en az 6 karekter uzunluğunda olmalı
+Failed to set password! = Parola belirlenemedi
+Password set successfully for server [serverURL] = [serverURL] için başarıyla parola belirlendi
+Password = Parola
+Your userId is password secured = Kullanıcı ID'n parola ile korundu
+Set a password to secure your userId = Kullanıcı ID'ni korumak için parola belirle
+Authenticate = Doğrulama
+This server does not support authentication = Bu sunucu doğrulama desteklemiyor
+Authentication failed = Doğrulama başarısız
 
 # Save game menu
 
@@ -751,18 +663,14 @@ Current saves = Mevcut kayıtlar
 Show autosaves = Otomatik kaydetmeleri göster
 Saved game name = Kaydedilmiş oyun adı
 # This is the save game name the dialog will suggest
- # Requires translation!
-[player] - [turns] turns = 
+[player] - [turns] turns = [player] - [turns] tur sayısı
 Copy to clipboard = Panoya kopyala
 Copy saved game to clipboard = Kaydedilmiş oyunu panoya kopyala
- # Requires translation!
-Could not load game! = 
+Could not load game! = Oyun yüklenemedi!
 Could not load game from clipboard! = Panodan oyun yüklenemedi!
 Could not load game from custom location! = Oyun özel konumdan yüklenemiyor!
- # Requires translation!
-The file data seems to be corrupted. = 
- # Requires translation!
-The save was created with an incompatible version of Unciv: [version]. Please update Unciv to this version or later and try again. = 
+The file data seems to be corrupted. = Dosya verileri bozulmuş gözüküyor
+The save was created with an incompatible version of Unciv: [version]. Please update Unciv to this version or later and try again. = Bu kayıt Unciv'in uyumsuz bir versiyonu ile yaratılmış. Lütfen Unciv'i güncelleyin ve tekrar deneyin.
 Load [saveFileName] = Yükle [saveFileName]
 Are you sure you want to delete this save? = Bu kaydı silmek istediğine emin misin?
 Delete save = Kayıtları sil
@@ -802,48 +710,35 @@ Display = Görünüş
 
 ### Screen subgroup
 
- # Requires translation!
-Screen = 
+Screen = Ekran
 Screen Mode = Ekran Kipi
 Windowed = Pencereli
 Fullscreen = Tam Ekran
 Borderless = Kenarsız
 
- # Requires translation!
-Screen Size = 
+Screen Size = Ekran boyutu
 
 ### Enable panning the map when you move the mouse to the edge of the window
- # Requires translation!
-Map mouse auto-scroll = 
- # Requires translation!
-Map panning speed = 
+Map mouse auto-scroll = Harita fare oto-kaydır
+Map panning speed = Harita yatay kaydırma hızı
 
 ### Graphics subgroup
 
 Tileset = Grafik seti
- # Requires translation!
-Unitset = 
- # Requires translation!
-UI Skin = 
+Unitset = Birim seti
+UI Skin = Arayüz Görünümü
 
 ### UI subgroup
 
- # Requires translation!
-UI = 
+UI = Arayüz
 
- # Requires translation!
-Notifications on world screen = 
- # Requires translation!
-Disabled = 
- # Requires translation!
-Hidden = 
- # Requires translation!
-Visible = 
- # Requires translation!
-Permanent = 
+Notifications on world screen = Dünya ekranındaki bildirimler
+Disabled = Engelli
+Hidden = Gizli
+Visible = Görünür
+Permanent = Kalıcı
 
- # Requires translation!
-Minimap size = 
+Minimap size = Miniharita boyu
 # This is the leftmost Minimap size slider position
 off = kapalı
 
@@ -853,23 +748,19 @@ Do you want to reset completed tutorials? = Tamamlanmış eğiticileri sıfırla
 Reset = Sıfırla
 
 Show zoom buttons in world screen = Dünya ekranında yakınlaştırma tuşlarını göster
- # Requires translation!
-Experimental Demographics scoreboard = 
+Experimental Demographics scoreboard = Deneysel Demografik skortahtası
 
 ### Visual Hints subgroup
 
- # Requires translation!
-Visual Hints = 
-Show worked tiles = Çalışılan alanları göster
+Visual Hints = Görsel İpuçları
+Show worked tiles = Çalışılan karoları göster
 Show resources and improvements = Kaynakları ve geliştirmeleri göster
 Show tile yields = Karo verimleri Göster
 Show unit movement arrows = Birim hareket oklarını göster
- # Requires translation!
-Show suggested city locations for units that can found cities = 
+Show suggested city locations for units that can found cities = Şehirlerde bulunabilen birimler için önerilen şehir lokasyonlarını göster 
 Show pixel units = Piksel birimlerini göster
 Show pixel improvements = Piksel geliştirmeleri göster
- # Requires translation!
-Unit icon opacity = 
+Unit icon opacity = Birim ikonu opaklığı
 
 ### Performance subgroup
 
@@ -879,22 +770,17 @@ When disabled, saves battery life but certain animations will be suspended = Dev
 ## Gameplay tab
 Gameplay = Oynanış
 Check for idle units = Boş birimleri kontrol edin
- # Requires translation!
-Auto Unit Cycle = 
+Auto Unit Cycle = Oto Birim döngüsü 
 Move units with a single tap = Tek dokunuşla birimleri taşı
 Auto-assign city production = Şehir üretimini otomatik ata
 Auto-build roads = Yolları otomatik oluştur
 Automated workers replace improvements = Otomatik moddaki işciler geliştirmeleri değiştirebilsin
- # Requires translation!
-Automated units move on turn start = 
- # Requires translation!
-Automated units can upgrade = 
- # Requires translation!
-Automated units choose promotions = 
+Automated units move on turn start = Tur başındaki Otomatik moddaki birimler hareket etsin
+Automated units can upgrade = Otomatik moddaki birimler gelişebilir
+Automated units choose promotions = Otomatik moddaki birimler terfi seçebilir
 Order trade offers by amount = Kaynakları ticaret penceresinde sayıya göre büyükten küçüğe sırala
 Ask for confirmation when pressing next turn = Sonraki tura basınca onaylama sor
- # Requires translation!
-Notifications log max turns = 
+Notifications log max turns = Bildirim kayıtlarının azami tur 
 
 ## Language tab
 
@@ -915,12 +801,9 @@ Currently playing: [title] = Şimdi çalan: [title]
 Download music = Müzik indir
 Downloading... = İndiriliyor...
 Could not download music! = Müzik indirilemedi!
- # Requires translation!
-—Paused— = 
- # Requires translation!
-—Default— = 
- # Requires translation!
-—History— = 
+—Paused— = —Durduruldu—
+—Default— = —Standart—
+—History— = —Geçmiş—
 
 ## Advanced tab
 Advanced = Gelişmiş
@@ -931,42 +814,31 @@ Landscape (fixed) = Yatay (sabit)
 Portrait (fixed) = Dikey (sabit)
 Auto (sensor adjusted) = Kendiliğinden
 
- # Requires translation!
-Enable display cutout (requires restart) = 
+Enable display cutout (requires restart) = Ekran kesmeyi etkinleştir (yeniden başlatma şart)
 
 Max zoom out = Maks uzaklaştırma
 
 Font family = Yazı Türü Ailesi
- # Requires translation!
-Font size multiplier = 
+Font size multiplier = Yazı boyutu çarpanı
 Default Font = Varsayılan Yazı Türü
 
 Generate translation files = Çeviri dosyaları oluştur
 Translation files are generated successfully. = Çeviri dosyaları başarıyla oluşturuldu
- # Requires translation!
-Fastlane files are generated successfully. = 
- # Requires translation!
-Update Mod categories = 
+Fastlane files are generated successfully. = Fastlane dosyaları başarıyla oluşturuldu.
+Update Mod categories = Mod kategorilerini güncelle
 
- # Requires translation!
-Enable Easter Eggs = 
- # Requires translation!
-Enlarge selected notifications = 
+Enable Easter Eggs = Gönderme'leri aktif et
+ Enlarge selected notifications = Seçili bildirimleri büyüt
 
 ## Keys tab
- # Requires translation!
-Keys = 
- # Requires translation!
-Please see the Tutorial. = 
- # Requires translation!
-Hit the desired key now = 
+Keys = Tuşlar
+Please see the Tutorial. = Lütfen Eğitime bakın
+Hit the desired key now = Lütfen dilediğiniz tuşa basın
 
 ## Locate mod errors tab
 Locate mod errors = Mod hatalarını bulun
- # Requires translation!
-Check extension mods based on: = 
- # Requires translation!
--none- = 
+Check extension mods based on: = Modun temelli olduğu eklentiyi kontrol et
+-none- = -hiçbirşey-
 Reload mods = Modları yeniden yükle
 Checking mods for errors... = Hatalar için modalar kontrol ediliyor...
 No problems found. = Sorun bulunamadı.
@@ -980,15 +852,13 @@ Debug = Hata Ayıklama
 Show = Göster
 Hide = Gizle
 HIGHLY EXPERIMENTAL - YOU HAVE BEEN WARNED! = AŞIRI DENEYSEL - UYARILDINIZ!
- # Requires translation!
-You need to restart the game for this change to take effect. = 
+You need to restart the game for this change to take effect. = Bunun etki etmesi için oyunu yeniden başlatmanız gerekiyor.
 
 
 # Notifications
 
 Research of [technologyName] has completed! = [technologyName] araştırması tamamlandı!
- # Requires translation!
-We gained [amount] Science from Research Agreement = 
+We gained [amount] Science from Research Agreement = Araştırma anlaşmasından [amount] bilim kazandık
 [construction] has become obsolete and was removed from the queue in [cityName]! = [construction] yapısı eskidi, [cityName] şehrindeki inşaat sırasından kaldırılacak!
 [construction] has become obsolete and was removed from the queue in [amount] cities! = [construction] üretimi gereksiz bulundu ve [amount] şehirde üretim sırasından kaldırıldı!
 [cityName] changed production from [oldUnit] to [newUnit] = [cityName] şehri üretimi [oldUnit]'ten [newUnit]'e çevirdi
@@ -1001,10 +871,8 @@ A [greatPerson] has been born in [cityName]! = [cityName] şehrinde bir [greatPe
 We have encountered [civName]! = [civName] ile karşılaştık!
 [cityStateName] has given us [stats] as a token of goodwill for meeting us = [cityStateName] tanışmamızın şerefine bize [stats] verdi!
 [cityStateName] has given us [stats] as we are the first major civ to meet them = [cityStateName] onlar ile tanışan ilk büyük uygarlık olmamız şerefine bize [stats] verdi!
- # Requires translation!
-[cityStateName] has also given us [stats] = 
- # Requires translation!
-[cityStateName] gave us a [unitName] as a gift! = 
+[cityStateName] has also given us [stats] = [cityStateName] bize [stats] verdi
+[cityStateName] gave us a [unitName] as a gift! = [cityStateName] bize hediye olarak [unitName] verdi!
 Cannot provide unit upkeep for [unitName] - unit has been disbanded! = [unitName] için birim bakımı sağlanamıyor - birim dağıtıldı!
 [cityName] has grown! = [cityName] büyüdü!
 [cityName] is starving! = [cityName] açlıktan ölüyor!
@@ -1021,68 +889,44 @@ Work has started on [construction] = [construction] üzerine çalışma başlat�
 Your Golden Age has ended. = Altın Çağınız sona erdi.
 [cityName] has been razed to the ground! = [cityName] yerle bir edildi!
 We have conquered the city of [cityName]! = [cityName] şehrini fethettik!
- # Requires translation!
-Your citizens are revolting due to very high unhappiness! = 
+Your citizens are revolting due to very high unhappiness! = Vatandaşlarınız mutsuzluk sebebi ile ayaklanıyorlar!
 An enemy [unit] has attacked [cityName] = Bir düşman [unit], [cityName] şehrine saldırdı
- # Requires translation!
-An enemy [unit] ([amount] HP) has attacked [cityName] ([amount2] HP) = 
+An enemy [unit] ([amount] HP) has attacked [cityName] ([amount2] HP) = Düşman [unit] ([amount] HP) ,[cityName] ([amount2] HP) 'a saldırdı
 An enemy [unit] has attacked our [ourUnit] = Bir düşman [unit], [ourUnit] birimimize saldırdı
- # Requires translation!
-An enemy [unit] ([amount] HP) has attacked our [ourUnit] ([amount2] HP) = 
-Enemy city [cityName] has attacked our [ourUnit] = Düşman şehri [cityName], [ourUnit] birimimize saldırdı
- # Requires translation!
-Enemy city [cityName] ([amount] HP) has attacked our [ourUnit] ([amount2] HP) = 
+An enemy [unit] ([amount] HP) has attacked our [ourUnit] ([amount2] HP) = Bir düşman [unit] ([amount] HP) bizim [cityName] ([amount2] HP) 'e saldırdı
+Enemy city [cityName] has attacked our [ourUnit] = Bir düşman şehri [cityName], [ourUnit] birimimize saldırdı
+Enemy city [cityName] ([amount] HP) has attacked our [ourUnit] ([amount2] HP) = Bir düşman şehri [cityName] ([amount] HP) bizim [ourUnit] ([amount2] HP) 'e saldırdı
 An enemy [unit] has captured [cityName] = Bir düşman [unit], [cityName] şehrini ele geçirdi
- # Requires translation!
-An enemy [unit] ([amount] HP) has captured [cityName] ([amount2] HP) = 
+An enemy [unit] ([amount] HP) has captured [cityName] ([amount2] HP) = Bir düşman [unit] ([amount] HP) , [cityName] ([amount2] HP) 'i ele geçirdi
 An enemy [unit] has raided [cityName] = Bir düşman [unit] [cityName] şehrini yağmaladı
- # Requires translation!
-An enemy [unit] ([amount] HP) has raided [cityName] ([amount2] HP) = 
-An enemy [unit] has captured our [ourUnit] = Bir düşman [unit], [ourUnit] birimimizi ele geçirdi 
- # Requires translation!
-An enemy [unit] ([amount] HP) has captured our [ourUnit] ([amount2] HP) = 
+An enemy [unit] ([amount] HP) has raided [cityName] ([amount2] HP) = Bir düşman [unit] ([amount] HP) ,[cityName] ([amount2] HP) 'i yağmaladı
+An enemy [unit] has captured our [ourUnit] = Bir düşman [unit], bizim [ourUnit] 'i ele geçirdi 
+An enemy [unit] ([amount] HP) has captured our [ourUnit] ([amount2] HP) =  Düşman [unit] ([amount] HP) bizim [ourUnit] ([amount2] HP) 'i ele geçirdi
 An enemy [unit] has destroyed our [ourUnit] = Bir düşman [unit], [ourUnit] birimimizi yok etti
- # Requires translation!
-An enemy [unit] ([amount] HP) has destroyed our [ourUnit] ([amount2] HP) = 
+An enemy [unit] ([amount] HP) has destroyed our [ourUnit] ([amount2] HP) = Bir düşman [unit] ([amount] HP) bizim [ourUnit] ([amount2] HP) birimimizi yok etti.
 Your [ourUnit] has destroyed an enemy [unit] = Sizin [ourUnit]'iniz bir düşman [unit]'ini yoketti.
- # Requires translation!
-Your [ourUnit] ([amount] HP) has destroyed an enemy [unit] ([amount2] HP) = 
+Your [ourUnit] ([amount] HP) has destroyed an enemy [unit] ([amount2] HP) = Sizin [ourUnit] ([amount] HP) düşmanın [unit] ([amount2] HP) birimini yok etti.
 An enemy [RangedUnit] has destroyed the defence of [cityName] = Bir düşman [RangedUnit], [cityName] şehrinin savunmasını yok etti
- # Requires translation!
-An enemy [RangedUnit] ([amount] HP) has destroyed the defence of [cityName] ([amount2] HP) = 
+An enemy [RangedUnit] ([amount] HP) has destroyed the defence of [cityName] ([amount2] HP) = Bir düşman [RangedUnit] ([amount] HP) , [cityName] ([amount2] HP) şehrinin savunmasını yok etti.
 Enemy city [cityName] has destroyed our [ourUnit] = Düşman şehri [cityName], [ourUnit] birimimizi yok etti
- # Requires translation!
-Enemy city [cityName] ([amount] HP) has destroyed our [ourUnit] ([amount2] HP) = 
+Enemy city [cityName] ([amount] HP) has destroyed our [ourUnit] ([amount2] HP) = Düşman şehri [cityName] , bizim [ourUnit] ([amount2] HP) birimimizi yok etti.
 An enemy [unit] was destroyed while attacking [cityName] = Bir düşman [unit], [cityName] şehrine saldırırken yok edildi
- # Requires translation!
-An enemy [unit] ([amount] HP) was destroyed while attacking [cityName] ([amount2] HP) = 
+An enemy [unit] ([amount] HP) was destroyed while attacking [cityName] ([amount2] HP) = Bir düşman [unit] ([amount] HP) birimi [cityName] ([amount2] HP) şehrine saldırırken yok edildi.
 An enemy [unit] was destroyed while attacking our [ourUnit] = Bir düşman [unit], [ourUnit] birimimize saldırırken yok edildi
- # Requires translation!
-An enemy [unit] ([amount] HP) was destroyed while attacking our [ourUnit] ([amount2] HP) = 
- # Requires translation!
-Our [attackerName] ([amount] HP) was destroyed by an intercepting [interceptorName] ([amount2] HP) = 
- # Requires translation!
-Our [attackerName] ([amount] HP) was destroyed by an unknown interceptor = 
- # Requires translation!
-Our [interceptorName] ([amount] HP) intercepted and destroyed an enemy [attackerName] ([amount2] HP) = 
- # Requires translation!
-Our [attackerName] ([amount] HP) destroyed an intercepting [interceptorName] ([amount2] HP) = 
- # Requires translation!
-Our [interceptorName] ([amount] HP) intercepted and was destroyed by an enemy [attackerName] ([amount2] HP) = 
- # Requires translation!
-Our [interceptorName] ([amount] HP) intercepted and was destroyed by an unknown enemy = 
- # Requires translation!
-Our [attackerName] ([amount] HP) was attacked by an intercepting [interceptorName] ([amount2] HP) = 
- # Requires translation!
-Our [attackerName] ([amount] HP) was attacked by an unknown interceptor = 
- # Requires translation!
-Our [interceptorName] ([amount] HP) intercepted and attacked an enemy [attackerName] ([amount2] HP) = 
- # Requires translation!
-Nothing tried to intercept our [attackerName] = 
+An enemy [unit] ([amount] HP) was destroyed while attacking our [ourUnit] ([amount2] HP) = Bir düşman [unit] ([amount] HP) bizim [ourUnit] ([amount2] HP) birimimize saldırmaya çalışırken yok edildi.
+Our [attackerName] ([amount] HP) was destroyed by an intercepting [interceptorName] ([amount2] HP) = Bizim [attackerName] ([amount] HP) bir engelleyici [interceptorName] ([amount2] HP) tarafından yok edildi.
+Our [attackerName] ([amount] HP) was destroyed by an unknown interceptor = Bizim [attackerName] ([amount] HP) bilinmeyen bir engelleyici tarafından yok edildi.
+Our [interceptorName] ([amount] HP) intercepted and destroyed an enemy [attackerName] ([amount2] HP) = Bizim [interceptorName] ([amount] HP) birimimiz düşmanın [attackerName] ([amount2] HP) birimini engelleyip yok etti.
+Our [attackerName] ([amount] HP) destroyed an intercepting [interceptorName] ([amount2] HP) = Bizim [attackerName] ([amount] HP) birimimiz bir [interceptorName] ([amount2] HP) yok etti.
+Our [interceptorName] ([amount] HP) intercepted and was destroyed by an enemy [attackerName] ([amount2] HP) = Bizim [interceptorName] ([amount] HP) birimi düşmanın [attackerName] ([amount2] HP) tarafından engellendi ve yok edildi.
+Our [interceptorName] ([amount] HP) intercepted and was destroyed by an unknown enemy = Bizim [interceptorName] ([amount] HP) birimimiz bilinmeyen bir düşman tarafından engellenip yok edildi.
+Our [attackerName] ([amount] HP) was attacked by an intercepting [interceptorName] ([amount2] HP) = Bizim [interceptorName] ([amount] HP) birimimiz [interceptorName] ([amount2] HP) tarafından engellenip saldırıya uğradı.
+Our [attackerName] ([amount] HP) was attacked by an unknown interceptor = Bizim [attackerName] ([amount] HP) bilinmeyen bir engelleyici tarafından saldırıya uğradı.
+Our [interceptorName] ([amount] HP) intercepted and attacked an enemy [attackerName] ([amount2] HP) = Bizim [interceptorName] ([amount] HP) birimimiz düşmananın [attackerName] ([amount2] HP) birimini engelleyip saldırdı.
+Nothing tried to intercept our [attackerName] = Kimse bizim [attackerName] birimimizi engellemeye kalkmadı
 An enemy [unit] was spotted near our territory = Bölgemiz yakınında bir düşman [unit] tespit edildi
 An enemy [unit] was spotted in our territory = Bölgemizde bir düşman [unit] tespit edildi
- # Requires translation!
-An enemy [unit] has destroyed our tile improvement [improvement] = 
+An enemy [unit] has destroyed our tile improvement [improvement] = Bir düşman [unit] bizim [improvement] karo geliştirmemizi yok etti.
 Your city [cityName] can bombard the enemy! = [cityName] şehriniz düşmanı topa tutabilir!
 [amount] of your cities can bombard the enemy! = [amount] şehriniz düşmanı topa tutabilir!
 [amount] enemy units were spotted near our territory = [amount] düşman birimi bölgemizin yakınında tespit edildi
@@ -1092,14 +936,11 @@ After being hit by our [nukeType], [civName] has declared war on us! = Bizim [nu
 The civilization of [civName] has been destroyed! = [civName] medeniyeti yok edildi!
 The City-State of [name] has been destroyed! = [name] Şehir Devleti yok edildi!
 Your [ourUnit] captured an enemy [theirUnit]! = [ourUnit] birliğiniz düşman [theirUnit] birliğini ele geçirdi!
- # Requires translation!
-Your captured [unitName] has been returned by [civName] = 
+Your captured [unitName] has been returned by [civName] = Yakalanmış [unitName] biriminiz [civName] tarafından salındı.
 Your [ourUnit] plundered [amount] [Stat] from [theirUnit] = [ourUnit] birliğiniz [theirUnit] birliğinden yağma yoluyla ganimet olarak [amount] [Stat] aldı
 We have captured a barbarian encampment and recovered [goldAmount] gold! = Bir barbar kampı aldık ve [goldAmount] altını geri kazandık!
- # Requires translation!
-An enemy [unitType] has joined us! = 
- # Requires translation!
-[unitName] can be promoted! = 
+An enemy [unitType] has joined us! = Bir düşman [unitType] bize katıldı!
+[unitName] can be promoted! = [unitName] terfi edilebilir!
 
 # This might be needed for a rewrite of Germany's unique - see #7376
 A barbarian [unitType] has joined us! = Bir barbar [unitType] bize katıldı!
@@ -1121,15 +962,12 @@ You and [name] are no longer allies! = Siz ve [name] artık müttefik değilsini
 [cityName] has been connected to your capital! = [cityName] başkentinize bağlandı!
 [cityName] has been disconnected from your capital! = [cityName], başkentinizle bağlantısı kesildi!
 [civName] has accepted your trade request = [civName] ticaret talebinizi kabul etti
- # Requires translation!
-[civName] has made a counteroffer to your trade request = 
+[civName] has made a counteroffer to your trade request = [civName] ticaret isteğine bir adet karşıteklif yaptı
 [civName] has denied your trade request = [civName] ticaret talebinizi reddetti
 [tradeOffer] from [otherCivName] has ended = [otherCivName] medeniyetinden gelen [tradeOffer] sona erdi
-[tradeOffer] to [otherCivName] has ended = [otherCivName] uygarlığına giden [tradeOffer] teklifimiz sona erdi
- # Requires translation!
-[tradeOffer] from [otherCivName] will end in [amount] turns = 
- # Requires translation!
-[tradeOffer] from [otherCivName] will end next turn = 
+[tradeOffer] to [otherCivName] has ended = [otherCivName] medeniyetine giden [tradeOffer] teklifimiz sona erdi
+[tradeOffer] from [otherCivName] will end in [amount] turns = [otherCivName] medeniyetinden gelen [tradeOffer], [amount] tur sonra son bulacak
+[tradeOffer] from [otherCivName] will end next turn = [otherCivName] medeniyetinden gelen [tradeOffer] gelecek tur bitecek
 One of our trades with [nation] has ended = [nation] ile yaptığımız ticaretlerden biri sona erdi
 One of our trades with [nation] has been cut short = [nation] ile yaptığımız ticaretlerden biri kısa kesildi
 [nation] agreed to stop settling cities near us! = [nation] yakınımızdaki şehirlere yerleşmeyi durdurmayı kabul etti!
@@ -1146,22 +984,17 @@ Received [goldAmount] Gold for capturing [cityName] = [cityName] ele geçirildi�
 Our proposed trade is no longer relevant! = Teklif edilen ticaret talebimiz artık geçerli değil!
 [defender] could not withdraw from a [attacker] - blocked. = [defender], ona saldıran [attacker] biriminden kaçamadı.
 [defender] withdrew from a [attacker] = [defender], ona saldıran [attacker] biriminden kaçtı
- # Requires translation!
-By expending your [unit] you gained [Stats]! = 
+By expending your [unit] you gained [Stats]! = [unit] biriminizi genişletmek size [Stats] kazandırdı!
 Your territory has been stolen by [civName]! = [civName] sizin toprağınızı çaldı!
 Clearing a [forest] has created [amount] Production for [cityName] = Bir [forest] temizlemek, [cityName] için [amount] Üretim yarattı
 [civName] assigned you a new quest: [questName]. = [civName] size yeni bir görev atadı: [questName].
 [civName] rewarded you with [influence] influence for completing the [questName] quest. = [civName], [questName] görevini tamamlamanız için sizi [influence] nüfuz ile ödüllendirdi.
- # Requires translation!
-[civName] no longer needs your help with the [questName] quest. = 
- # Requires translation!
-The [questName] quest for [civName] has ended. It was won by [civNames]. = 
+[civName] no longer needs your help with the [questName] quest. = [civName] daha fazla [questName] görevi için size ihtiyaç duymuyor.
+The [questName] quest for [civName] has ended. It was won by [civNames]. = [civName] için [questName] görevi son buldu. [civNames] tarafından kazanıldı.
 The resistance in [cityName] has ended! = [cityName] şehrindeki direniş sona erdi!
 [cityName] demands [resource]! = [cityName] [resource] istiyor!
- # Requires translation!
-Because they have [resource], the citizens of [cityName] are celebrating We Love The King Day! = 
- # Requires translation!
-We Love The King Day in [cityName] has ended. = 
+Because they have [resource], the citizens of [cityName] are celebrating We Love The King Day! = [resource] sahibi oldukları için, [cityName] sakinleri Kralı Seviyoruz Gün'ünü kutluyorlar!
+We Love The King Day in [cityName] has ended. = [cityName] şehrinde Kralı Seciyoruz Gün'ü bitti.
 Our [name] took [tileDamage] tile damage and was destroyed = Bizim [name], [tileDamage] karo hasarı aldı ve yok edildi
 Our [name] took [tileDamage] tile damage = Bizim [name], [tileDamage] karo hasarı aldı
 [civName] has adopted the [policyName] policy = [civName] [policyName] politikasını kabul etti
@@ -1169,24 +1002,15 @@ An unknown civilization has adopted the [policyName] policy = Bilinmeyen bir uyg
 You gained [Stats] as your religion was spread to [cityName] = Dininiz [cityName] şehrinde yayıldığı için [Stats] kazandınız
 You gained [Stats] as your religion was spread to an unknown city = Dininiz bilinmeyen bir şehirde yayıldığı için [Stats] kazandınız
 Your city [cityName] was converted to [religionName]! = [cityName] şehriniz [religionName] dinini benimsedi!
- # Requires translation!
-Your [unitName] lost its faith after spending too long inside enemy territory! = 
- # Requires translation!
-An [unitName] has removed your religion [religionName] from its Holy City [cityName]! = 
- # Requires translation!
-An [unitName] has restored [cityName] as the Holy City of your religion [religionName]! = 
- # Requires translation!
-You have unlocked [ability] = 
- # Requires translation!
-A new b'ak'tun has just begun! = 
- # Requires translation!
-A Great Person joins you! = 
- # Requires translation!
-[civ1] has liberated [civ2] = 
- # Requires translation!
-[civ] has liberated an unknown civilization = 
- # Requires translation!
-An unknown civilization has liberated [civ] = 
+Your [unitName] lost its faith after spending too long inside enemy territory! = [unitName] biriminiz düşman topraklarında çok fazla vakit geçirdikten sonra inancını kaybetti.
+An [unitName] has removed your religion [religionName] from its Holy City [cityName]! = [unitName] birimi sizin [religionName] dinini Kutsal [cityName] Şehrinden sildi!
+An [unitName] has restored [cityName] as the Holy City of your religion [religionName]! = [unitName] birimi [cityName] şehrini sizin [religionName] dininizin Kutsal Şehri olarak atadı!
+You have unlocked [ability] = [ability] becerisini açtınız!
+A new b'ak'tun has just begun! = Yeni bir b'ak'tun şimdi başladı!
+A Great Person joins you! = Yüce Kişilik size katılıyor!
+[civ1] has liberated [civ2] = [civ1] medeniyeti [civ2] medeniyetini özgürlüğüne kavuşturdu
+[civ] has liberated an unknown civilization = [civ1] medeniyeti bilinmeyen bir medeniyeti özgürlüğüne kavuşturdu
+An unknown civilization has liberated [civ] = Bilinmeyen bir medeniyet [civ2] medeniyetini özgürlüğüne kavuşturdu
 
 # Trigger notifications
 
@@ -1196,55 +1020,33 @@ An unknown civilization has liberated [civ] =
 # put the english word 'true' behind the '=', otherwise 'false'.
 # Don't translate these words to your language, only put 'true' or 'false'. Defaults to 'true'.
  # Requires translation!
-EffectBeforeCause = 
+EffectBeforeCause = false
 
 ## Trigger effects
 
- # Requires translation!
-Gained [amount] [unitName] unit(s) = 
- # Requires translation!
-Gained [stats] = 
- # Requires translation!
-You may choose a free Policy = 
- # Requires translation!
-You may choose [amount] free Policies = 
- # Requires translation!
-You gain the [policy] Policy = 
- # Requires translation!
-You enter a Golden Age = 
- # Requires translation!
-You have gained [amount] [resourceName] = 
- # Requires translation!
-You have lost [amount] [resourceName] = 
+Gained [amount] [unitName] unit(s) = [amount] [unitName] unit(s) birim kazanıldı
+Gained [stats] = [stats] kazanıldı
+You may choose a free Policy = Bedava Poliçe seçebilirsiniz
+You may choose [amount] free Policies = [amount] kadar Bedava Poliçe seçebilirsiniz
+You enter a Golden Age = Altın çağa giriyorsunuz
+You have gained [amount] [resourceName] = [amount] [resourceName] kazandınız
+You have lost [amount] [resourceName] = [amount] [resourceName] kaybettiniz
 
 ## Trigger causes
 
- # Requires translation!
-due to researching [tech] = 
- # Requires translation!
-due to adopting [policy] = 
- # Requires translation!
-due to discovering [naturalWonder] = 
- # Requires translation!
-due to entering the [eraName] = 
- # Requires translation!
-due to constructing [buildingName] = 
- # Requires translation!
-due to gaining a [unitName] = 
- # Requires translation!
-due to founding a city = 
- # Requires translation!
-due to discovering a Natural Wonder = 
- # Requires translation!
-due to our [unitName] defeating a [otherUnitName] = 
- # Requires translation!
-due to our [unitName] being defeated by a [otherUnitName] = 
- # Requires translation!
-due to our [unitName] losing [amount] HP = 
- # Requires translation!
-due to our [unitName] being promoted = 
- # Requires translation!
-from the ruins = 
+due to researching [tech] = [tech] teknolojisini araştırdığınız için
+due to adopting [policy] = [policy] poliçesini benimsediğiniz için
+due to discovering [naturalWonder] = [naturalWonder] harikasını keşfettiğiniz için
+due to entering the [eraName] = [eraName] çağına girdiğiniz için
+due to constructing [buildingName] = [buildingName] binasını inşaa ettiğiniz için
+due to gaining a [unitName] = [unitName] birimini kazandığınız için
+due to founding a city = Şehir bulduğunuz için
+due to discovering a Natural Wonder = Harika keşfettiğiniz için
+due to our [unitName] defeating a [otherUnitName] = [unitName] birimimiz [otherUnitName] birimini yendiği için
+due to our [unitName] being defeated by a [otherUnitName] = [unitName] birimimiz [otherUnitName] birimi tarafından yenildiği için
+due to our [unitName] losing [amount] HP = [unitName] birimimiz [amount] can kaybettiği için
+due to our [unitName] being promoted = [unitName] birimimiz terfi aldığı için
+from the ruins = Harabelerden
 
 # World Screen UI
 
@@ -1254,8 +1056,7 @@ Waiting for [civName]... = [civName] bekleniyor...
 in = içinde
 Next turn = Sonraki tur
 Confirm next turn = Sonraki turu onayla
- # Requires translation!
-Move automated units = 
+Move automated units = Otomatik moddaki birimleri hareket ettir
 [currentPlayerCiv] ready? = [currentPlayerCiv] hazır mı?
 1 turn = 1 tur
 [numberOfTurns] turns = [numberOfTurns] tur
@@ -1270,12 +1071,10 @@ Strength = Güç
 Ranged strength = Menzilli gücü
 Bombard strength = Bombardıman gücü
 Range = Menzil
- # Requires translation!
-XP = 
+XP = Tecrübe
 Move unit = Birliği taşı
 Stop movement = Hareketi durdur
- # Requires translation!
-Show unit destination = 
+Show unit destination = Birim tanımını göster
 Swap units = Yer Değiş
 Construct improvement = İyileştirme inşa et
 Automate = Otomatikleştir
@@ -1289,17 +1088,13 @@ Sleep until healed = İyileşene kadar uyu
 Moving = Harekette
 Set up = Kur
 Paradrop = Paraşütle Atla
- # Requires translation!
-Air Sweep = 
- # Requires translation!
-Add in capital = 
- # Requires translation!
-Add to [comment] = 
+Air Sweep = Hava taraması
+Add in capital = Başkente ekle
+Add to [comment] = [comment] 'a ekle
 Upgrade to [unitType] ([goldCost] gold) = [unitType] birliğine yükseltin ([goldCost] altın)
  # Requires translation!
 Upgrade to [unitType]\n([goldCost] gold, [resources]) = 
- # Requires translation!
-Transform to [unitType] = 
+Transform to [unitType] = [unitType] birliğine dönüştür
  # Requires translation!
 Transform to [unitType]\n([resources]) = 
 Found city = Şehir kur
@@ -1364,8 +1159,7 @@ Resume = Devam et
 Cannot resume game! = Oyuna devam edilemiyor!
 Not enough memory on phone to load game! = Telefonda oyunu yükleyemeye yetecek kadar hafıza yok!
 Quickstart = Hızlı Başla
- # Requires translation!
-Cannot start game with the default new game parameters! = 
+Cannot start game with the default new game parameters! = Oyunu standart yeni oyun parametreleriyle başlatamıyoruz!
 Victory status = Zafer durumu
 Social policies = Sosyal politikalar
 Community = Topluluk


### PR DESCRIPTION
Changelog
-Fixed a few words and added some stuff in #Diplomacy,Trade,Nations segment -Fully translated New Game Screen 
-Fully translated Multiplayer segment
--Fixed some badly translated words in multiplayer that lacked context. For example İstifa etmek shouldnt be used in a civlike battle context. Correct term for it is Geri cekilmek. 
-Fully translated Map Editor
-Fully translated Labels/Messages
-Fully translated Map Tool Names
-Fully translated Save Game Menu
-Fully translated Options-About tab-Display tab-graphics ui etc subgroup parts -Fully translated Visual hints subgroup
-Fully translated Gameplay tab
-Fully translated Advanced tab
-Fully translated Notifications tab
-Translated Trigger effects
-Translated Trigger causes
-Partially translated World UI Screen

Currently from 30 to 1094 are fully translated into Turkish within this changelog