### PR TITLE
Show average damage in battle calculations

### DIFF
--- a/core/src/com/unciv/ui/screens/worldscreen/bottombar/BattleTable.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/bottombar/BattleTable.kt
@@ -204,9 +204,11 @@ class BattleTable(val worldScreen: WorldScreen) : Table() {
 
         val maxDamageToDefender = BattleDamage.calculateDamageToDefender(attacker, defender, tileToAttackFrom, 1f)
         val minDamageToDefender = BattleDamage.calculateDamageToDefender(attacker, defender, tileToAttackFrom, 0f)
+        val avgDamageToDefender = arrayOf(maxDamageToDefender, minDamageToDefender).average().roundToInt()
 
         val maxDamageToAttacker = BattleDamage.calculateDamageToAttacker(attacker, defender, tileToAttackFrom, 1f)
         val minDamageToAttacker = BattleDamage.calculateDamageToAttacker(attacker, defender, tileToAttackFrom, 0f)
+        val avgDamageToAttacker = arrayOf(maxDamageToAttacker, minDamageToAttacker).average().roundToInt()
 
         if (attacker.isMelee() &&
                 (defender.isCivilian() || defender is CityCombatant && defender.isDefeated())) {
@@ -230,12 +232,12 @@ class BattleTable(val worldScreen: WorldScreen) : Table() {
             add(getHealthBar(defender.getMaxHealth(), defender.getHealth(), maxRemainingLifeDefender, minRemainingLifeDefender)).row()
 
             if (minRemainingLifeAttacker == attackerHealth) add(attackerHealth.toLabel())
-            else if (maxRemainingLifeAttacker == minRemainingLifeAttacker) add("$attackerHealth → $maxRemainingLifeAttacker".toLabel())
-            else add("$attackerHealth → $minRemainingLifeAttacker-$maxRemainingLifeAttacker".toLabel())
+            else if (maxRemainingLifeAttacker == minRemainingLifeAttacker) add("$attackerHealth → $maxRemainingLifeAttacker ($avgDamageToAttacker)".toLabel())
+            else add("$attackerHealth → $minRemainingLifeAttacker-$maxRemainingLifeAttacker (~$avgDamageToAttacker)".toLabel())
 
 
-            if (minRemainingLifeDefender == maxRemainingLifeDefender) add("$defenderHealth → $maxRemainingLifeDefender".toLabel())
-            else add("$defenderHealth → $minRemainingLifeDefender-$maxRemainingLifeDefender".toLabel())
+            if (minRemainingLifeDefender == maxRemainingLifeDefender) add("$defenderHealth → $maxRemainingLifeDefender ($avgDamageToDefender)".toLabel())
+            else add("$defenderHealth → $minRemainingLifeDefender-$maxRemainingLifeDefender (~$avgDamageToDefender)".toLabel())
         }
 
         row().pad(5f)


### PR DESCRIPTION
Change BattleTable to calulate average damage and show alongside the min and max for easier calculations when planning to attack with multiple units such as when sieging a city

Unfortunately for min-maxers the randomness is still turn dependent for a given defending unit, so the damage randomness will not average out across multiple attacks on a given turn but they will all be more or all be less depending on the luck that turn.