### PR TITLE
Refactor Countables into an enum with better validation, tests, and auto documentation

### DIFF
--- a/core/src/com/unciv/models/ruleset/unique/Countables.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Countables.kt
@@ -1,51 +1,168 @@
 package com.unciv.models.ruleset.unique
 
+import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.stats.Stat
 import com.unciv.models.translations.equalsPlaceholderText
 import com.unciv.models.translations.getPlaceholderParameters
 
-object Countables {
+/**
+ *  Prototype for each new [Countables] instance, to ensure a baseline.
+ *
+ *  Notes:
+ *  - Each instance ***must*** implement _either_ overload of [validate] and indicate which one via [validateWithRuleset].
+ *  - Override [getKnownValuesForAutocomplete] only if a sensible number of suggestions is obvious.
+ */
+interface ICountable {
+    fun validate(parameterText: String): Boolean = false
+    val validateWithRuleset: Boolean
+        get() = false
+    fun validate(parameterText: String, ruleset: Ruleset): Boolean = false
+    fun eval(parameterText: String, stateForConditionals: StateForConditionals): Int?
+    fun getKnownValuesForAutocomplete(ruleset: Ruleset): Set<String> = emptySet()
+}
 
-    fun getCountableAmount(countable: String, stateForConditionals: StateForConditionals): Int? {
-        if (countable.toIntOrNull() != null) return countable.toInt()
+/**
+ *  Contains all knowledge about how to check and evaluate [countable Unique parameters][UniqueParameterType.Countable].
+ *
+ *  Expansion instructions:
+ *  - A new simple "variable" needs to implement only [simpleName] and [eval].
+ *  - A new "variable" using placeholder(s) needs to implement [validate] and [eval].
+ *    Using [simpleName] inside [validate] as the examples do is only done for readability.
+ *    Implement [getKnownValuesForAutocomplete] only when a meaningful, not too large set of suggestions is obvious.
+ *  - A new countable that draws from an existing enum or set of RulesetObjects should work along the lines of the [Stats] or [TileResources] examples.
+ *  - When implementing a formula language for Countables, create a new object in a separate file with the actual
+ *    implementation, then a new instance here that delegates all its methods to that object. And delete these lines.
+ */
+enum class Countables(protected val simpleName: String = "") : ICountable {
+    Integer {
+        override fun validate(parameterText: String) = parameterText.toIntOrNull() != null
+        override fun eval(parameterText: String, stateForConditionals: StateForConditionals) = parameterText.toIntOrNull()
+    },
 
-        val relevantStat = Stat.safeValueOf(countable)
-        if (relevantStat != null) return stateForConditionals.getStatAmount(relevantStat)
+    Turns("turns") {
+        override fun eval(parameterText: String, stateForConditionals: StateForConditionals) =
+            stateForConditionals.gameInfo?.turns
+    },
+    Year("year") {
+        override fun eval(parameterText: String, stateForConditionals: StateForConditionals) =
+            stateForConditionals.gameInfo?.run { getYear(turns) }
+    },
+    Cities("Cities") {
+        override fun eval(parameterText: String, stateForConditionals: StateForConditionals) =
+            stateForConditionals.civInfo?.cities?.size
+    },
+    Units("Units") {
+        override fun eval(parameterText: String, stateForConditionals: StateForConditionals) =
+            stateForConditionals.civInfo?.units?.getCivUnitsSize()
+    },
 
-        val gameInfo = stateForConditionals.gameInfo ?: return null
+    Stats {
+        override fun validate(parameterText: String) = Stat.isStat(parameterText)
+        override fun eval(parameterText: String, stateForConditionals: StateForConditionals): Int? {
+            val relevantStat = Stat.safeValueOf(parameterText) ?: return null
+            return stateForConditionals.getStatAmount(relevantStat)
+        }
+        override fun getKnownValuesForAutocomplete(ruleset: Ruleset) = Stat.names()
+    },
 
-        if (countable == "turns") return gameInfo.turns
-        if (countable == "year") return gameInfo.getYear(gameInfo.turns)
+    PolicyBranches("Completed Policy branches") {
+        override fun eval(parameterText: String, stateForConditionals: StateForConditionals) =
+            stateForConditionals.civInfo?.getCompletedPolicyBranchesCount()
+    },
 
-        val civInfo = stateForConditionals.relevantCiv ?: return null
+    FilteredCities("[] Cities") {
+        override fun validate(parameterText: String) = parameterText.equalsPlaceholderText(simpleName)
+        override fun eval(parameterText: String, stateForConditionals: StateForConditionals): Int? {
+            val filter = parameterText.getPlaceholderParameters()[0]
+            val cities = stateForConditionals.civInfo?.cities ?: return null
+            return cities.count { it.matchesFilter(filter) }
+        }
+    },
 
-        if (countable == "Cities") return civInfo.cities.size
+    FilteredUnits("[] Units") {
+        override fun validate(parameterText: String) = parameterText.equalsPlaceholderText(simpleName)
+        override fun eval(parameterText: String, stateForConditionals: StateForConditionals): Int? {
+            val filter = parameterText.getPlaceholderParameters()[0]
+            val unitManager = stateForConditionals.civInfo?.units ?: return null
+            return unitManager.getCivUnits().count { it.matchesFilter(filter) }
+        }
+        override fun getKnownValuesForAutocomplete(ruleset: Ruleset): Set<String> =
+            (ruleset.unitTypes.keys + ruleset.units.keys).mapTo(mutableSetOf()) { "[$it] Units" }
+    },
 
-        val placeholderParameters = countable.getPlaceholderParameters()
-        if (countable.equalsPlaceholderText("[] Cities"))
-            return civInfo.cities.count { it.matchesFilter(placeholderParameters[0]) }
+    FilteredBuildings("[] Buildings") {
+        override fun validate(parameterText: String) = parameterText.equalsPlaceholderText(simpleName)
+        override fun eval(parameterText: String, stateForConditionals: StateForConditionals): Int? {
+            val filter = parameterText.getPlaceholderParameters()[0]
+            val cities = stateForConditionals.civInfo?.cities ?: return null
+            return cities.sumOf { city ->
+                city.cityConstructions.getBuiltBuildings().count { it.matchesFilter(filter) }
+            }
+        }
+        override fun getKnownValuesForAutocomplete(ruleset: Ruleset) = setOf<String>()
+    },
 
-        if (countable == "Units") return civInfo.units.getCivUnitsSize()
-        if (countable.equalsPlaceholderText("[] Units"))
-            return civInfo.units.getCivUnits().count { it.matchesFilter(placeholderParameters[0]) }
+    RemainingCivs("Remaining [] Civilizations") {
+        override fun validate(parameterText: String) = parameterText.equalsPlaceholderText(simpleName)
+        override fun eval(parameterText: String, stateForConditionals: StateForConditionals): Int? {
+            val filter = parameterText.getPlaceholderParameters()[0]
+            val civilizations = stateForConditionals.gameInfo?.civilizations ?: return null
+            return civilizations.count { it.isAlive() && it.matchesFilter(filter) }
+        }
+        override fun getKnownValuesForAutocomplete(ruleset: Ruleset) = setOf<String>()
+    },
 
-        if (countable.equalsPlaceholderText("[] Buildings"))
-            return civInfo.cities.sumOf { it.cityConstructions.getBuiltBuildings()
-                .count { it.matchesFilter(placeholderParameters[0]) } }
-        
-        if (countable.equalsPlaceholderText("Remaining [] Civilizations"))
-            return gameInfo.civilizations.filter { !it.isDefeated() }
-                .count { it.matchesFilter(placeholderParameters[0]) }
-        
-        if (countable.equalsPlaceholderText("Completed Policy branches"))
-            return civInfo.getCompletedPolicyBranchesCount()
-        
-        if (countable.equalsPlaceholderText("Owned [] Tiles")) 
-            return civInfo.cities.sumOf { it.getTiles().count { it.matchesFilter(placeholderParameters[0]) } }
+    OwnedTiles("Owned [] Tiles") {
+        override fun validate(parameterText: String) = parameterText.equalsPlaceholderText(simpleName)
+        override fun eval(parameterText: String, stateForConditionals: StateForConditionals): Int? {
+            val filter = parameterText.getPlaceholderParameters()[0]
+            val cities = stateForConditionals.civInfo?.cities ?: return null
+            return cities.sumOf { city ->
+                city.getTiles().count { it.matchesFilter(filter) }
+            }
+        }
+        override fun getKnownValuesForAutocomplete(ruleset: Ruleset) = setOf<String>()
+    },
 
-        if (gameInfo.ruleset.tileResources.containsKey(countable))
-            return stateForConditionals.getResourceAmount(countable)
+    TileResources {
+        override val validateWithRuleset = true
+        override fun validate(parameterText: String, ruleset: Ruleset) = parameterText in ruleset.tileResources
+        override fun eval(parameterText: String, stateForConditionals: StateForConditionals) =
+            stateForConditionals.getResourceAmount(parameterText)
+        override fun getKnownValuesForAutocomplete(ruleset: Ruleset) = ruleset.tileResources.keys
+    }
+    ;
 
-        return null
+    // Leave these in place only for the really simple cases
+    override fun validate(parameterText: String) = parameterText == simpleName
+    override fun getKnownValuesForAutocomplete(ruleset: Ruleset) = setOf(simpleName)
+
+    companion object {
+        fun getCountableAmount(parameterText: String, stateForConditionals: StateForConditionals): Int? {
+            val ruleset = stateForConditionals.gameInfo?.ruleset
+            for (countable in Countables.entries) {
+                if (countable.validateWithRuleset)
+                    if (ruleset == null || !countable.validate(parameterText, ruleset)) continue
+                else
+                    if (!countable.validate(parameterText)) continue
+                val potentialResult = countable.eval(parameterText, stateForConditionals)
+                if (potentialResult != null) return potentialResult
+            }
+            return null
+        }
+
+        fun isKnownValue(parameterText: String, ruleset: Ruleset) =
+            Countables.entries.any {
+                if (it.validateWithRuleset) it.validate(parameterText, ruleset) else it.validate(parameterText)
+            }
+
+        // This will "leak memory" if game rulesets are changed over application lifetime, but it's a simple way to cache
+        private val autocompleteCache = mutableMapOf<Ruleset, Set<String>>()
+        fun getKnownValuesForAutocomplete(ruleset: Ruleset) =
+            autocompleteCache.getOrPut(ruleset) {
+                Countables.entries.fold(setOf()) { acc, next ->
+                    acc + next.getKnownValuesForAutocomplete(ruleset)
+                }
+            }
     }
 }

--- a/core/src/com/unciv/models/ruleset/unique/Countables.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Countables.kt
@@ -3,22 +3,26 @@ package com.unciv.models.ruleset.unique
 import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.stats.Stat
 import com.unciv.models.translations.equalsPlaceholderText
+import com.unciv.models.translations.fillPlaceholders
 import com.unciv.models.translations.getPlaceholderParameters
 
 /**
  *  Prototype for each new [Countables] instance, to ensure a baseline.
  *
  *  Notes:
- *  - Each instance ***must*** implement _either_ overload of [validate] and indicate which one via [validateWithRuleset].
+ *  - Each instance ***must*** implement _either_ overload of [matches] and indicate which one via [matchesWithRuleset].
+ *  - [matches] is used to look up which instance implements a given string, [getErrorSeverity] is responsible for validating placeholders.
  *  - Override [getKnownValuesForAutocomplete] only if a sensible number of suggestions is obvious.
  */
 interface ICountable {
-    fun validate(parameterText: String): Boolean = false
-    val validateWithRuleset: Boolean
+    fun matches(parameterText: String): Boolean = false
+    val matchesWithRuleset: Boolean
         get() = false
-    fun validate(parameterText: String, ruleset: Ruleset): Boolean = false
+    fun matches(parameterText: String, ruleset: Ruleset): Boolean = false
     fun eval(parameterText: String, stateForConditionals: StateForConditionals): Int?
     fun getKnownValuesForAutocomplete(ruleset: Ruleset): Set<String> = emptySet()
+    fun getErrorSeverity(parameterText: String, ruleset: Ruleset): UniqueType.UniqueParameterErrorSeverity?
+    fun getDeprecationAnnotation(): Deprecated?
 }
 
 /**
@@ -26,16 +30,17 @@ interface ICountable {
  *
  *  Expansion instructions:
  *  - A new simple "variable" needs to implement only [simpleName] and [eval].
- *  - A new "variable" using placeholder(s) needs to implement [validate] and [eval].
- *    Using [simpleName] inside [validate] as the examples do is only done for readability.
- *    Implement [getKnownValuesForAutocomplete] only when a meaningful, not too large set of suggestions is obvious.
+ *  - A new "variable" _using placeholder(s)_ needs to implement [matches] and [eval].
+ *    - Using [simpleName] inside [validate] as the examples do is only done for readability.
+ *    - Implement [getErrorSeverity] in most cases, use [UniqueParameterType] to validate each placeholder content.
+ *    - Implement [getKnownValuesForAutocomplete] only when a meaningful, not too large set of suggestions is obvious.
  *  - A new countable that draws from an existing enum or set of RulesetObjects should work along the lines of the [Stats] or [TileResources] examples.
  *  - When implementing a formula language for Countables, create a new object in a separate file with the actual
  *    implementation, then a new instance here that delegates all its methods to that object. And delete these lines.
  */
 enum class Countables(protected val simpleName: String = "") : ICountable {
     Integer {
-        override fun validate(parameterText: String) = parameterText.toIntOrNull() != null
+        override fun matches(parameterText: String) = parameterText.toIntOrNull() != null
         override fun eval(parameterText: String, stateForConditionals: StateForConditionals) = parameterText.toIntOrNull()
     },
 
@@ -57,9 +62,12 @@ enum class Countables(protected val simpleName: String = "") : ICountable {
     },
 
     Stats {
-        override fun validate(parameterText: String) = Stat.isStat(parameterText)
+        override fun matches(parameterText: String) = Stat.isStat(parameterText)
         override fun eval(parameterText: String, stateForConditionals: StateForConditionals): Int? {
             val relevantStat = Stat.safeValueOf(parameterText) ?: return null
+            // This one isn't covered by City.getStatReserve or Civilization.getStatReserve but should be available here
+            if (relevantStat == Stat.Happiness)
+                return stateForConditionals.civInfo?.getHappiness()
             return stateForConditionals.getStatAmount(relevantStat)
         }
         override fun getKnownValuesForAutocomplete(ruleset: Ruleset) = Stat.names()
@@ -71,27 +79,31 @@ enum class Countables(protected val simpleName: String = "") : ICountable {
     },
 
     FilteredCities("[] Cities") {
-        override fun validate(parameterText: String) = parameterText.equalsPlaceholderText(simpleName)
+        override fun matches(parameterText: String) = parameterText.equalsPlaceholderText(simpleName)
         override fun eval(parameterText: String, stateForConditionals: StateForConditionals): Int? {
             val filter = parameterText.getPlaceholderParameters()[0]
             val cities = stateForConditionals.civInfo?.cities ?: return null
             return cities.count { it.matchesFilter(filter) }
         }
+        override fun getErrorSeverity(parameterText: String, ruleset: Ruleset): UniqueType.UniqueParameterErrorSeverity? =
+            UniqueParameterType.CityFilter.getErrorSeverity(parameterText.getPlaceholderParameters().first(), ruleset)
     },
 
     FilteredUnits("[] Units") {
-        override fun validate(parameterText: String) = parameterText.equalsPlaceholderText(simpleName)
+        override fun matches(parameterText: String) = parameterText.equalsPlaceholderText(simpleName)
         override fun eval(parameterText: String, stateForConditionals: StateForConditionals): Int? {
             val filter = parameterText.getPlaceholderParameters()[0]
             val unitManager = stateForConditionals.civInfo?.units ?: return null
             return unitManager.getCivUnits().count { it.matchesFilter(filter) }
         }
+        override fun getErrorSeverity(parameterText: String, ruleset: Ruleset): UniqueType.UniqueParameterErrorSeverity? =
+            UniqueParameterType.MapUnitFilter.getErrorSeverity(parameterText.getPlaceholderParameters().first(), ruleset)
         override fun getKnownValuesForAutocomplete(ruleset: Ruleset): Set<String> =
             (ruleset.unitTypes.keys + ruleset.units.keys).mapTo(mutableSetOf()) { "[$it] Units" }
     },
 
     FilteredBuildings("[] Buildings") {
-        override fun validate(parameterText: String) = parameterText.equalsPlaceholderText(simpleName)
+        override fun matches(parameterText: String) = parameterText.equalsPlaceholderText(simpleName)
         override fun eval(parameterText: String, stateForConditionals: StateForConditionals): Int? {
             val filter = parameterText.getPlaceholderParameters()[0]
             val cities = stateForConditionals.civInfo?.cities ?: return null
@@ -99,21 +111,25 @@ enum class Countables(protected val simpleName: String = "") : ICountable {
                 city.cityConstructions.getBuiltBuildings().count { it.matchesFilter(filter) }
             }
         }
+        override fun getErrorSeverity(parameterText: String, ruleset: Ruleset): UniqueType.UniqueParameterErrorSeverity? =
+            UniqueParameterType.BuildingFilter.getErrorSeverity(parameterText.getPlaceholderParameters().first(), ruleset)
         override fun getKnownValuesForAutocomplete(ruleset: Ruleset) = setOf<String>()
     },
 
     RemainingCivs("Remaining [] Civilizations") {
-        override fun validate(parameterText: String) = parameterText.equalsPlaceholderText(simpleName)
+        override fun matches(parameterText: String) = parameterText.equalsPlaceholderText(simpleName)
         override fun eval(parameterText: String, stateForConditionals: StateForConditionals): Int? {
             val filter = parameterText.getPlaceholderParameters()[0]
             val civilizations = stateForConditionals.gameInfo?.civilizations ?: return null
             return civilizations.count { it.isAlive() && it.matchesFilter(filter) }
         }
+        override fun getErrorSeverity(parameterText: String, ruleset: Ruleset): UniqueType.UniqueParameterErrorSeverity? =
+            UniqueParameterType.CivFilter.getErrorSeverity(parameterText.getPlaceholderParameters().first(), ruleset)
         override fun getKnownValuesForAutocomplete(ruleset: Ruleset) = setOf<String>()
     },
 
     OwnedTiles("Owned [] Tiles") {
-        override fun validate(parameterText: String) = parameterText.equalsPlaceholderText(simpleName)
+        override fun matches(parameterText: String) = parameterText.equalsPlaceholderText(simpleName)
         override fun eval(parameterText: String, stateForConditionals: StateForConditionals): Int? {
             val filter = parameterText.getPlaceholderParameters()[0]
             val cities = stateForConditionals.civInfo?.cities ?: return null
@@ -125,26 +141,39 @@ enum class Countables(protected val simpleName: String = "") : ICountable {
     },
 
     TileResources {
-        override val validateWithRuleset = true
-        override fun validate(parameterText: String, ruleset: Ruleset) = parameterText in ruleset.tileResources
+        override val matchesWithRuleset = true
+        override fun matches(parameterText: String, ruleset: Ruleset) = parameterText in ruleset.tileResources
         override fun eval(parameterText: String, stateForConditionals: StateForConditionals) =
             stateForConditionals.getResourceAmount(parameterText)
         override fun getKnownValuesForAutocomplete(ruleset: Ruleset) = ruleset.tileResources.keys
+    },
+
+    @Deprecated("was never actually supported", ReplaceWith("Remaining [City-State] Civilizations"), DeprecationLevel.ERROR)
+    CityStates("City-States") {
+        override fun eval(parameterText: String, stateForConditionals: StateForConditionals): Int? {
+            val civilizations = stateForConditionals.gameInfo?.civilizations ?: return null
+            return civilizations.count { it.isAlive() && it.isCityState }
+        }
     }
     ;
 
     // Leave these in place only for the really simple cases
-    override fun validate(parameterText: String) = parameterText == simpleName
+    override fun matches(parameterText: String) = parameterText == simpleName
     override fun getKnownValuesForAutocomplete(ruleset: Ruleset) = setOf(simpleName)
+
+    override fun getErrorSeverity(parameterText: String, ruleset: Ruleset): UniqueType.UniqueParameterErrorSeverity? = null
+
+    override fun getDeprecationAnnotation(): Deprecated? = declaringJavaClass.getField(name).getAnnotation(Deprecated::class.java)
 
     companion object {
         fun getCountableAmount(parameterText: String, stateForConditionals: StateForConditionals): Int? {
             val ruleset = stateForConditionals.gameInfo?.ruleset
             for (countable in Countables.entries) {
-                if (countable.validateWithRuleset)
-                    if (ruleset == null || !countable.validate(parameterText, ruleset)) continue
-                else
-                    if (!countable.validate(parameterText)) continue
+                if (countable.matchesWithRuleset) {
+                    if (ruleset == null || !countable.matches(parameterText, ruleset)) continue
+                } else {
+                    if (!countable.matches(parameterText)) continue
+                }
                 val potentialResult = countable.eval(parameterText, stateForConditionals)
                 if (potentialResult != null) return potentialResult
             }
@@ -153,7 +182,7 @@ enum class Countables(protected val simpleName: String = "") : ICountable {
 
         fun isKnownValue(parameterText: String, ruleset: Ruleset) =
             Countables.entries.any {
-                if (it.validateWithRuleset) it.validate(parameterText, ruleset) else it.validate(parameterText)
+                if (it.matchesWithRuleset) it.matches(parameterText, ruleset) else it.matches(parameterText)
             }
 
         // This will "leak memory" if game rulesets are changed over application lifetime, but it's a simple way to cache
@@ -164,5 +193,12 @@ enum class Countables(protected val simpleName: String = "") : ICountable {
                     acc + next.getKnownValuesForAutocomplete(ruleset)
                 }
             }
+
+        fun getErrorSeverity(parameterText: String, ruleset: Ruleset): UniqueType.UniqueParameterErrorSeverity? {
+            val countable = Countables.entries.firstOrNull {
+                if (it.matchesWithRuleset) it.matches(parameterText, ruleset) else it.matches(parameterText)
+            } ?: return UniqueType.UniqueParameterErrorSeverity.RulesetInvariant
+            return countable.getErrorSeverity(parameterText, ruleset)
+        }
     }
 }

--- a/core/src/com/unciv/models/ruleset/unique/Countables.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Countables.kt
@@ -168,7 +168,8 @@ enum class Countables(
         override fun getKnownValuesForAutocomplete(ruleset: Ruleset) = ruleset.tileResources.keys
     },
 
-    @Deprecated("was never actually supported", ReplaceWith("Remaining [City-State] Civilizations"), DeprecationLevel.ERROR)
+    /** Please leave this one in, it is tested against in [com.unciv.uniques.CountableTests.testRulesetValidation] */
+    @Deprecated("because it was never actually supported", ReplaceWith("Remaining [City-State] Civilizations"), DeprecationLevel.ERROR)
     CityStates("City-States", shortDocumentation = "counts all undefeated city-states") {
         override fun eval(parameterText: String, stateForConditionals: StateForConditionals): Int? {
             val civilizations = stateForConditionals.gameInfo?.civilizations ?: return null

--- a/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
@@ -71,29 +71,11 @@ enum class UniqueParameterType(
     },
 
     Countable("countable", "1000", "This indicates a number or a numeric variable") {
-        // todo add more countables
-        override val staticKnownValues = setOf(
-            "year", "turns", "Cities", "Units", "Completed Policy branches"
-        )
+        override fun isKnownValue(parameterText: String, ruleset: Ruleset) =
+            Countables.isKnownValue(parameterText, ruleset)
 
-        override fun isKnownValue(parameterText: String, ruleset: Ruleset) = when {
-            parameterText.toIntOrNull() != null -> true
-            parameterText.equalsPlaceholderText("[] Buildings") -> true
-            parameterText.equalsPlaceholderText("[] Cities") -> true
-            parameterText.equalsPlaceholderText("[] Units") -> true
-            parameterText.equalsPlaceholderText("Remaining [] Civilizations") -> true
-            parameterText.equalsPlaceholderText("Owned [] Tiles") -> true
-            else -> super.isKnownValue(parameterText, ruleset)
-        }
-
-        override fun getKnownValuesForAutocomplete(ruleset: Ruleset): Set<String> =
-            staticKnownValues +
-                Stat.entries.map { it.name } +
-                ruleset.tileResources.keys +
-                ruleset.units.keys +
-                ruleset.unitTypes.keys.map { "[$it] Units" } +
-                ruleset.buildings.keys.map { "[$it] Buildings" } +
-                ruleset.buildings.keys
+        override fun getKnownValuesForAutocomplete(ruleset: Ruleset) =
+            Countables.getKnownValuesForAutocomplete(ruleset)
     },
 
     // todo potentially remove if OneTimeRevealSpecificMapTiles changes

--- a/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
@@ -13,7 +13,6 @@ import com.unciv.models.ruleset.validation.Suppression
 import com.unciv.models.stats.Stat
 import com.unciv.models.stats.SubStat
 import com.unciv.models.translations.TranslationFileWriter
-import com.unciv.models.translations.equalsPlaceholderText
 
 // 'region' names beginning with an underscore are used here for a prettier "Structure window" - they go in front of the rest.
 
@@ -76,6 +75,10 @@ enum class UniqueParameterType(
 
         override fun getKnownValuesForAutocomplete(ruleset: Ruleset) =
             Countables.getKnownValuesForAutocomplete(ruleset)
+
+        override fun getErrorSeverity(parameterText: String, ruleset: Ruleset): UniqueType.UniqueParameterErrorSeverity? {
+            return Countables.getErrorSeverity(parameterText, ruleset)
+        }
     },
 
     // todo potentially remove if OneTimeRevealSpecificMapTiles changes

--- a/core/src/com/unciv/models/ruleset/validation/RulesetErrorList.kt
+++ b/core/src/com/unciv/models/ruleset/validation/RulesetErrorList.kt
@@ -13,7 +13,7 @@ enum class RulesetErrorSeverity(val color: Color) {
     OK(Color.GREEN),
     WarningOptionsOnly(Color.YELLOW),
     Warning(Color.YELLOW),
-    ErrorOptionsOnly(Color.RED),
+    ErrorOptionsOnly(Color.ORANGE),
     Error(Color.RED),
 }
 

--- a/core/src/com/unciv/models/ruleset/validation/RulesetErrorList.kt
+++ b/core/src/com/unciv/models/ruleset/validation/RulesetErrorList.kt
@@ -13,6 +13,7 @@ enum class RulesetErrorSeverity(val color: Color) {
     OK(Color.GREEN),
     WarningOptionsOnly(Color.YELLOW),
     Warning(Color.YELLOW),
+    ErrorOptionsOnly(Color.RED),
     Error(Color.RED),
 }
 

--- a/core/src/com/unciv/models/ruleset/validation/UniqueValidator.kt
+++ b/core/src/com/unciv/models/ruleset/validation/UniqueValidator.kt
@@ -223,7 +223,7 @@ class UniqueValidator(val ruleset: Ruleset) {
                         if (deprecationAnnotation.replaceWith.expression != "") " replace with \"${replacementUniqueText}\"" else ""
             val severity = if (deprecationAnnotation.level == DeprecationLevel.WARNING)
                 RulesetErrorSeverity.WarningOptionsOnly // Not user-visible
-            else RulesetErrorSeverity.Warning // User visible
+            else RulesetErrorSeverity.ErrorOptionsOnly // User visible
 
             rulesetErrors.add(deprecationText, severity, uniqueContainer, unique)
         }

--- a/docs/Modders/Unique-parameters.md
+++ b/docs/Modders/Unique-parameters.md
@@ -339,16 +339,25 @@ Indicates *something that can be counted*, used both for comparisons and for mul
 
 Allowed values:
 
-- `year`, `turns`
-- `Cities`, `[cityFilter] Cities`
-- `City-States` - counts all undefeated city-states
-- `Units`, `[mapUnitFilter] Units`
-- `[buildingFilter] Buildings`
-- `Remaining [civFilter] Civilizations`
-- `Owned [tileFilter] Tiles`
-- Stat name - gets the stat *reserve*, not the amount per turn (can be city stats or civilization stats, depending on where the unique is used)
-- Resource name (can be city stats or civilization stats, depending on where the unique is used)
+[//]: # (Countables automatically generated BEGIN)
+-   Integer constant - any positive or negative integer number
+-   `turns` - Number of turns played
+    (Always starts at zero irrespective of game speed or start era)
+-   `year` - The current year
+    (Depends on game speed or start era, negative for years BC)
+-   `Cities` - The number of cities the relevant Civilization owns
+-   `Units` - The number of units the relevant Civilization owns
+-   Stat name (`Production`, `Food`, `Gold`, `Science`, `Culture`, `Happiness` or `Faith`)
+    gets the stat *reserve*, not the amount per turn (can be city stats or civilization stats, depending on where the unique is used)
+-   `Completed Policy branches`
+-   `[cityFilter] Cities`
+-   `[mapUnitFilter] Units`
+-   `[buildingFilter] Buildings`
+-   `Remaining [civFilter] Civilizations`
+-   `Owned [tileFilter] Tiles`
+-   Resource name - From [TileResources.json](3-Map-related-JSON-files.md#tileresourcesjson)
+    (can be city stats or civilization stats, depending on where the unique is used)
+    For example: If a unique is placed on a building, then the retrieved resources will be of the city. If placed on a policy, they will be of the civilization.
+    This can make a difference for e.g. local resources, which are counted per city.
 
-For example: If a unique is placed on a building, then the retrieved resources will be of the city. If placed on a policy, they will be of the civilization.
-
-This can make a difference for e.g. local resources, which are counted per city.
+[//]: # (Countables automatically generated END)

--- a/tests/src/com/unciv/testing/TestGame.kt
+++ b/tests/src/com/unciv/testing/TestGame.kt
@@ -32,7 +32,7 @@ import com.unciv.models.ruleset.unit.BaseUnit
 import com.unciv.models.ruleset.unit.Promotion
 import com.unciv.models.ruleset.unit.UnitType
 
-class TestGame {
+class TestGame(overrideRuleset: (() -> Ruleset)? = null) {
 
     private var objectsCreated = 0
     val ruleset: Ruleset
@@ -50,7 +50,7 @@ class TestGame {
 
         // Create a new ruleset we can easily edit, and set the important variables of gameInfo
         RulesetCache.loadRulesets(noMods = true)
-        ruleset = RulesetCache[BaseRuleset.Civ_V_GnK.fullName]!!
+        ruleset = overrideRuleset?.invoke() ?: RulesetCache[BaseRuleset.Civ_V_GnK.fullName]!!
         gameInfo.ruleset = ruleset
         gameInfo.difficulty = "Prince"
         gameInfo.difficultyObject = ruleset.difficulties["Prince"]!!

--- a/tests/src/com/unciv/uniques/CountableTests.kt
+++ b/tests/src/com/unciv/uniques/CountableTests.kt
@@ -1,0 +1,96 @@
+package com.unciv.uniques
+
+import com.unciv.models.ruleset.unique.Countables
+import com.unciv.models.ruleset.unique.StateForConditionals
+import com.unciv.models.ruleset.unique.Unique
+import com.unciv.models.ruleset.unique.UniqueTriggerActivation
+import com.unciv.models.stats.Stat
+import com.unciv.testing.GdxTestRunner
+import com.unciv.testing.TestGame
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+// TODO better coverage:
+//      - Each modifier using UniqueParameterType.Countable
+//      - Each actual Countables enum instance
+
+@RunWith(GdxTestRunner::class)
+class CountableTests {
+    private val game = TestGame().apply { makeHexagonalMap(3) }
+    private val civInfo = game.addCiv()
+    private val city = game.addCity(civInfo, game.tileMap[2,0])
+
+    @Test
+    fun testPerCountableForGlobalAndLocalResources() {
+        // one coal provided locally
+        val providesCoal = game.createBuilding("Provides [1] [Coal]")
+        city.cityConstructions.addBuilding(providesCoal)
+        // one globally
+        UniqueTriggerActivation.triggerUnique(Unique("Provides [1] [Coal] <for [2] turns>"), civInfo)
+        val providesFaithPerCoal = game.createBuilding("[+1 Faith] [in this city] <for every [Coal]>")
+        city.cityConstructions.addBuilding(providesFaithPerCoal)
+        assertEquals(2f, city.cityStats.currentCityStats.faith)
+    }
+
+    @Test
+    fun testStatsCountables() {
+        fun verifyStats(state: StateForConditionals) {
+            for (stat in Stat.entries) {
+                val countableResult = Countables.Stats.eval(stat.name, state)
+                val expected = if (stat == Stat.Happiness) civInfo.getHappiness()
+                else state.getStatAmount(stat)
+                assertEquals("Testing $stat countable:", countableResult, expected)
+            }
+        }
+
+        val providesStats =
+            game.createBuilding("[+1 Gold, +2 Food, +3 Production, +4 Happiness, +3 Science, +2 Culture, +1 Faith] [in this city] <when number of [Cities] is equal to [1]>")
+        city.cityConstructions.addBuilding(providesStats)
+        verifyStats(StateForConditionals(civInfo, city))
+
+        val city2 = game.addCity(civInfo, game.tileMap[-2,0])
+        val providesStats2 =
+            game.createBuilding("[+3 Gold, +2 Food, +1 Production, -4 Happiness, +1 Science, +2 Culture, +3 Faith] [in this city] <when number of [Cities] is more than [1]>")
+        city2.cityConstructions.addBuilding(providesStats2)
+        verifyStats(StateForConditionals(civInfo, city2))
+    }
+
+    @Test
+    fun testOwnedTilesCountable() {
+        UniqueTriggerActivation.triggerUnique(Unique("Turn this tile into a [Coast] tile"), civInfo, tile = game.tileMap[-3,0])
+        UniqueTriggerActivation.triggerUnique(Unique("Turn this tile into a [Coast] tile"), civInfo, tile = game.tileMap[3,0])
+
+        val city2 = game.addCity(civInfo, game.tileMap[-2,0], initialPopulation = 9)
+        val tests = listOf(
+            "Owned [All] Tiles" to 14,
+            "Owned [worked] Tiles" to 8,
+            "Owned [Coastal] Tiles" to 6,
+            "Owned [Coast] Tiles" to 2,
+            "Owned [Land] Tiles" to 12,
+            "Owned [Farm] Tiles" to 0,
+        )
+        for ((test, expected) in tests) {
+            val actual = Countables.getCountableAmount(test, StateForConditionals(civInfo))
+            assertEquals("Testing `$test` countable:", expected, actual)
+        }
+    }
+
+    @Test
+    fun testFilteredCitiesCountable() {
+        UniqueTriggerActivation.triggerUnique(Unique("Turn this tile into a [Coast] tile"), civInfo, tile = game.tileMap[-3,0])
+
+        val city2 = game.addCity(civInfo, game.tileMap[-2,0], initialPopulation = 9)
+        city2.isPuppet = true
+        val tests = listOf(
+            "[Capital] Cities" to 1,
+            "[Puppeted] Cities" to 1,
+            "[Coastal] Cities" to 1,
+            "[Your] Cities" to 2,
+        )
+        for ((test, expected) in tests) {
+            val actual = Countables.getCountableAmount(test, StateForConditionals(civInfo))
+            assertEquals("Testing `$test` countable:", expected, actual)
+        }
+    }
+}

--- a/tests/src/com/unciv/uniques/ResourceTests.kt
+++ b/tests/src/com/unciv/uniques/ResourceTests.kt
@@ -129,18 +129,6 @@ class ResourceTests {
         Assert.assertTrue(civInfo.getCivResourcesByName()["Coal"] == 4)
     }
 
-    @Test
-    fun testPerCountableForGlobalAndLocalResources() {
-        // one coal provided locally
-        val consumesCoal = game.createBuilding("Provides [1] [Coal]")
-        city.cityConstructions.addBuilding(consumesCoal)
-        // one globally
-        UniqueTriggerActivation.triggerUnique(Unique("Provides [1] [Coal] <for [2] turns>"), civInfo)
-        val providesFaithPerCoal = game.createBuilding("[+1 Faith] [in this city] <for every [Coal]>")
-        city.cityConstructions.addBuilding(providesFaithPerCoal)
-        assertEquals(2f, city.cityStats.currentCityStats.faith)
-    }
-
 
     // Resource tests
     @Test


### PR DESCRIPTION
See commit history.

Needs more testing. Any alive mods heavily using `countable` to test with? @AutumnPizazz 's stuff likely... Other than that, several turns with G&K and minor mods run normally.

- Fixes https://github.com/yairm210/Unciv/pull/13137#issuecomment-2781586714 - again almost involuntarily, before reading that mail
- Fixes #13154 on the fly because I'm lazy. The new Countables deprecation check follows the same pattern anyway, so separating that out would permit an inconsistent version.
- Fixes #13160 'cuz the new unit test was delivering the wrong results.
- Fixes bad info in the documentation... automatically from now on. The literal `City-States` was not implemented, do I implemented it to deprecate it right away then test that the deprecation is caught in validation.