### PR TITLE
Declare War Reason

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -147,12 +147,12 @@ Denounce ([numberOfTurns] turns) =
 We will remember this. = 
 
 [civName] has declared war on [targetCivName]! = 
-[civName] has joined [civName] in the war against us! = 
-We have joined [civName] in the war against [civName]! = 
-[civName has joined [civName] in the war against [civName]! = 
-[civName] has joined us in the war against [civName]! = 
+[civName] has joined [allyCivName] in the war against us! = 
+We have joined [allyCivName] in the war against [enemyCivName]! = 
+[civName] has joined [allyCivName] in the war against [enemyCivName]! = 
+[civName] has joined us in the war against [enemyCivName]! = 
 
-[civName] canceled their Defensive Pact with [CivName]! = 
+[civName] canceled their Defensive Pact with [otherCivName]! = 
 [civName] canceled their Defensive Pact with us! = 
 We have canceled our Defensive Pact with [civName]! = 
 
@@ -1542,7 +1542,7 @@ My friend, shall we declare our friendship to the world? =
 Sign Declaration of Friendship ([30] turns) = 
 We are not interested. = 
 We have signed a Declaration of Friendship with [otherCiv]! = 
-[civName] and [civName] have signed the Defensive Pact! = 
+[civName] and [otherCivName] have signed a Defensive Pact! = 
 [otherCiv] has denied our Declaration of Friendship! = 
 
 Basics = 

--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -152,9 +152,9 @@ We have joined [allyCivName] in the war against [enemyCivName]! =
 [civName] has joined [allyCivName] in the war against [enemyCivName]! = 
 [civName] has joined us in the war against [enemyCivName]! = 
 
-[civName] canceled their Defensive Pact with [otherCivName]! = 
-[civName] canceled their Defensive Pact with us! = 
-We have canceled our Defensive Pact with [civName]! = 
+[civName] cancelled their Defensive Pact with [otherCivName]! = 
+[civName] cancelled their Defensive Pact with us! = 
+We have cancelled our Defensive Pact with [civName]! = 
 
 [civName] and [targetCivName] have signed a Peace Treaty! = 
 [civName] and [targetCivName] have signed the Declaration of Friendship! = 

--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -147,10 +147,14 @@ Denounce ([numberOfTurns] turns) =
 We will remember this. = 
 
 [civName] has declared war on [targetCivName]! = 
-[civName] has joined [civName] in the war against us!
-We have joined [civName] in the war against [civName]!
-[civName has joined [civName] in the war against [civName]!
-[civName] has joined us in the war against [civName]!
+[civName] has joined [civName] in the war against us! = 
+We have joined [civName] in the war against [civName]! = 
+[civName has joined [civName] in the war against [civName]! = 
+[civName] has joined us in the war against [civName]! = 
+
+[civName] canceled their Defensive Pact with [CivName]! = 
+[civName] canceled their Defensive Pact with us! = 
+We have canceled our Defensive Pact with [civName]! = 
 
 [civName] and [targetCivName] have signed a Peace Treaty! = 
 [civName] and [targetCivName] have signed the Declaration of Friendship! = 
@@ -1538,6 +1542,7 @@ My friend, shall we declare our friendship to the world? =
 Sign Declaration of Friendship ([30] turns) = 
 We are not interested. = 
 We have signed a Declaration of Friendship with [otherCiv]! = 
+[civName] and [civName] have signed the Defensive Pact! = 
 [otherCiv] has denied our Declaration of Friendship! = 
 
 Basics = 

--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -147,6 +147,11 @@ Denounce ([numberOfTurns] turns) =
 We will remember this. = 
 
 [civName] has declared war on [targetCivName]! = 
+[civName] has joined [civName] in the war against us!
+We have joined [civName] in the war against [civName]!
+[civName has joined [civName] in the war against [civName]!
+[civName] has joined us in the war against [civName]!
+
 [civName] and [targetCivName] have signed a Peace Treaty! = 
 [civName] and [targetCivName] have signed the Declaration of Friendship! = 
 [civName] has denounced [targetCivName]! = 

--- a/core/src/com/unciv/logic/civilization/diplomacy/CityStateFunctions.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/CityStateFunctions.kt
@@ -249,7 +249,7 @@ class CityStateFunctions(val civInfo: Civilization) {
                         if (!civInfo.knows(newEnemy))
                             // We have to meet first
                             civInfo.diplomacyFunctions.makeCivilizationsMeet(newEnemy, warOnContact = true)
-                        civInfo.getDiplomacyManager(newEnemy).declareWar(DeclareWarReason.CityStateAllianceWar)
+                        civInfo.getDiplomacyManager(newEnemy).declareWar(DeclareWarReason(WarType.CityStateAllianceWar, newAllyCiv))
                     }
                 }
             }

--- a/core/src/com/unciv/logic/civilization/diplomacy/CityStateFunctions.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/CityStateFunctions.kt
@@ -245,12 +245,11 @@ class CityStateFunctions(val civInfo: Civilization) {
 
                 // Join the wars of our new ally - loop through all civs they are at war with
                 for (newEnemy in civInfo.gameInfo.civilizations.filter { it.isAtWarWith(newAllyCiv) && it.isAlive() } ) {
-                    if (civInfo.knows(newEnemy) && !civInfo.isAtWarWith(newEnemy))
-                        civInfo.getDiplomacyManager(newEnemy).declareWar()
-                    else if (!civInfo.knows(newEnemy)) {
-                        // We have to meet first
-                        civInfo.diplomacyFunctions.makeCivilizationsMeet(newEnemy, warOnContact = true)
-                        civInfo.getDiplomacyManager(newEnemy).declareWar()
+                    if (!civInfo.isAtWarWith(newEnemy)) {
+                        if (!civInfo.knows(newEnemy))
+                            // We have to meet first
+                            civInfo.diplomacyFunctions.makeCivilizationsMeet(newEnemy, warOnContact = true)
+                        civInfo.getDiplomacyManager(newEnemy).declareWar(DeclareWarReason.CityStateAllianceWar)
                     }
                 }
             }

--- a/core/src/com/unciv/logic/civilization/diplomacy/DeclareWar.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DeclareWar.kt
@@ -281,12 +281,14 @@ enum class WarType {
     CityStateAllianceWar,
     /** A civilization has joined a war through it's defensive pact. */
     DefensivePactWar,
-    /** A civilization has joined a war through a trade. */
+    /** A civilization has joined a war through a trade. Has the same diplomatic repercussions as direct war.*/
     JoinWar,
 }
 
 /**
- * Stores the reason for the war. We might want to add justified wars in the future
+ * Stores the reason for the war. We might want to add justified wars in the future.
+ * @param allyCiv If the given [WarType] is [WarType.CityStateAllianceWar], [WarType.DefensivePactWar] or [WarType.JoinWar]
+ * the allyCiv needs to be given
  */
 class DeclareWarReason(val warType: WarType, val allyCiv: Civilization? = null)
 

--- a/core/src/com/unciv/logic/civilization/diplomacy/DeclareWar.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DeclareWar.kt
@@ -35,7 +35,7 @@ object DeclareWar {
         onWarDeclared(diplomacyManager, true)
         onWarDeclared(otherCivDiplomacy, false)
 
-        changeOpinions(diplomacyManager)
+        changeOpinions(diplomacyManager, declareWarReason)
 
         breakTreaties(diplomacyManager)
 
@@ -138,7 +138,7 @@ object DeclareWar {
         diplomacyManager.removeFlag(DiplomacyFlags.BorderConflict)
     }
 
-    private fun changeOpinions(diplomacyManager: DiplomacyManager) {
+    private fun changeOpinions(diplomacyManager: DiplomacyManager, declareWarReason: DeclareWarReason) {
         val civInfo = diplomacyManager.civInfo
         val otherCiv = diplomacyManager.otherCiv()
         val otherCivDiplomacy = diplomacyManager.otherCivDiplomacy()
@@ -150,7 +150,9 @@ object DeclareWar {
             if (thirdCiv.isAtWarWith(otherCiv)) {
                 if (thirdCiv.isCityState()) thirdCiv.getDiplomacyManager(civInfo).addInfluence(10f)
                 else thirdCiv.getDiplomacyManager(civInfo).addModifier(DiplomaticModifiers.SharedEnemy, 5f)
-            } else thirdCiv.getDiplomacyManager(civInfo).addModifier(DiplomaticModifiers.WarMongerer, -5f)
+            } else if (declareWarReason.warType == WarType.DirectWar || declareWarReason.warType == WarType.JoinWar)
+                // We don't want this modify to stack if there is a defensive pact
+                thirdCiv.getDiplomacyManager(civInfo).addModifier(DiplomaticModifiers.WarMongerer, -5f)
         }
     }
 

--- a/core/src/com/unciv/logic/civilization/diplomacy/DeclareWar.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DeclareWar.kt
@@ -246,14 +246,14 @@ object DeclareWar {
                 thirdPartyDiploManager.otherCivDiplomacy().removeFlag(DiplomacyFlags.DefensivePact)
             }
             for (civ in thirdPartyDiploManager.getCommonKnownCivsWithSpectators()) {
-                civ.addNotification("[${diplomacyManager.civInfo.civName}] canceled their Defensive Pact with [${thirdPartyDiploManager.otherCivName}]!",
+                civ.addNotification("[${diplomacyManager.civInfo.civName}] cancelled their Defensive Pact with [${thirdPartyDiploManager.otherCivName}]!",
                     NotificationCategory.Diplomacy, diplomacyManager.civInfo.civName, NotificationIcon.Diplomacy, thirdPartyDiploManager.otherCivName)
             }
 
-            thirdPartyDiploManager.otherCiv().addNotification("[${diplomacyManager.civInfo.civName}] canceled their Defensive Pact with us!",
+            thirdPartyDiploManager.otherCiv().addNotification("[${diplomacyManager.civInfo.civName}] cancelled their Defensive Pact with us!",
                 NotificationCategory.Diplomacy, diplomacyManager.civInfo.civName, NotificationIcon.Diplomacy, thirdPartyDiploManager.otherCivName)
 
-            thirdPartyDiploManager.civInfo.addNotification("We have canceled our Defensive Pact with [${thirdPartyDiploManager.otherCivName}]!",
+            thirdPartyDiploManager.civInfo.addNotification("We have cancelled our Defensive Pact with [${thirdPartyDiploManager.otherCivName}]!",
                 NotificationCategory.Diplomacy, NotificationIcon.Diplomacy, thirdPartyDiploManager.otherCivName)
         }
     }

--- a/core/src/com/unciv/logic/civilization/diplomacy/DeclareWar.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DeclareWar.kt
@@ -82,20 +82,22 @@ object DeclareWar {
             WarType.DefensivePactWar, WarType.CityStateAllianceWar, WarType.JoinWar -> {
                 val allyCiv = declareWarReason.allyCiv!!
                 otherCiv.popupAlerts.add(PopupAlert(AlertType.WarDeclaration, civInfo.civName))
+                val agressor = if (declareWarReason.warType == WarType.JoinWar) civInfo else otherCiv
+                val defender = if (declareWarReason.warType == WarType.JoinWar) otherCiv else civInfo
 
-                civInfo.addNotification("[${otherCiv.civName}] has joined [${allyCiv.civName}] in the war against us!",
-                    NotificationCategory.Diplomacy, NotificationIcon.War, otherCiv.civName)
+                defender.addNotification("[${agressor.civName}] has joined [${allyCiv.civName}] in the war against us!",
+                    NotificationCategory.Diplomacy, NotificationIcon.War, agressor.civName)
 
-                otherCiv.addNotification("We have joined [${allyCiv.civName}] in the war against [${civInfo.civName}]!",
-                    NotificationCategory.Diplomacy, NotificationIcon.War, civInfo.civName)
+                agressor.addNotification("We have joined [${allyCiv.civName}] in the war against [${defender.civName}]!",
+                    NotificationCategory.Diplomacy, NotificationIcon.War, defender.civName)
 
                 diplomacyManager.getCommonKnownCivsWithSpectators().filterNot { it == allyCiv }.forEach {
-                    it.addNotification("[${otherCiv.civName}] has joined [${allyCiv.civName}] in the war against [${civInfo.civName}]!",
-                        NotificationCategory.Diplomacy, civInfo.civName, NotificationIcon.War, otherCiv.civName)
+                    it.addNotification("[${agressor.civName}] has joined [${allyCiv.civName}] in the war against [${defender.civName}]!",
+                        NotificationCategory.Diplomacy, agressor.civName, NotificationIcon.War, defender.civName)
                 }
 
-                allyCiv.addNotification("[${otherCiv.civName}] has joined us in the war against [${civInfo.civName}]!",
-                        NotificationCategory.Diplomacy, civInfo.civName, NotificationIcon.War, otherCiv.civName)
+                allyCiv.addNotification("[${agressor.civName}] has joined us in the war against [${defender.civName}]!",
+                        NotificationCategory.Diplomacy, agressor.civName, NotificationIcon.War, defender.civName)
             }
         }
     }
@@ -304,7 +306,7 @@ enum class WarType {
 /**
  * Stores the reason for the war. We might want to add justified wars in the future.
  * @param allyCiv If the given [WarType] is [WarType.CityStateAllianceWar], [WarType.DefensivePactWar] or [WarType.JoinWar]
- * the allyCiv needs to be given
+ * the allyCiv needs to be given.
  */
 class DeclareWarReason(val warType: WarType, val allyCiv: Civilization? = null)
 

--- a/core/src/com/unciv/logic/civilization/diplomacy/DeclareWar.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DeclareWar.kt
@@ -27,20 +27,8 @@ object DeclareWar {
         val otherCiv = diplomacyManager.otherCiv()
         val otherCivDiplomacy = diplomacyManager.otherCivDiplomacy()
 
-        if (otherCiv.isCityState() && declareWarReason.warType == WarType.DirectWar) {
-            otherCivDiplomacy.setInfluence(-60f)
-            civInfo.numMinorCivsAttacked += 1
-            otherCiv.cityStateFunctions.cityStateAttacked(civInfo)
-
-            // You attacked your own ally, you're a right bastard
-            if (otherCiv.getAllyCiv() == civInfo.civName) {
-                otherCiv.cityStateFunctions.updateAllyCivForCityState()
-                otherCivDiplomacy.setInfluence(-120f)
-                for (knownCiv in civInfo.getKnownCivs()) {
-                    knownCiv.getDiplomacyManager(civInfo).addModifier(DiplomaticModifiers.BetrayedDeclarationOfFriendship, -10f)
-                }
-            }
-        }
+        if (otherCiv.isCityState() && declareWarReason.warType == WarType.DirectWar)
+            handleCityStateDirectAttack(diplomacyManager)
 
         onWarDeclared(diplomacyManager, true)
         onWarDeclared(otherCivDiplomacy, false)
@@ -62,6 +50,25 @@ object DeclareWar {
         if (otherCiv.isMajorCiv())
             for (unique in civInfo.getTriggeredUniques(UniqueType.TriggerUponDeclaringWar))
                 UniqueTriggerActivation.triggerUnique(unique, civInfo)
+    }
+
+    private fun handleCityStateDirectAttack(diplomacyManager: DiplomacyManager) {
+        val civInfo = diplomacyManager.civInfo
+        val otherCiv = diplomacyManager.otherCiv()
+        val otherCivDiplomacy = diplomacyManager.otherCivDiplomacy()
+
+        otherCivDiplomacy.setInfluence(-60f)
+        civInfo.numMinorCivsAttacked += 1
+        otherCiv.cityStateFunctions.cityStateAttacked(civInfo)
+
+        // You attacked your own ally, you're a right bastard
+        if (otherCiv.getAllyCiv() == civInfo.civName) {
+            otherCiv.cityStateFunctions.updateAllyCivForCityState()
+            otherCivDiplomacy.setInfluence(-120f)
+            for (knownCiv in civInfo.getKnownCivs()) {
+                knownCiv.getDiplomacyManager(civInfo).addModifier(DiplomaticModifiers.BetrayedDeclarationOfFriendship, -10f)
+            }
+        }
     }
 
     private fun notifyOfWar(diplomacyManager: DiplomacyManager, declareWarReason: DeclareWarReason) {

--- a/core/src/com/unciv/logic/civilization/diplomacy/DeclareWar.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DeclareWar.kt
@@ -227,11 +227,15 @@ object DeclareWar {
                 thirdPartyDiploManager.removeFlag(DiplomacyFlags.DefensivePact)
                 thirdPartyDiploManager.otherCivDiplomacy().removeFlag(DiplomacyFlags.DefensivePact)
             }
-            for (civ in diplomacyManager.getCommonKnownCivsWithSpectators()) {
+            for (civ in thirdPartyDiploManager.getCommonKnownCivsWithSpectators()) {
                 civ.addNotification("[${diplomacyManager.civInfo.civName}] canceled their Defensive Pact with [${thirdPartyDiploManager.otherCivName}]!",
                     NotificationCategory.Diplomacy, diplomacyManager.civInfo.civName, NotificationIcon.Diplomacy, thirdPartyDiploManager.otherCivName)
             }
-            diplomacyManager.civInfo.addNotification("We have canceled our Defensive Pact with [${thirdPartyDiploManager.otherCivName}]!",
+
+            thirdPartyDiploManager.otherCiv().addNotification("[${diplomacyManager.civInfo.civName}] canceled their Defensive Pact with us!",
+                NotificationCategory.Diplomacy, diplomacyManager.civInfo.civName, NotificationIcon.Diplomacy, thirdPartyDiploManager.otherCivName)
+
+            thirdPartyDiploManager.civInfo.addNotification("We have canceled our Defensive Pact with [${thirdPartyDiploManager.otherCivName}]!",
                 NotificationCategory.Diplomacy, NotificationIcon.Diplomacy, thirdPartyDiploManager.otherCivName)
         }
     }

--- a/core/src/com/unciv/logic/civilization/diplomacy/DeclareWar.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DeclareWar.kt
@@ -16,7 +16,7 @@ object DeclareWar {
      * Handles all war effects and diplomatic changes with other civs and such.
      *
      * @param declareWarReason Changes what sort of effects the war has depending on how it was initiated.
-     * If it was a direct attack put [DeclareWarReason.DirectWar] for the following effects.
+     * If it was a direct attack put [WarType.DirectWar] for the following effects.
      * Influence with city states should only be set to -60
      * when they are attacked directly, not when their ally is attacked.
      * When @indirectCityStateAttack is set to true, we thus don't reset the influence with this city state.
@@ -35,15 +35,7 @@ object DeclareWar {
 
         notifyOfWar(diplomacyManager, declareWarReason)
 
-        otherCivDiplomacy.setModifier(DiplomaticModifiers.DeclaredWarOnUs, -20f)
-        otherCivDiplomacy.removeModifier(DiplomaticModifiers.ReturnedCapturedUnits)
-
-        for (thirdCiv in civInfo.getKnownCivs()) {
-            if (thirdCiv.isAtWarWith(otherCiv)) {
-                if (thirdCiv.isCityState()) thirdCiv.getDiplomacyManager(civInfo).addInfluence(10f)
-                else thirdCiv.getDiplomacyManager(civInfo).addModifier(DiplomaticModifiers.SharedEnemy, 5f)
-            } else thirdCiv.getDiplomacyManager(civInfo).addModifier(DiplomaticModifiers.WarMongerer, -5f)
-        }
+        changeOpinions(diplomacyManager)
 
         breakTreaties(diplomacyManager)
 
@@ -105,6 +97,22 @@ object DeclareWar {
                 allyCiv.addNotification("[${otherCiv.civName}] has joined us in the war against [${civInfo.civName}]!",
                         NotificationCategory.Diplomacy, civInfo.civName, NotificationIcon.War, otherCiv.civName)
             }
+        }
+    }
+
+    private fun changeOpinions(diplomacyManager: DiplomacyManager) {
+        val civInfo = diplomacyManager.civInfo
+        val otherCiv = diplomacyManager.otherCiv()
+        val otherCivDiplomacy = diplomacyManager.otherCivDiplomacy()
+
+        otherCivDiplomacy.setModifier(DiplomaticModifiers.DeclaredWarOnUs, -20f)
+        otherCivDiplomacy.removeModifier(DiplomaticModifiers.ReturnedCapturedUnits)
+
+        for (thirdCiv in civInfo.getKnownCivs()) {
+            if (thirdCiv.isAtWarWith(otherCiv)) {
+                if (thirdCiv.isCityState()) thirdCiv.getDiplomacyManager(civInfo).addInfluence(10f)
+                else thirdCiv.getDiplomacyManager(civInfo).addModifier(DiplomaticModifiers.SharedEnemy, 5f)
+            } else thirdCiv.getDiplomacyManager(civInfo).addModifier(DiplomaticModifiers.WarMongerer, -5f)
         }
     }
 

--- a/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
@@ -379,7 +379,7 @@ class DiplomacyManager() : IsPartOfGameInfoSerialization {
 
     fun canDeclareWar() = turnsToPeaceTreaty() == 0 && diplomaticStatus != DiplomaticStatus.War
 
-    fun declareWar(declareWarReason: DeclareWarReason = DeclareWarReason.DirectWar) = DeclareWar.declareWar(this, declareWarReason)
+    fun declareWar(declareWarReason: DeclareWarReason = DeclareWarReason(WarType.DirectWar)) = DeclareWar.declareWar(this, declareWarReason)
 
     //Used for nuke
     fun canAttack() = turnsToPeaceTreaty() == 0

--- a/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
@@ -563,7 +563,7 @@ class DiplomacyManager() : IsPartOfGameInfoSerialization {
 
 
         for (thirdCiv in getCommonKnownCivsWithSpectators()) {
-            thirdCiv.addNotification("[${civInfo.civName}] and [$otherCivName] have signed the Defensive Pact!",
+            thirdCiv.addNotification("[${civInfo.civName}] and [$otherCivName] have signed a Defensive Pact!",
                 NotificationCategory.Diplomacy, civInfo.civName, NotificationIcon.Diplomacy, otherCivName)
             if (thirdCiv.isSpectator()) return
             thirdCiv.getDiplomacyManager(civInfo).setDefensivePactBasedModifier()

--- a/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
@@ -379,7 +379,7 @@ class DiplomacyManager() : IsPartOfGameInfoSerialization {
 
     fun canDeclareWar() = turnsToPeaceTreaty() == 0 && diplomaticStatus != DiplomaticStatus.War
 
-    fun declareWar(indirectCityStateAttack: Boolean = false) = DeclareWar.declareWar(this, indirectCityStateAttack)
+    fun declareWar(declareWarReason: DeclareWarReason = DeclareWarReason.DirectWar) = DeclareWar.declareWar(this, declareWarReason)
 
     //Used for nuke
     fun canAttack() = turnsToPeaceTreaty() == 0

--- a/core/src/com/unciv/logic/trade/TradeLogic.kt
+++ b/core/src/com/unciv/logic/trade/TradeLogic.kt
@@ -8,6 +8,7 @@ import com.unciv.logic.civilization.diplomacy.CityStateFunctions
 import com.unciv.logic.civilization.diplomacy.DeclareWarReason
 import com.unciv.logic.civilization.diplomacy.DiplomacyFlags
 import com.unciv.logic.civilization.diplomacy.DiplomaticModifiers
+import com.unciv.logic.civilization.diplomacy.WarType
 import com.unciv.models.ruleset.tile.ResourceType
 import com.unciv.models.ruleset.unique.UniqueType
 
@@ -138,7 +139,7 @@ class TradeLogic(val ourCivilization: Civilization, val otherCivilization: Civil
                 TradeType.Introduction -> to.diplomacyFunctions.makeCivilizationsMeet(to.gameInfo.getCivilization(offer.name))
                 TradeType.WarDeclaration -> {
                     val nameOfCivToDeclareWarOn = offer.name
-                    from.getDiplomacyManager(nameOfCivToDeclareWarOn).declareWar(DeclareWarReason.JoinWar)
+                    from.getDiplomacyManager(nameOfCivToDeclareWarOn).declareWar(DeclareWarReason(WarType.JoinWar))
                 }
                 else -> {}
             }

--- a/core/src/com/unciv/logic/trade/TradeLogic.kt
+++ b/core/src/com/unciv/logic/trade/TradeLogic.kt
@@ -139,7 +139,7 @@ class TradeLogic(val ourCivilization: Civilization, val otherCivilization: Civil
                 TradeType.Introduction -> to.diplomacyFunctions.makeCivilizationsMeet(to.gameInfo.getCivilization(offer.name))
                 TradeType.WarDeclaration -> {
                     val nameOfCivToDeclareWarOn = offer.name
-                    from.getDiplomacyManager(nameOfCivToDeclareWarOn).declareWar(DeclareWarReason(WarType.JoinWar))
+                    from.getDiplomacyManager(nameOfCivToDeclareWarOn).declareWar(DeclareWarReason(WarType.JoinWar, to))
                 }
                 else -> {}
             }

--- a/core/src/com/unciv/logic/trade/TradeLogic.kt
+++ b/core/src/com/unciv/logic/trade/TradeLogic.kt
@@ -5,6 +5,7 @@ import com.unciv.logic.civilization.AlertType
 import com.unciv.logic.civilization.Civilization
 import com.unciv.logic.civilization.PopupAlert
 import com.unciv.logic.civilization.diplomacy.CityStateFunctions
+import com.unciv.logic.civilization.diplomacy.DeclareWarReason
 import com.unciv.logic.civilization.diplomacy.DiplomacyFlags
 import com.unciv.logic.civilization.diplomacy.DiplomaticModifiers
 import com.unciv.models.ruleset.tile.ResourceType
@@ -137,7 +138,7 @@ class TradeLogic(val ourCivilization: Civilization, val otherCivilization: Civil
                 TradeType.Introduction -> to.diplomacyFunctions.makeCivilizationsMeet(to.gameInfo.getCivilization(offer.name))
                 TradeType.WarDeclaration -> {
                     val nameOfCivToDeclareWarOn = offer.name
-                    from.getDiplomacyManager(nameOfCivToDeclareWarOn).declareWar()
+                    from.getDiplomacyManager(nameOfCivToDeclareWarOn).declareWar(DeclareWarReason.JoinWar)
                 }
                 else -> {}
             }

--- a/tests/src/com/unciv/logic/civilization/diplomacy/DiplomacyManagerTests.kt
+++ b/tests/src/com/unciv/logic/civilization/diplomacy/DiplomacyManagerTests.kt
@@ -228,7 +228,7 @@ class DiplomacyManagerTests {
         cityState.getDiplomacyManager(a).addInfluence(61f)
 
         // when
-        a.getDiplomacyManager(cityState).declareWar()
+        a.getDiplomacyManager(cityState).declareWar(DeclareWarReason.DirectWar)
 
         // then
         assertTrue(cityState.getDiplomacyManager(a).isRelationshipLevelEQ(RelationshipLevel.Unforgivable))
@@ -243,7 +243,7 @@ class DiplomacyManagerTests {
         meet(e, cityState)
         // we cannot be allied and simoultaneously having a city state declare indirect war on us
         cityState.getDiplomacyManager(e).addInfluence(31f)
-        cityState.getDiplomacyManager(e).declareWar(indirectCityStateAttack = true)
+        cityState.getDiplomacyManager(e).declareWar(DeclareWarReason.DefensivePactWar)
 
         // when
         e.getDiplomacyManager(cityState).makePeace()

--- a/tests/src/com/unciv/logic/civilization/diplomacy/DiplomacyManagerTests.kt
+++ b/tests/src/com/unciv/logic/civilization/diplomacy/DiplomacyManagerTests.kt
@@ -228,7 +228,7 @@ class DiplomacyManagerTests {
         cityState.getDiplomacyManager(a).addInfluence(61f)
 
         // when
-        a.getDiplomacyManager(cityState).declareWar(DeclareWarReason.DirectWar)
+        a.getDiplomacyManager(cityState).declareWar()
 
         // then
         assertTrue(cityState.getDiplomacyManager(a).isRelationshipLevelEQ(RelationshipLevel.Unforgivable))
@@ -243,7 +243,7 @@ class DiplomacyManagerTests {
         meet(e, cityState)
         // we cannot be allied and simoultaneously having a city state declare indirect war on us
         cityState.getDiplomacyManager(e).addInfluence(31f)
-        cityState.getDiplomacyManager(e).declareWar(DeclareWarReason.DefensivePactWar)
+        cityState.getDiplomacyManager(e).declareWar(DeclareWarReason(WarType.DefensivePactWar, a))
 
         // when
         e.getDiplomacyManager(cityState).makePeace()


### PR DESCRIPTION
This PR addresses the concerns stated in  #10809. Unfortunately I got a little carried away an decided to refactor/rework most of the functions in `DeclareWar.kt`. So there is a lot of changed lines which doesn't reflect the minor functional changes.

Here is a list of the changes:

- There are now 4 types of war declaration, DirectWar, CityStateAllianceWar, DefensivePactWar, and JoinWar. The later three must be accompanied with an ally Civ that represents who they are joining with. Based on the discussion in #11380 there will likely be more reasons in the future so I made a class `DeclareWarReason` to pass this data in.
- Moved all of the heavy logic outside of the `DeclareWar` function.
- Notifications occur before the war is declared, this means the original war notification will be sent before the defensive pact war join notifications.
- The Warmongering modify no longer applies when defensive pacts are triggered.
- Shared enemy modifiers are given to the attacking and defending Civ. (Previously it was just the attacking Civ)
- Adds translations and missing defensive pact translations (oops, should have been done in #9900).

<details><summary>Picture</summary>
Here is a notification of Rome declaring war on The Huns who has a defensive pact with Polynesia who has a defensive pact with Austria.

![DefensivePactJoinWar](https://github.com/yairm210/Unciv/assets/7538725/b2aaddbd-25ec-49eb-989b-56653cd8369f)

</details> 