### PR TITLE
Remove mod blacklist for really outdated mods

### DIFF
--- a/android/assets/jsons/ManuallyBlockedMods.json
+++ b/android/assets/jsons/ManuallyBlockedMods.json
@@ -1,6 +1,0 @@
-[
-    "https://github.com/k4zoo/Civ5ExpansionMod",
-    "https://github.com/k4zoo/Civilization-6-Mod",
-    "https://github.com/k4zoo/EmpireOfSmokySkies",
-    "https://github.com/ID1m0nI/PolyCiv"
-]

--- a/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
+++ b/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
@@ -412,7 +412,7 @@ class RulesetValidator(val ruleset: Ruleset) {
                 && improvement.name != Constants.cancelImprovementOrder
             ) {
                 lines.add(
-                    "${improvement.name} has an empty `terrainsCanBeBuiltOn`, isn't allowed to only improve resources and isn't unbuildable! Support for this will soon end. Either give this the unique \"Unbuildable\", \"Can only be built to improve a resource\" or add \"Land\", \"Water\" or any other value to `terrainsCanBeBuiltOn`.",
+                    "${improvement.name} has an empty `terrainsCanBeBuiltOn`, isn't allowed to only improve resources. As such it isn't buildable! Either give this the unique \"Unbuildable\", \"Can only be built to improve a resource\", or add \"Land\", \"Water\" or any other value to `terrainsCanBeBuiltOn`.",
                     RulesetErrorSeverity.Warning, improvement
                 )
             }

--- a/core/src/com/unciv/ui/screens/modmanager/ModManagementScreen.kt
+++ b/core/src/com/unciv/ui/screens/modmanager/ModManagementScreen.kt
@@ -76,11 +76,6 @@ class ModManagementScreen private constructor(
         const val maxAllowedPreviewImageSize = 200f
         /** Github queries use this limit */
         const val amountPerPage = 100
-
-        val modsToHideAsUrl by lazy {
-            val blockedModsFile = Gdx.files.internal("jsons/ManuallyBlockedMods.json")
-            json().fromJsonFile(Array<String>::class.java, blockedModsFile)
-        }
     }
 
     // Since we're `RecreateOnResize`, preserve the portrait/landscape mode for our lifetime
@@ -317,11 +312,6 @@ class ModManagementScreen private constructor(
 
             if (onlineModInfo.containsKey(repo.name))
                 continue // we already got this mod in a previous download, since one has been added in between
-
-            // Mods we have manually decided to remove for instability are removed here
-            // If at some later point these mods are updated, we should definitely remove
-            // this piece of code. This is a band-aid, not a full solution.
-            if (repo.html_url in modsToHideAsUrl) continue
 
             val installedMod = RulesetCache.values.firstOrNull { it.name == repo.name }
             val isUpdatedVersionOfInstalledMod = installedMod?.modOptions?.let {


### PR DESCRIPTION
PR removes the blacklist for mods showing in the modmanager screen. This is not due to these mods being fixed or being moved to a new repo, but rather due to poor optics

- [k4zoo/EmpireOfSmokySkies](https://github.com/k4zoo/EmpireOfSmokySkies) and [ID1m0nI/PolyCiv](https://github.com/ID1m0nI/PolyCiv) are no longer relevant in any manner. Neither has enough stars to appear high in the list of mods, meaning that neither is worth our attention notifying they are nonfunctional (as there's plenty of other mods just as nonfunctional)
- Many of these mods wouldn't work even if they had an Eras file, making the stated goal redundant at this time
- The idea of a blacklist makes these mods look worse than they actually are. Typically, the idea of "blacklisted" mods implies the mods in question break some sort of terms of service or similar (e.g. some racist mod or something), when this list only exists to mention a technical issue. Even if the idea of a blacklist existed just in case, for these mods, it would be significantly better to give these mods a different label to make it clear they need fixing
- Hiding dead mods is sorta the worst solution here, as it means it's significantly less likely a mod gets moved to a new repo, similar to Deciv Redux (or any of the other "Redux" mods like that lord of the rings one)

One thing that does bother me is that there is no actual error anymore stating that the ruleset combination doesn't have an eras file. Instead the number of errors is unnecessarily inflated by complaining about every single tech in the mod. I'm not sure if this is intentional or not, so I haven't added it to the PR at the time of writing this OP.

Also, About that warning that I edited... I think "soon" probably passed already. Could be wrong. I'm not sure the point in claiming its unsupported (or even escalating to an error). What's the worst that'll happen? Slightly less optimized improvement checking? Actually, not even, because most of the suggested solutions go over the same amount or almost the same amount of code. Keeping the warning to more or less say "this seems unintentional", but otherwise it seems unnecessary