### PR TITLE
River terraform

### DIFF
--- a/core/src/com/unciv/logic/map/mapgenerator/MapGenerator.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/MapGenerator.kt
@@ -220,20 +220,23 @@ class MapGenerator(val ruleset: Ruleset, private val coroutineScope: CoroutineSc
         debug("MapGenerator.%s took %s.%sms", text, delta/1000000L, (delta/10000L).rem(100))
     }
 
-    fun convertTerrains(tiles: Iterable<Tile>) {
-        for (tile in tiles) {
-            val conversionUnique =
-                tile.getBaseTerrain().getMatchingUniques(UniqueType.ChangesTerrain)
-                    .firstOrNull { tile.isAdjacentTo(it.params[1]) }
-                    ?: continue
-            val terrain = ruleset.terrains[conversionUnique.params[0]] ?: continue
+    fun convertTerrains(tiles: Iterable<Tile>) = Helpers.convertTerrains(ruleset, tiles)
+    object Helpers {
+        fun convertTerrains(ruleset: Ruleset, tiles: Iterable<Tile>) {
+            for (tile in tiles) {
+                val conversionUnique =
+                    tile.getBaseTerrain().getMatchingUniques(UniqueType.ChangesTerrain)
+                        .firstOrNull { tile.isAdjacentTo(it.params[1]) }
+                        ?: continue
+                val terrain = ruleset.terrains[conversionUnique.params[0]] ?: continue
 
-            if (terrain.type == TerrainType.TerrainFeature) {
-                if (!terrain.occursOn.contains(tile.lastTerrain.name)) continue
-                tile.addTerrainFeature(terrain.name)
-            } else
-                tile.baseTerrain = terrain.name
-            tile.setTerrainTransients()
+                if (terrain.type == TerrainType.TerrainFeature) {
+                    if (!terrain.occursOn.contains(tile.lastTerrain.name)) continue
+                    tile.addTerrainFeature(terrain.name)
+                } else
+                    tile.baseTerrain = terrain.name
+                tile.setTerrainTransients()
+            }
         }
     }
 

--- a/core/src/com/unciv/logic/map/mapgenerator/MapGenerator.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/MapGenerator.kt
@@ -230,11 +230,11 @@ class MapGenerator(val ruleset: Ruleset, private val coroutineScope: CoroutineSc
                         ?: continue
                 val terrain = ruleset.terrains[conversionUnique.params[0]] ?: continue
 
-                if (terrain.type == TerrainType.TerrainFeature) {
-                    if (!terrain.occursOn.contains(tile.lastTerrain.name)) continue
-                    tile.addTerrainFeature(terrain.name)
-                } else
+                if (terrain.type != TerrainType.TerrainFeature)
                     tile.baseTerrain = terrain.name
+                else if (!terrain.occursOn.contains(tile.lastTerrain.name)) continue
+                else
+                    tile.addTerrainFeature(terrain.name)
                 tile.setTerrainTransients()
             }
         }

--- a/core/src/com/unciv/logic/map/mapgenerator/RiverGenerator.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/RiverGenerator.kt
@@ -258,7 +258,7 @@ class RiverGenerator(
                     neighbor.edgeLeadsToSea -> edgeToSeaPriority + neighbor.connectedRiverCount - 3 * neighbor.verticesFormYCount
                     // Just 6 possible cases left:
                     //  * Connect two bends = -2
-                    //  * Connect a bend to nothing = -1
+                    //  * Connect a bend to nothing = -1 // debatable!
                     //  * Connect nothing = 0
                     //  * Connect a bend with an open end = 1
                     //  * Connect to one open end = 2
@@ -272,23 +272,7 @@ class RiverGenerator(
 
             // Finally - choose
             val choice = viableNeighbors.filter { it.priority == maxPriority }.random()
-            tile.setConnectedByRiver(choice.otherTile, choice.clockPosition)
-            return true
-        }
-
-        private fun Tile.setConnectedByRiver(otherTile: Tile, clockPosition: Int) {
-            when (clockPosition) {
-                2 -> otherTile.hasBottomLeftRiver = true // we're to the bottom-left of it
-                4 -> hasBottomRightRiver = true // we're to the top-left of it
-                6 -> hasBottomRiver = true // we're directly above it
-                8 -> hasBottomLeftRiver = true // we're to the top-right of it
-                10 -> otherTile.hasBottomRightRiver = true // we're to the bottom-right of it
-                12 -> otherTile.hasBottomRiver = true // we're directly below it
-            }
-            val affectedTiles = listOf(this, otherTile)
-            for (tile in affectedTiles)
-                tile.resetAdjacentToRiverTransient(true)
-            MapGenerator.Helpers.convertTerrains(ruleset, affectedTiles)
+            return tile.setConnectedByRiver(choice.otherTile, newValue = true, convertTerrains = true)
         }
     }
 }

