### PR TITLE
Update ReligionAutomation.kt

### DIFF
--- a/core/src/com/unciv/logic/automation/civilization/ReligionAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/ReligionAutomation.kt
@@ -216,7 +216,7 @@ object ReligionAutomation {
                 score += tileScore * when {
                     city.workedTiles.contains(tile.position) -> 1f // worked
                     tile.getCity() == city -> 0.7f // workable
-                    else -> 0.3f // unavailable
+                    else -> 0.5f // unavailable - for now
                 } * (Random.nextFloat() * 0.05f + 0.975f)
             }
 
@@ -237,14 +237,15 @@ object ReligionAutomation {
         var bonusYield = 0f
         for (unique in belief.uniqueObjects) {
             when (unique.type) {
-                UniqueType.StatsFromObject -> if (tile.matchesFilter(unique.params[1]))
+                UniqueType.StatsFromObject -> if ((tile.matchesFilter(unique.params[1])
+                    && !(tile.lastTerrain.hasUnique(UniqueType.ProductionBonusWhenRemoved) && tile.lastTerrain.matchesFilter(unique.params[1])) //forest pantheons are bad, as we want to remove the forests
+                    || (tile.resource != null && (tile.tileResource.matchesFilter(unique.params[1]) || tile.tileResource.isImprovedBy(unique.params[1]))))) //resource pantheons are good, as we want to work the tile anyways
                     bonusYield += unique.stats.values.sum()
                 UniqueType.StatsFromTilesWithout ->
                     if (city.matchesFilter(unique.params[3])
                         && tile.matchesFilter(unique.params[1])
                         && !tile.matchesFilter(unique.params[2])
                     ) bonusYield += unique.stats.values.sum()
-                // ToDo: Also calculate add stats for improvements that will be buildable
                 else -> {}
             }
         }
@@ -261,7 +262,7 @@ object ReligionAutomation {
             // If obsoleted, continue
             score += modifier * when (unique.type) {
                 UniqueType.GrowthPercentBonus -> unique.params[0].toFloat() / 3f
-                UniqueType.BorderGrowthPercentage -> -unique.params[0].toFloat() * 2f / 10f
+                UniqueType.BorderGrowthPercentage -> -unique.params[0].toFloat() / 10f
                 UniqueType.StrengthForCities -> unique.params[0].toFloat() / 10f // Modified by personality
                 UniqueType.CityHealingUnits -> unique.params[1].toFloat() / 10f
                 UniqueType.PercentProductionBuildings -> unique.params[0].toFloat() / 3f
@@ -275,8 +276,8 @@ object ReligionAutomation {
                     when {
                         ruleSet.buildings.containsKey(unique.params[1]) -> {
                             unique.stats.values.sum() *
-                                if (ruleSet.buildings[unique.params[1]]!!.isNationalWonder) 0.5f //there's at most 1 copy of each of these in our empire
-                                else 1.5f //yields for buildings are usually more desireable than faith-purchased buildings, as we might not need an upfront investment
+                                if (ruleSet.buildings[unique.params[1]]!!.isNationalWonder) 0.25f //there's at most 1 copy of each of these in our empire, and the AI is slow at getting it
+                                else 1f // Yields from regular buildings won't need the upfront purchase cost as is the case with religion buildings, but they may have weird requirements (gardens etc.)
 
                         }
                         ruleSet.specialists.containsKey(unique.params[1]) -> {
@@ -284,17 +285,17 @@ object ReligionAutomation {
                                 if (city.population.population > 8f) 2f
                                 else 1f
                         }
-                        else -> unique.stats.values.sum() * 1f //should account for most edge cases here
+                        else -> unique.stats.values.sum() * 0f //yields from world wonders and great improvements - the latter needs additional AI logic to be used correctly
                     }
                 UniqueType.StatsFromTradeRoute ->
                     unique.stats.values.sum() *
-                        if (city.isConnectedToCapital()) 2f
-                        else 1f
+                        if (city.isConnectedToCapital()) 1f
+                        else 0f //no yields from the belief yet, also for pantheons it's quite low-tempo
                 UniqueType.StatPercentFromReligionFollowers ->
                     min(unique.params[0].toFloat() * city.population.population, unique.params[2].toFloat())
                 UniqueType.StatsPerCity ->
                     if (city.matchesFilter(unique.params[1]))
-                        unique.stats.values.sum() * 2f //free yields
+                        unique.stats.values.sum() * 1f //free yields
                     else 0f
                 else -> 0f
             }
@@ -344,27 +345,28 @@ object ReligionAutomation {
             // Some city-filters are modified by personality (non-enemy foreign cities)
             score += modifier * when (unique.type) {
                 UniqueType.KillUnitPlunderNearCity ->
-                    unique.params[0].toFloat() * 0.5f * //can be very strong, but a low weight for now as the AI currently isn't farming barb camp
-                        if (civInfo.wantsToFocusOn(Victory.Focus.Military)) 2f
-                        else 1f
+                    unique.params[0].toFloat() * //can be very strong, but a low weight for now as the AI currently isn't farming barb camp
+                        if (civInfo.wantsToFocusOn(Victory.Focus.Military)) 0.5f
+                        else 0.25f
                 UniqueType.BuyUnitsForAmountStat, UniqueType.BuyBuildingsForAmountStat ->
                     if (civInfo.religionManager.religion != null
                         && civInfo.religionManager.religion!!.followerBeliefUniqueMap.getUniques(unique.type).any()
                     ) 0f
                     // This is something completely different from the original, but I have no idea
                     // what happens over there
-                    else civInfo.stats.statsForNextTurn[Stat.valueOf(unique.params[2])] * 200f / unique.params[1].toFloat() //the costs of these are probably similar to the baseUnitBuyCost
+                    else civInfo.stats.statsForNextTurn[Stat.valueOf(unique.params[2])] * 300f / unique.params[1].toFloat() //the costs of these are probably similar to the baseUnitBuyCost
                 UniqueType.BuyUnitsWithStat, UniqueType.BuyBuildingsWithStat ->
                     if (civInfo.religionManager.religion != null
                         && civInfo.religionManager.religion!!.followerBeliefUniqueMap.getUniques(unique.type).any()
                     ) 0f
                     // This is something completely different from the original, but I have no idea
                     // what happens over there
-                    else civInfo.stats.statsForNextTurn[Stat.valueOf(unique.params[1])] * 200f / civInfo.getEra().baseUnitBuyCost //baseUnitBuyCost is 200 in Standard speed pre-Renaissance
+                    else civInfo.stats.statsForNextTurn[Stat.valueOf(unique.params[1])] * 300f / civInfo.getEra().baseUnitBuyCost
+                    //baseUnitBuyCost is 200 in Standard speed pre-Renaissance, but overvalue such as to let the high-faith civs pick the good faith sinks 
                 UniqueType.BuyUnitsByProductionCost ->
                     0f //Holy Warriors is a waste if we don't buy units with it, and if we buy units with it'll cost us great persons
                 UniqueType.StatsWhenSpreading ->
-                    unique.params[0].toFloat() / 10f
+                    unique.params[0].toFloat() / 15f
                 UniqueType.StatsWhenAdoptingReligion ->
                     unique.stats.values.sum() / 50f
                 UniqueType.RestingPointOfCityStatesFollowingReligionChange ->
@@ -377,13 +379,13 @@ object ReligionAutomation {
                 UniqueType.StatsFromGlobalFollowers ->
                     10f * (unique.stats.values.sum() / unique.params[1].toFloat())
                 UniqueType.Strength ->
-                    unique.params[0].toFloat() * 2f//combat strength from beliefs is very strong
+                    unique.params[0].toFloat() * 3f//combat strength from beliefs is very strong
                 UniqueType.ReligionSpreadDistance ->
                     (10f + unique.params[0].toFloat()) * goodEarlyModifier
                 UniqueType.NaturalReligionSpreadStrength ->
-                    unique.params[0].toFloat() * goodEarlyModifier / 5f //We should weigh this according to cityFilter; Religious Texts is way stronger than Religious Unity
+                    unique.params[0].toFloat() * goodEarlyModifier / 10f //We should weigh this according to cityFilter; Religious Texts is way stronger than Religious Unity
                 UniqueType.SpreadReligionStrength ->
-                    unique.params[0].toFloat() * goodLateModifier / 5f
+                    unique.params[0].toFloat() * goodLateModifier / 10f //Cheaper missionaries are generally better than stronger missionaries
                 UniqueType.FaithCostOfGreatProphetChange ->
                     -unique.params[0].toFloat() * goodLateModifier / 10f //It's only about 1 more prophet, due to the increasing costs.
                 UniqueType.BuyBuildingsDiscount, UniqueType.BuyUnitsDiscount ->


### PR DESCRIPTION
With today's change to terrain pantheons, the AI tends to favour building pantheons over terrain pantheons and city pantheons. Those three need to be better balanced relative to one another in a future update (buildings are low tempo).

Lines 241-242 look a bit convoluted, but it was effective at letting AI choose Seafood Rituals instead of Sacred Path in Rekmod, so I suppose it did the right thing.

Reworked some modifiers, and added new design philosophy on line 365, which leads to pretty G&K religions as in https://discord.com/channels/586194543280390151/586194543716859916/1315781052618510429