### PR TITLE
Spy UI improvements

### DIFF
--- a/android/assets/jsons/Civ V - Gods & Kings/Buildings.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Buildings.json
@@ -986,8 +986,11 @@
         "cost": 120,
         "culture": 1,
         "isNationalWonder": true,
-        "uniques": ["Hidden when espionage is disabled", "Gain an extra spy", "Promotes all spies",
-			"[-15]% enemy spy effectiveness [in this city]", "New spies start with [1] level(s)",
+        "uniques": ["Hidden when espionage is disabled",
+            "New spies start with [1] level(s)",
+            "Promotes all spies",
+            "Gain an extra spy", // Order is significant here
+			"[-15]% enemy spy effectiveness [in this city]",
 			"Only available <if [Police Station] is constructed in all [non-[Puppeted]] cities>",
 			"Cost increases by [30] per owned city"],
         "requiredTech": "Radio"

--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -1756,7 +1756,9 @@ Enhanced religion =
 Spy = 
 Spy Hideout = 
 Spy present = 
-Move = 
+Move =
+Spy skill from rank: [percent] (influences success) = 
+Spy effectiveness: [percent] (influences time) = 
 
 After an unknown civilization entered the [eraName], we have recruited [spyName] as a spy! = 
 We have recruited [spyName] as a spy! = 

--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -1756,9 +1756,7 @@ Enhanced religion =
 Spy = 
 Spy Hideout = 
 Spy present = 
-Move =
-Spy skill from rank: [percent] (influences success) = 
-Spy effectiveness: [percent] (influences time) = 
+Move = 
 
 After an unknown civilization entered the [eraName], we have recruited [spyName] as a spy! = 
 We have recruited [spyName] as a spy! = 

--- a/core/src/com/unciv/UncivGame.kt
+++ b/core/src/com/unciv/UncivGame.kt
@@ -329,7 +329,7 @@ open class UncivGame(val isConsoleMode: Boolean = false) : Game(), PlatformSpeci
     fun resetToWorldScreen(): WorldScreen {
         for (screen in screenStack.filter { it !is WorldScreen }) screen.dispose()
         screenStack.removeAll { it !is WorldScreen }
-        val worldScreen= screenStack.last() as WorldScreen
+        val worldScreen = screenStack.last() as WorldScreen
 
         // Re-initialize translations, images etc. that may have been 'lost' when we were playing around in NewGameScreen
         val ruleset = worldScreen.gameInfo.ruleset

--- a/core/src/com/unciv/logic/automation/unit/EspionageAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/EspionageAutomation.kt
@@ -1,6 +1,5 @@
 package com.unciv.logic.automation.unit
 
-import com.unciv.logic.city.City
 import com.unciv.logic.civilization.Civilization
 import com.unciv.models.Spy
 import com.unciv.models.SpyAction
@@ -15,7 +14,7 @@ class EspionageAutomation(val civInfo: Civilization) {
 
     private val getCivsToStealFromSorted: List<Civilization> =
         civsToStealFrom.sortedBy { otherCiv -> civInfo.espionageManager.spyList
-            .count { it.isDoingWork() && it.getLocation()?.civ == otherCiv }
+            .count { it.isDoingWork() && it.getCityOrNull()?.civ == otherCiv }
         }.toList()
 
     private val cityStatesToRig: List<Civilization> by lazy {

--- a/core/src/com/unciv/logic/city/managers/CityEspionageManager.kt
+++ b/core/src/com/unciv/logic/city/managers/CityEspionageManager.kt
@@ -26,7 +26,7 @@ class CityEspionageManager : IsPartOfGameInfoSerialization {
     }
 
     fun hasSpyOf(civInfo: Civilization): Boolean {
-        return civInfo.espionageManager.spyList.any { it.getLocation() == city }
+        return civInfo.espionageManager.spyList.any { it.getCityOrNull() == city }
     }
 
     private fun getAllStationedSpies(): List<Spy> {

--- a/core/src/com/unciv/logic/city/managers/CityEspionageManager.kt
+++ b/core/src/com/unciv/logic/city/managers/CityEspionageManager.kt
@@ -35,13 +35,12 @@ class CityEspionageManager : IsPartOfGameInfoSerialization {
 
     fun removeAllPresentSpies(reason: SpyFleeReason) {
         for (spy in getAllStationedSpies()) {
-            val owningCiv = spy.civInfo
             val notificationString = when (reason) {
                 SpyFleeReason.CityDestroyed -> "After the city of [${city.name}] was destroyed, your spy [${spy.name}] has fled back to our hideout."
                 SpyFleeReason.CityCaptured -> "After the city of [${city.name}] was conquered, your spy [${spy.name}] has fled back to our hideout."
                 else -> "Due to the chaos ensuing in [${city.name}], your spy [${spy.name}] has fled back to our hideout."
             }
-            owningCiv.addNotification(notificationString, city.location, NotificationCategory.Espionage, NotificationIcon.Spy)
+            spy.addNotification(notificationString)
             spy.moveTo(null)
         }
     }

--- a/core/src/com/unciv/logic/civilization/NotificationActions.kt
+++ b/core/src/com/unciv/logic/civilization/NotificationActions.kt
@@ -12,6 +12,7 @@ import com.unciv.ui.screens.civilopediascreen.CivilopediaScreen
 import com.unciv.ui.screens.diplomacyscreen.DiplomacyScreen
 import com.unciv.ui.screens.overviewscreen.EmpireOverviewCategories
 import com.unciv.ui.screens.overviewscreen.EmpireOverviewScreen
+import com.unciv.ui.screens.overviewscreen.EspionageOverviewScreen
 import com.unciv.ui.screens.pickerscreens.PolicyPickerScreen
 import com.unciv.ui.screens.pickerscreens.PromotionPickerScreen
 import com.unciv.ui.screens.pickerscreens.TechPickerScreen
@@ -165,6 +166,18 @@ class PolicyAction(
     }
 }
 
+/** Open [EspionageOverviewScreen] */
+class EspionageAction : NotificationAction {
+    override fun execute(worldScreen: WorldScreen) {
+        worldScreen.game.pushScreen(EspionageOverviewScreen(worldScreen.selectedCiv, worldScreen))
+    }
+    companion object {
+        fun withLocation(location: Vector2?): Sequence<NotificationAction> =
+            LocationAction(location) + EspionageAction()
+    }
+}
+
+
 @Suppress("PrivatePropertyName")  // These names *must* match their class name, see below
 internal class NotificationActionsDeserializer {
     /* This exists as trick to leverage readFields for Json deserialization.
@@ -187,12 +200,14 @@ internal class NotificationActionsDeserializer {
     private val PromoteUnitAction: PromoteUnitAction? = null
     private val OverviewAction: OverviewAction? = null
     private val PolicyAction: PolicyAction? = null
+    private val EspionageAction: EspionageAction? = null
 
     fun read(json: Json, jsonData: JsonValue): List<NotificationAction> {
         json.readFields(this, jsonData)
         return listOfNotNull(
             LocationAction, TechAction, CityAction, DiplomacyAction, MayaLongCountAction,
-            MapUnitAction, CivilopediaAction, PromoteUnitAction, OverviewAction, PolicyAction
+            MapUnitAction, CivilopediaAction, PromoteUnitAction, OverviewAction, PolicyAction,
+            EspionageAction
         )
     }
 }

--- a/core/src/com/unciv/logic/civilization/managers/EspionageManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/EspionageManager.kt
@@ -91,5 +91,13 @@ class EspionageManager : IsPartOfGameInfoSerialization {
      * Determines whether the NextTurnAction MoveSpies should be shown or not
      * @return true if there are spies waiting to be moved
      */
-    fun shouldShowMoveSpies(): Boolean = !dismissedShouldMoveSpies && spyList.any { it.isIdle() }
+    fun shouldShowMoveSpies(): Boolean = !dismissedShouldMoveSpies && hasIdleSpies()
+
+    /** Are any spies in the hideout?
+     *  @see shouldShowMoveSpies */
+    fun hasIdleSpies() = spyList.any { it.isIdle() }
+
+    fun getIdleSpies(): List<Spy> {
+        return spyList.filterTo(mutableListOf()) { it.isIdle() }
+    }
 }

--- a/core/src/com/unciv/logic/civilization/managers/EspionageManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/EspionageManager.kt
@@ -59,7 +59,7 @@ class EspionageManager : IsPartOfGameInfoSerialization {
     fun getTilesVisibleViaSpies(): Sequence<Tile> {
         return spyList.asSequence()
             .filter { it.isSetUp() }
-            .mapNotNull { it.getLocation() }
+            .mapNotNull { it.getCityOrNull() }
             .flatMap { it.getCenterTile().getTilesInDistance(1) }
     }
 
@@ -83,9 +83,9 @@ class EspionageManager : IsPartOfGameInfoSerialization {
      * Returns a list of all cities with our spies in them.
      * The list needs to be stable across calls on the same turn.
      */
-    fun getCitiesWithOurSpies(): List<City> = spyList.filter { it.isSetUp() }.mapNotNull { it.getLocation() }
+    fun getCitiesWithOurSpies(): List<City> = spyList.filter { it.isSetUp() }.mapNotNull { it.getCityOrNull() }
 
-    fun getSpyAssignedToCity(city: City): Spy? = spyList.firstOrNull {it.getLocation() == city}
+    fun getSpyAssignedToCity(city: City): Spy? = spyList.firstOrNull { it.getCityOrNull() == city }
 
     /**
      * Determines whether the NextTurnAction MoveSpies should be shown or not

--- a/core/src/com/unciv/logic/civilization/managers/EspionageManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/EspionageManager.kt
@@ -45,8 +45,7 @@ class EspionageManager : IsPartOfGameInfoSerialization {
     fun getSpyName(): String {
         val usedSpyNames = spyList.map { it.name }.toHashSet()
         val validSpyNames = civInfo.nation.spyNames.filter { it !in usedSpyNames }
-        if (validSpyNames.isEmpty()) { return "Spy ${spyList.size+1}" } // +1 as non-programmers count from 1
-        return validSpyNames.random()
+        return validSpyNames.randomOrNull() ?: "Spy ${spyList.size+1}" // +1 as non-programmers count from 1
     }
 
     fun addSpy(): Spy {
@@ -74,15 +73,15 @@ class EspionageManager : IsPartOfGameInfoSerialization {
         return techsToSteal
     }
 
-    fun getSpiesInCity(city: City): MutableList<Spy> {
-        return spyList.filter { it.getLocation() == city }.toMutableList()
+    fun getSpiesInCity(city: City): List<Spy> {
+        return spyList.filterTo(mutableListOf()) { it.getCityOrNull() == city }
     }
 
     fun getStartingSpyRank(): Int = 1 + civInfo.getMatchingUniques(UniqueType.SpyStartingLevel).sumOf { it.params[0].toInt() }
 
     /**
      * Returns a list of all cities with our spies in them.
-     * The list needs to be stable accross calls on the same turn.
+     * The list needs to be stable across calls on the same turn.
      */
     fun getCitiesWithOurSpies(): List<City> = spyList.filter { it.isSetUp() }.mapNotNull { it.getLocation() }
 

--- a/core/src/com/unciv/models/Spy.kt
+++ b/core/src/com/unciv/models/Spy.kt
@@ -246,7 +246,7 @@ class Spy private constructor() : IsPartOfGameInfoSerialization {
 
     fun isSetUp() = action.isSetUp
 
-    fun isIdle(): Boolean =action == SpyAction.None || action == SpyAction.Surveillance
+    fun isIdle() = action == SpyAction.None
 
     fun isDoingWork() = action.isDoingWork(this)
 

--- a/core/src/com/unciv/models/Spy.kt
+++ b/core/src/com/unciv/models/Spy.kt
@@ -90,7 +90,9 @@ class Spy private constructor() : IsPartOfGameInfoSerialization {
         when (action) {
             SpyAction.None -> return
             SpyAction.Moving ->
-                setAction(SpyAction.EstablishNetwork, 3)
+                // Your own cities are certainly familiar surroundings, so establish network quickly
+                // Should depend on cultural familiarity level if that is ever implemented inter-civ
+                setAction(SpyAction.EstablishNetwork, if (getCity().civ == civInfo) 1 else 3)
             SpyAction.EstablishNetwork -> {
                 val city = getCity() // This should never throw an exception, as going to the hideout sets your action to None.
                 if (city.civ.isCityState())

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -808,17 +808,13 @@ object UniqueTriggerActivation {
                     val currentEra = civInfo.getEra().name
                     for (otherCiv in civInfo.gameInfo.getAliveMajorCivs()) {
                         if (currentEra !in otherCiv.espionageManager.erasSpyEarnedFor) {
-                            val spyName = otherCiv.espionageManager.addSpy().name
+                            val spy = otherCiv.espionageManager.addSpy()
                             otherCiv.espionageManager.erasSpyEarnedFor.add(currentEra)
                             if (otherCiv == civInfo || otherCiv.knows(civInfo))
                             // We don't tell which civilization entered the new era, as that is done in the notification directly above this one
-                                otherCiv.addNotification("We have recruited [${spyName}] as a spy!", NotificationCategory.Espionage, NotificationIcon.Spy)
+                                spy.addNotification("We have recruited [${spy.name}] as a spy!")
                             else
-                                otherCiv.addNotification(
-                                    "After an unknown civilization entered the [${currentEra}], we have recruited [${spyName}] as a spy!",
-                                    NotificationCategory.Espionage,
-                                    NotificationIcon.Spy
-                                )
+                                spy.addNotification("After an unknown civilization entered the [$currentEra], we have recruited [${spy.name}] as a spy!")
                         }
                     }
                     true
@@ -840,8 +836,8 @@ object UniqueTriggerActivation {
                 if (!civInfo.gameInfo.isEspionageEnabled()) return null
 
                 return {
-                    val spyName = civInfo.espionageManager.addSpy().name
-                    civInfo.addNotification("We have recruited [${spyName}] as a spy!", NotificationCategory.Espionage, NotificationIcon.Spy)
+                    val spy = civInfo.espionageManager.addSpy()
+                    spy.addNotification("We have recruited [${spy.name}] as a spy!")
                     true
                 }
             }

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -228,8 +228,8 @@ enum class UniqueType(
     FaithCostOfGreatProphetChange("[relativeAmount]% Faith cost of generating Great Prophet equivalents", UniqueTarget.Global),
 
     /// Espionage
-    SpyEffectiveness("[relativeAmount]% spy effectiveness [cityFilter]", UniqueTarget.Global, UniqueTarget.Global),
-    EnemySpyEffectiveness("[relativeAmount]% enemy spy effectiveness [cityFilter]", UniqueTarget.Global, UniqueTarget.Global),
+    SpyEffectiveness("[relativeAmount]% spy effectiveness [cityFilter]", UniqueTarget.Global),
+    EnemySpyEffectiveness("[relativeAmount]% enemy spy effectiveness [cityFilter]", UniqueTarget.Global),
     SpyStartingLevel("New spies start with [amount] level(s)", UniqueTarget.Global),
 
     /// Things you get at the start of the game

--- a/core/src/com/unciv/ui/components/SmallButtonStyle.kt
+++ b/core/src/com/unciv/ui/components/SmallButtonStyle.kt
@@ -1,0 +1,43 @@
+package com.unciv.ui.components
+
+import com.badlogic.gdx.graphics.Color
+import com.badlogic.gdx.graphics.g2d.NinePatch
+import com.badlogic.gdx.scenes.scene2d.ui.TextButton
+import com.badlogic.gdx.scenes.scene2d.utils.NinePatchDrawable
+import com.unciv.ui.images.ImageGetter
+import com.unciv.ui.screens.basescreen.BaseScreen
+
+class SmallButtonStyle : TextButton.TextButtonStyle(BaseScreen.skin[TextButton.TextButtonStyle::class.java]) {
+    /** Modify NinePatch geometry so the roundedEdgeRectangleMidShape button is 38f high instead of 48f,
+     *  Otherwise this excercise would be futile - normal roundedEdgeRectangleShape based buttons are 50f high.
+     */
+    private fun NinePatchDrawable.reduce(): NinePatchDrawable {
+        val patch = NinePatch(this.patch)
+        patch.padTop = 10f
+        patch.padBottom = 10f
+        patch.topHeight = 10f
+        patch.bottomHeight = 10f
+        return NinePatchDrawable(this).also { it.patch = patch }
+    }
+
+    init {
+        val upColor = BaseScreen.skin.getColor("color")
+        val downColor = BaseScreen.skin.getColor("pressed")
+        val overColor = BaseScreen.skin.getColor("highlight")
+        val disabledColor = BaseScreen.skin.getColor("disabled")
+        // UiElementDocsWriter inspects source, which is why this isn't prettified better
+        val shape = BaseScreen.run {
+            // Let's use _one_ skinnable background lookup but with different tints
+            val skinned = skinStrings.getUiBackground("AnimatedMenu/Button", skinStrings.roundedEdgeRectangleMidShape)
+            // Reduce height only if not skinned
+            val default = ImageGetter.getNinePatch(skinStrings.roundedEdgeRectangleMidShape)
+            if (skinned === default) default.reduce() else skinned
+        }
+        // Now get the tinted variants
+        up = shape.tint(upColor)
+        down = shape.tint(downColor)
+        over = shape.tint(overColor)
+        disabled = shape.tint(disabledColor)
+        disabledFontColor = Color.GRAY
+    }
+}

--- a/core/src/com/unciv/ui/images/ImageGetter.kt
+++ b/core/src/com/unciv/ui/images/ImageGetter.kt
@@ -330,7 +330,7 @@ object ImageGetter {
             addActor(cross)
         }
 
-    fun getArrowImage(align:Int = Align.right): Image {
+    fun getArrowImage(align: Int = Align.right): Image {
         val image = getImage("OtherIcons/ArrowRight")
         image.setOrigin(Align.center)
         if (align == Align.left) image.rotation = 180f

--- a/core/src/com/unciv/ui/popups/AnimatedMenuPopup.kt
+++ b/core/src/com/unciv/ui/popups/AnimatedMenuPopup.kt
@@ -1,7 +1,6 @@
 package com.unciv.ui.popups
 
 import com.badlogic.gdx.graphics.Color
-import com.badlogic.gdx.graphics.g2d.NinePatch
 import com.badlogic.gdx.math.Interpolation
 import com.badlogic.gdx.math.Vector2
 import com.badlogic.gdx.scenes.scene2d.Actor
@@ -10,14 +9,13 @@ import com.badlogic.gdx.scenes.scene2d.Touchable
 import com.badlogic.gdx.scenes.scene2d.actions.Actions
 import com.badlogic.gdx.scenes.scene2d.ui.Container
 import com.badlogic.gdx.scenes.scene2d.ui.Table
-import com.badlogic.gdx.scenes.scene2d.ui.TextButton
 import com.badlogic.gdx.scenes.scene2d.utils.NinePatchDrawable
+import com.unciv.ui.components.SmallButtonStyle
 import com.unciv.ui.components.extensions.toTextButton
 import com.unciv.ui.components.input.KeyCharAndCode
 import com.unciv.ui.components.input.KeyboardBinding
 import com.unciv.ui.components.input.keyShortcuts
 import com.unciv.ui.components.input.onActivation
-import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.screens.basescreen.BaseScreen
 import com.unciv.utils.Concurrency
 
@@ -163,40 +161,4 @@ open class AnimatedMenuPopup(
                 close()
             }
         }
-
-    //todo Reused in SpecialistAllocationTable - refactor to another package
-    class SmallButtonStyle : TextButton.TextButtonStyle(BaseScreen.skin[TextButton.TextButtonStyle::class.java]) {
-        /** Modify NinePatch geometry so the roundedEdgeRectangleMidShape button is 38f high instead of 48f,
-         *  Otherwise this excercise would be futile - normal roundedEdgeRectangleShape based buttons are 50f high.
-         */
-        private fun NinePatchDrawable.reduce(): NinePatchDrawable {
-            val patch = NinePatch(this.patch)
-            patch.padTop = 10f
-            patch.padBottom = 10f
-            patch.topHeight = 10f
-            patch.bottomHeight = 10f
-            return NinePatchDrawable(this).also { it.patch = patch }
-        }
-
-        init {
-            val upColor = BaseScreen.skin.getColor("color")
-            val downColor = BaseScreen.skin.getColor("pressed")
-            val overColor = BaseScreen.skin.getColor("highlight")
-            val disabledColor = BaseScreen.skin.getColor("disabled")
-            // UiElementDocsWriter inspects source, which is why this isn't prettified better
-            val shape = BaseScreen.run {
-                // Let's use _one_ skinnable background lookup but with different tints
-                val skinned = skinStrings.getUiBackground("AnimatedMenu/Button", skinStrings.roundedEdgeRectangleMidShape)
-                // Reduce height only if not skinned
-                val default = ImageGetter.getNinePatch(skinStrings.roundedEdgeRectangleMidShape)
-                if (skinned === default) default.reduce() else skinned
-            }
-            // Now get the tinted variants
-            up = shape.tint(upColor)
-            down = shape.tint(downColor)
-            over = shape.tint(overColor)
-            disabled = shape.tint(disabledColor)
-            disabledFontColor = Color.GRAY
-        }
-    }
 }

--- a/core/src/com/unciv/ui/screens/cityscreen/SpecialistAllocationTable.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/SpecialistAllocationTable.kt
@@ -5,6 +5,7 @@ import com.badlogic.gdx.scenes.scene2d.Actor
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.utils.Align
 import com.unciv.Constants
+import com.unciv.ui.components.SmallButtonStyle
 import com.unciv.ui.components.UncivTooltip.Companion.addTooltip
 import com.unciv.ui.components.extensions.addSeparatorVertical
 import com.unciv.ui.components.extensions.darken
@@ -16,15 +17,14 @@ import com.unciv.ui.components.input.onActivation
 import com.unciv.ui.components.input.onClick
 import com.unciv.ui.components.widgets.ExpanderTab
 import com.unciv.ui.images.ImageGetter
-import com.unciv.ui.popups.AnimatedMenuPopup
 import com.unciv.ui.screens.basescreen.BaseScreen
 
 class SpecialistAllocationTable(private val cityScreen: CityScreen) : Table(BaseScreen.skin) {
     val city = cityScreen.city
-    private val smallButtonStyle = AnimatedMenuPopup.SmallButtonStyle()
+    private val smallButtonStyle = SmallButtonStyle()
 
     fun update() {
-        // 5 columns: "-" unassignButton, AllocationTable, "+" assignButton, SeparatorVertical, SpecialistsStatsTabe
+        // 5 columns: "-" unassignButton, AllocationTable, "+" assignButton, SeparatorVertical, SpecialistsStatsTable
         clear()
 
         // Auto/Manual Specialists Toggle

--- a/core/src/com/unciv/ui/screens/newgamescreen/MapFileSelectTable.kt
+++ b/core/src/com/unciv/ui/screens/newgamescreen/MapFileSelectTable.kt
@@ -19,6 +19,7 @@ import com.unciv.models.metadata.Player
 import com.unciv.models.ruleset.RulesetCache
 import com.unciv.models.ruleset.nation.Nation
 import com.unciv.models.translations.tr
+import com.unciv.ui.components.SmallButtonStyle
 import com.unciv.ui.components.extensions.disable
 import com.unciv.ui.components.extensions.enable
 import com.unciv.ui.components.extensions.pad
@@ -28,7 +29,6 @@ import com.unciv.ui.components.extensions.toTextButton
 import com.unciv.ui.components.input.onActivation
 import com.unciv.ui.components.input.onChange
 import com.unciv.ui.components.widgets.LoadingImage
-import com.unciv.ui.popups.AnimatedMenuPopup
 import com.unciv.ui.screens.basescreen.BaseScreen
 import com.unciv.ui.screens.victoryscreen.LoadMapPreview
 import com.unciv.utils.Concurrency
@@ -53,7 +53,7 @@ class MapFileSelectTable(
     private val mapCategorySelectBox = SelectBox<String>(BaseScreen.skin)
     private val mapFileSelectBox = SelectBox<MapWrapper>(BaseScreen.skin)
     private val loadingIcon = LoadingImage(30f, LoadingImage.Style(loadingColor = Color.SCARLET))
-    private val useNationsFromMapButton = "Select players from starting locations".toTextButton(AnimatedMenuPopup.SmallButtonStyle())
+    private val useNationsFromMapButton = "Select players from starting locations".toTextButton(SmallButtonStyle())
     private val useNationsButtonCell: Cell<Actor?>
     private var mapNations = emptyList<Nation>()
     private var mapHumanPick: String? = null

--- a/core/src/com/unciv/ui/screens/overviewscreen/EspionageOverviewScreen.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/EspionageOverviewScreen.kt
@@ -180,8 +180,7 @@ class EspionageOverviewScreen(val civInfo: Civilization, val worldScreen: WorldS
 
     private fun resetSelection() {
         selectedSpy = null
-        if (selectedSpyButton != null)
-            selectedSpyButton!!.label.setText("Move".tr())
+        selectedSpyButton?.label?.setText("Move".tr())
         selectedSpyButton = null
         for ((button, _) in moveSpyHereButtons)
             button.isVisible = false

--- a/core/src/com/unciv/ui/screens/overviewscreen/EspionageOverviewScreen.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/EspionageOverviewScreen.kt
@@ -124,7 +124,7 @@ class EspionageOverviewScreen(val civInfo: Civilization, val worldScreen: WorldS
 
         citySelectionTable.add()
         citySelectionTable.add("Spy Hideout".toLabel())
-        citySelectionTable.add()
+        citySelectionTable.add(getSpyIcons(manager.getIdleSpies()))
         val moveSpyHereButton = MoveToCityButton(null)
         citySelectionTable.add(moveSpyHereButton).row()
 
@@ -152,20 +152,36 @@ class EspionageOverviewScreen(val civInfo: Civilization, val worldScreen: WorldS
         citySelectionTable.add(ImageGetter.getNationPortrait(city.civ.nation, 30f))
             .padLeft(20f)
         citySelectionTable.add(city.name.toLabel(hideIcons = true))
-        if (city.espionage.hasSpyOf(civInfo)) {
-            citySelectionTable.add(
-                ImageGetter.getImage("OtherIcons/Spy_White").apply {
-                    setSize(30f)
-                    color = Color.WHITE
-                }
-            )
-        } else {
-            citySelectionTable.add()
-        }
+        citySelectionTable.add(getSpyIcons(manager.getSpiesInCity(city)))
 
         val moveSpyHereButton = MoveToCityButton(city)
         citySelectionTable.add(moveSpyHereButton)
         citySelectionTable.row()
+    }
+
+    private fun getSpyIcon(spy: Spy) = Table().apply {
+        add (ImageGetter.getImage("OtherIcons/Spy_White").apply {
+            color = Color.WHITE
+        }).size(30f)
+        val color = when(spy.rank) {
+            1 -> Color.BROWN
+            2 -> Color.LIGHT_GRAY
+            3 -> Color.GOLD
+            else -> return@apply
+        }
+        val starTable = Table()
+        repeat(spy.rank) {
+            val star = ImageGetter.getImage("OtherIcons/Star")
+            star.color = color
+            starTable.add(star).size(8f).pad(1f).row()
+        }
+        add(starTable).center().padLeft(-4f)
+    }
+
+    private fun getSpyIcons(spies: Iterable<Spy>) = Table().apply {
+        defaults().space(0f, 2f, 0f, 2f)
+        for (spy in spies)
+            add(getSpyIcon(spy))
     }
 
     // city == null is interpreted as 'spy hideout'

--- a/core/src/com/unciv/ui/screens/overviewscreen/EspionageOverviewScreen.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/EspionageOverviewScreen.kt
@@ -91,10 +91,8 @@ class EspionageOverviewScreen(val civInfo: Civilization, val worldScreen: WorldS
                 selectedSpy = spy
                 selectedSpyButton!!.label.setText(Constants.cancel.tr())
                 for ((button, city) in moveSpyHereButtons) {
-                    // Not own cities as counterintelligence isn't implemented
-                    // Not city-state civs as rigging elections isn't implemented
                     button.isVisible = city == null // hideout
-                        || (city.civ != civInfo && !city.espionage.hasSpyOf(civInfo))
+                        || !city.espionage.hasSpyOf(civInfo)
                 }
             }
             if (!worldScreen.canChangeState || !spy.isAlive()) {

--- a/core/src/com/unciv/ui/screens/overviewscreen/EspionageOverviewScreen.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/EspionageOverviewScreen.kt
@@ -151,7 +151,12 @@ class EspionageOverviewScreen(val civInfo: Civilization, val worldScreen: WorldS
     private fun addCityToSelectionTable(city: City) {
         citySelectionTable.add(ImageGetter.getNationPortrait(city.civ.nation, 30f))
             .padLeft(20f)
-        citySelectionTable.add(city.name.toLabel(hideIcons = true))
+        val label = city.name.toLabel(hideIcons = true)
+        label.onClick {
+            worldScreen.game.popScreen() // If a detour to this screen (i.e. not directly from worldScreen) is made possible, use resetToWorldScreen instead
+            worldScreen.mapHolder.setCenterPosition(city.location)
+        }
+        citySelectionTable.add(label).fill()
         citySelectionTable.add(getSpyIcons(manager.getSpiesInCity(city)))
 
         val moveSpyHereButton = MoveToCityButton(city)

--- a/core/src/com/unciv/ui/screens/overviewscreen/EspionageOverviewScreen.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/EspionageOverviewScreen.kt
@@ -10,7 +10,6 @@ import com.unciv.UncivGame
 import com.unciv.logic.city.City
 import com.unciv.logic.civilization.Civilization
 import com.unciv.models.Spy
-import com.unciv.models.SpyAction
 import com.unciv.models.translations.tr
 import com.unciv.ui.components.extensions.addSeparatorVertical
 import com.unciv.ui.components.extensions.disable
@@ -77,11 +76,8 @@ class EspionageOverviewScreen(val civInfo: Civilization, val worldScreen: WorldS
             spySelectionTable.add(spy.name.toLabel())
             spySelectionTable.add(spy.rank.toLabel())
             spySelectionTable.add(spy.getLocationName().toLabel())
-            val actionString =
-                when (spy.action) {
-                    SpyAction.None, SpyAction.StealingTech, SpyAction.Surveillance, SpyAction.CounterIntelligence -> spy.action.displayString
-                    SpyAction.Moving, SpyAction.EstablishNetwork, SpyAction.Dead, SpyAction.RiggingElections -> "[${spy.action.displayString}] ${spy.turnsRemainingForAction}${Fonts.turn}"
-                }
+            val actionString = if (spy.action.hasTurns) "[${spy.action.displayString}] ${spy.turnsRemainingForAction}${Fonts.turn}"
+                else spy.action.displayString
             spySelectionTable.add(actionString.toLabel())
 
             val moveSpyButton = "Move".toTextButton()


### PR DESCRIPTION
This is already a few days old and won't get more features... Read commit messages!
Closes #11569 .

For screenie, see issue. As this is still an opt-in feature, I think the scope/diff size is still OK. Most of it is lint and prettification anyway.

After that discussion and more playtesting with logged spy stuff (so I can observe what the enemies do, too) I am content with unchanged formulae - could tweak later if we need to. But there still *are* rule changes, I'll try to summarize them:
* [Fix National Intelligence Agency giving one extra Spy level](https://github.com/yairm210/Unciv/commit/b491ae310c2d4c0dcd39d3043b9c3283140915ab)
* [Fix failed tech theft rewarding tech anyway](https://github.com/yairm210/Unciv/commit/a47a9650535741742bcdb913f7a4377275c5108d)
* Change to be killed is applied for a Spy performing steal tech even when the outcome is no techs to steal
* [Shorten establish-network phase for domestic spy placement](https://github.com/yairm210/Unciv/commit/bcfcd48f8b3a16bc9263b77db82f559fd5fe5667) ... to zero after input by @tuvus (this not really a rule change as the changed behaviour was inaccessible)
