### PR TITLE
RulesetValidator: Raise severity for untyped uniques with parameters

### DIFF
--- a/core/src/com/unciv/models/ruleset/validation/UniqueValidator.kt
+++ b/core/src/com/unciv/models/ruleset/validation/UniqueValidator.kt
@@ -217,7 +217,8 @@ class UniqueValidator(val ruleset: Ruleset) {
 
         return listOf(RulesetError(
             "$prefix unique \"${unique.text}\" not found in Unciv's unique types, and is not used as a filtering unique.",
-            RulesetErrorSeverity.OK))
+            if (unique.params.isEmpty()) RulesetErrorSeverity.OK else RulesetErrorSeverity.Warning
+        ))
     }
 
     private fun isFilteringUniqueAllowed(unique: Unique): Boolean {


### PR DESCRIPTION
Tiny thing I noticed because some issue authors insert mods in my unciv I didn't really want...

![image](https://github.com/yairm210/Unciv/assets/63000004/3298ed0a-8216-43b7-a075-b6cc380d7d9a)

... or raise unconditionally to warning since the other kind should now use the Comment Unique?