### PR TITLE
Better military unit retreat

### DIFF
--- a/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
@@ -305,9 +305,9 @@ object UnitAutomation {
             unitDistanceToTiles.asSequence().map { it.key }.sortedByDescending { unit.civ.threatManager.getDistanceToClosestEnemyUnit(it, 3, false) }
         }
 
+        val ourDistanceToClosestEnemy = unit.civ.threatManager.getDistanceToClosestEnemyUnit(unit.getTile(),6, false)
         // Lets check all tiles and swap with the first one
         for (retreatTile in sortedTilesToRetreatTo) {
-            val ourDistanceToClosestEnemy = unit.civ.threatManager.getDistanceToClosestEnemyUnit(unit.getTile(),6, false)
             val tileDistanceToClosestEnemy = unit.civ.threatManager.getDistanceToClosestEnemyUnit(retreatTile,6,false)
             if (ourDistanceToClosestEnemy >= tileDistanceToClosestEnemy) continue
 


### PR DESCRIPTION
This PR changes the functionality and name of trySwapRetreat to tryRetreat. 

TryRetreat uses `ThreatManager.getDistanceToClosestEnemy()` to find which tiles are suitable to retreat to. Previously trySwapRetreat only checked tiles with units to swap to. Now tryRetreat checks tiles that don't have military units on them as well.

Checking the `distanceToClosestEnemy()` on a tile is expensive so it tries to sort the tiles by a cheaper `getArielDistanceTo(closestCity)` first. If there is no close city, then it will try a cheaper getDistanceToClosestEnemy to filter out the tiles that are very close to an enemy.

Added a calvary unit tactic: If a unit has successfully attacked and is at low health afterward it will try to spend the remaining movement points to run away.

Overall, the performance impact should be relatively light compared to the AI decision improvement.