### PR TITLE
Refactor: Move Capital building function from city to civ

### DIFF
--- a/core/src/com/unciv/logic/city/City.kt
+++ b/core/src/com/unciv/logic/city/City.kt
@@ -163,14 +163,6 @@ class City : IsPartOfGameInfoSerialization, INamed {
     fun getWorkRange(): Int = civ.gameInfo.ruleset.modOptions.constants.cityWorkRange
     fun getExpandRange(): Int = civ.gameInfo.ruleset.modOptions.constants.cityExpandRange
 
-    fun capitalCityIndicator(): Building? {
-        val indicatorBuildings = getRuleset().buildings.values.asSequence()
-            .filter { it.hasUnique(UniqueType.IndicatesCapital, state) }
-
-        val civSpecificBuilding = indicatorBuildings.firstOrNull { it.uniqueTo != null && civ.matchesFilter(it.uniqueTo!!, state) }
-        return civSpecificBuilding ?: indicatorBuildings.firstOrNull()
-    }
-
     fun isConnectedToCapital(connectionTypePredicate: (Set<String>) -> Boolean = { true }): Boolean {
         val mediumTypes = civ.cache.citiesConnectedToCapitalToMediums[this] ?: return false
         return connectionTypePredicate(mediumTypes)

--- a/core/src/com/unciv/logic/city/managers/CityConquestFunctions.kt
+++ b/core/src/com/unciv/logic/city/managers/CityConquestFunctions.kt
@@ -186,7 +186,7 @@ class CityConquestFunctions(val city: City) {
 
         if (foundingCiv.cities.size == 1) {
             // Resurrection!
-            val capitalCityIndicator = city.capitalCityIndicator()
+            val capitalCityIndicator = conqueringCiv.capitalCityIndicator(city)
             if (capitalCityIndicator != null) city.cityConstructions.addBuilding(capitalCityIndicator)
             for (civ in city.civ.gameInfo.civilizations) {
                 if (civ == foundingCiv || civ == conqueringCiv) continue // don't need to notify these civs

--- a/core/src/com/unciv/logic/city/managers/CityFounder.kt
+++ b/core/src/com/unciv/logic/city/managers/CityFounder.kt
@@ -205,7 +205,7 @@ class CityFounder {
     private fun addStartingBuildings(city: City, civInfo: Civilization, startingEra: String) {
         val ruleset = civInfo.gameInfo.ruleset
         if (civInfo.cities.size == 1) {
-            val capitalCityIndicator = city.capitalCityIndicator()
+            val capitalCityIndicator = civInfo.capitalCityIndicator(city)
             if (capitalCityIndicator != null)
                 city.cityConstructions.addBuilding(capitalCityIndicator, tryAddFreeBuildings = false)
         }

--- a/core/src/com/unciv/logic/civilization/Civilization.kt
+++ b/core/src/com/unciv/logic/civilization/Civilization.kt
@@ -621,6 +621,17 @@ class Civilization : IsPartOfGameInfoSerialization {
         return baseUnit
     }
 
+    fun capitalCityIndicator(city: City? = null): Building? {
+        val stateForConditionals = if (city?.civ == this) city.state
+        else if (city == null) state
+        else StateForConditionals(this, city)
+        val indicatorBuildings = gameInfo.ruleset.buildings.values.asSequence()
+            .filter { it.hasUnique(UniqueType.IndicatesCapital, stateForConditionals) }
+
+        val civSpecificBuilding = indicatorBuildings.firstOrNull { it.uniqueTo != null && matchesFilter(it.uniqueTo!!, stateForConditionals) }
+        return civSpecificBuilding ?: indicatorBuildings.firstOrNull()
+    }
+
     override fun toString(): String = civName // for debug
 
     /**
@@ -926,10 +937,10 @@ class Civilization : IsPartOfGameInfoSerialization {
      */
     fun moveCapitalTo(city: City?, oldCapital: City?) {
         // Add new capital first so the civ doesn't get stuck in a state where it has cities but no capital
-        val newCapitalIndicator = city?.capitalCityIndicator()
+        val newCapitalIndicator = if (city == null) null else capitalCityIndicator(city)
         if (newCapitalIndicator != null) {
             // move new capital
-            city.cityConstructions.addBuilding(newCapitalIndicator)
+            city!!.cityConstructions.addBuilding(newCapitalIndicator)
             city.isBeingRazed = false // stop razing the new capital if it was being razed
 
             // move the buildings with MovedToNewCapital unique
@@ -946,8 +957,8 @@ class Civilization : IsPartOfGameInfoSerialization {
             }
         }
 
-        val oldCapitalIndicator = oldCapital?.capitalCityIndicator()
-        if (oldCapitalIndicator != null) oldCapital.cityConstructions.removeBuilding(oldCapitalIndicator)
+        val oldCapitalIndicator = if (oldCapital == null) null else capitalCityIndicator(oldCapital)
+        if (oldCapitalIndicator != null) oldCapital!!.cityConstructions.removeBuilding(oldCapitalIndicator)
     }
 
     /** @param oldCapital `null` when destroying, otherwise old capital */


### PR DESCRIPTION
No functional change, just moving as the code is technically more relevant to the Civ and only uses the city for state reasons

Side note: imo it's a bit awkward that the code for moving the capital doesn't actually look for any buildings in the city that indicates the capital. Theoretically, in a mad mod, it could mean that with rulesets where you can get multiples of such buildings that you can end up either leaving behind some of the capital buildings or simply not remove any of them