### PR TITLE
Added spy steal tech timer

### DIFF
--- a/core/src/com/unciv/ui/screens/overviewscreen/EspionageOverviewScreen.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/EspionageOverviewScreen.kt
@@ -85,7 +85,8 @@ class EspionageOverviewScreen(val civInfo: Civilization, val worldScreen: WorldS
             spySelectionTable.add(spy.name.toLabel())
             spySelectionTable.add(spy.rank.toLabel())
             spySelectionTable.add(spy.getLocationName().toLabel())
-            val actionString = if (spy.action.hasTurns) "[${spy.action.displayString}] ${spy.turnsRemainingForAction}${Fonts.turn}"
+            val actionString = if (spy.action.showTurns && spy.turnsRemainingForAction != -1) 
+                "[${spy.action.displayString}] ${spy.turnsRemainingForAction}${Fonts.turn}"
                 else spy.action.displayString
             spySelectionTable.add(actionString.toLabel())
 


### PR DESCRIPTION
UI change of #7610.

All other timed spy actions except for stealing technology has a timer. 
This PR adds a rough but correct timer that counts down until the spy steals the technology. This makes the spy game more interactive and allows the player to manage their spies better. It also doesn't give the player too much information because switching the spy to another city takes an extra 4 turns.

<details><summary>Pictures</summary>

![SpyStealTechTimer1](https://github.com/yairm210/Unciv/assets/7538725/28febd3b-727e-4438-b1a7-8835cafc08d3)
![SpyStealTechTimer2](https://github.com/yairm210/Unciv/assets/7538725/15bfdc81-741c-4c71-a3e4-90e0766cdb22)

</details> 

Note: I needed to split hasCountdownTurns and showTurns from hasTurns because StealTech doesn't use the countdown timer, it needs to be re-calculated every turn.