### PR TITLE
UI: standardised alignment and creation of options checkboxes, Unciv-themed slider buttons, multiplayer settings server text field layout and spacing

### DIFF
--- a/core/src/com/unciv/ui/components/widgets/UncivSlider.kt
+++ b/core/src/com/unciv/ui/components/widgets/UncivSlider.kt
@@ -156,9 +156,9 @@ class UncivSlider (
         stepChanged()   // Initialize tip formatting
 
         if (plusMinus) {
-            minusButton = "-".toLabel(ImageGetter.CHARCOAL, plusMinusFontSize)
+            minusButton = "-".toLabel(Color.WHITE, plusMinusFontSize)
                 .apply { setAlignment(Align.center) }
-                .surroundWithCircle(plusMinusCircleSize)
+                .surroundWithCircle(plusMinusCircleSize, true, BaseScreen.skin.getColor("color"))
             minusButton.onClick {
                 addToValue(-stepSize)
             }
@@ -172,9 +172,9 @@ class UncivSlider (
 
         if (plusMinus) {
             if (vertical) row()
-            plusButton = "+".toLabel(ImageGetter.CHARCOAL, plusMinusFontSize)
+            plusButton = "+".toLabel(Color.WHITE, plusMinusFontSize)
                 .apply { setAlignment(Align.center) }
-                .surroundWithCircle(plusMinusCircleSize)
+                .surroundWithCircle(plusMinusCircleSize, true, BaseScreen.skin.getColor("color"))
             plusButton.onClick {
                 addToValue(stepSize)
             }

--- a/core/src/com/unciv/ui/popups/options/AdvancedTab.kt
+++ b/core/src/com/unciv/ui/popups/options/AdvancedTab.kt
@@ -353,12 +353,12 @@ class AdvancedTab(
 
     private fun addEasterEggsCheckBox() {
         val checkbox = "Enable Easter Eggs".toCheckBox(settings.enableEasterEggs) { settings.enableEasterEggs = it }
-        add(checkbox).colspan(2).row()
+        add(checkbox).row()
     }
 
     private fun addEnlargeNotificationsCheckBox() {
         val checkbox = "Enlarge selected notifications"
             .toCheckBox(settings.enlargeSelectedNotification) { settings.enlargeSelectedNotification = it }
-        add(checkbox).colspan(2).row()
+        add(checkbox).row()
     }
 }

--- a/core/src/com/unciv/ui/popups/options/AdvancedTab.kt
+++ b/core/src/com/unciv/ui/popups/options/AdvancedTab.kt
@@ -352,13 +352,10 @@ class AdvancedTab(
     }
 
     private fun addEasterEggsCheckBox() {
-        val checkbox = "Enable Easter Eggs".toCheckBox(settings.enableEasterEggs) { settings.enableEasterEggs = it }
-        add(checkbox).row()
+        optionsPopup.addCheckbox(this, "Enable Easter Eggs", settings.enableEasterEggs) { settings.enableEasterEggs = it }
     }
 
     private fun addEnlargeNotificationsCheckBox() {
-        val checkbox = "Enlarge selected notifications"
-            .toCheckBox(settings.enlargeSelectedNotification) { settings.enlargeSelectedNotification = it }
-        add(checkbox).row()
+        optionsPopup.addCheckbox(this, "Enlarge selected notifications", settings.enlargeSelectedNotification) { settings.enlargeSelectedNotification = it }
     }
 }

--- a/core/src/com/unciv/ui/popups/options/AutomationTab.kt
+++ b/core/src/com/unciv/ui/popups/options/AutomationTab.kt
@@ -2,6 +2,7 @@ package com.unciv.ui.popups.options
 
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.unciv.GUI
+import com.unciv.Constants
 import com.unciv.logic.civilization.PlayerType
 import com.unciv.models.metadata.GameSettings
 import com.unciv.ui.components.extensions.addSeparator
@@ -15,7 +16,7 @@ fun automationTab(optionsPopup: OptionsPopup
     defaults().pad(5f)
 
     val settings = optionsPopup.settings
-    add("Automation".toLabel(fontSize = 24)).colspan(2).row()
+    add("Automation".toLabel(fontSize = Constants.headingFontSize)).colspan(2).row()
 
     optionsPopup.addCheckbox(this, "Auto-assign city production", settings.autoAssignCityProduction, true) { shouldAutoAssignCityProduction ->
         settings.autoAssignCityProduction = shouldAutoAssignCityProduction
@@ -56,7 +57,7 @@ fun automationTab(optionsPopup: OptionsPopup
     ) { settings.citiesAutoBombardAtEndOfTurn = it }
 
     addSeparator()
-    add("AutoPlay".toLabel(fontSize = 24)).colspan(2).row()
+    add("AutoPlay".toLabel(fontSize = Constants.headingFontSize)).colspan(2).row()
 //    fun addAutoPlaySections() {
 //        optionsPopup.addCheckbox(
 //            this,

--- a/core/src/com/unciv/ui/popups/options/DebugTab.kt
+++ b/core/src/com/unciv/ui/popups/options/DebugTab.kt
@@ -51,34 +51,34 @@ fun debugTab(
 
     add("Supercharged".toCheckBox(DebugUtils.SUPERCHARGED) {
         DebugUtils.SUPERCHARGED = it
-    }).colspan(2).row()
+    }).row()
     add("View entire map".toCheckBox(DebugUtils.VISIBLE_MAP) {
         DebugUtils.VISIBLE_MAP = it
-    }).colspan(2).row()
+    }).row()
     add("Show coordinates on tiles".toCheckBox(DebugUtils.SHOW_TILE_COORDS) {
         DebugUtils.SHOW_TILE_COORDS = it
-    }).colspan(2).row()
+    }).row()
     add("Show tile image locations".toCheckBox(DebugUtils.SHOW_TILE_IMAGE_LOCATIONS) {
         DebugUtils.SHOW_TILE_IMAGE_LOCATIONS = it
-    }).colspan(2).row()
+    }).row()
 
     val curGameInfo = game.gameInfo
     if (curGameInfo != null) {
         add("God mode (current game)".toCheckBox(curGameInfo.gameParameters.godMode) {
             curGameInfo.gameParameters.godMode = it
-        }).colspan(2).row()
+        }).row()
     }
 
     add("Save games compressed".toCheckBox(UncivFiles.saveZipped) {
         UncivFiles.saveZipped = it
-    }).colspan(2).row()
+    }).row()
     add("Save maps compressed".toCheckBox(MapSaver.saveZipped) {
         MapSaver.saveZipped = it
-    }).colspan(2).row()
+    }).row()
 
     add("Gdx Scene2D debug".toCheckBox(BaseScreen.enableSceneDebug) {
         BaseScreen.enableSceneDebug = it
-    }).colspan(2).row()
+    }).row()
 
     add(Table().apply {
         add("Unique misspelling threshold".toLabel()).left().fillX()

--- a/core/src/com/unciv/ui/popups/options/DebugTab.kt
+++ b/core/src/com/unciv/ui/popups/options/DebugTab.kt
@@ -49,36 +49,20 @@ fun debugTab(
         add(invalidInputLabel).colspan(2).row()
     }
 
-    add("Supercharged".toCheckBox(DebugUtils.SUPERCHARGED) {
-        DebugUtils.SUPERCHARGED = it
-    }).row()
-    add("View entire map".toCheckBox(DebugUtils.VISIBLE_MAP) {
-        DebugUtils.VISIBLE_MAP = it
-    }).row()
-    add("Show coordinates on tiles".toCheckBox(DebugUtils.SHOW_TILE_COORDS) {
-        DebugUtils.SHOW_TILE_COORDS = it
-    }).row()
-    add("Show tile image locations".toCheckBox(DebugUtils.SHOW_TILE_IMAGE_LOCATIONS) {
-        DebugUtils.SHOW_TILE_IMAGE_LOCATIONS = it
-    }).row()
+    optionsPopup.addCheckbox(this, "Supercharged", DebugUtils.SUPERCHARGED) { DebugUtils.SUPERCHARGED = it }
+    optionsPopup.addCheckbox(this, "View entire map", DebugUtils.VISIBLE_MAP) { DebugUtils.VISIBLE_MAP = it }
+    optionsPopup.addCheckbox(this, "Show coordinates on tiles", DebugUtils.SHOW_TILE_COORDS) { DebugUtils.SHOW_TILE_COORDS = it }
+    optionsPopup.addCheckbox(this, "Show tile image locations", DebugUtils.SHOW_TILE_IMAGE_LOCATIONS) { DebugUtils.SHOW_TILE_IMAGE_LOCATIONS = it }
 
     val curGameInfo = game.gameInfo
     if (curGameInfo != null) {
-        add("God mode (current game)".toCheckBox(curGameInfo.gameParameters.godMode) {
-            curGameInfo.gameParameters.godMode = it
-        }).row()
+        optionsPopup.addCheckbox(this, "God mode (current game)", curGameInfo.gameParameters.godMode) { curGameInfo.gameParameters.godMode = it }
     }
 
-    add("Save games compressed".toCheckBox(UncivFiles.saveZipped) {
-        UncivFiles.saveZipped = it
-    }).row()
-    add("Save maps compressed".toCheckBox(MapSaver.saveZipped) {
-        MapSaver.saveZipped = it
-    }).row()
-
-    add("Gdx Scene2D debug".toCheckBox(BaseScreen.enableSceneDebug) {
-        BaseScreen.enableSceneDebug = it
-    }).row()
+    optionsPopup.addCheckbox(this, "Save games compressed", UncivFiles.saveZipped) { UncivFiles.saveZipped = it }
+    optionsPopup.addCheckbox(this, "Save maps compressed", MapSaver.saveZipped) { MapSaver.saveZipped = it }
+    optionsPopup.addCheckbox(this, "Gdx Scene2D debug", BaseScreen.enableSceneDebug) { BaseScreen.enableSceneDebug = it }
+        
 
     add(Table().apply {
         add("Unique misspelling threshold".toLabel()).left().fillX()

--- a/core/src/com/unciv/ui/popups/options/DisplayTab.kt
+++ b/core/src/com/unciv/ui/popups/options/DisplayTab.kt
@@ -7,6 +7,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.SelectBox
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.utils.Array
 import com.unciv.GUI
+import com.unciv.Constants
 import com.unciv.models.metadata.GameSettings
 import com.unciv.models.metadata.GameSettings.ScreenSize
 import com.unciv.models.skins.SkinCache
@@ -41,7 +42,7 @@ fun displayTab(
 
     val settings = optionsPopup.settings
 
-    add("Screen".toLabel(fontSize = 24)).colspan(2).row()
+    add("Screen".toLabel(fontSize = Constants.headingFontSize)).colspan(2).row()
 
     addScreenSizeSelectBox(this, settings, optionsPopup.selectBoxMinWidth, onChange)
     addScreenOrientationSelectBox(this, settings, optionsPopup.selectBoxMinWidth, onChange)
@@ -58,14 +59,14 @@ fun displayTab(
     }
 
     addSeparator()
-    add("Graphics".toLabel(fontSize = 24)).colspan(2).row()
+    add("Graphics".toLabel(fontSize = Constants.headingFontSize)).colspan(2).row()
 
     addTileSetSelectBox(this, settings, optionsPopup.selectBoxMinWidth, onChange)
     addUnitSetSelectBox(this, settings, optionsPopup.selectBoxMinWidth, onChange)
     addSkinSelectBox(this, settings, optionsPopup.selectBoxMinWidth, onChange)
 
     addSeparator()
-    add("UI".toLabel(fontSize = 24)).colspan(2).row()
+    add("UI".toLabel(fontSize = Constants.headingFontSize)).colspan(2).row()
 
     addNotificationScrollSelect(this, settings, optionsPopup.selectBoxMinWidth)
     addMinimapSizeSlider(this, settings, optionsPopup.selectBoxMinWidth)
@@ -77,7 +78,7 @@ fun displayTab(
     addPediaUnitArtSizeSlider(this, settings, optionsPopup.selectBoxMinWidth)
 
     addSeparator()
-    add("Visual Hints".toLabel(fontSize = 24)).colspan(2).row()
+    add("Visual Hints".toLabel(fontSize = Constants.headingFontSize)).colspan(2).row()
 
     optionsPopup.addCheckbox(this, "Show unit movement arrows", settings.showUnitMovements, true) { settings.showUnitMovements = it }
     optionsPopup.addCheckbox(this, "Show suggested city locations for units that can found cities", settings.showSettlersSuggestedCityLocations, true) { settings.showSettlersSuggestedCityLocations = it }
@@ -89,7 +90,7 @@ fun displayTab(
     addUnitIconAlphaSlider(this, settings, optionsPopup.selectBoxMinWidth)
 
     addSeparator()
-    add("Performance".toLabel(fontSize = 24)).colspan(2).row()
+    add("Performance".toLabel(fontSize = Constants.headingFontSize)).colspan(2).row()
 
     optionsPopup.addCheckbox(this, "Continuous rendering", settings.continuousRendering) {
         settings.continuousRendering = it

--- a/core/src/com/unciv/ui/popups/options/MultiplayerTab.kt
+++ b/core/src/com/unciv/ui/popups/options/MultiplayerTab.kt
@@ -5,6 +5,7 @@ import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.scenes.scene2d.ui.TextField
 import com.unciv.UncivGame
+import com.unciv.Constants
 import com.unciv.logic.files.IMediaFinder
 import com.unciv.logic.multiplayer.Multiplayer
 import com.unciv.logic.multiplayer.storage.FileStorageRateLimitReached
@@ -101,7 +102,7 @@ private fun addMultiplayerServerOptions(
 ) {
     val settings = optionsPopup.settings
 
-    val connectionToServerButton = "Check connection to server".toTextButton()
+    val connectionToServerButton = "Check connection".toTextButton()
 
     val textToShowForOnlineMultiplayerAddress = if (Multiplayer.usesCustomServer()) {
         settings.multiplayer.server
@@ -115,7 +116,7 @@ private fun addMultiplayerServerOptions(
 
     serverIpTable.add("Server address".toLabel().onClick {
         multiplayerServerTextField.text = Gdx.app.clipboard.contents
-        }).colspan(2).row()
+        }).colspan(2).padBottom(Constants.defaultFontSize / 2.0f).row()
     multiplayerServerTextField.onChange {
         fixTextFieldUrlOnType(multiplayerServerTextField)
         // we can't trim on 'fixTextFieldUrlOnType' for reasons
@@ -128,8 +129,7 @@ private fun addMultiplayerServerOptions(
     }
 
     serverIpTable.add(multiplayerServerTextField)
-        .minWidth(optionsPopup.stageToShowOn.width / 2)
-        .colspan(2).growX().padBottom(8f).row()
+        .minWidth(optionsPopup.stageToShowOn.width / 3).padRight(Constants.defaultFontSize.toFloat()).growX()
 
     serverIpTable.add(connectionToServerButton.onClick {
         val popup = Popup(optionsPopup.stageToShowOn).apply {
@@ -152,7 +152,7 @@ private fun addMultiplayerServerOptions(
                 popup.reuseWith("Failed!", true)
             }
         }
-    }).colspan(2).row()
+    }).row()
 
     if (UncivGame.Current.onlineMultiplayer.multiplayerServer.featureSet.authVersion > 0) {
         val passwordTextField = UncivTextField(


### PR DESCRIPTION
## [1]

Commits labelled [1] replace the hard-coded 24 font size in some files with the defined constant `headingFontSize`, which, based on the name, was intended for these.  Nothing else of note.

## [2]

The commit labelled [2] deals with the server options in the multiplayer tab.

The "check connection to server" button has been trimmed to say "check connection"; it was already plenty obvious what it was referring to.  I've also moved it next to the server text field: displaying action buttons inline is an established design pattern that improves contextual clarity, and there's plenty of space for the text field.  Other minor changes include adding some white-space below the text to mitigate the cluttered appearance.

### Old
![image](https://github.com/user-attachments/assets/ee50635c-5d0f-48cd-814a-038dcd8619fd)
### New
![image](https://github.com/user-attachments/assets/af3930ec-149e-4101-b341-ae6fb6cf3817)

## [3]

Commits labelled [3] standardise the display of the checkboxes.  Previously, they were displayed either centered or left-aligned at random, some tabs using the former, others defaulting to the latter.  The left-alignment is a far better choice, because it helps group the information together visually.  In addition, I've made them use the `addCheckbox` function of OptionsPopup instead of the auxiliary `String.toCheckBox`.  By the way, I'm not sure they should be capitalised differently: "Checkbox" vs. "CheckBox", but I won't change that lest I break anything else.

### Old
![image](https://github.com/user-attachments/assets/8ae4d3de-6ff2-4fcb-ae29-34298b3ed74e)
### New
![image](https://github.com/user-attachments/assets/de9bb2e5-476b-4b01-8549-e75014affb18)

## [4]

The commit labelled [4] applies an Unciv-like blue colour to the slider buttons instead of the white one.  I feel that this design matches the other UI elements like the checkboxes and the buttons more without compromising usability or clarity.  Nothing much else to add here.

### Old
![image](https://github.com/user-attachments/assets/e4300540-bd0d-4c43-b6d9-d54e0739072b)
### New
![image](https://github.com/user-attachments/assets/c193c85e-afac-48ba-9773-2903120ac6b7)

