### PR TITLE
Fix Civ resources being counted multiple times

### DIFF
--- a/core/src/com/unciv/logic/city/CityResources.kt
+++ b/core/src/com/unciv/logic/city/CityResources.kt
@@ -82,11 +82,11 @@ object CityResources {
     }
 
     private fun getCityResourcesFromCiv(city: City, cityResources: ResourceSupplyList, resourceModifer: HashMap<String, Float>) {
-        // This includes the uniques from buildings, from this and all other cities
-        for (unique in city.civ.getMatchingUniques(UniqueType.ProvidesResources, StateForConditionals(city.civ, city))) { // E.G "Provides [1] [Iron]"
+        val stateForConditionals = StateForConditionals(city)
+        for (unique in city.getMatchingUniques(UniqueType.ProvidesResources, stateForConditionals)) { // E.G "Provides [1] [Iron]"
             val resource = city.getRuleset().tileResources[unique.params[1]]
                 ?: continue
-            if (!resource.hasUnique(UniqueType.CityResource, StateForConditionals(city))) continue
+            if (!resource.hasUnique(UniqueType.CityResource, stateForConditionals)) continue
             cityResources.add(
                 resource, "Buildings",
                 (unique.params[0].toFloat() * resourceModifer[resource.name]!!).toInt()

--- a/core/src/com/unciv/logic/city/CityResources.kt
+++ b/core/src/com/unciv/logic/city/CityResources.kt
@@ -88,7 +88,7 @@ object CityResources {
                 ?: continue
             if (!resource.hasUnique(UniqueType.CityResource, stateForConditionals)) continue
             cityResources.add(
-                resource, "Buildings",
+                resource, unique.getSourceNameForUser(),
                 (unique.params[0].toFloat() * resourceModifer[resource.name]!!).toInt()
             )
         }

--- a/core/src/com/unciv/logic/city/CityResources.kt
+++ b/core/src/com/unciv/logic/city/CityResources.kt
@@ -86,6 +86,7 @@ object CityResources {
         for (unique in city.civ.getMatchingUniques(UniqueType.ProvidesResources, StateForConditionals(city.civ, city))) { // E.G "Provides [1] [Iron]"
             val resource = city.getRuleset().tileResources[unique.params[1]]
                 ?: continue
+            if (!resource.hasUnique(UniqueType.CityResource, StateForConditionals(city))) continue
             cityResources.add(
                 resource, "Buildings",
                 (unique.params[0].toFloat() * resourceModifer[resource.name]!!).toInt()

--- a/core/src/com/unciv/logic/civilization/transients/CivInfoTransientCache.kt
+++ b/core/src/com/unciv/logic/civilization/transients/CivInfoTransientCache.kt
@@ -302,7 +302,6 @@ class CivInfoTransientCache(val civInfo: Civilization) {
         }
 
         for (unique in civInfo.getMatchingUniques(UniqueType.ProvidesResources)) {
-            if (unique.sourceObjectType == UniqueTarget.Building || unique.sourceObjectType == UniqueTarget.Wonder) continue // already calculated in city
             val resource = civInfo.gameInfo.ruleset.tileResources[unique.params[1]]!!
             newDetailedCivResources.add(
                 resource,

--- a/tests/src/com/unciv/logic/city/CityTest.kt
+++ b/tests/src/com/unciv/logic/city/CityTest.kt
@@ -108,11 +108,11 @@ class CityTest {
         tile.improvement = "Mine"
 
         // when
-        val cityResources = capitalCity.getCityResources()
+        val resources = testCiv.detailedCivResources
 
         // then
-        assertEquals(1, cityResources.size)
-        assertEquals("4 Iron from Tiles", cityResources[0].toString())
+        assertEquals(1, resources.size)
+        assertEquals("4 Iron from Tiles", resources[0].toString())
     }
 
     @Test
@@ -122,11 +122,11 @@ class CityTest {
         capitalCity.cityConstructions.addBuilding(building)
 
         // when
-        val cityResources = capitalCity.getCityResources()
+        val resources = testCiv.detailedCivResources
 
         // then
-        assertEquals(1, cityResources.size)
-        assertEquals("4 Iron from Buildings", cityResources[0].toString())
+        assertEquals(1, resources.size)
+        assertEquals("4 Iron from Buildings", resources[0].toString())
     }
 
     @Test
@@ -135,10 +135,10 @@ class CityTest {
         capitalCity.cityConstructions.addBuilding("Factory")
 
         // when
-        val cityResources = capitalCity.getCityResources()
+        val resources = testCiv.detailedCivResources
 
         // then
-        assertEquals(1, cityResources.size)
-        assertEquals("-1 Coal from Buildings", cityResources[0].toString())
+        assertEquals(1, resources.size)
+        assertEquals("-1 Coal from Buildings", resources[0].toString())
     }
 }

--- a/tests/src/com/unciv/logic/city/CityTest.kt
+++ b/tests/src/com/unciv/logic/city/CityTest.kt
@@ -106,6 +106,7 @@ class CityTest {
         tile.resource = "Iron"
         tile.resourceAmount = 4
         tile.improvement = "Mine"
+        testCiv.cache.updateCivResources()
 
         // when
         val resources = testCiv.detailedCivResources


### PR DESCRIPTION
Note: No matter what, either you're checking the unique's sources and trying to find what city it came from that way or you're checking each city twice for building uniques. Unless you can find a way past one of those two scenarios, there's no real valuing in continuing over uniques here that claim to be from Buildings or Wonders


Also......... Wtf, why is Civ based city resources counted from coming from buildings. That's makes it very difficult to understand why it's breaking. That alone is a reason to remove the continue in CivInfoTransients. Even if it didn't add a new entry to the civ for every resource, we would be better off trying to find a way to give uniques a better trail to find where it came from than relying on that as a hack