### PR TITLE
Update CityLocationTileRanker.kt

### DIFF
--- a/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
+++ b/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
@@ -139,8 +139,9 @@ object CityLocationTileRanker {
                 distanceToCity < 4 -> -30f // Even if it is a mod that lets us settle closer, lets still not do it
                 else -> 0f
             }
+            val rankDistanceToCapital = city.isCapital() && newCityTile.aerialDistanceTo(city.getCenterTile()) > 3 //exlude first 3 rings
             // We want a defensive ring around our capital
-            if (city.civ == civ) distanceToCityModifier += if (city.isCapital()) 3 * (15 - newCityTile.aerialDistanceTo(city.getCenterTile())).coerceIn(0, 11) else 0
+            if (city.civ == civ) distanceToCityModifier += if (rankDistanceToCapital) 3 * (15 - newCityTile.aerialDistanceTo(city.getCenterTile())).coerceAtLeast(0) else 0
             modifier += distanceToCityModifier
         }
         return modifier

--- a/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
+++ b/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
@@ -133,7 +133,7 @@ object CityLocationTileRanker {
                 // If it is not higher the settler may get stuck when it ranks the same tile differently
                 // as it moves away from the city and doesn't include it in the calculation
                 // and values it higher than when it moves closer to the city
-                distanceToCity == 6 -> 4f
+                distanceToCity == 6 -> 3f
                 distanceToCity == 5 -> 8f // Settling further away sacrifices tempo
                 distanceToCity == 4 -> 4f
                 distanceToCity < 4 -> -30f // Even if it is a mod that lets us settle closer, lets still not do it

--- a/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
+++ b/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
@@ -133,16 +133,15 @@ object CityLocationTileRanker {
                 // If it is not higher the settler may get stuck when it ranks the same tile differently
                 // as it moves away from the city and doesn't include it in the calculation
                 // and values it higher than when it moves closer to the city
-                distanceToCity == 7 -> 2f
                 distanceToCity == 6 -> 4f
                 distanceToCity == 5 -> 8f // Settling further away sacrifices tempo
-                distanceToCity == 4 -> 6f
+                distanceToCity == 4 -> 4f
                 distanceToCity == 3 -> -25f
                 distanceToCity < 3 -> -30f // Even if it is a mod that lets us settle closer, lets still not do it
                 else -> 0f
             }
             // We want a defensive ring around our capital
-            if (city.civ == civ) distanceToCityModifier *= if (city.isCapital()) 2 else 1
+            if (city.civ == civ) distanceToCityModifier += if (city.isCapital()) 3 * (15 - newCityTile.aerialDistanceTo(city.getCenterTile())).coerceIn(0, 11) else 0
             modifier += distanceToCityModifier
         }
         return modifier

--- a/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
+++ b/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
@@ -141,7 +141,7 @@ object CityLocationTileRanker {
             }
             val rankDistanceToCapital = city.isCapital() && distanceToCity > 3 //exclude first 3 rings
             // We want a defensive ring around our capital
-            if (city.civ == civ) distanceToCityModifier += if (rankDistanceToCapital) 3 * (15 - distanceToCity).coerceAtLeast(0) else 0
+            if (city.civ == civ) distanceToCityModifier += if (rankDistanceToCapital) 3 * (10 - distanceToCity).coerceAtLeast(0) else 0
             modifier += distanceToCityModifier
         }
         return modifier

--- a/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
+++ b/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
@@ -134,10 +134,9 @@ object CityLocationTileRanker {
                 // as it moves away from the city and doesn't include it in the calculation
                 // and values it higher than when it moves closer to the city
                 distanceToCity == 6 -> 4f
-                distanceToCity == 5 -> 8f // Settling further away sacrifices tempo
-                distanceToCity == 4 -> 4f
-                distanceToCity == 3 -> -25f
-                distanceToCity < 3 -> -30f // Even if it is a mod that lets us settle closer, lets still not do it
+                distanceToCity == 5 -> 9f // Settling further away sacrifices tempo
+                distanceToCity == 4 -> 3f
+                distanceToCity < 4 -> -30f // Even if it is a mod that lets us settle closer, lets still not do it
                 else -> 0f
             }
             // We want a defensive ring around our capital

--- a/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
+++ b/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
@@ -139,7 +139,7 @@ object CityLocationTileRanker {
                 distanceToCity < 4 -> -30f // Even if it is a mod that lets us settle closer, lets still not do it
                 else -> 0f
             }
-            val rankDistanceToCapital = city.isCapital() && newCityTile.aerialDistanceTo(city.getCenterTile()) > 3 //exlude first 3 rings
+            val rankDistanceToCapital = city.isCapital() && newCityTile.aerialDistanceTo(city.getCenterTile()) > 3 //exclude first 3 rings
             // We want a defensive ring around our capital
             if (city.civ == civ) distanceToCityModifier += if (rankDistanceToCapital) 3 * (15 - newCityTile.aerialDistanceTo(city.getCenterTile())).coerceAtLeast(0) else 0
             modifier += distanceToCityModifier

--- a/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
+++ b/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
@@ -134,8 +134,8 @@ object CityLocationTileRanker {
                 // as it moves away from the city and doesn't include it in the calculation
                 // and values it higher than when it moves closer to the city
                 distanceToCity == 6 -> 4f
-                distanceToCity == 5 -> 9f // Settling further away sacrifices tempo
-                distanceToCity == 4 -> 3f
+                distanceToCity == 5 -> 8f // Settling further away sacrifices tempo
+                distanceToCity == 4 -> 4f
                 distanceToCity < 4 -> -30f // Even if it is a mod that lets us settle closer, lets still not do it
                 else -> 0f
             }

--- a/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
+++ b/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
@@ -139,9 +139,9 @@ object CityLocationTileRanker {
                 distanceToCity < 4 -> -30f // Even if it is a mod that lets us settle closer, lets still not do it
                 else -> 0f
             }
-            val rankDistanceToCapital = city.isCapital() && newCityTile.aerialDistanceTo(city.getCenterTile()) > 3 //exclude first 3 rings
+            val rankDistanceToCapital = city.isCapital() && distanceToCity > 3 //exclude first 3 rings
             // We want a defensive ring around our capital
-            if (city.civ == civ) distanceToCityModifier += if (rankDistanceToCapital) 3 * (15 - newCityTile.aerialDistanceTo(city.getCenterTile())).coerceAtLeast(0) else 0
+            if (city.civ == civ) distanceToCityModifier += if (rankDistanceToCapital) 3 * (15 - distanceToCity).coerceAtLeast(0) else 0
             modifier += distanceToCityModifier
         }
         return modifier


### PR DESCRIPTION
@itanasi, what do you think of something like this, to let AI settle in better orders (and probably let the settler locations wander less)?

Note that a range of 15 should be enough for most maps, but maybe not enough in huge map marathon games. Also, the distance value 3 should probably be treated differently if we're on a different continent or on the same continent (3 tiles apart can be correct if we're trying to fit cities on a cramped Archipelago map).