### PR TITLE
Add TechManager.isObsolete(unit)

### DIFF
--- a/core/src/com/unciv/logic/civilization/diplomacy/CityStateFunctions.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/CityStateFunctions.kt
@@ -94,7 +94,7 @@ class CityStateFunctions(val civInfo: Civilization) {
                 ?: return null
             if (!receivingCiv.tech.isResearched(uniqueUnit))
                 return null
-            if (uniqueUnit.obsoleteTech != null && receivingCiv.tech.isResearched(uniqueUnit.obsoleteTech!!))
+            if (receivingCiv.tech.isObsolete(uniqueUnit))
                 return null
             return uniqueUnit
         }

--- a/core/src/com/unciv/logic/civilization/managers/TechManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/TechManager.kt
@@ -157,6 +157,8 @@ class TechManager : IsPartOfGameInfoSerialization {
 
     fun isResearched(construction: INonPerpetualConstruction): Boolean = construction.requiredTechs().all{ requiredTech -> isResearched(requiredTech) }
 
+    fun isObsolete(unit: BaseUnit): Boolean = unit.techsThatObsoleteThis().any{ obsoleteTech -> isResearched(obsoleteTech) }
+
     fun canBeResearched(techName: String): Boolean {
         val tech = getRuleset().technologies[techName]!!
         if (tech.uniqueObjects.any { it.type == UniqueType.OnlyAvailableWhen && !it.conditionalsApply(civInfo) })


### PR DESCRIPTION
I think we might want to break the concept of "obsolete" into its component parts (unavailable to build and automatically upgraded if in production), but in any case we'll still want to wrap this into a function.

This is like https://github.com/yairm210/Unciv/pull/10646, but for obsolete units.