### PR TITLE
Fix connect road button for when auto unit cycle is turned on

### DIFF
--- a/core/src/com/unciv/models/UnitAction.kt
+++ b/core/src/com/unciv/models/UnitAction.kt
@@ -100,7 +100,7 @@ enum class UnitActionType(
     Automate("Automate",
         { ImageGetter.getUnitActionPortrait("Automate") }),
     ConnectRoad("Connect road",
-        { ImageGetter.getUnitActionPortrait("RoadConnection") }),
+        { ImageGetter.getUnitActionPortrait("RoadConnection") }, false),
     StopAutomation("Stop automation",
         { ImageGetter.getUnitActionPortrait("Stop") }, false),
     StopMovement("Stop movement",


### PR DESCRIPTION
Bug found here
https://github.com/yairm210/Unciv/pull/10631

Connect road button would not work when auto unit cycle setting is turned on.

Solution is to add a missing parameter `isSkippingToNextUnit=false`