### PR TITLE
Fixed not being able to nuke barbairans

### DIFF
--- a/core/src/com/unciv/logic/battle/Nuke.kt
+++ b/core/src/com/unciv/logic/battle/Nuke.kt
@@ -39,6 +39,7 @@ object Nuke {
             if (defenderCiv == null) return
             // Allow nuking yourself! (Civ5 source: CvUnit::isNukeVictim)
             if (defenderCiv == attackerCiv || defenderCiv.isDefeated()) return
+            if (defenderCiv.isBarbarian()) return
             // Gleaned from Civ5 source - this disallows nuking unknown civs even in invisible tiles
             // https://github.com/Gedemon/Civ5-DLL/blob/master/CvGameCoreDLL_Expansion1/CvUnit.cpp#L5056
             // https://github.com/Gedemon/Civ5-DLL/blob/master/CvGameCoreDLL_Expansion1/CvTeam.cpp#L986


### PR DESCRIPTION
Solves a problem brought up in discord. The way I solved it was just by adding an explicit check for barbarians.

Should every Civ have a DiplomacyManager with the barbarians? The problem is in line 46 of Nuke.kt civs don't have a DiplomacyManager with the barbarians and therefore, haven't met them and as a result can't nuke them. I am asking in case there was some unchecked regression.