### PR TITLE
Defensive pact functionality cancels before calling in allies

### DIFF
--- a/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
@@ -770,7 +770,12 @@ class DiplomacyManager() : IsPartOfGameInfoSerialization {
         for (diploManager in civInfo.diplomacy.values) {
             if (diploManager.diplomaticStatus != DiplomaticStatus.DefensivePact) continue
 
-            // We already removed the trades and we don't want to remove the flags yet.
+            // Cancel the defensive pact functionality
+            diploManager.diplomaticStatus = DiplomaticStatus.Peace
+            diploManager.otherCivDiplomacy().diplomaticStatus = DiplomaticStatus.Peace
+            
+            // We already removed the trades and functionality
+            // But we don't want to remove the flags yet so we can process BetrayedDefensivePact later
             if (diploManager.otherCiv() != civAtWarWith) {
                 // Trades with defensive pact are now invalid
                 val defensivePactOffer = diploManager.trades
@@ -779,10 +784,9 @@ class DiplomacyManager() : IsPartOfGameInfoSerialization {
                 val theirDefensivePactOffer = diploManager.otherCivDiplomacy().trades
                     .firstOrNull { trade -> trade.ourOffers.any { offer -> offer.name == Constants.defensivePact } }
                 diploManager.otherCivDiplomacy().trades.remove(theirDefensivePactOffer)
+                
                 diploManager.removeFlag(DiplomacyFlags.DefensivePact)
                 diploManager.otherCivDiplomacy().removeFlag(DiplomacyFlags.DefensivePact)
-                diploManager.diplomaticStatus = DiplomaticStatus.Peace
-                diploManager.otherCivDiplomacy().diplomaticStatus = DiplomaticStatus.Peace
             }
             for (civ in getCommonKnownCivs().filter { civ -> civ.isMajorCiv() || civ.isSpectator() }) {
                 civ.addNotification("[${civInfo.civName}] canceled their Defensive Pact with [${diploManager.otherCivName}]!",


### PR DESCRIPTION
Solves https://discord.com/channels/586194543280390151/1158693504789270548

This commit removes the DiplomaticStatus.Defensive pact with the Civ that was sent a DoW on without removing the flags. This prevents the Civ that was sent the DoW from calling in the civ declaring war to defend them. Preventing City-states and allies from declaring war on their allies and themselves.

<details><summary>Allied City-State declares war on themselves because the defensive pact is not broken early enough in the program.</summary>

![DefensivePactSelfWar](https://github.com/yairm210/Unciv/assets/7538725/6205dedb-a67f-4bc6-af35-1fb66ab4659f)

</details> 