### PR TITLE
Update Automation.kt

### DIFF
--- a/core/src/com/unciv/logic/automation/Automation.kt
+++ b/core/src/com/unciv/logic/automation/Automation.kt
@@ -484,8 +484,8 @@ object Automation {
             if (tile.tileResource.resourceType != ResourceType.Bonus) score -= 105
             else if (distance <= city.getWorkRange()) score -= 104
         } else {
-            // Water tiles without resources aren't great
-            if (tile.isWater) score += 25
+            // Water tiles without resources aren't great unless they're Atolls
+            if (tile.isWater) score += 3
             // Can't work it anyways
             if (distance > city.getWorkRange()) score += 100
         }


### PR DESCRIPTION
+3 so regular G&K lighthouse + golden age coast (4 yield) is still valued below inland workable tile (2 yield), but lighthouse atoll (5-6 yield) equal/above inland workable tile, and all water above 0-yield mountains. https://discord.com/channels/586194543280390151/1361797423525138472