### PR TITLE
Ranged units capture civilian

### DIFF
--- a/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
@@ -496,6 +496,7 @@ object UnitAutomation {
 
     private fun chooseBombardTarget(city: City): ICombatant? {
         var targets = TargetHelper.getBombardableTiles(city).map { Battle.getMapCombatantOfTile(it)!! }
+            .filterNot { it.isCivilian() && !it.getUnitType().hasUnique(UniqueType.Uncapturable) } // Don't bombard capturable civilians
         if (targets.none()) return null
 
         val siegeUnits = targets


### PR DESCRIPTION
This PR addresses the problem of ranged units, such as cities and archers, shooting captured workers and settlers instead of capturing them.

- Cities no longer shoot capturable civilian units
- Ranged units only shoot uncapturable civilian units when necessary. Otherwise, they try to capture the civilian unit by moving to them instead.