### PR TITLE
Better portrait city-screen UI

### DIFF
--- a/core/src/com/unciv/ui/screens/cityscreen/CityConstructionsTable.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/CityConstructionsTable.kt
@@ -131,7 +131,7 @@ class CityConstructionsTable(private val cityScreen: CityScreen) {
     fun addActorsToStage() {
         cityScreen.stage.addActor(upperTable)
         cityScreen.stage.addActor(lowerTable)
-        lowerTable.setPosition(posFromEdge, posFromEdge, Align.bottomLeft)
+        lowerTable.setPosition(posFromEdge, if (cityScreen.isPortrait()) posFromEdge + 60f else posFromEdge,  Align.bottomLeft)
     }
 
     fun update(selectedConstruction: IConstruction?) {

--- a/core/src/com/unciv/ui/screens/cityscreen/CityConstructionsTable.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/CityConstructionsTable.kt
@@ -131,7 +131,7 @@ class CityConstructionsTable(private val cityScreen: CityScreen) {
     fun addActorsToStage() {
         cityScreen.stage.addActor(upperTable)
         cityScreen.stage.addActor(lowerTable)
-        lowerTable.setPosition(posFromEdge, if (cityScreen.isPortrait()) posFromEdge + 60f else posFromEdge,  Align.bottomLeft)
+        lowerTable.setPosition(posFromEdge, if (cityScreen.isPortrait()) posFromEdge + 70f else posFromEdge,  Align.bottomLeft)
     }
 
     fun update(selectedConstruction: IConstruction?) {

--- a/core/src/com/unciv/ui/screens/cityscreen/CityScreen.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/CityScreen.kt
@@ -23,6 +23,7 @@ import com.unciv.ui.audio.CityAmbiencePlayer
 import com.unciv.ui.audio.SoundPlayer
 import com.unciv.ui.components.extensions.colorFromRGB
 import com.unciv.ui.components.extensions.disable
+import com.unciv.ui.components.extensions.enable
 import com.unciv.ui.components.extensions.packIfNeeded
 import com.unciv.ui.components.extensions.toTextButton
 import com.unciv.ui.components.input.KeyCharAndCode
@@ -181,12 +182,6 @@ class CityScreen(
 
         // Rest of screen: Map of surroundings
         updateTileGroups()
-        if (isPortrait()) mapScrollPane.apply {
-            // center scrolling so city center sits more to the bottom right
-            scrollX = (maxX - constructionsTable.getLowerWidth() - posFromEdge) / 2
-            scrollY = (maxY - cityStatsTable.packIfNeeded().height - posFromEdge + cityPickerTable.top) / 2
-            updateVisualScroll()
-        }
     }
 
     internal fun updateWithoutConstructionAndMap() {
@@ -544,6 +539,9 @@ class CityScreen(
         cityPickerTable.isVisible = false
         exitCityButton.isVisible = false
         razeCityButtonHolder.isVisible = false
+        cityVerticalTabs.constructionButton.disable()
+        cityVerticalTabs.viewCityButton.enable()
+        cityVerticalTabs.viewBuildingsButton.enable()
     }
 
     fun selectCityPanel() {
@@ -553,6 +551,9 @@ class CityScreen(
         cityPickerTable.isVisible = true
         exitCityButton.isVisible = true
         razeCityButtonHolder.isVisible = true
+        cityVerticalTabs.constructionButton.enable()
+        cityVerticalTabs.viewCityButton.disable()
+        cityVerticalTabs.viewBuildingsButton.enable()
     }
 
     fun selectCityBuildingsPanel() {
@@ -562,6 +563,9 @@ class CityScreen(
         cityPickerTable.isVisible = false
         exitCityButton.isVisible = false
         razeCityButtonHolder.isVisible = false
+        cityVerticalTabs.constructionButton.enable()
+        cityVerticalTabs.viewCityButton.enable()
+        cityVerticalTabs.viewBuildingsButton.disable()
     }
 
     // Don't use passOnCityAmbiencePlayer here - continuing play on the replacement screen would be nice,

--- a/core/src/com/unciv/ui/screens/cityscreen/CityScreen.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/CityScreen.kt
@@ -98,6 +98,8 @@ class CityScreen(
     /** Displays city name, allows switching between cities - sits on BOTTOM CENTER */
     private var cityPickerTable = CityScreenCityPickerTable(this)
 
+    private var cityVerticalTabs = CityVerticalTabs(this)
+
     /** Button for exiting the city - sits on BOTTOM CENTER */
     private val exitCityButton = "Exit city".toTextButton().apply {
         labelCell.pad(10f)
@@ -154,6 +156,11 @@ class CityScreen(
         stage.addActor(tileTable)
         stage.addActor(cityPickerTable)  // add late so it's top in Z-order and doesn't get covered in cramped portrait
         stage.addActor(exitCityButton)
+        if (isPortrait()) {
+            stage.addActor(cityVerticalTabs)
+            selectCityPanel()
+        }
+
         update()
 
         globalShortcuts.add(KeyboardBinding.PreviousCity) { page(-1) }
@@ -166,7 +173,8 @@ class CityScreen(
         // Recalculate Stats
         city.cityStats.update()
 
-        constructionsTable.isVisible = !isSpying
+        if (!isPortrait())
+            constructionsTable.isVisible = !isSpying
         constructionsTable.update(selectedConstruction)
 
         updateWithoutConstructionAndMap()
@@ -199,12 +207,16 @@ class CityScreen(
             !isPortrait() -> 0f
             else -> constructionsTable.getLowerWidth()
         }
-
         // Bottom center: Name, paging, exit city button
         val centeredX = (stage.width - leftMargin - rightMargin) / 2 + leftMargin
-        exitCityButton.setPosition(centeredX, 10f, Align.bottom)
+        if (isPortrait()) {
+            cityVerticalTabs.setPosition(stage.width / 2, cityVerticalTabs.height / 2, Align.bottom)
+        }
+        val exitCityButtonHeight = if (isPortrait()) 60f else 20f
+
+        exitCityButton.setPosition(stage.width / 2, exitCityButtonHeight, Align.bottom)
         cityPickerTable.update()
-        cityPickerTable.setPosition(centeredX, exitCityButton.top + 10f, Align.bottom)
+        cityPickerTable.setPosition(stage.width / 2, exitCityButton.top + 10f, Align.bottom)
 
         // Top right of screen: Stats / Specialists
         var statsHeight = stage.height - posFromEdge * 2
@@ -523,6 +535,33 @@ class CityScreen(
         val newCityScreen = CityScreen(viewableCities[indexOfNextCity], ambiencePlayer = passOnCityAmbiencePlayer())
         newCityScreen.update()
         game.replaceCurrentScreen(newCityScreen)
+    }
+
+    fun selectConstructionPanel() {
+        constructionsTable.isVisible = true
+        selectedConstructionTable.isVisible = true
+        cityStatsTable.isVisible = false
+        cityPickerTable.isVisible = false
+        exitCityButton.isVisible = false
+        razeCityButtonHolder.isVisible = false
+    }
+
+    fun selectCityPanel() {
+        constructionsTable.isVisible = false
+        selectedConstructionTable.isVisible = false
+        cityStatsTable.isVisible = false
+        cityPickerTable.isVisible = true
+        exitCityButton.isVisible = true
+        razeCityButtonHolder.isVisible = true
+    }
+
+    fun selectCityBuildingsPanel() {
+        constructionsTable.isVisible = false
+        selectedConstructionTable.isVisible = false
+        cityStatsTable.isVisible = true
+        cityPickerTable.isVisible = false
+        exitCityButton.isVisible = false
+        razeCityButtonHolder.isVisible = false
     }
 
     // Don't use passOnCityAmbiencePlayer here - continuing play on the replacement screen would be nice,

--- a/core/src/com/unciv/ui/screens/cityscreen/CityScreen.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/CityScreen.kt
@@ -205,9 +205,9 @@ class CityScreen(
         // Bottom center: Name, paging, exit city button
         val centeredX = (stage.width - leftMargin - rightMargin) / 2 + leftMargin
         if (isPortrait()) {
-            cityVerticalTabs.setPosition(stage.width / 2, cityVerticalTabs.height / 2, Align.bottom)
+            cityVerticalTabs.setPosition(stage.width / 2, cityVerticalTabs.height / 2 + 10f, Align.bottom)
         }
-        val exitCityButtonHeight = if (isPortrait()) 60f else 20f
+        val exitCityButtonHeight = if (isPortrait()) 70f else 20f
 
         exitCityButton.setPosition(stage.width / 2, exitCityButtonHeight, Align.bottom)
         cityPickerTable.update()

--- a/core/src/com/unciv/ui/screens/cityscreen/CityScreenCityPickerTable.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/CityScreenCityPickerTable.kt
@@ -72,7 +72,7 @@ class CityScreenCityPickerTable(private val cityScreen: CityScreen) : Table() {
             cityNameTable.add(UnitGroup(garrison, 30f)).padLeft(5f)
         }
 
-        add(cityNameTable).width(stage.width / 4)
+        add(cityNameTable).width((stage.width / 4).coerceAtLeast(300f))
 
         if (cityScreen.viewableCities.size > 1) {
             val nextCityButton = Table() // so we gt a wider clickable area than just the image itself

--- a/core/src/com/unciv/ui/screens/cityscreen/CityVerticalTabs.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/CityVerticalTabs.kt
@@ -22,3 +22,4 @@ class CityVerticalTabs(cityScreen: CityScreen) : HorizontalGroup() {
         addActor(viewBuildingsButton)
     }
 }
+

--- a/core/src/com/unciv/ui/screens/cityscreen/CityVerticalTabs.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/CityVerticalTabs.kt
@@ -1,0 +1,25 @@
+package com.unciv.ui.screens.cityscreen
+
+import com.badlogic.gdx.scenes.scene2d.ui.HorizontalGroup
+import com.badlogic.gdx.scenes.scene2d.ui.TextButton
+import com.badlogic.gdx.utils.Align
+import com.unciv.ui.components.extensions.toTextButton
+import com.unciv.ui.components.input.onClick
+
+class CityVerticalTabs(cityScreen: CityScreen) : HorizontalGroup() {
+    private val constructionButton = "Constructions".toTextButton()
+    private val viewCityButton = "View City".toTextButton()
+    private val viewBuildingsButton = "Buildings".toTextButton()
+    init {
+        align(Align.bottom)
+        space(10f)
+
+        constructionButton.onClick { cityScreen.selectConstructionPanel() }
+        viewCityButton.onClick { cityScreen.selectCityPanel() }
+        viewBuildingsButton.onClick { cityScreen.selectCityBuildingsPanel() }
+
+        addActor(constructionButton)
+        addActor(viewCityButton)
+        addActor(viewBuildingsButton)
+    }
+}

--- a/core/src/com/unciv/ui/screens/cityscreen/CityVerticalTabs.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/CityVerticalTabs.kt
@@ -1,15 +1,14 @@
 package com.unciv.ui.screens.cityscreen
 
 import com.badlogic.gdx.scenes.scene2d.ui.HorizontalGroup
-import com.badlogic.gdx.scenes.scene2d.ui.TextButton
 import com.badlogic.gdx.utils.Align
 import com.unciv.ui.components.extensions.toTextButton
 import com.unciv.ui.components.input.onClick
 
 class CityVerticalTabs(cityScreen: CityScreen) : HorizontalGroup() {
-    private val constructionButton = "Constructions".toTextButton()
-    private val viewCityButton = "View City".toTextButton()
-    private val viewBuildingsButton = "Buildings".toTextButton()
+    val constructionButton = "Constructions".toTextButton()
+    val viewCityButton = "View City".toTextButton()
+    val viewBuildingsButton = "Buildings".toTextButton()
     init {
         align(Align.bottom)
         space(10f)

--- a/core/src/com/unciv/ui/screens/worldscreen/status/StatusButtons.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/status/StatusButtons.kt
@@ -24,7 +24,7 @@ class StatusButtons(
                 addActorAt(0, button)
             }
         }
-    
+
 
     init {
         space(10f)


### PR DESCRIPTION
This PR aims to improve the portrait experience by improving the city-screen UI, but is more of an attempt than an actual solution.

The main problem with the city-screen is that there isn't enough space for the two panels and to actually see the tiles as well.
As a solution I created a tab system to only show one of them at a time. It might look nicer if these buttons were rectangular, the same size and took an entire width.
As you can see from the pictures it's still a little rough, especially with the tile selection in the bottom right. And that add to queue button might be a little off.

Also, I want to put the multiplayer status button in line with the AutoPlay status button instead of on a completely new row but I haven't been able to figure it out. 

Any thoughts?


<details><summary>Pictures</summary>

![VerticalBuildings](https://github.com/yairm210/Unciv/assets/7538725/99e815d7-b807-49ea-b5cc-8819327b3325)
![VerticalCityPage](https://github.com/yairm210/Unciv/assets/7538725/6b8fcaac-cd96-4c40-8b5d-bfa15fc1755c)
![VerticalConstructions](https://github.com/yairm210/Unciv/assets/7538725/11b1fb41-4d4d-4c74-92d0-ecbe7751cb8f)
![VerticalStatusButtons](https://github.com/yairm210/Unciv/assets/7538725/6477e287-0578-436d-b069-c88fb4cb262b)

</details> 