### PR TITLE
Fix Great Scientist science calculation

### DIFF
--- a/core/src/com/unciv/logic/civilization/managers/TechManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/TechManager.kt
@@ -198,16 +198,8 @@ class TechManager : IsPartOfGameInfoSerialization {
         return (scienceOfLast8Turns.sum() * civInfo.gameInfo.speed.scienceCostModifier).toInt()
     }
 
-    private fun addCurrentScienceToScienceOfLast8Turns() {
-        // The Science the Great Scientist generates does not include Science from Policies, Trade routes and City-States.
-        var allCitiesScience = 0f
-        for (city in civInfo.cities) {
-            val totalBaseScience = city.cityStats.baseStatTree.totalStats.science
-            val totalBonusPercents = city.cityStats.statPercentBonusTree.children.asSequence()
-                .filter { it.key != "Policies" }.map { it.value.totalStats.science }.sum()
-            allCitiesScience += totalBaseScience * totalBonusPercents.toPercent()
-        }
-        scienceOfLast8Turns[civInfo.gameInfo.turns % 8] = allCitiesScience.toInt()
+    private fun addCurrentScienceToScienceOfLast8Turns(science: Int) {
+        scienceOfLast8Turns[civInfo.gameInfo.turns % 8] = science
     }
 
     private fun limitOverflowScience(overflowScience: Int): Int {
@@ -228,7 +220,7 @@ class TechManager : IsPartOfGameInfoSerialization {
     }
 
     fun endTurn(scienceForNewTurn: Int) {
-        addCurrentScienceToScienceOfLast8Turns()
+        addCurrentScienceToScienceOfLast8Turns(scienceForNewTurn)
         if (currentTechnologyName() == null) return
 
         var finalScienceToAdd = scienceForNewTurn

--- a/core/src/com/unciv/logic/civilization/managers/TechManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/TechManager.kt
@@ -201,10 +201,10 @@ class TechManager : IsPartOfGameInfoSerialization {
     private fun addCurrentScienceToScienceOfLast8Turns() {
         // The Science the Great Scientist generates does not include Science from Policies, Trade routes and City-States.
         var allCitiesScience = 0f
-        civInfo.cities.forEach {
-            val totalBaseScience = it.cityStats.baseStatTree.totalStats.science
-            val totalBonusPercents = it.cityStats.statPercentBonusTree.children.asSequence()
-                .filter { it2 -> it2.key != "Policies" }.map { it2 ->  it2.value.totalStats.science }.sum()
+        for (city in civInfo.cities) {
+            val totalBaseScience = city.cityStats.baseStatTree.totalStats.science
+            val totalBonusPercents = city.cityStats.statPercentBonusTree.children.asSequence()
+                .filter { it.key != "Policies" }.map { it.value.totalStats.science }.sum()
             allCitiesScience += totalBaseScience * totalBonusPercents.toPercent()
         }
         scienceOfLast8Turns[civInfo.gameInfo.turns % 8] = allCitiesScience.toInt()


### PR DESCRIPTION
Decided to work on this because of #10721

Reasons for this PR
1. The comment was wrong about ignoring trade route science. Since that is stored in the baseStatTree, it would've been counted anyways. This means the comment alone would've needed to be updated
2. The part about ignoring policies only affected the percentage increase, not the base stat increase, given by policies. Yet again, this would've needed to get an update to the comment to be more accurate
3. Even if it counted the base stats, it is highly inconsistent what actually counts as originating from Policies. For example, the `UniqueType.StatsFromObject` unique does not count as originating from a policy as this unique is instead calculated alongside the object that parms[1] is refering to. A similar story is true for `UniqueType.StatPercentFromObject`. This means the Policies that say `"[+17]% [Science] from every [University]"` or `"[+1 Science] from every [Trading post]"` do not count, but policies like Order's `"[+2 Food, +2 Production, +2 Science, +2 Gold, +2 Culture] [in all cities]"` does
4. For a modder, it's highly puzzling why such a unique would count if it came from a tech or nation, but not a policy. We rarely make such distinctions. Even if this was how Civ 5 actually work, this seems like one of those "smells like a bug" situations that's worth fixing anyways
5. According to the [Civ 5 DLL](https://github.com/Gedemon/Civ5-DLL/blob/aa29e80751f541ae04858b6d2a2c7dcca454201e/CvGameCoreDLL_Expansion2/CvPlayer.cpp#L16706), This function merely gets the last x (x=8 in this case) turns out of the replay data. Meaning it may not be accurate to make these sorts of distinctions. ~~It also has a default of 3 science if that many turns haven't happened yet, not the 0 we assume~~. As such, This PR is likely correcting this to how they work in Civ 5
6. While I haven't mentioned anything about the City State science (which only shows up in a single policy in both of the non modded rulesets), I have doubts we're supposed to ignore this as well. At minimum, if we are, this information should be explained to players