### PR TITLE
Update Ukrainian translations

### DIFF
--- a/android/assets/jsons/translations/Ukrainian.properties
+++ b/android/assets/jsons/translations/Ukrainian.properties
@@ -241,9 +241,9 @@ Build [improvementName] on [resourceName] (200 Gold) = Побудувати [imp
 Gift Improvement = Подарувати покращення
 [civName] is able to provide [unitName] once [techName] [isOrAre] researched. = [civName] зможе надати [unitName] лише після дослідження [techName] [isOrAre].
  # Requires translation!
-is = 
+is = ""
  # Requires translation!
-are = 
+are = ""
 
 Diplomatic Marriage ([amount] Gold) = Дипломатичний шлюб ([amount] ¤Золота)
 We have married into the ruling family of [civName], bringing them under our control. = Укладений нами шлюб з правлячою родиною міста-держави [civName] забезпечив нам контроль над ним.
@@ -6979,4 +6979,3 @@ Miscellaneous = Різне
 External links = Зовнішні посилання
 External links support right-click or long press to copy the link to the clipboard instead of launching the browser. = Зовнішні посилання підтримують правий клік або довге натиснення для копіювання посилання в буфер обміну замість відкриття браузера.
 Example: The 'Open Github page' button on the Mod management screen. = Приклад: кнопка 'Відкрити сторінку Github' на екрані керування Модами.
-


### PR DESCRIPTION
Added some `""` as needless translations, hope this works.

Overall, this sentence in English better be reworded in my opinion to not include any need for `[isOrAre]` as that seems to be a grammatic necessity specific to English (and a few more languages maybe):
```
[civName] is able to provide [unitName] once [techName] [isOrAre] researched.
```
f.e. =>
```
[civName] is able to provide [unitName] once the [techName] technology is researched.
```