### PR TITLE
Improved queue in city screen

### DIFF
--- a/core/src/com/unciv/ui/components/widgets/ExpanderTab.kt
+++ b/core/src/com/unciv/ui/components/widgets/ExpanderTab.kt
@@ -54,6 +54,7 @@ class ExpanderTab(
     }
 
     val header = Table(skin)  // Header with label and icon, touchable to show/hide
+    val headerContent = Table()
     private val headerLabel = title.toLabel(fontSize = fontSize, hideIcons = true)
     private val headerIcon = ImageGetter.getImage(arrowImage)
     private val contentWrapper = Table()  // Wrapper for innerTable, this is what will be shown/hidden
@@ -83,7 +84,8 @@ class ExpanderTab(
             )
         )
         if (icon != null) header.add(icon)
-        header.add(headerLabel).expandX()
+        header.add(headerLabel)
+        header.add(headerContent).growX()
         header.add(headerIcon).size(arrowSize).align(Align.center)
         header.touchable= Touchable.enabled
         header.onActivation { toggle() }
@@ -93,7 +95,7 @@ class ExpanderTab(
         defaults().growX()
         contentWrapper.defaults().growX().pad(defaultPad)
         innerTable.defaults().growX()
-        add(header).fillY().row()
+        add(header).fill().row()
         add(contentWrapper)
         contentWrapper.add(innerTable)      // update will revert this
         initContent?.invoke(innerTable)

--- a/core/src/com/unciv/ui/components/widgets/ExpanderTab.kt
+++ b/core/src/com/unciv/ui/components/widgets/ExpanderTab.kt
@@ -83,7 +83,7 @@ class ExpanderTab(
             )
         )
         if (icon != null) header.add(icon)
-        header.add(headerLabel).expandX().padLeft(arrowSize) // pad left have it centered despite the arrow
+        header.add(headerLabel).expandX()
         header.add(headerIcon).size(arrowSize).align(Align.center)
         header.touchable= Touchable.enabled
         header.onActivation { toggle() }

