### PR TITLE
Fixed problem with selecting city constructions option and AutoPlay

### DIFF
--- a/core/src/com/unciv/logic/city/CityConstructions.kt
+++ b/core/src/com/unciv/logic/city/CityConstructions.kt
@@ -35,6 +35,7 @@ import com.unciv.ui.components.extensions.withoutItem
 import com.unciv.ui.components.fonts.Fonts
 import com.unciv.ui.screens.civilopediascreen.CivilopediaCategories
 import com.unciv.ui.screens.civilopediascreen.FormattedLine
+import com.unciv.ui.screens.worldscreen.WorldScreen
 import kotlin.math.ceil
 import kotlin.math.min
 import kotlin.math.roundToInt
@@ -709,7 +710,7 @@ class CityConstructions : IsPartOfGameInfoSerialization {
         val isCurrentPlayersTurn = city.civ.gameInfo.isUsersTurn()
                 || !city.civ.gameInfo.gameParameters.isOnlineMultiplayer
         if ((isCurrentPlayersTurn && (UncivGame.Current.settings.autoAssignCityProduction
-                || UncivGame.Current.settings.autoPlay.fullAutoPlayAI)) // only automate if the active human player has the setting to automate production
+                || UncivGame.Current.worldScreen!!.autoPlay.isAutoPlayingAndFullAutoPlayAI())) // only automate if the active human player has the setting to automate production
                 || !city.civ.isHuman() || city.isPuppet) {
             ConstructionAutomation(this).chooseNextConstruction()
         }

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/AutoPlay.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/AutoPlay.kt
@@ -63,7 +63,7 @@ class AutoPlay(private var autoPlaySettings: GameSettings.GameSettingsAutoPlay) 
 
     fun isAutoPlaying(): Boolean = turnsToAutoPlay > 0 || autoPlayTurnInProgress
 
-    fun fullAutoPlayAI(): Boolean = isAutoPlaying() && autoPlaySettings.fullAutoPlayAI
+    fun isAutoPlayingAndFullAutoPlayAI(): Boolean = isAutoPlaying() && autoPlaySettings.fullAutoPlayAI
 
     /**
      * @return true if we should play at least 1 more turn and we are not currenlty processing any AutoPlay


### PR DESCRIPTION
Fixes the problem "Unciv 4.11.7 auto assign city production" on discord.
The problem stems from #11329 but should be fixed now from the one line of change.