### PR TITLE
Some German translations

### DIFF
--- a/android/assets/jsons/translations/German.properties
+++ b/android/assets/jsons/translations/German.properties
@@ -147,8 +147,7 @@ We will remember this. = Das werden wir nie vergessen!
 
 [civName] has declared war on [targetCivName]! = [civName] hat [targetCivName] den Krieg erklärt!
 [civName] and [targetCivName] have signed a Peace Treaty! = [civName] und [targetCivName] haben einen Friedensvertrag unterzeichnet!
- # Requires translation!
-Declaration of Friendship = 
+Declaration of Friendship = Freundschaftserklärung
 [civName] and [targetCivName] have signed the Declaration of Friendship! = [civName] und [targetCivName] haben die Freundschaftserklärung unterzeichnet!
 [civName] has denounced [targetCivName]! = [civName] hat [targetCivName] angeprangert!
 Do you want to break your promise to [leaderName]? = Möchtest du dein Versprechen gegenüber [leaderName] brechen?
@@ -505,8 +504,7 @@ Except improvements = Außer Verbesserungen
 Base and terrain features = Gelände und -Merkmale
 Base terrain only = Gelände
 Land or water only = Nur Land/Wasser
- # Requires translation!
-Import a Wesnoth map = 
+Import a Wesnoth map = Eine Karte aus Wesnoth imporieren
 
 ## Labels/messages
 Brush ([size]): = Pinsel ([size]):
@@ -538,12 +536,9 @@ Overlay opacity: = Deckungsgrad Überlagerung
 Invalid overlay image = Ungültiges Überlagerungsbild
 World wrap is incompatible with an overlay and was deactivated. = World Wrap ist mit einer Überlagerung nicht kompatibel und wurde deaktiviert.
 An overlay image is incompatible with world wrap and was deactivated. = Ein Überlagerungsbild ist nicht mit dem World Wrap kompatibel und wurde deaktiviert.
- # Requires translation!
-Choose a Wesnoth map file = 
- # Requires translation!
-That map is invalid! = 
- # Requires translation!
-("[code]" does not conform to TerrainCodesWML) = 
+Choose a Wesnoth map file = Wähle eine Wesnoth-Kartendatei
+That map is invalid! = Das ist keine gültige Kartendatei!
+("[code]" does not conform to TerrainCodesWML) = (Element "[code]" ist nicht konform zu TerrainCodesWML)
 
 ## Map/Tool names
 My new map = Meine neue Karte
@@ -756,8 +751,7 @@ Reset = Zurücksetzen
 
 Show zoom buttons in world screen = Zoom-Tasten in der Weltansicht anzeigen
 Experimental Demographics scoreboard = Experimentelle Demographien-Übersicht
- # Requires translation!
-Never close popups by clicking outside = 
+Never close popups by clicking outside = Dialoge nicht durch Klick außerhalb ihrer Fläche schließen
 
 Size of Unitset art in Civilopedia = Größe der Einheitengrafik in der Zivilopädie
 
@@ -804,8 +798,7 @@ Sound = Sound
 Sound effects volume = Lautstärke Soundeffekte
 Music volume = Lautstärke Musik
 City ambient sound volume = Lautstärke der Stadt-Hintergrundgeräusche
- # Requires translation!
-Leader voices volume = 
+Leader voices volume = Lautstärke Stimmen
 Pause between tracks = Pause zwischen den Titeln
 Pause = Pause
 Music = Musik
@@ -826,10 +819,8 @@ Screen orientation = Bildschirmausrichtung
 Landscape (fixed) = Quer (fixiert)
 Portrait (fixed) = Hochkant (fixiert)
 Auto (sensor adjusted) = Auto (durch Sensor justiert)
- # Requires translation!
-Enable using display cutout areas = 
- # Requires translation!
-Hide system status and navigation bars = 
+Enable using display cutout areas = Anzeige im Bereich mit Ausschnitten zulassen
+Hide system status and navigation bars = Status- und Navigationsleisten des Systems ausblenden
 Font family = Schriftart
 Font size multiplier = Schriftgrößen-Multiplikator
 Default Font = Standardschrift
@@ -2602,8 +2593,7 @@ Pan Up Alternate = Nach oben verschieben (alternativ)
 Pan Left Alternate = Nach links verschieben (alternativ)
 Pan Down Alternate = Nach unten verschieben (alternativ)
 Pan Right Alternate = Nach rechts verschieben (alternativ)
