### PR TITLE
EditorConfig now uses crlf instead of lf like the rest of the project

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,7 +2,7 @@ root = true
 
 [*]
 charset = utf-8
-end_of_line = lf
+end_of_line = crlf
 indent_style = space
 indent_size = 4
 insert_final_newline = true


### PR DESCRIPTION
I finally found what caused the unique.md and some other .md file to always show in my changes! Intellij was set to use crlf line endings, however it was still changing it to lf. This is because the .editorconfig overrides the Intellij setting. 

Since our project uses crlf we should change the .editorconfig to match it.