### PR TITLE
Fix founding cities removing city center tile improvement

### DIFF
--- a/core/src/com/unciv/logic/city/managers/CityFounder.kt
+++ b/core/src/com/unciv/logic/city/managers/CityFounder.kt
@@ -14,8 +14,6 @@ import com.unciv.models.ruleset.unique.UniqueType
 
 class CityFounder {
     fun foundCity(civInfo: Civilization, cityLocation: Vector2): City {
-        if (civInfo.gameInfo.ruleset.tileImprovements.containsKey(Constants.cityCenter))
-            civInfo.gameInfo.tileMap[cityLocation].changeImprovement(Constants.cityCenter)
         val city = City()
 
         city.foundingCiv = civInfo.civName
@@ -56,7 +54,8 @@ class CityFounder {
         })
             tile.removeTerrainFeature(terrainFeature)
 
-        tile.removeImprovement()
+        if (civInfo.gameInfo.ruleset.tileImprovements.containsKey(Constants.cityCenter))
+            civInfo.gameInfo.tileMap[cityLocation].changeImprovement(Constants.cityCenter, civInfo)
         tile.improvementInProgress = null
 
         val ruleset = civInfo.gameInfo.ruleset

--- a/core/src/com/unciv/logic/city/managers/CityFounder.kt
+++ b/core/src/com/unciv/logic/city/managers/CityFounder.kt
@@ -55,7 +55,7 @@ class CityFounder {
             tile.removeTerrainFeature(terrainFeature)
 
         if (civInfo.gameInfo.ruleset.tileImprovements.containsKey(Constants.cityCenter))
-            civInfo.gameInfo.tileMap[cityLocation].changeImprovement(Constants.cityCenter, civInfo)
+            tile.changeImprovement(Constants.cityCenter, civInfo)
         tile.improvementInProgress = null
 
         val ruleset = civInfo.gameInfo.ruleset


### PR DESCRIPTION
Not at computer, so no tests done. Simple enough hotfix, though


Fun fact: we are assigning population 3 separate times now. Not sure that's intentional