### PR TITLE
Treat all timed uniques as functioning as always true regardless of conditionals

### DIFF
--- a/core/src/com/unciv/models/ruleset/unique/Unique.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Unique.kt
@@ -64,6 +64,8 @@ class Unique(val text: String, val sourceObjectType: UniqueTarget? = null, val s
 
     fun conditionalsApply(state: StateForConditionals = StateForConditionals()): Boolean {
         if (state.ignoreConditionals) return true
+        // Always allow Timed conditional uniques. They are managed elsewhere
+        if (conditionals.any{ it.isOfType(UniqueType.ConditionalTimedUnique) }) return true
         for (condition in conditionals) {
             if (!conditionalApplies(condition, state)) return false
         }
@@ -465,7 +467,8 @@ class UniqueMap: HashMap<String, ArrayList<Unique>>() {
 class TemporaryUnique() : IsPartOfGameInfoSerialization {
 
     constructor(uniqueObject: Unique, turns: Int) : this() {
-        unique = uniqueObject.text
+        val turnsText = uniqueObject.conditionals.first { it.isOfType(UniqueType.ConditionalTimedUnique) }.text
+        unique = uniqueObject.text.replace("<$turnsText>", "")
         sourceObjectType = uniqueObject.sourceObjectType
         sourceObjectName = uniqueObject.sourceObjectName
         turnsLeft = turns

--- a/core/src/com/unciv/models/ruleset/unique/Unique.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Unique.kt
@@ -468,7 +468,7 @@ class TemporaryUnique() : IsPartOfGameInfoSerialization {
 
     constructor(uniqueObject: Unique, turns: Int) : this() {
         val turnsText = uniqueObject.conditionals.first { it.isOfType(UniqueType.ConditionalTimedUnique) }.text
-        unique = uniqueObject.text.replace("<$turnsText>", "")
+        unique = uniqueObject.text.replaceFirst("<$turnsText>", "")
         sourceObjectType = uniqueObject.sourceObjectType
         sourceObjectName = uniqueObject.sourceObjectName
         turnsLeft = turns


### PR DESCRIPTION
For any mods functioning as intended, this should have no effect on anything. Treat it as a refactor of sorts

Necessary for #10839. I admit, this is probably a really sketchy way to handle it, but not sure what the better way would be. The way I see it, we handle the situation in one of 3 ways

1. This PR. Don't check `conditionsApplies` if it has a timed conditional. We should check the condtionals later anyways
2. We decide which conditionals should be ignored in this situation and which shouldn't. Significantly more code to basically do what this PR is already doing, and would be extremely arbitrary
3. We somehow treat conditionsApplies with its own set of conditionals (maybe showing it to the player in parenthesis). Still kinda just option 1 with extra steps


Also, is there a better String function than `replaces` that only removes the first instance of the noted string? I kinda, maybe, kinda was lazy about checking for a better function