### PR TITLE
Fix conditionals and triggers being valid for cities on non city tiles

### DIFF
--- a/core/src/com/unciv/models/ruleset/unique/Conditionals.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Conditionals.kt
@@ -33,8 +33,9 @@ object Conditionals {
         }
 
         val relevantCity by lazy {
-            state.city
-                ?: relevantTile?.getCity()
+            state.city 
+                ?: if (relevantTile?.isCityCenter() == true) relevantTile?.getCity() 
+                else null
         }
 
         val relevantCiv by lazy {

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -78,8 +78,9 @@ object UniqueTriggerActivation {
         triggerNotificationText: String? = null
     ): (()->Boolean)? {
 
-        val relevantCity by lazy {
-            city?: tile?.getCity()
+        val relevantCity by lazy { 
+            city ?: if (tile?.isCityCenter() == true) tile.getCity() 
+            else null
         }
 
         val timingConditional = unique.conditionals.firstOrNull { it.type == UniqueType.ConditionalTimedUnique }


### PR DESCRIPTION
Another "Idk what the title should be". Also, seems weird that `getCity` doesn't exactly match what it's intended to do (seems like it should be "getOwningCity"), but the amount of places where this mistake was made seems to be low if at all