### PR TITLE
Melee Escort Attacking Fix

### DIFF
--- a/core/src/com/unciv/logic/battle/TargetHelper.kt
+++ b/core/src/com/unciv/logic/battle/TargetHelper.kt
@@ -30,7 +30,7 @@ object TargetHelper {
             if (unit.baseUnit.isMelee() && unit.isEscorting()) {
                 val escortingUnit = unit.getOtherEscortUnit()!!
                 if (!escortingUnit.movement.canReachInCurrentTurn(reachableTile)
-                    || escortingUnit.currentMovement - unit.getOtherEscortUnit()!!.movement.getDistanceToTiles()[reachableTile]!!.totalDistance <= 0f) 
+                    || escortingUnit.currentMovement - escortingUnit.movement.getDistanceToTiles()[reachableTile]!!.totalDistance <= 0f) 
                     continue
             }
             val tilesInAttackRange =

--- a/core/src/com/unciv/logic/battle/TargetHelper.kt
+++ b/core/src/com/unciv/logic/battle/TargetHelper.kt
@@ -25,11 +25,18 @@ object TargetHelper {
         val tilesWithEnemies: HashSet<Tile> = HashSet()
         val tilesWithoutEnemies: HashSet<Tile> = HashSet()
         for ((reachableTile, movementLeft) in tilesToAttackFrom) {  // tiles we'll still have energy after we reach there
+            // If we are a melee unit that is escorting, we only want to be able to attack from this
+            // tile if the escorted unit can also move into the tile we are attacking if we kill the enemy unit.
+            if (unit.baseUnit.isMelee() && unit.isEscorting()) {
+                val escortingUnit = unit.getOtherEscortUnit()!!
+                if (!escortingUnit.movement.canReachInCurrentTurn(reachableTile)
+                    || escortingUnit.currentMovement - unit.getOtherEscortUnit()!!.movement.getDistanceToTiles()[reachableTile]!!.totalDistance <= 0f) 
+                    continue
+            }
             val tilesInAttackRange =
                 if (unit.hasUnique(UniqueType.IndirectFire) || unit.baseUnit.movesLikeAirUnits())
                     reachableTile.getTilesInDistance(rangeOfAttack)
                 else reachableTile.tileMap.getViewableTiles(reachableTile.position, rangeOfAttack, true).asSequence()
-
             for (tile in tilesInAttackRange) {
                 when {
                     // Since military units can technically enter tiles with enemy civilians,

--- a/tests/src/com/unciv/logic/map/UnitFomationTests.kt
+++ b/tests/src/com/unciv/logic/map/UnitFomationTests.kt
@@ -2,6 +2,7 @@ package com.unciv.logic.map
 
 import com.badlogic.gdx.math.Vector2
 import com.unciv.Constants
+import com.unciv.logic.battle.TargetHelper
 import com.unciv.logic.civilization.Civilization
 import com.unciv.testing.GdxTestRunner
 import com.unciv.testing.TestGame
@@ -194,5 +195,25 @@ internal class UnitFormationTests {
         civilianUnit.startEscorting()
         civilianDistanceToTiles = civilianUnit.movement.getDistanceToTiles()
         assertFalse(militaryUnit.movement.getDistanceToTiles().any { !civilianDistanceToTiles.contains(it.key) })
+    }
+
+    @Test
+    fun `test escort attack with military unit having ignoreTerrainCost`() {
+        setUp(3)
+        val enemyCiv = testGame.addCiv()
+        civInfo.diplomacyFunctions.makeCivilizationsMeet(enemyCiv)
+        civInfo.getDiplomacyManager(enemyCiv).declareWar()
+        val centerTile = testGame.getTile(Vector2(0f,0f))
+        val swampTile = testGame.getTile(Vector2(1f,1f))
+        val enemyTile = testGame.getTile(Vector2(2f,2f))
+        val scout = testGame.addUnit("Scout", civInfo, centerTile)
+        val civilianUnit = testGame.addUnit("Worker", civInfo, centerTile)
+        val enemyUnit = testGame.addUnit("Warrior", enemyCiv , enemyTile)
+        enemyUnit.health = 1 // Needs to be killable by the scout
+        swampTile.baseTerrain = "Swamp"
+        scout.startEscorting()
+        assertTrue(scout.isEscorting())
+        assertTrue(civilianUnit.isEscorting())
+        assertTrue(TargetHelper.getAttackableEnemies(scout, scout.movement.getDistanceToTiles()).isEmpty())
     }
 }

--- a/tests/src/com/unciv/logic/map/UnitFomationTests.kt
+++ b/tests/src/com/unciv/logic/map/UnitFomationTests.kt
@@ -2,10 +2,15 @@ package com.unciv.logic.map
 
 import com.badlogic.gdx.math.Vector2
 import com.unciv.Constants
+import com.unciv.logic.battle.Battle
+import com.unciv.logic.battle.MapUnitCombatant
 import com.unciv.logic.battle.TargetHelper
 import com.unciv.logic.civilization.Civilization
 import com.unciv.testing.GdxTestRunner
 import com.unciv.testing.TestGame
+import com.unciv.utils.DebugUtils
+import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -19,6 +24,11 @@ internal class UnitFormationTests {
     fun setUp(size: Int, baseTerrain: String = Constants.desert) {
         testGame.makeHexagonalMap(size)
         civInfo = testGame.addCiv()
+    }
+    
+    @After
+    fun wrapUp() {
+        DebugUtils.VISIBLE_MAP = false
     }
     
     @Test
@@ -198,19 +208,69 @@ internal class UnitFormationTests {
     }
 
     @Test
+    fun `test escort attack and move civilian unit`() {
+        setUp(3)
+        val enemyCiv = testGame.addCiv()
+        civInfo.diplomacyFunctions.makeCivilizationsMeet(enemyCiv)
+        civInfo.getDiplomacyManager(enemyCiv).declareWar()
+        val centerTile = testGame.getTile(Vector2(0f,0f))
+        val enemyTile = testGame.getTile(Vector2(2f,2f))
+        val scout = testGame.addUnit("Warrior", civInfo, centerTile)
+        val civilianUnit = testGame.addUnit("Worker", civInfo, centerTile)
+        val enemyUnit = testGame.addUnit("Warrior", enemyCiv , enemyTile)
+        enemyUnit.health = 1 // Needs to be killable by the scout
+        scout.startEscorting()
+        assertTrue(scout.isEscorting())
+        assertTrue(civilianUnit.isEscorting())
+
+        assertEquals(1, TargetHelper.getAttackableEnemies(scout, scout.movement.getDistanceToTiles()).count())
+        Battle.attack(MapUnitCombatant(scout), MapUnitCombatant(enemyUnit))
+        assertEquals(0, enemyUnit.health)
+        assertEquals(enemyTile, scout.getTile())
+        assertEquals(enemyTile, civilianUnit.getTile())
+        assertTrue(scout.isEscorting())
+        assertTrue(civilianUnit.isEscorting())
+    }
+
+    @Test
+    fun `test escort attack with ranged unit`() {
+        setUp(3)
+        val enemyCiv = testGame.addCiv()
+        DebugUtils.VISIBLE_MAP = true
+        civInfo.diplomacyFunctions.makeCivilizationsMeet(enemyCiv)
+        civInfo.getDiplomacyManager(enemyCiv).declareWar()
+        val centerTile = testGame.getTile(Vector2(0f,0f))
+        val enemyTile = testGame.getTile(Vector2(3f,3f))
+        val archer = testGame.addUnit("Archer", civInfo, centerTile)
+        val civilianUnit = testGame.addUnit("Worker", civInfo, centerTile)
+        val enemyUnit = testGame.addUnit("Warrior", enemyCiv , enemyTile)
+        enemyUnit.health = 1 // Needs to be killable by the scout
+        archer.startEscorting()
+        assertTrue(archer.isEscorting())
+        assertTrue(civilianUnit.isEscorting())
+
+        assertEquals(1, TargetHelper.getAttackableEnemies(archer, archer.movement.getDistanceToTiles()).count())
+        Battle.attack(MapUnitCombatant(archer), MapUnitCombatant(enemyUnit))
+        assertEquals(0, enemyUnit.health)
+        assertTrue(archer.isEscorting())
+        assertTrue(civilianUnit.isEscorting())
+        assertEquals(archer.getTile(), civilianUnit.getTile())
+    }
+
+    @Test
     fun `test escort attack with military unit having ignoreTerrainCost`() {
         setUp(3)
         val enemyCiv = testGame.addCiv()
         civInfo.diplomacyFunctions.makeCivilizationsMeet(enemyCiv)
         civInfo.getDiplomacyManager(enemyCiv).declareWar()
         val centerTile = testGame.getTile(Vector2(0f,0f))
-        val swampTile = testGame.getTile(Vector2(1f,1f))
+        val forestTile = testGame.getTile(Vector2(1f,1f))
         val enemyTile = testGame.getTile(Vector2(2f,2f))
-        val scout = testGame.addUnit("Scout", civInfo, centerTile)
+        val scout = testGame.addUnit("Warrior", civInfo, centerTile)
         val civilianUnit = testGame.addUnit("Worker", civInfo, centerTile)
         val enemyUnit = testGame.addUnit("Warrior", enemyCiv , enemyTile)
         enemyUnit.health = 1 // Needs to be killable by the scout
-        swampTile.baseTerrain = "Swamp"
+        forestTile.addTerrainFeature("Forest")
         scout.startEscorting()
         assertTrue(scout.isEscorting())
         assertTrue(civilianUnit.isEscorting())


### PR DESCRIPTION
Solves #11287. (This is the second option described in that issue; I thought it would be harder to implement)
This PR adds in an extra check for melee units' `getAttackableEnemies()`. A melee unit that is escorting may only attack a unit if the escorting unit can also move into the tile after it attacks.

<details><summary>Pictures</summary>
Scout without escorting, should be able to attack

![EscortAttackMovmentFix](https://github.com/yairm210/Unciv/assets/7538725/78307cc8-3ab0-4db3-a2d4-545928f99bbe)
Scout with escorting should not be able to attack

![EscortAttackMovmentFix2](https://github.com/yairm210/Unciv/assets/7538725/69f2fc1b-55ad-4c44-8ea0-7933a4ba2b0b)
</details> 

Note that it doesn't matter if the melee unit can actually kill the enemy unit or not. Either way, it won't be eligible to attack unless the player stops escorting.