### PR TITLE
Fix stats from tileFilter unique not working on improvements

### DIFF
--- a/core/src/com/unciv/logic/map/tile/TileStatFunctions.kt
+++ b/core/src/com/unciv/logic/map/tile/TileStatFunctions.kt
@@ -286,7 +286,7 @@ class TileStatFunctions(val tile: Tile) {
                     improvement.getMatchingUniques(UniqueType.ImprovementStatsOnTile, conditionalState)
 
             for (unique in tileUniques + improvementUniques) {
-                if (improvement.matchesFilter(unique.params[1])
+                if (tile.matchesFilter(unique.params[1])
                         || unique.params[1] == Constants.freshWater && tile.isAdjacentTo(Constants.freshWater)
                         || unique.params[1] == "non-fresh water" && !tile.isAdjacentTo(Constants.freshWater)
                 )


### PR DESCRIPTION
I totally haven't noticed that the Fresh Water line below this on it now redundant. Also, the "non-fresh water" line \*should\* be redundant, but accidentally isn't a tileFilter. I could probably fix that here tbh, it would be functionally unnoticeable, but the question would be should we keep "non-fresh water" for compatibility reasons or should we expect people to update to "non-[Fresh Water]"