### PR TITLE
Worker AI short distance priority fix

### DIFF
--- a/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
@@ -468,7 +468,6 @@ class WorkerAutomation(
                 && (it.civilianUnit == null || it == currentTile)
                 && (it.owningCity == null || it.getOwner() == civInfo)
                 && !it.isCityCenter()
-                && !tilesToAvoid.contains(currentTile)
                 && getBasePriority(it, unit) > 1
             }
 

--- a/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
@@ -500,7 +500,7 @@ class WorkerAutomation(
      * This is a cheap guess on how helpful it might be to do work on this tile
      */
     fun getBasePriority(tile: Tile, unit: MapUnit): Float {
-        val unitSpecificPriority = 2 - tile.aerialDistanceTo(unit.getTile()).coerceAtMost(4)
+        val unitSpecificPriority = 2 - (tile.aerialDistanceTo(unit.getTile()) / 2.0f).coerceIn(0f, 2f)
         if (tileRankings.containsKey(tile)) 
             return tileRankings[tile]!!.tilePriority + unitSpecificPriority
         


### PR DESCRIPTION
Here is a quick change, basically, the AI workers would have a tile with an aerial distance of 3 or 4, which made the unitSpecificPriority < 0. When added to the tile priority, it made it <= 1, so the worker would sit around and not move to the tile to try to improve it in the early game.

This fixes only one of the problems that I have seen. I'll have to see what to do with connecting roads.