### PR TITLE
Clarify translation template header of the obsoleted tutorial tasks

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -32,7 +32,8 @@ Delete =
 Civ V - Vanilla = 
 Civ V - Gods & Kings = 
 
-# Tutorial tasks
+# Obsolete Tutorial tasks - the active lines are moved to 'Lines from Events', much later in the tranlsation file.
+# TODO remove after grace period which allows translators to copy and paste existing translations to the new format.
 
 Move a unit!\nClick on a unit > Click on a destination > Click the arrow popup = 
 Found a city!\nSelect the Settler (flag unit) > Click on 'Found city' (bottom-left corner) = 


### PR DESCRIPTION
Should have been part of #11717. Kudos to touhidurrr for noticing in #11806 