### PR TITLE
Made Gold Gifting moddable

### DIFF
--- a/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyTurnManager.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyTurnManager.kt
@@ -294,22 +294,22 @@ object DiplomacyTurnManager {
         revertToZero(DiplomaticModifiers.LiberatedCity, 1 / 8f)
         if (hasModifier(DiplomaticModifiers.GaveUsGifts)) {
             val giftLoss = when {
-                relationshipLevel() == RelationshipLevel.Ally -> .5f
-                relationshipLevel() == RelationshipLevel.Friend -> 1f
-                relationshipLevel() == RelationshipLevel.Favorable -> 1.5f
+                relationshipLevel() == RelationshipLevel.Ally -> 1f
+                relationshipLevel() == RelationshipLevel.Friend -> 1.5f
+                relationshipLevel() == RelationshipLevel.Favorable -> 2f
+                relationshipLevel() == RelationshipLevel.Neutral -> 2.5f
                 relationshipLevel() == RelationshipLevel.Competitor -> 5f
                 relationshipLevel() == RelationshipLevel.Enemy -> 7.5f
                 relationshipLevel() == RelationshipLevel.Unforgivable -> 10f
-                else -> 2f // Neutral
-            }
+                else -> 2.5f
+            } * civInfo.gameInfo.ruleset.modOptions.constants.goldGiftDegradationMultiplier
             // We should subtract a certain amount from this balanced each turn
             // Assuming neutral relations we will subtract the higher of either:
-            //  2% of the total amount or
-            //  roughly 40 gold per turn (a value of ~.4 without inflation)
+            //  2.5% of the total amount or roughly 50 gold per turn (a value of ~.5 without inflation)
             // This ensures that the amount can be reduced to zero but scales with larger numbers
             val amountLost = (getModifier(DiplomaticModifiers.GaveUsGifts).absoluteValue * giftLoss / 100)
                 .coerceAtLeast(giftLoss / 5)
-            revertToZero(DiplomaticModifiers.GaveUsGifts, amountLost) // Roughly worth 20 GPT without inflation
+            revertToZero(DiplomaticModifiers.GaveUsGifts, amountLost)
         }
 
         setFriendshipBasedModifier()

--- a/core/src/com/unciv/logic/trade/TradeLogic.kt
+++ b/core/src/com/unciv/logic/trade/TradeLogic.kt
@@ -159,9 +159,11 @@ class TradeLogic(val ourCivilization: Civilization, val otherCivilization: Civil
             val ourGoldValueOfTrade = TradeEvaluation().getTradeAcceptability(currentTrade, ourCivilization, otherCivilization, includeDiplomaticGifts = false)
             val theirGoldValueOfTrade = TradeEvaluation().getTradeAcceptability(currentTrade.reverse(), otherCivilization, ourCivilization, includeDiplomaticGifts = false)
             if (ourGoldValueOfTrade > theirGoldValueOfTrade) {
-                ourDiploManager.giftGold(ourGoldValueOfTrade - theirGoldValueOfTrade.coerceAtLeast(0))
+                val isPureGift = currentTrade.ourOffers.isEmpty()
+                ourDiploManager.giftGold(ourGoldValueOfTrade - theirGoldValueOfTrade.coerceAtLeast(0), isPureGift)
             } else if (theirGoldValueOfTrade > ourGoldValueOfTrade) {
-                theirDiploManger.giftGold(theirGoldValueOfTrade - ourGoldValueOfTrade.coerceAtLeast(0))
+                val isPureGift = currentTrade.theirOffers.isEmpty()
+                theirDiploManger.giftGold(theirGoldValueOfTrade - ourGoldValueOfTrade.coerceAtLeast(0), isPureGift)
             }
         }
 

