### PR TITLE
Fade in and out for City Ambiance Sounds

### DIFF
--- a/core/src/com/unciv/ui/audio/CityAmbiencePlayer.kt
+++ b/core/src/com/unciv/ui/audio/CityAmbiencePlayer.kt
@@ -1,72 +1,22 @@
 package com.unciv.ui.audio
 
-import com.badlogic.gdx.Gdx
-import com.badlogic.gdx.audio.Music
-import com.badlogic.gdx.files.FileHandle
 import com.badlogic.gdx.utils.Disposable
 import com.unciv.UncivGame
 import com.unciv.logic.city.City
-import com.unciv.utils.Log
 
 /** Must be [disposed][dispose]. Starts playing an ambience sound for the city when created. Stops playing the ambience sound when [disposed][dispose]. */
 class CityAmbiencePlayer(
     city: City
 ) : Disposable {
-    private var playingCitySound: Music? = null
-
     init {
-        play(city)
-    }
-
-    private fun getModsFolder(): FileHandle {
-        val path = "mods"
-        val internal = Gdx.files.internal(path)
-        if (internal.exists()) return internal
-        return Gdx.files.local(path)
-    }
-
-    private fun getModSoundFolders(): Sequence<FileHandle> {
-        val visualMods = UncivGame.Current.settings.visualMods
-        val mods = UncivGame.Current.gameInfo!!.gameParameters.getModsAndBaseRuleset()
-        return (visualMods + mods).asSequence()
-            .map { modName ->
-                getModsFolder()
-                    .child(modName)
-                    .child("sounds")
-            }
-    }
-
-    private fun getSoundFile(fileName: String): FileHandle {
-        val fileFromMods = getModSoundFolders()
-            .filter { it.isDirectory }
-            .flatMap { it.list().asSequence() }
-            .filter { !it.isDirectory && it.extension() in MusicController.gdxSupportedFileExtensions }
-            .firstOrNull { it.nameWithoutExtension() == fileName }
-
-        return fileFromMods ?: Gdx.files.internal("sounds/$fileName.ogg")
-    }
-
-    private fun play(city: City) {
-        if (UncivGame.Current.settings.citySoundsVolume == 0f) return
-
-        if (playingCitySound != null)
-            stop()
-        try {
-            playingCitySound = Gdx.audio.newMusic(getSoundFile(city.civ.getEra().citySound))
-            playingCitySound?.volume = UncivGame.Current.settings.citySoundsVolume
-            playingCitySound?.isLooping = true
-            playingCitySound?.play()
-        } catch (ex: Throwable) {
-            playingCitySound?.dispose()
-            Log.error("Error while playing city sound: ", ex)
+        val volume = UncivGame.Current.settings.citySoundsVolume
+        if (volume > 0f) {
+            UncivGame.Current.musicController
+                .playOverlay("sounds", city.civ.getEra().citySound, volume)
         }
     }
 
-    private fun stop() {
-        playingCitySound?.dispose()
-    }
-
     override fun dispose() {
-        stop()
+        UncivGame.Current.musicController.stopOverlay()
     }
 }

--- a/core/src/com/unciv/ui/audio/CityAmbiencePlayer.kt
+++ b/core/src/com/unciv/ui/audio/CityAmbiencePlayer.kt
@@ -4,7 +4,9 @@ import com.badlogic.gdx.utils.Disposable
 import com.unciv.UncivGame
 import com.unciv.logic.city.City
 
-/** Must be [disposed][dispose]. Starts playing an ambience sound for the city when created. Stops playing the ambience sound when [disposed][dispose]. */
+/** Must be [disposed][dispose].
+ *  Starts playing an ambience sound for the city when created.
+ *  Stops playing the ambience sound when [disposed][dispose]. */
 class CityAmbiencePlayer(
     city: City
 ) : Disposable {

--- a/core/src/com/unciv/ui/audio/MusicTrackController.kt
+++ b/core/src/com/unciv/ui/audio/MusicTrackController.kt
@@ -7,7 +7,7 @@ import com.unciv.utils.Log
 import com.unciv.utils.debug
 
 /** Wraps one Gdx Music instance and manages loading, playback, fading and cleanup */
-internal class MusicTrackController(private var volume: Float) {
+internal class MusicTrackController(private var volume: Float, initialFadeVolume: Float = 1f) {
 
     /** Internal state of this Music track */
     enum class State(val canPlay: Boolean) {
@@ -25,7 +25,7 @@ internal class MusicTrackController(private var volume: Float) {
     var music: Music? = null
         private set
     private var fadeStep = MusicController.defaultFadingStep
-    private var fadeVolume: Float = 1f
+    private var fadeVolume: Float = initialFadeVolume
 
     //region Functions for MusicController
 
@@ -80,7 +80,7 @@ internal class MusicTrackController(private var volume: Float) {
      */
     fun startFade(fade: State, step: Float = 0f) {
         if (!state.canPlay) return
-        if (fadeStep > 0f) fadeStep = step
+        if (step > 0f) fadeStep = step
         state = fade
     }
 
@@ -153,7 +153,7 @@ internal class MusicTrackController(private var volume: Float) {
 
     private fun tryPlay(music: Music): Boolean {
         return try {
-            music.volume = volume
+            music.volume = volume * fadeVolume
             if (!music.isPlaying)  // for fade-over this could be called by the end of the previous track
                 music.play()
             true

--- a/core/src/com/unciv/ui/audio/MusicTrackController.kt
+++ b/core/src/com/unciv/ui/audio/MusicTrackController.kt
@@ -47,7 +47,9 @@ internal class MusicTrackController(private var volume: Float, initialFadeVolume
         onError: ((MusicTrackController)->Unit)? = null,
         onSuccess: ((MusicTrackController)->Unit)? = null
     ) {
-        check(state == State.None && music == null) { "MusicTrackController.load should only be called once" }
+        check(state == State.None && music == null) {
+            "MusicTrackController.load should only be called once"
+        }
 
         state = State.Loading
         try {
@@ -75,7 +77,8 @@ internal class MusicTrackController(private var volume: Float, initialFadeVolume
 
     /** Starts fadeIn or fadeOut.
      *
-     *  Note this does _not_ set the current fade "percentage" to allow smoothly changing direction mid-fade
+     *  Note this does _not_ set the current fade "percentage" to allow smoothly
+     *  changing direction mid-fade
      *  @param step Overrides current fade step only if >0
      */
     fun startFade(fade: State, step: Float = 0f) {
@@ -97,7 +100,8 @@ internal class MusicTrackController(private var volume: Float, initialFadeVolume
         return timerTick() == State.Idle
     }
 
-    /** @return [Music.isPlaying] (Gdx music stream is playing) unless [state] says it won't make sense */
+    /** @return [Music.isPlaying] (Gdx music stream is playing)
+     *      unless [state] says it won't make sense */
     fun isPlaying() = state.canPlay && music?.isPlaying == true
 
     /** Calls play() on the wrapped Gdx Music, catching exceptions to console.
@@ -105,11 +109,14 @@ internal class MusicTrackController(private var volume: Float, initialFadeVolume
      *  @throws IllegalStateException if called on uninitialized instance
      */
     fun play(): Boolean {
-        check(state.canPlay && music != null) { "MusicTrackController.play called on uninitialized instance" }
+        check(state.canPlay && music != null) {
+            "MusicTrackController.play called on uninitialized instance"
+        }
 
         // Unexplained observed exception: Gdx.Music.play fails with
         // "Unable to allocate audio buffers. AL Error: 40964" (AL_INVALID_OPERATION)
-        // Approach: This track dies, parent controller will enter state Silence thus retry after a while.
+        // Approach: This track dies, parent controller will enter state Silence thus
+        // retry after a while.
         if (tryPlay(music!!)) return true
         state = State.Error
         return false
@@ -136,7 +143,8 @@ internal class MusicTrackController(private var volume: Float, initialFadeVolume
         state = State.Playing
     }
     private fun fadeOutStep() {
-        // fade-out: linearly ramp fadeVolume to 0.0, then act according to Status (Playing->Silence/Pause/Shutdown)
+        // fade-out: linearly ramp fadeVolume to 0.0, then act according to Status
+        //   (Playing->Silence/Pause/Shutdown)
         // This needs to guard against the music backend breaking mid-fade away during game shutdown
         fadeVolume -= fadeStep
         try {
@@ -154,8 +162,8 @@ internal class MusicTrackController(private var volume: Float, initialFadeVolume
     private fun tryPlay(music: Music): Boolean {
         return try {
             music.volume = volume * fadeVolume
-            if (!music.isPlaying)  // for fade-over this could be called by the end of the previous track
-                music.play()
+            // for fade-over this could be called by the end of the previous track:
+            if (!music.isPlaying) music.play()
             true
         } catch (ex: Throwable) {
             audioExceptionHandler(ex)


### PR DESCRIPTION
Closes #10217 and fixes an old bug [^1]

<details><summary>As for the radical `LongLine` commit...</summary>

<br/>
That new setting in inspectionProfiles/Project_Default.xml - can't we have that with a slightly longer limit for comment lines?

Nice:
![image](https://github.com/yairm210/Unciv/assets/63000004/e4abed3c-5935-4a3e-8eb3-a866b1a45950)
... took Studio over half an hour to see that one was bogus
</details>

[^1]: one would have to pause music while two tracks were in the middle of a fade-over to observe the bug, and even then it would only cut off one of them instead of fading out. Wow, critical bug, right? But an inane oversight nonetheless....