### PR TITLE
Unit actions from Uniques shouldn't be active at zero movement

### DIFF
--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsFromUniques.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsFromUniques.kt
@@ -199,12 +199,15 @@ object UnitActionsFromUniques {
             }
             val title = UnitActionModifiers.actionTextWithSideEffects(baseTitle, unique, unit)
 
-            val triggerFunction = UniqueTriggerActivation.getTriggerFunction(unique, unit.civ, unit = unit, tile = unit.currentTile)
-            val unitAction = if (triggerFunction == null) null else
-            { -> // This is the *action* that will be triggered!
-                UniqueTriggerActivation.triggerUnique(unique, unit)
-                UnitActionModifiers.activateSideEffects(unit, unique)
-            }
+            val unitAction = fun (): (()->Unit)? {
+                if (unit.currentMovement == 0f) return null
+                val triggerFunction = UniqueTriggerActivation.getTriggerFunction(unique, unit.civ, unit = unit, tile = unit.currentTile)
+                    ?: return null
+                return { // This is the *action* that will be triggered!
+                    triggerFunction.invoke()
+                    UnitActionModifiers.activateSideEffects(unit, unique)
+                }
+            }()
 
             yield(UnitAction(UnitActionType.TriggerUnique, title, action = unitAction))
         }


### PR DESCRIPTION
Consider carefully...
* Once #11181 is merged, unit uniques such as the _other_ example[^1] in #11167 will work (though still be defamed by mod checker) - even for freshly bought units, or units that have exhausted their movement this turn. In contrast, Great People don't have that luxury.
* So I propose _any_ action supplied through getTriggerUniqueActions should "grey out" and show as "not available right now" when currentMovement==0

...

* Thus this approach - doing the test earlier, e.g. in canUse, would hide the action button entirely.
* Thought about looking for a "for [x] movement" modifier and testing against that x - decided against. Gut feeling.
* I looked at that getTriggerFunction that is just compared to null then discarded and evaluated _again_ shortly after in triggerUnique - can't imagine the context between those two points in time changing, so not doing the work twice seemed a good thing. You might think otherwise - throw of the dice to me. One more reference passed as closure into that action lambda than before, cheap enough.
* Same with using a temp one-shot anonymous factory function just for its "shout-out" ability. I find it clear enough, but others may not. Can comment or unwrap the hard way.

[^1]: `"[+2 Science] [in all cities] <for [10] turns> <by consuming this unit>"`