### PR TITLE
Update Automation.kt

### DIFF
--- a/core/src/com/unciv/logic/automation/Automation.kt
+++ b/core/src/com/unciv/logic/automation/Automation.kt
@@ -105,12 +105,10 @@ object Automation {
                 yieldStats.food += growthFood * (foodBaseWeight / 4)
         } else {
             // NoFocus or Food/Growth Focus.
-            // When Happy, EmperorPenguin has run sims comparing weights
-            // 1.5f is preferred,
-            // but 2 provides more protection against badly configured personalities
-            // If unhappy, see above
-            val growthFoodScaling = if (city.civ.getHappiness() >= 0) foodBaseWeight * 2 else foodBaseWeight / 4
-            yieldStats.food += growthFood * growthFoodScaling
+            // When Happy, 2 production is better than 1 growth,
+            // but setting such by default worsens AI civ citizen assignment,
+            // probably due to badly configured personalities not properly weighing food vs non-food yields
+            val growthFoodScaling = if (city.civ.getHappiness() > 0) foodBaseWeight * 2 else if (city.civ.getHappiness() < 8) foodBaseWeight * 0 else foodBaseWeight / 4
         }
 
         if (city.population.population < 10) {

--- a/core/src/com/unciv/logic/automation/Automation.kt
+++ b/core/src/com/unciv/logic/automation/Automation.kt
@@ -109,6 +109,7 @@ object Automation {
             // but setting such by default worsens AI civ citizen assignment,
             // probably due to badly configured personalities not properly weighing food vs non-food yields
             val growthFoodScaling = if (city.civ.getHappiness() > 0) foodBaseWeight * 2 else if (city.civ.getHappiness() < 8) foodBaseWeight * 0 else foodBaseWeight / 4
+            yieldStats.food += growthFood * growthFoodScaling
         }
 
         if (city.population.population < 10) {

--- a/core/src/com/unciv/logic/automation/Automation.kt
+++ b/core/src/com/unciv/logic/automation/Automation.kt
@@ -108,7 +108,9 @@ object Automation {
             // When Happy, 2 production is better than 1 growth,
             // but setting such by default worsens AI civ citizen assignment,
             // probably due to badly configured personalities not properly weighing food vs non-food yields
-            val growthFoodScaling = if (city.civ.getHappiness() > 0) foodBaseWeight * 2 else if (city.civ.getHappiness() < 8) foodBaseWeight * 0 else foodBaseWeight / 4
+            val growthFoodScaling = if (city.civ.getHappiness() > 0) foodBaseWeight * 2 
+                else if (city.civ.getHappiness() < 8) foodBaseWeight * 0 
+                else foodBaseWeight / 4
             yieldStats.food += growthFood * growthFoodScaling
         }
 


### PR DESCRIPTION
* Updates AI citizen assignement to take into account a 1-happiness margin (instead of growing into unhappiness asap), and attempt preventing growth into -11 happiness (treshold set at -9 instead of -10, in case we find a pop ruin or something).