### PR TITLE
Clarify wording of UnitStartingPromotions

### DIFF
--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -181,6 +181,7 @@ enum class UniqueType(
 
     /// Unit Abilities
     UnitStartingExperience("New [baseUnitFilter] units start with [amount] Experience [cityFilter]", UniqueTarget.Global, UniqueTarget.FollowerBelief),
+    UnitStartingPromotions2("All newly-trained (but not automatically generated) [baseUnitFilter] units [cityFilter] receive the [promotion] promotion", UniqueTarget.Global, UniqueTarget.FollowerBelief),
     UnitStartingPromotions("All newly-trained [baseUnitFilter] units [cityFilter] receive the [promotion] promotion", UniqueTarget.Global, UniqueTarget.FollowerBelief),
     // Todo: Lowercase the 'U' of 'Units' in this unique
     CityHealingUnits("[mapUnitFilter] Units adjacent to this city heal [amount] HP per turn when healing", UniqueTarget.Global, UniqueTarget.FollowerBelief),


### PR DESCRIPTION
This just shows an example of how UnitStartingPromotions might be reworded for clarity.

Not sure about this, and deprecating the old Unique would be annoying, but this seems to keep coming up (see https://github.com/yairm210/Unciv/issues/10643).

Going by the way the wiki talks about it, this always confused people in Civ V too.