### PR TITLE
Workboats improve resources outside of city work range

### DIFF
--- a/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
@@ -399,7 +399,7 @@ class WorkerAutomation(
             val removedObject = improvementName.replace(Constants.remove, "")
             val removedFeature = tile.terrainFeatures.firstOrNull { it == removedObject }
             val removedImprovement = if (removedObject == tile.improvement) removedObject else null
-            
+
             if (removedFeature != null || removedImprovement != null) {
                 val newTile = tile.clone()
                 newTile.setTerrainTransients()
@@ -577,6 +577,9 @@ class WorkerAutomation(
     private fun hasWorkableSeaResource(tile: Tile, civInfo: Civilization): Boolean =
         tile.isWater && tile.improvement == null && tile.hasViewableResource(civInfo)
 
+    private fun isLuxuryResourceOrWorkable(tile:Tile, civInfo: Civilization): Boolean =
+        tile.tileResource.resourceType == ResourceType.Luxury || civInfo.cities.any { it.tilesInRange.contains(tile) }
+
     /** Try improving a Water Resource
      *
      *  No logic to avoid capture by enemies yet!
@@ -585,13 +588,13 @@ class WorkerAutomation(
      */
     fun automateWorkBoats(unit: MapUnit): Boolean {
         val closestReachableResource = unit.civ.cities.asSequence()
-            .flatMap { city -> city.getWorkableTiles() }
+            .flatMap { city -> city.getTiles() }
             .filter {
                 hasWorkableSeaResource(it, unit.civ)
                     && (unit.currentTile == it || unit.movement.canMoveTo(it))
             }
             .sortedBy { it.aerialDistanceTo(unit.currentTile) }
-            .firstOrNull { unit.movement.canReach(it) }
+            .firstOrNull { unit.movement.canReach(it) && isLuxuryResourceOrWorkable(it, unit.civ) }
             ?: return false
 
         // could be either fishing boats or oil well

--- a/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
@@ -577,7 +577,7 @@ class WorkerAutomation(
     private fun hasWorkableSeaResource(tile: Tile, civInfo: Civilization): Boolean =
         tile.isWater && tile.improvement == null && tile.hasViewableResource(civInfo)
 
-    private fun isLuxuryResourceOrWorkable(tile:Tile, civInfo: Civilization): Boolean =
+    private fun isNotBonusResourceOrWorkable(tile:Tile, civInfo: Civilization): Boolean =
         tile.tileResource.resourceType != ResourceType.Bonus || civInfo.cities.any { it.tilesInRange.contains(tile) }
 
     /** Try improving a Water Resource
@@ -594,7 +594,7 @@ class WorkerAutomation(
                     && (unit.currentTile == it || unit.movement.canMoveTo(it))
             }
             .sortedBy { it.aerialDistanceTo(unit.currentTile) }
-            .firstOrNull { unit.movement.canReach(it) && isLuxuryResourceOrWorkable(it, unit.civ) }
+            .firstOrNull { unit.movement.canReach(it) && isNotBonusResourceOrWorkable(it, unit.civ) }
             ?: return false
 
         // could be either fishing boats or oil well

--- a/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
@@ -578,7 +578,7 @@ class WorkerAutomation(
         tile.isWater && tile.improvement == null && tile.hasViewableResource(civInfo)
 
     private fun isLuxuryResourceOrWorkable(tile:Tile, civInfo: Civilization): Boolean =
-        tile.tileResource.resourceType == ResourceType.Luxury || civInfo.cities.any { it.tilesInRange.contains(tile) }
+        tile.tileResource.resourceType != ResourceType.Bonus || civInfo.cities.any { it.tilesInRange.contains(tile) }
 
     /** Try improving a Water Resource
      *

--- a/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
@@ -570,14 +570,14 @@ class WorkerAutomation(
             && evaluateFortSurroundings(tile, isCitadel) > 0
     }
 
-    fun isImprovementProbablyAFort(improvementName:String): Boolean = isImprovementProbablyAFort(ruleSet.tileImprovements[improvementName]!!)
+    fun isImprovementProbablyAFort(improvementName: String): Boolean = isImprovementProbablyAFort(ruleSet.tileImprovements[improvementName]!!)
     fun isImprovementProbablyAFort(improvement: TileImprovement): Boolean = improvement.hasUnique(UniqueType.DefensiveBonus)
 
 
     private fun hasWorkableSeaResource(tile: Tile, civInfo: Civilization): Boolean =
         tile.isWater && tile.improvement == null && tile.hasViewableResource(civInfo)
 
-    private fun isNotBonusResourceOrWorkable(tile:Tile, civInfo: Civilization): Boolean =
+    private fun isNotBonusResourceOrWorkable(tile: Tile, civInfo: Civilization): Boolean =
         tile.tileResource.resourceType != ResourceType.Bonus || civInfo.cities.any { it.tilesInRange.contains(tile) }
 
     /** Try improving a Water Resource


### PR DESCRIPTION
Solves #11189
Workboats now check every tile that a city owns for all resources, then when it looks at the closest resources it filters out bonus resources that are outside of working range.

<details><summary>Picture</summary>

![WorkboatLuxuryNonWorkable](https://github.com/yairm210/Unciv/assets/7538725/5fbc88da-39aa-4244-9744-94cac528d6e3)



</details> 