### PR TITLE
Some minor behind-the-scenes UI architecture changes

### DIFF
--- a/android/assets/jsons/Tutorials.json
+++ b/android/assets/jsons/Tutorials.json
@@ -425,7 +425,7 @@
         "name": "Keyboard Bindings",
         "civilopediaText": [
             {"text":"Limitations","header":3},
-            {"text":"This is a work in progress.","color":"#b22222","starred":true},
+            {"text":"This is a work in progress.","color":"FIREBRICK","starred":true},
             {"text":"For technical reasons, only direct keys or Ctrl-Letter combinations can be used.","starred":true},
             {},
             {"text":"Using the Keys page","header":3},

--- a/android/assets/jsons/Tutorials.json
+++ b/android/assets/jsons/Tutorials.json
@@ -237,11 +237,14 @@
   },
   {
     "name": "Keyboard",
-    "steps": [
-    "If you have a keyboard, some shortcut keys become available. Unit command or improvement picker keys, for example, are shown directly in their corresponding buttons.",
-    "On the world screen the hotkeys are as follows:", "Space or 'N' - Next unit or turn\n'E' - Empire overview (last viewed page)\n'+', '-' - Zoom in / out\nHome - center on capital or open its city screen if already centered",
-    "F1 - Open Civilopedia\nF2 - Empire overview Trades\nF3 - Empire overview Units\nF4 - Empire overview Diplomacy\nF5 - Social policies\nF6 - Technologies\nF7 - Empire overview Cities\nF8 - Victory Progress\nF9 - Empire overview Stats\nF10 - Empire overview Resources\nF11 - Quicksave\nF12 - Quickload",
-    "Ctrl-R - Toggle tile resource display\nCtrl-Y - Toggle tile yield display\nCtrl-O - Game options\nCtrl-S - Save game\nCtrl-L - Load game\nCtrl-U - Toggle UI (World Screen only)"
+      "civilopediaText": [
+          {"text": "If you have a keyboard, some shortcut keys become available. Unit command or improvement picker keys, for example, are shown directly in their corresponding buttons."},
+          {"text": "On the world screen the hotkeys are as follows:"},
+          {"text": "Space or 'N' - Next unit or turn\n'E' - Empire overview (last viewed page)\n'+', '-' - Zoom in / out\nHome - center on capital or open its city screen if already centered"},
+          {"text": "F1 - Open Civilopedia\nF2 - Empire overview Trades\nF3 - Empire overview Units\nF4 - Empire overview Diplomacy\nF5 - Social policies\nF6 - Technologies\nF7 - Empire overview Cities\nF8 - Victory Progress\nF9 - Empire overview Stats\nF10 - Empire overview Resources\nF11 - Quicksave\nF12 - Quickload"},
+          {"text": "Ctrl-R - Toggle tile resource display\nCtrl-Y - Toggle tile yield display\nCtrl-O - Game options\nCtrl-S - Save game\nCtrl-L - Load game\nCtrl-U - Toggle UI (World Screen only)"},
+          {},
+          {"text": "All of these can be reassigned.", "link": "Tutorial/Keyboard Bindings"}
     ]
   },
   {
@@ -424,7 +427,6 @@
             {"text":"Limitations","header":3},
             {"text":"This is a work in progress.","color":"#b22222","starred":true},
             {"text":"For technical reasons, only direct keys or Ctrl-Letter combinations can be used.","starred":true},
-            {"text":"The Escape key is intentionally excluded from being reassigned.","starred":true},
             {},
             {"text":"Using the Keys page","header":3},
             {"text":"Each binding has a button with an image looking like this:"},

--- a/core/src/com/unciv/ui/components/UncivTextField.kt
+++ b/core/src/com/unciv/ui/components/UncivTextField.kt
@@ -17,6 +17,7 @@ import com.unciv.ui.components.extensions.getOverlap
 import com.unciv.ui.components.extensions.right
 import com.unciv.ui.components.extensions.stageBoundingBox
 import com.unciv.ui.components.extensions.top
+import com.unciv.ui.components.input.keyShortcuts
 import com.unciv.ui.popups.Popup
 import com.unciv.ui.screens.basescreen.BaseScreen
 import com.unciv.ui.screens.basescreen.UncivStage
@@ -26,10 +27,18 @@ import kotlinx.coroutines.delay
 
 object UncivTextField {
     /**
-     * Creates a text field that has nicer platform-specific input added compared to the default gdx [TextField].
-     * @param hint The text that should be displayed in the text field when no text is entered, will automatically be translated
-     * @param preEnteredText The text already entered within this text field. Supported on all platforms.
-     * @param onFocusChange This will be called every time the field receives or loses focus. Receiver is the field, so you can simply use its elements. Parameter `it` is a Boolean indicating focus was received.
+     * Creates a text field that has nicer platform-specific input added compared to the default Gdx [TextField].
+     *
+     * - On Android, manages on-screen keyboard visibility and reacts to how the on-screen keyboard reduces screen space.
+     * - Tries to scroll the field into view when receiving focus using an ascendant ScrollPane.
+     * - If view of the field is still obscured, show am "emergency" Popup instead (can help when on Android the on-screen keyboard is large and the screen small).
+     * - If this TextField handles the Tab key (see [keyShortcuts]), its [focus navigation feature][TextField.next] is disabled (otherwise it would search for another TextField in the same parent to give focus to, and remove the on-screen keyboard if it finds none).
+     * - All parameters are supported on all platforms.
+     *
+     * @param hint The text that should be displayed in the text field when no text is entered and it does not have focus, will automatically be translated. Also shown as Label in the "emergency" Popup.
+     * @param preEnteredText the text initially entered within this text field.
+     * @param onFocusChange a callback that will be notified when this TextField loses or gains the [keyboardFocus][com.badlogic.gdx.scenes.scene2d.Stage.keyboardFocus].
+     *        Receiver is the field, so you can simply use its elements. Parameter `it` is a Boolean indicating focus was received.
      */
     fun create(hint: String, preEnteredText: String = "", onFocusChange: (TextField.(Boolean) -> Unit)? = null): TextField {
         @Suppress("UNCIV_RAW_TEXTFIELD")

--- a/core/src/com/unciv/ui/components/UncivTextField.kt
+++ b/core/src/com/unciv/ui/components/UncivTextField.kt
@@ -28,9 +28,10 @@ object UncivTextField {
     /**
      * Creates a text field that has nicer platform-specific input added compared to the default gdx [TextField].
      * @param hint The text that should be displayed in the text field when no text is entered, will automatically be translated
-     * @param preEnteredText the text already entered within this text field. Supported on all platforms.
+     * @param preEnteredText The text already entered within this text field. Supported on all platforms.
+     * @param onFocusChange This will be called every time the field receives or loses focus. Receiver is the field, so you can simply use its elements. Parameter `it` is a Boolean indicating focus was received.
      */
-    fun create(hint: String, preEnteredText: String = "", onFocusChange: ((Boolean) -> Unit)? = null): TextField {
+    fun create(hint: String, preEnteredText: String = "", onFocusChange: (TextField.(Boolean) -> Unit)? = null): TextField {
         @Suppress("UNCIV_RAW_TEXTFIELD")
         val textField = TextField(preEnteredText, BaseScreen.skin)
         val translatedHint = hint.tr()
@@ -40,7 +41,7 @@ object UncivTextField {
                 if (focused) {
                     textField.scrollAscendantToTextField()
                 }
-                onFocusChange?.invoke(focused)
+                onFocusChange?.invoke(textField, focused)
             }
         })
 

--- a/core/src/com/unciv/ui/objectdescriptions/BaseUnitDescriptions.kt
+++ b/core/src/com/unciv/ui/objectdescriptions/BaseUnitDescriptions.kt
@@ -201,7 +201,7 @@ object BaseUnitDescriptions {
         val imageName = "TileSets/${settings.unitSet}/Units/${baseUnit.name}"
         if (!ImageGetter.imageExists(imageName)) return  // Some units don't have Unit art (e.g. nukes)
         add(FormattedLine(extraImage = imageName, imageSize = settings.pediaUnitArtSize, centered = true))
-        add(FormattedLine(separator = true, color = "#7f7f7f"))
+        add(FormattedLine(separator = true, color = "GRAY"))
     }
 
     @Suppress("RemoveExplicitTypeArguments")  // for faster IDE - inferring sequence types can be slow

--- a/core/src/com/unciv/ui/popups/ToastPopup.kt
+++ b/core/src/com/unciv/ui/popups/ToastPopup.kt
@@ -11,9 +11,11 @@ import kotlinx.coroutines.delay
 
 /**
  * This is an unobtrusive popup which will close itself after a given amount of time.
- * Default time is two seconds (in milliseconds)
- *
- * Note: Supports color markup via [ColorMarkupLabel], using «» instead of Gdx's [].
+ * - Will show on top of other Popups, but not on top of other ToastPopups
+ * - Several calls in a short time will be shown sequentially, each "waiting their turn"
+ * - The user can close a Toast by clicking it
+ * - Supports color markup via [ColorMarkupLabel], using «» instead of Gdx's [].
+ * @param time Duration in milliseconds, defaults to 2 seconds
  */
 class ToastPopup (message: String, stageToShowOn: Stage, val time: Long = 2000) : Popup(stageToShowOn) {
 
@@ -29,9 +31,10 @@ class ToastPopup (message: String, stageToShowOn: Stage, val time: Long = 2000) 
             setAlignment(Align.center)
         }).width(stageToShowOn.width / 2)
 
-        open()
-        //move it to the top so its not in the middle of the screen
-        //have to be done after open() because open() centers the popup
+        open(force = stageToShowOn.actors.none { it is ToastPopup })
+
+        // move it to the top so its not in the middle of the screen
+        // has to be done after open() because open() centers the popup
         y = stageToShowOn.height - (height + 20f)
     }
 

--- a/core/src/com/unciv/ui/popups/options/AdvancedTab.kt
+++ b/core/src/com/unciv/ui/popups/options/AdvancedTab.kt
@@ -48,338 +48,341 @@ import kotlinx.coroutines.withContext
 import java.util.UUID
 import java.util.zip.Deflater
 
-fun advancedTab(
-    optionsPopup: OptionsPopup,
+class AdvancedTab(
+    private val optionsPopup: OptionsPopup,
     onFontChange: () -> Unit
-) = Table(BaseScreen.skin).apply {
-    pad(10f)
-    defaults().pad(5f)
+): Table(BaseScreen.skin) {
+    private val settings = optionsPopup.settings
 
-    val settings = optionsPopup.settings
+    init {
+        pad(10f)
+        defaults().pad(5f)
 
-    addAutosaveTurnsSelectBox(this, settings)
-    addSeparator(Color.GRAY)
+        addAutosaveTurnsSelectBox()
+        addSeparator(Color.GRAY)
 
-    if (Display.hasOrientation())
-        addOrientationSelectBox(this, optionsPopup)
+        if (Display.hasOrientation())
+            addOrientationSelectBox()
 
-    if (Display.hasCutout())
-        addCutoutCheckbox(this, optionsPopup)
+        if (Display.hasCutout())
+            addCutoutCheckbox()
 
-    if (Display.hasSystemUiVisibility())
-        addHideSystemUiCheckbox(this, optionsPopup)
+        if (Display.hasSystemUiVisibility())
+            addHideSystemUiCheckbox()
 
-    addFontFamilySelect(this, settings, optionsPopup.selectBoxMinWidth, onFontChange)
-    addFontSizeMultiplier(this, settings, onFontChange)
-    addSeparator(Color.GRAY)
+        addFontFamilySelect(onFontChange)
+        addFontSizeMultiplier(onFontChange)
+        addSeparator(Color.GRAY)
 
-    addMaxZoomSlider(this, settings)
+        addMaxZoomSlider()
 
-    addEasterEggsCheckBox(this, settings)
+        addEasterEggsCheckBox()
 
-    addEnlargeNotificationsCheckBox(this, settings)
-    addSeparator(Color.GRAY)
+        addEnlargeNotificationsCheckBox()
+        addSeparator(Color.GRAY)
 
-    addSetUserId(this, settings)
+        addSetUserId()
 
-    addTranslationGeneration(this, optionsPopup)
-}
-
-private fun addCutoutCheckbox(table: Table, optionsPopup: OptionsPopup) {
-    optionsPopup.addCheckbox(table, "Enable using display cutout areas", optionsPopup.settings.androidCutout)
-    {
-        optionsPopup.settings.androidCutout = it
-        Display.setCutout(it)
-        optionsPopup.reopenAfterDisplayLayoutChange()
-    }
-}
-
-private fun addHideSystemUiCheckbox(table: Table, optionsPopup: OptionsPopup) {
-    optionsPopup.addCheckbox(table, "Hide system status and navigation bars", optionsPopup.settings.androidHideSystemUi)
-    {
-        optionsPopup.settings.androidHideSystemUi = it
-        Display.setSystemUiVisibility(hide = it)
-        optionsPopup.reopenAfterDisplayLayoutChange()
-    }
-}
-
-private fun addOrientationSelectBox(table: Table, optionsPopup: OptionsPopup) {
-
-    val settings = optionsPopup.settings
-
-    table.add("Screen orientation".toLabel()).left().fillX()
-
-    val selectBox = SelectBox<ScreenOrientation>(table.skin)
-    selectBox.items = Array(ScreenOrientation.values())
-    selectBox.selected = settings.displayOrientation
-    selectBox.onChange {
-        val orientation = selectBox.selected
-        settings.displayOrientation = orientation
-        Display.setOrientation(orientation)
-        optionsPopup.reopenAfterDisplayLayoutChange()
+        addTranslationGeneration()
     }
 
-    table.add(selectBox).minWidth(optionsPopup.selectBoxMinWidth).pad(10f).row()
-}
-
-private fun addAutosaveTurnsSelectBox(table: Table, settings: GameSettings) {
-    table.add("Turns between autosaves".toLabel()).left().fillX()
-
-    val autosaveTurnsSelectBox = SelectBox<Int>(table.skin)
-    val autosaveTurnsArray = Array<Int>()
-    autosaveTurnsArray.addAll(1, 2, 5, 10)
-    autosaveTurnsSelectBox.items = autosaveTurnsArray
-    autosaveTurnsSelectBox.selected = settings.turnsBetweenAutosaves
-
-    table.add(autosaveTurnsSelectBox).pad(10f).row()
-
-    autosaveTurnsSelectBox.onChange {
-        settings.turnsBetweenAutosaves = autosaveTurnsSelectBox.selected
-    }
-}
-
-private fun addFontFamilySelect(table: Table, settings: GameSettings, selectBoxMinWidth: Float, onFontChange: () -> Unit) {
-    table.add("Font family".toLabel()).left().fillX()
-    val selectCell = table.add()
-    table.row()
-
-    fun loadFontSelect(fonts: Array<FontFamilyData>, selectCell: Cell<Actor>) {
-        if (fonts.isEmpty) return
-
-        val fontSelectBox = SelectBox<FontFamilyData>(table.skin)
-        fontSelectBox.items = fonts
-
-        // `FontFamilyData` implements kotlin equality contract such that _only_ the invariantName field is compared.
-        // The Gdx SelectBox should honor that - but it doesn't, as it is a _kotlin_ thing to implement
-        // `==` by calling `equals`, and there's precompiled _Java_ `==` in the widget code.
-        // `setSelected` first calls a `contains` which can switch between using `==` and `equals` (set to `equals`)
-        // but just one step later (where it re-checks whether the new selection is equal to the old one)
-        // it does a hard `==`. Also, setSelection copies its argument to the selection var, it doesn't pull a match from `items`.
-        // Therefore, _selecting_ an item in a `SelectBox` by an instance of `FontFamilyData` where only the `invariantName` is valid won't work properly.
-        //
-        // This is why it's _not_ `fontSelectBox.selected = FontFamilyData(settings.fontFamily)`
-        val fontToSelect = settings.fontFamilyData
-        fontSelectBox.selected = fonts.firstOrNull { it.invariantName == fontToSelect.invariantName } // will default to first entry if `null` is passed
-
-        selectCell.setActor(fontSelectBox).minWidth(selectBoxMinWidth).pad(10f)
-
-        fontSelectBox.onChange {
-            settings.fontFamilyData = fontSelectBox.selected
-            onFontChange()
+    private fun addCutoutCheckbox() {
+        optionsPopup.addCheckbox(this, "Enable using display cutout areas", settings.androidCutout) {
+            optionsPopup.settings.androidCutout = it
+            Display.setCutout(it)
+            optionsPopup.reopenAfterDisplayLayoutChange()
         }
     }
 
-    // This is a heavy operation and causes ANRs
-    Concurrency.run("Add Font Select") {
+    private fun addHideSystemUiCheckbox() {
+        optionsPopup.addCheckbox(this, "Hide system status and navigation bars", settings.androidHideSystemUi) {
+            optionsPopup.settings.androidHideSystemUi = it
+            Display.setSystemUiVisibility(hide = it)
+            optionsPopup.reopenAfterDisplayLayoutChange()
+        }
+    }
 
-        val fonts = Array<FontFamilyData>()
+    private fun addOrientationSelectBox() {
+        add("Screen orientation".toLabel()).left().fillX()
 
-        // Add default font
-        fonts.add(FontFamilyData.default)
+        val selectBox = SelectBox<ScreenOrientation>(skin)
+        selectBox.items = Array(ScreenOrientation.values())
+        selectBox.selected = settings.displayOrientation
+        selectBox.onChange {
+            val orientation = selectBox.selected
+            settings.displayOrientation = orientation
+            Display.setOrientation(orientation)
+            optionsPopup.reopenAfterDisplayLayoutChange()
+        }
 
-        // Add mods fonts
-        val modsDir = Gdx.files.local("mods/")
-        for (mod in modsDir.list()) {
+        add(selectBox).minWidth(optionsPopup.selectBoxMinWidth).pad(10f).row()
+    }
 
-            // Not a dir, continue
-            if (!mod.isDirectory)
-                continue
+    private fun addAutosaveTurnsSelectBox() {
+        add("Turns between autosaves".toLabel()).left().fillX()
 
-            val modFontsDir = mod.child("fonts")
+        val autosaveTurnsSelectBox = SelectBox<Int>(skin)
+        val autosaveTurnsArray = Array<Int>()
+        autosaveTurnsArray.addAll(1, 2, 5, 10)
+        autosaveTurnsSelectBox.items = autosaveTurnsArray
+        autosaveTurnsSelectBox.selected = settings.turnsBetweenAutosaves
 
-            // Mod doesn't have fonts, continue
-            if (!modFontsDir.exists())
-                continue
+        add(autosaveTurnsSelectBox).pad(10f).row()
 
-            // Find .ttf files and add construct FontFamilyData
-            for (fontFile in modFontsDir.list()) {
-                if (fontFile.extension().lowercase() == "ttf") {
-                    fonts.add(
-                        FontFamilyData(
-                            "${fontFile.nameWithoutExtension()} (${mod.name()})",
-                            fontFile.nameWithoutExtension(),
-                            fontFile.path())
-                    )
+        autosaveTurnsSelectBox.onChange {
+            settings.turnsBetweenAutosaves = autosaveTurnsSelectBox.selected
+        }
+    }
+
+    private fun addFontFamilySelect(onFontChange: () -> Unit) {
+        add("Font family".toLabel()).left().fillX()
+        val selectCell = add()
+        row()
+
+        fun loadFontSelect(fonts: Array<FontFamilyData>, selectCell: Cell<Actor>) {
+            if (fonts.isEmpty) return
+
+            val fontSelectBox = SelectBox<FontFamilyData>(skin)
+            fontSelectBox.items = fonts
+
+            // `FontFamilyData` implements kotlin equality contract such that _only_ the invariantName field is compared.
+            // The Gdx SelectBox should honor that - but it doesn't, as it is a _kotlin_ thing to implement
+            // `==` by calling `equals`, and there's precompiled _Java_ `==` in the widget code.
+            // `setSelected` first calls a `contains` which can switch between using `==` and `equals` (set to `equals`)
+            // but just one step later (where it re-checks whether the new selection is equal to the old one)
+            // it does a hard `==`. Also, setSelection copies its argument to the selection var, it doesn't pull a match from `items`.
+            // Therefore, _selecting_ an item in a `SelectBox` by an instance of `FontFamilyData` where only the `invariantName` is valid won't work properly.
+            //
+            // This is why it's _not_ `fontSelectBox.selected = FontFamilyData(settings.fontFamily)`
+            val fontToSelect = settings.fontFamilyData
+            fontSelectBox.selected = fonts.firstOrNull { it.invariantName == fontToSelect.invariantName } // will default to first entry if `null` is passed
+
+            selectCell.setActor(fontSelectBox).minWidth(optionsPopup.selectBoxMinWidth).pad(10f)
+
+            fontSelectBox.onChange {
+                settings.fontFamilyData = fontSelectBox.selected
+                onFontChange()
+            }
+        }
+
+        // This is a heavy operation and causes ANRs
+        Concurrency.run("Add Font Select") {
+
+            val fonts = Array<FontFamilyData>()
+
+            // Add default font
+            fonts.add(FontFamilyData.default)
+
+            // Add mods fonts
+            val modsDir = Gdx.files.local("mods/")
+            for (mod in modsDir.list()) {
+
+                // Not a dir, continue
+                if (!mod.isDirectory)
+                    continue
+
+                val modFontsDir = mod.child("fonts")
+
+                // Mod doesn't have fonts, continue
+                if (!modFontsDir.exists())
+                    continue
+
+                // Find .ttf files and add construct FontFamilyData
+                for (fontFile in modFontsDir.list()) {
+                    if (fontFile.extension().lowercase() == "ttf") {
+                        fonts.add(
+                            FontFamilyData(
+                                "${fontFile.nameWithoutExtension()} (${mod.name()})",
+                                fontFile.nameWithoutExtension(),
+                                fontFile.path()
+                            )
+                        )
+                    }
+                }
+
+            }
+
+            // Add system fonts
+            for (font in Fonts.getSystemFonts())
+                fonts.add(font)
+
+            launchOnGLThread { loadFontSelect(fonts, selectCell) }
+        }
+    }
+
+    private fun addFontSizeMultiplier(onFontChange: () -> Unit) {
+        add("Font size multiplier".toLabel()).left().fillX().padTop(5f)
+
+        val fontSizeSlider = UncivSlider(
+            0.7f, 1.5f, 0.05f,
+            initial = settings.fontSizeMultiplier
+        ) {
+            settings.fontSizeMultiplier = it
+        }
+        fontSizeSlider.onChange {
+            if (!fontSizeSlider.isDragging)
+                onFontChange()
+        }
+        add(fontSizeSlider).pad(5f).padTop(10f).row()
+    }
+
+    private fun addMaxZoomSlider() {
+        add("Max zoom out".tr()).left().fillX().padTop(5f)
+        val maxZoomSlider = UncivSlider(
+            2f, 6f, 1f,
+            initial = settings.maxWorldZoomOut
+        ) {
+            settings.maxWorldZoomOut = it
+            if (GUI.isWorldLoaded())
+                GUI.getMap().reloadMaxZoom()
+        }
+        add(maxZoomSlider).pad(5f).padTop(10f).row()
+    }
+
+    private fun addTranslationGeneration() {
+        if (Gdx.app.type != Application.ApplicationType.Desktop) return
+
+        val generateTranslationsButton = "Generate translation files".toTextButton()
+
+        generateTranslationsButton.onActivation {
+            optionsPopup.tabs.selectPage("Advanced")  // only because key F12 works from any page
+            generateTranslationsButton.setText(Constants.working.tr())
+            Concurrency.run("WriteTranslations") {
+                val result = TranslationFileWriter.writeNewTranslationFiles()
+                launchOnGLThread {
+                    // notify about completion
+                    generateTranslationsButton.setText(result.tr())
+                    generateTranslationsButton.disable()
                 }
             }
-
         }
 
-        // Add system fonts
-        for (font in Fonts.getSystemFonts())
-            fonts.add(font)
+        generateTranslationsButton.keyShortcuts.add(Input.Keys.F12)
+        generateTranslationsButton.addTooltip("F12", 18f)
+        add(generateTranslationsButton).colspan(2).row()
 
-        launchOnGLThread { loadFontSelect(fonts, selectCell) }
-    }
-}
-
-private fun addFontSizeMultiplier(
-    table: Table,
-    settings: GameSettings,
-    onFontChange: () -> Unit
-) {
-    table.add("Font size multiplier".toLabel()).left().fillX().padTop(5f)
-
-    val fontSizeSlider = UncivSlider(
-        0.7f, 1.5f, 0.05f,
-        initial = settings.fontSizeMultiplier
-    ) {
-        settings.fontSizeMultiplier = it
-    }
-    fontSizeSlider.onChange {
-        if (!fontSizeSlider.isDragging)
-            onFontChange()
-    }
-    table.add(fontSizeSlider).pad(5f).padTop(10f).row()
-}
-
-private fun addMaxZoomSlider(table: Table, settings: GameSettings) {
-    table.add("Max zoom out".tr()).left().fillX().padTop(5f)
-    val maxZoomSlider = UncivSlider(
-        2f, 6f, 1f,
-        initial = settings.maxWorldZoomOut
-    ) {
-        settings.maxWorldZoomOut = it
-        if (GUI.isWorldLoaded())
-            GUI.getMap().reloadMaxZoom()
-    }
-    table.add(maxZoomSlider).pad(5f).padTop(10f).row()
-}
-
-private fun addTranslationGeneration(table: Table, optionsPopup: OptionsPopup) {
-    if (Gdx.app.type != Application.ApplicationType.Desktop) return
-
-    val generateTranslationsButton = "Generate translation files".toTextButton()
-
-    generateTranslationsButton.onActivation {
-        optionsPopup.tabs.selectPage("Advanced")  // only because key F12 works from any page
-        generateTranslationsButton.setText(Constants.working.tr())
-        Concurrency.run("WriteTranslations") {
-            val result = TranslationFileWriter.writeNewTranslationFiles()
-            launchOnGLThread {
-                // notify about completion
-                generateTranslationsButton.setText(result.tr())
-                generateTranslationsButton.disable()
+        val updateModCategoriesButton = "Update Mod categories".toTextButton()
+        updateModCategoriesButton.onActivation {
+            updateModCategoriesButton.setText(Constants.working.tr())
+            Concurrency.run("GithubTopicQuery") {
+                val result = ModCategories.mergeOnline()
+                launchOnGLThread {
+                    updateModCategoriesButton.setText(result)
+                }
             }
         }
-    }
+        add(updateModCategoriesButton).colspan(2).row()
 
-    generateTranslationsButton.keyShortcuts.add(Input.Keys.F12)
-    generateTranslationsButton.addTooltip("F12", 18f)
-    table.add(generateTranslationsButton).colspan(2).row()
+        if (!UncivGame.Current.files.getSave("ScreenshotGenerationGame").exists()) return
 
-    val updateModCategoriesButton = "Update Mod categories".toTextButton()
-    updateModCategoriesButton.onActivation {
-        updateModCategoriesButton.setText(Constants.working.tr())
-        Concurrency.run("GithubTopicQuery") {
-            val result = ModCategories.mergeOnline()
-            launchOnGLThread {
-                updateModCategoriesButton.setText(result)
+        val generateScreenshotsButton = "Generate screenshots".toTextButton()
+
+        generateScreenshotsButton.onActivation {
+            generateScreenshotsButton.setText(Constants.working.tr())
+            Concurrency.run("GenerateScreenshot") {
+                val extraImagesLocation = "../../extraImages"
+                // I'm not sure why we need to advance the y by 2 for every screenshot... but that's the only way it remains centered
+                generateScreenshots(
+                    optionsPopup.settings, arrayListOf(
+                        ScreenshotConfig(630, 500, ScreenSize.Medium, "$extraImagesLocation/itch.io image.png", Vector2(-2f, 2f), false),
+                        ScreenshotConfig(1280, 640, ScreenSize.Medium, "$extraImagesLocation/GithubPreviewImage.png", Vector2(-2f, 4f)),
+                        ScreenshotConfig(1024, 500, ScreenSize.Medium, "$extraImagesLocation/Feature graphic - Google Play.png", Vector2(-2f, 6f)),
+                        ScreenshotConfig(1024, 500, ScreenSize.Medium, "../../fastlane/metadata/android/en-US/images/featureGraphic.png", Vector2(-2f, 8f))
+                    )
+                )
             }
         }
-    }
-    table.add(updateModCategoriesButton).colspan(2).row()
 
-    if (!UncivGame.Current.files.getSave("ScreenshotGenerationGame").exists()) return
-
-    val generateScreenshotsButton = "Generate screenshots".toTextButton()
-
-    generateScreenshotsButton.onActivation {
-        generateScreenshotsButton.setText(Constants.working.tr())
-        Concurrency.run("GenerateScreenshot") {
-            val extraImagesLocation = "../../extraImages"
-            // I'm not sure why we need to advance the y by 2 for every screenshot... but that's the only way it remains centered
-            generateScreenshots(optionsPopup.settings, arrayListOf(
-                ScreenshotConfig(630, 500, ScreenSize.Medium, "$extraImagesLocation/itch.io image.png", Vector2(-2f, 2f),false),
-                ScreenshotConfig(1280, 640, ScreenSize.Medium, "$extraImagesLocation/GithubPreviewImage.png", Vector2(-2f, 4f)),
-                ScreenshotConfig(1024, 500, ScreenSize.Medium, "$extraImagesLocation/Feature graphic - Google Play.png",Vector2(-2f, 6f)),
-                ScreenshotConfig(1024, 500, ScreenSize.Medium, "../../fastlane/metadata/android/en-US/images/featureGraphic.png",Vector2(-2f, 8f))
-            ))
-        }
+        add(generateScreenshotsButton).colspan(2).row()
     }
 
-    table.add(generateScreenshotsButton).colspan(2).row()
-}
+    data class ScreenshotConfig(
+        val width: Int,
+        val height: Int,
+        val screenSize: ScreenSize,
+        var fileLocation: String,
+        var centerTile: Vector2,
+        var attackCity: Boolean = true
+    )
 
-data class ScreenshotConfig(val width: Int, val height: Int, val screenSize: ScreenSize, var fileLocation: String, var centerTile: Vector2, var attackCity: Boolean = true)
-
-private fun CoroutineScope.generateScreenshots(settings: GameSettings, configs: ArrayList<ScreenshotConfig>) {
-    val currentConfig = configs.first()
-    launchOnGLThread {
-        val screenshotGame =
+    private fun CoroutineScope.generateScreenshots(settings: GameSettings, configs: ArrayList<ScreenshotConfig>) {
+        val currentConfig = configs.first()
+        launchOnGLThread {
+            val screenshotGame =
                 UncivGame.Current.files.loadGameByName("ScreenshotGenerationGame")
-        settings.screenSize = currentConfig.screenSize
-        val newScreen = UncivGame.Current.loadGame(screenshotGame)
-        newScreen.stage.viewport.update(currentConfig.width, currentConfig.height, true)
+            settings.screenSize = currentConfig.screenSize
+            val newScreen = UncivGame.Current.loadGame(screenshotGame)
+            newScreen.stage.viewport.update(currentConfig.width, currentConfig.height, true)
 
-        // Reposition mapholder and minimap whose position was based on the previous stage size...
-        newScreen.mapHolder.setSize(newScreen.stage.width, newScreen.stage.height)
-        newScreen.mapHolder.layout()
-        newScreen.minimapWrapper.x = newScreen.stage.width - newScreen.minimapWrapper.width
+            // Reposition mapholder and minimap whose position was based on the previous stage size...
+            newScreen.mapHolder.setSize(newScreen.stage.width, newScreen.stage.height)
+            newScreen.mapHolder.layout()
+            newScreen.minimapWrapper.x = newScreen.stage.width - newScreen.minimapWrapper.width
 
-        newScreen.mapHolder.setCenterPosition( // Center on the city
-            currentConfig.centerTile,
-            immediately = true,
-            selectUnit = true
-        )
+            newScreen.mapHolder.setCenterPosition( // Center on the city
+                currentConfig.centerTile,
+                immediately = true,
+                selectUnit = true
+            )
 
-        newScreen.mapHolder.onTileClicked(newScreen.mapHolder.tileMap[-2, 3]) // Then click on Keshik
-        if (currentConfig.attackCity)
-            newScreen.mapHolder.onTileClicked(newScreen.mapHolder.tileMap[-2, 2]) // Then click city again for attack table
-        newScreen.mapHolder.zoomIn(true)
-        withContext(Dispatchers.IO) {
-            Thread.sleep(300)
-            launchOnGLThread {
-                val pixmap = Pixmap.createFromFrameBuffer(
-                    0, 0,
-                    currentConfig.width, currentConfig.height
-                )
-                PixmapIO.writePNG(
-                    FileHandle(currentConfig.fileLocation),
-                    pixmap,
-                    Deflater.DEFAULT_COMPRESSION,
-                    true
-                )
-                pixmap.dispose()
-                val newConfigs = configs.withoutItem(currentConfig)
-                if (newConfigs.isNotEmpty()) generateScreenshots(settings, newConfigs)
+            newScreen.mapHolder.onTileClicked(newScreen.mapHolder.tileMap[-2, 3]) // Then click on Keshik
+            if (currentConfig.attackCity)
+                newScreen.mapHolder.onTileClicked(newScreen.mapHolder.tileMap[-2, 2]) // Then click city again for attack table
+            newScreen.mapHolder.zoomIn(true)
+            withContext(Dispatchers.IO) {
+                Thread.sleep(300)
+                launchOnGLThread {
+                    val pixmap = Pixmap.createFromFrameBuffer(
+                        0, 0,
+                        currentConfig.width, currentConfig.height
+                    )
+                    PixmapIO.writePNG(
+                        FileHandle(currentConfig.fileLocation),
+                        pixmap,
+                        Deflater.DEFAULT_COMPRESSION,
+                        true
+                    )
+                    pixmap.dispose()
+                    val newConfigs = configs.withoutItem(currentConfig)
+                    if (newConfigs.isNotEmpty()) generateScreenshots(settings, newConfigs)
+                }
             }
         }
     }
-}
 
-private fun addSetUserId(table: Table, settings: GameSettings) {
-    val idSetLabel = "".toLabel()
-    val takeUserIdFromClipboardButton = "Take user ID from clipboard".toTextButton()
-        .onClick {
-            try {
-                val clipboardContents = Gdx.app.clipboard.contents.trim()
-                UUID.fromString(clipboardContents)
-                ConfirmPopup(
-                    table.stage,
-                    "Doing this will reset your current user ID to the clipboard contents - are you sure?",
-                    "Take user ID from clipboard"
-                ) {
-                    settings.multiplayer.userId = clipboardContents
-                    idSetLabel.setFontColor(Color.WHITE).setText("ID successfully set!".tr())
-                }.open(true)
-                idSetLabel.isVisible = true
-            } catch (_: Exception) {
-                idSetLabel.isVisible = true
-                idSetLabel.setFontColor(Color.RED).setText("Invalid ID!".tr())
+    private fun addSetUserId() {
+        val idSetLabel = "".toLabel()
+        val takeUserIdFromClipboardButton = "Take user ID from clipboard".toTextButton()
+            .onClick {
+                try {
+                    val clipboardContents = Gdx.app.clipboard.contents.trim()
+                    UUID.fromString(clipboardContents)
+                    ConfirmPopup(
+                        stage,
+                        "Doing this will reset your current user ID to the clipboard contents - are you sure?",
+                        "Take user ID from clipboard"
+                    ) {
+                        settings.multiplayer.userId = clipboardContents
+                        idSetLabel.setFontColor(Color.WHITE).setText("ID successfully set!".tr())
+                    }.open(true)
+                    idSetLabel.isVisible = true
+                } catch (_: Exception) {
+                    idSetLabel.isVisible = true
+                    idSetLabel.setFontColor(Color.RED).setText("Invalid ID!".tr())
+                }
             }
-        }
-    table.add(takeUserIdFromClipboardButton).pad(5f).colspan(2).row()
-    table.add(idSetLabel).colspan(2).row()
-}
+        add(takeUserIdFromClipboardButton).pad(5f).colspan(2).row()
+        add(idSetLabel).colspan(2).row()
+    }
 
-private fun addEasterEggsCheckBox(table: Table, settings: GameSettings) {
-    val checkbox = "Enable Easter Eggs".toCheckBox(settings.enableEasterEggs) { settings.enableEasterEggs = it }
-    table.add(checkbox).colspan(2).row()
-}
+    private fun addEasterEggsCheckBox() {
+        val checkbox = "Enable Easter Eggs".toCheckBox(settings.enableEasterEggs) { settings.enableEasterEggs = it }
+        add(checkbox).colspan(2).row()
+    }
 
-private fun addEnlargeNotificationsCheckBox(table: Table, settings: GameSettings) {
-    val checkbox = "Enlarge selected notifications"
-        .toCheckBox(settings.enlargeSelectedNotification) { settings.enlargeSelectedNotification = it }
-    table.add(checkbox).colspan(2).row()
+    private fun addEnlargeNotificationsCheckBox() {
+        val checkbox = "Enlarge selected notifications"
+            .toCheckBox(settings.enlargeSelectedNotification) { settings.enlargeSelectedNotification = it }
+        add(checkbox).colspan(2).row()
+    }
 }

--- a/core/src/com/unciv/ui/popups/options/DebugTab.kt
+++ b/core/src/com/unciv/ui/popups/options/DebugTab.kt
@@ -75,13 +75,6 @@ fun debugTab(
         MapSaver.saveZipped = it
     }).colspan(2).row()
 
-    if (GUI.keyboardAvailable) {
-        add("Show keyboard bindings".toCheckBox(optionsPopup.enableKeyBindingsTab) {
-            optionsPopup.enableKeyBindingsTab = it
-            optionsPopup.showOrHideKeyBindings()
-        }).colspan(2).row()
-    }
-
     add("Gdx Scene2D debug".toCheckBox(BaseScreen.enableSceneDebug) {
         BaseScreen.enableSceneDebug = it
     }).colspan(2).row()

--- a/core/src/com/unciv/ui/popups/options/DebugTab.kt
+++ b/core/src/com/unciv/ui/popups/options/DebugTab.kt
@@ -138,7 +138,7 @@ fun debugTab(
                 optionsPopup.game.loadGame(loadedGame, callFromLoadScreen =  true)
                 optionsPopup.close()
             } catch (ex: Exception) {
-                ToastPopup(ex.message ?: ex::class.java.simpleName, optionsPopup.stageToShowOn).open(true)
+                ToastPopup(ex.message ?: ex::class.java.simpleName, optionsPopup.stageToShowOn)
             }
         }
     }).colspan(2).row()

--- a/core/src/com/unciv/ui/popups/options/KeyBindingsTab.kt
+++ b/core/src/com/unciv/ui/popups/options/KeyBindingsTab.kt
@@ -27,7 +27,7 @@ class KeyBindingsTab(
     private val groupedWidgets by lazy { createGroupedWidgets() }
 
     private val disclaimer = MarkupRenderer.render(listOf(
-        FormattedLine("This is a work in progress.", color = "#b22222", centered = true),  // FIREBRICK
+        FormattedLine("This is a work in progress.", color = "FIREBRICK", centered = true),
         FormattedLine(),
         // FormattedLine("Do not pester the developers for missing entries!"),  // little joke
         FormattedLine("Please see the Tutorial.", link = "Tutorial/Keyboard Bindings"),

--- a/core/src/com/unciv/ui/popups/options/ModCheckTab.kt
+++ b/core/src/com/unciv/ui/popups/options/ModCheckTab.kt
@@ -256,7 +256,7 @@ class ModCheckTab(
             file.writeString(newFileText, false)
         }
         val toastText = "Uniques updated!"
-        ToastPopup(toastText, screen).open(true)
+        ToastPopup(toastText, screen)
         runModChecker()
     }
 }

--- a/core/src/com/unciv/ui/popups/options/OptionsPopup.kt
+++ b/core/src/com/unciv/ui/popups/options/OptionsPopup.kt
@@ -42,17 +42,10 @@ class OptionsPopup(
     val selectBoxMinWidth: Float
     private val tabMinWidth: Float
 
-    private var keyBindingsTab: KeyBindingsTab? = null
-    /** Enable the still experimental Keyboard Bindings page in OptionsPopup */
-    var enableKeyBindingsTab: Boolean = true
-
     //endregion
 
     companion object {
         const val defaultPage = 2  // Gameplay
-
-        const val keysTabCaption = "Keys"
-        const val keysTabBeforeCaption = "Advanced"
     }
 
     init {
@@ -112,6 +105,14 @@ class OptionsPopup(
             ImageGetter.getImage("OtherIcons/Multiplayer"), 24f
         )
 
+        if (GUI.keyboardAvailable) {
+            tabs.addPage(
+                "Keys",
+                KeyBindingsTab(this, tabMinWidth - 40f),  // 40 = padding
+                ImageGetter.getImage("OtherIcons/Keyboard"), 24f
+            )
+        }
+
         tabs.addPage(
             "Advanced",
             AdvancedTab(this, ::reloadWorldAndOptions),
@@ -134,10 +135,6 @@ class OptionsPopup(
             onClose() // activate the passed 'on close' callback
             close() // close this popup
         })
-
-        if (GUI.keyboardAvailable) {
-            showOrHideKeyBindings()  // Do this late because it looks for the page to insert before
-        }
 
         pack() // Needed to show the background.
         center(screen.stage)
@@ -207,26 +204,6 @@ class OptionsPopup(
         addCheckbox(table, text, settingsProperty.get(), updateWorld) {
             action(it)
             settingsProperty.set(it)
-        }
-    }
-
-    internal fun showOrHideKeyBindings() {
-        // At the moment, the Key bindings Tab exists only on-demand. To refactor it back to permanent,
-        // move the `keyBindingsTab =` line and addPage call to before the Advanced Tab creation,
-        // then delete this function, delete the enableKeyBindingsTab flag and clean up what is flagged
-        // by the compiler as missing or unused - like the `add("Show keyboard bindings".toCheckBox` option on DebugTab.
-        val existingIndex = tabs.getPageIndex(keysTabCaption)
-        if (enableKeyBindingsTab && existingIndex < 0) {
-            if (keyBindingsTab == null)
-                keyBindingsTab = KeyBindingsTab(this, tabMinWidth - 40f)  // 40 = padding
-            val beforeIndex = tabs.getPageIndex(keysTabBeforeCaption)
-            tabs.addPage(
-                keysTabCaption, keyBindingsTab,
-                ImageGetter.getImage("OtherIcons/Keyboard"), 24f,
-                insertBefore = beforeIndex
-            )
-        } else if (!enableKeyBindingsTab && existingIndex >= 0) {
-            tabs.removePage(existingIndex)
         }
     }
 }

--- a/core/src/com/unciv/ui/popups/options/OptionsPopup.kt
+++ b/core/src/com/unciv/ui/popups/options/OptionsPopup.kt
@@ -114,7 +114,7 @@ class OptionsPopup(
 
         tabs.addPage(
             "Advanced",
-            advancedTab(this, ::reloadWorldAndOptions),
+            AdvancedTab(this, ::reloadWorldAndOptions),
             ImageGetter.getImage("OtherIcons/Settings"), 24f
         )
 
@@ -129,9 +129,9 @@ class OptionsPopup(
         tabs.decorateHeader(getCloseButton {
             screen.game.musicController.onChange(null)
             center(screen.stage)
-            keyBindingsTab?.save()
+            tabs.selectPage(-1, false)
             settings.save()
-            onClose() // activate the passed 'on close' button
+            onClose() // activate the passed 'on close' callback
             close() // close this popup
         })
 

--- a/core/src/com/unciv/ui/screens/civilopediascreen/CivilopediaSearchPopup.kt
+++ b/core/src/com/unciv/ui/screens/civilopediascreen/CivilopediaSearchPopup.kt
@@ -80,7 +80,7 @@ class CivilopediaSearchPopup(
                 val regex = Regex(text, RegexOption.IGNORE_CASE)
                 checkLine = { regex.containsMatchIn(it) }
             } catch (ex: Exception) {
-                ToastPopup("Invalid regular expression", pediaScreen, 4000).open(true)
+                ToastPopup("Invalid regular expression", pediaScreen, 4000)
                 searchButton.enable()
                 return
             }

--- a/core/src/com/unciv/ui/screens/mainmenuscreen/MainMenuScreen.kt
+++ b/core/src/com/unciv/ui/screens/mainmenuscreen/MainMenuScreen.kt
@@ -350,7 +350,7 @@ class MainMenuScreen: BaseScreen(), RecreateOnResize {
         UncivGame.Current.translations.translationActiveMods = ruleset.mods
         ImageGetter.setNewRuleset(ruleset)
         setSkin()
-        openCivilopedia(ruleset)
+        openCivilopedia(ruleset, link = link)
     }
 
     override fun recreate(): BaseScreen {

--- a/core/src/com/unciv/ui/screens/modmanager/ModManagementScreen.kt
+++ b/core/src/com/unciv/ui/screens/modmanager/ModManagementScreen.kt
@@ -423,7 +423,6 @@ class ModManagementScreen private constructor(
                 val repo = GithubAPI.Repo.parseUrl(textField.text)
                 if (repo == null) {
                     ToastPopup("«RED»{Invalid link!}«»", this@ModManagementScreen)
-                        .apply { isVisible = true }
                     actualDownloadButton.setText("Download".tr())
                     actualDownloadButton.enable()
                 } else


### PR DESCRIPTION
- Removed the debug switch for the key bindings tab in options
- A few tutorial tweaks to go with that - was tempted to remove the "work in progress" too but - later.
- ToastPopup was used on top of other Popups via the horrible kludge to call `open(force=true)` again. This had the side effect to re-center the Toast on the screen back from its moved-up position. It also wouldn't play nice if you manage to trigger several such Toasts within their timeout. Only one place used isVisible instead, still a kludge. Now, as coder, you can just create the instance and forget about it. All Toasts are back at the same top position.
- Timo's arguements back then when he converted the class-based OptionsPopup tabs into loose collections of top-level functions - well, I forgot. But we accepted. Or do I remember that entirely wrong? (somewhere around #6857) Now I believe that's too much sacrifice... This flips just the advanced tab back to the class model, because I might be needing the IPageExtensions interface there soon.
- Save tab data on deselect and deselecting all tabs on close is the extensible approach, no need to tell all tabs separately to save.
- And a bugfix for a dumb oversight in (#11590) - hard to find the effect though