### PR TITLE
Defensive pact button now shows on both sides when a DoF is about to end

### DIFF
--- a/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyFunctions.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyFunctions.kt
@@ -131,7 +131,8 @@ class DiplomacyFunctions(val civInfo: Civilization){
     fun canSignDefensivePactWith(otherCiv: Civilization): Boolean {
         val diplomacyManager = civInfo.getDiplomacyManager(otherCiv)
         return canSignDefensivePact() && otherCiv.diplomacyFunctions.canSignDefensivePact()
-            && diplomacyManager.hasFlag(DiplomacyFlags.DeclarationOfFriendship)
+            && (diplomacyManager.hasFlag(DiplomacyFlags.DeclarationOfFriendship) 
+            || diplomacyManager.otherCivDiplomacy().hasFlag(DiplomacyFlags.DeclarationOfFriendship))
             && !diplomacyManager.hasFlag(DiplomacyFlags.DefensivePact)
             && !diplomacyManager.otherCivDiplomacy().hasFlag(DiplomacyFlags.DefensivePact)
             && diplomacyManager.diplomaticStatus != DiplomaticStatus.DefensivePact


### PR DESCRIPTION
Fixes #10236

When checking if we should show the defensive pact buttons in the TradeLogic class, for one button, we check if we have a DoF flag and for the other button we check if they have a DoF flag. This leads to the effect that one button may be visible with the other button being invisible. If the one button is clicked the trade will go through as normal but the other button will appear disabled.

This commit changes canSignDefensivePactWith to return true if one of the Civs has a DoF flag, resulting in both of the buttons being shown.