### PR TITLE
Improve save file name and errors handling

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -768,6 +768,7 @@ Load from custom location =
 Save to custom location = 
 Could not save game to custom location! = 
 '[saveFileName]' copied to clipboard! = 
+Current game copied to clipboard! = 
 Could not save game to clipboard! = 
 Download missing mods = 
 Missing mods are downloaded successfully. = 

--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -758,6 +758,7 @@ Saved at =
 Saving... = 
 Overwrite existing file? = 
 Overwrite = 
+The file is marked read-only. = 
 It looks like your saved game can't be loaded! = 
 If you could copy your game data ("Copy saved game to clipboard" -  = 
   paste into an email to yairm210@hotmail.com) = 

--- a/core/src/com/unciv/logic/files/FileChooser.kt
+++ b/core/src/com/unciv/logic/files/FileChooser.kt
@@ -130,9 +130,7 @@ open class FileChooser(
             result = textField.text
             enableOKButton()
         }
-        fileNameInput.setTextFieldFilter { _, char ->
-            char != File.separatorChar
-        }
+        fileNameInput.textFieldFilter = UncivFiles.fileNameTextFieldFilter()
 
         if (title != null) {
             addGoodSizedLabel(title).colspan(2).center().row()
@@ -283,7 +281,7 @@ open class FileChooser(
         fun getSaveEnable(): Boolean {
             if (currentDir?.exists() != true) return false
             if (allowFolderSelect) return true
-            return result?.run { isEmpty() || startsWith(' ') || endsWith(' ') } == false
+            return result != null && UncivFiles.isValidFileName(result!!)
         }
         okButton.isEnabled = if (fileNameEnabled) getSaveEnable() else getLoadEnable()
     }

--- a/core/src/com/unciv/logic/files/UncivFiles.kt
+++ b/core/src/com/unciv/logic/files/UncivFiles.kt
@@ -3,6 +3,7 @@ package com.unciv.logic.files
 import com.badlogic.gdx.Files
 import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.files.FileHandle
+import com.badlogic.gdx.scenes.scene2d.ui.TextField
 import com.badlogic.gdx.utils.GdxRuntimeException
 import com.badlogic.gdx.utils.JsonReader
 import com.badlogic.gdx.utils.SerializationException
@@ -443,6 +444,25 @@ class UncivFiles(
             return Gzip.zip(json().toJson(game))
         }
 
+        private val charsForbiddenInFileNames = setOf('\\', '/', ':')
+        private val _fileNameTextFieldFilter = TextField.TextFieldFilter { _, char ->
+            char !in charsForbiddenInFileNames
+        }
+        /** Check characters typed into a file name TextField: Disallows both Unix and Windows path separators, plus the
+         *  ['NTFS alternate streams'](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/b134f29a-6278-4f3f-904f-5e58a713d2c5)
+         *  indicator, irrespective of platform, in case players wish to exchange files cross-platform.
+         *  @see isValidFileName
+         *  @return A `TextFieldFilter` appropriate for `TextField`s used to enter a file name for saving
+         */
+        fun fileNameTextFieldFilter() = _fileNameTextFieldFilter
+
+        /** Determines whether a filename is acceptable.
+         *  - Forbids trailing blanks because Windows has trouble with them.
+         *  - Forbids leading blanks because they might confuse users (neither Windows nor Linux have noteworthy problems with them).
+         *  - Does **not** deal with problems that can be recognized inspecting a single character, use [fileNameTextFieldFilter] for that.
+         *  @param  fileName A base file name, not a path.
+         */
+        fun isValidFileName(fileName: String) = fileName.isNotEmpty() && !fileName.endsWith(' ') && !fileName.startsWith(' ')
     }
 }
 

--- a/core/src/com/unciv/ui/screens/multiplayerscreens/MultiplayerScreen.kt
+++ b/core/src/com/unciv/ui/screens/multiplayerscreens/MultiplayerScreen.kt
@@ -4,6 +4,7 @@ import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton
 import com.unciv.Constants
+import com.unciv.logic.files.UncivFiles
 import com.unciv.logic.multiplayer.MultiplayerGame
 import com.unciv.logic.multiplayer.storage.MultiplayerAuthException
 import com.unciv.models.ruleset.RulesetCache
