### PR TITLE
Fix constructions that's always visible showing when belonging to another civ

### DIFF
--- a/core/src/com/unciv/models/ruleset/Building.kt
+++ b/core/src/com/unciv/models/ruleset/Building.kt
@@ -245,10 +245,12 @@ class Building : RulesetStatsObject(), INonPerpetualConstruction {
             if (cityConstructions.city.civ.civConstructions.countConstructedObjects(this) >= unique.params[0].toInt())
                 return false
         }
-        if (hasUnique(UniqueType.ShowsWhenUnbuilable, StateForConditionals(cityConstructions.city)))
-            return true
 
         val rejectionReasons = getRejectionReasons(cityConstructions)
+
+        if (hasUnique(UniqueType.ShowsWhenUnbuilable, StateForConditionals(cityConstructions.city)) &&
+            rejectionReasons.none { it.isNeverVisible() })
+            return true
 
         if (rejectionReasons.any { it.type == RejectionReasonType.RequiresBuildingInSomeCities }
                 && cityConstructions.city.civ.gameInfo.gameParameters.oneCityChallenge)

--- a/core/src/com/unciv/models/ruleset/IConstruction.kt
+++ b/core/src/com/unciv/models/ruleset/IConstruction.kt
@@ -151,43 +151,55 @@ class RejectionReason(val type: RejectionReasonType,
         return orderedImportantRejectionTypes.indexOf(type)
     }
 
-    // Used for constant variables in the functions above
-    private val techPolicyEraWonderRequirements = hashSetOf(
-        RejectionReasonType.Obsoleted,
-        RejectionReasonType.RequiresTech,
-        RejectionReasonType.RequiresPolicy,
-        RejectionReasonType.MorePolicyBranches,
-        RejectionReasonType.RequiresBuildingInSomeCity,
-    )
-    private val reasonsToDefinitivelyRemoveFromQueue = hashSetOf(
-        RejectionReasonType.Obsoleted,
-        RejectionReasonType.WonderAlreadyBuilt,
-        RejectionReasonType.NationalWonderAlreadyBuilt,
-        RejectionReasonType.CannotBeBuiltWith,
-        RejectionReasonType.MaxNumberBuildable,
-    )
-    private val orderedImportantRejectionTypes = listOf(
-        RejectionReasonType.ShouldNotBeDisplayed,
-        RejectionReasonType.WonderBeingBuiltElsewhere,
-        RejectionReasonType.RequiresBuildingInAllCities,
-        RejectionReasonType.RequiresBuildingInThisCity,
-        RejectionReasonType.RequiresBuildingInSomeCity,
-        RejectionReasonType.RequiresBuildingInSomeCities,
-        RejectionReasonType.CanOnlyBeBuiltInSpecificCities,
-        RejectionReasonType.CannotBeBuiltUnhappiness,
-        RejectionReasonType.PopulationRequirement,
-        RejectionReasonType.ConsumesResources,
-        RejectionReasonType.CanOnlyBePurchased,
-        RejectionReasonType.MaxNumberBuildable,
-        RejectionReasonType.NoPlaceToPutUnit,
-    )
-    // Exceptions. Used for units spawned/upgrade path, not built
-    private val constructionRejectionReasonType = listOf(
-        RejectionReasonType.Unbuildable,
-        RejectionReasonType.CannotBeBuiltUnhappiness,
-        RejectionReasonType.CannotBeBuilt,
-        RejectionReasonType.CanOnlyBeBuiltInSpecificCities,
-    )
+    companion object {
+        // Used for constant variables in the functions above
+        private val techPolicyEraWonderRequirements = hashSetOf(
+            RejectionReasonType.Obsoleted,
+            RejectionReasonType.RequiresTech,
+            RejectionReasonType.RequiresPolicy,
+            RejectionReasonType.MorePolicyBranches,
+            RejectionReasonType.RequiresBuildingInSomeCity,
+        )
+        private val reasonsToDefinitivelyRemoveFromQueue = hashSetOf(
+            RejectionReasonType.Obsoleted,
+            RejectionReasonType.WonderAlreadyBuilt,
+            RejectionReasonType.NationalWonderAlreadyBuilt,
+            RejectionReasonType.CannotBeBuiltWith,
+            RejectionReasonType.MaxNumberBuildable,
+        )
+        private val orderedImportantRejectionTypes = listOf(
+            RejectionReasonType.ShouldNotBeDisplayed,
+            RejectionReasonType.WonderBeingBuiltElsewhere,
+            RejectionReasonType.RequiresBuildingInAllCities,
+            RejectionReasonType.RequiresBuildingInThisCity,
+            RejectionReasonType.RequiresBuildingInSomeCity,
+            RejectionReasonType.RequiresBuildingInSomeCities,
+            RejectionReasonType.CanOnlyBeBuiltInSpecificCities,
+            RejectionReasonType.CannotBeBuiltUnhappiness,
+            RejectionReasonType.PopulationRequirement,
+            RejectionReasonType.ConsumesResources,
+            RejectionReasonType.CanOnlyBePurchased,
+            RejectionReasonType.MaxNumberBuildable,
+            RejectionReasonType.NoPlaceToPutUnit,
+        )
+        // Exceptions. Used for units spawned/upgrade path, not built
+        private val constructionRejectionReasonType = listOf(
+            RejectionReasonType.Unbuildable,
+            RejectionReasonType.CannotBeBuiltUnhappiness,
+            RejectionReasonType.CannotBeBuilt,
+            RejectionReasonType.CanOnlyBeBuiltInSpecificCities,
+        )
+        private val neverVisible = listOf(
+            RejectionReasonType.AlreadyBuilt,
+            RejectionReasonType.WonderAlreadyBuilt,
+            RejectionReasonType.NationalWonderAlreadyBuilt,
+            RejectionReasonType.DisabledBySetting,
+            RejectionReasonType.UniqueToOtherNation,
+            RejectionReasonType.ReplacedByOurUnique,
+            RejectionReasonType.Obsoleted,
+            RejectionReasonType.WonderBeingBuiltElsewhere
+        )
+    }
 }
 
 

