### PR TITLE
Espionage Uniques, Buildings and Policy

### DIFF
--- a/android/assets/jsons/Civ V - Gods & Kings/Buildings.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Buildings.json
@@ -714,7 +714,7 @@
         "cost": 160,
         "maintenance": 1,
         "hurryCostModifier": 10,
-        "uniques": ["Hidden when espionage is disabled", "[25]% reduction in enemy spy effectivenes [in this city]"],
+        "uniques": ["Hidden when espionage is disabled", "[25]% reduction in enemy spy effectiveness [in this city]"],
         "requiredTech": "Banking"
     },
 	// will be introduced in BNW expansion pack
@@ -947,7 +947,7 @@
         "cost": 300,
         "maintenance": 1,
         "hurryCostModifier": 10,
-        "uniques": ["Hidden when espionage is disabled", "[25]% reduction in enemy spy effectivenes [in this city]"],
+        "uniques": ["Hidden when espionage is disabled", "[25]% reduction in enemy spy effectiveness [in this city]"],
         "requiredBuilding": "Constabulary",
         "requiredTech": "Electricity"
     },
@@ -986,7 +986,7 @@
         "cost": 120,
         "culture": 1,
         "isNationalWonder": true,
-        "uniques": ["Hidden when espionage is disabled", "Gain a spy", "Gives all spies one level", "[15]% reduction in enemy spy effectivenes [in this city]",
+        "uniques": ["Hidden when espionage is disabled", "Gain a spy", "Gives all spies one level", "[15]% reduction in enemy spy effectiveness [in this city]",
             "Only available <if [Police Station] is constructed in all [non-[Puppeted]] cities>", "Cost increases by [30] per owned city"],
         "requiredTech": "Radio"
     },
@@ -1112,8 +1112,8 @@
     {
         "name": "Great Firewall",
         "isWonder": true,
-        "uniques": ["Hidden when espionage is disabled", "[99]% reduction in enemy spy effectivenes [in this city]",
-            "[25]% reduction in enemy spy effectivenes [in all cities]",],
+        "uniques": ["Hidden when espionage is disabled", "[99]% reduction in enemy spy effectiveness [in this city]",
+            "[25]% reduction in enemy spy effectiveness [in all cities]",],
         "requiredTech": "Computers"
     },
 

--- a/android/assets/jsons/Civ V - Gods & Kings/Buildings.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Buildings.json
@@ -986,7 +986,7 @@
         "cost": 120,
         "culture": 1,
         "isNationalWonder": true,
-        "uniques": ["Hidden when espionage is disabled", "Gain a spy", "Gives all spies one level", "[-15]% enemy spy effectiveness [in this city]",
+        "uniques": ["Hidden when espionage is disabled", "Gain an extra spy", "Promotes all spies", "[-15]% enemy spy effectiveness [in this city]",
             "Only available <if [Police Station] is constructed in all [non-[Puppeted]] cities>", "Cost increases by [30] per owned city"],
         "requiredTech": "Radio"
     },

--- a/android/assets/jsons/Civ V - Gods & Kings/Buildings.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Buildings.json
@@ -1109,6 +1109,13 @@
 			"Hidden when [Scientific] Victory is disabled", "Cannot be hurried"],
 		"requiredTech": "Rocketry"
 	},
+    {
+        "name": "Great Firewall",
+        "isWonder": true,
+        "uniques": ["Hidden when esionage is disabled", "[99.9]% reduction in enemy spy effectivenes [in this city]",
+            "[25]% reduction in enemy spy effectivenes [in all cities]",],
+        "requiredTech": "Computers"
+    },
 
 	// Information Era
 

--- a/android/assets/jsons/Civ V - Gods & Kings/Buildings.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Buildings.json
@@ -1112,7 +1112,7 @@
     {
         "name": "Great Firewall",
         "isWonder": true,
-        "uniques": ["Hidden when esionage is disabled", "[99.9]% reduction in enemy spy effectivenes [in this city]",
+        "uniques": ["Hidden when esionage is disabled", "[99]% reduction in enemy spy effectivenes [in this city]",
             "[25]% reduction in enemy spy effectivenes [in all cities]",],
         "requiredTech": "Computers"
     },

--- a/android/assets/jsons/Civ V - Gods & Kings/Buildings.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Buildings.json
@@ -714,7 +714,7 @@
         "cost": 160,
         "maintenance": 1,
         "hurryCostModifier": 10,
-        "uniques": ["Hidden when espionage is disabled", "[25]% reduction in enemy spy effectiveness [in this city]"],
+        "uniques": ["Hidden when espionage is disabled", "[-25]% enemy spy effectiveness [in this city]"],
         "requiredTech": "Banking"
     },
 	// will be introduced in BNW expansion pack
@@ -947,7 +947,7 @@
         "cost": 300,
         "maintenance": 1,
         "hurryCostModifier": 10,
-        "uniques": ["Hidden when espionage is disabled", "[25]% reduction in enemy spy effectiveness [in this city]"],
+        "uniques": ["Hidden when espionage is disabled", "[-25]% enemy spy effectiveness [in this city]"],
         "requiredBuilding": "Constabulary",
         "requiredTech": "Electricity"
     },
@@ -986,7 +986,7 @@
         "cost": 120,
         "culture": 1,
         "isNationalWonder": true,
