### PR TITLE
Minor: Fix default of NotificationsScroll visibility setting

### DIFF
--- a/core/src/com/unciv/models/metadata/GameSettings.kt
+++ b/core/src/com/unciv/models/metadata/GameSettings.kt
@@ -11,6 +11,7 @@ import com.unciv.ui.components.fonts.FontFamilyData
 import com.unciv.ui.components.fonts.Fonts
 import com.unciv.ui.components.input.KeyboardBindings
 import com.unciv.ui.screens.overviewscreen.EmpireOverviewCategories
+import com.unciv.ui.screens.worldscreen.NotificationsScroll
 import com.unciv.utils.Display
 import com.unciv.utils.ScreenOrientation
 import java.text.Collator
@@ -116,8 +117,9 @@ class GameSettings {
 
     var keyBindings = KeyboardBindings()
 
-    /** NotificationScroll on Word Screen visibility control - mapped to NotificationsScroll.UserSetting enum */
-    var notificationScroll: String = ""
+    /** NotificationScroll on Word Screen visibility control - mapped to [NotificationsScroll.UserSetting] enum */
+    // Defaulting this to "" - and implement the fallback only in NotificationsScroll leads to Options popup and actual effect being in disagreement!
+    var notificationScroll: String = NotificationsScroll.UserSetting.default().name
 
     /** If on, selected notifications are drawn enlarged with wider padding */
     var enlargeSelectedNotification = true

--- a/core/src/com/unciv/ui/screens/worldscreen/NotificationsScroll.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/NotificationsScroll.kt
@@ -13,15 +13,15 @@ import com.badlogic.gdx.utils.Align
 import com.unciv.GUI
 import com.unciv.logic.civilization.Notification
 import com.unciv.logic.civilization.NotificationCategory
-import com.unciv.ui.components.widgets.AutoScrollPane as ScrollPane
-import com.unciv.ui.components.widgets.ColorMarkupLabel
-import com.unciv.ui.components.widgets.WrappableLabel
-import com.unciv.ui.components.input.onClick
 import com.unciv.ui.components.extensions.packIfNeeded
 import com.unciv.ui.components.extensions.surroundWithCircle
+import com.unciv.ui.components.input.onClick
+import com.unciv.ui.components.widgets.ColorMarkupLabel
+import com.unciv.ui.components.widgets.WrappableLabel
 import com.unciv.ui.images.IconCircleGroup
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.screens.basescreen.BaseScreen
+import com.unciv.ui.components.widgets.AutoScrollPane as ScrollPane
 
 /*TODO
  *  Un-hiding the notifications when new ones arrive is a little pointless due to Categories:
@@ -34,7 +34,10 @@ import com.unciv.ui.screens.basescreen.BaseScreen
 class NotificationsScroll(
     private val worldScreen: WorldScreen
 ) : ScrollPane(null) {
-    enum class UserSetting(val static: Boolean = false) { Disabled(true), Hidden, Visible, Permanent(true) }
+    enum class UserSetting(val static: Boolean = false) {
+        Disabled(true), Hidden, Visible, Permanent(true);
+        companion object { fun default() = Visible }
+    }
 
     private companion object {
         /** Scale the entire ScrollPane by this factor */
@@ -455,7 +458,7 @@ class NotificationsScroll(
     private fun getUserSettingCheckDisabled(): Boolean {
         val settingString = GUI.getSettings().notificationScroll
         val setting = UserSetting.values().firstOrNull { it.name == settingString }
-            ?: UserSetting.Visible
+            ?: UserSetting.default()
         userSettingChanged = false
         if (setting == userSetting)
             return setting == UserSetting.Disabled


### PR DESCRIPTION
Issue: Delete your settings file, start and look at the "Notifications on world screen" setting: It says "Disabled" when in fact it works like "Visible" - until you change it one of two ways, then it's in sync.

Fix: back to enum - or set a meaningful default, not one that has no enum entry. I moved the responsibility to decide what the default **is** into the enum - matter of taste that...

Very minor but has irked me for ***ages***...