### PR TITLE
Change modifierFocus

### DIFF
--- a/core/src/com/unciv/logic/automation/Automation.kt
+++ b/core/src/com/unciv/logic/automation/Automation.kt
@@ -157,8 +157,8 @@ object Automation {
             if (city.civ.wantsToFocusOn(stat))
                 yieldStats[stat] *= 2f
 
-            val scaledFocus = civPersonality.scaledFocus(PersonalityValue[stat])
-            if (scaledFocus != 1f) yieldStats[stat] *= scaledFocus
+            val modifierFocus = civPersonality.modifierFocus(PersonalityValue[stat])
+            if (modifierFocus != 1f) yieldStats[stat] *= modifierFocus
         }
 
         // Apply City focus

--- a/core/src/com/unciv/logic/automation/civilization/MotivationToAttackAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/MotivationToAttackAutomation.kt
@@ -81,7 +81,7 @@ object MotivationToAttackAutomation {
             modifiers.add(Pair("Close cities", 5f * personality.inverseModifierFocus(PersonalityValue.Aggressive, 1f)))
 
         if (diplomacyManager.hasFlag(DiplomacyFlags.ResearchAgreement))
-            modifiers.add(Pair("Research Agreement", -5f * personality.scaledFocus(PersonalityValue.Science) * personality.scaledFocus(PersonalityValue.Commerce)))
+            modifiers.add(Pair("Research Agreement", -5f * personality.modifierFocus(PersonalityValue.Science) * personality.modifierFocus(PersonalityValue.Commerce)))
 
         if (diplomacyManager.hasFlag(DiplomacyFlags.DeclarationOfFriendship))
             modifiers.add(Pair("Declaration of Friendship", -10f * personality.modifierFocus(PersonalityValue.Loyal, .5f)))
@@ -97,7 +97,7 @@ object MotivationToAttackAutomation {
 
         if (diplomacyManager.hasFlag(DiplomacyFlags.WaryOf) && diplomacyManager.getFlag(DiplomacyFlags.WaryOf) < 0) {
             // Completely defensive civs will plan defensively and have a 0 here
-            modifiers.add(Pair("PlanningAttack", -diplomacyManager.getFlag(DiplomacyFlags.WaryOf) * personality.scaledFocus(PersonalityValue.Aggressive) / 2))
+            modifiers.add(Pair("PlanningAttack", -diplomacyManager.getFlag(DiplomacyFlags.WaryOf) * personality.modifierFocus(PersonalityValue.Aggressive) / 2))
         } else {
             val attacksPlanned = civInfo.diplomacy.values.count { it.hasFlag(DiplomacyFlags.WaryOf) && it.getFlag(DiplomacyFlags.WaryOf) < 0 }
             modifiers.add(Pair("PlanningAttackAgainstOtherCivs", -attacksPlanned * 5f * personality.inverseModifierFocus(PersonalityValue.Aggressive, .5f)))

--- a/core/src/com/unciv/models/ruleset/nation/Personality.kt
+++ b/core/src/com/unciv/models/ruleset/nation/Personality.kt
@@ -6,6 +6,7 @@ import com.unciv.models.ruleset.RulesetObject
 import com.unciv.models.ruleset.unique.UniqueTarget
 import com.unciv.models.stats.Stat
 import com.unciv.models.stats.Stats
+import kotlin.math.pow
 import kotlin.reflect.KMutableProperty0
 
 /**
@@ -93,34 +94,20 @@ class Personality: RulesetObject() {
     }
 
     /**
-     * Scales the value to a more meaningful range, where 10 is 2, and 5 is 1, and 0 is 0
+     * @param weight a value to multiplicatively rescale the outcomes (in range [0.5, 2] centered around 1 for default weight = 1)
+     * @return a modifier based off of the personality value and the weight given 
      */
-    fun scaledFocus(value: PersonalityValue): Float {
-        return nameToVariable(value).get() / 5
-    }
-
-    /**
-     * Inverse scales the value to a more meaningful range, where 0 is 2, and 5 is 1 and 10 is 0
-     */
-    fun inverseScaledFocus(value: PersonalityValue): Float {
-        return  (10 - nameToVariable(value).get()) / 5
-    }
-
-    /**
-     * @param weight a value between 0 and 1 that determines how much the modifier deviates from 1
-     * @return a modifier between 0 and 2 centered around 1 based off of the personality value and the weight given 
-     */
-    fun modifierFocus(value: PersonalityValue, weight: Float): Float {
-        return 1f + (scaledFocus(value) - 1) * weight
+    fun modifierFocus(value: PersonalityValue, weight: Float = 1f): Float {
+        return (1+weight).pow(nameToVariable(value).get()/10 - 1)
     }
 
     /**
      * An inverted version of [modifierFocus], a personality value of 0 becomes a 10, 8 becomes a 2, etc.
-     * @param weight a value between 0 and 1 that determines how much the modifier deviates from 1
-     * @return a modifier between 0 and 2 centered around 1 based off of the personality value and the weight given
+     * @param weight a value to multiplicatively rescale the outcomes (in range [0.5, 2] centered around 1 for default weight = 1)
+     * @return a modifier based off of the personality value and the weight given
      */
-    fun inverseModifierFocus(value: PersonalityValue, weight: Float): Float {
-        return 1f - (inverseScaledFocus(value) - 2) * weight
+    fun inverseModifierFocus(value: PersonalityValue, weight: Float = 1f): Float {
+        return 1f / modifierFocus(value, weight) 
     }
 
     /**


### PR DESCRIPTION
Changes the modifierFocus from linear to multiplicative, to take a range of [0.5, 2] instead of [0, 2], such that the product with the inverse of it stays 1 (instead of going to 0).

I don't know if this actually does what modders expect it to do, and how much it changes the existing personalities (which have been 'tuned' to use the linear rescaling).