### PR TITLE
Fix free populatoion buildings not working when settling cities

### DIFF
--- a/core/src/com/unciv/logic/city/managers/CityFounder.kt
+++ b/core/src/com/unciv/logic/city/managers/CityFounder.kt
@@ -39,8 +39,6 @@ class CityFounder {
 
         val startingEra = civInfo.gameInfo.gameParameters.startingEra
 
-        addStartingBuildings(city, civInfo, startingEra)
-
         city.expansion.reset()
 
         city.tryUpdateRoadStatus()
@@ -85,6 +83,8 @@ class CityFounder {
 
         triggerCitiesSettledNearOtherCiv(city)
         civInfo.gameInfo.cityDistances.setDirty()
+
+        addStartingBuildings(city, civInfo, startingEra)
 
         for (unique in civInfo.getTriggeredUniques(UniqueType.TriggerUponFoundingCity,
             StateForConditionals(civInfo, city, unit)


### PR DESCRIPTION
Actual fix: reorder the order of operations for when free buildings are gotten. As the PR title claims, this is primarily a fix towards free population buildings (which add population before losing population when set to the era's starting population). This should ideally fix other stuff too (Idk what, though)