### PR TITLE
Dev Console: Lint, crash fix, add Stat

### DIFF
--- a/core/src/com/unciv/ui/screens/devconsole/DevConsoleCommand.kt
+++ b/core/src/com/unciv/ui/screens/devconsole/DevConsoleCommand.kt
@@ -153,7 +153,7 @@ class ConsoleCityCommands : ConsoleCommandNode {
             val city = console.gameInfo.getCities().firstOrNull { it.name.toCliInput() == params[0] }
                 ?: return@ConsoleAction DevConsoleResponse.error("Unknown city")
             if (selectedTile.neighbors.none { it.getCity() == city })
-                return@ConsoleAction DevConsoleResponse.error("Tile is not adjacent any tile already owned by the city")
+                return@ConsoleAction DevConsoleResponse.error("Tile is not adjacent to any tile already owned by the city")
             city.expansion.takeOwnership(selectedTile)
             return@ConsoleAction DevConsoleResponse.OK
         },

--- a/core/src/com/unciv/ui/screens/devconsole/DevConsoleCommand.kt
+++ b/core/src/com/unciv/ui/screens/devconsole/DevConsoleCommand.kt
@@ -6,12 +6,12 @@ import com.unciv.models.ruleset.tile.TerrainType
 internal fun String.toCliInput() = this.lowercase().replace(" ","-")
 
 interface ConsoleCommand {
-    fun handle(console: DevConsolePopup, params: List<String>): String?
+    fun handle(console: DevConsolePopup, params: List<String>): DevConsoleResponse
     fun autocomplete(params: List<String>): String? = ""
 }
 
