### PR TITLE
Mod checker reports some problems with texture atlases or their source images

### DIFF
--- a/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
+++ b/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
@@ -30,7 +30,7 @@ class RulesetValidator(val ruleset: Ruleset) {
 
     private val uniqueValidator = UniqueValidator(ruleset)
 
-    private val textureNamesCache by lazy { AtlasPreview(ruleset) }
+    private lateinit var textureNamesCache: AtlasPreview
 
     fun getErrorList(tryFixUnknownUniques: Boolean = false): RulesetErrorList {
         // When no base ruleset is loaded - references cannot be checked
@@ -53,10 +53,13 @@ class RulesetValidator(val ruleset: Ruleset) {
         addPromotionErrorsRulesetInvariant(lines, tryFixUnknownUniques)
         addResourceErrorsRulesetInvariant(lines, tryFixUnknownUniques)
 
-        // Tileset tests - e.g. json configs complete and parseable
-        checkTilesetSanity(lines)
+        if (!::textureNamesCache.isInitialized)
+            textureNamesCache = AtlasPreview(ruleset, lines)  // This logs Atlas list errors, and if these exist, scans for invalid png's
 
-        checkCivilopediaText(lines)
+        // Tileset tests - e.g. json configs complete and parseable
+        checkTilesetSanity(lines)  // relies on textureNamesCache
+
+        checkCivilopediaText(lines)  // relies on textureNamesCache
 
         return lines
     }
@@ -90,6 +93,9 @@ class RulesetValidator(val ruleset: Ruleset) {
         addDifficultyErrors(lines)
         addEventErrors(lines, tryFixUnknownUniques)
         addCityStateTypeErrors(tryFixUnknownUniques, lines)
+
+        if (!::textureNamesCache.isInitialized)
+            textureNamesCache = AtlasPreview(ruleset, lines)  // This logs Atlas list errors, and if these exist, scans for invalid png's
 
         // Tileset tests - e.g. json configs complete and parseable
         // Check for mod or Civ_V_GnK to avoid running the same test twice (~200ms for the builtin assets)
@@ -781,7 +787,7 @@ class RulesetValidator(val ruleset: Ruleset) {
         if (ruleset.folderLocation == null && this::class.java.`package`?.specificationVersion != null)
             return
 
-        val tilesetConfigFolder = (ruleset.folderLocation ?: Gdx.files.internal("")).child("jsons\\TileSets")
+        val tilesetConfigFolder = (ruleset.folderLocation ?: Gdx.files.internal("")).child("jsons/TileSets")
         if (!tilesetConfigFolder.exists()) return
 
         val configTilesets = mutableSetOf<String>()

--- a/core/src/com/unciv/ui/images/AtlasPreview.kt
+++ b/core/src/com/unciv/ui/images/AtlasPreview.kt
@@ -1,30 +1,52 @@
 package com.unciv.ui.images
 
 import com.badlogic.gdx.Gdx
+import com.badlogic.gdx.graphics.Pixmap
 import com.badlogic.gdx.graphics.g2d.TextureAtlas.TextureAtlasData
 import com.unciv.json.json
 import com.unciv.models.ruleset.Ruleset
+import com.unciv.models.ruleset.validation.RulesetErrorList
+import com.unciv.models.ruleset.validation.RulesetErrorSeverity
 import com.unciv.utils.Log
+import java.io.File
 
-class AtlasPreview(ruleset: Ruleset) : Iterable<String> {
+/**
+ *  This extracts all texture names from all atlases of a Ruleset.
+ *  - Used by RulesetValidator to check texture names without relying on ImageGetter
+ *  - Doubles as integrity checker and detects:
+ *      - Atlases.json names an atlas that does not exist
+ *      - Existing atlas is empty
+ *      - If Atlases.json names an atlas that does not exist, but the corresponding Images folder exists...
+ *         * Non-png files in the Images folders
+ *         * Any png files in the Images folders that Gdx can't load
+ */
+class AtlasPreview(ruleset: Ruleset, errorList: RulesetErrorList) : Iterable<String> {
     // This partially duplicates code in ImageGetter.getAvailableTilesets, but we don't want to reload that singleton cache.
 
     private val regionNames = mutableSetOf<String>()
 
     init {
         // For builtin rulesets, the Atlases.json is right in internal root
-        val folder = ruleset.folderLocation ?: Gdx.files.internal(".")
+        val folder = ruleset.folder()
         val controlFile = folder.child("Atlases.json")
-        val fileNames = (if (controlFile.exists()) json().fromJson(Array<String>::class.java, controlFile)
+        val controlFileExists = controlFile.exists()
+        val fileNames = (if (controlFileExists) json().fromJson(Array<String>::class.java, controlFile)
             else emptyArray()).toMutableSet()
-        if (ruleset.name.isNotEmpty())
+        val backwardsCompatibility = ruleset.name.isNotEmpty() && "game" !in fileNames
+        if (backwardsCompatibility)
             fileNames += "game"  // Backwards compatibility - when packed by 4.9.15+ this is already in the control file
         for (fileName in fileNames) {
             val file = folder.child("$fileName.atlas")
-            if (!file.exists()) continue
+            if (!file.exists()) {
+                if (controlFileExists && (fileName != "game" || !backwardsCompatibility))
+                    logMissingAtlas(fileName, ruleset, errorList)
+                continue
+            }
 
             // Next, we need to cope with this running without GL context (unit test) - no TextureAtlas(file)
             val data = TextureAtlasData(file, file.parent(), false)
+            if (data.regions.isEmpty)
+                errorList.add("${file.name()} contains no textures")
             data.regions.mapTo(regionNames) { it.name }
         }
         Log.debug("Atlas preview for $ruleset: ${regionNames.size} entries.")
@@ -33,4 +55,36 @@ class AtlasPreview(ruleset: Ruleset) : Iterable<String> {
     fun imageExists(name: String) = name in regionNames
 
     override fun iterator(): Iterator<String> = regionNames.iterator()
+
+    private fun logMissingAtlas(name: String, ruleset: Ruleset, errorList: RulesetErrorList) {
+        errorList.add("Atlases.json contains \"$name\" but there is no corresponding atlas file.")
+        val imagesFolder = ruleset.folder().child(if (name == "game") "Images" else "Images.$name")
+        if (!imagesFolder.exists() || !imagesFolder.isDirectory) return
+
+        // switch over from Gdx file handling to kotlin.io.FileTreeWalk because it's easy
+        for (file in imagesFolder.file().walk()) {
+            if (file.isDirectory || file.isHidden) continue
+            if (file.extension != "png") {
+                errorList.add("${imagesFolder.name()} contains ${file.relativePath(ruleset)} which does not have the png extension", RulesetErrorSeverity.WarningOptionsOnly)
+                continue
+            }
+            try {
+                // Since we have walked for java.io.File instances, getting the bytes manually is easier than converting that back to a Gdx FileHandle
+                val bytes = file.readBytes()
+                // This tests the bits whether they can be understood as png
+                // (or jpeg or bmp - but since we already checked the extension, it's quite unlikely this succeeds but TexturePacker.process still chokes on it)
+                val pixmap = Pixmap(bytes, 0, bytes.size)
+                pixmap.dispose()
+            } catch (ex: Throwable) {
+                var innerException = ex
+                while (innerException.cause != null && innerException.cause !== innerException) innerException = innerException.cause!!
+                errorList.add("Cannot load ${file.relativePath(ruleset)}: ${innerException.message}")
+            }
+        }
+    }
+
+    private fun Ruleset.folder() = folderLocation ?: Gdx.files.internal("")
+
+    private fun File.relativePath(ruleset: Ruleset) =
+        path.removePrefix(ruleset.folder().file().path).removePrefix("/")
 }

--- a/desktop/src/com/unciv/app/desktop/ImagePacker.kt
+++ b/desktop/src/com/unciv/app/desktop/ImagePacker.kt
@@ -11,11 +11,15 @@ import java.nio.file.Files
 import java.nio.file.attribute.BasicFileAttributes
 
 /**
- * Entry point: _ImagePacker.[packImages] ()_
+ * Entry point: _ImagePacker.[packImages]`()`_
  *
  * Re-packs our texture assets into atlas + png File pairs, which will be loaded by the game.
- * With the exception of the ExtraImages folder and the Font system these are the only
- * graphics used (The source Image folders are unused at run time except here).
+ * With the exception of the ExtraImages folder and the Font system these are the only graphics used
+ * (The source Image folders are unused at run time except here, and in RulesetValidator when it detects this failed).
+ *
+ * RulesetValidator relies on packer failures to remove the atlas files, but write the atlas name into Atlases.json nevertheless:
+ * It detects that case and only then does a scan for corrupt images.
+ * This is fulfilled by [packImagesIfOutdated] catching and logging exceptions, and [packImagesPerMod] ignoring that.
  *
  * [TexturePacker] documentation is [here](https://github.com/libgdx/libgdx/wiki/Texture-packer)
  */

--- a/desktop/src/com/unciv/app/desktop/ImagePacker.kt
+++ b/desktop/src/com/unciv/app/desktop/ImagePacker.kt
@@ -84,7 +84,12 @@ internal object ImagePacker {
                     try {
                         packImagesPerMod(mod.path, mod.path, defaultSettings)
                     } catch (ex: Throwable) {
-                        Log.error("Exception in ImagePacker: %s", ex.message)
+                        var innerException = ex
+                        while (innerException.cause != null && innerException.cause !== innerException) innerException = innerException.cause!!
+                        if (innerException === ex)
+                            Log.error("Exception in ImagePacker: %s", ex.message)
+                        else
+                            Log.error("Exception in ImagePacker: %s (%s)", ex.message, innerException.message)
                     }
                 }
             }


### PR DESCRIPTION
Closes #11618 - see screenshot there [at the end](https://github.com/yairm210/Unciv/issues/11618#issuecomment-2119026825).

That mod has a few corrupt png images - their bits are webp and do not match the extension. Thus, gimp loads them without any complaint (as it rightfully ignores the extension), but TexturePacker fails (it has no webp handler), but the modder is stumped (I see no bad files)... Now they can see the innermost cause message that Gdx throws. Which is surprisingly accurate.

For that check to run, the ImagePacker run must have failed - only then will RulesetValidator run a full scan for any bad png's.