### PR TITLE
Allow for city level stockpiles to actually function

### DIFF
--- a/core/src/com/unciv/logic/city/City.kt
+++ b/core/src/com/unciv/logic/city/City.kt
@@ -210,11 +210,6 @@ class City : IsPartOfGameInfoSerialization, INamed {
 
     fun getGreatPersonPercentageBonus() = GreatPersonPointsBreakdown.getGreatPersonPercentageBonus(this)
     fun getGreatPersonPoints() = GreatPersonPointsBreakdown(this).sum()
-    
-    fun gainStockpiledResource(resourceName: String, amount: Int) {
-        
-        resourceStockpiles.add(resourceName, amount)
-    }
 
     fun gainStockpiledResource(resource: TileResource, amount: Int) {
         if (resource.isCityWide) resourceStockpiles.add(resource.name, amount)

--- a/core/src/com/unciv/logic/city/City.kt
+++ b/core/src/com/unciv/logic/city/City.kt
@@ -16,6 +16,7 @@ import com.unciv.logic.map.TileMap
 import com.unciv.logic.map.mapunit.MapUnit
 import com.unciv.logic.map.tile.RoadStatus
 import com.unciv.logic.map.tile.Tile
+import com.unciv.models.Counter
 import com.unciv.models.ruleset.Building
 import com.unciv.models.ruleset.tile.TileResource
 import com.unciv.models.ruleset.unique.StateForConditionals
@@ -73,6 +74,8 @@ class City : IsPartOfGameInfoSerialization, INamed {
 
     @Transient  // CityStats has no serializable fields
     var cityStats = CityStats(this)
+    
+    var resourceStockpiles = Counter<String>()
 
     /** All tiles that this city controls */
     var tiles = HashSet<Vector2>()
@@ -136,6 +139,7 @@ class City : IsPartOfGameInfoSerialization, INamed {
         toReturn.tiles = tiles
         toReturn.workedTiles = workedTiles
         toReturn.lockedTiles = lockedTiles
+        toReturn.resourceStockpiles = resourceStockpiles.clone()
         toReturn.isBeingRazed = isBeingRazed
         toReturn.attackedThisTurn = attackedThisTurn
         toReturn.foundingCiv = foundingCiv
@@ -206,6 +210,15 @@ class City : IsPartOfGameInfoSerialization, INamed {
 
     fun getGreatPersonPercentageBonus() = GreatPersonPointsBreakdown.getGreatPersonPercentageBonus(this)
     fun getGreatPersonPoints() = GreatPersonPointsBreakdown(this).sum()
+    
+    fun gainStockpiledResource(resourceName: String, amount: Int) {
+        resourceStockpiles.add(resourceName, amount)
+    }
+
+    fun gainStockpiledResource(resource: TileResource, amount: Int) {
+        if (resource.isCityWide) resourceStockpiles.add(resource.name, amount)
+        else civ.gainStockpiledResource(resource.name, amount)
+    }
 
     fun addStat(stat: Stat, amount: Int) {
         when (stat) {
@@ -219,7 +232,7 @@ class City : IsPartOfGameInfoSerialization, INamed {
         if (stat is TileResource) {
             if (!stat.isStockpiled) return
             if (!stat.isCityWide) civ.gainStockpiledResource(stat.name, amount)
-            else { /*TODO*/ }
+            else gainStockpiledResource(stat.name, amount)
             return
         }
         when (stat) {
@@ -238,11 +251,9 @@ class City : IsPartOfGameInfoSerialization, INamed {
     }
 
     fun getReserve(stat: GameResource): Int {
-        if (stat is TileResource && stat.isCityWide) {
-            return if (stat.isStockpiled) {
-                // TODO
-                0
-            } else 0
+        if (stat is TileResource) {
+            if (!stat.isStockpiled) return 0
+            if (stat.isCityWide) return resourceStockpiles[stat.name]
         }
         return when (stat) {
             Stat.Production -> cityConstructions.getWorkDone(cityConstructions.getCurrentConstruction().name)

--- a/core/src/com/unciv/logic/city/City.kt
+++ b/core/src/com/unciv/logic/city/City.kt
@@ -212,6 +212,7 @@ class City : IsPartOfGameInfoSerialization, INamed {
     fun getGreatPersonPoints() = GreatPersonPointsBreakdown(this).sum()
     
     fun gainStockpiledResource(resourceName: String, amount: Int) {
+        
         resourceStockpiles.add(resourceName, amount)
     }
 
@@ -253,6 +254,7 @@ class City : IsPartOfGameInfoSerialization, INamed {
         if (stat is TileResource) {
             if (!stat.isStockpiled) return 0
             if (stat.isCityWide) return resourceStockpiles[stat.name]
+            else return civ.resourceStockpiles[stat.name]
         }
         return when (stat) {
             Stat.Production -> cityConstructions.getWorkDone(cityConstructions.getCurrentConstruction().name)

--- a/core/src/com/unciv/logic/city/City.kt
+++ b/core/src/com/unciv/logic/city/City.kt
@@ -231,8 +231,7 @@ class City : IsPartOfGameInfoSerialization, INamed {
     fun addGameResource(stat: GameResource, amount: Int) {
         if (stat is TileResource) {
             if (!stat.isStockpiled) return
-            if (!stat.isCityWide) civ.gainStockpiledResource(stat.name, amount)
-            else gainStockpiledResource(stat.name, amount)
+            gainStockpiledResource(stat, amount)
             return
         }
         when (stat) {

--- a/core/src/com/unciv/logic/city/City.kt
+++ b/core/src/com/unciv/logic/city/City.kt
@@ -213,7 +213,7 @@ class City : IsPartOfGameInfoSerialization, INamed {
 
     fun gainStockpiledResource(resource: TileResource, amount: Int) {
         if (resource.isCityWide) resourceStockpiles.add(resource.name, amount)
-        else civ.gainStockpiledResource(resource.name, amount)
+        else civ.resourceStockpiles.add(resource.name, amount)
     }
 
     fun addStat(stat: Stat, amount: Int) {
@@ -249,7 +249,7 @@ class City : IsPartOfGameInfoSerialization, INamed {
         if (stat is TileResource) {
             if (!stat.isStockpiled) return 0
             if (stat.isCityWide) return resourceStockpiles[stat.name]
-            else return civ.resourceStockpiles[stat.name]
+            return civ.resourceStockpiles[stat.name]
         }
         return when (stat) {
             Stat.Production -> cityConstructions.getWorkDone(cityConstructions.getCurrentConstruction().name)

--- a/core/src/com/unciv/logic/city/CityConstructions.kt
+++ b/core/src/com/unciv/logic/city/CityConstructions.kt
@@ -435,7 +435,8 @@ class CityConstructions : IsPartOfGameInfoSerialization {
         for (unique in costUniques) {
             val amount = unique.params[0].toInt()
             val resourceName = unique.params[1]
-            city.civ.gainStockpiledResource(resourceName, -amount)
+            val resource = city.civ.gameInfo.ruleset.tileResources[resourceName] ?: continue
+            city.gainStockpiledResource(resource, -amount)
         }
 
         if (construction !is Building) return
@@ -705,7 +706,8 @@ class CityConstructions : IsPartOfGameInfoSerialization {
                 for (unique in costUniques) {
                     val amount = unique.params[0].toInt()
                     val resourceName = unique.params[1]
-                    city.civ.gainStockpiledResource(resourceName, -amount)
+                    val resource = city.civ.gameInfo.ruleset.tileResources[resourceName] ?: continue
+                    city.gainStockpiledResource(resource, -amount)
                 }
             }
         }

--- a/core/src/com/unciv/logic/city/CityResources.kt
+++ b/core/src/com/unciv/logic/city/CityResources.kt
@@ -69,9 +69,9 @@ object CityResources {
     fun getAvailableResourceAmount(city: City, resourceName: String): Int {
         val resource = city.getRuleset().tileResources[resourceName] ?: return 0
 
-        if (resource.isCityWide)
-            return getCityResourcesAvailableToCity(city).asSequence().filter { it.resource == resource }.sumOf { it.amount }
-        return city.civ.getResourceAmount(resourceName)
+        if (!resource.isCityWide) return city.civ.getResourceAmount(resourceName)
+        if (resource.isStockpiled) return city.resourceStockpiles[resourceName]
+        return getCityResourcesAvailableToCity(city).asSequence().filter { it.resource == resource }.sumOf { it.amount }
     }
 
     private fun addResourcesFromTiles(city: City, resourceModifer: HashMap<String, Float>, cityResources: ResourceSupplyList) {

--- a/core/src/com/unciv/logic/civilization/Civilization.kt
+++ b/core/src/com/unciv/logic/civilization/Civilization.kt
@@ -866,7 +866,7 @@ class Civilization : IsPartOfGameInfoSerialization {
     }
 
     fun addGameResource(stat: GameResource, amount: Int) {
-        if (stat is TileResource && !stat.isCityWide && stat.isStockpiled) gainStockpiledResource(stat.name, amount)
+        if (stat is TileResource && stat.isStockpiled) gainStockpiledResource(stat.name, amount)
         when (stat) {
             Stat.Culture -> { policies.addCulture(amount)
                 if (amount > 0) totalCultureForContests += amount }
@@ -879,6 +879,11 @@ class Civilization : IsPartOfGameInfoSerialization {
             // Food and Production wouldn't make sense to be added nationwide
             // Happiness cannot be added as it is recalculated again, use a unique instead
         }
+    }
+
+    fun gainStockpiledResource(resource: TileResource, amount: Int) {
+        if (resource.isCityWide) return
+        resourceStockpiles.add(resource.name, amount)
     }
     
     fun gainStockpiledResource(resourceName: String, amount: Int) {

--- a/core/src/com/unciv/logic/civilization/Civilization.kt
+++ b/core/src/com/unciv/logic/civilization/Civilization.kt
@@ -866,7 +866,7 @@ class Civilization : IsPartOfGameInfoSerialization {
     }
 
     fun addGameResource(stat: GameResource, amount: Int) {
-        if (stat is TileResource && stat.isStockpiled) gainStockpiledResource(stat.name, amount)
+        if (stat is TileResource && stat.isStockpiled) gainStockpiledResource(stat, amount)
         when (stat) {
             Stat.Culture -> { policies.addCulture(amount)
                 if (amount > 0) totalCultureForContests += amount }
@@ -884,10 +884,6 @@ class Civilization : IsPartOfGameInfoSerialization {
     fun gainStockpiledResource(resource: TileResource, amount: Int) {
         if (resource.isCityWide) return
         resourceStockpiles.add(resource.name, amount)
-    }
-    
-    fun gainStockpiledResource(resourceName: String, amount: Int) {
-        resourceStockpiles.add(resourceName, amount)
     }
 
     fun getStatReserve(stat: Stat): Int {

--- a/core/src/com/unciv/logic/civilization/managers/TurnManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/TurnManager.kt
@@ -41,7 +41,7 @@ class TurnManager(val civInfo: Civilization) {
 
         civInfo.cache.updateCivResources() // If you offered a trade last turn, this turn it will have been accepted/declined
         for (stockpiledResource in civInfo.getCivResourceSupply().filter { it.resource.isStockpiled })
-            civInfo.gainStockpiledResource(stockpiledResource.resource.name, stockpiledResource.amount)
+            civInfo.gainStockpiledResource(stockpiledResource.resource, stockpiledResource.amount)
 
         civInfo.civConstructions.startTurn()
         civInfo.attacksSinceTurnStart.clear()

--- a/core/src/com/unciv/logic/civilization/transients/CivInfoTransientCache.kt
+++ b/core/src/com/unciv/logic/civilization/transients/CivInfoTransientCache.kt
@@ -355,7 +355,7 @@ class CivInfoTransientCache(val civInfo: Civilization) {
             newDetailedCivResources.subtractResourceRequirements(
                 unit.getResourceRequirementsPerTurn(), civInfo.gameInfo.ruleset, "Units")
 
-        newDetailedCivResources.removeAll { it.resource.hasUnique(UniqueType.CityResource) }
+        newDetailedCivResources.removeAll { it.resource.isCityWide }
 
         // Check if anything has actually changed so we don't update stats for no reason - this uses List equality which means it checks the elements
         if (civInfo.detailedCivResources == newDetailedCivResources) return

--- a/core/src/com/unciv/models/ruleset/tile/TileResource.kt
+++ b/core/src/com/unciv/models/ruleset/tile/TileResource.kt
@@ -36,11 +36,9 @@ class TileResource : RulesetStatsObject(), GameResource {
 
     var majorDepositAmount: DepositAmount = DepositAmount()
     var minorDepositAmount: DepositAmount = DepositAmount()
-    
-    @delegate:Transient
+
     val isCityWide by lazy { hasUnique(UniqueType.CityResource, StateForConditionals.IgnoreConditionals) }
 
-    @delegate:Transient
     val isStockpiled by lazy { hasUnique(UniqueType.Stockpiled, StateForConditionals.IgnoreConditionals) }
 
     private var improvementsInitialized = false

--- a/core/src/com/unciv/models/ruleset/tile/TileResource.kt
+++ b/core/src/com/unciv/models/ruleset/tile/TileResource.kt
@@ -37,8 +37,10 @@ class TileResource : RulesetStatsObject(), GameResource {
     var majorDepositAmount: DepositAmount = DepositAmount()
     var minorDepositAmount: DepositAmount = DepositAmount()
     
+    @delegate:Transient
     val isCityWide by lazy { hasUnique(UniqueType.CityResource, StateForConditionals.IgnoreConditionals) }
 
+    @delegate:Transient
     val isStockpiled by lazy { hasUnique(UniqueType.Stockpiled, StateForConditionals.IgnoreConditionals) }
 
     private var improvementsInitialized = false

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -527,7 +527,7 @@ object UniqueTriggerActivation {
                 return {
                     val amount = unique.params[0].toInt()
                     if (city != null) city.gainStockpiledResource(resource, amount)
-                    else civInfo.gainStockpiledResource(resourceName, amount)
+                    else civInfo.gainStockpiledResource(resource, amount)
 
                     val notificationText = getNotificationText(
                         notification, triggerNotificationText,
@@ -547,7 +547,7 @@ object UniqueTriggerActivation {
                 return {
                     val amount = unique.params[0].toInt()
                     if (city != null) city.gainStockpiledResource(resource, -amount)
-                    else civInfo.gainStockpiledResource(resourceName, -amount)
+                    else civInfo.gainStockpiledResource(resource, -amount)
 
                     val notificationText = getNotificationText(
                         notification, triggerNotificationText,

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -526,7 +526,8 @@ object UniqueTriggerActivation {
 
                 return {
                     val amount = unique.params[0].toInt()
-                    civInfo.gainStockpiledResource(resourceName, amount)
+                    if (city != null) city.gainStockpiledResource(resource, amount)
+                    else civInfo.gainStockpiledResource(resourceName, amount)
 
                     val notificationText = getNotificationText(
                         notification, triggerNotificationText,
@@ -545,7 +546,8 @@ object UniqueTriggerActivation {
 
                 return {
                     val amount = unique.params[0].toInt()
-                    civInfo.gainStockpiledResource(resourceName, -amount)
+                    if (city != null) city.gainStockpiledResource(resource, -amount)
+                    else civInfo.gainStockpiledResource(resourceName, -amount)
 
                     val notificationText = getNotificationText(
                         notification, triggerNotificationText,

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionModifiers.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionModifiers.kt
@@ -115,8 +115,9 @@ object UnitActionModifiers {
                 UniqueType.UnitActionStockpileCost -> {
                     val amount = conditional.params[0].toInt()
                     val resourceName = conditional.params[1]
-                    if(unit.civ.getCivResourcesByName()[resourceName] != null)
-                        unit.civ.gainStockpiledResource(resourceName, -amount)
+                    val resource = unit.civ.gameInfo.ruleset.tileResources[resourceName]
+                    if (resource != null && resource.isStockpiled)
+                        unit.civ.gainStockpiledResource(resource, -amount)
                 }
                 UniqueType.UnitActionRemovingPromotion -> {
                     val promotionName = conditional.params[0]


### PR DESCRIPTION
Currently stockpiles for cities don't actually exist. Previously, I believe (but never checked) that they would function as if they were civwide regardless, which doesn't match up with the clear and obvious intent. During the last few PRs, I've since changed it so that under some circumstances, gaining a citywide stockpile from a city context would do nothing. This PR aims to do 2 things
1. Go the extra mile to try to enforce citywide resources as being "citywide" from these contexts
2. Provide at least the barebones needed for a functioning citywide stockpile

As of writing this PR description, I'm not entirely sure the best way into the resource logic to add citywide stockpile resources, so I haven't immediately focused on adding it