### PR TITLE
avoid initializing with terrain that shouldn't be naturally generated

### DIFF
--- a/core/src/com/unciv/logic/map/mapgenerator/MapLandmassGenerator.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/MapLandmassGenerator.kt
@@ -28,7 +28,7 @@ class MapLandmassGenerator(val ruleset: Ruleset, val randomness: MapGenerationRa
     companion object {
         // this is called from TileMap constructors as well
         internal fun getInitializationTerrain(ruleset: Ruleset, type: TerrainType) =
-            ruleset.terrains.values.firstOrNull { it.type == type }?.name
+            ruleset.terrains.values.firstOrNull { it.type == type && it.isNaturallyGenerated()}?.name
                 ?: throw Exception("Cannot create map - no $type terrains found!")
     }
 

--- a/core/src/com/unciv/logic/map/mapgenerator/MapLandmassGenerator.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/MapLandmassGenerator.kt
@@ -7,6 +7,7 @@ import com.unciv.logic.map.TileMap
 import com.unciv.logic.map.tile.Tile
 import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.ruleset.tile.TerrainType
+import com.unciv.models.ruleset.unique.UniqueType
 import kotlin.math.abs
 import kotlin.math.max
 import kotlin.math.min
@@ -28,7 +29,7 @@ class MapLandmassGenerator(val ruleset: Ruleset, val randomness: MapGenerationRa
     companion object {
         // this is called from TileMap constructors as well
         internal fun getInitializationTerrain(ruleset: Ruleset, type: TerrainType) =
-            ruleset.terrains.values.firstOrNull { it.type == type && it.isNaturallyGenerated() }?.name
+            ruleset.terrains.values.firstOrNull { it.type == type && !it.hasUnique(UniqueType.NoNaturalGeneration) }?.name
                 ?: throw Exception("Cannot create map - no $type terrains found!")
     }
 

--- a/core/src/com/unciv/logic/map/mapgenerator/MapLandmassGenerator.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/MapLandmassGenerator.kt
@@ -28,7 +28,7 @@ class MapLandmassGenerator(val ruleset: Ruleset, val randomness: MapGenerationRa
     companion object {
         // this is called from TileMap constructors as well
         internal fun getInitializationTerrain(ruleset: Ruleset, type: TerrainType) =
-            ruleset.terrains.values.firstOrNull { it.type == type && it.isNaturallyGenerated()}?.name
+            ruleset.terrains.values.firstOrNull { it.type == type && it.isNaturallyGenerated() }?.name
                 ?: throw Exception("Cannot create map - no $type terrains found!")
     }
 

--- a/core/src/com/unciv/logic/map/mapgenerator/MapLandmassGenerator.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/MapLandmassGenerator.kt
@@ -157,6 +157,7 @@ class MapLandmassGenerator(val ruleset: Ruleset, val randomness: MapGenerationRa
                 var elevation = randomness.getPerlinNoise(tile, elevationSeed)
                 elevation = elevation * (3 / 4f) + getEllipticContinent(tile, tileMap) / 4
                 spawnLandOrWater(tile, elevation)
+                tile.setTerrainTransients() // necessary for assignContinents
             }
 
             tileMap.assignContinents(TileMap.AssignContinentsMode.Reassign)

--- a/core/src/com/unciv/models/ruleset/tile/Terrain.kt
+++ b/core/src/com/unciv/models/ruleset/tile/Terrain.kt
@@ -44,6 +44,8 @@ class Terrain : RulesetStatsObject() {
     // Shouldn't this just be a lazy property so it's automatically cached?
     fun isRough(): Boolean = hasUnique(UniqueType.RoughTerrain)
 
+    fun isNaturallyGenerated(): Boolean = !hasUnique(UniqueType.NoNaturalGeneration)
+
     /** Tests base terrains, features and natural wonders whether they should be treated as Land/Water.
      *  Currently only used for civilopedia display, as other code can test the tile itself.
      */

--- a/core/src/com/unciv/models/ruleset/tile/Terrain.kt
+++ b/core/src/com/unciv/models/ruleset/tile/Terrain.kt
@@ -44,8 +44,6 @@ class Terrain : RulesetStatsObject() {
     // Shouldn't this just be a lazy property so it's automatically cached?
     fun isRough(): Boolean = hasUnique(UniqueType.RoughTerrain)
 
-    fun isNaturallyGenerated(): Boolean = !hasUnique(UniqueType.NoNaturalGeneration)
-
     /** Tests base terrains, features and natural wonders whether they should be treated as Land/Water.
      *  Currently only used for civilopedia display, as other code can test the tile itself.
      */


### PR DESCRIPTION
Someone23 on discord posted a weird bug that they had with their mod, that adds a terrain type named "Impassable", of "Land" type, that has `"impassable": true` and the unique ""Doesn't generate naturally" and that is placed first in the list of terrains https://github.com/prod0ad/Ancient-Total-War/blob/main/jsons/Terrains.json

It caused a freeze when starting a new game with map type pangaea. I found that is because "Doesn't generate naturally" is not actually taken into account when initializing the tilemap, and depending on the ruleset this "Impassable" terrain type was used for all tiles, causing Pangaea generation to run forever because it keeps trying to get 1 continent with > 25 not impassable tiles.

So I change slightly the getInitializationTerrain function to take into account the "Doesn't generate naturally" unique (which is translated in code as "NoNaturalgeneration".

Edit :
I found another somewhat related bug, this time happening without a mod. When doing partial generation of landmass with maptype Pangaea, the game froze, always trying and failing to generate a map with > 25 tiles continent. I think this happens because in MapEditorGenerateTab, when we do a step for landmass, the map is generated with only ocean tiles (MapType.Empty), and after generating the continents in createPangaea, the transients weren't updated, so assignContinents couldn't find any continent. I fix this by adding
`tile.setTerrainTransients() `
to createPangaea so that it can assign continents properly.