### PR TITLE
Two extension features for custom maps

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -545,6 +545,7 @@ Choose a Wesnoth map file =
 That map is invalid! = 
 ("[code]" does not conform to TerrainCodesWML) = 
 Use for new game "Select players" button: = 
+Enter a description for the users of this map = 
 
 ## Map/Tool names
 My new map = 

--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -544,6 +544,7 @@ An overlay image is incompatible with world wrap and was deactivated. =
 Choose a Wesnoth map file = 
 That map is invalid! = 
 ("[code]" does not conform to TerrainCodesWML) = 
+Use for new game "Select players" button: = 
 
 ## Map/Tool names
 My new map = 
@@ -571,6 +572,7 @@ Spawn river from/to =
 Bottom left river = 
 Bottom right river = 
 Bottom river = 
+Player = 
 
 # Multiplayer
 

--- a/core/src/com/unciv/logic/map/TileMap.kt
+++ b/core/src/com/unciv/logic/map/TileMap.kt
@@ -673,7 +673,7 @@ class TileMap(initialCapacity: Int = 10) : IsPartOfGameInfoSerialization {
     /** Removes a starting position, maintaining the transients
      * @return true if the starting position was removed as per [Collection]'s remove */
     fun removeStartingLocation(nationName: String, tile: Tile): Boolean {
-        if (startingLocationsByNation.contains(nationName, tile)) return false
+        if (!startingLocationsByNation.contains(nationName, tile)) return false
         startingLocations.remove(StartingLocation(tile.position, nationName))
         return startingLocationsByNation[nationName]!!.remove(tile)
         // we do not clean up an empty startingLocationsByNation[nationName] set - not worth it

--- a/core/src/com/unciv/logic/map/TileMap.kt
+++ b/core/src/com/unciv/logic/map/TileMap.kt
@@ -60,6 +60,9 @@ class TileMap(initialCapacity: Int = 10) : IsPartOfGameInfoSerialization {
     }
     val startingLocations = arrayListOf<StartingLocation>()
 
+    /** Optional freeform text a mod map creator can set for their "customers" */
+    var description = ""
+
     //endregion
     //region Fields, Transient
 
@@ -185,6 +188,8 @@ class TileMap(initialCapacity: Int = 10) : IsPartOfGameInfoSerialization {
         toReturn.startingLocations.clear()
         toReturn.startingLocations.ensureCapacity(startingLocations.size)
         toReturn.startingLocations.addAll(startingLocations)
+
+        toReturn.description = description
         toReturn.tileUniqueMapCache = tileUniqueMapCache
 
         return toReturn

--- a/core/src/com/unciv/ui/screens/mapeditorscreen/MapEditorScreen.kt
+++ b/core/src/com/unciv/ui/screens/mapeditorscreen/MapEditorScreen.kt
@@ -21,9 +21,11 @@ import com.unciv.models.metadata.BaseRuleset
 import com.unciv.models.metadata.GameSetupInfo
 import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.ruleset.RulesetCache
+import com.unciv.ui.components.UncivTextField
 import com.unciv.ui.components.input.KeyCharAndCode
 import com.unciv.ui.components.input.KeyShortcutDispatcherVeto
 import com.unciv.ui.components.input.KeyboardPanningListener
+import com.unciv.ui.components.input.onChange
 import com.unciv.ui.components.tilegroups.TileGroup
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.images.ImageWithCustomSize
@@ -83,6 +85,7 @@ class MapEditorScreen(map: TileMap? = null) : BaseScreen(), RecreateOnResize {
     val tabs: MapEditorMainTabs
     var tileClickHandler: ((tile: Tile)->Unit)? = null
     private var zoomController: ZoomButtonPair? = null
+    val descriptionTextField = UncivTextField.create("Enter a description for the users of this map")
 
     private val highlightedTileGroups = mutableListOf<TileGroup>()
 
@@ -98,10 +101,12 @@ class MapEditorScreen(map: TileMap? = null) : BaseScreen(), RecreateOnResize {
         } else {
             ruleset = map.ruleset ?: RulesetCache.getComplexRuleset(map.mapParameters)
             tileMap = map
+            descriptionTextField.text = map.description
         }
 
         mapHolder = newMapHolder() // will set up ImageGetter and translations, and all dirty flags
         isDirty = false
+        descriptionTextField.onChange { isDirty = true }
 
         tabs = MapEditorMainTabs(this)
         MapEditorToolsDrawer(tabs, stage, mapHolder)
@@ -212,6 +217,7 @@ class MapEditorScreen(map: TileMap? = null) : BaseScreen(), RecreateOnResize {
         clearOverlayImages()
         mapHolder.remove()
         tileMap = map
+        descriptionTextField.text = map.description
         ruleset = newRuleset ?: RulesetCache.getComplexRuleset(map.mapParameters)
         mapHolder = newMapHolder()
         isDirty = false

--- a/core/src/com/unciv/ui/screens/mapeditorscreen/tabs/MapEditorSaveTab.kt
+++ b/core/src/com/unciv/ui/screens/mapeditorscreen/tabs/MapEditorSaveTab.kt
@@ -9,8 +9,6 @@ import com.unciv.logic.files.MapSaver
 import com.unciv.logic.map.MapGeneratedMainType
 import com.unciv.logic.map.TileMap
 import com.unciv.models.translations.tr
-import com.unciv.ui.components.widgets.AutoScrollPane
-import com.unciv.ui.components.widgets.TabbedPager
 import com.unciv.ui.components.UncivTextField
 import com.unciv.ui.components.extensions.isEnabled
 import com.unciv.ui.components.extensions.toTextButton
@@ -19,6 +17,8 @@ import com.unciv.ui.components.input.keyShortcuts
 import com.unciv.ui.components.input.onActivation
 import com.unciv.ui.components.input.onChange
 import com.unciv.ui.components.input.onClick
+import com.unciv.ui.components.widgets.AutoScrollPane
+import com.unciv.ui.components.widgets.TabbedPager
 import com.unciv.ui.popups.ConfirmPopup
 import com.unciv.ui.popups.Popup
 import com.unciv.ui.popups.ToastPopup
@@ -89,6 +89,7 @@ class MapEditorSaveTab(
         if (mapNameTextField.text.isBlank()) return
         editorScreen.tileMap.mapParameters.name = mapNameTextField.text
         editorScreen.tileMap.mapParameters.type = MapGeneratedMainType.custom
+        editorScreen.tileMap.description = editorScreen.descriptionTextField.text
         setSaveButton(false)
         editorScreen.startBackgroundJob("MapSaver", false) { saverThread() }
     }

--- a/core/src/com/unciv/ui/screens/mapeditorscreen/tabs/MapEditorViewTab.kt
+++ b/core/src/com/unciv/ui/screens/mapeditorscreen/tabs/MapEditorViewTab.kt
@@ -191,8 +191,7 @@ class MapEditorViewTab(
             lines += FormattedLine(stats.toString())
         }
 
-        val nations = tile.tileMap.getTileStartingLocations(tile)
-            .joinToString { it.name.tr() }
+        val nations = tile.tileMap.getTileStartingLocationSummary(tile)
         if (nations.isNotEmpty()) {
             lines += FormattedLine()
             lines += FormattedLine("Starting location(s): [$nations]")
@@ -257,11 +256,12 @@ class MapEditorViewTab(
         tileClickHandler(tile)
     }
 
-    private fun TileMap.getTileStartingLocations(tile: Tile?) =
-        startingLocationsByNation.asSequence()
-        .filter { tile == null || tile in it.value }
-        .mapNotNull { ruleset!!.nations[it.key] }
-        .sortedWith(compareBy<Nation>{ it.isCityState }.thenBy(collator) { it.name.tr(hideIcons = true) })
+    private fun TileMap.getTileStartingLocationSummary(tile: Tile) =
+        startingLocations.asSequence()
+            .filter { it.position == tile.position }
+            .mapNotNull { if (it.nation in ruleset!!.nations) ruleset!!.nations[it.nation]!! to it.usage else null }
+            .sortedWith(compareBy<Pair<Nation,TileMap.StartingLocation.Usage>>{ it.first.isCityState }.thenBy(collator) { it.first.name.tr(hideIcons = true) })
+            .joinToString { "{${it.first.name}} ({${it.second}})".tr() }
 
     private fun TileMap.getStartingLocationSummary() =
         startingLocationsByNation.asSequence()

--- a/core/src/com/unciv/ui/screens/mapeditorscreen/tabs/MapEditorViewTab.kt
+++ b/core/src/com/unciv/ui/screens/mapeditorscreen/tabs/MapEditorViewTab.kt
@@ -263,7 +263,7 @@ class MapEditorViewTab(
             .filter { it.position == tile.position }
             .mapNotNull { if (it.nation in ruleset!!.nations) ruleset!!.nations[it.nation]!! to it.usage else null }
             .sortedWith(compareBy<Pair<Nation,TileMap.StartingLocation.Usage>>{ it.first.isCityState }.thenBy(collator) { it.first.name.tr(hideIcons = true) })
-            .joinToString { "{${it.first.name}} ({${it.second}})".tr() }
+            .joinToString { "{${it.first.name}} ({${it.second.label}})".tr() }
 
     private fun TileMap.getStartingLocationSummary() =
         startingLocationsByNation.asSequence()

--- a/core/src/com/unciv/ui/screens/mapeditorscreen/tabs/MapEditorViewTab.kt
+++ b/core/src/com/unciv/ui/screens/mapeditorscreen/tabs/MapEditorViewTab.kt
@@ -101,6 +101,8 @@ class MapEditorViewTab(
         val statsLabel = WrappableLabel(statsText, labelWidth)
         add(statsLabel.apply { wrap = true }).row()
 
+        add(editorScreen.descriptionTextField).growX().row()
+
         // Map editor must not touch tileMap.naturalWonders as it is a by lazy immutable list,
         // and we wouldn't be able to fix it when the natural wonders change
         if (editorScreen.naturalWondersNeedRefresh) {

--- a/core/src/com/unciv/ui/screens/newgamescreen/MapFileSelectTable.kt
+++ b/core/src/com/unciv/ui/screens/newgamescreen/MapFileSelectTable.kt
@@ -133,7 +133,7 @@ class MapFileSelectTable(
                 loadingIcon.hide {
                     loadingIcon.remove()
                 }
-                onCategorySelectBoxChange() // re-sort lower SelectBox
+                onCategorySelectBoxChange() // re-sort lower SelectBox, and trigger map selection (mod select, description and preview)
             }
         }
     }
@@ -214,10 +214,15 @@ class MapFileSelectTable(
         // (all expensive) for something that will be overthrown momentarily
         mapFileSelectBox.selection.setProgrammaticChangeEvents(false)
         mapFileSelectBox.items = mapFiles
-        // Now, we want this ON because the event removes map selections which are pulling mods
-        // that trip updateRuleset - so that code should still be active for the pre-selection
-        mapFileSelectBox.selection.setProgrammaticChangeEvents(true)
         mapFileSelectBox.selected = selectedItem
+        mapFileSelectBox.selection.setProgrammaticChangeEvents(true)
+
+        // Now, we want this to *always* run even when setting mapFileSelectBox.selected would
+        // not have fired the event (which it won't if the selection is already as asked).
+        // Reasons:
+        // * Mods that trip validation in updateRuleset
+        // * Update description and minimap preview
+        onFileSelectBoxChange()
         // In the event described above, we now have: mapFileSelectBox.selected != selectedItem
         // Do NOT try to put back the "bad" preselection!
     }

--- a/core/src/com/unciv/ui/screens/newgamescreen/MapFileSelectTable.kt
+++ b/core/src/com/unciv/ui/screens/newgamescreen/MapFileSelectTable.kt
@@ -40,6 +40,12 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.isActive
 
+private inline fun <T> SelectBox<T>.withoutChangeEvents(block: SelectBox<T>.() -> Unit) {
+    selection.setProgrammaticChangeEvents(false)
+    block()
+    selection.setProgrammaticChangeEvents(true)
+}
+
 class MapFileSelectTable(
     private val newGameScreen: NewGameScreen,
     private val mapParameters: MapParameters
@@ -152,19 +158,19 @@ class MapFileSelectTable(
                     compareBy<String?> { it != sortToTop }
                         .thenBy(collator) { it }
                 ).toGdxArray()
-            mapCategorySelectBox.selection.setProgrammaticChangeEvents(false)
-            mapCategorySelectBox.items = newItems
-            mapCategorySelectBox.selected = select
-            mapCategorySelectBox.selection.setProgrammaticChangeEvents(true)
+            mapCategorySelectBox.withoutChangeEvents {
+                items = newItems
+                selected = select
+            }
         }
 
         if (mapCategorySelectBox.selected != categoryName) return
 
         // .. but add the maps themselves as they come
-        mapFileSelectBox.selection.setProgrammaticChangeEvents(false)
-        mapFileSelectBox.items.add(mapWrapper)
-        mapFileSelectBox.items = mapFileSelectBox.items  // Call setItems so SelectBox sees the change
-        mapFileSelectBox.selection.setProgrammaticChangeEvents(true)
+        mapFileSelectBox.withoutChangeEvents {
+            items.add(mapWrapper)
+            setItems(items) // Call setItems so SelectBox sees the change
+        }
     }
 
     private val firstMap: FileHandle? by lazy {
@@ -212,10 +218,10 @@ class MapFileSelectTable(
 
         // avoid the overhead of doing a full updateRuleset + updateTables + startMapPreview
         // (all expensive) for something that will be overthrown momentarily
-        mapFileSelectBox.selection.setProgrammaticChangeEvents(false)
-        mapFileSelectBox.items = mapFiles
-        mapFileSelectBox.selected = selectedItem
-        mapFileSelectBox.selection.setProgrammaticChangeEvents(true)
+        mapFileSelectBox.withoutChangeEvents {
+            items = mapFiles
+            selected = selectedItem
+        }
 
         // Now, we want this to *always* run even when setting mapFileSelectBox.selected would
         // not have fired the event (which it won't if the selection is already as asked).

--- a/core/src/com/unciv/ui/screens/newgamescreen/MapFileSelectTable.kt
+++ b/core/src/com/unciv/ui/screens/newgamescreen/MapFileSelectTable.kt
@@ -7,6 +7,7 @@ import com.badlogic.gdx.scenes.scene2d.Group
 import com.badlogic.gdx.scenes.scene2d.actions.Actions
 import com.badlogic.gdx.scenes.scene2d.ui.Cell
 import com.badlogic.gdx.scenes.scene2d.ui.Container
+import com.badlogic.gdx.scenes.scene2d.ui.Label
 import com.badlogic.gdx.scenes.scene2d.ui.SelectBox
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.unciv.UncivGame
@@ -53,6 +54,8 @@ class MapFileSelectTable(
     private val miniMapWrapper = Container<Group?>()
     private var mapPreviewJob: Job? = null
     private var preselectedName = mapParameters.name
+    private val descriptionLabel = "".toLabel()
+    private val descriptionLabelCell: Cell<Label>
 
     // The SelectBox auto displays the text a object.toString(), which on the FileHandle itself includes the folder path.
     //  So we wrap it in another object with a custom toString()
@@ -85,6 +88,9 @@ class MapFileSelectTable(
 
         useNationsButtonCell = add().pad(0f)
         row()
+
+        descriptionLabelCell = add(descriptionLabel)
+        descriptionLabelCell.height(0f).row()
 
         add(miniMapWrapper)
             .pad(15f)
@@ -279,8 +285,10 @@ class MapFileSelectTable(
                 // ReplayMap still paints outside its bounds - so we subtract padding and a little extra
                 val size = (columnWidth - 40f).coerceAtMost(500f)
                 val miniMap = LoadMapPreview(map, size, size)
+                val description = map.description
                 if (!isActive) return@run
                 Concurrency.runOnGLThread {
+                    showDescription(description)
                     showMinimap(miniMap)
                 }
             } catch (_: Throwable) {}
@@ -304,6 +312,13 @@ class MapFileSelectTable(
         miniMapWrapper.actor = miniMap
         miniMapWrapper.invalidateHierarchy()
         miniMapWrapper.addAction(Actions.fadeIn(0.2f))
+    }
+
+    private fun showDescription(text: String) {
+        descriptionLabel.setText(text)
+        descriptionLabelCell
+            .height(if (text.isEmpty()) 0f else descriptionLabel.prefHeight)
+            .padTop(if (text.isEmpty()) 0f else 10f)
     }
 
     private fun hideMiniMap() {


### PR DESCRIPTION
* A description - think a "message" from the map author to their users. Editor support, and shows in new game map select between the dropdowns and the minimap preview. No multiline🙃 or markdown🤪 support.
* Starting locations can control their effect on the "Select players from starting locations" button from #11423. As before, or be ignored, or get the Human slot preferentially.
* Re-fixed a sync problem #11423 already tried to fix - from too often to not always - should be once always now.

<details><summary>Screenies</summary>

![image](https://github.com/yairm210/Unciv/assets/63000004/3f0dae79-6d0a-4a99-82cd-8ba039df36d5)
![image](https://github.com/yairm210/Unciv/assets/63000004/0bcab820-47ad-412d-be3f-fe9c3a6ab815)
![image](https://github.com/yairm210/Unciv/assets/63000004/6ee3fb63-d129-4955-b873-72927ca74dc2)

</details>

... not 100% happy with the UX or the label choices, but works without too much effort ... ~(But I need to re-check that None/Normal discrepancy)~

Now I'd like one more such mini-offer: Allow a map-collection mod like lat-am to control which map gets preselected preferentially. Remember, mod unpacking flattens timestamps on Linux, so these on the author's side can't do it. Map name == mod name? a ModOptions unique? 

@Caballero-Arepa yes this is for you