### PR TITLE
Add tech cost uniques

### DIFF
--- a/core/src/com/unciv/logic/civilization/managers/TechManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/TechManager.kt
@@ -25,6 +25,7 @@ import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.ruleset.unit.BaseUnit
 import com.unciv.models.translations.tr
 import com.unciv.ui.components.MayaCalendar
+import com.unciv.ui.components.extensions.toPercent
 import com.unciv.ui.components.fonts.Fonts
 import com.unciv.utils.withItem
 import kotlin.math.ceil
@@ -119,7 +120,10 @@ class TechManager : IsPartOfGameInfoSerialization {
         techCost /= getScienceModifier(techName)
         val mapSizePredef = civInfo.gameInfo.tileMap.mapParameters.mapSize.getPredefinedOrNextSmaller()
         techCost *= mapSizePredef.techCostMultiplier
-        techCost *= 1 + (civInfo.cities.size - 1) * mapSizePredef.techCostPerCityModifier
+        var cityModifier = (civInfo.cities.size - 1) * mapSizePredef.techCostPerCityModifier
+        for (unique in civInfo.getMatchingUniques(UniqueType.LessTechCostFromCities)) cityModifier *= 1 - unique.params[0].toFloat() / 100
+        for (unique in civInfo.getMatchingUniques(UniqueType.LessTechCost)) techCost *= unique.params[0].toPercent()
+        techCost *= 1 + cityModifier
         return techCost.toInt()
     }
 

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -157,7 +157,7 @@ enum class UniqueType(
     LessPolicyCost("[relativeAmount]% Culture cost of adopting new Policies", UniqueTarget.Global),
 
     /// Tech Cost
-    LessTechCostFromCities("Each city founded increases science cost of technologies [relativeAmount]% less than normal", UniqueTarget.Global),
+    LessTechCostFromCities("Each city founded increases Science cost of Technologies [relativeAmount]% less than normal", UniqueTarget.Global),
     LessTechCost("[relativeAmount]% Science cost of researching new Technologies", UniqueTarget.Global),
 
     /// Natural Wonders

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -156,6 +156,10 @@ enum class UniqueType(
     LessPolicyCostFromCities("Each city founded increases culture cost of policies [relativeAmount]% less than normal", UniqueTarget.Global),
     LessPolicyCost("[relativeAmount]% Culture cost of adopting new Policies", UniqueTarget.Global),
 
+    /// Tech Cost
+    LessTechCostFromCities("Each city founded increases science cost of technologies [relativeAmount]% less than normal", UniqueTarget.Global),
+    LessTechCost("[relativeAmount]% Science cost of researching new Technologies", UniqueTarget.Global),
+
     /// Natural Wonders
     StatsFromNaturalWonders("[stats] for every known Natural Wonder", UniqueTarget.Global),
     StatBonusWhenDiscoveringNaturalWonder("[stats] for discovering a Natural Wonder (bonus enhanced to [stats] if first to discover it)", UniqueTarget.Global),


### PR DESCRIPTION
Implemented similary as the Policy uniques, a LessTechCostFromCities unique is needed to implement Communism in Rekmod.