### PR TITLE
Credits maintenance - normalize, fix or improve attributions

### DIFF
--- a/docs/Credits.md
+++ b/docs/Credits.md
@@ -36,26 +36,26 @@ Unless otherwise specified, all the following are from [the Noun Project](https:
 
 #### Ancient Era
 
--   [Hammer](https://thenounproject.com/search/?q=Hammer&i=667666) By Hea Poh Lin for Worker
--   [Flag](https://thenounproject.com/search/?q=Flag&i=50114) By Melvin Poppelaars for Settler
--   [Eagle](https://thenounproject.com/search/?q=Eagle&i=1619932) By anggun for Scout
--   [Axe](https://thenounproject.com/search/?q=Axe&i=1688143) By ehab.abdullah for Warrior
--   [Haka](https://thenounproject.com/search/?q=haka&i=379655) By Josh for Maori Warrior
--   [Spiked Club](https://thenounproject.com/search/?q=spiked%20club&i=831793) by Hamish
--   [Bow And Arrow](https://thenounproject.com/search/?q=Bow%20and%20Arrow&i=338261) By Viktor Ostrovsky for Archer
--   [Bow](https://thenounproject.com/search/?q=bow&i=101736) By Arthur Shlain for Bowman
+-   [Hammer](https://thenounproject.com/icon/Hammer-667666) By Hea Poh Lin for Worker
+-   [Flag](https://thenounproject.com/icon/Flag-50114) By Melvin Poppelaars for Settler
+-   [Eagle](https://thenounproject.com/icon/Eagle-1619932) By anggun for Scout
+-   [Axe](https://thenounproject.com/icon/Axe-1688143) By ehab.abdullah for Warrior
+-   [Haka](https://thenounproject.com/icon/haka-379655) By Josh for Maori Warrior
+-   [Spiked Club](https://thenounproject.com/icon/spiked%20club-831793) by Hamish
+-   [Bow And Arrow](https://thenounproject.com/icon/Bow%20and%20Arrow-338261) By Viktor Ostrovsky for Archer
+-   [Bow](https://thenounproject.com/icon/bow-101736) By Arthur Shlain for Bowman
 -   [Javelin](https://thenounproject.com/term/javelin-thrower/2118369/) By WEBTECHOPS LLP for Atlatlist
 -   [arrows](https://thenounproject.com/term/arrows/2047488/) by Ayub Irawan for Skirmisher
 -   [Fishing Vessel](https://thenounproject.com/term/fishing-vessel/23815/) By Luis Prado for Work Boats
--   [Greek Trireme](https://thenounproject.com/search/?q=ancient%20boat&i=1626303) By Zachary McCune for Trireme
--   [Greek Trireme](https://thenounproject.com/search/?q=ancient%20boat&i=1626303) By Zachary McCune for Quinquereme. The original work has been modified.
--   [dragon](https://thenounproject.com/search/?q=dragon&i=1646681) by BGBOXXX Design for Dromon
--   [Viking Boat](https://thenounproject.com/search/?q=longship&i=3782922) by Eucalyp for Galley
--   [Chariot](https://thenounproject.com/search/?q=Chariot&i=1189930) By Andrew Doane for Chariot Archer
+-   [Greek Trireme](https://thenounproject.com/icon/ancient%20boat-1626303) By Zachary McCune for Trireme
+-   [Greek Trireme](https://thenounproject.com/icon/ancient%20boat-1626303) By Zachary McCune for Quinquereme. The original work has been modified.
+-   [dragon](https://thenounproject.com/icon/dragon-1646681) by BGBOXXX Design for Dromon
+-   [Viking Boat](https://thenounproject.com/icon/longship-3782922) by Eucalyp for Galley
+-   [Chariot](https://thenounproject.com/icon/Chariot-1189930) By Andrew Doane for Chariot Archer
 -   [Elephant](https://thenounproject.com/Luis/uploads/?i=14048) By Luis Prado for War Elephant
--   [Centaur](https://thenounproject.com/search/?q=horse+archer&i=1791296) by Michael Wohlwend for Horse Archer
--   [Spear](https://thenounproject.com/search/?q=Spear&i=11432) By Stephen Copinger for Spearman
--   [Greek shield](https://thenounproject.com/search/?q=hoplite&i=440135) for Hoplite
+-   [Centaur](https://thenounproject.com/icon/horse+archer-1791296) by Michael Wohlwend for Horse Archer
+-   [Spear](https://thenounproject.com/icon/Spear-11432) By Stephen Copinger for Spearman
+-   [Greek shield](https://thenounproject.com/icon/hoplite-440135) for Hoplite
 -   [ram](https://thenounproject.com/icon/ram-3971194/) by Becris for Battering Ram
 -   [Spear](https://thenounproject.com/term/spear/313412/) by lastspark for Marauder
 -   [Spiked club](https://thenounproject.com/search/?q=club%20weapon&creator=1933477&i=831794) for Brute
@@ -65,65 +65,65 @@ Unless otherwise specified, all the following are from [the Noun Project](https:
 
 #### Classical Era
 
--   [Catapult](https://thenounproject.com/search/?q=Spear&i=1233840) By Jakub Ukrop
+-   [Catapult](https://thenounproject.com/icon/Spear-1233840) By Jakub Ukrop
 -   [Unloaded Crossbow](https://thenounproject.com/term/unloaded-crossbow/815992/) By Hamish as Ballista
 -   [Bow and arrow](https://thenounproject.com/term/bow-and-arrow/3929618/) By Lars Meiertoberens for Composite Bowman
--   [Sword](https://thenounproject.com/search/?q=Sword&i=1215443) By Guilherme Furtado for Swordsman
--   [Mohawk](https://thenounproject.com/search/?q=mohawk&i=1426649) By Dairy Free Design for Mohawk Warrior
--   [Roman Helmet](https://thenounproject.com/search/?q=legion&i=440134) By parkjisun for Legion
--   [Horse](https://thenounproject.com/search/?q=Horse&i=1373793) By AFY Studio for Horseman
--   [Horse Head](https://thenounproject.com/search/?q=Cavalry&i=374037) By Juan Pablo Bravo for Companion Cavalry
+-   [Sword](https://thenounproject.com/icon/Sword-1215443) By Guilherme Furtado for Swordsman
+-   [Mohawk](https://thenounproject.com/icon/mohawk-1426649) By Dairy Free Design for Mohawk Warrior
+-   [Roman Helmet](https://thenounproject.com/icon/legion-440134) By parkjisun for Legion
+-   [Horse](https://thenounproject.com/icon/Horse-1373793) By AFY Studio for Horseman
+-   [Horse Head](https://thenounproject.com/icon/Cavalry-374037) By Juan Pablo Bravo for Companion Cavalry
 -   [Elephant](https://thenounproject.com/term/elephant/1302749) By Angriawan Ditya Zulkarnain for African Forest Elephant. The original work has been modified.
--   [Horse](https://thenounproject.com/search/?q=horse&i=3270758) By Ranah Pixel Studio for Cataphract
+-   [Horse](https://thenounproject.com/icon/horse-3270758) By Ranah Pixel Studio for Cataphract
 
 #### Medieval Era
 
 -   [Ship](https://thenounproject.com/term/ship/1998589/) By Vanisha for Galleass
 -   [Crossbow](https://thenounproject.com/term/crossbow/965389/) By Creaticca Creative Agency for Crossbowman
--   [Longbow](https://thenounproject.com/search/?q=longbow&i=815991) By Hamish for Longbowman
--   [Trebuchet](https://thenounproject.com/search/?q=trebuchet&i=828475) By Ben Davis
--   [Sword](https://thenounproject.com/search/?q=Sword&i=1432662) By uzeir syarief for Longswordsman
--   [Samurai](https://thenounproject.com/search/?q=samurai&i=1683729) By Chanut is Industries
--   [Spear](https://thenounproject.com/search/?q=Spear&i=1233840) By Alvaro Cabrera for Pikeman
+-   [Longbow](https://thenounproject.com/icon/longbow-815991) By Hamish for Longbowman
+-   [Trebuchet](https://thenounproject.com/icon/trebuchet-828475) By Ben Davis
+-   [Sword](https://thenounproject.com/icon/Sword-1432662) By uzeir syarief for Longswordsman
+-   [Samurai](https://thenounproject.com/icon/samurai-1683729) By Chanut is Industries
+-   [Spear](https://thenounproject.com/icon/Spear-1233840) By Alvaro Cabrera for Pikeman
 -   [Halberd](https://thenounproject.com/naripuru/uploads/?i=440128) parkjisun for Landsknecht
--   [Knight](https://thenounproject.com/search/?q=Knight&i=30912) By Tyler Glaude
+-   [Knight](https://thenounproject.com/icon/Knight-30912) By Tyler Glaude
 
 #### Renaissance Era
 
 -   [Portuguese Caravel](https://thenounproject.com/icon/portuguese-caravel-1626301/) by Zack McCune for Caravel
--   [Cannon](https://thenounproject.com/search/?q=Cannon&i=1618747) By Orin Zuu
--   [Musket](https://thenounproject.com/search/?q=Musket&i=298302) By Cezary Lopacinski for Musketman
--   [Tarbouche](https://thenounproject.com/search/?q=turkish%20hat&i=245391) By Mohamed Amine for Janissary
+-   [Cannon](https://thenounproject.com/icon/Cannon-1618747) By Orin Zuu
+-   [Musket](https://thenounproject.com/icon/Musket-298302) By Cezary Lopacinski for Musketman
+-   [Tarbouche](https://thenounproject.com/icon/turkish%20hat-245391) By Mohamed Amine for Janissary
 -   [Black powder musket](https://thenounproject.com/term/black-powder-musket/1202078/) By Jarem Fyre for Minuteman
--   [Rapier](https://thenounproject.com/search/?q=musketeer&i=819822) By Hamish for Musketeer
+-   [Rapier](https://thenounproject.com/icon/musketeer-819822) By Hamish for Musketeer
 -   [Ship](https://thenounproject.com/term/ship/1293899/) By Orin Zuu for Frigate
--   [Pirate](https://thenounproject.com/search/?q=pirate&i=2349496) by Berkah Icon for Privateer
--   [Pirate](https://thenounproject.com/search/?q=frigate&i=3447522) by Smalllike for Sea Beggar\*
--   [Ship](https://thenounproject.com/search/?q=ship&i=800131) By Mungang Kim for Ship of the Line
--   [Lance](https://thenounproject.com/search/?q=Lance&i=440122) By parkjisun for Lancer
--   [Sword](https://thenounproject.com/search/?q=saber&i=1174742) By Daniela Baptista for Sipahi
+-   [Pirate](https://thenounproject.com/icon/pirate-2349496) by Berkah Icon for Privateer
+-   [Pirate](https://thenounproject.com/icon/frigate-3447522) by Smalllike for Sea Beggar\*
+-   [Ship](https://thenounproject.com/icon/ship-800131) By Mungang Kim for Ship of the Line
+-   [Lance](https://thenounproject.com/icon/Lance-440122) By parkjisun for Lancer
+-   [Sword](https://thenounproject.com/icon/saber-1174742) By Daniela Baptista for Sipahi
 -   [Helmet](https://thenounproject.com/term/helmet/1514355/) by Robert Bjurshagen for Hakkapeliitta
 
 #### Industrial Era
 
--   [Rifle](https://thenounproject.com/search/?q=Rifle&i=604291) By Chameleon Design for Rifleman
+-   [Rifle](https://thenounproject.com/icon/Rifle-604291) By Chameleon Design for Rifleman
 -   [Bayonet](https://thenounproject.com/term/bayonet/3101681/) By food lover for Carolean
 -   [military cap](https://thenounproject.com/icon/military-cap-4112703/) by Robert Bjurshagen for Mehal Sefari
--   [Horse](https://thenounproject.com/search/?q=Horse&i=1023745) By Bakunetso Kaito for Cavalry
+-   [Horse](https://thenounproject.com/icon/Horse-1023745) By Bakunetso Kaito for Cavalry
 -   [horse racing](https://thenounproject.com/antimso/uploads/?i=2427932) By Sergio Morozov for Cossack
 -   [Marching Band](https://thenounproject.com/term/marching-band/871426/) by Darrin Loeliger, US for Hussar. The original work has been modified.
--   [Artillery](https://thenounproject.com/search/?q=Artillery&i=1165261) By Creative Mania
+-   [Artillery](https://thenounproject.com/icon/Artillery-1165261) By Creative Mania
 -   [Ship](https://thenounproject.com/term/ship/1594793/) By Aisyah for Ironclad
 
 #### Modern Era
 
--   [Submarine](https://thenounproject.com/search/?q=submarine&i=589519) By Hea Poh Lin, MY
+-   [Submarine](https://thenounproject.com/icon/submarine-589519) By Hea Poh Lin, MY
 -   [Helmet](https://thenounproject.com/term/helmet/25216/) By Daniel Turner for Great War Infantry
--   [Cap](https://thenounproject.com/search/?q=kepi&i=950267) By Creative Mania for Foreign Legion
+-   [Cap](https://thenounproject.com/icon/kepi-950267) By Creative Mania for Foreign Legion
 -   [xm8](https://thenounproject.com/term/xm8/172007/) By Xela Ub for Infantry
 -   Icon for Carrier made by [JackRainy](https://github.com/JackRainy), based on [Aircraft Carrier](https://thenounproject.com/icolabs/collection/flat-icons-transport/?i=2332914) By IcoLabs, BR
--   [Battleship](https://thenounproject.com/search/?q=battleship&i=1986807) By Vitaliy Gorbachev, KZ for Battleship
--   [machine-gun](https://thenounproject.com/search/?q=machine%20gun&i=591058) By Joana Pereira for Machine Gun
+-   [Battleship](https://thenounproject.com/icon/battleship-1986807) By Vitaliy Gorbachev, KZ for Battleship
+-   [machine-gun](https://thenounproject.com/icon/machine%20gun-591058) By Joana Pereira for Machine Gun
 -   [artillery](https://www.vectorstock.com/royalty-free-vector/flat-icon-design-collection-anti-aircraft-gun-vector-16396060) by Izwar Muis for Anti-Aircraft Gun
 -   [Tank](https://thenounproject.com/term/tank/1287510/) By corpus delicti for Landship
 -   [Warship](https://thenounproject.com/term/warship/1597474/) By zidney for Destroyer
@@ -132,19 +132,19 @@ Unless otherwise specified, all the following are from [the Noun Project](https:
 
 -   [Water Gun](https://thenounproject.com/term/water-gun/2121571) by ProSymbols for Marine
 -   [Parachute](https://thenounproject.com/term/parachute/2025018) by Nociconist for Paratrooper
--   [Tank](https://thenounproject.com/search/?q=tank&i=981914) By jeff for Tank
+-   [Tank](https://thenounproject.com/icon/tank-981914) By jeff for Tank
 -   [Tank](https://thenounproject.com/manueldixken/collection/german-tanks/?i=960769) Manuel Dixken, DE for Panzer
 -   [Anti-Tank Gun](https://thenounproject.com/term/anti-tank-gun/1802450/) By Tom Fricker
--   [atomic bomb](https://thenounproject.com/search/?q=atomic+bomb&i=3712713) by AmruID for Atomic Bomb
--   [Military vehicle](https://thenounproject.com/search/?q=Army%20rocket&i=23115) By Luke Anthony Firth For Rocket Artillery
+-   [atomic bomb](https://thenounproject.com/icon/atomic+bomb-3712713) by AmruID for Atomic Bomb
+-   [Military vehicle](https://thenounproject.com/icon/Army%20rocket-23115) By Luke Anthony Firth For Rocket Artillery
 -   [Missile](https://thenounproject.com/term/missile/2311325/) By Eucalyp for Mobile SAM
 
 #### Information Era
 
 -   [Submarine](https://www.flaticon.com/free-icon/submarine_1534201) by Freepik adapted for Nuclear Submarine
--   [APC](https://thenounproject.com/search/?q=apc&i=9965) By Luke Anthony Firth for Mechanized Infantry
--   [Battleship](https://thenounproject.com/search/?q=battleship&i=3441862) by Edi Prastyo for Missile Cruiser
--   [Modern Armor](https://thenounproject.com/search/?q=tank&i=218) By Public Domain Nouns for Modern Armor
+-   [APC](https://thenounproject.com/icon/apc-9965) By Luke Anthony Firth for Mechanized Infantry
+-   [Battleship](https://thenounproject.com/icon/battleship-3441862) by Edi Prastyo for Missile Cruiser
+-   [Modern Armor](https://thenounproject.com/icon/tank-218) By Public Domain Nouns for Modern Armor
 -   [Nuclear Missile](https://thenounproject.com/marialuisa.iborra/collection/missiles-bombs/?i=1022574) By Lluisa Iborra, ES
 -   [Robot](https://thenounproject.com/term/robot/1182459/) by Lluisa Iborra, ES for Giant Death Robot
 -   [Missile](https://thenounproject.com/term/missile/799922/) By ProSymbols for SS Booster
@@ -154,12 +154,12 @@ Unless otherwise specified, all the following are from [the Noun Project](https:
 
 #### All Eras
 
--   [Pallet](https://thenounproject.com/search/?q=Pallet&i=6862) By James Keuning for Great Artist
--   [Gear](https://thenounproject.com/search/?q=Gear&i=17369) By Melvin Salas for Great Engineer
--   [Beaker](https://thenounproject.com/search/?q=Beaker&i=621510) By Delwar Hossain for Great Scientist
--   [Dove](https://thenounproject.com/search/?q=dove&i=1344088) by sandra for Great Prophet
--   [General](https://thenounproject.com/search/?q=general&i=933566) By anbileru adaleru for Great General
--   [Religion](https://thenounproject.com/search/?q=preach&i=53064) by Bruno Gätjens González adapted for Missionary
+-   [Pallet](https://thenounproject.com/icon/Pallet-6862) By James Keuning for Great Artist
+-   [Gear](https://thenounproject.com/icon/Gear-17369) By Melvin Salas for Great Engineer
+-   [Beaker](https://thenounproject.com/icon/Beaker-621510) By Delwar Hossain for Great Scientist
+-   [Dove](https://thenounproject.com/icon/dove-1344088) by sandra for Great Prophet
+-   [General](https://thenounproject.com/icon/general-933566) By anbileru adaleru for Great General
+-   [Religion](https://thenounproject.com/icon/preach-53064) by Bruno Gätjens González adapted for Missionary
 -   [invisibility cloak ](https://thenounproject.com/term/invisibility-cloak/1419648/) by Locad for Inquisitor
 
 ### Resources
@@ -185,14 +185,14 @@ Unless otherwise specified, all the following are from [the Noun Project](https:
 -   [Cattle](https://thenounproject.com/term/cattle/781342/) By Daniela Baptista
 -   [Leather](https://thenounproject.com/term/leather/16499/) By Alen Krummenacher for Furs
 -   [Gem](https://thenounproject.com/term/gem/948920/) By Lluisa Iborra
--   [Joss Stick](https://thenounproject.com/search/?q=incense&i=583033) By Hea Poh Lin for Incense
+-   [Joss Stick](https://thenounproject.com/icon/incense-583033) By Hea Poh Lin for Incense
 -   [Pottery](https://thenounproject.com/term/pottery/2317144/) By Laymik, UA for Porcelain
 -   [Jewelry](https://thenounproject.com/term/jewelry/3688098/) By Shocho, IN
--   [Lemons](https://thenounproject.com/search/?q=lemon&i=4147611) By sachin modgekar, IN for Citrus
--   [Pipes](https://thenounproject.com/search/?q=pipes&i=1637792) By Nibras@design for Copper
--   [Crab](https://thenounproject.com/search/?q=crab&i=246420) By YuguDesign
--   [Truffle](https://thenounproject.com/search/?q=Truffles&i=1576609) By parkjisun
--   [Salt](https://thenounproject.com/search/?q=salt&i=3614173) By HAMEL KHALED, DZ
+-   [Lemons](https://thenounproject.com/icon/lemon-4147611) By sachin modgekar, IN for Citrus
+-   [Pipes](https://thenounproject.com/icon/pipes-1637792) By Nibras@design for Copper
+-   [Crab](https://thenounproject.com/icon/crab-246420) By YuguDesign
+-   [Truffle](https://thenounproject.com/icon/Truffles-1576609) By parkjisun
+-   [Salt](https://thenounproject.com/icon/salt-3614173) By HAMEL KHALED, DZ
 
 ### Improvements
 
@@ -211,11 +211,11 @@ Unless otherwise specified, all the following are from [the Noun Project](https:
 -   [Ruins](https://thenounproject.com/term/ruins/175277/) By Creative Stall for Ancient runs
 -   [Ruins](https://thenounproject.com/term/ruins/3849/) By Paulo Volkova for City ruins
 -   [Fishing Net](https://thenounproject.com/term/fishing-net/1073133/) By Made for Fishing Boats
--   [Moai](https://thenounproject.com/search/?q=moai&i=2878111) By Template
+-   [Moai](https://thenounproject.com/icon/moai-2878111) By Template
 -   [Fort](https://thenounproject.com/term/fort/1697645/) By Adrien Coquet
 -   [Citadel](https://thenounproject.com/term/fort/1697646/) By Adrien Coquet
--   [Village](https://thenounproject.com/search/?q=city+center&i=476338) by Andrey Vasiliev
--   [pumping station](https://thenounproject.com/search/?q=dike&i=555172) by Peter van Driel for Polder
+-   [Village](https://thenounproject.com/icon/city+center-476338) by Andrey Vasiliev
+-   [pumping station](https://thenounproject.com/icon/dike-555172) by Peter van Driel for Polder
 -   [Oil Platform](https://thenounproject.com/icon/oil-platform-1364795/) by Georgiana Ionescu for Offshore Platform
 -   [Broom](https://thenounproject.com/icon/broom-1642644/) by Rakhmat Setiawan for Remove Fallout
 -   [Axe](https://www.flaticon.com/ru/free-icon/axe_803805) by Those Icons for Remove Forest and Remove Jungle
@@ -230,45 +230,45 @@ Unless otherwise specified, all the following are from [the Noun Project](https:
 #### Ancient Era
 
 -   [Storehouse](https://thenounproject.com/term/storehouse/966786/) By Pedro Santos for Granary
--   [Shinto Gate](https://thenounproject.com/search/?q=shrine&i=253325) by Alexander Skowalsky for Shrine
+-   [Shinto Gate](https://thenounproject.com/icon/shrine-253325) by Alexander Skowalsky for Shrine
 -   [Pyramid](https://thenounproject.com/term/pyramid/17225/) by Oscar Yáñez for Mayan Pyramid
 -   [Great Wall Of China](https://thenounproject.com/term/great-wall-of-china/146039/) By Arthur Shlain for Walls
--   [Markadan Tower](https://thenounproject.com/search/?q=fortification&i=2107694) by Vectors Market for Walls of Babylon
+-   [Markadan Tower](https://thenounproject.com/icon/fortification-2107694) by Vectors Market for Walls of Babylon
 -   [Block](https://thenounproject.com/term/block/1711553/) By Monjin Friends for Stone Works
 -   [korean palace](https://thenounproject.com/term/korean-palace/1797542/) By 1516 for Palace
 -   [Obelisk](https://thenounproject.com/term/obelisk/749104/) By Eliricon for Monument
 -   [obelisk](https://thenounproject.com/term/obelisk/3520415/) By IconMark for Stele
 -   [Cross swords](https://thenounproject.com/term/cross-swords/965398/) By Creaticca Creative Agency for Barracks
--   [Fortress](https://thenounproject.com/search/?q=fortress&i=146989) By Creative Stall for Krepost
+-   [Fortress](https://thenounproject.com/icon/fortress-146989) By Creative Stall for Krepost
 -   [WaterMill](https://thenounproject.com/icon/watermill-4255/) by Jakub Ukrop for Water Mill
 -   [Paper](https://thenounproject.com/term/paper/1443472/) By anam
 -   [Circus](https://thenounproject.com/term/circus/743734/) By Ralph Schmitzer
 -   [Stonehenge](https://thenounproject.com/term/stonehenge/543289/) By icon 54
 -   [Ho Chi Minh mausoleum](https://thenounproject.com/thanhloc1009/collection/asia-landmark/?i=2412921) By Phạm Thanh Lộc for Mausoleum of Halicarnassus
 -   Icon for Statue of Zeus made by [JackRainy](https://github.com/JackRainy), based on [King](https://thenounproject.com/eucalyp/collection/game-elements-glyph1/?i=3155251) By Eucalyp
--   [temple](https://thenounproject.com/search/?q=temple&i=28256) By Fabio Meroni for Temple of Artemis
+-   [temple](https://thenounproject.com/icon/temple-28256) By Fabio Meroni for Temple of Artemis
 
 #### Classical Era
 
--   [Lighthouse](https://thenounproject.com/search/?q=lighthouse&i=866966) By Dolly Holmes
+-   [Lighthouse](https://thenounproject.com/icon/lighthouse-866966) By Dolly Holmes
 -   [Lighthouse](https://thenounproject.com/term/lighthouse/583069/) By Hea Poh Lin for The Great Lighthouse
 -   [Temple](https://thenounproject.com/term/temple/1808407/) By 1516
 -   [Anubis](https://thenounproject.com/term/anubis/1080090/) By Carpe Diem for Burial Tomb
 -   [Parthenon](https://thenounproject.com/term/parthenon/493272/) By Christopher T. Howlett for The Oracle
 -   [Stadium](https://thenounproject.com/term/stadium/1500595/) By sandra for Colosseum
--   [Terracotta Army](https://thenounproject.com/search/?q=terracotta&i=2412905) By Phạm Thanh Lộc
+-   [Terracotta Army](https://thenounproject.com/icon/terracotta-2412905) By Phạm Thanh Lộc
 -   [Stadium](https://thenounproject.com/term/stadium/1152530/) By Creaticca Creative Agency for Circus Maximus
 -   [Market](https://thenounproject.com/term/market/1723050/) By sofi
 -   [Bazaar](https://thenounproject.com/term/bazaar/902288/) By Tokka Elkholy
 -   [Shekel Coin](https://thenounproject.com/term/shekel-coin/204154/) By Till Teenck for Mint
 -   [Aqueduct](https://thenounproject.com/term/aqueduct/24639/) By Arthur Shlain
--   [Great Wall](https://thenounproject.com/search/?q=great%20wall&i=545909) By icon 54
+-   [Great Wall](https://thenounproject.com/icon/great%20wall-545909) By icon 54
 -   [Rice Field](https://thenounproject.com/term/rice-field/2511648/) by Graphic Engineer for Terrace farm
 -   [Canoe](https://thenounproject.com/term/canoe/402285/) By Viktor Fedyuk (Tim P) for Floating Gardens
--   [Arc de Triomphe](https://thenounproject.com/search/?q=Arc+de+Triomphe&i=789893) By Andrejs Kirma, LV for National Epic
+-   [Arc de Triomphe](https://thenounproject.com/icon/Arc+de+Triomphe-789893) By Andrejs Kirma, LV for National Epic
 -   [Bank](https://thenounproject.com/term/bank/213472/) by By P Thanga Vignesh for National Treasury
--   [Judge](https://thenounproject.com/search/?q=judge&i=1076388) By Krisztián Mátyás for Courthouse
--   [Petra](https://thenounproject.com/search/?q=petra&i=2855893) By Ranah Pixel Studio for Petra
+-   [Judge](https://thenounproject.com/icon/judge-1076388) By Krisztián Mátyás for Courthouse
+-   [Petra](https://thenounproject.com/icon/petra-2855893) By Ranah Pixel Studio for Petra
 
 #### Medieval Era
 
@@ -276,23 +276,23 @@ Unless otherwise specified, all the following are from [the Noun Project](https:
 -   [Wat Arun Ratchawararam Ratchawaramahawihan](https://thenounproject.com/term/wat-arun-ratchawararam-ratchawaramahawihan/320664/) By József Balázs-Hegedüs for Wat
 -   [College](https://thenounproject.com/term/college/1203703/) By Vectors Market for National College
 -   [Chichen Itza](https://thenounproject.com/term/chichen-itza/668065/) By Hea Poh Lin
--   [Castle](https://thenounproject.com/search/?q=castle&i=390189) By Mint Shirt
+-   [Castle](https://thenounproject.com/icon/castle-390189) By Mint Shirt
 -   [Red Fort](https://thenounproject.com/arunabh.jain.0fficial/collection/famous-indian-monuments/?i=2092466), [Gateway of India](https://thenounproject.com/arunabh.jain.0fficial/collection/famous-indian-monuments/?i=2092468) By Arunabh Jain, IN for Mughal Fort
--   [Angkor Wat](https://thenounproject.com/search/?q=angkor%20wat&i=2412873) By Phạm Thanh Lộc for Angkor Wat
--   [Alhambra](https://thenounproject.com/search/?q=alhambra&i=2322217) By Phạm Thanh Lộc
+-   [Angkor Wat](https://thenounproject.com/icon/angkor%20wat-2412873) By Phạm Thanh Lộc for Angkor Wat
+-   [Alhambra](https://thenounproject.com/icon/alhambra-2322217) By Phạm Thanh Lộc
 -   [Books](https://thenounproject.com/term/books/1140218/) By Abir Alward for Oxford University
 -   Icon for Heroic Epic made by [SomeTroglodyte](https://github.com/SomeTroglodyte) based on [Iwo Jima Memorial](https://upload.wikimedia.org/wikipedia/commons/5/54/2018-10-31_15_25_21_The_west_side_of_the_Marine_Corps_War_Memorial_in_Arlington_County%2C_Virginia.jpg) photo taken by Famartin
 -   [Forge](https://thenounproject.com/term/forge/1044767/) By Monjin Friends
 -   [Anchor](https://thenounproject.com/term/anchor/1258518/) By Saeful Muslim for Harbor
 -   [Hand saw](https://thenounproject.com/term/hand-saw/990902/) By b farias for Workshop
--   [House](https://thenounproject.com/search/?q=house&i=1651759) By sofy for Longhouse
+-   [House](https://thenounproject.com/icon/house-1651759) By sofy for Longhouse
 -   [Hagia Sophia](https://thenounproject.com/term/hagia-sophia/1907752/) By Felipe Alvarado
 -   [Factory](https://thenounproject.com/term/factory/1624235/) By Maxim Kulikov for Ironworks
 -   [Notre Dame](https://thenounproject.com/term/notre-dame/1361725/) By Marco Livolsi
 -   [Shield and Swords](https://thenounproject.com/term/shield-and-swords/1477527/) By Alina Oleynik for Armory
 -   [Machu Picchu](https://thenounproject.com/browse/?i=1678226/) By [Chanut is Industries](https://thenounproject.com/chanut-is)
--   [Garden](https://thenounproject.com/search/?q=garden&i=1478380) By Bharat
--   [Mosque](https://thenounproject.com/search/?q=mosque&i=2458353) by yanti for Great Mosque of Djenne
+-   [Garden](https://thenounproject.com/icon/garden-1478380) By Bharat
+-   [Mosque](https://thenounproject.com/icon/mosque-2458353) by yanti for Great Mosque of Djenne
 
 #### Renaissance Era
 
@@ -301,8 +301,8 @@ Unless otherwise specified, all the following are from [the Noun Project](https:
 -   [The Louvre](https://thenounproject.com/term/the-louvre/1577539/) By roundicons.com
 -   [Forbidden City](https://thenounproject.com/term/forbidden-city/1797540/) By 1516
 -   [Theatre](https://thenounproject.com/term/theatre/1780401/) By b farias
--   [Tower of Pisa](https://thenounproject.com/search/?q=leaning%20tower%20of%20pisa&i=1002578) By Pedro Santos
--   [Himeji Castle](https://thenounproject.com/search/?q=himeji&i=1125277) By Chanut is Industries
+-   [Tower of Pisa](https://thenounproject.com/icon/leaning%20tower%20of%20pisa-1002578) By Pedro Santos
+-   [Himeji Castle](https://thenounproject.com/icon/himeji-1125277) By Chanut is Industries
 -   [Windmill](https://thenounproject.com/term/windmill/1705107/) By corpus delicti
 -   [Coffee](https://thenounproject.com/term/coffee/3954451/) by SURYANI, ID for Coffee House
 -   [Taj Mahal](https://thenounproject.com/term/taj-mahal/1907755/) By Felipe Alvarado
@@ -313,7 +313,7 @@ Unless otherwise specified, all the following are from [the Noun Project](https:
 -   [Harbor](https://thenounproject.com/term/harbor/225583/) By Rflor for Seaport
 -   [Mansion](https://www.flaticon.com/free-icon/mansion_509903#term=persian&page=1&position=19) by Freepik for Satrap's Court
 -   [Bullets](https://thenounproject.com/term/bullets/810156/) By Aldric Rodriguez for Arsenal
--   [St. Petersburg](https://thenounproject.com/search/?q=kremlin&i=1569704) By Carpe Diem for Kremlin
+-   [St. Petersburg](https://thenounproject.com/icon/kremlin-1569704) By Carpe Diem for Kremlin
 -   [cottage](https://thenounproject.com/icon/cottage-16478/) by Ole Sturm for Ceilidh Hall
 
 #### Industrial Era
@@ -328,41 +328,41 @@ Unless otherwise specified, all the following are from [the Noun Project](https:
 
 -   [Stadium](https://thenounproject.com/term/stadium/13872/) By Karuna Lalvani
 -   [Signal Tower](https://thenounproject.com/term/signal-tower/1547758/) By Nociconist for Broadcast Tower
--   [Hangar](https://thenounproject.com/search/?q=hangar&i=1705288) By Rflor for Military Base
+-   [Hangar](https://thenounproject.com/icon/hangar-1705288) By Rflor for Military Base
 -   [Eiffel Tower](https://thenounproject.com/term/eiffel-tower/1907757/) By Felipe Alvarado
--   [Statue of Liberty](https://thenounproject.com/search/?q=statue%20of%20liberty&i=1801199) By 1516
+-   [Statue of Liberty](https://thenounproject.com/icon/statue%20of%20liberty-1801199) By 1516
 -   [Microscope](https://thenounproject.com/term/microscope/1452362/) By Arafat Uddin for Research Lab
 -   [Christ the redeemer](https://thenounproject.com/term/christ-the-redeemer/56112/) By Stefan Spieler for Cristo Redentor
--   [Neuschwanstein](https://thenounproject.com/search/?q=Neuschwanstein&i=2107683) By Vectors Market
--   [Big Ben](https://thenounproject.com/search/?q=Big%20Ben&i=443690) By Ben Davis, RO
+-   [Neuschwanstein](https://thenounproject.com/icon/Neuschwanstein-2107683) By Vectors Market
+-   [Big Ben](https://thenounproject.com/icon/Big%20Ben-443690) By Ben Davis, RO
 
 #### Atomic Era
 
 -   [Chemistry](https://thenounproject.com/term/chemistry/175847/) By Creative Stall for Medical Lab
--   [Pentagon](https://thenounproject.com/search/?q=the%20pentagon&i=1788323) By Maxim Kulikov
+-   [Pentagon](https://thenounproject.com/icon/the%20pentagon-1788323) By Maxim Kulikov
 -   [Solar panel](https://thenounproject.com/term/solar-panel/1131/) By Modik for Solar Plant
--   [Recycle](https://thenounproject.com/search/?q=recycling&i=4397434) By Umer Younas, PK for Recycling Center
+-   [Recycle](https://thenounproject.com/icon/recycling-4397434) By Umer Younas, PK for Recycling Center
 -   [Opera House Sydney](https://thenounproject.com/term/opera-house-sydney/1626283/) By Pham Duy Phuong Hung for Sydney Opera House
 -   [hydro electric plant](https://thenounproject.com/term/water-dam/1002726/) By Juicy Fish for Hydro Plant
--   [Manhattan Project](https://thenounproject.com/search/?q=Nuclear%20Bomb&i=2041074) By corpus delicti, GR
+-   [Manhattan Project](https://thenounproject.com/icon/Nuclear%20Bomb-2041074) By corpus delicti, GR
 -   [Nuclear Plant](https://thenounproject.com/term/nuclear-plant/1132340/) By Andrejs Kirma
 -   [Spaceship](https://thenounproject.com/term/spaceship/1444621/) By Dinosoft Labs for Apollo Program
 
 #### Information Era
 
--   [CN Tower Toronto](https://thenounproject.com/search/?q=cn%20tower&i=807678) By mikicon for CN tower
+-   [CN Tower Toronto](https://thenounproject.com/icon/cn%20tower-807678) By mikicon for CN tower
 -   [War Shelter](https://www.flaticon.com/free-icon/war-shelter_978661) by [Frepik](https://www.freepik.com) for Bomb Shelter
--   [Hubble Telescope](https://thenounproject.com/search/?q=hubble%20space&i=445502) By Scott Lewis for Hubble Space Telescope
+-   [Hubble Telescope](https://thenounproject.com/icon/hubble%20space-445502) By Scott Lewis for Hubble Space Telescope
 -   [Build](https://thenounproject.com/term/build/1156478/) By Michael G Brown for Spaceship Factory
--   [United Nations](https://thenounproject.com/search/?q=united+nations&i=3104698) by Imam for United Nations
+-   [United Nations](https://thenounproject.com/icon/united+nations-3104698) by Imam for United Nations
 
 #### All Era's
 
 -   [Illuminati](https://thenounproject.com/term/illuminati/1617812) by emilegraphics for the Utopia Project
 -   [Christian Church](https://thenounproject.com/term/christian-church/1174183/) by Andrejs Kirma for Monastery
--   [cathedral](https://thenounproject.com/search/?q=Cathedral&i=4136407) by Pixel Bazaar for Cathedral
--   [Mosque](https://thenounproject.com/search/?q=mosque&i=1744106) by yanti for Mosque
--   [Pagoda](https://thenounproject.com/search/?q=pagoda&i=446665) by Xinh Studio for Pagoda
+-   [cathedral](https://thenounproject.com/icon/Cathedral-4136407) by Pixel Bazaar for Cathedral
+-   [Mosque](https://thenounproject.com/icon/mosque-1744106) by yanti for Mosque
+-   [Pagoda](https://thenounproject.com/icon/pagoda-446665) by Xinh Studio for Pagoda
 
 ### Social Policies
 
@@ -484,7 +484,7 @@ Unless otherwise specified, all the following are from [the Noun Project](https:
 -   [Casting](https://thenounproject.com/term/casting/10773/) By Jasmine Rae Friedrich
 -   [Bar association](https://thenounproject.com/term/bar-association/217443/) By Miroslav Kurdov for Guilds
 -   [Knight](https://thenounproject.com/term/knight/1026633/) By Robert Bjurshagen for Chivalry
--   [Camel](https://thenounproject.com/search/?q=camel&i=1210751) By Orin Zuu for Camel Archer
+-   [Camel](https://thenounproject.com/icon/camel-1210751) By Orin Zuu for Camel Archer
 -   [Machinery](https://thenounproject.com/term/machinery/1170931/) By Greenhill
 -   [Lever](https://thenounproject.com/term/lever/4927/) By Jakob Ukrop for Physics
 -   [Sword](https://thenounproject.com/term/sword/1365080/) By Jonathan P Lambert for Steel
@@ -499,7 +499,7 @@ Unless otherwise specified, all the following are from [the Noun Project](https:
 -   [Fossil](https://thenounproject.com/term/fossil/168650/) By Raf Verbraeken for Archaeology
 -   [Sextant](https://thenounproject.com/term/sextant/313438/) By lastspark for Navigation
 -   [Architecture](https://thenounproject.com/term/architecture/795297/) By Andrew Doane
--   [Money Growth](https://thenounproject.com/search/?q=economic%20model&i=136159) By DesignNex for Economics
+-   [Money Growth](https://thenounproject.com/icon/economic%20model-136159) By DesignNex for Economics
 -   [Metal Block](https://thenounproject.com/term/metal-bock/1518464/) By Creaticca Creative Agency for Metallurgy
 -   [Chemistry](https://thenounproject.com/term/chemistry/175847/) By Creative Stall
 
@@ -524,13 +524,13 @@ Unless otherwise specified, all the following are from [the Noun Project](https:
 -   [Microphone](https://thenounproject.com/term/microphone/470266/) By Viktor Vorobyev for Mass Media
 -   [Flight](https://thenounproject.com/term/flight/1014306/) By Genius Icons
 -   [Train](https://thenounproject.com/term/train/651644/) By Federico Panzano for Railroad
--   [Fridge](https://thenounproject.com/search/?q=refridgerator&i=1188873) By b farias for Refrigeration
+-   [Fridge](https://thenounproject.com/icon/refridgerator-1188873) By b farias for Refrigeration
 -   [telegraph](https://thenounproject.com/icon/telegraph-22058/) by Luke Anthony Firth for Telegraph\*
 
 #### Atomic
 
 -   [Pill](https://thenounproject.com/term/pill/780458/) By Alex Arseneau for Pharmaceuticals
--   [Satellite Dish](https://thenounproject.com/search/?q=satellite%20dish&i=2054441) By Vectors Market for Radar
+-   [Satellite Dish](https://thenounproject.com/icon/satellite%20dish-2054441) By Vectors Market for Radar
 -   [Ecology](https://thenounproject.com/term/ecology/1970666/) By ProSymbols
 -   [Nuclear Reactor](https://thenounproject.com/term/nuclear-reactor/426463/) By Jeremie Sommet for Nuclear Fission
 -   [Rocket](https://thenounproject.com/term/rocket/1743642/) By kareemov for Rocketry
@@ -538,17 +538,17 @@ Unless otherwise specified, all the following are from [the Noun Project](https:
 
 #### Information
 
--   [telecommunications](https://thenounproject.com/search/?q=telecommunications&i=3191260) by Wichai Wi for Telcommunications
--   [Tactics](https://thenounproject.com/search/?q=tactics&i=2290123) By Grafix Point for Mobile Tactics
+-   [telecommunications](https://thenounproject.com/icon/telecommunications-3191260) by Wichai Wi for Telcommunications
+-   [Tactics](https://thenounproject.com/icon/tactics-2290123) By Grafix Point for Mobile Tactics
 -   [Rocket](https://thenounproject.com/term/rocket/3999811) Kusdarti for Advanced Ballistics
 -   [Satellite](https://thenounproject.com/term/satellite/1466641/) By Ben Davis for Satellites
 -   [Robotic Arm](https://thenounproject.com/term/robotic-arm/1970874/) By Karl Gilbert for Robotics
--   [Laser](https://thenounproject.com/search/?q=laser&i=232249) by Andrew Doane for Lasers
--   [global](https://thenounproject.com/search/?q=globalization&i=4073147) by Rank Sol for Globilization
+-   [Laser](https://thenounproject.com/icon/laser-232249) by Andrew Doane for Lasers
+-   [global](https://thenounproject.com/icon/globalization-4073147) by Rank Sol for Globilization
 -   [Atom](https://thenounproject.com/term/atom/1586852/) By Kelsey Armstrong for Particle Physics
 -   [Nanoparticles](https://thenounproject.com/term/nanoparticles/822286/) By Gyan Lakhwani for Nanotechnology
--   [Thermonuclear fusion](https://thenounproject.com/search/?q=fusion&i=3292735) by Olena Panasovska, UA for Nuclear Fusion
--   [Electronics](https://thenounproject.com/search/?q=Electronics&i=1565843) By Cuby Design
+-   [Thermonuclear fusion](https://thenounproject.com/icon/fusion-3292735) by Olena Panasovska, UA for Nuclear Fusion
+-   [Electronics](https://thenounproject.com/icon/Electronics-1565843) By Cuby Design
 -   [Radar](https://thenounproject.com/term/radar/1546196/) By CINDYFLA, ID for Stealth
 
 #### Future
@@ -560,41 +560,41 @@ Unless otherwise specified, all the following are from [the Noun Project](https:
 -   [Hills](https://thenounproject.com/term/hills/540185/) By Juraj Sedlák
 -   [Mountains](https://thenounproject.com/term/mountains/2062034/) By icon 54
 -   [Forest](https://thenounproject.com/term/forest/1826995/) by Milinda Courey for Jungle
--   [Forest](https://thenounproject.com/search/?q=forest&i=1744681) By Lance B
--   [Palm Tree](https://thenounproject.com/search/?q=palm%20tree&i=366833) By Tatiana for Oasis
+-   [Forest](https://thenounproject.com/icon/forest-1744681) By Lance B
+-   [Palm Tree](https://thenounproject.com/icon/palm%20tree-366833) By Tatiana for Oasis
 -   [Water](https://thenounproject.com/term/water/1762848/) By Kozan for Marsh
 -   [Harvest](https://thenounproject.com/term/harvest/1022373/) By Made for Flood plains
--   [Puddle](https://thenounproject.com/search/?q=puddle&i=1138155) By Bakunetsu Kaito for Lakes
--   [Island](https://thenounproject.com/search/?q=island&i=1546376) By Chanut is Industries for Atoll
--   [Iceberg](https://thenounproject.com/search/?q=iceberg&i=44820) By Jaime Carrion for Ice
+-   [Puddle](https://thenounproject.com/icon/puddle-1138155) By Bakunetsu Kaito for Lakes
+-   [Island](https://thenounproject.com/icon/island-1546376) By Chanut is Industries for Atoll
+-   [Iceberg](https://thenounproject.com/icon/iceberg-44820) By Jaime Carrion for Ice
 
 ### Nations
 
--   [Eye of Horus](https://thenounproject.com/search/?q=eye%20of%20horus&i=92471) By Lilit Kalachyan for Egypt
--   [Russia](https://thenounproject.com/search/?q=russia&i=64137) By Eugen Belyakoff
+-   [Eye of Horus](https://thenounproject.com/icon/eye%20of%20horus-92471) By Lilit Kalachyan for Egypt
+-   [Russia](https://thenounproject.com/icon/russia-64137) By Eugen Belyakoff
 -   [Dragon Head](https://github.com/ravignir/5Hex-Tileset/blob/master/Images/NationIcons/China.png) By Ravignir for China
--   [Lion](https://thenounproject.com/search/?q=lion&i=912735) By parkjisun for Babylon
--   [Omega](https://thenounproject.com/search/?q=omega&i=1925519) By icon 54 for Greece
--   [Shield](https://thenounproject.com/search/?q=American%20shield&i=5825) By Nathan Driskell for America
--   [Fleaur de Lis](https://thenounproject.com/search/?q=fleur%20de&i=78672) By Jessika Gadoury for France
--   [Crown](https://thenounproject.com/search/?q=crown&i=607405) By Peter van Driel for England
--   [Wreath](https://thenounproject.com/search/?q=laurel&i=692545) by VectorBakery or Roman
--   [Iron Cross](https://thenounproject.com/search/?q=iron%20cross&i=373241) By Souvik Maity for Germany
--   [Star and Crecent](https://thenounproject.com/search/?q=star%20and%20crescent&i=2552427) for Arabia
--   [Family Crest Komon](https://thenounproject.com/search/?q=oda&i=2293528) by sahua d for Japan
--   [Ashika Chakra](https://thenounproject.com/search/?q=ashoka%20chakra&i=2328559) by sahua d for India
--   Variation on [crescent moon](https://thenounproject.com/search/?q=crescents&i=1438333) by Estu Suhartono for The Ottomans
--   [Korea](https://thenounproject.com/search/?q=korea&i=1689701) by CJS for Korea
+-   [Lion](https://thenounproject.com/icon/lion-912735) By parkjisun for Babylon
+-   [Omega](https://thenounproject.com/icon/omega-1925519) By icon 54 for Greece
+-   [Shield](https://thenounproject.com/icon/American%20shield-5825) By Nathan Driskell for America
+-   [Fleaur de Lis](https://thenounproject.com/icon/fleur%20de-78672) By Jessika Gadoury for France
+-   [Crown](https://thenounproject.com/icon/crown-607405) By Peter van Driel for England
+-   [Wreath](https://thenounproject.com/icon/laurel-692545) by VectorBakery or Roman
+-   [Iron Cross](https://thenounproject.com/icon/iron%20cross-373241) By Souvik Maity for Germany
+-   [Star and Crecent](https://thenounproject.com/icon/star%20and%20crescent-2552427) for Arabia
+-   [Family Crest Komon](https://thenounproject.com/icon/oda-2293528) by sahua d for Japan
+-   [Ashika Chakra](https://thenounproject.com/icon/ashoka%20chakra-2328559) by sahua d for India
+-   Variation on [crescent moon](https://thenounproject.com/icon/crescents-1438333) by Estu Suhartono for The Ottomans
+-   [Korea](https://thenounproject.com/icon/korea-1689701) by CJS for Korea
 -   Two [Sword](https://www.flaticon.com/free-icon/sword_812259#term=scimitar&page=1&position=2) Scimitars by Those Icons for Persia
 -   [Swirl](https://thenounproject.com/icon/swirl-4040027/) by IronSV for Polynesia
--   [Dharmachakra](https://thenounproject.com/search/?q=dharmachakra&i=740796) by Parkjisun for Siam
+-   [Dharmachakra](https://thenounproject.com/icon/dharmachakra-740796) by Parkjisun for Siam
 -   [Inca](https://github.com/ravignir/5Hex-Tileset/blob/master/Images/NationIcons/Inca.png) by Ravignir for Inca
 -   [Sun symbol black](https://en.wikiquote.org/wiki/File:Sun_symbol_black.svg) by Eddo for The Huns
--   [Lion](https://thenounproject.com/search/?q=lion&i=76154) by Nikki Rodriguez for The Netherlands
--   [Three Crowns](https://thenounproject.com/search/?q=three+crowns&i=1155972) by Daniel Falk for Sweden
+-   [Lion](https://thenounproject.com/icon/lion-76154) by Nikki Rodriguez for The Netherlands
+-   [Three Crowns](https://thenounproject.com/icon/three+crowns-1155972) by Daniel Falk for Sweden
 -   [Flag of Austria](https://thenounproject.com/term/flag-of-austria/3292053/) by Olena Panasovska, UA for Austria. The original work has been modified.
 -   [Elephant](https://thenounproject.com/term/elephant/564421/) by Hea Poh Lin for Carthage. The original work has been modified.
--   [Orthodox Cross](https://thenounproject.com/search/?q=orthodox&i=2069822) by Avana Vana for Byzantium
+-   [Orthodox Cross](https://thenounproject.com/icon/orthodox-2069822) by Avana Vana for Byzantium
 -   [Iroquois](https://github.com/ravignir/5Hex-Tileset/blob/master/Images/NationIcons/Iroquois.png) by Ravignir for Iroquois
 -   [Songhai](https://github.com/ravignir/5Hex-Tileset/blob/master/Images/NationIcons/Songhai.png) by Ravignir for Songhai
 -   [Celtic Knot](https://thenounproject.com/term/celtic/168483/) by Ervin Bolat for the Celts
@@ -610,53 +610,53 @@ Unless otherwise specified, all the following are from [the Noun Project](https:
 
 ### Promotions
 
--   [Sight](https://thenounproject.com/search/?q=sight&i=2631027) By Jejen Juliansyah Nur Agung for Scouting
--   [skill bow rain arrow](https://thenounproject.com/search/?q=rain%20of%20arrows&i=2360192) by Maxicons for Barrage
--   [Bomb](https://thenounproject.com/search/?q=bombardment&i=1705276) By Angelo Troiano for Bombardment
+-   [Sight](https://thenounproject.com/icon/sight-2631027) By Jejen Juliansyah Nur Agung for Scouting
+-   [skill bow rain arrow](https://thenounproject.com/icon/rain%20of%20arrows-2360192) by Maxicons for Barrage
+-   [Bomb](https://thenounproject.com/icon/bombardment-1705276) By Angelo Troiano for Bombardment
 -   [Private E2](https://thenounproject.com/yeongrong.kim.5/collection/miltary-rank/?i=833152) By Yeong Rong Kim for Shock
 -   [Private First Class](https://thenounproject.com/yeongrong.kim.5/collection/miltary-rank/?i=833161) By Yeong Rong Kim for Drill
--   [Medic](https://thenounproject.com/search/?q=medic&i=48740) By Yohann Berger for Medic
--   [City](https://thenounproject.com/search/?q=city&i=2402817) By iconcheese for Siege
--   [Skull and Crossbones](https://thenounproject.com/search/?q=skull%20and%20cross%20bones&i=15526) By Anton Outkine for Coastal Raider
--   [Spear](https://thenounproject.com/search/?q=spear&i=1754184) By Deemak Daksina for Formation
--   [Wall](https://thenounproject.com/search/?q=wall&i=1305174) By Graphic Tigers for Volley
--   [Lightning](https://thenounproject.com/search/?q=lightning&i=1187991) By Mooms for Blitz
--   [Move](https://thenounproject.com/search/?q=move&i=790952) By Sandra for Mobility
--   [accuracy](https://thenounproject.com/search/?q=accuracy&i=2017348) By vigtographics for Targeting
--   [location](https://thenounproject.com/search/?q=location&i=2858979) by Humantech for Accuracy
--   [Plane](https://thenounproject.com/search/?q=plane&i=1875398) By Tran Minh Villageois for Interception / Domain Air
--   [Hammer](https://thenounproject.com/search/?q=hammer&i=854936) by Thengakola for Air Repair
--   [Hook](https://thenounproject.com/search/?q=hook&i=738678) By Yeong Rong Kim for Boarding Party
--   [Leaf](https://thenounproject.com/search/?q=Leaf&i=1627477) By Paul Verhulst for Indirect Fire
--   [Move](https://thenounproject.com/search/?q=move&i=344603) By Muneer A.Safiah for Logistics
--   [Evasion](https://thenounproject.com/search/?q=evasion&i=2013749) By Anna Sophie for Evasion
--   [Interrupt](https://thenounproject.com/search/?q=interrupt&i=366680) by Stephen Plaster for Ambush
--   [Submarine](https://thenounproject.com/search/?q=submarines&i=96833) by Lloyd Humphreys for Wolfpack
--   [Axe](https://thenounproject.com/search/?q=axe&i=14290) by Brian Oppenlander for Woodsman
--   [Competition](https://thenounproject.com/search/?q=move%20fast&i=1743826) by luca fruzza
+-   [Medic](https://thenounproject.com/icon/medic-48740) By Yohann Berger for Medic
+-   [City](https://thenounproject.com/icon/city-2402817) By iconcheese for Siege
+-   [Skull and Crossbones](https://thenounproject.com/icon/skull%20and%20cross%20bones-15526) By Anton Outkine for Coastal Raider
+-   [Spear](https://thenounproject.com/icon/spear-1754184) By Deemak Daksina for Formation
+-   [Wall](https://thenounproject.com/icon/wall-1305174) By Graphic Tigers for Volley
+-   [Lightning](https://thenounproject.com/icon/lightning-1187991) By Mooms for Blitz
+-   [Move](https://thenounproject.com/icon/move-790952) By Sandra for Mobility
+-   [accuracy](https://thenounproject.com/icon/accuracy-2017348) By vigtographics for Targeting
+-   [location](https://thenounproject.com/icon/location-2858979) by Humantech for Accuracy
+-   [Plane](https://thenounproject.com/icon/plane-1875398) By Tran Minh Villageois for Interception / Domain Air
+-   [Hammer](https://thenounproject.com/icon/hammer-854936) by Thengakola for Air Repair
+-   [Hook](https://thenounproject.com/icon/hook-738678) By Yeong Rong Kim for Boarding Party
+-   [Leaf](https://thenounproject.com/icon/Leaf-1627477) By Paul Verhulst for Indirect Fire
+-   [Move](https://thenounproject.com/icon/move-344603) By Muneer A.Safiah for Logistics
+-   [Evasion](https://thenounproject.com/icon/evasion-2013749) By Anna Sophie for Evasion
+-   [Interrupt](https://thenounproject.com/icon/interrupt-366680) by Stephen Plaster for Ambush
+-   [Submarine](https://thenounproject.com/icon/submarines-96833) by Lloyd Humphreys for Wolfpack
+-   [Axe](https://thenounproject.com/icon/axe-14290) by Brian Oppenlander for Woodsman
+-   [Competition](https://thenounproject.com/icon/move%20fast-1743826) by luca fruzza
 -   Icon for Flight Deck is made by [JackRainy](https://github.com/JackRainy)
 -   Icon for Armor Plating is made by [JackRainy](https://github.com/JackRainy)
 -   [Slingshot](https://thenounproject.com/term/slingshot/9106/) by James Keuning for Slinger Withdraw
 -   [Anchor](https://thenounproject.com/term/anchor/676586) by Gregor Cresnar for Amphibious / Domain Water
--   [survival knife](https://thenounproject.com/search/?q=survival&i=2663392) by b faris for Survivalism
+-   [survival knife](https://thenounproject.com/icon/survival-2663392) by b faris for Survivalism
 -   [Shamrock](https://thenounproject.com/term/shamrock/358507/) By P Thanga Vignesh for Pictish Courage
 -   [home sweet home](https://thenounproject.com/term/home-sweet-home/3817166/) By Silviu Ojog for Home Sweet Home
 -   [Star](https://thenounproject.com/icon/star-35340/) by Trent Kuhn for Dogfighting
 
 ### Religions
 
--   [Lightning Bolt](https://thenounproject.com/search/?q=lightning+bolt&i=154820) by sian huxtable for Pantheon
--   [Christianity](https://thenounproject.com/search/?q=christianity&i=181) by Public Domain Nouns for Christianity
--   [Islam](https://thenounproject.com/search/?q=Islam&i=2431350) by Muhammed Riza for Islam
--   [taoism](https://thenounproject.com/search/?q=Taoism&i=740812) by parkjisun for Taosim
--   [Buddhism](https://thenounproject.com/search/?q=buddhism&i=38764) by Julio Yanes for Buddhism
--   [Hinduism](https://thenounproject.com/search/?q=hinduism&i=20383) by Mugda Damle for Hinduism
--   [Confucianism](https://thenounproject.com/search/?q=Confucianism&i=200406) by Dabid J. Pascual for Confucianism
--   [Judaism](https://thenounproject.com/search/?q=Judaism&i=200418) by Dabid J. Pascual for Judaism
+-   [Lightning Bolt](https://thenounproject.com/icon/lightning+bolt-154820) by sian huxtable for Pantheon
+-   [Christianity](https://thenounproject.com/icon/christianity-181) by Public Domain Nouns for Christianity
+-   [Islam](https://thenounproject.com/icon/Islam-2431350) by Muhammed Riza for Islam
+-   [taoism](https://thenounproject.com/icon/Taoism-740812) by parkjisun for Taosim
+-   [Buddhism](https://thenounproject.com/icon/buddhism-38764) by Julio Yanes for Buddhism
+-   [Hinduism](https://thenounproject.com/icon/hinduism-20383) by Mugda Damle for Hinduism
+-   [Confucianism](https://thenounproject.com/icon/Confucianism-200406) by Dabid J. Pascual for Confucianism
+-   [Judaism](https://thenounproject.com/icon/Judaism-200418) by Dabid J. Pascual for Judaism
 -   [Shinto](https://thenounproject.com/dabid/uploads/?i=238069) by Dabid J. Pascual for Shinto
 -   [Sikhism](https://thenounproject.com/dabid/uploads/?i=238064) by Dabid J. Pascual for Sikhism
--   [Tengrism](https://thenounproject.com/search/?q=Tengrism&i=238067) by Dabid J. Pascual for Tengriism
--   [Zoroastrianism](https://thenounproject.com/search/?q=Zoroastrianism&i=238059) by Dabid J. Pascual for Zoroastrianism
+-   [Tengrism](https://thenounproject.com/icon/Tengrism-238067) by Dabid J. Pascual for Tengriism
+-   [Zoroastrianism](https://thenounproject.com/icon/Zoroastrianism-238059) by Dabid J. Pascual for Zoroastrianism
 -   [praying](https://thenounproject.com/term/praying/740809/) by parkjisun for Religion (Civilopedia concept entry)
 -   [praying](https://thenounproject.com/term/praying/886367/) by Gan Khoon Lay for Follower
 -   [Hero](https://thenounproject.com/term/preacher/195465/) by Andrew J. Young for Founder
@@ -664,34 +664,34 @@ Unless otherwise specified, all the following are from [the Noun Project](https:
 
 ### Others
 
-- [Circle](https://thenounproject.com/term/circle/1841891/) By Aybige
+- [Circle](https://thenounproject.com/term/circle/1841891/) By Aybige - Circle used to compose icons on the fly
 - [Arrow](https://thenounproject.com/term/arrow/18123/) By Joe Mortell for movement
-- [Swap](https://thenounproject.com/search/?q=swap&i=1259600) By iconomania for swapping units
+- [Swap](https://thenounproject.com/term/swap/1259600) By iconomania for swapping units
 - [Road](https://thenounproject.com/icon/road-224428/) By Gábor István Karaba for connect road automation
-- [Connection](https://thenounproject.com/search/?q=connection&i=1521886) By Travis Avery
-- [Skull](https://thenounproject.com/search/?q=Skull&i=1030702) By Vladimir Belochkin for disbanding units
-- [Crosshair](https://thenounproject.com/search/?q=crosshairs&i=916030) By Bakunetsu Kaito for selecting enemies to attack
-- [City](https://thenounproject.com/search/?q=city&i=571332) By Felix Westphal
-- [Fire](https://thenounproject.com/search/?q=Fire&i=96564) By Lloyd Humphreys for "city being razed" icon
-- [Sleep](https://thenounproject.com/search/?q=sleep&i=1760085) By Saeful Muslim
+- [Connection](https://thenounproject.com/icon/connection-1521886) By Travis Avery
+- [Skull](https://thenounproject.com/icon/skull-1030702) By Vladimir Belochkin for disbanding units
+- [Crosshair](https://thenounproject.com/icon/crosshairs-916030) By Bakunetsu Kaito for selecting enemies to attack
+- [City](https://thenounproject.com/icon/city-571332) By Felix Westphal
+- [Fire](https://thenounproject.com/icon/96564) By Lloyd Humphreys for "city being razed" icon
+- [Sleep](https://thenounproject.com/icon/sleep-1760085) By Saeful Muslim for unit "sleep" action and status
 - [Clockwise](https://thenounproject.com/icon/clockwise-184528/) By Universal Icons (Louis Dawson) for "Wait" icon. The original work has been slightly modified.
 - [Banner](https://thenounproject.com/term/banner/866282/) By Emir Palavan for embarked units
 - [Arrow](https://thenounproject.com/icon/arrow-2032227/) By uzeir syarief for moving between idle units, expanders, etc.
-- [Replace](https://thenounproject.com/search/?q=replace&i=17858) By Mike Rowe for switching tiles between cities
-- [Resistance](https://thenounproject.com/term/revolution/1315305/) By HeadsOfBirds
-- [Viking Hat](https://thenounproject.com/search/?q=pillage&i=185405) By my name is mud for pillaging improvements
-- [Aim](https://thenounproject.com/search/?q=aim&i=2034920) By Kaviashri for ranged strength
-- [Capitol](https://thenounproject.com/search/?q=capitol&i=160031) By Loren Klein for City-States
-- [Aircraft](https://thenounproject.com/search/?q=aircraft&i=1629000) By Tom Fricker for aircraft icon in city button
-- [radar scan](https://thenounproject.com/search/?q=range&i=1500234) By icon 54 for Range
-- [short range radar](https://thenounproject.com/search/?q=air%20range&i=2612731) by Vectors Point for Intercept range
-- Puppet by [vegeta1k95](https://github.com/veget1k95) based on [Puppet](https://thenounproject.com/search/?q=puppet&i=285735) by Ben Davis, for puppeted cities
-- [City](https://thenounproject.com/search/?q=city&i=1765370) By Muhajir ila Robbi in the Icon center
-- [Lock](https://thenounproject.com/search/?q=lock&i=3217613) by Vadim Solomakhin for locked tiles
-- [Hourglass](https://thenounproject.com/search/?q=hourglass&i=142268) by I Create Stuff for the 'Turn' icon
-- [Shield](https://thenounproject.com/search/?q=shield&i=813568) by Gregor Cresnar for Religious Strength
+- [Exchange](https://thenounproject.com/icon/exchange-17858) By Mike Rowe for switching tiles between cities
+- [Revolution](https://thenounproject.com/term/revolution/1315305/) By HeadsOfBirds for cities in resistance - world screen, city screen, city overview
+- [Viking Hat](https://thenounproject.com/icon/pillage-185405) By my name is mud for pillaging improvements
+- [Aim](https://thenounproject.com/icon/aim-2034920) By Kaviashri for ranged strength
+- [Capitol](https://thenounproject.com/icon/capitol-160031) By Loren Klein for City-States
+- [Aircraft](https://thenounproject.com/icon/aircraft-1629000) By Tom Fricker for aircraft icon in city button
+- [radar scan](https://thenounproject.com/icon/range-1500234) By icon 54 for Range
+- [short range radar](https://thenounproject.com/icon/air%20range-2612731) by Vectors Point for Intercept range
+- Puppet by [vegeta1k95](https://github.com/veget1k95) based on [Puppet](https://thenounproject.com/icon/puppet-285735) by Ben Davis, for puppeted cities
+- [City](https://thenounproject.com/icon/city-1765370) By Muhajir ila Robbi in the Icon center
+- [Lock](https://thenounproject.com/icon/lock-3217613) by Vadim Solomakhin for locked tiles
+- [Hourglass](https://thenounproject.com/icon/hourglass-142268) by I Create Stuff for the 'Turn' icon
+- [Shield](https://thenounproject.com/icon/shield-813568) by Gregor Cresnar for Religious Strength
 - [skill sword flame](https://thenounproject.com/term/skill-sword-flame/2360212/) by Maxicons) for Remove Heresy
-- [Pencil](https://thenounproject.com/search/?q=pencil&i=4195852) by Muhamad Aldi Maulana for Enter Text Prompt Button / Pencil
+- [Pencil](https://thenounproject.com/icon/pencil-4195852) by Muhamad Aldi Maulana for Enter Text Prompt Button / Pencil
 - [Parchment](https://thenounproject.com/term/parchment/1516378/) by hans draiman for Cultured City-States
 - [connection](https://thenounproject.com/term/connection/1365233/) by Popular for Mercantile City-States
 - [crossed sword](https://thenounproject.com/term/crossed-sword/2427559/) by ProSymbols for Militaristic City-States
@@ -712,25 +712,25 @@ Unless otherwise specified, all the following are from [the Noun Project](https:
 - [spy](https://thenounproject.com/icon/spy-2905374/) by Vectorstall for Spy
 - [turn right](https://thenounproject.com/icon/turn-right-1920867/) by Alice Design for Resource Overview
 - [Tyrannosaurus Rex](https://thenounproject.com/icon/tyrannosaurus-rex-4130976/) by Amethyst Studio for Civilopedia Eras header
-- [Realistic easter day eggs with curvy lines and dots](https://www.freepik.com/free-vector/realistic-easter-day-eggs-with-curvy-lines-dots_6839373.htm) by freepik
-- [Eggs Easter Scrapbook](https://pixabay.com/illustrations/eggs-easter-scrapbooking-672457/) by Claudette Gallant
-- [Pumpkin vector](https://www.freepik.com/vectors/pumpkin) by freepik
-- [Lollipop vector](https://www.freepik.com/vectors/lollipop) by macrovector
-- Part of [Christmas symbols vector](https://www.freepik.com/vectors/christmas-symbols) by vikayatskina
-- Part of [Christmas tree 3d vector](https://www.freepik.com/vectors/christmas-tree-3d) rawpixel.com
-- [Present card vector](https://www.freepik.com/vectors/present-card) by katemangostar
-- [Ribbon box vector](https://www.freepik.com/vectors/ribbon-box) by nikapeshkov
-- [Funny christmas vector](https://www.freepik.com/free-vector/reindeer-santa-hat-peeping-out_1430479.htm) by katemangostar
-- [Santa beard vector](https://www.freepik.com/free-vector/positive-santa-ringing-bell-waving-hand_3636285.htm) by katemangostar
-- [Funny christmas vector](https://www.freepik.com/free-vector/snowman-wearing-santa-hat-scarf-mittens_3636292.htm) by katemangostar
+- [Realistic easter day eggs with curvy lines and dots](https://www.freepik.com/free-vector/realistic-easter-day-eggs-with-curvy-lines-dots_6839373.htm) by freepik for easter eggs
+- [Eggs Easter Scrapbook](https://pixabay.com/illustrations/eggs-easter-scrapbooking-672457/) by Claudette Gallant for easter eggs
+- [Halloween pumpkin](https://www.freepik.com/free-vector/halloween-pumpkin_753628.htm) by freepik for easter eggs
+- [Vector set of different sweets](https://www.freepik.com/free-vector/vector-set-different-sweets-pink-red-striped-foil-wrappers-swirl-lollipops-xmas-cane-cotton-candy-isolated-white-background_11060369.htm) by macrovector for easter eggs
+- Part of [Merry christmas design elements set](https://www.freepik.com/free-vector/merry-christmas-design-elements-set-xmas-decorations-objects-poinsettia-fir-tree-branch-mistletoe-pinecone-design-elements-christmas-ball-ribbon-bow-isolated-vector-detailed-illustration_18165406.htm) by vikayatskina for easter eggs
+- Part of [3d winter holidays background](https://www.freepik.com/free-vector/3d-winter-holidays-background-christmas-tree-candy-cane-vector_19597244.htm) rawpixel.com for easter eggs
+- [Stack of dollar bills with bow](https://www.freepik.com/free-vector/stack-dollar-bills-with-bow_1371562.htm) by katemangostar for easter eggs
+- [present boxes collection](https://www.freepik.com/free-vector/realistic-vector-icon-set-present-boxes-collection-white-black-with-golden-red-ribbons_26413220.htm) by nikapeshkov for easter eggs
+- [Reindeer in santa hat peeping out](https://www.freepik.com/free-vector/reindeer-santa-hat-peeping-out_1430479.htm) by katemangostar for easter eggs
+- [Positive santa ringing bell](https://www.freepik.com/free-vector/positive-santa-ringing-bell-waving-hand_3636285.htm) by katemangostar for easter eggs
+- [Snowman wearing santa hat scarf and mittens](https://www.freepik.com/free-vector/snowman-wearing-santa-hat-scarf-mittens_3636292.htm) by katemangostar for easter eggs
 - [AirSweep](https://thenounproject.com/icon/jet-134340/) by Creative Stall for Air Sweep icon
-- [Timer](https://www.flaticon.com/free-icons/timer) created by Gregor Cresnar Premium - Flaticon
-- [Political Science](https://www.flaticon.com/premium-icon/political-science_5403775) created by Hilmy Abiyyu A. - Flaticon
+- [Timer](https://www.flaticon.com/free-icon/stopwatch_563480) created by Gregor Cresnar Premium - Flaticon - for Game speeds civilopedia category
+- [Political Science](https://www.flaticon.com/premium-icon/political-science_5403775) created by Hilmy Abiyyu A. - Flaticon - for Global politics overview screen
 - [Question](https://thenounproject.com/icon/question-1157126/) created by Aneeque Ahmed for Question Icon
 - [Trade](https://www.flaticon.com/free-icon/trade_4257019) created by Smashicons for Conduct Trade Mission
 - [Nothing](https://www.flaticon.com/free-icon/nothing_5084125) created by Freepik for Nothing construction process
 - Icon for Unique created by [vegeta1k95](https://github.com/vegeta1k95)
-- [Transform] created by letstalkaboutdune
+- [Transform] created by [letstalkaboutdune](https://github.com/letstalkaboutdune) for the Transform unit action
 - [Swords](https://thenounproject.com/icon/swords-1580316/) created by Muhajir ila Robbi for Blockaded tile marker
 - [Keyboard](https://thenounproject.com/icon/keyboard-2685534/) by Twenty Foo Studio for Options Keys
 - [charts](https://thenounproject.com/icon/charts-2312023/) by Srinivas Agra (gimped to appear bolder) for the Charts page
@@ -741,13 +741,13 @@ Unless otherwise specified, all the following are from [the Noun Project](https:
 
 ### Main menu
 
--   [Lightning](https://thenounproject.com/search/?q=lightning&i=102300) by Rohith M S for Quickstart
--   [Loading](https://thenounproject.com/search/?q=load&i=208033) by Universal Icons for Load Game
--   [New](https://thenounproject.com/search/?q=new&i=1886943) by Alice Design for New Game
--   [Go back](https://thenounproject.com/search/?q=go%20back&i=1901947) by Salvia Santos for Resume
--   [Multiplayer](https://thenounproject.com/search/?q=multiplayer&i=1215652) by Roy Charles
--   [Options](https://thenounproject.com/search/?q=options&i=866090) By Thengakola
--   [Package](https://thenounproject.com/search/?q=package&i=1886048) by shashank singh
+-   [Lightning](https://thenounproject.com/icon/lightning-102300) by Rohith M S for Quickstart
+-   [Loading](https://thenounproject.com/icon/load-208033) by Universal Icons for Load Game
+-   [New](https://thenounproject.com/icon/new-1886943) by Alice Design for New Game
+-   [Go back](https://thenounproject.com/icon/go%20back-1901947) by Salvia Santos for Resume
+-   [Multiplayer](https://thenounproject.com/icon/multiplayer-1215652) by Roy Charles
+-   [Options](https://thenounproject.com/icon/options-866090) By Thengakola
+-   [Package](https://thenounproject.com/icon/package-1886048) by shashank singh
 
 ## Sound credits
 


### PR DESCRIPTION
First batch of credit attribution fixes from #11176

Note: The regex search&replace to change the `search?q=` link form was not optimal - I used the original search term as the tag before the ID, as TNP ignores it if the ID works but converts to search if not. Ideally, I should have checked them all and replaced it with the actual icon title as TNP sees it - our display part of the link (`[this]`) isn't reliably same as that title either. Would have been a few tedious hours - no thanks.

Sorry I didn't split the actual investigation-result fixes as separate commit - can redo if needed. They're all in the `### Others` section.