### PR TITLE
Wrap INonPerpetualConstruction.requiredTech into function

### DIFF
--- a/core/src/com/unciv/logic/civilization/diplomacy/CityStateFunctions.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/CityStateFunctions.kt
@@ -51,7 +51,7 @@ class CityStateFunctions(val civInfo: Civilization) {
 
         // Unique unit for militaristic city-states
         if (uniqueTypes.contains(UniqueType.CityStateMilitaryUnits)) {
-            val possibleUnits = ruleset.units.values.filter { it.requiredTech != null
+            val possibleUnits = ruleset.units.values.filter { it.requiredTechs().any()
                 && ruleset.eras[ruleset.technologies[it.requiredTech!!]!!.era()]!!.eraNumber > ruleset.eras[startingEra]!!.eraNumber // Not from the start era or before
                 && it.uniqueTo != null && it.uniqueTo in unusedMajorCivs // Must be from a major civ not in the game
                 && ruleset.unitTypes[it.unitType]!!.isLandUnit() && ( it.strength > 0 || it.rangedStrength > 0 ) } // Must be a land military unit

--- a/core/src/com/unciv/models/ruleset/Building.kt
+++ b/core/src/com/unciv/models/ruleset/Building.kt
@@ -22,6 +22,7 @@ import com.unciv.ui.objectdescriptions.BuildingDescriptions
 
 class Building : RulesetStatsObject(), INonPerpetualConstruction {
 
+    @Deprecated
     override var requiredTech: String? = null
     override var cost: Int = -1
 

--- a/core/src/com/unciv/models/ruleset/Building.kt
+++ b/core/src/com/unciv/models/ruleset/Building.kt
@@ -22,7 +22,7 @@ import com.unciv.ui.objectdescriptions.BuildingDescriptions
 
 class Building : RulesetStatsObject(), INonPerpetualConstruction {
 
-    @Deprecated
+    @Deprecated("The functionality provided by the requiredTech field is provided by the OnlyAvailableWhen unique.")
     override var requiredTech: String? = null
     override var cost: Int = -1
 

--- a/core/src/com/unciv/models/ruleset/Building.kt
+++ b/core/src/com/unciv/models/ruleset/Building.kt
@@ -361,8 +361,9 @@ class Building : RulesetStatsObject(), INonPerpetualConstruction {
         if (civ.cache.uniqueBuildings.any { it.replaces == name })
             yield(RejectionReasonType.ReplacedByOurUnique.toInstance())
 
-        if (requiredTech != null && !civ.tech.isResearched(requiredTech!!))
-            yield(RejectionReasonType.RequiresTech.toInstance("$requiredTech not researched!"))
+        for (requiredTech: String in requiredTechs())
+            if (!civ.tech.isResearched(requiredTech))
+                yield(RejectionReasonType.RequiresTech.toInstance("$requiredTech not researched!"))
 
         // Regular wonders
         if (isWonder) {

--- a/core/src/com/unciv/models/ruleset/IConstruction.kt
+++ b/core/src/com/unciv/models/ruleset/IConstruction.kt
@@ -32,7 +32,7 @@ interface INonPerpetualConstruction : IConstruction, INamed, IHasUniques {
     @Deprecated("The functionality provided by the requiredTech field is provided by the OnlyAvailableWhen unique.")
     var requiredTech: String?
 
-    fun requiredTechs: Sequence<String> = if (requiredTech == null) sequenceOf() else sequenceOf(requiredTech)
+    fun requiredTechs(): Sequence<String> = if (requiredTech == null) sequenceOf() else sequenceOf(requiredTech)
 
     fun getProductionCost(civInfo: Civilization): Int
     fun getStatBuyCost(city: City, stat: Stat): Int?

--- a/core/src/com/unciv/models/ruleset/IConstruction.kt
+++ b/core/src/com/unciv/models/ruleset/IConstruction.kt
@@ -32,7 +32,7 @@ interface INonPerpetualConstruction : IConstruction, INamed, IHasUniques {
     @Deprecated("The functionality provided by the requiredTech field is provided by the OnlyAvailableWhen unique.")
     var requiredTech: String?
 
-    fun requiredTechs(): Sequence<String> = if (requiredTech == null) sequenceOf() else sequenceOf(requiredTech)
+    fun requiredTechs(): Sequence<String> = if (requiredTech == null) sequenceOf() else sequenceOf(requiredTech!!)
 
     fun getProductionCost(civInfo: Civilization): Int
     fun getStatBuyCost(city: City, stat: Stat): Int?

--- a/core/src/com/unciv/models/ruleset/IConstruction.kt
+++ b/core/src/com/unciv/models/ruleset/IConstruction.kt
@@ -29,6 +29,8 @@ interface IConstruction : INamed {
 interface INonPerpetualConstruction : IConstruction, INamed, IHasUniques {
     var cost: Int
     val hurryCostModifier: Int
+    // Future development should not increase the role of requiredTech, and should reduce it when possible.
+    // https://yairm210.github.io/Unciv/Developers/Translations%2C-mods%2C-and-modding-freedom-in-Open-Source#filters
     @Deprecated("The functionality provided by the requiredTech field is provided by the OnlyAvailableWhen unique.")
     var requiredTech: String?
 

--- a/core/src/com/unciv/models/ruleset/IConstruction.kt
+++ b/core/src/com/unciv/models/ruleset/IConstruction.kt
@@ -32,7 +32,7 @@ interface INonPerpetualConstruction : IConstruction, INamed, IHasUniques {
     @Deprecated("The functionality provided by the requiredTech field is provided by the OnlyAvailableWhen unique.")
     var requiredTech: String?
 
-    fun requiredTechs: Sequence<String> = sequenceOf(requiredTech)
+    fun requiredTechs: Sequence<String> = if (requiredTech == null) sequenceOf() else sequenceOf(requiredTech)
 
     fun getProductionCost(civInfo: Civilization): Int
     fun getStatBuyCost(city: City, stat: Stat): Int?

--- a/core/src/com/unciv/models/ruleset/IConstruction.kt
+++ b/core/src/com/unciv/models/ruleset/IConstruction.kt
@@ -29,7 +29,10 @@ interface IConstruction : INamed {
 interface INonPerpetualConstruction : IConstruction, INamed, IHasUniques {
     var cost: Int
     val hurryCostModifier: Int
+    @Deprecated
     var requiredTech: String?
+
+    fun requiredTechs: Sequence<String> = sequenceOf(requiredTech)
 
     fun getProductionCost(civInfo: Civilization): Int
     fun getStatBuyCost(city: City, stat: Stat): Int?

--- a/core/src/com/unciv/models/ruleset/IConstruction.kt
+++ b/core/src/com/unciv/models/ruleset/IConstruction.kt
@@ -29,7 +29,7 @@ interface IConstruction : INamed {
 interface INonPerpetualConstruction : IConstruction, INamed, IHasUniques {
     var cost: Int
     val hurryCostModifier: Int
-    @Deprecated
+    @Deprecated("The functionality provided by the requiredTech field is provided by the OnlyAvailableWhen unique.")
     var requiredTech: String?
 
     fun requiredTechs: Sequence<String> = sequenceOf(requiredTech)

--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -39,6 +39,7 @@ class BaseUnit : RulesetObject(), INonPerpetualConstruction {
     var unitType: String = ""
 
     val type by lazy { ruleset.unitTypes[unitType]!! }
+    @Deprecated
     override var requiredTech: String? = null
     var requiredResource: String? = null
 

--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -39,7 +39,7 @@ class BaseUnit : RulesetObject(), INonPerpetualConstruction {
     var unitType: String = ""
 
     val type by lazy { ruleset.unitTypes[unitType]!! }
-    @Deprecated
+    @Deprecated("The functionality provided by the requiredTech field is provided by the OnlyAvailableWhen unique.")
     override var requiredTech: String? = null
     var requiredResource: String? = null
 

--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -156,8 +156,9 @@ class BaseUnit : RulesetObject(), INonPerpetualConstruction {
         city: City? = null,
         additionalResources: Counter<String> = Counter.ZERO
     ): Sequence<RejectionReason> = sequence {
-        if (requiredTech != null && !civ.tech.isResearched(requiredTech!!))
-            yield(RejectionReasonType.RequiresTech.toInstance("$requiredTech not researched"))
+        for (requiredTech: String in requiredTechs())
+            if (!civ.tech.isResearched(requiredTech))
+                yield(RejectionReasonType.RequiresTech.toInstance("$requiredTech not researched"))
         if (obsoleteTech != null && civ.tech.isResearched(obsoleteTech!!))
             yield(RejectionReasonType.Obsoleted.toInstance("Obsolete by $obsoleteTech"))
 
@@ -290,7 +291,8 @@ class BaseUnit : RulesetObject(), INonPerpetualConstruction {
 
             else -> {
                 if (type.matchesFilter(filter)) return true
-                if (requiredTech != null && ruleset.technologies[requiredTech]?.matchesFilter(filter) == true) return true
+                for (requiredTech: String in requiredTechs())
+                    if (ruleset.technologies[requiredTech]?.matchesFilter(filter) == true) return true
                 if (
                 // Uniques using these kinds of filters should be deprecated and replaced with adjective-only parameters
                     filter.endsWith(" units")

--- a/core/src/com/unciv/ui/objectdescriptions/TechnologyDescriptions.kt
+++ b/core/src/com/unciv/ui/objectdescriptions/TechnologyDescriptions.kt
@@ -272,7 +272,7 @@ object TechnologyDescriptions {
      */
     // Used for Civilopedia, Alert and Picker, so if any of these decide to ignore the "Will not be displayed in Civilopedia" unique this needs refactoring
     private fun getEnabledBuildings(techName: String, ruleset: Ruleset, civInfo: Civilization?) =
-            getFilteredBuildings(ruleset, civInfo) { it.requiredTech == techName }
+            getFilteredBuildings(ruleset, civInfo) { it.requiredTechs().contains(techName) }
 
     /**
      * Returns a Sequence of [RulesetStatsObject]s obsoleted by this Technology, filtered for [civInfo]'s uniques,
@@ -334,7 +334,7 @@ object TechnologyDescriptions {
         val (nuclearWeaponsEnabled, religionEnabled) = getNukeAndReligionSwitches(civInfo)
         return ruleset.units.values.asSequence()
             .filter {
-                it.requiredTech == techName
+                it.requiredTechs().contains(techName)
                         && (it.uniqueTo == civInfo?.civName || it.uniqueTo == null && civInfo?.getEquivalentUnit(it) == it)
                         && (nuclearWeaponsEnabled || !it.isNuclearWeapon())
                         && (religionEnabled || !it.hasUnique(UniqueType.HiddenWithoutReligion))

--- a/core/src/com/unciv/ui/screens/diplomacyscreen/CityStateDiplomacyTable.kt
+++ b/core/src/com/unciv/ui/screens/diplomacyscreen/CityStateDiplomacyTable.kt
@@ -195,6 +195,7 @@ class CityStateDiplomacyTable(private val diplomacyScreen: DiplomacyScreen) {
         diplomacyTable.add(allyBonusLabel).row()
 
         if (otherCiv.cityStateUniqueUnit != null) {
+            val unitName = otherCiv.cityStateUniqueUnit
             val techNames = viewingCiv.gameInfo.ruleset.units[otherCiv.cityStateUniqueUnit]!!.requiredTechs()
             val techAndTech = techNames.joinToString(" and ")
             val isOrAre = if (techNames.count() == 1) "is" else "are"

--- a/core/src/com/unciv/ui/screens/diplomacyscreen/CityStateDiplomacyTable.kt
+++ b/core/src/com/unciv/ui/screens/diplomacyscreen/CityStateDiplomacyTable.kt
@@ -195,9 +195,10 @@ class CityStateDiplomacyTable(private val diplomacyScreen: DiplomacyScreen) {
         diplomacyTable.add(allyBonusLabel).row()
 
         if (otherCiv.cityStateUniqueUnit != null) {
-            val unitName = otherCiv.cityStateUniqueUnit
-            val techName = viewingCiv.gameInfo.ruleset.units[otherCiv.cityStateUniqueUnit]!!.requiredTech
-            diplomacyTable.add("[${otherCiv.civName}] is able to provide [${unitName}] once [${techName}] is researched.".toLabel(fontSize = Constants.defaultFontSize)).row()
+            val techNames = viewingCiv.gameInfo.ruleset.units[otherCiv.cityStateUniqueUnit]!!.requiredTechs()
+            val techAndTech = techNames.joinToString(" and ")
+            val isOrAre = if (techNames.count() == 1) "is" else "are"
+            diplomacyTable.add("[${otherCiv.civName}] is able to provide [${unitName}] once [${techAndTech}] [${isOrAre}] researched.".toLabel(fontSize = Constants.defaultFontSize)).row()
         }
 
         return diplomacyTable


### PR DESCRIPTION
This is Step Zero, not changing any functionality. The function in this branch is a stub function that doesn't pull from the Uniques.

This doesn't touch the more complicated usages yet since those should use the new era functions that this branch does not include. So this doesn't remove all references to `requiredTech`, but it does put a deprecated warning on it to discourage adding new usages.