### PR TITLE
Fix untranslated strings

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -996,6 +996,7 @@ Your Golden Age has ended. =
 [cityName] has been razed to the ground! = 
 We have conquered the city of [cityName]! = 
 Your citizens are revolting due to very high unhappiness! = 
+Connect road cancelled! = 
 
 # Battle messages
 An enemy [unit] has attacked [cityName] ([amount2] HP) = 
@@ -1330,6 +1331,7 @@ Build [building] =
 Train [unit] = 
 Produce [thingToProduce] = 
 Nothing = 
+Puppet City = 
 Annex city = 
 Specialist Buildings = 
 Specialist Allocation = 

--- a/core/src/com/unciv/models/Spy.kt
+++ b/core/src/com/unciv/models/Spy.kt
@@ -290,11 +290,11 @@ class Spy private constructor() : IsPartOfGameInfoSerialization {
             // Failure
             val spy = allyCiv?.espionageManager?.getSpyAssignedToCity(getCity())
             cityState.getDiplomacyManager(civInfo)!!.addInfluence(-20f)
-            allyCiv?.addNotification("A spy from [${civInfo.civName}] failed to stag a coup in our ally [${cityState.civName}] and was killed!", getCity().location,
+            allyCiv?.addNotification("A spy from [${civInfo.civName}] failed to stage a coup in our ally [${cityState.civName}] and was killed!", getCity().location,
                     NotificationCategory.Espionage, civInfo.civName,  NotificationIcon.Spy, cityState.civName)
             allyCiv?.getDiplomacyManagerOrMeet(civInfo)?.addModifier(DiplomaticModifiers.SpiedOnUs, -10f)
 
-            civInfo.addNotification("Our spy [$name] failed to stag a coup in [${cityState.civName}] and was killed!", getCity().location,
+            civInfo.addNotification("Our spy [$name] failed to stage a coup in [${cityState.civName}] and was killed!", getCity().location,
                     NotificationCategory.Espionage, civInfo.civName,  NotificationIcon.Spy, cityState.civName)
 
             killSpy()


### PR DESCRIPTION
<details>
<summary>Before:</summary>
<img src="https://github.com/user-attachments/assets/6e688e83-cb5f-44a6-885a-e0b2d4b4d990"><br>
In City Screen > Statistics:<br>
<img src="https://github.com/user-attachments/assets/075c30fa-5078-4e6d-9498-c5d7782ff152"><br>
<img src="https://github.com/user-attachments/assets/484356b3-c8e7-4fb5-964c-339102a7f7d5"><br>
This one above is a typo in Spy.kt, the string is already correct in the translation files.
</details>

<details>
<summary>After:</summary>
<img src="https://github.com/user-attachments/assets/a5cd6e5a-a235-45f7-b326-aab078033308"><br>
<img src="https://github.com/user-attachments/assets/686c5bf4-8d0e-44b6-bda5-ee3454abf2d6"><br>
<img src="https://github.com/user-attachments/assets/d490a928-5a75-4571-88ff-824fec34d324">
</details>


