### PR TITLE
Delete duplicate trade denied message

### DIFF
--- a/core/src/com/unciv/logic/trade/Trade.kt
+++ b/core/src/com/unciv/logic/trade/Trade.kt
@@ -3,8 +3,6 @@ package com.unciv.logic.trade
 import com.unciv.Constants
 import com.unciv.logic.IsPartOfGameInfoSerialization
 import com.unciv.logic.civilization.Civilization
-import com.unciv.logic.civilization.NotificationCategory
-import com.unciv.logic.civilization.NotificationIcon
 import com.unciv.logic.civilization.diplomacy.DiplomacyFlags
 import com.unciv.models.ruleset.nation.PersonalityValue
 
@@ -71,12 +69,8 @@ class TradeRequest : IsPartOfGameInfoSerialization {
             requestingCivDiploManager.otherCivDiplomacy().setFlag(DiplomacyFlags.DeclinedJoinWarOffer, if (decliningCiv.isAI()) 5 else 10)
 
         if (trade.isPeaceTreaty()) requestingCivDiploManager.setFlag(DiplomacyFlags.DeclinedPeace, 3)
-
-        requestingCivInfo.addNotification("[${decliningCiv.civName}] has denied your trade request",
-            NotificationCategory.Trade, decliningCiv.civName, NotificationIcon.Trade)
     }
-
-
+    
     lateinit var requestingCiv: String
 
     /** Their offers are what they offer us, and our offers are what they want in return */


### PR DESCRIPTION
I made this small change as a by-product while working on (https://github.com/yairm210/Unciv/issues/12705), so I don't plan to open a new issue.
When a trade is denied, the sender of trade will receive 2 duplicate trade denied messages (as the screen shot below). I checked the code and found that the message was sent repeatedly in two places (TradePopup.kt and Trade.kt), so I deleted one of them.
<img width="1440" alt="screen_shot2" src="https://github.com/user-attachments/assets/97336dbe-117b-40e0-a0dd-966f5e8c957c" />
