### PR TITLE
Improved settler AI

### DIFF
--- a/core/src/com/unciv/logic/automation/Automation.kt
+++ b/core/src/com/unciv/logic/automation/Automation.kt
@@ -450,7 +450,7 @@ object Automation {
                     stats.gold
                 else
                     stats.gold / 3 // 3 gold is much worse than 2 production
-
+        rank += stats.happiness * 3
         rank += stats.production
         rank += stats.science
         rank += stats.culture

--- a/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
+++ b/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
@@ -18,7 +18,7 @@ object CityLocationTileRanker {
         else unit.civ.cities.minOf { it.getCenterTile().aerialDistanceTo(unit.getTile()) }
         val range = (8 - distanceFromHome).coerceIn(1, 5) // Restrict vision when far from home to avoid death marches
         val nearbyCities = unit.civ.gameInfo.getCities()
-            .filter { it.getCenterTile().aerialDistanceTo(unit.getTile()) <= 4 + range }
+            .filter { it.getCenterTile().aerialDistanceTo(unit.getTile()) <= 3 + range }
 
         val possibleCityLocations = unit.getTile().getTilesInDistance(range)
             .filter { canSettleTile(it, unit.civ, nearbyCities) && (unit.currentTile == it || unit.movement.canMoveTo(it)) }
@@ -42,10 +42,10 @@ object CityLocationTileRanker {
         val modConstants = civ.gameInfo.ruleset.modOptions.constants
         // The AI is allowed to cheat and act like it knows the whole map.
         if (!(tile.isExplored(civ) || civ.isAI())) return false
-        if (!tile.isLand) return false
+        if (!tile.isLand || tile.isImpassible()) return false
         if (!(tile.getOwner() == null || tile.getOwner() == civ)) return false
         if (nearbyCities.any {
-                it.getCenterTile().aerialDistanceTo(tile) <
+                it.getCenterTile().aerialDistanceTo(tile) <=
                     if (tile.getContinent() == it.getCenterTile().getContinent()) modConstants.minimalCityDistance
                     else modConstants.minimalCityDistanceOnDifferentContinents
             }) return false

--- a/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
+++ b/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
@@ -18,7 +18,7 @@ object CityLocationTileRanker {
             .filter { it.getCenterTile().aerialDistanceTo(unit.getTile()) > 3 + range }
 
         val possibleCityLocations = unit.getTile().getTilesInDistance(range)
-            .filter { canSettleTile(it, unit.civ, nearbyCities) && unit.movement.canMoveTo(it) }
+            .filter { canSettleTile(it, unit.civ, nearbyCities) && (unit.currentTile == it || unit.movement.canMoveTo(it)) }
         val uniqueCache = LocalUniqueCache()
         val baseTileMap = HashMap<Tile, Float>()
         return possibleCityLocations.map {
@@ -31,7 +31,7 @@ object CityLocationTileRanker {
         if (!(tile.isExplored(civ) || civ.isAI())) return false
         if (!tile.isLand) return false
         if (!(tile.getOwner() == null || tile.getOwner() == civ)) return false
-        if (!nearbyCities.any {
+        if (nearbyCities.any {
                 it.getCenterTile().aerialDistanceTo(tile) <
                     if (tile.getContinent() == it.getCenterTile().getContinent()) modConstants.minimalCityDistance
                     else modConstants.minimalCityDistanceOnDifferentContinents
@@ -86,7 +86,7 @@ object CityLocationTileRanker {
             return rankTileValue + locationSpecificTileValue
         }
 
-        if (onCoast) tileValue += 10
+        if (onCoast) tileValue += 30
         if (tile.isAdjacentToRiver()) tileValue += 5
         if (tile.terrainHasUnique(UniqueType.FreshWater)) tileValue += 5
         // We want to found the city on an oasis because it can't be improved otherwise

--- a/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
+++ b/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
@@ -24,7 +24,7 @@ object CityLocationTileRanker {
             .filter { canSettleTile(it, unit.civ, nearbyCities) && (unit.currentTile == it || unit.movement.canMoveTo(it)) }
         val uniqueCache = LocalUniqueCache()
         val baseTileMap = HashMap<Tile, Float>()
-        val tileRankMap = HashMap<Tile,Float>()
+        val tileRankMap = HashMap<Tile, Float>()
         var maxValueTile: Tile? = null
         var maxValueRank: Float = 0f
         for (tile in possibleCityLocations) {
@@ -52,7 +52,7 @@ object CityLocationTileRanker {
         return true
     }
 
-    private fun rankTileToSettle(tile: Tile, civ: Civilization, nearbyCities: Sequence<City>, 
+    private fun rankTileToSettle(tile: Tile, civ: Civilization, nearbyCities: Sequence<City>,
                                  baseTileMap: HashMap<Tile, Float>, uniqueCache: LocalUniqueCache): Float {
         var tileValue = 0f
         for (city in nearbyCities) {
@@ -65,8 +65,9 @@ object CityLocationTileRanker {
                 else -> 0
             }
             // It is worse to settle cities near our own compare to near another civ
-            if (city.civ == civ)
             // Do not settle near our capital unless really necessary
+            // Having a strong capital is esential to constructing wonders
+            if (city.civ == civ)
                 distanceToCityModifier *= if (city.isCapital()) 5 else 2
             tileValue -= distanceToCityModifier
         }
@@ -75,35 +76,39 @@ object CityLocationTileRanker {
 
         fun rankTile(rankTile: Tile): Float {
             var locationSpecificTileValue = 0f
-            // Don't settle near by not on the coast
-            if (tile.isWater && !onCoast) locationSpecificTileValue -= 20
+            // Don't settle near but not on the coast
+            if (tile.isCoastalTile() && !onCoast) locationSpecificTileValue -= 20
             // Check if everything else has been calculated, if so return it
             if (baseTileMap.containsKey(rankTile)) return locationSpecificTileValue + baseTileMap[rankTile]!!
             if (rankTile.getOwner() != null && rankTile.getOwner() != civ) return 0f
-            
+
             var rankTileValue = Automation.rankStatsValue(rankTile.stats.getTileStats(null, civ, uniqueCache), civ)
 
             if (rankTile.resource != null) {
-                if (rankTile.tileResource.resourceType == ResourceType.Strategic) {
-                    rankTileValue += 3 * rankTile.resourceAmount
-                } else if (rankTile.tileResource.resourceType == ResourceType.Luxury) {
-                    rankTileValue += if (civ.hasResource(rankTile.resource!!)) 10 * rankTile.resourceAmount
-                    else 30 + 10 * (rankTile.resourceAmount - 1)
+                rankTileValue += when (rankTile.tileResource.resourceType) {
+                    ResourceType.Bonus -> 2
+                    ResourceType.Strategic -> 3 * rankTile.resourceAmount
+                    ResourceType.Luxury ->
+                        // For all normal maps, lets just assume resourceAmmount = 1
+                        if (civ.hasResource(rankTile.resource!!)) 5 * rankTile.resourceAmount
+                        else 12 + 5 * (rankTile.resourceAmount - 1)
                 }
             }
-            
-            if (rankTile.isNaturalWonder()) rankTileValue += 15
+
+            if (rankTile.isNaturalWonder()) rankTileValue += 10
 
             baseTileMap[rankTile] = rankTileValue
 
             return rankTileValue + locationSpecificTileValue
         }
 
-        if (onCoast) tileValue += 30
-        if (tile.isAdjacentToRiver()) tileValue += 5
+        if (onCoast) tileValue += 10
+        if (tile.isAdjacentToRiver()) tileValue += 3
         if (tile.terrainHasUnique(UniqueType.FreshWater)) tileValue += 5
         // We want to found the city on an oasis because it can't be improved otherwise
-        if (tile.terrainHasUnique(UniqueType.Unbuildable)) tileValue += 5
+        if (tile.terrainHasUnique(UniqueType.Unbuildable)) tileValue += 3
+        // If we build the city on a resource tile, then we can't build any special improvements on it
+        if (tile.resource != null) tileValue -= 2
 
         for (i in 0..3) {
             for (nearbyTile in tile.getTilesInDistanceRange(IntRange(i, i))) {

--- a/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
+++ b/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
@@ -41,11 +41,11 @@ object CityLocationTileRanker {
     private fun canSettleTile(tile: Tile, civ: Civilization, nearbyCities: Sequence<City>): Boolean {
         val modConstants = civ.gameInfo.ruleset.modOptions.constants
         // The AI is allowed to cheat and act like it knows the whole map.
-        if (!(tile.isExplored(civ) || civ.isAI())) return false
+        if (!tile.isExplored(civ) && !civ.isAI()) return false
         if (!tile.isLand || tile.isImpassible()) return false
-        if (!(tile.getOwner() == null || tile.getOwner() == civ)) return false
+        if (tile.getOwner() != null && tile.getOwner() != civ) return false
         if (nearbyCities.any {
-                it.getCenterTile().aerialDistanceTo(tile) <=
+                it.getCenterTile().aerialDistanceTo(tile) - 1 <=
                     if (tile.getContinent() == it.getCenterTile().getContinent()) modConstants.minimalCityDistance
                     else modConstants.minimalCityDistanceOnDifferentContinents
             }) return false

--- a/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
+++ b/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
@@ -60,25 +60,25 @@ object CityLocationTileRanker {
         for (city in nearbyCities) {
             val distanceToCity = newCityTile.aerialDistanceTo(city.getCenterTile())
             var distanceToCityModifier = when {
-                distanceToCity == 5 -> 3
-                distanceToCity == 4 -> 6
-                distanceToCity == 3 -> 9
-                distanceToCity < 3 -> 15 // Even if it is a mod that lets us settle closer, lets still not do it
-                else -> 0
+                distanceToCity == 6 -> 2f
+                distanceToCity == 5 -> 5f
+                distanceToCity == 4 -> 10f
+                distanceToCity == 3 -> 15f
+                distanceToCity < 3 -> 25f // Even if it is a mod that lets us settle closer, lets still not do it
+                else -> 0f
             }
             // Bigger cities will expand more so we want to stay away from them
             // Reduces the chance that we don't settle at the begining
             distanceToCityModifier *= when {
-                city.population.population >= 12 -> 4
-                city.population.population >= 8 -> 3
-                city.population.population >= 3 -> 2
-                else -> 1
+                city.population.population >= 12 -> 4f
+                city.population.population >= 8 -> 3f
+                city.population.population >= 3 -> 2f
+                else -> 1f
             }
             // It is worse to settle cities near our own compare to near another civ
             // Do not settle near our capital unless really necessary
             // Having a strong capital is esential to constructing wonders
-            if (city.civ == civ && city.isCapital())
-                distanceToCityModifier *= 2
+            if (city.civ == civ) distanceToCityModifier *= if (city.isCapital()) 5 else 2
             tileValue -= distanceToCityModifier
         }
 

--- a/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
+++ b/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
@@ -20,7 +20,7 @@ object CityLocationTileRanker {
             (8 - distanceFromHome).coerceIn(1, 5) // Restrict vision when far from home to avoid death marches
         }
         val nearbyCities = unit.civ.gameInfo.getCities()
-            .filter { it.getCenterTile().aerialDistanceTo(unit.getTile()) <= 6 + range }
+            .filter { it.getCenterTile().aerialDistanceTo(unit.getTile()) <= 7 + range }
 
         val possibleCityLocations = unit.getTile().getTilesInDistance(range)
             .filter { canSettleTile(it, unit.civ, nearbyCities) && (unit.getTile() == it || unit.movement.canMoveTo(it)) }
@@ -61,7 +61,7 @@ object CityLocationTileRanker {
             val distanceToCity = newCityTile.aerialDistanceTo(city.getCenterTile())
             var distanceToCityModifier = when {
                 // NOTE: the line it.getCenterTile().aerialDistanceTo(unit.getTile()) <= X + range
-                // above MUST have the constant X that is added to the range be higher or equal to the highest distance here
+                // above MUST have the constant X that is added to the range be higher or equal to the highest distance here + 1
                 // If it is not higher the settler may get stuck when it ranks the same tile differently 
                 // as it moves away from the city and doesn't include it in the calculation 
                 // and values it higher than when it moves closer to the city

--- a/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
+++ b/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
@@ -60,17 +60,25 @@ object CityLocationTileRanker {
         for (city in nearbyCities) {
             val distanceToCity = newCityTile.aerialDistanceTo(city.getCenterTile())
             var distanceToCityModifier = when {
-                distanceToCity == 5 -> 20
-                distanceToCity == 4 -> 30
-                distanceToCity == 3 -> 50
-                distanceToCity < 3 -> 100 // Even if it is a mod that lets us settle closer, lets still not do it
+                distanceToCity == 5 -> 3
+                distanceToCity == 4 -> 6
+                distanceToCity == 3 -> 9
+                distanceToCity < 3 -> 15 // Even if it is a mod that lets us settle closer, lets still not do it
                 else -> 0
+            }
+            // Bigger cities will expand more so we want to stay away from them
+            // Reduces the chance that we don't settle at the begining
+            distanceToCityModifier *= when {
+                city.population.population >= 12 -> 4
+                city.population.population >= 8 -> 3
+                city.population.population >= 3 -> 2
+                else -> 1
             }
             // It is worse to settle cities near our own compare to near another civ
             // Do not settle near our capital unless really necessary
             // Having a strong capital is esential to constructing wonders
-            if (city.civ == civ)
-                distanceToCityModifier *= if (city.isCapital()) 5 else 2
+            if (city.civ == civ && city.isCapital())
+                distanceToCityModifier *= 2
             tileValue -= distanceToCityModifier
         }
 

--- a/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
+++ b/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
@@ -92,40 +92,6 @@ object CityLocationTileRanker {
         // Only count a luxary resource that we don't have yet as unique once
         val newUniqueLuxuryResources = HashSet<String>()
 
-        fun rankTile(rankTile: Tile): Float {
-            var locationSpecificTileValue = 0f
-            // Don't settle near but not on the coast
-            if (rankTile.isCoastalTile() && !onCoast) locationSpecificTileValue -= 10
-            // Apply the effect of having a lighthouse, since we can probably assume that we will build it
-            if (onCoast && rankTile.isOcean) locationSpecificTileValue += 1
-            // Check if there are any new unique luxury resources
-            if (rankTile.resource != null && rankTile.tileResource.resourceType == ResourceType.Luxury
-                && !(civ.hasResource(rankTile.resource!!) || newUniqueLuxuryResources.contains(rankTile.resource))) {
-                locationSpecificTileValue += 10
-                newUniqueLuxuryResources.add(rankTile.resource!!)
-            }
-
-            // Check if everything else has been calculated, if so return it
-            if (baseTileMap.containsKey(rankTile)) return locationSpecificTileValue + baseTileMap[rankTile]!!
-            if (rankTile.getOwner() != null && rankTile.getOwner() != civ) return 0f
-
-            var rankTileValue = Automation.rankStatsValue(rankTile.stats.getTileStats(null, civ, uniqueCache), civ)
-
-            if (rankTile.resource != null) {
-                rankTileValue += when (rankTile.tileResource.resourceType) {
-                    ResourceType.Bonus -> 2f
-                    ResourceType.Strategic -> 1.2f * rankTile.resourceAmount
-                    ResourceType.Luxury -> 5f * rankTile.resourceAmount
-                }
-            }
-
-            if (rankTile.isNaturalWonder()) rankTileValue += 10
-
-            baseTileMap[rankTile] = rankTileValue
-
-            return rankTileValue + locationSpecificTileValue
-        }
-
         if (onCoast) tileValue += 15
         if (newCityTile.isAdjacentToRiver()) tileValue += 10
         if (newCityTile.terrainHasUnique(UniqueType.FreshWater)) tileValue += 5
@@ -136,9 +102,45 @@ object CityLocationTileRanker {
 
         for (i in 0..3) {
             for (nearbyTile in newCityTile.getTilesAtDistance(i)) {
-                tileValue += rankTile(nearbyTile)
+                tileValue += rankTile(nearbyTile, civ, onCoast, newUniqueLuxuryResources, baseTileMap, uniqueCache)
             }
         }
         return tileValue
     }
+
+    private fun rankTile(rankTile: Tile, civ:Civilization, onCoast: Boolean, newUniqueLuxuryResources:HashSet<String>, 
+                         baseTileMap: HashMap<Tile, Float>, uniqueCache: LocalUniqueCache): Float {
+        var locationSpecificTileValue = 0f
+        // Don't settle near but not on the coast
+        if (rankTile.isCoastalTile() && !onCoast) locationSpecificTileValue -= 10
+        // Apply the effect of having a lighthouse, since we can probably assume that we will build it
+        if (onCoast && rankTile.isOcean) locationSpecificTileValue += 1
+        // Check if there are any new unique luxury resources
+        if (rankTile.resource != null && rankTile.tileResource.resourceType == ResourceType.Luxury
+            && !(civ.hasResource(rankTile.resource!!) || newUniqueLuxuryResources.contains(rankTile.resource))) {
+            locationSpecificTileValue += 10
+            newUniqueLuxuryResources.add(rankTile.resource!!)
+        }
+
+        // Check if everything else has been calculated, if so return it
+        if (baseTileMap.containsKey(rankTile)) return locationSpecificTileValue + baseTileMap[rankTile]!!
+        if (rankTile.getOwner() != null && rankTile.getOwner() != civ) return 0f
+
+        var rankTileValue = Automation.rankStatsValue(rankTile.stats.getTileStats(null, civ, uniqueCache), civ)
+
+        if (rankTile.resource != null) {
+            rankTileValue += when (rankTile.tileResource.resourceType) {
+                ResourceType.Bonus -> 2f
+                ResourceType.Strategic -> 1.2f * rankTile.resourceAmount
+                ResourceType.Luxury -> 5f * rankTile.resourceAmount
+            }
+        }
+
+        if (rankTile.isNaturalWonder()) rankTileValue += 10
+
+        baseTileMap[rankTile] = rankTileValue
+
+        return rankTileValue + locationSpecificTileValue
+    }
+
 }

--- a/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
+++ b/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
@@ -88,6 +88,8 @@ object CityLocationTileRanker {
             var locationSpecificTileValue = 0f
             // Don't settle near but not on the coast
             if (rankTile.isCoastalTile() && !onCoast) locationSpecificTileValue -= 10
+            // Apply the effect of having a lighthouse, since we can probably assume that we will build it
+            if (onCoast && rankTile.isOcean) locationSpecificTileValue += 1
             // Check if everything else has been calculated, if so return it
             if (baseTileMap.containsKey(rankTile)) return locationSpecificTileValue + baseTileMap[rankTile]!!
             if (rankTile.getOwner() != null && rankTile.getOwner() != civ) return 0f

--- a/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
+++ b/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
@@ -20,7 +20,7 @@ object CityLocationTileRanker {
             (8 - distanceFromHome).coerceIn(1, 5) // Restrict vision when far from home to avoid death marches
         }
         val nearbyCities = unit.civ.gameInfo.getCities()
-            .filter { it.getCenterTile().aerialDistanceTo(unit.getTile()) <= 3 + range }
+            .filter { it.getCenterTile().aerialDistanceTo(unit.getTile()) <= 6 + range }
 
         val possibleCityLocations = unit.getTile().getTilesInDistance(range)
             .filter { canSettleTile(it, unit.civ, nearbyCities) && (unit.getTile() == it || unit.movement.canMoveTo(it)) }
@@ -60,6 +60,11 @@ object CityLocationTileRanker {
         for (city in nearbyCities) {
             val distanceToCity = newCityTile.aerialDistanceTo(city.getCenterTile())
             var distanceToCityModifier = when {
+                // NOTE: the line it.getCenterTile().aerialDistanceTo(unit.getTile()) <= X + range
+                // above MUST have the constant X that is added to the range be higher or equal to the highest distance here
+                // If it is not higher the settler may get stuck when it ranks the same tile differently 
+                // as it moves away from the city and doesn't include it in the calculation 
+                // and values it higher than when it moves closer to the city
                 distanceToCity == 6 -> 2f
                 distanceToCity == 5 -> 5f
                 distanceToCity == 4 -> 10f

--- a/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
+++ b/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
@@ -18,7 +18,7 @@ object CityLocationTileRanker {
         else unit.civ.cities.minOf { it.getCenterTile().aerialDistanceTo(unit.getTile()) }
         val range = (8 - distanceFromHome).coerceIn(1, 5) // Restrict vision when far from home to avoid death marches
         val nearbyCities = unit.civ.gameInfo.getCities()
-            .filter { it.getCenterTile().aerialDistanceTo(unit.getTile()) > 3 + range }
+            .filter { it.getCenterTile().aerialDistanceTo(unit.getTile()) <= 4 + range }
 
         val possibleCityLocations = unit.getTile().getTilesInDistance(range)
             .filter { canSettleTile(it, unit.civ, nearbyCities) && (unit.currentTile == it || unit.movement.canMoveTo(it)) }

--- a/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
+++ b/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
@@ -13,7 +13,7 @@ object CityLocationTileRanker {
     /**
      * Returns a hashmap of tiles to their ranking plus the a the highest value tile and its value
      */
-    fun getBestTilesToFoundCity(unit: MapUnit, distanceToSearch: Int? = null): Pair<HashMap<Tile, Float>, Pair<Tile?, Float>> {
+    fun getBestTilesToFoundCity(unit: MapUnit, distanceToSearch: Int? = null): Pair<HashMap<Tile, Float>, Tile?> {
         val range =  if (distanceToSearch != null) distanceToSearch else {
             val distanceFromHome = if (unit.civ.cities.isEmpty()) 0
             else unit.civ.cities.minOf { it.getCenterTile().aerialDistanceTo(unit.getTile()) }
@@ -37,7 +37,7 @@ object CityLocationTileRanker {
             }
             tileRankMap[tile] = tileValue
         }
-        return Pair(tileRankMap, Pair(maxValueTile, maxValueRank))
+        return Pair(tileRankMap, maxValueTile)
     }
 
     private fun canSettleTile(tile: Tile, civ: Civilization, nearbyCities: Sequence<City>): Boolean {

--- a/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
+++ b/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
@@ -45,7 +45,7 @@ object CityLocationTileRanker {
         if (!tile.isLand || tile.isImpassible()) return false
         if (tile.getOwner() != null && tile.getOwner() != civ) return false
         if (nearbyCities.any {
-                it.getCenterTile().aerialDistanceTo(tile) - 1 <=
+                it.getCenterTile().aerialDistanceTo(tile) <=
                     if (tile.getContinent() == it.getCenterTile().getContinent()) modConstants.minimalCityDistance
                     else modConstants.minimalCityDistanceOnDifferentContinents
             }) return false

--- a/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
+++ b/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
@@ -42,8 +42,6 @@ object CityLocationTileRanker {
 
     private fun canSettleTile(tile: Tile, civ: Civilization, nearbyCities: Sequence<City>): Boolean {
         val modConstants = civ.gameInfo.ruleset.modOptions.constants
-        // The AI is allowed to cheat and act like it knows the whole map.
-        if (!tile.isExplored(civ) && !civ.isAI()) return false
         if (!tile.isLand || tile.isImpassible()) return false
         if (tile.getOwner() != null && tile.getOwner() != civ) return false
         if (nearbyCities.any {

--- a/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
+++ b/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
@@ -125,7 +125,7 @@ object CityLocationTileRanker {
             return rankTileValue + locationSpecificTileValue
         }
 
-        if (onCoast) tileValue += 10
+        if (onCoast) tileValue += 15
         if (newCityTile.isAdjacentToRiver()) tileValue += 10
         if (newCityTile.terrainHasUnique(UniqueType.FreshWater)) tileValue += 5
         // We want to found the city on an oasis because it can't be improved otherwise

--- a/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
+++ b/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
@@ -44,11 +44,14 @@ object CityLocationTileRanker {
         val modConstants = civ.gameInfo.ruleset.modOptions.constants
         if (!tile.isLand || tile.isImpassible()) return false
         if (tile.getOwner() != null && tile.getOwner() != civ) return false
-        if (nearbyCities.any {
-                it.getCenterTile().aerialDistanceTo(tile) <=
-                    if (tile.getContinent() == it.getCenterTile().getContinent()) modConstants.minimalCityDistance
-                    else modConstants.minimalCityDistanceOnDifferentContinents
-            }) return false
+        for (city in nearbyCities) {
+            val distance = city.getCenterTile().aerialDistanceTo(tile)
+            if (tile.getContinent() == city.getCenterTile().getContinent()) {
+                if (distance <= modConstants.minimalCityDistance) return false
+            } else {
+                if (distance <= modConstants.minimalCityDistanceOnDifferentContinents) return false
+            }
+        }
         return true
     }
 

--- a/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
+++ b/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
@@ -77,7 +77,7 @@ object CityLocationTileRanker {
         fun rankTile(rankTile: Tile): Float {
             var locationSpecificTileValue = 0f
             // Don't settle near but not on the coast
-            if (tile.isCoastalTile() && !onCoast) locationSpecificTileValue -= 20
+            if (rankTile.isCoastalTile() && !onCoast) locationSpecificTileValue -= 20
             // Check if everything else has been calculated, if so return it
             if (baseTileMap.containsKey(rankTile)) return locationSpecificTileValue + baseTileMap[rankTile]!!
             if (rankTile.getOwner() != null && rankTile.getOwner() != civ) return 0f

--- a/core/src/com/unciv/logic/automation/unit/SpecificUnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/SpecificUnitAutomation.kt
@@ -118,20 +118,18 @@ object SpecificUnitAutomation {
             val allUnsettledSettlers = unit.civ.units.getCivUnits().filter { it.currentMovement > 0 && it.baseUnit == unit.baseUnit }
 
             // Don't settle immediately if we only have one settler, look for a better location
-            if (allUnsettledSettlers.count() > 1) {
-                val bestSettlerInRange = allUnsettledSettlers.maxByOrNull {
-                    if (bestTilesToFoundCity.containsKey(it.getTile()))
-                        bestTilesToFoundCity[it.getTile()]!!
-                    else -1f
-                }
-                if (bestSettlerInRange == unit && foundCityAction?.action != null) {
-                    foundCityAction.action.invoke()
-                    return
-                }
-                // Since this settler is not in the best location, lets assume the best settler will found their city where they are
-                if (bestSettlerInRange != null)
-                    bestTilesToFoundCity = HashMap(bestTilesToFoundCity.filter { it.key.aerialDistanceTo(bestSettlerInRange.getTile()) > 4 })
+            val bestSettlerInRange = allUnsettledSettlers.maxByOrNull {
+                if (bestTilesToFoundCity.containsKey(it.getTile()))
+                    bestTilesToFoundCity[it.getTile()]!!
+                else -1f
             }
+            if (bestSettlerInRange == unit && foundCityAction?.action != null) {
+                foundCityAction.action.invoke()
+                return
+            }
+            // Since this settler is not in the best location, lets assume the best settler will found their city where they are
+            if (bestSettlerInRange != null)
+                bestTilesToFoundCity = HashMap(bestTilesToFoundCity.filter { it.key.aerialDistanceTo(bestSettlerInRange.getTile()) > 4 })
         }
 
 

--- a/core/src/com/unciv/logic/automation/unit/SpecificUnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/SpecificUnitAutomation.kt
@@ -107,7 +107,7 @@ object SpecificUnitAutomation {
         // It's possible that we'll see a tile "over the sea" that's better than the tiles close by, but that's not a reason to abandon the close tiles!
         // Also this lead to some routing problems, see https://github.com/yairm210/Unciv/issues/3653
         val bestTilesToFoundCityReturn = CityLocationTileRanker.getBestTilesToFoundCity(unit, rangeToSearch)
-        val bestTilesToFoundCity = bestTilesToFoundCityReturn.first
+        var bestTilesToFoundCity = bestTilesToFoundCityReturn.first
         val bestTile = bestTilesToFoundCityReturn.second.first
         val bestTileRank = bestTilesToFoundCityReturn.second.second
         var bestCityLocation: Tile? = null
@@ -130,7 +130,7 @@ object SpecificUnitAutomation {
                 }
                 // Since this settler is not in the best location, lets assume the best settler will found their city where they are
                 if (bestSettlerInRange != null)
-                    bestTilesToFoundCity.filter { it.key.aerialDistanceTo(bestSettlerInRange.getTile()) > 4 }
+                    bestTilesToFoundCity = HashMap(bestTilesToFoundCity.filter { it.key.aerialDistanceTo(bestSettlerInRange.getTile()) > 4 })
             }
         }
 

--- a/core/src/com/unciv/logic/automation/unit/SpecificUnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/SpecificUnitAutomation.kt
@@ -115,7 +115,7 @@ object SpecificUnitAutomation {
         // It's possible that we'll see a tile "over the sea" that's better than the tiles close by, but that's not a reason to abandon the close tiles!
         // Also this lead to some routing problems, see https://github.com/yairm210/Unciv/issues/3653
         val bestCityLocation: Tile? =
-                CityLocationTileRanker.getBestTilesToFoundCity(unit).firstOrNull {
+                CityLocationTileRanker.getBestTilesToFoundCity(unit).take(5).firstOrNull {
                     if (it.first in tilesWhereWeWillBeCaptured) return@firstOrNull false
                     val pathSize = unit.movement.getShortestPath(it.first).size
                     return@firstOrNull pathSize in 1..3

--- a/core/src/com/unciv/logic/automation/unit/SpecificUnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/SpecificUnitAutomation.kt
@@ -103,7 +103,7 @@ object SpecificUnitAutomation {
         // If we have gone more than 3 turns without founding a city lets search a wider area
         // TODO: Figure out a way to not use turns as it might not be the best metric, what if we are a civ starting in the middle of a game?
         val rangeToSearch = if (unit.civ.cities.isEmpty() && unit.civ.gameInfo.turns < 4) (3 - unit.civ.gameInfo.turns).coerceAtLeast(1) else null
-        
+
         // It's possible that we'll see a tile "over the sea" that's better than the tiles close by, but that's not a reason to abandon the close tiles!
         // Also this lead to some routing problems, see https://github.com/yairm210/Unciv/issues/3653
         val bestTilesInfo = CityLocationTileRanker.getBestTilesToFoundCity(unit, rangeToSearch)
@@ -135,12 +135,12 @@ object SpecificUnitAutomation {
                 && (bestTilesInfo.bestTile == null || bestTilesInfo.tileRankMap[unit.getTile()]!! >= bestTilesInfo.tileRankMap[bestTilesInfo.bestTile]!! - 10)) {
                 bestCityLocation = unit.getTile()
         }
-        
+
         //Shortcut, if the best tile is nearby than lets just take it
         if (bestCityLocation == null && bestTilesInfo.bestTile != null && unit.movement.getShortestPath(bestTilesInfo.bestTile!!).size in 1..3) {
             bestCityLocation = bestTilesInfo.bestTile
         }
-        
+
         if (bestCityLocation == null) {
             // Find the best tile that is within
             bestCityLocation = bestTilesInfo.tileRankMap.filter { bestTilesInfo.bestTile == null || it.value >= bestTilesInfo.tileRankMap[bestTilesInfo.bestTile]!! - 5 }.asSequence().sortedByDescending { it.value }.firstOrNull {

--- a/core/src/com/unciv/logic/automation/unit/SpecificUnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/SpecificUnitAutomation.kt
@@ -156,7 +156,8 @@ object SpecificUnitAutomation {
         }
 
         // We still haven't found a best city tile within 3 turns so lets just head to the best tile
-        if (bestCityLocation == null && bestTile != null) {
+        // Note that we must check that the shortest path exists or else an error will be thrown
+        if (bestCityLocation == null && bestTile != null && unit.movement.getShortestPath(bestTile).size in 1..8) {
             bestCityLocation = bestTile
         }
 

--- a/core/src/com/unciv/logic/automation/unit/SpecificUnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/SpecificUnitAutomation.kt
@@ -128,7 +128,7 @@ object SpecificUnitAutomation {
         }
         
         //Shortcut, if the best tile is nearby than lets just take it
-        if (bestCityLocation == null && bestTile != null && unit.movement.getShortestPath(bestTile).size <= 3) {
+        if (bestCityLocation == null && bestTile != null && unit.movement.getShortestPath(bestTile).size in 1..3) {
             bestCityLocation = bestTile
         }
         

--- a/core/src/com/unciv/logic/automation/unit/SpecificUnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/SpecificUnitAutomation.kt
@@ -128,7 +128,7 @@ object SpecificUnitAutomation {
         }
         
         //Shortcut, if the best tile is nearby than lets just take it
-        if (bestCityLocation == null && unit.movement.getShortestPath(bestTile!!).size <= 3) {
+        if (bestCityLocation == null && bestTile != null && unit.movement.getShortestPath(bestTile).size <= 3) {
             bestCityLocation = bestTile
         }
         
@@ -139,7 +139,6 @@ object SpecificUnitAutomation {
                 val pathSize = unit.movement.getShortestPath(it.key).size
                 return@firstOrNull pathSize in 1..3
             }?.key
-            
         }
 
         if (bestCityLocation == null) { // We got a badass over here, all tiles within 5 are taken?

--- a/core/src/com/unciv/logic/automation/unit/SpecificUnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/SpecificUnitAutomation.kt
@@ -97,20 +97,20 @@ object SpecificUnitAutomation {
     }
 
     fun automateSettlerActions(unit: MapUnit, tilesWhereWeWillBeCaptured: Set<Tile>) {
-        if (unit.civ.gameInfo.turns == 0) {   // Special case, we want AI to settle in place on turn 1.
-            val foundCityAction = UnitActionsFromUniques.getFoundCityAction(unit, unit.getTile())
-            // Depending on era and difficulty we might start with more than one settler. In that case settle the one with the best location
-            val otherSettlers = unit.civ.units.getCivUnits().filter { it.currentMovement > 0 && it.baseUnit == unit.baseUnit }
-            val unitTileRanking = CityLocationTileRanker.rankTileAsCityCenter(unit.getTile(), unit.civ)
-            if (foundCityAction?.action != null &&
-                    otherSettlers.none {
-                        CityLocationTileRanker.rankTileAsCityCenter(it.getTile(), unit.civ) > unitTileRanking
-                    }
-            ) {
-                foundCityAction.action.invoke()
-                return
-            }
-        }
+//        if (unit.civ.gameInfo.turns == 0) {   // Special case, we want AI to settle in place on turn 1.
+//            val foundCityAction = UnitActionsFromUniques.getFoundCityAction(unit, unit.getTile())
+//            // Depending on era and difficulty we might start with more than one settler. In that case settle the one with the best location
+//            val otherSettlers = unit.civ.units.getCivUnits().filter { it.currentMovement > 0 && it.baseUnit == unit.baseUnit }
+//            val unitTileRanking = CityLocationTileRanker.rankTileAsCityCenter(unit.getTile(), unit.civ)
+//            if (foundCityAction?.action != null &&
+//                    otherSettlers.none {
+//                        CityLocationTileRanker.rankTileAsCityCenter(it.getTile(), unit.civ) > unitTileRanking
+//                    }
+//            ) {
+//                foundCityAction.action.invoke()
+//                return
+//            }
+//        }
 
         // It's possible that we'll see a tile "over the sea" that's better than the tiles close by, but that's not a reason to abandon the close tiles!
         // Also this lead to some routing problems, see https://github.com/yairm210/Unciv/issues/3653

--- a/core/src/com/unciv/logic/automation/unit/SpecificUnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/SpecificUnitAutomation.kt
@@ -108,8 +108,7 @@ object SpecificUnitAutomation {
         // Also this lead to some routing problems, see https://github.com/yairm210/Unciv/issues/3653
         val bestTilesToFoundCityReturn = CityLocationTileRanker.getBestTilesToFoundCity(unit, rangeToSearch)
         var bestTilesToFoundCity = bestTilesToFoundCityReturn.first
-        val bestTile = bestTilesToFoundCityReturn.second.first
-        val bestTileRank = bestTilesToFoundCityReturn.second.second
+        val bestTile = bestTilesToFoundCityReturn.second
         var bestCityLocation: Tile? = null
 
         if (unit.civ.gameInfo.turns == 0 && unit.civ.cities.isEmpty() && bestTilesToFoundCity.containsKey(unit.getTile())) {   // Special case, we want AI to settle in place on turn 1.
@@ -135,7 +134,7 @@ object SpecificUnitAutomation {
 
         // If the tile we are currently on is close to the best tile, then lets just settle here instead
         if (bestTilesToFoundCity.containsKey(unit.getTile()) 
-                && bestTilesToFoundCity[unit.getTile()]!! >= bestTileRank - 10) {
+                && (bestTile == null || bestTilesToFoundCity[unit.getTile()]!! >= bestTilesToFoundCity[bestTile]!! - 10)) {
                 bestCityLocation = unit.getTile()
         }
         
@@ -146,7 +145,7 @@ object SpecificUnitAutomation {
         
         if (bestCityLocation == null) {
             // Find the best tile that is within
-            bestCityLocation = bestTilesToFoundCity.filter { it.value >= bestTileRank - 5 }.asSequence().sortedByDescending { it.value }.firstOrNull {
+            bestCityLocation = bestTilesToFoundCity.filter { bestTile == null || it.value >= bestTilesToFoundCity[bestTile]!! - 5 }.asSequence().sortedByDescending { it.value }.firstOrNull {
                 if (it.key in tilesWhereWeWillBeCaptured) return@firstOrNull false
                 val pathSize = unit.movement.getShortestPath(it.key).size
                 return@firstOrNull pathSize in 1..3

--- a/core/src/com/unciv/logic/automation/unit/SpecificUnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/SpecificUnitAutomation.kt
@@ -134,7 +134,7 @@ object SpecificUnitAutomation {
         
         if (bestCityLocation == null) {
             // Find the best tile that is within
-            bestCityLocation = bestTilesToFoundCity.filter { it.value >= bestTileRank - 5 }.asSequence().sortedBy { it.value }.firstOrNull {
+            bestCityLocation = bestTilesToFoundCity.filter { it.value >= bestTileRank - 5 }.asSequence().sortedByDescending { it.value }.firstOrNull {
                 if (it.key in tilesWhereWeWillBeCaptured) return@firstOrNull false
                 val pathSize = unit.movement.getShortestPath(it.key).size
                 return@firstOrNull pathSize in 1..3

--- a/core/src/com/unciv/logic/automation/unit/SpecificUnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/SpecificUnitAutomation.kt
@@ -155,6 +155,11 @@ object SpecificUnitAutomation {
             }?.key
         }
 
+        // We still haven't found a best city tile within 3 turns so lets just head to the best tile
+        if (bestCityLocation == null && bestTile != null) {
+            bestCityLocation = bestTile
+        }
+
         if (bestCityLocation == null) { // We got a badass over here, all tiles within 5 are taken?
             // Try to move towards the frontier
 

--- a/core/src/com/unciv/ui/screens/worldscreen/WorldMapHolder.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/WorldMapHolder.kt
@@ -713,7 +713,7 @@ class WorldMapHolder(
         // Highlight best tiles for city founding
         if (unit.hasUnique(UniqueType.FoundCity)
                 && UncivGame.Current.settings.showSettlersSuggestedCityLocations) {
-            CityLocationTileRanker.getBestTilesToFoundCity(unit).first.asSequence()
+            CityLocationTileRanker.getBestTilesToFoundCity(unit).tileRankMap.asSequence()
                 .filter { it.key.isExplored(unit.civ) }.sortedByDescending { it.value }.take(3).forEach {
                 tileGroups[it.key]!!.layerOverlay.showGoodCityLocationIndicator()
             }

--- a/core/src/com/unciv/ui/screens/worldscreen/WorldMapHolder.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/WorldMapHolder.kt
@@ -714,7 +714,7 @@ class WorldMapHolder(
         if (unit.hasUnique(UniqueType.FoundCity)
                 && UncivGame.Current.settings.showSettlersSuggestedCityLocations) {
             CityLocationTileRanker.getBestTilesToFoundCity(unit).first.asSequence()
-                .sortedByDescending { it.value }.filter { it.key.isExplored(unit.civ) }.take(3).forEach {
+                .filter { it.key.isExplored(unit.civ) }.sortedByDescending { it.value }.take(3).forEach {
                 tileGroups[it.key]!!.layerOverlay.showGoodCityLocationIndicator()
             }
         }

--- a/core/src/com/unciv/ui/screens/worldscreen/WorldMapHolder.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/WorldMapHolder.kt
@@ -712,13 +712,11 @@ class WorldMapHolder(
 
         // Highlight best tiles for city founding
         if (unit.hasUnique(UniqueType.FoundCity)
-                && UncivGame.Current.settings.showSettlersSuggestedCityLocations
-        ) {
-            CityLocationTileRanker.getBestTilesToFoundCity(unit).map { it.first }
-                .filter { it.isExplored(unit.civ) }.take(3).forEach {
-                    tileGroups[it]!!.layerOverlay.showGoodCityLocationIndicator()
-                }
-
+                && UncivGame.Current.settings.showSettlersSuggestedCityLocations) {
+            CityLocationTileRanker.getBestTilesToFoundCity(unit).first.asSequence()
+                .sortedBy { it.value }.filter { it.key.isExplored(unit.civ) }.take(3).forEach {
+                tileGroups[it.key]!!.layerOverlay.showGoodCityLocationIndicator()
+            }
         }
     }
 

--- a/core/src/com/unciv/ui/screens/worldscreen/WorldMapHolder.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/WorldMapHolder.kt
@@ -714,7 +714,7 @@ class WorldMapHolder(
         if (unit.hasUnique(UniqueType.FoundCity)
                 && UncivGame.Current.settings.showSettlersSuggestedCityLocations) {
             CityLocationTileRanker.getBestTilesToFoundCity(unit).first.asSequence()
-                .sortedBy { it.value }.filter { it.key.isExplored(unit.civ) }.take(3).forEach {
+                .sortedByDescending { it.value }.filter { it.key.isExplored(unit.civ) }.take(3).forEach {
                 tileGroups[it.key]!!.layerOverlay.showGoodCityLocationIndicator()
             }
         }


### PR DESCRIPTION
How often have you seen the AI settle their cities one tile away from the coast or river? I have, and I decided to make a change to it. What I didn't expect was the CityLocationTileRanker code to search for _every_ tile in a distance of 6 of _every_ city just to add them to a list to exclude from ranking. So, I decided that I had to rewrite the entire CityLocationTileRanker class to fix this and its other inefficiencies.

<details><summary>Picture</summary>

![AISettleNotOnCoast](https://github.com/yairm210/Unciv/assets/7538725/f383134f-b2f6-4ebd-a1fa-9ac9b24ba75b)

</details> 

Changes:
- AI now settles closer to rivers and coasts.
- AI now ranks tiles to settle not only by their stats but also all the resource types, freshwater etc.
- AI also ranks tiles to settle based on how close it is to the city, how big the city is and if it is their own city.
- The AI no longer settles the first settler in place. It might, after all, be one tile from a coast. Instead, it tries to settle within three turns.
- The settle location highlights now account for every tile even if the player can't see them or their resources to keep them consistent with the AI. If we are going to give the players a hint, it should be a good one.
- Players should be freer to search for a better location to settle now since the AI will likely spend a few turns to search as well.

In conclusion, the new code should be more dynamic and logical and should also be easier to edit and change the weights.
I can confirm that I have done extensive testing.

Any thoughts?