### PR TITLE
Pedia pixel units

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -748,6 +748,8 @@ Reset =
 Show zoom buttons in world screen = 
 Experimental Demographics scoreboard = 
 
+Size of Unitset art in Civilopedia = 
+
 ### Visual Hints subgroup
 
 Visual Hints = 

--- a/core/src/com/unciv/models/metadata/GameSettings.kt
+++ b/core/src/com/unciv/models/metadata/GameSettings.kt
@@ -134,6 +134,9 @@ class GameSettings {
     enum class NationPickerListMode { Icons, List }
     var nationPickerListMode = NationPickerListMode.List
 
+    /** Size of automatic display of UnitSet art in Civilopedia - 0 to disable */
+    var pediaUnitArtSize = 0f
+
     /** used to migrate from older versions of the settings */
     var version: Int? = null
 

--- a/core/src/com/unciv/ui/objectdescriptions/BaseUnitDescriptions.kt
+++ b/core/src/com/unciv/ui/objectdescriptions/BaseUnitDescriptions.kt
@@ -211,15 +211,12 @@ object BaseUnitDescriptions {
      */
     // Note: By popular request (this is a simple variant of one of the ideas in #10175)
     private fun ArrayList<FormattedLine>.addPixelUnitImage(baseUnit: BaseUnit) {
-        // These are usually off-center within their bounding box, which looks bad. A correction
-        // would need to detect widths of transparent borders and re-map a smaller TextureRegion
-        // with different coords than the atlas file says...
         if (baseUnit.civilopediaText.any { it.extraImage.isNotEmpty() }) return
         val settings = GUI.getSettings()
         if (settings.unitSet.isNullOrEmpty() || settings.pediaUnitArtSize < 1f) return
         val imageName = "TileSets/${settings.unitSet}/Units/${baseUnit.name}"
         if (!ImageGetter.imageExists(imageName)) return  // Some units don't have Unit art (e.g. nukes)
-        add(FormattedLine(extraImage = imageName, imageSize = settings.pediaUnitArtSize))
+        add(FormattedLine(extraImage = imageName, imageSize = settings.pediaUnitArtSize, centered = true))
         add(FormattedLine(separator = true, color = "#7f7f7f"))
     }
 

--- a/core/src/com/unciv/ui/objectdescriptions/BaseUnitDescriptions.kt
+++ b/core/src/com/unciv/ui/objectdescriptions/BaseUnitDescriptions.kt
@@ -2,7 +2,10 @@ package com.unciv.ui.objectdescriptions
 
 import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.scenes.scene2d.ui.Table
+import com.unciv.GUI
 import com.unciv.logic.city.City
+import com.unciv.models.metadata.GameSettings
+import com.unciv.models.ruleset.IRulesetObject
 import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.ruleset.unique.Unique
 import com.unciv.models.ruleset.unique.UniqueFlag
@@ -14,11 +17,10 @@ import com.unciv.models.stats.Stat
 import com.unciv.models.translations.tr
 import com.unciv.ui.components.Fonts
 import com.unciv.ui.components.extensions.getConsumesAmountString
-import com.unciv.ui.components.extensions.toPercent
+import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.screens.basescreen.BaseScreen
 import com.unciv.ui.screens.civilopediascreen.FormattedLine
 import com.unciv.ui.screens.civilopediascreen.MarkupRenderer
-import kotlin.math.pow
 
 object BaseUnitDescriptions {
 
@@ -73,6 +75,9 @@ object BaseUnitDescriptions {
 
     fun getCivilopediaTextLines(baseUnit: BaseUnit, ruleset: Ruleset): List<FormattedLine> {
         val textList = ArrayList<FormattedLine>()
+
+        // Potentially show pixel unit on top (other civilopediaText is handled by the caller)
+        textList.addPixelUnitImage(baseUnit)
 
         // Don't call baseUnit.getType() here - coming from the main menu baseUnit isn't fully initialized
         val unitTypeLink = ruleset.unitTypes[baseUnit.unitType]?.makeLink() ?: ""
@@ -197,6 +202,25 @@ object BaseUnitDescriptions {
         }
 
         return textList
+    }
+
+    /** Show Pixel Unit Art for the unit.
+     *  * _Unless_ the mod already uses [extraImage][FormattedLine.extraImage] in the unit's [civilopediaText][IRulesetObject.civilopediaText]
+     *  * _Unless_ user has selected no [unitSet][GameSettings.unitSet]
+     *  * For units with era or style variants, only the default is shown (todo: extend FormattedLine with slideshow capability)
+     */
+    // Note: By popular request (this is a simple variant of one of the ideas in #10175)
+    private fun ArrayList<FormattedLine>.addPixelUnitImage(baseUnit: BaseUnit) {
+        // These are usually off-center within their bounding box, which looks bad. A correction
+        // would need to detect widths of transparent borders and re-map a smaller TextureRegion
+        // with different coords than the atlas file says...
+        if (baseUnit.civilopediaText.any { it.extraImage.isNotEmpty() }) return
+        val settings = GUI.getSettings()
+        if (settings.unitSet.isNullOrEmpty() || settings.pediaUnitArtSize < 1f) return
+        val imageName = "TileSets/${settings.unitSet}/Units/${baseUnit.name}"
+        if (!ImageGetter.imageExists(imageName)) return  // Some units don't have Unit art (e.g. nukes)
+        add(FormattedLine(extraImage = imageName, imageSize = settings.pediaUnitArtSize))
+        add(FormattedLine(separator = true, color = "#7f7f7f"))
     }
 
     @Suppress("RemoveExplicitTypeArguments")  // for faster IDE - inferring sequence types can be slow

--- a/core/src/com/unciv/ui/popups/options/DisplayTab.kt
+++ b/core/src/com/unciv/ui/popups/options/DisplayTab.kt
@@ -12,18 +12,18 @@ import com.unciv.models.metadata.ScreenSize
 import com.unciv.models.skins.SkinCache
 import com.unciv.models.tilesets.TileSetCache
 import com.unciv.models.translations.tr
+import com.unciv.ui.components.TranslatedSelectBox
 import com.unciv.ui.components.UncivSlider
 import com.unciv.ui.components.WrappableLabel
 import com.unciv.ui.components.extensions.addSeparator
 import com.unciv.ui.components.extensions.brighten
-import com.unciv.ui.components.input.onChange
-import com.unciv.ui.components.input.onClick
 import com.unciv.ui.components.extensions.toLabel
 import com.unciv.ui.components.extensions.toTextButton
+import com.unciv.ui.components.input.onChange
+import com.unciv.ui.components.input.onClick
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.popups.ConfirmPopup
 import com.unciv.ui.screens.basescreen.BaseScreen
-import com.unciv.ui.components.TranslatedSelectBox
 import com.unciv.ui.screens.worldscreen.NotificationsScroll
 import com.unciv.utils.Display
 import com.unciv.utils.ScreenMode
@@ -71,6 +71,7 @@ fun displayTab(
     addResetTutorials(this, settings)
     optionsPopup.addCheckbox(this, "Show zoom buttons in world screen", settings.showZoomButtons, true) { settings.showZoomButtons = it }
     optionsPopup.addCheckbox(this, "Experimental Demographics scoreboard", settings.useDemographics, true) { settings.useDemographics = it }
+    addPediaUnitArtSizeSlider(this, settings, optionsPopup.selectBoxMinWidth)
 
     addSeparator()
     add("Visual Hints".toLabel(fontSize = 24)).colspan(2).row()
@@ -157,6 +158,19 @@ private fun addUnitIconAlphaSlider(table: Table, settings: GameSettings, selectB
         GUI.setUpdateWorldOnNextRender()
     }
     table.add(unitIconAlphaSlider).minWidth(selectBoxMinWidth).pad(10f).row()
+}
+
+private fun addPediaUnitArtSizeSlider(table: Table, settings: GameSettings, selectBoxMinWidth: Float) {
+    table.add("Size of Unitset art in Civilopedia".toLabel()).left().fillX()
+
+    val unitArtSizeSlider = UncivSlider(
+        0f, 360f, 1f, initial = settings.pediaUnitArtSize
+    ) {
+        settings.pediaUnitArtSize = it
+        GUI.setUpdateWorldOnNextRender()
+    }
+    unitArtSizeSlider.setSnapToValues(floatArrayOf(0f, 32f, 48f, 64f, 96f, 120f, 180f, 240f, 360f), 60f)
+    table.add(unitArtSizeSlider).minWidth(selectBoxMinWidth).pad(10f).row()
 }
 
 private fun addScreenModeSelectBox(table: Table, settings: GameSettings, selectBoxMinWidth: Float) {

--- a/core/src/com/unciv/ui/screens/civilopediascreen/FormattedLine.kt
+++ b/core/src/com/unciv/ui/screens/civilopediascreen/FormattedLine.kt
@@ -245,8 +245,11 @@ class FormattedLine (
                         ImageGetter.getExternalImage("$extraImage.jpg")
                     else -> return table
                 }
-                val width = if (imageSize.isNaN()) labelWidth else imageSize
-                val height = width * image.height / image.width
+                // limit larger cordinate to a given max size
+                val maxSize = if (imageSize.isNaN()) labelWidth else imageSize
+                val (width, height) = if (image.width > image.height)
+                        maxSize to maxSize * image.height / image.width
+                    else maxSize * image.width / image.height to maxSize
                 table.add(image).size(width, height)
             } catch (exception: Exception) {
                 Log.error("Exception while rendering civilopedia text", exception)

--- a/docs/Modders/Mod-file-structure/5-Miscellaneous-JSON-files.md
+++ b/docs/Modders/Mod-file-structure/5-Miscellaneous-JSON-files.md
@@ -296,21 +296,21 @@ An example of the format is:
 
 List of attributes - note not all combinations are valid:
 
-| Attribute | Type | Description |
-| --------- | ---- | ----------- |
-|`text`|String|Text to display.|
-|`link`|String|Create link and icon, format: Category/Name or _external_ link ('http://','https://','mailto:').|
-|`icon`|String|Show icon without linking, format: Category/Name.|
-|`extraImage`|String|Display an Image instead of text. Can be a path found in a texture atlas or or the name of a png or jpg in the ExtraImages folder.|
-|`imageSize`|Float|Width in world units of the [extraImage], height is calculated preserving aspect ratio. Defaults to available width.|
-|`header`|Integer|Header level. 1 means double text size and decreases from there.|
-|`size`|Integer|Text size, default is 18. Use `size` or `header` but not both.|
-|`indent`|Integer|Indent level. 0 means text will follow icons, 1 aligns to the right of all icons, each further step is 30 units.|
-|`padding`|Float|Vertical padding between rows, defaults to 5 units.|
-|`color`|String|Sets text color, accepts names or 6/3-digit web colors (e.g. #FFA040).|
-|`separator`|Boolean|Renders a separator line instead of text. Can be combined only with `color` and `size` (line width, default 2).|
-|`starred`|Boolean|Decorates text with a star icon - if set, it receives the `color` instead of the text.|
-|`centered`|Boolean|Centers the line (and turns off automatic wrap).|
+| Attribute    | Type    | Description                                                                                                                         |
+|--------------|---------|-------------------------------------------------------------------------------------------------------------------------------------|
+| `text`       | String  | Text to display.                                                                                                                    |
+| `link`       | String  | Create link and icon, format: Category/Name or _external_ link ('http://','https://','mailto:').                                    |
+| `icon`       | String  | Show icon without linking, format: Category/Name.                                                                                   |
+| `extraImage` | String  | Display an Image instead of text. Can be a path found in a texture atlas or or the name of a png or jpg in the ExtraImages folder.  |
+| `imageSize`  | Float   | Size in world units of the [extraImage], the smaller coordinate is calculated preserving aspect ratio. Defaults to available width. |
+| `header`     | Integer | Header level. 1 means double text size and decreases from there.                                                                    |
+| `size`       | Integer | Text size, default is 18. Use `size` or `header` but not both.                                                                      |
+| `indent`     | Integer | Indent level. 0 means text will follow icons, 1 aligns to the right of all icons, each further step is 30 units.                    |
+| `padding`    | Float   | Vertical padding between rows, defaults to 5 units.                                                                                 |
+| `color`      | String  | Sets text color, accepts names or 6/3-digit web colors (e.g. #FFA040).                                                              |
+| `separator`  | Boolean | Renders a separator line instead of text. Can be combined only with `color` and `size` (line width, default 2).                     |
+| `starred`    | Boolean | Decorates text with a star icon - if set, it receives the `color` instead of the text.                                              |
+| `centered`   | Boolean | Centers the line (and turns off automatic wrap).                                                                                    |
 
 The lines from json will 'surround' the automatically generated lines such that the latter are inserted just above the first json line carrying a link, if any. If no json lines have links, they will be inserted between the automatic title and the automatic info. This method may, however, change in the future.
 

--- a/docs/Modders/Mod-file-structure/5-Miscellaneous-JSON-files.md
+++ b/docs/Modders/Mod-file-structure/5-Miscellaneous-JSON-files.md
@@ -310,7 +310,7 @@ List of attributes - note not all combinations are valid:
 | `color`      | String  | Sets text color, accepts names or 6/3-digit web colors (e.g. #FFA040).                                                              |
 | `separator`  | Boolean | Renders a separator line instead of text. Can be combined only with `color` and `size` (line width, default 2).                     |
 | `starred`    | Boolean | Decorates text with a star icon - if set, it receives the `color` instead of the text.                                              |
-| `centered`   | Boolean | Centers the line (and turns off automatic wrap).                                                                                    |
+| `centered`   | Boolean | Centers the line (and turns off automatic wrap). For an `extraImage`, turns on crop-to-content to equalize transparent borders.     |
 
 The lines from json will 'surround' the automatically generated lines such that the latter are inserted just above the first json line carrying a link, if any. If no json lines have links, they will be inserted between the automatic title and the automatic info. This method may, however, change in the future.
 


### PR DESCRIPTION
Partial simplified #10175
See commit history
Screenshots contained in issue comments apply, except they didn't have the cropping code yet, so this now has better centering/padding than shown there.

Big Questions:
* Is that "crop off transparent borders" part too over the top? Too little gain for that much complexity?
* Where should that slider go? Which "Display" tab section? I chose "UI". Or Advanced tab?

Open ideas:
* Era/style variants - but how to design new extensions into the already loaded FormattedLine API. I had a click-to-cycle kludge working and removed it - it was just texture region cache lookups, no actual steering from BaseUnitDescriptions. But a slideshow using fade actions _would_ look cool...
* Moddable control over what civlopediaText goes above, what below the generated lines. Waiting for the mega-simple idea where to add that metadata.

@letstalkaboutdune - AbsoluteUnits look good enough with this, without your art I would have ditched the experiment. Only Gatling Gun isn't centered nicely - and gimp confirms some almost-transparent pixels on the left are not entirely transparent... Perfect proof that crop code works correctly 😸 
@carriontrooper - Thanks for part of the inspiration