### PR TITLE
Update AI spending gold on city states

### DIFF
--- a/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
@@ -182,11 +182,12 @@ object NextTurnAutomation {
         if (civInfo.wantsToFocusOn(Victory.Focus.CityStates)) {
             value += 5  // Generally be friendly
         }
-        if (civInfo.getHappiness() < 5 && cityState.cityStateFunctions.canProvideStat(Stat.Happiness)) {
-            value += 10 - civInfo.getHappiness()
+        if (cityState.cityStateFunctions.canProvideStat(Stat.Happiness)) {
+            if (civInfo.getHappiness() < 10)
+                value += 10 - civInfo.getHappiness()
             value += civPersonality[PersonalityValue.Happiness].toInt() - 5
         }
-        if (civInfo.getHappiness() > 5 && cityState.cityStateFunctions.canProvideStat(Stat.Food)) {
+        if (cityState.cityStateFunctions.canProvideStat(Stat.Food)) {
             value += 5
             value += civPersonality[PersonalityValue.Food].toInt() - 5
         }
@@ -198,7 +199,7 @@ object NextTurnAutomation {
         val ourInfluence = if (civInfo.knows(cityState))
             cityState.getDiplomacyManager(civInfo)!!.getInfluence().toInt()
         else 0
-        value += ourInfluence / 10
+        value += minOf(10, ourInfluence / 10) // don't let this spiral out of control
 
         if (ourInfluence < 30) {
             // Consider bullying for cash

--- a/core/src/com/unciv/logic/automation/civilization/UseGoldAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/UseGoldAutomation.kt
@@ -6,7 +6,6 @@ import com.unciv.logic.civilization.Civilization
 import com.unciv.logic.map.BFS
 import com.unciv.logic.map.tile.Tile
 import com.unciv.models.ruleset.INonPerpetualConstruction
-import com.unciv.models.ruleset.Victory
 import com.unciv.models.ruleset.tile.ResourceType
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.stats.Stat
@@ -50,17 +49,7 @@ object UseGoldAutomation {
             }
         }
 
-        if (civ.gold < 250) return  // skip checks if tryGainInfluence will bail anyway
-        if (civ.wantsToFocusOn(Victory.Focus.Culture)) {
-            for (cityState in knownCityStates.filter { it.cityStateFunctions.canProvideStat(Stat.Culture) }) {
-                val diploManager = cityState.getDiplomacyManager(civ)!!
-                if (diploManager.getInfluence() < 40) { // we want to gain influence with them
-                    tryGainInfluence(civ, cityState)
-                }
-            }
-        }
-
-        if (civ.gold < 250 || knownCityStates.none()) return
+        if (civ.gold < 500 || knownCityStates.none()) return // skip checks if tryGainInfluence will bail anyway
         val cityState = knownCityStates
             .filter { it.getAllyCiv() != civ.civName }
             .associateWith { NextTurnAutomation.valueCityStateAlliance(civ, it, true) }
@@ -166,15 +155,15 @@ object UseGoldAutomation {
     }
 
     private fun tryGainInfluence(civInfo: Civilization, cityState: Civilization) {
-        if (civInfo.gold < 250) return // Save up
-        if (cityState.getDiplomacyManager(civInfo)!!.getInfluence() >= 20
-            && civInfo.gold < 500) {
-            // Only make a small investment if we have a bit of influence already to build off of so we don't waste our money
-            cityState.cityStateFunctions.receiveGoldGift(civInfo, 250)
-            return
-        }
-        if (civInfo.gold < 500) return // It's not worth it to invest now, wait until you have enough for 2
-        cityState.cityStateFunctions.receiveGoldGift(civInfo, 500)
+        if (civInfo.gold < 500) return // Save up, giving 500 gold in one go typically grants +5 influence compared to giving 2×250 gold
+        val influence = cityState.getDiplomacyManager(civInfo)!!.getInfluence()
+        val stopSpending =  influence > 60 + 2 * NextTurnAutomation.valueCityStateAlliance(civInfo, cityState, true)
+        // Don't go into a gold gift race: be content with friendship for cheap, or use the gold on more productive uses,
+        // for example upgrading an army to conquer the player who's contesting our city states
+        if (influence < 10 || stopSpending) return
+        // Only make an investment if we got our Pledge to Protect influence at the highest level
+        if (civInfo.gold >= 1000) cityState.cityStateFunctions.receiveGoldGift(civInfo, 1000)
+        else cityState.cityStateFunctions.receiveGoldGift(civInfo, 500)
         return
     }
 


### PR DESCRIPTION
* Lines 53-61 consider the case of cultural CS giving gold to cultural CS, but lines 63-71 already looks at all the civ/CS pairs (with priority given to cultural city states in the case of cultural civs) so I decided to remove it.
* Spend amounts of either 1000 gold or 500 gold, instead of 250 gold, as per https://discord.com/channels/586194543280390151/618491418859798539/1327905664521080873
* Stop giving gold when above approximately 120 influence, to prevent gold-spending death spiral, as reported by https://discord.com/channels/586194543280390151/588357826758574106/1327390654841487445
* Include Happiness personality trait into evaluation of happiness CS also when happy
* Consider evaluation of food CS independently of happiness (it's base food yields, so it allows you to assign a higher proportion of citizens to mines/specialists when unhappy)

I did a test game, and it appears most of the city states quickly gain an ally, while influence indeed doesn't go to super high levels, as predicted. 

A couple of notes:
* The influence levels are staying rather close to 120 points. So close infact, it looks like the AI is terrible at completing quests. This is going to need more work
* All the city states are staying alive, which is odd. In my games against competitive players, they tend to slowly dissapear from the map.