### PR TITLE
Fixed "they declared war on us" notification not being given to the defender

### DIFF
--- a/core/src/com/unciv/logic/civilization/diplomacy/DeclareWar.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DeclareWar.kt
@@ -114,7 +114,7 @@ object DeclareWar {
                 allyCiv.addNotification("You and [${civInfo.civName}] have declared war against [${otherCiv.civName}]!",
                         NotificationCategory.Diplomacy, otherCiv.civName, NotificationIcon.War, civInfo.civName, allyCiv.civName)
 
-                civInfo.addNotification("[${civInfo.civName}] and [${allyCiv.civName}] have declared war against us!",
+                otherCiv.addNotification("[${civInfo.civName}] and [${allyCiv.civName}] have declared war against us!",
                         NotificationCategory.Diplomacy, otherCiv.civName, NotificationIcon.War, allyCiv.civName, civInfo.civName)
 
                 diplomacyManager.getCommonKnownCivsWithSpectators().filterNot { it == allyCiv }.forEach {


### PR DESCRIPTION
This PR addresses a bug brought up on discord. The defender notification of a team war was being sent to the accepting civ instead of the defending civ. This PR fixes that.