### PR TITLE
"Skip turn" automation

### DIFF
--- a/core/src/com/unciv/logic/automation/civilization/TradeAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/TradeAutomation.kt
@@ -17,10 +17,11 @@ import kotlin.math.min
 object TradeAutomation {
 
 
-    fun respondToTradeRequests(civInfo: Civilization) {
+    fun respondToTradeRequests(civInfo: Civilization, tradeAndChangeState: Boolean) {
         for (tradeRequest in civInfo.tradeRequests.toList()) {
             val otherCiv = civInfo.gameInfo.getCivilization(tradeRequest.requestingCiv)
-            if (!TradeEvaluation().isTradeValid(tradeRequest.trade, civInfo, otherCiv))
+            // Treat 'no trade' state as if all trades are invalid - thus AIs will not update its "turns to offer"
+            if (!tradeAndChangeState || !TradeEvaluation().isTradeValid(tradeRequest.trade, civInfo, otherCiv))
                 continue
 
             val tradeLogic = TradeLogic(civInfo, otherCiv)

--- a/core/src/com/unciv/ui/screens/multiplayerscreens/MultiplayerHelpers.kt
+++ b/core/src/com/unciv/ui/screens/multiplayerscreens/MultiplayerHelpers.kt
@@ -8,6 +8,7 @@ import com.unciv.logic.multiplayer.MultiplayerGame
 import com.unciv.models.translations.tr
 import com.unciv.ui.components.extensions.formatShort
 import com.unciv.ui.components.extensions.toCheckBox
+import com.unciv.ui.components.fonts.Fonts
 import com.unciv.ui.popups.Popup
 import com.unciv.ui.screens.basescreen.BaseScreen
 import com.unciv.ui.screens.savescreens.LoadGameScreen
@@ -35,7 +36,7 @@ object MultiplayerHelpers {
         }
     }
 
-    fun buildDescriptionText(multiplayerGame: MultiplayerGame): StringBuilder {
+    fun buildDescriptionText(multiplayerGame: MultiplayerGame): String {
         val descriptionText = StringBuilder()
         val ex = multiplayerGame.error
         if (ex != null) {
@@ -58,8 +59,17 @@ object MultiplayerHelpers {
             val playerText = "{${preview.currentPlayer}}{ }({$playerDescriptor})"
 
             descriptionText.appendLine("Current Turn: [$playerText] since [${Duration.between(currentTurnStartTime, Instant.now()).formatShort()}] ago".tr())
+
+            val playerCivName = preview.civilizations
+                .firstOrNull{ it.playerId == UncivGame.Current.settings.multiplayer.userId }?.civName ?: "Unknown"
+
+            descriptionText.appendLine("{$playerCivName}, ${preview.difficulty.tr()}, ${Fonts.turn}${preview.turns}")
+            descriptionText.appendLine("{Base ruleset:} ${preview.gameParameters.baseRuleset}")
+            if (preview.gameParameters.mods.isNotEmpty())
+                descriptionText.appendLine("{Mods:} " + preview.gameParameters.mods.joinToString())
+
         }
-        return descriptionText
+        return descriptionText.toString().tr()
     }
 
     fun showDropboxWarning(screen: BaseScreen) {


### PR DESCRIPTION
Many players have asked for a way to "skip a turn" for players whose turn it is, that have been inactive for X amount of time
The first step to that, is allowing for such an automation function. What would I deem unacceptable for an AI to do for me?

For me that is:
- Accept or offer trades (AI doesn't know what I want!)
- Use limited resources (policy picks, gold, faith, etc) when I can decide to use them next turn
- Change diplomacy (declare war / peace)

This PR adds an automation parameter that will enable this