### PR TITLE
Avoid Growth blocks New Population

### DIFF
--- a/core/src/com/unciv/logic/city/managers/CityPopulationManager.kt
+++ b/core/src/com/unciv/logic/city/managers/CityPopulationManager.kt
@@ -109,6 +109,12 @@ class CityPopulationManager : IsPartOfGameInfoSerialization {
         if (city.getMatchingUniques(UniqueType.NullifiesGrowth).any())
             return
 
+        // Hard block growth when using Avoid Growth, cap stored food
+        if (city.avoidGrowth) {
+            foodStored = foodNeededToGrow
+            return
+        }
+
         // growth!
         foodStored -= foodNeededToGrow
         val percentOfFoodCarriedOver =


### PR DESCRIPTION
Breaks from Civ5 baseline behavior, but would provide more control for players to not get into unhappiness spirals.

Edit: Correction, testing shows this aligns us to Civ5 behavior 