### PR TITLE
Fix Civilopedia content clipped at the top

### DIFF
--- a/core/src/com/unciv/ui/images/Portrait.kt
+++ b/core/src/com/unciv/ui/images/Portrait.kt
@@ -4,6 +4,7 @@ import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.scenes.scene2d.Group
 import com.badlogic.gdx.scenes.scene2d.ui.Image
 import com.badlogic.gdx.scenes.scene2d.ui.Table
+import com.badlogic.gdx.scenes.scene2d.utils.Layout
 import com.badlogic.gdx.utils.Align
 import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.ruleset.unit.Promotion
@@ -16,6 +17,17 @@ import com.unciv.ui.components.extensions.surroundWithCircle
 import com.unciv.ui.components.extensions.toGroup
 import com.unciv.ui.components.extensions.toLabel
 
+/**
+ *  ### Manages "portraits" for a subset of RulesetObjects
+ *  - A Portrait will be a classic circular Icon in vanilla
+ *  - Mods can supply portraits in separate texture paths that can fill a square
+ *  - Instantiate through [ImageGetter]`.get<type>Portrait()` methods
+ *  - TODO - that's as far as I understand this - @SomeTroglodyte
+ *  ### Caveat
+ *  - This is a Group and does **not** support [Layout].
+ *  - It sets its own [size] but **paints outside these bounds** - by [borderSize].
+ *  - Typically, if you want one in a Table Cell, add an extra [borderSize] padding to avoid surprises.
+ */
 open class Portrait(val type: Type, val imageName: String, val size: Float, val borderSize: Float = 2f) : Group() {
 
     enum class Type(val directory: String) {

--- a/core/src/com/unciv/ui/screens/civilopediascreen/CivilopediaScreen.kt
+++ b/core/src/com/unciv/ui/screens/civilopediascreen/CivilopediaScreen.kt
@@ -260,7 +260,7 @@ class CivilopediaScreen(
         entrySelectTable.top()
         entrySelectScroll.setOverscroll(false, false)
         val descriptionTable = Table()
-        descriptionTable.add(flavourTable).row()
+        descriptionTable.add(flavourTable).padTop(7f).padBottom(5f).row()  // 2f of that 7f is used up by Portrait painting e.g. a Nation's outer border *outside its bounds*
         val entrySplitPane = SplitPane(entrySelectScroll, ScrollPane(descriptionTable), false, skin)
         entrySplitPane.splitAmount = 0.3f
         entryTable.addActor(entrySplitPane)


### PR DESCRIPTION
Very very minor but it's irked me for a while now.
![image](https://github.com/yairm210/Unciv/assets/63000004/19129a92-1c04-4b6c-a035-492ef5e44022)
That's _not_ scrolled down.