### PR TITLE
Further Espionage Implementation

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -1731,18 +1731,22 @@ After an unknown civilization entered the [eraName], we have recruited [spyName]
 We have recruited [spyName] as a spy! = 
 Your spy [spyName] has leveled up! = 
 Your spy [spyName] cannot steal any more techs from [civName] as we've already researched all the technology they know! = 
+
 # Stealing Technology defending civ
 An unidentified spy stole the Technology [techName] from [cityName]! = 
 A spy from [civName] stole the Technology [techName] from [cityName]! = 
 A spy from [civName] tried to steal our Technology was found and killed in [cityName]! = 
 A spy from [civName] tried to steal our Technology was found and killed in [cityName] by [spyName]! = 
+
 # Stealing Technology offending civ
 Your spy [spyName] stole the Technology [techName] from [cityName]! = 
 Your spy [spyName] was killed trying to steal Technology in [cityName]! = 
+
 # Rigging elections
 A spy from [civName] tried to rig elections and was found and killed in [cityName] by [spyName]! = 
 Your spy [spyName] was killed trying to rig the election in [cityName]! = 
 Your spy successfully rigged the election in [cityName]! = 
+
 # Spy fleeing city
 After the city of [cityName] was destroyed, your spy [spyName] has fled back to our hideout. = 
 After the city of [cityName] was conquered, your spy [spyName] has fled back to our hideout. = 

--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -1729,14 +1729,24 @@ Move =
 
 After an unknown civilization entered the [eraName], we have recruited [spyName] as a spy! = 
 We have recruited [spyName] as a spy! = 
-A spy from [civilization] stole the Technology [techName] from [cityName]! = 
+Your spy [spyName] has leveled up! = 
+Your spy [spyName] cannot steal any more techs from [civName] as we've already researched all the technology they know! = 
+# Stealing Technology defending civ
 An unidentified spy stole the Technology [techName] from [cityName]! = 
-Your spy [name] stole the Technology [techName] from [cityName]! = 
-Your spy [name] cannot steal any more techs from [civilization] as we've already researched all the technology they know! = 
-
+A spy from [civName] stole the Technology [techName] from [cityName]! = 
+A spy from [civName] tried to steal our Technology was found and killed in [cityName]! = 
+A spy from [civName] tried to steal our Technology was found and killed in [cityName] by [spyName]! = 
+# Stealing Technology offending civ
+Your spy [spyName] stole the Technology [techName] from [cityName]! = 
+Your spy [spyName] was killed trying to steal Technology in [cityName]! = 
+# Rigging elections
+A spy from [civName] tried to rig elections and was found and killed in [cityName] by [spyName]! = 
+Your spy [spyName] was killed trying to rig the election in [cityName]! = 
+Your spy successfully rigged the election in [cityName]! = 
+# Spy fleeing city
 After the city of [cityName] was destroyed, your spy [spyName] has fled back to our hideout. = 
 After the city of [cityName] was conquered, your spy [spyName] has fled back to our hideout. = 
-Due to the chaos ensuing in [cityName], your spy [spyname] has fled back to our hideout. = 
+Due to the chaos ensuing in [cityName], your spy [spyName] has fled back to our hideout. = 
 
 # Promotions
 

--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -1735,8 +1735,8 @@ Your spy [spyName] cannot steal any more techs from [civName] as we've already r
 # Stealing Technology defending civ
 An unidentified spy stole the Technology [techName] from [cityName]! = 
 A spy from [civName] stole the Technology [techName] from [cityName]! = 
-A spy from [civName] tried to steal our Technology was found and killed in [cityName]! = 
-A spy from [civName] tried to steal our Technology was found and killed in [cityName] by [spyName]! = 
+A spy from [civName] was found and killed trying to steal Technology in [cityName]! = 
+A spy from [civName] was found and killed by [spyName] trying to steal Technology in [cityName]! = 
 
 # Stealing Technology offending civ
 Your spy [spyName] stole the Technology [techName] from [cityName]! = 

--- a/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
@@ -76,7 +76,7 @@ object NextTurnAutomation {
             }
             if (civInfo.gameInfo.isEspionageEnabled()) {
                 // Do after cities are conquered
-                EspionageAutomation.automateSpies(civInfo)
+                EspionageAutomation(civInfo).automateSpies()
             }
         }
 

