### PR TITLE
More espionage UI improvements

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -1755,7 +1755,13 @@ Enhanced religion =
 Spy = 
 Spy Hideout = 
 Spy present = 
-Move = 
+Move =
+Establishing Network = 
+Observing City = 
+Stealing Tech = 
+Rigging Elections = 
+Counter-intelligence =
+Dead =
 
 After an unknown civilization entered the [eraName], we have recruited [spyName] as a spy! = 
 We have recruited [spyName] as a spy! = 

--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -1756,12 +1756,6 @@ Spy =
 Spy Hideout = 
 Spy present = 
 Move = 
-Establishing Network = 
-Observing City = 
-Stealing Tech = 
-Rigging Elections = 
-Counter-intelligence = 
-Dead = 
 
 After an unknown civilization entered the [eraName], we have recruited [spyName] as a spy! = 
 We have recruited [spyName] as a spy! = 

--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -1755,13 +1755,13 @@ Enhanced religion =
 Spy = 
 Spy Hideout = 
 Spy present = 
-Move =
+Move = 
 Establishing Network = 
 Observing City = 
 Stealing Tech = 
 Rigging Elections = 
-Counter-intelligence =
-Dead =
+Counter-intelligence = 
+Dead = 
 
 After an unknown civilization entered the [eraName], we have recruited [spyName] as a spy! = 
 We have recruited [spyName] as a spy! = 

--- a/core/src/com/unciv/models/Spy.kt
+++ b/core/src/com/unciv/models/Spy.kt
@@ -25,7 +25,7 @@ enum class SpyAction(val displayString: String, val hasTurns: Boolean, internal 
     RiggingElections("Rigging Elections", true, true) {
         override fun isDoingWork(spy: Spy) = !spy.civInfo.isAtWarWith(spy.getCity().civ)
     },
-    CounterIntelligence("Conducting Counter-intelligence", false, true) {
+    CounterIntelligence("Counter-intelligence", false, true) {
         override fun isDoingWork(spy: Spy) = spy.turnsRemainingForAction > 0
     },
     Dead("Dead", true, false),

--- a/core/src/com/unciv/ui/screens/overviewscreen/EspionageOverviewScreen.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/EspionageOverviewScreen.kt
@@ -42,6 +42,7 @@ class EspionageOverviewScreen(val civInfo: Civilization, val worldScreen: WorldS
 
     // if the value == null, this means the Spy Hideout.
     private var moveSpyHereButtons = hashMapOf<MoveToCityButton, City?>()
+    private var moveSpyButtons = hashMapOf<Spy, TextButton>()
 
     /** Readability shortcut */
     private val manager get() = civInfo.espionageManager
@@ -72,6 +73,7 @@ class EspionageOverviewScreen(val civInfo: Civilization, val worldScreen: WorldS
 
     private fun updateSpyList() {
         spySelectionTable.clear()
+        moveSpyButtons.clear()
         spySelectionTable.add("Spy".toLabel())
         spySelectionTable.add("Rank".toLabel())
         spySelectionTable.add("Location".toLabel())
@@ -86,30 +88,14 @@ class EspionageOverviewScreen(val civInfo: Civilization, val worldScreen: WorldS
 
             val moveSpyButton = "Move".toTextButton()
             moveSpyButton.onClick {
-                if (selectedSpyButton == moveSpyButton) {
-                    resetSelection()
-                    return@onClick
-                }
-                resetSelection()
-                selectedSpyButton = moveSpyButton
-                selectedSpy = spy
-                selectedSpyButton!!.label.setText(Constants.cancel.tr())
-                for ((button, city) in moveSpyHereButtons) {
-                    if (city == spy.getCityOrNull()) {
-                        button.isVisible = true
-                        button.setDirection(Align.right)
-                    } else {
-                        button.isVisible = city == null // hideout
-                            || !city.espionage.hasSpyOf(civInfo)
-                        button.setDirection(Align.left)
-                    }
-                }
+                onSpyClicked(moveSpyButton, spy)
             }
             if (!worldScreen.canChangeState || !spy.isAlive()) {
                 // Spectators aren't allowed to move the spies of the Civs they are viewing
                 moveSpyButton.disable()
             }
             spySelectionTable.add(moveSpyButton).pad(5f, 10f, 5f, 20f).row()
+            moveSpyButtons[spy] = moveSpyButton
         }
     }
 
@@ -181,6 +167,10 @@ class EspionageOverviewScreen(val civInfo: Civilization, val worldScreen: WorldS
             starTable.add(star).size(8f).pad(1f).row()
         }
         add(starTable).center().padLeft(-4f)
+
+        onClick {
+            onSpyClicked(moveSpyButtons[spy]!!, spy)
+        }
     }
 
     private fun getSpyIcons(spies: Iterable<Spy>) = Table().apply {
@@ -209,6 +199,27 @@ class EspionageOverviewScreen(val civInfo: Civilization, val worldScreen: WorldS
         fun setDirection(align: Int) {
             arrow.rotation = if (align == Align.right) 0f else 180f
             isDisabled = align == Align.right
+        }
+    }
+
+    private fun onSpyClicked(moveSpyButton: TextButton, spy: Spy) {
+        if (selectedSpyButton == moveSpyButton) {
+            resetSelection()
+            return
+        }
+        resetSelection()
+        selectedSpyButton = moveSpyButton
+        selectedSpy = spy
+        selectedSpyButton!!.label.setText(Constants.cancel.tr())
+        for ((button, city) in moveSpyHereButtons) {
+            if (city == spy.getCityOrNull()) {
+                button.isVisible = true
+                button.setDirection(Align.right)
+            } else {
+                button.isVisible = city == null // hideout
+                        || !city.espionage.hasSpyOf(civInfo)
+                button.setDirection(Align.left)
+            }
         }
     }
 


### PR DESCRIPTION
This PR builds off of #11570 thanks to SomeTroglodyte and brings 3 minor changes:

- First I found that there were no translations for Spy Actions so I added them.
- Second I renamed Conducting Counter-Intelligence to Counter-Intelligence. This makes the columns look nicer without reducing any information
<details><summary>Pictures</summary>
Before (Monitor, not phone)

![CounterIntelligenceRename2](https://github.com/yairm210/Unciv/assets/7538725/c1f012a8-2322-4cab-aad8-0eb90d283a8a)

After

![CounterIntelligenceRename1](https://github.com/yairm210/Unciv/assets/7538725/da801d4f-0b43-4adb-9b7b-63508029e22f)

</details> 

- Third I made the spy portrait clickable so the associated spy can be easily selected.

<details><summary>Pictures</summary>
Before Click

![CounterIntelligenceRename3](https://github.com/yairm210/Unciv/assets/7538725/7f5e1df6-cb94-4aa3-94d3-7413c793c702)

After Click

![CounterIntelligenceRename4](https://github.com/yairm210/Unciv/assets/7538725/12e9b69c-2d5c-4935-9115-731561493a75)

</details> 


Also, I really like the new UI improvements.