### PR TITLE
Move Policy cost modifiers to mod constants

### DIFF
--- a/core/src/com/unciv/logic/civilization/managers/PolicyManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/PolicyManager.kt
@@ -157,7 +157,8 @@ class PolicyManager : IsPartOfGameInfoSerialization {
     }
 
     fun getPolicyCultureCost(numberOfAdoptedPolicies: Int): Int {
-        var policyCultureCost = 25 + (numberOfAdoptedPolicies * 6).toDouble().pow(1.7)
+        val constants = civInfo.gameInfo.ruleset.modOptions.constants
+        var policyCultureCost = constants.policyBase + (numberOfAdoptedPolicies * constants.policyMultiplier).toDouble().pow(constants.policyExponent)
         val worldSizeModifier = civInfo.gameInfo.tileMap.mapParameters.mapSize.getPredefinedOrNextSmaller().policyCostPerCityModifier
         var cityModifier = worldSizeModifier * (civInfo.cities.count { !it.isPuppet } - 1)
 

--- a/core/src/com/unciv/models/ModConstants.kt
+++ b/core/src/com/unciv/models/ModConstants.kt
@@ -98,6 +98,11 @@ class ModConstants {
     var pantheonBase = 10
     var pantheonGrowth = 5
 
+    // Factors in formula for policy costs
+    var policyBase = 25
+    var policyMultiplier = 6
+    var policyExponent = 1.7
+
     var workboatAutomationSearchMaxTiles = 20
 
     // Civilization

--- a/core/src/com/unciv/models/ModConstants.kt
+++ b/core/src/com/unciv/models/ModConstants.kt
@@ -101,7 +101,7 @@ class ModConstants {
     // Factors in formula for policy costs
     var policyBase = 25
     var policyMultiplier = 6
-    var policyExponent = 1.7f
+    var policyExponent = 1.7
 
     var workboatAutomationSearchMaxTiles = 20
 

--- a/core/src/com/unciv/models/ModConstants.kt
+++ b/core/src/com/unciv/models/ModConstants.kt
@@ -100,8 +100,8 @@ class ModConstants {
 
     // Factors in formula for policy costs
     var policyBase = 25
-    var policyMultiplier = 6
-    var policyExponent = 1.7
+    var policyMultiplier = 6 //3 in BNW
+    var policyExponent = 1.7 //2.01 in BNW
 
     var workboatAutomationSearchMaxTiles = 20
 

--- a/core/src/com/unciv/models/ModConstants.kt
+++ b/core/src/com/unciv/models/ModConstants.kt
@@ -101,7 +101,7 @@ class ModConstants {
     // Factors in formula for policy costs
     var policyBase = 25
     var policyMultiplier = 6
-    var policyExponent = 1.7
+    var policyExponent = 1.7f
 
     var workboatAutomationSearchMaxTiles = 20
 


### PR DESCRIPTION
G&K apparently uses a modifier of 3 instead of 6 and an exponent of 2.01 instead of 1.7.