### PR TITLE
Overhaul "hidden" architecture, closing some gaps

### DIFF
--- a/core/src/com/unciv/UncivGame.kt
+++ b/core/src/com/unciv/UncivGame.kt
@@ -479,6 +479,8 @@ open class UncivGame(val isConsoleMode: Boolean = false) : Game(), PlatformSpeci
         lateinit var Current: UncivGame
         /** @return `true` if [Current] has been set yet and can be accessed */
         fun isCurrentInitialized() = this::Current.isInitialized
+        /** Get the game currently in progress safely - null either if [Current] has not yet been set or if its gameInfo field has no game */
+        fun getGameInfoOrNull() = if (isCurrentInitialized()) Current.gameInfo else null
         fun isCurrentGame(gameId: String): Boolean = isCurrentInitialized() && Current.gameInfo != null && Current.gameInfo!!.gameId == gameId
         fun isDeepLinkedGameLoading() = isCurrentInitialized() && Current.deepLinkedMultiplayerGame != null
     }

--- a/core/src/com/unciv/UncivGame.kt
+++ b/core/src/com/unciv/UncivGame.kt
@@ -52,9 +52,16 @@ import java.io.PrintWriter
 import java.util.EnumSet
 import java.util.UUID
 
+/** Represents the Unciv app itself:
+ *  - implements the [Game] interface Gdx requires.
+ *  - marshals [platform-specific stuff][PlatformSpecific].
+ *  - contains references to [the game being played][gameInfo], and high-level UI elements.
+ */
 open class UncivGame(val isConsoleMode: Boolean = false) : Game(), PlatformSpecific {
 
     var deepLinkedMultiplayerGame: String? = null
+
+    /** The game currently in progress */
     var gameInfo: GameInfo? = null
 
     lateinit var settings: GameSettings
@@ -467,7 +474,10 @@ open class UncivGame(val isConsoleMode: Boolean = false) : Game(), PlatformSpeci
         val VERSION = Version("4.11.9", 993)
         //endregion
 
+        /** Global reference to the one Gdx.Game instance created by the platform launchers - do not use without checking [isCurrentInitialized] first. */
+        // Set by Gdx Game.create callback, or the special cases ConsoleLauncher and unit tests make do with out Gdx and set this themselves.
         lateinit var Current: UncivGame
+        /** @return `true` if [Current] has been set yet and can be accessed */
         fun isCurrentInitialized() = this::Current.isInitialized
         fun isCurrentGame(gameId: String): Boolean = isCurrentInitialized() && Current.gameInfo != null && Current.gameInfo!!.gameId == gameId
         fun isDeepLinkedGameLoading() = isCurrentInitialized() && Current.deepLinkedMultiplayerGame != null

--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -87,6 +87,7 @@ data class VictoryData(val winningCiv: String, val victoryType: String, val vict
     constructor(): this("","",0)
 }
 
+/** The virtual world the users play in */
 class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion {
     companion object {
         /** The current compatibility version of [GameInfo]. This number is incremented whenever changes are made to the save file structure that guarantee that

--- a/core/src/com/unciv/logic/civilization/managers/GreatPersonManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/GreatPersonManager.kt
@@ -6,7 +6,6 @@ import com.unciv.logic.civilization.MayaLongCountAction
 import com.unciv.logic.civilization.NotificationCategory
 import com.unciv.models.Counter
 import com.unciv.models.ruleset.unique.UniqueType
-import com.unciv.models.ruleset.unit.BaseUnit
 import com.unciv.ui.components.MayaCalendar
 
 
@@ -102,14 +101,12 @@ class GreatPersonManager : IsPartOfGameInfoSerialization {
         civInfo.addNotification(notification, MayaLongCountAction(), NotificationCategory.General, MayaCalendar.notificationIcon)
     }
 
-    fun getGreatPeople(): HashSet<BaseUnit> {
-        val greatPeople = civInfo.gameInfo.ruleset.units.values.asSequence()
-            .filter { it.isGreatPerson() }
-            .map { civInfo.getEquivalentUnit(it.name) }
-        return if (!civInfo.gameInfo.isReligionEnabled())
-            greatPeople.filter { !it.hasUnique(UniqueType.HiddenWithoutReligion) }.toHashSet()
-        else greatPeople.toHashSet()
-    }
+    /** Get Great People specific to this manager's Civilization, already filtered by `isHiddenBySettings` */
+    fun getGreatPeople() = civInfo.gameInfo.ruleset.units.values.asSequence()
+        .filter { it.isGreatPerson() }
+        .map { civInfo.getEquivalentUnit(it.name) }
+        .filterNot { it.isHiddenBySettings(civInfo.gameInfo) }
+        .toHashSet()
 
     fun getGreatPersonPointsForNextTurn(): Counter<String> {
         val greatPersonPoints = Counter<String>()

--- a/core/src/com/unciv/logic/civilization/managers/GreatPersonManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/GreatPersonManager.kt
@@ -28,7 +28,7 @@ class GreatPersonManager : IsPartOfGameInfoSerialization {
     var greatGeneralPointsCounter = Counter<String>()
     var greatGeneralPoints = 0
     var freeGreatPeople = 0
-    /** Marks subset of [freeGreatPeople] as subject to maya ability restrictions (each only once untill all used) */
+    /** Marks subset of [freeGreatPeople] as subject to maya ability restrictions (each only once until all used) */
     var mayaLimitedFreeGP = 0
     /** Remaining candidates for maya ability - whenever empty refilled from all GP, starts out empty */
     var longCountGPPool = HashSet<String>()

--- a/core/src/com/unciv/logic/civilization/managers/QuestManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/QuestManager.kt
@@ -192,7 +192,7 @@ class QuestManager : IsPartOfGameInfoSerialization {
         individualQuestCountdown[challenger.civName] = (countdown * civ.gameInfo.speed.modifier).toInt()
     }
 
-    // Readabilty helper - No asSequence(): call frequency * data size is small
+    // Readability helper - No asSequence(): call frequency * data size is small
     private fun getQuests(predicate: (Quest) -> Boolean) = ruleset.quests.values.filter(predicate)
 
     private fun tryStartNewGlobalQuest() {
@@ -755,10 +755,7 @@ class QuestManager : IsPartOfGameInfoSerialization {
         val encampments = civ.getCapital()!!.getCenterTile().getTilesInDistance(8)
                 .filter { it.improvement == Constants.barbarianEncampment }.toList()
 
-        if (encampments.isNotEmpty())
-            return encampments.random()
-
-        return null
+        return encampments.randomOrNull()
     }
 
     /**
@@ -781,10 +778,7 @@ class QuestManager : IsPartOfGameInfoSerialization {
                     !ownedByMajorResources.contains(it)
         }.toList()
 
-        if (notOwnedResources.isNotEmpty())
-            return notOwnedResources.random()
-
-        return null
+        return notOwnedResources.randomOrNull()
     }
 
     private fun getWonderToBuildForQuest(challenger: Civilization): Building? {
@@ -805,10 +799,7 @@ class QuestManager : IsPartOfGameInfoSerialization {
                             && building.uniqueTo == null
                 }
 
-        if (wonders.isNotEmpty())
-            return wonders.random()
-
-        return null
+        return wonders.randomOrNull()
     }
 
     /**
@@ -817,10 +808,7 @@ class QuestManager : IsPartOfGameInfoSerialization {
     private fun getNaturalWonderToFindForQuest(challenger: Civilization): String? {
         val naturalWondersToFind = civ.gameInfo.tileMap.naturalWonders.subtract(challenger.naturalWonders)
 
-        if (naturalWondersToFind.isNotEmpty())
-            return naturalWondersToFind.random()
-
-        return null
+        return naturalWondersToFind.randomOrNull()
     }
 
     /**
@@ -840,10 +828,7 @@ class QuestManager : IsPartOfGameInfoSerialization {
                         || (it.hasUnique(UniqueType.HiddenWithoutReligion) && !civ.gameInfo.isReligionEnabled()) }
                 .toList()
 
-        if (greatPeople.isNotEmpty())
-            return greatPeople.random()
-
-        return null
+        return greatPeople.randomOrNull()
     }
 
     /**
@@ -852,12 +837,10 @@ class QuestManager : IsPartOfGameInfoSerialization {
      */
     private fun getCivilizationToFindForQuest(challenger: Civilization): Civilization? {
         val civilizationsToFind = challenger.getKnownCivs()
-                .filter { it.isAlive() && it.isMajorCiv() && !challenger.hasMetCivTerritory(it) }
+            .filter { it.isAlive() && it.isMajorCiv() && !challenger.hasMetCivTerritory(it) }
+            .toList()
 
-        if (civilizationsToFind.any())
-            return civilizationsToFind.toList().random()
-
-        return null
+        return civilizationsToFind.randomOrNull()
     }
 
     /**

--- a/core/src/com/unciv/logic/civilization/managers/RuinsManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/RuinsManager.kt
@@ -47,9 +47,8 @@ class RuinsManager(
 
     private fun isPossibleReward(ruinReward: RuinReward, unit: MapUnit): Boolean {
         if (ruinReward.name in lastChosenRewards) return false
-        if (civInfo.gameInfo.difficulty in ruinReward.excludedDifficulties) return false
+        if (ruinReward.isHiddenBySettings(civInfo.gameInfo)) return false
         val stateForConditionals = StateForConditionals(civInfo, unit = unit, tile = unit.getTile())
-        if (ruinReward.hasUnique(UniqueType.HiddenWithoutReligion, stateForConditionals) && !civInfo.gameInfo.isReligionEnabled()) return false
         if (ruinReward.hasUnique(UniqueType.Unavailable, stateForConditionals)) return false
         if (ruinReward.getMatchingUniques(UniqueType.OnlyAvailable, StateForConditionals.IgnoreConditionals)
                 .any { !it.conditionalsApply(stateForConditionals) }) return false

--- a/core/src/com/unciv/models/ruleset/Belief.kt
+++ b/core/src/com/unciv/models/ruleset/Belief.kt
@@ -5,7 +5,6 @@ import com.unciv.UncivGame
 import com.unciv.models.ruleset.unique.UniqueTarget
 import com.unciv.models.translations.tr
 import com.unciv.ui.objectdescriptions.uniquesToCivilopediaTextLines
-import com.unciv.ui.screens.civilopediascreen.CivilopediaScreen.Companion.showReligionInCivilopedia
 import com.unciv.ui.screens.civilopediascreen.FormattedLine
 
 class Belief() : RulesetObject() {
@@ -42,12 +41,10 @@ class Belief() : RulesetObject() {
 
     companion object {
         // private but potentially reusable, therefore not folded into getCivilopediaTextMatching
-        private fun getBeliefsMatching(name: String, ruleset: Ruleset): Sequence<Belief> {
-            if (!showReligionInCivilopedia(ruleset)) return sequenceOf()
-            return ruleset.beliefs.asSequence().map { it.value }
-                .filter { belief -> belief.uniqueObjects.any { unique -> unique.params.any { it == name } }
-            }
-        }
+        private fun getBeliefsMatching(name: String, ruleset: Ruleset) =
+            ruleset.beliefs.values.asSequence()
+            .filterNot { it.isHiddenFromCivilopedia(ruleset) }
+            .filter { belief -> belief.uniqueObjects.any { unique -> unique.params.any { it == name } } }
 
         /** Get CivilopediaText lines for all Beliefs referencing a given name in an unique parameter,
          *  With optional spacing and "See Also:" header.

--- a/core/src/com/unciv/models/ruleset/Building.kt
+++ b/core/src/com/unciv/models/ruleset/Building.kt
@@ -1,6 +1,7 @@
 package com.unciv.models.ruleset
 
 import com.unciv.Constants
+import com.unciv.logic.GameInfo
 import com.unciv.logic.MultiFilter
 import com.unciv.logic.city.City
 import com.unciv.logic.city.CityConstructions
@@ -63,6 +64,17 @@ class Building : RulesetStatsObject(), INonPerpetualConstruction {
     fun getShortDescription(multiline: Boolean = false, uniqueInclusionFilter: ((Unique) -> Boolean)? = null) = BuildingDescriptions.getShortDescription(this, multiline, uniqueInclusionFilter)
     fun getDescription(city: City, showAdditionalInfo: Boolean) = BuildingDescriptions.getDescription(this, city, showAdditionalInfo)
     override fun getCivilopediaTextLines(ruleset: Ruleset) = BuildingDescriptions.getCivilopediaTextLines(this, ruleset)
+
+    override fun isHiddenBySettings(gameInfo: GameInfo): Boolean {
+        if (super<INonPerpetualConstruction>.isHiddenBySettings(gameInfo)) return true
+        if (!gameInfo.gameParameters.nuclearWeaponsEnabled && hasUnique(UniqueType.EnablesNuclearWeapons)) return true
+        return isHiddenByStartingEra(gameInfo)
+    }
+    private fun isHiddenByStartingEra(gameInfo: GameInfo): Boolean {
+        if (!isWonder) return false
+        val startingEra = ruleset.eras[gameInfo.gameParameters.startingEra] ?: return false
+        return name in startingEra.startingObsoleteWonders
+    }
 
     fun getStats(city: City,
                  /* By default, do not cache - if we're getting stats for only one building this isn't efficient.
@@ -252,6 +264,14 @@ class Building : RulesetStatsObject(), INonPerpetualConstruction {
         if (cityConstructions.isBuilt(name))
             yield(RejectionReasonType.AlreadyBuilt.toInstance())
 
+        if (isHiddenBySettings(civ.gameInfo)) {
+            // Repeat the starting era test isHiddenBySettings already did to change the RejectionReasonType
+            if (isHiddenByStartingEra(civ.gameInfo))
+                yield(RejectionReasonType.WonderDisabledEra.toInstance())
+            else
+                yield(RejectionReasonType.DisabledBySetting.toInstance())
+        }
+
         for (unique in uniqueObjects) {
             // skip uniques that don't have conditionals apply
             // EXCEPT for [UniqueType.OnlyAvailable] and [UniqueType.CanOnlyBeBuiltInCertainCities]
@@ -277,9 +297,6 @@ class Building : RulesetStatsObject(), INonPerpetualConstruction {
                 UniqueType.RequiresPopulation ->
                     if (unique.params[0].toInt() > cityConstructions.city.population.population)
                         yield(RejectionReasonType.PopulationRequirement.toInstance(unique.text))
-
-                UniqueType.EnablesNuclearWeapons -> if (!cityConstructions.city.civ.gameInfo.gameParameters.nuclearWeaponsEnabled)
-                    yield(RejectionReasonType.DisabledBySetting.toInstance())
 
                 UniqueType.MustBeOn ->
                     if (!cityCenter.matchesTerrainFilter(unique.params[0], civ))
@@ -310,14 +327,6 @@ class Building : RulesetStatsObject(), INonPerpetualConstruction {
                 UniqueType.ObsoleteWith ->
                     if (civ.tech.isResearched(unique.params[0]))
                         yield(RejectionReasonType.Obsoleted.toInstance(unique.text))
-
-                UniqueType.HiddenWithoutReligion ->
-                    if (!civ.gameInfo.isReligionEnabled())
-                        yield(RejectionReasonType.DisabledBySetting.toInstance())
-
-                UniqueType.HiddenWithoutEspionage ->
-                    if (!civ.gameInfo.isEspionageEnabled())
-                        yield(RejectionReasonType.DisabledBySetting.toInstance())
 
                 UniqueType.MaxNumberBuildable ->
                     if (civ.civConstructions.countConstructedObjects(this@Building) >= unique.params[0].toInt())
@@ -369,11 +378,6 @@ class Building : RulesetStatsObject(), INonPerpetualConstruction {
                         yield(RejectionReasonType.MorePolicyBranches.toInstance(unique.text))
                 }
 
-                UniqueType.HiddenWithoutVictoryType -> {
-                    if (!civ.gameInfo.gameParameters.victoryTypes.contains(unique.params[0]))
-                        yield(RejectionReasonType.HiddenWithoutVictory.toInstance(unique.text))
-                }
-
                 else -> {}
             }
         }
@@ -404,10 +408,6 @@ class Building : RulesetStatsObject(), INonPerpetualConstruction {
         if (isWonder) {
             if (civ.gameInfo.getCities().any { it.cityConstructions.isBuilt(name) })
                 yield(RejectionReasonType.WonderAlreadyBuilt.toInstance())
-
-            val startingEra = civ.gameInfo.gameParameters.startingEra
-            if (name in ruleSet.eras[startingEra]!!.startingObsoleteWonders)
-                yield(RejectionReasonType.WonderDisabledEra.toInstance())
         }
 
         // National Wonders

--- a/core/src/com/unciv/models/ruleset/Building.kt
+++ b/core/src/com/unciv/models/ruleset/Building.kt
@@ -505,7 +505,7 @@ class Building : RulesetStatsObject(), INonPerpetualConstruction {
     }
 
 
-    val cachedMatchesFilterResult = HashMap<String, Boolean>()
+    private val cachedMatchesFilterResult = HashMap<String, Boolean>()
 
     /** Implements [UniqueParameterType.BuildingFilter] */
     fun matchesFilter(filter: String): Boolean {
@@ -552,7 +552,7 @@ class Building : RulesetStatsObject(), INonPerpetualConstruction {
     fun hasCreateOneImprovementUnique() = _hasCreatesOneImprovementUnique
 
     private var _getImprovementToCreate: TileImprovement? = null
-    fun getImprovementToCreate(ruleset: Ruleset): TileImprovement? {
+    private fun getImprovementToCreate(ruleset: Ruleset): TileImprovement? {
         if (!hasCreateOneImprovementUnique()) return null
         if (_getImprovementToCreate == null) {
             val improvementUnique = getMatchingUniques(UniqueType.CreatesOneImprovement)

--- a/core/src/com/unciv/models/ruleset/Building.kt
+++ b/core/src/com/unciv/models/ruleset/Building.kt
@@ -72,7 +72,8 @@ class Building : RulesetStatsObject(), INonPerpetualConstruction {
     }
     private fun isHiddenByStartingEra(gameInfo: GameInfo): Boolean {
         if (!isWonder) return false
-        val startingEra = ruleset.eras[gameInfo.gameParameters.startingEra] ?: return false
+        // do not rely on this.ruleset or unit tests break
+        val startingEra = gameInfo.ruleset.eras[gameInfo.gameParameters.startingEra] ?: return false
         return name in startingEra.startingObsoleteWonders
     }
 

--- a/core/src/com/unciv/models/ruleset/RuinReward.kt
+++ b/core/src/com/unciv/models/ruleset/RuinReward.kt
@@ -1,5 +1,6 @@
 package com.unciv.models.ruleset
 
+import com.unciv.logic.GameInfo
 import com.unciv.models.ruleset.unique.UniqueTarget
 
 class RuinReward : RulesetObject() {
@@ -12,4 +13,7 @@ class RuinReward : RulesetObject() {
     val color: String = ""  // For Civilopedia
 
     override fun makeLink() = "" //No own category on Civilopedia screen
+
+    override fun isHiddenBySettings(gameInfo: GameInfo) =
+        gameInfo.difficulty in excludedDifficulties || super.isHiddenBySettings(gameInfo)
 }

--- a/core/src/com/unciv/models/ruleset/nation/Nation.kt
+++ b/core/src/com/unciv/models/ruleset/nation/Nation.kt
@@ -15,8 +15,6 @@ import com.unciv.ui.objectdescriptions.BaseUnitDescriptions
 import com.unciv.ui.objectdescriptions.BuildingDescriptions
 import com.unciv.ui.objectdescriptions.ImprovementDescriptions
 import com.unciv.ui.objectdescriptions.uniquesToCivilopediaTextLines
-import com.unciv.ui.screens.civilopediascreen.CivilopediaScreen.Companion.showEspionageInCivilopedia
-import com.unciv.ui.screens.civilopediascreen.CivilopediaScreen.Companion.showReligionInCivilopedia
 import com.unciv.ui.screens.civilopediascreen.FormattedLine
 import kotlin.math.pow
 
@@ -193,15 +191,9 @@ class Nation : RulesetObject() {
     }
 
     private fun getUniqueBuildingsText(ruleset: Ruleset) = sequence {
-        val religionEnabled = showReligionInCivilopedia(ruleset)
-        val espionageEnabled = showEspionageInCivilopedia(ruleset)
         for (building in ruleset.buildings.values) {
-            when {
-                building.uniqueTo != name -> continue
-                building.hasUnique(UniqueType.HiddenFromCivilopedia) -> continue
-                !religionEnabled && building.hasUnique(UniqueType.HiddenWithoutReligion) -> continue
-                !espionageEnabled && building.hasUnique(UniqueType.HiddenWithoutEspionage) -> continue
-            }
+            if (building.uniqueTo != name) continue
+            if (building.isHiddenFromCivilopedia(ruleset)) continue
             yield(FormattedLine(separator = true))
             yield(FormattedLine("{${building.name}} -", link = building.makeLink()))
             if (building.replaces != null && ruleset.buildings.containsKey(building.replaces!!)) {
@@ -219,7 +211,7 @@ class Nation : RulesetObject() {
 
     private fun getUniqueUnitsText(ruleset: Ruleset) = sequence {
         for (unit in ruleset.units.values) {
-            if (unit.uniqueTo != name || unit.hasUnique(UniqueType.HiddenFromCivilopedia)) continue
+            if (unit.uniqueTo != name || unit.isHiddenFromCivilopedia(ruleset)) continue
             yield(FormattedLine(separator = true))
             yield(FormattedLine("{${unit.name}} -", link = "Unit/${unit.name}"))
             if (unit.replaces != null && ruleset.units.containsKey(unit.replaces!!)) {
@@ -245,7 +237,7 @@ class Nation : RulesetObject() {
 
     private fun getUniqueImprovementsText(ruleset: Ruleset) = sequence {
         for (improvement in ruleset.tileImprovements.values) {
-            if (improvement.uniqueTo != name || improvement.hasUnique(UniqueType.HiddenFromCivilopedia)) continue
+            if (improvement.uniqueTo != name || improvement.isHiddenFromCivilopedia(ruleset)) continue
 
             yield(FormattedLine(separator = true))
             yield(FormattedLine(improvement.name, link = "Improvement/${improvement.name}"))

--- a/core/src/com/unciv/models/ruleset/nation/Nation.kt
+++ b/core/src/com/unciv/models/ruleset/nation/Nation.kt
@@ -203,16 +203,16 @@ class Nation : RulesetObject() {
                 !espionageEnabled && building.hasUnique(UniqueType.HiddenWithoutEspionage) -> continue
             }
             yield(FormattedLine(separator = true))
-            yield(FormattedLine("{${building.name}} -", link=building.makeLink()))
+            yield(FormattedLine("{${building.name}} -", link = building.makeLink()))
             if (building.replaces != null && ruleset.buildings.containsKey(building.replaces!!)) {
                 val originalBuilding = ruleset.buildings[building.replaces!!]!!
-                yield(FormattedLine("Replaces [${originalBuilding.name}]", link = originalBuilding.makeLink(), indent=1))
+                yield(FormattedLine("Replaces [${originalBuilding.name}]", link = originalBuilding.makeLink(), indent = 1))
                 yieldAll(BuildingDescriptions.getDifferences(ruleset, originalBuilding, building))
                 yield(FormattedLine())
             } else if (building.replaces != null) {
-                yield(FormattedLine("Replaces [${building.replaces}], which is not found in the ruleset!", indent=1))
+                yield(FormattedLine("Replaces [${building.replaces}], which is not found in the ruleset!", indent = 1))
             } else {
-                yield(FormattedLine(building.getShortDescription(true), indent=1))
+                yield(FormattedLine(building.getShortDescription(true), indent = 1))
             }
         }
     }
@@ -221,12 +221,12 @@ class Nation : RulesetObject() {
         for (unit in ruleset.units.values) {
             if (unit.uniqueTo != name || unit.hasUnique(UniqueType.HiddenFromCivilopedia)) continue
             yield(FormattedLine(separator = true))
-            yield(FormattedLine("{${unit.name}} -", link="Unit/${unit.name}"))
+            yield(FormattedLine("{${unit.name}} -", link = "Unit/${unit.name}"))
             if (unit.replaces != null && ruleset.units.containsKey(unit.replaces!!)) {
                 val originalUnit = ruleset.units[unit.replaces!!]!!
-                yield(FormattedLine("Replaces [${originalUnit.name}]", link="Unit/${originalUnit.name}", indent=1))
+                yield(FormattedLine("Replaces [${originalUnit.name}]", link = "Unit/${originalUnit.name}", indent = 1))
                 if (unit.cost != originalUnit.cost)
-                    yield(FormattedLine("{Cost} ".tr() + "[${unit.cost}] vs [${originalUnit.cost}]".tr(), indent=1))
+                    yield(FormattedLine("{Cost} ".tr() + "[${unit.cost}] vs [${originalUnit.cost}]".tr(), indent = 1))
                 yieldAll(
                     BaseUnitDescriptions.getDifferences(ruleset, originalUnit, unit)
                     .map { (text, link) -> FormattedLine(text, link = link ?: "", indent = 1) }
@@ -252,11 +252,11 @@ class Nation : RulesetObject() {
             yield(FormattedLine(improvement.cloneStats().toString(), indent = 1))   // = (improvement as Stats).toString minus import plus copy overhead
             if (improvement.replaces != null && ruleset.tileImprovements.containsKey(improvement.replaces!!)) {
                 val originalImprovement = ruleset.tileImprovements[improvement.replaces!!]!!
-                yield(FormattedLine("Replaces [${originalImprovement.name}]", link = originalImprovement.makeLink(), indent=1))
+                yield(FormattedLine("Replaces [${originalImprovement.name}]", link = originalImprovement.makeLink(), indent = 1))
                 yieldAll(ImprovementDescriptions.getDifferences(ruleset, originalImprovement, improvement))
                 yield(FormattedLine())
             } else if (improvement.replaces != null) {
-                yield(FormattedLine("Replaces [${improvement.replaces}], which is not found in the ruleset!", indent=1))
+                yield(FormattedLine("Replaces [${improvement.replaces}], which is not found in the ruleset!", indent = 1))
             } else {
                 yieldAll(improvement.getShortDecription())
             }

--- a/core/src/com/unciv/models/ruleset/unique/IHasUniques.kt
+++ b/core/src/com/unciv/models/ruleset/unique/IHasUniques.kt
@@ -1,5 +1,7 @@
 package com.unciv.models.ruleset.unique
 
+import com.unciv.UncivGame
+import com.unciv.logic.GameInfo
 import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.ruleset.tech.Era
 import com.unciv.models.ruleset.tech.TechColumn
@@ -82,4 +84,40 @@ interface IHasUniques : INamed {
         // Currently this is only used in CityStateFunctions.kt.
         return eraAvailable.eraNumber <= ruleset.eras[requestedEra]!!.eraNumber
     }
+
+    /**
+     *  Is this ruleset object unavailable as determined by settings chosen at game start?
+     *
+     *  - **Not** checked: HiddenFromCivilopedia - That is a Mod choice and less a user choice and these objects should otherwise work.
+     *  - Default implementation checks disabling by Religion, Espionage or Victory types.
+     *  - Overrides need to deal with e.g. Era-specific wonder disabling, no-nukes, ruin rewards by difficulty, and so on!
+     */
+    fun isHiddenBySettings(gameInfo: GameInfo): Boolean {
+        if (!gameInfo.isReligionEnabled() && hasUnique(UniqueType.HiddenWithoutReligion)) return true
+        if (!gameInfo.isEspionageEnabled() && hasUnique(UniqueType.HiddenWithoutEspionage)) return true
+        if (getMatchingUniques(UniqueType.HiddenWithoutVictoryType).any { it.params[0] !in gameInfo.gameParameters.victoryTypes }) return true
+        return false
+    }
+
+    /**
+     *  Is this ruleset object hidden from Civilopedia?
+     *
+     *  - Obviously, the [UniqueType.HiddenFromCivilopedia] test is done here (and nowhere else - exception TranslationFileWriter for Tutorials).
+     *  - Includes the [isHiddenBySettings] test if [gameInfo] is known, otherwise existence of Religion is guessed from [ruleset], and all victory types are assumed enabled.
+     *  - Note: RulesetObject-type specific overrides should not be necessary unless (TODO) we implement support for conditionals on the 'Hidden*' Uniques.
+     *  @param gameInfo Defaults to [UncivGame.getGameInfoOrNull]. Civilopedia must also be able to run from MainMenu without a game loaded. In that case only this parameter can be `null`. So if you know it - provide!
+     *  @param ruleset required if [gameInfo] is null, otherwise optional.
+     *  @throws NullPointerException if both parameters are null
+     */
+    fun isHiddenFromCivilopedia(
+        gameInfo: GameInfo?,
+        ruleset: Ruleset? = null
+    ): Boolean {
+        if (hasUnique(UniqueType.HiddenFromCivilopedia)) return true
+        if (gameInfo != null && isHiddenBySettings(gameInfo)) return true
+        if (gameInfo == null && hasUnique(UniqueType.HiddenWithoutReligion) && ruleset!!.beliefs.isEmpty()) return true
+        return false
+    }
+    /** Overload of [isHiddenFromCivilopedia] for use in actually game-agnostic parts of Civilopedia */
+    fun isHiddenFromCivilopedia(ruleset: Ruleset) = isHiddenFromCivilopedia(UncivGame.getGameInfoOrNull(), ruleset)
 }

--- a/core/src/com/unciv/models/ruleset/unique/IHasUniques.kt
+++ b/core/src/com/unciv/models/ruleset/unique/IHasUniques.kt
@@ -74,10 +74,8 @@ interface IHasUniques : INamed {
             // This will return null only if *all* required techs have null TechColumn.
 
     fun availableInEra(ruleset: Ruleset, requestedEra: String): Boolean {
-        val eraAvailable: Era? = era(ruleset)
-        if (eraAvailable == null)
-            // No technologies are required, so available in the starting era.
-            return true
+        val eraAvailable: Era = era(ruleset)
+            ?: return true // No technologies are required, so available in the starting era.
         // This is not very efficient, because era() inspects the eraNumbers and then returns the whole object.
         // We could take a max of the eraNumbers directly.
         // But it's unlikely to make any significant difference.

--- a/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
@@ -626,7 +626,7 @@ enum class UniqueParameterType(
         }
     },
 
-    /** Used by [UniqueType.HiddenWithoutVictoryType], implementation in Civilopedia and OverviewScreen */
+    /** Used by [UniqueType.HiddenWithoutVictoryType], implementation in Civilopedia, OverviewScreen and to exclude e.g. from Quests */
     VictoryT("victoryType", "Domination", "The name of any victory type: 'Neutral', 'Cultural', 'Diplomatic', 'Domination', 'Scientific', 'Time'") {
         override fun getErrorSeverity(
             parameterText: String,

--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -53,6 +53,7 @@ class BaseUnit : RulesetObject(), INonPerpetualConstruction {
     fun techsThatObsoleteThis(): Sequence<String> = if (obsoleteTech == null) sequenceOf() else sequenceOf(obsoleteTech!!)
     fun techsAtWhichAutoUpgradeInProduction(): Sequence<String> = techsThatObsoleteThis()
     fun techsAtWhichNoLongerAvailable(): Sequence<String> = techsThatObsoleteThis()
+    @Suppress("unused") // Keep the how-to around
     fun isObsoletedBy(techName: String): Boolean = techsThatObsoleteThis().contains(techName)
     var upgradesTo: String? = null
     var replaces: String? = null
@@ -139,7 +140,7 @@ class BaseUnit : RulesetObject(), INonPerpetualConstruction {
         val baseUnitMatchingUniques = super<RulesetObject>.getMatchingUniques(uniqueTemplate, stateForConditionals)
         return if (::ruleset.isInitialized) baseUnitMatchingUniques +
                 type.getMatchingUniques(uniqueTemplate, stateForConditionals)
-        else baseUnitMatchingUniques // for e.g. Mod Checker, we may chech a BaseUnit's uniques without initializing ruleset
+        else baseUnitMatchingUniques // for e.g. Mod Checker, we may check a BaseUnit's uniques without initializing ruleset
     }
 
     override fun getBaseBuyCost(city: City, stat: Stat): Float? {
@@ -361,7 +362,7 @@ class BaseUnit : RulesetObject(), INonPerpetualConstruction {
     }
 
 
-    val cachedMatchesFilterResult = HashMap<String, Boolean>()
+    private val cachedMatchesFilterResult = HashMap<String, Boolean>()
 
     /** Implements [UniqueParameterType.BaseUnitFilter][com.unciv.models.ruleset.unique.UniqueParameterType.BaseUnitFilter] */
     fun matchesFilter(filter: String): Boolean {

--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -1,6 +1,7 @@
 package com.unciv.models.ruleset.unit
 
 import com.unciv.Constants
+import com.unciv.logic.GameInfo
 import com.unciv.logic.MultiFilter
 import com.unciv.logic.city.City
 import com.unciv.logic.city.CityConstructions
@@ -80,6 +81,10 @@ class BaseUnit : RulesetObject(), INonPerpetualConstruction {
 
     override fun getCivilopediaTextLines(ruleset: Ruleset): List<FormattedLine> =
             BaseUnitDescriptions.getCivilopediaTextLines(this, ruleset)
+
+    override fun isHiddenBySettings(gameInfo: GameInfo) =
+        super<INonPerpetualConstruction>.isHiddenBySettings(gameInfo) ||
+        (!gameInfo.gameParameters.nuclearWeaponsEnabled && isNuclearWeapon())
 
     fun getUpgradeUnits(stateForConditionals: StateForConditionals? = null): Sequence<String> {
         return sequence {
@@ -209,7 +214,7 @@ class BaseUnit : RulesetObject(), INonPerpetualConstruction {
         if (civ.cache.uniqueUnits.any { it.replaces == name })
             yield(RejectionReasonType.ReplacedByOurUnique.toInstance("Our unique unit replaces this"))
 
-        if (!civ.gameInfo.gameParameters.nuclearWeaponsEnabled && isNuclearWeapon())
+        if (isHiddenBySettings(civ.gameInfo))
             yield(RejectionReasonType.DisabledBySetting.toInstance())
 
         val stateForConditionals = StateForConditionals(civ, city)

--- a/core/src/com/unciv/ui/crashhandling/CrashScreen.kt
+++ b/core/src/com/unciv/ui/crashhandling/CrashScreen.kt
@@ -49,11 +49,10 @@ class CrashScreen(val exception: Throwable) : BaseScreen() {
 
     /** @return The last active save game serialized as a compressed string if any, or an informational note otherwise. */
     private fun tryGetSaveGame(): String {
-        if (!UncivGame.isCurrentInitialized() || UncivGame.Current.gameInfo == null)
-            return ""
+        val gameInfo = UncivGame.getGameInfoOrNull() ?: return ""
         return "\n**Save Data:**\n<details><summary>Show Saved Game</summary>\n\n```\n" +
             try {
-                UncivFiles.gameInfoToString(UncivGame.Current.gameInfo!!, forceZip = true)
+                UncivFiles.gameInfoToString(gameInfo, forceZip = true)
             } catch (e: Throwable) {
                 "No save data: $e" // In theory .toString() could still error here.
             } + "\n```\n</details>\n"
@@ -61,16 +60,17 @@ class CrashScreen(val exception: Throwable) : BaseScreen() {
 
     /** @return Mods from the last active save game if any, or an informational note otherwise. */
     private fun tryGetSaveMods(): String {
-        if (!UncivGame.isCurrentInitialized()) return ""
-        val game = UncivGame.Current.gameInfo ?: return ""
         val sb = StringBuilder(160)  // capacity: Just some guess
-        sb.append("\n**Save Mods:**\n```\n")
-        try { // Also from old CrashController().buildReport(), also could still error at .toString().
-            sb.append(game.gameParameters.getModsAndBaseRuleset().toString())
-        } catch (e: Throwable) {
-            sb.append("No mod data: $e")
+        val gameInfo = UncivGame.getGameInfoOrNull()
+        if (gameInfo != null) {
+            sb.append("\n**Save Mods:**\n```\n")
+            try { // Also from old CrashController().buildReport(), also could still error at .toString().
+                sb.append(gameInfo.gameParameters.getModsAndBaseRuleset().toString())
+            } catch (e: Throwable) {
+                sb.append("No mod data: $e")
+            }
+            sb.append("\n```\n")
         }
-        sb.append("\n```\n")
         val visualMods = UncivGame.Current.settings.visualMods
         if (visualMods.isEmpty())
             return sb.toString()

--- a/core/src/com/unciv/ui/objectdescriptions/ImprovementDescriptions.kt
+++ b/core/src/com/unciv/ui/objectdescriptions/ImprovementDescriptions.kt
@@ -1,6 +1,5 @@
 package com.unciv.ui.objectdescriptions
 
-import com.unciv.UncivGame
 import com.unciv.models.ruleset.Belief
 import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.ruleset.tile.TileImprovement
@@ -8,7 +7,6 @@ import com.unciv.models.ruleset.tile.TileResource
 import com.unciv.models.ruleset.unique.Unique
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.translations.tr
-import com.unciv.ui.screens.civilopediascreen.CivilopediaScreen
 import com.unciv.ui.screens.civilopediascreen.FormattedLine
 
 object ImprovementDescriptions {
@@ -111,17 +109,10 @@ object ImprovementDescriptions {
             textList += FormattedLine("Needs removal of terrain features to be built")
 
         if (improvement.isAncientRuinsEquivalent() && ruleset.ruinRewards.isNotEmpty()) {
-            val difficulty = if (!UncivGame.isCurrentInitialized() || UncivGame.Current.gameInfo == null)
-                "Prince"  // most factors == 1
-            else UncivGame.Current.gameInfo!!.gameParameters.difficulty
-            val religionEnabled = CivilopediaScreen.showReligionInCivilopedia(ruleset)
             textList += FormattedLine()
             textList += FormattedLine("The possible rewards are:")
             ruleset.ruinRewards.values.asSequence()
-                .filter { reward ->
-                    difficulty !in reward.excludedDifficulties &&
-                        (religionEnabled || !reward.hasUnique(UniqueType.HiddenWithoutReligion))
-                }
+                .filterNot { it.isHiddenFromCivilopedia(ruleset) }
                 .forEach { reward ->
                     textList += FormattedLine(reward.name, starred = true, color = reward.color)
                     textList += reward.civilopediaText

--- a/core/src/com/unciv/ui/objectdescriptions/ImprovementDescriptions.kt
+++ b/core/src/com/unciv/ui/objectdescriptions/ImprovementDescriptions.kt
@@ -39,7 +39,7 @@ object ImprovementDescriptions {
 
         val newAbilityPredicate: (Unique)->Boolean = { it.text in originalImprovement.uniques || it.isHiddenToUsers() }
         for (unique in replacementImprovement.uniqueObjects.filterNot(newAbilityPredicate))
-            yield(FormattedLine(unique.text, indent=1))  // FormattedLine(unique) would look worse - no indent and autolinking could distract
+            yield(FormattedLine(unique.text, indent=1))  // FormattedLine(unique) would look worse - no indent and auto-linking could distract
 
         val lostAbilityPredicate: (Unique)->Boolean = { it.text in replacementImprovement.uniques || it.isHiddenToUsers() }
         for (unique in originalImprovement.uniqueObjects.filterNot(lostAbilityPredicate)) {

--- a/core/src/com/unciv/ui/objectdescriptions/TechnologyDescriptions.kt
+++ b/core/src/com/unciv/ui/objectdescriptions/TechnologyDescriptions.kt
@@ -309,21 +309,12 @@ object TechnologyDescriptions {
         civInfo: Civilization?,
         predicate: (Building) -> Boolean
     ): Sequence<Building> {
-        val (nuclearWeaponsEnabled, religionEnabled, espionageEnabled) = getNukeAndReligionSwitches(civInfo)
         return ruleset.buildings.values.asSequence()
             .filter {
                 predicate(it)   // expected to be the most selective, thus tested first
-                        && (it.uniqueTo == civInfo?.civName || it.uniqueTo == null && civInfo?.getEquivalentBuilding(it) == it)
-                        && (nuclearWeaponsEnabled || !it.hasUnique(UniqueType.EnablesNuclearWeapons))
-                        && (religionEnabled || !it.hasUnique(UniqueType.HiddenWithoutReligion))
-                        && (espionageEnabled || !it.hasUnique(UniqueType.HiddenWithoutEspionage))
-                        && !it.hasUnique(UniqueType.HiddenFromCivilopedia)
+                && (it.uniqueTo == civInfo?.civName || it.uniqueTo == null && civInfo?.getEquivalentBuilding(it) == it)
+                && !it.isHiddenFromCivilopedia(ruleset)
             }
-    }
-
-    private fun getNukeAndReligionSwitches(civInfo: Civilization?): Triple<Boolean, Boolean, Boolean> {
-        if (civInfo == null) return Triple(true, true, true)
-        return civInfo.gameInfo.run { Triple(gameParameters.nuclearWeaponsEnabled, isReligionEnabled(), isEspionageEnabled()) }
     }
 
     /**
@@ -332,14 +323,11 @@ object TechnologyDescriptions {
      */
     // Used for Civilopedia, Alert and Picker, so if any of these decide to ignore the "Will not be displayed in Civilopedia"/HiddenFromCivilopedia unique this needs refactoring
     private fun getEnabledUnits(techName: String, ruleset: Ruleset, civInfo: Civilization?): Sequence<BaseUnit> {
-        val (nuclearWeaponsEnabled, religionEnabled) = getNukeAndReligionSwitches(civInfo)
         return ruleset.units.values.asSequence()
             .filter {
                 it.requiredTechs().contains(techName)
-                        && (it.uniqueTo == civInfo?.civName || it.uniqueTo == null && civInfo?.getEquivalentUnit(it) == it)
-                        && (nuclearWeaponsEnabled || !it.isNuclearWeapon())
-                        && (religionEnabled || !it.hasUnique(UniqueType.HiddenWithoutReligion))
-                        && !it.hasUnique(UniqueType.HiddenFromCivilopedia)
+                && (it.uniqueTo == civInfo?.civName || it.uniqueTo == null && civInfo?.getEquivalentUnit(it) == it)
+                && !it.isHiddenFromCivilopedia(ruleset)
             }
     }
 

--- a/core/src/com/unciv/ui/screens/civilopediascreen/CivilopediaCategories.kt
+++ b/core/src/com/unciv/ui/screens/civilopediascreen/CivilopediaCategories.kt
@@ -16,105 +16,103 @@ import com.unciv.models.ruleset.unit.UnitType as BaseUnitType
  */
 enum class CivilopediaCategories (
     val label: String,
-    val hide: Boolean,      // Omitted on CivilopediaScreen
     val getImage: ((name: String, size: Float) -> Actor?)?,
     val binding: KeyboardBinding,
     val headerIcon: String,
     val getCategoryIterator: (ruleset: Ruleset, tutorialController: TutorialController) -> Collection<ICivilopediaText>
 ) {
-    Building ("Buildings", false,
+    Building ("Buildings",
         CivilopediaImageGetters.construction,
         KeyboardBinding.PediaBuildings,
         "OtherIcons/Cities",
         { ruleset, _ -> ruleset.buildings.values.filter { !it.isAnyWonder() } }
     ),
-    Wonder ("Wonders", false,
+    Wonder ("Wonders",
         CivilopediaImageGetters.construction,
         KeyboardBinding.PediaWonders,
         "OtherIcons/Wonders",
         { ruleset, _ -> ruleset.buildings.values.filter { it.isAnyWonder() } }
     ),
-    Resource ("Resources", false,
+    Resource ("Resources",
         CivilopediaImageGetters.resource,
         KeyboardBinding.PediaResources,
         "OtherIcons/Resources",
         { ruleset, _ -> ruleset.tileResources.values }
     ),
-    Terrain ("Terrains", false,
+    Terrain ("Terrains",
         CivilopediaImageGetters.terrain,
         KeyboardBinding.PediaTerrains,
         "OtherIcons/Terrains",
         { ruleset, _ -> ruleset.terrains.values }
     ),
-    Improvement ("Tile Improvements", false,
+    Improvement ("Tile Improvements",
         CivilopediaImageGetters.improvement,
         KeyboardBinding.PediaImprovements,
         "OtherIcons/Improvements",
         { ruleset, _ -> ruleset.tileImprovements.values }
     ),
-    Unit ("Units", false,
+    Unit ("Units",
         CivilopediaImageGetters.construction,
         KeyboardBinding.PediaUnits,
         "OtherIcons/Shield",
         { ruleset, _ -> ruleset.units.values }
     ),
-    UnitType ("Unit types", false,
+    UnitType ("Unit types",
         CivilopediaImageGetters.unitType,
         KeyboardBinding.PediaUnitTypes,
         "UnitTypeIcons/UnitTypes",
         { ruleset, _ -> BaseUnitType.getCivilopediaIterator(ruleset) }
     ),
-    Nation ("Nations", false,
+    Nation ("Nations",
         CivilopediaImageGetters.nation,
         KeyboardBinding.PediaNations,
         "OtherIcons/Nations",
         { ruleset, _ -> ruleset.nations.values.filter { !it.isSpectator } }
     ),
-    Technology ("Technologies", false,
+    Technology ("Technologies",
         CivilopediaImageGetters.technology,
         KeyboardBinding.PediaTechnologies,
         "TechIcons/Philosophy",
         { ruleset, _ -> ruleset.technologies.values }
     ),
-    Promotion ("Promotions", false,
+    Promotion ("Promotions",
         CivilopediaImageGetters.promotion,
         KeyboardBinding.PediaPromotions,
         "UnitPromotionIcons/Mobility",
         { ruleset, _ -> ruleset.unitPromotions.values }
     ),
-    Policy ("Policies", false,
+    Policy ("Policies",
         CivilopediaImageGetters.policy,
         KeyboardBinding.PediaPolicies,
         "PolicyIcons/Constitution",
         { ruleset, _ -> ruleset.policies.values }
     ),
     Belief("Religions and Beliefs",
-        hide = false, // Skipping this page when showReligionInCivilopedia returns false is hardcoded
         CivilopediaImageGetters.belief,
         KeyboardBinding.PediaBeliefs,
         "ReligionIcons/Religion",
         { ruleset, _ -> (ruleset.beliefs.values.asSequence() +
             BaseBelief.getCivilopediaReligionEntry(ruleset)).toList() }
     ),
-    Tutorial ("Tutorials", false,
+    Tutorial ("Tutorials",
         getImage = null,
         KeyboardBinding.PediaTutorials,
         "OtherIcons/ExclamationMark",
         { _, tutorialController -> tutorialController.getCivilopediaTutorials() }
     ),
-    Difficulty ("Difficulty levels", false,
+    Difficulty ("Difficulty levels",
         getImage = null,
         KeyboardBinding.PediaDifficulties,
         "OtherIcons/Quickstart",
         { ruleset, _ -> ruleset.difficulties.values }
     ),
-    Era ("Eras", false,
+    Era ("Eras",
         getImage = null,
         KeyboardBinding.PediaEras,
         "OtherIcons/Tyrannosaurus",
         { ruleset, _ -> ruleset.eras.values }
     ),
-    Speed ("Speeds", false,
+    Speed ("Speeds",
         getImage = null,
         KeyboardBinding.PediaSpeeds,
         "OtherIcons/Timer",
@@ -125,6 +123,5 @@ enum class CivilopediaCategories (
         fun fromLink(name: String): CivilopediaCategories? =
             values().firstOrNull { it.name == name }
             ?: values().firstOrNull { it.label == name }
-
     }
 }

--- a/core/src/com/unciv/ui/screens/civilopediascreen/CivilopediaScreen.kt
+++ b/core/src/com/unciv/ui/screens/civilopediascreen/CivilopediaScreen.kt
@@ -214,7 +214,6 @@ class CivilopediaScreen(
         }
 
         for (loopCategory in CivilopediaCategories.values()) {
-            if (loopCategory.hide) continue
             if (!religionEnabled && loopCategory == CivilopediaCategories.Belief) continue
             categoryToEntries[loopCategory] =
                 loopCategory.getCategoryIterator(ruleset, tutorialController)

--- a/core/src/com/unciv/ui/screens/civilopediascreen/CivilopediaSearchPopup.kt
+++ b/core/src/com/unciv/ui/screens/civilopediascreen/CivilopediaSearchPopup.kt
@@ -113,7 +113,6 @@ class CivilopediaSearchPopup(
     private fun CoroutineScope.searchLoop() {
         for (category in CivilopediaCategories.values()) {
             if (!isActive) break
-            if (category.hide) continue
             if (!ruleset.modOptions.isBaseRuleset && category == CivilopediaCategories.Tutorial)
                 continue  // Search tutorials only when the mod filter is a base ruleset
             for (entry in category.getCategoryIterator(ruleset, tutorialController)) {

--- a/core/src/com/unciv/ui/screens/civilopediascreen/FormattedLine.kt
+++ b/core/src/com/unciv/ui/screens/civilopediascreen/FormattedLine.kt
@@ -225,7 +225,7 @@ class FormattedLine (
                 yield(CivilopediaCategories.Wonder to ruleSet.buildings.filter { it.value.isAnyWonder() })
             }
             val result = HashMap<String, CivilopediaCategories>()
-            allObjectMapsSequence.filter { !it.first.hide }
+            allObjectMapsSequence
                 .flatMap { pair -> pair.second.keys.asSequence().map { key -> pair.first to key } }
                 .forEach {
                     result[it.second] = it.first

--- a/core/src/com/unciv/ui/screens/overviewscreen/WonderOverviewTab.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/WonderOverviewTab.kt
@@ -26,7 +26,7 @@ class WonderOverviewTab(
 ) : EmpireOverviewTab(viewingPlayer, overviewScreen) {
     val ruleSet = gameInfo.ruleset
 
-    val wonderInfo = WonderInfo()
+    private val wonderInfo = WonderInfo()
     private val wonders: Array<WonderInfo.WonderInfo> = wonderInfo.collectInfo(viewingPlayer)
 
     private val fixedContent = Table()
@@ -55,7 +55,7 @@ class WonderOverviewTab(
         equalizeColumns(fixedContent, this)
     }
 
-    fun createGrid() {
+    private fun createGrid() {
         var lastGroup = ""
 
         for (wonder in wonders) {
@@ -120,7 +120,7 @@ class WonderInfo {
         val city: City?,
         val location: Tile?
     ) {
-        val viewEntireMapForDebug = DebugUtils.VISIBLE_MAP
+        private val viewEntireMapForDebug = DebugUtils.VISIBLE_MAP
 
         fun getImage() = if (status == WonderStatus.Unknown && !viewEntireMapForDebug) null
         else category.getImage?.invoke(name, if (category == CivilopediaCategories.Terrain) 50f else 45f)

--- a/core/src/com/unciv/ui/screens/overviewscreen/WonderOverviewTab.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/WonderOverviewTab.kt
@@ -10,7 +10,6 @@ import com.unciv.logic.map.tile.Tile
 import com.unciv.models.ruleset.Building
 import com.unciv.models.ruleset.QuestName
 import com.unciv.models.ruleset.tech.Era
-import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.translations.tr
 import com.unciv.ui.components.extensions.equalizeColumns
 import com.unciv.ui.components.extensions.toLabel
@@ -97,9 +96,6 @@ class WonderOverviewTab(
 class WonderInfo {
     val gameInfo = UncivGame.Current.gameInfo!!
     val ruleSet = gameInfo.ruleset
-    private val hideReligionItems = !gameInfo.isReligionEnabled()
-    private val hideEspionageItems = !gameInfo.isEspionageEnabled()
-    private val startingObsolete = ruleSet.eras[gameInfo.gameParameters.startingEra]!!.startingObsoleteWonders
 
     enum class WonderStatus(val label: String) {
         Hidden(""),
@@ -148,17 +144,9 @@ class WonderInfo {
         }
     }
 
-    private fun shouldBeDisplayed(viewingPlayer: Civilization, wonder: Building, wonderEra: Int?) = when {
-        wonder.hasUnique(UniqueType.HiddenFromCivilopedia) -> false
-        wonder.hasUnique(UniqueType.HiddenWithoutReligion) && hideReligionItems -> false
-        wonder.hasUnique(UniqueType.HiddenWithoutEspionage) && hideEspionageItems -> false
-        wonder.name in startingObsolete -> false
-        wonder.getMatchingUniques(UniqueType.HiddenWithoutVictoryType)
-            .any { unique ->
-                !gameInfo.gameParameters.victoryTypes.contains(unique.params[0])
-            } -> false
-        else -> wonderEra==null || wonderEra <= viewingPlayer.getEraNumber()
-    }
+    private fun shouldBeDisplayed(viewingPlayer: Civilization, wonder: Building, wonderEra: Int?) =
+        !wonder.isHiddenFromCivilopedia(viewingPlayer.gameInfo) &&
+        (wonderEra == null || wonderEra <= viewingPlayer.getEraNumber())
 
     /** Do we know about a natural wonder despite not having found it yet? */
     private fun knownFromQuest(viewingPlayer: Civilization, name: String): Boolean {


### PR DESCRIPTION
> "a quest for a wonder blocked by a missing victory type is possible" (https://github.com/yairm210/Unciv/pull/11545#issuecomment-2088814081)

... led to toppling most of the 'how do we hide RulesetObjects' stuff. Some ugly compromises that have irked for a long time are gone, and city-states will no longer tell you to build the United Nations if Diplomatic Victory is off. However, there are subtle potential changes in behaviour, and I'm too tired to recap the diff to point them out right now.

Hiding now works centrally and there *were* one or two more oversights than only that Quest filter. On the other hand, there was a StateForConditionals on some RuinReward code that blocked the migration and I couldn't imagine any mod successfully using that, so it's gone for now - but the way to structured conditional support specifically of the hidden from pedia unique is paved - no not paved but the perspective that there's no real blockers is cleared up. May need another abstract/open helper on that interface for readability...

I'll PR this as reviewable because I can play with it and have tested most edge cases I could think of, but more independent testers would be very welcome.