### PR TITLE
Added mod constant and unique to adjust air unit capacity

### DIFF
--- a/core/src/com/unciv/logic/city/City.kt
+++ b/core/src/com/unciv/logic/city/City.kt
@@ -403,9 +403,14 @@ class City : IsPartOfGameInfoSerialization {
 
     fun canPlaceNewUnit(construction: BaseUnit): Boolean {
         val tile = getCenterTile()
+        val airUnitCapacity = tile.getCity()?.civ!!.gameInfo.ruleset.modOptions.constants.airUnitCapacity
+        val airUnitCapacityFromUniques = getMatchingUniques(UniqueType.AirUnitCapacity)
+            .filter { matchesFilter(it.params[1]) }
+            .sumOf { it.params[0].toInt() }
+
         return when {
             construction.isCivilian() -> tile.civilianUnit == null
-            construction.movesLikeAirUnits() -> tile.airUnits.count { !it.isTransported } < 6
+            construction.movesLikeAirUnits() -> tile.airUnits.count { !it.isTransported } < (airUnitCapacity + airUnitCapacityFromUniques)
             else -> tile.militaryUnit == null
         }
     }

--- a/core/src/com/unciv/logic/city/City.kt
+++ b/core/src/com/unciv/logic/city/City.kt
@@ -403,14 +403,10 @@ class City : IsPartOfGameInfoSerialization {
 
     fun canPlaceNewUnit(construction: BaseUnit): Boolean {
         val tile = getCenterTile()
-        val airUnitCapacity = tile.getCity()?.civ!!.gameInfo.ruleset.modOptions.constants.airUnitCapacity
-        val airUnitCapacityFromUniques = getMatchingUniques(UniqueType.AirUnitCapacity)
-            .filter { matchesFilter(it.params[1]) }
-            .sumOf { it.params[0].toInt() }
 
         return when {
             construction.isCivilian() -> tile.civilianUnit == null
-            construction.movesLikeAirUnits() -> tile.airUnits.count { !it.isTransported } < (airUnitCapacity + airUnitCapacityFromUniques)
+            construction.movesLikeAirUnits() -> tile.airUnits.count { !it.isTransported } < tile.getAirUnitCapacity()
             else -> tile.militaryUnit == null
         }
     }

--- a/core/src/com/unciv/logic/map/mapunit/movement/UnitMovement.kt
+++ b/core/src/com/unciv/logic/map/mapunit/movement/UnitMovement.kt
@@ -602,12 +602,7 @@ class UnitMovement(val unit: MapUnit) {
     private fun canAirUnitMoveTo(tile: Tile, unit: MapUnit): Boolean {
         // landing in the city
         if (tile.isCityCenter()) {
-            val airUnitCapacity = tile.getCity()?.civ!!.gameInfo.ruleset.modOptions.constants.airUnitCapacity
-            val airUnitCapacityFromUniques = tile.getCity()!!.getMatchingUniques(UniqueType.AirUnitCapacity)
-                .filter { tile.getCity()!!.matchesFilter(it.params[1]) }
-                .sumOf { it.params[0].toInt() }
-
-            if (tile.airUnits.filter { !it.isTransported }.size < (airUnitCapacity + airUnitCapacityFromUniques)
+            if (tile.airUnits.filter { !it.isTransported }.size < tile.getAirUnitCapacity()
                 && tile.getCity()?.civ == unit.civ)
                 return true // if city is free - no problem, get in
         } // let's check whether it enters city on carrier now...

--- a/core/src/com/unciv/logic/map/mapunit/movement/UnitMovement.kt
+++ b/core/src/com/unciv/logic/map/mapunit/movement/UnitMovement.kt
@@ -602,7 +602,13 @@ class UnitMovement(val unit: MapUnit) {
     private fun canAirUnitMoveTo(tile: Tile, unit: MapUnit): Boolean {
         // landing in the city
         if (tile.isCityCenter()) {
-            if (tile.airUnits.filter { !it.isTransported }.size < 6 && tile.getCity()?.civ == unit.civ)
+            val airUnitCapacity = tile.getCity()?.civ!!.gameInfo.ruleset.modOptions.constants.airUnitCapacity
+            val airUnitCapacityFromUniques = tile.getCity()!!.getMatchingUniques(UniqueType.AirUnitCapacity)
+                .filter { tile.getCity()!!.matchesFilter(it.params[1]) }
+                .sumOf { it.params[0].toInt() }
+
+            if (tile.airUnits.filter { !it.isTransported }.size < (airUnitCapacity + airUnitCapacityFromUniques)
+                && tile.getCity()?.civ == unit.civ)
                 return true // if city is free - no problem, get in
         } // let's check whether it enters city on carrier now...
 

--- a/core/src/com/unciv/logic/map/tile/Tile.kt
+++ b/core/src/com/unciv/logic/map/tile/Tile.kt
@@ -519,7 +519,7 @@ class Tile : IsPartOfGameInfoSerialization {
             "Water resource" -> isWater && observingCiv != null && hasViewableResource(observingCiv)
             "Featureless" -> terrainFeatures.isEmpty()
             Constants.freshWaterFilter -> isAdjacentTo(Constants.freshWater, observingCiv)
-            
+
             else -> {
                 if (allTerrains.any { it.matchesFilter(filter) }) return true
                 if (getOwner()?.matchesFilter(filter) == true) return true
@@ -559,6 +559,15 @@ class Tile : IsPartOfGameInfoSerialization {
     fun getTilesInDistance(distance: Int): Sequence<Tile> = tileMap.getTilesInDistance(position, distance)
     fun getTilesInDistanceRange(range: IntRange): Sequence<Tile> = tileMap.getTilesInDistanceRange(position, range)
     fun getTilesAtDistance(distance: Int): Sequence<Tile> =tileMap.getTilesAtDistance(position, distance)
+
+    fun getAirUnitCapacity(): Int {
+        val airUnitCapacity = this.getCity()!!.civ.gameInfo.ruleset.modOptions.constants.airUnitCapacity
+        val airUnitCapacityFromUniques = this.getCity()!!.getMatchingUniques(UniqueType.AirUnitCapacity)
+            .filter { this.getCity()!!.matchesFilter(it.params[1]) }
+            .sumOf { it.params[0].toInt() }
+
+        return airUnitCapacity + airUnitCapacityFromUniques
+    }
 
     fun getDefensiveBonus(includeImprovementBonus: Boolean = true): Float {
         var bonus = baseTerrainObject.defenceBonus

--- a/core/src/com/unciv/models/ModConstants.kt
+++ b/core/src/com/unciv/models/ModConstants.kt
@@ -84,6 +84,8 @@ class ModConstants {
 
     var workboatAutomationSearchMaxTiles = 20
 
+    var airUnitCapacity = 6
+
     fun merge(other: ModConstants) {
         for (field in this::class.java.declaredFields) {
             val value = field.get(other)

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -252,6 +252,8 @@ enum class UniqueType(
 
     SpawnRebels("Rebel units may spawn", UniqueTarget.Global),
 
+    AirUnitCapacity("[amount] air unit capacity [cityFilter]", UniqueTarget.Global),
+
     // endregion Other global uniques
 
     // endregion 01 Global uniques

--- a/docs/Modders/Mod-file-structure/5-Miscellaneous-JSON-files.md
+++ b/docs/Modders/Mod-file-structure/5-Miscellaneous-JSON-files.md
@@ -203,6 +203,7 @@ and city distance in another. In case of conflicts, there is no guarantee which 
 | pantheonBase                             | Int    | 10                            | [^L]  |
 | pantheonGrowth                           | Int    | 5                             | [^L]  |
 | workboatAutomationSearchMaxTiles         | Int    | 20                            | [^M]  |
+| airUnitCapacity                          | Int    | 6                             | [^N]  |
 
 Legend:
 
@@ -233,6 +234,7 @@ Legend:
 - [^K]: Maximum foundable Religions = religionLimitBase + floor(MajorCivCount * religionLimitMultiplier)
 - [^L]: Cost of pantheon = pantheonBase + CivsWithReligion * pantheonGrowth
 - [^M]: When the AI decidees whether to build a work boat, how many tiles to search from the city center for an improvable tile
+- [^N]: The maximum number of air units that a city can hold
 
 #### UnitUpgradeCost
 

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -800,7 +800,7 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 	Applicable to: Global
 
 ??? example  "[amount] air unit capacity [cityFilter]"
-Example: "[3] air unit capacity [in all cities]"
+	Example: "[3] air unit capacity [in all cities]"
 
 	Applicable to: Global
 

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -799,6 +799,11 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 ??? example  "Rebel units may spawn"
 	Applicable to: Global
 
+??? example  "[amount] air unit capacity [cityFilter]"
+Example: "[3] air unit capacity [in all cities]"
+
+	Applicable to: Global
+
 ??? example  "[relativeAmount]% Strength"
 	Example: "[+20]% Strength"
 


### PR DESCRIPTION
In the game by default, the maximum air unit capacity in a city is limited to only 6. This PR added a new mod constant to store this value and a new global unique for modders to adjust it.

The new unique is tested by including it in the following JSON files:
- GlobalUniques.json: `[+2] air unit capacity [in all cities]`
- **Air Port** in Buildings.json: `[+4] air unit capacity [in this city]`

Result:
<img src="https://github.com/yairm210/Unciv/assets/71725118/d37140be-ff9a-4113-b529-34d46639b816" alt="gameplay picture" width="625" height="363" />

- Beijing has air unit capacity of 12 (default 6 + 2 from global + 4 from air port)
- Shanghai has air unit capacity of 8 (default 6 + 2 from global)
