### PR TITLE
Trigger 'capture city' as a unit trigger

### DIFF
--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -2,7 +2,6 @@ package com.unciv.logic.battle
 
 import com.badlogic.gdx.math.Vector2
 import com.unciv.Constants
-import com.unciv.GUI
 import com.unciv.UncivGame
 import com.unciv.logic.automation.civilization.NextTurnAutomation
 import com.unciv.logic.city.City
@@ -546,7 +545,7 @@ object Battle {
 
         for (unique in attackerCiv.getTriggeredUniques(UniqueType.TriggerUponConqueringCity, stateForConditionals)
                 + attacker.unit.getTriggeredUniques(UniqueType.TriggerUponConqueringCity, stateForConditionals))
-            UniqueTriggerActivation.triggerCivwideUnique(unique, attackerCiv, city)
+            UniqueTriggerActivation.triggerUnitwideUnique(unique, attacker.unit)
     }
 
     /** Handle decision making after city conquest, namely whether the AI should liberate, puppet,

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -49,7 +49,10 @@ object UniqueTriggerActivation {
 
         if (!unique.conditionalsApply(civInfo, city)) return false
 
-        val chosenCity = city ?: civInfo.cities.firstOrNull { it.isCapital() }
+        val chosenCity = city ?:
+            tile?.getCity() ?:
+            civInfo.cities.firstOrNull { it.isCapital() }
+
         val tileBasedRandom =
             if (tile != null) Random(tile.position.toString().hashCode())
             else Random(-550) // Very random indeed


### PR DESCRIPTION
This will default back to civ trigger if the unique is not a unit trigger, so there should be 100% backwards compatibility