### PR TITLE
uniques: Add `<if [buildingFilter] is not constructed by anybody>` conditional

### DIFF
--- a/core/src/com/unciv/models/ruleset/unique/Conditionals.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Conditionals.kt
@@ -190,6 +190,8 @@ object Conditionals {
                     && it.matchesFilter(conditional.params[2]) } >= conditional.params[1].toInt() }
             UniqueType.ConditionalBuildingBuiltByAnybody ->
                 checkOnGameInfo { getCities().any { it.cityConstructions.containsBuildingOrEquivalent(conditional.params[0]) } }
+            UniqueType.ConditionalBuildingNotBuiltByAnybody ->
+                !checkOnGameInfo { getCities().any { it.cityConstructions.containsBuildingOrEquivalent(conditional.params[0]) } }
 
             // Filtered via city.getMatchingUniques
             UniqueType.ConditionalInThisCity -> state.relevantCity != null

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -731,6 +731,7 @@ enum class UniqueType(
     ConditionalBuildingBuiltAll("if [buildingFilter] is constructed in all [cityFilter] cities", UniqueTarget.Conditional),
     ConditionalBuildingBuiltAmount("if [buildingFilter] is constructed in at least [positiveAmount] of [cityFilter] cities", UniqueTarget.Conditional),
     ConditionalBuildingBuiltByAnybody("if [buildingFilter] is constructed by anybody", UniqueTarget.Conditional),
+    ConditionalBuildingNotBuiltByAnybody("if [buildingFilter] is not constructed by anybody", UniqueTarget.Conditional),
 
     ConditionalWithResource("with [resource]", UniqueTarget.Conditional),
     ConditionalWithoutResource("without [resource]", UniqueTarget.Conditional),

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -3024,6 +3024,11 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 	Applicable to: Conditional
 
+??? example  "&lt;if [buildingFilter] is not constructed by anybody&gt;"
+	Example: "&lt;if [Culture] is not constructed by anybody&gt;"
+
+	Applicable to: Conditional
+
 ??? example  "&lt;with [resource]&gt;"
 	Example: "&lt;with [Iron]&gt;"
 


### PR DESCRIPTION
Needed a unique for the Great Firewall's unique...

> Negates the Tourism bonus from other players' Internet technology.

https://civilization.fandom.com/wiki/Great_Firewall_(Civ5)

So, on The Internet, I'd add `Doubles quality of [Tourism] <if [Great Firewall] is not constructed by anybody>`.

