### PR TITLE
Avoid crash from city combantants

### DIFF
--- a/core/src/com/unciv/models/ruleset/unique/StateForConditionals.kt
+++ b/core/src/com/unciv/models/ruleset/unique/StateForConditionals.kt
@@ -29,12 +29,13 @@ data class StateForConditionals(
     constructor(ourCombatant: ICombatant, theirCombatant: ICombatant? = null,
                 attackedTile: Tile? = null, combatAction: CombatAction? = null) : this(
         ourCombatant.getCivInfo(),
-        unit = (ourCombatant as? MapUnitCombatant)?.unit,
-        tile = ourCombatant.getTile(),
-        ourCombatant = ourCombatant,
-        theirCombatant = theirCombatant,
-        attackedTile = attackedTile,
-        combatAction = combatAction
+        (ourCombatant as? CityCombatant)?.city,
+        (ourCombatant as? MapUnitCombatant)?.unit,
+        ourCombatant.getTile(),
+        ourCombatant,
+        theirCombatant,
+        attackedTile,
+        combatAction
     )
 
     companion object {

--- a/core/src/com/unciv/models/ruleset/unique/StateForConditionals.kt
+++ b/core/src/com/unciv/models/ruleset/unique/StateForConditionals.kt
@@ -26,18 +26,15 @@ data class StateForConditionals(
 ) {
     constructor(city: City) : this(city.civ, city, tile = city.getCenterTile())
     constructor(unit: MapUnit) : this(unit.civ, unit = unit, tile = unit.currentTile)
-    constructor(ourCombatant: ICombatant) : this(
+    constructor(ourCombatant: ICombatant, theirCombatant: ICombatant = null,
+                attackedTile: Tile? = null, combatAction: CombatAction? = null) : this(
         ourCombatant.getCivInfo(),
-        unit = (ourCombatant as MapUnitCombatant).unit,
-        tile = ourCombatant.getTile(),
-        ourCombatant = ourCombatant,
-    )
-    constructor(ourCombatant: ICombatant, theirCombatant: ICombatant) : this(
-        ourCombatant.getCivInfo(),
-        unit = (ourCombatant as MapUnitCombatant).unit,
+        unit = (ourCombatant as? MapUnitCombatant)?.unit,
         tile = ourCombatant.getTile(),
         ourCombatant = ourCombatant,
         theirCombatant = theirCombatant,
+        attackedTile = attackedTile,
+        combatAction = combatAction
     )
 
     companion object {

--- a/core/src/com/unciv/models/ruleset/unique/StateForConditionals.kt
+++ b/core/src/com/unciv/models/ruleset/unique/StateForConditionals.kt
@@ -26,7 +26,7 @@ data class StateForConditionals(
 ) {
     constructor(city: City) : this(city.civ, city, tile = city.getCenterTile())
     constructor(unit: MapUnit) : this(unit.civ, unit = unit, tile = unit.currentTile)
-    constructor(ourCombatant: ICombatant, theirCombatant: ICombatant = null,
+    constructor(ourCombatant: ICombatant, theirCombatant: ICombatant? = null,
                 attackedTile: Tile? = null, combatAction: CombatAction? = null) : this(
         ourCombatant.getCivInfo(),
         unit = (ourCombatant as? MapUnitCombatant)?.unit,

--- a/core/src/com/unciv/models/ruleset/unique/StateForConditionals.kt
+++ b/core/src/com/unciv/models/ruleset/unique/StateForConditionals.kt
@@ -1,5 +1,6 @@
 package com.unciv.models.ruleset.unique
 
+import com.unciv.logic.battle.CityCombatant
 import com.unciv.logic.battle.CombatAction
 import com.unciv.logic.battle.ICombatant
 import com.unciv.logic.battle.MapUnitCombatant


### PR DESCRIPTION
Genuinely doubt anyone will see the relevant crash given I only started editing the StatForConditionals on my personal build

~~Also, kinda annoying I can't do `city = ourCombatant as? CityCombatant?.city` simply because `city` is not actually an accessible value~~ edit: ignore this, i'm silly