### PR TITLE
Fix Citizen Assignment Cycling

### DIFF
--- a/core/src/com/unciv/logic/city/managers/CityPopulationManager.kt
+++ b/core/src/com/unciv/logic/city/managers/CityPopulationManager.kt
@@ -149,7 +149,7 @@ class CityPopulationManager : IsPartOfGameInfoSerialization {
 
     /** Only assigns free population */
     internal fun autoAssignPopulation() {
-        city.cityStats.update(updateCivStats = false)  // calculate current stats with current assignments
+        city.cityStats.update()  // calculate current stats with current assignments
         val freePopulation = getFreePopulation()
         if (freePopulation <= 0) return
 


### PR DESCRIPTION
Fix rare bug where Citizen Assignment would cycle due to Civ Happiness going above and below the threshold.

Reported originally by Eggy here
https://discord.com/channels/586194543280390151/588357826758574106/1329106526761128058

Sample save file
[Babylon - 0 turns.txt](https://github.com/user-attachments/files/18627929/Babylon.-.0.turns.txt)

In master, if you press Food Focus, the assignments will cycle. This is because the Civ Happiness stat isn't being updated. So when it tries to assign Pop, it may think the Civ is Happy and not assign to Kailesh. But this will result in Civ at -1 Happy (Unhappy!). Assign again, and the algo thinks we're unhappy, increases weight for Happiness, and assigns to Kailesh. Now the civ is +1 Happy!! Repeat.
![image](https://github.com/user-attachments/assets/3ca7a28a-2dea-4116-81e0-caa694f4cdb9)

Simple fix is to calculate the civ-wide Happiness stat at the start while all Citizens aren't assigned. An advanced fix would involve recalculating Happiness after every assignment, but that's probably not necessary.