### PR TITLE
Fixed city-state alliance join war notification

### DIFF
--- a/core/src/com/unciv/logic/civilization/diplomacy/DeclareWar.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DeclareWar.kt
@@ -82,8 +82,8 @@ object DeclareWar {
             WarType.DefensivePactWar, WarType.CityStateAllianceWar, WarType.JoinWar -> {
                 val allyCiv = declareWarReason.allyCiv!!
                 otherCiv.popupAlerts.add(PopupAlert(AlertType.WarDeclaration, civInfo.civName))
-                val agressor = if (declareWarReason.warType == WarType.JoinWar) civInfo else otherCiv
-                val defender = if (declareWarReason.warType == WarType.JoinWar) otherCiv else civInfo
+                val agressor = if (declareWarReason.warType == WarType.DefensivePactWar) otherCiv else civInfo
+                val defender = if (declareWarReason.warType == WarType.DefensivePactWar) civInfo else otherCiv
 
                 defender.addNotification("[${agressor.civName}] has joined [${allyCiv.civName}] in the war against us!",
                     NotificationCategory.Diplomacy, NotificationIcon.War, agressor.civName)


### PR DESCRIPTION
This PR fixes the problem found in #11540.
The City State notification for joining a war was being treated as a defensive pact war when it should have been treated as a join war.

Also, we might want to revisit why we sort the notifications in order from bottom to top instead of from top down. Here is an example where it is confusing.

<details><summary>Pictures</summary>
Old version
China is declaring war on the Aztecs and their city states are joining them with an incorrect notification

![CityStateJoinWar1](https://github.com/yairm210/Unciv/assets/7538725/8a20fa5d-78ce-48aa-beab-9569ece473df)

Here is the correct notification

![CityStateJoinWar2](https://github.com/yairm210/Unciv/assets/7538725/27b6375b-c006-4d1c-8b4e-8a037b7e98a2)






</p>
</details> 