### PR TITLE
UI: various improvements mostly relating to centering and WorldScreenTopBar

### DIFF
--- a/core/src/com/unciv/ui/components/fonts/Fonts.kt
+++ b/core/src/com/unciv/ui/components/fonts/Fonts.kt
@@ -71,7 +71,7 @@ object Fonts {
             descent / height }
         // For whatever reason, undershooting the adjustment slightly
         // causes rounding to work better
-        return ratio * fontSize.toFloat() + 0.10f
+        return ratio * fontSize.toFloat() + 2.25f
     }
 
     /**

--- a/core/src/com/unciv/ui/components/fonts/Fonts.kt
+++ b/core/src/com/unciv/ui/components/fonts/Fonts.kt
@@ -58,9 +58,20 @@ object Fonts {
             .sortedWith(compareBy(UncivGame.Current.settings.getCollatorFromLocale()) { it.localName })
     }
 
+    /**
+     * Helper for v-centering the text of Icon – Label -type components:
+     *
+     * Normal vertical centering uses the entire font height. In reality,
+     * it is customary to align the centre from the baseline to the ascent
+     * with the centre of the other element.  This function estimates the
+     * correct amount to shift the text element.
+     */
     fun getDescenderHeight(fontSize: Int): Float {
-        val ratio = font.run { getDescent() / (getAscent() + getDescent() + getCapHeight()) }
-        return ratio * fontSize.toFloat()
+        val ratio = fontImplementation.getMetrics().run {
+            descent / height }
+        // For whatever reason, undershooting the adjustment slightly
+        // causes rounding to work better
+        return ratio * fontSize.toFloat() + 0.10f
     }
 
     /**

--- a/core/src/com/unciv/ui/components/fonts/Fonts.kt
+++ b/core/src/com/unciv/ui/components/fonts/Fonts.kt
@@ -58,6 +58,11 @@ object Fonts {
             .sortedWith(compareBy(UncivGame.Current.settings.getCollatorFromLocale()) { it.localName })
     }
 
+    fun getDescenderHeight(fontSize: Int): Float {
+        val ratio = font.run { getDescent() / (getAscent() + getDescent() + getCapHeight()) }
+        return ratio * fontSize.toFloat()
+    }
+
     /**
      * Turn a TextureRegion into a Pixmap.
      *

--- a/core/src/com/unciv/ui/images/IconTextButton.kt
+++ b/core/src/com/unciv/ui/images/IconTextButton.kt
@@ -7,8 +7,11 @@ import com.badlogic.gdx.scenes.scene2d.ui.Cell
 import com.badlogic.gdx.scenes.scene2d.ui.Label
 import com.badlogic.gdx.utils.Align
 import com.unciv.Constants
+import com.unciv.ui.components.fonts.Fonts
 import com.unciv.ui.components.extensions.toLabel
 import com.unciv.ui.screens.basescreen.BaseScreen
+import kotlin.math.floor
+import kotlin.math.ceil
 
 /**
  * Translate a [String] and make a [Button] widget from it, with control over font size, font colour, an optional icon, and custom formatting.
@@ -32,10 +35,21 @@ open class IconTextButton(
             val size = fontSize.toFloat()
             icon.setSize(size, size)
             icon.setOrigin(Align.center)
-            add(icon).size(size).padRight(size / 3)
+            add(icon).size(size).padRight(size / 3.0f)
         } else {
-            add()
+            add().padRight(fontSize / 2f)
         }
     /** Table cell instance containing the [label]. */
     val labelCell: Cell<Label> = add(label)
+
+    init {
+        pad(10f)
+        val descenderHeight = Fonts.fontImplementation.getMetrics().run {
+            descent / height } * fontSize.toFloat()
+
+        // This handles weird rounding situations slightly
+        // better for some reason that I don't understand
+        labelCell.padTop(9.75f)
+        labelCell.padBottom(ceil(descenderHeight));
+    }
 }

--- a/core/src/com/unciv/ui/images/IconTextButton.kt
+++ b/core/src/com/unciv/ui/images/IconTextButton.kt
@@ -44,10 +44,6 @@ open class IconTextButton(
 
     init {
         pad(10f)
-
-        // This handles weird rounding situations slightly
-        // better for some reason that I don't understand
-        labelCell.padTop(9.75f)
-        labelCell.padBottom(ceil(Fonts.getDescenderHeight(fontSize)));
+        labelCell.padTop(10f - Fonts.getDescenderHeight(fontSize));
     }
 }

