### PR TITLE
Fixed AutoPlay not working after victory

### DIFF
--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -398,7 +398,7 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
             }
 
             // Do we need to stop AutoPlay?
-            if (UncivGame.Current.settings.autoPlay.isAutoPlaying() && player.victoryManager.hasWon())
+            if (UncivGame.Current.settings.autoPlay.isAutoPlaying() && player.victoryManager.hasWon() && !oneMoreTurnMode)
                 UncivGame.Current.settings.autoPlay.stopAutoPlay()
 
             // Clean up


### PR DESCRIPTION
Added in a check for oneTurnMode. The problem was introduced in the AutoPlayUntilEnd update.