### PR TITLE
Fix NullPointerException on founding a pantheon

### DIFF
--- a/core/src/com/unciv/logic/civilization/managers/ReligionManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/ReligionManager.kt
@@ -375,6 +375,12 @@ class ReligionManager : IsPartOfGameInfoSerialization {
         // Must be done first in case when gain more later
         freeBeliefs.clear()
 
+        when (religionState) {
+            ReligionState.None -> {
+                foundPantheon(beliefs[0].name, useFreeBeliefs)  // makes religion non-null
+            }
+            else -> {}
+        }
         // add beliefs (religion exists at this point)
         religion!!.followerBeliefs.addAll(
             beliefs
@@ -388,9 +394,6 @@ class ReligionManager : IsPartOfGameInfoSerialization {
         )
 
         when (religionState) {
-            ReligionState.None -> {
-                foundPantheon(beliefs[0].name, useFreeBeliefs)
-            }
             ReligionState.FoundingReligion -> {
                 religionState = ReligionState.Religion
                 for (unique in civInfo.getTriggeredUniques(UniqueType.TriggerUponFoundingReligion))

--- a/core/src/com/unciv/logic/civilization/managers/ReligionManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/ReligionManager.kt
@@ -371,12 +371,8 @@ class ReligionManager : IsPartOfGameInfoSerialization {
         // Must be done first in case when gain more later
         freeBeliefs.clear()
 
-        when (religionState) {
-            ReligionState.None -> {
-                foundPantheon(beliefs[0].name, useFreeBeliefs)  // makes religion non-null
-            }
-            else -> {}
-        }
+        if (religionState == ReligionState.None)
+            foundPantheon(beliefs[0].name, useFreeBeliefs)  // makes religion non-null
         // add beliefs (religion exists at this point)
         religion!!.followerBeliefs.addAll(
             beliefs

--- a/core/src/com/unciv/logic/civilization/managers/ReligionManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/ReligionManager.kt
@@ -135,10 +135,6 @@ class ReligionManager : IsPartOfGameInfoSerialization {
         civInfo.gameInfo.religions[beliefName] = religion!!
         for (city in civInfo.cities)
             city.religion.addPressure(beliefName, 200 * city.population.population)
-        religionState = ReligionState.Pantheon
-
-        for (unique in civInfo.getTriggeredUniques(UniqueType.TriggerUponFoundingPantheon))
-            UniqueTriggerActivation.triggerCivwideUnique(unique, civInfo)
     }
 
     fun greatProphetsEarned(): Int = civInfo.civConstructions.boughtItemsWithIncreasingPrice[getGreatProphetEquivalent()?.name ?: ""]
@@ -394,6 +390,11 @@ class ReligionManager : IsPartOfGameInfoSerialization {
         )
 
         when (religionState) {
+            ReligionState.None -> {
+                religionState = ReligionState.Pantheon
+                for (unique in civInfo.getTriggeredUniques(UniqueType.TriggerUponFoundingPantheon))
+                    UniqueTriggerActivation.triggerCivwideUnique(unique, civInfo)
+            }
             ReligionState.FoundingReligion -> {
                 religionState = ReligionState.Religion
                 for (unique in civInfo.getTriggeredUniques(UniqueType.TriggerUponFoundingReligion))
@@ -402,8 +403,7 @@ class ReligionManager : IsPartOfGameInfoSerialization {
             ReligionState.EnhancingReligion -> {
                 religionState = ReligionState.EnhancedReligion
                 for (unique in civInfo.getTriggeredUniques(UniqueType.TriggerUponEnhancingReligion))
-                UniqueTriggerActivation.triggerCivwideUnique(unique, civInfo)
-
+                    UniqueTriggerActivation.triggerCivwideUnique(unique, civInfo)
             }
             else -> {}
         }


### PR DESCRIPTION
Unciv crashes at https://github.com/yairm210/Unciv/blob/master/core/src/com/unciv/logic/civilization/managers/ReligionManager.kt#L378 because `religion` is needed to be non-null and is null (because it has not yet been created).

Maybe setting `ReligionState` needs to be down at https://github.com/yairm210/Unciv/blob/master/core/src/com/unciv/logic/civilization/managers/ReligionManager.kt#L390, I don't know, I don't really follow the logic there. But I think `foundPantheon` needs to happen before `religion` is used, because that's what makes `religion` non-null.

```
2024-01-07T21:58:35.775775Z [main] [UncivGame] [ERROR] Uncaught throwable | java.lang.NullPointerException
        at com.unciv.logic.civilization.managers.ReligionManager.chooseBeliefs(ReligionManager.kt:379)
        at com.unciv.ui.screens.pickerscreens.PantheonPickerScreen$3.invoke(PantheonPickerScreen.kt:36)
        at com.unciv.ui.screens.pickerscreens.PantheonPickerScreen$3.invoke(PantheonPickerScreen.kt:35)
        at com.unciv.ui.screens.pickerscreens.ReligionPickerScreenCommon$setOKAction$1.invoke(ReligionPickerScreenCommon.kt:68)
        at com.unciv.ui.screens.pickerscreens.ReligionPickerScreenCommon$setOKAction$1.invoke(ReligionPickerScreenCommon.kt:67)
        at com.unciv.ui.components.input.ActivationActionMap.activate(ActivationActionMap.kt:56)
        at com.unciv.ui.components.input.ActorAttachments.activate(ActorAttachments.kt:42)
        at com.unciv.ui.components.input.ActivationExtensionsKt.activate(ActivationExtensions.kt:17)
        at com.unciv.ui.components.input.ActivationListener.tap(ActivationListener.kt:15)
        at com.badlogic.gdx.scenes.scene2d.utils.ActorGestureListener$1.tap(ActorGestureListener.java:52)
        at com.badlogic.gdx.input.GestureDetector.touchUp(GestureDetector.java:206)
        at com.badlogic.gdx.scenes.scene2d.utils.ActorGestureListener.handle(ActorGestureListener.java:125)
        at com.badlogic.gdx.scenes.scene2d.Stage.touchUp(Stage.java:354)
        at com.unciv.ui.screens.basescreen.UncivStage.access$touchUp$s80204510(UncivStage.kt:17)
        at com.unciv.ui.screens.basescreen.UncivStage$touchUp$1.invoke(UncivStage.kt:87)
        at com.unciv.ui.screens.basescreen.UncivStage$touchUp$1.invoke(UncivStage.kt:87)
        at com.unciv.ui.crashhandling.CrashHandlingExtensionsKt$wrapCrashHandling$1.invoke(CrashHandlingExtensions.kt:17)
        at com.unciv.ui.screens.basescreen.UncivStage.touchUp(UncivStage.kt:87)
        at com.badlogic.gdx.InputEventQueue.drain(InputEventQueue.java:70)
        at com.badlogic.gdx.backends.lwjgl3.DefaultLwjgl3Input.update(DefaultLwjgl3Input.java:189)
        at com.badlogic.gdx.backends.lwjgl3.Lwjgl3Window.update(Lwjgl3Window.java:378)
        at com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application.loop(Lwjgl3Application.java:193)
        at com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application.<init>(Lwjgl3Application.java:167)
        at com.unciv.app.desktop.HardenGdxAudio.<init>(HardenGdxAudio.kt:46)
        at com.unciv.app.desktop.DesktopLauncher.main(DesktopLauncher.kt:76)

```
This branch makes the `NullPointerException` not happen.