### PR TITLE
Fix [stats] unique adding multiple times

### DIFF
--- a/core/src/com/unciv/logic/map/tile/TileStatFunctions.kt
+++ b/core/src/com/unciv/logic/map/tile/TileStatFunctions.kt
@@ -100,7 +100,7 @@ class TileStatFunctions(val tile: Tile) {
         for (terrain in tile.allTerrains) {
             for (unique in terrain.getMatchingUniques(UniqueType.Stats, stateForConditionals)) {
                 if (stats == null) {
-                    stats = unique.stats
+                    stats = unique.stats.cloneStats()
                 }
                 else stats.add(unique.stats)
             }

--- a/core/src/com/unciv/logic/map/tile/TileStatFunctions.kt
+++ b/core/src/com/unciv/logic/map/tile/TileStatFunctions.kt
@@ -100,7 +100,7 @@ class TileStatFunctions(val tile: Tile) {
         for (terrain in tile.allTerrains) {
             for (unique in terrain.getMatchingUniques(UniqueType.Stats, stateForConditionals)) {
                 if (stats == null) {
-                    stats = unique.stats.cloneStats()
+                    stats = unique.stats.clone()
                 }
                 else stats.add(unique.stats)
             }


### PR DESCRIPTION
Tbh, haven't gotten to a computer to test this
Fixes #10351 
Once again I ask: Why are we starting at `stats = null` and not `stats = Stats.ZERO`? I feel like there must be a reason