### PR TITLE
Fix untranslatable

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -754,6 +754,7 @@ About =
 Version = 
 See online Readme = 
 Visit repository = 
+Visit the wiki = 
 
 ## Display tab
 Display = 


### PR DESCRIPTION
"Visit the wiki" wasn't translatable:

Before: 
![before](https://github.com/user-attachments/assets/c8dfc1ff-9bed-4235-9e57-c544648f93ab)

After:
![after](https://github.com/user-attachments/assets/73041643-0940-404e-aadc-5a8226d6cf53)
