### PR TITLE
Allow AI to consider building stats more accurately

### DIFF
--- a/core/src/com/unciv/logic/city/CityStats.kt
+++ b/core/src/com/unciv/logic/city/CityStats.kt
@@ -633,4 +633,13 @@ class CityStats(val city: City) {
     }
 
     //endregion
+
+    fun getStatDifferenceFromBuilding(building: String): Stats {
+        val newCity = city.clone()
+        newCity.setTransients(city.civ)
+        newCity.cityConstructions.builtBuildings.add(building)
+        newCity.cityConstructions.setTransients()
+        newCity.cityStats.update(updateCivStats = false)
+        return newCity.cityStats.currentCityStats - currentCityStats
+    }
 }

--- a/core/src/com/unciv/models/ruleset/nation/Personality.kt
+++ b/core/src/com/unciv/models/ruleset/nation/Personality.kt
@@ -3,6 +3,7 @@ package com.unciv.models.ruleset.nation
 import com.unciv.Constants
 import com.unciv.models.ruleset.RulesetObject
 import com.unciv.models.ruleset.unique.UniqueTarget
+import com.unciv.models.stats.Stat
 import kotlin.reflect.KMutableProperty0
 
 /**
@@ -17,7 +18,21 @@ enum class PersonalityValue {
     Happiness,
     Faith,
     Military,
-    WarMongering,
+    WarMongering,;
+
+    companion object  {
+        operator fun get(stat: Stat): PersonalityValue {
+            return when (stat) {
+                Stat.Production -> Production
+                Stat.Food -> Food
+                Stat.Gold -> Gold
+                Stat.Science -> Science
+                Stat.Culture -> Culture
+                Stat.Happiness -> Happiness
+                Stat.Faith -> Faith
+            }
+        }
+    }
 }
 
 class Personality: RulesetObject() {


### PR DESCRIPTION
Address a part of #11264. Namely, it makes it so that it considers buildings by what it expects the stat change will be. There likely are some cracks this has that the old version didn't (e.g., this PR no longer considers if a building will give stats to a tile), but this should overall make the AIs smarter than before. It should also integrate better with Personalities