### PR TITLE
Consider passive strength bonuses for force value

### DIFF
--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -502,6 +502,8 @@ class BaseUnit : RulesetObject(), INonPerpetualConstruction {
                         } // Bonus in terrain or feature - half the bonus
                     ) {
                         power *= (unique.params[0].toInt() / 2f).toPercent()
+                    } else {
+                        power *= (unique.params[0].toInt()).toPercent() // Static bonus
                     }
                 }
                 UniqueType.StrengthNearCapital ->


### PR DESCRIPTION
Previously, "[relativeAmount]% Strength <vs [filter] units>" would count towards this calculation, but not "[relativeAmount]% Strength". This seems very clearly wrong. There's two options here
1. (This PR) treat all other conditionals as if they are always active. This can let us take a better look later if a conditional should have a lower bonus
2. Treat all conditionals with the 50% bonus, and any without conditionals as a full bonus


Side note: force evaluation itself has pretty noticeable issues in that it only checks the base unit, not the mapUnit if the map unit happen to get more promotions. This is relevant for tributes, the AI deciding when to disband units, and the score (which both players and the AI might/does use for threat assessment). However, editing that looks to be much trickier