--- a/core/src/com/unciv/ui/images/IconTextButton.kt
+++ b/core/src/com/unciv/ui/images/IconTextButton.kt
@@ -44,12 +44,10 @@ open class IconTextButton(
 
     init {
         pad(10f)
-        val descenderHeight = Fonts.fontImplementation.getMetrics().run {
-            descent / height } * fontSize.toFloat()
 
         // This handles weird rounding situations slightly
         // better for some reason that I don't understand
         labelCell.padTop(9.75f)
-        labelCell.padBottom(ceil(descenderHeight));
+        labelCell.padBottom(ceil(Fonts.getDescenderHeight(fontSize)));
     }
 }

--- a/core/src/com/unciv/ui/screens/worldscreen/topbar/WorldScreenTopBar.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/topbar/WorldScreenTopBar.kt
@@ -205,17 +205,8 @@ class WorldScreenTopBar(internal val worldScreen: WorldScreen) : Table() {
         private val menuButtonWrapper = Container(menuButton)
 
         init {
-            // vertically align the Nation name by ascender height without descender:
-            //  Normal vertical centering uses the entire font height, but that looks off here because there's
-            //  few descenders in the typical Nation name. So we calculate an estimate of the descender height
-            //  in world coordinates (25 is the Label font size set below), then, since the cells themselves
-            //  have no default padding, we remove that much padding from the top of this entire Table, and
-            //  give the Label that much top padding in return. Approximated since we're ignoring 'leading'.
-            val descenderHeight = Fonts.fontImplementation.getMetrics().run { descent / height } * 25f
-
             left()
             pad(10f)
-            padTop((10f - descenderHeight).coerceAtLeast(0f))
 
             menuButton.color = Color.WHITE
             menuButton.onActivation(binding = KeyboardBinding.Menu) { WorldScreenMenuPopup(worldScreen) }
@@ -225,7 +216,7 @@ class WorldScreenTopBar(internal val worldScreen: WorldScreen) : Table() {
                 worldScreen.openCivilopedia(worldScreen.selectedCiv.nation.makeLink())
             }
 
-            selectedCivLabel.setFontSize(25)
+            selectedCivLabel.setFontSize(Constants.headingFontSize)
             selectedCivLabel.onClick(onNationClick)
             selectedCivIcon.onClick(onNationClick)
 
@@ -234,7 +225,8 @@ class WorldScreenTopBar(internal val worldScreen: WorldScreen) : Table() {
             add(menuButtonWrapper)
 
             selectedCivIconCell = add(selectedCivIcon).padLeft(Constants.defaultFontSize / 1.5f)
-            add(selectedCivLabel).padTop(descenderHeight).padLeft(Constants.defaultFontSize / 2.0f)
+            add(selectedCivLabel).padTop(10f - Fonts.getDescenderHeight(Constants.headingFontSize))
+                .padLeft(Constants.defaultFontSize / 2.0f)
             pack()
         }
 

--- a/core/src/com/unciv/ui/screens/worldscreen/topbar/WorldScreenTopBar.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/topbar/WorldScreenTopBar.kt
@@ -4,8 +4,10 @@ import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.scenes.scene2d.Actor
 import com.badlogic.gdx.scenes.scene2d.Group
 import com.badlogic.gdx.scenes.scene2d.ui.Cell
+import com.badlogic.gdx.scenes.scene2d.ui.Container
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.utils.Align
+import com.unciv.Constants
 import com.unciv.logic.civilization.Civilization
 import com.unciv.models.translations.tr
 import com.unciv.ui.components.extensions.darken
@@ -198,7 +200,9 @@ class WorldScreenTopBar(internal val worldScreen: WorldScreen) : Table() {
         private var selectedCivIcon = Group()
         private val selectedCivIconCell: Cell<Group>
         private val selectedCivLabel = "".toLabel()
+
         private val menuButton = ImageGetter.getImage("OtherIcons/MenuIcon")
+        private val menuButtonWrapper = Container(menuButton)
 
         init {
             // vertically align the Nation name by ascender height without descender:
@@ -225,9 +229,12 @@ class WorldScreenTopBar(internal val worldScreen: WorldScreen) : Table() {
             selectedCivLabel.onClick(onNationClick)
             selectedCivIcon.onClick(onNationClick)
 
-            add(menuButton).size(50f)
-            selectedCivIconCell = add(selectedCivIcon).padLeft(10f)
-            add(selectedCivLabel).padTop(descenderHeight)
+            menuButtonWrapper.size(Constants.headingFontSize * 1.5f);
+            menuButtonWrapper.center()
+            add(menuButtonWrapper)
+
+            selectedCivIconCell = add(selectedCivIcon).padLeft(Constants.defaultFontSize / 1.5f)
+            add(selectedCivLabel).padTop(descenderHeight).padLeft(Constants.defaultFontSize / 2.0f)
             pack()
         }
 

--- a/core/src/com/unciv/ui/screens/worldscreen/topbar/WorldScreenTopBarResources.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/topbar/WorldScreenTopBarResources.kt
@@ -84,7 +84,7 @@ internal class WorldScreenTopBarResources(topbar: WorldScreenTopBar) : ScalingTa
         val yearText = YearTextUtil.toYearText(
             civInfo.gameInfo.getYear(), civInfo.isLongCountDisplay()
         )
-        turnsLabel.setText(Fonts.turn + "" + civInfo.gameInfo.turns.tr() + " | " + yearText)
+        turnsLabel.setText(Fonts.turn + " " + civInfo.gameInfo.turns.tr() + " | " + yearText)
 
         resourcesWrapper.clearChildren()
         val civResources = civInfo.getCivResourcesByName()

--- a/core/src/com/unciv/ui/screens/worldscreen/topbar/WorldScreenTopBarStats.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/topbar/WorldScreenTopBarStats.kt
@@ -156,9 +156,9 @@ internal class WorldScreenTopBarStats(topbar: WorldScreenTopBar) : ScalingTableW
         // kotlin Float division by Zero produces `Float.POSITIVE_INFINITY`, not an exception
         val turnsToNextPolicy = (civInfo.policies.getCultureNeededForNextPolicy() - civInfo.policies.storedCulture) / nextTurnStats.culture
         cultureString += when {
-            turnsToNextPolicy <= 0f -> " (!)" // Can choose policy right now
-            nextTurnStats.culture <= 0 -> " (${Fonts.infinity})" // when you start the game, you're not producing any culture
-            else -> " (" + ceil(turnsToNextPolicy).toInt().tr() + ")"
+            turnsToNextPolicy <= 0f -> " (!)" // Can choose policy right now
+            nextTurnStats.culture <= 0 -> " (${Fonts.infinity})" // when you start the game, you're not producing any culture
+            else -> " (" + Fonts.turn + " " + ceil(turnsToNextPolicy).toInt().tr() + ")"
         }
         return cultureString
     }

--- a/core/src/com/unciv/ui/screens/worldscreen/topbar/WorldScreenTopBarStats.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/topbar/WorldScreenTopBarStats.kt
@@ -1,7 +1,9 @@
 package com.unciv.ui.screens.worldscreen.topbar
 
 import com.badlogic.gdx.scenes.scene2d.Group
+import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.scenes.scene2d.ui.Label
+import com.unciv.Constants
 import com.unciv.logic.civilization.Civilization
 import com.unciv.models.stats.Stats
 import com.unciv.models.translations.tr
@@ -22,11 +24,18 @@ import kotlin.math.ceil
 import kotlin.math.roundToInt
 
 internal class WorldScreenTopBarStats(topbar: WorldScreenTopBar) : ScalingTableWrapper() {
-    private val goldLabel = "0".toLabel(colorFromRGB(225, 217, 71))
-    private val scienceLabel = "0".toLabel(colorFromRGB(78, 140, 151))
+
+    private val goldLabel = "0".toLabel(colorFromRGB(225, 217, 71)) // #ed1947
+    private val goldPerTurnLabel = "+0"
+        .toLabel(colorFromRGB(225, 217, 71), 12)
+
+    private val scienceLabel = "0".toLabel(colorFromRGB(78, 140, 151)) // #4e8c97
     private val happinessLabel = "0".toLabel()
-    private val cultureLabel = "0".toLabel(colorFromRGB(210, 94, 210))
-    private val faithLabel = "0".toLabel(colorFromRGB(168, 196, 241))
+    private val cultureLabel = "0".toLabel(colorFromRGB(210, 94, 210)) // #d25ed2
+
+    private val faithLabel = "0".toLabel(colorFromRGB(168, 196, 241)) // #a8c4f1
+    private val faithPerTurnLabel = "+0"
+        .toLabel(colorFromRGB(168, 196, 241), 12)
 
     private val happinessContainer = Group()
 
@@ -51,8 +60,14 @@ internal class WorldScreenTopBarStats(topbar: WorldScreenTopBar) : ScalingTableW
     init {
         isTransform = false
 
-
-        fun addStat(label: Label, icon: String, isLast: Boolean = false, screenFactory: ()-> BaseScreen?) {
+        defaults().pad(defaultTopPad, defaultHorizontalPad, defaultBottomPad, defaultHorizontalPad)
+        
+        fun addStat(
+            icon: String,
+            label: Label,
+            noPad: Boolean = false,
+            screenFactory: () -> BaseScreen?
+        ) {
             val image = ImageGetter.getStatIcon(icon)
             val action = {
                 val screen = screenFactory()
@@ -60,47 +75,59 @@ internal class WorldScreenTopBarStats(topbar: WorldScreenTopBar) : ScalingTableW
             }
             label.onClick(action)
             image.onClick(action)
-            add(label)
-            add(image).padBottom(defaultImageBottomPad).size(defaultImageSize).apply {
-                if (!isLast) padRight(padRightBetweenStats)
-            }
+            add(image).padBottom(defaultImageBottomPad).size(defaultImageSize)
+            add(label).padRight(if (noPad) 0f else padRightBetweenStats)
         }
 
-        fun addStat(label: Label, icon: String, overviewPage: EmpireOverviewCategories, isLast: Boolean = false) =
-            addStat(label, icon, isLast) { EmpireOverviewScreen(worldScreen.selectedCiv, overviewPage) }
+        fun addStat(
+            icon: String,
+            label: Label,
+            overviewPage: EmpireOverviewCategories,
+            noPad: Boolean = false
+        ) = addStat(icon, label, noPad) {
+            EmpireOverviewScreen(worldScreen.selectedCiv, overviewPage)
+        }
 
-        defaults().pad(defaultTopPad, defaultHorizontalPad, defaultBottomPad, defaultHorizontalPad)
-        addStat(goldLabel, "Gold", EmpireOverviewCategories.Stats)
-        addStat(scienceLabel, "Science") { TechPickerScreen(worldScreen.selectedCiv) }
+        fun addPerTurnLabel(label: Label) {
+            add(label).padRight(padRightBetweenStats)
+                .height(Constants.defaultFontSize.toFloat()).top()
+        }
 
-        add(happinessContainer).padBottom(defaultImageBottomPad).size(defaultImageSize)
-        add(happinessLabel).padRight(padRightBetweenStats)
+
+        addStat("Gold", goldLabel, EmpireOverviewCategories.Stats, true)
+        addPerTurnLabel(goldPerTurnLabel);
+
+        addStat("Science", scienceLabel) { TechPickerScreen(worldScreen.selectedCiv) }
+
         val invokeResourcesPage = {
             worldScreen.openEmpireOverview(EmpireOverviewCategories.Resources)
         }
         happinessContainer.onClick(invokeResourcesPage)
         happinessLabel.onClick(invokeResourcesPage)
+        add(happinessContainer).padBottom(defaultImageBottomPad).size(defaultImageSize)
+        add(happinessLabel).padRight(padRightBetweenStats)
 
-        addStat(cultureLabel, "Culture") {
+        addStat("Culture", cultureLabel) {
             if (worldScreen.gameInfo.ruleset.policyBranches.isEmpty()) null
             else PolicyPickerScreen(worldScreen.selectedCiv, worldScreen.canChangeState)
         }
+
         if (worldScreen.gameInfo.isReligionEnabled()) {
-            addStat(faithLabel, "Faith", EmpireOverviewCategories.Religion, isLast = true)
-        } else {
-            add("Religion: Off".toLabel())
-        }
+            addStat("Faith", faithLabel, EmpireOverviewCategories.Religion, true)
+            addPerTurnLabel(faithPerTurnLabel)
+        } else add("Religion: Off".toLabel())
+
+
     }
 
-
-    private fun rateLabel(value: Float) = value.roundToInt().toStringSigned()
 
     fun update(civInfo: Civilization) {
         resetScale()
 
         val nextTurnStats = civInfo.stats.statsForNextTurn
-        val goldPerTurn = " (" + rateLabel(nextTurnStats.gold) + ")"
-        goldLabel.setText(civInfo.gold.tr() + goldPerTurn)
+        
+        goldLabel.setText(civInfo.gold.tr())
+        goldPerTurnLabel.setText(rateLabel(nextTurnStats.gold))
 
         scienceLabel.setText(rateLabel(nextTurnStats.science))
 
@@ -117,9 +144,9 @@ internal class WorldScreenTopBarStats(topbar: WorldScreenTopBar) : ScalingTableW
         }
 
         cultureLabel.setText(getCultureText(civInfo, nextTurnStats))
-        faithLabel.setText(
-            civInfo.religionManager.storedFaith.tr() + " (" + rateLabel(nextTurnStats.faith) + ")"
-        )
+
+        faithLabel.setText(civInfo.religionManager.storedFaith.tr())
+        faithPerTurnLabel.setText(rateLabel(nextTurnStats.faith))
 
         scaleTo(worldScreen.stage.width)
     }
@@ -145,5 +172,9 @@ internal class WorldScreenTopBarStats(topbar: WorldScreenTopBar) : ScalingTableW
             else
                 " (${goldenAges.storedHappiness.tr()}/${goldenAges.happinessRequiredForNextGoldenAge().tr()})"
         return happinessText
+    }
+
+    private fun rateLabel(value: Float): String {
+        return if (value.roundToInt() == 0) "±0" else value.roundToInt().toStringSigned()
     }
 }


### PR DESCRIPTION
## Notable changes
- reuse selectedCivIcon centering for IconTextButtons,
- standardise top bar icon–text order,
- replace parenthesised per-turn text with a new style,
- improve spacing of the turn count label
- improve spacing of the selectedCivIcon area
- reduce size of the hamburger menu
- add turn count icon to the culture stat label

## Comparison
### Old:
![image](https://github.com/user-attachments/assets/1542e11e-b332-4bbc-97c8-d2f686f75796)
![image](https://github.com/user-attachments/assets/e3d29465-a313-46f8-b374-66ef38475f9e)

### New:
![image](https://github.com/user-attachments/assets/092ba021-d398-4d30-8023-ec36a0283c43)
![image](https://github.com/user-attachments/assets/d7c9f711-dfa1-4136-8e90-5d10e6f00e75)


## Rationale

### reuse selectedCivIcon centering for IconTextButtons
This is not perfect, but it aligns text with icons much better than the default system of alignment.  Effect is particularly noticeable when both the icon and text are fairly small.

### standardise top bar icon–text order
Happiness being the only one where the icon comes first is very odd and inconsistent.  Icon-before-text is a much more idiomatic order for simple labels that are intended to communicate how much of something there is.

### replace parenthesised per-turn text with a new style
This one might be controversial, but I prefer this.  Removing the parentheses reduces cognitive load and makes it easier to find the information the player is looking for, and overall makes the section less cluttered.

### improve spacing of the turn count label
Self-explanatory.  The icon was clearly too close to the text.

### improve spacing of the selectedCivIcon area
Self-explanatory.  The icon was clearly too close to the text.

### reduce size of the hamburger menu
I understand the need for it to be easily accessible on mobile, but it was comically large before in my opinion.  Menu buttons like this are usually no larger than the "main" element of the header; usually a brand logo or similar, but in this case, the current civilisation's icon reflects a similar purpose.

### add turn count icon to the culture stat label
Might be controversial.  However, the purpose of a parenthesised number with no context can be difficult to guess, especially for new players.  I think it's plenty worth it to sacrifice some space in the name of clear communication.