### PR TITLE
(UX, QOL) World screen top stats row scales down to squeeze into available width

### DIFF
--- a/core/src/com/unciv/ui/components/widgets/ScalingTableWrapper.kt
+++ b/core/src/com/unciv/ui/components/widgets/ScalingTableWrapper.kt
@@ -1,0 +1,72 @@
+package com.unciv.ui.components.widgets
+
+import com.badlogic.gdx.scenes.scene2d.Actor
+import com.badlogic.gdx.scenes.scene2d.ui.Cell
+import com.badlogic.gdx.scenes.scene2d.ui.Table
+import com.badlogic.gdx.scenes.scene2d.ui.WidgetGroup
+import com.badlogic.gdx.scenes.scene2d.utils.Drawable
+
+/** Allows inserting a scaled Table into another, such that the outer Table "sees" correct inner Table dimensions.
+ *
+ *  Note: Delegates only the basic Table API: [background], [columns], [rows], [add], [row] and [defaults].
+ *  Add to these as needed.
+ */
+open class ScalingTableWrapper(
+    private val minScale: Float = 0.5f
+) : WidgetGroup() {
+    private val innerTable = Table()
+
+    init {
+        isTransform = false
+        super.addActor(innerTable)
+    }
+
+    //region WidgetGroup overrides
+
+    // I'd like to report "we could, if needed, shrink to innerTable.minWidth * minScale"
+    // - but then we get overall a glitch during resizes where the outer Table sets our height
+    // to minHeight despite there being room (as far as WorldScreenTopBar is concened) and scale > minScale...
+    override fun getMinWidth() = innerTable.minWidth * innerTable.scaleX
+
+    override fun getPrefWidth() = innerTable.prefWidth * innerTable.scaleX
+    override fun getMaxWidth() = innerTable.prefWidth
+
+    override fun getMinHeight() = innerTable.minHeight * innerTable.scaleY
+    override fun getPrefHeight() = innerTable.prefHeight * innerTable.scaleY
+    override fun getMaxHeight() = innerTable.prefHeight
+
+    override fun layout() {
+        innerTable.setBounds(0f, 0f, width / innerTable.scaleX, height / innerTable.scaleY)
+    }
+    //endregion
+
+    //region Table API delegates
+    var background: Drawable?
+        get() = innerTable.background
+        set(value) { innerTable.background = value }
+    val columns: Int get() = innerTable.columns
+    val rows: Int get() = innerTable.rows
+
+    fun defaults(): Cell<Actor> = innerTable.defaults()
+    fun add(actor: Actor): Cell<Actor> = innerTable.add(actor)
+    fun add(): Cell<Actor?> = innerTable.add()
+    fun row(): Cell<Actor> = innerTable.row()
+    //endregion
+
+    fun resetScale() {
+        innerTable.setScale(1f)
+        innerTable.isTransform = false
+    }
+
+    fun scaleTo(maxWidth: Float) {
+        innerTable.pack()
+        val scale = (maxWidth / innerTable.prefWidth).coerceIn(minScale, 1f)
+        if (scale >= 1f) return
+        innerTable.isTransform = true
+        innerTable.setScale(scale)
+        if (!innerTable.needsLayout()) {
+            innerTable.invalidate()
+            invalidate()
+        }
+    }
+}

