### PR TITLE
Civs now have a 50% chance of picking their favored religion

### DIFF
--- a/core/src/com/unciv/logic/automation/civilization/ReligionAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/ReligionAutomation.kt
@@ -422,7 +422,8 @@ object ReligionAutomation {
             .filterNot { civInfo.gameInfo.religions.values.map { religion -> religion.name }.contains(it) }
         val favoredReligion = civInfo.nation.favoredReligion
         val religionIcon =
-            if (favoredReligion != null && favoredReligion in availableReligionIcons) favoredReligion
+            if (favoredReligion != null && favoredReligion in availableReligionIcons
+                && (1..10).random() <= 5) favoredReligion
             else availableReligionIcons.randomOrNull()
                 ?: return // Wait what? How did we pass the checking when using a great prophet but not this?
 


### PR DESCRIPTION
Currently, the AI picks its Civ's favored religion first over all other religions. Since 20 Civs have Christianity as their favored religion, it has a very high chance of being picked first. Also at least 2 of the religion options have no Civs that favor it, and a few only have 1. So this PR addresses that by simply giving the AI a 50% chance of picking their favored religion when able. 

Note that the chance that they pick their favored religion is more like 55% since they choose a random religion when failing to pick their favored religion.