### PR TITLE
Fix Mod download issue - github url and indicator refresh

### DIFF
--- a/core/src/com/unciv/ui/screens/modmanager/ModDecoratedButton.kt
+++ b/core/src/com/unciv/ui/screens/modmanager/ModDecoratedButton.kt
@@ -18,7 +18,7 @@ import com.unciv.ui.images.ImageGetter
  *  The "installed" version shows indicators for "Selected as permanent visual mod" and "update available",
  *  as read from the [modInfo] fields, but requires a [updateIndicators] call when those change.
  */
-internal class ModDecoratedButton(private val modInfo: ModUIData) : Table() {
+internal class ModDecoratedButton(private var modInfo: ModUIData) : Table() {
     private val stateImages: ModStateImages?
     private val textButton: TextButton
 
@@ -55,6 +55,10 @@ internal class ModDecoratedButton(private val modInfo: ModUIData) : Table() {
     fun setText(text: String) = textButton.setText(text)
     override fun setColor(color: Color) { textButton.color = color }
     override fun getColor(): Color = textButton.color
+
+    fun updateUIData(newModUIData: ModUIData) {
+        modInfo = newModUIData
+    }
 
     /** Helper class keeps references to decoration images of installed mods to enable dynamic visibility
      * (actually we do not use isVisible but refill thiis container selectively which allows the aggregate height to adapt and the set to center vertically)

--- a/core/src/com/unciv/ui/screens/pickerscreens/GitHub.kt
+++ b/core/src/com/unciv/ui/screens/pickerscreens/GitHub.kt
@@ -81,7 +81,10 @@ object Github {
         val defaultBranch = repo.default_branch
         val gitRepoUrl = repo.html_url
         // Initiate download - the helper returns null when it fails
-        val zipUrl = "$gitRepoUrl/archive/$defaultBranch.zip"
+        // URL format see: https://docs.github.com/en/repositories/working-with-files/using-files/downloading-source-code-archives#source-code-archive-urls
+        // Note: https://api.github.com/repos/owner/mod/zipball would be an alternative. Its response is a redirect, but our lib follows that and delivers the zip just fine.
+        // Problems with the latter: Internal zip structure different, finalDestinationName would need a patch. Plus, normal URL escaping for owner/reponame does not work.
+        val zipUrl = "$gitRepoUrl/archive/refs/heads/$defaultBranch.zip"
         val inputStream = download(zipUrl) ?: return null
 
         // Get a mod-specific temp file name


### PR DESCRIPTION
Fixes #10447 and a quirk I noticed while testing, my notes see that issue.

This is a "lazy" approach:
* The URL change was the simplest solution, actually using the github API endpoints might be a little safer against future github updates, but I only invested a superficial check how that could play out. One blocker stumping me - so choose simple.
* The "indicator update fails" was a kind of stale-cache thing, and needed some immutable/mutable change, other places to apply the crowbar were possible. I failed to get a good big picture of a better model in my brain, so I chose "just patch".
* Lastly, the situation Mod is in settings.visualMods but not presently installed - I knew it was an issue, but always forgot to do something about it. Allow cleanly or disallow? 🎲 said the former, also simpler for existing settings out there.