### PR TITLE
Allow map editor to generate smaller than "tiny" Pangaea maps

### DIFF
--- a/core/src/com/unciv/logic/map/mapgenerator/MapLandmassGenerator.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/MapLandmassGenerator.kt
@@ -153,9 +153,9 @@ class MapLandmassGenerator(val ruleset: Ruleset, val randomness: MapGenerationRa
 
     private fun createPangaea(tileMap: TileMap) {
         val largeContinentThreshold = (tileMap.values.size / 4).coerceAtMost(25)
-        var maxRetries = 200  // A bit much but enough to reach waterThreshold -1
+        var retryCount = 200  // A bit much but when relevant (tiny map) an iteration is relatively cheap
 
-        while(--maxRetries >= 0) {
+        while(--retryCount >= 0) {
             val elevationSeed = randomness.RNG.nextInt().toDouble()
             for (tile in tileMap.values) {
                 var elevation = randomness.getPerlinNoise(tile, elevationSeed)

--- a/core/src/com/unciv/logic/map/mapgenerator/MapLandmassGenerator.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/MapLandmassGenerator.kt
@@ -152,7 +152,10 @@ class MapLandmassGenerator(val ruleset: Ruleset, val randomness: MapGenerationRa
     }
 
     private fun createPangaea(tileMap: TileMap) {
-        do {
+        val largeContinentThreshold = (tileMap.values.size / 4).coerceAtMost(25)
+        var maxRetries = 200  // A bit much but enough to reach waterThreshold -1
+
+        while(--maxRetries >= 0) {
             val elevationSeed = randomness.RNG.nextInt().toDouble()
             for (tile in tileMap.values) {
                 var elevation = randomness.getPerlinNoise(tile, elevationSeed)
@@ -162,9 +165,11 @@ class MapLandmassGenerator(val ruleset: Ruleset, val randomness: MapGenerationRa
             }
 
             tileMap.assignContinents(TileMap.AssignContinentsMode.Reassign)
+            if ( tileMap.continentSizes.values.count { it > largeContinentThreshold } == 1  // Only one large continent
+                    && tileMap.values.count { it.baseTerrain == waterTerrainName } <= tileMap.values.size * 0.7f // And at most 70% water
+                ) break
             waterThreshold -= 0.01
-        } while (tileMap.continentSizes.values.count { it > 25 } != 1 // Multiple large continents
-                || tileMap.values.count { it.baseTerrain == waterTerrainName } > tileMap.values.size * 0.7f) // Over 70% water
+        }
         tileMap.assignContinents(TileMap.AssignContinentsMode.Clear)
     }
 


### PR DESCRIPTION
https://github.com/yairm210/Unciv/commit/b9299ac50dbef13004f990b9050c60ddb10fd93f broke an edge case: Enter a very small map size, and it becomes impossible to get continent size >= 25, resulting in an infinite loop.

This picture was not possible without this fix:
<details>

![image](https://github.com/yairm210/Unciv/assets/63000004/020ffd58-5d89-4e49-be28-b519047f9e9e)
</details>