### PR TITLE
Simplify Adoptium API usage

### DIFF
--- a/.github/workflows/buildAndDeploy.yml
+++ b/.github/workflows/buildAndDeploy.yml
@@ -204,12 +204,10 @@ jobs:
 
           wget -q -O packr-all-4.0.0.jar https://github.com/libgdx/packr/releases/download/4.0.0/packr-all-4.0.0.jar
 
-          LINUX_JRE_URL=$(curl -fsSL 'https://api.adoptium.net/v3/assets/latest/11/hotspot?os=linux&architecture=x64&image_type=jre' | jq -r '.[].binary.package.link')
-          wget -q -O jre-linux-64.tar.gz $LINUX_JRE_URL
+          wget -q -O jre-linux-64.tar.gz https://api.adoptium.net/v3/binary/latest/11/ga/linux/x64/jre/hotspot/normal/eclipse
           ./gradlew desktop:packrLinux64
 
-          WIN_JRE_URL=$(curl -fsSL 'https://api.adoptium.net/v3/assets/latest/11/hotspot?os=windows&architecture=x64&image_type=jre' | jq -r '.[].binary.package.link')
-          wget -q -O jdk-windows-64.zip $WIN_JRE_URL
+          wget -q -O jdk-windows-64.zip https://api.adoptium.net/v3/binary/latest/11/ga/windows/x64/jre/hotspot/normal/eclipse
           ./gradlew desktop:packrWindows64
 
       - name: Upload packed zips


### PR DESCRIPTION
First of all, sorry for this.

In my previous PR, I did not know such a convenient thing existed. Actually, I did not even know that Adoptium API is open to the public.

Sometimes, when visiting a website to do repetitive stuff (Like downloading the latest Temurin JRE for my Windows system) I check their scripts to see if I can automate that. Before opening my last PR [#11747](https://github.com/yairm210/Unciv/pull/11747), I was doing something like that as usual and noticed that they were using some kind of API to fetch the version you would download from their site. I realized that this can be used to automate JRE download on Unciv with a little bit of `jq`. But again, I did not know that docs for this API actually existed here:

https://api.adoptium.net/q/swagger-ui/

Anyway, after that, I wondered if this API was open or internal, searched for it, and found the docs... The current version uses one of their [endpoint ](https://api.adoptium.net/q/swagger-ui/#/Binary/getBinary)that would automatically redirect to the latest download link, which wget can follow and download the JREs automatically without `jq`.

Since this looks like more maintainable in the long term and will most likely cause less confusion, I decided to change the script to use this API instead of doing `jq` stuff.