### PR TITLE
Fix tileset sanity check for builtin rulesets when run from jar

### DIFF
--- a/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
+++ b/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
@@ -1,6 +1,7 @@
 package com.unciv.models.ruleset.validation
 
 import com.badlogic.gdx.Gdx
+import com.badlogic.gdx.files.FileHandle
 import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.graphics.g2d.TextureAtlas.TextureAtlasData
 import com.unciv.Constants
@@ -757,6 +758,8 @@ class RulesetValidator(val ruleset: Ruleset) {
     private fun checkTilesetSanity(lines: RulesetErrorList) {
         val tilesetConfigFolder = (ruleset.folderLocation ?: Gdx.files.internal("")).child("jsons\\TileSets")
         if (!tilesetConfigFolder.exists()) return
+        if (ruleset.folderLocation == null && this::class.java.`package`?.specificationVersion != null)
+            return checkTilesetSanityForJar(lines, tilesetConfigFolder)
 
         val configTilesets = mutableSetOf<String>()
         val allFallbacks = mutableSetOf<String>()
@@ -789,8 +792,11 @@ class RulesetValidator(val ruleset: Ruleset) {
         if (configOnlyTilesets.isNotEmpty())
             lines.add("Mod has no graphics for configured tilesets: ${configOnlyTilesets.joinToString()}", RulesetErrorSeverity.Warning, sourceObject = null)
 
+        checkTilesetSanityFinish(lines, atlasTilesets - configTilesets, allFallbacks)
+    }
+
+    private fun checkTilesetSanityFinish(lines: RulesetErrorList, atlasOnlyTilesets: Set<String>, allFallbacks: Set<String>) {
         // For all atlas images matching "TileSets/*" there should be a json
-        val atlasOnlyTilesets = atlasTilesets - configTilesets
         if (atlasOnlyTilesets.isNotEmpty())
             lines.add("Mod has no configuration for tileset graphics: ${atlasOnlyTilesets.joinToString()}", RulesetErrorSeverity.Warning, sourceObject = null)
 
@@ -798,6 +804,31 @@ class RulesetValidator(val ruleset: Ruleset) {
         val unknownFallbacks = allFallbacks - TileSetCache.keys - Constants.defaultFallbackTileset
         if (unknownFallbacks.isNotEmpty())
             lines.add("Fallback tileset invalid: ${unknownFallbacks.joinToString()}", RulesetErrorSeverity.Warning, sourceObject = null)
+    }
+
+    private fun checkTilesetSanityForJar(lines: RulesetErrorList, tilesetConfigFolder: FileHandle) {
+        // We're checking a builin ruleset from the jar, so no folder listing
+        val atlasOnlyTilesets = mutableSetOf<String>()
+        val allFallbacks = mutableSetOf<String>()
+
+        // Perform the 'json exits', 'parseable', 'fallback exists' tests like above, but "reversed"
+        for (tilesetName in getTilesetNamesFromAtlases()) {
+            var file = tilesetConfigFolder.child("$tilesetName.json")
+            if (!file.exists()) file = tilesetConfigFolder.child("${tilesetName}Config.json")
+            if (!file.exists()) {
+                atlasOnlyTilesets += tilesetName
+                continue
+            }
+            val config = try {
+                json().fromJsonFile(TileSetConfig::class.java, file)
+            } catch (ex: Exception) {
+                lines.add("Tileset config '${file.name()}' cannot be loaded (${ex.cause?.message})", RulesetErrorSeverity.Warning, sourceObject = null)
+                continue
+            }
+            if (!config.fallbackTileSet.isNullOrEmpty()) allFallbacks += config.fallbackTileSet!!
+        }
+
+        checkTilesetSanityFinish(lines, atlasOnlyTilesets, allFallbacks)
     }
 
     private fun getTilesetNamesFromAtlases(): Set<String> {

--- a/core/src/com/unciv/ui/components/widgets/ZoomableScrollPane.kt
+++ b/core/src/com/unciv/ui/components/widgets/ZoomableScrollPane.kt
@@ -19,8 +19,6 @@ import com.unciv.UncivGame
 import com.unciv.models.metadata.GameSettings
 import com.unciv.ui.components.ZoomGestureListener
 import com.unciv.ui.components.input.KeyboardPanningListener
-import java.lang.Float.max
-import java.lang.Float.min
 import kotlin.math.sqrt
 
 
@@ -138,7 +136,7 @@ open class ZoomableScrollPane(
     }
 
     open fun zoom(zoomScale: Float) {
-        val newZoom = min(max(zoomScale, minZoom), maxZoom)
+        val newZoom = zoomScale.coerceIn(minZoom, maxZoom)
         val oldZoomX = scaleX
         val oldZoomY = scaleY
 


### PR DESCRIPTION
Fixes #11228, the "large" way.

Just bailing from that `if (ruleset.folderLocation == null && this::class.java.package?.specificationVersion != null)` would be fine too - if we trust the released builtin ruleset must have passed the full test in the release workflow... Whaddayouthink?