### PR TITLE
Cleaner Json custom serialization and unit tests

### DIFF
--- a/core/src/com/unciv/json/UncivJson.kt
+++ b/core/src/com/unciv/json/UncivJson.kt
@@ -27,10 +27,6 @@ fun json() = Json(JsonWriter.OutputType.json).apply {
     setSerializer(HashMapVector2.getSerializerClass(), HashMapVector2.createSerializer())
     setSerializer(Duration::class.java, DurationSerializer())
     setSerializer(KeyCharAndCode::class.java, KeyCharAndCode.Serializer())
-    setSerializer(KeyboardBindings::class.java, KeyboardBindings.Serializer())
-    setSerializer(TileHistory::class.java, TileHistory.Serializer())
-    setSerializer(CivRankingHistory::class.java, CivRankingHistory.Serializer())
-    setSerializer(Notification::class.java, Notification.Serializer())
 }
 
 /**

--- a/core/src/com/unciv/logic/automation/civilization/BarbarianManager.kt
+++ b/core/src/com/unciv/logic/automation/civilization/BarbarianManager.kt
@@ -73,9 +73,9 @@ class BarbarianManager : IsPartOfGameInfoSerialization {
         encampments.firstOrNull { it.position == position }?.wasAttacked()
     }
 
-    fun placeBarbarianEncampment() {
+    fun placeBarbarianEncampment(forTesting: Boolean = false) {
         // Before we do the expensive stuff, do a roll to see if we will place a camp at all
-        if (gameInfo.turns > 1 && Random.Default.nextBoolean())
+        if (!forTesting && gameInfo.turns > 1 && Random.Default.nextBoolean())
             return
 
         // Barbarians will only spawn in places that no one can see

--- a/core/src/com/unciv/logic/civilization/CivRankingHistory.kt
+++ b/core/src/com/unciv/logic/civilization/CivRankingHistory.kt
@@ -6,8 +6,7 @@ import com.unciv.logic.IsPartOfGameInfoSerialization
 import com.unciv.ui.screens.victoryscreen.RankingType
 
 /** Records for each turn (key of outer map) what the score (value of inner map) was for each RankingType. */
