### PR TITLE
Fix loop when AI is trying to remove an improvement with the same name as a terrain feature

### DIFF
--- a/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
@@ -368,7 +368,7 @@ class WorkerAutomation(
         return ruleSet.tileImprovements[improvementString] // For mods, the tile improvement may not exist, so don't assume.
     }
 
-    private fun getImprovementRanking(tile: Tile, unit: MapUnit, improvement: String, localUniqueCache: LocalUniqueCache): Float {
+    private fun getImprovementRanking(tile: Tile, unit: MapUnit, improvementName: String, localUniqueCache: LocalUniqueCache): Float {
         val improvement = ruleSet.tileImprovements[improvementName]!!
 
         // Add the value of roads if we want to build it here

--- a/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
@@ -320,7 +320,7 @@ class WorkerAutomation(
         val localUniqueCache = LocalUniqueCache()
 
         var bestBuildableImprovement = potentialTileImprovements.values.asSequence()
-            .map { Pair(it, getImprovementRanking(tile, unit,it.name, localUniqueCache)) }
+            .map { Pair(it, getImprovementRanking(tile, unit, it.name, localUniqueCache)) }
             .filter { it.second > 0f }
             .maxByOrNull { it.second }?.first
 
@@ -341,8 +341,8 @@ class WorkerAutomation(
                 && isRemovable(lastTerrain)
                 && !tile.providesResources(civInfo)
                 && !isResourceImprovementAllowedOnFeature(tile, potentialTileImprovements) -> Constants.remove + lastTerrain.name
-            else -> tile.tileResource.getImprovements().filter { it in potentialTileImprovements || it==tile.improvement }
-                .maxByOrNull { getImprovementRanking(tile, unit,it, localUniqueCache) }
+            else -> tile.tileResource.getImprovements().filter { it in potentialTileImprovements || it == tile.improvement }
+                .maxByOrNull { getImprovementRanking(tile, unit, it, localUniqueCache) }
         }
 
         // After gathering all the data, we conduct the hierarchy in one place
@@ -354,7 +354,7 @@ class WorkerAutomation(
             bestBuildableImprovement == null -> null
 
             tile.improvement != null &&
-                    getImprovementRanking(tile, unit, tile.improvement!!, localUniqueCache) > getImprovementRanking(tile, unit,bestBuildableImprovement.name, localUniqueCache)
+                    getImprovementRanking(tile, unit, tile.improvement!!, localUniqueCache) > getImprovementRanking(tile, unit, bestBuildableImprovement.name, localUniqueCache)
                 -> null // What we have is better, even if it's pillaged we should repair it
 
             lastTerrain.let {
@@ -368,7 +368,7 @@ class WorkerAutomation(
         return ruleSet.tileImprovements[improvementString] // For mods, the tile improvement may not exist, so don't assume.
     }
 
-    private fun getImprovementRanking(tile: Tile, unit: MapUnit, improvementName: String, localUniqueCache: LocalUniqueCache): Float {
+    private fun getImprovementRanking(tile: Tile, unit: MapUnit, improvement: String, localUniqueCache: LocalUniqueCache): Float {
         val improvement = ruleSet.tileImprovements[improvementName]!!
 
         // Add the value of roads if we want to build it here
@@ -394,15 +394,22 @@ class WorkerAutomation(
 
         val stats = tile.stats.getStatDiffForImprovement(improvement, civInfo, tile.getCity(), localUniqueCache)
 
-        if (improvementName.startsWith("Remove ")) {
+        if (improvementName.startsWith(Constants.remove)) {
             // We need to look beyond what we are doing right now and at the final improvement that will be on this tile
-            val terrainName = improvementName.replace("Remove ", "")
-            if (ruleSet.terrains.containsKey(terrainName)) { // Otherwise we get an infinite loop with remove roads
-                tile.removeTerrainFeature(terrainName)
-                val wantedFinalImprovement = chooseImprovement(unit, tile)
+            val removedObject = improvementName.replace(Constants.remove, "")
+            val removedFeature = tile.terrainFeatures.firstOrNull { it == removedObject }
+            val removedImprovement = if (removedObject == tile.improvement) removedObject else null
+            
+            if (removedFeature != null || removedImprovement != null) {
+                val newTile = tile.clone()
+                newTile.setTerrainTransients()
+                if (removedFeature != null)
+                    newTile.removeTerrainFeature(removedFeature)
+                if (removedImprovement != null)
+                    newTile.removeImprovement()
+                val wantedFinalImprovement = chooseImprovement(unit, newTile)
                 if (wantedFinalImprovement != null)
-                    stats.add(tile.stats.getStatDiffForImprovement(wantedFinalImprovement, civInfo, tile.getCity(), localUniqueCache))
-                tile.addTerrainFeature(terrainName)
+                    stats.add(newTile.stats.getStatDiffForImprovement(wantedFinalImprovement, civInfo, newTile.getCity(), localUniqueCache))
             }
         }
 


### PR DESCRIPTION
Fixes related bug: AI couldn't evaluate removals that removed improvements

Fixes related bug: AI evaluates logic on the actual tile and not a clone. Idk if this actually is an issue yet, but it could be with that removal. Here, it actually tries to remove a feature that was never there originally, and would've added it back in. Though I guess it doesn't matter this time

Fixes #11350

Man, this scenario is a bit convoluted almost solely because the improvement shares a name. At the very least, there's at least some level of justification for fixing it and not saying this is just a mod error