### PR TITLE
Fix softlock for spectator with free policies

### DIFF
--- a/core/src/com/unciv/ui/screens/pickerscreens/PolicyPickerScreen.kt
+++ b/core/src/com/unciv/ui/screens/pickerscreens/PolicyPickerScreen.kt
@@ -178,7 +178,7 @@ class PolicyPickerScreen(
 
         setDefaultCloseAction()
 
-        if (!viewingCiv.isSpectator() && policies.freePolicies > 0 && policies.canAdoptPolicy())
+        if (viewingCiv.isCurrentPlayer() && policies.freePolicies > 0 && policies.canAdoptPolicy())
             closeButton.disable()
 
         rightSideButton.onClick(UncivSound.Policy) {

--- a/core/src/com/unciv/ui/screens/pickerscreens/PolicyPickerScreen.kt
+++ b/core/src/com/unciv/ui/screens/pickerscreens/PolicyPickerScreen.kt
@@ -178,7 +178,7 @@ class PolicyPickerScreen(
 
         setDefaultCloseAction()
 
-        if (policies.freePolicies > 0 && policies.canAdoptPolicy() && !viewingCiv.isSpectator())
+        if (!viewingCiv.isSpectator() && policies.freePolicies > 0 && policies.canAdoptPolicy())
             closeButton.disable()
 
         rightSideButton.onClick(UncivSound.Policy) {

--- a/core/src/com/unciv/ui/screens/pickerscreens/PolicyPickerScreen.kt
+++ b/core/src/com/unciv/ui/screens/pickerscreens/PolicyPickerScreen.kt
@@ -178,7 +178,7 @@ class PolicyPickerScreen(
 
         setDefaultCloseAction()
 
-        if (policies.freePolicies > 0 && policies.canAdoptPolicy())
+        if (policies.freePolicies > 0 && policies.canAdoptPolicy() && !viewingCiv.isSpectator())
             closeButton.disable()
 
         rightSideButton.onClick(UncivSound.Policy) {


### PR DESCRIPTION
Btw, this feels like the wrong approach. I'm pretty sure if you have a free policy, the menu will always force you to pick a policy, so disabling the close button at all is unnecessary (and is annoying if you want to confirm sometime before picking). But I want to request if removing these lines is the route we want to go down before doing it, and this seems like the simpler fix