### PR TITLE
City overview refreshes for changes done in a CityScreen called from it

### DIFF
--- a/core/src/com/unciv/ui/screens/overviewscreen/CityOverviewTab.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/CityOverviewTab.kt
@@ -1,8 +1,9 @@
 package com.unciv.ui.screens.overviewscreen
 
 import com.unciv.logic.civilization.Civilization
-import com.unciv.ui.components.widgets.SortableGrid
 import com.unciv.ui.components.extensions.equalizeColumns
+import com.unciv.ui.components.widgets.SortableGrid
+import com.unciv.ui.components.widgets.TabbedPager
 
 
 /**
@@ -52,5 +53,14 @@ class CityOverviewTab(
     init {
         top()
         add(grid)
+    }
+
+    override fun activated(index: Int, caption: String, pager: TabbedPager) {
+        super.activated(index, caption, pager)
+        // Being here can mean the user closed a CityScreen we opened from the first column - or the overview was just opened.
+        // To differentiate, the EmpireOverviewScreen.resume code lies and passes an empty caption - a kludge, but a clean
+        // callback architecture would mean a lot more work
+        if (caption.isEmpty())
+            grid.updateDetails()
     }
 }

--- a/core/src/com/unciv/ui/screens/overviewscreen/EmpireOverviewScreen.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/EmpireOverviewScreen.kt
@@ -5,8 +5,8 @@ import com.unciv.Constants
 import com.unciv.GUI
 import com.unciv.logic.civilization.Civilization
 import com.unciv.logic.civilization.Notification
-import com.unciv.ui.components.widgets.TabbedPager
 import com.unciv.ui.components.input.KeyCharAndCode
+import com.unciv.ui.components.widgets.TabbedPager
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.screens.basescreen.BaseScreen
 import com.unciv.ui.screens.basescreen.RecreateOnResize
@@ -110,5 +110,13 @@ class EmpireOverviewScreen(
         GUI.resetToWorldScreen()
         notification.resetExecuteRoundRobin()
         notification.execute(worldScreen)
+    }
+
+    override fun resume() {
+        // This is called by UncivGame.popScreen - e.g. after City Tab opened a City and the user closes that CityScreen...
+        // Notify the current tab via its IPageExtensions.activated entry point so it can refresh if needed
+        val index = tabbedPager.activePage
+        val category = EmpireOverviewCategories.values()[index - 1]
+        pageObjects[category]?.activated(index, "", tabbedPager) // Fake caption marks this as popScreen-triggered
     }
 }


### PR DESCRIPTION
To clarify: Currently, you click on the city name button in city overview, annex, raze, change production or somesuch, and upon 'exit city' you wouldn't see the changes until closing and reopening overview. This fixes that.

... I set out to add two more things but those could get complex, and I didn't have the energy: Positioning the city selected (button moved) on WorldScreen into view on opening the Overview, and moving the WorldScreen to the last opened City when closing City Overview. For `#`1 I would need to implement the existing open 'select' function and for `#`2 I would need to shift the grid column provider's "activation context" down to the city tab context, and remap all activations ...