### PR TITLE
Added Human and AI filters, separated civFilter from nationFilter

### DIFF
--- a/core/src/com/unciv/logic/civilization/Civilization.kt
+++ b/core/src/com/unciv/logic/civilization/Civilization.kt
@@ -492,8 +492,8 @@ class Civilization : IsPartOfGameInfoSerialization {
 
     fun matchesFilter(filter: String): Boolean {
         return when (filter){
-            "Human" -> isHuman()
-            "AI" -> isAI()
+            "Human player" -> isHuman()
+            "AI player" -> isAI()
             else -> nation.matchesFilter(filter)
         }
     }

--- a/core/src/com/unciv/logic/civilization/Civilization.kt
+++ b/core/src/com/unciv/logic/civilization/Civilization.kt
@@ -490,6 +490,13 @@ class Civilization : IsPartOfGameInfoSerialization {
         yieldAll(gameInfo.ruleset.globalUniques.uniqueMap.getTriggeredUniques(trigger, stateForConditionals))
     }
 
+    fun matchesFilter(filter: String): Boolean {
+        return when (filter){
+            "Human" -> isHuman()
+            "AI" -> isAI()
+            else -> nation.matchesFilter(filter)
+        }
+    }
 
     fun shouldOpenTechPicker(): Boolean {
         if (!tech.canResearchTech()) return false

--- a/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
@@ -477,20 +477,20 @@ class MapUnit : IsPartOfGameInfoSerialization {
             // In some cases we might rely on every distance farther than maxDist being the same
             else Int.MAX_VALUE
         }
-        
-        fun tileHasEnemyCity(tile: Tile): Boolean = tile.isExplored(civ) 
-            && tile.isCityCenter() 
+
+        fun tileHasEnemyCity(tile: Tile): Boolean = tile.isExplored(civ)
+            && tile.isCityCenter()
             && tile.getCity()!!.civ.isAtWarWith(civ)
-        
+
         fun tileHasEnemyMilitaryUnit(tile: Tile): Boolean = tile.isVisible(civ)
             && tile.militaryUnit != null
             && tile.militaryUnit!!.civ.isAtWarWith(civ)
             && !tile.militaryUnit!!.isInvisible(civ)
-        
+
         // Needs to be a high value, but not the max value so we can still add to it
         cache.distanceToClosestEnemyUnit = 500000
         for (i in 1..maxDist) {
-            if (currentTile.getTilesAtDistance(i).any { 
+            if (currentTile.getTilesAtDistance(i).any {
                     tileHasEnemyCity(it) || tileHasEnemyMilitaryUnit(it) }) {
                 cache.distanceToClosestEnemyUnit = i
                 break
@@ -545,7 +545,7 @@ class MapUnit : IsPartOfGameInfoSerialization {
             // We have moved so invalidate the previous calculation
             cache.distanceToClosestEnemyUnit = null
             cache.distanceToClosestEnemyUnitSearched = null
-            
+
             val destinationTile = getMovementDestination()
             if (!movement.canReach(destinationTile)) { // That tile that we were moving towards is now unreachable -
                 // for instance we headed towards an unknown tile and it's apparently unreachable
@@ -892,7 +892,7 @@ class MapUnit : IsPartOfGameInfoSerialization {
             "Non-City" -> true
             else -> {
                 if (baseUnit.matchesFilter(filter)) return true
-                if (civ.nation.matchesFilter(filter)) return true
+                if (civ.matchesFilter(filter)) return true
                 if (tempUniquesMap.containsKey(filter)) return true
                 return false
             }

--- a/core/src/com/unciv/logic/map/tile/Tile.kt
+++ b/core/src/com/unciv/logic/map/tile/Tile.kt
@@ -503,7 +503,7 @@ open class Tile : IsPartOfGameInfoSerialization {
             in terrainFeatures -> true
             else -> {
                 if (terrainUniqueMap.getUniques(filter).any()) return true
-                if (getOwner()?.nation?.matchesFilter(filter) == true) return true
+                if (getOwner()?.matchesFilter(filter) == true) return true
 
                 // Resource type check is last - cannot succeed if no resource here
                 if (resource == null) return false

--- a/core/src/com/unciv/models/ruleset/unique/Unique.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Unique.kt
@@ -211,7 +211,7 @@ class Unique(val text: String, val sourceObjectType: UniqueTarget? = null, val s
             UniqueType.ConditionalBeforeTurns -> checkOnCiv { gameInfo.turns < condition.params[0].toInt() }
             UniqueType.ConditionalAfterTurns -> checkOnCiv { gameInfo.turns >= condition.params[0].toInt() }
 
-            UniqueType.ConditionalNationFilter -> checkOnCiv { nation.matchesFilter(condition.params[0]) }
+            UniqueType.ConditionalCivFilter -> checkOnCiv { matchesFilter(condition.params[0]) }
             UniqueType.ConditionalWar -> checkOnCiv { isAtWar() }
             UniqueType.ConditionalNotWar -> checkOnCiv { !isAtWar() }
             UniqueType.ConditionalWithResource -> getResourceAmount(condition.params[0]) > 0

--- a/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
@@ -183,8 +183,10 @@ enum class UniqueParameterType(
         }
     },
 
+
+    /** Implemented by [Civ.matchesFilter][com.unciv.logic.civilization.Civilization.matchesFilter] */
     CivFilter("civFilter", Constants.cityStates) {
-        private val knownValues = setOf("AI", "Human")
+        private val knownValues = setOf("AI player", "Human player")
 
         override fun getErrorSeverity(parameterText: String, ruleset: Ruleset): UniqueType.UniqueParameterErrorSeverity? {
             if (parameterText in knownValues) return null
@@ -192,7 +194,7 @@ enum class UniqueParameterType(
         }
     },
 
-    /** Implemented by [Nation.matchesFilter][com.unciv.models.ruleset.Building.matchesFilter] */
+    /** Implemented by [Nation.matchesFilter][com.unciv.models.ruleset.nation.Nation.matchesFilter] */
     NationFilter("nationFilter", Constants.cityStates) {
         private val knownValues = setOf(Constants.cityStates, "Major", "All")
 

--- a/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
@@ -183,6 +183,15 @@ enum class UniqueParameterType(
         }
     },
 
+    CivFilter("civFilter", Constants.cityStates) {
+        private val knownValues = setOf("AI", "Human")
+
+        override fun getErrorSeverity(parameterText: String, ruleset: Ruleset): UniqueType.UniqueParameterErrorSeverity? {
+            if (parameterText in knownValues) return null
+            return NationFilter.getErrorSeverity(parameterText, ruleset)
+        }
+    },
+
     /** Implemented by [Nation.matchesFilter][com.unciv.models.ruleset.Building.matchesFilter] */
     NationFilter("nationFilter", Constants.cityStates) {
         private val knownValues = setOf(Constants.cityStates, "Major", "All")

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -598,7 +598,7 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
 
 
     /////// civ conditionals
-    ConditionalNationFilter("for [nationFilter]", UniqueTarget.Conditional),
+    ConditionalCivFilter("for [civFilter]", UniqueTarget.Conditional),
     ConditionalWar("when at war", UniqueTarget.Conditional),
     ConditionalNotWar("when not at war", UniqueTarget.Conditional),
     ConditionalGoldenAge("during a Golden Age", UniqueTarget.Conditional),

--- a/docs/Modders/Unique-parameters.md
+++ b/docs/Modders/Unique-parameters.md
@@ -16,8 +16,8 @@ Allows filtering for specific civs.
 - `All`
 - `City-states`
 - `Major`
-- `Human`
-- `AI`
+- `Human player`
+- `AI player`
 - Nation name
 - A unique a Nation has (verbatim, no placeholders)
 

--- a/docs/Modders/Unique-parameters.md
+++ b/docs/Modders/Unique-parameters.md
@@ -9,13 +9,15 @@ These are split into two categories:
 
 Note that all of these are case-sensitive!
 
-## nationFilter
+## civFilter
 
-Allows filtering for specific nations.
+Allows filtering for specific civs.
 
 - `All`
 - `City-states`
 - `Major`
+- `Human`
+- `AI`
 - Nation name
 - A unique a Nation has (verbatim, no placeholders)
 

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -1775,7 +1775,7 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 	Applicable to: Conditional
 
-??? example  "&lt;for [nationFilter]&gt;"
+??? example  "&lt;for [civFilter]&gt;"
 	Example: "&lt;for [City-States]&gt;"
 
 	Applicable to: Conditional


### PR DESCRIPTION
As discussed in #10443, we separate between filtering on the *nation* - the object independent of the current game - to the *civ* - the instance of that nation in the specific game

Only one usage of nation filtering not via civ filtering exists, but I want to keep the option open

This adds "Human" and "AI" filters at the Civ level, since it is game-dependent

@SeventhM