### PR TITLE
Military unit healing improvement

### DIFF
--- a/core/src/com/unciv/logic/automation/civilization/BarbarianAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/BarbarianAutomation.kt
@@ -49,7 +49,7 @@ class BarbarianAutomation(val civInfo: Civilization) {
 
     private fun automateCombatUnit(unit: MapUnit) {
         // 1 - Try pillaging to restore health (barbs don't auto-heal)
-        if (unit.health < 50 && UnitAutomation.tryPillageImprovement(unit)) return
+        if (unit.health < 50 && UnitAutomation.tryPillageImprovement(unit, true) && unit.currentMovement == 0f) return
 
         // 2 - trying to upgrade
         if (UnitAutomation.tryUpgradeUnit(unit)) return
@@ -60,7 +60,9 @@ class BarbarianAutomation(val civInfo: Civilization) {
         if (!unit.isCivilian() && BattleHelper.tryAttackNearbyEnemy(unit)) return
 
         // 4 - trying to pillage tile or route
-        if (UnitAutomation.tryPillageImprovement(unit)) return
+        while (UnitAutomation.tryPillageImprovement(unit)) {
+            if (unit.currentMovement == 0f) return
+        }
 
         // 6 - wander
         UnitAutomation.wander(unit)

--- a/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
@@ -212,12 +212,12 @@ object UnitAutomation {
 
         if (tryUpgradeUnit(unit)) return
 
+        if (unit.health < 50 && (trySwapRetreat(unit) || tryHealUnit(unit))) return // do nothing but heal
+
         // Accompany settlers
         if (tryAccompanySettlerOrGreatPerson(unit)) return
 
         if (tryHeadTowardsOurSiegedCity(unit)) return
-
-        if (unit.health < 50 && (trySwapRetreat(unit) || tryHealUnit(unit))) return // do nothing but heal
 
         // if a embarked melee unit can land and attack next turn, do not attack from water.
         if (BattleHelper.tryDisembarkUnitToAttackPosition(unit)) return

--- a/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
@@ -318,7 +318,8 @@ object UnitAutomation {
 
         // Try pillage improvements until healed
         while(tryPillageImprovement(unit, false)) {
-            if (unit.currentMovement == 0f || unit.health == 100) return true
+            // If we are fully healed and can still do things, lets keep on going by returning false
+            if (unit.currentMovement == 0f || unit.health == 100) return unit.currentMovement == 0f
         }
 
         val unitDistanceToTiles = unit.movement.getDistanceToTiles()

--- a/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
@@ -380,11 +380,13 @@ object UnitAutomation {
      * @return true if the tile is safe and the unit can heal to full within [turns]
      */
     private fun canUnitHealInTurnsOnCurrentTile(unit: MapUnit, turns: Int, noEnemyDistance: Int = 3): Boolean {
+        if (unit.hasUnique(UniqueType.HealsEvenAfterAction)) return false // We can keep on moving
         // Check if we are not in a safe city and there is an enemy nearby this isn't a good tile to heal on
         if (!(unit.getTile().isCityCenter() && unit.getTile().getCity()!!.health > 50) 
             && unit.civ.threatManager.getDistanceToClosestEnemyUnit(unit.getTile(), noEnemyDistance) <= noEnemyDistance) return false
-        return (!unit.hasUnique(UniqueType.HealsEvenAfterAction)
-            && (100 - unit.health) / turns <= unit.rankTileForHealing(unit.getTile()))
+
+        val healthRequiredPerTurn =  (100 - unit.health) / turns
+        return healthRequiredPerTurn <= unit.rankTileForHealing(unit.getTile())
     }
 
     private fun getDangerousTiles(unit: MapUnit): HashSet<Tile> {

--- a/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
@@ -325,6 +325,11 @@ object UnitAutomation {
 
         val dangerousTiles = unit.civ.threatManager.getDangerousTiles(unit)
 
+        // If the unit can heal on this tile in two turns, just heal here
+        if (!dangerousTiles.contains(unit.getTile()) && !unit.hasUnique(UniqueType.HealsEvenAfterAction) 
+            && (100 - unit.health) / 2 <= unit.rankTileForHealing(unit.getTile())) return true
+
+
         val viableTilesForHealing = unitDistanceToTiles.keys
                 .filter { it !in dangerousTiles && unit.movement.canMoveTo(it) }
         val tilesByHealingRate = viableTilesForHealing.groupBy { unit.rankTileForHealing(it) }

--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -22,6 +22,7 @@ import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.stats.Stat
 import com.unciv.models.stats.Stats
 import com.unciv.ui.components.UnitMovementMemoryType
+import com.unciv.ui.screens.worldscreen.unit.actions.UnitActionsPillage
 import com.unciv.utils.debug
 import kotlin.math.max
 import kotlin.math.min
@@ -39,7 +40,7 @@ object Battle {
      * Currently not used by UI, only by automation via [BattleHelper.tryAttackNearbyEnemy][com.unciv.logic.automation.unit.BattleHelper.tryAttackNearbyEnemy]
      */
     fun moveAndAttack(attacker: ICombatant, attackableTile: AttackableTile) {
-        if (!movePreparingAttack(attacker, attackableTile)) return
+        if (!movePreparingAttack(attacker, attackableTile, true)) return
         attackOrNuke(attacker, attackableTile)
     }
 
@@ -48,8 +49,9 @@ object Battle {
      *
      * This is a logic function, not UI, so e.g. sound needs to be handled after calling this.
      */
-    fun movePreparingAttack(attacker: ICombatant, attackableTile: AttackableTile): Boolean {
+    fun movePreparingAttack(attacker: ICombatant, attackableTile: AttackableTile, tryHealPillage: Boolean = false): Boolean {
         if (attacker !is MapUnitCombatant) return true
+        val tilesMovedThrough = attacker.unit.movement.getDistanceToTiles().getPathToTile(attackableTile.tileToAttackFrom)
         attacker.unit.movement.moveToTile(attackableTile.tileToAttackFrom)
         /**
          * When calculating movement distance, we assume that a hidden tile is 1 movement point,
@@ -73,6 +75,21 @@ object Battle {
         ) {
             attacker.unit.action = UnitActionType.SetUp.value
             attacker.unit.useMovementPoints(1f)
+        }
+
+        if (tryHealPillage) {
+            // Now lets retroactively see if we can pillage any improvement on the path improvement to heal
+            // While still being able to attack
+            val pillageIterator = tilesMovedThrough.toMutableList().listIterator()
+            while (attacker.unit.currentMovement > 1f && attacker.unit.health < 90 && pillageIterator.hasNext()) {
+                val tileToPillage = pillageIterator.next() 
+                if (UnitActionsPillage.canPillage(attacker.unit, tileToPillage)
+                    && tileToPillage.canPillageTileImprovement()) {
+                    UnitActionsPillage.getPillageAction(attacker.unit, tileToPillage)?.action?.invoke()
+                }
+                // Either we were successfull or we coulden't pillage the tile, it should be removed from the list
+                pillageIterator.remove()
+            }
         }
         return (attacker.unit.currentMovement > 0f)
     }

--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -79,16 +79,14 @@ object Battle {
 
         if (tryHealPillage) {
             // Now lets retroactively see if we can pillage any improvement on the path improvement to heal
-            // While still being able to attack
-            val pillageIterator = tilesMovedThrough.toMutableList().listIterator()
-            while (attacker.unit.currentMovement > 1f && attacker.unit.health < 90 && pillageIterator.hasNext()) {
-                val tileToPillage = pillageIterator.next() 
+            // while still being able to attack
+            for (tileToPillage in tilesMovedThrough) {
+                if (attacker.unit.currentMovement <= 1f || attacker.unit.health > 90) break // We are done pillaging
+
                 if (UnitActionsPillage.canPillage(attacker.unit, tileToPillage)
                     && tileToPillage.canPillageTileImprovement()) {
                     UnitActionsPillage.getPillageAction(attacker.unit, tileToPillage)?.action?.invoke()
                 }
-                // Either we were successfull or we coulden't pillage the tile, it should be removed from the list
-                pillageIterator.remove()
             }
         }
         return (attacker.unit.currentMovement > 0f)


### PR DESCRIPTION
This PR works on improving the AI military unit's healing decisions.
It does have a merge conflict with #11192, so I will have to handle that once one of these gets merged.

Here is a list of the changes
- Units will prioritize healing over accompanying a great person or heading to a city under siege. If the unit is damaged, they aren't going to be too helpful anyway.
- Military units try to pillage while attacking. The implementation is a little funky. They retroactively pillage tiles that they moved through before attacking.
- UnitAutomation.tryHeal() now tries to pillage multiple tiles if able to heal. It will only try to pillage non-road tiles as well. I think this means that the civ AI will not pillage roads at all now.
- Barbarians now pillage more
- Units will stay on their tile to heal instead of moving to a different tile if they can heal safely to full in 2 turns

There is no mentionable performance impact (tryHeal() could actually be faster on average)