### PR TITLE
Linting for missing blanks after type declaration colons

### DIFF
--- a/core/src/com/unciv/json/UncivJson.kt
+++ b/core/src/com/unciv/json/UncivJson.kt
@@ -53,7 +53,7 @@ fun <T> Json.fromJsonFile(tClass: Class<T>, file: FileHandle): T {
     try {
         val jsonText = file.readString(Charsets.UTF_8.name())
         return fromJson(tClass, jsonText)
-    } catch (exception:Exception) {
+    } catch (exception: Exception) {
         throw Exception("Could not parse json of file ${file.name()}", exception)
     }
 }

--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -115,7 +115,7 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
     var gameId = UUID.randomUUID().toString() // random string
     var checksum = ""
 
-    var victoryData:VictoryData? = null
+    var victoryData: VictoryData? = null
 
     /** Maps a civ to the civ they voted for - `null` on the value side means they abstained */
     var diplomaticVictoryVotesCast = HashMap<String, String?>()
@@ -316,7 +316,7 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
         return year.toInt()
     }
 
-    fun calculateChecksum():String {
+    fun calculateChecksum(): String {
         val oldChecksum = checksum
         checksum = "" // Checksum calculation cannot include old checksum, obvs
         val bytes = MessageDigest

--- a/core/src/com/unciv/logic/MultiFilter.kt
+++ b/core/src/com/unciv/logic/MultiFilter.kt
@@ -2,7 +2,7 @@ package com.unciv.logic
 
 object MultiFilter {
     fun multiFilter(input: String, filterFunction: (String)->Boolean,
-                    /** Unique validity doesn't check for actual matching */ forUniqueValidityTests:Boolean=false): Boolean {
+                    /** Unique validity doesn't check for actual matching */ forUniqueValidityTests: Boolean=false): Boolean {
         if (input.contains("} {"))
             return input.removePrefix("{").removeSuffix("}").split("} {")
                 .all{ multiFilter(it, filterFunction, forUniqueValidityTests) }

--- a/core/src/com/unciv/logic/automation/unit/AirUnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/AirUnitAutomation.kt
@@ -79,7 +79,7 @@ object AirUnitAutomation {
 
     }
 
-    private fun tryAirSweep(unit: MapUnit, tilesWithEnemyUnitsInRange: List<Tile>):Boolean {
+    private fun tryAirSweep(unit: MapUnit, tilesWithEnemyUnitsInRange: List<Tile>): Boolean {
         val targetTile = tilesWithEnemyUnitsInRange.filter {
             tile -> tile.getUnits().any { it.civ.isAtWarWith(unit.civ)
                 || (tile.isCityCenter() && tile.getCity()!!.civ.isAtWarWith(unit.civ)) }

--- a/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
+++ b/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
@@ -135,7 +135,7 @@ object CityLocationTileRanker {
         return modifier
     }
 
-    private fun rankTile(rankTile: Tile, civ:Civilization, onCoast: Boolean, newUniqueLuxuryResources:HashSet<String>,
+    private fun rankTile(rankTile: Tile, civ: Civilization, onCoast: Boolean, newUniqueLuxuryResources: HashSet<String>,
                          baseTileMap: HashMap<Tile, Float>, uniqueCache: LocalUniqueCache): Float {
         var locationSpecificTileValue = 0f
         // Don't settle near but not on the coast

--- a/core/src/com/unciv/logic/automation/unit/CivilianUnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/CivilianUnitAutomation.kt
@@ -10,7 +10,8 @@ import com.unciv.ui.screens.worldscreen.unit.actions.UnitActions
 
 object CivilianUnitAutomation {
 
-    fun shouldClearTileForAddInCapitalUnits(unit: MapUnit, tile:Tile) = tile.getCity()?.isCapital() == true
+    fun shouldClearTileForAddInCapitalUnits(unit: MapUnit, tile: Tile) =
+        tile.getCity()?.isCapital() == true
         && !unit.hasUnique(UniqueType.AddInCapital)
         && unit.civ.units.getCivUnits().any { unit.hasUnique(UniqueType.AddInCapital) }
 

--- a/core/src/com/unciv/logic/automation/unit/HeadTowardsEnemyCityAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/HeadTowardsEnemyCityAutomation.kt
@@ -28,7 +28,7 @@ object HeadTowardsEnemyCityAutomation {
         )
     }
 
-    private fun getEnemyCitiesByPriority(unit: MapUnit):Sequence<City>{
+    private fun getEnemyCitiesByPriority(unit: MapUnit): Sequence<City> {
         val enemies = unit.civ.getKnownCivs()
             .filter { unit.civ.isAtWarWith(it) && it.cities.isNotEmpty() }
 

--- a/core/src/com/unciv/logic/automation/unit/RoadBetweenCitiesAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/RoadBetweenCitiesAutomation.kt
@@ -19,7 +19,7 @@ private object WorkerAutomationConst {
 }
 
 /** Responsible for the "connect cities" automation as part of worker automation */
-class RoadBetweenCitiesAutomation(val civInfo: Civilization, cachedForTurn:Int, cloningSource: RoadBetweenCitiesAutomation? = null) {
+class RoadBetweenCitiesAutomation(val civInfo: Civilization, cachedForTurn: Int, cloningSource: RoadBetweenCitiesAutomation? = null) {
 
     /** Caches BFS by city locations (cities needing connecting).
      *

--- a/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
@@ -109,7 +109,7 @@ object UnitAutomation {
                 && unit.movement.canReach(tile) // expensive, evaluate last
     }
 
-    fun wander(unit: MapUnit, stayInTerritory: Boolean = false, tilesToAvoid:Set<Tile> = setOf()) {
+    fun wander(unit: MapUnit, stayInTerritory: Boolean = false, tilesToAvoid: Set<Tile> = setOf()) {
         val unitDistanceToTiles = unit.movement.getDistanceToTiles()
         val reachableTiles = unitDistanceToTiles
                 .filter {

--- a/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
@@ -39,8 +39,9 @@ class WorkerAutomation(
 ) {
     ///////////////////////////////////////// Cached data /////////////////////////////////////////
 
-    val roadToAutomation:RoadToAutomation = RoadToAutomation(civInfo)
-    val roadBetweenCitiesAutomation:RoadBetweenCitiesAutomation = RoadBetweenCitiesAutomation(civInfo, cachedForTurn, cloningSource?.roadBetweenCitiesAutomation)
+    val roadToAutomation = RoadToAutomation(civInfo)
+    val roadBetweenCitiesAutomation: RoadBetweenCitiesAutomation =
+        RoadBetweenCitiesAutomation(civInfo, cachedForTurn, cloningSource?.roadBetweenCitiesAutomation)
 
     private val ruleSet = civInfo.gameInfo.ruleset
 
@@ -559,7 +560,7 @@ class WorkerAutomation(
      */
     fun evaluateFortPlacement(tile: Tile, isCitadel: Boolean): Boolean {
         return tile.improvement != Constants.fort // don't build fort if it is already here
-            && evaluateFortSurroundings(tile,isCitadel) > 0
+            && evaluateFortSurroundings(tile, isCitadel) > 0
     }
 
     fun isImprovementProbablyAFort(improvementName:String): Boolean = isImprovementProbablyAFort(ruleSet.tileImprovements[improvementName]!!)

--- a/core/src/com/unciv/logic/battle/AttackableTile.kt
+++ b/core/src/com/unciv/logic/battle/AttackableTile.kt
@@ -1,8 +1,11 @@
 package com.unciv.logic.battle
 
-import com.unciv.logic.battle.ICombatant
 import com.unciv.logic.map.tile.Tile
 
-class AttackableTile(val tileToAttackFrom: Tile, val tileToAttack: Tile,
-                     val movementLeftAfterMovingToAttackTile:Float,
-                     /** This is only for debug purposes */ val combatant:ICombatant?)
+class AttackableTile(
+    val tileToAttackFrom: Tile,
+    val tileToAttack: Tile,
+    val movementLeftAfterMovingToAttackTile: Float,
+    /** This is only for debug purposes */
+    val combatant: ICombatant?
+)

--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -150,9 +150,9 @@ object Battle {
         if (!defender.isDefeated() && defender is MapUnitCombatant && defender.unit.isExploring())
             defender.unit.action = null
 
-        fun triggerVictoryUniques(ourUnit:MapUnitCombatant, enemy:MapUnitCombatant) {
+        fun triggerVictoryUniques(ourUnit: MapUnitCombatant, enemy: MapUnitCombatant) {
             val stateForConditionals = StateForConditionals(civInfo = ourUnit.getCivInfo(),
-                ourCombatant = ourUnit, theirCombatant=enemy, tile = attackedTile)
+                ourCombatant = ourUnit, theirCombatant = enemy, tile = attackedTile)
             for (unique in ourUnit.unit.getTriggeredUniques(UniqueType.TriggerUponDefeatingUnit, stateForConditionals))
                 if (unique.conditionals.any { it.type == UniqueType.TriggerUponDefeatingUnit
                                 && enemy.unit.matchesFilter(it.params[0]) })
@@ -526,7 +526,7 @@ object Battle {
             if (civilianUnit != null) BattleUnitCapture.captureCivilianUnit(attacker, MapUnitCombatant(civilianUnit!!), checkDefeat = false)
             for (airUnit in airUnits.toList()) airUnit.destroy()
         }
-        
+
         val stateForConditionals = StateForConditionals(civInfo = attackerCiv, city=city, unit = attacker.unit, ourCombatant = attacker, attackedTile = city.getCenterTile())
         for (unique in attacker.getMatchingUniques(UniqueType.CaptureCityPlunder, stateForConditionals, true)) {
             attackerCiv.addStat(

--- a/core/src/com/unciv/logic/city/City.kt
+++ b/core/src/com/unciv/logic/city/City.kt
@@ -203,7 +203,7 @@ class City : IsPartOfGameInfoSerialization {
     fun getRuleset() = civ.gameInfo.ruleset
 
     fun getCityResources() = CityResources.getCityResources(this)
-    fun getResourceAmount(resourceName:String) = CityResources.getResourceAmount(this, resourceName)
+    fun getResourceAmount(resourceName: String) = CityResources.getResourceAmount(this, resourceName)
 
     fun isGrowing() = foodForNextTurn() > 0
     fun isStarving() = foodForNextTurn() < 0

--- a/core/src/com/unciv/logic/city/CityConstructions.kt
+++ b/core/src/com/unciv/logic/city/CityConstructions.kt
@@ -140,11 +140,11 @@ class CityConstructions : IsPartOfGameInfoSerialization {
     }
 
     /** @param constructionName needs to be a non-perpetual construction, else an empty string is returned */
-    internal fun getTurnsToConstructionString(constructionName: String, useStoredProduction:Boolean = true) =
+    internal fun getTurnsToConstructionString(constructionName: String, useStoredProduction: Boolean = true) =
         getTurnsToConstructionString(getConstruction(constructionName), useStoredProduction)
 
     /** @param construction needs to be a non-perpetual construction, else an empty string is returned */
-    internal fun getTurnsToConstructionString(construction: IConstruction, useStoredProduction:Boolean = true): String {
+    internal fun getTurnsToConstructionString(construction: IConstruction, useStoredProduction: Boolean = true): String {
         if (construction !is INonPerpetualConstruction) return ""   // shouldn't happen
         val cost = construction.getProductionCost(city.civ, city)
         val turnsToConstruction = turnsToConstruction(construction.name, useStoredProduction)
@@ -590,7 +590,7 @@ class CityConstructions : IsPartOfGameInfoSerialization {
         setTransients()
     }
 
-    fun updateUniques(onLoadGame:Boolean = false) {
+    fun updateUniques(onLoadGame: Boolean = false) {
         builtBuildingUniqueMap.clear()
         for (building in getBuiltBuildings())
             builtBuildingUniqueMap.addUniques(building.uniqueObjects)

--- a/core/src/com/unciv/logic/city/CityStats.kt
+++ b/core/src/com/unciv/logic/city/CityStats.kt
@@ -204,7 +204,7 @@ class CityStats(val city: City) {
 
         val cityStateStatsMultipliers = city.civ.getMatchingUniques(UniqueType.BonusStatsFromCityStates).toList()
 
-        fun addUniqueStats(unique:Unique) {
+        fun addUniqueStats(unique: Unique) {
             val stats = unique.stats.clone()
             if (unique.sourceObjectType==UniqueTarget.CityState)
                 for (multiplierUnique in cityStateStatsMultipliers)
@@ -244,7 +244,7 @@ class CityStats(val city: City) {
     private fun getStatsPercentBonusesFromUniquesBySource(currentConstruction: IConstruction): StatTreeNode {
         val sourceToStats = StatTreeNode()
 
-        fun addUniqueStats(unique:Unique, stat:Stat, amount:Float) {
+        fun addUniqueStats(unique: Unique, stat: Stat, amount: Float) {
             sourceToStats.addStats(Stats().add(stat, amount), unique.getSourceNameForUser(), unique.sourceObjectName ?: "")
         }
 
@@ -339,7 +339,7 @@ class CityStats(val city: City) {
     //endregion
     //region State-Changing Methods
 
-    fun updateTileStats(localUniqueCache:LocalUniqueCache = LocalUniqueCache()) {
+    fun updateTileStats(localUniqueCache: LocalUniqueCache = LocalUniqueCache()) {
         val stats = Stats()
         val workedTiles = city.tilesInRange.asSequence()
             .filter {

--- a/core/src/com/unciv/logic/civilization/Civilization.kt
+++ b/core/src/com/unciv/logic/civilization/Civilization.kt
@@ -443,7 +443,7 @@ class Civilization : IsPartOfGameInfoSerialization {
     /** Gets the number of resources available to this city
      * Does not include city-wide resources
      * Returns 0 for undefined resources */
-    fun getResourceAmount(resourceName:String): Int {
+    fun getResourceAmount(resourceName: String): Int {
         return getCivResourcesByName()[resourceName] ?: 0
     }
 

--- a/core/src/com/unciv/logic/civilization/ExploredRegion.kt
+++ b/core/src/com/unciv/logic/civilization/ExploredRegion.kt
@@ -62,9 +62,9 @@ class ExploredRegion : IsPartOfGameInfoSerialization {
     fun getRectangle(): Rectangle = exploredRectangle
     fun shouldRestrictX(): Boolean = shouldRestrictX
     fun getLeftX(): Float = topLeftStage.x
-    fun getRightX():Float = bottomRightStage.x
+    fun getRightX(): Float = bottomRightStage.x
     fun getTopY(): Float = topLeftStage.y
-    fun getBottomY():Float = bottomRightStage.y
+    fun getBottomY(): Float = bottomRightStage.y
 
     fun clone(): ExploredRegion {
         val toReturn = ExploredRegion()

--- a/core/src/com/unciv/logic/civilization/diplomacy/DeclareWar.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DeclareWar.kt
@@ -116,7 +116,7 @@ object DeclareWar {
 
 
     /** Everything that happens to both sides equally when war is declared by one side on the other */
-    private fun onWarDeclared(diplomacyManager:DiplomacyManager, isOffensiveWar: Boolean) {
+    private fun onWarDeclared(diplomacyManager: DiplomacyManager, isOffensiveWar: Boolean) {
         // Cancel all trades.
         for (trade in diplomacyManager.trades)
             for (offer in trade.theirOffers.filter { it.duration > 0 && it.name != Constants.defensivePact})

--- a/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
@@ -67,7 +67,7 @@ enum class DiplomacyFlags {
     RecentlyAttacked,
 }
 
-enum class DiplomaticModifiers(val text:String) {
+enum class DiplomaticModifiers(val text: String) {
     // Negative
     DeclaredWarOnUs("You declared war on us!"),
     WarMongerer("Your warmongering ways are unacceptable to us."),

--- a/core/src/com/unciv/logic/civilization/managers/UnitManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/UnitManager.kt
@@ -12,7 +12,7 @@ import com.unciv.models.ruleset.unique.UniqueTriggerActivation
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.ruleset.unit.BaseUnit
 
-class UnitManager(val civInfo:Civilization) {
+class UnitManager(val civInfo: Civilization) {
 
     /**
      * We never add or remove from here directly, could cause comodification problems.

--- a/core/src/com/unciv/logic/files/MapSaver.kt
+++ b/core/src/com/unciv/logic/files/MapSaver.kt
@@ -12,7 +12,7 @@ object MapSaver {
     const val mapsFolder = "maps"
     var saveZipped = true
 
-    private fun getMap(mapName:String) = Gdx.files.local("$mapsFolder/$mapName")
+    private fun getMap(mapName: String) = Gdx.files.local("$mapsFolder/$mapName")
 
     fun mapFromSavedString(mapString: String): TileMap {
         val unzippedJson = try {

--- a/core/src/com/unciv/logic/files/UncivFiles.kt
+++ b/core/src/com/unciv/logic/files/UncivFiles.kt
@@ -404,7 +404,7 @@ class UncivFiles(
         }
 
         /** Returns gzipped serialization of [game], optionally gzipped ([forceZip] overrides [saveZipped]) */
-        fun gameInfoToString(game: GameInfo, forceZip: Boolean? = null, updateChecksum:Boolean=false): String {
+        fun gameInfoToString(game: GameInfo, forceZip: Boolean? = null, updateChecksum: Boolean = false): String {
             game.version = GameInfo.CURRENT_COMPATIBILITY_VERSION
 
             if (updateChecksum) game.checksum = game.calculateChecksum()

--- a/core/src/com/unciv/logic/github/Github.kt
+++ b/core/src/com/unciv/logic/github/Github.kt
@@ -197,7 +197,7 @@ object Github {
      * @return              Parsed [RepoSearch][GithubAPI.RepoSearch] json on success, `null` on failure.
      * @see <a href="https://docs.github.com/en/rest/reference/search#search-repositories">Github API doc</a>
      */
-    fun tryGetGithubReposWithTopic(amountPerPage:Int, page:Int, searchRequest: String = ""): GithubAPI.RepoSearch? {
+    fun tryGetGithubReposWithTopic(amountPerPage: Int, page: Int, searchRequest: String = ""): GithubAPI.RepoSearch? {
         val link = GithubAPI.getUrlForModListing(searchRequest, amountPerPage, page)
         var retries = 2
         while (retries > 0) {

--- a/core/src/com/unciv/logic/map/TileMap.kt
+++ b/core/src/com/unciv/logic/map/TileMap.kt
@@ -355,10 +355,10 @@ class TileMap(initialCapacity: Int = 10) : IsPartOfGameInfoSerialization {
             vectorUnwrappedLeft
     }
 
-    data class ViewableTile(val tile: Tile, val maxHeightSeenToTile:Int, val isVisible:Boolean, val isAttackable: Boolean)
+    data class ViewableTile(val tile: Tile, val maxHeightSeenToTile: Int, val isVisible: Boolean, val isAttackable: Boolean)
 
     /** @return List of tiles visible from location [position] for a unit with sight range [sightDistance] */
-    fun getViewableTiles(position: Vector2, sightDistance: Int, forAttack:Boolean = false): List<Tile> {
+    fun getViewableTiles(position: Vector2, sightDistance: Int, forAttack: Boolean = false): List<Tile> {
         val aUnitHeight = get(position).unitHeight
         val viewableTiles = mutableListOf(ViewableTile(
             get(position),

--- a/core/src/com/unciv/logic/map/mapgenerator/mapregions/MapRegions.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/mapregions/MapRegions.kt
@@ -29,7 +29,7 @@ import kotlin.math.min
 import kotlin.math.roundToInt
 import kotlin.random.Random
 
-class TileDataMap:HashMap<Vector2, MapGenTileData>() {
+class TileDataMap : HashMap<Vector2, MapGenTileData>() {
 
     /** Adds numbers to tileData in a similar way to closeStartPenalty, but for different types */
     fun placeImpact(type: MapRegions.ImpactType, tile: Tile, radius: Int) {

--- a/core/src/com/unciv/logic/map/mapgenerator/mapregions/MinorCivPlacer.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/mapregions/MinorCivPlacer.kt
@@ -14,7 +14,7 @@ object MinorCivPlacer {
      *  Note: can silently fail to place all city states if there is too little room.
      *  Currently our GameStarter fills out with random city states, Civ V behavior is to
      *  forget about the discarded city states entirely. */
-    fun placeMinorCivs(regions: List<Region>, tileMap: TileMap, civs: List<Civilization>, usingArchipelagoRegions:Boolean, tileData: TileDataMap, ruleset: Ruleset) {
+    fun placeMinorCivs(regions: List<Region>, tileMap: TileMap, civs: List<Civilization>, usingArchipelagoRegions: Boolean, tileData: TileDataMap, ruleset: Ruleset) {
         if (civs.isEmpty()) return
 
         // Some but not all city states are assigned to regions directly. Determine the CS density.

--- a/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
@@ -460,7 +460,7 @@ class MapUnit : IsPartOfGameInfoSerialization {
         return true
     }
 
-    fun getInterceptionRange():Int {
+    fun getInterceptionRange(): Int {
         val rangeFromUniques = getMatchingUniques(UniqueType.AirInterceptionRange, checkCivInfoUniques = true)
             .sumOf { it.params[0].toInt() }
         return baseUnit.interceptRange + rangeFromUniques
@@ -534,7 +534,7 @@ class MapUnit : IsPartOfGameInfoSerialization {
         return MultiFilter.multiFilter(filter, ::matchesSingleFilter)
     }
 
-    private fun matchesSingleFilter(filter:String): Boolean {
+    private fun matchesSingleFilter(filter: String): Boolean {
         return when (filter) {
             Constants.wounded, "wounded units" -> health < 100
             Constants.barbarians, "Barbarian" -> civ.isBarbarian()

--- a/core/src/com/unciv/logic/map/mapunit/UnitPromotions.kt
+++ b/core/src/com/unciv/logic/map/mapunit/UnitPromotions.kt
@@ -116,7 +116,7 @@ class UnitPromotions : IsPartOfGameInfoSerialization {
         return unit.civ.gameInfo.ruleset.unitPromotions.values.asSequence().filter { isAvailable(it) }
     }
 
-    private fun isAvailable(promotion: Promotion):Boolean {
+    private fun isAvailable(promotion: Promotion): Boolean {
         if (promotion.name in promotions) return false
         if (unit.type.name !in promotion.unitTypes) return false
         if (promotion.prerequisites.isNotEmpty() && promotion.prerequisites.none { it in promotions }) return false

--- a/core/src/com/unciv/logic/map/mapunit/UnitUpgradeManager.kt
+++ b/core/src/com/unciv/logic/map/mapunit/UnitUpgradeManager.kt
@@ -8,7 +8,7 @@ import com.unciv.ui.components.extensions.toPercent
 import com.unciv.ui.screens.worldscreen.unit.actions.UnitActionsUpgrade
 import kotlin.math.pow
 
-class UnitUpgradeManager(val unit:MapUnit) {
+class UnitUpgradeManager(val unit: MapUnit) {
 
     /** Check whether this unit can upgrade to [unitToUpgradeTo]. This does not check or follow the
      *  normal upgrade chain defined by [BaseUnit.getUpgradeUnits]

--- a/core/src/com/unciv/logic/map/mapunit/movement/MovementCost.kt
+++ b/core/src/com/unciv/logic/map/mapunit/movement/MovementCost.kt
@@ -120,7 +120,7 @@ object MovementCost {
         return hasDoubleMovement(doubleMovement, target, stateForConditionals)
     }
 
-    private fun getEnemyMovementPenalty(civInfo:Civilization, enemyUnit: MapUnit): Float {
+    private fun getEnemyMovementPenalty(civInfo: Civilization, enemyUnit: MapUnit): Float {
         if (civInfo.enemyMovementPenaltyUniques != null && civInfo.enemyMovementPenaltyUniques!!.any()) {
             return civInfo.enemyMovementPenaltyUniques!!.sumOf {
                 if (it.type!! == UniqueType.EnemyUnitsSpendExtraMovement

--- a/core/src/com/unciv/logic/map/mapunit/movement/UnitMovement.kt
+++ b/core/src/com/unciv/logic/map/mapunit/movement/UnitMovement.kt
@@ -16,7 +16,7 @@ class UnitMovement(val unit: MapUnit) {
 
     private val pathfindingCache = PathfindingCache(unit)
 
-    class ParentTileAndTotalDistance(val tile:Tile, val parentTile: Tile, val totalDistance: Float)
+    class ParentTileAndTotalDistance(val tile: Tile, val parentTile: Tile, val totalDistance: Float)
 
     fun isUnknownTileWeShouldAssumeToBePassable(tile: Tile) = !unit.civ.hasExplored(tile)
 

--- a/core/src/com/unciv/logic/map/tile/Tile.kt
+++ b/core/src/com/unciv/logic/map/tile/Tile.kt
@@ -472,7 +472,7 @@ open class Tile : IsPartOfGameInfoSerialization {
     }
 
     // This should be the only adjacency function
-    fun isAdjacentTo(terrainFilter:String, observingCiv: Civilization?=null): Boolean {
+    fun isAdjacentTo(terrainFilter: String, observingCiv: Civilization? = null): Boolean {
         // Rivers are odd, as they aren't technically part of any specific tile but still count towards adjacency
         if (terrainFilter == Constants.river) return isAdjacentToRiver()
         if (terrainFilter == Constants.freshWater && isAdjacentToRiver()) return true

--- a/core/src/com/unciv/logic/map/tile/TileInfoImprovementFunctions.kt
+++ b/core/src/com/unciv/logic/map/tile/TileInfoImprovementFunctions.kt
@@ -247,7 +247,7 @@ class TileInfoImprovementFunctions(val tile: Tile) {
         unit: MapUnit? = null
     ) {
         val stateForConditionals = StateForConditionals(civ, unit = unit, tile = tile)
-        
+
         for (unique in improvement.uniqueObjects.filter { !it.hasTriggerConditional()
             && it.conditionalsApply(stateForConditionals) })
             UniqueTriggerActivation.triggerUnique(unique, civ, unit = unit, tile = tile)
@@ -255,7 +255,7 @@ class TileInfoImprovementFunctions(val tile: Tile) {
         for (unique in civ.getTriggeredUniques(UniqueType.TriggerUponBuildingImprovement, stateForConditionals)
             .filter { improvement.matchesFilter(it.params[0]) })
             UniqueTriggerActivation.triggerUnique(unique, civ, unit = unit, tile = tile)
-        
+
         if (unit == null) return
         for (unique in unit.getTriggeredUniques(UniqueType.TriggerUponBuildingImprovement, stateForConditionals)
             .filter { improvement.matchesFilter(it.params[0]) })
@@ -292,7 +292,7 @@ class TileInfoImprovementFunctions(val tile: Tile) {
         }
     }
 
-    private fun tryProvideProductionToClosestCity(removedTerrainFeature: String, civ:Civilization) {
+    private fun tryProvideProductionToClosestCity(removedTerrainFeature: String, civ: Civilization) {
         val closestCity = civ.cities.minByOrNull { it.getCenterTile().aerialDistanceTo(tile) }
         @Suppress("FoldInitializerAndIfToElvis")
         if (closestCity == null) return

--- a/core/src/com/unciv/logic/multiplayer/OnlineMultiplayer.kt
+++ b/core/src/com/unciv/logic/multiplayer/OnlineMultiplayer.kt
@@ -294,7 +294,7 @@ class OnlineMultiplayer {
     /**
      * Fires [MultiplayerGameNameChanged]
      */
-    fun changeGameName(game: OnlineMultiplayerGame, newName: String, onException:(Exception?)->Unit) {
+    fun changeGameName(game: OnlineMultiplayerGame, newName: String, onException: (Exception?)->Unit) {
         debug("Changing name of game %s to", game.name, newName)
         val oldPreview = game.preview ?: throw game.error!!
         val oldLastUpdate = game.lastUpdate

--- a/core/src/com/unciv/logic/trade/Trade.kt
+++ b/core/src/com/unciv/logic/trade/Trade.kt
@@ -19,7 +19,7 @@ class Trade : IsPartOfGameInfoSerialization {
         return newTrade
     }
 
-    fun equalTrade(trade: Trade):Boolean{
+    fun equalTrade(trade: Trade): Boolean {
        if(trade.ourOffers.size!=ourOffers.size
            || trade.theirOffers.size!=theirOffers.size) return false
 
@@ -32,7 +32,7 @@ class Trade : IsPartOfGameInfoSerialization {
         return true
     }
 
-    fun clone():Trade{
+    fun clone(): Trade {
         val toReturn = Trade()
         toReturn.theirOffers.addAll(theirOffers)
         toReturn.ourOffers.addAll(ourOffers)
@@ -51,7 +51,7 @@ class Trade : IsPartOfGameInfoSerialization {
 
 
 class TradeRequest : IsPartOfGameInfoSerialization {
-    fun decline(decliningCiv:Civilization) {
+    fun decline(decliningCiv: Civilization) {
         val requestingCivInfo = decliningCiv.gameInfo.getCivilization(requestingCiv)
         val requestingCivDiploManager = requestingCivInfo.getDiplomacyManager(decliningCiv)
         // the numbers of the flags (20,5) are the amount of turns to wait until offering again

--- a/core/src/com/unciv/logic/trade/TradeEvaluation.kt
+++ b/core/src/com/unciv/logic/trade/TradeEvaluation.kt
@@ -186,7 +186,7 @@ class TradeEvaluation {
         return 0
     }
 
-    private fun getNeighbouringCivs(city:City): Set<String> {
+    private fun getNeighbouringCivs(city: City): Set<String> {
         val tilesList: HashSet<Tile> = city.getTiles().toHashSet()
         val cityPositionList: ArrayList<Tile> = arrayListOf()
 

--- a/core/src/com/unciv/logic/trade/TradeLogic.kt
+++ b/core/src/com/unciv/logic/trade/TradeLogic.kt
@@ -10,7 +10,7 @@ import com.unciv.logic.civilization.diplomacy.DiplomaticModifiers
 import com.unciv.models.ruleset.tile.ResourceType
 import com.unciv.models.ruleset.unique.UniqueType
 
-class TradeLogic(val ourCivilization:Civilization, val otherCivilization: Civilization) {
+class TradeLogic(val ourCivilization: Civilization, val otherCivilization: Civilization) {
 
     /** Contains everything we could offer the other player, whether we've actually offered it or not */
     val ourAvailableOffers = getAvailableOffers(ourCivilization, otherCivilization)

--- a/core/src/com/unciv/models/metadata/BaseRuleset.kt
+++ b/core/src/com/unciv/models/metadata/BaseRuleset.kt
@@ -1,7 +1,7 @@
 package com.unciv.models.metadata
 
 @Suppress("EnumEntryName")  // These merit unusual names
-enum class BaseRuleset(val fullName:String) {
+enum class BaseRuleset(val fullName: String) {
     Civ_V_Vanilla("Civ V - Vanilla"),
     Civ_V_GnK("Civ V - Gods & Kings"),
 }

--- a/core/src/com/unciv/models/metadata/GameSettings.kt
+++ b/core/src/com/unciv/models/metadata/GameSettings.kt
@@ -39,7 +39,7 @@ class GameSettings {
     var language: String = Constants.english
     @Transient
     var locale: Locale? = null
-    var screenSize:ScreenSize = ScreenSize.Small
+    var screenSize: ScreenSize = ScreenSize.Small
     var screenMode: Int = 0
     var tutorialsShown = HashSet<String>()
     var tutorialTasksCompleted = HashSet<String>()
@@ -354,7 +354,7 @@ class GameSettings {
 
         fun isAutoPlaying(): Boolean = turnsToAutoPlay > 0
 
-        fun isAutoPlayingAndFullAI():Boolean = isAutoPlaying() && fullAutoPlayAI
+        fun isAutoPlayingAndFullAI(): Boolean = isAutoPlaying() && fullAutoPlayAI
     }
 
     @Suppress("SuspiciousCallableReferenceInLambda")  // By @Azzurite, safe as long as that warning below is followed

--- a/core/src/com/unciv/models/metadata/Player.kt
+++ b/core/src/com/unciv/models/metadata/Player.kt
@@ -7,5 +7,5 @@ import com.unciv.logic.civilization.PlayerType
 class Player(
     var chosenCiv: String = Constants.random,
     var playerType: PlayerType = PlayerType.AI,
-    var playerId:String = ""
+    var playerId: String = ""
 ) : IsPartOfGameInfoSerialization

--- a/core/src/com/unciv/models/ruleset/RulesetCache.kt
+++ b/core/src/com/unciv/models/ruleset/RulesetCache.kt
@@ -23,7 +23,7 @@ object RulesetCache : HashMap<String, Ruleset>() {
 
 
     /** Returns error lines from loading the rulesets, so we can display the errors to users */
-    fun loadRulesets(consoleMode: Boolean = false, noMods: Boolean = false) :List<String> {
+    fun loadRulesets(consoleMode: Boolean = false, noMods: Boolean = false): List<String> {
         val newRulesets = HashMap<String, Ruleset>()
 
         for (ruleset in BaseRuleset.values()) {

--- a/core/src/com/unciv/models/ruleset/nation/CityStateType.kt
+++ b/core/src/com/unciv/models/ruleset/nation/CityStateType.kt
@@ -13,7 +13,7 @@ class CityStateType: INamed {
     var allyBonusUniques = ArrayList<String>()
     val allyBonusUniqueMap by lazy { UniqueMap().apply { addUniques(allyBonusUniques.map { Unique(it, sourceObjectType = UniqueTarget.CityState) }) } }
 
-    var color:List<Int> = listOf(255,255,255)
+    var color: List<Int> = listOf(255,255,255)
     private val colorObject by lazy { colorFromRGB(color) }
     fun getColor() = colorObject
 }

--- a/core/src/com/unciv/models/ruleset/nation/Difficulty.kt
+++ b/core/src/com/unciv/models/ruleset/nation/Difficulty.kt
@@ -11,30 +11,30 @@ class Difficulty: INamed, ICivilopediaText {
     override lateinit var name: String
     var baseHappiness: Int = 0
     var extraHappinessPerLuxury: Float = 0f
-    var researchCostModifier:Float = 1f
-    var unitCostModifier:Float = 1f
+    var researchCostModifier: Float = 1f
+    var unitCostModifier: Float = 1f
     var unitSupplyBase: Int = 5
     var unitSupplyPerCity: Int = 2
-    var buildingCostModifier:Float = 1f
-    var policyCostModifier:Float = 1f
-    var unhappinessModifier:Float = 1f
-    var barbarianBonus:Float = 0f
+    var buildingCostModifier: Float = 1f
+    var policyCostModifier: Float = 1f
+    var unhappinessModifier: Float = 1f
+    var barbarianBonus: Float = 0f
     var barbarianSpawnDelay: Int = 0
     var playerBonusStartingUnits = ArrayList<String>()
 
-    var aiCityGrowthModifier:Float = 1f
-    var aiUnitCostModifier:Float = 1f
-    var aiBuildingCostModifier:Float = 1f
-    var aiWonderCostModifier:Float = 1f
-    var aiBuildingMaintenanceModifier:Float = 1f
-    var aiUnitMaintenanceModifier = 1f
+    var aiCityGrowthModifier: Float = 1f
+    var aiUnitCostModifier: Float = 1f
+    var aiBuildingCostModifier: Float = 1f
+    var aiWonderCostModifier: Float = 1f
+    var aiBuildingMaintenanceModifier: Float = 1f
+    var aiUnitMaintenanceModifier: Float = 1f
     var aiUnitSupplyModifier: Float = 0f
     var aiFreeTechs = ArrayList<String>()
     var aiMajorCivBonusStartingUnits = ArrayList<String>()
     var aiCityStateBonusStartingUnits = ArrayList<String>()
-    var aiUnhappinessModifier = 1f
-    var turnBarbariansCanEnterPlayerTiles = 0
-    var clearBarbarianCampReward = 25
+    var aiUnhappinessModifier: Float = 1f
+    var turnBarbariansCanEnterPlayerTiles: Int = 0
+    var clearBarbarianCampReward: Int = 25
 
     // property defined in json but so far unused:
     // var aisExchangeTechs = false

--- a/core/src/com/unciv/models/ruleset/nation/Personality.kt
+++ b/core/src/com/unciv/models/ruleset/nation/Personality.kt
@@ -34,7 +34,7 @@ class Personality: RulesetObject() {
     var preferredVictoryType: String = Constants.neutralVictoryType
     var isNeutralPersonality: Boolean = false
 
-    private fun nameToVariable(value: PersonalityValue):KMutableProperty0<Float> {
+    private fun nameToVariable(value: PersonalityValue): KMutableProperty0<Float> {
         return when(value) {
             PersonalityValue.Production -> ::production
             PersonalityValue.Food -> ::food

--- a/core/src/com/unciv/models/ruleset/tile/ResourceType.kt
+++ b/core/src/com/unciv/models/ruleset/tile/ResourceType.kt
@@ -2,7 +2,7 @@ package com.unciv.models.ruleset.tile
 
 import com.badlogic.gdx.graphics.Color
 
-enum class ResourceType(val color:String) {
+enum class ResourceType(val color: String) {
     Luxury("#ffd800"),
     Strategic("#c14d00"),
     Bonus("#a8c3c9");

--- a/core/src/com/unciv/models/ruleset/tile/Terrain.kt
+++ b/core/src/com/unciv/models/ruleset/tile/Terrain.kt
@@ -35,7 +35,7 @@ class Terrain : RulesetStatsObject() {
     @Suppress("PropertyName")   // RGB is expected to be in caps
     var RGB: List<Int>? = null
     var movementCost = 1
-    var defenceBonus:Float = 0f
+    var defenceBonus: Float = 0f
     var impassable = false
 
     @Transient

--- a/core/src/com/unciv/models/ruleset/tile/TileImprovement.kt
+++ b/core/src/com/unciv/models/ruleset/tile/TileImprovement.kt
@@ -25,7 +25,7 @@ class TileImprovement : RulesetStatsObject() {
 
     var terrainsCanBeBuiltOn: Collection<String> = ArrayList()
     var techRequired: String? = null
-    var uniqueTo:String? = null
+    var uniqueTo: String? = null
     override fun getUniqueTarget() = UniqueTarget.Improvement
     val shortcutKey: Char? = null
     // This is the base cost. A cost of 0 means created instead of buildable.

--- a/core/src/com/unciv/models/ruleset/tile/TileResource.kt
+++ b/core/src/com/unciv/models/ruleset/tile/TileResource.kt
@@ -141,7 +141,7 @@ class TileResource : RulesetStatsObject() {
         }
     }
 
-    fun generatesNaturallyOn(tile:Tile): Boolean {
+    fun generatesNaturallyOn(tile: Tile): Boolean {
         if (tile.lastTerrain.name !in terrainsCanBeFoundOn) return false
         val stateForConditionals = StateForConditionals(tile = tile)
         if (hasUnique(UniqueType.NoNaturalGeneration, stateForConditionals)) return false

--- a/core/src/com/unciv/models/ruleset/unique/Unique.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Unique.kt
@@ -151,7 +151,7 @@ class Unique(val text: String, val sourceObjectType: UniqueTarget? = null, val s
 
 /** Used to cache results of getMatchingUniques
  * Must only be used when we're sure the matching uniques will not change in the meantime */
-class LocalUniqueCache(val cache:Boolean = true) {
+class LocalUniqueCache(val cache: Boolean = true) {
     // This stores sequences *that iterate directly on a list* - that is, pre-resolved
     private val keyToUniques = HashMap<String, Sequence<Unique>>()
 

--- a/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
@@ -101,7 +101,7 @@ enum class UniqueParameterType(
         override fun getErrorSeverity(parameterText: String, ruleset: Ruleset):
                 UniqueType.UniqueParameterErrorSeverity? = getErrorSeverityForFilter(parameterText, ruleset)
 
-        override fun isKnownValue(parameterText:String, ruleset: Ruleset): Boolean {
+        override fun isKnownValue(parameterText: String, ruleset: Ruleset): Boolean {
             if (parameterText in knownValues) return true
             if (ruleset.unitPromotions.values.any { it.hasUnique(parameterText) }) return true
             if (CivFilter.isKnownValue(parameterText, ruleset)) return true
@@ -122,7 +122,7 @@ enum class UniqueParameterType(
         override fun getErrorSeverity(parameterText: String, ruleset: Ruleset):
             UniqueType.UniqueParameterErrorSeverity? = getErrorSeverityForFilter(parameterText, ruleset)
 
-        override fun isKnownValue(parameterText:String, ruleset: Ruleset): Boolean {
+        override fun isKnownValue(parameterText: String, ruleset: Ruleset): Boolean {
             if (parameterText in knownValues) return true
             if (UnitName.getErrorSeverity(parameterText, ruleset) == null) return true
             if (ruleset.units.values.any { it.uniques.contains(parameterText) }) return true

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -158,7 +158,7 @@ object UniqueTriggerActivation {
 
                 if (actualAmount <= 0) return null
 
-                fun placeUnits():Boolean {
+                fun placeUnits(): Boolean {
                     val tilesUnitsWerePlacedOn: MutableList<Vector2> = mutableListOf()
                     repeat(actualAmount) {
                         val placedUnit = when {
@@ -208,7 +208,7 @@ object UniqueTriggerActivation {
                 val placingTile =
                     tile ?: civInfo.cities.random().getCenterTile()
 
-                fun placeUnit():Boolean {
+                fun placeUnit(): Boolean {
                     val placedUnit = civInfo.units.placeUnitNearTile(placingTile.position, civUnit.name)
                     if (notification != null && placedUnit != null) {
                         val notificationText =

--- a/core/src/com/unciv/models/ruleset/unit/Promotion.kt
+++ b/core/src/com/unciv/models/ruleset/unit/Promotion.kt
@@ -43,7 +43,7 @@ class Promotion : RulesetObject() {
 
 
     /** Used to describe a Promotion on the PromotionPickerScreen - fully translated */
-    fun getDescription(promotionsForUnitType: Collection<Promotion>):String {
+    fun getDescription(promotionsForUnitType: Collection<Promotion>): String {
         val textList = ArrayList<String>()
 
         uniquesToDescription(textList)

--- a/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
+++ b/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
@@ -564,7 +564,7 @@ class RulesetValidator(val ruleset: Ruleset) {
         }
     }
 
-    data class SuggestedColors(val innerColor: Color, val outerColor:Color)
+    data class SuggestedColors(val innerColor: Color, val outerColor: Color)
 
     private fun getSuggestedColors(nation: Nation): SuggestedColors {
         val innerColorLuminance = getRelativeLuminance(nation.getInnerColor())

--- a/core/src/com/unciv/models/ruleset/validation/TextSimilarity.kt
+++ b/core/src/com/unciv/models/ruleset/validation/TextSimilarity.kt
@@ -76,7 +76,7 @@ fun getTextDistance(text1: String, text2: String): Int {
 /** @return the [getTextDistance] of two strings relative to their average length.
  * The original algorithm is very weak to short strings with errors at the start (can't figure out that "on [] tiles" and "in [] tiles" are the same)
  * So we run it twice, once with the string reversed */
-fun getRelativeTextDistance(text1: String, text2: String): Double{
-    fun textDistance(a:String, b:String):Double = getTextDistance(a, b).toDouble() / (text1.length + text2.length) * 2.0
+fun getRelativeTextDistance(text1: String, text2: String): Double {
+    fun textDistance(a: String, b: String): Double = getTextDistance(a, b).toDouble() / (text1.length + text2.length) * 2.0
     return min(textDistance(text1, text2), textDistance(text1.reversed(), text2.reversed()))
 }

--- a/core/src/com/unciv/models/ruleset/validation/UniqueValidator.kt
+++ b/core/src/com/unciv/models/ruleset/validation/UniqueValidator.kt
@@ -215,7 +215,7 @@ class UniqueValidator(val ruleset: Ruleset) {
     }
 
     private val paramTypeErrorSeverityCache = HashMap<UniqueParameterType, HashMap<String, UniqueType.UniqueParameterErrorSeverity?>>()
-    private fun getParamTypeErrorSeverityCached(uniqueParameterType: UniqueParameterType, param:String): UniqueType.UniqueParameterErrorSeverity? {
+    private fun getParamTypeErrorSeverityCached(uniqueParameterType: UniqueParameterType, param: String): UniqueType.UniqueParameterErrorSeverity? {
         if (!paramTypeErrorSeverityCache.containsKey(uniqueParameterType))
             paramTypeErrorSeverityCache[uniqueParameterType] = hashMapOf()
         val uniqueParamCache = paramTypeErrorSeverityCache[uniqueParameterType]!!

--- a/core/src/com/unciv/models/stats/Stat.kt
+++ b/core/src/com/unciv/models/stats/Stat.kt
@@ -10,7 +10,7 @@ enum class Stat(
     val notificationIcon: String,
     val purchaseSound: UncivSound,
     val character: Char,
-    val color:Color
+    val color: Color
 ) {
     Production(NotificationIcon.Production, UncivSound.Click, Fonts.production, colorFromHex(0xc14d00)),
     Food(NotificationIcon.Food, UncivSound.Click, Fonts.food, colorFromHex(0x24A348)),

--- a/core/src/com/unciv/models/stats/Stats.kt
+++ b/core/src/com/unciv/models/stats/Stats.kt
@@ -23,7 +23,7 @@ open class Stats(
 
     // This is what facilitates indexed access by [Stat] or add(Stat,Float)
     // without additional memory allocation or expensive conditionals
-    private fun statToProperty(stat: Stat):KMutableProperty0<Float>{
+    private fun statToProperty(stat: Stat): KMutableProperty0<Float> {
         return when(stat) {
             Stat.Production -> ::production
             Stat.Food -> ::food
@@ -262,7 +262,7 @@ open class Stats(
     }
 }
 
-class StatMap:LinkedHashMap<String,Stats>() {
+class StatMap : LinkedHashMap<String,Stats>() {
     fun add(source: String, stats: Stats) {
         // We always clone to avoid touching the mutable stats of uniques
         if (!containsKey(source)) put(source, stats.clone())

--- a/core/src/com/unciv/models/tilesets/TileSetCache.kt
+++ b/core/src/com/unciv/models/tilesets/TileSetCache.kt
@@ -101,7 +101,7 @@ object TileSetCache : HashMap<String, TileSet>() {
     /** Determines potentially available TileSets - by scanning for TileSet jsons.
      *  Available before initialization finishes.
      */
-    fun getAvailableTilesets(imageGetterTilesets:Sequence<String>): Set<String> {
+    fun getAvailableTilesets(imageGetterTilesets: Sequence<String>): Set<String> {
         val modTilesetConfigFiles = Gdx.files.local("mods").list().asSequence()
             .filter { it.isDirectory && !it.name().startsWith('.') }
             .flatMap { it.child("jsons/TileSets").list().asSequence() }

--- a/core/src/com/unciv/models/translations/TranslationFileReader.kt
+++ b/core/src/com/unciv/models/translations/TranslationFileReader.kt
@@ -23,7 +23,7 @@ object TranslationFileReader {
         return translations
     }
 
-    fun readLanguagePercentages():HashMap<String,Int>{
+    fun readLanguagePercentages(): HashMap<String,Int> {
 
         val hashmap = HashMap<String,Int>()
         val percentageFile = Gdx.files.internal(percentagesFileLocation)

--- a/core/src/com/unciv/models/translations/Translations.kt
+++ b/core/src/com/unciv/models/translations/Translations.kt
@@ -147,7 +147,7 @@ class Translations : LinkedHashMap<String, TranslationEntry>() {
             for (file in Gdx.files.internal("jsons/translations").list())
                 languages.add(file.nameWithoutExtension())
         }
-        catch (ex:Exception) {
+        catch (ex: Exception) {
             Log.error("Failed to add languages", ex)
         } // Iterating on internal files will not work when running from a .jar
 
@@ -467,7 +467,7 @@ fun String.getPlaceholderText(): String {
     return stringToReturn
 }
 
-fun String.equalsPlaceholderText(str:String): Boolean {
+fun String.equalsPlaceholderText(str: String): Boolean {
     if (first() != str.first()) return false // for quick negative return 95% of the time
     return this.getPlaceholderText() == str
 }

--- a/core/src/com/unciv/ui/components/extensions/CollectionExtensions.kt
+++ b/core/src/com/unciv/ui/components/extensions/CollectionExtensions.kt
@@ -27,7 +27,7 @@ fun <T> List<T>.randomWeighted(weights: List<Float>, random: Random = Random): T
  *
  * Solves concurrent modification problems - everyone who had a reference to the previous arrayList can keep using it because it hasn't changed
  */
-fun <T> ArrayList<T>.withItem(item:T): ArrayList<T> {
+fun <T> ArrayList<T>.withItem(item: T): ArrayList<T> {
     val newArrayList = ArrayList(this)
     newArrayList.add(item)
     return newArrayList
@@ -37,7 +37,7 @@ fun <T> ArrayList<T>.withItem(item:T): ArrayList<T> {
  *
  * Solves concurrent modification problems - everyone who had a reference to the previous hashSet can keep using it because it hasn't changed
  */
-fun <T> HashSet<T>.withItem(item:T): HashSet<T> {
+fun <T> HashSet<T>.withItem(item: T): HashSet<T> {
     val newHashSet = HashSet(this)
     newHashSet.add(item)
     return newHashSet
@@ -47,7 +47,7 @@ fun <T> HashSet<T>.withItem(item:T): HashSet<T> {
  *
  * Solves concurrent modification problems - everyone who had a reference to the previous arrayList can keep using it because it hasn't changed
  */
-fun <T> ArrayList<T>.withoutItem(item:T): ArrayList<T> {
+fun <T> ArrayList<T>.withoutItem(item: T): ArrayList<T> {
     val newArrayList = ArrayList(this)
     newArrayList.remove(item)
     return newArrayList
@@ -57,7 +57,7 @@ fun <T> ArrayList<T>.withoutItem(item:T): ArrayList<T> {
  *
  * Solves concurrent modification problems - everyone who had a reference to the previous hashSet can keep using it because it hasn't changed
  */
-fun <T> HashSet<T>.withoutItem(item:T): HashSet<T> {
+fun <T> HashSet<T>.withoutItem(item: T): HashSet<T> {
     val newHashSet = HashSet(this)
     newHashSet.remove(item)
     return newHashSet

--- a/core/src/com/unciv/ui/components/extensions/FormattingExtensions.kt
+++ b/core/src/com/unciv/ui/components/extensions/FormattingExtensions.kt
@@ -20,7 +20,7 @@ fun Int.toPercent() = toFloat().toPercent()
 fun Float.toPercent() = 1 + this/100
 
 /** Convert a [resource name][this] into "Consumes [amount] $resource" string (untranslated) */
-fun String.getConsumesAmountString(amount: Int, isStockpiled:Boolean): String {
+fun String.getConsumesAmountString(amount: Int, isStockpiled: Boolean): String {
     val uniqueString = "{Consumes [$amount] [$this]}"
     return if (isStockpiled) "$uniqueString /${Fonts.turn}" else uniqueString
 }

--- a/core/src/com/unciv/ui/components/extensions/Scene2dExtensions.kt
+++ b/core/src/com/unciv/ui/components/extensions/Scene2dExtensions.kt
@@ -117,7 +117,7 @@ fun Actor.surroundWithCircle(
 fun Actor.surroundWithThinCircle(color: Color=Color.BLACK): IconCircleGroup = surroundWithCircle(width+2f, false, color)
 
 
-fun Actor.addBorder(size:Float, color: Color, expandCell:Boolean = false): Table {
+fun Actor.addBorder(size: Float, color: Color, expandCell: Boolean = false): Table {
     val table = Table()
     table.pad(size)
     table.background = BaseScreen.skinStrings.getUiBackground("General/Border", tintColor = color)
@@ -182,7 +182,7 @@ fun Rectangle.getOverlap(other: Rectangle): Rectangle? {
 val Rectangle.top get() = y + height
 val Rectangle.right get() = x + width
 
-fun Group.addBorderAllowOpacity(size:Float, color: Color): Group {
+fun Group.addBorderAllowOpacity(size: Float, color: Color): Group {
     val group = this
     fun getTopBottomBorder() = ImageGetter.getDot(color).apply { width=group.width; height=size }
     addActor(getTopBottomBorder().apply { setPosition(0f, group.height, Align.topLeft) })
@@ -324,7 +324,7 @@ fun Label.setFontColor(color: Color): Label {
 }
 
 /** Sets the font size on a [Label] and returns it to allow chaining */
-fun Label.setFontSize(size:Int): Label {
+fun Label.setFontSize(size: Int): Label {
     style = Label.LabelStyle(style)
     style.font = Fonts.font
     @Suppress("UsePropertyAccessSyntax") setStyle(style)

--- a/core/src/com/unciv/ui/components/tilegroups/TileSetStrings.kt
+++ b/core/src/com/unciv/ui/components/tilegroups/TileSetStrings.kt
@@ -88,7 +88,7 @@ class TileSetStrings(
 
     fun getTile(baseTerrain: String) = getString(tilesLocation, baseTerrain)
 
-    fun getBorder(borderShapeString: String, innerOrOuter:String) = getString(bordersLocation, borderShapeString, innerOrOuter)
+    fun getBorder(borderShapeString: String, innerOrOuter: String) = getString(bordersLocation, borderShapeString, innerOrOuter)
 
     /** Fallback [TileSetStrings] to use when the currently chosen tileset is missing an image. */
     val fallback by lazy {

--- a/core/src/com/unciv/ui/components/tilegroups/layers/TileLayerTerrain.kt
+++ b/core/src/com/unciv/ui/components/tilegroups/layers/TileLayerTerrain.kt
@@ -19,9 +19,9 @@ class TileLayerTerrain(tileGroup: TileGroup, size: Float) : TileLayer(tileGroup,
 
     private val tileBaseImages: ArrayList<Image> = ArrayList()
     private var tileImageIdentifiers = listOf<String>()
-    private var bottomRightRiverImage :Image?=null
-    private var bottomRiverImage :Image?=null
-    private var bottomLeftRiverImage :Image?=null
+    private var bottomRightRiverImage: Image? = null
+    private var bottomRiverImage: Image? = null
+    private var bottomLeftRiverImage: Image? = null
 
     private fun getTerrainImageLocations(terrainSequence: Sequence<String>): List<String> {
         val allTerrains = terrainSequence.joinToString("+")
@@ -160,13 +160,13 @@ class TileLayerTerrain(tileGroup: TileGroup, size: Float) : TileLayer(tileGroup,
             image.color = if (index == 0) baseTerrainColor else color
     }
 
-    private fun updateRivers(displayBottomRight:Boolean, displayBottom:Boolean, displayBottomLeft:Boolean) {
+    private fun updateRivers(displayBottomRight: Boolean, displayBottom: Boolean, displayBottomLeft: Boolean) {
         bottomRightRiverImage = updateRiver(bottomRightRiverImage,displayBottomRight, strings().bottomRightRiver)
         bottomRiverImage = updateRiver(bottomRiverImage, displayBottom, strings().bottomRiver)
         bottomLeftRiverImage = updateRiver(bottomLeftRiverImage, displayBottomLeft, strings().bottomLeftRiver)
     }
 
-    private fun updateRiver(currentImage:Image?, shouldDisplay:Boolean,imageName:String): Image? {
+    private fun updateRiver(currentImage: Image?, shouldDisplay: Boolean, imageName: String): Image? {
         if (!shouldDisplay) {
             currentImage?.remove()
             return null

--- a/core/src/com/unciv/ui/components/widgets/LanguageTable.kt
+++ b/core/src/com/unciv/ui/components/widgets/LanguageTable.kt
@@ -24,7 +24,7 @@ import java.util.Locale
 /** Represents a row in the Language picker, used both in [OptionsPopup] and in [LanguagePickerScreen]
  *  @see addLanguageTables
  */
-internal class LanguageTable(val language:String, val percentComplete: Int) : Table() {
+internal class LanguageTable(val language: String, val percentComplete: Int) : Table() {
     private val baseColor = BaseScreen.skinStrings.skinConfig.baseColor
     private val darkBaseColor = baseColor.darken(0.5f)
 
@@ -43,7 +43,7 @@ internal class LanguageTable(val language:String, val percentComplete: Int) : Ta
         pack()
     }
 
-    fun update(chosenLanguage:String) {
+    fun update(chosenLanguage: String) {
         background = BaseScreen.skinStrings.getUiBackground(
             "LanguagePickerScreen/LanguageTable",
             tintColor = if (chosenLanguage == language) baseColor else darkBaseColor

--- a/core/src/com/unciv/ui/components/widgets/TranslatedSelectBox.kt
+++ b/core/src/com/unciv/ui/components/widgets/TranslatedSelectBox.kt
@@ -5,7 +5,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.Skin
 import com.badlogic.gdx.utils.Array
 import com.unciv.models.translations.tr
 
-class TranslatedSelectBox(values : Collection<String>, default:String, skin: Skin) : SelectBox<TranslatedSelectBox.TranslatedString>(skin) {
+class TranslatedSelectBox(values: Collection<String>, default: String, skin: Skin) : SelectBox<TranslatedSelectBox.TranslatedString>(skin) {
     class TranslatedString(val value: String) {
         val translation = value.tr(hideIcons = true)
         override fun toString() = translation

--- a/core/src/com/unciv/ui/components/widgets/UnitGroup.kt
+++ b/core/src/com/unciv/ui/components/widgets/UnitGroup.kt
@@ -78,7 +78,7 @@ private class FlagBackground(drawable: TextureRegionDrawable, size: Float) : Ima
 }
 
 class UnitGroup(val unit: MapUnit, val size: Float) : Group() {
-    var actionGroup :Group? = null
+    var actionGroup: Group? = null
 
     private val flagIcon = ImageGetter.getUnitIcon(unit.name, unit.civ.nation.getInnerColor())
     private var flagBg: FlagBackground = FlagBackground(getBackgroundDrawableForUnit(), size)

--- a/core/src/com/unciv/ui/components/widgets/ZoomableScrollPane.kt
+++ b/core/src/com/unciv/ui/components/widgets/ZoomableScrollPane.kt
@@ -362,7 +362,7 @@ open class ZoomableScrollPane(
         return if (isScrolling()) scrollingTo!! else Vector2(scrollX, scrollY)
     }
 
-    class ScrollToAction(private val zoomableScrollPane: ZoomableScrollPane) :FloatAction(0f, 1f, 0.4f) {
+    class ScrollToAction(private val zoomableScrollPane: ZoomableScrollPane) : FloatAction(0f, 1f, 0.4f) {
 
         private val originalScrollX = zoomableScrollPane.scrollX
         private val originalScrollY = zoomableScrollPane.scrollY

--- a/core/src/com/unciv/ui/popups/options/AdvancedTab.kt
+++ b/core/src/com/unciv/ui/popups/options/AdvancedTab.kt
@@ -301,9 +301,9 @@ private fun addTranslationGeneration(table: Table, optionsPopup: OptionsPopup) {
     table.add(generateScreenshotsButton).colspan(2).row()
 }
 
-data class ScreenshotConfig(val width: Int, val height: Int, val screenSize: ScreenSize, var fileLocation:String, var centerTile:Vector2, var attackCity:Boolean=true)
+data class ScreenshotConfig(val width: Int, val height: Int, val screenSize: ScreenSize, var fileLocation: String, var centerTile: Vector2, var attackCity: Boolean = true)
 
-private fun CoroutineScope.generateScreenshots(settings: GameSettings, configs:ArrayList<ScreenshotConfig>) {
+private fun CoroutineScope.generateScreenshots(settings: GameSettings, configs: ArrayList<ScreenshotConfig>) {
     val currentConfig = configs.first()
     launchOnGLThread {
         val screenshotGame =

--- a/core/src/com/unciv/ui/screens/devconsole/DevConsoleCommand.kt
+++ b/core/src/com/unciv/ui/screens/devconsole/DevConsoleCommand.kt
@@ -17,7 +17,7 @@ internal fun <T: IRulesetObject> Iterable<T>.findCliInput(param: String): T? {
 internal fun <T: IRulesetObject> Sequence<T>.findCliInput(param: String) = asIterable().findCliInput(param)
 
 /** Returns the string to *add* to the existing command */
-internal fun getAutocompleteString(lastWord: String, allOptions: Iterable<String>):String? {
+internal fun getAutocompleteString(lastWord: String, allOptions: Iterable<String>): String? {
     val matchingOptions = allOptions.map { it.toCliInput() }.filter { it.startsWith(lastWord.toCliInput()) }
     if (matchingOptions.isEmpty()) return null
     if (matchingOptions.size == 1) return matchingOptions.first().drop(lastWord.length) + " "
@@ -81,7 +81,7 @@ open class ConsoleAction(val format: String, val action: (console: DevConsolePop
         return getAutocompleteString(lastParam, options)
     }
 
-    private fun validateFormat(format: String, params:List<String>){
+    private fun validateFormat(format: String, params: List<String>) {
         val allParams = format.split(" ")
         val requiredParamsAmount = allParams.count { it.startsWith('<') }
         val optionalParamsAmount = allParams.count { it.startsWith('[') }

--- a/core/src/com/unciv/ui/screens/devconsole/DevConsolePopup.kt
+++ b/core/src/com/unciv/ui/screens/devconsole/DevConsolePopup.kt
@@ -97,7 +97,7 @@ class DevConsolePopup(val screen: WorldScreen) : Popup(screen) {
     /** Gets city by selected tile */
     internal fun getSelectedCity() = getSelectedTile().getCity() ?: throw ConsoleErrorException("Select tile belonging to city")
 
-    internal fun getCity(cityName:String) = gameInfo.getCities().firstOrNull { it.name.toCliInput() == cityName.toCliInput() }
+    internal fun getCity(cityName: String) = gameInfo.getCities().firstOrNull { it.name.toCliInput() == cityName.toCliInput() }
         ?: throw ConsoleErrorException("Unknown city: $cityName")
 
     internal fun getSelectedUnit(): MapUnit {

--- a/core/src/com/unciv/ui/screens/pickerscreens/GreatPersonPickerScreen.kt
+++ b/core/src/com/unciv/ui/screens/pickerscreens/GreatPersonPickerScreen.kt
@@ -10,7 +10,7 @@ import com.unciv.ui.components.extensions.isEnabled
 import com.unciv.ui.components.input.onClick
 import com.unciv.ui.components.input.onDoubleClick
 
-class GreatPersonPickerScreen(val civInfo:Civilization) : PickerScreen() {
+class GreatPersonPickerScreen(val civInfo: Civilization) : PickerScreen() {
     private var theChosenOne: BaseUnit? = null
 
     init {

--- a/core/src/com/unciv/ui/screens/worldscreen/bottombar/BattleTable.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/bottombar/BattleTable.kt
@@ -122,7 +122,7 @@ class BattleTable(val worldScreen: WorldScreen) : Table() {
         return defender
     }
 
-    private fun getIcon(combatant:ICombatant) =
+    private fun getIcon(combatant: ICombatant) =
         if (combatant is MapUnitCombatant) UnitGroup(combatant.unit,25f)
         else ImageGetter.getNationPortrait(combatant.getCivInfo().nation, 25f)
 

--- a/core/src/com/unciv/ui/screens/worldscreen/bottombar/BattleTableHelpers.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/bottombar/BattleTableHelpers.kt
@@ -148,7 +148,7 @@ object BattleTableHelpers {
         attacker: ICombatant, damageToAttacker: Int,
         defender: ICombatant, damageToDefender: Int
     ) {
-        fun getMapActorsForCombatant(combatant: ICombatant):Sequence<Actor> =
+        fun getMapActorsForCombatant(combatant: ICombatant): Sequence<Actor> =
                 sequence {
                     val tileGroup = mapHolder.tileGroups[combatant.getTile()]!!
                     if (combatant.isCity()) {
@@ -219,7 +219,7 @@ object BattleTableHelpers {
     fun getHealthBar(maxHealth: Int, currentHealth: Int, maxRemainingHealth: Int, minRemainingHealth: Int): Table {
         val healthBar = Table()
         val totalWidth = 100f
-        fun addHealthToBar(image: Image, amount:Int) {
+        fun addHealthToBar(image: Image, amount: Int) {
             val width = totalWidth * amount / maxHealth
             healthBar.add(image).size(width.coerceIn(0f, totalWidth),3f)
         }

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/IdleUnitButton.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/IdleUnitButton.kt
@@ -13,7 +13,7 @@ import com.unciv.ui.components.extensions.pad
 class IdleUnitButton (
     internal val unitTable: UnitTable,
     private val tileMapHolder: WorldMapHolder,
-    val previous:Boolean
+    val previous: Boolean
 ) : Table() {
 
     val image = ImageGetter.getImage("OtherIcons/BackArrow")

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/UnitTable.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/UnitTable.kt
@@ -50,7 +50,7 @@ class UnitTable(val worldScreen: WorldScreen) : Table() {
     var selectedUnitIsConnectingRoad = false
 
     /** Sending no unit clears the selected units entirely */
-    fun selectUnit(unit: MapUnit?=null, append:Boolean=false) {
+    fun selectUnit(unit: MapUnit? = null, append: Boolean = false) {
         if (!append) selectedUnits.clear()
         selectedCity = null
         if (unit != null) {

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionModifiers.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionModifiers.kt
@@ -13,9 +13,9 @@ object UnitActionModifiers {
         return usagesLeft == null || usagesLeft > 0
     }
 
-    fun getUsableUnitActionUniques(unit:MapUnit, actionUniqueType: UniqueType) =
+    fun getUsableUnitActionUniques(unit: MapUnit, actionUniqueType: UniqueType) =
         unit.getMatchingUniques(actionUniqueType)
-            .filter { it.conditionals.none { it.type == UniqueType.UnitActionExtraLimitedTimes } }
+            .filter { unique -> unique.conditionals.none { it.type == UniqueType.UnitActionExtraLimitedTimes } }
             .filter { canUse(unit, it) }
 
     private fun getMovementPointsToUse(actionUnique: Unique): Int {

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsGreatPerson.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsGreatPerson.kt
@@ -14,7 +14,7 @@ import kotlin.math.min
 @Suppress("UNUSED_PARAMETER") // references need to have the signature expected by UnitActions.actionTypeToFunctions
 object UnitActionsGreatPerson {
 
-    internal fun getHurryResearchActions(unit:MapUnit, tile: Tile) = sequence {
+    internal fun getHurryResearchActions(unit: MapUnit, tile: Tile) = sequence {
         for (unique in unit.getMatchingUniques(UniqueType.CanHurryResearch)){
             yield(UnitAction(
                 UnitActionType.HurryResearch,
@@ -30,7 +30,7 @@ object UnitActionsGreatPerson {
         }
     }
 
-    internal fun getHurryPolicyActions(unit:MapUnit, tile: Tile) = sequence {
+    internal fun getHurryPolicyActions(unit: MapUnit, tile: Tile) = sequence {
         for (unique in unit.getMatchingUniques(UniqueType.CanHurryPolicy)){
             yield(UnitAction(
                 UnitActionType.HurryPolicy,
@@ -64,7 +64,7 @@ object UnitActionsGreatPerson {
         }
     }
 
-    internal fun getHurryBuildingActions(unit:MapUnit, tile: Tile) = sequence {
+    internal fun getHurryBuildingActions(unit: MapUnit, tile: Tile) = sequence {
         for (unique in unit.getMatchingUniques(UniqueType.CanSpeedupConstruction)) {
             if (!tile.isCityCenter()) {
                 yield(UnitAction(UnitActionType.HurryBuilding, action = null))
@@ -97,7 +97,7 @@ object UnitActionsGreatPerson {
         }
     }
 
-    internal fun getConductTradeMissionActions(unit:MapUnit, tile: Tile) = sequence {
+    internal fun getConductTradeMissionActions(unit: MapUnit, tile: Tile) = sequence {
         for (unique in unit.getMatchingUniques(UniqueType.CanTradeWithCityStateForGoldAndInfluence)) {
             val canConductTradeMission = tile.owningCity?.civ?.isCityState() == true
                 && tile.owningCity?.civ != unit.civ

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsReligion.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsReligion.kt
@@ -12,7 +12,7 @@ import com.unciv.ui.components.extensions.toPercent
 
 object UnitActionsReligion {
 
-    internal fun getFoundReligionActions(unit: MapUnit, tile:Tile): Sequence<UnitAction> {
+    internal fun getFoundReligionActions(unit: MapUnit, tile: Tile): Sequence<UnitAction> {
         if (!unit.civ.religionManager.mayFoundReligionAtAll()) return emptySequence()
 
         val unique = UnitActionModifiers.getUsableUnitActionUniques(unit, UniqueType.MayFoundReligion)

--- a/tests/src/com/unciv/logic/TranslationTests.kt
+++ b/tests/src/com/unciv/logic/TranslationTests.kt
@@ -293,7 +293,7 @@ class TranslationTests {
         UncivGame.Current = UncivGame()
         UncivGame.Current.settings = GameSettings()
 
-        fun addTranslation(original:String, result:String) {
+        fun addTranslation(original: String, result: String) {
             UncivGame.Current.translations[original.getPlaceholderText()] = TranslationEntry(original)
                 .apply { this[Constants.english] = result }
         }

--- a/tests/src/com/unciv/logic/civilization/CapitalConnectionsFinderTests.kt
+++ b/tests/src/com/unciv/logic/civilization/CapitalConnectionsFinderTests.kt
@@ -36,7 +36,7 @@ class CapitalConnectionsFinderTests {
         ourCiv.tech.addTechnology(testGame.ruleset.tileImprovements[RoadStatus.Railroad.name]?.techRequired!!)
     }
 
-    private fun createMedium(from:Int, to: Int, type: RoadStatus) {
+    private fun createMedium(from: Int, to: Int, type: RoadStatus) {
         for (i in from..to) {
             val tile = testGame.tileMap[0, i]
             tile.roadStatus = type

--- a/tests/src/com/unciv/logic/map/UnitMovementTests.kt
+++ b/tests/src/com/unciv/logic/map/UnitMovementTests.kt
@@ -22,8 +22,8 @@ import org.junit.runner.RunWith
 @RunWith(GdxTestRunner::class)
 class UnitMovementTests {
 
-    private lateinit var tile:Tile
-    private lateinit var civInfo:Civilization
+    private lateinit var tile: Tile
+    private lateinit var civInfo: Civilization
     private var testGame = TestGame()
 
     @Before
@@ -48,7 +48,7 @@ class UnitMovementTests {
         }
     }
 
-    fun addFakeUnit(unitType: UnitType, uniques:List<String> = listOf()): MapUnit {
+    fun addFakeUnit(unitType: UnitType, uniques: List<String> = listOf()): MapUnit {
         val baseUnit = BaseUnit()
         baseUnit.unitType = unitType.name
         baseUnit.ruleset = testGame.ruleset


### PR DESCRIPTION
Regex: `(?<=(fun|val|var|catch|class|object).*)[^:]:[^\s:/]` - all hits sieved manually.

That's a lot - I would almost vote to ignore, as it is highly likely to provoke conflicts. But you should at least see...