### PR TITLE
Spies can be moved on map

### DIFF
--- a/core/src/com/unciv/ui/components/tilegroups/CityButton.kt
+++ b/core/src/com/unciv/ui/components/tilegroups/CityButton.kt
@@ -554,7 +554,7 @@ class CityButton(val city: City, private val tileGroup: TileGroup) : Table(BaseS
 
         // when deselected, move city button to its original position
         if (unitTable.selectedCity != city
-                && unitTable.selectedUnit?.currentTile != city.getCenterTile()) {
+                && unitTable.selectedUnit?.currentTile != city.getCenterTile() && unitTable.selectedSpy == null) {
 
             moveButtonUp()
         }

--- a/core/src/com/unciv/ui/screens/diplomacyscreen/MajorCivDiplomacyTable.kt
+++ b/core/src/com/unciv/ui/screens/diplomacyscreen/MajorCivDiplomacyTable.kt
@@ -85,12 +85,12 @@ class MajorCivDiplomacyTable(private val diplomacyScreen: DiplomacyScreen) {
         if (otherCiv.cities.isNotEmpty() && otherCiv.getCapital() != null && viewingCiv.hasExplored(otherCiv.getCapital()!!.getCenterTile()))
             diplomacyTable.add(diplomacyScreen.getGoToOnMapButton(otherCiv)).row()
 
-//        if (!otherCiv.isHuman()) { // human players make their own choices
+        if (!otherCiv.isHuman()) { // human players make their own choices
             diplomacyTable.add(diplomacyScreen.getRelationshipTable(otherCivDiplomacyManager)).row()
             diplomacyTable.add(getDiplomacyModifiersTable(otherCivDiplomacyManager)).row()
             val promisesTable = getPromisesTable(diplomacyManager, otherCivDiplomacyManager)
             if (promisesTable != null) diplomacyTable.add(promisesTable).row()
-//        }
+        }
 
         // Starting playback here assumes the MajorCivDiplomacyTable is shown immediately
         UncivGame.Current.musicController.playVoice(helloVoice)

--- a/core/src/com/unciv/ui/screens/diplomacyscreen/MajorCivDiplomacyTable.kt
+++ b/core/src/com/unciv/ui/screens/diplomacyscreen/MajorCivDiplomacyTable.kt
@@ -85,12 +85,12 @@ class MajorCivDiplomacyTable(private val diplomacyScreen: DiplomacyScreen) {
         if (otherCiv.cities.isNotEmpty() && otherCiv.getCapital() != null && viewingCiv.hasExplored(otherCiv.getCapital()!!.getCenterTile()))
             diplomacyTable.add(diplomacyScreen.getGoToOnMapButton(otherCiv)).row()
 
-        if (!otherCiv.isHuman()) { // human players make their own choices
+//        if (!otherCiv.isHuman()) { // human players make their own choices
             diplomacyTable.add(diplomacyScreen.getRelationshipTable(otherCivDiplomacyManager)).row()
             diplomacyTable.add(getDiplomacyModifiersTable(otherCivDiplomacyManager)).row()
             val promisesTable = getPromisesTable(diplomacyManager, otherCivDiplomacyManager)
             if (promisesTable != null) diplomacyTable.add(promisesTable).row()
-        }
+//        }
 
         // Starting playback here assumes the MajorCivDiplomacyTable is shown immediately
         UncivGame.Current.musicController.playVoice(helloVoice)

--- a/core/src/com/unciv/ui/screens/overviewscreen/EspionageOverviewScreen.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/EspionageOverviewScreen.kt
@@ -92,9 +92,7 @@ class EspionageOverviewScreen(val civInfo: Civilization, val worldScreen: WorldS
                 onSpyClicked(moveSpyButton, spy)
             }
             moveSpyButton.onRightClick { 
-                worldScreen.bottomUnitTable.selectSpy(spy)
-                worldScreen.game.popScreen()
-                worldScreen.shouldUpdate = true
+                onSpyRightClicked(spy)
             }
             if (!worldScreen.canChangeState || !spy.isAlive()) {
                 // Spectators aren't allowed to move the spies of the Civs they are viewing
@@ -177,6 +175,9 @@ class EspionageOverviewScreen(val civInfo: Civilization, val worldScreen: WorldS
         onClick {
             onSpyClicked(moveSpyButtons[spy]!!, spy)
         }
+        onRightClick {
+            onSpyRightClicked(spy)
+        }
     }
 
     private fun getSpyIcons(spies: Iterable<Spy>) = Table().apply {
@@ -229,6 +230,12 @@ class EspionageOverviewScreen(val civInfo: Civilization, val worldScreen: WorldS
         }
     }
 
+    private fun onSpyRightClicked(spy: Spy) {
+        worldScreen.bottomUnitTable.selectSpy(spy)
+        worldScreen.game.popScreen()
+        worldScreen.shouldUpdate = true
+    }
+    
     private fun resetSelection() {
         selectedSpy = null
         selectedSpyButton?.label?.setText("Move".tr())

--- a/core/src/com/unciv/ui/screens/overviewscreen/EspionageOverviewScreen.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/EspionageOverviewScreen.kt
@@ -22,6 +22,7 @@ import com.unciv.ui.components.input.KeyCharAndCode
 import com.unciv.ui.components.input.keyShortcuts
 import com.unciv.ui.components.input.onActivation
 import com.unciv.ui.components.input.onClick
+import com.unciv.ui.components.input.onRightClick
 import com.unciv.ui.components.widgets.AutoScrollPane
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.screens.pickerscreens.PickerScreen
@@ -104,6 +105,11 @@ class EspionageOverviewScreen(val civInfo: Civilization, val worldScreen: WorldS
                         button.setDirection(Align.left)
                     }
                 }
+            }
+            moveSpyButton.onRightClick { 
+                worldScreen.bottomUnitTable.selectSpy(spy)
+                worldScreen.game.popScreen()
+                worldScreen.shouldUpdate = true
             }
             if (!worldScreen.canChangeState || !spy.isAlive()) {
                 // Spectators aren't allowed to move the spies of the Civs they are viewing

--- a/core/src/com/unciv/ui/screens/worldscreen/WorldMapHolder.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/WorldMapHolder.kt
@@ -208,7 +208,7 @@ class WorldMapHolder(
                     else -> addTileOverlaysWithUnitMovement(previousSelectedUnits, tile) // Long-running task
                 }
             }
-        } else if (movingSpyOnMap && tile.getCity() != null && unitTable.selectedSpy!!.canMoveTo(tile.getCity()!!)) {
+        } else if (movingSpyOnMap && tile.isCityCenter() != null && unitTable.selectedSpy!!.canMoveTo(tile.getCity()!!)) {
             addMovingSpyOverlay(unitTable.selectedSpy!!, tile)
         } else {
             addTileOverlays(tile) // no unit movement but display the units in the tile etc.

--- a/core/src/com/unciv/ui/screens/worldscreen/WorldMapHolder.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/WorldMapHolder.kt
@@ -937,11 +937,11 @@ class WorldMapHolder(
         for (city in worldScreen.gameInfo.getCities()) {
             if (spy.canMoveTo(city)) {
                 tileGroups[city.getCenterTile()]!!.layerOverlay.showHighlight(Color.CYAN, .7f)
-                
+
             }
         }
     }
-    
+
     private fun updateBombardableTilesForSelectedCity(city: City) {
         if (!city.canBombard()) return
         for (attackableTile in TargetHelper.getBombardableTiles(city)) {

--- a/core/src/com/unciv/ui/screens/worldscreen/WorldMapHolder.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/WorldMapHolder.kt
@@ -178,7 +178,8 @@ class WorldMapHolder(
         val previousSelectedUnitIsSwapping = unitTable.selectedUnitIsSwapping
         val previousSelectedUnitIsConnectingRoad = unitTable.selectedUnitIsConnectingRoad
         val movingSpyOnMap = unitTable.selectedSpy != null
-        unitTable.tileSelected(tile)
+        if (!movingSpyOnMap)
+            unitTable.tileSelected(tile)
         val newSelectedUnit = unitTable.selectedUnit
 
         if (previousSelectedCity != null && tile != previousSelectedCity.getCenterTile() && !movingSpyOnMap)
@@ -208,7 +209,7 @@ class WorldMapHolder(
                     else -> addTileOverlaysWithUnitMovement(previousSelectedUnits, tile) // Long-running task
                 }
             }
-        } else if (movingSpyOnMap && tile.isCityCenter() != null && unitTable.selectedSpy!!.canMoveTo(tile.getCity()!!)) {
+        } else if (movingSpyOnMap && tile.isCityCenter() && unitTable.selectedSpy!!.canMoveTo(tile.getCity()!!)) {
             addMovingSpyOverlay(unitTable.selectedSpy!!, tile)
         } else {
             addTileOverlays(tile) // no unit movement but display the units in the tile etc.
@@ -611,7 +612,7 @@ class WorldMapHolder(
         swapWithButton.setSize(buttonSize, buttonSize)
         swapWithButton.addActor(ImageGetter.getCircle(size = buttonSize))
         swapWithButton.addActor(
-                ImageGetter.getImage("OtherIcons/Swap").apply {
+                ImageGetter.getStatIcon("Movement").apply {
                     color = Color.BLACK
                     setSize(buttonSize / 2)
                     center(swapWithButton)

--- a/core/src/com/unciv/ui/screens/worldscreen/WorldMapHolder.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/WorldMapHolder.kt
@@ -912,13 +912,13 @@ class WorldMapHolder(
     private fun updateTilesForSelectedSpy(spy: Spy) {
         for (group in tileGroups.values) {
             group.layerOverlay.reset()
-            group.layerMisc.dimImprovement(true)
+            if (!group.tile.isCityCenter())
+                group.layerMisc.dimImprovement(true)
             group.layerCityButton.moveDown()
         }
         for (city in worldScreen.gameInfo.getCities()) {
             if (spy.canMoveTo(city)) {
-                tileGroups[city.getCenterTile()]!!.layerOverlay.showHighlight(Color.CYAN,
-                        if (UncivGame.Current.settings.singleTapMove) 0.7f else 0.3f)
+                tileGroups[city.getCenterTile()]!!.layerOverlay.showHighlight(Color.CYAN, .7f)
                 
             }
         }

--- a/core/src/com/unciv/ui/screens/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/WorldScreen.kt
@@ -791,6 +791,12 @@ class WorldScreen(
             shouldUpdate = true
             return
         }
+        
+        if (bottomUnitTable.selectedSpy != null) {
+            bottomUnitTable.selectSpy(null)
+            shouldUpdate = true
+            return
+        }
 
         game.popScreen()
     }

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/UnitTable.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/UnitTable.kt
@@ -233,13 +233,13 @@ class UnitTable(val worldScreen: WorldScreen) : Table() {
             unitNameLabel.clearListeners()
             unitNameLabel.onClick {
                 if (!worldScreen.canChangeState) return@onClick
-                    CityRenamePopup(
-                        screen = worldScreen,
-                        city = city,
-                        actionOnClose = {
-                            unitNameLabel.setText(city.name.tr())
-                            worldScreen.shouldUpdate = true
-                        })
+                CityRenamePopup(
+                    screen = worldScreen,
+                    city = city,
+                    actionOnClose = {
+                        unitNameLabel.setText(city.name.tr())
+                        worldScreen.shouldUpdate = true
+                    })
             }
 
             unitDescriptionTable.clear()

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/UnitTable.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/UnitTable.kt
@@ -10,6 +10,7 @@ import com.unciv.logic.battle.CityCombatant
 import com.unciv.logic.city.City
 import com.unciv.logic.map.mapunit.MapUnit
 import com.unciv.logic.map.tile.Tile
+import com.unciv.models.Spy
 import com.unciv.models.translations.tr
 import com.unciv.ui.components.extensions.addSeparator
 import com.unciv.ui.components.extensions.center
@@ -24,6 +25,7 @@ import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.screens.basescreen.BaseScreen
 import com.unciv.ui.screens.civilopediascreen.CivilopediaCategories
 import com.unciv.ui.screens.civilopediascreen.CivilopediaScreen
+import com.unciv.ui.screens.overviewscreen.EspionageOverviewScreen
 import com.unciv.ui.screens.pickerscreens.CityRenamePopup
 import com.unciv.ui.screens.pickerscreens.PromotionPickerScreen
 import com.unciv.ui.screens.pickerscreens.UnitRenamePopup
@@ -67,6 +69,16 @@ class UnitTable(val worldScreen: WorldScreen) : Table() {
     // Most of the time it's the same unit with the same stats so why waste precious time?
     private var selectedUnitHasChanged = false
     val separator: Actor
+    
+    var selectedSpy: Spy? = null
+    
+    fun selectSpy(spy: Spy?) {
+        selectedSpy = spy
+        selectedCity = null
+        selectedUnits.clear()
+        selectedUnitIsSwapping = false
+        selectedUnitIsConnectingRoad = false
+    }
 
     private var bg = Image(
         BaseScreen.skinStrings.getUiBackground("WorldScreen/UnitTable",
@@ -220,15 +232,14 @@ class UnitTable(val worldScreen: WorldScreen) : Table() {
 
             unitNameLabel.clearListeners()
             unitNameLabel.onClick {
-            if (!worldScreen.canChangeState) return@onClick
-                CityRenamePopup(
-                    screen = worldScreen,
-                    city = city,
-                    actionOnClose = {
-                        unitNameLabel.setText(city.name.tr())
-                        worldScreen.shouldUpdate = true
-                    }
-                )
+                if (!worldScreen.canChangeState) return@onClick
+                    CityRenamePopup(
+                        screen = worldScreen,
+                        city = city,
+                        actionOnClose = {
+                            unitNameLabel.setText(city.name.tr())
+                            worldScreen.shouldUpdate = true
+                        })
             }
 
             unitDescriptionTable.clear()

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/UnitTable.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/UnitTable.kt
@@ -250,6 +250,30 @@ class UnitTable(val worldScreen: WorldScreen) : Table() {
             unitDescriptionTable.add(CityCombatant(city).getAttackingStrength().toString()).row()
 
             selectedUnitHasChanged = true
+        } else if (selectedSpy != null) {
+            val spy = selectedSpy!!
+            isVisible = true
+            unitNameLabel.clearListeners()
+            unitNameLabel.setText(spy.name)
+            unitDescriptionTable.clear()
+            
+            unitIconHolder.clear()
+            unitIconHolder.add (ImageGetter.getImage("OtherIcons/Spy_White").apply {
+                color = Color.WHITE
+            }).size(30f)
+            
+            separator.isVisible = true
+            val color = when(spy.rank) {
+                1 -> Color.BROWN
+                2 -> Color.LIGHT_GRAY
+                3 -> Color.GOLD
+                else -> Color.BLACK
+            }
+            repeat(spy.rank) {
+                val star = ImageGetter.getImage("OtherIcons/Star")
+                star.color = color
+                unitDescriptionTable.add(star).size(20f).pad(1f)
+            }
         } else {
             isVisible = false
         }

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/UnitTable.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/UnitTable.kt
@@ -61,6 +61,7 @@ class UnitTable(val worldScreen: WorldScreen) : Table() {
         }
         selectedUnitIsSwapping = false
         selectedUnitIsConnectingRoad = false
+        selectedSpy = null
     }
 
     var selectedCity : City? = null
@@ -220,9 +221,7 @@ class UnitTable(val worldScreen: WorldScreen) : Table() {
                 unitNameLabel.setText("")
                 unitDescriptionTable.clear()
             }
-        }
-
-        else if (selectedCity != null) {
+        } else if (selectedCity != null) {
             isVisible = true
             separator.isVisible = true
             val city = selectedCity!!


### PR DESCRIPTION
This PR adds on to #7610 by adding a new more visual way of moving spies using the world screen.

Right clicking the move button will close the espionage screen and open the world screen with the spy selected. The player can then move the spy to any available city that the spy can move to. Available cities have a cyan circle on them _(I chose cyan because I like it and it stands out. This can definitely be changed. Maybe it should depend on the resulting action in the city)_. Clicking on the tile shows a move button that moves the spy there when clicked and opens the espionage screen.

Pressing esc or the X button on the spy panel exits this mode.

<details><summary>Details</summary>

![MoveSpyViaMap](https://github.com/yairm210/Unciv/assets/7538725/4c384832-99e8-4f3c-9d96-6178f8bed70c)

</details> 