### PR TITLE
Add owned tiles countable

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -1973,6 +1973,7 @@ Gain a free [building] [cityFilter] =
 # Countables
 
 Remaining [civFilter] Civilizations = 
+Owned [tileFilter] Tiles = 
 
 # Unused Resources
 

--- a/core/src/com/unciv/models/ruleset/unique/Countables.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Countables.kt
@@ -37,12 +37,8 @@ object Countables {
             return gameInfo.civilizations.filter { !it.isDefeated() }
                 .count { it.matchesFilter(placeholderParameters[0]) }
         
-        if (countable.equalsPlaceholderText("[] Tiles")) {
-            val ownedTiles = gameInfo.tileMap.values.filter {
-                it.getOwner() == civInfo
-            }
-            return ownedTiles.count { it.matchesFilter(placeholderParameters[0]) }
-        }
+        if (countable.equalsPlaceholderText("Owned [] Tiles")) 
+            return civInfo.cities.sumOf { it.getTiles().count { it.matchesFilter(placeholderParameters[0]) } }
 
         if (gameInfo.ruleset.tileResources.containsKey(countable))
             return stateForConditionals.getResourceAmount(countable)

--- a/core/src/com/unciv/models/ruleset/unique/Countables.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Countables.kt
@@ -36,6 +36,13 @@ object Countables {
         if (countable.equalsPlaceholderText("Remaining [] Civilizations"))
             return gameInfo.civilizations.filter { !it.isDefeated() }
                 .count { it.matchesFilter(placeholderParameters[0]) }
+        
+        if (countable.equalsPlaceholderText("[] Tiles")) {
+            val ownedTiles = gameInfo.tileMap.values.filter {
+                it.getOwner() == civInfo
+            }
+            return ownedTiles.count { it.matchesFilter(placeholderParameters[0]) }
+        }
 
         if (gameInfo.ruleset.tileResources.containsKey(countable))
             return stateForConditionals.getResourceAmount(countable)

--- a/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
@@ -76,6 +76,7 @@ enum class UniqueParameterType(
             parameterText.equalsPlaceholderText("[] Cities") -> true
             parameterText.equalsPlaceholderText("[] Units") -> true
             parameterText.equalsPlaceholderText("Remaining [] Civilizations") -> true
+            parameterText.equalsPlaceholderText("Owned [] Tiles") -> true
             else -> super.isKnownValue(parameterText, ruleset)
         }
 

--- a/docs/Modders/Unique-parameters.md
+++ b/docs/Modders/Unique-parameters.md
@@ -313,6 +313,7 @@ Allowed values:
 - `Units`, `[mapUnitFilter] Units`
 - `[buildingFilter] Buildings`
 - `Remaining [civFilter] Civilizations`
+- `[tileFilter] Tiles`
 - Stat name - gets the stat *reserve*, not the amount per turn (can be city stats or civilization stats, depending on where the unique is used)
 - Resource name (can be city stats or civilization stats, depending on where the unique is used)
 


### PR DESCRIPTION
I would like to introduce tile-counting countable. Unlike my previous attempt, it counts only tiles owned by relevant civilization.

If you see some problems, let me know. Constructive feedback welcome.