### PR TITLE
Console: `civ addpolicy`

### DIFF
--- a/core/src/com/unciv/ui/screens/devconsole/ConsoleCityCommands.kt
+++ b/core/src/com/unciv/ui/screens/devconsole/ConsoleCityCommands.kt
@@ -1,5 +1,7 @@
 package com.unciv.ui.screens.devconsole
 
+import com.unciv.models.ruleset.Building
+
 class ConsoleCityCommands : ConsoleCommandNode {
     override val subcommands = hashMapOf<String, ConsoleCommand>(
 
@@ -77,15 +79,15 @@ class ConsoleCityCommands : ConsoleCommandNode {
 
         "addbuilding" to ConsoleAction("city addbuilding [buildingName]") { console, params ->
             val city = console.getSelectedCity()
-            val building = console.gameInfo.ruleset.buildings.values
-                .firstOrNull { it.name.toCliInput() == params[0] }  ?: throw ConsoleErrorException("Unknown building")
+            val building = console.findCliInput<Building>(params[0])
+                ?: throw ConsoleErrorException("Unknown building")
             city.cityConstructions.addBuilding(building)
             DevConsoleResponse.OK
         },
         "removebuilding" to ConsoleAction("city removebuilding [buildingName]") { console, params ->
             val city = console.getSelectedCity()
-            val building = console.gameInfo.ruleset.buildings.values
-                .firstOrNull { it.name.toCliInput() == params[0] } ?: throw ConsoleErrorException("Unknown building")
+            val building = console.findCliInput<Building>(params[0])
+                ?: throw ConsoleErrorException("Unknown building")
             city.cityConstructions.removeBuilding(building)
             DevConsoleResponse.OK
         },

--- a/core/src/com/unciv/ui/screens/devconsole/ConsoleCivCommands.kt
+++ b/core/src/com/unciv/ui/screens/devconsole/ConsoleCivCommands.kt
@@ -1,6 +1,8 @@
 package com.unciv.ui.screens.devconsole
 
 import com.unciv.logic.civilization.PlayerType
+import com.unciv.models.ruleset.Policy
+import com.unciv.models.ruleset.PolicyBranch
 import com.unciv.models.ruleset.unique.Unique
 import com.unciv.models.ruleset.unique.UniqueTriggerActivation
 import com.unciv.models.stats.Stat
@@ -45,6 +47,19 @@ class ConsoleCivCommands : ConsoleCommandNode {
             val city = tile?.getCity()
             UniqueTriggerActivation.triggerUnique(unique, civ, city, tile = tile)
             DevConsoleResponse.OK
+        },
+
+        "addpolicy" to ConsoleAction("civ addpolicy <civName> <policyName>")  { console, params ->
+            val civ = console.getCivByName(params[0])
+            val policy = console.findCliInput<Policy>(params[1]) // yes this also finds PolicyBranch instances
+                ?: throw ConsoleErrorException("Unrecognized policy")
+            if (civ.policies.isAdopted(policy.name))
+                DevConsoleResponse.hint("${civ.civName} already has adopted ${policy.name}")
+            else {
+                civ.policies.freePolicies++
+                civ.policies.adopt(policy)
+                DevConsoleResponse.OK
+            }
         }
     )
 }

--- a/core/src/com/unciv/ui/screens/devconsole/DevConsoleCommand.kt
+++ b/core/src/com/unciv/ui/screens/devconsole/DevConsoleCommand.kt
@@ -25,6 +25,10 @@ internal inline fun <reified T: Enum<T>> findCliInput(param: String): T? {
     }
 }
 
+@Suppress("USELESS_CAST")  // not useless, filterIsInstance annotates `T` with `@NoInfer`
+internal inline fun <reified T: IRulesetObject> DevConsolePopup.findCliInput(param: String) =
+    (gameInfo.ruleset.allRulesetObjects().filterIsInstance<T>() as Sequence<T>).findCliInput(param)
+
 /** Returns the string to *add* to the existing command */
 internal fun getAutocompleteString(lastWord: String, allOptions: Iterable<String>, console: DevConsolePopup): String {
     console.showResponse(null, Color.WHITE)
@@ -88,6 +92,7 @@ open class ConsoleAction(val format: String, val action: (console: DevConsolePop
             "religionName" -> console.gameInfo.religions.keys
             "buildingName" -> console.gameInfo.ruleset.buildings.keys
             "direction" -> RiverGenerator.RiverDirections.names
+            "policyName" -> console.gameInfo.ruleset.policyBranches.keys + console.gameInfo.ruleset.policies.keys
             else -> listOf()
         }
         return getAutocompleteString(lastParam, options, console)


### PR DESCRIPTION
Another drive-by...

Worth mentioning: I actually was a little blind for a while there how useful that new `findCliInput` variant is, and coded `console.findCliInput<PolicyBranch>(params[1]) ?: console.findCliInput<Policy>(params[1])` - embarrassing :see_no_evil:.

`console.findCliInput<Iconstruction>(param)` or even `console.findCliInput<IRulesetObject>(param)` would work just fine - opens possibilities. On buildings, it's less efficient than `console.gameInfo.ruleset.buildings.values.findCliInput(thing)` but shorter.