### PR TITLE
Multiplayer: Add button to skip current player if he's taking too long

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -674,20 +674,20 @@ GameID =
 Game name = 
 Loading latest game state... = 
 You are not allowed to spectate! = 
-Couldn't download the latest game state! =
+Couldn't download the latest game state! = 
 
 ## Resign button
 Resign = 
 Are you sure you want to resign? = 
 You can only resign if it's your turn = 
-[civName] resigned and is now controlled by AI =
+[civName] resigned and is now controlled by AI = 
 
 ## Force resign button
-Force current player to resign =
-Are you sure you want to force the current player to resign? =
+Force current player to resign = 
+Are you sure you want to force the current player to resign? = 
 
-Skip turn of current player =
-Are you sure you want to skip the turn of the current player? =
+Skip turn of current player = 
+Are you sure you want to skip the turn of the current player? = 
 
 Last refresh: [duration] ago = 
 Current Turn: [civName] since [duration] ago = 

--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -674,11 +674,21 @@ GameID =
 Game name = 
 Loading latest game state... = 
 You are not allowed to spectate! = 
-Couldn't download the latest game state! = 
+Couldn't download the latest game state! =
+
+## Resign button
 Resign = 
 Are you sure you want to resign? = 
 You can only resign if it's your turn = 
-[civName] resigned and is now controlled by AI = 
+[civName] resigned and is now controlled by AI =
+
+## Force resign button
+Force current player to resign =
+Are you sure you want to force the current player to resign? =
+
+Skip turn of current player =
+Are you sure you want to skip the turn of the current player? =
+
 Last refresh: [duration] ago = 
 Current Turn: [civName] since [duration] ago = 
 Seconds = 

--- a/core/src/com/unciv/models/metadata/GameParameters.kt
+++ b/core/src/com/unciv/models/metadata/GameParameters.kt
@@ -35,9 +35,13 @@ class GameParameters : IsPartOfGameInfoSerialization { // Default values are the
     var victoryTypes: ArrayList<String> = arrayListOf()
     var startingEra = "Ancient era"
 
+    // Multiplayer parameters
     var isOnlineMultiplayer = false
     var multiplayerServerUrl: String? = null
     var anyoneCanSpectate = true
+    /** After this amount of minutes, anyone can choose to 'skip turn' of the current player to keep the game going */
+    var minutesUntilSkipTurn = 60 * 24
+
     var baseRuleset: String = BaseRuleset.Civ_V_GnK.fullName
     var mods = LinkedHashSet<String>()
 


### PR DESCRIPTION
Can be viewed as "second part of #12105", but mergeable separately

Adds a "skip current player" button to multiplayer screen if the current last update was more than X minutes ago, allowing other players to automate the current turn and advance the game to the next player

This does NOT add a way to configure the 'time between turns' per game - that's planned, but a separate issue