### PR TITLE
Spy rank UI and fixes

### DIFF
--- a/core/src/com/unciv/logic/automation/unit/EspionageAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/EspionageAutomation.kt
@@ -8,7 +8,8 @@ import kotlin.random.Random
 
 class EspionageAutomation(val civInfo: Civilization) {
     private val civsToStealFrom: List<Civilization> by lazy {
-        civInfo.getKnownCivs().filter {otherCiv -> otherCiv.isMajorCiv() && otherCiv.cities.any { it.getCenterTile().isVisible(civInfo) }
+        civInfo.getKnownCivs().filter {otherCiv -> otherCiv.isMajorCiv()
+            && otherCiv.cities.any { it.getCenterTile().isExplored(civInfo) && civInfo.espionageManager.getSpyAssignedToCity(it) == null }
             && civInfo.espionageManager.getTechsToSteal(otherCiv).isNotEmpty() }.toList()
     }
 
@@ -57,17 +58,19 @@ class EspionageAutomation(val civInfo: Civilization) {
         if (civsToStealFrom.isEmpty()) return false
         // We want to move the spy to the city with the highest science generation
         // Players can't usually figure this out so lets do highest population instead
-        spy.moveTo(getCivsToStealFromSorted.first().cities.filter { spy.canMoveTo(it) }.maxByOrNull { it.population.population })
-        return spy.action == SpyAction.StealingTech
+        val cityToMoveTo = getCivsToStealFromSorted.first().cities.filter { spy.canMoveTo(it) }.maxByOrNull { it.population.population }
+        spy.moveTo(cityToMoveTo)
+        return cityToMoveTo != null
     }
 
     /**
      * Moves the spy to a random city-state
      */
     private fun automateSpyRigElection(spy: Spy): Boolean {
-        val potentialCities = cityStatesToRig.flatMap { it.cities }.filter { !it.isBeingRazed && spy.canMoveTo(it) }
-        spy.moveTo(potentialCities.randomOrNull())
-        return spy.action == SpyAction.RiggingElections
+        val cityToMoveTo = cityStatesToRig.flatMap { it.cities }.filter { !it.isBeingRazed && spy.canMoveTo(it) && (it.civ.getDiplomacyManager(civInfo).getInfluence() < 150 || it.civ.getAllyCiv() != civInfo.civName) }
+            .maxByOrNull { it.civ.getDiplomacyManager(civInfo).getInfluence() }
+        spy.moveTo(cityToMoveTo)
+        return cityToMoveTo != null
     }
 
     /**

--- a/core/src/com/unciv/models/Spy.kt
+++ b/core/src/com/unciv/models/Spy.kt
@@ -50,6 +50,7 @@ class Spy() : IsPartOfGameInfoSerialization {
     fun clone(): Spy {
         val toReturn = Spy(name)
         toReturn.location = location
+        toReturn.rank = rank
         toReturn.action = action
         toReturn.turnsRemainingForAction = turnsRemainingForAction
         toReturn.progressTowardsStealingTech = progressTowardsStealingTech
@@ -235,7 +236,7 @@ class Spy() : IsPartOfGameInfoSerialization {
 
     fun canMoveTo(city: City): Boolean {
         if (getLocation() == city) return true
-        if (!city.getCenterTile().isVisible(civInfo)) return false
+        if (!city.getCenterTile().isExplored(civInfo)) return false
         return espionageManager.getSpyAssignedToCity(city) == null
     }
 

--- a/core/src/com/unciv/models/Spy.kt
+++ b/core/src/com/unciv/models/Spy.kt
@@ -50,7 +50,6 @@ class Spy() : IsPartOfGameInfoSerialization {
     fun clone(): Spy {
         val toReturn = Spy(name)
         toReturn.location = location
-        toReturn.rank = rank
         toReturn.action = action
         toReturn.turnsRemainingForAction = turnsRemainingForAction
         toReturn.progressTowardsStealingTech = progressTowardsStealingTech

--- a/core/src/com/unciv/ui/screens/overviewscreen/EspionageOverviewScreen.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/EspionageOverviewScreen.kt
@@ -70,10 +70,12 @@ class EspionageOverviewScreen(val civInfo: Civilization, val worldScreen: WorldS
     private fun updateSpyList() {
         spySelectionTable.clear()
         spySelectionTable.add("Spy".toLabel())
+        spySelectionTable.add("Rank".toLabel())
         spySelectionTable.add("Location".toLabel())
         spySelectionTable.add("Action".toLabel()).row()
         for (spy in civInfo.espionageManager.spyList) {
             spySelectionTable.add(spy.name.toLabel())
+            spySelectionTable.add(spy.rank.toLabel())
             spySelectionTable.add(spy.getLocationName().toLabel())
             val actionString =
                 when (spy.action) {

--- a/core/src/com/unciv/ui/screens/overviewscreen/EspionageOverviewScreen.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/EspionageOverviewScreen.kt
@@ -101,7 +101,7 @@ class EspionageOverviewScreen(val civInfo: Civilization, val worldScreen: WorldS
                         || (city.civ != civInfo && !city.espionage.hasSpyOf(civInfo))
                 }
             }
-            if (!worldScreen.canChangeState) {
+            if (!worldScreen.canChangeState || !spy.isAlive()) {
                 // Spectators aren't allowed to move the spies of the Civs they are viewing
                 moveSpyButton.disable()
             }


### PR DESCRIPTION
This PR does a few things and is part of #7610.

- First it adds a new spy rank column that displays the spies rank.
<details><summary>Picture</summary>

![SpyRankUI](https://github.com/yairm210/Unciv/assets/7538725/90bb4c29-298c-4fb3-aa15-ddbca95c09e5)

</details> 

- Better fix in #11559  ~Second it fixes the spy rank not being cloned. So basically it is reset and the rank did not persist.~
- Third dead spies can't move to a different location. I disabled the move button.
- Fourth I fixed the EspionageAutomation AI. It wouldn't send spies to steal tech or rig elections because there was a logical error while checking if the action was successful or not. A spy takes time to set up so it's state won't be StealingTech or RiggingElections and will be Moving instead. So I changed it to return true if it found a viable target instead.