### PR TITLE
Increase starting Luxury amount to match Civ 5

### DIFF
--- a/core/src/com/unciv/logic/map/mapgenerator/mapregions/LuxuryResourcePlacementLogic.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/mapregions/LuxuryResourcePlacementLogic.kt
@@ -366,7 +366,7 @@ object LuxuryResourcePlacementLogic {
         val averageFertilityDensity =
             regions.sumOf { it.totalFertility } / regions.sumOf { it.tiles.size }.toFloat()
         for (region in regions) {
-            var targetLuxuries = 1
+            var targetLuxuries = 2
             if (tileMap.mapParameters.getLegendaryStart())
                 targetLuxuries++
             if (region.totalFertility / region.tiles.size.toFloat() < averageFertilityDensity) {


### PR DESCRIPTION
A quick glance at a few Civ 5 maps implies that we should be guaranteed 2 of our assigned luxury in our capital normally and 3 with legendary start on. I did make sure to test this on base Civ 5 Brave New World maps, not just Lekmod. Unciv currently only guarantees 1 of our assigned luxury in our capital and 2 on legendary start