@@ -290,7 +291,7 @@ class MultiplayerScreen : PickerScreen() {
             Popup(this).apply {
                 val textField = UncivTextField("Game name", selectedGame!!.name)
                 // slashes in mp names are interpreted as directory separators, so we don't allow them
-                textField.setTextFieldFilter { _, c -> c != '/' && c != '\\' }
+                textField.textFieldFilter = UncivFiles.fileNameTextFieldFilter()
                 add(textField).width(stageToShowOn.width / 2).row()
                 val saveButton = "Save".toTextButton()
 

--- a/core/src/com/unciv/ui/screens/savescreens/LoadOrSaveScreen.kt
+++ b/core/src/com/unciv/ui/screens/savescreens/LoadOrSaveScreen.kt
@@ -1,11 +1,18 @@
 package com.unciv.ui.screens.savescreens
 
 import com.badlogic.gdx.files.FileHandle
+import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.scenes.scene2d.ui.CheckBox
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton
+import com.badlogic.gdx.utils.Align
+import com.badlogic.gdx.utils.GdxRuntimeException
+import com.badlogic.gdx.utils.SerializationException
 import com.unciv.Constants
 import com.unciv.UncivGame
+import com.unciv.logic.UncivShowableException
+import com.unciv.logic.github.Github
+import com.unciv.logic.github.Github.folderNameToRepoName
 import com.unciv.models.translations.tr
 import com.unciv.ui.components.UncivTooltip.Companion.addTooltip
 import com.unciv.ui.components.extensions.UncivDateFormat.formatDate
@@ -23,8 +30,13 @@ import com.unciv.ui.components.input.onDoubleClick
 import com.unciv.ui.popups.ConfirmPopup
 import com.unciv.ui.screens.pickerscreens.PickerScreen
 import com.unciv.utils.Concurrency
+import com.unciv.utils.Log
 import com.unciv.utils.launchOnGLThread
+import java.io.FileNotFoundException
+import java.nio.file.attribute.DosFileAttributes
 import java.util.Date
+import kotlin.io.path.Path
+import kotlin.io.path.readAttributes
 
 
 abstract class LoadOrSaveScreen(
@@ -41,6 +53,11 @@ abstract class LoadOrSaveScreen(
     protected val rightSideTable = Table()
     protected val deleteSaveButton = "Delete save".toTextButton(skin.get("negative", TextButton.TextButtonStyle::class.java))
     protected val showAutosavesCheckbox = CheckBox("Show autosaves".tr(), skin)
+    protected val errorLabel = "".toLabel(Color.RED, alignment = Align.center)
+
+    companion object : Helpers {
+        internal const val saveToClipboardErrorMessage = "Could not save game to clipboard!"
+    }
 
     init {
         savesScrollPane.onChange(::selectExistingSave)
@@ -103,6 +120,7 @@ abstract class LoadOrSaveScreen(
     }
 
     private fun selectExistingSave(saveGameFile: FileHandle) {
+        errorLabel.isVisible = false
         deleteSaveButton.enable()
 
         selectedSave = saveGameFile
@@ -133,6 +151,85 @@ abstract class LoadOrSaveScreen(
             launchOnGLThread {
                 descriptionLabel.setText(textToSet.tr())
             }
+        }
+    }
+
+    /** Show appropriate message for an exception and log the severe cases
+     *  @return isUserFixable */
+    protected fun handleException(ex: Exception, primaryText: String, file: FileHandle? = null): Boolean {
+        val (errorText, isUserFixable) = getLoadExceptionMessage(ex, primaryText, file)
+        if (!isUserFixable)
+            Log.error(primaryText, ex)
+        errorLabel.setText(errorText)
+        errorLabel.isVisible = true
+        return isUserFixable
+    }
+
+    interface Helpers {
+        /** Gets a translated exception message to show to the user.
+         * @param file Optional, used for detection of local read-only files, only relevant for write operations on Windows desktops.
+         * @return The first returned value is the message, the second is signifying if the user can likely fix this problem. */
+        fun getLoadExceptionMessage(ex: Throwable, primaryText: String = "Could not load game!", file: FileHandle? = null): Pair<String, Boolean> {
+            val errorText = StringBuilder(primaryText.tr())
+            errorText.appendLine()
+            var cause = ex
+            while (cause.cause != null && cause is GdxRuntimeException) cause = cause.cause!!
+
+            fun FileHandle.isReadOnly(): Boolean {
+                try {
+                    val attr = Path(file().absolutePath).readAttributes<DosFileAttributes>()
+                    return attr.isReadOnly
+                } catch (_: Throwable) { return false }
+            }
+
+            val isUserFixable = when (cause) {
+                is UncivShowableException -> {
+                    errorText.append(ex.localizedMessage)
+                    true
+                }
+                is SerializationException -> {
+                    errorText.append("The file data seems to be corrupted.".tr())
+                    false
+                }
+                is FileNotFoundException -> {
+                    // This is thrown both for chmod/ACL denials and for writing to a file with the read-only attribute set
+                    // On Windows, `message` is already (and illegally) partially localized.
+                    val localizedMessage = UncivGame.Current.getSystemErrorMessage(5)
+                    val isPermissionDenied = cause.message?.run {
+                        contains("Permission denied") || (localizedMessage != null && contains(localizedMessage))
+                    } == true
+                    if (isPermissionDenied) {
+                        if (file != null && file.isReadOnly())
+                            errorText.append("The file is marked read-only.".tr())
+                        else
+                            errorText.append("You do not have sufficient permissions to access the file.".tr())
+                    }
+                    isPermissionDenied
+                }
+                else -> {
+                    errorText.append("Unhandled problem, [${ex::class.simpleName} ${ex.stackTraceToString()}]".tr())
+                    false
+                }
+            }
+            return Pair(errorText.toString(), isUserFixable)
+        }
+
+        fun loadMissingMods(missingMods: Iterable<String>, onModDownloaded:(String)->Unit, onCompleted:()->Unit) {
+            for (rawName in missingMods) {
+                val modName = rawName.folderNameToRepoName().lowercase()
+                val repos = Github.tryGetGithubReposWithTopic(10, 1, modName)
+                    ?: throw UncivShowableException("Could not download mod list.")
+                val repo = repos.items.firstOrNull { it.name.lowercase() == modName }
+                    ?: throw UncivShowableException("Could not find a mod named \"[$modName]\".")
+                val modFolder = Github.downloadAndExtract(
+                    repo,
+                    UncivGame.Current.files.getModsFolder()
+                )
+                    ?: throw Exception("Unexpected 404 error") // downloadAndExtract returns null for 404 errors and the like -> display something!
+                Github.rewriteModOptions(repo, modFolder)
+                onModDownloaded(repo.name)
+            }
+            onCompleted()
         }
     }
 }

--- a/core/src/com/unciv/ui/screens/savescreens/SaveGameScreen.kt
+++ b/core/src/com/unciv/ui/screens/savescreens/SaveGameScreen.kt
@@ -66,6 +66,7 @@ class SaveGameScreen(val gameInfo: GameInfo) : LoadOrSaveScreen("Current saves")
 
     private fun Table.addGameNameField() {
         gameNameTextField.setTextFieldFilter { _, char -> char != '\\' && char != '/' }
+        gameNameTextField.textFieldFilter = UncivFiles.fileNameTextFieldFilter()
         val defaultSaveName = "[${gameInfo.currentPlayer}] - [${gameInfo.turns}] turns".tr(hideIcons = true)
         gameNameTextField.text = defaultSaveName
         gameNameTextField.setSelection(0, defaultSaveName.length)

--- a/core/src/com/unciv/utils/PlatformSpecific.kt
+++ b/core/src/com/unciv/utils/PlatformSpecific.kt
@@ -10,4 +10,7 @@ interface PlatformSpecific {
 
     /** If not null, this is the path to the directory in which to store the local files - mods, saves, maps, etc */
     var customDataDirectory: String?
+
+    /** If the OS localizes all error messages, this should provide a lookup */
+    fun getSystemErrorMessage(errorCode: Int): String? = null
 }

--- a/desktop/src/com/unciv/app/desktop/DesktopGame.kt
+++ b/desktop/src/com/unciv/app/desktop/DesktopGame.kt
@@ -2,6 +2,7 @@ package com.unciv.app.desktop
 
 import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3ApplicationConfiguration
+import com.sun.jna.platform.win32.Kernel32Util
 import com.unciv.UncivGame
 
 class DesktopGame(config: Lwjgl3ApplicationConfiguration, override var customDataDirectory: String?) : UncivGame() {
@@ -47,5 +48,15 @@ class DesktopGame(config: Lwjgl3ApplicationConfiguration, override var customDat
     override fun dispose() {
         discordUpdater.stopUpdates()
         super.dispose()
+    }
+
+    override fun getSystemErrorMessage(errorCode: Int): String? {
+        return try {
+            if (System.getProperty("os.name")?.contains("Windows") == true)
+                Kernel32Util.formatMessage(errorCode)
+            else null
+        } catch (_: Throwable) {
+            null
+        }
     }
 }


### PR DESCRIPTION
Fixes #13135
- Solves: Message "You do not have sufficient permissions to access the file" never appearing due to Gdx wrapping Java exceptions
- Solves: Message "You do not have sufficient permissions to access the file" never appearing on Windows due to Windows localizing the string we look for in english[^1]
- Feature: Tells you when trying to save to a file that happens to have the (Windows filesystems only) read-only attribute set
- Centralize common elements for Load/Save-screens a bit more
- More consistently use error Label for disk, Toasts for Clipboard or Success (Delete still uses the bottom descriptionLabel though - more input welcome)
- Using `UncivFiles` as central host for the file name validity rules is arbitrary - could have been `LoadOrSaveScreen` - prefs?
- The new 'home' for `getLoadExceptionMessage` is tricky - a normal refactor would have needed to touch ~15 other places outside these files. We could do that later in a dedicated PR, same as renaming it to reflect it's good for all file ops. After that, it should be easy to make those companion objects 'normal' again - except I very much like having constants on top and 'static' helpers at the end.

[^1]: [These are not the Droids you're looking for](https://duckduckgo.com/?q=These+are+not+the+Droids+you%27re+looking+for)