### PR TITLE
Prevent AI chosing techs with 0 weight for AI decisions

### DIFF
--- a/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
@@ -277,7 +277,9 @@ object NextTurnAutomation {
             val costs = getGroupedResearchableTechs()
             if (costs.isEmpty()) return
 
-            val cheapestTechs = costs[0]
+            val cheapestTechs = costs.firstOrNull{
+                // Ignore rows where all techs have 0 weight
+                it.any { it.getWeightForAiDecision(stateForConditionals) > 0 } }?: costs.first()
             //Do not consider advanced techs if only one tech left in cheapest group
             val techToResearch: Technology =
                 if (cheapestTechs.size == 1 || costs.size == 1) {


### PR DESCRIPTION
This appears to work, mirroring the logic of the most expensive tech picker.