### PR TITLE
Small fix to uniques.md - hide all text for "Neighboring tiles" unique description

### DIFF
--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -2204,7 +2204,7 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 ??? example  "Neighboring tiles will convert to [baseTerrain/terrainFeature]"
 	Supports conditionals that need only a Tile as context and nothing else, like `<with [n]% chance>`, and applies them per neighbor.
-If your mod renames Coast or Lakes, do not use this with one of these as parameter, as the code preventing artifacts won't work.
+    If your mod renames Coast or Lakes, do not use this with one of these as parameter, as the code preventing artifacts won't work.
 	Example: "Neighboring tiles will convert to [Grassland]"
 
 	Applicable to: Terrain


### PR DESCRIPTION
There's a slight error in the Uniques doc that results in some of the text not being hidden before clicking on the unique description. This should fix that error.