### PR TITLE
Fix Multiplayer spectator ids not logging

### DIFF
--- a/core/src/com/unciv/logic/GameStarter.kt
+++ b/core/src/com/unciv/logic/GameStarter.kt
@@ -350,9 +350,7 @@ object GameStarter {
         for (player in chosenPlayers) {
             val civ = Civilization(player.chosenCiv)
             when (player.chosenCiv) {
-                Constants.spectator ->
-                    civ.playerType = player.playerType
-                in usedMajorCivs -> {
+                in usedMajorCivs, Constants.spectator -> {
                     civ.playerType = player.playerType
                     civ.playerId = player.playerId
                 }


### PR DESCRIPTION
Fun fact: since this issue is related to game creation, not game viewing, an player with this fix can set players as spectators and outdated versions can still view the game as intended
Side note: this now presents a difference in spectators with ids and temporary spectators without ids. Namely, temporary spectators do not have every tech unlocked, unlike non temporary or offline spectators