### PR TITLE
Comment unique

### DIFF
--- a/android/assets/jsons/translations/Afrikaans.properties
+++ b/android/assets/jsons/translations/Afrikaans.properties
@@ -4005,6 +4005,7 @@ upon discovering a [tileFilter] tile =
 Hidden after generating a Great Prophet = 
  # Requires translation!
 hidden from users = 
+Comment [comment] = [comment]
  # Requires translation!
 Mod is incompatible with [modFilter] = 
  # Requires translation!

--- a/android/assets/jsons/translations/Belarusian.properties
+++ b/android/assets/jsons/translations/Belarusian.properties
@@ -4231,6 +4231,7 @@ upon discovering a [tileFilter] tile =
 Hidden after generating a Great Prophet = 
  # Requires translation!
 hidden from users = 
+Comment [comment] = [comment]
  # Requires translation!
 Mod is incompatible with [modFilter] = 
  # Requires translation!

--- a/android/assets/jsons/translations/Bosnian.properties
+++ b/android/assets/jsons/translations/Bosnian.properties
@@ -4158,6 +4158,7 @@ upon discovering a [tileFilter] tile =
 Hidden after generating a Great Prophet = 
  # Requires translation!
 hidden from users = 
+Comment [comment] = [comment]
  # Requires translation!
 Mod is incompatible with [modFilter] = 
  # Requires translation!
@@ -11737,4 +11738,3 @@ If you opened the Civilopedia from the main menu, the "Ruleset" will be that of 
 Letters can select categories, and when there are multiple categories matching the same letter, you can press that repeatedly to cycle between these. = 
  # Requires translation!
 The arrow keys allow navigation as well - left/right for categories, up/down for entries. = 
-

