### PR TITLE
Optimize screen orientation

### DIFF
--- a/android/src/com/unciv/app/AndroidDisplay.kt
+++ b/android/src/com/unciv/app/AndroidDisplay.kt
@@ -122,11 +122,12 @@ class AndroidDisplay(private val activity: AndroidApplication) : PlatformDisplay
 
     override fun setOrientation(orientation: ScreenOrientation) {
         val mode = when (orientation) {
-            ScreenOrientation.Landscape -> ActivityInfo.SCREEN_ORIENTATION_USER_LANDSCAPE
-            ScreenOrientation.Portrait -> ActivityInfo.SCREEN_ORIENTATION_USER_PORTRAIT
+            // Automatically adjust landscape based on sensors.
+            ScreenOrientation.Landscape -> ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
+            // Automatically adjust the portrait based on the sensor.
+            ScreenOrientation.Portrait -> ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT
             ScreenOrientation.Auto -> ActivityInfo.SCREEN_ORIENTATION_SENSOR
         }
-
         // Ensure ActivityTaskManager.getService().setRequestedOrientation isn't called unless necessary!
         if (activity.requestedOrientation != mode)
             activity.requestedOrientation = mode


### PR DESCRIPTION
I think using sensor-based orientation settings is better than just relying on the default values. 

Currently, setting the screen to landscape mode in the game only uses the default orientation, which isn't always convenient. For example, when playing the game while lying in bed, the charging cable might not be long enough to rotate the screen to the default landscape mode.  :)
﻿
Although the auto option is available, it sometimes switches the screen to portrait mode, which isn't what I want.

Thanks!