### PR TITLE
Pass-through exclude and filterUniques, respectively

### DIFF
--- a/core/src/com/unciv/ui/objectdescriptions/BaseUnitDescriptions.kt
+++ b/core/src/com/unciv/ui/objectdescriptions/BaseUnitDescriptions.kt
@@ -25,7 +25,7 @@ import com.unciv.ui.screens.civilopediascreen.MarkupRenderer
 object BaseUnitDescriptions {
 
     /** Generate short description as comma-separated string for Technology description "Units enabled" and GreatPersonPickerScreen */
-    fun getShortDescription(baseUnit: BaseUnit): String {
+    fun getShortDescription(baseUnit: BaseUnit, exclude: Unique.() -> Boolean = {false}): String {
         val infoList = mutableListOf<String>()
         if (baseUnit.strength != 0) infoList += "${baseUnit.strength}${Fonts.strength}"
         if (baseUnit.rangedStrength != 0) infoList += "${baseUnit.rangedStrength}${Fonts.rangedStrength}"
@@ -33,7 +33,7 @@ object BaseUnitDescriptions {
         for (promotion in baseUnit.promotions)
             infoList += promotion.tr()
         if (baseUnit.replacementTextForUniques != "") infoList += baseUnit.replacementTextForUniques
-        else baseUnit.uniquesToDescription(infoList)
+        else baseUnit.uniquesToDescription(infoList, exclude)
         return infoList.joinToString()
     }
 

--- a/core/src/com/unciv/ui/objectdescriptions/BuildingDescriptions.kt
+++ b/core/src/com/unciv/ui/objectdescriptions/BuildingDescriptions.kt
@@ -273,7 +273,7 @@ object BuildingDescriptions {
     /**
      * @param filterUniques If provided, include only uniques for which this function returns true.
      */
-    private fun Building.getUniquesStringsWithoutDisablers(filterUniques: ((Unique) -> Boolean)? = null) = getUniquesStrings {
+    private fun Building.getUniquesStringsWithoutDisablers(filterUniques: ((Unique) -> Boolean)? = null): Sequence<String> = getUniquesStrings {
         !it.isHiddenToUsers()
             && (filterUniques?.invoke(it) ?: true)
     }

--- a/core/src/com/unciv/ui/objectdescriptions/BuildingDescriptions.kt
+++ b/core/src/com/unciv/ui/objectdescriptions/BuildingDescriptions.kt
@@ -20,7 +20,7 @@ object BuildingDescriptions {
     // To stay consistent, all take the Building as normal parameter instead.
 
     /** Used for AlertType.WonderBuilt, and as sub-text in Nation and Tech descriptions */
-    fun getShortDescription(building: Building, multiline: Boolean = false): String = building.run {
+    fun getShortDescription(building: Building, multiline: Boolean = false, filterUniques: ((Unique) -> Boolean)? = null): String = building.run {
         val infoList = mutableListOf<String>()
         this.clone().toString().also { if (it.isNotEmpty()) infoList += it }
         for ((key, value) in getStatPercentageBonuses(null))
@@ -30,7 +30,7 @@ object BuildingDescriptions {
             infoList += "Requires worked [" + requiredNearbyImprovedResources!!.joinToString("/") { it.tr() } + "] near city"
         if (uniques.isNotEmpty()) {
             if (replacementTextForUniques.isNotEmpty()) infoList += replacementTextForUniques
-            else infoList += getUniquesStringsWithoutDisablers()
+            else infoList += getUniquesStringsWithoutDisablers(filterUniques)
         }
         if (cityStrength != 0) infoList += "{City strength} +$cityStrength"
         if (cityHealth != 0) infoList += "{City health} +$cityHealth"

--- a/core/src/com/unciv/ui/objectdescriptions/DescriptionHelpers.kt
+++ b/core/src/com/unciv/ui/objectdescriptions/DescriptionHelpers.kt
@@ -15,7 +15,7 @@ import com.unciv.ui.screens.civilopediascreen.FormattedLine
 fun IHasUniques.uniquesToDescription(
     lineList: MutableCollection<String>,
     exclude: Unique.() -> Boolean = {false}
-): Void {
+): Unit {
     for (unique in uniqueObjects) {
         if (unique.isHiddenToUsers()) continue
         if (unique.exclude()) continue

--- a/core/src/com/unciv/ui/objectdescriptions/DescriptionHelpers.kt
+++ b/core/src/com/unciv/ui/objectdescriptions/DescriptionHelpers.kt
@@ -15,7 +15,7 @@ import com.unciv.ui.screens.civilopediascreen.FormattedLine
 fun IHasUniques.uniquesToDescription(
     lineList: MutableCollection<String>,
     exclude: Unique.() -> Boolean = {false}
-) {
+): Void {
     for (unique in uniqueObjects) {
         if (unique.isHiddenToUsers()) continue
         if (unique.exclude()) continue


### PR DESCRIPTION
This allows passing `exclude` to `IHasUniques.uniquesToDescription()` and separately `filterUniques` to `Building.getUniquesStringsWithoutDisablers()`.

This should not change any behavior.

Incidentally, maybe I'm missing something obvious, but is there a reason why `Building` needs `Building.getUniquesStringsWithoutDisablers()`, given that it already inherits `IHasUniques.uniquesToDescription()`? The two have different signatures, so it's not a drop-in replacement, but it seems to be doing basically the same thing.