### PR TITLE
Moved automation settings to AutoPlayTab and renamed it to AutomationTab

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -890,6 +890,9 @@ Hide =
 HIGHLY EXPERIMENTAL - YOU HAVE BEEN WARNED! = 
 You need to restart the game for this change to take effect. = 
 
+# AutomationTab
+Automation = 
+
 # AutoPlay
 AutoPlay = 
 Show AutoPlay button = 

--- a/core/src/com/unciv/ui/popups/options/AutoPlayTab.kt
+++ b/core/src/com/unciv/ui/popups/options/AutoPlayTab.kt
@@ -2,7 +2,9 @@ package com.unciv.ui.popups.options
 
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.unciv.GUI
+import com.unciv.logic.civilization.PlayerType
 import com.unciv.models.metadata.GameSettings
+import com.unciv.ui.components.extensions.addSeparator
 import com.unciv.ui.components.widgets.UncivSlider
 import com.unciv.ui.components.extensions.toLabel
 import com.unciv.ui.screens.basescreen.BaseScreen
@@ -14,6 +16,48 @@ fun autoPlayTab(optionsPopup: OptionsPopup
     defaults().pad(5f)
 
     val settings = optionsPopup.settings
+    add("Unit Automation".toLabel(fontSize = 24)).colspan(2).row()
+
+    optionsPopup.addCheckbox(this, "Auto-assign city production", settings.autoAssignCityProduction, true) { shouldAutoAssignCityProduction ->
+        settings.autoAssignCityProduction = shouldAutoAssignCityProduction
+        val worldScreen = GUI.getWorldScreenIfActive()
+        if (shouldAutoAssignCityProduction && worldScreen != null &&
+            worldScreen.viewingCiv.isCurrentPlayer() && worldScreen.viewingCiv.playerType == PlayerType.Human
+        ) {
+            worldScreen.gameInfo.getCurrentPlayerCivilization().cities.forEach { city ->
+                city.cityConstructions.chooseNextConstruction()
+            }
+        }
+    }
+    optionsPopup.addCheckbox(this, "Auto-build roads", settings.autoBuildingRoads) { settings.autoBuildingRoads = it }
+    optionsPopup.addCheckbox(
+        this,
+        "Automated workers replace improvements",
+        settings.automatedWorkersReplaceImprovements
+    ) { settings.automatedWorkersReplaceImprovements = it }
+    optionsPopup.addCheckbox(
+        this,
+        "Automated units move on turn start",
+        settings.automatedUnitsMoveOnTurnStart, true
+    ) { settings.automatedUnitsMoveOnTurnStart = it }
+    optionsPopup.addCheckbox(
+        this,
+        "Automated units can upgrade",
+        settings.automatedUnitsCanUpgrade, false
+    ) { settings.automatedUnitsCanUpgrade = it }
+    optionsPopup.addCheckbox(
+        this,
+        "Automated units choose promotions",
+        settings.automatedUnitsChoosePromotions, false
+    ) { settings.automatedUnitsChoosePromotions = it }
+    optionsPopup.addCheckbox(
+        this,
+        "Cities auto-bombard at end of turn",
+        settings.citiesAutoBombardAtEndOfTurn, false
+    ) { settings.citiesAutoBombardAtEndOfTurn = it }
+
+    addSeparator()
+    add("AutoPlay".toLabel(fontSize = 24)).colspan(2).row()
 //    fun addAutoPlaySections() {
 //        optionsPopup.addCheckbox(
 //            this,
@@ -60,7 +104,7 @@ fun autoPlayTab(optionsPopup: OptionsPopup
         GUI.getWorldScreenIfActive()?.autoPlay?.stopAutoPlay() 
     }
 
-    
+
     optionsPopup.addCheckbox(
         this,
         "AutoPlay until victory",
@@ -72,7 +116,7 @@ fun autoPlayTab(optionsPopup: OptionsPopup
 
     if (!settings.autoPlay.autoPlayUntilEnd)
         addAutoPlayMaxTurnsSlider(this, settings, optionsPopup.selectBoxMinWidth)
-    
+
 //    optionsPopup.addCheckbox(
 //        this,
 //        "Full AutoPlay AI",

--- a/core/src/com/unciv/ui/popups/options/AutomationTab.kt
+++ b/core/src/com/unciv/ui/popups/options/AutomationTab.kt
@@ -15,7 +15,7 @@ fun automationTab(optionsPopup: OptionsPopup
     defaults().pad(5f)
 
     val settings = optionsPopup.settings
-    add("Unit Automation".toLabel(fontSize = 24)).colspan(2).row()
+    add("Automation".toLabel(fontSize = 24)).colspan(2).row()
 
     optionsPopup.addCheckbox(this, "Auto-assign city production", settings.autoAssignCityProduction, true) { shouldAutoAssignCityProduction ->
         settings.autoAssignCityProduction = shouldAutoAssignCityProduction

--- a/core/src/com/unciv/ui/popups/options/AutomationTab.kt
+++ b/core/src/com/unciv/ui/popups/options/AutomationTab.kt
@@ -8,9 +8,8 @@ import com.unciv.ui.components.extensions.addSeparator
 import com.unciv.ui.components.widgets.UncivSlider
 import com.unciv.ui.components.extensions.toLabel
 import com.unciv.ui.screens.basescreen.BaseScreen
-import com.unciv.ui.screens.worldscreen.WorldScreen
 
-fun autoPlayTab(optionsPopup: OptionsPopup
+fun automationTab(optionsPopup: OptionsPopup
 ): Table = Table(BaseScreen.skin).apply {
     pad(10f)
     defaults().pad(5f)
@@ -111,7 +110,7 @@ fun autoPlayTab(optionsPopup: OptionsPopup
         settings.autoPlay.autoPlayUntilEnd, false
     ) { settings.autoPlay.autoPlayUntilEnd = it
         if (!it) addAutoPlayMaxTurnsSlider(this, settings, optionsPopup.selectBoxMinWidth) 
-        else optionsPopup.tabs.replacePage(optionsPopup.tabs.activePage, autoPlayTab(optionsPopup))}
+        else optionsPopup.tabs.replacePage(optionsPopup.tabs.activePage, automationTab(optionsPopup))}
 
 
     if (!settings.autoPlay.autoPlayUntilEnd)

--- a/core/src/com/unciv/ui/popups/options/GameplayTab.kt
+++ b/core/src/com/unciv/ui/popups/options/GameplayTab.kt
@@ -20,43 +20,6 @@ fun gameplayTab(
     optionsPopup.addCheckbox(this, "Auto Unit Cycle", settings.autoUnitCycle, true) { settings.autoUnitCycle = it }
     optionsPopup.addCheckbox(this, "Move units with a single tap", settings.singleTapMove) { settings.singleTapMove = it }
     optionsPopup.addCheckbox(this, "Move units with a long tap", settings.longTapMove) { settings.longTapMove = it }
-    optionsPopup.addCheckbox(this, "Auto-assign city production", settings.autoAssignCityProduction, true) { shouldAutoAssignCityProduction ->
-        settings.autoAssignCityProduction = shouldAutoAssignCityProduction
-        val worldScreen = GUI.getWorldScreenIfActive()
-        if (shouldAutoAssignCityProduction && worldScreen != null &&
-                worldScreen.viewingCiv.isCurrentPlayer() && worldScreen.viewingCiv.playerType == PlayerType.Human
-        ) {
-            worldScreen.gameInfo.getCurrentPlayerCivilization().cities.forEach { city ->
-                city.cityConstructions.chooseNextConstruction()
-            }
-        }
-    }
-    optionsPopup.addCheckbox(this, "Auto-build roads", settings.autoBuildingRoads) { settings.autoBuildingRoads = it }
-    optionsPopup.addCheckbox(
-        this,
-        "Automated workers replace improvements",
-        settings.automatedWorkersReplaceImprovements
-    ) { settings.automatedWorkersReplaceImprovements = it }
-    optionsPopup.addCheckbox(
-        this,
-        "Automated units move on turn start",
-        settings.automatedUnitsMoveOnTurnStart, true
-    ) { settings.automatedUnitsMoveOnTurnStart = it }
-    optionsPopup.addCheckbox(
-        this,
-        "Automated units can upgrade",
-        settings.automatedUnitsCanUpgrade, false
-    ) { settings.automatedUnitsCanUpgrade = it }
-    optionsPopup.addCheckbox(
-        this,
-        "Automated units choose promotions",
-        settings.automatedUnitsChoosePromotions, false
-    ) { settings.automatedUnitsChoosePromotions = it }
-    optionsPopup.addCheckbox(
-        this,
-        "Cities auto-bombard at end of turn",
-        settings.citiesAutoBombardAtEndOfTurn, false
-    ) { settings.citiesAutoBombardAtEndOfTurn = it }
     optionsPopup.addCheckbox(this, "Order trade offers by amount", settings.orderTradeOffersByAmount) { settings.orderTradeOffersByAmount = it }
     optionsPopup.addCheckbox(this, "Ask for confirmation when pressing next turn", settings.confirmNextTurn) { settings.confirmNextTurn = it }
 

--- a/core/src/com/unciv/ui/popups/options/OptionsPopup.kt
+++ b/core/src/com/unciv/ui/popups/options/OptionsPopup.kt
@@ -85,8 +85,8 @@ class OptionsPopup(
             ImageGetter.getImage("OtherIcons/Options"), 24f
         )
         tabs.addPage(
-            "AutoPlay",
-            autoPlayTab(this),
+            "Automation",
+            automationTab(this),
             ImageGetter.getImage("OtherIcons/NationSwap"), 24f
         )
         tabs.addPage(


### PR DESCRIPTION
This PR improves the organization of settings in the GamePlayTab. I find it a little weird and disorganized how we put more UI settings along with unit automation settings. So I moved the automation settings into the AutoPlay tab and renamed the AutoPlay tab to Automation. (I feel like this makes it look better)

<details><summary>PIctures</summary>

![AutomationTab1](https://github.com/yairm210/Unciv/assets/7538725/d74c3e2c-7e5a-49bb-8200-eb842c624c7c)
![AutomationTab2](https://github.com/yairm210/Unciv/assets/7538725/17951dd4-ad85-40d3-8db2-8fc7c87bb5f2)

</details> 