### PR TITLE
Better Unit Actions Sorting

### DIFF
--- a/core/src/com/unciv/models/UnitAction.kt
+++ b/core/src/com/unciv/models/UnitAction.kt
@@ -79,7 +79,7 @@ class UpgradeUnitAction(
     val goldCostOfUpgrade: Int,
     val newResourceRequirements: Counter<String>,
     action: (() -> Unit)?
-) : UnitAction(UnitActionType.Upgrade, 10, title, action = action)
+) : UnitAction(UnitActionType.Upgrade, 120, title, action = action)
 
 /** Unit Actions - generic enum with static properties
  *
@@ -107,7 +107,7 @@ enum class UnitActionType(
     EscortFormation("Escort formation",
         { ImageGetter.getImage("OtherIcons/Link") }, false, defaultPage = 1),
     SwapUnits("Swap units",
-        { ImageGetter.getUnitActionPortrait("Swap") }, false, defaultPage = 1),
+        { ImageGetter.getUnitActionPortrait("Swap") }, false, defaultPage = 0),
     Automate("Automate",
         { ImageGetter.getUnitActionPortrait("Automate") }),
     ConnectRoad("Connect road",

--- a/core/src/com/unciv/models/UnitAction.kt
+++ b/core/src/com/unciv/models/UnitAction.kt
@@ -15,6 +15,11 @@ import com.unciv.ui.images.ImageGetter
  */
 open class UnitAction(
     val type: UnitActionType,
+    /** How often this action is used, a higher value means more often and that it should be on an earlier page. 
+     * 100 is very frequent, 50 is somewhat frequent, less than 25 is press one time for multi-turn movement. 
+     * A Rare case is > 100 if a button is something like add in capital, promote or something,
+     * we need to inform the player that taking the action is an option. */
+    val useFrequency: Int,
     val title: String = type.value,
     val isCurrentAction: Boolean = false,
     val uncivSound: UncivSound = type.uncivSound,
@@ -74,7 +79,7 @@ class UpgradeUnitAction(
     val goldCostOfUpgrade: Int,
     val newResourceRequirements: Counter<String>,
     action: (() -> Unit)?
-) : UnitAction(UnitActionType.Upgrade, title, action = action)
+) : UnitAction(UnitActionType.Upgrade, 10, title, action = action)
 
 /** Unit Actions - generic enum with static properties
  *

--- a/core/src/com/unciv/models/UnitAction.kt
+++ b/core/src/com/unciv/models/UnitAction.kt
@@ -19,7 +19,7 @@ open class UnitAction(
      * 100 is very frequent, 50 is somewhat frequent, less than 25 is press one time for multi-turn movement. 
      * A Rare case is > 100 if a button is something like add in capital, promote or something,
      * we need to inform the player that taking the action is an option. */
-    val useFrequency: Int,
+    val useFrequency: Float,
     val title: String = type.value,
     val isCurrentAction: Boolean = false,
     val uncivSound: UncivSound = type.uncivSound,
