### PR TITLE
Add resource support to stat gamespeed conditional

### DIFF
--- a/core/src/com/unciv/models/ruleset/unique/Unique.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Unique.kt
@@ -195,7 +195,7 @@ class Unique(val text: String, val sourceObjectType: UniqueTarget? = null, val s
         }
 
         /** Helper for ConditionalWhenAboveAmountStatSpeed and its below counterpart */
-        fun checkStatAmountWithSpeed(compare: (current: Int, limit: Float) -> Boolean): Boolean {
+        fun checkResourceOrStatAmountWithSpeed(compare: (current: Int, limit: Float) -> Boolean): Boolean {
             if (state.civInfo == null) return false
             val limit = condition.params[0].toInt()
             val resourceOrStatName = condition.params[1]
@@ -229,10 +229,10 @@ class Unique(val text: String, val sourceObjectType: UniqueTarget? = null, val s
                 checkResourceOrStatAmount { current, limit -> current > limit }
             UniqueType.ConditionalWhenBelowAmountStatResource ->
                 checkResourceOrStatAmount { current, limit -> current < limit }
-            UniqueType.ConditionalWhenAboveAmountStatSpeed ->
-                checkStatAmountWithSpeed { current, limit -> current > limit }  // Note: Int.compareTo(Float)!
-            UniqueType.ConditionalWhenBelowAmountStatSpeed ->
-                checkStatAmountWithSpeed { current, limit -> current < limit }  // Note: Int.compareTo(Float)!
+            UniqueType.ConditionalWhenAboveAmountStatResourceSpeed ->
+                checkResourceOrStatAmountWithSpeed { current, limit -> current > limit }  // Note: Int.compareTo(Float)!
+            UniqueType.ConditionalWhenBelowAmountStatResourceSpeed ->
+                checkResourceOrStatAmountWithSpeed { current, limit -> current < limit }  // Note: Int.compareTo(Float)!
 
             UniqueType.ConditionalHappy -> checkOnCiv { stats.happiness >= 0 }
             UniqueType.ConditionalBetweenHappiness ->

--- a/core/src/com/unciv/models/ruleset/unique/Unique.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Unique.kt
@@ -197,10 +197,17 @@ class Unique(val text: String, val sourceObjectType: UniqueTarget? = null, val s
         /** Helper for ConditionalWhenAboveAmountStatSpeed and its below counterpart */
         fun checkStatAmountWithSpeed(compare: (current: Int, limit: Float) -> Boolean): Boolean {
             if (state.civInfo == null) return false
-            val stat = Stat.safeValueOf(condition.params[1])
+            val limit = condition.params[0].toInt()
+            val resourceOrStatName = condition.params[1]
+            var gameSpeedModifier = state.civInfo.gameInfo.speed.modifier
+
+            if (state.civInfo.gameInfo.ruleset.tileResources.containsKey(resourceOrStatName))
+                return compare(getResourceAmount(resourceOrStatName), limit * gameSpeedModifier)
+            val stat = Stat.safeValueOf(resourceOrStatName)
                 ?: return false
-            val limit = condition.params[0].toFloat() * state.civInfo.gameInfo.speed.statCostModifiers[stat]!!
-            return compare(state.civInfo.getStatReserve(stat), limit)
+
+            gameSpeedModifier = condition.params[0].toFloat() * state.civInfo.gameInfo.speed.statCostModifiers[stat]!!
+            return compare(state.civInfo.getStatReserve(stat), limit * gameSpeedModifier)
         }
 
         return when (condition.type) {

--- a/core/src/com/unciv/models/ruleset/unique/Unique.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Unique.kt
@@ -206,7 +206,7 @@ class Unique(val text: String, val sourceObjectType: UniqueTarget? = null, val s
             val stat = Stat.safeValueOf(resourceOrStatName)
                 ?: return false
 
-            gameSpeedModifier = condition.params[0].toFloat() * state.civInfo.gameInfo.speed.statCostModifiers[stat]!!
+            gameSpeedModifier = state.civInfo.gameInfo.speed.statCostModifiers[stat]!!
             return compare(state.civInfo.getStatReserve(stat), limit * gameSpeedModifier)
         }
 

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -650,8 +650,8 @@ enum class UniqueType(
     ConditionalWhenBelowAmountStatResource("when below [amount] [stat/resource]", UniqueTarget.Conditional),
 
     // The game speed-adjusted versions of above
-    ConditionalWhenAboveAmountStatSpeed("when above [amount] [stat] (modified by game speed)", UniqueTarget.Conditional),
-    ConditionalWhenBelowAmountStatSpeed("when below [amount] [stat] (modified by game speed)", UniqueTarget.Conditional),
+    ConditionalWhenAboveAmountStatSpeed("when above [amount] [stat/resource] (modified by game speed)", UniqueTarget.Conditional),
+    ConditionalWhenBelowAmountStatSpeed("when below [amount] [stat/resource] (modified by game speed)", UniqueTarget.Conditional),
 
     /////// city conditionals
     ConditionalInThisCity("in this city", UniqueTarget.Conditional),

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -650,8 +650,8 @@ enum class UniqueType(
     ConditionalWhenBelowAmountStatResource("when below [amount] [stat/resource]", UniqueTarget.Conditional),
 
     // The game speed-adjusted versions of above
-    ConditionalWhenAboveAmountStatSpeed("when above [amount] [stat/resource] (modified by game speed)", UniqueTarget.Conditional),
-    ConditionalWhenBelowAmountStatSpeed("when below [amount] [stat/resource] (modified by game speed)", UniqueTarget.Conditional),
+    ConditionalWhenAboveAmountStatResourceSpeed("when above [amount] [stat/resource] (modified by game speed)", UniqueTarget.Conditional),
+    ConditionalWhenBelowAmountStatResourceSpeed("when below [amount] [stat/resource] (modified by game speed)", UniqueTarget.Conditional),
 
     /////// city conditionals
     ConditionalInThisCity("in this city", UniqueTarget.Conditional),

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -1926,12 +1926,12 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 	Applicable to: Conditional
 
-??? example  "&lt;when above [amount] [stat] (modified by game speed)&gt;"
+??? example  "&lt;when above [amount] [stat/resource] (modified by game speed)&gt;"
 	Example: "&lt;when above [3] [Culture] (modified by game speed)&gt;"
 
 	Applicable to: Conditional
 
-??? example  "&lt;when below [amount] [stat] (modified by game speed)&gt;"
+??? example  "&lt;when below [amount] [stat/resource] (modified by game speed)&gt;"
 	Example: "&lt;when below [3] [Culture] (modified by game speed)&gt;"
 
 	Applicable to: Conditional


### PR DESCRIPTION
I've come up with an idea to expand the possibilities of using the tileResources mechanic as custom civ-wide variables. Threrefore I decided to tweak the conditional stat function to accept the resource values.

If there is anything wrong with this PR then let me know in the comments. Constructive feedback is welcome.