--- a/core/src/com/unciv/logic/map/tile/Tile.kt
+++ b/core/src/com/unciv/logic/map/tile/Tile.kt
@@ -644,13 +644,25 @@ class Tile : IsPartOfGameInfoSerialization {
         }
     }
 
-    @delegate:Transient
-    private val isAdjacentToRiverLazy by lazy {
-        // These are so if you add a river at the bottom of the map (no neighboring tile to be connected to)
-        //   that tile is still considered adjacent to river
-        hasBottomLeftRiver || hasBottomRiver || hasBottomRightRiver
-        || neighbors.any { isConnectedByRiver(it) } }
-    fun isAdjacentToRiver() = isAdjacentToRiverLazy
+    @Transient
+    private var isAdjacentToRiver = false
+    @Transient
+    private var isAdjacentToRiverKnown = false
+    fun isAdjacentToRiver(): Boolean {
+        if (!isAdjacentToRiverKnown) {
+            isAdjacentToRiver =
+            // These are so if you add a river at the bottom of the map (no neighboring tile to be connected to)
+                //   that tile is still considered adjacent to river
+                hasBottomLeftRiver || hasBottomRiver || hasBottomRightRiver
+                    || neighbors.any { isConnectedByRiver(it) }
+            isAdjacentToRiverKnown = true
+        }
+        return isAdjacentToRiver
+    }
+    fun resetAdjacentToRiverTransient(isKnownTrue: Boolean = false) {
+        isAdjacentToRiver = isKnownTrue
+        isAdjacentToRiverKnown = isKnownTrue
+    }
 
     /**
      * @returns whether units of [civInfo] can pass through this tile, considering only civ-wide filters.

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -16,6 +16,7 @@ import com.unciv.logic.civilization.PolicyAction
 import com.unciv.logic.civilization.TechAction
 import com.unciv.logic.civilization.managers.ReligionState
 import com.unciv.logic.map.mapgenerator.NaturalWonderGenerator
+import com.unciv.logic.map.mapgenerator.RiverGenerator
 import com.unciv.logic.map.mapunit.MapUnit
 import com.unciv.logic.map.tile.Tile
 import com.unciv.models.UpgradeUnitAction
@@ -932,6 +933,8 @@ object UniqueTriggerActivation {
             UniqueType.OneTimeChangeTerrain -> {
                 if (tile == null) return null
                 val terrain = ruleSet.terrains[unique.params[0]] ?: return null
+                if (terrain.name == Constants.river)
+                    return getOneTimeChangeRiverTriggerFunction(tile)
                 if (terrain.type == TerrainType.TerrainFeature && !terrain.occursOn.contains(tile.lastTerrain.name))
                     return null
                 if (tile.terrainFeatures.contains(terrain.name)) return null
@@ -963,5 +966,11 @@ object UniqueTriggerActivation {
             else "{$triggerNotificationText}{ }{$effectNotificationText}"
         }
         else null
+    }
+
+    private fun getOneTimeChangeRiverTriggerFunction(tile: Tile): (()->Boolean)? {
+        if (tile.neighbors.none { it.isLand && !tile.isConnectedByRiver(it) })
+            return null  // no place for another river
+        return { RiverGenerator.continueRiverOn(tile) }
     }
 }

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -96,12 +96,12 @@ object UniqueTriggerActivation {
         val tileBasedRandom =
             if (tile != null) Random(tile.position.toString().hashCode())
             else Random(-550) // Very random indeed
-        val ruleSet = civInfo.gameInfo.ruleset
+        val ruleset = civInfo.gameInfo.ruleset
 
         when (unique.type) {
             UniqueType.OneTimeFreeUnit -> {
                 val unitName = unique.params[0]
-                val baseUnit = ruleSet.units[unitName] ?: return null
+                val baseUnit = ruleset.units[unitName] ?: return null
                 val civUnit = civInfo.getEquivalentUnit(baseUnit)
                 if (civUnit.isCityFounder() && civInfo.isOneCityChallenger())
                     return null
@@ -142,7 +142,7 @@ object UniqueTriggerActivation {
 
             UniqueType.OneTimeAmountFreeUnits -> {
                 val unitName = unique.params[1]
-                val baseUnit = ruleSet.units[unitName] ?: return null
+                val baseUnit = ruleset.units[unitName] ?: return null
                 val civUnit = civInfo.getEquivalentUnit(baseUnit)
                 if (civUnit.isCityFounder() && civInfo.isOneCityChallenger())
                     return null
@@ -198,7 +198,7 @@ object UniqueTriggerActivation {
             UniqueType.OneTimeFreeUnitRuins -> {
                 var civUnit = civInfo.getEquivalentUnit(unique.params[0])
                 if ( civUnit.isCityFounder() && civInfo.isOneCityChallenger()) {
-                     val replacementUnit = ruleSet.units.values
+                     val replacementUnit = ruleset.units.values
                          .firstOrNull {
                              it.getMatchingUniques(UniqueType.BuildImprovements)
                                 .any { unique -> unique.params[0] == "Land" }
@@ -369,7 +369,7 @@ object UniqueTriggerActivation {
                 }
             }
             UniqueType.OneTimeFreeTechRuins -> {
-                val researchableTechsFromThatEra = ruleSet.technologies.values
+                val researchableTechsFromThatEra = ruleset.technologies.values
                     .filter {
                         (it.column!!.era == unique.params[1] || unique.params[1] == "any era")
                                 && civInfo.tech.canBeResearched(it.name)
@@ -431,7 +431,7 @@ object UniqueTriggerActivation {
 
             UniqueType.OneTimeProvideResources -> {
                 val resourceName = unique.params[1]
-                val resource = ruleSet.tileResources[resourceName] ?: return null
+                val resource = ruleset.tileResources[resourceName] ?: return null
                 if (!resource.isStockpiled()) return null
 
                 return {
@@ -450,7 +450,7 @@ object UniqueTriggerActivation {
 
             UniqueType.OneTimeConsumeResources -> {
                 val resourceName = unique.params[1]
-                val resource = ruleSet.tileResources[resourceName] ?: return null
+                val resource = ruleset.tileResources[resourceName] ?: return null
                 if (!resource.isStockpiled()) return null
 
                 return {
@@ -484,7 +484,7 @@ object UniqueTriggerActivation {
 
                 val unitsToPromote = civInfo.units.getCivUnits().filter { it.matchesFilter(filter) }
                     .filter { unitToPromote ->
-                        ruleSet.unitPromotions.values.any {
+                        ruleset.unitPromotions.values.any {
                             it.name == promotion && unitToPromote.type.name in it.unitTypes
                         }
                     }.toList()
@@ -814,7 +814,7 @@ object UniqueTriggerActivation {
                 }
             }
             UniqueType.FreeSpecificBuildings ->{
-                val building = ruleSet.buildings[unique.params[0]] ?: return null
+                val building = ruleset.buildings[unique.params[0]] ?: return null
                 return {
                     civInfo.civConstructions.addFreeBuildings(building, unique.params[1].toInt())
                     true
@@ -932,7 +932,7 @@ object UniqueTriggerActivation {
 
             UniqueType.OneTimeChangeTerrain -> {
                 if (tile == null) return null
-                val terrain = ruleSet.terrains[unique.params[0]] ?: return null
+                val terrain = ruleset.terrains[unique.params[0]] ?: return null
                 if (terrain.name == Constants.river)
                     return getOneTimeChangeRiverTriggerFunction(tile)
                 if (terrain.type == TerrainType.TerrainFeature && !terrain.occursOn.contains(tile.lastTerrain.name))
@@ -947,7 +947,7 @@ object UniqueTriggerActivation {
                         TerrainType.TerrainFeature -> tile.addTerrainFeature(terrain.name)
                         TerrainType.NaturalWonder -> NaturalWonderGenerator.placeNaturalWonder(terrain, tile)
                     }
-                    TileInfoNormalizer.normalizeToRuleset(tile, ruleSet)
+                    TileInfoNormalizer.normalizeToRuleset(tile, ruleset)
                     tile.getUnits().filter { !it.movement.canPassThrough(tile) }.toList()
                         .forEach { it.movement.teleportToClosestMoveableTile() }
                     true


### PR DESCRIPTION
Extension to #11152.

Currently, using "River" as parameter will not be flagged on validation, but will never be active - occursOn empty. Which is good, actually placing that feature would be bad.

Caveat: convertTerrains - RiverGenerator runs it once after the river is done, on the collected neighbors. You get double conversion only if two rivers by chance get close enough. Snow-Tundra-Plains, was it? Well, since this will run stepwise one edge at a time, you'll get that more often. No idea how to mitigate.

This image (from [this comment](https://github.com/yairm210/Unciv/pull/11152#issuecomment-1954188127)) was done with not quite the same code, but should still apply:
<details><summary>anim gif</summary>

![Untitled](https://github.com/yairm210/Unciv/assets/63000004/6b05e424-b2e2-465f-a2e7-e612c78696b8)

</details>

... and I still have no idea how this Unique can be made to take several turns to "build" ...
