### PR TITLE
Cancel the chain reaction of defense pact

### DIFF
--- a/core/src/com/unciv/logic/civilization/diplomacy/DeclareWar.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DeclareWar.kt
@@ -33,8 +33,8 @@ object DeclareWar {
 
         notifyOfWar(diplomacyManager, declareWarReason)
 
-        onWarDeclared(diplomacyManager, true)
-        onWarDeclared(otherCivDiplomacy, false)
+        onWarDeclared(diplomacyManager, true, declareWarReason.warType)
+        onWarDeclared(otherCivDiplomacy, false, declareWarReason.warType)
 
         changeOpinions(diplomacyManager, declareWarReason)
 
@@ -127,7 +127,7 @@ object DeclareWar {
     }
 
     /** Everything that happens to both sides equally when war is declared by one side on the other */
-    private fun onWarDeclared(diplomacyManager: DiplomacyManager, isOffensiveWar: Boolean) {
+    private fun onWarDeclared(diplomacyManager: DiplomacyManager, isOffensiveWar: Boolean, warType: WarType) {
         // Cancel all trades.
         for (trade in diplomacyManager.trades)
             for (offer in trade.theirOffers.filter { it.duration > 0 && it.name != Constants.defensivePact})
@@ -147,10 +147,11 @@ object DeclareWar {
             removeDefensivePacts(diplomacyManager)
         }
         diplomacyManager.diplomaticStatus = DiplomaticStatus.War
-
+        
+        // Defensive pact chains are not allowed now
         if (diplomacyManager.civInfo.isMajorCiv()) {
-            if (!isOffensiveWar && !civAtWarWith.isCityState)
-                callInDefensivePactAllies(diplomacyManager)
+            if (!isOffensiveWar && warType != WarType.DefensivePactWar && !civAtWarWith.isCityState)
+                callInDefensivePactAllies(diplomacyManager)                
             callInCityStateAllies(diplomacyManager)
         }
 

--- a/core/src/com/unciv/ui/screens/diplomacyscreen/DiplomacyScreen.kt
+++ b/core/src/com/unciv/ui/screens/diplomacyscreen/DiplomacyScreen.kt
@@ -281,24 +281,15 @@ class DiplomacyScreen(
             otherCivDiploManager -> otherCivDiploManager.otherCiv() != viewingCiv
             && otherCivDiploManager.diplomaticStatus == DiplomaticStatus.DefensivePact
             && !otherCivDiploManager.otherCiv().isAtWarWith(viewingCiv) }
-            .map { it.otherCiv() }.toMutableList()
-            
-            // Defensive pact chains are not allowed now
-            var listIndex = 0
-            while (listIndex < otherCivDefensivePactList.size) {
-                messageLines += if (viewingCiv.knows(otherCivDefensivePactList[listIndex]))
-                    "[${otherCivDefensivePactList[listIndex].civName}] will also join them in the war"
-                else "An unknown civilization will also join them in the war"
-                /*
-                // Add their defensive pact allies
-                otherCivDefensivePactList.addAll(otherCivDefensivePactList[listIndex].diplomacy.values
-                    .filter { diploChain -> diploChain.diplomaticStatus == DiplomaticStatus.DefensivePact
-                        && !otherCivDefensivePactList.contains(diploChain.otherCiv())
-                        && diploChain.otherCiv() != viewingCiv && diploChain.otherCiv() != otherCiv
-                        && !diploChain.otherCiv().isAtWarWith(viewingCiv) }
-                    .map { it.otherCiv() })
-                */
-            listIndex++
+            .map { it.otherCiv() }
+
+        // Defensive pact chains are not allowed now
+        for (civ in otherCivDefensivePactList) {
+            messageLines += if (viewingCiv.knows(civ)) {
+                "[${civ.civName}] will also join them in the war"
+            } else {
+                "An unknown civilization will also join them in the war"
+            }
         }
 
         // Tell the player that their defensive pacts will be canceled.

--- a/core/src/com/unciv/ui/screens/diplomacyscreen/DiplomacyScreen.kt
+++ b/core/src/com/unciv/ui/screens/diplomacyscreen/DiplomacyScreen.kt
@@ -282,20 +282,22 @@ class DiplomacyScreen(
             && otherCivDiploManager.diplomaticStatus == DiplomaticStatus.DefensivePact
             && !otherCivDiploManager.otherCiv().isAtWarWith(viewingCiv) }
             .map { it.otherCiv() }.toMutableList()
-        // Go through and find all of the defensive pact chains and add them to the list
-        var listIndex = 0
-        while (listIndex < otherCivDefensivePactList.size) {
-            messageLines += if (viewingCiv.knows(otherCivDefensivePactList[listIndex]))
-                "[${otherCivDefensivePactList[listIndex].civName}] will also join them in the war"
-            else "An unknown civilization will also join them in the war"
-
-            // Add their defensive pact allies
-            otherCivDefensivePactList.addAll(otherCivDefensivePactList[listIndex].diplomacy.values
-                .filter { diploChain -> diploChain.diplomaticStatus == DiplomaticStatus.DefensivePact
-                    && !otherCivDefensivePactList.contains(diploChain.otherCiv())
-                    && diploChain.otherCiv() != viewingCiv && diploChain.otherCiv() != otherCiv
-                    && !diploChain.otherCiv().isAtWarWith(viewingCiv) }
-                .map { it.otherCiv() })
+            
+            // Defensive pact chains are not allowed now
+            var listIndex = 0
+            while (listIndex < otherCivDefensivePactList.size) {
+                messageLines += if (viewingCiv.knows(otherCivDefensivePactList[listIndex]))
+                    "[${otherCivDefensivePactList[listIndex].civName}] will also join them in the war"
+                else "An unknown civilization will also join them in the war"
+                /*
+                // Add their defensive pact allies
+                otherCivDefensivePactList.addAll(otherCivDefensivePactList[listIndex].diplomacy.values
+                    .filter { diploChain -> diploChain.diplomaticStatus == DiplomaticStatus.DefensivePact
+                        && !otherCivDefensivePactList.contains(diploChain.otherCiv())
+                        && diploChain.otherCiv() != viewingCiv && diploChain.otherCiv() != otherCiv
+                        && !diploChain.otherCiv().isAtWarWith(viewingCiv) }
+                    .map { it.otherCiv() })
+                */
             listIndex++
         }
 


### PR DESCRIPTION
I noticed the discussion in Discord about whether to cancel the chain reaction of defense pact. Based on this, I made some corresponding changes. Before a civilization calls a defense pact ally, it will check the Type of the war it is participating in. If it is already a DefensivePactWar, it will not continue to call allies.
Resolves #12564 