### PR TITLE
Show carried over production from obsolete units in city queue when you get a 'Free Tech'

### DIFF
--- a/core/src/com/unciv/logic/city/CityConstructions.kt
+++ b/core/src/com/unciv/logic/city/CityConstructions.kt
@@ -386,7 +386,7 @@ class CityConstructions : IsPartOfGameInfoSerialization {
         chooseNextConstruction()
     }
 
-    private fun validateInProgressConstructions() {
+    fun validateInProgressConstructions() {
         // remove obsolete stuff from in progress constructions - happens often and leaves clutter in memory and save files
         // should have little visible consequences - any accumulated points that may be reused later should stay (nukes when manhattan project city lost, nat wonder when conquered an empty city...), all other points should be refunded
         // Should at least be called before each turn - if another civ completes a wonder after our previous turn, we should get the refund this turn

--- a/core/src/com/unciv/logic/civilization/managers/TechManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/TechManager.kt
@@ -369,12 +369,17 @@ class TechManager : IsPartOfGameInfoSerialization {
                 .toMutableList()
         }
 
-        // As long as TurnManager does cities after tech, we don't need to clean up
-        // inProgressConstructions - CityConstructions.validateInProgressConstructions does it.
-
         // Add notifications for obsolete units/constructions
         for ((unit, cities) in unitUpgrades) {
             if (cities.isEmpty()) continue
+
+            //The validation check happens again while processing start and end of turn,
+            //but for mid-turn free tech picks like Oxford University, it should happen immediately
+            //so the hammers from the obsolete unit are guaranteed to go to the upgraded unit
+            //and players don't think they lost all their production mid turn
+            for(city in cities)
+                city.cityConstructions.validateInProgressConstructions()
+
             val locationAction = LocationAction(cities.asSequence().map { it.location })
             val cityText = if (cities.size == 1) "[${cities.first().name}]"
                 else "[${cities.size}] cities"


### PR DESCRIPTION
Without this, when you get a mid-turn free tech like Oxford University, the units in city queues are updated but the hammers aren't carried over from the obsolete unit until the end of turn. This means that to the player it shows 0 progress for all the new units in queue and appears like the progress from obsolete units was lost which can be disconcerting and makes strategizing during that turn difficult.