### PR TITLE
Patch AlertPopup to correctly close when it cannot find a required asset

### DIFF
--- a/core/src/com/unciv/ui/screens/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/WorldScreen.kt
@@ -421,7 +421,7 @@ class WorldScreen(
                     game.pushScreen(VictoryScreen(this))
                 viewingCiv.greatPeople.freeGreatPeople > 0 ->
                     game.pushScreen(GreatPersonPickerScreen(viewingCiv))
-                viewingCiv.popupAlerts.any() -> AlertPopup(this, viewingCiv.popupAlerts.first()).open()
+                viewingCiv.popupAlerts.any() -> AlertPopup(this, viewingCiv.popupAlerts.first())
                 viewingCiv.tradeRequests.isNotEmpty() -> {
                     // In the meantime this became invalid, perhaps because we accepted previous trades
                     for (tradeRequest in viewingCiv.tradeRequests.toList())


### PR DESCRIPTION
One way to fix #11090, though not the only one possible, and leaves questions open.
Compare the result of capturing that settler pre-patch as shown in the issue with:
![image](https://github.com/yairm210/Unciv/assets/63000004/81844dea-ea78-471e-8d39-dadb5f5610a1)

* So the Settler was thrown off the tile into the sea where it has a right to exist
* It also was not converted to a Worker as it should when captured (but I've seen the code preparing that by looking for what a Worker _is_ running while debugging)
* Could we detect that teleport and change the PopupAlert's value? (this hardening would still have independent merit)
* Should we instead look for unique identifiers for units, like cities have, which would not only be a better `value`to pass here (but breaking save compat), but also in some other places - like upgrading from unit overview, selection in some cases,...
* Could also have been done by making Popup.open open and overriding it, and could also have been done without flag - at that point, 'no cells' could also be tested. I threw the dice and did this instead.
* Entirely untreated: That observation that capture code (actually, UnitManager.placeUnitNearTile) would run UniqueTriggerActivation.triggerUnique on _all_ uniques of a created Worker, just not the ones having a trigger conditional... Or why that function doesn't save 76 indentation spaces and a line by `?: return null`