-        "uniques": ["Hidden when espionage is disabled", "Gain a spy", "Gives all spies one level", "[15]% reduction in enemy spy effectiveness [in this city]",
+        "uniques": ["Hidden when espionage is disabled", "Gain a spy", "Gives all spies one level", "[-15]% enemy spy effectiveness [in this city]",
             "Only available <if [Police Station] is constructed in all [non-[Puppeted]] cities>", "Cost increases by [30] per owned city"],
         "requiredTech": "Radio"
     },
@@ -1112,8 +1112,8 @@
     {
         "name": "Great Firewall",
         "isWonder": true,
-        "uniques": ["Hidden when espionage is disabled", "[99]% reduction in enemy spy effectiveness [in this city]",
-            "[25]% reduction in enemy spy effectiveness [in all cities]",],
+        "uniques": ["Hidden when espionage is disabled", "[-99]% enemy spy effectiveness [in this city]",
+            "[-25]% enemy spy effectiveness [in all cities]",],
         "requiredTech": "Computers"
     },
 

--- a/android/assets/jsons/Civ V - Gods & Kings/Buildings.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Buildings.json
@@ -714,7 +714,7 @@
         "cost": 160,
         "maintenance": 1,
         "hurryCostModifier": 10,
-        "uniques": ["Hidden when esionage is disabled", "[25]% reduction in enemy spy effectivenes"],
+        "uniques": ["Hidden when esionage is disabled", "[25]% reduction in enemy spy effectivenes [in this city]"],
         "requiredTech": "Banking"
     },
 	// will be introduced in BNW expansion pack
@@ -947,7 +947,7 @@
         "cost": 300,
         "maintenance": 1,
         "hurryCostModifier": 10,
-        "uniques": ["Hidden when esionage is disabled", "[25]% reduction in enemy spy effectivenes"],
+        "uniques": ["Hidden when esionage is disabled", "[25]% reduction in enemy spy effectivenes [in this city]"],
         "requiredBuilding": "Constabulary",
         "requiredTech": "Electricity"
     },
@@ -981,6 +981,15 @@
 		"requiredTech": "Radio",
 		"quote": "'We live only to discover beauty, all else is a form of waiting' - Kahlil Gibran"
 	},
+    {
+        "name": "National Intelligence Agency",
+        "cost": 120,
+        "culture": 1,
+        "isNationalWonder": true,
+        "uniques": ["Hidden when esionage is disabled", "Gain a spy", "Gives all spies one level", "[15]% reduction in enemy spy effectivenes [in this city]",
+            "Only available <if [Police Station] is constructed in all [non-[Puppeted]] cities>", "Cost increases by [30] per owned city"],
+        "requiredTech": "Radio"
+    },
 	{
 		"name": "Military Base",
 		"cityStrength": 12,

--- a/android/assets/jsons/Civ V - Gods & Kings/Buildings.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Buildings.json
@@ -714,7 +714,7 @@
         "cost": 160,
         "maintenance": 1,
         "hurryCostModifier": 10,
-        "uniques": ["Hidden when esionage is disabled", "[25]% reduction in enemy spy effectivenes [in this city]"],
+        "uniques": ["Hidden when espionage is disabled", "[25]% reduction in enemy spy effectivenes [in this city]"],
         "requiredTech": "Banking"
     },
 	// will be introduced in BNW expansion pack
@@ -947,7 +947,7 @@
         "cost": 300,
         "maintenance": 1,
         "hurryCostModifier": 10,
-        "uniques": ["Hidden when esionage is disabled", "[25]% reduction in enemy spy effectivenes [in this city]"],
+        "uniques": ["Hidden when espionage is disabled", "[25]% reduction in enemy spy effectivenes [in this city]"],
         "requiredBuilding": "Constabulary",
         "requiredTech": "Electricity"
     },
@@ -986,7 +986,7 @@
         "cost": 120,
         "culture": 1,
         "isNationalWonder": true,
-        "uniques": ["Hidden when esionage is disabled", "Gain a spy", "Gives all spies one level", "[15]% reduction in enemy spy effectivenes [in this city]",
+        "uniques": ["Hidden when espionage is disabled", "Gain a spy", "Gives all spies one level", "[15]% reduction in enemy spy effectivenes [in this city]",
             "Only available <if [Police Station] is constructed in all [non-[Puppeted]] cities>", "Cost increases by [30] per owned city"],
         "requiredTech": "Radio"
     },
@@ -1112,7 +1112,7 @@
     {
         "name": "Great Firewall",
         "isWonder": true,
-        "uniques": ["Hidden when esionage is disabled", "[99]% reduction in enemy spy effectivenes [in this city]",
+        "uniques": ["Hidden when espionage is disabled", "[99]% reduction in enemy spy effectivenes [in this city]",
             "[25]% reduction in enemy spy effectivenes [in all cities]",],
         "requiredTech": "Computers"
     },

--- a/android/assets/jsons/Civ V - Gods & Kings/Buildings.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Buildings.json
@@ -709,6 +709,14 @@
 		"requiredBuilding": "Market",
 		"requiredTech": "Banking"
 	},
+    {
+        "name": "Constabulary",
+        "cost": 160,
+        "maintenance": 1,
+        "hurryCostModifier": 10,
+        "uniques": ["Hidden when esionage is disabled", "[25]% reduction in enemy spy effectivenes"],
+        "requiredTech": "Banking"
+    },
 	// will be introduced in BNW expansion pack
 //	{
 //		"name": "Hanse",
@@ -934,6 +942,15 @@
 		"uniques": ["Must be on [River]","[+1 Production] from [River] tiles [in this city]"],
 		"requiredTech": "Electricity"
 	},
