### PR TITLE
AI doesn't counter offer and request a defesive pact, open borders or research pact at the same time

### DIFF
--- a/core/src/com/unciv/logic/automation/civilization/DiplomacyAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/DiplomacyAutomation.kt
@@ -98,10 +98,7 @@ object DiplomacyAutomation {
                 && it.hasUnique(UniqueType.EnablesOpenBorders)
                 && !civInfo.getDiplomacyManager(it).hasOpenBorders
                 && !civInfo.getDiplomacyManager(it).hasFlag(DiplomacyFlags.DeclinedOpenBorders)
-                && !civInfo.tradeRequests.filter { request -> request.requestingCiv == it.civName }
-                    .any { trade -> trade.trade.ourOffers.any { offer -> offer.name == Constants.openBorders }}
-                && !civInfo.tradeRequests.filter { request -> request.requestingCiv == it.civName }
-                    .any { trade -> trade.trade.theirOffers.any { offer -> offer.name == Constants.openBorders }}
+                && !isTradeBeingOffered(civInfo, it, Constants.openBorders)
             }
             
             .sortedByDescending { it.getDiplomacyManager(civInfo).relationshipLevel() }.toList()
@@ -140,8 +137,7 @@ object DiplomacyAutomation {
             .filter {
                 civInfo.diplomacyFunctions.canSignResearchAgreementsWith(it)
                     && !civInfo.getDiplomacyManager(it).hasFlag(DiplomacyFlags.DeclinedResearchAgreement)
-                    && !civInfo.tradeRequests.filter { request -> request.requestingCiv == it.civName }
-                        .any { trade -> trade.trade.ourOffers.any { offer -> offer.name == Constants.researchAgreement }}
+                    && !isTradeBeingOffered(civInfo, it, Constants.researchAgreement)
             }
             .sortedByDescending { it.stats.statsForNextTurn.science }
 
@@ -165,8 +161,7 @@ object DiplomacyAutomation {
                 civInfo.diplomacyFunctions.canSignDefensivePactWith(it)
                     && !civInfo.getDiplomacyManager(it).hasFlag(DiplomacyFlags.DeclinedDefensivePact)
                     && civInfo.getDiplomacyManager(it).relationshipIgnoreAfraid() == RelationshipLevel.Ally
-                    && !civInfo.tradeRequests.filter { request -> request.requestingCiv == it.civName }
-                        .any { trade -> trade.trade.ourOffers.any { offer -> offer.name == Constants.defensivePact }}
+                    && !isTradeBeingOffered(civInfo, it, Constants.defensivePact)
             }
 
         for (otherCiv in canSignDefensivePactCiv) {
@@ -311,4 +306,10 @@ object DiplomacyAutomation {
         }
     }
 
+    private fun isTradeBeingOffered(civInfo: Civilization, otherCiv: Civilization, offerName:String): Boolean {
+        return civInfo.tradeRequests.filter { request -> request.requestingCiv == otherCiv.civName }
+            .any { trade -> trade.trade.ourOffers.any { offer -> offer.name == offerName }}
+            || civInfo.tradeRequests.filter { request -> request.requestingCiv == otherCiv.civName }
+            .any { trade -> trade.trade.theirOffers.any { offer -> offer.name == offerName }}
+    }
 }

--- a/core/src/com/unciv/logic/automation/civilization/DiplomacyAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/DiplomacyAutomation.kt
@@ -97,7 +97,13 @@ object DiplomacyAutomation {
             .filter { it.isMajorCiv() && !civInfo.isAtWarWith(it)
                 && it.hasUnique(UniqueType.EnablesOpenBorders)
                 && !civInfo.getDiplomacyManager(it).hasOpenBorders
-                && !civInfo.getDiplomacyManager(it).hasFlag(DiplomacyFlags.DeclinedOpenBorders) }
+                && !civInfo.getDiplomacyManager(it).hasFlag(DiplomacyFlags.DeclinedOpenBorders)
+                && !civInfo.tradeRequests.filter { request -> request.requestingCiv == it.civName }
+                    .any { trade -> trade.trade.ourOffers.any { offer -> offer.name == Constants.openBorders }}
+                && !civInfo.tradeRequests.filter { request -> request.requestingCiv == it.civName }
+                    .any { trade -> trade.trade.theirOffers.any { offer -> offer.name == Constants.openBorders }}
+            }
+            
             .sortedByDescending { it.getDiplomacyManager(civInfo).relationshipLevel() }.toList()
         for (otherCiv in civsThatWeCanOpenBordersWith) {
             // Default setting is 3, this will be changed according to different civ.
@@ -134,6 +140,8 @@ object DiplomacyAutomation {
             .filter {
                 civInfo.diplomacyFunctions.canSignResearchAgreementsWith(it)
                     && !civInfo.getDiplomacyManager(it).hasFlag(DiplomacyFlags.DeclinedResearchAgreement)
+                    && !civInfo.tradeRequests.filter { request -> request.requestingCiv == it.civName }
+                        .any { trade -> trade.trade.ourOffers.any { offer -> offer.name == Constants.researchAgreement }}
             }
             .sortedByDescending { it.stats.statsForNextTurn.science }
 
@@ -157,6 +165,8 @@ object DiplomacyAutomation {
                 civInfo.diplomacyFunctions.canSignDefensivePactWith(it)
                     && !civInfo.getDiplomacyManager(it).hasFlag(DiplomacyFlags.DeclinedDefensivePact)
                     && civInfo.getDiplomacyManager(it).relationshipIgnoreAfraid() == RelationshipLevel.Ally
+                    && !civInfo.tradeRequests.filter { request -> request.requestingCiv == it.civName }
+                        .any { trade -> trade.trade.ourOffers.any { offer -> offer.name == Constants.defensivePact }}
             }
 
         for (otherCiv in canSignDefensivePactCiv) {


### PR DESCRIPTION
This PR fixes  #10822 by having the AI search through the pending trades for defensive pact, open borders or research pact when determining if they are eligible to offer it to the player.