### PR TITLE
Fix activating unit art in civilopedia crashes

### DIFF
--- a/core/src/com/unciv/ui/screens/civilopediascreen/FormattedLine.kt
+++ b/core/src/com/unciv/ui/screens/civilopediascreen/FormattedLine.kt
@@ -416,7 +416,6 @@ class FormattedLine (
         var height: Int
     ) {
         // Note: Gdx *has* an Integer equivalent of Vector2: GridPoint2 - but not of Rectangle (all in com.badlogic.gdx.math)
-        val v = Vector2()
 
         /** Grow both left and right edges horizontally by [h] and correspondingly top, bottom by [v]
          *


### PR DESCRIPTION
This time tested on 'roid:
<details>

![Screenshot_20231002_Unciv](https://github.com/yairm210/Unciv/assets/63000004/8db72d67-f5aa-4642-9d8d-ca95ccb3f6cf)
</details>