### PR TITLE
New ActionModifiers to enable Stats and Minimum Movement

### DIFF
--- a/core/src/com/unciv/logic/city/City.kt
+++ b/core/src/com/unciv/logic/city/City.kt
@@ -212,8 +212,17 @@ class City : IsPartOfGameInfoSerialization {
 
     fun getStatReserve(stat: Stat): Int {
         return when (stat) {
+            Stat.Production -> cityConstructions.getWorkDone(cityConstructions.getCurrentConstruction().name)
             Stat.Food -> population.foodStored
             else -> civ.getStatReserve(stat)
+        }
+    }
+
+    fun hasStatToBuy(stat: Stat, price: Int): Boolean {
+        return when {
+            civ.gameInfo.gameParameters.godMode -> true
+            price == 0 -> true
+            else -> getStatReserve(stat) >= price
         }
     }
 

--- a/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
@@ -7,6 +7,7 @@ import com.unciv.logic.MultiFilter
 import com.unciv.logic.automation.unit.UnitAutomation
 import com.unciv.logic.battle.BattleUnitCapture
 import com.unciv.logic.battle.MapUnitCombatant
+import com.unciv.logic.city.City
 import com.unciv.logic.civilization.Civilization
 import com.unciv.logic.civilization.NotificationCategory
 import com.unciv.logic.civilization.NotificationIcon
@@ -203,6 +204,10 @@ class MapUnit : IsPartOfGameInfoSerialization {
         DecimalFormat("0.#").format(currentMovement.toDouble()) + "/" + getMaxMovement()
 
     fun getTile(): Tile = currentTile
+
+    fun getClosestCity(): City? = civ.cities.minByOrNull {
+        it.getCenterTile().aerialDistanceTo(currentTile)
+    }
 
     fun isMilitary() = baseUnit.isMilitary()
     fun isCivilian() = baseUnit.isCivilian()

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -504,7 +504,12 @@ enum class UniqueType(
     ///////////////////////////////////////// region 05 UNIT ACTION MODIFIERS /////////////////////////////////////////
 
     UnitActionConsumeUnit("by consuming this unit", UniqueTarget.UnitActionModifier),
-    UnitActionMovementCost("for [amount] movement", UniqueTarget.UnitActionModifier),
+    UnitActionMovementCost("for [amount] movement", UniqueTarget.UnitActionModifier,
+        docDescription = "Will consume up to [amount] of Movement to execute"),
+    UnitActionMovementCostAll("for all movement", UniqueTarget.UnitActionModifier,
+        docDescription = "Will consume all Movement to execute"),
+    UnitActionMovementCostRequired("requires [amount] movement", UniqueTarget.UnitActionModifier,
+        docDescription = "Requires [amount] of Movement to execute. Unit's Movement is rounded up"),
     UnitActionStatsCost("costs [stats] stats", UniqueTarget.UnitActionModifier,
         docDescription = "A positive Integer value will be subtracted from your stock. Food and Production will be removed from Closest City's current stock"),
     UnitActionOnce("once", UniqueTarget.UnitActionModifier),

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -505,8 +505,8 @@ enum class UniqueType(
 
     UnitActionConsumeUnit("by consuming this unit", UniqueTarget.UnitActionModifier),
     UnitActionMovementCost("for [amount] movement", UniqueTarget.UnitActionModifier),
-    UnitActionStatCost("for [stats]", UniqueTarget.UnitActionModifier,
-        docDescription = "Currently specifically for Transform Action. Will deduct positive Integer value"),
+    UnitActionStatCost("costs [stats] to do", UniqueTarget.UnitActionModifier,
+        docDescription = "Currently specifically for Transform Action. A positive Integer value will be subtracted from your stock"),
     UnitActionOnce("once", UniqueTarget.UnitActionModifier),
     UnitActionLimitedTimes("[amount] times", UniqueTarget.UnitActionModifier),
     UnitActionExtraLimitedTimes("[amount] additional time(s)", UniqueTarget.UnitActionModifier),

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -506,7 +506,7 @@ enum class UniqueType(
     UnitActionConsumeUnit("by consuming this unit", UniqueTarget.UnitActionModifier),
     UnitActionMovementCost("for [amount] movement", UniqueTarget.UnitActionModifier),
     UnitActionStatCost("costs [stats] stats", UniqueTarget.UnitActionModifier,
-        docDescription = "Currently specifically for Transform Action. A positive Integer value will be subtracted from your stock"),
+        docDescription = "A positive Integer value will be subtracted from your stock. Food and Production will be removed from Closest City's current stock"),
     UnitActionOnce("once", UniqueTarget.UnitActionModifier),
     UnitActionLimitedTimes("[amount] times", UniqueTarget.UnitActionModifier),
     UnitActionExtraLimitedTimes("[amount] additional time(s)", UniqueTarget.UnitActionModifier),

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -505,7 +505,7 @@ enum class UniqueType(
 
     UnitActionConsumeUnit("by consuming this unit", UniqueTarget.UnitActionModifier),
     UnitActionMovementCost("for [amount] movement", UniqueTarget.UnitActionModifier),
-    UnitActionStatCost("costs [stats] to do", UniqueTarget.UnitActionModifier,
+    UnitActionStatCost("costs [stats] stats", UniqueTarget.UnitActionModifier,
         docDescription = "Currently specifically for Transform Action. A positive Integer value will be subtracted from your stock"),
     UnitActionOnce("once", UniqueTarget.UnitActionModifier),
     UnitActionLimitedTimes("[amount] times", UniqueTarget.UnitActionModifier),

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -505,7 +505,7 @@ enum class UniqueType(
 
     UnitActionConsumeUnit("by consuming this unit", UniqueTarget.UnitActionModifier),
     UnitActionMovementCost("for [amount] movement", UniqueTarget.UnitActionModifier),
-    UnitActionStatCost("costs [stats] stats", UniqueTarget.UnitActionModifier,
+    UnitActionStatsCost("costs [stats] stats", UniqueTarget.UnitActionModifier,
         docDescription = "A positive Integer value will be subtracted from your stock. Food and Production will be removed from Closest City's current stock"),
     UnitActionOnce("once", UniqueTarget.UnitActionModifier),
     UnitActionLimitedTimes("[amount] times", UniqueTarget.UnitActionModifier),

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -359,7 +359,7 @@ enum class UniqueType(
     CanHurryResearch("Can hurry technology research", UniqueTarget.Unit),
     CanHurryPolicy("Can generate a large amount of culture", UniqueTarget.Unit),
     CanTradeWithCityStateForGoldAndInfluence("Can undertake a trade mission with City-State, giving a large sum of gold and [amount] Influence", UniqueTarget.Unit),
-    CanTransform("Can transform to [unit]", UniqueTarget.Unit),
+    CanTransform("Can transform to [unit]", UniqueTarget.UnitAction),
 
     AutomationPrimaryAction("Automation is a primary action", UniqueTarget.Unit, flags = UniqueFlag.setOfHiddenToUsers),
 
@@ -505,6 +505,8 @@ enum class UniqueType(
 
     UnitActionConsumeUnit("by consuming this unit", UniqueTarget.UnitActionModifier),
     UnitActionMovementCost("for [amount] movement", UniqueTarget.UnitActionModifier),
+    UnitActionStatCost("for [stats]", UniqueTarget.UnitActionModifier,
+        docDescription = "Currently specifically for Transform Action. Will deduct positive Integer value"),
     UnitActionOnce("once", UniqueTarget.UnitActionModifier),
     UnitActionLimitedTimes("[amount] times", UniqueTarget.UnitActionModifier),
     UnitActionExtraLimitedTimes("[amount] additional time(s)", UniqueTarget.UnitActionModifier),

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -359,7 +359,8 @@ enum class UniqueType(
     CanHurryResearch("Can hurry technology research", UniqueTarget.Unit),
     CanHurryPolicy("Can generate a large amount of culture", UniqueTarget.Unit),
     CanTradeWithCityStateForGoldAndInfluence("Can undertake a trade mission with City-State, giving a large sum of gold and [amount] Influence", UniqueTarget.Unit),
-    CanTransform("Can transform to [unit]", UniqueTarget.UnitAction),
+    CanTransform("Can transform to [unit]", UniqueTarget.UnitAction,
+        docDescription = "By default consumes all movement"),
 
     AutomationPrimaryAction("Automation is a primary action", UniqueTarget.Unit, flags = UniqueFlag.setOfHiddenToUsers),
 

--- a/core/src/com/unciv/models/stats/Stats.kt
+++ b/core/src/com/unciv/models/stats/Stats.kt
@@ -1,6 +1,8 @@
 package com.unciv.models.stats
 
 import com.unciv.models.translations.tr
+import com.unciv.ui.components.fonts.FontRulesetIcons
+import com.unciv.ui.components.fonts.Fonts
 import kotlin.reflect.KMutableProperty0
 
 /**

--- a/core/src/com/unciv/models/stats/Stats.kt
+++ b/core/src/com/unciv/models/stats/Stats.kt
@@ -1,8 +1,6 @@
 package com.unciv.models.stats
 
 import com.unciv.models.translations.tr
-import com.unciv.ui.components.fonts.FontRulesetIcons
-import com.unciv.ui.components.fonts.Fonts
 import kotlin.reflect.KMutableProperty0
 
 /**

--- a/core/src/com/unciv/models/stats/Stats.kt
+++ b/core/src/com/unciv/models/stats/Stats.kt
@@ -1,6 +1,8 @@
 package com.unciv.models.stats
 
 import com.unciv.models.translations.tr
+import com.unciv.ui.components.fonts.FontRulesetIcons
+import com.unciv.ui.components.fonts.Fonts
 import kotlin.reflect.KMutableProperty0
 
 /**
@@ -182,6 +184,13 @@ open class Stats(
     fun toStringWithoutIcons(): String {
         return this.joinToString {
             it.value.toInt().toString() + " " + it.key.name.tr().substring(startIndex = 1)
+        }
+    }
+
+    /** Return a string of just +/- value and Stat symbol*/
+    fun toStringOnlyIcons(): String {
+        return this.joinToString {
+            (if (it.value > 0) "+" else "") + it.value.toInt() + " " + it.key.character
         }
     }
 

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionModifiers.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionModifiers.kt
@@ -21,7 +21,7 @@ object UnitActionModifiers {
             .filter { unique -> unique.conditionals.none { it.type == UniqueType.UnitActionExtraLimitedTimes } }
             .filter { canUse(unit, it) }
 
-    private fun getMovementPointsToUse(unit: MapUnit, actionUnique: Unique): Int {
+    private fun getMovementPointsToUse(unit: MapUnit, actionUnique: Unique, defaultAllMovement: Boolean = false): Int {
         if (actionUnique.conditionals.any { it.type == UniqueType.UnitActionMovementCostAll })
             return unit.getMaxMovement()
         val movementCost = actionUnique.conditionals
@@ -38,7 +38,7 @@ object UnitActionModifiers {
             if (movementCostRequired != null)
                 return movementCostRequired
         }
-        return 1
+        return if (defaultAllMovement) unit.getMaxMovement() else 1
     }
 
     private fun getMovementPointsRequired(actionUnique: Unique): Int {
@@ -82,8 +82,8 @@ object UnitActionModifiers {
             && canSpendStatsCost(unit, actionUnique)
     }
 
-    fun activateSideEffects(unit: MapUnit, actionUnique: Unique) {
-        val movementCost = getMovementPointsToUse(unit, actionUnique)
+    fun activateSideEffects(unit: MapUnit, actionUnique: Unique, defaultAllMovement: Boolean = false) {
+        val movementCost = getMovementPointsToUse(unit, actionUnique, defaultAllMovement)
         unit.useMovementPoints(movementCost.toFloat())
 
         for (conditional in actionUnique.conditionals) {
@@ -140,7 +140,7 @@ object UnitActionModifiers {
         else return "{$originalText} $sideEffectString"
     }
 
-    fun getSideEffectString(unit: MapUnit, actionUnique: Unique): String {
+    fun getSideEffectString(unit: MapUnit, actionUnique: Unique, defaultAllMovement: Boolean = false): String {
         val effects = ArrayList<String>()
 
         val maxUsages = getMaxUsages(unit, actionUnique)
@@ -156,7 +156,7 @@ object UnitActionModifiers {
         if (actionUnique.conditionals.any { it.type == UniqueType.UnitActionConsumeUnit }
             || actionUnique.conditionals.any { it.type == UniqueType.UnitActionAfterWhichConsumed } && usagesLeft(unit, actionUnique) == 1
         ) effects += Fonts.death.toString()
-        else effects += getMovementPointsToUse(unit, actionUnique).toString() + Fonts.movement
+        else effects += getMovementPointsToUse(unit, actionUnique, defaultAllMovement).toString() + Fonts.movement
 
         return if (effects.isEmpty()) ""
         else "(${effects.joinToString { it.tr() }})"

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionModifiers.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionModifiers.kt
@@ -32,16 +32,18 @@ object UnitActionModifiers {
      * going into the negatives
      * @return Boolean
      */
-    fun canSpendStatCost(unit: MapUnit, actionUnique: Unique): Boolean {
+    private fun canSpendStatsCost(unit: MapUnit, actionUnique: Unique): Boolean {
         for (conditional in actionUnique.conditionals.filter { it.type == UniqueType.UnitActionStatsCost }) {
             for ((stat, value) in conditional.stats) {
                 if (stat in Stat.statsWithCivWideField) {
                     if (!unit.civ.hasStatToBuy(stat, value.toInt()))
                         return false
                 } else {
-                    if (unit.getClosestCity() != null)
-                        if (!unit.getClosestCity()!!.hasStatToBuy(stat, value.toInt()))
+                    if (unit.getClosestCity() != null) {
+                        if (!unit.getClosestCity()!!.hasStatToBuy(stat, value.toInt())) {
                             return false
+                        }
+                    } else return false
                 }
             }
         }
@@ -55,7 +57,7 @@ object UnitActionModifiers {
     fun canAcivateSideEffects(unit: MapUnit, actionUnique: Unique): Boolean {
         return canUse(unit, actionUnique)
             && getMovementPointsToUse(actionUnique) <= (unit.currentMovement+0.5f).roundToInt() // ceiling
-            && canSpendStatCost(unit, actionUnique)
+            && canSpendStatsCost(unit, actionUnique)
     }
 
     fun activateSideEffects(unit: MapUnit, actionUnique: Unique) {

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionModifiers.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionModifiers.kt
@@ -33,7 +33,7 @@ object UnitActionModifiers {
      * @return Boolean
      */
     fun canSpendStatCost(unit: MapUnit, actionUnique: Unique): Boolean {
-        for (conditional in actionUnique.conditionals.filter { it.type == UniqueType.UnitActionStatCost }) {
+        for (conditional in actionUnique.conditionals.filter { it.type == UniqueType.UnitActionStatsCost }) {
             for ((stat, value) in conditional.stats) {
                 if (stat in Stat.statsWithCivWideField) {
                     if (!unit.civ.hasStatToBuy(stat, value.toInt()))
@@ -74,7 +74,7 @@ object UnitActionModifiers {
                     val usagesSoFar = unit.abilityToTimesUsed[actionUnique.placeholderText] ?: 0
                     unit.abilityToTimesUsed[actionUnique.placeholderText] = usagesSoFar + 1
                 }
-                UniqueType.UnitActionStatCost -> {
+                UniqueType.UnitActionStatsCost -> {
                     // do Stat costs, either Civ-wide or local city
                     // should have validated this doesn't send us negative
                     for ((stat, value) in conditional.stats) {

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsFromUniques.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsFromUniques.kt
@@ -362,7 +362,7 @@ object UnitActionsFromUniques {
                 .joinToString { "${it.value} {${it.key}}".tr() }
 
             var title = "Transform to [${unitToTransformTo.name}] "
-            title += UnitActionModifiers.getSideEffectString(unit, unique)
+            title += UnitActionModifiers.getSideEffectString(unit, unique, true)
             if (newResourceRequirementsString.isNotEmpty())
                 title += "\n([$newResourceRequirementsString])"
 
@@ -387,11 +387,11 @@ object UnitActionsFromUniques {
                         // a .destroy() unit has 0 movement
                         // and a new one may have less Max Movement
                         newUnit.currentMovement = oldMovement
-                        // execute any side effects, Stat and Movement adjustments
-                        UnitActionModifiers.activateSideEffects(newUnit, unique)
                         // adjust if newUnit has lower Max Movement
                         if (newUnit.currentMovement.toInt() > newUnit.getMaxMovement())
                             newUnit.currentMovement = newUnit.getMaxMovement().toFloat()
+                        // execute any side effects, Stat and Movement adjustments
+                        UnitActionModifiers.activateSideEffects(newUnit, unique, true)
                     }
                 }.takeIf {
                     !unit.isEmbarked() && UnitActionModifiers.canActivateSideEffects(unit, unique)

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsFromUniques.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsFromUniques.kt
@@ -42,6 +42,7 @@ object UnitActionsFromUniques {
     internal fun getFoundCityAction(unit: MapUnit, tile: Tile): UnitAction? {
         val unique = UnitActionModifiers.getUsableUnitActionUniques(unit, UniqueType.FoundCity)
             .firstOrNull() ?: return null
+        if (!UnitActionModifiers.canAcivateSideEffects(unit, unique)) return null
 
         if (tile.isWater || tile.isImpassible()) return null
         // Spain should still be able to build Conquistadors in a one city challenge - but can't settle them
@@ -296,6 +297,7 @@ object UnitActionsFromUniques {
                             // not pretty, but users *can* remove the building from the city queue an thus clear this:
                             && !tile.isMarkedForCreatesOneImprovement()
                             && !tile.isImpassible() // Not 100% sure that this check is necessary...
+                            && UnitActionModifiers.canAcivateSideEffects(unit, unique)
                     }
                 ))
             }

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsFromUniques.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsFromUniques.kt
@@ -338,15 +338,11 @@ object UnitActionsFromUniques {
         val statCost = Stats()
 
         for (unique in unit.getMatchingUniques(UniqueType.CanTransform, stateForConditionals)) {
-            for (conditional in unique.conditionals)
-                println(conditional)
             val unitToTransformTo = civInfo.getEquivalentUnit(unique.params[0])
             for (conditional in unique.conditionals.filter { it.type == UniqueType.UnitActionMovementCost })
                 movementCost = conditional.params[0].toInt()
-            for (conditional in unique.conditionals.filter { it.type == UniqueType.UnitActionStatCost }) {
+            for (conditional in unique.conditionals.filter { it.type == UniqueType.UnitActionStatCost })
                 statCost.add(conditional.stats)
-                println("$conditional")
-            }
 
             // Respect OnlyAvailable criteria
             if (unitToTransformTo.getMatchingUniques(

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsFromUniques.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsFromUniques.kt
@@ -42,7 +42,6 @@ object UnitActionsFromUniques {
     internal fun getFoundCityAction(unit: MapUnit, tile: Tile): UnitAction? {
         val unique = UnitActionModifiers.getUsableUnitActionUniques(unit, UniqueType.FoundCity)
             .firstOrNull() ?: return null
-        if (!UnitActionModifiers.canActivateSideEffects(unit, unique)) return null
 
         if (tile.isWater || tile.isImpassible()) return null
         // Spain should still be able to build Conquistadors in a one city challenge - but can't settle them
@@ -95,7 +94,7 @@ object UnitActionsFromUniques {
                         action = foundAction
                     ).open(force = true)
                 }
-            }
+            }.takeIf { UnitActionModifiers.canActivateSideEffects(unit, unique) }
         )
     }
 
@@ -215,7 +214,12 @@ object UnitActionsFromUniques {
                 }
             }()
 
-            yield(UnitAction(UnitActionType.TriggerUnique, 80f, title, action = unitAction))
+            yield(
+                UnitAction(UnitActionType.TriggerUnique, 80f, title,
+                    action = unitAction.takeIf {
+                        UnitActionModifiers.canActivateSideEffects(unit, unique)
+                    })
+            )
         }
     }
 

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsFromUniques.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsFromUniques.kt
@@ -365,7 +365,7 @@ object UnitActionsFromUniques {
             if (movementCost != Int.MIN_VALUE)
                 title += " ($movementCost${Fonts.movement})"
             if (!statCost.isEmpty())
-                title += " (${statCost.toString()})"
+                title += " (${(statCost*-1).toStringOnlyIcons()})"
             if (newResourceRequirementsString.isNotEmpty())
                 title += "\n([$newResourceRequirementsString])"
 
@@ -395,37 +395,14 @@ object UnitActionsFromUniques {
                                 newUnit.currentMovement = newUnit.getMaxMovement().toFloat()
                         }
 
-                        // do Stat costs, potentially to local city
-                        // takeIf should have validated this doesn't send us negative
-                        for ((stat, value) in statCost) {
-                            if (stat in Stat.statsWithCivWideField) {
-                                unit.civ.addStat(stat, -value.toInt())
-                            } else unit.civ.cities.minByOrNull {
-                                it.getCenterTile().aerialDistanceTo(tile)
-                            }?.addStat(stat, -value.toInt())
-                        }
+                        UnitActionModifiers.activateSideEffects(unit, unique) // execute any side effects
                     }
                 }.takeIf {
                     if (movementCost == Int.MIN_VALUE)
                         unit.currentMovement > 0f && !unit.isEmbarked() // movement and embark check
-                            && statCost.asSequence().all { // stat cost check
-                            if (unit.civ.cities.minByOrNull {
-                                    it.getCenterTile().aerialDistanceTo(tile)
-                                } != null) unit.civ.cities.minByOrNull {
-                                it.getCenterTile().aerialDistanceTo(tile)
-                            }!!.hasStatToBuy(it.key, it.value.toInt()) // city check
-                            else unit.civ.hasStatToBuy(it.key, it.value.toInt()) // civ check
-                        }
-                    else unit.currentMovement > movementCost.toFloat() && !unit.isEmbarked()
-                        && statCost.asSequence().all {
-                        if (unit.civ.cities.minByOrNull {
-                                it.getCenterTile().aerialDistanceTo(tile)
-                            } != null) unit.civ.cities.minByOrNull {
-                            it.getCenterTile().aerialDistanceTo(tile)
-                        }!!.hasStatToBuy(it.key, it.value.toInt())
-                        else unit.civ.hasStatToBuy(it.key, it.value.toInt())
-                    }
-
+                            && UnitActionModifiers.canAcivateSideEffects(unit, unique)
+                    else unit.currentMovement >= movementCost.toFloat() && !unit.isEmbarked()
+                        && UnitActionModifiers.canAcivateSideEffects(unit, unique)
                 }
             ))
         }

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsFromUniques.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsFromUniques.kt
@@ -341,7 +341,7 @@ object UnitActionsFromUniques {
             val unitToTransformTo = civInfo.getEquivalentUnit(unique.params[0])
             for (conditional in unique.conditionals.filter { it.type == UniqueType.UnitActionMovementCost })
                 movementCost = conditional.params[0].toInt()
-            for (conditional in unique.conditionals.filter { it.type == UniqueType.UnitActionStatCost })
+            for (conditional in unique.conditionals.filter { it.type == UniqueType.UnitActionStatsCost })
                 statCost.add(conditional.stats)
 
             // Respect OnlyAvailable criteria

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsFromUniques.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsFromUniques.kt
@@ -365,7 +365,7 @@ object UnitActionsFromUniques {
             if (movementCost != Int.MIN_VALUE)
                 title += " ($movementCost${Fonts.movement})"
             if (!statCost.isEmpty())
-                title += " (${statCost.toStringForNotifications()})"
+                title += " (${statCost.toString()})"
             if (newResourceRequirementsString.isNotEmpty())
                 title += "\n([$newResourceRequirementsString])"
 

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsFromUniques.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsFromUniques.kt
@@ -386,6 +386,9 @@ object UnitActionsFromUniques {
                         unit.copyStatisticsTo(resurrectedUnit)
                     } else { // Managed to upgrade
                         unit.copyStatisticsTo(newUnit)
+                        // have to handle movement manually because we killed the old unit
+                        // a .destroy() unit has 0 movement
+                        // and a new one may have less Max Movement
                         if (movementCost == Int.MIN_VALUE)
                             newUnit.currentMovement = 0f
                         else {
@@ -394,8 +397,9 @@ object UnitActionsFromUniques {
                             if (newUnit.currentMovement.toInt() > newUnit.getMaxMovement())
                                 newUnit.currentMovement = newUnit.getMaxMovement().toFloat()
                         }
-
-                        UnitActionModifiers.activateSideEffects(unit, unique) // execute any side effects
+                        // execute any side effects, mainly Stats.
+                        // currentMovement for newUnit handled manually above
+                        UnitActionModifiers.activateSideEffects(unit, unique)
                     }
                 }.takeIf {
                     if (movementCost == Int.MIN_VALUE)

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsFromUniques.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsFromUniques.kt
@@ -42,7 +42,7 @@ object UnitActionsFromUniques {
     internal fun getFoundCityAction(unit: MapUnit, tile: Tile): UnitAction? {
         val unique = UnitActionModifiers.getUsableUnitActionUniques(unit, UniqueType.FoundCity)
             .firstOrNull() ?: return null
-        if (!UnitActionModifiers.canAcivateSideEffects(unit, unique)) return null
+        if (!UnitActionModifiers.canActivateSideEffects(unit, unique)) return null
 
         if (tile.isWater || tile.isImpassible()) return null
         // Spain should still be able to build Conquistadors in a one city challenge - but can't settle them
@@ -297,7 +297,7 @@ object UnitActionsFromUniques {
                             // not pretty, but users *can* remove the building from the city queue an thus clear this:
                             && !tile.isMarkedForCreatesOneImprovement()
                             && !tile.isImpassible() // Not 100% sure that this check is necessary...
-                            && UnitActionModifiers.canAcivateSideEffects(unit, unique)
+                            && UnitActionModifiers.canActivateSideEffects(unit, unique)
                     }
                 ))
             }
@@ -336,15 +336,24 @@ object UnitActionsFromUniques {
         val civInfo = unit.civ
         val stateForConditionals =
             StateForConditionals(unit = unit, civInfo = civInfo, tile = unitTile)
-        var movementCost = Int.MIN_VALUE  // default, consume all movement
-        val statCost = Stats()
+        var movementCost: Int? = null  // default, consume all movement
+        var movementCostReq: Int? = null
 
         for (unique in unit.getMatchingUniques(UniqueType.CanTransform, stateForConditionals)) {
             val unitToTransformTo = civInfo.getEquivalentUnit(unique.params[0])
-            for (conditional in unique.conditionals.filter { it.type == UniqueType.UnitActionMovementCost })
-                movementCost = conditional.params[0].toInt()
-            for (conditional in unique.conditionals.filter { it.type == UniqueType.UnitActionStatsCost })
-                statCost.add(conditional.stats)
+            movementCost = unique.conditionals
+                .filter { it.type == UniqueType.UnitActionMovementCost }
+                .minOfOrNull { it.params[0].toInt() }
+            movementCostReq = unique.conditionals
+                .filter { it.type == UniqueType.UnitActionMovementCostRequired }
+                .minOfOrNull { it.params[0].toInt() }
+
+            if (movementCost != null && movementCostReq != null)
+                movementCost = maxOf(movementCost, movementCostReq)
+            else {
+                if (movementCostReq != null)
+                    movementCost = movementCostReq
+            }
 
             // Respect OnlyAvailable criteria
             if (unitToTransformTo.getMatchingUniques(
@@ -363,11 +372,8 @@ object UnitActionsFromUniques {
                 .filter { it.value > 0 }
                 .joinToString { "${it.value} {${it.key}}".tr() }
 
-            var title = "Transform to [${unitToTransformTo.name}]"
-            if (movementCost != Int.MIN_VALUE)
-                title += " ($movementCost${Fonts.movement})"
-            if (!statCost.isEmpty())
-                title += " (${(statCost*-1).toStringOnlyIcons()})"
+            var title = "Transform to [${unitToTransformTo.name}] "
+            title += UnitActionModifiers.getSideEffectString(unit, unique)
             if (newResourceRequirementsString.isNotEmpty())
                 title += "\n([$newResourceRequirementsString])"
 
@@ -391,7 +397,7 @@ object UnitActionsFromUniques {
                         // have to handle movement manually because we killed the old unit
                         // a .destroy() unit has 0 movement
                         // and a new one may have less Max Movement
-                        if (movementCost == Int.MIN_VALUE)
+                        if (movementCost == null)
                             newUnit.currentMovement = 0f
                         else {
                             newUnit.currentMovement = oldMovement - movementCost.toFloat()
@@ -404,11 +410,7 @@ object UnitActionsFromUniques {
                         UnitActionModifiers.activateSideEffects(unit, unique)
                     }
                 }.takeIf {
-                    if (movementCost == Int.MIN_VALUE)
-                        unit.currentMovement > 0f && !unit.isEmbarked() // movement and embark check
-                            && UnitActionModifiers.canAcivateSideEffects(unit, unique)
-                    else unit.currentMovement >= movementCost.toFloat() && !unit.isEmbarked()
-                        && UnitActionModifiers.canAcivateSideEffects(unit, unique)
+                    !unit.isEmbarked() && UnitActionModifiers.canActivateSideEffects(unit, unique)
                 }
             ))
         }

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsFromUniques.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsFromUniques.kt
@@ -18,6 +18,7 @@ import com.unciv.models.ruleset.unique.UniqueTarget
 import com.unciv.models.ruleset.unique.UniqueTriggerActivation
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.stats.Stat
+import com.unciv.models.stats.Stats
 import com.unciv.models.translations.fillPlaceholders
 import com.unciv.models.translations.removeConditionals
 import com.unciv.models.translations.tr
@@ -334,11 +335,18 @@ object UnitActionsFromUniques {
         val stateForConditionals =
             StateForConditionals(unit = unit, civInfo = civInfo, tile = unitTile)
         var movementCost = Int.MIN_VALUE  // default, consume all movement
+        val statCost = Stats()
 
         for (unique in unit.getMatchingUniques(UniqueType.CanTransform, stateForConditionals)) {
+            for (conditional in unique.conditionals)
+                println(conditional)
             val unitToTransformTo = civInfo.getEquivalentUnit(unique.params[0])
             for (conditional in unique.conditionals.filter { it.type == UniqueType.UnitActionMovementCost })
                 movementCost = conditional.params[0].toInt()
+            for (conditional in unique.conditionals.filter { it.type == UniqueType.UnitActionStatCost }) {
+                statCost.add(conditional.stats)
+                println("$conditional")
+            }
 
             // Respect OnlyAvailable criteria
             if (unitToTransformTo.getMatchingUniques(
@@ -357,11 +365,13 @@ object UnitActionsFromUniques {
                 .filter { it.value > 0 }
                 .joinToString { "${it.value} {${it.key}}".tr() }
 
-            var title = if (newResourceRequirementsString.isEmpty())
-                "Transform to [${unitToTransformTo.name}]"
-            else "Transform to [${unitToTransformTo.name}]\n([$newResourceRequirementsString])"
+            var title = "Transform to [${unitToTransformTo.name}]"
             if (movementCost != Int.MIN_VALUE)
                 title += " ($movementCost${Fonts.movement})"
+            if (!statCost.isEmpty())
+                title += " (${statCost.toStringForNotifications()})"
+            if (newResourceRequirementsString.isNotEmpty())
+                title += "\n([$newResourceRequirementsString])"
 
             yield(UnitAction(UnitActionType.Transform, 70f,
                 title = title,
@@ -388,11 +398,38 @@ object UnitActionsFromUniques {
                             if (newUnit.currentMovement.toInt() > newUnit.getMaxMovement())
                                 newUnit.currentMovement = newUnit.getMaxMovement().toFloat()
                         }
+
+                        // do Stat costs, potentially to local city
+                        // takeIf should have validated this doesn't send us negative
+                        for ((stat, value) in statCost) {
+                            if (stat in Stat.statsWithCivWideField) {
+                                unit.civ.addStat(stat, -value.toInt())
+                            } else unit.civ.cities.minByOrNull {
+                                it.getCenterTile().aerialDistanceTo(tile)
+                            }?.addStat(stat, -value.toInt())
+                        }
                     }
                 }.takeIf {
                     if (movementCost == Int.MIN_VALUE)
-                        unit.currentMovement > 0f && !unit.isEmbarked()
+                        unit.currentMovement > 0f && !unit.isEmbarked() // movement and embark check
+                            && statCost.asSequence().all { // stat cost check
+                            if (unit.civ.cities.minByOrNull {
+                                    it.getCenterTile().aerialDistanceTo(tile)
+                                } != null) unit.civ.cities.minByOrNull {
+                                it.getCenterTile().aerialDistanceTo(tile)
+                            }!!.hasStatToBuy(it.key, it.value.toInt()) // city check
+                            else unit.civ.hasStatToBuy(it.key, it.value.toInt()) // civ check
+                        }
                     else unit.currentMovement > movementCost.toFloat() && !unit.isEmbarked()
+                        && statCost.asSequence().all {
+                        if (unit.civ.cities.minByOrNull {
+                                it.getCenterTile().aerialDistanceTo(tile)
+                            } != null) unit.civ.cities.minByOrNull {
+                            it.getCenterTile().aerialDistanceTo(tile)
+                        }!!.hasStatToBuy(it.key, it.value.toInt())
+                        else unit.civ.hasStatToBuy(it.key, it.value.toInt())
+                    }
+
                 }
             ))
         }

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsReligion.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsReligion.kt
@@ -36,7 +36,8 @@ object UnitActionsReligion {
 
                 if (hasActionModifiers) UnitActionModifiers.activateSideEffects(unit, unique)
                 else unit.consume()
-            }.takeIf { unit.civ.religionManager.mayFoundReligionHere(tile) }
+            }.takeIf { unit.civ.religionManager.mayFoundReligionHere(tile)
+                && UnitActionModifiers.canAcivateSideEffects(unit, unique)}
         ))
     }
 
@@ -63,7 +64,8 @@ object UnitActionsReligion {
                 unit.civ.religionManager.useProphetForEnhancingReligion(unit)
                 if (hasActionModifiers) UnitActionModifiers.activateSideEffects(unit, unique)
                 else unit.consume()
-            }.takeIf { unit.civ.religionManager.mayEnhanceReligionHere(tile) }
+            }.takeIf { unit.civ.religionManager.mayEnhanceReligionHere(tile)
+                && UnitActionModifiers.canAcivateSideEffects(unit, unique)}
         ))
     }
 
@@ -99,7 +101,8 @@ object UnitActionsReligion {
                     city.religion.removeAllPressuresExceptFor(unit.religion!!)
 
                 UnitActionModifiers.activateSideEffects(unit, newStyleUnique)
-            }.takeIf { unit.currentMovement > 0 && unit.civ.religionManager.maySpreadReligionNow(unit) }
+            }.takeIf { unit.civ.religionManager.maySpreadReligionNow(unit)
+                && UnitActionModifiers.canAcivateSideEffects(unit, newStyleUnique)}
         ))
     }
 
@@ -138,7 +141,7 @@ object UnitActionsReligion {
                     }
                 }
                 UnitActionModifiers.activateSideEffects(unit, newStyleUnique)
-            }.takeIf { unit.currentMovement > 0f }
+            }.takeIf { UnitActionModifiers.canAcivateSideEffects(unit, newStyleUnique)}
         ))
     }
 }

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsReligion.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsReligion.kt
@@ -37,7 +37,7 @@ object UnitActionsReligion {
                 if (hasActionModifiers) UnitActionModifiers.activateSideEffects(unit, unique)
                 else unit.consume()
             }.takeIf { unit.civ.religionManager.mayFoundReligionHere(tile)
-                && UnitActionModifiers.canAcivateSideEffects(unit, unique)}
+                && UnitActionModifiers.canActivateSideEffects(unit, unique)}
         ))
     }
 
@@ -65,7 +65,7 @@ object UnitActionsReligion {
                 if (hasActionModifiers) UnitActionModifiers.activateSideEffects(unit, unique)
                 else unit.consume()
             }.takeIf { unit.civ.religionManager.mayEnhanceReligionHere(tile)
-                && UnitActionModifiers.canAcivateSideEffects(unit, unique)}
+                && UnitActionModifiers.canActivateSideEffects(unit, unique)}
         ))
     }
 
@@ -102,7 +102,7 @@ object UnitActionsReligion {
 
                 UnitActionModifiers.activateSideEffects(unit, newStyleUnique)
             }.takeIf { unit.civ.religionManager.maySpreadReligionNow(unit)
-                && UnitActionModifiers.canAcivateSideEffects(unit, newStyleUnique)}
+                && UnitActionModifiers.canActivateSideEffects(unit, newStyleUnique)}
         ))
     }
 
@@ -141,7 +141,7 @@ object UnitActionsReligion {
                     }
                 }
                 UnitActionModifiers.activateSideEffects(unit, newStyleUnique)
-            }.takeIf { UnitActionModifiers.canAcivateSideEffects(unit, newStyleUnique)}
+            }.takeIf { UnitActionModifiers.canActivateSideEffects(unit, newStyleUnique)}
         ))
     }
 }

