### PR TITLE
Add unique for increasing price every time it's built

### DIFF
--- a/core/src/com/unciv/logic/city/CityConstructions.kt
+++ b/core/src/com/unciv/logic/city/CityConstructions.kt
@@ -345,7 +345,7 @@ class CityConstructions : IsPartOfGameInfoSerialization {
                     city.civ.addNotification("No space available to place [${construction.name}] near [${city.name}]",
                         city.location, NotificationCategory.Production, construction.name)
                 }
-                city.civ.civConstructions.builtItemsWithIncreasingPrice[construction.name] += 1
+                city.civ.civConstructions.builtItemsWithIncreasingCost[construction.name] += 1
             }
         }
     }

--- a/core/src/com/unciv/logic/city/CityConstructions.kt
+++ b/core/src/com/unciv/logic/city/CityConstructions.kt
@@ -345,6 +345,7 @@ class CityConstructions : IsPartOfGameInfoSerialization {
                     city.civ.addNotification("No space available to place [${construction.name}] near [${city.name}]",
                         city.location, NotificationCategory.Production, construction.name)
                 }
+                city.civ.civConstructions.builtItemsWithIncreasingPrice[construction.name] += 1
             }
         }
     }

--- a/core/src/com/unciv/logic/civilization/CivConstructions.kt
+++ b/core/src/com/unciv/logic/civilization/CivConstructions.kt
@@ -21,6 +21,9 @@ class CivConstructions : IsPartOfGameInfoSerialization {
     /** Maps construction names to the amount of times bought */
     val boughtItemsWithIncreasingPrice: Counter<String> = Counter()
 
+    /** Maps construction names to the amount of times bought */
+    val builtItemsWithIncreasingPrice: Counter<String> = Counter()
+
     /** Maps cities by id to a set of all free buildings by name they contain.
      *  The building name is the Nation-specific equivalent if available.
      *  Sources: [UniqueType.FreeStatBuildings] **and** [UniqueType.FreeSpecificBuildings]
@@ -51,6 +54,7 @@ class CivConstructions : IsPartOfGameInfoSerialization {
         toReturn.freeStatBuildingsProvided.putAll(freeStatBuildingsProvided)
         toReturn.freeSpecificBuildingsProvided.putAll(freeSpecificBuildingsProvided)
         toReturn.boughtItemsWithIncreasingPrice.add(boughtItemsWithIncreasingPrice)  // add copies
+        toReturn.builtItemsWithIncreasingPrice.add(builtItemsWithIncreasingPrice)
         return toReturn
     }
 

--- a/core/src/com/unciv/logic/civilization/CivConstructions.kt
+++ b/core/src/com/unciv/logic/civilization/CivConstructions.kt
@@ -54,7 +54,7 @@ class CivConstructions : IsPartOfGameInfoSerialization {
         toReturn.freeStatBuildingsProvided.putAll(freeStatBuildingsProvided)
         toReturn.freeSpecificBuildingsProvided.putAll(freeSpecificBuildingsProvided)
         toReturn.boughtItemsWithIncreasingPrice.add(boughtItemsWithIncreasingPrice)  // add copies
-        toReturn.builtItemsWithIncreasingPrice.add(builtItemsWithIncreasingPrice)
+        toReturn.builtItemsWithIncreasingCost.add(builtItemsWithIncreasingCost)
         return toReturn
     }
 

--- a/core/src/com/unciv/logic/civilization/CivConstructions.kt
+++ b/core/src/com/unciv/logic/civilization/CivConstructions.kt
@@ -21,8 +21,8 @@ class CivConstructions : IsPartOfGameInfoSerialization {
     /** Maps construction names to the amount of times bought */
     val boughtItemsWithIncreasingPrice: Counter<String> = Counter()
 
-    /** Maps construction names to the amount of times bought */
-    val builtItemsWithIncreasingPrice: Counter<String> = Counter()
+    /** Maps construction names to the amount of times built */
+    val builtItemsWithIncreasingCost: Counter<String> = Counter()
 
     /** Maps cities by id to a set of all free buildings by name they contain.
      *  The building name is the Nation-specific equivalent if available.

--- a/core/src/com/unciv/models/ruleset/Building.kt
+++ b/core/src/com/unciv/models/ruleset/Building.kt
@@ -106,7 +106,7 @@ class Building : RulesetStatsObject(), INonPerpetualConstruction {
         var productionCost = cost.toFloat()
 
         for (unique in getMatchingUniques(UniqueType.CostIncreasesWhenBuilt, StateForConditionals(civInfo)))
-            productionCost += civInfo.civConstructions.builtItemsWithIncreasingPrice[name] * unique.params[0].toInt()
+            productionCost += civInfo.civConstructions.builtItemsWithIncreasingCost[name] * unique.params[0].toInt()
 
         for (unique in getMatchingUniques(UniqueType.CostIncreasesPerCity, StateForConditionals(civInfo)))
             productionCost += civInfo.cities.size * unique.params[0].toInt()

--- a/core/src/com/unciv/models/ruleset/Building.kt
+++ b/core/src/com/unciv/models/ruleset/Building.kt
@@ -105,6 +105,9 @@ class Building : RulesetStatsObject(), INonPerpetualConstruction {
     override fun getProductionCost(civInfo: Civilization): Int {
         var productionCost = cost.toFloat()
 
+        for (unique in getMatchingUniques(UniqueType.CostIncreasesWhenBuilt, StateForConditionals(civInfo)))
+            productionCost += civInfo.civConstructions.builtItemsWithIncreasingPrice[name] * unique.params[0].toInt()
+
         for (unique in getMatchingUniques(UniqueType.CostIncreasesPerCity, StateForConditionals(civInfo)))
             productionCost += civInfo.cities.size * unique.params[0].toInt()
 

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -280,7 +280,8 @@ enum class UniqueType(
     ///////////////////////////////////////// region 03 BUILDING UNIQUES /////////////////////////////////////////
 
 
-    CostIncreasesPerCity("Cost increases by [amount] per owned city", UniqueTarget.Building),
+    CostIncreasesPerCity("Cost increases by [amount] per owned city", UniqueTarget.Building, UniqueTarget.Unit),
+    CostIncreasesWhenBuilt("Cost increases by [amount] when built", UniqueTarget.Building, UniqueTarget.Unit),
 
     RequiresBuildingInAllCities("Requires a [buildingFilter] in all cities", UniqueTarget.Building),
     RequiresBuildingInSomeCities("Requires a [buildingFilter] in at least [amount] cities", UniqueTarget.Building),

--- a/core/src/com/unciv/models/ruleset/unit/BaseUnitCost.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnitCost.kt
@@ -16,7 +16,7 @@ class BaseUnitCost(val baseUnit: BaseUnit) {
             productionCost += civInfo.cities.size * unique.params[0].toInt()
 
         for (unique in baseUnit.getMatchingUniques(UniqueType.CostIncreasesWhenBuilt, StateForConditionals(civInfo)))
-            productionCost += civInfo.civConstructions.builtItemsWithIncreasingPrice[baseUnit.name] * unique.params[0].toInt()
+            productionCost += civInfo.civConstructions.builtItemsWithIncreasingCost[baseUnit.name] * unique.params[0].toInt()
 
         if (civInfo.isCityState())
             productionCost *= 1.5f

--- a/core/src/com/unciv/models/ruleset/unit/BaseUnitCost.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnitCost.kt
@@ -11,6 +11,13 @@ class BaseUnitCost(val baseUnit: BaseUnit) {
 
     fun getProductionCost(civInfo: Civilization): Int {
         var productionCost = baseUnit.cost.toFloat()
+
+        for (unique in baseUnit.getMatchingUniques(UniqueType.CostIncreasesPerCity, StateForConditionals(civInfo)))
+            productionCost += civInfo.cities.size * unique.params[0].toInt()
+
+        for (unique in baseUnit.getMatchingUniques(UniqueType.CostIncreasesWhenBuilt, StateForConditionals(civInfo)))
+            productionCost += civInfo.civConstructions.builtItemsWithIncreasingPrice[baseUnit.name] * unique.params[0].toInt()
+
         if (civInfo.isCityState())
             productionCost *= 1.5f
         productionCost *= if (civInfo.isHuman())


### PR DESCRIPTION
Also extends the unique for cost increasing for number of cities to units, as there's no real harm to it


Side note... Why exactly do we not have a version to pass in the city? That seems like it'll be more useful, at least here (maybe not for unit gold prices) than the civ itself for the sake of StateForConditionals