### PR TITLE
Implement Same-majority-religion-based diplomatic modifier

### DIFF
--- a/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
@@ -278,16 +278,11 @@ class DiplomacyManager() : IsPartOfGameInfoSerialization {
     }
 
     private fun believesSameReligion(): Boolean {
-        // what is the majority religion of civInfo?
-        val civMajorityReligion = civInfo.religionManager.getMajorityReligion()
-        // if civInfo has a majority religion
-        return if (civMajorityReligion==null) {
-            // if civInfo hasn't a majority religion
-            false
-        } else {
-            // if civInfo's majority religion is also majority religion of otherCiv (Boolean)
-            otherCiv().religionManager.isMajorityReligionForCiv(civMajorityReligion)
-        }
+        // what is the majorityReligion of civInfo? If it is null, we immediately return false
+        val civMajorityReligion = civInfo.religionManager.getMajorityReligion() ?: return false
+        // if not yet returned false from previous line, return the Boolean isMajorityReligionForCiv
+        // true if majorityReligion of civInfo is also majorityReligion of otherCiv, false otherwise
+        return otherCiv().religionManager.isMajorityReligionForCiv(civMajorityReligion)
     }
 
     /** Returns the number of turns to degrade from Ally or from Friend */
@@ -602,14 +597,12 @@ class DiplomacyManager() : IsPartOfGameInfoSerialization {
     }
 
     internal fun setReligionBasedModifier() {
-        if (civInfo.getDiplomacyManager(otherCiv()).believesSameReligion()) {
+        if (civInfo.getDiplomacyManager(otherCiv()).believesSameReligion())
             // they share same majority religion
             setModifier(DiplomaticModifiers.BelieveSameReligion, 5f)
-        }
-        else {
+        else
             // their majority religions differ or one or both don't have a majority religion at all
             removeModifier(DiplomaticModifiers.BelieveSameReligion)
-        }
     }
 
     fun denounce() {

--- a/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
@@ -277,30 +277,18 @@ class DiplomacyManager() : IsPartOfGameInfoSerialization {
         }
     }
 
