### PR TITLE
Add golden age points to stats

### DIFF
--- a/core/src/com/unciv/logic/civilization/Civilization.kt
+++ b/core/src/com/unciv/logic/civilization/Civilization.kt
@@ -855,6 +855,7 @@ class Civilization : IsPartOfGameInfoSerialization {
                               if(amount > 0) totalCultureForContests += amount }
             Stat.Science -> tech.addScience(amount)
             Stat.Gold -> addGold(amount)
+            Stat.GoldenAge -> goldenAges.addHappiness(amount)
             Stat.Faith -> { religionManager.storedFaith += amount
                             if(amount > 0) totalFaithForContests += amount }
             else -> {}
@@ -871,6 +872,7 @@ class Civilization : IsPartOfGameInfoSerialization {
                 else tech.researchOfTech(tech.currentTechnology()!!.name)
             }
             Stat.Gold -> gold
+            Stat.GoldenAge -> goldenAges.storedHappiness
             Stat.Faith -> religionManager.storedFaith
             else -> 0
         }

--- a/core/src/com/unciv/logic/civilization/managers/GoldenAgeManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/GoldenAgeManager.kt
@@ -9,7 +9,6 @@ import com.unciv.logic.civilization.PopupAlert
 import com.unciv.models.ruleset.unique.UniqueTriggerActivation
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.ui.components.extensions.toPercent
-import kotlin.math.max
 
 class GoldenAgeManager : IsPartOfGameInfoSerialization {
     @Transient
@@ -28,6 +27,10 @@ class GoldenAgeManager : IsPartOfGameInfoSerialization {
     }
 
     fun isGoldenAge(): Boolean = turnsLeftForCurrentGoldenAge > 0
+    
+    fun addHappiness(amount: Int) {
+        storedHappiness += amount
+    }
 
     fun happinessRequiredForNextGoldenAge(): Int {
         var cost = (500 + numberOfGoldenAges * 250).toFloat()

--- a/core/src/com/unciv/models/ruleset/nation/Personality.kt
+++ b/core/src/com/unciv/models/ruleset/nation/Personality.kt
@@ -1,7 +1,6 @@
 package com.unciv.models.ruleset.nation
 
 import com.unciv.Constants
-import com.unciv.logic.civilization.Civilization
 import com.unciv.models.ruleset.RulesetObject
 import com.unciv.models.ruleset.unique.UniqueTarget
 import com.unciv.models.stats.Stat
@@ -39,6 +38,7 @@ enum class PersonalityValue {
                 Stat.Culture -> Culture
                 Stat.Happiness -> Happiness
                 Stat.Faith -> Faith
+                Stat.GoldenAge -> Happiness
             }
         }
     }

--- a/core/src/com/unciv/models/stats/Stat.kt
+++ b/core/src/com/unciv/models/stats/Stat.kt
@@ -18,14 +18,16 @@ enum class Stat(
     Science(NotificationIcon.Science, UncivSound.Chimes, Fonts.science, colorFromHex(0x8c9dff)),
     Culture(NotificationIcon.Culture, UncivSound.Paper, Fonts.culture, colorFromHex(0x8b60ff)),
     Happiness(NotificationIcon.Happiness, UncivSound.Click, Fonts.happiness, colorFromHex(0xffd800)),
-    Faith(NotificationIcon.Faith, UncivSound.Choir, Fonts.faith, colorFromHex(0xcbdfff));
+    GoldenAge(NotificationIcon.Happiness, UncivSound.Click, Fonts.happiness, colorFromHex(0xffd800)),
+    Faith(NotificationIcon.Faith, UncivSound.Choir, Fonts.faith, colorFromHex(0xcbdfff)),
+    ;
 
     companion object {
-        val statsUsableToBuy = setOf(Gold, Food, Science, Culture, Faith)
-        private val valuesAsMap = values().associateBy { it.name }
+        val statsUsableToBuy = setOf(Gold, Food, Science, Culture, Faith, GoldenAge)
+        private val valuesAsMap = entries.associateBy { it.name }
         fun safeValueOf(name: String) = valuesAsMap[name]
         fun isStat(name: String) = name in valuesAsMap
         fun names() = valuesAsMap.keys
-        val statsWithCivWideField = setOf(Gold, Science, Culture, Faith)
+        val statsWithCivWideField = setOf(Gold, Science, Culture, Faith, GoldenAge)
     }
 }

--- a/core/src/com/unciv/models/stats/Stats.kt
+++ b/core/src/com/unciv/models/stats/Stats.kt
@@ -18,7 +18,8 @@ open class Stats(
     var science: Float = 0f,
     var culture: Float = 0f,
     var happiness: Float = 0f,
-    var faith: Float = 0f
+    var faith: Float = 0f,
+    var goldenAge: Float = 0f
 ): Iterable<Stats.StatValuePair> {
 
     // This is what facilitates indexed access by [Stat] or add(Stat,Float)
@@ -32,6 +33,7 @@ open class Stats(
             Stat.Culture -> ::culture
             Stat.Happiness -> ::happiness
             Stat.Faith -> ::faith
+            Stat.GoldenAge -> ::goldenAge
         }
     }
 
@@ -206,6 +208,7 @@ open class Stats(
         if (culture != 0f) yield(StatValuePair(Stat.Culture, culture))
         if (happiness != 0f) yield(StatValuePair(Stat.Happiness, happiness))
         if (faith != 0f) yield(StatValuePair(Stat.Faith, faith))
+        if (goldenAge != 0f) yield(StatValuePair(Stat.GoldenAge, goldenAge))
     }
 
     /** Enables aggregates over the values, never empty */

--- a/tests/src/com/unciv/testing/BasicTests.kt
+++ b/tests/src/com/unciv/testing/BasicTests.kt
@@ -295,13 +295,14 @@ class BasicTests {
     fun statMathRandomResultTest() {
         val iterations = 42
         val expectedStats = Stats(
-            production = 212765.08f,
-            food = 776.8394f,
-            gold = -4987.297f,
-            science = 14880.18f,
-            culture = -49435.21f,
-            happiness = -13046.4375f,
-            faith = 7291.375f
+            production = 121978.49f,
+            food = -61781.594f,
+            gold = 26999.16f,
+            science = -314892.78f,
+            culture = -863140.8f,
+            happiness = -3383080.8f,
+            faith = -120111.21f,
+            goldenAge = 1774618.2f
         )
         // This is dependent on iterator order, so when that changes the expected values must change too
         val stats = statMathRunner(iterations)


### PR DESCRIPTION
I know I asked on Discord how I should do this ahead of time, but I do want to actually write out the question kinda as an implementation in code just to give a better understanding of what I'm requesting here. This PR is not meant to be merged alongside #12577 or #12578, and is just a possible solution

closes #12577, closes #12578

This PR adds golden age points as if it was a stat

Pros:
- Doesn't actually need to add a unique as we have plenty of uniques for stats around these sorts of topics
- Also potentially opens up other doors for other things (adding to golden age points per turn without affecting happiness)

Cons:
- This is not really a stat as it is a substat (it's more or less directly handled by happiness)
- This does not have its own icon
- It also means stuff like buildings can directly add to it per turn. I consider this both a pro and a con

Side note: We could create a separate interface that encompasses stats and these sorts of "substats" and then maneuver a lot of the code around that instead. That would actually give a benefit of not needing to add logic to this alongside stats objects like buildings and tiles