### PR TITLE
AI worker amount increase

### DIFF
--- a/core/src/com/unciv/logic/automation/city/ConstructionAutomation.kt
+++ b/core/src/com/unciv/logic/automation/city/ConstructionAutomation.kt
@@ -193,8 +193,8 @@ class ConstructionAutomation(val cityConstructions: CityConstructions) {
             }.filterBuildable()
         if (workerEquivalents.none()) return // for mods with no worker units
 
-        // For the first 3 cities, dedicate a worker, from then on only build another worker if you have 12 cities.
-        val numberOfWorkersWeWant = if (cities < 4) cities else max(3, cities/3)
+        // Dedicate a worker for the first 7 cities, from then on only build another worker for every 2 cities.
+        val numberOfWorkersWeWant = if (cities < 7) cities else 7 + (cities - 7 / 2)
 
         if (workers < numberOfWorkersWeWant) {
             var modifier = numberOfWorkersWeWant / (workers + 0.1f) // The worse our worker to city ratio is, the more desperate we are

--- a/core/src/com/unciv/logic/automation/city/ConstructionAutomation.kt
+++ b/core/src/com/unciv/logic/automation/city/ConstructionAutomation.kt
@@ -193,8 +193,8 @@ class ConstructionAutomation(val cityConstructions: CityConstructions) {
             }.filterBuildable()
         if (workerEquivalents.none()) return // for mods with no worker units
 
-        // Dedicate a worker for the first 7 cities, from then on only build another worker for every 2 cities.
-        val numberOfWorkersWeWant = if (cities < 7) cities else 7 + (cities - 7 / 2)
+        // Dedicate a worker for the first 5 cities, from then on only build another worker for every 2 cities.
+        val numberOfWorkersWeWant = if (cities <= 5) cities else 5 + (cities - 5 / 2)
 
         if (workers < numberOfWorkersWeWant) {
             var modifier = numberOfWorkersWeWant / (workers + 0.1f) // The worse our worker to city ratio is, the more desperate we are


### PR DESCRIPTION
Currently, the AI doesn't build very many workers so this PR increases that value to handle improvement and road building. Previously the AI only builds 3 workers up until it has 12 cities where it then builds one more every 3 cities. Now the AI builds up to 5 workers and then one more for every two new cities.