### PR TITLE
Move capitalCityIndicator

### DIFF
--- a/core/src/com/unciv/logic/city/City.kt
+++ b/core/src/com/unciv/logic/city/City.kt
@@ -163,14 +163,6 @@ class City : IsPartOfGameInfoSerialization, INamed {
     fun getWorkRange(): Int = civ.gameInfo.ruleset.modOptions.constants.cityWorkRange
     fun getExpandRange(): Int = civ.gameInfo.ruleset.modOptions.constants.cityExpandRange
 
-    fun capitalCityIndicator(): Building? {
-        val indicatorBuildings = getRuleset().buildings.values.asSequence()
-            .filter { it.hasUnique(UniqueType.IndicatesCapital) }
-
-        val civSpecificBuilding = indicatorBuildings.firstOrNull { it.uniqueTo != null && civ.matchesFilter(it.uniqueTo!!, state) }
-        return civSpecificBuilding ?: indicatorBuildings.firstOrNull()
-    }
-
     fun isConnectedToCapital(connectionTypePredicate: (Set<String>) -> Boolean = { true }): Boolean {
         val mediumTypes = civ.cache.citiesConnectedToCapitalToMediums[this] ?: return false
         return connectionTypePredicate(mediumTypes)

--- a/core/src/com/unciv/logic/city/managers/CityConquestFunctions.kt
+++ b/core/src/com/unciv/logic/city/managers/CityConquestFunctions.kt
@@ -186,7 +186,7 @@ class CityConquestFunctions(val city: City) {
 
         if (foundingCiv.cities.size == 1) {
             // Resurrection!
-            val capitalCityIndicator = city.capitalCityIndicator()
+            val capitalCityIndicator = conqueringCiv.capitalCityIndicator(city.state)
             if (capitalCityIndicator != null) city.cityConstructions.addBuilding(capitalCityIndicator)
             for (civ in city.civ.gameInfo.civilizations) {
                 if (civ == foundingCiv || civ == conqueringCiv) continue // don't need to notify these civs

--- a/core/src/com/unciv/logic/city/managers/CityFounder.kt
+++ b/core/src/com/unciv/logic/city/managers/CityFounder.kt
@@ -205,7 +205,7 @@ class CityFounder {
     private fun addStartingBuildings(city: City, civInfo: Civilization, startingEra: String) {
         val ruleset = civInfo.gameInfo.ruleset
         if (civInfo.cities.size == 1) {
-            val capitalCityIndicator = city.capitalCityIndicator()
+            val capitalCityIndicator = civInfo.capitalCityIndicator(city.state)
             if (capitalCityIndicator != null)
                 city.cityConstructions.addBuilding(capitalCityIndicator, tryAddFreeBuildings = false)
         }


### PR DESCRIPTION
PR is to move capitalCityIndicator, as it ~~previously~~ doesn't make sense in the city code. Starting as a draft because there are many, many, many questions. I wish I PR'ed this a while ago before "uniqueTo" became something you can filter from as many aspects made more sense before then

1. Currently, the ``IndicatesCapital`` unique does not use conditionals. ``City.isCapital`` uses getUniqiues instead of getMatchingUniques, which inherently ignores condtionals. ``CityConquestFunctions.destroyBuildingsOnCapture`` uses hasUnique, but this is not given a state, so it uses ``EmptyState`` instead of ``IgnoreConditionals``, auto-failing any civ/city check. previously, this function also used hasUnique without a state, thus having the same problem. This PR changes it to specifically use IgnoreConditionals for consistency with ``isCapital``
2.  Since uniqueTo uses filters and filters can now have conditionals ~~and uniqueTo can multiFilter~~, there is a question of which state this should use. I would assume IgnoreConditionals here as well, not the civ's state or the city's state like I erroneously used prior. This PR as of writing this keeps the incorrect behavior of the previous PR, but I can easily change it back
3. If there is an assumption that this should be consistent all game, then this information should be cached. This would change the answer of point 2 to be "the civ state at the time of caching", same as the ``uniqueBulidings`` cache. This isn't a particularly complicated bit, but it does force the question of when we want to check the filter as what to cache changes based on when we want to check for filters

Side note, regardless of those points, the changes to ``Civ.moveCapitalTo`` to keep the code functioning as it did prior. kotlin's smart casting isn't recognizing that ``city`` can't be null if the indicator isn't null