### PR TITLE
Allow improvements that don't need removal to build

### DIFF
--- a/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
@@ -443,7 +443,7 @@ class WorkerAutomation(
         return tile.tileResource.getImprovements().any { resourceImprovementName ->
             if (resourceImprovementName !in potentialTileImprovements) return@any false
             val resourceImprovement = potentialTileImprovements[resourceImprovementName]!!
-            tile.terrainFeatures.any { resourceImprovement.isAllowedOnFeature(it) }
+            tile.terrainFeatureObjects.any { resourceImprovement.isAllowedOnFeature(it) }
         }
     }
 

--- a/core/src/com/unciv/logic/map/tile/Tile.kt
+++ b/core/src/com/unciv/logic/map/tile/Tile.kt
@@ -494,7 +494,7 @@ class Tile : IsPartOfGameInfoSerialization {
     }
 
     fun matchesTerrainFilter(filter: String, observingCiv: Civilization? = null): Boolean {
-        return MultiFilter.multiFilter(filter, {matchesSingleTerrainFilter(it, observingCiv)})
+        return MultiFilter.multiFilter(filter, { matchesSingleTerrainFilter(it, observingCiv) })
     }
 
     /** Implements [UniqueParameterType.TerrainFilter][com.unciv.models.ruleset.unique.UniqueParameterType.TerrainFilter] */
