### PR TITLE
Add the remove unit promotion unique

### DIFF
--- a/core/src/com/unciv/logic/map/mapunit/UnitPromotions.kt
+++ b/core/src/com/unciv/logic/map/mapunit/UnitPromotions.kt
@@ -97,10 +97,9 @@ class UnitPromotions : IsPartOfGameInfoSerialization {
 
         if (getPromotions().contains(promotion)) {
             promotions.remove(promotionName)
+            unit.updateUniques()
+            unit.updateVisibleTiles()
         }
-
-        unit.updateUniques()
-        unit.updateVisibleTiles()
     }
 
     private fun doDirectPromotionEffects(promotion: Promotion) {

--- a/core/src/com/unciv/logic/map/mapunit/UnitPromotions.kt
+++ b/core/src/com/unciv/logic/map/mapunit/UnitPromotions.kt
@@ -91,6 +91,18 @@ class UnitPromotions : IsPartOfGameInfoSerialization {
         unit.updateVisibleTiles()  // some promotions/uniques give the unit bonus sight
     }
 
+    fun removePromotion(promotionName: String) {
+        val ruleset = unit.civ.gameInfo.ruleset
+        val promotion = ruleset.unitPromotions[promotionName]!!
+
+        if (getPromotions().contains(promotion)) {
+            promotions.remove(promotionName)
+        }
+
+        unit.updateUniques()
+        unit.updateVisibleTiles()
+    }
+
     private fun doDirectPromotionEffects(promotion: Promotion) {
         for (unique in promotion.uniqueObjects)
             if (unique.conditionalsApply(StateForConditionals(civInfo = unit.civ, unit = unit))

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -809,6 +809,14 @@ object UniqueTriggerActivation {
                     unit.civ.addNotification(notification, unit.getTile().position, NotificationCategory.Units, unit.name)
                 return true
             }
+            UniqueType.OneTimeUnitRemovePromotion -> {
+                val promotion = unit.civ.gameInfo.ruleset.unitPromotions.keys
+                    .firstOrNull { it == unique.params[0]}
+                    ?: return false
+                unit.promotions.removePromotion(promotion)
+                return true
+            }
+
             else -> return triggerCivwideUnique(unique, civInfo = unit.civ, tile=unit.currentTile, triggerNotificationText = triggerNotificationText)
         }
     }

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -734,6 +734,7 @@ enum class UniqueType(
     OneTimeUnitUpgrade("This Unit upgrades for free", UniqueTarget.UnitTriggerable),  // Not used in Vanilla
     OneTimeUnitSpecialUpgrade("This Unit upgrades for free including special upgrades", UniqueTarget.UnitTriggerable),
     OneTimeUnitGainPromotion("This Unit gains the [promotion] promotion", UniqueTarget.UnitTriggerable),  // Not used in Vanilla
+    OneTimeUnitRemovePromotion("This Unit loses the [promotion] promotion", UniqueTarget.UnitTriggerable),
     SkipPromotion("Doing so will consume this opportunity to choose a Promotion", UniqueTarget.Promotion),
     FreePromotion("This Promotion is free", UniqueTarget.Promotion),
 

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -185,6 +185,11 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 	Applicable to: UnitTriggerable
 
+??? example  "This Unit loses the [promotion] promotion"
+	Example: "This Unit loses the [Shock I] promotion"
+
+	Applicable to: UnitTriggerable
+
 ## Global uniques
 !!! note ""
 


### PR DESCRIPTION
Some players and modders asked for this feature, so I decided to implement it to the game. 

I believe it will be useful for modders to make the unit effects that can be removed under certain conditions or unit actions.

If you have some remarks, please share your thoughts in the comments. Constructive feedback welcome
