### PR TITLE
Add configurable natural wonder discovery stat bonuses

### DIFF
--- a/android/assets/jsons/Civ V - Gods & Kings/Nations.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Nations.json
@@ -597,7 +597,7 @@
 		"innerColor": [255,168,168],
 		"favoredReligion": "Christianity",
 		"uniqueName": "Seven Cities of Gold",
-		"uniques": ["[100] [Gold] for discovering a Natural Wonder (bonus enhanced to [500] if first to discover it)",
+		"uniques": ["[+100 Gold] for discovering a Natural Wonder (bonus enhanced to [+500 Gold] if first to discover it)",
 			"[+1 Happiness] for every known Natural Wonder", "[+100]% Yield from every [Natural Wonder]"],
 		"cities": ["Madrid","Barcelona","Seville","Cordoba","Toledo","Santiago","Salamanca","Murcia","Valencia","Zaragoza","Pamplona",
 			"Vitoria","Santander","Oviedo","Jaen","Logroño","Valladolid","Palma","Teruel","Almeria","Leon","Zamora","Mida",

--- a/android/assets/jsons/Civ V - Gods & Kings/Nations.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Nations.json
@@ -597,7 +597,7 @@
 		"innerColor": [255,168,168],
 		"favoredReligion": "Christianity",
 		"uniqueName": "Seven Cities of Gold",
-		"uniques": ["100 Gold for discovering a Natural Wonder (bonus enhanced to 500 Gold if first to discover it)",
+		"uniques": ["[100] [Gold] for discovering a Natural Wonder (bonus enhanced to [500] if first to discover it)",
 			"[+1 Happiness] for every known Natural Wonder", "[+100]% Yield from every [Natural Wonder]"],
 		"cities": ["Madrid","Barcelona","Seville","Cordoba","Toledo","Santiago","Salamanca","Murcia","Valencia","Zaragoza","Pamplona",
 			"Vitoria","Santander","Oviedo","Jaen","Logroño","Valladolid","Palma","Teruel","Almeria","Leon","Zamora","Mida",

--- a/android/assets/jsons/Civ V - Gods & Kings/Terrains.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Terrains.json
@@ -375,7 +375,7 @@
 		"unbuildable": true,
 		"uniques": ["Must be adjacent to [0] [Coast] tiles",
 			"Must be adjacent to [1] to [6] [Jungle] tiles",
-			"Grants 500 Gold to the first civilization to discover it"],
+			"Grants [500] [Gold] to the first civilization to discover it"],
 		"weight": 2
 	},
 	{ // This will count as "Fresh water" in civ 6

--- a/android/assets/jsons/Civ V - Gods & Kings/Terrains.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Terrains.json
@@ -375,7 +375,7 @@
 		"unbuildable": true,
 		"uniques": ["Must be adjacent to [0] [Coast] tiles",
 			"Must be adjacent to [1] to [6] [Jungle] tiles",
-			"Grants [500] [Gold] to the first civilization to discover it"],
+			"Grants [+500 Gold] to the first civilization to discover it"],
 		"weight": 2
 	},
 	{ // This will count as "Fresh water" in civ 6

--- a/android/assets/jsons/Civ V - Vanilla/Nations.json
+++ b/android/assets/jsons/Civ V - Vanilla/Nations.json
@@ -555,7 +555,7 @@
 		"outerColor": [84,26,26],
 		"innerColor": [255,168,168],
 		"uniqueName": "Seven Cities of Gold",
-		"uniques": ["100 Gold for discovering a Natural Wonder (bonus enhanced to 500 Gold if first to discover it)",
+		"uniques": ["[100] [Gold] for discovering a Natural Wonder (bonus enhanced to [500] if first to discover it)",
 			"[+1 Happiness] for every known Natural Wonder", "[+100]% Yield from every [Natural Wonder]"],
 		"cities": ["Madrid","Barcelona","Seville","Cordoba","Toledo","Santiago","Salamanca","Murcia","Valencia","Zaragoza","Pamplona",
 			"Vitoria","Santander","Oviedo","Jaen","Logroño","Valladolid","Palma","Teruel","Almeria","Leon","Zamora","Mida",

--- a/android/assets/jsons/Civ V - Vanilla/Nations.json
+++ b/android/assets/jsons/Civ V - Vanilla/Nations.json
@@ -555,7 +555,7 @@
 		"outerColor": [84,26,26],
 		"innerColor": [255,168,168],
 		"uniqueName": "Seven Cities of Gold",
-		"uniques": ["[100] [Gold] for discovering a Natural Wonder (bonus enhanced to [500] if first to discover it)",
+		"uniques": ["[+100 Gold] for discovering a Natural Wonder (bonus enhanced to [+500 Gold] if first to discover it)",
 			"[+1 Happiness] for every known Natural Wonder", "[+100]% Yield from every [Natural Wonder]"],
 		"cities": ["Madrid","Barcelona","Seville","Cordoba","Toledo","Santiago","Salamanca","Murcia","Valencia","Zaragoza","Pamplona",
 			"Vitoria","Santander","Oviedo","Jaen","Logroño","Valladolid","Palma","Teruel","Almeria","Leon","Zamora","Mida",

--- a/android/assets/jsons/Civ V - Vanilla/Terrains.json
+++ b/android/assets/jsons/Civ V - Vanilla/Terrains.json
@@ -376,7 +376,7 @@
 		"unbuildable": true,
 		"uniques": ["Must be adjacent to [0] [Coast] tiles",
 			"Must be adjacent to [1] to [6] [Jungle] tiles",
-			"Grants 500 Gold to the first civilization to discover it"],
+			"Grants [500] [Gold] to the first civilization to discover it"],
 		"weight": 2
 	},
 	{ // This will count as "Fresh water" in civ 6

--- a/android/assets/jsons/Civ V - Vanilla/Terrains.json
+++ b/android/assets/jsons/Civ V - Vanilla/Terrains.json
@@ -376,7 +376,7 @@
 		"unbuildable": true,
 		"uniques": ["Must be adjacent to [0] [Coast] tiles",
 			"Must be adjacent to [1] to [6] [Jungle] tiles",
-			"Grants [500] [Gold] to the first civilization to discover it"],
+			"Grants [+500 Gold] to the first civilization to discover it"],
 		"weight": 2
 	},
 	{ // This will count as "Fresh water" in civ 6

--- a/core/src/com/unciv/logic/civilization/transients/CivInfoTransientCache.kt
+++ b/core/src/com/unciv/logic/civilization/transients/CivInfoTransientCache.kt
@@ -262,17 +262,26 @@ class CivInfoTransientCache(val civInfo: Civilization) {
                 }
             }
 
+            var naturalWonder: String? = null
 
             if (!statsGained.isEmpty()) {
+                naturalWonder = tile.naturalWonder!!
+            }
+
+            if (!statsGained.isEmpty() && naturalWonder != null) {
                 civInfo.addStats(statsGained)
-                civInfo.addNotification("We have received [${statsGained}] for discovering [${tile.naturalWonder}]",
+                civInfo.addNotification("We have received [${statsGained}] for discovering [${naturalWonder}]",
                     Notification.NotificationCategory.General, statsGained.toString()
                     )
             }
 
             if (goldGained > 0) {
+                naturalWonder = tile.naturalWonder
+            }
+
+            if (goldGained > 0 && naturalWonder != null) {
                 civInfo.addGold(goldGained)
-                civInfo.addNotification("We have received [$goldGained] Gold for discovering [${tile.naturalWonder}]",
+                civInfo.addNotification("We have received [$goldGained] Gold for discovering [${naturalWonder}]",
                     Notification.NotificationCategory.General, NotificationIcon.Gold)
             }
 

--- a/core/src/com/unciv/logic/civilization/transients/CivInfoTransientCache.kt
+++ b/core/src/com/unciv/logic/civilization/transients/CivInfoTransientCache.kt
@@ -221,10 +221,10 @@ class CivInfoTransientCache(val civInfo: Civilization) {
 
             val discoveredNaturalWonders = civInfo.gameInfo.civilizations.filter { it != civInfo && it.isMajorCiv() }
                     .flatMap { it.naturalWonders }
-            if (tile.terrainHasUnique(UniqueType.GrantsStatToFirstToDiscover)
+            if (tile.terrainHasUnique(UniqueType.GrantsStatsToFirstToDiscover)
                     && !discoveredNaturalWonders.contains(tile.naturalWonder!!)) {
 
-                for (unique in tile.getTerrainMatchingUniques(UniqueType.GrantsStatToFirstToDiscover)) {
+                for (unique in tile.getTerrainMatchingUniques(UniqueType.GrantsStatsToFirstToDiscover)) {
                     statsGained.add(unique.stats)
                 }
             }
@@ -240,12 +240,40 @@ class CivInfoTransientCache(val civInfo: Civilization) {
                     statsGained.add(firstDiscoveredBonus)
             }
 
+            // Variable for support of twooo deprecated uniques
+            var goldGained = 0
+
+            // Support for depreciated GoldWhenDiscoveringNaturalWonder unique
+            for (unique in civInfo.getMatchingUniques(UniqueType.GoldWhenDiscoveringNaturalWonder)) {
+
+                goldGained += if (discoveredNaturalWonders.contains(tile.naturalWonder!!)) {
+                    100
+                } else {
+                    500
+                }
+            }
+
+            // Support for depreciated GrantsGoldToFirstToDiscover unique
+            if (tile.terrainHasUnique(UniqueType.GrantsGoldToFirstToDiscover)
+                && !discoveredNaturalWonders.contains(tile.naturalWonder!!)) {
+
+                for (unique in tile.getTerrainMatchingUniques(UniqueType.GoldWhenDiscoveringNaturalWonder)) {
+                    goldGained += 500
+                }
+            }
+
 
             if (!statsGained.isEmpty()) {
                 civInfo.addStats(statsGained)
                 civInfo.addNotification("We have received [${statsGained}] for discovering [${tile.naturalWonder}]",
                     Notification.NotificationCategory.General, statsGained.toString()
                     )
+            }
+
+            if (goldGained > 0) {
+                civInfo.addGold(goldGained)
+                civInfo.addNotification("We have received [$goldGained] Gold for discovering [${tile.naturalWonder}]",
+                    Notification.NotificationCategory.General, NotificationIcon.Gold)
             }
 
             for (unique in civInfo.getTriggeredUniques(UniqueType.TriggerUponDiscoveringNaturalWonder,

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -513,7 +513,7 @@ enum class UniqueType(
     NaturalWonderConvertNeighborsExcept("Neighboring tiles except [baseTerrain] will convert to [baseTerrain]", UniqueTarget.Terrain, flags = UniqueFlag.setOfHiddenToUsers),
     @Deprecated("As of 4.10.17", ReplaceWith("Grants [+500 Gold] to the first civilization to discover it"))
     GrantsGoldToFirstToDiscover("Grants 500 Gold to the first civilization to discover it", UniqueTarget.Terrain),
-    GrantsStatToFirstToDiscover("Grants [stats] to the first civilization to discover it", UniqueTarget.Terrain),
+    GrantsStatsToFirstToDiscover("Grants [stats] to the first civilization to discover it", UniqueTarget.Terrain),
 
     // General terrain
     DamagesContainingUnits("Units ending their turn on this terrain take [amount] damage", UniqueTarget.Terrain),

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -149,8 +149,9 @@ enum class UniqueType(
 
     /// Natural Wonders
     StatsFromNaturalWonders("[stats] for every known Natural Wonder", UniqueTarget.Global),
-    // TODO: moddability of the numbers
+    @Deprecated("as of 4.10.16", ReplaceWith("[100] [Gold] for discovering a Natural Wonder (bonus enhanced to [500] if first to discover it)"))
     GoldWhenDiscoveringNaturalWonder("100 Gold for discovering a Natural Wonder (bonus enhanced to 500 Gold if first to discover it)", UniqueTarget.Global),
+    StatBonusWhenDiscoveringNaturalWonder("[amount] [civWideStat] for discovering a Natural Wonder (bonus enhanced to [amount] if first to discover it)", UniqueTarget.Global),
 
     /// Great Persons
     GreatPersonPointPercentage("[relativeAmount]% Great Person generation [cityFilter]", UniqueTarget.Global, UniqueTarget.FollowerBelief),
@@ -510,7 +511,9 @@ enum class UniqueType(
     NaturalWonderConvertNeighbors("Neighboring tiles will convert to [baseTerrain]", UniqueTarget.Terrain, flags = UniqueFlag.setOfHiddenToUsers),
     // The "Except [terrainFilter]" could theoretically be implemented with a conditional
     NaturalWonderConvertNeighborsExcept("Neighboring tiles except [baseTerrain] will convert to [baseTerrain]", UniqueTarget.Terrain, flags = UniqueFlag.setOfHiddenToUsers),
+    @Deprecated("As of 4.10.16", ReplaceWith("Grants [500] [Gold] to the first civilization to discover it"))
     GrantsGoldToFirstToDiscover("Grants 500 Gold to the first civilization to discover it", UniqueTarget.Terrain),
+    GrantsStatToFirstToDiscover("Grants [amount] [civWideStat] to the first civilization to discover it", UniqueTarget.Terrain),
 
     // General terrain
     DamagesContainingUnits("Units ending their turn on this terrain take [amount] damage", UniqueTarget.Terrain),

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -149,9 +149,9 @@ enum class UniqueType(
 
     /// Natural Wonders
     StatsFromNaturalWonders("[stats] for every known Natural Wonder", UniqueTarget.Global),
-    @Deprecated("as of 4.10.16", ReplaceWith("[100] [Gold] for discovering a Natural Wonder (bonus enhanced to [500] if first to discover it)"))
+    @Deprecated("as of 4.10.17", ReplaceWith("[+100 Gold] for discovering a Natural Wonder (bonus enhanced to [+500 Gold] if first to discover it)"))
     GoldWhenDiscoveringNaturalWonder("100 Gold for discovering a Natural Wonder (bonus enhanced to 500 Gold if first to discover it)", UniqueTarget.Global),
-    StatBonusWhenDiscoveringNaturalWonder("[amount] [civWideStat] for discovering a Natural Wonder (bonus enhanced to [amount] if first to discover it)", UniqueTarget.Global),
+    StatBonusWhenDiscoveringNaturalWonder("[stats] for discovering a Natural Wonder (bonus enhanced to [stats] if first to discover it)", UniqueTarget.Global),
 
     /// Great Persons
     GreatPersonPointPercentage("[relativeAmount]% Great Person generation [cityFilter]", UniqueTarget.Global, UniqueTarget.FollowerBelief),
@@ -511,9 +511,9 @@ enum class UniqueType(
     NaturalWonderConvertNeighbors("Neighboring tiles will convert to [baseTerrain]", UniqueTarget.Terrain, flags = UniqueFlag.setOfHiddenToUsers),
     // The "Except [terrainFilter]" could theoretically be implemented with a conditional
     NaturalWonderConvertNeighborsExcept("Neighboring tiles except [baseTerrain] will convert to [baseTerrain]", UniqueTarget.Terrain, flags = UniqueFlag.setOfHiddenToUsers),
-    @Deprecated("As of 4.10.16", ReplaceWith("Grants [500] [Gold] to the first civilization to discover it"))
+    @Deprecated("As of 4.10.17", ReplaceWith("Grants [+500 Gold] to the first civilization to discover it"))
     GrantsGoldToFirstToDiscover("Grants 500 Gold to the first civilization to discover it", UniqueTarget.Terrain),
-    GrantsStatToFirstToDiscover("Grants [amount] [civWideStat] to the first civilization to discover it", UniqueTarget.Terrain),
+    GrantsStatToFirstToDiscover("Grants [stats] to the first civilization to discover it", UniqueTarget.Terrain),
 
     // General terrain
     DamagesContainingUnits("Units ending their turn on this terrain take [amount] damage", UniqueTarget.Terrain),

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -545,8 +545,8 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 	Applicable to: Global
 
-??? example  "[amount] [civWideStat] for discovering a Natural Wonder (bonus enhanced to [amount] if first to discover it)"
-	Example: "[3] [Gold] for discovering a Natural Wonder (bonus enhanced to [3] if first to discover it)"
+??? example  "[stats] for discovering a Natural Wonder (bonus enhanced to [stats] if first to discover it)"
+	Example: "[+1 Gold, +2 Production] for discovering a Natural Wonder (bonus enhanced to [+1 Gold, +2 Production] if first to discover it)"
 
 	Applicable to: Global
 
@@ -1544,8 +1544,8 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 	Applicable to: Terrain
 
-??? example  "Grants [amount] [civWideStat] to the first civilization to discover it"
-	Example: "Grants [3] [Gold] to the first civilization to discover it"
+??? example  "Grants [stats] to the first civilization to discover it"
+	Example: "Grants [+1 Gold, +2 Production] to the first civilization to discover it"
 
 	Applicable to: Terrain
 

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -227,6 +227,7 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 	Applicable to: Global, FollowerBelief
 
 ??? example  "[stats] per [amount] social policies adopted"
+	Only works for civ-wide stats
 	Example: "[+1 Gold, +2 Production] per [3] social policies adopted"
 
 	Applicable to: Global
@@ -544,7 +545,9 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 	Applicable to: Global
 
-??? example  "100 Gold for discovering a Natural Wonder (bonus enhanced to 500 Gold if first to discover it)"
+??? example  "[amount] [civWideStat] for discovering a Natural Wonder (bonus enhanced to [amount] if first to discover it)"
+	Example: "[3] [Gold] for discovering a Natural Wonder (bonus enhanced to [3] if first to discover it)"
+
 	Applicable to: Global
 
 ??? example  "[relativeAmount]% Great Person generation [cityFilter]"
@@ -1541,7 +1544,9 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 	Applicable to: Terrain
 
-??? example  "Grants 500 Gold to the first civilization to discover it"
+??? example  "Grants [amount] [civWideStat] to the first civilization to discover it"
+	Example: "Grants [3] [Gold] to the first civilization to discover it"
+
 	Applicable to: Terrain
 
 ??? example  "Units ending their turn on this terrain take [amount] damage"


### PR DESCRIPTION
Some time ago, I noticed that the natural wonder discovery stat bonus was hard-coded at 100 Gold (or 500 when discovered as first). I've changed that and from now, modders can configure not only the amount of bonus, but also type of granted stat. It can be Gold, Science, Culture or Faith (these are civ-wide stats)