### PR TITLE
Cache state for units, civs, and cities

### DIFF
--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -39,6 +39,7 @@ import com.unciv.models.ruleset.RulesetCache
 import com.unciv.models.ruleset.Speed
 import com.unciv.models.ruleset.nation.Difficulty
 import com.unciv.models.ruleset.unique.LocalUniqueCache
+import com.unciv.models.ruleset.unique.StateForConditionals
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.translations.tr
 import com.unciv.ui.audio.MusicMood
@@ -287,6 +288,7 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
         civilizations.add(it)
         it.gameInfo = this
         it.setNationTransient()
+        it.cache.updateState()
         it.cache.updateViewableTiles()
         it.setTransients()
     }
@@ -646,7 +648,10 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
         // This needs to go before tileMap.setTransients, as units need to access
         // the nation of their civilization when setting transients
         for (civInfo in civilizations) civInfo.gameInfo = this
-        for (civInfo in civilizations) civInfo.setNationTransient()
+        for (civInfo in civilizations) {
+            civInfo.setNationTransient()
+            civInfo.cache.updateState()
+        }
         // must be done before updating tileMap, since unit uniques depend on civ uniques depend on allied city-state uniques depend on diplomacy
         for (civInfo in civilizations) {
             for (diplomacyManager in civInfo.diplomacy.values) {

--- a/core/src/com/unciv/logic/GameStarter.kt
+++ b/core/src/com/unciv/logic/GameStarter.kt
@@ -429,7 +429,7 @@ object GameStarter {
             //Trigger any global or nation uniques that should triggered.
             //We may need the starting location for some uniques, which is why we're doing it now
             val startingTriggers = (ruleset.globalUniques.uniqueObjects + civ.nation.uniqueObjects)
-            for (unique in startingTriggers.filter { !it.hasTriggerConditional() && it.conditionalsApply(civ) })
+            for (unique in startingTriggers.filter { !it.hasTriggerConditional() && it.conditionalsApply(civ.state) })
                 UniqueTriggerActivation.triggerUnique(unique, civ, tile = startingLocation)
         }
     }

--- a/core/src/com/unciv/logic/automation/Automation.kt
+++ b/core/src/com/unciv/logic/automation/Automation.kt
@@ -328,8 +328,8 @@ object Automation {
             return true
 
         val requiredResources = if (construction is BaseUnit)
-            construction.getResourceRequirementsPerTurn(StateForConditionals(civInfo))
-        else construction.getResourceRequirementsPerTurn(StateForConditionals(civInfo, cityInfo))
+            construction.getResourceRequirementsPerTurn(civInfo.state)
+        else construction.getResourceRequirementsPerTurn(cityInfo?.state ?: civInfo.state)
         // Does it even require any resources?
         if (requiredResources.isEmpty())
             return true
@@ -349,8 +349,7 @@ object Automation {
                 if (otherConstruction is Building)
                     futureForBuildings += otherConstruction.getResourceRequirementsPerTurn(city.state)[resource]
                 else
-                    futureForUnits += otherConstruction.getResourceRequirementsPerTurn(
-                        StateForConditionals(civInfo))[resource]
+                    futureForUnits += otherConstruction.getResourceRequirementsPerTurn(civInfo.state)[resource]
             }
 
             // Make sure we have some for space

--- a/core/src/com/unciv/logic/automation/Automation.kt
+++ b/core/src/com/unciv/logic/automation/Automation.kt
@@ -347,8 +347,7 @@ object Automation {
             for (city in civInfo.cities) {
                 val otherConstruction = city.cityConstructions.getCurrentConstruction()
                 if (otherConstruction is Building)
-                    futureForBuildings += otherConstruction.getResourceRequirementsPerTurn(
-                        StateForConditionals(civInfo, city))[resource]
+                    futureForBuildings += otherConstruction.getResourceRequirementsPerTurn(city.state)[resource]
                 else
                     futureForUnits += otherConstruction.getResourceRequirementsPerTurn(
                         StateForConditionals(civInfo))[resource]

--- a/core/src/com/unciv/logic/automation/city/ConstructionAutomation.kt
+++ b/core/src/com/unciv/logic/automation/city/ConstructionAutomation.kt
@@ -20,7 +20,6 @@ import com.unciv.models.ruleset.PerpetualConstruction
 import com.unciv.models.ruleset.Victory
 import com.unciv.models.ruleset.nation.PersonalityValue
 import com.unciv.models.ruleset.unique.LocalUniqueCache
-import com.unciv.models.ruleset.unique.StateForConditionals
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.ruleset.unit.BaseUnit
 import com.unciv.models.stats.Stat
@@ -34,12 +33,16 @@ class ConstructionAutomation(val cityConstructions: CityConstructions) {
     private val city = cityConstructions.city
     private val civInfo = city.civ
 
+    private val relativeCostEffectiveness = ArrayList<ConstructionChoice>()
+    private val cityState = city.state
+    private val cityStats = city.cityStats
+
     private val personality = civInfo.getPersonality()
 
-    private val constructionsToAvoid = personality.getMatchingUniques(UniqueType.WillNotBuild, StateForConditionals(city))
+    private val constructionsToAvoid = personality.getMatchingUniques(UniqueType.WillNotBuild, cityState)
         .map{ it.params[0] }
     private fun shouldAvoidConstruction (construction: IConstruction): Boolean {
-        val stateForConditionals = StateForConditionals(city)
+        val stateForConditionals = cityState
         for (toAvoid in constructionsToAvoid) {
             if (construction is Building && construction.matchesFilter(toAvoid, stateForConditionals))
                 return true
@@ -86,10 +89,6 @@ class ConstructionAutomation(val cityConstructions: CityConstructions) {
 
     private val averageProduction = civInfo.cities.map { it.cityStats.currentCityStats.production }.average()
     private val cityIsOverAverageProduction = city.cityStats.currentCityStats.production >= averageProduction
-
-    private val relativeCostEffectiveness = ArrayList<ConstructionChoice>()
-    private val cityState = StateForConditionals(city)
-    private val cityStats = city.cityStats
 
     private data class ConstructionChoice(val choice: String, var choiceModifier: Float,
                                           val remainingWork: Int, val production: Int)

--- a/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
@@ -402,7 +402,7 @@ object NextTurnAutomation {
                     continue
                 val buildingToSell = civInfo.gameInfo.ruleset.buildings.values.filter {
                         city.cityConstructions.isBuilt(it.name)
-                        && it.requiredResources(StateForConditionals(civInfo, city)).contains(resource)
+                        && it.requiredResources(city.state).contains(resource)
                         && it.isSellable()
                         && !civInfo.civConstructions.hasFreeBuilding(city, it) }
                     .randomOrNull()

--- a/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
@@ -24,7 +24,6 @@ import com.unciv.models.ruleset.Victory
 import com.unciv.models.ruleset.nation.PersonalityValue
 import com.unciv.models.ruleset.tech.Technology
 import com.unciv.models.ruleset.tile.ResourceType
-import com.unciv.models.ruleset.unique.StateForConditionals
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.ruleset.unit.BaseUnit
 import com.unciv.models.stats.Stat
@@ -262,7 +261,7 @@ object NextTurnAutomation {
             return researchableTechs.toSortedMap().values.toList()
         }
 
-        val stateForConditionals = StateForConditionals(civInfo)
+        val stateForConditionals = civInfo.state
         while(civInfo.tech.freeTechs > 0) {
             val costs = getGroupedResearchableTechs()
             if (costs.isEmpty()) return
@@ -351,7 +350,7 @@ object NextTurnAutomation {
             val policyToAdopt: Policy =
                 if (civInfo.policies.isAdoptable(targetBranch)) targetBranch
                 else targetBranch.policies.filter { civInfo.policies.isAdoptable(it) }
-                    .randomWeighted { it.getWeightForAiDecision(StateForConditionals(civInfo)) }
+                    .randomWeighted { it.getWeightForAiDecision(civInfo.state) }
 
             civInfo.policies.adopt(policyToAdopt)
         }
@@ -538,8 +537,8 @@ object NextTurnAutomation {
             }) return
         val settlerUnits = civInfo.gameInfo.ruleset.units.values
                 .filter { it.isCityFounder() && it.isBuildable(civInfo) &&
-                    personality.getMatchingUniques(UniqueType.WillNotBuild, StateForConditionals(civInfo))
-                        .none { unique -> it.matchesFilter(unique.params[0], StateForConditionals(civInfo)) } }
+                    personality.getMatchingUniques(UniqueType.WillNotBuild, civInfo.state)
+                        .none { unique -> it.matchesFilter(unique.params[0], civInfo.state) } }
         if (settlerUnits.isEmpty()) return
 
         if (civInfo.units.getCivUnits().count { it.isMilitary() } < civInfo.cities.size) return // We need someone to defend them first

--- a/core/src/com/unciv/logic/automation/civilization/ReligionAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/ReligionAutomation.kt
@@ -477,7 +477,7 @@ object ReligionAutomation {
                     && !additionalBeliefsToExclude.contains(it)
                     && civInfo.religionManager.getReligionWithBelief(it) == null
                     && it.getMatchingUniques(UniqueType.OnlyAvailable, StateForConditionals.IgnoreConditionals)
-                    .none { unique -> !unique.conditionalsApply(civInfo) }
+                    .none { unique -> !unique.conditionalsApply(civInfo.state) }
             }
             .maxByOrNull { rateBelief(civInfo, it) }
     }

--- a/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
@@ -136,7 +136,7 @@ object UnitAutomation {
         if (upgradeUnits.none()) return false // for resource reasons, usually
         val upgradedUnit = upgradeUnits.minBy { it.cost }
 
-        if (upgradedUnit.getResourceRequirementsPerTurn(StateForConditionals(unit.civ, unit = unit)).keys.any { !unit.requiresResource(it) }) {
+        if (upgradedUnit.getResourceRequirementsPerTurn(unit.cache.state).keys.any { !unit.requiresResource(it) }) {
             // The upgrade requires new resource types, so check if we are willing to invest them
             if (!Automation.allowSpendingResource(unit.civ, upgradedUnit)) return false
         }
@@ -157,10 +157,10 @@ object UnitAutomation {
             if (!unit.civ.tech.isResearched(baseUnit))
                 return true
             return baseUnit.getMatchingUniques(UniqueType.OnlyAvailable, StateForConditionals.IgnoreConditionals)
-                .any { !it.conditionalsApply(StateForConditionals(unit.civ, unit = unit)) }
+                .any { !it.conditionalsApply(unit.cache.state) }
         }
 
-        return unit.baseUnit.getRulesetUpgradeUnits(StateForConditionals(unit.civ, unit = unit))
+        return unit.baseUnit.getRulesetUpgradeUnits(unit.cache.state)
             .map { unit.civ.getEquivalentUnit(it) }
             .filter { !isInvalidUpgradeDestination(it) && unit.upgrade.canUpgrade(it) }
     }
@@ -184,7 +184,7 @@ object UnitAutomation {
                 .filterNot { it.hasUnique(UniqueType.SkipPromotion) }
             if (availablePromotions.none()) break
             val freePromotions = availablePromotions.filter { it.hasUnique(UniqueType.FreePromotion) }.toList()
-            val stateForConditionals = StateForConditionals(unit)
+            val stateForConditionals = unit.cache.state
             
             val chosenPromotion = if (freePromotions.isNotEmpty()) freePromotions.randomWeighted { it.getWeightForAiDecision(stateForConditionals) }
             else availablePromotions.toList().randomWeighted { it.getWeightForAiDecision(stateForConditionals) }

--- a/core/src/com/unciv/logic/battle/BattleUnitCapture.kt
+++ b/core/src/com/unciv/logic/battle/BattleUnitCapture.kt
@@ -215,6 +215,7 @@ object BattleUnitCapture {
         // This is so that future checks which check if a unit has been captured are caught give the right answer
         //  For example, in postBattleMoveToAttackedTile
         capturedUnit.civ = capturingCiv
+        capturedUnit.cache.state = StateForConditionals(capturedUnit)
 
         val workerTypeUnit = capturingCiv.gameInfo.ruleset.units.values
             .firstOrNull { it.isCivilian() && it.getMatchingUniques(UniqueType.BuildImprovements)

--- a/core/src/com/unciv/logic/city/CityResources.kt
+++ b/core/src/com/unciv/logic/city/CityResources.kt
@@ -54,7 +54,7 @@ object CityResources {
     }
 
     private fun addCityResourcesGeneratedFromUniqueBuildings(city: City, cityResources: ResourceSupplyList, resourceModifer: HashMap<String, Float>) {
-        for (unique in city.getMatchingUniques(UniqueType.ProvidesResources, StateForConditionals(city), false)) { // E.G "Provides [1] [Iron]"
+        for (unique in city.getMatchingUniques(UniqueType.ProvidesResources, city.state, false)) { // E.G "Provides [1] [Iron]"
             val resource = city.getRuleset().tileResources[unique.params[1]]
                 ?: continue
             cityResources.add(
@@ -108,13 +108,13 @@ object CityResources {
         for (building in city.cityConstructions.getBuiltBuildings()) {
             // Free buildings cost no resources
             if (building.name in freeBuildings) continue
-            cityResources.subtractResourceRequirements(building.getResourceRequirementsPerTurn(StateForConditionals(city)), city.getRuleset(), "Buildings")
+            cityResources.subtractResourceRequirements(building.getResourceRequirementsPerTurn(city.state), city.getRuleset(), "Buildings")
         }
     }
 
     private fun getCityResourcesFromCiv(city: City, cityResources: ResourceSupplyList, resourceModifers: HashMap<String, Float>) {
         // This includes the uniques from buildings, from this and all other cities
-        for (unique in city.getMatchingUniques(UniqueType.ProvidesResources, StateForConditionals(city))) { // E.G "Provides [1] [Iron]"
+        for (unique in city.getMatchingUniques(UniqueType.ProvidesResources, city.state)) { // E.G "Provides [1] [Iron]"
             val resource = city.getRuleset().tileResources[unique.params[1]]
                 ?: continue
             cityResources.add(

--- a/core/src/com/unciv/logic/city/CityStats.kt
+++ b/core/src/com/unciv/logic/city/CityStats.kt
@@ -6,7 +6,6 @@ import com.unciv.models.ruleset.Building
 import com.unciv.models.ruleset.IConstruction
 import com.unciv.models.ruleset.INonPerpetualConstruction
 import com.unciv.models.ruleset.unique.LocalUniqueCache
-import com.unciv.models.ruleset.unique.StateForConditionals
 import com.unciv.models.ruleset.unique.Unique
 import com.unciv.models.ruleset.unique.UniqueTarget
 import com.unciv.models.ruleset.unique.UniqueType
@@ -160,7 +159,7 @@ class CityStats(val city: City) {
 
     private fun getGrowthBonus(totalFood: Float): StatMap {
         val growthSources = StatMap()
-        val stateForConditionals = StateForConditionals(city.civ, city)
+        val stateForConditionals = city.state
         // "[amount]% growth [cityFilter]"
         for (unique in city.getMatchingUniques(UniqueType.GrowthPercentBonus, stateForConditionals = stateForConditionals)) {
             if (!city.matchesFilter(unique.params[1])) continue
@@ -304,7 +303,7 @@ class CityStats(val city: City) {
     }
 
     private fun constructionMatchesFilter(construction: IConstruction, filter: String): Boolean {
-        val state = StateForConditionals(city)
+        val state = city.state
         if (construction is Building) return construction.matchesFilter(filter, state)
         if (construction is BaseUnit) return construction.matchesFilter(filter, state)
         return false

--- a/core/src/com/unciv/logic/city/GreatPersonPointsBreakdown.kt
+++ b/core/src/com/unciv/logic/city/GreatPersonPointsBreakdown.kt
@@ -3,7 +3,6 @@ package com.unciv.logic.city
 import com.unciv.logic.civilization.diplomacy.DiplomacyFlags
 import com.unciv.models.Counter
 import com.unciv.models.ruleset.Ruleset
-import com.unciv.models.ruleset.unique.StateForConditionals
 import com.unciv.models.ruleset.unique.Unique
 import com.unciv.models.ruleset.unique.UniqueType
 
@@ -116,7 +115,7 @@ class GreatPersonPointsBreakdown private constructor(private val ruleset: Rulese
         }
 
         // And last, the GPP-type-specific GreatPersonEarnedFaster Unique
-        val stateForConditionals = StateForConditionals(city)
+        val stateForConditionals = city.state
         for (unique in city.civ.getMatchingUniques(UniqueType.GreatPersonEarnedFaster, stateForConditionals)) {
             val gppName = unique.params[0]
             if (gppName !in allNames) continue // No sense applying a percentage without base points

--- a/core/src/com/unciv/logic/city/managers/CityConquestFunctions.kt
+++ b/core/src/com/unciv/logic/city/managers/CityConquestFunctions.kt
@@ -14,6 +14,7 @@ import com.unciv.logic.civilization.diplomacy.DiplomaticStatus
 import com.unciv.logic.trade.TradeLogic
 import com.unciv.logic.trade.TradeOffer
 import com.unciv.logic.trade.TradeOfferType
+import com.unciv.models.ruleset.unique.StateForConditionals
 import com.unciv.models.ruleset.unique.UniqueType
 import kotlin.math.max
 import kotlin.math.min
@@ -255,6 +256,7 @@ class CityConquestFunctions(val city: City) {
         oldCiv.cities = oldCiv.cities.toMutableList().apply { remove(city) }
         newCiv.cities = newCiv.cities.toMutableList().apply { add(city) }
         city.civ = newCiv
+        city.state = StateForConditionals(city)
         city.hasJustBeenConquered = false
         city.turnAcquired = city.civ.gameInfo.turns
         city.previousOwner = oldCiv.civName

--- a/core/src/com/unciv/logic/civilization/CivConstructions.kt
+++ b/core/src/com/unciv/logic/civilization/CivConstructions.kt
@@ -155,7 +155,7 @@ class CivConstructions : IsPartOfGameInfoSerialization {
         for (city in civInfo.cities) {
             val freeBuildingsFromCity = city.getLocalMatchingUniques(UniqueType.GainFreeBuildings, StateForConditionals.IgnoreConditionals)
             val freeBuildingUniques = (freeBuildingsFromCiv + freeBuildingsFromCity)
-                .filter { city.matchesFilter(it.params[1]) && it.conditionalsApply(StateForConditionals(city.civ, city))
+                .filter { city.matchesFilter(it.params[1]) && it.conditionalsApply(city.state)
                     && !it.hasTriggerConditional() }
             for (unique in freeBuildingUniques) {
                 val freeBuilding = city.civ.getEquivalentBuilding(unique.params[0])

--- a/core/src/com/unciv/logic/civilization/Civilization.kt
+++ b/core/src/com/unciv/logic/civilization/Civilization.kt
@@ -87,7 +87,7 @@ class Civilization : IsPartOfGameInfoSerialization {
     lateinit var nation: Nation
     
     @Transient
-    val state = StateForConditionals(this)
+    var state = StateForConditionals.EmptyState
 
     @Transient
     val units = UnitManager(this)

--- a/core/src/com/unciv/logic/civilization/diplomacy/CityStateFunctions.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/CityStateFunctions.kt
@@ -153,7 +153,7 @@ class CityStateFunctions(val civInfo: Civilization) {
                 city.cityConstructions.getConstructableUnits()
                 .filter { !it.isCivilian() && it.isLandUnit && it.uniqueTo == null }
                 // Does not make us go over any resource quota
-                .filter { it.getResourceRequirementsPerTurn(StateForConditionals(civInfo = receivingCiv)).none {
+                .filter { it.getResourceRequirementsPerTurn(receivingCiv.state).none {
                     it.value > 0 && receivingCiv.getResourceAmount(it.key) < it.value
                 } }
                 .toList().randomOrNull()

--- a/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyTurnManager.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyTurnManager.kt
@@ -341,7 +341,7 @@ object DiplomacyTurnManager {
 
         val provideMilitaryUnitUniques = civInfo.cityStateFunctions
             .getCityStateBonuses(otherCiv().cityStateType, relationshipIgnoreAfraid(), UniqueType.CityStateMilitaryUnits)
-            .filter { it.conditionalsApply(civInfo) }.toList()
+            .filter { it.conditionalsApply(civInfo.state) }.toList()
         if (provideMilitaryUnitUniques.isEmpty()) removeFlag(DiplomacyFlags.ProvideMilitaryUnit)
 
         for (unique in provideMilitaryUnitUniques) {

--- a/core/src/com/unciv/logic/civilization/managers/PolicyManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/PolicyManager.kt
@@ -47,7 +47,7 @@ class PolicyManager : IsPartOfGameInfoSerialization {
                 val victoryPriority = civInfo.getPreferredVictoryTypes().sumOf { branch.priorities[it] ?: 0}
                 val personalityPriority = civInfo.getPersonality().priorities[branch.name] ?: 0
                 val branchPriority = (victoryPriority + personalityPriority) * 
-                        branch.getWeightForAiDecision(StateForConditionals(civInfo))
+                        branch.getWeightForAiDecision(civInfo.state)
                 value[branch] = branchPriority.roundToInt()
             }
             return value
@@ -186,8 +186,8 @@ class PolicyManager : IsPartOfGameInfoSerialization {
         if (!getAdoptedPolicies().containsAll(policy.requires!!)) return false
         if (checkEra && civInfo.gameInfo.ruleset.eras[policy.branch.era]!!.eraNumber > civInfo.getEraNumber()) return false
         if (policy.getMatchingUniques(UniqueType.OnlyAvailable, StateForConditionals.IgnoreConditionals)
-                .any { !it.conditionalsApply(civInfo) }) return false
-        if (policy.hasUnique(UniqueType.Unavailable, StateForConditionals(civInfo))) return false
+                .any { !it.conditionalsApply(civInfo.state) }) return false
+        if (policy.hasUnique(UniqueType.Unavailable, civInfo.state)) return false
         return true
     }
 
@@ -231,7 +231,7 @@ class PolicyManager : IsPartOfGameInfoSerialization {
         //todo Can this be mapped downstream to a PolicyAction:NotificationAction?
         val triggerNotificationText = "due to adopting [${policy.name}]"
         for (unique in policy.uniqueObjects)
-            if (!unique.hasTriggerConditional() && unique.conditionalsApply(StateForConditionals(civInfo)))
+            if (!unique.hasTriggerConditional() && unique.conditionalsApply(civInfo.state))
                 UniqueTriggerActivation.triggerUnique(unique, civInfo, triggerNotificationText = triggerNotificationText)
 
         for (unique in civInfo.getTriggeredUniques(UniqueType.TriggerUponAdoptingPolicyOrBelief) {it.params[0] == policy.name})

--- a/core/src/com/unciv/logic/civilization/managers/ReligionManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/ReligionManager.kt
@@ -9,7 +9,6 @@ import com.unciv.models.Counter
 import com.unciv.models.Religion
 import com.unciv.models.ruleset.Belief
 import com.unciv.models.ruleset.BeliefType
-import com.unciv.models.ruleset.unique.StateForConditionals
 import com.unciv.models.ruleset.unique.UniqueTriggerActivation
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.ruleset.unit.BaseUnit
@@ -403,7 +402,7 @@ class ReligionManager : IsPartOfGameInfoSerialization {
                         triggerNotificationText = "due to adopting [${belief.name}]")
 
         for (belief in beliefs)
-            for (unique in belief.uniqueObjects.filter { !it.hasTriggerConditional() && it.conditionalsApply(StateForConditionals(civInfo)) })
+            for (unique in belief.uniqueObjects.filter { !it.hasTriggerConditional() && it.conditionalsApply(civInfo.state) })
                 UniqueTriggerActivation.triggerUnique(unique, civInfo)
 
         civInfo.updateStatsForNextTurn()  // a belief can have an immediate effect on stats

--- a/core/src/com/unciv/logic/civilization/managers/TechManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/TechManager.kt
@@ -165,9 +165,9 @@ class TechManager : IsPartOfGameInfoSerialization {
     fun isObsolete(unit: BaseUnit): Boolean = unit.techsThatObsoleteThis().any{ obsoleteTech -> isResearched(obsoleteTech) }
 
     fun isUnresearchable(tech: Technology): Boolean {
-        if (tech.getMatchingUniques(UniqueType.OnlyAvailable, StateForConditionals.IgnoreConditionals).any { !it.conditionalsApply(civInfo) })
+        if (tech.getMatchingUniques(UniqueType.OnlyAvailable, StateForConditionals.IgnoreConditionals).any { !it.conditionalsApply(civInfo.state) })
             return true
-        if (tech.hasUnique(UniqueType.Unavailable, StateForConditionals(civInfo))) return true
+        if (tech.hasUnique(UniqueType.Unavailable, civInfo.state)) return true
         return false
     }
 
@@ -313,10 +313,10 @@ class TechManager : IsPartOfGameInfoSerialization {
 
         val triggerNotificationText = "due to researching [$techName]"
         for (unique in newTech.uniqueObjects)
-            if (!unique.hasTriggerConditional() && unique.conditionalsApply(StateForConditionals(civInfo)))
+            if (!unique.hasTriggerConditional() && unique.conditionalsApply(civInfo.state))
                 UniqueTriggerActivation.triggerUnique(unique, civInfo, triggerNotificationText = triggerNotificationText)
 
-        for (unique in civInfo.getTriggeredUniques(UniqueType.TriggerUponResearch) { newTech.matchesFilter(it.params[0], StateForConditionals(civInfo)) })
+        for (unique in civInfo.getTriggeredUniques(UniqueType.TriggerUponResearch) { newTech.matchesFilter(it.params[0], civInfo.state) })
             UniqueTriggerActivation.triggerUnique(unique, civInfo, triggerNotificationText = triggerNotificationText)
 
 
@@ -453,7 +453,7 @@ class TechManager : IsPartOfGameInfoSerialization {
 
             for (era in erasPassed)
                 for (unique in era.uniqueObjects)
-                    if (!unique.hasTriggerConditional() && unique.conditionalsApply(StateForConditionals(civInfo)))
+                    if (!unique.hasTriggerConditional() && unique.conditionalsApply(civInfo.state))
                         UniqueTriggerActivation.triggerUnique(
                             unique,
                             civInfo,

--- a/core/src/com/unciv/logic/civilization/managers/TurnManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/TurnManager.kt
@@ -15,7 +15,6 @@ import com.unciv.logic.civilization.diplomacy.DiplomacyTurnManager.nextTurn
 import com.unciv.logic.map.mapunit.UnitTurnManager
 import com.unciv.logic.map.tile.Tile
 import com.unciv.logic.trade.TradeEvaluation
-import com.unciv.models.ruleset.unique.StateForConditionals
 import com.unciv.models.ruleset.unique.UniqueTriggerActivation
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.ruleset.unique.endTurn
@@ -231,7 +230,7 @@ class TurnManager(val civInfo: Civilization) {
         if (UncivGame.Current.settings.citiesAutoBombardAtEndOfTurn)
             NextTurnAutomation.automateCityBombardment(civInfo) // Bombard with all cities that haven't, maybe you missed one
 
-        for (unique in civInfo.getTriggeredUniques(UniqueType.TriggerUponTurnEnd, StateForConditionals(civInfo)))
+        for (unique in civInfo.getTriggeredUniques(UniqueType.TriggerUponTurnEnd, civInfo.state))
             UniqueTriggerActivation.triggerUnique(unique, civInfo)
 
         val notificationsLog = civInfo.notificationsLog

--- a/core/src/com/unciv/logic/civilization/managers/UnitManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/UnitManager.kt
@@ -9,7 +9,6 @@ import com.unciv.logic.civilization.NotificationCategory
 import com.unciv.logic.civilization.transients.CivInfoTransientCache
 import com.unciv.logic.map.mapunit.MapUnit
 import com.unciv.logic.map.tile.Tile
-import com.unciv.models.ruleset.unique.StateForConditionals
 import com.unciv.models.ruleset.unique.UniqueTriggerActivation
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.ruleset.unit.BaseUnit
@@ -100,7 +99,7 @@ class UnitManager(val civInfo: Civilization) {
         if (unit != null) {
             val triggerNotificationText = "due to gaining a [${unit.name}]"
             for (unique in unit.getUniques())
-                if (!unique.hasTriggerConditional() && unique.conditionalsApply(StateForConditionals(civInfo, unit = unit)))
+                if (!unique.hasTriggerConditional() && unique.conditionalsApply(unit.cache.state))
                     UniqueTriggerActivation.triggerUnique(unique, unit, triggerNotificationText = triggerNotificationText)
 
             for (unique in civInfo.getTriggeredUniques(UniqueType.TriggerUponGainingUnit) 

--- a/core/src/com/unciv/logic/civilization/transients/CivInfoStatsForNextTurn.kt
+++ b/core/src/com/unciv/logic/civilization/transients/CivInfoStatsForNextTurn.kt
@@ -53,7 +53,7 @@ class CivInfoStatsForNextTurn(val civInfo: Civilization) {
             .toList().asSequence()
 
         for (unit in unitsToPayFor) {
-            val stateForConditionals = StateForConditionals(civInfo = civInfo, unit = unit)
+            val stateForConditionals = unit.cache.state
             var unitMaintenance = 1f
             val uniquesThatApply = unit.getMatchingUniques(
                 UniqueType.UnitMaintenanceDiscount,

--- a/core/src/com/unciv/logic/civilization/transients/CivInfoStatsForNextTurn.kt
+++ b/core/src/com/unciv/logic/civilization/transients/CivInfoStatsForNextTurn.kt
@@ -32,7 +32,7 @@ class CivInfoStatsForNextTurn(val civInfo: Civilization) {
     private fun getUnitMaintenance(): Int {
         val baseUnitCost = 0.5f
         var freeUnits = 3
-        for (unique in civInfo.getMatchingUniques(UniqueType.FreeUnits, StateForConditionals(civInfo))) {
+        for (unique in civInfo.getMatchingUniques(UniqueType.FreeUnits, civInfo.state)) {
             freeUnits += unique.params[0].toInt()
         }
 
@@ -286,7 +286,7 @@ class CivInfoStatsForNextTurn(val civInfo: Civilization) {
         val statMap = StatMap()
         if (civInfo.religionManager.religion != null) {
             for (unique in civInfo.religionManager.religion!!.founderBeliefUniqueMap.getMatchingUniques(
-                UniqueType.StatsFromGlobalCitiesFollowingReligion, StateForConditionals(civInfo)
+                UniqueType.StatsFromGlobalCitiesFollowingReligion, civInfo.state
             ))
                 statMap.add(
                     "Religion",
@@ -294,7 +294,7 @@ class CivInfoStatsForNextTurn(val civInfo: Civilization) {
                 )
 
             for (unique in civInfo.religionManager.religion!!.founderBeliefUniqueMap.getMatchingUniques(
-                UniqueType.StatsFromGlobalFollowers, StateForConditionals(civInfo)
+                UniqueType.StatsFromGlobalFollowers, civInfo.state
             ))
                 statMap.add(
                     "Religion",

--- a/core/src/com/unciv/logic/civilization/transients/CivInfoTransientCache.kt
+++ b/core/src/com/unciv/logic/civilization/transients/CivInfoTransientCache.kt
@@ -46,7 +46,7 @@ class CivInfoTransientCache(val civInfo: Civilization) {
     fun setTransients() {
         val ruleset = civInfo.gameInfo.ruleset
 
-        val state = StateForConditionals(civInfo)
+        val state = civInfo.state
         val buildingsToRequiredResources = ruleset.buildings.values
                 .filter { civInfo.getEquivalentBuilding(it) == it }
                 .associateWith { it.requiredResources(state) }
@@ -325,7 +325,7 @@ class CivInfoTransientCache(val civInfo: Civilization) {
                 resourceBonusPercentage += unique.params[0].toFloat() / 100
             for (cityStateAlly in civInfo.getKnownCivs().filter { it.getAllyCiv() == civInfo.civName }) {
                 for (resourceSupply in cityStateAlly.cityStateFunctions.getCityStateResourcesForAlly()) {
-                    if (resourceSupply.resource.hasUnique(UniqueType.CannotBeTraded, StateForConditionals(cityStateAlly))) continue
+                    if (resourceSupply.resource.hasUnique(UniqueType.CannotBeTraded, cityStateAlly.state)) continue
                     val newAmount = (resourceSupply.amount * resourceBonusPercentage).toInt()
                     cityStateProvidedResources.add(resourceSupply.copy(amount = newAmount))
                 }

--- a/core/src/com/unciv/logic/civilization/transients/CivInfoTransientCache.kt
+++ b/core/src/com/unciv/logic/civilization/transients/CivInfoTransientCache.kt
@@ -42,6 +42,10 @@ class CivInfoTransientCache(val civInfo: Civilization) {
     /** Contains mapping of cities to travel mediums from ALL civilizations connected by trade routes to the capital */
     @Transient
     var citiesConnectedToCapitalToMediums = mapOf<City, Set<String>>()
+    
+    fun updateState() {
+        civInfo.state = StateForConditionals(civInfo)
+    }
 
     fun setTransients() {
         val ruleset = civInfo.gameInfo.ruleset

--- a/core/src/com/unciv/logic/map/TileMap.kt
+++ b/core/src/com/unciv/logic/map/TileMap.kt
@@ -12,6 +12,7 @@ import com.unciv.models.metadata.Player
 import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.ruleset.nation.Nation
 import com.unciv.models.ruleset.tile.TerrainType
+import com.unciv.models.ruleset.unique.StateForConditionals
 import com.unciv.models.ruleset.unique.UniqueMap
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.ruleset.unit.BaseUnit
@@ -565,6 +566,7 @@ class TileMap(initialCapacity: Int = 10) : IsPartOfGameInfoSerialization {
         // try to place at the original point (this is the most probable scenario)
         val currentTile = get(position)
         unit.currentTile = currentTile  // temporary
+        unit.cache.state = StateForConditionals(unit)
         if (unit.movement.canMoveTo(currentTile)) unitToPlaceTile = currentTile
 
         // if it's not suitable, try to find another tile nearby
@@ -642,6 +644,7 @@ class TileMap(initialCapacity: Int = 10) : IsPartOfGameInfoSerialization {
             for (unit in it.getUnits()) if (unit.owner == player.chosenCiv) {
                 unit.owner = newNation.name
                 unit.civ = newCiv
+                unit.setTransients(newCiv.gameInfo.ruleset)
             }
         }
         for (element in startingLocations.filter { it.nation != player.chosenCiv }) {

--- a/core/src/com/unciv/logic/map/mapunit/MapUnitCache.kt
+++ b/core/src/com/unciv/logic/map/mapunit/MapUnitCache.kt
@@ -65,9 +65,12 @@ class MapUnitCache(private val mapUnit: MapUnit) {
 
     var hasStrengthBonusInRadiusUnique = false
     var hasCitadelPlacementUnique = false
+    
+    var state = StateForConditionals.EmptyState
 
     fun updateUniques() {
 
+        state = StateForConditionals(mapUnit)
         allTilesCosts1 = mapUnit.hasUnique(UniqueType.AllTilesCost1Move)
         canPassThroughImpassableTiles = mapUnit.hasUnique(UniqueType.CanPassImpassable)
         ignoresTerrainCost = mapUnit.hasUnique(UniqueType.IgnoresTerrainCost)
@@ -104,10 +107,7 @@ class MapUnitCache(private val mapUnit: MapUnit) {
 
         //todo: consider parameterizing [terrainFilter] in some of the following:
         canEnterIceTiles = mapUnit.hasUnique(UniqueType.CanEnterIceTiles)
-        cannotEnterOceanTiles = mapUnit.hasUnique(
-            UniqueType.CannotEnterOcean,
-            StateForConditionals(civInfo = mapUnit.civ, unit = mapUnit)
-        )
+        cannotEnterOceanTiles = mapUnit.hasUnique(UniqueType.CannotEnterOcean, state)
 
         hasUniqueToBuildImprovements = mapUnit.hasUnique(UniqueType.BuildImprovements)
         hasUniqueToCreateWaterImprovements = mapUnit.hasUnique(UniqueType.CreateWaterImprovements)

--- a/core/src/com/unciv/logic/map/mapunit/UnitPromotions.kt
+++ b/core/src/com/unciv/logic/map/mapunit/UnitPromotions.kt
@@ -111,7 +111,7 @@ class UnitPromotions : IsPartOfGameInfoSerialization {
 
     private fun doDirectPromotionEffects(promotion: Promotion) {
         for (unique in promotion.uniqueObjects)
-            if (unique.conditionalsApply(StateForConditionals(civInfo = unit.civ, unit = unit))
+            if (unique.conditionalsApply(unit.cache.state)
                     && !unique.hasTriggerConditional())
                 UniqueTriggerActivation.triggerUnique(unique, unit, triggerNotificationText = "due to our [${unit.name}] being promoted")
     }
@@ -128,7 +128,7 @@ class UnitPromotions : IsPartOfGameInfoSerialization {
         if (unit.type.name !in promotion.unitTypes) return false
         if (promotion.prerequisites.isNotEmpty() && promotion.prerequisites.none { it in promotions }) return false
 
-        val stateForConditionals = StateForConditionals(unit.civ, unit = unit)
+        val stateForConditionals = unit.cache.state
         if (promotion.hasUnique(UniqueType.Unavailable, stateForConditionals)) return false
         if (promotion.getMatchingUniques(UniqueType.OnlyAvailable, StateForConditionals.IgnoreConditionals)
             .any { !it.conditionalsApply(stateForConditionals) }) return false

--- a/core/src/com/unciv/logic/map/mapunit/UnitUpgradeManager.kt
+++ b/core/src/com/unciv/logic/map/mapunit/UnitUpgradeManager.kt
@@ -1,7 +1,6 @@
 package com.unciv.logic.map.mapunit
 
 import com.unciv.models.ruleset.RejectionReasonType
-import com.unciv.models.ruleset.unique.StateForConditionals
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.ruleset.unit.BaseUnit
 import com.unciv.ui.components.extensions.toPercent
@@ -56,7 +55,7 @@ class UnitUpgradeManager(val unit: MapUnit) {
         // the UniqueType being allowed on a BaseUnit - we don't have a MapUnit in the loop.
         // Actually instantiating every intermediate to support such mods: todo
         var civModifier = 1f
-        val stateForConditionals = StateForConditionals(unit.civ, unit = unit)
+        val stateForConditionals = unit.cache.state
         for (unique in unit.civ.getMatchingUniques(UniqueType.UnitUpgradeCost, stateForConditionals))
             civModifier *= unique.params[0].toPercent()
 

--- a/core/src/com/unciv/logic/trade/TradeEvaluation.kt
+++ b/core/src/com/unciv/logic/trade/TradeEvaluation.kt
@@ -154,7 +154,7 @@ class TradeEvaluation {
 
                 val canUseForBuildings = civInfo.cities
                         .any { city -> city.cityConstructions.getBuildableBuildings().any {
-                            it.getResourceRequirementsPerTurn(StateForConditionals(civInfo, city)).containsKey(offer.name) } }
+                            it.getResourceRequirementsPerTurn(city.state).containsKey(offer.name) } }
                 val canUseForUnits = civInfo.cities
                         .any { city -> city.cityConstructions.getConstructableUnits().any {
                             it.getResourceRequirementsPerTurn(StateForConditionals(civInfo)).containsKey(offer.name) } }

--- a/core/src/com/unciv/logic/trade/TradeEvaluation.kt
+++ b/core/src/com/unciv/logic/trade/TradeEvaluation.kt
@@ -10,7 +10,6 @@ import com.unciv.logic.civilization.diplomacy.DiplomacyFlags
 import com.unciv.logic.civilization.diplomacy.RelationshipLevel
 import com.unciv.logic.map.tile.Tile
 import com.unciv.models.ruleset.Ruleset
-import com.unciv.models.ruleset.unique.StateForConditionals
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.ui.components.extensions.toPercent
 import com.unciv.ui.screens.victoryscreen.RankingType
@@ -157,7 +156,7 @@ class TradeEvaluation {
                             it.getResourceRequirementsPerTurn(city.state).containsKey(offer.name) } }
                 val canUseForUnits = civInfo.cities
                         .any { city -> city.cityConstructions.getConstructableUnits().any {
-                            it.getResourceRequirementsPerTurn(StateForConditionals(civInfo)).containsKey(offer.name) } }
+                            it.getResourceRequirementsPerTurn(civInfo.state).containsKey(offer.name) } }
                 if (!canUseForBuildings && !canUseForUnits) return 0
 
                 return 50 * amountToBuyInOffer
@@ -264,7 +263,7 @@ class TradeEvaluation {
                 if (!civInfo.isAtWar()) return 50 * offer.amount
 
                 val canUseForUnits = civInfo.gameInfo.ruleset.units.values
-                    .any { it.getResourceRequirementsPerTurn(StateForConditionals(civInfo)).containsKey(offer.name)
+                    .any { it.getResourceRequirementsPerTurn(civInfo.state).containsKey(offer.name)
                             && it.isBuildable(civInfo) }
                 if (!canUseForUnits) return 50 * offer.amount
 

--- a/core/src/com/unciv/models/Spy.kt
+++ b/core/src/com/unciv/models/Spy.kt
@@ -11,7 +11,6 @@ import com.unciv.logic.civilization.NotificationCategory
 import com.unciv.logic.civilization.NotificationIcon
 import com.unciv.logic.civilization.diplomacy.DiplomaticModifiers
 import com.unciv.logic.civilization.managers.EspionageManager
-import com.unciv.models.ruleset.unique.StateForConditionals
 import com.unciv.models.ruleset.unique.Unique
 import com.unciv.models.ruleset.unique.UniqueType
 import kotlin.math.ceil
@@ -390,13 +389,13 @@ class Spy private constructor() : IsPartOfGameInfoSerialization {
             }
             city.civ == civInfo -> {
                 // Spy is in our own city
-                friendlyUniques = city.getMatchingUniques(UniqueType.SpyEffectiveness, StateForConditionals(city), includeCivUniques = true)
+                friendlyUniques = city.getMatchingUniques(UniqueType.SpyEffectiveness, city.state, includeCivUniques = true)
                 enemyUniques = emptySequence()
             }
             else -> {
                 // Spy is active in a foreign city
                 friendlyUniques = civInfo.getMatchingUniques(UniqueType.SpyEffectiveness)
-                enemyUniques = city.getMatchingUniques(UniqueType.EnemySpyEffectiveness, StateForConditionals(city), includeCivUniques = true)
+                enemyUniques = city.getMatchingUniques(UniqueType.EnemySpyEffectiveness, city.state, includeCivUniques = true)
             }
         }
         var totalEfficiency = 1.0

--- a/core/src/com/unciv/models/ruleset/Building.kt
+++ b/core/src/com/unciv/models/ruleset/Building.kt
@@ -83,7 +83,7 @@ class Building : RulesetStatsObject(), INonPerpetualConstruction {
         // Calls the clone function of the NamedStats this class is derived from, not a clone function of this class
         val stats = cloneStats()
         
-        val conditionalState = StateForConditionals(city)
+        val conditionalState = city.state
 
         for (unique in localUniqueCache.forCityGetMatchingUniques(city, UniqueType.StatsFromObject)) {
             if (!matchesFilter(unique.params[1], conditionalState)) continue
@@ -105,7 +105,7 @@ class Building : RulesetStatsObject(), INonPerpetualConstruction {
         val stats = percentStatBonus?.clone() ?: Stats()
         val civInfo = city?.civ ?: return stats  // initial stats
         
-        val conditionalState = StateForConditionals(city)
+        val conditionalState = city.state
 
         for (unique in localUniqueCache.forCivGetMatchingUniques(civInfo, UniqueType.StatPercentFromObject)) {
             if (matchesFilter(unique.params[2], conditionalState))
@@ -124,7 +124,7 @@ class Building : RulesetStatsObject(), INonPerpetualConstruction {
 
     override fun getProductionCost(civInfo: Civilization, city: City?): Int {
         var productionCost = cost.toFloat()
-        val stateForConditionals = StateForConditionals(civInfo, city)
+        val stateForConditionals = city?.state ?: StateForConditionals(civInfo)
 
         for (unique in getMatchingUniques(UniqueType.CostIncreasesWhenBuilt, stateForConditionals))
             productionCost += civInfo.civConstructions.builtItemsWithIncreasingCost[name] * unique.params[0].toInt()
@@ -158,7 +158,7 @@ class Building : RulesetStatsObject(), INonPerpetualConstruction {
         if (purchaseReason != PurchaseReason.UniqueAllowed && stat == Stat.Gold && isAnyWonder()) return false
         if (city == null) return purchaseReason.purchasable
 
-        val conditionalState = StateForConditionals(civInfo = city.civ, city = city)
+        val conditionalState = city.state
         return (
             city.getMatchingUniques(UniqueType.BuyBuildingsIncreasingCost, conditionalState)
                 .any {
@@ -185,7 +185,7 @@ class Building : RulesetStatsObject(), INonPerpetualConstruction {
     }
 
     override fun getBaseBuyCost(city: City, stat: Stat): Float? {
-        val conditionalState = StateForConditionals(civInfo = city.civ, city = city)
+        val conditionalState = city.state
 
         return sequence {
             val baseCost = super.getBaseBuyCost(city, stat)
@@ -229,7 +229,7 @@ class Building : RulesetStatsObject(), INonPerpetualConstruction {
 
     override fun getStatBuyCost(city: City, stat: Stat): Int? {
         var cost = getBaseBuyCost(city, stat)?.toDouble() ?: return null
-        val conditionalState = StateForConditionals(city)
+        val conditionalState = city.state
 
         for (unique in city.getMatchingUniques(UniqueType.BuyItemsDiscount))
             if (stat.name == unique.params[0])
@@ -253,7 +253,7 @@ class Building : RulesetStatsObject(), INonPerpetualConstruction {
 
         val rejectionReasons = getRejectionReasons(cityConstructions)
 
-        if (hasUnique(UniqueType.ShowsWhenUnbuilable, StateForConditionals(cityConstructions.city)) &&
+        if (hasUnique(UniqueType.ShowsWhenUnbuilable, cityConstructions.city.state) &&
             rejectionReasons.none { it.isNeverVisible() })
             return true
 
@@ -267,9 +267,10 @@ class Building : RulesetStatsObject(), INonPerpetualConstruction {
     }
 
     override fun getRejectionReasons(cityConstructions: CityConstructions): Sequence<RejectionReason> = sequence {
-        val cityCenter = cityConstructions.city.getCenterTile()
-        val civ = cityConstructions.city.civ
-        val stateForConditionals = StateForConditionals(civ, cityConstructions.city)
+        val city = cityConstructions.city
+        val cityCenter = city.getCenterTile()
+        val civ = city.civ
+        val stateForConditionals = city.state
 
         if (cityConstructions.isBuilt(name))
             yield(RejectionReasonType.AlreadyBuilt.toInstance())
@@ -305,7 +306,7 @@ class Building : RulesetStatsObject(), INonPerpetualConstruction {
                     yield(RejectionReasonType.ShouldNotBeDisplayed.toInstance())
 
                 UniqueType.RequiresPopulation ->
-                    if (unique.params[0].toInt() > cityConstructions.city.population.population)
+                    if (unique.params[0].toInt() > city.population.population)
                         yield(RejectionReasonType.PopulationRequirement.toInstance(unique.text))
 
                 UniqueType.MustBeOn ->
@@ -326,7 +327,7 @@ class Building : RulesetStatsObject(), INonPerpetualConstruction {
 
                 UniqueType.MustHaveOwnedWithinTiles ->
                     if (cityCenter.getTilesInDistance(unique.params[1].toInt())
-                        .none { it.matchesFilter(unique.params[0], civ) && it.getOwner() == cityConstructions.city.civ }
+                        .none { it.matchesFilter(unique.params[0], civ) && it.getOwner() == civ }
                     )
                         yield(RejectionReasonType.MustOwnTile.toInstance(unique.text))
 
@@ -429,7 +430,7 @@ class Building : RulesetStatsObject(), INonPerpetualConstruction {
         val civ = cityConstructions.city.civ
         for (conditional in unique.modifiers) {
             // We yield a rejection only when conditionals are NOT met
-            if (Conditionals.conditionalApplies(unique, conditional, StateForConditionals(civ, cityConstructions.city)))
+            if (Conditionals.conditionalApplies(unique, conditional, cityConstructions.city.state))
                 continue
             when (conditional.type) {
                 UniqueType.ConditionalBuildingBuiltAmount -> {

--- a/core/src/com/unciv/models/ruleset/Building.kt
+++ b/core/src/com/unciv/models/ruleset/Building.kt
@@ -124,7 +124,7 @@ class Building : RulesetStatsObject(), INonPerpetualConstruction {
 
     override fun getProductionCost(civInfo: Civilization, city: City?): Int {
         var productionCost = cost.toFloat()
-        val stateForConditionals = city?.state ?: StateForConditionals(civInfo)
+        val stateForConditionals = city?.state ?: civInfo.state
 
         for (unique in getMatchingUniques(UniqueType.CostIncreasesWhenBuilt, stateForConditionals))
             productionCost += civInfo.civConstructions.builtItemsWithIncreasingCost[name] * unique.params[0].toInt()

--- a/core/src/com/unciv/models/ruleset/IConstruction.kt
+++ b/core/src/com/unciv/models/ruleset/IConstruction.kt
@@ -50,7 +50,7 @@ interface INonPerpetualConstruction : IConstruction, INamed, IHasUniques {
 
     /** Only checks if it has the unique to be bought with this stat, not whether it is purchasable at all */
     fun canBePurchasedWithStatReasons(city: City?, stat: Stat): PurchaseReason {
-        val stateForConditionals = StateForConditionals(city?.civ, city)
+        val stateForConditionals = city?.state ?: StateForConditionals.EmptyState
         if (stat == Stat.Production || stat == Stat.Happiness) return PurchaseReason.Invalid
         if (hasUnique(UniqueType.CannotBePurchased, stateForConditionals)) return PurchaseReason.Unpurchasable
         // Can be purchased with [Stat] [cityFilter]
@@ -92,7 +92,7 @@ interface INonPerpetualConstruction : IConstruction, INamed, IHasUniques {
     }
 
     fun getBaseBuyCost(city: City, stat: Stat): Float? {
-        val conditionalState = StateForConditionals(civInfo = city.civ, city = city)
+        val conditionalState = city.state
 
         // Can be purchased for [amount] [Stat] [cityFilter]
         val lowestCostUnique = getMatchingUniques(UniqueType.CanBePurchasedForAmountStat, conditionalState)
@@ -310,7 +310,7 @@ open class PerpetualStatConversion(val stat: Stat) :
         if (stat == Stat.Faith && !city.civ.gameInfo.isReligionEnabled())
             return false
 
-        val stateForConditionals = StateForConditionals(city.civ, city, tile = city.getCenterTile())
+        val stateForConditionals = city.state
         return city.civ.getMatchingUniques(UniqueType.EnablesCivWideStatProduction, stateForConditionals)
             .any { it.params[0] == stat.name }
     }

--- a/core/src/com/unciv/models/ruleset/unique/Unique.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Unique.kt
@@ -209,7 +209,7 @@ class LocalUniqueCache(val cache: Boolean = true) {
     fun forCityGetMatchingUniques(
         city: City,
         uniqueType: UniqueType,
-        stateForConditionals: StateForConditionals = StateForConditionals(city.civ, city)
+        stateForConditionals: StateForConditionals = city.state
     ): Sequence<Unique> {
         // City uniques are a combination of *global civ* uniques plus *city relevant* uniques (see City.getMatchingUniques())
         // We can cache the civ uniques separately, so if we have several cities using the same cache,

--- a/core/src/com/unciv/models/ruleset/unique/Unique.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Unique.kt
@@ -228,9 +228,7 @@ class LocalUniqueCache(val cache: Boolean = true) {
     fun forCivGetMatchingUniques(
         civ: Civilization,
         uniqueType: UniqueType,
-        stateForConditionals: StateForConditionals = StateForConditionals(
-            civ
-        )
+        stateForConditionals: StateForConditionals = civ.state
     ): Sequence<Unique> {
         val sequence = civ.getMatchingUniques(uniqueType, StateForConditionals.IgnoreConditionals)
         // The uniques CACHED are ALL civ uniques, regardless of conditional matching.

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -907,7 +907,7 @@ object UniqueTriggerActivation {
                 return {
                     for (applicableCity in applicableCities) {
                         val buildingsToRemove = applicableCity.cityConstructions.getBuiltBuildings().filter {
-                            it.matchesFilter(unique.params[0], StateForConditionals(applicableCity))
+                            it.matchesFilter(unique.params[0], applicableCity.state)
                         }.toSet()
                         applicableCity.cityConstructions.removeBuildings(buildingsToRemove)
                     }
@@ -924,7 +924,7 @@ object UniqueTriggerActivation {
                 return {
                     for (applicableCity in applicableCities) {
                         val buildingsToSell = applicableCity.cityConstructions.getBuiltBuildings().filter {
-                            it.matchesFilter(unique.params[0], StateForConditionals(applicableCity)) && it.isSellable()
+                            it.matchesFilter(unique.params[0], applicableCity.state) && it.isSellable()
                         }
 
                         for (building in buildingsToSell) applicableCity.sellBuilding(building)

--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -202,7 +202,7 @@ class BaseUnit : RulesetObject(), INonPerpetualConstruction {
         additionalResources: Counter<String> = Counter.ZERO
     ): Sequence<RejectionReason> = sequence {
 
-        val stateForConditionals = city?.state ?: StateForConditionals(civ)
+        val stateForConditionals = city?.state ?: civ.state
 
         if (city != null && isWaterUnit && !city.isCoastal())
             yield(RejectionReasonType.WaterUnitsInCoastalCities.toInstance())
@@ -293,7 +293,7 @@ class BaseUnit : RulesetObject(), INonPerpetualConstruction {
     private fun notMetRejections(unique: Unique, civ: Civilization, city: City?, built: Boolean=false): Sequence<RejectionReason> = sequence {
         for (conditional in unique.modifiers) {
             // We yield a rejection only when conditionals are NOT met
-            if (Conditionals.conditionalApplies(unique, conditional, city?.state ?: StateForConditionals(civ)))
+            if (Conditionals.conditionalApplies(unique, conditional, city?.state ?: civ.state))
                 continue
             when (conditional.type) {
                 UniqueType.ConditionalBuildingBuiltAmount -> {

--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -183,7 +183,7 @@ class BaseUnit : RulesetObject(), INonPerpetualConstruction {
     override fun shouldBeDisplayed(cityConstructions: CityConstructions): Boolean {
         val rejectionReasons = getRejectionReasons(cityConstructions)
 
-        if (hasUnique(UniqueType.ShowsWhenUnbuilable, StateForConditionals(cityConstructions.city)) &&
+        if (hasUnique(UniqueType.ShowsWhenUnbuilable, cityConstructions.city.state) &&
             rejectionReasons.none { it.isNeverVisible() })
             return true
 
@@ -202,7 +202,7 @@ class BaseUnit : RulesetObject(), INonPerpetualConstruction {
         additionalResources: Counter<String> = Counter.ZERO
     ): Sequence<RejectionReason> = sequence {
 
-        val stateForConditionals = StateForConditionals(civ, city)
+        val stateForConditionals = city?.state ?: StateForConditionals(civ)
 
         if (city != null && isWaterUnit && !city.isCoastal())
             yield(RejectionReasonType.WaterUnitsInCoastalCities.toInstance())
@@ -293,7 +293,7 @@ class BaseUnit : RulesetObject(), INonPerpetualConstruction {
     private fun notMetRejections(unique: Unique, civ: Civilization, city: City?, built: Boolean=false): Sequence<RejectionReason> = sequence {
         for (conditional in unique.modifiers) {
             // We yield a rejection only when conditionals are NOT met
-            if (Conditionals.conditionalApplies(unique, conditional, StateForConditionals(civ, city)))
+            if (Conditionals.conditionalApplies(unique, conditional, city?.state ?: StateForConditionals(civ)))
                 continue
             when (conditional.type) {
                 UniqueType.ConditionalBuildingBuiltAmount -> {

--- a/core/src/com/unciv/models/ruleset/unit/BaseUnitCost.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnitCost.kt
@@ -12,7 +12,7 @@ class BaseUnitCost(val baseUnit: BaseUnit) {
     fun getProductionCost(civInfo: Civilization, city: City?): Int {
         var productionCost = baseUnit.cost.toFloat()
 
-        val stateForConditionals = StateForConditionals(civInfo, city)
+        val stateForConditionals = city?.state ?: StateForConditionals(civInfo)
         for (unique in baseUnit.getMatchingUniques(UniqueType.CostIncreasesPerCity, stateForConditionals))
             productionCost += civInfo.cities.size * unique.params[0].toInt()
 
@@ -36,7 +36,7 @@ class BaseUnitCost(val baseUnit: BaseUnit) {
 
     /** Contains only unit-specific uniques that allow purchasing with stat */
     fun canBePurchasedWithStat(city: City, stat: Stat): Boolean {
-        val conditionalState = StateForConditionals(city)
+        val conditionalState = city.state
 
         if (city.getMatchingUniques(UniqueType.BuyUnitsIncreasingCost, conditionalState)
                     .any {
@@ -75,7 +75,7 @@ class BaseUnitCost(val baseUnit: BaseUnit) {
 
     fun getStatBuyCost(city: City, stat: Stat): Int? {
         var cost = baseUnit.getBaseBuyCost(city, stat)?.toDouble() ?: return null
-        val conditionalState = StateForConditionals(city)
+        val conditionalState = city.state
 
         for (unique in city.getMatchingUniques(UniqueType.BuyUnitsDiscount)) {
             if (stat.name == unique.params[0] && baseUnit.matchesFilter(unique.params[1], conditionalState))
@@ -90,7 +90,7 @@ class BaseUnitCost(val baseUnit: BaseUnit) {
 
 
     fun getBaseBuyCosts(city: City, stat: Stat): Sequence<Float> {
-        val conditionalState = StateForConditionals(civInfo = city.civ, city = city)
+        val conditionalState = city.state
         return sequence {
             yieldAll(city.getMatchingUniques(UniqueType.BuyUnitsIncreasingCost, conditionalState)
                 .filter {

--- a/core/src/com/unciv/models/ruleset/unit/BaseUnitCost.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnitCost.kt
@@ -2,7 +2,6 @@ package com.unciv.models.ruleset.unit
 
 import com.unciv.logic.city.City
 import com.unciv.logic.civilization.Civilization
-import com.unciv.models.ruleset.unique.StateForConditionals
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.stats.Stat
 import com.unciv.ui.components.extensions.toPercent
@@ -12,7 +11,7 @@ class BaseUnitCost(val baseUnit: BaseUnit) {
     fun getProductionCost(civInfo: Civilization, city: City?): Int {
         var productionCost = baseUnit.cost.toFloat()
 
-        val stateForConditionals = city?.state ?: StateForConditionals(civInfo)
+        val stateForConditionals = city?.state ?: civInfo.state
         for (unique in baseUnit.getMatchingUniques(UniqueType.CostIncreasesPerCity, stateForConditionals))
             productionCost += civInfo.cities.size * unique.params[0].toInt()
 

--- a/core/src/com/unciv/ui/objectdescriptions/BaseUnitDescriptions.kt
+++ b/core/src/com/unciv/ui/objectdescriptions/BaseUnitDescriptions.kt
@@ -41,7 +41,7 @@ object BaseUnitDescriptions {
     fun getDescription(baseUnit: BaseUnit, city: City): String {
         val lines = mutableListOf<String>()
         val availableResources = city.civ.getCivResourcesByName()
-        for ((resourceName, amount) in baseUnit.getResourceRequirementsPerTurn(StateForConditionals(city.civ))) {
+        for ((resourceName, amount) in baseUnit.getResourceRequirementsPerTurn(city.civ.state)) {
             val available = availableResources[resourceName] ?: 0
             val resource = baseUnit.ruleset.tileResources[resourceName] ?: continue
             val consumesString = resourceName.getConsumesAmountString(amount, resource.isStockpiled())

--- a/core/src/com/unciv/ui/objectdescriptions/BuildingDescriptions.kt
+++ b/core/src/com/unciv/ui/objectdescriptions/BuildingDescriptions.kt
@@ -4,7 +4,6 @@ import com.unciv.logic.city.City
 import com.unciv.models.ruleset.Belief
 import com.unciv.models.ruleset.Building
 import com.unciv.models.ruleset.Ruleset
-import com.unciv.models.ruleset.unique.StateForConditionals
 import com.unciv.models.ruleset.unique.Unique
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.stats.Stat
@@ -48,7 +47,7 @@ object BuildingDescriptions {
         if (isWonder) translatedLines += "Wonder".tr()
         if (isNationalWonder) translatedLines += "National Wonder".tr()
         if (!isFree) {
-            for ((resourceName, amount) in getResourceRequirementsPerTurn(StateForConditionals(city.civ, city))) {
+            for ((resourceName, amount) in getResourceRequirementsPerTurn(city.state)) {
                 val available = city.getAvailableResourceAmount(resourceName)
                 val resource = city.getRuleset().tileResources[resourceName] ?: continue
                 val consumesString = resourceName.getConsumesAmountString(amount, resource.isStockpiled())

--- a/core/src/com/unciv/ui/screens/cityscreen/CityConstructionsTable.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/CityConstructionsTable.kt
@@ -17,7 +17,6 @@ import com.unciv.models.ruleset.INonPerpetualConstruction
 import com.unciv.models.ruleset.PerpetualConstruction
 import com.unciv.models.ruleset.RejectionReason
 import com.unciv.models.ruleset.RejectionReasonType
-import com.unciv.models.ruleset.unique.StateForConditionals
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.ruleset.unit.BaseUnit
 import com.unciv.models.stats.Stat
@@ -206,7 +205,7 @@ class CityConstructionsTable(private val cityScreen: CityScreen) {
             val useStoredProduction = entry is Building || !cityConstructions.isBeingConstructedOrEnqueued(entry.name)
             val buttonText = cityConstructions.getTurnsToConstructionString(entry, useStoredProduction).trim()
             val resourcesRequired = if (entry is BaseUnit)
-                entry.getResourceRequirementsPerTurn(StateForConditionals(city.civ))
+                entry.getResourceRequirementsPerTurn(city.civ.state)
                 else entry.getResourceRequirementsPerTurn(city.state)
             val mostImportantRejection =
                     entry.getRejectionReasons(cityConstructions)
@@ -329,8 +328,8 @@ class CityConstructionsTable(private val cityScreen: CityScreen) {
                 else cityConstructions.getTurnsToConstructionString(construction, isFirstConstructionOfItsKind)
 
         val constructionResource = if (construction is BaseUnit)
-                construction.getResourceRequirementsPerTurn(city.state)
-            else construction.getResourceRequirementsPerTurn(StateForConditionals(city.civ))
+                construction.getResourceRequirementsPerTurn(city.civ.state)
+            else construction.getResourceRequirementsPerTurn(city.state)
         for ((resourceName, amount) in constructionResource) {
             val resource = cityConstructions.city.getRuleset().tileResources[resourceName] ?: continue
             text += "\n" + resourceName.getConsumesAmountString(amount, resource.isStockpiled()).tr()

--- a/core/src/com/unciv/ui/screens/cityscreen/CityConstructionsTable.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/CityConstructionsTable.kt
@@ -207,7 +207,7 @@ class CityConstructionsTable(private val cityScreen: CityScreen) {
             val buttonText = cityConstructions.getTurnsToConstructionString(entry, useStoredProduction).trim()
             val resourcesRequired = if (entry is BaseUnit)
                 entry.getResourceRequirementsPerTurn(StateForConditionals(city.civ))
-                else entry.getResourceRequirementsPerTurn(StateForConditionals(city.civ, city))
+                else entry.getResourceRequirementsPerTurn(city.state)
             val mostImportantRejection =
                     entry.getRejectionReasons(cityConstructions)
                         .filter { it.isImportantRejection() }
@@ -269,7 +269,7 @@ class CityConstructionsTable(private val cityScreen: CityScreen) {
                             && constructionButtonDTOList.any {
                                 (it.construction is Building) && (it.construction.name == dto.construction.requiredBuilding
                                         || it.construction.replaces == dto.construction.requiredBuilding
-                                        || it.construction.hasUnique(dto.construction.requiredBuilding!!, StateForConditionals(cityScreen.city)))
+                                        || it.construction.hasUnique(dto.construction.requiredBuilding!!, cityScreen.city.state))
                             })
                         continue
 
@@ -329,7 +329,7 @@ class CityConstructionsTable(private val cityScreen: CityScreen) {
                 else cityConstructions.getTurnsToConstructionString(construction, isFirstConstructionOfItsKind)
 
         val constructionResource = if (construction is BaseUnit)
-                construction.getResourceRequirementsPerTurn(StateForConditionals(city.civ, city))
+                construction.getResourceRequirementsPerTurn(city.state)
             else construction.getResourceRequirementsPerTurn(StateForConditionals(city.civ))
         for ((resourceName, amount) in constructionResource) {
             val resource = cityConstructions.city.getRuleset().tileResources[resourceName] ?: continue
@@ -431,7 +431,7 @@ class CityConstructionsTable(private val cityScreen: CityScreen) {
             }
         }
         for (unique in constructionButtonDTO.construction
-            .getMatchingUniquesNotConflicting(UniqueType.CostsResources, StateForConditionals(cityScreen.city))) {
+            .getMatchingUniquesNotConflicting(UniqueType.CostsResources, cityScreen.city.state)) {
             val color = if (constructionButtonDTO.rejectionReason?.type == RejectionReasonType.ConsumesResources)
                 Color.RED else Color.WHITE
             resourceTable.add(ColorMarkupLabel(unique.params[0], color)).expandX().left().padLeft(5f)

--- a/core/src/com/unciv/ui/screens/mapeditorscreen/tabs/MapEditorViewTab.kt
+++ b/core/src/com/unciv/ui/screens/mapeditorscreen/tabs/MapEditorViewTab.kt
@@ -14,6 +14,7 @@ import com.unciv.models.Counter
 import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.ruleset.nation.Nation
 import com.unciv.models.ruleset.tile.ResourceType
+import com.unciv.models.ruleset.unique.StateForConditionals
 import com.unciv.models.stats.Stats
 import com.unciv.models.translations.tr
 import com.unciv.ui.components.extensions.addSeparator
@@ -58,6 +59,8 @@ class MapEditorViewTab(
         nation.name = "Test"
         gameInfo = GameInfo()
         gameInfo.ruleset = ruleset
+        cache.updateState()
+        
         // show yields of strategic resources too
         tech.techsResearched.addAll(ruleset.technologies.keys)
     }

--- a/core/src/com/unciv/ui/screens/pickerscreens/PantheonPickerScreen.kt
+++ b/core/src/com/unciv/ui/screens/pickerscreens/PantheonPickerScreen.kt
@@ -21,7 +21,7 @@ class PantheonPickerScreen(
             val beliefButton = getBeliefButton(belief, withTypeLabel = false)
             if (choosingCiv.religionManager.getReligionWithBelief(belief) == null
                 && belief.getMatchingUniques(UniqueType.OnlyAvailable, StateForConditionals.IgnoreConditionals)
-                    .none { !it.conditionalsApply(choosingCiv) }) {
+                    .none { !it.conditionalsApply(choosingCiv.state) }) {
                 beliefButton.onClickSelect(selection, belief) {
                     selectedPantheon = belief
                     pick("Follow [${belief.name}]".tr())

--- a/core/src/com/unciv/ui/screens/pickerscreens/PromotionTree.kt
+++ b/core/src/com/unciv/ui/screens/pickerscreens/PromotionTree.kt
@@ -104,7 +104,7 @@ class PromotionTree(val unit: MapUnit) {
         }
 
         // Determine unreachable / disabled nodes
-        val state = StateForConditionals(unit.civ, unit = unit)
+        val state = unit.cache.state
         for (node in nodes.values) {
             // defensive - I don't know how to provoke the situation, but if it ever occurs, disallow choosing that promotion
             if (node.promotion.prerequisites.isNotEmpty() && node.parents.isEmpty())

--- a/core/src/com/unciv/ui/screens/pickerscreens/ReligiousBeliefsPickerScreen.kt
+++ b/core/src/com/unciv/ui/screens/pickerscreens/ReligiousBeliefsPickerScreen.kt
@@ -221,7 +221,7 @@ class ReligiousBeliefsPickerScreen (
                     beliefButton.disable(redDisableColor)
                 }
                 belief.getMatchingUniques(UniqueType.OnlyAvailable, StateForConditionals.IgnoreConditionals)
-                    .any { !it.conditionalsApply(choosingCiv) } ->
+                    .any { !it.conditionalsApply(choosingCiv.state) } ->
                     // The Belief is blocked
                     beliefButton.disable(redDisableColor)
 

--- a/core/src/com/unciv/ui/screens/pickerscreens/TechPickerScreen.kt
+++ b/core/src/com/unciv/ui/screens/pickerscreens/TechPickerScreen.kt
@@ -409,7 +409,7 @@ class TechPickerScreen(
         val pathToTech = civTech.getRequiredTechsToDestination(tech)
         for (requiredTech in pathToTech) {
             for (unique in requiredTech.uniqueObjects
-                .filter { it.type == UniqueType.OnlyAvailable && !it.conditionalsApply(civInfo) }) {
+                .filter { it.type == UniqueType.OnlyAvailable && !it.conditionalsApply(civInfo.state) }) {
                 rightSideButton.setText(unique.getDisplayText().tr())
                 rightSideButton.disable()
                 return

--- a/core/src/com/unciv/ui/screens/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/WorldScreen.kt
@@ -23,7 +23,6 @@ import com.unciv.models.TutorialTrigger
 import com.unciv.models.metadata.GameSetupInfo
 import com.unciv.models.ruleset.Event
 import com.unciv.models.ruleset.tile.ResourceType
-import com.unciv.models.ruleset.unique.StateForConditionals
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.ui.components.extensions.centerX
 import com.unciv.ui.components.extensions.darken
@@ -461,7 +460,7 @@ class WorldScreen(
             if (viewingCiv.cache.citiesConnectedToCapitalToMediums.any { it.key.civ == viewingCiv })
                 game.settings.addCompletedTutorialTask("Create a trade route")
         }
-        val stateForConditionals = StateForConditionals(viewingCiv)
+        val stateForConditionals = viewingCiv.state
         return gameInfo.ruleset.events.values.firstOrNull {
             it.presentation == Event.Presentation.Floating &&
                 it.isAvailable(stateForConditionals)

--- a/core/src/com/unciv/ui/screens/worldscreen/topbar/WorldScreenTopBarResources.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/topbar/WorldScreenTopBarResources.kt
@@ -7,7 +7,6 @@ import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.unciv.logic.civilization.Civilization
 import com.unciv.models.ruleset.tile.ResourceType
 import com.unciv.models.ruleset.tile.TileResource
-import com.unciv.models.ruleset.unique.StateForConditionals
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.translations.tr
 import com.unciv.ui.components.MayaCalendar
@@ -93,7 +92,7 @@ internal class WorldScreenTopBarResources(topbar: WorldScreenTopBar) : ScalingTa
         for ((index, resourceActors) in resourceActors.withIndex()) {
             val (resource, label, icon) = resourceActors
 
-            if (resource.hasUnique(UniqueType.NotShownOnWorldScreen, StateForConditionals(civInfo))) continue
+            if (resource.hasUnique(UniqueType.NotShownOnWorldScreen, civInfo.state)) continue
 
             val amount = civResources[resource.name] ?: 0
 

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsFromUniques.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsFromUniques.kt
@@ -197,7 +197,7 @@ object UnitActionsFromUniques {
             // extends an existing unit action
             if (unique.hasModifier(UniqueType.UnitActionExtraLimitedTimes)) continue
             if (!unique.isTriggerable) continue
-            if (!unique.conditionalsApply(StateForConditionals(civInfo = unit.civ, unit = unit, tile = unit.currentTile))) continue
+            if (!unique.conditionalsApply(unit.cache.state)) continue
             if (!UnitActionModifiers.canUse(unit, unique)) continue
 
             val baseTitle = when (unique.type) {
@@ -366,8 +366,7 @@ object UnitActionsFromUniques {
     internal fun getTransformActions(unit: MapUnit, tile: Tile) = sequence {
         val unitTile = unit.getTile()
         val civInfo = unit.civ
-        val stateForConditionals =
-            StateForConditionals(unit = unit, civInfo = civInfo, tile = unitTile)
+        val stateForConditionals = unit.cache.state
 
         for (unique in unit.getMatchingUniques(UniqueType.CanTransform, stateForConditionals)) {
             val unitToTransformTo = civInfo.getEquivalentUnit(unique.params[0])
@@ -383,7 +382,7 @@ object UnitActionsFromUniques {
             val resourceRequirementsDelta = Counter<String>()
             for ((resource, amount) in unit.getResourceRequirementsPerTurn())
                 resourceRequirementsDelta.add(resource, -amount)
-            for ((resource, amount) in unitToTransformTo.getResourceRequirementsPerTurn(StateForConditionals(unit.civ, unit = unit)))
+            for ((resource, amount) in unitToTransformTo.getResourceRequirementsPerTurn(unit.cache.state))
                 resourceRequirementsDelta.add(resource, amount)
             val newResourceRequirementsString = resourceRequirementsDelta.entries
                 .filter { it.value > 0 }

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsPillage.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsPillage.kt
@@ -7,7 +7,6 @@ import com.unciv.logic.map.mapunit.MapUnit
 import com.unciv.logic.map.tile.Tile
 import com.unciv.models.UnitAction
 import com.unciv.models.UnitActionType
-import com.unciv.models.ruleset.unique.StateForConditionals
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.stats.Stat
 import com.unciv.models.stats.Stats
@@ -74,7 +73,7 @@ object UnitActionsPillage {
 
         // Accumulate the loot
         val pillageYield = Stats()
-        val stateForConditionals = StateForConditionals(unit=unit)
+        val stateForConditionals = unit.cache.state
         for (unique in improvement.getMatchingUniques(UniqueType.PillageYieldRandom, stateForConditionals)) {
             for ((stat, value) in unique.stats) {
                 // Unique text says "approximately [X]", so we add 0..X twice - think an RPG's 2d12

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsUpgrade.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsUpgrade.kt
@@ -4,7 +4,6 @@ import com.unciv.logic.map.mapunit.MapUnit
 import com.unciv.models.Counter
 import com.unciv.models.UnitAction
 import com.unciv.models.UpgradeUnitAction
-import com.unciv.models.ruleset.unique.StateForConditionals
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.translations.tr
 
@@ -20,11 +19,11 @@ object UnitActionsUpgrade {
         val unitTile = unit.getTile()
         val civInfo = unit.civ
         val specialUpgradesTo = if (isSpecial)
-            unit.baseUnit.getMatchingUniques(UniqueType.RuinsUpgrade, StateForConditionals(civInfo, unit = unit))
+            unit.baseUnit.getMatchingUniques(UniqueType.RuinsUpgrade, unit.cache.state)
                 .map { it.params[0] }.firstOrNull()
         else null
         val upgradeUnits = if (specialUpgradesTo != null) sequenceOf(specialUpgradesTo)
-            else unit.baseUnit.getUpgradeUnits(StateForConditionals(civInfo, unit = unit))
+            else unit.baseUnit.getUpgradeUnits(unit.cache.state)
         if (upgradeUnits.none()) return@sequence // can't upgrade to anything
         if (!isAnywhere && unitTile.getOwner() != civInfo) return@sequence
 
@@ -39,7 +38,7 @@ object UnitActionsUpgrade {
             val resourceRequirementsDelta = Counter<String>()
             for ((resource, amount) in unit.getResourceRequirementsPerTurn())
                 resourceRequirementsDelta.add(resource, -amount)
-            for ((resource, amount) in upgradedUnit.getResourceRequirementsPerTurn(StateForConditionals(unit.civ, unit = unit)))
+            for ((resource, amount) in upgradedUnit.getResourceRequirementsPerTurn(unit.cache.state))
                 resourceRequirementsDelta.add(resource, amount)
             for ((resource, _) in resourceRequirementsDelta.filter { it.value < 0 })  // filter copies, so no CCM
                 resourceRequirementsDelta[resource] = 0

--- a/tests/src/com/unciv/logic/map/UnitMovementTests.kt
+++ b/tests/src/com/unciv/logic/map/UnitMovementTests.kt
@@ -11,6 +11,7 @@ import com.unciv.logic.civilization.diplomacy.DiplomaticStatus
 import com.unciv.logic.map.mapunit.MapUnit
 import com.unciv.logic.map.tile.Tile
 import com.unciv.models.ruleset.nation.Nation
+import com.unciv.models.ruleset.unique.StateForConditionals
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.ruleset.unit.BaseUnit
 import com.unciv.models.ruleset.unit.UnitType
@@ -178,6 +179,7 @@ class UnitMovementTests {
         barbCiv.gameInfo = testGame.gameInfo
         barbCiv.setNameForUnitTests(Constants.barbarians) // they are always enemies
         barbCiv.nation = Nation().apply { name = Constants.barbarians }
+        barbCiv.cache.updateState()
 
         testGame.gameInfo.civilizations.add(barbCiv)
 

--- a/tests/src/com/unciv/testing/TestGame.kt
+++ b/tests/src/com/unciv/testing/TestGame.kt
@@ -136,6 +136,7 @@ class TestGame {
         civInfo.gameInfo = gameInfo
         civInfo.setNameForUnitTests(nation.name)
         if (isPlayer) civInfo.playerType = PlayerType.Human
+        civInfo.cache.updateState()
         gameInfo.civilizations.add(civInfo)
         civInfo.setTransients()
 
@@ -153,6 +154,7 @@ class TestGame {
         nation.name = Constants.barbarians
         barbarianCivilization.nation = nation
         barbarianCivilization.gameInfo = gameInfo
+        barbarianCivilization.cache.updateState()
         gameInfo.civilizations.add(barbarianCivilization)
         return barbarianCivilization
     }


### PR DESCRIPTION
Side note: I don't know if it makes sense to refresh the state for civs in ``setTransients``. The only thing I can think of is if the gameInfo changes midgame