### PR TITLE
Make right arrow glyph moddable

### DIFF
--- a/core/src/com/unciv/ui/components/fonts/Fonts.kt
+++ b/core/src/com/unciv/ui/components/fonts/Fonts.kt
@@ -137,6 +137,7 @@ object Fonts {
     // Taken into account when limiting FontRulesetIcons codepoints (it respects the private area ending at U+F8FF)
     const val sortUpArrow = '￪'         // U+FFEA 'half wide upward arrow'
     const val sortDownArrow = '￬'       // U+FFEC 'half wide downward arrow'
+    const val rightArrow = '→'          // U+2192, e.g. Battle table or event-based tutorials
     //endregion
 
     val allSymbols = mapOf(
@@ -165,6 +166,7 @@ object Fonts {
         status to "EmojiIcons/SortedByStatus",
         sortUpArrow to "EmojiIcons/SortedAscending",
         sortDownArrow to "EmojiIcons/SortedDescending",
+        rightArrow to "EmojiIcons/RightArrow",
         *MayaCalendar.allSymbols
     )
     //endregion


### PR DESCRIPTION
Tiny change to better support https://github.com/SomeTroglodyte/Sort-Icons
@touhidurrr  - because with Font choice "Nirmala UI" the sort arrows, infinity, star and watch are gone, and that mod can replace them.