### PR TITLE
Fix uniques being affected by city relevant uniques after a unit is already built

### DIFF
--- a/core/src/com/unciv/models/ruleset/unique/Unique.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Unique.kt
@@ -171,7 +171,7 @@ class Unique(val text: String, val sourceObjectType: UniqueTarget? = null, val s
 
         /** Helper to simplify conditional tests requiring a City */
         fun checkOnCity(predicate: (City.() -> Boolean)): Boolean {
-            if (state.city == null) return false
+            if (state.city == null) return true
             return state.city.predicate()
         }
 


### PR DESCRIPTION
Closes #10603
Couple reasonings here:
1. For non air units, city relevant uniques don't make a whole lot of sense. Even if a unit is garrisoned, it's rare that it's reasonable that a unit is expected to be affected by city based uniques. Also, for non air garrisoned uniques, it make have inconsistent results just moving a unit away from the city that is unexpected
2. Changing checkOnCiv to be similar is mostly unnecessary. It's rare for a unique to not pass in a civ intentionally, and this lets us find bugs more easily. Changing checkOnCiv also would be inconsistent with the many conditionals that use the Civ to find the ruleset