### PR TITLE
UX: New game: Do not preselect custom map option and defer map file loading

### DIFF
--- a/core/src/com/unciv/ui/screens/newgamescreen/MapOptionsTable.kt
+++ b/core/src/com/unciv/ui/screens/newgamescreen/MapOptionsTable.kt
@@ -24,13 +24,7 @@ class MapOptionsTable(private val newGameScreen: NewGameScreen, isReset: Boolean
         val mapTypes = arrayListOf(MapGeneratedMainType.generated, MapGeneratedMainType.randomGenerated)
         if (savedMapOptionsTable.isNotEmpty()) mapTypes.add(MapGeneratedMainType.custom)
 
-        // Pre-select custom if any map saved within last 15 minutes
-        val chooseCustom = !isReset && (
-                savedMapOptionsTable.recentlySavedMapExists() ||
-                savedMapOptionsTable.isNotEmpty() && mapParameters.type == MapGeneratedMainType.custom && mapParameters.name.isNotEmpty()
-            )
-        val mapTypeDefault = if (chooseCustom) MapGeneratedMainType.custom else MapGeneratedMainType.generated
-        mapTypeSelectBox = TranslatedSelectBox(mapTypes, mapTypeDefault, BaseScreen.skin)
+        mapTypeSelectBox = TranslatedSelectBox(mapTypes, MapGeneratedMainType.generated, BaseScreen.skin)
 
         fun updateOnMapTypeChange() {
             mapTypeSpecificTable.clear()
@@ -46,7 +40,6 @@ class MapOptionsTable(private val newGameScreen: NewGameScreen, isReset: Boolean
                     mapParameters.type = generatedMapOptionsTable.mapTypeSelectBox.selected.value
                     mapTypeSpecificTable.add(generatedMapOptionsTable)
                     newGameScreen.unlockTables()
-
                 }
                 MapGeneratedMainType.randomGenerated -> {
                     mapParameters.name = ""
@@ -58,7 +51,7 @@ class MapOptionsTable(private val newGameScreen: NewGameScreen, isReset: Boolean
             newGameScreen.updateTables()
         }
 
-        // activate once, so when we had a file map before we'll have the right things set for another one
+        // activate once, so the MapGeneratedMainType.generated controls show
         updateOnMapTypeChange()
 
         mapTypeSelectBox.onChange { updateOnMapTypeChange() }


### PR DESCRIPTION
... to prevent maps overwriting the mod selection from the last successful game start, see discussion in #11443.

 Could also make new game screen a little snappier if the custom maps option is not selected at all - but once it is it'll take a little longer since it has not precached in the background.

Has seen only 10min of testing so far, and seems to do exactly what's intended. Any coders with time are urged to check out the branch and test.

The alternative would be to not sync the mod selection from any map selection to the mod checkboxes at all - until "start" is clicked, then compare, then ask if different. I'd tend to this.