### PR TITLE
Fix some right-side uses of square brackets in translations

### DIFF
--- a/android/assets/jsons/translations/Lithuanian.properties
+++ b/android/assets/jsons/translations/Lithuanian.properties
@@ -5837,7 +5837,7 @@ Ceilidh Hall = Ceilidh salė
 
 
 Leaning Tower of Pisa = Pizos bokštas
-'Don't clap too hard - it's a very old building.' - John Osbourne = 'Arba anie aštuoniolika, kuriuos užgriuvo bokštas prie Siloamo [tvenkinio] ir užmušė; jūs manote, kad jie buvo kaltesni už visus kitus Jeruzalės gyventojus?!  Ne, sakau jums, bet jei neatsiversite, visi taip pat pražūsite“.' - Luko 13:4-5
+'Don't clap too hard - it's a very old building.' - John Osbourne = 'Arba anie aštuoniolika, kuriuos užgriuvo bokštas prie Siloamo tvenkinio ir užmušė; jūs manote, kad jie buvo kaltesni už visus kitus Jeruzalės gyventojus?!  Ne, sakau jums, bet jei neatsiversite, visi taip pat pražūsite“.' - Luko 13:4-5
 
 
 Coffee House = Kavinė
@@ -7157,4 +7157,3 @@ In the Resources overview, click on a resource icon to center the world screen o
 Alternatively, click on the "Unimproved" number to center the world screen only on owned tiles where the resource is not improved. = 
  # Requires translation!
 If more than one tile is available, click repeatedly on the notification to cycle through all of them. = 
-

--- a/android/assets/jsons/translations/Vietnamese.properties
+++ b/android/assets/jsons/translations/Vietnamese.properties
@@ -2302,7 +2302,7 @@ Cities are razed [amount] times as fast = Các thành phố được xếp hạn
 Receive a tech boost when scientific buildings/wonders are built in capital = Nhận được sự thúc đẩy công nghệ khi các tòa nhà / kỳ quan khoa học được xây dựng bằng thủ đô
 Can be continually researched = Có thể liên tục nghiên cứu 
 [relativeAmount]% Golden Age length = [relativeAmount]% Độ dài thời kỳ Hoàng Kim
-Population loss from nuclear attacks [relativeAmount]% [cityFilter] = Tổn thất dân số do các cuộc tấn công hạt nhân [relativeAmount]% [cityFilter] Tổn thất dân số do các cuộc tấn công hạt nhân [relAmount]% [cityFilter] Tổn thất dân số do các cuộc tấn công hạt nhân [relAmount]% [cityFilter]
+Population loss from nuclear attacks [relativeAmount]% [cityFilter] = Tổn thất dân số do các cuộc tấn công hạt nhân [relativeAmount]% [cityFilter]
  # Requires translation!
 Damage to garrison from nuclear attacks [relativeAmount]% [cityFilter] = 
 Rebel units may spawn = Các đơn vị nổi dậy có thể xuất hiện
@@ -7152,4 +7152,3 @@ In the Resources overview, click on a resource icon to center the world screen o
 Alternatively, click on the "Unimproved" number to center the world screen only on owned tiles where the resource is not improved. = 
  # Requires translation!
 If more than one tile is available, click repeatedly on the notification to cycle through all of them. = 
-


### PR DESCRIPTION
See #10858 - with the other quick reactions that leaves only the Hungarian use of `[...]` - if unanswered we could just drop those - or replace with `(...)`