### PR TITLE
Event Choice AI Priority

### DIFF
--- a/core/src/com/unciv/models/ruleset/Event.kt
+++ b/core/src/com/unciv/models/ruleset/Event.kt
@@ -52,6 +52,9 @@ class EventChoice : ICivilopediaText {
     var conditions = ArrayList<String>()
     val conditionObjects by lazy { conditions.map { Unique(it) } }
 
+    var modifiers = ArrayList<String>()
+    val modifierObjects by lazy { modifiers.map { Unique(it) } }
+
     fun matchesConditions(stateForConditionals: StateForConditionals) =
         conditionObjects.all { Conditionals.conditionalApplies(null, it, stateForConditionals) }
 

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -121,10 +121,11 @@ object UniqueTriggerActivation {
                 fun calculateEventChoiceWeight(choice: EventChoice): Float {
                     var weight = 1f
                     for (modifier in choice.modifierObjects) {
-                        if (modifier.type == UniqueType.AIPriorityModifier && modifier.conditionalsApply(stateForConditionals)) {
-                            weight += unique.params[0].toFloat() / 100f
+                        if (modifier.type == UniqueType.AiDecisonWeight && modifier.conditionalsApply(stateForConditionals)) {
+                            weight += unique.params[0].toFloat()
                         }
                     }
+                    weight.coerceAtLeast(0f)
                     return weight
                 }
 
@@ -141,7 +142,7 @@ object UniqueTriggerActivation {
                         }
                         random -= choiceWeights[choice]!!
                     }
-                    
+
                     chosenChoice?.triggerChoice(civInfo) ?: false
                 }
                 if (event.presentation == Event.Presentation.Alert) return {

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -879,8 +879,8 @@ enum class UniqueType(
     ForEveryAmountCountable("for every [amount] [countable]", UniqueTarget.MetaModifier),
     ModifiedByGameSpeed("(modified by game speed)", UniqueTarget.MetaModifier,
         docDescription = "Can only be applied to certain uniques, see details of each unique for specifics"),
-    AIPriorityModifier("[relativeAmount]% priority", UniqueTarget.MetaModifier,
-        docDescription = "Used for determining AI priority, mostly in combination with conditionals."),
+    AiDecisonWeight("[Amount] weight for AI decisions", UniqueTarget.Event,
+        docDescription = "Used for determining AI decisions, can be used in combination with conditionals."),
     Comment("Comment [comment]", *UniqueTarget.Displayable,
         docDescription = "Allows displaying arbitrary text in a Unique listing. Only the text within the '[]' brackets will be displayed, the rest serves to allow Ruleset validation to recognize the intent."),
 

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -879,6 +879,8 @@ enum class UniqueType(
     ForEveryAmountCountable("for every [amount] [countable]", UniqueTarget.MetaModifier),
     ModifiedByGameSpeed("(modified by game speed)", UniqueTarget.MetaModifier,
         docDescription = "Can only be applied to certain uniques, see details of each unique for specifics"),
+    AIPriorityModifier("[relativeAmount]% priority", UniqueTarget.MetaModifier,
+        docDescription = "Used for determining AI priority, mostly in combination with conditionals."),
     Comment("Comment [comment]", *UniqueTarget.Displayable,
         docDescription = "Allows displaying arbitrary text in a Unique listing. Only the text within the '[]' brackets will be displayed, the rest serves to allow Ruleset validation to recognize the intent."),
 

--- a/docs/Modders/Mod-file-structure/5-Miscellaneous-JSON-files.md
+++ b/docs/Modders/Mod-file-structure/5-Miscellaneous-JSON-files.md
@@ -134,6 +134,7 @@ Event choices are comprised of:
 | text             | String                      | Required   | Displayed to user as button. Should be an action name - "Do X"                                                       |
 | triggeredUniques | List of trigger uniques     | Required   | The triggers that this choice activates upon being chosen                                                            |
 | conditions       | List of conditional uniques | Empty list | If any conditional is not met, this option becomes unpickable (not shown)                                            |
+| modifiers        | List of priority modifiers  | Empty list | List of AI priority modifiers, increasing or decresing the probability of choosing the EventChoice by AI             |
 | keyShortcut      | key to select (name)        | none       | Key names see [Gdx.Input.Keys](https://github.com/libgdx/libgdx/blob/master/gdx/src/com/badlogic/gdx/Input.java#L69) |
 | civilopediaText  | List                        | Optional   | See [civilopediaText chapter](5-Miscellaneous-JSON-files.md#civilopedia-text)                                        |
 

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -1916,6 +1916,12 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 	Applicable to: ModOptions
 
 ## Event uniques
+??? example  "[Amount] weight for AI decisions"
+	Used for determining AI decisions, can be used in combination with conditionals.
+	Example: "[Unknown] weight for AI decisions"
+
+	Applicable to: Event
+
 ??? example  "Mark tutorial [comment] complete"
 	Example: "Mark tutorial [comment] complete"
 


### PR DESCRIPTION
I requested this feature, but I didn't see anyone doing it, so I decided to make it yourself. I believe my PR will greatly increase the usefulness of Events, which were added some time ago.

I introduced the new unique below not only for events, but possibly for Buildings, Units and Policies, as the Modding Philosophy states that "we want as little uniques as possible, that do as much as possible"

`[relativeAmount]% priority`

If you have some remarks regarding my PR, please share them in the comments.