### PR TITLE
Add a filter for religions

### DIFF
--- a/core/src/com/unciv/models/Religion.kt
+++ b/core/src/com/unciv/models/Religion.kt
@@ -132,7 +132,7 @@ class Religion() : INamed, IsPartOfGameInfoSerialization {
         val known = civ != null && civ.knows(foundingCiv)
         if (filter == "enemy") return known && civ!!.isAtWarWith(foundingCiv)
         if (founderBeliefUniqueMap.hasMatchingUnique(filter, state)) return true
-        if (founderBeliefUniqueMap.hasMatchingUnique(filter, state)) return true
+        if (followerBeliefUniqueMap.hasMatchingUnique(filter, state)) return true
         return false
     }
 

--- a/core/src/com/unciv/models/Religion.kt
+++ b/core/src/com/unciv/models/Religion.kt
@@ -122,18 +122,24 @@ class Religion() : INamed, IsPartOfGameInfoSerialization {
     }
     
     private fun matchesSingleFilter(filter: String, state: StateForConditionals = StateForConditionals.IgnoreConditionals, civ: Civilization? = null): Boolean {
-        if (filter == "any") return true
-        if (filter == name) return true
-        if (filter == "major") return isMajorReligion()
-        if (filter == "enhanced") return isEnhancedReligion()
         val foundingCiv = getFounder()
-        if (filter == "your") return civ == foundingCiv
-        if (filter == "foreign") return civ != null && civ != foundingCiv
-        val known = civ != null && civ.knows(foundingCiv)
-        if (filter == "enemy") return known && civ!!.isAtWarWith(foundingCiv)
-        if (founderBeliefUniqueMap.hasMatchingUnique(filter, state)) return true
-        if (followerBeliefUniqueMap.hasMatchingUnique(filter, state)) return true
-        return false
+        when (filter) {
+            "any" -> return true
+            "major" -> return isMajorReligion()
+            "enhanced" -> return isEnhancedReligion()
+            "your" -> return civ == foundingCiv
+            "foreign" -> return civ != null && civ != foundingCiv
+            "enemy" -> {
+                val known = civ != null && civ.knows(foundingCiv)
+                return known && civ!!.isAtWarWith(foundingCiv)
+            }
+            else -> {
+                if (filter == name) return true
+                if (founderBeliefUniqueMap.hasMatchingUnique(filter, state)) return true
+                if (followerBeliefUniqueMap.hasMatchingUnique(filter, state)) return true
+                return false
+            }
+        }
     }
 
     private fun unlockedBuildingsPurchasable(): List<String> {

--- a/core/src/com/unciv/models/Religion.kt
+++ b/core/src/com/unciv/models/Religion.kt
@@ -79,10 +79,7 @@ class Religion() : INamed, IsPartOfGameInfoSerialization {
 
     private fun mapToExistingBeliefs(beliefs: Set<String>): Sequence<Belief> {
         val rulesetBeliefs = gameInfo.ruleset.beliefs
-        return beliefs.asSequence().mapNotNull {
-            if (it !in rulesetBeliefs) null
-            else rulesetBeliefs[it]!!
-        }
+        return beliefs.asSequence().mapNotNull { rulesetBeliefs[it] }
     }
 
     fun getBeliefs(beliefType: BeliefType): Sequence<Belief> {

--- a/core/src/com/unciv/models/Religion.kt
+++ b/core/src/com/unciv/models/Religion.kt
@@ -132,6 +132,7 @@ class Religion() : INamed, IsPartOfGameInfoSerialization {
             }
             else -> {
                 if (filter == name) return true
+                if (filter in getBeliefs(BeliefType.Any).map { it.name }) return true
                 if (founderBeliefUniqueMap.hasMatchingUnique(filter, state)) return true
                 if (followerBeliefUniqueMap.hasMatchingUnique(filter, state)) return true
                 return false

--- a/core/src/com/unciv/models/ruleset/unique/Conditionals.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Conditionals.kt
@@ -194,6 +194,10 @@ object Conditionals {
             UniqueType.ConditionalInThisCity -> state.relevantCity != null
             UniqueType.ConditionalCityFilter -> checkOnCity { matchesFilter(conditional.params[0], state.relevantCiv) }
             UniqueType.ConditionalCityConnected -> checkOnCity { isConnectedToCapital() }
+            UniqueType.ConditionalCityReligion -> checkOnCity {
+                religion.getMajorityReligion()
+                    ?.matchesFilter(conditional.params[0], state, state.relevantCiv) == true
+            }
             UniqueType.ConditionalCityMajorReligion -> checkOnCity {
                 religion.getMajorityReligion()?.isMajorReligion() == true }
             UniqueType.ConditionalCityEnhancedReligion -> checkOnCity {

--- a/core/src/com/unciv/models/ruleset/unique/Conditionals.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Conditionals.kt
@@ -198,6 +198,10 @@ object Conditionals {
                 religion.getMajorityReligion()
                     ?.matchesFilter(conditional.params[0], state, state.relevantCiv) == true
             }
+            UniqueType.ConditionalCityNotReligion -> checkOnCity {
+                religion.getMajorityReligion()
+                    ?.matchesFilter(conditional.params[0], state, state.relevantCiv) != true
+            }
             UniqueType.ConditionalCityMajorReligion -> checkOnCity {
                 religion.getMajorityReligion()?.isMajorReligion() == true }
             UniqueType.ConditionalCityEnhancedReligion -> checkOnCity {

--- a/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
@@ -517,7 +517,6 @@ enum class UniqueParameterType(
         override fun isKnownValue(parameterText: String, ruleset: Ruleset): Boolean {
             return when (parameterText) {
                 in staticKnownValues -> true
-                in ruleset.nations -> true
                 in ruleset.religions -> true
                 else -> ruleset.beliefs.values.any { it.hasTagUnique(parameterText) }
             }

--- a/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
@@ -510,6 +510,19 @@ enum class UniqueParameterType(
     Belief("belief", "God of War", "The name of any belief") {
         override fun getKnownValuesForAutocomplete(ruleset: Ruleset) = ruleset.beliefs.keys
     },
+    
+    /**Used by [UniqueType.ConditionalCityReligion]*/
+    ReligionFilter("religionFilter", "major") {
+        override val staticKnownValues = setOf("any", "major", "enhanced", "your", "foreign","enemy")
+        override fun isKnownValue(parameterText: String, ruleset: Ruleset): Boolean {
+            return when (parameterText) {
+                in staticKnownValues -> true
+                in ruleset.nations -> true
+                in ruleset.religions -> true
+                else -> ruleset.beliefs.values.any { it.hasTagUnique(parameterText) }
+            }
+        }
+    },
 
     /** Used by [UniqueType.FreeExtraBeliefs] and its any variant, see ReligionManager.getBeliefsToChooseAt* functions */
     FoundingOrEnhancing("foundingOrEnhancing", "founding", "`founding` or `enhancing`", "Prophet Action Filters",

--- a/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
@@ -518,6 +518,7 @@ enum class UniqueParameterType(
             return when (parameterText) {
                 in staticKnownValues -> true
                 in ruleset.religions -> true
+                in ruleset.beliefs -> true
                 else -> ruleset.beliefs.values.any { it.hasTagUnique(parameterText) }
             }
         }

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -737,6 +737,7 @@ enum class UniqueType(
     ConditionalCityFilter("in [cityFilter] cities", UniqueTarget.Conditional),
     ConditionalCityConnected("in cities connected to the capital", UniqueTarget.Conditional),
     ConditionalCityReligion("in cities with a [religionFilter] religion", UniqueTarget.Conditional),
+    ConditionalCityNotReligion("in cities not following a [religionFilter] religion", UniqueTarget.Conditional),
     ConditionalCityMajorReligion("in cities with a major religion", UniqueTarget.Conditional),
     ConditionalCityEnhancedReligion("in cities with an enhanced religion", UniqueTarget.Conditional),
     ConditionalCityThisReligion("in cities following our religion", UniqueTarget.Conditional),

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -736,6 +736,7 @@ enum class UniqueType(
     ConditionalInThisCity("in this city", UniqueTarget.Conditional),
     ConditionalCityFilter("in [cityFilter] cities", UniqueTarget.Conditional),
     ConditionalCityConnected("in cities connected to the capital", UniqueTarget.Conditional),
+    ConditionalCityReligion("in cities with a [religionFilter] religion", UniqueTarget.Conditional),
     ConditionalCityMajorReligion("in cities with a major religion", UniqueTarget.Conditional),
     ConditionalCityEnhancedReligion("in cities with an enhanced religion", UniqueTarget.Conditional),
     ConditionalCityThisReligion("in cities following our religion", UniqueTarget.Conditional),

--- a/docs/Modders/Unique-parameters.md
+++ b/docs/Modders/Unique-parameters.md
@@ -171,6 +171,20 @@ Allowed values:
 - `Followers of the Majority Religion` or `Followers of this Religion`, both of which only apply when this religion is the majority religion in that city
 - Specialist names
 
+## religionFilter
+
+For filtering specific relgions
+
+- `any`
+- `major`
+- `enhanced`
+- `your`
+- `foriegn`
+- `enemy`
+- The name of a relgion symbol
+- The name of a belief
+- A unique of a belief the religion has
+
 ## policyFilter
 
 Allowed values:


### PR DESCRIPTION
And you get a filter, and you get a filter. Everything gets a multifilter

I mostly thought of this to allow for moving uniques for unlocking religious buildings off of the beliefs themselves and onto the buildings, but almost surely some other modder will find use for it

I really, really, really, really want to find some way to integrate this into city filter (as I believe there is actually a niche case use for that), but I can't figure out how I would go about doing that or if it's just the unique in question needs better alternatives