### PR TITLE
Update ruins notification to show exact amount of culture

### DIFF
--- a/android/assets/jsons/Civ V - Gods & Kings/Ruins.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Ruins.json
@@ -1,7 +1,7 @@
 [
     {
         "name": "discover cultural artifacts",
-        "notification": "We have discovered cultural artifacts in the ruins! (+20 culture)",
+        "notification": "We have discovered cultural artifacts in the ruins! (+[cultureAmount] culture)",
         "uniques": ["Gain [20] [Culture] <(modified by game speed)>"],
         "color": "#cf8ff7"
     },

--- a/android/assets/jsons/Civ V - Vanilla/Ruins.json
+++ b/android/assets/jsons/Civ V - Vanilla/Ruins.json
@@ -1,7 +1,7 @@
 [
     {
         "name": "discover cultural artifacts",
-        "notification": "We have discovered cultural artifacts in the ruins! (+20 culture)",
+        "notification": "We have discovered cultural artifacts in the ruins! (+[cultureAmount] culture)",
         "uniques": ["Gain [20] [Culture] <(modified by game speed)>"],
         "color": "#cf8ff7"
     },


### PR DESCRIPTION
Now that the ruins reward granting culture adjusts to game speed, it no longer necessarily grants 20 culture. This PR changes the notification to reflect this fact.