### PR TITLE
AI units swap-retreat

### DIFF
--- a/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
@@ -1016,9 +1016,10 @@ object NextTurnAutomation {
         if (unit.isCivilian() && !unit.isGreatPersonOfType("War")) return 1 // Civilian
         if (unit.baseUnit.isAirUnit()) return 2
         val distance = if (!isAtWar) 0 else unit.getDistanceToEnemyUnit(6)
-        return (distance ?: 5) + when {
-            unit.baseUnit.isRanged() -> 2
-            unit.baseUnit.isMelee() -> 3
+        // Lower health units should move earlier to swap with higher health units
+        return distance + (unit.health / 10) + when {
+            unit.baseUnit.isRanged() -> 10
+            unit.baseUnit.isMelee() -> 30
             unit.isGreatPersonOfType("War") -> 100 // Generals move after military units
             else -> 1
         }

--- a/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
@@ -195,7 +195,7 @@ object UnitAutomation {
 
         if (tryHeadTowardsOurSiegedCity(unit)) return
 
-        if (unit.health < 50 && (tryRetreat(unit) || tryHealUnit(unit))) return // do nothing but heal
+        if (unit.health < 50 && (trySwapRetreat(unit) || tryHealUnit(unit))) return // do nothing but heal
 
         // if a embarked melee unit can land and attack next turn, do not attack from water.
         if (BattleHelper.tryDisembarkUnitToAttackPosition(unit)) return
@@ -254,7 +254,7 @@ object UnitAutomation {
         return true
     }
     
-    private fun tryRetreat(unit: MapUnit): Boolean {
+    private fun trySwapRetreat(unit: MapUnit): Boolean {
         if (!unit.civ.isAtWar()) return false
         // Precondition: This must be a military unit
         if (unit.isCivilian()) return false

--- a/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
@@ -267,7 +267,7 @@ object UnitAutomation {
         for (swapTile in swapableTiles) {
             val otherUnit = swapTile.militaryUnit!!
             if (otherUnit.health > 80 
-                && otherUnit.getDistanceToEnemyUnit(6, false) < unit.getDistanceToEnemyUnit(6,false)) {
+                && unit.getDistanceToEnemyUnit(6, false) < otherUnit.getDistanceToEnemyUnit(6,false)) {
                 if (otherUnit.baseUnit.isRanged()) {
                     // Don't swap ranged units closer than they have to be
                     val range = otherUnit.baseUnit.range

--- a/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
@@ -255,6 +255,7 @@ object UnitAutomation {
     }
     
     private fun tryRetreat(unit: MapUnit): Boolean {
+        if (!unit.civ.isAtWar()) return false
         // Precondition: This must be a military unit
         if (unit.isCivilian()) return false
         // Better to do a more healing oriented move then

--- a/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
@@ -263,7 +263,7 @@ object UnitAutomation {
         }
 
         val unitDistanceToTiles = unit.movement.getDistanceToTiles()
-        val swapableTiles = unitDistanceToTiles.keys.filter { it.militaryUnit != null && it.militaryUnit!!.owner == unit.owner}
+        val swapableTiles = unitDistanceToTiles.keys.filter { it.militaryUnit != null && it.militaryUnit!!.owner == unit.owner}.reversed()
         for (swapTile in swapableTiles) {
             val otherUnit = swapTile.militaryUnit!!
             if (otherUnit.health > 80 

--- a/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
@@ -257,6 +257,8 @@ object UnitAutomation {
     private fun tryRetreat(unit: MapUnit): Boolean {
         // Precondition: This must be a military unit
         if (unit.isCivilian()) return false
+        // Better to do a more healing oriented move then
+        if (unit.getDistanceToEnemyUnit(6, true) > 5) return false
         
         if (unit.baseUnit.isAirUnit()) {
             return false

--- a/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
@@ -259,7 +259,7 @@ object UnitAutomation {
         // Precondition: This must be a military unit
         if (unit.isCivilian()) return false
         // Better to do a more healing oriented move then
-        if (unit.getDistanceToEnemyUnit(6, true) > 5) return false
+        if (unit.getDistanceToEnemyUnit(6, true) > 4) return false
         
         if (unit.baseUnit.isAirUnit()) {
             return false

--- a/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
@@ -485,7 +485,8 @@ class MapUnit : IsPartOfGameInfoSerialization {
             && tile.militaryUnit!!.civ.isAtWarWith(civ)
             && !tile.militaryUnit!!.isInvisible(civ)
         
-        cache.distanceToClosestEnemyUnit = Int.MAX_VALUE
+        // Needs to be a high value, but not the max value so we can still add to it
+        cache.distanceToClosestEnemyUnit = 500000
         for (i in 1..maxDist) {
             if (currentTile.getTilesAtDistance(i).any { 
                     tileHasEnemyCity(it) || tileHasEnemyMilitaryUnit(it) }) {

--- a/core/src/com/unciv/logic/map/mapunit/MapUnitCache.kt
+++ b/core/src/com/unciv/logic/map/mapunit/MapUnitCache.kt
@@ -70,6 +70,9 @@ class MapUnitCache(private val mapUnit: MapUnit) {
     var hasStrengthBonusInRadiusUnique = false
 
     var hasCitadelPlacementUnique = false
+    
+    var distanceToClosestEnemyUnit: Int? = null
+    var distanceToClosestEnemyUnitSearched: Int? = null
 
     fun updateUniques(){
 

--- a/core/src/com/unciv/logic/map/mapunit/movement/UnitMovement.kt
+++ b/core/src/com/unciv/logic/map/mapunit/movement/UnitMovement.kt
@@ -300,16 +300,9 @@ class UnitMovement(val unit: MapUnit) {
         if (otherUnit.owner != unit.owner
                 || otherUnit.cache.cannotMove  // redundant, line below would cover it too
                 || !otherUnit.movement.canReachInCurrentTurn(ourPosition)) return false
-        // Check if we could enter their tile if they wouldn't be there
-        otherUnit.removeFromTile()
-        val weCanEnterTheirTile = canMoveTo(reachableTile)
-        otherUnit.putInTile(reachableTile)
-        if (!weCanEnterTheirTile) return false
-        // Check if they could enter our tile if we wouldn't be here
-        unit.removeFromTile()
-        val theyCanEnterOurTile = otherUnit.movement.canMoveTo(ourPosition)
-        unit.putInTile(ourPosition)
-        if (!theyCanEnterOurTile) return false
+        
+        if (!canMoveTo(reachableTile, canSwap = true)) return false
+        if (!otherUnit.movement.canMoveTo(ourPosition, canSwap = true)) return false
         // All clear!
         return true
     }


### PR DESCRIPTION
Part of #10362

When an AI has a big group of units I often see that melee units tend to fortify in front of an enemy city when they are lower on hp since they can't move anywhere to heal. This commit addresses that issue by allowing those units to swap with the healthier melee units that are waiting on them.

Previously I implemented the MapUnit.getDistanceToClosestEnemyUnit() to prioritize updating units closer to enemy units first. Now I have changed this function to store its value in a cache. I also changed the unit update priority to include the unit's health, since more damaged units need to be swapped first.

The main addition is the tryRetreat() function. If a unit is below 50 health, it will check all tiles that the unit can move to and see if it should swap with a friendly unit. This function makes use of the cached getDistanceToClosestEnemy() value for a quick comparison.

tryRetreat() does not do anything with the non-swappable tiles yet. If we do want to include the non-swappable tiles, I would suggest changing getDistanceToClosestEnemy() to be assigned only to a tile instead of a unit.

One last thing to note, I changed canMoveTo() to also include a swap option and canUnitSwapToReachableTile() to use the canMoveTo() swap option so that it doesn't remove and place units back again. For context, I was getting some rare errors with the tryRetreat() function and this solved it.