### PR TITLE
UI: Allow any mod sound to be selected as a multiplayer turn notification sound

### DIFF
--- a/core/src/com/unciv/logic/files/IMediaFinder.kt
+++ b/core/src/com/unciv/logic/files/IMediaFinder.kt
@@ -1,0 +1,264 @@
+package com.unciv.logic.files
+
+import com.badlogic.gdx.Application
+import com.badlogic.gdx.Files
+import com.badlogic.gdx.Gdx
+import com.badlogic.gdx.files.FileHandle
+import com.unciv.UncivGame
+import com.unciv.models.UncivSound
+import com.unciv.models.metadata.BaseRuleset
+import com.unciv.models.ruleset.Ruleset
+import com.unciv.models.ruleset.RulesetCache
+import com.unciv.models.ruleset.unit.BaseUnit
+import com.unciv.ui.audio.SoundPlayer
+import com.unciv.ui.audio.MusicController
+import com.unciv.ui.screens.civilopediascreen.FormattedLine
+import com.unciv.ui.images.ImageGetter
+import com.unciv.ui.popups.options.SettingsSelect
+import kotlin.reflect.full.declaredMemberProperties
+
+/**
+ *  Encapsulate how media files are found and enumerated.
+ *
+ *  ## API requirements
+ *  - Map a name to a FileHandle
+ *  - Enumerate folders over all active mods
+ *  - Enumerate files over all active mods
+ *  - Allow fine-tuning where the list of mods comes from
+ *  - By default, "active mods" means selected in a running game, or selected as permanent audiovisual mod, and including builtin, in that order.
+ *
+ *  ## Instructions
+ *  - Inherit the interface or one of the specializations [Sounds], [Music], [Images], [Voices]
+ *  - Simply call [findMedia], [listMediaFolders] or [listMediaFiles]
+ *  - If you need a specialization but your host already has a superclass - use delegation:
+ *    `class SoundPlayer : Popup(), IMediaFinder by IMediaFinder.Sounds() { ... }`
+ *  - Direct instantiation is fine too when the call is simple.
+ *
+ *  ## Usages
+ *  - OptionsPopup multiplayer notification sounds: [multiplayerTab][com.unciv.ui.popups.options.multiplayerTab]
+ *  - todo, prepared: [SoundPlayer.getFolders]
+ *  - todo, prepared: [MusicController.getAllMusicFiles]
+ *  - todo, prepared: Leader voices: [MusicController.playVoice]
+ *  - todo, prepared: ExtraImages: [ImageGetter.findExternalImage], [FormattedLine.extraImage]
+ *  - todo: Particle effect definitions: Open PR
+ *
+ *  ## Caveats
+ *  - FileHandle.list() won't work for internal folders when running a desktop jar (unless the assets in extracted form are actually available)
+ *  - FileHandle.exists() - doc claims it won't work on Android for internal _folders_. Cannot repro on Android S, but respected here nonetheless.
+ *  - FileHandle.exists() - doc quote: "Note that this can be very slow for internal files on Android!" (meaning files).
+ *      I disagree - that's very true if there's an obb, so the zip directory has to be scanned.
+ *      But otherwise, asking the Android asset manager should not be too bad - better than file access since SAF anyway.
+ *  - FileHandle.isDirectory - won't work for internal folders when running a desktop jar
+ *    Doc: "On Android, an Files.FileType.Internal handle to an empty directory will return false. On the desktop, an Files.FileType.Internal handle to a directory on the classpath will return false."
+ */
+interface IMediaFinder {
+    //////////////////////////////////////////// Control
+
+    /** Set of supported extensions **including the leading dot**.
+     *  - use `setOf("")` if the [findMedia] API should not guess extensions but require the name parameter to only match full names.
+     *  - supplying "" ***and*** a list of extensions will make [findMedia] accept both an explicit full name and have it guess extensions.
+     *  - Don't use emptyset() - that will cause [findMedia] to always return `null`.
+     */
+    val supportedMediaExtensions: Set<String>
+
+    /** Name of assets subfolder.
+     *  - Will be interpreted as a direct child of a Mod folder or the Unciv internal assets folder.
+     */
+    val mediaSubFolderName: String
+
+    /** Access the current Ruleset.
+     *  - Defaults to [UncivGame.getGameInfoOrNull]`()?.ruleset`.
+     *  - Override to provide a direct source to enumerate game mods.
+     *  @return `null` if no game is loaded - only permanent audiovisual mods and builtin are valid sources
+     */
+    fun getRuleset(): Ruleset? = UncivGame.getGameInfoOrNull()?.ruleset
+
+    /** Supply a list of possible file names for the builtin folder.
+     *  - The children of builtin folders cannot be enumerated.
+     *  - Thus [listMediaFiles] will throw unless this is overridden.
+     */
+    fun getInternalMediaNames(folder: FileHandle): Sequence<String> =
+        throw UnsupportedOperationException("Using IMediaFinder.listMediaFiles from a jar requires overriding getInternalMediaNames")
+
+    //////////////////////////////////////////// API
+
+    /** Find a specific asset by name.
+     *  - Calls [listMediaFolders] and looks in each candidate folder.
+     *  - [supportedMediaExtensions] are the extensions searched.
+     */
+    fun findMedia(name: String): FileHandle? = listMediaFolders()
+        .flatMap { folder -> supportedMediaExtensions.map { folder.child(name + it) } }
+        .firstOrNull { it.exists() }
+
+    /** Enumerate all candidate media folders according to current Ruleset mod choice, Permanent audiovisual mods, and builtin sources.
+     *  - Remember builtin are under Gdx.internal and will not support listing children on most build types.
+     */
+    fun listMediaFolders(): Sequence<FileHandle> =
+        (listModFolders() + Gdx.files.internal(mediaSubFolderName))
+        .filter { it.directoryExists() }
+
+    /** Enumerate all media files.
+     *  - Existence is ensured.
+     */
+    fun listMediaFiles(): Sequence<FileHandle> = listMediaFolders().flatMap { folder ->
+        if (folder.type() == Files.FileType.Internal && isRunFromJar())
+            getInternalMediaNames(folder).flatMap { name ->
+                supportedMediaExtensions.map { ext ->
+                    folder.child(name + ext)
+                }
+            }.filter { it.exists() }
+        else folder.list().asSequence()
+    }
+
+    //////////////////////////////////////////// Internal helpers
+
+    fun getModMediaFolder(modName: String): FileHandle =
+        Gdx.files.local("mods").child(modName).child(mediaSubFolderName)
+
+    private fun FileHandle.directoryExists() = when {
+        type() != Files.FileType.Internal -> exists() && isDirectory
+        Gdx.app.type == Application.ApplicationType.Android -> isDirectory  // We accept that an empty folder is no folder in this case
+        isRunFromJar() -> exists()
+        else -> exists() && isDirectory
+    }
+
+    private fun listModFolders() = sequence {
+        // Order determines winner if several sources contain the same asset!
+        // todo: Can there be a deterministic priority/ordering within game mods or visualMods?
+
+        // Mods chosen in the running game go first
+        // - including BaseRuleset (which can be Vanilla/G&K but those don't have folders under local/mods), which always is first in Ruleset.mods
+        getRuleset()?.run { yieldAll(mods) }
+        // Permanent audiovisual mods next
+        if (UncivGame.isCurrentInitialized())
+            yieldAll(UncivGame.Current.settings.visualMods)
+        // Our caller will append the one builtin folder candidate (not here, as it's internal instead of local)
+    }.map { getModMediaFolder(it) }
+
+    //////////////////////////////////////////// Specializations
+
+    companion object {
+        private fun supportedAudioExtensions() = setOf(".mp3", ".ogg", ".wav")   // Per Gdx docs, no aac/m4a
+        private fun supportedImageExtensions() = setOf(".png", ".jpg", ".jpeg")
+        private fun isRunFromJar(): Boolean =
+            Gdx.app.type == Application.ApplicationType.Desktop &&
+            this::class.java.`package`.specificationVersion != null
+    }
+
+    open class Sounds : IMediaFinder {
+        override val mediaSubFolderName = "sounds"
+        override val supportedMediaExtensions = supportedAudioExtensions()
+
+        private val uncivSoundNames by lazy { uncivSoundNames().toList() }
+        private val unitAttackSounds by lazy { unitAttackSounds().map { it.second }.toList() }
+
+        override fun getInternalMediaNames(folder: FileHandle) = uncivSoundNames.asSequence() + unitAttackSounds
+
+        protected companion object {
+            // Warning: reflection monster to enumerate a non-enum.
+            fun uncivSoundNames() = UncivSound.Companion::class.declaredMemberProperties.asSequence()
+                .map { (it.get(UncivSound.Companion) as UncivSound).fileName }
+
+            // Extract Unit attack sounds from the larger vanilla ruleset
+            // Remember this replaces enumeration over *bundled* assets - not necessary for mods
+            // Keeps unit around not for this class but for the labeled version
+            fun unitAttackSounds(): Sequence<Pair<BaseUnit, String>> {
+                val ruleset = RulesetCache[BaseRuleset.Civ_V_GnK.fullName] ?: return emptySequence()
+                return ruleset.units.values.asSequence()
+                    .filter { it.attackSound != null }
+                    .distinctBy { it.attackSound }
+                    .map { it to it.attackSound!! }
+            }
+        }
+    }
+
+    open class Music : IMediaFinder {
+        override val mediaSubFolderName = "music"
+        override val supportedMediaExtensions = supportedAudioExtensions()
+        val names = sequenceOf("Thatched Villagers - Ambient")
+        override fun getInternalMediaNames(folder: FileHandle) = names
+    }
+
+    open class Voices : IMediaFinder {
+        override val mediaSubFolderName = "voices"
+        override val supportedMediaExtensions = supportedAudioExtensions()
+    }
+
+    open class Images : IMediaFinder {
+        override val mediaSubFolderName = "ExtraImages"
+        override val supportedMediaExtensions = supportedImageExtensions()
+        // no getInternalMediaNames - no listMediaFiles() for internal assets needed
+    }
+
+    /** Specialized subclass to provide all accessible sounds with a human-readable label.
+     *  - API: Use [getLabeledSounds] only.
+     *  - Note: Redesign if UncivSound should ever be made into or use an Enum, to store the label there.
+     */
+    open class LabeledSounds : Sounds() {
+        private companion object {
+            // Also determines display order
+            val prettifyUncivSoundNames = mapOf(
+                "" to "None",
+                "notification1" to "Notification [1]",
+                "notification2" to "Notification [2]",
+                "coin" to "Buy",
+                "construction" to "Create",
+                "paper" to "Pick a tech",
+                "policy" to "Adopt policy",
+                "setup" to "Set up",
+                "swap" to "Swap units",
+            )
+            // Previous code in createNotificationSoundOptions also excluded UncivSound.Whoosh - now included
+            val exclusions = setOf("nuke", "fire", "slider")
+        }
+
+        private val cache = mutableMapOf<String, String>()
+
+        fun getLabeledSounds(): Iterable<SettingsSelect.SelectItem<UncivSound>> {
+            fillCache()
+            return cache.asSequence()
+                .map { SettingsSelect.SelectItem(it.value, UncivSound(it.key)) }
+                .asIterable()
+        }
+
+        override fun listMediaFolders(): Sequence<FileHandle> =
+            throw UnsupportedOperationException("LabeledSounds does not support the normal IMediaFinder API")
+
+        private fun fillCache() {
+            if (cache.isNotEmpty()) return
+            cacheBuiltins()
+            cacheMods()
+            for (sound in exclusions) cache.remove(sound)
+        }
+
+        private fun cacheBuiltins() {
+            cache.putAll(prettifyUncivSoundNames)
+            for (sound in uncivSoundNames())
+                if (sound !in cache)
+                    cache[sound] = sound.replaceFirstChar(Char::titlecase)
+            for ((unit, sound) in unitAttackSounds())
+                cache[sound] = "[${unit.name}] Attack Sound"
+        }
+
+        private fun cacheMods() {
+            if (!UncivGame.isCurrentInitialized()) return
+            for (folder in super.listMediaFolders()) {
+                if (folder.type() == Files.FileType.Internal) continue
+                val mod = folder.parent().name()
+                val ruleset = RulesetCache[mod]
+                if (ruleset != null) {
+                    for (unit in ruleset.units.values) {
+                        val sound = unit.attackSound ?: continue
+                        if (sound in cache) continue
+                        cache[sound] = "${mod.take(32)}: {[${unit.name}] Attack Sound}"
+                    }
+                }
+                for (file in folder.list()) {
+                    val sound = file.nameWithoutExtension()
+                    if (sound in cache) continue
+                    cache[sound] = "${mod.take(32)}: ${sound.replaceFirstChar(Char::titlecase)} {}"
+                }
+            }
+        }
+    }
+}