@@ -79,7 +79,7 @@ class UpgradeUnitAction(
     val goldCostOfUpgrade: Int,
     val newResourceRequirements: Counter<String>,
     action: (() -> Unit)?
-) : UnitAction(UnitActionType.Upgrade, 120, title, action = action)
+) : UnitAction(UnitActionType.Upgrade, 120f, title, action = action)
 
 /** Unit Actions - generic enum with static properties
  *

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActions.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActions.kt
@@ -132,11 +132,11 @@ object UnitActions {
         // General actions
         addAutomateActions(unit)
         if (unit.isMoving())
-            yield(UnitAction(UnitActionType.StopMovement, 20) { unit.action = null })
+            yield(UnitAction(UnitActionType.StopMovement, 20f) { unit.action = null })
         if (unit.isExploring())
-            yield(UnitAction(UnitActionType.StopExploration, 20) { unit.action = null })
+            yield(UnitAction(UnitActionType.StopExploration, 20f) { unit.action = null })
         if (unit.isAutomated())
-            yield(UnitAction(UnitActionType.StopAutomation, 10) {
+            yield(UnitAction(UnitActionType.StopAutomation, 10f) {
                 unit.action = null
                 unit.automated = false
             })
@@ -154,7 +154,7 @@ object UnitActions {
 
         // From here we have actions defaulting to the second page
         if (unit.isMoving()) {
-            yield(UnitAction(UnitActionType.ShowUnitDestination, 30) {
+            yield(UnitAction(UnitActionType.ShowUnitDestination, 30f) {
                 GUI.getMap().setCenterPosition(unit.getMovementDestination().position, true)
             })
         }
@@ -182,14 +182,14 @@ object UnitActions {
         if (!unit.isEscorting()) {
             yield(UnitAction(
                 type = UnitActionType.EscortFormation,
-                useFrequency = 50,
+                useFrequency = 50f,
                 action = {
                     unit.startEscorting()
                 }))
         } else {
             yield(UnitAction(
                 type = UnitActionType.StopEscortFormation,
-                useFrequency = 50,
+                useFrequency = 50f,
                 action = {
                     unit.stopEscorting()
                 }))
@@ -212,7 +212,7 @@ object UnitActions {
         yield(UnitAction(
             type = UnitActionType.SwapUnits,
             isCurrentAction = worldScreen.bottomUnitTable.selectedUnitIsSwapping,
-            useFrequency = 60,
+            useFrequency = 60f,
             action = {
                 worldScreen.bottomUnitTable.selectedUnitIsSwapping =
                     !worldScreen.bottomUnitTable.selectedUnitIsSwapping
@@ -223,7 +223,7 @@ object UnitActions {
 
     private suspend fun SequenceScope<UnitAction>.addDisbandAction(unit: MapUnit) {
         yield(UnitAction(type = UnitActionType.DisbandUnit,
-            useFrequency = 0, // Only can happen once per unit
+            useFrequency = 0f, // Only can happen once per unit
             action = {
                 val worldScreen = GUI.getWorldScreen()
                 if (!worldScreen.hasOpenPopups()) {
@@ -246,7 +246,7 @@ object UnitActions {
         if (unit.isCivilian() || !unit.promotions.canBePromoted()) return
         // promotion does not consume movement points, but is not allowed if a unit has exhausted its movement or has attacked
         yield(UnitAction(UnitActionType.Promote,
-            useFrequency = 150, // We want to show the player that they can promote
+            useFrequency = 150f, // We want to show the player that they can promote
             action = {
                 UncivGame.Current.pushScreen(PromotionPickerScreen(unit))
             }.takeIf { unit.currentMovement > 0 && unit.attacksThisTurn == 0 }
@@ -256,7 +256,7 @@ object UnitActions {
     private suspend fun SequenceScope<UnitAction>.addExplorationActions(unit: MapUnit) {
         if (unit.baseUnit.movesLikeAirUnits()) return
         if (unit.isExploring()) return
-        yield(UnitAction(UnitActionType.Explore, 5) {
+        yield(UnitAction(UnitActionType.Explore, 5f) {
             unit.action = UnitActionType.Explore.value
             if (unit.currentMovement > 0) UnitAutomation.automatedExplore(unit)
         })
@@ -268,7 +268,7 @@ object UnitActions {
                 type = if (unit.isActionUntilHealed())
                     UnitActionType.FortifyUntilHealed else
                     UnitActionType.Fortify,
-                useFrequency = 10,
+                useFrequency = 10f,
                 isCurrentAction = true,
                 title = "${"Fortification".tr()} ${unit.getFortificationTurns() * 20}%"
             ))
@@ -279,14 +279,14 @@ object UnitActions {
 
         yield(UnitAction(UnitActionType.Fortify,
             action = { unit.fortify() }.takeIf { !unit.isFortified() || unit.isFortifyingUntilHealed() },
-            useFrequency = 30
+            useFrequency = 30f
         ))
 
         if (unit.health == 100) return
         yield(UnitAction(UnitActionType.FortifyUntilHealed,
             action = { unit.fortifyUntilHealed() }
                 .takeIf { !unit.isFortifyingUntilHealed() && unit.canHealInCurrentTile() },
-            useFrequency = 45
+            useFrequency = 45f
         ))
     }
 
@@ -295,13 +295,13 @@ object UnitActions {
         if (tile.hasImprovementInProgress() && unit.canBuildImprovement(tile.getTileImprovementInProgress()!!)) return
 
         yield(UnitAction(UnitActionType.Sleep,
-            useFrequency = if (!unit.isSleeping()) 29 else 21,
+            useFrequency = if (!unit.isSleeping()) 29f else 21f,
             action = { unit.action = UnitActionType.Sleep.value }.takeIf { !unit.isSleeping() || unit.isSleepingUntilHealed() }
         ))
 
         if (unit.health == 100) return
         yield(UnitAction(UnitActionType.SleepUntilHealed,
-            useFrequency = if (!unit.isSleepingUntilHealed()) 44 else 20,
+            useFrequency = if (!unit.isSleepingUntilHealed()) 44f else 20f,
             action = { unit.action = UnitActionType.SleepUntilHealed.value }
                 .takeIf { !unit.isSleepingUntilHealed() && unit.canHealInCurrentTile() }
         ))
@@ -330,7 +330,7 @@ object UnitActions {
         if (unit.isTransported) return@sequence
 
         if (unit.currentMovement <= 0) {
-            yield(UnitAction(UnitActionType.GiftUnit, 1, action = null))
+            yield(UnitAction(UnitActionType.GiftUnit, 1f, action = null))
             return@sequence
         }
 
@@ -357,14 +357,14 @@ object UnitActions {
                 unit.gift(recipient)
             GUI.setUpdateWorldOnNextRender()
         }
-        yield(UnitAction(UnitActionType.GiftUnit, 5, action = giftAction))
+        yield(UnitAction(UnitActionType.GiftUnit, 5f, action = giftAction))
     }
 
     private suspend fun SequenceScope<UnitAction>.addAutomateActions(unit: MapUnit) {
         if (unit.isAutomated()) return
         yield(UnitAction(UnitActionType.Automate,
             isCurrentAction = unit.isAutomated(),
-            useFrequency = 25,
+            useFrequency = 25f,
             action = {
                 // Temporary, for compatibility - we want games serialized *moving through old versions* to come out the other end with units still automated
                 unit.action = UnitActionType.Automate.value
@@ -377,7 +377,7 @@ object UnitActions {
     private suspend fun SequenceScope<UnitAction>.addWaitAction(unit: MapUnit) {
         yield(UnitAction(
             type = UnitActionType.Wait,
-            useFrequency = 65, // Preferably have this on the first page
+            useFrequency = 65f, // Preferably have this on the first page
             action = {
                 unit.due = false
                 GUI.getWorldScreen().switchToNextUnit()
@@ -395,8 +395,8 @@ object UnitActions {
     // This function is here for historic reasons, and to keep UnitActionType implementations closer together.
     // The code might move to UnitActionsTable altogether, no big difference.
     internal fun getPagingActions(unit: MapUnit, actionsTable: UnitActionsTable): Pair<UnitAction, UnitAction> {
-        return UnitAction(UnitActionType.ShowAdditionalActions, 0) { actionsTable.changePage(1, unit) } to
-            UnitAction(UnitActionType.HideAdditionalActions, 0) { actionsTable.changePage(-1, unit) }
+        return UnitAction(UnitActionType.ShowAdditionalActions, 0f) { actionsTable.changePage(1, unit) } to
+            UnitAction(UnitActionType.HideAdditionalActions, 0f) { actionsTable.changePage(-1, unit) }
     }
 
 }

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActions.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActions.kt
@@ -212,7 +212,7 @@ object UnitActions {
         yield(UnitAction(
             type = UnitActionType.SwapUnits,
             isCurrentAction = worldScreen.bottomUnitTable.selectedUnitIsSwapping,
-            useFrequency = 70,
+            useFrequency = 60,
             action = {
                 worldScreen.bottomUnitTable.selectedUnitIsSwapping =
                     !worldScreen.bottomUnitTable.selectedUnitIsSwapping
@@ -295,15 +295,15 @@ object UnitActions {
         if (tile.hasImprovementInProgress() && unit.canBuildImprovement(tile.getTileImprovementInProgress()!!)) return
 
         yield(UnitAction(UnitActionType.Sleep,
-            action = { unit.action = UnitActionType.Sleep.value }.takeIf { !unit.isSleeping() || unit.isSleepingUntilHealed() },
-            useFrequency = 29
+            useFrequency = if (!unit.isSleeping()) 29 else 21,
+            action = { unit.action = UnitActionType.Sleep.value }.takeIf { !unit.isSleeping() || unit.isSleepingUntilHealed() }
         ))
 
         if (unit.health == 100) return
         yield(UnitAction(UnitActionType.SleepUntilHealed,
+            useFrequency = if (!unit.isSleepingUntilHealed()) 44 else 20,
             action = { unit.action = UnitActionType.SleepUntilHealed.value }
-                .takeIf { !unit.isSleepingUntilHealed() && unit.canHealInCurrentTile() },
-            useFrequency = 44
+                .takeIf { !unit.isSleepingUntilHealed() && unit.canHealInCurrentTile() }
         ))
     }
 
@@ -377,7 +377,7 @@ object UnitActions {
     private suspend fun SequenceScope<UnitAction>.addWaitAction(unit: MapUnit) {
         yield(UnitAction(
             type = UnitActionType.Wait,
-            useFrequency = 85, // Preferably have this on the first page
+            useFrequency = 65, // Preferably have this on the first page
             action = {
                 unit.due = false
                 GUI.getWorldScreen().switchToNextUnit()

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsFromUniques.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsFromUniques.kt
@@ -47,7 +47,7 @@ object UnitActionsFromUniques {
         if (unit.civ.isOneCityChallenger() && unit.civ.hasEverOwnedOriginalCapital) return null
 
         if (unit.currentMovement <= 0 || !tile.canBeSettled())
-            return UnitAction(UnitActionType.FoundCity, 80, action = null)
+            return UnitAction(UnitActionType.FoundCity, 80f, action = null)
 
         val hasActionModifiers = unique.conditionals.any { it.type?.targetTypes?.contains(
             UniqueTarget.UnitActionModifier
@@ -63,7 +63,7 @@ object UnitActionsFromUniques {
         }
 
         if (unit.civ.playerType == PlayerType.AI)
-            return UnitAction(UnitActionType.FoundCity, 80, action = foundAction)
+            return UnitAction(UnitActionType.FoundCity, 80f, action = foundAction)
 
         val title =
             if (hasActionModifiers) UnitActionModifiers.actionTextWithSideEffects(
@@ -75,7 +75,7 @@ object UnitActionsFromUniques {
 
         return UnitAction(
             type = UnitActionType.FoundCity,
-            useFrequency = 80,
+            useFrequency = 80f,
             title = title,
             uncivSound = UncivSound.Chimes,
             action = {
@@ -122,7 +122,7 @@ object UnitActionsFromUniques {
         val isSetUp = unit.isSetUpForSiege()
         return sequenceOf(UnitAction(UnitActionType.SetUp,
             isCurrentAction = isSetUp,
-            useFrequency = 85,
+            useFrequency = 85f,
             action = {
                 unit.action = UnitActionType.SetUp.value
                 unit.useMovementPoints(1f)
@@ -137,7 +137,7 @@ object UnitActionsFromUniques {
         unit.cache.paradropRange = paradropUniques.maxOfOrNull { it.params[0] }!!.toInt()
         return sequenceOf(UnitAction(UnitActionType.Paradrop,
             isCurrentAction = unit.isPreparingParadrop(),
-            useFrequency = 60, // While it is important to see, it isn't nessesary used a lot
+            useFrequency = 60f, // While it is important to see, it isn't nessesary used a lot
             action = {
                 if (unit.isPreparingParadrop()) unit.action = null
                 else unit.action = UnitActionType.Paradrop.value
@@ -155,7 +155,7 @@ object UnitActionsFromUniques {
         if (!airsweepUniques.any()) return emptySequence()
         return sequenceOf(UnitAction(UnitActionType.AirSweep,
             isCurrentAction = unit.isPreparingAirSweep(),
-            useFrequency = 90,
+            useFrequency = 90f,
             action = {
                 if (unit.isPreparingAirSweep()) unit.action = null
                 else unit.action = UnitActionType.AirSweep.value
@@ -213,7 +213,7 @@ object UnitActionsFromUniques {
                 }
             }()
 
-            yield(UnitAction(UnitActionType.TriggerUnique, 80, title, action = unitAction))
+            yield(UnitAction(UnitActionType.TriggerUnique, 80f, title, action = unitAction))
         }
     }
 
@@ -223,7 +223,7 @@ object UnitActionsFromUniques {
             title = "Add to [${
                 unit.getMatchingUniques(UniqueType.AddInCapital).first().params[0]
             }]",
-            useFrequency = 80,
+            useFrequency = 80f,
             action = {
                 unit.civ.victoryManager.currentsSpaceshipParts.add(unit.name, 1)
                 unit.destroy()
@@ -247,7 +247,7 @@ object UnitActionsFromUniques {
         val improvement = tile.ruleset.tileImprovements[improvementName] ?: return null
         if (!tile.improvementFunctions.canBuildImprovement(improvement, unit.civ)) return null
 
-        return UnitAction(UnitActionType.CreateImprovement, 82, "Create [$improvementName]",
+        return UnitAction(UnitActionType.CreateImprovement, 82f, "Create [$improvementName]",
             action = {
                 tile.changeImprovement(improvementName, unit.civ, unit)
                 unit.destroy()  // Modders may wish for a nondestructive way, but that should be another Unique
@@ -274,7 +274,7 @@ object UnitActionsFromUniques {
                         (civResources[improvementUnique.params[1]] ?: 0) < improvementUnique.params[0].toInt()
                 }
 
-                yield(UnitAction(UnitActionType.CreateImprovement, 85,
+                yield(UnitAction(UnitActionType.CreateImprovement, 85f,
                     title = UnitActionModifiers.actionTextWithSideEffects(
                         "Create [${improvement.name}]",
                         unique,
@@ -317,7 +317,7 @@ object UnitActionsFromUniques {
         if(!unitCanBuildRoad) return@sequence
 
         val worldScreen = GUI.getWorldScreen()
-        yield(UnitAction(UnitActionType.ConnectRoad, 25, // Press once for a multiturn command, it doesn't need to be used that frequently
+        yield(UnitAction(UnitActionType.ConnectRoad, 25f, // Press once for a multiturn command, it doesn't need to be used that frequently
                isCurrentAction = unit.isAutomatingRoadConnection(),
                action = {
                    worldScreen.bottomUnitTable.selectedUnitIsConnectingRoad =
@@ -359,7 +359,7 @@ object UnitActionsFromUniques {
                 "Transform to [${unitToTransformTo.name}]"
             else "Transform to [${unitToTransformTo.name}]\n([$newResourceRequirementsString])"
 
-            yield(UnitAction(UnitActionType.Transform, 70,
+            yield(UnitAction(UnitActionType.Transform, 70f,
                 title = title,
                 action = {
                     unit.destroy()
@@ -403,7 +403,7 @@ object UnitActionsFromUniques {
                 && unit.canBuildImprovement(it)
         }
 
-        return sequenceOf(UnitAction(UnitActionType.ConstructImprovement, 85,
+        return sequenceOf(UnitAction(UnitActionType.ConstructImprovement, 85f,
             isCurrentAction = tile.hasImprovementInProgress(),
             action = {
                 GUI.pushScreen(ImprovementPickerScreen(tile, unit) {
@@ -443,7 +443,7 @@ object UnitActionsFromUniques {
 
         val turnsToBuild = getRepairTurns(unit)
 
-        return UnitAction(UnitActionType.Repair, 90,
+        return UnitAction(UnitActionType.Repair, 90f,
             title = "${UnitActionType.Repair} [${unit.currentTile.getImprovementToRepair()!!.name}] - [${turnsToBuild}${Fonts.turn}]",
             action = {
                 tile.turnsToImprovement = getRepairTurns(unit)

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsFromUniques.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsFromUniques.kt
@@ -47,7 +47,7 @@ object UnitActionsFromUniques {
         if (unit.civ.isOneCityChallenger() && unit.civ.hasEverOwnedOriginalCapital) return null
 
         if (unit.currentMovement <= 0 || !tile.canBeSettled())
-            return UnitAction(UnitActionType.FoundCity, action = null)
+            return UnitAction(UnitActionType.FoundCity, 80, action = null)
 
         val hasActionModifiers = unique.conditionals.any { it.type?.targetTypes?.contains(
             UniqueTarget.UnitActionModifier
@@ -63,7 +63,7 @@ object UnitActionsFromUniques {
         }
 
         if (unit.civ.playerType == PlayerType.AI)
-            return UnitAction(UnitActionType.FoundCity, action = foundAction)
+            return UnitAction(UnitActionType.FoundCity, 80, action = foundAction)
 
         val title =
             if (hasActionModifiers) UnitActionModifiers.actionTextWithSideEffects(
@@ -75,6 +75,7 @@ object UnitActionsFromUniques {
 
         return UnitAction(
             type = UnitActionType.FoundCity,
+            useFrequency = 80,
             title = title,
             uncivSound = UncivSound.Chimes,
             action = {
@@ -121,6 +122,7 @@ object UnitActionsFromUniques {
         val isSetUp = unit.isSetUpForSiege()
         return sequenceOf(UnitAction(UnitActionType.SetUp,
             isCurrentAction = isSetUp,
+            useFrequency = 85,
             action = {
                 unit.action = UnitActionType.SetUp.value
                 unit.useMovementPoints(1f)
@@ -135,6 +137,7 @@ object UnitActionsFromUniques {
         unit.cache.paradropRange = paradropUniques.maxOfOrNull { it.params[0] }!!.toInt()
         return sequenceOf(UnitAction(UnitActionType.Paradrop,
             isCurrentAction = unit.isPreparingParadrop(),
+            useFrequency = 60, // While it is important to see, it isn't nessesary used a lot
             action = {
                 if (unit.isPreparingParadrop()) unit.action = null
                 else unit.action = UnitActionType.Paradrop.value
@@ -152,6 +155,7 @@ object UnitActionsFromUniques {
         if (!airsweepUniques.any()) return emptySequence()
         return sequenceOf(UnitAction(UnitActionType.AirSweep,
             isCurrentAction = unit.isPreparingAirSweep(),
+            useFrequency = 90,
             action = {
                 if (unit.isPreparingAirSweep()) unit.action = null
                 else unit.action = UnitActionType.AirSweep.value
@@ -209,7 +213,7 @@ object UnitActionsFromUniques {
                 }
             }()
 
-            yield(UnitAction(UnitActionType.TriggerUnique, title, action = unitAction))
+            yield(UnitAction(UnitActionType.TriggerUnique, 80, title, action = unitAction))
         }
     }
 
@@ -219,6 +223,7 @@ object UnitActionsFromUniques {
             title = "Add to [${
                 unit.getMatchingUniques(UniqueType.AddInCapital).first().params[0]
             }]",
+            useFrequency = 80,
             action = {
                 unit.civ.victoryManager.currentsSpaceshipParts.add(unit.name, 1)
                 unit.destroy()
@@ -242,7 +247,7 @@ object UnitActionsFromUniques {
         val improvement = tile.ruleset.tileImprovements[improvementName] ?: return null
         if (!tile.improvementFunctions.canBuildImprovement(improvement, unit.civ)) return null
 
-        return UnitAction(UnitActionType.CreateImprovement, "Create [$improvementName]",
+        return UnitAction(UnitActionType.CreateImprovement, 82, "Create [$improvementName]",
             action = {
                 tile.changeImprovement(improvementName, unit.civ, unit)
                 unit.destroy()  // Modders may wish for a nondestructive way, but that should be another Unique
@@ -269,7 +274,7 @@ object UnitActionsFromUniques {
                         (civResources[improvementUnique.params[1]] ?: 0) < improvementUnique.params[0].toInt()
                 }
 
-                yield(UnitAction(UnitActionType.CreateImprovement,
+                yield(UnitAction(UnitActionType.CreateImprovement, 85,
                     title = UnitActionModifiers.actionTextWithSideEffects(
                         "Create [${improvement.name}]",
                         unique,
@@ -312,7 +317,7 @@ object UnitActionsFromUniques {
         if(!unitCanBuildRoad) return@sequence
 
         val worldScreen = GUI.getWorldScreen()
-        yield(UnitAction(UnitActionType.ConnectRoad,
+        yield(UnitAction(UnitActionType.ConnectRoad, 25, // Press once for a multiturn command, it doesn't need to be used that frequently
                isCurrentAction = unit.isAutomatingRoadConnection(),
                action = {
                    worldScreen.bottomUnitTable.selectedUnitIsConnectingRoad =
@@ -354,7 +359,7 @@ object UnitActionsFromUniques {
                 "Transform to [${unitToTransformTo.name}]"
             else "Transform to [${unitToTransformTo.name}]\n([$newResourceRequirementsString])"
 
-            yield(UnitAction(UnitActionType.Transform,
+            yield(UnitAction(UnitActionType.Transform, 70,
                 title = title,
                 action = {
                     unit.destroy()
@@ -398,7 +403,7 @@ object UnitActionsFromUniques {
                 && unit.canBuildImprovement(it)
         }
 
-        return sequenceOf(UnitAction(UnitActionType.ConstructImprovement,
+        return sequenceOf(UnitAction(UnitActionType.ConstructImprovement, 85,
             isCurrentAction = tile.hasImprovementInProgress(),
             action = {
                 GUI.pushScreen(ImprovementPickerScreen(tile, unit) {
@@ -438,7 +443,7 @@ object UnitActionsFromUniques {
 
         val turnsToBuild = getRepairTurns(unit)
 
-        return UnitAction(UnitActionType.Repair,
+        return UnitAction(UnitActionType.Repair, 90,
             title = "${UnitActionType.Repair} [${unit.currentTile.getImprovementToRepair()!!.name}] - [${turnsToBuild}${Fonts.turn}]",
             action = {
                 tile.turnsToImprovement = getRepairTurns(unit)

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsGreatPerson.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsGreatPerson.kt
@@ -17,7 +17,7 @@ object UnitActionsGreatPerson {
     internal fun getHurryResearchActions(unit: MapUnit, tile: Tile) = sequence {
         for (unique in unit.getMatchingUniques(UniqueType.CanHurryResearch)){
             yield(UnitAction(
-                UnitActionType.HurryResearch,
+                UnitActionType.HurryResearch, 76,
                 action = {
                     unit.civ.tech.addScience(unit.civ.tech.getScienceFromGreatScientist())
                     unit.consume()
@@ -33,7 +33,7 @@ object UnitActionsGreatPerson {
     internal fun getHurryPolicyActions(unit: MapUnit, tile: Tile) = sequence {
         for (unique in unit.getMatchingUniques(UniqueType.CanHurryPolicy)){
             yield(UnitAction(
-                UnitActionType.HurryPolicy,
+                UnitActionType.HurryPolicy, 76,
                 action = {
                     unit.civ.policies.addCulture(unit.civ.policies.getCultureFromGreatWriter())
                     unit.consume()
@@ -50,7 +50,7 @@ object UnitActionsGreatPerson {
                     && tile.getCity()!!.cityConstructions.canBeHurried()
 
             yield(UnitAction(
-                UnitActionType.HurryWonder,
+                UnitActionType.HurryWonder, 75,
                 action = {
                     tile.getCity()!!.cityConstructions.apply {
                         //http://civilization.wikia.com/wiki/Great_engineer_(Civ5)
@@ -67,7 +67,7 @@ object UnitActionsGreatPerson {
     internal fun getHurryBuildingActions(unit: MapUnit, tile: Tile) = sequence {
         for (unique in unit.getMatchingUniques(UniqueType.CanSpeedupConstruction)) {
             if (!tile.isCityCenter()) {
-                yield(UnitAction(UnitActionType.HurryBuilding, action = null))
+                yield(UnitAction(UnitActionType.HurryBuilding, 75, action = null))
                 continue
             }
 
@@ -83,7 +83,7 @@ object UnitActionsGreatPerson {
             if (productionPointsToAdd <= 0) continue
 
             yield(UnitAction(
-                UnitActionType.HurryBuilding,
+                UnitActionType.HurryBuilding, 75,
                 title = "Hurry Construction (+[$productionPointsToAdd]⚙)",
                 action = {
                     cityConstructions.apply {
@@ -105,7 +105,7 @@ object UnitActionsGreatPerson {
             val influenceEarned = unique.params[0].toFloat()
 
             yield(UnitAction(
-                UnitActionType.ConductTradeMission,
+                UnitActionType.ConductTradeMission, 70,
                 action = {
                     // http://civilization.wikia.com/wiki/Great_Merchant_(Civ5)
                     var goldEarned = (350 + 50 * unit.civ.getEraNumber()) * unit.civ.gameInfo.speed.goldCostModifier

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsGreatPerson.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsGreatPerson.kt
@@ -17,7 +17,7 @@ object UnitActionsGreatPerson {
     internal fun getHurryResearchActions(unit: MapUnit, tile: Tile) = sequence {
         for (unique in unit.getMatchingUniques(UniqueType.CanHurryResearch)){
             yield(UnitAction(
-                UnitActionType.HurryResearch, 76,
+                UnitActionType.HurryResearch, 76f,
                 action = {
                     unit.civ.tech.addScience(unit.civ.tech.getScienceFromGreatScientist())
                     unit.consume()
@@ -33,7 +33,7 @@ object UnitActionsGreatPerson {
     internal fun getHurryPolicyActions(unit: MapUnit, tile: Tile) = sequence {
         for (unique in unit.getMatchingUniques(UniqueType.CanHurryPolicy)){
             yield(UnitAction(
-                UnitActionType.HurryPolicy, 76,
+                UnitActionType.HurryPolicy, 76f,
                 action = {
                     unit.civ.policies.addCulture(unit.civ.policies.getCultureFromGreatWriter())
                     unit.consume()
@@ -50,7 +50,7 @@ object UnitActionsGreatPerson {
                     && tile.getCity()!!.cityConstructions.canBeHurried()
 
             yield(UnitAction(
-                UnitActionType.HurryWonder, 75,
+                UnitActionType.HurryWonder, 75f,
                 action = {
                     tile.getCity()!!.cityConstructions.apply {
                         //http://civilization.wikia.com/wiki/Great_engineer_(Civ5)
@@ -67,7 +67,7 @@ object UnitActionsGreatPerson {
     internal fun getHurryBuildingActions(unit: MapUnit, tile: Tile) = sequence {
         for (unique in unit.getMatchingUniques(UniqueType.CanSpeedupConstruction)) {
             if (!tile.isCityCenter()) {
-                yield(UnitAction(UnitActionType.HurryBuilding, 75, action = null))
+                yield(UnitAction(UnitActionType.HurryBuilding, 75f, action = null))
                 continue
             }
 
@@ -83,7 +83,7 @@ object UnitActionsGreatPerson {
             if (productionPointsToAdd <= 0) continue
 
             yield(UnitAction(
-                UnitActionType.HurryBuilding, 75,
+                UnitActionType.HurryBuilding, 75f,
                 title = "Hurry Construction (+[$productionPointsToAdd]⚙)",
                 action = {
                     cityConstructions.apply {
@@ -105,7 +105,7 @@ object UnitActionsGreatPerson {
             val influenceEarned = unique.params[0].toFloat()
 
             yield(UnitAction(
-                UnitActionType.ConductTradeMission, 70,
+                UnitActionType.ConductTradeMission, 70f,
                 action = {
                     // http://civilization.wikia.com/wiki/Great_Merchant_(Civ5)
                     var goldEarned = (350 + 50 * unit.civ.getEraNumber()) * unit.civ.gameInfo.speed.goldCostModifier

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsPillage.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsPillage.kt
@@ -22,7 +22,7 @@ object UnitActionsPillage {
             ?: return emptySequence()
         if (pillageAction.action == null || unit.civ.isAI() || (unit.civ.isHuman() && UncivGame.Current.settings.autoPlay.isAutoPlaying()))
             return sequenceOf(pillageAction)
-        else return sequenceOf(UnitAction(UnitActionType.Pillage, 65, pillageAction.title) {
+        else return sequenceOf(UnitAction(UnitActionType.Pillage, 65f, pillageAction.title) {
             val pillageText = "Are you sure you want to pillage this [${tile.getImprovementToPillageName()!!}]?"
             ConfirmPopup(
                 GUI.getWorldScreen(),
@@ -40,7 +40,7 @@ object UnitActionsPillage {
         val improvementName = unit.currentTile.getImprovementToPillageName()
         if (unit.isCivilian() || improvementName == null || tile.getOwner() == unit.civ) return null
         return UnitAction(
-            UnitActionType.Pillage, 65,
+            UnitActionType.Pillage, 65f,
             title = "${UnitActionType.Pillage} [$improvementName]",
             action = {
                 val pillagedImprovement = unit.currentTile.getImprovementToPillageName()!!  // can this differ from improvementName due to later execution???

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsPillage.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsPillage.kt
@@ -22,7 +22,7 @@ object UnitActionsPillage {
             ?: return emptySequence()
         if (pillageAction.action == null || unit.civ.isAI() || (unit.civ.isHuman() && UncivGame.Current.settings.autoPlay.isAutoPlaying()))
             return sequenceOf(pillageAction)
-        else return sequenceOf(UnitAction(UnitActionType.Pillage, pillageAction.title) {
+        else return sequenceOf(UnitAction(UnitActionType.Pillage, 65, pillageAction.title) {
             val pillageText = "Are you sure you want to pillage this [${tile.getImprovementToPillageName()!!}]?"
             ConfirmPopup(
                 GUI.getWorldScreen(),
@@ -40,7 +40,7 @@ object UnitActionsPillage {
         val improvementName = unit.currentTile.getImprovementToPillageName()
         if (unit.isCivilian() || improvementName == null || tile.getOwner() == unit.civ) return null
         return UnitAction(
-            UnitActionType.Pillage,
+            UnitActionType.Pillage, 65,
             title = "${UnitActionType.Pillage} [$improvementName]",
             action = {
                 val pillagedImprovement = unit.currentTile.getImprovementToPillageName()!!  // can this differ from improvementName due to later execution???

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsReligion.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsReligion.kt
@@ -23,7 +23,7 @@ object UnitActionsReligion {
         ) == true }
 
         return sequenceOf(UnitAction(
-            UnitActionType.FoundReligion,
+            UnitActionType.FoundReligion, 80,
 
             if (hasActionModifiers) UnitActionModifiers.actionTextWithSideEffects(
                 UnitActionType.FoundReligion.value,
@@ -52,7 +52,7 @@ object UnitActionsReligion {
 
         val baseTitle = "Enhance [${unit.civ.religionManager.religion!!.getReligionDisplayName()}]"
         return sequenceOf(UnitAction(
-            UnitActionType.EnhanceReligion,
+            UnitActionType.EnhanceReligion, 79,
             title = if (hasActionModifiers) UnitActionModifiers.actionTextWithSideEffects(
                 baseTitle,
                 unique,
@@ -87,7 +87,7 @@ object UnitActionsReligion {
             newStyleUnique, unit)
 
         return sequenceOf(UnitAction(
-            UnitActionType.SpreadReligion,
+            UnitActionType.SpreadReligion, 68,
             title = title,
             action = {
                 val followersOfOtherReligions = city.religion.getFollowersOfOtherReligionsThan(unit.religion!!)
@@ -123,7 +123,7 @@ object UnitActionsReligion {
             UnitActionModifiers.actionTextWithSideEffects("Remove Heresy", newStyleUnique!!, unit)
 
         return sequenceOf(UnitAction(
-            UnitActionType.RemoveHeresy,
+            UnitActionType.RemoveHeresy, 69,
             title = title,
             action = {
                 city.religion.removeAllPressuresExceptFor(unit.religion!!)

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsReligion.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsReligion.kt
@@ -23,7 +23,7 @@ object UnitActionsReligion {
         ) == true }
 
         return sequenceOf(UnitAction(
-            UnitActionType.FoundReligion, 80,
+            UnitActionType.FoundReligion, 80f,
 
             if (hasActionModifiers) UnitActionModifiers.actionTextWithSideEffects(
                 UnitActionType.FoundReligion.value,
@@ -52,7 +52,7 @@ object UnitActionsReligion {
 
         val baseTitle = "Enhance [${unit.civ.religionManager.religion!!.getReligionDisplayName()}]"
         return sequenceOf(UnitAction(
-            UnitActionType.EnhanceReligion, 79,
+            UnitActionType.EnhanceReligion, 79f,
             title = if (hasActionModifiers) UnitActionModifiers.actionTextWithSideEffects(
                 baseTitle,
                 unique,
@@ -87,7 +87,7 @@ object UnitActionsReligion {
             newStyleUnique, unit)
 
         return sequenceOf(UnitAction(
-            UnitActionType.SpreadReligion, 68,
+            UnitActionType.SpreadReligion, 68f,
             title = title,
             action = {
                 val followersOfOtherReligions = city.religion.getFollowersOfOtherReligionsThan(unit.religion!!)
@@ -123,7 +123,7 @@ object UnitActionsReligion {
             UnitActionModifiers.actionTextWithSideEffects("Remove Heresy", newStyleUnique!!, unit)
 
         return sequenceOf(UnitAction(
-            UnitActionType.RemoveHeresy, 69,
+            UnitActionType.RemoveHeresy, 69f,
             title = title,
             action = {
                 city.religion.removeAllPressuresExceptFor(unit.religion!!)

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsTable.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsTable.kt
@@ -73,8 +73,9 @@ class UnitActionsTable(val worldScreen: WorldScreen) : Table() {
         val previousPageButton = getUnitActionButton(unit, previousPageAction)
         updateButtonsPerPage(nextPageButton)
 
+        val sortedUnitActions = UnitActions.getUnitActions(unit).sortedByDescending { it.useFrequency }
         // Distribute sequentially into the buckets
-        for (unitAction in UnitActions.getUnitActions(unit)) {
+        for (unitAction in sortedUnitActions) {
             var actionPage = UnitActions.getActionDefaultPage(unit, unitAction.type)
             while (actionPage < maxAllowedPages && freeSlotsOnPage(actionPage) <= 0)
                 actionPage++


### PR DESCRIPTION
Related to #10533
Some of the UnitActions aren't displayed in an order that makes much sense. 
For example, sleep, connect road, and automate are in front of wait and swap units when they are used less often and are multiturn actions. Explore tends to be one of the most visible buttons but can't be used in the middle/late game. (see "before pictures" below)

As a fix, this PR adds in a new frequency sorting system. Each action is given a "use frequency", which is an int, usually between 0 and 100 of how the actions should be ordered. 
A higher value means more often and that it should be on an earlier page. 100 is very frequently used, 50 is somewhat frequently used, less than 25 is press one time for multi-turn movement. A Rare case is > 100 if a button is something like add in capital, promote or something that we need to inform the player that it is an option.

<details><summary>Here is the general order of actions from highest to lowest:</summary>
<p>

- Promotion
- Upgrading
- ReligionActions, One time uniques
- Construction
- Setup
- AirSweep
- Wait
- SwapUnits
- SleepUntilHealed/FortifyUntilHealed
- Sleep/Fortify
- ConnectRoad
- Automate
- Explore
- Gift
- Disband


</p>
</details> 


<details><summary>BeforePictures</summary>

![ButtonSortingBefore1](https://github.com/yairm210/Unciv/assets/7538725/c426abe6-abc9-48fa-8935-02105ad3b5e5)
![ButtonSortingBefore2](https://github.com/yairm210/Unciv/assets/7538725/2eda0b5c-d6da-4bc3-ab25-58880b54d991)
![ButtonSortingBefore3](https://github.com/yairm210/Unciv/assets/7538725/32ff43b0-69a3-4c23-8a23-2c3036e4cb56)
![ButtonSortingBefore4](https://github.com/yairm210/Unciv/assets/7538725/b380e801-4587-4c81-b72a-62b90dd304a8)
![ButtonSortingBefore5](https://github.com/yairm210/Unciv/assets/7538725/f2b374bf-74ef-4ccc-8519-214295a507dd)


</details> 

<details><summary>AfterPictures</summary>

![ButtonSorting1](https://github.com/yairm210/Unciv/assets/7538725/aa1eaf9f-4931-4096-baf5-8c9af1327070)
![ButtonSorting2](https://github.com/yairm210/Unciv/assets/7538725/aac52ad0-6d39-497f-b761-10ce7426478e)
![ButtonSorting3](https://github.com/yairm210/Unciv/assets/7538725/79784528-912c-4dbc-8108-657f8aaedf8e)


</details> 


There also is a `getActionDefaultPage()` system. However, it isn't very comprehensive, doesn't allow for sorting within a page, and may force a new page to be created even if it is the only action on it. I have left this in for now, but we might want to completely replace it.