### PR TITLE
Work boat construction automation tweaks

### DIFF
--- a/core/src/com/unciv/logic/automation/city/ConstructionAutomation.kt
+++ b/core/src/com/unciv/logic/automation/city/ConstructionAutomation.kt
@@ -196,17 +196,18 @@ class ConstructionAutomation(val cityConstructions: CityConstructions) {
         }
 
         // Search for a tile justifiying producing a Workboat
-        // todo Cheats - unexplored tiles are treated as known
-        // todo The constant 20 should be dynamic - moddable or depend on rules and/or game state? (e.g. more if a Workboat has >2 movement?)
+        // todo should workboatAutomationSearchMaxTiles depend on game state?
         fun findTileWorthImproving(): Boolean {
+            val searchMaxTiles = civInfo.gameInfo.ruleset.modOptions.constants.workboatAutomationSearchMaxTiles
             val bfs = BFS(city.getCenterTile()) {
                 (it.isWater || it.isCityCenter())
                     && (it.getOwner() == null || it.isFriendlyTerritory(civInfo))
+                    && it.isExplored(civInfo)  // Sending WB's through unexplored terrain would be cheating
             }
             do {
                 val tile = bfs.nextStep() ?: break
                 if (tile.isWorthImproving()) return true
-            } while (bfs.size() < 20)
+            } while (bfs.size() < searchMaxTiles)
             return false
         }
 

--- a/core/src/com/unciv/logic/automation/city/ConstructionAutomation.kt
+++ b/core/src/com/unciv/logic/automation/city/ConstructionAutomation.kt
@@ -174,11 +174,13 @@ class ConstructionAutomation(val cityConstructions: CityConstructions) {
                 it.hasUnique(UniqueType.CreateWaterImprovements)
                     && Automation.allowAutomatedConstruction(civInfo, city, it)
             }.filterBuildable()
-        if (buildableWorkboatUnits.none()) return
+            .toSet()
+        if (buildableWorkboatUnits.isEmpty()) return
 
         // Is there already a Workboat nearby?
