### PR TITLE
Fix Sipahi translation for RU — should be 'Сипахи', not 'Сипаи'

### DIFF
--- a/android/assets/jsons/translations/Russian.properties
+++ b/android/assets/jsons/translations/Russian.properties
@@ -5374,7 +5374,7 @@ Ship of the Line = Линейный корабль
 
 Lancer = Улан
 
-Sipahi = Сипаи
+Sipahi = Сипахи
 
 Cannon = Пушка
 


### PR DESCRIPTION
Fix *Sipahi* translation for RU — here should be [Сипахи](https://ru.wikipedia.org/wiki/%D0%A1%D0%B8%D0%BF%D0%B0%D1%85%D0%B8) (*Turkish professional cavalrymen*), not [Сипаи](https://ru.wikipedia.org/wiki/%D0%A1%D0%B8%D0%BF%D0%B0%D0%B8) (*Indian infantryman*)