### PR TITLE
Update TradeEvaluation.kt

### DIFF
--- a/core/src/com/unciv/logic/trade/TradeEvaluation.kt
+++ b/core/src/com/unciv/logic/trade/TradeEvaluation.kt
@@ -247,10 +247,10 @@ class TradeEvaluation {
             TradeOfferType.Luxury_Resource -> {
                 return when {
                     civInfo.getResourceAmount(offer.name) > 1 -> 250 // fair price
-                    civInfo.hasUnique(UniqueType.RetainHappinessFromLuxury) -> // If we retain 50% happiness, value at 375
-                        750 - (civInfo.getMatchingUniques(UniqueType.RetainHappinessFromLuxury)
-                            .first().params[0].toPercent() * 250).toInt()
-                    else -> 500 // you want to take away our last lux of this type?!
+                    civInfo.hasUnique(UniqueType.RetainHappinessFromLuxury) -> // If we retain 100% happiness, value it as a duplicate lux
+                        600 - (civInfo.getMatchingUniques(UniqueType.RetainHappinessFromLuxury)
+                            .first().params[0].toPercent() * 350).toInt()
+                    else -> 600 // you want to take away our last lux of this type?!
                 }
             }
             TradeOfferType.Strategic_Resource -> {


### PR DESCRIPTION
* The value of a last copy of unique luxury is valued at 750 in line 251 in TradeEvaluation, but at 500 in line 253, which is it supposed to be? I decided to set them both to an intermediate value of 600.