### PR TITLE
Tweak Overview-Politics-Diagram for a defeated player

### DIFF
--- a/core/src/com/unciv/ui/screens/overviewscreen/GlobalPoliticsOverviewTable.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/GlobalPoliticsOverviewTable.kt
@@ -357,7 +357,9 @@ class GlobalPoliticsOverviewTable(
         add("[$relevantCivsCount] Civilizations in the game".toLabel()).colspan(columns).row()
         add("Our Civilization:".toLabel()).colspan(columns).left().padLeft(10f).padTop(10f).row()
         add(getCivMiniTable(viewingPlayer)).left()
-        add(viewingPlayer.calculateTotalScore().toInt().toLabel()).left().row()
+        val scoreText = if (viewingPlayer.isDefeated()) Fonts.death.toString()
+            else viewingPlayer.calculateTotalScore().toInt().toString()
+        add(scoreText.toLabel()).left().row()
         val turnsTillNextDiplomaticVote = viewingPlayer.getTurnsTillNextDiplomaticVote() ?: return
         add("Turns until the next\ndiplomacy victory vote: [$turnsTillNextDiplomaticVote]".toLabel()).colspan(columns).row()
     }
@@ -394,7 +396,10 @@ class GlobalPoliticsOverviewTable(
         }
     }
 
-    /** This is the 'spider net'-like polygon showing one line per civ-civ relation */
+    /** This is the 'spider net'-like polygon showing one line per civ-civ relation
+     *  @param undefeatedCivs Civs to display - note the viewing player is always included, so it's possible the name is off and there's a dead civ included.
+     *  @param freeSize Width and height this [Group] sizes itself to
+     */
     private class DiplomacyGroup(
         undefeatedCivs: Sequence<Civilization>,
         freeSize: Float
@@ -466,6 +471,7 @@ class GlobalPoliticsOverviewTable(
             }
 
             for (civ in undefeatedCivs) {
+                if (civ.isDefeated()) continue // if you're dead, icon but no lines (One more turn mode after losing)
                 for (diplomacy in civ.diplomacy.values) {
                     if (diplomacy.otherCiv() !in undefeatedCivs) continue
                     val civGroup = civGroups[civ.civName]!!

--- a/core/src/com/unciv/ui/screens/overviewscreen/GlobalPoliticsOverviewTable.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/GlobalPoliticsOverviewTable.kt
@@ -473,7 +473,8 @@ class GlobalPoliticsOverviewTable(
             for (civ in undefeatedCivs) {
                 if (civ.isDefeated()) continue // if you're dead, icon but no lines (One more turn mode after losing)
                 for (diplomacy in civ.diplomacy.values) {
-                    if (diplomacy.otherCiv() !in undefeatedCivs) continue
+                    val otherCiv = diplomacy.otherCiv()
+                    if (otherCiv !in undefeatedCivs || otherCiv.isDefeated()) continue
                     val civGroup = civGroups[civ.civName]!!
                     val otherCivGroup = civGroups[diplomacy.otherCivName]!!
 
@@ -488,7 +489,7 @@ class GlobalPoliticsOverviewTable(
                     statusLine.color = if (diplomacy.diplomaticStatus == DiplomaticStatus.War) Color.RED
                     else if (diplomacy.diplomaticStatus == DiplomaticStatus.DefensivePact
                         || (diplomacy.civInfo.isCityState() && diplomacy.civInfo.getAllyCiv() == diplomacy.otherCivName)
-                        || (diplomacy.otherCiv().isCityState() && diplomacy.otherCiv().getAllyCiv() == diplomacy.civInfo.civName)
+                        || (otherCiv.isCityState() && otherCiv.getAllyCiv() == diplomacy.civInfo.civName)
                     ) Color.CYAN
                     else diplomacy.relationshipLevel().color
 

--- a/core/src/com/unciv/ui/screens/overviewscreen/GlobalPoliticsOverviewTable.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/GlobalPoliticsOverviewTable.kt
@@ -206,6 +206,11 @@ class GlobalPoliticsOverviewTable(
         if (!viewingPlayer.knows(civ) && civ.civName != viewingPlayer.civName)
             return politicsTable
 
+        if (civ.isDefeated()) {
+            politicsTable.add("{Defeated} ${Fonts.death}".toLabel())
+            return politicsTable
+        }
+
         // wars
         for (otherCiv in civ.getKnownCivs()) {
             if (civ.isAtWarWith(otherCiv)) {


### PR DESCRIPTION
The two minor ideas mentioned in #11083 - completely untested, no saves, thus no pix.

Seeing `class DiplomacyGroup` - it begs for a refactor into a separate file, it begs for a rename (though I would name it BallOfYarn - admittedly even worse), and to rename the parameters, these names have more meaning _outside_ the class... Not really scope here, but should I include that nevertheless?