### PR TITLE
Add the multiple comparison unique pack

### DIFF
--- a/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
@@ -439,6 +439,14 @@ enum class UniqueParameterType(
             }
     },
 
+    Year("year", "year", "For BC years use negative numbers as amount. For example for 750 BC use -750") {
+        override fun getErrorSeverity(parameterText: String, ruleset: Ruleset):
+            UniqueType.UniqueParameterErrorSeverity? = when (parameterText) {
+            "year" -> null
+            else -> UniqueType.UniqueParameterErrorSeverity.RulesetInvariant
+        }
+    },
+
     /** For [UniqueType.CreatesOneImprovement] */
     ImprovementName("improvementName", "Trading Post", "The name of any improvement") {
         override fun getErrorSeverity(parameterText: String, ruleset: Ruleset):

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -660,15 +660,23 @@ enum class UniqueType(
     ConditionalWithResource("with [resource]", UniqueTarget.Conditional),
     ConditionalWithoutResource("without [resource]", UniqueTarget.Conditional),
 
-    // Supports also stockpileable resources (Gold, Faith, Culture, Science)
-    ConditionalWhenAboveAmountStatResource("when above [amount] [stat/resource]", UniqueTarget.Conditional),
-    ConditionalWhenBelowAmountStatResource("when below [amount] [stat/resource]", UniqueTarget.Conditional),
-    ConditionalWhenBetweenStatResource("when between [amount] and [amount] [stat/resource]", UniqueTarget.Conditional),
+    // Supports civ-wide stats (Gold, Faith, Culture, Science), resources and year
+    ConditionalWhenAboveAmountStatResourceYear("when above [amount] [stat/resource/year]", UniqueTarget.Conditional),
+    ConditionalWhenBelowAmountStatResourceYear("when below [amount] [stat/resource/year]", UniqueTarget.Conditional),
+    ConditionalWhenBetweenStatResourceYear("when between [amount] and [amount] [stat/resource/year]", UniqueTarget.Conditional),
 
     // The game speed-adjusted versions of above
-    ConditionalWhenAboveAmountStatResourceSpeed("when above [amount] [stat/resource] (modified by game speed)", UniqueTarget.Conditional),
-    ConditionalWhenBelowAmountStatResourceSpeed("when below [amount] [stat/resource] (modified by game speed)", UniqueTarget.Conditional),
-    ConditionalWhenBetweenStatResourceSpeed("when between [amount] and [amount] [stat/resource] (modified by game speed)", UniqueTarget.Conditional),
+    ConditionalWhenAboveAmountStatResourceYearSpeed("when above [amount] [stat/resource/year] (modified by game speed)", UniqueTarget.Conditional),
+    ConditionalWhenBelowAmountStatResourceYearSpeed("when below [amount] [stat/resource/year] (modified by game speed)", UniqueTarget.Conditional),
+    ConditionalWhenBetweenStatResourceYearSpeed("when between [amount] and [amount] [stat/resource/year] (modified by game speed)", UniqueTarget.Conditional),
+
+    // For exact amount of stats, resources or year
+    ConditionalExactStatResourceYearAmount("with exactly [amount] [stat/resource/year]", UniqueTarget.Conditional),
+
+    // For comparison between resources, stats or year
+    ConditionalSameAmountOfTwoStatsResourcesYears("with the same number of [stat/resource/year] and [stat/resource/year]", UniqueTarget.Conditional),
+    ConditionalHasMoreStatResourceYear("with more [stat/resource/year] than [stat/resource/year]", UniqueTarget.Conditional),
+    ConditionalHasLessStatResourceYear("with less [stat/resource/year] than [stat/resource/year]", UniqueTarget.Conditional),
 
     /////// city conditionals
     ConditionalInThisCity("in this city", UniqueTarget.Conditional),


### PR DESCRIPTION
I made a multiple comparison unique pack, which contains 4 new uniques and 6 modified ones to support year as a parameter. Though i made a similar PR several days ago #11250 and the PR for support of years #11262 (which was rejected), I've combined these two pull requests into this one.

I hope that this time year-related uniques will be introduced, as there is another PR adding events #11276

If you have some remarks, share them in the comments. Constructive feedback welcome.