### PR TITLE
Centralize and organize use of special unicode codepoints

### DIFF
--- a/core/src/com/unciv/ui/components/fonts/Fonts.kt
+++ b/core/src/com/unciv/ui/components/fonts/Fonts.kt
@@ -98,6 +98,7 @@ object Fonts {
         return pixmap
     }
 
+    //region Symbols added to font from atlas textures
     const val turn = '⏳'               // U+23F3 'hourglass'
     const val strength = '†'            // U+2020 'dagger'
     const val rangedStrength = '‡'      // U+2021 'double dagger'
@@ -122,7 +123,21 @@ object Fonts {
     const val greatScientist = '⚛'      // U+269B 'atom'
     const val death = '☠'               // U+2620 'skull and crossbones'
     const val automate = '⛏'            // U+26CF 'pick'
-    const val infinity = '∞'            // U+221E - not in `allSymbols`, taken as-is from system font
+
+    //region Symbols that can be optionally added to the font from atlas textures
+    // (a mod can override these, otherwise the font supplies the glyph)
+    const val infinity = '∞'            // U+221E
+    const val clock = '⌚'               // U+231A 'watch'
+    const val star = '✯'                // U+272F 'pinwheel star'
+    const val status = '◉'              // U+25C9 'fisheye'
+    // The following two are used for sort visualization.
+    // They may disappear (show as placeholder box) on Linux if you clean out asian fonts.
+    // Alternatives: "↑" U+2191, "↓" U+2193 - much wider and weird spacing in some fonts (e.g. Verdana).
+    // These are possibly the highest codepoints in use in Unciv -
+    // Taken into account when limiting FontRulesetIcons codepoints (it respects the private area ending at U+F8FF)
+    const val sortUpArrow = '￪'         // U+FFEA 'half wide upward arrow'
+    const val sortDownArrow = '￬'       // U+FFEC 'half wide downward arrow'
+    //endregion
 
     val allSymbols = mapOf(
         turn to "EmojiIcons/Turn",
@@ -144,6 +159,14 @@ object Fonts {
         greatScientist to "EmojiIcons/Great Scientist",
         death to "EmojiIcons/Death",
         automate to "EmojiIcons/Automate",
+        infinity to "EmojiIcons/Infinity",
+        clock to "EmojiIcons/SortedByTime",
+        star to "EmojiIcons/Star",
+        status to "EmojiIcons/SortedByStatus",
+        sortUpArrow to "EmojiIcons/SortedAscending",
+        sortDownArrow to "EmojiIcons/SortedDescending",
         *MayaCalendar.allSymbols
     )
+    //endregion
+
 }

--- a/core/src/com/unciv/ui/components/fonts/NativeBitmapFontData.kt
+++ b/core/src/com/unciv/ui/components/fonts/NativeBitmapFontData.kt
@@ -137,17 +137,18 @@ class NativeBitmapFontData(
         Fonts.extractPixmapFromTextureRegion(ImageGetter.getDrawable(regionName).region)
 
     private fun getPixmapFromChar(ch: Char): Pixmap {
-        return when (ch) {
-            in Fonts.allSymbols -> getPixmapForTextureName(Fonts.allSymbols[ch]!!)
-            in FontRulesetIcons.charToRulesetImageActor ->
-                try {
+        val textureName = Fonts.allSymbols[ch]
+        if (textureName != null && ImageGetter.imageExists(textureName))
+            return getPixmapForTextureName(textureName)
+        val actor = FontRulesetIcons.charToRulesetImageActor[ch]
+        if (actor != null)
+            return try {
                     // This sometimes fails with a "Frame buffer couldn't be constructed: incomplete attachment" error, unclear why
-                    FontRulesetIcons.getPixmapFromActor(FontRulesetIcons.charToRulesetImageActor[ch]!!)
+                    FontRulesetIcons.getPixmapFromActor(actor)
                 } catch (_: Exception) {
                     Pixmap(0, 0, Pixmap.Format.RGBA8888) // Empty space
                 }
-            else -> fontImplementation.getCharPixmap(ch)
-        }
+        return fontImplementation.getCharPixmap(ch)
     }
 
     override fun getGlyphs(run: GlyphLayout.GlyphRun, str: CharSequence, start: Int, end: Int, lastGlyph: BitmapFont.Glyph?) {

--- a/core/src/com/unciv/ui/components/widgets/SortableGrid.kt
+++ b/core/src/com/unciv/ui/components/widgets/SortableGrid.kt
@@ -14,6 +14,7 @@ import com.unciv.ui.components.extensions.addSeparator
 import com.unciv.ui.components.extensions.center
 import com.unciv.ui.components.extensions.pad
 import com.unciv.ui.components.extensions.toLabel
+import com.unciv.ui.components.fonts.Fonts
 import com.unciv.ui.components.input.onClick
 import com.unciv.ui.screens.basescreen.BaseScreen
 
@@ -121,13 +122,10 @@ class SortableGrid<IT, ACT, CT: ISortableGridContentProvider<IT, ACT>> (
     }
 
     private fun initHeader() {
-        // These are possibly the highest codepoints in use in Unciv -
-        // Take into account when limiting Fonts.nextUnusedCharacterNumber
-        // Alternatives: "↑" U+2191, "↓" U+2193 - much wider and weird spacing in some fonts (e.g. Verdana)
         // Note: These will scale with GameSettings.fontSizeMultiplier - could be *partly* countered
         // with `toLabel(fontSize = (Constants.defaultFontSize / GUI.getSettings().fontSizeMultiplier).toInt())`
-        sortSymbols[false] = "￪".toLabel()  // U+FFEA
-        sortSymbols[true] = "￬".toLabel()   // U+FFEC
+        sortSymbols[false] = Fonts.sortUpArrow.toString().toLabel()
+        sortSymbols[true] = Fonts.sortDownArrow.toString().toLabel()
 
         for (column in columns) {
             val group = HeaderGroup(column)

--- a/core/src/com/unciv/ui/screens/modmanager/ModManagementOptions.kt
+++ b/core/src/com/unciv/ui/screens/modmanager/ModManagementOptions.kt
@@ -11,6 +11,7 @@ import com.unciv.ui.components.UncivTextField
 import com.unciv.ui.components.UncivTooltip.Companion.addTooltip
 import com.unciv.ui.components.extensions.surroundWithCircle
 import com.unciv.ui.components.extensions.toLabel
+import com.unciv.ui.components.fonts.Fonts
 import com.unciv.ui.components.input.KeyCharAndCode
 import com.unciv.ui.components.input.keyShortcuts
 import com.unciv.ui.components.input.onActivation
@@ -51,13 +52,13 @@ internal class ModManagementOptions(private val modManagementScreen: ModManageme
         val symbols: String,
         val comparator: Comparator<in ModUIData>
     ) {
-        Name("Name ￪", "￪", sortByName),
-        NameDesc("Name ￬", "￬", sortByNameDesc),
-        Date("Date ￪", "⌚￪", sortByDate),
-        DateDesc("Date ￬", "⌚￬", sortByDateDesc),
-        Stars("Stars ￬", "✯￬", sortByStars),
-        Status("Status ￬", "◉￬", sortByStatus);
-
+        Name("Name ${Fonts.sortUpArrow}", Fonts.sortUpArrow.toString(), sortByName),
+        NameDesc("Name ${Fonts.sortDownArrow}", Fonts.sortDownArrow.toString(), sortByNameDesc),
+        Date("Date ${Fonts.sortUpArrow}", "${Fonts.clock}${Fonts.sortUpArrow}", sortByDate),
+        DateDesc("Date ${Fonts.sortDownArrow}", "${Fonts.clock}${Fonts.sortDownArrow}", sortByDateDesc),
+        Stars("Stars ${Fonts.sortDownArrow}", "${Fonts.star}${Fonts.sortDownArrow}", sortByStars),
+        Status("Status ${Fonts.sortDownArrow}", "${Fonts.status}${Fonts.sortDownArrow}", sortByStatus)
+        ;
         fun next() = values()[(ordinal + 1) % values().size]
 
         companion object {

--- a/core/src/com/unciv/ui/screens/modmanager/ModUIData.kt
+++ b/core/src/com/unciv/ui/screens/modmanager/ModUIData.kt
@@ -4,6 +4,7 @@ import com.unciv.logic.github.GithubAPI
 import com.unciv.models.metadata.ModCategories
 import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.translations.tr
+import com.unciv.ui.components.fonts.Fonts
 
 /** Helper class holds combined mod info for ModManagementScreen, used for both installed and online lists.
  *
@@ -30,7 +31,7 @@ internal class ModUIData private constructor(
     constructor(repo: GithubAPI.Repo, isUpdated: Boolean): this (
         repo.name,
         (repo.description ?: "-{No description provided}-".tr()) +
-                "\n" + "[${repo.stargazers_count}]✯".tr(),
+                "\n" + "[${repo.stargazers_count}]${Fonts.star}".tr(),
         null, repo, hasUpdate = isUpdated
     )
 

--- a/docs/Modders/Images-and-Audio.md
+++ b/docs/Modders/Images-and-Audio.md
@@ -96,6 +96,62 @@ You can add custom `.ttf` fonts into the game: place `.ttf` file inside of `/fon
 
 All fonts are rendered by default at 50 pixel size and rescaled later for the game's needs. Currently fonts are NOT mipmapped on minification.
 
+### Overriding special characters
+
+The textures in the EmojiIcons subfolder and some others are mapped into the font at specific codepoints. They are used by the game, can be used in any text of a mod, and can be overridden by mod textures.
+Additionally, some code points are normally provided by the chosen system font, but have EmojiIcons names that will override the font glyph if a mod supplies them (marked 'optional' in the table below).
+
+| Symbol | Codepoint | Unicode name                       | Texture path                | Optional |
+|:------:|:---------:|:-----------------------------------|:----------------------------|:--------:|
+|   ⛏    |  U+26CF   | pick                               | EmojiIcons/Automate         |          |
+|   ♪    |  U+266A   | eighth note                        | EmojiIcons/Culture          |          |
+|   ☠    |  U+2620   | skull and crossbones               | EmojiIcons/Death            |          |
+|   ☮    |  U+262E   | peace symbol                       | EmojiIcons/Faith            |          |
+|   ⁂    |  U+2042   | asterism                           | EmojiIcons/Food             |          |
+|   ¤    |  U+00A4   | currency sign                      | EmojiIcons/Gold             |          |
+|   ♬    |  U+266C   | sixteenth note                     | EmojiIcons/Great Artist     |          |
+|   ⚒    |  U+2692   | hammer                             | EmojiIcons/Great Engineer   |          |
+|   ⛤    |  U+26E4   | pentagram                          | EmojiIcons/Great General    |          |
+|   ⚖    |  U+2696   | scale                              | EmojiIcons/Great Merchant   |          |
+|   ⚛    |  U+269B   | atom                               | EmojiIcons/Great Scientist  |          |
+|   ⌣    |  U+2323   | smile                              | EmojiIcons/Happiness        |          |
+|   ∞    |  U+221E   | infinity                           | EmojiIcons/Infinity         |    *     |
+|   ⚙    |  U+2699   | gear                               | EmojiIcons/Production       |          |
+|   ⍾    |  U+237E   | bell symbol                        | EmojiIcons/Science          |          |
+|   ￪    |  U+FFEA   | halfwidth upwards arrow            | EmojiIcons/SortedAscending  |    *     |
+|   ◉    |  U+25C9   | fisheye                            | EmojiIcons/SortedByStatus   |    *     |
+|   ⌚    |  U+231A   | watch                              | EmojiIcons/SortedByTime     |    *     |
+|   ￬    |  U+FFEC   | halfwidth upwards arrow            | EmojiIcons/SortedDescending |    *     |
+|   ✯    |  U+272F   | pinwheel star                      | EmojiIcons/Star             |    *     |
+|   ⏳    |  U+23F3   | hourglass                          | EmojiIcons/Turn             |          |
+|   ⅰ    |  U+2170   | small roman numeral one            | MayaCalendar/0              |          |
+|   ⅱ    |  U+2171   | small roman numeral two            | MayaCalendar/1              |          |
+|   ⅲ    |  U+2172   | small roman numeral three          | MayaCalendar/2              |          |
+|   ⅳ    |  U+2173   | small roman numeral four           | MayaCalendar/3              |          |
+|   ⅴ    |  U+2174   | small roman numeral five           | MayaCalendar/4              |          |
+|   ⅵ    |  U+2175   | small roman numeral six            | MayaCalendar/5              |          |
+|   ⅶ    |  U+2176   | small roman numeral seven          | MayaCalendar/6              |          |
+|   ⅷ    |  U+2177   | small roman numeral eight          | MayaCalendar/7              |          |
+|   ⅸ    |  U+2178   | small roman numeral nine           | MayaCalendar/8              |          |
+|   ⅹ    |  U+2179   | small roman numeral ten            | MayaCalendar/9              |          |
+|   ⅺ    |  U+217A   | small roman numeral eleven         | MayaCalendar/10             |          |
+|   ⅻ    |  U+217B   | small roman numeral twelve         | MayaCalendar/11             |          |
+|   ⅼ    |  U+217C   | small roman numeral fifty          | MayaCalendar/12             |          |
+|   ⅽ    |  U+217D   | small roman numeral one hundred    | MayaCalendar/13             |          |
+|   ⅾ    |  U+217E   | small roman numeral five hundred   | MayaCalendar/14             |          |
+|   ⅿ    |  U+217F   | small roman numeral one thousand   | MayaCalendar/15             |          |
+|   ↀ    |  U+2180   | roman numeral one thousand cd      | MayaCalendar/16             |          |
+|   ↁ    |  U+2181   | roman numeral five thousand        | MayaCalendar/17             |          |
+|   ↂ    |  U+2182   | roman numeral ten thousand         | MayaCalendar/18             |          |
+|   Ↄ    |  U+2183   | roman numeral reversed one hundred | MayaCalendar/19             |          |
+|   ය    |  U+0DBA   | sinhala letter yayanna             | MayaCalendar/Baktun         |          |
+|   ඹ    |  U+0DB9   | sinhala letter amba bayanna        | MayaCalendar/Katun          |          |
+|   ම    |  U+0DB8   | sinhala letter mayanna             | MayaCalendar/Tun            |          |
+|   ➡    |  U+27A1   | black rightwards arrow             | StatIcons/Movement          |          |
+|   …    |  U+2026   | horizontal ellipsis                | StatIcons/Range             |          |
+|   ‡    |  U+2021   | double dagger                      | StatIcons/RangedStrength    |          |
+|   †    |  U+2020   | dagger                             | StatIcons/Strength          |          |
+
 ### Adding Wonder Splash Screens
 
 You can add wonder images to mods and they'll be displayed instead of the standard icon when a wonder is finished. The image needs to be a .png and 2:1 ratio so for example 200x100 px.

--- a/docs/Modders/Images-and-Audio.md
+++ b/docs/Modders/Images-and-Audio.md
@@ -100,6 +100,7 @@ All fonts are rendered by default at 50 pixel size and rescaled later for the ga
 
 The textures in the EmojiIcons subfolder and some others are mapped into the font at specific codepoints. They are used by the game, can be used in any text of a mod, and can be overridden by mod textures.
 Additionally, some code points are normally provided by the chosen system font, but have EmojiIcons names that will override the font glyph if a mod supplies them (marked 'optional' in the table below).
+Note textures provided for such codepoints *do* respect aspect ratio, they do *not* need to be square like many built-in icons are!
 
 | Symbol | Codepoint | Unicode name                       | Texture path                | Optional |
 |:------:|:---------:|:-----------------------------------|:----------------------------|:--------:|


### PR DESCRIPTION
## Motivation

<details><summary><code>&lt;story mode&gt;</code></summary>

I bricked my distro.. No not quite, but some `apt purge` orgy made Unciv miss the sorting up/down arrows. Turns out some maintainer maybe thought "oh that half-width unicode block is full of hangul characters, so it must be relevant for asians only" - or not, but removing bloat by uninstalling asian fonts removes the glyphs for U+FFEA and U+FFEC from the default font.

The interesting thing is, I had already determined months ago by reading down into the sources that a NativeFontImplementation like we're getting from the underlying libraries is not 1:1 mapped from a system font, but it has the ability to collect glyphs from several system fonts... Which is exactly what I now observed.

I'll probably fix my system eventually, but in the meantime...

`</story mode>`
</details>

## Content notes
- First, it moves all uses (those I found) of higher codepoints (that are displayed) into Fonts.kt so there's a central place to exchange them if needed, and an easier cross-reference leveraging Studio Alt-F7/Ctrl-B and such.
- Next, I made the lookup performed on `allSymbols` optional - falls back to font if no texture found.
- Then I added all special symbols that don't yet have a texture to `allSymbols`
- This enables a minimod to supply the missing arrows: [SortIcons.zip](https://github.com/yairm210/Unciv/files/15440438/SortIcons.zip) - essentially just an atlas with those 2 texture paths.

## Question
- Idea: Define optional texture path `FontGlyphs/U+hhhh` - texture lookup is a hashmap lookup thus fast enough[^1] - if modder supplies patch as glyph into font. Would enable the above too, and open more possibilities, up to faking the old '.fnt' bitmap fonts... Not useful, but just adding a few glyphs wherever the modder chooses for free use in their texts... why not? Klingon mod...
- Didn't implement that right away as it might be a bit harder to understand for a mad hatter - pardon, modder
- Is the doc too much? Nobody cares about unicode codepoint names? Nobody wants to mod the Mayan glyphs?

[^1]: So I don't forget: There's `Int.toString(radix)` and `String.padLeft(num, char)`