-        // todo Checks only tiles belonging to this city irrespective of distance
-        val alreadyHasWorkBoat = city.getTiles().any {
+        // todo Still ignores whether that boat can reach the not-yet-found tile to improve
+        val twoTurnsMoves = buildableWorkboatUnits.maxOf { (it as BaseUnit).movement } * 2
+        val alreadyHasWorkBoat = city.getCenterTile().getTilesInDistanceRange(1..twoTurnsMoves).any {
                 it.civilianUnit?.hasUnique(UniqueType.CreateWaterImprovements) == true
             }
         if (alreadyHasWorkBoat) return

--- a/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
@@ -574,15 +574,9 @@ class WorkerAutomation(
     fun isImprovementProbablyAFort(improvement: TileImprovement): Boolean = improvement.hasUnique(UniqueType.DefensiveBonus)
 
 
-    private fun hasWorkableSeaResource(tile: Tile, civInfo: Civilization): Boolean =
-        tile.isWater && tile.improvement == null && tile.hasViewableResource(civInfo)
-
-    private fun isNotBonusResourceOrWorkable(tile: Tile, civInfo: Civilization): Boolean =
-        tile.tileResource.resourceType != ResourceType.Bonus || civInfo.cities.any { it.tilesInRange.contains(tile) }
-
     /** Try improving a Water Resource
      *
-     *  No logic to avoid capture by enemies yet!
+     *  todo: No logic to avoid capture by enemies yet!
      *
      *  @return Whether any progress was made (improved a tile or at least moved towards an opportunity)
      */
@@ -597,13 +591,38 @@ class WorkerAutomation(
             .firstOrNull { unit.movement.canReach(it) && isNotBonusResourceOrWorkable(it, unit.civ) }
             ?: return false
 
-        // could be either fishing boats or oil well
-        val isImprovable = closestReachableResource.tileResource.getImprovements().any()
-        if (!isImprovable) return false
-
         unit.movement.headTowards(closestReachableResource)
         if (unit.currentTile != closestReachableResource) return true // moving counts as progress
 
         return UnitActions.invokeUnitAction(unit, UnitActionType.CreateImprovement)
+    }
+
+    companion object {
+        // Static methods so they can be reused in ConstructionAutomation
+        /** Checks whether [tile] is water and has a resource [civInfo] can improve
+         *
+         *  Does check whether a matching improvement can currently be built (e.g. Oil before Refrigeration).
+         *  Can return `true` if there is an improvement that does not match the resource (for future modding abilities).
+         *  Does not check tile ownership - caller [automateWorkBoats] already did, other callers need to ensure this explicitly.
+         */
+        fun hasWorkableSeaResource(tile: Tile, civInfo: Civilization) = when {
+            !tile.isWater -> false
+            tile.resource == null -> false
+            tile.improvement != null && tile.tileResource.isImprovedBy(tile.improvement!!) -> false
+            !tile.hasViewableResource(civInfo) -> false
+            else -> tile.tileResource.getImprovements().any {
+                val improvement = civInfo.gameInfo.ruleset.tileImprovements[it]!!
+                tile.improvementFunctions.canBuildImprovement(improvement, civInfo)
+            }
+        }
+
+        /** Test whether improving the resource on [tile] benefits [civInfo] (yields or strategic or luxury)
+         *
+         *  Only tests resource type and city range, not any improvement requirements.
+         *  @throws NullPointerException on tiles without a resource
+         */
+        fun isNotBonusResourceOrWorkable(tile: Tile, civInfo: Civilization): Boolean =
+            tile.tileResource.resourceType != ResourceType.Bonus // Improve Oil even if no City reaps the yields
+                || civInfo.cities.any { it.tilesInRange.contains(tile) } // Improve Fish only if any of our Cities reaps the yields
     }
 }

--- a/core/src/com/unciv/logic/map/mapunit/movement/UnitMovement.kt
+++ b/core/src/com/unciv/logic/map/mapunit/movement/UnitMovement.kt
@@ -248,21 +248,27 @@ class UnitMovement(val unit: MapUnit) {
     }
 
     /** This is performance-heavy - use as last resort, only after checking everything else!
-     * Also note that REACHABLE tiles are not necessarily tiles that the unit CAN ENTER */
-    fun canReach(destination: Tile): Boolean {
-        if (unit.cache.cannotMove) return destination == unit.getTile()
-        if (unit.baseUnit.movesLikeAirUnits() || unit.isPreparingParadrop())
-            return canReachInCurrentTurn(destination)
-        return getShortestPath(destination).any()
+     *  Also note that REACHABLE tiles are not necessarily tiles that the unit CAN ENTER
+     *  @see canReachInCurrentTurn
+     */
+    fun canReach(destination: Tile) = canReachCommon(destination) {
+        getShortestPath(it).any()
     }
 
-    fun canReachInCurrentTurn(destination: Tile): Boolean {
-        if (unit.cache.cannotMove) return destination == unit.getTile()
-        if (unit.baseUnit.movesLikeAirUnits())
-            return unit.currentTile.aerialDistanceTo(destination) <= unit.getMaxMovementForAirUnits()
-        if (unit.isPreparingParadrop())
-            return unit.currentTile.aerialDistanceTo(destination) <= unit.cache.paradropRange && canParadropOn(destination)
-        return getDistanceToTiles().containsKey(destination)
+    /** Cached and thus not as performance-heavy as [canReach] */
+    fun canReachInCurrentTurn(destination: Tile) = canReachCommon(destination) {
+        getDistanceToTiles().containsKey(it)
+    }
+
+    private inline fun canReachCommon(destination: Tile, specificFunction: (Tile) -> Boolean) = when {
+        unit.cache.cannotMove ->
+            destination == unit.getTile()
+        unit.baseUnit.movesLikeAirUnits() ->
+            unit.currentTile.aerialDistanceTo(destination) <= unit.getMaxMovementForAirUnits()
+        unit.isPreparingParadrop() ->
+            unit.currentTile.aerialDistanceTo(destination) <= unit.cache.paradropRange && canParadropOn(destination)
+        else ->
+            specificFunction(destination)  // Note: Could pass destination as implicit closure from outer fun to lambda, but explicit is clearer
     }
 
     /**
@@ -689,8 +695,8 @@ class UnitMovement(val unit: MapUnit) {
         considerZoneOfControl: Boolean = true,
         passThroughCache: HashMap<Tile, Boolean> = HashMap(),
         movementCostCache: HashMap<Pair<Tile, Tile>, Float> = HashMap(),
-        includeOtherEscortUnit: Boolean = true)
-        : PathsToTilesWithinTurn {
+        includeOtherEscortUnit: Boolean = true
+    ): PathsToTilesWithinTurn {
         val cacheResults = pathfindingCache.getDistanceToTiles(considerZoneOfControl)
         if (cacheResults != null) {
             return cacheResults

--- a/core/src/com/unciv/models/ModConstants.kt
+++ b/core/src/com/unciv/models/ModConstants.kt
@@ -78,9 +78,11 @@ class ModConstants {
     var religionLimitBase = 1
     var religionLimitMultiplier = 0.5f
 
-    //Factors in formula for pantheon cost
+    // Factors in formula for pantheon cost
     var pantheonBase = 10
     var pantheonGrowth = 5
+
+    var workboatAutomationSearchMaxTiles = 20
 
     fun merge(other: ModConstants) {
         for (field in this::class.java.declaredFields) {

--- a/docs/Modders/Mod-file-structure/5-Miscellaneous-JSON-files.md
+++ b/docs/Modders/Mod-file-structure/5-Miscellaneous-JSON-files.md
@@ -202,6 +202,7 @@ and city distance in another. In case of conflicts, there is no guarantee which 
 | religionLimitMultiplier                  | Float  | 0.5                           | [^K]  |
 | pantheonBase                             | Int    | 10                            | [^L]  |
 | pantheonGrowth                           | Int    | 5                             | [^L]  |
+| workboatAutomationSearchMaxTiles         | Int    | 20                            | [^M]  |
 
 Legend:
 
@@ -231,6 +232,7 @@ Legend:
 - [^J]: A [UnitUpgradeCost](#unitupgradecost) sub-structure.
 - [^K]: Maximum foundable Religions = religionLimitBase + floor(MajorCivCount * religionLimitMultiplier)
 - [^L]: Cost of pantheon = pantheonBase + CivsWithReligion * pantheonGrowth
+- [^M]: When the AI decidees whether to build a work boat, how many tiles to search from the city center for an improvable tile
 
 #### UnitUpgradeCost
 


### PR DESCRIPTION
Let's close #10060
Related: #11384 - that one improved the unit automation, this deals with the city deciding "should I queue a work boat?"

In hindsight, I'd say most is readability, behavioral changes come from looking for existing boats in a wider area, and applying more complete "can/should I improve this" tests. Read commit history.

With this, we might want to instigate some modder to test out the newly json-i-fied `workboatAutomationSearchMaxTiles` constant that still defaults to 20 tiles - I suspect larger values might markedly improve the decisions...