### PR TITLE
Update ConstructionAutomation.kt

### DIFF
--- a/core/src/com/unciv/logic/automation/city/ConstructionAutomation.kt
+++ b/core/src/com/unciv/logic/automation/city/ConstructionAutomation.kt
@@ -381,5 +381,11 @@ class ConstructionAutomation(val cityConstructions: CityConstructions) {
                 buildingStats[Stat.Food] += foodGain * relativeAmount // Essentialy gives us the food per turn this unique saves us
             }
         }
+        
+        for (unique in building.getMatchingUniques(UniqueType.StatsFromTiles)) {
+            val statType = Stat.Food //placeholder
+            val extraTileYields = 1f //placeholder
+            buildingStats[statType] += extraTileYields
+        }
     }
 }


### PR DESCRIPTION
The AI currently does not evaluate tile yields from buildings. For granaries, stables, etc. this is not much of a problem as they're also valued in other ways, but the AI not building lighthouses is pretty bad.

Merging this PR simply as-is will allow the AI to build lighthouses again, but it would be better to extract the type and amount of stats from the unique, and multiply this by the number of respective tiles the AI is currently working in the city. How does one do so?