### PR TITLE
Let AI choose healing promotions

### DIFF
--- a/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
@@ -181,7 +181,9 @@ object UnitAutomation {
             // Restrict Human automated units from promotions via setting
                 (UncivGame.Current.settings.automatedUnitsChoosePromotions || unit.civ.isAI())) {
             val availablePromotions = unit.promotions.getAvailablePromotions()
-                .filterNot { it.hasUnique(UniqueType.SkipPromotion) }
+            if (unit.health < 60 && !(unit.baseUnit.isAirUnit() || unit.baseUnit.hasUnique(UniqueType.CanMoveAfterAttacking)))
+                availablePromotions.filter { it.hasUnique(UniqueType.OneTimeUnitHeal) } //choose healing promotions only when beneficial
+            else availablePromotions.filterNot { it.hasUnique(UniqueType.SkipPromotion) }
             if (availablePromotions.none()) break
             val freePromotions = availablePromotions.filter { it.hasUnique(UniqueType.FreePromotion) }.toList()
             val stateForConditionals = unit.cache.state
@@ -192,6 +194,13 @@ object UnitAutomation {
             unit.promotions.addPromotion(chosenPromotion.name)
         }
 
+        //This allows for military units with certain civilian abilities to behave as civilians in peace and soldiers in war
+        if ((unit.hasUnique(UniqueType.BuildImprovements) || unit.hasUnique(UniqueType.FoundCity) ||
+                unit.hasUnique(UniqueType.ReligiousUnit) || unit.hasUnique(UniqueType.CreateWaterImprovements))
+                && !unit.civ.isAtWar()){
+            CivilianUnitAutomation.automateCivilianUnit(unit, getDangerousTiles(unit))
+            return
+        }
         //This allows for military units with certain civilian abilities to behave as civilians in peace and soldiers in war
         if ((unit.hasUnique(UniqueType.BuildImprovements) || unit.hasUnique(UniqueType.FoundCity) ||
                 unit.hasUnique(UniqueType.ReligiousUnit) || unit.hasUnique(UniqueType.CreateWaterImprovements))

--- a/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
@@ -201,13 +201,6 @@ object UnitAutomation {
             CivilianUnitAutomation.automateCivilianUnit(unit, getDangerousTiles(unit))
             return
         }
-        //This allows for military units with certain civilian abilities to behave as civilians in peace and soldiers in war
-        if ((unit.hasUnique(UniqueType.BuildImprovements) || unit.hasUnique(UniqueType.FoundCity) ||
-                unit.hasUnique(UniqueType.ReligiousUnit) || unit.hasUnique(UniqueType.CreateWaterImprovements))
-                && !unit.civ.isAtWar()){
-            CivilianUnitAutomation.automateCivilianUnit(unit, getDangerousTiles(unit))
-            return
-        }
 
         // Note that not all nukes have to be air units
         if (unit.isNuclearWeapon()) {

--- a/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
@@ -181,7 +181,7 @@ object UnitAutomation {
             // Restrict Human automated units from promotions via setting
                 (UncivGame.Current.settings.automatedUnitsChoosePromotions || unit.civ.isAI())) {
             val availablePromotions = unit.promotions.getAvailablePromotions()
-            if (unit.health < 60 && !(unit.baseUnit.isAirUnit() || unit.baseUnit.hasUnique(UniqueType.CanMoveAfterAttacking)))
+            if (unit.health < 60 && !(unit.baseUnit.isAirUnit() || unit.baseUnit.hasUnique(UniqueType.CanMoveAfterAttacking)) && availablePromotions.any { it.hasUnique(UniqueType.OneTimeUnitHeal) })
                 availablePromotions.filter { it.hasUnique(UniqueType.OneTimeUnitHeal) } //choose healing promotions only when beneficial
             else availablePromotions.filterNot { it.hasUnique(UniqueType.SkipPromotion) }
             if (availablePromotions.none()) break


### PR DESCRIPTION
It is currently filtering out the healing promotion from consideration it seems, even though it can be the best choice.

Note that 60hp treshold is a bit arbitrary, it may be worthwhile to test with a higher or lower treshold.