### PR TITLE
Randomize seed checkbox

### DIFF
--- a/core/src/com/unciv/ui/screens/mapeditorscreen/tabs/MapEditorGenerateTab.kt
+++ b/core/src/com/unciv/ui/screens/mapeditorscreen/tabs/MapEditorGenerateTab.kt
@@ -66,7 +66,10 @@ class MapEditorGenerateTab(
     }
 
     private fun generate(step: MapGeneratorSteps) {
-        if (step <= MapGeneratorSteps.Landmass && step in seedUsedForStep) {
+        if (step == MapGeneratorSteps.All && newTab.mapParametersTable.randomizeSeed) {
+            newTab.mapParametersTable.reseed()
+        }
+        if (step == MapGeneratorSteps.Landmass && step in seedUsedForStep) {
             // reseed visibly when starting from scratch (new seed shows in advanced settings widget)
             newTab.mapParametersTable.reseed()
             seedUsedForStep -= step
@@ -92,7 +95,7 @@ class MapEditorGenerateTab(
 
         if (step in seedUsedForStep) {
             mapParameters.reseed()
-        } else {
+        } else if (step != MapGeneratorSteps.All){
             seedUsedForStep += step
         }
 

--- a/core/src/com/unciv/ui/screens/newgamescreen/MapParametersTable.kt
+++ b/core/src/com/unciv/ui/screens/newgamescreen/MapParametersTable.kt
@@ -68,6 +68,9 @@ class MapParametersTable(
     // overrides nor is a Widget a data class. Seems to work anyway.
     private val advancedSliders = HashMap<UncivSlider, ()->Float>()
 
+    // used only in map editor (forMapEditor == true)
+    var randomizeSeed = true
+
     init {
         update()
     }
@@ -386,6 +389,20 @@ class MapParametersTable(
                 table.add(button).colspan(2).padTop(10f).row()
         }
 
+        fun addCheckBox(text: String, initialState: Boolean, action: ((Boolean) -> Unit)) {
+            val checkbox = text.toCheckBox(initialState){
+                action(it)
+            }
+            table.add(checkbox).colspan(2).row()
+        }
+        if (forMapEditor) {
+            addCheckBox("Randomize seed", true) {
+                randomizeSeed = it
+                if (randomizeSeed) {
+                    reseed()
+                }
+            }
+        }
         addSlider("Map Elevation", {mapParameters.elevationExponent}, 0.6f, 0.8f)
         { mapParameters.elevationExponent = it }
 

--- a/core/src/com/unciv/ui/screens/newgamescreen/MapParametersTable.kt
+++ b/core/src/com/unciv/ui/screens/newgamescreen/MapParametersTable.kt
@@ -398,9 +398,6 @@ class MapParametersTable(
         if (forMapEditor) {
             addCheckBox("Randomize seed", true) {
                 randomizeSeed = it
-                if (randomizeSeed) {
-                    reseed()
-                }
             }
         }
         addSlider("Map Elevation", {mapParameters.elevationExponent}, 0.6f, 0.8f)


### PR DESCRIPTION
So I noticed something annoying when using the map editor.
When you manually modify the seed and click create, it will work and use the input seed if it is the first time since you opened the map editor, but otherwise it will generate a new random seed just before generating the map. This is because there is code for generating anew when doing partial map generation that also applies to new (MapGeneratorSteps.All) maps. That makes it annoying when you want to use a seed you like.
I tested different solutions

1. Avoid reseed when doing new full generation. This allows to manually choose the seed, but you always need to choose the seed, which is annoying.
2. Same as 1 but add a "Randomize seed" button. This works well but you can't generate new maps every time you click "create" anymore. You have to click "Randomize seed" every time.
3. Reseed after the map is generated rather than before. This allows to manually put your own seed, but when you find by accident a map you like, you can't save its seed anymore.
4. The method I think is best. Same as 1 but add a "Randomize seed" checkbox. This solves all of these problems.

I've tested it on desktop and in an emulator running Android 11.0 and it works.

Here's a screenshot of how the new checkbox looks : 
![image](https://github.com/yairm210/Unciv/assets/7916212/9fda6619-1858-4199-be5c-fb761563f0f3)
