### PR TITLE
Vietnamese Translations

### DIFF
--- a/android/assets/jsons/translations/Vietnamese.properties
+++ b/android/assets/jsons/translations/Vietnamese.properties
@@ -1316,7 +1316,7 @@ Victory status = Chỉ số thắng lợi
 Social policies = Chính sách xã hội
 Close = Đóng
 Do you want to exit the game? = Bạn có muốn thoát trò chơi?
-Exit = Đóng
+Exit = Đóng Unciv
 Start bias: = Thiên kiến khởi điểm: 
 Avoid [terrain] = Tránh [terrain]
 
@@ -5135,7 +5135,7 @@ Barringer Crater = Miệng núi lửa Barringer
 
 Lumber mill = Nhà máy gỗ
 
-Mine = Của tôi
+Mine = Hầm mỏ
 
 Trading post = Nơi buôn bán
 


### PR DESCRIPTION
Reference: https://discord.com/channels/586194543280390151/640249234238472282/1352784269789106326

Updating a mistranslation where a 'Mine' (where you dig things) was mistranslated to 'mine' (this object is mine).

Correction: Của tôi >>>> Hầm mỏ

~~~~~~~~~~

Additionally, adding 'Unciv' to the 'Exit' Unciv button, to differentiate the button from the 'Close Menu' Button (as both Exit and Close translate to 'Dong' in Vietnamese.