### PR TITLE
Fixed promise not to settle

### DIFF
--- a/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
+++ b/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
@@ -3,6 +3,7 @@ package com.unciv.logic.automation.unit
 import com.unciv.logic.automation.Automation
 import com.unciv.logic.city.City
 import com.unciv.logic.civilization.Civilization
+import com.unciv.logic.civilization.diplomacy.DiplomacyFlags
 import com.unciv.logic.map.mapunit.MapUnit
 import com.unciv.logic.map.tile.Tile
 import com.unciv.models.ruleset.tile.ResourceType
@@ -51,6 +52,12 @@ object CityLocationTileRanker {
         if (tile.getOwner() != null && tile.getOwner() != civ) return false
         for (city in nearbyCities) {
             val distance = city.getCenterTile().aerialDistanceTo(tile)
+            // todo: AgreedToNotSettleNearUs is hardcoded for now but it may be better to softcode it below in getDistanceToCityModifier
+            if (distance <= 6 && civ.knows(city.civ) &&
+                // If the CITY OWNER knows that the UNIT OWNER agreed not to settle near them
+                city.civ.getDiplomacyManager(civ)
+                    .hasFlag(DiplomacyFlags.AgreedToNotSettleNearUs))
+                return false
             if (tile.getContinent() == city.getCenterTile().getContinent()) {
                 if (distance <= modConstants.minimalCityDistance) return false
             } else {

--- a/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
+++ b/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
@@ -53,9 +53,10 @@ object CityLocationTileRanker {
         for (city in nearbyCities) {
             val distance = city.getCenterTile().aerialDistanceTo(tile)
             // todo: AgreedToNotSettleNearUs is hardcoded for now but it may be better to softcode it below in getDistanceToCityModifier
-            if (distance <= 6 && civ.knows(city.civ) &&
+            if (distance <= 6 && civ.knows(city.civ) 
+                && !civ.isAtWarWith(city.civ)
                 // If the CITY OWNER knows that the UNIT OWNER agreed not to settle near them
-                city.civ.getDiplomacyManager(civ)
+                && city.civ.getDiplomacyManager(civ)
                     .hasFlag(DiplomacyFlags.AgreedToNotSettleNearUs))
                 return false
             if (tile.getContinent() == city.getCenterTile().getContinent()) {


### PR DESCRIPTION
Fixes #10487

When I was rewriting the settler AI in #10428, I removed the logic to make the AI follow the AgreedNotToSettleNearUS diplomatic flag. This PR adds it back in. I also added in that the AI doesn't care about AgreedNotToSettleNearUs while at war with the other civ.