### PR TITLE
Renamed getDistanceToTilesWithinTurn to getDistanceToTilesAtPosition

### DIFF
--- a/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
@@ -467,7 +467,7 @@ object UnitAutomation {
      *  Tiles attack from which would result in instant death of the [unit] are ignored. */
     private fun tryAdvanceTowardsCloseEnemy(unit: MapUnit): Boolean {
         // this can be sped up if we check each layer separately
-        val unitDistanceToTiles = unit.movement.getDistanceToTilesWithinTurn(
+        val unitDistanceToTiles = unit.movement.getDistanceToTilesAtPosition(
                 unit.getTile().position,
                 unit.getMaxMovement() * CLOSE_ENEMY_TURNS_AWAY_LIMIT
         )

--- a/core/src/com/unciv/logic/map/mapunit/movement/UnitMovement.kt
+++ b/core/src/com/unciv/logic/map/mapunit/movement/UnitMovement.kt
@@ -21,11 +21,12 @@ class UnitMovement(val unit: MapUnit) {
     fun isUnknownTileWeShouldAssumeToBePassable(tile: Tile) = !unit.civ.hasExplored(tile)
 
     /**
+     * Gets the tiles the unit could move to at [position] with [unitMovement].
      * Does not consider if tiles can actually be entered, use canMoveTo for that.
      * If a tile can be reached within the turn, but it cannot be passed through, the total distance to it is set to unitMovement
      */
-    fun getDistanceToTilesWithinTurn(
-        origin: Vector2,
+    fun getDistanceToTilesAtPosition(
+        position: Vector2,
         unitMovement: Float,
         considerZoneOfControl: Boolean = true,
         tilesToIgnore: HashSet<Tile>? = null,
@@ -36,7 +37,7 @@ class UnitMovement(val unit: MapUnit) {
 
         val currentUnitTile = unit.currentTile
         // This is for performance, because this is called all the time
-        val unitTile = if (origin == currentUnitTile.position) currentUnitTile else currentUnitTile.tileMap[origin]
+        val unitTile = if (position == currentUnitTile.position) currentUnitTile else currentUnitTile.tileMap[position]
         distanceToTiles[unitTile] = ParentTileAndTotalDistance(unitTile, unitTile, 0f)
 
         // If I can't move my only option is to stay...
@@ -140,7 +141,7 @@ class UnitMovement(val unit: MapUnit) {
                     getDistanceToTiles(true, passThroughCache, movementCostCache) // check cache
                 }
                 else {
-                    getDistanceToTilesWithinTurn(
+                    getDistanceToTilesAtPosition(
                         tileToCheck.position,
                         unitMaxMovement,
                         false,
@@ -700,7 +701,7 @@ class UnitMovement(val unit: MapUnit) {
         if (cacheResults != null) {
             return cacheResults
         }
-        val distanceToTiles = getDistanceToTilesWithinTurn(
+        val distanceToTiles = getDistanceToTilesAtPosition(
             unit.currentTile.position,
             unit.currentMovement,
             considerZoneOfControl,


### PR DESCRIPTION
I am generally confused every time I look at `getDistanceToTiles()` and `getDistanceToTilesWIthinTurn()`. Part of the reason being that `getDistanceToTilesWIthinTurn()` actually does the opposite. As much as I understand, it can check not only the tiles multiple turns away, but also as if the unit were standing on a different tile.

So to reflect it's behaviour better I renamed it to `getDistanceToTilesAtPosition()` and added a small comment to it.

This PR is half about re-nameing and half asking for confirmation that that is what the method does. Thanks!