### PR TITLE
Add Adjacent Tiles Multipled Object Stat Bonus

### DIFF
--- a/core/src/com/unciv/logic/city/CityStats.kt
+++ b/core/src/com/unciv/logic/city/CityStats.kt
@@ -172,6 +172,13 @@ class CityStats(val city: City) {
         return growthSources
     }
 
+    private fun getTileCountAdjacentToCity(city: City, tileFilter: String): Int {
+        val tileCount = city.getCenterTile().neighbors.count {
+            it.matchesFilter(tileFilter)
+        }
+        return tileCount
+    }
+
     fun hasExtraAnnexUnhappiness(): Boolean {
         if (city.civ.civName == city.foundingCiv || city.isPuppet) return false
         return !city.containsBuildingUnique(UniqueType.RemoveAnnexUnhappiness)
@@ -187,6 +194,18 @@ class CityStats(val city: City) {
         for (unique in localUniqueCache.forCityGetMatchingUniques(city, UniqueType.StatsFromObject))
             if (unique.params[1] == specialistName)
                 stats.add(unique.stats)
+        for (unique in localUniqueCache.forCityGetMatchingUniques(city, UniqueType.StatsFromObjectAdjacencyScaled))
+            if (unique.params[1] == specialistName)
+                stats.add(unique.stats * getTileCountAdjacentToCity(city, unique.params[2]))
+        for (unique in localUniqueCache.forCityGetMatchingUniques(city, UniqueType.StatsFromObjectAdjacencyScaledCapped))
+            if (unique.params[1] == specialistName) {
+                if (getTileCountAdjacentToCity(city, unique.params[2]) in unique.params[3].toInt()..unique.params[4].toInt()) {
+                    stats.add(unique.stats * getTileCountAdjacentToCity(city, unique.params[2]))
+                }
+                else if (getTileCountAdjacentToCity(city, unique.params[2]) > unique.params[4].toInt()) {
+                    stats.add(unique.stats * unique.params[4].toInt())
+                }
+            }
         return stats
     }
 

--- a/core/src/com/unciv/models/ruleset/Building.kt
+++ b/core/src/com/unciv/models/ruleset/Building.kt
@@ -89,6 +89,29 @@ class Building : RulesetStatsObject(), INonPerpetualConstruction {
             stats.add(unique.stats)
         }
 
+        for (unique in localUniqueCache.forCityGetMatchingUniques(city, UniqueType.StatsFromObjectAdjacencyScaled)) {
+            val adjacentTileCount = city.getCenterTile().neighbors.count {
+                it.matchesFilter(unique.params[2])
+            }
+
+            if (!matchesFilter(unique.params[1])) continue
+            stats.add(unique.stats * adjacentTileCount)
+        }
+
+        for (unique in localUniqueCache.forCityGetMatchingUniques(city, UniqueType.StatsFromObjectAdjacencyScaledCapped)) {
+            val adjacentTileCount = city.getCenterTile().neighbors.count {
+                it.matchesFilter(unique.params[2])
+            }
+
+            if (!matchesFilter(unique.params[1])) continue
+            if (adjacentTileCount in unique.params[3].toInt()..unique.params[4].toInt()) {
+                stats.add(unique.stats * adjacentTileCount)
+            }
+            else if (adjacentTileCount > unique.params[4].toInt()) {
+                stats.add(unique.stats * unique.params[4].toInt())
+            }
+        }
+
         for (unique in getMatchingUniques(UniqueType.Stats, StateForConditionals(city.civ, city)))
             stats.add(unique.stats)
 

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -61,6 +61,14 @@ enum class UniqueType(
 
     // endregion Stat providing uniques
 
+    // region Adjacency-Scaled Stat providing uniques
+    StatsFromObjectAdjacencyScaled("[stats] from every [tileFilter/specialist/buildingFilter] per every neighboring [tileFilter]", UniqueTarget.Global, UniqueTarget.FollowerBelief,
+        docDescription = "The stat bonus scale with the number of adjacent tiles, up to 6 times"),
+    StatsFromObjectAdjacencyScaledCapped("[stats] from every [tileFilter/specialist/buildingFilter] per every neighboring [tileFilter] (from [positiveAmount] to [positiveAmount])", UniqueTarget.Global, UniqueTarget.FollowerBelief,
+        docDescription = "Works similarly as previous unique, but the effect applies when the object is adjacent to at least X tiles, and is capped at following amount"),
+
+    // endregion Adjacency-Scaled Stat providing uniques
+
     // region City-State related uniques
 
     CityStateMilitaryUnits("Provides military units every ≈[amount] turns", UniqueTarget.CityState),

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -62,9 +62,9 @@ enum class UniqueType(
     // endregion Stat providing uniques
 
     // region Adjacency-Scaled Stat providing uniques
-    StatsFromObjectAdjacencyScaled("[stats] from every [tileFilter/specialist/buildingFilter] per every neighboring [tileFilter]", UniqueTarget.Global, UniqueTarget.FollowerBelief,
+    StatsFromObjectAdjacencyScaled("[stats] from every [tileFilter/specialist/buildingFilter] per every neighboring [tileFilter] tile", UniqueTarget.Global, UniqueTarget.FollowerBelief,
         docDescription = "The stat bonus scale with the number of adjacent tiles, up to 6 times"),
-    StatsFromObjectAdjacencyScaledCapped("[stats] from every [tileFilter/specialist/buildingFilter] per every neighboring [tileFilter] (from [positiveAmount] to [positiveAmount])", UniqueTarget.Global, UniqueTarget.FollowerBelief,
+    StatsFromObjectAdjacencyScaledCapped("[stats] from every [tileFilter/specialist/buildingFilter] per every neighboring [tileFilter] tile (from [positiveAmount] to [positiveAmount])", UniqueTarget.Global, UniqueTarget.FollowerBelief,
         docDescription = "Works similarly as previous unique, but the effect applies when the object is adjacent to at least X tiles, and is capped at following amount"),
 
     // endregion Adjacency-Scaled Stat providing uniques

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -348,6 +348,18 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 	Applicable to: Global, FollowerBelief
 
+??? example  "[stats] from every [tileFilter/specialist/buildingFilter] per every neighboring [tileFilter]"
+	The stat bonus scale with the number of adjacent tiles, up to 6 times
+	Example: "[+1 Gold, +2 Production] from every [Farm] per every neighboring [Farm]"
+
+	Applicable to: Global, FollowerBelief
+
+??? example  "[stats] from every [tileFilter/specialist/buildingFilter] per every neighboring [tileFilter] (from [positiveAmount] to [positiveAmount])"
+	Works similarly as previous unique, but the effect applies when the object is adjacent to at least X tiles, and is capped at following amount
+	Example: "[+1 Gold, +2 Production] from every [Farm] per every neighboring [Farm] (from [3] to [3])"
+
+	Applicable to: Global, FollowerBelief
+
 ??? example  "Military Units gifted from City-States start with [amount] XP"
 	Example: "Military Units gifted from City-States start with [3] XP"
 


### PR DESCRIPTION
I would like to implement two uniques that provide stat bonus to tiles, buildings and specialists multiplied by the number of adjacent tiles of specified type.

Their primary use cases are Civ 6 recreations mods, that heavily depend on the tile adjacency stat bonuses. Currently, the modders have to rely on repeated stat bonus uniques paired with conditional checking the amount of neighboring tiles of specified type. It looks like this:

```
"[+1 Production] from every [Manufactory] <with [1] to [1] neighboring [Mountain] tiles>",
"[+2 Production] from every [Manufactory] <with [2] to [2] neighboring [Mountain] tiles>",
"[+3 Production] from every [Manufactory] <with [3] to [3] neighboring [Mountain] tiles>",
"[+4 Production] from every [Manufactory] <with [4] to [4] neighboring [Mountain] tiles>",
"[+5 Production] from every [Manufactory] <with [5] to [5] neighboring [Mountain] tiles>",
"[+6 Production] from every [Manufactory] <with [6] to [6] neighboring [Mountain] tiles>",
``` 

Using my new uniques can shorten this to this:

```
"[+1 Production] from every [Manufactory] per every neighboring [Mountain] tile"
``` 

There is also a capped version of this unique:
```
"[stats] from every [tileFilter/specialist/buildingFilter] per every neighboring [tileFilter] tile (from [positiveAmount] to [positiveAmount])"
``` 

The first number in parentheses is the minimum number of neighboring tiles, that is necessary to trigger the effect. The second one is a multiplier cap, so if the number of matching tiles is above it, then it's capped to the upper limit.

If you have some remarks or questions, please share them below, as my code may contain errors and/or code smells. Constructive feedback is welcome, but please refrain from overly criticizing my pull request unless it's necessary. This is my first pull request of that size, so please be considerate towards my effort.