### PR TITLE
Add a setting to forbid closing popups by clicking behind them

### DIFF
--- a/android/assets/jsons/translations/Russian.properties
+++ b/android/assets/jsons/translations/Russian.properties
@@ -746,6 +746,7 @@ Reset = Сбросить
 
 Show zoom buttons in world screen = Показывать кнопки масштабирования на экране мира
 Experimental Demographics scoreboard = Экспериментальная таблица рейтинга
+Never close popups by clicking outside = Не закрывать всплывающие окна нажатием на их фон
 
 Size of Unitset art in Civilopedia = Размер изображений палитры юнитов в Цивилопедии
 

--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -746,6 +746,7 @@ Reset =
 
 Show zoom buttons in world screen = 
 Experimental Demographics scoreboard = 
+Never close popups by clicking outside = 
 
 Size of Unitset art in Civilopedia = 
 

--- a/core/src/com/unciv/models/metadata/GameSettings.kt
+++ b/core/src/com/unciv/models/metadata/GameSettings.kt
@@ -81,6 +81,7 @@ class GameSettings {
     var visualMods = HashSet<String>()
     var useDemographics: Boolean = false
     var showZoomButtons: Boolean = false
+    var forbidPopupClickBehindToClose: Boolean = false
 
     var notificationsLogMaxTurns = 5
 

--- a/core/src/com/unciv/ui/popups/Popup.kt
+++ b/core/src/com/unciv/ui/popups/Popup.kt
@@ -18,6 +18,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.WidgetGroup
 import com.badlogic.gdx.scenes.scene2d.utils.ClickListener
 import com.badlogic.gdx.utils.Align
 import com.unciv.Constants
+import com.unciv.GUI
 import com.unciv.logic.event.EventBus
 import com.unciv.ui.components.widgets.AutoScrollPane
 import com.unciv.ui.components.extensions.addSeparator
@@ -227,7 +228,7 @@ open class Popup(
     /** Allow closing a popup by clicking 'outside', Android-style, but only if a Close button exists */
     private fun getBehindClickListener() = object : ClickListener() {
         override fun clicked(event: InputEvent?, x: Float, y: Float) {
-            if (!clickBehindToClose) return
+            if (!clickBehindToClose || GUI.getSettings().forbidPopupClickBehindToClose) return
             // Since Gdx doesn't limit events to the actually `hit` actors...
             if (event?.target != this@Popup) return
             close()

--- a/core/src/com/unciv/ui/popups/options/DisplayTab.kt
+++ b/core/src/com/unciv/ui/popups/options/DisplayTab.kt
@@ -71,6 +71,7 @@ fun displayTab(
     addResetTutorials(this, settings)
     optionsPopup.addCheckbox(this, "Show zoom buttons in world screen", settings.showZoomButtons, true) { settings.showZoomButtons = it }
     optionsPopup.addCheckbox(this, "Experimental Demographics scoreboard", settings.useDemographics, true) { settings.useDemographics = it }
+    optionsPopup.addCheckbox(this, "Never close popups by clicking outside", settings.forbidPopupClickBehindToClose, true) { settings.forbidPopupClickBehindToClose = it }
     addPediaUnitArtSizeSlider(this, settings, optionsPopup.selectBoxMinWidth)
 
     addSeparator()

--- a/core/src/com/unciv/ui/popups/options/DisplayTab.kt
+++ b/core/src/com/unciv/ui/popups/options/DisplayTab.kt
@@ -71,7 +71,7 @@ fun displayTab(
     addResetTutorials(this, settings)
     optionsPopup.addCheckbox(this, "Show zoom buttons in world screen", settings.showZoomButtons, true) { settings.showZoomButtons = it }
     optionsPopup.addCheckbox(this, "Experimental Demographics scoreboard", settings.useDemographics, true) { settings.useDemographics = it }
-    optionsPopup.addCheckbox(this, "Never close popups by clicking outside", settings.forbidPopupClickBehindToClose, true) { settings.forbidPopupClickBehindToClose = it }
+    optionsPopup.addCheckbox(this, "Never close popups by clicking outside", settings.forbidPopupClickBehindToClose, false) { settings.forbidPopupClickBehindToClose = it }
     addPediaUnitArtSizeSlider(this, settings, optionsPopup.selectBoxMinWidth)
 
     addSeparator()


### PR DESCRIPTION
These changes add a setting which, when enabled, prevents popups from being closed by clicking outside of them. Default value is `false` - this will keep original behavior. This feature was requested in [this Discord thread](https://discord.com/channels/586194543280390151/1176287339870425240) and I agreed it would be nice to have.

I've tested this change on a "meeting a city-state" popup.

<details>
<summary>A screenshot of "Display" setting tab</summary>

![image](https://github.com/yairm210/Unciv/assets/8749115/ca18c90b-cacd-4514-abcf-2c641e6afd39)

</details>

I feel that `forbidPopupClickBehindToClose` is a bit verbose, but I can't think of a better name.