### PR TITLE
Fix top bar layout

### DIFF
--- a/core/src/com/unciv/ui/screens/worldscreen/topbar/WorldScreenTopBar.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/topbar/WorldScreenTopBar.kt
@@ -102,6 +102,7 @@ class WorldScreenTopBar(internal val worldScreen: WorldScreen) : Table() {
     /** Performs the layout tricks mentioned in the class Kdoc */
     private fun updateLayout() {
         val targetWidth = stage.width
+        val statsWidth = statsTable.minWidth
         val resourceWidth = resourceTable.minWidth
         val overviewWidth = overviewButton.minWidth
         val overviewHeight = overviewButton.minHeight
@@ -121,7 +122,6 @@ class WorldScreenTopBar(internal val worldScreen: WorldScreen) : Table() {
         layout()  // force rowHeight calculation - validate is not enough - Table quirks
         val statsRowHeight = getRowHeight(0)
         val baseHeight = statsRowHeight + getRowHeight(1)
-        val statsWidth = statsTable.width
 
         fun addFillers(fillerHeight: Float) {
             add(leftFiller).size(selectedCivWidth, fillerHeight + gapFillingExtraHeight)

--- a/core/src/com/unciv/ui/screens/worldscreen/topbar/WorldScreenTopBarResources.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/topbar/WorldScreenTopBarResources.kt
@@ -24,12 +24,29 @@ internal class WorldScreenTopBarResources(topbar: WorldScreenTopBar) : Table() {
     private val resourceActors = ArrayList<ResourceActors>(12)
     private val resourcesWrapper = Table()
 
+    // Note: For a proper functioning of the "shift floating buttons down when cramped" feature, it is
+    // important that this entire Widget has only the bare minimum padding to its left and right.
+    // #7193 did let the resources and turn label swap places, with the side effect of the "first resource getting extra left padding"
+    // now being on the outside - the buttons moved out of the way despite there being visually ample space.
+
+    private companion object {
+        const val defaultPad = 5f
+        const val extraPadBetweenLabelAndResources = 20f
+        const val bottomPad = 10f
+        const val extraPadBetweenResources = 5f
+        const val outerHorizontalPad = 2f
+        const val iconSize = 20f
+        const val resourceAmountDescentTweak = 3f
+    }
+
     init {
-        resourcesWrapper.defaults().pad(5f, 5f, 10f, 5f)
+        defaults().space(extraPadBetweenLabelAndResources)
+            .pad(defaultPad, outerHorizontalPad, bottomPad, outerHorizontalPad)
+
+        resourcesWrapper.defaults().space(defaultPad)
         resourcesWrapper.touchable = Touchable.enabled
 
         val worldScreen = topbar.worldScreen
-
         turnsLabel.onClick {
             if (worldScreen.selectedCiv.isLongCountDisplay()) {
                 val gameInfo = worldScreen.selectedCiv.gameInfo
@@ -45,29 +62,32 @@ internal class WorldScreenTopBarResources(topbar: WorldScreenTopBar) : Table() {
         val strategicResources = worldScreen.gameInfo.ruleset.tileResources.values
             .filter { it.resourceType == ResourceType.Strategic && !it.hasUnique(UniqueType.CityResource) }
         for (resource in strategicResources) {
-            val resourceImage = ImageGetter.getResourcePortrait(resource.name, 20f)
+            val resourceImage = ImageGetter.getResourcePortrait(resource.name, iconSize)
             val resourceLabel = "0".toLabel()
             resourceActors += ResourceActors(resource, resourceLabel, resourceImage)
         }
+
+        add(turnsLabel)
 
         // in case the icons are configured higher than a label, we add a dummy - height will be measured once before it's updated
         if (resourceActors.isNotEmpty()) {
             resourcesWrapper.add(resourceActors[0].icon)
             add(resourcesWrapper)
         }
-
-        add(turnsLabel).pad(5f, 5f, 10f, 5f)
     }
+
     fun update(civInfo: Civilization) {
         val yearText = YearTextUtil.toYearText(
             civInfo.gameInfo.getYear(), civInfo.isLongCountDisplay()
         )
         turnsLabel.setText(Fonts.turn + "" + civInfo.gameInfo.turns + " | " + yearText)
+
         resourcesWrapper.clearChildren()
-        var firstPadLeft = 20f  // We want a distance from the turns entry to the first resource, but only if any resource is displayed
         val civResources = civInfo.getCivResourcesByName()
         val civResourceSupply = civInfo.getCivResourceSupply()
-        for ((resource, label, icon) in resourceActors) {
+        for ((index, resourceActors) in resourceActors.withIndex()) {
+            val (resource, label, icon) = resourceActors
+
             if (resource.hasUnique(UniqueType.NotShownOnWorldScreen)) continue
 
             val amount = civResources[resource.name] ?: 0
@@ -76,8 +96,8 @@ internal class WorldScreenTopBarResources(topbar: WorldScreenTopBar) : Table() {
                 && amount == 0) // You can trade for resources you cannot process yourself yet
                 continue
 
-            resourcesWrapper.add(icon).padLeft(firstPadLeft).padRight(0f)
-            firstPadLeft = 5f
+            resourcesWrapper.add(icon).padLeft(if (index == 0) 0f else extraPadBetweenResources)
+
             if (!resource.isStockpiled())
                 label.setText(amount)
             else {
@@ -85,7 +105,7 @@ internal class WorldScreenTopBarResources(topbar: WorldScreenTopBar) : Table() {
                 if (perTurn == 0) label.setText(amount)
                 else label.setText("$amount (${perTurn.toStringSigned()})")
             }
-            resourcesWrapper.add(label).padTop(8f)  // digits don't have descenders, so push them down a little
+            resourcesWrapper.add(label).padTop(resourceAmountDescentTweak)  // digits don't have descenders, so push them down a little
         }
 
         pack()


### PR DESCRIPTION
Part of #10169

<details><summary>After-screenshot (for before, see issue)</summary>

![image](https://github.com/yairm210/Unciv/assets/63000004/a5bb2c2c-e147-4086-aaea-63f956acf972)

</details>

Makes the "Menu+Civ" and "Overview" buttons move back up earlier, or at all (the normal in-line position was blocked due to reading a wrong width).
Swaps back what #7193 swapped - turns was to left of resources originally, looks better IMHO
Restores the wider visual separation between turns label and resources - also the 7193 PR

Note - the dancing baseline for in-text ruleset icons ~seems Windows-only. I can fix easily by reading AWT FontMetrics and _respecting_ the descent value in there when drawing the actors - BUT - the situation is entirely different on Linux _and_ Android (better not ask AWT there, and Android has an entirely different FontMetrics from the Paint API - all very complicated). I'll need to understand first why their _size_ is (as of current master) so markedly different on Windows vs. Linux and Android, and that may take more effort than my lazy old soul can muster these days. A statistic (discrap poll?) may help - maybe not all Windows users see that much baseline drop, maybe other Linux distros look different,... ...?~ ***Edit***: Oversight: I had the Window box set to "Font Scale" = 1.25 but not the other hosts. That alone makes that analysis invalid. It probably *is* necessary to have getPixmapFromActor (and the one for 'symbols' too) read and respect FontMetrics to fix that, but the 'how exactly' is entirely open.