### PR TITLE
Added ConditionalWhenBetweenStatResource unique

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ com_crashlytics_export_strings.xml
 .classpath
 .project
 .metadata/
+/tests/bin/
 /android/bin/
 /core/bin/
 /desktop/bin/

--- a/core/src/com/unciv/logic/city/City.kt
+++ b/core/src/com/unciv/logic/city/City.kt
@@ -227,7 +227,8 @@ class City : IsPartOfGameInfoSerialization {
 
     fun getStatReserve(stat: Stat): Int {
         return when (stat) {
-            Stat.Food -> population.foodStored
+            Stat.Food -> cityStats.currentCityStats.food.roundToInt()
+            Stat.Production -> cityStats.currentCityStats.production.roundToInt()
             else -> civ.getStatReserve(stat)
         }
     }

--- a/core/src/com/unciv/logic/city/City.kt
+++ b/core/src/com/unciv/logic/city/City.kt
@@ -227,8 +227,7 @@ class City : IsPartOfGameInfoSerialization {
 
     fun getStatReserve(stat: Stat): Int {
         return when (stat) {
-            Stat.Food -> cityStats.currentCityStats.food.roundToInt()
-            Stat.Production -> cityStats.currentCityStats.production.roundToInt()
+            Stat.Food -> population.foodStored
             else -> civ.getStatReserve(stat)
         }
     }

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -662,10 +662,12 @@ enum class UniqueType(
     // Supports also stockpileable resources (Gold, Faith, Culture, Science)
     ConditionalWhenAboveAmountStatResource("when above [amount] [stat/resource]", UniqueTarget.Conditional),
     ConditionalWhenBelowAmountStatResource("when below [amount] [stat/resource]", UniqueTarget.Conditional),
+    ConditionalWhenBetweenStatResource("when between [amount] to [amount] [stat/resource]", UniqueTarget.Conditional),
 
     // The game speed-adjusted versions of above
     ConditionalWhenAboveAmountStatResourceSpeed("when above [amount] [stat/resource] (modified by game speed)", UniqueTarget.Conditional),
     ConditionalWhenBelowAmountStatResourceSpeed("when below [amount] [stat/resource] (modified by game speed)", UniqueTarget.Conditional),
+    ConditionalWhenBetweenStatResourceSpeed("when between [amount] to [amount] [stat/resource] (modified by game speed)", UniqueTarget.Conditional),
 
     /////// city conditionals
     ConditionalInThisCity("in this city", UniqueTarget.Conditional),

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -662,12 +662,12 @@ enum class UniqueType(
     // Supports also stockpileable resources (Gold, Faith, Culture, Science)
     ConditionalWhenAboveAmountStatResource("when above [amount] [stat/resource]", UniqueTarget.Conditional),
     ConditionalWhenBelowAmountStatResource("when below [amount] [stat/resource]", UniqueTarget.Conditional),
-    ConditionalWhenBetweenStatResource("when between [amount] to [amount] [stat/resource]", UniqueTarget.Conditional),
+    ConditionalWhenBetweenStatResource("when between [amount] and [amount] [stat/resource]", UniqueTarget.Conditional),
 
     // The game speed-adjusted versions of above
     ConditionalWhenAboveAmountStatResourceSpeed("when above [amount] [stat/resource] (modified by game speed)", UniqueTarget.Conditional),
     ConditionalWhenBelowAmountStatResourceSpeed("when below [amount] [stat/resource] (modified by game speed)", UniqueTarget.Conditional),
-    ConditionalWhenBetweenStatResourceSpeed("when between [amount] to [amount] [stat/resource] (modified by game speed)", UniqueTarget.Conditional),
+    ConditionalWhenBetweenStatResourceSpeed("when between [amount] and [amount] [stat/resource] (modified by game speed)", UniqueTarget.Conditional),
 
     /////// city conditionals
     ConditionalInThisCity("in this city", UniqueTarget.Conditional),

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -2039,6 +2039,11 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 	Applicable to: Conditional
 
+??? example  "&lt;when between [amount] to [amount] [stat/resource]&gt;"
+	Example: "&lt;when between [3] to [3] [Culture]&gt;"
+
+	Applicable to: Conditional
+
 ??? example  "&lt;when above [amount] [stat/resource] (modified by game speed)&gt;"
 	Example: "&lt;when above [3] [Culture] (modified by game speed)&gt;"
 
@@ -2046,6 +2051,11 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 ??? example  "&lt;when below [amount] [stat/resource] (modified by game speed)&gt;"
 	Example: "&lt;when below [3] [Culture] (modified by game speed)&gt;"
+
+	Applicable to: Conditional
+
+??? example  "&lt;when between [amount] to [amount] [stat/resource] (modified by game speed)&gt;"
+	Example: "&lt;when between [3] to [3] [Culture] (modified by game speed)&gt;"
 
 	Applicable to: Conditional
 
@@ -2081,6 +2091,11 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 ??? example  "&lt;in cities with at least [amount] [populationFilter]&gt;"
 	Example: "&lt;in cities with at least [3] [Followers of this Religion]&gt;"
+
+	Applicable to: Conditional
+
+??? example  "&lt;in cities with [amount] [populationFilter]&gt;"
+	Example: "&lt;in cities with [3] [Followers of this Religion]&gt;"
 
 	Applicable to: Conditional
 

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -2039,8 +2039,8 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 	Applicable to: Conditional
 
-??? example  "&lt;when between [amount] to [amount] [stat/resource]&gt;"
-	Example: "&lt;when between [3] to [3] [Culture]&gt;"
+??? example  "&lt;when between [amount] and [amount] [stat/resource]&gt;"
+	Example: "&lt;when between [3] and [3] [Culture]&gt;"
 
 	Applicable to: Conditional
 
@@ -2054,8 +2054,8 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 	Applicable to: Conditional
 
-??? example  "&lt;when between [amount] to [amount] [stat/resource] (modified by game speed)&gt;"
-	Example: "&lt;when between [3] to [3] [Culture] (modified by game speed)&gt;"
+??? example  "&lt;when between [amount] and [amount] [stat/resource] (modified by game speed)&gt;"
+	Example: "&lt;when between [3] and [3] [Culture] (modified by game speed)&gt;"
 
 	Applicable to: Conditional
 


### PR DESCRIPTION
Currently the ConditionalBetweenHappiness function only applies to Happiness. Wouldn't it be even better if it could also be extended to other stats and resources. 😊

This new unique has been tested using the following examples:

    1. In GlobalUniques.json:
            - "[+12]% [Gold] [in all cities] <when between [1] and [100] [Gold]>",
            - "[+24]% [Gold] [in all cities] <when between [1] and [100] [Gold] (modified by game speed)>",