### PR TITLE
Fix stat on tile uniques doubling on improvement tiles

### DIFF
--- a/core/src/com/unciv/logic/map/tile/TileStatFunctions.kt
+++ b/core/src/com/unciv/logic/map/tile/TileStatFunctions.kt
@@ -280,10 +280,6 @@ class TileStatFunctions(val tile: Tile) {
         val stats = Stats()
 
         fun statsFromTiles() {
-            for (unique in uniqueCache.forCityGetMatchingUniques(city, UniqueType.StatsFromTiles, conditionalState)
-                .filter { city.matchesFilter(it.params[2]) && improvement.matchesFilter(it.params[1]) })
-                stats.add(unique.stats)
-
             for (unique in improvement.getMatchingUniques(UniqueType.ImprovementStatsOnTile, conditionalState)) {
                 if (tile.matchesFilter(unique.params[1])
                         || unique.params[1] == Constants.freshWater && tile.isAdjacentTo(Constants.freshWater)
@@ -295,11 +291,10 @@ class TileStatFunctions(val tile: Tile) {
         statsFromTiles()
 
         fun statsFromObject() {
-            val uniques = uniqueCache.forCityGetMatchingUniques(
-                    city,
-                    UniqueType.StatsFromObject,
-                    conditionalState
-                )
+            val uniques = uniqueCache.forCityGetMatchingUniques(city, 
+                UniqueType.StatsFromObject, conditionalState) +
+                uniqueCache.forCityGetMatchingUniques(city,
+                    UniqueType.StatsFromTiles, conditionalState).filter { city.matchesFilter(it.params[2]) }
             for (unique in uniques) {
                 if (improvement.matchesFilter(unique.params[1])) {
                     stats.add(unique.stats)

--- a/core/src/com/unciv/logic/map/tile/TileStatFunctions.kt
+++ b/core/src/com/unciv/logic/map/tile/TileStatFunctions.kt
@@ -280,12 +280,11 @@ class TileStatFunctions(val tile: Tile) {
         val stats = Stats()
 
         fun statsFromTiles() {
-            val tileUniques = uniqueCache.forCityGetMatchingUniques(city, UniqueType.StatsFromTiles, conditionalState)
-                .filter { city.matchesFilter(it.params[2]) }
-            val improvementUniques =
-                    improvement.getMatchingUniques(UniqueType.ImprovementStatsOnTile, conditionalState)
+            for (unique in uniqueCache.forCityGetMatchingUniques(city, UniqueType.StatsFromTiles, conditionalState)
+                .filter { city.matchesFilter(it.params[2]) && improvement.matchesFilter(it.params[1]) })
+                stats.add(unique.stats)
 
-            for (unique in tileUniques + improvementUniques) {
+            for (unique in improvement.getMatchingUniques(UniqueType.ImprovementStatsOnTile, conditionalState)) {
                 if (tile.matchesFilter(unique.params[1])
                         || unique.params[1] == Constants.freshWater && tile.isAdjacentTo(Constants.freshWater)
                         || unique.params[1] == "non-fresh water" && !tile.isAdjacentTo(Constants.freshWater)


### PR DESCRIPTION
Note: this functionality is already covered on a more general basis by line 34. The whole point of "statFromTiles" here is to catch improvements as if it was a tileFilter, since line 34 only catches terrainFilters. The reason these aren't caught together is so we can increase the modifiers on them separately