### PR TITLE
Fix election crash

### DIFF
--- a/core/src/com/unciv/logic/civilization/diplomacy/CityStateFunctions.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/CityStateFunctions.kt
@@ -63,11 +63,6 @@ class CityStateFunctions(val civInfo: Civilization) {
                 civInfo.cityStateUniqueUnit = possibleUnits.random().name
         }
 
-        // Set turns to elections to a random number so not every city-state has the same election date
-        if (civInfo.gameInfo.isEspionageEnabled()) {
-            civInfo.addFlag(CivFlags.TurnsTillCityStateElection.name, Random.nextInt(civInfo.gameInfo.ruleset.modOptions.constants.cityStateElectionTurns + 1))
-        }
-
         // TODO: Return false if attempting to put a religious city-state in a game without religion
 
         return true

--- a/core/src/com/unciv/logic/civilization/managers/TurnManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/TurnManager.kt
@@ -262,7 +262,6 @@ class TurnManager(val civInfo: Civilization) {
 
         if (civInfo.isCityState()) {
             civInfo.questManager.endTurn()
-            // Todo: Remove this later
             // The purpouse of this addition is to migrate the old election system to the new flag system
             if (civInfo.gameInfo.isEspionageEnabled() && !civInfo.hasFlag(CivFlags.TurnsTillCityStateElection.name)) {
                 civInfo.addFlag(CivFlags.TurnsTillCityStateElection.name, Random.nextInt(civInfo.gameInfo.ruleset.modOptions.constants.cityStateElectionTurns + 1))

--- a/core/src/com/unciv/logic/civilization/managers/TurnManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/TurnManager.kt
@@ -262,7 +262,9 @@ class TurnManager(val civInfo: Civilization) {
 
         if (civInfo.isCityState()) {
             civInfo.questManager.endTurn()
-            // The purpouse of this addition is to migrate the old election system to the new flag system
+
+            // Set turns to elections to a random number so not every city-state has the same election date
+            // May be called at game start or when migrating a game from an older version
             if (civInfo.gameInfo.isEspionageEnabled() && !civInfo.hasFlag(CivFlags.TurnsTillCityStateElection.name)) {
                 civInfo.addFlag(CivFlags.TurnsTillCityStateElection.name, Random.nextInt(civInfo.gameInfo.ruleset.modOptions.constants.cityStateElectionTurns + 1))
             }


### PR DESCRIPTION
This PR fixes the issue raised in #11730. 
The problem was that a city-state was trying to check if espionage was enabled to determine if it should generate the election flag. However the civ.gameInfo variable wasn't initialized yet. I looked and it turns out no transient variables would be initialized at this time. 
So I decided to remove it. The effect will be the same since the flag will be created later in TurnManger.kt. However this does change the plans of removing it from there.