### PR TITLE
Update TradeEvaluation.kt

### DIFF
--- a/core/src/com/unciv/logic/trade/TradeEvaluation.kt
+++ b/core/src/com/unciv/logic/trade/TradeEvaluation.kt
@@ -189,7 +189,7 @@ class TradeEvaluation {
                     return 0 // we can't really afford to go into negative happiness because of buying a city
                 val sumOfPop = city.population.population
                 val sumOfBuildings = city.cityConstructions.getBuiltBuildings().count()
-                return ((sumOfPop * 4 + sumOfBuildings * 1 + 4 + surrounded) * 100).coerceAtLeast(1000)
+                return ((sumOfPop * 4 + sumOfBuildings * 1 + 4 + surrounded) * 100)
             }
             TradeOfferType.Agreement -> {
                 if (offer.name == Constants.openBorders) return 100

--- a/core/src/com/unciv/logic/trade/TradeEvaluation.kt
+++ b/core/src/com/unciv/logic/trade/TradeEvaluation.kt
@@ -189,7 +189,7 @@ class TradeEvaluation {
                     return 0 // we can't really afford to go into negative happiness because of buying a city
                 val sumOfPop = city.population.population
                 val sumOfBuildings = city.cityConstructions.getBuiltBuildings().count()
-                return ((sumOfPop * 4 + sumOfBuildings * 1 + 4 + surrounded) * 100)
+                return (sumOfPop * 4 + sumOfBuildings * 1 + 4 + surrounded) * 100
             }
             TradeOfferType.Agreement -> {
                 if (offer.name == Constants.openBorders) return 100

--- a/core/src/com/unciv/logic/trade/TradeEvaluation.kt
+++ b/core/src/com/unciv/logic/trade/TradeEvaluation.kt
@@ -184,12 +184,12 @@ class TradeEvaluation {
             TradeOfferType.City -> {
                 val city = tradePartner.cities.firstOrNull { it.id == offer.name }
                     ?: throw Exception("Got an offer for city id "+offer.name+" which does't seem to exist for this civ!")
-                val stats = city.cityStats.currentCityStats
                 val surrounded: Int = surroundedByOurCities(city, civInfo)
                 if (civInfo.getHappiness() + city.cityStats.happinessList.values.sum() < 0)
                     return 0 // we can't really afford to go into negative happiness because of buying a city
-                val sumOfStats = stats.culture + stats.gold + stats.science + stats.production + stats.happiness + stats.food + surrounded
-                return sumOfStats.toInt() * 100
+                val sumOfPop = city.population.population
+                val sumOfBuildings = city.cityConstructions.getBuiltBuildings().count()
+                return ((sumOfPop * 4 + sumOfBuildings * 1 + 4 + surrounded) * 100).coerceAtLeast(1000)
             }
             TradeOfferType.Agreement -> {
                 if (offer.name == Constants.openBorders) return 100
@@ -308,10 +308,9 @@ class TradeEvaluation {
                     ?: throw Exception("Got an offer to sell city id " + offer.name + " which does't seem to exist for this civ!")
 
                 val distanceBonus = distanceCityTradeModifier(civInfo, city)
-                val stats = city.cityStats.currentCityStats
-                val sumOfStats =
-                    stats.culture + stats.gold + stats.science + stats.production + stats.happiness + stats.food + distanceBonus
-                return (sumOfStats.toInt() * 100).coerceAtLeast(1000)
+                val sumOfPop = city.population.population
+                val sumOfBuildings = city.cityConstructions.getBuiltBuildings().count()
+                return ((sumOfPop * 4 + sumOfBuildings * 1 + 4 + distanceBonus) * 100).coerceAtLeast(1000)
             }
             TradeOfferType.Agreement -> {
                 if (offer.name == Constants.openBorders) {


### PR DESCRIPTION
Currently the AI evaluates the city buy/sell cost according to the stat output of the city. While this is sensible metric to assess the utility of the city, it can change quickly due to citizen assignment, trade route status, policies, happiness status etc., which leads to inconsistent (exploitable) evaluation as reported by https://github.com/yairm210/Unciv/issues/12458. Using metrics that can't easily change between turns such as Population or number of constructed buildings might be a better way to evaluate city buy/sell value. 

To try to keep values consistent with the previous approach: a population contributes approximately (5 yield from tile + 1 gold from trade route + 1 science - 2 food -1 happiness) = +4 stats, and a buildings such as an (amphi)theater contributes approximately (3 yield - 2 gold maintenance) = +1 stat. City center provides +4 stats.

What's the purpose of the distanceCityTradeModifier? It returns 0 in practically all games it seems. and cities closer to capital are more important (easier to connect & protect) than cities far away.