### PR TITLE
Some religion stuff

### DIFF
--- a/android/assets/jsons/Civ V - Gods & Kings/Units.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Units.json
@@ -1636,7 +1636,7 @@
 		"unitType": "Civilian",
 		"uniques": [
             "Can instantly construct a [Holy site] improvement <by consuming this unit> <if it hasn't used other actions yet>",
-            "Can Spread Religion <[4] times>",
+            "Can Spread Religion <for [2] movement> <[4] times> <after which this unit is consumed>",
 			"Removes other religions when spreading religion",
             "May found a religion <by consuming this unit> <if it hasn't used other actions yet>",
             "May enhance a religion <by consuming this unit>  <if it hasn't used other actions yet>",
@@ -1676,7 +1676,7 @@
 		"name": "Missionary",
 		"unitType": "Civilian",
 		"uniques": [
-            "Can Spread Religion <[2] times>",
+            "Can Spread Religion <for [4] movement> <[2] times> <after which this unit is consumed>",
             "May enter foreign tiles without open borders, but loses [250] religious strength each turn it ends there",
 			"Can be purchased with [Faith] [in all cities in which the majority religion is a major religion]",
 			"[-1] Sight", "Unbuildable", "Religious Unit", "Hidden when religion is disabled"],

--- a/android/assets/jsons/Civ V - Vanilla/Units.json
+++ b/android/assets/jsons/Civ V - Vanilla/Units.json
@@ -1290,21 +1290,6 @@
 		"movement": 2
 	},
 	{
-		"name": "Great Prophet",
-		"unitType": "Civilian",
-		"uniques": [
-            "Can instantly construct a [Holy site] improvement <by consuming this unit> <if it hasn't used other actions yet>",
-            "Can Spread Religion <[4] times>",
-			"Removes other religions when spreading religion",
-            "May found a religion <by consuming this unit> <if it hasn't used other actions yet>",
-            "May enhance a religion <by consuming this unit>  <if it hasn't used other actions yet>",
-			"May enter foreign tiles without open borders", "[-1] Sight", "Great Person - [Faith]",
-			"Unbuildable", "Religious Unit", "Hidden when religion is disabled",
-			"Takes your religion over the one in their birth city"],
-		"movement": 2,
-		"religiousStrength": 1000
-	},
-	{
 		"name": "Great General",
 		"unitType": "Civilian",
 		"uniques": [
@@ -1327,30 +1312,6 @@
             "Great Person - [War]", "Unbuildable", "Uncapturable"],
 		"movement": 5
 	},
-
-	/* Religious units */
-
-	{
-		"name": "Missionary",
-		"unitType": "Civilian",
-		"uniques": [
-            "Can Spread Religion <[2] times>",
-            "May enter foreign tiles without open borders, but loses [250] religious strength each turn it ends there",
-			"Can be purchased with [Faith] [in all cities in which the majority religion is a major religion]",
-			"[-1] Sight", "Unbuildable", "Religious Unit", "Hidden when religion is disabled"],
-		"movement": 4,
-		"religiousStrength": 1000
-	},
-	{
-		"name": "Inquisitor",
-		"unitType": "Civilian",
-		"uniques": ["Prevents spreading of religion to the city it is next to",
-            "Can remove other religions from cities <in [Friendly] tiles> <once> <after which this unit is consumed>",
-			"Can be purchased with [Faith] [in all cities in which the majority religion is an enhanced religion]",
-			"[+1] Sight", "Hidden when religion is disabled", "Unbuildable", "Religious Unit"
-		],
-		"movement": 3
-	}
 
 	/* Spaceship Parts */
 	// Must be transported to the Capital for launch.

--- a/android/assets/jsons/Tutorials.json
+++ b/android/assets/jsons/Tutorials.json
@@ -292,7 +292,8 @@
         "A pantheon will provide a small bonus for your civilization that will apply to all cities that have it as a majority religion.",
         "Each civilization can only choose a single pantheon belief, and each pantheon can only be chosen once.",
         "Generating more ☮Faith will allow you to found a religion."
