### PR TITLE
Settling Suggestion Improvements

### DIFF
--- a/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
+++ b/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
@@ -1,6 +1,5 @@
 package com.unciv.logic.automation.unit
 
-import com.unciv.Constants
 import com.unciv.logic.automation.Automation
 import com.unciv.logic.city.City
 import com.unciv.logic.civilization.Civilization

--- a/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
+++ b/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
@@ -26,16 +26,10 @@ object CityLocationTileRanker {
      */
     fun getBestTilesToFoundCity(unit: MapUnit, distanceToSearch: Int? = null, minimumValue: Float): BestTilesToFoundCity {
         val distanceModifier = 2.7f // percentage penalty per aerial distance
-        val range =  if (distanceToSearch != null) distanceToSearch else {
-            if (unit.civ.isHuman()) {
-                val distanceFromHome = if (unit.civ.cities.isEmpty()) 0
-                else unit.civ.cities.minOf { it.getCenterTile().aerialDistanceTo(unit.getTile()) }
-                (9 - distanceFromHome).coerceIn(2, 5)
-            } else {
-                val distanceFromHome = if (unit.civ.cities.isEmpty()) 0
-                else unit.civ.cities.minOf { it.getCenterTile().aerialDistanceTo(unit.getTile()) }
-                (8 - distanceFromHome).coerceIn(1, 5) // Restrict vision when far from home to avoid death marches
-            }
+        val range = if (distanceToSearch != null) distanceToSearch else {
+            val distanceFromHome = if (unit.civ.cities.isEmpty()) 0
+            else unit.civ.cities.minOf { it.getCenterTile().aerialDistanceTo(unit.getTile()) }
+            (8 - distanceFromHome).coerceIn(1, 5) // Restrict vision when far from home to avoid death marches
         }
         val nearbyCities = unit.civ.gameInfo.getCities()
             .filter { it.getCenterTile().aerialDistanceTo(unit.getTile()) <= 7 + range }

--- a/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
+++ b/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
@@ -172,19 +172,13 @@ object CityLocationTileRanker {
         // Check if there are any new unique luxury resources
         if (civ.isHuman()) {
             if (rankTile.hasViewableResource(civ) && rankTile.tileResource.resourceType == ResourceType.Luxury
-                && !(civ.hasResource(rankTile.resource!!) || newUniqueLuxuryResources.contains(
-                    rankTile.resource
-                ))
-            ) {
+                && !(civ.hasResource(rankTile.resource!!) || newUniqueLuxuryResources.contains(rankTile.resource))) {
                 locationSpecificTileValue += 10
                 newUniqueLuxuryResources.add(rankTile.resource!!)
             }
         } else {
             if (rankTile.resource != null && rankTile.tileResource.resourceType == ResourceType.Luxury
-                && !(civ.hasResource(rankTile.resource!!) || newUniqueLuxuryResources.contains(
-                    rankTile.resource
-                ))
-            ) {
+                && !(civ.hasResource(rankTile.resource!!) || newUniqueLuxuryResources.contains(rankTile.resource))) {
                 locationSpecificTileValue += 10
                 newUniqueLuxuryResources.add(rankTile.resource!!)
             }

--- a/core/src/com/unciv/ui/screens/worldscreen/worldmap/WorldMapTileUpdater.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/worldmap/WorldMapTileUpdater.kt
@@ -230,7 +230,7 @@ object WorldMapTileUpdater {
         // Highlight best tiles for city founding
         if (unit.hasUnique(UniqueType.FoundCity)
             && UncivGame.Current.settings.showSettlersSuggestedCityLocations) {
-            CityLocationTileRanker.getBestTilesToFoundCity(unit, minimumValue = 50f).tileRankMap.asSequence()
+            CityLocationTileRanker.getBestTilesToFoundCity(unit, 5, minimumValue = 70f).tileRankMap.asSequence()
                 .filter { it.key.isExplored(unit.civ) }.sortedByDescending { it.value }.take(3).forEach {
                     tileGroups[it.key]!!.layerOverlay.showGoodCityLocationIndicator()
                 }


### PR DESCRIPTION
Bring up floor for Settle Suggestions, and increase radius to a fixed 5 tiles
Add distance from Settler penalty to help keep suggestions closer
Human Suggestions do not take into account unseen resources