### PR TITLE
Worker remove feature AI fix

### DIFF
--- a/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
@@ -655,6 +655,18 @@ class WorkerAutomation(
             tile.neighbors.any {it.getOwner() == unit.civ && it.owningCity != null && tile.aerialDistanceTo(it.owningCity!!.getCenterTile()) <= 3}) 
             stats = tile.stats.getStatDiffForImprovement(improvement, civInfo, tile.getCity(), localUniqueCache).div(3f)
 
+        if (improvementName.startsWith("Remove ")) {
+            // We need to look beyond what we are doing right now and at the final improvement that will be on this tile
+            val terrainName = improvementName.replace("Remove ", "")
+            if (ruleSet.terrains.containsKey(terrainName)) { // Otherwise we get an infinite road loop
+                tile.removeTerrainFeature(terrainName)
+                val wantedFinalImprovement = chooseImprovement(unit, tile)
+                if (wantedFinalImprovement != null)
+                    stats.add(tile.stats.getStatDiffForImprovement(wantedFinalImprovement, civInfo, tile.getCity(), localUniqueCache))
+                tile.addTerrainFeature(terrainName)
+            }
+        }
+        
         var value = Automation.rankStatsValue(stats, unit.civ)
         // Calculate the bonus from gaining the resources, this isn't included in the stats above
         if (tile.resource != null && tile.tileResource.resourceType != ResourceType.Bonus) {

--- a/tests/src/com/unciv/logic/automation/unit/WorkerAutomationTest.kt
+++ b/tests/src/com/unciv/logic/automation/unit/WorkerAutomationTest.kt
@@ -55,6 +55,30 @@ internal class WorkerAutomationTest {
     }
 
     @Test
+    fun `should remove terrain feature enable resource`() {
+        // Add the needed tech to construct the improvements below
+        for (improvement in listOf("Remove Forest", "Plantation")) {
+            civInfo.tech.techsResearched.add(testGame.ruleset.tileImprovements[improvement]!!.techRequired!!)
+        }
+
+        testGame.addCity(civInfo, testGame.tileMap[0,0])
+
+        val currentTile = testGame.tileMap[1,1]
+        currentTile.addTerrainFeature("Hill")
+        currentTile.addTerrainFeature("Forest")
+        currentTile.resource = "Citrus"
+        currentTile.resourceAmount = 1
+
+        val mapUnit = testGame.addUnit("Worker", civInfo, currentTile)
+
+        workerAutomation.automateWorkerAction(mapUnit, hashSetOf())
+
+        assertEquals("Worker should begun removing the forest to clear a luxury resource but didn't",
+            "Remove Forest", currentTile.improvementInProgress)
+        assertTrue(currentTile.turnsToImprovement > 0)
+    }
+
+    @Test
     fun `should build improvement on unseen resource`() {
         // Add the needed tech to construct the improvements below
         for (improvement in listOf(RoadStatus.Road.name, "Farm")) {


### PR DESCRIPTION
This PR fixes part of #10776, specifically regarding the value of removing a terrain feature so that a better improvement can be built. Also adds one test!

When determining the value of removing a feature, we need to take into account the improvement that can be built afterwards. This change does that and hopefully doesn't include any bugs for mods. The test that was added specifically fails in the version before this change.