### PR TITLE
Avoid Growth and Food Ranking Improvements

### DIFF
--- a/core/src/com/unciv/logic/automation/Automation.kt
+++ b/core/src/com/unciv/logic/automation/Automation.kt
@@ -88,8 +88,11 @@ object Automation {
             growthFood = 0f
         }
 
-        // if starving, need Food, so feedFood > 0
+        // If starving, need Food, so feedFood > 0
         // scale feedFood by 14(base weight)*8(super important)
+        // By only scaling what we need to reach Not Starving by x8, we can pick a tile that gives
+        // exactly as much Food as we need to Not Starve that also has other good yields instead of
+        // always picking the Highest Food tile until Not Starving
         yieldStats.food = feedFood * (14 * 8)
         // growthFood is any additional food not required to meet Starvation
         if (cityAIFocus in CityFocus.zeroFoodFocuses) {

--- a/core/src/com/unciv/logic/automation/Automation.kt
+++ b/core/src/com/unciv/logic/automation/Automation.kt
@@ -73,9 +73,6 @@ object Automation {
             yieldStats.production += cityStatsObj.getProductionFromExcessiveFood(surplusFood+yieldStats.food) - cityStatsObj.getProductionFromExcessiveFood(surplusFood)
             yieldStats.food = 0f  // all food goes to 0
         }
-        
-        // Apply base weights
-        yieldStats.applyRankingWeights()
 
         // Split Food Yield into feedFood, amount needed to not Starve
         // and growthFood, any amount above that
@@ -87,26 +84,32 @@ object Automation {
         if (city.avoidGrowth) {
             growthFood = 0f
         }
+        yieldStats.food = 1f
+        
+        // Apply base weights
+        yieldStats.applyRankingWeights()
+
+        val foodBaseWeight = yieldStats.food
 
         // If starving, need Food, so feedFood > 0
         // scale feedFood by 14(base weight)*8(super important)
         // By only scaling what we need to reach Not Starving by x8, we can pick a tile that gives
         // exactly as much Food as we need to Not Starve that also has other good yields instead of
         // always picking the Highest Food tile until Not Starving
-        yieldStats.food = feedFood * (14 * 8)
+        yieldStats.food = feedFood * (foodBaseWeight * 8)
         // growthFood is any additional food not required to meet Starvation
         if (cityAIFocus in CityFocus.zeroFoodFocuses) {
             // Focus on non-food/growth
             // Reduce excess food focus to prevent Happiness spiral
             if (city.civ.getHappiness() < 1)
-                yieldStats.food += growthFood * (14 / 4)
+                yieldStats.food += growthFood * (foodBaseWeight / 4)
         } else {
             // NoFocus or Food/Growth Focus.
             // When Happy, EmperorPenguin has run sims comparing weights
             // 1.5f is preferred,
             // but 2 provides more protection against badly configured personalities
             // If unhappy, see above
-            val growthFoodScaling = if (city.civ.getHappiness() >= 0) 14 * 2 else 14 / 4
+            val growthFoodScaling = if (city.civ.getHappiness() >= 0) foodBaseWeight * 2 else foodBaseWeight / 4
             yieldStats.food += growthFood * growthFoodScaling
         }
 

--- a/core/src/com/unciv/logic/automation/Automation.kt
+++ b/core/src/com/unciv/logic/automation/Automation.kt
@@ -99,7 +99,7 @@ object Automation {
             // Focus on non-food/growth
             // Reduce excess food focus to prevent Happiness spiral
             if (city.civ.getHappiness() < 1)
-                yieldStats.food += growthFood * (14 / 4 - 1)
+                yieldStats.food += growthFood * (14 / 4)
         } else {
             // NoFocus or Food/Growth Focus.
             // When Happy, EmperorPenguin has run sims comparing weights
@@ -107,7 +107,7 @@ object Automation {
             // but 2 provides more protection against badly configured personalities
             // If unhappy, see above
             val growthFoodScaling = if (city.civ.getHappiness() >= 0) 14 * 2 else 14 / 4
-            yieldStats.food += growthFood * (growthFoodScaling - 1)
+            yieldStats.food += growthFood * growthFoodScaling
         }
 
         if (city.population.population < 10) {

--- a/core/src/com/unciv/logic/city/CityFocus.kt
+++ b/core/src/com/unciv/logic/city/CityFocus.kt
@@ -62,7 +62,7 @@ enum class CityFocus(
         KeyboardBinding.None
 
     open fun getStatMultiplier(stat: Stat) = when (this.stat) {
-        stat -> 3f
+        stat -> 3.05f // on ties, prefer the Focus
         else -> 1f
     }
 

--- a/core/src/com/unciv/models/stats/Stats.kt
+++ b/core/src/com/unciv/models/stats/Stats.kt
@@ -146,10 +146,10 @@ open class Stats(
     /** **Mutating function**
      * Apply weighting for Production Ranking */
     fun applyRankingWeights() {
-        //food *= 14  // Do weighting in rankStatsForCityWork() instead
-        production *= 12
+        food *= 14
+        production *= 12.01f // tie break Production vs gold
         gold *= 6 // 2 gold worth about 1 production
-        science *= 9
+        science *= 9.01f // 4 Science better than 3 Production
         culture *= 8
         happiness *= 10 // base
         faith *= 7

--- a/core/src/com/unciv/models/stats/Stats.kt
+++ b/core/src/com/unciv/models/stats/Stats.kt
@@ -146,7 +146,7 @@ open class Stats(
     /** **Mutating function**
      * Apply weighting for Production Ranking */
     fun applyRankingWeights() {
-        food *= 14
+        //food *= 14  // Do weighting in rankStatsForCityWork() instead
         production *= 12
         gold *= 6 // 2 gold worth about 1 production
         science *= 9


### PR DESCRIPTION
Cleans up the Food weights to make more clear/robust.
All Automation will now only x8 the food required to Not Starve. Rest get base weight.
Avoid Growth evaluates all additional Food beyond needed for starvation as 0. Should allow it to prioritize tiles with just enough Food to get positive
Avoid Growth actually evaluates Food for Starvation as important (used to allow Starvation since no x8 in the logic)
Add in small bonus weights to help with tie-breaking (Production over gold, 4 Science over 3 Production, Focus should take priority)

Notice here with Avoid Growth it picked a 2Food tile with other yields instead of blindly picking  a 4Food tile, which is what the old algorithm would do. So now the Growth Food is closer to 0, and we get better other yields.
![image](https://github.com/user-attachments/assets/447e184c-fe7d-43f0-8f08-a447c3fab922)

Or switch out of perpetual Gold Production, and here we pick a 1Food with a lot of Production.
![image](https://github.com/user-attachments/assets/597faaf3-4fa2-4bd8-abb1-56850560421e)
