### PR TITLE
Rebalance Food Weights

### DIFF
--- a/core/src/com/unciv/logic/city/CityFocus.kt
+++ b/core/src/com/unciv/logic/city/CityFocus.kt
@@ -41,13 +41,15 @@ enum class CityFocus(
     FaithFocus("${Stat.Faith.character}", true, Stat.Faith),
     GoldGrowthFocus("${Stat.Gold.character} ${Stat.Food.character}", true) {
         override fun getStatMultiplier(stat: Stat) = when (stat) {
-            Stat.Gold, Stat.Food -> 2f
+            Stat.Gold -> 2f
+            Stat.Food -> 1.5f
             else -> 1f
         }
     },
     ProductionGrowthFocus("${Stat.Production.character} ${Stat.Food.character}", true) {
         override fun getStatMultiplier(stat: Stat) = when (stat) {
-            Stat.Production, Stat.Food -> 2f
+            Stat.Production -> 2f
+            Stat.Food -> 1.5f
             else -> 1f
         }
     },


### PR DESCRIPTION
Rework the weight of Food evaluation for Citizen Management.
Generic AI Civ performance improves and this matches closer to human expectations. Some AIs such as Korea will perform a bit worse in certain scenarios due to Personalities, but we should fix the Personalities instead of break base behavior.
Still room for improvements in corner cases.
Discussion and data in Discord thread:
https://discord.com/channels/586194543280390151/1306726293102006453/1306726299884195932

Also adding a small feature to the console sims

Cleaner rebase of #12582

@EmperorPinguin redoing here