### PR TITLE
Improved Spectator selected Civ coloring

### DIFF
--- a/core/src/com/unciv/ui/components/tilegroups/CityButton.kt
+++ b/core/src/com/unciv/ui/components/tilegroups/CityButton.kt
@@ -209,6 +209,7 @@ private class CityTable(city: City, forPopup: Boolean = false) : BorderedTable(
         touchable = Touchable.enabled
 
         val selectedCiv = GUI.getSelectedPlayer()
+        val viewingCiv = GUI.getViewingPlayer()
 
         bgBorderColor = when {
             city.civ == selectedCiv -> colorFromRGB(233, 233, 172)
@@ -228,7 +229,7 @@ private class CityTable(city: City, forPopup: Boolean = false) : BorderedTable(
 
         val isShowDetailedInfo = DebugUtils.VISIBLE_MAP
                 || city.civ == selectedCiv
-                || selectedCiv.isSpectator()
+                || viewingCiv.isSpectator()
 
         addCityPopNumber(city)
 
@@ -240,7 +241,7 @@ private class CityTable(city: City, forPopup: Boolean = false) : BorderedTable(
         if (isShowDetailedInfo)
             addCityConstruction(city)
 
-        if (city.civ != selectedCiv)
+        if (city.civ != viewingCiv)
             addCivIcon(city)
 
         cells.first().padLeft(4f)

--- a/core/src/com/unciv/ui/components/tilegroups/CityButton.kt
+++ b/core/src/com/unciv/ui/components/tilegroups/CityButton.kt
@@ -111,13 +111,12 @@ private class DefenceTable(city: City) : BorderedTable(
 
     init {
 
-        val viewingCiv = GUI.getViewingPlayer()
-
+        val selectedCiv = GUI.getSelectedPlayer()
         borderSize = 4f
         bgColor = Color.BLACK
         bgBorderColor = when {
-            city.civ == viewingCiv -> colorFromRGB(255, 237, 200)
-            city.civ.isAtWarWith(viewingCiv) -> Color.RED
+            city.civ == selectedCiv -> colorFromRGB(255, 237, 200)
+            city.civ.isAtWarWith(selectedCiv) -> Color.RED
             else -> Color.BLACK
         }
 
@@ -164,9 +163,9 @@ private class StatusTable(city: City, iconSize: Float = 18f) : Table() {
     init {
 
         val padBetween = 2f
-        val viewingCiv = GUI.getViewingPlayer()
+        val selectedCiv = GUI.getSelectedPlayer()
 
-        if (city.civ == viewingCiv) {
+        if (city.civ == selectedCiv) {
             if (city.isBlockaded()) {
                 val connectionImage = ImageGetter.getImage("OtherIcons/Blockade")
                 add(connectionImage).size(iconSize)
@@ -192,7 +191,7 @@ private class StatusTable(city: City, iconSize: Float = 18f) : Table() {
             add(fireImage).size(iconSize).padLeft(padBetween)
         }
 
-        if (city.civ == viewingCiv && city.isWeLoveTheKingDayActive()) {
+        if (city.civ == selectedCiv && city.isWeLoveTheKingDayActive()) {
             val wltkdImage = ImageGetter.getImage("OtherIcons/WLTKD")
             add(wltkdImage).size(iconSize).padLeft(padBetween)
         }
@@ -209,27 +208,27 @@ private class CityTable(city: City, forPopup: Boolean = false) : BorderedTable(
         isTransform = false
         touchable = Touchable.enabled
 
-        val viewingCiv = GUI.getViewingPlayer()
+        val selectedCiv = GUI.getSelectedPlayer()
 
         bgBorderColor = when {
-            city.civ == viewingCiv -> colorFromRGB(233, 233, 172)
-            city.civ.isAtWarWith(viewingCiv) -> colorFromRGB(230, 51, 0)
+            city.civ == selectedCiv -> colorFromRGB(233, 233, 172)
+            city.civ.isAtWarWith(selectedCiv) -> colorFromRGB(230, 51, 0)
             else -> Color.BLACK
         }
         borderSize = when {
-            city.civ == viewingCiv -> 4f
-            city.civ.isAtWarWith(viewingCiv) -> 4f
+            city.civ == selectedCiv -> 4f
+            city.civ.isAtWarWith(selectedCiv) -> 4f
             else -> 2f
         }
         bgColor = city.civ.nation.getOuterColor().cpy().apply { a = 0.9f }
-        borderOnTop = city.civ == viewingCiv
+        borderOnTop = city.civ == selectedCiv
 
         pad(0f)
         defaults().pad(0f)
 
         val isShowDetailedInfo = DebugUtils.VISIBLE_MAP
-                || city.civ == viewingCiv
-                || viewingCiv.isSpectator()
+                || city.civ == selectedCiv
+                || selectedCiv.isSpectator()
 
         addCityPopNumber(city)
 
@@ -241,7 +240,7 @@ private class CityTable(city: City, forPopup: Boolean = false) : BorderedTable(
         if (isShowDetailedInfo)
             addCityConstruction(city)
 
-        if (city.civ != viewingCiv)
+        if (city.civ != selectedCiv)
             addCivIcon(city)
 
         cells.first().padLeft(4f)


### PR DESCRIPTION
While working on the air unit improvement, I noticed that the spectator Civ coloring was off when selecting a Civ. This PR simply turns enemy Civs red and the selected civ cyan.

<details><summary>Pictures</summary>
Old

![SpectatorSelectedCivUIColorOld](https://github.com/yairm210/Unciv/assets/7538725/d4690cee-eb14-45d8-b593-cc1e91027143)

New

![SpectatorSelectedCivUIColorNew](https://github.com/yairm210/Unciv/assets/7538725/be0bb2a2-9ece-4b53-a880-7823e29b1dee)

</details> 