### PR TITLE
Fix: Damage average is raw before clamping to health range

### DIFF
--- a/core/src/com/unciv/ui/screens/worldscreen/bottombar/BattleTable.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/bottombar/BattleTable.kt
@@ -200,14 +200,6 @@ class BattleTable(val worldScreen: WorldScreen) : Table() {
             row()
         }
 
-        val maxDamageToDefender = BattleDamage.calculateDamageToDefender(attacker, defender, tileToAttackFrom, 1f)
-        val minDamageToDefender = BattleDamage.calculateDamageToDefender(attacker, defender, tileToAttackFrom, 0f)
-        val avgDamageToDefender = arrayOf(maxDamageToDefender, minDamageToDefender).average().roundToInt()
-
-        val maxDamageToAttacker = BattleDamage.calculateDamageToAttacker(attacker, defender, tileToAttackFrom, 1f)
-        val minDamageToAttacker = BattleDamage.calculateDamageToAttacker(attacker, defender, tileToAttackFrom, 0f)
-        val avgDamageToAttacker = arrayOf(maxDamageToAttacker, minDamageToAttacker).average().roundToInt()
-
         if (attacker.isMelee() &&
                 (defender.isCivilian() || defender is CityCombatant && defender.isDefeated())) {
             add()
@@ -218,6 +210,12 @@ class BattleTable(val worldScreen: WorldScreen) : Table() {
             }
             add(defeatedText.toLabel())
         } else {
+            val maxDamageToDefender = BattleDamage.calculateDamageToDefender(attacker, defender, tileToAttackFrom, 1f)
+            val minDamageToDefender = BattleDamage.calculateDamageToDefender(attacker, defender, tileToAttackFrom, 0f)
+
+            val maxDamageToAttacker = BattleDamage.calculateDamageToAttacker(attacker, defender, tileToAttackFrom, 1f)
+            val minDamageToAttacker = BattleDamage.calculateDamageToAttacker(attacker, defender, tileToAttackFrom, 0f)
+
             val attackerHealth = attacker.getHealth()
             val minRemainingLifeAttacker = max(attackerHealth-maxDamageToAttacker, 0)
             val maxRemainingLifeAttacker = max(attackerHealth-minDamageToAttacker, 0)
@@ -228,6 +226,11 @@ class BattleTable(val worldScreen: WorldScreen) : Table() {
 
             add(getHealthBar(attacker.getMaxHealth(), attacker.getHealth(), maxRemainingLifeAttacker, minRemainingLifeAttacker))
             add(getHealthBar(defender.getMaxHealth(), defender.getHealth(), maxRemainingLifeDefender, minRemainingLifeDefender)).row()
+
+            fun avg(vararg values: Int) = values.average().roundToInt()
+            // Don't use original damage estimates - they're raw, before clamping to 0..max
+            val avgDamageToDefender = avg(defenderHealth - minRemainingLifeDefender, defenderHealth - maxRemainingLifeDefender)
+            val avgDamageToAttacker = avg(attackerHealth - minRemainingLifeAttacker, attackerHealth - maxRemainingLifeAttacker)
 
             if (minRemainingLifeAttacker == attackerHealth) add(attackerHealth.toLabel())
             else if (maxRemainingLifeAttacker == minRemainingLifeAttacker) add("$attackerHealth → $maxRemainingLifeAttacker ($avgDamageToAttacker)".toLabel())


### PR DESCRIPTION
Fixes #11039

New:
![image](https://github.com/yairm210/Unciv/assets/63000004/4cf6381c-25ab-4b6b-9c25-38805318092f)

Old:
![image](https://github.com/yairm210/Unciv/assets/63000004/a3b25806-5ded-446f-83ce-76133e2a107b)
(compiled with toolchain +target 17, wouldn't run with target 11, while that screenie above was made with toolchain 17, target 11 - gradle is a four-letter word after all)

Another edit: Debatable whether for cities that shouldn't rather display 1->1(0), but that would have been more code...