### PR TITLE
Removing possible peace exploit

### DIFF
--- a/core/src/com/unciv/logic/trade/TradeEvaluation.kt
+++ b/core/src/com/unciv/logic/trade/TradeEvaluation.kt
@@ -338,7 +338,10 @@ class TradeEvaluation {
             val percentageAdvantage = absoluteAdvantage / theirCombatStrength.toFloat()
             // We don't add the same constraint here. We should not make peace easily if we're
             // heavily advantaged.
-            return (absoluteAdvantage * percentageAdvantage).toInt() * 10
+            val totalAdvantage = (absoluteAdvantage * percentageAdvantage).toInt() * 10
+            if(totalAdvantage < 0) //May be a negative number if strength disparity is such that it leads to integer overflow
+                return 10000    //in that rare case, the AI would accept peace against a defeated foe.
+            return totalAdvantage
         } else {
             // This results in huge values for large power imbalances. However, we should not give
             // up everything just because there is a big power imbalance. There's a better chance to


### PR DESCRIPTION
I was running simulations and analyzing AI behavior for an unrelated reason and found that the AI may accept peace against a disarmed enemy. This is caused by an integer overflow in TradeEvaluation.evaluatePeaceCostForThem() making it return a negative number when it should return positive, which can happen if the evaluator is thousands of times more powerful than the enemy, the more likely scenario beign if the enemy's army is wiped out (theirCombatStrength = 1) and the evaluator force (ourCombatStrength) >= 14655. This is rare, happening in only 6 out of 34 AI-only games, always in turn 360 or higher, but a human player going for a victory other than domination could abuse this possibility by disbanding their army and suing for peace as soon as possible, optimizing their time and resources. 