### PR TITLE
Get rid of old religion style actions!!!

### DIFF
--- a/android/assets/jsons/Civ V - Gods & Kings/Buildings.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Buildings.json
@@ -458,7 +458,8 @@
 		"greatPersonPoints": {"Great Engineer": 1},
 		"isWonder": true,
 		"uniques": ["Gain a free [Mosque] [in this city]", "Hidden when religion is disabled",
-			"[Missionary] units built [in this city] can [Spread Religion] [1] extra times", "[Great Prophet] units built [in this city] can [Spread Religion] [1] extra times"],
+            "All newly-trained [Missionary] units [in this city] receive the [Devout] promotion",
+            "All newly-trained [Great Prophet] units [in this city] receive the [Devout] promotion"],
 		"requiredTech": "Theology",
 		"quote": "'With the magnificence of eternity before us, let time, with all its fluctuations, dwindle into its own littleness.' - Thomas Chalmers"
 	},

--- a/android/assets/jsons/Civ V - Gods & Kings/UnitPromotions.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/UnitPromotions.json
@@ -707,6 +707,10 @@
 		"name": "Home Sweet Home", // only for Mehal Sefari and subsequent upgrades
 		"uniques": ["[+30]% Strength decreasing with distance from the capital"]
 	},
+    {
+        "name": "Devout",
+        "uniques": ["Can Spread Religion <[1] additional time(s)>"]
+    },
 	{
 		"name": "[Mohawk Warrior] ability",
 		"uniques": ["[+33]% Strength <when fighting in [Forest] tiles>", "[+33]% Strength <when fighting in [Jungle] tiles>"]
@@ -756,6 +760,10 @@
 		"name": "[Zero] ability",
 		"uniques": ["[+33]% Strength <vs [Fighter] units>"]
 	},
+    {
+        "name": "[Chu-Ko-Nu] ability",
+        "uniques": ["[1] additional attacks per turn", "Can move after attacking"]
+    },
     {
         "name": "[Chu-Ko-Nu] ability",
         "uniques": ["[1] additional attacks per turn", "Can move after attacking"]

--- a/android/assets/jsons/Civ V - Gods & Kings/UnitPromotions.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/UnitPromotions.json
@@ -763,9 +763,5 @@
     {
         "name": "[Chu-Ko-Nu] ability",
         "uniques": ["[1] additional attacks per turn", "Can move after attacking"]
-    },
-    {
-        "name": "[Chu-Ko-Nu] ability",
-        "uniques": ["[1] additional attacks per turn", "Can move after attacking"]
     }
 ]

