### PR TITLE
Fixed land/sea nukes trying to act like air units

### DIFF
--- a/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
@@ -173,18 +173,21 @@ object UnitAutomation {
             CivilianUnitAutomation.automateCivilianUnit(unit)
             return
         }
-
-        if (unit.baseUnit.isAirUnit() && unit.canIntercept())
-            return AirUnitAutomation.automateFighter(unit)
-
-        if (unit.baseUnit.isAirUnit() && !unit.baseUnit.isNuclearWeapon())
-            return AirUnitAutomation.automateBomber(unit)
-
-        if (unit.baseUnit.isNuclearWeapon())
-            return AirUnitAutomation.automateNukes(unit)
-
-        if (unit.baseUnit.isAirUnit() && unit.hasUnique(UniqueType.SelfDestructs))
-            return AirUnitAutomation.automateMissile(unit)
+        
+        if (unit.baseUnit.isAirUnit()) {
+            if (unit.canIntercept())
+                return AirUnitAutomation.automateFighter(unit)
+    
+            if (!unit.baseUnit.isNuclearWeapon())
+                return AirUnitAutomation.automateBomber(unit)
+    
+            // Note that not all nukes have to be air units
+            if (unit.baseUnit.isNuclearWeapon())
+                return AirUnitAutomation.automateNukes(unit)
+    
+            if (unit.hasUnique(UniqueType.SelfDestructs))
+                return AirUnitAutomation.automateMissile(unit)
+        }
 
         if (tryGoToRuinAndEncampment(unit) && unit.currentMovement == 0f) return
 


### PR DESCRIPTION
Fixes #10468

Basically, there was a problem with land nukes trying to fly to a location. This is a quick fix so that the game doesn't crash. We should definitely look into this more later, but I don't really have the time for it right now.