### PR TITLE
Fixed trading with city-state through notifications

### DIFF
--- a/core/src/com/unciv/logic/civilization/NotificationActions.kt
+++ b/core/src/com/unciv/logic/civilization/NotificationActions.kt
@@ -79,7 +79,7 @@ class CityAction(private val city: Vector2 = Vector2.Zero) : NotificationAction 
 /** enter diplomacy screen */
 class DiplomacyAction(
     private val otherCivName: String = "",
-    private val showTrade: Boolean = false
+    private var showTrade: Boolean = false
 ) : NotificationAction {
     override fun execute(worldScreen: WorldScreen) {
         val otherCiv = worldScreen.gameInfo.getCivilization(otherCivName)
@@ -87,6 +87,8 @@ class DiplomacyAction(
             // Because TradeTable will set up otherCiv against that one,
             // not the one we pass below, and two equal civs will crash - can't look up a DiplomacyManager.
             return
+        if (showTrade && (otherCiv.isCityState() || worldScreen.gameInfo.getCurrentPlayerCivilization().isCityState()))
+            showTrade = false
         worldScreen.game.pushScreen(DiplomacyScreen(worldScreen.selectedCiv, otherCiv, showTrade = showTrade))
     }
 }

--- a/core/src/com/unciv/logic/civilization/NotificationActions.kt
+++ b/core/src/com/unciv/logic/civilization/NotificationActions.kt
@@ -87,8 +87,10 @@ class DiplomacyAction(
             // Because TradeTable will set up otherCiv against that one,
             // not the one we pass below, and two equal civs will crash - can't look up a DiplomacyManager.
             return
+        // We should not be able to trade with city-states
         if (showTrade && (otherCiv.isCityState() || worldScreen.gameInfo.getCurrentPlayerCivilization().isCityState()))
             showTrade = false
+        
         worldScreen.game.pushScreen(DiplomacyScreen(worldScreen.selectedCiv, otherCiv, showTrade = showTrade))
     }
 }


### PR DESCRIPTION
There was a bug reported on Discord where a player found that after signing peace with a city-state and clicking on the "Peace treaty will end in 3 turns", the NotificationAction will open up a trade with the city-state.

This PR simply changes the Diplomacy action to force showTrade to be false if either the current civ or the other civ is a city-state. This allows us to blindly pass a true showTrade parameter without having to worry if the other civ is a city-state or not.