### PR TITLE
AI focuses city-state gold gifting

### DIFF
--- a/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
@@ -118,7 +118,7 @@ object NextTurnAutomation {
         civInfo.popupAlerts.clear() // AIs don't care about popups.
     }
 
-    internal fun valueCityStateAlliance(civInfo: Civilization, cityState: Civilization): Int {
+    internal fun valueCityStateAlliance(civInfo: Civilization, cityState: Civilization, includeQuests: Boolean = false): Int {
         var value = 0
 
         if (civInfo.wantsToFocusOn(Victory.Focus.Culture) && cityState.cityStateFunctions.canProvideStat(Stat.Culture)) {
@@ -172,8 +172,10 @@ object NextTurnAutomation {
             && it.resource !in civInfo.detailedCivResources.map { supply -> supply.resource }
         }
         
-        // Better if there is an investment bonus quest active.
-        value += (cityState.questManager.getInvestmentMultiplier(civInfo.civName) * 10).toInt() - 10
+        if (includeQuests) {
+            // Investing is better if there is an investment bonus quest active.
+            value += (cityState.questManager.getInvestmentMultiplier(civInfo.civName) * 10).toInt() - 10
+        }
 
         return value
     }

--- a/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
@@ -150,8 +150,12 @@ object NextTurnAutomation {
 
         if (!cityState.isAlive() || cityState.cities.isEmpty() || civInfo.cities.isEmpty())
             return value
+        
+        // The more we have invested into the city-state the more the alliance is worth
+        val ourInfluence = cityState.getDiplomacyManager(civInfo).getInfluence().toInt()
+        value += ourInfluence / 10
 
-        if (civInfo.gold < 100) {
+        if (civInfo.gold < 100 && ourInfluence < 30) {
             // Consider bullying for cash
             value -= 5
         }
@@ -159,7 +163,7 @@ object NextTurnAutomation {
         if (cityState.getAllyCiv() != null && cityState.getAllyCiv() != civInfo.civName) {
             // easier not to compete if a third civ has this locked down
             val thirdCivInfluence = cityState.getDiplomacyManager(cityState.getAllyCiv()!!).getInfluence().toInt()
-            value -= (thirdCivInfluence - 60) / 10
+            value -= (thirdCivInfluence - 30) / 10
         }
 
         // Bonus for luxury resources we can get from them

--- a/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
@@ -171,6 +171,9 @@ object NextTurnAutomation {
             it.resource.resourceType == ResourceType.Luxury
             && it.resource !in civInfo.detailedCivResources.map { supply -> supply.resource }
         }
+        
+        // Better if there is an investment bonus quest active.
+        value += (cityState.questManager.getInvestmentMultiplier(civInfo.civName) * 10).toInt() - 10
 
         return value
     }

--- a/core/src/com/unciv/logic/automation/civilization/UseGoldAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/UseGoldAutomation.kt
@@ -164,12 +164,14 @@ object UseGoldAutomation {
     }
 
     private fun tryGainInfluence(civInfo: Civilization, cityState: Civilization) {
-        if (civInfo.gold < 250) return // save up
-        if (cityState.getDiplomacyManager(civInfo).getInfluence() < 20) {
+        if (civInfo.gold < 250) return // Save up
+        if (cityState.getDiplomacyManager(civInfo).getInfluence() >= 20
+            && civInfo.gold < 500) {
+            // Only make a small investment if we have a bit of influence already to build off of so we don't waste our money
             cityState.cityStateFunctions.receiveGoldGift(civInfo, 250)
             return
         }
-        if (civInfo.gold < 500) return // it's not worth it to invest now, wait until you have enough for 2
+        if (civInfo.gold < 500) return // It's not worth it to invest now, wait until you have enough for 2
         cityState.cityStateFunctions.receiveGoldGift(civInfo, 500)
         return
     }

--- a/core/src/com/unciv/logic/automation/civilization/UseGoldAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/UseGoldAutomation.kt
@@ -61,7 +61,7 @@ object UseGoldAutomation {
         if (civ.gold < 250 || knownCityStates.none()) return
         val cityState = knownCityStates
             .filter { it.getAllyCiv() != civ.civName }
-            .associateWith { NextTurnAutomation.valueCityStateAlliance(civ, it) }
+            .associateWith { NextTurnAutomation.valueCityStateAlliance(civ, it, true) }
             .maxByOrNull { it.value }?.takeIf { it.value > 0 }?.key
         if (cityState != null) {
             tryGainInfluence(civ, cityState)


### PR DESCRIPTION
This PR makes three small changes to the behavior of the city-state gold gifting AI.
- The AI values a city-state's alliance more based on how much they have invested already into it.
This makes the AI less likely to bully a city-state which they have invested into.
- The AI values a city-state's alliance more if it has an investment quest for gifting gold
- The AI will not make a small investment into a city-state if its influence is < 20. It will save up for a big investment instead.

Does the AI spend too much money on gifting gold? It is hard to tell.