### PR TITLE
City-stationed unit icons get a circular touchable area

### DIFF
--- a/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
@@ -150,7 +150,7 @@ object NextTurnAutomation {
 
         if (!cityState.isAlive() || cityState.cities.isEmpty() || civInfo.cities.isEmpty())
             return value
-        
+
         // The more we have invested into the city-state the more the alliance is worth
         val ourInfluence = cityState.getDiplomacyManager(civInfo).getInfluence().toInt()
         value += ourInfluence / 10
@@ -171,7 +171,7 @@ object NextTurnAutomation {
             it.resource.resourceType == ResourceType.Luxury
             && it.resource !in civInfo.detailedCivResources.map { supply -> supply.resource }
         }
-        
+
         if (includeQuests) {
             // Investing is better if there is an investment bonus quest active.
             value += (cityState.questManager.getInvestmentMultiplier(civInfo.civName) * 10).toInt() - 10

--- a/core/src/com/unciv/ui/components/input/ClickableCircle.kt
+++ b/core/src/com/unciv/ui/components/input/ClickableCircle.kt
@@ -1,0 +1,30 @@
+package com.unciv.ui.components.input
+
+import com.badlogic.gdx.math.Vector2
+import com.badlogic.gdx.scenes.scene2d.Actor
+import com.badlogic.gdx.scenes.scene2d.Group
+import com.badlogic.gdx.scenes.scene2d.Touchable
+
+/**
+ *  Invisible Widget that supports detecting clicks in a circular area.
+ *
+ *  (An Image Actor does not respect alpha for its hit area, it's always square, but we want a clickable _circle_)
+ *
+ *  Usage: instantiate, position and overlay on something with [addActor], add listener using [onActivation].
+ *  Does not implement Layout at the moment - usage e.g. in a Table Cell may need that.
+ *
+ *  Note this is a [Group] that is supposed to have no [children] - as a simple [Actor] the Scene2D framework won't know to call our [hit] method.
+ */
+class ClickableCircle(size: Float) : Group() {
+    private val center = Vector2(size / 2, size / 2)
+    private val maxDst2 = size * size / 4 // squared radius
+
+    init {
+        touchable = Touchable.enabled
+        setSize(size, size)
+    }
+
+    override fun hit(x: Float, y: Float, touchable: Boolean): Actor? {
+        return if (center.dst2(x, y) < maxDst2) this else null
+    }
+}

--- a/core/src/com/unciv/ui/screens/overviewscreen/GlobalPoliticsOverviewTable.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/GlobalPoliticsOverviewTable.kt
@@ -28,6 +28,7 @@ import com.unciv.ui.components.extensions.equalizeColumns
 import com.unciv.ui.components.extensions.toLabel
 import com.unciv.ui.components.extensions.toTextButton
 import com.unciv.ui.components.fonts.Fonts
+import com.unciv.ui.components.input.ClickableCircle
 import com.unciv.ui.components.input.onActivation
 import com.unciv.ui.components.input.onClick
 import com.unciv.ui.components.widgets.AutoScrollPane
@@ -533,19 +534,6 @@ class GlobalPoliticsOverviewTable(
             line.color = color
             add(line).size(lineLength, width).padTop(5f)
             add(ShadowedLabel(text)).padLeft(5f).padTop(10f).row()
-        }
-    }
-
-    /** An Image Actor does not respect alpha for its hit area, it's always square, but we want a clickable _circle_ */
-    private class ClickableCircle(size: Float) : Group() {
-        val center = Vector2(size / 2, size / 2)
-        val maxDst2 = size * size / 4 // squared radius
-        init {
-            touchable = Touchable.enabled
-            setSize(size, size)
-        }
-        override fun hit(x: Float, y: Float, touchable: Boolean): Actor? {
-            return if (center.dst2(x, y) < maxDst2) this else null
         }
     }
 

--- a/core/src/com/unciv/ui/screens/worldscreen/WorldMapHolder.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/WorldMapHolder.kt
@@ -655,7 +655,7 @@ class WorldMapHolder(
                 val city = unitTable.selectedCity!!
                 updateBombardableTilesForSelectedCity(city)
                 // We still want to show road paths to the selected city if they are present
-                if (unitTable.selectedUnitIsConnectingRoad){
+                if (unitTable.selectedUnitIsConnectingRoad) {
                     updateTilesForSelectedUnit(unitTable.selectedUnits[0])
                 }
             }
@@ -715,11 +715,10 @@ class WorldMapHolder(
 
         // Z-Layer: 0
         // Highlight suitable tiles in road connecting mode
-        if (worldScreen.bottomUnitTable.selectedUnitIsConnectingRoad){
+        if (worldScreen.bottomUnitTable.selectedUnitIsConnectingRoad) {
             val validTiles = unit.civ.gameInfo.tileMap.tileList.filter {
                 MapPathing.isValidRoadPathTile(unit, it)
             }
-            unit.civ.gameInfo.civilizations
             val connectRoadTileOverlayColor = Color.RED
             for (tile in validTiles)  {
                 tileGroups[tile]!!.layerOverlay.showHighlight(connectRoadTileOverlayColor, 0.3f)
@@ -796,10 +795,10 @@ class WorldMapHolder(
             if (currTileIndex != -1) {
                 val futureTiles = unit.automatedRoadConnectionPath!!.filterIndexed { index, _ ->
                     index > currTileIndex
-                }.map{tilePos ->
+                }.map { tilePos ->
                     tileMap[tilePos]
                 }
-                for (tile in futureTiles){
+                for (tile in futureTiles) {
                     tileGroups[tile]!!.layerOverlay.showHighlight(Color.ORANGE, if (UncivGame.Current.settings.singleTapMove) 0.7f else 0.3f)
                 }
             }

--- a/core/src/com/unciv/ui/screens/worldscreen/WorldMapHolder.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/WorldMapHolder.kt
@@ -41,6 +41,7 @@ import com.unciv.ui.components.extensions.isShiftKeyPressed
 import com.unciv.ui.components.extensions.surroundWithCircle
 import com.unciv.ui.components.extensions.toLabel
 import com.unciv.ui.components.input.ActivationTypes
+import com.unciv.ui.components.input.ClickableCircle
 import com.unciv.ui.components.input.KeyCharAndCode
 import com.unciv.ui.components.input.KeyboardBinding
 import com.unciv.ui.components.input.keyShortcuts
@@ -480,12 +481,14 @@ class WorldMapHolder(
             val unitGroup = UnitGroup(unit, 48f).surroundWithCircle(68f, resizeActor = false)
             unitGroup.circle.color = Color.GRAY.cpy().apply { a = 0.5f }
             if (unit.currentMovement == 0f) unitGroup.color.a = 0.66f
-            unitGroup.touchable = Touchable.enabled
-            unitGroup.onClick {
+            val clickableCircle = ClickableCircle(68f)
+            clickableCircle.touchable = Touchable.enabled
+            clickableCircle.onClick {
                 worldScreen.bottomUnitTable.selectUnit(unit, Gdx.input.isShiftKeyPressed())
                 worldScreen.shouldUpdate = true
                 removeUnitActionOverlay()
             }
+            unitGroup.addActor(clickableCircle)
             table.add(unitGroup)
         }
 

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/UnitTable.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/UnitTable.kt
@@ -214,7 +214,7 @@ class UnitTable(val worldScreen: WorldScreen) : Table() {
             separator.isVisible = true
             val city = selectedCity!!
             var nameLabelText = city.name.tr()
-            if(city.health<city.getMaxHealth()) nameLabelText+=" ("+city.health+")"
+            if (city.health < city.getMaxHealth()) nameLabelText += " ("+city.health+")"
             unitNameLabel.setText(nameLabelText)
 
             unitNameLabel.clearListeners()
@@ -286,10 +286,10 @@ class UnitTable(val worldScreen: WorldScreen) : Table() {
 
     fun citySelected(city: City) : Boolean {
         // If the last selected unit connecting a road, keep it selected. Otherwise, clear.
-        if(selectedUnitIsConnectingRoad){
+        if (selectedUnitIsConnectingRoad) {
             selectUnit(selectedUnits[0])
             selectedUnitIsConnectingRoad = true // selectUnit resets this
-        }else{
+        } else {
             selectUnit()
         }
         if (city == selectedCity) return false


### PR DESCRIPTION
Started as pure experiment: Could **maybe** help with the "can't bombard enemy to the north" problem. Emphasis "maybe" as in Ink Dots. What do you think?
![image](https://github.com/yairm210/Unciv/assets/63000004/2dd9aeab-eda7-4232-9d74-18c0862e29ba)

Bombarding to the south, SE or SW can be tricky too, as we know, but improving that with rounded clickable areas might not be that easy. E.g. the CityButton:
![image](https://github.com/yairm210/Unciv/assets/63000004/daf2375a-9b55-497b-8b39-17f13fa5e115)
... "cutting off" those corners would not help much (and would need more code). I would need to see an actual situation to look for opportunities, and I've forgotten which issues dealt with that, or am too lazy to search for them atm...



