### PR TITLE
Add MovedToNewCapital buiding unique

### DIFF
--- a/core/src/com/unciv/logic/civilization/Civilization.kt
+++ b/core/src/com/unciv/logic/civilization/Civilization.kt
@@ -865,6 +865,22 @@ class Civilization : IsPartOfGameInfoSerialization {
             // move new capital
             city.cityConstructions.addBuilding(city.capitalCityIndicator())
             city.isBeingRazed = false // stop razing the new capital if it was being razed
+
+            // move the buildings with MovedToNewCapital unique
+            if (oldCapital != null) {
+                // Get the Sequence of the buildings to move
+                val buildingsToMove = oldCapital.cityConstructions.getBuiltBuildings().filter {
+                    it.hasUnique(UniqueType.MovedToNewCapital)
+                }
+
+                // Remove the buildings from old capital
+                oldCapital.cityConstructions.removeBuildings(buildingsToMove.toSet())
+
+                // Add the buildings to new capital
+                buildingsToMove.forEach {
+                    city.cityConstructions.addBuilding(it)
+                }
+            }
         }
         oldCapital?.cityConstructions?.removeBuilding(oldCapital.capitalCityIndicator())
     }

--- a/core/src/com/unciv/logic/civilization/Civilization.kt
+++ b/core/src/com/unciv/logic/civilization/Civilization.kt
@@ -868,13 +868,13 @@ class Civilization : IsPartOfGameInfoSerialization {
 
             // move the buildings with MovedToNewCapital unique
             if (oldCapital != null) {
-                // Get the Sequence of the buildings to move
+                // Get the Set of the buildings to move
                 val buildingsToMove = oldCapital.cityConstructions.getBuiltBuildings().filter {
-                    it.hasUnique(UniqueType.MovedToNewCapital)
-                }
+                    it.hasUnique(UniqueType.MovesToNewCapital)
+                }.toSet()
 
                 // Remove the buildings from old capital
-                oldCapital.cityConstructions.removeBuildings(buildingsToMove.toSet())
+                oldCapital.cityConstructions.removeBuildings(buildingsToMove)
 
                 // Add the buildings to new capital
                 buildingsToMove.forEach {

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -305,6 +305,7 @@ enum class UniqueType(
     Unsellable("Unsellable", UniqueTarget.Building),
     ObsoleteWith("Obsolete with [tech]", UniqueTarget.Building, UniqueTarget.Resource, UniqueTarget.Improvement),
     IndicatesCapital("Indicates the capital city", UniqueTarget.Building),
+    MovedToNewCapital("Moved to the new capital", UniqueTarget.Building),
     ProvidesExtraLuxuryFromCityResources("Provides 1 extra copy of each improved luxury resource near this City", UniqueTarget.Building),
 
     DestroyedWhenCityCaptured("Destroyed when the city is captured", UniqueTarget.Building),

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -305,7 +305,7 @@ enum class UniqueType(
     Unsellable("Unsellable", UniqueTarget.Building),
     ObsoleteWith("Obsolete with [tech]", UniqueTarget.Building, UniqueTarget.Resource, UniqueTarget.Improvement),
     IndicatesCapital("Indicates the capital city", UniqueTarget.Building),
-    MovedToNewCapital("Moved to the new capital", UniqueTarget.Building),
+    MovesToNewCapital("Moves to new capital when capital changes", UniqueTarget.Building),
     ProvidesExtraLuxuryFromCityResources("Provides 1 extra copy of each improved luxury resource near this City", UniqueTarget.Building),
 
     DestroyedWhenCityCaptured("Destroyed when the city is captured", UniqueTarget.Building),

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -1120,6 +1120,9 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 ??? example  "Indicates the capital city"
 	Applicable to: Building
 
+??? example  "Moved to the new capital"
+	Applicable to: Building
+
 ??? example  "Provides 1 extra copy of each improved luxury resource near this City"
 	Applicable to: Building
 


### PR DESCRIPTION
This building-specific unique indicates that building will be relocated to the new capital, when the capital is moved to new city.

I think it will be useful for buildings that must be coupled with the capital city, especially the abstract buildings like edicts, modifiers, laws or country missions (like those from Europa Universalis IV)

This code is untested, so I don't know whether it works or not. If you have any objections, tell me in the comments. Constructive feedback welcome.