### PR TITLE
New options control over Animations

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -811,11 +811,11 @@ Show pixel units =
 Show pixel improvements = 
 Unit icon opacity = 
 
-### Performance subgroup
-
-Performance = 
-Continuous rendering = 
-When disabled, saves battery life but certain animations will be suspended = 
+### Animations subgroup
+Animations = 
+Animation level = 
+Some = 
+Expert = 
 
 ## Gameplay tab
 Gameplay = 

--- a/core/src/com/unciv/UncivGame.kt
+++ b/core/src/com/unciv/UncivGame.kt
@@ -139,7 +139,7 @@ open class UncivGame(val isConsoleMode: Boolean = false) : Game(), PlatformSpeci
             settings.tileSet = Constants.defaultTileset
         }
 
-        Gdx.graphics.isContinuousRendering = settings.continuousRendering
+        Gdx.graphics.isContinuousRendering = false
 
         Concurrency.run("LoadJSON") {
             RulesetCache.loadRulesets()

--- a/core/src/com/unciv/models/metadata/GameSettingsMigrations.kt
+++ b/core/src/com/unciv/models/metadata/GameSettingsMigrations.kt
@@ -8,8 +8,12 @@ private const val CURRENT_VERSION = 2
 fun GameSettings.doMigrations(json: JsonValue) {
     if (version == null) {
         migrateMultiplayerSettings(json)
-        version = 1
     }
+    if (continuousRendering != null) {
+        enabledAnimations.setLevel(if (continuousRendering!!) GameSettings.AnimationLevels.All else GameSettings.AnimationLevels.None)
+        continuousRendering = null
+    }
+    version = CURRENT_VERSION
 }
 
 fun GameSettings.isMigrationNecessary(): Boolean {

--- a/core/src/com/unciv/models/translations/TranslationFileWriter.kt
+++ b/core/src/com/unciv/models/translations/TranslationFileWriter.kt
@@ -8,6 +8,7 @@ import com.unciv.json.json
 import com.unciv.logic.civilization.diplomacy.DiplomaticModifiers
 import com.unciv.models.SpyAction
 import com.unciv.models.metadata.BaseRuleset
+import com.unciv.models.metadata.GameSettings
 import com.unciv.models.metadata.GameSettings.LocaleCode
 import com.unciv.models.ruleset.Belief
 import com.unciv.models.ruleset.Building
@@ -138,6 +139,10 @@ object TranslationFileWriter {
             linesToTranslate += "\n\n#################### Lines from key bindings #######################\n"
             for (bindingLabel in KeyboardBinding.getTranslationEntries())
                 linesToTranslate += "$bindingLabel = "
+
+            linesToTranslate += "\n\n#################### Lines from animation settings #######################\n"
+            for (animation in GameSettings.Animations.entries)
+                linesToTranslate += "${animation.label} = "
 
             for (baseRuleset in BaseRuleset.entries) {
                 val generatedStringsFromBaseRuleset =

--- a/core/src/com/unciv/ui/components/ParticleEffectAnimation.kt
+++ b/core/src/com/unciv/ui/components/ParticleEffectAnimation.kt
@@ -12,6 +12,7 @@ import com.badlogic.gdx.scenes.scene2d.Stage
 import com.badlogic.gdx.utils.Array
 import com.badlogic.gdx.utils.Disposable
 import com.unciv.UncivGame
+import com.unciv.models.metadata.GameSettings
 import com.unciv.ui.images.ImageGetter
 
 /** Hosts one template ParticleEffect and any number of clones, and each can travel linearly over part of its lifetime.
@@ -28,7 +29,8 @@ abstract class ParticleEffectAnimation : Disposable {
         const val defaultAtlasName = "ConstructionIcons"
 
         fun isEnabled(game: UncivGame, atlasName: String = defaultAtlasName) =
-            game.settings.continuousRendering && ImageGetter.getSpecificAtlas(atlasName) != null
+            GameSettings.Animations.WLTKFireworks in game.settings.enabledAnimations &&
+            ImageGetter.getSpecificAtlas(atlasName) != null
 
         private val halfPoint = Vector2(0.5f, 0.5f)
     }

--- a/core/src/com/unciv/ui/components/widgets/ExpanderTab.kt
+++ b/core/src/com/unciv/ui/components/widgets/ExpanderTab.kt
@@ -9,7 +9,8 @@ import com.badlogic.gdx.scenes.scene2d.ui.ScrollPane
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.utils.Align
 import com.unciv.Constants
-import com.unciv.UncivGame
+import com.unciv.GUI
+import com.unciv.models.metadata.GameSettings
 import com.unciv.ui.components.extensions.toLabel
 import com.unciv.ui.components.input.KeyboardBinding
 import com.unciv.ui.components.input.keyShortcuts
@@ -108,7 +109,7 @@ class ExpanderTab(
     private fun update(noAnimation: Boolean = false) {
         if (persistenceID != null)
             persistedStates[persistenceID] = isOpen
-        if (noAnimation || !UncivGame.Current.settings.continuousRendering) {
+        if (noAnimation || GameSettings.Animations.Expanders !in GUI.getSettings().enabledAnimations) {
             contentWrapper.clear()
             if (isOpen) contentWrapper.add(innerTable)
             headerIcon.rotation = if (isOpen) 90f else 180f

--- a/core/src/com/unciv/ui/components/widgets/LoadingImage.kt
+++ b/core/src/com/unciv/ui/components/widgets/LoadingImage.kt
@@ -1,5 +1,3 @@
-@file:OptIn(ExperimentalTime::class)
-
 package com.unciv.ui.components.widgets
 
 import com.badlogic.gdx.graphics.Color
@@ -13,6 +11,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.WidgetGroup
 import com.badlogic.gdx.utils.Align
 import com.badlogic.gdx.utils.Disposable
 import com.unciv.GUI
+import com.unciv.models.metadata.GameSettings
 import com.unciv.ui.components.extensions.center
 import com.unciv.ui.components.extensions.setSize
 import com.unciv.ui.components.input.onChange
@@ -21,7 +20,6 @@ import com.unciv.ui.components.widgets.LoadingImage.Style
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.screens.basescreen.BaseScreen
 import kotlin.math.absoluteValue
-import kotlin.time.ExperimentalTime
 import kotlin.time.TimeMark
 import kotlin.time.TimeSource
 
@@ -48,7 +46,7 @@ class LoadingImage(
     private val circle: Image?
     private val idleIcon: Image?
     private val loadingIcon: Image
-    var animated = GUI.getSettings().continuousRendering
+    var animated = GameSettings.Animations.Loading in GUI.getSettings().enabledAnimations
     private var loadingStarted: TimeMark? = null
     //endregion
 

--- a/core/src/com/unciv/ui/components/widgets/UnitIconGroup.kt
+++ b/core/src/com/unciv/ui/components/widgets/UnitIconGroup.kt
@@ -11,6 +11,7 @@ import com.badlogic.gdx.utils.Align
 import com.unciv.GUI
 import com.unciv.UncivGame
 import com.unciv.logic.map.mapunit.MapUnit
+import com.unciv.models.metadata.GameSettings
 import com.unciv.ui.components.extensions.addToCenter
 import com.unciv.ui.components.extensions.centerX
 import com.unciv.ui.components.extensions.colorFromRGB
@@ -216,7 +217,7 @@ class UnitIconGroup(val unit: MapUnit, val size: Float) : Group() {
         flagBg.color.a = alpha
         flagSelection.color.a = opacity
 
-        if (GUI.getSettings().continuousRendering) {
+        if (GameSettings.Animations.SelectedUnit in GUI.getSettings().enabledAnimations) {
             flagSelection.color.a = opacity
             flagSelection.addAction(
                 Actions.repeat(

--- a/core/src/com/unciv/ui/popups/options/DisplayTab.kt
+++ b/core/src/com/unciv/ui/popups/options/DisplayTab.kt
@@ -2,25 +2,21 @@ package com.unciv.ui.popups.options
 
 import com.badlogic.gdx.Application
 import com.badlogic.gdx.Gdx
-import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.scenes.scene2d.ui.SelectBox
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.utils.Array
 import com.unciv.GUI
-import com.unciv.models.metadata.GameSettings
 import com.unciv.models.metadata.GameSettings.ScreenSize
 import com.unciv.models.skins.SkinCache
 import com.unciv.models.tilesets.TileSetCache
 import com.unciv.models.translations.tr
 import com.unciv.ui.components.extensions.addSeparator
-import com.unciv.ui.components.extensions.brighten
 import com.unciv.ui.components.extensions.toLabel
 import com.unciv.ui.components.extensions.toTextButton
 import com.unciv.ui.components.input.onChange
 import com.unciv.ui.components.input.onClick
 import com.unciv.ui.components.widgets.TranslatedSelectBox
 import com.unciv.ui.components.widgets.UncivSlider
-import com.unciv.ui.components.widgets.WrappableLabel
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.popups.ConfirmPopup
 import com.unciv.ui.screens.basescreen.BaseScreen
@@ -31,250 +27,246 @@ import com.unciv.utils.ScreenMode
 /**
  *  @param onChange Callback for _major_ changes, OptionsPopup will rebuild itself and the WorldScreen
  */
-fun displayTab(
-    optionsPopup: OptionsPopup,
-    onChange: () -> Unit,
-) = Table(BaseScreen.skin).apply {
-    pad(10f)
-    defaults().pad(2.5f)
+internal class DisplayTab (
+    private val optionsPopup: OptionsPopup,
+    private val onChange: () -> Unit,
+) : Table(BaseScreen.skin) {
+    private val selectBoxMinWidth by optionsPopup::selectBoxMinWidth
+    private val settings by optionsPopup::settings
 
-    val settings = optionsPopup.settings
+    init {
+        pad(10f)
+        defaults().pad(2.5f)
 
-    add("Screen".toLabel(fontSize = 24)).colspan(2).row()
+        val settings = optionsPopup.settings
 
-    addScreenModeSelectBox(this, settings, optionsPopup.selectBoxMinWidth)
-    addScreenSizeSelectBox(this, settings, optionsPopup.selectBoxMinWidth, onChange)
+        add("Screen".toLabel(fontSize = 24)).colspan(2).row()
+
+        addScreenModeSelectBox()
+        addScreenSizeSelectBox()
 
 
-    if (Gdx.app.type == Application.ApplicationType.Desktop) {
-        optionsPopup.addCheckbox(this, "Map mouse auto-scroll", settings.mapAutoScroll, true) {
-            settings.mapAutoScroll = it
+        if (Gdx.app.type == Application.ApplicationType.Desktop) {
+            optionsPopup.addCheckbox(this, "Map mouse auto-scroll", settings.mapAutoScroll, true) {
+                settings.mapAutoScroll = it
+                if (GUI.isWorldLoaded())
+                    GUI.getMap().isAutoScrollEnabled = settings.mapAutoScroll
+            }
+            addScrollSpeedSlider()
+        }
+
+        addSeparator()
+        add("Graphics".toLabel(fontSize = 24)).colspan(2).row()
+
+        addTileSetSelectBox()
+        addUnitSetSelectBox()
+        addSkinSelectBox()
+
+        addSeparator()
+        add("UI".toLabel(fontSize = 24)).colspan(2).row()
+
+        addNotificationScrollSelect()
+        addMinimapSizeSlider()
+        optionsPopup.addCheckbox(this, "Show tutorials", settings.showTutorials, updateWorld = true, newRow = false) { settings.showTutorials = it }
+        addResetTutorials()
+        optionsPopup.addCheckbox(this, "Show zoom buttons in world screen", settings.showZoomButtons, true) { settings.showZoomButtons = it }
+        optionsPopup.addCheckbox(this, "Experimental Demographics scoreboard", settings.useDemographics, true) { settings.useDemographics = it }
+        optionsPopup.addCheckbox(this, "Never close popups by clicking outside", settings.forbidPopupClickBehindToClose, false) { settings.forbidPopupClickBehindToClose = it }
+        addPediaUnitArtSizeSlider()
+
+        addSeparator()
+        add("Visual Hints".toLabel(fontSize = 24)).colspan(2).row()
+
+        optionsPopup.addCheckbox(this, "Show unit movement arrows", settings.showUnitMovements, true) { settings.showUnitMovements = it }
+        optionsPopup.addCheckbox(
+            this,
+            "Show suggested city locations for units that can found cities",
+            settings.showSettlersSuggestedCityLocations,
+            true
+        ) { settings.showSettlersSuggestedCityLocations = it }
+        optionsPopup.addCheckbox(this, "Show tile yields", settings.showTileYields, true) { settings.showTileYields = it } // JN
+        optionsPopup.addCheckbox(this, "Show worked tiles", settings.showWorkedTiles, true) { settings.showWorkedTiles = it }
+        optionsPopup.addCheckbox(this, "Show resources and improvements", settings.showResourcesAndImprovements, true) { settings.showResourcesAndImprovements = it }
+        optionsPopup.addCheckbox(this, "Show pixel improvements", settings.showPixelImprovements, true) { settings.showPixelImprovements = it }
+
+        addUnitIconAlphaSlider()
+
+        addAnimationOptions()
+    }
+
+
+    private fun addMinimapSizeSlider() {
+        add("Minimap size".toLabel()).left().fillX()
+
+        // The meaning of the values needs a formula to be synchronized between here and
+        // [Minimap.init]. It goes off-10%-11%..29%-30%-35%-40%-45%-50% - and the percentages
+        // correspond roughly to the minimap's proportion relative to screen dimensions.
+        val offTranslated = "off".tr()  // translate only once and cache in closure
+        val getTipText: (Float) -> String = {
+            when (it) {
+                0f -> offTranslated
+                in 0.99f..21.01f -> "%.0f".format(it + 9) + "%"
+                else -> "%.0f".format(it * 5 - 75) + "%"
+            }
+        }
+        val minimapSlider = UncivSlider(
+            0f, 25f, 1f,
+            initial = if (settings.showMinimap) settings.minimapSize.toFloat() else 0f,
+            getTipText = getTipText
+        ) {
+            val size = it.toInt()
+            if (size == 0) settings.showMinimap = false
+            else {
+                settings.showMinimap = true
+                settings.minimapSize = size
+            }
+            GUI.setUpdateWorldOnNextRender()
+        }
+        add(minimapSlider).minWidth(selectBoxMinWidth).pad(10f).row()
+    }
+
+    private fun addScrollSpeedSlider() {
+        add("Map panning speed".toLabel()).left().fillX()
+
+        val scrollSpeedSlider = UncivSlider(
+            0.2f, 25f, 0.2f, initial = settings.mapPanningSpeed
+        ) {
+            settings.mapPanningSpeed = it
+            settings.save()
             if (GUI.isWorldLoaded())
-                GUI.getMap().isAutoScrollEnabled = settings.mapAutoScroll
+                GUI.getMap().mapPanningSpeed = settings.mapPanningSpeed
         }
-        addScrollSpeedSlider(this, settings, optionsPopup.selectBoxMinWidth)
+        add(scrollSpeedSlider).minWidth(selectBoxMinWidth).pad(10f).row()
     }
 
-    addSeparator()
-    add("Graphics".toLabel(fontSize = 24)).colspan(2).row()
+    private fun addUnitIconAlphaSlider() {
+        add("Unit icon opacity".toLabel()).left().fillX()
 
-    addTileSetSelectBox(this, settings, optionsPopup.selectBoxMinWidth, onChange)
-    addUnitSetSelectBox(this, settings, optionsPopup.selectBoxMinWidth, onChange)
-    addSkinSelectBox(this, settings, optionsPopup.selectBoxMinWidth, onChange)
+        val getTipText: (Float) -> String = { "%.0f".format(it * 100) + "%" }
 
-    addSeparator()
-    add("UI".toLabel(fontSize = 24)).colspan(2).row()
-
-    addNotificationScrollSelect(this, settings, optionsPopup.selectBoxMinWidth)
-    addMinimapSizeSlider(this, settings, optionsPopup.selectBoxMinWidth)
-    optionsPopup.addCheckbox(this, "Show tutorials", settings.showTutorials, updateWorld = true, newRow = false) { settings.showTutorials = it }
-    addResetTutorials(this, settings)
-    optionsPopup.addCheckbox(this, "Show zoom buttons in world screen", settings.showZoomButtons, true) { settings.showZoomButtons = it }
-    optionsPopup.addCheckbox(this, "Experimental Demographics scoreboard", settings.useDemographics, true) { settings.useDemographics = it }
-    optionsPopup.addCheckbox(this, "Never close popups by clicking outside", settings.forbidPopupClickBehindToClose, false) { settings.forbidPopupClickBehindToClose = it }
-    addPediaUnitArtSizeSlider(this, settings, optionsPopup.selectBoxMinWidth)
-
-    addSeparator()
-    add("Visual Hints".toLabel(fontSize = 24)).colspan(2).row()
-
-    optionsPopup.addCheckbox(this, "Show unit movement arrows", settings.showUnitMovements, true) { settings.showUnitMovements = it }
-    optionsPopup.addCheckbox(this, "Show suggested city locations for units that can found cities", settings.showSettlersSuggestedCityLocations, true) { settings.showSettlersSuggestedCityLocations = it }
-    optionsPopup.addCheckbox(this, "Show tile yields", settings.showTileYields, true) { settings.showTileYields = it } // JN
-    optionsPopup.addCheckbox(this, "Show worked tiles", settings.showWorkedTiles, true) { settings.showWorkedTiles = it }
-    optionsPopup.addCheckbox(this, "Show resources and improvements", settings.showResourcesAndImprovements, true) { settings.showResourcesAndImprovements = it }
-    optionsPopup.addCheckbox(this, "Show pixel improvements", settings.showPixelImprovements, true) { settings.showPixelImprovements = it }
-
-    addUnitIconAlphaSlider(this, settings, optionsPopup.selectBoxMinWidth)
-
-    addSeparator()
-    add("Performance".toLabel(fontSize = 24)).colspan(2).row()
-
-    optionsPopup.addCheckbox(this, "Continuous rendering", settings.continuousRendering == true) {
-        settings.continuousRendering = it
-        Gdx.graphics.isContinuousRendering = it
+        val unitIconAlphaSlider = UncivSlider(
+            0f, 1f, 0.1f, initial = settings.unitIconOpacity, getTipText = getTipText
+        ) {
+            settings.unitIconOpacity = it
+            GUI.setUpdateWorldOnNextRender()
+        }
+        add(unitIconAlphaSlider).minWidth(selectBoxMinWidth).pad(10f).row()
     }
 
-    val continuousRenderingDescription = "When disabled, saves battery life but certain animations will be suspended"
-    val continuousRenderingLabel = WrappableLabel(
-        continuousRenderingDescription,
-        optionsPopup.tabs.prefWidth, Color.ORANGE.brighten(0.7f), 14
-    )
-    continuousRenderingLabel.wrap = true
-    add(continuousRenderingLabel).colspan(2).padTop(10f).row()
-}
+    private fun addPediaUnitArtSizeSlider() {
+        add("Size of Unitset art in Civilopedia".toLabel()).left().fillX()
 
-private fun addMinimapSizeSlider(table: Table, settings: GameSettings, selectBoxMinWidth: Float) {
-    table.add("Minimap size".toLabel()).left().fillX()
+        val unitArtSizeSlider = UncivSlider(
+            0f, 360f, 1f, initial = settings.pediaUnitArtSize
+        ) {
+            settings.pediaUnitArtSize = it
+            GUI.setUpdateWorldOnNextRender()
+        }
+        unitArtSizeSlider.setSnapToValues(threshold = 60f, 0f, 32f, 48f, 64f, 96f, 120f, 180f, 240f, 360f)
+        add(unitArtSizeSlider).minWidth(selectBoxMinWidth).pad(10f).row()
+    }
 
-    // The meaning of the values needs a formula to be synchronized between here and
-    // [Minimap.init]. It goes off-10%-11%..29%-30%-35%-40%-45%-50% - and the percentages
-    // correspond roughly to the minimap's proportion relative to screen dimensions.
-    val offTranslated = "off".tr()  // translate only once and cache in closure
-    val getTipText: (Float) -> String = {
-        when (it) {
-            0f -> offTranslated
-            in 0.99f..21.01f -> "%.0f".format(it + 9) + "%"
-            else -> "%.0f".format(it * 5 - 75) + "%"
+    private fun addScreenModeSelectBox() {
+        add("Screen Mode".toLabel()).left().fillX()
+
+        val modes = Display.getScreenModes()
+        val current: ScreenMode? = modes[settings.screenMode]
+
+        val selectBox = SelectBox<ScreenMode>(skin)
+        selectBox.items = Array(modes.values.toTypedArray())
+        selectBox.selected = current
+        selectBox.onChange {
+            settings.refreshWindowSize()
+            val mode = selectBox.selected
+            settings.screenMode = mode.getId()
+            Display.setScreenMode(mode.getId(), settings)
+        }
+
+        add(selectBox).minWidth(selectBoxMinWidth).pad(10f).row()
+    }
+
+    private fun addScreenSizeSelectBox() {
+        add("Screen Size".toLabel()).left().fillX()
+
+        val screenSizeSelectBox = TranslatedSelectBox(ScreenSize.entries.map { it.name }, settings.screenSize.name)
+        add(screenSizeSelectBox).minWidth(selectBoxMinWidth).pad(10f).row()
+
+        screenSizeSelectBox.onChange {
+            settings.screenSize = ScreenSize.valueOf(screenSizeSelectBox.selected.value)
+            onChange()
         }
     }
-    val minimapSlider = UncivSlider(
-        0f, 25f, 1f,
-        initial = if (settings.showMinimap) settings.minimapSize.toFloat() else 0f,
-        getTipText = getTipText
-    ) {
-        val size = it.toInt()
-        if (size == 0) settings.showMinimap = false
-        else {
-            settings.showMinimap = true
-            settings.minimapSize = size
+
+    private fun addTileSetSelectBox() {
+        add("Tileset".toLabel()).left().fillX()
+
+        val tileSetSelectBox = SelectBox<String>(skin)
+        val tileSetArray = Array<String>()
+        val tileSets = ImageGetter.getAvailableTilesets()
+        for (tileset in tileSets) tileSetArray.add(tileset)
+        tileSetSelectBox.items = tileSetArray
+        tileSetSelectBox.selected = settings.tileSet
+        add(tileSetSelectBox).minWidth(selectBoxMinWidth).pad(10f).row()
+
+        val unitSets = ImageGetter.getAvailableUnitsets()
+
+        tileSetSelectBox.onChange {
+            // Switch unitSet together with tileSet as long as one with the same name exists and both are selected
+            if (settings.tileSet == settings.unitSet && unitSets.contains(tileSetSelectBox.selected)) {
+                settings.unitSet = tileSetSelectBox.selected
+            }
+            settings.tileSet = tileSetSelectBox.selected
+            // ImageGetter ruleset should be correct no matter what screen we're on
+            TileSetCache.assembleTileSetConfigs(ImageGetter.ruleset.mods)
+            onChange()
         }
-        GUI.setUpdateWorldOnNextRender()
-    }
-    table.add(minimapSlider).minWidth(selectBoxMinWidth).pad(10f).row()
-}
-
-private fun addScrollSpeedSlider(table: Table, settings: GameSettings, selectBoxMinWidth: Float) {
-    table.add("Map panning speed".toLabel()).left().fillX()
-
-    val scrollSpeedSlider = UncivSlider(
-        0.2f, 25f, 0.2f, initial = settings.mapPanningSpeed
-    ) {
-        settings.mapPanningSpeed = it
-        settings.save()
-        if (GUI.isWorldLoaded())
-            GUI.getMap().mapPanningSpeed = settings.mapPanningSpeed
-    }
-    table.add(scrollSpeedSlider).minWidth(selectBoxMinWidth).pad(10f).row()
-}
-
-private fun addUnitIconAlphaSlider(table: Table, settings: GameSettings, selectBoxMinWidth: Float) {
-    table.add("Unit icon opacity".toLabel()).left().fillX()
-
-    val getTipText: (Float) -> String = {"%.0f".format(it*100) + "%"}
-
-    val unitIconAlphaSlider = UncivSlider(
-        0f, 1f, 0.1f, initial = settings.unitIconOpacity, getTipText = getTipText
-    ) {
-        settings.unitIconOpacity = it
-        GUI.setUpdateWorldOnNextRender()
-    }
-    table.add(unitIconAlphaSlider).minWidth(selectBoxMinWidth).pad(10f).row()
-}
-
-private fun addPediaUnitArtSizeSlider(table: Table, settings: GameSettings, selectBoxMinWidth: Float) {
-    table.add("Size of Unitset art in Civilopedia".toLabel()).left().fillX()
-
-    val unitArtSizeSlider = UncivSlider(
-        0f, 360f, 1f, initial = settings.pediaUnitArtSize
-    ) {
-        settings.pediaUnitArtSize = it
-        GUI.setUpdateWorldOnNextRender()
-    }
-    unitArtSizeSlider.setSnapToValues(threshold = 60f, 0f, 32f, 48f, 64f, 96f, 120f, 180f, 240f, 360f)
-    table.add(unitArtSizeSlider).minWidth(selectBoxMinWidth).pad(10f).row()
-}
-
-private fun addScreenModeSelectBox(table: Table, settings: GameSettings, selectBoxMinWidth: Float) {
-    table.add("Screen Mode".toLabel()).left().fillX()
-
-    val modes = Display.getScreenModes()
-    val current: ScreenMode? = modes[settings.screenMode]
-
-    val selectBox = SelectBox<ScreenMode>(table.skin)
-    selectBox.items = Array(modes.values.toTypedArray())
-    selectBox.selected = current
-    selectBox.onChange {
-        settings.refreshWindowSize()
-        val mode = selectBox.selected
-        settings.screenMode = mode.getId()
-        Display.setScreenMode(mode.getId(), settings)
     }
 
-    table.add(selectBox).minWidth(selectBoxMinWidth).pad(10f).row()
-}
+    private fun addUnitSetSelectBox() {
+        add("Unitset".toLabel()).left().fillX()
 
-private fun addScreenSizeSelectBox(table: Table, settings: GameSettings, selectBoxMinWidth: Float, onResolutionChange: () -> Unit) {
-    table.add("Screen Size".toLabel()).left().fillX()
+        val unitSetSelectBox = SelectBox<String>(skin)
+        val unitSetArray = Array<String>()
+        val nullValue = "None".tr()
+        unitSetArray.add(nullValue)
+        val unitSets = ImageGetter.getAvailableUnitsets()
+        for (unitset in unitSets) unitSetArray.add(unitset)
+        unitSetSelectBox.items = unitSetArray
+        unitSetSelectBox.selected = settings.unitSet ?: nullValue
+        add(unitSetSelectBox).minWidth(selectBoxMinWidth).pad(10f).row()
 
-    val screenSizeSelectBox = TranslatedSelectBox(ScreenSize.entries.map { it.name }, settings.screenSize.name)
-    table.add(screenSizeSelectBox).minWidth(selectBoxMinWidth).pad(10f).row()
-
-    screenSizeSelectBox.onChange {
-        settings.screenSize = ScreenSize.valueOf(screenSizeSelectBox.selected.value)
-        onResolutionChange()
-    }
-}
-
-private fun addTileSetSelectBox(table: Table, settings: GameSettings, selectBoxMinWidth: Float, onTilesetChange: () -> Unit) {
-    table.add("Tileset".toLabel()).left().fillX()
-
-    val tileSetSelectBox = SelectBox<String>(table.skin)
-    val tileSetArray = Array<String>()
-    val tileSets = ImageGetter.getAvailableTilesets()
-    for (tileset in tileSets) tileSetArray.add(tileset)
-    tileSetSelectBox.items = tileSetArray
-    tileSetSelectBox.selected = settings.tileSet
-    table.add(tileSetSelectBox).minWidth(selectBoxMinWidth).pad(10f).row()
-
-    val unitSets = ImageGetter.getAvailableUnitsets()
-
-    tileSetSelectBox.onChange {
-        // Switch unitSet together with tileSet as long as one with the same name exists and both are selected
-        if (settings.tileSet == settings.unitSet && unitSets.contains(tileSetSelectBox.selected)) {
-            settings.unitSet = tileSetSelectBox.selected
+        unitSetSelectBox.onChange {
+            settings.unitSet = if (unitSetSelectBox.selected != nullValue) unitSetSelectBox.selected else null
+            // ImageGetter ruleset should be correct no matter what screen we're on
+            TileSetCache.assembleTileSetConfigs(ImageGetter.ruleset.mods)
+            onChange()
         }
-        settings.tileSet = tileSetSelectBox.selected
-        // ImageGetter ruleset should be correct no matter what screen we're on
-        TileSetCache.assembleTileSetConfigs(ImageGetter.ruleset.mods)
-        onTilesetChange()
     }
-}
 
-private fun addUnitSetSelectBox(table: Table, settings: GameSettings, selectBoxMinWidth: Float, onUnitsetChange: () -> Unit) {
-    table.add("Unitset".toLabel()).left().fillX()
+    private fun addSkinSelectBox() {
+        add("UI Skin".toLabel()).left().fillX()
 
-    val unitSetSelectBox = SelectBox<String>(table.skin)
-    val unitSetArray = Array<String>()
-    val nullValue = "None".tr()
-    unitSetArray.add(nullValue)
-    val unitSets = ImageGetter.getAvailableUnitsets()
-    for (unitset in unitSets) unitSetArray.add(unitset)
-    unitSetSelectBox.items = unitSetArray
-    unitSetSelectBox.selected = settings.unitSet ?: nullValue
-    table.add(unitSetSelectBox).minWidth(selectBoxMinWidth).pad(10f).row()
+        val skinSelectBox = SelectBox<String>(skin)
+        val skinArray = Array<String>()
+        val skins = ImageGetter.getAvailableSkins()
+        for (skin in skins) skinArray.add(skin)
+        skinSelectBox.items = skinArray
+        skinSelectBox.selected = settings.skin
+        add(skinSelectBox).minWidth(selectBoxMinWidth).pad(10f).row()
 
-    unitSetSelectBox.onChange {
-        settings.unitSet = if (unitSetSelectBox.selected != nullValue) unitSetSelectBox.selected else null
-        // ImageGetter ruleset should be correct no matter what screen we're on
-        TileSetCache.assembleTileSetConfigs(ImageGetter.ruleset.mods)
-        onUnitsetChange()
+        skinSelectBox.onChange {
+            settings.skin = skinSelectBox.selected
+            // ImageGetter ruleset should be correct no matter what screen we're on
+            SkinCache.assembleSkinConfigs(ImageGetter.ruleset.mods)
+            onChange()
+        }
     }
-}
 
-private fun addSkinSelectBox(table: Table, settings: GameSettings, selectBoxMinWidth: Float, onSkinChange: () -> Unit) {
-    table.add("UI Skin".toLabel()).left().fillX()
-
-    val skinSelectBox = SelectBox<String>(table.skin)
-    val skinArray = Array<String>()
-    val skins = ImageGetter.getAvailableSkins()
-    for (skin in skins) skinArray.add(skin)
-    skinSelectBox.items = skinArray
-    skinSelectBox.selected = settings.skin
-    table.add(skinSelectBox).minWidth(selectBoxMinWidth).pad(10f).row()
-
-    skinSelectBox.onChange {
-        settings.skin = skinSelectBox.selected
-        // ImageGetter ruleset should be correct no matter what screen we're on
-        SkinCache.assembleSkinConfigs(ImageGetter.ruleset.mods)
-        onSkinChange()
-    }
-}
-
-private fun addResetTutorials(table: Table, settings: GameSettings) {
-    val resetTutorialsButton = "Reset tutorials".toTextButton()
-    resetTutorialsButton.onClick {
+    private fun addResetTutorials() {
+        val resetTutorialsButton = "Reset tutorials".toTextButton()
+        resetTutorialsButton.onClick {
             ConfirmPopup(
-                table.stage,
+                stage,
                 "Do you want to reset completed tutorials?",
                 "Reset"
             ) {
@@ -283,21 +275,40 @@ private fun addResetTutorials(table: Table, settings: GameSettings) {
                 resetTutorialsButton.setText("Done!".tr())
                 resetTutorialsButton.clearListeners()
             }.open(true)
+        }
+        add(resetTutorialsButton).center().row()
     }
-    table.add(resetTutorialsButton).center().row()
-}
 
-private fun addNotificationScrollSelect(table: Table, settings: GameSettings, selectBoxMinWidth: Float) {
-    table.add("Notifications on world screen".toLabel()).left().fillX()
+    private fun addNotificationScrollSelect() {
+        add("Notifications on world screen".toLabel()).left().fillX()
 
-    val selectBox = TranslatedSelectBox(
-        NotificationsScroll.UserSetting.entries.map { it.name },
-        settings.notificationScroll
-    )
-    table.add(selectBox).minWidth(selectBoxMinWidth).pad(10f).row()
+        val selectBox = TranslatedSelectBox(
+            NotificationsScroll.UserSetting.entries.map { it.name },
+            settings.notificationScroll
+        )
+        add(selectBox).minWidth(selectBoxMinWidth).pad(10f).row()
 
-    selectBox.onChange {
-        settings.notificationScroll = selectBox.selected.value
-        GUI.setUpdateWorldOnNextRender()
+        selectBox.onChange {
+            settings.notificationScroll = selectBox.selected.value
+            GUI.setUpdateWorldOnNextRender()
+        }
+    }
+
+    private fun addAnimationOptions() {
+        addSeparator()
+        add("Performance".toLabel(fontSize = 24)).colspan(2).row()
+
+        optionsPopup.addCheckbox(this, "Continuous rendering", settings.continuousRendering == true) {
+            settings.continuousRendering = it
+            Gdx.graphics.isContinuousRendering = it
+        }
+
+        val continuousRenderingDescription = "When disabled, saves battery life but certain animations will be suspended"
+        val continuousRenderingLabel = WrappableLabel(
+            continuousRenderingDescription,
+            optionsPopup.tabs.prefWidth, Color.ORANGE.brighten(0.7f), 14
+        )
+        continuousRenderingLabel.wrap = true
+        add(continuousRenderingLabel).colspan(2).padTop(10f).row()
     }
 }

--- a/core/src/com/unciv/ui/popups/options/DisplayTab.kt
+++ b/core/src/com/unciv/ui/popups/options/DisplayTab.kt
@@ -89,7 +89,7 @@ fun displayTab(
     addSeparator()
     add("Performance".toLabel(fontSize = 24)).colspan(2).row()
 
-    optionsPopup.addCheckbox(this, "Continuous rendering", settings.continuousRendering) {
+    optionsPopup.addCheckbox(this, "Continuous rendering", settings.continuousRendering == true) {
         settings.continuousRendering = it
         Gdx.graphics.isContinuousRendering = it
     }

--- a/core/src/com/unciv/ui/popups/options/OptionsPopup.kt
+++ b/core/src/com/unciv/ui/popups/options/OptionsPopup.kt
@@ -2,6 +2,7 @@ package com.unciv.ui.popups.options
 
 import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.graphics.Color
+import com.badlogic.gdx.scenes.scene2d.ui.CheckBox
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.unciv.GUI
 import com.unciv.UncivGame
@@ -184,14 +185,14 @@ class OptionsPopup(
         }
     }
 
-    internal fun addCheckbox(table: Table, text: String, initialState: Boolean, updateWorld: Boolean = false, newRow: Boolean = true, action: ((Boolean) -> Unit)) {
+    internal fun addCheckbox(table: Table, text: String, initialState: Boolean, updateWorld: Boolean = false, newRow: Boolean = true, action: ((Boolean) -> Unit)): CheckBox {
         val checkbox = text.toCheckBox(initialState) {
             action(it)
-            val worldScreen = GUI.getWorldScreenIfActive()
-            if (updateWorld && worldScreen != null) worldScreen.shouldUpdate = true
+            if (updateWorld) GUI.setUpdateWorldOnNextRender()
         }
         if (newRow) table.add(checkbox).colspan(2).left().row()
         else table.add(checkbox).left()
+        return checkbox
     }
 
     internal fun addCheckbox(

--- a/core/src/com/unciv/ui/popups/options/OptionsPopup.kt
+++ b/core/src/com/unciv/ui/popups/options/OptionsPopup.kt
@@ -76,7 +76,7 @@ class OptionsPopup(
         )
         tabs.addPage(
             "Display",
-            displayTab(this, ::reloadWorldAndOptions),
+            DisplayTab(this, ::reloadWorldAndOptions),
             ImageGetter.getImage("UnitPromotionIcons/Scouting"), 24f
         )
         tabs.addPage(

--- a/core/src/com/unciv/ui/screens/worldscreen/bottombar/BattleTable.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/bottombar/BattleTable.kt
@@ -7,6 +7,7 @@ import com.badlogic.gdx.scenes.scene2d.actions.Actions
 import com.badlogic.gdx.scenes.scene2d.ui.Label
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.utils.Align
+import com.unciv.GUI
 import com.unciv.logic.battle.AirInterception
 import com.unciv.logic.battle.AttackableTile
 import com.unciv.logic.battle.Battle
@@ -18,6 +19,7 @@ import com.unciv.logic.battle.Nuke
 import com.unciv.logic.battle.TargetHelper
 import com.unciv.logic.map.tile.Tile
 import com.unciv.models.UncivSound
+import com.unciv.models.metadata.GameSettings
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.translations.tr
 import com.unciv.ui.audio.SoundPlayer
@@ -348,6 +350,7 @@ class BattleTable(val worldScreen: WorldScreen) : Table() {
             attackButton.onClick(attacker.getAttackSound()) {
                 Nuke.NUKE(attacker, targetTile)
 
+                if (GameSettings.Animations.NukeExplosion !in GUI.getSettings().enabledAnimations) return@onClick
                 val nukeCircle = ImageGetter.getCircle()
                 nukeCircle.setSize(10f)
                 nukeCircle.setOrigin(Align.center)

--- a/core/src/com/unciv/ui/screens/worldscreen/worldmap/WorldMapHolder.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/worldmap/WorldMapHolder.kt
@@ -25,6 +25,7 @@ import com.unciv.logic.map.mapunit.movement.UnitMovement
 import com.unciv.logic.map.tile.Tile
 import com.unciv.models.Spy
 import com.unciv.models.UncivSound
+import com.unciv.models.metadata.GameSettings
 import com.unciv.ui.audio.SoundPlayer
 import com.unciv.ui.components.MapArrowType
 import com.unciv.ui.components.MiscArrowTypes
@@ -273,7 +274,8 @@ class WorldMapHolder(
             var pathToTile: List<Tile>? = null
             try {
                 tileToMoveTo = selectedUnit.movement.getTileToMoveToThisTurn(targetTile)
-                if (!selectedUnit.type.isAirUnit() && !selectedUnit.isPreparingParadrop())
+                if (!selectedUnit.type.isAirUnit() && !selectedUnit.isPreparingParadrop() &&
+                        GameSettings.Animations.MovementPath in worldScreen.game.settings.enabledAnimations)
                     pathToTile = selectedUnit.movement.getDistanceToTiles().getPathToTile(tileToMoveTo)
             } catch (ex: Exception) {
                 when (ex) {


### PR DESCRIPTION
Solves #11986 - luxury version

### Screwnshots
<details>

Predefined sets SelectBox (the "Expert" entry allows controlling each anim individually, the other set all individual options to a preset):
![image](https://github.com/user-attachments/assets/0ada8b31-839a-40a0-b8a6-d412d3da20e4)

Expert mode:
![image](https://github.com/user-attachments/assets/578c8496-09c3-4e87-815b-806187f6525c)
</details>

### Notes
- Wording up for discussion
- Choice of predefined sets up for discussion - more of them? Which options on for them?
- Nuke untested, haven't got an advanced game here
- Yes my understanding and testing say it's perfectly fine to leave `Gdx.graphics.isContinuousRendering` off - or did I miss anything that animates without using Gdx Actions?
- Default on new installs up for discussion
- Migration does not map `continuousRendering==false` into the new world perfectly - some anims weren't gated at all, to get identical behaviour we would need to create a preset with only the ungated anims on - worth it?