### PR TITLE
Warmongering doesn't apply to civs that are angry at the target civ

### DIFF
--- a/core/src/com/unciv/logic/civilization/diplomacy/DeclareWar.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DeclareWar.kt
@@ -175,9 +175,9 @@ object DeclareWar {
 
         // Apply warmongering
         if (warType == WarType.DirectWar || warType == WarType.JoinWar || warType == WarType.TeamWar) {
-            for (thirdCiv in diplomacyManager.getCommonKnownCivs()) {
-                if (!thirdCiv.isAtWarWith(otherCiv) 
-                    && thirdCiv.getDiplomacyManager(otherCiv)!!.isRelationshipLevelGT(RelationshipLevel.Competitor) 
+            for (thirdCiv in civInfo.getKnownCivs()) {
+                if (!thirdCiv.isAtWarWith(otherCiv)
+                    && thirdCiv.getDiplomacyManager(otherCiv)?.isRelationshipLevelGT(RelationshipLevel.Competitor) != false
                     && thirdCiv != declareWarReason.allyCiv) {
                     // We don't want this modify to stack if there is a defensive pact
                     thirdCiv.getDiplomacyManager(civInfo)!!
@@ -188,7 +188,7 @@ object DeclareWar {
 
         // Apply shared enemy modifiers
         for (thirdCiv in diplomacyManager.getCommonKnownCivs()) {
-            if (thirdCiv.isAtWarWith(otherCiv) && !thirdCiv.isAtWarWith(civInfo)) {
+            if ((thirdCiv.isAtWarWith(otherCiv) || thirdCiv == declareWarReason.allyCiv) && !thirdCiv.isAtWarWith(civInfo)) {
                 // Improve our relations
                 if (thirdCiv.isCityState()) thirdCiv.getDiplomacyManager(civInfo)!!.addInfluence(10f)
                 else thirdCiv.getDiplomacyManager(civInfo)!!.addModifier(DiplomaticModifiers.SharedEnemy, 5f * civInfo.getPersonality().modifierFocus(PersonalityValue.Loyal, .3f))


### PR DESCRIPTION
This PR addresses two minor areas. 

First, I added in a TeamWar type but didn't include it for warmongering. Now TeamWar civs get the shared enemy modifier on eachother.
Secondly, war mongering shouldn't really apply when the third civ when they have below a certain amount of relations with the target civ. I chose Competitor <= -15 as the cutoff point which was sort of arbitrary if anyone thinks a different value would be better. (From a discord conversation)