### PR TITLE
Add TechManager.isResearched(construction)

### DIFF
--- a/core/src/com/unciv/logic/civilization/diplomacy/CityStateFunctions.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/CityStateFunctions.kt
@@ -93,7 +93,7 @@ class CityStateFunctions(val civInfo: Civilization) {
         fun giftableUniqueUnit(): BaseUnit? {
             val uniqueUnit = civInfo.gameInfo.ruleset.units[civInfo.cityStateUniqueUnit]
                 ?: return null
-            if (uniqueUnit.requiredTech != null && !receivingCiv.tech.isResearched(uniqueUnit.requiredTech!!))
+            if (!receivingCiv.tech.isResearched(uniqueUnit))
                 return null
             if (uniqueUnit.obsoleteTech != null && receivingCiv.tech.isResearched(uniqueUnit.obsoleteTech!!))
                 return null

--- a/core/src/com/unciv/logic/civilization/managers/QuestManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/QuestManager.kt
@@ -720,7 +720,7 @@ class QuestManager : IsPartOfGameInfoSerialization {
                 .filter { building ->
                             // Buildable wonder
                             building.isWonder
-                            && (building.requiredTech == null || challenger.tech.isResearched(building.requiredTech!!))
+                            && challenger.tech.isResearched(building)
                             && civInfo.gameInfo.getCities().none { it.cityConstructions.isBuilt(building.name) }
                             // Can't be disabled
                             && building.name !in startingEra.startingObsoleteWonders

--- a/core/src/com/unciv/logic/civilization/managers/TechManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/TechManager.kt
@@ -153,6 +153,8 @@ class TechManager : IsPartOfGameInfoSerialization {
 
     fun isResearched(techName: String): Boolean = techsResearched.contains(techName)
 
+    fun isResearched(construction: INonPerpetualConstruction): Boolean = construction.requiredTechs().all{ requiredTech -> !isResearched(requiredTech) }
+
     fun canBeResearched(techName: String): Boolean {
         val tech = getRuleset().technologies[techName]!!
         if (tech.uniqueObjects.any { it.type == UniqueType.OnlyAvailableWhen && !it.conditionalsApply(civInfo) })

--- a/core/src/com/unciv/logic/civilization/managers/TechManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/TechManager.kt
@@ -14,6 +14,7 @@ import com.unciv.logic.civilization.PopupAlert
 import com.unciv.logic.civilization.TechAction
 import com.unciv.logic.map.MapSize
 import com.unciv.logic.map.tile.RoadStatus
+import com.unciv.models.ruleset.INonPerpetualConstruction
 import com.unciv.models.ruleset.tech.Era
 import com.unciv.models.ruleset.tech.Technology
 import com.unciv.models.ruleset.unique.UniqueMap

--- a/core/src/com/unciv/logic/civilization/managers/TechManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/TechManager.kt
@@ -153,7 +153,7 @@ class TechManager : IsPartOfGameInfoSerialization {
 
     fun isResearched(techName: String): Boolean = techsResearched.contains(techName)
 
-    fun isResearched(construction: INonPerpetualConstruction): Boolean = construction.requiredTechs().all{ requiredTech -> !isResearched(requiredTech) }
+    fun isResearched(construction: INonPerpetualConstruction): Boolean = construction.requiredTechs().all{ requiredTech -> isResearched(requiredTech) }
 
     fun canBeResearched(techName: String): Boolean {
         val tech = getRuleset().technologies[techName]!!

--- a/core/src/com/unciv/logic/map/mapunit/UnitUpgradeManager.kt
+++ b/core/src/com/unciv/logic/map/mapunit/UnitUpgradeManager.kt
@@ -33,7 +33,7 @@ class UnitUpgradeManager(val unit:MapUnit) {
         val upgradePath = getUpgradePath()
 
         fun isInvalidUpgradeDestination(baseUnit: BaseUnit): Boolean{
-            if (baseUnit.requiredTech != null && !unit.civ.tech.isResearched(baseUnit.requiredTech!!))
+            if (!unit.civ.tech.isResearched(baseUnit))
                 return true
             if (baseUnit.getMatchingUniques(UniqueType.OnlyAvailableWhen, StateForConditionals.IgnoreConditionals).any {
                         !it.conditionalsApply(StateForConditionals(unit.civ, unit = unit ))

--- a/core/src/com/unciv/models/ruleset/Victory.kt
+++ b/core/src/com/unciv/models/ruleset/Victory.kt
@@ -270,13 +270,13 @@ class Milestone(val uniqueDescription: String, private val parentVictory: Victor
         return when (type!!) {
             MilestoneType.BuiltBuilding -> {
                 val building = ruleset.buildings[params[0]]!!
-                if (building.requiredTech != null && !civInfo.tech.isResearched(building.requiredTech!!)) Victory.Focus.Science
+                if (!civInfo.tech.isResearched(building)) Victory.Focus.Science
 //                if (building.hasUnique(UniqueType.Unbuildable)) Stat.Gold // Temporary, should be replaced with whatever is required to buy
                 Victory.Focus.Production
             }
             MilestoneType.BuildingBuiltGlobally -> {
                 val building = ruleset.buildings[params[0]]!!
-                if (building.requiredTech != null && !civInfo.tech.isResearched(building.requiredTech!!)) Victory.Focus.Science
+                if (!civInfo.tech.isResearched(building)) Victory.Focus.Science
 //                if (building.hasUnique(UniqueType.Unbuildable)) Victory.Focus.Gold
                 Victory.Focus.Production
             }
@@ -287,7 +287,7 @@ class Milestone(val uniqueDescription: String, private val parentVictory: Victor
                             ruleset.buildings[it]!!
                         else ruleset.units[it]!!
                     }
-                if (constructions.any { it.requiredTech != null && !civInfo.tech.isResearched(it.requiredTech!!) } ) Victory.Focus.Science
+                if (constructions.any { !civInfo.tech.isResearched(it) } ) Victory.Focus.Science
 //                if (constructions.any { it.hasUnique(UniqueType.Unbuildable) } ) Stat.Gold
                 Victory.Focus.Production
             }


### PR DESCRIPTION
This adds a convenience function that checks whether an `INonPerpetualConstruction` is researched.

This replaces all references to e.g. `tech.isResearched(uniqueUnit.requiredTech!!)` with calls to this new function.