### PR TITLE
Air unit automation improvement

### DIFF
--- a/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
@@ -351,9 +351,15 @@ object NextTurnAutomation {
         for (unit in sortedUnits) UnitAutomation.automateUnitMoves(unit)
     }
 
+    /** Returns the priority of the unit, a lower value is higher priority **/
     fun getUnitPriority(unit: MapUnit, isAtWar: Boolean): Int {
         if (unit.isCivilian() && !unit.isGreatPersonOfType("War")) return 1 // Civilian
-        if (unit.baseUnit.isAirUnit()) return 2
+        if (unit.baseUnit.isAirUnit()) return when {
+            unit.canIntercept() -> 2 // Fighers first
+            unit.baseUnit.isNuclearWeapon() -> 3 // Then Nukes (area damage)
+            !unit.hasUnique(UniqueType.SelfDestructs) -> 4 // Then Bombers (reusable)
+            else -> 5 // Missiles
+        }
         val distance = if (!isAtWar) 0 else unit.civ.threatManager.getDistanceToClosestEnemyUnit(unit.getTile(),6)
         // Lower health units should move earlier to swap with higher health units
         return distance + (unit.health / 10) + when {

--- a/core/src/com/unciv/logic/automation/unit/AirUnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/AirUnitAutomation.kt
@@ -28,11 +28,16 @@ object AirUnitAutomation {
         if (friendlyUnusedFighterCount < enemyFighters) return 
 
         if (friendlyUsedFighterCount <= enemyFighters) {
+            fun airSweepDamagePercentBonus(): Int {
+                return unit.getMatchingUniques(UniqueType.StrengthWhenAirsweep)
+                    .sumOf { it.params[0].toInt() }
+            }
+            
             // If we are outnumbered, don't heal after attacking and don't have an Air Sweep bonus
             // Then we shouldn't speed the air battle by killing our fighters, instead, focus on defending
             if (friendlyUsedFighterCount + friendlyUnusedFighterCount < enemyFighters 
                 && !unit.hasUnique(UniqueType.HealsEvenAfterAction)
-                && unit.airSweepDamagePercentBonus() <= 0) {
+                && airSweepDamagePercentBonus() <= 0) {
                 return
             } else {
                 if (tryAirSweep(unit, tilesWithEnemyUnitsInRange)) return

--- a/core/src/com/unciv/logic/automation/unit/BattleHelper.kt
+++ b/core/src/com/unciv/logic/automation/unit/BattleHelper.kt
@@ -15,8 +15,8 @@ object BattleHelper {
     fun tryAttackNearbyEnemy(unit: MapUnit, stayOnTile: Boolean = false): Boolean {
         if (unit.hasUnique(UniqueType.CannotAttack)) return false
         val attackableEnemies = TargetHelper.getAttackableEnemies(unit, unit.movement.getDistanceToTiles(), stayOnTile=stayOnTile)
-            // Only take enemies we can fight without dying
-            .filter {
+            // Only take enemies we can fight without dying or are made to die
+            .filter {unit.hasUnique(UniqueType.SelfDestructs) ||
                 BattleDamage.calculateDamageToAttacker(
                     MapUnitCombatant(unit),
                     Battle.getMapCombatantOfTile(it.tileToAttack)!!
@@ -92,7 +92,7 @@ object BattleHelper {
         
         if (attacker.baseUnit.isMelee()) {
             val battleDamage = BattleDamage.calculateDamageToAttacker(attackerUnit, cityUnit)
-            if (attacker.health - battleDamage * 2 <= 0) {
+            if (attacker.health - battleDamage * 2 <= 0 && !attacker.hasUnique(UniqueType.SelfDestructs)) {
                 // The more fiendly units around the city, the more willing we should be to just attack the city
                 val friendlyUnitsAroundCity = city.getCenterTile().getTilesInDistance(3).count { it.militaryUnit?.civ == attacker.civ }
                 // If we have more than 4 other units around the city, go for it

--- a/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
@@ -178,15 +178,14 @@ object UnitAutomation {
             if (unit.canIntercept())
                 return AirUnitAutomation.automateFighter(unit)
 
-            if (!unit.baseUnit.isNuclearWeapon())
-                return AirUnitAutomation.automateBomber(unit)
-
             // Note that not all nukes have to be air units
             if (unit.baseUnit.isNuclearWeapon())
                 return AirUnitAutomation.automateNukes(unit)
 
             if (unit.hasUnique(UniqueType.SelfDestructs))
                 return AirUnitAutomation.automateMissile(unit)
+
+            return AirUnitAutomation.automateBomber(unit)
         }
 
         if (tryGoToRuinAndEncampment(unit) && unit.currentMovement == 0f) return

--- a/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
@@ -486,11 +486,6 @@ class MapUnit : IsPartOfGameInfoSerialization {
             damageFactor *= 1f - unique.params[0].toFloat() / 100f
         return damageFactor
     }
-    
-    fun airSweepDamagePercentBonus(): Int {
-        return getMatchingUniques(UniqueType.StrengthWhenAirsweep)
-            .sumOf { it.params[0].toInt() }
-    }
 
     fun getDamageFromTerrain(tile: Tile = currentTile): Int {
         if (civ.nonStandardTerrainDamage) {

--- a/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
@@ -486,6 +486,11 @@ class MapUnit : IsPartOfGameInfoSerialization {
             damageFactor *= 1f - unique.params[0].toFloat() / 100f
         return damageFactor
     }
+    
+    fun airSweepDamagePercentBonus(): Int {
+        return getMatchingUniques(UniqueType.StrengthWhenAirsweep)
+            .sumOf { it.params[0].toInt() }
+    }
 
     fun getDamageFromTerrain(tile: Tile = currentTile): Int {
         if (civ.nonStandardTerrainDamage) {


### PR DESCRIPTION
Before this PR a few essential things were missing from the air unit automation. First is that fighters didn't air sweep, and second is that fighters and bombers didn't account for low health, and third is that missiles (like nukes) used bomber automation instead of missile automation.

Changes:
- Added fighter air sweep logic. Targets the closest tile with an enemy unit (kind of arbitrary, mostly, we need to air sweep in the right direction).
- Added fighter air supremacy logic. When to air sweep, heal and attack ground units. (based on the number of our fighters and their planes).
- Changed air unit priority to: fighters -> nukes -> bombers -> missiles. (Was random)
- Bombers and fighters are more aware of their health.
- Units that self-destruct on attack don't take into account how much damage is dealt to them.

As usual more tweaks are probably needed later. I don't promise there won't be any bugs (logical or otherwise). Testing every edge case would take way too much time and effort.