### PR TITLE
Fix Multiplayer Specatator being unable to move the screen

### DIFF
--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -280,6 +280,7 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
         civilizations.add(it)
         it.gameInfo = this
         it.setNationTransient()
+        it.cache.updateViewableTiles()
         it.setTransients()
     }
 


### PR DESCRIPTION
Closes #10429, closes #10077, closes #9959 

Edit: It's possible this should be inserted into civ.cache.setTransients, not here, but inserting it here was sorta the immediate thing I noticed when debugging it