### PR TITLE
ThreatManager improvement

### DIFF
--- a/core/src/com/unciv/logic/civilization/managers/ThreatManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/ThreatManager.kt
@@ -89,18 +89,14 @@ class ThreatManager(val civInfo: Civilization) {
 
         if (tileData != null && tileData.distanceSearched >= maxDist) {
             // Add all tiles that we have previously found
-            var index = 0
-            while (tileDataTilesWithEnemies.size > index) {
-                val tileWithDistance = tileDataTilesWithEnemies[index]
-                if (tileWithDistance.second > maxDist)
-                    return tilesWithEnemies
-                if (doesTileHaveMilitaryEnemy(tileWithDistance.first)) {
+            val tilesWithEnemiesIterator = tileDataTilesWithEnemies.listIterator()
+            for (tileWithDistance in tilesWithEnemiesIterator) {
+                // Check if the next tile is out of our search range, if so lets stop here
+                if (tileWithDistance.second > maxDist) return tilesWithEnemies
+                // Check if the threat on the tile is still present
+                if (doesTileHaveMilitaryEnemy(tileWithDistance.first))
                     tilesWithEnemies.add(tileWithDistance.first)
-                } else {
-                    tileDataTilesWithEnemies.removeAt(index)
-                    continue
-                }
-                index++
+                else tilesWithEnemiesIterator.remove()
             }
         }
 

--- a/core/src/com/unciv/logic/civilization/managers/ThreatManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/ThreatManager.kt
@@ -83,10 +83,7 @@ class ThreatManager(val civInfo: Civilization) {
     fun getTilesWithEnemyUnitsInDistance(tile: Tile, maxDist: Int): MutableList<Tile> {
         val tileData = distanceToClosestEnemyTiles[tile]
 
-        // Shortcut, we don't need to search for anything
-        if (tileData != null && maxDist <= tileData.distanceSearched)
-            return mutableListOf()
-        val tilesWithEnemies = if (tileData?.tilesWithEnemies != null) tileData.tilesWithEnemies.map { it.first }.toMutableList() else mutableListOf()
+        val tilesWithEnemies: MutableList<Tile> = mutableListOf()
         val tileDataTilesWithEnemies: MutableList<Pair<Tile,Int>> = if (tileData?.tilesWithEnemies != null) tileData.tilesWithEnemies else mutableListOf()
 
 
@@ -106,6 +103,10 @@ class ThreatManager(val civInfo: Civilization) {
                 index++
             }
         }
+
+        // Shortcut, we don't need to search for anything more
+        if (tileData != null && maxDist <= tileData.distanceSearched)
+            return tilesWithEnemies
 
         val minDistanceToSearch = (tileData?.distanceSearched?.coerceAtLeast(0) ?: 0) + 1
 
@@ -162,9 +163,9 @@ class ThreatManager(val civInfo: Civilization) {
         if (!tile.isExplored(civInfo)) return false
         if (tile.isCityCenter() && tile.getCity()!!.civ.isAtWarWith(civInfo)) return true
         if (!tile.isVisible(civInfo)) return false
-        if (tile.getUnits().any {it.isMilitary()
+        if (tile.getUnits().any { it.isMilitary()
             && it.civ.isAtWarWith(civInfo)
-            && it.isInvisible(civInfo) })
+            && !it.isInvisible(civInfo) })
             return true
         return false
     }

--- a/core/src/com/unciv/logic/civilization/managers/ThreatManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/ThreatManager.kt
@@ -162,9 +162,9 @@ class ThreatManager(val civInfo: Civilization) {
         if (!tile.isExplored(civInfo)) return false
         if (tile.isCityCenter() && tile.getCity()!!.civ.isAtWarWith(civInfo)) return true
         if (!tile.isVisible(civInfo)) return false
-        if (tile.militaryUnit != null
-            && tile.militaryUnit!!.civ.isAtWarWith(civInfo)
-            && !tile.militaryUnit!!.isInvisible(civInfo))
+        if (tile.getUnits().any {it.isMilitary()
+            && it.civ.isAtWarWith(civInfo)
+            && it.isInvisible(civInfo) })
             return true
         return false
     }

--- a/core/src/com/unciv/logic/civilization/managers/ThreatManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/ThreatManager.kt
@@ -34,16 +34,16 @@ class ThreatManager(val civInfo: Civilization) {
         var minDistanceToSearch = 1
         // Look if we can return the cache or if we can reduce our search
         if (tileData != null) {
-            val tilesWithEnemy = tileData.tilesWithEnemies
+            val tilesWithEnemies = tileData.tilesWithEnemies
             // Check the tiles where we have previously found an enemy, if so it must be the closest
-            while (tilesWithEnemy.isNotEmpty()) {
-                val enemyTile = tilesWithEnemy.first()
+            while (tilesWithEnemies.isNotEmpty()) {
+                val enemyTile = tilesWithEnemies.first()
                 if (doesTileHaveMilitaryEnemy(enemyTile.first)) {
                     return if (takeLargerValues) enemyTile.second
                     else enemyTile.second.coerceAtMost(maxDist)
                 } else {
                     // This tile is no longer valid
-                    tilesWithEnemy.removeFirst()
+                    tilesWithEnemies.removeFirst()
                 }
             }
 
@@ -51,10 +51,12 @@ class ThreatManager(val civInfo: Civilization) {
                 // We have already searched past the range we want to search and haven't found any enemies
                 return if (takeLargerValues) notFoundDistance else maxDist
             }
+
             // Only search the tiles that we haven't searched yet
             minDistanceToSearch = (tileData.distanceSearched + 1).coerceAtLeast(1)
         }
 
+        if (tileData != null && tileData.tilesWithEnemies.isNotEmpty()) throw IllegalStateException("There must be no elements in tile.data.tilesWithEnemies at this point")
         val tilesWithEnemyAtDistance: MutableList<Pair<Tile,Int>> = mutableListOf()
         // Search for nearby enemies and store the results
         for (i in minDistanceToSearch..maxDist) {

--- a/core/src/com/unciv/logic/civilization/managers/ThreatManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/ThreatManager.kt
@@ -56,6 +56,7 @@ class ThreatManager(val civInfo: Civilization) {
             minDistanceToSearch = (tileData.distanceSearched + 1).coerceAtLeast(1)
         }
 
+
         if (tileData != null && tileData.tilesWithEnemies.isNotEmpty()) throw IllegalStateException("There must be no elements in tile.data.tilesWithEnemies at this point")
         val tilesWithEnemyAtDistance: MutableList<Pair<Tile,Int>> = mutableListOf()
         // Search for nearby enemies and store the results
@@ -83,9 +84,10 @@ class ThreatManager(val civInfo: Civilization) {
     fun getTilesWithEnemyUnitsInDistance(tile: Tile, maxDist: Int): MutableList<Tile> {
         val tileData = distanceToClosestEnemyTiles[tile]
 
+        // The list of tiles that we will return
         val tilesWithEnemies: MutableList<Tile> = mutableListOf()
+        // The list of tiles with distance that will be stored in distanceToClosestEnemyTiles
         val tileDataTilesWithEnemies: MutableList<Pair<Tile,Int>> = if (tileData?.tilesWithEnemies != null) tileData.tilesWithEnemies else mutableListOf()
-
 
         if (tileData != null && tileData.distanceSearched >= maxDist) {
             // Add all tiles that we have previously found
@@ -100,10 +102,12 @@ class ThreatManager(val civInfo: Civilization) {
             }
         }
 
-        // Shortcut, we don't need to search for anything more
+        // We don't need to search for anything more if we have previously searched past maxDist
         if (tileData != null && maxDist <= tileData.distanceSearched)
             return tilesWithEnemies
 
+
+        // Search all tiles that haven't been searched yet up until madDist
         val minDistanceToSearch = (tileData?.distanceSearched?.coerceAtLeast(0) ?: 0) + 1
 
         for (i in minDistanceToSearch..maxDist) {
@@ -118,7 +122,6 @@ class ThreatManager(val civInfo: Civilization) {
             tileData.distanceSearched = maxOf(tileData.distanceSearched, maxDist)
         } else {
             // Cache our results for later
-            // tilesWithEnemies must return the enemy at a distance of closestEnemyDistance
             distanceToClosestEnemyTiles[tile] = ClosestEnemyTileData(maxDist, tileDataTilesWithEnemies)
         }
         return tilesWithEnemies


### PR DESCRIPTION
This PR is a rework of `ThreatManager` that improves upon #10481.
There are two functions that `ThreatManager` currently offers, `getDistanceToClosestEnemy()` and `getEnemyTilesInDistance()`. Previously it was optimized mostly to `getDistanceToClosestEnem()`, this PR, however, reduces the optimization to `ClosestEnemy` in favor of caching more information that is used to optimize `EnemyTiles`.

This PR is more of a checkpoint for future plans to expand the ThreatManager system. 

My AutoPlay Testing has not found any bugs yet (surprising! Oh wait, I forgot to run the unit tests... thank you, unit testing, I have to mess up at least one thing).