### PR TITLE
Fix creating 105x90 rectangular no-wrap maps

### DIFF
--- a/core/src/com/unciv/logic/map/TileMap.kt
+++ b/core/src/com/unciv/logic/map/TileMap.kt
@@ -465,8 +465,8 @@ class TileMap(initialCapacity: Int = 10) : IsPartOfGameInfoSerialization {
             }
         } else {
             // Yes the map generator calls this repeatedly, and we don't want to end up with an oversized tileMatrix
-            // rightX is -leftX or -leftX + 1 or -leftX + 2
-            check(tileMatrix.size in (1 - 2 * leftX)..(3 - 2 * leftX)) {
+            // rightX is between -leftX - 1 (e.g. 105x90 map thanks @ravignir) and -leftX + 2
+            check(tileMatrix.size in (- 2 * leftX)..(3 - 2 * leftX)) {
                 "TileMap.setTransients called on existing tileMatrix of different size"
             }
         }


### PR DESCRIPTION
seen [on disc :vomiting_face: rd](https://discord.com/channels/586194543280390151/1195754723542835282).
Also reported earlier by at least @Caballero-Arepa - issue ... hmmm .... #10908 this one. I'm sure it was the same underlying problem.

And no, no increased presence of me on d*. I just reacted to an insulting mail by Dirtcord itself.

After all, repro turned out easy: Reset to defaults, rect, custom, 105x90, that check trips, with leftX a -71 and a recalculated rightX = +70, so the check looks for 142 in the 143..145 range. Or looked after this PR.