### PR TITLE
New game and custom/mod maps UI update and sync fixes

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -349,6 +349,7 @@ Four Corners =
 Archipelago = 
 Inner Sea = 
 Perlin = 
+Select players from starting locations = 
 Random number of Civilizations = 
 Min number of Civilizations = 
 Max number of Civilizations = 

--- a/core/src/com/unciv/logic/files/MapSaver.kt
+++ b/core/src/com/unciv/logic/files/MapSaver.kt
@@ -40,22 +40,20 @@ object MapSaver {
 
     private fun mapFromJson(json: String): TileMap = json().fromJson(TileMap::class.java, json)
 
-    /** Class to parse only the parameters out of a map file */
-    private class TileMapPreview {
-        val mapParameters = MapParameters()
-    }
-
     fun loadMapParameters(mapFile: FileHandle): MapParameters {
-        return mapParametersFromSavedString(mapFile.readString())
+        return loadMapPreview(mapFile).mapParameters
     }
 
-    @Suppress("MemberVisibilityCanBePrivate")
-    fun mapParametersFromSavedString(mapString: String): MapParameters {
+    fun loadMapPreview(mapFile: FileHandle): TileMap.Preview {
+        return mapPreviewFromSavedString(mapFile.readString())
+    }
+
+    private fun mapPreviewFromSavedString(mapString: String): TileMap.Preview {
         val unzippedJson = try {
             Gzip.unzip(mapString.trim())
         } catch (_: Exception) {
             mapString
         }
-        return json().fromJson(TileMapPreview::class.java, unzippedJson).mapParameters
+        return json().fromJson(TileMap.Preview::class.java, unzippedJson)
     }
 }

--- a/core/src/com/unciv/logic/map/TileMap.kt
+++ b/core/src/com/unciv/logic/map/TileMap.kt
@@ -106,7 +106,7 @@ class TileMap(initialCapacity: Int = 10) : IsPartOfGameInfoSerialization {
     /**
      * creates a hexagonal map of given radius (filled with grassland)
      *
-     * To help you visualize how UnCiv hexagonal cooridinate system works, here's a small example:
+     * To help you visualize how UnCiv hexagonal coordinate system works, here's a small example:
      *
      *          _____         _____         _____
      *         /     \       /     \       /     \
@@ -119,10 +119,10 @@ class TileMap(initialCapacity: Int = 10) : IsPartOfGameInfoSerialization {
      * / 1 ,-2 \_____/ 0,-1  \_____/ -1,0  \_____/ -2,1  \
      * \       /     \       /     \       /     \       /
      *  \_____/ 0,-2  \_____/ -1,-1 \_____/ -2,0  \_____/
-     *  /     \       /     \       /     \       /
-     * / 0,-3  \_____/ -1,-2 \_____/ -2,-1 \_____/
-     * \       /     \       /     \       /
-     *  \_____/       \_____/       \_____/
+     *  /     \       /     \       /     \       /     \
+     * / 0,-3  \_____/ -1,-2 \_____/ -2,-1 \_____/ -3,0  \
+     * \       /     \       /     \       /     \       /
+     *  \_____/       \_____/       \_____/       \_____/
      *
      *
      * The rules are simple if you think about your X and Y axis as diagonal w.r.t. a standard carthesian plane. As such:
@@ -132,8 +132,9 @@ class TileMap(initialCapacity: Int = 10) : IsPartOfGameInfoSerialization {
      * moving "up-right" and "down-left": moving along Y axis
      * moving "up-left" and "down-right": moving along X axis
      *
-     * Tip: you can always use the in-game map editor if you have any doubt
-     * */
+     * Tip: you can always use the in-game map editor if you have any doubt,
+     * and the "secret" options can turn on coordinate display on the main map.
+     */
     constructor(radius: Int, ruleset: Ruleset, worldWrap: Boolean = false)
             : this (HexMath.getNumberOfTilesInHexagon(radius)) {
         startingLocations.clear()
@@ -749,4 +750,11 @@ class TileMap(initialCapacity: Int = 10) : IsPartOfGameInfoSerialization {
         }
     }
     //endregion
+
+    /** Class to parse only the parameters and starting locations out of a map file */
+    class Preview {
+        val mapParameters = MapParameters()
+        private val startingLocations = arrayListOf<StartingLocation>()
+        fun getDeclaredNations() = startingLocations.asSequence().map { it.nation }.distinct()
+    }
 }

--- a/core/src/com/unciv/ui/components/extensions/CollectionExtensions.kt
+++ b/core/src/com/unciv/ui/components/extensions/CollectionExtensions.kt
@@ -75,6 +75,11 @@ fun <T> Iterable<T>.toGdxArray(): Array<T> {
     for (it in this) arr.add(it)
     return arr
 }
+fun <T> Sequence<T>.toGdxArray(): Array<T> {
+    val arr = Array<T>()
+    for (it in this) arr.add(it)
+    return arr
+}
 
 /** [yield][SequenceScope.yield]s [element] if it's not null */
 suspend fun <T> SequenceScope<T>.yieldIfNotNull(element: T?) {

--- a/core/src/com/unciv/ui/components/widgets/LoadingImage.kt
+++ b/core/src/com/unciv/ui/components/widgets/LoadingImage.kt
@@ -132,6 +132,8 @@ class LoadingImage(
         if (animated) hideAnimated(onComplete)
         else hideDelayed(onComplete)
 
+    fun isShowing() = loadingIcon.isVisible && actions.isEmpty
+
     //region Hiding helpers
     private fun hideAnimated(onComplete: (() -> Unit)?) {
         actions.clear()

--- a/core/src/com/unciv/ui/screens/newgamescreen/GameOptionsTable.kt
+++ b/core/src/com/unciv/ui/screens/newgamescreen/GameOptionsTable.kt
@@ -42,9 +42,9 @@ class GameOptionsTable(
     private val updatePlayerPickerTable: (desiredCiv: String) -> Unit,
     private val updatePlayerPickerRandomLabel: () -> Unit
 ) : Table(BaseScreen.skin) {
-    var gameParameters = previousScreen.gameSetupInfo.gameParameters
-    var ruleset = previousScreen.ruleset
-    var locked = false
+    private var gameParameters = previousScreen.gameSetupInfo.gameParameters
+    private var ruleset = previousScreen.ruleset
+    internal var locked = false
 
     private var baseRulesetHash = gameParameters.baseRuleset.hashCode()
 
@@ -56,7 +56,7 @@ class GameOptionsTable(
      *
      *  The second reason this is public: [NewGameScreen] accesses [ModCheckboxTable.savedModcheckResult] for display.
      */
-    val modCheckboxes = getModCheckboxes(isPortrait = isPortrait)
+    internal val modCheckboxes = getModCheckboxes(isPortrait = isPortrait)
 
     // Remember this so we can unselect it when the pool dialog returns an empty pool
     private var randomNationsPoolCheckbox: CheckBox? = null
@@ -74,12 +74,12 @@ class GameOptionsTable(
         clear()
 
         // Mods may have changed (e.g. custom map selection)
+        modCheckboxes.updateSelection()
         val newBaseRulesetHash = gameParameters.baseRuleset.hashCode()
         if (newBaseRulesetHash != baseRulesetHash) {
             baseRulesetHash = newBaseRulesetHash
             modCheckboxes.setBaseRuleset(gameParameters.baseRuleset)
         }
-        modCheckboxes.updateSelection()
 
         add(Table().apply {
             defaults().pad(5f)
@@ -442,6 +442,7 @@ class GameOptionsTable(
     fun updateRuleset(ruleset: Ruleset) {
         this.ruleset = ruleset
         gameParameters.acceptedModCheckErrors = ""
+        modCheckboxes.updateSelection()
         modCheckboxes.setBaseRuleset(gameParameters.baseRuleset)
     }
 
@@ -492,6 +493,11 @@ class GameOptionsTable(
         }
 
         updatePlayerPickerTable(desiredCiv)
+    }
+
+    fun changeGameParameters(newGameParameters: GameParameters) {
+        gameParameters = newGameParameters
+        modCheckboxes.changeGameParameters(newGameParameters)
     }
 }
 

--- a/core/src/com/unciv/ui/screens/newgamescreen/MapFileSelectTable.kt
+++ b/core/src/com/unciv/ui/screens/newgamescreen/MapFileSelectTable.kt
@@ -1,6 +1,8 @@
 package com.unciv.ui.screens.newgamescreen
 
 import com.badlogic.gdx.files.FileHandle
+import com.badlogic.gdx.graphics.Color
+import com.badlogic.gdx.scenes.scene2d.Actor
 import com.badlogic.gdx.scenes.scene2d.Group
 import com.badlogic.gdx.scenes.scene2d.actions.Actions
 import com.badlogic.gdx.scenes.scene2d.ui.Cell
@@ -23,6 +25,7 @@ import com.unciv.ui.components.extensions.toLabel
 import com.unciv.ui.components.extensions.toTextButton
 import com.unciv.ui.components.input.onActivation
 import com.unciv.ui.components.input.onChange
+import com.unciv.ui.components.widgets.LoadingImage
 import com.unciv.ui.popups.AnimatedMenuPopup
 import com.unciv.ui.screens.basescreen.BaseScreen
 import com.unciv.ui.screens.victoryscreen.LoadMapPreview
@@ -41,6 +44,7 @@ class MapFileSelectTable(
 ) : Table() {
     private val mapCategorySelectBox = SelectBox<String>(BaseScreen.skin)
     private val mapFileSelectBox = SelectBox<MapWrapper>(BaseScreen.skin)
+    private val loadingIcon = LoadingImage(30f, loadingColor = Color.SCARLET)
     private val useNationsFromMapButton = "Select players from starting locations".toTextButton(AnimatedMenuPopup.SmallButtonStyle())
     private val useNationsButtonCell: Cell<Actor?>
     private var mapNations = emptySequence<String>()
@@ -74,6 +78,8 @@ class MapFileSelectTable(
             add(mapFileSelectBox).width(selectBoxWidth).right().row()
         }).growX()
 
+        add(loadingIcon).padRight(5f).padLeft(0f).row()
+
         useNationsButtonCell = add().pad(0f)
         row()
 
@@ -103,6 +109,7 @@ class MapFileSelectTable(
             MapWrapper(it, MapSaver.loadMapPreview(it))
         }
 
+        loadingIcon.show()
         Concurrency.run {
             mapFilesFlow
                 .onEach {
@@ -114,6 +121,9 @@ class MapFileSelectTable(
                 .catch {}
                 .collect()
             Concurrency.runOnGLThread {
+                loadingIcon.hide {
+                    loadingIcon.remove()
+                }
                 onCategorySelectBoxChange() // re-sort lower SelectBox
             }
         }

--- a/core/src/com/unciv/ui/screens/newgamescreen/MapFileSelectTable.kt
+++ b/core/src/com/unciv/ui/screens/newgamescreen/MapFileSelectTable.kt
@@ -44,7 +44,7 @@ class MapFileSelectTable(
 ) : Table() {
     private val mapCategorySelectBox = SelectBox<String>(BaseScreen.skin)
     private val mapFileSelectBox = SelectBox<MapWrapper>(BaseScreen.skin)
-    private val loadingIcon = LoadingImage(30f, loadingColor = Color.SCARLET)
+    private val loadingIcon = LoadingImage(30f, LoadingImage.Style(loadingColor = Color.SCARLET))
     private val useNationsFromMapButton = "Select players from starting locations".toTextButton(AnimatedMenuPopup.SmallButtonStyle())
     private val useNationsButtonCell: Cell<Actor?>
     private var mapNations = emptySequence<String>()
@@ -137,7 +137,7 @@ class MapFileSelectTable(
             val sortToTop = newGameScreen.gameSetupInfo.gameParameters.baseRuleset
             val select = if (mapCategorySelectBox.selection.isEmpty) categoryName
                     else mapCategorySelectBox.selected
-            // keep Ruleset Selectbox sorted while async is running - few entries
+            // keep Ruleset SelectBox sorted while async is running - few entries
             val newItems = (mapCategorySelectBox.items.asSequence() + categoryName)
                 .sortedWith(
                     compareBy<String?> { it != sortToTop }
@@ -168,6 +168,11 @@ class MapFileSelectTable(
     private fun FileHandle.isRecentlyModified() = lastModified() > System.currentTimeMillis() - 900000
     fun isNotEmpty() = firstMap != null
     fun recentlySavedMapExists() = firstMap != null && firstMap!!.isRecentlyModified()
+
+    fun activateCustomMaps() {
+        if (loadingIcon.isShowing()) return // Default map selection will be handled when background loading finishes
+        onFileSelectBoxChange()
+    }
 
     private fun onCategorySelectBoxChange() {
         val selectedRuleset: String? = mapCategorySelectBox.selected
@@ -203,7 +208,7 @@ class MapFileSelectTable(
         // Do NOT try to put back the "bad" preselection!
     }
 
-    fun onSelectBoxChange() {
+    private fun onFileSelectBoxChange() {
         cancelBackgroundJobs()
         if (mapFileSelectBox.selection.isEmpty) return
         val selection = mapFileSelectBox.selected
@@ -226,7 +231,7 @@ class MapFileSelectTable(
         newGameScreen.gameSetupInfo.gameParameters.mods = LinkedHashSet(mapMods.second)
         newGameScreen.gameSetupInfo.gameParameters.baseRuleset = mapMods.first.firstOrNull()
             ?: selection.mapPreview.mapParameters.baseRuleset
-        val success = newGameScreen.tryUpdateRuleset()
+        val success = newGameScreen.tryUpdateRuleset(updateUI = true)
         newGameScreen.updateTables()
         hideMiniMap()
         if (success) {

--- a/core/src/com/unciv/ui/screens/newgamescreen/MapOptionsTable.kt
+++ b/core/src/com/unciv/ui/screens/newgamescreen/MapOptionsTable.kt
@@ -38,7 +38,7 @@ class MapOptionsTable(private val newGameScreen: NewGameScreen, isReset: Boolean
                 MapGeneratedMainType.custom -> {
                     mapParameters.type = MapGeneratedMainType.custom
                     mapTypeSpecificTable.add(savedMapOptionsTable)
-                    savedMapOptionsTable.onSelectBoxChange()
+                    savedMapOptionsTable.activateCustomMaps()
                     newGameScreen.unlockTables()
                 }
                 MapGeneratedMainType.generated -> {

--- a/core/src/com/unciv/ui/screens/newgamescreen/ModCheckboxTable.kt
+++ b/core/src/com/unciv/ui/screens/newgamescreen/ModCheckboxTable.kt
@@ -4,6 +4,7 @@ import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.scenes.scene2d.ui.CheckBox
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener
+import com.unciv.models.metadata.GameParameters
 import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.ruleset.RulesetCache
 import com.unciv.models.ruleset.validation.ModCompatibility
@@ -18,14 +19,14 @@ import com.unciv.ui.screens.basescreen.BaseScreen
  * A widget containing one expander for extension mods.
  * Manages compatibility checks, warns or prevents incompatibilities.
  *
- * @param mods In/out set of active mods, modified in place
+ * @param mods **Reference**: In/out set of active mods, modified in place: If this needs to change, call [changeGameParameters]
  * @param initialBaseRuleset The selected base Ruleset, only for running mod checks against. Use [setBaseRuleset] to change on the fly.
  * @param screen Parent screen, used only to show [ToastPopup]s
  * @param isPortrait Used only for minor layout tweaks, arrangement is always vertical
  * @param onUpdate Callback, parameter is the mod name, called after any checks that may prevent mod selection succeed.
  */
 class ModCheckboxTable(
-    private val mods: LinkedHashSet<String>,
+    private var mods: LinkedHashSet<String>,
     initialBaseRuleset: String,
     private val screen: BaseScreen,
     isPortrait: Boolean = false,
@@ -217,4 +218,8 @@ class ModCheckboxTable(
              .filter { it.widget.isChecked }
              .map { it.mod }
              .asIterable()
+
+    fun changeGameParameters(newGameParameters: GameParameters) {
+        mods = newGameParameters.mods
+    }
 }

--- a/core/src/com/unciv/ui/screens/newgamescreen/NewGameScreen.kt
+++ b/core/src/com/unciv/ui/screens/newgamescreen/NewGameScreen.kt
@@ -406,7 +406,7 @@ class NewGameScreen(
     fun updateTables() {
         playerPickerTable.gameParameters = gameSetupInfo.gameParameters
         playerPickerTable.update()
-        newGameOptionsTable.gameParameters = gameSetupInfo.gameParameters
+        newGameOptionsTable.changeGameParameters(gameSetupInfo.gameParameters)
         newGameOptionsTable.update()
     }
 

--- a/core/src/com/unciv/ui/screens/newgamescreen/NewGameScreen.kt
+++ b/core/src/com/unciv/ui/screens/newgamescreen/NewGameScreen.kt
@@ -41,9 +41,9 @@ import com.unciv.ui.screens.pickerscreens.PickerScreen
 import com.unciv.utils.Concurrency
 import com.unciv.utils.Log
 import com.unciv.utils.launchOnGLThread
-import kotlinx.coroutines.coroutineScope
 import java.net.URL
 import java.util.UUID
+import kotlinx.coroutines.coroutineScope
 import kotlin.math.floor
 import com.unciv.ui.components.widgets.AutoScrollPane as ScrollPane
 
@@ -55,7 +55,7 @@ class NewGameScreen(
     override var gameSetupInfo = defaultGameSetupInfo ?: GameSetupInfo.fromSettings()
     override val ruleset = Ruleset()  // updateRuleset will clear and add
     private val newGameOptionsTable: GameOptionsTable
-    private val playerPickerTable: PlayerPickerTable
+    internal val playerPickerTable: PlayerPickerTable
     private val mapOptionsTable: MapOptionsTable
 
     init {


### PR DESCRIPTION
Following #11368 and #11398 - there's still nasty bugs plaguing the new game screen.
However, I only noticed + tested + fixed because I cleaned up branches and found a months-old one that I then tried to merge-forward. Turns out it's running better now than when I abandoned it 'cuz those other PR's paved the way a little...

So, markedly changed UI with important fixes on top - I could backport them to master and do those first, but that would mean a few hours extra at this point - and lazy.

<details><summary>clip</summary>

https://github.com/yairm210/Unciv/assets/63000004/2b811b7d-d987-4487-a3b2-abc8346818b3

</details>

* Maps presented in master-child dropdown boxes, no more superlong decorated names.
* Async loading / pre-parsing map files implemented as flow
* Loading indicator - with tons of maps and some artificial delay in the map parsing I could even _watch_ the entries trickling in.
* Selecting a map that has at least one non-generic, non-city-state starting location, there's a "Select players from starting locations" button. One random candidate is set as human, the rest in alphabetic order as AI.
* Selecting a map sets the mods it had when saved in the editor - now correctly as intended. Dunno if the clip shows, could be scrolled out of sight, but Latam America XXL doesn't have Latam selected, but America XL does, and you see that both in the mods list and the player list.
* (at the end demoed: going back to generated won't revert the mod selection - but doing so manually will now clean up the latam-specific civs - in arepa's video that was not the case - due to out of sync instances of the mod collection)