### PR TITLE
UI tweaks and fixes: dividers, checkbox-to-text spacing, multiplayer tab connection button

### DIFF
--- a/core/src/com/unciv/ui/components/extensions/Scene2dExtensions.kt
+++ b/core/src/com/unciv/ui/components/extensions/Scene2dExtensions.kt
@@ -206,7 +206,7 @@ private fun getSeparatorImage(color: Color) = Image(ImageGetter.getWhiteDotDrawa
  * Create a horizontal separator as an empty Container with a colored background.
  * @param colSpan Optionally override [colspan][Cell.colspan] which defaults to the current column count.
  */
-fun Table.addSeparator(color: Color = Color.WHITE, colSpan: Int = 0, height: Float = 2f): Cell<Image> {
+fun Table.addSeparator(color: Color = BaseScreen.skin.getColor("color"), colSpan: Int = 0, height: Float = 1f): Cell<Image> {
     if (!cells.isEmpty && !cells.last().isEndRow) row()
     val separator = getSeparatorImage(color)
     val cell = add(separator)

--- a/core/src/com/unciv/ui/components/extensions/Scene2dExtensions.kt
+++ b/core/src/com/unciv/ui/components/extensions/Scene2dExtensions.kt
@@ -323,7 +323,7 @@ fun String.toCheckBox(startsOutChecked: Boolean = false, changeAction: ((Boolean
         }
         // Add a little distance between the icon and the text. 0 looks glued together,
         // 5 is about half an uppercase letter, and 1 about the width of the vertical line in "P".
-        imageCell.padRight(1f)
+        imageCell.padRight(Constants.defaultFontSize / 2.0f)
     }
 
 /** Sets the [font color][Label.LabelStyle.fontColor] on a [Label] and returns it to allow chaining */

--- a/core/src/com/unciv/ui/popups/options/AdvancedTab.kt
+++ b/core/src/com/unciv/ui/popups/options/AdvancedTab.kt
@@ -53,7 +53,7 @@ class AdvancedTab(
         defaults().pad(5f)
 
         addAutosaveTurnsSelectBox()
-        addSeparator(Color.GRAY)
+        addSeparator()
 
         if (Display.hasCutout())
             addCutoutCheckbox()
@@ -63,14 +63,14 @@ class AdvancedTab(
 
         addFontFamilySelect(onFontChange)
         addFontSizeMultiplier(onFontChange)
-        addSeparator(Color.GRAY)
+        addSeparator()
 
         addMaxZoomSlider()
 
         addEasterEggsCheckBox()
 
         addEnlargeNotificationsCheckBox()
-        addSeparator(Color.GRAY)
+        addSeparator()
 
         addSetUserId()
 

--- a/core/src/com/unciv/ui/popups/options/MultiplayerTab.kt
+++ b/core/src/com/unciv/ui/popups/options/MultiplayerTab.kt
@@ -32,19 +32,18 @@ import java.time.temporal.ChronoUnit
 
 fun multiplayerTab(
     optionsPopup: OptionsPopup
-): Table {
-    val tab = Table(BaseScreen.skin)
-    tab.pad(10f)
-    tab.defaults().pad(5f)
+) = Table(BaseScreen.skin).apply {
+    pad(10f)
+    defaults().pad(5f)
 
     val settings = optionsPopup.settings
 
     optionsPopup.addCheckbox(
-        tab, "Enable multiplayer status button in singleplayer games",
+        this, "Enable multiplayer status button in singleplayer games",
         settings.multiplayer::statusButtonInSinglePlayer, updateWorld = true
     )
 
-    addSeparator(tab)
+    addSeparator()
 
     val curRefreshSelect = RefreshSelect(
         "Update status of currently played game every:",
@@ -53,7 +52,7 @@ fun multiplayerTab(
         GameSetting.MULTIPLAYER_CURRENT_GAME_REFRESH_DELAY,
         settings
     )
-    addSelectAsSeparateTable(tab, curRefreshSelect)
+    addSelectAsSeparateTable(this, curRefreshSelect)
 
     val allRefreshSelect = RefreshSelect(
         "In-game, update status of all games every:",
@@ -62,39 +61,37 @@ fun multiplayerTab(
         GameSetting.MULTIPLAYER_ALL_GAME_REFRESH_DELAY,
         settings
     )
-    addSelectAsSeparateTable(tab, allRefreshSelect)
+    addSelectAsSeparateTable(this, allRefreshSelect)
 
-    addSeparator(tab)
+    addSeparator()
 
     // at the moment the notification service only exists on Android
     val turnCheckerSelect: RefreshSelect?
     if (Gdx.app.type == Application.ApplicationType.Android) {
-        turnCheckerSelect = addTurnCheckerOptions(tab, optionsPopup)
-        addSeparator(tab)
+        turnCheckerSelect = addTurnCheckerOptions(this, optionsPopup)
+        addSeparator()
     } else {
         turnCheckerSelect = null
     }
 
     val sounds = IMediaFinder.LabeledSounds().getLabeledSounds()
-    addSelectAsSeparateTable(tab, SettingsSelect("Sound notification for when it's your turn in your currently open game:",
+    addSelectAsSeparateTable(this, SettingsSelect("Sound notification for when it's your turn in your currently open game:",
         sounds,
         GameSetting.MULTIPLAYER_CURRENT_GAME_TURN_NOTIFICATION_SOUND,
         settings
     ))
 
-    addSelectAsSeparateTable(tab, SettingsSelect("Sound notification for when it's your turn in any other game:",
+    addSelectAsSeparateTable(this, SettingsSelect("Sound notification for when it's your turn in any other game:",
         sounds,
         GameSetting.MULTIPLAYER_OTHER_GAME_TURN_NOTIFICATION_SOUND,
         settings
     ))
 
-    addSeparator(tab)
+    addSeparator()
 
-    addMultiplayerServerOptions(tab, optionsPopup,
+    addMultiplayerServerOptions(this, optionsPopup,
         listOfNotNull(curRefreshSelect, allRefreshSelect, turnCheckerSelect)
     )
-
-    return tab
 }
 
 private fun addMultiplayerServerOptions(
@@ -362,6 +359,3 @@ private fun addSelectAsSeparateTable(tab: Table, settingsSelect: SettingsSelect<
     tab.add(table).growX().fillX().row()
 }
 
-private fun addSeparator(tab: Table) {
-    tab.addSeparator(BaseScreen.skinStrings.skinConfig.baseColor.brighten(0.1f))
-}

--- a/core/src/com/unciv/ui/popups/options/MultiplayerTab.kt
+++ b/core/src/com/unciv/ui/popups/options/MultiplayerTab.kt
@@ -152,7 +152,7 @@ private fun addMultiplayerServerOptions(
                 popup.reuseWith("Failed!", true)
             }
         }
-    }).row()
+    }).colspan(2).row()
 
     if (UncivGame.Current.onlineMultiplayer.multiplayerServer.featureSet.authVersion > 0) {
         val passwordTextField = UncivTextField(

--- a/core/src/com/unciv/ui/popups/options/OptionsPopup.kt
+++ b/core/src/com/unciv/ui/popups/options/OptionsPopup.kt
@@ -3,6 +3,7 @@ package com.unciv.ui.popups.options
 import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.scenes.scene2d.ui.Table
+import com.unciv.Constants
 import com.unciv.GUI
 import com.unciv.UncivGame
 import com.unciv.models.metadata.BaseRuleset
@@ -190,6 +191,7 @@ class OptionsPopup(
             val worldScreen = GUI.getWorldScreenIfActive()
             if (updateWorld && worldScreen != null) worldScreen.shouldUpdate = true
         }
+        checkbox.getImageCell().padRight(Constants.defaultFontSize / 2.0f);
         if (newRow) table.add(checkbox).colspan(2).left().row()
         else table.add(checkbox).left()
     }

--- a/core/src/com/unciv/ui/popups/options/OptionsPopup.kt
+++ b/core/src/com/unciv/ui/popups/options/OptionsPopup.kt
@@ -3,7 +3,6 @@ package com.unciv.ui.popups.options
 import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.scenes.scene2d.ui.Table
-import com.unciv.Constants
 import com.unciv.GUI
 import com.unciv.UncivGame
 import com.unciv.models.metadata.BaseRuleset
@@ -191,7 +190,6 @@ class OptionsPopup(
             val worldScreen = GUI.getWorldScreenIfActive()
             if (updateWorld && worldScreen != null) worldScreen.shouldUpdate = true
         }
-        checkbox.getImageCell().padRight(Constants.defaultFontSize / 2.0f);
         if (newRow) table.add(checkbox).colspan(2).left().row()
         else table.add(checkbox).left()
     }


### PR DESCRIPTION
This description covers my reasoning for these changes.  I'll attempt to argue for why I think they're sensible, but feel free to challenge me on any point.  To clarify, the following is my opinion, but I'll try to support it with evidence.

## [1]

Commits labelled [1] deal with consistency.  Previously, the Options popup contained three different types of dividers, and the multiplayer tab was structured as a real function instead of a single-expression, unlike the rest.  I've standardised the dividers to use the styling provided by the skin by default, which was the behaviour previously used in the multiplayer tab.  This is for several reasons:

- Dividers are meant to be subtle and used sparingly.  Making them pure white and using one for every two or three checkboxes or dropdowns is a hard antipattern and is more distracting than helpful for users.  Width 1.0 is enough, and they certainly need not have the maximum possible contrast from the background (white); in fact, the opposite is desirable.
- [Adobe](https://spectrum.adobe.com/page/divider/), for example, recommends defaulting to 1px light grey dividers on light themes, and using larger and more intense ones only when they are actually needed.  The multiplayer tab's dividers were a good approximation of this, so I've adopted them everywhere.
- By the way, the dividers on GitHub that you can see in this very PR (below headers, for example) also reflect this paradigm.  They're subtle, but clearly recognisable as dividers and they do a good job at contextualising content.  You might imagine what it'd look like if it were pure black: rather awkward.
- In truth, this game simply has too many dividers to begin with.  I believe that most of them could be safely replaced with white-space instead.  Dividers are for headers primarily and sometimes for separating aggregate sections of an interface that doesn't use headers; white-space should be the primary choice for other situations.
- I also believe the dividers should impose a greater margin beneath themselves, but I haven't changed that for fear of breaking other parts of the interface.  1rem would probably be a good baseline to play around with.

The function structure change in MultiplayerTab.kt is just for internal consistency with the order tabs and should have no effect.

Visual comparison:

### **Old:**
![image](https://github.com/user-attachments/assets/56d53736-292c-452d-aa72-fefbb313429e)
### **New:**
![image](https://github.com/user-attachments/assets/66de53fb-92fd-4923-bf49-bf7152dea1f1)


## [2]

Commits labelled [2] deal with checkboxes.  They are clearly not spaced far enough away from the text.  Checkbox-to-text spacing varies on Web, Desktop, and Mobile UIs, but it is **_almost never less than 0.5rem_**.  I've set it to an approximation of that value to make checkboxes less cramped; this should also help with future consistency.  Here's a visual comparison:

### **Old:**
![image](https://github.com/user-attachments/assets/d389908a-d1c2-42c5-b1a2-65a737a0b8ab)
### **New:**
![image](https://github.com/user-attachments/assets/bc066c7d-a4db-4f18-bcad-9e11107781ba)

## [3]

The commit labelled [3] centres the "Check connection" button in the multiplayer tab.  This change should be less controversial than the others, unless the button was off-centre for a reason that I'm not aware of.

### **Old:**
![image](https://github.com/user-attachments/assets/522246be-496a-404e-9f64-400cc6150eb2)
### **New:**
![image](https://github.com/user-attachments/assets/08cf3b3a-7f69-4034-a183-49796a8ccffc)
