### PR TITLE
Fix ai buy tiles

### DIFF
--- a/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
@@ -422,6 +422,7 @@ object NextTurnAutomation {
                     goldSpent += goldCostOfTile
                 } else {
                     ranOutOfMoney = true
+                    break
                 }
             }
             if (ranOutOfMoney) {

--- a/core/src/com/unciv/logic/city/managers/CityExpansionManager.kt
+++ b/core/src/com/unciv/logic/city/managers/CityExpansionManager.kt
@@ -68,13 +68,14 @@ class CityExpansionManager : IsPartOfGameInfoSerialization {
     fun buyTile(tile: Tile) {
         val goldCost = getGoldCostOfTile(tile)
 
-        class TriedToBuyNonContiguousTileException:Exception()
+        class TriedToBuyNonContiguousTileException(msg: String) : Exception(msg)
         if (tile.neighbors.none { it.getCity() == city })
-            throw TriedToBuyNonContiguousTileException()
+            throw TriedToBuyNonContiguousTileException("$city tried to buy $tile, but it owns none of the neighbors")
 
-        class NotEnoughGoldToBuyTileException : Exception()
+        class NotEnoughGoldToBuyTileException(msg: String) : Exception(msg)
         if (city.civ.gold < goldCost && !city.civ.gameInfo.gameParameters.godMode)
-            throw NotEnoughGoldToBuyTileException()
+            throw NotEnoughGoldToBuyTileException("$city tried to buy $tile, but lacks gold (cost $goldCost, has ${city.civ.gold})")
+
         city.civ.addGold(-goldCost)
         takeOwnership(tile)
 


### PR DESCRIPTION
Fixes #10232 

I can confirm that one measly `break` fixes the crash, but there's more that stinks here... But I'm lazy. This is the tiny band-aid that 
just happens to get around the stink, no more. Can someone help with actual application of brain to that code? At least limit that path to tiles in buyable radius - but is that all?