### PR TITLE
Workaround for clipboard size limitation

### DIFF
--- a/desktop/src/com/unciv/app/desktop/AwtClipboard.kt
+++ b/desktop/src/com/unciv/app/desktop/AwtClipboard.kt
@@ -1,0 +1,42 @@
+package com.unciv.app.desktop
+
+import java.awt.Toolkit
+import java.awt.datatransfer.DataFlavor
+import java.awt.datatransfer.StringSelection
+import java.awt.datatransfer.Clipboard as ClipboardAwt
+import com.badlogic.gdx.utils.Clipboard as ClipboardGdx
+
+/**
+ *  A plug-in replacement for Gdx Lwjgl3Clipboard that goes through AWT instead of GLFW and removes the stack size limitation.
+ *
+ *  Gdx.app.clipboard on desktop is a Lwjgl3Clipboard instance, which allocates a buffer on the stack for UTF8 conversion at the Lwjgl3-GLFW interface.
+ *  The default stack size is a severe limitation, which we **originally** treated by increasing the limit, which can only be done statically at launch time:
+```
+         // 386 is an almost-arbitrary choice from the saves I had at the moment and their GZipped size.
+         // There must be a reason for lwjgl3 being so stingy, which for me meant to stay conservative.
+         System.setProperty("org.lwjgl.system.stackSize", "384")
+```
+ *  - See [setContents](https://github.com/libgdx/libgdx/blob/master/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Clipboard.java#L40)
+ *  - See [glfwSetClipboardString](https://github.com/LWJGL/lwjgl3/blob/master/modules/lwjgl/glfw/src/generated/java/org/lwjgl/glfw/GLFW.java#L5068-L5077)
+ *  - See [Higher available clipboard size](https://github.com/orgs/LWJGL/discussions/769)
+ */
+class AwtClipboard : ClipboardGdx {
+    // A lazy seems to work too, but not keeping a reference when not active is safer (also debuggable while a lazy is not):
+    private val clipboard: ClipboardAwt
+        get() = Toolkit.getDefaultToolkit().systemClipboard
+
+    override fun hasContents(): Boolean {
+        return DataFlavor.stringFlavor in clipboard.availableDataFlavors
+    }
+
+    override fun getContents(): String? {
+        val transferable = clipboard.getContents(null)
+        if (!transferable.isDataFlavorSupported(DataFlavor.stringFlavor)) return null
+        return transferable.getTransferData(DataFlavor.stringFlavor) as String
+    }
+
+    override fun setContents(content: String?) {
+        val selection = StringSelection(content)  // Yes this supports null
+        clipboard.setContents(selection, selection)
+    }
+}

--- a/desktop/src/com/unciv/app/desktop/DesktopLauncher.kt
+++ b/desktop/src/com/unciv/app/desktop/DesktopLauncher.kt
@@ -36,10 +36,6 @@ internal object DesktopLauncher {
         // Solves a rendering problem in specific GPUs and drivers.
         // For more info see https://github.com/yairm210/Unciv/pull/3202 and https://github.com/LWJGL/lwjgl/issues/119
         System.setProperty("org.lwjgl.opengl.Display.allowSoftwareOpenGL", "true")
-        // This setting (default 64) limits clipboard transfers. Value in kB!
-        // 386 is an almost-arbitrary choice from the saves I had at the moment and their GZipped size.
-        // There must be a reason for lwjgl3 being so stingy, which for me meant to stay conservative.
-        System.setProperty("org.lwjgl.system.stackSize", "384")
 
         val isRunFromJAR = DesktopLauncher.javaClass.`package`.specificationVersion != null
         ImagePacker.packImages(isRunFromJAR)


### PR DESCRIPTION
Fixes #11822
See #6929 (stacksize increase)
See [Higher available clipboard size](https://github.com/orgs/LWJGL/discussions/769) (lwjgl discussion)

### Clipboard size limitation begone
This is the big and hard hammer. [Softer hammers](https://github.com/yairm210/Unciv/assets/63000004/7f2b6e73-cb66-42b9-bf28-fa15a61370b9) are feasible...

On desktop, replace Gdx clipboard (the Lwjgl3Clipboard implementation) with an alternate implementation of the interface using AWT, and return it from `Gdx.app.clipboard`, thus replacing _all_ clipboard access in Unciv (yes affects copy&paste in TextField too etc etc). In other words, if Lwjgl is crap, redirect to a better API.

### Risk
We've had problems loading the AWT library while Unciv is running - which is why we now have a non-AWT file picker for "load from custom location". This here hopes that using `Toolkit.getDefaultToolkit().systemClipboard` is harmless, maybe because it's independent enough, hopefully, let's pray. See "Softer hammers" - those would need to touch every single access, around 30 to 50 or so.

### Alternative
Increase stackSize once again? To what? 1M? 2M? 3.141592653M?

### Note
The way this needed to be hooked in is interesting to read. A class that has an instance that is doing its job, but its constructor never ran, a breakpoint in `init{}` never hits??? Yup, that's the Gdx design. `init` on a Gdx.Lwjgl3Application subclass runs, but only after the game is done. Make do without initialization - or - don't subclass but delegate, quite a bit more complicated to pull off because you can't use kotlin's `by` help without falling into the same trap.