### PR TITLE
Another proposal for civ personalities

### DIFF
--- a/core/src/com/unciv/logic/automation/profile/AutomationProfile.kt
+++ b/core/src/com/unciv/logic/automation/profile/AutomationProfile.kt
@@ -2,4 +2,11 @@ package com.unciv.logic.automation.profile
 
 class AutomationProfile {
     val policy = PolicyProfile()
+
+    fun clone():AutomationProfile{
+        val toReturn = AutomationProfile()
+        toReturn.policy.increase = policy.increase.clone() as ArrayList<String>
+        toReturn.policy.decrease = policy.decrease.clone() as ArrayList<String>
+        return toReturn
+    }
 }

--- a/core/src/com/unciv/logic/automation/profile/AutomationProfile.kt
+++ b/core/src/com/unciv/logic/automation/profile/AutomationProfile.kt
@@ -1,0 +1,5 @@
+package com.unciv.logic.automation.profile
+
+class AutomationProfile {
+    val policy = PolicyProfile()
+}

--- a/core/src/com/unciv/logic/automation/profile/AutomationProfile.kt
+++ b/core/src/com/unciv/logic/automation/profile/AutomationProfile.kt
@@ -1,6 +1,9 @@
 package com.unciv.logic.automation.profile
 
-class AutomationProfile {
+import com.unciv.models.ruleset.RulesetObject
+import com.unciv.models.ruleset.unique.UniqueTarget
+
+class AutomationProfile : RulesetObject(){
     val policy = PolicyProfile()
 
     fun clone():AutomationProfile{
@@ -8,5 +11,13 @@ class AutomationProfile {
         toReturn.policy.increase = policy.increase.clone() as ArrayList<String>
         toReturn.policy.decrease = policy.decrease.clone() as ArrayList<String>
         return toReturn
+    }
+
+    override fun getUniqueTarget(): UniqueTarget {
+        TODO("Not yet implemented")
+    }
+
+    override fun makeLink(): String {
+        TODO("Not yet implemented")
     }
 }

--- a/core/src/com/unciv/logic/automation/profile/PolicyProfile.kt
+++ b/core/src/com/unciv/logic/automation/profile/PolicyProfile.kt
@@ -7,6 +7,7 @@ class PolicyProfile {
     var decrease = ArrayList<String>()
 
     fun getPriotiyModifier(policy: PolicyBranch): Int {
+        //Half the value of the most basic policy priority
         if (increase.contains(policy.name))
             return 5
         if (decrease.contains(policy.name))

--- a/core/src/com/unciv/logic/automation/profile/PolicyProfile.kt
+++ b/core/src/com/unciv/logic/automation/profile/PolicyProfile.kt
@@ -1,6 +1,16 @@
 package com.unciv.logic.automation.profile
 
+import com.unciv.models.ruleset.PolicyBranch
+
 class PolicyProfile {
-    val increase = ArrayList<String>()
-    val decrease = ArrayList<String>()
+    var increase = ArrayList<String>()
+    var decrease = ArrayList<String>()
+
+    fun getPriotiyModifier(policy: PolicyBranch): Int {
+        if (increase.contains(policy.name))
+            return 1
+        if (decrease.contains(policy.name))
+            return -1
+        return 0
+    }
 }

--- a/core/src/com/unciv/logic/automation/profile/PolicyProfile.kt
+++ b/core/src/com/unciv/logic/automation/profile/PolicyProfile.kt
@@ -1,0 +1,6 @@
+package com.unciv.logic.automation.profile
+
+class PolicyProfile {
+    val increase = ArrayList<String>()
+    val decrease = ArrayList<String>()
+}

--- a/core/src/com/unciv/logic/automation/profile/PolicyProfile.kt
+++ b/core/src/com/unciv/logic/automation/profile/PolicyProfile.kt
@@ -8,9 +8,9 @@ class PolicyProfile {
 
     fun getPriotiyModifier(policy: PolicyBranch): Int {
         if (increase.contains(policy.name))
-            return 1
+            return 5
         if (decrease.contains(policy.name))
-            return -1
+            return -5
         return 0
     }
 }

--- a/core/src/com/unciv/logic/civilization/Civilization.kt
+++ b/core/src/com/unciv/logic/civilization/Civilization.kt
@@ -707,7 +707,7 @@ class Civilization : IsPartOfGameInfoSerialization {
         hasLongCountDisplayUnique = hasUnique(UniqueType.MayanCalendarDisplay)
 
         tacticalAI.init(this)
-        profile = findAutomationProfile()
+        profile = findAutomationProfile()?: AutomationProfile()
 
         cache.setTransients()
     }
@@ -718,16 +718,13 @@ class Civilization : IsPartOfGameInfoSerialization {
     Then for a profile called default
     If none is found, returns an empty profile
      */
-    private fun findAutomationProfile():AutomationProfile{
+    private fun findAutomationProfile():AutomationProfile?{
         //There is propably a less ugly way to do this
         var profile = gameInfo.ruleset.automationProfiles[nation.profileName]
         if(profile == null){
             profile = gameInfo.ruleset.automationProfiles[civName]
-            if (profile == null){
+            if (profile == null && !nation.isBarbarian){
                 profile = gameInfo.ruleset.automationProfiles["Default"]
-                if (profile == null){
-                    profile = AutomationProfile()
-                }
             }
         }
 

--- a/core/src/com/unciv/logic/civilization/Civilization.kt
+++ b/core/src/com/unciv/logic/civilization/Civilization.kt
@@ -268,6 +268,7 @@ class Civilization : IsPartOfGameInfoSerialization {
         toReturn.ruinsManager = ruinsManager.clone()
         toReturn.espionageManager = espionageManager.clone()
         toReturn.victoryManager = victoryManager.clone()
+        toReturn.profile = profile.clone()
         toReturn.allyCivName = allyCivName
         for (diplomacyManager in diplomacy.values.map { it.clone() })
             toReturn.diplomacy[diplomacyManager.otherCivName] = diplomacyManager

--- a/core/src/com/unciv/logic/civilization/Civilization.kt
+++ b/core/src/com/unciv/logic/civilization/Civilization.kt
@@ -8,6 +8,7 @@ import com.unciv.logic.IsPartOfGameInfoSerialization
 import com.unciv.logic.MultiFilter
 import com.unciv.logic.UncivShowableException
 import com.unciv.logic.automation.ai.TacticalAI
+import com.unciv.logic.automation.profile.AutomationProfile
 import com.unciv.logic.automation.unit.WorkerAutomation
 import com.unciv.logic.city.City
 import com.unciv.logic.city.managers.CityFounder
@@ -89,7 +90,7 @@ class Civilization : IsPartOfGameInfoSerialization {
 
     @Transient
     val units = UnitManager(this)
-    
+
     @Transient
     var threatManager = ThreatManager(this)
 
@@ -161,6 +162,7 @@ class Civilization : IsPartOfGameInfoSerialization {
 
     /* AI section */
     val tacticalAI = TacticalAI()
+    var profile = AutomationProfile()
 
     var notifications = ArrayList<Notification>()
 

--- a/core/src/com/unciv/logic/civilization/Civilization.kt
+++ b/core/src/com/unciv/logic/civilization/Civilization.kt
@@ -162,6 +162,8 @@ class Civilization : IsPartOfGameInfoSerialization {
 
     /* AI section */
     val tacticalAI = TacticalAI()
+
+    @Transient
     var profile = AutomationProfile()
 
     var notifications = ArrayList<Notification>()
@@ -705,8 +707,31 @@ class Civilization : IsPartOfGameInfoSerialization {
         hasLongCountDisplayUnique = hasUnique(UniqueType.MayanCalendarDisplay)
 
         tacticalAI.init(this)
+        profile = findAutomationProfile()
 
         cache.setTransients()
+    }
+
+    /*
+    Looks for a profile with the name set in nation
+    Then for a profile with this civ name
+    Then for a profile called default
+    If none is found, returns an empty profile
+     */
+    private fun findAutomationProfile():AutomationProfile{
+        //There is propably a less ugly way to do this
+        var profile = gameInfo.ruleset.automationProfiles[nation.profileName]
+        if(profile == null){
+            profile = gameInfo.ruleset.automationProfiles[civName]
+            if (profile == null){
+                profile = gameInfo.ruleset.automationProfiles["Default"]
+                if (profile == null){
+                    profile = AutomationProfile()
+                }
+            }
+        }
+
+        return profile
     }
 
 

--- a/core/src/com/unciv/logic/civilization/Civilization.kt
+++ b/core/src/com/unciv/logic/civilization/Civilization.kt
@@ -707,7 +707,7 @@ class Civilization : IsPartOfGameInfoSerialization {
         hasLongCountDisplayUnique = hasUnique(UniqueType.MayanCalendarDisplay)
 
         tacticalAI.init(this)
-        profile = findAutomationProfile()?: AutomationProfile()
+        //profile = findAutomationProfile()?: AutomationProfile()
 
         cache.setTransients()
     }

--- a/core/src/com/unciv/logic/civilization/Civilization.kt
+++ b/core/src/com/unciv/logic/civilization/Civilization.kt
@@ -715,7 +715,7 @@ class Civilization : IsPartOfGameInfoSerialization {
     /*
     Looks for a profile with the name set in nation
     Then for a profile with this civ name
-    Then for a profile called default
+    Then for a profile called Default
     If none is found, returns an empty profile
      */
     private fun findAutomationProfile():AutomationProfile?{

--- a/core/src/com/unciv/logic/civilization/managers/PolicyManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/PolicyManager.kt
@@ -42,7 +42,8 @@ class PolicyManager : IsPartOfGameInfoSerialization {
         get() {
             val value = HashMap<PolicyBranch, Int>()
             for (branch in branches) {
-                value[branch] = branch.priorities[civInfo.nation.preferredVictoryType] ?: 0
+                value[branch] = branch.priorities[civInfo.nation.preferredVictoryType] ?: 0 + civInfo.profile.policy.getPriotiyModifier(branch)
+
             }
             return value
         }

--- a/core/src/com/unciv/logic/civilization/managers/PolicyManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/PolicyManager.kt
@@ -42,7 +42,8 @@ class PolicyManager : IsPartOfGameInfoSerialization {
         get() {
             val value = HashMap<PolicyBranch, Int>()
             for (branch in branches) {
-                value[branch] = branch.priorities[civInfo.nation.preferredVictoryType] ?: 0 + civInfo.profile.policy.getPriotiyModifier(branch)
+                value[branch] = branch.priorities[civInfo.nation.preferredVictoryType] ?: 0
+                value[branch] = value[branch]!! + civInfo.profile.policy.getPriotiyModifier(branch)
 
             }
             return value

--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -4,6 +4,7 @@ import com.badlogic.gdx.files.FileHandle
 import com.unciv.json.fromJsonFile
 import com.unciv.json.json
 import com.unciv.logic.BackwardCompatibility.updateDeprecations
+import com.unciv.logic.automation.profile.AutomationProfile
 import com.unciv.models.metadata.BaseRuleset
 import com.unciv.models.ruleset.nation.CityStateType
 import com.unciv.models.ruleset.nation.Difficulty
@@ -68,6 +69,7 @@ class Ruleset {
     val unitTypes = LinkedHashMap<String, UnitType>()
     var victories = LinkedHashMap<String, Victory>()
     var cityStateTypes = LinkedHashMap<String, CityStateType>()
+    val automationProfiles = LinkedHashMap<String, AutomationProfile>()
 
     val mods = LinkedHashSet<String>()
     var modOptions = ModOptions()

--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -132,6 +132,7 @@ class Ruleset {
         unitTypes.putAll(ruleset.unitTypes)
         victories.putAll(ruleset.victories)
         cityStateTypes.putAll(ruleset.cityStateTypes)
+        automationProfiles.putAll(ruleset.automationProfiles)
         ruleset.modOptions.unitsToRemove
             .flatMap { unitToRemove ->
                 units.filter { it.apply { value.ruleset = this@Ruleset }.value.matchesFilter(unitToRemove) }.keys
@@ -172,6 +173,7 @@ class Ruleset {
         unitTypes.clear()
         victories.clear()
         cityStateTypes.clear()
+        automationProfiles.clear()
     }
 
     fun allRulesetObjects(): Sequence<IRulesetObject> =
@@ -194,7 +196,8 @@ class Ruleset {
             tileResources.values.asSequence() +
             unitPromotions.values.asSequence() +
             units.values.asSequence() +
-            unitTypes.values.asSequence()
+            unitTypes.values.asSequence() +
+            automationProfiles.values.asSequence()
             // Victories is only INamed
     fun allIHasUniques(): Sequence<IHasUniques> =
             allRulesetObjects() + sequenceOf(modOptions)
@@ -352,6 +355,11 @@ class Ruleset {
         val cityStateTypesFile = folderHandle.child("CityStateTypes.json")
         if (cityStateTypesFile.exists()) {
             cityStateTypes += createHashmap(json().fromJsonFile(Array<CityStateType>::class.java, cityStateTypesFile))
+        }
+
+        val automationProfilesFile = folderHandle.child("AutomationProfiles.json")
+        if (automationProfilesFile.exists()) {
+            automationProfiles += createHashmap(json().fromJsonFile(Array<AutomationProfile>::class.java, automationProfilesFile))
         }
 
 

--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -132,7 +132,7 @@ class Ruleset {
         unitTypes.putAll(ruleset.unitTypes)
         victories.putAll(ruleset.victories)
         cityStateTypes.putAll(ruleset.cityStateTypes)
-        automationProfiles.putAll(ruleset.automationProfiles)
+        //automationProfiles.putAll(ruleset.automationProfiles)
         ruleset.modOptions.unitsToRemove
             .flatMap { unitToRemove ->
                 units.filter { it.apply { value.ruleset = this@Ruleset }.value.matchesFilter(unitToRemove) }.keys
@@ -173,7 +173,7 @@ class Ruleset {
         unitTypes.clear()
         victories.clear()
         cityStateTypes.clear()
-        automationProfiles.clear()
+        //automationProfiles.clear()
     }
 
     fun allRulesetObjects(): Sequence<IRulesetObject> =
@@ -196,8 +196,8 @@ class Ruleset {
             tileResources.values.asSequence() +
             unitPromotions.values.asSequence() +
             units.values.asSequence() +
-            unitTypes.values.asSequence() +
-            automationProfiles.values.asSequence()
+            unitTypes.values.asSequence()
+            //automationProfiles.values.asSequence()
             // Victories is only INamed
     fun allIHasUniques(): Sequence<IHasUniques> =
             allRulesetObjects() + sequenceOf(modOptions)
@@ -357,10 +357,10 @@ class Ruleset {
             cityStateTypes += createHashmap(json().fromJsonFile(Array<CityStateType>::class.java, cityStateTypesFile))
         }
 
-        val automationProfilesFile = folderHandle.child("AutomationProfiles.json")
+        /*val automationProfilesFile = folderHandle.child("AutomationProfiles.json")
         if (automationProfilesFile.exists()) {
             automationProfiles += createHashmap(json().fromJsonFile(Array<AutomationProfile>::class.java, automationProfilesFile))
-        }
+        }*/
 
 
 

--- a/core/src/com/unciv/models/ruleset/nation/Nation.kt
+++ b/core/src/com/unciv/models/ruleset/nation/Nation.kt
@@ -64,6 +64,8 @@ class Nation : RulesetObject() {
 
     var cities: ArrayList<String> = arrayListOf()
 
+    var profileName = ""
+
     override fun getUniqueTarget() = UniqueTarget.Nation
 
     @Transient


### PR DESCRIPTION
This a proposal to implement personalities trying to avoid the pitfalls of #10717, namely that it was too convoluted and defined a behaviour the AI could not execute correctly. So, this one tries to be simpler and start from the fundamental block of policy rather than more complex decisions.

Instead of defining possibly dozens of numbers in Nations that may or may not mean what they seem, you define an AutomationProfile in a separate JSON, listing what to increase and what to decrease, with properties defined in a Profile class for each major area. Those modifiers operate in the very same way as victory focus does but with half the strength, serving as tiebreakers but mostly not overriding the victory focus. 

Civs receive the profile that has the name indicated in a profileName property in Nations, or has the same name as the civ, or is called Default, in that order. This allows for a single profile to be applied to multiple civs and for mods to manipulate all civs with a single profile. 

This PR only implements policy, but, if accepted, research and buildings will be done in the very same way. 

Left the readings from JSON commented because what it should be called or wether it should be a separate file at all is probaly to be decided by someone who knows better. 