### PR TITLE
Added AutoPlay until end setting

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -862,6 +862,7 @@ You need to restart the game for this change to take effect. =
 AutoPlay = 
 Show AutoPlay button = 
 Multi-turn AutoPlay amount = 
+AutoPlay until victory = 
 
 Start AutoPlay = 
 AutoPlay End Turn = 

--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -396,12 +396,12 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
         if (turns == DebugUtils.SIMULATE_UNTIL_TURN)
             DebugUtils.SIMULATE_UNTIL_TURN = 0
 
-        // We found human player, so we are making them current
+        // We found human player, so we are making him current
         currentTurnStartTime = System.currentTimeMillis()
         currentPlayer = player.civName
         currentPlayerCiv = getCivilization(currentPlayer)
 
-        // Starting them turn
+        // Starting his turn
         TurnManager(player).startTurn(progressBar)
 
         // No popups for spectators

--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -378,8 +378,13 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
             // Do we need to break if player won?
             if (simulateUntilWin && player.victoryManager.hasWon()) {
                 simulateUntilWin = false
+                UncivGame.Current.settings.autoPlay.stopAutoPlay()
                 break
             }
+            
+            // Do we need to stop AutoPlay?
+            if (UncivGame.Current.settings.autoPlay.isAutoPlaying() && player.victoryManager.hasWon())
+                UncivGame.Current.settings.autoPlay.stopAutoPlay()
 
             // Clean up
             TurnManager(player).endTurn(progressBar)
@@ -391,12 +396,12 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
         if (turns == DebugUtils.SIMULATE_UNTIL_TURN)
             DebugUtils.SIMULATE_UNTIL_TURN = 0
 
-        // We found human player, so we are making him current
+        // We found human player, so we are making them current
         currentTurnStartTime = System.currentTimeMillis()
         currentPlayer = player.civName
         currentPlayerCiv = getCivilization(currentPlayer)
 
-        // Starting his turn
+        // Starting them turn
         TurnManager(player).startTurn(progressBar)
 
         // No popups for spectators

--- a/core/src/com/unciv/models/metadata/GameSettings.kt
+++ b/core/src/com/unciv/models/metadata/GameSettings.kt
@@ -326,6 +326,7 @@ class GameSettings {
 
     class GameSettingsAutoPlay {
         var showAutoPlayButton: Boolean = false
+        var autoPlayUntilEnd: Boolean = false
         var autoPlayMaxTurns = 10
         var fullAutoPlayAI: Boolean = true
         var autoPlayMilitary: Boolean = true

--- a/core/src/com/unciv/ui/popups/options/AutoPlayTab.kt
+++ b/core/src/com/unciv/ui/popups/options/AutoPlayTab.kt
@@ -58,8 +58,19 @@ fun autoPlayTab(
     ) { settings.autoPlay.showAutoPlayButton = it
         settings.autoPlay.stopAutoPlay() }
 
+    
+    optionsPopup.addCheckbox(
+        this,
+        "AutoPlay until victory",
+        settings.autoPlay.autoPlayUntilEnd, false
+    ) { settings.autoPlay.autoPlayUntilEnd = it
+        if (!it) addAutoPlayMaxTurnsSlider(this, settings, optionsPopup.selectBoxMinWidth) 
+        else optionsPopup.tabs.replacePage(optionsPopup.tabs.activePage, autoPlayTab(optionsPopup))}
 
-    addAutoPlayMaxTurnsSlider(this, settings, optionsPopup.selectBoxMinWidth)
+
+    if (!settings.autoPlay.autoPlayUntilEnd)
+        addAutoPlayMaxTurnsSlider(this, settings, optionsPopup.selectBoxMinWidth)
+    
 //    optionsPopup.addCheckbox(
 //        this,
 //        "Full AutoPlay AI",

--- a/core/src/com/unciv/ui/screens/worldscreen/status/NextTurnButton.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/status/NextTurnButton.kt
@@ -38,7 +38,8 @@ class NextTurnButton(
             if (!worldScreen.viewingCiv.isSpectator())
                 TurnManager(worldScreen.viewingCiv).automateTurn()
             worldScreen.nextTurn()
-            settings.autoPlay.turnsToAutoPlay--
+            if (!settings.autoPlay.autoPlayUntilEnd)
+                settings.autoPlay.turnsToAutoPlay--
             settings.autoPlay.autoPlayTurnInProgress = false
         }
                 

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsPillage.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsPillage.kt
@@ -1,6 +1,7 @@
 package com.unciv.ui.screens.worldscreen.unit.actions
 
 import com.unciv.GUI
+import com.unciv.UncivGame
 import com.unciv.logic.civilization.NotificationCategory
 import com.unciv.logic.civilization.NotificationIcon
 import com.unciv.logic.map.mapunit.MapUnit
@@ -18,7 +19,7 @@ object UnitActionsPillage {
     fun getPillageActions(unit: MapUnit, tile: Tile): List<UnitAction> {
         val pillageAction = getPillageAction(unit, tile)
             ?: return listOf()
-        if (pillageAction.action == null || unit.civ.isAI())
+        if (pillageAction.action == null || unit.civ.isAI() || (unit.civ.isHuman() && UncivGame.Current.settings.autoPlay.isAutoPlaying()))
             return listOf(pillageAction)
         else return listOf(UnitAction(UnitActionType.Pillage, pillageAction.title) {
             val pillageText = "Are you sure you want to pillage this [${tile.getImprovementToPillageName()!!}]?"


### PR DESCRIPTION
This PR addresses the feature requested in #10705 by adding a new `AutoPlay until end` setting. When this is turned on, the game will AutoPlay until a victory has been reached. After the victory has been reached, the multiturn AutoPlay will only play one turn unless the `AutoPlay until end` setting has been turned off.

<details><summary>Pictures</summary>

![AutoPlayUntilEnd1](https://github.com/yairm210/Unciv/assets/7538725/33f0090b-1932-4d17-8cbc-95ab46443d6a)
![AutoPlayUntilEnd2](https://github.com/yairm210/Unciv/assets/7538725/865d1a13-3c25-4fea-ab28-aad1b1e1dbf6)



</details> 