+    {
+        "name": "Police Station",
+        "cost": 300,
+        "maintenance": 1,
+        "hurryCostModifier": 10,
+        "uniques": ["Hidden when esionage is disabled", "[25]% reduction in enemy spy effectivenes"],
+        "requiredBuilding": "Constabulary",
+        "requiredTech": "Electricity"
+    },
 
 	// Modern Era
 

--- a/android/assets/jsons/Civ V - Gods & Kings/Policies.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Policies.json
@@ -577,7 +577,8 @@
                 "name": "Police State",
                 "uniques": [
                     "[+3 Happiness] from every [Courthouse]",
-                    "[+100]% Production when constructing [Courthouse] buildings [in all cities]"
+                    "[+100]% Production when constructing [Courthouse] buildings [in all cities]",
+                    "[25]% reduction in enemy spy effectivenes [in all cities]"
                 ],
                 // There are also some uniques regarding espoinage, which as of this writing is not yet implemented
                 "requires": ["Militarism"],

--- a/android/assets/jsons/Civ V - Gods & Kings/Policies.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Policies.json
@@ -578,7 +578,7 @@
                 "uniques": [
                     "[+3 Happiness] from every [Courthouse]",
                     "[+100]% Production when constructing [Courthouse] buildings [in all cities]",
-                    "[25]% reduction in enemy spy effectivenes [in all cities]"
+                    "[-25]% enemy spy effectiveness [in all cities]"
                 ],
                 // There are also some uniques regarding espoinage, which as of this writing is not yet implemented
                 "requires": ["Militarism"],

--- a/android/assets/jsons/Civ V - Gods & Kings/Policies.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Policies.json
@@ -580,7 +580,6 @@
                     "[+100]% Production when constructing [Courthouse] buildings [in all cities]",
                     "[-25]% enemy spy effectiveness [in all cities]"
                 ],
-                // There are also some uniques regarding espoinage, which as of this writing is not yet implemented
                 "requires": ["Militarism"],
                 "row": 2,
                 "column": 4

--- a/core/src/com/unciv/logic/civilization/managers/EspionageManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/EspionageManager.kt
@@ -5,7 +5,6 @@ import com.unciv.logic.city.City
 import com.unciv.logic.civilization.Civilization
 import com.unciv.logic.map.tile.Tile
 import com.unciv.models.Spy
