### PR TITLE
RFC: Direction for converting unit actions to map

### DIFF
--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActions.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActions.kt
@@ -31,28 +31,29 @@ object UnitActions {
         return true
     }
 
-    private val actionTypeToFunctions = linkedMapOf<UnitActionType, (unit:MapUnit, tile:Tile) -> ArrayList<UnitAction>>(
-        UnitActionType.Transform to UnitActionsFromUniques::getTransformActions
+    private val actionTypeToFunctions = linkedMapOf<UnitActionType, (unit:MapUnit, tile:Tile) -> Iterable<UnitAction>>(
+        // Determined by unit uniques
+        UnitActionType.Transform to UnitActionsFromUniques::getTransformActions,
+        UnitActionType.Paradrop to UnitActionsFromUniques::getParadropActions,
+        UnitActionType.AirSweep to UnitActionsFromUniques::getAirSweepActions,
+        UnitActionType.SetUp to UnitActionsFromUniques::getSetupActions,
+        UnitActionType.FoundCity to UnitActionsFromUniques::getFoundCityActions,
+        UnitActionType.ConstructImprovement to UnitActionsFromUniques::getBuildingImprovementsActions,
+        UnitActionType.Repair to UnitActionsFromUniques::getRepairActions
     )
 
     private fun getNormalActions(unit: MapUnit): List<UnitAction> {
         val tile = unit.getTile()
         val actionList = ArrayList<UnitAction>()
 
-        // Determined by unit uniques
         for (getActionsFunction in actionTypeToFunctions.values)
-            actionList += getActionsFunction(unit, tile)
+            actionList.addAll(getActionsFunction(unit, tile))
 
-        UnitActionsFromUniques.addParadropAction(unit, actionList)
-        UnitActionsFromUniques.addAirSweepAction(unit, actionList)
-        UnitActionsFromUniques.addSetupAction(unit, actionList)
-        UnitActionsFromUniques.addFoundCityAction(unit, actionList, tile)
-        UnitActionsFromUniques.addBuildingImprovementsAction(unit, actionList, tile)
-        UnitActionsFromUniques.addRepairAction(unit, actionList)
-        UnitActionsFromUniques.addCreateWaterImprovements(unit, actionList)
+        // Determined by unit uniques
         UnitActionsGreatPerson.addGreatPersonActions(unit, actionList, tile)
         UnitActionsReligion.addFoundReligionAction(unit, actionList)
         UnitActionsReligion.addEnhanceReligionAction(unit, actionList)
+        UnitActionsFromUniques.addCreateWaterImprovements(unit, actionList)
         actionList += UnitActionsFromUniques.getImprovementConstructionActions(unit, tile)
         UnitActionsReligion.addSpreadReligionActions(unit, actionList)
         UnitActionsReligion.addRemoveHeresyActions(unit, actionList)

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsFromUniques.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsFromUniques.kt
@@ -46,9 +46,10 @@ object UnitActionsFromUniques {
     }
 
 
-    fun addFoundCityAction(unit: MapUnit, actionList: ArrayList<UnitAction>, tile: Tile) {
-        val getFoundCityAction = getFoundCityAction(unit, tile)
-        if (getFoundCityAction != null) actionList += getFoundCityAction
+
+    fun getFoundCityActions(unit: MapUnit, tile: Tile): List<UnitAction> {
+        val getFoundCityAction = getFoundCityAction(unit, tile) ?: return emptyList()
+        return listOf(getFoundCityAction)
     }
 
     /** Produce a [UnitAction] for founding a city.
@@ -135,39 +136,41 @@ object UnitActionsFromUniques {
         return if(brokenPromises.isEmpty()) null else brokenPromises.joinToString(", ")
     }
 
-    fun addSetupAction(unit: MapUnit, actionList: ArrayList<UnitAction>) {
-        if (!unit.hasUnique(UniqueType.MustSetUp) || unit.isEmbarked()) return
+    fun getSetupActions(unit: MapUnit, tile: Tile): List<UnitAction> {
+        if (!unit.hasUnique(UniqueType.MustSetUp) || unit.isEmbarked()) return emptyList()
         val isSetUp = unit.isSetUpForSiege()
-        actionList += UnitAction(UnitActionType.SetUp,
+        return listOf(UnitAction(UnitActionType.SetUp,
             isCurrentAction = isSetUp,
             action = {
                 unit.action = UnitActionType.SetUp.value
                 unit.useMovementPoints(1f)
             }.takeIf { unit.currentMovement > 0 && !isSetUp })
+        )
     }
 
-    fun addParadropAction(unit: MapUnit, actionList: ArrayList<UnitAction>) {
+    fun getParadropActions(unit: MapUnit, tile: Tile): List<UnitAction> {
         val paradropUniques =
             unit.getMatchingUniques(UniqueType.MayParadrop)
-        if (!paradropUniques.any() || unit.isEmbarked()) return
+        if (!paradropUniques.any() || unit.isEmbarked()) return emptyList()
         unit.cache.paradropRange = paradropUniques.maxOfOrNull { it.params[0] }!!.toInt()
-        actionList += UnitAction(UnitActionType.Paradrop,
+        return listOf(UnitAction(UnitActionType.Paradrop,
             isCurrentAction = unit.isPreparingParadrop(),
             action = {
                 if (unit.isPreparingParadrop()) unit.action = null
                 else unit.action = UnitActionType.Paradrop.value
             }.takeIf {
                 !unit.hasUnitMovedThisTurn() &&
-                        unit.currentTile.isFriendlyTerritory(unit.civ) &&
-                        !unit.isEmbarked()
+                        tile.isFriendlyTerritory(unit.civ) &&
+                        !tile.isWater
             })
+        )
     }
 
-    fun addAirSweepAction(unit: MapUnit, actionList: ArrayList<UnitAction>) {
+    fun getAirSweepActions(unit: MapUnit, tile: Tile): List<UnitAction> {
         val airsweepUniques =
             unit.getMatchingUniques(UniqueType.CanAirsweep)
-        if (!airsweepUniques.any()) return
-        actionList += UnitAction(UnitActionType.AirSweep,
+        if (!airsweepUniques.any()) return emptyList()
+        return listOf(UnitAction(UnitActionType.AirSweep,
             isCurrentAction = unit.isPreparingAirSweep(),
             action = {
                 if (unit.isPreparingAirSweep()) unit.action = null
@@ -175,7 +178,7 @@ object UnitActionsFromUniques {
             }.takeIf {
                 unit.canAttack()
             }
-        )
+        ))
     }
     fun addTriggerUniqueActions(unit: MapUnit, actionList: ArrayList<UnitAction>) {
         for (unique in unit.getUniques()) {
@@ -335,12 +338,11 @@ object UnitActionsFromUniques {
         return transformList
     }
 
-    fun addBuildingImprovementsAction(
+    fun getBuildingImprovementsActions(
         unit: MapUnit,
-        actionList: ArrayList<UnitAction>,
         tile: Tile
-    ) {
-        if (!unit.cache.hasUniqueToBuildImprovements) return
+    ): List<UnitAction> {
+        if (!unit.cache.hasUniqueToBuildImprovements) return emptyList()
 
         val couldConstruct = unit.currentMovement > 0
             && !tile.isCityCenter()
@@ -354,7 +356,7 @@ object UnitActionsFromUniques {
                 && unit.canBuildImprovement(it)
         }
 
-        actionList += UnitAction(UnitActionType.ConstructImprovement,
+        return listOf(UnitAction(UnitActionType.ConstructImprovement,
             isCurrentAction = unit.currentTile.hasImprovementInProgress(),
             action = {
                 GUI.pushScreen(ImprovementPickerScreen(tile, unit) {
@@ -362,7 +364,7 @@ object UnitActionsFromUniques {
                         GUI.getWorldScreen().switchToNextUnit()
                 })
             }.takeIf { couldConstruct }
-        )
+        ))
     }
 
     private fun getRepairTurns(unit: MapUnit): Int {
@@ -378,9 +380,9 @@ object UnitActionsFromUniques {
         return repairTurns
     }
 
-    fun addRepairAction(unit: MapUnit, actionList: ArrayList<UnitAction>) {
-        val repairAction = getRepairAction(unit)
-        if (repairAction != null) actionList.add(repairAction)
+    fun getRepairActions(unit: MapUnit, tile: Tile): List<UnitAction> {
+        val repairAction = getRepairAction(unit) ?: return emptyList()
+        return listOf(repairAction)
     }
     fun getRepairAction(unit: MapUnit) : UnitAction? {
         if (!unit.currentTile.ruleset.tileImprovements.containsKey(Constants.repair)) return null

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsFromUniques.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsFromUniques.kt
@@ -271,16 +271,9 @@ object UnitActionsFromUniques {
         return finalActions
     }
 
-    fun addTransformActions(
-        unit: MapUnit,
-        actionList: ArrayList<UnitAction>
-    ) {
-        val upgradeAction = getTransformActions(unit)
-        actionList += upgradeAction
-    }
 
-    private fun getTransformActions(
-        unit: MapUnit
+    fun getTransformActions(
+        unit: MapUnit, tile: Tile
     ): ArrayList<UnitAction> {
         val unitTile = unit.getTile()
         val civInfo = unit.civ


### PR DESCRIPTION
Problem pointed out by @SomeTroglodyte in #10628 is that to invoke a single unit action, we currently generate *all* possible unit actions just to choose one
This PR is a possible solution for this problem - we convert the list of 

```kotlin
        UnitActionsFromUniques.addParadropAction(unit, actionList)
        UnitActionsFromUniques.addAirSweepAction(unit, actionList)
        UnitActionsFromUniques.addSetupAction(unit, actionList)
```

to a dictionary of "this unit action is generated from this function", keeping in mind there may be multiple actions of a single type

This mapping can be used in both the "get all actions" function, and for single actions.

This is a better solution than the enum, because 
A. we can do this change gradually, one function at a time
B. We can decide where the generation function for each type of action goes - no massive rewrite required

After we have all actions mapped out, we can revisit and see if it makes sense to convert to an Enum - I personally don't see any advantage, but we'll see when we get there