### PR TITLE
Unify unit and civ triggers

### DIFF
--- a/core/src/com/unciv/logic/GameStarter.kt
+++ b/core/src/com/unciv/logic/GameStarter.kt
@@ -430,7 +430,7 @@ object GameStarter {
             //We may need the starting location for some uniques, which is why we're doing it now
             val startingTriggers = (ruleset.globalUniques.uniqueObjects + civ.nation.uniqueObjects)
             for (unique in startingTriggers.filter { !it.hasTriggerConditional() && it.conditionalsApply(civ) })
-                UniqueTriggerActivation.triggerCivwideUnique(unique, civ, tile = startingLocation)
+                UniqueTriggerActivation.triggerUnique(unique, civ, tile = startingLocation)
         }
     }
 

--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -156,7 +156,7 @@ object Battle {
             for (unique in ourUnit.unit.getTriggeredUniques(UniqueType.TriggerUponDefeatingUnit, stateForConditionals))
                 if (unique.conditionals.any { it.type == UniqueType.TriggerUponDefeatingUnit
                                 && enemy.unit.matchesFilter(it.params[0]) })
-                    UniqueTriggerActivation.triggerUnitwideUnique(unique, ourUnit.unit, triggerNotificationText = "due to our [${ourUnit.getName()}] defeating a [${enemy.getName()}]")
+                    UniqueTriggerActivation.triggerUnique(unique, ourUnit.unit, triggerNotificationText = "due to our [${ourUnit.getName()}] defeating a [${enemy.getName()}]")
         }
 
         // Add culture when defeating a barbarian when Honor policy is adopted, gold from enemy killed when honor is complete
