### PR TITLE
Fix: A unit with no sight can still see its own tile

### DIFF
--- a/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
@@ -653,7 +653,7 @@ class MapUnit : IsPartOfGameInfoSerialization {
         val oldViewableTiles = viewableTiles
 
         viewableTiles = when {
-            hasUnique(UniqueType.NoSight) -> hashSetOf()
+            hasUnique(UniqueType.NoSight) -> hashSetOf(getTile()) // 0 sight distance still means we can see the Tile we're in
             hasUnique(UniqueType.CanSeeOverObstacles) ->
                 getTile().getTilesInDistance(getVisibilityRange()).toHashSet() // it's that simple
             else -> getTile().getViewableTilesList(getVisibilityRange()).toHashSet()


### PR DESCRIPTION
Closes #11504...

Actually not really a Fix but a rule change - if "No sight" is really meant to mean "entirely blind", then the "lose unit in fog" behaviour is _entirely correct_!

Update UniqueType.NoSight.docDescription too maybe?

<details><summary>screenshot</summary>

![image](https://github.com/yairm210/Unciv/assets/63000004/d54fafa8-7012-4e65-be99-39adbfb4f2fb)
</details>