### PR TITLE
City-States don't trigger defensive pacts

### DIFF
--- a/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
@@ -744,7 +744,7 @@ class DiplomacyManager() : IsPartOfGameInfoSerialization {
         diplomaticStatus = DiplomaticStatus.War
 
         if (civInfo.isMajorCiv()) {
-            if (!isOffensiveWar) callInDefensivePactAllies()
+            if (!isOffensiveWar && !civAtWarWith.isCityState()) callInDefensivePactAllies()
             callInCityStateAllies()
         }
 


### PR DESCRIPTION
This commit does as stated above.

<details>

If Civs India and Celts are friends and Siam declares war on India, then afterward India and Celts sign a defensive pact. Siam will still only be at war with India. If Siam then allies with City-State Valetta, Valetta will also declare war on India. However, since India and Celts now have a defensive pact, Valetta will also end up declaring war on Celts even though its ally is not at war with Celts.

Here's how it looks on the politics overview.
![Screenshot_20231002-201017_Unciv](https://github.com/yairm210/Unciv/assets/7538725/0f52d0f8-031f-4b86-b55f-001e9010264f)

The solution is that when CIty-States declare war, they shouldn't declare war on the Civ's defensive pact allies.
</details> 