### PR TITLE
Gift gold fix

### DIFF
--- a/core/src/com/unciv/logic/automation/civilization/DeclareWarPlanEvaluator.kt
+++ b/core/src/com/unciv/logic/automation/civilization/DeclareWarPlanEvaluator.kt
@@ -131,7 +131,7 @@ object DeclareWarPlanEvaluator {
 
         // They should to be at least half the targets size
         val thirdCivForce = (civToJoin.getStatForRanking(RankingType.Force) - 0.8f * civToJoin.getCivsAtWarWith().sumOf { it.getStatForRanking(RankingType.Force) }).coerceAtLeast(100f)
-        motivation += (2 * thirdCivForce / targetForce.toFloat()).coerceAtMost(40f)
+        motivation += (20 * (1 - (thirdCivForce / targetForce.toFloat()))).coerceAtMost(40f)
 
         // If we have less relative force then the target then we have more motivation to accept
         motivation += 20 * (1 - (civForce / targetForce.toFloat())).coerceIn(-40f, 40f)

--- a/core/src/com/unciv/logic/automation/civilization/DeclareWarPlanEvaluator.kt
+++ b/core/src/com/unciv/logic/automation/civilization/DeclareWarPlanEvaluator.kt
@@ -131,10 +131,10 @@ object DeclareWarPlanEvaluator {
 
         // They should to be at least half the targets size
         val thirdCivForce = (civToJoin.getStatForRanking(RankingType.Force) - 0.8f * civToJoin.getCivsAtWarWith().sumOf { it.getStatForRanking(RankingType.Force) }).coerceAtLeast(100f)
-        motivation += (20 * (1 - (thirdCivForce / targetForce.toFloat()))).coerceAtMost(40f)
+        motivation += (20 * (1 - thirdCivForce / targetForce.toFloat())).coerceAtMost(40f)
 
         // If we have less relative force then the target then we have more motivation to accept
-        motivation += 20 * (1 - (civForce / targetForce.toFloat())).coerceIn(-40f, 40f)
+        motivation += 20 * (1 - civForce / targetForce.toFloat()).coerceIn(-40f, 40f)
 
         return motivation - 20
     }

--- a/core/src/com/unciv/ui/screens/diplomacyscreen/MajorCivDiplomacyTable.kt
+++ b/core/src/com/unciv/ui/screens/diplomacyscreen/MajorCivDiplomacyTable.kt
@@ -85,12 +85,12 @@ class MajorCivDiplomacyTable(private val diplomacyScreen: DiplomacyScreen) {
         if (otherCiv.getCapital() != null && viewingCiv.hasExplored(otherCiv.getCapital()!!.getCenterTile()))
             diplomacyTable.add(diplomacyScreen.getGoToOnMapButton(otherCiv)).row()
 
-//         if (!otherCiv.isHuman()) { // human players make their own choices
-        diplomacyTable.add(diplomacyScreen.getRelationshipTable(otherCivDiplomacyManager)).row()
-        diplomacyTable.add(getDiplomacyModifiersTable(otherCivDiplomacyManager)).row()
-        val promisesTable = getPromisesTable(diplomacyManager, otherCivDiplomacyManager)
-        if (promisesTable != null) diplomacyTable.add(promisesTable).row()
-//         }
+        if (!otherCiv.isHuman()) { // human players make their own choices
+            diplomacyTable.add(diplomacyScreen.getRelationshipTable(otherCivDiplomacyManager)).row()
+            diplomacyTable.add(getDiplomacyModifiersTable(otherCivDiplomacyManager)).row()
+            val promisesTable = getPromisesTable(diplomacyManager, otherCivDiplomacyManager)
+            if (promisesTable != null) diplomacyTable.add(promisesTable).row()
+        }
 
         // Starting playback here assumes the MajorCivDiplomacyTable is shown immediately
         UncivGame.Current.musicController.playVoice(helloVoice)

--- a/core/src/com/unciv/ui/screens/diplomacyscreen/MajorCivDiplomacyTable.kt
+++ b/core/src/com/unciv/ui/screens/diplomacyscreen/MajorCivDiplomacyTable.kt
@@ -85,12 +85,12 @@ class MajorCivDiplomacyTable(private val diplomacyScreen: DiplomacyScreen) {
         if (otherCiv.getCapital() != null && viewingCiv.hasExplored(otherCiv.getCapital()!!.getCenterTile()))
             diplomacyTable.add(diplomacyScreen.getGoToOnMapButton(otherCiv)).row()
 
-        if (!otherCiv.isHuman()) { // human players make their own choices
-            diplomacyTable.add(diplomacyScreen.getRelationshipTable(otherCivDiplomacyManager)).row()
-            diplomacyTable.add(getDiplomacyModifiersTable(otherCivDiplomacyManager)).row()
-            val promisesTable = getPromisesTable(diplomacyManager, otherCivDiplomacyManager)
-            if (promisesTable != null) diplomacyTable.add(promisesTable).row()
-        }
+//         if (!otherCiv.isHuman()) { // human players make their own choices
+        diplomacyTable.add(diplomacyScreen.getRelationshipTable(otherCivDiplomacyManager)).row()
+        diplomacyTable.add(getDiplomacyModifiersTable(otherCivDiplomacyManager)).row()
+        val promisesTable = getPromisesTable(diplomacyManager, otherCivDiplomacyManager)
+        if (promisesTable != null) diplomacyTable.add(promisesTable).row()
+//         }
 
         // Starting playback here assumes the MajorCivDiplomacyTable is shown immediately
         UncivGame.Current.musicController.playVoice(helloVoice)


### PR DESCRIPTION
This PR fixes the bug reported in #11969 and other discord messages. The situation was that some trade was resulting in a very high gift value. The users then reported it after using the gold gift for an unbalanced trade. Debugging the problem was hard, since the logical bug occurred turns earlier than the save given. While testing I used a simple testing game so the force value of the civilizations was very low, making it impossible to see the bug.

The bug: I was missing a pair of parenthesis on `motivation += 2 * thirdCivForce / targetForce.toFloat().coerceAtMost(40f)`. So the target force had a max value of 40 while the thirdCivForce can be in the hundreds of thousands.
So I fixed it, and added a few other minor tweaks.