### PR TITLE
Sound cache preloader

### DIFF
--- a/core/src/com/unciv/ui/screens/mainmenuscreen/MainMenuScreen.kt
+++ b/core/src/com/unciv/ui/screens/mainmenuscreen/MainMenuScreen.kt
@@ -22,6 +22,7 @@ import com.unciv.models.metadata.GameSetupInfo
 import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.ruleset.RulesetCache
 import com.unciv.models.tilesets.TileSetCache
+import com.unciv.ui.audio.SoundPlayer
 import com.unciv.ui.components.UncivTooltip.Companion.addTooltip
 import com.unciv.ui.components.extensions.center
 import com.unciv.ui.components.extensions.surroundWithCircle
@@ -108,6 +109,8 @@ class MainMenuScreen: BaseScreen(), RecreateOnResize {
     }
 
     init {
+        SoundPlayer.initializeForMainMenu()
+
         val background = skinStrings.getUiBackground("MainMenuScreen/Background", tintColor = clearColor)
         backgroundStack.add(BackgroundActor(background, Align.center))
         stage.addActor(backgroundStack)


### PR DESCRIPTION
Closes #10216 
- I've been testing the first commit of this for weeks, and _feel_ it sounds snappier, but to prove that isn't easy.
- Second commit is from code review triggered by that OpenAL issue - more like defense in depth, but also tested on two devices. The desktop 'not thread-safe' vulnerability is theoretical at best, never seen it happen, but better safe than sorry.