- # Requires translation!
-Connect road = 
+Connect road = Straße nach...
 Transform = Transformieren
 Repair = Reparieren
 Add to or remove from queue = Hinzufügen zur oder entfernen aus der Warteschlange
@@ -2625,8 +2615,7 @@ Great People Detail = Große Persönlichkeiten Details
 Specialist Detail = Spezialistendetails
 Religion Detail = Religionsdetails
 Buildings Detail = Gebäudedetails
- # Requires translation!
-Open the Search Dialog = 
+Open the Search Dialog = Suchdialog öffnen
 Confirm Dialog = Dialog bestätigen
 Cancel Dialog = Dialog ablehnen
 Upgrade All = Alle aufrüsten
@@ -4636,8 +4625,7 @@ Tundra = Tundra
 Desert = Wüste
 
 Lakes = Seen
- # Requires translation!
-Lakes provide fresh water to adjacent tiles, allowing farming where it would otherwise not be possible (similar to Rivers and Oases). = 
+Lakes provide fresh water to adjacent tiles, allowing farming where it would otherwise not be possible (similar to Rivers and Oases). = Seen erlauben benachbarten Feldern Zugang zu frischem Wasser wie Flüsse und Oasen. Das erlaubt z.B. Ackerbau wo es sonst nicht möglich wäre.
 Oasis = Oase
 Farm = Farm
 
@@ -4657,8 +4645,7 @@ Only Polders can be built here = Hier können nur Polder gebaut werden
 
 Fallout = Verseucht
 
- # Requires translation!
-Oases provide fresh water to adjacent tiles, allowing farming where it would otherwise not be possible (similar to Rivers and Lakes). = 
+Oases provide fresh water to adjacent tiles, allowing farming where it would otherwise not be possible (similar to Rivers and Lakes). = Oasen erlauben benachbarten Feldern Zugang zu frischem Wasser wie Flüsse und Seen. Das erlaubt z.B. Ackerbau wo es sonst nicht möglich wäre.
 
 Flood plains = Flussaue
 
@@ -4666,16 +4653,11 @@ Ice = Eis
 
 Atoll = Atoll
 
- # Requires translation!
-Rivers exist on tile edges, not as terrain feature per se. = 
- # Requires translation!
-Tiles on both sides gain its benefits. These benefits do not stack. = 
- # Requires translation!
-The tile has access to fresh water, allowing farming where it would otherwise not be possible (similar to Oases and Lakes). = 
- # Requires translation!
-Movement across rivers takes all remaining movement points of a unit unless there is a bridge. = 
- # Requires translation!
-When attacking across a river, the attacker gets a -20% strength malus. = 
+Rivers exist on tile edges, not as terrain feature per se. = Flüsse verlaufen an den Kanten von Feldern und sind daher mit anderen Geländemerkmale nicht vergleichbar.
+Tiles on both sides gain its benefits. These benefits do not stack. = Die Felder auf beiden Seiten erhalten die Wirkung des Flusses, wobei mehrere Fluß-Kanten nur einmal wirken.
+The tile has access to fresh water, allowing farming where it would otherwise not be possible (similar to Oases and Lakes). = Diese Felder sind mit frischem Wasser versorgt. Das erlaubt z.B. Ackerbau wo es sonst nicht möglich wäre.
+Movement across rivers takes all remaining movement points of a unit unless there is a bridge. = Bewegung über einen Fluß hinweg verbraucht alle verbleibenden Bewegungspunkte, es sei denn, dort befindet sich eine Brücke.
+When attacking across a river, the attacker gets a -20% strength malus. = Angriffe über einen Fluß hinweg bestrafen den Angreifer mit -20% Malus.
 Road = Straße
 Amphibious = Amphibisch
 
@@ -4731,8 +4713,7 @@ Requires Engineering to bridge rivers = Erfordert Ingenieurswesen zur Überbrüc
 
 Railroad = Schienen
 Reduces movement cost to ⅒ if the other tile also has a Railroad = Reduziert die Bewegungskosten auf ⅒, wenn das andere Feld ebenfalls eine Schiene hat
