### PR TITLE
ConditionalDisjunction

### DIFF
--- a/core/src/com/unciv/models/ruleset/unique/Unique.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Unique.kt
@@ -208,6 +208,9 @@ class Unique(val text: String, val sourceObjectType: UniqueTarget? = null, val s
             UniqueType.ConditionalTimedUnique -> true
             UniqueType.ConditionalHideUniqueFromUsers -> true  // allowed to be attached to any Unique to hide it, no-op otherwise
 
+            // Recursion is always dangerous, but this will only infinite-loop if we already have a loop in the conditionals.
+            UniqueType.ConditionalDisjunction -> condition.conditionals.any{ conditionalApplies(it, state) }
+
             UniqueType.ConditionalChance -> stateBasedRandom.nextFloat() < condition.params[0].toFloat() / 100f
             UniqueType.ConditionalBeforeTurns -> checkOnCiv { gameInfo.turns < condition.params[0].toInt() }
             UniqueType.ConditionalAfterTurns -> checkOnCiv { gameInfo.turns >= condition.params[0].toInt() }

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -601,6 +601,7 @@ enum class UniqueType(
 
 
     /////// general conditionals
+    ConditionalDisjunction("[conditional] or [conditional]", UniqueTarget.Conditional),
     ConditionalTimedUnique("for [amount] turns", UniqueTarget.Conditional),
     ConditionalChance("with [amount]% chance", UniqueTarget.Conditional),
     ConditionalBeforeTurns("before [amount] turns", UniqueTarget.Conditional),

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -601,7 +601,7 @@ enum class UniqueType(
 
 
     /////// general conditionals
-    ConditionalDisjunction("[conditional] or [conditional]", UniqueTarget.Conditional),
+    ConditionalDisjunction("Either", UniqueTarget.Conditional),
     ConditionalTimedUnique("for [amount] turns", UniqueTarget.Conditional),
     ConditionalChance("with [amount]% chance", UniqueTarget.Conditional),
     ConditionalBeforeTurns("before [amount] turns", UniqueTarget.Conditional),


### PR DESCRIPTION
This doesn't actually work, this is just to follow up on discussion. As you can see, implementing "This policy cannot be adopted unless *either* Theology is discovered *or* a religion is founded" would be quite straightforward on the back end, unless I'm missing something. The hard part is the text parsing. I don't know how to make that work.

The reason it doesn't work is because https://github.com/yairm210/Unciv/blob/master/core/src/com/unciv/models/translations/Translations.kt#L492
```
fun String.getConditionals(): List<Unique> {
    if (!this.contains('<')) return emptyList()
    return pointyBraceRegex.findAll(this).map { Unique(it.groups[1]!!.value) }.toList()
}
```
doesn't allow nesting conditionals. (Obviously, once everything is parsed into objects, the Unique objects do allow nesting conditionals.)