### PR TITLE
Tweaks for Screen Size small-portrait

### DIFF
--- a/core/src/com/unciv/ui/components/extensions/Scene2dExtensions.kt
+++ b/core/src/com/unciv/ui/components/extensions/Scene2dExtensions.kt
@@ -293,6 +293,28 @@ fun getCloseButton(
     return closeButton
 }
 
+/**
+ * Adds a white-circled (x) close button to [parent], positioned to the top right,
+ * slightly shifted outwards.
+ */
+fun addRoundCloseButton(
+    parent: Group? = null,
+    size: Float = 30f,
+    iconSize: Float = size - 15f,
+    circleColor: Color = Color.CLEAR,
+    overColor: Color = Color.RED,
+    action: () -> Unit
+): Group {
+    val button = getCloseButton(size, iconSize, circleColor, overColor, action)
+        .surroundWithCircle(size, false, BaseScreen.clearColor)
+        .surroundWithCircle(size+4f, false, Color.WHITE)
+    if (parent != null) {
+        parent.addActor(button)
+        button.setPosition(parent.width - button.width*3/4, parent.height - button.height*3/4)
+    }
+    return button
+}
+
 /** Translate a [String] and make a [Label] widget from it */
 fun String.toLabel() = Label(this.tr(), BaseScreen.skin)
 /** Make a [Label] widget containing this [Int] as text */

