### PR TITLE
Extra Civ and Spy moddability

### DIFF
--- a/core/src/com/unciv/logic/civilization/Civilization.kt
+++ b/core/src/com/unciv/logic/civilization/Civilization.kt
@@ -304,7 +304,6 @@ class Civilization : IsPartOfGameInfoSerialization {
         toReturn.hasMovedAutomatedUnits = hasMovedAutomatedUnits
         toReturn.statsHistory = statsHistory.clone()
         toReturn.resourceStockpiles = resourceStockpiles.clone()
-        toReturn.cityStateTurnsUntilElection = cityStateTurnsUntilElection
         return toReturn
     }
 
@@ -365,7 +364,6 @@ class Civilization : IsPartOfGameInfoSerialization {
     var cityStatePersonality: CityStatePersonality = CityStatePersonality.Neutral
     var cityStateResource: String? = null
     var cityStateUniqueUnit: String? = null // Unique unit for militaristic city state. Might still be null if there are no appropriate units
-    var cityStateTurnsUntilElection: Int = 0
 
     fun hasMetCivTerritory(otherCiv: Civilization): Boolean =
             otherCiv.getCivTerritory().any { gameInfo.tileMap[it].isExplored(this) }
@@ -1000,6 +998,7 @@ class CivilizationInfoPreview() {
 
 enum class CivFlags {
     CityStateGreatPersonGift,
+    TurnsTillCityStateElection,
     TurnsTillNextDiplomaticVote,
     ShowDiplomaticVotingResults,
     ShouldResetDiplomaticVotes,

--- a/core/src/com/unciv/logic/civilization/diplomacy/CityStateFunctions.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/CityStateFunctions.kt
@@ -83,7 +83,7 @@ class CityStateFunctions(val civInfo: Civilization) {
             fun getVotesFromSpy(spy: Spy?): Float {
                 if (spy == null) return 20f
                 var votes = (civInfo.getDiplomacyManager(spy.civInfo).influence / 2)
-                votes += (spy.getSkillModifier() * spy.getEfficiencyModifier()).toFloat() // ranges from 30 to 90
+                votes += (spy.getSkillModifierPercent() * spy.getEfficiencyModifier()).toFloat() // ranges from 30 to 90
                 return votes
             }
 

--- a/core/src/com/unciv/logic/civilization/diplomacy/DeclareWar.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DeclareWar.kt
@@ -135,8 +135,8 @@ object DeclareWar {
         diplomacyManager.updateHasOpenBorders()
 
         diplomacyManager.removeModifier(DiplomaticModifiers.YearsOfPeace)
-        diplomacyManager.setFlag(DiplomacyFlags.DeclinedPeace, diplomacyManager.civInfo.gameInfo.ruleset.modOptions.constants.minWarDuration)/// AI won't propose peace for 10 turns
-        diplomacyManager.setFlag(DiplomacyFlags.DeclaredWar, diplomacyManager.civInfo.gameInfo.ruleset.modOptions.constants.minWarDuration) // AI won't agree to trade for 10 turns
+        diplomacyManager.setFlag(DiplomacyFlags.DeclinedPeace, diplomacyManager.civInfo.gameInfo.ruleset.modOptions.constants.minimumWarDuration)/// AI won't propose peace for 10 turns
+        diplomacyManager.setFlag(DiplomacyFlags.DeclaredWar, diplomacyManager.civInfo.gameInfo.ruleset.modOptions.constants.minimumWarDuration) // AI won't agree to trade for 10 turns
         diplomacyManager.removeFlag(DiplomacyFlags.BorderConflict)
     }
 

--- a/core/src/com/unciv/logic/civilization/diplomacy/DeclareWar.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DeclareWar.kt
@@ -135,8 +135,8 @@ object DeclareWar {
         diplomacyManager.updateHasOpenBorders()
 
         diplomacyManager.removeModifier(DiplomaticModifiers.YearsOfPeace)
-        diplomacyManager.setFlag(DiplomacyFlags.DeclinedPeace, 10)/// AI won't propose peace for 10 turns
-        diplomacyManager.setFlag(DiplomacyFlags.DeclaredWar, 10) // AI won't agree to trade for 10 turns
+        diplomacyManager.setFlag(DiplomacyFlags.DeclinedPeace, diplomacyManager.civInfo.gameInfo.ruleset.modOptions.constants.minWarDuration)/// AI won't propose peace for 10 turns
+        diplomacyManager.setFlag(DiplomacyFlags.DeclaredWar, diplomacyManager.civInfo.gameInfo.ruleset.modOptions.constants.minWarDuration) // AI won't agree to trade for 10 turns
         diplomacyManager.removeFlag(DiplomacyFlags.BorderConflict)
     }
 

--- a/core/src/com/unciv/logic/civilization/diplomacy/DeclareWar.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DeclareWar.kt
@@ -72,11 +72,11 @@ object DeclareWar {
                 otherCiv.popupAlerts.add(PopupAlert(AlertType.WarDeclaration, civInfo.civName))
 
                 otherCiv.addNotification("[${civInfo.civName}] has declared war on us!",
-                    NotificationCategory.Diplomacy, NotificationIcon.War, civInfo.civName)
+                    NotificationCategory.Diplomacy, otherCiv.civName, NotificationIcon.War, civInfo.civName)
 
                 diplomacyManager.getCommonKnownCivsWithSpectators().forEach {
-                    it.addNotification("[${civInfo.civName}] has declared war on [${diplomacyManager.otherCivName}]!",
-                        NotificationCategory.Diplomacy, civInfo.civName, NotificationIcon.War, otherCiv.civName)
+                    it.addNotification("[${civInfo.civName}] has declared war on [${otherCiv.civName}]!",
+                        NotificationCategory.Diplomacy, otherCiv.civName, NotificationIcon.War, civInfo.civName)
                 }
             }
             WarType.DefensivePactWar, WarType.CityStateAllianceWar, WarType.JoinWar -> {
@@ -86,18 +86,40 @@ object DeclareWar {
                 val defender = if (declareWarReason.warType == WarType.DefensivePactWar) civInfo else otherCiv
 
                 defender.addNotification("[${agressor.civName}] has joined [${allyCiv.civName}] in the war against us!",
-                    NotificationCategory.Diplomacy, NotificationIcon.War, agressor.civName)
+                    NotificationCategory.Diplomacy, defender.civName, NotificationIcon.War, allyCiv.civName, agressor.civName)
 
                 agressor.addNotification("We have joined [${allyCiv.civName}] in the war against [${defender.civName}]!",
-                    NotificationCategory.Diplomacy, NotificationIcon.War, defender.civName)
+                    NotificationCategory.Diplomacy, defender.civName, NotificationIcon.War, allyCiv.civName, agressor.civName)
 
                 diplomacyManager.getCommonKnownCivsWithSpectators().filterNot { it == allyCiv }.forEach {
                     it.addNotification("[${agressor.civName}] has joined [${allyCiv.civName}] in the war against [${defender.civName}]!",
-                        NotificationCategory.Diplomacy, agressor.civName, NotificationIcon.War, defender.civName)
+                        NotificationCategory.Diplomacy, defender.civName, NotificationIcon.War, allyCiv.civName, agressor.civName)
                 }
 
                 allyCiv.addNotification("[${agressor.civName}] has joined us in the war against [${defender.civName}]!",
-                        NotificationCategory.Diplomacy, agressor.civName, NotificationIcon.War, defender.civName)
+                        NotificationCategory.Diplomacy, defender.civName, NotificationIcon.War, allyCiv.civName, agressor.civName)
+            }
+            WarType.TeamWar -> {
+                val allyCiv = declareWarReason.allyCiv!!
+                // We only want to send these notifications once, it doesn't matter who sends it though
+                if (civInfo.gameInfo.civilizations.indexOf(civInfo) > civInfo.gameInfo.civilizations.indexOf(allyCiv)) return
+
+                otherCiv.popupAlerts.add(PopupAlert(AlertType.WarDeclaration, civInfo.civName))
+                otherCiv.popupAlerts.add(PopupAlert(AlertType.WarDeclaration, allyCiv.civName))
+
+                civInfo.addNotification("You and [${allyCiv.civName}] have declared war against [${otherCiv.civName}]!",
+                        NotificationCategory.Diplomacy, otherCiv.civName, NotificationIcon.War, allyCiv.civName, civInfo.civName)
+
+                allyCiv.addNotification("You and [${civInfo.civName}] have declared war against [${otherCiv.civName}]!",
+                        NotificationCategory.Diplomacy, otherCiv.civName, NotificationIcon.War, civInfo.civName, allyCiv.civName)
+
+                civInfo.addNotification("[${civInfo.civName}] and [${allyCiv.civName}] have declared war against us!",
+                        NotificationCategory.Diplomacy, otherCiv.civName, NotificationIcon.War, allyCiv.civName, civInfo.civName)
+
+                diplomacyManager.getCommonKnownCivsWithSpectators().filterNot { it == allyCiv }.forEach {
+                    it.addNotification("[${civInfo.civName}] and [${allyCiv.civName}] have declared war against [${otherCiv.civName}]!",
+                            NotificationCategory.Diplomacy, otherCiv.civName, NotificationIcon.War, allyCiv.civName, civInfo.civName)
+                }
             }
         }
     }
