### PR TITLE
Stats per Stat unique

### DIFF
--- a/core/src/com/unciv/logic/civilization/transients/CivInfoStatsForNextTurn.kt
+++ b/core/src/com/unciv/logic/civilization/transients/CivInfoStatsForNextTurn.kt
@@ -311,6 +311,11 @@ class CivInfoStatsForNextTurn(val civInfo: Civilization) {
             if (unique.sourceObjectType != UniqueTarget.Building && unique.sourceObjectType != UniqueTarget.Wonder)
                 statMap.add(unique.sourceObjectType!!.name, unique.stats)
 
+        for (unique in civInfo.getMatchingUniques(UniqueType.StatsPerStat)) {
+            val amount = civInfo.getStatReserve(Stat.valueOf(unique.params[2])) / unique.params[1].toInt()
+            statMap.add("Stats", unique.stats.times(amount))
+        }
+
         val statsPerNaturalWonder = Stats(happiness = 1f)
 
         for (unique in civInfo.getMatchingUniques(UniqueType.StatsFromNaturalWonders))

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -28,7 +28,7 @@ enum class UniqueType(
     StatsFromSpecialist("[stats] from every specialist [cityFilter]", UniqueTarget.Global, UniqueTarget.FollowerBelief),
     StatsPerPopulation("[stats] per [amount] population [cityFilter]", UniqueTarget.Global, UniqueTarget.FollowerBelief),
     StatsPerPolicies("[stats] per [amount] social policies adopted", UniqueTarget.Global),
-    StatsPerStat("[stats] per [amount] [stat]", UniqueTarget.Global),
+    StatsPerStat("[stats] per every [amount] [civWideStat]", UniqueTarget.Global),
 
     StatsFromCitiesOnSpecificTiles("[stats] in cities on [terrainFilter] tiles", UniqueTarget.Global, UniqueTarget.FollowerBelief),
     StatsFromBuildings("[stats] from all [buildingFilter] buildings", UniqueTarget.Global, UniqueTarget.FollowerBelief),

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -28,7 +28,7 @@ enum class UniqueType(
     StatsFromSpecialist("[stats] from every specialist [cityFilter]", UniqueTarget.Global, UniqueTarget.FollowerBelief),
     StatsPerPopulation("[stats] per [amount] population [cityFilter]", UniqueTarget.Global, UniqueTarget.FollowerBelief),
     StatsPerPolicies("[stats] per [amount] social policies adopted", UniqueTarget.Global),
-
+    StatsPerStat("[stats] per [amount] [stat]", UniqueTarget.Global),
 
     StatsFromCitiesOnSpecificTiles("[stats] in cities on [terrainFilter] tiles", UniqueTarget.Global, UniqueTarget.FollowerBelief),
     StatsFromBuildings("[stats] from all [buildingFilter] buildings", UniqueTarget.Global, UniqueTarget.FollowerBelief),

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -210,6 +210,11 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 	Applicable to: Global
 
+??? example  "[stats] per every [amount] [civWideStat]"
+	Example: "[+1 Gold, +2 Production] per every [3] [Gold]"
+
+	Applicable to: Global
+
 ??? example  "[stats] in cities on [terrainFilter] tiles"
 	Example: "[+1 Gold, +2 Production] in cities on [Fresh Water] tiles"
 


### PR DESCRIPTION
Syntax:
[stats] per [amount] [stat]

Example: 
[+1 Gold] per [100] [Gold]

In that case, if player has 1000 gold, he/she gets additonal 10 gold per turn. If the number of stockpiled gold is 5000, the bonus is 50 gold per turn. If the player has less than 100 gold, there is no bonus.

Why?
This unique can be used by modders to give players the additional bonus for accumulating a large amount of specified stat. The most obvious example is the compound interest.

If you have any suggestions, please share your thoughts in comments