### PR TITLE
Mention the Railroad production bonus in the Civilopedia

### DIFF
--- a/android/assets/jsons/Civ V - Gods & Kings/TileImprovements.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/TileImprovements.json
@@ -123,7 +123,10 @@
 		"techRequired": "Railroads",
 		"uniques": ["Can be built outside your borders", "Costs [2] [Gold] per turn"],
 		"shortcutKey": "R",
-        "civilopediaText": [{"text":"Reduces movement cost to ⅒ if the other tile also has a Railroad"}]
+        "civilopediaText": [
+            {"text":"Reduces movement cost to ⅒ if the other tile also has a Railroad"},
+            {"text":"Provides a +25% ⚙Production bonus to cities connected to the capital by Railroads"}
+        ]
 	},
 
 	// Removals

--- a/android/assets/jsons/Civ V - Gods & Kings/TileImprovements.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/TileImprovements.json
@@ -125,7 +125,7 @@
 		"shortcutKey": "R",
         "civilopediaText": [
             {"text":"Reduces movement cost to ⅒ if the other tile also has a Railroad"},
-            {"text":"Provides a +25% ⚙Production bonus to cities connected to the capital by Railroads"}
+            {"text":"Provides a +25% [Production] bonus to cities connected to the capital by Railroads"}
         ]
 	},
 

--- a/android/assets/jsons/Civ V - Vanilla/TileImprovements.json
+++ b/android/assets/jsons/Civ V - Vanilla/TileImprovements.json
@@ -123,7 +123,8 @@
 		"techRequired": "Railroads",
 		"uniques": ["Can be built outside your borders", "Costs [2] [Gold] per turn when in your territory"],
 		"shortcutKey": "R",
-        "civilopediaText": [{"text":"Reduces movement cost to ⅒ if the other tile also has a Railroad",
+        "civilopediaText": [
+            {"text":"Reduces movement cost to ⅒ if the other tile also has a Railroad",
             {"text":"Provides a +25% ⚙Production bonus to cities connected to the capital by Railroads"}
         ]
 	},

--- a/android/assets/jsons/Civ V - Vanilla/TileImprovements.json
+++ b/android/assets/jsons/Civ V - Vanilla/TileImprovements.json
@@ -124,7 +124,7 @@
 		"uniques": ["Can be built outside your borders", "Costs [2] [Gold] per turn when in your territory"],
 		"shortcutKey": "R",
         "civilopediaText": [
-            {"text":"Reduces movement cost to ⅒ if the other tile also has a Railroad",
+            {"text":"Reduces movement cost to ⅒ if the other tile also has a Railroad"},
             {"text":"Provides a +25% ⚙Production bonus to cities connected to the capital by Railroads"}
         ]
 	},

--- a/android/assets/jsons/Civ V - Vanilla/TileImprovements.json
+++ b/android/assets/jsons/Civ V - Vanilla/TileImprovements.json
@@ -123,7 +123,9 @@
 		"techRequired": "Railroads",
 		"uniques": ["Can be built outside your borders", "Costs [2] [Gold] per turn when in your territory"],
 		"shortcutKey": "R",
-        "civilopediaText": [{"text":"Reduces movement cost to ⅒ if the other tile also has a Railroad"}]
+        "civilopediaText": [{"text":"Reduces movement cost to ⅒ if the other tile also has a Railroad",
+            {"text":"Provides a +25% ⚙Production bonus to cities connected to the capital by Railroads"}
+        ]
 	},
 
 	// Removals

--- a/android/assets/jsons/Civ V - Vanilla/TileImprovements.json
+++ b/android/assets/jsons/Civ V - Vanilla/TileImprovements.json
@@ -125,7 +125,7 @@
 		"shortcutKey": "R",
         "civilopediaText": [
             {"text":"Reduces movement cost to ⅒ if the other tile also has a Railroad"},
-            {"text":"Provides a +25% ⚙Production bonus to cities connected to the capital by Railroads"}
+            {"text":"Provides a +25% [Production] bonus to cities connected to the capital by Railroads"}
         ]
 	},
 


### PR DESCRIPTION
For most players it is unknown that Railroads provide a production bonus to cities when connected to the capital with railroads. ![image](https://github.com/yairm210/Unciv/assets/78449553/c1746fd1-d25c-4025-8f97-6d5767ba1bcc)

Phrasing open to suggestions for grammar or wording.
