### PR TITLE
Fixed Ships not being able to move into one size lakes connected by a city

### DIFF
--- a/core/src/com/unciv/logic/map/mapunit/movement/UnitMovement.kt
+++ b/core/src/com/unciv/logic/map/mapunit/movement/UnitMovement.kt
@@ -96,10 +96,9 @@ class UnitMovement(val unit: MapUnit) {
             val damageFreePath = getShortestPath(destination, true)
             if (damageFreePath.isNotEmpty()) return damageFreePath
         }
-        if (unit.baseUnit.isWaterUnit()
-            && destination.neighbors.none { isUnknownTileWeShouldAssumeToBePassable(it) || it.isWater }) {
-            // edge case where this unit is a boat and all of the tiles around the destination are
-            // explored and known to be land so we know a priori that no path exists
+        if (destination.neighbors.none { isUnknownTileWeShouldAssumeToBePassable(it) || canPassThrough(it) }) {
+            // edge case where this all of the tiles around the destination are
+            // explored and known the unit can't pass through any of thoes tiles so we know a priori that no path exists
             pathfindingCache.setShortestPathCache(destination, listOf())
             return listOf()
         }


### PR DESCRIPTION
Related to #11148

The original problem lies in a peace of optimization code where a water unit won't move to a single water tile surrounded with land tile that has a city bridging it to the ocean.
This version simply uses canPassThrough() instead of isWater(). I also generalized it to be applicable to land units as well since it doesn't necessarily have to be water units.

<details><summary>After Picture</summary>

![SingleLakeTile](https://github.com/yairm210/Unciv/assets/7538725/35a0683b-8587-4adc-b8c5-4a979b7abc54)


</details> 