### PR TITLE
docs: fix light/dark mode tooltip in the wiki

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,13 +10,13 @@ theme:
       accent: amber
       toggle:
         icon: material/lightbulb
-        name: Switch to light mode
+        name: Switch to dark mode
     - scheme: slate
       primary: teal
       accent: amber
       toggle:
         icon: material/lightbulb-outline
-        name: Switch to dark mode
+        name: Switch to light mode
 
   icon:
     repo: fontawesome/brands/github


### PR DESCRIPTION
I just ~~stole~~ borrowed your mkdocs.yml config and noticed the tooltip for the light/dark mode button are reversed. 

When in light mode it said switch to light mode which was probably a mistake. :D

Same for dark mode