### PR TITLE
World screen resize delayed

### DIFF
--- a/core/src/com/unciv/ui/screens/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/WorldScreen.kt
@@ -63,12 +63,15 @@ import com.unciv.ui.screens.worldscreen.topbar.WorldScreenTopBar
 import com.unciv.ui.screens.worldscreen.unit.UnitTable
 import com.unciv.ui.screens.worldscreen.unit.actions.UnitActionsTable
 import com.unciv.utils.Concurrency
+import com.unciv.utils.Log
 import com.unciv.utils.debug
 import com.unciv.utils.launchOnGLThread
 import com.unciv.utils.launchOnThreadPool
 import com.unciv.utils.withGLContext
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.coroutineScope
+import java.util.Timer
+import kotlin.concurrent.timer
 
 /**
  * Do not create this screen without seriously thinking about the implications: this is the single most memory-intensive class in the application.
@@ -216,6 +219,7 @@ class WorldScreen(
     }
 
     override fun dispose() {
+        resizeDeferTimer?.cancel()
         events.stopReceiving()
         statusButtons.dispose()
         super.dispose()
@@ -712,8 +716,20 @@ class WorldScreen(
         }
     }
 
+
+    private var resizeDeferTimer: Timer? = null
+
     override fun resize(width: Int, height: Int) {
-        if (stage.viewport.screenWidth != width || stage.viewport.screenHeight != height) {
+        resizeDeferTimer?.cancel()
+        if (resizeDeferTimer == null && stage.viewport.screenWidth == width && stage.viewport.screenHeight == height) return
+        if (resizeDeferTimer == null)
+            Log.debug("start resize timer")
+        else
+            Log.debug("prolong resize timer")
+        resizeDeferTimer = timer("Resize", daemon = true, 500L, Long.MAX_VALUE) {
+            resizeDeferTimer?.cancel()
+            resizeDeferTimer = null
+            Log.debug("finish resize timer")
             startNewScreenJob(gameInfo, true) // start over
         }
     }
@@ -722,7 +738,9 @@ class WorldScreen(
     override fun render(delta: Float) {
         //  This is so that updates happen in the MAIN THREAD, where there is a GL Context,
         //    otherwise images will not load properly!
-        if (shouldUpdate) {
+        if (resizeDeferTimer != null && shouldUpdate) {
+            Log.debug("defer update during resize")
+        } else if (shouldUpdate) {
             shouldUpdate = false
 
             // Since updating the worldscreen can take a long time, *especially* the first time, we disable input processing to avoid ANRs
@@ -732,8 +750,6 @@ class WorldScreen(
             if (Gdx.input.inputProcessor == null) // Update may have replaced the worldscreen with a GreatPersonPickerScreen etc, so the input would already be set
                 Gdx.input.inputProcessor = stage
         }
-//        topBar.selectedCivLabel.setText(Gdx.graphics.framesPerSecond) // for framerate testing
-
 
         super.render(delta)
     }
@@ -796,7 +812,7 @@ class WorldScreen(
 }
 
 /** This exists so that no reference to the current world screen remains, so the old world screen can get garbage collected during [UncivGame.loadGame]. */
-private fun startNewScreenJob(gameInfo: GameInfo, autosaveDisabled:Boolean = false) {
+private fun startNewScreenJob(gameInfo: GameInfo, autosaveDisabled: Boolean = false) {
     Concurrency.run {
         val newWorldScreen = try {
             UncivGame.Current.loadGame(gameInfo)

--- a/core/src/com/unciv/ui/screens/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/WorldScreen.kt
@@ -63,7 +63,6 @@ import com.unciv.ui.screens.worldscreen.topbar.WorldScreenTopBar
 import com.unciv.ui.screens.worldscreen.unit.UnitTable
 import com.unciv.ui.screens.worldscreen.unit.actions.UnitActionsTable
 import com.unciv.utils.Concurrency
-import com.unciv.utils.Log
 import com.unciv.utils.debug
 import com.unciv.utils.launchOnGLThread
 import com.unciv.utils.launchOnThreadPool
@@ -722,25 +721,17 @@ class WorldScreen(
     override fun resize(width: Int, height: Int) {
         resizeDeferTimer?.cancel()
         if (resizeDeferTimer == null && stage.viewport.screenWidth == width && stage.viewport.screenHeight == height) return
-        if (resizeDeferTimer == null)
-            Log.debug("start resize timer")
-        else
-            Log.debug("prolong resize timer")
         resizeDeferTimer = timer("Resize", daemon = true, 500L, Long.MAX_VALUE) {
             resizeDeferTimer?.cancel()
             resizeDeferTimer = null
-            Log.debug("finish resize timer")
             startNewScreenJob(gameInfo, true) // start over
         }
     }
 
-
     override fun render(delta: Float) {
         //  This is so that updates happen in the MAIN THREAD, where there is a GL Context,
         //    otherwise images will not load properly!
-        if (resizeDeferTimer != null && shouldUpdate) {
-            Log.debug("defer update during resize")
-        } else if (shouldUpdate) {
+        if (shouldUpdate && resizeDeferTimer == null) {
             shouldUpdate = false
 
             // Since updating the worldscreen can take a long time, *especially* the first time, we disable input processing to avoid ANRs
@@ -753,6 +744,7 @@ class WorldScreen(
 
         super.render(delta)
     }
+
 
     private fun showTutorialsOnNextTurn() {
         if (!game.settings.showTutorials) return


### PR DESCRIPTION
Closes #10993 via the third idea mentioned there. Works much better than expected (so far only tested on Windows) - the visuals while "drawing circles" dragging the window corner are interesting to say the least, but entirely acceptable IMHO. And the same test on master crashes this box (intentionally left at -Xmx512m).

#9544 (resize while next turn is running may result in the old worldscreen winning of the next-turn result) is not solved here, nor is the relatively high oom risk mitigated. Means I have no good clue how to treat that without rewriting tons of code. Alternative - as soon as a resize event is seen during next-turn, stop updating, bail from the draw overload, until the instance dies. Gives a black screen, which you can continue to resize freely without OOM risk, and when next turn is finally done - flash! Unciv is back...

Note on technology: There's rate limiting [libraries](https://github.com/bucket4j/bucket4j), there's the coroutine with delay option, there's asking the Executor for a scheduled thread start... This is throw-the-dice choice. Importing another java stdlib class instead of using a native kotlin alternative is icky, but kotlin's timer support still delegates directly, the extensions in use _are_ kotlin, so it's fine methinks - and the coroutine variant reads a little more complex.

As for removing the 'for framerate testing' comment -> our 'scene2d debug' has that, although I neglected to decorate the number with the 'fps' letters.