### PR TITLE
Unhappy Food Ranking Fix

### DIFF
--- a/core/src/com/unciv/logic/automation/Automation.kt
+++ b/core/src/com/unciv/logic/automation/Automation.kt
@@ -98,18 +98,16 @@ object Automation {
         // always picking the Highest Food tile until Not Starving
         yieldStats.food = feedFood * (foodBaseWeight * 8)
         // growthFood is any additional food not required to meet Starvation
-        if (cityAIFocus in CityFocus.zeroFoodFocuses) {
-            // Focus on non-food/growth
-            // Reduce excess food focus to prevent Happiness spiral
-            if (city.civ.getHappiness() < 1)
-                yieldStats.food += growthFood * (foodBaseWeight / 4)
-        } else {
+        // if zeroFoodFocuses, ignore Growth as a metric for ranking
+        if (cityAIFocus !in CityFocus.zeroFoodFocuses) {
             // NoFocus or Food/Growth Focus.
             // When Happy, EmperorPenguin has run sims comparing weights
             // 1.5f is preferred,
             // but 2 provides more protection against badly configured personalities
-            // If unhappy, see above
-            val growthFoodScaling = if (city.civ.getHappiness() >= 0) foodBaseWeight * 2 else foodBaseWeight / 4
+            // Growth is penalized when Unhappy
+            // No Growth if <=-10, 1/4 if <0
+            val growthFoodScaling =
+                if (city.civ.getHappiness() <= -10) 0f else (if (city.civ.getHappiness() < 0) foodBaseWeight / 4 else foodBaseWeight * 2)
             yieldStats.food += growthFood * growthFoodScaling
         }
 

--- a/core/src/com/unciv/logic/automation/Automation.kt
+++ b/core/src/com/unciv/logic/automation/Automation.kt
@@ -105,9 +105,9 @@ object Automation {
             // 1.5f is preferred,
             // but 2 provides more protection against badly configured personalities
             // Growth is penalized when Unhappy
-            // No Growth if <=-10, 1/4 if <0
+            // No Growth if <-10, 1/4 if <0
             val growthFoodScaling =
-                if (city.civ.getHappiness() <= -10) 0f else (if (city.civ.getHappiness() < 0) foodBaseWeight / 4 else foodBaseWeight * 2)
+                if (city.civ.getHappiness() < -10) 0f else (if (city.civ.getHappiness() < 0) foodBaseWeight / 4 else foodBaseWeight * 2)
             yieldStats.food += growthFood * growthFoodScaling
         }
 

--- a/core/src/com/unciv/logic/automation/Automation.kt
+++ b/core/src/com/unciv/logic/automation/Automation.kt
@@ -99,28 +99,30 @@ object Automation {
         // always picking the Highest Food tile until Not Starving
         yieldStats.food = feedFood * (foodBaseWeight * 8)
         // growthFood is any additional food not required to meet Starvation
-        // if zeroFoodFocuses, ignore Growth as a metric for ranking
-        if (cityAIFocus !in CityFocus.zeroFoodFocuses) {
-            // NoFocus or Food/Growth Focus.
+
+        // Growth is penalized when Unhappy, see GlobalUniques.json
+        // No Growth if <-10, 1/4 if <0
+        // Reusing food growth code from CityStats.updateFinalStatList()
+        val growthNullifyingUnique =
+            city.getMatchingUniques(UniqueType.NullifiesGrowth).firstOrNull()
+        if (growthNullifyingUnique == null) { // if growth not nullified
+            var newGrowthFood = growthFood  // running count of growthFood
+            val cityStats = CityStats(city)
+            val growthBonuses = cityStats.getGrowthBonus(growthFood)
+            for (growthBonus in growthBonuses) {
+                newGrowthFood += growthBonus.value.food
+            }
+            if (city.isWeLoveTheKingDayActive() && city.civ.getHappiness() >= 0) {
+                newGrowthFood += growthFood / 4
+            }
+            newGrowthFood = newGrowthFood.coerceAtLeast(0f) // floor to 0 for safety
+
             // When Happy, EmperorPenguin has run sims comparing weights
             // 1.5f is preferred,
             // but 2 provides more protection against badly configured personalities
-            // Growth is penalized when Unhappy
-            // No Growth if <-10, 1/4 if <0
-            // Reusing food growth code from CityStats.updateFinalStatList()
-            val growthNullifyingUnique = city.getMatchingUniques(UniqueType.NullifiesGrowth).firstOrNull()
-            if (growthNullifyingUnique == null) { // if not nullified
-                var newGrowthFood = growthFood  // running count of growthFood
-                val cityStats = CityStats(city)
-                val growthBonuses = cityStats.getGrowthBonus(growthFood)
-                for (growthBonus in growthBonuses) {
-                    newGrowthFood += growthBonus.value.food
-                }
-                if (city.isWeLoveTheKingDayActive() && city.civ.getHappiness() >= 0) {
-                    newGrowthFood += growthFood / 4
-                }
-                yieldStats.food += newGrowthFood * foodBaseWeight * 2
-            }
+            // For non-Food/non-Default, use base weight
+            val baseFocusWeight = if (cityAIFocus in CityFocus.zeroFoodFocuses) 1 else 2
+            yieldStats.food += newGrowthFood * foodBaseWeight * baseFocusWeight
         }
 
         if (city.population.population < 10) {

--- a/core/src/com/unciv/logic/city/CityStats.kt
+++ b/core/src/com/unciv/logic/city/CityStats.kt
@@ -158,7 +158,7 @@ class CityStats(val city: City) {
         return stats
     }
 
-    private fun getGrowthBonus(totalFood: Float): StatMap {
+    fun getGrowthBonus(totalFood: Float): StatMap {
         val growthSources = StatMap()
         val stateForConditionals = StateForConditionals(city.civ, city)
         // "[amount]% growth [cityFilter]"


### PR DESCRIPTION
Aligns the code to automatically take into account the Unhappiness penalty to Growth.
Currently also puts back in Growth for Non-Default/Non-Food Focus. But waiting on Discord Poll results.

Confirmed that we do have the Growth Penalty when Unhappy. It's being set in the Global Uniques
![image](https://github.com/user-attachments/assets/a42667c0-74e9-4cb8-8c5b-31b2b5322e6b)
Screenshot when 5 Growth
![image](https://github.com/user-attachments/assets/b31579ed-1ac0-4546-8446-97ecb50a521e)
And when <-10 Unhappiness, no growth!
![image](https://github.com/user-attachments/assets/17e82e6e-c491-4695-87a1-383b6ee1665a)

Therefore we should rank the tiles appropriately
[Polynesia - 10unhappy.txt](https://github.com/user-attachments/files/17686303/Polynesia.-.10unhappy.txt)
[Autosave-Polynesia-69.txt](https://github.com/user-attachments/files/17686304/Autosave-Polynesia-69.txt)

@EmperorPinguin since they are also messing with rank weights