### PR TITLE
Added multi filter support for BuildingFilter !!

### DIFF
--- a/android/assets/jsons/Civ V - Gods & Kings/Beliefs.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Beliefs.json
@@ -75,7 +75,9 @@
     {
         "name": "Monument to the Gods",
         "type": "Pantheon",
-        "uniques": ["[+15]% Production when constructing [All] wonders [in cities following this religion]"]
+        "uniques": [
+            "[+15]% Production when constructing [{Faith} {Ancient era}] wonders [in cities following this religion]",
+            "[+15]% Production when constructing [{Ancient era} {Military}] units [in cities following this religion]"]
         // ToDo: Should only be ancient/classical era wonders, but implementing that is another can of worms
         // For that we really should need an era.matchesFilter(), so we could write something like:
         //"uniques": ["[+15]% Production when constructing [Ancient era] wonders [in cities following this religion]",

--- a/android/assets/jsons/Civ V - Gods & Kings/Beliefs.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Beliefs.json
@@ -75,16 +75,8 @@
     {
         "name": "Monument to the Gods",
         "type": "Pantheon",
-        "uniques": [
-            "[+15]% Production when constructing [{Faith} {Ancient era}] wonders [in cities following this religion]",
-            "[+15]% Production when constructing [{Ancient era} {Military}] units [in cities following this religion]"]
-        // ToDo: Should only be ancient/classical era wonders, but implementing that is another can of worms
-        // For that we really should need an era.matchesFilter(), so we could write something like:
-        //"uniques": ["[+15]% Production when constructing [Ancient era] wonders [in cities following this religion]",
-        // "[+15]% Production when constructing [Classical era] wonders [in cities following this religion]"]
-        // For now this feels like overkill, but I'll leave this here for the future
-
-        // Alternatively, we could approximate this with "[+15]% Production when constructing [All] wonders [in all cities] <during the [Ancient era]>"
+        "uniques": ["[+15]% Production when constructing [Ancient era] wonders [in cities following this religion]",
+            "[+15]% Production when constructing [Classical era] wonders [in cities following this religion]"]
     },
     {
         "name": "One with Nature",

--- a/android/assets/jsons/Civ V - Gods & Kings/Policies.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Policies.json
@@ -85,7 +85,6 @@
                 "uniques": [
                     "[+1 Production] [in all cities]",
                     "[+5]% Production when constructing [All] buildings [in all cities]",
-                    "[+5]% Production when constructing [All] wonders [in all cities]"
                 ],
                 "row": 1,
                 "column": 1

--- a/android/assets/jsons/Civ V - Gods & Kings/Policies.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Policies.json
@@ -84,7 +84,8 @@
                 "name": "Republic",
                 "uniques": [
                     "[+1 Production] [in all cities]",
-                    "[+5]% Production when constructing [All] buildings [in all cities]"
+                    "[+5]% Production when constructing [All] buildings [in all cities]",
+                    "[+5]% Production when constructing [All] wonders [in all cities]"
                 ],
                 "row": 1,
                 "column": 1

--- a/android/assets/jsons/Civ V - Gods & Kings/TileResources.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/TileResources.json
@@ -1,4 +1,4 @@
-[	
+[
 	// Bonus resources
 	{
 		"name": "Cattle",
@@ -84,7 +84,7 @@
 		"improvementStats": {"production": 1}
 	},
 	*/
-	
+
 	// Strategic resources
 	{
 		"name": "Horses",
@@ -207,7 +207,7 @@
 		"majorDepositAmount": {"sparse": 2, "default": 4, "abundant": 4},
 		"minorDepositAmount": {"sparse": 1, "default": 2, "abundant": 3}
 	},
-	
+
 	// Luxury resources
 	{
 		"name": "Furs",
@@ -371,7 +371,8 @@
 		"gold": 2,
 		"improvement": "Quarry",
 		"improvementStats": {"production": 1},
-		"uniques": ["[+15]% Production when constructing [All] wonders [in all cities]",
+		"uniques": ["[+15]% Production when constructing [Ancient era] wonders [in this city]",
+                    "[+15]% Production when constructing [Classical era] wonders [in this city]",
 					"Special placement during map generation",
 					"Doesn't generate naturally <in [Grassland] [Fresh Water] tiles>"]
 	},
@@ -449,7 +450,7 @@
 					"Doesn't generate naturally <in [Jungle] tiles> <in tiles without [Hill]>",
 					"Doesn't generate naturally <in [Forest] tiles> <in tiles without [Hill]> <in tiles without [Tundra]>"]
 	},
-	/* 
+	/*
 	{
 		"name": "Cocoa",
 		"resourceType": "Luxury",

--- a/android/assets/jsons/Civ V - Vanilla/Policies.json
+++ b/android/assets/jsons/Civ V - Vanilla/Policies.json
@@ -104,7 +104,6 @@
                 "uniques": [
                     "[+1 Production] [in all cities]",
                     "[+5]% Production when constructing [All] buildings [in all cities]",
-                    "[+5]% Production when constructing [All] wonders [in all cities]"
                 ],
                 "requires": ["Collective Rule"],
                 "row": 2,
@@ -220,7 +219,6 @@
         },
         "uniques": [
             "[+15]% Production when constructing [Culture] buildings [in all cities]",
-            "[+15]% Production when constructing [Culture] wonders [in all cities]",
             "Only available <before adopting [Rationalism]>"
         ],
         "policies": [
@@ -657,7 +655,6 @@
                 "uniques": [
                     "[+1 Production] [in all cities]",
                     "[+10]% Production when constructing [All] buildings [in all cities]",
-                    "[+10]% Production when constructing [All] wonders [in all cities]",
                     "[+1 Production] from every [Quarry]"
                 ],
                 "row": 3,

--- a/android/assets/jsons/Civ V - Vanilla/Policies.json
+++ b/android/assets/jsons/Civ V - Vanilla/Policies.json
@@ -103,7 +103,8 @@
                 "name": "Republic",
                 "uniques": [
                     "[+1 Production] [in all cities]",
-                    "[+5]% Production when constructing [All] buildings [in all cities]"
+                    "[+5]% Production when constructing [All] buildings [in all cities]",
+                    "[+5]% Production when constructing [All] wonders [in all cities]"
                 ],
                 "requires": ["Collective Rule"],
                 "row": 2,
@@ -219,6 +220,7 @@
         },
         "uniques": [
             "[+15]% Production when constructing [Culture] buildings [in all cities]",
+            "[+15]% Production when constructing [Culture] wonders [in all cities]",
             "Only available <before adopting [Rationalism]>"
         ],
         "policies": [
@@ -655,6 +657,7 @@
                 "uniques": [
                     "[+1 Production] [in all cities]",
                     "[+10]% Production when constructing [All] buildings [in all cities]",
+                    "[+10]% Production when constructing [All] wonders [in all cities]",
                     "[+1 Production] from every [Quarry]"
                 ],
                 "row": 3,

--- a/android/assets/jsons/Civ V - Vanilla/TileResources.json
+++ b/android/assets/jsons/Civ V - Vanilla/TileResources.json
@@ -1,4 +1,4 @@
-[	
+[
 	// Bonus resources
 	{
 		"name": "Cattle",
@@ -86,7 +86,7 @@
 		"improvementStats": {"food": 1}
 	},
 	*/
-	
+
 	// Strategic resources
 	{
 		"name": "Horses",
@@ -384,7 +384,8 @@
 		"gold": 2,
 		"improvement": "Quarry",
 		"improvementStats": {"production": 1},
-		"uniques": ["[+15]% Production when constructing [All] wonders [in all cities]",
+		"uniques": ["[+15]% Production when constructing [Ancient era] wonders [in this city]",
+            "[+15]% Production when constructing [Classical era] wonders [in this city]",
 			"Special placement during map generation",
 			"Doesn't generate naturally <in [Grassland] [Fresh Water] tiles>"]
 	},

--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -621,6 +621,9 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
         for (baseUnit in ruleset.units.values)
             baseUnit.ruleset = ruleset
 
+        for (building in ruleset.buildings.values)
+            building.ruleset = ruleset
+
         // This needs to go before tileMap.setTransients, as units need to access
         // the nation of their civilization when setting transients
         for (civInfo in civilizations) civInfo.gameInfo = this

--- a/core/src/com/unciv/models/ruleset/Building.kt
+++ b/core/src/com/unciv/models/ruleset/Building.kt
@@ -54,6 +54,8 @@ class Building : RulesetStatsObject(), INonPerpetualConstruction {
     var quote: String = ""
     var replacementTextForUniques = ""
 
+    lateinit var ruleset: Ruleset
+
     override fun getUniqueTarget() = if (isAnyWonder()) UniqueTarget.Wonder else UniqueTarget.Building
 
     override fun makeLink() = if (isAnyWonder()) "Wonder/$name" else "Building/$name"
@@ -515,8 +517,10 @@ class Building : RulesetStatsObject(), INonPerpetualConstruction {
             replaces -> true
             else -> {
                 if (uniques.contains(filter)) return true
+                for (requiredTech: String in requiredTechs())
+                    if (ruleset.technologies[requiredTech]?.matchesFilter(filter) == true) return true
                 val stat = Stat.safeValueOf(filter)
-                return stat != null && isStatRelated(stat)
+                return (stat != null && isStatRelated(stat))
             }
         }
     }

--- a/core/src/com/unciv/models/ruleset/Building.kt
+++ b/core/src/com/unciv/models/ruleset/Building.kt
@@ -510,14 +510,13 @@ class Building : RulesetStatsObject(), INonPerpetualConstruction {
             name -> true
             "Building", "Buildings" -> !isAnyWonder()
             "Wonder", "Wonders" -> isAnyWonder()
-            "National Wonder" -> isNationalWonder
-            "World Wonder" -> isWonder
+            "National Wonder", "National" -> isNationalWonder
+            "World Wonder", "World" -> isWonder
             replaces -> true
             else -> {
                 if (uniques.contains(filter)) return true
                 val stat = Stat.safeValueOf(filter)
-                if (stat != null && isStatRelated(stat)) return true
-                return false
+                return stat != null && isStatRelated(stat)
             }
         }
     }

--- a/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
@@ -287,7 +287,7 @@ enum class UniqueParameterType(
 
     /** Implemented by [Building.matchesFilter][com.unciv.models.ruleset.Building.matchesFilter] */
     BuildingFilter("buildingFilter", "Culture") {
-        private val knownValues = mutableSetOf("Building", "Buildings", "Wonder", "Wonders", "National Wonder", "World Wonder")
+        private val knownValues = mutableSetOf("Building", "Buildings", "Wonder", "Wonders", "National Wonder", "National", "World Wonder", "World")
             .apply { addAll(Stat.names()); addAll(Constants.all) }
 
         override fun getErrorSeverity(parameterText: String, ruleset: Ruleset):

--- a/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
@@ -297,6 +297,7 @@ enum class UniqueParameterType(
             if (parameterText in knownValues) return true
             if (BuildingName.getErrorSeverity(parameterText, ruleset) == null) return true
             if (ruleset.buildings.values.any { it.hasUnique(parameterText) }) return true
+            if (ruleset.eras.containsKey(parameterText)) return true
             return false
         }
 

--- a/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
@@ -128,6 +128,7 @@ enum class UniqueParameterType(
             if (UnitName.getErrorSeverity(parameterText, ruleset) == null) return true
             if (ruleset.units.values.any { it.uniques.contains(parameterText) }) return true
             if (UnitTypeFilter.isKnownValue(parameterText, ruleset)) return true
+            if (TechFilter.isKnownValue(parameterText, ruleset)) return true
             return false
         }
 
@@ -145,7 +146,6 @@ enum class UniqueParameterType(
         override fun isKnownValue(parameterText: String, ruleset: Ruleset): Boolean {
             if (parameterText in knownValues) return true
             if (ruleset.unitTypes.containsKey(parameterText)) return true
-            if (ruleset.eras.containsKey(parameterText)) return true
             if (ruleset.unitTypes.values.any { it.uniques.contains(parameterText) }) return true
             return false
         }
@@ -297,7 +297,7 @@ enum class UniqueParameterType(
             if (parameterText in knownValues) return true
             if (BuildingName.getErrorSeverity(parameterText, ruleset) == null) return true
             if (ruleset.buildings.values.any { it.hasUnique(parameterText) }) return true
-            if (ruleset.eras.containsKey(parameterText)) return true
+            if (TechFilter.isKnownValue(parameterText, ruleset)) return true
             return false
         }
 

--- a/docs/Modders/Unique-parameters.md
+++ b/docs/Modders/Unique-parameters.md
@@ -72,7 +72,7 @@ The following are allowed to be used:
 - Matching [technologyfilter](#technologyfilter) for the tech this unit requires - e.g. `Modern Era`
 - Any exact unique the unit has
 - Any exact unique the unit type has
-- Any combination of the above (will match only if all match). The format is `{filter1} {filter2}` and can match any number of filters. For example: `
+- Any combination of the above (will match only if all match). The format is `{filter1} {filter2}` and can match any number of filters. For example: `[{Modern era} {Land}]` units
 
 ## mapUnitFilter
 
@@ -98,12 +98,14 @@ Allows to only activate a unique for certain buildings. Allowed options are:
 - `World Wonder`, `World` -- All wonders that are not national wonders
 - building name
 - The name of the building it replaces (so for example uniques for libraries will apply to paper makers as well)
-- an exact unique the building has (e.g.: `spaceship part`)
+- Matching [technologyfilter](#technologyfilter) for the tech this building requires - e.g. Modern Era
+- An exact unique the building has (e.g.: `spaceship part`)
 - `Culture`, `Gold`, etc. if the building is `stat-related` for that stat. Stat-related buildings are defined as one of the following:
     - Provides that stat directly (e.g. +1 Culture)
     - Provides a percentage bonus for that stat (e.g. +10% Production)
     - Provides that stat as a bonus for resources (e.g. +1 Food from every Wheat)
     - Provides that stat per some amount of population (e.g. +1 Science for every 2 population [cityFilter])
+- Any combination of the above (will match only if all match). The format is `{filter1} {filter2}` up to any number of filters. For example `[{Ancient era} {Food}]` buildings.
 
 ## cityFilter
 

--- a/docs/Modders/Unique-parameters.md
+++ b/docs/Modders/Unique-parameters.md
@@ -93,9 +93,9 @@ Allows to only activate a unique for certain buildings. Allowed options are:
 
 - `All`
 - `Buildings`, `Building`
-- `Wonders`, `Wonders`
-- `National Wonder`
-- `World Wonder` -- All wonders that are not national wonders
+- `Wonder`, `Wonders`
+- `National Wonder`, `National`
+- `World Wonder`, `World` -- All wonders that are not national wonders
 - building name
 - The name of the building it replaces (so for example uniques for libraries will apply to paper makers as well)
 - an exact unique the building has (e.g.: `spaceship part`)


### PR DESCRIPTION
<b>Finally</b> Here it comes !!!  BuildingFilter can now include techFilter to form multiple filters within a single unique, similar to baseUnitFilter. While it might seem like a simple fix, it actually took me several days to thoroughly read and understand the entire unique system.😖🥴

So Now, the problem regarding the 'Monument to the Gods' pantheon and 'Marbles' has finally been resolved. Please refer to the attached references below :
- https://civilization.fandom.com/wiki/Marble_(Civ5)
- https://civilization.fandom.com/wiki/Religion_(Civ5)#Pantheons

The updated buildingFilter has been tested with the following uniques :

`"[+11]% Production when constructing [{Faith} {Calendar} {Ancient era}] wonders [in all cities]", // stonehenge`
`"[+12]% Production when constructing [{Science} {Writing} {Ancient era}] wonders [in all cities]", // great library`
`"[+13]% Production when constructing [{Science} {Writing}] buildings [in all cities]", // library`
`"[+14]% Production when constructing [{Ancient era} {Food}] buildings [in all cities]", // granary and water mill`
`"[+15]% Production when constructing [{non-[Culture]} {non-[Food]} {Faith} {Ancient era}] buildings [in all cities]", // shrine`