--- a/core/src/com/unciv/ui/components/widgets/ExpanderTab.kt
+++ b/core/src/com/unciv/ui/components/widgets/ExpanderTab.kt
@@ -74,7 +74,7 @@ class ExpanderTab(
         header.defaults().pad(headerPad)
         headerIcon.setSize(arrowSize, arrowSize)
         headerIcon.setOrigin(Align.center)
-        headerIcon.rotation = 180f
+        headerIcon.rotation = 0f
         headerIcon.color = arrowColor
         header.background(
             BaseScreen.skinStrings.getUiBackground(
@@ -83,7 +83,7 @@ class ExpanderTab(
             )
         )
         if (icon != null) header.add(icon)
-        header.add(headerLabel)
+        header.add(headerLabel).expandX().padLeft(arrowSize) // pad left have it centered despite the arrow
         header.add(headerIcon).size(arrowSize).align(Align.center)
         header.touchable= Touchable.enabled
         header.onActivation { toggle() }
@@ -111,11 +111,11 @@ class ExpanderTab(
         if (noAnimation || !UncivGame.Current.settings.continuousRendering) {
             contentWrapper.clear()
             if (isOpen) contentWrapper.add(innerTable)
-            headerIcon.rotation = if (isOpen) 90f else 180f
+            headerIcon.rotation = if (isOpen) 90f else 0f
             if (!noAnimation) onChange?.invoke()
             return
         }
-        val action = object: FloatAction ( 90f, 180f, animationDuration, Interpolation.linear) {
+        val action = object: FloatAction ( 90f, 0f, animationDuration, Interpolation.linear) {
             override fun update(percent: Float) {
                 super.update(percent)
                 headerIcon.rotation = this.value

--- a/core/src/com/unciv/ui/screens/cityscreen/BuyButtonFactory.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/BuyButtonFactory.kt
@@ -1,0 +1,200 @@
+package com.unciv.ui.screens.cityscreen
+
+import com.badlogic.gdx.graphics.Color
+import com.badlogic.gdx.scenes.scene2d.ui.Cell
+import com.badlogic.gdx.scenes.scene2d.ui.Table
+import com.badlogic.gdx.scenes.scene2d.ui.TextButton
+import com.unciv.Constants
+import com.unciv.logic.city.CityConstructions
+import com.unciv.logic.map.tile.Tile
+import com.unciv.models.Religion
+import com.unciv.models.ruleset.Building
+import com.unciv.models.ruleset.IConstruction
+import com.unciv.models.ruleset.INonPerpetualConstruction
+import com.unciv.models.ruleset.PerpetualConstruction
+import com.unciv.models.ruleset.unique.UniqueType
+import com.unciv.models.stats.Stat
+import com.unciv.models.translations.tr
+import com.unciv.ui.audio.SoundPlayer
+import com.unciv.ui.components.extensions.disable
+import com.unciv.ui.components.extensions.isEnabled
+import com.unciv.ui.components.extensions.toTextButton
+import com.unciv.ui.components.input.KeyboardBinding
+import com.unciv.ui.components.input.onActivation
+import com.unciv.ui.popups.Popup
+import com.unciv.ui.popups.closeAllPopups
+import com.unciv.ui.screens.basescreen.BaseScreen
+
+/**
+ * Use [addBuyButtons] to add buy buttons to a table.
+ * This class handles everything related to buying constructions. This includes
+ * showing and handling [ConfirmBuyPopup] and the actual purchase in [purchaseConstruction].
+ */
+class BuyButtonFactory(val cityScreen: CityScreen) {
+
+    private var preferredBuyStat = Stat.Gold  // Used for keyboard buy
+    
+    fun addBuyButtons(table: Table, construction: IConstruction?, onButtonAdded: (Cell<TextButton>) -> Unit) {
+        for (button in getBuyButtons(construction)) {
+            onButtonAdded(table.add(button))
+        }
+    }
+
+    fun hasBuyButtons(construction: IConstruction?): Boolean {
+        return getBuyButtons(construction).isNotEmpty()
+    }
+    
+    private fun getBuyButtons(construction: IConstruction?): List<TextButton> {
+        val selection = cityScreen.selectedConstruction!=null || cityScreen.selectedQueueEntry >= 0
+        if (selection && construction != null && construction !is PerpetualConstruction)
+            return Stat.statsUsableToBuy.mapNotNull {
+                getBuyButton(construction as INonPerpetualConstruction, it)
+            }
+        return emptyList()
+    }
+
+    private fun getBuyButton(construction: INonPerpetualConstruction?, stat: Stat = Stat.Gold): TextButton? {
+        if (stat !in Stat.statsUsableToBuy || construction == null)
+            return null
+
+        val city = cityScreen.city
+        val button = "".toTextButton()
+
+        if (!isConstructionPurchaseShown(construction, stat)) {
+            // This can't ever be bought with the given currency.
+            // We want one disabled "buy" button without a price for "priceless" buildings such as wonders
+            // We don't want such a button when the construction can be bought using a different currency
+            if (stat != Stat.Gold || construction.canBePurchasedWithAnyStat(city))
+                return null
+            button.setText("Buy".tr())
+            button.disable()
+        } else {
+            val constructionBuyCost = construction.getStatBuyCost(city, stat)!!
+            button.setText("Buy".tr() + " " + constructionBuyCost.tr() + stat.character)
+
+            button.onActivation(binding = KeyboardBinding.BuyConstruction) {
+                button.disable()
+                buyButtonOnClick(construction, stat)
+            }
+            button.isEnabled = cityScreen.canCityBeChanged() &&
+                city.cityConstructions.isConstructionPurchaseAllowed(construction, stat, constructionBuyCost)
+            preferredBuyStat = stat  // Not very intelligent, but the least common currency "wins"
+        }
+
+        button.labelCell.pad(5f)
+
+        return button
+    }
+
+    private fun buyButtonOnClick(construction: INonPerpetualConstruction, stat: Stat = preferredBuyStat) {
+        if (construction !is Building || !construction.hasCreateOneImprovementUnique())
+            return askToBuyConstruction(construction, stat)
+        if (cityScreen.selectedQueueEntry < 0)
+            return cityScreen.startPickTileForCreatesOneImprovement(construction, stat, true)
+        // Buying a UniqueType.CreatesOneImprovement building from queue must pass down
+        // the already selected tile, otherwise a new one is chosen from Automation code.
+        val improvement = construction.getImprovementToCreate(
+            cityScreen.city.getRuleset(), cityScreen.city.civ)!!
+        val tileForImprovement = cityScreen.city.cityConstructions.getTileForImprovement(improvement.name)
+        askToBuyConstruction(construction, stat, tileForImprovement)
+    }
+
+    /** Ask whether user wants to buy [construction] for [stat].
+     *
+     * Used from onClick and keyboard dispatch, thus only minimal parameters are passed,
+     * and it needs to do all checks and the sound as appropriate.
+     */
+    fun askToBuyConstruction(
+        construction: INonPerpetualConstruction,
+        stat: Stat = preferredBuyStat,
+        tile: Tile? = null
+    ) {
+        if (!isConstructionPurchaseShown(construction, stat)) return
+        val city = cityScreen.city
+        val constructionStatBuyCost = construction.getStatBuyCost(city, stat)!!
+        if (!city.cityConstructions.isConstructionPurchaseAllowed(construction, stat, constructionStatBuyCost)) return
+
+        cityScreen.closeAllPopups()
+        ConfirmBuyPopup(construction, stat,constructionStatBuyCost, tile)
+    }
+
+    private inner class ConfirmBuyPopup(
+        construction: INonPerpetualConstruction,
+        stat: Stat,
+        constructionStatBuyCost: Int,
+        tile: Tile?
+    ) : Popup(cityScreen.stage) {
+        init {
+            val city = cityScreen.city
+            val balance = city.getStatReserve(stat)
+            val majorityReligion = city.religion.getMajorityReligion()
+            val yourReligion = city.civ.religionManager.religion
+            val isBuyingWithFaithForForeignReligion = construction.hasUnique(UniqueType.ReligiousUnit)
+                && !construction.hasUnique(UniqueType.TakeReligionOverBirthCity)
+                && majorityReligion != yourReligion
+
+            addGoodSizedLabel("Currently you have [$balance] [${stat.name}].").padBottom(10f).row()
+            if (isBuyingWithFaithForForeignReligion) {
+                // Earlier tests should forbid this Popup unless both religions are non-null, but to be safe:
+                fun Religion?.getName() = this?.getReligionDisplayName() ?: Constants.unknownCityName
+                addGoodSizedLabel("You are buying a religious unit in a city that doesn't follow the religion you founded ([${yourReligion.getName()}]). " +
+                    "This means that the unit is tied to that foreign religion ([${majorityReligion.getName()}]) and will be less useful.").row()
+                addGoodSizedLabel("Are you really sure you want to purchase this unit?", Constants.headingFontSize).run {
+                    actor.color = Color.FIREBRICK
+                    padBottom(10f)
+                    row()
+                }
+            }
+            addGoodSizedLabel("Would you like to purchase [${construction.name}] for [$constructionStatBuyCost] [${stat.character}]?").row()
+
+            addCloseButton(Constants.cancel, KeyboardBinding.Cancel) { cityScreen.update() }
+            val confirmStyle = BaseScreen.skin.get("positive", TextButton.TextButtonStyle::class.java)
+            addOKButton("Purchase", KeyboardBinding.Confirm, confirmStyle) {
+                purchaseConstruction(construction, stat, tile)
+            }
+            equalizeLastTwoButtonWidths()
+            open(true)
+        }
+    }
+
+    /** This tests whether the buy button should be _shown_ */
+    private fun isConstructionPurchaseShown(construction: INonPerpetualConstruction, stat: Stat): Boolean {
+        val city = cityScreen.city
+        return construction.canBePurchasedWithStat(city, stat)
+    }
+
+    /** Called only by askToBuyConstruction's Yes answer - not to be confused with [CityConstructions.purchaseConstruction]
+     * @param tile supports [UniqueType.CreatesOneImprovement]
+     */
+    private fun purchaseConstruction(
+        construction: INonPerpetualConstruction,
+        stat: Stat = Stat.Gold,
+        tile: Tile? = null
+    ) {
+        SoundPlayer.play(stat.purchaseSound)
+        val city = cityScreen.city
+        if (!city.cityConstructions.purchaseConstruction(construction, cityScreen.selectedQueueEntry, false, stat, tile)) {
+            Popup(cityScreen).apply {
+                add("No space available to place [${construction.name}] near [${city.name}]".tr()).row()
+                addCloseButton()
+                open()
+            }
+            return
+        }
+        if (cityScreen.selectedQueueEntry>=0 || cityScreen.selectedConstruction?.isBuildable(city.cityConstructions) != true) {
+            cityScreen.selectedQueueEntry = -1
+            cityScreen.clearSelection()
+
+            // Allow buying next queued or auto-assigned construction right away
+            city.cityConstructions.chooseNextConstruction()
+            if (city.cityConstructions.currentConstructionFromQueue.isNotEmpty()) {
+                val newConstruction = city.cityConstructions.getCurrentConstruction()
+                if (newConstruction is INonPerpetualConstruction)
+                    cityScreen.selectConstruction(newConstruction)
+            }
+        }
+        cityScreen.city.reassignPopulation()
+        cityScreen.update()
+    }
+
+}

--- a/core/src/com/unciv/ui/screens/cityscreen/CityConstructionsTable.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/CityConstructionsTable.kt
@@ -58,7 +58,8 @@ private class ConstructionButtonDTO(
 
 /**
  * Manager to hold and coordinate two widgets for the city screen left side:
- * - Construction queue which is scrollable, limited to one third of the stage height.
+ * - Construction queue with the buy button.
+ *   The queue is scrollable, limited to one third of the stage height.
  * - Available constructions display, scrolling, grouped with expanders and therefore of dynamic height.
  */
 class CityConstructionsTable(private val cityScreen: CityScreen) {
@@ -68,6 +69,8 @@ class CityConstructionsTable(private val cityScreen: CityScreen) {
     private val upperTable = Table(BaseScreen.skin)
     private val constructionsQueueScrollPane: ScrollPane
     private val constructionsQueueTable = Table()
+    private val buttonsTable = Table()
+    private val buyButtonFactory = BuyButtonFactory(cityScreen)
 
     private val lowerTable = Table()
     private val availableConstructionsScrollPane: ScrollPane
@@ -98,6 +101,7 @@ class CityConstructionsTable(private val cityScreen: CityScreen) {
         upperTable.add(constructionsQueueScrollPane)
             .maxHeight(stageHeight / 3 - 10f)
             .padBottom(pad).row()
+        upperTable.add(buttonsTable).padBottom(pad).row()
 
         availableConstructionsScrollPane = ScrollPane(availableConstructionsTable.addBorder(2f, Color.WHITE))
         availableConstructionsScrollPane.setOverscroll(false, false)
@@ -140,6 +144,10 @@ class CityConstructionsTable(private val cityScreen: CityScreen) {
         if (!cityScreen.canChangeState) return
         /** [UniqueType.MayBuyConstructionsInPuppets] support - we need a buy button for civs that could buy items in puppets */
         if (cityScreen.city.isPuppet && !cityScreen.city.getMatchingUniques(UniqueType.MayBuyConstructionsInPuppets).any()) return
+        buttonsTable.clear()
+        buyButtonFactory.addBuyButtons(buttonsTable, construction) {
+            it.padRight(5f)
+        }
     }
 
     private fun updateConstructionQueue() {

--- a/core/src/com/unciv/ui/screens/cityscreen/CityScreen.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/CityScreen.kt
@@ -133,6 +133,9 @@ class CityScreen(
     var pickTileData: PickTileForImprovementData? = null
     /** A [Building] with [UniqueType.CreatesOneImprovement] has been selected _in the queue_: show the tile it will place the improvement on */
     private var selectedQueueEntryTargetTile: Tile? = null
+    var selectedQueueEntry
+        get() = constructionsTable.selectedQueueEntry
+        set(value) { constructionsTable.selectedQueueEntry = value }
     /** Cached city.expansion.chooseNewTileToOwn() */
     // val should be OK as buying tiles is what changes this, and that would re-create the whole CityScreen
     private val nextTileToOwn = city.expansion.chooseNewTileToOwn()
@@ -452,7 +455,7 @@ class CityScreen(
             val improvement = pickTileData.improvement
             if (tileInfo.improvementFunctions.canBuildImprovement(improvement, city.civ)) {
                 if (pickTileData.isBuying) {
-                    constructionsTable.askToBuyConstruction(pickTileData.building, pickTileData.buyStat, tileInfo)
+                    selectedConstructionTable.askToBuyConstruction(pickTileData.building, pickTileData.buyStat, tileInfo)
                 } else {
                     // This way to store where the improvement a CreatesOneImprovement Building will create goes
                     // might get a bit fragile if several buildings constructing the same improvement type

--- a/core/src/com/unciv/ui/screens/cityscreen/CityScreen.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/CityScreen.kt
@@ -455,7 +455,7 @@ class CityScreen(
             val improvement = pickTileData.improvement
             if (tileInfo.improvementFunctions.canBuildImprovement(improvement, city.civ)) {
                 if (pickTileData.isBuying) {
-                    selectedConstructionTable.askToBuyConstruction(pickTileData.building, pickTileData.buyStat, tileInfo)
+                    BuyButtonFactory(this).askToBuyConstruction(pickTileData.building, pickTileData.buyStat, tileInfo)
                 } else {
                     // This way to store where the improvement a CreatesOneImprovement Building will create goes
                     // might get a bit fragile if several buildings constructing the same improvement type

--- a/core/src/com/unciv/ui/screens/cityscreen/CityScreen.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/CityScreen.kt
@@ -167,6 +167,13 @@ class CityScreen(
 
         globalShortcuts.add(KeyboardBinding.PreviousCity) { page(-1) }
         globalShortcuts.add(KeyboardBinding.NextCity) { page(1) }
+
+        if (isPortrait()) mapScrollPane.apply {
+            // center scrolling so city center sits more to the bottom right
+            scrollX = (maxX - constructionsTable.getLowerWidth() - posFromEdge) / 2
+            scrollY = (maxY - cityStatsTable.packIfNeeded().height - posFromEdge + cityPickerTable.top) / 2
+            updateVisualScroll()
+        }
     }
 
     override fun getCivilopediaRuleset() = selectedCiv.gameInfo.ruleset
@@ -182,12 +189,6 @@ class CityScreen(
 
         // Rest of screen: Map of surroundings
         updateTileGroups()
-        if (isPortrait()) mapScrollPane.apply {
-            // center scrolling so city center sits more to the bottom right
-            scrollX = (maxX - constructionsTable.getLowerWidth() - posFromEdge) / 2
-            scrollY = (maxY - cityStatsTable.packIfNeeded().height - posFromEdge + cityPickerTable.top) / 2
-            updateVisualScroll()
-        }
     }
 
     internal fun updateWithoutConstructionAndMap() {
@@ -216,16 +217,25 @@ class CityScreen(
         cityPickerTable.setPosition(centeredX, exitCityButton.top + 10f, Align.bottom)
 
         // Top right of screen: Stats / Specialists
-        var statsHeight = stage.height - posFromEdge * 2
-        if (selectedTile != null)
-            statsHeight -= tileTable.height + 10f
-        if (selectedConstruction != null)
-            statsHeight -= selectedConstructionTable.height + 10f
-        cityStatsTable.update(statsHeight)
-        cityStatsTable.setPosition(stage.width - posFromEdge, stage.height - posFromEdge, Align.topRight)
+        updateCityStats()
 
         // Top center: Annex/Raze button
         updateAnnexAndRazeCityButton()
+
+    }
+
+    private fun updateCityStats() {
+        var statsHeight = stage.height - posFromEdge * 2
+        if (selectedTile != null)
+            statsHeight -= tileTable.top + 10f
+        if (selectedConstruction != null)
+            statsHeight -= selectedConstructionTable.top + 10f
+        cityStatsTable.update(statsHeight)
+        cityStatsTable.setPosition(
+            stage.width - posFromEdge,
+            stage.height - posFromEdge,
+            Align.topRight
+        )
     }
 
     fun canCityBeChanged(): Boolean {
@@ -332,9 +342,21 @@ class CityScreen(
         }
 
         razeCityButtonHolder.pack()
-        val centerX = if (!isPortrait()) stage.width / 2
-            else constructionsTable.getUpperWidth().let { it + (stage.width - cityStatsTable.width - it) / 2 }
-        razeCityButtonHolder.setPosition(centerX, stage.height - 20f, Align.top)
+        if(isCrampedPortrait()) {
+            // cramped portrait: move raze button down to city picker
+            val centerX = cityPickerTable.x + cityPickerTable.width / 2 - razeCityButtonHolder.width / 2
+            razeCityButtonHolder.setPosition(centerX, cityPickerTable.y + cityPickerTable.height + 10)
+            // and also re-position the tooltips, which would otherwise be covered
+            tileTable.setPosition(stage.width - posFromEdge, razeCityButtonHolder.top + 10f, Align.bottomRight)
+            selectedConstructionTable.setPosition(stage.width - posFromEdge, razeCityButtonHolder.top + 10f, Align.bottomRight)
+            updateCityStats() // limit city stats height according to the tooltips
+        } else {
+            val centerX = if (isPortrait())
+                constructionsTable.getUpperWidth().let { it + (stage.width - cityStatsTable.width - it) / 2 }
+            else
+                stage.width / 2
+            razeCityButtonHolder.setPosition(centerX, stage.height - 20f, Align.top)
+        }
         stage.addActor(razeCityButtonHolder)
     }
 

--- a/core/src/com/unciv/ui/screens/cityscreen/CityStatsTable.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/CityStatsTable.kt
@@ -48,7 +48,7 @@ class CityStatsTable(private val cityScreen: CityScreen) : Table() {
         rotation = 90f
     }
     private var headerIconClickArea = Table()
-    private var isOpen = true
+    private var isOpen = !cityScreen.isCrampedPortrait()
     
     private val detailedStatsButton = "Stats".toTextButton().apply {
         labelCell.pad(10f)
@@ -114,6 +114,9 @@ class CityStatsTable(private val cityScreen: CityScreen) : Table() {
             miniStatsTable.add(icon).size(27f).padRight(3f)
             val valueToDisplay = if (stat == Stat.Happiness) city.cityStats.happinessList.values.sum() else amount
             miniStatsTable.add(round(valueToDisplay).toInt().toLabel()).padRight(5f)
+            if (cityScreen.isCrampedPortrait() && stat == Stat.Gold) {
+                miniStatsTable.row()
+            }
         }
         upperTable.add(miniStatsTable).expandX()
         upperTable.addSeparator()
@@ -135,7 +138,10 @@ class CityStatsTable(private val cityScreen: CityScreen) : Table() {
         headerIcon.rotation = if(isOpen) 90f else 0f
         
         innerTable.clear()
-        innerTable.add(upperTable).expandX()
+        val upperCell = innerTable.add(upperTable).expandX()
+        if (cityScreen.isCrampedPortrait()) {
+            upperCell.right()
+        }
         innerTable.add(headerIconClickArea).row()
         val lowerCell = if (isOpen) {
             innerTable.add(lowerPane).colspan(2)

--- a/core/src/com/unciv/ui/screens/cityscreen/CityStatsTable.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/CityStatsTable.kt
@@ -7,7 +7,6 @@ import com.badlogic.gdx.scenes.scene2d.ui.Label
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.utils.Align
 import com.unciv.Constants
-import com.unciv.UncivGame
 import com.unciv.logic.city.City
 import com.unciv.logic.city.CityFlags
 import com.unciv.logic.city.CityFocus
@@ -33,7 +32,6 @@ import com.unciv.ui.components.input.onClick
 import com.unciv.ui.components.widgets.ExpanderTab
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.screens.basescreen.BaseScreen
-import com.unciv.ui.screens.civilopediascreen.CivilopediaScreen
 import kotlin.math.ceil
 import kotlin.math.round
 import com.unciv.ui.components.widgets.AutoScrollPane as ScrollPane
@@ -108,7 +106,7 @@ class CityStatsTable(private val cityScreen: CityScreen) : Table() {
         upperTable.add(miniStatsTable)
 
         upperTable.addSeparator()
-        upperTable.add(detailedStatsButton).row()
+        lowerTable.add(detailedStatsButton).row()
         addText()
 
         // begin lowerTable
@@ -170,9 +168,9 @@ class CityStatsTable(private val cityScreen: CityScreen) : Table() {
                 }.tr()
         turnsToPopString += " (${city.population.foodStored}${Fonts.food}/${city.population.getFoodToNextPopulation()}${Fonts.food})"
 
-        upperTable.add(unassignedPopLabel).row()
-        upperTable.add(turnsToExpansionString.toLabel()).row()
-        upperTable.add(turnsToPopString.toLabel()).row()
+        lowerTable.add(unassignedPopLabel).row()
+        lowerTable.add(turnsToExpansionString.toLabel()).row()
+        lowerTable.add(turnsToPopString.toLabel()).row()
 
         val tableWithIcons = Table()
         tableWithIcons.defaults().pad(2f)
@@ -212,7 +210,7 @@ class CityStatsTable(private val cityScreen: CityScreen) : Table() {
             tableWithIcons.add(wltkLabel).row()
         }
 
-        upperTable.add(tableWithIcons).row()
+        lowerTable.add(tableWithIcons).row()
     }
 
     private fun addCitizenManagement() {

--- a/core/src/com/unciv/ui/screens/cityscreen/CityStatsTable.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/CityStatsTable.kt
@@ -85,7 +85,6 @@ class CityStatsTable(private val cityScreen: CityScreen) : Table() {
             isOpen = !isOpen
             cityScreen.updateWithoutConstructionAndMap()
         }
-        headerIconClickArea.setDebug(true)
     }
 
     fun update(height: Float) {

--- a/core/src/com/unciv/ui/screens/cityscreen/ConstructionInfoTable.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/ConstructionInfoTable.kt
@@ -4,40 +4,28 @@ import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.scenes.scene2d.Touchable
 import com.badlogic.gdx.scenes.scene2d.ui.Label
 import com.badlogic.gdx.scenes.scene2d.ui.Table
-import com.badlogic.gdx.scenes.scene2d.ui.TextButton
-import com.unciv.Constants
-import com.unciv.logic.city.CityConstructions
-import com.unciv.logic.map.tile.Tile
-import com.unciv.models.Religion
 import com.unciv.models.UncivSound
 import com.unciv.models.ruleset.Building
 import com.unciv.models.ruleset.IConstruction
-import com.unciv.models.ruleset.INonPerpetualConstruction
 import com.unciv.models.ruleset.IRulesetObject
 import com.unciv.models.ruleset.PerpetualConstruction
 import com.unciv.models.ruleset.PerpetualStatConversion
-import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.ruleset.unit.BaseUnit
-import com.unciv.models.stats.Stat
 import com.unciv.models.translations.tr
-import com.unciv.ui.audio.SoundPlayer
 import com.unciv.ui.components.extensions.darken
 import com.unciv.ui.components.extensions.disable
 import com.unciv.ui.components.extensions.isEnabled
 import com.unciv.ui.components.extensions.toTextButton
 import com.unciv.ui.components.fonts.Fonts
-import com.unciv.ui.components.input.KeyboardBinding
-import com.unciv.ui.components.input.onActivation
 import com.unciv.ui.components.input.onClick
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.popups.ConfirmPopup
-import com.unciv.ui.popups.Popup
 import com.unciv.ui.popups.closeAllPopups
 import com.unciv.ui.screens.basescreen.BaseScreen
 
 class ConstructionInfoTable(val cityScreen: CityScreen) : Table() {
     private val selectedConstructionTable = Table()
-    private var preferredBuyStat = Stat.Gold  // Used for keyboard buy
+    private val buyButtonFactory = BuyButtonFactory(cityScreen)
 
     init {
         selectedConstructionTable.background = BaseScreen.skinStrings.getUiBackground(
@@ -102,10 +90,14 @@ class ConstructionInfoTable(val cityScreen: CityScreen) : Table() {
             descriptionLabel.wrap = true
             add(descriptionLabel).colspan(2).width(stage.width / 4)
 
-            if (cityConstructions.isBuilt(construction.name))
+            if (cityConstructions.isBuilt(construction.name)) {
                 showSellButton(construction)
-            else
-                showBuyButtons(construction)
+            } else if (buyButtonFactory.hasBuyButtons(construction)) {
+                row()
+                buyButtonFactory.addBuyButtons(selectedConstructionTable, construction) {
+                    it.padTop(5f).colspan(2).center()
+                }
+            }
         }
     }
 
@@ -161,164 +153,5 @@ class ConstructionInfoTable(val cityScreen: CityScreen) : Table() {
         cityScreen.clearSelection()
         cityScreen.update()
     }
-
-    private fun showBuyButtons(construction: IConstruction?) {
-        val selection = cityScreen.selectedConstruction!=null || cityScreen.selectedQueueEntry >= 0
-        if (selection && construction != null && construction !is PerpetualConstruction)
-            selectedConstructionTable.run {
-                for (button in getBuyButtons(construction as INonPerpetualConstruction)) {
-                    row()
-                    add(button).padTop(5f).colspan(2).center()
-            }
-        }
-    }
-
-    private fun getBuyButtons(construction: INonPerpetualConstruction?): List<TextButton> {
-        return Stat.statsUsableToBuy.mapNotNull { getBuyButton(construction, it) }
-    }
-
-    private fun getBuyButton(construction: INonPerpetualConstruction?, stat: Stat = Stat.Gold): TextButton? {
-        if (stat !in Stat.statsUsableToBuy || construction == null)
-            return null
-
-        val city = cityScreen.city
-        val button = "".toTextButton()
-        
-        if (!isConstructionPurchaseShown(construction, stat)) {
-            // This can't ever be bought with the given currency.
-            // We want one disabled "buy" button without a price for "priceless" buildings such as wonders
-            // We don't want such a button when the construction can be bought using a different currency
-            if (stat != Stat.Gold || construction.canBePurchasedWithAnyStat(city))
-                return null
-            button.setText("Buy".tr())
-            button.disable()
-        } else {
-            val constructionBuyCost = construction.getStatBuyCost(city, stat)!!
-            button.setText("Buy".tr() + " " + constructionBuyCost.tr() + stat.character)
-
-            button.onActivation(binding = KeyboardBinding.BuyConstruction) {
-                button.disable()
-                buyButtonOnClick(construction, stat)
-            }
-            button.isEnabled = cityScreen.canCityBeChanged() &&
-                city.cityConstructions.isConstructionPurchaseAllowed(construction, stat, constructionBuyCost)
-            preferredBuyStat = stat  // Not very intelligent, but the least common currency "wins"
-        }
-
-        button.labelCell.pad(5f)
-
-        return button
-    }
-
-    private fun buyButtonOnClick(construction: INonPerpetualConstruction, stat: Stat = preferredBuyStat) {
-        if (construction !is Building || !construction.hasCreateOneImprovementUnique())
-            return askToBuyConstruction(construction, stat)
-        if (cityScreen.selectedQueueEntry < 0)
-            return cityScreen.startPickTileForCreatesOneImprovement(construction, stat, true)
-        // Buying a UniqueType.CreatesOneImprovement building from queue must pass down
-        // the already selected tile, otherwise a new one is chosen from Automation code.
-        val improvement = construction.getImprovementToCreate(
-            cityScreen.city.getRuleset(), cityScreen.city.civ)!!
-        val tileForImprovement = cityScreen.city.cityConstructions.getTileForImprovement(improvement.name)
-        askToBuyConstruction(construction, stat, tileForImprovement)
-    }
-
-    /** Ask whether user wants to buy [construction] for [stat].
-     *
-     * Used from onClick and keyboard dispatch, thus only minimal parameters are passed,
-     * and it needs to do all checks and the sound as appropriate.
-     */
-    fun askToBuyConstruction(
-        construction: INonPerpetualConstruction,
-        stat: Stat = preferredBuyStat,
-        tile: Tile? = null
-    ) {
-        if (!isConstructionPurchaseShown(construction, stat)) return
-        val city = cityScreen.city
-        val constructionStatBuyCost = construction.getStatBuyCost(city, stat)!!
-        if (!city.cityConstructions.isConstructionPurchaseAllowed(construction, stat, constructionStatBuyCost)) return
-
-        cityScreen.closeAllPopups()
-        ConfirmBuyPopup(construction, stat,constructionStatBuyCost, tile)
-    }
-
-    private inner class ConfirmBuyPopup(
-        construction: INonPerpetualConstruction,
-        stat: Stat,
-        constructionStatBuyCost: Int,
-        tile: Tile?
-    ) : Popup(cityScreen.stage) {
-        init {
-            val city = cityScreen.city
-            val balance = city.getStatReserve(stat)
-            val majorityReligion = city.religion.getMajorityReligion()
-            val yourReligion = city.civ.religionManager.religion
-            val isBuyingWithFaithForForeignReligion = construction.hasUnique(UniqueType.ReligiousUnit)
-                && !construction.hasUnique(UniqueType.TakeReligionOverBirthCity)
-                && majorityReligion != yourReligion
-
-            addGoodSizedLabel("Currently you have [$balance] [${stat.name}].").padBottom(10f).row()
-            if (isBuyingWithFaithForForeignReligion) {
-                // Earlier tests should forbid this Popup unless both religions are non-null, but to be safe:
-                fun Religion?.getName() = this?.getReligionDisplayName() ?: Constants.unknownCityName
-                addGoodSizedLabel("You are buying a religious unit in a city that doesn't follow the religion you founded ([${yourReligion.getName()}]). " +
-                    "This means that the unit is tied to that foreign religion ([${majorityReligion.getName()}]) and will be less useful.").row()
-                addGoodSizedLabel("Are you really sure you want to purchase this unit?", Constants.headingFontSize).run {
-                    actor.color = Color.FIREBRICK
-                    padBottom(10f)
-                    row()
-                }
-            }
-            addGoodSizedLabel("Would you like to purchase [${construction.name}] for [$constructionStatBuyCost] [${stat.character}]?").row()
-
-            addCloseButton(Constants.cancel, KeyboardBinding.Cancel) { cityScreen.update() }
-            val confirmStyle = BaseScreen.skin.get("positive", TextButton.TextButtonStyle::class.java)
-            addOKButton("Purchase", KeyboardBinding.Confirm, confirmStyle) {
-                purchaseConstruction(construction, stat, tile)
-            }
-            equalizeLastTwoButtonWidths()
-            open(true)
-        }
-    }
-
-    /** This tests whether the buy button should be _shown_ */
-    private fun isConstructionPurchaseShown(construction: INonPerpetualConstruction, stat: Stat): Boolean {
-        val city = cityScreen.city
-        return construction.canBePurchasedWithStat(city, stat)
-    }
-
-    /** Called only by askToBuyConstruction's Yes answer - not to be confused with [CityConstructions.purchaseConstruction]
-     * @param tile supports [UniqueType.CreatesOneImprovement]
-     */
-    private fun purchaseConstruction(
-        construction: INonPerpetualConstruction,
-        stat: Stat = Stat.Gold,
-        tile: Tile? = null
-    ) {
-        SoundPlayer.play(stat.purchaseSound)
-        val city = cityScreen.city
-        if (!city.cityConstructions.purchaseConstruction(construction, cityScreen.selectedQueueEntry, false, stat, tile)) {
-            Popup(cityScreen).apply {
-                add("No space available to place [${construction.name}] near [${city.name}]".tr()).row()
-                addCloseButton()
-                open()
-            }
-            return
-        }
-        if (cityScreen.selectedQueueEntry>=0 || cityScreen.selectedConstruction?.isBuildable(city.cityConstructions) != true) {
-            cityScreen.selectedQueueEntry = -1
-            cityScreen.clearSelection()
-
-            // Allow buying next queued or auto-assigned construction right away
-            city.cityConstructions.chooseNextConstruction()
-            if (city.cityConstructions.currentConstructionFromQueue.isNotEmpty()) {
-                val newConstruction = city.cityConstructions.getCurrentConstruction()
-                if (newConstruction is INonPerpetualConstruction)
-                    cityScreen.selectConstruction(newConstruction)
-            }
-        }
-        cityScreen.city.reassignPopulation()
-        cityScreen.update()
-    }
-
+    
 }

--- a/core/src/com/unciv/ui/screens/cityscreen/ConstructionInfoTable.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/ConstructionInfoTable.kt
@@ -4,27 +4,40 @@ import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.scenes.scene2d.Touchable
 import com.badlogic.gdx.scenes.scene2d.ui.Label
 import com.badlogic.gdx.scenes.scene2d.ui.Table
+import com.badlogic.gdx.scenes.scene2d.ui.TextButton
+import com.unciv.Constants
+import com.unciv.logic.city.CityConstructions
+import com.unciv.logic.map.tile.Tile
+import com.unciv.models.Religion
 import com.unciv.models.UncivSound
 import com.unciv.models.ruleset.Building
 import com.unciv.models.ruleset.IConstruction
+import com.unciv.models.ruleset.INonPerpetualConstruction
 import com.unciv.models.ruleset.IRulesetObject
 import com.unciv.models.ruleset.PerpetualConstruction
 import com.unciv.models.ruleset.PerpetualStatConversion
+import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.ruleset.unit.BaseUnit
+import com.unciv.models.stats.Stat
 import com.unciv.models.translations.tr
+import com.unciv.ui.audio.SoundPlayer
 import com.unciv.ui.components.extensions.darken
 import com.unciv.ui.components.extensions.disable
 import com.unciv.ui.components.extensions.isEnabled
 import com.unciv.ui.components.extensions.toTextButton
 import com.unciv.ui.components.fonts.Fonts
+import com.unciv.ui.components.input.KeyboardBinding
+import com.unciv.ui.components.input.onActivation
 import com.unciv.ui.components.input.onClick
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.popups.ConfirmPopup
+import com.unciv.ui.popups.Popup
 import com.unciv.ui.popups.closeAllPopups
 import com.unciv.ui.screens.basescreen.BaseScreen
 
 class ConstructionInfoTable(val cityScreen: CityScreen) : Table() {
     private val selectedConstructionTable = Table()
+    private var preferredBuyStat = Stat.Gold  // Used for keyboard buy
 
     init {
         selectedConstructionTable.background = BaseScreen.skinStrings.getUiBackground(
@@ -89,9 +102,19 @@ class ConstructionInfoTable(val cityScreen: CityScreen) : Table() {
             descriptionLabel.wrap = true
             add(descriptionLabel).colspan(2).width(stage.width / 4)
 
-            // Show sell button if construction is a currently sellable building
-            if (construction is Building && cityConstructions.isBuilt(construction.name)
-                    && construction.isSellable()) {
+            if (cityConstructions.isBuilt(construction.name))
+                showSellButton(construction)
+            else
+                showBuyButtons(construction)
+        }
+    }
+
+    // Show sell button if construction is a currently sellable building
+    private fun showSellButton(
+        construction: IConstruction
+    ) {
+        if (construction is Building && construction.isSellable()) {
+            selectedConstructionTable.run {
                 val sellAmount = cityScreen.city.getGoldForSellingBuilding(construction.name)
                 val sellText = "{Sell} $sellAmount " + Fonts.gold
                 val sellBuildingButton = sellText.toTextButton()
@@ -138,4 +161,164 @@ class ConstructionInfoTable(val cityScreen: CityScreen) : Table() {
         cityScreen.clearSelection()
         cityScreen.update()
     }
+
+    private fun showBuyButtons(construction: IConstruction?) {
+        val selection = cityScreen.selectedConstruction!=null || cityScreen.selectedQueueEntry >= 0
+        if (selection && construction != null && construction !is PerpetualConstruction)
+            selectedConstructionTable.run {
+                for (button in getBuyButtons(construction as INonPerpetualConstruction)) {
+                    row()
+                    add(button).padTop(5f).colspan(2).center()
+            }
+        }
+    }
+
+    private fun getBuyButtons(construction: INonPerpetualConstruction?): List<TextButton> {
+        return Stat.statsUsableToBuy.mapNotNull { getBuyButton(construction, it) }
+    }
+
+    private fun getBuyButton(construction: INonPerpetualConstruction?, stat: Stat = Stat.Gold): TextButton? {
+        if (stat !in Stat.statsUsableToBuy || construction == null)
+            return null
+
+        val city = cityScreen.city
+        val button = "".toTextButton()
+        
+        if (!isConstructionPurchaseShown(construction, stat)) {
+            // This can't ever be bought with the given currency.
+            // We want one disabled "buy" button without a price for "priceless" buildings such as wonders
+            // We don't want such a button when the construction can be bought using a different currency
+            if (stat != Stat.Gold || construction.canBePurchasedWithAnyStat(city))
+                return null
+            button.setText("Buy".tr())
+            button.disable()
+        } else {
+            val constructionBuyCost = construction.getStatBuyCost(city, stat)!!
+            button.setText("Buy".tr() + " " + constructionBuyCost.tr() + stat.character)
+
+            button.onActivation(binding = KeyboardBinding.BuyConstruction) {
+                button.disable()
+                buyButtonOnClick(construction, stat)
+            }
+            button.isEnabled = cityScreen.canCityBeChanged() &&
+                city.cityConstructions.isConstructionPurchaseAllowed(construction, stat, constructionBuyCost)
+            preferredBuyStat = stat  // Not very intelligent, but the least common currency "wins"
+        }
+
+        button.labelCell.pad(5f)
+
+        return button
+    }
+
+    private fun buyButtonOnClick(construction: INonPerpetualConstruction, stat: Stat = preferredBuyStat) {
+        if (construction !is Building || !construction.hasCreateOneImprovementUnique())
+            return askToBuyConstruction(construction, stat)
+        if (cityScreen.selectedQueueEntry < 0)
+            return cityScreen.startPickTileForCreatesOneImprovement(construction, stat, true)
+        // Buying a UniqueType.CreatesOneImprovement building from queue must pass down
+        // the already selected tile, otherwise a new one is chosen from Automation code.
+        val improvement = construction.getImprovementToCreate(
+            cityScreen.city.getRuleset(), cityScreen.city.civ)!!
+        val tileForImprovement = cityScreen.city.cityConstructions.getTileForImprovement(improvement.name)
+        askToBuyConstruction(construction, stat, tileForImprovement)
+    }
+
+    /** Ask whether user wants to buy [construction] for [stat].
+     *
+     * Used from onClick and keyboard dispatch, thus only minimal parameters are passed,
+     * and it needs to do all checks and the sound as appropriate.
+     */
+    fun askToBuyConstruction(
+        construction: INonPerpetualConstruction,
+        stat: Stat = preferredBuyStat,
+        tile: Tile? = null
+    ) {
+        if (!isConstructionPurchaseShown(construction, stat)) return
+        val city = cityScreen.city
+        val constructionStatBuyCost = construction.getStatBuyCost(city, stat)!!
+        if (!city.cityConstructions.isConstructionPurchaseAllowed(construction, stat, constructionStatBuyCost)) return
+
+        cityScreen.closeAllPopups()
+        ConfirmBuyPopup(construction, stat,constructionStatBuyCost, tile)
+    }
+
+    private inner class ConfirmBuyPopup(
+        construction: INonPerpetualConstruction,
+        stat: Stat,
+        constructionStatBuyCost: Int,
+        tile: Tile?
+    ) : Popup(cityScreen.stage) {
+        init {
+            val city = cityScreen.city
+            val balance = city.getStatReserve(stat)
+            val majorityReligion = city.religion.getMajorityReligion()
+            val yourReligion = city.civ.religionManager.religion
+            val isBuyingWithFaithForForeignReligion = construction.hasUnique(UniqueType.ReligiousUnit)
+                && !construction.hasUnique(UniqueType.TakeReligionOverBirthCity)
+                && majorityReligion != yourReligion
+
+            addGoodSizedLabel("Currently you have [$balance] [${stat.name}].").padBottom(10f).row()
+            if (isBuyingWithFaithForForeignReligion) {
+                // Earlier tests should forbid this Popup unless both religions are non-null, but to be safe:
+                fun Religion?.getName() = this?.getReligionDisplayName() ?: Constants.unknownCityName
+                addGoodSizedLabel("You are buying a religious unit in a city that doesn't follow the religion you founded ([${yourReligion.getName()}]). " +
+                    "This means that the unit is tied to that foreign religion ([${majorityReligion.getName()}]) and will be less useful.").row()
+                addGoodSizedLabel("Are you really sure you want to purchase this unit?", Constants.headingFontSize).run {
+                    actor.color = Color.FIREBRICK
+                    padBottom(10f)
+                    row()
+                }
+            }
+            addGoodSizedLabel("Would you like to purchase [${construction.name}] for [$constructionStatBuyCost] [${stat.character}]?").row()
+
+            addCloseButton(Constants.cancel, KeyboardBinding.Cancel) { cityScreen.update() }
+            val confirmStyle = BaseScreen.skin.get("positive", TextButton.TextButtonStyle::class.java)
+            addOKButton("Purchase", KeyboardBinding.Confirm, confirmStyle) {
+                purchaseConstruction(construction, stat, tile)
+            }
+            equalizeLastTwoButtonWidths()
+            open(true)
+        }
+    }
+
+    /** This tests whether the buy button should be _shown_ */
+    private fun isConstructionPurchaseShown(construction: INonPerpetualConstruction, stat: Stat): Boolean {
+        val city = cityScreen.city
+        return construction.canBePurchasedWithStat(city, stat)
+    }
+
+    /** Called only by askToBuyConstruction's Yes answer - not to be confused with [CityConstructions.purchaseConstruction]
+     * @param tile supports [UniqueType.CreatesOneImprovement]
+     */
+    private fun purchaseConstruction(
+        construction: INonPerpetualConstruction,
+        stat: Stat = Stat.Gold,
+        tile: Tile? = null
+    ) {
+        SoundPlayer.play(stat.purchaseSound)
+        val city = cityScreen.city
+        if (!city.cityConstructions.purchaseConstruction(construction, cityScreen.selectedQueueEntry, false, stat, tile)) {
+            Popup(cityScreen).apply {
+                add("No space available to place [${construction.name}] near [${city.name}]".tr()).row()
+                addCloseButton()
+                open()
+            }
+            return
+        }
+        if (cityScreen.selectedQueueEntry>=0 || cityScreen.selectedConstruction?.isBuildable(city.cityConstructions) != true) {
+            cityScreen.selectedQueueEntry = -1
+            cityScreen.clearSelection()
+
+            // Allow buying next queued or auto-assigned construction right away
+            city.cityConstructions.chooseNextConstruction()
+            if (city.cityConstructions.currentConstructionFromQueue.isNotEmpty()) {
+                val newConstruction = city.cityConstructions.getCurrentConstruction()
+                if (newConstruction is INonPerpetualConstruction)
+                    cityScreen.selectConstruction(newConstruction)
+            }
+        }
+        cityScreen.city.reassignPopulation()
+        cityScreen.update()
+    }
+
 }


### PR DESCRIPTION
optimized city screen construction queue for space and optimized for cramped portrait
- moved priority buttons under the queue
- queue is collapsible and shows preview
- when expanded, the queue takes available space
- collapse stats on cramped portrait
- collapsed stats show 2 lines of resources in cramped portrait to reduce width, right aligned
- raze button moved close to city button in cramped portrait

![grafik](https://github.com/user-attachments/assets/9f61e534-eca2-491f-8d9f-9e7cb4a6a68a)

This PR depends on #12315, which should be merged first. After merge, the actual changes of this PR become visible in the *files changed* tab.