### PR TITLE
Add quote to Great Firewall 

### DIFF
--- a/docs/Modders/Unique-parameters.md
+++ b/docs/Modders/Unique-parameters.md
@@ -313,7 +313,7 @@ Allowed values:
 - `Units`, `[mapUnitFilter] Units`
 - `[buildingFilter] Buildings`
 - `Remaining [civFilter] Civilizations`
-- `[tileFilter] Tiles`
+- `Owned [tileFilter] Tiles`
 - Stat name - gets the stat *reserve*, not the amount per turn (can be city stats or civilization stats, depending on where the unique is used)
 - Resource name (can be city stats or civilization stats, depending on where the unique is used)
 


### PR DESCRIPTION
This adds to the Great Firewall the quote that Civ V uses, so that the wonder won't look so sad without a quote on its splash page.