### PR TITLE
Update MapRegions.kt

### DIFF
--- a/core/src/com/unciv/logic/map/mapgenerator/mapregions/MapRegions.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/mapregions/MapRegions.kt
@@ -61,7 +61,9 @@ class MapRegions (val ruleset: Ruleset) {
         val closeStartPenaltyForRing = mapOf(
                 0 to 99, 1 to 97, 2 to 95,
                 3 to 92, 4 to 89, 5 to 69,
-                6 to 57, 7 to 24, 8 to 15 )
+                6 to 57, 7 to 24, 8 to 15,
+                9 to 12, 10 to 10, 11 to 8, 
+                12 to 6, 13 to 4) //at 14, both of us can settle a min distance expand without competing for tiles
 
         val randomLuxuryRatios = mapOf(
                 1 to listOf(1f),

--- a/core/src/com/unciv/logic/map/mapgenerator/mapregions/MapRegions.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/mapregions/MapRegions.kt
@@ -61,8 +61,8 @@ class MapRegions (val ruleset: Ruleset) {
         val closeStartPenaltyForRing = mapOf(
                 0 to 99, 1 to 97, 2 to 95,
                 3 to 92, 4 to 89, 5 to 69,
-                6 to 57, 7 to 24, 8 to 15,
-                9 to 12, 10 to 10, 11 to 8, 
+                6 to 57, 7 to 24, 8 to 20,
+                9 to 16, 10 to 12, 11 to 8, 
                 12 to 6, 13 to 4) //at 14, both of us can settle a min distance expand without competing for tiles
 
         val randomLuxuryRatios = mapOf(


### PR DESCRIPTION
It looks like the closeStartPenaltyForRing governs the distance between players spawns, is that correct? Loading up a couple of test maps with this change, this seems to resolve the problem of players spawning way too close even on spacious Huge maps @DeStup. 