### PR TITLE
Simulation: Consistent Report

### DIFF
--- a/core/src/com/unciv/logic/simulation/Simulation.kt
+++ b/core/src/com/unciv/logic/simulation/Simulation.kt
@@ -55,6 +55,7 @@ class Simulation(
         val jobs: ArrayList<Job> = ArrayList()
         println("Starting new game with major civs: "+newGameInfo.civilizations.filter { it.isMajorCiv() }.joinToString { it.civName }
         + " and minor civs: "+newGameInfo.civilizations.filter { it.isCityState }.joinToString { it.civName })
+        newGameInfo.gameParameters.shufflePlayerOrder = true
         for (threadId in 1..threadsNumber) {
             jobs.add(launch(CoroutineName("simulation-${threadId}")) {
                 repeat(simulationsPerThread) {
@@ -64,6 +65,7 @@ class Simulation(
                     gameInfo.nextTurn()
 
                     val step = SimulationStep(gameInfo)
+                    println("First: ${gameInfo.civilizations.first().civName}")
 
                     if (step.victoryType != null) {
                         step.winner = step.currentPlayer

--- a/desktop/src/com/unciv/app/desktop/ConsoleLauncher.kt
+++ b/desktop/src/com/unciv/app/desktop/ConsoleLauncher.kt
@@ -79,7 +79,6 @@ internal object ConsoleLauncher {
             numberOfCityStates = 0
             speed = Speed.DEFAULT
             noBarbarians = true
-            shufflePlayerOrder = true
             players = ArrayList<Player>().apply {
                 civilizations.forEach { add(Player(it)) }
                 add(Player(Constants.spectator, PlayerType.Human))


### PR DESCRIPTION
Move when the shuffle happens so Simulation prints consistently based on the Civ order in Console Launcher.

Previous version would shuffle before calling Simulation.