### PR TITLE
Great Person Points - Rounding changes, Breakdown UI

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -147,6 +147,7 @@ We will remember this. =
 
 [civName] has declared war on [targetCivName]! = 
 [civName] and [targetCivName] have signed a Peace Treaty! = 
+Declaration of Friendship = 
 [civName] and [targetCivName] have signed the Declaration of Friendship! = 
 [civName] has denounced [targetCivName]! = 
 Do you want to break your promise to [leaderName]? = 

--- a/core/src/com/unciv/logic/city/City.kt
+++ b/core/src/com/unciv/logic/city/City.kt
@@ -34,7 +34,6 @@ enum class CityFlags {
 
 
 class City : IsPartOfGameInfoSerialization {
-    @Suppress("JoinDeclarationAndAssignment")
     @Transient
     lateinit var civ: Civilization
 
@@ -212,7 +211,9 @@ class City : IsPartOfGameInfoSerialization {
 
     fun getGreatPersonPercentageBonus() = getGreatPersonPercentageBonusBreakdown().sumOf { it.second }
 
-    fun getGreatPersonPercentageBonusBreakdown() = sequence<Pair<String, Int>> {
+    @Suppress("RemoveExplicitTypeArguments")  // Clearer readability
+    /** Collects percentage boni applying to all GPP. Each returned entry is a Pair naming the source and the integer percentage. */
+    private fun getGreatPersonPercentageBonusBreakdown() = sequence<Pair<String, Int>> {
         for (unique in getMatchingUniques(UniqueType.GreatPersonPointPercentage)) {
             if (!matchesFilter(unique.params[1])) continue
             yield((unique.sourceObjectName ?: "Bonus") to unique.params[0].toInt())

--- a/core/src/com/unciv/ui/screens/cityscreen/CityStatsTable.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/CityStatsTable.kt
@@ -2,6 +2,7 @@ package com.unciv.ui.screens.cityscreen
 
 import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.scenes.scene2d.Actor
+import com.badlogic.gdx.scenes.scene2d.Touchable
 import com.badlogic.gdx.scenes.scene2d.ui.Cell
 import com.badlogic.gdx.scenes.scene2d.ui.Label
 import com.badlogic.gdx.scenes.scene2d.ui.Table
@@ -23,6 +24,7 @@ import com.unciv.ui.components.extensions.colorFromRGB
 import com.unciv.ui.components.extensions.surroundWithCircle
 import com.unciv.ui.components.extensions.toGroup
 import com.unciv.ui.components.extensions.toLabel
+import com.unciv.ui.components.extensions.toStringSigned
 import com.unciv.ui.components.extensions.toTextButton
 import com.unciv.ui.components.fonts.Fonts
 import com.unciv.ui.components.input.KeyboardBinding
@@ -30,6 +32,7 @@ import com.unciv.ui.components.input.onActivation
 import com.unciv.ui.components.input.onClick
 import com.unciv.ui.components.widgets.ExpanderTab
 import com.unciv.ui.images.ImageGetter
+import com.unciv.ui.popups.Popup
 import com.unciv.ui.screens.basescreen.BaseScreen
 import com.unciv.ui.screens.civilopediascreen.CivilopediaScreen
 import kotlin.math.ceil
@@ -350,31 +353,19 @@ class CityStatsTable(private val cityScreen: CityScreen) : Table() {
 
         val greatPeopleTable = Table()
 
-        val greatPersonPoints = city.getGreatPersonPointsForNextTurn()
-        val allGreatPersonNames = greatPersonPoints.asSequence().flatMap { it.value.keys }.distinct()
-
-        if (allGreatPersonNames.none())
+        val greatPersonPoints = city.getGreatPersonPoints()
+        if (greatPersonPoints.isEmpty())
             return
 
-        for (greatPersonName in allGreatPersonNames) {
-
-            var gppPerTurn = 0
-
-            for ((_, gppCounter) in greatPersonPoints) {
-                val gppPointsFromSource = gppCounter[greatPersonName]
-                if (gppPointsFromSource == 0) continue
-                gppPerTurn += gppPointsFromSource
-            }
-
+        for ((greatPersonName, gppPerTurn) in greatPersonPoints.asIterable().sortedBy { it.key }) {
             val info = Table()
 
-            info.add(ImageGetter.getUnitIcon(greatPersonName, Color.GOLD).toGroup(20f))
-                .left().padBottom(4f).padRight(5f)
+            val specialistIcon = ImageGetter.getUnitIcon(greatPersonName, Color.GOLD).toGroup(20f)
+            info.add(specialistIcon).left().padBottom(4f).padRight(5f)
             info.add("{$greatPersonName} (+$gppPerTurn)".toLabel(hideIcons = true)).left().padBottom(4f).expandX().row()
 
             val gppCurrent = city.civ.greatPeople.greatPersonPointsCounter[greatPersonName]
             val gppNeeded = city.civ.greatPeople.getPointsRequiredForGreatPerson(greatPersonName)
-
             val percent = gppCurrent / gppNeeded.toFloat()
 
             val progressBar = ImageGetter.ProgressBar(300f, 25f, false)
@@ -389,14 +380,35 @@ class CityStatsTable(private val cityScreen: CityScreen) : Table() {
                 bar.toBack()
             }
             progressBar.setLabel(Color.WHITE, "$gppCurrent/$gppNeeded", fontSize = 14)
-
             info.add(progressBar).colspan(2).left().expandX().row()
 
             greatPeopleTable.add(info).growX().top().padBottom(10f)
-            greatPeopleTable.add(ImageGetter.getConstructionPortrait(greatPersonName, 50f)).row()
+            val unitIcon = ImageGetter.getConstructionPortrait(greatPersonName, 45f) // Will be 2f bigger than ordered
+            greatPeopleTable.add(unitIcon).padLeft(10f).row()
+
+            info.touchable = Touchable.enabled
+            info.onClick { GppBreakDownPopup(greatPersonName) }
+            unitIcon.onClick { GppBreakDownPopup(greatPersonName) }
         }
 
         lowerTable.addCategory("Great People", greatPeopleTable, KeyboardBinding.GreatPeopleDetail)
     }
 
+    inner class GppBreakDownPopup(gppName: String) : Popup(cityScreen) {
+        init {
+            for ((key, counter) in city.getGreatPersonPointsBreakdown()) {
+                val (source, isBonus) = key
+                val points = counter[gppName]
+                if (points == 0) continue
+                add("{$source}:".toLabel()).left().growX()
+                add((if (isBonus) points.toStringSigned() + "%" else points.toString()).toLabel(alignment = Align.right)).right().row()
+            }
+            addSeparator()
+            val total = city.getGreatPersonPoints()[gppName]
+            add("{Total}:".toLabel()).left().growX()
+            add(total.toString().toLabel(alignment = Align.right)).right().row()
+            addCloseButton()
+            open(true)
+        }
+    }
 }

--- a/core/src/com/unciv/ui/screens/cityscreen/CityStatsTable.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/CityStatsTable.kt
@@ -396,8 +396,7 @@ class CityStatsTable(private val cityScreen: CityScreen) : Table() {
 
     inner class GppBreakDownPopup(gppName: String) : Popup(cityScreen) {
         init {
-            for ((key, counter) in city.getGreatPersonPointsBreakdown()) {
-                val (source, isBonus) = key
+            for ((source, isBonus, counter) in city.getGreatPersonPointsBreakdown()) {
                 val points = counter[gppName]
                 if (points == 0) continue
                 add("{$source}:".toLabel()).left().growX()


### PR DESCRIPTION
... and since it irked me for ages, I secretly snuck in.... :speak_no_evil: another minor rule change... :speak_no_evil: :speak_no_evil: :speak_no_evil:  (:angel: :smiling_imp: shut up, no spoilers!)  <sub><sup>And I reduced that unit icon a little and moved it off the stuff it was overlapping :see_no_evil: :hear_no_evil: :speak_no_evil: </sup></sub>

Closes #10671 , screenies there still apply. To get that Popup, click/tap anywhere in that GPP's row (do we need to communicate that new option somehow??)