### PR TITLE
Fix Capture when a teleport was necessary

### DIFF
--- a/core/src/com/unciv/logic/battle/BattleUnitCapture.kt
+++ b/core/src/com/unciv/logic/battle/BattleUnitCapture.kt
@@ -120,7 +120,7 @@ object BattleUnitCapture {
             "Can't capture our own unit!"
         }
 
-        // need to save this because if the unit is captured its owner wil be overwritten
+        // need to save this because if the unit is captured its owner will be overwritten
         val defenderCiv = defender.getCivInfo()
 
         val capturedUnit = defender.unit

--- a/core/src/com/unciv/logic/battle/BattleUnitCapture.kt
+++ b/core/src/com/unciv/logic/battle/BattleUnitCapture.kt
@@ -163,7 +163,7 @@ object BattleUnitCapture {
                 attacker.getCivInfo().popupAlerts.add(
                     PopupAlert(
                         AlertType.RecapturedCivilian,
-                        capturedUnitTile.position.toString()
+                        capturedUnit.currentTile.position.toString()
                     )
                 )
             }


### PR DESCRIPTION
Complementing #11095, also fixes #11090, by itself. The actual fix - first commit - is tiny and allows proper liberation (exact same action as before):
![image](https://github.com/yairm210/Unciv/assets/63000004/dda0ee00-ef85-4575-8bcf-b2725245c276)

The second commit is - well I thought I would need it, then strictly speaking didn't, but I still liked the function better this way. Minor side effect - rare cases would no longer display "An enemy ... has captured our ..." but "destroyed" instead when in fact it is gone.