### PR TITLE
[code quality] Reorg, clean up and comment a few things

### DIFF
--- a/android/src/com/unciv/app/MultiplayerTurnCheckWorker.kt
+++ b/android/src/com/unciv/app/MultiplayerTurnCheckWorker.kt
@@ -30,8 +30,7 @@ import com.unciv.logic.GameInfo
 import com.unciv.logic.files.UncivFiles
 import com.unciv.logic.multiplayer.storage.FileStorageRateLimitReached
 import com.unciv.logic.multiplayer.storage.OnlineMultiplayerServer
-import com.unciv.models.metadata.GameSettingsMultiplayer
-import kotlinx.coroutines.runBlocking
+import com.unciv.models.metadata.GameSettings.GameSettingsMultiplayer
 import java.io.FileNotFoundException
 import java.io.PrintWriter
 import java.io.StringWriter
@@ -39,6 +38,7 @@ import java.io.Writer
 import java.time.Duration
 import java.util.GregorianCalendar
 import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.runBlocking
 
 
 class MultiplayerTurnCheckWorker(appContext: Context, workerParams: WorkerParameters)

--- a/core/src/com/unciv/GUI.kt
+++ b/core/src/com/unciv/GUI.kt
@@ -1,0 +1,83 @@
+package com.unciv
+
+import com.badlogic.gdx.Gdx
+import com.badlogic.gdx.Input
+import com.unciv.logic.civilization.Civilization
+import com.unciv.models.metadata.GameSettings
+import com.unciv.ui.screens.basescreen.BaseScreen
+import com.unciv.ui.screens.worldscreen.UndoHandler.Companion.clearUndoCheckpoints
+import com.unciv.ui.screens.worldscreen.WorldMapHolder
+import com.unciv.ui.screens.worldscreen.WorldScreen
+import com.unciv.ui.screens.worldscreen.unit.UnitTable
+
+object GUI {
+
+    fun setUpdateWorldOnNextRender() {
+        UncivGame.Current.worldScreen?.shouldUpdate = true
+    }
+
+    fun pushScreen(screen: BaseScreen) {
+        UncivGame.Current.pushScreen(screen)
+    }
+
+    fun resetToWorldScreen() {
+        UncivGame.Current.resetToWorldScreen()
+    }
+
+    fun getSettings(): GameSettings {
+        return UncivGame.Current.settings
+    }
+
+    fun isWorldLoaded(): Boolean {
+        return UncivGame.Current.worldScreen != null
+    }
+
+    fun isMyTurn(): Boolean {
+        if (!UncivGame.isCurrentInitialized() || !isWorldLoaded()) return false
+        return UncivGame.Current.worldScreen!!.isPlayersTurn
+    }
+
+    fun isAllowedChangeState(): Boolean {
+        return UncivGame.Current.worldScreen!!.canChangeState
+    }
+
+    fun getWorldScreen(): WorldScreen {
+        return UncivGame.Current.worldScreen!!
+    }
+
+    fun getWorldScreenIfActive(): WorldScreen? {
+        return UncivGame.Current.getWorldScreenIfActive()
+    }
+
+    fun getMap(): WorldMapHolder {
+        return UncivGame.Current.worldScreen!!.mapHolder
+    }
+
+    fun getUnitTable(): UnitTable {
+        return UncivGame.Current.worldScreen!!.bottomUnitTable
+    }
+
+    fun getViewingPlayer(): Civilization {
+        return UncivGame.Current.worldScreen!!.viewingCiv
+    }
+
+    fun getSelectedPlayer(): Civilization {
+        return UncivGame.Current.worldScreen!!.selectedCiv
+    }
+
+    /** Disable Undo (as in: forget the way back, but allow future undo checkpoints) */
+    fun clearUndoCheckpoints() {
+        UncivGame.Current.worldScreen?.clearUndoCheckpoints()
+    }
+
+    private var keyboardAvailableCache: Boolean? = null
+    /** Tests availability of a physical keyboard */
+    val keyboardAvailable: Boolean
+        get() {
+            // defer decision if Gdx.input not yet initialized
+            if (keyboardAvailableCache == null && Gdx.input != null)
+                keyboardAvailableCache = Gdx.input.isPeripheralAvailable(Input.Peripheral.HardwareKeyboard)
+            return keyboardAvailableCache ?: false
+        }
+
+}

--- a/core/src/com/unciv/UncivGame.kt
+++ b/core/src/com/unciv/UncivGame.kt
@@ -11,7 +11,6 @@ import com.badlogic.gdx.utils.Align
 import com.unciv.logic.GameInfo
 import com.unciv.logic.IsPartOfGameInfoSerialization
 import com.unciv.logic.UncivShowableException
-import com.unciv.logic.civilization.Civilization
 import com.unciv.logic.civilization.PlayerType
 import com.unciv.logic.files.UncivFiles
 import com.unciv.logic.multiplayer.OnlineMultiplayer
