### PR TITLE
Fixed crash when a worker tryies to build a cached improvement that it can't build

### DIFF
--- a/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
@@ -565,6 +565,8 @@ class WorkerAutomation(
             }
         }
 
+        // A better tile than this unit can build might have been stored in the cache
+        if (rank.bestImprovement == null || !unit.canBuildImprovement(rank.bestImprovement!!, tile)) return -100f
         return rank.improvementPriority!!
     }
 


### PR DESCRIPTION
This fixes an error that was reported on Discord.
The problem came from the caching feature in #10776. 
In the bug, a worker valued the tile and did not go to it. Instead, a military unit that can build roads and forts looked at the cache of the previous worker and tried to build an improvement it couldn't build.

The solution is more of a temporary fix to a problem with caching and the difference in the buildings that workers can build. We just check if the current worker can build that improvement. This solution works as of now only because the workers (in this case, military units) with the smaller pool of buildings that they can build are a subset of the buildings of the regular worker's pool. And since the regular workers move before the military workers there isn't any clashing yet. 

But what if we have two civilian workers that can build different types of buildings...