### PR TITLE
Fix free stat buildings not giving unique stat buildings in certain cases

### DIFF
--- a/core/src/com/unciv/logic/city/CityConstructions.kt
+++ b/core/src/com/unciv/logic/city/CityConstructions.kt
@@ -104,10 +104,6 @@ class CityConstructions : IsPartOfGameInfoSerialization {
     fun getConstructableUnits() = city.getRuleset().units.values
         .asSequence().filter { it.isBuildable(this) }
 
-    private fun getBasicStatBuildings(stat: Stat) = city.getRuleset().buildings.values
-        .asSequence()
-        .filter { !it.isAnyWonder() && it.replaces == null && it[stat] > 0f }
-
     /**
      * @return [Stats] provided by all built buildings in city plus the bonus from Library
      */
@@ -298,9 +294,9 @@ class CityConstructions : IsPartOfGameInfoSerialization {
     }
 
     fun cheapestStatBuilding(stat: Stat): Building? {
-        return getBasicStatBuildings(stat)
-            .map { city.civ.getEquivalentBuilding(it) }
-            .filter { it.isBuildable(this) || isBeingConstructedOrEnqueued(it.name) }
+        return city.getRuleset().buildings.values
+            .filter { !it.isAnyWonder() && it.isStatRelated(stat) &&
+                (it.isBuildable(this) || isBeingConstructedOrEnqueued(it.name)) }
             .minByOrNull { it.cost }
     }
 


### PR DESCRIPTION
I have no clue how to properly title this

Fun fact: In most cases this never comes up, so it might've gone unnoticed. However, in the Civ V mod Lekmod, they do in fact give a civ a unique library that gives culture, and it turns out Civ V does actually give the library for free as a culture building if they already built a monument. So this PR is technically more accurate to Civ V

Also note: mapping it by equivalent building is unnecessary. Checking `isBuildable` filters that out for us