### PR TITLE
Stop on Path Blocked

### DIFF
--- a/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
@@ -540,8 +540,10 @@ class MapUnit : IsPartOfGameInfoSerialization {
                 return
             }
             val gotTo = movement.headTowards(destinationTile)
-            if (gotTo == currentTile) { // We didn't move at all, pathway blocked
-                action = null
+            if (gotTo == currentTile) { // We didn't move at all
+                // pathway blocked? Are we still at the same spot as start of turn?
+                if(movementMemories.last().position == currentTile.position)
+                    action = null
                 return
             }
             if (gotTo.position == destinationTile.position) action = null

--- a/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
@@ -540,8 +540,10 @@ class MapUnit : IsPartOfGameInfoSerialization {
                 return
             }
             val gotTo = movement.headTowards(destinationTile)
-            if (gotTo == currentTile) // We didn't move at all
+            if (gotTo == currentTile) { // We didn't move at all, pathway blocked
+                action = null
                 return
+            }
             if (gotTo.position == destinationTile.position) action = null
             if (currentMovement > 0) doAction()
             return


### PR DESCRIPTION
If a unit is trying to move to a tile, and doesn't move this turn, likely path is blocked and we should stop the unit so that it can get new orders