### PR TITLE
Add unique to allow for generalized great generals

### DIFF
--- a/android/assets/jsons/Civ V - Gods & Kings/Units.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Units.json
@@ -1653,6 +1653,7 @@
             "Empire enters a [8]-turn Golden Age <by consuming this unit>",
             "[+15]% Strength bonus for [Military] units within [2] tiles",
             "Can instantly construct a [Citadel] improvement <by consuming this unit>",
+			"Can be earned through combat",
 			"Great Person - [War]", "Unbuildable", "Uncapturable"],
 		"movement": 2
 	},
@@ -1666,6 +1667,7 @@
             "[+15]% Strength bonus for [Military] units within [2] tiles",
 			"All adjacent units heal [+15] HP when healing", "[+15] HP when healing",
             "Can instantly construct a [Citadel] improvement <by consuming this unit>",
+			"Can be earned through combat",
             "Great Person - [War]", "Unbuildable", "Uncapturable"],
 		"movement": 5
 	},

--- a/android/assets/jsons/Civ V - Vanilla/Units.json
+++ b/android/assets/jsons/Civ V - Vanilla/Units.json
@@ -1296,6 +1296,7 @@
             "Empire enters a [8]-turn Golden Age <by consuming this unit>",
             "[+15]% Strength bonus for [Military] units within [2] tiles",
             "Can instantly construct a [Citadel] improvement <by consuming this unit>",
+			"Can be earned through combat",
 			"Great Person - [War]", "Unbuildable", "Uncapturable"],
 		"movement": 2
 	},
@@ -1309,6 +1310,7 @@
             "[+15]% Strength bonus for [Military] units within [2] tiles",
 			"All adjacent units heal [+15] HP when healing", "[+15] HP when healing",
             "Can instantly construct a [Citadel] improvement <by consuming this unit>",
+			"Can be earned through combat",
             "Great Person - [War]", "Unbuildable", "Uncapturable"],
 		"movement": 5
 	},

