### PR TITLE
Add IHasUniques.era()

### DIFF
--- a/core/src/com/unciv/logic/civilization/transients/CivInfoTransientCache.kt
+++ b/core/src/com/unciv/logic/civilization/transients/CivInfoTransientCache.kt
@@ -47,8 +47,8 @@ class CivInfoTransientCache(val civInfo: Civilization) {
             val applicableBuildings = ruleset.buildings.values.filter { it.requiresResource(resource, StateForConditionals.IgnoreConditionals) && civInfo.getEquivalentBuilding(it) == it }
             val applicableUnits = ruleset.units.values.filter { it.requiresResource(resource, StateForConditionals.IgnoreConditionals) && civInfo.getEquivalentUnit(it) == it }
 
-            val lastEraForBuilding = applicableBuildings.maxOfOrNull { ruleset.eras[ruleset.technologies[it.requiredTech]?.era()]?.eraNumber ?: 0 }
-            val lastEraForUnit = applicableUnits.maxOfOrNull { ruleset.eras[ruleset.technologies[it.requiredTech]?.era()]?.eraNumber ?: 0 }
+            val lastEraForBuilding = applicableBuildings.maxOfOrNull { it.era(ruleset)?.eraNumber ?: 0 }
+            val lastEraForUnit = applicableUnits.maxOfOrNull { it.era(ruleset)?.eraNumber ?: 0 }
 
             if (lastEraForBuilding != null)
                 lastEraResourceUsedForBuilding[resource] = lastEraForBuilding

--- a/core/src/com/unciv/logic/map/mapunit/UnitUpgradeManager.kt
+++ b/core/src/com/unciv/logic/map/mapunit/UnitUpgradeManager.kt
@@ -102,7 +102,7 @@ class UnitUpgradeManager(val unit:MapUnit) {
             // do clamping and rounding here so upgrading stepwise costs the same as upgrading far down the chain
             var stepCost = constants.base
             stepCost += (constants.perProduction * (baseUnit.cost - currentUnit.cost)).coerceAtLeast(0f)
-            val era = ruleset.eras[ruleset.technologies[baseUnit.requiredTech]?.era()]
+            val era = baseUnit.era(ruleset)
             if (era != null)
                 stepCost *= (1f + era.eraNumber * constants.eraMultiplier)
             stepCost = (stepCost * civModifier).pow(constants.exponent)

--- a/core/src/com/unciv/models/ruleset/IConstruction.kt
+++ b/core/src/com/unciv/models/ruleset/IConstruction.kt
@@ -34,7 +34,7 @@ interface INonPerpetualConstruction : IConstruction, INamed, IHasUniques {
     @Deprecated("The functionality provided by the requiredTech field is provided by the OnlyAvailableWhen unique.")
     var requiredTech: String?
 
-    fun requiredTechs(): Sequence<String> = if (requiredTech == null) sequenceOf() else sequenceOf(requiredTech!!)
+    override fun legacyRequiredTechs(): Sequence<String> = if (requiredTech == null) sequenceOf() else sequenceOf(requiredTech!!)
 
     fun getProductionCost(civInfo: Civilization): Int
     fun getStatBuyCost(city: City, stat: Stat): Int?

--- a/core/src/com/unciv/models/ruleset/unique/IHasUniques.kt
+++ b/core/src/com/unciv/models/ruleset/unique/IHasUniques.kt
@@ -42,4 +42,11 @@ interface IHasUniques : INamed {
 
     fun hasUnique(uniqueType: UniqueType, stateForConditionals: StateForConditionals? = null) =
         getMatchingUniques(uniqueType.placeholderText, stateForConditionals).any()
+
+    fun requiredTechs(): Sequence<String> {
+        val uniquesForWhenThisIsAvailable: Sequence<Unique> = getMatchingUniques(UniqueType.OnlyAvailableWhen, StateForConditionals.IgnoreConditionals)
+        val conditionalsForWhenThisIsAvailable: Sequence<Unique> = uniquesForWhenThisIsAvailable.flatMap{ it.conditionals }
+        val techRequiringConditionalsForWhenThisIsAvailable: Sequence<Unique> = conditionalsForWhenThisIsAvailable.filter{ it.isOfType(UniqueType.ConditionalTech) }
+        return techRequiringConditionalsForWhenThisIsAvailable.map{ it.params[0] }
+    }
 }

--- a/core/src/com/unciv/models/ruleset/unique/IHasUniques.kt
+++ b/core/src/com/unciv/models/ruleset/unique/IHasUniques.kt
@@ -43,10 +43,14 @@ interface IHasUniques : INamed {
     fun hasUnique(uniqueType: UniqueType, stateForConditionals: StateForConditionals? = null) =
         getMatchingUniques(uniqueType.placeholderText, stateForConditionals).any()
 
-    fun requiredTechs(): Sequence<String> {
+    fun techsRequiredByUniques(): Sequence<String> {
         val uniquesForWhenThisIsAvailable: Sequence<Unique> = getMatchingUniques(UniqueType.OnlyAvailableWhen, StateForConditionals.IgnoreConditionals)
         val conditionalsForWhenThisIsAvailable: Sequence<Unique> = uniquesForWhenThisIsAvailable.flatMap{ it.conditionals }
         val techRequiringConditionalsForWhenThisIsAvailable: Sequence<Unique> = conditionalsForWhenThisIsAvailable.filter{ it.isOfType(UniqueType.ConditionalTech) }
         return techRequiringConditionalsForWhenThisIsAvailable.map{ it.params[0] }
     }
+
+    fun legacyRequiredTechs(): Sequence<String> = sequenceOf()
+
+    fun requiredTechs(): Sequence<String> = legacyRequiredTechs() + techsRequiredByUniques()
 }

--- a/core/src/com/unciv/models/ruleset/unique/IHasUniques.kt
+++ b/core/src/com/unciv/models/ruleset/unique/IHasUniques.kt
@@ -1,5 +1,8 @@
 package com.unciv.models.ruleset.unique
 
+import com.unciv.models.ruleset.Ruleset
+import com.unciv.models.ruleset.tech.Era
+import com.unciv.models.ruleset.tech.Technology
 import com.unciv.models.stats.INamed
 
 /**

--- a/core/src/com/unciv/models/ruleset/unique/IHasUniques.kt
+++ b/core/src/com/unciv/models/ruleset/unique/IHasUniques.kt
@@ -53,4 +53,11 @@ interface IHasUniques : INamed {
     fun legacyRequiredTechs(): Sequence<String> = sequenceOf()
 
     fun requiredTechs(): Sequence<String> = legacyRequiredTechs() + techsRequiredByUniques()
+
+    fun requiredTechnologies(ruleset: Ruleset): Sequence<Technology> =
+        requiredTechs().map{ ruleset.technologies[it]!! }
+
+    fun era(ruleset: Ruleset): Era? =
+            requiredTechnologies(ruleset).map{ it.era() }.map{ ruleset.eras[it]!! }.maxByOrNull{ it.eraNumber }
+            // This will return null only if requiredTechnologies() is empty.
 }

--- a/core/src/com/unciv/ui/screens/overviewscreen/WonderOverviewTab.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/WonderOverviewTab.kt
@@ -178,7 +178,7 @@ class WonderInfo {
         val wonderEraMap: Map<String, Era?> =
                 ruleSet.buildings.values.asSequence()
                     .filter { it.isWonder }
-                    .associate { it.name to ruleSet.eras[ruleSet.technologies[it.requiredTech]?.era()] }
+                    .associate { it.name to it.era(ruleSet) }
 
         // Maps all World Wonders by their position in sort order to their name
         val allWonderMap: Map<Int, String> =


### PR DESCRIPTION
Don't look at this before https://github.com/yairm210/Unciv/pull/10587 is resolved!

This branch is branched off of https://github.com/yairm210/Unciv/pull/10587. This will be much harder to read with https://github.com/yairm210/Unciv/pull/10587's changes intermixed. After https://github.com/yairm210/Unciv/pull/10587 is merged, this should be much more readable. (I won't be able to make pull requests during the week, so I thought I'd jump ahead a step and put this in the queue before https://github.com/yairm210/Unciv/pull/10587 is resolved.)

This just adds the convenience function `era()` and replaces all references to `ruleset.eras[ruleset.technologies[it.requiredTech]?.era()` with calls to `era()`.