### PR TITLE
Fix Paradrop crossing World-wrap seam

### DIFF
--- a/core/src/com/unciv/logic/map/HexMath.kt
+++ b/core/src/com/unciv/logic/map/HexMath.kt
@@ -4,13 +4,13 @@ import com.badlogic.gdx.math.Vector2
 import com.badlogic.gdx.math.Vector3
 import kotlin.math.abs
 import kotlin.math.cos
+import kotlin.math.max
+import kotlin.math.min
 import kotlin.math.round
 import kotlin.math.roundToInt
 import kotlin.math.sign
 import kotlin.math.sin
 import kotlin.math.sqrt
-import kotlin.math.max
-import kotlin.math.min
 
 @Suppress("MemberVisibilityCanBePrivate", "unused")  // this is a library offering optional services
 object HexMath {
@@ -227,6 +227,7 @@ object HexMath {
         return hexesToReturn
     }
 
+    /** Get number of hexes from [origin] to [destination] _without respecting world-wrap_ */
     fun getDistance(origin: Vector2, destination: Vector2): Int {
         val relativeX = origin.x - destination.x
         val relativeY = origin.y - destination.y

--- a/core/src/com/unciv/logic/map/mapunit/movement/UnitMovement.kt
+++ b/core/src/com/unciv/logic/map/mapunit/movement/UnitMovement.kt
@@ -5,7 +5,6 @@ package com.unciv.logic.map.mapunit.movement
 import com.badlogic.gdx.math.Vector2
 import com.unciv.Constants
 import com.unciv.logic.map.BFS
-import com.unciv.logic.map.HexMath.getDistance
 import com.unciv.logic.map.mapunit.MapUnit
 import com.unciv.logic.map.tile.Tile
 import com.unciv.models.UnitActionType
@@ -258,7 +257,7 @@ class UnitMovement(val unit: MapUnit) {
         if (unit.baseUnit.movesLikeAirUnits())
             return unit.currentTile.aerialDistanceTo(destination) <= unit.getMaxMovementForAirUnits()
         if (unit.isPreparingParadrop())
-            return getDistance(unit.currentTile.position, destination.position) <= unit.cache.paradropRange && canParadropOn(destination)
+            return unit.currentTile.aerialDistanceTo(destination) <= unit.cache.paradropRange && canParadropOn(destination)
         return getDistanceToTiles().containsKey(destination)
     }
 

--- a/core/src/com/unciv/ui/screens/worldscreen/WorldMapHolder.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/WorldMapHolder.kt
@@ -501,18 +501,22 @@ class WorldMapHolder(
     val smallerCircleSizes = 25f
 
     private fun getMoveHereButton(dto: MoveHereButtonDto): Group {
-        val moveHereButton = ImageGetter.getStatIcon("Movement")
-            .apply { color = Color.BLACK; width = buttonSize / 2; height = buttonSize / 2 }
-            .surroundWithCircle(buttonSize-2, false)
+        val isParadrop = dto.unitToTurnsToDestination.keys.all { it.isPreparingParadrop() }
+        val image = if (isParadrop)
+                ImageGetter.getUnitActionPortrait("Paradrop", buttonSize / 2)
+            else ImageGetter.getStatIcon("Movement")
+                .apply { color = Color.BLACK; width = buttonSize / 2; height = buttonSize / 2 }
+        val moveHereButton = image
+            .surroundWithCircle(buttonSize - 2, false)
             .surroundWithCircle(buttonSize, false, Color.BLACK)
 
-
-        val numberCircle = dto.unitToTurnsToDestination.values.maxOrNull()!!.toString().toLabel(fontSize = 14)
-            .apply { setAlignment(Align.center) }
-            .surroundWithCircle(smallerCircleSizes-2, color = BaseScreen.skinStrings.skinConfig.baseColor.darken(0.3f))
-            .surroundWithCircle(smallerCircleSizes,false)
-
-        moveHereButton.addActor(numberCircle)
+        if (!isParadrop) {
+            val numberCircle = dto.unitToTurnsToDestination.values.maxOrNull()!!.toString().toLabel(fontSize = 14)
+                .apply { setAlignment(Align.center) }
+                .surroundWithCircle(smallerCircleSizes - 2, color = BaseScreen.skinStrings.skinConfig.baseColor.darken(0.3f))
+                .surroundWithCircle(smallerCircleSizes, false)
+            moveHereButton.addActor(numberCircle)
+        }
 
         val firstUnit = dto.unitToTurnsToDestination.keys.first()
         val unitIcon = if (dto.unitToTurnsToDestination.size == 1) UnitGroup(firstUnit, smallerCircleSizes)
@@ -536,7 +540,7 @@ class WorldMapHolder(
     }
 
     private fun getSwapWithButton(dto: SwapWithButtonDto): Group {
-        val swapWithButton = Group().apply { width = buttonSize;height = buttonSize; }
+        val swapWithButton = Group().apply { width = buttonSize; height = buttonSize }
         swapWithButton.addActor(ImageGetter.getCircle().apply { width = buttonSize; height = buttonSize })
         swapWithButton.addActor(
             ImageGetter.getImage("OtherIcons/Swap")


### PR DESCRIPTION
Fixes #10922 

New paradropping "MoveToButton" looks like this:
<details>

![image](https://github.com/yairm210/Unciv/assets/63000004/72f5f2d0-6d74-4f38-a50e-2e6b78338837)
(yes that is the unit and destination tile the issue OP @Rw-Ro fingered)
</details>

#### Note
Multi-selecting two Paradrop-capable units then selecting like above (tile is in paradrop range but needs multiple turns to reach "normally") will behave like this:
- MoveToButton is normal - shows two units needing 6 turns (this is why the code uses `all` instead of first or any there)
- When activated, the first unit paradrops, the second starts the 6-turn journey
- As mentioned in the issue, I got no clear what-to-do-about-that ideas

The extra inner circle in that picture is part of the used icon - if it irks, we could repaint one without (regrettably, the word 'paradrop' does not appear in credits.md)