### PR TITLE
Separate unit automation from other actions

### DIFF
--- a/core/src/com/unciv/logic/battle/BattleUnitCapture.kt
+++ b/core/src/com/unciv/logic/battle/BattleUnitCapture.kt
@@ -118,7 +118,7 @@ object BattleUnitCapture {
         val capturedUnit = defender.unit
         // Stop current action
         capturedUnit.action = null
-        capturedUnit.isAutomated = false
+        capturedUnit.automated = false
 
         val capturedUnitTile = capturedUnit.getTile()
         val originalOwner = if (capturedUnit.originalOwner != null)

--- a/core/src/com/unciv/logic/battle/BattleUnitCapture.kt
+++ b/core/src/com/unciv/logic/battle/BattleUnitCapture.kt
@@ -118,6 +118,7 @@ object BattleUnitCapture {
         val capturedUnit = defender.unit
         // Stop current action
         capturedUnit.action = null
+        capturedUnit.isAutomated = false
 
         val capturedUnitTile = capturedUnit.getTile()
         val originalOwner = if (capturedUnit.originalOwner != null)

--- a/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
@@ -101,7 +101,7 @@ class MapUnit : IsPartOfGameInfoSerialization {
     var health: Int = 100
 
     var action: String? = null // work, automation, fortifying, I dunno what.
-    var isAutomated: Boolean = false
+    var automated: Boolean = false
 
     @Transient
     var showAdditionalActions: Boolean = false
@@ -177,7 +177,7 @@ class MapUnit : IsPartOfGameInfoSerialization {
         toReturn.currentMovement = currentMovement
         toReturn.health = health
         toReturn.action = action
-        toReturn.isAutomated = isAutomated
+        toReturn.automated = automated
         toReturn.attacksThisTurn = attacksThisTurn
         toReturn.turnsFortified = turnsFortified
         toReturn.promotions = promotions.clone()
@@ -338,7 +338,7 @@ class MapUnit : IsPartOfGameInfoSerialization {
 
     fun isMoving() = action?.startsWith("moveTo") == true
 
-    fun isAutomated() = isAutomated
+    fun isAutomated() = automated
     fun isExploring() = action == UnitActionType.Explore.value
     fun isPreparingParadrop() = action == UnitActionType.Paradrop.value
     fun isPreparingAirSweep() = action == UnitActionType.AirSweep.value
@@ -463,7 +463,7 @@ class MapUnit : IsPartOfGameInfoSerialization {
             ?: throw java.lang.Exception("Unit $name is not found!")
 
         updateUniques()
-        if (action == UnitActionType.Automate.value) isAutomated = true
+        if (action == UnitActionType.Automate.value) automated = true
     }
 
     fun getTriggeredUniques(trigger: UniqueType,

--- a/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
@@ -101,6 +101,8 @@ class MapUnit : IsPartOfGameInfoSerialization {
     var health: Int = 100
 
     var action: String? = null // work, automation, fortifying, I dunno what.
+    var isAutomated: Boolean = false
+
     @Transient
     var showAdditionalActions: Boolean = false
 
@@ -175,6 +177,7 @@ class MapUnit : IsPartOfGameInfoSerialization {
         toReturn.currentMovement = currentMovement
         toReturn.health = health
         toReturn.action = action
+        toReturn.isAutomated = isAutomated
         toReturn.attacksThisTurn = attacksThisTurn
         toReturn.turnsFortified = turnsFortified
         toReturn.promotions = promotions.clone()
@@ -335,7 +338,7 @@ class MapUnit : IsPartOfGameInfoSerialization {
 
     fun isMoving() = action?.startsWith("moveTo") == true
 
-    fun isAutomated() = action == UnitActionType.Automate.value
+    fun isAutomated() = isAutomated
     fun isExploring() = action == UnitActionType.Explore.value
     fun isPreparingParadrop() = action == UnitActionType.Paradrop.value
     fun isPreparingAirSweep() = action == UnitActionType.AirSweep.value
@@ -460,6 +463,7 @@ class MapUnit : IsPartOfGameInfoSerialization {
             ?: throw java.lang.Exception("Unit $name is not found!")
 
         updateUniques()
+        if (action == UnitActionType.Automate.value) isAutomated = true
     }
 
     fun getTriggeredUniques(trigger: UniqueType,

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActions.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActions.kt
@@ -8,7 +8,6 @@ import com.unciv.logic.map.mapunit.MapUnit
 import com.unciv.logic.map.tile.Tile
 import com.unciv.models.UnitAction
 import com.unciv.models.UnitActionType
-import com.unciv.models.ruleset.unique.Unique
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.translations.tr
 import com.unciv.ui.popups.ConfirmPopup
@@ -62,7 +61,10 @@ object UnitActions {
         if (unit.isExploring())
             actionList += UnitAction(UnitActionType.StopExploration) { unit.action = null }
         if (unit.isAutomated())
-            actionList += UnitAction(UnitActionType.StopAutomation) { unit.action = null }
+            actionList += UnitAction(UnitActionType.StopAutomation) {
+                unit.action = null
+                unit.isAutomated = false
+            }
 
         addPromoteAction(unit, actionList)
         UnitActionsUpgrade.addUnitUpgradeAction(unit, actionList)
@@ -293,7 +295,9 @@ object UnitActions {
         actionList += UnitAction(UnitActionType.Automate,
             isCurrentAction = unit.isAutomated(),
             action = {
+                // Temporary, for compatibility - we want games serialized *moving through old versions* to come out the other end with units still automated
                 unit.action = UnitActionType.Automate.value
+                unit.isAutomated = true
                 UnitAutomation.automateUnitMoves(unit)
             }.takeIf { unit.currentMovement > 0 }
         )

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActions.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActions.kt
@@ -63,7 +63,7 @@ object UnitActions {
         if (unit.isAutomated())
             actionList += UnitAction(UnitActionType.StopAutomation) {
                 unit.action = null
-                unit.isAutomated = false
+                unit.automated = false
             }
 
         addPromoteAction(unit, actionList)
@@ -297,7 +297,7 @@ object UnitActions {
             action = {
                 // Temporary, for compatibility - we want games serialized *moving through old versions* to come out the other end with units still automated
                 unit.action = UnitActionType.Automate.value
-                unit.isAutomated = true
+                unit.automated = true
                 UnitAutomation.automateUnitMoves(unit)
             }.takeIf { unit.currentMovement > 0 }
         )


### PR DESCRIPTION
A while back we added the option to automate *every* unit.

This raised an issue regarding automation PLUS other actions, for example: Automated units fortifying, automated units 'setting up' to bombard, etc
The point being, that 'is automated' seems to be a setting that can be true whatever action the unit is taking, It's an *additional* parameter.

This PR is Step 1 in bridging that gap, by moving unit automation to a second boolean field.

Once we've dealt with the inevitable fallout from this change (other places the unit should or should not stop automating) we can move on the final stage - removing 'automate' as a unit action entirely, and thus allowing automated units to do all the unit actions a regular unit can.

This also means that you will be able to issue commands to automated units, and they will still remain automated after them - so like 'temporarily take manual control for this one thing, but after that keep automating'