### PR TITLE
Fixed Nuke Error

### DIFF
--- a/core/src/com/unciv/logic/automation/unit/AirUnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/AirUnitAutomation.kt
@@ -127,10 +127,10 @@ object AirUnitAutomation {
                     val tileExplosionValue = if (targetTile == tile) 80 else 50
                     
                     if (targetUnit.isMilitary()) {
-                        explosionValue += if (targetTile == tile) evaluateCivValue(targetTile.militaryUnit?.civ!!, -200, tileExplosionValue)
-                        else evaluateCivValue(targetTile.militaryUnit?.civ!!, -150, 50)
+                        explosionValue += if (targetTile == tile) evaluateCivValue(targetUnit.civ, -200, tileExplosionValue)
+                        else evaluateCivValue(targetUnit.civ, -150, 50)
                     } else if (targetUnit.isCivilian()) {
-                        explosionValue += evaluateCivValue(targetTile.civilianUnit?.civ!!, -100, tileExplosionValue / 2)
+                        explosionValue += evaluateCivValue(targetUnit.civ, -100, tileExplosionValue / 2)
                     }
                 }
             }


### PR DESCRIPTION
Fixes #10405 

This error comes from a nuke checking if a unit on a tile is a military unit but checks the owning civ of the land/sea military unit on the tile. So if a tile has a plane or missile it will have a military unit without having a land/sea military unit. The error originally came from my PR #10346.