### PR TITLE
Fix bug in ModConstants handling

### DIFF
--- a/android/assets/jsons/Civ V - Gods & Kings/Buildings.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Buildings.json
@@ -407,7 +407,7 @@
 		"culture": 3,
 		"greatPersonPoints": {"Great Engineer": 1},
 		"isWonder": true,
-		"uniques": ["Enemy [Land] units must spend [1] extra movement points when inside your territory <before discovering [Dynamite]>",
+		"uniques": ["Enemy [Land] units must spend [1] extra movement points when inside your territory <before discovering [Dynamite]> <Suppress warning [*contains a conditional on a unit movement unique*]>",
 			"Gain a free [Walls] [in this city]"],
 		"requiredTech": "Engineering",
 		"quote": "'The art of war teaches us to rely not on the likelihood of the enemy's not attacking, but rather on the fact that we have made our position unassailable.' - Sun Tzu"

--- a/android/assets/jsons/Civ V - Gods & Kings/Nations.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Nations.json
@@ -539,7 +539,7 @@
 		"innerColor": [255,255,75],
 		"favoredReligion": "Christianity",
 		"uniqueName": "Wayfinding",
-		"uniques": ["Enables embarkation for land units <starting from the [Ancient era]>",
+		"uniques": ["Enables embarkation for land units <starting from the [Ancient era]> <Suppress warning [*contains a conditional on a unit movement unique*]>",
             "Enables [All] units to enter ocean tiles <starting from the [Ancient era]>",
             "[+1] Sight <for [Embarked] units>",  "[+10]% Strength <within [2] tiles of a [Moai]>"],
 		"cities": ["Honolulu","Samoa","Tonga","Nuku Hiva","Raiatea","Aotearoa","Tahiti","Hilo","Te Wai Pounamu","Rapa Nui",

--- a/android/assets/jsons/Civ V - Vanilla/Buildings.json
+++ b/android/assets/jsons/Civ V - Vanilla/Buildings.json
@@ -254,7 +254,7 @@
 		"culture": 3,
 		"greatPersonPoints": {"Great Engineer": 1},
 		"isWonder": true,
-		"uniques": ["Enemy [Land] units must spend [1] extra movement points when inside your territory <before discovering [Dynamite]>",
+		"uniques": ["Enemy [Land] units must spend [1] extra movement points when inside your territory <before discovering [Dynamite]> <Suppress warning [*contains a conditional on a unit movement unique*]>",
 			"Gain a free [Walls] [in this city]"],
 		"requiredTech": "Construction",
 		"quote": "'The art of war teaches us to rely not on the likelihood of the enemy's not attacking, but rather on the fact that we have made our position unassailable.' - Sun Tzu"

--- a/android/assets/jsons/Civ V - Vanilla/Nations.json
+++ b/android/assets/jsons/Civ V - Vanilla/Nations.json
@@ -500,7 +500,7 @@
 		"outerColor": [217,89,0],
 		"innerColor": [255,255,75],
 		"uniqueName": "Wayfinding",
-		"uniques": ["Enables embarkation for land units <starting from the [Ancient era]>",
+		"uniques": ["Enables embarkation for land units <starting from the [Ancient era]> <Suppress warning [*contains a conditional on a unit movement unique*]>",
             "Enables [All] units to enter ocean tiles <starting from the [Ancient era]>",
             "[+1] Sight <for [Embarked] units>",
             "[+10]% Strength <within [2] tiles of a [Moai]>"],

--- a/core/src/com/unciv/models/ModConstants.kt
+++ b/core/src/com/unciv/models/ModConstants.kt
@@ -1,5 +1,7 @@
 package com.unciv.models
 
+import java.lang.reflect.Modifier
+
 /** Used as a member of [ModOptions][com.unciv.models.ruleset.ModOptions] for moddable "constants" - factors in formulae and such.
  *
  *  When combining mods, this is [merge]d _per constant/field_, not as entire object like other RulesetObjects.
@@ -8,8 +10,9 @@ package com.unciv.models
  *
  *  Supports equality contract to enable the Json serializer to recognize unchanged defaults.
  *
- *  Methods [merge], [equals] and [hashCode] are done through reflection so adding a field will not need to update these methods
- *  (overhead is not a factor, these routines run very rarely).
+ *  Methods [merge], [equals], [hashCode] and [toString] are done through reflection!
+ *  Therefore, adding a field will not need to update these methods, but all members ***must*** conform to the equality contract.
+ *  (overhead is not a factor, these routines run very rarely. The alternative would be to make the entire thing a data class.)
  */
 class ModConstants {
     // Max amount of experience that can be gained from combat with barbarians
@@ -86,6 +89,7 @@ class ModConstants {
 
     fun merge(other: ModConstants) {
         for (field in this::class.java.declaredFields) {
+            if (field.modifiers and Modifier.STATIC != 0) continue
             val value = field.get(other)
             if (field.get(defaults).equals(value)) continue
             field.set(this, value)
@@ -99,8 +103,14 @@ class ModConstants {
     }
 
     override fun hashCode(): Int {
+        // Note: This is of course heavily dependent on iteration order.
+        // Java reflection uses declaration order, but its doc claims "The elements in the returned array are not sorted and are not in any particular order."
+        // kotlin reflection is alphabetically sorted. Embarrassingly, the best documentation guarantee seems to be: https://youtrack.jetbrains.com/issue/KT-41042
+        // But - let's rely on at least the order being deterministic over instances of the same class in both reflection engines, so which we use is moot.
+        // A kotlin version of this (different result!): `this::class.declaredMemberProperties.fold(0) { a, b -> a * 31 + b.getter.call(this).hashCode() }`
         var result = 0
         for (field in this::class.java.declaredFields) {
+            if (field.modifiers and Modifier.STATIC != 0) continue
             result = result * 31 + field.get(this).hashCode()
         }
         return result
@@ -108,9 +118,27 @@ class ModConstants {
 
     private fun equalsReflected(other: ModConstants): Boolean {
         for (field in this::class.java.declaredFields) {
+            if (field.modifiers and Modifier.STATIC != 0) continue
             if (!field.get(this).equals(field.get(other))) return false
         }
         return true
+    }
+
+    /** Debug only so far */
+    override fun toString(): String {
+        val sb = StringBuilder()
+        sb.append('{')
+        for (field in this::class.java.declaredFields) {
+            if (field.modifiers and Modifier.STATIC != 0) continue
+            if (field.get(this).equals(field.get(defaults))) continue
+            sb.append(field.name)
+            sb.append(':')
+            sb.append(field.get(this))
+            sb.append(',')
+        }
+        sb.deleteCharAt(sb.length - 1) // remove extra ',' with StringBuilder method
+        sb.append('}')
+        return sb.toString().takeUnless { it == "}" } ?: "defaults"
     }
 
     companion object {

--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -473,7 +473,7 @@ class Ruleset {
     override fun toString() = when {
         name.isNotEmpty() -> name
         mods.size == 1 && RulesetCache[mods.first()]!!.modOptions.isBaseRuleset -> mods.first()
-        else -> "Combined RuleSet"
+        else -> "Combined RuleSet ($mods)"
     }
 
     fun getSummary(): String {

--- a/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
+++ b/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
@@ -785,7 +785,7 @@ class RulesetValidator(val ruleset: Ruleset) {
 
     private fun checkTilesetSanity(lines: RulesetErrorList) {
         // If running from a jar *and* checking a builtin ruleset, skip this check.
-        // - We can't list() the jsons, and the unit test before relase is sufficient, the tileset config can't have changed since then.
+        // - We can't list() the jsons, and the unit test before release is sufficient, the tileset config can't have changed since then.
         if (ruleset.folderLocation == null && this::class.java.`package`?.specificationVersion != null)
             return
 

--- a/core/src/com/unciv/ui/images/AtlasPreview.kt
+++ b/core/src/com/unciv/ui/images/AtlasPreview.kt
@@ -12,6 +12,7 @@ import java.io.File
 
 /**
  *  This extracts all texture names from all atlases of a Ruleset.
+ *  - Weak point: For combined rulesets, this always loads the builtin assets.
  *  - Used by RulesetValidator to check texture names without relying on ImageGetter
  *  - Doubles as integrity checker and detects:
  *      - Atlases.json names an atlas that does not exist

--- a/tests/src/com/unciv/logic/ModConstantsTests.kt
+++ b/tests/src/com/unciv/logic/ModConstantsTests.kt
@@ -1,0 +1,52 @@
+package com.unciv.logic
+
+import com.unciv.models.ModConstants
+import com.unciv.testing.GdxTestRunner
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.math.ulp
+
+/**
+ *  These exist because the ModConstants class makes its extensibility easier by using reflection to include new members automatically.
+ *
+ *  There was a bug in an earlier version where includion of the companion object created a recursion.
+ *  This prevents such occurrences and guards against side effects from library/jvm changes.
+ */
+@RunWith(GdxTestRunner::class)
+class ModConstantsTests {
+    @Test
+    fun `Test ModConstants hashCode`() {
+        val hash1 = ModConstants.defaults.hashCode()
+        val hash2 = ModConstants().hashCode()
+        Assert.assertEquals(hash1, hash2)
+    }
+
+    @Test
+    fun `Test ModConstants equals`() {
+        val instance1 = ModConstants().apply { maxXPfromBarbarians = 99 }
+        val instance2 = ModConstants().apply { cityStrengthBase = 6.0 }
+        Assert.assertNotEquals(instance1, instance2)
+        instance1.cityStrengthBase = instance2.cityStrengthBase
+        instance2.maxXPfromBarbarians = instance1.maxXPfromBarbarians
+        Assert.assertEquals(instance1, instance2)
+    }
+
+    @Test
+    fun `Test ModConstants toString`() {
+        val instance1 = ModConstants().apply {
+            maxXPfromBarbarians = 99
+            cityStrengthBase = 6.0
+        }
+        Assert.assertEquals(instance1.toString(), "{maxXPfromBarbarians:99,cityStrengthBase:6.0}")
+        Assert.assertEquals(ModConstants.defaults.toString(), "defaults")
+    }
+
+    @Test
+    fun `Test ModConstants merge`() {
+        val instance1 = ModConstants().apply { maxXPfromBarbarians = 99 }
+        val instance2 = ModConstants().apply { cityStrengthBase = 6.0 }
+        instance1.merge(instance2)
+        Assert.assertEquals(instance1.cityStrengthBase, 6.0, 1.0.ulp)
+    }
+}


### PR DESCRIPTION
No idea why the bug that the second commit fixes doesn't crash us all the time - but it made the debugger sluggish.

First commit suppresses the green warnings in mod checks of Vanilla and G&K - mostly because - they are also shown in any combined mod check for expansion mods.

The problem I originally set out to fix here is not treated (except 1 comment) - need idea first.
- The civilopediaText extraImage checker uses AtlasPreview - the test is fine when a mod is checked standalone.
- But - if the user switches to a check combining with a base ruleset, then AtlasPreview will contain only the vanilla textures, no matter which base ruleset was chosen.
- That quirk didn't trip up checkTilesetSanity - that check validates vanilla textures against vanilla tilesetconfigs in that case, again no matter which base ruleset was chosen.
- I suspect the way to go is to teach AtlasPreview to load multiple mod assets too - but I'm not sure yet.

If you have an opinion on whether the reflection in ModConstants should stay Java or switch to Kotlin...? I left it as java despite generally advocating using kotlin tools, mainly because - they supported `field.get(this)` just fine a while ago, but now that syntax gives you inane errors, and `field.getter.call(this)` is so much uglier.

Edit: Another inconsistency in mod checking I noticed: The separation between getBaseRulesetErrorList and getNonBaseRulesetErrorList has debatable consequences - a terrain unique on a wrong target in an expansion mod is always an error, it's RulesetInvariant, but **only shows** when the mod is checked against a base. Long ago such errors would always show. Now, there is no addTerrainErrorsRulesetInvariant. Are we to code all these missing variants to check uniques properly? Which brings me to - the existing calls are differently sorted in the two master functions. Resort so missing ones are easier to see or is order important?