--- a/core/src/com/unciv/models/ruleset/IConstruction.kt
+++ b/core/src/com/unciv/models/ruleset/IConstruction.kt
@@ -201,6 +201,8 @@ class RejectionReason(val type: RejectionReasonType,
             RejectionReasonType.Obsoleted,
             RejectionReasonType.WonderBeingBuiltElsewhere,
             RejectionReasonType.RequiresTech,
+            RejectionReasonType.NoSettlerForOneCityPlayers,
+            RejectionReasonType.WaterUnitsInCoastalCities,
         )
     }
 }

--- a/core/src/com/unciv/models/ruleset/IConstruction.kt
+++ b/core/src/com/unciv/models/ruleset/IConstruction.kt
@@ -200,6 +200,7 @@ class RejectionReason(val type: RejectionReasonType,
             RejectionReasonType.ReplacedByOurUnique,
             RejectionReasonType.Obsoleted,
             RejectionReasonType.WonderBeingBuiltElsewhere,
+            RejectionReasonType.RequiresTech,
         )
     }
 }

--- a/core/src/com/unciv/models/ruleset/IConstruction.kt
+++ b/core/src/com/unciv/models/ruleset/IConstruction.kt
@@ -145,6 +145,8 @@ class RejectionReason(val type: RejectionReasonType,
 
     fun isConstructionRejection(): Boolean = type in constructionRejectionReasonType
 
+    fun isNeverVisible(): Boolean = type in neverVisible
+
     /** Returns the index of [orderedImportantRejectionTypes] with the smallest index having the
      * highest precedence */
     fun getRejectionPrecedence(): Int {
@@ -197,7 +199,7 @@ class RejectionReason(val type: RejectionReasonType,
             RejectionReasonType.UniqueToOtherNation,
             RejectionReasonType.ReplacedByOurUnique,
             RejectionReasonType.Obsoleted,
-            RejectionReasonType.WonderBeingBuiltElsewhere
+            RejectionReasonType.WonderBeingBuiltElsewhere,
         )
     }
 }

--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -163,9 +163,11 @@ class BaseUnit : RulesetObject(), INonPerpetualConstruction {
     fun getDisbandGold(civInfo: Civilization) = getBaseGoldCost(civInfo, null).toInt() / 20
 
     override fun shouldBeDisplayed(cityConstructions: CityConstructions): Boolean {
-        if (hasUnique(UniqueType.ShowsWhenUnbuilable, StateForConditionals(cityConstructions.city)))
-            return true
         val rejectionReasons = getRejectionReasons(cityConstructions)
+
+        if (hasUnique(UniqueType.ShowsWhenUnbuilable, StateForConditionals(cityConstructions.city)) &&
+            rejectionReasons.none { it.isNeverVisible() })
+            return true
 
         if (rejectionReasons.none { !it.shouldShow }) return true
         if (canBePurchasedWithAnyStat(cityConstructions.city)


### PR DESCRIPTION
#12313 completely missed that this logic is also the single point that checks for stuff like whether it's on the correct Civ. This patch attempts to address that while avoiding only the least amount of important rejections

Added in a minor optimization while I'm here: moving the lists to a companion means the list isn't built for each individual rejection reason and is only done once