### PR TITLE
Show tied civs and player score in city state competitions

### DIFF
--- a/android/assets/jsons/translations/French.properties
+++ b/android/assets/jsons/translations/French.properties
@@ -172,8 +172,8 @@ Ally = Allié
 
 [questName] (+[influenceAmount] influence) = [questName] (+[influenceAmount] influence)
 [remainingTurns] turns remaining = [remainingTurns] tours restants
-Current leader is [civInfo] with [amount] [stat] generated. = [civInfo] est actuellement en tête et a généré [amount] [stat].
-Current leader is [civInfo] with [amount] Technologies discovered. = [civInfo] est actuellement en tête avec [amount] Technologies découvertes.
+Current leader(s) = Le/Les Leader(s)
+[civInfo] with [value] [valueType] = [civInfo] a [value] [valueType]
 
 Demands = Demandes
 Please don't settle new cities near us. = Veuillez ne pas fonder de villes près de nous.

--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -171,8 +171,8 @@ Ally =
 
 [questName] (+[influenceAmount] influence) = 
 [remainingTurns] turns remaining = 
-Current leader is [civInfo] with [amount] [stat] generated. = 
-Current leader is [civInfo] with [amount] Technologies discovered. = 
+Current leader(s) =
+[civInfo] with [value] [valueType] =
 
 Demands = 
 Please don't settle new cities near us. = 

--- a/core/src/com/unciv/ui/screens/diplomacyscreen/CityStateDiplomacyTable.kt
+++ b/core/src/com/unciv/ui/screens/diplomacyscreen/CityStateDiplomacyTable.kt
@@ -467,7 +467,7 @@ class CityStateDiplomacyTable(private val diplomacyScreen: DiplomacyScreen) {
         if (quest.duration > 0)
             questTable.add("[${remainingTurns}] turns remaining".toLabel()).row()
         if (quest.isGlobal()) {
-            val leaderString = viewingCiv.gameInfo.getCivilization(assignedQuest.assigner).questManager.getLeaderStringForQuest(assignedQuest.questName)
+            val leaderString = viewingCiv.gameInfo.getCivilization(assignedQuest.assigner).questManager.getScoreStringForGlobalQuest(assignedQuest)
             if (leaderString != "")
                 questTable.add(leaderString.toLabel()).row()
         }


### PR DESCRIPTION
Show all leading civilizations in City State global competitions when there is a tie for the lead. Also, show the viewing civ's score, so a player can see how they compare to leaders without having to keep track/calculate in their head.