### PR TITLE
translate: russian 100%

### DIFF
--- a/android/assets/jsons/translations/Russian.properties
+++ b/android/assets/jsons/translations/Russian.properties
@@ -41,7 +41,7 @@ Delete = Удалить
 Civ V - Vanilla = Civ V - Основная версия
 Civ V - Gods & Kings = Civ V - Боги и короли
 
-# Obsolete Tutorial tasks - the active lines are moved to 'Lines from Events', much later in the tranlsation file.
+# Obsolete Tutorial tasks - the active lines are moved to 'Lines from Events', much later in the translation file.
 # TODO remove after grace period which allows translators to copy and paste existing translations to the new format.
 
 Move a unit!\nClick on a unit > Click on a destination > Click the arrow popup = Передвиньте юнит!\nВыберите юнит > Выберите клетку на карте > Нажмите на стрелку
@@ -96,10 +96,8 @@ New [civName]\n(formerly known as [cityName]) = Новый [civName]\n(ране�
 Requires [buildingName] to be built in the city = Требуется [buildingName] в городе
 Requires [buildingName] to be built in all cities = Требуется [buildingName] во всех городах
 Provides a free [buildingName] in the city = В городе бесплатно появляется [buildingName]
- # Requires translation!
-Requires improved [resource] near city = 
- # Requires translation!
-Requires at least one of the following resources improved near the city: = 
+Requires improved [resource] near city = Требуется улучшенный [resource] около города
+Requires at least one of the following resources improved near the city: = Требуется как минимум один из улучшенных ресурсов около города:
 Wonder is being built elsewhere = Чудо света уже строится в другом месте
 National Wonder is being built elsewhere = Национальное чудо уже строится в другом месте
 Requires a [buildingName] in all [cityFilter] cities = Требуется [buildingName] во всех городах [cityFilter]
@@ -115,12 +113,9 @@ Requires [PolicyOrNationalWonder] = Требуется [PolicyOrNationalWonder]
 Cannot be purchased = Нельзя купить
 Can only be purchased = Можно только купить
 See also = См. также
- # Requires translation!
-Use default promotions = 
- # Requires translation!
-Default promotions for [unitName] = 
- # Requires translation!
-Statuses = 
+Use default promotions = Использовать стандартные повышения
+Default promotions for [unitName] = Стандартные повышения для [unitName]
+Statuses = Статусы
 
 Requires at least one of the following: = Требуется хотя бы одно из следующего:
 Requires all of the following: = Требуется всё из следующего:
@@ -354,8 +349,7 @@ Introduction to [nation] = Представиться державе [nation]
 Declare war on [nation] = Объявить войну: [nation]
 Luxury resources = Редкие ресурсы
 Strategic resources = Стратегические ресурсы
- # Requires translation!
-Stockpiled resources = 
+Stockpiled resources = Накапливаемые ресурсы
 Owned by you: [amountOwned] = В наличии: [amountOwned]
 Non-existent city = Несуществующий город
 
@@ -385,8 +379,7 @@ Start game! = Начать игру!
 Map Options = Настройки Карты
 Game Options = Настройки Игры
 Civilizations = Цивилизации
- # Requires translation!
-Shuffle Civ Order at Start = 
+Shuffle Civ Order at Start = Перемешать порядок цивилизаций в начале
 Map Type = Тип карты
 Map file = Файл карты
 Max Turns = Макс. ходов
@@ -398,8 +391,7 @@ Existing = Существующий
 Custom = Свой
 Map Generation Type = Тип генерации карты
 Enabled Map Generation Types = Включенные типы генерации карт
- # Requires translation!
-Example map = 
+Example map = Пример карты
 
 # Map types
 Default = По умолчанию
@@ -464,8 +456,7 @@ This is used for painting resources, not in map generator steps: = Исполь�
 Advanced Settings = Дополнительные настройки
 RNG Seed = Сид
 Map Elevation = Гористость
- # Requires translation!
-Temperature intensity = 
+Temperature intensity = Интенсивность температуры
 Temperature shift = Смещение температуры
 Resource richness = Богатство ресурсами
 Vegetation richness = Богатство растительностью
@@ -827,8 +818,7 @@ Hidden = Скрыты
 Visible = Видимы
 Permanent = Перманентны
 
- # Requires translation!
-Show minimap = 
+Show minimap = Показывать миникарту
 
 Show tutorials = Показывать обучение
 Reset tutorials = Сбросить обучение
@@ -864,8 +854,7 @@ Gameplay = Геймплей
 Check for idle units = Проверять незанятые юниты
 'Next unit' button cycles idle units = Кнопка 'Следующий юнит' зацикливается на незанятых юнитах
 Auto Unit Cycle = Автоматически переключаться между незанятыми юнитами
- # Requires translation!
-Show Small Skip/Cycle Unit Button = 
+Show Small Skip/Cycle Unit Button = Показывать маленькую кнопку пропуска/переключения юнитов
 Move units with a single tap = Перемещать юниты одним касанием
 Move units with a long tap = Перемещать юниты долгим касанием
 Auto-assign city production = Автопроизводство в городах
@@ -1004,33 +993,31 @@ We have conquered the city of [cityName]! = Мы завоевываем горо
 Your citizens are revolting due to very high unhappiness! = Ваши граждане восстают из-за высокого уровня недовольства!
 
   
- # Requires translation!
-An enemy [unit] has attacked [cityName] ([amount2] HP) = 
+An enemy [unit] has attacked [cityName] ([amount2] HP) = [unit] врага атаковал [cityName] ([amount2] ОЗ)
 An enemy [unit] ([amount] HP) has attacked [cityName] ([amount2] HP) = [unit] ([amount] ОЗ) врага атаковал [cityName] ([amount2] ОЗ)
-An enemy [unit] ([amount] HP) has [battleAction] our [ourUnit] ([amount2] HP) = [unit] ([amount] ОЗ) врага [battleAction] [ourUnit] ([amount2] ОЗ)
-An enemy [unit] has attacked our [ourUnit] ([amount] HP) = [unit] врага атаковал [ourUnit] ([amount] ОЗ)
- # Requires translation!
-An enemy [unit] ([amount] HP) has attacked our [ourUnit] ([amount2] HP) = 
-Enemy city [cityName] has attacked our [ourUnit] = Вражеский город [cityName] атакует [ourUnit]
-Enemy city [cityName] has attacked our [ourUnit] ([amount2] HP) = Вражеский город [cityName] атакует [ourUnit] ([amount2] ОЗ)
+An enemy [unit] ([amount] HP) has [battleAction] our [ourUnit] ([amount2] HP) = [unit] ([amount] ОЗ) врага [battleAction] наших [ourUnit] ([amount2] ОЗ)
+An enemy [unit] has attacked our [ourUnit] ([amount] HP) = [unit] врага атаковал наших [ourUnit] ([amount] ОЗ)
+An enemy [unit] ([amount] HP) has attacked our [ourUnit] ([amount2] HP) = [unit] ([amount] ОЗ) врага атаковал наших [ourUnit] ([amount2] ОЗ)
+Enemy city [cityName] has attacked our [ourUnit] = Вражеский город [cityName] атакует наш [ourUnit]
+Enemy city [cityName] has attacked our [ourUnit] ([amount2] HP) = Вражеский город [cityName] атакует наших [ourUnit] ([amount2] ОЗ)
 An enemy [unit] has captured [cityName] = [unit] врага захватывает город [cityName]
 An enemy [unit] ([amount] HP) has captured [cityName] ([amount2] HP) = [unit] ([amount] ОЗ) врага захватывает город [cityName] ([amount2] ОЗ)
 An enemy [unit] has raided [cityName] = [unit] врага грабит город [cityName]
 An enemy [unit] ([amount] HP) has raided [cityName] ([amount2] HP) = [unit] ([amount] ОЗ) врага грабит город [cityName] ([amount2] ОЗ)
-An enemy [unit] has captured our [ourUnit] = [unit] врага захватывает [ourUnit]
-An enemy [unit] ([amount] HP) has captured our [ourUnit] ([amount2] HP) = [unit] ([amount] ОЗ) врага захватывает [ourUnit] ([amount2] ОЗ)
-An enemy [unit] has destroyed our [ourUnit] = [unit] врага уничтожает [ourUnit]
-An enemy [unit] ([amount] HP) has destroyed our [ourUnit] ([amount2] HP) = [unit] ([amount] ОЗ) врага уничтожает [ourUnit] ([amount2] ОЗ)
+An enemy [unit] has captured our [ourUnit] = [unit] врага захватывает наших [ourUnit]
+An enemy [unit] ([amount] HP) has captured our [ourUnit] ([amount2] HP) = [unit] ([amount] ОЗ) врага захватывает наших [ourUnit] ([amount2] ОЗ)
+An enemy [unit] has destroyed our [ourUnit] = [unit] врага уничтожает наших [ourUnit]
+An enemy [unit] ([amount] HP) has destroyed our [ourUnit] ([amount2] HP) = [unit] ([amount] ОЗ) врага уничтожает наших [ourUnit] ([amount2] ОЗ)
 Your [ourUnit] has destroyed an enemy [unit] = Наш [ourUnit] уничтожает вражеский юнит [unit]
 Your [ourUnit] ([amount] HP) has destroyed an enemy [unit] ([amount2] HP) = Наш [ourUnit] ([amount] ОЗ) уничтожает вражеский юнит [unit] ([amount2] ОЗ)
 An enemy [RangedUnit] has destroyed the defence of [cityName] = [RangedUnit] врага прорывает оборону города [cityName]
 An enemy [RangedUnit] ([amount] HP) has destroyed the defence of [cityName] ([amount2] HP) = [RangedUnit] ([amount] ОЗ) врага прорывает оборону города [cityName] ([amount2] ОЗ)
-Enemy city [cityName] has destroyed our [ourUnit] = Вражеский город [cityName] уничтожает [ourUnit]
-Enemy city [cityName] ([amount] HP) has destroyed our [ourUnit] ([amount2] HP) = Вражеский город [cityName] ([amount] ОЗ) уничтожает [ourUnit] ([amount2] ОЗ)
+Enemy city [cityName] has destroyed our [ourUnit] = Вражеский город [cityName] уничтожает наших [ourUnit]
+Enemy city [cityName] ([amount] HP) has destroyed our [ourUnit] ([amount2] HP) = Вражеский город [cityName] ([amount] ОЗ) уничтожает наших [ourUnit] ([amount2] ОЗ)
 An enemy [unit] was destroyed while attacking [cityName] = [unit] врага был уничтожен при попытке атаковать город [cityName]
 An enemy [unit] ([amount] HP) was destroyed while attacking [cityName] ([amount2] HP) = [unit] ([amount] ОЗ) врага был уничтожен при попытке атаковать город [cityName] ([amount2] ОЗ)
-An enemy [unit] was destroyed while attacking our [ourUnit] = [unit] врага был уничтожен при попытке атаковать [ourUnit]
-An enemy [unit] ([amount] HP) was destroyed while attacking our [ourUnit] ([amount2] HP) = [unit] ([amount] ОЗ) врага был уничтожен при попытке атаковать [ourUnit] ([amount2] ОЗ)
+An enemy [unit] was destroyed while attacking our [ourUnit] = [unit] врага был уничтожен при попытке атаковать наших [ourUnit]
+An enemy [unit] ([amount] HP) was destroyed while attacking our [ourUnit] ([amount2] HP) = [unit] ([amount] ОЗ) врага был уничтожен при попытке атаковать наших [ourUnit] ([amount2] ОЗ)
 
 # Interception messages
 Our [attackerName] ([amount] HP) was attacked by an intercepting [interceptorName] ([amount2] HP) = Наш [attackerName] ([amount] ОЗ) был атакован юнитом-перехватчиком [interceptorName] ([amount2] ОЗ)
@@ -1194,10 +1181,8 @@ turn = ход
 Next unit = Следующий юнит
 [amount] units idle = [amount] незанятых юнитов
 [idleCount] idle = [idleCount] без действий
- # Requires translation!
-[skipCount] skipping = 
- # Requires translation!
-Cycle = 
+[skipCount] skipping = [skipCount] пропускает ход
+Cycle = Переключить
 Fog of War = Туман войны
 Pick a policy = Выбрать институт
 Move Spies = Переместить Шпионов
@@ -1247,8 +1232,7 @@ Pillage = Разграбить
 Pillage [improvement] = Разграбить [improvement]
 [improvement] (Pillaged!) = [improvement] (Разграблено!)
 Repair [improvement] - [turns] = Починить [improvement] - [turns]
- # Requires translation!
-Skip turn = 
+Skip turn = Пропустить ход
 Are you sure you want to pillage this [improvement]? = Вы уверены, что хотите разграбить: [improvement]?
 We have looted [amount] from a [improvement] = Мы добыли [amount] с улучшения [improvement]
 We have looted [amount] from a [improvement] which has been sent to [cityName] = Мы добыли [amount] с улучшения [improvement], переслав всё городу [cityName]
@@ -1312,8 +1296,7 @@ Raze city = Разрушить город
 Stop razing city = Остановить разрушение города
 Buy for [amount] gold = Купить за [amount] золота
 Buy = Купить
- # Requires translation!
-Move unit out of city first = 
+Move unit out of city first = Переместить юнит из города первым
 Currently you have [amount] [stat]. = В данный момент у вас имеется [amount] [stat].
 Would you like to purchase [constructionName] for [buildingGoldCost] [stat]? = Вы хотите купить [constructionName] за [buildingGoldCost] [stat]?
 You are buying a religious unit in a city that doesn't follow the religion you founded ([yourReligion]). This means that the unit is tied to that foreign religion ([majorityReligion]) and will be less useful. = Вы покупаете религиозного юнита в городе, который не исповедует основанную вами религию ([yourReligion]). Это значит, что этот юнит будет связан с чужеземной религией ([majorityReligion]) и потому менее полезен.
@@ -1466,8 +1449,7 @@ Hurry Construction = Ускорить строительство
 Hurry Construction (+[productionAmount]⚙) = Ускорить строительство (+[productionAmount]⚙)
 Spread Religion = Распространить религию
 Spread [religionName] = Распространить [religionName]
- # Requires translation!
-[civName]'s [unitName] has converted [cityName] to [religionName] = 
+[civName]'s [unitName] has converted [cityName] to [religionName] = [unitName] цивилизации [civName] обратил [cityName] в [religionName]
 Remove Heresy = Устранить ересь
 Found a Religion = Основать религию
 Enhance a Religion = Укрепить религию
@@ -1624,8 +1606,7 @@ Your civilization may not annex this city. = Ваша цивилизация н�
 Puppet = Создать сателлита
 Puppeted cities do not increase your tech or policy cost. = Города-сателлиты не увеличивают стоимость технологий или общественных институтов.
 You have no control over the the production of puppeted cities. = Вы не имеете контроля над их производством.
- # Requires translation!
-Puppeted cities also generate 25% less Science and Culture. = 
+Puppeted cities also generate 25% less Science and Culture. = Города-сателлиты будут также генерировать на 25% меньше науки и культуры
 A puppeted city can be annexed at any time. = Город-сателлит можно аннексировать в любое время.
 Liberate (city returns to [originalOwner]) = Освободить (город возвращается к [originalOwner])
 Liberating a city returns it to its original owner, giving you a massive relationship boost with them! = Освобождение города возвращает его исходному владельцу и значительно улучшает отношения с ним!
@@ -1640,9 +1621,7 @@ Keep it = Оставить
 Remove your troops in our border immediately! = Уберите свои войска из наших границ немедленно!
 Sorry. = Простите.
 Never! = Никогда!
- # Requires translation!
-Those lands were not yours to take. This has not gone unnoticed. = 
-
+Those lands were not yours to take. This has not gone unnoticed. = Эти земли не были вашими чтобы их брать. Это не осталось незамеченным. 
 Offer Declaration of Friendship ([30] turns) = Предложить Декларацию дружбы ([30] ходов)
 My friend, shall we declare our friendship to the world? = Предлагаю объявить о нашей дружбе всему миру. Что скажете?
 Sign Declaration of Friendship ([30] turns) = Подписать Декларацию дружбы ([30] ходов)
@@ -1676,8 +1655,7 @@ Bonus stats for improvement = Бонусы за улучшение
 Buildings that consume this resource = Постройки, которые потребляют этот ресурс
 Buildings that provide this resource = Постройки, которые предоставляют этот ресурс
 Improvements that provide this resource = Улучшения, которые предоставляют этот ресурс
- # Requires translation!
-Buildings that require this resource improved near the city = 
+Buildings that require this resource improved near the city = Здания которые требуют улучшение этого ресурса около города
 Units that consume this resource = Юниты, которые потребляют этот ресурс
 Can be built on = Можно строить на клетках
 Cannot be built on = Невозможно построить на
@@ -1880,7 +1858,7 @@ Your spy lost the election in [cityStateName] to [civName]! = Ваш шпион 
 The election in [cityStateName] were rigged by [civName]! = Выборы в [cityStateName] были сфальсифицированы [civName]!
 Your spy lost the election in [cityName]! = Ваш шпион проиграл выборы в [cityName]!
 
-# City-Ctate Coups
+# City-State Coups
 Stage Coup = Этап переворота
 Your spy [spyName] successfully staged a coup in [cityName]! = Ваш шпион [spyName] успешно устроил переворот в [cityName]!
 A spy from [civName] successfully staged a coup in our former ally [cityStateName]! = Шпион из [civName] успешно устроил переворот в нашем бывшем союзнике [cityStateName]!
@@ -2096,8 +2074,7 @@ Provides a unique luxury = Даёт уникальный ресурс
 Military Units gifted from City-States start with [amount] XP = Военные юниты, подаренные городами-государствами, начинают с [amount] ОО
 Militaristic City-States grant units [amount] times as fast when you are at war with a common nation = Воинственные города-государства дарят юниты в [amount] раз(а) чаще, когда вы воюете против общего врага
 Gifts of Gold to City-States generate [relativeAmount]% more Influence = Подарки золотом городам-государствам приносят на [relativeAmount]% больше влияния
- # Requires translation!
-Can spend Gold to annex or puppet a City-State that has been your Ally for [amount] turns = 
+Can spend Gold to annex or puppet a City-State that has been your Ally for [amount] turns = Может тратить золото чтобы аннексировать или сделать сателлитом город-государство который был вашим союзником на протяжении [amount] ходов
 City-State territory always counts as friendly territory = Территория города-государства всегда считается дружественной
 Allied City-States will occasionally gift Great People = Союзные города-государства иногда будут дарить Великих людей
 [relativeAmount]% City-State Influence degradation = [relativeAmount]% к снижению влияния на город-государство
@@ -2141,10 +2118,8 @@ Sell [buildingFilter] buildings [cityFilter] = Продать здания [buil
 [relativeAmount]% Gold cost of acquiring tiles [cityFilter] = [relativeAmount]% к затратам золота на приобретение клеток [cityFilter]
 Each city founded increases culture cost of policies [relativeAmount]% less than normal = Каждый основанный город увеличивает затраты на принятие общественных институтов на [relativeAmount]% меньше чем обычно
 [relativeAmount]% Culture cost of adopting new Policies = [relativeAmount]% к затратам культуры на принятие новых общественных институтов
- # Requires translation!
-Each city founded increases Science cost of Technologies [relativeAmount]% less than normal = 
- # Requires translation!
-[relativeAmount]% Science cost of researching new Technologies = 
+Each city founded increases Science cost of Technologies [relativeAmount]% less than normal = Каждый основанный город увеличивает стоимость науки для технологий на [relativeAmount]% меньше чем обычно
+[relativeAmount]% Science cost of researching new Technologies = [relativeAmount]% стоимость науки для исследования новых технологий
 [stats] for every known Natural Wonder = [stats] за каждое известное чудо природы
 [stats] for discovering a Natural Wonder (bonus enhanced to [stats2] if first to discover it) = [stats] за открытие чуда природы (бонус увеличивается до [stats2], если он обнаружен первым)
 [relativeAmount]% Great Person generation [cityFilter] = [relativeAmount]% к скорости появления Великих людей [cityFilter]
@@ -2161,12 +2136,10 @@ Enables embarkation for land units = Позволяет сухопутным ю�
 Enables [mapUnitFilter] units to enter ocean tiles = Позволяет юнитам: [mapUnitFilter] выходить в океан
 Land units may cross [terrainName] tiles after the first [baseUnitFilter] is earned = Сухопутные юниты могут пересекать клетки [terrainName] после того, как появился первый [baseUnitFilter]
 Enemy [mapUnitFilter] units must spend [amount] extra movement points when inside your territory = Вражеские юниты: [mapUnitFilter] тратят дополнительные [amount] очков передвижения в пределах ваших земель
- # Requires translation!
-New [baseUnitFilter] units start with [amount] XP [cityFilter] = 
+New [baseUnitFilter] units start with [amount] XP [cityFilter] = Новый [baseUnitFilter] юниты начинают с [amount] ОО [cityFilter]
 All newly-trained [baseUnitFilter] units [cityFilter] receive the [promotion] promotion = Все [baseUnitFilter] юниты после прохождения обучения [cityFilter] получают повышение [promotion]
 [mapUnitFilter] Units adjacent to this city heal [amount] HP per turn when healing = [mapUnitFilter] юниты рядом с городом восстанавливают [amount] ОЗ за ход во время лечения
- # Requires translation!
-[relativeAmount]% XP required for promotions = 
+[relativeAmount]% XP required for promotions = [relativeAmount]% ОО требуется для повышений
 [relativeAmount]% City Strength from defensive buildings = [relativeAmount]% к мощи города от защитных сооружений
 [relativeAmount]% Strength for cities = [relativeAmount]% к мощи городов
 Costs [amount] [stockpiledResource] = Стоит [amount] [stockpiledResource]
@@ -2240,8 +2213,7 @@ Connects trade routes over water = Создает морские торговы�
 Automatically built in all cities where it is buildable = Автоматически строится во всех городах, где его можно построить
 Creates a [improvementName] improvement on a specific tile = Создает улучшение [improvementName] на определенной клетке
 Founds a new city = Может основать город
- # Requires translation!
-Founds a new puppet city = 
+Founds a new puppet city = Может основать город-сателлит
 Can instantly construct a [improvementFilter] improvement = Может мгновенно создать [improvementFilter]
 May create improvements on water resources = Может создавать улучшения на морских ресурсах
 Can build [improvementFilter/terrainFilter] improvements on tiles = Может создавать на клетках улучшения: [improvementFilter/terrainFilter]
@@ -2397,8 +2369,7 @@ Adjacent enemy units ending their turn take [amount] damage = Соседние �
 Great Improvement = Великое улучшение
 Provides a random bonus when entered = Предоставляет случайный бонус при заходе
 Unpillagable = Нельзя разграбить
- # Requires translation!
-Destroyed when pillaged = 
+Destroyed when pillaged = Уничтожается когда разграблен
 Irremovable = Нельзя удалить
 Will not be replaced by automated units = Не будет заменён автоматизированными юнитами
 Improves [resourceFilter] resource in this tile = Улучшает [resourceFilter] ресурс в этой клетке
@@ -2414,15 +2385,13 @@ when religion is enabled = когда религия включена
 when religion is disabled = когда религия отключена
 when espionage is enabled = когда шпионаж включен
 when espionage is disabled = когда шпионаж выключен
- # Requires translation!
-when nuclear weapons are enabled = 
+when nuclear weapons are enabled = когда включены ядерные оружия
 with [amount]% chance = с [amount]% шансом
 for [civFilter] Civilizations = для [civFilter] цивилизаций
 when at war = во время войны
 when not at war = в мирное время
 during a Golden Age = во время золотого века
- # Requires translation!
-when not in a Golden Age = 
+when not in a Golden Age = когда не в золотом веке
 during We Love The King Day = во время Дня любви к отчизне
 while the empire is happy = когда цивилизация счастлива
 when between [amount] and [amount2] Happiness = когда счастье между [amount] и [amount2]
@@ -2459,10 +2428,8 @@ when between [amount] and [amount2] [stat/resource] = когда между [amo
 in this city = в этом городе
 in [cityFilter] cities = в [cityFilter] городах
 in cities connected to the capital = в городах, соединенных со столицей
- # Requires translation!
-in cities with a [religionFilter] religion = 
- # Requires translation!
-in cities not following a [religionFilter] religion = 
+in cities with a [religionFilter] religion = в городах с [religionFilter] религией
+in cities not following a [religionFilter] religion = в городах, не исповедующих [religionFilter] религию
 in cities with a major religion = в городах с преобладающей религией
 in cities with an enhanced religion = с городах с укрепленной религией
 in cities following our religion = в городах, исповедующих нашу религию
@@ -2570,8 +2537,7 @@ upon constructing [buildingFilter] = при строительстве [building
 upon constructing [buildingFilter] [cityFilter] = при строительстве [buildingFilter] в [cityFilter]
 upon gaining a [baseUnitFilter] unit = при получении юнита [baseUnitFilter]
 upon turn end = в конце хода
- # Requires translation!
-upon turn start = 
+upon turn start = в начале хода
 upon founding a Pantheon = при основании пантеона
 upon founding a Religion = при основании религии
 upon enhancing a Religion = при укреплении религии
@@ -2587,8 +2553,7 @@ upon losing the [promotion] status = при потере статуса [promoti
 upon losing at least [amount] HP in a single attack = при потере как минимум [amount] ОЗ за одну атаку
 upon ending a turn in a [tileFilter] tile = при окончании хода на [tileFilter]
 upon discovering a [tileFilter] tile = при нахождении клетки [tileFilter]
- # Requires translation!
-upon entering a [tileFilter] tile = 
+upon entering a [tileFilter] tile = при вхождении на [tileFilter] клетку
 for [amount] turns = на [amount] ходов
 hidden from users = спрятано от пользователей
 Will not be chosen for new games = Не будет выбрано для новых игр
@@ -2735,10 +2700,8 @@ Bonus resource = Бонусный ресурс
 
 unimproved = неулучшенные
 improved = улучшенные
- # Requires translation!
-worked = 
- # Requires translation!
-pillaged = 
+worked = частично обработанные
+pillaged = разграбленные
 All Road = Все дороги
 
 ######### simpleTerrain ###########
@@ -2772,14 +2735,10 @@ Any = Любой
 
 ######### religionFilter ###########
 
- # Requires translation!
-major = 
- # Requires translation!
-enhanced = 
- # Requires translation!
-foreign = 
- # Requires translation!
-enemy = 
+major = основная
+enhanced = улучшенная
+foreign = чужая
+enemy = вражеская
 
 ######### Prophet Action Filters ###########
 
@@ -2909,10 +2868,8 @@ Open AutoPlay menu = Открыть меню авто-игры
 Empire Overview = Обзор империи
 Music Player = Музыкальный проигрыватель
 Developer Console = Консоль разработчика
- # Requires translation!
-Idle Prev = 
- # Requires translation!
-Idle Next = 
+Idle Prev = Незанятые пред.
+Idle Next = Незанятые след.
 Empire Overview Trades = Обзор торговли империи
 Empire Overview Units = Обзор юнитов империи
 Empire Overview Politics = Обзор институтов империи
@@ -6974,16 +6931,11 @@ Once a certain tech is researched, your land units can embark, allowing them to 
 Units are defenseless while embarked (cannot use modifiers), and have a fixed Defending Strength based on your tech Era, so be careful!\nRanged Units can't attack, Melee Units have a Strength penalty, and all have limited vision. = Юниты теряют обороноспособность когда погружены (не могут использовать модификаторы), и имеют фиксированную силу защиты в зависимости от вашей технологической эпохи, так что будьте осторожны!\nДальнобойные юниты не могут атаковать, юниты ближнего боя получают боевой штраф, и вместе имеют ограниченную дальность видимости.
 
 Idle Units = Незанятые юниты
- # Requires translation!
-Clicking 'Next unit' moves to the next idle unit in the queue (as listed in Overview -> Units). After issuing an order to an unit, if 'Auto Unit Cycle' in Options -> Gameplay is enabled, you will automatically select the next idle unit. = 
- # Requires translation!
-If you don't want to move a unit this turn, you can skip it by clicking 'Next unit' again, or command the unit to 'Skip turn'. = 
- # Requires translation!
-If you want to disable the 'Next unit' feature entirely, you can toggle it in Options -> Gameplay -> Check for idle units. = 
- # Requires translation!
-If you'd rather 'Next unit' cycle the units and not mark them as Done, you can change it in the Options -> Gameplay menu. = 
- # Requires translation!
-You can also cycle through the idle units using the left and right triangles on the Unit Table in the lower left of the screen. Or by default using the Cycle button next to the 'Next Unit' button. = 
+Clicking 'Next unit' moves to the next idle unit in the queue (as listed in Overview -> Units). After issuing an order to an unit, if 'Auto Unit Cycle' in Options -> Gameplay is enabled, you will automatically select the next idle unit. = Нажатие 'Следующий юнит' перемещает к следующему незанятому юниту в очереди (как показано в Обзор -> Юниты). После выдачи приказа юниту, если 'Автоматически переключаться между незанятыми юнитами' в Настройках -> Геймплей включено, вы будете автоматически перемещаться к следующему незанятому юниту.
+If you don't want to move a unit this turn, you can skip it by clicking 'Next unit' again, or command the unit to 'Skip turn'. = Если вы не хотите перемещать юнит на этом ходу, вы можете пропустить его нажав 'Следующий юнит' снова, или приказав юниту 'Пропустить ход'.
+If you want to disable the 'Next unit' feature entirely, you can toggle it in Options -> Gameplay -> Check for idle units. = Если вы хотите выключить возможность использовать 'Следующий юнит', вы можете отключить ее в Настройках -> Геймплей -> Проверять незанятые юниты
+If you'd rather 'Next unit' cycle the units and not mark them as Done, you can change it in the Options -> Gameplay menu. = Если вы хотите переключаться между следующими юнитами с помощью 'Следующий юнит' и не отмечать их приказы как выполненные, вы можете изменить это в Настройках -> Геймплей.
+You can also cycle through the idle units using the left and right triangles on the Unit Table in the lower left of the screen. Or by default using the Cycle button next to the 'Next Unit' button. = Вы также можете переключаться между незанятыми юнитами используя левые и правые треугольники используя таблицу юнитов в левой нижней части экрана. Или по умолчанию используя кнопку переключения рядом с кнопкой 'Следующий юнит'
 
 Contact Me = Связь с разработчиком
 Hi there! If you've played this far, you've probably seen that the game is currently incomplete.\n Unciv is meant to be open-source and free, forever.\n That means no ads or any other nonsense. = Привет! Если вы доиграли до этого момента, то наверно\nзаметили, что игра еще не закончена.\nUnciv задумана как бесплатная игра с открытым исходным\nкодом, поэтому в ней нет рекламы и прочей ерунды.
@@ -7051,8 +7003,7 @@ This is where you spend most of your time playing Unciv. See the world, control 
 ⑥: Unit Action Buttons - while a unit is selected its possible actions appear here. = ⑥: Кнопки "Действий юнита" - если вы выбрали юнита тут появятся его доступные действия.
 ⑦: The unit/city info pane - shows information about a selected unit or city. = ⑦: Инфо-панель юнита/города - показывает информацию о выбранном юните или городе.
 ⑧: The name (and unit icon) of the selected unit or city, with current health if wounded. Clicking a unit name or icon will open its civilopedia entry. = ⑧: Имя (и значок юнита) выбранного юнита или города, с текущим здоровьем, если повреждён. Нажатие на имя или значок юнита откроет его описание в цивилопедии.
- # Requires translation!
-⑨: The arrow buttons allow jumping to the next/previous idle unit. = 
+⑨: The arrow buttons allow jumping to the next/previous idle unit. = Кнопки со стрелками позволяют переключаться между следующим/предыдущим незанятым юнитом.
 ⑩: For a selected unit, its promotions appear here, and clicking leads to the promotions screen for that unit. = ⑩: Здесь появляются улучшения выбранного юнита, нажатие на них ведëт в экран улучшений этого юнита.
 ⑪: Remaining/per turn movement points, strength and experience / XP needed for promotion. For cities, you get its combat strength. = ⑪: Доступно/максимум очков передвижения, боевая мощь и опыт/опыт нужный для повышения. В случае города отображается его мощь.
 ⑫: This button closes the selected unit/city info pane. = ⑫: Эта кнопка закрывает инфо-панель выбранного юнита/города.


### PR DESCRIPTION
I had some free time on my hands, and I decided to 100% russian translation
1) Translated 100% missing translations to russian
2) Added missing 'our'='наш/наших'
3) Found some typos in comments (they are auto generated, so if you want to fix them, check my commit please)

P.S. I found on lines 7040/7041 menue typos. Is it intentional?
