### PR TITLE
Update ConstructionAutomation.kt

### DIFF
--- a/core/src/com/unciv/logic/automation/city/ConstructionAutomation.kt
+++ b/core/src/com/unciv/logic/automation/city/ConstructionAutomation.kt
@@ -248,7 +248,7 @@ class ConstructionAutomation(val cityConstructions: CityConstructions) {
         if (workerEquivalents.none()) return // for mods with no worker units
 
         // Dedicate 1.5 workers for the first 5 cities, from then on only build one worker for every city.
-        val numberOfWorkersWeWant = if (cities <= 5) (cities * 1.5f) else 7.5f + ((cities - 5))
+        val numberOfWorkersWeWant = if (cities <= 6) (cities * 1.5f - 0.5f) else 8.5f + ((cities - 6))
 
         if (workers < numberOfWorkersWeWant) {
             val modifier = numberOfWorkersWeWant / (workers + 0.17f) // The worse our worker to city ratio is, the more desperate we are


### PR DESCRIPTION
City states probably shouldn't build more than one worker, this is something I forgot about. Half a worker less in the early game shouldn't affect major AI civs by too much I think.