### PR TITLE
Add pillage yield uniques

### DIFF
--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -58,7 +58,9 @@ enum class UniqueType(
     PercentProductionUnits("[relativeAmount]% Production when constructing [baseUnitFilter] units [cityFilter]", UniqueTarget.Global, UniqueTarget.FollowerBelief),
     PercentProductionWonders("[relativeAmount]% Production when constructing [buildingFilter] wonders [cityFilter]", UniqueTarget.Global, UniqueTarget.FollowerBelief),
     PercentProductionBuildingsInCapital("[relativeAmount]% Production towards any buildings that already exist in the Capital", UniqueTarget.Global, UniqueTarget.FollowerBelief),
-
+    PercentYieldFromPillaging("[relativeAmount]% Yield from pillaging tiles", UniqueTarget.Global),
+    PercentHealthFromPillaging("[relativeAmount]% Health from pillaging tiles", UniqueTarget.Global),
+    
     // endregion Stat providing uniques
 
     // region City-State related uniques

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsPillage.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsPillage.kt
@@ -10,6 +10,7 @@ import com.unciv.models.UnitActionType
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.stats.Stat
 import com.unciv.models.stats.Stats
+import com.unciv.ui.components.extensions.toPercent
 import com.unciv.ui.popups.ConfirmPopup
 import kotlin.random.Random
 
@@ -63,9 +64,8 @@ object UnitActionsPillage {
 
                 if (pillagingImprovement) { // only Improvements heal HP
                     var healAmount = 25f
-                    if (unit.civ.hasUnique(UniqueType.PercentHealthFromPillaging)) {
-                        for (unique in unit.civ.getMatchingUniques(UniqueType.PercentHealthFromPillaging))
-                            healAmount *= 1 + unique.params[0].toFloat() / 100
+                    for (unique in unit.civ.getMatchingUniques(UniqueType.PercentHealthFromPillaging)) {
+                            healAmount *= unique.params[0].toPercent()
                     }
                     unit.healBy(healAmount.toInt())
                 }
@@ -97,9 +97,8 @@ object UnitActionsPillage {
         }
 
         //Multiply according to global uniques
-        if (unit.civ.hasUnique(UniqueType.PercentYieldFromPillaging)) {
-            for (unique in unit.civ.getMatchingUniques(UniqueType.PercentYieldFromPillaging))
-                pillageYield *= 1 + unique.params[0].toFloat() / 100
+        for (unique in unit.civ.getMatchingUniques(UniqueType.PercentYieldFromPillaging)) {
+                pillageYield *= unique.params[0].toPercent()
         }
 
         // Please no notification when there's no loot


### PR DESCRIPTION
For Civ6 mod policy cards it's not very necessary, but for other mods it'd be useful if these can accept conditionals. How do I do so?