### PR TITLE
Improve concurrency of listing existing saves

### DIFF
--- a/core/src/com/unciv/logic/files/UncivFiles.kt
+++ b/core/src/com/unciv/logic/files/UncivFiles.kt
@@ -112,10 +112,8 @@ class UncivFiles(
 
     fun getSaves(autoSaves: Boolean = true): Sequence<FileHandle> {
         val saves = getSaves(SAVE_FILES_FOLDER)
-        val filteredSaves = if (autoSaves) { saves } else { saves.filter { !it.name().startsWith(
-            AUTOSAVE_FILE_NAME
-        ) }}
-        return filteredSaves
+        if (autoSaves) return saves
+        return saves.filter { !it.name().startsWith(AUTOSAVE_FILE_NAME) }
     }
 
     private fun getSaves(saveFolder: String): Sequence<FileHandle> {
@@ -157,7 +155,7 @@ class UncivFiles(
     }
 
     //endregion
-    
+
     //region Saving
 
     fun saveGame(game: GameInfo, gameName: String, saveCompletionCallback: (Exception?) -> Unit = { if (it != null) throw it }): FileHandle {
@@ -289,7 +287,7 @@ class UncivFiles(
 
 
     //endregion
-    
+
     //region Settings
 
     private fun getGeneralSettingsFile(): FileHandle {
@@ -322,7 +320,7 @@ class UncivFiles(
     }
 
     //endregion
-    
+
     //region Scenarios
     val scenarioFolder = "scenarios"
     fun getScenarioFiles() = sequence {
@@ -335,7 +333,7 @@ class UncivFiles(
         }
     }
     //endregion
-    
+
     //region Mod caching
     fun saveModCache(modDataList: List<ModUIData>){
         val file = getLocalFile(MOD_LIST_CACHE_FILE_NAME)
@@ -475,7 +473,7 @@ class Autosaves(val files: UncivFiles) {
     fun autoSave(gameInfo: GameInfo, nextTurn: Boolean = false) {
         // get GameSettings to check the maxAutosavesStored in the autoSave function
         val settings = files.getGeneralSettings()
-        
+
         try {
             files.saveGame(gameInfo, AUTOSAVE_FILE_NAME)
         } catch (oom: OutOfMemoryError) {


### PR DESCRIPTION
Closes #13127 
... and a SequenceBuilder seems slightly less efficient than a certain Sequence constructor ...
Plus a separate lint commit for the same file.

I've tested on desktop when exactly the list() runs using breakpoints, and yes, the list() is not triggered until [the toList() in the load/save screen's `Conrurrency.run`](https://github.com/yairm210/Unciv/blob/d5515ede9cc272a5948d6d634b617ac2a7c490c8/core/src/com/unciv/ui/screens/savescreens/VerticalFileListScrollPane.kt#L65).