--- a/core/src/com/unciv/logic/automation/unit/EspionageAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/EspionageAutomation.kt
@@ -24,16 +24,17 @@ class EspionageAutomation(val civInfo: Civilization) {
     fun automateSpies() {
         val spies = civInfo.espionageManager.spyList
         val spiesDoingCounterIntelligence = spies.count { it.action == SpyAction.CounterIntelligence }
-        val spiesToMove = spies.filter { !it.isDoingWork() || (it.action == SpyAction.CounterIntelligence && spiesDoingCounterIntelligence > 2)}
+        val spiesToMove = spies.filter { it.isAlive() && 
+            (!it.isDoingWork() || (it.action == SpyAction.CounterIntelligence && spiesDoingCounterIntelligence > 2))}
         for (spy in spiesToMove) {
             val randomSeed = spies.size + spies.indexOf(spy) + civInfo.gameInfo.turns
-            val randomAction = Random(randomSeed).nextInt()
+            val randomAction = Random(randomSeed).nextInt(10)
 
             // Try each operation based on the random value and the success rate
             // If an operation was not successfull try the next one
             if (randomAction <= 6 && automateSpyStealTech(spy)) {
                 continue
-            } else if (randomAction <= 8 && automateSpyRigElection(spy)) {
+            } else if (randomAction <= 9 && automateSpyRigElection(spy)) {
                 continue
             } else if (automateSpyCounterInteligence(spy)) {
                 continue

--- a/core/src/com/unciv/logic/automation/unit/EspionageAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/EspionageAutomation.kt
@@ -32,7 +32,7 @@ class EspionageAutomation(val civInfo: Civilization) {
 
             // Try each operation based on the random value and the success rate
             // If an operation was not successfull try the next one
-            if (randomAction <= 6 && automateSpyStealTech(spy)) {
+            if (randomAction <= 7 && automateSpyStealTech(spy)) {
                 continue
             } else if (randomAction <= 9 && automateSpyRigElection(spy)) {
                 continue
@@ -58,12 +58,10 @@ class EspionageAutomation(val civInfo: Civilization) {
         if (civsToStealFrom.isNotEmpty()) {
             // We want to move the spy to the city with the highest science generation
             // Players can't usually figure this out so lets do highest population instead
-            spy.moveTo(getCivsToStealFromSorted.first().cities.filter { it.getCenterTile().isVisible(civInfo) }.maxByOrNull { it.population.population })
-            return false
+            spy.moveTo(getCivsToStealFromSorted.first().cities.filter { it.getCenterTile().isVisible(civInfo) && spy.canMoveTo(it) }.maxByOrNull { it.population.population })
+            return true
         }
-        spy.moveTo(civInfo.getKnownCivs().filter { otherCiv -> otherCiv.isMajorCiv() && otherCiv.cities.any { it.getCenterTile().isVisible(civInfo) }}
-            .toList().randomOrNull()?.cities?.filter { it.getCenterTile().isVisible(civInfo) }?.randomOrNull())
-        return true
+        return false
     }
 
     /**

--- a/core/src/com/unciv/logic/automation/unit/EspionageAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/EspionageAutomation.kt
@@ -47,7 +47,7 @@ class EspionageAutomation(val civInfo: Civilization) {
                 if(automateSpyCounterInteligence(spy)) continue
             }
             // There is nothing for our spy to do, put it in a random city
-            spy.moveTo(civInfo.gameInfo.getCities().filter { it.getCenterTile().isVisible(civInfo) && spy.canMoveTo(it) }.toList().random())
+            spy.moveTo(civInfo.gameInfo.getCities().filter { it.getCenterTile().isVisible(civInfo) && spy.canMoveTo(it) }.toList().randomOrNull())
         }
     }
 

--- a/core/src/com/unciv/logic/automation/unit/EspionageAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/EspionageAutomation.kt
@@ -18,7 +18,7 @@ class EspionageAutomation(val civInfo: Civilization) {
         }.toList()
 
     private val cityStatesToRig: List<Civilization> by lazy {
-        civInfo.getKnownCivs().filter {otherCiv -> otherCiv.isMinorCiv() && otherCiv.knows(civInfo) }.toList()
+        civInfo.getKnownCivs().filter { otherCiv -> otherCiv.isMinorCiv() && otherCiv.knows(civInfo) && !civInfo.isAtWarWith(otherCiv) }.toList()
     }
 
     fun automateSpies() {

--- a/core/src/com/unciv/logic/automation/unit/EspionageAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/EspionageAutomation.kt
@@ -58,7 +58,7 @@ class EspionageAutomation(val civInfo: Civilization) {
         if (civsToStealFrom.isNotEmpty()) {
             // We want to move the spy to the city with the highest science generation
             // Players can't usually figure this out so lets do highest population instead
-            spy.moveTo(getCivsToStealFromSorted.first().cities.filter { it.getCenterTile().isVisible(civInfo) && spy.canMoveTo(it) }.maxByOrNull { it.population.population })
+            spy.moveTo(getCivsToStealFromSorted.first().cities.filter { spy.canMoveTo(it) }.maxByOrNull { it.population.population })
             return true
         }
         return false

--- a/core/src/com/unciv/logic/automation/unit/EspionageAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/EspionageAutomation.kt
@@ -23,9 +23,7 @@ class EspionageAutomation(val civInfo: Civilization) {
 
     fun automateSpies() {
         val spies = civInfo.espionageManager.spyList
-        val spiesDoingCounterIntelligence = spies.count { it.action == SpyAction.CounterIntelligence }
-        val spiesToMove = spies.filter { it.isAlive() && 
-            (!it.isDoingWork() || (it.action == SpyAction.CounterIntelligence && spiesDoingCounterIntelligence > 2))}
+        val spiesToMove = spies.filter { it.isAlive() && !it.isDoingWork() }
         for (spy in spiesToMove) {
             val randomSeed = spies.size + spies.indexOf(spy) + civInfo.gameInfo.turns
             val randomAction = Random(randomSeed).nextInt(10)
@@ -47,7 +45,8 @@ class EspionageAutomation(val civInfo: Civilization) {
                 if(automateSpyCounterInteligence(spy)) continue
             }
             // There is nothing for our spy to do, put it in a random city
-            spy.moveTo(civInfo.gameInfo.getCities().filter { it.getCenterTile().isVisible(civInfo) && spy.canMoveTo(it) }.toList().randomOrNull())
+            val randomCity = civInfo.gameInfo.getCities().filter { spy.canMoveTo(it) }.toList().randomOrNull()
+            spy.moveTo(randomCity)
         }
     }
 

--- a/core/src/com/unciv/logic/automation/unit/EspionageAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/EspionageAutomation.kt
@@ -55,13 +55,11 @@ class EspionageAutomation(val civInfo: Civilization) {
      * Moves the spy to a city that we can steal a tech from
      */
     fun automateSpyStealTech(spy: Spy): Boolean {
-        if (civsToStealFrom.isNotEmpty()) {
-            // We want to move the spy to the city with the highest science generation
-            // Players can't usually figure this out so lets do highest population instead
-            spy.moveTo(getCivsToStealFromSorted.first().cities.filter { spy.canMoveTo(it) }.maxByOrNull { it.population.population })
-            return true
-        }
-        return false
+        if (civsToStealFrom.isEmpty()) return false
+        // We want to move the spy to the city with the highest science generation
+        // Players can't usually figure this out so lets do highest population instead
+        spy.moveTo(getCivsToStealFromSorted.first().cities.filter { spy.canMoveTo(it) }.maxByOrNull { it.population.population })
+        return spy.action == SpyAction.StealingTech
     }
 
     /**
@@ -70,7 +68,7 @@ class EspionageAutomation(val civInfo: Civilization) {
     private fun automateSpyRigElection(spy: Spy): Boolean {
         val potentialCities = cityStatesToRig.flatMap { it.cities }.filter { !it.isBeingRazed && spy.canMoveTo(it) }
         spy.moveTo(potentialCities.randomOrNull())
-        return spy.getLocation() != null
+        return spy.action == SpyAction.RiggingElections
     }
 
     /**
@@ -78,6 +76,6 @@ class EspionageAutomation(val civInfo: Civilization) {
      */
     private fun automateSpyCounterInteligence(spy: Spy): Boolean {
         spy.moveTo(civInfo.cities.filter { spy.canMoveTo(it) }.randomOrNull())
-        return spy.getLocation() != null
+        return spy.action == SpyAction.CounterIntelligence
     }
 }

--- a/core/src/com/unciv/logic/automation/unit/EspionageAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/EspionageAutomation.kt
@@ -1,33 +1,84 @@
 package com.unciv.logic.automation.unit
 
+import com.unciv.logic.city.City
 import com.unciv.logic.civilization.Civilization
+import com.unciv.models.Spy
 import com.unciv.models.SpyAction
+import kotlin.random.Random
 
-object EspionageAutomation {
+class EspionageAutomation(val civInfo: Civilization) {
+    private val civsToStealFrom: List<Civilization> by lazy {
+        civInfo.getKnownCivs().filter {otherCiv -> otherCiv.isMajorCiv() && otherCiv.cities.any { it.getCenterTile().isVisible(civInfo) }
+            && civInfo.espionageManager.getTechsToSteal(otherCiv).isNotEmpty() }.toList()
+    }
 
-    fun automateSpies(civInfo: Civilization) {
-        val civsToStealFrom: List<Civilization> by lazy { 
-            civInfo.getKnownCivs().filter {otherCiv -> otherCiv.isMajorCiv() && otherCiv.cities.any { it.getCenterTile().isVisible(civInfo) } 
-                && civInfo.espionageManager.getTechsToSteal(otherCiv).isNotEmpty() }.toList()
-        }
+    private val getCivsToStealFromSorted: List<Civilization> =
+        civsToStealFrom.sortedBy { otherCiv -> civInfo.espionageManager.spyList
+            .count { it.isDoingWork() && it.getLocation()?.civ == otherCiv }
+        }.toList()
 
-        val getCivsToStealFromSorted: List<Civilization> =
-            civsToStealFrom.sortedBy { otherCiv -> civInfo.espionageManager.spyList
-                .count { it.isDoingWork() && it.getLocation()?.civ == otherCiv } 
-            }.toList()
+    private val cityStatesToRig: List<Civilization> by lazy {
+        civInfo.getKnownCivs().filter {otherCiv -> otherCiv.isMinorCiv() && otherCiv.knows(civInfo) }.toList()
+    }
 
-        for (spy in civInfo.espionageManager.spyList) {
-            if (spy.isDoingWork()) continue
-            if (civsToStealFrom.isNotEmpty()) {
-                // We want to move the spy to the city with the highest science generation
-                // Players can't usually figure this out so lets do highest population instead
-                spy.moveTo(getCivsToStealFromSorted.first().cities.filter { it.getCenterTile().isVisible(civInfo) }.maxByOrNull { it.population.population })
+    fun automateSpies() {
+        val spies = civInfo.espionageManager.spyList
+        val spiesDoingCounterIntelligence = spies.count { it.action == SpyAction.CounterIntelligence }
+        val spiesToMove = spies.filter { !it.isDoingWork() || (it.action == SpyAction.CounterIntelligence && spiesDoingCounterIntelligence > 2)}
+        for (spy in spiesToMove) {
+            val randomSeed = spies.size + spies.indexOf(spy) + civInfo.gameInfo.turns
+            val randomAction = Random(randomSeed).nextInt()
+
+            // Try each operation based on the random value and the success rate
+            // If an operation was not successfull try the next one
+            if (randomAction <= 6 && automateSpyStealTech(spy)) {
                 continue
+            } else if (randomAction <= 8 && automateSpyRigElection(spy)) {
+                continue
+            } else if (automateSpyCounterInteligence(spy)) {
+                continue
+            } else if (spy.isDoingWork()) {
+                continue // We might have been doing counter intelligence and wanted to look for something better
+            } else {
+                // Retry all of the operations one more time
+                if (automateSpyStealTech(spy)) continue
+                if (automateSpyRigElection(spy)) continue
+                if(automateSpyCounterInteligence(spy)) continue
             }
-            if (spy.action == SpyAction.None) {
-                spy.moveTo(civInfo.getKnownCivs().filter { otherCiv -> otherCiv.isMajorCiv() && otherCiv.cities.any { it.getCenterTile().isVisible(civInfo) }}
-                    .toList().randomOrNull()?.cities?.filter { it.getCenterTile().isVisible(civInfo) }?.randomOrNull())
-            }
+            // There is nothing for our spy to do, put it in a random city
+            spy.moveTo(civInfo.gameInfo.getCities().filter { it.getCenterTile().isVisible(civInfo) && spy.canMoveTo(it) }.toList().random())
         }
+    }
+
+    /**
+     * Moves the spy to a city that we can steal a tech from
+     */
+    fun automateSpyStealTech(spy: Spy): Boolean {
+        if (civsToStealFrom.isNotEmpty()) {
+            // We want to move the spy to the city with the highest science generation
+            // Players can't usually figure this out so lets do highest population instead
+            spy.moveTo(getCivsToStealFromSorted.first().cities.filter { it.getCenterTile().isVisible(civInfo) }.maxByOrNull { it.population.population })
+            return false
+        }
+        spy.moveTo(civInfo.getKnownCivs().filter { otherCiv -> otherCiv.isMajorCiv() && otherCiv.cities.any { it.getCenterTile().isVisible(civInfo) }}
+            .toList().randomOrNull()?.cities?.filter { it.getCenterTile().isVisible(civInfo) }?.randomOrNull())
+        return true
+    }
+
+    /**
+     * Moves the spy to a random city-state
+     */
+    private fun automateSpyRigElection(spy: Spy): Boolean {
+        val potentialCities = cityStatesToRig.flatMap { it.cities }.filter { !it.isBeingRazed && spy.canMoveTo(it) }
+        spy.moveTo(potentialCities.randomOrNull())
+        return spy.getLocation() != null
+    }
+
+    /**
+     * Moves the spy to a random city of ours
+     */
+    private fun automateSpyCounterInteligence(spy: Spy): Boolean {
+        spy.moveTo(civInfo.cities.filter { spy.canMoveTo(it) }.randomOrNull())
+        return spy.getLocation() != null
     }
 }

--- a/core/src/com/unciv/logic/city/managers/CityEspionageManager.kt
+++ b/core/src/com/unciv/logic/city/managers/CityEspionageManager.kt
@@ -26,7 +26,7 @@ class CityEspionageManager : IsPartOfGameInfoSerialization {
     }
 
     fun hasSpyOf(civInfo: Civilization): Boolean {
-        return civInfo.espionageManager.spyList.any { it.location == city.id }
+        return civInfo.espionageManager.spyList.any { it.getLocation() == city }
     }
 
     private fun getAllStationedSpies(): List<Spy> {
@@ -42,7 +42,7 @@ class CityEspionageManager : IsPartOfGameInfoSerialization {
                 else -> "Due to the chaos ensuing in [${city.name}], your spy [${spy.name}] has fled back to our hideout."
             }
             owningCiv.addNotification(notificationString, city.location, NotificationCategory.Espionage, NotificationIcon.Spy)
-            spy.location = null
+            spy.moveTo(null)
         }
     }
 }

--- a/core/src/com/unciv/logic/city/managers/CityEspionageManager.kt
+++ b/core/src/com/unciv/logic/city/managers/CityEspionageManager.kt
@@ -30,9 +30,7 @@ class CityEspionageManager : IsPartOfGameInfoSerialization {
     }
 
     private fun getAllStationedSpies(): List<Spy> {
-        return city.civ.gameInfo.civilizations.flatMap { civ ->
-            civ.espionageManager.spyList.filter { it.location == city.id }
-        }
+        return city.civ.gameInfo.civilizations.flatMap { it.espionageManager.getSpiesInCity(city) }
     }
 
     fun removeAllPresentSpies(reason: SpyFleeReason) {

--- a/core/src/com/unciv/logic/civilization/managers/EspionageManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/EspionageManager.kt
@@ -67,7 +67,7 @@ class EspionageManager : IsPartOfGameInfoSerialization {
     }
 
     fun getSpiesInCity(city: City): MutableList<Spy> {
-        return spyList.filter { it.getLocation() != city }.toMutableList()
+        return spyList.filter { it.getLocation() == city }.toMutableList()
     }
 
     fun getSpyAssignedToCity(city: City): Spy? = spyList.firstOrNull {it.getLocation() == city}

--- a/core/src/com/unciv/logic/civilization/managers/EspionageManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/EspionageManager.kt
@@ -34,7 +34,7 @@ class EspionageManager : IsPartOfGameInfoSerialization {
             spy.endTurn()
     }
 
-    private fun getSpyName(): String {
+    fun getSpyName(): String {
         val usedSpyNames = spyList.map { it.name }.toHashSet()
         val validSpyNames = civInfo.nation.spyNames.filter { it !in usedSpyNames }
         if (validSpyNames.isEmpty()) { return "Spy ${spyList.size+1}" } // +1 as non-programmers count from 1

--- a/core/src/com/unciv/logic/civilization/managers/EspionageManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/EspionageManager.kt
@@ -1,6 +1,7 @@
 package com.unciv.logic.civilization.managers
 
 import com.unciv.logic.IsPartOfGameInfoSerialization
+import com.unciv.logic.city.City
 import com.unciv.logic.civilization.Civilization
 import com.unciv.logic.map.tile.Tile
 import com.unciv.models.Spy
@@ -63,5 +64,9 @@ class EspionageManager : IsPartOfGameInfoSerialization {
             techsToSteal.add(tech)
         }
         return techsToSteal
+    }
+
+    fun getSpiesInCity(city: City): MutableList<Spy> {
+        return spyList.filter { it.getLocation() != city }.toMutableList()
     }
 }

--- a/core/src/com/unciv/logic/civilization/managers/EspionageManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/EspionageManager.kt
@@ -69,4 +69,6 @@ class EspionageManager : IsPartOfGameInfoSerialization {
     fun getSpiesInCity(city: City): MutableList<Spy> {
         return spyList.filter { it.getLocation() != city }.toMutableList()
     }
+
+    fun getSpyAssignedToCity(city: City): Spy? = spyList.firstOrNull {it.getLocation() == city}
 }

--- a/core/src/com/unciv/models/Spy.kt
+++ b/core/src/com/unciv/models/Spy.kt
@@ -73,6 +73,7 @@ class Spy() : IsPartOfGameInfoSerialization {
                 val location = getLocation()!! // This should never throw an exception, as going to the hideout sets your action to None.
                 if (location.civ.isCityState()) {
                     action = SpyAction.RiggingElections
+                    turnsRemainingForAction = 10
                 } else if (location.civ == civInfo) {
                     action = SpyAction.CounterIntelligence
                 } else {
@@ -102,15 +103,23 @@ class Spy() : IsPartOfGameInfoSerialization {
                     stealTech()
                 }
             }
+            SpyAction.RiggingElections -> {
+                --turnsRemainingForAction
+                if (turnsRemainingForAction > 0) return
+
+                // TODO: Simple implementation, please implement this in the future. This is a guess.
+                getLocation()!!.civ.getDiplomacyManager(civInfo).addInfluence(5f + getSpyRank())
+                turnsRemainingForAction = 10
+            }
             SpyAction.Dead -> {
-                turnsRemainingForAction--
-                if (turnsRemainingForAction <= 0) {
-                    val oldSpyName = name
-                    name = espionageManager.getSpyName()
-                    action = SpyAction.None
-                    civInfo.addNotification("We have recruited a new spy name [$name] after [$oldSpyName] was killed.", 
-                        NotificationCategory.Espionage, NotificationIcon.Spy)
-                }
+                --turnsRemainingForAction
+                if (turnsRemainingForAction > 0) return
+
+                val oldSpyName = name
+                name = espionageManager.getSpyName()
+                action = SpyAction.None
+                civInfo.addNotification("We have recruited a new spy name [$name] after [$oldSpyName] was killed.", 
+                    NotificationCategory.Espionage, NotificationIcon.Spy)
             }
             SpyAction.CounterIntelligence -> return // Counter inteligence spies don't do anything here
             else -> return // Not implemented yet, so don't do anything

--- a/core/src/com/unciv/models/Spy.kt
+++ b/core/src/com/unciv/models/Spy.kt
@@ -1,5 +1,6 @@
 package com.unciv.models
 
+import com.badlogic.gdx.math.Vector2
 import com.unciv.Constants
 import com.unciv.logic.IsPartOfGameInfoSerialization
 import com.unciv.logic.city.City
@@ -24,7 +25,7 @@ enum class SpyAction(val displayString: String) {
 
 class Spy() : IsPartOfGameInfoSerialization {
     // `location == null` means that the spy is in its hideout
-    var location: String? = null
+    private var location: Vector2? = null
     lateinit var name: String
     var action = SpyAction.None
         private set
@@ -210,12 +211,13 @@ class Spy() : IsPartOfGameInfoSerialization {
     }
 
     fun moveTo(city: City?) {
-        location = city?.id
         if (city == null) { // Moving to spy hideout
+            location = null
             action = SpyAction.None
             turnsRemainingForAction = 0
             return
         }
+        location = city.location
         action = SpyAction.Moving
         turnsRemainingForAction = 1
     }
@@ -232,7 +234,8 @@ class Spy() : IsPartOfGameInfoSerialization {
         || action == SpyAction.RiggingElections || action == SpyAction.CounterIntelligence || action == SpyAction.Moving
 
     fun getLocation(): City? {
-        return civInfo.gameInfo.getCities().firstOrNull { it.id == location }
+        if (location == null) return null
+        return civInfo.gameInfo.tileMap[location!!].getCity()
     }
 
     fun getLocationName(): String {

--- a/core/src/com/unciv/models/Spy.kt
+++ b/core/src/com/unciv/models/Spy.kt
@@ -78,6 +78,7 @@ class Spy() : IsPartOfGameInfoSerialization {
                     turnsRemainingForAction = 10
                 } else if (location.civ == civInfo) {
                     action = SpyAction.CounterIntelligence
+                    turnsRemainingForAction = 10
                 } else {
                     startStealingTech()
                 }
@@ -122,7 +123,13 @@ class Spy() : IsPartOfGameInfoSerialization {
                 civInfo.addNotification("We have recruited a new spy name [$name] after [$oldSpyName] was killed.", 
                     NotificationCategory.Espionage, NotificationIcon.Spy)
             }
-            SpyAction.CounterIntelligence -> return // Counter inteligence spies don't do anything here
+            SpyAction.CounterIntelligence -> {
+                // Counter inteligence spies don't do anything here
+                // However the AI will want to keep track of how long a spy has been doing counter intelligence for
+                // Once turnRemainingForAction is <= 0 the spy won't be considered to be doing work any more
+                --turnsRemainingForAction
+                return
+            } 
             else -> return // Not implemented yet, so don't do anything
         }
     }
@@ -231,7 +238,7 @@ class Spy() : IsPartOfGameInfoSerialization {
 
     // Only returns true if the spy is doing a helpful and implemented action
     fun isDoingWork() = action == SpyAction.StealingTech || action == SpyAction.EstablishNetwork 
-        || action == SpyAction.RiggingElections || action == SpyAction.CounterIntelligence || action == SpyAction.Moving
+        || action == SpyAction.RiggingElections || (action == SpyAction.CounterIntelligence && turnsRemainingForAction > 0) || action == SpyAction.Moving
 
     fun getLocation(): City? {
         if (location == null) return null

--- a/core/src/com/unciv/models/Spy.kt
+++ b/core/src/com/unciv/models/Spy.kt
@@ -231,6 +231,7 @@ class Spy() : IsPartOfGameInfoSerialization {
     
     fun canMoveTo(city: City): Boolean {
         if (getLocation() == city) return true
+        if (!city.getCenterTile().isVisible(civInfo)) return false
         return espionageManager.getSpyAssignedToCity(city) == null
     }
 

--- a/core/src/com/unciv/models/Spy.kt
+++ b/core/src/com/unciv/models/Spy.kt
@@ -99,8 +99,8 @@ class Spy() : IsPartOfGameInfoSerialization {
                     return
                 }
                 val techStealCost = stealableTechs.maxOfOrNull { civInfo.gameInfo.ruleset.technologies[it]!!.cost }!!
-                // 20% spy bonus for each level
-                val progressThisTurn = getLocation()!!.cityStats.currentCityStats.science * (rank + 4) / 5
+                // 33% spy bonus for each level
+                val progressThisTurn = getLocation()!!.cityStats.currentCityStats.science * (rank + 2f) / 3f
                 progressTowardsStealingTech += progressThisTurn.toInt()
                 if (progressTowardsStealingTech > techStealCost) {
                     stealTech()

--- a/core/src/com/unciv/models/Spy.kt
+++ b/core/src/com/unciv/models/Spy.kt
@@ -164,8 +164,8 @@ class Spy() : IsPartOfGameInfoSerialization {
             spyResult < 100 -> "An unidentified spy stole the Technology [$stolenTech] from [$city]!"
             spyResult < 200 -> "A spy from [${civInfo.civName}] stole the Technology [$stolenTech] from [$city]!"
             else -> { // The spy was killed in the attempt
-                if (defendingSpy == null) "A spy from [${civInfo.civName}] tried to steal our Technology was found and killed in [$city]!"
-                else "A spy from [${civInfo.civName}] tried to steal our Technology was found and killed in [$city] by [${defendingSpy.name}]!"
+                if (defendingSpy == null) "A spy from [${civInfo.civName}] was found and killed trying to steal Technology in [$city]!"
+                else "A spy from [${civInfo.civName}] was found and killed by [${defendingSpy.name}] trying to steal Technology in [$city]!"
             }
         }
         if (detectionString != null)

--- a/core/src/com/unciv/models/Spy.kt
+++ b/core/src/com/unciv/models/Spy.kt
@@ -204,7 +204,8 @@ class Spy() : IsPartOfGameInfoSerialization {
                 }
             }
         }
-        cityStateCiv.getDiplomacyManager(civInfo).addInfluence(5f + getSpyRank())
+        // Starts at 10 influence and increases by 3 for each extra rank.
+        cityStateCiv.getDiplomacyManager(civInfo).addInfluence(7f + getSpyRank() * 3)
         civInfo.addNotification("Your spy successfully rigged the election in [$city]!", city.location,
             NotificationCategory.Espionage, NotificationIcon.Spy)
     }

--- a/core/src/com/unciv/models/Spy.kt
+++ b/core/src/com/unciv/models/Spy.kt
@@ -237,8 +237,12 @@ class Spy() : IsPartOfGameInfoSerialization {
     fun isSetUp() = action !in listOf(SpyAction.Moving, SpyAction.None, SpyAction.EstablishNetwork)
 
     // Only returns true if the spy is doing a helpful and implemented action
-    fun isDoingWork() = action == SpyAction.StealingTech || action == SpyAction.EstablishNetwork 
-        || action == SpyAction.RiggingElections || (action == SpyAction.CounterIntelligence && turnsRemainingForAction > 0) || action == SpyAction.Moving
+    fun isDoingWork(): Boolean { 
+        if (action == SpyAction.StealingTech || action == SpyAction.EstablishNetwork || action == SpyAction.Moving) return true
+        if (action == SpyAction.RiggingElections && !civInfo.isAtWarWith(getLocation()!!.civ)) return true
+        if (action == SpyAction.CounterIntelligence && turnsRemainingForAction > 0) return true
+        else return false
+    }
 
     fun getLocation(): City? {
         if (location == null) return null

--- a/core/src/com/unciv/models/Spy.kt
+++ b/core/src/com/unciv/models/Spy.kt
@@ -98,7 +98,8 @@ class Spy() : IsPartOfGameInfoSerialization {
                     return
                 }
                 val techStealCost = stealableTechs.maxOfOrNull { civInfo.gameInfo.ruleset.technologies[it]!!.cost }!!
-                val progressThisTurn = getLocation()!!.cityStats.currentCityStats.science
+                // 20% spy bonus for each level
+                val progressThisTurn = getLocation()!!.cityStats.currentCityStats.science * (rank + 4) / 5
                 progressTowardsStealingTech += progressThisTurn.toInt()
                 if (progressTowardsStealingTech > techStealCost) {
                     stealTech()

--- a/core/src/com/unciv/models/Spy.kt
+++ b/core/src/com/unciv/models/Spy.kt
@@ -168,6 +168,7 @@ class Spy() : IsPartOfGameInfoSerialization {
             civInfo.addNotification("Your spy [$name] stole the Technology [$stolenTech] from [$city]!", city.location,
                 NotificationCategory.Espionage, NotificationIcon.Spy)
             startStealingTech()
+            levelUpSpy()
         } else {
             civInfo.addNotification("Your spy [$name] was killed trying to steal Technology in [$city]!", city.location,
                 NotificationCategory.Espionage, NotificationIcon.Spy)

--- a/core/src/com/unciv/models/Spy.kt
+++ b/core/src/com/unciv/models/Spy.kt
@@ -219,11 +219,17 @@ class Spy() : IsPartOfGameInfoSerialization {
         action = SpyAction.Moving
         turnsRemainingForAction = 1
     }
+    
+    fun canMoveTo(city: City): Boolean {
+        if (getLocation() == city) return true
+        return espionageManager.getSpyAssignedToCity(city) == null
+    }
 
     fun isSetUp() = action !in listOf(SpyAction.Moving, SpyAction.None, SpyAction.EstablishNetwork)
 
     // Only returns true if the spy is doing a helpful and implemented action
-    fun isDoingWork() = action == SpyAction.StealingTech || action == SpyAction.EstablishNetwork
+    fun isDoingWork() = action == SpyAction.StealingTech || action == SpyAction.EstablishNetwork 
+        || action == SpyAction.RiggingElections || action == SpyAction.CounterIntelligence
 
     fun getLocation(): City? {
         return civInfo.gameInfo.getCities().firstOrNull { it.id == location }

--- a/core/src/com/unciv/models/Spy.kt
+++ b/core/src/com/unciv/models/Spy.kt
@@ -28,6 +28,7 @@ class Spy() : IsPartOfGameInfoSerialization {
     lateinit var name: String
     var action = SpyAction.None
         private set
+    var rank: Int = 1
     var turnsRemainingForAction = 0
         private set
     private var progressTowardsStealingTech = 0
@@ -232,7 +233,7 @@ class Spy() : IsPartOfGameInfoSerialization {
     }
 
     fun getSpyRank(): Int {
-        return 1
+        return rank
     }
 
     fun levelUpSpy() {
@@ -243,6 +244,7 @@ class Spy() : IsPartOfGameInfoSerialization {
             civInfo.addNotification("Your spy [$name] has leveled up!",
                 NotificationCategory.Espionage, NotificationIcon.Spy)
         }
+        rank++
     }
 
     fun getSkillModifier(): Int {
@@ -254,5 +256,6 @@ class Spy() : IsPartOfGameInfoSerialization {
         moveTo(null)
         action = SpyAction.Dead
         turnsRemainingForAction = 5
+        rank = 1
     }
 }

--- a/core/src/com/unciv/models/Spy.kt
+++ b/core/src/com/unciv/models/Spy.kt
@@ -229,7 +229,7 @@ class Spy() : IsPartOfGameInfoSerialization {
 
     // Only returns true if the spy is doing a helpful and implemented action
     fun isDoingWork() = action == SpyAction.StealingTech || action == SpyAction.EstablishNetwork 
-        || action == SpyAction.RiggingElections || action == SpyAction.CounterIntelligence
+        || action == SpyAction.RiggingElections || action == SpyAction.CounterIntelligence || action == SpyAction.Moving
 
     fun getLocation(): City? {
         return civInfo.gameInfo.getCities().firstOrNull { it.id == location }
@@ -265,4 +265,6 @@ class Spy() : IsPartOfGameInfoSerialization {
         turnsRemainingForAction = 5
         rank = 1
     }
+    
+    fun isAlive(): Boolean = action != SpyAction.Dead
 }

--- a/core/src/com/unciv/models/Spy.kt
+++ b/core/src/com/unciv/models/Spy.kt
@@ -247,6 +247,8 @@ class Spy() : IsPartOfGameInfoSerialization {
     }
 
     fun levelUpSpy() {
+        //TODO: Make the spy level cap dependent on some unique
+        if (rank >= 3) return 
         if (getLocation() != null) {
             civInfo.addNotification("Your spy [$name] has leveled up!", getLocation()!!.location, 
                 NotificationCategory.Espionage, NotificationIcon.Spy)

--- a/core/src/com/unciv/models/Spy.kt
+++ b/core/src/com/unciv/models/Spy.kt
@@ -103,8 +103,16 @@ class Spy() : IsPartOfGameInfoSerialization {
                 }
             }
             SpyAction.Dead -> {
-                
+                turnsRemainingForAction--
+                if (turnsRemainingForAction <= 0) {
+                    val oldSpyName = name
+                    name = espionageManager.getSpyName()
+                    action = SpyAction.None
+                    civInfo.addNotification("We have recruited a new spy name [$name] after [$oldSpyName] was killed.", 
+                        NotificationCategory.Espionage, NotificationIcon.Spy)
+                }
             }
+            SpyAction.CounterIntelligence -> return // Counter inteligence spies don't do anything here
             else -> return // Not implemented yet, so don't do anything
         }
     }
@@ -190,11 +198,19 @@ class Spy() : IsPartOfGameInfoSerialization {
     }
 
     fun levelUpSpy() {
-
+        if (getLocation() != null) {
+            civInfo.addNotification("Your spy [$name] has leveled up!", getLocation()!!.location, 
+                NotificationCategory.Espionage, NotificationIcon.Spy)
+        } else {
+            civInfo.addNotification("Your spy [$name] has leveled up!",
+                NotificationCategory.Espionage, NotificationIcon.Spy)
+        }
     }
 
     fun killSpy() {
+        // We don't actually remove this spy object, we set them as dead and let them revive
         moveTo(null)
         action = SpyAction.Dead
+        turnsRemainingForAction = 5
     }
 }

--- a/core/src/com/unciv/ui/screens/overviewscreen/EspionageOverviewScreen.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/EspionageOverviewScreen.kt
@@ -77,10 +77,8 @@ class EspionageOverviewScreen(val civInfo: Civilization, val worldScreen: WorldS
             spySelectionTable.add(spy.getLocationName().toLabel())
             val actionString =
                 when (spy.action) {
-                    SpyAction.None, SpyAction.StealingTech, SpyAction.Surveillance -> spy.action.displayString
-                    SpyAction.Moving, SpyAction.EstablishNetwork -> "[${spy.action.displayString}] ${spy.turnsRemainingForAction}${Fonts.turn}"
-                    SpyAction.RiggingElections -> TODO()
-                    SpyAction.CounterIntelligence -> TODO()
+                    SpyAction.None, SpyAction.StealingTech, SpyAction.Surveillance, SpyAction.CounterIntelligence -> spy.action.displayString
+                    SpyAction.Moving, SpyAction.EstablishNetwork, SpyAction.Dead, SpyAction.RiggingElections -> "[${spy.action.displayString}] ${spy.turnsRemainingForAction}${Fonts.turn}"
                 }
             spySelectionTable.add(actionString.toLabel())
 
@@ -95,14 +93,10 @@ class EspionageOverviewScreen(val civInfo: Civilization, val worldScreen: WorldS
                 selectedSpy = spy
                 selectedSpyButton!!.label.setText(Constants.cancel.tr())
                 for ((button, city) in moveSpyHereButtons) {
-                    // For now, only allow spies to be sent to cities of other major civs and their hideout
                     // Not own cities as counterintelligence isn't implemented
                     // Not city-state civs as rigging elections isn't implemented
                     button.isVisible = city == null // hideout
-                        || (city.civ.isMajorCiv()
-                            && city.civ != civInfo
-                            && !city.espionage.hasSpyOf(civInfo)
-                        )
+                        || (city.civ != civInfo && !city.espionage.hasSpyOf(civInfo))
                 }
             }
             if (!worldScreen.canChangeState) {


### PR DESCRIPTION
This PR adds most of what was missing in the base structure of espionage excluding buildings, policies and religions:

- Spies now have ranks, they start at 1 and as of now the limit is 3. The limit should probably be added in a global unique to be customizable.
- Spies can now be killed when failing to steal tech, or when rigging elections with an allied spy also rigging elections. The chance of death depends on the rank of each spy. If the spy is killed, the defending spy will level up and the action will fail.
- When a spy dies it revives after 5 turns as a new rank 1 spy with a new name. (This is how civ V does it)
- Spies now steal tech 33% faster for each extra rank.
- Spies can now rig elections, in my implementation, they get around 10 influence every 10 turns. Each bonus spy rank increases the influence gained by 3. This is not how Civ V does it, they use city-state elections and rigging elections can decrease the city-states influence with other civs. However I didn't want to spend much more time searching for little benefit. So I made my own implementation.
- The AI has some spy behavior, it is mostly random though and will need to be improved in a different commit.
- The location of a spy is no longer stored as a string and instead is stored as a vector 2. This will allow for much easier debugging in the future and makes the value a little more concrete. **As a side effect, all current espionage games will become incompatible with all future espionage games.** My expectation is that players shouldn't have been playing with espionage since it was hidden behind the debug screen.

<details><summary>Pictures</summary>
Both of these are AI viewed as a spectator.

![EspionageScreen1](https://github.com/yairm210/Unciv/assets/7538725/1471ce1e-fd8b-4d33-9f99-048638cee053)
![EspionageScreen2](https://github.com/yairm210/Unciv/assets/7538725/f1913da3-f858-446f-b7b0-83753875867f)


</details> 

And yes, I will add translations soon. (Done)