### PR TITLE
Revert Crash caused by Religion Caching

### DIFF
--- a/core/src/com/unciv/logic/city/City.kt
+++ b/core/src/com/unciv/logic/city/City.kt
@@ -492,9 +492,8 @@ class City : IsPartOfGameInfoSerialization, INamed {
     fun getLocalMatchingUniques(uniqueType: UniqueType, stateForConditionals: StateForConditionals = StateForConditionals(this)): Sequence<Unique> {
         val uniques = cityConstructions.builtBuildingUniqueMap.getUniques(uniqueType).filter { it.isLocalEffect } +
             religion.getUniques().filter { it.type == uniqueType }
-        return if (uniques.any())
-            uniques.filter { !it.isTimedTriggerable && it.conditionalsApply(stateForConditionals) }
-                .flatMap { it.getMultiplied(stateForConditionals) }
+        return if (uniques.any()) uniques.filter { !it.isTimedTriggerable && it.conditionalsApply(stateForConditionals) }
+            .flatMap { it.getMultiplied(stateForConditionals) }
         else uniques
     }
 


### PR DESCRIPTION
This PR reverts the Religion Caching commit which causes a bad crash on game load. See #11813.

Briefly looking into it, when the city-religion is initializing it is checking resources on all cities and not all cities have been initialized which causes a problem. Commenting out the two problem lines of code resulted in a different crash. Therefore the best option is to revert this for now.

Since this is a game-breaking level bug for any save with religion enabled I will be patching it immediately.