### PR TITLE
Fix untranslated string

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -795,7 +795,7 @@ Reset =
 
 Show zoom buttons in world screen = 
 Experimental Demographics scoreboard = 
-Never close popups by Clicking outside = 
+Never close popups by clicking outside = 
 
 Size of Unitset art in Civilopedia = 
 


### PR DESCRIPTION
`Never close popups by Clicking outside` in template.properties modified to `Never close popups by clicking outside`

Before:
![before](https://github.com/user-attachments/assets/357a14e5-e0c7-46b5-b4f6-eb685ef25ac9)

After:
![after](https://github.com/user-attachments/assets/6b4a55c2-661e-4c2d-a01d-73436ead7d4b)
