### PR TITLE
Add Google Maps - like pinching

### DIFF
--- a/core/src/com/unciv/ui/components/widgets/ZoomableScrollPane.kt
+++ b/core/src/com/unciv/ui/components/widgets/ZoomableScrollPane.kt
@@ -246,11 +246,16 @@ open class ZoomableScrollPane(
             }
         }
 
-        override fun pinch() {
+        override fun pinch(delta: Vector2) {
             if (!isZooming) {
                 isZooming = true
                 onZoomStartListener?.invoke()
             }
+            scrollTo(
+                scrollX - delta.x,
+                scrollY + delta.y,
+                true
+            )
         }
 
         override fun pinchStop() {
@@ -317,8 +322,6 @@ open class ZoomableScrollPane(
 
             //clamp() call is missing here but it doesn't seem to make any big difference in this case
 
-            if ((isScrollX && deltaX != 0f || isScrollY && deltaY != 0f))
-                cancelTouchFocus()
         }
 
         override fun panStop(event: InputEvent?, x: Float, y: Float, pointer: Int, button: Int) {


### PR DESCRIPTION
Up to now, the pinch gesture resulted zooming centered on the screen. This PR introduces pinching centered on the pointers (fingers) used for the gesture, which results in a more natural feel when navigating the map. Panning and pinching can be smoothly transitioned from/to by adding the second finger, much like in Google Maps.