### PR TITLE
Add the culture-refunding version of remove policy unique

### DIFF
--- a/core/src/com/unciv/logic/civilization/managers/PolicyManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/PolicyManager.kt
@@ -139,6 +139,23 @@ class PolicyManager : IsPartOfGameInfoSerialization {
     // from https://forums.civfanatics.com/threads/the-number-crunching-thread.389702/
     // round down to nearest 5
     fun getCultureNeededForNextPolicy(): Int {
+        return getPolicyCultureCost(numberOfAdoptedPolicies)
+    }
+
+    fun getCultureRefundMap(policiesToRemove: List<Policy>, refundPercentage: Int): Map<Policy, Int> {
+        var policyCostInput = numberOfAdoptedPolicies
+
+        val policyMap = mutableMapOf<Policy, Int>()
+
+        for (policy in policiesToRemove) {
+            policyCostInput--
+            policyMap.put(policy, getPolicyCultureCost(policyCostInput))
+        }
+
+        return policyMap.toMap()
+    }
+
+    fun getPolicyCultureCost(numberOfAdoptedPolicies: Int): Int {
         var policyCultureCost = 25 + (numberOfAdoptedPolicies * 6).toDouble().pow(1.7)
         // https://civilization.fandom.com/wiki/Map_(Civ5)
         val worldSizeModifier = with(civInfo.gameInfo.tileMap.mapParameters.mapSize) {

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -770,6 +770,7 @@ enum class UniqueType(
     OneTimeDiscoverTech("Discover [tech]", UniqueTarget.Triggerable),
     OneTimeAdoptPolicy("Adopt [policy]", UniqueTarget.Triggerable),
     OneTimeRemovePolicy("Remove [policy]", UniqueTarget.Triggerable),
+    OneTimeRemovePolicyRefund("Remove [policy] and refund [amount]% of its cost", UniqueTarget.Triggerable),
     OneTimeFreeTech("Free Technology", UniqueTarget.Triggerable),  // used in Buildings
     OneTimeAmountFreeTechs("[positiveAmount] Free Technologies", UniqueTarget.Triggerable),  // used in Policy
     OneTimeFreeTechRuins("[positiveAmount] free random researchable Tech(s) from the [era]", UniqueTarget.Triggerable),

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -77,6 +77,11 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 	Applicable to: Triggerable
 
+??? example  "Remove [policy] and refund [amount]% of its cost"
+	Example: "Remove [Oligarchy] and refund [3]% of its cost"
+
+	Applicable to: Triggerable
+
 ??? example  "Free Technology"
 	Applicable to: Triggerable
 


### PR DESCRIPTION
I've made the culture-refunding version of remove policy unique  #11405 

I believe it will be useful for non-permanent policies, present in original Civ 4 and not present in original Civ 5.

If you have any remarks, tell me in the comments.