### PR TITLE
Add a TriggerUponDiscoveringTile unique type

### DIFF
--- a/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
@@ -21,6 +21,7 @@ import com.unciv.models.ruleset.unique.StateForConditionals
 import com.unciv.models.ruleset.unique.Unique
 import com.unciv.models.ruleset.unique.UniqueMap
 import com.unciv.models.ruleset.unique.UniqueType
+import com.unciv.models.ruleset.unique.UniqueTriggerActivation
 import com.unciv.models.ruleset.unit.BaseUnit
 import com.unciv.models.ruleset.unit.UnitType
 import com.unciv.models.stats.Stats
@@ -343,8 +344,23 @@ class MapUnit : IsPartOfGameInfoSerialization {
         if (updateCivViewableTiles && oldViewableTiles != viewableTiles
                 // Don't bother updating if all previous and current viewable tiles are within our borders
                 && (oldViewableTiles.any { it !in civ.cache.ourTilesAndNeighboringTiles }
-                        || viewableTiles.any { it !in civ.cache.ourTilesAndNeighboringTiles }))
+                        || viewableTiles.any { it !in civ.cache.ourTilesAndNeighboringTiles })) {
+
+            val newlyExploredTiles = viewableTiles.filter {
+                !it.isExplored(civ)
+            }
+            for (tile in newlyExploredTiles) {
+                // Include tile in the state for correct RNG seeding
+                val state = StateForConditionals(civInfo=civ, unit=this, tile=tile);
+                for (unique in getTriggeredUniques(UniqueType.TriggerUponDiscoveringTile, state)) {
+                    if (unique.conditionals.any { it.type == UniqueType.TriggerUponDiscoveringTile
+                        && tile.matchesFilter(it.params[0], civ) })
+                        UniqueTriggerActivation.triggerUnitwideUnique(unique, this)
+                }
+            }
+            
             civ.cache.updateViewableTiles(explorerPosition)
+        }
     }
 
     fun isActionUntilHealed() = action?.endsWith("until healed") == true

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -766,6 +766,7 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
     TriggerUponPromotion("upon being promoted", UniqueTarget.UnitTriggerCondition),
     TriggerUponLosingHealth("upon losing at least [amount] HP in a single attack", UniqueTarget.UnitTriggerCondition),
     TriggerUponEndingTurnInTile("upon ending a turn in a [tileFilter] tile", UniqueTarget.UnitTriggerCondition),
+    TriggerUponDiscoveringTile("upon discovering a [tileFilter] tile", UniqueTarget.UnitTriggerCondition),
 
     //endregion
 

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -2133,6 +2133,12 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 	Applicable to: UnitTriggerCondition
 
+??? example  "&lt;upon discovering a [tileFilter] tile&gt;"
+	Triggers for each tile discovered (unfogged) by the unit.
+	Example: "&lt;upon discovering a [Farm] tile&gt;"
+
+	Applicable to: UnitTriggerCondition
+
 ## UnitActionModifier uniques
 !!! note ""
 


### PR DESCRIPTION
These changes add a `TriggerUponDiscoveringTile` unique of target `UnitTriggerCondition`. It allows to define actions that occur when a unit discovers a previously fogged tile and triggers for each such tile.

It is a modding-related feature since AFAIK there are no relevant mechanics in Civ5.

I have tested following uniques:
 - `This Unit gains [5] XP <upon discovering a [Water] tile>`
 - `This Unit gains [5] XP <with [50]% chance> <upon discovering a [Water] tile>`

This is my first Unciv PR and my first Kotlin PR - reviews are welcome and encouraged!