--- a/core/src/com/unciv/ui/components/extensions/Scene2dExtensions.kt
+++ b/core/src/com/unciv/ui/components/extensions/Scene2dExtensions.kt
@@ -298,20 +298,15 @@ fun getCloseButton(
  * slightly shifted outwards.
  */
 fun addRoundCloseButton(
-    parent: Group? = null,
-    size: Float = 30f,
-    iconSize: Float = size - 15f,
-    circleColor: Color = Color.CLEAR,
-    overColor: Color = Color.RED,
+    parent: Group,
     action: () -> Unit
 ): Group {
-    val button = getCloseButton(size, iconSize, circleColor, overColor, action)
+    val size = 30f
+    val button = getCloseButton(size, size-15f, Color.CLEAR, Color.RED, action = action)
         .surroundWithCircle(size, false, BaseScreen.clearColor)
         .surroundWithCircle(size+4f, false, Color.WHITE)
-    if (parent != null) {
-        parent.addActor(button)
-        button.setPosition(parent.width - button.width*3/4, parent.height - button.height*3/4)
-    }
+    parent.addActor(button)
+    button.setPosition(parent.width - button.width*3/4, parent.height - button.height*3/4)
     return button
 }
 

--- a/core/src/com/unciv/ui/screens/cityscreen/CityScreen.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/CityScreen.kt
@@ -156,9 +156,9 @@ class CityScreen(
 
         addTiles()
 
-        stage.addActor(cityStatsTable)
         // If we are spying then we shoulden't be able to see their construction screen.
         constructionsTable.addActorsToStage()
+        stage.addActor(cityStatsTable)
         stage.addActor(selectedConstructionTable)
         stage.addActor(tileTable)
         stage.addActor(cityPickerTable)  // add late so it's top in Z-order and doesn't get covered in cramped portrait
@@ -200,7 +200,7 @@ class CityScreen(
 
         // In portrait mode only: calculate already occupied horizontal space
         val rightMargin = when {
-            !isPortrait() -> 0f
+            !isPortrait() || isCrampedPortrait() -> 0f
             selectedTile != null -> tileTable.packIfNeeded().width
             selectedConstruction != null -> selectedConstructionTable.packIfNeeded().width
             else -> posFromEdge

--- a/core/src/com/unciv/ui/screens/cityscreen/CityScreenCityPickerTable.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/CityScreenCityPickerTable.kt
@@ -78,7 +78,8 @@ class CityScreenCityPickerTable(private val cityScreen: CityScreen) : Table() {
             cityNameTable.add(UnitIconGroup(garrison, 30f)).padLeft(5f)
         }
 
-        add(cityNameTable).width(stage.width / 4)
+        val width = if (cityScreen.isCrampedPortrait()) stage.width / 3 else stage.width / 4
+        add(cityNameTable).width(width)
 
         if (cityScreen.viewableCities.size > 1) {
             val nextCityButton = Table() // so we gt a wider clickable area than just the image itself

--- a/core/src/com/unciv/ui/screens/cityscreen/CityStatsTable.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/CityStatsTable.kt
@@ -104,13 +104,12 @@ class CityStatsTable(private val cityScreen: CityScreen) : Table() {
             miniStatsTable.add(icon).size(27f).padRight(3f)
             val valueToDisplay = if (stat == Stat.Happiness) city.cityStats.happinessList.values.sum() else amount
             miniStatsTable.add(round(valueToDisplay).toInt().toLabel()).padRight(5f)
-            if (cityScreen.isCrampedPortrait() && stat == Stat.Gold) {
+            if (cityScreen.isCrampedPortrait() && !isOpen && stat == Stat.Gold) {
                 miniStatsTable.row()
             }
         }
         upperTable.add(miniStatsTable).expandX()
-        upperTable.addSeparator()
-        
+
         lowerTable.add(detailedStatsButton).row()
         addText()
 
@@ -128,10 +127,7 @@ class CityStatsTable(private val cityScreen: CityScreen) : Table() {
         headerIcon.rotation = if(isOpen) 90f else 0f
         
         innerTable.clear()
-        val upperCell = innerTable.add(upperTable).expandX()
-        if (cityScreen.isCrampedPortrait()) {
-            upperCell.right()
-        }
+        innerTable.add(upperTable).expandX()
         innerTable.add(headerIconClickArea).row()
         val lowerCell = if (isOpen) {
             innerTable.add(lowerPane).colspan(2)

--- a/core/src/com/unciv/ui/screens/cityscreen/ConstructionInfoTable.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/ConstructionInfoTable.kt
@@ -76,7 +76,7 @@ class ConstructionInfoTable(val cityScreen: CityScreen) : Table() {
             buildingText += specialConstruction?.getProductionTooltip(city)
                     ?: cityConstructions.getTurnsToConstructionString(construction)
 
-            add(Label(buildingText, BaseScreen.skin)).row()  // already translated
+            add(Label(buildingText, BaseScreen.skin)).expandX().row()  // already translated
 
             val description = when (construction) {
                 is BaseUnit -> construction.getDescription(city)
@@ -88,7 +88,7 @@ class ConstructionInfoTable(val cityScreen: CityScreen) : Table() {
 
             val descriptionLabel = Label(description, BaseScreen.skin)  // already translated
             descriptionLabel.wrap = true
-            add(descriptionLabel).colspan(2).width(stage.width / 4)
+            add(descriptionLabel).colspan(2).width(stage.width / if(cityScreen.isCrampedPortrait()) 3 else 4)
 
             if (cityConstructions.isBuilt(construction.name)) {
                 showSellButton(construction)

--- a/core/src/com/unciv/ui/screens/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/WorldScreen.kt
@@ -161,12 +161,11 @@ class WorldScreen(
         zoomController.isVisible = UncivGame.Current.settings.showZoomButtons
 
         stage.addActor(bottomUnitTable)
+        stage.addActor(unitActionsTable)
         stage.addActor(bottomTileInfoTable)
         battleTable.width = stage.width / 3
         battleTable.x = stage.width / 3
         stage.addActor(battleTable)
-
-        stage.addActor(unitActionsTable)
 
         val tileToCenterOn: Vector2 =
                 when {

--- a/core/src/com/unciv/ui/screens/worldscreen/bottombar/BattleTable.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/bottombar/BattleTable.kt
@@ -83,7 +83,12 @@ class BattleTable(val worldScreen: WorldScreen) : Table() {
 
         isVisible = true
         pack()
-        addBorderAllowOpacity(1f, Color.WHITE)
+
+        addBorderAllowOpacity(2f, Color.WHITE)
+        addRoundCloseButton(this) {
+            isVisible = false
+        }
+
     }
 
     private fun tryGetAttacker(): ICombatant? {

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/IdleUnitButton.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/IdleUnitButton.kt
@@ -43,7 +43,6 @@ class IdleUnitButton (
                 unitToSelect = idleUnits.elementAt(index)
             }
 
-            unitToSelect.due = false
             tileMapHolder.setCenterPosition(unitToSelect.currentTile.position)
             unitTable.selectUnit(unitToSelect)
             unitTable.worldScreen.shouldUpdate = true

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/UnitTable.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/UnitTable.kt
@@ -93,13 +93,12 @@ class UnitTable(val worldScreen: WorldScreen) : Table() {
 
         promotionsTable.touchable = Touchable.enabled
 
-        deselectUnitButton = getCloseButton(30f, 15f, Color.CLEAR, Color.RED) {
+        deselectUnitButton = addRoundCloseButton(this) {
             selectUnit()
             worldScreen.shouldUpdate = true
             this@UnitTable.isVisible = false
-        }.surroundWithCircle(30f, resizeActor = false, color = BaseScreen.clearColor).surroundWithThinCircle(Color.WHITE)
+        }
         deselectUnitButton.keyShortcuts.clear() // This is the only place we don't want the BACK keyshortcut getCloseButton assigns
-        addActor(deselectUnitButton)
 
         add(Table().apply {
             val moveBetweenUnitsTable = Table().apply {


### PR DESCRIPTION
- add close button (x) to battle table (fixes [#12745](https://github.com/yairm210/Unciv/issues/12745))
- fixed drawing order of battle table and city stats
- unit info table arrow buttons won't set due=false [#12745](https://github.com/yairm210/Unciv/issues/12745) [#12308](https://github.com/yairm210/Unciv/issues/12308) 
- a few smaller UI tweaks for small-portrait