### PR TITLE
ProductionBonusWhenRemoved moddability

### DIFF
--- a/android/assets/jsons/Civ V - Gods & Kings/Terrains.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Terrains.json
@@ -188,7 +188,7 @@
 		"defenceBonus": 0.25,
 		"occursOn": ["Tundra","Plains","Grassland","Hill"],
 		"uniques": ["Rough terrain", "Vegetation",
-					"Provides a one-time Production bonus to the closest city when cut down",
+					"Provides a one-time bonus of [30] Production to the closest city when cut down",
 					"Blocks line-of-sight from tiles at same elevation",
 					"[25]% Chance to be destroyed by nukes",
 					"A Region is formed with at least [30]% [Forest] tiles, with priority [3]",

--- a/android/assets/jsons/Civ V - Vanilla/Terrains.json
+++ b/android/assets/jsons/Civ V - Vanilla/Terrains.json
@@ -188,7 +188,7 @@
 		"occursOn": ["Tundra","Plains","Grassland","Hill"],
 		"uniques": [
 			"Rough terrain", "Vegetation",
-			"Provides a one-time Production bonus to the closest city when cut down",
+			"Provides a one-time bonus of [30] Production to the closest city when cut down",
 			"Blocks line-of-sight from tiles at same elevation",
 			"[25]% Chance to be destroyed by nukes",
 			"A Region is formed with at least [30]% [Forest] tiles, with priority [3]",

--- a/core/src/com/unciv/logic/map/tile/TileImprovementFunctions.kt
+++ b/core/src/com/unciv/logic/map/tile/TileImprovementFunctions.kt
@@ -309,7 +309,6 @@ class TileImprovementFunctions(val tile: Tile) {
         val closestCity = civ.cities.minByOrNull { it.getCenterTile().aerialDistanceTo(tile) }
             ?: return
         val distance = closestCity.getCenterTile().aerialDistanceTo(tile)
-
         var productionPoints = 0f
         for (unique in tile.getTerrainMatchingUniques(UniqueType.ProductionBonusWhenRemoved)) {
             productionPoints = unique.params[0].toFloatOrNull() ?: return

--- a/core/src/com/unciv/logic/map/tile/TileImprovementFunctions.kt
+++ b/core/src/com/unciv/logic/map/tile/TileImprovementFunctions.kt
@@ -309,19 +309,32 @@ class TileImprovementFunctions(val tile: Tile) {
         val closestCity = civ.cities.minByOrNull { it.getCenterTile().aerialDistanceTo(tile) }
             ?: return
         val distance = closestCity.getCenterTile().aerialDistanceTo(tile)
-        var productionPointsToAdd = if (distance == 1) 20 else 20 - (distance - 2) * 5
+
+        var productionPoints = 0f
+        for (unique in tile.getTerrainMatchingUniques(UniqueType.ProductionBonusWhenRemoved)) {
+            productionPoints = unique.params[0].toFloatOrNull() ?: return
+        }
+        val ruleset = civ.gameInfo.ruleset
+        val choppingYieldsIncreaseWithGameProgress = ruleset.modOptions.constants.choppingYieldsIncreaseWithGameProgress
+        // Civ6 yields increase with game progression: https://www.reddit.com/r/civ/comments/gvx44v/comment/fsrifc2/
+        if (choppingYieldsIncreaseWithGameProgress) {
+            val gameProgress = max(civ.tech.researchedTechnologies.size.toFloat() / ruleset.technologies.size, civ.policies.adoptedPolicies.size.toFloat() / ruleset.policies.size)
+            productionPoints *= (1 + 9 * gameProgress)
+        }
+        var productionPointsToAdd = if (distance == 1) productionPoints else productionPoints - (distance - 2) * productionPoints/4
         if (tile.owningCity == null || tile.owningCity!!.civ != civ) productionPointsToAdd =
             productionPointsToAdd * 2 / 3
+        productionPointsToAdd *= civ.gameInfo.speed.productionCostModifier
+        productionPointsToAdd = floor(productionPointsToAdd)
         if (productionPointsToAdd > 0) {
-            closestCity.cityConstructions.addProductionPoints(productionPointsToAdd)
+            closestCity.cityConstructions.addProductionPoints(productionPointsToAdd.toInt())
             val locations = LocationAction(tile.position, closestCity.location)
             civ.addNotification(
-                "Clearing a [$removedTerrainFeature] has created [$productionPointsToAdd] Production for [${closestCity.name}]",
+                "Clearing a [$removedTerrainFeature] has created [${productionPointsToAdd.toInt()}] Production for [${closestCity.name}]",
                 locations, NotificationCategory.Production, NotificationIcon.Construction
             )
         }
     }
-
 
     /** Marks tile as target tile for a building with a [UniqueType.CreatesOneImprovement] unique */
     fun markForCreatesOneImprovement(improvement: String) {

--- a/core/src/com/unciv/models/ModConstants.kt
+++ b/core/src/com/unciv/models/ModConstants.kt
@@ -109,6 +109,9 @@ class ModConstants {
     var tributeGlobalModifier = 100 // 75 in BNW
     var tributeLocalModifier = 100 // 125 in BNW
 
+    // Forest chops: if Production bonus from removing terrain features should increase with game progress
+    var choppingYieldsIncreaseWithGameProgress = false // true in Civ6
+
     // Espionage
     var maxSpyRank = 3
     // How much of a skill bonus each rank gives.

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -561,7 +561,7 @@ enum class UniqueType(
     DamagesContainingUnits("Units ending their turn on this terrain take [amount] damage", UniqueTarget.Terrain),
     TerrainGrantsPromotion("Grants [promotion] ([comment]) to adjacent [mapUnitFilter] units for the rest of the game", UniqueTarget.Terrain),
     GrantsCityStrength("[amount] Strength for cities built on this terrain", UniqueTarget.Terrain),
-    ProductionBonusWhenRemoved("Provides a one-time Production bonus to the closest city when cut down", UniqueTarget.Terrain),
+    ProductionBonusWhenRemoved("Provides a one-time bonus of [amount] Production to the closest city when cut down", UniqueTarget.Terrain),
     Vegetation("Vegetation", UniqueTarget.Terrain, UniqueTarget.Improvement, flags = UniqueFlag.setOfHiddenToUsers),  // Improvement included because use as tileFilter works
 
 


### PR DESCRIPTION
Scales production bonus with game speed, and adds option to scale it by game speed as well.

Rather than [amount], I'd like to add [stats] as input, so I can add e.g. the food + production jungle chops of Civ6, but how do I extract the stats from the unique in this case?