### PR TITLE
Allow Barbarians to make units that must set up to ranged attack

### DIFF
--- a/core/src/com/unciv/logic/automation/civilization/BarbarianManager.kt
+++ b/core/src/com/unciv/logic/automation/civilization/BarbarianManager.kt
@@ -258,8 +258,7 @@ class Encampment() : IsPartOfGameInfoSerialization {
         barbarianCiv.tech.techsResearched = allResearchedTechs.toHashSet()
         val unitList = gameInfo.ruleset.units.values
             .filter { it.isMilitary() &&
-                    !(it.hasUnique(UniqueType.MustSetUp) ||
-                            it.hasUnique(UniqueType.CannotAttack) ||
+                    !(it.hasUnique(UniqueType.CannotAttack) ||
                             it.hasUnique(UniqueType.CannotBeBarbarian)) &&
                     (if (naval) it.isWaterUnit() else it.isLandUnit()) &&
                     it.isBuildable(barbarianCiv) }


### PR DESCRIPTION
The current code prevents Barbarians from making units that have to set up to do ranged attacks. This prevention is unnecessary, since we have a dedicated unique that prevents units from being Barbarian.