### PR TITLE
"(modified by game speed)" modifier

### DIFF
--- a/android/assets/jsons/Civ V - Gods & Kings/Beliefs.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Beliefs.json
@@ -209,7 +209,7 @@
     {
         "name": "Initiation Rites",
         "type": "Founder",
-        "uniques": ["[+100 Gold] when a city adopts this religion for the first time (modified by game speed)"]
+        "uniques": ["[+100 Gold] when a city adopts this religion for the first time <(modified by game speed)>"]
     },
     {
         "name": "Interfaith Dialogue",

--- a/core/src/com/unciv/logic/city/managers/CityReligionManager.kt
+++ b/core/src/com/unciv/logic/city/managers/CityReligionManager.kt
@@ -117,7 +117,7 @@ class CityReligionManager : IsPartOfGameInfoSerialization {
                 (
                     religionOwningCiv.getMatchingUniques(UniqueType.StatsWhenAdoptingReligionSpeed)
                     + religionOwningCiv.getMatchingUniques(UniqueType.StatsWhenAdoptingReligion)
-                ).map { it.stats }
+                ).map { it.stats.times(if (!it.isModifiedByGameSpeed()) 1f else city.civ.gameInfo.speed.modifier) }
                 .reduce { acc, stats -> acc + stats }
 
             for ((key, value) in statsGranted)

--- a/core/src/com/unciv/models/ruleset/unique/Conditionals.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Conditionals.kt
@@ -111,13 +111,13 @@ object Conditionals {
             UniqueType.ConditionalWithoutResource -> state.getResourceAmount(condition.params[0]) <= 0
 
             UniqueType.ConditionalWhenAboveAmountStatResource ->
-                checkResourceOrStatAmount(condition.params[1], condition.params[0].toFloat(), Float.MAX_VALUE)
+                checkResourceOrStatAmount(condition.params[1], condition.params[0].toFloat(), Float.MAX_VALUE, unique?.isModifiedByGameSpeed() == true)
                     { current, lowerLimit, _ -> current > lowerLimit }
             UniqueType.ConditionalWhenBelowAmountStatResource ->
-                checkResourceOrStatAmount(condition.params[1], Float.MIN_VALUE, condition.params[0].toFloat())
+                checkResourceOrStatAmount(condition.params[1], Float.MIN_VALUE, condition.params[0].toFloat(), unique?.isModifiedByGameSpeed() == true)
                     { current, _, upperLimit -> current < upperLimit }
             UniqueType.ConditionalWhenBetweenStatResource ->
-                checkResourceOrStatAmount(condition.params[2], condition.params[0].toFloat(), condition.params[1].toFloat())
+                checkResourceOrStatAmount(condition.params[2], condition.params[0].toFloat(), condition.params[1].toFloat(), unique?.isModifiedByGameSpeed() == true)
                     { current, lowerLimit, upperLimit -> current >= lowerLimit && current <= upperLimit }
             UniqueType.ConditionalWhenAboveAmountStatResourceSpeed ->
                 checkResourceOrStatAmount(condition.params[1], condition.params[0].toFloat(), Float.MAX_VALUE, true)

--- a/core/src/com/unciv/models/ruleset/unique/Unique.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Unique.kt
@@ -43,7 +43,7 @@ class Unique(val text: String, val sourceObjectType: UniqueTarget? = null, val s
 
     fun hasFlag(flag: UniqueFlag) = type != null && type.flags.contains(flag)
     fun isHiddenToUsers() = hasFlag(UniqueFlag.HiddenToUsers) || conditionals.any { it.type == UniqueType.ModifierHiddenFromUsers }
-
+    fun isModifiedByGameSpeed() = conditionals.any { it.type == UniqueType.ModifiedByGameSpeed }
     fun hasTriggerConditional(): Boolean {
         if (conditionals.none()) return false
         return conditionals.any { conditional ->

--- a/core/src/com/unciv/models/ruleset/unique/UniqueFlag.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueFlag.kt
@@ -5,6 +5,7 @@ import java.util.EnumSet
 enum class UniqueFlag {
     HiddenToUsers,
     NoConditionals,
+    AcceptsSpeedModifier
     ;
     companion object {
         val setOfHiddenToUsers: EnumSet<UniqueFlag> = EnumSet.of(HiddenToUsers)

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -604,7 +604,9 @@ object UniqueTriggerActivation {
                 ) return null
 
                 return {
-                    val statAmount = unique.params[0].toInt()
+                    var statAmount = unique.params[0].toInt()
+                    if (unique.isModifiedByGameSpeed()) statAmount = (statAmount * civInfo.gameInfo.speed.statCostModifiers[stat]!!).roundToInt()
+
                     val stats = Stats().add(stat, statAmount.toFloat())
                     civInfo.addStats(stats)
 

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -218,8 +218,9 @@ enum class UniqueType(
     DisablesReligion("Starting in this era disables religion", UniqueTarget.Era),
     FreeExtraBeliefs("May choose [amount] additional [beliefType] beliefs when [foundingOrEnhancing] a religion", UniqueTarget.Global),
     FreeExtraAnyBeliefs("May choose [amount] additional belief(s) of any type when [foundingOrEnhancing] a religion", UniqueTarget.Global),
-    StatsWhenAdoptingReligionSpeed("[stats] when a city adopts this religion for the first time (modified by game speed)", UniqueTarget.Global),
     StatsWhenAdoptingReligion("[stats] when a city adopts this religion for the first time", UniqueTarget.Global),
+    @Deprecated("As of 4.11.18", ReplaceWith("[stats] when a city adopts this religion for the first time <(modified by game speed)>"))
+    StatsWhenAdoptingReligionSpeed("[stats] when a city adopts this religion for the first time (modified by game speed)", UniqueTarget.Global),
     NaturalReligionSpreadStrength("[relativeAmount]% Natural religion spread [cityFilter]", UniqueTarget.FollowerBelief, UniqueTarget.Global),
     ReligionSpreadDistance("Religion naturally spreads to cities [amount] tiles away", UniqueTarget.Global, UniqueTarget.FollowerBelief),
     MayNotGenerateGreatProphet("May not generate great prophet equivalents naturally", UniqueTarget.Global),
@@ -687,13 +688,17 @@ enum class UniqueType(
     ConditionalWithoutResource("without [resource]", UniqueTarget.Conditional),
 
     // Supports also stockpileable resources (Gold, Faith, Culture, Science)
-    ConditionalWhenAboveAmountStatResource("when above [amount] [stat/resource]", UniqueTarget.Conditional),
-    ConditionalWhenBelowAmountStatResource("when below [amount] [stat/resource]", UniqueTarget.Conditional),
-    ConditionalWhenBetweenStatResource("when between [amount] and [amount] [stat/resource]", UniqueTarget.Conditional),
+    ConditionalWhenAboveAmountStatResource("when above [amount] [stat/resource]", UniqueTarget.Conditional, flags = setOf(UniqueFlag.AcceptsSpeedModifier)),
+    ConditionalWhenBelowAmountStatResource("when below [amount] [stat/resource]", UniqueTarget.Conditional, flags = setOf(UniqueFlag.AcceptsSpeedModifier)),
+    ConditionalWhenBetweenStatResource("when between [amount] and [amount] [stat/resource]", UniqueTarget.Conditional, flags = setOf(UniqueFlag.AcceptsSpeedModifier)),
 
     // The game speed-adjusted versions of above
+
+    @Deprecated("As of 4.11.18", ReplaceWith("when above [amount] [stat/resource] <(modified by game speed)>"))
     ConditionalWhenAboveAmountStatResourceSpeed("when above [amount] [stat/resource] (modified by game speed)", UniqueTarget.Conditional),
+    @Deprecated("As of 4.11.18", ReplaceWith("when below [amount] [stat/resource] <(modified by game speed)>"))
     ConditionalWhenBelowAmountStatResourceSpeed("when below [amount] [stat/resource] (modified by game speed)", UniqueTarget.Conditional),
+    @Deprecated("As of 4.11.18", ReplaceWith("when between [amount] and [amount] [stat/resource] <(modified by game speed)>"))
     ConditionalWhenBetweenStatResourceSpeed("when between [amount] and [amount] [stat/resource] (modified by game speed)", UniqueTarget.Conditional),
 
     /////// city conditionals
@@ -777,6 +782,7 @@ enum class UniqueType(
     OneTimeProvideResources("Instantly provides [positiveAmount] [stockpiledResource]", UniqueTarget.Triggerable),
 
     OneTimeGainStat("Gain [amount] [stat]", UniqueTarget.Triggerable),
+    @Deprecated("As of 4.11.18", ReplaceWith("Gain [amount] [stat] <(modified by game speed)>"))
     OneTimeGainStatSpeed("Gain [amount] [stat] (modified by game speed)", UniqueTarget.Triggerable),
     OneTimeGainStatRange("Gain [amount]-[amount] [stat]", UniqueTarget.Triggerable),
     OneTimeGainPantheon("Gain enough Faith for a Pantheon", UniqueTarget.Triggerable),
@@ -861,6 +867,8 @@ enum class UniqueType(
     ModifierHiddenFromUsers("hidden from users", UniqueTarget.MetaModifier),
     ForEveryCountable("for every [countable]", UniqueTarget.MetaModifier),
     ForEveryAmountCountable("for every [amount] [countable]", UniqueTarget.MetaModifier),
+    ModifiedByGameSpeed("(modified by game speed)", UniqueTarget.MetaModifier,
+        docDescription = "Can only be applied to certain uniques, see details of each unique for specifics"),
     Comment("Comment [comment]", *UniqueTarget.Displayable,
         docDescription = "Allows displaying arbitrary text in a Unique listing. Only the text within the '[]' brackets will be displayed, the rest serves to allow Ruleset validation to recognize the intent."),
 

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -218,7 +218,7 @@ enum class UniqueType(
     DisablesReligion("Starting in this era disables religion", UniqueTarget.Era),
     FreeExtraBeliefs("May choose [amount] additional [beliefType] beliefs when [foundingOrEnhancing] a religion", UniqueTarget.Global),
     FreeExtraAnyBeliefs("May choose [amount] additional belief(s) of any type when [foundingOrEnhancing] a religion", UniqueTarget.Global),
-    StatsWhenAdoptingReligion("[stats] when a city adopts this religion for the first time", UniqueTarget.Global),
+    StatsWhenAdoptingReligion("[stats] when a city adopts this religion for the first time", UniqueTarget.Global, flags = setOf(UniqueFlag.AcceptsSpeedModifier)),
     @Deprecated("As of 4.11.18", ReplaceWith("[stats] when a city adopts this religion for the first time <(modified by game speed)>"))
     StatsWhenAdoptingReligionSpeed("[stats] when a city adopts this religion for the first time (modified by game speed)", UniqueTarget.Global),
     NaturalReligionSpreadStrength("[relativeAmount]% Natural religion spread [cityFilter]", UniqueTarget.FollowerBelief, UniqueTarget.Global),
@@ -781,7 +781,7 @@ enum class UniqueType(
     OneTimeConsumeResources("Instantly consumes [positiveAmount] [stockpiledResource]", UniqueTarget.Triggerable),
     OneTimeProvideResources("Instantly provides [positiveAmount] [stockpiledResource]", UniqueTarget.Triggerable),
 
-    OneTimeGainStat("Gain [amount] [stat]", UniqueTarget.Triggerable),
+    OneTimeGainStat("Gain [amount] [stat]", UniqueTarget.Triggerable, flags = setOf(UniqueFlag.AcceptsSpeedModifier)),
     @Deprecated("As of 4.11.18", ReplaceWith("Gain [amount] [stat] <(modified by game speed)>"))
     OneTimeGainStatSpeed("Gain [amount] [stat] (modified by game speed)", UniqueTarget.Triggerable),
     OneTimeGainStatRange("Gain [amount]-[amount] [stat]", UniqueTarget.Triggerable),

--- a/desktop/src/com/unciv/app/desktop/UniqueDocsWriter.kt
+++ b/desktop/src/com/unciv/app/desktop/UniqueDocsWriter.kt
@@ -1,6 +1,7 @@
 package com.unciv.app.desktop
 
 import com.unciv.logic.map.mapunit.MapUnitCache
+import com.unciv.models.ruleset.unique.UniqueFlag
 import com.unciv.models.ruleset.unique.UniqueParameterType
 import com.unciv.models.ruleset.unique.UniqueTarget
 import com.unciv.models.ruleset.unique.UniqueType
@@ -84,6 +85,8 @@ class UniqueDocsWriter {
                     val paramExamples = uniqueType.parameterTypeMap.map { it.first().docExample }.toTypedArray()
                     lines += "\tExample: \"${uniqueText.fillPlaceholders(*paramExamples)}\"\n"
                 }
+                if (uniqueType.flags.contains(UniqueFlag.AcceptsSpeedModifier))
+                    lines += "\tThis unique's effect can be modified with &lt;${UniqueType.ModifiedByGameSpeed.text}&gt;"
                 if (uniqueType in MapUnitCache.UnitMovementUniques) {
                     lines += "\tDue to performance considerations, this unique is cached, thus conditionals that may change within a turn may not work."
                 }

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -119,6 +119,7 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 ??? example  "Gain [amount] [stat]"
 	Example: "Gain [3] [Culture]"
 
+	This unique's effect can be modified with &lt;(modified by game speed)&gt;
 	Applicable to: Triggerable
 
 ??? example  "Gain [amount]-[amount] [stat]"
@@ -744,6 +745,7 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 ??? example  "[stats] when a city adopts this religion for the first time"
 	Example: "[+1 Gold, +2 Production] when a city adopts this religion for the first time"
 
+	This unique's effect can be modified with &lt;(modified by game speed)&gt;
 	Applicable to: Global
 
 ??? example  "[relativeAmount]% Natural religion spread [cityFilter]"

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -121,11 +121,6 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 	Applicable to: Triggerable
 
-??? example  "Gain [amount] [stat] (modified by game speed)"
-	Example: "Gain [3] [Culture] (modified by game speed)"
-
-	Applicable to: Triggerable
-
 ??? example  "Gain [amount]-[amount] [stat]"
 	Example: "Gain [3]-[3] [Culture]"
 
@@ -743,11 +738,6 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 ??? example  "May choose [amount] additional belief(s) of any type when [foundingOrEnhancing] a religion"
 	Example: "May choose [3] additional belief(s) of any type when [founding] a religion"
-
-	Applicable to: Global
-
-??? example  "[stats] when a city adopts this religion for the first time (modified by game speed)"
-	Example: "[+1 Gold, +2 Production] when a city adopts this religion for the first time (modified by game speed)"
 
 	Applicable to: Global
 
@@ -2115,31 +2105,19 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 ??? example  "&lt;when above [amount] [stat/resource]&gt;"
 	Example: "&lt;when above [3] [Culture]&gt;"
 
+	This unique's effect can be modified with &lt;(modified by game speed)&gt;
 	Applicable to: Conditional
 
 ??? example  "&lt;when below [amount] [stat/resource]&gt;"
 	Example: "&lt;when below [3] [Culture]&gt;"
 
+	This unique's effect can be modified with &lt;(modified by game speed)&gt;
 	Applicable to: Conditional
 
 ??? example  "&lt;when between [amount] and [amount] [stat/resource]&gt;"
 	Example: "&lt;when between [3] and [3] [Culture]&gt;"
 
-	Applicable to: Conditional
-
-??? example  "&lt;when above [amount] [stat/resource] (modified by game speed)&gt;"
-	Example: "&lt;when above [3] [Culture] (modified by game speed)&gt;"
-
-	Applicable to: Conditional
-
-??? example  "&lt;when below [amount] [stat/resource] (modified by game speed)&gt;"
-	Example: "&lt;when below [3] [Culture] (modified by game speed)&gt;"
-
-	Applicable to: Conditional
-
-??? example  "&lt;when between [amount] and [amount] [stat/resource] (modified by game speed)&gt;"
-	Example: "&lt;when between [3] and [3] [Culture] (modified by game speed)&gt;"
-
+	This unique's effect can be modified with &lt;(modified by game speed)&gt;
 	Applicable to: Conditional
 
 ??? example  "&lt;in this city&gt;"
@@ -2496,6 +2474,10 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 ??? example  "&lt;for every [amount] [countable]&gt;"
 	Example: "&lt;for every [3] [1000]&gt;"
 
+	Applicable to: MetaModifier
+
+??? example  "&lt;(modified by game speed)&gt;"
+	Can only be applied to certain uniques, see details of each unique for specifics
 	Applicable to: MetaModifier
 
 


### PR DESCRIPTION
There are already 5 uniques that have "versions" of themselves with this postfix, which indicates it should be a modifier.
Since only specific uniques will be affected by it, we need modder visibility, meaning we should track this on the unique - a job for flags.

Possible next step is adding a warning when using this modifier on a unique that doesn't accept it

The biggest win isn't the smaller number of uniques, it's the minimization of duplicate code, both present and future