### PR TITLE
Remove unnecessary/harmful `open` on classes without subclasses

### DIFF
--- a/core/src/com/unciv/logic/automation/unit/SpecificUnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/SpecificUnitAutomation.kt
@@ -144,11 +144,17 @@ object SpecificUnitAutomation {
 
         if (bestCityLocation == null) {
             // Find the best tile that is within
-            bestCityLocation = bestTilesInfo.tileRankMap.filter { bestTilesInfo.bestTile == null || it.value >= bestTilesInfo.tileRankMap[bestTilesInfo.bestTile]!! - 5 }.asSequence().sortedByDescending { it.value }.firstOrNull {
-                if (it.key in dangerousTiles && it != unit.getTile()) return@firstOrNull false
+            fun isTileRankOK(it: Map.Entry<Tile, Float>): Boolean {
+                if (it.key in dangerousTiles && it.key != unit.getTile()) return false
                 val pathSize = unit.movement.getShortestPath(it.key).size
-                return@firstOrNull pathSize in 1..3
-            }?.key
+                return pathSize in 1..3
+            }
+
+            bestCityLocation = bestTilesInfo.tileRankMap.entries.asSequence()
+                .filter { bestTilesInfo.bestTile == null || it.value >= bestTilesInfo.tileRankMap[bestTilesInfo.bestTile]!! - 5 }
+                .sortedByDescending { it.value }
+                .firstOrNull(::isTileRankOK)
+                ?.key
         }
 
         // We still haven't found a best city tile within 3 turns so lets just head to the best tile

--- a/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
@@ -168,7 +168,7 @@ class WorkerAutomation(
      */
     private fun findTileToWork(unit: MapUnit, tilesToAvoid: Set<Tile>): Tile {
         val currentTile = unit.getTile()
-        if (currentTile != tilesToAvoid && getBasePriority(currentTile, unit) >= 5
+        if (currentTile !in tilesToAvoid && getBasePriority(currentTile, unit) >= 5
             && (tileHasWorkToDo(currentTile, unit) || currentTile.isPillaged() || currentTile.hasFalloutEquivalent())) {
             return currentTile
         }

--- a/core/src/com/unciv/logic/civilization/CivRankingHistory.kt
+++ b/core/src/com/unciv/logic/civilization/CivRankingHistory.kt
@@ -6,7 +6,7 @@ import com.unciv.logic.IsPartOfGameInfoSerialization
 import com.unciv.ui.screens.victoryscreen.RankingType
 
 /** Records for each turn (key of outer map) what the score (value of inner map) was for each RankingType. */
-open class CivRankingHistory : HashMap<Int, Map<RankingType, Int>>(),
+class CivRankingHistory : HashMap<Int, Map<RankingType, Int>>(),
     IsPartOfGameInfoSerialization {
 
     /**

--- a/core/src/com/unciv/logic/map/mapunit/movement/UnitMovement.kt
+++ b/core/src/com/unciv/logic/map/mapunit/movement/UnitMovement.kt
@@ -108,7 +108,7 @@ class UnitMovement(val unit: MapUnit) {
             return cachedPath
 
         val currentTile = unit.getTile()
-        if (currentTile.position == destination) {
+        if (currentTile.position == destination.position) {
             // edge case that's needed, so that workers will know that they can reach their own tile. *sigh*
             pathfindingCache.setShortestPathCache(destination, listOf(currentTile))
             return listOf(currentTile)

--- a/core/src/com/unciv/logic/map/tile/Tile.kt
+++ b/core/src/com/unciv/logic/map/tile/Tile.kt
@@ -33,7 +33,7 @@ import kotlin.math.abs
 import kotlin.math.min
 import kotlin.random.Random
 
-open class Tile : IsPartOfGameInfoSerialization {
+class Tile : IsPartOfGameInfoSerialization {
     @Transient
     lateinit var tileMap: TileMap
 

--- a/core/src/com/unciv/logic/map/tile/TileHistory.kt
+++ b/core/src/com/unciv/logic/map/tile/TileHistory.kt
@@ -13,7 +13,7 @@ import java.util.TreeMap
  *
  * @see com.unciv.ui.screens.victoryscreen.ReplayMap
  */
-open class TileHistory : IsPartOfGameInfoSerialization {
+class TileHistory : IsPartOfGameInfoSerialization {
 
     class TileHistoryState(
         /** The name of the civilization owning this tile or `null` if there is no owner. */


### PR DESCRIPTION
This is a surprise.

That `open` on the `Tile` class somehow tickled: I asked Studio for any implementations - none. So changing open to final should be simple, right? Oooooppppsssss....

That modifier is there since [2018-05-31](https://github.com/yairm210/Unciv/commit/f6ca98b1d721406f147828344319e8d843425b51#diff-1267af508ecc10bccb9df36531bea0d238bb64c01a707e4b22290c77c7724c05)... No reason I can discern.

Result:
```
e: file:///home/bob/Work/Unciv/core/src/com/unciv/logic/automation/unit/SpecificUnitAutomation.kt:148:49 Operator '!=' cannot be applied to 'Map.Entry<Tile, Float>' and 'Tile'
e: file:///home/bob/Work/Unciv/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt:171:13 Operator '!=' cannot be applied to 'Tile' and 'Set<Tile>'
e: file:///home/bob/Work/Unciv/core/src/com/unciv/logic/map/mapunit/movement/UnitMovement.kt:111:13 Operator '==' cannot be applied to 'Vector2' and 'Tile'
```
... well OK, I fixed them.

But how in all hell's snowstorms could that ever compile with the simple `open`?

Answer: 'cuz in those comparisons, Tile was on the left. And that calls for an `operator fun equals`, which by design is open and takes an `Any?` parameter - I always thought that an mor**ic decision. So - the compiler thinks "well, that reference may actually hold a subclass where this particular equality is meaningfully implemented, and the runtime just calls the `Any.equals` code... I guess. That's so gruesome it's giving me headaches and I can't evaluate whether that fairly tale I present as explanation is actually real magic.

Guess that caught a few unnoticed bugs? The `!=` would always have been `true` and the `==` always `false`...

Can't even _test_ this.

Finally: I reviewed _all_ open class occurrences for validity. All except these here have a reason.