### PR TITLE
Add stockpile uniques for golden ages

### DIFF
--- a/core/src/com/unciv/Constants.kt
+++ b/core/src/com/unciv/Constants.kt
@@ -43,6 +43,8 @@ object Constants {
     const val barbarianEncampment = "Barbarian encampment"
     const val cityCenter = "City center"
     
+    const val goldenAgePoints = "GA Points"
+    
     // Treaties
     const val peaceTreaty = "Peace Treaty"
     const val researchAgreement = "Research Agreement"

--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -390,7 +390,7 @@ object Battle {
                 val percentage = unique.params[0].toFloat()
                 val stockpile = unique.params[2]
                 if (stockpile == "golden age points") {
-                    civ.goldenAges.addHappines((percentage / 100f * damageDealt).roundToInt())
+                    civ.goldenAges.addHappiness((percentage / 100f * damageDealt).roundToInt())
                     continue
                 }
                 val plunderedResource = civ.gameInfo.ruleset.tileResources[stockpile]

--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -389,7 +389,7 @@ object Battle {
             if (plunderedUnit.matchesFilter(unique.params[1])) {
                 val percentage = unique.params[0].toFloat()
                 val stockpile = unique.params[2]
-                if (stockpile == "golden age points") {
+                if (stockpile == Constants.goldenAgePoints) {
                     civ.goldenAges.addHappiness((percentage / 100f * damageDealt).roundToInt())
                     continue
                 }

--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -26,6 +26,7 @@ import com.unciv.ui.screens.worldscreen.unit.actions.UnitActionsPillage
 import com.unciv.utils.debug
 import kotlin.math.max
 import kotlin.math.min
+import kotlin.math.roundToInt
 import kotlin.random.Random
 
 /**
@@ -383,6 +384,20 @@ object Battle {
                 plunderingUnit.getName(), NotificationIcon.War, "StatIcons/${key.name}",
                 if (plunderedUnit is CityCombatant) NotificationIcon.City else plunderedUnit.getName()
             )
+        }
+        for (unique in plunderingUnit.unit.getMatchingUniques(UniqueType.DamageUnitsPlunderStockpile, checkCivInfoUniques = true)) {
+            if (plunderedUnit.matchesFilter(unique.params[1])) {
+                val percentage = unique.params[0].toFloat()
+                val stockpile = unique.params[2]
+                if (stockpile == "golden age points") {
+                    civ.goldenAges.addHappines((percentage / 100f * damageDealt).roundToInt())
+                    continue
+                }
+                val plunderedResource = civ.gameInfo.ruleset.tileResources[stockpile]
+                if (plunderedResource != null && plunderedResource.isStockpiled()) {
+                    civ.resourceStockpiles.add(stockpile, (percentage / 100f * damageDealt).roundToInt())
+                }
+            }
         }
     }
 

--- a/core/src/com/unciv/logic/civilization/managers/GoldenAgeManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/GoldenAgeManager.kt
@@ -9,7 +9,6 @@ import com.unciv.logic.civilization.PopupAlert
 import com.unciv.models.ruleset.unique.UniqueTriggerActivation
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.ui.components.extensions.toPercent
-import kotlin.math.max
 
 class GoldenAgeManager : IsPartOfGameInfoSerialization {
     @Transient
@@ -28,6 +27,10 @@ class GoldenAgeManager : IsPartOfGameInfoSerialization {
     }
 
     fun isGoldenAge(): Boolean = turnsLeftForCurrentGoldenAge > 0
+    
+    fun addHappines(amount: Int) {
+        storedHappiness += amount
+    }
 
     fun happinessRequiredForNextGoldenAge(): Int {
         var cost = (500 + numberOfGoldenAges * 250).toFloat()

--- a/core/src/com/unciv/logic/civilization/managers/GoldenAgeManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/GoldenAgeManager.kt
@@ -28,7 +28,7 @@ class GoldenAgeManager : IsPartOfGameInfoSerialization {
 
     fun isGoldenAge(): Boolean = turnsLeftForCurrentGoldenAge > 0
     
-    fun addHappines(amount: Int) {
+    fun addHappiness(amount: Int) {
         storedHappiness += amount
     }
 

--- a/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
@@ -470,6 +470,11 @@ enum class UniqueParameterType(
     StockpiledResource("stockpiledResource", "Mana", "The name of any stockpiled resource") {
         override fun getKnownValuesForAutocomplete(ruleset: Ruleset) = ruleset.tileResources.filter { it.value.isStockpiled() }.keys
     },
+    
+    StockPile("stockpile", "Mana", "The name of any stockpiled resource or stockpilable stat"){
+        override fun getKnownValuesForAutocomplete(ruleset: Ruleset): Set<String> =
+            ruleset.tileResources.filter { it.value.isStockpiled() }.keys + "golden age points"
+    },
 
     /** Used by [UniqueType.ImprovesResources], implemented by [com.unciv.models.ruleset.tile.TileResource.matchesFilter] */
     ResourceFilter("resourceFilter", "Strategic", "A resource name, type, 'all', or a Stat listed in the resource's improvementStats",

--- a/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
@@ -473,7 +473,7 @@ enum class UniqueParameterType(
     
     StockPile("stockpile", "Mana", "The name of any stockpiled resource or stockpilable stat"){
         override fun getKnownValuesForAutocomplete(ruleset: Ruleset): Set<String> =
-            ruleset.tileResources.filter { it.value.isStockpiled() }.keys + "golden age points"
+            ruleset.tileResources.filter { it.value.isStockpiled() }.keys + Constants.goldenAgePoints
     },
 
     /** Used by [UniqueType.ImprovesResources], implemented by [com.unciv.models.ruleset.tile.TileResource.matchesFilter] */

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -560,12 +560,12 @@ object UniqueTriggerActivation {
                 var amount = unique.params[0].toIntOrNull() ?: return null
                 if (unique.isModifiedByGameSpeed()) amount = (amount * civInfo.gameInfo.speed.modifier).roundToInt()
                 val resourceName = unique.params[1]
-                val goldenAge = resourceName == "golden age points"
+                val goldenAge = resourceName == Constants.goldenAgePoints
                 if (goldenAge) return {
                     civInfo.goldenAges.addHappiness(amount)
                     val notificationText = getNotificationText(
                         notification, triggerNotificationText,
-                        "You have gained [$amount] golden age points"
+                        "You have gained [$amount] points towards a golden age"
                     )
                     if (notificationText != null)
                         civInfo.addNotification(notificationText, NotificationCategory.General, NotificationIcon.Science, NotificationIcon.Happiness)
@@ -595,12 +595,12 @@ object UniqueTriggerActivation {
                 }
                 val amount = tileBasedRandom.nextInt(minAmount, maxAmount)
                 val resourceName = unique.params[2]
-                val goldenAge = resourceName == "golden age points"
+                val goldenAge = resourceName == Constants.goldenAgePoints
                 if (goldenAge) return {
                     civInfo.goldenAges.addHappiness(amount)
                     val notificationText = getNotificationText(
                         notification, triggerNotificationText,
-                        "You have gained [$amount] golden age points"
+                        "You have gained [$amount] points towards a golden age"
                     )
                     if (notificationText != null)
                         civInfo.addNotification(notificationText, NotificationCategory.General, NotificationIcon.Science, NotificationIcon.Happiness)

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -562,7 +562,7 @@ object UniqueTriggerActivation {
                 val resourceName = unique.params[1]
                 val goldenAge = resourceName == "golden age points"
                 if (goldenAge) return {
-                    civInfo.goldenAges.addHappines(amount)
+                    civInfo.goldenAges.addHappiness(amount)
                     val notificationText = getNotificationText(
                         notification, triggerNotificationText,
                         "You have gained [$amount] golden age points"
@@ -597,7 +597,7 @@ object UniqueTriggerActivation {
                 val resourceName = unique.params[2]
                 val goldenAge = resourceName == "golden age points"
                 if (goldenAge) return {
-                    civInfo.goldenAges.addHappines(amount)
+                    civInfo.goldenAges.addHappiness(amount)
                     val notificationText = getNotificationText(
                         notification, triggerNotificationText,
                         "You have gained [$amount] golden age points"

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -555,6 +555,71 @@ object UniqueTriggerActivation {
                     true
                 }
             }
+            
+            UniqueType.OneTimeGainStockpile -> {
+                var amount = unique.params[0].toIntOrNull() ?: return null
+                if (unique.isModifiedByGameSpeed()) amount = (amount * civInfo.gameInfo.speed.modifier).roundToInt()
+                val resourceName = unique.params[1]
+                val goldenAge = resourceName == "golden age points"
+                if (goldenAge) return {
+                    civInfo.goldenAges.addHappines(amount)
+                    val notificationText = getNotificationText(
+                        notification, triggerNotificationText,
+                        "You have gained [$amount] golden age points"
+                    )
+                    if (notificationText != null)
+                        civInfo.addNotification(notificationText, NotificationCategory.General, NotificationIcon.Science, NotificationIcon.Happiness)
+                    true
+                }
+                val resource = ruleset.tileResources[resourceName] ?: return null
+                if (!resource.isStockpiled()) return null
+                return {
+                    civInfo.resourceStockpiles.add(resourceName, amount)
+
+                    val notificationText = getNotificationText(
+                        notification, triggerNotificationText,
+                        "You have gained [$amount] [$resourceName]"
+                    )
+                    if (notificationText != null)
+                        civInfo.addNotification(notificationText, NotificationCategory.General, NotificationIcon.Science, "ResourceIcons/$resourceName")
+                    true
+                }
+            }
+
+            UniqueType.OneTimeGainStockpileRange -> {
+                var minAmount = unique.params[0].toIntOrNull() ?: return null
+                var maxAmount = unique.params[1].toIntOrNull() ?: return null
+                if (unique.isModifiedByGameSpeed()) {
+                    minAmount = (minAmount * civInfo.gameInfo.speed.modifier).roundToInt()
+                    maxAmount = (maxAmount * civInfo.gameInfo.speed.modifier).roundToInt()
+                }
+                val amount = tileBasedRandom.nextInt(minAmount, maxAmount)
+                val resourceName = unique.params[2]
+                val goldenAge = resourceName == "golden age points"
+                if (goldenAge) return {
+                    civInfo.goldenAges.addHappines(amount)
+                    val notificationText = getNotificationText(
+                        notification, triggerNotificationText,
+                        "You have gained [$amount] golden age points"
+                    )
+                    if (notificationText != null)
+                        civInfo.addNotification(notificationText, NotificationCategory.General, NotificationIcon.Science, NotificationIcon.Happiness)
+                    true
+                }
+                val resource = ruleset.tileResources[resourceName] ?: return null
+                if (!resource.isStockpiled()) return null
+                return {
+                    civInfo.resourceStockpiles.add(resourceName, amount)
+
+                    val notificationText = getNotificationText(
+                        notification, triggerNotificationText,
+                        "You have gained [$amount] [$resourceName]"
+                    )
+                    if (notificationText != null)
+                        civInfo.addNotification(notificationText, NotificationCategory.General, NotificationIcon.Science, "ResourceIcons/$resourceName")
+                    true
+                }
+            }
 
             UniqueType.UnitsGainPromotion -> {
                 val filter = unique.params[0]

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -449,7 +449,6 @@ enum class UniqueType(
 
     // Gains from battle
     DamageUnitsPlunder("Earn [amount]% of the damage done to [combatantFilter] units as [stockpile/civWideStat]", UniqueTarget.Unit, UniqueTarget.Global),
-    DamageUnitsPlunderStockpile("Gain [amount]% of the damage done to [combatantFilter] units as [stockpile]", UniqueTarget.Unit, UniqueTarget.Global),
     CaptureCityPlunder("Upon capturing a city, receive [amount] times its [stat] production as [civWideStat] immediately", UniqueTarget.Unit, UniqueTarget.Global),
     KillUnitPlunder("Earn [amount]% of killed [mapUnitFilter] unit's [costOrStrength] as [civWideStat]", UniqueTarget.Unit, UniqueTarget.Global),
     KillUnitPlunderNearCity("Earn [amount]% of [mapUnitFilter] unit's [costOrStrength] as [civWideStat] when killed within 4 tiles of a city following this religion", UniqueTarget.FollowerBelief),

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -448,8 +448,8 @@ enum class UniqueType(
     UnitUpgradeCost("[relativeAmount]% Gold cost of upgrading", UniqueTarget.Unit, UniqueTarget.Global),
 
     // Gains from battle
-    DamageUnitsPlunder("Earn [amount]% of the damage done to [combatantFilter] units as [civWideStat]", UniqueTarget.Unit, UniqueTarget.Global),
-    DamageUnitsPlunderStockpile("Earn [amount]% of the damage done to [combatantFilter] units as [stockpile]", UniqueTarget.Unit, UniqueTarget.Global),
+    DamageUnitsPlunder("Earn [amount]% of the damage done to [combatantFilter] units as [stockpile/civWideStat]", UniqueTarget.Unit, UniqueTarget.Global),
+    DamageUnitsPlunderStockpile("Gain [amount]% of the damage done to [combatantFilter] units as [stockpile]", UniqueTarget.Unit, UniqueTarget.Global),
     CaptureCityPlunder("Upon capturing a city, receive [amount] times its [stat] production as [civWideStat] immediately", UniqueTarget.Unit, UniqueTarget.Global),
     KillUnitPlunder("Earn [amount]% of killed [mapUnitFilter] unit's [costOrStrength] as [civWideStat]", UniqueTarget.Unit, UniqueTarget.Global),
     KillUnitPlunderNearCity("Earn [amount]% of [mapUnitFilter] unit's [costOrStrength] as [civWideStat] when killed within 4 tiles of a city following this religion", UniqueTarget.FollowerBelief),

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -449,6 +449,7 @@ enum class UniqueType(
 
     // Gains from battle
     DamageUnitsPlunder("Earn [amount]% of the damage done to [combatantFilter] units as [civWideStat]", UniqueTarget.Unit, UniqueTarget.Global),
+    DamageUnitsPlunderStockpile("Earn [amount]% of the damage done to [combatantFilter] units as [stockpile]", UniqueTarget.Unit, UniqueTarget.Global),
     CaptureCityPlunder("Upon capturing a city, receive [amount] times its [stat] production as [civWideStat] immediately", UniqueTarget.Unit, UniqueTarget.Global),
     KillUnitPlunder("Earn [amount]% of killed [mapUnitFilter] unit's [costOrStrength] as [civWideStat]", UniqueTarget.Unit, UniqueTarget.Global),
     KillUnitPlunderNearCity("Earn [amount]% of [mapUnitFilter] unit's [costOrStrength] as [civWideStat] when killed within 4 tiles of a city following this religion", UniqueTarget.FollowerBelief),
@@ -806,6 +807,8 @@ enum class UniqueType(
     OneTimeFreeBelief("Gain a free [beliefType] belief", UniqueTarget.Triggerable),
     OneTimeTriggerVoting("Triggers voting for the Diplomatic Victory", UniqueTarget.Triggerable),  // used in Building
 
+    OneTimeGainStockpile("Instantly gain [amount] [stockpile]", UniqueTarget.Triggerable, flags = setOf(UniqueFlag.AcceptsSpeedModifier)),
+    OneTimeGainStockpileRange("Instantly gain [amount]-[amount] [stockpile]", UniqueTarget.Triggerable, flags = setOf(UniqueFlag.AcceptsSpeedModifier)),
     OneTimeConsumeResources("Instantly consumes [positiveAmount] [stockpiledResource]", UniqueTarget.Triggerable),
     OneTimeProvideResources("Instantly provides [positiveAmount] [stockpiledResource]", UniqueTarget.Triggerable),
 


### PR DESCRIPTION
I know I asked on Discord how I should do this ahead of time, but I do want to actually write out the question kinda as an implementation in code just to give a better understanding of what I'm requesting here. This PR is not meant to be merged alongside #12578 or #12579, and is just a possible solution

closes #12578, closes #12579

This PR adds uniques for stockpiles and golden age points to be gained either as a triggerable or from combat

Pros:
- Allows us to deprecate both the gain and lose uniques for stockpiles similar to how we would do for other similar scenarios
- Adds a unique for gaining resources by combat as well, which may see use elsewhere

Cons:
- Defining what is or isn't a stockpile is kinda tricky. It kinda makes sense for resources, but for hard coded values it becomes a question of definitions. Why isn't stats a stockpile? Are stockpiles supposed to be for resources or other stuff?
- Likewise, the text for golden age points is a bit awkward. Do you put the whole thing "golden age points", or some shortened form ("GA points" or "Golden Age")
- The unique for damage in particular is pretty heavily copy and paste from the stat one which keeps with the pure unique alternative of being something that'll likely be deprecated further