### PR TITLE
proper vs cityFilter conditional

### DIFF
--- a/core/src/com/unciv/models/ruleset/unique/Conditionals.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Conditionals.kt
@@ -1,6 +1,7 @@
 package com.unciv.models.ruleset.unique
 
 import com.unciv.logic.GameInfo
+import com.unciv.logic.battle.CityCombatant
 import com.unciv.logic.battle.CombatAction
 import com.unciv.logic.battle.MapUnitCombatant
 import com.unciv.logic.city.City
@@ -188,8 +189,9 @@ object Conditionals {
             UniqueType.ConditionalWhenGarrisoned ->
                 checkOnCity { getCenterTile().militaryUnit?.canGarrison() == true }
 
-            UniqueType.ConditionalVsCity -> state.theirCombatant?.matchesFilter("City") == true
-            UniqueType.ConditionalVsUnits,  UniqueType.ConditionalVsCombatant -> state.theirCombatant?.matchesFilter(condition.params[0]) == true
+            UniqueType.ConditionalVsCity -> state.theirCombatant?.let {
+                it is CityCombatant && it.city.matchesFilter(condition.params[0]) } == true
+            UniqueType.ConditionalVsUnits,  UniqueType.ConditionalVsCiv -> state.theirCombatant?.matchesFilter(condition.params[0]) == true
             UniqueType.ConditionalOurUnit, UniqueType.ConditionalOurUnitOnUnit ->
                 relevantUnit?.matchesFilter(condition.params[0]) == true
             UniqueType.ConditionalUnitWithPromotion -> relevantUnit?.promotions?.promotions?.contains(condition.params[0]) == true

--- a/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
@@ -80,19 +80,6 @@ enum class UniqueParameterType(
             if (parameterText in Constants.all) null else UniqueType.UniqueParameterErrorSeverity.RulesetInvariant
     },
 
-    /** Implemented by [ICombatant.matchesCategory][com.unciv.logic.battle.ICombatant.matchesFilter] */
-    CombatantFilter("combatantFilter", "City", "This indicates a combatant, which can either be a unit or a city (when bombarding). Must either be `City` or a `mapUnitFilter`") {
-        override fun getErrorSeverity(parameterText: String, ruleset: Ruleset):
-            UniqueType.UniqueParameterErrorSeverity? = getErrorSeverityForFilter(parameterText, ruleset)
-
-        override fun isKnownValue(parameterText: String, ruleset: Ruleset): Boolean {
-            if (parameterText == "City") return true
-            if (MapUnitFilter.isKnownValue(parameterText, ruleset)) return true
-            if (CityFilter.isKnownValue(parameterText, ruleset)) return true
-            return false
-        }
-    },
-
     /** Implemented by [MapUnit.matchesFilter][com.unciv.logic.map.mapunit.MapUnit.matchesFilter] */
     MapUnitFilter("mapUnitFilter", Constants.wounded, null, "Map Unit Filters") {
         private val knownValues = setOf(Constants.wounded, Constants.barbarians, "Barbarian",

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -351,7 +351,7 @@ enum class UniqueType(
     FlankAttackBonus("[relativeAmount]% to Flank Attack bonuses", UniqueTarget.Unit, UniqueTarget.Global),
     @Deprecated("as of 4.10.3", ReplaceWith("[+30]% Strength <vs [City-States]>"))
     StrengthBonusVsCityStates("+30% Strength when fighting City-State units and cities", UniqueTarget.Global),
-    StrengthForAdjacentEnemies("[relativeAmount]% Strength for enemy [combatantFilter] units in adjacent [tileFilter] tiles", UniqueTarget.Unit),
+    StrengthForAdjacentEnemies("[relativeAmount]% Strength for enemy [mapUnitFilter] units in adjacent [tileFilter] tiles", UniqueTarget.Unit),
     StrengthWhenStacked("[relativeAmount]% Strength when stacked with [mapUnitFilter]", UniqueTarget.Unit),  // candidate for conditional!
     StrengthBonusInRadius("[relativeAmount]% Strength bonus for [mapUnitFilter] units within [amount] tiles", UniqueTarget.Unit),
 
@@ -367,7 +367,7 @@ enum class UniqueType(
     StatsWhenSpreading("When spreading religion to a city, gain [amount] times the amount of followers of other religions as [stat]", UniqueTarget.Unit, UniqueTarget.Global),
 
     // Attack restrictions
-    CanOnlyAttackUnits("Can only attack [combatantFilter] units", UniqueTarget.Unit),
+    CanOnlyAttackUnits("Can only attack [mapUnitFilter] units", UniqueTarget.Unit),
     CanOnlyAttackTiles("Can only attack [tileFilter] tiles", UniqueTarget.Unit),
     CannotAttack("Cannot attack", UniqueTarget.Unit),
     MustSetUp("Must set up to ranged attack", UniqueTarget.Unit),
@@ -429,7 +429,7 @@ enum class UniqueType(
     UnitUpgradeCost("[relativeAmount]% Gold cost of upgrading", UniqueTarget.Unit, UniqueTarget.Global),
 
     // Gains from battle
-    DamageUnitsPlunder("Earn [amount]% of the damage done to [combatantFilter] units as [civWideStat]", UniqueTarget.Unit, UniqueTarget.Global),
+    DamageUnitsPlunder("Earn [amount]% of the damage done to [mapUnitFilter] units as [civWideStat]", UniqueTarget.Unit, UniqueTarget.Global),
     CaptureCityPlunder("Upon capturing a city, receive [amount] times its [stat] production as [civWideStat] immediately", UniqueTarget.Unit, UniqueTarget.Global),
     KillUnitPlunder("Earn [amount]% of killed [mapUnitFilter] unit's [costOrStrength] as [civWideStat]", UniqueTarget.Unit, UniqueTarget.Global),
     KillUnitPlunderNearCity("Earn [amount]% of [mapUnitFilter] unit's [costOrStrength] as [civWideStat] when killed within 4 tiles of a city following this religion", UniqueTarget.FollowerBelief),
@@ -672,9 +672,13 @@ enum class UniqueType(
     ConditionalOurUnitOnUnit("when [mapUnitFilter]", UniqueTarget.Conditional), // Same but for the unit itself
     ConditionalUnitWithPromotion("for units with [promotion]", UniqueTarget.Conditional),
     ConditionalUnitWithoutPromotion("for units without [promotion]", UniqueTarget.Conditional),
-    ConditionalVsCity("vs cities", UniqueTarget.Conditional),
+
+    ConditionalVsCity("vs [cityFilter] cities", UniqueTarget.Conditional),
+    @Deprecated("as of 4.10.9", ReplaceWith("vs [all] cities"))
+    ConditionalVsCityOld("vs cities", UniqueTarget.Conditional),
+
     ConditionalVsUnits("vs [mapUnitFilter] units", UniqueTarget.Conditional),
-    ConditionalVsCombatant("vs [combatantFilter]", UniqueTarget.Conditional),
+    ConditionalVsCiv("vs [civFilter]", UniqueTarget.Conditional),
     ConditionalVsLargerCiv("when fighting units from a Civilization with more Cities than you", UniqueTarget.Conditional),
     ConditionalAttacking("when attacking", UniqueTarget.Conditional),
     ConditionalDefending("when defending", UniqueTarget.Conditional),


### PR DESCRIPTION
- combatantFilter was a mistake - almost all places we use it have "[combatantFilter] units" which gives the game away.
- The only time we'll have a single effect for both cities and units is if we're using a civFilter - so let's just say so directly
- The cityFilter that I shoved into the combatant was not the right place - this should be part of the "vs cities" conditional soyou can say which cities, just like with units