@@ -38,10 +37,7 @@ import com.unciv.ui.screens.basescreen.BaseScreen
 import com.unciv.ui.screens.mainmenuscreen.MainMenuScreen
 import com.unciv.ui.screens.savescreens.LoadGameScreen
 import com.unciv.ui.screens.worldscreen.PlayerReadyScreen
-import com.unciv.ui.screens.worldscreen.UndoHandler.Companion.clearUndoCheckpoints
-import com.unciv.ui.screens.worldscreen.WorldMapHolder
 import com.unciv.ui.screens.worldscreen.WorldScreen
-import com.unciv.ui.screens.worldscreen.unit.UnitTable
 import com.unciv.utils.Concurrency
 import com.unciv.utils.DebugUtils
 import com.unciv.utils.Display
@@ -56,78 +52,6 @@ import java.util.EnumSet
 import java.util.UUID
 import kotlinx.coroutines.CancellationException
 import kotlin.system.exitProcess
-
-object GUI {
-
-    fun setUpdateWorldOnNextRender() {
-        UncivGame.Current.worldScreen?.shouldUpdate = true
-    }
-
-    fun pushScreen(screen: BaseScreen) {
-        UncivGame.Current.pushScreen(screen)
-    }
-
-    fun resetToWorldScreen() {
-        UncivGame.Current.resetToWorldScreen()
-    }
-
-    fun getSettings(): GameSettings {
-        return UncivGame.Current.settings
-    }
-
-    fun isWorldLoaded(): Boolean {
-        return UncivGame.Current.worldScreen != null
-    }
-
-    fun isMyTurn(): Boolean {
-        if (!UncivGame.isCurrentInitialized() || !isWorldLoaded()) return false
-        return UncivGame.Current.worldScreen!!.isPlayersTurn
-    }
-
-    fun isAllowedChangeState(): Boolean {
-        return UncivGame.Current.worldScreen!!.canChangeState
-    }
-
-    fun getWorldScreen(): WorldScreen {
-        return UncivGame.Current.worldScreen!!
-    }
-
-    fun getWorldScreenIfActive(): WorldScreen? {
-        return UncivGame.Current.getWorldScreenIfActive()
-    }
-
-    fun getMap(): WorldMapHolder {
-        return UncivGame.Current.worldScreen!!.mapHolder
-    }
-
-    fun getUnitTable(): UnitTable {
-        return UncivGame.Current.worldScreen!!.bottomUnitTable
-    }
-
-    fun getViewingPlayer(): Civilization {
-        return UncivGame.Current.worldScreen!!.viewingCiv
-    }
-
-    fun getSelectedPlayer(): Civilization {
-        return UncivGame.Current.worldScreen!!.selectedCiv
-    }
-
-    /** Disable Undo (as in: forget the way back, but allow future undo checkpoints) */
-    fun clearUndoCheckpoints() {
-        UncivGame.Current.worldScreen?.clearUndoCheckpoints()
-    }
-
-    private var keyboardAvailableCache: Boolean? = null
-    /** Tests availability of a physical keyboard */
-    val keyboardAvailable: Boolean
-        get() {
-            // defer decision if Gdx.input not yet initialized
-            if (keyboardAvailableCache == null && Gdx.input != null)
-                keyboardAvailableCache = Gdx.input.isPeripheralAvailable(Input.Peripheral.HardwareKeyboard)
-            return keyboardAvailableCache ?: false
-        }
-
-}
 
 open class UncivGame(val isConsoleMode: Boolean = false) : Game(), PlatformSpecific {
 

--- a/core/src/com/unciv/models/metadata/BaseRuleset.kt
+++ b/core/src/com/unciv/models/metadata/BaseRuleset.kt
@@ -1,0 +1,7 @@
+package com.unciv.models.metadata
+
+@Suppress("EnumEntryName")  // These merit unusual names
+enum class BaseRuleset(val fullName:String) {
+    Civ_V_Vanilla("Civ V - Vanilla"),
+    Civ_V_GnK("Civ V - Gods & Kings"),
+}

--- a/core/src/com/unciv/models/metadata/GameParameters.kt
+++ b/core/src/com/unciv/models/metadata/GameParameters.kt
@@ -4,13 +4,6 @@ import com.unciv.logic.IsPartOfGameInfoSerialization
 import com.unciv.logic.civilization.PlayerType
 import com.unciv.models.ruleset.Speed
 
-
-@Suppress("EnumEntryName")  // These merit unusual names
-enum class BaseRuleset(val fullName:String) {
-    Civ_V_Vanilla("Civ V - Vanilla"),
-    Civ_V_GnK("Civ V - Gods & Kings"),
-}
-
 class GameParameters : IsPartOfGameInfoSerialization { // Default values are the default new game
     var difficulty = "Prince"
     var speed = Speed.DEFAULT

--- a/core/src/com/unciv/models/metadata/GameSettings.kt
+++ b/core/src/com/unciv/models/metadata/GameSettings.kt
@@ -243,54 +243,57 @@ class GameSettings {
         Afrikaans("af", "ZA")
     }
 
-    //endregiuon
-}
+    //endregion
+    //region Multiplayer-specific
 
-class GameSettingsMultiplayer {
-    var userId = ""
-    var passwords = mutableMapOf<String, String>()
-    @Suppress("unused")  // @GGuenni knows what he intended with this field
-    var userName: String = ""
-    var server = Constants.uncivXyzServer
-    var friendList: MutableList<FriendList.Friend> = mutableListOf()
-    var turnCheckerEnabled = true
-    var turnCheckerPersistentNotificationEnabled = true
-    var turnCheckerDelay: Duration = Duration.ofMinutes(5)
-    var statusButtonInSinglePlayer = false
-    var currentGameRefreshDelay: Duration = Duration.ofSeconds(10)
-    var allGameRefreshDelay: Duration = Duration.ofMinutes(5)
-    var currentGameTurnNotificationSound: UncivSound = UncivSound.Silent
-    var otherGameTurnNotificationSound: UncivSound = UncivSound.Silent
-    var hideDropboxWarning = false
+    class GameSettingsMultiplayer {
+        var userId = ""
+        var passwords = mutableMapOf<String, String>()
+        @Suppress("unused")  // @GGuenni knows what he intended with this field
+        var userName: String = ""
+        var server = Constants.uncivXyzServer
+        var friendList: MutableList<FriendList.Friend> = mutableListOf()
+        var turnCheckerEnabled = true
+        var turnCheckerPersistentNotificationEnabled = true
+        var turnCheckerDelay: Duration = Duration.ofMinutes(5)
+        var statusButtonInSinglePlayer = false
+        var currentGameRefreshDelay: Duration = Duration.ofSeconds(10)
+        var allGameRefreshDelay: Duration = Duration.ofMinutes(5)
+        var currentGameTurnNotificationSound: UncivSound = UncivSound.Silent
+        var otherGameTurnNotificationSound: UncivSound = UncivSound.Silent
+        var hideDropboxWarning = false
 
-    fun getAuthHeader(): String {
-        val serverPassword = passwords[server] ?: ""
-        val preEncodedAuthValue = "$userId:$serverPassword"
-        return "Basic ${Base64Coder.encodeString(preEncodedAuthValue)}"
+        fun getAuthHeader(): String {
+            val serverPassword = passwords[server] ?: ""
+            val preEncodedAuthValue = "$userId:$serverPassword"
+            return "Basic ${Base64Coder.encodeString(preEncodedAuthValue)}"
+        }
     }
-}
 
-@Suppress("SuspiciousCallableReferenceInLambda")  // By @Azzurite, safe as long as that warning below is followed
-enum class GameSetting(
-    val kClass: KClass<*>,
-    private val propertyGetter: (GameSettings) -> KMutableProperty0<*>
-) {
-//     Uncomment these once they are refactored to send events on change
+    @Suppress("SuspiciousCallableReferenceInLambda")  // By @Azzurite, safe as long as that warning below is followed
+    enum class GameSetting(
+        val kClass: KClass<*>,
+        private val propertyGetter: (GameSettings) -> KMutableProperty0<*>
+    ) {
+        //     Uncomment these once they are refactored to send events on change
 //     MULTIPLAYER_USER_ID(String::class, { it.multiplayer::userId }),
 //     MULTIPLAYER_SERVER(String::class, { it.multiplayer::server }),
 //     MULTIPLAYER_STATUSBUTTON_IN_SINGLEPLAYER(Boolean::class, { it.multiplayer::statusButtonInSinglePlayer }),
 //     MULTIPLAYER_TURN_CHECKER_ENABLED(Boolean::class, { it.multiplayer::turnCheckerEnabled }),
 //     MULTIPLAYER_TURN_CHECKER_PERSISTENT_NOTIFICATION_ENABLED(Boolean::class, { it.multiplayer::turnCheckerPersistentNotificationEnabled }),
 //     MULTIPLAYER_HIDE_DROPBOX_WARNING(Boolean::class, { it.multiplayer::hideDropboxWarning }),
-    MULTIPLAYER_TURN_CHECKER_DELAY(Duration::class, { it.multiplayer::turnCheckerDelay }),
-    MULTIPLAYER_CURRENT_GAME_REFRESH_DELAY(Duration::class, { it.multiplayer::currentGameRefreshDelay }),
-    MULTIPLAYER_ALL_GAME_REFRESH_DELAY(Duration::class, { it.multiplayer::allGameRefreshDelay }),
-    MULTIPLAYER_CURRENT_GAME_TURN_NOTIFICATION_SOUND(UncivSound::class, { it.multiplayer::currentGameTurnNotificationSound }),
-    MULTIPLAYER_OTHER_GAME_TURN_NOTIFICATION_SOUND(UncivSound::class, { it.multiplayer::otherGameTurnNotificationSound });
+        MULTIPLAYER_TURN_CHECKER_DELAY(Duration::class, { it.multiplayer::turnCheckerDelay }),
+        MULTIPLAYER_CURRENT_GAME_REFRESH_DELAY(Duration::class, { it.multiplayer::currentGameRefreshDelay }),
+        MULTIPLAYER_ALL_GAME_REFRESH_DELAY(Duration::class, { it.multiplayer::allGameRefreshDelay }),
+        MULTIPLAYER_CURRENT_GAME_TURN_NOTIFICATION_SOUND(UncivSound::class, { it.multiplayer::currentGameTurnNotificationSound }),
+        MULTIPLAYER_OTHER_GAME_TURN_NOTIFICATION_SOUND(UncivSound::class, { it.multiplayer::otherGameTurnNotificationSound });
 
-    /** **Warning:** It is the obligation of the caller to select the same type [T] that the [kClass] of this property has */
-    fun <T> getProperty(settings: GameSettings): KMutableProperty0<T> {
-        @Suppress("UNCHECKED_CAST")
-        return propertyGetter(settings) as KMutableProperty0<T>
+        /** **Warning:** It is the obligation of the caller to select the same type [T] that the [kClass] of this property has */
+        fun <T> getProperty(settings: GameSettings): KMutableProperty0<T> {
+            @Suppress("UNCHECKED_CAST")
+            return propertyGetter(settings) as KMutableProperty0<T>
+        }
     }
+
+    //endregion
 }

--- a/core/src/com/unciv/models/metadata/GameSettings.kt
+++ b/core/src/com/unciv/models/metadata/GameSettings.kt
@@ -19,20 +19,6 @@ import java.util.Locale
 import kotlin.reflect.KClass
 import kotlin.reflect.KMutableProperty0
 
-data class WindowState (val width: Int = 900, val height: Int = 600)
-
-enum class ScreenSize(
-    @Suppress("unused")  // Actual width determined by screen aspect ratio, this as comment only
-    val virtualWidth: Float,
-    val virtualHeight: Float
-) {
-    Tiny(750f,500f),
-    Small(900f,600f),
-    Medium(1050f,700f),
-    Large(1200f,800f),
-    Huge(1500f,1000f)
-}
-
 class GameSettings {
 
     /** Allows panning the map by moving the pointer to the screen edges */
@@ -132,7 +118,6 @@ class GameSettings {
     var enlargeSelectedNotification = true
 
     /** Whether the Nation Picker shows icons only or the horizontal "civBlocks" with leader/nation name */
-    enum class NationPickerListMode { Icons, List }
     var nationPickerListMode = NationPickerListMode.List
 
     /** Size of automatic display of UnitSet art in Civilopedia - 0 to disable */
@@ -148,10 +133,13 @@ class GameSettings {
         }
     }
 
+    //region <Methods>
+
     fun save() {
         refreshWindowSize()
         UncivGame.Current.files.setGeneralSettings(this)
     }
+
     fun refreshWindowSize() {
         if (isFreshlyCreated || Gdx.app.type != ApplicationType.Desktop) return
         if (!Display.hasUserSelectableSize(screenMode)) return
@@ -189,52 +177,73 @@ class GameSettings {
     fun getCollatorFromLocale(): Collator {
         return Collator.getInstance(getCurrentLocale())
     }
-}
 
-enum class LocaleCode(var language: String, var country: String) {
-    Arabic("ar", "IQ"),
-    Belarusian("be", "BY"),
-    BrazilianPortuguese("pt", "BR"),
-    Bulgarian("bg", "BG"),
-    Catalan("ca", "ES"),
-    Croatian("hr", "HR"),
-    Czech("cs", "CZ"),
-    Danish("da", "DK"),
-    Dutch("nl", "NL"),
-    English("en", "US"),
-    Estonian("et", "EE"),
-    Finnish("fi", "FI"),
-    French("fr", "FR"),
-    German("de", "DE"),
-    Greek("el", "GR"),
-    Hindi("hi", "IN"),
-    Hungarian("hu", "HU"),
-    Indonesian("in", "ID"),
-    Italian("it", "IT"),
-    Japanese("ja", "JP"),
-    Korean("ko", "KR"),
-    Latvian("lv", "LV"),
-    Lithuanian("lt", "LT"),
-    Malay("ms", "MY"),
-    Norwegian("no", "NO"),
-    NorwegianNynorsk("nn", "NO"),
-    PersianPinglishDIN("fa", "IR"), // These might just fall back to default
-    PersianPinglishUN("fa", "IR"),
-    Polish("pl", "PL"),
-    Portuguese("pt", "PT"),
-    Romanian("ro", "RO"),
-    Russian("ru", "RU"),
-    Serbian("sr", "RS"),
-    SimplifiedChinese("zh", "CN"),
-    Slovak("sk", "SK"),
-    Spanish("es", "ES"),
-    Swedish("sv", "SE"),
-    Thai("th", "TH"),
-    TraditionalChinese("zh", "TW"),
-    Turkish("tr", "TR"),
-    Ukrainian("uk", "UA"),
-    Vietnamese("vi", "VN"),
-    Afrikaans("af", "ZA")
+    //endregion
+    //region <Nested classes>
+
+    data class WindowState (val width: Int = 900, val height: Int = 600)
+
+    enum class ScreenSize(
+        @Suppress("unused")  // Actual width determined by screen aspect ratio, this as comment only
+        val virtualWidth: Float,
+        val virtualHeight: Float
+    ) {
+        Tiny(750f,500f),
+        Small(900f,600f),
+        Medium(1050f,700f),
+        Large(1200f,800f),
+        Huge(1500f,1000f)
+    }
+
+    enum class NationPickerListMode { Icons, List }
+
+    enum class LocaleCode(var language: String, var country: String) {
+        Arabic("ar", "IQ"),
+        Belarusian("be", "BY"),
+        BrazilianPortuguese("pt", "BR"),
+        Bulgarian("bg", "BG"),
+        Catalan("ca", "ES"),
+        Croatian("hr", "HR"),
+        Czech("cs", "CZ"),
+        Danish("da", "DK"),
+        Dutch("nl", "NL"),
+        English("en", "US"),
+        Estonian("et", "EE"),
+        Finnish("fi", "FI"),
+        French("fr", "FR"),
+        German("de", "DE"),
+        Greek("el", "GR"),
+        Hindi("hi", "IN"),
+        Hungarian("hu", "HU"),
+        Indonesian("in", "ID"),
+        Italian("it", "IT"),
+        Japanese("ja", "JP"),
+        Korean("ko", "KR"),
+        Latvian("lv", "LV"),
+        Lithuanian("lt", "LT"),
+        Malay("ms", "MY"),
+        Norwegian("no", "NO"),
+        NorwegianNynorsk("nn", "NO"),
+        PersianPinglishDIN("fa", "IR"), // These might just fall back to default
+        PersianPinglishUN("fa", "IR"),
+        Polish("pl", "PL"),
+        Portuguese("pt", "PT"),
+        Romanian("ro", "RO"),
+        Russian("ru", "RU"),
+        Serbian("sr", "RS"),
+        SimplifiedChinese("zh", "CN"),
+        Slovak("sk", "SK"),
+        Spanish("es", "ES"),
+        Swedish("sv", "SE"),
+        Thai("th", "TH"),
+        TraditionalChinese("zh", "TW"),
+        Turkish("tr", "TR"),
+        Ukrainian("uk", "UA"),
+        Vietnamese("vi", "VN"),
+        Afrikaans("af", "ZA")
+    }
+
+    //endregiuon
 }
 
 class GameSettingsMultiplayer {

--- a/core/src/com/unciv/models/metadata/SettingsEvents.kt
+++ b/core/src/com/unciv/models/metadata/SettingsEvents.kt
@@ -2,6 +2,7 @@ package com.unciv.models.metadata
 
 import com.unciv.logic.event.Event
 import com.unciv.models.UncivSound
+import com.unciv.models.metadata.GameSettings.GameSetting
 
 /** **Warning:** this event is in the process of completion and **not** used for all settings yet! **Only the settings in [GameSetting] get events sent!** */
 interface SettingsPropertyChanged : Event {

--- a/core/src/com/unciv/models/translations/TranslationFileWriter.kt
+++ b/core/src/com/unciv/models/translations/TranslationFileWriter.kt
@@ -7,7 +7,7 @@ import com.unciv.json.json
 import com.unciv.logic.civilization.diplomacy.DiplomaticModifiers
 import com.unciv.models.SpyAction
 import com.unciv.models.metadata.BaseRuleset
-import com.unciv.models.metadata.LocaleCode
+import com.unciv.models.metadata.GameSettings.LocaleCode
 import com.unciv.models.ruleset.Belief
 import com.unciv.models.ruleset.Building
 import com.unciv.models.ruleset.GlobalUniques

--- a/core/src/com/unciv/ui/popups/options/AdvancedTab.kt
+++ b/core/src/com/unciv/ui/popups/options/AdvancedTab.kt
@@ -18,7 +18,7 @@ import com.unciv.GUI
 import com.unciv.UncivGame
 import com.unciv.models.metadata.GameSettings
 import com.unciv.models.metadata.ModCategories
-import com.unciv.models.metadata.ScreenSize
+import com.unciv.models.metadata.GameSettings.ScreenSize
 import com.unciv.models.translations.TranslationFileWriter
 import com.unciv.models.translations.tr
 import com.unciv.ui.components.UncivTooltip.Companion.addTooltip

--- a/core/src/com/unciv/ui/popups/options/DisplayTab.kt
+++ b/core/src/com/unciv/ui/popups/options/DisplayTab.kt
@@ -8,7 +8,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.utils.Array
 import com.unciv.GUI
 import com.unciv.models.metadata.GameSettings
-import com.unciv.models.metadata.ScreenSize
+import com.unciv.models.metadata.GameSettings.ScreenSize
 import com.unciv.models.skins.SkinCache
 import com.unciv.models.tilesets.TileSetCache
 import com.unciv.models.translations.tr

--- a/core/src/com/unciv/ui/popups/options/MultiplayerTab.kt
+++ b/core/src/com/unciv/ui/popups/options/MultiplayerTab.kt
@@ -9,8 +9,8 @@ import com.unciv.logic.multiplayer.OnlineMultiplayer
 import com.unciv.logic.multiplayer.storage.FileStorageRateLimitReached
 import com.unciv.logic.multiplayer.storage.MultiplayerAuthException
 import com.unciv.models.UncivSound
-import com.unciv.models.metadata.GameSetting
 import com.unciv.models.metadata.GameSettings
+import com.unciv.models.metadata.GameSettings.GameSetting
 import com.unciv.models.ruleset.RulesetCache
 import com.unciv.ui.components.UncivTextField
 import com.unciv.ui.components.extensions.addSeparator

--- a/core/src/com/unciv/ui/popups/options/SettingsSelect.kt
+++ b/core/src/com/unciv/ui/popups/options/SettingsSelect.kt
@@ -7,8 +7,8 @@ import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener
 import com.badlogic.gdx.utils.Array
 import com.unciv.logic.event.EventBus
 import com.unciv.models.UncivSound
-import com.unciv.models.metadata.GameSetting
 import com.unciv.models.metadata.GameSettings
+import com.unciv.models.metadata.GameSettings.GameSetting
 import com.unciv.models.metadata.SettingsPropertyChanged
 import com.unciv.models.metadata.SettingsPropertyUncivSoundChanged
 import com.unciv.models.translations.tr

--- a/core/src/com/unciv/ui/screens/worldscreen/mainmenu/WorldScreenMusicPopup.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/mainmenu/WorldScreenMusicPopup.kt
@@ -7,7 +7,7 @@ import com.badlogic.gdx.utils.Align
 import com.unciv.Constants
 import com.unciv.UncivGame
 import com.unciv.models.metadata.GameSettings
-import com.unciv.models.metadata.ScreenSize
+import com.unciv.models.metadata.GameSettings.ScreenSize
 import com.unciv.ui.audio.MusicController
 import com.unciv.ui.components.extensions.setSize
 import com.unciv.ui.components.fonts.Fonts

--- a/desktop/src/com/unciv/app/desktop/DesktopDisplay.kt
+++ b/desktop/src/com/unciv/app/desktop/DesktopDisplay.kt
@@ -58,8 +58,7 @@ enum class DesktopScreenMode : ScreenMode {
         val maximumWindowBounds = getMaximumWindowBounds()
 
         // Make sure an inappropriate saved size doesn't make the window unusable
-        val width = settings.windowState.width.coerceIn(120, maximumWindowBounds.width)
-        val height = settings.windowState.height.coerceIn(80, maximumWindowBounds.height)
+        val (width, height) = settings.windowState.coerceIn(maximumWindowBounds)
 
         // Kludge - see also DesktopLauncher - without, moving the window might revert to the size stored in config
         (Lwjgl3Application::class.java).getDeclaredField("config").run {

--- a/desktop/src/com/unciv/app/desktop/DesktopGame.kt
+++ b/desktop/src/com/unciv/app/desktop/DesktopGame.kt
@@ -7,7 +7,7 @@ class DesktopGame(config: Lwjgl3ApplicationConfiguration) : UncivGame() {
 
     private val audio = HardenGdxAudio()
     private var discordUpdater = DiscordUpdater()
-    private val turnNotifier = MultiplayerTurnNotifierDesktop()
+    private val turnNotifier = UncivWindowListener()
 
     init {
         config.setWindowListener(turnNotifier)

--- a/desktop/src/com/unciv/app/desktop/DesktopGame.kt
+++ b/desktop/src/com/unciv/app/desktop/DesktopGame.kt
@@ -7,10 +7,10 @@ class DesktopGame(config: Lwjgl3ApplicationConfiguration) : UncivGame() {
 
     private val audio = HardenGdxAudio()
     private var discordUpdater = DiscordUpdater()
-    private val turnNotifier = UncivWindowListener()
+    private val windowListener = UncivWindowListener()
 
     init {
-        config.setWindowListener(turnNotifier)
+        config.setWindowListener(windowListener)
 
         discordUpdater.setOnUpdate {
 
@@ -41,7 +41,7 @@ class DesktopGame(config: Lwjgl3ApplicationConfiguration) : UncivGame() {
     }
 
     override fun notifyTurnStarted() {
-        turnNotifier.turnStarted()
+        windowListener.turnStarted()
     }
 
     override fun dispose() {

--- a/desktop/src/com/unciv/app/desktop/DesktopLauncher.kt
+++ b/desktop/src/com/unciv/app/desktop/DesktopLauncher.kt
@@ -8,8 +8,8 @@ import com.unciv.app.desktop.DesktopScreenMode.Companion.getMaximumWindowBounds
 import com.unciv.json.json
 import com.unciv.logic.files.SETTINGS_FILE_NAME
 import com.unciv.logic.files.UncivFiles
-import com.unciv.models.metadata.ScreenSize
-import com.unciv.models.metadata.WindowState
+import com.unciv.models.metadata.GameSettings.ScreenSize
+import com.unciv.models.metadata.GameSettings.WindowState
 import com.unciv.ui.components.fonts.Fonts
 import com.unciv.ui.screens.basescreen.BaseScreen
 import com.unciv.utils.Display

--- a/desktop/src/com/unciv/app/desktop/DesktopLauncher.kt
+++ b/desktop/src/com/unciv/app/desktop/DesktopLauncher.kt
@@ -14,7 +14,6 @@ import com.unciv.ui.components.fonts.Fonts
 import com.unciv.ui.screens.basescreen.BaseScreen
 import com.unciv.utils.Display
 import com.unciv.utils.Log
-import kotlin.math.max
 
 internal object DesktopLauncher {
 
@@ -49,27 +48,27 @@ internal object DesktopLauncher {
         config.setWindowIcon("ExtraImages/Icon.png")
         config.setTitle("Unciv")
         config.setHdpiMode(HdpiMode.Logical)
-        config.setWindowSizeLimits(120, 80, -1, -1)
+        config.setWindowSizeLimits(WindowState.minimumWidth, WindowState.minimumHeight, -1, -1)
 
         // We don't need the initial Audio created in Lwjgl3Application, HardenGdxAudio will replace it anyway.
         // Note that means config.setAudioConfig() would be ignored too, those would need to go into the HardenedGdxAudio constructor.
         config.disableAudio(true)
 
+        // LibGDX not yet configured, use regular java class
+        val maximumWindowBounds = getMaximumWindowBounds()
+
         val settings = UncivFiles.getSettingsForPlatformLaunchers()
         if (settings.isFreshlyCreated) {
             settings.screenSize = ScreenSize.Large // By default we guess that Desktops have larger screens
-            // LibGDX not yet configured, use regular java class
-            val maximumWindowBounds = getMaximumWindowBounds()
-            settings.windowState = WindowState(
-                width = maximumWindowBounds.width,
-                height = maximumWindowBounds.height
-            )
+            settings.windowState = WindowState(maximumWindowBounds)
             FileHandle(SETTINGS_FILE_NAME).writeString(json().toJson(settings), false, Charsets.UTF_8.name()) // so when we later open the game we get fullscreen
         }
         // Kludge! This is a workaround - the matching call in DesktopDisplay doesn't "take" quite permanently,
         // the window might revert to the "config" values when the user moves the window - worse if they
         // minimize/restore. And the config default is 640x480 unless we set something here.
-        config.setWindowedMode(max(settings.windowState.width, 100), max(settings.windowState.height, 100))
+        val (width, height) = settings.windowState.coerceIn(maximumWindowBounds)
+        config.setWindowedMode(width, height)
+
         config.setInitialBackgroundColor(BaseScreen.clearColor)
 
         if (!isRunFromJAR) {

--- a/desktop/src/com/unciv/app/desktop/UncivWindowListener.kt
+++ b/desktop/src/com/unciv/app/desktop/UncivWindowListener.kt
@@ -10,7 +10,7 @@ import com.sun.jna.platform.win32.WinUser
 import com.unciv.utils.Log
 import org.lwjgl.glfw.GLFWNativeWin32
 
-class MultiplayerTurnNotifierDesktop: Lwjgl3WindowAdapter() {
+class UncivWindowListener: Lwjgl3WindowAdapter() {
     companion object {
         val user32: User32? = try {
             if (System.getProperty("os.name")?.contains("Windows") == true) {

--- a/desktop/src/com/unciv/app/desktop/UncivWindowListener.kt
+++ b/desktop/src/com/unciv/app/desktop/UncivWindowListener.kt
@@ -10,23 +10,21 @@ import com.sun.jna.platform.win32.WinUser
 import com.unciv.utils.Log
 import org.lwjgl.glfw.GLFWNativeWin32
 
-class UncivWindowListener: Lwjgl3WindowAdapter() {
-    companion object {
-        val user32: User32? = try {
-            if (System.getProperty("os.name")?.contains("Windows") == true) {
-                Native.load(User32::class.java)
-            } else {
-                null
-            }
-        } catch (e: UnsatisfiedLinkError) {
-            Log.error("Error while initializing turn notifier", e)
-            null
-        }
-    }
+/**
+ *  This is a Lwjgl3WindowListener serving the following purposes:
+ *
+ *  - Catch and store our Lwjgl3Window instance
+ *  - Track whether the Window has focus
+ *  - "Flash" the Window to alert "your turn" in multiplayer
+ */
+class UncivWindowListener : Lwjgl3WindowAdapter() {
+
     private var window: Lwjgl3Window? = null
     private var hasFocus: Boolean = true
 
     override fun created(window: Lwjgl3Window?) {
+        // In DesktopDisplay we use `(Gdx.graphics as? Lwjgl3Graphics)?.window`, so this entire listener could be made redundant.
+        // But we might need other uses in the future, so leave it as is.
         this.window = window
     }
 
@@ -39,27 +37,57 @@ class UncivWindowListener: Lwjgl3WindowAdapter() {
     }
 
 
+    /** Asks the operating system to request the player's attention */
     fun turnStarted() {
         flashWindow()
     }
 
     /**
-     * See https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-flashwindowex
+     * Requests user attention
      *
-     * We should've used FlashWindow instead of FlashWindowEx, but for some reason the former has no binding in Java's User32
+     * Excerpt from the [GLFW.glfwRequestWindowAttention](https://www.glfw.org/docs/latest/window_guide.html#window_attention) JavaDoc:
+     * - This function must only be called from the main thread.
+     * - **macOS:** Attention is requested to the application as a whole, not the specific window.
+     *
+     * On Windows, the OS-specific API is called directly instead.
+     * - See [FlashWindowEx](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-flashwindowex)
+     *
      */
     private fun flashWindow() {
         try {
-            if (user32 == null || window == null || hasFocus) return
+            if (window == null || hasFocus) return
+            if (user32 == null)
+                // Use Cross-Platform implementation
+                return window!!.flash()
+
+            // Windows-specific implementation:
             val flashwinfo = WinUser.FLASHWINFO()
             val hwnd = GLFWNativeWin32.glfwGetWin32Window(window!!.windowHandle)
             flashwinfo.hWnd = WinNT.HANDLE(Pointer.createConstant(hwnd))
             flashwinfo.dwFlags = 3 // FLASHW_ALL
             flashwinfo.uCount = 3
+            // FlashWindow (no binding in Java's User32) instead of FlashWindowEx would flash just once
             user32.FlashWindowEx(flashwinfo)
         } catch (e: Throwable) {
             /** try to ignore even if we get an [Error], just log it */
             Log.error("Error while notifying the user of their turn", e)
+        }
+    }
+
+    private companion object {
+        /** Marshals JNA access to the Windows User32 API through [com.sun.jna.platform.win32.User32]
+         *
+         *  (which, by the way, says "Incomplete implementation to support demos.")
+         */
+        val user32: User32? = try {
+            if (System.getProperty("os.name")?.contains("Windows") == true) {
+                Native.load(User32::class.java)
+            } else {
+                null
+            }
+        } catch (e: UnsatisfiedLinkError) {
+            Log.error("Error while initializing turn notifier", e)
+            null
         }
     }
 }

--- a/tests/src/com/unciv/dev/FasterUIDevelopment.kt
+++ b/tests/src/com/unciv/dev/FasterUIDevelopment.kt
@@ -62,7 +62,8 @@ object FasterUIDevelopment {
 
         val settings = UncivFiles.getSettingsForPlatformLaunchers()
         if (!settings.isFreshlyCreated) {
-            config.setWindowedMode(settings.windowState.width.coerceAtLeast(120), settings.windowState.height.coerceAtLeast(80))
+            val (width, height) = settings.windowState.coerceIn()
+            config.setWindowedMode(width, height)
         }
 
         Lwjgl3Application(UIDevGame(), config)


### PR DESCRIPTION
I promise I've paid utmost attention to introduce zero functional changes - one exception. Descriptive commit messages.

The one change is: `DesktopGame.notifyTurnStarted` now has an effect on non-Windows, too, simply passing off to `GLFW.glfwRequestWindowAttention` as intended by the framework. Actually, the entire ex-MultiplayerTurnNotifierDesktop file could go and be replaced by 
```kotlin
    override fun notifyTurnStarted() {
        (Gdx.graphics as? Lwjgl3Graphics)?.window?.flash()
    }
```
... (But then it is possible it would flash only once on Windows, instead of our thrice - left to upstream discretion)... but I left the listener in, will be useful in the future.