### PR TITLE
Add missing espionage uniques

### DIFF
--- a/android/assets/jsons/Civ V - Gods & Kings/Buildings.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Buildings.json
@@ -986,8 +986,10 @@
         "cost": 120,
         "culture": 1,
         "isNationalWonder": true,
-        "uniques": ["Hidden when espionage is disabled", "Gain an extra spy", "Promotes all spies", "[-15]% enemy spy effectiveness [in this city]",
-            "Only available <if [Police Station] is constructed in all [non-[Puppeted]] cities>", "Cost increases by [30] per owned city"],
+        "uniques": ["Hidden when espionage is disabled", "Gain an extra spy", "Promotes all spies",
+			"[-15]% enemy spy effectiveness [in this city]", "New spies start with [1] level(s)",
+			"Only available <if [Police Station] is constructed in all [non-[Puppeted]] cities>",
+			"Cost increases by [30] per owned city"],
         "requiredTech": "Radio"
     },
 	{

--- a/android/assets/jsons/Civ V - Gods & Kings/Nations.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Nations.json
@@ -154,7 +154,7 @@
 		"innerColor": [255, 255, 255],
 		"favoredReligion": "Christianity",
 		"uniqueName": "Sun Never Sets",
-		"uniques": ["[+2] Movement <for [Water] units>"],
+		"uniques": ["[+2] Movement <for [Water] units>", "Gain an extra spy <upon entering the [Renaissance era]>"],
 		"cities": ["London","York","Nottingham","Hastings","Canterbury","Coventry","Warwick","Newcastle","Oxford","Liverpool",
 			"Dover","Brighton","Norwich","Leeds","Reading","Birmingham","Richmond","Exeter","Cambridge","Gloucester",
 			"Manchester","Bristol","Leicester","Carlisle","Ipswich","Portsmouth","Berwick","Bath","Mumbles","Southampton",

--- a/core/src/com/unciv/logic/civilization/managers/EspionageManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/EspionageManager.kt
@@ -5,6 +5,7 @@ import com.unciv.logic.city.City
 import com.unciv.logic.civilization.Civilization
 import com.unciv.logic.map.tile.Tile
 import com.unciv.models.Spy
+import com.unciv.models.ruleset.unique.UniqueType
 
 
 class EspionageManager : IsPartOfGameInfoSerialization {
@@ -43,7 +44,7 @@ class EspionageManager : IsPartOfGameInfoSerialization {
 
     fun addSpy(): Spy {
         val spyName = getSpyName()
-        val newSpy = Spy(spyName)
+        val newSpy = Spy(spyName, getStartingSpyRank())
         newSpy.setTransients(civInfo)
         spyList.add(newSpy)
         return newSpy
@@ -69,6 +70,8 @@ class EspionageManager : IsPartOfGameInfoSerialization {
     fun getSpiesInCity(city: City): MutableList<Spy> {
         return spyList.filter { it.getLocation() == city }.toMutableList()
     }
+
+    fun getStartingSpyRank(): Int = 1 + civInfo.getMatchingUniques(UniqueType.SpyStartingLevel).sumOf { it.params[0].toInt() }
 
     /**
      * Returns a list of all cities with our spies in them.

--- a/core/src/com/unciv/models/Spy.kt
+++ b/core/src/com/unciv/models/Spy.kt
@@ -43,12 +43,13 @@ class Spy() : IsPartOfGameInfoSerialization {
     @Transient
     private lateinit var espionageManager: EspionageManager
 
-    constructor(name: String) : this() {
+    constructor(name: String, rank:Int) : this() {
         this.name = name
+        this.rank = rank
     }
 
     fun clone(): Spy {
-        val toReturn = Spy(name)
+        val toReturn = Spy(name, rank)
         toReturn.location = location
         toReturn.action = action
         toReturn.turnsRemainingForAction = turnsRemainingForAction
@@ -125,6 +126,7 @@ class Spy() : IsPartOfGameInfoSerialization {
                 val oldSpyName = name
                 name = espionageManager.getSpyName()
                 action = SpyAction.None
+                rank = espionageManager.getStartingSpyRank()
                 civInfo.addNotification("We have recruited a new spy name [$name] after [$oldSpyName] was killed.",
                     NotificationCategory.Espionage, NotificationIcon.Spy)
             }

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -840,7 +840,8 @@ object UniqueTriggerActivation {
                 if (!civInfo.gameInfo.isEspionageEnabled()) return null
 
                 return {
-                    civInfo.espionageManager.addSpy()
+                    val spyName = civInfo.espionageManager.addSpy().name
+                    civInfo.addNotification("We have recruited [${spyName}] as a spy!", NotificationCategory.Espionage, NotificationIcon.Spy)
                     true
                 }
             }

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -230,7 +230,7 @@ enum class UniqueType(
     /// Espionage
     SpyEffectiveness("[relativeAmount]% spy effectiveness [cityFilter]", UniqueTarget.Global, UniqueTarget.Global),
     EnemySpyEffectiveness("[relativeAmount]% enemy spy effectiveness [cityFilter]", UniqueTarget.Global, UniqueTarget.Global),
-    SpyStartingLevel("New spies start with [amount] level(s)", UniqueTarget.Nation),
+    SpyStartingLevel("New spies start with [amount] level(s)", UniqueTarget.Global),
 
     /// Things you get at the start of the game
     StartingTech("Starting tech", UniqueTarget.Tech),

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -230,6 +230,7 @@ enum class UniqueType(
     /// Espionage
     SpyEffectiveness("[relativeAmount]% spy effectiveness [cityFilter]", UniqueTarget.Global, UniqueTarget.Global),
     EnemySpyEffectiveness("[relativeAmount]% enemy spy effectiveness [cityFilter]", UniqueTarget.Global, UniqueTarget.Global),
+    SpyStartingLevel("New spies start with [amount] level(s)", UniqueTarget.Nation),
 
     /// Things you get at the start of the game
     StartingTech("Starting tech", UniqueTarget.Tech),


### PR DESCRIPTION
Part of  #7610, #11551

This adds two uniques, the first one is the spy revive level unique from the national intelligence agency and the second is that England gets an extra spy when entering the Renaissance era.

Also fixes the bug where spies steal technologies even if they are killed trying to steal the technology.