### PR TITLE
Spies deselect when moved on map

### DIFF
--- a/core/src/com/unciv/ui/screens/worldscreen/WorldMapHolder.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/WorldMapHolder.kt
@@ -642,6 +642,7 @@ class WorldMapHolder(
             removeUnitActionOverlay()
             selectedTile = null
             worldScreen.shouldUpdate = true
+            worldScreen.bottomUnitTable.selectSpy(null)
         }
         spyActionButton.keyShortcuts.add(KeyCharAndCode.TAB)
         spyActionButton.keyShortcuts.add(KeyCharAndCode.RETURN)


### PR DESCRIPTION
This PR adds a simple UX improvement. When the player moves a spy on the map it deselects the spy when going into the EspionageOverviewScreen. This makes it so the player doesn't have the spy selected when they close the EspionageOverviewScreen.