### PR TITLE
Allow "[stats]" unique on terrains

### DIFF
--- a/core/src/com/unciv/logic/map/tile/TileStatFunctions.kt
+++ b/core/src/com/unciv/logic/map/tile/TileStatFunctions.kt
@@ -21,7 +21,7 @@ class TileStatFunctions(val tile: Tile) {
     fun getTileStats(city: City?, observingCiv: Civilization?,
                      localUniqueCache: LocalUniqueCache = LocalUniqueCache(false)
     ): Stats {
-        val stats = getTerrainStats()
+        val stats = getTerrainStats(city, observingCiv)
         var minimumStats = if (tile.isCityCenter()) Stats.DefaultCityCenterMinimum else Stats.ZERO
 
         val stateForConditionals = StateForConditionals(civInfo = observingCiv, city = city, tile = tile)
@@ -93,7 +93,7 @@ class TileStatFunctions(val tile: Tile) {
     }
 
     /** Gets basic stats to start off [getTileStats] or [getTileStartYield], independently mutable result */
-    private fun getTerrainStats(): Stats {
+    private fun getTerrainStats(city: City? = null, observingCiv: Civilization? = null): Stats {
         var stats: Stats? = null
 
         // allTerrains iterates over base, natural wonder, then features
@@ -105,6 +105,11 @@ class TileStatFunctions(val tile: Tile) {
                     stats = terrain.cloneStats()
                 else ->
                     stats.add(terrain)
+            }
+            val stateForConditionals = StateForConditionals(observingCiv, city)
+            for (unique in terrain.getMatchingUniques(UniqueType.Stats, stateForConditionals))
+            {
+                stats.add(unique.stats)
             }
         }
         return stats ?: Stats.ZERO // For tests

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -16,7 +16,7 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
     // region Stat providing uniques
 
     // Used for *global* bonuses and improvement/terrain bonuses
-    Stats("[stats]", UniqueTarget.Global, UniqueTarget.Improvement),
+    Stats("[stats]", UniqueTarget.Global, UniqueTarget.Improvement, UniqueTarget.Terrain),
     // Used for city-wide bonuses
     StatsPerCity("[stats] [cityFilter]", UniqueTarget.Global, UniqueTarget.FollowerBelief),
 


### PR DESCRIPTION
Probably should also add using the unique to resources at some point, but that looks noticeably more complicated