### PR TITLE
Added an experimental option to cancel AutoPlay immediately

### DIFF
--- a/core/src/com/unciv/models/metadata/GameSettings.kt
+++ b/core/src/com/unciv/models/metadata/GameSettings.kt
@@ -5,12 +5,16 @@ import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.utils.Base64Coder
 import com.unciv.Constants
 import com.unciv.UncivGame
+import com.unciv.logic.GameInfo
+import com.unciv.logic.files.UncivFiles
 import com.unciv.logic.multiplayer.FriendList
 import com.unciv.models.UncivSound
 import com.unciv.ui.components.fonts.FontFamilyData
 import com.unciv.ui.components.fonts.Fonts
 import com.unciv.ui.components.input.KeyboardBindings
+import com.unciv.ui.screens.mainmenuscreen.MainMenuScreen
 import com.unciv.ui.screens.overviewscreen.EmpireOverviewCategories
+import com.unciv.ui.screens.savescreens.QuickSave
 import com.unciv.utils.Display
 import com.unciv.utils.ScreenOrientation
 import java.text.Collator
@@ -335,15 +339,24 @@ class GameSettings {
         var autoPlayPolicies: Boolean = true
         var autoPlayReligion: Boolean = true
         var autoPlayDiplomacy: Boolean = true
+        var imediateAutoPlayCancel: Boolean = false
     
         var turnsToAutoPlay: Int = 0
         var autoPlayTurnInProgress: Boolean = false
     
-        fun startAutoPlay() {
-            turnsToAutoPlay = autoPlayMaxTurns
+        fun startAutoPlay(gameInfo: GameInfo) {
+            if (!isAutoPlaying()) {
+                UncivFiles(Gdx.files).requestAutoSave(gameInfo)
+                turnsToAutoPlay = autoPlayMaxTurns
+            }
         }
         
-        fun stopAutoPlay() {
+        fun stopAutoPlay(game: UncivGame? = null) {
+            if (imediateAutoPlayCancel && game != null && game.worldScreen!!.isNextTurnUpdateRunning()) {
+                // Cancel and load the last save
+                game.worldScreen!!.cancelNextTurn()
+                QuickSave.autoLoadGame(MainMenuScreen())
+            }
             turnsToAutoPlay = 0
             autoPlayTurnInProgress = false
         }

--- a/core/src/com/unciv/ui/popups/options/AutoPlayTab.kt
+++ b/core/src/com/unciv/ui/popups/options/AutoPlayTab.kt
@@ -70,6 +70,13 @@ fun autoPlayTab(
 //    }
 //    if (!settings.autoPlay.fullAutoPlayAI)
 //        addAutoPlaySections()
+
+    optionsPopup.addCheckbox(
+        this,
+        "Cancel AutoPlay immediately (Experimental)",
+        settings.autoPlay.imediateAutoPlayCancel, true
+    ) { settings.autoPlay.imediateAutoPlayCancel = it
+        settings.autoPlay.stopAutoPlay() }
 }
 
 private fun addAutoPlayMaxTurnsSlider(

--- a/core/src/com/unciv/ui/screens/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/WorldScreen.kt
@@ -73,6 +73,7 @@ import com.unciv.utils.launchOnThreadPool
 import com.unciv.utils.withGLContext
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.coroutineScope
+import java.util.concurrent.CancellationException
 
 /**
  * Do not create this screen without seriously thinking about the implications: this is the single most memory-intensive class in the application.
@@ -671,6 +672,16 @@ class WorldScreen(
             startNewScreenJob(gameInfoClone)
         }
     }
+
+    /**
+     * An experimental addition for canceling AutoPlay immediately
+     */
+    fun cancelNextTurn() {
+        if (isNextTurnUpdateRunning()) {
+            nextTurnUpdateJob!!.cancel(CancellationException("Next turn cancel requested"))
+        }
+    }
+
 
     fun switchToNextUnit() {
         // Try to select something new if we already have the next pending unit selected.

--- a/core/src/com/unciv/ui/screens/worldscreen/status/AutoPlayMenu.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/status/AutoPlayMenu.kt
@@ -48,7 +48,7 @@ class AutoPlayMenu(
     }
 
     private fun autoPlay() {
-        settings.autoPlay.startAutoPlay()
+        settings.autoPlay.startAutoPlay(worldScreen.gameInfo)
         nextTurnButton.update()
     }
     

--- a/core/src/com/unciv/ui/screens/worldscreen/status/AutoPlayStatusButton.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/status/AutoPlayStatusButton.kt
@@ -25,14 +25,14 @@ class AutoPlayStatusButton(
         val settings = GUI.getSettings()
         onClick {
             if (settings.autoPlay.isAutoPlaying())
-                settings.autoPlay.stopAutoPlay()
+                settings.autoPlay.stopAutoPlay(worldScreen.game)
             else if (worldScreen.viewingCiv == worldScreen.gameInfo.currentPlayerCiv)
                 AutoPlayMenu(stage,this, nextTurnButton, worldScreen)
         }
         onRightClick {
             if (!worldScreen.gameInfo.gameParameters.isOnlineMultiplayer 
                 && worldScreen.viewingCiv == worldScreen.gameInfo.currentPlayerCiv) {
-                settings.autoPlay.startAutoPlay()
+                settings.autoPlay.startAutoPlay(worldScreen.gameInfo)
                 nextTurnButton.update()
             }
         }
@@ -47,7 +47,7 @@ class AutoPlayStatusButton(
     override fun dispose() {
         val settings = GUI.getSettings()
         if (isPressed && settings.autoPlay.isAutoPlaying()) {
-            settings.autoPlay.stopAutoPlay()
+            settings.autoPlay.stopAutoPlay(worldScreen.game)
         }
     }
 }


### PR DESCRIPTION
Turns can take a while when AutoPlaying in the late game. This PR allows an experimental option to cancel the AutoPlay function immediately instead of waiting for the turn to finish.

The feature is still quite experimental. There is occasionally an error that pops up and a center screen bug. Loading before the save finishes also might be a problem, along with other concurrency issues. However, those occur mainly when stress testing, so it might be okay to implement this feature as an option.

The new option checkbox is not translated because it won't be permanent (is that a good idea?).