-      ]
+      ],
+    "uniques": ["Hidden when religion is disabled"]
   },
   {
     "name": "Religion",
@@ -305,14 +306,16 @@
         "One of these great prophets can then be used to enhance your religion.",
         "This will allow you to choose another follower belief, as well as an enhancer belief, that only applies to you.",
         "Do take care founding a religion soon, only about half the players in the game are able to found a religion!"
-      ]
+      ],
+    "uniques": ["Hidden when religion is disabled"]
   },
   {
     "name": "Beliefs",
     "steps": [
         "There are four types of beliefs: Pantheon, Founder, Follower and Enhancer beliefs.",
         "Pantheon and Follower beliefs apply to each city following your religion, while Founder and Enhancer beliefs only apply to the founder of a religion."
-      ]
+      ],
+    "uniques": ["Hidden when religion is disabled"]
   },
   {
     "name": "Religion inside cities",
@@ -324,7 +327,8 @@
         "In both places, a tap/click on the icon of a religion will show detailed information with its effects.",
         "Based on this, you can get a feel for which religions have a lot of pressure built up in the city, and which have almost none.",
         "The city follows a religion if a majority of its population follows that religion, and will only then receive the effects of Follower and Pantheon beliefs of that religion."
-      ]
+      ],
+    "uniques": ["Hidden when religion is disabled"]
   },
   {
     "name": "Spreading Religion",
@@ -345,7 +349,8 @@
         "Holy cities also provide +30 pressure of the religion founded there to themselves, making it very difficult to effectively convert a holy city.",
         "Lastly, before founding a religion, new cities you settle will start with 200 pressure for your pantheon.",
         "This way, all your cities will starting following your pantheon as long as you haven't founded a religion yet."
-      ]
+      ],
+    "uniques": ["Hidden when religion is disabled"]
   },
   {
     "name": "Inquisitors",
@@ -355,7 +360,8 @@
         "Great prophets also have this ability, and remove all other religions in the city when spreading their religion.",
         "Often this results in the city immediately converting to their religion",
         "Additionally, when an inquisitor is stationed in or directly next to a city center, units of other religions cannot spread their faith there, though natural spread is uneffected."
-      ]
+      ],
+    "uniques": ["Hidden when religion is disabled"]
   },
   {
     "name": "Maya Long Count calendar cycle",

--- a/core/src/com/unciv/models/ruleset/Tutorial.kt
+++ b/core/src/com/unciv/models/ruleset/Tutorial.kt
@@ -1,6 +1,7 @@
 package com.unciv.models.ruleset
 
 import com.unciv.models.ruleset.unique.UniqueTarget
+import com.unciv.ui.screens.civilopediascreen.FormattedLine
 
 /**
  *  Container for json-read "Tutorial" text, potentially decorated.
@@ -13,11 +14,12 @@ import com.unciv.models.ruleset.unique.UniqueTarget
  *  @see com.unciv.models.TutorialTrigger
  */
 class Tutorial : RulesetObject() {
-    // Why does this override RulesetObject()? The only unique it overrides is `Will not be displayed in Civilopedia`,
-    // so allowing it access to the full power of uniques is completely unnecessary.
-    // (Also, what even would it mean for this to have uniques like "[+10]% Production"? When should it even apply.)
-    // imo just having a flag for this (and maybe one if religion is disabled, but even then, that should be a ruleset choice) should suffice.
-    // -xlenstra
+    // Has access to the full power of uniques for:
+    // * Easier integration into Civilopedia
+    // * HiddenWithoutReligion, HiddenFromCivilopedia work _directly_
+    // * Future expansion - other meta tests to display or not are thinkable,
+    //   e.g. modders may want to hide instructions until you discover the game element?
+    // -SomeTrog
     override var name = ""  // overridden only to have the name seen first by TranslationFileWriter
 
     /** These lines will be displayed (when the Tutorial is _triggered_) one after another,
@@ -27,4 +29,10 @@ class Tutorial : RulesetObject() {
 
     override fun getUniqueTarget() = UniqueTarget.Tutorial
     override fun makeLink() = "Tutorial/$name"
+
+    override fun getCivilopediaTextLines(ruleset: Ruleset): List<FormattedLine> {
+        val imageLine = FormattedLine(extraImage = name.replace(' ', '_'))
+        if (steps == null) return listOf(imageLine)
+        return (sequenceOf(imageLine) + steps.asSequence().map { FormattedLine(it) }).toList()
+    }
 }

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -1,9 +1,8 @@
 package com.unciv.models.ruleset.unique
 
 import com.unciv.Constants
-import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.ruleset.validation.RulesetErrorSeverity
-import com.unciv.models.ruleset.validation.RulesetValidator  // Kdoc only
+import com.unciv.models.ruleset.validation.RulesetValidator
 import com.unciv.models.translations.getPlaceholderParameters
 import com.unciv.models.translations.getPlaceholderText
 
@@ -761,12 +760,15 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
     //endregion
 
     ///////////////////////////////////////////// region 90 META /////////////////////////////////////////////
-    HiddenWithoutReligion("Hidden when religion is disabled", UniqueTarget.Unit, UniqueTarget.Building, UniqueTarget.Ruins, flags = UniqueFlag.setOfHiddenToUsers),
+    HiddenWithoutReligion("Hidden when religion is disabled",
+        UniqueTarget.Unit, UniqueTarget.Building, UniqueTarget.Ruins, UniqueTarget.Tutorial,
+        flags = UniqueFlag.setOfHiddenToUsers),
 
     HiddenAfterGreatProphet("Hidden after generating a Great Prophet", UniqueTarget.Ruins),
     HiddenWithoutVictoryType("Hidden when [victoryType] Victory is disabled", UniqueTarget.Building, UniqueTarget.Unit, flags = UniqueFlag.setOfHiddenToUsers),
-    HiddenFromCivilopedia("Will not be displayed in Civilopedia", UniqueTarget.Building, UniqueTarget.Unit, UniqueTarget.UnitType, UniqueTarget.Improvement,
-        UniqueTarget.Tech, UniqueTarget.Terrain, UniqueTarget.Resource, UniqueTarget.Policy, UniqueTarget.Promotion,
+    HiddenFromCivilopedia("Will not be displayed in Civilopedia", UniqueTarget.Building,
+        UniqueTarget.Unit, UniqueTarget.UnitType, UniqueTarget.Improvement, UniqueTarget.Tech,
+        UniqueTarget.Terrain, UniqueTarget.Resource, UniqueTarget.Policy, UniqueTarget.Promotion,
         UniqueTarget.Nation, UniqueTarget.Ruins, flags = UniqueFlag.setOfHiddenToUsers),
 
     // Declarative Mod compatibility (so far rudimentary):

--- a/core/src/com/unciv/ui/screens/basescreen/TutorialController.kt
+++ b/core/src/com/unciv/ui/screens/basescreen/TutorialController.kt
@@ -7,13 +7,10 @@ import com.unciv.json.fromJsonFile
 import com.unciv.json.json
 import com.unciv.models.TutorialTrigger
 import com.unciv.models.ruleset.Tutorial
-import com.unciv.models.ruleset.unique.UniqueType
-import com.unciv.models.stats.INamed
 import com.unciv.ui.components.input.KeyCharAndCode
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.popups.Popup
-import com.unciv.ui.screens.civilopediascreen.FormattedLine
-import com.unciv.ui.screens.civilopediascreen.SimpleCivilopediaText
+import com.unciv.ui.screens.civilopediascreen.ICivilopediaText
 
 
 class TutorialController(screen: BaseScreen) {
@@ -80,32 +77,12 @@ class TutorialController(screen: BaseScreen) {
         return tutorials[name]?.steps ?: emptyList()
     }
 
-    /** Wrapper for a Tutorial, supports INamed and ICivilopediaText,
-     *  and already provisions for the display of an ExtraImage on top.
-     *  @param name from Tutorial.name, also used for ExtraImage (with spaces replaced by underscores)
-     *  @param tutorial provides [Tutorial.civilopediaText] and [Tutorial.steps] for display
-     */
-    //todo Replace - Civilopedia should display Tutorials directly as the RulesetObjects they are
-    class CivilopediaTutorial(
-        override var name: String,
-        tutorial: Tutorial
-    ) : INamed, SimpleCivilopediaText(
-        sequenceOf(FormattedLine(extraImage = name.replace(' ', '_'))) + tutorial.civilopediaText.asSequence(),
-        tutorial.steps?.asSequence() ?: emptySequence()
-    ) {
-        override fun makeLink() = "Tutorial/$name"
-    }
-
-    /** Get all Tutorials intended to be displayed in the Civilopedia
-     *  as a List of wrappers supporting INamed and ICivilopediaText
-     */
-    fun getCivilopediaTutorials(): List<CivilopediaTutorial> {
-        val civilopediaTutorials = tutorials.filter {
-            !it.value.hasUnique(UniqueType.HiddenFromCivilopedia)
-        }.map {
-            tutorial -> CivilopediaTutorial(tutorial.key, tutorial.value)
-        }
-        return civilopediaTutorials
+    /** Get all Tutorials to be displayed in the Civilopedia */
+    fun getCivilopediaTutorials(): Collection<ICivilopediaText> {
+        // Todo This is essentially an 'un-private' kludge and the accessor
+        //      in CivilopediaCategories desperately needs independence from TutorialController:
+        //      Move storage to RuleSet someday?
+        return tutorials.values
     }
 }
 

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -1084,7 +1084,7 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 	Applicable to: Building, Unit
 
 ??? example  "Hidden when religion is disabled"
-	Applicable to: Building, Unit, Ruins
+	Applicable to: Building, Unit, Ruins, Tutorial
 
 ??? example  "Hidden when [victoryType] Victory is disabled"
 	Example: "Hidden when [Domination] Victory is disabled"


### PR DESCRIPTION
Uh, I shouldn't have simply left all of this in the (just barely renamed) 'Debug' branch, and could use more testing.

But - it's such a nice surprise I need to show it.

Closes #10235 

* Includes conditionals for the Missionary (and Prophet) to restore proper behaviour - suboptimal display for now
* Removes the Religious units from Vanilla (works a few turns - this is where I say could use more testing)
* Simplifies Civilopedia access to Tutorials and thereby enables hiding Tutorials selectively
* Hides Religion tutorials from Civilopedia - duh

The ease with which that simplification went is facepalm level. I suspect that stale 'Tutorials2' branch I got in my local git may have gone there too.... But I'm too much of a coward to check-out and re-read the diffs. I had that vision before the long pause and I even vaguely remember a working demo where the 'guidance' tutorials - both float-on-top and popup - had all the power of MarkupRender...

And that @xlenstra comment - I loved it and it pains me a little taking it out, but it will be preserved in git history. The 'signed by' style is a hommage...