### PR TITLE
Rename BaseUnit.techsAtWhichNoLongerAvailable()

### DIFF
--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -49,6 +49,7 @@ class BaseUnit : RulesetObject(), INonPerpetualConstruction {
     var promotions = HashSet<String>()
     var obsoleteTech: String? = null
     fun techsThatObsoleteThis(): Sequence<String> = if (obsoleteTech == null) sequenceOf() else sequenceOf(obsoleteTech!!)
+    fun techsAtWhichNoLongerAvailable(): Sequence<String> = techsThatObsoleteThis()
     fun isObsoletedBy(techName: String): Boolean = techsThatObsoleteThis().contains(techName)
     var upgradesTo: String? = null
     var replaces: String? = null

--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -162,7 +162,7 @@ class BaseUnit : RulesetObject(), INonPerpetualConstruction {
         for (requiredTech: String in requiredTechs())
             if (!civ.tech.isResearched(requiredTech))
                 yield(RejectionReasonType.RequiresTech.toInstance("$requiredTech not researched"))
-        for (obsoleteTech: String in techsThatObsoleteThis())
+        for (obsoleteTech: String in techsAtWhichNoLongerAvailable())
             if (civ.tech.isResearched(obsoleteTech))
                 yield(RejectionReasonType.Obsoleted.toInstance("Obsolete by $obsoleteTech"))
 

--- a/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
+++ b/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
@@ -658,7 +658,7 @@ class RulesetValidator(val ruleset: Ruleset) {
         for (requiredTech: String in unit.requiredTechs())
             if (!ruleset.technologies.containsKey(requiredTech))
                 lines += "${unit.name} requires tech ${requiredTech} which does not exist!"
-        for (obsoleteTech: String in unit.techsThatObsoleteThis())
+        for (obsoleteTech: String in unit.techsAtWhichNoLongerAvailable())
             if (!ruleset.technologies.containsKey(obsoleteTech))
                 lines += "${unit.name} obsoletes at tech ${obsoleteTech} which does not exist!"
         if (unit.upgradesTo != null && !ruleset.units.containsKey(unit.upgradesTo!!))


### PR DESCRIPTION
As discussed in https://github.com/yairm210/Unciv/pull/10654, I want to split apart the effect of automatically upgrading from the effect of no longer being buildable.

This does not change any functionality, just relabels the places where the question is whether a unit is buildable, so that these can be separated later.