### PR TITLE
Provide a default unitType for units to gain global uniques

### DIFF
--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -118,6 +118,8 @@ class Ruleset {
     val greatGeneralUnits by lazy {
         units.values.filter { it.hasUnique(UniqueType.GreatPersonFromCombat, StateForConditionals.IgnoreConditionals) }
     }
+    
+    val allUnitTypes by lazy { unitTypes["All"] }
 
     val tileRemovals by lazy { tileImprovements.values.filter { it.name.startsWith(Constants.remove) } }
     val nonRoadTileRemovals by lazy { tileRemovals.filter { rulesetImprovement ->


### PR DESCRIPTION
Currently, there's no way to have global uniques for mods. At best, you have to hand out promotions to units that give whatever global effects you want. While this technically works, not only does it require the promotion system to always handle out the unit (which I think is always doable, but it's possible there's some edge case I'm not aware of), but some modders don't seem to be  aware that this is an option. As such, you get mods that have extremely ugly/ likely unmaintable UnitTypes files[^1]. Pretty sure this comes up occansionally as a mod request[^2]


[^1]: https://github.com/Jiangeshi/Leader-Mission-2-Rising-Power/blob/main/jsons/UnitTypes.json
[^2]: https://github.com/yairm210/Unciv/issues/3242#issuecomment-1813988667