### PR TITLE
Potpourri of RekMod-inspired little updates

### DIFF
--- a/core/src/com/unciv/logic/city/CityStats.kt
+++ b/core/src/com/unciv/logic/city/CityStats.kt
@@ -295,7 +295,7 @@ class CityStats(val city: City) {
         for (unique in city.getMatchingUniques(UniqueType.StatPercentFromReligionFollowers))
             addUniqueStats(unique, Stat.valueOf(unique.params[1]),
                 min(
-                    unique.params[0].toFloat() * city.religion.getFollowersOfMajorityReligion(),
+                    unique.params[0].toFloat() * city.religion.getFollowersOfOurReligion(),
                     unique.params[2].toFloat()
                 ))
 

--- a/core/src/com/unciv/logic/city/managers/CityReligionManager.kt
+++ b/core/src/com/unciv/logic/city/managers/CityReligionManager.kt
@@ -199,6 +199,11 @@ class CityReligionManager : IsPartOfGameInfoSerialization {
         return followers[majorityReligion]
     }
 
+    fun getFollowersOfOurReligion(): Int {
+        val ourReligion = city.civ.religionManager.religion ?: return 0
+        return followers[ourReligion.name]
+    }
+
     fun getFollowersOfOtherReligionsThan(religion: String): Int {
         return followers.filterNot { it.key == religion }.values.sum()
     }

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -40,7 +40,7 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
     StatPercentBonusCities("[relativeAmount]% [stat] [cityFilter]", UniqueTarget.Global, UniqueTarget.FollowerBelief),
     StatPercentFromObject("[relativeAmount]% [stat] from every [tileFilter/buildingFilter]", UniqueTarget.Global, UniqueTarget.FollowerBelief),
     AllStatsPercentFromObject("[relativeAmount]% Yield from every [tileFilter/buildingFilter]", UniqueTarget.Global, UniqueTarget.FollowerBelief),
-    StatPercentFromReligionFollowers("[relativeAmount]% [stat] from every follower, up to [relativeAmount]%", UniqueTarget.FollowerBelief),
+    StatPercentFromReligionFollowers("[relativeAmount]% [stat] from every follower, up to [relativeAmount]%", UniqueTarget.FollowerBelief, UniqueTarget.FounderBelief),
     BonusStatsFromCityStates("[relativeAmount]% [stat] from City-States", UniqueTarget.Global),
     StatPercentFromTradeRoutes("[relativeAmount]% [stat] from Trade Routes", UniqueTarget.Global),
 

--- a/core/src/com/unciv/models/ruleset/validation/UniqueValidator.kt
+++ b/core/src/com/unciv/models/ruleset/validation/UniqueValidator.kt
@@ -216,7 +216,7 @@ class UniqueValidator(val ruleset: Ruleset) {
 
     private fun isFilteringUniqueAllowed(unique: Unique): Boolean {
         // Isolate this decision, to allow easy change of approach
-        // This says: Must have no conditionals or parameters, and is contained in GlobalUniques
+        // This says: Must have no conditionals or parameters, and is used in any "filtering" parameter of another Unique
         if (unique.conditionals.isNotEmpty() || unique.params.isNotEmpty()) return false
         return unique.text in allUniqueParameters // referenced at least once from elsewhere
     }

--- a/core/src/com/unciv/ui/screens/pickerscreens/ImprovementPickerScreen.kt
+++ b/core/src/com/unciv/ui/screens/pickerscreens/ImprovementPickerScreen.kt
@@ -31,16 +31,8 @@ class ImprovementPickerScreen(
 ) : PickerScreen() {
 
     companion object {
-        /** Set of resolvable improvement building problems that this class knows how to report. */
-        private val reportableProblems = setOf(
-            ImprovementBuildingProblem.MissingTech,
-            ImprovementBuildingProblem.NotJustOutsideBorders,
-            ImprovementBuildingProblem.OutsideBorders,
-            ImprovementBuildingProblem.MissingResources
-        )
-
         /** Return true if we can report improvements associated with the [problems] (or there are no problems for it at all). */
-        fun canReport(problems: Collection<ImprovementBuildingProblem>) = problems.all { it in reportableProblems }
+        fun canReport(problems: Collection<ImprovementBuildingProblem>) = problems.all { it.reportable }
     }
 
     private var selectedImprovement: TileImprovement? = null

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsFromUniques.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsFromUniques.kt
@@ -236,6 +236,11 @@ object UnitActionsFromUniques {
             val improvement = tile.ruleset.tileImprovements[improvementName]
                 ?: continue
 
+            // Try to skip Improvements we can never build
+            // (getImprovementBuildingProblems catches those so the button is always disabled, but it nevertheless looks nicer)
+            if (tile.improvementFunctions.getImprovementBuildingProblems(improvement, unit.civ).any { it.permanent })
+                continue
+
             val resourcesAvailable = improvement.uniqueObjects.none {
                     improvementUnique ->
                 improvementUnique.isOfType(UniqueType.ConsumesResources) &&

--- a/docs/Modders/Mod-file-structure/1-Overview.md
+++ b/docs/Modders/Mod-file-structure/1-Overview.md
@@ -95,7 +95,10 @@ Example: `"uniques":["[+1 Gold] <with a garrison>"]` on a building - does almost
 
 All Unique "types" that have an implementation in Unciv are automatically documented in [uniques](../uniques.md). Note that file is entirely machine-generated from source code structures. Also kindly note the separate sections for [conditionals](../uniques.md#conditional-uniques) and [trigger conditions](../uniques.md#triggercondition-uniques).
 Uniques that do not correspond to any of those entries (verbatim including upper/lower case!) are called "untyped", will have no _direct_ effect, and may result in the "Ruleset Validator" showing warnings (see the Options Tab "Locate mod errors", it also runs when starting new games).
-A legitimate use of "untyped" Uniques is their use as markers that can be recognized elsewhere in filters (example: "Aircraft" in the vanilla rulesets used as [Unit filter](../Unique-parameters.md#baseunitfilter)). To allow "Ruleset Validator" to warn about mistakes leading to untyped uniques, but still allow the "filtering Unique" use, those should be "declared" by including each in [GlobalUniques](5-Miscellaneous-JSON-files.md#globaluniquesjson), too.
+A legitimate use of "untyped" Uniques is their use as markers that can be recognized elsewhere in **filters** (example: "Aircraft" in the vanilla rulesets used as [Unit filter](../Unique-parameters.md#baseunitfilter)).
+This use is recognized by the "Ruleset Validator" and not flagged as invalid - but a filtering Unique must also use _no placeholders or conditionals_ to pass the test.
+If you get the "not found in Unciv's unique types" warning, but are sure you are using a correct filtering Unique, please look for exactly identical spelling in all places, including upper/lower case.
+Note: Currently some mods use untyped Uniques not for filtering purposes, but as purely informational tool. The team will try to think of an approach for that use that won't trigger validation warnings without reducing validation quality, but as of now, those are unavoidable.
 
 ## Information on JSON files used in the game
 

--- a/docs/Modders/Mod-file-structure/5-Miscellaneous-JSON-files.md
+++ b/docs/Modders/Mod-file-structure/5-Miscellaneous-JSON-files.md
@@ -214,9 +214,6 @@ Defines uniques that apply globally. e.g. Vanilla rulesets define the effects of
 Only the `uniques` field is used, but a name must still be set (the Ruleset validator might display it).
 When extension rulesets define GlobalUniques, all uniques are merged. At the moment there is no way to change/remove uniques set by a base mod.
 
-Note: Mods can use "arbitrary" Uniques as purely filtering uniques. They are not "Typed" by Unciv code and thus have no actual effect implementation - except by being filterable elsewhere.
-In the near future, the ruleset validator will show warnings for all these, unless they are also included here, as validation that they are intentional (and - they **must** have **no** placeholders or conditionals).
-
 ## Tutorials.json
 
 [link to original](https://github.com/yairm210/Unciv/tree/master/android/assets/jsons/Tutorials.json)

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -934,15 +934,15 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 	Applicable to: FounderBelief
 
+??? example  "[relativeAmount]% [stat] from every follower, up to [relativeAmount]%"
+	Example: "[+20]% [Culture] from every follower, up to [+20]%"
+
+	Applicable to: FounderBelief, FollowerBelief
+
 ## FollowerBelief uniques
 !!! note ""
 
     Uniques for Pantheon and Follower type beliefs, that will apply to each city where the religion is the majority religion
-
-??? example  "[relativeAmount]% [stat] from every follower, up to [relativeAmount]%"
-	Example: "[+20]% [Culture] from every follower, up to [+20]%"
-
-	Applicable to: FollowerBelief
 
 ??? example  "Earn [amount]% of [mapUnitFilter] unit's [costOrStrength] as [civWideStat] when killed within 4 tiles of a city following this religion"
 	Example: "Earn [3]% of [Wounded] unit's [Cost] as [Gold] when killed within 4 tiles of a city following this religion"


### PR DESCRIPTION
Sorry, really, for not splitting the commits into PR's. All stem from one evening of actually trying out RekMod - and have descriptive commit messages. Also included, the mentioned filtering Unique documentation update.

I'm promising a better solution for "comment" Uniques there...
* To be displayed e.g. within the "Policy branch box" for "on adopt, on complete" -> begs the question whether showing the full Civilopedia text might be an acceptable compromise - in the description label, not the policy box, too crowded
* Other examples where the implementation is elsewhere as Conditional, but the referenced object does not show the use as Conditional parameter?? Can all be covered without untyped Uniques perhaps? More deep-digging lookups (Nah) to automatically display the relations?
* AND/OR a dedicated "Comment" UniqueType, maybe `Comment("Comment: []", UniqueTarget.*),` and hide the UniqueType-recognition key from UI via english.properties?
* Sugar - That UniqueTarget list on HiddenFromCivilopedia should then read `*UniqueTarget.All`...
* I feel more and more we should have some extra documentation field on UniqueType too, like UniqueParameterType.docDescription, to pass through in UniqueDocsWriter... 