### PR TITLE
Fixed swapping a unit with a unit that is escorting

### DIFF
--- a/core/src/com/unciv/logic/map/mapunit/movement/UnitMovement.kt
+++ b/core/src/com/unciv/logic/map/mapunit/movement/UnitMovement.kt
@@ -523,7 +523,7 @@ class UnitMovement(val unit: MapUnit) {
             else
                 destination.militaryUnit
             )?: return // The precondition guarantees that there is an eligible same-type unit at the destination
-
+        otherUnit.stopEscorting()
         val ourOldPosition = unit.getTile()
         val theirOldPosition = otherUnit.getTile()
 


### PR DESCRIPTION
Fixes #11234
This PR fixes the problem by canceling the escort of the other unit being swapped with.
More features such as moving the escorted unit, will have to go in a different PR since I think it is a little more complicated.