--- a/android/assets/jsons/Civ V - Gods & Kings/Units.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Units.json
@@ -1636,7 +1636,7 @@
 		"unitType": "Civilian",
 		"uniques": [
             "Can instantly construct a [Holy site] improvement <by consuming this unit> <if it hasn't used other actions yet>",
-            "Can [Spread Religion] [4] times",
+            "Can Spread Religion <[4] times>",
 			"Removes other religions when spreading religion",
             "May found a religion",
             "May enhance a religion",
@@ -1675,7 +1675,9 @@
 	{
 		"name": "Missionary",
 		"unitType": "Civilian",
-		"uniques": ["Can [Spread Religion] [2] times", "May enter foreign tiles without open borders, but loses [250] religious strength each turn it ends there",
+		"uniques": [
+            "Can Spread Religion <[2] times>",
+            "May enter foreign tiles without open borders, but loses [250] religious strength each turn it ends there",
 			"Can be purchased with [Faith] [in all cities in which the majority religion is a major religion]",
 			"[-1] Sight", "Unbuildable", "Religious Unit", "Hidden when religion is disabled"],
 		"movement": 4,
@@ -1685,8 +1687,8 @@
 		"name": "Inquisitor",
 		"unitType": "Civilian",
 		"uniques": ["Prevents spreading of religion to the city it is next to",
-			"Can [Remove Foreign religions from your own cities] [1] times",
-			"Can be purchased with [Faith] [in all cities in which the majority religion is an enhanced religion]",
+			"Can remove other religions from cities <in [Friendly] tiles> <once> <after which this unit is consumed>",
+			"Can be purchased with [Faith] [in all cities]",
 			"[+1] Sight", "Hidden when religion is disabled", "Unbuildable", "Religious Unit"
 		],
 		"movement": 3

--- a/android/assets/jsons/Civ V - Gods & Kings/Units.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Units.json
@@ -1688,7 +1688,7 @@
 		"unitType": "Civilian",
 		"uniques": ["Prevents spreading of religion to the city it is next to",
 			"Can remove other religions from cities <in [Friendly] tiles> <once> <after which this unit is consumed>",
-			"Can be purchased with [Faith] [in all cities]",
+            "Can be purchased with [Faith] [in all cities in which the majority religion is a major religion]",
 			"[+1] Sight", "Hidden when religion is disabled", "Unbuildable", "Religious Unit"
 		],
 		"movement": 3

--- a/android/assets/jsons/Civ V - Vanilla/Units.json
+++ b/android/assets/jsons/Civ V - Vanilla/Units.json
@@ -1294,7 +1294,7 @@
 		"unitType": "Civilian",
 		"uniques": [
             "Can instantly construct a [Holy site] improvement <by consuming this unit> <if it hasn't used other actions yet>",
-            "Can [Spread Religion] [4] times",
+            "Can Spread Religion <[4] times>",
 			"Removes other religions when spreading religion",
             "May found a religion",
             "May enhance a religion",
@@ -1333,7 +1333,9 @@
 	{
 		"name": "Missionary",
 		"unitType": "Civilian",
-		"uniques": ["Can [Spread Religion] [2] times", "May enter foreign tiles without open borders, but loses [250] religious strength each turn it ends there",
+		"uniques": [
+            "Can Spread Religion <[2] times>",
+            "May enter foreign tiles without open borders, but loses [250] religious strength each turn it ends there",
 			"Can be purchased with [Faith] [in all cities in which the majority religion is a major religion]",
 			"[-1] Sight", "Unbuildable", "Religious Unit", "Hidden when religion is disabled"],
 		"movement": 4,
@@ -1343,7 +1345,7 @@
 		"name": "Inquisitor",
 		"unitType": "Civilian",
 		"uniques": ["Prevents spreading of religion to the city it is next to",
-			"Can [Remove Foreign religions from your own cities] [1] times",
+            "Can remove other religions from cities <in [Friendly] tiles> <once> <after which this unit is consumed>",
 			"Can be purchased with [Faith] [in all cities in which the majority religion is an enhanced religion]",
 			"[+1] Sight", "Hidden when religion is disabled", "Unbuildable", "Religious Unit"
 		],

--- a/core/src/com/unciv/logic/automation/civilization/ReligionAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/ReligionAutomation.kt
@@ -135,8 +135,12 @@ object ReligionAutomation {
         if (validCitiesToBuy.isEmpty()) return
 
         val citiesWithBonusCharges = validCitiesToBuy.filter { city ->
-            // To be replaced by special promotion
             city.getMatchingUniques(UniqueType.UnitStartingActions).any { it.params[2] == Constants.spreadReligion }
+                || city.getMatchingUniques(UniqueType.UnitStartingPromotions).any {
+                    val promotionName = it.params[2]
+                    val promotion = city.getRuleset().unitPromotions[promotionName] ?: return@any false
+                    promotion.hasUnique(UniqueType.CanSpreadReligion)
+            }
         }
         val holyCity = validCitiesToBuy.firstOrNull { it.isHolyCityOf(civInfo.religionManager.religion!!.name) }
 

--- a/core/src/com/unciv/logic/automation/unit/SpecificUnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/SpecificUnitAutomation.kt
@@ -11,7 +11,6 @@ import com.unciv.logic.civilization.Civilization
 import com.unciv.logic.civilization.diplomacy.DiplomaticModifiers
 import com.unciv.logic.map.mapunit.MapUnit
 import com.unciv.logic.map.tile.Tile
-import com.unciv.models.UnitAction
 import com.unciv.models.UnitActionType
 import com.unciv.models.ruleset.Building
 import com.unciv.models.ruleset.unique.LocalUniqueCache
@@ -351,7 +350,8 @@ object SpecificUnitAutomation {
         unit.movement.headTowards(destination)
 
         if (unit.getTile() in city.getTiles() && unit.civ.religionManager.maySpreadReligionNow(unit)) {
-            doReligiousAction(unit, unit.getTile())
+            val action = UnitActions.getUnitActions(unit).firstOrNull { it.type == UnitActionType.SpreadReligion }?.action
+            if (action != null) action()
         }
     }
 
@@ -407,7 +407,8 @@ object SpecificUnitAutomation {
         unit.movement.headTowards(destination)
 
         if (cityToConvert != null && unit.getTile().getCity() == destination.getCity()) {
-            doReligiousAction(unit, destination)
+            val action = UnitActions.getUnitActions(unit).firstOrNull { it.type == UnitActionType.RemoveHeresy }?.action
+            if (action != null) action()
         }
     }
 
@@ -648,10 +649,4 @@ object SpecificUnitAutomation {
         UnitActionsReligion.getEnhanceReligionAction(unit)()
     }
 
-    private fun doReligiousAction(unit: MapUnit, destination: Tile) {
-        val religiousActions = ArrayList<UnitAction>()
-        UnitActionsReligion.addActionsWithLimitedUses(unit, religiousActions, destination)
-        if (religiousActions.firstOrNull()?.action == null) return
-        religiousActions.first().action!!.invoke()
-    }
 }

--- a/core/src/com/unciv/logic/automation/unit/SpecificUnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/SpecificUnitAutomation.kt
@@ -340,8 +340,7 @@ object SpecificUnitAutomation {
         unit.movement.headTowards(destination)
 
         if (unit.getTile() in city.getTiles() && unit.civ.religionManager.maySpreadReligionNow(unit)) {
-            val action = UnitActions.getUnitActions(unit).firstOrNull { it.type == UnitActionType.SpreadReligion }?.action
-            if (action != null) action()
+            UnitActions.invokeUnitAction(unit, UnitActionType.SpreadReligion)
         }
     }
 
@@ -397,8 +396,7 @@ object SpecificUnitAutomation {
         unit.movement.headTowards(destination)
 
         if (cityToConvert != null && unit.getTile().getCity() == destination.getCity()) {
-            val action = UnitActions.getUnitActions(unit).firstOrNull { it.type == UnitActionType.RemoveHeresy }?.action
-            if (action != null) action()
+            UnitActions.invokeUnitAction(unit, UnitActionType.RemoveHeresy)
         }
     }
 

--- a/core/src/com/unciv/logic/civilization/managers/ReligionManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/ReligionManager.kt
@@ -445,6 +445,9 @@ class ReligionManager : IsPartOfGameInfoSerialization {
     fun maySpreadReligionAtAll(missionary: MapUnit): Boolean {
         if (!civInfo.isMajorCiv()) return false // Only major civs
         if (!civInfo.gameInfo.isReligionEnabled()) return false // No religion, no spreading
+
+        val religion = missionary.civ.gameInfo.religions[missionary.religion] ?: return false
+        if (religion.isPantheon()) return false
         val spreadReligionUniques = missionary.getMatchingUniques(UniqueType.CanSpreadReligion)
         if (!missionary.canDoLimitedAction(Constants.spreadReligion)
             && (spreadReligionUniques.none()

--- a/core/src/com/unciv/logic/civilization/managers/ReligionManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/ReligionManager.kt
@@ -448,10 +448,8 @@ class ReligionManager : IsPartOfGameInfoSerialization {
 
         val religion = missionary.civ.gameInfo.religions[missionary.religion] ?: return false
         if (religion.isPantheon()) return false
-        val spreadReligionUniques = missionary.getMatchingUniques(UniqueType.CanSpreadReligion)
         if (!missionary.canDoLimitedAction(Constants.spreadReligion)
-            && (spreadReligionUniques.none()
-                || UnitActionModifiers.usagesLeft(missionary, spreadReligionUniques.first()) == 0)) return false
+            && UnitActionModifiers.getUsableUnitActionUniques(missionary, UniqueType.CanSpreadReligion).any()) return false
         return true
     }
 

--- a/core/src/com/unciv/logic/civilization/managers/ReligionManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/ReligionManager.kt
@@ -13,7 +13,7 @@ import com.unciv.models.ruleset.unique.UniqueTriggerActivation
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.ruleset.unit.BaseUnit
 import com.unciv.ui.components.extensions.toPercent
-import com.unciv.ui.screens.worldscreen.unit.actions.UnitActions
+import com.unciv.ui.screens.worldscreen.unit.actions.UnitActionModifiers
 import java.lang.Integer.min
 import kotlin.random.Random
 
@@ -451,7 +451,7 @@ class ReligionManager : IsPartOfGameInfoSerialization {
         val spreadReligionUniques = missionary.getMatchingUniques(UniqueType.CanSpreadReligion)
         if (!missionary.canDoLimitedAction(Constants.spreadReligion)
             && (spreadReligionUniques.none()
-                || UnitActions.usagesLeft(missionary, spreadReligionUniques.first()) == 0)) return false
+                || UnitActionModifiers.usagesLeft(missionary, spreadReligionUniques.first()) == 0)) return false
         return true
     }
 

--- a/core/src/com/unciv/logic/civilization/managers/ReligionManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/ReligionManager.kt
@@ -13,7 +13,7 @@ import com.unciv.models.ruleset.unique.UniqueTriggerActivation
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.ruleset.unit.BaseUnit
 import com.unciv.ui.components.extensions.toPercent
-import java.lang.Integer.max
+import com.unciv.ui.screens.worldscreen.unit.actions.UnitActions
 import java.lang.Integer.min
 import kotlin.random.Random
 
@@ -445,7 +445,10 @@ class ReligionManager : IsPartOfGameInfoSerialization {
     fun maySpreadReligionAtAll(missionary: MapUnit): Boolean {
         if (!civInfo.isMajorCiv()) return false // Only major civs
         if (!civInfo.gameInfo.isReligionEnabled()) return false // No religion, no spreading
-        if (!missionary.canDoLimitedAction(Constants.spreadReligion)) return false
+        val spreadReligionUniques = missionary.getMatchingUniques(UniqueType.CanSpreadReligion)
+        if (!missionary.canDoLimitedAction(Constants.spreadReligion)
+            && (spreadReligionUniques.none()
+                || UnitActions.usagesLeft(missionary, spreadReligionUniques.first()) == 0)) return false
         return true
     }
 

--- a/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
@@ -499,6 +499,7 @@ enum class UniqueParameterType(
     },
 
     /** For untyped "Can [] [] times" unique */
+    @Deprecated("As of 4.8.9")
     Action("action", Constants.spreadReligion, "An action that a unit can perform. Currently, there are only two actions part of this: 'Spread Religion' and 'Remove Foreign religions from your own cities'", "Religious Action Filters") {
         private val knownValues = setOf(Constants.spreadReligion, Constants.removeHeresy)
         override fun getErrorSeverity(

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -219,7 +219,7 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
     ReligionSpreadDistance("Religion naturally spreads to cities [amount] tiles away", UniqueTarget.Global, UniqueTarget.FollowerBelief),
     MayNotGenerateGreatProphet("May not generate great prophet equivalents naturally", UniqueTarget.Global),
     FaithCostOfGreatProphetChange("[relativeAmount]% Faith cost of generating Great Prophet equivalents", UniqueTarget.Global),
-    @Deprecated("As of 4.8.9", ReplaceWith("Promotion-granting ability on the religion"))
+    @Deprecated("As of 4.8.9", ReplaceWith("All newly-trained [baseUnitFilter] units [cityFilter] receive the [Devout] promotion"))
     UnitStartingActions("[baseUnitFilter] units built [cityFilter] can [action] [amount] extra times", UniqueTarget.Global, UniqueTarget.FollowerBelief),
 
     /// Things you get at the start of the game

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -219,6 +219,7 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
     ReligionSpreadDistance("Religion naturally spreads to cities [amount] tiles away", UniqueTarget.Global, UniqueTarget.FollowerBelief),
     MayNotGenerateGreatProphet("May not generate great prophet equivalents naturally", UniqueTarget.Global),
     FaithCostOfGreatProphetChange("[relativeAmount]% Faith cost of generating Great Prophet equivalents", UniqueTarget.Global),
+    @Deprecated("As of 4.8.9", ReplaceWith("Promotion-granting ability on the religion"))
     UnitStartingActions("[baseUnitFilter] units built [cityFilter] can [action] [amount] extra times", UniqueTarget.Global, UniqueTarget.FollowerBelief),
 
     /// Things you get at the start of the game
@@ -326,7 +327,12 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
 
     MayParadrop("May Paradrop up to [amount] tiles from inside friendly territory", UniqueTarget.Unit),
     CanAirsweep("Can perform Air Sweep", UniqueTarget.Unit),
+
+    @Deprecated("As of 4.8.9", ReplaceWith("Can Spread Religion <[amount] times> <after which this unit is consumed>\" OR \"Can remove other religions from cities <in [Friendly] tiles> <once> <after which this unit is consumed>"))
     CanActionSeveralTimes("Can [action] [amount] times", UniqueTarget.Unit),
+    CanSpreadReligion("Can Spread Religion", UniqueTarget.Unit),
+    CanRemoveHeresy("Can remove other religions from cities", UniqueTarget.Unit),
+
     CanSpeedupConstruction("Can speed up construction of a building", UniqueTarget.Unit),
     CanSpeedupWonderConstruction("Can speed up the construction of a wonder", UniqueTarget.Unit),
     CanHurryResearch("Can hurry technology research", UniqueTarget.Unit),

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionModifiers.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionModifiers.kt
@@ -16,7 +16,7 @@ object UnitActionModifiers {
     fun getUsableUnitActionUniques(unit:MapUnit, actionUniqueType: UniqueType) =
         unit.getMatchingUniques(actionUniqueType)
             .filter { it.conditionals.none { it.type == UniqueType.UnitActionExtraLimitedTimes } }
-            .filter { usagesLeft(unit, it) != 0 }
+            .filter { canUse(unit, it) }
 
     private fun getMovementPointsToUse(actionUnique: Unique): Int {
         val movementCost = actionUnique.conditionals
@@ -48,7 +48,7 @@ object UnitActionModifiers {
     }
 
     /** Returns 'null' if usages are not limited */
-    fun usagesLeft(unit: MapUnit, actionUnique: Unique): Int?{
+    private fun usagesLeft(unit: MapUnit, actionUnique: Unique): Int?{
         val usagesTotal = getMaxUsages(unit, actionUnique) ?: return null
         val usagesSoFar = unit.abilityToTimesUsed[actionUnique.placeholderText] ?: 0
         return usagesTotal - usagesSoFar

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionModifiers.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionModifiers.kt
@@ -8,6 +8,10 @@ import com.unciv.models.translations.tr
 import com.unciv.ui.components.Fonts
 
 object UnitActionModifiers {
+    fun canUse(unit: MapUnit, actionUnique: Unique): Boolean {
+        val usagesLeft = usagesLeft(unit, actionUnique)
+        return usagesLeft == null || usagesLeft > 0
+    }
 
     private fun getMovementPointsToUse(actionUnique: Unique): Int {
         val movementCost = actionUnique.conditionals

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActions.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActions.kt
@@ -320,9 +320,5 @@ object UnitActions {
         )
     }
 
-    fun canUse(unit: MapUnit, actionUnique: Unique): Boolean {
-        val usagesLeft = usagesLeft(unit, actionUnique)
-        return usagesLeft == null || usagesLeft > 0
-    }
 
 }

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActions.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActions.kt
@@ -54,7 +54,8 @@ object UnitActions {
         UnitActionsReligion.addFoundReligionAction(unit, actionList)
         UnitActionsReligion.addEnhanceReligionAction(unit, actionList)
         actionList += getImprovementConstructionActions(unit, tile)
-        UnitActionsReligion.addActionsWithLimitedUses(unit, actionList, tile)
+        UnitActionsReligion.addSpreadReligionActions(unit, actionList)
+        UnitActionsReligion.addRemoveHeresyActions(unit, actionList)
 
         addAutomateAction(unit, actionList, true)
         addTriggerUniqueActions(unit, actionList)
@@ -745,6 +746,11 @@ object UnitActions {
         val usagesTotal = getMaxUsages(unit, actionUnique) ?: return null
         val usagesSoFar = unit.abilityToTimesUsed[actionUnique.placeholderText] ?: 0
         return usagesTotal - usagesSoFar
+    }
+
+    fun canUse(unit: MapUnit, actionUnique: Unique): Boolean {
+        val usagesLeft = usagesLeft(unit, actionUnique)
+        return usagesLeft == null || usagesLeft > 0
     }
 
     fun getMaxUsages(unit: MapUnit, actionUnique: Unique): Int? {

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsFromUniques.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsFromUniques.kt
@@ -187,7 +187,7 @@ object UnitActionsFromUniques {
             // extends an existing unit action
             if (unique.conditionals.any { it.type == UniqueType.UnitActionExtraLimitedTimes }) continue
             if (!unique.isTriggerable) continue
-            if (UnitActionModifiers.usagesLeft(unit, unique) ==0) continue
+            if (!UnitActionModifiers.canUse(unit, unique)) continue
 
             val baseTitle = if (unique.isOfType(UniqueType.OneTimeEnterGoldenAgeTurns))
                 unique.placeholderText.fillPlaceholders(

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsReligion.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsReligion.kt
@@ -1,10 +1,8 @@
 package com.unciv.ui.screens.worldscreen.unit.actions
 
 import com.unciv.Constants
-import com.unciv.logic.city.City
 import com.unciv.logic.civilization.NotificationCategory
 import com.unciv.logic.map.mapunit.MapUnit
-import com.unciv.logic.map.tile.Tile
 import com.unciv.models.UnitAction
 import com.unciv.models.UnitActionType
 import com.unciv.models.ruleset.unique.UniqueType
@@ -43,22 +41,6 @@ object UnitActionsReligion {
         }
     }
 
-    fun addActionsWithLimitedUses(unit: MapUnit, actionList: ArrayList<UnitAction>, tile: Tile) {
-
-        val actionsToAdd = unit.limitedActionsUnitCanDo()
-        if (actionsToAdd.none()) return
-        if (unit.religion == null || unit.civ.gameInfo.religions[unit.religion]!!.isPantheon()) return
-        val city = tile.getCity() ?: return
-        for (action in actionsToAdd) {
-            if (!unit.abilityUsesLeft.containsKey(action)) continue
-            if (unit.abilityUsesLeft[action]!! <= 0) continue
-            when (action) {
-                Constants.spreadReligion -> addSpreadReligionActions(unit, actionList, city)
-                Constants.removeHeresy -> addRemoveHeresyActions(unit, actionList, city)
-            }
-        }
-    }
-
     private fun useActionWithLimitedUses(unit: MapUnit, action: String) {
         unit.abilityUsesLeft[action] = unit.abilityUsesLeft[action]!! - 1
         if (unit.abilityUsesLeft[action]!! <= 0) {
@@ -75,11 +57,19 @@ object UnitActionsReligion {
         return pressureAdded.toInt()
     }
 
-    private fun addSpreadReligionActions(unit: MapUnit, actionList: ArrayList<UnitAction>, city: City) {
+    fun addSpreadReligionActions(unit: MapUnit, actionList: ArrayList<UnitAction>) {
         if (!unit.civ.religionManager.maySpreadReligionAtAll(unit)) return
+        val city = unit.currentTile.getCity() ?: return
+
+        val newStyleUnique = unit.getMatchingUniques(UniqueType.CanSpreadReligion).firstOrNull()
+
+        val title = if (newStyleUnique != null)
+                UnitActions.actionTextWithSideEffects("Spread [${unit.getReligionDisplayName()!!}]", newStyleUnique, unit)
+        else "Spread [${unit.getReligionDisplayName()!!}]"
+
         actionList += UnitAction(
             UnitActionType.SpreadReligion,
-            title = "Spread [${unit.getReligionDisplayName()!!}]",
+            title = title,
             action = {
                 val followersOfOtherReligions = city.religion.getFollowersOfOtherReligionsThan(unit.religion!!)
                 for (unique in unit.getMatchingUniques(UniqueType.StatsWhenSpreading, checkCivInfoUniques = true)) {
@@ -89,20 +79,37 @@ object UnitActionsReligion {
                 if (unit.hasUnique(UniqueType.RemoveOtherReligions))
                     city.religion.removeAllPressuresExceptFor(unit.religion!!)
                 unit.currentMovement = 0f
-                useActionWithLimitedUses(unit, Constants.spreadReligion)
+
+                if (newStyleUnique != null) UnitActions.activateSideEffects(unit, newStyleUnique)
+                else useActionWithLimitedUses(unit, Constants.spreadReligion)
             }.takeIf { unit.currentMovement > 0 && unit.civ.religionManager.maySpreadReligionNow(unit) }
         )
     }
 
-    private fun addRemoveHeresyActions(unit: MapUnit, actionList: ArrayList<UnitAction>, city: City) {
+    internal fun addRemoveHeresyActions(unit: MapUnit, actionList: ArrayList<UnitAction>) {
         if (!unit.civ.gameInfo.isReligionEnabled()) return
+        if (unit.religion ==null) return
+        val city = unit.currentTile.getCity() ?: return
         if (city.civ != unit.civ) return
         // Only allow the action if the city actually has any foreign religion
         // This will almost be always due to pressure from cities close-by
         if (city.religion.getPressures().none { it.key != unit.religion!! }) return
+
+        val hasOldStyleAbility = unit.abilityUsesLeft.containsKey(Constants.removeHeresy)
+            && unit.abilityUsesLeft[Constants.removeHeresy]!! > 0
+
+        val newStyleUnique = unit.getMatchingUniques(UniqueType.CanRemoveHeresy).firstOrNull()
+        val hasNewStyleAbility = newStyleUnique != null && UnitActions.canUse(unit, newStyleUnique)
+
+        if (!hasOldStyleAbility && !hasNewStyleAbility) return
+
+        val title = if (hasNewStyleAbility)
+            UnitActions.actionTextWithSideEffects("Remove Heresy", newStyleUnique!!, unit)
+        else "Remove Heresy"
+
         actionList += UnitAction(
             UnitActionType.RemoveHeresy,
-            title = "Remove Heresy",
+            title = title,
             action = {
                 city.religion.removeAllPressuresExceptFor(unit.religion!!)
                 if (city.religion.religionThisIsTheHolyCityOf != null) {
@@ -116,6 +123,8 @@ object UnitActionsReligion {
                     }
                 }
                 unit.currentMovement = 0f
+
+                if (hasNewStyleAbility) UnitActions.activateSideEffects(unit, newStyleUnique!!)
                 useActionWithLimitedUses(unit, Constants.removeHeresy)
             }.takeIf { unit.currentMovement > 0f }
         )

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsReligion.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsReligion.kt
@@ -64,7 +64,7 @@ object UnitActionsReligion {
         val newStyleUnique = unit.getMatchingUniques(UniqueType.CanSpreadReligion).firstOrNull()
 
         val title = if (newStyleUnique != null)
-                UnitActions.actionTextWithSideEffects("Spread [${unit.getReligionDisplayName()!!}]", newStyleUnique, unit)
+                UnitActionModifiers.actionTextWithSideEffects("Spread [${unit.getReligionDisplayName()!!}]", newStyleUnique, unit)
         else "Spread [${unit.getReligionDisplayName()!!}]"
 
         actionList += UnitAction(
@@ -80,7 +80,7 @@ object UnitActionsReligion {
                     city.religion.removeAllPressuresExceptFor(unit.religion!!)
                 unit.currentMovement = 0f
 
-                if (newStyleUnique != null) UnitActions.activateSideEffects(unit, newStyleUnique)
+                if (newStyleUnique != null) UnitActionModifiers.activateSideEffects(unit, newStyleUnique)
                 else useActionWithLimitedUses(unit, Constants.spreadReligion)
             }.takeIf { unit.currentMovement > 0 && unit.civ.religionManager.maySpreadReligionNow(unit) }
         )
@@ -101,12 +101,12 @@ object UnitActionsReligion {
             && unit.abilityUsesLeft[Constants.removeHeresy]!! > 0
 
         val newStyleUnique = unit.getMatchingUniques(UniqueType.CanRemoveHeresy).firstOrNull()
-        val hasNewStyleAbility = newStyleUnique != null && UnitActions.canUse(unit, newStyleUnique)
+        val hasNewStyleAbility = newStyleUnique != null && UnitActionModifiers.canUse(unit, newStyleUnique)
 
         if (!hasOldStyleAbility && !hasNewStyleAbility) return
 
         val title = if (hasNewStyleAbility)
-            UnitActions.actionTextWithSideEffects("Remove Heresy", newStyleUnique!!, unit)
+            UnitActionModifiers.actionTextWithSideEffects("Remove Heresy", newStyleUnique!!, unit)
         else "Remove Heresy"
 
         actionList += UnitAction(
@@ -126,7 +126,7 @@ object UnitActionsReligion {
                 }
                 unit.currentMovement = 0f
 
-                if (hasNewStyleAbility) UnitActions.activateSideEffects(unit, newStyleUnique!!)
+                if (hasNewStyleAbility) UnitActionModifiers.activateSideEffects(unit, newStyleUnique!!)
                 useActionWithLimitedUses(unit, Constants.removeHeresy)
             }.takeIf { unit.currentMovement > 0f }
         )

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsReligion.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsReligion.kt
@@ -103,7 +103,7 @@ object UnitActionsReligion {
             && unit.abilityUsesLeft[Constants.removeHeresy]!! > 0
 
         val newStyleUnique = UnitActionModifiers.getUsableUnitActionUniques(unit, UniqueType.CanRemoveHeresy).firstOrNull()
-        val hasNewStyleAbility = newStyleUnique != null && UnitActionModifiers.canUse(unit, newStyleUnique)
+        val hasNewStyleAbility = newStyleUnique != null
 
         if (!hasOldStyleAbility && !hasNewStyleAbility) return
 

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsReligion.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsReligion.kt
@@ -88,7 +88,9 @@ object UnitActionsReligion {
 
     internal fun addRemoveHeresyActions(unit: MapUnit, actionList: ArrayList<UnitAction>) {
         if (!unit.civ.gameInfo.isReligionEnabled()) return
-        if (unit.religion ==null) return
+        val religion = unit.civ.gameInfo.religions[unit.religion] ?: return
+        if (religion.isPantheon()) return
+
         val city = unit.currentTile.getCity() ?: return
         if (city.civ != unit.civ) return
         // Only allow the action if the city actually has any foreign religion

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsReligion.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsReligion.kt
@@ -61,7 +61,7 @@ object UnitActionsReligion {
         if (!unit.civ.religionManager.maySpreadReligionAtAll(unit)) return
         val city = unit.currentTile.getCity() ?: return
 
-        val newStyleUnique = unit.getMatchingUniques(UniqueType.CanSpreadReligion).firstOrNull()
+        val newStyleUnique = UnitActionModifiers.getUsableUnitActionUniques(unit, UniqueType.CanSpreadReligion).firstOrNull()
 
         val title = if (newStyleUnique != null)
                 UnitActionModifiers.actionTextWithSideEffects("Spread [${unit.getReligionDisplayName()!!}]", newStyleUnique, unit)
@@ -78,10 +78,12 @@ object UnitActionsReligion {
                 city.religion.addPressure(unit.religion!!, getPressureAddedFromSpread(unit))
                 if (unit.hasUnique(UniqueType.RemoveOtherReligions))
                     city.religion.removeAllPressuresExceptFor(unit.religion!!)
-                unit.currentMovement = 0f
 
                 if (newStyleUnique != null) UnitActionModifiers.activateSideEffects(unit, newStyleUnique)
-                else useActionWithLimitedUses(unit, Constants.spreadReligion)
+                else {
+                    useActionWithLimitedUses(unit, Constants.spreadReligion)
+                    unit.currentMovement = 0f
+                }
             }.takeIf { unit.currentMovement > 0 && unit.civ.religionManager.maySpreadReligionNow(unit) }
         )
     }
@@ -100,7 +102,7 @@ object UnitActionsReligion {
         val hasOldStyleAbility = unit.abilityUsesLeft.containsKey(Constants.removeHeresy)
             && unit.abilityUsesLeft[Constants.removeHeresy]!! > 0
 
-        val newStyleUnique = unit.getMatchingUniques(UniqueType.CanRemoveHeresy).firstOrNull()
+        val newStyleUnique = UnitActionModifiers.getUsableUnitActionUniques(unit, UniqueType.CanRemoveHeresy).firstOrNull()
         val hasNewStyleAbility = newStyleUnique != null && UnitActionModifiers.canUse(unit, newStyleUnique)
 
         if (!hasOldStyleAbility && !hasNewStyleAbility) return
@@ -124,10 +126,12 @@ object UnitActionsReligion {
                         city.religion.isBlockedHolyCity = false
                     }
                 }
-                unit.currentMovement = 0f
 
                 if (hasNewStyleAbility) UnitActionModifiers.activateSideEffects(unit, newStyleUnique!!)
-                useActionWithLimitedUses(unit, Constants.removeHeresy)
+                else {
+                    useActionWithLimitedUses(unit, Constants.removeHeresy)
+                    unit.currentMovement = 0f
+                }
             }.takeIf { unit.currentMovement > 0f }
         )
     }

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -701,11 +701,6 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 	Applicable to: Global
 
-??? example  "[baseUnitFilter] units built [cityFilter] can [action] [amount] extra times"
-	Example: "[Melee] units built [in all cities] can [Spread Religion] [3] extra times"
-
-	Applicable to: Global, FollowerBelief
-
 ??? example  "Triggers victory"
 	Applicable to: Global
 
@@ -1142,9 +1137,10 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 ??? example  "Can perform Air Sweep"
 	Applicable to: Unit
 
-??? example  "Can [action] [amount] times"
-	Example: "Can [Spread Religion] [3] times"
+??? example  "Can Spread Religion"
+	Applicable to: Unit
 
+??? example  "Can remove other religions from cities"
 	Applicable to: Unit
 
 ??? example  "Can speed up construction of a building"


### PR DESCRIPTION
This is the "fit of pique" version of this.

Tested with both old and new style uniques, both perform as expected.

Converting from old to new is not possible, since the old ones go by 'how many left' and the new ones by 'how many allowed' so I feel it's just better to say 'screw it you get everything back'

All in all it's considerably smaller than I expected compared to what a massive pain it was to do


There are pieces here that are acceptable refactorings of the old system that don't necessarily need the new system, we can see what there is done

Only missing piece is to properly set up a promotion to replace "[baseUnitFilter] units built [cityFilter] can [action] [amount] extra times"