### PR TITLE
Fix crash when a starting unit has a random conditional

### DIFF
--- a/core/src/com/unciv/models/ruleset/unique/StateForConditionals.kt
+++ b/core/src/com/unciv/models/ruleset/unique/StateForConditionals.kt
@@ -48,8 +48,10 @@ data class StateForConditionals(
         fun Civilization?.hash() = this?.civName?.hashCode() ?: 0
         fun City?.hash() = this?.id?.hashCode() ?: 0
         fun Tile?.hash() = this?.position?.hashCode() ?: 0
-        fun MapUnit?.hash() = (this?.name?.hashCode() ?: 0) + 17 * this?.currentTile.hash()
-        fun ICombatant?.hash() = (this?.getName()?.hashCode() ?: 0) + 17 * this?.getTile().hash()
+        fun MapUnit?.hash() = if (this == null) 0 else name.hashCode() + (if (hasTile()) 17 * currentTile.hash() else 0)
+        fun ICombatant?.hash() = if (this == null) 0
+            else if (this is MapUnitCombatant) unit.hash()  // line only serves as `lateinit currentTile not initialized` guard
+            else getName().hashCode() + 17 * getTile().hash()
         fun CombatAction?.hash() = this?.name?.hashCode() ?: 0
         fun Region?.hash() = this?.rect?.hashCode() ?: 0
 

--- a/core/src/com/unciv/ui/screens/newgamescreen/ModCheckboxTable.kt
+++ b/core/src/com/unciv/ui/screens/newgamescreen/ModCheckboxTable.kt
@@ -212,7 +212,7 @@ class ModCheckboxTable(
     private fun disableIncompatibleMods() {
         for (modWidget in modWidgets) {
             val enable = ModCompatibility.meetsAllRequirements(modWidget.mod, baseRuleset, getSelectedMods())
-            assert(enable || !modWidget.widget.isChecked) { "Mod compatibility conflict: Trying to disable ${modWidget.mod.name} while it is selected" }
+            if (!enable && modWidget.widget.isChecked) modWidget.widget.isChecked = false  // mod widgets can't, but selecting a map can cause this situation
             modWidget.widget.isDisabled = !enable  // isEnabled is only for TextButtons
         }
     }


### PR DESCRIPTION
Can't include currentTile in the hash when the unit isn't on the map yet - but Uniques are evaluated that early, namely when updateUniques runs *while the unit is being placed*

There might be a code flow reorder that would also "fix" this mad modder, but - a hardened hashCode is better than a rarely throwing one anyway.