### PR TITLE
Turn Privateer's unique ability into a promotion

### DIFF
--- a/android/assets/jsons/Civ V - Gods & Kings/UnitPromotions.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/UnitPromotions.json
@@ -764,6 +764,10 @@
 		"name": "[Chu-Ko-Nu] ability",
 		"uniques": ["[1] additional attacks per turn", "Can move after attacking"]
 	},
+	{
+		"name": "[Privateer] ability",
+		"uniques": ["May capture killed [Water] units"]
+	},
 	{	// For barbarian water units
 		"name": "Unable to pillage tiles",
 		"uniques": ["Unable to pillage tiles"]

--- a/android/assets/jsons/Civ V - Gods & Kings/Units.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Units.json
@@ -890,8 +890,7 @@
 		"cost": 150,
 		"requiredTech": "Navigation",
 		"upgradesTo": "Destroyer",
-		"promotions": ["Coastal Raider I"],
-		"uniques": ["May capture killed [Water] units"],
+		"promotions": ["Coastal Raider I", "[Privateer] ability"],
 		"attackSound": "cannon"
 	},
 	{
@@ -904,8 +903,7 @@
 		"cost": 150,
 		"requiredTech": "Navigation",
 		"upgradesTo": "Destroyer",
-		"promotions": ["Coastal Raider I", "Coastal Raider II", "Supply"],
-		"uniques": ["May capture killed [Water] units"],
+		"promotions": ["Coastal Raider I", "Coastal Raider II", "Supply", "[Privateer] ability"],
 		"attackSound": "cannon"
 	},
 	{


### PR DESCRIPTION
In the original Civilization game, the Privateer's ability to capture water units is passed as a promotion to upgrades. This pull request makes that change to Unciv's Privateer and Sea Beggar units.