--- a/core/src/com/unciv/ui/screens/worldscreen/topbar/WorldScreenTopBar.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/topbar/WorldScreenTopBar.kt
@@ -104,8 +104,8 @@ class WorldScreenTopBar(internal val worldScreen: WorldScreen) : Table() {
     /** Performs the layout tricks mentioned in the class Kdoc */
     private fun updateLayout() {
         val targetWidth = stage.width
-        val statsWidth = statsTable.prefWidth // use minWidth if the downscaling ability of WorldScreenTopBarStats should help out leaving the floating buttons "up"
-        val resourceWidth = resourceTable.minWidth
+        val statsWidth = statsTable.prefWidth
+        val resourceWidth = resourceTable.prefWidth
         val overviewWidth = overviewButton.minWidth
         val overviewHeight = overviewButton.minHeight
         val selectedCivWidth = selectedCivTable.minWidth

--- a/core/src/com/unciv/ui/screens/worldscreen/topbar/WorldScreenTopBar.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/topbar/WorldScreenTopBar.kt
@@ -104,7 +104,7 @@ class WorldScreenTopBar(internal val worldScreen: WorldScreen) : Table() {
     /** Performs the layout tricks mentioned in the class Kdoc */
     private fun updateLayout() {
         val targetWidth = stage.width
-        val statsWidth = statsTable.minWidth
+        val statsWidth = statsTable.prefWidth // use minWidth if the downscaling ability of WorldScreenTopBarStats should help out leaving the floating buttons "up"
         val resourceWidth = resourceTable.minWidth
         val overviewWidth = overviewButton.minWidth
         val overviewHeight = overviewButton.minHeight

--- a/core/src/com/unciv/ui/screens/worldscreen/topbar/WorldScreenTopBarResources.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/topbar/WorldScreenTopBarResources.kt
@@ -14,15 +14,17 @@ import com.unciv.ui.components.extensions.toLabel
 import com.unciv.ui.components.extensions.toStringSigned
 import com.unciv.ui.components.fonts.Fonts
 import com.unciv.ui.components.input.onClick
+import com.unciv.ui.components.widgets.ScalingTableWrapper
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.screens.overviewscreen.EmpireOverviewCategories
 import com.unciv.ui.screens.victoryscreen.VictoryScreen
 
-internal class WorldScreenTopBarResources(topbar: WorldScreenTopBar) : Table() {
+internal class WorldScreenTopBarResources(topbar: WorldScreenTopBar) : ScalingTableWrapper() {
     private val turnsLabel = "Turns: 0/400".toLabel()
     private data class ResourceActors(val resource: TileResource, val label: Label, val icon: Group)
     private val resourceActors = ArrayList<ResourceActors>(12)
     private val resourcesWrapper = Table()
+    val worldScreen = topbar.worldScreen
 
     // Note: For a proper functioning of the "shift floating buttons down when cramped" feature, it is
     // important that this entire Widget has only the bare minimum padding to its left and right.
@@ -46,7 +48,6 @@ internal class WorldScreenTopBarResources(topbar: WorldScreenTopBar) : Table() {
         resourcesWrapper.defaults().space(defaultPad)
         resourcesWrapper.touchable = Touchable.enabled
 
-        val worldScreen = topbar.worldScreen
         turnsLabel.onClick {
             if (worldScreen.selectedCiv.isLongCountDisplay()) {
                 val gameInfo = worldScreen.selectedCiv.gameInfo
@@ -77,6 +78,8 @@ internal class WorldScreenTopBarResources(topbar: WorldScreenTopBar) : Table() {
     }
 
     fun update(civInfo: Civilization) {
+        resetScale()
+
         val yearText = YearTextUtil.toYearText(
             civInfo.gameInfo.getYear(), civInfo.isLongCountDisplay()
         )
@@ -108,6 +111,6 @@ internal class WorldScreenTopBarResources(topbar: WorldScreenTopBar) : Table() {
             resourcesWrapper.add(label).padTop(resourceAmountDescentTweak)  // digits don't have descenders, so push them down a little
         }
 
-        pack()
+        scaleTo(worldScreen.stage.width)
     }
 }

--- a/core/src/com/unciv/ui/screens/worldscreen/topbar/WorldScreenTopBarStats.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/topbar/WorldScreenTopBarStats.kt
@@ -2,9 +2,6 @@ package com.unciv.ui.screens.worldscreen.topbar
 
 import com.badlogic.gdx.scenes.scene2d.Group
 import com.badlogic.gdx.scenes.scene2d.ui.Label
-import com.badlogic.gdx.scenes.scene2d.ui.Table
-import com.badlogic.gdx.scenes.scene2d.ui.WidgetGroup
-import com.badlogic.gdx.scenes.scene2d.utils.Drawable
 import com.unciv.logic.civilization.Civilization
 import com.unciv.models.stats.Stats
 import com.unciv.models.translations.tr
@@ -13,6 +10,7 @@ import com.unciv.ui.components.extensions.setFontColor
 import com.unciv.ui.components.extensions.toLabel
 import com.unciv.ui.components.extensions.toStringSigned
 import com.unciv.ui.components.input.onClick
+import com.unciv.ui.components.widgets.ScalingTableWrapper
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.screens.basescreen.BaseScreen
 import com.unciv.ui.screens.overviewscreen.EmpireOverviewCategories
@@ -22,8 +20,7 @@ import com.unciv.ui.screens.pickerscreens.TechPickerScreen
 import kotlin.math.ceil
 import kotlin.math.roundToInt
 
-internal class WorldScreenTopBarStats(topbar: WorldScreenTopBar) : WidgetGroup() {
-    private val innerTable = Table()
+internal class WorldScreenTopBarStats(topbar: WorldScreenTopBar) : ScalingTableWrapper() {
     private val goldLabel = "0".toLabel(colorFromRGB(225, 217, 71))
     private val scienceLabel = "0".toLabel(colorFromRGB(78, 140, 151))
     private val happinessLabel = "0".toLabel()
@@ -48,11 +45,11 @@ internal class WorldScreenTopBarStats(topbar: WorldScreenTopBar) : WidgetGroup()
         const val defaultBottomPad = 3f
         const val defaultImageBottomPad = 6f
         const val padRightBetweenStats = 20f
-        const val minScale = 0.5f
     }
 
     init {
         isTransform = false
+
 
         fun addStat(label: Label, icon: String, isLast: Boolean = false, screenFactory: ()-> BaseScreen) {
             val image = ImageGetter.getStatIcon(icon)
@@ -61,8 +58,8 @@ internal class WorldScreenTopBarStats(topbar: WorldScreenTopBar) : WidgetGroup()
             }
             label.onClick(action)
             image.onClick(action)
-            innerTable.add(label)
-            innerTable.add(image).padBottom(defaultImageBottomPad).size(defaultImageSize).apply {
+            add(label)
+            add(image).padBottom(defaultImageBottomPad).size(defaultImageSize).apply {
                 if (!isLast) padRight(padRightBetweenStats)
             }
         }
@@ -70,12 +67,12 @@ internal class WorldScreenTopBarStats(topbar: WorldScreenTopBar) : WidgetGroup()
         fun addStat(label: Label, icon: String, overviewPage: EmpireOverviewCategories, isLast: Boolean = false) =
             addStat(label, icon, isLast) { EmpireOverviewScreen(worldScreen.selectedCiv, overviewPage) }
 
-        innerTable.defaults().pad(defaultTopPad, defaultHorizontalPad, defaultBottomPad, defaultHorizontalPad)
+        defaults().pad(defaultTopPad, defaultHorizontalPad, defaultBottomPad, defaultHorizontalPad)
         addStat(goldLabel, "Gold", EmpireOverviewCategories.Stats)
         addStat(scienceLabel, "Science") { TechPickerScreen(worldScreen.selectedCiv) }
 
-        innerTable.add(happinessContainer).padBottom(defaultImageBottomPad).size(defaultImageSize)
-        innerTable.add(happinessLabel).padRight(padRightBetweenStats)
+        add(happinessContainer).padBottom(defaultImageBottomPad).size(defaultImageSize)
+        add(happinessLabel).padRight(padRightBetweenStats)
         val invokeResourcesPage = {
             worldScreen.openEmpireOverview(EmpireOverviewCategories.Resources)
         }
@@ -86,37 +83,15 @@ internal class WorldScreenTopBarStats(topbar: WorldScreenTopBar) : WidgetGroup()
         if (worldScreen.gameInfo.isReligionEnabled()) {
             addStat(faithLabel, "Faith", EmpireOverviewCategories.Religion, isLast = true)
         } else {
-            innerTable.add("Religion: Off".toLabel())
+            add("Religion: Off".toLabel())
         }
-
-        addActor(innerTable)
     }
 
-    // I'd like to report "we could, if needed, shrink to innerTable.minWidth * minScale"
-    // - but then we get overall a glitch during resizes where the outer Table sets our height
-    // to minHeight despite there being room (as far as WorldScreenTopBar is concened) and scale > minScale...
-    override fun getMinWidth() = innerTable.minWidth * innerTable.scaleX
-
-    override fun getPrefWidth() = innerTable.prefWidth * innerTable.scaleX
-    override fun getMaxWidth() = innerTable.prefWidth
-
-    override fun getMinHeight() = innerTable.minHeight * innerTable.scaleY
-    override fun getPrefHeight() = innerTable.prefHeight * innerTable.scaleY
-    override fun getMaxHeight() = innerTable.prefHeight
-
-    override fun layout() {
-        innerTable.setBounds(0f, 0f, width / innerTable.scaleX, height / innerTable.scaleY)
-    }
-
-    var background: Drawable?
-        get() = innerTable.background
-        set(value) { innerTable.background = value }
 
     private fun rateLabel(value: Float) = value.roundToInt().toStringSigned()
 
     fun update(civInfo: Civilization) {
-        innerTable.isTransform = false
-        innerTable.setScale(1f)
+        resetScale()
 
         val nextTurnStats = civInfo.stats.statsForNextTurn
         val goldPerTurn = " (" + rateLabel(nextTurnStats.gold) + ")"
@@ -140,19 +115,7 @@ internal class WorldScreenTopBarStats(topbar: WorldScreenTopBar) : WidgetGroup()
         faithLabel.setText(civInfo.religionManager.storedFaith.toString() +
             " (" + rateLabel(nextTurnStats.faith) + ")")
 
-        innerTable.pack()
-        scaleToMaxWidth()
-    }
-
-    private fun scaleToMaxWidth() {
-        val scale = worldScreen.stage.width / innerTable.prefWidth
-        if (scale >= 1f) return
-        innerTable.isTransform = true
-        innerTable.setScale(scale)
-        if (!innerTable.needsLayout()) {
-            innerTable.invalidate()
-            invalidate()
-        }
+        scaleTo(worldScreen.stage.width)
     }
 
     private fun getCultureText(civInfo: Civilization, nextTurnStats: Stats): String {


### PR DESCRIPTION
<details><summary>Phone screenshots</summary>

<h2>Before</h2>
<img alt="Screenshot_20231111-before" src="https://github.com/yairm210/Unciv/assets/63000004/92c27929-f7de-4f3d-9219-40ec3eb255b6" />
... missing 190k gold and the Faith icon. Not much, but that can get much worse.

<h2>After</h2>
<img alt="Screenshot_20231111-after" src="https://github.com/yairm210/Unciv/assets/63000004/9973bae3-8427-4580-9d95-151de73ca1b1" />
... better
</details>

So this is a little tiny improvement for Portrait Mode lovers.

... which I tried for days on end weeks ago and kept failing, but with [a little help](https://github.com/libgdx/libgdx/issues/7223) and a little let-it-go it now worked as intended in no time. Mostly. The minSizes the new helper reports are not what I'd like them to be, if they reported the mimimum size the scalable Widget is willing to let itself squeeze in, then a simple on/off switch could be made to get the topbar rows to scale down more aggressively so they allow the floating buttons back up longer... Causes a glitch, so the minSizes are conservative for now.

Another note: The resources row will do the same when a mod has tons of strategic resources - but I forget which one to test with. With vanilla and 6 resources you can't provoke it. Civ 6 Mod???

By the way, the CityScreen on the same screen and portrait orientation - a usability catastrophe, though you can still get everything done somehow. I'm tempted to either make it an endless vertical ScrollPane in cramped-portrait mode, or a TabbedPager. But TabbedPager has its own glitches in portrait that would need work first... Plus, I have no _clear_ mental picture of an optimal solution, so waiting-for-inspiration-mode.