### PR TITLE
Refactor the save/load file list "Widget"

### DIFF
--- a/core/src/com/unciv/ui/screens/savescreens/LoadGameScreen.kt
+++ b/core/src/com/unciv/ui/screens/savescreens/LoadGameScreen.kt
@@ -105,7 +105,7 @@ class LoadGameScreen : LoadOrSaveScreen() {
 
         setDefaultCloseAction()
         rightSideTable.initRightSideTable()
-        rightSideButton.onActivation { onLoadGame() }
+        rightSideButton.onActivation { onLoadGame(selectedSave) }
         rightSideButton.keyShortcuts.add(KeyCharAndCode.RETURN)
         rightSideButton.isVisible = false
         pickerPane.bottomTable.background = skinStrings.getUiBackground("LoadGameScreen/BottomTable", tintColor = skinStrings.skinConfig.clearColor)
@@ -126,8 +126,8 @@ class LoadGameScreen : LoadOrSaveScreen() {
         rightSideButton.enable()
     }
 
-    override fun doubleClickAction() {
-        onLoadGame()
+    override fun doubleClickAction(saveGameFile: FileHandle) {
+        onLoadGame(saveGameFile)
     }
 
     private fun Table.initRightSideTable() {
@@ -140,13 +140,13 @@ class LoadGameScreen : LoadOrSaveScreen() {
         add(showAutosavesCheckbox).row()
     }
 
-    private fun onLoadGame() {
-        if (selectedSave == null) return
+    private fun onLoadGame(saveGameFile: FileHandle?) {
+        if (saveGameFile == null) return
         val loadingPopup = LoadingPopup(this)
         Concurrency.run(loadGame) {
             try {
                 // This is what can lead to ANRs - reading the file and setting the transients, that's why this is in another thread
-                val loadedGame = game.files.loadGameFromFile(selectedSave!!)
+                val loadedGame = game.files.loadGameFromFile(saveGameFile)
                 game.loadGame(loadedGame, callFromLoadScreen = true)
             } catch (notAPlayer: UncivShowableException) {
                 launchOnGLThread {

--- a/core/src/com/unciv/ui/screens/savescreens/LoadOrSaveScreen.kt
+++ b/core/src/com/unciv/ui/screens/savescreens/LoadOrSaveScreen.kt
@@ -19,7 +19,6 @@ import com.unciv.ui.components.input.KeyCharAndCode
 import com.unciv.ui.components.input.keyShortcuts
 import com.unciv.ui.components.input.onActivation
 import com.unciv.ui.components.input.onChange
-import com.unciv.ui.components.input.onDoubleClick
 import com.unciv.ui.popups.ConfirmPopup
 import com.unciv.ui.screens.pickerscreens.PickerScreen
 import com.unciv.utils.Concurrency
@@ -32,7 +31,7 @@ abstract class LoadOrSaveScreen(
 ) : PickerScreen(disableScroll = true) {
 
     abstract fun onExistingSaveSelected(saveGameFile: FileHandle)
-    abstract fun doubleClickAction()
+    abstract fun doubleClickAction(saveGameFile: FileHandle)
 
     protected var selectedSave: FileHandle? = null
         private set
@@ -44,7 +43,7 @@ abstract class LoadOrSaveScreen(
 
     init {
         savesScrollPane.onChange(::selectExistingSave)
-        savesScrollPane.onDoubleClick { doubleClickAction() }
+        savesScrollPane.onDoubleClick(::doubleClickAction)
 
         rightSideTable.defaults().pad(5f, 10f)
 

--- a/core/src/com/unciv/ui/screens/savescreens/SaveGameScreen.kt
+++ b/core/src/com/unciv/ui/screens/savescreens/SaveGameScreen.kt
@@ -41,9 +41,10 @@ class SaveGameScreen(val gameInfo: GameInfo) : LoadOrSaveScreen("Current saves")
 
         rightSideButton.setText("Save game".tr())
         rightSideButton.onActivation {
-            if (game.files.getSave(gameNameTextField.text).exists())
-                doubleClickAction()
-            else saveGame()
+            if (selectedSave == null) return@onActivation
+            if (selectedSave!!.exists())
+                doubleClickAction(selectedSave!!)
+            else saveGame(selectedSave!!)
         }
         rightSideButton.keyShortcuts.add(KeyCharAndCode.RETURN)
         rightSideButton.enable()
@@ -116,10 +117,10 @@ class SaveGameScreen(val gameInfo: GameInfo) : LoadOrSaveScreen("Current saves")
         add(errorLabel).row()
     }
 
-    private fun saveGame() {
+    private fun saveGame(saveGameFile: FileHandle) {
         rightSideButton.setText(savingText.tr())
         Concurrency.runOnNonDaemonThreadPool("SaveGame") {
-            game.files.saveGame(gameInfo, gameNameTextField.text) {
+            game.files.saveGame(gameInfo, saveGameFile) {
                 launchOnGLThread {
                     if (it != null) ToastPopup("Could not save game!", this@SaveGameScreen)
                     else UncivGame.Current.popScreen()
@@ -132,12 +133,12 @@ class SaveGameScreen(val gameInfo: GameInfo) : LoadOrSaveScreen("Current saves")
         gameNameTextField.text = saveGameFile.name()
     }
 
-    override fun doubleClickAction() {
+    override fun doubleClickAction(saveGameFile: FileHandle) {
         ConfirmPopup(
             this,
             "Overwrite existing file?",
             "Overwrite",
-        ) { saveGame() }.open()
+        ) { saveGame(saveGameFile) }.open()
     }
 
 }

--- a/core/src/com/unciv/ui/screens/savescreens/VerticalFileListScrollPane.kt
+++ b/core/src/com/unciv/ui/screens/savescreens/VerticalFileListScrollPane.kt
@@ -1,145 +1,68 @@
 package com.unciv.ui.screens.savescreens
 
-import com.badlogic.gdx.Input
 import com.badlogic.gdx.files.FileHandle
-import com.badlogic.gdx.graphics.Color
-import com.badlogic.gdx.scenes.scene2d.ui.Table
-import com.badlogic.gdx.scenes.scene2d.ui.TextButton
+import com.badlogic.gdx.scenes.scene2d.Actor
 import com.unciv.logic.files.UncivFiles
-import com.unciv.ui.components.input.keyShortcuts
-import com.unciv.ui.components.input.onClick
 import com.unciv.ui.components.widgets.AutoScrollPane
-import com.unciv.ui.components.widgets.LoadingImage
-import com.unciv.ui.screens.basescreen.BaseScreen
-import com.unciv.utils.Concurrency
-import com.unciv.utils.launchOnGLThread
 
 //todo key auto-repeat for navigation keys?
 
 /** A widget holding TextButtons vertically in a Table contained in a ScrollPane, with methods to
  *  hold file names and FileHandle's in those buttons. Used to display existing saves in the Load and Save game dialogs.
- *
- *  @param existingSavesTable exists here for coder convenience. No need to touch.
  */
-class VerticalFileListScrollPane(
-    private val existingSavesTable: Table = Table()
-) : AutoScrollPane(existingSavesTable) {
-
-    private val savesPerButton = mutableMapOf<TextButton, FileHandle>()
-
-    private var previousSelection: TextButton? = null
+class VerticalFileListScrollPane : AutoScrollPane(null) {
+    private val existingSavesTable = ExistingSavesTable()
+    init {
+        setActor(existingSavesTable)
+    }
 
     private var onChangeListener: ((FileHandle) -> Unit)? = null
-
-    init {
-        keyShortcuts.add(Input.Keys.UP) { onArrowKey(-1) }
-        keyShortcuts.add(Input.Keys.DOWN) { onArrowKey(1) }
-        keyShortcuts.add(Input.Keys.PAGE_UP) { onPageKey(-1) }
-        keyShortcuts.add(Input.Keys.PAGE_DOWN) { onPageKey(1) }
-        keyShortcuts.add(Input.Keys.HOME) { onHomeEndKey(0) }
-        keyShortcuts.add(Input.Keys.END) { onHomeEndKey(1) }
-    }
+    private var onDoubleClickListener: ((FileHandle) -> Unit)? = null
 
     fun onChange(action: (FileHandle) -> Unit) {
         onChangeListener = action
     }
+    fun onDoubleClick(action: (FileHandle) -> Unit) {
+        onDoubleClickListener = action
+    }
 
     /** repopulate with existing saved games */
     fun updateSaveGames(files: UncivFiles, showAutosaves: Boolean) {
-        update(files.getSaves(showAutosaves)
+        existingSavesTable.update(files.getSaves(showAutosaves)
             .sortedByDescending { it.lastModified() })
     }
 
-    /** repopulate from a FileHandle Sequence - for other sources than saved games */
-    fun update(files: Sequence<FileHandle>) {
-        existingSavesTable.clear()
-        previousSelection = null
-        val loadingImage = LoadingImage(62f, LoadingImage.Style(innerSizeFactor = 0.8f))
-        existingSavesTable.add(loadingImage)
-        loadingImage.show()
-
-        // Apparently, even just getting the list of saves can cause ANRs -
-        // not sure how many saves these guys had but Google Play reports this to have happened hundreds of times
-        Concurrency.run("GetSaves") {
-            // .toList() materializes the result of the sequence
-            val saves = files.toList()
-
-            launchOnGLThread {
-                loadingImage.hide()
-                existingSavesTable.clear()
-                savesPerButton.clear()
-                for (saveGameFile in saves) {
-                    val textButton = TextButton(saveGameFile.name(), BaseScreen.skin)
-                    savesPerButton[textButton] = saveGameFile
-                    textButton.onClick {
-                        selectExistingSave(textButton)
-                    }
-                    existingSavesTable.add(textButton).pad(5f).row()
-                }
-            }
-        }
-    }
-
-    private fun selectExistingSave(textButton: TextButton) {
-        previousSelection?.color = Color.WHITE
-        textButton.color = Color.GREEN
-        previousSelection = textButton
-
-        val saveGameFile = savesPerButton[textButton] ?: return
-        onChangeListener?.invoke(saveGameFile)
-    }
-
-    //region Keyboard scrolling
-
-    // Helpers to simplify Scroll positioning - ScrollPane.scrollY goes down, normal Gdx Y goes up
-    // These functions all operate in the scrollY 'coordinate system'
-    private fun Table.getVerticalSpan(button: TextButton): ClosedFloatingPointRange<Float> {
-        val invertedY = height - button.y
-        return (invertedY - button.height)..invertedY
-    }
     private fun getVerticalSpan() = scrollY..(scrollY + height)
-    private fun Table.getButtonAt(y: Float) = cells[getRow(height - y)].actor as TextButton
 
-    private fun onArrowKey(direction: Int) {
-        if (existingSavesTable.rows == 0) return
-        val rowIndex = if (previousSelection == null)
-            if (direction == 1) -1 else 0
-        else existingSavesTable.getCell(previousSelection).row
-        val newRow = (rowIndex + direction).let {
-            if (it < 0) existingSavesTable.rows - 1
-            else if (it >= existingSavesTable.rows) 0
-            else it
+    private inner class ExistingSavesTable : VerticalFileListTable() {
+        override fun onSelect(selection: FileHandle) {
+            onChangeListener?.invoke(selection)
         }
-        val button = existingSavesTable.cells[newRow].actor as TextButton
-        selectExistingSave(button)
 
-        // Make ScrollPane follow the selection
-        val buttonSpan = existingSavesTable.getVerticalSpan(button)
-        val scrollSpan = getVerticalSpan()
-        if (buttonSpan.start < scrollSpan.start)
-            scrollY = buttonSpan.start
-        if (buttonSpan.endInclusive > scrollSpan.endInclusive)
-            scrollY = buttonSpan.endInclusive - height
-    }
+        override fun onDoubleClick(selection: FileHandle) {
+            onDoubleClickListener?.invoke(selection)
+        }
 
-    private fun onPageKey(direction: Int) {
-        scrollY += (height - 60f) * direction  // ScrollPane does the clamping to 0..maxY
-        val buttonHeight = previousSelection?.height ?: return
-        val buttonSpan = existingSavesTable.getVerticalSpan(previousSelection!!)
-        val scrollSpan = getVerticalSpan()
-        val newButtonY = if (buttonSpan.start < scrollSpan.start)
-            scrollSpan.start + buttonHeight
-        else if (buttonSpan.endInclusive > scrollSpan.endInclusive)
-            scrollSpan.endInclusive - buttonHeight
-        else return
-        selectExistingSave(existingSavesTable.getButtonAt(newButtonY))
-    }
+        override fun onScrollTo(actor: Actor) {
+            // Make ScrollPane follow the selection
+            val buttonSpan = existingSavesTable.getVerticalSpan(actor)
+            val scrollSpan = getVerticalSpan()
+            if (buttonSpan.start < scrollSpan.start)
+                scrollY = buttonSpan.start
+            if (buttonSpan.endInclusive > scrollSpan.endInclusive)
+                scrollY = buttonSpan.endInclusive - this@VerticalFileListScrollPane.height
+        }
 
-    private fun onHomeEndKey(direction: Int) {
-        scrollY = direction * maxY
-        if (existingSavesTable.rows == 0) return
-        val row =  (existingSavesTable.rows - 1) * direction
-        selectExistingSave(existingSavesTable.cells[row].actor as TextButton)
+        override fun onScrollPage(direction: Int, actor: Actor?): Float? {
+            scrollY += (this@VerticalFileListScrollPane.height - 60f) * direction  // ScrollPane does the clamping to 0..maxY
+            val actorHeight = actor?.height ?: return null
+            val actorSpan = existingSavesTable.getVerticalSpan(actor)
+            val scrollSpan = getVerticalSpan()
+            return if (actorSpan.start < scrollSpan.start)
+                scrollSpan.start + actorHeight
+            else if (actorSpan.endInclusive > scrollSpan.endInclusive)
+                scrollSpan.endInclusive - actorHeight
+            else null
+        }
     }
-    //endregion
 }

--- a/core/src/com/unciv/ui/screens/savescreens/VerticalFileListTable.kt
+++ b/core/src/com/unciv/ui/screens/savescreens/VerticalFileListTable.kt
@@ -1,0 +1,131 @@
+package com.unciv.ui.screens.savescreens
+
+import com.badlogic.gdx.Input
+import com.badlogic.gdx.files.FileHandle
+import com.badlogic.gdx.graphics.Color
+import com.badlogic.gdx.scenes.scene2d.Actor
+import com.badlogic.gdx.scenes.scene2d.ui.Table
+import com.badlogic.gdx.scenes.scene2d.ui.TextButton
+import com.unciv.ui.components.input.keyShortcuts
+import com.unciv.ui.components.input.onClick
+import com.unciv.ui.components.input.onDoubleClick
+import com.unciv.ui.components.widgets.LoadingImage
+import com.unciv.ui.screens.basescreen.BaseScreen
+import com.unciv.utils.Concurrency
+import com.unciv.utils.launchOnGLThread
+
+/** A widget holding TextButtons vertically, with methods to hold file names and FileHandle's
+ *  in those buttons. Used to display existing saves in the Load and Save game dialogs.
+ *
+ *  Usage: subclass and override at least one of [onSelect] or [onDoubleClick].
+ *  If placed in a vertically scrolling container, override [onScrollTo] and [onScrollPage] as well.
+ */
+abstract class VerticalFileListTable : Table() {
+    private val savesPerButton = mutableMapOf<TextButton, FileHandle>()
+
+    private var selectedButton: TextButton? = null
+    private val selectedFile: FileHandle
+        get() = savesPerButton[selectedButton] ?: throw IllegalStateException("VerticalFileListTable state out of sync")
+
+    /** Called to tell host when a file is selected */
+    open fun onSelect(selection: FileHandle) {}
+    /** Called to tell host when a file is by Double-Click ([onSelect] is called first) */
+    open fun onDoubleClick(selection: FileHandle) {}
+    /** Called to tell host to scroll [actor] into View */
+    open fun onScrollTo(actor: Actor) {}
+    /** Called to tell host to scroll one page in [direction].
+     *  @param actor Can optionally be checked whether it's still in view to decide on a return value.
+     *  @return `null` when [actor] is null or selection should not move.
+     *          A value should be an inverted y coordinate into this Widget and will be used to select a new entry. 
+     */
+    open fun onScrollPage(direction: Int, actor: Actor?): Float? = null
+
+    init {
+        keyShortcuts.add(Input.Keys.UP) { onArrowKey(-1) }
+        keyShortcuts.add(Input.Keys.DOWN) { onArrowKey(1) }
+        keyShortcuts.add(Input.Keys.PAGE_UP) { onPageKey(-1) }
+        keyShortcuts.add(Input.Keys.PAGE_DOWN) { onPageKey(1) }
+        keyShortcuts.add(Input.Keys.HOME) { onHomeEndKey(0) }
+        keyShortcuts.add(Input.Keys.END) { onHomeEndKey(1) }
+    }
+
+    /** repopulate from a FileHandle Sequence - for other sources than saved games */
+    fun update(files: Sequence<FileHandle>) {
+        clear()
+        selectedButton = null
+        savesPerButton.clear()
+
+        val loadingImage = LoadingImage(62f, LoadingImage.Style(innerSizeFactor = 0.8f))
+        add(loadingImage)
+        loadingImage.show()
+
+        // Apparently, even just getting the list of saves can cause ANRs -
+        // not sure how many saves these guys had but Google Play reports this to have happened hundreds of times
+        Concurrency.run("GetSaves") {
+            // .toList() materializes the result of the sequence
+            val saves = files.toList()
+
+            launchOnGLThread {
+                loadingImage.hide()
+                clear()
+                for (saveGameFile in saves) {
+                    val textButton = TextButton(saveGameFile.name(), BaseScreen.skin)
+                    savesPerButton[textButton] = saveGameFile
+                    textButton.onClick {
+                        selectEntry(textButton)
+                    }
+                    textButton.onDoubleClick {
+                        selectEntry(textButton)
+                        onDoubleClick(selectedFile)
+                    }
+                    add(textButton).pad(5f).row()
+                }
+            }
+        }
+    }
+
+    private fun selectEntry(textButton: TextButton) {
+        selectedButton?.color = Color.WHITE
+        textButton.color = Color.GREEN
+        selectedButton = textButton
+        onScrollTo(textButton)
+        onSelect(selectedFile)
+    }
+
+    // Helpers to simplify Scroll positioning - ScrollPane.scrollY goes down, normal Gdx Y goes up
+    // These functions all operate in the scrollY 'coordinate system'
+    protected fun getVerticalSpan(button: Actor): ClosedFloatingPointRange<Float> {
+        val invertedY = height - button.y
+        return (invertedY - button.height)..invertedY
+    }
+    private fun getButtonAt(y: Float) = cells[getRow(height - y)].actor as TextButton
+
+    //region Keyboard scrolling
+    private fun onArrowKey(direction: Int) {
+        if (rows == 0) return
+        val rowIndex = when {
+            selectedButton != null -> getCell(selectedButton).row
+            direction == 1 -> -1
+            else -> 0
+        }
+        val newRow = (rowIndex + direction).let {
+            if (it < 0) rows - 1
+            else if (it >= rows) 0
+            else it
+        }
+        val button = cells[newRow].actor as TextButton
+        selectEntry(button)
+    }
+
+    private fun onPageKey(direction: Int) {
+        val newButtonY = onScrollPage(direction, selectedButton) ?: return
+        selectEntry(getButtonAt(newButtonY))
+    }
+
+    private fun onHomeEndKey(direction: Int) {
+        if (rows == 0) return
+        val row = (rows - 1) * direction
+        selectEntry(cells[row].actor as TextButton)
+    }
+    //endregion
+}


### PR DESCRIPTION
... to prepare to remove the code duplication in `MapEditorFilesTable`. Should be entirely transparent - I hope.

Can't test Android though, somehow this setup is hosed, all knowledge about modules is gone (and thus the run config invalid) and stays so no matter how I mix Invalidate Caches, Repair IDE and Gradle Sync...

Mainly
* Separate the Table and FileHandle/Buttons part out of VerticalFileListScrollPane
* DoubleClick handling inside instead of on the Container
* More consistent callback scheme up in and into the actual PickerScreen layer
* I opted for a different callback scheme for the new Widget, though - as overridable methods - felt cleaner at the time. A few more source lines, maye a tad more efficient bytecode, but IMO slightly clearer to see where things from the hosting class are pulled in. Can do the lambda form instead if you insist.
