### PR TITLE
Add a field for global unit uniques

### DIFF
--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -645,6 +645,9 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
         for (building in ruleset.buildings.values)
             building.ruleset = ruleset
 
+        for (type in ruleset.unitTypes.values)
+            type.ruleset = ruleset
+
         // This needs to go before tileMap.setTransients, as units need to access
         // the nation of their civilization when setting transients
         for (civInfo in civilizations) civInfo.gameInfo = this

--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -39,7 +39,6 @@ import com.unciv.models.ruleset.RulesetCache
 import com.unciv.models.ruleset.Speed
 import com.unciv.models.ruleset.nation.Difficulty
 import com.unciv.models.ruleset.unique.LocalUniqueCache
-import com.unciv.models.ruleset.unique.StateForConditionals
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.translations.tr
 import com.unciv.ui.audio.MusicMood
@@ -640,13 +639,10 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
         removeMissingModReferences()
 
         for (baseUnit in ruleset.units.values)
-            baseUnit.ruleset = ruleset
+            baseUnit.setRuleset(ruleset)
 
         for (building in ruleset.buildings.values)
             building.ruleset = ruleset
-
-        for (type in ruleset.unitTypes.values)
-            type.ruleset = ruleset
 
         // This needs to go before tileMap.setTransients, as units need to access
         // the nation of their civilization when setting transients

