### PR TITLE
Fix untranslated string

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -1351,6 +1351,7 @@ Stopped expansion =
 Food converts to production = 
 [turnsToStarvation] turns to lose population = 
 Stopped population growth = 
+Excess food to production = 
 In resistance for another [numberOfTurns] turns = 
 We Love The King Day for another [numberOfTurns] turns = 
 Demanding [resource] = 


### PR DESCRIPTION
Only one this time... (I try to group them in one PR usually, so I don't clutter the commit history, but I have only this one currently... until I find another one ^^)

In City Screen > Statistics, when a Settler is produced:

Before:
![excess](https://github.com/user-attachments/assets/013337b6-7d94-409b-9e27-ac2a8d24c791)

After:
![excess_a](https://github.com/user-attachments/assets/6adec7c9-b0c1-421b-af01-a031e15c44c3)
