### PR TITLE
Remove comments of the terrain colors, and enhance tundra color

### DIFF
--- a/android/assets/jsons/Civ V - Gods & Kings/Terrains.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Terrains.json
@@ -13,7 +13,7 @@
 		"type": "Water",
 		"food": 1,
 		"movementCost": 1,
-		"RGB": [70, 138, 216], //Darker87, 139, 199  Lighter59, 137, 227
+		"RGB": [70, 138, 216],
 		"uniques": ["[+2] to Fertility for Map Generation",
             "Considered [Desirable] when determining start locations <on water maps>",
             "Every [60] tiles with this terrain will receive a major deposit of a strategic resource."]
@@ -76,7 +76,7 @@
 		"type": "Land",
 		"food": 1,
 		"movementCost": 1,
-		"RGB": [30, 113, 69],
+		"RGB": [124, 62, 57],
 		"uniques": ["Occurs at temperature between [-0.9] and [-0.6] and humidity between [0.8] and [1]",
             "Occurs at temperature between [-0.8] and [-0.5] and humidity between [0.6] and [0.8]",
             "Occurs at temperature between [-0.7] and [-0.4] and humidity between [0.4] and [0.6]",

--- a/android/assets/jsons/Civ V - Vanilla/Terrains.json
+++ b/android/assets/jsons/Civ V - Vanilla/Terrains.json
@@ -13,7 +13,7 @@
 		"type": "Water",
 		"food": 1,
 		"movementCost": 1,
-		"RGB": [70, 138, 216], //Darker87, 139, 199  Lighter59, 137, 227
+		"RGB": [70, 138, 216],
 		"uniques": ["[+2] to Fertility for Map Generation",
 			"Considered [Desirable] when determining start locations <on water maps>",
 			"Every [60] tiles with this terrain will receive a major deposit of a strategic resource."]
@@ -76,7 +76,7 @@
 		"type": "Land",
 		"food": 1,
 		"movementCost": 1,
-		"RGB": [30, 113, 69],
+		"RGB": [124, 62, 57],
 		"uniques": ["Occurs at temperature between [-0.9] and [-0.6] and humidity between [0.8] and [1]",
 			"Occurs at temperature between [-0.8] and [-0.5] and humidity between [0.6] and [0.8]",
 			"Occurs at temperature between [-0.7] and [-0.4] and humidity between [0.4] and [0.6]",
@@ -140,7 +140,7 @@
 		"name": "Snow",
 		"type": "Land",
 		"movementCost": 1,
-		"RGB": [230, 238, 255], //Darker229, 229, 255
+		"RGB": [230, 238, 255],
 		"uniques": ["Occurs at temperature between [-1] and [-0.9] and humidity between [0] and [1]",
 			"Occurs at temperature between [-0.9] and [-0.8] and humidity between [0] and [0.8]",
 			"Occurs at temperature between [-0.8] and [-0.7] and humidity between [0] and [0.6]",


### PR DESCRIPTION
I forgot that I left out these alternative colors there. Those were to save them in case you wanted a darker/lighter color.

And, after hearing some complaints that Tundra color was too green and is easily mistake with grassland, which is very true, I present you a very distinct color for easy Tundra recognition on a mini map.
*If you are not willing to change it once again, then I'll remove it no problem.

<details><summary>Images to compare</summary>
<p>

![image](https://github.com/yairm210/Unciv/assets/78449553/2fbe46ab-a4ea-4723-acff-ca01be57b218)

![image](https://github.com/yairm210/Unciv/assets/78449553/b2181e32-dbed-4df2-ac97-901c0d278877)


</p>
</details> 