--- a/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
@@ -594,7 +594,8 @@ object UnitAutomation {
 
     private fun chooseBombardTarget(city: City): ICombatant? {
         var targets = TargetHelper.getBombardableTiles(city).map { Battle.getMapCombatantOfTile(it)!! }
-            .filterNot { it.isCivilian() && !it.getUnitType().hasUnique(UniqueType.Uncapturable) } // Don't bombard capturable civilians
+            .filterNot { it is MapUnitCombatant &&
+                it.isCivilian() && !it.unit.hasUnique(UniqueType.Uncapturable) } // Don't bombard capturable civilians
         if (targets.none()) return null
 
         val siegeUnits = targets

--- a/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
@@ -673,12 +673,9 @@ class MapUnit : IsPartOfGameInfoSerialization {
     }
 
     fun updateUniques() {
-        val unitUniqueSources =
-            baseUnit.uniqueObjects.asSequence() +
-                type.uniqueObjects
         val otherUniqueSources = promotions.getPromotions().flatMap { it.uniqueObjects } +
             statuses.flatMap { it.uniques }
-        val uniqueSources = unitUniqueSources + otherUniqueSources
+        val uniqueSources = baseUnit.rulesetUniqueObjects.asSequence() + otherUniqueSources
         
         tempUniquesMap = UniqueMap(uniqueSources)
         nonUnitUniquesMap = UniqueMap(otherUniqueSources)

--- a/core/src/com/unciv/models/ruleset/GlobalUniques.kt
+++ b/core/src/com/unciv/models/ruleset/GlobalUniques.kt
@@ -7,6 +7,7 @@ import com.unciv.models.ruleset.unique.UniqueType
 class GlobalUniques: RulesetObject() {
     override var name = "GlobalUniques"
 
+    var unitUniques: ArrayList<String> = ArrayList()
     override fun getUniqueTarget() = UniqueTarget.Global
     override fun makeLink() = "" // No own category on Civilopedia screen
 

--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -216,7 +216,7 @@ class Ruleset {
         cityStateTypes.putAll(ruleset.cityStateTypes)
         ruleset.modOptions.unitsToRemove
             .flatMap { unitToRemove ->
-                units.filter { it.apply { value.ruleset = this@Ruleset }.value.matchesFilter(unitToRemove) }.keys
+                units.filter { it.apply { value.setRuleset(this@Ruleset) }.value.matchesFilter(unitToRemove) }.keys
             }.toSet().forEach {
                 units.remove(it)
             }

--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -184,6 +184,7 @@ class Ruleset {
         globalUniques = GlobalUniques().apply {
             uniques.addAll(globalUniques.uniques)
             uniques.addAll(ruleset.globalUniques.uniques)
+            unitUniques.addAll(globalUniques.unitUniques)
             unitUniques.addAll(ruleset.globalUniques.unitUniques)
         }
         ruleset.modOptions.nationsToRemove

--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -184,6 +184,7 @@ class Ruleset {
         globalUniques = GlobalUniques().apply {
             uniques.addAll(globalUniques.uniques)
             uniques.addAll(ruleset.globalUniques.uniques)
+            unitUniques.addAll(ruleset.globalUniques.unitUniques)
         }
         ruleset.modOptions.nationsToRemove
             .flatMap { nationToRemove ->

--- a/core/src/com/unciv/models/ruleset/unique/IHasUniques.kt
+++ b/core/src/com/unciv/models/ruleset/unique/IHasUniques.kt
@@ -21,12 +21,18 @@ interface IHasUniques : INamed {
     val uniqueMap: UniqueMap
 
     fun uniqueObjectsProvider(): List<Unique> {
+        return uniqueObjectsProvider(uniques)
+    }
+    fun uniqueMapProvider(): UniqueMap {
+        return uniqueMapProvider(uniqueObjects)
+    }
+    fun uniqueObjectsProvider(uniques: List<String>): List<Unique> {
         if (uniques.isEmpty()) return emptyList()
         return uniques.map { Unique(it, getUniqueTarget(), name) }
     }
-    fun uniqueMapProvider(): UniqueMap {
+    fun uniqueMapProvider(uniqueObjects: List<Unique>): UniqueMap {
         val newUniqueMap = UniqueMap()
-        if (uniques.isNotEmpty())
+        if (uniqueObjects.isNotEmpty())
             newUniqueMap.addUniques(uniqueObjects)
         return newUniqueMap
     }

--- a/core/src/com/unciv/models/ruleset/unique/Unique.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Unique.kt
@@ -266,7 +266,7 @@ open class UniqueMap() {
         addUniques(uniques.asIterable())
     }
 
-    fun isEmpty(): Boolean = innerUniqueMap.isEmpty()
+    fun isEmpty(): Boolean get() = innerUniqueMap.isEmpty()
 
     /** Adds one [unique] unless it has a ConditionalTimedUnique conditional */
     open fun addUnique(unique: Unique) {

--- a/core/src/com/unciv/models/ruleset/unique/Unique.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Unique.kt
@@ -266,6 +266,8 @@ open class UniqueMap() {
         addUniques(uniques.asIterable())
     }
 
+    fun isEmpty(): Boolean = innerUniqueMap.isEmpty()
+
     /** Adds one [unique] unless it has a ConditionalTimedUnique conditional */
     open fun addUnique(unique: Unique) {
         val existingArrayList = innerUniqueMap[unique.placeholderText]

--- a/core/src/com/unciv/models/ruleset/unique/Unique.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Unique.kt
@@ -266,7 +266,7 @@ open class UniqueMap() {
         addUniques(uniques.asIterable())
     }
 
-    fun isEmpty(): Boolean get() = innerUniqueMap.isEmpty()
+    fun isEmpty(): Boolean = innerUniqueMap.isEmpty()
 
     /** Adds one [unique] unless it has a ConditionalTimedUnique conditional */
     open fun addUnique(unique: Unique) {

--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -16,6 +16,7 @@ import com.unciv.models.ruleset.RulesetObject
 import com.unciv.models.ruleset.unique.Conditionals
 import com.unciv.models.ruleset.unique.StateForConditionals
 import com.unciv.models.ruleset.unique.Unique
+import com.unciv.models.ruleset.unique.UniqueMap
 import com.unciv.models.ruleset.unique.UniqueTarget
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.stats.Stat
@@ -70,6 +71,16 @@ class BaseUnit : RulesetObject(), INonPerpetualConstruction {
 
     lateinit var ruleset: Ruleset
 
+    @delegate:Transient
+    val rulesetUniqueObjects: List<Unique> by lazy {
+        val list = ArrayList(uniques)
+        list.addAll(ruleset.globalUniques.unitUniques)
+        list.addAll(type.uniques)
+        uniqueObjectsProvider(list)
+    }
+
+    @delegate:Transient
+    val rulesetUniqueMap: UniqueMap by lazy { uniqueMapProvider(rulesetUniqueObjects) } // Has global uniques by the unique objects already
 
     /** Generate short description as comma-separated string for Technology description "Units enabled" and GreatPersonPickerScreen */
     fun getShortDescription(uniqueExclusionFilter: Unique.() -> Boolean = {false}) = BaseUnitDescriptions.getShortDescription(this, uniqueExclusionFilter)
@@ -116,45 +127,33 @@ class BaseUnit : RulesetObject(), INonPerpetualConstruction {
         return unit
     }
 
-    
     override fun hasUnique(uniqueType: UniqueType, state: StateForConditionals?): Boolean {
-        return super<RulesetObject>.hasUnique(uniqueType, state) || ::ruleset.isInitialized && type.hasUnique(uniqueType, state)
+        val stateForConditionals = state ?: StateForConditionals.EmptyState
+        return if (::ruleset.isInitialized) rulesetUniqueMap.hasUnique(uniqueType, stateForConditionals)
+        else super<RulesetObject>.hasUnique(uniqueType, stateForConditionals)
     }
 
     override fun hasUnique(uniqueTag: String, state: StateForConditionals?): Boolean {
-        return super<RulesetObject>.hasUnique(uniqueTag, state) || ::ruleset.isInitialized && type.hasUnique(uniqueTag, state)
+        val stateForConditionals = state ?: StateForConditionals.EmptyState
+        return if (::ruleset.isInitialized) rulesetUniqueMap.hasUnique(uniqueTag, stateForConditionals)
+        else super<RulesetObject>.hasUnique(uniqueTag, stateForConditionals)
     }
 
     override fun hasTagUnique(tagUnique: String): Boolean {
-        return super<RulesetObject>.hasTagUnique(tagUnique) || ::ruleset.isInitialized && type.hasTagUnique(tagUnique) 
+        return if (::ruleset.isInitialized) rulesetUniqueMap.hasTagUnique(tagUnique)
+        else super<RulesetObject>.hasTagUnique(tagUnique)
     }
 
     /** Allows unique functions (getMatchingUniques, hasUnique) to "see" uniques from the UnitType */
     override fun getMatchingUniques(uniqueType: UniqueType, state: StateForConditionals): Sequence<Unique> {
-        val ourUniques = super<RulesetObject>.getMatchingUniques(uniqueType, state)
-        if (! ::ruleset.isInitialized) { // Not sure if this will ever actually happen, but better safe than sorry
-            return ourUniques
-        }
-        val typeUniques = type.getMatchingUniques(uniqueType, state)
-        // Memory optimization - very rarely do we actually get uniques from both sources,
-        //   and sequence addition is expensive relative to the rare case that we'll actually need it
-        if (ourUniques.none()) return typeUniques
-        if (typeUniques.none()) return ourUniques
-        return ourUniques + type.getMatchingUniques(uniqueType, state)
+        return if (::ruleset.isInitialized) rulesetUniqueMap.getMatchingUniques(uniqueType, state)
+        else super<RulesetObject>.getMatchingUniques(uniqueType, state)
     }
 
     /** Allows unique functions (getMatchingUniques, hasUnique) to "see" uniques from the UnitType */
     override fun getMatchingUniques(uniqueTag: String, state: StateForConditionals): Sequence<Unique> {
-        val ourUniques = super<RulesetObject>.getMatchingUniques(uniqueTag, state)
-        if (! ::ruleset.isInitialized) { // Not sure if this will ever actually happen, but better safe than sorry
-            return ourUniques
-        }
-        val typeUniques = type.getMatchingUniques(uniqueTag, state)
-        // Memory optimization - very rarely do we actually get uniques from both sources,
-        //   and sequence addition is expensive relative to the rare case that we'll actually need it
-        if (ourUniques.none()) return typeUniques
-        if (typeUniques.none()) return ourUniques
-        return ourUniques + type.getMatchingUniques(uniqueTag, state)
+        return if (::ruleset.isInitialized) rulesetUniqueMap.getMatchingUniques(uniqueTag, state)
+        else super<RulesetObject>.getMatchingUniques(uniqueTag, state)
     }
 
     override fun getProductionCost(civInfo: Civilization, city: City?): Int  = costFunctions.getProductionCost(civInfo, city)
@@ -519,7 +518,7 @@ class BaseUnit : RulesetObject(), INonPerpetualConstruction {
             power += 4000
 
         // Uniques
-        val allUniques = uniqueObjects.asSequence() +
+        val allUniques = rulesetUniqueObjects.asSequence() +
             promotions.asSequence()
                 .mapNotNull { ruleset.unitPromotions[it] }
                 .flatMap { it.uniqueObjects }

--- a/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
+++ b/core/src/com/unciv/models/ruleset/unit/BaseUnit.kt
@@ -70,17 +70,24 @@ class BaseUnit : RulesetObject(), INonPerpetualConstruction {
     val costFunctions = BaseUnitCost(this)
 
     lateinit var ruleset: Ruleset
+        private set
 
-    @delegate:Transient
-    val rulesetUniqueObjects: List<Unique> by lazy {
+    fun setRuleset(ruleset: Ruleset) {
+        this.ruleset = ruleset
         val list = ArrayList(uniques)
         list.addAll(ruleset.globalUniques.unitUniques)
         list.addAll(type.uniques)
-        uniqueObjectsProvider(list)
+        rulesetUniqueObjects = uniqueObjectsProvider(list)
+        rulesetUniqueMap = uniqueMapProvider(rulesetUniqueObjects) // Has global uniques by the unique objects already
     }
 
-    @delegate:Transient
-    val rulesetUniqueMap: UniqueMap by lazy { uniqueMapProvider(rulesetUniqueObjects) } // Has global uniques by the unique objects already
+    @Transient
+    var rulesetUniqueObjects: List<Unique> = ArrayList()
+        private set
+
+    @Transient
+    var rulesetUniqueMap: UniqueMap = UniqueMap()
+        private set
 
     /** Generate short description as comma-separated string for Technology description "Units enabled" and GreatPersonPickerScreen */
     fun getShortDescription(uniqueExclusionFilter: Unique.() -> Boolean = {false}) = BaseUnitDescriptions.getShortDescription(this, uniqueExclusionFilter)

--- a/core/src/com/unciv/models/ruleset/unit/UnitType.kt
+++ b/core/src/com/unciv/models/ruleset/unit/UnitType.kt
@@ -2,8 +2,6 @@ package com.unciv.models.ruleset.unit
 
 import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.ruleset.RulesetObject
-import com.unciv.models.ruleset.unique.Unique
-import com.unciv.models.ruleset.unique.UniqueMap
 import com.unciv.models.ruleset.unique.UniqueTarget
 import com.unciv.ui.objectdescriptions.BaseUnitDescriptions.getUnitTypeCivilopediaTextLines
 
@@ -17,38 +15,6 @@ enum class UnitMovementType { // The types of tiles the unit can by default ente
 class UnitType() : RulesetObject() {
     private var movementType: String? = null
     private val unitMovementType: UnitMovementType? by lazy { if (movementType == null) null else UnitMovementType.valueOf(movementType!!) }
-    @Transient lateinit var ruleset: Ruleset
-
-    @delegate:Transient
-    private val iUniqueObjects: List<Unique> by lazy {
-        uniqueObjectsProvider(uniques + ruleset.globalUniques.unitUniques)
-    }
-
-    @delegate:Transient
-    private val iUniqueMap: UniqueMap by lazy { uniqueMapProvider(iUniqueObjects) } // Has global uniques by the unique objects already
-
-    @Transient
-    override var uniqueObjects: List<Unique> = emptyList()
-        get() {
-            if (::ruleset.isInitialized) return iUniqueObjects
-            else if (uniques.isEmpty()) return field
-            else if (field.isEmpty()) field = uniqueObjectsProvider()
-
-            return field
-        }
-        private set
-
-    @Transient
-    override var uniqueMap: UniqueMap = UniqueMap()
-        get() {
-            if (::ruleset.isInitialized) return iUniqueMap
-            else if (uniqueObjects.isEmpty()) return field
-            else if (field.isEmpty()) field = uniqueMapProvider()
-
-            return field
-        }
-        private set
-
     override fun getUniqueTarget() = UniqueTarget.UnitType
     override fun makeLink() = "UnitType/$name"
 

--- a/core/src/com/unciv/models/ruleset/unit/UnitType.kt
+++ b/core/src/com/unciv/models/ruleset/unit/UnitType.kt
@@ -2,6 +2,8 @@ package com.unciv.models.ruleset.unit
 
 import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.ruleset.RulesetObject
+import com.unciv.models.ruleset.unique.Unique
+import com.unciv.models.ruleset.unique.UniqueMap
 import com.unciv.models.ruleset.unique.UniqueTarget
 import com.unciv.ui.objectdescriptions.BaseUnitDescriptions.getUnitTypeCivilopediaTextLines
 
@@ -15,6 +17,37 @@ enum class UnitMovementType { // The types of tiles the unit can by default ente
 class UnitType() : RulesetObject() {
     private var movementType: String? = null
     private val unitMovementType: UnitMovementType? by lazy { if (movementType == null) null else UnitMovementType.valueOf(movementType!!) }
+    @Transient lateinit var ruleset: Ruleset
+
+    @delegate:Transient
+    private val iUniqueObjects: List<Unique> by lazy {
+        uniqueObjectsProvider(uniques + ruleset.globalUniques.unitUniques)
+    }
+
+    @delegate:Transient
+    private val iUniqueMap: UniqueMap by lazy { uniqueMapProvider(iUniqueObjects) } // Has global uniques by the unique objects already
+
+    @Transient
+    override var uniqueObjects: List<Unique> = emptyList()
+        get() {
+            if (::ruleset.isInitialized) return iUniqueObjects
+            else if (uniques.isEmpty()) return field
+            else if (field.isEmpty()) field = uniqueObjectsProvider()
+
+            return field
+        }
+        private set
+
+    @Transient
+    override var uniqueMap: UniqueMap = UniqueMap()
+        get() {
+            if (::ruleset.isInitialized) return iUniqueMap
+            else if (uniqueObjects.isEmpty()) return field
+            else if (uniqueMap.isEmpty()) field = uniqueMapProvider()
+
+            return field
+        }
+        private set
 
     override fun getUniqueTarget() = UniqueTarget.UnitType
     override fun makeLink() = "UnitType/$name"

--- a/core/src/com/unciv/models/ruleset/unit/UnitType.kt
+++ b/core/src/com/unciv/models/ruleset/unit/UnitType.kt
@@ -43,7 +43,7 @@ class UnitType() : RulesetObject() {
         get() {
             if (::ruleset.isInitialized) return iUniqueMap
             else if (uniqueObjects.isEmpty()) return field
-            else if (uniqueMap.isEmpty()) field = uniqueMapProvider()
+            else if (field.isEmpty()) field = uniqueMapProvider()
 
             return field
         }

--- a/docs/Modders/Mod-file-structure/5-Miscellaneous-JSON-files.md
+++ b/docs/Modders/Mod-file-structure/5-Miscellaneous-JSON-files.md
@@ -292,7 +292,15 @@ With `civModifier` being the multiplicative aggregate of ["\[relativeAmount\]% G
 [link to original](https://github.com/yairm210/Unciv/tree/master/android/assets/jsons/GlobalUniques.json)
 
 GlobalUniques defines uniques that apply globally. e.g. Vanilla rulesets define the effects of Unhappiness here.
-Only the `uniques` field is used, but a name must still be set (the Ruleset validator might display it).
+
+It has the following structure:
+
+| Attribute   | Type            | Default         | Notes                                                                                       |
+|-------------|-----------------|-----------------|---------------------------------------------------------------------------------------------|
+| name        | String          | "GlobalUniques" | The name field is not used, but still must be set (the Ruleset validator might display it). |
+| uniques     | List of Strings | empty           | List of [unique abilities](../../uniques) that apply globally                               |
+| unitUniques | List of Strings | empty           | List of [unique abilities](../../uniques) that applies to each unit                         |
+
 When extension rulesets define GlobalUniques, all uniques are merged. At the moment there is no way to change/remove uniques set by a base mod.
 
 ## Tutorials.json

--- a/tests/src/com/unciv/logic/map/UnitMovementTests.kt
+++ b/tests/src/com/unciv/logic/map/UnitMovementTests.kt
@@ -11,7 +11,6 @@ import com.unciv.logic.civilization.diplomacy.DiplomaticStatus
 import com.unciv.logic.map.mapunit.MapUnit
 import com.unciv.logic.map.tile.Tile
 import com.unciv.models.ruleset.nation.Nation
-import com.unciv.models.ruleset.unique.StateForConditionals
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.ruleset.unit.BaseUnit
 import com.unciv.models.ruleset.unit.UnitType
@@ -54,7 +53,7 @@ class UnitMovementTests {
     fun addFakeUnit(unitType: UnitType, uniques: List<String> = listOf()): MapUnit {
         val baseUnit = BaseUnit()
         baseUnit.unitType = unitType.name
-        baseUnit.ruleset = testGame.ruleset
+        baseUnit.setRuleset(testGame.ruleset)
         baseUnit.uniques.addAll(uniques)
 
         val unit = MapUnit()

--- a/tests/src/com/unciv/logic/map/UnitMovementTests.kt
+++ b/tests/src/com/unciv/logic/map/UnitMovementTests.kt
@@ -53,8 +53,8 @@ class UnitMovementTests {
     fun addFakeUnit(unitType: UnitType, uniques: List<String> = listOf()): MapUnit {
         val baseUnit = BaseUnit()
         baseUnit.unitType = unitType.name
-        baseUnit.setRuleset(testGame.ruleset)
         baseUnit.uniques.addAll(uniques)
+        baseUnit.setRuleset(testGame.ruleset)
 
         val unit = MapUnit()
         unit.name = baseUnit.name

--- a/tests/src/com/unciv/testing/TestGame.kt
+++ b/tests/src/com/unciv/testing/TestGame.kt
@@ -64,7 +64,7 @@ class TestGame {
         tileMap.gameInfo = gameInfo
 
         for (baseUnit in ruleset.units.values)
-            baseUnit.ruleset = ruleset
+            baseUnit.setRuleset(ruleset)
     }
 
     /** Makes a new rectangular tileMap and sets it in gameInfo. Removes all existing tiles. All new tiles have terrain [baseTerrain] */
@@ -183,7 +183,7 @@ class TestGame {
 
     fun addUnit(name: String, civInfo: Civilization, tile: Tile?): MapUnit {
         val baseUnit = ruleset.units[name]!!
-        baseUnit.ruleset = ruleset
+        baseUnit.setRuleset(ruleset)
         val mapUnit = baseUnit.getMapUnit(civInfo)
         civInfo.units.addUnit(mapUnit)
         if (tile!=null) {
@@ -238,7 +238,7 @@ class TestGame {
     fun createBaseUnit(unitType: String = createUnitType().name, vararg uniques: String) =
         createRulesetObject(ruleset.units, *uniques) {
             val baseUnit = BaseUnit()
-            baseUnit.ruleset = gameInfo.ruleset
+            baseUnit.setRuleset(gameInfo.ruleset)
             baseUnit.unitType = unitType
             baseUnit
         }
@@ -259,11 +259,7 @@ class TestGame {
     fun createTileImprovement(vararg uniques: String) =
         createRulesetObject(ruleset.tileImprovements, *uniques) { TileImprovement() }
     fun createUnitType(vararg uniques: String) =
-        createRulesetObject(ruleset.unitTypes, *uniques) {
-            val unitType = UnitType()
-            unitType.ruleset = ruleset
-            unitType
-        }
+        createRulesetObject(ruleset.unitTypes, *uniques) { UnitType() }
     fun createUnitPromotion(vararg uniques: String) =
         createRulesetObject(ruleset.unitPromotions, *uniques) { Promotion() }
 }

--- a/tests/src/com/unciv/testing/TestGame.kt
+++ b/tests/src/com/unciv/testing/TestGame.kt
@@ -259,7 +259,11 @@ class TestGame {
     fun createTileImprovement(vararg uniques: String) =
         createRulesetObject(ruleset.tileImprovements, *uniques) { TileImprovement() }
     fun createUnitType(vararg uniques: String) =
-        createRulesetObject(ruleset.unitTypes, *uniques) { UnitType() }
+        createRulesetObject(ruleset.unitTypes, *uniques) {
+            val unitType = UnitType()
+            unitType.ruleset = ruleset
+            unitType
+        }
     fun createUnitPromotion(vararg uniques: String) =
         createRulesetObject(ruleset.unitPromotions, *uniques) { Promotion() }
 }

--- a/tests/src/com/unciv/testing/TestGame.kt
+++ b/tests/src/com/unciv/testing/TestGame.kt
@@ -238,8 +238,8 @@ class TestGame {
     fun createBaseUnit(unitType: String = createUnitType().name, vararg uniques: String) =
         createRulesetObject(ruleset.units, *uniques) {
             val baseUnit = BaseUnit()
-            baseUnit.setRuleset(gameInfo.ruleset)
             baseUnit.unitType = unitType
+            baseUnit.setRuleset(gameInfo.ruleset)
             baseUnit
         }
     fun createBelief(type: BeliefType = BeliefType.Any, vararg uniques: String) =


### PR DESCRIPTION
Sorry for the delay on this one. Been real busy

Replaces #12690. Rather than doing things as a special unit type, this creates a separate unique list for global unit uniques and dumps them directly into the uniques for each unit type. I'm not sure if this is the correct approach (rather than dumping the uniques into the unit itself)

Also adds in a number of helper functions needed to make these sorts of things easier to work with

Keep in mind, this code does not go through validation as of the writing of this PR description. Not sure if that should be in this PR or a sort of next PR