-class CivRankingHistory : HashMap<Int, Map<RankingType, Int>>(),
-    IsPartOfGameInfoSerialization {
+class CivRankingHistory : HashMap<Int, Map<RankingType, Int>>(), IsPartOfGameInfoSerialization, Json.Serializable {
 
     /**
      * Returns a shallow copy of this [CivRankingHistory] instance.
@@ -24,34 +23,30 @@ class CivRankingHistory : HashMap<Int, Map<RankingType, Int>>(),
                 RankingType.values().associateWith { civilization.getStatForRanking(it) }
     }
 
-    /** Custom Json formatter for a [CivRankingHistory].
-     *  Output looks like this: `statsHistory:{0:{S:50,G:120,...},1:{S:55,G:80,...}}`
+    /** Implement Json.Serializable
+     *  - Output looked like this: `statsHistory:{0:{S:50,G:120,...},1:{S:55,G:80,...}}`
+     *    (but now we have turned off simplifed json, so it's properly quoted)
      */
-    class Serializer : Json.Serializer<CivRankingHistory> {
-        override fun write(json: Json, `object`: CivRankingHistory, knownType: Class<*>?) {
-            json.writeObjectStart()
-            for ((turn, rankings) in `object`) {
-                json.writeObjectStart(turn.toString())
-                for ((rankingType, score) in rankings) {
-                    json.writeValue(rankingType.idForSerialization, score)
-                }
-                json.writeObjectEnd()
+    override fun write(json: Json) {
+        for ((turn, rankings) in this) {
+            json.writeObjectStart(turn.toString())
+            for ((rankingType, score) in rankings) {
+                json.writeValue(rankingType.idForSerialization, score)
             }
             json.writeObjectEnd()
         }
+    }
 
-        override fun read(json: Json, jsonData: JsonValue, type: Class<*>?) =
-                CivRankingHistory().apply {
-                    for (entry in jsonData) {
-                        val turn = entry.name.toInt()
-                        val rankings = mutableMapOf<RankingType, Int>()
-                        for (rankingEntry in entry) {
-                            val rankingType = RankingType.fromIdForSerialization(rankingEntry.name)
-                                ?: continue  // Silently drop unknown ranking types.
-                            rankings[rankingType] = rankingEntry.asInt()
-                        }
-                        this[turn] = rankings
-                    }
-                }
+    override fun read(json: Json, jsonData: JsonValue) {
+        for (entry in jsonData) {
+            val turn = entry.name.toInt()
+            val rankings = mutableMapOf<RankingType, Int>()
+            for (rankingEntry in entry) {
+                val rankingType = RankingType.fromIdForSerialization(rankingEntry.name)
+                    ?: continue  // Silently drop unknown ranking types.
+                rankings[rankingType] = rankingEntry.asInt()
+            }
+            this[turn] = rankings
+        }
     }
 }

--- a/core/src/com/unciv/logic/map/tile/TileHistory.kt
+++ b/core/src/com/unciv/logic/map/tile/TileHistory.kt
@@ -5,21 +5,24 @@ import com.badlogic.gdx.utils.JsonValue
 import com.unciv.logic.IsPartOfGameInfoSerialization
 import com.unciv.logic.map.tile.TileHistory.TileHistoryState.CityCenterType
 import java.util.TreeMap
+import org.jetbrains.annotations.VisibleForTesting
 
 /**
  * Records events throughout the game related to a tile.
  *
  * Used for end of game replay.
  *
+ * @property history History records by turn.
  * @see com.unciv.ui.screens.victoryscreen.ReplayMap
  */
-class TileHistory : IsPartOfGameInfoSerialization {
-
+class TileHistory(
+    private val history: TreeMap<Int, TileHistoryState> = TreeMap()
+) : IsPartOfGameInfoSerialization, Iterable<MutableMap.MutableEntry<Int, TileHistory.TileHistoryState>> {
     class TileHistoryState(
         /** The name of the civilization owning this tile or `null` if there is no owner. */
-        var owningCivName: String? = null,
+        val owningCivName: String? = null,
         /** `null` if this tile does not have a city center. Otherwise this field denotes of which type this city center is. */
-        var cityCenterType: CityCenterType = CityCenterType.None
+        val cityCenterType: CityCenterType = CityCenterType.None
     ) : IsPartOfGameInfoSerialization {
         enum class CityCenterType(val serializedRepresentation: String) {
             None("N"),
@@ -42,9 +45,6 @@ class TileHistory : IsPartOfGameInfoSerialization {
         )
     }
 
-    /** History records by turn. */
-    private var history: TreeMap<Int, TileHistoryState> = TreeMap()
-
     fun recordTakeOwnership(tile: Tile) {
         history[tile.tileMap.gameInfo.turns] =
                 TileHistoryState(tile)
@@ -59,11 +59,7 @@ class TileHistory : IsPartOfGameInfoSerialization {
         return history.floorEntry(turn)?.value ?: TileHistoryState()
     }
 
-    fun clone(): TileHistory {
-        val toReturn = TileHistory()
-        toReturn.history = TreeMap(history)
-        return toReturn
-    }
+    fun clone(): TileHistory = TileHistory(TreeMap(history))
 
     /** Custom Json formatter for a [TileHistory].
      *  Output looks like this: `history:{0:[Spain,C],12:[China,R]}`
@@ -90,4 +86,12 @@ class TileHistory : IsPartOfGameInfoSerialization {
             }
         }
     }
+
+    @VisibleForTesting
+    fun addTestEntry(turn: Int, entry: TileHistoryState) {
+        history[turn] = entry
+    }
+
+    @VisibleForTesting
+    override fun iterator() = history.iterator()
 }

--- a/core/src/com/unciv/ui/components/input/KeyCharAndCode.kt
+++ b/core/src/com/unciv/ui/components/input/KeyCharAndCode.kt
@@ -102,6 +102,14 @@ data class KeyCharAndCode(val char: Char, val code: Int) {
             }
     }
 
+    /**
+     *  A Serializer that needs to be registered via [Json.setSerializer]
+     *  - Output syntax is just the string from toString() that will be parsed on deserialization,
+     *    e.g. "keyBindings":{"Diplomacy":"Ctrl-D","DeveloperConsole":"`"}
+     *  - Implementing [Json.Serializable] instead would be possible, but not allow the terse json syntax above, since that interface is restrictive:
+     *    1) It expects output to always use the object notation and writes the delimiters before you are asked to serialize.
+     *    2) it expects you to deserialize into a mutable default instance it has already instantiated for you.
+     */
     class Serializer : Json.Serializer<KeyCharAndCode> {
         override fun write(json: Json, key: KeyCharAndCode, knownType: Class<*>?) {
             // Gdx Json is.... No comment. This `Any` is needed to resolve the ambiguity between

--- a/core/src/com/unciv/ui/components/input/KeyboardBindings.kt
+++ b/core/src/com/unciv/ui/components/input/KeyboardBindings.kt
@@ -10,7 +10,7 @@ import com.unciv.GUI
  *  A primary instance lives in [UncivGame.Current.settings][com.unciv.models.metadata.GameSettings]
  *  and is read/write accessible through the `KeyboardBindings[]` syntax.
  **/
-class KeyboardBindings : HashMap<KeyboardBinding, KeyCharAndCode>() {
+class KeyboardBindings : HashMap<KeyboardBinding, KeyCharAndCode>(), Json.Serializable {
 
     /** this [put] overload helps the Json [Serializer] read method */
     private fun put(element: JsonValue) {
@@ -62,21 +62,17 @@ class KeyboardBindings : HashMap<KeyboardBinding, KeyCharAndCode>() {
     }
 
     /**
-     *  This class helps Gdx Json to read/write a readable, minimal serialization
+     *  Implementing Json.Serializable helps Gdx Json to read/write a readable, minimal serialization
      *  - without, KeyCharAndCode.Serializer.write will not be used properly
      */
-    class Serializer : Json.Serializer<KeyboardBindings> {
-        override fun write(json: Json, bindings: KeyboardBindings, knownType: Class<*>?) {
-            json.writeObjectStart()
-            for ((binding, key) in bindings) {
-                json.writeValue(binding.name, key, KeyCharAndCode::class.java)
-            }
-            json.writeObjectEnd()
+    override fun write(json: Json) {
+        for ((binding, key) in this) {
+            json.writeValue(binding.name, key, KeyCharAndCode::class.java)
         }
+    }
 
-        override fun read(json: Json, jsonData: JsonValue, type: Class<*>?) = KeyboardBindings().apply {
-            if (jsonData.isObject && jsonData.notEmpty())
-                for (element in jsonData) put(element)
-        }
+    override fun read(json: Json, jsonData: JsonValue) {
+        if (jsonData.isObject && jsonData.notEmpty())
+            for (element in jsonData) put(element)
     }
 }

--- a/tests/src/com/unciv/logic/GameSerializationTests.kt
+++ b/tests/src/com/unciv/logic/GameSerializationTests.kt
@@ -1,0 +1,128 @@
+package com.unciv.logic
+
+import com.badlogic.gdx.Gdx
+import com.unciv.Constants
+import com.unciv.UncivGame
+import com.unciv.json.json
+import com.unciv.logic.civilization.PlayerType
+import com.unciv.logic.files.UncivFiles
+import com.unciv.logic.map.MapParameters
+import com.unciv.logic.map.MapSize
+import com.unciv.logic.map.MapSizeNew
+import com.unciv.models.metadata.GameParameters
+import com.unciv.models.metadata.GameSettings
+import com.unciv.models.metadata.GameSetupInfo
+import com.unciv.models.metadata.Player
+import com.unciv.models.ruleset.RulesetCache
+import com.unciv.models.ruleset.unique.UniqueType
+import com.unciv.testing.GdxTestRunner
+import com.unciv.utils.Log
+import com.unciv.utils.debug
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+
+@RunWith(GdxTestRunner::class)
+class GameSerializationTests {
+
+    private var game = GameInfo()
+    private var settingsBackup = GameSettings()
+
+    /** A runtime Class object for [kotlin.SynchronizedLazyImpl] to enable helping Gdx.Json to
+     * not StackOverflow on them, as a direct compile time retrieval is forbidden */
+    private val classSynchronizedLazyImpl: Class<*> by lazy {
+        // I hope you get the irony...
+        @Suppress("unused") // No, test is not _directly_ used, only reflected on
+        class TestWithLazy { val test: Int by lazy { 0 } }
+        val badInstance = TestWithLazy()
+        val badField = badInstance::class.java.declaredFields[0]
+        badField.isAccessible = true
+        badField.get(badInstance)::class.java
+    }
+
+    @Before
+    fun prepareGame() {
+        RulesetCache.loadRulesets(noMods = true)
+
+        // Create a tiny game with just 1 human player and the barbarians
+        // Must be 1 human otherwise GameInfo.setTransients crashes on the `if (currentPlayer == "")` line
+        val param = GameParameters().apply {
+            numberOfCityStates = 0
+            players.clear()
+            players.add(Player("Rome", PlayerType.Human))
+            players.add(Player("Greece"))
+        }
+        val mapParameters = MapParameters().apply {
+            mapSize = MapSizeNew(MapSize.Tiny)
+            seed = 42L
+        }
+        val setup = GameSetupInfo(param, mapParameters)
+        UncivGame.Current = UncivGame()
+        UncivGame.Current.files = UncivFiles(Gdx.files)
+
+        // Both startNewGame and makeCivilizationsMeet will cause a save to storage of our empty settings
+        settingsBackup = UncivGame.Current.files.getGeneralSettings()
+
+        UncivGame.Current.settings = GameSettings()
+        game = GameStarter.startNewGame(setup)
+        UncivGame.Current.startSimulation(game)
+
+        // Found a city otherwise too many classes have no instance and are not tested
+        val civ = game.getCurrentPlayerCivilization()
+        val unit = civ.units.getCivUnits().first { it.hasUnique(UniqueType.FoundCity) }
+        val tile = unit.getTile()
+        unit.civ.addCity(tile.position)
+        if (tile.ruleset.tileImprovements.containsKey(Constants.cityCenter))
+            tile.changeImprovement(Constants.cityCenter)
+        unit.destroy()
+
+        // Ensure some diplomacy objects are instantiated
+        val otherCiv = game.getCivilization("Greece")
+        civ.diplomacyFunctions.makeCivilizationsMeet(otherCiv)
+
+        // Ensure a barbarian encampment is included
+        game.barbarians.placeBarbarianEncampment(forTesting = true)
+    }
+
+    @Test
+    fun canSerializeGame() {
+        val json = try {
+            json().toJson(game)
+        } catch (_: Exception) {
+            ""
+        }
+        Assert.assertTrue("This test will only pass when a game can be serialized", json.isNotEmpty())
+    }
+
+    @Test
+    fun serializedLaziesTest() {
+        val jsonSerializer = com.badlogic.gdx.utils.Json().apply {
+            setIgnoreDeprecated(true)
+            setDeprecated(classSynchronizedLazyImpl, "initializer", true)
+            setDeprecated(classSynchronizedLazyImpl, "lock", true)  // this is the culprit as kotlin initializes it to `this@SynchronizedLazyImpl`
+        }
+
+        val json = try {
+            jsonSerializer.toJson(game)
+        } catch (ex: Throwable) {
+            Log.error("Failed to serialize game", ex)
+            return
+        }
+
+        val pattern = """\{(\w+)\\${'$'}delegate:\{class:kotlin.SynchronizedLazyImpl,"""
+        val matches = Regex(pattern).findAll(json)
+        matches.forEach {
+            debug("Lazy missing `@delegate:Transient` annotation: %s", it.groups[1]!!.value)
+        }
+        val result = matches.any()
+        Assert.assertFalse("This test will only pass when no serializable lazy fields are found", result)
+    }
+
+    @After
+    fun cleanup() {
+        settingsBackup.save()
+    }
+}


### PR DESCRIPTION
See commit titles

main motivation: having a class declare they know hot to serialize themselves (instead of using a json-global hook) is a tiny little bit shorter, cleaner and easier to maintain. Back when some of these hooks were created I just didn't have enough insight to see the better alternative.

Notes:
- That rename of SerializationTests to GameSerializationTests and then adding back an empty SerializationTests wasn't properly seen as such by git, sorry. Motivation: The game instantiation in the `@Before` method is quite costly and I didn't want to have that ballast run for each new test - those don't need a game. And I didn't have a better ideas for test class names.
- Getting rid of KeyCharAndCode.Serializer would require using reflection to backpoke the values into a default instance, and break compatibility - nah
- Getting rid of HashMapVector2.createSerializer - oh my, I spent hours. Again.
    By now the only client is `Civilization.lastSeenImprovement` - I had some versions using companion `inline operator fun <reified T> invoke` to catch the generic type at instantiation, which is a superb trick, but directing Gdx to use the empty primary constructor (easy - unavoidable but it must exist) but _other_ callers to use the invoke _factory_ by steering with visibility is blocked by the compiler... The best I could come up with is an abstract - final hierarchy with an abstract getValueType, but while that works perfectly and is only a fraction of the code lines - I was unable to get backward compatibility into the mix...
- Having the tester reinvent equality contract for classes that don't have it is a questionable choice. But **implementing** the full equality contract on four classes that otherwise don't need it is too...