### PR TITLE
Fix new game screen mod selection

### DIFF
--- a/core/src/com/unciv/ui/screens/newgamescreen/GameOptionsTable.kt
+++ b/core/src/com/unciv/ui/screens/newgamescreen/GameOptionsTable.kt
@@ -47,7 +47,6 @@ class GameOptionsTable(
     var locked = false
 
     private var baseRulesetHash = gameParameters.baseRuleset.hashCode()
-    private var selectedModsHash = gameParameters.mods.hashCode()
 
     /** Holds the UI for the Extension Mods
      *
@@ -80,11 +79,7 @@ class GameOptionsTable(
             baseRulesetHash = newBaseRulesetHash
             modCheckboxes.setBaseRuleset(gameParameters.baseRuleset)
         }
-        val newSelectedModsHash = gameParameters.mods.hashCode()
-        if (newSelectedModsHash != selectedModsHash) {
-            selectedModsHash = newSelectedModsHash
-            modCheckboxes.updateSelection(gameParameters.mods)
-        }
+        modCheckboxes.updateSelection()
 
         add(Table().apply {
             defaults().pad(5f)

--- a/core/src/com/unciv/ui/screens/newgamescreen/ModCheckboxTable.kt
+++ b/core/src/com/unciv/ui/screens/newgamescreen/ModCheckboxTable.kt
@@ -68,10 +68,8 @@ class ModCheckboxTable(
         setBaseRuleset(initialBaseRuleset)
     }
 
-    fun updateSelection(newMods: Collection<String>) {
+    fun updateSelection() {
         savedModcheckResult = null
-        mods.clear()
-        mods.addAll(newMods)
         disableChangeEvents = true
         for (mod in modWidgets) {
             mod.widget.isChecked = mod.mod.name in mods
@@ -202,7 +200,7 @@ class ModCheckboxTable(
                 mods.remove(modWidget.mod.name)
             }
         }
-        disableChangeEvents = true
+        disableChangeEvents = false
     }
 
     /** Disable incompatible mods - those that could not be turned on with the current selection */


### PR DESCRIPTION
Fixes #11398 
Explanation:
*  `disableChangeEvents = false` is obvious - this one actually concealed the problem in initial tests of #11387 
* The main issue was -  updateSelection intended to copy the newMods content to its 'work area' `mods` - but it got passed the same instance, so clear-addAll is *not* a copy, just a clear
* The feature that `updateSelection` can change the selection proved unnecessary on closer look, making an `if (newMods !== mods)` approach moot
* Likewise the `selectedModsHash` thing was intended to avoid calling `updateSelection` within a `checkBoxChanged` callback - but that would have needed another hash update, too much code to be worth it