### PR TITLE
Allow civ based conditionals for improvement tile limitations

### DIFF
--- a/core/src/com/unciv/logic/map/tile/TileImprovementFunctions.kt
+++ b/core/src/com/unciv/logic/map/tile/TileImprovementFunctions.kt
@@ -157,14 +157,14 @@ class TileImprovementFunctions(val tile: Tile) {
 
             // Can't build if the improvement specifically prevents building on some present feature
             improvement.getMatchingUniques(UniqueType.CannotBuildOnTile, stateForConditionals).any {
-                    unique -> tile.matchesTerrainFilter(unique.params[0])
+                    unique -> tile.matchesFilter(unique.params[0], stateForConditionals.civInfo)
             } ->
                 false
 
             // Can't build if an improvement is only allowed to be built on specific tiles and this is not one of them
             // If multiple uniques of this type exists, we want all to match (e.g. Hill _and_ Forest would be meaningful)
             improvement.getMatchingUniques(UniqueType.CanOnlyBeBuiltOnTile, stateForConditionals).let {
-                it.any() && it.any { unique -> !tile.matchesTerrainFilter(unique.params[0]) }
+                it.any() && it.any { unique -> !tile.matchesFilter(unique.params[0], stateForConditionals.civInfo) }
             } -> false
 
             // Can't build if the improvement requires an adjacent terrain that is not present


### PR DESCRIPTION
Two changes:
1. The uniques `CannotBuildOnTile` and `CanOnlyBeBuiltOnTile` says tileFilter, not terrainFilter. Code has been edited to match expectations
2. Passing in the civ for the purposes of checking terranFilters. This seems like the only 2 places that does this check in regards to this check, but I didn't look very hard. This is important for the purposes of checking for a specific player's terrain ("your", "enemy") and for checking if resources are on the tile (as we need to check if we can see the resource)

Side note: I wonder if the check for a resource in particular should be necessary for resources that don't need a tech. Something to think about, I guess