### PR TITLE
Add hotkey for Idle Unit cycle buttons

### DIFF
--- a/core/src/com/unciv/ui/components/input/KeyboardBinding.kt
+++ b/core/src/com/unciv/ui/components/input/KeyboardBinding.kt
@@ -48,6 +48,8 @@ enum class KeyboardBinding(
     EmpireOverview(Category.WorldScreen),
     MusicPlayer(Category.WorldScreen, KeyCharAndCode.ctrl('m')),
     DeveloperConsole(Category.WorldScreen, '`'),
+    PrevIdleButton(Category.WorldScreen, ','),
+    NextIdleButton(Category.WorldScreen, '/'),
 
     /*
      * These try to be faithful to default Civ5 key bindings as found in several places online

--- a/core/src/com/unciv/ui/components/input/KeyboardBinding.kt
+++ b/core/src/com/unciv/ui/components/input/KeyboardBinding.kt
@@ -48,8 +48,8 @@ enum class KeyboardBinding(
     EmpireOverview(Category.WorldScreen),
     MusicPlayer(Category.WorldScreen, KeyCharAndCode.ctrl('m')),
     DeveloperConsole(Category.WorldScreen, '`'),
-    PrevIdleButton(Category.WorldScreen, ','),
-    NextIdleButton(Category.WorldScreen, '/'),
+    PrevIdleButton(Category.WorldScreen, "Idle Prev",','),
+    NextIdleButton(Category.WorldScreen, "Idle Next", '.'),
 
     /*
      * These try to be faithful to default Civ5 key bindings as found in several places online
@@ -106,7 +106,7 @@ enum class KeyboardBinding(
     Automate(Category.UnitActions, 'm'),
     ConnectRoad(Category.UnitActions, "Connect road", 'c'),
     StopAutomation(Category.UnitActions,"Stop automation", 'm'),
-    StopMovement(Category.UnitActions,"Stop movement", '.'),
+    StopMovement(Category.UnitActions,"Stop movement", 'm'),
     ShowUnitDestination(Category.UnitActions, "Show unit destination", 'j'),
     Sleep(Category.UnitActions, 'f'),
     SleepUntilHealed(Category.UnitActions,"Sleep until healed", 'h'),

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/IdleUnitButton.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/IdleUnitButton.kt
@@ -5,6 +5,7 @@ import com.badlogic.gdx.scenes.scene2d.Touchable
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.utils.Align
 import com.unciv.logic.map.mapunit.MapUnit
+import com.unciv.ui.components.UncivTooltip.Companion.addTooltip
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.screens.worldscreen.worldmap.WorldMapHolder
 import com.unciv.ui.components.input.onClick
@@ -32,6 +33,7 @@ class IdleUnitButton (
         add(image).size(imageSize).pad(10f,20f)
         enable()
         keyShortcuts.add(keyShortcutBind)
+        addTooltip(keyShortcutBind)
         onActivation {
 
             val idleUnits = unitTable.worldScreen.viewingCiv.units.getIdleUnits()

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/IdleUnitButton.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/IdleUnitButton.kt
@@ -9,11 +9,15 @@ import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.screens.worldscreen.worldmap.WorldMapHolder
 import com.unciv.ui.components.input.onClick
 import com.unciv.ui.components.extensions.pad
+import com.unciv.ui.components.input.KeyboardBinding
+import com.unciv.ui.components.input.keyShortcuts
+import com.unciv.ui.components.input.onActivation
 
 class IdleUnitButton (
     internal val unitTable: UnitTable,
     private val tileMapHolder: WorldMapHolder,
-    val previous: Boolean
+    val previous: Boolean,
+    private val keyShortcutBind: KeyboardBinding
 ) : Table() {
 
     val image = ImageGetter.getImage("OtherIcons/BackArrow")
@@ -27,10 +31,11 @@ class IdleUnitButton (
         }
         add(image).size(imageSize).pad(10f,20f)
         enable()
-        onClick {
+        keyShortcuts.add(keyShortcutBind)
+        onActivation {
 
             val idleUnits = unitTable.worldScreen.viewingCiv.units.getIdleUnits()
-            if (idleUnits.none()) return@onClick
+            if (idleUnits.none()) return@onActivation
 
             val unitToSelect: MapUnit
             if (unitTable.selectedUnit == null || !idleUnits.contains(unitTable.selectedUnit!!))

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/UnitTable.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/UnitTable.kt
@@ -15,6 +15,7 @@ import com.unciv.models.Spy
 import com.unciv.models.translations.tr
 import com.unciv.ui.components.extensions.*
 import com.unciv.ui.components.fonts.Fonts
+import com.unciv.ui.components.input.KeyboardBinding
 import com.unciv.ui.components.input.keyShortcuts
 import com.unciv.ui.components.input.onClick
 import com.unciv.ui.components.widgets.UnitIconGroup
@@ -27,8 +28,8 @@ import com.unciv.ui.screens.pickerscreens.UnitRenamePopup
 import com.unciv.ui.screens.worldscreen.WorldScreen
 
 class UnitTable(val worldScreen: WorldScreen) : Table() {
-    private val prevIdleUnitButton = IdleUnitButton(this,worldScreen.mapHolder,true)
-    private val nextIdleUnitButton = IdleUnitButton(this,worldScreen.mapHolder,false)
+    private val prevIdleUnitButton = IdleUnitButton(this,worldScreen.mapHolder,true, KeyboardBinding.PrevIdleButton)
+    private val nextIdleUnitButton = IdleUnitButton(this,worldScreen.mapHolder,false, KeyboardBinding.NextIdleButton)
     private val unitIconHolder = Table()
     private val unitNameLabel = "".toLabel(fontSize = 24)
     private val unitIconNameGroup = Table()


### PR DESCRIPTION
Add bindable hotkeys, default ',' and '/', to the Idle Unit Buttons in the UnitTable

'.' is Stop Movement, so this seemed relevant

#12785