### PR TITLE
Allow controlling Android fullscreen from options

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -812,22 +812,20 @@ Screen orientation =
 Landscape (fixed) = 
 Portrait (fixed) = 
 Auto (sensor adjusted) = 
-
-Enable display cutout (requires restart) = 
-
-Max zoom out = 
-
+Enable using display cutout areas = 
+Hide system status and navigation bars = 
 Font family = 
 Font size multiplier = 
 Default Font = 
+
+Max zoom out = 
+Enable Easter Eggs = 
+Enlarge selected notifications = 
 
 Generate translation files = 
 Translation files are generated successfully. = 
 Fastlane files are generated successfully. = 
 Update Mod categories = 
-
-Enable Easter Eggs = 
-Enlarge selected notifications = 
 
 ## Keys tab
 Keys = 

--- a/android/src/com/unciv/app/AndroidDisplay.kt
+++ b/android/src/com/unciv/app/AndroidDisplay.kt
@@ -2,40 +2,18 @@ package com.unciv.app
 
 import android.app.Activity
 import android.content.pm.ActivityInfo
-import android.database.ContentObserver
 import android.os.Build
-import android.os.Handler
-import android.provider.Settings
 import android.view.Display
 import android.view.Display.Mode
+import android.view.View
 import android.view.WindowManager
 import androidx.annotation.RequiresApi
 import com.unciv.models.metadata.GameSettings
 import com.unciv.models.translations.tr
-import com.unciv.utils.Log
 import com.unciv.utils.PlatformDisplay
 import com.unciv.utils.ScreenMode
 import com.unciv.utils.ScreenOrientation
 
-
-class AndroidScreenMode(
-    private val modeId: Int) : ScreenMode {
-    private var name: String = "Default"
-
-    @RequiresApi(Build.VERSION_CODES.M)
-    constructor(mode: Mode) : this(mode.modeId) {
-        name = "${mode.physicalWidth}x${mode.physicalHeight} (${mode.refreshRate.toInt()}HZ)"
-    }
-
-    override fun getId(): Int {
-        return modeId
-    }
-
-    override fun toString(): String {
-        return name.tr()
-    }
-
-}
 
 class AndroidDisplay(private val activity: Activity) : PlatformDisplay {
 
@@ -45,6 +23,7 @@ class AndroidDisplay(private val activity: Activity) : PlatformDisplay {
     init {
 
         // Fetch current display
+        @Suppress("DEPRECATION") // M..P should use the deprecated API
         display = when {
             Build.VERSION.SDK_INT >= Build.VERSION_CODES.R -> activity.display
             Build.VERSION.SDK_INT >= Build.VERSION_CODES.M -> activity.windowManager.defaultDisplay
@@ -52,7 +31,7 @@ class AndroidDisplay(private val activity: Activity) : PlatformDisplay {
         }
 
         // Add default mode
-        displayModes[0] = AndroidScreenMode(0)
+        displayModes[AndroidScreenMode.defaultId] = AndroidScreenMode.default
 
         // Add other supported modes
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
@@ -71,14 +50,31 @@ class AndroidDisplay(private val activity: Activity) : PlatformDisplay {
     }
 
     override fun setScreenMode(id: Int, settings: GameSettings) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            activity.runOnUiThread {
-                val params = activity.window.attributes
-                params.preferredDisplayModeId = id
-                activity.window.attributes = params
-            }
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) return
+        activity.runOnUiThread {
+            val params = activity.window.attributes
+            params.preferredDisplayModeId = id
+            activity.window.attributes = params
         }
+    }
 
+    override fun hasSystemUiVisibility() = true
+
+    override fun setSystemUiVisibility(hide: Boolean) {
+        activity.runOnUiThread {
+            setSystemUiVisibilityFromUiThread(hide)
+        }
+    }
+    internal fun setSystemUiVisibilityFromUiThread(hide: Boolean) {
+        @Suppress("DEPRECATION") // Avoids @RequiresApi(Build.VERSION_CODES.R)
+        activity.window.decorView.systemUiVisibility =
+            if (hide)
+                View.SYSTEM_UI_FLAG_LAYOUT_STABLE or
+                    View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN or
+                    View.SYSTEM_UI_FLAG_HIDE_NAVIGATION or View.SYSTEM_UI_FLAG_FULLSCREEN or
+                    View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
+            else
+                View.SYSTEM_UI_FLAG_LAYOUT_STABLE
     }
 
     override fun hasCutout(): Boolean {
@@ -95,14 +91,18 @@ class AndroidDisplay(private val activity: Activity) : PlatformDisplay {
     }
 
     override fun setCutout(enabled: Boolean) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-            val params = activity.window.attributes
-            params.layoutInDisplayCutoutMode = when {
-                enabled -> WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
-                else -> WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_NEVER
-            }
-            activity.window.attributes = params
+        activity.runOnUiThread {
+            setCutoutFromUiThread(enabled)
         }
+    }
+    internal fun setCutoutFromUiThread(enabled: Boolean) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) return
+        val params = activity.window.attributes
+        params.layoutInDisplayCutoutMode = when {
+            enabled -> WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
+            else -> WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_NEVER
+        }
+        activity.window.attributes = params  // This is the only line to actually need to be running on the Ui Thread
     }
 
 
