### PR TITLE
Fix new-game initialization crash due to "Espionage Enabled" test

### DIFF
--- a/core/src/com/unciv/logic/GameStarter.kt
+++ b/core/src/com/unciv/logic/GameStarter.kt
@@ -356,7 +356,7 @@ object GameStarter {
                     civ.playerId = player.playerId
                 }
                 else ->
-                    if (!civ.cityStateFunctions.initCityState(ruleset, newGameParameters.startingEra, unusedMajorCivs))
+                    if (!civ.cityStateFunctions.initCityState(ruleset, newGameParameters.startingEra, unusedMajorCivs, newGameParameters.espionageEnabled))
                         continue
             }
             gameInfo.civilizations.add(civ)

--- a/core/src/com/unciv/logic/civilization/diplomacy/CityStateFunctions.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/CityStateFunctions.kt
@@ -33,8 +33,11 @@ import kotlin.random.Random
 /** Class containing city-state-specific functions */
 class CityStateFunctions(val civInfo: Civilization) {
 
-    /** Attempts to initialize the city state, returning true if successful. */
-    fun initCityState(ruleset: Ruleset, startingEra: String, unusedMajorCivs: Collection<String>): Boolean {
+    /** Attempts to initialize the city state, returning true if successful.
+     *
+     *  ***This runs early in game initialization, do not rely on transients to be set***
+     */
+    fun initCityState(ruleset: Ruleset, startingEra: String, unusedMajorCivs: Collection<String>, espionageEnabled: Boolean): Boolean {
         val allMercantileResources = ruleset.tileResources.values.filter { it.hasUnique(UniqueType.CityStateOnlyResource) }.map { it.name }
         val uniqueTypes = HashSet<UniqueType>()    // We look through these to determine what kinds of city states we have
 
@@ -64,7 +67,7 @@ class CityStateFunctions(val civInfo: Civilization) {
         }
 
         // Set turns to elections to a random number so not every city-state has the same election date
-        if (civInfo.gameInfo.isEspionageEnabled()) {
+        if (espionageEnabled) {
             civInfo.addFlag(CivFlags.TurnsTillCityStateElection.name, Random.nextInt(civInfo.gameInfo.ruleset.modOptions.constants.cityStateElectionTurns + 1))
         }
 


### PR DESCRIPTION
Fix #11732, fix #11730 - hi tuvus! No thinking, trivial safe way instead.