### PR TITLE
Tighten RulesetValidator for Terrain

### DIFF
--- a/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
+++ b/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
@@ -328,9 +328,23 @@ class RulesetValidator(val ruleset: Ruleset) {
         if (ruleset.terrains.values.none { it.type == TerrainType.Land && !it.impassable })
             lines += "No passable land terrains exist!"
         for (terrain in ruleset.terrains.values) {
-            for (baseTerrain in terrain.occursOn)
-                if (!ruleset.terrains.containsKey(baseTerrain))
-                    lines += "${terrain.name} occurs on terrain $baseTerrain which does not exist!"
+            for (baseTerrainName in terrain.occursOn) {
+                val baseTerrain = ruleset.terrains[baseTerrainName]
+                if (baseTerrain == null)
+                    lines += "${terrain.name} occurs on terrain $baseTerrainName which does not exist!"
+                else if (baseTerrain.type == TerrainType.NaturalWonder)
+                    lines.add("${terrain.name} occurs on natural wonder $baseTerrainName: Unsupported.", RulesetErrorSeverity.WarningOptionsOnly)
+            }
+            if (terrain.type == TerrainType.NaturalWonder) {
+                if (terrain.turnsInto == null)
+                    lines += "Natural Wonder ${terrain.name} is missing the turnsInto attribute!"
+                val baseTerrain = ruleset.terrains[terrain.turnsInto]
+                if (baseTerrain == null)
+                    lines += "${terrain.name} turns into terrain ${terrain.turnsInto} which does not exist!"
+                else if (!baseTerrain.type.isBaseTerrain)
+                // See https://github.com/hackedpassword/Z2/blob/main/HybridTileTech.md for a clever exploit
+                    lines.add("${terrain.name} turns into terrain ${terrain.turnsInto} which is not a base terrain!", RulesetErrorSeverity.Warning)
+            }
             uniqueValidator.checkUniques(terrain, lines, rulesetSpecific, tryFixUnknownUniques)
         }
     }

--- a/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
+++ b/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
@@ -342,7 +342,7 @@ class RulesetValidator(val ruleset: Ruleset) {
                 if (baseTerrain == null)
                     lines += "${terrain.name} turns into terrain ${terrain.turnsInto} which does not exist!"
                 else if (!baseTerrain.type.isBaseTerrain)
-                // See https://github.com/hackedpassword/Z2/blob/main/HybridTileTech.md for a clever exploit
+                    // See https://github.com/hackedpassword/Z2/blob/main/HybridTileTech.md for a clever exploit
                     lines.add("${terrain.name} turns into terrain ${terrain.turnsInto} which is not a base terrain!", RulesetErrorSeverity.Warning)
             }
             uniqueValidator.checkUniques(terrain, lines, rulesetSpecific, tryFixUnknownUniques)


### PR DESCRIPTION
This adds a warning for the exploit documented in [HybridTileTech.md](https://github.com/hackedpassword/Z2/blob/main/HybridTileTech.md). Sorry, @hackedpassword, but at least you get a Warning only and a honorable mention in a source comment.

What happens with that exploit is - you get a tile where neither isLand nor isWater return true. Consequences for pathfinding *seem* nondestructive, but that unintentional un-planned-for situation is a time bomb - a regression trigger waiting to happen.

The idea in that Mod, however, should get a solution some day. "Bridges and Canals", if and when implemented in some form, may also solve some current problems - ships passing cities on hills take 2 movement for the step iirc, and so on. Something that allows ships and land units to share tile movement domains, both being able to cross without embarkation, if possible constructible (think panama canal), and optionally requiring a road to function as bridge? Something in a supported and unit-tested fashion.