### PR TITLE
Update TradeEvaluation.kt

### DIFF
--- a/core/src/com/unciv/logic/trade/TradeEvaluation.kt
+++ b/core/src/com/unciv/logic/trade/TradeEvaluation.kt
@@ -227,10 +227,10 @@ class TradeEvaluation {
     private fun surroundedByOurCities(city: City, civInfo: Civilization): Int {
         val borderingCivs: Set<String> = getNeighbouringCivs(city)
         if (borderingCivs.size == 1 && borderingCivs.contains(civInfo.civName)) {
-            return 10 * civInfo.getEraNumber() // if the city is surrounded only by trading civ
+            return 10 // if the city is surrounded only by trading civ
         }
         if (borderingCivs.contains(civInfo.civName))
-            return 2 * civInfo.getEraNumber() // if the city has a border with trading civ
+            return 2 // if the city has a border with trading civ
         return 0
     }
 


### PR DESCRIPTION
Remove the era scaling from surroundedByOurCities(): the more advanced the era, the less turns left to turn a profit from the bought city. This may or may not sufficiently adress the issue encountered by https://discord.com/channels/586194543280390151/586194543716859916/1363110037500854482 (the cost of settlers stays the same or becomes cheaper with game progress).