### PR TITLE
Fixed spies errors

### DIFF
--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -526,18 +526,7 @@ object Battle {
             if (civilianUnit != null) BattleUnitCapture.captureCivilianUnit(attacker, MapUnitCombatant(civilianUnit!!), checkDefeat = false)
             for (airUnit in airUnits.toList()) airUnit.destroy()
         }
-
-        // Move all spies in the city
-        if (attackerCiv.gameInfo.isEspionageEnabled()) {
-            for (civ in attackerCiv.gameInfo.civilizations.filter { it.isMajorCiv() }) {
-                for (spy in civ.espionageManager.spyList) {
-                    if (spy.getLocation() == city) {
-                        spy.moveTo(null)
-                    }
-                }
-            }
-        }
-
+        
         val stateForConditionals = StateForConditionals(civInfo = attackerCiv, city=city, unit = attacker.unit, ourCombatant = attacker, attackedTile = city.getCenterTile())
         for (unique in attacker.getMatchingUniques(UniqueType.CaptureCityPlunder, stateForConditionals, true)) {
             attackerCiv.addStat(

--- a/core/src/com/unciv/logic/city/managers/CityConquestFunctions.kt
+++ b/core/src/com/unciv/logic/city/managers/CityConquestFunctions.kt
@@ -79,6 +79,8 @@ class CityConquestFunctions(val city: City) {
      * should go in `this.moveToCiv()`, which is called by `this.conquerCity()`.
      */
     private fun conquerCity(conqueringCiv: Civilization, conqueredCiv: Civilization, receivingCiv: Civilization) {
+        city.espionage.removeAllPresentSpies(SpyFleeReason.CityCaptured)
+        
         val goldPlundered = getGoldForCapturingCity(conqueringCiv)
         conqueringCiv.addGold(goldPlundered)
         conqueringCiv.addNotification("Received [$goldPlundered] Gold for capturing [${city.name}]",
@@ -105,8 +107,6 @@ class CityConquestFunctions(val city: City) {
             // reconquering or liberating city in resistance so eliminate it
             city.removeFlag(CityFlags.Resistance)
         }
-
-        city.espionage.removeAllPresentSpies(SpyFleeReason.CityCaptured)
     }
 
 

--- a/core/src/com/unciv/logic/city/managers/CityTurnManager.kt
+++ b/core/src/com/unciv/logic/city/managers/CityTurnManager.kt
@@ -125,6 +125,7 @@ class CityTurnManager(val city: City) {
             city.population.addPopulation(-1 * removedPopulation)
 
             if (city.population.population <= 0) {
+                city.espionage.removeAllPresentSpies(SpyFleeReason.CityCaptured)
                 city.civ.addNotification(
                     "[${city.name}] has been razed to the ground!",
                     city.location, NotificationCategory.General,

--- a/core/src/com/unciv/logic/civilization/managers/EspionageManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/EspionageManager.kt
@@ -29,7 +29,7 @@ class EspionageManager : IsPartOfGameInfoSerialization {
     }
 
     fun endTurn() {
-        for (spy in spyList)
+        for (spy in spyList.toList())
             spy.endTurn()
     }
 


### PR DESCRIPTION
This PR fixes a few errors related to spies.

- Fixed cities that are razed did not remove spies, causing an error.
- Removed my fix for spies running away from conquered cities and fixed the previous attempt, which occurred after the city changed sides causing an error.
- Fixed the case where a spy steals a technology, getting the civ to the next era and gaining a spy. Which causes a concurrency modification exception in the for loop.