### PR TITLE
Simplify tile damage code

### DIFF
--- a/core/src/com/unciv/logic/civilization/Civilization.kt
+++ b/core/src/com/unciv/logic/civilization/Civilization.kt
@@ -126,10 +126,6 @@ class Civilization : IsPartOfGameInfoSerialization {
     var passThroughImpassableUnlocked = false   // Cached Boolean equal to passableImpassables.isNotEmpty()
 
     @Transient
-    var nonStandardTerrainDamage = false
-
-
-    @Transient
     var thingsToFocusOnForVictory = setOf<Victory.Focus>()
 
     @Transient
@@ -701,9 +697,6 @@ class Civilization : IsPartOfGameInfoSerialization {
                     city.workedTiles.remove(workedTile)
 
         passThroughImpassableUnlocked = passableImpassables.isNotEmpty()
-        // Cache whether this civ gets nonstandard terrain damage for performance reasons.
-        nonStandardTerrainDamage = getMatchingUniques(UniqueType.DamagesContainingUnits)
-            .any { gameInfo.ruleset.terrains[it.params[0]]!!.damagePerTurn != it.params[1].toInt() }
 
         hasLongCountDisplayUnique = hasUnique(UniqueType.MayanCalendarDisplay)
 

--- a/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
@@ -485,14 +485,6 @@ class MapUnit : IsPartOfGameInfoSerialization {
     }
 
     fun getDamageFromTerrain(tile: Tile = currentTile): Int {
-        if (civ.nonStandardTerrainDamage) {
-            for (unique in getMatchingUniques(UniqueType.DamagesContainingUnits)) {
-                if (unique.params[0] in tile.allTerrains.map { it.name }) {
-                    return unique.params[1].toInt() // Use the damage from the unique
-                }
-            }
-        }
-        // Otherwise fall back to the defined standard damage
         return  tile.allTerrains.sumOf { it.damagePerTurn }
     }
 


### PR DESCRIPTION
The main bulk of the code is to remove the extra caching for non standard tile damage. This is for a few main reasons
1. The unique in question `Units ending their turn on this terrain take [amount] damage` both implies it only works for terrains and is only set as a terrain unique. If any mods used this before, they likely would be warned off against it by the mod checker
2. The code around it is sketchy in the first place. Despite being a civ level cache (shouldn't this be in `CivInfoTransientCache`?) the check in MapUnit check only the unit's uniques. Once again, this implies that this never worked in this context before in the first place, unless some mad mod repeating the unique on both the civ and the unit... despite mod checker warnings
3. While they don't play nicely with the caching we have, we have alternatives to what something like #11060 wants to do, the most obvious being `This Unit takes [positiveAmount] damage <in [tileFilter] tiles> <upon turn end>` on the unit itself or at least a request for a better worded unique

Main thing about this PR I want to ask about before I go around editing the whole codebase: the function has been simplified down to more or less just `tile.allTerrains.sumOf { it.damagePerTurn }`, which reads to be more of a function in Tile itself. I don't know if I should move it now or leave this stub of a function in case we want add more support along these lines, particularly to  satisfy #11060 