### PR TITLE
AI trading uses gold inflation

### DIFF
--- a/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
@@ -175,7 +175,7 @@ object NextTurnAutomation {
             if (offer.type == TradeType.Treaty)
                 continue // Don't try to counter with a defensive pact or research pact
 
-            val value = evaluation.evaluateBuyCost(offer, civInfo, otherCiv)
+            val value = evaluation.evaluateBuyCostWithInflation(offer, civInfo, otherCiv)
             if (value > 0)
                 potentialAsks[offer] = value
         }
@@ -204,7 +204,7 @@ object NextTurnAutomation {
             // Remove 1 amount as long as doing so does not change the price
             val originalValue = counterofferAsks[ask]!!
             while (ask.amount > 1
-                    && originalValue == evaluation.evaluateBuyCost(
+                    && originalValue == evaluation.evaluateBuyCostWithInflation(
                             TradeOffer(ask.name, ask.type, ask.amount - 1, ask.duration),
                             civInfo, otherCiv) ) {
                 ask.amount--
@@ -216,7 +216,7 @@ object NextTurnAutomation {
         for (goldAsk in counterofferAsks.keys
                 .filter { it.type == TradeType.Gold_Per_Turn || it.type == TradeType.Gold }
                 .sortedByDescending { it.type.ordinal }) { // Do GPT first
-            val valueOfOne = evaluation.evaluateBuyCost(TradeOffer(goldAsk.name, goldAsk.type, 1, goldAsk.duration), civInfo, otherCiv)
+            val valueOfOne = evaluation.evaluateBuyCostWithInflation(TradeOffer(goldAsk.name, goldAsk.type, 1, goldAsk.duration), civInfo, otherCiv)
             val amountCanBeRemoved = deltaInOurFavor / valueOfOne
             if (amountCanBeRemoved >= goldAsk.amount) {
                 deltaInOurFavor -= counterofferAsks[goldAsk]!!
@@ -236,7 +236,7 @@ object NextTurnAutomation {
                     .sortedByDescending { it.type.ordinal }) {
                 if (tradeLogic.currentTrade.theirOffers.none { it.type == ourGold.type } &&
                         counterofferAsks.keys.none { it.type == ourGold.type } ) {
-                    val valueOfOne = evaluation.evaluateSellCost(TradeOffer(ourGold.name, ourGold.type, 1, ourGold.duration), civInfo, otherCiv)
+                    val valueOfOne = evaluation.evaluateSellCostWithInflation(TradeOffer(ourGold.name, ourGold.type, 1, ourGold.duration), civInfo, otherCiv)
                     val amountToGive = min(deltaInOurFavor / valueOfOne, ourGold.amount)
                     deltaInOurFavor -= amountToGive * valueOfOne
                     if (amountToGive > 0) {

--- a/core/src/com/unciv/logic/trade/TradeEvaluation.kt
+++ b/core/src/com/unciv/logic/trade/TradeEvaluation.kt
@@ -97,7 +97,7 @@ class TradeEvaluation {
     
     fun evaluateBuyCostWithInflation(offer: TradeOffer, civInfo: Civilization, tradePartner: Civilization): Int {
         if (offer.type != TradeType.Gold && offer.type != TradeType.Gold_Per_Turn)
-            return (evaluateBuyCost(offer, civInfo, tradePartner) * getGoldInflation(civInfo)).toInt()
+            return (evaluateBuyCost(offer, civInfo, tradePartner) / getGoldInflation(civInfo)).toInt()
         return evaluateBuyCost(offer, civInfo, tradePartner)
     }
 
@@ -206,7 +206,7 @@ class TradeEvaluation {
 
     fun evaluateSellCostWithInflation(offer: TradeOffer, civInfo: Civilization, tradePartner: Civilization): Int {
         if (offer.type != TradeType.Gold && offer.type != TradeType.Gold_Per_Turn)
-            return (evaluateSellCost(offer, civInfo, tradePartner) * getGoldInflation(civInfo)).toInt()
+            return (evaluateSellCost(offer, civInfo, tradePartner) / getGoldInflation(civInfo)).toInt()
         return evaluateSellCost(offer, civInfo, tradePartner)
     }
 
@@ -314,7 +314,8 @@ class TradeEvaluation {
         // To visualise the function, plug this into a 2d graphing calculator
         // \frac{500}{x^{1.2}+500}
         // Goes from 1 at GPT = 0 to .11 at GPT = 1000 
-        return  modifier / (goldPerTurn.pow(1.2) + modifier)
+        val returnValue = modifier / (goldPerTurn.pow(1.2).coerceAtLeast(0.0) + modifier)
+        return  returnValue
     }
     
     /** This code returns a positive value if the city is significantly far away from the capital

--- a/core/src/com/unciv/logic/trade/TradeEvaluation.kt
+++ b/core/src/com/unciv/logic/trade/TradeEvaluation.kt
@@ -275,7 +275,7 @@ class TradeEvaluation {
                 val stats = city.cityStats.currentCityStats
                 val sumOfStats =
                     stats.culture + stats.gold + stats.science + stats.production + stats.happiness + stats.food + distanceBonus
-                return min(sumOfStats.toInt() * 100, 1000)
+                return (sumOfStats.toInt() * 100).coerceAtLeast(1000)
             }
             TradeType.Agreement -> {
                 if (offer.name == Constants.openBorders) {

--- a/core/src/com/unciv/logic/trade/TradeEvaluation.kt
+++ b/core/src/com/unciv/logic/trade/TradeEvaluation.kt
@@ -309,12 +309,14 @@ class TradeEvaluation {
      * Gold is worth less as the civilization has a higher income
      */
     fun getGoldInflation(civInfo: Civilization): Double {
-        val modifier: Double = 1500.0
+        val modifier: Double = 1000.0
         val goldPerTurn = civInfo.stats.statsForNextTurn.gold.toDouble()
         // To visualise the function, plug this into a 2d graphing calculator
-        // \frac{500}{x^{1.2}+500}
-        // Goes from 1 at GPT = 0 to .11 at GPT = 1000 
-        val returnValue = modifier / (goldPerTurn.pow(1.2).coerceAtLeast(0.0) + modifier)
+        // \frac{1000}{x^{1.2}+1.11*1000}
+        // Goes from 1 at GPT = 0 to .834 at GPT = 100, .296 at GPT = 1000 and 0.116 at GPT = 10000
+        // The current value of gold will never go below 10% or the .1f that it is set to
+        // So this does not scale off to infinity
+        val returnValue = modifier / (goldPerTurn.pow(1.2).coerceAtLeast(0.0) + (1.11f * modifier)) + .1f
         return  returnValue
     }
     

--- a/core/src/com/unciv/logic/trade/TradeEvaluation.kt
+++ b/core/src/com/unciv/logic/trade/TradeEvaluation.kt
@@ -309,7 +309,7 @@ class TradeEvaluation {
      * Gold is worth less as the civilization has a higher income
      */
     fun getGoldInflation(civInfo: Civilization): Double {
-        val modifier: Double = 500.0
+        val modifier: Double = 1500.0
         val goldPerTurn = civInfo.stats.statsForNextTurn.gold.toDouble()
         // To visualise the function, plug this into a 2d graphing calculator
         // \frac{500}{x^{1.2}+500}

--- a/core/src/com/unciv/logic/trade/TradeEvaluation.kt
+++ b/core/src/com/unciv/logic/trade/TradeEvaluation.kt
@@ -6,7 +6,6 @@ import com.unciv.logic.automation.ThreatLevel
 import com.unciv.logic.automation.civilization.NextTurnAutomation
 import com.unciv.logic.city.City
 import com.unciv.logic.civilization.Civilization
-import com.unciv.logic.civilization.diplomacy.DiplomacyFlags
 import com.unciv.logic.civilization.diplomacy.RelationshipLevel
 import com.unciv.logic.map.tile.Tile
 import com.unciv.models.ruleset.ModOptionsConstants
@@ -309,15 +308,13 @@ class TradeEvaluation {
      * Gold is worth less as the civilization has a higher income
      */
     fun getGoldInflation(civInfo: Civilization): Double {
-        val modifier: Double = 1000.0
+        val modifier = 1000.0
         val goldPerTurn = civInfo.stats.statsForNextTurn.gold.toDouble()
-        // To visualise the function, plug this into a 2d graphing calculator
-        // \frac{1000}{x^{1.2}+1.11*1000}
+        // To visualise the function, plug this into a 2d graphing calculator \frac{1000}{x^{1.2}+1.11*1000}
         // Goes from 1 at GPT = 0 to .834 at GPT = 100, .296 at GPT = 1000 and 0.116 at GPT = 10000
         // The current value of gold will never go below 10% or the .1f that it is set to
         // So this does not scale off to infinity
-        val returnValue = modifier / (goldPerTurn.pow(1.2).coerceAtLeast(0.0) + (1.11f * modifier)) + .1f
-        return  returnValue
+        return modifier / (goldPerTurn.pow(1.2).coerceAtLeast(0.0) + (1.11f * modifier)) + .1f
     }
     
     /** This code returns a positive value if the city is significantly far away from the capital


### PR DESCRIPTION
This commit addresses the issues discussed in #7328. However, instead of hardcoding it into each era, I created an inflation function to smooth out the process and dynamically apply inflation.

All offers that aren't directly gold now have an extra modifier based on inflation multiplied to them. The function of inflation is based on the GPT of the civ as follows: `(1000/(x^(1.2)+1.11*1000)) + .1`. To get the current value of any offer, we divide the offer by the inflation function. Since the inflation function is always <= 1, it will increase the value of the offer.

<details><summary>Here is the graph of the function</summary>
The inflation value can never go below .1, so the current value of gold will never be less than 10% of its original value.
At GPT = 500, the value of each offer is twice as much.
At GPT = 1000, the value of each offer is more than three times as much.

![InflationGraph](https://github.com/yairm210/Unciv/assets/7538725/15794c51-8a7d-49cf-9cd6-06706f3884f5)

</details> 

How inflation and the function should be implemented is still in question, so please tell me if you think it could be improved. I guess I sort of skipped the question, but should there even be an inflation mechanic?

While adding this feature, I found an error that was introduced in the #9096 commit. Instead of setting the minimum sell value of a city, they actually set the maximum sell value of any city to 1000. This caused the AI to sell its cities for very cheap.