### PR TITLE
More city filters: Resisting, being razed

### DIFF
--- a/core/src/com/unciv/logic/city/City.kt
+++ b/core/src/com/unciv/logic/city/City.kt
@@ -432,6 +432,8 @@ class City : IsPartOfGameInfoSerialization {
             "in foreign cities", "Foreign" -> viewingCiv != null && viewingCiv != civ
             "in annexed cities", "Annexed" -> foundingCiv != civ.civName && !isPuppet
             "in puppeted cities", "Puppeted" -> isPuppet
+            "in resisting cities", "Resisting" -> isInResistance()
+            "in cities being razed", "Razing" -> isBeingRazed
             "in holy cities", "Holy" -> isHolyCity()
             "in City-State cities" -> civ.isCityState()
             // This is only used in communication to the user indicating that only in cities with this

--- a/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
@@ -255,6 +255,8 @@ enum class UniqueParameterType(
             "in foreign cities", "Foreign",
             "in annexed cities", "Annexed",
             "in puppeted cities", "Puppeted",
+            "in resisting cities", "Resisting",
+            "in cities being razed", "Razing",
             "in holy cities", "Holy",
             "in City-State cities",
             "in cities following this religion",
@@ -394,7 +396,7 @@ enum class UniqueParameterType(
 
     /** Used for region definitions, can be a terrain type with region unique, or "Hybrid"
      *
-     *  See also: [UniqueType.ConditionalInRegionOfType], [UniqueType.ConditionalInRegionExceptOfType], [MapRegions][com.unciv.logic.map.mapgenerator.MapRegions] */
+     *  See also: [UniqueType.ConditionalInRegionOfType], [UniqueType.ConditionalInRegionExceptOfType], [MapRegions][com.unciv.logic.map.mapgenerator.mapregions.MapRegions] */
     RegionType("regionType", "Hybrid", null, "Region Types") {
         private val knownValues = setOf("Hybrid")
         override fun getErrorSeverity(parameterText: String, ruleset: Ruleset):


### PR DESCRIPTION
Just an idea - what if some mod wished to alleviate the strict rule that my Oxford University just disappears from construction queues the moment I start winning a war, no matter what I do to conquered cities... Also, more symmetry.

The short form should fit into "<if [whatnot] is constructed in all [filter] cities>" - and I found no form of "being razed" that does. At least "Razing" doesn't get worse with the "non" modifier. I'd like "Burning" but that's not quite intuitive. Better ideas?