### PR TITLE
Added an option to disable move by long press

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -801,6 +801,7 @@ Gameplay =
 Check for idle units = 
 Auto Unit Cycle = 
 Move units with a single tap = 
+Move units with a long tap = 
 Auto-assign city production = 
 Auto-build roads = 
 Automated workers replace improvements = 

--- a/core/src/com/unciv/models/metadata/GameSettings.kt
+++ b/core/src/com/unciv/models/metadata/GameSettings.kt
@@ -36,6 +36,7 @@ class GameSettings {
     var checkForDueUnits: Boolean = true
     var autoUnitCycle: Boolean = true
     var singleTapMove: Boolean = false
+    var longTapMove: Boolean = true
     var language: String = Constants.english
     @Transient
     var locale: Locale? = null

--- a/core/src/com/unciv/ui/popups/options/GameplayTab.kt
+++ b/core/src/com/unciv/ui/popups/options/GameplayTab.kt
@@ -19,6 +19,7 @@ fun gameplayTab(
     optionsPopup.addCheckbox(this, "Check for idle units", settings.checkForDueUnits, true) { settings.checkForDueUnits = it }
     optionsPopup.addCheckbox(this, "Auto Unit Cycle", settings.autoUnitCycle, true) { settings.autoUnitCycle = it }
     optionsPopup.addCheckbox(this, "Move units with a single tap", settings.singleTapMove) { settings.singleTapMove = it }
+    optionsPopup.addCheckbox(this, "Move units with a long tap", settings.longTapMove) { settings.longTapMove = it }
     optionsPopup.addCheckbox(this, "Auto-assign city production", settings.autoAssignCityProduction, true) { shouldAutoAssignCityProduction ->
         settings.autoAssignCityProduction = shouldAutoAssignCityProduction
         val worldScreen = GUI.getWorldScreenIfActive()

--- a/core/src/com/unciv/ui/screens/worldscreen/WorldMapHolder.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/WorldMapHolder.kt
@@ -149,6 +149,7 @@ class WorldMapHolder(
                     ActivationTypes.Longpress else ActivationTypes.RightClick,
                 noEquivalence = true
             ) {
+                if (!UncivGame.Current.settings.longTapMove) return@onActivation
                 val unit = worldScreen.bottomUnitTable.selectedUnit
                     ?: return@onActivation
                 Concurrency.run("WorldScreenClick") {
@@ -230,8 +231,6 @@ class WorldMapHolder(
     }
 
     private fun onTileRightClicked(unit: MapUnit, tile: Tile) {
-        if (!UncivGame.Current.settings.singleTapMove) return
-
         removeUnitActionOverlay()
         selectedTile = tile
         unitMovementPaths.clear()

--- a/core/src/com/unciv/ui/screens/worldscreen/WorldMapHolder.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/WorldMapHolder.kt
@@ -230,6 +230,8 @@ class WorldMapHolder(
     }
 
     private fun onTileRightClicked(unit: MapUnit, tile: Tile) {
+        if (!UncivGame.Current.settings.singleTapMove) return
+
         removeUnitActionOverlay()
         selectedTile = tile
         unitMovementPaths.clear()


### PR DESCRIPTION
I find it annoying when I play on the phone and my units accidentally move because of a registered long tap when I put my finger down to pan on the map and keep it in place for a while before moving it.
The optimal solution that I would like would be to only move the unit after releasing the tap so when I do pan the unit won't move.

This solution would take a bit of work, so instead I am being lazy and adding another option called longTapMove. It is initially enabled but can be disabled to prevent tiles from being right-clicked (long tapped). This solves my problem stated above which probably should have been in a separate issue.

Also, not in this PR but in a different one, I plan to move any automation-based setting in the Gameplay tab to the AutoPlay tab. This will greatly clean up the GameplayTab and give a bit more in the AutoPlay tab. (Even though they aren't technically a part of AutoPlay, maybe we could rename it to automation.)