### PR TITLE
Wrap BaseUnit.obsoleteTech into function

### DIFF
--- a/core/src/com/unciv/logic/civilization/managers/TechManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/TechManager.kt
@@ -345,7 +345,7 @@ class TechManager : IsPartOfGameInfoSerialization {
             return civInfo.getEquivalentUnit(upgradesTo!!)
         }
         val obsoleteUnits = getRuleset().units.asSequence()
-            .filter { it.value.obsoleteTech == techName }
+            .filter { it.value.isObsoletedBy(techName) }
             .map { it.key to it.value.getEquivalentUpgradeOrNull() }
             .toMap()
         if (obsoleteUnits.isEmpty()) return

--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -49,6 +49,7 @@ class BaseUnit : RulesetObject(), INonPerpetualConstruction {
     var promotions = HashSet<String>()
     var obsoleteTech: String? = null
     fun techsThatObsoleteThis(): Sequence<String> = if (obsoleteTech == null) sequenceOf() else sequenceOf(obsoleteTech!!)
+    fun isObsoletedBy(techName: String): Boolean = techsThatObsoleteThis().contains(techName)
     var upgradesTo: String? = null
     var replaces: String? = null
     var uniqueTo: String? = null

--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -48,6 +48,7 @@ class BaseUnit : RulesetObject(), INonPerpetualConstruction {
     var replacementTextForUniques = ""
     var promotions = HashSet<String>()
     var obsoleteTech: String? = null
+    fun techsThatObsoleteThis(): Sequence<String> = if (obsoleteTech == null) sequenceOf() else sequenceOf(obsoleteTech!!)
     var upgradesTo: String? = null
     var replaces: String? = null
     var uniqueTo: String? = null

--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -161,8 +161,9 @@ class BaseUnit : RulesetObject(), INonPerpetualConstruction {
         for (requiredTech: String in requiredTechs())
             if (!civ.tech.isResearched(requiredTech))
                 yield(RejectionReasonType.RequiresTech.toInstance("$requiredTech not researched"))
-        if (obsoleteTech != null && civ.tech.isResearched(obsoleteTech!!))
-            yield(RejectionReasonType.Obsoleted.toInstance("Obsolete by $obsoleteTech"))
+        for (obsoleteTech: String in techsThatObsoleteThis())
+            if (civ.tech.isResearched(obsoleteTech))
+                yield(RejectionReasonType.Obsoleted.toInstance("Obsolete by $obsoleteTech"))
 
         if (uniqueTo != null && uniqueTo != civ.civName)
             yield(RejectionReasonType.UniqueToOtherNation.toInstance("Unique to $uniqueTo"))

--- a/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
+++ b/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
@@ -658,25 +658,27 @@ class RulesetValidator(val ruleset: Ruleset) {
         for (requiredTech: String in unit.requiredTechs())
             if (!ruleset.technologies.containsKey(requiredTech))
                 lines += "${unit.name} requires tech ${requiredTech} which does not exist!"
-        if (unit.obsoleteTech != null && !ruleset.technologies.containsKey(unit.obsoleteTech!!))
-            lines += "${unit.name} obsoletes at tech ${unit.obsoleteTech} which does not exist!"
+        for (obsoleteTech: String in unit.techsThatObsoleteThis())
+            if (!ruleset.technologies.containsKey(obsoleteTech))
+                lines += "${unit.name} obsoletes at tech ${obsoleteTech} which does not exist!"
         if (unit.upgradesTo != null && !ruleset.units.containsKey(unit.upgradesTo!!))
             lines += "${unit.name} upgrades to unit ${unit.upgradesTo} which does not exist!"
 
         // Check that we don't obsolete ourselves before we can upgrade
-        if (unit.upgradesTo!=null && ruleset.units.containsKey(unit.upgradesTo!!)
-            && unit.obsoleteTech!=null && ruleset.technologies.containsKey(unit.obsoleteTech!!)) {
-            val upgradedUnit = ruleset.units[unit.upgradesTo!!]!!
-            for (requiredTech: String in upgradedUnit.requiredTechs())
-                if (requiredTech != unit.obsoleteTech
-                    && !getPrereqTree(unit.obsoleteTech!!).contains(requiredTech)
-                )
-                    lines.add(
-                        "${unit.name} obsoletes at tech ${unit.obsoleteTech}," +
-                            " and therefore ${requiredTech} for its upgrade ${upgradedUnit.name} may not yet be researched!",
-                        RulesetErrorSeverity.Warning
+        for (obsoleteTech: String in unit.techsThatObsoleteThis())
+            if (unit.upgradesTo!=null && ruleset.units.containsKey(unit.upgradesTo!!)
+                && ruleset.technologies.containsKey(obsoleteTech)) {
+                val upgradedUnit = ruleset.units[unit.upgradesTo!!]!!
+                for (requiredTech: String in upgradedUnit.requiredTechs())
+                    if (requiredTech != obsoleteTech
+                        && !getPrereqTree(obsoleteTech).contains(requiredTech)
                     )
-        }
+                        lines.add(
+                            "${unit.name} obsoletes at tech ${obsoleteTech}," +
+                                " and therefore ${requiredTech} for its upgrade ${upgradedUnit.name} may not yet be researched!",
+                            RulesetErrorSeverity.Warning
+                        )
+            }
 
         for (resource in unit.getResourceRequirementsPerTurn(StateForConditionals.IgnoreConditionals).keys)
             if (!ruleset.tileResources.containsKey(resource))

--- a/tests/src/com/unciv/testing/BasicTests.kt
+++ b/tests/src/com/unciv/testing/BasicTests.kt
@@ -68,7 +68,7 @@ class BasicTests {
         val units: Collection<BaseUnit> = ruleset.units.values
         var allObsoletingUnitsHaveUpgrades = true
         for (unit in units) {
-            if (unit.obsoleteTech != null && unit.upgradesTo == null && unit.name !="Scout" ) {
+            if (unit.techsThatObsoleteThis().any() && unit.upgradesTo == null && unit.name !="Scout" ) {
                 debug("%s obsoletes but has no upgrade", unit.name)
                 allObsoletingUnitsHaveUpgrades = false
             }


### PR DESCRIPTION
This is Step Zero, not changing any functionality. The function in this branch is a stub function that doesn't pull from the Uniques.

There is one more complicated usage of `obsoleteTech` that this doesn't touch.

Basically, this is https://github.com/yairm210/Unciv/pull/10585 for `obsoleteTech`.

There is one spot in BasicTests.kt where a `unit.obsoleteTech != null` gets replaced by `unit.techsThatObsoleteThis().any()`, but on closer inspection this isn't a https://github.com/yairm210/Unciv/issues/10626-style problem; in context, `unit.techsThatObsoleteThis().any()` is indeed what we want. It's just checking whether the unit ever obsoletes at all, and isn't trying to get the `obsoleteTech` itself.