### PR TITLE
Added diplomatic repercussions for spying on a civ

### DIFF
--- a/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
@@ -87,6 +87,7 @@ enum class DiplomaticModifiers(val text: String) {
     AttackedProtectedMinor("You attacked City-States that were under our protection!"),
     BulliedProtectedMinor("You demanded tribute from City-States that were under our protection!"),
     SidedWithProtectedMinor("You sided with a City-State over us"),
+    SpiedOnUs("You spied on us!"),
 
     // Positive
     YearsOfPeace("Years of peace have strengthened our relations."),

--- a/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyTurnManager.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyTurnManager.kt
@@ -281,6 +281,7 @@ object DiplomacyTurnManager {
         revertToZero(DiplomaticModifiers.DenouncedOurAllies, 1 / 4f)
         revertToZero(DiplomaticModifiers.DenouncedOurEnemies, 1 / 4f)
         revertToZero(DiplomaticModifiers.Denunciation, 1 / 8f) // That's personal, it'll take a long time to fade
+        revertToZero(DiplomaticModifiers.SpiedOnUs, 1 / 4f)
 
         // Positives
         revertToZero(DiplomaticModifiers.GaveUsUnits, 1 / 4f)

--- a/core/src/com/unciv/models/Spy.kt
+++ b/core/src/com/unciv/models/Spy.kt
@@ -7,6 +7,7 @@ import com.unciv.logic.city.City
 import com.unciv.logic.civilization.Civilization
 import com.unciv.logic.civilization.NotificationCategory
 import com.unciv.logic.civilization.NotificationIcon
+import com.unciv.logic.civilization.diplomacy.DiplomaticModifiers
 import com.unciv.logic.civilization.managers.EspionageManager
 import com.unciv.models.ruleset.unique.StateForConditionals
 import com.unciv.models.ruleset.unique.Unique
@@ -187,6 +188,9 @@ class Spy() : IsPartOfGameInfoSerialization {
             killSpy()
         }
 
+        if (spyResult >= 100) {
+            otherCiv.getDiplomacyManager(civInfo).addModifier(DiplomaticModifiers.SpiedOnUs, -15f)
+        }
     }
 
     private fun rigElection() {


### PR DESCRIPTION
Part of #7610

When you spy gets caught or killed when trying to steal tech it will give them a -15 penalty in opinion. This can stack and will go down to zero in 60 turns.

<details><summary>Picture</summary>

![SpyRepercussions](https://github.com/yairm210/Unciv/assets/7538725/a8144d9b-94b2-43c4-a8f5-12c460fdbb12)

</details> 

Also I am not sure where the translation page for diplomatic modifiers is so I haven't added it to translations yet.