### PR TITLE
Fixed crash related to AI trying to value an unmet city-state

### DIFF
--- a/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
@@ -152,7 +152,9 @@ object NextTurnAutomation {
             return value
         
         // The more we have invested into the city-state the more the alliance is worth
-        val ourInfluence = cityState.getDiplomacyManager(civInfo).getInfluence().toInt()
+        val ourInfluence = if (civInfo.knows(cityState)) 
+            cityState.getDiplomacyManager(civInfo).getInfluence().toInt()
+        else 0
         value += ourInfluence / 10
 
         if (civInfo.gold < 100 && ourInfluence < 30) {


### PR DESCRIPTION
Fixes  #10852
The problem was that an AI civ was trying to determine if it should liberate a city-state it hadn't yet met. Therefore, this caused an error since the diplomacy manager pair did not exist. 
The fix is simple and would take longer to explain than read.