@@ -299,8 +321,10 @@ enum class WarType {
     CityStateAllianceWar,
     /** A civilization has joined a war through it's defensive pact. */
     DefensivePactWar,
-    /** A civilization has joined a war through a trade. Has the same diplomatic repercussions as direct war.*/
+    /** A civilization has joined a war through a trade.*/
     JoinWar,
+    /** Two civilizations are starting a war through a trade. */ 
+    TeamWar,
 }
 
 /**

--- a/core/src/com/unciv/logic/civilization/managers/TurnManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/TurnManager.kt
@@ -23,7 +23,6 @@ import com.unciv.models.stats.Stats
 import com.unciv.ui.components.MayaCalendar
 import com.unciv.ui.screens.worldscreen.status.NextTurnProgress
 import com.unciv.utils.Log
-import kotlin.math.max
 import kotlin.math.min
 import kotlin.random.Random
 
@@ -126,6 +125,7 @@ class TurnManager(val civInfo: Civilization) {
 
             when (flag) {
                 CivFlags.RevoltSpawning.name -> doRevoltSpawn()
+                CivFlags.TurnsTillCityStateElection.name -> civInfo.cityStateFunctions.holdElections()
             }
         }
         handleDiplomaticVictoryFlags()
@@ -262,7 +262,11 @@ class TurnManager(val civInfo: Civilization) {
 
         if (civInfo.isCityState()) {
             civInfo.questManager.endTurn()
-            civInfo.cityStateFunctions.nextTurnElections()
+            // Todo: Remove this later
+            // The purpouse of this addition is to migrate the old election system to the new flag system
+            if (civInfo.gameInfo.isEspionageEnabled() && !civInfo.hasFlag(CivFlags.TurnsTillCityStateElection.name)) {
+                civInfo.addFlag(CivFlags.TurnsTillCityStateElection.name, Random.nextInt(civInfo.gameInfo.ruleset.modOptions.constants.cityStateElectionTurns + 1))
+            }
         }
 
         // disband units until there are none left OR the gold values are normal

--- a/core/src/com/unciv/logic/civilization/managers/TurnManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/TurnManager.kt
@@ -166,7 +166,7 @@ class TurnManager(val civInfo: Civilization) {
         }
 
         if (!civInfo.hasFlag(CivFlags.RevoltSpawning.name)) {
-            civInfo.addFlag(CivFlags.RevoltSpawning.name, max(getTurnsBeforeRevolt(),1))
+            civInfo.addFlag(CivFlags.RevoltSpawning.name, getTurnsBeforeRevolt().coerceAtLeast(1))
             return
         }
     }
@@ -223,7 +223,8 @@ class TurnManager(val civInfo: Civilization) {
     }
 
     private fun getTurnsBeforeRevolt() =
-            ((4 + Random.Default.nextInt(3)) * max(civInfo.gameInfo.speed.modifier, 1f)).toInt()
+        ((civInfo.gameInfo.ruleset.modOptions.constants.baseTurnsUntilRevolt + Random.Default.nextInt(3)) 
+            * civInfo.gameInfo.speed.modifier.coerceAtLeast(1f)).toInt()
 
 
     fun endTurn(progressBar: NextTurnProgress? = null) {

--- a/core/src/com/unciv/models/ModConstants.kt
+++ b/core/src/com/unciv/models/ModConstants.kt
@@ -87,8 +87,10 @@ class ModConstants {
 
     var workboatAutomationSearchMaxTiles = 20
 
+    // Civilization
     var minWarDuration = 10
     var baseTurnsUntilRevolt = 4
+    var cityStateElectionTurns = 15
 
     // Espionage
     var maxSpyRank = 3
@@ -96,7 +98,7 @@ class ModConstants {
     // Rank 0 is 100%, rank 1 is 130%, and so on for stealing technology. 
     // Half as much for a coup.
     var spyRankSkillPercentBonus = 30
-    var cityStateElectionTurns = 15
+
 
     fun merge(other: ModConstants) {
         for (field in this::class.java.declaredFields) {

--- a/core/src/com/unciv/models/ModConstants.kt
+++ b/core/src/com/unciv/models/ModConstants.kt
@@ -89,7 +89,11 @@ class ModConstants {
 
     var minWarDuration = 10
     var baseTurnsUntilRevolt = 4 
-    var maxSpyLevel = 3
+    var maxSpyRank = 3
+    // How much of a skill bonus each rank gives. 
+    // Rank 0 is 100%, rank 1 is 130%, and so on for stealing technology. 
+    // Half as much for a coup.
+    var spyRankSkillPercentBonus = 30
 
     fun merge(other: ModConstants) {
         for (field in this::class.java.declaredFields) {

--- a/core/src/com/unciv/models/ModConstants.kt
+++ b/core/src/com/unciv/models/ModConstants.kt
@@ -87,6 +87,7 @@ class ModConstants {
 
     var workboatAutomationSearchMaxTiles = 20
 
+    var baseTurnsUntilRevolt = 4 
     var maxSpyLevel = 3
 
     fun merge(other: ModConstants) {

--- a/core/src/com/unciv/models/ModConstants.kt
+++ b/core/src/com/unciv/models/ModConstants.kt
@@ -88,7 +88,7 @@ class ModConstants {
     var workboatAutomationSearchMaxTiles = 20
 
     // Civilization
-    var minWarDuration = 10
+    var minimumWarDuration = 10
     var baseTurnsUntilRevolt = 4
     var cityStateElectionTurns = 15
 

--- a/core/src/com/unciv/models/ModConstants.kt
+++ b/core/src/com/unciv/models/ModConstants.kt
@@ -87,6 +87,7 @@ class ModConstants {
 
     var workboatAutomationSearchMaxTiles = 20
 
+    var minWarDuration = 10
     var baseTurnsUntilRevolt = 4 
     var maxSpyLevel = 3
 

--- a/core/src/com/unciv/models/ModConstants.kt
+++ b/core/src/com/unciv/models/ModConstants.kt
@@ -88,12 +88,15 @@ class ModConstants {
     var workboatAutomationSearchMaxTiles = 20
 
     var minWarDuration = 10
-    var baseTurnsUntilRevolt = 4 
+    var baseTurnsUntilRevolt = 4
+
+    // Espionage
     var maxSpyRank = 3
     // How much of a skill bonus each rank gives. 
     // Rank 0 is 100%, rank 1 is 130%, and so on for stealing technology. 
     // Half as much for a coup.
     var spyRankSkillPercentBonus = 30
+    var cityStateElectionTurns = 15
 
     fun merge(other: ModConstants) {
         for (field in this::class.java.declaredFields) {

--- a/core/src/com/unciv/models/Spy.kt
+++ b/core/src/com/unciv/models/Spy.kt
@@ -184,6 +184,14 @@ class Spy private constructor() : IsPartOfGameInfoSerialization {
         }
     }
 
+    /**
+     * With the defult spy leveling:
+     * 100 units change one step in results, there are 4 such steps, and the default random spans 300 units and excludes the best result (undetected success).
+     * Thus the return value translates into (return / 3) percent chance to get the very best result, reducing the chance to get the worst result (kill) by the same amount.
+     * The same modifier from defending counter-intelligence spies goes linearly in the opposite direction.
+     * With the range of this function being hardcoded to 30..90 (and 0 for no defensive spy present), ranks cannot guarantee either best or worst outcome.
+     * Or - chance range of best result is 0% (rank 1 vs rank 3 defender) to 30% (rank 3 vs no defender), range of worst is 53% to 3%, respectively.
+     */
     private fun stealTech() {
         val city = getCity()
         val otherCiv = city.civ
@@ -195,10 +203,10 @@ class Spy private constructor() : IsPartOfGameInfoSerialization {
         // Lower is better
         var spyResult = Random(randomSeed).nextInt(300)
         // Add our spies experience
-        spyResult -= getSkillModifier()
+        spyResult -= getSkillModifierPercent()
         // Subtract the experience of the counter intelligence spies
         val defendingSpy = city.civ.espionageManager.getSpyAssignedToCity(city)
-        spyResult += defendingSpy?.getSkillModifier() ?: 0
+        spyResult += defendingSpy?.getSkillModifierPercent() ?: 0
 
         val detectionString = when {
             spyResult >= 200 -> { // The spy was killed in the attempt (should be able to happen even if there's nothing to steal?)
@@ -309,7 +317,7 @@ class Spy private constructor() : IsPartOfGameInfoSerialization {
             cityState.getAllyCiv()?.let { civInfo.gameInfo.getCivilization(it) }?.espionageManager?.getSpyAssignedToCity(getCity()) 
         else null
 
-        val spyRanks = getSkillModifier() - (defendingSpy?.getSkillModifier() ?: 0)
+        val spyRanks = getSkillModifierPercent() - (defendingSpy?.getSkillModifierPercent() ?: 0)
         successPercentage += spyRanks / 2f // Each rank counts for 15%
 
         successPercentage = successPercentage.coerceIn(0f, 85f)
@@ -354,24 +362,16 @@ class Spy private constructor() : IsPartOfGameInfoSerialization {
     fun getLocationName() = getCityOrNull()?.name ?: Constants.spyHideout
 
     fun levelUpSpy(amount: Int = 1) {
-        if (rank >= civInfo.gameInfo.ruleset.modOptions.constants.maxSpyLevel) return
-        val ranksToLevelUp = amount.coerceAtMost(civInfo.gameInfo.ruleset.modOptions.constants.maxSpyLevel - rank)
+        if (rank >= civInfo.gameInfo.ruleset.modOptions.constants.maxSpyRank) return
+        val ranksToLevelUp = amount.coerceAtMost(civInfo.gameInfo.ruleset.modOptions.constants.maxSpyRank - rank)
 
         if (ranksToLevelUp == 1) addNotification("Your spy [$name] has leveled up!")
         else addNotification("Your spy [$name] has leveled up [$ranksToLevelUp] times!")
         rank += ranksToLevelUp
     }
 
-    /** Zero-based modifier expressing shift of probabilities from Spy Rank
-     *
-     *  100 units change one step in results, there are 4 such steps, and the default random spans 300 units and excludes the best result (undetected success).
-     *  Thus the return value translates into (return / 3) percent chance to get the very best result, reducing the chance to get the worst result (kill) by the same amount.
-     *  The same modifier from defending counter-intelligence spies goes linearly in the opposite direction.
-     *  With the range of this function being hardcoded to 30..90 (and 0 for no defensive spy present), ranks cannot guarantee either best or worst outcome.
-     *  Or - chance range of best result is 0% (rank 1 vs rank 3 defender) to 30% (rank 3 vs no defender), range of worst is 53% to 3%, respectively.
-     */
-    // Todo Moddable as some global and/or in-game-gainable Uniques?
-    fun getSkillModifier() = rank * 30
+    /** Modifier of the skill bonus of the spy by percent */
+    fun getSkillModifierPercent() = rank * civInfo.gameInfo.ruleset.modOptions.constants.spyRankSkillPercentBonus
 
     /**
      * Gets a friendly and enemy efficiency uniques for the spy at the location

--- a/core/src/com/unciv/models/Spy.kt
+++ b/core/src/com/unciv/models/Spy.kt
@@ -4,6 +4,7 @@ import com.badlogic.gdx.math.Vector2
 import com.unciv.Constants
 import com.unciv.logic.IsPartOfGameInfoSerialization
 import com.unciv.logic.city.City
+import com.unciv.logic.civilization.CivFlags
 import com.unciv.logic.civilization.Civilization
 import com.unciv.logic.civilization.EspionageAction
 import com.unciv.logic.civilization.NotificationCategory
@@ -102,7 +103,7 @@ class Spy private constructor() : IsPartOfGameInfoSerialization {
             SpyAction.EstablishNetwork -> {
                 val city = getCity() // This should never throw an exception, as going to the hideout sets your action to None.
                 if (city.civ.isCityState())
-                    setAction(SpyAction.RiggingElections, getCity().civ.cityStateTurnsUntilElection - 1)
+                    setAction(SpyAction.RiggingElections, (getCity().civ.flagsCountdown[CivFlags.TurnsTillCityStateElection.name] ?: 1) - 1)
                 else if (city.civ == civInfo)
                     setAction(SpyAction.CounterIntelligence, 10)
                 else
@@ -130,7 +131,9 @@ class Spy private constructor() : IsPartOfGameInfoSerialization {
             SpyAction.RiggingElections -> {
                 // No action done here
                 // Handled in CityStateFunctions.nextTurnElections()
-                turnsRemainingForAction = getCity().civ.cityStateTurnsUntilElection - 1
+                // TODO: Once we remove support for the old flag system we can remove the null check
+                // Our spies might update before the flag is created in the city-state
+                turnsRemainingForAction = (getCity().civ.flagsCountdown[CivFlags.TurnsTillCityStateElection.name] ?: 0) - 1
             }
             SpyAction.Coup -> {
                 initiateCoup()

--- a/docs/Modders/Mod-file-structure/5-Miscellaneous-JSON-files.md
+++ b/docs/Modders/Mod-file-structure/5-Miscellaneous-JSON-files.md
@@ -209,6 +209,11 @@ and city distance in another. In case of conflicts, there is no guarantee which 
 | pantheonBase                             | Int    | 10                            | [^L]  |
 | pantheonGrowth                           | Int    | 5                             | [^L]  |
 | workboatAutomationSearchMaxTiles         | Int    | 20                            | [^M]  |
+| maxSpyRank                               | Int    | 3                             | [^N]  |
+| spyRankSkillPercentBonus                 | Float  | 30                            | [^O]  |
+| minimumWarDuration                       | Int    | 10                            | [^P]  |
+| baseTurnsUntilRevolt                     | Int    | 4                             | [^Q]  |
+| cityStateElectionTurns                   | Int    | 15                            | [^R]  |
 
 Legend:
 
@@ -238,7 +243,12 @@ Legend:
 - [^J]: A [UnitUpgradeCost](#unitupgradecost) sub-structure.
 - [^K]: Maximum foundable Religions = religionLimitBase + floor(MajorCivCount * religionLimitMultiplier)
 - [^L]: Cost of pantheon = pantheonBase + CivsWithReligion * pantheonGrowth
-- [^M]: When the AI decidees whether to build a work boat, how many tiles to search from the city center for an improvable tile
+- [^M]: When the AI decides whether to build a work boat, how many tiles to search from the city center for an improvable tile
+- [^N]: The maximum rank any spy can reach
+- [^O]: How much skill bonus each rank gives
+- [^P]: The number of turns a civ has to wait before negotiating for peace
+- [^Q]: The number of turns before a revolt is spawned
+- [^R]: The number of turns between city-state elections
 
 #### UnitUpgradeCost
 


### PR DESCRIPTION
I recently discovered the easy of making constants moddable by using ModConstants.kt. Here are some extra things that this PR makes moddable:

- Minimum war duration
- Turns until revolt
- Spy skill per rank
- City-State election cycle

Note: I renamed maxSpyLevel to maxSpyRank
Also Note: I refactored the City-State election to use Civ flags instead of it's own custom variable as it should. I tested it cross version and wrote it in a way so that it doesn't break. Each version removes the other versions counter/flag and tries to replace it. The old version starts back at 15 while the new version starts at a random value form 1 to 15. Then once all players upgrade to the new version it will count down like normal.

<sub>That diff looks annoying</sub>