### PR TITLE
Fix "Performance" not translatable

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -768,6 +768,7 @@ Unit icon opacity =
 
 ### Performance subgroup
 
+Performance = 
 Continuous rendering = 
 When disabled, saves battery life but certain animations will be suspended = 
 


### PR DESCRIPTION
![image](https://github.com/yairm210/Unciv/assets/11946570/70887f4e-b6dd-474d-b21c-45b897bb765f)

"Performance" is "Performance" in french, so no before/after (but the translation works if I enter something else)