### PR TITLE
Fixed a city-state coup crash

### DIFF
--- a/core/src/com/unciv/models/Spy.kt
+++ b/core/src/com/unciv/models/Spy.kt
@@ -9,6 +9,7 @@ import com.unciv.logic.civilization.Civilization
 import com.unciv.logic.civilization.EspionageAction
 import com.unciv.logic.civilization.NotificationCategory
 import com.unciv.logic.civilization.NotificationIcon
+import com.unciv.logic.civilization.diplomacy.DiplomacyFunctions
 import com.unciv.logic.civilization.diplomacy.DiplomaticModifiers
 import com.unciv.logic.civilization.managers.EspionageManager
 import com.unciv.models.ruleset.unique.StateForConditionals
@@ -269,6 +270,7 @@ class Spy private constructor() : IsPartOfGameInfoSerialization {
                     NotificationCategory.Espionage, NotificationIcon.Spy, cityState.civName)
             if (pastAlly != null) {
                 cityState.getDiplomacyManager(pastAlly).reduceInfluence(20f)
+                if (!pastAlly.knows(civInfo)) civInfo.diplomacyFunctions.makeCivilizationsMeet(pastAlly)
                 pastAlly.addNotification("A spy from [${civInfo.civName}] successfully staged a coup in our former ally [${cityState.civName}]!", getCity().location,
                         NotificationCategory.Espionage, civInfo.civName,  NotificationIcon.Spy, cityState.civName)
                 pastAlly.getDiplomacyManager(civInfo).addModifier(DiplomaticModifiers.SpiedOnUs, -15f)


### PR DESCRIPTION
This PR fixes the crash in #11768 where a civ is initiating a coup in a city-state with an ally that they haven't met. This crash could actually happen on both a successful and a failed coup.

The solution I came up with is to make sure that the civilization that is attempting to coup has met the ally civilization before applying the diplomatic modifiers.

An alternative would be to keep the couping civilization anonymous and don't force the civilizations to meet. This seems a little unintuitive and would require an extra notification string as well.