### PR TITLE
Avoid crash if "Only available" unique in policy branch has 2 or more params

### DIFF
--- a/core/src/com/unciv/ui/screens/pickerscreens/PolicyPickerScreen.kt
+++ b/core/src/com/unciv/ui/screens/pickerscreens/PolicyPickerScreen.kt
@@ -302,8 +302,8 @@ class PolicyPickerScreen(
 
             if (branch.uniqueMap.getUniques(UniqueType.OnlyAvailableWhen).any()) {
                 var warning = UniqueType.OnlyAvailableWhen.text.tr() + ":\n"
-                for (k in branch.uniqueMap.getUniques(UniqueType.OnlyAvailableWhen))
-                    for (conditional in k.conditionals) {
+                for (unique in branch.uniqueMap.getUniques(UniqueType.OnlyAvailableWhen))
+                    for (conditional in unique.conditionals) {
                         warning += "• " + conditional.text.tr() + "\n"
                     }
                 val warningLabel = ColorMarkupLabel(warning, Color.RED, fontSize = 13)

--- a/core/src/com/unciv/ui/screens/pickerscreens/PolicyPickerScreen.kt
+++ b/core/src/com/unciv/ui/screens/pickerscreens/PolicyPickerScreen.kt
@@ -15,7 +15,6 @@ import com.unciv.models.ruleset.Policy
 import com.unciv.models.ruleset.Policy.PolicyBranchType
 import com.unciv.models.ruleset.PolicyBranch
 import com.unciv.models.ruleset.unique.UniqueType
-import com.unciv.models.translations.fillPlaceholders
 import com.unciv.models.translations.tr
 import com.unciv.ui.components.extensions.addSeparator
 import com.unciv.ui.components.extensions.center
@@ -301,23 +300,12 @@ class PolicyPickerScreen(
             label.wrap = true
             labelTable.add(label).pad(7f, 20f, 10f, 20f).grow().row()
 
-            val conditionals = LinkedHashMap<UniqueType, ArrayList<String>>()
-
-            for(unique in branch.uniqueMap.getUniques(UniqueType.OnlyAvailableWhen)) {
-                for (conditional in unique.conditionals) {
-                    if (conditional.type != null) {
-                        if (conditionals[conditional.type] == null)
-                            conditionals[conditional.type] = ArrayList()
-                        conditionals[conditional.type]!!.add(conditional.params.toString().tr())
-                    }
-                }
-            }
-
-            if (conditionals.isNotEmpty()) {
+            if (branch.uniqueMap.getUniques(UniqueType.OnlyAvailableWhen).any()) {
                 var warning = UniqueType.OnlyAvailableWhen.text.tr() + ":\n"
-                for ((k, v) in conditionals) {
-                    warning += "• " + k.text.fillPlaceholders(v.joinToString()).tr() + "\n"
-                }
+                for (k in branch.uniqueMap.getUniques(UniqueType.OnlyAvailableWhen))
+                    for (conditional in k.conditionals) {
+                        warning += "• " + conditional.text.tr() + "\n"
+                    }
                 val warningLabel = ColorMarkupLabel(warning, Color.RED, fontSize = 13)
                 warningLabel.setAlignment(Align.topLeft)
                 warningLabel.wrap = true

--- a/core/src/com/unciv/ui/screens/pickerscreens/PolicyPickerScreen.kt
+++ b/core/src/com/unciv/ui/screens/pickerscreens/PolicyPickerScreen.kt
@@ -303,12 +303,12 @@ class PolicyPickerScreen(
 
             val conditionals = LinkedHashMap<UniqueType, ArrayList<String>>()
 
-            branch.uniqueMap[UniqueType.OnlyAvailableWhen.text]?.forEach { unique ->
-                unique.conditionals.forEach {
-                    if (it.type != null) {
-                        if (conditionals[it.type] == null)
-                            conditionals[it.type] = ArrayList()
-                        conditionals[it.type]!!.add(it.params.toString().tr())
+            for(unique in branch.uniqueMap.getUniques(UniqueType.OnlyAvailableWhen)) {
+                for (conditional in unique.conditionals) {
+                    if (conditional.type != null) {
+                        if (conditionals[conditional.type] == null)
+                            conditionals[conditional.type] = ArrayList()
+                        conditionals[conditional.type]!!.add(conditional.params.toString().tr())
                     }
                 }
             }


### PR DESCRIPTION
The idea: currently, we render this unique a special way on the screen for branches. We do this by combining the params into one super conditional and displaying the conditional types separately. An example would be as so:
![Screenshot 1](https://github.com/yairm210/Unciv/assets/127357473/c09c547b-61ce-4854-841c-d5a1d5854dda)
This has some issues. The lesser issue is that there's no guarantee the resulting text looks particularly well. For example, `<with [Iron> <with [Horse]>` reads as `with [Iron], [Horse]`, which... is fine, I guess, but not amazing to look at. The larger issue is that the translation engine crashes if it reads a conditional with more than 2 params, as we currently hand the translation engine the string all of the params in 1 string instead of as a sequence of multiple strings like the translation engine expects.

This PR changes the behavior slightly. It still has a special way of showing its contents, but now it separates each conditional separately, even if they have the same type, as such:
![Screenshot 2](https://github.com/yairm210/Unciv/assets/127357473/b0516ba5-d6a7-4688-a5c8-318fae0a217f)
This technically gives a different look as before (particularly for Freedom/Order/Autocracy), but it avoids the crash entirely by simply showing the whole conditional without compromises