### PR TITLE
Allow barb camps to function after giving ruins effects

### DIFF
--- a/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
@@ -802,6 +802,7 @@ class MapUnit : IsPartOfGameInfoSerialization {
         // addPromotion requires currentTile to be valid because it accesses ruleset through it.
         // getAncientRuinBonus, if it places a new unit, does too
         currentTile = tile
+        // The improvement may get removed if it has ruins effects or is a barbarian camp, and will still be needed if removed
         val improvement = tile.improvement
 
         if (civ.isMajorCiv()

--- a/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
@@ -802,14 +802,15 @@ class MapUnit : IsPartOfGameInfoSerialization {
         // addPromotion requires currentTile to be valid because it accesses ruleset through it.
         // getAncientRuinBonus, if it places a new unit, does too
         currentTile = tile
+        val improvement = tile.improvement
 
         if (civ.isMajorCiv()
-            && tile.improvement != null
-            && tile.getTileImprovement()!!.isAncientRuinsEquivalent()
+            && improvement != null
+            && tile.ruleset.tileImprovements[improvement]!!.isAncientRuinsEquivalent()
         ) {
             getAncientRuinBonus(tile)
         }
-        if (tile.improvement == Constants.barbarianEncampment && !civ.isBarbarian())
+        if (improvement == Constants.barbarianEncampment && !civ.isBarbarian())
             clearEncampment(tile)
         // Check whether any civilians without military units are there.
         // Keep in mind that putInTile(), which calls this method,


### PR DESCRIPTION
Haven't tested this, but does this means that mods that placed ruins effects on barb camps didn't clear city state requests properly? Or was they at least fixed on new turns? Seems like that could've been and issue in its own right