### PR TITLE
Remove last uses of requiredTech, integrate requiredTech into Uniques

### DIFF
--- a/core/src/com/unciv/models/ruleset/unique/IHasUniques.kt
+++ b/core/src/com/unciv/models/ruleset/unique/IHasUniques.kt
@@ -17,8 +17,12 @@ interface IHasUniques : INamed {
     val uniqueMap: Map<String, List<Unique>>
 
     fun uniqueObjectsProvider(): List<Unique> {
-        if (uniques.isEmpty()) return emptyList()
-        return uniques.map { Unique(it, getUniqueTarget(), name) } + legacyRequiredTechsAsUniques().toList()
+        var uniqueObjectList: List<Unique>
+        if (uniques.isEmpty())
+            uniqueObjectList = emptyList()
+        else
+            uniqueObjectList = uniques.map { Unique(it, getUniqueTarget(), name) }
+        return uniqueObjectList + legacyRequiredTechsAsUniques().toList()
     }
     fun uniqueMapProvider(): UniqueMap {
         val newUniqueMap = UniqueMap()

--- a/core/src/com/unciv/models/ruleset/unique/IHasUniques.kt
+++ b/core/src/com/unciv/models/ruleset/unique/IHasUniques.kt
@@ -59,6 +59,10 @@ interface IHasUniques : INamed {
 
     fun legacyRequiredTechs(): Sequence<String> = sequenceOf()
 
+    fun legacyRequiredTechsAsUniques(): Sequence<Unique> = legacyRequiredTechs()
+            .map{ "Only available <after discovering [$it]>" }
+            .map{ Unique(it, getUniqueTarget(), name) }
+
     fun requiredTechs(): Sequence<String> = legacyRequiredTechs() + techsRequiredByUniques()
 
     fun requiredTechnologies(ruleset: Ruleset): Sequence<Technology> =

--- a/core/src/com/unciv/models/ruleset/unique/IHasUniques.kt
+++ b/core/src/com/unciv/models/ruleset/unique/IHasUniques.kt
@@ -18,7 +18,7 @@ interface IHasUniques : INamed {
 
     fun uniqueObjectsProvider(): List<Unique> {
         if (uniques.isEmpty()) return emptyList()
-        return uniques.map { Unique(it, getUniqueTarget(), name) }
+        return uniques.map { Unique(it, getUniqueTarget(), name) } + legacyRequiredTechsAsUniques().toList()
     }
     fun uniqueMapProvider(): UniqueMap {
         val newUniqueMap = UniqueMap()

--- a/core/src/com/unciv/ui/objectdescriptions/BaseUnitDescriptions.kt
+++ b/core/src/com/unciv/ui/objectdescriptions/BaseUnitDescriptions.kt
@@ -124,11 +124,7 @@ object BaseUnitDescriptions {
                 )
         }
 
-        if (baseUnit.requiredTech != null || baseUnit.upgradesTo != null || baseUnit.obsoleteTech != null) textList += FormattedLine()
-        if (baseUnit.requiredTech != null) textList += FormattedLine(
-            "Required tech: [${baseUnit.requiredTech}]",
-            link = "Technology/${baseUnit.requiredTech}"
-        )
+        if (baseUnit.upgradesTo != null || baseUnit.obsoleteTech != null) textList += FormattedLine()
 
         val canUpgradeFrom = ruleset.units
             .filterValues {

--- a/core/src/com/unciv/ui/objectdescriptions/BuildingDescriptions.kt
+++ b/core/src/com/unciv/ui/objectdescriptions/BuildingDescriptions.kt
@@ -169,9 +169,6 @@ object BuildingDescriptions {
             textList += FormattedLine(stats.joinToString("/", "{Cost}: "))
         }
 
-        if (requiredTech != null)
-            textList += FormattedLine("Required tech: [$requiredTech]",
-                link="Technology/$requiredTech")
         if (requiredBuilding != null)
             textList += FormattedLine("Requires [$requiredBuilding] to be built in the city",
                 link="Building/$requiredBuilding")


### PR DESCRIPTION
Don't look at this before https://github.com/yairm210/Unciv/pull/10650 is resolved!

...well, technically they're orthogonal, but this greatly increases use of existing functionality that I think https://github.com/yairm210/Unciv/pull/10650 improves.

Background: There are just a couple of remaining uses of the `@Deprecated requiredTech: String` field, now that https://github.com/yairm210/Unciv/pull/10595 is merged. ~~(Last except for https://github.com/yairm210/Unciv/pull/10595, but I got the impression https://github.com/yairm210/Unciv/pull/10595 was approved-in-principle with just some minor revisions.)~~

In every other case, there was functionality for `requiredTech` that was not active for techs required via Uniques, and so it was a simple matter of dropping in the `requiredTechs()` function for every use of `requiredTech`. We didn't really do that, because in many cases it would have added complications to already-complicated bits of code, so in many cases we did some simplifications to avoid that. But still.

The last couple of uses of `requiredTech` are in the Civilopedia. Here the "problem", which in a sense is not really a problem, is that you *already* have a fully-functional system for displaying Uniques.

(With one caveat: I think it's a little *too* functional in some cases, displaying Uniques when they don't really need to be displayed. But https://github.com/yairm210/Unciv/pull/10650 fixes that.)

So we don't need to pull the additional required techs from the Uniques and work them into the existing code that currently uses `requiredTech`. These last few lines of code really do apply to `requiredTech` and *only* to `requiredTech`, because the techs required via Uniques are already handled.

If we integrate `requiredTech` with the Uniques, then the "problem" immediately evaporates: we can simply *delete* these lines of code, and replace them with *nothing*. The infrastructure that you already built for handling Uniques already handles everything that those lines are doing.

But if `requiredTech` is kept separately from the Uniques, then these additional external uses of `requiredTech` will have to persist indefinitely.

This branch integrates `requiredTech` with the Uniques and removes the last uses of `requiredTech` outside the `legacyRequiredTechs()` function.

You previously rejected something similar to this branch when it was hacking the JSON parsing, but I figured I'd try again just in case your underlying objection was literally to messing with the JSON parsing itself. This instead intercepts the uniques at the moment of converting them from Strings to Unique objects, and splices in an additional Unique if `requiredTech` is set. Same basic principle, but without messing with the JSON parsing (because indeed JSON parsing is very fiddly and it's good to avoid messing with that if possible).

This makes the descriptions look like:
![image](https://github.com/yairm210/Unciv/assets/13223511/5ebec67d-bc1f-4772-afa2-4a960fe014fd)
