### PR TITLE
Allow AI civilian unit to consider other triggerable uniques

### DIFF
--- a/core/src/com/unciv/logic/automation/unit/CivilianUnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/CivilianUnitAutomation.kt
@@ -7,6 +7,7 @@ import com.unciv.logic.map.tile.Tile
 import com.unciv.models.UnitActionType
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.ui.screens.worldscreen.unit.actions.UnitActions
+import com.unciv.ui.screens.worldscreen.unit.actions.UnitActionsFromUniques
 
 object CivilianUnitAutomation {
 
@@ -105,7 +106,6 @@ object CivilianUnitAutomation {
                 return
         }
 
-
         // This has to come after the individual abilities for the great people that can also place
         // instant improvements (e.g. great scientist).
         if (unit.hasUnique(UniqueType.ConstructImprovementInstantly)) {
@@ -116,6 +116,10 @@ object CivilianUnitAutomation {
             if (!improvementCanBePlacedEventually)
                 UnitActions.invokeUnitAction(unit, UnitActionType.StartGoldenAge)
         }
+
+        // if none of the conditions above are met,
+        // AI will attempt to activate the first triggerable unique whenever it is available.
+        UnitActionsFromUniques.getTriggerUniqueActions(unit, unit.getTile()).firstOrNull()?.action?.invoke()
 
         // TODO: The AI tends to have a lot of great generals. Maybe there should be a cutoff
         //  (depending on number of cities) and after that they should just be used to start golden

--- a/core/src/com/unciv/logic/automation/unit/CivilianUnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/CivilianUnitAutomation.kt
@@ -77,9 +77,13 @@ object CivilianUnitAutomation {
 
         val isLateGame = isLateGame(unit.civ)
         // Great scientist -> Hurry research if late game
+        // Great writer -> Hurry policy  if late game
         if (isLateGame) {
             val hurriedResearch = UnitActions.invokeUnitAction(unit, UnitActionType.HurryResearch)
             if (hurriedResearch) return
+
+            val hurriedPolicy = UnitActions.invokeUnitAction(unit, UnitActionType.HurryPolicy)
+            if (hurriedPolicy) return
         }
 
         // Great merchant -> Conduct trade mission if late game and if not at war.

--- a/core/src/com/unciv/logic/automation/unit/CivilianUnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/CivilianUnitAutomation.kt
@@ -146,10 +146,6 @@ object CivilianUnitAutomation {
             return
         }
 
-        // if none of the conditions above are met,
-        // AI will attempt to activate the first triggerable unique whenever it is available.
-        UnitActionsFromUniques.getTriggerUniqueActions(unit, unit.getTile()).firstOrNull()?.action?.invoke()
-
         // TODO: The AI tends to have a lot of great generals. Maybe there should be a cutoff
         //  (depending on number of cities) and after that they should just be used to start golden
         //  ages?


### PR DESCRIPTION
Currently, the AI automation for civilian units only support a limited range of unit actions associated with the base ruleset, such as conducting trade routes or spreading religion but it does not consider for other triggerable uniques like free unit appears or gain free building. Consequently, moddable civilian units that have these uniques will remain idle and done nothing. This PR has address the problem.