### PR TITLE
Fix: New game screen, selection of mods from custom maps

### DIFF
--- a/core/src/com/unciv/ui/screens/newgamescreen/GameOptionsTable.kt
+++ b/core/src/com/unciv/ui/screens/newgamescreen/GameOptionsTable.kt
@@ -43,7 +43,7 @@ class GameOptionsTable(
     private val updatePlayerPickerRandomLabel: () -> Unit
 ) : Table(BaseScreen.skin) {
     var gameParameters = previousScreen.gameSetupInfo.gameParameters
-    val ruleset = previousScreen.ruleset
+    var ruleset = previousScreen.ruleset
     var locked = false
 
     private var baseRulesetHash = gameParameters.baseRuleset.hashCode()
@@ -444,6 +444,12 @@ class GameOptionsTable(
         add(victoryConditionsTable).colspan(2).row()
     }
 
+    fun updateRuleset(ruleset: Ruleset) {
+        this.ruleset = ruleset
+        gameParameters.acceptedModCheckErrors = ""
+        modCheckboxes.setBaseRuleset(gameParameters.baseRuleset)
+    }
+
     fun resetRuleset() {
         val rulesetName = BaseRuleset.Civ_V_GnK.fullName
         gameParameters.baseRuleset = rulesetName
@@ -460,6 +466,7 @@ class GameOptionsTable(
         ruleset.mods += gameParameters.baseRuleset
         ruleset.mods += gameParameters.mods
         ruleset.modOptions = newRuleset.modOptions
+        gameParameters.acceptedModCheckErrors = ""
 
         ImageGetter.setNewRuleset(ruleset)
         UncivGame.Current.musicController.setModList(gameParameters.getModsAndBaseRuleset())

--- a/core/src/com/unciv/ui/screens/newgamescreen/GameOptionsTable.kt
+++ b/core/src/com/unciv/ui/screens/newgamescreen/GameOptionsTable.kt
@@ -11,6 +11,7 @@ import com.unciv.logic.civilization.PlayerType
 import com.unciv.models.metadata.BaseRuleset
 import com.unciv.models.metadata.GameParameters
 import com.unciv.models.metadata.Player
+import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.ruleset.RulesetCache
 import com.unciv.models.ruleset.nation.Nation
 import com.unciv.models.ruleset.unique.UniqueType
@@ -45,6 +46,9 @@ class GameOptionsTable(
     val ruleset = previousScreen.ruleset
     var locked = false
 
+    private var baseRulesetHash = gameParameters.baseRuleset.hashCode()
+    private var selectedModsHash = gameParameters.mods.hashCode()
+
     /** Holds the UI for the Extension Mods
      *
      *  Attention: This Widget is a little tricky due to the UI changes to support portrait mode:
@@ -53,7 +57,7 @@ class GameOptionsTable(
      *
      *  The second reason this is public: [NewGameScreen] accesses [ModCheckboxTable.savedModcheckResult] for display.
      */
-    var modCheckboxes = getModCheckboxes(isPortrait = isPortrait)
+    val modCheckboxes = getModCheckboxes(isPortrait = isPortrait)
 
     // Remember this so we can unselect it when the pool dialog returns an empty pool
     private var randomNationsPoolCheckbox: CheckBox? = null
@@ -69,8 +73,18 @@ class GameOptionsTable(
 
     fun update() {
         clear()
-        // Mods may have changed
-        modCheckboxes = getModCheckboxes(isPortrait = isPortrait)
+
+        // Mods may have changed (e.g. custom map selection)
+        val newBaseRulesetHash = gameParameters.baseRuleset.hashCode()
+        if (newBaseRulesetHash != baseRulesetHash) {
+            baseRulesetHash = newBaseRulesetHash
+            modCheckboxes.setBaseRuleset(gameParameters.baseRuleset)
+        }
+        val newSelectedModsHash = gameParameters.mods.hashCode()
+        if (newSelectedModsHash != selectedModsHash) {
+            selectedModsHash = newSelectedModsHash
+            modCheckboxes.updateSelection(gameParameters.mods)
+        }
 
         add(Table().apply {
             defaults().pad(5f)

--- a/core/src/com/unciv/ui/screens/newgamescreen/MapFileSelectTable.kt
+++ b/core/src/com/unciv/ui/screens/newgamescreen/MapFileSelectTable.kt
@@ -131,8 +131,9 @@ class MapFileSelectTable(
         // Do NOT try to put back the "bad" preselection!
     }
 
-    private fun onSelectBoxChange() {
+    fun onSelectBoxChange() {
         cancelBackgroundJobs()
+        if (mapFileSelectBox.selection.isEmpty) return
         val mapFile = mapFileSelectBox.selected.fileHandle
         mapParameters.name = mapFile.name()
         newGameScreen.gameSetupInfo.mapFile = mapFile
@@ -140,7 +141,7 @@ class MapFileSelectTable(
         newGameScreen.gameSetupInfo.gameParameters.mods = LinkedHashSet(mapMods.second)
         newGameScreen.gameSetupInfo.gameParameters.baseRuleset = mapMods.first.firstOrNull()
             ?: mapFileSelectBox.selected.mapParameters.baseRuleset
-        val success = newGameScreen.tryUpdateRuleset()
+        val success = newGameScreen.tryUpdateRuleset(updateUI = true)
         newGameScreen.updateTables()
         hideMiniMap()
         if (success) {

--- a/core/src/com/unciv/ui/screens/newgamescreen/MapOptionsTable.kt
+++ b/core/src/com/unciv/ui/screens/newgamescreen/MapOptionsTable.kt
@@ -38,6 +38,7 @@ class MapOptionsTable(private val newGameScreen: NewGameScreen, isReset: Boolean
                 MapGeneratedMainType.custom -> {
                     mapParameters.type = MapGeneratedMainType.custom
                     mapTypeSpecificTable.add(savedMapOptionsTable)
+                    savedMapOptionsTable.onSelectBoxChange()
                     newGameScreen.unlockTables()
                 }
                 MapGeneratedMainType.generated -> {

--- a/core/src/com/unciv/ui/screens/newgamescreen/ModCheckboxTable.kt
+++ b/core/src/com/unciv/ui/screens/newgamescreen/ModCheckboxTable.kt
@@ -68,6 +68,18 @@ class ModCheckboxTable(
         setBaseRuleset(initialBaseRuleset)
     }
 
+    fun updateSelection(newMods: Collection<String>) {
+        savedModcheckResult = null
+        mods.clear()
+        mods.addAll(newMods)
+        disableChangeEvents = true
+        for (mod in modWidgets) {
+            mod.widget.isChecked = mod.mod.name in mods
+        }
+        disableChangeEvents = false
+        deselectIncompatibleMods(null)
+    }
+
     fun setBaseRuleset(newBaseRuleset: String) {
         baseRulesetName = newBaseRuleset
         savedModcheckResult = null
@@ -104,6 +116,7 @@ class ModCheckboxTable(
         mods.clear()
         disableChangeEvents = false
 
+        savedModcheckResult = null
         disableIncompatibleMods()
         onUpdate("-")  // should match no mod
     }
@@ -177,11 +190,10 @@ class ModCheckboxTable(
 
     /** Deselect incompatible mods after [skipCheckBox] was selected.
      *
-     *  Note: Inactive - we don'n even allow a conflict to be turned on using [disableIncompatibleMods].
+     *  Note: Inactive - we don't even allow a conflict to be turned on using [disableIncompatibleMods].
      *  But if we want the alternative UX instead - use this in [checkBoxChanged] near `mods.add` and skip disabling...
      */
-    @Suppress("unused")
-    private fun deselectIncompatibleMods(skipCheckBox: CheckBox) {
+    private fun deselectIncompatibleMods(skipCheckBox: CheckBox?) {
         disableChangeEvents = true
         for (modWidget in modWidgets) {
             if (modWidget.widget == skipCheckBox) continue

--- a/core/src/com/unciv/ui/screens/newgamescreen/ModCheckboxTable.kt
+++ b/core/src/com/unciv/ui/screens/newgamescreen/ModCheckboxTable.kt
@@ -47,6 +47,7 @@ class ModCheckboxTable(
     private var disableChangeEvents = false
 
     private val expanderPadTop = if (isPortrait) 0f else 16f
+    private val expanderPadOther = if (isPortrait) 0f else 10f
 
     init {
         val modRulesets = RulesetCache.values.filter {
@@ -88,7 +89,7 @@ class ModCheckboxTable(
             for (mod in compatibleMods) {
                 it.add(mod.widget).row()
             }
-        }).pad(10f).padTop(expanderPadTop).growX().row()
+        }).pad(expanderPadOther).padTop(expanderPadTop).growX().row()
 
         disableIncompatibleMods()
 

--- a/core/src/com/unciv/ui/screens/newgamescreen/NewGameScreen.kt
+++ b/core/src/com/unciv/ui/screens/newgamescreen/NewGameScreen.kt
@@ -61,7 +61,7 @@ class NewGameScreen(
     init {
         val isPortrait = isNarrowerThan4to3()
 
-        tryUpdateRuleset()  // must come before playerPickerTable so mod nations from fromSettings
+        tryUpdateRuleset(updateUI = false)  // must come before playerPickerTable so mod nations from fromSettings
 
         // remove the victory types which are not in the rule set (e.g. were in the recently disabled mod)
         gameSetupInfo.gameParameters.victoryTypes.removeAll { it !in ruleset.victories.keys }
@@ -365,7 +365,7 @@ class NewGameScreen(
      *
      *  @return Success - failure means gameSetupInfo was reset to defaults and the Ruleset was reverted to G&K
      */
-    fun tryUpdateRuleset(): Boolean {
+    fun tryUpdateRuleset(updateUI: Boolean): Boolean {
         var success = true
         fun handleFailure(message: String): Ruleset {
             success = false
@@ -388,6 +388,8 @@ class NewGameScreen(
         ruleset.add(newRuleset)
         ImageGetter.setNewRuleset(ruleset)
         game.musicController.setModList(gameSetupInfo.gameParameters.getModsAndBaseRuleset())
+
+        if (updateUI) newGameOptionsTable.updateRuleset(ruleset)
         return success
     }
 


### PR DESCRIPTION
The patch from the comment which fixes #11368, a little more tested.

* Approach - bidirectional sync data-view and add missing "events" (in the widest sense of the word - just function calls)
* I just hope mod compatibility constraints are handled sufficiently - too lazy to set up test scenarios
* When a map is loaded - the mod selection changes -> the UI widgets are now updated
* When user changes generated to custom - the map selectbox has a selection but the selection change code didn't run, does now
* There were still windows where the propagation of the "last ruleset validation errors" to UI and then the saved game could become outdated - not sure there are not more, but the changes here felt right.

Please any contributors reading this - double-check this code.