### PR TITLE
Fix AUR deploy step

### DIFF
--- a/.github/workflows/buildAndDeploy.yml
+++ b/.github/workflows/buildAndDeploy.yml
@@ -316,6 +316,6 @@ jobs:
             Update to ${{ github.ref_name }}
 
             ${{needs.get-release-body.outputs.release_body}}
-          ssh_keyscan_types: rsa,dsa,ecdsa,ed25519
+          ssh_keyscan_types: rsa
           updpkgsums: true
           allow_empty_commits: false


### PR DESCRIPTION
Due to some changes somewhere, the deploy step for the AUR was broken with error `Unknown key type "dsa"`. Since we just use a `rsa` key, I have removed all unnecessary options.

Fixes yairm210/Unciv#11907