### PR TITLE
Add uniques to gain golden age points

### DIFF
--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -26,6 +26,7 @@ import com.unciv.ui.screens.worldscreen.unit.actions.UnitActionsPillage
 import com.unciv.utils.debug
 import kotlin.math.max
 import kotlin.math.min
+import kotlin.math.roundToInt
 import kotlin.random.Random
 
 /**
@@ -352,6 +353,7 @@ object Battle {
                 UniqueTriggerActivation.triggerUnique(unique, defender.unit, triggerNotificationText = "due to losing [$attackerDamageDealt] HP")
 
         plunderFromDamage(attacker, defender, attackerDamageDealt)
+        goldenAgeFromDamage(attacker, defender, defenderDamageDealt)
         return DamageDealt(attackerDamageDealt, defenderDamageDealt)
     }
 
@@ -383,6 +385,23 @@ object Battle {
                 plunderingUnit.getName(), NotificationIcon.War, "StatIcons/${key.name}",
                 if (plunderedUnit is CityCombatant) NotificationIcon.City else plunderedUnit.getName()
             )
+        }
+    }
+
+    private fun goldenAgeFromDamage(
+        plunderingUnit: ICombatant,
+        plunderedUnit: ICombatant,
+        damageDealt: Int
+    ) {
+        // implementation based on the description of the original civilopedia, see issue #4374
+        if (plunderingUnit !is MapUnitCombatant) return
+
+        val civ = plunderingUnit.getCivInfo()
+        for (unique in plunderingUnit.unit.getMatchingUniques(UniqueType.DamageUnitsGoldenAge, checkCivInfoUniques = true)) {
+            if (plunderedUnit.matchesFilter(unique.params[1])) {
+                val percentage = unique.params[0].toFloat()
+                civ.goldenAges.addHappiness((percentage / 100f * damageDealt).roundToInt())
+            }
         }
     }
 

--- a/core/src/com/unciv/logic/civilization/managers/GoldenAgeManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/GoldenAgeManager.kt
@@ -9,7 +9,6 @@ import com.unciv.logic.civilization.PopupAlert
 import com.unciv.models.ruleset.unique.UniqueTriggerActivation
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.ui.components.extensions.toPercent
-import kotlin.math.max
 
 class GoldenAgeManager : IsPartOfGameInfoSerialization {
     @Transient
@@ -28,6 +27,10 @@ class GoldenAgeManager : IsPartOfGameInfoSerialization {
     }
 
     fun isGoldenAge(): Boolean = turnsLeftForCurrentGoldenAge > 0
+
+    fun addHappiness(amount: Int) {
+        storedHappiness += amount
+    }
 
     fun happinessRequiredForNextGoldenAge(): Int {
         var cost = (500 + numberOfGoldenAges * 250).toFloat()

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -672,6 +672,28 @@ object UniqueTriggerActivation {
                     true
                 }
             }
+            UniqueType.OneTimeGainGoldenAge -> {
+                if (unique.params[0].toIntOrNull() == null) return null
+
+                return {
+                    var amount = unique.params[0].toInt()
+                    if (unique.isModifiedByGameSpeed()) amount = (amount * civInfo.gameInfo.speed.modifier).roundToInt()
+
+                    civInfo.goldenAges.addHappiness(amount)
+
+                    val filledNotification = if (notification != null && notification.hasPlaceholderParameters())
+                        notification.fillPlaceholders(amount.tr())
+                    else notification
+
+                    val notificationText = getNotificationText(
+                        filledNotification, triggerNotificationText,
+                        "Gained $amount golden age points"
+                    )
+                    if (notificationText != null)
+                        civInfo.addNotification(notificationText, LocationAction(tile?.position), NotificationCategory.General, NotificationIcon.Happiness)
+                    true
+                }
+            }
             UniqueType.OneTimeGainPantheon -> {
                 if (civInfo.religionManager.religionState != ReligionState.None) return null
                 val gainedFaith = civInfo.religionManager.faithForPantheon(2)

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -449,6 +449,7 @@ enum class UniqueType(
 
     // Gains from battle
     DamageUnitsPlunder("Earn [amount]% of the damage done to [combatantFilter] units as [civWideStat]", UniqueTarget.Unit, UniqueTarget.Global),
+    DamageUnitsGoldenAge("Earn [amount]% of the damage done to [combatantFilter] units as golden age points", UniqueTarget.Unit, UniqueTarget.Global),
     CaptureCityPlunder("Upon capturing a city, receive [amount] times its [stat] production as [civWideStat] immediately", UniqueTarget.Unit, UniqueTarget.Global),
     KillUnitPlunder("Earn [amount]% of killed [mapUnitFilter] unit's [costOrStrength] as [civWideStat]", UniqueTarget.Unit, UniqueTarget.Global),
     KillUnitPlunderNearCity("Earn [amount]% of [mapUnitFilter] unit's [costOrStrength] as [civWideStat] when killed within 4 tiles of a city following this religion", UniqueTarget.FollowerBelief),
@@ -808,6 +809,7 @@ enum class UniqueType(
 
     OneTimeConsumeResources("Instantly consumes [positiveAmount] [stockpiledResource]", UniqueTarget.Triggerable),
     OneTimeProvideResources("Instantly provides [positiveAmount] [stockpiledResource]", UniqueTarget.Triggerable),
+    OneTimeGainGoldenAge("Gain [amount] golden age points", UniqueTarget.Triggerable, flags = setOf(UniqueFlag.AcceptsSpeedModifier)),
 
     OneTimeGainStat("Gain [amount] [stat]", UniqueTarget.Triggerable, flags = setOf(UniqueFlag.AcceptsSpeedModifier)),
     OneTimeGainStatRange("Gain [amount]-[amount] [stat]", UniqueTarget.Triggerable),


### PR DESCRIPTION
I know I asked on Discord how I should do this ahead of time, but I do want to actually write out the question kinda as an implementation in code just to give a better understanding of what I'm requesting here. This PR is not meant to be merged alongside #12577 or #12579, and is just a possible solution

closes #12577, closes #12579

This PR adds uniques for golden age points to be gained either as a triggerable or from combat

Pros:
- Simple. Easy. What I would typically expect if I wasn't overthinking this
- Probably the easier to create good text for

Cons:
- Very similar to other uniques. Probably should be rolled into the uniques for stats arpund this topic