### PR TITLE
Workers wake up on tile expansion

### DIFF
--- a/core/src/com/unciv/logic/city/managers/CityExpansionManager.kt
+++ b/core/src/com/unciv/logic/city/managers/CityExpansionManager.kt
@@ -186,7 +186,7 @@ class CityExpansionManager : IsPartOfGameInfoSerialization {
         for (unit in tile.getUnits().toList()) // toListed because we're modifying
             if (!unit.civ.diplomacyFunctions.canPassThroughTiles(city.civ))
                 unit.movement.teleportToClosestMoveableTile()
-            else if (unit.isSleeping()) {
+            else if (unit.civ == city.civ && unit.isSleeping()) {
                 // If the unit is sleeping and is a worker, it might want to build on this tile
                 // So lets try to wake it up for the player to notice it
                 if (unit.cache.hasUniqueToBuildImprovements || unit.cache.hasUniqueToCreateWaterImprovements) {
@@ -194,7 +194,6 @@ class CityExpansionManager : IsPartOfGameInfoSerialization {
                     unit.action = null;
                 }
             }
-
 
         tile.history.recordTakeOwnership(tile)
     }

--- a/core/src/com/unciv/logic/city/managers/CityExpansionManager.kt
+++ b/core/src/com/unciv/logic/city/managers/CityExpansionManager.kt
@@ -1,6 +1,7 @@
 package com.unciv.logic.city.managers
 
 import com.badlogic.gdx.math.Vector2
+import com.unciv.Constants
 import com.unciv.logic.IsPartOfGameInfoSerialization
 import com.unciv.logic.automation.Automation
 import com.unciv.logic.city.City
@@ -13,6 +14,7 @@ import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.ui.components.extensions.toPercent
 import com.unciv.ui.components.extensions.withItem
 import com.unciv.ui.components.extensions.withoutItem
+import com.unciv.ui.screens.worldscreen.unit.actions.UnitActions
 import kotlin.math.max
 import kotlin.math.pow
 import kotlin.math.roundToInt
@@ -184,6 +186,14 @@ class CityExpansionManager : IsPartOfGameInfoSerialization {
         for (unit in tile.getUnits().toList()) // toListed because we're modifying
             if (!unit.civ.diplomacyFunctions.canPassThroughTiles(city.civ))
                 unit.movement.teleportToClosestMoveableTile()
+            else if (unit.isSleeping()) {
+                // If the unit is sleeping and is a worker, it might want to build on this tile
+                // So lets try to wake it up for the player to notice it
+                if (unit.cache.hasUniqueToBuildImprovements || unit.cache.hasUniqueToCreateWaterImprovements) {
+                    unit.due = true
+                    unit.action = null;
+                }
+            }
 
 
         tile.history.recordTakeOwnership(tile)


### PR DESCRIPTION
It does as stated. This allows players to pre-emptively put their workers on tiles that the city may expand to in order to construct the improvement there.
Should the city look for workers on tiles around the tile that has been expanded to?