### PR TITLE
Implement "Make Peace With"  TradeOffer Type

### DIFF
--- a/core/src/com/unciv/Constants.kt
+++ b/core/src/com/unciv/Constants.kt
@@ -43,6 +43,7 @@ object Constants {
     const val cityCenter = "City center"
 
     const val peaceTreaty = "Peace Treaty"
+    const val peaceNegotiation = "Peace Negotiation"
     const val researchAgreement = "Research Agreement"
     const val openBorders = "Open Borders"
     const val defensivePact = "Defensive Pact"

--- a/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
@@ -168,9 +168,11 @@ class DiplomacyManager() : IsPartOfGameInfoSerialization {
     fun otherCivDiplomacy() = otherCiv().getDiplomacyManager(civInfo)
 
     fun turnsToPeaceTreaty(): Int {
-        for (trade in trades)
-            for (offer in trade.ourOffers)
+        for (trade in trades) {
+            val allOffers = trade.ourOffers.union(trade.theirOffers)
+            for (offer in allOffers)
                 if (offer.name == Constants.peaceTreaty && offer.duration > 0) return offer.duration
+        }
         return 0
     }
 

--- a/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
@@ -168,11 +168,9 @@ class DiplomacyManager() : IsPartOfGameInfoSerialization {
     fun otherCivDiplomacy() = otherCiv().getDiplomacyManager(civInfo)
 
     fun turnsToPeaceTreaty(): Int {
-        for (trade in trades) {
-            val allOffers = trade.ourOffers.union(trade.theirOffers)
-            for (offer in allOffers)
+        for (trade in trades)
+            for (offer in trade.ourOffers)
                 if (offer.name == Constants.peaceTreaty && offer.duration > 0) return offer.duration
-        }
         return 0
     }
 

--- a/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
@@ -65,6 +65,7 @@ enum class DiplomacyFlags {
     WaryOf,
     Bullied,
     RecentlyAttacked,
+    AcceptedPeaceNegotiationPeriod
 }
 
 enum class DiplomaticModifiers(val text: String) {

--- a/core/src/com/unciv/logic/trade/TradeLogic.kt
+++ b/core/src/com/unciv/logic/trade/TradeLogic.kt
@@ -151,7 +151,7 @@ class TradeLogic(val ourCivilization: Civilization, val otherCivilization: Civil
                 }
                 TradeType.PeaceNegotiation -> {
                     val nameOfCivToDeclarePeaceOn = offer.name
-                    from.getDiplomacyManager(nameOfCivToDeclarePeaceOn).setFlag(DiplomacyFlags.AcceptedPeaceNegotiationPeriod, 10)
+                    from.getDiplomacyManager(nameOfCivToDeclarePeaceOn).setFlag(DiplomacyFlags.AcceptedPeaceNegotiationPeriod, com.unciv.UncivGame.Current.gameInfo!!.speed.peaceNegotiationDuration)
                 }
                 else -> {}
             }

--- a/core/src/com/unciv/logic/trade/TradeLogic.kt
+++ b/core/src/com/unciv/logic/trade/TradeLogic.kt
@@ -157,12 +157,13 @@ class TradeLogic(val ourCivilization: Civilization, val otherCivilization: Civil
                     // let's create a "puppet" peaceTreaty to propagate turnsToPeaceTreaty duration-related effects
                     val peaceTrade = Trade()
                     peaceTrade.ourOffers.add(TradeOffer(Constants.peaceTreaty, TradeType.Treaty, 1, com.unciv.UncivGame.Current.gameInfo!!.speed))
+                    peaceTrade.theirOffers.add(TradeOffer(Constants.peaceTreaty, TradeType.Treaty, 1, com.unciv.UncivGame.Current.gameInfo!!.speed))
                     // let's add peaceTreaties to both diplomacyManagers
                     from.getDiplomacyManager(civToDeclarePeaceOn).apply {
                         trades.add(peaceTrade)
                     }
                     civToDeclarePeaceOn.getDiplomacyManager(from).apply {
-                        trades.add(peaceTrade.reverse())
+                        trades.add(peaceTrade)
                     }
                 }
                 else -> {}

--- a/core/src/com/unciv/logic/trade/TradeLogic.kt
+++ b/core/src/com/unciv/logic/trade/TradeLogic.kt
@@ -82,7 +82,7 @@ class TradeLogic(val ourCivilization: Civilization, val otherCivilization: Civil
                 .filter { civInfo.getDiplomacyManager(it).diplomaticStatus == DiplomaticStatus.War }
 
             for (thirdCiv in civsWeAreAtWarWith) {
-                offers.add(TradeOffer(thirdCiv.civName, TradeType.PeaceDeclaration))
+                offers.add(TradeOffer(thirdCiv.civName, TradeType.PeaceNegotiation))
             }
         }
 
@@ -149,22 +149,9 @@ class TradeLogic(val ourCivilization: Civilization, val otherCivilization: Civil
                     val nameOfCivToDeclareWarOn = offer.name
                     from.getDiplomacyManager(nameOfCivToDeclareWarOn).declareWar()
                 }
-                TradeType.PeaceDeclaration -> {
+                TradeType.PeaceNegotiation -> {
                     val nameOfCivToDeclarePeaceOn = offer.name
-                    from.getDiplomacyManager(nameOfCivToDeclarePeaceOn).makePeace()
-                    //let's get the civilization to declare peace on
-                    val civToDeclarePeaceOn = from.gameInfo.civilizations.first() { it.civName == nameOfCivToDeclarePeaceOn}
-                    // let's create a "puppet" peaceTreaty to propagate turnsToPeaceTreaty duration-related effects
-                    val peaceTrade = Trade()
-                    peaceTrade.ourOffers.add(TradeOffer(Constants.peaceTreaty, TradeType.Treaty, 1, com.unciv.UncivGame.Current.gameInfo!!.speed))
-                    peaceTrade.theirOffers.add(TradeOffer(Constants.peaceTreaty, TradeType.Treaty, 1, com.unciv.UncivGame.Current.gameInfo!!.speed))
-                    // let's add peaceTreaties to both diplomacyManagers
-                    from.getDiplomacyManager(civToDeclarePeaceOn).apply {
-                        trades.add(peaceTrade)
-                    }
-                    civToDeclarePeaceOn.getDiplomacyManager(from).apply {
-                        trades.add(peaceTrade)
-                    }
+                    from.getDiplomacyManager(nameOfCivToDeclarePeaceOn).setFlag(DiplomacyFlags.AcceptedPeaceNegotiationPeriod, 10)
                 }
                 else -> {}
             }

--- a/core/src/com/unciv/logic/trade/TradeOffer.kt
+++ b/core/src/com/unciv/logic/trade/TradeOffer.kt
@@ -36,7 +36,7 @@ data class TradeOffer(val name: String, val type: TradeType, var amount: Int = 1
 
     fun getOfferText(untradable: Int = 0): String {
         var offerText = when(type) {
-            TradeType.PeaceDeclaration -> "Make peace with [$name]"
+            TradeType.PeaceNegotiation -> "Negotiate peace with [$name]"
             TradeType.WarDeclaration -> "Declare war on [$name]"
             TradeType.Introduction -> "Introduction to [$name]"
             TradeType.City -> {

--- a/core/src/com/unciv/logic/trade/TradeOffer.kt
+++ b/core/src/com/unciv/logic/trade/TradeOffer.kt
@@ -36,6 +36,7 @@ data class TradeOffer(val name: String, val type: TradeType, var amount: Int = 1
 
     fun getOfferText(untradable: Int = 0): String {
         var offerText = when(type) {
+            TradeType.PeaceDeclaration -> "Make peace with [$name]"
             TradeType.WarDeclaration -> "Declare war on [$name]"
             TradeType.Introduction -> "Introduction to [$name]"
             TradeType.City -> {

--- a/core/src/com/unciv/logic/trade/TradeType.kt
+++ b/core/src/com/unciv/logic/trade/TradeType.kt
@@ -17,7 +17,8 @@ enum class TradeType(val numberType: TradeTypeNumberType, val isImmediate: Boole
     Technology          (TradeTypeNumberType.None, true),
     Introduction        (TradeTypeNumberType.None, true),
     WarDeclaration      (TradeTypeNumberType.None, true),
+    PeaceDeclaration    (TradeTypeNumberType.None, true),
     City                (TradeTypeNumberType.None, true);
-    
+
     enum class TradeTypeNumberType { None, Simple, Gold }
 }

--- a/core/src/com/unciv/logic/trade/TradeType.kt
+++ b/core/src/com/unciv/logic/trade/TradeType.kt
@@ -17,7 +17,7 @@ enum class TradeType(val numberType: TradeTypeNumberType, val isImmediate: Boole
     Technology          (TradeTypeNumberType.None, true),
     Introduction        (TradeTypeNumberType.None, true),
     WarDeclaration      (TradeTypeNumberType.None, true),
-    PeaceDeclaration    (TradeTypeNumberType.None, true),
+    PeaceNegotiation   (TradeTypeNumberType.None, true),
     City                (TradeTypeNumberType.None, true);
 
     enum class TradeTypeNumberType { None, Simple, Gold }

--- a/core/src/com/unciv/models/ruleset/Speed.kt
+++ b/core/src/com/unciv/models/ruleset/Speed.kt
@@ -22,6 +22,7 @@ class Speed : RulesetObject(), IsPartOfGameInfoSerialization {
     var goldenAgeLengthModifier: Float = modifier
     var religiousPressureAdjacentCity: Int = 6
     var peaceDealDuration: Int = 10
+    var peaceNegotiationDuration: Int = 10
     var dealDuration: Int = 30
     var startYear: Float = -4000f
     var turns: ArrayList<HashMap<String, Float>> = ArrayList()

--- a/core/src/com/unciv/ui/screens/diplomacyscreen/OffersListScroll.kt
+++ b/core/src/com/unciv/ui/screens/diplomacyscreen/OffersListScroll.kt
@@ -19,6 +19,7 @@ import com.unciv.logic.trade.TradeType.Strategic_Resource
 import com.unciv.logic.trade.TradeType.Technology
 import com.unciv.logic.trade.TradeType.Treaty
 import com.unciv.logic.trade.TradeType.WarDeclaration
+import com.unciv.logic.trade.TradeType.PeaceDeclaration
 import com.unciv.logic.trade.TradeType.values
 import com.unciv.models.ruleset.tile.ResourceSupplyList
 import com.unciv.models.translations.tr
@@ -72,6 +73,7 @@ class OffersListScroll(
                 Strategic_Resource -> "Strategic resources"
                 Technology -> "Technologies"
                 WarDeclaration -> "Declarations of war"
+                PeaceDeclaration -> "Declaration of peace"
                 City -> "Cities"
             }
             val offersOfType = offersToDisplay.filter { it.type == offerType }


### PR DESCRIPTION
This PR aims to introduce the "make peace with /civname/" proposal within trade.
I don't know if there were critical aspects that I might have missed with regard to this feature, I was wondering why this was not implemented before, then if I am missing some super important critical details please let me know.

The need for this feature that is present in Civ5 is documented here:
#4697 
In particular 

> Diplomacy:
> - [ ] A civ can ask another civ to make peace with a third civ

The implementation is basically the same of WarDeclaration in terms of adding civs to offers, evaluating costs etc.

- ADDING CORRECT CIVS TO OFFERS
There is one new minor change affecting WarDeclaration as well in TradeLogic.kt:
`val civsWeBothKnow = civInfo.getDiplomacyManager(otherCivilization).getCommonKnownCivs()`
is used in this code change for _both_ War and Peace declarations instead of previous:
`val civsWeBothKnow = otherCivsWeKnow
                    .filter { otherCivilization.diplomacy.containsKey(it.civName) }`
 otherCivsWeKnow is meant to provide a list of third civs (not including city-states and defeated civs) that is then used for the "Introduction" part, and in that case is fine.
For Peace and War declaration in Civ5, if I remember well, you can propose to ask to declare war or make peace with major civs but also with city-states as well, then new code for PeaceDeclaration now fixes this point as well for WarDeclaration.
Of course while WarDeclaration is then filtered for Civs not yet at war with (and with no current truce periods) to offer them, in the case of PeaceDeclaration instead we simply filter for Civs we are currently at war with.

- TRADE EVALUATION
I chose to reverse more or less the evaluation of WarDeclaration, then if the war-opponent is a Strong Threat the evaluated cost is low, while if the opponent is a Weak Threat the cost is high, because continuing the war is much more convenient for the trading-counterpart than accepting the offer.
I basically used exactly the same scores, just reversed:
Buy Cost (War)
`
 ThreatLevel.VeryLow -> 0
 ThreatLevel.Low -> 0
 ThreatLevel.Medium -> 100
 ThreatLevel.High -> 500
 ThreatLevel.VeryHigh -> 1000
 `
Buy Cost (Peace)
 `
 ThreatLevel.VeryLow -> 1000
 ThreatLevel.Low -> 500
 ThreatLevel.Medium -> 100
 ThreatLevel.High -> 0
 ThreatLevel.VeryHigh -> 0
 `
 Sell Cost (War)
 `                  
 ThreatLevel.VeryLow -> 100
 ThreatLevel.Low -> 250
 ThreatLevel.Medium -> 500
 ThreatLevel.High -> 1000
 ThreatLevel.VeryHigh -> 10000 // declaring war to a super power is NO WAY
 `
 Sell Cost (Peace)
 `
 ThreatLevel.VeryLow -> 1000 // making peace with someone very weak, for just some turns is not a nightmare
 ThreatLevel.Low -> 750
 ThreatLevel.Medium -> 500
 ThreatLevel.High -> 250
 ThreatLevel.VeryHigh -> 100
 `
Here I changed slightly the values after reversing the War cost, because declaring war to a super power basically can lead to disappear from the world, while a temporary 10-turns truce with a weak opponent is still something acceptable for a certain price.

- EFFECTS
Here is where the implementation differs the most from WarDeclaration, that is basically immediate in its effects and just leads to the War status for both and, starting from that moment, things just go like if the Civ accepting the offer of  WarDeclaration (against a third civ) had directly declared war in the first place, nothing more.
PeaceDeclaration is a bit more complicated, in fact, in my first tests of the implemented feature I faced the following issue: after just one turn the civ went back declaring war to the third civ, or the third civ declared war again on the offer-recipient civ.
After some checking I realized that what **I was missing was the side effects of an actual PeaceTreaty, in terms of duration and turnsToPeaceTreaty**. 

This was particularly evident with this feature enabled because if you offer the "Make the peace with"/PeaceDeclaration to the weak opponent, he will likely accept, but then the next turn the strong opponent will declare war immediately (making the whole trade exchange meaningless) because it is not the one who offered the PeaceTreaty and somehow then seamed to be not bound to wait by canDeclareWar check.

Going back to PeaceDeclaration TradeOffer, I needed to make it add "placeholder" PeaceTreaties TradeOffers to the trades inside the respective diplomacyManagers of the two civs engaged in the war (the civ accepting the PeaceDeclaration offer and the third civ with which it was in war). 
Like this, the PeaceTreaty duration effects are propagated correctly when a PeaceDeclaration is traded as well.
After this addition the feature works properly in the tests done. The civ declares peace and does not come back declaring war the next turn, nor the opponent declares war back immediately, and its allied city-states declare peace as well, everything fine, I would say.

I don't know if I am missing other relevant super critical aspects then again please let me know if I am.
Thank you in advance for any feedback.