### PR TITLE
Centralize infinity symbol

### DIFF
--- a/core/src/com/unciv/logic/civilization/managers/TechManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/TechManager.kt
@@ -25,6 +25,7 @@ import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.ruleset.unit.BaseUnit
 import com.unciv.ui.components.MayaCalendar
 import com.unciv.ui.components.extensions.withItem
+import com.unciv.ui.components.fonts.Fonts
 import kotlin.math.ceil
 import kotlin.math.max
 import kotlin.math.min
@@ -148,7 +149,7 @@ class TechManager : IsPartOfGameInfoSerialization {
         val remainingCost = remainingScienceToTech(techName).toDouble()
         return when {
             remainingCost <= 0f -> "0"
-            civInfo.stats.statsForNextTurn.science <= 0f -> "∞"
+            civInfo.stats.statsForNextTurn.science <= 0f -> Fonts.infinity.toString()
             else -> max(1, ceil(remainingCost / civInfo.stats.statsForNextTurn.science).toInt()).toString()
         }
     }

--- a/core/src/com/unciv/ui/components/fonts/Fonts.kt
+++ b/core/src/com/unciv/ui/components/fonts/Fonts.kt
@@ -122,6 +122,7 @@ object Fonts {
     const val greatScientist = '⚛'      // U+269B 'atom'
     const val death = '☠'               // U+2620 'skull and crossbones'
     const val automate = '⛏'            // U+26CF 'pick'
+    const val infinity = '∞'            // U+221E - not in `allSymbols`, taken as-is from system font
 
     val allSymbols = mapOf(
         turn to "EmojiIcons/Turn",

--- a/core/src/com/unciv/ui/components/tilegroups/CityButton.kt
+++ b/core/src/com/unciv/ui/components/tilegroups/CityButton.kt
@@ -274,11 +274,11 @@ private class CityTable(city: City, forPopup: Boolean = false) : BorderedTable(
         val turnLabelText = when {
             city.isGrowing() -> {
                 val turnsToGrowth = city.population.getNumTurnsToNewPopulation()
-                if (turnsToGrowth != null && turnsToGrowth < 100) turnsToGrowth.toString() else "∞"
+                if (turnsToGrowth != null && turnsToGrowth < 100) turnsToGrowth.toString() else Fonts.infinity.toString()
             }
             city.isStarving() -> {
                 val turnsToStarvation = city.population.getNumTurnsToStarvation()
-                if (turnsToStarvation != null && turnsToStarvation < 100) turnsToStarvation.toString() else "∞"
+                if (turnsToStarvation != null && turnsToStarvation < 100) turnsToStarvation.toString() else Fonts.infinity.toString()
             }
             else -> "-"
         }
@@ -360,7 +360,7 @@ private class CityTable(city: City, forPopup: Boolean = false) : BorderedTable(
                 if (nextTurnPercentage > 1f) nextTurnPercentage = 1f
                 if (nextTurnPercentage < 0f) nextTurnPercentage = 0f
             } else {
-                turns = "∞"
+                turns = Fonts.infinity.toString()
             }
             icon = ImageGetter.getConstructionPortrait(cityCurrentConstruction.name, 24f)
         }

--- a/core/src/com/unciv/ui/screens/cityscreen/CityConstructionsTable.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/CityConstructionsTable.kt
@@ -39,6 +39,7 @@ import com.unciv.ui.components.extensions.packIfNeeded
 import com.unciv.ui.components.extensions.surroundWithCircle
 import com.unciv.ui.components.extensions.toLabel
 import com.unciv.ui.components.extensions.toTextButton
+import com.unciv.ui.components.fonts.Fonts
 import com.unciv.ui.components.input.KeyboardBinding
 import com.unciv.ui.components.input.keyShortcuts
 import com.unciv.ui.components.input.onActivation
@@ -327,7 +328,7 @@ class CityConstructionsTable(private val cityScreen: CityScreen) {
         val isFirstConstructionOfItsKind = cityConstructions.isFirstConstructionOfItsKind(constructionQueueIndex, constructionName)
 
         var text = constructionName.tr(true) +
-                if (constructionName in PerpetualConstruction.perpetualConstructionsMap) "\n∞"
+                if (constructionName in PerpetualConstruction.perpetualConstructionsMap) "\n" + Fonts.infinity
                 else cityConstructions.getTurnsToConstructionString(construction, isFirstConstructionOfItsKind)
 
         val constructionResource = if (construction is BaseUnit)

--- a/core/src/com/unciv/ui/screens/worldscreen/topbar/WorldScreenTopBarStats.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/topbar/WorldScreenTopBarStats.kt
@@ -9,6 +9,7 @@ import com.unciv.ui.components.extensions.colorFromRGB
 import com.unciv.ui.components.extensions.setFontColor
 import com.unciv.ui.components.extensions.toLabel
 import com.unciv.ui.components.extensions.toStringSigned
+import com.unciv.ui.components.fonts.Fonts
 import com.unciv.ui.components.input.onClick
 import com.unciv.ui.components.widgets.ScalingTableWrapper
 import com.unciv.ui.images.ImageGetter
@@ -124,12 +125,13 @@ internal class WorldScreenTopBarStats(topbar: WorldScreenTopBar) : ScalingTableW
 
     private fun getCultureText(civInfo: Civilization, nextTurnStats: Stats): String {
         var cultureString = rateLabel(nextTurnStats.culture)
-        //if (nextTurnStats.culture == 0f) return cultureString // when you start the game, you're not producing any culture
-
+        // kotlin Float division by Zero produces `Float.POSITIVE_INFINITY`, not an exception
         val turnsToNextPolicy = (civInfo.policies.getCultureNeededForNextPolicy() - civInfo.policies.storedCulture) / nextTurnStats.culture
-        cultureString +=  if  (turnsToNextPolicy <= 0f) " (!)"
-        else if (nextTurnStats.culture <= 0) " (∞)"
-        else " (" + ceil(turnsToNextPolicy).toInt() + ")"
+        cultureString += when {
+            turnsToNextPolicy <= 0f -> " (!)" // Can choose policy right now
+            nextTurnStats.culture <= 0 -> " (${Fonts.infinity})" // when you start the game, you're not producing any culture
+            else -> " (" + ceil(turnsToNextPolicy).toInt() + ")"
+        }
         return cultureString
     }
 


### PR DESCRIPTION
Half of a kludge-Fix to #11246. Just centralizes the notion of the codepoint. Which might be a good thing even without an actual fix until we know why the Windows/Java combo behaves so dumb regardng default font - or maybe it's just this one box?

From here, one Set entry and some markdown/image stuff, and we could fix that the hard way, by replacing the symbol with our own - same one for all fonts.

<details><summary>Excercise</summary>

![image](https://github.com/yairm210/Unciv/assets/63000004/6f1810f8-c4e1-4d27-a50f-0522303fcbc8)
... guess I exaggerated the baseline shift too much

```patch
Index: core/src/com/unciv/ui/components/fonts/Fonts.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/core/src/com/unciv/ui/components/fonts/Fonts.kt b/core/src/com/unciv/ui/components/fonts/Fonts.kt
--- a/core/src/com/unciv/ui/components/fonts/Fonts.kt	(revision 4503e724006690a334ef01f351c61948f1efa8ac)
+++ b/core/src/com/unciv/ui/components/fonts/Fonts.kt	(date 1709631040548)
@@ -144,6 +144,7 @@
         greatScientist to "EmojiIcons/Great Scientist",
         death to "EmojiIcons/Death",
         automate to "EmojiIcons/Automate",
+        infinity to "EmojiIcons/Infinity",
         *MayaCalendar.allSymbols
     )
 }
Index: docs/Credits.md
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/docs/Credits.md b/docs/Credits.md
--- a/docs/Credits.md	(revision 4503e724006690a334ef01f351c61948f1efa8ac)
+++ b/docs/Credits.md	(date 1709632134669)
@@ -738,6 +738,7 @@
 - [down](https://thenounproject.com/icon/down-39378/) by Cengiz SARI for Show unit destination
 - [Cat](https://thenounproject.com/icon/cat-158942/) by Josi for Politics overview diagram legend
 - [Bell](https://thenounproject.com/icon/bell-2054409) by Lyhn, transparency modified, for Notifications (overview, unhide button)
+- [Infinity](https://thenounproject.com/icon/infinity-3838367) by brandpublico, as infinity symbol in text, to support incomplete system fonts
 
 ### Main menu
 
diff --git a/android/Images.Icons/EmojiIcons/Infinity.png b/android/Images.Icons/EmojiIcons/Infinity.png
new file mode 100644
index 0000000000000000000000000000000000000000..7289937f47458e813f47c7b4ad55864cf42e8ca5
GIT binary patch
literal 725
zc$@*%0xJE9P)<h;3K|Lk000e1NJLTq001%o001%w1^@s69zTe&0007<Nkl<ZXx{CZ
zPl!!X9LK-!%^1@oEM!5C<j+#clx9VdWYmm}Fp7zVQj>^6LsPROC54%yjADhbFd1T@
zEJny!2>DY|%4Q4(V|;9mx;^LIch0>Qn$EB8;+^|DpL0Lw-FwdO-U6WU5JioXh$2xW
zibRnp5=HVvZD9T!NzIZPB+Zh9q(Mn{BwfpR4QnK=l(fi9>^n&VhWFN+0{9&Bfvcp)
zYoNuGC!h&<S%rBCnCrvy8E`Z38UHv7Oi1C?0zCn|VW2gy$QH82EuduKm4N<?%&l2P
z8h{^Uj~hT;f>&qSvc@Q|G>gbX2k;rt4lD<nf$J%QZ%EuummN93fNr1>SPZNOZaZ=x
zhl(^gKs`XwlHUr9ROB8r=Ze5Z2X6>i<+z4}jy`KcM0zcN{wmMYiiFJRMEkjvhq$o{
z^NOWkZ-~eX3t*Y&lG>g4ea0d2)sxp?>H9oH#1_SXJwm`K2j@Gm+LKXmFmj26NE~%A
zegf+PS-C_$Svr?J2kuN+oi>@AdQa8@$FucUuB&Jqu(WOWsCf2DI^;OlCh3BtlB7OK
zT^_t0mbM2Wwbm}nOpE|aQf6;w%6`)3*c1<>@LJ5jSQ)!RZmsE#`f3>12TV!imQ8)-
ziftyZ#uR~-aUPhR;7tQMfH6z%7hp!{&c44&$?(KfylK&1QGBMw8{lb`oQ^CdN&)E0
zQ5zk$Fi+;--A&s9s;wH6ftwiy?Mz`F&%nE1aXV*vA1RpG{pK;?2hV+CBk<9KHwGL5
zCjN^Tt3Ss~pbHqZY;yO^sx>KqHx<|eJaRlQCxCgryh6sW@imgll13%HH}CFwqF&NM
z!+j-bC=`%YBz_KxB2grYM3E>GMWRR)i6T)XibRnp@}I_U;v77`<Xl%*00000NkvXX
Hu0mjf#R*DG


```

And the gimp: [noun-infinity-3838367.zip](https://github.com/yairm210/Unciv/files/14493572/noun-infinity-3838367.zip)

</details>

Note: I'll pause in a few days for the rest of the month. No 'net.