### PR TITLE
fix some docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ If you want a small, fast, moddable, FOSS, in-depth 4X that can still run on a p
 - **Raspberry Pi** - [Pi-apps](https://github.com/Botspot/pi-apps)
 - **MacOS** - Via [Brew](https://brew.sh/) (`brew update && brew install unciv`) or install [with this guide](https://yairm210.github.io/Unciv/Other/Installing-on-macOS/) 
 - Jars, APKs and Windows/Linux builds also available in [Releases](https://github.com/yairm210/Unciv/releases) (run jar with `java -jar Unciv.jar`) - *not recommended* since we update frequently and you will quickly become out-of-date
-- [Build from scratch](https://yairm210.github.io/Unciv/Developers/Building-locally-without-Android-Studio/) if that's your thing
+- [Build from scratch](https://yairm210.github.io/Unciv/Developers/Building-Locally/#without-android-studio) if that's your thing
 
 ## What's the roadmap?
 

--- a/docs/Developers/Building-Locally.md
+++ b/docs/Developers/Building-Locally.md
@@ -55,7 +55,7 @@ Unciv uses Gradle 8.7 and the Android Gradle Plugin 8.5. Can check in File > Pro
 - Clone the project (see above initial steps)
 - Open a terminal in the Unciv folder and run the following commands
 
-### Windows / Linux / Mac OS
+### Desktop
 
 -   Running: `./gradlew desktop:run`
 -   Building: `./gradlew desktop:dist`

--- a/docs/Developers/Building-Locally.md
+++ b/docs/Developers/Building-Locally.md
@@ -55,7 +55,12 @@ Unciv uses Gradle 8.7 and the Android Gradle Plugin 8.5. Can check in File > Pro
 - Clone the project (see above initial steps)
 - Open a terminal in the Unciv folder and run the following commands
 
-### Desktop
+### Windows (CMD)
+
+-   Running: `gradlew desktop:run`
+-   Building: `gradlew desktop:dist`
+
+### Linux / MacOS / Windows (PowerShell)
 
 -   Running: `./gradlew desktop:run`
 -   Building: `./gradlew desktop:dist`

--- a/docs/Developers/Building-Locally.md
+++ b/docs/Developers/Building-Locally.md
@@ -55,12 +55,7 @@ Unciv uses Gradle 8.7 and the Android Gradle Plugin 8.5. Can check in File > Pro
 - Clone the project (see above initial steps)
 - Open a terminal in the Unciv folder and run the following commands
 
-### Windows
-
--   Running: `gradlew desktop:run`
--   Building: `gradlew desktop:dist`
-
-### Linux/Mac OS
+### Windows / Linux / Mac OS
 
 -   Running: `./gradlew desktop:run`
 -   Building: `./gradlew desktop:dist`

--- a/docs/Developers/Building-Locally.md
+++ b/docs/Developers/Building-Locally.md
@@ -60,7 +60,7 @@ Unciv uses Gradle 8.7 and the Android Gradle Plugin 8.5. Can check in File > Pro
 -   Running: `gradlew desktop:run`
 -   Building: `gradlew desktop:dist`
 
-### Linux / MacOS / Windows (PowerShell)
+### Linux / macOS / Windows (PowerShell)
 
 -   Running: `./gradlew desktop:run`
 -   Building: `./gradlew desktop:dist`


### PR DESCRIPTION
Changes:
1. fix broken url in readme
2. update run / build command in doc. the given windows command does not work. even if does in some versions, adding `./` is safer anyways.
![image](https://github.com/user-attachments/assets/98ccb8e2-175d-4eaa-a873-8896c74ce881)
