### PR TITLE
Modded Citadel no longer hard-codes name and icon in Notification

### DIFF
--- a/core/src/com/unciv/logic/civilization/NotificationIcons.kt
+++ b/core/src/com/unciv/logic/civilization/NotificationIcons.kt
@@ -4,7 +4,6 @@ object NotificationIcon {
     // Remember: The typical white-on-transparency icon will not be visible on Notifications
 
     const val Barbarians = "ImprovementIcons/Barbarian encampment"
-    const val Citadel = "ImprovementIcons/Citadel"
     const val City = "ImprovementIcons/City center"
     const val CityState = "OtherIcons/CityState"
     const val Crosshair = "OtherIcons/CrosshairB"

--- a/core/src/com/unciv/logic/map/mapunit/UnitTurnManager.kt
+++ b/core/src/com/unciv/logic/map/mapunit/UnitTurnManager.kt
@@ -84,26 +84,28 @@ class UnitTurnManager(val unit: MapUnit) {
             ?: return
         if (damage == 0) return
         unit.health -= damage
+        val improvementName = citadelTile.improvement!!  // guarded by `getUnpillagedImprovement() != null` above
+        val improvementIcon = "ImprovementIcons/$improvementName"
         val locations = LocationAction(citadelTile.position, unit.currentTile.position)
         if (unit.health <= 0) {
             unit.civ.addNotification(
-                "An enemy [Citadel] has destroyed our [${unit.name}]",
+                "An enemy [$improvementName] has destroyed our [${unit.name}]",
                 locations,
                 NotificationCategory.War,
-                NotificationIcon.Citadel, NotificationIcon.Death, unit.name
+                improvementIcon, NotificationIcon.Death, unit.name
             )
             citadelTile.getOwner()?.addNotification(
-                "Your [Citadel] has destroyed an enemy [${unit.name}]",
+                "Your [$improvementName] has destroyed an enemy [${unit.name}]",
                 locations,
                 NotificationCategory.War,
-                NotificationIcon.Citadel, NotificationIcon.Death, unit.name
+                improvementIcon, NotificationIcon.Death, unit.name
             )
             unit.destroy()
         } else unit.civ.addNotification(
-            "An enemy [Citadel] has attacked our [${unit.name}]",
+            "An enemy [$improvementName] has attacked our [${unit.name}]",
             locations,
             NotificationCategory.War,
-            NotificationIcon.Citadel, NotificationIcon.War, unit.name
+            improvementIcon, NotificationIcon.War, unit.name
         )
     }
 


### PR DESCRIPTION
Closes #10329. Delayed since I asked for a save in that issue - but re-reading the diff I guess it can't go wrong?