### PR TITLE
Add unique to show construction when unbuildable

### DIFF
--- a/core/src/com/unciv/models/ruleset/Building.kt
+++ b/core/src/com/unciv/models/ruleset/Building.kt
@@ -244,6 +244,8 @@ class Building : RulesetStatsObject(), INonPerpetualConstruction {
             if (cityConstructions.city.civ.civConstructions.countConstructedObjects(this) >= unique.params[0].toInt())
                 return false
         }
+        if (hasUnique(UniqueType.ShowsWhenUnbuilable, StateForConditionals(cityConstructions.city)))
+            return true
 
         val rejectionReasons = getRejectionReasons(cityConstructions)
 

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -946,6 +946,7 @@ enum class UniqueType(
     
     HiddenWithoutVictoryType("Hidden when [victoryType] Victory is disabled", UniqueTarget.Building, UniqueTarget.Unit, flags = UniqueFlag.setOfHiddenToUsers),
     HiddenFromCivilopedia("Will not be displayed in Civilopedia", *UniqueTarget.Displayable, flags = UniqueFlag.setOfHiddenToUsers),
+    ShowsWhenUnbuilable("Shown while unbuilable", UniqueTarget.Building, UniqueTarget.Unit, flags = UniqueFlag.setOfHiddenToUsers),
     ModifierHiddenFromUsers("hidden from users", UniqueTarget.MetaModifier),
     ForEveryCountable("for every [countable]", UniqueTarget.MetaModifier),
     ForEveryAmountCountable("for every [amount] [countable]", UniqueTarget.MetaModifier),

--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -163,6 +163,8 @@ class BaseUnit : RulesetObject(), INonPerpetualConstruction {
     fun getDisbandGold(civInfo: Civilization) = getBaseGoldCost(civInfo, null).toInt() / 20
 
     override fun shouldBeDisplayed(cityConstructions: CityConstructions): Boolean {
+        if (hasUnique(UniqueType.ShowsWhenUnbuilable, StateForConditionals(cityConstructions.city)))
+            return true
         val rejectionReasons = getRejectionReasons(cityConstructions)
 
         if (rejectionReasons.none { !it.shouldShow }) return true


### PR DESCRIPTION
Currently, there are plenty of scenarios where you want to show a building or unit to make it clear that it is buildable, but it realistically cannot be accounted for as a baseline for Unciv in a generic sense. One trick around this could be ``Requires at least [999] population``, which forces the UI to show the building/unit, but it is relatively ugly, only implements the "Unavailable" unique (meaning you need a separate trick for "Only available"), and may limit what uniques are viable on the building to make it still work properly

This unique is to sidestep the discussion and allow showing the building regardless of reason. This should have no other impact on anything else as deciding to disable a button is handled elsewhere