-class ConsoleAction(val action: (console: DevConsolePopup, params: List<String>) -> String?) : ConsoleCommand {
-    override fun handle(console: DevConsolePopup, params: List<String>): String? {
+class ConsoleAction(val action: (console: DevConsolePopup, params: List<String>) -> DevConsoleResponse) : ConsoleCommand {
+    override fun handle(console: DevConsolePopup, params: List<String>): DevConsoleResponse {
         return action(console, params)
     }
 }
@@ -19,11 +19,11 @@ class ConsoleAction(val action: (console: DevConsolePopup, params: List<String>)
 interface ConsoleCommandNode : ConsoleCommand {
     val subcommands: HashMap<String, ConsoleCommand>
 
-    override fun handle(console: DevConsolePopup, params: List<String>): String? {
+    override fun handle(console: DevConsolePopup, params: List<String>): DevConsoleResponse {
         if (params.isEmpty())
-            return "Available commands: " + subcommands.keys.joinToString()
+            return DevConsoleResponse.hint("Available commands: " + subcommands.keys.joinToString())
         val handler = subcommands[params[0]]
-            ?: return "Invalid command.\nAvailable commands:" + subcommands.keys.joinToString("") { "\n- $it" }
+            ?: return DevConsoleResponse.error("Invalid command.\nAvailable commands:" + subcommands.keys.joinToString("") { "\n- $it" })
         return handler.handle(console, params.drop(1))
     }
 
@@ -58,49 +58,49 @@ class ConsoleUnitCommands : ConsoleCommandNode {
 
         "add" to ConsoleAction { console, params ->
             if (params.size != 2)
-                return@ConsoleAction "Format: unit add <civName> <unitName>"
+                return@ConsoleAction DevConsoleResponse.hint("Format: unit add <civName> <unitName>")
             val selectedTile = console.screen.mapHolder.selectedTile
-                ?: return@ConsoleAction "No tile selected"
+                ?: return@ConsoleAction DevConsoleResponse.error("No tile selected")
             val civ = console.getCivByName(params[0])
-                ?: return@ConsoleAction "Unknown civ"
+                ?: return@ConsoleAction DevConsoleResponse.error("Unknown civ")
             val baseUnit = console.gameInfo.ruleset.units.values.firstOrNull { it.name.toCliInput() == params[1] }
-                ?: return@ConsoleAction "Unknown unit"
+                ?: return@ConsoleAction DevConsoleResponse.error("Unknown unit")
             civ.units.placeUnitNearTile(selectedTile.position, baseUnit)
-            return@ConsoleAction null
+            return@ConsoleAction DevConsoleResponse.OK
         },
 
         "remove" to ConsoleAction { console, params ->
             if (params.isNotEmpty())
-                return@ConsoleAction "Format: unit remove"
+                return@ConsoleAction DevConsoleResponse.hint("Format: unit remove")
             val unit = console.getSelectedUnit()
-                ?: return@ConsoleAction "Select tile with unit"
+                ?: return@ConsoleAction DevConsoleResponse.error("Select tile with unit")
             unit.destroy()
-            return@ConsoleAction null
+            return@ConsoleAction DevConsoleResponse.OK
         },
 
         "addpromotion" to ConsoleAction { console, params ->
             if (params.size != 1)
-                return@ConsoleAction "Format: unit addpromotion <promotionName>"
+                return@ConsoleAction DevConsoleResponse.hint("Format: unit addpromotion <promotionName>")
             val unit = console.getSelectedUnit()
-                ?: return@ConsoleAction "Select tile with unit"
+                ?: return@ConsoleAction DevConsoleResponse.error("Select tile with unit")
             val promotion = console.gameInfo.ruleset.unitPromotions.values.firstOrNull { it.name.toCliInput() == params[2] }
-                ?: return@ConsoleAction "Unknown promotion"
+                ?: return@ConsoleAction DevConsoleResponse.error("Unknown promotion")
             unit.promotions.addPromotion(promotion.name, true)
-            return@ConsoleAction null
+            return@ConsoleAction DevConsoleResponse.OK
         },
 
         "removepromotion" to ConsoleAction { console, params ->
             if (params.size != 1)
-                return@ConsoleAction "Format: unit removepromotion <promotionName>"
+                return@ConsoleAction DevConsoleResponse.hint("Format: unit removepromotion <promotionName>")
             val unit = console.getSelectedUnit()
-                ?: return@ConsoleAction "Select tile with unit"
+                ?: return@ConsoleAction DevConsoleResponse.error("Select tile with unit")
             val promotion = unit.promotions.getPromotions().firstOrNull { it.name.toCliInput() == params[2] }
-                ?: return@ConsoleAction "Promotion not found on unit"
+                ?: return@ConsoleAction DevConsoleResponse.error("Promotion not found on unit")
             // No such action in-game so we need to manually update
             unit.promotions.promotions.remove(promotion.name)
             unit.updateUniques()
             unit.updateVisibleTiles()
-            return@ConsoleAction null
+            return@ConsoleAction DevConsoleResponse.OK
         }
     )
 }
@@ -110,60 +110,60 @@ class ConsoleCityCommands : ConsoleCommandNode {
 
         "add" to ConsoleAction { console, params ->
             if (params.size != 1)
-                return@ConsoleAction "Format: city add <civName>"
+                return@ConsoleAction DevConsoleResponse.hint("Format: city add <civName>")
             val civ = console.getCivByName(params[0])
-                ?: return@ConsoleAction "Unknown civ"
+                ?: return@ConsoleAction DevConsoleResponse.error("Unknown civ")
             val selectedTile = console.screen.mapHolder.selectedTile
-                ?: return@ConsoleAction "No tile selected"
+                ?: return@ConsoleAction DevConsoleResponse.error("No tile selected")
             if (selectedTile.isCityCenter())
-                return@ConsoleAction "Tile already contains a city center"
+                return@ConsoleAction DevConsoleResponse.error("Tile already contains a city center")
             civ.addCity(selectedTile.position)
-            return@ConsoleAction null
+            return@ConsoleAction DevConsoleResponse.OK
         },
 
         "remove" to ConsoleAction { console, params ->
             if (params.isNotEmpty())
-                return@ConsoleAction "Format: city remove"
+                return@ConsoleAction DevConsoleResponse.hint("Format: city remove")
             val selectedTile = console.screen.mapHolder.selectedTile
-                ?: return@ConsoleAction "No tile selected"
+                ?: return@ConsoleAction DevConsoleResponse.error("No tile selected")
             val city = selectedTile.getCity()
-                ?: return@ConsoleAction "No city in selected tile"
+                ?: return@ConsoleAction DevConsoleResponse.error("No city in selected tile")
             city.destroyCity(overrideSafeties = true)
-            return@ConsoleAction null
+            return@ConsoleAction DevConsoleResponse.OK
         },
 
         "setpop" to ConsoleAction { console, params ->
             if (params.size != 2)
-                return@ConsoleAction "Format: city setpop <cityName> <amount>"
-            val newPop = params[1].toIntOrNull() ?: return@ConsoleAction "Invalid amount " + params[1]
-            if (newPop < 1) return@ConsoleAction "Invalid amount $newPop"
+                return@ConsoleAction DevConsoleResponse.hint("Format: city setpop <cityName> <amount>")
+            val newPop = params[1].toIntOrNull() ?: return@ConsoleAction DevConsoleResponse.error("Invalid amount " + params[1])
+            if (newPop < 1) return@ConsoleAction DevConsoleResponse.error("Invalid amount $newPop")
             val city = console.gameInfo.getCities().firstOrNull { it.name.toCliInput() == params[0] }
-                ?: return@ConsoleAction "Unknown city"
+                ?: return@ConsoleAction DevConsoleResponse.error("Unknown city")
             city.population.setPopulation(newPop)
-            return@ConsoleAction null
+            return@ConsoleAction DevConsoleResponse.OK
         },
 
         "addtile" to ConsoleAction { console, params ->
             if (params.size != 1)
-                return@ConsoleAction "Format: city addtile <cityName>"
+                return@ConsoleAction DevConsoleResponse.hint("Format: city addtile <cityName>")
             val selectedTile = console.screen.mapHolder.selectedTile
-                ?: return@ConsoleAction "No tile selected"
+                ?: return@ConsoleAction DevConsoleResponse.error("No tile selected")
             val city = console.gameInfo.getCities().firstOrNull { it.name.toCliInput() == params[0] }
-                ?: return@ConsoleAction "Unknown city"
+                ?: return@ConsoleAction DevConsoleResponse.error("Unknown city")
             if (selectedTile.neighbors.none { it.getCity() == city })
-                return@ConsoleAction "Tile is not adjacent any tile already owned by the city"
+                return@ConsoleAction DevConsoleResponse.error("Tile is not adjacent any tile already owned by the city")
             city.expansion.takeOwnership(selectedTile)
-            return@ConsoleAction null
+            return@ConsoleAction DevConsoleResponse.OK
         },
 
         "removetile" to ConsoleAction { console, params ->
             if (params.isNotEmpty())
-                return@ConsoleAction "Format: city removetile"
+                return@ConsoleAction DevConsoleResponse.hint("Format: city removetile")
             val selectedTile = console.screen.mapHolder.selectedTile
-                ?: return@ConsoleAction "No tile selected"
-            val city = selectedTile.getCity() ?: return@ConsoleAction "No city for selected tile"
+                ?: return@ConsoleAction DevConsoleResponse.error("No tile selected")
+            val city = selectedTile.getCity() ?: return@ConsoleAction DevConsoleResponse.error("No city for selected tile")
             city.expansion.relinquishOwnership(selectedTile)
-            return@ConsoleAction null
+            return@ConsoleAction DevConsoleResponse.OK
         })
 }
 
@@ -172,52 +172,52 @@ class ConsoleTileCommands: ConsoleCommandNode {
 
         "setimprovement" to ConsoleAction { console, params ->
             if (params.size != 1 && params.size != 2)
-                return@ConsoleAction "Format: tile setimprovement <improvementName> [<civName>]"
+                return@ConsoleAction DevConsoleResponse.hint("Format: tile setimprovement <improvementName> [<civName>]")
             val selectedTile = console.screen.mapHolder.selectedTile
-                ?: return@ConsoleAction "No tile selected"
+                ?: return@ConsoleAction DevConsoleResponse.error("No tile selected")
             val improvement = console.gameInfo.ruleset.tileImprovements.values.firstOrNull {
                 it.name.toCliInput() == params[0]
-            } ?: return@ConsoleAction "Unknown improvement"
+            } ?: return@ConsoleAction DevConsoleResponse.error("Unknown improvement")
             var civ:Civilization? = null
             if (params.size == 2){
                 civ = console.getCivByName(params[1])
-                    ?: return@ConsoleAction "Unknown civ"
+                    ?: return@ConsoleAction DevConsoleResponse.error("Unknown civ")
             }
             selectedTile.improvementFunctions.changeImprovement(improvement.name, civ)
-            return@ConsoleAction null
+            return@ConsoleAction DevConsoleResponse.OK
         },
 
         "removeimprovement" to ConsoleAction { console, params ->
             if (params.isNotEmpty())
-                return@ConsoleAction "Format: tile removeimprovement"
+                return@ConsoleAction DevConsoleResponse.hint("Format: tile removeimprovement")
             val selectedTile = console.screen.mapHolder.selectedTile
-                ?: return@ConsoleAction "No tile selected"
+                ?: return@ConsoleAction DevConsoleResponse.error("No tile selected")
             selectedTile.improvementFunctions.changeImprovement(null)
-            return@ConsoleAction null
+            return@ConsoleAction DevConsoleResponse.OK
         },
 
         "addfeature" to ConsoleAction { console, params ->
             if (params.size != 1)
-                return@ConsoleAction "Format: tile addfeature <featureName>"
+                return@ConsoleAction DevConsoleResponse.hint("Format: tile addfeature <featureName>")
             val selectedTile = console.screen.mapHolder.selectedTile
-                ?: return@ConsoleAction "No tile selected"
+                ?: return@ConsoleAction DevConsoleResponse.error("No tile selected")
             val feature = console.gameInfo.ruleset.terrains.values
                 .firstOrNull { it.type == TerrainType.TerrainFeature && it.name.toCliInput() == params[0] }
-                ?: return@ConsoleAction "Unknown feature"
+                ?: return@ConsoleAction DevConsoleResponse.error("Unknown feature")
             selectedTile.addTerrainFeature(feature.name)
-            return@ConsoleAction null
+            return@ConsoleAction DevConsoleResponse.OK
         },
 
         "removefeature" to ConsoleAction { console, params ->
             if (params.size != 1)
-                return@ConsoleAction "Format: tile addfeature <featureName>"
+                return@ConsoleAction DevConsoleResponse.hint("Format: tile addfeature <featureName>")
             val selectedTile = console.screen.mapHolder.selectedTile
-                ?: return@ConsoleAction "No tile selected"
+                ?: return@ConsoleAction DevConsoleResponse.error("No tile selected")
             val feature = console.gameInfo.ruleset.terrains.values
                 .firstOrNull { it.type == TerrainType.TerrainFeature && it.name.toCliInput() == params[0] }
-                ?: return@ConsoleAction "Unknown feature"
+                ?: return@ConsoleAction DevConsoleResponse.error("Unknown feature")
             selectedTile.removeTerrainFeature(feature.name)
-            return@ConsoleAction null
+            return@ConsoleAction DevConsoleResponse.OK
         }
     )
 }

--- a/core/src/com/unciv/ui/screens/devconsole/DevConsolePopup.kt
+++ b/core/src/com/unciv/ui/screens/devconsole/DevConsolePopup.kt
@@ -27,15 +27,7 @@ class DevConsolePopup(val screen: WorldScreen) : Popup(screen) {
 
     init {
         add(textField).width(stageToShowOn.width / 2).row()
-        textField.keyShortcuts.add(Input.Keys.ENTER) {
-            val handleCommandResponse = handleCommand()
-            if (handleCommandResponse == null) {
-                screen.shouldUpdate = true
-                history.add(textField.text)
-                close()
-            }
-            else responseLabel.setText(handleCommandResponse)
-        }
+        textField.keyShortcuts.add(Input.Keys.ENTER, ::onEnter)
 
         // Without this, console popup will always contain a `
         textField.addAction(Actions.delay(0.05f, Actions.run { textField.text = "" }))
@@ -68,9 +60,21 @@ class DevConsolePopup(val screen: WorldScreen) : Popup(screen) {
         screen.stage.keyboardFocus = textField
     }
 
+    private fun onEnter() {
+        val handleCommandResponse = handleCommand()
+        if (handleCommandResponse.isOK) {
+            screen.shouldUpdate = true
+            history.add(textField.text)
+            close()
+            return
+        }
+        responseLabel.setText(handleCommandResponse.message)
+        responseLabel.style.fontColor = handleCommandResponse.color
+    }
+
     private fun getParams(text: String) = text.split(" ").filter { it.isNotEmpty() }.map { it.lowercase() }
 
-    private fun handleCommand(): String? {
+    private fun handleCommand(): DevConsoleResponse {
         val params = getParams(textField.text)
         return commandRoot.handle(this, params)
     }

--- a/core/src/com/unciv/ui/screens/devconsole/DevConsoleResponse.kt
+++ b/core/src/com/unciv/ui/screens/devconsole/DevConsoleResponse.kt
@@ -1,0 +1,18 @@
+
+package com.unciv.ui.screens.devconsole
+
+import com.badlogic.gdx.graphics.Color
+
+@Suppress("DataClassPrivateConstructor") // abuser need to find copy() first
+data class DevConsoleResponse private constructor (
+    val color: Color,
+    val message: String? = null,
+    val isOK: Boolean = false
+) {
+    companion object {
+        val OK = DevConsoleResponse(Color.GREEN, isOK = true)
+        fun ok(message: String) = DevConsoleResponse(Color.GREEN, message, true)
+        fun error(message: String) = DevConsoleResponse(Color.RED, message)
+        fun hint(message: String) = DevConsoleResponse(Color.GOLD, message)
+    }
+}

--- a/core/src/com/unciv/ui/screens/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/WorldScreen.kt
@@ -196,7 +196,6 @@ class WorldScreen(
             // No cheating unless you're by yourself
             if (gameInfo.civilizations.count { it.isHuman() } > 1) return@add
             val consolePopup = DevConsolePopup(this)
-            stage.keyboardFocus = consolePopup.textField
         }
 
         addKeyboardListener() // for map panning by W,S,A,D


### PR DESCRIPTION
Oops, bungled separating the crash fix into a separate commit: It's the two `params[2]` to `params[0]` in unit a/r promotion.
That was all I set out to do, but since there were a few missing horizontal whitespaces...

This also prepares a bit for leaving the console open after a successful command and display some helpful message - like `civ add india faith 100` -> "India now has 999 stored Faith" or somesuch. Opinion?