### PR TITLE
Policies: Fix Monarchy happiness

### DIFF
--- a/android/assets/jsons/Civ V - Gods & Kings/Policies.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Policies.json
@@ -54,7 +54,7 @@
             {
                 "name": "Monarchy",
                 "uniques": [
-                    "[+1 Gold, +1 Happiness] per [2] population [in capital]"
+                    "[+1 Gold, -1 Happiness] per [2] population [in capital]"
                 ],
                 "requires": ["Legalism"],
                 "row": 2,

--- a/android/assets/jsons/Civ V - Vanilla/Policies.json
+++ b/android/assets/jsons/Civ V - Vanilla/Policies.json
@@ -53,7 +53,7 @@
             {
                 "name": "Monarchy",
                 "uniques": [
-                    "[+1 Gold, +1 Happiness] per [2] population [in capital]"
+                    "[+1 Gold, -1 Happiness] per [2] population [in capital]"
                 ],
                 "requires": ["Legalism"],
                 "row": 2,


### PR DESCRIPTION
Monarchy causes -1 happiness  instead of +1 happiness.

https://civilization.fandom.com/wiki/Monarchy_(Civ5)