--- a/core/src/com/unciv/models/UncivSound.kt
+++ b/core/src/com/unciv/models/UncivSound.kt
@@ -7,7 +7,8 @@ data class UncivSound(
     /** The base filename without extension. */
     val fileName: String
 ) {
-    /** For serialization */
+    /** For deserialization - used in [GameSettingsMultiplayer][com.unciv.models.metadata.GameSettings.GameSettingsMultiplayer] */
+    @Suppress("unused")
     private constructor() : this("")
 
     companion object {

--- a/core/src/com/unciv/ui/popups/options/MultiplayerTab.kt
+++ b/core/src/com/unciv/ui/popups/options/MultiplayerTab.kt
@@ -5,6 +5,7 @@ import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.scenes.scene2d.ui.TextField
 import com.unciv.UncivGame
+import com.unciv.logic.files.IMediaFinder
 import com.unciv.logic.multiplayer.OnlineMultiplayer
 import com.unciv.logic.multiplayer.storage.FileStorageRateLimitReached
 import com.unciv.logic.multiplayer.storage.MultiplayerAuthException
@@ -76,19 +77,18 @@ fun multiplayerTab(
         turnCheckerSelect = null
     }
 
+    val sounds = IMediaFinder.LabeledSounds().getLabeledSounds()
     addSelectAsSeparateTable(tab, SettingsSelect("Sound notification for when it's your turn in your currently open game:",
-        createNotificationSoundOptions(),
+        sounds,
         GameSetting.MULTIPLAYER_CURRENT_GAME_TURN_NOTIFICATION_SOUND,
         settings
-    )
-    )
+    ))
 
     addSelectAsSeparateTable(tab, SettingsSelect("Sound notification for when it's your turn in any other game:",
-        createNotificationSoundOptions(),
+        sounds,
         GameSetting.MULTIPLAYER_OTHER_GAME_TURN_NOTIFICATION_SOUND,
         settings
-    )
-    )
+    ))
 
     addSeparator(tab)
 
