### PR TITLE
Architecture overhaul: openCivilopedia and its ruleset management

### DIFF
--- a/core/src/com/unciv/GUI.kt
+++ b/core/src/com/unciv/GUI.kt
@@ -70,6 +70,12 @@ object GUI {
         UncivGame.Current.worldScreen?.clearUndoCheckpoints()
     }
 
+    /** Fallback in case you have no easy access to a BaseScreen that knows which Ruleset Civilopedia should display.
+     *  If at all possible, use [BaseScreen.openCivilopedia] instead. */
+    fun openCivilopedia(link: String = "") {
+        UncivGame.Current.screen?.openCivilopedia(link)
+    }
+
     private var keyboardAvailableCache: Boolean? = null
     /** Tests availability of a physical keyboard */
     val keyboardAvailable: Boolean

--- a/core/src/com/unciv/logic/civilization/NotificationActions.kt
+++ b/core/src/com/unciv/logic/civilization/NotificationActions.kt
@@ -133,7 +133,7 @@ class MapUnitAction(private val location: Vector2 = Vector2.Zero) : Notification
 /** A notification action that shows a Civilopedia entry, e.g. for a Wonder. */
 class CivilopediaAction(private val link: String = "") : NotificationAction {
     override fun execute(worldScreen: WorldScreen) {
-        worldScreen.game.pushScreen(CivilopediaScreen(worldScreen.gameInfo.ruleset, link = link))
+        worldScreen.openCivilopedia(link)
     }
 }
 

