### PR TITLE
Next turn button reactivates after closing a popup menu

### DIFF
--- a/core/src/com/unciv/ui/screens/worldscreen/status/AutoPlayMenu.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/status/AutoPlayMenu.kt
@@ -22,6 +22,11 @@ class AutoPlayMenu(
 ) : AnimatedMenuPopup(stage, getActorTopRight(positionNextTo)) {
     private val settings = GUI.getSettings()
 
+    init {
+        // We need to activate the end turn button again after the menu closes
+        afterCloseCallback = { worldScreen.shouldUpdate = true }
+    }
+    
     override fun createContentTable(): Table {
         val table = super.createContentTable()!!
         // Using the same keyboard binding for bypassing this menu and the default option

--- a/core/src/com/unciv/ui/screens/worldscreen/status/NextTurnMenu.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/status/NextTurnMenu.kt
@@ -13,6 +13,12 @@ class NextTurnMenu(
     private val nextTurnButton: NextTurnButton,
     private val worldScreen: WorldScreen
 ) : AnimatedMenuPopup(stage, getActorTopRight(positionNextTo)) {
+
+    init {
+        // We need to activate the end turn button again after the menu closes
+        afterCloseCallback = { worldScreen.shouldUpdate = true }
+    }
+    
     override fun createContentTable(): Table {
         val table = super.createContentTable()!!
         table.add(getButton("Next Turn", KeyboardBinding.NextTurnMenuNextTurn) { 


### PR DESCRIPTION
Very simple continuation of #11244.
This PR fixes the problem of the next turn button staying deactivated after closing, as discussed in #11244.