### PR TITLE
City overview Fix Hotfix

### DIFF
--- a/core/src/com/unciv/ui/components/SortableGrid.kt
+++ b/core/src/com/unciv/ui/components/SortableGrid.kt
@@ -87,6 +87,10 @@ class SortableGrid<IT, ACT, CT: ISortableGridContentProvider<IT, ACT>> (
     private val totalsRow = Table(skin)
 
     init {
+        require (!separateHeader || columns.none { it.expandX }) {
+            "SortableGrid currently does not support separateHeader combined with expanding columns"
+        }
+
         headerRow.defaults().pad(paddingVert, paddingHorz).minWidth(iconSize)
         details.defaults().pad(paddingVert, paddingHorz).minWidth(iconSize)
         totalsRow.defaults().pad(paddingVert, paddingHorz).minWidth(iconSize)

--- a/core/src/com/unciv/ui/screens/overviewscreen/CityOverviewTab.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/CityOverviewTab.kt
@@ -36,13 +36,21 @@ class CityOverviewTab(
         separateHeader = true
     ) {
         header, details, totals ->
+        // Notes: header.parent is the LinkedScrollPane of TabbedPager. Its linked twin is details.parent.parent.parent however!
+        // horizontal "slack" if available width > content width is taken up between SortableGrid and CityOverviewTab for the details,
+        // but not so for the header. We must force the LinkedScrollPane somehow (no? how?) to do so - or the header Table itself.
+
         equalizeColumns(details, header, totals)
+        // todo Kludge! Positioning and alignment of the header Table within its parent has quirks when content width < stage width
+        //      This code should likely be included in SortableGrid anyway?
+        if (header.width < this.width) header.width = this.width
         this.validate()
     }
 
     override fun getFixedContent() = grid.getHeader()
 
     init {
+        top()
         add(grid)
     }
 }

--- a/core/src/com/unciv/ui/screens/overviewscreen/CityOverviewTabColumn.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/CityOverviewTabColumn.kt
@@ -85,7 +85,7 @@ enum class CityOverviewTabColumn : ISortableGridContentProvider<City, EmpireOver
 
     Construction {
         override val align = Align.left
-        override val expandX = true
+        override val expandX = false
         override val equalizeHeight = true
         override val headerTip = "Current construction"
         override val defaultDescending = false


### PR DESCRIPTION
See commit messages - closes #10204 - but not a proper ***solution***.

A correct solution, scoped to the SortableGrid widget, needs more time and understanding the causes. City screen header still jumps a few pixels vertically when sorting, maybe same cause maybe not. From Scene2D debug mode looks like the padding jumps from symmetrical to one side... Maybe another wrapper between the fixed header Table and its ScrollPane??? Maybe. Needs brain and calm and inspiration and perseverant tests...