-    private fun believesSameReligion(): Boolean? {
-        // believing same/different religion - modifiers
+    private fun believesSameReligion(): Boolean {
         // what is the majority religion of civInfo?
         val civMajorityReligion = civInfo.gameInfo.religions.values.firstOrNull {
             civInfo.religionManager.isMajorityReligionForCiv(it)
         }
         // if civInfo has a majority religion
-        if (civMajorityReligion!=null) {
-            val otherCivMajorityReligion = otherCiv().gameInfo.religions.values.firstOrNull {
-                otherCiv().religionManager.isMajorityReligionForCiv(it)
-            }
-            // if otherCiv has a majority religion
-            return if (otherCivMajorityReligion!=null) {
-                // if otherCiv's majority religion equals civInfo's religion return "true", "else" otherwise
-                (civMajorityReligion.name == otherCivMajorityReligion.name)
-            }
-            // if otherCiv hasn't a majority religion
-            else {
-                null
-            }
-        }
-        // if civInfo hasn't a majority religion
-        else {
-            return null
+        return if (civMajorityReligion==null) {
+            // if civInfo hasn't a majority religion
+            false
+        } else {
+            // if civInfo's majority religion is also majority religion of otherCiv (Boolean)
+            otherCiv().religionManager.isMajorityReligionForCiv(civMajorityReligion)
         }
     }
 
@@ -616,19 +604,13 @@ class DiplomacyManager() : IsPartOfGameInfoSerialization {
     }
 
     internal fun setReligionBasedModifier() {
-        val shareReligionTrueFalseOrNull = civInfo.getDiplomacyManager(otherCiv()).believesSameReligion()
-        if (shareReligionTrueFalseOrNull!=null) {
-            if (shareReligionTrueFalseOrNull) {
-                // they share same majority religion
-                setModifier(DiplomaticModifiers.BelieveSameReligion, 5f)
-            }
-            else {
-                // their majority religions differ
-                removeModifier(DiplomaticModifiers.BelieveSameReligion)
-            }
+        val shareReligionBoolean = civInfo.getDiplomacyManager(otherCiv()).believesSameReligion()
+        if (shareReligionBoolean) {
+            // they share same majority religion
+            setModifier(DiplomaticModifiers.BelieveSameReligion, 5f)
         }
         else {
-            // one or both civs don't have a majority religion at all
+            // their majority religions differ or one or both don't have a majority religion at all
             removeModifier(DiplomaticModifiers.BelieveSameReligion)
         }
     }

--- a/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
@@ -604,8 +604,7 @@ class DiplomacyManager() : IsPartOfGameInfoSerialization {
     }
 
     internal fun setReligionBasedModifier() {
-        val shareReligionBoolean = civInfo.getDiplomacyManager(otherCiv()).believesSameReligion()
-        if (shareReligionBoolean) {
+        if (civInfo.getDiplomacyManager(otherCiv()).believesSameReligion()) {
             // they share same majority religion
             setModifier(DiplomaticModifiers.BelieveSameReligion, 5f)
         }

--- a/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
@@ -279,9 +279,7 @@ class DiplomacyManager() : IsPartOfGameInfoSerialization {
 
     private fun believesSameReligion(): Boolean {
         // what is the majority religion of civInfo?
-        val civMajorityReligion = civInfo.gameInfo.religions.values.firstOrNull {
-            civInfo.religionManager.isMajorityReligionForCiv(it)
-        }
+        val civMajorityReligion = civInfo.religionManager.getMajorityReligion()
         // if civInfo has a majority religion
         return if (civMajorityReligion==null) {
             // if civInfo hasn't a majority religion

--- a/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyTurnManager.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyTurnManager.kt
@@ -291,6 +291,8 @@ object DiplomacyTurnManager {
 
         setDefensivePactBasedModifier()
 
+        setReligionBasedModifier()
+
         if (!hasFlag(DiplomacyFlags.DeclarationOfFriendship))
             revertToZero(DiplomaticModifiers.DeclarationOfFriendship, 1 / 2f) //decreases slowly and will revert to full if it is declared later
 

--- a/core/src/com/unciv/logic/civilization/managers/ReligionManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/ReligionManager.kt
@@ -478,6 +478,27 @@ class ReligionManager : IsPartOfGameInfoSerialization {
         if (religion == null) return null
         return civInfo.gameInfo.getCities().firstOrNull { it.isHolyCityOf(religion!!.name) }
     }
+
+    fun getMajorityReligion(): Religion? {
+        // let's count for each religion (among those actually presents in civ's cities)
+        val religionCounter = Counter<Religion>()
+        for (city in civInfo.cities) {
+            val cityMajorityReligion = city.religion.getMajorityReligion()
+            if (cityMajorityReligion != null) {
+                // if city's majority Religion is not null let's add to counter
+                religionCounter.add(cityMajorityReligion, 1)
+            }
+        }
+        // let's get the max-counted Religion if there is one or null otherwise
+        val maxReligionCounterEntry = religionCounter.maxByOrNull { it.value }
+        // if maxReligionCounterEntry is not null AND maxReligionCounterEntry > half-cities-count we return the Religion of maxReligionCounterEntry
+        return if ((maxReligionCounterEntry != null) && (maxReligionCounterEntry.value > civInfo.cities.size / 2)) {
+            maxReligionCounterEntry.key
+        } else {
+            // if maxReligionCounterEntry is null or <= half-cities-count we just return null
+            null
+        }
+    }
 }
 
 enum class ReligionState : IsPartOfGameInfoSerialization {

--- a/core/src/com/unciv/logic/civilization/managers/ReligionManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/ReligionManager.kt
@@ -483,21 +483,20 @@ class ReligionManager : IsPartOfGameInfoSerialization {
         // let's count for each religion (among those actually presents in civ's cities)
         val religionCounter = Counter<Religion>()
         for (city in civInfo.cities) {
-            val cityMajorityReligion = city.religion.getMajorityReligion()
-            if (cityMajorityReligion != null) {
-                // if city's majority Religion is not null let's add to counter
-                religionCounter.add(cityMajorityReligion, 1)
-            }
+            // if city's majority Religion is null, let's just continue to next loop iteration
+            val cityMajorityReligion = city.religion.getMajorityReligion() ?: continue
+            // if not yet continued to next iteration from previous line, let's add the Religion to religionCounter
+            religionCounter.add(cityMajorityReligion, 1)
         }
-        // let's get the max-counted Religion if there is one or null otherwise
-        val maxReligionCounterEntry = religionCounter.maxByOrNull { it.value }
-        // if maxReligionCounterEntry is not null AND maxReligionCounterEntry > half-cities-count we return the Religion of maxReligionCounterEntry
-        return if ((maxReligionCounterEntry != null) && (maxReligionCounterEntry.value > civInfo.cities.size / 2)) {
+        // let's get the max-counted Religion if there is one, null otherwise; if null, return null
+        val maxReligionCounterEntry = religionCounter.maxByOrNull { it.value } ?: return null
+        // if not returned null from prev. line, check if the maxReligion is in most of the cities
+        return if (maxReligionCounterEntry.value > civInfo.cities.size / 2)
+        // if maxReligionCounterEntry > half-cities-count we return the Religion of maxReligionCounterEntry
             maxReligionCounterEntry.key
-        } else {
-            // if maxReligionCounterEntry is null or <= half-cities-count we just return null
+        else
+        // if maxReligionCounterEntry <= half-cities-count we just return null
             null
-        }
     }
 }
 


### PR DESCRIPTION
@yairm210 Hi, this is my very fist attempt at implementing an actual feature (my previous contributions where mainly translations to Italian), so, I'm sorry if I might have not strictly followed some guidelines or standards.
My Pull Request is meant to add handling for specific Diplomatic Modifier for "we believe in the same religion".
I have found this guide that is quite complete for Civ5 Diplomacy:

https://forums.civfanatics.com/resources/diplomacy-interacting-with-civs-and-positive-negative-diplomacy-modifiers-bnw.25611/
> -5|You have adopted their Religion in the majority of your Cities

Then I put +5 and considered only the "positive" modifier if the majority religion is the same and considered no negative modifier for the opposite situation (majority religion is different).

The need for this feature comes from #4674, and more specifically:
> Sharing Religion - If at least half of their cities share your Religion, it has similar effects to the lower spectrum of providing help to them.

Let me know if there is any specific steps further I should follow (I have debugged it a bit using the debugger and the logic seems be working, even if it is a bit complicated to reach the condition/situation starting a game from scratch, which I did) I don't know if you have suggestions about how to test it more efficiently.
   
Also: will the Language assets, and in particular properties lines requiring for custom translations, be created automatically by some specific procedure? Should I add a line in some template file to let it propagate to all Language-specific properties files with `#Requires translation` line comment?
   
   Thank you very much in advance.
    