### PR TITLE
Add "Will be destroyed when pillaged" unique

### DIFF
--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -642,6 +642,7 @@ enum class UniqueType(
     Unpillagable("Unpillagable", UniqueTarget.Improvement),
     PillageYieldRandom("Pillaging this improvement yields approximately [stats]", UniqueTarget.Improvement),
     PillageYieldFixed("Pillaging this improvement yields [stats]", UniqueTarget.Improvement),
+    DestroyedWhenPillaged("Will be destroyed when pillaged", UniqueTarget.Improvement),
     Irremovable("Irremovable", UniqueTarget.Improvement),
     AutomatedUnitsWillNotReplace("Will not be replaced by automated units", UniqueTarget.Improvement),
     ImprovesResources("Improves [resourceFilter] resource in this tile", UniqueTarget.Improvement, flags = UniqueFlag.setOfNoConditionals,

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsPillage.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsPillage.kt
@@ -63,6 +63,13 @@ object UnitActionsPillage {
 
                 if (pillagingImprovement)  // only Improvements heal HP
                     unit.healBy(25)
+                
+                if (tile.getImprovementToPillage() != null) {
+                    if (tile.getImprovementToPillage()!!.hasUnique(UniqueType.DestroyedWhenPillaged)) {
+                        tile.removeImprovement()
+                    }
+                }
+                    
             }.takeIf { unit.hasMovement() && canPillage(unit, tile) }
         )
     }

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -2510,6 +2510,9 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 	Applicable to: Improvement
 
+??? example  "Will be destroyed when pillaged"
+	Applicable to: Improvement
+
 ??? example  "Irremovable"
 	Applicable to: Improvement
 


### PR DESCRIPTION
After long period of inactivity, I have decided to implement a request from modding requests thread [https://github.com/yairm210/Unciv/issues/3242#issuecomment-2638111517](https://github.com/yairm210/Unciv/issues/3242#issuecomment-2638111517)

I believe this new unique will be useful for Civ 4 mods, as improvements get destroyed when pillaged in Civ 4

If you have some remarks, tell me in the comments