### PR TITLE
City sounds again

### DIFF
--- a/core/src/com/unciv/ui/audio/CityAmbiencePlayer.kt
+++ b/core/src/com/unciv/ui/audio/CityAmbiencePlayer.kt
@@ -14,7 +14,7 @@ class CityAmbiencePlayer(
         val volume = UncivGame.Current.settings.citySoundsVolume
         if (volume > 0f) {
             UncivGame.Current.musicController
-                .playOverlay(city.civ.getEra().citySound, volume = volume, isLooping = true)
+                .playOverlay(city.civ.getEra().citySound, volume = volume, isLooping = true, fadeIn = true)
         }
     }
 


### PR DESCRIPTION
Follow up to #10574 - two commits fixing little things I noticed.
- One is - I bungled my own fade-in for them with the voices branch. I had this exact code in mind then forgot.
- The other - they stop when switching cities (left/right). Not sure the extra complexity of this fix is worth the borderline case.

Note: As commented, I tried to get them to behave when you resize the window too, but failed. Went too convoluted quickly. Only clean solution would be to manage without RecreateOnResize, meaning a more or less complete rewrite of CityScreen. At least I have no better idea.