### PR TITLE
Add Conditionals for comparing Stats and Resources 

### DIFF
--- a/core/src/com/unciv/models/ruleset/unique/Conditionals.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Conditionals.kt
@@ -83,6 +83,42 @@ object Conditionals {
             return compare(relevantCiv!!.getEraNumber(), era.eraNumber)
         }
 
+        /** Helper for comparing the Resource and Stat numbers **/
+        fun compareResourceOrStatAmount(compare: (first: Int, second: Int) -> Boolean): Boolean {
+            if (gameInfo == null) return false
+            val first = condition.params[0]
+            val second = condition.params[1]
+
+            // Compare Resource with Resource
+            if (checkOnResourceName(first) && checkOnResourceName(second)) {
+                return compare(getResourceAmount(first), getResourceAmount(second))
+            }
+            // Compare Stat with Stat
+            else if (Stat.isStat(first) && Stat.isStat(second)) {
+                val firstStat = Stat.safeValueOf(first) ?: return false
+                val secondStat = Stat.safeValueOf(second) ?: return false
+
+                return compare(relevantCiv!!.getStatReserve(firstStat), relevantCiv!!.getStatReserve(secondStat))
+            }
+            // Compare Stat with Resource
+            else if (Stat.isStat(first) && checkOnResourceName(second)) {
+                val stat = Stat.safeValueOf(first) ?: return false
+                val resourceAmount = getResourceAmount(second)
+
+                return compare(relevantCiv!!.getStatReserve(stat), resourceAmount)
+            }
+            // Compare Resource with Stat
+            else if (checkOnResourceName(first) && Stat.isStat(second)) {
+                val resourceAmount = getResourceAmount(first)
+                val stat = Stat.safeValueOf(second) ?: return false
+
+                return compare(resourceAmount, relevantCiv!!.getStatReserve(stat))
+            }
+            else {
+                return false
+            }
+        }
+
         /** Helper for ConditionalWhenAboveAmountStatResource and its below counterpart */
         fun checkResourceOrStatAmount(compare: (current: Int, limit: Int) -> Boolean): Boolean {
             if (gameInfo == null) return false

--- a/core/src/com/unciv/models/ruleset/unique/Conditionals.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Conditionals.kt
@@ -53,6 +53,11 @@ object Conditionals {
             return 0
         }
 
+        fun checkOnResourceName(resourceName: String): Boolean {
+            if (gameInfo == null) return false
+            return gameInfo!!.ruleset.tileResources.containsKey(resourceName)
+        }
+
         /** Helper to simplify conditional tests requiring gameInfo */
         fun checkOnGameInfo(predicate: (GameInfo.() -> Boolean)): Boolean {
             if (gameInfo == null) return false

--- a/core/src/com/unciv/models/ruleset/unique/Conditionals.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Conditionals.kt
@@ -86,37 +86,35 @@ object Conditionals {
         /** Helper for comparing the Resource and Stat numbers **/
         fun compareResourceOrStatAmount(compare: (first: Int, second: Int) -> Boolean): Boolean {
             if (gameInfo == null) return false
+
+            // Get Stat or resource names
             val first = condition.params[0]
             val second = condition.params[1]
 
-            // Compare Resource with Resource
-            if (checkOnResourceName(first) && checkOnResourceName(second)) {
-                return compare(getResourceAmount(first), getResourceAmount(second))
-            }
-            // Compare Stat with Stat
-            else if (Stat.isStat(first) && Stat.isStat(second)) {
-                val firstStat = Stat.safeValueOf(first) ?: return false
-                val secondStat = Stat.safeValueOf(second) ?: return false
+            // Declare variables for Stat or Resource numbers
+            var firstAmount = 0
+            var secondAmount = 0
 
-                return compare(relevantCiv!!.getStatReserve(firstStat), relevantCiv!!.getStatReserve(secondStat))
-            }
-            // Compare Stat with Resource
-            else if (Stat.isStat(first) && checkOnResourceName(second)) {
-                val stat = Stat.safeValueOf(first) ?: return false
-                val resourceAmount = getResourceAmount(second)
-
-                return compare(relevantCiv!!.getStatReserve(stat), resourceAmount)
-            }
-            // Compare Resource with Stat
-            else if (checkOnResourceName(first) && Stat.isStat(second)) {
-                val resourceAmount = getResourceAmount(first)
-                val stat = Stat.safeValueOf(second) ?: return false
-
-                return compare(resourceAmount, relevantCiv!!.getStatReserve(stat))
-            }
-            else {
+            // Return false if the parameters are not Stat or Resource
+            if (!Stat.isStat(first) && !checkOnResourceName(first))
                 return false
-            }
+            if (!Stat.isStat(second) && !checkOnResourceName(second))
+                return false
+
+            // Get number of first
+            if (checkOnResourceName(first))
+                firstAmount = getResourceAmount(first)
+            else if (Stat.isStat(first))
+                firstAmount = relevantCiv!!.getStatReserve(Stat.safeValueOf(first)!!)
+
+            // Get number of second
+            if (checkOnResourceName(second))
+                secondAmount = getResourceAmount(second)
+            else if (Stat.isStat(second))
+                secondAmount = relevantCiv!!.getStatReserve(Stat.safeValueOf(second)!!)
+
+            // Compare the numbers
+            return compare(firstAmount, secondAmount)
         }
 
         /** Helper for ConditionalWhenAboveAmountStatResource and its below counterpart */

--- a/core/src/com/unciv/models/ruleset/unique/Conditionals.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Conditionals.kt
@@ -170,6 +170,14 @@ object Conditionals {
                 checkResourceOrStatAmountWithSpeed { current, limit -> current > limit }  // Note: Int.compareTo(Float)!
             UniqueType.ConditionalWhenBelowAmountStatResourceSpeed ->
                 checkResourceOrStatAmountWithSpeed { current, limit -> current < limit }  // Note: Int.compareTo(Float)!
+            UniqueType.ConditionalExactStatResourceNumber ->
+                checkResourceOrStatAmount { current, limit ->  current == limit }
+            UniqueType.ConditionalHasSameAmountOfTwoStatsResources ->
+                compareResourceOrStatAmount { first, second -> first == second }
+            UniqueType.ConditionalHasMoreStatResource ->
+                compareResourceOrStatAmount { first, second -> first > second }
+            UniqueType.ConditionalHasLessStatResource ->
+                compareResourceOrStatAmount { first, second -> first < second }
 
             UniqueType.ConditionalHappy -> checkOnCiv { stats.happiness >= 0 }
             UniqueType.ConditionalBetweenHappiness ->

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -668,6 +668,14 @@ enum class UniqueType(
     ConditionalWhenAboveAmountStatResourceSpeed("when above [amount] [stat/resource] (modified by game speed)", UniqueTarget.Conditional),
     ConditionalWhenBelowAmountStatResourceSpeed("when below [amount] [stat/resource] (modified by game speed)", UniqueTarget.Conditional),
 
+    // For exact number of resources or stats
+    ConditionalExactStatResourceNumber("has exactly [amount] [stat/resource]", UniqueTarget.Conditional),
+
+    // For comparison between resources
+    ConditionalHasSameAmountOfTwoStatsResources("has the same number of [stat/resource] and [stat/resource]", UniqueTarget.Conditional),
+    ConditionalHasMoreStatResource("has more [stat/resource] than [stat/resource]", UniqueTarget.Conditional),
+    ConditionalHasLessStatResource("has less [stat/resource] than [stat/resource]", UniqueTarget.Conditional),
+
     /////// city conditionals
     ConditionalInThisCity("in this city", UniqueTarget.Conditional),
     ConditionalCityFilter("in [cityFilter] cities", UniqueTarget.Conditional),

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -669,12 +669,12 @@ enum class UniqueType(
     ConditionalWhenBelowAmountStatResourceSpeed("when below [amount] [stat/resource] (modified by game speed)", UniqueTarget.Conditional),
 
     // When exact number of resources or stats
-    ConditionalExactStatResourceNumber("when exactly [amount] [stat/resource]", UniqueTarget.Conditional),
+    ConditionalExactStatResourceNumber("with exactly [amount] [stat/resource]", UniqueTarget.Conditional),
 
     // For comparison between resources
-    ConditionalHasSameAmountOfTwoStatsResources("has the same number of [stat/resource] and [stat/resource]", UniqueTarget.Conditional),
-    ConditionalHasMoreStatResource("when more [stat/resource] than [stat/resource]", UniqueTarget.Conditional),
-    ConditionalHasLessStatResource("when less [stat/resource] than [stat/resource]", UniqueTarget.Conditional),
+    ConditionalHasSameAmountOfTwoStatsResources("with the same number of [stat/resource] and [stat/resource]", UniqueTarget.Conditional),
+    ConditionalHasMoreStatResource("with more [stat/resource] than [stat/resource]", UniqueTarget.Conditional),
+    ConditionalHasLessStatResource("with less [stat/resource] than [stat/resource]", UniqueTarget.Conditional),
 
     /////// city conditionals
     ConditionalInThisCity("in this city", UniqueTarget.Conditional),

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -660,7 +660,7 @@ enum class UniqueType(
     ConditionalWithResource("with [resource]", UniqueTarget.Conditional),
     ConditionalWithoutResource("without [resource]", UniqueTarget.Conditional),
 
-    // Supports also stockpileable resources (Gold, Faith, Culture, Science)
+    // Supports also stockpileable stats (Gold, Faith, Culture, Science)
     ConditionalWhenAboveAmountStatResource("when above [amount] [stat/resource]", UniqueTarget.Conditional),
     ConditionalWhenBelowAmountStatResource("when below [amount] [stat/resource]", UniqueTarget.Conditional),
 

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -668,13 +668,13 @@ enum class UniqueType(
     ConditionalWhenAboveAmountStatResourceSpeed("when above [amount] [stat/resource] (modified by game speed)", UniqueTarget.Conditional),
     ConditionalWhenBelowAmountStatResourceSpeed("when below [amount] [stat/resource] (modified by game speed)", UniqueTarget.Conditional),
 
-    // For exact number of resources or stats
-    ConditionalExactStatResourceNumber("has exactly [amount] [stat/resource]", UniqueTarget.Conditional),
+    // When exact number of resources or stats
+    ConditionalExactStatResourceNumber("when exactly [amount] [stat/resource]", UniqueTarget.Conditional),
 
     // For comparison between resources
     ConditionalHasSameAmountOfTwoStatsResources("has the same number of [stat/resource] and [stat/resource]", UniqueTarget.Conditional),
-    ConditionalHasMoreStatResource("has more [stat/resource] than [stat/resource]", UniqueTarget.Conditional),
-    ConditionalHasLessStatResource("has less [stat/resource] than [stat/resource]", UniqueTarget.Conditional),
+    ConditionalHasMoreStatResource("when more [stat/resource] than [stat/resource]", UniqueTarget.Conditional),
+    ConditionalHasLessStatResource("when less [stat/resource] than [stat/resource]", UniqueTarget.Conditional),
 
     /////// city conditionals
     ConditionalInThisCity("in this city", UniqueTarget.Conditional),

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -2059,8 +2059,8 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 	Applicable to: Conditional
 
-??? example  "&lt;has exactly [amount] [stat/resource]&gt;"
-	Example: "&lt;has exactly [3] [Culture]&gt;"
+??? example  "&lt;when exactly [amount] [stat/resource]&gt;"
+	Example: "&lt;when exactly [3] [Culture]&gt;"
 
 	Applicable to: Conditional
 
@@ -2069,13 +2069,13 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 	Applicable to: Conditional
 
-??? example  "&lt;has more [stat/resource] than [stat/resource]&gt;"
-	Example: "&lt;has more [Culture] than [Culture]&gt;"
+??? example  "&lt;when more [stat/resource] than [stat/resource]&gt;"
+	Example: "&lt;when more [Culture] than [Culture]&gt;"
 
 	Applicable to: Conditional
 
-??? example  "&lt;has less [stat/resource] than [stat/resource]&gt;"
-	Example: "&lt;has less [Culture] than [Culture]&gt;"
+??? example  "&lt;when less [stat/resource] than [stat/resource]&gt;"
+	Example: "&lt;when less [Culture] than [Culture]&gt;"
 
 	Applicable to: Conditional
 

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -227,6 +227,7 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 	Applicable to: Global, FollowerBelief
 
 ??? example  "[stats] per [amount] social policies adopted"
+	Only works for civ-wide stats
 	Example: "[+1 Gold, +2 Production] per [3] social policies adopted"
 
 	Applicable to: Global
@@ -2055,6 +2056,26 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 ??? example  "&lt;when below [amount] [stat/resource] (modified by game speed)&gt;"
 	Example: "&lt;when below [3] [Culture] (modified by game speed)&gt;"
+
+	Applicable to: Conditional
+
+??? example  "&lt;has exactly [amount] [stat/resource]&gt;"
+	Example: "&lt;has exactly [3] [Culture]&gt;"
+
+	Applicable to: Conditional
+
+??? example  "&lt;has the same number of [stat/resource] and [stat/resource]&gt;"
+	Example: "&lt;has the same number of [Culture] and [Culture]&gt;"
+
+	Applicable to: Conditional
+
+??? example  "&lt;has more [stat/resource] than [stat/resource]&gt;"
+	Example: "&lt;has more [Culture] than [Culture]&gt;"
+
+	Applicable to: Conditional
+
+??? example  "&lt;has less [stat/resource] than [stat/resource]&gt;"
+	Example: "&lt;has less [Culture] than [Culture]&gt;"
 
 	Applicable to: Conditional
 


### PR DESCRIPTION
I've made 4 new conditional uniques for comparing Stats and Resources numbers.

- The first one is true when stat or resource has an exact number.
- The second one is true when two of these have equal amount.
- The third and fourth are very similar, because they both compare stat and resource with each other, and return true when first or second is bigger.

The last three uniques support all 4 ways of comparison:
1. Resource - Resource
2. Stat - Stat
3. Stat - Resource
4. Resource - Stat

I believe these additions will give modders a range of possibilities as Resources can be used as custom variables

If you have some suggestions, please tell me in comments below. Constructive feedback welcome.