### PR TITLE
Settler settle best tile when not escorted and dangerous Tiles

### DIFF
--- a/core/src/com/unciv/logic/automation/unit/SpecificUnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/SpecificUnitAutomation.kt
@@ -192,6 +192,16 @@ object SpecificUnitAutomation {
         }
 
         unit.movement.headTowards(bestCityLocation)
+        
+        // This if setement is to check if settler is on the bast tile and has no escort unit and its in a dangerous Tiles and can still move.
+        // then settle there 
+        if (bestTilesInfo.tileRankMap.containsKey(unit.getTile()) && unit.getOtherEscortUnit() == null && dangerousTiles.contains(unit.getTile())
+            && unit.hasMovement()) {
+            foundCityAction.action.invoke()
+            return
+        }
+
+        
         if (unit.getTile() == bestCityLocation && unit.hasMovement())
             foundCityAction.action.invoke()
     }


### PR DESCRIPTION
Settler unit will now settle on the best tile in dangerous Tiles without escort instead of running away.