### PR TITLE
Some linting and readability helpers

### DIFF
--- a/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
@@ -612,18 +612,11 @@ class MapUnit : IsPartOfGameInfoSerialization {
     }
 
     fun updateUniques() {
-        val uniques = ArrayList<Unique>()
-        uniques.addAll(baseUnit.uniqueObjects)
-        uniques.addAll(type.uniqueObjects)
-
-        for (promotion in promotions.getPromotions()) {
-            uniques.addAll(promotion.uniqueObjects)
-        }
-
-        tempUniquesMap = UniqueMap().apply {
-            addUniques(uniques)
-        }
-
+        val uniqueSources =
+            baseUnit.uniqueObjects.asSequence() +
+                type.uniqueObjects +
+                promotions.getPromotions().flatMap { it.uniqueObjects }
+        tempUniquesMap = UniqueMap(uniqueSources)
         cache.updateUniques()
     }
 

--- a/core/src/com/unciv/models/ruleset/nation/CityStateType.kt
+++ b/core/src/com/unciv/models/ruleset/nation/CityStateType.kt
@@ -8,10 +8,13 @@ import com.unciv.ui.components.extensions.colorFromRGB
 
 class CityStateType: INamed {
     override var name = ""
+
     var friendBonusUniques = ArrayList<String>()
-    val friendBonusUniqueMap by lazy { UniqueMap().apply { addUniques(friendBonusUniques.map { Unique(it, sourceObjectType = UniqueTarget.CityState) }) } }
+    val friendBonusUniqueMap by lazy { friendBonusUniques.toUniqueMap() }
     var allyBonusUniques = ArrayList<String>()
-    val allyBonusUniqueMap by lazy { UniqueMap().apply { addUniques(allyBonusUniques.map { Unique(it, sourceObjectType = UniqueTarget.CityState) }) } }
+    val allyBonusUniqueMap by lazy { allyBonusUniques.toUniqueMap() }
+    private fun ArrayList<String>.toUniqueMap() =
+        UniqueMap(asSequence().map { Unique(it, sourceObjectType = UniqueTarget.CityState) })
 
     var color:List<Int> = listOf(255,255,255)
     private val colorObject by lazy { colorFromRGB(color) }

--- a/core/src/com/unciv/models/ruleset/unique/Unique.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Unique.kt
@@ -204,10 +204,14 @@ class LocalUniqueCache(val cache:Boolean = true) {
     }
 }
 
-class UniqueMap: HashMap<String, ArrayList<Unique>>() {
+class UniqueMap() : HashMap<String, ArrayList<Unique>>() {
     //todo Once all untyped Uniques are converted, this should be  HashMap<UniqueType, *>
     // For now, we can have both map types "side by side" each serving their own purpose,
     // and gradually this one will be deprecated in favor of the other
+
+    constructor(uniques: Sequence<Unique>) : this() {
+        addUniques(uniques.asIterable())
+    }
 
     /** Adds one [unique] unless it has a ConditionalTimedUnique conditional */
     fun addUnique(unique: Unique) {
@@ -221,11 +225,8 @@ class UniqueMap: HashMap<String, ArrayList<Unique>>() {
         for (unique in uniques) addUnique(unique)
     }
 
-    fun getUniques(placeholderText: String): Sequence<Unique> {
-        return this[placeholderText]?.asSequence() ?: emptySequence()
-    }
-
-    fun getUniques(uniqueType: UniqueType) = getUniques(uniqueType.placeholderText)
+    fun getUniques(uniqueType: UniqueType) =
+        this[uniqueType.placeholderText]?.asSequence() ?: emptySequence()
 
     fun getMatchingUniques(uniqueType: UniqueType, state: StateForConditionals) = getUniques(uniqueType)
         .filter { it.conditionalsApply(state) && !it.isTimedTriggerable }
@@ -238,6 +239,9 @@ class UniqueMap: HashMap<String, ArrayList<Unique>>() {
             && unique.conditionalsApply(stateForConditionals)
         }
     }
+
+    /** This is an alias for [containsKey] to clarify when a pure string-based check is legitimate. */
+    fun containsFilteringUnique(filter: String) = containsKey(filter)
 }
 
 
@@ -253,8 +257,8 @@ class TemporaryUnique() : IsPartOfGameInfoSerialization {
 
     var unique: String = ""
 
-    var sourceObjectType: UniqueTarget? = null
-    var sourceObjectName: String? = null
+    private var sourceObjectType: UniqueTarget? = null
+    private var sourceObjectName: String? = null
 
     @delegate:Transient
     val uniqueObject: Unique by lazy { Unique(unique, sourceObjectType, sourceObjectName) }


### PR DESCRIPTION
This is the diff shown in #11202 _without_ the actual "medicine", with a little sprinkling on top.

Most notable - UniqueMap.getUniques(String) **removed** - tiny step direction fully typed Uniques only. Turned out surprisingly simple to pull off - there was only the one outside caller, and that one wanted essentially just a containsKey not an iterator... If one trusts an UniqueMap will not have empty value-side Lists, which I looked for and couldn't find a path to. Those lists aren't technically protected from removal, but no search approach turned up one...

Note on the "medicine" - reordering a virgin MapUnit setTransients so the baseUnit is set _before_ the assignOwner would IMHO still be a good thing, that is, ordering the inits by complexity of side effects, simplest first, but that has so many ramifications... For now the hotfix will do.

Otherwise - mostly just readability and a little linting, following Studio inspections where I touched the file and there were just too many (when I see a "name shadowed" I can't resist, a bunch of "could be private" I can ignore - "redundant if" aren't a must per se, but these just lent themselves for better readability anyway)

Note I started touching some missing blanks - then stopped hard. A separate whitespace PR may follow, 'cuz a simple search turned up more than a hundred of type declaration colons missing their space... And some inconsistently within a single line, some with the space on the wrong side, etc.....