--- a/core/src/com/unciv/ui/popups/options/KeyBindingsTab.kt
+++ b/core/src/com/unciv/ui/popups/options/KeyBindingsTab.kt
@@ -33,9 +33,7 @@ class KeyBindingsTab(
         FormattedLine("Please see the Tutorial.", link = "Tutorial/Keyboard Bindings"),
         FormattedLine(separator = true),
     ), labelWidth) {
-        // This ruleset is a kludge - but since OptionPopup can be called from anywhere, getting the relevant one is a chore
-        //TODO better pedia call architecture, or a tutorial render method once that has markup capability
-        GUI.pushScreen(CivilopediaScreen(RulesetCache.getVanillaRuleset(), link = it))
+        GUI.openCivilopedia(it)
     }
 
     init {

--- a/core/src/com/unciv/ui/screens/basescreen/BaseScreen.kt
+++ b/core/src/com/unciv/ui/screens/basescreen/BaseScreen.kt
@@ -17,6 +17,9 @@ import com.badlogic.gdx.scenes.scene2d.utils.Drawable
 import com.badlogic.gdx.utils.viewport.ExtendViewport
 import com.unciv.UncivGame
 import com.unciv.models.TutorialTrigger
+import com.unciv.models.metadata.BaseRuleset
+import com.unciv.models.ruleset.Ruleset
+import com.unciv.models.ruleset.RulesetCache
 import com.unciv.models.skins.SkinStrings
 import com.unciv.ui.components.extensions.isNarrowerThan4to3
 import com.unciv.ui.components.fonts.Fonts
@@ -30,6 +33,8 @@ import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.popups.Popup
 import com.unciv.ui.popups.activePopup
 import com.unciv.ui.popups.options.OptionsPopup
+import com.unciv.ui.screens.civilopediascreen.CivilopediaScreen
+import com.unciv.ui.screens.mainmenuscreen.MainMenuScreen
 
 // Both `this is CrashScreen` and `this::createPopupBasedDispatcherVetoer` are flagged.
 // First - not a leak; second - passes out a pure function
@@ -177,6 +182,32 @@ abstract class BaseScreen : Screen {
     open fun openOptionsPopup(startingPage: Int = OptionsPopup.defaultPage, withDebug: Boolean = false, onClose: () -> Unit = {}) {
         OptionsPopup(this, startingPage, withDebug, onClose).open(force = true)
     }
+
+    /**
+     *  Determine a Ruleset for Civilopedia to use (remember: it is supposed to work without a running game loaded)
+     *
+     *  - `open` as some important screens are supposed to provide directly.
+     *  - The default implementation searches using the [screenStack][UncivGame.screenStack] for a source of a Ruleset and returns Civ_V_GnK when that fails.
+     *  - Care must be taken in [PickerScreen][com.unciv.ui.screens.pickerscreens.PickerScreen] derivates - they will default to the searching implementation, but often could do the task more efficiently.
+     */
+    open fun getCivilopediaRuleset(): Ruleset {
+        if (game.worldScreen != null) return game.worldScreen!!.gameInfo.ruleset
+        val mainMenuScreen = game.screenStack.filterIsInstance<MainMenuScreen>().firstOrNull()
+        if (mainMenuScreen != null) return mainMenuScreen.getCivilopediaRuleset()
+        return RulesetCache[BaseRuleset.Civ_V_GnK.fullName]!!
+    }
+
+    /** Opens Civilopedia
+     *
+     *  It's an open method of BaseScreen because especially MainMenuScreen has cleanup things to do first.
+     *  @see getCivilopediaRuleset
+     */
+    open fun openCivilopedia(link: String = "") = openCivilopedia(getCivilopediaRuleset(), link)
+
+    /** Helper for the [openCivilopedia] (link: String) overload to use
+     *  - Note: At the time of wrinting, this was the ***only*** CivilopediaScreen constructor call outside itself
+     */
+    fun openCivilopedia(ruleset: Ruleset, link: String = "") = game.pushScreen(CivilopediaScreen(ruleset, link = link))
 }
 
 interface RecreateOnResize {

--- a/core/src/com/unciv/ui/screens/cityscreen/CityReligionInfoTable.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/CityReligionInfoTable.kt
@@ -84,14 +84,15 @@ class CityReligionInfoTable(
     private fun linkedReligionIcon(iconName: String, religion: String?): Portrait {
         val icon = ImageGetter.getReligionPortrait(iconName, 30f)
         if (religion == null) return icon
-        icon.onClick {
-            val newScreen = if (religion == iconName) {
-                EmpireOverviewScreen(GUI.getViewingPlayer(), EmpireOverviewCategories.Religion, religion)
-            } else {
-                CivilopediaScreen(gameInfo.ruleset, CivilopediaCategories.Belief, religion)
+        if (religion == iconName)
+            icon.onClick {
+                val newScreen = EmpireOverviewScreen(GUI.getViewingPlayer(), EmpireOverviewCategories.Religion, religion)
+                UncivGame.Current.pushScreen(newScreen)
             }
-            UncivGame.Current.pushScreen(newScreen)
-        }
+        else // This is used only for Pantheons
+            icon.onClick {
+                GUI.openCivilopedia("Belief/$religion")
+            }
         return icon
     }
 

--- a/core/src/com/unciv/ui/screens/cityscreen/CityScreen.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/CityScreen.kt
@@ -160,6 +160,8 @@ class CityScreen(
         globalShortcuts.add(KeyboardBinding.NextCity) { page(1) }
     }
 
+    override fun getCivilopediaRuleset() = selectedCiv.gameInfo.ruleset
+
     internal fun update() {
         // Recalculate Stats
         city.cityStats.update()

--- a/core/src/com/unciv/ui/screens/cityscreen/CityScreenTileTable.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/CityScreenTileTable.kt
@@ -50,7 +50,7 @@ class CityScreenTileTable(private val cityScreen: CityScreen) : Table() {
         innerTable.pad(5f)
 
         innerTable.add(MarkupRenderer.render(TileDescription.toMarkup(selectedTile, city.civ), iconDisplay = IconDisplay.None) {
-            UncivGame.Current.pushScreen(CivilopediaScreen(city.getRuleset(), link = it))
+            cityScreen.openCivilopedia(it)
         } )
         innerTable.row()
         innerTable.add(getTileStatsTable(stats)).row()

--- a/core/src/com/unciv/ui/screens/cityscreen/CityStatsTable.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/CityStatsTable.kt
@@ -207,7 +207,7 @@ class CityStatsTable(private val cityScreen: CityScreen) : Table() {
         if (wltkLabel != null) {
             tableWithIcons.add(wltkIcon!!).size(20f).padRight(5f)
             wltkLabel.onClick {
-                UncivGame.Current.pushScreen(CivilopediaScreen(city.getRuleset(), link = "We Love The King Day"))
+                cityScreen.openCivilopedia("Tutorial/We Love The King Day")
             }
             tableWithIcons.add(wltkLabel).row()
         }

--- a/core/src/com/unciv/ui/screens/cityscreen/ConstructionInfoTable.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/ConstructionInfoTable.kt
@@ -67,7 +67,7 @@ class ConstructionInfoTable(val cityScreen: CityScreen) : Table() {
                 if (link.isEmpty()) return@apply
                 touchable = Touchable.enabled
                 this.onClick {
-                    UncivGame.Current.pushScreen(CivilopediaScreen(city.getRuleset(), link = link))
+                    cityScreen.openCivilopedia(link)
                 }
             }).pad(5f)
 

--- a/core/src/com/unciv/ui/screens/cityscreen/GreatPersonPointsBreakdownPopup.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/GreatPersonPointsBreakdownPopup.kt
@@ -34,10 +34,8 @@ class GreatPersonPointsBreakdownPopup(cityScreen: CityScreen, gppBreakdown: Grea
         for (entry in gppBreakdown.percentBonuses)
             addFormattedEntry(entry, true)
 
-        val game = cityScreen.game
-        val ruleset = game.gameInfo!!.ruleset
         add(MarkupRenderer.render(lines) {
-            game.pushScreen(CivilopediaScreen(ruleset, link = it))
+            cityScreen.openCivilopedia(it)
         })
 
         addCloseButton()

--- a/core/src/com/unciv/ui/screens/diplomacyscreen/CityStateDiplomacyTable.kt
+++ b/core/src/com/unciv/ui/screens/diplomacyscreen/CityStateDiplomacyTable.kt
@@ -32,7 +32,6 @@ import com.unciv.ui.components.input.onClick
 import com.unciv.ui.components.widgets.ColorMarkupLabel
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.popups.ConfirmPopup
-import com.unciv.ui.screens.civilopediascreen.CivilopediaScreen
 
 class CityStateDiplomacyTable(private val diplomacyScreen: DiplomacyScreen) {
     val viewingCiv = diplomacyScreen.viewingCiv
@@ -121,7 +120,7 @@ class CityStateDiplomacyTable(private val diplomacyScreen: DiplomacyScreen) {
                 resourcesTable.add(wrapper).padRight(20f)
                 wrapper.addTooltip(name, 18f)
                 wrapper.onClick {
-                    UncivGame.Current.pushScreen(CivilopediaScreen(UncivGame.Current.gameInfo!!.ruleset, link = "Resource/$name"))
+                    diplomacyScreen.openCivilopedia(supplyList.resource.makeLink())
                 }
             }
             diplomacyTable.add(resourcesTable).row()

--- a/core/src/com/unciv/ui/screens/diplomacyscreen/DiplomacyScreen.kt
+++ b/core/src/com/unciv/ui/screens/diplomacyscreen/DiplomacyScreen.kt
@@ -99,6 +99,8 @@ class DiplomacyScreen(
         }
     }
 
+    override fun getCivilopediaRuleset() = viewingCiv.gameInfo.ruleset
+
     private inner class ScrollPaneWithMinSize : ScrollPane(leftSideTable) {
         // On cramped screens 20% default splitAmount can make the left side smaller than a nation icon.
         // Also, content changes of the right side may claim too much space, pushing the split further to the left.

--- a/core/src/com/unciv/ui/screens/mainmenuscreen/MainMenuScreen.kt
+++ b/core/src/com/unciv/ui/screens/mainmenuscreen/MainMenuScreen.kt
@@ -336,17 +336,21 @@ class MainMenuScreen: BaseScreen(), RecreateOnResize {
         }
     }
 
-    private fun openCivilopedia() {
-        stopBackgroundMapGeneration()
+    override fun getCivilopediaRuleset(): Ruleset {
+        if (easterEggRuleset != null) return easterEggRuleset!!
         val rulesetParameters = game.settings.lastGameSetup?.gameParameters
-        val ruleset = easterEggRuleset ?:
-            if (rulesetParameters == null)
-                RulesetCache[BaseRuleset.Civ_V_GnK.fullName] ?: return
-            else RulesetCache.getComplexRuleset(rulesetParameters)
+        if (rulesetParameters != null) return RulesetCache.getComplexRuleset(rulesetParameters)
+        return RulesetCache[BaseRuleset.Civ_V_GnK.fullName]
+            ?: throw IllegalStateException("No ruleset found")
+    }
+
+    override fun openCivilopedia(link: String) {
+        stopBackgroundMapGeneration()
+        val ruleset = getCivilopediaRuleset()
         UncivGame.Current.translations.translationActiveMods = ruleset.mods
         ImageGetter.setNewRuleset(ruleset)
         setSkin()
-        game.pushScreen(CivilopediaScreen(ruleset))
+        openCivilopedia(ruleset)
     }
 
     override fun recreate(): BaseScreen {

--- a/core/src/com/unciv/ui/screens/mapeditorscreen/MapEditorScreen.kt
+++ b/core/src/com/unciv/ui/screens/mapeditorscreen/MapEditorScreen.kt
@@ -121,6 +121,8 @@ class MapEditorScreen(map: TileMap? = null) : BaseScreen(), RecreateOnResize {
         globalShortcuts.add(KeyCharAndCode.BACK) { closeEditor() }
     }
 
+    override fun getCivilopediaRuleset() = ruleset
+
     companion object {
         private fun getDefaultParameters(): MapParameters {
             val lastSetup = UncivGame.Current.settings.lastGameSetup
@@ -250,7 +252,7 @@ class MapEditorScreen(map: TileMap? = null) : BaseScreen(), RecreateOnResize {
         }
     }
 
-    fun askIfDirty(question: String, confirmText: String, isConfirmPositive: Boolean = false, action: ()->Unit) {
+    private fun askIfDirty(question: String, confirmText: String, isConfirmPositive: Boolean = false, action: ()->Unit) {
         if (!isDirty) return action()
         ConfirmPopup(screen = this, question, confirmText, isConfirmPositive, action = action).open()
     }

--- a/core/src/com/unciv/ui/screens/mapeditorscreen/tabs/MapEditorEditTab.kt
+++ b/core/src/com/unciv/ui/screens/mapeditorscreen/tabs/MapEditorEditTab.kt
@@ -24,7 +24,6 @@ import com.unciv.ui.components.widgets.UncivSlider
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.popups.ToastPopup
 import com.unciv.ui.screens.basescreen.BaseScreen
-import com.unciv.ui.screens.civilopediascreen.CivilopediaScreen
 import com.unciv.ui.screens.civilopediascreen.FormattedLine
 import com.unciv.ui.screens.mapeditorscreen.MapEditorScreen
 import com.unciv.ui.screens.mapeditorscreen.TileInfoNormalizer
@@ -145,7 +144,7 @@ class MapEditorEditTab(
         brushActor.touchable = Touchable.enabled
         // As so often, doing the binding separately to avoid the tooltip
         brushActor.onActivation {
-            editorScreen.game.pushScreen(CivilopediaScreen(ruleset, link = link))
+            editorScreen.openCivilopedia(link)
         }
         brushActor.keyShortcuts.add(KeyboardBinding.Civilopedia)
     }

--- a/core/src/com/unciv/ui/screens/mapeditorscreen/tabs/MapEditorViewTab.kt
+++ b/core/src/com/unciv/ui/screens/mapeditorscreen/tabs/MapEditorViewTab.kt
@@ -28,7 +28,6 @@ import com.unciv.ui.components.widgets.UncivSlider
 import com.unciv.ui.components.widgets.WrappableLabel
 import com.unciv.ui.popups.ToastPopup
 import com.unciv.ui.screens.basescreen.BaseScreen
-import com.unciv.ui.screens.civilopediascreen.CivilopediaScreen
 import com.unciv.ui.screens.civilopediascreen.FormattedLine
 import com.unciv.ui.screens.civilopediascreen.FormattedLine.IconDisplay
 import com.unciv.ui.screens.civilopediascreen.MarkupRenderer
@@ -216,7 +215,7 @@ class MapEditorViewTab(
                 }
             } else {
                 // This needs CivilopediaScreen to be able to work without a GameInfo!
-                UncivGame.Current.pushScreen(CivilopediaScreen(tile.ruleset, link = it))
+                editorScreen.openCivilopedia(it)
             }
         }
 

--- a/core/src/com/unciv/ui/screens/overviewscreen/EmpireOverviewScreen.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/EmpireOverviewScreen.kt
@@ -40,6 +40,8 @@ class EmpireOverviewScreen(
         super.dispose()
     }
 
+    override fun getCivilopediaRuleset() = viewingPlayer.gameInfo.ruleset
+
     init {
         val selectCategory = defaultCategory ?: EmpireOverviewCategories.values().firstOrNull { it.name == game.settings.lastOverviewPage }
         val iconSize = Constants.defaultFontSize.toFloat()

--- a/core/src/com/unciv/ui/screens/overviewscreen/ReligionOverviewTab.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/ReligionOverviewTab.kt
@@ -6,14 +6,12 @@ import com.badlogic.gdx.scenes.scene2d.ui.ScrollPane
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.utils.Align
 import com.unciv.Constants
-import com.unciv.UncivGame
 import com.unciv.logic.civilization.Civilization
 import com.unciv.models.Religion
 import com.unciv.models.ruleset.Belief
 import com.unciv.models.translations.fillPlaceholders
 import com.unciv.models.translations.tr
 import com.unciv.ui.components.widgets.ExpanderTab
-import com.unciv.ui.screens.civilopediascreen.CivilopediaScreen
 import com.unciv.ui.screens.civilopediascreen.MarkupRenderer
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.screens.basescreen.BaseScreen
@@ -197,7 +195,7 @@ class ReligionOverviewTab(
         MarkupRenderer.render(
             belief.getCivilopediaTextLines(withHeader = true)
         ) {
-            UncivGame.Current.pushScreen(CivilopediaScreen(gameInfo.ruleset, link = it))
+            overviewScreen.openCivilopedia(it)
         }.apply {
             background = BaseScreen.skinStrings.getUiBackground(
                 "OverviewScreen/ReligionOverviewTab/BeliefDescription",

--- a/core/src/com/unciv/ui/screens/overviewscreen/ResourcesOverviewTab.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/ResourcesOverviewTab.kt
@@ -23,8 +23,6 @@ import com.unciv.ui.components.extensions.surroundWithCircle
 import com.unciv.ui.components.extensions.toLabel
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.screens.basescreen.BaseScreen
-import com.unciv.ui.screens.civilopediascreen.CivilopediaCategories
-import com.unciv.ui.screens.civilopediascreen.CivilopediaScreen
 
 
 class ResourcesOverviewTab(
@@ -106,7 +104,7 @@ class ResourcesOverviewTab(
         }
     private fun TileResource.getLabel() = name.toLabel(hideIcons = true).apply {
         onClick {
-            overviewScreen.game.pushScreen(CivilopediaScreen(gameInfo.ruleset, CivilopediaCategories.Resource, this@getLabel.name))
+            overviewScreen.openCivilopedia(makeLink())
         }
     }
 

--- a/core/src/com/unciv/ui/screens/overviewscreen/WonderOverviewTab.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/WonderOverviewTab.kt
@@ -16,15 +16,12 @@ import com.unciv.ui.components.extensions.toLabel
 import com.unciv.ui.components.input.onClick
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.screens.civilopediascreen.CivilopediaCategories
-import com.unciv.ui.screens.civilopediascreen.CivilopediaScreen
 import com.unciv.utils.DebugUtils
 
 class WonderOverviewTab(
     viewingPlayer: Civilization,
     overviewScreen: EmpireOverviewScreen
 ) : EmpireOverviewTab(viewingPlayer, overviewScreen) {
-    val ruleSet = gameInfo.ruleset
-
     private val wonderInfo = WonderInfo()
     private val wonders: Array<WonderInfo.WonderInfo> = wonderInfo.collectInfo(viewingPlayer)
 
@@ -70,7 +67,7 @@ class WonderOverviewTab(
 
             val image = wonder.getImage()
             image?.onClick {
-                UncivGame.Current.pushScreen(CivilopediaScreen(ruleSet, wonder.category, wonder.name))
+                overviewScreen.openCivilopedia(wonder.makeLink())
             }
             // Terrain image padding is a bit unpredictable, they need ~5f more. Ensure equal line spacing on name, not image:
             add(image).pad(0f, 10f, 0f, 10f)
@@ -142,6 +139,8 @@ class WonderInfo {
             viewEntireMapForDebug -> location.position.toString()
             else -> "Far away"
         }
+
+        fun makeLink() = category.name + "/" + name
     }
 
     private fun shouldBeDisplayed(viewingPlayer: Civilization, wonder: Building, wonderEra: Int?) =

--- a/core/src/com/unciv/ui/screens/pickerscreens/PolicyPickerScreen.kt
+++ b/core/src/com/unciv/ui/screens/pickerscreens/PolicyPickerScreen.kt
@@ -35,10 +35,9 @@ import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.popups.ConfirmPopup
 import com.unciv.ui.screens.basescreen.BaseScreen
 import com.unciv.ui.screens.basescreen.RecreateOnResize
-import com.unciv.ui.screens.civilopediascreen.CivilopediaScreen
-import java.lang.Integer.max
 import kotlin.math.abs
 import kotlin.math.ceil
+import kotlin.math.max
 import kotlin.math.min
 
 private enum class PolicyColors(
@@ -147,8 +146,7 @@ class PolicyPickerScreen(
     val viewingCiv: Civilization,
     val canChangeState: Boolean,
     select: String? = null
-)
-    : PickerScreen(), RecreateOnResize {
+) : PickerScreen(), RecreateOnResize {
 
     object Sizes {
         const val paddingVertical = 10f
@@ -201,10 +199,7 @@ class PolicyPickerScreen(
 
 
         // Actually create and distribute the policy branches
-        var wrapper = Table()
         val numberOfRows = ceil(branches.size / branchesPerRow.toFloat()).toInt()
-        val size = numberOfRows * branchesPerRow
-
 
         val positionToTable = HashMap<String,Table>()
         val allPoliciesTable = Table()
@@ -252,6 +247,8 @@ class PolicyPickerScreen(
         }
     }
 
+    override fun getCivilopediaRuleset() = viewingCiv.gameInfo.ruleset
+
     private fun pickPolicy(button: PolicyButton) {
 
         val policy = button.policy
@@ -270,7 +267,7 @@ class PolicyPickerScreen(
         descriptionLabel.setText(policy.getDescription())
         descriptionLabel.clearListeners()
         descriptionLabel.onActivation {
-            game.pushScreen(CivilopediaScreen(viewingCiv.gameInfo.ruleset, link = policy.makeLink()))
+            openCivilopedia(policy.makeLink())
         }
         descriptionLabel.keyShortcuts.add(KeyboardBinding.Civilopedia)
     }

--- a/core/src/com/unciv/ui/screens/pickerscreens/PromotionPickerScreen.kt
+++ b/core/src/com/unciv/ui/screens/pickerscreens/PromotionPickerScreen.kt
@@ -24,7 +24,6 @@ import com.unciv.ui.components.input.onDoubleClick
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.screens.basescreen.BaseScreen
 import com.unciv.ui.screens.basescreen.RecreateOnResize
-import com.unciv.ui.screens.civilopediascreen.CivilopediaScreen
 import kotlin.math.abs
 
 class PromotionPickerScreen(
@@ -93,6 +92,8 @@ class PromotionPickerScreen(
 
         displayTutorial(TutorialTrigger.Experience)
     }
+
+    override fun getCivilopediaRuleset() = unit.civ.gameInfo.ruleset
 
     private fun acceptPromotion(button: PromotionButton?) {
         // if user managed to click disabled button, still do nothing
@@ -330,7 +331,7 @@ class PromotionPickerScreen(
         descriptionLabel.setText("$topLine\n$promotionText")
         descriptionLabel.clearListeners()
         descriptionLabel.onActivation {
-            game.pushScreen(CivilopediaScreen(unit.baseUnit.ruleset, link = node.promotion.makeLink()))
+            openCivilopedia(node.promotion.makeLink())
         }
         descriptionLabel.keyShortcuts.add(KeyboardBinding.Civilopedia)
     }

--- a/core/src/com/unciv/ui/screens/pickerscreens/ReligionPickerScreenCommon.kt
+++ b/core/src/com/unciv/ui/screens/pickerscreens/ReligionPickerScreenCommon.kt
@@ -21,7 +21,6 @@ import com.unciv.ui.components.extensions.enable
 import com.unciv.ui.components.extensions.toLabel
 import com.unciv.ui.components.input.onClick
 import com.unciv.ui.components.widgets.WrappableLabel
-import com.unciv.ui.screens.civilopediascreen.CivilopediaScreen
 import com.unciv.ui.screens.civilopediascreen.MarkupRenderer
 
 abstract class ReligionPickerScreenCommon(
@@ -61,6 +60,8 @@ abstract class ReligionPickerScreenCommon(
         closeButton.isVisible = true
         setDefaultCloseAction()
     }
+
+    override fun getCivilopediaRuleset() = ruleset
 
     protected fun setOKAction(buttonText: String, action: ReligionManager.() -> Unit) {
         rightSideButton.setText(buttonText.tr())
@@ -109,7 +110,7 @@ abstract class ReligionPickerScreenCommon(
                     MarkupRenderer.render(
                     belief.getCivilopediaTextLines(withHeader = true), width - 20f
                 ) {
-                    UncivGame.Current.pushScreen(CivilopediaScreen(ruleset,  link = it))
+                    openCivilopedia(it)
                 }).growX()
                 // Icon should it be needed:  CivilopediaImageGetters.belief(belief.getIconName(), 50f)
             }

--- a/core/src/com/unciv/ui/screens/pickerscreens/TechPickerScreen.kt
+++ b/core/src/com/unciv/ui/screens/pickerscreens/TechPickerScreen.kt
@@ -26,8 +26,6 @@ import com.unciv.ui.components.input.onRightClick
 import com.unciv.ui.components.input.onDoubleClick
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.popups.ToastPopup
-import com.unciv.ui.screens.civilopediascreen.CivilopediaCategories
-import com.unciv.ui.screens.civilopediascreen.CivilopediaScreen
 import com.unciv.utils.Concurrency
 import kotlin.math.abs
 
@@ -38,6 +36,7 @@ class TechPickerScreen(
     private val freeTechPick: Boolean = false
 ) : PickerScreen() {
 
+    private val ruleset = civInfo.gameInfo.ruleset
     private var techNameToButton = HashMap<String, TechButton>()
     private var selectedTech: Technology? = null
     private var civTech: TechManager = civInfo.tech
@@ -56,7 +55,7 @@ class TechPickerScreen(
     private val techTable = Table()
 
     // All these are to counter performance problems when updating buttons for all techs.
-    private var researchableTechs = civInfo.gameInfo.ruleset.technologies.keys
+    private var researchableTechs = ruleset.technologies.keys
             .filter { civTech.canBeResearched(it) }.toHashSet()
 
     private val currentTechColor = skinStrings.getUIColor("TechPickerScreen/CurrentTechColor", colorFromRGB(72, 147, 175))
@@ -65,7 +64,7 @@ class TechPickerScreen(
     private val queuedTechColor = skinStrings.getUIColor("TechPickerScreen/QueuedTechColor", colorFromRGB(7*2, 46*2, 43*2))
     private val researchedFutureTechColor = skinStrings.getUIColor("TechPickerScreen/ResearchedFutureTechColor", colorFromRGB(127, 50, 0))
 
-    private val turnsToTech = civInfo.gameInfo.ruleset.technologies.values.associateBy({ it.name }, { civTech.turnsToTech(it.name) })
+    private val turnsToTech = ruleset.technologies.values.associateBy({ it.name }, { civTech.turnsToTech(it.name) })
 
     init {
         setDefaultCloseAction()
@@ -73,7 +72,7 @@ class TechPickerScreen(
 
         descriptionLabel.onClick {
             if (selectedTech != null)
-                game.pushScreen(CivilopediaScreen(civInfo.gameInfo.ruleset, CivilopediaCategories.Technology, selectedTech!!.name))
+                openCivilopedia(selectedTech!!.makeLink())
         }
 
         tempTechsToResearch = ArrayList(civTech.techsToResearch)
@@ -101,11 +100,14 @@ class TechPickerScreen(
         } else {
             // center on any possible technology which is ready for the research right now
             val firstAvailable = researchableTechs.firstOrNull()
-            val firstAvailableTech = civInfo.gameInfo.ruleset.technologies[firstAvailable]
+            val firstAvailableTech = ruleset.technologies[firstAvailable]
             if (firstAvailableTech != null)
                 centerOnTechnology(firstAvailableTech)
         }
     }
+
+    override fun getCivilopediaRuleset() = ruleset
+
 
     private fun tryExit() {
         if (freeTechPick) {
@@ -128,7 +130,7 @@ class TechPickerScreen(
         for (label in eraLabels) label.remove()
         eraLabels.clear()
 
-        val allTechs = civInfo.gameInfo.ruleset.technologies.values
+        val allTechs = ruleset.technologies.values
         if (allTechs.isEmpty()) return
         val columns = allTechs.maxOf { it.column!!.columnNumber } + 1
         val rows = allTechs.maxOf { it.row } + 1
@@ -149,7 +151,7 @@ class TechPickerScreen(
             val columnSpan = eraColumns.size
             val color = when {
                 civTech.era.name == era -> queuedTechColor
-                civInfo.gameInfo.ruleset.eras[era]!!.eraNumber < civTech.era.eraNumber -> colorFromRGB(255, 175, 0)
+                ruleset.eras[era]!!.eraNumber < civTech.era.eraNumber -> colorFromRGB(255, 175, 0)
                 else -> Color.BLACK.cpy()
             }
 
@@ -161,7 +163,7 @@ class TechPickerScreen(
 
             val label = era.toLabel().apply {
                 setAlignment(Align.center)
-                if (civInfo.gameInfo.ruleset.eras[era]!!.eraNumber < civTech.era.eraNumber)
+                if (ruleset.eras[era]!!.eraNumber < civTech.era.eraNumber)
                     this.color = colorFromRGB(120, 46, 16) }
 
             eraLabels.add(label)
@@ -246,7 +248,7 @@ class TechPickerScreen(
             lines.addActor(line)
         }
 
-        for (tech in civInfo.gameInfo.ruleset.technologies.values) {
+        for (tech in ruleset.technologies.values) {
             if (!techNameToButton.containsKey(tech.name)) {
                 ToastPopup("Tech ${tech.name} appears to be missing - perhaps two techs have the same row & column", this)
                 continue

--- a/core/src/com/unciv/ui/screens/worldscreen/AlertPopup.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/AlertPopup.kt
@@ -36,7 +36,6 @@ import com.unciv.ui.components.input.keyShortcuts
 import com.unciv.ui.components.input.onActivation
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.popups.Popup
-import com.unciv.ui.screens.civilopediascreen.CivilopediaScreen
 import com.unciv.ui.screens.civilopediascreen.FormattedLine
 import com.unciv.ui.screens.civilopediascreen.MarkupRenderer
 import com.unciv.ui.screens.diplomacyscreen.LeaderIntroTable
@@ -555,7 +554,5 @@ class AlertPopup(
         add(MarkupRenderer.render(lines, stageWidth * 0.5f, linkAction = ::openCivilopedia)).row()
     }
 
-    private fun openCivilopedia(link: String) {
-        worldScreen.game.pushScreen(CivilopediaScreen(gameInfo.ruleset, link = link))
-    }
+    private fun openCivilopedia(link: String) = worldScreen.openCivilopedia(link)
 }

--- a/core/src/com/unciv/ui/screens/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/WorldScreen.kt
@@ -21,6 +21,7 @@ import com.unciv.logic.multiplayer.storage.MultiplayerAuthException
 import com.unciv.logic.trade.TradeEvaluation
 import com.unciv.models.TutorialTrigger
 import com.unciv.models.metadata.GameSetupInfo
+import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.ruleset.tile.ResourceType
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.ui.components.extensions.centerX
@@ -217,6 +218,18 @@ class WorldScreen(
         super.dispose()
     }
 
+    override fun getCivilopediaRuleset() = gameInfo.ruleset
+
+    // Handle disabling and re-enabling WASD listener while Options are open
+    override fun openOptionsPopup(startingPage: Int, withDebug: Boolean, onClose: () -> Unit) {
+        val oldListener = stage.root.listeners.filterIsInstance<KeyboardPanningListener>().firstOrNull()
+        if (oldListener != null) stage.removeListener(oldListener)
+        super.openOptionsPopup(startingPage, withDebug) {
+            addKeyboardListener()
+            onClose()
+        }
+    }
+
     fun openEmpireOverview(category: EmpireOverviewCategories? = null) {
         game.pushScreen(EmpireOverviewScreen(selectedCiv, category))
     }
@@ -239,7 +252,7 @@ class WorldScreen(
 
         // Space and N are assigned in NextTurnButton constructor
         // Functions that have a big button are assigned there (WorldScreenTopBar, TechPolicyDiplomacyButtons..)
-        globalShortcuts.add(KeyboardBinding.Civilopedia) { game.pushScreen(CivilopediaScreen(gameInfo.ruleset)) }
+        globalShortcuts.add(KeyboardBinding.Civilopedia) { openCivilopedia() }
         globalShortcuts.add(KeyboardBinding.EmpireOverviewTrades) { openEmpireOverview(EmpireOverviewCategories.Trades) }
         globalShortcuts.add(KeyboardBinding.EmpireOverviewUnits) { openEmpireOverview(EmpireOverviewCategories.Units) }
         globalShortcuts.add(KeyboardBinding.EmpireOverviewPolitics) { openEmpireOverview(EmpireOverviewCategories.Politics) }
@@ -276,16 +289,6 @@ class WorldScreen(
             // No cheating unless you're by yourself
             if (gameInfo.civilizations.count { it.isHuman() } > 1) return@add
             val consolePopup = DevConsolePopup(this)
-        }
-    }
-
-    // Handle disabling and re-enabling WASD listener while Options are open
-    override fun openOptionsPopup(startingPage: Int, withDebug: Boolean, onClose: () -> Unit) {
-        val oldListener = stage.root.listeners.filterIsInstance<KeyboardPanningListener>().firstOrNull()
-        if (oldListener != null) stage.removeListener(oldListener)
-        super.openOptionsPopup(startingPage, withDebug) {
-            addKeyboardListener()
-            onClose()
         }
     }
 

--- a/core/src/com/unciv/ui/screens/worldscreen/bottombar/TileInfoTable.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/bottombar/TileInfoTable.kt
@@ -4,7 +4,6 @@ import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.scenes.scene2d.Touchable
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.utils.Align
-import com.unciv.UncivGame
 import com.unciv.logic.map.tile.Tile
 import com.unciv.logic.map.tile.TileDescription
 import com.unciv.models.translations.tr
@@ -16,7 +15,6 @@ import com.unciv.ui.components.input.onClick
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.popups.Popup
 import com.unciv.ui.screens.basescreen.BaseScreen
-import com.unciv.ui.screens.civilopediascreen.CivilopediaScreen
 import com.unciv.ui.screens.civilopediascreen.FormattedLine.IconDisplay
 import com.unciv.ui.screens.civilopediascreen.MarkupRenderer
 import com.unciv.ui.screens.worldscreen.WorldScreen
@@ -38,7 +36,7 @@ class TileInfoTable(private val worldScreen: WorldScreen) : Table(BaseScreen.ski
         if (tile != null && (DebugUtils.VISIBLE_MAP || selectedCiv.hasExplored(tile)) ) {
             add(getStatsTable(tile))
             add(MarkupRenderer.render(TileDescription.toMarkup(tile, selectedCiv), padding = 0f, iconDisplay = IconDisplay.None) {
-                UncivGame.Current.pushScreen(CivilopediaScreen(selectedCiv.gameInfo.ruleset, link = it))
+                worldScreen.openCivilopedia(it)
             } ).pad(5f).row()
             if (DebugUtils.VISIBLE_MAP)
                 add(tile.position.toPrettyString().toLabel()).colspan(2).pad(5f)
@@ -48,7 +46,7 @@ class TileInfoTable(private val worldScreen: WorldScreen) : Table(BaseScreen.ski
         addBorderAllowOpacity(1f, Color.WHITE)
     }
 
-    fun getStatsTable(tile: Tile): Table {
+    private fun getStatsTable(tile: Tile): Table {
         val table = Table()
         table.defaults().pad(2f)
 

--- a/core/src/com/unciv/ui/screens/worldscreen/mainmenu/WorldScreenMenuPopup.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/mainmenu/WorldScreenMenuPopup.kt
@@ -19,7 +19,7 @@ class WorldScreenMenuPopup(val worldScreen: WorldScreen) : Popup(worldScreen, sc
         }.row()
         addButton("Civilopedia", KeyboardBinding.Civilopedia) {
             close()
-            worldScreen.game.pushScreen(CivilopediaScreen(worldScreen.gameInfo.ruleset))
+            worldScreen.openCivilopedia()
         }.row()
         if (!worldScreen.gameInfo.gameParameters.isOnlineMultiplayer)
             addButton("Save game", KeyboardBinding.SaveGame) {

--- a/core/src/com/unciv/ui/screens/worldscreen/topbar/WorldScreenTopBar.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/topbar/WorldScreenTopBar.kt
@@ -217,12 +217,7 @@ class WorldScreenTopBar(internal val worldScreen: WorldScreen) : Table() {
             }
 
             val onNationClick = {
-                val civilopediaScreen = CivilopediaScreen(
-                    worldScreen.selectedCiv.gameInfo.ruleset,
-                    CivilopediaCategories.Nation,
-                    worldScreen.selectedCiv.civName
-                )
-                worldScreen.game.pushScreen(civilopediaScreen)
+                worldScreen.openCivilopedia(worldScreen.selectedCiv.nation.makeLink())
             }
 
             selectedCivLabel.setFontSize(25)

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/UnitTable.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/UnitTable.kt
@@ -22,8 +22,6 @@ import com.unciv.ui.components.input.onClick
 import com.unciv.ui.components.widgets.UnitGroup
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.screens.basescreen.BaseScreen
-import com.unciv.ui.screens.civilopediascreen.CivilopediaCategories
-import com.unciv.ui.screens.civilopediascreen.CivilopediaScreen
 import com.unciv.ui.screens.pickerscreens.CityRenamePopup
 import com.unciv.ui.screens.pickerscreens.PromotionPickerScreen
 import com.unciv.ui.screens.pickerscreens.UnitRenamePopup
@@ -264,7 +262,7 @@ class UnitTable(val worldScreen: WorldScreen) : Table() {
                 }
 
                 unitIconHolder.onClick {
-                    worldScreen.game.pushScreen(CivilopediaScreen(worldScreen.gameInfo.ruleset, CivilopediaCategories.Unit, selectedUnit!!.name))
+                    worldScreen.openCivilopedia(selectedUnit!!.baseUnit.makeLink())
                 }
             } else { // multiple selected units
                 for (unit in selectedUnits)


### PR DESCRIPTION
#### Notes
- I hope this is a more robust way to manage "which Ruleset should Civilopedia display"...
- Intentionally left separate from local requirements to access Ruleset for logic or UI purposes - mixing might be an option - as in, all screens get to use `val ruleset get() = ...` with impunity, didn't want to think too much about that, as mistakes would be hard to catch. Mistakes in what pedia displays are more benign...
- The CivilopediaScreen constructor call using a category is dead except for the internal recreate with this PR. Consequences to be thought about later.
- Only two uses of the new GUI.openCivilopedia - both cases could be changed to bubble down parent info from upstream, but I decided that was too much signature changes for one PR.