### PR TITLE
fix: user only receives yellow resource notification if it is researched

### DIFF
--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -552,7 +552,7 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
     ): Notification? {
 
         val resource = ruleset.tileResources[resourceName] ?: return null
-        if (!civ.tech.isResearched(resource)) {
+        if (!civ.tech.isRevealed(resource)) {
             return null
         }
         

--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -38,7 +38,6 @@ import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.ruleset.RulesetCache
 import com.unciv.models.ruleset.Speed
 import com.unciv.models.ruleset.nation.Difficulty
-import com.unciv.models.ruleset.tile.TileResource
 import com.unciv.models.ruleset.unique.LocalUniqueCache
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.translations.tr
@@ -552,7 +551,8 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
         filter: (Tile) -> Boolean = { true }
     ): Notification? {
 
-        if (!civ.tech.isResearched(ruleset.getResource(resourceName))) {
+        val resource = ruleset.tileResources[resourceName] ?: return null
+        if (!civ.tech.isResearched(resource)) {
             return null
         }
         

--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -38,6 +38,7 @@ import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.ruleset.RulesetCache
 import com.unciv.models.ruleset.Speed
 import com.unciv.models.ruleset.nation.Difficulty
+import com.unciv.models.ruleset.tile.TileResource
 import com.unciv.models.ruleset.unique.LocalUniqueCache
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.translations.tr
@@ -538,7 +539,7 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
         return true
     }
 
-    /** Generate a notification pointing out resources.
+    /** Generate a notification pointing out resources. Only researched Resources are considered.
      * @param maxDistance from next City, default removes distance limitation.
      * @param filter optional tile filter predicate, e.g. to exclude foreign territory.
      * @return `null` if no resources were found, otherwise a Notification instance.
@@ -550,6 +551,11 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
         maxDistance: Int = Int.MAX_VALUE,
         filter: (Tile) -> Boolean = { true }
     ): Notification? {
+
+        if (!civ.tech.isResearched(ruleset.getResource(resourceName))) {
+            return null
+        }
+        
         data class CityTileAndDistance(val city: City, val tile: Tile, val distance: Int)
 
         // Include your city-state allies' cities with your own for the purpose of showing the closest city

--- a/core/src/com/unciv/logic/civilization/managers/TechManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/TechManager.kt
@@ -17,6 +17,7 @@ import com.unciv.logic.map.tile.RoadStatus
 import com.unciv.models.ruleset.INonPerpetualConstruction
 import com.unciv.models.ruleset.tech.Era
 import com.unciv.models.ruleset.tech.Technology
+import com.unciv.models.ruleset.tile.TileResource
 import com.unciv.models.ruleset.unique.StateForConditionals
 import com.unciv.models.ruleset.unique.UniqueMap
 import com.unciv.models.ruleset.unique.UniqueTriggerActivation
@@ -155,6 +156,9 @@ class TechManager : IsPartOfGameInfoSerialization {
 
     fun isResearched(construction: INonPerpetualConstruction): Boolean = construction.requiredTechs().all{ requiredTech -> isResearched(requiredTech) }
 
+    /** resources which need no research count as researched */
+    fun isResearched(resource: TileResource) = resource.revealedBy?.let { isResearched(it) } ?: true
+    
     fun isObsolete(unit: BaseUnit): Boolean = unit.techsThatObsoleteThis().any{ obsoleteTech -> isResearched(obsoleteTech) }
 
     fun isUnresearchable(tech: Technology): Boolean {

--- a/core/src/com/unciv/logic/civilization/managers/TechManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/TechManager.kt
@@ -157,7 +157,10 @@ class TechManager : IsPartOfGameInfoSerialization {
     fun isResearched(construction: INonPerpetualConstruction): Boolean = construction.requiredTechs().all{ requiredTech -> isResearched(requiredTech) }
 
     /** resources which need no research count as researched */
-    fun isResearched(resource: TileResource) = resource.revealedBy?.let { isResearched(it) } ?: true
+    fun isRevealed(resource: TileResource): Boolean {
+        val revealedBy = resource.revealedBy ?: return true
+        return isResearched(revealedBy)
+    }
     
     fun isObsolete(unit: BaseUnit): Boolean = unit.techsThatObsoleteThis().any{ obsoleteTech -> isResearched(obsoleteTech) }
 

--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -510,4 +510,8 @@ class Ruleset {
     }
 
     fun getErrorList(tryFixUnknownUniques: Boolean = false) = RulesetValidator(this).getErrorList(tryFixUnknownUniques)
+
+    fun getResource(resourceName: String): TileResource {
+        return tileResources[resourceName]!!
+    }
 }

--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -510,8 +510,4 @@ class Ruleset {
     }
 
     fun getErrorList(tryFixUnknownUniques: Boolean = false) = RulesetValidator(this).getErrorList(tryFixUnknownUniques)
-
-    fun getResource(resourceName: String): TileResource {
-        return tileResources[resourceName]!!
-    }
 }


### PR DESCRIPTION
For example, don't allow the user to scan the map for aluminum when he got it through trading or allied city states, but is not researched yet. Because the user did not research that resource yet, its deposits on the map should not be revealed.