### PR TITLE
Tile in work range UI fix

### DIFF
--- a/core/src/com/unciv/ui/screens/pickerscreens/ImprovementPickerScreen.kt
+++ b/core/src/com/unciv/ui/screens/pickerscreens/ImprovementPickerScreen.kt
@@ -161,13 +161,13 @@ class ImprovementPickerScreen(
             )
 
             //Warn when the current improvement will increase a stat for the tile,
-            // but the tile is outside of the range (> 3 tiles from city center) that can be
+            // but the tile is outside of the range (> 3 tiles from any city center) that can be
             // worked by a city's population
             if (tile.owningCity != null
                 && !improvement.isRoad()
                     && stats.values.any { it > 0f }
                     && !improvement.name.startsWith(Constants.remove)
-                    && !tile.owningCity!!.getWorkableTiles().contains(tile)
+                    && !tile.getTilesInDistance(3).any { it.isCityCenter() && it.getCity()!!.civ == currentPlayerCiv }
             )
                 labelText += "\n" + "Not in city work range".tr()
 


### PR DESCRIPTION
This PR fixes a visual problem where improving a tile owned by a city more than 3 tiles away but within 3 tiles of another city shows that the tile is not in work range. Perfomance is not a worry since this is only happening once in the UI.

<details><summary>Pictures</summary>

![TileInWorkRangeUI](https://github.com/yairm210/Unciv/assets/7538725/15071403-a5a0-4012-949d-1d52baf43026)

![TileInWorkRangeUI2](https://github.com/yairm210/Unciv/assets/7538725/ec701f68-8a45-48bd-9fe9-3e8221b7c1e4)

</details> 