### PR TITLE
Allow Civilian units to promote

### DIFF
--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActions.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActions.kt
@@ -243,7 +243,7 @@ object UnitActions {
     }
 
     private suspend fun SequenceScope<UnitAction>.addPromoteActions(unit: MapUnit) {
-        if (unit.isCivilian() || !unit.promotions.canBePromoted()) return
+        if (!unit.promotions.canBePromoted()) return
         // promotion does not consume movement points, but is not allowed if a unit has exhausted its movement or has attacked
         yield(UnitAction(UnitActionType.Promote,
             useFrequency = 150f, // We want to show the player that they can promote


### PR DESCRIPTION
Should have next to no relevance in any ruleset. Built-in rulesets only give extra xp to military units, no civilian units have promotions to get (meaning this check was only good for optimization, but not modability), civilian units can't get xp from combat, and we could always adjust other stuff around this