### PR TITLE
Worker automation option fix

### DIFF
--- a/core/src/com/unciv/logic/automation/unit/AirUnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/AirUnitAutomation.kt
@@ -190,7 +190,7 @@ object AirUnitAutomation {
             else if (targetTile.owningCity != null) {
                 val owningCiv = targetTile.owningCity?.civ!!
                 // If there is a tile to add fallout to there is a 50% chance it will get fallout
-                if (!(tile.isWater || tile.isImpassible() || targetTile.terrainFeatures.any { it == "Fallout" }))
+                if (!(tile.isWater || tile.isImpassible() || targetTile.hasFalloutEquivalent()))
                     explosionValue += evaluateCivValue(owningCiv, -40, 10)
                 // If there is an improvment to pillage
                 if (targetTile.improvement != null && !targetTile.improvementIsPillaged)

--- a/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
@@ -25,7 +25,6 @@ import com.unciv.models.ruleset.tile.Terrain
 import com.unciv.models.ruleset.tile.TileImprovement
 import com.unciv.models.ruleset.unique.LocalUniqueCache
 import com.unciv.models.ruleset.unique.UniqueType
-import com.unciv.models.stats.Stats
 import com.unciv.ui.screens.worldscreen.unit.actions.UnitActions
 import com.unciv.ui.screens.worldscreen.unit.actions.UnitActionsFromUniques
 import com.unciv.utils.Log
@@ -474,7 +473,7 @@ class WorkerAutomation(
     private fun findTileToWork(unit: MapUnit, tilesToAvoid: Set<Tile>): Tile {
         val currentTile = unit.getTile()
         if (currentTile != tilesToAvoid && getBasePriority(currentTile, unit) >= 5
-            && (tileHasWorkToDo(currentTile, unit) || currentTile.isPillaged() || currentTile.terrainFeatures.contains("Fallout"))) {
+            && (tileHasWorkToDo(currentTile, unit) || currentTile.isPillaged() || currentTile.hasFalloutEquivalent())) {
             return currentTile
         }
         val workableTilesCenterFirst = currentTile.getTilesInDistance(4)
@@ -524,8 +523,7 @@ class WorkerAutomation(
             priority += Automation.rankStatsValue(tile.stats.getTerrainStatsBreakdown().toStats(), civInfo)
             if (tile.providesYield()) priority += 2
             if (tile.isPillaged()) priority += 1
-            // TODO: Removing fallout is hardcoded for now, but what if we want to have other bad features on tiles?
-            if (tile.terrainFeatures.contains("Fallout")) priority += 1
+            if (tile.hasFalloutEquivalent()) priority += 1
         }
         // give a minor priority to tiles that we could expand onto
         else if (tile.getOwner() == null && tile.neighbors.any { it.getOwner() == civInfo })

--- a/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
@@ -621,10 +621,16 @@ class WorkerAutomation(
 
         val localUniqueCache = LocalUniqueCache()
 
-        val bestBuildableImprovement = potentialTileImprovements.values.asSequence()
+        var bestBuildableImprovement = potentialTileImprovements.values.asSequence()
             .map { Pair(it, getImprovementRanking(tile, unit,it.name, localUniqueCache)) }
             .filter { it.second > 0f }
             .maxByOrNull { it.second }?.first
+
+        if (tile.improvement != null && civInfo.isHuman() && (!UncivGame.Current.settings.automatedWorkersReplaceImprovements
+                || UncivGame.Current.settings.autoPlay.isAutoPlayingAndFullAI())) {
+            // Note that we might still want to build roads or remove fallout, so we can't exit the function immedietly
+            bestBuildableImprovement = null
+        }
 
         val lastTerrain = tile.lastTerrain
 

--- a/core/src/com/unciv/logic/map/tile/Tile.kt
+++ b/core/src/com/unciv/logic/map/tile/Tile.kt
@@ -343,6 +343,9 @@ open class Tile : IsPartOfGameInfoSerialization {
             viewingCiv.lastSeenImprovement[position]
     }
 
+    /** Returns true if this tile has fallout or an equivalent terrain feature */
+    fun hasFalloutEquivalent(): Boolean = terrainFeatures.any { ruleset.terrains[it]!!.hasUnique(UniqueType.NullifyYields)}
+
 
     // This is for performance - since we access the neighbors of a tile ALL THE TIME,
     // and the neighbors of a tile never change, it's much more efficient to save the list once and for all!


### PR DESCRIPTION
Fixes #10776 resolves #11022 
The new worker AI did not account for the automated workers don't replace improvements option. This PR fixes that. It also adds a new Tile.hasFalloutEquivalent() method.