- # Requires translation!
-Provides a +25% [Production] bonus to cities connected to the capital by Railroads = 
+Provides a +25% [Production] bonus to cities connected to the capital by Railroads = Städte, die via Eisenbahn mit der Hauptstadt verbunden sind, erhalten einen +25% [Production] Bonus.
 
 Remove Forest = Wald abholzen
 Provides a one-time Production bonus depending on distance to the closest city once finished = Generiert nach der Fertigstellung einen einmaligen Produktionsbonus in Abhängigkeit der Entfernung zur nächstgelegenen Stadt
@@ -6675,40 +6656,23 @@ If you opened the Civilopedia from the main menu, the "Ruleset" will be that of 
 Letters can select categories, and when there are multiple categories matching the same letter, you can press that repeatedly to cycle between these. = Buchstaben können Kategorien auswählen. Wenn mehrere Kategorien mit dem gleichen Buchstaben anfangen, kannst du den Buchstaben wiederholt drücken, um durch diese durchzuwechseln. (Aktuell werden die Buchstaben aus der englischen Version verwendet.)
 The arrow keys allow navigation as well - left/right for categories, up/down for entries. = Die Pfeiltasten können auch zur Navigation verwendet werden. - Links/rechts für Kategorien, hoch/runter für Einträge.
 
