### PR TITLE
Fix problems with stats from tiles and improvements

### DIFF
--- a/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
@@ -557,7 +557,7 @@ class WorkerAutomation(
                 var repairBonusPriority = tile.getImprovementToRepair()!!.getTurnsToBuild(unit.civ,unit) - UnitActionsFromUniques.getRepairTurns(unit)
                 if (tile.improvementInProgress == Constants.repair) repairBonusPriority += UnitActionsFromUniques.getRepairTurns(unit) - tile.turnsToImprovement
 
-                val repairPriority = repairBonusPriority + Automation.rankStatsValue(TileStatFunctions(tile).getImprovementStats(tile.getTileImprovement()!!,unit.civ, tile.owningCity), unit.civ)
+                val repairPriority = repairBonusPriority + Automation.rankStatsValue(TileStatFunctions(tile).getStatDiffForImprovement(tile.getTileImprovement()!!, unit.civ, tile.owningCity), unit.civ)
                 if (repairPriority > rank.improvementPriority!!) {
                     rank.improvementPriority = repairPriority
                     rank.bestImprovement = null

--- a/core/src/com/unciv/logic/map/tile/Tile.kt
+++ b/core/src/com/unciv/logic/map/tile/Tile.kt
@@ -484,10 +484,8 @@ open class Tile : IsPartOfGameInfoSerialization {
         if ((improvement == null || improvementIsPillaged) && filter == "unimproved") return true
         if (improvement != null && !improvementIsPillaged && filter == "improved") return true
         if (ignoreImprovement) return false
-        if (improvement != null && !improvementIsPillaged && ruleset.tileImprovements[improvement]!!.matchesFilter(filter))
-            return true
-        return roadStatus != RoadStatus.None &&
-            roadStatus.improvement(ruleset)!!.matchesFilter(filter) && !roadIsPillaged
+        if (getUnpillagedTileImprovement()?.matchesFilter(filter) == true) return true
+        return getUnpillagedRoadImprovement()?.matchesFilter(filter) == true
     }
 
     fun matchesTerrainFilter(filter: String, observingCiv: Civilization? = null): Boolean {

--- a/core/src/com/unciv/logic/map/tile/Tile.kt
+++ b/core/src/com/unciv/logic/map/tile/Tile.kt
@@ -484,8 +484,10 @@ open class Tile : IsPartOfGameInfoSerialization {
         if ((improvement == null || improvementIsPillaged) && filter == "unimproved") return true
         if (improvement != null && !improvementIsPillaged && filter == "improved") return true
         if (ignoreImprovement) return false
-        if (roadStatus.name == filter && !roadIsPillaged) return true
-        return improvement != null && !improvementIsPillaged && ruleset.tileImprovements[improvement]!!.matchesFilter(filter)
+        if (improvement != null && !improvementIsPillaged && ruleset.tileImprovements[improvement]!!.matchesFilter(filter))
+            return true
+        return roadStatus != RoadStatus.None &&
+            roadStatus.improvement(ruleset)!!.matchesFilter(filter) && !roadIsPillaged
     }
 
     fun matchesTerrainFilter(filter: String, observingCiv: Civilization? = null): Boolean {

--- a/core/src/com/unciv/logic/map/tile/Tile.kt
+++ b/core/src/com/unciv/logic/map/tile/Tile.kt
@@ -475,10 +475,16 @@ open class Tile : IsPartOfGameInfoSerialization {
     }
 
     /** Implements [UniqueParameterType.TileFilter][com.unciv.models.ruleset.unique.UniqueParameterType.TileFilter] */
-    fun matchesFilter(filter: String, civInfo: Civilization? = null): Boolean {
+    fun matchesFilter(filter: String, civInfo: Civilization? = null, ignoreImprovement: Boolean = false): Boolean {
+        return MultiFilter.multiFilter(filter, { matchesSingleFilter(it, civInfo, ignoreImprovement) })
+    }
+
+    fun matchesSingleFilter(filter: String, civInfo: Civilization? = null, ignoreImprovement: Boolean = false): Boolean {
         if (matchesTerrainFilter(filter, civInfo)) return true
         if ((improvement == null || improvementIsPillaged) && filter == "unimproved") return true
         if (improvement != null && !improvementIsPillaged && filter == "improved") return true
+        if (ignoreImprovement) return false
+        if (roadStatus.name == filter && !roadIsPillaged) return true
         return improvement != null && !improvementIsPillaged && ruleset.tileImprovements[improvement]!!.matchesFilter(filter)
     }
 

--- a/core/src/com/unciv/logic/map/tile/TileStatFunctions.kt
+++ b/core/src/com/unciv/logic/map/tile/TileStatFunctions.kt
@@ -121,9 +121,9 @@ class TileStatFunctions(val tile: Tile) {
         val statsFromMinimum = missingFromMinimum(listOfStats.toStats(), minimumStats)
         listOfStats.add("Minimum" to statsFromMinimum)
 
-        if (observingCiv != null)
-            if (listOfStats.toStats().gold != 0f && observingCiv.goldenAges.isGoldenAge())
-                listOfStats.add("Golden Age" to Stats(gold = 1f))
+        if (observingCiv != null && 
+            listOfStats.toStats().gold != 0f && observingCiv.goldenAges.isGoldenAge())
+            listOfStats.add("Golden Age" to Stats(gold = 1f))
 
         return listOfStats.filter { !it.second.isEmpty() }
     }
@@ -180,72 +180,43 @@ class TileStatFunctions(val tile: Tile) {
 
         val road = tile.getUnpillagedRoadImprovement()
         val roadStats = Stats()
+        
+        fun addStats(filter: String, stat: Stat, amount: Float) {
+            if (tile.matchesFilter(filter, observingCiv, true))
+                terrainStats.add(stat, amount)
+            else if (improvement != null && improvement.matchesFilter(filter))
+                improvementStats.add(stat, amount)
+            else if (road != null && road.matchesFilter(filter))
+                roadStats.add(stat, amount)
+        }
 
         if (city != null) {
             val cachedStatPercentFromObjectCityUniques = uniqueCache.forCityGetMatchingUniques(
                 city, UniqueType.StatPercentFromObject, stateForConditionals)
 
             for (unique in cachedStatPercentFromObjectCityUniques) {
-                val amount = unique.params[0].toFloat()
-                val stat = Stat.valueOf(unique.params[1])
-                val tileFilter = unique.params[2]
-
-                if (tile.matchesFilter(tileFilter, observingCiv, true))
-                    terrainStats.add(stat, amount)
-                if (improvement != null && improvement.matchesFilter(tileFilter))
-                    improvementStats.add(stat, amount)
-                if (road != null && road.matchesFilter(tileFilter))
-                    roadStats.add(stat, amount)
+                addStats(unique.params[2], Stat.valueOf(unique.params[1]), unique.params[0].toFloat())
             }
 
             val cachedAllStatPercentFromObjectCityUniques = uniqueCache.forCityGetMatchingUniques(
                 city, UniqueType.AllStatsPercentFromObject, stateForConditionals)
             for (unique in cachedAllStatPercentFromObjectCityUniques) {
-                val tileFilter = unique.params[1]
-                val statPercentage = unique.params[0].toFloat()
-
-                if (tile.matchesFilter(tileFilter, observingCiv, true))
-                    for (stat in Stat.values())
-                        terrainStats.add(stat, statPercentage)
-                if (improvement != null && improvement.matchesFilter(tileFilter))
-                    for (stat in Stat.values())
-                        improvementStats.add(stat, statPercentage)
-                if (road != null && road.matchesFilter(tileFilter))
-                    for (stat in Stat.values())
-                        roadStats.add(stat, statPercentage)
+                for (stat in Stat.values())
+                    addStats(unique.params[1], stat, unique.params[0].toFloat())
             }
 
         } else if (observingCiv != null) {
             val cachedStatPercentFromObjectCivUniques = uniqueCache.forCivGetMatchingUniques(
                 observingCiv, UniqueType.StatPercentFromObject, stateForConditionals)
             for (unique in cachedStatPercentFromObjectCivUniques) {
-                val amount = unique.params[0].toFloat()
-                val stat = Stat.valueOf(unique.params[1])
-                val tileFilter = unique.params[2]
-
-                if (tile.matchesFilter(tileFilter, observingCiv, true))
-                    terrainStats.add(stat, amount)
-                if (improvement != null && improvement.matchesFilter(tileFilter))
-                    improvementStats.add(stat, amount)
-                if (road != null && road.matchesFilter(tileFilter))
-                    roadStats.add(stat, amount)
+                addStats(unique.params[2], Stat.valueOf(unique.params[1]), unique.params[0].toFloat())
             }
 
             val cachedAllStatPercentFromObjectCivUniques = uniqueCache.forCivGetMatchingUniques(
                 observingCiv, UniqueType.AllStatsPercentFromObject, stateForConditionals)
             for (unique in cachedAllStatPercentFromObjectCivUniques) {
-                val tileFilter = unique.params[1]
-                val statPercentage = unique.params[0].toFloat()
-
-                if (tile.matchesFilter(tileFilter, observingCiv, true))
-                    for (stat in Stat.values())
-                        terrainStats.add(stat, statPercentage)
-                if (improvement != null && improvement.matchesFilter(tileFilter))
-                    for (stat in Stat.values())
-                        improvementStats.add(stat, statPercentage)
-                if (road != null && road.matchesFilter(tileFilter))
-                    for (stat in Stat.values())
-                        roadStats.add(stat, statPercentage)
+                for (stat in Stat.values())
+                    addStats(unique.params[1], stat, unique.params[0].toFloat())
             }
         }
         return hashMapOf(

--- a/core/src/com/unciv/logic/map/tile/TileStatFunctions.kt
+++ b/core/src/com/unciv/logic/map/tile/TileStatFunctions.kt
@@ -40,13 +40,13 @@ class TileStatFunctions(val tile: Tile) {
         else null
 
         val percentageStats = getTilePercentageStats(observingCiv, city, localUniqueCache)
-        for (stats in statsBreakdown.filter { it.first != improvement?.name })
+        for (stats in statsBreakdown.filter { it.first != improvement?.name && it.first != road?.name })
             for ((stat, value) in percentageStats["Terrain"]!!)
                 stats.second[stat] *= value.toPercent()
         for ((stat, value) in percentageStats["Improvement"]!!)
-            statsBreakdown.firstOrNull { it.first == improvement?.name }?.second?.set(stat, value.toPercent())
+            statsBreakdown.firstOrNull { it.first == improvement?.name }?.second?.let { it[stat] *= value.toPercent() }
         for ((stat, value) in percentageStats["Road"]!!)
-            statsBreakdown.firstOrNull { it.first == road?.name }?.second?.set(stat, value.toPercent())
+            statsBreakdown.firstOrNull { it.first == road?.name }?.second?.let { it[stat] *= value.toPercent() }
 
         return statsBreakdown.toStats()
     }

--- a/core/src/com/unciv/logic/map/tile/TileStatFunctions.kt
+++ b/core/src/com/unciv/logic/map/tile/TileStatFunctions.kt
@@ -33,14 +33,14 @@ class TileStatFunctions(val tile: Tile) {
     ): Stats {
         val statsBreakdown = getTileStatsBreakdown(city, observingCiv, localUniqueCache)
 
-        val improvement = tile.getUnpillagedTileImprovement()
-        val road = tile.getUnpillagedRoadImprovement()
+        val improvement = tile.getUnpillagedImprovement()
+        val road = tile.getUnpillagedRoad()
 
         val percentageStats = getTilePercentageStats(observingCiv, city, localUniqueCache)
         for (stats in statsBreakdown) {
             val tileType = when(stats.first) {
-                improvement?.name -> "Improvement"
-                road?.name -> "Road"
+                improvement -> "Improvement"
+                road.name -> "Road"
                 else -> "Terrain"
             }
             for ((stat, value) in percentageStats[tileType]!!)

--- a/core/src/com/unciv/logic/map/tile/TileStatFunctions.kt
+++ b/core/src/com/unciv/logic/map/tile/TileStatFunctions.kt
@@ -193,9 +193,9 @@ class TileStatFunctions(val tile: Tile) {
                 val tileFilter = unique.params[2]
                 if (tile.matchesFilter(tileFilter, observingCiv, true))
                     terrainStats[Stat.valueOf(unique.params[1])] += unique.params[0].toFloat()
-                else if (improvement != null && improvement.matchesFilter(tileFilter))
+                if (improvement != null && improvement.matchesFilter(tileFilter))
                     improvementStats[Stat.valueOf(unique.params[1])] += unique.params[0].toFloat()
-                else if (road != null && road.matchesFilter(tileFilter))
+                if (road != null && road.matchesFilter(tileFilter))
                     roadStats[Stat.valueOf(unique.params[1])] += unique.params[0].toFloat()
             }
 
@@ -207,10 +207,10 @@ class TileStatFunctions(val tile: Tile) {
                 if (tile.matchesFilter(tileFilter, observingCiv, true))
                     for (stat in Stat.values())
                         terrainStats[stat] += statPercentage
-                else if (improvement != null && improvement.matchesFilter(tileFilter))
+                if (improvement != null && improvement.matchesFilter(tileFilter))
                     for (stat in Stat.values())
                         improvementStats[stat] += statPercentage
-                else if (road != null && road.matchesFilter(tileFilter))
+                if (road != null && road.matchesFilter(tileFilter))
                     for (stat in Stat.values())
                         roadStats[stat] += statPercentage
             }
@@ -222,9 +222,9 @@ class TileStatFunctions(val tile: Tile) {
                 val tileFilter = unique.params[2]
                 if (tile.matchesFilter(tileFilter, observingCiv, true))
                     terrainStats[Stat.valueOf(unique.params[1])] += unique.params[0].toFloat()
-                else if (improvement != null && improvement.matchesFilter(tileFilter))
+                if (improvement != null && improvement.matchesFilter(tileFilter))
                     improvementStats[Stat.valueOf(unique.params[1])] += unique.params[0].toFloat()
-                else if (road != null && road.matchesFilter(tileFilter))
+                if (road != null && road.matchesFilter(tileFilter))
                     roadStats[Stat.valueOf(unique.params[1])] += unique.params[0].toFloat()
             }
 
@@ -236,10 +236,10 @@ class TileStatFunctions(val tile: Tile) {
                 if (tile.matchesFilter(tileFilter, observingCiv, true))
                     for (stat in Stat.values())
                         terrainStats[stat] += statPercentage
-                else if (improvement != null && improvement.matchesFilter(tileFilter))
+                if (improvement != null && improvement.matchesFilter(tileFilter))
                     for (stat in Stat.values())
                         improvementStats[stat] += statPercentage
-                else if (road != null && road.matchesFilter(tileFilter))
+                if (road != null && road.matchesFilter(tileFilter))
                     for (stat in Stat.values())
                         roadStats[stat] += statPercentage
             }

--- a/core/src/com/unciv/logic/map/tile/TileStatFunctions.kt
+++ b/core/src/com/unciv/logic/map/tile/TileStatFunctions.kt
@@ -107,9 +107,6 @@ class TileStatFunctions(val tile: Tile) {
             if (road != null)
                 roadStats.add(getExtraImprovementStats(road, observingCiv, city))
 
-            if (listOfStats.toStats().gold != 0f && observingCiv.goldenAges.isGoldenAge())
-                listOfStats.add("Golden Age" to Stats(gold = 1f))
-
             if (improvement != null) {
                 val ensureMinUnique = improvement
                     .getMatchingUniques(UniqueType.EnsureMinimumStats, stateForConditionals)
@@ -123,6 +120,10 @@ class TileStatFunctions(val tile: Tile) {
 
         val statsFromMinimum = missingFromMinimum(listOfStats.toStats(), minimumStats)
         listOfStats.add("Minimum" to statsFromMinimum)
+
+        if (observingCiv != null)
+            if (listOfStats.toStats().gold != 0f && observingCiv.goldenAges.isGoldenAge())
+                listOfStats.add("Golden Age" to Stats(gold = 1f))
 
         return listOfStats.filter { !it.second.isEmpty() }
     }

--- a/core/src/com/unciv/logic/map/tile/TileStatFunctions.kt
+++ b/core/src/com/unciv/logic/map/tile/TileStatFunctions.kt
@@ -35,8 +35,8 @@ class TileStatFunctions(val tile: Tile) {
 
         val improvement = tile.getUnpillagedTileImprovement()
 
-        val road = if (!tile.roadIsPillaged && tile.roadStatus != RoadStatus.None && observingCiv != null)
-            tile.roadStatus.improvement(observingCiv.gameInfo.ruleset)
+        val road = if (!tile.roadIsPillaged && tile.roadStatus != RoadStatus.None)
+            tile.roadStatus.improvement(tile.ruleset)
         else null
 
         val percentageStats = getTilePercentageStats(observingCiv, city, localUniqueCache)
@@ -60,8 +60,8 @@ class TileStatFunctions(val tile: Tile) {
         val improvement = tile.getUnpillagedTileImprovement()
         val improvementStats = improvement?.cloneStats() ?: Stats()
 
-        val road = if (!tile.roadIsPillaged && tile.roadStatus != RoadStatus.None && observingCiv != null)
-            tile.roadStatus.improvement(observingCiv.gameInfo.ruleset)
+        val road = if (!tile.roadIsPillaged && tile.roadStatus != RoadStatus.None)
+            tile.roadStatus.improvement(tile.ruleset)
         else null
         val roadStats = road?.cloneStats() ?: Stats()
 
@@ -180,11 +180,10 @@ class TileStatFunctions(val tile: Tile) {
         val improvement = tile.getUnpillagedTileImprovement()
         val improvementStats = Stats()
 
-        val road = if (!tile.roadIsPillaged && tile.roadStatus != RoadStatus.None && observingCiv != null)
-            tile.roadStatus.improvement(observingCiv.gameInfo.ruleset)
+        val road = if (!tile.roadIsPillaged && tile.roadStatus != RoadStatus.None)
+            tile.roadStatus.improvement(tile.ruleset)
         else null
         val roadStats = Stats()
-
 
         if (city != null) {
             val cachedStatPercentFromObjectCityUniques = uniqueCache.forCityGetMatchingUniques(

--- a/docs/Modders/Unique-parameters.md
+++ b/docs/Modders/Unique-parameters.md
@@ -134,7 +134,7 @@ For filtering a specific improvement.
 
 Allowed values are:
 
-- improvement name (Note that "Road" and "Railroad" _do_ work as improvementFilters, but not as tileFilters at the moment.)
+- improvement name
 - `All`
 - `Great Improvements`, `Great`
 - `All Road` - for Roads & Railroads


### PR DESCRIPTION
Should close #10868

There's several problems this PR aims to fix

1. If an improvement and a terrain type share a filter on a unique that gives stats to tiles/objects, the effects of the unique will apply both to the improvement and the tile as a whole. This is most notable with the "All" filter
2. Despite claiming to use tileFilter, these uniques instead use an amalgamation of terrainFilter and improvementFilter 
   1. Even if you fixed this, it also comes with a weird side effect. Unlike other filters, tileFilter does not use the newer multifilter system. This means even if things functioned correctly, a filter of `{unimproved} {whatever}` would still not work as players expected

This PR aims to fix these problems in the following manner:
- Do all uniques all at the same time instead of splitting the improvement stats into its own category. If a unique works for the terrain, don't do anything with it for the improvement. Nicely, this should have no serious implications outside of this context thanks to `getStatDiffForImprovement`
- Add multifilter support to tileFilter
- Do all terrain checks as tileFilter checks. These check are given a boolean to ignore improvements. Sure, this basically is the same as terrainFilter, but it avoids the awkward conversation of putting  "unimproved"/"improved" in terrainFilter. It also is sorta a way to not worry about if tileFilter/terrainFilter changes in the future
- While we're at it, add support for roads here. It puts us one step closer to generalized roads

Main notes
1. I have no clue how to add percent stuff to the breakdown. Maybe that should also return as an `ArrayList<Pair<String, Stats>>`
2. The cached Percent uniques section kinda bothers me with the blatant code duplication