### PR TITLE
Added triggerable unique to remove policy

### DIFF
--- a/core/src/com/unciv/logic/civilization/managers/PolicyManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/PolicyManager.kt
@@ -117,6 +117,12 @@ class PolicyManager : IsPartOfGameInfoSerialization {
         }
     }
 
+    private fun removePolicyFromTransients(policy: Policy) {
+        for (unique in policy.uniqueObjects) {
+            policyUniques.removeUnique(unique)
+        }
+    }
+
     fun addCulture(culture: Int) {
         val couldAdoptPolicyBefore = canAdoptPolicy()
         storedCulture += culture
@@ -230,6 +236,12 @@ class PolicyManager : IsPartOfGameInfoSerialization {
         }
 
         if (!canAdoptPolicy()) shouldOpenPolicyPicker = false
+    }
+
+    fun removePolicy(policy: Policy) {
+        adoptedPolicies.remove(policy.name)
+        removePolicyFromTransients(policy)
+        numberOfAdoptedPolicies--
     }
 
     /**

--- a/core/src/com/unciv/logic/civilization/managers/PolicyManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/PolicyManager.kt
@@ -245,7 +245,7 @@ class PolicyManager : IsPartOfGameInfoSerialization {
         adoptedPolicies.remove(policy.name)
         removePolicyFromTransients(policy)
 
-        // if a branch is already complete, revert it back to uncomplete
+        // if a branch is already marked as complete, revert it to incomplete
         if (!branchCompletion) {
             val branch = policy.branch
             if (branch.policies.count { isAdopted(it.name) } == branch.policies.size - 1) {

--- a/core/src/com/unciv/models/ruleset/unique/Unique.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Unique.kt
@@ -225,6 +225,11 @@ class UniqueMap() : HashMap<String, ArrayList<Unique>>() {
         for (unique in uniques) addUnique(unique)
     }
 
+    fun removeUnique(unique: Unique) {
+        val existingArrayList = get(unique.placeholderText)
+        existingArrayList?.remove(unique)
+    }
+
     fun getUniques(uniqueType: UniqueType) =
         this[uniqueType.placeholderText]?.asSequence() ?: emptySequence()
 

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -295,6 +295,23 @@ object UniqueTriggerActivation {
                     true
                 }
             }
+            UniqueType.OneTimeRemovePolicy -> {
+                val policyName = unique.params[0]
+                if (!civInfo.policies.isAdopted(policyName)) return null
+                val policy = civInfo.gameInfo.ruleset.policies[policyName] ?: return null
+
+                return {
+                    civInfo.policies.removePolicy(policy)
+
+                    val notificationText = getNotificationText(
+                        notification, triggerNotificationText,
+                        "You loss the [$policyName] Policy"
+                    )
+                    if (notificationText != null)
+                        civInfo.addNotification(notificationText, PolicyAction(policyName), NotificationCategory.General, NotificationIcon.Culture)
+                    true
+                }
+            }
             UniqueType.OneTimeEnterGoldenAge, UniqueType.OneTimeEnterGoldenAgeTurns -> {
                 return {
                     if (unique.type == UniqueType.OneTimeEnterGoldenAgeTurns) civInfo.goldenAges.enterGoldenAge(unique.params[0].toInt())

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -305,7 +305,7 @@ object UniqueTriggerActivation {
 
                     val notificationText = getNotificationText(
                         notification, triggerNotificationText,
-                        "You loss the [$policyName] Policy"
+                        "You lose the [$policyName] Policy"
                     )
                     if (notificationText != null)
                         civInfo.addNotification(notificationText, PolicyAction(policyName), NotificationCategory.General, NotificationIcon.Culture)

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -759,6 +759,7 @@ enum class UniqueType(
     OneTimeGainPopulationRandomCity("[amount] population in a random city", UniqueTarget.Triggerable),
     OneTimeDiscoverTech("Discover [tech]", UniqueTarget.Triggerable),
     OneTimeAdoptPolicy("Adopt [policy]", UniqueTarget.Triggerable),
+    OneTimeRemovePolicy("Remove [policy]", UniqueTarget.Triggerable),
     OneTimeFreeTech("Free Technology", UniqueTarget.Triggerable),  // used in Buildings
     OneTimeAmountFreeTechs("[positiveAmount] Free Technologies", UniqueTarget.Triggerable),  // used in Policy
     OneTimeFreeTechRuins("[positiveAmount] free random researchable Tech(s) from the [era]", UniqueTarget.Triggerable),

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -72,6 +72,11 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 	Applicable to: Triggerable
 
+??? example  "Remove [policy]"
+	Example: "Remove [Oligarchy]"
+
+	Applicable to: Triggerable
+
 ??? example  "Free Technology"
 	Applicable to: Triggerable
 


### PR DESCRIPTION
As per @AutumnPizazz's request in #11388, this unique will remove a specific policy while leaving unaffected any subsequent policies that have this policy as a prerequisite. If a policy branch has been completed, removing the policy will revert the branch to incomplete.
This unique has been thoroughly tested and work well either as a building unique or when combined with UnitActionModifier to trigger a unit action.