### PR TITLE
Multi-filter improve code clarity and more unit tests

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -1583,7 +1583,9 @@ Resource [resource] does not exist in ruleset! =
 Improvement [improvement] does not exist in ruleset! = 
 Nation [nation] does not exist in ruleset! = 
 Natural Wonder [naturalWonder] does not exist in ruleset! = 
+
 non-[filter] = 
+[filter1] or [filter2] = 
 
 # Civilopedia difficulty levels
 Player settings = 

--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -1583,9 +1583,7 @@ Resource [resource] does not exist in ruleset! =
 Improvement [improvement] does not exist in ruleset! = 
 Nation [nation] does not exist in ruleset! = 
 Natural Wonder [naturalWonder] does not exist in ruleset! = 
-
 non-[filter] = 
-[filter1] or [filter2] = 
 
 # Civilopedia difficulty levels
 Player settings = 

--- a/core/src/com/unciv/logic/MultiFilter.kt
+++ b/core/src/com/unciv/logic/MultiFilter.kt
@@ -6,16 +6,12 @@ object MultiFilter {
     private const val andSuffix = "}"
     private const val notPrefix = "non-["
     private const val notSuffix = "]"
-    private const val orPrefix = "["
-    private const val orSeparator = "] or ["
-    private const val orSuffix = "]"
 
     /**
-     *  Implements `and`, `or` and `not` logic on top of a [filterFunction].
+     *  Implements `and` and `not` logic on top of a [filterFunction].
      *
      *  Syntax:
      *      - `and`: `{filter1} {filter2}`... (can repeat as needed)
-     *      - `or`:  `[filter1] or [filter2]`... (can repeat as needed)
      *      - `not`: `non-[filter]`
      *  @param input The complex filtering term
      *  @param filterFunction The single filter implementation
@@ -29,9 +25,6 @@ object MultiFilter {
         if (input.hasSurrounding(andPrefix, andSuffix) && input.contains(andSeparator))
             return input.removeSurrounding(andPrefix, andSuffix).split(andSeparator)
                 .all { multiFilter(it, filterFunction, forUniqueValidityTests) }
-        if (input.hasSurrounding(orPrefix, orSuffix) && input.contains(orSeparator))
-            return input.removeSurrounding(orPrefix, orSuffix).split(orSeparator)
-                .any { multiFilter(it, filterFunction, forUniqueValidityTests) }
         if (input.hasSurrounding(notPrefix, notSuffix)) {
             //same as `return multiFilter() == forUniqueValidityTests`, but clearer
             val internalResult = multiFilter(input.removeSurrounding(notPrefix, notSuffix), filterFunction, forUniqueValidityTests)
@@ -45,11 +38,6 @@ object MultiFilter {
             // Resolve "AND" filters
             input.removeSurrounding(andPrefix, andSuffix)
                 .splitToSequence(andSeparator)
-                .flatMap { getAllSingleFilters(it) }
-        input.hasSurrounding(orPrefix, orSuffix) && input.contains(orSeparator) ->
-            // Resolve "OR" filters
-            input.removeSurrounding(orPrefix, orSuffix)
-                .splitToSequence(orSeparator)
                 .flatMap { getAllSingleFilters(it) }
         input.hasSurrounding(notPrefix, notSuffix) ->
             // Simply remove "non" syntax

--- a/core/src/com/unciv/logic/MultiFilter.kt
+++ b/core/src/com/unciv/logic/MultiFilter.kt
@@ -1,17 +1,50 @@
 package com.unciv.logic
 
 object MultiFilter {
-    fun multiFilter(input: String, filterFunction: (String)->Boolean,
-                    /** Unique validity doesn't check for actual matching */ forUniqueValidityTests: Boolean=false): Boolean {
-        if (input.contains("} {"))
-            return input.removePrefix("{").removeSuffix("}").split("} {")
-                .all{ multiFilter(it, filterFunction, forUniqueValidityTests) }
-        if (input.startsWith("non-[") && input.endsWith("]")) {
-            val internalResult = multiFilter(input.removePrefix("non-[").removeSuffix("]"), filterFunction)
+    private const val andPrefix = "{"
+    private const val andSeparator = "} {"
+    private const val andSuffix = "}"
+    private const val notPrefix = "non-["
+    private const val notSuffix = "]"
+
+    /**
+     *  Implements `and` and `not` logic on top of a [filterFunction].
+     *
+     *  Syntax:
+     *      - `and`: `{filter1} {filter2}`... (can repeat as needed)
+     *      - `not`: `non-[filter]`
+     *  @param input The complex filtering term
+     *  @param filterFunction The single filter implementation
+     *  @param forUniqueValidityTests Inverts the `non-[filter]` test because Unique validity doesn't check for actual matching
+     */
+    fun multiFilter(
+        input: String,
+        filterFunction: (String) -> Boolean,
+        forUniqueValidityTests: Boolean = false
+    ): Boolean {
+        if (input.hasSurrounding(andPrefix, andSuffix) && input.contains(andSeparator))
+            return input.removeSurrounding(andPrefix, andSuffix).split(andSeparator)
+                .all { multiFilter(it, filterFunction, forUniqueValidityTests) }
+        if (input.hasSurrounding(notPrefix, notSuffix)) {
+            //same as `return multiFilter() == forUniqueValidityTests`, but clearer
+            val internalResult = multiFilter(input.removeSurrounding(notPrefix, notSuffix), filterFunction, forUniqueValidityTests)
             return if (forUniqueValidityTests) internalResult else !internalResult
         }
         return filterFunction(input)
     }
 
+    fun getAllSingleFilters(input: String): Sequence<String> = when {
+        input.hasSurrounding(andPrefix, andSuffix) && input.contains(andSeparator) ->
+            // Resolve "AND" filters
+            input.removeSurrounding(andPrefix, andSuffix)
+                .splitToSequence(andSeparator)
+                .flatMap { getAllSingleFilters(it) }
+        input.hasSurrounding(notPrefix, notSuffix) ->
+            // Simply remove "non" syntax
+            getAllSingleFilters(input.removeSurrounding(notPrefix, notSuffix))
+        else -> sequenceOf(input)
+    }
 
+    fun String.hasSurrounding(prefix: String, suffix: String) =
+        startsWith(prefix) && endsWith(suffix)
 }

--- a/core/src/com/unciv/logic/MultiFilter.kt
+++ b/core/src/com/unciv/logic/MultiFilter.kt
@@ -6,12 +6,16 @@ object MultiFilter {
     private const val andSuffix = "}"
     private const val notPrefix = "non-["
     private const val notSuffix = "]"
+    private const val orPrefix = "["
+    private const val orSeparator = "] or ["
+    private const val orSuffix = "]"
 
     /**
-     *  Implements `and` and `not` logic on top of a [filterFunction].
+     *  Implements `and`, `or` and `not` logic on top of a [filterFunction].
      *
      *  Syntax:
      *      - `and`: `{filter1} {filter2}`... (can repeat as needed)
+     *      - `or`:  `[filter1] or [filter2]`... (can repeat as needed)
      *      - `not`: `non-[filter]`
      *  @param input The complex filtering term
      *  @param filterFunction The single filter implementation
@@ -25,6 +29,9 @@ object MultiFilter {
         if (input.hasSurrounding(andPrefix, andSuffix) && input.contains(andSeparator))
             return input.removeSurrounding(andPrefix, andSuffix).split(andSeparator)
                 .all { multiFilter(it, filterFunction, forUniqueValidityTests) }
+        if (input.hasSurrounding(orPrefix, orSuffix) && input.contains(orSeparator))
+            return input.removeSurrounding(orPrefix, orSuffix).split(orSeparator)
+                .any { multiFilter(it, filterFunction, forUniqueValidityTests) }
         if (input.hasSurrounding(notPrefix, notSuffix)) {
             //same as `return multiFilter() == forUniqueValidityTests`, but clearer
             val internalResult = multiFilter(input.removeSurrounding(notPrefix, notSuffix), filterFunction, forUniqueValidityTests)
@@ -38,6 +45,11 @@ object MultiFilter {
             // Resolve "AND" filters
             input.removeSurrounding(andPrefix, andSuffix)
                 .splitToSequence(andSeparator)
+                .flatMap { getAllSingleFilters(it) }
+        input.hasSurrounding(orPrefix, orSuffix) && input.contains(orSeparator) ->
+            // Resolve "OR" filters
+            input.removeSurrounding(orPrefix, orSuffix)
+                .splitToSequence(orSeparator)
                 .flatMap { getAllSingleFilters(it) }
         input.hasSurrounding(notPrefix, notSuffix) ->
             // Simply remove "non" syntax

--- a/core/src/com/unciv/logic/civilization/managers/RuinsManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/RuinsManager.kt
@@ -16,13 +16,13 @@ class RuinsManager(
     @Transient
     lateinit var civInfo: Civilization
     @Transient
-    lateinit var validRewards: List<RuinReward>
+    lateinit var validRewards: Collection<RuinReward>
 
     fun clone() = RuinsManager(ArrayList(lastChosenRewards))  // needs to deep-clone (the List, not the Strings) so undo works
 
     fun setTransients(civInfo: Civilization) {
         this.civInfo = civInfo
-        validRewards = civInfo.gameInfo.ruleset.ruinRewards.values.toList()
+        validRewards = civInfo.gameInfo.ruleset.ruinRewards.values
     }
 
     private fun rememberReward(reward: String) {

--- a/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
@@ -840,10 +840,7 @@ class MapUnit : IsPartOfGameInfoSerialization {
         // The improvement may get removed if it has ruins effects or is a barbarian camp, and will still be needed if removed
         val improvement = tile.improvement
 
-        if (civ.isMajorCiv()
-            && improvement != null
-            && tile.ruleset.tileImprovements[improvement]!!.isAncientRuinsEquivalent()
-        ) {
+        if (civ.isMajorCiv() && tile.getTileImprovement()?.isAncientRuinsEquivalent() == true) {
             getAncientRuinBonus(tile)
         }
         if (improvement == Constants.barbarianEncampment && !civ.isBarbarian())

--- a/core/src/com/unciv/logic/map/tile/Tile.kt
+++ b/core/src/com/unciv/logic/map/tile/Tile.kt
@@ -35,6 +35,45 @@ import kotlin.math.min
 import kotlin.random.Random
 
 class Tile : IsPartOfGameInfoSerialization {
+    //region Serialized fields
+    var militaryUnit: MapUnit? = null
+    var civilianUnit: MapUnit? = null
+    var airUnits = ArrayList<MapUnit>()
+
+    var position: Vector2 = Vector2.Zero
+    lateinit var baseTerrain: String
+    var terrainFeatures: List<String> = listOf()
+        private set
+
+    /** Should be immutable - never be altered in-place, instead replaced */
+    var exploredBy = HashSet<String>()
+
+    var naturalWonder: String? = null
+    var resource: String? = null
+        set(value) {
+            tileResourceCache = null
+            field = value
+        }
+    var resourceAmount: Int = 0
+    var improvement: String? = null
+    var improvementInProgress: String? = null
+    var improvementIsPillaged = false
+
+    var roadStatus = RoadStatus.None
+    var roadIsPillaged = false
+    var roadOwner: String = "" // either who last built the road or last owner of tile
+    var turnsToImprovement: Int = 0
+
+    var hasBottomRightRiver = false
+    var hasBottomRiver = false
+    var hasBottomLeftRiver = false
+
+    var history: TileHistory = TileHistory()
+
+    private var continent = -1
+    //endregion
+
+    //region Transient fields
     @Transient
     lateinit var tileMap: TileMap
 
@@ -54,21 +93,6 @@ class Tile : IsPartOfGameInfoSerialization {
     var owningCity: City? = null
         private set
 
-    fun setOwningCity(city: City?) {
-        if (city != null) {
-            if (roadStatus != RoadStatus.None && roadOwner != "") {
-                // remove previous neutral tile owner
-                getRoadOwner()!!.neutralRoads.remove(this.position)
-            }
-            roadOwner = city.civ.civName // only when taking control, otherwise last owner
-        } else if (roadStatus != RoadStatus.None && owningCity != null) {
-            // Razing City! Remove owner
-            roadOwner = ""
-        }
-        owningCity = city
-        isCityCenterInternal = getCity()?.location == position
-    }
-
     @Transient
     private lateinit var baseTerrainObject: Terrain
 
@@ -87,18 +111,6 @@ class Tile : IsPartOfGameInfoSerialization {
 
     @Transient
     var tileHeight = 0
-
-    var militaryUnit: MapUnit? = null
-    var civilianUnit: MapUnit? = null
-    var airUnits = ArrayList<MapUnit>()
-
-    var position: Vector2 = Vector2.Zero
-    lateinit var baseTerrain: String
-    var terrainFeatures: List<String> = listOf()
-        private set
-
-    /** Should be immutable - never be altered in-place, instead replaced */
-    var exploredBy = HashSet<String>()
 
     @Transient
     var terrainFeatureObjects: List<Terrain> = listOf()
@@ -125,36 +137,23 @@ class Tile : IsPartOfGameInfoSerialization {
     /** Between -1.0 and 1.0 - For map generation use only */
     var temperature: Double? = null
 
-    var naturalWonder: String? = null
-    var resource: String? = null
-        set(value) {
-            tileResourceCache = null
-            field = value
-        }
-    var resourceAmount: Int = 0
-    var improvement: String? = null
-    var improvementInProgress: String? = null
-    var improvementIsPillaged = false
-
-    var roadStatus = RoadStatus.None
-    var roadIsPillaged = false
-    var roadOwner: String = "" // either who last built the road or last owner of tile
-    var turnsToImprovement: Int = 0
-
-    fun isHill() = baseTerrain == Constants.hill || terrainFeatures.contains(Constants.hill)
-
-    var hasBottomRightRiver = false
-    var hasBottomRiver = false
-    var hasBottomLeftRiver = false
-
-    var history: TileHistory = TileHistory()
-
-    private var continent = -1
-
     val latitude: Float
         get() = HexMath.getLatitude(position)
     val longitude: Float
         get() = HexMath.getLongitude(position)
+
+    @Transient
+    private var tileResourceCache: TileResource? = null
+    val tileResource: TileResource
+        get() {
+            if (tileResourceCache == null) {
+                if (resource == null) throw Exception("No resource exists for this tile!")
+                if (!ruleset.tileResources.containsKey(resource!!)) throw Exception("Resource $resource does not exist in this ruleset!")
+                tileResourceCache = ruleset.tileResources[resource!!]!!
+            }
+            return tileResourceCache!!
+        }
+    //endregion
 
     fun clone(): Tile {
         val toReturn = Tile()
@@ -196,6 +195,8 @@ class Tile : IsPartOfGameInfoSerialization {
 
     //region pure functions
 
+    fun isHill() = baseTerrain == Constants.hill || terrainFeatures.contains(Constants.hill)
+
     fun containsGreatImprovement(): Boolean {
         return getTileImprovement()?.isGreatImprovement() == true
     }
@@ -216,18 +217,6 @@ class Tile : IsPartOfGameInfoSerialization {
     }
 
     fun getCity(): City? = owningCity
-
-    @Transient
-    private var tileResourceCache: TileResource? = null
-    val tileResource: TileResource
-        get() {
-            if (tileResourceCache == null) {
-                if (resource == null) throw Exception("No resource exists for this tile!")
-                if (!ruleset.tileResources.containsKey(resource!!)) throw Exception("Resource $resource does not exist in this ruleset!")
-                tileResourceCache = ruleset.tileResources[resource!!]!!
-            }
-            return tileResourceCache!!
-        }
 
     internal fun getNaturalWonder(): Terrain =
             if (naturalWonder == null) throw Exception("No natural wonder exists for this tile!")
@@ -485,8 +474,8 @@ class Tile : IsPartOfGameInfoSerialization {
         return MultiFilter.multiFilter(filter, { matchesSingleFilter(it, civInfo, ignoreImprovement) })
     }
 
-    fun matchesSingleFilter(filter: String, civInfo: Civilization? = null, ignoreImprovement: Boolean = false): Boolean {
-        if (matchesTerrainFilter(filter, civInfo)) return true
+    private fun matchesSingleFilter(filter: String, civInfo: Civilization? = null, ignoreImprovement: Boolean = false): Boolean {
+        if (matchesSingleTerrainFilter(filter, civInfo)) return true
         if ((improvement == null || improvementIsPillaged) && filter == "unimproved") return true
         if (improvement != null && !improvementIsPillaged && filter == "improved") return true
         if (ignoreImprovement) return false
@@ -494,12 +483,12 @@ class Tile : IsPartOfGameInfoSerialization {
         return getUnpillagedRoadImprovement()?.matchesFilter(filter) == true
     }
 
+    /** Implements [UniqueParameterType.TerrainFilter][com.unciv.models.ruleset.unique.UniqueParameterType.TerrainFilter] */
     fun matchesTerrainFilter(filter: String, observingCiv: Civilization? = null): Boolean {
         return MultiFilter.multiFilter(filter, { matchesSingleTerrainFilter(it, observingCiv) })
     }
 
-    /** Implements [UniqueParameterType.TerrainFilter][com.unciv.models.ruleset.unique.UniqueParameterType.TerrainFilter] */
-    fun matchesSingleTerrainFilter(filter: String, observingCiv: Civilization? = null): Boolean {
+    private fun matchesSingleTerrainFilter(filter: String, observingCiv: Civilization? = null): Boolean {
         return when (filter) {
             "Terrain" -> true
             in Constants.all -> true
@@ -519,7 +508,7 @@ class Tile : IsPartOfGameInfoSerialization {
             "Water resource" -> isWater && observingCiv != null && hasViewableResource(observingCiv)
             "Featureless" -> terrainFeatures.isEmpty()
             Constants.freshWaterFilter -> isAdjacentTo(Constants.freshWater, observingCiv)
-            
+
             else -> {
                 if (allTerrains.any { it.matchesFilter(filter) }) return true
                 if (getOwner()?.matchesFilter(filter) == true) return true
@@ -800,6 +789,21 @@ class Tile : IsPartOfGameInfoSerialization {
     fun setOwnerTransients() {
         if (owningCity == null && roadOwner != "")
             getRoadOwner()!!.neutralRoads.add(this.position)
+    }
+
+    fun setOwningCity(city: City?) {
+        if (city != null) {
+            if (roadStatus != RoadStatus.None && roadOwner != "") {
+                // remove previous neutral tile owner
+                getRoadOwner()!!.neutralRoads.remove(this.position)
+            }
+            roadOwner = city.civ.civName // only when taking control, otherwise last owner
+        } else if (roadStatus != RoadStatus.None && owningCity != null) {
+            // Razing City! Remove owner
+            roadOwner = ""
+        }
+        owningCity = city
+        isCityCenterInternal = getCity()?.location == position
     }
 
     /**

--- a/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
@@ -694,7 +694,7 @@ enum class UniqueParameterType(
     open fun isKnownValue(parameterText: String, ruleset: Ruleset): Boolean = false
 
     fun getErrorSeverityForFilter(parameterText: String, ruleset: Ruleset): UniqueType.UniqueParameterErrorSeverity? {
-        val isKnown = MultiFilter.multiFilter(parameterText, {isKnownValue(it, ruleset)}, true)
+        val isKnown = MultiFilter.multiFilter(parameterText, { isKnownValue(it, ruleset) }, true)
         if (isKnown) return null
         return UniqueType.UniqueParameterErrorSeverity.PossibleFilteringUnique
     }

--- a/core/src/com/unciv/models/ruleset/validation/UniqueValidator.kt
+++ b/core/src/com/unciv/models/ruleset/validation/UniqueValidator.kt
@@ -1,6 +1,7 @@
 package com.unciv.models.ruleset.validation
 
 import com.unciv.Constants
+import com.unciv.logic.MultiFilter
 import com.unciv.logic.map.mapunit.MapUnitCache
 import com.unciv.models.ruleset.IRulesetObject
 import com.unciv.models.ruleset.Ruleset
@@ -23,11 +24,8 @@ class UniqueValidator(val ruleset: Ruleset) {
     private fun addToHashsets(uniqueHolder: IHasUniques) {
         for (unique in uniqueHolder.uniqueObjects) {
             if (unique.type == null) allNonTypedUniques.add(unique.text)
-            else allUniqueParameters.addAll(unique.allParams.flatMap {
-                // Multifilters have the actual filtering uniques
-                it.removePrefix("{").removeSuffix("}").split("} {")}
-                // Non-filters
-                .map { if (it.startsWith("non-[")) {it.removePrefix("non-[").removeSuffix("]")} else it }
+            else allUniqueParameters.addAll(
+                unique.allParams.asSequence().flatMap { MultiFilter.getAllSingleFilters(it) }
             )
         }
     }

--- a/core/src/com/unciv/ui/components/extensions/FormattingExtensions.kt
+++ b/core/src/com/unciv/ui/components/extensions/FormattingExtensions.kt
@@ -92,18 +92,5 @@ object UncivDateFormat {
     fun String.parseDate(): Date = utcFormat.parse(this)
 }
 
-/** For filters containing '{', apply the [predicate] to each part inside "{}" and aggregate using [operation];
- *  otherwise return `null` for Elvis chaining of the individual filter. */
-fun <T> String.filterCompositeLogic(predicate: (String) -> T?, operation: (T, T) -> T): T? {
-    val elements: List<T> = removePrefix("{").removeSuffix("}").split("} {")
-        .mapNotNull(predicate)
-    if (elements.isEmpty()) return null
-    return elements.reduce(operation)
-}
-/** If a filter string contains '{', apply the [predicate] to each part inside "{}" then 'and' (`&&`) them together;
- *  otherwise return `null` for Elvis chaining of the individual filter. */
-fun String.filterAndLogic(predicate: (String) -> Boolean): Boolean? =
-        if (contains('{')) filterCompositeLogic(predicate) { a, b -> a && b } else null
-
 /** Format a Vector2 like (0,0) instead of (0.0,0.0) like [toString][Vector2.toString] does */
 fun Vector2.toPrettyString(): String = "(${x.toInt()},${y.toInt()})"

--- a/docs/Modders/Unique-parameters.md
+++ b/docs/Modders/Unique-parameters.md
@@ -11,22 +11,29 @@ Note that all of these are case-sensitive!
 
 ## General Filter Rules
 
-All filters except for `populationFilter` accept multiple values in the format: `{A} {B} {C}` etc, meaning "the object must match ALL of these filters"
+All filters except for `populationFilter` accept combining sub-filters with 'and', 'or' or 'not' logic.
+
+'And' logic combines multiple values in the format: `{A} {B} {C}` etc, meaning "the object must match ALL of these filters".
 
 > Example: `[{Military} {Water}] units`, `[{Wounded} {Armor}] units`, etc.
 
 No space or other text is allowed between the `[` and the first `{`, nor between the last `}` and the ending `]`. The space in `} {`, however, is mandatory.
 
-All filters accept `non-[filter]` as a possible value
+'Or' logic combines multiple values in the format: `[A] or [B] or [C]` etc, meaning "the object must match ANY of these filters".
+
+> Example: `[[Water] or [Helicopter]] units`, `[[Puppeted] or [Razing]] cities`, etc.
+
+'Not' logic uses the syntax `non-[filter]`.
 
 > Example: `[non-[Wounded]] units`
 
-These can be combined by nesting, with the exception that an "ALL" filter cannot contain another "ALL" filter, even with a NON-filter in between.
+These can be combined by nesting, with the exception that an "ALL" filter cannot contain another "ALL" filter, or an "ANY" filter cannot contain another "ANY" filter, even with other logic types in between.
 
 > Example: `[{non-[Wounded]} {Armor}] units` means unit is type Armor and at full health.
 > Example: `[non-[{Wounded} {Armor}]] units` means unit is neither wounded nor an Armor one.
+> Example: `[[{Wounded} {Water}] or [{Embarked} {Scout}]] units`
 
-`[{non-[{Wounded} {Armor}]} {Embarked}] units` WILL FAIL because the game will treat both "} {" at the same time and see `non-[{Wounded` and `Armor}]`, both invalid.
+However, `[{non-[{Wounded} {Armor}]} {Embarked}] units` WILL FAIL because the game will treat both "} {" at the same time and see `non-[{Wounded` and `Armor}]`, both invalid.
 
 Display of complex filters in Civilopedia may become unreadable. If so, consider hiding that unique and provide a better wording using the `Comment []` unique separately.
 

--- a/docs/Modders/Unique-parameters.md
+++ b/docs/Modders/Unique-parameters.md
@@ -21,13 +21,14 @@ All filters accept `non-[filter]` as a possible value
 
 > Example: `[non-[Wounded]] units`
 
-These can be combined by having the values be negative filters
+These can be combined by nesting, with the exception that an "ALL" filter cannot contain another "ALL" filter, even with a NON-filter in between.
 
-> Example: `[{non-[Wounded]} {Armor}] units`
+> Example: `[{non-[Wounded]} {Armor}] units` means unit is type Armor and at full health.
+> Example: `[non-[{Wounded} {Armor}]] units` means unit is neither wounded nor an Armor one.
 
-These CANNOT be combined in the other way - e.g. `[non-[{Wounded} {Armor}]] units` is NOT valid and will fail to register any units.
+`[{non-[{Wounded} {Armor}]} {Embarked}] units` WILL FAIL because the game will treat both "} {" at the same time and see `non-[{Wounded` and `Armor}]`, both invalid.
 
-This is because to the player, the text will be `non-Wounded Armor units`, which parses like `[{non-[Wounded]} {Armor}] units`
+Display of complex filters in Civilopedia may become unreadable. If so, consider hiding that unique and provide a better wording using the `Comment []` unique separately.
 
 ## civFilter
 

--- a/docs/Modders/Unique-parameters.md
+++ b/docs/Modders/Unique-parameters.md
@@ -11,29 +11,22 @@ Note that all of these are case-sensitive!
 
 ## General Filter Rules
 
-All filters except for `populationFilter` accept combining sub-filters with 'and', 'or' or 'not' logic.
-
-'And' logic combines multiple values in the format: `{A} {B} {C}` etc, meaning "the object must match ALL of these filters".
+All filters except for `populationFilter` accept multiple values in the format: `{A} {B} {C}` etc, meaning "the object must match ALL of these filters"
 
 > Example: `[{Military} {Water}] units`, `[{Wounded} {Armor}] units`, etc.
 
 No space or other text is allowed between the `[` and the first `{`, nor between the last `}` and the ending `]`. The space in `} {`, however, is mandatory.
 
-'Or' logic combines multiple values in the format: `[A] or [B] or [C]` etc, meaning "the object must match ANY of these filters".
-
-> Example: `[[Water] or [Helicopter]] units`, `[[Puppeted] or [Razing]] cities`, etc.
-
-'Not' logic uses the syntax `non-[filter]`.
+All filters accept `non-[filter]` as a possible value
 
 > Example: `[non-[Wounded]] units`
 
-These can be combined by nesting, with the exception that an "ALL" filter cannot contain another "ALL" filter, or an "ANY" filter cannot contain another "ANY" filter, even with other logic types in between.
+These can be combined by nesting, with the exception that an "ALL" filter cannot contain another "ALL" filter, even with a NON-filter in between.
 
 > Example: `[{non-[Wounded]} {Armor}] units` means unit is type Armor and at full health.
 > Example: `[non-[{Wounded} {Armor}]] units` means unit is neither wounded nor an Armor one.
-> Example: `[[{Wounded} {Water}] or [{Embarked} {Scout}]] units`
 
-However, `[{non-[{Wounded} {Armor}]} {Embarked}] units` WILL FAIL because the game will treat both "} {" at the same time and see `non-[{Wounded` and `Armor}]`, both invalid.
+`[{non-[{Wounded} {Armor}]} {Embarked}] units` WILL FAIL because the game will treat both "} {" at the same time and see `non-[{Wounded` and `Armor}]`, both invalid.
 
 Display of complex filters in Civilopedia may become unreadable. If so, consider hiding that unique and provide a better wording using the `Comment []` unique separately.
 

--- a/docs/Modders/Unique-parameters.md
+++ b/docs/Modders/Unique-parameters.md
@@ -15,7 +15,7 @@ All filters except for `populationFilter` accept multiple values in the format: 
 
 > Example: `[{Military} {Water}] units`, `[{Wounded} {Armor}] units`, etc.
 
-No space or other text is allowed between the `[` and the first `{`.
+No space or other text is allowed between the `[` and the first `{`, nor between the last `}` and the ending `]`. The space in `} {`, however, is mandatory.
 
 All filters accept `non-[filter]` as a possible value
 
@@ -125,6 +125,7 @@ cityFilters allow us to choose the range of cities affected by this unique:
 - `in foreign cities`, `Foreign`
 - `in annexed cities`, `Annexed`
 - `in puppeted cities`, `Puppeted`
+- `in cities being razed`, `Razing`
 - `in holy cities`, `Holy`
 - `in City-State cities`
 - `in cities following this religion` - Should only be used in pantheon/follower uniques for religions

--- a/tests/src/com/unciv/logic/MultiFilterTests.kt
+++ b/tests/src/com/unciv/logic/MultiFilterTests.kt
@@ -63,20 +63,6 @@ class MultiFilterTests {
     }
 
     @Test
-    fun testOrLogic() {
-        Assert.assertTrue(MultiFilter.multiFilter("[A] or [B]", { it=="A"}))
-        Assert.assertTrue(MultiFilter.multiFilter("[A] or [B]", { it=="B"}))
-        Assert.assertFalse(MultiFilter.multiFilter("[A] or [B]", { it=="C"}))
-    }
-
-    @Test
-    fun testAndNestedInOrLogic() {
-        Assert.assertTrue(MultiFilter.multiFilter("[{A} {B}] or [{C} {D}]", { it=="A" || it == "B"}))
-        Assert.assertTrue(MultiFilter.multiFilter("[{A} {B}] or [{C} {D}]", { it=="C" || it == "D"}))
-        Assert.assertFalse(MultiFilter.multiFilter("[{A} {B}] or [{C} {D}]", { it=="A" || it == "C"}))
-    }
-
-    @Test
     fun `test a complete Unique with a complex multi-filter is parsed and validated correctly`() {
         val text = "Only available <if [Colosseum] is constructed in all [non-[{non-[Resisting]} {non-[Razing]} {non-[Coastal]}]] cities>"
         val unique = Unique(text)
@@ -122,18 +108,5 @@ class MultiFilterTests {
 
         city.isPuppet = true
         Assert.assertFalse(Conditionals.conditionalApplies(null, conditional, stateForConditionals))
-    }
-
-    @Test
-    fun `test cityFilter nesting 'or' logic in 'and' logic`() {
-        val condition = "in [{[Puppeted] or [Razing]} {[Coastal] or [non-[Garrisoned]]}] cities"
-        val conditional = Unique(condition)
-        Assert.assertFalse(Conditionals.conditionalApplies(null, conditional, stateForConditionals)) // only [non-[Garrisoned]] is true
-
-        city.isPuppet = true
-        Assert.assertTrue(Conditionals.conditionalApplies(null, conditional, stateForConditionals)) // Puppeted fulfills left of AND, no garrison right
-
-        game.addUnit("Warrior", civ, game.getTile(Vector2.Zero)).fortify()
-        Assert.assertFalse(Conditionals.conditionalApplies(null, conditional, stateForConditionals)) // Adding garrison will make right term false
     }
 }

--- a/tests/src/com/unciv/logic/MultiFilterTests.kt
+++ b/tests/src/com/unciv/logic/MultiFilterTests.kt
@@ -1,15 +1,28 @@
 package com.unciv.logic
 
+import com.badlogic.gdx.math.Vector2
+import com.unciv.logic.city.CityFlags
 import com.unciv.models.ruleset.Ruleset
+import com.unciv.models.ruleset.unique.Conditionals
+import com.unciv.models.ruleset.unique.StateForConditionals
+import com.unciv.models.ruleset.unique.Unique
 import com.unciv.models.ruleset.unique.UniqueParameterType
 import com.unciv.models.ruleset.unique.UniqueType
+import com.unciv.models.ruleset.validation.UniqueValidator
 import com.unciv.testing.GdxTestRunner
+import com.unciv.testing.TestGame
 import org.junit.Assert
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(GdxTestRunner::class)
 class MultiFilterTests {
+    private val game = TestGame()
+    private val civ = game.addCiv()
+    private val city = game.addCity(civ, game.getTile(Vector2.Zero))
+    private val stateForConditionals = StateForConditionals(city)
+
     @Test
     fun testSplitTerms() {
         Assert.assertTrue(MultiFilter.multiFilter("{A} {B}", { it=="A" || it=="B"}))
@@ -31,8 +44,8 @@ class MultiFilterTests {
 
     @Test
     fun testParameterTypeSplits(){
-        Assert.assertNull(UniqueParameterType.MapUnitFilter.getErrorSeverity("{Wounded} {Barbarian}", Ruleset()))
-        Assert.assertEquals(UniqueParameterType.MapUnitFilter.getErrorSeverity("{Wounded} {NONEXISTANTFILTER}", Ruleset()),
+        Assert.assertNull(UniqueParameterType.MapUnitFilter.getErrorSeverity("{Wounded} {Barbarian}", game.ruleset))
+        Assert.assertEquals(UniqueParameterType.MapUnitFilter.getErrorSeverity("{Wounded} {NONEXISTANTFILTER}", game.ruleset),
             UniqueType.UniqueParameterErrorSeverity.PossibleFilteringUnique)
     }
 
@@ -40,12 +53,60 @@ class MultiFilterTests {
     @Test
     fun testParameterNonFilters(){
         Assert.assertNull(UniqueParameterType.MapUnitFilter.getErrorSeverity("non-[Wounded]", Ruleset()))
-        Assert.assertNull(UniqueParameterType.MapUnitFilter.getErrorSeverity("{non-[Wounded]} {Barbarian}", Ruleset()))
+        Assert.assertNull(UniqueParameterType.MapUnitFilter.getErrorSeverity("{non-[Wounded]} {Barbarian}", game.ruleset))
     }
 
     @Test
     fun testParameterTypeSplitsWorkWithMultipleLevels() {
         // Wounded is part of MapUnitFilter, Melee - BaseUnitFilter, and Land - UnitTypeFilter
-        Assert.assertNull(UniqueParameterType.MapUnitFilter.getErrorSeverity("{Wounded} {Melee} {Land}", Ruleset()))
+        Assert.assertNull(UniqueParameterType.MapUnitFilter.getErrorSeverity("{Wounded} {Melee} {Land}", game.ruleset))
+    }
+
+    @Test
+    fun `test a complete Unique with a complex multi-filter is parsed and validated correctly`() {
+        val text = "Only available <if [Colosseum] is constructed in all [non-[{non-[Resisting]} {non-[Razing]} {non-[Coastal]}]] cities>"
+        val unique = Unique(text)
+        val errors = UniqueValidator(game.ruleset).checkUnique(unique, false, null, false)
+        Assert.assertFalse(errors.isNotOK())
+    }
+
+    @Before
+    fun resetCity() {
+        city.isBeingRazed = false
+        city.isPuppet = false
+    }
+
+    @Test
+    fun `test cityFilter combining two non-filters`() {
+        val condition = "in [{non-[Puppeted]} {non-[Razing]}] cities"
+        val conditional = Unique(condition)
+        Assert.assertTrue(Conditionals.conditionalApplies(null, conditional, stateForConditionals))
+
+        city.isBeingRazed = true
+        Assert.assertFalse(Conditionals.conditionalApplies(null, conditional, stateForConditionals))
+
+        city.isBeingRazed = false
+        city.isPuppet = true
+        Assert.assertFalse(Conditionals.conditionalApplies(null, conditional, stateForConditionals))
+
+        city.isBeingRazed = true
+        Assert.assertFalse(Conditionals.conditionalApplies(null, conditional, stateForConditionals))
+    }
+
+    @Test
+    fun `test cityFilter negating a combined filter`() {
+        val condition = "in [non-[{Puppeted} {Resisting}]] cities"
+        val conditional = Unique(condition)
+        Assert.assertTrue(Conditionals.conditionalApplies(null, conditional, stateForConditionals))
+
+        city.isPuppet = true
+        Assert.assertTrue(Conditionals.conditionalApplies(null, conditional, stateForConditionals))
+
+        city.isPuppet = false
+        city.setFlag(CityFlags.Resistance, 3)
+        Assert.assertTrue(Conditionals.conditionalApplies(null, conditional, stateForConditionals))
+
+        city.isPuppet = true
+        Assert.assertFalse(Conditionals.conditionalApplies(null, conditional, stateForConditionals))
     }
 }


### PR DESCRIPTION
... and quite some linting and more unit tests. Read commits separately.

- Up to the last commit with the 'or' logic this is harmless - can revert & split off if you want a no-brainer.
- Tile class reorder: Just because I couldn't find stuff how I expected to. Other classes would need similar - e.g. City has pure functions in the "state-changing" region, and having 'primary' as in serialized fields first in the source should be a general rule...
- Dead code removed - surprised to find it
- the placement of `non-[filter]` in the templates file... Could do better, too lazy to really think of a good place & header comment
- String.hasSurrounding is named to match the kotlin library's removeSurrounding - could be private but I expect reuse, or could be in one of the Extensions files - but none sounds like a match, FormattingExtensions sounds least off. Doesn't do much but helps readability quite some IMHO.
- Why does RuinsManager not need a copy of all rewards? No need, it iterates, filters, *then* copies later anyway, and for that the view-based iterator is fine.