- # Requires translation!
-UI Tips = 
- # Requires translation!
-Toggle notification list display = 
- # Requires translation!
-On the World screen, swipe the notification list to the right to temporarily hide it. Click the "Bell" button to display them again. = 
- # Requires translation!
-The default state for the notification list can be set in Options > Display > UI - Notifications on world screen. = 
- # Requires translation!
-Additional controls for the construction queue = 
- # Requires translation!
-Right-click or long press a construction item to open a popup menu with additional controls, allowing to manage production of the same item in all cities, by issuing the commands from the same City screen. = 
- # Requires translation!
-The "Disable" option moves an item to a separated "Disabled" tab, preventing its automatic queueing by the "Auto-assign city production" option. To move a disabled item back to its initial place, enter again the popup menu, and choose "Enable". = 
- # Requires translation!
-Disabled items are set globally and persistent: they are not reset in a new game, or by restarting Unciv. = 
- # Requires translation!
-Queue multiple technologies in different branches = 
- # Requires translation!
-On the Tech screen, right-click or long press a technology to automatically queue it, even if this tech is in another branch than the item currently researched. Prerequisite techs to research will also be automatically queued. = 
- # Requires translation!
-Right-click or long press multiple techs to append them to the research queue, whatever their branch is. = 
- # Requires translation!
-Upgrade multiple units of the same type = 
- # Requires translation!
-On the World screen, select an unit that can be upgraded, then right-click or long press the "Upgrade" button to open a popup menu allowing to upgrade all units of this type at once. = 
- # Requires translation!
-In the Units overview, the same upgrade menu is available by clicking the unit icon in the "Upgrade" column. When an unit is upgradeable, the icon is lit if conditions are met (enough gold and/or resources), otherwise it is dimmed. = 
- # Requires translation!
-Reveal known resources on world screen = 
- # Requires translation!
-In the Resources overview, click on a resource icon to center the world screen on tiles already discovered and providing this resource. = 
- # Requires translation!
-Alternatively, click on the "Unimproved" number to center the world screen only on owned tiles where the resource is not improved. = 
- # Requires translation!
-If more than one tile is available, click repeatedly on the notification to cycle through all of them. = 
-
+UI Tips = Tipps zur Bedienung
+Toggle notification list display = Benachrichtigungen verstecken
+On the World screen, swipe the notification list to the right to temporarily hide it. Click the "Bell" button to display them again. = Auf der Weltansicht kann man die Benachrichtigungen nach rechts schieben oder "wegschubsen" um sie zu verstecken. Wenn sie ganz versteckt sind, erscheint ein Symbol mit einer Glocke, das sie wieder hervorholt.
+The default state for the notification list can be set in Options > Display > UI - Notifications on world screen. = Diese Wahl kann auch in den Optionen unter 'Anzeige - Benutzeroberfläche - Benachrichtigungen auf der Weltansicht' kontrolliert werden.
+Additional controls for the construction queue = Menü für Produktionswarteschlange
+Right-click or long press a construction item to open a popup menu with additional controls, allowing to manage production of the same item in all cities, by issuing the commands from the same City screen. = Ein Rechts-Klick oder langer Druck auf ein angebotenes Bauwerk (oder Einheit) öffnet ein Menü. Dort kann man auch die Produktion in anderen Städten beeinflussen.
+The "Disable" option moves an item to a separated "Disabled" tab, preventing its automatic queueing by the "Auto-assign city production" option. To move a disabled item back to its initial place, enter again the popup menu, and choose "Enable". = Die Option "Deaktivieren" verschiebt den Eintrag und schließt ihn von der automatischen Zuordnung aus. Um ihn wieder zu aktivieren, öffne das selbe Menü erneut aus der gesonderten Kategorie am Ende des Angebots.
+Disabled items are set globally and persistent: they are not reset in a new game, or by restarting Unciv. = Deaktivierte Einträge werden global gespeichert, ein neues Spiel beginnen oder Unciv neu starten bringt sie nicht zurück.
+Queue multiple technologies in different branches = Mehrfache Forschungsziele
+On the Tech screen, right-click or long press a technology to automatically queue it, even if this tech is in another branch than the item currently researched. Prerequisite techs to research will also be automatically queued. = In der Technologien-Ansicht kann man mehrere Forschungsziele nacheinander bestellen, indem man sie rechts-klickt oder lang drückt. 
+Right-click or long press multiple techs to append them to the research queue, whatever their branch is. = Das funktioniert auch für Einträge mit unerforschten Voraussetzungen, diese werden wie üblich mit in die Forschungsziele eingereiht.
+Upgrade multiple units of the same type = Mehrere Einheiten gleichen Typs aufrüsten
+On the World screen, select an unit that can be upgraded, then right-click or long press the "Upgrade" button to open a popup menu allowing to upgrade all units of this type at once. = In der Weltansicht, wenn eine aufrüstbare Einheit selektiert ist, kann man die "Aufrüsten"-Schaltfläche rechts-klicken oder lang drücken für ein Menü, das auch die Aufrüstung aller gleichen Einheiten anbietet.
+In the Units overview, the same upgrade menu is available by clicking the unit icon in the "Upgrade" column. When an unit is upgradeable, the icon is lit if conditions are met (enough gold and/or resources), otherwise it is dimmed. = Es ist dasselbe Menü, das in der Einheiten-Übersicht von der Spalte "Aufrüsten" verwendet wird. Dort ist das Symbol allerdings ausgegraut falls die Aufrüstung im Moment für die betreffende Einheit nicht möglich ist.
+Reveal known resources on world screen = Bekannte Ressourcen auf der Weltansicht zeigen
+In the Resources overview, click on a resource icon to center the world screen on tiles already discovered and providing this resource. = In der Ressource-Übersicht kann man auf das Symbol klicken und erhält eine Benachrichtigung auf der Weltansicht, die bekannte Vorkommen zeigt.
+Alternatively, click on the "Unimproved" number to center the world screen only on owned tiles where the resource is not improved. = Klickt man stattdessen auf die Zahl unter "Unverbessert", bekommt man nur diejenigen gezeigt, die man erschließen könnte, dies aber noch nicht getan ist.
+If more than one tile is available, click repeatedly on the notification to cycle through all of them. = Wie bei den meisten solchen Benachrichtigungen, kann wiederholtes Klicken alle Vorkommen reihum zeigen.
+Entering a city screen quickly = Schneller in die Stadtansicht gelangen
+You can Right-click or long press a city button on the World screen. The result is the same as tapping it twice - once to select and move the button, again to trigger a reaction: show the city screen (if the city is yours to inspect), or offer the foreign city info popup. = Eine Stadt-Schaltfläche auf der Weltansicht rechts-klicken oder lang drücken kürzt ab. Es öffnet die Stadtansicht (wenn es deine Stadt ist oder du Zuschauer bist) oder das Religions-Info-Menü so wie wenn man die Schaltfläche zwei mal klickt.


### PR DESCRIPTION
Seems @Mape6  is pausing... So, since I just PR'ed "Entering a city screen quickly" in #10771, I got roped into doing a few.

I stopped when I dicovered that old bug from nested brackets: `Comment [comment] tiles take [] damage] = ` - I thought we done dat? At least I did the analysis a while ago... It's still Carthage with `"Comment [Units ending their turn on [Mountain] tiles take [50] damage]"`. cuz any closing `]` will end the first `[`'s run...