### PR TITLE
Added five new uniques

### DIFF
--- a/core/src/com/unciv/logic/city/CityConstructions.kt
+++ b/core/src/com/unciv/logic/city/CityConstructions.kt
@@ -581,6 +581,23 @@ class CityConstructions : IsPartOfGameInfoSerialization {
         updateUniques()
     }
 
+    fun removeBuildings(buildings: Set<Building>) {
+        val newBuildings = ArrayList<Building>(builtBuildingObjects.size - buildings.size)
+        builtBuildingObjects.asSequence().filter { it !in buildings }.toCollection(newBuildings)
+
+        builtBuildingObjects = newBuildings
+
+        val buildingNames = buildings.map {
+            it.name
+        }.toSet()
+
+        builtBuildings.removeIf {
+            it in buildingNames
+        }
+
+        updateUniques()
+    }
+
     fun updateUniques(onLoadGame:Boolean = false) {
         builtBuildingUniqueMap.clear()
         for (building in getBuiltBuildings())

--- a/core/src/com/unciv/logic/city/CityConstructions.kt
+++ b/core/src/com/unciv/logic/city/CityConstructions.kt
@@ -582,20 +582,11 @@ class CityConstructions : IsPartOfGameInfoSerialization {
     }
 
     fun removeBuildings(buildings: Set<Building>) {
-        val newBuildings = ArrayList<Building>(builtBuildingObjects.size - buildings.size)
-        builtBuildingObjects.asSequence().filter { it !in buildings }.toCollection(newBuildings)
-
-        builtBuildingObjects = newBuildings
-
-        val buildingNames = buildings.map {
-            it.name
-        }.toSet()
-
+        val buildingsToRemove = buildings.map { it.name }.toSet()
         builtBuildings.removeIf {
-            it in buildingNames
+            it in buildingsToRemove
         }
-
-        updateUniques()
+        setTransients()
     }
 
     fun updateUniques(onLoadGame:Boolean = false) {

--- a/core/src/com/unciv/models/ruleset/unique/Unique.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Unique.kt
@@ -176,6 +176,8 @@ class Unique(val text: String, val sourceObjectType: UniqueTarget? = null, val s
             UniqueType.ConditionalWithoutResource -> getResourceAmount(condition.params[0]) <= 0
             UniqueType.ConditionalWhenAboveAmountResource -> getResourceAmount(condition.params[1]) > condition.params[0].toInt()
             UniqueType.ConditionalWhenBelowAmountResource -> getResourceAmount(condition.params[1]) < condition.params[0].toInt()
+            UniqueType.ConditionalWhenAboveAmountGold -> state.civInfo != null && state.civInfo.gold > condition.params[0].toInt()
+            UniqueType.ConditionalWhenBelowAmountGold -> state.civInfo != null && state.civInfo.gold < condition.params[0].toInt()
             UniqueType.ConditionalHappy ->
                 state.civInfo != null && state.civInfo.stats.happiness >= 0
             UniqueType.ConditionalBetweenHappiness ->

--- a/core/src/com/unciv/models/ruleset/unique/Unique.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Unique.kt
@@ -175,33 +175,26 @@ class Unique(val text: String, val sourceObjectType: UniqueTarget? = null, val s
             UniqueType.ConditionalNotWar -> state.civInfo?.isAtWar() == false
             UniqueType.ConditionalWithResource -> getResourceAmount(condition.params[0]) > 0
             UniqueType.ConditionalWithoutResource -> getResourceAmount(condition.params[0]) <= 0
-            UniqueType.ConditionalWhenAboveAmountStatResource ->
 
+            UniqueType.ConditionalWhenAboveAmountStatResource ->
                 if (ruleset().tileResources.containsKey(condition.params[1])) {
                     return getResourceAmount(condition.params[1]) > condition.params[0].toInt()
-                }
-                else if (Stat.isStat(condition.params[1])) {
+                } else if (Stat.isStat(condition.params[1])) {
                     return state.civInfo != null &&
                         state.civInfo.getStatReserve(Stat.valueOf(condition.params[1])) > condition.params[0].toInt()
-                }
-                else {
+                } else {
                     return false
                 }
-
 
             UniqueType.ConditionalWhenBelowAmountStatResource ->
-
                 if (ruleset().tileResources.containsKey(condition.params[1])) {
                     return getResourceAmount(condition.params[1]) < condition.params[0].toInt()
-                }
-                else if (Stat.isStat(condition.params[1])) {
+                } else if (Stat.isStat(condition.params[1])) {
                     return state.civInfo != null &&
                         state.civInfo.getStatReserve(Stat.valueOf(condition.params[1])) < condition.params[0].toInt()
-                }
-                else {
+                } else {
                     return false
                 }
-
 
             UniqueType.ConditionalWhenAboveAmountStatSpeed -> state.civInfo != null &&
                 state.civInfo.getStatReserve(Stat.valueOf(condition.params[1])) > condition.params[0].toInt() *

--- a/core/src/com/unciv/models/ruleset/unique/Unique.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Unique.kt
@@ -175,13 +175,33 @@ class Unique(val text: String, val sourceObjectType: UniqueTarget? = null, val s
             UniqueType.ConditionalNotWar -> state.civInfo?.isAtWar() == false
             UniqueType.ConditionalWithResource -> getResourceAmount(condition.params[0]) > 0
             UniqueType.ConditionalWithoutResource -> getResourceAmount(condition.params[0]) <= 0
-            UniqueType.ConditionalWhenAboveAmountResource -> getResourceAmount(condition.params[1]) > condition.params[0].toInt()
-            UniqueType.ConditionalWhenBelowAmountResource -> getResourceAmount(condition.params[1]) < condition.params[0].toInt()
+            UniqueType.ConditionalWhenAboveAmountResource -> {
 
-            UniqueType.ConditionalWhenAboveAmountStat -> state.civInfo != null &&
-                state.civInfo.getStatReserve(Stat.valueOf(condition.params[1])) > condition.params[0].toInt()
-            UniqueType.ConditionalWhenBelowAmountStat -> state.civInfo != null &&
-                state.civInfo.getStatReserve(Stat.valueOf(condition.params[1])) < condition.params[0].toInt()
+                if (ruleset().tileResources.containsKey(condition.params[1])) {
+                    return getResourceAmount(condition.params[1]) > condition.params[0].toInt()
+                }
+                else if (Stat.isStat(condition.params[1])) {
+                    return state.civInfo != null &&
+                        state.civInfo.getStatReserve(Stat.valueOf(condition.params[1])) > condition.params[0].toInt()
+                }
+                else {
+                    return false
+                }
+            }
+
+            UniqueType.ConditionalWhenBelowAmountResource -> {
+
+                if (ruleset().tileResources.containsKey(condition.params[1])) {
+                    return getResourceAmount(condition.params[1]) < condition.params[0].toInt()
+                }
+                else if (Stat.isStat(condition.params[1])) {
+                    return state.civInfo != null &&
+                        state.civInfo.getStatReserve(Stat.valueOf(condition.params[1])) < condition.params[0].toInt()
+                }
+                else {
+                    return false
+                }
+            }
 
             UniqueType.ConditionalWhenAboveAmountStatSpeed -> state.civInfo != null &&
                 state.civInfo.getStatReserve(Stat.valueOf(condition.params[1])) > condition.params[0].toInt() *

--- a/core/src/com/unciv/models/ruleset/unique/Unique.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Unique.kt
@@ -175,7 +175,7 @@ class Unique(val text: String, val sourceObjectType: UniqueTarget? = null, val s
             UniqueType.ConditionalNotWar -> state.civInfo?.isAtWar() == false
             UniqueType.ConditionalWithResource -> getResourceAmount(condition.params[0]) > 0
             UniqueType.ConditionalWithoutResource -> getResourceAmount(condition.params[0]) <= 0
-            UniqueType.ConditionalWhenAboveAmountResource -> {
+            UniqueType.ConditionalWhenAboveAmountStatResource ->
 
                 if (ruleset().tileResources.containsKey(condition.params[1])) {
                     return getResourceAmount(condition.params[1]) > condition.params[0].toInt()
@@ -187,9 +187,9 @@ class Unique(val text: String, val sourceObjectType: UniqueTarget? = null, val s
                 else {
                     return false
                 }
-            }
 
-            UniqueType.ConditionalWhenBelowAmountResource -> {
+
+            UniqueType.ConditionalWhenBelowAmountStatResource ->
 
                 if (ruleset().tileResources.containsKey(condition.params[1])) {
                     return getResourceAmount(condition.params[1]) < condition.params[0].toInt()
@@ -201,7 +201,7 @@ class Unique(val text: String, val sourceObjectType: UniqueTarget? = null, val s
                 else {
                     return false
                 }
-            }
+
 
             UniqueType.ConditionalWhenAboveAmountStatSpeed -> state.civInfo != null &&
                 state.civInfo.getStatReserve(Stat.valueOf(condition.params[1])) > condition.params[0].toInt() *

--- a/core/src/com/unciv/models/ruleset/unique/Unique.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Unique.kt
@@ -178,8 +178,18 @@ class Unique(val text: String, val sourceObjectType: UniqueTarget? = null, val s
             UniqueType.ConditionalWhenAboveAmountResource -> getResourceAmount(condition.params[1]) > condition.params[0].toInt()
             UniqueType.ConditionalWhenBelowAmountResource -> getResourceAmount(condition.params[1]) < condition.params[0].toInt()
 
-            UniqueType.ConditionalWhenAboveAmountStat -> state.civInfo != null && state.civInfo.getStatReserve(Stat.valueOf(condition.params[1])) > condition.params[0].toInt()
-            UniqueType.ConditionalWhenBelowAmountStat -> state.civInfo != null && state.civInfo.getStatReserve(Stat.valueOf(condition.params[1])) < condition.params[0].toInt()
+            UniqueType.ConditionalWhenAboveAmountStat -> state.civInfo != null &&
+                state.civInfo.getStatReserve(Stat.valueOf(condition.params[1])) > condition.params[0].toInt()
+            UniqueType.ConditionalWhenBelowAmountStat -> state.civInfo != null &&
+                state.civInfo.getStatReserve(Stat.valueOf(condition.params[1])) < condition.params[0].toInt()
+
+            UniqueType.ConditionalWhenAboveAmountStatSpeed -> state.civInfo != null &&
+                state.civInfo.getStatReserve(Stat.valueOf(condition.params[1])) > condition.params[0].toInt() *
+                state.civInfo.gameInfo.speed.statCostModifiers[Stat.valueOf(condition.params[1])]!!
+
+            UniqueType.ConditionalWhenBelowAmountStatSpeed -> state.civInfo != null &&
+                state.civInfo.getStatReserve(Stat.valueOf(condition.params[1])) < condition.params[0].toInt() *
+                state.civInfo.gameInfo.speed.statCostModifiers[Stat.valueOf(condition.params[1])]!!
 
             UniqueType.ConditionalHappy ->
                 state.civInfo != null && state.civInfo.stats.happiness >= 0

--- a/core/src/com/unciv/models/ruleset/unique/Unique.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Unique.kt
@@ -9,6 +9,7 @@ import com.unciv.logic.civilization.Civilization
 import com.unciv.logic.civilization.managers.ReligionState
 import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.ruleset.validation.UniqueValidator
+import com.unciv.models.stats.Stat
 import com.unciv.models.stats.Stats
 import com.unciv.models.translations.getConditionals
 import com.unciv.models.translations.getPlaceholderParameters
@@ -176,8 +177,10 @@ class Unique(val text: String, val sourceObjectType: UniqueTarget? = null, val s
             UniqueType.ConditionalWithoutResource -> getResourceAmount(condition.params[0]) <= 0
             UniqueType.ConditionalWhenAboveAmountResource -> getResourceAmount(condition.params[1]) > condition.params[0].toInt()
             UniqueType.ConditionalWhenBelowAmountResource -> getResourceAmount(condition.params[1]) < condition.params[0].toInt()
-            UniqueType.ConditionalWhenAboveAmountGold -> state.civInfo != null && state.civInfo.gold > condition.params[0].toInt()
-            UniqueType.ConditionalWhenBelowAmountGold -> state.civInfo != null && state.civInfo.gold < condition.params[0].toInt()
+
+            UniqueType.ConditionalWhenAboveAmountStat -> state.civInfo != null && state.civInfo.getStatReserve(Stat.valueOf(condition.params[1])) > condition.params[0].toInt()
+            UniqueType.ConditionalWhenBelowAmountStat -> state.civInfo != null && state.civInfo.getStatReserve(Stat.valueOf(condition.params[1])) < condition.params[0].toInt()
+
             UniqueType.ConditionalHappy ->
                 state.civInfo != null && state.civInfo.stats.happiness >= 0
             UniqueType.ConditionalBetweenHappiness ->

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -648,25 +648,19 @@ object UniqueTriggerActivation {
             }
 
             UniqueType.RemoveBuilding -> {
-                if (!civInfo.isMajorCiv()) {
-                    return false
-                }
 
-                val applicableCities =
-                    if (unique.params[1] == "in this city") {
-                        sequenceOf(city!!)
-                    }
-                    else civInfo.cities.asSequence().filter {
+                val applicableCities = civInfo.cities.asSequence().filter {
                         it.matchesFilter(unique.params[1])
                     }
 
                 for (applicableCity in applicableCities) {
-                    for (buildingToRemove in applicableCity.cityConstructions.getBuiltBuildings()) {
-                        if (buildingToRemove.matchesFilter(unique.params[0])) {
-                            applicableCity.cityConstructions.removeBuilding(buildingToRemove)
-                        }
-                    }
+                    val buildingsToRemove = applicableCity.cityConstructions.getBuiltBuildings().filter {
+                        it.matchesFilter(unique.params[0])
+                    }.toSet()
+
+                    applicableCity.cityConstructions.removeBuildings(buildingsToRemove)
                 }
+
                 return true
             }
 

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -647,6 +647,29 @@ object UniqueTriggerActivation {
                 return true // not fully correct
             }
 
+            UniqueType.RemoveBuilding -> {
+                if (!civInfo.isMajorCiv()) {
+                    return false
+                }
+
+                val applicableCities =
+                    if (unique.params[1] == "in this city") {
+                        sequenceOf(city!!)
+                    }
+                    else civInfo.cities.asSequence().filter {
+                        it.matchesFilter(unique.params[1])
+                    }
+
+                for (applicableCity in applicableCities) {
+                    for (buildingToRemove in applicableCity.cityConstructions.getBuiltBuildings()) {
+                        if (buildingToRemove.matchesFilter(unique.params[0])) {
+                            applicableCity.cityConstructions.removeBuilding(buildingToRemove)
+                        }
+                    }
+                }
+                return true
+            }
+
             else -> {}
         }
         return false

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -130,6 +130,7 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
     /// Building Maintenance
     GainFreeBuildings("Gain a free [buildingName] [cityFilter]", UniqueTarget.Global, UniqueTarget.Triggerable),
     BuildingMaintenance("[relativeAmount]% maintenance cost for buildings [cityFilter]", UniqueTarget.Global, UniqueTarget.FollowerBelief),
+    RemoveBuilding("Remove [buildingFilter] in [cityFilter]", UniqueTarget.Global, UniqueTarget.Triggerable),
 
     /// Border growth
     BorderGrowthPercentage("[relativeAmount]% Culture cost of natural border growth [cityFilter]", UniqueTarget.Global, UniqueTarget.FollowerBelief),

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -634,6 +634,9 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
     ConditionalWhenAboveAmountResource("when above [amount] [resource]", UniqueTarget.Conditional),
     ConditionalWhenBelowAmountResource("when below [amount] [resource]", UniqueTarget.Conditional),
 
+    ConditionalWhenAboveAmountGold("when above [amount] gold", UniqueTarget.Conditional),
+    ConditionalWhenBelowAmountGold("when below [amount] gold", UniqueTarget.Conditional),
+
     /////// city conditionals
     ConditionalInThisCity("in this city", UniqueTarget.Conditional),
     ConditionalCityWithBuilding("in cities with a [buildingFilter]", UniqueTarget.Conditional),

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -635,8 +635,9 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
     ConditionalWhenAboveAmountResource("when above [amount] [resource]", UniqueTarget.Conditional),
     ConditionalWhenBelowAmountResource("when below [amount] [resource]", UniqueTarget.Conditional),
 
-    ConditionalWhenAboveAmountGold("when above [amount] gold", UniqueTarget.Conditional),
-    ConditionalWhenBelowAmountGold("when below [amount] gold", UniqueTarget.Conditional),
+    // These two functions support only stockpileable resources (Gold, Faith, Culture, Science)
+    ConditionalWhenAboveAmountStat("has more than [amount] [stat]", UniqueTarget.Conditional),
+    ConditionalWhenBelowAmountStat("has less than [amount] [stat]", UniqueTarget.Conditional),
 
     /////// city conditionals
     ConditionalInThisCity("in this city", UniqueTarget.Conditional),

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -632,16 +632,13 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
     ConditionalWithResource("with [resource]", UniqueTarget.Conditional),
     ConditionalWithoutResource("without [resource]", UniqueTarget.Conditional),
 
+    // Supports also stockpileable resources (Gold, Faith, Culture, Science)
     ConditionalWhenAboveAmountResource("when above [amount] [resource]", UniqueTarget.Conditional),
     ConditionalWhenBelowAmountResource("when below [amount] [resource]", UniqueTarget.Conditional),
 
-    // These two conditionals support only stockpileable resources (Gold, Faith, Culture, Science)
-    ConditionalWhenAboveAmountStat("has more than [amount] [stat]", UniqueTarget.Conditional),
-    ConditionalWhenBelowAmountStat("has less than [amount] [stat]", UniqueTarget.Conditional),
-
     // The game speed-adjusted versions of above
-    ConditionalWhenAboveAmountStatSpeed("has more than [amount] [stat] (modified by game speed)", UniqueTarget.Conditional),
-    ConditionalWhenBelowAmountStatSpeed("has less than [amount] [stat] (modified by game speed)", UniqueTarget.Conditional),
+    ConditionalWhenAboveAmountStatSpeed("when above [amount] [stat] (modified by game speed)", UniqueTarget.Conditional),
+    ConditionalWhenBelowAmountStatSpeed("when below [amount] [stat] (modified by game speed)", UniqueTarget.Conditional),
 
     /////// city conditionals
     ConditionalInThisCity("in this city", UniqueTarget.Conditional),

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -130,7 +130,7 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
     /// Building Maintenance
     GainFreeBuildings("Gain a free [buildingName] [cityFilter]", UniqueTarget.Global, UniqueTarget.Triggerable),
     BuildingMaintenance("[relativeAmount]% maintenance cost for buildings [cityFilter]", UniqueTarget.Global, UniqueTarget.FollowerBelief),
-    RemoveBuilding("Remove [buildingFilter] in [cityFilter]", UniqueTarget.Global, UniqueTarget.Triggerable),
+    RemoveBuilding("Remove [buildingFilter] [cityFilter]", UniqueTarget.Global, UniqueTarget.Triggerable),
 
     /// Border growth
     BorderGrowthPercentage("[relativeAmount]% Culture cost of natural border growth [cityFilter]", UniqueTarget.Global, UniqueTarget.FollowerBelief),

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -635,9 +635,13 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
     ConditionalWhenAboveAmountResource("when above [amount] [resource]", UniqueTarget.Conditional),
     ConditionalWhenBelowAmountResource("when below [amount] [resource]", UniqueTarget.Conditional),
 
-    // These two functions support only stockpileable resources (Gold, Faith, Culture, Science)
+    // These two conditionals support only stockpileable resources (Gold, Faith, Culture, Science)
     ConditionalWhenAboveAmountStat("has more than [amount] [stat]", UniqueTarget.Conditional),
     ConditionalWhenBelowAmountStat("has less than [amount] [stat]", UniqueTarget.Conditional),
+
+    // The game speed-adjusted versions of above
+    ConditionalWhenAboveAmountStatSpeed("has more than [amount] [stat] (modified by game speed)", UniqueTarget.Conditional),
+    ConditionalWhenBelowAmountStatSpeed("has less than [amount] [stat] (modified by game speed)", UniqueTarget.Conditional),
 
     /////// city conditionals
     ConditionalInThisCity("in this city", UniqueTarget.Conditional),

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -633,8 +633,8 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
     ConditionalWithoutResource("without [resource]", UniqueTarget.Conditional),
 
     // Supports also stockpileable resources (Gold, Faith, Culture, Science)
-    ConditionalWhenAboveAmountResource("when above [amount] [resource]", UniqueTarget.Conditional),
-    ConditionalWhenBelowAmountResource("when below [amount] [resource]", UniqueTarget.Conditional),
+    ConditionalWhenAboveAmountStatResource("when above [amount] [stat/resource]", UniqueTarget.Conditional),
+    ConditionalWhenBelowAmountStatResource("when below [amount] [stat/resource]", UniqueTarget.Conditional),
 
     // The game speed-adjusted versions of above
     ConditionalWhenAboveAmountStatSpeed("when above [amount] [stat] (modified by game speed)", UniqueTarget.Conditional),

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -1883,6 +1883,16 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 	Applicable to: Conditional
 
+??? example  "&lt;when above [amount] gold&gt;"
+	Example: "&lt;when above [3] gold&gt;"
+
+	Applicable to: Conditional
+
+??? example  "&lt;when below [amount] gold&gt;"
+	Example: "&lt;when below [3] gold&gt;"
+
+	Applicable to: Conditional
+
 ??? example  "&lt;in this city&gt;"
 	Applicable to: Conditional
 

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -10,6 +10,11 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 	Applicable to: Triggerable, Global
 
+??? example  "Remove [buildingFilter] in [cityFilter]"
+	Example: "Remove [Monument] in [in all cities]"
+
+	Applicable to: Triggerable, Global
+
 ??? example  "Free [unit] appears"
 	Example: "Free [Musketman] appears"
 

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -1898,6 +1898,16 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 	Applicable to: Conditional
 
+??? example  "&lt;has more than [amount] [stat] (modified by game speed)&gt;"
+	Example: "&lt;has more than [3] [Culture] (modified by game speed)&gt;"
+
+	Applicable to: Conditional
+
+??? example  "&lt;has less than [amount] [stat] (modified by game speed)&gt;"
+	Example: "&lt;has less than [3] [Culture] (modified by game speed)&gt;"
+
+	Applicable to: Conditional
+
 ??? example  "&lt;in this city&gt;"
 	Applicable to: Conditional
 

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -1888,23 +1888,13 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 	Applicable to: Conditional
 
-??? example  "&lt;has more than [amount] [stat]&gt;"
-	Example: "&lt;has more than [3] [Culture]&gt;"
+??? example  "&lt;when above [amount] [stat] (modified by game speed)&gt;"
+	Example: "&lt;when above [3] [Culture] (modified by game speed)&gt;"
 
 	Applicable to: Conditional
 
-??? example  "&lt;has less than [amount] [stat]&gt;"
-	Example: "&lt;has less than [3] [Culture]&gt;"
-
-	Applicable to: Conditional
-
-??? example  "&lt;has more than [amount] [stat] (modified by game speed)&gt;"
-	Example: "&lt;has more than [3] [Culture] (modified by game speed)&gt;"
-
-	Applicable to: Conditional
-
-??? example  "&lt;has less than [amount] [stat] (modified by game speed)&gt;"
-	Example: "&lt;has less than [3] [Culture] (modified by game speed)&gt;"
+??? example  "&lt;when below [amount] [stat] (modified by game speed)&gt;"
+	Example: "&lt;when below [3] [Culture] (modified by game speed)&gt;"
 
 	Applicable to: Conditional
 

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -10,8 +10,8 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 	Applicable to: Triggerable, Global
 
-??? example  "Remove [buildingFilter] in [cityFilter]"
-	Example: "Remove [Culture] in [in all cities]"
+??? example  "Remove [buildingFilter] [cityFilter]"
+	Example: "Remove [Culture] [in all cities]"
 
 	Applicable to: Triggerable, Global
 

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -1889,12 +1889,12 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 	Applicable to: Conditional
 
 ??? example  "&lt;when above [amount] gold&gt;"
-	Example: "&lt;when above [3] gold&gt;"
+	Example: "&lt;when above [1000] gold&gt;"
 
 	Applicable to: Conditional
 
 ??? example  "&lt;when below [amount] gold&gt;"
-	Example: "&lt;when below [3] gold&gt;"
+	Example: "&lt;when below [100] gold&gt;"
 
 	Applicable to: Conditional
 

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -11,7 +11,7 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 	Applicable to: Triggerable, Global
 
 ??? example  "Remove [buildingFilter] in [cityFilter]"
-	Example: "Remove [Monument] in [in all cities]"
+	Example: "Remove [Culture] in [in all cities]"
 
 	Applicable to: Triggerable, Global
 
@@ -1889,12 +1889,12 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 	Applicable to: Conditional
 
 ??? example  "&lt;when above [amount] gold&gt;"
-	Example: "&lt;when above [1000] gold&gt;"
+	Example: "&lt;when above [3] gold&gt;"
 
 	Applicable to: Conditional
 
 ??? example  "&lt;when below [amount] gold&gt;"
-	Example: "&lt;when below [100] gold&gt;"
+	Example: "&lt;when below [3] gold&gt;"
 
 	Applicable to: Conditional
 

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -1888,13 +1888,13 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 	Applicable to: Conditional
 
-??? example  "&lt;when above [amount] gold&gt;"
-	Example: "&lt;when above [3] gold&gt;"
+??? example  "&lt;has more than [amount] [stat]&gt;"
+	Example: "&lt;has more than [3] [Culture]&gt;"
 
 	Applicable to: Conditional
 
-??? example  "&lt;when below [amount] gold&gt;"
-	Example: "&lt;when below [3] gold&gt;"
+??? example  "&lt;has less than [amount] [stat]&gt;"
+	Example: "&lt;has less than [3] [Culture]&gt;"
 
 	Applicable to: Conditional
 


### PR DESCRIPTION
This is my first programming pull request (I made some translatins two years ago). It consists of three new uniques:

1. <when above [amount] gold>
2. <when below [amount] gold>
3. Remove [buildingFilter] in [cityFilter]

I believe that the 1 will be useful for in-game activities involving stockpiling gold and the 3 will be useful for mods adding "abstaract buildings" (that's how i call it). These can be empire-wide edicts and city-related decisions that can be revoked, unlike social policies.

Unit tests were passed
I also updated the documentation to cover the new uniques