### PR TITLE
RFC: A resettable Lazy alternative

### DIFF
--- a/core/src/com/unciv/utils/ResettableLazy.kt
+++ b/core/src/com/unciv/utils/ResettableLazy.kt
@@ -1,0 +1,87 @@
+package com.unciv.utils
+
+import kotlin.reflect.KProperty
+import kotlin.reflect.KProperty0
+import kotlin.reflect.jvm.isAccessible
+
+/**
+ *  A replacement for `lazy {}` that allows use as resettable cache.
+ *
+ *  Typical usage: `val foo by resettableLazy { bar() }; ::foo.resetLazy()`
+ *
+ *  Code mirrors [SynchronizedLazyImpl] closely, including adapted Kdoc on the accessor extensions.
+ *  No support for the other [LazyThreadSafetyMode]s.
+ *
+ *  - Note this does ***not*** extend the default [Lazy] interface, but it has all the same elements.
+ *    When doing so the compiler will redirect instantiation to its own 'publication' implementation.
+ */
+class ResettableLazy<out T>(private val initializer: () -> T, lock: Any?) {
+    private var _value: Any? = UninitializedValue
+    private val lock = lock ?: this
+
+    val value: T
+        get() {
+            val v1 = _value
+            if (v1 !== UninitializedValue)
+                @Suppress("UNCHECKED_CAST")
+                return v1 as T
+            return synchronized(lock) {
+                val v2 = _value
+                if (v2 !== UninitializedValue)
+                    @Suppress("UNCHECKED_CAST")
+                    v2 as T
+                else {
+                    val newValue = initializer()
+                    _value = newValue
+                    newValue
+                }
+            }
+        }
+
+    @Suppress("NOTHING_TO_INLINE")
+    inline operator fun getValue(thisRef: Any?, property: KProperty<*>): T = value
+
+    internal fun reset() {
+        _value = UninitializedValue
+    }
+
+    private fun isInitialized() = _value !== UninitializedValue
+    override fun toString(): String = if (isInitialized()) value.toString() else "Lazy value not initialized yet."
+    private object UninitializedValue
+}
+
+/**
+ * Creates a new instance of the [ResettableLazy] that uses the specified initialization function [initializer].
+ *
+ * Note: ResettableLazy only supports thread-safety mode [LazyThreadSafetyMode.SYNCHRONIZED].
+ * If the initialization of a value throws an exception, it will attempt to reinitialize the value at next access.
+ *
+ * Note that the returned instance uses itself to synchronize on. Do not synchronize from external code on
+ * the returned instance as it may cause accidental deadlock. Also this behavior can be changed in the future.
+ */
+fun <T> resettableLazy (initializer: () -> T) = ResettableLazy(initializer, null)
+
+/**
+ * Creates a new instance of the [ResettableLazy] that uses the specified initialization function [initializer].
+ *
+ * Note: ResettableLazy only supports thread-safety mode [LazyThreadSafetyMode.SYNCHRONIZED].
+ * If the initialization of a value throws an exception, it will attempt to reinitialize the value at next access.
+ *
+ * The returned instance uses the specified [lock] object to synchronize on.
+ */
+@Suppress("unused")
+fun <T> resettableLazy (lock: Any, initializer: () -> T) = ResettableLazy(initializer, lock)
+
+/**
+ *  Reset the [ResettableLazy] feeding this field.
+ *
+ *  The cached value is forgotten, and the next time the property is accessed will call the initializer again.
+ *
+ *  @throws ClassCastException If called on a field not using the [ResettableLazy] delegate.
+ *  @throws NullPointerException I called on a non-delegated field.
+ */
+fun <T> KProperty0<T>.resetLazy() {
+    isAccessible = true
+    @Suppress("UNCHECKED_CAST")
+    (getDelegate() as ResettableLazy<T>).reset()
+}

--- a/tests/src/com/unciv/testing/TestResetLazy.kt
+++ b/tests/src/com/unciv/testing/TestResetLazy.kt
@@ -1,0 +1,57 @@
+package com.unciv.testing
+
+import com.unciv.utils.resetLazy
+import com.unciv.utils.resettableLazy
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.lang.ClassCastException
+
+
+@RunWith(GdxTestRunner::class)
+class TestResetLazy {
+    private val data = mutableListOf<Int>()
+
+    private val test1 by resettableLazy {
+        data.hashCode()
+    }
+
+    private val test2 by lazy {
+        data.hashCode()
+    }
+
+    @Before
+    fun resetTest() {
+        ::test1.resetLazy()
+        data.clear()
+        data += listOf(1, 7, 19, 42)
+    }
+
+    @Test
+    fun `resettableLazy should be functionally equivalent to lazy`() {
+        Assert.assertEquals(data.hashCode(), test1)
+        Assert.assertEquals(data.hashCode(), test2)
+    }
+
+    @Test
+    fun `resettableLazy is able to re-evaluate`() {
+        Assert.assertEquals(data.hashCode(), test1)
+        Assert.assertEquals(data.hashCode(), test2)
+        data += 666
+        Assert.assertNotEquals(data.hashCode(), test1)
+        ::test1.resetLazy()
+        Assert.assertEquals(data.hashCode(), test1)
+        Assert.assertNotEquals(data.hashCode(), test2)
+    }
+    @Test
+    fun `resetLazy cannot be called on a normal Lazy`() {
+        val threw = try {
+            ::test2.resetLazy()
+            false
+        } catch (ex: ClassCastException) {
+            true
+        }
+        Assert.assertTrue("resetLazy should throw when called on a normal Lazy", threw)
+    }
+}


### PR DESCRIPTION
An experiment: What if there were a way to tell a `by lazy { ... }` field that its cached value is obsolete?

This is just the tool and its unit tests... But if liked, we could refactor some existing fields - see `resetAdjacentToRiverTransient`? Should be oodles of candidates, but that was the only direct example I could find.

Notes:
* Can't reflect-hack the existing Lazy as it forgets its initializer lambda as soon as it is tripped
* Not 100% compatible as inheriting from Lazy directly breaks it - the compiler no longer does as it is told, the Lazy thing must have hardcoded support one cannot modify - we inherit and we're no longer actually instantiated even if the constructor call is explicit. The field gets a SafePublicationLazyImpl delegate instead.
* Won't get the Lazy optimization that a tripped lazy will get its delegate replaced by the much faster `InitializedLazyImpl` stub - one, need to keep knowledge about initializer, two, that seems to be done compiler-hardcoded too: There's a `writeReplace` method but I don't see where it is called, actually it can't really be legally called as it is private...