### PR TITLE
AI Builds Courthouse immediately

### DIFF
--- a/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
@@ -369,7 +369,7 @@ object NextTurnAutomation {
                     && !city.isInResistance() && !civInfo.hasUnique(UniqueType.MayNotAnnexCities)
             ) {
                 city.annexCity()
-                
+
                 // Immediately buy a courthouse or equivalent if we can
                 if (city.cityStats.hasExtraAnnexUnhappiness() && civInfo.getHappiness() < 35) {
                     val courthouseBuilding = city.cityConstructions.getBuildableBuildings()

--- a/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
@@ -369,6 +369,16 @@ object NextTurnAutomation {
                     && !city.isInResistance() && !civInfo.hasUnique(UniqueType.MayNotAnnexCities)
             ) {
                 city.annexCity()
+                
+                // Immediately buy a courthouse or equivalent if we can
+                if (city.cityStats.hasExtraAnnexUnhappiness() && civInfo.getHappiness() < 35) {
+                    val courthouseBuilding = city.cityConstructions.getBuildableBuildings()
+                        .filter {it.hasUnique(UniqueType.RemoveAnnexUnhappiness)}
+                        .filter { it.getStatBuyCost(city, Stat.Gold)!! >= civInfo.gold }
+                        .minByOrNull { it.getStatBuyCost(city, Stat.Gold)!! }
+                    if (courthouseBuilding != null)
+                        city.cityConstructions.purchaseConstruction(courthouseBuilding, city.cityConstructions.constructionQueue.indexOf(courthouseBuilding.name), false)
+                }
             }
 
             city.reassignAllPopulation()


### PR DESCRIPTION
This PR doesn't really address any problems. Since the AI will only buy buildings earlier in the turn than annexing a city, the AI will at least wait to buy a courthouse in the next turn, if at all. So this PR adds an extra buy courthouse immediately after annexing behavior.