### PR TITLE
Remove old "will be replaced by automated units" unique

### DIFF
--- a/android/assets/jsons/Civ V - Gods & Kings/TileImprovements.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/TileImprovements.json
@@ -284,7 +284,7 @@
 	{
 		"name": "City ruins",
 		"terrainsCanBeBuiltOn": ["Land"],
-		"uniques": ["Unpillagable", "Unbuildable", "Will be replaced by automated units"],
+		"uniques": ["Unpillagable", "Unbuildable"],
         "civilopediaText": [{"text":"A bleak reminder of the destruction wreaked by War"}]
 	},
 	{

--- a/android/assets/jsons/Civ V - Vanilla/TileImprovements.json
+++ b/android/assets/jsons/Civ V - Vanilla/TileImprovements.json
@@ -273,7 +273,7 @@
 	{
 		"name": "City ruins",
 		"terrainsCanBeBuiltOn": ["Land"],
-		"uniques": ["Unpillagable", "Unbuildable", "Will be replaced by automated units"],
+		"uniques": ["Unpillagable", "Unbuildable"],
         "civilopediaText": [{"text":"A bleak reminder of the destruction wreaked by War"}]
 	},
 	{


### PR DESCRIPTION
The "will be replaced" unique is now a dead letter, so it should be removed from the city ruins improvement.