### PR TITLE
AutoAssign Population with Food Converts to Production

### DIFF
--- a/core/src/com/unciv/logic/automation/Automation.kt
+++ b/core/src/com/unciv/logic/automation/Automation.kt
@@ -47,6 +47,7 @@ object Automation {
         val cityAIFocus = city.getCityFocus()
         val yieldStats = stats.clone()
         val civPersonality = city.civ.getPersonality()
+        val cityStatsObj = city.cityStats
 
         if (specialist) {
             // If you have the Food Bonus, count as 1 extra food production (base is 2food)
@@ -61,6 +62,12 @@ object Automation {
         }
 
         val surplusFood = cityStats[Stat.Food]
+        // If current Production converts Food into Production, then calculate increased Production Yield
+        if(cityStatsObj.canConvertFoodToProduction(surplusFood, city.cityConstructions.getCurrentConstruction())) {
+            // calculate delta increase of food->prod. This isn't linear
+            yieldStats.production += cityStatsObj.getProductionFromExcessiveFood(surplusFood+yieldStats.food) - cityStatsObj.getProductionFromExcessiveFood(surplusFood)
+            yieldStats.food = 0f  // all food goes to 0
+        }
         // Apply base weights
         yieldStats.applyRankingWeights()
 

--- a/core/src/com/unciv/logic/city/CityConstructions.kt
+++ b/core/src/com/unciv/logic/city/CityConstructions.kt
@@ -66,7 +66,6 @@ class CityConstructions : IsPartOfGameInfoSerialization {
         }
         set(value) {
             if (constructionQueue.isEmpty()) constructionQueue.add(value) else constructionQueue[0] = value
-            city.reassignPopulation()
         }
 
     //endregion
@@ -757,7 +756,6 @@ class CityConstructions : IsPartOfGameInfoSerialization {
                 constructionQueue.add(constructionName)
         }
         currentConstructionIsUserSet = true
-        city.reassignPopulation()
     }
 
     /** Add a construction named [constructionName] to the end of the queue with all checks
@@ -786,8 +784,6 @@ class CityConstructions : IsPartOfGameInfoSerialization {
             else constructionQueue.add(PerpetualConstruction.idle.name) // To prevent Construction Automation
             false
         } else true // we're just continuing the regular queue
-        if(constructionQueueIndex==0)
-            city.reassignPopulation()
     }
 
     /** Remove all queue entries for [constructionName].
@@ -809,7 +805,6 @@ class CityConstructions : IsPartOfGameInfoSerialization {
         if (constructionQueueIndex == 0 || constructionQueueIndex >= constructionQueue.size) return
         val constructionName = constructionQueue.removeAt(constructionQueueIndex)
         constructionQueue.add(0, constructionName)
-        city.reassignPopulation()
     }
 
     /** Moves an entry by index to the end of the queue, or just before a PerpetualConstruction
@@ -821,13 +816,10 @@ class CityConstructions : IsPartOfGameInfoSerialization {
         // Some of the overhead of addToQueue is redundant here, but if the complex "needs to replace or go before a perpetual" logic is needed, then use it anyway
         if (isLastConstructionPerpetual()) return addToQueue(constructionName)
         constructionQueue.add(constructionName)
-        city.reassignPopulation()
     }
 
     fun raisePriority(constructionQueueIndex: Int): Int {
         constructionQueue.swap(constructionQueueIndex - 1, constructionQueueIndex)
-        if(constructionQueueIndex==1)
-            city.reassignPopulation()
         return constructionQueueIndex - 1
     }
 

--- a/core/src/com/unciv/logic/city/CityConstructions.kt
+++ b/core/src/com/unciv/logic/city/CityConstructions.kt
@@ -871,7 +871,6 @@ class CityConstructions : IsPartOfGameInfoSerialization {
             constructionQueue.add(PerpetualConstruction.idle.name)
             false
         } else true
-        city.reassignPopulation()
     }
 
     /** Support for [UniqueType.CreatesOneImprovement]:

--- a/core/src/com/unciv/logic/city/CityConstructions.kt
+++ b/core/src/com/unciv/logic/city/CityConstructions.kt
@@ -66,6 +66,7 @@ class CityConstructions : IsPartOfGameInfoSerialization {
         }
         set(value) {
             if (constructionQueue.isEmpty()) constructionQueue.add(value) else constructionQueue[0] = value
+            city.reassignPopulation()
         }
 
     //endregion
@@ -756,6 +757,7 @@ class CityConstructions : IsPartOfGameInfoSerialization {
                 constructionQueue.add(constructionName)
         }
         currentConstructionIsUserSet = true
+        city.reassignPopulation()
     }
 
     /** Add a construction named [constructionName] to the end of the queue with all checks
@@ -784,6 +786,8 @@ class CityConstructions : IsPartOfGameInfoSerialization {
             else constructionQueue.add(PerpetualConstruction.idle.name) // To prevent Construction Automation
             false
         } else true // we're just continuing the regular queue
+        if(constructionQueueIndex==0)
+            city.reassignPopulation()
     }
 
     /** Remove all queue entries for [constructionName].
@@ -805,6 +809,7 @@ class CityConstructions : IsPartOfGameInfoSerialization {
         if (constructionQueueIndex == 0 || constructionQueueIndex >= constructionQueue.size) return
         val constructionName = constructionQueue.removeAt(constructionQueueIndex)
         constructionQueue.add(0, constructionName)
+        city.reassignPopulation()
     }
 
     /** Moves an entry by index to the end of the queue, or just before a PerpetualConstruction
@@ -816,10 +821,13 @@ class CityConstructions : IsPartOfGameInfoSerialization {
         // Some of the overhead of addToQueue is redundant here, but if the complex "needs to replace or go before a perpetual" logic is needed, then use it anyway
         if (isLastConstructionPerpetual()) return addToQueue(constructionName)
         constructionQueue.add(constructionName)
+        city.reassignPopulation()
     }
 
     fun raisePriority(constructionQueueIndex: Int): Int {
         constructionQueue.swap(constructionQueueIndex - 1, constructionQueueIndex)
+        if(constructionQueueIndex==1)
+            city.reassignPopulation()
         return constructionQueueIndex - 1
     }
 
@@ -871,6 +879,7 @@ class CityConstructions : IsPartOfGameInfoSerialization {
             constructionQueue.add(PerpetualConstruction.idle.name)
             false
         } else true
+        city.reassignPopulation()
     }
 
     /** Support for [UniqueType.CreatesOneImprovement]:

--- a/core/src/com/unciv/logic/city/CityStats.kt
+++ b/core/src/com/unciv/logic/city/CityStats.kt
@@ -577,10 +577,7 @@ class CityStats(val city: City) {
         val buildingsMaintenance = getBuildingMaintenanceCosts() // this is AFTER the bonus calculation!
         newFinalStatList["Maintenance"] = Stats(gold = -buildingsMaintenance.toInt().toFloat())
 
-        if (totalFood > 0
-            && currentConstruction is INonPerpetualConstruction
-            && currentConstruction.hasUnique(UniqueType.ConvertFoodToProductionWhenConstructed)
-        ) {
+        if (canConvertFoodToProduction(totalFood, currentConstruction)) {
             newFinalStatList["Excess food to production"] =
                 Stats(production = getProductionFromExcessiveFood(totalFood), food = -totalFood)
         }
@@ -603,9 +600,15 @@ class CityStats(val city: City) {
         finalStatList = newFinalStatList
     }
 
+    fun canConvertFoodToProduction(food: Float, currentConstruction: IConstruction): Boolean {
+        return (food > 0
+            && currentConstruction is INonPerpetualConstruction
+            && currentConstruction.hasUnique(UniqueType.ConvertFoodToProductionWhenConstructed))
+    }
+
     // calculate the conversion of the excessive food to the production
     // See for details: https://civilization.fandom.com/wiki/Settler_(Civ5)
-    private fun getProductionFromExcessiveFood(food : Float): Float {
+    fun getProductionFromExcessiveFood(food : Float): Float {
         return if (food >= 4.0f ) 2.0f + (food / 4.0f).toInt()
           else if (food >= 2.0f ) 2.0f
           else if (food >= 1.0f ) 1.0f

--- a/core/src/com/unciv/ui/screens/cityscreen/CityConstructionsTable.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/CityConstructionsTable.kt
@@ -368,6 +368,7 @@ class CityConstructionsTable(private val cityScreen: CityScreen) {
         if (cityScreen.canCityBeChanged())
             table.onRightClick { selectQueueEntry {
                 CityScreenConstructionMenu(cityScreen.stage, table, cityScreen.city, construction) {
+                    cityScreen.city.reassignPopulation()
                     cityScreen.update()
                 }
             } }
@@ -487,6 +488,7 @@ class CityConstructionsTable(private val cityScreen: CityScreen) {
                 cityScreen.updateWithoutConstructionAndMap()
             }
             CityScreenConstructionMenu(cityScreen.stage, pickConstructionButton, cityScreen.city, construction) {
+                cityScreen.city.reassignPopulation()
                 cityScreen.update()
             }
         }
@@ -554,6 +556,7 @@ class CityConstructionsTable(private val cityScreen: CityScreen) {
                 cityConstructions.removeFromQueue(selectedQueueEntry, false)
                 cityScreen.clearSelection()
                 selectedQueueEntry = -1
+                cityScreen.city.reassignPopulation()
                 cityScreen.update()
             }
             if (city.isPuppet)
@@ -591,6 +594,7 @@ class CityConstructionsTable(private val cityScreen: CityScreen) {
         cityConstructions.addToQueue(construction.name)
         if (!construction.shouldBeDisplayed(cityConstructions)) // For buildings - unlike units which can be queued multiple times
             cityScreen.clearSelection()
+        cityScreen.city.reassignPopulation()
         cityScreen.update()
         cityScreen.game.settings.addCompletedTutorialTask("Pick construction")
     }
@@ -762,6 +766,7 @@ class CityConstructionsTable(private val cityScreen: CityScreen) {
                     cityScreen.selectConstruction(newConstruction)
             }
         }
+        cityScreen.city.reassignPopulation()
         cityScreen.update()
     }
 
@@ -779,11 +784,11 @@ class CityConstructionsTable(private val cityScreen: CityScreen) {
         button.onActivation {
             button.touchable = Touchable.disabled
             selectedQueueEntry = movePriority(constructionQueueIndex)
-            // No need to call entire cityScreen.update() as reordering doesn't influence Stat or Map,
-            // nor does it need an expensive rebuild of the available constructions.
             // Selection display may need to update as I can click the button of a non-selected entry.
             cityScreen.selectConstruction(name)
-            cityScreen.updateWithoutConstructionAndMap()
+            cityScreen.city.reassignPopulation()
+            cityScreen.update()
+            //cityScreen.updateWithoutConstructionAndMap()
             updateQueueAndButtons(cityScreen.selectedConstruction)
             ensureQueueEntryVisible()  // Not passing current button info - already outdated, our parent is already removed from the stage hierarchy and replaced
         }
@@ -808,6 +813,7 @@ class CityConstructionsTable(private val cityScreen: CityScreen) {
             tab.touchable = Touchable.disabled
             city.cityConstructions.removeFromQueue(constructionQueueIndex, false)
             cityScreen.clearSelection()
+            cityScreen.city.reassignPopulation()
             cityScreen.update()
         }
         return tab


### PR DESCRIPTION
Properly Calculate Assign Population based on Food Conversion to Production affecting yields
Trigger Auto Assign when Queue is changed
![image](https://github.com/yairm210/Unciv/assets/44038014/e688ba59-15a7-4ed5-adba-0b31de8f3b92)
![image](https://github.com/yairm210/Unciv/assets/44038014/0c01cb22-de5a-4a13-b97c-a1cd7d161ee0)
Triggers tested:
* Add to queue
* Remove from Queue
* Change Queue Priority (both up and down)
* Add to Top of Queue
* Move to Bottom of Queue
* Purchase Construction