### PR TITLE
Countable comparison conditional uniques

### DIFF
--- a/core/src/com/unciv/models/ruleset/unique/Conditionals.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Conditionals.kt
@@ -100,22 +100,23 @@ object Conditionals {
         }
 
         fun getCountableAmount(countable: String): Float? {
-            if (countable.toIntOrNull() != null) return countable.toFloat()
             if (countable.toFloatOrNull() != null) return countable.toFloat()
-            if (countable == "year") return gameInfo!!.getYear(gameInfo!!.turns).toFloat()
 
             val relevantStat = Stat.safeValueOf(countable)
 
             if (relevantStat != null) {
-                if (relevantCity != null) {
-                    return relevantCity!!.getStatReserve(relevantStat).toFloat()
-                } else if (relevantStat in Stat.statsWithCivWideField) {
-                    return relevantCiv!!.getStatReserve(relevantStat).toFloat()
+                return if (relevantCity != null) {
+                    relevantCity!!.getStatReserve(relevantStat).toFloat()
+                } else if (relevantStat in Stat.statsWithCivWideField && relevantCiv != null) {
+                    relevantCiv!!.getStatReserve(relevantStat).toFloat()
                 } else {
-                    return null
+                    null
                 }
             }
 
+            if (gameInfo == null) return null
+
+            if (countable == "year") return gameInfo!!.getYear(gameInfo!!.turns).toFloat()
             if (gameInfo!!.ruleset.tileResources.containsKey(countable))
                 return getResourceAmount(countable).toFloat()
 
@@ -127,16 +128,24 @@ object Conditionals {
             second: String,
             compare: (first: Float, second: Float) -> Boolean): Boolean {
 
-            return if (getCountableAmount(first) != null && getCountableAmount(second) != null)
-                compare(getCountableAmount(first)!!, getCountableAmount(second)!!)
+            val firstNumber = getCountableAmount(first)
+            val secondNumber = getCountableAmount(second)
+
+            return if (firstNumber != null && secondNumber != null)
+                compare(firstNumber, secondNumber)
             else
                 false
         }
 
         fun compareCountables(first: String, second: String, third: String,
                               compare: (first: Float, second: Float, third: Float) -> Boolean): Boolean {
-            return if (getCountableAmount(first) != null && getCountableAmount(second) != null && getCountableAmount(third) != null)
-                compare(getCountableAmount(first)!!, getCountableAmount(second)!!, getCountableAmount(third)!!)
+
+            val firstNumber = getCountableAmount(first)
+            val secondNumber = getCountableAmount(second)
+            val thirdNumber = getCountableAmount(third)
+
+            return if (firstNumber != null && secondNumber != null && thirdNumber != null)
+                compare(firstNumber, secondNumber, thirdNumber)
             else
                 false
         }

--- a/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
@@ -75,6 +75,28 @@ enum class UniqueParameterType(
         }
     },
 
+    Countable("countable", "1000", "This indicate a number or a numeric variable") {
+        // todo add more countables
+        private val knownValues = setOf(
+            "year"
+        )
+
+        override fun isKnownValue(parameterText: String, ruleset: Ruleset): Boolean {
+            if (parameterText in knownValues) return true
+            if (parameterText.toIntOrNull() != null) return true
+            if (parameterText.toFloatOrNull() != null) return true
+            if (Stat.isStat(parameterText)) return true
+            if (parameterText in ruleset.tileResources) return true
+            return false
+        }
+
+        override fun getErrorSeverity(
+            parameterText: String, ruleset: Ruleset): UniqueType.UniqueParameterErrorSeverity? {
+            return if (isKnownValue(parameterText, ruleset)) null
+            else UniqueType.UniqueParameterErrorSeverity.RulesetSpecific
+        }
+    },
+
     // todo potentially remove if OneTimeRevealSpecificMapTiles changes
     KeywordAll("'all'", "All") {
         override fun getErrorSeverity(parameterText: String, ruleset: Ruleset) =

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -734,6 +734,13 @@ enum class UniqueType(
     ConditionalInRegionOfType("in [regionType] Regions", UniqueTarget.Conditional),
     ConditionalInRegionExceptOfType("in all except [regionType] Regions", UniqueTarget.Conditional),
 
+    /////// countables conditionals
+    ConditionalCountableEqualTo("when number of [countable] is equal to [countable]", UniqueTarget.Conditional),
+    ConditionalCountableDifferentThan("when number of [countable] is different than [countable]", UniqueTarget.Conditional),
+    ConditionalCountableGreaterThan("when number of [countable] is greater than [countable]", UniqueTarget.Conditional),
+    ConditionalCountableLessThan("when number of [countable] is less than [countable]", UniqueTarget.Conditional),
+    ConditionalCountableBetween("when number of [countable] between [countable] and [countable]", UniqueTarget.Conditional),
+
     //endregion
 
     ///////////////////////////////////////// region 09 TRIGGERED ONE-TIME /////////////////////////////////////////

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -739,7 +739,7 @@ enum class UniqueType(
     ConditionalCountableDifferentThan("when number of [countable] is different than [countable]", UniqueTarget.Conditional),
     ConditionalCountableGreaterThan("when number of [countable] is greater than [countable]", UniqueTarget.Conditional),
     ConditionalCountableLessThan("when number of [countable] is less than [countable]", UniqueTarget.Conditional),
-    ConditionalCountableBetween("when number of [countable] between [countable] and [countable]", UniqueTarget.Conditional),
+    ConditionalCountableBetween("when number of [countable] is between [countable] and [countable]", UniqueTarget.Conditional),
 
     //endregion
 

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -2235,6 +2235,31 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 	Applicable to: Conditional
 
+??? example  "&lt;when number of [countable] is equal to [countable]&gt;"
+	Example: "&lt;when number of [1000] is equal to [1000]&gt;"
+
+	Applicable to: Conditional
+
+??? example  "&lt;when number of [countable] is different than [countable]&gt;"
+	Example: "&lt;when number of [1000] is different than [1000]&gt;"
+
+	Applicable to: Conditional
+
+??? example  "&lt;when number of [countable] is greater than [countable]&gt;"
+	Example: "&lt;when number of [1000] is greater than [1000]&gt;"
+
+	Applicable to: Conditional
+
+??? example  "&lt;when number of [countable] is less than [countable]&gt;"
+	Example: "&lt;when number of [1000] is less than [1000]&gt;"
+
+	Applicable to: Conditional
+
+??? example  "&lt;when number of [countable] between [countable] and [countable]&gt;"
+	Example: "&lt;when number of [1000] between [1000] and [1000]&gt;"
+
+	Applicable to: Conditional
+
 ## TriggerCondition uniques
 !!! note ""
 
@@ -2388,6 +2413,7 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 *[civWideStat]: All the following stats have civ-wide fields: `Gold`, `Science`, `Culture`, `Faith`.
 *[combatantFilter]: This indicates a combatant, which can either be a unit or a city (when bombarding). Must either be `City` or a `mapUnitFilter`.
 *[costOrStrength]: `Cost` or `Strength`.
+*[countable]: This indicate a number or a numeric variable.
 *[era]: The name of any era.
 *[event]: The name of any event.
 *[foundingOrEnhancing]: `founding` or `enhancing`.

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -2255,8 +2255,8 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 	Applicable to: Conditional
 
-??? example  "&lt;when number of [countable] between [countable] and [countable]&gt;"
-	Example: "&lt;when number of [1000] between [1000] and [1000]&gt;"
+??? example  "&lt;when number of [countable] is between [countable] and [countable]&gt;"
+	Example: "&lt;when number of [1000] is between [1000] and [1000]&gt;"
 
 	Applicable to: Conditional
 


### PR DESCRIPTION
As I promised two days ago #11280 , I've made a pull request which contains five new uniques for comparing countables.
Countables can be numbers (both integer and float) and numeric variables. For now, only these variables are supported:

- Current year
- Stat amounts
- Resource amounts

If you have more ideas for the countables, give me a lot of them, as adding new countables is a quick and easy process.

I would also like to add two TriggerCondition uniques, which are true when the number of one countable becomes higher or lower than another countable. Please give me some advice about it.

Better yet, we can add support of nested parameters or even evaluation of mathematical expressions into numbers, either by using this [https://github.com/notKamui/Keval](https://github.com/notKamui/Keval) or similar library or our custom code for that task.