### PR TITLE
Allow arbitrary victory types for the purposes of policies

### DIFF
--- a/core/src/com/unciv/logic/civilization/managers/PolicyManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/PolicyManager.kt
@@ -42,7 +42,7 @@ class PolicyManager : IsPartOfGameInfoSerialization {
         get() {
             val value = HashMap<PolicyBranch, Int>()
             for (branch in branches) {
-                value[branch] = branch.priorities[civInfo.getPreferredVictoryType()] ?: 0
+                value[branch] = branch.priorities[civInfo.nation.preferredVictoryType] ?: 0
             }
             return value
         }


### PR DESCRIPTION
This \*should\* have little effect on anything except for any mods giving civs non-standard victory types. In theory, this is not how we should do this; policy choice likely should be separated from victory preference for the most amount of options (hell, Civ 5 doesn't even seem to have victory preferences from my lazy quick glances). In practice, this should be harmless even if victory type was separated from policy preference