### PR TITLE
Allow conditional timed triggers for unit actions or most other trigger conditionals

### DIFF
--- a/core/src/com/unciv/logic/civilization/Civilization.kt
+++ b/core/src/com/unciv/logic/civilization/Civilization.kt
@@ -482,7 +482,7 @@ class Civilization : IsPartOfGameInfoSerialization {
         yieldAll(cityStateFunctions.getUniquesProvidedByCityStates(uniqueType, stateForConditionals))
         if (religionManager.religion != null)
             yieldAll(religionManager.religion!!.getFounderUniques()
-                .filter { it.type == uniqueType && it.conditionalsApply(stateForConditionals) })
+                .filter { !it.isTimedTriggerable && it.type == uniqueType && it.conditionalsApply(stateForConditionals) })
 
         yieldAll(getCivResourceSupply().asSequence()
             .filter { it.amount > 0 }
@@ -500,6 +500,10 @@ class Civilization : IsPartOfGameInfoSerialization {
         yieldAll(cities.asSequence()
             .flatMap { city -> city.cityConstructions.builtBuildingUniqueMap.getTriggeredUniques(trigger, stateForConditionals) }
         )
+        if (religionManager.religion != null)
+            yieldAll(religionManager.religion!!.getFounderUniques()
+                .filter { unique -> unique.conditionals.any { it.type == trigger }
+                    && unique.conditionalsApply(stateForConditionals) })
         yieldAll(policies.policyUniques.getTriggeredUniques(trigger, stateForConditionals))
         yieldAll(tech.techUniques.getTriggeredUniques(trigger, stateForConditionals))
         yieldAll(getEra().uniqueMap.getTriggeredUniques (trigger, stateForConditionals))

--- a/core/src/com/unciv/logic/civilization/transients/CapitalConnectionsFinder.kt
+++ b/core/src/com/unciv/logic/civilization/transients/CapitalConnectionsFinder.kt
@@ -85,8 +85,8 @@ class CapitalConnectionsFinder(private val civInfo: Civilization) {
         )
     }
 
-    private fun City.containsHarbor() =
-            this.cityConstructions.builtBuildingUniqueMap.getUniques(UniqueType.ConnectTradeRoutes).any()
+    private fun City.containsHarbor() = 
+        this.containsBuildingUnique(UniqueType.ConnectTradeRoutes)
 
     private fun check(cityToConnectFrom: City,
                       transportType: String,

--- a/core/src/com/unciv/logic/map/tile/Tile.kt
+++ b/core/src/com/unciv/logic/map/tile/Tile.kt
@@ -387,9 +387,10 @@ open class Tile : IsPartOfGameInfoSerialization {
     fun isRoughTerrain() = allTerrains.any { it.isRough() }
 
     /** Checks whether any of the TERRAINS of this tile has a certain unique */
-    fun terrainHasUnique(uniqueType: UniqueType) = terrainUniqueMap.getUniques(uniqueType).any()
+    fun terrainHasUnique(uniqueType: UniqueType, state: StateForConditionals = StateForConditionals(tile = this)) =
+        terrainUniqueMap.getMatchingUniques(uniqueType, state).any()
     /** Get all uniques of this type that any TERRAIN on this tile has */
-    fun getTerrainMatchingUniques(uniqueType: UniqueType, stateForConditionals: StateForConditionals = StateForConditionals(tile=this) ): Sequence<Unique> {
+    fun getTerrainMatchingUniques(uniqueType: UniqueType, stateForConditionals: StateForConditionals = StateForConditionals(tile = this) ): Sequence<Unique> {
         return terrainUniqueMap.getMatchingUniques(uniqueType, stateForConditionals)
     }
 

--- a/core/src/com/unciv/models/ruleset/unique/Unique.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Unique.kt
@@ -228,7 +228,7 @@ class UniqueMap: HashMap<String, ArrayList<Unique>>() {
     fun getUniques(uniqueType: UniqueType) = getUniques(uniqueType.placeholderText)
 
     fun getMatchingUniques(uniqueType: UniqueType, state: StateForConditionals) = getUniques(uniqueType)
-        .filter { it.conditionalsApply(state) && !unique.isTimedTriggerable }
+        .filter { it.conditionalsApply(state) && !it.isTimedTriggerable }
 
     fun getAllUniques() = this.asSequence().flatMap { it.value.asSequence() }
 

--- a/core/src/com/unciv/models/ruleset/unique/Unique.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Unique.kt
@@ -28,10 +28,12 @@ class Unique(val text: String, val sourceObjectType: UniqueTarget? = null, val s
     }
     val conditionals: List<Unique> = text.getConditionals()
 
+    val isTimedTriggerable = conditionals.any { it.type == UniqueType.ConditionalTimedUnique }
+
     val isTriggerable = type != null && (
         type.targetTypes.contains(UniqueTarget.Triggerable)
             || type.targetTypes.contains(UniqueTarget.UnitTriggerable)
-            || conditionals.any { it.type == UniqueType.ConditionalTimedUnique }
+            || isTimedTriggerable
         )
 
     /** Includes conditional params */
@@ -59,7 +61,7 @@ class Unique(val text: String, val sourceObjectType: UniqueTarget? = null, val s
     fun conditionalsApply(state: StateForConditionals = StateForConditionals()): Boolean {
         if (state.ignoreConditionals) return true
         // Always allow Timed conditional uniques. They are managed elsewhere
-        if (conditionals.any { it.type == UniqueType.ConditionalTimedUnique }) return true
+        if (isTimedTriggerable) return true
         for (condition in conditionals) {
             if (!Conditionals.conditionalApplies(this, condition, state)) return false
         }
@@ -209,8 +211,6 @@ class UniqueMap: HashMap<String, ArrayList<Unique>>() {
 
     /** Adds one [unique] unless it has a ConditionalTimedUnique conditional */
     fun addUnique(unique: Unique) {
-        if (unique.conditionals.any { it.type == UniqueType.ConditionalTimedUnique }) return
-
         val existingArrayList = get(unique.placeholderText)
         if (existingArrayList != null) existingArrayList.add(unique)
         else this[unique.placeholderText] = arrayListOf(unique)
@@ -228,7 +228,7 @@ class UniqueMap: HashMap<String, ArrayList<Unique>>() {
     fun getUniques(uniqueType: UniqueType) = getUniques(uniqueType.placeholderText)
 
     fun getMatchingUniques(uniqueType: UniqueType, state: StateForConditionals) = getUniques(uniqueType)
-        .filter { it.conditionalsApply(state) }
+        .filter { it.conditionalsApply(state) && !unique.isTimedTriggerable }
 
     fun getAllUniques() = this.asSequence().flatMap { it.value.asSequence() }
 


### PR DESCRIPTION
Not sure how to title this to make it work for patch notes and stay accurate. Should close #11167

PR does the following
- Removes the hardcoded stripping of timed conditionals from UniqueMap. This is now instead done from `getMatchingUniques`. This is to ensure trigger conditionals (which relies on the uniqueMap in most cases) still function. Getting the full list of uniques can still be done via `getUniques`, which `getTriggeredUniques` does
- Fixes some cases of of functions using `getUniques` instead of `getMatchingUniques`. This also allows for the use of conditionals in more locations... though hopefully this shouldn't be cost for tiles
-  Addresses minor semi-related things here and there (why doesn't religions properly have a functioning UniqueMap? Makes things unnecessarily awkward. It also meant triggers didn't work from religions before)

Side thing, but I feel like `hasUnique` (which alot of the stuff that has a custom `getMatchingUniques` function also have) should probably be implemented in UniqueMap itself, if for no other reason than consistency

Also if a mad modder tries to abuse this to put a timed conditional on a unit spawning, the validator doesn't like it. Probably need to fix that