--- a/docs/Modders/Unique-parameters.md
+++ b/docs/Modders/Unique-parameters.md
@@ -182,10 +182,23 @@ Allowed values are:
 
 This indicates a text comprised of specific stats and is slightly more complex.
 
-Each stats is comprised of several stat changes, each in the form of `+{amount} {stat}`, where 'stat' is one of the seven major stats mentioned above.
+Each stats is comprised of several stat changes, each in the form of `+{amount} {stat}`,
+where 'stat' is one of the seven major stats
+(eg `Production`, `Food`, `Gold`, `Science`, `Culture`, `Happiness` and `Faith`).
 For example: `+1 Science`.
 
 These can be strung together with ", " between them, for example: `+2 Production, +3 Food`.
+
+## stockpiledResource
+
+This indicates a text that corresponds to a custom Stockpile Resource.
+
+These are global civilization resources that act similar to the main Civ-wide resources like `Gold` and `Faith`.
+You can generate them and consume them. And actions that would consume them are blocked if you
+don't have enough left in stock.
+
+To use, you need to first define a TileResources with the "Stockpiled" Unique. Then you can reference
+them in other Uniques.
 
 ## technologyFilter
 


### PR DESCRIPTION
Add ActionModifier UnitActionStatsCost that allows optional Stats application to UnitActions.
* Food and Production come from/go to nearest City

Add ActionModifier UnitActionMovementCostRequired that can force a minimum amount of movement to do an Action
Add ActionModifier UnitActionMovementCostAll to use all remaining Movement

Also add validation that the ActionModifier effects can be executed and added to other UnitAction Uniques.

UnitActions can default to using All Movement points (such as Transform)

![image](https://github.com/yairm210/Unciv/assets/44038014/8f561a55-f371-4665-ae93-a93d2a3759cf)

