### PR TITLE
Console: tile setowner, civ removepolicy

### DIFF
--- a/core/src/com/unciv/logic/civilization/managers/PolicyManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/PolicyManager.kt
@@ -30,9 +30,9 @@ class PolicyManager : IsPartOfGameInfoSerialization {
     var freePolicies = 0
     var storedCulture = 0
     internal val adoptedPolicies = HashSet<String>()
-    var numberOfAdoptedPolicies = 0
+    private var numberOfAdoptedPolicies = 0
 
-    var cultureOfLast8Turns = IntArray(8) { 0 }
+    private var cultureOfLast8Turns = IntArray(8) { 0 }
 
     /** Indicates whether we should *check* if policy is adoptible, and if so open */
     var shouldOpenPolicyPicker = false
@@ -238,11 +238,22 @@ class PolicyManager : IsPartOfGameInfoSerialization {
         if (!canAdoptPolicy()) shouldOpenPolicyPicker = false
     }
 
-    fun removePolicy(policy: Policy, branchCompletion: Boolean = false) {
-        if (!branchCompletion)
-            numberOfAdoptedPolicies--
+    /**
+     * @param branchCompletion Internal! Do not use in normal calls (used to recursively remove the "complete" object too)
+     * @param assumeWasFree If set, removal does not touch culture progression (numberOfAdoptedPolicies not decremented)
+     * @throws IllegalStateException when the given Policy is not adopted or when the removal would leave numberOfAdoptedPolicies negative
+     */
+    // Note: A policy gained as a free one is not marked as such, therefore we need the parameter
+    // Note: a negative numberOfAdoptedPolicies would later throw in getCultureNeededForNextPolicy: -1.pow() gives NaN, which throws on toInt... Autosaved!
+    fun removePolicy(policy: Policy, branchCompletion: Boolean = false, assumeWasFree: Boolean = false) {
+        if (!adoptedPolicies.remove(policy.name))
+            throw IllegalStateException("Attempt to remove non-adopted Policy ${policy.name}")
 
-        adoptedPolicies.remove(policy.name)
+        if (!assumeWasFree) {
+            if (--numberOfAdoptedPolicies < 0)
+                throw IllegalStateException("Attempt to remove Policy ${policy.name} but civ only has free policies left")
+        }
+
         removePolicyFromTransients(policy)
 
         // if a branch is already marked as complete, revert it to incomplete

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -303,7 +303,7 @@ object UniqueTriggerActivation {
                 if (policiesToRemove.isEmpty()) return null
 
                 return {
-                    for (policy in policiesToRemove){
+                    for (policy in policiesToRemove) {
                         civInfo.policies.removePolicy(policy)
 
                         val notificationText = getNotificationText(

--- a/core/src/com/unciv/ui/screens/devconsole/ConsoleCivCommands.kt
+++ b/core/src/com/unciv/ui/screens/devconsole/ConsoleCivCommands.kt
@@ -60,6 +60,18 @@ class ConsoleCivCommands : ConsoleCommandNode {
                 civ.policies.adopt(policy)
                 DevConsoleResponse.OK
             }
-        }
+        },
+
+        "removepolicy" to ConsoleAction("civ removepolicy <civName> <policyName>")  { console, params ->
+            val civ = console.getCivByName(params[0])
+            val policy = console.findCliInput<Policy>(params[1])
+                ?: throw ConsoleErrorException("Unrecognized policy")
+            if (!civ.policies.isAdopted(policy.name))
+                DevConsoleResponse.hint("${civ.civName} does not have ${policy.name}")
+            else {
+                civ.policies.removePolicy(policy, assumeWasFree = true) // See UniqueType.OneTimeRemovePolicy
+                DevConsoleResponse.OK
+            }
+        },
     )
 }

--- a/core/src/com/unciv/ui/screens/devconsole/ConsoleParameterTypes.kt
+++ b/core/src/com/unciv/ui/screens/devconsole/ConsoleParameterTypes.kt
@@ -1,0 +1,41 @@
+package com.unciv.ui.screens.devconsole
+
+import com.unciv.logic.GameInfo
+import com.unciv.logic.map.mapgenerator.RiverGenerator
+import com.unciv.models.ruleset.tile.TerrainType
+import com.unciv.models.stats.Stat
+
+@Suppress("EnumEntryName", "unused")
+
+/**
+ *  Enum encapsulates knowledge about console command parameter types
+ *  - Extensible
+ *  - Currently limited to supplying autocomplete possibilities: use [Companion.getOptions]
+ *  - Supports multi-type parameters via [Companion.multiOptions]
+ */
+internal enum class ConsoleParameterType(
+    private val getOptions: GameInfo.() -> Iterable<String>
+) {
+    none( { emptyList() } ),
+    civName( { civilizations.map { it.civName } } ),
+    unitName( { ruleset.units.keys } ),
+    promotionName( { ruleset.unitPromotions.keys } ),
+    improvementName( { ruleset.tileImprovements.keys } ),
+    featureName( { ruleset.terrains.values.filter { it.type == TerrainType.TerrainFeature }.map { it.name } } ),
+    terrainName( { ruleset.terrains.values.filter { it.type.isBaseTerrain }.map { it.name } } ),
+    resourceName( { ruleset.tileResources.keys } ),
+    stat( { Stat.names() } ),
+    religionName( { religions.keys } ),
+    buildingName( { ruleset.buildings.keys } ),
+    direction( { RiverGenerator.RiverDirections.names } ),
+    policyName( { ruleset.policyBranches.keys + ruleset.policies.keys } ),
+    cityName( { civilizations.flatMap { civ -> civ.cities.map { it.name } } } ),
+    ;
+
+    private fun getOptions(console: DevConsolePopup) = console.gameInfo.getOptions()
+
+    companion object {
+        fun safeValueOf(name: String): ConsoleParameterType = values().firstOrNull { it.name == name } ?: none
+        fun getOptions(name: String, console: DevConsolePopup) = safeValueOf(name).getOptions(console)
+    }
+}

--- a/core/src/com/unciv/ui/screens/devconsole/ConsoleParameterTypes.kt
+++ b/core/src/com/unciv/ui/screens/devconsole/ConsoleParameterTypes.kt
@@ -37,5 +37,6 @@ internal enum class ConsoleParameterType(
     companion object {
         fun safeValueOf(name: String): ConsoleParameterType = values().firstOrNull { it.name == name } ?: none
         fun getOptions(name: String, console: DevConsolePopup) = safeValueOf(name).getOptions(console)
+        fun multiOptions(name: String, console: DevConsolePopup) = name.split('|').flatMap { getOptions(it, console) }
     }
 }

--- a/core/src/com/unciv/ui/screens/devconsole/DevConsoleCommand.kt
+++ b/core/src/com/unciv/ui/screens/devconsole/DevConsoleCommand.kt
@@ -82,21 +82,7 @@ open class ConsoleAction(val format: String, val action: (console: DevConsolePop
                 formatParams[params.lastIndex] to params.last()
             else formatParams.first() to ""
 
-        val options = when (formatParam) {
-            "civName" -> console.gameInfo.civilizations.map { it.civName }
-            "unitName" -> console.gameInfo.ruleset.units.keys
-            "promotionName" -> console.gameInfo.ruleset.unitPromotions.keys
-            "improvementName" -> console.gameInfo.ruleset.tileImprovements.keys
-            "featureName" -> console.gameInfo.ruleset.terrains.values.filter { it.type == TerrainType.TerrainFeature }.map { it.name }
-            "terrainName" -> console.gameInfo.ruleset.terrains.values.filter { it.type.isBaseTerrain }.map { it.name }
-            "resourceName" -> console.gameInfo.ruleset.tileResources.keys
-            "stat" -> Stat.names()
-            "religionName" -> console.gameInfo.religions.keys
-            "buildingName" -> console.gameInfo.ruleset.buildings.keys
-            "direction" -> RiverGenerator.RiverDirections.names
-            "policyName" -> console.gameInfo.ruleset.policyBranches.keys + console.gameInfo.ruleset.policies.keys
-            else -> listOf()
-        }
+        val options = ConsoleParameterType.getOptions(formatParam, console)
         return getAutocompleteString(lastParam, options, console)
     }
 

--- a/core/src/com/unciv/ui/screens/devconsole/DevConsoleCommand.kt
+++ b/core/src/com/unciv/ui/screens/devconsole/DevConsoleCommand.kt
@@ -82,7 +82,7 @@ open class ConsoleAction(val format: String, val action: (console: DevConsolePop
                 formatParams[params.lastIndex] to params.last()
             else formatParams.first() to ""
 
-        val options = ConsoleParameterType.getOptions(formatParam, console)
+        val options = ConsoleParameterType.multiOptions(formatParam, console)
         return getAutocompleteString(lastParam, options, console)
     }
 


### PR DESCRIPTION
* You [mentioned symmetry for civ addpolicy](https://github.com/yairm210/Unciv/pull/11572) - well, included, but it's not 100% symmetrical since free/nonfree can't be.
* Hidden gem: UniqueType.OneTimeRemovePolicy (#11405) has the theoretical ability to produce Autosaves that crash on load. This will "fix" that - by crashing earlier. Would be very hard to pull off with mods and gameplay anyway - but console removepolicy would have made that easy.
* tile setowner also can't 100% undo itself - but mostly, and in certain situations it will be 100%...
* Since tile ownership is serialized on the City, I added the luxury to allow specifying either a specific city or just the civ as parameter, in which case some city is chosen for you...
* Minor fails: multiOptions is a bad name, still can't think of a better one, forgot to comment why `@Suppress`...
* In case you don't guess anyway: Setting fields private helps have confidence all uses were seen and evaluated, and sometimes that's the only reason.