--- a/core/src/com/unciv/models/ModConstants.kt
+++ b/core/src/com/unciv/models/ModConstants.kt
@@ -52,11 +52,14 @@ class ModConstants {
     var cityWorkRange = 3
     var cityExpandRange = 5
 
-    // Modifies how much the gold value of a one-sided trade is applied to the gifts diplomatic modifier
-    // Eg: One side offers a city, resource or gold for nothing in return
+    // Modifies how much the gold value of a one-sided trade is applied to the gifts diplomatic modifier.
+    // Eg: One side offers a city, resource or gold for nothing in return.
     var goldGiftMultiplier = 1f
-    // Modifies how much the gold value of a regular trade is applied to the gifts diplomatic modifier
+    // Modifies how much the gold value of a regular trade is applied to the gifts diplomatic modifier.
     var goldGiftTradeMultiplier = .8f
+    // Modifies how quickly the GaveUsGifts dimplomacy modifier runs out. A higher value makes it run out quicker.
+    // Normally the gifts reduced by ~2.5% per turn depending on the diplomatic relations with the default value.
+    var goldGiftDegradationMultiplier = 1f
 
     // Constants used to calculate Unit Upgrade gold Cost (can only be modded all-or-nothing)
     // This is a data class for one reason only: The equality implementation enables Gdx Json to omit it when default (otherwise only the individual fields are omitted)

--- a/core/src/com/unciv/models/ModConstants.kt
+++ b/core/src/com/unciv/models/ModConstants.kt
@@ -52,6 +52,12 @@ class ModConstants {
     var cityWorkRange = 3
     var cityExpandRange = 5
 
+    // Modifies how much the gold value of a one-sided trade is applied to the gifts diplomatic modifier
+    // Eg: One side offers a city, resource or gold for nothing in return
+    var goldGiftMultiplier = 1f
+    // Modifies how much the gold value of a regular trade is applied to the gifts diplomatic modifier
+    var goldGiftTradeMultiplier = .8f
+
     // Constants used to calculate Unit Upgrade gold Cost (can only be modded all-or-nothing)
     // This is a data class for one reason only: The equality implementation enables Gdx Json to omit it when default (otherwise only the individual fields are omitted)
     data class UnitUpgradeCost(

--- a/docs/Modders/Mod-file-structure/5-Miscellaneous-JSON-files.md
+++ b/docs/Modders/Mod-file-structure/5-Miscellaneous-JSON-files.md
@@ -218,6 +218,8 @@ and city distance in another. In case of conflicts, there is no guarantee which 
 | baseTurnsUntilRevolt                     | Int    | 4                             | [^Q]  |
 | cityStateElectionTurns                   | Int    | 15                            | [^R]  |
 | maxImprovementTechErasForward            | Int    | None                          | [^S]  |
+| goldGiftMultiplier                       | Float  | 1                             | [^T]  |
+| goldGiftTradeMultiplier                  | Float  | 0.8                           | [^U]  |
 
 Legend:
 
@@ -257,6 +259,8 @@ Legend:
 - [^Q]: The number of turns before a revolt is spawned
 - [^R]: The number of turns between city-state elections
 - [^S]: If set, the Improvement picker will silently skip improvements whose tech requirement is more advanced than your current Era + this value. Example: With a 0, Trade posts will not show until the Medieval Era, with a 1 they will already show in the CLassical Era.
+- [^T]: The multiplier of the gold value of a one-sided trade to be stored as gifts.
+- [^U]: The multiplier of the gold value of a regular trade to be stored as gifts. Set to 0 to disable gold gifting in two-sided trades.
 
 #### UnitUpgradeCost
 

--- a/docs/Modders/Mod-file-structure/5-Miscellaneous-JSON-files.md
+++ b/docs/Modders/Mod-file-structure/5-Miscellaneous-JSON-files.md
@@ -220,6 +220,7 @@ and city distance in another. In case of conflicts, there is no guarantee which 
 | maxImprovementTechErasForward            | Int    | None                          | [^S]  |
 | goldGiftMultiplier                       | Float  | 1                             | [^T]  |
 | goldGiftTradeMultiplier                  | Float  | 0.8                           | [^U]  |
+| goldGiftDegradationMultiplier            | Float  | 1.0                           | [^V]  |
 
 Legend:
 
@@ -261,6 +262,7 @@ Legend:
 - [^S]: If set, the Improvement picker will silently skip improvements whose tech requirement is more advanced than your current Era + this value. Example: With a 0, Trade posts will not show until the Medieval Era, with a 1 they will already show in the CLassical Era.
 - [^T]: The multiplier of the gold value of a one-sided trade to be stored as gifts.
 - [^U]: The multiplier of the gold value of a regular trade to be stored as gifts. Set to 0 to disable gold gifting in two-sided trades.
+- [^U]: Modifies how quickly the GaveUsGifts dimplomacy modifier runs out. A higher value makes it run out quicker. Normally the gifts reduced by ~2.5% per turn depending on the diplomatic relations with the default value.
 
 #### UnitUpgradeCost
 

--- a/tests/src/com/unciv/logic/civilization/diplomacy/GoldGiftingTests.kt
+++ b/tests/src/com/unciv/logic/civilization/diplomacy/GoldGiftingTests.kt
@@ -44,7 +44,7 @@ class GoldGiftingTests {
     fun `Gold Gift Test` () {
         assertEquals(0, aDiplomacy.getGoldGifts())
         assertEquals(0, bDiplomacy.getGoldGifts())
-        aDiplomacy.giftGold(10)
+        aDiplomacy.giftGold(10, true)
         assertTrue(aDiplomacy.getGoldGifts() > 0)
         assertEquals(0, bDiplomacy.getGoldGifts())
     }
@@ -72,7 +72,7 @@ class GoldGiftingTests {
         val gold2 = aDiplomacy.getGoldGifts()
         assertTrue(gold > gold2)
         assertTrue(gold2 >= gold * .9) // We shoulden't loose more than 10% of the value in one turn
-        assertTrue(gold2 >= 0) 
+        assertTrue(gold2 >= 0)
     }
 
     @Test
@@ -88,8 +88,8 @@ class GoldGiftingTests {
 
     @Test
     fun `Gifting gold reduces previous gifts taken` () {
-        aDiplomacy.giftGold(1000)
-        bDiplomacy.giftGold(500)
+        aDiplomacy.giftGold(1000, true)
+        bDiplomacy.giftGold(500, true)
         assertTrue(aDiplomacy.getGoldGifts() > 0)
         assertTrue(aDiplomacy.getGoldGifts() < 1000)
         assertTrue(bDiplomacy.getGoldGifts() == 0)
@@ -132,6 +132,30 @@ class GoldGiftingTests {
         tradeOffer.acceptTrade()
         val tradeOffer2 = TradeLogic(a,b)
         assertTrue(TradeEvaluation().getTradeAcceptability(tradeOffer2.currentTrade.reverse(), b,a,true) > 0)
+    }
+
+    @Test
+    fun `Gold gifted uses pure gold multiplier constant`() {
+        a.addGold(1000)
+        a.gameInfo.ruleset.modOptions.constants.goldGiftMultiplier = .5f
+        a.gameInfo.ruleset.modOptions.constants.goldGiftTradeMultiplier = 0f
+        val tradeOffer = TradeLogic(a,b)
+        tradeOffer.currentTrade.ourOffers.add(tradeOffer.ourAvailableOffers.first { it.type == TradeOfferType.Gold })
+        tradeOffer.acceptTrade()
+        assertEquals(500, bDiplomacy.getGoldGifts())
+    }
+
+    @Test
+    fun `Gold gifted uses gold multiplier constant`() {
+        a.addGold(1000)
+        b.addGold(500)
+        a.gameInfo.ruleset.modOptions.constants.goldGiftMultiplier = 0f
+        a.gameInfo.ruleset.modOptions.constants.goldGiftTradeMultiplier = .5f
+        val tradeOffer = TradeLogic(a,b)
+        tradeOffer.currentTrade.ourOffers.add(tradeOffer.ourAvailableOffers.first { it.type == TradeOfferType.Gold })
+        tradeOffer.currentTrade.theirOffers.add(tradeOffer.theirAvailableOffers.first { it.type == TradeOfferType.Gold })
+        tradeOffer.acceptTrade()
+        assertEquals(250, bDiplomacy.getGoldGifts())
     }
 
 }

--- a/tests/src/com/unciv/logic/civilization/diplomacy/GoldGiftingTests.kt
+++ b/tests/src/com/unciv/logic/civilization/diplomacy/GoldGiftingTests.kt
@@ -7,7 +7,6 @@ import com.unciv.logic.trade.TradeOffer
 import com.unciv.logic.trade.TradeOfferType
 import com.unciv.testing.GdxTestRunner
 import com.unciv.testing.TestGame
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before


### PR DESCRIPTION
This PR expands on #11326 by making the gold gifting moddable. Modders are able to completely disable gold gifting, or they can decide to make it OP.

There are two types of gold gifts that can be given: 

- "Pure" gold gifts, where the giver receives nothing in return. I put this multiplier at full value by default.
- Favorable trades, where one side of the trade has more value than the other side. I put this multiplier at 0.8 or 80% by default.

The rate at which the gifts degrade at is also moddable. I also slightly increased the friendly degradation rate.

Any input on what the default values should be would be appreciated.