### PR TITLE
Improve diplomatic vote result screen

### DIFF
--- a/core/src/com/unciv/logic/civilization/managers/VictoryManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/VictoryManager.kt
@@ -81,13 +81,14 @@ class VictoryManager : IsPartOfGameInfoSerialization {
         return (results.none { it != bestCiv && it.value == bestCiv.value })
     }
 
-    fun getDiplomaticVictoryVoteBreakdown(): String {
+    data class DiplomaticVictoryVoteBreakdown(val results: Counter<String>, val winnerText: String)
+    fun getDiplomaticVictoryVoteBreakdown(): DiplomaticVictoryVoteBreakdown {
         val results = calculateDiplomaticVotingResults(civInfo.gameInfo.diplomaticVictoryVotesCast)
         val (voteCount, winnerList) = results.asSequence()
             .groupBy({ it.value }, { it.key }).asSequence()
             .sortedByDescending { it.key }  // key is vote count here
             .firstOrNull()
-            ?: return "No valid votes were cast."
+            ?: return DiplomaticVictoryVoteBreakdown(results, "No valid votes were cast.")
 
         val lines = arrayListOf<String>()
         val minVotes = votesNeededForDiplomaticVictory()
@@ -101,7 +102,7 @@ class VictoryManager : IsPartOfGameInfoSerialization {
             winnerCiv == civInfo -> "You have been elected world leader!"
             else -> "${winnerCiv.nation.getLeaderDisplayName()} has been elected world leader!"
         }
-        return lines.joinToString("\n") { "{$it}" }
+        return DiplomaticVictoryVoteBreakdown(results, lines.joinToString("\n") { "{$it}" })
     }
 
     fun getVictoryTypeAchieved(): String? {

--- a/core/src/com/unciv/ui/screens/pickerscreens/DiplomaticVoteResultScreen.kt
+++ b/core/src/com/unciv/ui/screens/pickerscreens/DiplomaticVoteResultScreen.kt
@@ -22,17 +22,20 @@ class DiplomaticVoteResultScreen(
 
     init {
         closeButton.remove()
+        topTable.pad(10f)
+        topTable.defaults().space(15f)
 
         val findUN = viewingCiv.victoryManager.getUNBuildingAndOwnerNames()
         constructionNameUN = findUN.first
         civOwningUN = findUN.second
 
-        val orderedCivs = gameInfo.getCivsSorted(civToSortFirst = viewingCiv)
-        for (civ in orderedCivs) addVote(civ)
+        val (results, winnerText) = viewingCiv.victoryManager.getDiplomaticVictoryVoteBreakdown()
 
-        val result = viewingCiv.victoryManager.getDiplomaticVictoryVoteBreakdown()
+        val orderedCivs = gameInfo.getCivsSorted(civToSortFirst = viewingCiv)
+        for (civ in orderedCivs) addVote(civ, results[civ.civName])
+
         descriptionLabel.setAlignment(Align.center)
-        descriptionLabel.setText(result.tr())
+        descriptionLabel.setText(winnerText.tr())
 
         rightSideButton.onActivation(UncivSound.Click) {
             viewingCiv.addFlag(CivFlags.ShowDiplomaticVotingResults.name, -1)
@@ -45,15 +48,16 @@ class DiplomaticVoteResultScreen(
         bottomTable.cells[0].minWidth(rightSideButton.prefWidth + 20f)  // center descriptionLabel
     }
 
-    private fun addVote(civ: Civilization) {
+    private fun addVote(civ: Civilization, votesReceived: Int) {
         val civName = civ.civName
 
-        topTable.add(ImageGetter.getNationPortrait(civ.nation, 30f)).pad(10f)
-        topTable.add(civName.toLabel(hideIcons = true)).pad(20f)
+        if (civ.isMajorCiv()) topTable.add(votesReceived.toLabel()) else topTable.add()
+
+        topTable.add(ImageGetter.getNationPortrait(civ.nation, 30f))
+        topTable.add(civName.toLabel(hideIcons = true)).padLeft(20f).padRight(20f)
 
         if (civName == civOwningUN && constructionNameUN != null) {
             topTable.add(ImageGetter.getConstructionPortrait(constructionNameUN, 30f))
-                .pad(10f)
             topTable.add("[2] votes".toLabel())
         } else {
             topTable.add("[1] vote".toLabel()).colspan(2)
@@ -66,8 +70,8 @@ class DiplomaticVoteResultScreen(
         val votedCiv = gameInfo.getCivilization(votedCivName)
         if (votedCiv.isDefeated()) return abstained()
 
-        topTable.add("Voted for".toLabel()).pad(20f).padRight(0f)
-        topTable.add(ImageGetter.getNationPortrait(votedCiv.nation, 30f)).pad(10f)
+        topTable.add("Voted for".toLabel()).padLeft(20f)
+        topTable.add(ImageGetter.getNationPortrait(votedCiv.nation, 30f))
         topTable.add(votedCiv.civName.toLabel(hideIcons = true))
         topTable.row()
     }


### PR DESCRIPTION
Fixes #11382 and tweaks the screen a little.

<details>

![image](https://github.com/yairm210/Unciv/assets/63000004/59be4922-e07b-4ebb-93a9-5d3b651c3445)

</details>

I hope that new number is self-evident enough without adding column headers.