### PR TITLE
Add UnitActionModifier for Stockpile Cost

### DIFF
--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -513,6 +513,8 @@ enum class UniqueType(
         docDescription = "Requires [amount] of Movement to execute. Unit's Movement is rounded up"),
     UnitActionStatsCost("costs [stats] stats", UniqueTarget.UnitActionModifier,
         docDescription = "A positive Integer value will be subtracted from your stock. Food and Production will be removed from Closest City's current stock"),
+    UnitActionStockpileCost("costs [amount] [stockpiledResource]", UniqueTarget.UnitActionModifier,
+        docDescription = "A positive Integer value will be subtracted from your stock."),
     UnitActionOnce("once", UniqueTarget.UnitActionModifier),
     UnitActionLimitedTimes("[amount] times", UniqueTarget.UnitActionModifier),
     UnitActionExtraLimitedTimes("[amount] additional time(s)", UniqueTarget.UnitActionModifier),

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -302,7 +302,7 @@ enum class UniqueType(
      * @see [OnlyAvailable]
      */
     CanOnlyBeBuiltWhen("Can only be built", UniqueTarget.Building, UniqueTarget.Unit,
-        docDescription = "Meant to be used together with conditionals, like \"Can only be built <after adopting [policy]> <while the empire is happy>\". Only allows Building when ALL conditionals are met. Will also NOT block Upgrade and Transform actions. See also OnlyAvailable"),
+        docDescription = "Meant to be used together with conditionals, like \"Can only be built <after adopting [policy]> <while the empire is happy>\". Only allows Building when ALL conditionals are met. Will also NOT block Upgrade and Transform actions. See also OnlyAvailable."),
 
     MustHaveOwnedWithinTiles("Must have an owned [tileFilter] within [amount] tiles", UniqueTarget.Building),
 

--- a/core/src/com/unciv/models/stats/Stats.kt
+++ b/core/src/com/unciv/models/stats/Stats.kt
@@ -186,9 +186,9 @@ open class Stats(
     }
 
     /** Return a string of just +/- value and Stat symbol*/