@@ -205,7 +205,7 @@ object Battle {
         val stateForConditionals = StateForConditionals(civInfo = ourUnit.getCivInfo(),
             ourCombatant = ourUnit, theirCombatant=enemy, tile = attackedTile)
         for (unique in ourUnit.unit.getTriggeredUniques(UniqueType.TriggerUponDefeat, stateForConditionals))
-            UniqueTriggerActivation.triggerUnitwideUnique(unique, ourUnit.unit, triggerNotificationText = "due to our [${ourUnit.getName()}] being defeated by a [${enemy.getName()}]")
+            UniqueTriggerActivation.triggerUnique(unique, ourUnit.unit, triggerNotificationText = "due to our [${ourUnit.getName()}] being defeated by a [${enemy.getName()}]")
     }
 
     private fun tryEarnFromKilling(civUnit: ICombatant, defeatedUnit: MapUnitCombatant) {
@@ -310,12 +310,12 @@ object Battle {
         if (attacker is MapUnitCombatant)
             for (unique in attacker.unit.getTriggeredUniques(UniqueType.TriggerUponLosingHealth))
                 if (unique.conditionals.any { it.params[0].toInt() <= defenderDamageDealt })
-                    UniqueTriggerActivation.triggerUnitwideUnique(unique, attacker.unit, triggerNotificationText = "due to losing [$defenderDamageDealt] HP")
+                    UniqueTriggerActivation.triggerUnique(unique, attacker.unit, triggerNotificationText = "due to losing [$defenderDamageDealt] HP")
 
         if (defender is MapUnitCombatant)
             for (unique in defender.unit.getTriggeredUniques(UniqueType.TriggerUponLosingHealth))
                 if (unique.conditionals.any { it.params[0].toInt() <= attackerDamageDealt })
-                    UniqueTriggerActivation.triggerUnitwideUnique(unique, defender.unit, triggerNotificationText = "due to losing [$attackerDamageDealt] HP")
+                    UniqueTriggerActivation.triggerUnique(unique, defender.unit, triggerNotificationText = "due to losing [$attackerDamageDealt] HP")
 
         plunderFromDamage(attacker, defender, attackerDamageDealt)
         return DamageDealt(attackerDamageDealt, defenderDamageDealt)
@@ -566,7 +566,7 @@ object Battle {
 
         for (unique in attackerCiv.getTriggeredUniques(UniqueType.TriggerUponConqueringCity, stateForConditionals)
                 + attacker.unit.getTriggeredUniques(UniqueType.TriggerUponConqueringCity, stateForConditionals))
-            UniqueTriggerActivation.triggerUnitwideUnique(unique, attacker.unit)
+            UniqueTriggerActivation.triggerUnique(unique, attacker.unit)
     }
 
     /** Handle decision making after city conquest, namely whether the AI should liberate, puppet,

--- a/core/src/com/unciv/logic/city/CityConstructions.kt
+++ b/core/src/com/unciv/logic/city/CityConstructions.kt
@@ -552,17 +552,17 @@ class CityConstructions : IsPartOfGameInfoSerialization {
 
         for (unique in building.uniqueObjects)
             if (!unique.hasTriggerConditional() && unique.conditionalsApply(stateForConditionals))
-                UniqueTriggerActivation.triggerCivwideUnique(unique, city.civ, city, triggerNotificationText = triggerNotificationText)
+                UniqueTriggerActivation.triggerUnique(unique, city, triggerNotificationText = triggerNotificationText)
 
         for (unique in city.civ.getTriggeredUniques(UniqueType.TriggerUponConstructingBuilding, stateForConditionals))
             if (unique.conditionals.any {it.type == UniqueType.TriggerUponConstructingBuilding && building.matchesFilter(it.params[0])})
-                UniqueTriggerActivation.triggerCivwideUnique(unique, city.civ, city, triggerNotificationText = triggerNotificationText)
+                UniqueTriggerActivation.triggerUnique(unique, city, triggerNotificationText = triggerNotificationText)
 
         for (unique in city.civ.getTriggeredUniques(UniqueType.TriggerUponConstructingBuildingCityFilter, stateForConditionals))
             if (unique.conditionals.any {it.type == UniqueType.TriggerUponConstructingBuildingCityFilter
                     && building.matchesFilter(it.params[0])
                     && city.matchesFilter(it.params[1])})
-                UniqueTriggerActivation.triggerCivwideUnique(unique, city.civ, city, triggerNotificationText = triggerNotificationText)
+                UniqueTriggerActivation.triggerUnique(unique, city, triggerNotificationText = triggerNotificationText)
     }
 
     fun removeBuilding(buildingName: String) {

--- a/core/src/com/unciv/logic/city/managers/CityFounder.kt
+++ b/core/src/com/unciv/logic/city/managers/CityFounder.kt
@@ -7,6 +7,7 @@ import com.unciv.logic.civilization.Civilization
 import com.unciv.logic.civilization.Proximity
 import com.unciv.logic.civilization.diplomacy.DiplomacyFlags
 import com.unciv.logic.civilization.managers.ReligionState
+import com.unciv.logic.map.mapunit.MapUnit
 import com.unciv.models.ruleset.nation.Nation
 import com.unciv.models.ruleset.unique.StateForConditionals
 import com.unciv.models.ruleset.unique.UniqueTriggerActivation
@@ -89,11 +90,12 @@ class CityFounder {
 
 
         for (unique in civInfo.getTriggeredUniques(UniqueType.TriggerUponFoundingCity,
-            StateForConditionals(civInfo, city)
+            StateForConditionals(civInfo, city, unit)
         ))
             UniqueTriggerActivation.triggerUnique(unique, civInfo, city, unit, triggerNotificationText = "due to founding a city")
         if (unit != null)
-            for (unique in unit.getTriggeredUniques(UniqueType.TriggerUponFoundingCity))
+            for (unique in unit.getTriggeredUniques(UniqueType.TriggerUponFoundingCity,
+                StateForConditionals(civInfo, city, unit)
                 UniqueTriggerActivation.triggerUnique(unique, civInfo, city, unit, triggerNotificationText = "due to founding a city")
 
         return city

--- a/core/src/com/unciv/logic/city/managers/CityFounder.kt
+++ b/core/src/com/unciv/logic/city/managers/CityFounder.kt
@@ -88,14 +88,13 @@ class CityFounder {
         triggerCitiesSettledNearOtherCiv(city)
         civInfo.gameInfo.cityDistances.setDirty()
 
-
         for (unique in civInfo.getTriggeredUniques(UniqueType.TriggerUponFoundingCity,
             StateForConditionals(civInfo, city, unit)
         ))
             UniqueTriggerActivation.triggerUnique(unique, civInfo, city, unit, triggerNotificationText = "due to founding a city")
         if (unit != null)
             for (unique in unit.getTriggeredUniques(UniqueType.TriggerUponFoundingCity,
-                StateForConditionals(civInfo, city, unit)
+                StateForConditionals(civInfo, city, unit)))
                 UniqueTriggerActivation.triggerUnique(unique, civInfo, city, unit, triggerNotificationText = "due to founding a city")
 
         return city

--- a/core/src/com/unciv/logic/city/managers/CityFounder.kt
+++ b/core/src/com/unciv/logic/city/managers/CityFounder.kt
@@ -13,7 +13,7 @@ import com.unciv.models.ruleset.unique.UniqueTriggerActivation
 import com.unciv.models.ruleset.unique.UniqueType
 
 class CityFounder {
-    fun foundCity(civInfo: Civilization, cityLocation: Vector2): City {
+    fun foundCity(civInfo: Civilization, cityLocation: Vector2, unit: MapUnit? = null): City {
         val city = City()
 
         city.foundingCiv = civInfo.civName
@@ -91,8 +91,10 @@ class CityFounder {
         for (unique in civInfo.getTriggeredUniques(UniqueType.TriggerUponFoundingCity,
             StateForConditionals(civInfo, city)
         ))
-            UniqueTriggerActivation.triggerCivwideUnique(unique, civInfo, city, triggerNotificationText = "due to founding a city")
-
+            UniqueTriggerActivation.triggerUnique(unique, civInfo, city, unit, triggerNotificationText = "due to founding a city")
+        if (unit != null)
+            for (unique in unit.getTriggeredUniques(UniqueType.TriggerUponFoundingCity))
+                UniqueTriggerActivation.triggerUnique(unique, civInfo, city, unit, triggerNotificationText = "due to founding a city")
 
         return city
     }

--- a/core/src/com/unciv/logic/civilization/Civilization.kt
+++ b/core/src/com/unciv/logic/civilization/Civilization.kt
@@ -809,8 +809,8 @@ class Civilization : IsPartOfGameInfoSerialization {
     }
     // endregion
 
-    fun addCity(location: Vector2) {
-        val newCity = CityFounder().foundCity(this, location)
+    fun addCity(location: Vector2, unit: MapUnit? = null) {
+        val newCity = CityFounder().foundCity(this, location, unit)
         newCity.cityConstructions.chooseNextConstruction()
     }
 

--- a/core/src/com/unciv/logic/civilization/diplomacy/DeclareWar.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DeclareWar.kt
@@ -65,7 +65,7 @@ object DeclareWar {
 
         if (otherCiv.isMajorCiv())
             for (unique in civInfo.getTriggeredUniques(UniqueType.TriggerUponDeclaringWar))
-                UniqueTriggerActivation.triggerCivwideUnique(unique, civInfo)
+                UniqueTriggerActivation.triggerUnique(unique, civInfo)
     }
 
     private fun breakTreaties(diplomacyManager: DiplomacyManager) {

--- a/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
@@ -510,12 +510,12 @@ class DiplomacyManager() : IsPartOfGameInfoSerialization {
             thirdCiv.getDiplomacyManager(civInfo).setFriendshipBasedModifier()
         }
 
-        // Ignore contitionals as triggerCivwideUnique will check again, and that would break
+        // Ignore contitionals as triggerUnique will check again, and that would break
         // UniqueType.ConditionalChance - 25% declared chance would work as 6% actual chance
         for (unique in civInfo.getTriggeredUniques(UniqueType.TriggerUponDeclaringFriendship, StateForConditionals.IgnoreConditionals))
-            UniqueTriggerActivation.triggerCivwideUnique(unique, civInfo)
+            UniqueTriggerActivation.triggerUnique(unique, civInfo)
         for (unique in otherCiv().getTriggeredUniques(UniqueType.TriggerUponDeclaringFriendship, StateForConditionals.IgnoreConditionals))
-            UniqueTriggerActivation.triggerCivwideUnique(unique, otherCiv())
+            UniqueTriggerActivation.triggerUnique(unique, otherCiv())
     }
 
     internal fun setFriendshipBasedModifier() {
@@ -557,12 +557,12 @@ class DiplomacyManager() : IsPartOfGameInfoSerialization {
             thirdCiv.getDiplomacyManager(civInfo).setDefensivePactBasedModifier()
         }
 
-        // Ignore contitionals as triggerCivwideUnique will check again, and that would break
+        // Ignore contitionals as triggerUnique will check again, and that would break
         // UniqueType.ConditionalChance - 25% declared chance would work as 6% actual chance
         for (unique in civInfo.getTriggeredUniques(UniqueType.TriggerUponSigningDefensivePact, StateForConditionals.IgnoreConditionals))
-            UniqueTriggerActivation.triggerCivwideUnique(unique, civInfo)
+            UniqueTriggerActivation.triggerUnique(unique, civInfo)
         for (unique in otherCiv().getTriggeredUniques(UniqueType.TriggerUponSigningDefensivePact, StateForConditionals.IgnoreConditionals))
-            UniqueTriggerActivation.triggerCivwideUnique(unique, otherCiv())
+            UniqueTriggerActivation.triggerUnique(unique, otherCiv())
     }
 
     internal fun setDefensivePactBasedModifier() {

--- a/core/src/com/unciv/logic/civilization/managers/GoldenAgeManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/GoldenAgeManager.kt
@@ -52,7 +52,7 @@ class GoldenAgeManager : IsPartOfGameInfoSerialization {
         civInfo.popupAlerts.add(PopupAlert(AlertType.GoldenAge, ""))
 
         for (unique in civInfo.getTriggeredUniques(UniqueType.TriggerUponEnteringGoldenAge))
-            UniqueTriggerActivation.triggerCivwideUnique(unique, civInfo)
+            UniqueTriggerActivation.triggerUnique(unique, civInfo)
         //Golden Age can happen mid turn with Great Artist effects
         for (city in civInfo.cities)
             city.cityStats.update()

--- a/core/src/com/unciv/logic/civilization/managers/PolicyManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/PolicyManager.kt
@@ -213,11 +213,11 @@ class PolicyManager : IsPartOfGameInfoSerialization {
         val triggerNotificationText = "due to adopting [${policy.name}]"
         for (unique in policy.uniqueObjects)
             if (!unique.hasTriggerConditional() && unique.conditionalsApply(StateForConditionals(civInfo)))
-                UniqueTriggerActivation.triggerCivwideUnique(unique, civInfo, triggerNotificationText = triggerNotificationText)
+                UniqueTriggerActivation.triggerUnique(unique, civInfo, triggerNotificationText = triggerNotificationText)
 
         for (unique in civInfo.getTriggeredUniques(UniqueType.TriggerUponAdoptingPolicyOrBelief))
             if (unique.conditionals.any {it.type == UniqueType.TriggerUponAdoptingPolicyOrBelief && it.params[0] == policy.name})
-                UniqueTriggerActivation.triggerCivwideUnique(unique, civInfo, triggerNotificationText = triggerNotificationText)
+                UniqueTriggerActivation.triggerUnique(unique, civInfo, triggerNotificationText = triggerNotificationText)
 
         civInfo.cache.updateCivResources()
 

--- a/core/src/com/unciv/logic/civilization/managers/ReligionManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/ReligionManager.kt
@@ -390,17 +390,17 @@ class ReligionManager : IsPartOfGameInfoSerialization {
             ReligionState.None -> {
                 religionState = ReligionState.Pantheon
                 for (unique in civInfo.getTriggeredUniques(UniqueType.TriggerUponFoundingPantheon))
-                    UniqueTriggerActivation.triggerCivwideUnique(unique, civInfo)
+                    UniqueTriggerActivation.triggerUnique(unique, civInfo)
             }
             ReligionState.FoundingReligion -> {
                 religionState = ReligionState.Religion
                 for (unique in civInfo.getTriggeredUniques(UniqueType.TriggerUponFoundingReligion))
-                    UniqueTriggerActivation.triggerCivwideUnique(unique, civInfo)
+                    UniqueTriggerActivation.triggerUnique(unique, civInfo)
             }
             ReligionState.EnhancingReligion -> {
                 religionState = ReligionState.EnhancedReligion
                 for (unique in civInfo.getTriggeredUniques(UniqueType.TriggerUponEnhancingReligion))
-                    UniqueTriggerActivation.triggerCivwideUnique(unique, civInfo)
+                    UniqueTriggerActivation.triggerUnique(unique, civInfo)
             }
             else -> {}
         }
@@ -408,12 +408,12 @@ class ReligionManager : IsPartOfGameInfoSerialization {
         for (unique in civInfo.getTriggeredUniques(UniqueType.TriggerUponAdoptingPolicyOrBelief))
             for (belief in beliefs)
                 if (unique.conditionals.any {it.type == UniqueType.TriggerUponAdoptingPolicyOrBelief && it.params[0] == belief.name})
-                    UniqueTriggerActivation.triggerCivwideUnique(unique, civInfo,
+                    UniqueTriggerActivation.triggerUnique(unique, civInfo,
                         triggerNotificationText = "due to adopting [${belief.name}]")
 
         for (belief in beliefs)
             for (unique in belief.uniqueObjects.filter { !it.hasTriggerConditional() && it.conditionalsApply(StateForConditionals(civInfo)) })
-                UniqueTriggerActivation.triggerCivwideUnique(unique, civInfo)
+                UniqueTriggerActivation.triggerUnique(unique, civInfo)
 
         civInfo.updateStatsForNextTurn()  // a belief can have an immediate effect on stats
     }

--- a/core/src/com/unciv/logic/civilization/managers/RuinsManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/RuinsManager.kt
@@ -63,8 +63,7 @@ class RuinsManager(
             for (unique in possibleReward.uniqueObjects) {
                 atLeastOneUniqueHadEffect =
                     atLeastOneUniqueHadEffect
-                    || UniqueTriggerActivation.triggerCivwideUnique(unique, civInfo, tile = triggeringUnit.getTile(), notification = possibleReward.notification, triggerNotificationText = "from the ruins")
-                    || UniqueTriggerActivation.triggerUnitwideUnique(unique, triggeringUnit, notification = possibleReward.notification)
+                    || UniqueTriggerActivation.triggerUnique(unique, triggeringUnit, notification = possibleReward.notification)
             }
             if (atLeastOneUniqueHadEffect) {
                 rememberReward(possibleReward.name)

--- a/core/src/com/unciv/logic/civilization/managers/TechManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/TechManager.kt
@@ -299,11 +299,11 @@ class TechManager : IsPartOfGameInfoSerialization {
         val triggerNotificationText = "due to researching [$techName]"
         for (unique in newTech.uniqueObjects)
             if (!unique.hasTriggerConditional() && unique.conditionalsApply(StateForConditionals(civInfo)))
-                UniqueTriggerActivation.triggerCivwideUnique(unique, civInfo, triggerNotificationText = triggerNotificationText)
+                UniqueTriggerActivation.triggerUnique(unique, civInfo, triggerNotificationText = triggerNotificationText)
 
         for (unique in civInfo.getTriggeredUniques(UniqueType.TriggerUponResearch))
             if (unique.conditionals.any {it.type == UniqueType.TriggerUponResearch && it.params[0] == techName})
-                UniqueTriggerActivation.triggerCivwideUnique(unique, civInfo, triggerNotificationText = triggerNotificationText)
+                UniqueTriggerActivation.triggerUnique(unique, civInfo, triggerNotificationText = triggerNotificationText)
 
 
         val revealedResources = getRuleset().tileResources.values.filter { techName == it.revealedBy }
@@ -440,7 +440,7 @@ class TechManager : IsPartOfGameInfoSerialization {
             for (era in erasPassed)
                 for (unique in era.uniqueObjects)
                     if (!unique.hasTriggerConditional() && unique.conditionalsApply(StateForConditionals(civInfo)))
-                        UniqueTriggerActivation.triggerCivwideUnique(
+                        UniqueTriggerActivation.triggerUnique(
                             unique,
                             civInfo,
                             triggerNotificationText = "due to entering the [${era.name}]"
@@ -450,7 +450,7 @@ class TechManager : IsPartOfGameInfoSerialization {
             for (unique in civInfo.getTriggeredUniques(UniqueType.TriggerUponEnteringEra))
                 for (eraName in eraNames)
                     if (unique.conditionals.any { it.type == UniqueType.TriggerUponEnteringEra && it.params[0] == eraName })
-                        UniqueTriggerActivation.triggerCivwideUnique(
+                        UniqueTriggerActivation.triggerUnique(
                             unique,
                             civInfo,
                             triggerNotificationText = "due to entering the [$eraName]"

--- a/core/src/com/unciv/logic/civilization/managers/TurnManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/TurnManager.kt
@@ -234,7 +234,7 @@ class TurnManager(val civInfo: Civilization) {
             NextTurnAutomation.automateCityBombardment(civInfo) // Bombard with all cities that haven't, maybe you missed one
 
         for (unique in civInfo.getTriggeredUniques(UniqueType.TriggerUponTurnEnd, StateForConditionals(civInfo)))
-            UniqueTriggerActivation.triggerCivwideUnique(unique, civInfo)
+            UniqueTriggerActivation.triggerUnique(unique, civInfo)
 
         val notificationsLog = civInfo.notificationsLog
         val notificationsThisTurn = Civilization.NotificationsLog(civInfo.gameInfo.turns)

--- a/core/src/com/unciv/logic/civilization/managers/UnitManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/UnitManager.kt
@@ -82,11 +82,11 @@ class UnitManager(val civInfo:Civilization) {
             val triggerNotificationText = "due to gaining a [${unit.name}]"
             for (unique in unit.getUniques())
                 if (!unique.hasTriggerConditional() && unique.conditionalsApply(StateForConditionals(civInfo, unit = unit)))
-                    UniqueTriggerActivation.triggerUnitwideUnique(unique, unit, triggerNotificationText = triggerNotificationText)
+                    UniqueTriggerActivation.triggerUnique(unique, unit, triggerNotificationText = triggerNotificationText)
             for (unique in civInfo.getTriggeredUniques(UniqueType.TriggerUponGainingUnit))
                 if (unique.conditionals.any { it.type == UniqueType.TriggerUponGainingUnit &&
                         unit.matchesFilter(it.params[0]) })
-                    UniqueTriggerActivation.triggerCivwideUnique(unique, civInfo, triggerNotificationText = triggerNotificationText)
+                    UniqueTriggerActivation.triggerUnique(unique, unit, triggerNotificationText = triggerNotificationText)
             if (unit.getResourceRequirementsPerTurn().isNotEmpty())
                 civInfo.cache.updateCivResources()
 

--- a/core/src/com/unciv/logic/civilization/transients/CivInfoTransientCache.kt
+++ b/core/src/com/unciv/logic/civilization/transients/CivInfoTransientCache.kt
@@ -237,7 +237,7 @@ class CivInfoTransientCache(val civInfo: Civilization) {
             for (unique in civInfo.getTriggeredUniques(UniqueType.TriggerUponDiscoveringNaturalWonder,
                 StateForConditionals(civInfo, tile = tile)
             ))
-                UniqueTriggerActivation.triggerCivwideUnique(unique, civInfo, tile=tile, triggerNotificationText = "due to discovering a Natural Wonder")
+                UniqueTriggerActivation.triggerUnique(unique, civInfo, tile=tile, triggerNotificationText = "due to discovering a Natural Wonder")
         }
     }
 

--- a/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
@@ -664,7 +664,7 @@ class MapUnit : IsPartOfGameInfoSerialization {
                                     && tile.matchesFilter(it.params[0], civ)
                             } && unique.conditionalsApply(state)
                         )
-                            UniqueTriggerActivation.triggerUnitwideUnique(unique, this)
+                            UniqueTriggerActivation.triggerUnique(unique, this)
                     }
                 }
             }

--- a/core/src/com/unciv/logic/map/mapunit/UnitPromotions.kt
+++ b/core/src/com/unciv/logic/map/mapunit/UnitPromotions.kt
@@ -73,7 +73,7 @@ class UnitPromotions : IsPartOfGameInfoSerialization {
             }
 
             for (unique in unit.getTriggeredUniques(UniqueType.TriggerUponPromotion))
-                UniqueTriggerActivation.triggerUnitwideUnique(unique, unit)
+                UniqueTriggerActivation.triggerUnique(unique, unit)
         }
 
         if (!promotion.hasUnique(UniqueType.SkipPromotion))
@@ -106,7 +106,7 @@ class UnitPromotions : IsPartOfGameInfoSerialization {
         for (unique in promotion.uniqueObjects)
             if (unique.conditionalsApply(StateForConditionals(civInfo = unit.civ, unit = unit))
                     && !unique.hasTriggerConditional())
-                UniqueTriggerActivation.triggerUnitwideUnique(unique, unit, triggerNotificationText = "due to our [${unit.name}] being promoted")
+                UniqueTriggerActivation.triggerUnique(unique, unit, triggerNotificationText = "due to our [${unit.name}] being promoted")
     }
 
     /** Gets all promotions this unit could currently "buy" with enough [XP]

--- a/core/src/com/unciv/logic/map/mapunit/UnitTurnManager.kt
+++ b/core/src/com/unciv/logic/map/mapunit/UnitTurnManager.kt
@@ -60,7 +60,7 @@ class UnitTurnManager(val unit: MapUnit) {
         for (unique in unit.getTriggeredUniques(UniqueType.TriggerUponEndingTurnInTile))
             if (unique.conditionals.any { it.type == UniqueType.TriggerUponEndingTurnInTile
                             && unit.getTile().matchesFilter(it.params[0], unit.civ) })
-                UniqueTriggerActivation.triggerUnitwideUnique(unique, unit)
+                UniqueTriggerActivation.triggerUnique(unique, unit)
     }
 
 

--- a/core/src/com/unciv/logic/map/tile/TileInfoImprovementFunctions.kt
+++ b/core/src/com/unciv/logic/map/tile/TileInfoImprovementFunctions.kt
@@ -252,12 +252,12 @@ class TileInfoImprovementFunctions(val tile: Tile) {
             && it.conditionalsApply(stateForConditionals) })
             UniqueTriggerActivation.triggerUnique(unique, civ, unit = unit, tile = tile)
 
-        for (unique in civ.getMatchingUniques(UniqueType.TriggerUponBuildingImprovement, stateForConditionals)
+        for (unique in civ.getTriggeredUniques(UniqueType.TriggerUponBuildingImprovement, stateForConditionals)
             .filter { improvement.matchesFilter(it.params[0]) })
             UniqueTriggerActivation.triggerUnique(unique, civ, unit = unit, tile = tile)
         
         if (unit == null) return
-        for (unique in unit.getMatchingUniques(UniqueType.TriggerUponBuildingImprovement, stateForConditionals)
+        for (unique in unit.getTriggeredUniques(UniqueType.TriggerUponBuildingImprovement, stateForConditionals)
             .filter { improvement.matchesFilter(it.params[0]) })
             UniqueTriggerActivation.triggerUnique(unique, civ, unit = unit, tile = tile)
     }

--- a/core/src/com/unciv/logic/map/tile/TileInfoImprovementFunctions.kt
+++ b/core/src/com/unciv/logic/map/tile/TileInfoImprovementFunctions.kt
@@ -246,7 +246,7 @@ class TileInfoImprovementFunctions(val tile: Tile) {
         civ: Civilization,
         unit: MapUnit? = null
     ) {
-        val stateForConditionals = StateForConditionals(civ, unit = unit)
+        val stateForConditionals = StateForConditionals(civ, unit = unit, tile = tile)
         
         for (unique in improvement.uniqueObjects.filter { !it.hasTriggerConditional()
             && it.conditionalsApply(stateForConditionals) })

--- a/core/src/com/unciv/logic/map/tile/TileInfoImprovementFunctions.kt
+++ b/core/src/com/unciv/logic/map/tile/TileInfoImprovementFunctions.kt
@@ -247,11 +247,17 @@ class TileInfoImprovementFunctions(val tile: Tile) {
         unit: MapUnit? = null
     ) {
         val stateForConditionals = StateForConditionals(civ, unit = unit)
+        
         for (unique in improvement.uniqueObjects.filter { !it.hasTriggerConditional()
             && it.conditionalsApply(stateForConditionals) })
             UniqueTriggerActivation.triggerUnique(unique, civ, unit = unit, tile = tile)
 
-        for (unique in civ.getMatchingUniques(UniqueType.TriggerUponBuildingImprovement,stateForConditionals)
+        for (unique in civ.getMatchingUniques(UniqueType.TriggerUponBuildingImprovement, stateForConditionals)
+            .filter { improvement.matchesFilter(it.params[0]) })
+            UniqueTriggerActivation.triggerUnique(unique, civ, unit = unit, tile = tile)
+        
+        if (unit == null) return
+        for (unique in unit.getMatchingUniques(UniqueType.TriggerUponBuildingImprovement, stateForConditionals)
             .filter { improvement.matchesFilter(it.params[0]) })
             UniqueTriggerActivation.triggerUnique(unique, civ, unit = unit, tile = tile)
     }

--- a/core/src/com/unciv/logic/map/tile/TileInfoImprovementFunctions.kt
+++ b/core/src/com/unciv/logic/map/tile/TileInfoImprovementFunctions.kt
@@ -246,23 +246,14 @@ class TileInfoImprovementFunctions(val tile: Tile) {
         civ: Civilization,
         unit: MapUnit? = null
     ) {
+        val stateForConditionals = StateForConditionals(civ, unit = unit)
         for (unique in improvement.uniqueObjects.filter { !it.hasTriggerConditional()
-            && it.conditionalsApply(StateForConditionals(civ)) })
-            if (unit != null) {
-                UniqueTriggerActivation.triggerUnitwideUnique(unique, unit)
-            }
-            else UniqueTriggerActivation.triggerCivwideUnique(unique, civ, tile = tile)
+            && it.conditionalsApply(stateForConditionals) })
+            UniqueTriggerActivation.triggerUnique(unique, civ, unit = unit, tile = tile)
 
-        if (unit != null){
-            for (unique in unit.getTriggeredUniques(UniqueType.TriggerUponBuildingImprovement)
-                .filter { improvement.matchesFilter(it.params[0]) })
-                UniqueTriggerActivation.triggerUnitwideUnique(unique, unit)
-            }
-
-        for (unique in civ.getMatchingUniques(
-            UniqueType.TriggerUponBuildingImprovement, StateForConditionals(civInfo = civ, unit = unit))
+        for (unique in civ.getMatchingUniques(UniqueType.TriggerUponBuildingImprovement,stateForConditionals)
             .filter { improvement.matchesFilter(it.params[0]) })
-            UniqueTriggerActivation.triggerCivwideUnique(unique, civ, tile = tile)
+            UniqueTriggerActivation.triggerUnique(unique, civ, unit = unit, tile = tile)
     }
 
     private fun activateRemovalImprovement(

--- a/core/src/com/unciv/models/ruleset/unique/StateForConditionals.kt
+++ b/core/src/com/unciv/models/ruleset/unique/StateForConditionals.kt
@@ -2,6 +2,7 @@ package com.unciv.models.ruleset.unique
 
 import com.unciv.logic.battle.CombatAction
 import com.unciv.logic.battle.ICombatant
+import com.unciv.logic.battle.MapUnitCombatant
 import com.unciv.logic.city.City
 import com.unciv.logic.civilization.Civilization
 import com.unciv.logic.map.mapgenerator.mapregions.Region
@@ -23,6 +24,21 @@ data class StateForConditionals(
 
     val ignoreConditionals: Boolean = false,
 ) {
+    constructor(city: City) : this(city.civ, city, tile = city.getCenterTile())
+    constructor(unit: MapUnit) : this(unit.civ, unit = unit, tile = unit.currentTile)
+    constructor(ourCombatant: ICombatant) : this(
+        ourCombatant.getCivInfo(),
+        unit = (ourCombatant as MapUnitCombatant).unit,
+        tile = ourCombatant.getTile(),
+        ourCombatant = ourCombatant,
+    )
+    constructor(ourCombatant: ICombatant, theirCombatant: ICombatant) : this(
+        ourCombatant.getCivInfo(),
+        unit = (ourCombatant as MapUnitCombatant).unit,
+        tile = ourCombatant.getTile(),
+        ourCombatant = ourCombatant,
+        theirCombatant = theirCombatant,
+    )
 
     companion object {
         val IgnoreConditionals = StateForConditionals(ignoreConditionals = true)

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -72,7 +72,7 @@ object UniqueTriggerActivation {
             return true
         }
 
-        if (!unique.conditionalsApply(civInfo, relevantCity)) return false
+        if (!unique.conditionalsApply(StateForConditionals(civInfo, city, unit, tile))) return false
 
         val chosenCity = relevantCity ?:
             civInfo.cities.firstOrNull { it.isCapital() }

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -38,7 +38,7 @@ object UniqueTriggerActivation {
         notification: String? = null,
         triggerNotificationText: String? = null
     ): Boolean {
-        return triggerUnique(unique, city.civ, city,
+        return triggerUnique(unique, city.civ, city, tile = city.getCenterTile(),
             notification = notification, triggerNotificationText = triggerNotificationText)
     }
     fun triggerUnique(

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -57,7 +57,7 @@ object UniqueTriggerActivation {
         civInfo: Civilization,
         city: City? = null,
         unit: MapUnit? = null,
-        tile: Tile? = city?.getCenterTile(),
+        tile: Tile? = city?.getCenterTile() ?: unit?.currentTile,
         notification: String? = null,
         triggerNotificationText: String? = null
     ): Boolean {

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -38,7 +38,7 @@ object UniqueTriggerActivation {
         notification: String? = null,
         triggerNotificationText: String? = null
     ): Boolean {
-        return triggerUnique(unique, city.civ, city,
+        return triggerUnique(unique, city.civ, city, tile = city?.getCenterTile(),
             notification = notification, triggerNotificationText = triggerNotificationText)
     }
     fun triggerUnique(

--- a/core/src/com/unciv/ui/screens/devconsole/ConsoleCivCommands.kt
+++ b/core/src/com/unciv/ui/screens/devconsole/ConsoleCivCommands.kt
@@ -43,7 +43,7 @@ class ConsoleCivCommands : ConsoleCommandNode {
             if (unique.type == null) throw ConsoleErrorException("Unrecognized trigger")
             val tile = console.screen.mapHolder.selectedTile
             val city = tile?.getCity()
-            UniqueTriggerActivation.triggerCivwideUnique(unique, civ, city, tile)
+            UniqueTriggerActivation.triggerUnique(unique, civ, city, tile = tile)
             DevConsoleResponse.OK
         }
     )

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsFromUniques.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsFromUniques.kt
@@ -54,7 +54,7 @@ object UnitActionsFromUniques {
         val foundAction = {
             if (unit.civ.playerType != PlayerType.AI)
                 UncivGame.Current.settings.addCompletedTutorialTask("Found city")
-            unit.civ.addCity(tile.position)
+            unit.civ.addCity(tile.position, unit)
 
             if (hasActionModifiers) UnitActionModifiers.activateSideEffects(unit, unique)
             else unit.destroy()
@@ -178,7 +178,7 @@ object UnitActionsFromUniques {
             val title = UnitActionModifiers.actionTextWithSideEffects(baseTitle, unique, unit)
 
             yield(UnitAction(UnitActionType.TriggerUnique, title) {
-                UniqueTriggerActivation.triggerUnitwideUnique(unique, unit)
+                UniqueTriggerActivation.triggerUnique(unique, unit)
                 UnitActionModifiers.activateSideEffects(unit, unique)
             })
         }

--- a/tests/src/com/unciv/logic/map/UpgradeTests.kt
+++ b/tests/src/com/unciv/logic/map/UpgradeTests.kt
@@ -31,7 +31,7 @@ class UpgradeTests {
         val civ = testGame.addCiv()
         var unit1 = testGame.addUnit(testUnit.name, civ, testGame.getTile(Vector2.Zero))
         val triggerUnique = Unique("This Unit upgrades for free including special upgrades")
-        UniqueTriggerActivation.triggerUnitwideUnique(triggerUnique, unit1)
+        UniqueTriggerActivation.triggerUnique(triggerUnique, unit1)
         unit1 = testGame.getTile(Vector2.Zero).getFirstUnit()!!
 
         Assert.assertTrue("Unit should upgrade to special unit, not warrior", unit1.baseUnit == unitToUpgradeTo)
@@ -46,7 +46,7 @@ class UpgradeTests {
         val civ = testGame.addCiv()
         var unit1 = testGame.addUnit(testUnit.name, civ, testGame.getTile(Vector2.Zero))
         val triggerUnique = Unique("This Unit upgrades for free including special upgrades")
-        UniqueTriggerActivation.triggerUnitwideUnique(triggerUnique, unit1)
+        UniqueTriggerActivation.triggerUnique(triggerUnique, unit1)
         unit1 = testGame.getTile(Vector2.Zero).getFirstUnit()!!
 
         Assert.assertTrue("Unit should upgrade to Warrior without unique", unit1.baseUnit.name == "Warrior")
@@ -67,7 +67,7 @@ class UpgradeTests {
             upgradeActions.any { (it as UpgradeUnitAction).unitToUpgradeTo == unitToUpgradeTo })
 
         val triggerUnique = Unique("This Unit upgrades for free")
-        UniqueTriggerActivation.triggerUnitwideUnique(triggerUnique, unit1)
+        UniqueTriggerActivation.triggerUnique(triggerUnique, unit1)
         unit1 = testGame.getTile(Vector2.Zero).getFirstUnit()!!
 
         Assert.assertTrue(unit1.baseUnit.name == "Warrior")
@@ -88,7 +88,7 @@ class UpgradeTests {
         Assert.assertTrue(upgradeActions.count() == 2)
 
         val triggerUnique = Unique("This Unit upgrades for free")
-        UniqueTriggerActivation.triggerUnitwideUnique(triggerUnique, unit1)
+        UniqueTriggerActivation.triggerUnique(triggerUnique, unit1)
         unit1 = testGame.getTile(Vector2.Zero).getFirstUnit()!!
 
         Assert.assertFalse(unit1.baseUnit == testUnit)


### PR DESCRIPTION
This PR aims to simplify unique triggers by calling a central function instead of a different function based on if it's a unit or civ. This aims to do a few things

1. Make it easier to include triggers from units with triggers from other sources. Main benefits are seen in the simplification seen in `TileInfoImprovementFunctions`
2. Make it simpler when trying to edit a unique to include/not include a unit
3. Make the formatting closer to StateForConditionals (possibly we can unify the uses here


Extras added in
1. Overrides so that `triggerUnique(city.civ, city)` can simplify down to `triggerUnique(city)` and the same for units
2. StateForConditionals does not support constructors apparently. So conditionalsApplies was edited to assume the civ from the unit/city to allow for the same simplification
3. `upon founding a city` now triggers the uniques found on the unit itself


Main notes here:
1. Out of scope, but is there a better way to try to trigger uniques off of units? Particularly because we have a blindspot in that gaining techs or policies or whatever doesn't trigger uniques off of units
2. `triggerUnitwideUniques` was privated, but tbh everything in it should be moved to the main `triggerUniques` function. It can do so pretty safely now anyways
3. That `conditionalsApplies` check in `triggerUniques` still looks extremely out of place to me