@@ -97,35 +97,6 @@ fun multiplayerTab(
     )
 
     return tab
-}
-
-private fun createNotificationSoundOptions(): List<SelectItem<UncivSound>> = listOf(
-    SelectItem("None", UncivSound.Silent),
-    SelectItem("Notification [1]", UncivSound.Notification1),
-    SelectItem("Notification [2]", UncivSound.Notification2),
-    SelectItem("Chimes", UncivSound.Chimes),
-    SelectItem("Choir", UncivSound.Choir),
-    SelectItem("Buy", UncivSound.Coin),
-    SelectItem("Create", UncivSound.Construction),
-    SelectItem("Fortify", UncivSound.Fortify),
-    SelectItem("Pick a tech", UncivSound.Paper),
-    SelectItem("Adopt policy", UncivSound.Policy),
-    SelectItem("Promote", UncivSound.Promote),
-    SelectItem("Set up", UncivSound.Setup),
-    SelectItem("Swap units", UncivSound.Swap),
-    SelectItem("Upgrade", UncivSound.Upgrade),
-    SelectItem("Bombard", UncivSound.Bombard)
-) + buildUnitAttackSoundOptions()
-
-private fun buildUnitAttackSoundOptions(): List<SelectItem<UncivSound>> {
-    return RulesetCache.getSortedBaseRulesets()
-        .asSequence()
-        .mapNotNull(RulesetCache::get)
-        .flatMap { it.units.values }
-        .filter { it.attackSound != null && it.attackSound != "nuke" } // much too long for a notification
-        .distinctBy { it.attackSound }
-        .map { SelectItem("[${it.name}] Attack Sound", UncivSound(it.attackSound!!)) }
-        .toList()
 }
 
 private fun addMultiplayerServerOptions(

--- a/core/src/com/unciv/ui/popups/options/SettingsSelect.kt
+++ b/core/src/com/unciv/ui/popups/options/SettingsSelect.kt
@@ -24,10 +24,10 @@ import kotlin.reflect.KMutableProperty0
  *
  * This will also automatically send [SettingsPropertyChanged] events.
  */
-open class SettingsSelect<T : Any>(
+open class SettingsSelect<T>(
     labelText: String,
     items: Iterable<SelectItem<T>>,
-    private val setting: GameSetting,
+    setting: GameSetting,
     settings: GameSettings
 ) {
     class SelectItem<T>(val label: String, val value: T) {

--- a/core/src/com/unciv/ui/popups/options/SettingsSelect.kt
+++ b/core/src/com/unciv/ui/popups/options/SettingsSelect.kt
@@ -54,7 +54,7 @@ open class SettingsSelect<T>(
         val selectBox = SelectBox<SelectItem<T>>(BaseScreen.skin)
         selectBox.items = initialItems
 
-        selectBox.selected = initialItems.firstOrNull { it.value == settingsProperty.get() } ?: items.first()
+        selectBox.selected = initialItems.firstOrNull { it.value == settingsProperty.get() } ?: initialItems.first()
         selectBox.onChange {
             val newValue = selectBox.selected.value
             settingsProperty.set(newValue)

--- a/tests/src/com/unciv/logic/MediaFinderTests.kt
+++ b/tests/src/com/unciv/logic/MediaFinderTests.kt
@@ -1,0 +1,60 @@
+package com.unciv.logic
+
+import com.badlogic.gdx.Gdx
+import com.unciv.UncivGame
+import com.unciv.logic.files.IMediaFinder
+import com.unciv.logic.files.UncivFiles
+import com.unciv.models.UncivSound
+import com.unciv.models.metadata.GameSettings
+import com.unciv.testing.GdxTestRunner
+import org.junit.Assert
+import org.junit.Ignore
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ *  Notes:
+ *  - These tests ***cannot*** test the most interesting aspect of IMediaFinder:
+ *    dealing with Gdx `FileHandle` limitations limiting `list()`, `exists()` or `isDirectory` in specific situations.
+ *    We're always running something close to desktop with unpacked assets files available.
+ *  - This could use a private instance of Sounds() or subclass it directly, but I chose to demonstrate
+ *    the (intended!) way to seamlessly attach the API to a class already deriving from another superclass.
+ */
+@RunWith(GdxTestRunner::class)
+class MediaFinderTests : IMediaFinder by IMediaFinder.Sounds() {
+    init {
+        UncivGame.Current = UncivGame()
+        UncivGame.Current.settings = GameSettings()
+        UncivGame.Current.files = UncivFiles(Gdx.files)
+    }
+
+    @Test
+    fun `Sound finder finds Chimes`() {
+        val chimes = findMedia(UncivSound.Chimes.fileName)
+        Assert.assertNotNull(chimes)
+    }
+
+    @Test
+    fun `Sound finder does not find bullshit`() {
+        val bullshit = findMedia("bullshit.nul")
+        Assert.assertNull(bullshit)
+    }
+
+    @Test
+    fun `Sound listing includes Chimes`() {
+        val sounds = listMediaFiles()
+        Assert.assertTrue(sounds.any { it.nameWithoutExtension() == "chimes" })
+    }
+
+    @Test
+    @Ignore("""
+        listMediaFiles can return an actual folder listing, which includes unit attack sounds,
+        city ambient sounds per era, and e.g. WLTK -
+        getInternalMediaNames fails in the sense that it does not derive or hardcode all of those
+        """)
+    fun `Sound listing does not include bullshit`() {
+        val sounds = listMediaFiles()
+        val internalSounds = getInternalMediaNames(Gdx.files.internal("")).toSet()
+        Assert.assertTrue(sounds.all { it.nameWithoutExtension() in internalSounds })
+    }
+}


### PR DESCRIPTION
... Actually, "New architecture to find any non-texture-atlas media" would be more fitting. but that title up there can go into the changelog.

No issue, this is for a slightly miscast "Modding request": [Allow any mod sound to be selected as a multiplayer turn notification sound.](https://github.com/yairm210/Unciv/issues/3242#issuecomment-2118884661) - borrowed the title even though my first one was a tad shorter.

This is the extreme version - started with "how would I imagine an easy to use yet still flexible tool to answer the question 'which media file if any should I use for a given key'..." and then coded top-down from the framework draft. I did not yet check whether the other intended clients do anything in a significantly different way. I suspect the priority between newgame-selected mods, perm audiovisual ones, and builtin is not always exactly the same - but it should be.

The ugliest part of that request is how to attach human-readable labels to sounds, the old solution to that was ugly, and it's not much better here. As mentioned in my replies to the above, moving UncivSound back to enum-based - nope, without large refactorings that ultimately fails on unexpected impediments. Refactoring all UncivSound usages to cleanly distinguish between the interface and the enum - possible, but not right now. Then once that enum exists, it could carry display labels... Again, not yet. But in here there's still a tricky little imp that still enumerates the existing UncivSound.X instances almost as if the container _were_ an enum. Almost moot since most instances need a mapped label anyway, but - had fun coding it.

No screenshots since I don't know of any suitable mod

@5cover - your idea and you mentioned PR'ing the same - so your review would welcome, s'il vous plaît.