### PR TITLE
Allow city state uniques for nation descriptions

### DIFF
--- a/core/src/com/unciv/models/ruleset/nation/Nation.kt
+++ b/core/src/com/unciv/models/ruleset/nation/Nation.kt
@@ -109,9 +109,9 @@ class Nation : RulesetObject() {
     }
 
     override fun getCivilopediaTextLines(ruleset: Ruleset): List<FormattedLine> {
-        if (isCityState) return getCityStateInfo(ruleset)
-
         val textList = ArrayList<FormattedLine>()
+
+        if (isCityState) textList += getCityStateInfo(ruleset)
 
         if (leaderName.isNotEmpty()) {
             textList += FormattedLine(extraImage = "LeaderIcons/$leaderName", imageSize = 200f)
@@ -184,6 +184,7 @@ class Nation : RulesetObject() {
                 }
             }
         }
+        textList += FormattedLine(separator = true)
 
         // personality is not a nation property, it gets assigned to the civ randomly
         return textList


### PR DESCRIPTION
The idea is simple: Barbarians gets full descriptions, this has basically no effect on built in rulesets (besides the ending separator), and some mods (like Deciv) does actually make major edits to City States. This would also help make it easier to debug and balance any mod that experiments on City States this heavily

Note: if a City-State has no uniques, and buildings/units, it gets an empty area between it's city state description and it's unique components. Not sure what the fix is to that tbh