### PR TITLE
Skip next unit button

### DIFF
--- a/core/src/com/unciv/ui/components/input/KeyboardBinding.kt
+++ b/core/src/com/unciv/ui/components/input/KeyboardBinding.kt
@@ -142,6 +142,10 @@ enum class KeyboardBinding(
     AutoPlayMenuCivilians(Category.AutoPlayMenu, "AutoPlay Civilians Once", 'c'),
     AutoPlayMenuEconomy(Category.AutoPlayMenu, "AutoPlay Economy Once", 'e'),
 
+    // NextTurnMenu
+    NextTurnMenuNextTurn(Category.NextTurnMenu, "Next Turn", 'n'),
+    NextTurnMenuMoveAutomatedUnits(Category.NextTurnMenu, "Move Automated Units", 'm'),
+
     // City Screen
     AddConstruction(Category.CityScreen, "Add to or remove from queue", KeyCharAndCode.RETURN),
     RaisePriority(Category.CityScreen, "Raise queue priority", Input.Keys.UP),
@@ -216,6 +220,9 @@ enum class KeyboardBinding(
         },
         AutoPlayMenu {
             override val label = "AutoPlay menu" // adapt to existing usage
+        },
+        NextTurnMenu {
+            override val label = "NextTurn menu" // adapt to existing usage
         },
         MapPanning {
             override fun checkConflictsIn() = sequenceOf(this, WorldScreen)

--- a/core/src/com/unciv/ui/screens/worldscreen/status/NextTurnButton.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/status/NextTurnButton.kt
@@ -9,6 +9,7 @@ import com.unciv.ui.components.extensions.setSize
 import com.unciv.ui.components.input.KeyboardBinding
 import com.unciv.ui.components.input.keyShortcuts
 import com.unciv.ui.components.input.onActivation
+import com.unciv.ui.components.input.onRightClick
 import com.unciv.ui.images.IconTextButton
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.popups.hasOpenPopups
@@ -22,6 +23,7 @@ class NextTurnButton(
 //         label.setFontSize(30)
         labelCell.pad(10f)
         onActivation { nextTurnAction.action(worldScreen) }
+        onRightClick { NextTurnMenu(stage, this, this, worldScreen) }
         keyShortcuts.add(KeyboardBinding.NextTurn)
         keyShortcuts.add(KeyboardBinding.NextTurnAlternate)
         // Let unit actions override this for command "Wait".

--- a/core/src/com/unciv/ui/screens/worldscreen/status/NextTurnMenu.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/status/NextTurnMenu.kt
@@ -1,0 +1,22 @@
+package com.unciv.ui.screens.worldscreen.status
+
+import com.badlogic.gdx.scenes.scene2d.Actor
+import com.badlogic.gdx.scenes.scene2d.Stage
+import com.badlogic.gdx.scenes.scene2d.ui.Table
+import com.unciv.ui.components.input.KeyboardBinding
+import com.unciv.ui.popups.AnimatedMenuPopup
+import com.unciv.ui.screens.worldscreen.WorldScreen
+
+class NextTurnMenu(
+    stage: Stage,
+    positionNextTo: Actor,
+    private val nextTurnButton: NextTurnButton,
+    private val worldScreen: WorldScreen
+) : AnimatedMenuPopup(stage, getActorTopRight(positionNextTo)) {
+    override fun createContentTable(): Table {
+        val table = super.createContentTable()!!
+        table.add(getButton("Next Turn", KeyboardBinding.NextTurn) { worldScreen.nextTurn() }).row()
+
+        return table
+    }
+}

--- a/core/src/com/unciv/ui/screens/worldscreen/status/NextTurnMenu.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/status/NextTurnMenu.kt
@@ -22,3 +22,4 @@ class NextTurnMenu(
         return table
     }
 }
+

--- a/core/src/com/unciv/ui/screens/worldscreen/status/NextTurnMenu.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/status/NextTurnMenu.kt
@@ -15,10 +15,14 @@ class NextTurnMenu(
 ) : AnimatedMenuPopup(stage, getActorTopRight(positionNextTo)) {
     override fun createContentTable(): Table {
         val table = super.createContentTable()!!
-        table.add(getButton("Next Turn", KeyboardBinding.NextTurn) { worldScreen.nextTurn() }).row()
-        val automateUnitsAction = NextTurnAction.values().first { it == NextTurnAction.MoveAutomatedUnits }
+        table.add(getButton("Next Turn", KeyboardBinding.NextTurnMenuNextTurn) { 
+            worldScreen.nextTurn() 
+        }).row()
+        val automateUnitsAction = NextTurnAction.MoveAutomatedUnits
         if (automateUnitsAction.isChoice(worldScreen))
-            table.add(getButton("Move automated units", KeyboardBinding.NextTurn) { automateUnitsAction.action(worldScreen) }).row()
+            table.add(getButton("Move automated units", KeyboardBinding.NextTurnMenuMoveAutomatedUnits) { 
+                automateUnitsAction.action(worldScreen) 
+            }).row()
         return table
     }
 }

--- a/core/src/com/unciv/ui/screens/worldscreen/status/NextTurnMenu.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/status/NextTurnMenu.kt
@@ -16,7 +16,9 @@ class NextTurnMenu(
     override fun createContentTable(): Table {
         val table = super.createContentTable()!!
         table.add(getButton("Next Turn", KeyboardBinding.NextTurn) { worldScreen.nextTurn() }).row()
-
+        val automateUnitsAction = NextTurnAction.values().first { it == NextTurnAction.MoveAutomatedUnits }
+        if (automateUnitsAction.isChoice(worldScreen))
+            table.add(getButton("Move automated units", KeyboardBinding.NextTurn) { automateUnitsAction.action(worldScreen) }).row()
         return table
     }
 }


### PR DESCRIPTION
In the late game, it gets kind of annoying having to either press wait on each unit or press the next unit button for every unit to end a turn. 
This PR fixes this by adding a right click menu (or long press) where the player can skip pressing the next turn button. I also added a move automated units button so the player can still move their automated units and then end their turn. The move automated units button is only shown if there are units to automate.

<details><summary>Picture</summary>

![NextTurnMenu](https://github.com/yairm210/Unciv/assets/7538725/02c4ee97-8482-46f4-86ab-254204910abb)


</details> 