### PR TITLE
ConsoleLauncher: Randomize Civ Order

### DIFF
--- a/core/src/com/unciv/logic/GameStarter.kt
+++ b/core/src/com/unciv/logic/GameStarter.kt
@@ -349,7 +349,12 @@ object GameStarter {
             .map { it.key }
             .filter { it in usedCivNames }
 
-        for (player in chosenPlayers) {
+        val playersToAdd = if (newGameParameters.shufflePlayerOrder) {
+            chosenPlayers.toMutableList().apply { shuffle() }
+        } else {
+            chosenPlayers
+        }
+        for (player in playersToAdd) {
             val civ = Civilization(player.chosenCiv)
             when (player.chosenCiv) {
                 in usedMajorCivs, Constants.spectator -> {

--- a/core/src/com/unciv/models/metadata/GameParameters.kt
+++ b/core/src/com/unciv/models/metadata/GameParameters.kt
@@ -31,6 +31,7 @@ class GameParameters : IsPartOfGameInfoSerialization { // Default values are the
     var nuclearWeaponsEnabled = true
     var espionageEnabled = false
     var noStartBias = false
+    var shufflePlayerOrder = false
 
     var victoryTypes: ArrayList<String> = arrayListOf()
     var startingEra = "Ancient era"
@@ -71,6 +72,7 @@ class GameParameters : IsPartOfGameInfoSerialization { // Default values are the
         parameters.nuclearWeaponsEnabled = nuclearWeaponsEnabled
         parameters.espionageEnabled = espionageEnabled
         parameters.noStartBias = noStartBias
+        parameters.shufflePlayerOrder = shufflePlayerOrder
         parameters.victoryTypes = ArrayList(victoryTypes)
         parameters.startingEra = startingEra
         parameters.isOnlineMultiplayer = isOnlineMultiplayer

--- a/desktop/src/com/unciv/app/desktop/ConsoleLauncher.kt
+++ b/desktop/src/com/unciv/app/desktop/ConsoleLauncher.kt
@@ -77,6 +77,7 @@ internal object ConsoleLauncher {
             numberOfCityStates = 0
             speed = Speed.DEFAULT
             noBarbarians = true
+            shufflePlayerOrder = true
             players = ArrayList<Player>().apply {
                 civilizations.forEach { add(Player(it)) }
                 add(Player(Constants.spectator, PlayerType.Human))


### PR DESCRIPTION
Add support for randomized Civ Order at game start and use it for Sims
Helps fix the 52/48 first player advantage