### PR TITLE
Fix rare crash opening overview on turn 0

### DIFF
--- a/core/src/com/unciv/ui/screens/overviewscreen/ResourcesOverviewTab.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/ResourcesOverviewTab.kt
@@ -237,6 +237,7 @@ class ResourcesOverviewTab(
             row()
         }
 
+        if (rows == 0) return // can happen when opening overview on turn 0 before founding a city
         equalizeColumns(fixedContent, this)
         overviewScreen.resizePage(this)  // Without the height is miscalculated - shouldn't be
     }


### PR DESCRIPTION
Namely when resources vertical view is persisted and no resources have a reason to be listed... Like before founding your first city. What crashes is the `check(tables.all { it.columns >= columns })` in `equalizeColumns` - the second table has no columns...