-    fun toStringOnlyIcons(plusSign: Boolean = true): String {
+    fun toStringOnlyIcons(addPlusSign: Boolean = true): String {
         return this.joinToString {
-            (if (plusSign && it.value > 0) "+" else "") + it.value.toInt() + " " + it.key.character
+            (if (addPlusSign && it.value > 0) "+" else "") + it.value.toInt() + " " + it.key.character
         }
     }
 

--- a/core/src/com/unciv/models/stats/Stats.kt
+++ b/core/src/com/unciv/models/stats/Stats.kt
@@ -186,9 +186,9 @@ open class Stats(
     }
 
     /** Return a string of just +/- value and Stat symbol*/
-    fun toStringOnlyIcons(): String {
+    fun toStringOnlyIcons(plusSign: Boolean = true): String {
         return this.joinToString {
-            (if (it.value > 0) "+" else "") + it.value.toInt() + " " + it.key.character
+            (if (plusSign && it.value > 0) "+" else "") + it.value.toInt() + " " + it.key.character
         }
     }
 

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionModifiers.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionModifiers.kt
@@ -67,16 +67,9 @@ object UnitActionModifiers {
         for (conditional in actionUnique.conditionals.filter { it.type == UniqueType.UnitActionStockpileCost }) {
             val amount = conditional.params[0].toInt()
             val resourceName = conditional.params[1]
-            if (!unit.civ.resourceStockpiles.containsKey(resourceName) || unit.civ.resourceStockpiles[resourceName] < amount) {
-//                 if (!unit.civ.resourceStockpiles.containsKey(resourceName)) {
-//                     println("cannot find $resourceName")
-//                 } else {
-//                     println("$resourceName=${unit.civ.resourceStockpiles[resourceName]} < $amount")
-//                 }
+            if (unit.civ.getCivResourcesByName()[resourceName]!! < amount) {
                 return false
             }
-//             if (unit.civ.resourceStockpiles.containsKey(resourceName))
-//                 println("$resourceName=${unit.civ.resourceStockpiles[resourceName]}")
         }
         return true
     }
@@ -172,7 +165,7 @@ object UnitActionModifiers {
         if (actionUnique.conditionals.any { it.type == UniqueType.UnitActionStockpileCost }) {
             var stockpileString = ""
             for (conditionals in actionUnique.conditionals.filter { it.type == UniqueType.UnitActionStockpileCost })
-                stockpileString += " ${-conditionals.params[0].toInt()} ${conditionals.params[1]}"
+                stockpileString += " ${-conditionals.params[0].toInt()} [${conditionals.params[1]}]"
             effects += stockpileString.drop(1) // drop leading space
         }
 

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionModifiers.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionModifiers.kt
@@ -159,13 +159,13 @@ object UnitActionModifiers {
             val statCost = Stats()
             for (conditional in actionUnique.conditionals.filter { it.type == UniqueType.UnitActionStatsCost })
                 statCost.add(conditional.stats)
-            effects += (statCost * -1).toStringOnlyIcons()
+            effects += statCost.toStringOnlyIcons(false)
         }
 
         if (actionUnique.conditionals.any { it.type == UniqueType.UnitActionStockpileCost }) {
             var stockpileString = ""
             for (conditionals in actionUnique.conditionals.filter { it.type == UniqueType.UnitActionStockpileCost })
-                stockpileString += " ${-conditionals.params[0].toInt()} [${conditionals.params[1]}]"
+                stockpileString += " ${conditionals.params[0].toInt()} [${conditionals.params[1]}]"
             effects += stockpileString.drop(1) // drop leading space
         }
 

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionModifiers.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionModifiers.kt
@@ -63,13 +63,34 @@ object UnitActionModifiers {
         return true
     }
 
+    private fun canSpendStockpileCost(unit: MapUnit, actionUnique: Unique): Boolean {
+        for (conditional in actionUnique.conditionals.filter { it.type == UniqueType.UnitActionStockpileCost }) {
+            val amount = conditional.params[0].toInt()
+            val resourceName = conditional.params[1]
+            if (!unit.civ.resourceStockpiles.containsKey(resourceName) || unit.civ.resourceStockpiles[resourceName] < amount) {
+//                 if (!unit.civ.resourceStockpiles.containsKey(resourceName)) {
+//                     println("cannot find $resourceName")
+//                 } else {
+//                     println("$resourceName=${unit.civ.resourceStockpiles[resourceName]} < $amount")
+//                 }
+                return false
+            }
+//             if (unit.civ.resourceStockpiles.containsKey(resourceName))
+//                 println("$resourceName=${unit.civ.resourceStockpiles[resourceName]}")
+        }
+        return true
+    }
+
     /**Checks if this Action Unique can be executed, based on action modifiers
+     * @param unit: The specific unit executing the Action
+     * @param actionUnique: Unique that defines the Action
      * @return Boolean
      */
     fun canActivateSideEffects(unit: MapUnit, actionUnique: Unique): Boolean {
         return canUse(unit, actionUnique)
             && getMovementPointsRequired(actionUnique) <= ceil(unit.currentMovement).toInt()
             && canSpendStatsCost(unit, actionUnique)
+            && canSpendStockpileCost(unit, actionUnique)
     }
 
     fun activateSideEffects(unit: MapUnit, actionUnique: Unique, defaultAllMovement: Boolean = false) {
@@ -96,6 +117,11 @@ object UnitActionModifiers {
                             unit.civ.addStat(stat, -value.toInt())
                         } else unit.getClosestCity()?.addStat(stat, -value.toInt())
                     }
+                }
+                UniqueType.UnitActionStockpileCost -> {
+                    val amount = conditional.params[0].toInt()
+                    val resourceName = conditional.params[1]
+                    unit.civ.resourceStockpiles.add(resourceName, -amount)
                 }
                 else -> continue
             }
@@ -141,6 +167,13 @@ object UnitActionModifiers {
             for (conditional in actionUnique.conditionals.filter { it.type == UniqueType.UnitActionStatsCost })
                 statCost.add(conditional.stats)
             effects += (statCost * -1).toStringOnlyIcons()
+        }
+
+        if (actionUnique.conditionals.any { it.type == UniqueType.UnitActionStockpileCost }) {
+            var stockpileString = ""
+            for (conditionals in actionUnique.conditionals.filter { it.type == UniqueType.UnitActionStockpileCost })
+                stockpileString += " ${-conditionals.params[0].toInt()} ${conditionals.params[1]}"
+            effects += stockpileString.drop(1) // drop leading space
         }
 
         if (actionUnique.conditionals.any { it.type == UniqueType.UnitActionConsumeUnit }

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionModifiers.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionModifiers.kt
@@ -67,7 +67,7 @@ object UnitActionModifiers {
         for (conditional in actionUnique.conditionals.filter { it.type == UniqueType.UnitActionStockpileCost }) {
             val amount = conditional.params[0].toInt()
             val resourceName = conditional.params[1]
-            if (unit.civ.getCivResourcesByName()[resourceName]!! < amount) {
+            if (unit.civ.getResourceAmount(resourceName) < amount) {
                 return false
             }
         }
@@ -114,7 +114,8 @@ object UnitActionModifiers {
                 UniqueType.UnitActionStockpileCost -> {
                     val amount = conditional.params[0].toInt()
                     val resourceName = conditional.params[1]
-                    unit.civ.resourceStockpiles.add(resourceName, -amount)
+                    if(unit.civ.getCivResourcesByName()[resourceName] != null)
+                        unit.civ.resourceStockpiles.add(resourceName, -amount)
                 }
                 else -> continue
             }
@@ -165,8 +166,8 @@ object UnitActionModifiers {
         if (actionUnique.conditionals.any { it.type == UniqueType.UnitActionStockpileCost }) {
             var stockpileString = ""
             for (conditionals in actionUnique.conditionals.filter { it.type == UniqueType.UnitActionStockpileCost })
-                stockpileString += " ${conditionals.params[0].toInt()} [${conditionals.params[1]}]"
-            effects += stockpileString.drop(1) // drop leading space
+                stockpileString += " ${conditionals.params[0].toInt()} {${conditionals.params[1]}}"
+            effects += stockpileString.removePrefix(" ") // drop leading space
         }
 
         if (actionUnique.conditionals.any { it.type == UniqueType.UnitActionConsumeUnit }


### PR DESCRIPTION
Add Stockpile Resource Costs to any Action!
![image](https://github.com/yairm210/Unciv/assets/44038014/ec6fceb4-1843-455d-a69a-72873909a681)
Also flip the signs for Action cost to be more consistent. Positive value for Movement means it will cost X Movement, similarly Positive Food will cost (remove) that amount of Food