### PR TITLE
Fixed AI continueing to play after all players are defeated

### DIFF
--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -362,11 +362,25 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
 
         val isOnline = gameParameters.isOnlineMultiplayer
 
+        // Skip the player if we are playing hotseat
+        // If all hotseat players are defeated then skip all but the first one
+        fun shouldAutoProcessHotseatPlayer(): Boolean =
+            !isOnline &&
+            player.isDefeated() && (civilizations.any { it.isHuman() && it.isAlive() }
+                || civilizations.first { it.isHuman() } != player)
+        
+        // Skip all spectators and defeated players
+        // If all players are defeated then let the first player control next turn
+        fun shouldAutoProcessOnlinePlayer(): Boolean = 
+            isOnline && (player.isSpectator() || player.isDefeated() && 
+                (civilizations.any { it.isHuman() && it.isAlive() } 
+                    || civilizations.first { it.isHuman() } != player))
+        
         // We process player automatically if:
         while (isSimulation() ||                    // simulation is active
                 player.isAI() ||                    // or player is AI
-                player.isDefeated() ||
-                isOnline && player.isSpectator())      // or player is online spectator
+            shouldAutoProcessHotseatPlayer() ||     // or a player is defeated in hotseat
+            shouldAutoProcessOnlinePlayer())        // or player is online spectator
         {
 
             // Starting preparations
@@ -391,12 +405,12 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
         if (turns == DebugUtils.SIMULATE_UNTIL_TURN)
             DebugUtils.SIMULATE_UNTIL_TURN = 0
 
-        // We found human player, so we are making him current
+        // We found a human player, so we are making them current
         currentTurnStartTime = System.currentTimeMillis()
         currentPlayer = player.civName
         currentPlayerCiv = getCivilization(currentPlayer)
 
-        // Starting his turn
+        // Starting their turn
         TurnManager(player).startTurn(progressBar)
 
         // No popups for spectators


### PR DESCRIPTION
This PR fixes the situation when all players are defeated and the AI will continue playing for an infinite amount of time. The problem appeared after e872f5a, which fixed #10601. The problem prevents the turn of being defeated from being fully processed.

This PR changes that so one player in each round will always be processed even if all players are defeated. It can be a little weird online where you need to re-load the game again to press next turn.

Note that a defeated player still won't see the defeat screen in multiplayer games.

<details><summary>Picture</summary>

![DefeateStall](https://github.com/yairm210/Unciv/assets/7538725/16ebf2d1-3ea8-4937-bfc4-bffa2689f62d)

</details> 

