### PR TITLE
Spectators can now view espionage

### DIFF
--- a/core/src/com/unciv/ui/screens/overviewscreen/EspionageOverviewScreen.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/EspionageOverviewScreen.kt
@@ -13,6 +13,7 @@ import com.unciv.models.Spy
 import com.unciv.models.SpyAction
 import com.unciv.models.translations.tr
 import com.unciv.ui.components.extensions.addSeparatorVertical
+import com.unciv.ui.components.extensions.disable
 import com.unciv.ui.components.extensions.setSize
 import com.unciv.ui.components.extensions.toLabel
 import com.unciv.ui.components.extensions.toTextButton
@@ -24,9 +25,10 @@ import com.unciv.ui.components.input.onClick
 import com.unciv.ui.components.widgets.AutoScrollPane
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.screens.pickerscreens.PickerScreen
+import com.unciv.ui.screens.worldscreen.WorldScreen
 
 /** Screen used for moving spies between cities */
-class EspionageOverviewScreen(val civInfo: Civilization) : PickerScreen(true) {
+class EspionageOverviewScreen(val civInfo: Civilization, val worldScreen: WorldScreen) : PickerScreen(true) {
     private val collator = UncivGame.Current.settings.getCollatorFromLocale()
 
     private val spySelectionTable = Table(skin)
@@ -102,6 +104,10 @@ class EspionageOverviewScreen(val civInfo: Civilization) : PickerScreen(true) {
                             && !city.espionage.hasSpyOf(civInfo)
                         )
                 }
+            }
+            if (worldScreen.viewingCiv != civInfo) {
+                // Spectators aren't allowed to move the spies of the Civs they are viewing
+                moveSpyButton.disable()
             }
             spySelectionTable.add(moveSpyButton).pad(5f, 10f, 5f, 20f).row()
         }

--- a/core/src/com/unciv/ui/screens/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/WorldScreen.kt
@@ -98,7 +98,6 @@ class WorldScreen(
     var selectedCiv = viewingCiv
 
     var fogOfWar = true
-        private set
 
     /** `true` when it's the player's turn unless he is a spectator */
     val canChangeState
@@ -112,7 +111,6 @@ class WorldScreen(
     // Floating Widgets going counter-clockwise
     val topBar = WorldScreenTopBar(this)
     private val techPolicyAndDiplomacy = TechPolicyDiplomacyButtons(this)
-    private val fogOfWarButton = createFogOfWarButton()
     private val unitActionsTable = UnitActionsTable(this)
     /** Bottom left widget holding information about a selected unit or city */
     val bottomUnitTable = UnitTable(this)
@@ -148,8 +146,6 @@ class WorldScreen(
         // resume music (in case choices from the menu lead to instantiation of a new WorldScreen)
         UncivGame.Current.musicController.resume()
 
-        fogOfWarButton.isVisible = viewingCiv.isSpectator()
-
         stage.addActor(mapHolder)
         stage.scrollFocus = mapHolder
         stage.addActor(notificationsScroll)  // very low in z-order, so we're free to let it extend _below_ tile info and minimap if we want
@@ -162,7 +158,6 @@ class WorldScreen(
         stage.addActor(zoomController)
         zoomController.isVisible = UncivGame.Current.settings.showZoomButtons
 
-        stage.addActor(fogOfWarButton)
         stage.addActor(bottomUnitTable)
         stage.addActor(bottomTileInfoTable)
         battleTable.width = stage.width / 3
@@ -306,7 +301,6 @@ class WorldScreen(
         minimapWrapper.isVisible = uiEnabled
         bottomUnitTable.isVisible = uiEnabled
         if (uiEnabled) battleTable.update() else battleTable.isVisible = false
-        fogOfWarButton.isVisible = uiEnabled && viewingCiv.isSpectator()
     }
 
     private fun addKeyboardListener() {
@@ -408,9 +402,6 @@ class WorldScreen(
 
         if (techPolicyAndDiplomacy.update())
             displayTutorial(TutorialTrigger.OtherCivEncountered)
-
-        fogOfWarButton.isEnabled = !selectedCiv.isSpectator()
-        fogOfWarButton.setPosition(10f, topBar.y - fogOfWarButton.height - 10f)
 
         // If the game has ended, lets stop AutoPlay
         if (game.settings.autoPlay.isAutoPlaying()
@@ -555,19 +546,6 @@ class WorldScreen(
             bottomUnitTable.selectedCity != null -> bottomUnitTable.selectedCity!!.civ
             else -> viewingCiv
         }
-    }
-
-    private fun createFogOfWarButton(): TextButton {
-        val fogOfWarButton = "Fog of War".toTextButton()
-        fogOfWarButton.label.setFontSize(30)
-        fogOfWarButton.labelCell.pad(10f)
-        fogOfWarButton.pack()
-        fogOfWarButton.onClick {
-            fogOfWar = !fogOfWar
-            shouldUpdate = true
-        }
-        return fogOfWarButton
-
     }
 
     class RestoreState(


### PR DESCRIPTION
This PR adds the espionage button to the spectator's UI when they are selecting a civ. The move spy buttons are disabled when a spectator is viewing the civ.
As a consequence, I had to refactor the spectator Fog of war button to be in TechPolicyDiplomacyButtons class in order to display the espionage button below it. This is not a big deal since we should have done that anyway.

<details><summary>Pictures</summary>
Spectator viewing Mongolia with the espionage button showing

![SpectatorEspionageViewing](https://github.com/yairm210/Unciv/assets/7538725/1595b8b4-7780-4ee9-898c-5cbbc52ca95a)

![SpectatorEspionageViewingWindow](https://github.com/yairm210/Unciv/assets/7538725/7cc12d38-6d34-4f26-94e4-a4652c2310e9)

</details> 