### PR TITLE
Fix free buildings triggering from conditionals in incorrect places

### DIFF
--- a/core/src/com/unciv/logic/civilization/CivConstructions.kt
+++ b/core/src/com/unciv/logic/civilization/CivConstructions.kt
@@ -107,7 +107,7 @@ class CivConstructions : IsPartOfGameInfoSerialization {
         }
     }
 
-    private fun addFreeStatBuildings(stat: Stat, amount: Int) {
+    fun addFreeStatBuildings(stat: Stat, amount: Int) {
         for (city in civInfo.cities.take(amount)) {
             if (freeStatBuildingsProvided.contains(stat.name, city.id)) continue
             val building = city.cityConstructions.cheapestStatBuilding(stat)
@@ -131,7 +131,7 @@ class CivConstructions : IsPartOfGameInfoSerialization {
         }
     }
 
-    private fun addFreeBuildings(building: Building, amount: Int) {
+    fun addFreeBuildings(building: Building, amount: Int) {
         for (city in civInfo.cities.take(amount)) {
             if (freeSpecificBuildingsProvided.contains(building.name, city.id)
                 || city.cityConstructions.containsBuildingOrEquivalent(building.name)) continue

--- a/core/src/com/unciv/logic/civilization/CivConstructions.kt
+++ b/core/src/com/unciv/logic/civilization/CivConstructions.kt
@@ -97,6 +97,7 @@ class CivConstructions : IsPartOfGameInfoSerialization {
 
     private fun addFreeStatsBuildings() {
         val statUniquesData = civInfo.getMatchingUniques(UniqueType.FreeStatBuildings)
+            .filter { !it.hasTriggerConditional() }
             .groupBy { it.params[0] }
             .mapKeys { Stat.valueOf(it.key) }
             .mapValues { unique -> unique.value.sumOf { it.params[1].toInt() } }
@@ -120,6 +121,7 @@ class CivConstructions : IsPartOfGameInfoSerialization {
 
     private fun addFreeSpecificBuildings() {
         val buildingsUniquesData = civInfo.getMatchingUniques(UniqueType.FreeSpecificBuildings)
+            .filter { !it.hasTriggerConditional() }
             .groupBy { it.params[0] }
             .mapValues { unique -> unique.value.sumOf { it.params[1].toInt() } }
 
@@ -149,7 +151,8 @@ class CivConstructions : IsPartOfGameInfoSerialization {
         for (city in civInfo.cities) {
             val freeBuildingsFromCity = city.getMatchingLocalOnlyUniques(UniqueType.GainFreeBuildings, StateForConditionals.IgnoreConditionals)
             val freeBuildingUniques = (freeBuildingsFromCiv + freeBuildingsFromCity)
-                .filter { city.matchesFilter(it.params[1]) && it.conditionalsApply(StateForConditionals(city.civ, city)) }
+                .filter { city.matchesFilter(it.params[1]) && it.conditionalsApply(StateForConditionals(city.civ, city))
+                    && !it.hasTriggerConditional() }
             for (unique in freeBuildingUniques) {
                 val freeBuilding = city.civ.getEquivalentBuilding(unique.params[0])
                 city.cityConstructions.freeBuildingsProvidedFromThisCity.addToMapOfSets(city.id, freeBuilding.name)

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -665,11 +665,11 @@ object UniqueTriggerActivation {
             }
 
             UniqueType.GainFreeBuildings -> {
+                val freeBuilding = civInfo.getEquivalentBuilding(unique.params[0])
                 val applicableCities =
                     if (unique.params[1] == "in this city") sequenceOf(city!!)
                     else civInfo.cities.asSequence().filter { it.matchesFilter(unique.params[1]) }
                 for (applicableCity in applicableCities) {
-                    val freeBuilding = applicableCity.civ.getEquivalentBuilding(unique.params[0])
                     applicableCity.cityConstructions.freeBuildingsProvidedFromThisCity.addToMapOfSets(applicableCity.id, freeBuilding.name)
 
                     if (applicableCity.cityConstructions.containsBuildingOrEquivalent(freeBuilding.name)) continue

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -20,6 +20,7 @@ import com.unciv.models.stats.Stat
 import com.unciv.models.stats.Stats
 import com.unciv.models.translations.fillPlaceholders
 import com.unciv.models.translations.hasPlaceholderParameters
+import com.unciv.ui.components.extensions.addToMapOfSets
 import com.unciv.ui.components.MayaCalendar
 import com.unciv.ui.screens.worldscreen.unit.actions.UnitActionsUpgrade
 import kotlin.math.roundToInt

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -664,10 +664,28 @@ object UniqueTriggerActivation {
                 return true
             }
 
-            UniqueType.FreeStatBuildings, UniqueType.FreeSpecificBuildings,
             UniqueType.GainFreeBuildings -> {
-                civInfo.civConstructions.tryAddFreeBuildings()
-                return true // not fully correct
+                val applicableCities =
+                    if (unique.params[1] == "in this city") sequenceOf(city!!)
+                    else civInfo.cities.asSequence().filter { it.matchesFilter(unique.params[1]) }
+                for (applicableCity in applicableCities) {
+                    val freeBuilding = applicableCity.civ.getEquivalentBuilding(unique.params[0])
+                    applicableCity.cityConstructions.freeBuildingsProvidedFromThisCity.addToMapOfSets(applicableCity.id, freeBuilding.name)
+
+                    if (applicableCity.cityConstructions.containsBuildingOrEquivalent(freeBuilding.name)) continue
+                    applicableCity.cityConstructions.constructionComplete(freeBuilding)
+                }
+                return true
+            }
+            UniqueType.FreeStatBuildings -> {
+                val stat = Stat.safeValueOf(unique.params[0]) ?: return false
+                civInfo.civConstructions.addFreeStatBuildings(stat, unique.params[1].toInt())
+                return true
+            }
+            UniqueType.FreeSpecificBuildings ->{
+                val building = ruleSet.buildings[unique.params[0]] ?: return false
+                civInfo.civConstructions.addFreeBuildings(building, unique.params[1].toInt())
+                return true
             }
 
             UniqueType.RemoveBuilding -> {


### PR DESCRIPTION
Primarily intended as a fix for scenarios where "Gain a free [buildingName] [cityFilter] <upon entering the [Future era]>" would trigger anytime we would check for free buildings. 

I'll leave it at this for now, but I am a bit stuck on something. Ideally, if you get 2 `"Provides the cheapest [Culture] building in your first [4] cities for free"` uniques, I would expect an end user to expect to get a Monument and later an Amphitheater in their first 4 cities. Instead, I'm getting a Monument in the first 8 cities. I'm pretty sure I need to change how it adds to the free building list (instead of checking if we have added a stat building in the city, we should check if we made the right amount of stat buildings). But tbh, I'm a bit lost on the best way to do this, as we can have uniques where the second param could be anything from 4 to 100