### PR TITLE
(UX) Friendlier Language choosers

### DIFF
--- a/core/src/com/unciv/ui/components/extensions/Scene2dExtensions.kt
+++ b/core/src/com/unciv/ui/components/extensions/Scene2dExtensions.kt
@@ -19,6 +19,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.CheckBox
 import com.badlogic.gdx.scenes.scene2d.ui.Image
 import com.badlogic.gdx.scenes.scene2d.ui.ImageButton
 import com.badlogic.gdx.scenes.scene2d.ui.Label
+import com.badlogic.gdx.scenes.scene2d.ui.ScrollPane
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton.TextButtonStyle
@@ -130,6 +131,11 @@ fun Actor.getAscendant(predicate: (Actor) -> Boolean): Actor? {
     return null
 }
 
+/** Gets the nearest parent of this actor that is a [T], or null if none of its parents is of that type. */
+inline fun <reified T> Actor.getAscendant(): T? {
+    return  getAscendant { it is T } as? T
+}
+
 /** The actors bounding box in stage coordinates */
 val Actor.stageBoundingBox: Rectangle get() {
     val bottomLeft = localToStageCoordinates(Vector2.Zero.cpy())
@@ -224,6 +230,10 @@ fun <T : Actor> Cell<T>.pad(vertical: Float, horizontal: Float): Cell<T> {
 fun Image.setSize(size: Float) {
     setSize(size, size)
 }
+
+/** Proxy for [ScrollPane.scrollTo] using the [bounds][Actor.setBounds] of a given [actor] for its parameters */
+fun ScrollPane.scrollTo(actor: Actor, center: Boolean = false) =
+    scrollTo(actor.x, actor.y, actor.width, actor.height, center, center)
 
 /** Translate a [String] and make a [TextButton] widget from it */
 fun String.toTextButton(style: TextButtonStyle? = null, hideIcons: Boolean = false): TextButton {

--- a/core/src/com/unciv/ui/components/widgets/TabbedPager.kt
+++ b/core/src/com/unciv/ui/components/widgets/TabbedPager.kt
@@ -13,6 +13,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.ScrollPane
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.scenes.scene2d.ui.WidgetGroup
 import com.badlogic.gdx.scenes.scene2d.utils.ActorGestureListener
+import com.badlogic.gdx.scenes.scene2d.utils.Layout
 import com.badlogic.gdx.utils.Align
 import com.unciv.Constants
 import com.unciv.UncivGame
@@ -23,6 +24,7 @@ import com.unciv.ui.components.extensions.darken
 import com.unciv.ui.components.extensions.isEnabled
 import com.unciv.ui.components.extensions.packIfNeeded
 import com.unciv.ui.components.extensions.pad
+import com.unciv.ui.components.extensions.scrollTo
 import com.unciv.ui.components.input.KeyCharAndCode
 import com.unciv.ui.components.input.keyShortcuts
 import com.unciv.ui.components.input.onActivation
@@ -457,6 +459,18 @@ open class TabbedPager(
         page.scrollY = scrollY
         if (index != activePage) return
         contentScroll.scrollY = scrollY
+        if (!animation) contentScroll.updateVisualScroll()
+    }
+    /** Change the vertical scroll position af the [active][activePage] page's contents to scroll a given Actor into view
+     *
+     *  Assumes [actor] is a direct child of the content page, and **if** the page does **not** implement [Layout],
+     *  that [actor] has somehow been given valid [bounds][Actor.setBounds] within the page.
+     */
+    fun pageScrollTo(actor: Actor, animation: Boolean = false) {
+        if (activePage < 0) return
+        (contentScroll.actor as? Layout)?.validate()
+        contentScroll.scrollTo(actor)
+        pages[activePage].scrollY = contentScroll.scrollY
         if (!animation) contentScroll.updateVisualScroll()
     }
 

--- a/core/src/com/unciv/ui/popups/options/LanguageTab.kt
+++ b/core/src/com/unciv/ui/popups/options/LanguageTab.kt
@@ -2,37 +2,52 @@ package com.unciv.ui.popups.options
 
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.unciv.UncivGame
-import com.unciv.ui.screens.basescreen.BaseScreen
-import com.unciv.ui.components.widgets.LanguageTable.Companion.addLanguageTables
+import com.unciv.ui.components.extensions.getAscendant
 import com.unciv.ui.components.input.onClick
+import com.unciv.ui.components.widgets.LanguageTable.Companion.addLanguageKeyShortcuts
+import com.unciv.ui.components.widgets.LanguageTable.Companion.addLanguageTables
+import com.unciv.ui.components.widgets.TabbedPager
 
-fun languageTab(
+class LanguageTab(
     optionsPopup: OptionsPopup,
-    onLanguageSelected: () -> Unit
-): Table = Table(BaseScreen.skin).apply {
-    val settings = optionsPopup.settings
+    private val onLanguageSelected: () -> Unit
+): Table(), TabbedPager.IPageExtensions {
+    private val languageTables = this.addLanguageTables(optionsPopup.tabs.prefWidth * 0.9f - 10f)
+    private val settings = optionsPopup.settings
+    private var chosenLanguage = settings.language
 
-    val languageTables = this.addLanguageTables(optionsPopup.tabs.prefWidth * 0.9f - 10f)
-
-    var chosenLanguage = settings.language
-    fun selectLanguage() {
+    private fun selectLanguage() {
         settings.language = chosenLanguage
         settings.updateLocaleFromLanguage()
         UncivGame.Current.translations.tryReadTranslationForCurrentLanguage()
         onLanguageSelected()
     }
 
-    fun updateSelection() {
+    private fun updateSelection() {
         languageTables.forEach { it.update(chosenLanguage) }
         if (chosenLanguage != settings.language)
             selectLanguage()
     }
-    updateSelection()
 
-    languageTables.forEach {
-        it.onClick {
-            chosenLanguage = it.language
-            updateSelection()
+    init {
+        for (langTable in languageTables) {
+            langTable.onClick {
+                chosenLanguage = langTable.language
+                updateSelection()
+            }
         }
+        addLanguageKeyShortcuts(languageTables, getSelection = { chosenLanguage }) {
+            chosenLanguage = it
+            val pager = this.getAscendant<TabbedPager>()
+                ?: return@addLanguageKeyShortcuts
+            activated(pager.activePage, "", pager)
+        }
+    }
+
+    override fun activated(index: Int, caption: String, pager: TabbedPager) {
+        updateSelection()
+        val selectedTable = languageTables.firstOrNull { it.language == chosenLanguage }
+            ?: return
+        pager.pageScrollTo(selectedTable, true)
     }
 }

--- a/core/src/com/unciv/ui/popups/options/OptionsPopup.kt
+++ b/core/src/com/unciv/ui/popups/options/OptionsPopup.kt
@@ -90,7 +90,7 @@ class OptionsPopup(
         )
         tabs.addPage(
             "Language",
-            languageTab(this, ::reloadWorldAndOptions),
+            LanguageTab(this, ::reloadWorldAndOptions),
             ImageGetter.getImage("FlagIcons/${settings.language}"), 24f
         )
         tabs.addPage(

--- a/core/src/com/unciv/ui/screens/LanguagePickerScreen.kt
+++ b/core/src/com/unciv/ui/screens/LanguagePickerScreen.kt
@@ -2,20 +2,22 @@ package com.unciv.ui.screens
 
 import com.unciv.Constants
 import com.unciv.models.translations.tr
-import com.unciv.ui.popups.options.OptionsPopup
-import com.unciv.ui.screens.pickerscreens.PickerScreen
-import com.unciv.ui.components.widgets.LanguageTable
-import com.unciv.ui.components.widgets.LanguageTable.Companion.addLanguageTables
 import com.unciv.ui.components.extensions.enable
+import com.unciv.ui.components.extensions.scrollTo
 import com.unciv.ui.components.input.onClick
+import com.unciv.ui.components.widgets.LanguageTable
+import com.unciv.ui.components.widgets.LanguageTable.Companion.addLanguageKeyShortcuts
+import com.unciv.ui.components.widgets.LanguageTable.Companion.addLanguageTables
+import com.unciv.ui.popups.options.OptionsPopup
 import com.unciv.ui.screens.mainmenuscreen.MainMenuScreen
+import com.unciv.ui.screens.pickerscreens.PickerScreen
 
 /** A [PickerScreen] to select a language, used once on the initial run after a fresh install.
  *  After that, [OptionsPopup] provides the functionality.
  *  Reusable code is in [LanguageTable] and [addLanguageTables].
  */
 class LanguagePickerScreen : PickerScreen() {
-    var chosenLanguage = Constants.english
+    private var chosenLanguage = Constants.english
 
     private val languageTables: ArrayList<LanguageTable>
 
@@ -28,12 +30,17 @@ class LanguagePickerScreen : PickerScreen() {
 
         languageTables = topTable.addLanguageTables(stage.width - 60f)
 
-        languageTables.forEach {
-            it.onClick {
-                chosenLanguage = it.language
-                rightSideButton.enable()
-                update()
+        for (languageTable in languageTables) {
+            languageTable.onClick {
+                onChoice(languageTable.language)
             }
+        }
+
+        topTable.addLanguageKeyShortcuts(languageTables, { chosenLanguage }) { language ->
+            onChoice(language)
+            val selectedTable = languageTables.firstOrNull { it.language == language }
+                ?: return@addLanguageKeyShortcuts
+            scrollPane.scrollTo(selectedTable, true)
         }
 
         rightSideButton.setText("Pick language".tr())
@@ -42,7 +49,13 @@ class LanguagePickerScreen : PickerScreen() {
         }
     }
 
-    fun pickLanguage() {
+    private fun onChoice(choice: String) {
+        chosenLanguage = choice
+        rightSideButton.enable()
+        update()
+    }
+
+    private fun pickLanguage() {
         game.settings.language = chosenLanguage
         game.settings.updateLocaleFromLanguage()
         game.settings.isFreshlyCreated = false     // mark so the picker isn't called next launch


### PR DESCRIPTION
Idea:
- Tweak Language Pickers to scroll the selected one into view when appropriate
- Allow selection with letter keys, by english name's first letter, round-robin, so e.g. 'R' cycles Russian and Romanian...

... 90% success, but:
* Thanks to reloadWorldAndOptions, the round-robin on the Options page is limited to the first two
* Scroll-to-view on the one-time LanguagePicker compromises: Too lazy to search why the Layout of LanguagePickerScreen has the individual LanguageTable's local coordinate system mismatch that of the ScrollPane - centering made sure visibility is achieved anyway, if a little north of the center
* Far more code than I imagined
