### PR TITLE
Unit actions "paging" new architecture

### DIFF
--- a/core/src/com/unciv/logic/automation/unit/SpecificUnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/SpecificUnitAutomation.kt
@@ -313,7 +313,6 @@ object SpecificUnitAutomation {
                 0,
                 wonderToHurry.name
             )
-            unit.showAdditionalActions = false  // make sure getUnitActions doesn't skip the important ones
             return UnitActions.invokeUnitAction(unit, UnitActionType.HurryBuilding)
                 || UnitActions.invokeUnitAction(unit, UnitActionType.HurryWonder)
         }

--- a/core/src/com/unciv/logic/map/BFS.kt
+++ b/core/src/com/unciv/logic/map/BFS.kt
@@ -46,6 +46,8 @@ class BFS(
      * and to the yet-to-be-processed set.
      *
      * Will do nothing when [hasEnded] returns `true`
+     *
+     * @return The Tile that was checked, or `null` if there was nothing to do
      */
     fun nextStep(): Tile? {
         if (tilesReached.size >= maxSize) { tilesToCheck.clear(); return null }

--- a/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
@@ -122,9 +122,6 @@ class MapUnit : IsPartOfGameInfoSerialization {
     @Transient
     var viewableTiles = HashSet<Tile>()
 
-    @Transient
-    var showAdditionalActions: Boolean = false
-
     //endregion
 
     /**
@@ -931,7 +928,6 @@ class MapUnit : IsPartOfGameInfoSerialization {
     }
 
     fun actionsOnDeselect() {
-        showAdditionalActions = false
         if (isPreparingParadrop() || isPreparingAirSweep()) action = null
     }
 

--- a/core/src/com/unciv/models/UnitAction.kt
+++ b/core/src/com/unciv/models/UnitAction.kt
@@ -93,10 +93,12 @@ enum class UnitActionType(
     val imageGetter: (()-> Actor)?,
     binding: KeyboardBinding? = null,
     val isSkippingToNextUnit: Boolean = true,
-    val uncivSound: UncivSound = UncivSound.Click
+    val uncivSound: UncivSound = UncivSound.Click,
+    /** UI "page" preference, 0-based - Dynamic overrides to this are in `UnitActions.actionTypeToPageGetter` */
+    val defaultPage: Int
 ) {
     SwapUnits("Swap units",
-        { ImageGetter.getUnitActionPortrait("Swap") }, false),
+        { ImageGetter.getUnitActionPortrait("Swap") }, false, defaultPage = 1),
     Automate("Automate",
         { ImageGetter.getUnitActionPortrait("Automate") }),
     ConnectRoad("Connect road",
@@ -106,7 +108,7 @@ enum class UnitActionType(
     StopMovement("Stop movement",
         { ImageGetter.getUnitActionPortrait("StopMove") }, false),
     ShowUnitDestination("Show unit destination",
-        { ImageGetter.getUnitActionPortrait("ShowUnitDestination")}, false),
+        { ImageGetter.getUnitActionPortrait("ShowUnitDestination")}, false, defaultPage = 1),
     Sleep("Sleep",
         { ImageGetter.getUnitActionPortrait("Sleep") }),
     SleepUntilHealed("Sleep until healed",
@@ -164,24 +166,24 @@ enum class UnitActionType(
     EnhanceReligion("Enhance a Religion",
         { ImageGetter.getUnitActionPortrait("EnhanceReligion") }, UncivSound.Choir),
     DisbandUnit("Disband unit",
-        { ImageGetter.getUnitActionPortrait("DisbandUnit") }, false),
+        { ImageGetter.getUnitActionPortrait("DisbandUnit") }, false, defaultPage = 1),
     GiftUnit("Gift unit",
-        { ImageGetter.getUnitActionPortrait("Present") }, UncivSound.Silent),
+        { ImageGetter.getUnitActionPortrait("Present") }, UncivSound.Silent, defaultPage = 1),
     Wait("Wait",
         { ImageGetter.getUnitActionPortrait("Wait") }, UncivSound.Silent),
     ShowAdditionalActions("Show more",
         { ImageGetter.getUnitActionPortrait("ShowMore") }, false),
     HideAdditionalActions("Back",
-        { ImageGetter.getUnitActionPortrait("HideMore") }, false),
+        { ImageGetter.getUnitActionPortrait("HideMore") }, false, defaultPage = 1),
     AddInCapital( "Add in capital",
         { ImageGetter.getUnitActionPortrait("AddInCapital")}, UncivSound.Chimes),
     ;
 
     // Allow shorter initializations
-    constructor(value: String, imageGetter: (() -> Actor)?, uncivSound: UncivSound = UncivSound.Click)
-            : this(value, imageGetter, null, true, uncivSound)
-    constructor(value: String, imageGetter: (() -> Actor)?, isSkippingToNextUnit: Boolean = true, uncivSound: UncivSound = UncivSound.Click)
-            : this(value, imageGetter, null, isSkippingToNextUnit, uncivSound)
+    constructor(value: String, imageGetter: (() -> Actor)?, uncivSound: UncivSound = UncivSound.Click, defaultPage: Int = 0)
+            : this(value, imageGetter, null, true, uncivSound, defaultPage)
+    constructor(value: String, imageGetter: (() -> Actor)?, isSkippingToNextUnit: Boolean = true, uncivSound: UncivSound = UncivSound.Click, defaultPage: Int = 0)
+            : this(value, imageGetter, null, isSkippingToNextUnit, uncivSound, defaultPage)
 
     val binding: KeyboardBinding =
             binding ?:

--- a/core/src/com/unciv/models/ruleset/unique/Unique.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Unique.kt
@@ -66,7 +66,7 @@ class Unique(val text: String, val sourceObjectType: UniqueTarget? = null, val s
     fun conditionalsApply(state: StateForConditionals = StateForConditionals()): Boolean {
         if (state.ignoreConditionals) return true
         // Always allow Timed conditional uniques. They are managed elsewhere
-        if (conditionals.any{ it.isOfType(UniqueType.ConditionalTimedUnique) }) return true
+        if (conditionals.any { it.isOfType(UniqueType.ConditionalTimedUnique) }) return true
         for (condition in conditionals) {
             if (!conditionalApplies(condition, state)) return false
         }

--- a/core/src/com/unciv/ui/screens/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/WorldScreen.kt
@@ -5,7 +5,6 @@ import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.Input
 import com.badlogic.gdx.math.Vector2
 import com.badlogic.gdx.scenes.scene2d.ui.Table
-import com.badlogic.gdx.scenes.scene2d.ui.TextButton
 import com.badlogic.gdx.utils.Align
 import com.unciv.Constants
 import com.unciv.UncivGame
@@ -26,10 +25,7 @@ import com.unciv.models.ruleset.tile.ResourceType
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.ui.components.extensions.centerX
 import com.unciv.ui.components.extensions.darken
-import com.unciv.ui.components.extensions.isEnabled
-import com.unciv.ui.components.extensions.setFontSize
 import com.unciv.ui.components.extensions.toLabel
-import com.unciv.ui.components.extensions.toTextButton
 import com.unciv.ui.components.input.KeyCharAndCode
 import com.unciv.ui.components.input.KeyShortcutDispatcherVeto
 import com.unciv.ui.components.input.KeyboardBinding

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActions.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActions.kt
@@ -244,7 +244,7 @@ object UnitActions {
         if (!unit.canFortify() || unit.currentMovement == 0f) return
 
         yield(UnitAction(UnitActionType.Fortify,
-            action = { unit.fortify() }.takeIf { !unit.isFortified() }
+            action = { unit.fortify() }.takeIf { !unit.isFortified() || unit.isFortifyingUntilHealed() }
         ))
 
         if (unit.health == 100) return
@@ -259,7 +259,7 @@ object UnitActions {
         if (tile.hasImprovementInProgress() && unit.canBuildImprovement(tile.getTileImprovementInProgress()!!)) return
 
         yield(UnitAction(UnitActionType.Sleep,
-            action = { unit.action = UnitActionType.Sleep.value }.takeIf { !unit.isSleeping() }
+            action = { unit.action = UnitActionType.Sleep.value }.takeIf { !unit.isSleeping() || unit.isSleepingUntilHealed() }
         ))
 
         if (unit.health == 100) return

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsTable.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsTable.kt
@@ -21,6 +21,7 @@ class UnitActionsTable(val worldScreen: WorldScreen) : Table() {
         /** Padding between and to the left of the Buttons */
         private const val padBetweenButtons = 2f
     }
+
     init {
         defaults().left().padLeft(padBetweenButtons).padBottom(padBetweenButtons)
     }
@@ -74,6 +75,6 @@ class UnitActionsTable(val worldScreen: WorldScreen) : Table() {
             }
         }
 
-         return actionButton
+        return actionButton
     }
 }

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsTable.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsTable.kt
@@ -17,7 +17,15 @@ import com.unciv.ui.popups.UnitUpgradeMenu
 import com.unciv.ui.screens.worldscreen.WorldScreen
 
 class UnitActionsTable(val worldScreen: WorldScreen) : Table() {
+    /** Distribute UnitActions on "pages" */
+    // todo since this runs surprisingly often - some caching? Does it even need to do anything if unit and currentPage are the same?
+    private var currentPage = 0
+    private val numPages = 2  //todo static for now
+    private var shownForUnitHash = 0
+
     companion object {
+        /** Maximum for how many pages there can be. */
+        private const val maxAllowedPages = 10
         /** Padding between and to the left of the Buttons */
         private const val padBetweenButtons = 2f
     }
@@ -26,11 +34,40 @@ class UnitActionsTable(val worldScreen: WorldScreen) : Table() {
         defaults().left().padLeft(padBetweenButtons).padBottom(padBetweenButtons)
     }
 
+    fun changePage(delta: Int, unit: MapUnit) {
+        if (delta == 0) return
+        currentPage = (currentPage + delta) % numPages
+        update(unit)
+    }
+
     fun update(unit: MapUnit?) {
+        val newUnitHash = unit?.hashCode() ?: 0
+        if (shownForUnitHash != newUnitHash) {
+            currentPage = 0
+            shownForUnitHash = newUnitHash
+        }
+
         clear()
         if (unit == null) return
         if (!worldScreen.canChangeState) return // No actions when it's not your turn or spectator!
+
+        val pageActionBuckets = Array<ArrayDeque<UnitAction>>(maxAllowedPages) { ArrayDeque() }
+
+        val (nextPageAction, previousPageAction) = UnitActions.getPagingActions(unit, this)
+        val nextPageButton = getUnitActionButton(unit, nextPageAction)
+        val previousPageButton = getUnitActionButton(unit, previousPageAction)
+
+        // Distribute sequentially into the buckets
         for (unitAction in UnitActions.getUnitActions(unit)) {
+            val actionPage = UnitActions.getActionDefaultPage(unit, unitAction.type)
+            if (actionPage >= maxAllowedPages) break
+            pageActionBuckets[actionPage].addLast(unitAction)
+        }
+
+        // clamp currentPage
+        if (currentPage !in 0 until numPages) currentPage = 0
+        // actually show the buttons of the currentPage
+        for (unitAction in pageActionBuckets[currentPage]) {
             val button = getUnitActionButton(unit, unitAction)
             if (unitAction is UpgradeUnitAction) {
                 button.onRightClick {
@@ -39,11 +76,16 @@ class UnitActionsTable(val worldScreen: WorldScreen) : Table() {
                     }
                 }
             }
-            add(button).row()
+            add(button).colspan(2).row()
         }
+
+        // show page navigation
+        if (currentPage > 0)
+            add(previousPageButton)
+        if (currentPage < numPages - 1)
+            add(nextPageButton)
         pack()
     }
-
 
     private fun getUnitActionButton(unit: MapUnit, unitAction: UnitAction): Button {
         val icon = unitAction.getIcon()

--- a/tests/src/com/unciv/uniques/UnitUniquesTests.kt
+++ b/tests/src/com/unciv/uniques/UnitUniquesTests.kt
@@ -43,7 +43,8 @@ class UnitUniquesTests {
         val greatPerson = game.addUnit("Great Scientist", mainCiv, unitTile)
 
         // then
-        val giftAction = UnitActions.getUnitActions(greatPerson, UnitActionType.GiftUnit).firstOrNull()
+        val giftAction = UnitActions.getUnitActions(greatPerson, UnitActionType.GiftUnit)
+            .firstOrNull { it.action != null } // This tests that the action should be enabled, too
 
         Assert.assertNotNull("Great Person should have a gift action", giftAction)
     }

--- a/tests/src/com/unciv/uniques/UnitUniquesTests.kt
+++ b/tests/src/com/unciv/uniques/UnitUniquesTests.kt
@@ -2,6 +2,7 @@ package com.unciv.uniques
 
 import com.badlogic.gdx.math.Vector2
 import com.unciv.logic.map.mapunit.UnitTurnManager
+import com.unciv.models.UnitActionType
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.translations.fillPlaceholders
 import com.unciv.testing.GdxTestRunner
@@ -42,7 +43,7 @@ class UnitUniquesTests {
         val greatPerson = game.addUnit("Great Scientist", mainCiv, unitTile)
 
         // then
-        val giftAction = UnitActions.getGiftAction(greatPerson, unitTile)
+        val giftAction = UnitActions.getUnitActions(greatPerson, UnitActionType.GiftUnit).firstOrNull()
 
         Assert.assertNotNull("Great Person should have a gift action", giftAction)
     }


### PR DESCRIPTION
Continuation to #10966, still not reaching #10955 - but doing some things better along the way.

_Postponed_ UX features:
* Dynamic paging to avoid buttons overlapping on cramped displays
* Keyboard shortcuts available for out-of-page actions
* Avoid distributing very few actions to pages
* Vague idea: Ask ImprovementPicker if we happen to select a unit with just one enabled Worker action - and then offer it directly. Legionaries - they need to 'i'-'r' now while they had the road building offered directly ages ago, or am I mistaken? Maybe not the best example as Legion can build Forts too, so it would be _two_ extra UnitActions - but when made intelligently it could help a few mods nicely.

_Included_ features:
* Sleep for wounded units is back (closes #10906)
* Sleep/Fortify use the exact same rules
* Wounded units can switch Sleep/Fortify freely with '* until healed' back and forth (<sub><sup>only marred a little by auto next-unit stealing focus away.</sup></sub>)

_Postponed_ Architecture changes:
* Need to see if the map's getter function can't be switched to the `suspend fun SequenceScope<UnitAction>.addSomethingActions` signature which I believe to be much more efficient than the `sequence { yieldAll(otherSequence) }` construct - at the moment avoided as extension receiver and object-as-namespace are a bit excluding each other...

Toolset note:
* Somehow Android Studio lately has taken to auto-adding imports one cannot configure or turn off in any way, and that the compiler does not actually need - here it force-imports all public methods (or fields too if there were any) of UnitActions into the UnitActions file - complete bullshit in most cases, but I've given up on killing them. In other places it's worse - you can even get warnings from those unnecessary imports that would be fine without. Anybody observed that too, or even found a cure?