### PR TITLE
Add the unfiltered version of new era unique

### DIFF
--- a/core/src/com/unciv/logic/civilization/managers/TechManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/TechManager.kt
@@ -465,7 +465,7 @@ class TechManager : IsPartOfGameInfoSerialization {
                 UniqueTriggerActivation.triggerUnique(
                     unique,
                     civInfo,
-                    triggerNotificationText = "due to entering the new era")
+                    triggerNotificationText = "due to entering the [${currentEra.name}]")
         }
     }
 

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -780,7 +780,7 @@ enum class UniqueType(
     @Deprecated("as of 4.10.15", ReplaceWith("upon discovering [tech] technology"))
     TriggerUponResearchOld("upon discovering [tech]", UniqueTarget.TriggerCondition),
     TriggerUponEnteringEra("upon entering the [era]", UniqueTarget.TriggerCondition),
-    TriggerUponEnteringEraUnfiltered("upon entering the new era", UniqueTarget.TriggerCondition),
+    TriggerUponEnteringEraUnfiltered("upon entering a new era", UniqueTarget.TriggerCondition),
     TriggerUponAdoptingPolicyOrBelief("upon adopting [policy/belief]", UniqueTarget.TriggerCondition),
     TriggerUponDeclaringWar("upon declaring war with a major Civilization", UniqueTarget.TriggerCondition),
     TriggerUponDeclaringFriendship("upon declaring friendship", UniqueTarget.TriggerCondition),

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -2228,7 +2228,7 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 	Applicable to: TriggerCondition
 
-??? example  "&lt;upon entering the new era&gt;"
+??? example  "&lt;upon entering a new era&gt;"
 	Applicable to: TriggerCondition
 
 ??? example  "&lt;upon adopting [policy/belief]&gt;"


### PR DESCRIPTION
I've added the unfiltered version of new era unique. It may seem too simple, but it has some use cases:

1. It is intended to replace the multiple filtered new era uniques in mods, thus shortening their unique lists
2. It will be used for Polish Civilization's unique ability in future base BNW ruleset or in other mods, because in the original Civ 5 BNW Poland receives a free social policy on entering the new era. (see the link below)

[https://civilization.fandom.com/wiki/Civilizations_(Civ5)](https://civilization.fandom.com/wiki/Civilizations_(Civ5))