--- a/android/assets/jsons/translations/Brazilian_Portuguese.properties
+++ b/android/assets/jsons/translations/Brazilian_Portuguese.properties
@@ -2328,6 +2328,7 @@ upon ending a turn in a [tileFilter] tile = ao terminar um turno em um painel [t
 upon discovering a [tileFilter] tile = ao descobrir um painel [tileFilter]
 Hidden after generating a Great Prophet = Escondido depois de gerar um Grande Profeta
 hidden from users = escondido dos usuários
+Comment [comment] = [comment]
 Mod is incompatible with [modFilter] = O mod é incompatível com [modFilter]
 Should only be used as permanent audiovisual mod = Deve ser usado apenas como mod audiovisual permanente
 Can be used as permanent audiovisual mod = Pode ser usado como mod audiovisual permanente

--- a/android/assets/jsons/translations/Bulgarian.properties
+++ b/android/assets/jsons/translations/Bulgarian.properties
@@ -3243,6 +3243,7 @@ upon discovering a [tileFilter] tile =
 Hidden after generating a Great Prophet = 
  # Requires translation!
 hidden from users = 
+Comment [comment] = [comment]
  # Requires translation!
 Mod is incompatible with [modFilter] = 
  # Requires translation!

--- a/android/assets/jsons/translations/Catalan.properties
+++ b/android/assets/jsons/translations/Catalan.properties
@@ -2337,6 +2337,7 @@ upon ending a turn in a [tileFilter] tile = quan acaba el torn en una casella de
 upon discovering a [tileFilter] tile = 
 Hidden after generating a Great Prophet = Amagat després de generar un gran profeta.
 hidden from users = amagat als usuaris
+Comment [comment] = [comment]
 Mod is incompatible with [modFilter] = El mod no és compatible amb [modFilter]
 Should only be used as permanent audiovisual mod = Només es pot fer servir com a mod audiovisual permanent
 Can be used as permanent audiovisual mod = Es pot fer servir com a mod audiovisual permanent
@@ -6611,4 +6612,3 @@ However, it will reflect the mods you are playing! The combination of base rules
 If you opened the Civilopedia from the main menu, the "Ruleset" will be that of the last game you started. = Si obriu la civilopèdia des del menú principal, la informació que es mostrarà serà la del reglament de l’última partida que heu iniciat.
 Letters can select categories, and when there are multiple categories matching the same letter, you can press that repeatedly to cycle between these. = Les lletres permeten triar categories i, quan hi ha diferents categories que es corresponen amb la mateixa lletra, podeu prémer diverses vegades la tecla per a moure-vos-hi de manera cíclica.
 The arrow keys allow navigation as well - left/right for categories, up/down for entries. = Les tecles de cursor també permeten la navegació: esquerra/dreta per a categories i amunt/avall per a desplaçar-se per les diferents entrades.
-

--- a/android/assets/jsons/translations/Czech.properties
+++ b/android/assets/jsons/translations/Czech.properties
@@ -2709,6 +2709,7 @@ upon discovering a [tileFilter] tile =
 Hidden after generating a Great Prophet = Skrytý po příchodu Velkého proroka
  # Requires translation!
 hidden from users = 
+Comment [comment] = [comment]
  # Requires translation!
 Mod is incompatible with [modFilter] = 
  # Requires translation!

--- a/android/assets/jsons/translations/Dutch.properties
+++ b/android/assets/jsons/translations/Dutch.properties
@@ -2337,6 +2337,7 @@ upon ending a turn in a [tileFilter] tile = na het beindigen van een beurt in ee
 upon discovering a [tileFilter] tile = 
 Hidden after generating a Great Prophet = Verborgen na het genereren van een Grote Profeet
 hidden from users = Verborgen voor gebruikers
+Comment [comment] = [comment]
 Mod is incompatible with [modFilter] = Mod is niet compatibel met [modFilter]
 Should only be used as permanent audiovisual mod = Wordt best enkel gebruikt als een permanente audiovisuele mod
 Can be used as permanent audiovisual mod = Kan gebruikt worden als een permanente audiovisuele mod
@@ -6611,4 +6612,3 @@ However, it will reflect the mods you are playing! The combination of base rules
 If you opened the Civilopedia from the main menu, the "Ruleset" will be that of the last game you started. = Als je de Civilopedia geopend hebt vanop het hoofdmenu zal de 'Regelset' die zijn van het laatste spel dat je begonnen bent.
 Letters can select categories, and when there are multiple categories matching the same letter, you can press that repeatedly to cycle between these. = Letters kunnen categorieën selecteren, en als er meerdere categorieën zijn die overeenkomen met dezelfde letter, kan je daar herhaaldelijk op drukken om tussen deze categorieën te wisselen.
 The arrow keys allow navigation as well - left/right for categories, up/down for entries. = Je kan ook navigeren met de pijltjes, links/rechts voor Categorieën, omhoog/omlaag voor trefwoorden.
-

--- a/android/assets/jsons/translations/English.properties
+++ b/android/assets/jsons/translations/English.properties
@@ -4354,6 +4354,7 @@ upon discovering a [tileFilter] tile =
 Hidden after generating a Great Prophet = 
  # Requires translation!
 hidden from users = 
+Comment [comment] = [comment]
  # Requires translation!
 Mod is incompatible with [modFilter] = 
  # Requires translation!

--- a/android/assets/jsons/translations/Filipino.properties
+++ b/android/assets/jsons/translations/Filipino.properties
@@ -2485,6 +2485,7 @@ upon discovering a [tileFilter] tile =
 Hidden after generating a Great Prophet = Nakatago pagkatapos magpakita ang isang Dakilang Propeta
  # Requires translation!
 hidden from users = 
+Comment [comment] = [comment]
  # Requires translation!
 Mod is incompatible with [modFilter] = 
  # Requires translation!

--- a/android/assets/jsons/translations/Finnish.properties
+++ b/android/assets/jsons/translations/Finnish.properties
@@ -3514,6 +3514,7 @@ upon discovering a [tileFilter] tile =
 Hidden after generating a Great Prophet = 
  # Requires translation!
 hidden from users = 
+Comment [comment] = [comment]
  # Requires translation!
 Mod is incompatible with [modFilter] = 
  # Requires translation!

--- a/android/assets/jsons/translations/French.properties
+++ b/android/assets/jsons/translations/French.properties
@@ -2328,6 +2328,7 @@ upon ending a turn in a [tileFilter] tile = en terminant un tour sur une case [t
 upon discovering a [tileFilter] tile = en découvrant une case [tileFilter]
 Hidden after generating a Great Prophet = Caché après avoir généré un Grand Prophète
 hidden from users = Caché aux joueurs
+Comment [comment] = [comment]
 Mod is incompatible with [modFilter] = Le mod est incompatible avec [modFilter]
 Should only be used as permanent audiovisual mod = Devrait être activé uniquement comme mod audiovisuel permanent
 Can be used as permanent audiovisual mod = Peut être activé comme mod audiovisuel permanent

--- a/android/assets/jsons/translations/German.properties
+++ b/android/assets/jsons/translations/German.properties
@@ -2337,6 +2337,7 @@ upon ending a turn in a [tileFilter] tile = bei Beendigung einer Runde auf einem
 upon discovering a [tileFilter] tile = 
 Hidden after generating a Great Prophet = Versteckt, nachdem ein Großer Prophet erzeugt wurde
 hidden from users = vor dem Benutzer versteckt
+Comment [comment] = [comment]
 Mod is incompatible with [modFilter] = Mod ist nicht kompatibel mit [modFilter]
 Should only be used as permanent audiovisual mod = Sollte nur als permanente audiovisuelle Mod verwendet werden
 Can be used as permanent audiovisual mod = Kann als permanente audiovisuelle Mod verwendet werden

--- a/android/assets/jsons/translations/Greek.properties
+++ b/android/assets/jsons/translations/Greek.properties
@@ -3966,6 +3966,7 @@ upon discovering a [tileFilter] tile =
 Hidden after generating a Great Prophet = 
  # Requires translation!
 hidden from users = 
+Comment [comment] = [comment]
  # Requires translation!
 Mod is incompatible with [modFilter] = 
  # Requires translation!

--- a/android/assets/jsons/translations/Hungarian.properties
+++ b/android/assets/jsons/translations/Hungarian.properties
@@ -2393,6 +2393,7 @@ upon discovering a [tileFilter] tile =
 Hidden after generating a Great Prophet = Híres próféta születése után nem lesz látható
  # Requires translation!
 hidden from users = 
+Comment [comment] = [comment]
  # Requires translation!
 Mod is incompatible with [modFilter] = 
  # Requires translation!

--- a/android/assets/jsons/translations/Indonesian.properties
+++ b/android/assets/jsons/translations/Indonesian.properties
@@ -2338,6 +2338,7 @@ upon discovering a [tileFilter] tile =
 Hidden after generating a Great Prophet = Tersembunyi setelah mendapatkan Nabi
  # Requires translation!
 hidden from users = 
+Comment [comment] = [comment]
 Mod is incompatible with [modFilter] = Mod tidak kompatibel dengan [modFilter]
 Should only be used as permanent audiovisual mod = Hanya boleh digunakan sebagai mod audiovisual permanen
 Can be used as permanent audiovisual mod = Bisa digunakan sebagai mod audiovisual permanen

--- a/android/assets/jsons/translations/Italian.properties
+++ b/android/assets/jsons/translations/Italian.properties
@@ -2333,6 +2333,7 @@ upon ending a turn in a [tileFilter] tile = quando finisci un turno su una casel
 upon discovering a [tileFilter] tile = 
 Hidden after generating a Great Prophet = Nascosto quando ottieni un Grande Profeta
 hidden from users = nascosto dagli utenti
+Comment [comment] = [comment]
 Mod is incompatible with [modFilter] = La mod è incompatibile con [modFilter]
 Should only be used as permanent audiovisual mod = Va usata solo come mod audiovisuale
 Can be used as permanent audiovisual mod = Usabile come mod audiovisuale permanente

--- a/android/assets/jsons/translations/Japanese.properties
+++ b/android/assets/jsons/translations/Japanese.properties
@@ -2447,6 +2447,7 @@ upon discovering a [tileFilter] tile =
 Hidden after generating a Great Prophet = 
  # Requires translation!
 hidden from users = 
+Comment [comment] = [comment]
  # Requires translation!
 Mod is incompatible with [modFilter] = 
  # Requires translation!

--- a/android/assets/jsons/translations/Korean.properties
+++ b/android/assets/jsons/translations/Korean.properties
@@ -2411,6 +2411,7 @@ upon discovering a [tileFilter] tile =
 Hidden after generating a Great Prophet = 위대한 선지자 획득 후 숨겨짐
  # Requires translation!
 hidden from users = 
+Comment [comment] = [comment]
  # Requires translation!
 Mod is incompatible with [modFilter] = 
  # Requires translation!

--- a/android/assets/jsons/translations/Lithuanian.properties
+++ b/android/assets/jsons/translations/Lithuanian.properties
@@ -2639,6 +2639,7 @@ upon discovering a [tileFilter] tile =
 Hidden after generating a Great Prophet = Slepiama po Didžiojo pranašo atėjimo
  # Requires translation!
 hidden from users = 
+Comment [comment] = [comment]
  # Requires translation!
 Mod is incompatible with [modFilter] = 
  # Requires translation!

--- a/android/assets/jsons/translations/Malay.properties
+++ b/android/assets/jsons/translations/Malay.properties
@@ -3440,6 +3440,7 @@ upon discovering a [tileFilter] tile =
 Hidden after generating a Great Prophet = 
  # Requires translation!
 hidden from users = 
+Comment [comment] = [comment]
  # Requires translation!
 Mod is incompatible with [modFilter] = 
  # Requires translation!

--- a/android/assets/jsons/translations/Persian_(Pinglish-DIN).properties
+++ b/android/assets/jsons/translations/Persian_(Pinglish-DIN).properties
@@ -3746,6 +3746,7 @@ upon discovering a [tileFilter] tile =
 Hidden after generating a Great Prophet = 
  # Requires translation!
 hidden from users = 
+Comment [comment] = [comment]
  # Requires translation!
 Mod is incompatible with [modFilter] = 
  # Requires translation!

--- a/android/assets/jsons/translations/Persian_(Pinglish-UN).properties
+++ b/android/assets/jsons/translations/Persian_(Pinglish-UN).properties
@@ -3317,6 +3317,7 @@ upon discovering a [tileFilter] tile =
 Hidden after generating a Great Prophet = 
  # Requires translation!
 hidden from users = 
+Comment [comment] = [comment]
  # Requires translation!
 Mod is incompatible with [modFilter] = 
  # Requires translation!

--- a/android/assets/jsons/translations/Polish.properties
+++ b/android/assets/jsons/translations/Polish.properties
@@ -2329,6 +2329,7 @@ upon ending a turn in a [tileFilter] tile = po zakończeniu tury na polu [tileFi
 upon discovering a [tileFilter] tile = po odkryciu pola [tileFilter]
 Hidden after generating a Great Prophet = Ukryte po wygenerowaniu Wielkiego Proroka
 hidden from users = Ukryte przed graczami 
+Comment [comment] = [comment]
 Mod is incompatible with [modFilter] = Mod jest niekompatybilny z [modFilter] 
 Should only be used as permanent audiovisual mod = Powinien być zawsze używany jako mod permanentnie widoczny
 Can be used as permanent audiovisual mod = Może być używany jako mod permanentnie widoczny

--- a/android/assets/jsons/translations/Portuguese.properties
+++ b/android/assets/jsons/translations/Portuguese.properties
@@ -2786,6 +2786,7 @@ upon discovering a [tileFilter] tile =
 Hidden after generating a Great Prophet = 
  # Requires translation!
 hidden from users = 
+Comment [comment] = [comment]
  # Requires translation!
 Mod is incompatible with [modFilter] = 
  # Requires translation!

--- a/android/assets/jsons/translations/Romanian.properties
+++ b/android/assets/jsons/translations/Romanian.properties
@@ -2700,6 +2700,7 @@ upon discovering a [tileFilter] tile =
 Hidden after generating a Great Prophet = 
  # Requires translation!
 hidden from users = 
+Comment [comment] = [comment]
 Mod is incompatible with [modFilter] = Mod-ul este incompatibil cu [modFilter]
 Should only be used as permanent audiovisual mod = Ar trebui să fie folosit doar ca mod audiovizual permanent
 Can be used as permanent audiovisual mod = Poate fi folosit ca mod audiovizual permanent

--- a/android/assets/jsons/translations/Russian.properties
+++ b/android/assets/jsons/translations/Russian.properties
@@ -2341,6 +2341,7 @@ upon discovering a [tileFilter] tile =
 Hidden after generating a Great Prophet = Скрыто после появления Великого пророка
  # Requires translation!
 hidden from users = 
+Comment [comment] = [comment]
 Mod is incompatible with [modFilter] = Мод несовместим с [modFilter]
 Should only be used as permanent audiovisual mod = Следует использовать только в качестве постоянного аудиовизуального мода
 Can be used as permanent audiovisual mod = Может быть использован как постоянный аудиовизуальный мод

--- a/android/assets/jsons/translations/Rusyn.properties
+++ b/android/assets/jsons/translations/Rusyn.properties
@@ -3651,6 +3651,7 @@ upon discovering a [tileFilter] tile =
 Hidden after generating a Great Prophet = 
  # Requires translation!
 hidden from users = 
+Comment [comment] = [comment]
  # Requires translation!
 Mod is incompatible with [modFilter] = 
  # Requires translation!
@@ -8350,4 +8351,3 @@ If you opened the Civilopedia from the main menu, the "Ruleset" will be that of 
 Letters can select categories, and when there are multiple categories matching the same letter, you can press that repeatedly to cycle between these. = 
  # Requires translation!
 The arrow keys allow navigation as well - left/right for categories, up/down for entries. = 
-

--- a/android/assets/jsons/translations/Simplified_Chinese.properties
+++ b/android/assets/jsons/translations/Simplified_Chinese.properties
@@ -2328,6 +2328,7 @@ upon ending a turn in a [tileFilter] tile = 在 [tileFilter] 地块上结束一�
 upon discovering a [tileFilter] tile = 当发现 [tileFilter] 后
 Hidden after generating a Great Prophet = 在产生大先知后隐藏
 hidden from users = 对用户隐藏
+Comment [comment] = [comment]
 Mod is incompatible with [modFilter] = Mod 与 [modFilter] 不兼容
 Should only be used as permanent audiovisual mod = 只能用作永久视听Mod
 Can be used as permanent audiovisual mod = 可作为永久视听Mod
@@ -6600,4 +6601,3 @@ However, it will reflect the mods you are playing! The combination of base rules
 If you opened the Civilopedia from the main menu, the "Ruleset" will be that of the last game you started. = 如果您从主页打开文明百科，那么所适用的规则集将是您在之前游戏中选择的。
 Letters can select categories, and when there are multiple categories matching the same letter, you can press that repeatedly to cycle between these. = 您可以使用字母键来选择类别。当有多个类别与同一个字母匹配时，您可以重复按下该按钮，在这些类别之间循环。
 The arrow keys allow navigation as well - left/right for categories, up/down for entries. = 方向键也可以用来在文明百科导航，左右切换类别，上下切换条目。
-

--- a/android/assets/jsons/translations/Spanish.properties
+++ b/android/assets/jsons/translations/Spanish.properties
@@ -2328,6 +2328,7 @@ upon ending a turn in a [tileFilter] tile = al terminar turno en una casilla [ti
 upon discovering a [tileFilter] tile = al descubrir una casilla de [tileFilter]
 Hidden after generating a Great Prophet = Oculto después de generar un gran profeta
 hidden from users = oculto al jugador
+Comment [comment] = [comment]
 Mod is incompatible with [modFilter] = Este mod es incompatible con [modFilter]
 Should only be used as permanent audiovisual mod = Sólo debería ser usado con mod audiovisual
 Can be used as permanent audiovisual mod = Puede usarse como mod audiovisual

--- a/android/assets/jsons/translations/Swedish.properties
+++ b/android/assets/jsons/translations/Swedish.properties
@@ -2654,6 +2654,7 @@ upon discovering a [tileFilter] tile =
 Hidden after generating a Great Prophet = Gömt efter att en Stor Profet alstrats
  # Requires translation!
 hidden from users = 
+Comment [comment] = [comment]
  # Requires translation!
 Mod is incompatible with [modFilter] = 
  # Requires translation!

--- a/android/assets/jsons/translations/Traditional_Chinese.properties
+++ b/android/assets/jsons/translations/Traditional_Chinese.properties
@@ -2417,6 +2417,7 @@ upon discovering a [tileFilter] tile =
 Hidden after generating a Great Prophet = 在生成大先知後隱藏
  # Requires translation!
 hidden from users = 
+Comment [comment] = [comment]
  # Requires translation!
 Mod is incompatible with [modFilter] = 
  # Requires translation!

--- a/android/assets/jsons/translations/Turkish.properties
+++ b/android/assets/jsons/translations/Turkish.properties
@@ -2659,6 +2659,7 @@ upon discovering a [tileFilter] tile =
 Hidden after generating a Great Prophet = 
  # Requires translation!
 hidden from users = 
+Comment [comment] = [comment]
  # Requires translation!
 Mod is incompatible with [modFilter] = 
  # Requires translation!

--- a/android/assets/jsons/translations/Ukrainian.properties
+++ b/android/assets/jsons/translations/Ukrainian.properties
@@ -2338,6 +2338,7 @@ upon discovering a [tileFilter] tile =
 Hidden after generating a Great Prophet = Приховано після появи Видатного пророка
  # Requires translation!
 hidden from users = 
+Comment [comment] = [comment]
 Mod is incompatible with [modFilter] = Мод несумісний із [modFilter]
 Should only be used as permanent audiovisual mod = Має бути використано тільки як постійний аудіо-візуальний мод
 Can be used as permanent audiovisual mod = Може бути використано як постійний аудіо-візуальний мод

--- a/android/assets/jsons/translations/Vietnamese.properties
+++ b/android/assets/jsons/translations/Vietnamese.properties
@@ -2634,6 +2634,7 @@ upon discovering a [tileFilter] tile =
 Hidden after generating a Great Prophet = Ẩn sau khi tạo ra một nhà tiên tri vĩ đại
  # Requires translation!
 hidden from users = 
+Comment [comment] = [comment]
  # Requires translation!
 Mod is incompatible with [modFilter] = 
  # Requires translation!

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTarget.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTarget.kt
@@ -77,4 +77,12 @@ enum class UniqueTarget(
         if (inheritsFrom != null) return inheritsFrom.canAcceptUniqueTarget(uniqueTarget)
         return false
     }
+    companion object {
+        /** All targets that can display their Uniques */
+        // As Array so it can used in a vararg parameter list.
+        val Displayable = arrayOf(
+            Building, Unit, UnitType, Improvement, Tech,
+            Terrain, Resource, Policy, Promotion, Nation, Ruins, Speed
+        )
+    }
 }

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -9,7 +9,12 @@ import com.unciv.models.translations.getPlaceholderText
 // I didn't put this in a companion object because APPARENTLY doing that means you can't use it in the init function.
 private val numberRegex = Regex("\\d+$") // Any number of trailing digits
 
-enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags: List<UniqueFlag> = emptyList()) {
+enum class UniqueType(
+    val text: String,
+    vararg targets: UniqueTarget,
+    val flags: List<UniqueFlag> = emptyList(),
+    val docDescription: String? = null
+) {
 
     //////////////////////////////////////// region 01 GLOBAL UNIQUES ////////////////////////////////////////
 
@@ -783,7 +788,8 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
     HiddenWithoutVictoryType("Hidden when [victoryType] Victory is disabled", UniqueTarget.Building, UniqueTarget.Unit, flags = UniqueFlag.setOfHiddenToUsers),
     HiddenFromCivilopedia("Will not be displayed in Civilopedia", *UniqueTarget.Displayable, flags = UniqueFlag.setOfHiddenToUsers),
     ConditionalHideUniqueFromUsers("hidden from users", UniqueTarget.Conditional),
-    Comment("Comment [comment]", *UniqueTarget.Displayable),
+    Comment("Comment [comment]", *UniqueTarget.Displayable,
+        docDescription = "Allows displaying arbitrary text in a Unique listing. Only the text within the '[]' brackets will be displayed, the rest serves to allow Ruleset validation to recognize the intent."),
 
     // Declarative Mod compatibility (so far rudimentary):
     ModIncompatibleWith("Mod is incompatible with [modFilter]", UniqueTarget.ModOptions),

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -781,11 +781,9 @@ enum class UniqueType(val text: String, vararg targets: UniqueTarget, val flags:
 
     HiddenAfterGreatProphet("Hidden after generating a Great Prophet", UniqueTarget.Ruins),
     HiddenWithoutVictoryType("Hidden when [victoryType] Victory is disabled", UniqueTarget.Building, UniqueTarget.Unit, flags = UniqueFlag.setOfHiddenToUsers),
-    HiddenFromCivilopedia("Will not be displayed in Civilopedia", UniqueTarget.Building,
-        UniqueTarget.Unit, UniqueTarget.UnitType, UniqueTarget.Improvement, UniqueTarget.Tech,
-        UniqueTarget.Terrain, UniqueTarget.Resource, UniqueTarget.Policy, UniqueTarget.Promotion,
-        UniqueTarget.Nation, UniqueTarget.Ruins, flags = UniqueFlag.setOfHiddenToUsers),
+    HiddenFromCivilopedia("Will not be displayed in Civilopedia", *UniqueTarget.Displayable, flags = UniqueFlag.setOfHiddenToUsers),
     ConditionalHideUniqueFromUsers("hidden from users", UniqueTarget.Conditional),
+    Comment("Comment [comment]", *UniqueTarget.Displayable),
 
     // Declarative Mod compatibility (so far rudimentary):
     ModIncompatibleWith("Mod is incompatible with [modFilter]", UniqueTarget.ModOptions),

--- a/desktop/src/com/unciv/app/desktop/UniqueDocsWriter.kt
+++ b/desktop/src/com/unciv/app/desktop/UniqueDocsWriter.kt
@@ -73,6 +73,8 @@ class UniqueDocsWriter {
                     "&lt;${uniqueType.text}&gt;"
                 else uniqueType.text
                 lines += "??? example  \"$uniqueText\"" // collapsable material mkdocs block, see https://squidfunk.github.io/mkdocs-material/reference/admonitions/?h=%3F%3F%3F#collapsible-blocks
+                if (uniqueType.docDescription != null)
+                    lines += "\t${uniqueType.docDescription}"
                 if (uniqueType.parameterTypeMap.isNotEmpty()) {
                     // This one will give examples for _each_ filter in a "tileFilter/specialist/buildingFilter" kind of parameter e.g. "Farm/Merchant/Library":
                     // `val paramExamples = uniqueType.parameterTypeMap.map { it.joinToString("/") { pt -> pt.docExample } }.toTypedArray()`

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -918,7 +918,12 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 	Applicable to: Nation, Terrain, Improvement, Resource
 
 ??? example  "Will not be displayed in Civilopedia"
-	Applicable to: Nation, Tech, Policy, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins
+	Applicable to: Nation, Tech, Policy, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed
+
+??? example  "Comment [comment]"
+	Example: "Comment [comment]"
+
+	Applicable to: Nation, Tech, Policy, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed
 
 ## Era uniques
 ??? example  "Starting in this era disables religion"
@@ -1754,6 +1759,11 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 	Applicable to: CityState
 
 ## ModOptions uniques
+??? example  "Suppress Warning [validationWarning]"
+	Example: "Suppress Warning [not found in unique types]"
+
+	Applicable to: ModOptions
+
 ??? example  "Mod is incompatible with [modFilter]"
 	Example: "Mod is incompatible with [DeCiv Redux]"
 
@@ -2202,4 +2212,5 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 *[stockpiledResource]: The name of any stockpiled.
 *[tech]: The name of any tech.
 *[tileFilter]: Anything that can be used either in an improvementFilter or in a terrainFilter can be used here, plus 'unimproved'
+*[validationWarning]: Suppresses one specific Ruleset validation warning.
 *[victoryType]: The name of any victory type: 'Neutral', 'Cultural', 'Diplomatic', 'Domination', 'Scientific', 'Time'

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -921,6 +921,7 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 	Applicable to: Nation, Tech, Policy, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed
 
 ??? example  "Comment [comment]"
+	Allows displaying arbitrary text in a Unique listing. Only the text within the '[]' brackets will be displayed, the rest serves to allow Ruleset validation to recognize the intent.
 	Example: "Comment [comment]"
 
 	Applicable to: Nation, Tech, Policy, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed
@@ -1759,11 +1760,6 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 	Applicable to: CityState
 
 ## ModOptions uniques
-??? example  "Suppress Warning [validationWarning]"
-	Example: "Suppress Warning [not found in unique types]"
-
-	Applicable to: ModOptions
-
 ??? example  "Mod is incompatible with [modFilter]"
 	Example: "Mod is incompatible with [DeCiv Redux]"
 
@@ -2212,5 +2208,4 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 *[stockpiledResource]: The name of any stockpiled.
 *[tech]: The name of any tech.
 *[tileFilter]: Anything that can be used either in an improvementFilter or in a terrainFilter can be used here, plus 'unimproved'
-*[validationWarning]: Suppresses one specific Ruleset validation warning.
 *[victoryType]: The name of any victory type: 'Neutral', 'Cultural', 'Diplomatic', 'Domination', 'Scientific', 'Time'


### PR DESCRIPTION
Sic... Allows non-filtering pass-through text in `uniques` - as long as it doesn't break the brackets parser.
Since pass-through is the entire point, No need to bother translators with that line, all included.

Adds extra documentation capability to inject comments into uniques.md - which, being entirely generated, could do with hints of this kind in other Uniques, too. I'm not sure the format agrees with that preprocessor you're using, untested!