### PR TITLE
Change Gdx version for android:texturePacker gradle task

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.badlogicgames.gdx:gdx-tools:1.11.0") {
+    implementation("com.badlogicgames.gdx:gdx-tools:1.12.1") {
         exclude("com.badlogicgames.gdx", "gdx-backend-lwjgl")
     }
 }


### PR DESCRIPTION
Let's close #10726 the simple way.

### May need a github build cache nudge?
### Other devs pulling this (instead of typing it in like I did) may need to kick off a gradle sync manually