### PR TITLE
AI worker road priority rework

### DIFF
--- a/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
@@ -280,7 +280,7 @@ class WorkerAutomation(
      */
     private fun getRoadConnectionBetweenCities(unit: MapUnit, city: City): List<Tile> {
         if (city in roadsToConnectCitiesCache) return roadsToConnectCitiesCache[city]!!
-        
+
         val isCandidateTilePredicate: (Tile) -> Boolean = { it.isLand && unit.movement.canPassThrough(it) }
         val toConnectTile = city.getCenterTile()
         val bfs: BFS = bfsCache[toConnectTile.position] ?:
@@ -291,7 +291,7 @@ class WorkerAutomation(
             )
             bfsCache[toConnectTile.position] = this@apply
         }
-        val cityTilesToSeek = HashSet(tilesOfConnectedCities.sortedBy { it.aerialDistanceTo(city.getCenterTile()) })
+        val cityTilesToSeek = HashSet(tilesOfConnectedCities)
 
         var nextTile = bfs.nextStep()
         do {
@@ -309,7 +309,7 @@ class WorkerAutomation(
             if (bfs.hasEnded()) break // No tiles left
             nextTile = bfs.nextStep()
         } while (nextTile != null)
-        
+
         roadsToConnectCitiesCache[city] = listOf()
         return roadsToConnectCitiesCache[city]!!
     }
@@ -327,7 +327,7 @@ class WorkerAutomation(
             return
         }
         val tileToWork = findTileToWork(unit, dangerousTiles)
-        
+
         if (tileToWork != currentTile) {
             debug("WorkerAutomation: %s -> head towards %s", unit.label(), tileToWork)
             val reachedTile = unit.movement.headTowards(tileToWork)

--- a/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
@@ -294,21 +294,20 @@ class WorkerAutomation(
         val cityTilesToSeek = HashSet(tilesOfConnectedCities)
 
         var nextTile = bfs.nextStep()
-        do {
+        while (nextTile != null) {
             if (nextTile in cityTilesToSeek) {
                 // We have a winner!
-                val cityTile = nextTile!!
+                val cityTile = nextTile
                 val pathToCity = bfs.getPathTo(cityTile)
-                roadsToConnectCitiesCache[city] = pathToCity.toList()
+                roadsToConnectCitiesCache[city] = pathToCity.toList().filter { it.roadStatus != bestRoadAvailable }
                 for (tile in pathToCity) { 
                     if (tile !in tilesOfRoadsToConnectCities)
                         tilesOfRoadsToConnectCities[tile] = city
                 }
                 return roadsToConnectCitiesCache[city]!!
             }
-            if (bfs.hasEnded()) break // No tiles left
             nextTile = bfs.nextStep()
-        } while (nextTile != null)
+        } 
 
         roadsToConnectCitiesCache[city] = listOf()
         return roadsToConnectCitiesCache[city]!!

--- a/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
@@ -674,10 +674,11 @@ class WorkerAutomation(
             && tile in tilesOfRoadsToConnectCities) {
             var value = 1f
             val city = tilesOfRoadsToConnectCities[tile]!!
-            // Bigger cities have a higher priority to connect
-            value += (city.population.population - 3) * .2f
+            if (civInfo.stats.statsForNextTurn.gold >= 20)
+                // Bigger cities have a higher priority to connect
+                value += (city.population.population - 3) * .3f
             // Higher priority if we are closer to connecting the city
-            value += 2 - roadsToConnectCitiesCache[city]!!.size * .2f
+            value += 5 - roadsToConnectCitiesCache[city]!!.size
             return value
         }
 

--- a/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
@@ -449,7 +449,7 @@ class WorkerAutomation(
                 .filter { it.second < bestTileToConstructRoadOnDist }
                 .sortedBy { it.second }
                 .minByOrNull {
-                    unit.movement.canMoveTo(it.first) && unit.movement.canReach(it.first)
+                    unit.movement.canMoveTo(it.first) && unit.movement.canReach(it.first) 
                 } ?: continue // Apparently we can't reach any of these tiles at all
             bestTileToConstructRoadOn = reachableTile.first
             bestTileToConstructRoadOnDist = reachableTile.second
@@ -457,7 +457,7 @@ class WorkerAutomation(
 
         if (bestTileToConstructRoadOn == null) return false
 
-        if (bestTileToConstructRoadOn != currentTile)
+        if (bestTileToConstructRoadOn != currentTile && unit.currentMovement > 0)
             unit.movement.headTowards(bestTileToConstructRoadOn)
         if (unit.currentMovement > 0 && bestTileToConstructRoadOn == currentTile 
             && currentTile.improvementInProgress != bestRoadAvailable.name) {

--- a/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
@@ -678,7 +678,7 @@ class WorkerAutomation(
             // Bigger cities have a higher priority to connect
                 value += (city.population.population - 3) * .3f
             // Higher priority if we are closer to connecting the city
-            value += 5 - roadsToConnectCitiesCache[city]!!.size
+            value += (5 - roadsToConnectCitiesCache[city]!!.size).coerceAtLeast(0)
             return value
         }
         

--- a/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
@@ -274,8 +274,8 @@ class WorkerAutomation(
     }
 
     /**
-     * Uses a cache to find and return the connection to make that is assosiated with a city.
-     * May not work if the unit that originially created this cache is different from the next.
+     * Uses a cache to find and return the connection to make that is associated with a city.
+     * May not work if the unit that originally created this cache is different from the next.
      * (Due to the difference in [UnitMovement.canPassThrough()])
      */
     private fun getRoadConnectionBetweenCities(unit: MapUnit, city: City): List<Tile> {

--- a/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
@@ -447,7 +447,7 @@ class WorkerAutomation(
             val reachableTile = roadableTiles.map { Pair(it, it.aerialDistanceTo(unit.getTile())) }
                 .filter { it.second < bestTileToConstructRoadOnDist }
                 .sortedBy { it.second }
-                .minByOrNull {
+                .firstOrNull {
                     unit.movement.canMoveTo(it.first) && unit.movement.canReach(it.first) 
                 } ?: continue // Apparently we can't reach any of these tiles at all
             bestTileToConstructRoadOn = reachableTile.first

--- a/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
@@ -644,6 +644,7 @@ class WorkerAutomation(
 
         // After gathering all the data, we conduct the hierarchy in one place
         val improvementString = when {
+            bestBuildableImprovement != null && bestBuildableImprovement.isRoad() -> bestBuildableImprovement.name
             improvementStringForResource != null -> if (improvementStringForResource==tile.improvement) null else improvementStringForResource
             // If this is a resource that HAS an improvement that we can see, but this unit can't build it, don't waste your time
             tile.resource != null && tile.hasViewableResource(civInfo) && tile.tileResource.getImprovements().any() -> return null

--- a/core/src/com/unciv/logic/map/BFS.kt
+++ b/core/src/com/unciv/logic/map/BFS.kt
@@ -47,15 +47,16 @@ class BFS(
      *
      * Will do nothing when [hasEnded] returns `true`
      */
-    fun nextStep() {
-        if (tilesReached.size >= maxSize) { tilesToCheck.clear(); return }
-        val current = tilesToCheck.removeFirstOrNull() ?: return
+    fun nextStep(): Tile? {
+        if (tilesReached.size >= maxSize) { tilesToCheck.clear(); return null }
+        val current = tilesToCheck.removeFirstOrNull() ?: return null
         for (neighbor in current.neighbors) {
             if (neighbor !in tilesReached && predicate(neighbor)) {
                 tilesReached[neighbor] = current
                 tilesToCheck.add(neighbor)
             }
         }
+        return current
     }
 
     /**

--- a/tests/src/com/unciv/logic/automation/unit/WorkerAutomationTest.kt
+++ b/tests/src/com/unciv/logic/automation/unit/WorkerAutomationTest.kt
@@ -268,12 +268,13 @@ internal class WorkerAutomationTest {
             // Prevent any sort of worker spawning
             civInfo.addGold(-civInfo.gold)
             civInfo.policies.freePolicies = 0
-            civInfo.addStat(Stat.Science, - 100000)
 
             NextTurnAutomation.automateCivMoves(civInfo)
             TurnManager(civInfo).endTurn()
             // Invalidate WorkerAutomationCache
             testGame.gameInfo.turns++
+            // Because the civ will annoyingly try to research it again
+            civInfo.tech.techsResearched.remove(testGame.ruleset.tileImprovements["Farm"]!!.techRequired!!)
         }
 
         var finishedCount = 0


### PR DESCRIPTION
This PR is the main follow-up to #10776 and changes the approach that we use to build roads. The previous road-building AI is the reason for the indecisiveness and lack of overall work being done by the workers. So what exactly does this PR change?

- Before a worker does any logic on choosing which tile to improve, it searches for nearby cities that need to be connected to the road network. This is then cached for the rest of the workers and all tiles nearby that we would like to build a road on are marked in the `tilesOfRoadsToConnectCities` hashmap.
- Now that we have a way to check if we want to build a road on a tile close to the worker efficiently, `getImprovementRanking` can easily tell us how much we should value building the road there based on city size and how many roads need to be built to complete the connection. This allows `findTileToWork` to include desirable roads in its nearby search, moving the essential road building code out of `tryConnectCities`.
- `tryConnectCities` is now only used to go to a farther away road building location since `findTileToWork` has a higher priority than it. It isn't very efficient, it could be better if we can do a `unit.movement.distanceToTiles` combined with the `BFS.step` function since after each step we can check the new tile is in `tilesOfRoadsToConnectCities`.

The result is that the workers do a lot more work. They don't wander around aimlessly like they did before and actually sit down to build improvements. However, they now don't build roads unless they really have to. Causing the road network to be either non-existant or patchy. This, however, is a fix for another time since I am not sure if these changes broke that or if it was always broken and the bad AI hid it.

<details><summary>Example</summary>
The AI here has 5 workers, and most of them are off-screen (it needs to build more). The road connection is very funky because the cities are connected via port and, according to the AI don't need to be connected via road. The workers in this game have been constantly working, which is very good. This is sort of an extreme example since most cities can be connected via sea. Bigger maps with more inland will likely have better results.

![NewWorkerRoadAI](https://github.com/yairm210/Unciv/assets/7538725/c81aa33d-a19a-4f6e-a6dd-64c9960a2105)
![NewWorkerRoadAI](https://github.com/yairm210/Unciv/assets/7538725/e916ffb2-3838-4f20-96a6-a3dd1fa89a79)

</details> 