### PR TITLE
Allow units to upgrade to more than one unit

### DIFF
--- a/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
@@ -127,7 +127,7 @@ object UnitAutomation {
     internal fun tryUpgradeUnit(unit: MapUnit): Boolean {
         if (unit.civ.isHuman() && (!UncivGame.Current.settings.automatedUnitsCanUpgrade
                 || UncivGame.Current.settings.autoPlay.isAutoPlayingAndFullAI())) return false
-        if (unit.baseUnit.upgradesTo == null) return false
+        if (unit.baseUnit.upgradeUnits(StateForConditionals(unit.civ, unit = unit)).none()) return false
         val upgradedUnit = unit.upgrade.getUnitToUpgradeTo()
         if (!upgradedUnit.isBuildable(unit.civ)) return false // for resource reasons, usually
 
@@ -136,10 +136,9 @@ object UnitAutomation {
             if (!Automation.allowSpendingResource(unit.civ, upgradedUnit)) return false
         }
 
-        val upgradeAction = UnitActionsUpgrade.getUpgradeAction(unit)
-            ?: return false
+        val upgradeAction = UnitActionsUpgrade.getUpgradeActions(unit)
 
-        upgradeAction.action?.invoke()
+        upgradeAction.firstOrNull()?.action?.invoke()
         return unit.isDestroyed // a successful upgrade action will destroy this unit
     }
 

--- a/core/src/com/unciv/logic/city/CityConstructions.kt
+++ b/core/src/com/unciv/logic/city/CityConstructions.kt
@@ -413,9 +413,13 @@ class CityConstructions : IsPartOfGameInfoSerialization {
                     }
                 } else if (construction is BaseUnit) {
                     // Production put into upgradable units gets put into upgraded version
-                    if (rejectionReasons.all { it.type == RejectionReasonType.Obsoleted } && construction.upgradesTo != null) {
-                        val upgradedUnitName = city.civ.getEquivalentUnit(construction.upgradesTo!!).name
-                        inProgressConstructions[upgradedUnitName] = (inProgressConstructions[upgradedUnitName] ?: 0) + workDone
+                    val cheapestUpgradeUnit = construction.upgradeUnits(StateForConditionals(city.civ, city))
+                        .mapNotNull { city.civ.gameInfo.ruleset.units[it]?.let { 
+                            unit -> city.civ.getEquivalentUnit(unit) } }
+                        .filter { it.isBuildable(this) }
+                        .minByOrNull { it.cost }
+                    if (rejectionReasons.all { it.type == RejectionReasonType.Obsoleted } && cheapestUpgradeUnit != null) {
+                        inProgressConstructions[cheapestUpgradeUnit.name] = (inProgressConstructions[cheapestUpgradeUnit.name] ?: 0) + workDone
                     }
                 }
                 inProgressConstructions.remove(constructionName)

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -789,16 +789,16 @@ object UniqueTriggerActivation {
             }
             UniqueType.OneTimeUnitUpgrade -> {
                 val upgradeAction = UnitActionsUpgrade.getFreeUpgradeAction(unit)
-                    ?: return false
-                upgradeAction.action!!()
+                if (upgradeAction.none()) return false
+                upgradeAction.first().action!!()
                 if (notification != null)
                     unit.civ.addNotification(notification, unit.getTile().position, NotificationCategory.Units)
                 return true
             }
             UniqueType.OneTimeUnitSpecialUpgrade -> {
                 val upgradeAction = UnitActionsUpgrade.getAncientRuinsUpgradeAction(unit)
-                    ?: return false
-                upgradeAction.action!!()
+                if (upgradeAction.none()) return false
+                upgradeAction.first().action!!()
                 if (notification != null)
                     unit.civ.addNotification(notification, unit.getTile().position, NotificationCategory.Units)
                 return true

--- a/core/src/com/unciv/ui/popups/UnitUpgradeMenu.kt
+++ b/core/src/com/unciv/ui/popups/UnitUpgradeMenu.kt
@@ -1,6 +1,5 @@
 package com.unciv.ui.popups
 
-import com.badlogic.gdx.math.Vector2
 import com.badlogic.gdx.scenes.scene2d.Actor
 import com.badlogic.gdx.scenes.scene2d.Stage
 import com.badlogic.gdx.scenes.scene2d.ui.Table
@@ -93,8 +92,8 @@ class UnitUpgradeMenu(
     private fun doAllUpgrade() {
         SoundPlayer.playRepeated(unitAction.uncivSound)
         for (unit in allUpgradableUnits) {
-            val otherAction = UnitActionsUpgrade.getUpgradeAction(unit)
-            otherAction?.action?.invoke()
+            val otherAction = UnitActionsUpgrade.getUpgradeActions(unit)
+            otherAction.firstOrNull()?.action?.invoke()
         }
     }
 }

--- a/core/src/com/unciv/ui/screens/overviewscreen/UnitOverviewTab.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/UnitOverviewTab.kt
@@ -258,8 +258,8 @@ class UnitOverviewTab(
             add(promotionsTable)
 
             // Upgrade column
-            val unitAction = UnitActionsUpgrade.getUpgradeActionAnywhere(unit)
-            if (unitAction != null) {
+            val unitActions = UnitActionsUpgrade.getUpgradeActionAnywhere(unit)
+            for (unitAction in unitActions){
                 val enable = unitAction.action != null && viewingPlayer.isCurrentPlayer() &&
                     GUI.isAllowedChangeState()
                 val unitToUpgradeTo = (unitAction as UpgradeUnitAction).unitToUpgradeTo
@@ -273,8 +273,7 @@ class UnitOverviewTab(
                     }
                 }
                 add(upgradeIcon).size(28f)
-            } else add()
-
+            }
             // Numeric health column - there's already a health bar on the button, but...?
             if (unit.health < 100) add(unit.health.toLabel()) else add()
             row()

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsUpgrade.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsUpgrade.kt
@@ -15,96 +15,97 @@ object UnitActionsUpgrade {
         unit: MapUnit,
         tile: Tile
     ): List<UnitAction> {
-        val upgradeAction = getUpgradeAction(unit)
-        if (upgradeAction != null) return listOf(upgradeAction)
-        return listOf()
+        return getUpgradeActions(unit)
     }
 
-    /**  Common implementation for [getUpgradeAction], [getFreeUpgradeAction] and [getAncientRuinsUpgradeAction] */
-    private fun getUpgradeAction(
+    /**  Common implementation for [getUpgradeActions], [getFreeUpgradeAction] and [getAncientRuinsUpgradeAction] */
+    private fun getUpgradeActions(
         unit: MapUnit,
-        isFree: Boolean,
         isSpecial: Boolean,
+        isFree: Boolean,
         isAnywhere: Boolean
-    ): UnitAction? {
-        val specialUpgradesTo = unit.baseUnit().getMatchingUniques(UniqueType.RuinsUpgrade).map { it.params[0] }.firstOrNull()
-        if (unit.baseUnit().upgradesTo == null && specialUpgradesTo == null) return null // can't upgrade to anything
+    ): List<UnitAction> {
         val unitTile = unit.getTile()
         val civInfo = unit.civ
-        if (!isAnywhere && unitTile.getOwner() != civInfo) return null
+        val upgradeUnits = if (isSpecial) sequenceOf(
+            unit.baseUnit().getMatchingUniques(UniqueType.RuinsUpgrade, StateForConditionals(civInfo, unit= unit))
+                .map { it.params[0] }.firstOrNull()).filterNotNull() // empty the sequence if null
+            else unit.baseUnit.upgradeUnits(StateForConditionals(civInfo, unit = unit))
+        if (upgradeUnits.none()) return emptyList() // can't upgrade to anything
+        if (!isAnywhere && unitTile.getOwner() != civInfo) return emptyList()
 
-        val upgradesTo = unit.baseUnit().upgradesTo
-        val upgradedUnit = when {
-            isSpecial && specialUpgradesTo != null -> civInfo.getEquivalentUnit(specialUpgradesTo)
-            (isFree || isSpecial) && upgradesTo != null -> civInfo.getEquivalentUnit(upgradesTo) // Only get DIRECT upgrade
-            else -> unit.upgrade.getUnitToUpgradeTo() // Get EVENTUAL upgrade, all the way up the chain
-        }
+        var upgradeActions = emptySequence<UnitAction>()
+        for (upgradesTo in upgradeUnits){
+            if (upgradesTo == null) continue
+            val upgradedUnit = civInfo.getEquivalentUnit(upgradesTo)
 
-        if (!unit.upgrade.canUpgrade(unitToUpgradeTo = upgradedUnit, ignoreRequirements = isFree, ignoreResources = true))
-            return null
+            if (!unit.upgrade.canUpgrade(unitToUpgradeTo = upgradedUnit, ignoreRequirements = isFree, ignoreResources = true))
+                continue
 
-        // Check _new_ resource requirements (display only - yes even for free or special upgrades)
-        // Using Counter to aggregate is a bit exaggerated, but - respect the mad modder.
-        val resourceRequirementsDelta = Counter<String>()
-        for ((resource, amount) in unit.getResourceRequirementsPerTurn())
-            resourceRequirementsDelta.add(resource, -amount)
-        for ((resource, amount) in upgradedUnit.getResourceRequirementsPerTurn(StateForConditionals(unit.civ, unit = unit)))
-            resourceRequirementsDelta.add(resource, amount)
-        for ((resource, _) in resourceRequirementsDelta.filter { it.value < 0 })  // filter copies, so no CCM
-            resourceRequirementsDelta[resource] = 0
-        val newResourceRequirementsString = resourceRequirementsDelta.entries
-            .joinToString { "${it.value} {${it.key}}".tr() }
+            // Check _new_ resource requirements (display only - yes even for free or special upgrades)
+            // Using Counter to aggregate is a bit exaggerated, but - respect the mad modder.
+            val resourceRequirementsDelta = Counter<String>()
+            for ((resource, amount) in unit.getResourceRequirementsPerTurn())
+                resourceRequirementsDelta.add(resource, -amount)
+            for ((resource, amount) in upgradedUnit.getResourceRequirementsPerTurn(StateForConditionals(unit.civ, unit = unit)))
+                resourceRequirementsDelta.add(resource, amount)
+            for ((resource, _) in resourceRequirementsDelta.filter { it.value < 0 })  // filter copies, so no CCM
+                resourceRequirementsDelta[resource] = 0
+            val newResourceRequirementsString = resourceRequirementsDelta.entries
+                .joinToString { "${it.value} {${it.key}}".tr() }
 
-        val goldCostOfUpgrade = if (isFree) 0 else unit.upgrade.getCostOfUpgrade(upgradedUnit)
+            val goldCostOfUpgrade = if (isFree) 0 else unit.upgrade.getCostOfUpgrade(upgradedUnit)
 
-        // No string for "FREE" variants, these are never shown to the user.
-        // The free actions are only triggered via OneTimeUnitUpgrade or OneTimeUnitSpecialUpgrade in UniqueTriggerActivation.
-        val title = if (newResourceRequirementsString.isEmpty())
-            "Upgrade to [${upgradedUnit.name}] ([$goldCostOfUpgrade] gold)"
-        else "Upgrade to [${upgradedUnit.name}]\n([$goldCostOfUpgrade] gold, [$newResourceRequirementsString])"
+            // No string for "FREE" variants, these are never shown to the user.
+            // The free actions are only triggered via OneTimeUnitUpgrade or OneTimeUnitSpecialUpgrade in UniqueTriggerActivation.
+            val title = if (newResourceRequirementsString.isEmpty())
+                "Upgrade to [${upgradedUnit.name}] ([$goldCostOfUpgrade] gold)"
+            else "Upgrade to [${upgradedUnit.name}]\n([$goldCostOfUpgrade] gold, [$newResourceRequirementsString])"
 
-        return UpgradeUnitAction(
-            title = title,
-            unitToUpgradeTo = upgradedUnit,
-            goldCostOfUpgrade = goldCostOfUpgrade,
-            newResourceRequirements = resourceRequirementsDelta,
-            action = {
-                unit.destroy(destroyTransportedUnit = false)
-                val newUnit = civInfo.units.placeUnitNearTile(unitTile.position, upgradedUnit)
+            upgradeActions += UpgradeUnitAction(
+                title = title,
+                unitToUpgradeTo = upgradedUnit,
+                goldCostOfUpgrade = goldCostOfUpgrade,
+                newResourceRequirements = resourceRequirementsDelta,
+                action = {
+                    unit.destroy(destroyTransportedUnit = false)
+                    val newUnit = civInfo.units.placeUnitNearTile(unitTile.position, upgradedUnit)
 
-                /** We were UNABLE to place the new unit, which means that the unit failed to upgrade!
-                 * The only known cause of this currently is "land units upgrading to water units" which fail to be placed.
-                 */
+                    /** We were UNABLE to place the new unit, which means that the unit failed to upgrade!
+                     * The only known cause of this currently is "land units upgrading to water units" which fail to be placed.
+                     */
 
-                /** We were UNABLE to place the new unit, which means that the unit failed to upgrade!
-                 * The only known cause of this currently is "land units upgrading to water units" which fail to be placed.
-                 */
-                if (newUnit == null) {
-                    val resurrectedUnit = civInfo.units.placeUnitNearTile(unitTile.position, unit.baseUnit)!!
-                    unit.copyStatisticsTo(resurrectedUnit)
-                } else { // Managed to upgrade
-                    if (!isFree) civInfo.addGold(-goldCostOfUpgrade)
-                    unit.copyStatisticsTo(newUnit)
-                    newUnit.currentMovement = 0f
-                }
-            }.takeIf {
-                isFree || (
+                    /** We were UNABLE to place the new unit, which means that the unit failed to upgrade!
+                     * The only known cause of this currently is "land units upgrading to water units" which fail to be placed.
+                     */
+                    if (newUnit == null) {
+                        val resurrectedUnit = civInfo.units.placeUnitNearTile(unitTile.position, unit.baseUnit)!!
+                        unit.copyStatisticsTo(resurrectedUnit)
+                    } else { // Managed to upgrade
+                        if (!isFree) civInfo.addGold(-goldCostOfUpgrade)
+                        unit.copyStatisticsTo(newUnit)
+                        newUnit.currentMovement = 0f
+                    }
+                }.takeIf {
+                    isFree || (
                         unit.civ.gold >= goldCostOfUpgrade
-                                && unit.currentMovement > 0
-                                && unitTile.getOwner() == civInfo
-                                && !unit.isEmbarked()
-                                && unit.upgrade.canUpgrade(unitToUpgradeTo = upgradedUnit)
+                            && unit.currentMovement > 0
+                            && unitTile.getOwner() == civInfo
+                            && !unit.isEmbarked()
+                            && unit.upgrade.canUpgrade(unitToUpgradeTo = upgradedUnit)
                         )
-            }
-        )
+                }
+            )
+        }
+        return upgradeActions.toList()
     }
 
-    fun getUpgradeAction(unit: MapUnit) =
-            getUpgradeAction(unit, isFree = false, isSpecial = false, isAnywhere = false)
+    fun getUpgradeActions(unit: MapUnit) =
+        getUpgradeActions(unit, isSpecial = false, isFree = false, isAnywhere = false)
     fun getFreeUpgradeAction(unit: MapUnit) =
-            getUpgradeAction(unit, isFree = true, isSpecial = false, isAnywhere = true)
+        getUpgradeActions(unit, isSpecial = false, isFree = true, isAnywhere = true)
     fun getAncientRuinsUpgradeAction(unit: MapUnit) =
-            getUpgradeAction(unit, isFree = true, isSpecial = true, isAnywhere = true)
+        getUpgradeActions(unit, isSpecial = true, isFree = true, isAnywhere = true)
     fun getUpgradeActionAnywhere(unit: MapUnit) =
-            getUpgradeAction(unit, isFree = false, isSpecial = false, isAnywhere = true)
+        getUpgradeActions(unit, isSpecial = false, isFree = false, isAnywhere = true)
 }


### PR DESCRIPTION
Main notes here
1. It is intentional that I made it so the actions no longer tries to upgrade the unit all the way down the chain. Some (notably the obvious intention in Deciv) mods may allow for upgrading to multiple units via having a resource require and non resource required version where it's intentional that it doesn't want to automatically switch to the resource required version. Also, upgrading all the way is not accurate to civ 5, and Idk if that's intentional or not
2. There's several spots where there needed a reason to choose only 1 upgrade unit (most notably for the AI), so for the time being, I've to go with the simple option of the lowest cost one