### PR TITLE
Fix errors when starting games as Maya

### DIFF
--- a/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
@@ -310,6 +310,37 @@ object NextTurnAutomation {
         }
     }
 
+    fun chooseGreatPerson(civInfo: Civilization) {
+        if (civInfo.greatPeople.freeGreatPeople == 0) return
+        val mayanGreatPerson = civInfo.greatPeople.mayaLimitedFreeGP > 0
+        val greatPeople =
+            if (mayanGreatPerson)
+                civInfo.greatPeople.getGreatPeople().filter { it.name in civInfo.greatPeople.longCountGPPool }
+            else civInfo.greatPeople.getGreatPeople()
+
+        if (greatPeople.isEmpty()) return
+        var greatPerson = greatPeople.random()
+
+        if (civInfo.wantsToFocusOn(Victory.Focus.Culture)) {
+            val culturalGP =
+                greatPeople.firstOrNull { it.uniques.contains("Great Person - [Culture]") }
+            if (culturalGP != null) greatPerson = culturalGP
+        }
+        if (civInfo.wantsToFocusOn(Victory.Focus.Science)) {
+            val scientificGP =
+                greatPeople.firstOrNull { it.uniques.contains("Great Person - [Science]") }
+            if (scientificGP != null) greatPerson = scientificGP
+        }
+
+        civInfo.units.addUnit(greatPerson, civInfo.cities.firstOrNull { it.isCapital() })
+
+        civInfo.greatPeople.freeGreatPeople--
+        if (mayanGreatPerson){
+            civInfo.greatPeople.longCountGPPool.remove(greatPerson.name)
+            civInfo.greatPeople.mayaLimitedFreeGP--
+        }
+    }
+    
     /** If we are able to build a spaceship but have already spent our resources, try disbanding
      *  a unit and selling a building to make room. Can happen due to trades etc */
     private fun freeUpSpaceResources(civInfo: Civilization) {

--- a/core/src/com/unciv/logic/civilization/managers/GreatPersonManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/GreatPersonManager.kt
@@ -90,13 +90,14 @@ class GreatPersonManager : IsPartOfGameInfoSerialization {
 
     fun triggerMayanGreatPerson() {
         if (civInfo.isSpectator()) return
-        val greatPeople = civInfo.greatPeople.getGreatPeople()
-        if (civInfo.greatPeople.longCountGPPool.isEmpty())
-            civInfo.greatPeople.longCountGPPool = greatPeople.map { it.name }.toHashSet()
+        val greatPeople = getGreatPeople()
+        if (longCountGPPool.isEmpty())
+            longCountGPPool = greatPeople.map { it.name }.toHashSet()
 
-        civInfo.greatPeople.freeGreatPeople++
+        freeGreatPeople++
+        mayaLimitedFreeGP++
+
         // Anyone an idea for a good icon?
-        civInfo.greatPeople.mayaLimitedFreeGP++
         val notification = "{A new b'ak'tun has just begun!}\n{A Great Person joins you!}"
         civInfo.addNotification(notification, MayaLongCountAction(), NotificationCategory.General, MayaCalendar.notificationIcon)
     }

--- a/core/src/com/unciv/logic/civilization/managers/GreatPersonManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/GreatPersonManager.kt
@@ -2,9 +2,12 @@ package com.unciv.logic.civilization.managers
 
 import com.unciv.logic.IsPartOfGameInfoSerialization
 import com.unciv.logic.civilization.Civilization
+import com.unciv.logic.civilization.MayaLongCountAction
+import com.unciv.logic.civilization.NotificationCategory
 import com.unciv.models.Counter
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.ruleset.unit.BaseUnit
+import com.unciv.ui.components.MayaCalendar
 
 
 // todo: Great Admiral?
@@ -85,6 +88,18 @@ class GreatPersonManager : IsPartOfGameInfoSerialization {
         greatPersonPointsCounter.add(getGreatPersonPointsForNextTurn())
     }
 
+    fun triggerMayanGreatPerson() {
+        if (civInfo.isSpectator()) return
+        val greatPeople = civInfo.greatPeople.getGreatPeople()
+        if (civInfo.greatPeople.longCountGPPool.isEmpty())
+            civInfo.greatPeople.longCountGPPool = greatPeople.map { it.name }.toHashSet()
+
+        civInfo.greatPeople.freeGreatPeople++
+        // Anyone an idea for a good icon?
+        civInfo.greatPeople.mayaLimitedFreeGP++
+        val notification = "{A new b'ak'tun has just begun!}\n{A Great Person joins you!}"
+        civInfo.addNotification(notification, MayaLongCountAction(), NotificationCategory.General, MayaCalendar.notificationIcon)
+    }
 
     fun getGreatPeople(): HashSet<BaseUnit> {
         val greatPeople = civInfo.gameInfo.ruleset.units.values.asSequence()

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -232,23 +232,47 @@ object UniqueTriggerActivation {
                 return true
             }
 
-            UniqueType.OneTimeFreeGreatPerson, UniqueType.MayanGainGreatPerson -> {
+            UniqueType.OneTimeFreeGreatPerson -> {
                 if (civInfo.isSpectator()) return false
                 val greatPeople = civInfo.greatPeople.getGreatPeople()
-                if (unique.type == UniqueType.MayanGainGreatPerson && civInfo.greatPeople.longCountGPPool.isEmpty())
-                    civInfo.greatPeople.longCountGPPool = greatPeople.map { it.name }.toHashSet()
                 if (civInfo.isHuman() && !UncivGame.Current.settings.autoPlay.isAutoPlayingAndFullAI()) {
                     civInfo.greatPeople.freeGreatPeople++
                     // Anyone an idea for a good icon?
-                    if (unique.type == UniqueType.MayanGainGreatPerson) {
-                        civInfo.greatPeople.mayaLimitedFreeGP++
-                        civInfo.addNotification(notification!!, MayaLongCountAction(), NotificationCategory.General, MayaCalendar.notificationIcon)
-                    } else if (notification != null)
+                    if (notification != null)
                         civInfo.addNotification(notification, NotificationCategory.General)
                     return true
                 } else {
-                    if (unique.type == UniqueType.MayanGainGreatPerson)
-                        greatPeople.removeAll { it.name !in civInfo.greatPeople.longCountGPPool }
+                    if (greatPeople.isEmpty()) return false
+                    var greatPerson = greatPeople.random()
+
+                    if (civInfo.wantsToFocusOn(Victory.Focus.Culture)) {
+                        val culturalGP =
+                            greatPeople.firstOrNull { it.uniques.contains("Great Person - [Culture]") }
+                        if (culturalGP != null) greatPerson = culturalGP
+                    }
+                    if (civInfo.wantsToFocusOn(Victory.Focus.Science)) {
+                        val scientificGP =
+                            greatPeople.firstOrNull { it.uniques.contains("Great Person - [Science]") }
+                        if (scientificGP != null) greatPerson = scientificGP
+                    }
+                    return civInfo.units.addUnit(greatPerson.name, chosenCity) != null
+                }
+            }
+
+            UniqueType.MayanGainGreatPerson -> {
+                if (civInfo.isSpectator()) return false
+                val greatPeople = civInfo.greatPeople.getGreatPeople()
+                if (civInfo.greatPeople.longCountGPPool.isEmpty())
+                    civInfo.greatPeople.longCountGPPool = greatPeople.map { it.name }.toHashSet()
+                
+                if (civInfo.isHuman() && !UncivGame.Current.settings.autoPlay.isAutoPlayingAndFullAI()) {
+                    civInfo.greatPeople.freeGreatPeople++
+                    // Anyone an idea for a good icon?
+                    civInfo.greatPeople.mayaLimitedFreeGP++
+                    civInfo.addNotification(notification!!, MayaLongCountAction(), NotificationCategory.General, MayaCalendar.notificationIcon)
+                    return true
+                } else {
+                    greatPeople.removeAll { it.name !in civInfo.greatPeople.longCountGPPool }
                     if (greatPeople.isEmpty()) return false
                     var greatPerson = greatPeople.random()
 
@@ -263,8 +287,7 @@ object UniqueTriggerActivation {
                         if (scientificGP != null) greatPerson = scientificGP
                     }
 
-                    if (unique.type == UniqueType.MayanGainGreatPerson)
-                        civInfo.greatPeople.longCountGPPool.remove(greatPerson.name)
+                   civInfo.greatPeople.longCountGPPool.remove(greatPerson.name)
                     return civInfo.units.addUnit(greatPerson.name, chosenCity) != null
                 }
             }

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -269,7 +269,9 @@ object UniqueTriggerActivation {
                     civInfo.greatPeople.freeGreatPeople++
                     // Anyone an idea for a good icon?
                     civInfo.greatPeople.mayaLimitedFreeGP++
-                    civInfo.addNotification(notification!!, MayaLongCountAction(), NotificationCategory.General, MayaCalendar.notificationIcon)
+
+                    if (notification != null)
+                        civInfo.addNotification(notification!!, MayaLongCountAction(), NotificationCategory.General, MayaCalendar.notificationIcon)
                     return true
                 } else {
                     greatPeople.removeAll { it.name !in civInfo.greatPeople.longCountGPPool }

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -10,7 +10,6 @@ import com.unciv.logic.civilization.CivFlags
 import com.unciv.logic.civilization.Civilization
 import com.unciv.logic.civilization.LocationAction
 import com.unciv.logic.civilization.MapUnitAction
-import com.unciv.logic.civilization.MayaLongCountAction
 import com.unciv.logic.civilization.NotificationAction
 import com.unciv.logic.civilization.NotificationCategory
 import com.unciv.logic.civilization.NotificationIcon
@@ -25,7 +24,6 @@ import com.unciv.models.stats.Stat
 import com.unciv.models.stats.Stats
 import com.unciv.models.translations.fillPlaceholders
 import com.unciv.models.translations.hasPlaceholderParameters
-import com.unciv.ui.components.MayaCalendar
 import com.unciv.ui.components.extensions.addToMapOfSets
 import com.unciv.ui.screens.worldscreen.unit.actions.UnitActionsUpgrade
 import kotlin.math.roundToInt
@@ -242,26 +240,7 @@ object UniqueTriggerActivation {
                 if (civInfo.isAI() || UncivGame.Current.settings.autoPlay.isAutoPlayingAndFullAI()) {
                     NextTurnAutomation.chooseGreatPerson(civInfo)
                 }
-                
-                return true
-            }
-
-            UniqueType.MayanGainGreatPerson -> {
-                if (civInfo.isSpectator()) return false
-                val greatPeople = civInfo.greatPeople.getGreatPeople()
-                if (civInfo.greatPeople.longCountGPPool.isEmpty())
-                civInfo.greatPeople.longCountGPPool = greatPeople.map { it.name }.toHashSet()
-
-                civInfo.greatPeople.freeGreatPeople++
-                // Anyone an idea for a good icon?
-                civInfo.greatPeople.mayaLimitedFreeGP++
-                if (notification != null)
-                    civInfo.addNotification(notification, MayaLongCountAction(), NotificationCategory.General, MayaCalendar.notificationIcon)
-                
-                if (civInfo.isAI() || UncivGame.Current.settings.autoPlay.isAutoPlayingAndFullAI()) {
-                    NextTurnAutomation.chooseGreatPerson(civInfo)
-                }
-
+           
                 return true
             }
 

--- a/core/src/com/unciv/ui/components/MayaCalendar.kt
+++ b/core/src/com/unciv/ui/components/MayaCalendar.kt
@@ -2,6 +2,8 @@ package com.unciv.ui.components
 
 import com.badlogic.gdx.graphics.Color
 import com.unciv.Constants
+import com.unciv.UncivGame
+import com.unciv.logic.automation.civilization.NextTurnAutomation
 import com.unciv.logic.civilization.Civilization
 import com.unciv.models.ruleset.unique.UniqueTriggerActivation
 import com.unciv.models.ruleset.unique.UniqueType
@@ -73,12 +75,9 @@ object MayaCalendar {
         val game = civInfo.gameInfo
         val year = game.getYear()
         if (!isNewCycle(year, game.getYear(-1))) return
-        for (unique in civInfo.getMatchingUniques(UniqueType.MayanGainGreatPerson)) {
-            UniqueTriggerActivation.triggerCivwideUnique(
-                unique, civInfo,
-                notification = "{A new b'ak'tun has just begun!}\n{A Great Person joins you!}"
-            )
-        }
+        civInfo.greatPeople.triggerMayanGreatPerson()
+        if (civInfo.isAI() || UncivGame.Current.settings.autoPlay.isAutoPlayingAndFullAI())
+            NextTurnAutomation.chooseGreatPerson(civInfo)
     }
 
     // User interface to explain changed year display


### PR DESCRIPTION
Ok, so in theory, all I need to do is `if (notification != null)`, but actually... Why the hell was this in UniquerTriggerActivation in the first place? It never triggered as one before until #10940 and it's not supposed to act immediately. Hell, because of how it worked before, it also meant two different cases of the unique would give you 2 different triggers for free great people

PR moves everything much closer towards where it actually should be. Only oddity is the how I call NextTurnAutomation instead of doing stuff at the start of the turn exclusively. Not sure the best way to handle that (and NextTurn is probably the wrong spot, but I'm not quite sure where the "right" spot would be