@@ -507,9 +507,6 @@ class Tile : IsPartOfGameInfoSerialization {
             "Land" -> isLand
             Constants.coastal -> isCoastalTile()
             Constants.river -> isAdjacentToRiver()
-            naturalWonder -> true
-            "Open terrain" -> !isRoughTerrain()
-            "Rough terrain" -> isRoughTerrain()
 
             "your" -> observingCiv != null && getOwner() == observingCiv
             "Foreign Land", "Foreign" -> observingCiv != null && !isFriendlyTerritory(observingCiv)
@@ -519,13 +516,11 @@ class Tile : IsPartOfGameInfoSerialization {
             resource -> observingCiv != null && hasViewableResource(observingCiv)
             "resource" -> observingCiv != null && hasViewableResource(observingCiv)
             "Water resource" -> isWater && observingCiv != null && hasViewableResource(observingCiv)
-            "Natural Wonder" -> naturalWonder != null
             "Featureless" -> terrainFeatures.isEmpty()
             Constants.freshWaterFilter -> isAdjacentTo(Constants.freshWater, observingCiv)
-
-            in terrainFeatures -> true
+            
             else -> {
-                if (terrainUniqueMap.containsFilteringUnique(filter)) return true
+                if (allTerrains.any { it.matchesFilter(filter) }) return true
                 if (getOwner()?.matchesFilter(filter) == true) return true
 
                 // Resource type check is last - cannot succeed if no resource here

--- a/core/src/com/unciv/logic/map/tile/TileInfoImprovementFunctions.kt
+++ b/core/src/com/unciv/logic/map/tile/TileInfoImprovementFunctions.kt
@@ -175,7 +175,7 @@ class TileInfoImprovementFunctions(val tile: Tile) {
             // At this point we know this is a normal improvement and that there is no reason not to allow it to be built.
 
             // Lastly we check if the improvement may be built on this terrain or resource
-            improvement.canBeBuiltOn(tile.lastTerrain.name) -> true
+            improvement.isAllowedOnFeature(tile.lastTerrain) -> true
             tile.isLand && improvement.canBeBuiltOn("Land") -> true
             tile.isWater && improvement.canBeBuiltOn("Water") -> true
             // DO NOT reverse this &&. isAdjacentToFreshwater() is a lazy which calls a function, and reversing it breaks the tests.

--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -1,6 +1,7 @@
 package com.unciv.models.ruleset
 
 import com.badlogic.gdx.files.FileHandle
+import com.unciv.Constants
 import com.unciv.json.fromJsonFile
 import com.unciv.json.json
 import com.unciv.logic.BackwardCompatibility.updateDeprecations

--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -76,6 +76,8 @@ class Ruleset {
         units.values.filter { it.hasUnique(UniqueType.GreatPersonFromCombat, StateForConditionals.IgnoreConditionals) }
     }
 
+    val tileRemovals by lazy { tileImprovements.values.filter { it.name.startsWith(Constants.remove) } }
+
     /** Contains all happiness levels that moving *from* them, to one *below* them, can change uniques that apply */
     val allHappinessLevelsThatAffectUniques by lazy {
         sequence {

--- a/core/src/com/unciv/models/ruleset/tile/Terrain.kt
+++ b/core/src/com/unciv/models/ruleset/tile/Terrain.kt
@@ -161,9 +161,7 @@ class Terrain : RulesetStatsObject() {
             "Natural Wonder" -> type == TerrainType.NaturalWonder
             "Terrain Feature" -> type == TerrainType.TerrainFeature
 
-            else -> {
-                return uniques.contains(filter)
-            }
+            else -> uniques.contains(filter)
         }
     }
 

--- a/core/src/com/unciv/models/ruleset/tile/Terrain.kt
+++ b/core/src/com/unciv/models/ruleset/tile/Terrain.kt
@@ -2,6 +2,7 @@ package com.unciv.models.ruleset.tile
 
 import com.badlogic.gdx.graphics.Color
 import com.unciv.Constants
+import com.unciv.logic.MultiFilter
 import com.unciv.models.ruleset.Belief
 import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.ruleset.RulesetStatsObject
@@ -141,6 +142,29 @@ class Terrain : RulesetStatsObject() {
         }
 
         return textList
+    }
+
+    fun matchesFilter(filter: String): Boolean {
+        return MultiFilter.multiFilter(filter, { matchesSingleFilter(it) })
+    }
+
+    /** Implements [UniqueParameterType.TerrainFilter][com.unciv.models.ruleset.unique.UniqueParameterType.TerrainFilter] */
+    fun matchesSingleFilter(filter: String): Boolean {
+        return when (filter) {
+            in Constants.all -> true
+            name -> true
+            "Terrain" -> true
+            in Constants.all -> true
+            "Open terrain" -> !isRough()
+            "Rough terrain" -> isRough()
+            type.name -> true
+            "Natural Wonder" -> type == TerrainType.NaturalWonder
+            "Terrain Feature" -> type == TerrainType.TerrainFeature
+
+            else -> {
+                return uniques.contains(filter)
+            }
+        }
     }
 
     fun setTransients() {

--- a/core/src/com/unciv/models/ruleset/tile/TileImprovement.kt
+++ b/core/src/com/unciv/models/ruleset/tile/TileImprovement.kt
@@ -89,7 +89,8 @@ class TileImprovement : RulesetStatsObject() {
      * so this check is done in conjunction - for the user, success means he does not need to remove
      * a terrain feature, thus the unique name.
      */
-    fun isAllowedOnFeature(terrain: Terrain) = terrainsCanBeBuiltOn.any { terrain.matchesFilter(it) } || getMatchingUniques(UniqueType.NoFeatureRemovalNeeded).any { terrain.matchesFilter(it.params[0]) }
+    fun isAllowedOnFeature(terrain: Terrain) = canBeBuiltOn(terrain)
+        || getMatchingUniques(UniqueType.NoFeatureRemovalNeeded).any { terrain.matchesFilter(it.params[0]) }
 
     /** Implements [UniqueParameterType.ImprovementFilter][com.unciv.models.ruleset.unique.UniqueParameterType.ImprovementFilter] */
     fun matchesFilter(filter: String): Boolean {

--- a/core/src/com/unciv/models/ruleset/tile/TileImprovement.kt
+++ b/core/src/com/unciv/models/ruleset/tile/TileImprovement.kt
@@ -75,6 +75,9 @@ class TileImprovement : RulesetStatsObject() {
     fun canBeBuiltOn(terrain: String): Boolean {
         return terrain in terrainsCanBeBuiltOn
     }
+    fun canBeBuiltOn(terrain: Terrain): Boolean {
+        return terrainsCanBeBuiltOn.any{ terrain.matchesFilter(it) }
+    }
 
     /**
      * Check: Is this improvement allowed on a [given][name] terrain feature?
@@ -86,7 +89,7 @@ class TileImprovement : RulesetStatsObject() {
      * so this check is done in conjunction - for the user, success means he does not need to remove
      * a terrain feature, thus the unique name.
      */
-    fun isAllowedOnFeature(name: String) = terrainsCanBeBuiltOn.contains(name) || getMatchingUniques(UniqueType.NoFeatureRemovalNeeded).any { it.params[0] == name }
+    fun isAllowedOnFeature(terrain: Terrain) = terrainsCanBeBuiltOn.any { terrain.matchesFilter(it) } || getMatchingUniques(UniqueType.NoFeatureRemovalNeeded).any { terrain.matchesFilter(it.params[0]) }
 
     /** Implements [UniqueParameterType.ImprovementFilter][com.unciv.models.ruleset.unique.UniqueParameterType.ImprovementFilter] */
     fun matchesFilter(filter: String): Boolean {

--- a/tests/src/com/unciv/logic/map/TileImprovementConstructionTests.kt
+++ b/tests/src/com/unciv/logic/map/TileImprovementConstructionTests.kt
@@ -230,6 +230,7 @@ class TileImprovementConstructionTests {
             tile.improvementFunctions.canBuildImprovement(allowedImprovement, civInfo))
         tile.changeImprovement(allowedImprovement.name)
         Assert.assertTrue(tile.improvement == allowedImprovement.name)
+        Assert.assertTrue("Forest should not be removed with this improvement", tile.terrainFeatures.contains("Forest"))
     }
 
     @Test
@@ -242,7 +243,7 @@ class TileImprovementConstructionTests {
         Assert.assertTrue(tile.improvementFunctions.canBuildImprovement(improvement, civInfo))
         tile.changeImprovement(improvement.name)
         Assert.assertTrue(tile.improvement == improvement.name)
-        Assert.assertTrue("Forest should not be removed with this improvement",tile.terrainFeatures.contains("Forest"))
+        Assert.assertTrue("Forest should not be removed with this improvement", tile.terrainFeatures.contains("Forest"))
     }
 
     @Test

--- a/tests/src/com/unciv/logic/map/TileImprovementConstructionTests.kt
+++ b/tests/src/com/unciv/logic/map/TileImprovementConstructionTests.kt
@@ -227,7 +227,7 @@ class TileImprovementConstructionTests {
         val allowedImprovement = testGame.createTileImprovement()
         allowedImprovement.terrainsCanBeBuiltOn += "Forest"
         Assert.assertTrue("Forest should allow building when allowed",
-            tile.improvementFunctions.canBuildImprovement(improvement, civInfo))
+            tile.improvementFunctions.canBuildImprovement(allowedImprovement, civInfo))
         tile.changeImprovement(allowedImprovement.name)
         Assert.assertTrue(tile.improvement == allowedImprovement.name)
     }

--- a/tests/src/com/unciv/logic/map/TileImprovementConstructionTests.kt
+++ b/tests/src/com/unciv/logic/map/TileImprovementConstructionTests.kt
@@ -30,11 +30,10 @@ class TileImprovementConstructionTests {
         testGame.makeHexagonalMap(4)
         tileMap = testGame.tileMap
         civInfo = testGame.addCiv()
-        civInfo.tech.researchedTechnologies.addAll(testGame.ruleset.technologies.values)
-        civInfo.tech.techsResearched.addAll(testGame.ruleset.technologies.keys)
+        for (tech in testGame.ruleset.technologies.values)
+            civInfo.tech.addTechnology(tech.name)
         city = testGame.addCity(civInfo, tileMap[0,0])
     }
-
 
     @Test
     fun allTerrainSpecificImprovementsCanBeBuilt() {
@@ -212,6 +211,38 @@ class TileImprovementConstructionTests {
         tile.improvementFunctions.changeImprovement("Remove Forest")
         assert(tile.terrainFeatures.isEmpty())
         assert(tile.improvement == "Camp") // Camp can be both on Forest AND on Plains, so not removed
+    }
+
+    @Test
+    fun improvementCannotBuildWhenNotAllowed() {
+        val tile = tileMap[1,1]
+        tile.baseTerrain ="Grassland"
+        tile.addTerrainFeature("Forest")
+
+        val improvement = testGame.createTileImprovement()
+        Assert.assertFalse("Forest doesn't allow building unless allowed",
+            tile.improvementFunctions.canBuildImprovement(improvement, civInfo))
+
+
+        val allowedImprovement = testGame.createTileImprovement()
+        allowedImprovement.terrainsCanBeBuiltOn += "Forest"
+        Assert.assertTrue("Forest should allow building when allowed",
+            tile.improvementFunctions.canBuildImprovement(improvement, civInfo))
+        tile.changeImprovement(allowedImprovement.name)
+        Assert.assertTrue(tile.improvement == allowedImprovement.name)
+    }
+
+    @Test
+    fun improvementDoesntNeedRemovalCanBuildHere() {
+        val tile = tileMap[1,1]
+        tile.baseTerrain ="Grassland"
+        tile.addTerrainFeature("Forest")
+
+        val improvement = testGame.createTileImprovement("Does not need removal of [Forest]")
+        Assert.assertTrue(tile.improvementFunctions.canBuildImprovement(improvement, civInfo))
+        tile.changeImprovement(improvement.name)
+        Assert.assertTrue(tile.improvement == improvement.name)
+        Assert.assertTrue("Forest should not be removed with this improvement",tile.terrainFeatures.contains("Forest"))
     }
 
     @Test

--- a/tests/src/com/unciv/uniques/GlobalUniquesTests.kt
+++ b/tests/src/com/unciv/uniques/GlobalUniquesTests.kt
@@ -116,6 +116,7 @@ class GlobalUniquesTests {
         city.cityStats.update()
         Assert.assertTrue(city.cityStats.finalStatList["Buildings"]!!.gold == 3f)
         tile.baseTerrain = Constants.grassland
+        tile.setTransients()
         city.cityStats.update()
         Assert.assertTrue(city.cityStats.finalStatList["Buildings"]!!.gold == 0f)
     }


### PR DESCRIPTION
closes #11296

Also allows for Tile Feature removal to refer to features by filter. This opens a bit of a can of worms as we now have more or less 3 tile filter options:
1. This new version of TerrainFilter (filters for stuff inherent to the terrain)
2. The old TerrainFilter (filter for terrain on a tile
3. TileFilter (filters for any additional tile information, namely improvements)

There's also a secondary change thrown in since I noticed it (kinda as a red herring tbh) when I was adding in the TerrainFilter. Apparently, improvements that automatically removed removable terrain only checked if removing the top layer was valid, rather then all layers, which is extremely inconsistent if a mod wanted to abuse that fact. Main PR is rather small, and this fix is likely unknown (how many mods have stacking removable features?) so I have no issues myself sneaking it in