### PR TITLE
Add three new uniques

### DIFF
--- a/core/src/com/unciv/models/ruleset/nation/Nation.kt
+++ b/core/src/com/unciv/models/ruleset/nation/Nation.kt
@@ -2,6 +2,7 @@ package com.unciv.models.ruleset.nation
 
 import com.badlogic.gdx.graphics.Color
 import com.unciv.Constants
+import com.unciv.UncivGame
 import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.ruleset.RulesetObject
 import com.unciv.models.ruleset.unique.UniqueTarget
@@ -180,6 +181,16 @@ class Nation : RulesetObject() {
         return textList
     }
 
+    private fun isNationControlledByHuman(nationName: String): Boolean {
+        val gameInfo = UncivGame.Current.gameInfo
+
+        if (gameInfo != null) {
+            return gameInfo.getCivilization(nationName).isHuman()
+        }
+
+        return false
+    }
+
     private fun getUniqueBuildingsText(ruleset: Ruleset) = sequence {
         val religionEnabled = showReligionInCivilopedia(ruleset)
         for (building in ruleset.buildings.values) {
@@ -270,6 +281,8 @@ class Nation : RulesetObject() {
             "All" -> true
             name -> true
             "Major" -> isMajorCiv
+            "Human" -> isNationControlledByHuman(name)
+            "AI" -> !isNationControlledByHuman(name)
             // "CityState" to be deprecated, replaced by "City-States"
             "CityState", Constants.cityStates -> isCityState
             else -> uniques.contains(filter)

--- a/core/src/com/unciv/models/ruleset/unique/Unique.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Unique.kt
@@ -211,6 +211,9 @@ class Unique(val text: String, val sourceObjectType: UniqueTarget? = null, val s
             UniqueType.ConditionalBeforeTurns -> checkOnCiv { gameInfo.turns < condition.params[0].toInt() }
             UniqueType.ConditionalAfterTurns -> checkOnCiv { gameInfo.turns >= condition.params[0].toInt() }
 
+            UniqueType.ConditionalIsHuman -> checkOnCiv { isHuman() }
+            UniqueType.ConditionalIsAI -> checkOnCiv { isAI() }
+
             UniqueType.ConditionalNationFilter -> checkOnCiv { nation.matchesFilter(condition.params[0]) }
             UniqueType.ConditionalWar -> checkOnCiv { isAtWar() }
             UniqueType.ConditionalNotWar -> checkOnCiv { !isAtWar() }

--- a/core/src/com/unciv/models/ruleset/unique/Unique.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Unique.kt
@@ -210,10 +210,6 @@ class Unique(val text: String, val sourceObjectType: UniqueTarget? = null, val s
             UniqueType.ConditionalChance -> stateBasedRandom.nextFloat() < condition.params[0].toFloat() / 100f
             UniqueType.ConditionalBeforeTurns -> checkOnCiv { gameInfo.turns < condition.params[0].toInt() }
             UniqueType.ConditionalAfterTurns -> checkOnCiv { gameInfo.turns >= condition.params[0].toInt() }
-
-            UniqueType.ConditionalIsHuman -> checkOnCiv { isHuman() }
-            UniqueType.ConditionalIsAI -> checkOnCiv { isAI() }
-
             UniqueType.ConditionalNationFilter -> checkOnCiv { nation.matchesFilter(condition.params[0]) }
             UniqueType.ConditionalWar -> checkOnCiv { isAtWar() }
             UniqueType.ConditionalNotWar -> checkOnCiv { !isAtWar() }

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -664,6 +664,29 @@ object UniqueTriggerActivation {
                 return true
             }
 
+            UniqueType.SellBuilding -> {
+
+                val applicableCities = civInfo.cities.asSequence().filter {
+                    it.matchesFilter(unique.params[1])
+                }
+
+                for (applicableCity in applicableCities) {
+                    var buildingsToSell = applicableCity.cityConstructions.getBuiltBuildings().filter {
+                        it.matchesFilter(unique.params[0])
+                    }.toSet()
+
+                    buildingsToSell = buildingsToSell.filter {
+                        it.isSellable()
+                    }.toSet()
+
+                    for (building in buildingsToSell) {
+                        applicableCity.sellBuilding(building)
+                    }
+                }
+
+                return true
+            }
+
             else -> {}
         }
         return false

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -671,13 +671,11 @@ object UniqueTriggerActivation {
                 }
 
                 for (applicableCity in applicableCities) {
-                    var buildingsToSell = applicableCity.cityConstructions.getBuiltBuildings().filter {
+                    val buildingsToSell = applicableCity.cityConstructions.getBuiltBuildings().filter {
                         it.matchesFilter(unique.params[0])
-                    }.toSet()
-
-                    buildingsToSell = buildingsToSell.filter {
+                    }.filter {
                         it.isSellable()
-                    }.toSet()
+                    }
 
                     for (building in buildingsToSell) {
                         applicableCity.sellBuilding(building)

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -672,9 +672,7 @@ object UniqueTriggerActivation {
 
                 for (applicableCity in applicableCities) {
                     val buildingsToSell = applicableCity.cityConstructions.getBuiltBuildings().filter {
-                        it.matchesFilter(unique.params[0])
-                    }.filter {
-                        it.isSellable()
+                        it.matchesFilter(unique.params[0]) && it.isSellable()
                     }
 
                     for (building in buildingsToSell) {

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -598,6 +598,9 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
 
 
     /////// civ conditionals
+    ConditionalIsHuman("is controlled by human", UniqueTarget.Conditional),
+    ConditionalIsAI("is controlled by AI", UniqueTarget.Conditional),
+
     ConditionalNationFilter("for [nationFilter]", UniqueTarget.Conditional),
     ConditionalWar("when at war", UniqueTarget.Conditional),
     ConditionalNotWar("when not at war", UniqueTarget.Conditional),

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -131,6 +131,7 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
     GainFreeBuildings("Gain a free [buildingName] [cityFilter]", UniqueTarget.Global, UniqueTarget.Triggerable),
     BuildingMaintenance("[relativeAmount]% maintenance cost for buildings [cityFilter]", UniqueTarget.Global, UniqueTarget.FollowerBelief),
     RemoveBuilding("Remove [buildingFilter] [cityFilter]", UniqueTarget.Global, UniqueTarget.Triggerable),
+    SellBuilding("Sell [buildingFilter] [cityFilter]", UniqueTarget.Global, UniqueTarget.Triggerable),
 
     /// Border growth
     BorderGrowthPercentage("[relativeAmount]% Culture cost of natural border growth [cityFilter]", UniqueTarget.Global, UniqueTarget.FollowerBelief),

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -599,9 +599,6 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
 
 
     /////// civ conditionals
-    ConditionalIsHuman("when controlled by human", UniqueTarget.Conditional),
-    ConditionalIsAI("when controlled by AI", UniqueTarget.Conditional),
-
     ConditionalNationFilter("for [nationFilter]", UniqueTarget.Conditional),
     ConditionalWar("when at war", UniqueTarget.Conditional),
     ConditionalNotWar("when not at war", UniqueTarget.Conditional),

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -599,8 +599,8 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
 
 
     /////// civ conditionals
-    ConditionalIsHuman("is controlled by human", UniqueTarget.Conditional),
-    ConditionalIsAI("is controlled by AI", UniqueTarget.Conditional),
+    ConditionalIsHuman("when controlled by human", UniqueTarget.Conditional),
+    ConditionalIsAI("when controlled by AI", UniqueTarget.Conditional),
 
     ConditionalNationFilter("for [nationFilter]", UniqueTarget.Conditional),
     ConditionalWar("when at war", UniqueTarget.Conditional),

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -1772,6 +1772,12 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 	Applicable to: Conditional
 
+??? example  "&lt;is controlled by human&gt;"
+	Applicable to: Conditional
+
+??? example  "&lt;is controlled by AI&gt;"
+	Applicable to: Conditional
+
 ??? example  "&lt;for [nationFilter]&gt;"
 	Example: "&lt;for [City-States]&gt;"
 

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -15,6 +15,11 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 	Applicable to: Triggerable, Global
 
+??? example  "Sell [buildingFilter] [cityFilter]"
+	Example: "Sell [Culture] [in all cities]"
+
+	Applicable to: Triggerable, Global
+
 ??? example  "Free [unit] appears"
 	Example: "Free [Musketman] appears"
 

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -1777,10 +1777,10 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 	Applicable to: Conditional
 
-??? example  "&lt;is controlled by human&gt;"
+??? example  "&lt;when controlled by human&gt;"
 	Applicable to: Conditional
 
-??? example  "&lt;is controlled by AI&gt;"
+??? example  "&lt;when controlled by AI&gt;"
 	Applicable to: Conditional
 
 ??? example  "&lt;for [nationFilter]&gt;"

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -1777,12 +1777,6 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 	Applicable to: Conditional
 
-??? example  "&lt;when controlled by human&gt;"
-	Applicable to: Conditional
-
-??? example  "&lt;when controlled by AI&gt;"
-	Applicable to: Conditional
-
 ??? example  "&lt;for [nationFilter]&gt;"
 	Example: "&lt;for [City-States]&gt;"
 


### PR DESCRIPTION
I would like to add three new conditionals. These are

<is controlled by Human>
<is controlled by AI>
Sell [buildingFilter] [cityFilter]

The first two are very simple. They will be used by modders to make features restricted to Human players or AI.
The last is the variation of removeBuilding unique was added by me. The difference is that SellBuilding gives money for removed buildings. 

I hope the implementation would be quicker than in case of my before PR.