-import kotlinx.coroutines.newFixedThreadPoolContext
 
 
 class EspionageManager : IsPartOfGameInfoSerialization {

--- a/core/src/com/unciv/logic/civilization/managers/EspionageManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/EspionageManager.kt
@@ -5,6 +5,7 @@ import com.unciv.logic.city.City
 import com.unciv.logic.civilization.Civilization
 import com.unciv.logic.map.tile.Tile
 import com.unciv.models.Spy
+import kotlinx.coroutines.newFixedThreadPoolContext
 
 
 class EspionageManager : IsPartOfGameInfoSerialization {
@@ -41,12 +42,12 @@ class EspionageManager : IsPartOfGameInfoSerialization {
         return validSpyNames.random()
     }
 
-    fun addSpy(): String {
+    fun addSpy(): Spy {
         val spyName = getSpyName()
         val newSpy = Spy(spyName)
         newSpy.setTransients(civInfo)
         spyList.add(newSpy)
-        return spyName
+        return newSpy
     }
 
     fun getTilesVisibleViaSpies(): Sequence<Tile> {

--- a/core/src/com/unciv/models/Spy.kt
+++ b/core/src/com/unciv/models/Spy.kt
@@ -104,8 +104,8 @@ class Spy() : IsPartOfGameInfoSerialization {
                 }
                 val techStealCost = stealableTechs.maxOfOrNull { civInfo.gameInfo.ruleset.technologies[it]!!.cost }!!
                 var progressThisTurn = getLocation()!!.cityStats.currentCityStats.science
-                // 33% spy bonus for each level
-                progressThisTurn *= (rank + 2f) / 3f
+                // 25% spy bonus for each level
+                progressThisTurn *= (rank + 3) / 4
                 progressThisTurn *= getEfficiencyModifier().toFloat()
                 progressTowardsStealingTech += progressThisTurn.toInt()
                 if (progressTowardsStealingTech > techStealCost) {
@@ -162,7 +162,6 @@ class Spy() : IsPartOfGameInfoSerialization {
         // Subtract the experience of the counter inteligence spies
         val defendingSpy = city.civ.espionageManager.getSpyAssignedToCity(city)
         spyResult += defendingSpy?.getSkillModifier() ?: 0
-        spyResult = (spyResult * getEfficiencyModifier()).toInt()
 
         val detectionString = when {
             spyResult < 0 -> null // Not detected
@@ -204,7 +203,6 @@ class Spy() : IsPartOfGameInfoSerialization {
                 var spyResult = Random(randomSeed.toInt()).nextInt(120)
                 spyResult -= getSkillModifier()
                 spyResult += defendingSpy.getSkillModifier()
-                spyResult = (spyResult * getEfficiencyModifier()).toInt()
                 if (spyResult > 100) {
                     // The Spy was killed
                     allyCiv.addNotification("A spy from [${civInfo.civName}] tried to rig elections and was found and killed in [${city}] by [${defendingSpy.name}]!",
@@ -282,8 +280,8 @@ class Spy() : IsPartOfGameInfoSerialization {
     }
 
     /**
-     * Gets a feindly and enemy efficiency uniques for the spy at the location
-     * @return a value centered around 1 for the work efficiency of the spy
+     * Gets a friendly and enemy efficiency uniques for the spy at the location
+     * @return a value centered around 100 for the work efficiency of the spy, won't be negative
      */
     fun getEfficiencyModifier(): Double {
         lateinit var friendlyUniques: Sequence<Unique>
@@ -301,10 +299,10 @@ class Spy() : IsPartOfGameInfoSerialization {
             friendlyUniques = civInfo.getMatchingUniques(UniqueType.SpyEffectiveness)
             enemyUniques = sequenceOf()
         }
-        var totalEfficiency = 100.0
-        totalEfficiency += friendlyUniques.sumOf { it.params[0].toDouble() }
-        totalEfficiency += enemyUniques.sumOf { it.params[0].toDouble() }
-        return totalEfficiency.coerceAtLeast(0.0) / 100 // Convert to a percent to a value centered at 1
+        var totalEfficiency = 100
+        totalEfficiency += friendlyUniques.sumOf { it.params[0].toInt() }
+        totalEfficiency += enemyUniques.sumOf { it.params[0].toInt() }
+        return totalEfficiency.coerceAtLeast(0) / 100.0
     }
 
     fun killSpy() {

--- a/core/src/com/unciv/models/Spy.kt
+++ b/core/src/com/unciv/models/Spy.kt
@@ -104,8 +104,8 @@ class Spy() : IsPartOfGameInfoSerialization {
                 }
                 val techStealCost = stealableTechs.maxOfOrNull { civInfo.gameInfo.ruleset.technologies[it]!!.cost }!!
                 var progressThisTurn = getLocation()!!.cityStats.currentCityStats.science
-                // 25% spy bonus for each level
-                progressThisTurn *= (rank + 3) / 4
+                // 33% spy bonus for each level
+                progressThisTurn *= (rank + 2f) / 3f
                 progressThisTurn *= getEfficiencyModifier().toFloat()
                 progressTowardsStealingTech += progressThisTurn.toInt()
                 if (progressTowardsStealingTech > techStealCost) {
@@ -299,10 +299,10 @@ class Spy() : IsPartOfGameInfoSerialization {
             friendlyUniques = civInfo.getMatchingUniques(UniqueType.SpyEffectiveness)
             enemyUniques = sequenceOf()
         }
-        var totalEfficiency = 100
-        totalEfficiency += friendlyUniques.sumOf { it.params[0].toInt() }
-        totalEfficiency += enemyUniques.sumOf { it.params[0].toInt() }
-        return totalEfficiency.coerceAtLeast(0) / 100.0
+        var totalEfficiency = 1.0
+        totalEfficiency *= (100.0 + friendlyUniques.sumOf { it.params[0].toInt() }) / 100
+        totalEfficiency *= (100.0 + enemyUniques.sumOf { it.params[0].toInt() }) / 100
+        return totalEfficiency.coerceAtLeast(0.0)
     }
 
     fun killSpy() {

--- a/core/src/com/unciv/models/Spy.kt
+++ b/core/src/com/unciv/models/Spy.kt
@@ -156,13 +156,13 @@ class Spy() : IsPartOfGameInfoSerialization {
             civInfo.tech.addTechnology(stolenTech)
         }
         // Lower is better
-        var spyResult = (Random(randomSeed.toInt()).nextInt(300) * getEfficiencyModifier()).toInt()
+        var spyResult = Random(randomSeed.toInt()).nextInt(300)
         // Add our spies experience
         spyResult -= getSkillModifier()
         // Subtract the experience of the counter inteligence spies
         val defendingSpy = city.civ.espionageManager.getSpyAssignedToCity(city)
         spyResult += defendingSpy?.getSkillModifier() ?: 0
-        //TODO: Add policies modifier here
+        spyResult = (spyResult * getEfficiencyModifier()).toInt()
 
         val detectionString = when {
             spyResult < 0 -> null // Not detected
@@ -201,9 +201,10 @@ class Spy() : IsPartOfGameInfoSerialization {
             val defendingSpy = allyCiv.espionageManager.getSpyAssignedToCity(getLocation()!!)
             if (defendingSpy != null) {
                 val randomSeed = city.location.x * city.location.y + 123f * civInfo.gameInfo.turns
-                var spyResult = (Random(randomSeed.toInt()).nextInt(120) * getEfficiencyModifier()).toInt()
+                var spyResult = Random(randomSeed.toInt()).nextInt(120)
                 spyResult -= getSkillModifier()
                 spyResult += defendingSpy.getSkillModifier()
+                spyResult = (spyResult * getEfficiencyModifier()).toInt()
                 if (spyResult > 100) {
                     // The Spy was killed
                     allyCiv.addNotification("A spy from [${civInfo.civName}] tried to rig elections and was found and killed in [${city}] by [${defendingSpy.name}]!",

--- a/core/src/com/unciv/models/Spy.kt
+++ b/core/src/com/unciv/models/Spy.kt
@@ -303,7 +303,7 @@ class Spy() : IsPartOfGameInfoSerialization {
         }
         var totalEfficiency = 100.0
         totalEfficiency += friendlyUniques.sumOf { it.params[0].toDouble() }
-        totalEfficiency -= enemyUniques.sumOf { it.params[0].toDouble() }
+        totalEfficiency += enemyUniques.sumOf { it.params[0].toDouble() }
         return totalEfficiency.coerceAtLeast(0.0) / 100 // Convert to a percent to a value centered at 1
     }
 

--- a/core/src/com/unciv/models/ruleset/Building.kt
+++ b/core/src/com/unciv/models/ruleset/Building.kt
@@ -316,6 +316,10 @@ class Building : RulesetStatsObject(), INonPerpetualConstruction {
                     if (!civ.gameInfo.isReligionEnabled())
                         yield(RejectionReasonType.DisabledBySetting.toInstance())
 
+                UniqueType.HiddenWithoutEspionage ->
+                    if (!civ.gameInfo.isEspionageEnabled())
+                        yield(RejectionReasonType.DisabledBySetting.toInstance())
+
                 UniqueType.MaxNumberBuildable ->
                     if (civ.civConstructions.countConstructedObjects(this@Building) >= unique.params[0].toInt())
                         yield(RejectionReasonType.MaxNumberBuildable.toInstance())

--- a/core/src/com/unciv/models/ruleset/nation/Nation.kt
+++ b/core/src/com/unciv/models/ruleset/nation/Nation.kt
@@ -15,6 +15,7 @@ import com.unciv.ui.objectdescriptions.BaseUnitDescriptions
 import com.unciv.ui.objectdescriptions.BuildingDescriptions
 import com.unciv.ui.objectdescriptions.ImprovementDescriptions
 import com.unciv.ui.objectdescriptions.uniquesToCivilopediaTextLines
+import com.unciv.ui.screens.civilopediascreen.CivilopediaScreen.Companion.showEspionageInCivilopedia
 import com.unciv.ui.screens.civilopediascreen.CivilopediaScreen.Companion.showReligionInCivilopedia
 import com.unciv.ui.screens.civilopediascreen.FormattedLine
 import kotlin.math.pow
@@ -193,11 +194,13 @@ class Nation : RulesetObject() {
 
     private fun getUniqueBuildingsText(ruleset: Ruleset) = sequence {
         val religionEnabled = showReligionInCivilopedia(ruleset)
+        val espionageEnabled = showEspionageInCivilopedia(ruleset)
         for (building in ruleset.buildings.values) {
             when {
                 building.uniqueTo != name -> continue
                 building.hasUnique(UniqueType.HiddenFromCivilopedia) -> continue
                 !religionEnabled && building.hasUnique(UniqueType.HiddenWithoutReligion) -> continue
+                !espionageEnabled && building.hasUnique(UniqueType.HiddenWithoutEspionage) -> continue
             }
             yield(FormattedLine(separator = true))
             yield(FormattedLine("{${building.name}} -", link=building.makeLink()))

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -804,6 +804,27 @@ object UniqueTriggerActivation {
                 }
             }
 
+            UniqueType.OneTimeSpiesLevelUp -> {
+                if (!civInfo.isMajorCiv()) return null
+                if (!civInfo.gameInfo.isEspionageEnabled()) return null
+
+                return {
+                    unique.params[0].toInt()
+                    civInfo.espionageManager.spyList.forEach { it.levelUpSpy() }
+                    true
+                }
+            }
+
+            UniqueType.OneTimeGainSpy -> {
+                if (!civInfo.isMajorCiv()) return null
+                if (!civInfo.gameInfo.isEspionageEnabled()) return null
+
+                return {
+                    civInfo.espionageManager.addSpy()
+                    true
+                }
+            }
+
             UniqueType.GainFreeBuildings -> {
                 val freeBuilding = civInfo.getEquivalentBuilding(unique.params[0])
                 val applicableCities =

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -787,7 +787,7 @@ object UniqueTriggerActivation {
                     val currentEra = civInfo.getEra().name
                     for (otherCiv in civInfo.gameInfo.getAliveMajorCivs()) {
                         if (currentEra !in otherCiv.espionageManager.erasSpyEarnedFor) {
-                            val spyName = otherCiv.espionageManager.addSpy()
+                            val spyName = otherCiv.espionageManager.addSpy().name
                             otherCiv.espionageManager.erasSpyEarnedFor.add(currentEra)
                             if (otherCiv == civInfo || otherCiv.knows(civInfo))
                             // We don't tell which civilization entered the new era, as that is done in the notification directly above this one

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -809,7 +809,6 @@ object UniqueTriggerActivation {
                 if (!civInfo.gameInfo.isEspionageEnabled()) return null
 
                 return {
-                    unique.params[0].toInt()
                     civInfo.espionageManager.spyList.forEach { it.levelUpSpy() }
                     true
                 }

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -227,6 +227,10 @@ enum class UniqueType(
     MayNotGenerateGreatProphet("May not generate great prophet equivalents naturally", UniqueTarget.Global),
     FaithCostOfGreatProphetChange("[relativeAmount]% Faith cost of generating Great Prophet equivalents", UniqueTarget.Global),
 
+    /// Espionage
+    SpyEffectiveness("[relativeAmount]% spy effectivenes", UniqueTarget.Global, UniqueTarget.Global),
+    EnemySpyEffectiveness("[relativeAmount]% reduction in enemy spy effectivenes", UniqueTarget.Global, UniqueTarget.Global),
+
     /// Things you get at the start of the game
     StartingTech("Starting tech", UniqueTarget.Tech),
     StartsWithTech("Starts with [tech]", UniqueTarget.Nation),
@@ -786,6 +790,8 @@ enum class UniqueType(
     OneTimeRevealCrudeMap("From a randomly chosen tile [positiveAmount] tiles away from the ruins, reveal tiles up to [positiveAmount] tiles away with [positiveAmount]% chance", UniqueTarget.Ruins),
     OneTimeGlobalAlert("Triggers the following global alert: [comment]", UniqueTarget.Triggerable), // used in Policy
     OneTimeGlobalSpiesWhenEnteringEra("Every major Civilization gains a spy once a civilization enters this era", UniqueTarget.Era),
+    OneTimeSpiesLevelUp("Gives all spies one level", UniqueTarget.Triggerable),  // used in Policies, Buildings
+    OneTimeGainSpy("Gain a spy", UniqueTarget.Triggerable),  // used in Wonders
 
     OneTimeUnitHeal("Heal this unit by [positiveAmount] HP", UniqueTarget.UnitTriggerable),
     OneTimeUnitDamage("This Unit takes [positiveAmount] damage", UniqueTarget.UnitTriggerable),
@@ -850,6 +856,9 @@ enum class UniqueType(
 
     ///////////////////////////////////////////// region 90 META /////////////////////////////////////////////
     HiddenWithoutReligion("Hidden when religion is disabled",
+        UniqueTarget.Unit, UniqueTarget.Building, UniqueTarget.Ruins, UniqueTarget.Tutorial,
+        flags = UniqueFlag.setOfHiddenToUsers),
+    HiddenWithoutEspionage("Hidden when esionage is disabled",
         UniqueTarget.Unit, UniqueTarget.Building, UniqueTarget.Ruins, UniqueTarget.Tutorial,
         flags = UniqueFlag.setOfHiddenToUsers),
 

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -228,8 +228,8 @@ enum class UniqueType(
     FaithCostOfGreatProphetChange("[relativeAmount]% Faith cost of generating Great Prophet equivalents", UniqueTarget.Global),
 
     /// Espionage
-    SpyEffectiveness("[relativeAmount]% spy effectivenes", UniqueTarget.Global, UniqueTarget.Global),
-    EnemySpyEffectiveness("[relativeAmount]% reduction in enemy spy effectivenes", UniqueTarget.Global, UniqueTarget.Global),
+    SpyEffectiveness("[relativeAmount]% spy effectivenes [cityFilter]", UniqueTarget.Global, UniqueTarget.Global),
+    EnemySpyEffectiveness("[relativeAmount]% reduction in enemy spy effectivenes [cityFilter]", UniqueTarget.Global, UniqueTarget.Global),
 
     /// Things you get at the start of the game
     StartingTech("Starting tech", UniqueTarget.Tech),

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -228,8 +228,8 @@ enum class UniqueType(
     FaithCostOfGreatProphetChange("[relativeAmount]% Faith cost of generating Great Prophet equivalents", UniqueTarget.Global),
 
     /// Espionage
-    SpyEffectiveness("[relativeAmount]% spy effectivenes [cityFilter]", UniqueTarget.Global, UniqueTarget.Global),
-    EnemySpyEffectiveness("[relativeAmount]% reduction in enemy spy effectivenes [cityFilter]", UniqueTarget.Global, UniqueTarget.Global),
+    SpyEffectiveness("[relativeAmount]% spy effectiveness [cityFilter]", UniqueTarget.Global, UniqueTarget.Global),
+    EnemySpyEffectiveness("[relativeAmount]% reduction in enemy spy effectiveness [cityFilter]", UniqueTarget.Global, UniqueTarget.Global),
 
     /// Things you get at the start of the game
     StartingTech("Starting tech", UniqueTarget.Tech),

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -858,7 +858,7 @@ enum class UniqueType(
     HiddenWithoutReligion("Hidden when religion is disabled",
         UniqueTarget.Unit, UniqueTarget.Building, UniqueTarget.Ruins, UniqueTarget.Tutorial,
         flags = UniqueFlag.setOfHiddenToUsers),
-    HiddenWithoutEspionage("Hidden when esionage is disabled", UniqueTarget.Building,
+    HiddenWithoutEspionage("Hidden when espionage is disabled", UniqueTarget.Building,
         flags = UniqueFlag.setOfHiddenToUsers),
 
     HiddenWithoutVictoryType("Hidden when [victoryType] Victory is disabled", UniqueTarget.Building, UniqueTarget.Unit, flags = UniqueFlag.setOfHiddenToUsers),

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -858,8 +858,7 @@ enum class UniqueType(
     HiddenWithoutReligion("Hidden when religion is disabled",
         UniqueTarget.Unit, UniqueTarget.Building, UniqueTarget.Ruins, UniqueTarget.Tutorial,
         flags = UniqueFlag.setOfHiddenToUsers),
-    HiddenWithoutEspionage("Hidden when esionage is disabled",
-        UniqueTarget.Unit, UniqueTarget.Building, UniqueTarget.Ruins, UniqueTarget.Tutorial,
+    HiddenWithoutEspionage("Hidden when esionage is disabled", UniqueTarget.Building,
         flags = UniqueFlag.setOfHiddenToUsers),
 
     HiddenWithoutVictoryType("Hidden when [victoryType] Victory is disabled", UniqueTarget.Building, UniqueTarget.Unit, flags = UniqueFlag.setOfHiddenToUsers),

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -229,7 +229,7 @@ enum class UniqueType(
 
     /// Espionage
     SpyEffectiveness("[relativeAmount]% spy effectiveness [cityFilter]", UniqueTarget.Global, UniqueTarget.Global),
-    EnemySpyEffectiveness("[relativeAmount]% reduction in enemy spy effectiveness [cityFilter]", UniqueTarget.Global, UniqueTarget.Global),
+    EnemySpyEffectiveness("[relativeAmount]% enemy spy effectiveness [cityFilter]", UniqueTarget.Global, UniqueTarget.Global),
 
     /// Things you get at the start of the game
     StartingTech("Starting tech", UniqueTarget.Tech),

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -790,8 +790,8 @@ enum class UniqueType(
     OneTimeRevealCrudeMap("From a randomly chosen tile [positiveAmount] tiles away from the ruins, reveal tiles up to [positiveAmount] tiles away with [positiveAmount]% chance", UniqueTarget.Ruins),
     OneTimeGlobalAlert("Triggers the following global alert: [comment]", UniqueTarget.Triggerable), // used in Policy
     OneTimeGlobalSpiesWhenEnteringEra("Every major Civilization gains a spy once a civilization enters this era", UniqueTarget.Era),
-    OneTimeSpiesLevelUp("Gives all spies one level", UniqueTarget.Triggerable),  // used in Policies, Buildings
-    OneTimeGainSpy("Gain a spy", UniqueTarget.Triggerable),  // used in Wonders
+    OneTimeSpiesLevelUp("Promotes all spies", UniqueTarget.Triggerable),  // used in Policies, Buildings
+    OneTimeGainSpy("Gain an extra spy", UniqueTarget.Triggerable),  // used in Wonders
 
     OneTimeUnitHeal("Heal this unit by [positiveAmount] HP", UniqueTarget.UnitTriggerable),
     OneTimeUnitDamage("This Unit takes [positiveAmount] damage", UniqueTarget.UnitTriggerable),

--- a/core/src/com/unciv/ui/objectdescriptions/TechnologyDescriptions.kt
+++ b/core/src/com/unciv/ui/objectdescriptions/TechnologyDescriptions.kt
@@ -309,20 +309,21 @@ object TechnologyDescriptions {
         civInfo: Civilization?,
         predicate: (Building) -> Boolean
     ): Sequence<Building> {
-        val (nuclearWeaponsEnabled, religionEnabled) = getNukeAndReligionSwitches(civInfo)
+        val (nuclearWeaponsEnabled, religionEnabled, espionageEnabled) = getNukeAndReligionSwitches(civInfo)
         return ruleset.buildings.values.asSequence()
             .filter {
                 predicate(it)   // expected to be the most selective, thus tested first
                         && (it.uniqueTo == civInfo?.civName || it.uniqueTo == null && civInfo?.getEquivalentBuilding(it) == it)
                         && (nuclearWeaponsEnabled || !it.hasUnique(UniqueType.EnablesNuclearWeapons))
                         && (religionEnabled || !it.hasUnique(UniqueType.HiddenWithoutReligion))
+                        && (espionageEnabled || !it.hasUnique(UniqueType.HiddenWithoutEspionage))
                         && !it.hasUnique(UniqueType.HiddenFromCivilopedia)
             }
     }
 
-    private fun getNukeAndReligionSwitches(civInfo: Civilization?): Pair<Boolean, Boolean> {
-        if (civInfo == null) return true to true
-        return civInfo.gameInfo.run { gameParameters.nuclearWeaponsEnabled to isReligionEnabled() }
+    private fun getNukeAndReligionSwitches(civInfo: Civilization?): Triple<Boolean, Boolean, Boolean> {
+        if (civInfo == null) return Triple(true, true, true)
+        return civInfo.gameInfo.run { Triple(gameParameters.nuclearWeaponsEnabled, isReligionEnabled(), isEspionageEnabled()) }
     }
 
     /**

--- a/core/src/com/unciv/ui/screens/civilopediascreen/CivilopediaScreen.kt
+++ b/core/src/com/unciv/ui/screens/civilopediascreen/CivilopediaScreen.kt
@@ -200,12 +200,14 @@ class CivilopediaScreen(
         val imageSize = 50f
 
         val religionEnabled = showReligionInCivilopedia(ruleset)
+        val espionageEnabled = showEspionageInCivilopedia(ruleset)
         val victoryTypes = game.gameInfo?.gameParameters?.victoryTypes ?: ruleset.victories.keys
 
         fun shouldBeDisplayed(obj: IHasUniques): Boolean {
             return when {
                 obj.hasUnique(UniqueType.HiddenFromCivilopedia) -> false
                 (!religionEnabled && obj.hasUnique(UniqueType.HiddenWithoutReligion)) -> false
+                (!espionageEnabled && obj.hasUnique(UniqueType.HiddenWithoutEspionage)) -> false
                 obj.getMatchingUniques(UniqueType.HiddenWithoutVictoryType).any { !victoryTypes.contains(it.params[0]) } -> false
                 else -> true
             }
@@ -324,6 +326,12 @@ class CivilopediaScreen(
             UncivGame.isCurrentInitialized() && UncivGame.Current.gameInfo != null ->
                 UncivGame.Current.gameInfo!!.isReligionEnabled()
             ruleset != null -> ruleset.beliefs.isNotEmpty()
+            else -> true
+        }
+
+        fun showEspionageInCivilopedia(ruleset: Ruleset? = null) = when {
+            UncivGame.isCurrentInitialized() && UncivGame.Current.gameInfo != null ->
+                UncivGame.Current.gameInfo!!.isEspionageEnabled()
             else -> true
         }
     }

--- a/core/src/com/unciv/ui/screens/overviewscreen/WonderOverviewTab.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/WonderOverviewTab.kt
@@ -98,6 +98,7 @@ class WonderInfo {
     val gameInfo = UncivGame.Current.gameInfo!!
     val ruleSet = gameInfo.ruleset
     private val hideReligionItems = !gameInfo.isReligionEnabled()
+    private val hideEspionageItems = !gameInfo.isEspionageEnabled()
     private val startingObsolete = ruleSet.eras[gameInfo.gameParameters.startingEra]!!.startingObsoleteWonders
 
     enum class WonderStatus(val label: String) {
@@ -150,6 +151,7 @@ class WonderInfo {
     private fun shouldBeDisplayed(viewingPlayer: Civilization, wonder: Building, wonderEra: Int?) = when {
         wonder.hasUnique(UniqueType.HiddenFromCivilopedia) -> false
         wonder.hasUnique(UniqueType.HiddenWithoutReligion) && hideReligionItems -> false
+        wonder.hasUnique(UniqueType.HiddenWithoutEspionage) && hideEspionageItems -> false
         wonder.name in startingObsolete -> false
         wonder.getMatchingUniques(UniqueType.HiddenWithoutVictoryType)
             .any { unique ->

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -139,6 +139,12 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 	Applicable to: Triggerable
 
+??? example  "Promotes all spies"
+	Applicable to: Triggerable
+
+??? example  "Gain an extra spy"
+	Applicable to: Triggerable
+
 ??? example  "Turn this tile into a [terrainName] tile"
 	Example: "Turn this tile into a [Forest] tile"
 
@@ -753,6 +759,16 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 	Applicable to: Global
 
+??? example  "[relativeAmount]% spy effectiveness [cityFilter]"
+	Example: "[+20]% spy effectiveness [in all cities]"
+
+	Applicable to: Global
+
+??? example  "[relativeAmount]% enemy spy effectiveness [cityFilter]"
+	Example: "[+20]% enemy spy effectiveness [in all cities]"
+
+	Applicable to: Global
+
 ??? example  "Triggers victory"
 	Applicable to: Global
 
@@ -1170,6 +1186,9 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 ??? example  "Hidden when religion is disabled"
 	Applicable to: Building, Unit, Ruins, Tutorial
+
+??? example  "Hidden when espionage is disabled"
+	Applicable to: Building
 
 ??? example  "Hidden when [victoryType] Victory is disabled"
 	Example: "Hidden when [Domination] Victory is disabled"

--- a/tests/src/com/unciv/logic/civilization/EspionageTests.kt
+++ b/tests/src/com/unciv/logic/civilization/EspionageTests.kt
@@ -4,6 +4,7 @@ import com.badlogic.gdx.math.Vector2
 import com.unciv.testing.GdxTestRunner
 import com.unciv.testing.TestGame
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -38,6 +39,19 @@ class EspionageTests {
         assertEquals(1.0, spy.getEfficiencyModifier(), 0.1)
         city.cityConstructions.addBuilding("Constabulary")
         assertEquals(0.75, spy.getEfficiencyModifier(), 0.1)
+    }
+
+    @Test
+    fun `Spy effectiveness can't go below zero`() {
+        val espionageManagerA = civA.espionageManager
+        val spy = espionageManagerA.addSpy()
+        val city = civB.addCity(Vector2(1f,1f))
+        spy.moveTo(city)
+        city.cityConstructions.addBuilding("Constabulary")
+        city.cityConstructions.addBuilding("Police Station")
+        city.cityConstructions.addBuilding("National Intelligence Agency")
+        city.cityConstructions.addBuilding("Great Firewall")
+        assertTrue(spy.getEfficiencyModifier() >= 0)
     }
 
 }

--- a/tests/src/com/unciv/logic/civilization/EspionageTests.kt
+++ b/tests/src/com/unciv/logic/civilization/EspionageTests.kt
@@ -1,0 +1,43 @@
+package com.unciv.logic.civilization
+
+import com.badlogic.gdx.math.Vector2
+import com.unciv.testing.GdxTestRunner
+import com.unciv.testing.TestGame
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(GdxTestRunner::class)
+class EspionageTests {
+    private val testGame = TestGame()
+
+    val civA = testGame.addCiv()
+    val civB = testGame.addCiv()
+    @Before
+    fun setup() {
+        testGame.gameInfo.gameParameters.espionageEnabled = true
+        civA.diplomacyFunctions.makeCivilizationsMeet(civB)
+        testGame.makeHexagonalMap(3)
+    }
+
+    @Test
+    fun `Espionage manager add spy`() {
+        val espionageManagerA = civA.espionageManager
+        assertEquals(0, espionageManagerA.spyList.size)
+        espionageManagerA.addSpy()
+        assertEquals(1, espionageManagerA.spyList.size)
+    }
+
+    @Test
+    fun `Espionage check spy effectiveness reduction unique`() {
+        val espionageManagerA = civA.espionageManager
+        val spy = espionageManagerA.addSpy()
+        val city = civB.addCity(Vector2(1f,1f))
+        spy.moveTo(city)
+        assertEquals(1.0, spy.getEfficiencyModifier(), 0.1)
+        city.cityConstructions.addBuilding("Constabulary")
+        assertEquals(0.75, spy.getEfficiencyModifier(), 0.1)
+    }
+
+}


### PR DESCRIPTION
Part of #7610

This PR adds 5 new Espionage Uniques:
- SpyEffectiveness (unused)
- EnemySpyEffectiveness
- HiddenWithoutEspionage
- OneTimeSpiesLevelUp
- OneTimeGainSpy

4 new buildings (none have any pictures yet):
- Constabulary
- Police Station
- National Intelligence Agency (National Wonder)
- Great Firewall (Wonder)

Police State policy gains "[25]% reduction in enemy spy effectivenes [in all cities]"

And a few tests

The current way I have effectiveness calculated is a little weird, I think we will want to change it in the future (maybe even in this PR).