--- a/core/src/com/unciv/logic/BackwardCompatibility.kt
+++ b/core/src/com/unciv/logic/BackwardCompatibility.kt
@@ -39,12 +39,12 @@ object BackwardCompatibility {
 
     fun GameInfo.migrateGreatGeneralPools() {
         for (civ in civilizations) civ.greatPeople.run {
-            if (pointsForNextGreatGeneral >= pointsForNextGreatGeneralCounter["Great Genreral"]) {
+            if (pointsForNextGreatGeneral >= pointsForNextGreatGeneralCounter["Great General"]) {
                 pointsForNextGreatGeneralCounter["Great General"] = pointsForNextGreatGeneral
             } else pointsForNextGreatGeneral = pointsForNextGreatGeneralCounter["Great General"]
 
 
-            if (greatGeneralPoints >= greatGeneralPointsCounter["Great Genreral"]) {
+            if (greatGeneralPoints >= greatGeneralPointsCounter["Great General"]) {
                 greatGeneralPointsCounter["Great General"] = greatGeneralPoints
             } else greatGeneralPoints = greatGeneralPointsCounter["Great General"]
         }

--- a/core/src/com/unciv/logic/BackwardCompatibility.kt
+++ b/core/src/com/unciv/logic/BackwardCompatibility.kt
@@ -37,6 +37,19 @@ object BackwardCompatibility {
         removeTechAndPolicies()
     }
 
+    fun GameInfo.migrateGreatGeneralPools() {
+        for (civ in civilizations) civ.greatPeople.run {
+            if (pointsForNextGreatGeneral >= pointsForNextGreatGeneralCounter["Great Genreral"]) {
+                pointsForNextGreatGeneralCounter["Great General"] = pointsForNextGreatGeneral
+            } else pointsForNextGreatGeneral = pointsForNextGreatGeneralCounter["Great General"]
+
+
+            if (greatGeneralPoints >= greatGeneralPointsCounter["Great Genreral"]) {
+                greatGeneralPointsCounter["Great General"] = greatGeneralPoints
+            } else greatGeneralPoints = greatGeneralPointsCounter["Great General"]
+        }
+    }
+
     private fun GameInfo.removeUnitsAndPromotions() {
         for (tile in tileMap.values) {
             for (unit in tile.getUnits().toList()) {

--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -7,6 +7,7 @@ import com.unciv.UncivGame.Version
 import com.unciv.json.json
 import com.unciv.logic.BackwardCompatibility.convertFortify
 import com.unciv.logic.BackwardCompatibility.guaranteeUnitPromotions
+import com.unciv.logic.BackwardCompatibility.migrateGreatGeneralPools
 import com.unciv.logic.BackwardCompatibility.migrateToTileHistory
 import com.unciv.logic.BackwardCompatibility.removeMissingModReferences
 import com.unciv.logic.GameInfo.Companion.CURRENT_COMPATIBILITY_NUMBER
@@ -670,6 +671,8 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
         guaranteeUnitPromotions()
 
         migrateToTileHistory()
+
+        migrateGreatGeneralPools()
     }
 
     private fun updateCivilizationState() {

--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -496,6 +496,8 @@ object Battle {
                     }.toMutableList()
             // For compatibility with older rulesets
             if (greatGeneralUnits.isEmpty() && civ.gameInfo.ruleset.units["Great General"] != null)
+                && civ.gameInfo.ruleset.units.values.none { 
+                    it.hasUnique(UniqueType.GreatPersonFromCombat, StateForConditionals.IgnoreConditionals) })
                 greatGeneralUnits += civ.gameInfo.ruleset.units["Great General"]!!
 
             for (unit in greatGeneralUnits) {

--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -495,7 +495,7 @@ object Battle {
                         reason.type != RejectionReasonType.Obsoleted }
                     }.toMutableList()
             // For compatibility with older rulesets
-            if (greatGeneralUnits.isEmpty() && civ.gameInfo.ruleset.units["Great General"] != null)
+            if (greatGeneralUnits.isEmpty() && civ.gameInfo.ruleset.units["Great General"] != null
                 && civ.gameInfo.ruleset.units.values().none { 
                     it.hasUnique(UniqueType.GreatPersonFromCombat, StateForConditionals.IgnoreConditionals) })
                 greatGeneralUnits += civ.gameInfo.ruleset.units["Great General"]!!

--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -483,21 +483,20 @@ object Battle {
         promotions.XP += xpGained
 
         if (!otherIsBarbarian && civ.isMajorCiv()) { // Can't get great generals from Barbarians
-            val greatGeneralUnits = civ.gameInfo.ruleset.units.values
-                    .filter { it.hasUnique(UniqueType.GreatPersonFromCombat, stateForConditionals) }
-                    // Check if the unit is allowed for the Civ, ignoring build constrants
-                    .filter { !it.getRejectionReasons(civ).any { reason ->
-                        reason.type != RejectionReasonType.Unbuildable &&
-                        reason.type != RejectionReasonType.CannotBeBuilt &&
-                        reason.type != RejectionReasonType.CannotBeBuiltUnhappiness &&
-                        // Allow Generals even if not allowed via tech
-                        reason.type != RejectionReasonType.RequiresTech &&
-                        reason.type != RejectionReasonType.Obsoleted }
-                    }.toMutableList()
+            var greatGeneralUnits = civ.gameInfo.ruleset.greatGeneralUnits
+                    .filter { it.hasUnique(UniqueType.GreatPersonFromCombat, stateForConditionals) && 
+                        // Check if the unit is allowed for the Civ, ignoring build constrants
+                        !it.getRejectionReasons(civ).any { reason ->
+                            reason.type != RejectionReasonType.Unbuildable &&
+                            reason.type != RejectionReasonType.CannotBeBuilt &&
+                            reason.type != RejectionReasonType.CannotBeBuiltUnhappiness &&
+                            // Allow Generals even if not allowed via tech
+                            reason.type != RejectionReasonType.RequiresTech &&
+                            reason.type != RejectionReasonType.Obsoleted }
+                    }.asSequence()
             // For compatibility with older rulesets
-            if (greatGeneralUnits.isEmpty() && civ.gameInfo.ruleset.units["Great General"] != null
-                && civ.gameInfo.ruleset.units.values.none { 
-                    it.hasUnique(UniqueType.GreatPersonFromCombat, StateForConditionals.IgnoreConditionals) })
+            if (civ.gameInfo.ruleset.greatGeneralUnits.isEmpty() && 
+                civ.gameInfo.ruleset.units["Great General"] != null)
                 greatGeneralUnits += civ.gameInfo.ruleset.units["Great General"]!!
 
             for (unit in greatGeneralUnits) {

--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -487,12 +487,9 @@ object Battle {
                     .filter { it.hasUnique(UniqueType.GreatPersonFromCombat, stateForConditionals) && 
                         // Check if the unit is allowed for the Civ, ignoring build constrants
                         !it.getRejectionReasons(civ).any { reason ->
-                            reason.type != RejectionReasonType.Unbuildable &&
-                            reason.type != RejectionReasonType.CannotBeBuilt &&
-                            reason.type != RejectionReasonType.CannotBeBuiltUnhappiness &&
+                            !reason.isConstructionRejection() &&
                             // Allow Generals even if not allowed via tech
-                            reason.type != RejectionReasonType.RequiresTech &&
-                            reason.type != RejectionReasonType.Obsoleted }
+                            !reason.techPolicyEraWonderRequirements() }
                     }.asSequence()
             // For compatibility with older rulesets
             if (civ.gameInfo.ruleset.greatGeneralUnits.isEmpty() && 

--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -486,7 +486,7 @@ object Battle {
             var greatGeneralUnits = civ.gameInfo.ruleset.greatGeneralUnits
                     .filter { it.hasUnique(UniqueType.GreatPersonFromCombat, stateForConditionals) && 
                         // Check if the unit is allowed for the Civ, ignoring build constrants
-                        !it.getRejectionReasons(civ).any { reason ->
+                        it.getRejectionReasons(civ).none { reason ->
                             !reason.isConstructionRejection() &&
                             // Allow Generals even if not allowed via tech
                             !reason.techPolicyEraWonderRequirements() }

--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -496,7 +496,7 @@ object Battle {
                     }.toMutableList()
             // For compatibility with older rulesets
             if (greatGeneralUnits.isEmpty() && civ.gameInfo.ruleset.units["Great General"] != null
-                && civ.gameInfo.ruleset.units.values().none { 
+                && civ.gameInfo.ruleset.units.values.none { 
                     it.hasUnique(UniqueType.GreatPersonFromCombat, StateForConditionals.IgnoreConditionals) })
                 greatGeneralUnits += civ.gameInfo.ruleset.units["Great General"]!!
 

--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -496,7 +496,7 @@ object Battle {
                     }.toMutableList()
             // For compatibility with older rulesets
             if (greatGeneralUnits.isEmpty() && civ.gameInfo.ruleset.units["Great General"] != null)
-                && civ.gameInfo.ruleset.units.values.none { 
+                && civ.gameInfo.ruleset.units.values().none { 
                     it.hasUnique(UniqueType.GreatPersonFromCombat, StateForConditionals.IgnoreConditionals) })
                 greatGeneralUnits += civ.gameInfo.ruleset.units["Great General"]!!
 

--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -15,7 +15,6 @@ import com.unciv.logic.civilization.PopupAlert
 import com.unciv.logic.civilization.PromoteUnitAction
 import com.unciv.logic.map.tile.Tile
 import com.unciv.models.UnitActionType
-import com.unciv.models.ruleset.RejectionReasonType
 import com.unciv.models.ruleset.unique.StateForConditionals
 import com.unciv.models.ruleset.unique.Unique
 import com.unciv.models.ruleset.unique.UniqueTriggerActivation

--- a/core/src/com/unciv/logic/civilization/managers/GreatPersonManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/GreatPersonManager.kt
@@ -37,6 +37,8 @@ class GreatPersonManager : IsPartOfGameInfoSerialization {
         toReturn.pointsForNextGreatPersonCounter = pointsForNextGreatPersonCounter.clone()
         toReturn.pointsForNextGreatGeneralCounter = pointsForNextGreatGeneralCounter.clone()
         toReturn.greatGeneralPointsCounter = greatGeneralPointsCounter.clone()
+        toReturn.pointsForNextGreatGeneral = pointsForNextGreatGeneral
+        toReturn.greatGeneralPoints = greatGeneralPoints
         toReturn.mayaLimitedFreeGP = mayaLimitedFreeGP
         toReturn.longCountGPPool = longCountGPPool.toHashSet()
         return toReturn

--- a/core/src/com/unciv/logic/civilization/managers/GreatPersonManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/GreatPersonManager.kt
@@ -19,8 +19,10 @@ class GreatPersonManager : IsPartOfGameInfoSerialization {
     /** Base points, without speed modifier */
     var pointsForNextGreatPersonCounter = Counter<String>()  // Initial values assigned in getPointsRequiredForGreatPerson as needed
     var pointsForNextGreatGeneral = 200
+    var pointsForNextGreatGeneralCounter = Counter<String>() // Initial values assigned when needed
 
     var greatPersonPointsCounter = Counter<String>()
+    var greatGeneralPointsCounter = Counter<String>()
     var greatGeneralPoints = 0
     var freeGreatPeople = 0
     /** Marks subset of [freeGreatPeople] as subject to maya ability restrictions (each only once untill all used) */
@@ -33,8 +35,8 @@ class GreatPersonManager : IsPartOfGameInfoSerialization {
         toReturn.freeGreatPeople = freeGreatPeople
         toReturn.greatPersonPointsCounter = greatPersonPointsCounter.clone()
         toReturn.pointsForNextGreatPersonCounter = pointsForNextGreatPersonCounter.clone()
-        toReturn.pointsForNextGreatGeneral = pointsForNextGreatGeneral
-        toReturn.greatGeneralPoints = greatGeneralPoints
+        toReturn.pointsForNextGreatGeneralCounter = pointsForNextGreatGeneralCounter.clone()
+        toReturn.greatGeneralPointsCounter = greatGeneralPointsCounter.clone()
         toReturn.mayaLimitedFreeGP = mayaLimitedFreeGP
         toReturn.longCountGPPool = longCountGPPool.toHashSet()
         return toReturn
@@ -54,10 +56,16 @@ class GreatPersonManager : IsPartOfGameInfoSerialization {
     }
 
     fun getNewGreatPerson(): String? {
-        if (greatGeneralPoints > pointsForNextGreatGeneral) {
-            greatGeneralPoints -= pointsForNextGreatGeneral
-            pointsForNextGreatGeneral += 50
-            return "Great General"
+        for ((unit, value) in greatGeneralPointsCounter){
+            if (pointsForNextGreatGeneralCounter[unit] == 0) {
+                pointsForNextGreatGeneralCounter[unit] = 200
+            }
+            val requiredPoints = pointsForNextGreatGeneralCounter[unit]
+            if (value > requiredPoints) {
+                greatGeneralPointsCounter[unit] -= requiredPoints
+                pointsForNextGreatGeneralCounter[unit] += 50
+                return unit
+            }
         }
 
         for ((greatPerson, value) in greatPersonPointsCounter) {

--- a/core/src/com/unciv/models/ruleset/IConstruction.kt
+++ b/core/src/com/unciv/models/ruleset/IConstruction.kt
@@ -118,6 +118,8 @@ class RejectionReason(val type: RejectionReasonType,
 
     fun isImportantRejection(): Boolean = type in orderedImportantRejectionTypes
 
+    fun isConstructionRejection(): Boolean = type in constructionRejectionReasonType
+
     /** Returns the index of [orderedImportantRejectionTypes] with the smallest index having the
      * highest precedence */
     fun getRejectionPrecedence(): Int {
@@ -151,6 +153,12 @@ class RejectionReason(val type: RejectionReasonType,
         RejectionReasonType.CanOnlyBePurchased,
         RejectionReasonType.MaxNumberBuildable,
         RejectionReasonType.NoPlaceToPutUnit,
+    )
+    // Used for units spawned, not built
+    private val constructionRejectionReasonType = listOf(
+        RejectionReasonType.Unbuildable,
+        RejectionReasonType.CannotBeBuiltUnhappiness,
+        RejectionReasonType.CannotBeBuilt,
     )
 }
 

--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -69,6 +69,10 @@ class Ruleset {
     var victories = LinkedHashMap<String, Victory>()
     var cityStateTypes = LinkedHashMap<String, CityStateType>()
 
+    val greatGeneralUnits by lazy { 
+        units.values.filter { it.hasUnique(UniqueType.GreatPersonFromCombat, StateForConditionals.IgnoreConditionals) }
+    }
+
     val mods = LinkedHashSet<String>()
     var modOptions = ModOptions()
 

--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -15,6 +15,7 @@ import com.unciv.models.ruleset.tile.Terrain
 import com.unciv.models.ruleset.tile.TileImprovement
 import com.unciv.models.ruleset.tile.TileResource
 import com.unciv.models.ruleset.unique.IHasUniques
+import com.unciv.models.ruleset.unique.StateForConditionals
 import com.unciv.models.ruleset.unique.Unique
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.ruleset.unit.BaseUnit

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -440,6 +440,7 @@ enum class UniqueType(
     // XP
     FlatXPGain("[amount] XP gained from combat", UniqueTarget.Unit, UniqueTarget.Global),
     PercentageXPGain("[relativeAmount]% XP gained from combat", UniqueTarget.Unit, UniqueTarget.Global),
+    GreatPersonFromCombat("Can be earned through combat", UniqueTarget.Unit),
     GreatPersonEarnedFaster("[greatPerson] is earned [relativeAmount]% faster", UniqueTarget.Unit, UniqueTarget.Global),
 
     // Invisibility

--- a/core/src/com/unciv/ui/screens/overviewscreen/StatsOverviewTab.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/StatsOverviewTab.kt
@@ -211,10 +211,14 @@ class StatsOverviewTab(
             add(greatPersonPointsPerTurn[greatPerson].toLabel()).right().row()
         }
 
-        val pointsForGreatGeneral = viewingPlayer.greatPeople.greatGeneralPoints
-        val pointsForNextGreatGeneral = viewingPlayer.greatPeople.pointsForNextGreatGeneral
-        add("Great General".toLabel()).left()
-        add("$pointsForGreatGeneral/$pointsForNextGreatGeneral".toLabel())
+        val greatGeneralPoints = viewingPlayer.greatPeople.greatGeneralPointsCounter
+        val pointsForNextGreatGeneral = viewingPlayer.greatPeople.pointsForNextGreatGeneralCounter
+        for ((unit, points) in greatGeneralPoints) {
+            val pointsToGreatGeneral = pointsForNextGreatGeneral[unit]
+            add(unit.toLabel()).left()
+            add("$points/$pointsToGreatGeneral".toLabel())
+        }
+
         pack()
     }
 

--- a/tests/src/com/unciv/logic/battle/BattleTest.kt
+++ b/tests/src/com/unciv/logic/battle/BattleTest.kt
@@ -216,8 +216,8 @@ class BattleTest {
         Battle.attack(MapUnitCombatant(defaultAttackerUnit), MapUnitCombatant(defaultDefenderUnit))
 
         // then
-        assertEquals(5, attackerCiv.greatPeople.greatGeneralPoints)
-        assertEquals(4, defenderCiv.greatPeople.greatGeneralPoints)
+        assertEquals(5, attackerCiv.greatPeople.greatGeneralPointsCounter["Great General"])
+        assertEquals(4, defenderCiv.greatPeople.greatGeneralPointsCounter["Great General"])
     }
 
     @Test
@@ -230,8 +230,8 @@ class BattleTest {
         Battle.attack(MapUnitCombatant(defaultAttackerUnit), MapUnitCombatant(barbarianUnit))
 
         // then
-        assertEquals(0, attackerCiv.greatPeople.greatGeneralPoints)
-        assertEquals(0, barbarianCiv.greatPeople.greatGeneralPoints)
+        assertEquals(0, attackerCiv.greatPeople.greatGeneralPointsCounter["Great General"])
+        assertEquals(0, barbarianCiv.greatPeople.greatGeneralPointsCounter["Great General"])
     }
 
     @Test
@@ -243,7 +243,7 @@ class BattleTest {
         Battle.attack(MapUnitCombatant(attackerUnit), MapUnitCombatant(defaultDefenderUnit))
 
         // then
-        assertEquals(10, attackerCiv.greatPeople.greatGeneralPoints)
+        assertEquals(10, attackerCiv.greatPeople.greatGeneralPointsCounter["Great General"])
     }
 
     @Test


### PR DESCRIPTION
Couple of notes
1. The unique is somewhat intentionally unintuitive. The unique is not based on the Great Unit itself, but rather for  the unit that is attacking. That is to say "Can be earned through combat <for [Land] units>" is only valid if a land unit is attacking and "Can be earned through combat <vs [Water] units>" is only valid vs water units
2. I'm pretty sure that despite the name, most of our great people stuff functions all the same for non great people. As such, I decided to forgo checks for a great person here for consistency
3. In Battle.kt, it checked for a Great Person with the "War" label. This is inconsistent with how it was treated in GreatPersonManager. There, it was hard coded to strictly work with a "Great General" unit. That is to say, a fake "General Great" with the unique could still speed up the gain of a Great General despite having a different name. With how things are rearranged, this is no longer possible
4. `UniqueType.GreatPersonEarnedFaster.params[0]` uses "greatPerson", which I believe is an alias for "unitName". However, given neither the combat system of generating great people or the passive way (via buildings/specialists) is exclusive to great people, I've instead decided to treat it as an alias for "unitFilter" here, as it might be generally expected
5. Similar to #9614, I've added an entry in `BackwardsCompatibility` to migrate the great points over. A neat part of how I did things is that a ruleset with no unique based defined Great General and just a unit and a ruleset with a basic Great General unit with the unique should function identically once migrated