### PR TITLE
Console: Create natural wonder and `tile find`

### DIFF
--- a/core/src/com/unciv/logic/civilization/transients/CivInfoTransientCache.kt
+++ b/core/src/com/unciv/logic/civilization/transients/CivInfoTransientCache.kt
@@ -217,7 +217,8 @@ class CivInfoTransientCache(val civInfo: Civilization) {
         }
     }
 
-    private fun discoverNaturalWonders() {
+    /** Visible for DevConsole use only */
+    fun discoverNaturalWonders() {
         val newlyViewedNaturalWonders = HashSet<Tile>()
         for (tile in civInfo.viewableTiles) {
             if (tile.naturalWonder != null && !civInfo.naturalWonders.contains(tile.naturalWonder!!))

--- a/core/src/com/unciv/ui/screens/devconsole/ConsoleParameterTypes.kt
+++ b/core/src/com/unciv/ui/screens/devconsole/ConsoleParameterTypes.kt
@@ -22,7 +22,7 @@ internal enum class ConsoleParameterType(
     promotionName( { ruleset.unitPromotions.keys } ),
     improvementName( { ruleset.tileImprovements.keys } ),
     featureName( { ruleset.terrains.values.filter { it.type == TerrainType.TerrainFeature }.map { it.name } } ),
-    terrainName( { ruleset.terrains.values.filter { it.type.isBaseTerrain }.map { it.name } } ),
+    terrainName( { ruleset.terrains.values.filter { it.type.isBaseTerrain || it.type == TerrainType.NaturalWonder }.map { it.name } } ),
     resourceName( { ruleset.tileResources.keys } ),
     stat( { Stat.names() } ),
     religionName( { religions.keys } ),

--- a/core/src/com/unciv/ui/screens/devconsole/ConsoleTileCommands.kt
+++ b/core/src/com/unciv/ui/screens/devconsole/ConsoleTileCommands.kt
@@ -3,9 +3,15 @@ package com.unciv.ui.screens.devconsole
 import com.unciv.Constants
 import com.unciv.logic.city.City
 import com.unciv.logic.civilization.Civilization
+import com.unciv.logic.civilization.LocationAction
+import com.unciv.logic.civilization.Notification
+import com.unciv.logic.civilization.NotificationCategory
+import com.unciv.logic.civilization.NotificationIcon
 import com.unciv.logic.map.mapgenerator.RiverGenerator
 import com.unciv.logic.map.mapgenerator.RiverGenerator.RiverDirections
 import com.unciv.logic.map.tile.RoadStatus
+import com.unciv.logic.map.tile.Tile
+import com.unciv.models.ruleset.tile.Terrain
 import com.unciv.models.ruleset.tile.TerrainType
 
 class ConsoleTileCommands: ConsoleCommandNode {
@@ -74,12 +80,10 @@ class ConsoleTileCommands: ConsoleCommandNode {
             val selectedTile = console.getSelectedTile()
             val terrain = console.gameInfo.ruleset.terrains.values.findCliInput(params[0])
                 ?: throw ConsoleErrorException("Unknown terrain")
-            if (terrain.type != selectedTile.getBaseTerrain().type)
-                throw ConsoleErrorException("Changing terrain type is not allowed")
-            selectedTile.baseTerrain = terrain.name
-            selectedTile.setTerrainTransients()
-            selectedTile.getCity()?.reassignPopulation()
-            DevConsoleResponse.OK
+            if (terrain.type == TerrainType.NaturalWonder)
+                setNaturalWonder(selectedTile, terrain)
+            else
+                setBaseTerrain(selectedTile, terrain)
         },
 
         "setresource" to ConsoleAction("tile setresource <resourceName>") { console, params ->
@@ -124,7 +128,47 @@ class ConsoleTileCommands: ConsoleCommandNode {
             newOwner?.expansion?.takeOwnership(selectedTile)
             DevConsoleResponse.OK
         },
+
+        "find" to ConsoleAction("tile find <tileFilter>") { console, params ->
+            val filter = params[0]
+            val locations = console.gameInfo.tileMap.tileList
+                .filter { it.matchesFilter(filter) }
+                .map { it.position }
+            if (locations.isEmpty()) DevConsoleResponse.hint("None found")
+            else {
+                val notification = Notification("tile find [$filter]", arrayOf(NotificationIcon.Spy),
+                    LocationAction(locations).asIterable(), NotificationCategory.General)
+                console.screen.notificationsScroll.oneTimeNotification = notification
+                notification.execute(console.screen)
+                DevConsoleResponse.OK
+            }
+        },
     )
+
+    private fun setBaseTerrain(tile: Tile, terrain: Terrain): DevConsoleResponse {
+        if (terrain.type != tile.getBaseTerrain().type)
+            throw ConsoleErrorException("Changing terrain type is not allowed")
+        setBaseTerrain(tile, terrain.name)
+        return DevConsoleResponse.OK
+    }
+    private fun setBaseTerrain(tile: Tile, terrainName: String) {
+        tile.baseTerrain = terrainName
+        tile.setTerrainTransients()
+        tile.getCity()?.reassignPopulation()
+    }
+    private fun setNaturalWonder(tile: Tile, wonder: Terrain): DevConsoleResponse {
+        tile.removeTerrainFeatures()
+        tile.naturalWonder = wonder.name
+        setBaseTerrain(tile, wonder.turnsInto ?: tile.baseTerrain)
+        for (civ in tile.tileMap.gameInfo.civilizations) {
+            if (wonder.name in civ.naturalWonders) continue
+            if (civ.isDefeated() || civ.isBarbarian() || civ.isSpectator()) continue
+            if (!civ.hasExplored(tile)) continue
+            civ.cache.discoverNaturalWonders()
+            civ.updateStatsForNextTurn()
+        }
+        return DevConsoleResponse.OK
+    }
 
     private fun getTerrainFeature(console: DevConsolePopup, param: String) =
         console.gameInfo.ruleset.terrains.values.asSequence()


### PR DESCRIPTION
Usage:
- `tile setterrain natural-wonder`: autocomplete and cli-input support
- `file find tilefilter`: Neither autocomplete nor cli-input support, meaning you need to supply the filter case-sensitive and quoted if need be, same as `checkfilter`. Uses same notification concept as "show me resources" from the overview etc

Drawback:
- Removing a Natural Wonder is way harder - no support yet to "unsee" one. The easy code would leave the happiness benefit for civs that already have it. Do do it properly - would need to take into account a civ may have seen a Great Barrier Reef tile, but may or may not have seen the other one. Too much effort.