### PR TITLE
Espionage button cancels moving spy

### DIFF
--- a/core/src/com/unciv/ui/screens/worldscreen/TechPolicyDiplomacyButtons.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/TechPolicyDiplomacyButtons.kt
@@ -90,6 +90,11 @@ class TechPolicyDiplomacyButtons(val worldScreen: WorldScreen) : Table(BaseScree
         if (game.gameInfo!!.isEspionageEnabled()) {
             espionageButton.add(ImageGetter.getImage("OtherIcons/Espionage")).size(30f).pad(15f)
             espionageButtonHolder.onActivation(binding = KeyboardBinding.Espionage) {
+                // We want to make sure to deselect a spy in the case that the player wants to cancel moving
+                // the spy on the map screen by pressing this button
+                if (worldScreen.bottomUnitTable.selectedSpy != null) {
+                    worldScreen.bottomUnitTable.selectSpy(null)
+                }
                 game.pushScreen(EspionageOverviewScreen(worldScreen.selectedCiv, worldScreen))
             }
         }

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/UnitTable.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/UnitTable.kt
@@ -67,9 +67,9 @@ class UnitTable(val worldScreen: WorldScreen) : Table() {
     // Most of the time it's the same unit with the same stats so why waste precious time?
     private var selectedUnitHasChanged = false
     val separator: Actor
-    
+
     var selectedSpy: Spy? = null
-    
+
     fun selectSpy(spy: Spy?) {
         selectedSpy = spy
         selectedCity = null
@@ -252,12 +252,12 @@ class UnitTable(val worldScreen: WorldScreen) : Table() {
             unitNameLabel.clearListeners()
             unitNameLabel.setText(spy.name)
             unitDescriptionTable.clear()
-            
+
             unitIconHolder.clear()
             unitIconHolder.add (ImageGetter.getImage("OtherIcons/Spy_White").apply {
                 color = Color.WHITE
             }).size(30f)
-            
+
             separator.isVisible = true
             val color = when(spy.rank) {
                 1 -> Color.BROWN


### PR DESCRIPTION
Fixes part of #11587
Clicking the espionage button again should deselect the spy moving on the map. This PR simply deselects the spy if there was any when the espionage button is pressed.

<sub>And I also removed some extra white space, because now I am cursed with seeing the out of place dots as well.</sub>