### PR TITLE
Allow games with zero researched techs to be 'before' the Ancient Era

### DIFF
--- a/core/src/com/unciv/ui/screens/pickerscreens/TechPickerScreen.kt
+++ b/core/src/com/unciv/ui/screens/pickerscreens/TechPickerScreen.kt
@@ -182,7 +182,7 @@ class TechPickerScreen(
                 if (rowIndex == 0)
                     table.padTop(7f)
 
-                if (erasNamesToColumns[civTech.era.name]!!.contains(columnIndex))
+                if (erasNamesToColumns[civTech.era.name]?.contains(columnIndex) == true)
                     table.background = skinStrings.getUiBackground("TechPickerScreen/Background", tintColor = queuedTechColor.darken(0.5f))
 
                 if (tech == null) {


### PR DESCRIPTION
I would be so mean to fix #10307 like this. No techs researched means _before_ Ancient, and patched they could go and research the starting tech normally:

![image](https://github.com/yairm210/Unciv/assets/63000004/44f1db44-e88f-49d4-ab6f-508c9fc9f24d)
