### PR TITLE
Minor refactor: Save/Load game loading image uses `LoadingImage`

### DIFF
--- a/core/src/com/unciv/ui/screens/savescreens/VerticalFileListScrollPane.kt
+++ b/core/src/com/unciv/ui/screens/savescreens/VerticalFileListScrollPane.kt
@@ -3,16 +3,14 @@ package com.unciv.ui.screens.savescreens
 import com.badlogic.gdx.Input
 import com.badlogic.gdx.files.FileHandle
 import com.badlogic.gdx.graphics.Color
-import com.badlogic.gdx.scenes.scene2d.actions.Actions
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton
-import com.badlogic.gdx.utils.Align
 import com.unciv.logic.files.UncivFiles
-import com.unciv.ui.images.ImageGetter
-import com.unciv.ui.components.widgets.AutoScrollPane
-import com.unciv.ui.screens.basescreen.BaseScreen
 import com.unciv.ui.components.input.keyShortcuts
 import com.unciv.ui.components.input.onClick
+import com.unciv.ui.components.widgets.AutoScrollPane
+import com.unciv.ui.components.widgets.LoadingImage
+import com.unciv.ui.screens.basescreen.BaseScreen
 import com.unciv.utils.Concurrency
 import com.unciv.utils.launchOnGLThread
 
@@ -56,12 +54,9 @@ class VerticalFileListScrollPane(
     fun update(files: Sequence<FileHandle>) {
         existingSavesTable.clear()
         previousSelection = null
-        val loadImage = ImageGetter.getImage("OtherIcons/Load")
-        loadImage.setSize(50f, 50f) // So the origin sets correctly
-        loadImage.setOrigin(Align.center)
-        val loadAnimation = Actions.forever(Actions.rotateBy(360f, 2f))
-        loadImage.addAction(loadAnimation)
-        existingSavesTable.add(loadImage).size(50f).center()
+        val loadingImage = LoadingImage(62f, LoadingImage.Style(innerSizeFactor = 0.8f))
+        existingSavesTable.add(loadingImage)
+        loadingImage.show()
 
         // Apparently, even just getting the list of saves can cause ANRs -
         // not sure how many saves these guys had but Google Play reports this to have happened hundreds of times
@@ -70,7 +65,7 @@ class VerticalFileListScrollPane(
             val saves = files.toList()
 
             launchOnGLThread {
-                loadAnimation.reset()
+                loadingImage.hide()
                 existingSavesTable.clear()
                 savesPerButton.clear()
                 for (saveGameFile in saves) {


### PR DESCRIPTION
I thought #13052 would be easy and set out - then noticed there's code duplication between VerticalFileListScrollPane and MapEditorFilesTable - where I then noticed VerticalFileListScrollPane did a loading image manually despite an existing Widget dedicated to the task.

I chose to use LoadingImage defaults, therefore it looks slightly different:

<details> 

Before:
![image](https://github.com/user-attachments/assets/e1c34473-cd51-46db-af58-2ab46b5f96eb)
rotating at 30 rpm
After
![image](https://github.com/user-attachments/assets/8eca8b49-293c-4695-ab5a-3706d315e940)
rotating at 15 rpm
</details>

... the exact same visuals as before would be possible like this:
```kotlin
        val loadingImage = LoadingImage(50f, LoadingImage.Style(
            loadingImageName = "OtherIcons/Load",
            rotationDuration = 2f
        ))
```

Need to pause, thus packaging as is.