### PR TITLE
Fix TranslationFileWriter changing diacritic-using languages

### DIFF
--- a/core/src/com/unciv/models/translations/Translations.kt
+++ b/core/src/com/unciv/models/translations/Translations.kt
@@ -173,7 +173,15 @@ class Translations : LinkedHashMap<String, TranslationEntry>() {
         return languages.filter { Gdx.files.internal("jsons/translations/$it.properties").exists() }
     }
 
-    /** Ensure _all_ languages are loaded, used by [TranslationFileWriter] and `TranslationTests` */
+    /** Ensure _all_ languages are loaded, used by [TranslationFileWriter] and `TranslationTests` only.
+     *
+     *  #### Notes:
+     *  -  Expects to run on a newly created instance.
+     *  -  Loads the translations with no diacritic mapping, so what we read will be what we write
+     *     (otherwise we would write out the fake alphabet-conversions, a one-way destructive mistake).
+     *  -  Relies on usage by TFW and tests only, if the result is ever meant to support translations that are actually displayed, a refactor will be needed.
+     *  -  Does not clear the fake alphabet possibly present in DiacriticSupport, but will not use it either.
+     */
     fun readAllLanguagesTranslation() {
         // Apparently you can't iterate over the files in a directory when running out of a .jar...
         // https://www.badlogicgames.com/forum/viewtopic.php?f=11&t=27250
@@ -181,11 +189,9 @@ class Translations : LinkedHashMap<String, TranslationEntry>() {
 
         val translationStart = System.currentTimeMillis()
 
-        DiacriticSupport.reset()
         for (language in getLanguagesWithTranslationFile()) {
             tryReadTranslationForLanguage(language, noDiacritics = true)
         }
-        DiacriticSupport.freeTranslationData()
 
         debug("Loading translation files - %sms", System.currentTimeMillis() - translationStart)
     }

--- a/tests/src/com/unciv/logic/TranslationTests.kt
+++ b/tests/src/com/unciv/logic/TranslationTests.kt
@@ -27,6 +27,7 @@ import org.junit.runner.RunWith
 
 @RunWith(GdxTestRunner::class)
 class TranslationTests {
+    /** Translations to test with - all languages are loaded with diacritic support off */
     private var translations = Translations()
     private var ruleset = Ruleset()
 
@@ -364,6 +365,7 @@ class TranslationTests {
 
     @Test
     fun testNonBasePlaneUnicode() {
+        // This tries how a translation of "Test👍" with diacritic support comes out: Should be 5 codepoints not 6 as the original string representation
         translations.createTranslations("Test", hashMapOf("Test" to "Test\uD83D\uDC4D", "diacritics_support" to "true"))
         testRoundtrip("Test", "Test", "Test\uD83D\uDC4D") { translated ->
             val isOK = translated.startsWith("Test") && translated.length == 5 && translated.last() > DiacriticSupport.getCurrentFreeCode()


### PR DESCRIPTION
Should fix the cause of #11903 - doesn't replace the bungled bangla file itself.
Should also fix the resulting fastlane descriptions after the proper file is back in - though I suspect irrelevant as F-Droid itself hasn' learned /bn/ yet???

~Untested so far except yes it passes unit tests locally~
- chose not to reinstate the Bangla roundtrip test, we could rewrite it as standalone on the same basis as testNonBasePlaneUnicode?