### PR TITLE
Fixed gold ruin not displaying notification

### DIFF
--- a/core/src/com/unciv/logic/civilization/managers/RuinsManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/RuinsManager.kt
@@ -61,7 +61,7 @@ class RuinsManager(
             for (unique in possibleReward.uniqueObjects) {
                 atLeastOneUniqueHadEffect =
                     atLeastOneUniqueHadEffect
-                    || UniqueTriggerActivation.triggerUnique(unique, triggeringUnit, notification = possibleReward.notification)
+                    || UniqueTriggerActivation.triggerUnique(unique, triggeringUnit, notification = possibleReward.notification, triggerNotificationText = "from the ruins")
             }
             if (atLeastOneUniqueHadEffect) {
                 rememberReward(possibleReward.name)


### PR DESCRIPTION
This PR fixes a feature originally created in the commit 83ff2d1 which was then broken one we unified the unique triggers in #11011.

This problem was originally reported in two channels on discord.

This PR simply fixes this by adding back the `triggerNotificationText = "from the ruins" text to the trigger. I tested it with other ruin effects and it doesn't add the notificationText to them.

<details><summary>Details</summary>

![RuinGoldNotification](https://github.com/yairm210/Unciv/assets/7538725/4364fe61-f573-46f7-b68d-081fda4a760d)

</details> 

Also, how did I gain 42 gold? It should be between 50 and 100, it shouldn't be modified by the game speed.