### PR TITLE
Fortify until Healed removes Fortify at Turn Start

### DIFF
--- a/core/src/com/unciv/logic/map/mapunit/UnitTurnManager.kt
+++ b/core/src/com/unciv/logic/map/mapunit/UnitTurnManager.kt
@@ -35,11 +35,6 @@ class UnitTurnManager(val unit: MapUnit) {
         if (!unit.hasUnitMovedThisTurn() || unit.hasUnique(UniqueType.HealsEvenAfterAction))
             healUnit()
 
-        if (unit.action != null && unit.health > 99)
-            if (unit.isActionUntilHealed()) {
-                unit.action = null // wake up when healed
-            }
-
         if (unit.isPreparingParadrop() || unit.isPreparingAirSweep())
             unit.action = null
 
@@ -156,6 +151,11 @@ class UnitTurnManager(val unit: MapUnit) {
                     it.militaryUnit != null && it in unit.civ.viewableTiles && it.militaryUnit!!.civ.isAtWarWith(unit.civ)
                 }
         )  unit.action = null
+
+        if (unit.action != null && unit.health > 99)
+            if (unit.isActionUntilHealed()) {
+                unit.action = null // wake up when healed
+            }
 
         val tileOwner = unit.getTile().getOwner()
         if (tileOwner != null


### PR DESCRIPTION
Fix so that while Fortify Until Healed is active, the Fortify will persist until your own turn start.
Current behavior checks and removes the Fortify status at turn end, leaving your unit exposed during enemy turns until you can Fortify on your turn again.

Germany Turn, Fortify Until Healed on Spearman
![image](https://github.com/user-attachments/assets/2b71aa90-768c-4e0a-84a0-e1e005c2713c)
Denmark Turn, Spearman is fully Healed and still Fortify status
![image](https://github.com/user-attachments/assets/b8399336-bbdd-4661-aabc-7173f1550f5b)
Germany Turn, Spearman wakes and can Re-Fortify. Denmark Spear similarly has Healed and is still Fortified
![image](https://github.com/user-attachments/assets/b1fa0c70-3203-4ee4-aadc-d87cce6a62f1)
