### PR TITLE
Simplify Civiliopedia Alphabatized Sorting Code

### DIFF
--- a/core/src/com/unciv/models/translations/Translations.kt
+++ b/core/src/com/unciv/models/translations/Translations.kt
@@ -333,11 +333,12 @@ object TranslationActiveModsCache {
  *                  - phrases between curly braces are translated individually
  *                  Additionally, they may contain conditionals between '<' and '>'
  *  @param      hideIcons disables auto-inserting icons for ruleset objects (but not Stats)
+ *  @param      hideStats disables auto-inserting icons for Stats (but not rulset objects)
  *  @return     The translated string
  *                  defaults to the input string if no translation is available,
  *                  but with placeholder or sentence brackets removed.
  */
-fun String.tr(hideIcons: Boolean = false): String {
+fun String.tr(hideIcons: Boolean = false, hideStats: Boolean = false): String {
     val language: String = UncivGame.Current.settings.language
 
     // '<' and '>' checks for quick 'no' answer, regex to ensure that no one accidentally put '><' and ruined things
@@ -359,7 +360,7 @@ fun String.tr(hideIcons: Boolean = false): String {
     if (curlyBracketsEncounteredFirst) // Translating partial sentences
         return curlyBraceRegex.replace(this) { it.groups[1]!!.value.tr(hideIcons) }
 
-    return translateIndividualWord(language, hideIcons)
+    return translateIndividualWord(language, hideIcons, hideStats)
 }
 
 
@@ -471,7 +472,7 @@ private fun String.translatePlaceholders(language: String, hideIcons: Boolean): 
 
 
 /** No brackets of any kind, just a single word */
-private fun String.translateIndividualWord(language: String, hideIcons: Boolean): String {
+private fun String.translateIndividualWord(language: String, hideIcons: Boolean, hideStats: Boolean): String {
     if (Stats.isStats(this)) return Stats.parse(this).toString()
 
     val translation = UncivGame.Current.translations.getText(
@@ -481,7 +482,7 @@ private fun String.translateIndividualWord(language: String, hideIcons: Boolean)
     }
 
     val stat = Stat.safeValueOf(this)
-    if (stat != null) return stat.character + translation
+    if (!hideStats && stat != null) return stat.character + translation
 
     if (!hideIcons && FontRulesetIcons.rulesetObjectNameToChar.containsKey(this))
         return FontRulesetIcons.rulesetObjectNameToChar[this]!! + translation

--- a/core/src/com/unciv/ui/screens/civilopediascreen/CivilopediaScreen.kt
+++ b/core/src/com/unciv/ui/screens/civilopediascreen/CivilopediaScreen.kt
@@ -17,7 +17,6 @@ import com.unciv.ui.components.extensions.colorFromRGB
 import com.unciv.ui.components.extensions.getCloseButton
 import com.unciv.ui.components.extensions.toImageButton
 import com.unciv.ui.components.extensions.toLabel
-import com.unciv.ui.components.fonts.Fonts
 import com.unciv.ui.components.input.KeyboardBinding
 import com.unciv.ui.components.input.onActivation
 import com.unciv.ui.components.input.onClick
@@ -124,9 +123,7 @@ class CivilopediaScreen(
                 compareBy<CivilopediaEntry>{ it.sortBy }
                     .thenBy (UncivGame.Current.settings.getCollatorFromLocale()) {
                         // In order for the extra icons on Happiness and Faith to not affect sort order
-                        it.name.tr(true).replace(Fonts.happiness.toString(),"").replace(Fonts.faith.toString(),"")
-                            .replace(Fonts.food.toString(),"").replace(Fonts.production.toString(),"")
-                            .replace(Fonts.gold.toString(),"").replace(Fonts.science.toString(),"")})
+                        it.name.tr(true, true)})
 
         var currentY = -1f
 


### PR DESCRIPTION
Following up suggestion from #12043 to clean up and future proof the code to avoid sorting based on the prefixed icon in the Civilopedia