### PR TITLE
Enable buildingFilter values as cityFilter

### DIFF
--- a/core/src/com/unciv/logic/city/City.kt
+++ b/core/src/com/unciv/logic/city/City.kt
@@ -457,7 +457,7 @@ class City : IsPartOfGameInfoSerialization {
             // this will always be true when checked.
             "in cities following this religion" -> true
             "in cities following our religion" -> viewingCiv?.religionManager?.religion == religion.getMajorityReligion()
-            else -> civ.matchesFilter(filter)
+            else -> civ.matchesFilter(filter) || cityConstructions.getBuiltBuildings().any { it.matchesFilter(filter) }
         }
     }
 

--- a/docs/Modders/Unique-parameters.md
+++ b/docs/Modders/Unique-parameters.md
@@ -135,7 +135,8 @@ cityFilters allow us to choose the range of cities affected by this unique:
 - `in cities following our religion`
 - `in all cities in which the majority religion is a major religion`
 - `in all cities in which the majority religion is an enhanced religion`
-- [civFilter]
+- [civFilter] - Owner of the city
+- [buildingFilter] - Building(s) bulit in cities
 
 You can check this in-game using the console with the `city checkfilter <filter>` command
 


### PR DESCRIPTION
As I announced several days ago, I implemented the filtering of the cities with specified building(s), using buildingFilter values as cityFilter.

But there is an issue with wording:
`"[+5 Gold] [Currency]"` means the additional 5 Gold per turn per every city with buildings enabled by Currency tech.

It should be displayed like this:
`5 Gold in cities with Currency building`

I don't know how the uniques are processed from json files to display-ready form.
Explain me that.