@@ -121,7 +121,6 @@ class AndroidDisplay(private val activity: Activity) : PlatformDisplay {
     }
 
     override fun setOrientation(orientation: ScreenOrientation) {
-
         val mode = when (orientation) {
             ScreenOrientation.Landscape -> ActivityInfo.SCREEN_ORIENTATION_USER_LANDSCAPE
             ScreenOrientation.Portrait -> ActivityInfo.SCREEN_ORIENTATION_USER_PORTRAIT
@@ -133,4 +132,25 @@ class AndroidDisplay(private val activity: Activity) : PlatformDisplay {
             activity.requestedOrientation = mode
     }
 
+    class AndroidScreenMode private constructor(
+        private val modeId: Int,
+        private val name: String
+    ) : ScreenMode {
+        @RequiresApi(Build.VERSION_CODES.M)
+        constructor(mode: Mode) : this(mode.modeId, "${mode.physicalWidth}x${mode.physicalHeight} (${mode.refreshRate.toInt()}Hz)")
+
+        override fun getId(): Int {
+            return modeId
+        }
+
+        override fun toString(): String {
+            return name.tr()
+        }
+
+        companion object {
+            const val defaultId = 0
+            val default: AndroidScreenMode
+                get() = AndroidScreenMode(defaultId, "Default")
+        }
+    }
 }

--- a/android/src/com/unciv/app/AndroidLauncher.kt
+++ b/android/src/com/unciv/app/AndroidLauncher.kt
@@ -23,7 +23,8 @@ open class AndroidLauncher : AndroidApplication() {
         Log.backend = AndroidLogBackend(this)
 
         // Setup Android display
-        Display.platform = AndroidDisplay(this)
+        val displayImpl = AndroidDisplay(this)
+        Display.platform = displayImpl
 
         // Setup Android fonts
         Fonts.fontImplementation = AndroidFont()
@@ -32,17 +33,18 @@ open class AndroidLauncher : AndroidApplication() {
         UncivFiles.saverLoader = AndroidSaverLoader(this)
         UncivFiles.preferExternalStorage = true
 
+        val config = AndroidApplicationConfiguration().apply { useImmersiveMode = false }
+        val settings = UncivFiles.getSettingsForPlatformLaunchers(filesDir.path)
+
+        // Setup orientation, immersive mode and display cutout
+        displayImpl.setOrientation(settings.displayOrientation)
+        displayImpl.setCutoutFromUiThread(settings.androidCutout)
+        displayImpl.setSystemUiVisibilityFromUiThread(settings.androidHideSystemUi)
+
         // Create notification channels for Multiplayer notificator
         MultiplayerTurnCheckWorker.createNotificationChannels(applicationContext)
 
         copyMods()
-
-        val config = AndroidApplicationConfiguration().apply { useImmersiveMode = true }
-        val settings = UncivFiles.getSettingsForPlatformLaunchers(filesDir.path)
-
-        // Setup orientation and display cutout
-        Display.setOrientation(settings.displayOrientation)
-        Display.setCutout(settings.androidCutout)
 
         game = AndroidGame(this)
         initialize(game, config)

--- a/core/src/com/unciv/models/metadata/GameSettings.kt
+++ b/core/src/com/unciv/models/metadata/GameSettings.kt
@@ -100,6 +100,7 @@ class GameSettings {
     var showAutosaves: Boolean = false
 
     var androidCutout: Boolean = false
+    var androidHideSystemUi = true
 
     var multiplayer = GameSettingsMultiplayer()
 

--- a/core/src/com/unciv/ui/popups/options/AdvancedTab.kt
+++ b/core/src/com/unciv/ui/popups/options/AdvancedTab.kt
@@ -22,6 +22,7 @@ import com.unciv.models.metadata.ScreenSize
 import com.unciv.models.translations.TranslationFileWriter
 import com.unciv.models.translations.tr
 import com.unciv.ui.components.UncivTooltip.Companion.addTooltip
+import com.unciv.ui.components.extensions.addSeparator
 import com.unciv.ui.components.extensions.disable
 import com.unciv.ui.components.extensions.setFontColor
 import com.unciv.ui.components.extensions.toCheckBox
@@ -57,34 +58,48 @@ fun advancedTab(
     val settings = optionsPopup.settings
 
     addAutosaveTurnsSelectBox(this, settings)
+    addSeparator(Color.GRAY)
 
-    if (Display.hasOrientation()) {
+    if (Display.hasOrientation())
         addOrientationSelectBox(this, optionsPopup)
-    }
 
-    if (Display.hasCutout()) {
+    if (Display.hasCutout())
         addCutoutCheckbox(this, optionsPopup)
-    }
 
-    addMaxZoomSlider(this, settings)
+    if (Display.hasSystemUiVisibility())
+        addHideSystemUiCheckbox(this, optionsPopup)
 
     addFontFamilySelect(this, settings, optionsPopup.selectBoxMinWidth, onFontChange)
-
     addFontSizeMultiplier(this, settings, onFontChange)
+    addSeparator(Color.GRAY)
 
-    addTranslationGeneration(this, optionsPopup)
-
-    addSetUserId(this, settings)
+    addMaxZoomSlider(this, settings)
 
     addEasterEggsCheckBox(this, settings)
 
     addEnlargeNotificationsCheckBox(this, settings)
+    addSeparator(Color.GRAY)
+
+    addSetUserId(this, settings)
+
+    addTranslationGeneration(this, optionsPopup)
 }
 
 private fun addCutoutCheckbox(table: Table, optionsPopup: OptionsPopup) {
-    optionsPopup.addCheckbox(table, "Enable display cutout (requires restart)", optionsPopup.settings.androidCutout)
+    optionsPopup.addCheckbox(table, "Enable using display cutout areas", optionsPopup.settings.androidCutout)
     {
         optionsPopup.settings.androidCutout = it
+        Display.setCutout(it)
+        optionsPopup.reopenAfterDiplayLayoutChange()
+    }
+}
+
+private fun addHideSystemUiCheckbox(table: Table, optionsPopup: OptionsPopup) {
+    optionsPopup.addCheckbox(table, "Hide system status and navigation bars", optionsPopup.settings.androidHideSystemUi)
+    {
+        optionsPopup.settings.androidHideSystemUi = it
+        Display.setSystemUiVisibility(hide = it)
+        optionsPopup.reopenAfterDiplayLayoutChange()
     }
 }
 
@@ -101,6 +116,7 @@ private fun addOrientationSelectBox(table: Table, optionsPopup: OptionsPopup) {
         val orientation = selectBox.selected
         settings.displayOrientation = orientation
         Display.setOrientation(orientation)
+        optionsPopup.reopenAfterDiplayLayoutChange()
     }
 
     table.add(selectBox).minWidth(optionsPopup.selectBoxMinWidth).pad(10f).row()
@@ -202,7 +218,7 @@ private fun addFontSizeMultiplier(
     settings: GameSettings,
     onFontChange: () -> Unit
 ) {
-    table.add("Font size multiplier".toLabel()).left().fillX()
+    table.add("Font size multiplier".toLabel()).left().fillX().padTop(5f)
 
     val fontSizeSlider = UncivSlider(
         0.7f, 1.5f, 0.05f,
@@ -214,11 +230,11 @@ private fun addFontSizeMultiplier(
         if (!fontSizeSlider.isDragging)
             onFontChange()
     }
-    table.add(fontSizeSlider).pad(5f).row()
+    table.add(fontSizeSlider).pad(5f).padTop(10f).row()
 }
 
 private fun addMaxZoomSlider(table: Table, settings: GameSettings) {
-    table.add("Max zoom out".tr()).left().fillX()
+    table.add("Max zoom out".tr()).left().fillX().padTop(5f)
     val maxZoomSlider = UncivSlider(
         2f, 6f, 1f,
         initial = settings.maxWorldZoomOut
@@ -227,7 +243,7 @@ private fun addMaxZoomSlider(table: Table, settings: GameSettings) {
         if (GUI.isWorldLoaded())
             GUI.getMap().reloadMaxZoom()
     }
-    table.add(maxZoomSlider).pad(5f).row()
+    table.add(maxZoomSlider).pad(5f).padTop(10f).row()
 }
 
 private fun addTranslationGeneration(table: Table, optionsPopup: OptionsPopup) {

--- a/core/src/com/unciv/utils/Display.kt
+++ b/core/src/com/unciv/utils/Display.kt
@@ -19,31 +19,35 @@ interface ScreenMode {
 }
 
 interface PlatformDisplay {
-
     fun setScreenMode(id: Int, settings: GameSettings) {}
-    fun getScreenModes(): Map<Int, ScreenMode> { return hashMapOf() }
+    fun getScreenModes(): Map<Int, ScreenMode> = hashMapOf()
 
-    fun hasCutout(): Boolean { return false }
+    fun hasCutout(): Boolean = false
     fun setCutout(enabled: Boolean) {}
 
-    fun hasOrientation(): Boolean { return false }
+    fun hasOrientation(): Boolean = false
     fun setOrientation(orientation: ScreenOrientation) {}
 
     fun hasUserSelectableSize(id: Int): Boolean = false
+
+    fun hasSystemUiVisibility(): Boolean = false
+    fun setSystemUiVisibility(hide: Boolean) {}
 }
 
 object Display {
-
     lateinit var platform: PlatformDisplay
 
-    fun hasOrientation(): Boolean { return platform.hasOrientation() }
+    fun hasOrientation() = platform.hasOrientation()
     fun setOrientation(orientation: ScreenOrientation) { platform.setOrientation(orientation) }
 
-    fun hasCutout(): Boolean { return platform.hasCutout() }
+    fun hasCutout() = platform.hasCutout()
     fun setCutout(enabled: Boolean) { platform.setCutout(enabled) }
 
-    fun getScreenModes(): Map<Int, ScreenMode> { return platform.getScreenModes() }
+    fun getScreenModes() = platform.getScreenModes()
     fun setScreenMode(id: Int, settings: GameSettings) { platform.setScreenMode(id, settings) }
 
     fun hasUserSelectableSize(id: Int) = platform.hasUserSelectableSize(id)
+
+    fun hasSystemUiVisibility() = platform.hasSystemUiVisibility()
+    fun setSystemUiVisibility(hide: Boolean) = platform.setSystemUiVisibility(hide)
 }


### PR DESCRIPTION
Credits essentially go to Evan Debenham - or maybe watabou, that code might be older.

Pro: Closes #10499
Con: The desktop concept of "fullscreen" and the Android concept of the same name are handled entirely differently

Basically allows switching "immersive mode"[^1] as a setting from advanced options. Made the 'cutout' checkbox interactive, too.

Tested on `Build.VERSION_CODES.S_V2` level hardware.

Turns Gdx's version of "immersive mode" back off. Our `useImmersiveMode = true` was moot before, the default is 'on'. What it (I mean Gdx's config flag) does is set the same flags I'm controlling in this new code, but from a visibility listener, over and over. [^2]

Next, rearranged the Advanced page just a little. I believe some more rearrangement might be good, for example IMHO the Display mode setting belongs on advanced, but on Android only, in turn the Orientation setting is basic enough to replace it on 'Display'. But - [^3]

<details><summary>Screenshots of Options page</summary>

Maximum - camera eye pokes a hole the screenshot won't show
![Screenshot_20231118_Unciv_max](https://github.com/yairm210/Unciv/assets/63000004/b049e1e0-bec7-475e-8a12-496fe65763aa)

Medium - system ui still off but cutouts saved
![Screenshot_20231118_Unciv](https://github.com/yairm210/Unciv/assets/63000004/c09b2125-760d-4263-b34e-208c0afc66e8)

Minimum - classic app view. Don't ask me why the status bar is still hidden. Haven't found that yet. But it's that way for all Apps on the box. I think OEM's are allowed to change that some.
![Screenshot_20231118_Unciv_min](https://github.com/yairm210/Unciv/assets/63000004/f015b34f-dff6-484a-bdcb-f81368c80577)

</details>

[^1]: A term seemingly absent from the current Android docs, they talk about hiding system UI
[^2]: See [hook](https://github.com/libgdx/libgdx/blob/master/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplication.java#L167) [line](https://github.com/libgdx/libgdx/blob/master/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidVisibilityListener.java#L28) and [sinker](https://github.com/libgdx/libgdx/blob/master/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidFragmentApplication.java#L91) - this effectively ruins any attempt at controlling the relevant flags of the Android View's layout from within the application.
[^3]: I actually imagine redoing OptionsPopup as using a json-backed "definitions" collection, each entry naming, typing, and categorizing one GameSettings field. Behaviour would then be linked through reflection or through proxy classes named in the json... One list, and moving entries to different pages is just a category change. Separators controlled by subcategory change. One can dream... But the dream makes other tweaks to Options no fun.
