### PR TITLE
Update Spy Tech Stealing

### DIFF
--- a/core/src/com/unciv/models/Spy.kt
+++ b/core/src/com/unciv/models/Spy.kt
@@ -168,7 +168,7 @@ class Spy private constructor() : IsPartOfGameInfoSerialization {
     private fun getTurnsRemainingToStealTech(): Int {
         val stealableTechs = espionageManager.getTechsToSteal(getCity().civ)
         if (stealableTechs.isEmpty()) return -1
-        
+
         var techStealCost = stealableTechs.maxOfOrNull { civInfo.gameInfo.ruleset.technologies[it]!!.cost }!!.toFloat()
         val techSpeedModifier = civInfo.gameInfo.speed.scienceCostModifier //Modify steal cost according to game speed
         techStealCost *= techSpeedModifier * 1.25f //Multiply by 1.25f, according to Civ5 GlobalDefines.XML

--- a/core/src/com/unciv/models/Spy.kt
+++ b/core/src/com/unciv/models/Spy.kt
@@ -168,13 +168,15 @@ class Spy private constructor() : IsPartOfGameInfoSerialization {
     private fun getTurnsRemainingToStealTech(): Int {
         val stealableTechs = espionageManager.getTechsToSteal(getCity().civ)
         if (stealableTechs.isEmpty()) return -1
-
-        val techStealCost = stealableTechs.maxOfOrNull { civInfo.gameInfo.ruleset.technologies[it]!!.cost }!!
+        
+        var techStealCost = stealableTechs.maxOfOrNull { civInfo.gameInfo.ruleset.technologies[it]!!.cost }!!.toFloat()
+        val techSpeedModifier = civInfo.gameInfo.speed.scienceCostModifier //Modify steal cost according to game speed
+        techStealCost *= techSpeedModifier * 1.25f //Multiply by 1.25f, according to Civ5 GlobalDefines.XML
         var progressThisTurn = getCity().cityStats.currentCityStats.science
         if (progressThisTurn <= 0f) return -2 // The city has no science
 
-        // 33% spy bonus for each level
-        progressThisTurn *= (rank + 2f) / 3f
+        // 25% spy bonus for each level
+        progressThisTurn *= (rank + 3f) / 4f
         progressThisTurn *= getEfficiencyModifier().toFloat()
         progressTowardsStealingTech += progressThisTurn.toInt()
 


### PR DESCRIPTION
According to the Civ5 game code and the values in the GlobalDefines.XML, it looks like each rank of spy is supposed to grant +25% tech stealing speed, not +33%. The base tech steal cost appears to be modified by 1.25. I'm not sure if Civ5 modifies the tech cost by game speed, but it seems logical to me to do so.


https://github.com/Gedemon/Civ5-DLL/blob/master/CvGameCoreDLL_Expansion1/CvEspionageClasses.cpp
![Screenshot 2025-01-28 204738](https://github.com/user-attachments/assets/8763204c-bda9-400d-a922-7c4242dd7d40)