### PR TITLE
Update CivilianUnitAutomation.kt

### DIFF
--- a/core/src/com/unciv/logic/automation/unit/CivilianUnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/CivilianUnitAutomation.kt
@@ -79,7 +79,8 @@ object CivilianUnitAutomation {
         val isLateGame = isLateGame(unit.civ)
         // Great scientist -> Hurry research if late game
         // Great writer -> Hurry policy  if late game
-        if (isLateGame) {
+        // Also expend our idle great persons in case of war, otherwise the AI loses them in combat 
+        if (isLateGame || unit.civ.isAtWar()) {
             val hurriedResearch = UnitActions.invokeUnitAction(unit, UnitActionType.HurryResearch)
             if (hurriedResearch) return
 


### PR DESCRIPTION
On more crowded maps, the AI has a tendency to have their tiles improved before the great persons start to spawn, and then it can't place academies anymore, which can lead to loss of the unit.