### PR TITLE
Spy Icon disabled when not on turn

### DIFF
--- a/core/src/com/unciv/ui/screens/overviewscreen/EspionageOverviewScreen.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/EspionageOverviewScreen.kt
@@ -180,11 +180,14 @@ class EspionageOverviewScreen(val civInfo: Civilization, val worldScreen: WorldS
         }
         add(starTable).center().padLeft(-4f)
 
-        onClick {
-            onSpyClicked(moveSpyButtons[spy]!!, spy)
-        }
-        onRightClick {
-            onSpyRightClicked(spy)
+        // Spectators aren't allowed to move the spies of the Civs they are viewing
+        if (worldScreen.canChangeState && spy.isAlive()) {
+            onClick {
+                onSpyClicked(moveSpyButtons[spy]!!, spy)
+            }
+            onRightClick {
+                onSpyRightClicked(spy)
+            }
         }
     }
 


### PR DESCRIPTION
This PR is a small fix of  #11584 and #11587

Basically, the spy icon could be clicked from a spectator or when it isn't the active player's turn. I simply added an extra if statement since the icon can't be disabled.