### PR TITLE
Linting and re-sort Tile class so the regions are no longer lying

### DIFF
--- a/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
@@ -11,7 +11,6 @@ import com.unciv.logic.civilization.NotificationCategory
 import com.unciv.logic.civilization.diplomacy.RelationshipLevel
 import com.unciv.logic.map.mapunit.MapUnit
 import com.unciv.logic.map.tile.Tile
-import com.unciv.logic.map.tile.TileStatFunctions
 import com.unciv.logic.map.tile.toStats
 import com.unciv.models.UnitActionType
 import com.unciv.models.ruleset.tile.ResourceType
@@ -278,7 +277,7 @@ class WorkerAutomation(
                 var repairBonusPriority = tile.getImprovementToRepair()!!.getTurnsToBuild(unit.civ,unit) - UnitActionsFromUniques.getRepairTurns(unit)
                 if (tile.improvementInProgress == Constants.repair) repairBonusPriority += UnitActionsFromUniques.getRepairTurns(unit) - tile.turnsToImprovement
 
-                val repairPriority = repairBonusPriority + Automation.rankStatsValue(TileStatFunctions(tile).getStatDiffForImprovement(tile.getTileImprovement()!!, unit.civ, tile.owningCity), unit.civ)
+                val repairPriority = repairBonusPriority + Automation.rankStatsValue(tile.stats.getStatDiffForImprovement(tile.getTileImprovement()!!, unit.civ, tile.owningCity), unit.civ)
                 if (repairPriority > rank.improvementPriority!!) {
                     rank.improvementPriority = repairPriority
                     rank.bestImprovement = null

--- a/core/src/com/unciv/logic/city/CityConstructions.kt
+++ b/core/src/com/unciv/logic/city/CityConstructions.kt
@@ -35,7 +35,6 @@ import com.unciv.ui.components.extensions.withoutItem
 import com.unciv.ui.components.fonts.Fonts
 import com.unciv.ui.screens.civilopediascreen.CivilopediaCategories
 import com.unciv.ui.screens.civilopediascreen.FormattedLine
-import com.unciv.ui.screens.worldscreen.WorldScreen
 import kotlin.math.ceil
 import kotlin.math.min
 import kotlin.math.roundToInt

--- a/core/src/com/unciv/logic/city/managers/CityFounder.kt
+++ b/core/src/com/unciv/logic/city/managers/CityFounder.kt
@@ -56,7 +56,7 @@ class CityFounder {
 
         if (civInfo.gameInfo.ruleset.tileImprovements.containsKey(Constants.cityCenter))
             tile.changeImprovement(Constants.cityCenter, civInfo)
-        tile.improvementInProgress = null
+        tile.stopWorkingOnImprovement()
 
         val ruleset = civInfo.gameInfo.ruleset
         city.workedTiles = hashSetOf() //reassign 1st working tile
@@ -111,8 +111,8 @@ class CityFounder {
      * This method attempts to return the first unused city name of the [foundingCiv], taking used
      * city names into consideration (including foreign cities). If that fails, it then checks
      * whether the civilization has [UniqueType.BorrowsCityNames] and, if true, returns a borrowed
-     * name. Else, it repeatedly attaches one of the given [prefixes] to the list of names up to ten
-     * times until an unused name is successfully generated. If all else fails, null is returned.
+     * name. Else, it repeatedly attaches one of the given [prefixes][NamingConstants.prefixes] to the list of names
+     * up to ten times until an unused name is successfully generated. If all else fails, null is returned.
      *
      * @param foundingCiv The civilization that founded this city.
      * @param aliveCivs Every civilization currently alive.

--- a/core/src/com/unciv/logic/map/tile/Tile.kt
+++ b/core/src/com/unciv/logic/map/tile/Tile.kt
@@ -46,7 +46,7 @@ class Tile : IsPartOfGameInfoSerialization {
         private set
 
     /** Should be immutable - never be altered in-place, instead replaced */
-    var exploredBy = HashSet<String>(0)
+    private var exploredBy = HashSet<String>(0)
 
     var naturalWonder: String? = null
     var resource: String? = null
@@ -55,13 +55,14 @@ class Tile : IsPartOfGameInfoSerialization {
             field = value
         }
     var resourceAmount: Int = 0
+
     var improvement: String? = null
     var improvementInProgress: String? = null
     var improvementIsPillaged = false
 
     var roadStatus = RoadStatus.None
     var roadIsPillaged = false
-    var roadOwner: String = "" // either who last built the road or last owner of tile
+    private var roadOwner: String = "" // either who last built the road or last owner of tile
     var turnsToImprovement: Int = 0
 
     var hasBottomRightRiver = false
@@ -86,6 +87,13 @@ class Tile : IsPartOfGameInfoSerialization {
     @Transient
     val stats = TileStatFunctions(this)
 
+    // This is for performance - since we access the neighbors of a tile ALL THE TIME,
+    // and the neighbors of a tile never change, it's much more efficient to save the list once and for all!
+    @delegate:Transient
+    val neighbors: Sequence<Tile> by lazy { getTilesAtDistance(1).toList().asSequence() }
+    // We have to .toList() so that the values are stored together once for caching,
+    // and the toSequence so that aggregations (like neighbors.flatMap{it.units} don't take up their own space
+
     @Transient
     private var isCityCenterInternal = false
 
@@ -105,6 +113,9 @@ class Tile : IsPartOfGameInfoSerialization {
 
     @Transient
     var isOcean = false
+
+    @delegate:Transient
+    private val _isCoastalTile: Boolean by lazy { neighbors.any { it.baseTerrain == Constants.coast } }
 
     @Transient
     var unitHeight = 0
@@ -153,6 +164,11 @@ class Tile : IsPartOfGameInfoSerialization {
             }
             return tileResourceCache!!
         }
+
+    @Transient
+    private var isAdjacentToRiver = false
+    @Transient
+    private var isAdjacentToRiverKnown = false
     //endregion
 
     fun clone(): Tile {
@@ -197,10 +213,6 @@ class Tile : IsPartOfGameInfoSerialization {
 
     fun isHill() = baseTerrain == Constants.hill || terrainFeatures.contains(Constants.hill)
 
-    fun containsGreatImprovement(): Boolean {
-        return getTileImprovement()?.isGreatImprovement() == true
-    }
-
     /** Returns military, civilian and air units in tile */
     fun getUnits() = sequence {
         if (militaryUnit != null) yield(militaryUnit!!)
@@ -234,28 +246,16 @@ class Tile : IsPartOfGameInfoSerialization {
         return exploredBy.contains(player.civName)
     }
 
-    fun setExplored(player: Civilization, isExplored: Boolean, explorerPosition: Vector2? = null) {
-        if (isExplored) {
-            // Disable the undo button if a new tile has been explored
-            if (!exploredBy.contains(player.civName)) {
-                GUI.clearUndoCheckpoints()
-                exploredBy = exploredBy.withItem(player.civName)
-            }
-
-            if (player.playerType == PlayerType.Human)
-                player.exploredRegion.checkTilePosition(position, explorerPosition)
-        } else {
-            exploredBy = exploredBy.withoutItem(player.civName)
-        }
-    }
-
     fun isCityCenter(): Boolean = isCityCenterInternal
     fun isNaturalWonder(): Boolean = naturalWonder != null
     fun isImpassible() = lastTerrain.impassable
 
+
     fun getTileImprovement(): TileImprovement? = if (improvement == null) null else ruleset.tileImprovements[improvement!!]
+    fun isPillaged(): Boolean = improvementIsPillaged || roadIsPillaged
     fun getUnpillagedTileImprovement(): TileImprovement? = if (getUnpillagedImprovement() == null) null else ruleset.tileImprovements[improvement!!]
     fun getTileImprovementInProgress(): TileImprovement? = if (improvementInProgress == null) null else ruleset.tileImprovements[improvementInProgress!!]
+    fun containsGreatImprovement() = getTileImprovement()?.isGreatImprovement() == true
 
     fun getImprovementToPillage(): TileImprovement? {
         if (canPillageTileImprovement())
@@ -299,34 +299,6 @@ class Tile : IsPartOfGameInfoSerialization {
         else ruleset.tileImprovements[getUnpillagedRoad().name]
     }
 
-    /** Does not remove roads */
-    fun removeImprovement() =
-        improvementFunctions.changeImprovement(null)
-
-    fun changeImprovement(improvementStr: String, civToHandleCompletion: Civilization? = null, unit: MapUnit? = null) =
-        improvementFunctions.changeImprovement(improvementStr, civToHandleCompletion, unit)
-
-    // function handling when adding a road to the tile
-    fun addRoad(roadType: RoadStatus, creatingCivInfo: Civilization?) {
-        roadStatus = roadType
-        roadIsPillaged = false
-        if (getOwner() != null) {
-            roadOwner = getOwner()!!.civName
-        } else if (creatingCivInfo != null) {
-            roadOwner = creatingCivInfo.civName // neutral tile, use building unit
-            creatingCivInfo.neutralRoads.add(this.position)
-        }
-    }
-
-    // function handling when removing a road from the tile
-    fun removeRoad() {
-        roadIsPillaged = false
-        if (roadStatus == RoadStatus.None) return
-        roadStatus = RoadStatus.None
-        if (owningCity == null)
-            getRoadOwner()?.neutralRoads?.remove(this.position)
-    }
-
     fun getShownImprovement(viewingCiv: Civilization?): String? {
         return if (viewingCiv == null || viewingCiv.playerType == PlayerType.AI || viewingCiv.isSpectator())
             improvement
@@ -337,13 +309,6 @@ class Tile : IsPartOfGameInfoSerialization {
     /** Returns true if this tile has fallout or an equivalent terrain feature */
     fun hasFalloutEquivalent(): Boolean = terrainFeatures.any { ruleset.terrains[it]!!.hasUnique(UniqueType.NullifyYields)}
 
-
-    // This is for performance - since we access the neighbors of a tile ALL THE TIME,
-    // and the neighbors of a tile never change, it's much more efficient to save the list once and for all!
-    @delegate:Transient
-    val neighbors: Sequence<Tile> by lazy { getTilesAtDistance(1).toList().asSequence() }
-    // We have to .toList() so that the values are stored together once for caching,
-    // and the toSequence so that aggregations (like neighbors.flatMap{it.units} don't take up their own space
 
     fun getRow() = HexMath.getRow(position)
     fun getColumn() = HexMath.getColumn(position)
@@ -537,8 +502,6 @@ class Tile : IsPartOfGameInfoSerialization {
 
     fun hasImprovementInProgress() = improvementInProgress != null && turnsToImprovement > 0
 
-    @delegate:Transient
-    private val _isCoastalTile: Boolean by lazy { neighbors.any { it.baseTerrain == Constants.coast } }
     fun isCoastalTile() = _isCoastalTile
 
     fun hasViewableResource(civInfo: Civilization): Boolean =
@@ -593,28 +556,6 @@ class Tile : IsPartOfGameInfoSerialization {
         }
     }
 
-    /** Shows important properties of this tile for debugging _only_, it helps to see what you're doing */
-    override fun toString(): String {
-        val lineList = arrayListOf("Tile @$position")
-        if (!this::baseTerrain.isInitialized) return lineList[0] + ", uninitialized"
-        if (isCityCenter()) lineList += getCity()!!.name
-        lineList += baseTerrain
-        for (terrainFeature in terrainFeatures) lineList += terrainFeature
-        if (resource != null) {
-            lineList += if (tileResource.resourceType == ResourceType.Strategic)
-                    "{$resourceAmount} {$resource}"
-                else
-                    resource!!
-        }
-        if (naturalWonder != null) lineList += naturalWonder!!
-        if (roadStatus !== RoadStatus.None && !isCityCenter()) lineList += roadStatus.name
-        if (improvement != null) lineList += improvement!!
-        if (civilianUnit != null) lineList += civilianUnit!!.name + " - " + civilianUnit!!.civ.civName
-        if (militaryUnit != null) lineList += militaryUnit!!.name + " - " + militaryUnit!!.civ.civName
-        if (this::baseTerrainObject.isInitialized && isImpassible()) lineList += Constants.impassable
-        return lineList.joinToString()
-    }
-
     /** The two tiles have a river between them */
     fun isConnectedByRiver(otherTile: Tile): Boolean {
         if (otherTile == this) throw Exception("Should not be called to compare to self!")
@@ -630,10 +571,6 @@ class Tile : IsPartOfGameInfoSerialization {
         }
     }
 
-    @Transient
-    private var isAdjacentToRiver = false
-    @Transient
-    private var isAdjacentToRiverKnown = false
     fun isAdjacentToRiver(): Boolean {
         if (!isAdjacentToRiverKnown) {
             isAdjacentToRiver =
@@ -644,43 +581,6 @@ class Tile : IsPartOfGameInfoSerialization {
             isAdjacentToRiverKnown = true
         }
         return isAdjacentToRiver
-    }
-
-    /** Allows resetting the cached value [isAdjacentToRiver] will return
-     *  @param isKnownTrue Set this to indicate you need to update the cache due to **adding** a river edge
-     *         (removing would need to look at other edges, and that is what isAdjacentToRiver will do)
-     */
-    private fun resetAdjacentToRiverTransient(isKnownTrue: Boolean = false) {
-        isAdjacentToRiver = isKnownTrue
-        isAdjacentToRiverKnown = isKnownTrue
-    }
-
-    /**
-     *  Sets the "has river" state of one edge of this Tile. Works for all six directions.
-     *  @param  otherTile The neighbor tile in the direction the river we wish to change is (If it's not a neighbor, this does nothing).
-     *  @param  newValue The new river edge state: `true` to create a river, `false` to remove one.
-     *  @param  convertTerrains If true, calls MapGenerator's convertTerrains to apply UniqueType.ChangesTerrain effects.
-     *  @return The state did change (`false`: the edge already had the `newValue`)
-     */
-    fun setConnectedByRiver(otherTile: Tile, newValue: Boolean, convertTerrains: Boolean = false): Boolean {
-        //todo synergy potential with [MapEditorEditRiversTab]?
-        val field = when (tileMap.getNeighborTileClockPosition(this, otherTile)) {
-            2 -> otherTile::hasBottomLeftRiver // we're to the bottom-left of it
-            4 -> ::hasBottomRightRiver // we're to the top-left of it
-            6 -> ::hasBottomRiver // we're directly above it
-            8 -> ::hasBottomLeftRiver // we're to the top-right of it
-            10 -> otherTile::hasBottomRightRiver // we're to the bottom-right of it
-            12 -> otherTile::hasBottomRiver // we're directly below it
-            else -> return false
-        }
-        if (field.get() == newValue) return false
-        field.set(newValue)
-        val affectedTiles = listOf(this, otherTile)
-        for (tile in affectedTiles)
-            tile.resetAdjacentToRiverTransient(newValue)
-        if (convertTerrains)
-            MapGenerator.Helpers.convertTerrains(ruleset, affectedTiles)
-        return true
     }
 
     /**
@@ -750,6 +650,20 @@ class Tile : IsPartOfGameInfoSerialization {
     /** Checks if this tile is marked as target tile for a building with a [UniqueType.CreatesOneImprovement] unique creating a specific [improvement] */
     fun isMarkedForCreatesOneImprovement(improvement: String) =
         turnsToImprovement < 0 && improvementInProgress == improvement
+
+    private fun approximateMajorDepositDistribution(): Double {
+        // We can't replicate the MapRegions resource distributor, so let's try to get
+        // a close probability of major deposits per tile
+        var probability = 0.0
+        for (unique in allTerrains.flatMap { it.getMatchingUniques(UniqueType.MajorStrategicFrequency) }) {
+            val frequency = unique.params[0].toIntOrNull() ?: continue
+            if (frequency <= 0) continue
+            // The unique param is literally "every N tiles", so to get a probability p=1/f
+            probability += 1.0 / frequency
+        }
+        return if (probability == 0.0) 0.04  // This is the default of 1 per 25 tiles
+        else probability
+    }
 
     //endregion
     //region state-changing functions
@@ -839,20 +753,6 @@ class Tile : IsPartOfGameInfoSerialization {
         }
     }
 
-    private fun approximateMajorDepositDistribution(): Double {
-        // We can't replicate the MapRegions resource distributor, so let's try to get
-        // a close probability of major deposits per tile
-        var probability = 0.0
-        for (unique in allTerrains.flatMap { it.getMatchingUniques(UniqueType.MajorStrategicFrequency) }) {
-            val frequency = unique.params[0].toIntOrNull() ?: continue
-            if (frequency <= 0) continue
-            // The unique param is literally "every N tiles", so to get a probability p=1/f
-            probability += 1.0 / frequency
-        }
-        return if (probability == 0.0) 0.04  // This is the default of 1 per 25 tiles
-            else probability
-    }
-
     fun setTerrainFeatures(terrainFeatureList: List<String>) {
         terrainFeatures = terrainFeatureList
         terrainFeatureObjects = terrainFeatureList.mapNotNull { ruleset.terrains[it] }
@@ -928,6 +828,35 @@ class Tile : IsPartOfGameInfoSerialization {
         }
     }
 
+
+    /** Does not remove roads */
+    fun removeImprovement() =
+        improvementFunctions.changeImprovement(null)
+
+    fun changeImprovement(improvementStr: String, civToHandleCompletion: Civilization? = null, unit: MapUnit? = null) =
+        improvementFunctions.changeImprovement(improvementStr, civToHandleCompletion, unit)
+
+    // function handling when adding a road to the tile
+    fun addRoad(roadType: RoadStatus, creatingCivInfo: Civilization?) {
+        roadStatus = roadType
+        roadIsPillaged = false
+        if (getOwner() != null) {
+            roadOwner = getOwner()!!.civName
+        } else if (creatingCivInfo != null) {
+            roadOwner = creatingCivInfo.civName // neutral tile, use building unit
+            creatingCivInfo.neutralRoads.add(this.position)
+        }
+    }
+
+    // function handling when removing a road from the tile
+    fun removeRoad() {
+        roadIsPillaged = false
+        if (roadStatus == RoadStatus.None) return
+        roadStatus = RoadStatus.None
+        if (owningCity == null)
+            getRoadOwner()?.neutralRoads?.remove(this.position)
+    }
+
     fun startWorkingOnImprovement(improvement: TileImprovement, civInfo: Civilization, unit: MapUnit) {
         improvementInProgress = improvement.name
         turnsToImprovement = if (civInfo.gameInfo.gameParameters.godMode) 1
@@ -978,18 +907,6 @@ class Tile : IsPartOfGameInfoSerialization {
             owningCity!!.civ.cache.updateCivResources()
     }
 
-    private fun clearAllPathfindingCaches() {
-        val units = tileMap.gameInfo.civilizations.asSequence()
-            .filter { it.isAlive() }
-            .flatMap { it.units.getCivUnits() }
-        Log.debug("%s: road pillaged, clearing cache for %d units", this, { units.count() })
-        for (otherUnit in units) {
-            otherUnit.movement.clearPathfindingCache()
-        }
-    }
-
-    fun isPillaged(): Boolean = improvementIsPillaged || roadIsPillaged
-
     fun setRepaired() {
         improvementInProgress = null
         turnsToImprovement = 0
@@ -1001,6 +918,31 @@ class Tile : IsPartOfGameInfoSerialization {
         owningCity?.reassignPopulationDeferred()
     }
 
+
+    private fun clearAllPathfindingCaches() {
+        val units = tileMap.gameInfo.civilizations.asSequence()
+            .filter { it.isAlive() }
+            .flatMap { it.units.getCivUnits() }
+        Log.debug("%s: road pillaged, clearing cache for %d units", this, { units.count() })
+        for (otherUnit in units) {
+            otherUnit.movement.clearPathfindingCache()
+        }
+    }
+
+    fun setExplored(player: Civilization, isExplored: Boolean, explorerPosition: Vector2? = null) {
+        if (isExplored) {
+            // Disable the undo button if a new tile has been explored
+            if (!exploredBy.contains(player.civName)) {
+                GUI.clearUndoCheckpoints()
+                exploredBy = exploredBy.withItem(player.civName)
+            }
+
+            if (player.playerType == PlayerType.Human)
+                player.exploredRegion.checkTilePosition(position, explorerPosition)
+        } else {
+            exploredBy = exploredBy.withoutItem(player.civName)
+        }
+    }
 
     /**
      * Assign a continent ID to this tile.
@@ -1017,6 +959,68 @@ class Tile : IsPartOfGameInfoSerialization {
 
     /** Clear continent ID, for map editor */
     fun clearContinent() { continent = -1 }
+
+    /** Allows resetting the cached value [isAdjacentToRiver] will return
+     *  @param isKnownTrue Set this to indicate you need to update the cache due to **adding** a river edge
+     *         (removing would need to look at other edges, and that is what isAdjacentToRiver will do)
+     */
+    private fun resetAdjacentToRiverTransient(isKnownTrue: Boolean = false) {
+        isAdjacentToRiver = isKnownTrue
+        isAdjacentToRiverKnown = isKnownTrue
+    }
+
+    /**
+     *  Sets the "has river" state of one edge of this Tile. Works for all six directions.
+     *  @param  otherTile The neighbor tile in the direction the river we wish to change is (If it's not a neighbor, this does nothing).
+     *  @param  newValue The new river edge state: `true` to create a river, `false` to remove one.
+     *  @param  convertTerrains If true, calls MapGenerator's convertTerrains to apply UniqueType.ChangesTerrain effects.
+     *  @return The state did change (`false`: the edge already had the `newValue`)
+     */
+    fun setConnectedByRiver(otherTile: Tile, newValue: Boolean, convertTerrains: Boolean = false): Boolean {
+        //todo synergy potential with [MapEditorEditRiversTab]?
+        val field = when (tileMap.getNeighborTileClockPosition(this, otherTile)) {
+            2 -> otherTile::hasBottomLeftRiver // we're to the bottom-left of it
+            4 -> ::hasBottomRightRiver // we're to the top-left of it
+            6 -> ::hasBottomRiver // we're directly above it
+            8 -> ::hasBottomLeftRiver // we're to the top-right of it
+            10 -> otherTile::hasBottomRightRiver // we're to the bottom-right of it
+            12 -> otherTile::hasBottomRiver // we're directly below it
+            else -> return false
+        }
+        if (field.get() == newValue) return false
+        field.set(newValue)
+        val affectedTiles = listOf(this, otherTile)
+        for (tile in affectedTiles)
+            tile.resetAdjacentToRiverTransient(newValue)
+        if (convertTerrains)
+            MapGenerator.Helpers.convertTerrains(ruleset, affectedTiles)
+        return true
+    }
+
+    //endregion
+    //region Overrides
+
+    /** Shows important properties of this tile for debugging _only_, it helps to see what you're doing */
+    override fun toString(): String {
+        val lineList = arrayListOf("Tile @$position")
+        if (!this::baseTerrain.isInitialized) return lineList[0] + ", uninitialized"
+        if (isCityCenter()) lineList += getCity()!!.name
+        lineList += baseTerrain
+        for (terrainFeature in terrainFeatures) lineList += terrainFeature
+        if (resource != null) {
+            lineList += if (tileResource.resourceType == ResourceType.Strategic)
+                "{$resourceAmount} {$resource}"
+            else
+                resource!!
+        }
+        if (naturalWonder != null) lineList += naturalWonder!!
+        if (roadStatus !== RoadStatus.None && !isCityCenter()) lineList += roadStatus.name
+        if (improvement != null) lineList += improvement!!
+        if (civilianUnit != null) lineList += civilianUnit!!.name + " - " + civilianUnit!!.civ.civName
+        if (militaryUnit != null) lineList += militaryUnit!!.name + " - " + militaryUnit!!.civ.civName
+        if (this::baseTerrainObject.isInitialized && isImpassible()) lineList += Constants.impassable
+        return lineList.joinToString()
+    }
 
     //endregion
 }

--- a/core/src/com/unciv/logic/map/tile/Tile.kt
+++ b/core/src/com/unciv/logic/map/tile/Tile.kt
@@ -81,7 +81,7 @@ class Tile : IsPartOfGameInfoSerialization {
     lateinit var ruleset: Ruleset  // a tile can be a tile with a ruleset, even without a map.
 
     @Transient
-    val improvementFunctions = TileInfoImprovementFunctions(this)
+    val improvementFunctions = TileImprovementFunctions(this)
 
     @Transient
     val stats = TileStatFunctions(this)

--- a/core/src/com/unciv/logic/map/tile/TileImprovementFunctions.kt
+++ b/core/src/com/unciv/logic/map/tile/TileImprovementFunctions.kt
@@ -33,7 +33,7 @@ enum class ImprovementBuildingProblem(
     Other
 }
 
-class TileInfoImprovementFunctions(val tile: Tile) {
+class TileImprovementFunctions(val tile: Tile) {
 
     /** Returns true if the [improvement] can be built on this [Tile] */
     fun canBuildImprovement(improvement: TileImprovement, civInfo: Civilization): Boolean = getImprovementBuildingProblems(improvement, civInfo).none()
@@ -114,7 +114,7 @@ class TileInfoImprovementFunctions(val tile: Tile) {
             // Otherwise, we can if this improvement removes the top terrain
             if (!hasUnique(UniqueType.RemovesFeaturesIfBuilt, stateForConditionals)) return false
             if (knownFeatureRemovals.isNullOrEmpty()) return false
-            val featureRemovals = tile.terrainFeatures.mapNotNull { feature -> 
+            val featureRemovals = tile.terrainFeatures.mapNotNull { feature ->
                 tile.ruleset.tileRemovals.firstOrNull { it.name == Constants.remove + feature } }
             if (featureRemovals.isEmpty()) return false
             if (featureRemovals.any { it !in knownFeatureRemovals }) return false

--- a/core/src/com/unciv/ui/screens/devconsole/ConsoleTileCommands.kt
+++ b/core/src/com/unciv/ui/screens/devconsole/ConsoleTileCommands.kt
@@ -115,7 +115,7 @@ class ConsoleTileCommands: ConsoleCommandNode {
                         .flatMap { civ -> civ.cities }
                         .firstOrNull { it.name.toCliInput() == param }
                     // If the user didn't specify a City, they must have given us a Civilization instead -
-                    // copy of TileInfoImprovementFunctions.takeOverTilesAround.fallbackNearestCity
+                    // copy of TileImprovementFunctions.takeOverTilesAround.fallbackNearestCity
                     ?: console.getCivByName(params[0]) // throws if no match
                         .cities.minByOrNull { it.getCenterTile().aerialDistanceTo(selectedTile) + (if (it.isBeingRazed) 5 else 0) }
                 }

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsFromUniques.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsFromUniques.kt
@@ -428,13 +428,12 @@ object UnitActionsFromUniques {
         val tile = unit.currentTile
         if (!tile.isPillaged()) return 0
         if (tile.improvementInProgress == Constants.repair) return tile.turnsToImprovement
-        var repairTurns = tile.ruleset.tileImprovements[Constants.repair]!!.getTurnsToBuild(unit.civ, unit)
+        val repairTurns = tile.ruleset.tileImprovements[Constants.repair]!!.getTurnsToBuild(unit.civ, unit)
 
         val pillagedImprovement = tile.getImprovementToRepair()!!
         val turnsToBuild = pillagedImprovement.getTurnsToBuild(unit.civ, unit)
         // cap repair to number of turns to build original improvement
-        if (turnsToBuild < repairTurns) repairTurns = turnsToBuild
-        return repairTurns
+        return repairTurns.coerceAtMost(turnsToBuild)
     }
 
     internal fun getRepairActions(unit: MapUnit, tile: Tile) = sequenceOf(getRepairAction(unit)).filterNotNull()


### PR DESCRIPTION
... Rolled back from an almost finished "queue build terrace farm after removing forest" branch
Next step would be a major whopper - 29 files touched - but zero functional change, maybe a few bytes less memory usage:

<details>

***full patch***
[Convert_Tile__library__classes_to_interfaces.patch.zip](https://github.com/yairm210/Unciv/files/15445616/Convert_Tile__library__classes_to_interfaces.patch.zip)

***partial patch***
```patch
Subject: [PATCH] Convert Tile "library" classes to interfaces
---
Index: core/src/com/unciv/logic/map/tile/Tile.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/core/src/com/unciv/logic/map/tile/Tile.kt b/core/src/com/unciv/logic/map/tile/Tile.kt
--- a/core/src/com/unciv/logic/map/tile/Tile.kt	
+++ b/core/src/com/unciv/logic/map/tile/Tile.kt	
@@ -29,12 +29,11 @@
 import com.unciv.ui.components.extensions.withoutItem
 import com.unciv.ui.screens.mapeditorscreen.TileInfoNormalizer
 import com.unciv.utils.DebugUtils
-import com.unciv.utils.Log
 import kotlin.math.abs
 import kotlin.math.min
 import kotlin.random.Random
 
-class Tile : IsPartOfGameInfoSerialization {
+class Tile : IsPartOfGameInfoSerialization, TileImprovementFunctions, TileStatFunctions {
     //region Serialized fields
     var militaryUnit: MapUnit? = null
     var civilianUnit: MapUnit? = null
@@ -62,7 +61,7 @@
 
     var roadStatus = RoadStatus.None
     var roadIsPillaged = false
-    private var roadOwner: String = "" // either who last built the road or last owner of tile
+    internal var roadOwner: String = "" // either who last built the road or last owner of tile
     var turnsToImprovement: Int = 0
 
     var hasBottomRightRiver = false
@@ -81,11 +80,8 @@
     @Transient
     lateinit var ruleset: Ruleset  // a tile can be a tile with a ruleset, even without a map.
 
-    @Transient
-    val improvementFunctions = TileImprovementFunctions(this)
-
-    @Transient
-    val stats = TileStatFunctions(this)
+//     @Transient
+//     val stats = TileStatFunctions(this)
 
     // This is for performance - since we access the neighbors of a tile ALL THE TIME,
     // and the neighbors of a tile never change, it's much more efficient to save the list once and for all!
@@ -169,6 +165,9 @@
     private var isAdjacentToRiver = false
     @Transient
     private var isAdjacentToRiverKnown = false
+
+    @delegate:Transient
+    internal val riverTerrain by lazy { ruleset.terrains[Constants.river] }
     //endregion
 
     fun clone(): Tile {
@@ -253,7 +252,7 @@
 
     fun getTileImprovement(): TileImprovement? = if (improvement == null) null else ruleset.tileImprovements[improvement!!]
     fun isPillaged(): Boolean = improvementIsPillaged || roadIsPillaged
-    fun getUnpillagedTileImprovement(): TileImprovement? = if (getUnpillagedImprovement() == null) null else ruleset.tileImprovements[improvement!!]
+    fun getUnpillagedTileImprovement(): TileImprovement? = if (getUnpillagedImprovement() == null) null else getTileImprovement()
     fun getTileImprovementInProgress(): TileImprovement? = if (improvementInProgress == null) null else ruleset.tileImprovements[improvementInProgress!!]
     fun containsGreatImprovement() = getTileImprovement()?.isGreatImprovement() == true
 
@@ -644,13 +643,6 @@
 
     fun getContinent() = continent
 
-    /** Checks if this tile is marked as target tile for a building with a [UniqueType.CreatesOneImprovement] unique */
-    fun isMarkedForCreatesOneImprovement() =
-        turnsToImprovement < 0 && improvementInProgress != null
-    /** Checks if this tile is marked as target tile for a building with a [UniqueType.CreatesOneImprovement] unique creating a specific [improvement] */
-    fun isMarkedForCreatesOneImprovement(improvement: String) =
-        turnsToImprovement < 0 && improvementInProgress == improvement
-
     private fun approximateMajorDepositDistribution(): Double {
         // We can't replicate the MapRegions resource distributor, so let's try to get
         // a close probability of major deposits per tile
@@ -829,106 +821,6 @@
     }
 
 
-    /** Does not remove roads */
-    fun removeImprovement() =
-        improvementFunctions.changeImprovement(null)
-
-    fun changeImprovement(improvementStr: String, civToHandleCompletion: Civilization? = null, unit: MapUnit? = null) =
-        improvementFunctions.changeImprovement(improvementStr, civToHandleCompletion, unit)
-
-    // function handling when adding a road to the tile
-    fun addRoad(roadType: RoadStatus, creatingCivInfo: Civilization?) {
-        roadStatus = roadType
-        roadIsPillaged = false
-        if (getOwner() != null) {
-            roadOwner = getOwner()!!.civName
-        } else if (creatingCivInfo != null) {
-            roadOwner = creatingCivInfo.civName // neutral tile, use building unit
-            creatingCivInfo.neutralRoads.add(this.position)
-        }
-    }
-
-    // function handling when removing a road from the tile
-    fun removeRoad() {
-        roadIsPillaged = false
-        if (roadStatus == RoadStatus.None) return
-        roadStatus = RoadStatus.None
-        if (owningCity == null)
-            getRoadOwner()?.neutralRoads?.remove(this.position)
-    }
-
-    fun startWorkingOnImprovement(improvement: TileImprovement, civInfo: Civilization, unit: MapUnit) {
-        improvementInProgress = improvement.name
-        turnsToImprovement = if (civInfo.gameInfo.gameParameters.godMode) 1
-            else improvement.getTurnsToBuild(civInfo, unit)
-    }
-
-    /** Clears [improvementInProgress] and [turnsToImprovement] */
-    fun stopWorkingOnImprovement() {
-        improvementInProgress = null
-        turnsToImprovement = 0
-    }
-
-    /** Sets tile improvement to pillaged (without prior checks for validity)
-     *  and ensures that matching [UniqueType.CreatesOneImprovement] queued buildings are removed. */
-    fun setPillaged() {
-        if (!canPillageTile())
-            return
-        // http://well-of-souls.com/civ/civ5_improvements.html says that naval improvements are destroyed upon pillage
-        //    and I can't find any other sources so I'll go with that
-        if (!isLand) {
-            removeImprovement()
-            owningCity?.reassignPopulationDeferred()
-            return
-        }
-
-        // Setting turnsToImprovement might interfere with UniqueType.CreatesOneImprovement
-        improvementFunctions.removeCreatesOneImprovementMarker()
-        improvementInProgress = null  // remove any in progress work as well
-        turnsToImprovement = 0
-        // if no Repair action, destroy improvements instead
-        if (ruleset.tileImprovements[Constants.repair] == null) {
-            if (canPillageTileImprovement())
-                removeImprovement()
-            else
-                removeRoad()
-        } else {
-            // otherwise use pillage/repair systems
-            if (canPillageTileImprovement())
-                improvementIsPillaged = true
-            else {
-                roadIsPillaged = true
-                clearAllPathfindingCaches()
-            }
-        }
-
-        owningCity?.reassignPopulationDeferred()
-        if (owningCity != null)
-            owningCity!!.civ.cache.updateCivResources()
-    }
-
-    fun setRepaired() {
-        improvementInProgress = null
-        turnsToImprovement = 0
-        if (improvementIsPillaged)
-            improvementIsPillaged = false
-        else
-            roadIsPillaged = false
-
-        owningCity?.reassignPopulationDeferred()
-    }
-
-
-    private fun clearAllPathfindingCaches() {
-        val units = tileMap.gameInfo.civilizations.asSequence()
-            .filter { it.isAlive() }
-            .flatMap { it.units.getCivUnits() }
-        Log.debug("%s: road pillaged, clearing cache for %d units", this, { units.count() })
-        for (otherUnit in units) {
-            otherUnit.movement.clearPathfindingCache()
-        }
-    }
-
     fun setExplored(player: Civilization, isExplored: Boolean, explorerPosition: Vector2? = null) {
         if (isExplored) {
             // Disable the undo button if a new tile has been explored
Index: core/src/com/unciv/logic/map/tile/TileImprovementFunctions.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/core/src/com/unciv/logic/map/tile/TileImprovementFunctions.kt b/core/src/com/unciv/logic/map/tile/TileImprovementFunctions.kt
--- a/core/src/com/unciv/logic/map/tile/TileImprovementFunctions.kt	
+++ b/core/src/com/unciv/logic/map/tile/TileImprovementFunctions.kt	
@@ -9,8 +9,10 @@
 import com.unciv.logic.map.mapunit.MapUnit
 import com.unciv.models.ruleset.tile.TileImprovement
 import com.unciv.models.ruleset.unique.StateForConditionals
+import com.unciv.models.ruleset.unique.Unique
 import com.unciv.models.ruleset.unique.UniqueTriggerActivation
 import com.unciv.models.ruleset.unique.UniqueType
+import com.unciv.utils.Log
 
 
 /** Reason why an Improvement cannot be built by a given civ */
@@ -33,7 +35,8 @@
     Other
 }
 
-class TileImprovementFunctions(val tile: Tile) {
+internal interface TileImprovementFunctions {
+    private val tile get() = (this as Tile)
 
     /** Returns true if the [improvement] can be built on this [Tile] */
     fun canBuildImprovement(improvement: TileImprovement, civInfo: Civilization): Boolean = getImprovementBuildingProblems(improvement, civInfo).none()
@@ -97,22 +100,23 @@
     /** Without regards to what CivInfo it is, a lot of the checks are just for the improvement on the tile.
      *  Doubles as a check for the map editor.
      */
-    internal fun canImprovementBeBuiltHere(
-        improvement: TileImprovement,
+    fun canImprovementBeBuiltHere(
+        newImprovement: TileImprovement,
         resourceIsVisible: Boolean = tile.resource != null,
         knownFeatureRemovals: List<TileImprovement>? = null,
-        stateForConditionals: StateForConditionals = StateForConditionals(tile=tile)
+        stateForConditionals: StateForConditionals = StateForConditionals(tile = tile)
     ): Boolean {
 
-        fun TileImprovement.canBeBuildOnThisUnbuildableTerrain(
+        fun canBeBuiltOnThisUnbuildableTerrain(
+            newImprovement: TileImprovement,
             knownFeatureRemovals: List<TileImprovement>? = null,
         ): Boolean {
             val topTerrain = tile.lastTerrain
             // We can build if we are specifically allowed to build on this terrain
-            if (isAllowedOnFeature(topTerrain)) return true
+            if (newImprovement.isAllowedOnFeature(topTerrain)) return true
 
             // Otherwise, we can if this improvement removes the top terrain
-            if (!hasUnique(UniqueType.RemovesFeaturesIfBuilt, stateForConditionals)) return false
+            if (!newImprovement.hasUnique(UniqueType.RemovesFeaturesIfBuilt, stateForConditionals)) return false
             if (knownFeatureRemovals.isNullOrEmpty()) return false
             val featureRemovals = tile.terrainFeatures.mapNotNull { feature ->
                 tile.ruleset.tileRemovals.firstOrNull { it.name == Constants.remove + feature } }
@@ -121,25 +125,25 @@
             val clonedTile = tile.clone()
             clonedTile.setTerrainFeatures(tile.terrainFeatures.filterNot {
                 feature -> featureRemovals.any{ it.name.removePrefix(Constants.remove) == feature } })
-            return clonedTile.improvementFunctions.canImprovementBeBuiltHere(improvement, resourceIsVisible, knownFeatureRemovals, stateForConditionals)
+            return clonedTile.canImprovementBeBuiltHere(newImprovement, resourceIsVisible, knownFeatureRemovals, stateForConditionals)
         }
 
         return when {
-            improvement.name == tile.improvement -> false
+            newImprovement.name == tile.improvement -> false
             tile.isCityCenter() -> false
 
             // First we handle a few special improvements
 
             // Can only cancel if there is actually an improvement being built
-            improvement.name == Constants.cancelImprovementOrder -> (tile.improvementInProgress != null)
+            newImprovement.name == Constants.cancelImprovementOrder -> (tile.improvementInProgress != null)
             // Can only remove roads if that road is actually there
-            RoadStatus.values().any { it.removeAction == improvement.name } -> tile.roadStatus.removeAction == improvement.name
+            RoadStatus.values().any { it.removeAction == newImprovement.name } -> tile.roadStatus.removeAction == newImprovement.name
             // Can only remove features or improvement if that feature/improvement is actually there
-            improvement.name.startsWith(Constants.remove) -> tile.terrainFeatures.any { Constants.remove + it == improvement.name }
-                || Constants.remove + tile.improvement == improvement.name
+            newImprovement.name.startsWith(Constants.remove) -> tile.terrainFeatures.any { Constants.remove + it == newImprovement.name }
+                || Constants.remove + tile.improvement == newImprovement.name
             // Can only build roads if on land and they are better than the current road
-            RoadStatus.values().any { it.name == improvement.name } -> !tile.isWater
-                    && RoadStatus.valueOf(improvement.name) > tile.roadStatus
+            RoadStatus.values().any { it.name == newImprovement.name } -> !tile.isWater
+                    && RoadStatus.valueOf(newImprovement.name) > tile.roadStatus
 
             // Then we check if there is any reason to not allow this improvement to be build
 
@@ -147,52 +151,136 @@
             tile.improvement != null && tile.getTileImprovement()!!.hasUnique(UniqueType.Irremovable, stateForConditionals) -> false
 
             // Can't build if this terrain is unbuildable, except when we are specifically allowed to
-            tile.lastTerrain.unbuildable && !improvement.canBeBuildOnThisUnbuildableTerrain(knownFeatureRemovals) -> false
+            tile.lastTerrain.unbuildable && !canBeBuiltOnThisUnbuildableTerrain(newImprovement, knownFeatureRemovals) -> false
 
             // Can't build if any terrain specifically prevents building this improvement
             tile.getTerrainMatchingUniques(UniqueType.RestrictedBuildableImprovements, stateForConditionals).any {
-                    unique -> !improvement.matchesFilter(unique.params[0])
+                    unique -> !newImprovement.matchesFilter(unique.params[0])
             } -> false
 
             // Can't build if the improvement specifically prevents building on some present feature
-            improvement.getMatchingUniques(UniqueType.CannotBuildOnTile, stateForConditionals).any {
+            newImprovement.getMatchingUniques(UniqueType.CannotBuildOnTile, stateForConditionals).any {
                     unique -> tile.matchesTerrainFilter(unique.params[0])
             } ->
                 false
 
             // Can't build if an improvement is only allowed to be built on specific tiles and this is not one of them
             // If multiple uniques of this type exists, we want all to match (e.g. Hill _and_ Forest would be meaningful)
-            improvement.getMatchingUniques(UniqueType.CanOnlyBeBuiltOnTile, stateForConditionals).let {
+            newImprovement.getMatchingUniques(UniqueType.CanOnlyBeBuiltOnTile, stateForConditionals).let {
                 it.any() && it.any { unique -> !tile.matchesTerrainFilter(unique.params[0]) }
             } -> false
 
             // Can't build if the improvement requires an adjacent terrain that is not present
-            improvement.getMatchingUniques(UniqueType.MustBeNextTo, stateForConditionals).any {
+            newImprovement.getMatchingUniques(UniqueType.MustBeNextTo, stateForConditionals).any {
                 !tile.isAdjacentTo(it.params[0])
             } -> false
 
             // Can't build it if it is only allowed to improve resources and it doesn't improve this resource
-            improvement.hasUnique(UniqueType.CanOnlyImproveResource, stateForConditionals) && (
-                    !resourceIsVisible || !tile.tileResource.isImprovedBy(improvement.name)
+            newImprovement.hasUnique(UniqueType.CanOnlyImproveResource, stateForConditionals) && (
+                    !resourceIsVisible || !tile.tileResource.isImprovedBy(newImprovement.name)
                     ) -> false
 
             // At this point we know this is a normal improvement and that there is no reason not to allow it to be built.
 
             // Lastly we check if the improvement may be built on this terrain or resource
-            improvement.isAllowedOnFeature(tile.lastTerrain) -> true
-            tile.isLand && improvement.canBeBuiltOn("Land") -> true
-            tile.isWater && improvement.canBeBuiltOn("Water") -> true
+            newImprovement.isAllowedOnFeature(tile.lastTerrain) -> true
+            tile.isLand && newImprovement.canBeBuiltOn("Land") -> true
+            tile.isWater && newImprovement.canBeBuiltOn("Water") -> true
             // DO NOT reverse this &&. isAdjacentToFreshwater() is a lazy which calls a function, and reversing it breaks the tests.
-            improvement.hasUnique(UniqueType.ImprovementBuildableByFreshWater, stateForConditionals)
+            newImprovement.hasUnique(UniqueType.ImprovementBuildableByFreshWater, stateForConditionals)
                     && tile.isAdjacentTo(Constants.freshWater) -> true
 
             // I don't particularly like this check, but it is required to build mines on non-hill resources
-            resourceIsVisible && tile.tileResource.isImprovedBy(improvement.name) -> true
+            resourceIsVisible && tile.tileResource.isImprovedBy(newImprovement.name) -> true
             // No reason this improvement should be built here, so can't build it
             else -> false
         }
     }
 
+    // function handling when adding a road to the tile
+    fun addRoad(roadType: RoadStatus, creatingCivInfo: Civilization?) {
+        tile.roadStatus = roadType
+        tile.roadIsPillaged = false
+        if (tile.getOwner() != null) {
+            tile.roadOwner = tile.getOwner()!!.civName
+        } else if (creatingCivInfo != null) {
+            tile.roadOwner = creatingCivInfo.civName // neutral tile, use building unit
+            creatingCivInfo.neutralRoads.add(tile.position)
+        }
+    }
+
+    // function handling when removing a road from the tile
+    fun removeRoad() {
+        tile.roadIsPillaged = false
+        if (tile.roadStatus == RoadStatus.None) return
+        tile.roadStatus = RoadStatus.None
+        if (tile.owningCity == null)
+            tile.getRoadOwner()?.neutralRoads?.remove(tile.position)
+    }
+
+    fun startWorkingOnImprovement(improvement: TileImprovement, civInfo: Civilization, unit: MapUnit) {
+        tile.improvementInProgress = improvement.name
+        tile.turnsToImprovement = if (civInfo.gameInfo.gameParameters.godMode) 1
+            else improvement.getTurnsToBuild(civInfo, unit)
+    }
+
+    /** Clears [improvementInProgress][Tile.improvementInProgress] and [turnsToImprovement][Tile.turnsToImprovement] */
+    fun stopWorkingOnImprovement() {
+        tile.improvementInProgress = null
+        tile.turnsToImprovement = 0
+    }
+
+    /** Sets tile improvement to pillaged (without prior checks for validity)
+     *  and ensures that matching [UniqueType.CreatesOneImprovement] queued buildings are removed. */
+    fun setPillaged() {
+        if (!tile.canPillageTile())
+            return
+        // http://well-of-souls.com/civ/civ5_improvements.html says that naval improvements are destroyed upon pillage
+        //    and I can't find any other sources so I'll go with that
+        if (!tile.isLand) {
+            removeImprovement()
+            tile.owningCity?.reassignPopulationDeferred()
+            return
+        }
+
+        // Setting turnsToImprovement might interfere with UniqueType.CreatesOneImprovement
+        removeCreatesOneImprovementMarker()
+        tile.improvementInProgress = null  // remove any in progress work as well
+        tile.turnsToImprovement = 0
+        // if no Repair action, destroy improvements instead
+        if (tile.ruleset.tileImprovements[Constants.repair] == null) {
+            if (tile.canPillageTileImprovement())
+                removeImprovement()
+            else
+                removeRoad()
+        } else {
+            // otherwise use pillage/repair systems
+            if (tile.canPillageTileImprovement())
+                tile.improvementIsPillaged = true
+            else {
+                tile.roadIsPillaged = true
+                clearAllPathfindingCaches()
+            }
+        }
+
+        tile.owningCity?.reassignPopulationDeferred()
+        if (tile.owningCity != null)
+            tile.owningCity!!.civ.cache.updateCivResources()
+    }
+
+    fun setRepaired() {
+        tile.improvementInProgress = null
+        tile.turnsToImprovement = 0
+        if (tile.improvementIsPillaged)
+            tile.improvementIsPillaged = false
+        else
+            tile.roadIsPillaged = false
+
+        tile.owningCity?.reassignPopulationDeferred()
+    }
+
+    /** Does not remove roads */
+    fun removeImprovement() = changeImprovement(null)
 
     fun changeImprovement(improvementName: String?,
                           /** For road assignment and taking over tiles - DO NOT pass when simulating improvement effects! */
@@ -203,9 +291,9 @@
             improvementName?.startsWith(Constants.remove) == true -> {
                 activateRemovalImprovement(improvementName, civToActivateBroaderEffects)
             }
-            improvementName == RoadStatus.Road.name -> tile.addRoad(RoadStatus.Road, civToActivateBroaderEffects)
-            improvementName == RoadStatus.Railroad.name -> tile.addRoad(RoadStatus.Railroad, civToActivateBroaderEffects)
-            improvementName == Constants.repair -> tile.setRepaired()
+            improvementName == RoadStatus.Road.name -> addRoad(RoadStatus.Road, civToActivateBroaderEffects)
+            improvementName == RoadStatus.Railroad.name -> addRoad(RoadStatus.Railroad, civToActivateBroaderEffects)
+            improvementName == Constants.repair -> setRepaired()
             else -> {
                 tile.improvementIsPillaged = false
                 tile.improvement = improvementName
@@ -230,7 +318,7 @@
         if (civToActivateBroaderEffects != null && improvementObject != null
             && improvementObject.hasUnique(UniqueType.TakesOverAdjacentTiles)
         )
-            takeOverTilesAround(civToActivateBroaderEffects, tile)
+            takeOverTilesAround(civToActivateBroaderEffects)
 
         if (civToActivateBroaderEffects != null && improvementObject != null)
             triggerImprovementUniques(improvementObject, civToActivateBroaderEffects, unit)
@@ -254,14 +342,16 @@
             && it.conditionalsApply(stateForConditionals) })
             UniqueTriggerActivation.triggerUnique(unique, civ, unit = unit, tile = tile)
 
-        for (unique in civ.getTriggeredUniques(UniqueType.TriggerUponBuildingImprovement, stateForConditionals)
-            .filter { improvement.matchesFilter(it.params[0]) })
-            UniqueTriggerActivation.triggerUnique(unique, civ, unit = unit, tile = tile)
-
+        //todo An IGetTriggeredUniques would be cleaner, then pass civ and unit directly and call getTriggeredUniques in the loop init
+        fun triggerUponBuildingImprovement(source: () -> Iterable<Unique>) {
+            for (unique in source()) {
+                if (!improvement.matchesFilter(unique.params[0])) continue
+                UniqueTriggerActivation.triggerUnique(unique, civ, unit = unit, tile = tile)
+            }
+        }
+        triggerUponBuildingImprovement { civ.getTriggeredUniques(UniqueType.TriggerUponBuildingImprovement, stateForConditionals) }
         if (unit == null) return
-        for (unique in unit.getTriggeredUniques(UniqueType.TriggerUponBuildingImprovement, stateForConditionals)
-            .filter { improvement.matchesFilter(it.params[0]) })
-            UniqueTriggerActivation.triggerUnique(unique, civ, unit = unit, tile = tile)
+        triggerUponBuildingImprovement { unit.getTriggeredUniques(UniqueType.TriggerUponBuildingImprovement, stateForConditionals).asIterable() }
     }
 
     private fun activateRemovalImprovement(
@@ -276,12 +366,12 @@
                 currentTileImprovement.terrainsCanBeBuiltOn.contains(it) && it == removedFeatureName
             }
             && !currentTileImprovement.terrainsCanBeBuiltOn.contains(tile.baseTerrain)
-        ) tile.removeImprovement()
+        ) removeImprovement()
 
         if (RoadStatus.values().any { improvementName == it.removeAction }) {
-            tile.removeRoad()
+            removeRoad()
         }
-        else if (tile.improvement == removedFeatureName) tile.removeImprovement()
+        else if (tile.improvement == removedFeatureName) removeImprovement()
         else {
             val removedFeatureObject = tile.ruleset.terrains[removedFeatureName]
             if (removedFeatureObject != null
@@ -296,12 +386,11 @@
 
     private fun tryProvideProductionToClosestCity(removedTerrainFeature: String, civ: Civilization) {
         val closestCity = civ.cities.minByOrNull { it.getCenterTile().aerialDistanceTo(tile) }
-        @Suppress("FoldInitializerAndIfToElvis")
-        if (closestCity == null) return
+            ?: return
         val distance = closestCity.getCenterTile().aerialDistanceTo(tile)
         var productionPointsToAdd = if (distance == 1) 20 else 20 - (distance - 2) * 5
-        if (tile.owningCity == null || tile.owningCity!!.civ != civ) productionPointsToAdd =
-            productionPointsToAdd * 2 / 3
+        if (tile.owningCity == null || tile.owningCity!!.civ != civ)
+            productionPointsToAdd = productionPointsToAdd * 2 / 3
         if (productionPointsToAdd > 0) {
             closestCity.cityConstructions.addProductionPoints(productionPointsToAdd)
             val locations = LocationAction(tile.position, closestCity.location)
@@ -312,7 +401,7 @@
         }
     }
 
-    private fun takeOverTilesAround(civ: Civilization, tile: Tile) {
+    private fun takeOverTilesAround(civ: Civilization) {
         // This method should only be called for a citadel - therefore one of the neighbour tile
         // must belong to unit's civ, so minByOrNull in the nearestCity formula should be never `null`.
         // That is, unless a mod does not specify the proper unique - then fallbackNearestCity will take over.
@@ -358,6 +447,12 @@
     }
 
 
+    /** Checks if this tile is marked as target tile for a building with a [UniqueType.CreatesOneImprovement] unique */
+    fun isMarkedForCreatesOneImprovement() =
+        tile.turnsToImprovement < 0 && tile.improvementInProgress != null
+    /** Checks if this tile is marked as target tile for a building with a [UniqueType.CreatesOneImprovement] unique creating a specific [improvement] */
+    fun isMarkedForCreatesOneImprovement(improvement: String) =
+        tile.turnsToImprovement < 0 && tile.improvementInProgress == improvement
 
     /** Marks tile as target tile for a building with a [UniqueType.CreatesOneImprovement] unique */
     fun markForCreatesOneImprovement(improvement: String) {
@@ -368,10 +463,19 @@
     /** Un-Marks a tile as target tile for a building with a [UniqueType.CreatesOneImprovement] unique,
      *  and ensures that matching queued buildings are removed. */
     fun removeCreatesOneImprovementMarker() {
-        if (!tile.isMarkedForCreatesOneImprovement()) return
+        if (!isMarkedForCreatesOneImprovement()) return
         tile.owningCity?.cityConstructions?.removeCreateOneImprovementConstruction(tile.improvementInProgress!!)
-        tile.stopWorkingOnImprovement()
+        stopWorkingOnImprovement()
     }
 
 
+    private fun clearAllPathfindingCaches() {
+        val units = tile.tileMap.gameInfo.civilizations.asSequence()
+            .filter { it.isAlive() }
+            .flatMap { it.units.getCivUnits() }
+        Log.debug("%s: road pillaged, clearing cache for %d units", this, { units.count() })
+        for (otherUnit in units) {
+            otherUnit.movement.clearPathfindingCache()
+        }
+    }
 }
Index: core/src/com/unciv/logic/map/tile/TileStatFunctions.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/core/src/com/unciv/logic/map/tile/TileStatFunctions.kt b/core/src/com/unciv/logic/map/tile/TileStatFunctions.kt
--- a/core/src/com/unciv/logic/map/tile/TileStatFunctions.kt	
+++ b/core/src/com/unciv/logic/map/tile/TileStatFunctions.kt	
@@ -19,8 +19,8 @@
     return stats
 }
 
-class TileStatFunctions(val tile: Tile) {
-    private val riverTerrain by lazy { tile.ruleset.terrains[Constants.river] }
+internal interface TileStatFunctions {
+    private val tile get() = (this as Tile)
 
     fun getTileStats(
         observingCiv: Civilization?,
@@ -86,13 +86,13 @@
         }
 
         if (tile.isAdjacentToRiver()) {
-            if (riverTerrain == null)
+            if (tile.riverTerrain == null)
                 listOfStats.add("River" to Stats(gold = 1f))  // Fallback for legacy mods
             else
                 //TODO this is one approach to get these stats in - supporting only the Stats UniqueType.
                 //     Alternatives: append riverTerrain to allTerrains, or append riverTerrain.uniques to
                 //     the Tile's UniqueObjects/UniqueMap (while copying onl<e> base Stats directly here)
-                listOfStats += getSingleTerrainStats(riverTerrain!!, stateForConditionals)
+                listOfStats += getSingleTerrainStats(tile.riverTerrain!!, stateForConditionals)
         }
 
 
@@ -129,7 +129,7 @@
         return listOfStats.filter { !it.second.isEmpty() }.map { it.first to it.second.clone() }
     }
 
-    /** Ensures each stat is >= [other].stat - modifies in place */
+    /** Ensures each stat is >= [minimumStats].stat - modifies in place */
     private fun missingFromMinimum(current: Stats, minimumStats: Stats): Stats {
         // Note: Not `for ((stat, value) in other)` - that would skip zero values
         val missingStats = Stats()
@@ -231,7 +231,7 @@
     fun getTileStartScore(cityCenterMinStats: Stats): Float {
         var sum = 0f
         for (closeTile in tile.getTilesInDistance(2)) {
-            val tileYield = closeTile.stats.getTileStartYield(
+            val tileYield = closeTile.getTileStartYield(
                 if (closeTile == tile) cityCenterMinStats else Stats.ZERO
             )
             sum += tileYield
@@ -253,7 +253,7 @@
         return sum
     }
 
-    private fun getTileStartYield(minimumStats: Stats) =
+    fun getTileStartYield(minimumStats: Stats) =
         getTerrainStatsBreakdown().toStats().run {
             if (tile.resource != null) add(tile.tileResource)
             add(missingFromMinimum(this, minimumStats))
@@ -261,7 +261,9 @@
         }
 
     /** Returns the extra stats that we would get if we switched to this improvement
-     * Can be negative if we're switching to a worse improvement */
+     *  - Can be negative if we're switching to a worse improvement
+     *  - The virtual Tile this compares with won't be pillaged, so this function with improvement == tile.getTileImprovement() can be used to calculate a repairing effect.
+     */
     fun getStatDiffForImprovement(
         improvement: TileImprovement,
         observingCiv: Civilization,
@@ -274,7 +276,7 @@
         tileClone.setTerrainTransients()
 
         tileClone.changeImprovement(improvement.name)
-        val futureStats = tileClone.stats.getTileStats(city, observingCiv, cityUniqueCache)
+        val futureStats = tileClone.getTileStats(city, observingCiv, cityUniqueCache)
 
         return futureStats.minus(currentStats)
     }
```
</details>

... as you can see, eliminate a step, remove Tile.stats and Tile.improvementFunctions while maintaining "partial class" file split. That enabling trick in there (`private val tile get() = (this as Tile)`) was the last after a long experimentation session with delegation. A `val tile: Tile` abstract in both interfaces then an `override val tile get() = this` is under the hood exactly the same - except the getter exists only once. But for readability I preferred the local `this as` helper after some dice-throwing.

IMHO that makes for better readability in many cases, reduces confusion when a `stats` isn't a `Stats`, and adds maintainability - moving code between the files gets to be a local operation no longer touching all call sites. The interface architecture over a "bunch of extension functions" approach saves the imports, completing the picture.

What do you say - Do we want to go that path? That patch treats only one master class, and there's other big classes using similar "library code in a member field instace" approaches, aren't there? Those I'd go looking for later.

... Does this making `getImprovement()` easier too or not? Not. But not harder either. Such a cache could make good use of that other PR... #11536 and feels to me like it could be noticeable. If you include the inprogress one too.