### PR TITLE
Update City-States

### DIFF
--- a/android/assets/jsons/Civ V - Gods & Kings/Nations.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Nations.json
@@ -1072,8 +1072,20 @@
 		"attacked": "Very well, this shall not be forgotten.",
 		"defeated": "I guess you weren't here for the sprouts after all...",
 		"outerColor": [0, 0, 0],
-		"innerColor": [153,255,51],
+		"innerColor": [127, 177, 236],
 		"cities": ["Brussels"]
+	},
+	{
+		"name": "Bucharest",
+		"adjective": ["Bucuresti"],
+		"cityStateType": "Cultured",
+
+		"declaringWar": "You leave us no choice. War it must be.",
+		"attacked": "Very well, this shall not be forgotten.",
+		"defeated": "I guess you weren't here for the sprouts after all...",
+		"outerColor": [0, 0, 0],
+		"innerColor": [113, 227, 114],
+		"cities": ["Bucharest"]
 	},
 	{
 		"name": "Florence",
@@ -1084,7 +1096,7 @@
 		"attacked": "Very well, this shall not be forgotten.",
 		"defeated": "And so the flower of Florence falls to barbaric hands...",
 		"outerColor": [0, 0, 0],
-		"innerColor": [62,197,252],
+		"innerColor": [18, 188, 221],
 		"cities": ["Florence"]
 	},
 	{
@@ -1096,7 +1108,7 @@
 		"attacked": "Very well, this shall not be forgotten.",
 		"defeated": "So this is how it feels to die...",
 		"outerColor": [0, 0, 0],
-        "innerColor": [51,51,255],
+		"innerColor": [167, 162, 216],
 		"cities": ["Hanoi"]
 	},
 	{
@@ -1108,7 +1120,7 @@
 		"attacked": "Very well, this shall not be forgotten.",
 		"defeated": "Unacceptable!",
 		"outerColor": [0, 0, 0],
-		"innerColor": [168,38,102],
+		"innerColor": [121, 226, 0],
 		"cities": ["Kabul"]
 	},
 	{
@@ -1120,7 +1132,7 @@
 		"attacked": "Very well, this shall not be forgotten.",
 		"defeated": "Today, the Malay people obey you, but do not think this is over...",
 		"outerColor": [0, 0, 0],
-		"innerColor": [0,102,102],
+		"innerColor": [222, 237, 59],
 		"cities": ["Kuala Lumpur"]
 	},
 	{
@@ -1132,7 +1144,7 @@
 		"attacked": "Very well, this shall not be forgotten.",
 		"defeated": "Perhaps now we will find peace in death...",
 		"outerColor": [0, 0, 0],
-		"innerColor": [204,102,0],
+		"innerColor": [113, 227, 114],
 		"cities": ["Lhasa"]
 	},
 	{
@@ -1144,8 +1156,32 @@
 		"attacked": "Very well, this shall not be forgotten.",
 		"defeated": "You fiend! History shall remember this!",
 		"outerColor": [0, 0, 0],
-		"innerColor": [185,132,66],
+		"innerColor": [225, 194, 129],
 		"cities": ["Milan"]
+	},
+	{
+		"name": "Monaco",
+		"adjective": ["Monaco"],
+		"cityStateType": "Cultured",
+
+		"declaringWar": "You leave us no choice. War it must be.",
+		"attacked": "Very well, this shall not be forgotten.",
+		"defeated": "You fiend! History shall remember this!",
+		"outerColor": [0, 0, 0],
+		"innerColor": [193, 84, 255],
+		"cities": ["Milan"]
+	},
+	{
+		"name": "Prague",
+		"adjective": ["Prague"],
+		"cityStateType": "Cultured",
+
+		"declaringWar": "You leave us no choice. War it must be.",
+		"attacked": "Very well, this shall not be forgotten.",
+		"defeated": "You fiend! History shall remember this!",
+		"outerColor": [0, 0, 0],
+		"innerColor": [51, 97, 242],
+		"cities": ["Prague"]
 	},
 	{
 		"name": "Quebec City",
@@ -1156,7 +1192,7 @@
 		"attacked": "Very well, this shall not be forgotten.",
 		"defeated": "We were too weak to protect ourselves...",
 		"outerColor": [0, 0, 0],
-		"innerColor": [51,102,0],
+		"innerColor": [51, 97, 242],
 		"cities": ["Quebec City"]
 	},
 
@@ -1169,7 +1205,7 @@
 		"attacked": "Very well, this shall not be forgotten.",
 		"defeated": "I have failed. May you, at least, know compassion towards our people.",
 		"outerColor": [0, 0, 0],
-		"innerColor": [255,153,153],
+		"innerColor": [217, 158, 78],
 		"cities": ["Cape Town"]
 	},
 	{
@@ -1193,7 +1229,7 @@
 		"attacked": "Very well, this shall not be forgotten.",
 		"defeated": "Ah, Gods! Why have you forsaken us?",
 		"outerColor": [0, 0, 0],
-		"innerColor": [96,96,96],
+		"innerColor": [113, 227, 114],
 		"cities": ["Manila"]
 	},
 	{
@@ -1205,7 +1241,7 @@
 		"attacked": "Very well, this shall not be forgotten.",
 		"defeated": "Congratulations, conqueror. This tribe serves you now.",
 		"outerColor": [0, 0, 0],
-		"innerColor": [224,224,224],
+		"innerColor": [127, 177, 236],
 		"cities": ["Mogadishu"]
 	},
 	{
@@ -1230,7 +1266,7 @@
 		"attacked": "We will mobilize every means of resistance to stop this transgression against our nation!",
 		"defeated": "The principles for which we have fought will survive longer than any nation you could ever build.",
 		"outerColor": [0, 0, 0],
-		"innerColor": [255,204,204],
+		"innerColor": [51, 97, 242],
 		"cities": ["Sydney"]
 	},
 	{
@@ -1243,7 +1279,7 @@
 		"attacked": "Why do we fight? Because Inanna demands it. Now, witness the power of the Sumerians!",
 		"defeated": "What treachery has struck us? No, what evil?",
 		"outerColor": [0, 0, 0],
-		"innerColor": [255,69,0],
+		"innerColor": [167, 16, 216],
 		"cities": ["Ur"]
 	},
 	{
@@ -1255,7 +1291,7 @@
 		"attacked": "As we can reach no peaceful resolution with you, Canada must turn, with reluctance, to war.",
 		"defeated": "I regret not defending my country to the last, although it was not of use.",
 		"outerColor": [0, 0, 0],
-		"innerColor": [0,255,128],
+		"innerColor": [193, 84, 255],
 		"cities": ["Vancouver"]
 	},
 	{
@@ -1282,7 +1318,7 @@
 		"attacked": "Very well, this shall not be forgotten.",
 		"defeated": "They will write songs of this.... pray that they shall be in your favor.",
 		"outerColor": [0, 0, 0],
-		"innerColor": [194,97,255],
+		"innerColor": [193, 84, 255],
 		"cities": ["Antwerp"]
 	},
 	{
@@ -1295,7 +1331,7 @@
 		"attacked": "Very well, this shall not be forgotten.",
 		"defeated": "How barbaric. Those who live by the sword shall perish by the sword.",
 		"outerColor": [0, 0, 0],
-		"innerColor": [45,255,86],
+		"innerColor": [0, 163, 181],
 		"cities": ["Genoa"]
 	},
 	{
@@ -1307,7 +1343,7 @@
 		"attacked": "Very well, this shall not be forgotten.",
 		"defeated": "We... defeated? No... we had so much work to do!",
 		"outerColor": [0, 0, 0],
-		"innerColor": [151,125,0],
+		"innerColor": [186, 18, 202],
 		"cities": ["Kathmandu"]
 	},
 	{
@@ -1319,7 +1355,7 @@
 		"attacked": "Very well, this shall not be forgotten.",
 		"defeated": "Perhaps, in another world, we could have been friends...",
 		"outerColor": [0, 0, 0],
-		"innerColor": [255,255,0],
+		"innerColor": [246, 253, 160],
 		"cities": ["Singapore"]
 	},
 	{
@@ -1332,7 +1368,7 @@
 		"attacked": "Very well, this shall not be forgotten.",
 		"defeated": "We never fully trusted you from the start.",
 		"outerColor": [0, 0, 0],
-		"innerColor": [255,97,255],
+		"innerColor": [121, 226, 0],
 		"cities": ["Tyre"]
 	},
 	{
@@ -1344,7 +1380,7 @@
 		"attacked": "Very well, this shall not be forgotten.",
 		"defeated": "May the Heavens forgive you for inflicting this humiliation to our people.",
 		"outerColor": [0, 0, 0],
-		"innerColor": [255,153,255],
+		"innerColor": [127, 177, 236],
 		"cities": ["Zanzibar"]
 	},
 
@@ -1357,7 +1393,7 @@
 		"attacked": "Very well, this shall not be forgotten.",
 		"defeated": "How could we fall to the likes of you?!",
 		"outerColor": [0, 0, 0],
-		"innerColor": [152,0,241],
+		"innerColor": [217, 158, 78],
 		"cities": ["Almaty"]
 	},
 	{
@@ -1369,7 +1405,7 @@
 		"attacked": "If you need your nose bloodied, we'll happily serve.",
 		"defeated": "The serbian guerilla will never stop haunting you!",
 		"outerColor": [0, 0, 0],
-		"innerColor": [211,180,113],
+		"innerColor": [121, 226, 0],
 		"cities": ["Belgrade"]
 	},
 	{
@@ -1407,7 +1443,7 @@
 		"attacked": "We are no strangers to war. You have strayed from the right path, and now we will correct it.",
 		"defeated": "You are nothing but a glorified barbarian. Cruel, and ruthless.",
 		"outerColor": [0, 0, 0],
-		"innerColor": [255,128,0],
+		"innerColor": [18, 188, 221],
 		"cities": ["M'Banza-Kongo"]
 	},
 	{
@@ -1419,7 +1455,7 @@
 		"attacked": "Very well, this shall not be forgotten.",
 		"defeated": "What a fine battle! Sidon is willing to serve you!",
 		"outerColor": [0, 0, 0],
-		"innerColor": [250,128,114],
+		"innerColor": [186, 18, 202],
 		"cities": ["Sidon"]
 	},
 	{
@@ -1431,7 +1467,7 @@
 		"attacked": "You will see you have just bitten off more than you can chew.",
 		"defeated": "This ship may sink, but our spirits will linger.",
 		"outerColor": [0, 0, 0],
-		"innerColor": [0,102,102],
+		"innerColor": [222, 237, 59],
 		"cities": ["Valletta"]
 	},
 
@@ -1444,7 +1480,7 @@
 		"attacked": "I will fear no evil. For god is with me!",
 		"defeated": "Why have you forsaken us my lord?",
 		"outerColor": [0, 0, 0],
-		"innerColor": [255,255,255],
+		"innerColor": [255, 255, 255],
 		"cities": ["Bratislava"]
 	},
 	{
@@ -1456,7 +1492,7 @@
 		"attacked": "Very well, we will kick you back to the ancient era!",
 		"defeated": "This isn't how it is supposed to be!",
 		"outerColor": [0, 0, 0],
-		"innerColor": [203, 253, 232],
+		"innerColor": [255, 255, 255],
 		"cities": ["Cahokia"]
 	},
 	{
@@ -1468,7 +1504,7 @@
 		"attacked": "May god have mercy on your evil soul.",
 		"defeated": "I for one welcome our new conquer overlord!",
 		"outerColor": [0, 0, 0],
-		"innerColor": [198,255,192],
+		"innerColor": [255, 255, 255],
 		"cities": ["Jerusalem"]
 	},
 

--- a/android/assets/jsons/Civ V - Gods & Kings/Nations.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Nations.json
@@ -1101,7 +1101,7 @@
 	},
 	{
 		"name": "Kabul",
-		"adjective": ["Kabul"],
+		"adjective": ["Kabuli"],
 		"cityStateType": "Cultured",
 
 		"declaringWar": "You leave us no choice. War it must be.",
@@ -1113,7 +1113,7 @@
 	},
 	{
 		"name": "Kathmandu",
-		"adjective": ["Kathmandu"],
+		"adjective": ["Kathmanduites"],
 		"cityStateType": "Cultured", // Changed from Cultured to Religious in BNW
 
 		"declaringWar": "You leave us no choice. War it must be.",
@@ -1149,7 +1149,7 @@
 	},
 	{
 		"name": "Monaco",
-		"adjective": ["Monaco"],
+		"adjective": ["Monegasque"],
 		"cityStateType": "Cultured",
 
 		"declaringWar": "You leave us no choice. War it must be.",
@@ -1161,7 +1161,7 @@
 	},
 	{
 		"name": "Prague",
-		"adjective": ["Prague"],
+		"adjective": ["Praguer", "Pragueite"],
 		"cityStateType": "Cultured",
 
 		"declaringWar": "You leave us no choice. War it must be.",
@@ -1173,7 +1173,7 @@
 	},
 	{
 		"name": "Yerevan",
-		"adjective": ["Yerevan"],
+		"adjective": ["Yerevantsi"],
 		"cityStateType": "Cultured",
 
 		"declaringWar": "You leave us no choice. War it must be.",
@@ -1186,7 +1186,7 @@
 
 	{
 		"name": "Cape Town",
-		"adjective": ["Cape Town"],
+		"adjective": ["Capetonian"],
 		"cityStateType": "Maritime",
 
 		"declaringWar": "You leave us no choice. War it must be.",
@@ -1198,7 +1198,7 @@
 	},
 	{
 		"name": "Helsinki", // In GK, Helsinki becomes a Swedish city.
-		"adjective": ["Helsinki"],
+		"adjective": ["Helsinkian"],
 		"cityStateType": "Maritime",
 
 		"declaringWar": "You leave us no choice. War it must be.",
@@ -1223,7 +1223,7 @@
 	},
 	{
 		"name": "Mogadishu", // Introduced in BNW
-		"adjective": ["Mogadishu"],
+		"adjective": ["Maqdishawi"],
 		"cityStateType": "Maritime",
 
 		"declaringWar": "You leave us no choice. War it must be.",
@@ -1236,7 +1236,7 @@
 	},
 	{
 		"name": "Mombasa",
-		"adjective": ["Mombasa"],
+		"adjective": ["Mombasaan"],
 		"cityStateType": "Maritime",
 
 		"declaringWar": "You leave us no choice. War it must be.",
@@ -1260,8 +1260,9 @@
 	},
 	{
 		"name": "Ragusa",
-		"adjective": ["Ragusa"],
+		"adjective": ["Ragusan"],
 		"cityStateType": "Maritime",
+		"startBias": ["Coast"],
 
 		"declaringWar": "You leave us no choice. War it must be.",
 		"attacked": "Very well, this shall not be forgotten.",
@@ -1285,7 +1286,7 @@
 	},
 	{
 		"name": "Sydney",
-		"adjective": ["Sydney"],
+		"adjective": ["Sydneysider"],
 		"cityStateType": "Maritime",
 
 		"declaringWar": "After thorough deliberation, Australia finds itself at a crossroads. Prepare yourself, for war is upon us.",
@@ -1297,7 +1298,7 @@
 	},
 	{
 		"name": "Ur", // Introduced in BNW
-		"adjective": ["Ur"],
+		"adjective": ["Urian"],
 		"cityStateType": "Maritime",
 		"startBias": ["Coast"],
 
@@ -1338,7 +1339,7 @@
 
 	{
 		"name": "Antwerp",
-		"adjective": ["Antwerp"],
+		"adjective": ["Antwerpenaar", "Antwerpian"],
 		"cityStateType": "Mercantile",
 		"startBias": ["Coast"],
 
@@ -1351,7 +1352,7 @@
 	},
 	{
 		"name": "Cahokia",
-		"adjective": ["Cahokia"],
+		"adjective": ["Cahokian"],
 		"cityStateType": "Mercantile",
 
 		"declaringWar": "We have wanted this for a LONG time. War it shall be.",
@@ -1363,7 +1364,7 @@
 	},
 	{
 		"name": "Colombo",
-		"adjective": ["Colombo"],
+		"adjective": ["Colomboan"],
 		"cityStateType": "Mercantile",
 
 		"declaringWar": "We have wanted this for a LONG time. War it shall be.",
@@ -1388,7 +1389,7 @@
 	},
 	{
 		"name": "Hong Kong",
-		"adjective": ["Hong Kong"],
+		"adjective": ["Hongkonger", "Hongkongese"],
 		"cityStateType": "Mercantile",
 
 		"declaringWar": "You leave us no choice. War it must be.",
@@ -1425,7 +1426,7 @@
 	},
 	{
 		"name": "Zanzibar",
-		"adjective": ["Zanzibar"],
+		"adjective": ["Zanzibari"],
 		"cityStateType": "Mercantile",
 
 		"declaringWar": "You leave us no choice. War it must be.",
@@ -1437,7 +1438,7 @@
 	},
 	{
 		"name": "Zurich",
-		"adjective": ["Zurich"],
+		"adjective": ["Zuricher"],
 		"cityStateType": "Mercantile",
 
 		"declaringWar": "You leave us no choice. War it must be.",
@@ -1450,7 +1451,7 @@
 
 	{
 		"name": "Almaty",
-		"adjective": ["Almaty"],
+		"adjective": ["Almatinian"],
 		"cityStateType": "Militaristic",
 
 		"declaringWar": "You leave us no choice. War it must be.",
@@ -1462,7 +1463,7 @@
 	},
 	{
 		"name": "Belgrade",
-		"adjective": ["Belgrade"],
+		"adjective": ["Belgradian"],
 		"cityStateType": "Militaristic",
 
 		"declaringWar": "Let's have a nice little War, shall we?",
@@ -1474,7 +1475,7 @@
 	},
 	{
 		"name": "Budapest",
-		"adjective": ["Budapest"],
+		"adjective": ["Budapester", "Budapesti"],
 		"cityStateType": "Militaristic",
 
 		"declaringWar": "Let's have a nice little War, shall we?",
@@ -1512,7 +1513,7 @@
 	},
 	{
 		"name": "Hanoi",
-		"adjective": ["Hanoi"],
+		"adjective": ["Hanoian"],
 		"cityStateType": "Militaristic",
 
 		"declaringWar": "You leave us no choice. War it must be.",
@@ -1524,7 +1525,7 @@
 	},
 	{
 		"name": "M'Banza-Kongo", // Introduced in BNW
-		"adjective": ["M'Banza-Kongo"],
+		"adjective": ["Angolan"],
 		"cityStateType": "Militaristic",
 
 		"declaringWar": "Do you really think you can walk over us so easily? I will not let it happen. Not to Kongo - not to my people!",
@@ -1537,7 +1538,7 @@
 	},
 	{
 		"name": "Sidon",
-		"adjective": ["Sidon"],
+		"adjective": ["Sidonian"],
 		"cityStateType": "Militaristic",
 
 		"declaringWar": "You leave us no choice. War it must be.",
@@ -1549,7 +1550,7 @@
 	},
 	{
 		"name": "Valletta",
-		"adjective": ["Maltese"],
+		"adjective": ["Beltin"],
 		"cityStateType": "Militaristic",
 		"startBias": ["Coast"],
 
@@ -1563,7 +1564,7 @@
 
 	{
 		"name": "Bratislava",
-		"adjective": ["Bratislava"],
+		"adjective": ["Bratislavan"],
 		"cityStateType": "Religious",
 
 		"declaringWar": "I didn't want to do this. We declare war.",
@@ -1587,7 +1588,7 @@
 	},
 	{
 		"name": "Jerusalem",
-		"adjective": ["Jerusalem"],
+		"adjective": ["Jerusalemite"],
 		"cityStateType": "Religious",
 
 		"declaringWar": "By god's grace we will not allow these atrocities to occur any longer. We declare war!",
@@ -1611,7 +1612,7 @@
 	},
 	{
 		"name": "Lhasa",
-		"adjective": ["tibetano"],
+		"adjective": ["Tibetano"],
 		"cityStateType": "Religious", // Changed from Cultured to Religious in GK
 
 		"declaringWar": "You leave us no choice. War it must be.",
@@ -1635,7 +1636,7 @@
 	},
 	{
 		"name": "Wittenberg",
-		"adjective": ["Wittenberg"],
+		"adjective": ["Wittenberger"],
 		"cityStateType": "Religious",
 
 		"declaringWar": "You leave us no choice. War it must be.",

--- a/android/assets/jsons/Civ V - Gods & Kings/Nations.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Nations.json
@@ -863,7 +863,7 @@
 		"favoredReligion": "Christianity",
 		"uniqueName": "Nobel Prize",
 		"uniques": ["Gain [90] Influence with a [Great Person] gift to a City-State", "When declaring friendship, both parties gain a [10]% boost to great person generation"],
-		"cities": ["Stockholm","Uppsala","Gothenburg","Malmö","Linköping","Kalmar","Skara","Västerås","Jönköping",
+		"cities": ["Stockholm","Sigtuna","Helsinki","Birka","Uppsala","Gothenburg","Turku","Malmö","Linköping","Kalmar","Skara","Västerås","Jönköping",
             "Visby","Falun","Norrköping","Gävle","Halmstad","Karlskrona","Hudiksvall","Örebro","Umeå","Karlstad",
             "Helsingborg","Härnösand","Vadstena","Lund","Västervik","Enköping","Skövde","Eskilstuna","Luleå","Lidköping",
             "Södertälje","Mariestad","Östersund","Borås","Sundsvall","Vimmerby","Köping","Mora","Arboga","Växjö","Gränna",
@@ -1100,18 +1100,6 @@
 		"cities": ["Florence"]
 	},
 	{
-		"name": "Hanoi",
-		"adjective": ["Hanoi"],
-		"cityStateType": "Cultured",
-
-		"declaringWar": "You leave us no choice. War it must be.",
-		"attacked": "Very well, this shall not be forgotten.",
-		"defeated": "So this is how it feels to die...",
-		"outerColor": [0, 0, 0],
-		"innerColor": [167, 162, 216],
-		"cities": ["Hanoi"]
-	},
-	{
 		"name": "Kabul",
 		"adjective": ["Kabul"],
 		"cityStateType": "Cultured",
@@ -1124,6 +1112,18 @@
 		"cities": ["Kabul"]
 	},
 	{
+		"name": "Kathmandu",
+		"adjective": ["Kathmandu"],
+		"cityStateType": "Cultured", // Changed from Cultured to Religious in BNW
+
+		"declaringWar": "You leave us no choice. War it must be.",
+		"attacked": "Very well, this shall not be forgotten.",
+		"defeated": "We... defeated? No... we had so much work to do!",
+		"outerColor": [0, 0, 0],
+		"innerColor": [186, 18, 202],
+		"cities": ["Kathmandu"]
+	},
+	{
 		"name": "Kuala Lumpur",
 		"adjective": ["KLite"],
 		"cityStateType": "Cultured",
@@ -1134,18 +1134,6 @@
 		"outerColor": [0, 0, 0],
 		"innerColor": [222, 237, 59],
 		"cities": ["Kuala Lumpur"]
-	},
-	{
-		"name": "Lhasa",
-		"adjective": ["tibetano"],
-		"cityStateType": "Cultured",
-
-		"declaringWar": "You leave us no choice. War it must be.",
-		"attacked": "Very well, this shall not be forgotten.",
-		"defeated": "Perhaps now we will find peace in death...",
-		"outerColor": [0, 0, 0],
-		"innerColor": [113, 227, 114],
-		"cities": ["Lhasa"]
 	},
 	{
 		"name": "Milan",
@@ -1169,7 +1157,7 @@
 		"defeated": "You fiend! History shall remember this!",
 		"outerColor": [0, 0, 0],
 		"innerColor": [193, 84, 255],
-		"cities": ["Milan"]
+		"cities": ["Monaco"]
 	},
 	{
 		"name": "Prague",
@@ -1184,16 +1172,16 @@
 		"cities": ["Prague"]
 	},
 	{
-		"name": "Quebec City",
-		"adjective": ["Québécois"],
+		"name": "Yerevan",
+		"adjective": ["Yerevan"],
 		"cityStateType": "Cultured",
 
 		"declaringWar": "You leave us no choice. War it must be.",
 		"attacked": "Very well, this shall not be forgotten.",
 		"defeated": "We were too weak to protect ourselves...",
 		"outerColor": [0, 0, 0],
-		"innerColor": [51, 97, 242],
-		"cities": ["Quebec City"]
+		"innerColor": [225, 194, 129],
+		"cities": ["Yerevan"]
 	},
 
 	{
@@ -1209,7 +1197,7 @@
 		"cities": ["Cape Town"]
 	},
 	{
-		"name": "Helsinki",
+		"name": "Helsinki", // In GK, Helsinki becomes a Swedish city.
 		"adjective": ["Helsinki"],
 		"cityStateType": "Maritime",
 
@@ -1218,7 +1206,8 @@
 		"defeated": "The day of judgement has come to us. But rest assured, the same will go for you!",
 		"outerColor": [0, 0, 0],
 		"innerColor": [255,178,102],
-		"cities": ["Helsinki"]
+		"cities": ["Helsinki"],
+        "uniques": ["Will not be displayed in Civilopedia", "Will not be chosen for new games", "Excluded from map editor"]
 	},
 	{
 		"name": "Manila",
@@ -1233,7 +1222,7 @@
 		"cities": ["Manila"]
 	},
 	{
-		"name": "Mogadishu",
+		"name": "Mogadishu", // Introduced in BNW
 		"adjective": ["Mogadishu"],
 		"cityStateType": "Maritime",
 
@@ -1242,7 +1231,44 @@
 		"defeated": "Congratulations, conqueror. This tribe serves you now.",
 		"outerColor": [0, 0, 0],
 		"innerColor": [127, 177, 236],
-		"cities": ["Mogadishu"]
+		"cities": ["Mogadishu"],
+        "uniques": ["Will not be displayed in Civilopedia", "Will not be chosen for new games", "Excluded from map editor"]
+	},
+	{
+		"name": "Mombasa",
+		"adjective": ["Mombasa"],
+		"cityStateType": "Maritime",
+
+		"declaringWar": "You leave us no choice. War it must be.",
+		"attacked": "Very well, this shall not be forgotten.",
+		"defeated": "Congratulations, conqueror. This tribe serves you now.",
+		"outerColor": [0, 0, 0],
+		"innerColor": [121, 226, 0],
+		"cities": ["Mombasa"]
+	},
+	{
+		"name": "Quebec City",
+		"adjective": ["Québécois"],
+		"cityStateType": "Maritime",
+
+		"declaringWar": "You leave us no choice. War it must be.",
+		"attacked": "Very well, this shall not be forgotten.",
+		"defeated": "We were too weak to protect ourselves...",
+		"outerColor": [0, 0, 0],
+		"innerColor": [51, 97, 242],
+		"cities": ["Quebec City"]
+	},
+	{
+		"name": "Ragusa",
+		"adjective": ["Ragusa"],
+		"cityStateType": "Maritime",
+
+		"declaringWar": "You leave us no choice. War it must be.",
+		"attacked": "Very well, this shall not be forgotten.",
+		"defeated": "We were too weak to protect ourselves...",
+		"outerColor": [0, 0, 0],
+		"innerColor": [0, 163, 181],
+		"cities": ["Ragusa"]
 	},
 	{
 		"name": "Rio de Janeiro",
@@ -1270,7 +1296,7 @@
 		"cities": ["Sydney"]
 	},
 	{
-		"name": "Ur",
+		"name": "Ur", // Introduced in BNW
 		"adjective": ["Ur"],
 		"cityStateType": "Maritime",
 		"startBias": ["Coast"],
@@ -1280,10 +1306,11 @@
 		"defeated": "What treachery has struck us? No, what evil?",
 		"outerColor": [0, 0, 0],
 		"innerColor": [167, 16, 216],
-		"cities": ["Ur"]
+		"cities": ["Ur"],
+        "uniques": ["Will not be displayed in Civilopedia", "Will not be chosen for new games", "Excluded from map editor"]
 	},
 	{
-		"name": "Vancouver",
+		"name": "Vancouver", // Introduced in BNW
 		"adjective": ["Vancouverite"],
 		"cityStateType": "Maritime",
 
@@ -1292,7 +1319,8 @@
 		"defeated": "I regret not defending my country to the last, although it was not of use.",
 		"outerColor": [0, 0, 0],
 		"innerColor": [193, 84, 255],
-		"cities": ["Vancouver"]
+		"cities": ["Vancouver"],
+        "uniques": ["Will not be displayed in Civilopedia", "Will not be chosen for new games", "Excluded from map editor"]
 	},
 	{
 		"name": "Venice",
@@ -1322,9 +1350,33 @@
 		"cities": ["Antwerp"]
 	},
 	{
+		"name": "Cahokia",
+		"adjective": ["Cahokia"],
+		"cityStateType": "Mercantile",
+
+		"declaringWar": "We have wanted this for a LONG time. War it shall be.",
+		"attacked": "Very well, we will kick you back to the ancient era!",
+		"defeated": "This isn't how it is supposed to be!",
+		"outerColor": [0, 0, 0],
+		"innerColor": [255, 255, 255],
+		"cities": ["Cahokia"]
+	},
+	{
+		"name": "Colombo",
+		"adjective": ["Colombo"],
+		"cityStateType": "Mercantile",
+
+		"declaringWar": "We have wanted this for a LONG time. War it shall be.",
+		"attacked": "Very well, we will kick you back to the ancient era!",
+		"defeated": "This isn't how it is supposed to be!",
+		"outerColor": [0, 0, 0],
+		"innerColor": [167, 162, 216],
+		"cities": ["Colombo"]
+	},
+	{
 		"name": "Genoa",
 		"adjective": ["Genoese"],
-		"cityStateType": "Mercantile",
+		"cityStateType": "Mercantile", // Changed from Maritime to Mercantile in GK
 		"startBias": ["Coast"],
 
 		"declaringWar": "You leave us no choice. War it must be.",
@@ -1335,16 +1387,16 @@
 		"cities": ["Genoa"]
 	},
 	{
-		"name": "Kathmandu",
-		"adjective": ["Kathmandu"],
+		"name": "Hong Kong",
+		"adjective": ["Hong Kong"],
 		"cityStateType": "Mercantile",
 
 		"declaringWar": "You leave us no choice. War it must be.",
 		"attacked": "Very well, this shall not be forgotten.",
-		"defeated": "We... defeated? No... we had so much work to do!",
+		"defeated": "How barbaric. Those who live by the sword shall perish by the sword.",
 		"outerColor": [0, 0, 0],
-		"innerColor": [186, 18, 202],
-		"cities": ["Kathmandu"]
+		"innerColor": [52, 97, 242],
+		"cities": ["Hong Kong"]
 	},
 	{
 		"name": "Singapore",
@@ -1361,7 +1413,7 @@
 	{
 		"name": "Tyre",
 		"adjective": ["Tyrian"],
-		"cityStateType": "Mercantile",
+		"cityStateType": "Mercantile", // Changed from Militaristic to Mercantile in GK
 		"startBias": ["Coast"],
 
 		"declaringWar": "You leave us no choice. War it must be.",
@@ -1382,6 +1434,18 @@
 		"outerColor": [0, 0, 0],
 		"innerColor": [127, 177, 236],
 		"cities": ["Zanzibar"]
+	},
+	{
+		"name": "Zurich",
+		"adjective": ["Zurich"],
+		"cityStateType": "Mercantile",
+
+		"declaringWar": "You leave us no choice. War it must be.",
+		"attacked": "Very well, this shall not be forgotten.",
+		"defeated": "May the Heavens forgive you for inflicting this humiliation to our people.",
+		"outerColor": [0, 0, 0],
+		"innerColor": [172, 172, 172],
+		"cities": ["Zurich"]
 	},
 
 	{
@@ -1407,6 +1471,18 @@
 		"outerColor": [0, 0, 0],
 		"innerColor": [121, 226, 0],
 		"cities": ["Belgrade"]
+	},
+	{
+		"name": "Budapest",
+		"adjective": ["Budapest"],
+		"cityStateType": "Militaristic",
+
+		"declaringWar": "Let's have a nice little War, shall we?",
+		"attacked": "If you need your nose bloodied, we'll happily serve.",
+		"defeated": "The serbian guerilla will never stop haunting you!",
+		"outerColor": [0, 0, 0],
+		"innerColor": [217, 158, 78],
+		"cities": ["Budapest"]
 	},
 	{
 		"name": "Dublin",
@@ -1435,7 +1511,19 @@
 		"uniques": ["Will not be displayed in Civilopedia", "Will not be chosen for new games", "Excluded from map editor"]
 	},
 	{
-		"name": "M'Banza-Kongo",
+		"name": "Hanoi",
+		"adjective": ["Hanoi"],
+		"cityStateType": "Militaristic",
+
+		"declaringWar": "You leave us no choice. War it must be.",
+		"attacked": "Very well, this shall not be forgotten.",
+		"defeated": "So this is how it feels to die...",
+		"outerColor": [0, 0, 0],
+		"innerColor": [167, 162, 216],
+		"cities": ["Hanoi"]
+	},
+	{
+		"name": "M'Banza-Kongo", // Introduced in BNW
 		"adjective": ["M'Banza-Kongo"],
 		"cityStateType": "Militaristic",
 
@@ -1444,7 +1532,8 @@
 		"defeated": "You are nothing but a glorified barbarian. Cruel, and ruthless.",
 		"outerColor": [0, 0, 0],
 		"innerColor": [18, 188, 221],
-		"cities": ["M'Banza-Kongo"]
+		"cities": ["M'Banza-Kongo"],
+		"uniques": ["Will not be displayed in Civilopedia", "Will not be chosen for new games", "Excluded from map editor"]
 	},
 	{
 		"name": "Sidon",
@@ -1460,8 +1549,9 @@
 	},
 	{
 		"name": "Valletta",
-		"adjective": ["maltese"],
+		"adjective": ["Maltese"],
 		"cityStateType": "Militaristic",
+		"startBias": ["Coast"],
 
 		"declaringWar": "We don't like your face. To arms!",
 		"attacked": "You will see you have just bitten off more than you can chew.",
@@ -1484,16 +1574,16 @@
 		"cities": ["Bratislava"]
 	},
 	{
-		"name": "Cahokia",
-		"adjective": ["Cahokia"],
-		"cityStateType": "Religious",
+		"name": "Geneva",
+		"adjective": ["Genevan", "Genevese"],
+		"cityStateType": "Religious", // Changed from Cultured to Religious in GK
 
-		"declaringWar": "We have wanted this for a LONG time. War it shall be.",
-		"attacked": "Very well, we will kick you back to the ancient era!",
-		"defeated": "This isn't how it is supposed to be!",
+		"declaringWar": "You leave us no choice. War it must be.",
+		"attacked": "Very well, this shall not be forgotten.",
+		"defeated": "I guess you weren't here for the sprouts after all...",
 		"outerColor": [0, 0, 0],
-		"innerColor": [255, 255, 255],
-		"cities": ["Cahokia"]
+		"innerColor": [51, 97, 242],
+		"cities": ["Geneva"]
 	},
 	{
 		"name": "Jerusalem",
@@ -1506,6 +1596,54 @@
 		"outerColor": [0, 0, 0],
 		"innerColor": [255, 255, 255],
 		"cities": ["Jerusalem"]
+	},
+	{
+		"name": "La Venta",
+		"adjective": ["La Venta"],
+		"cityStateType": "Religious",
+
+		"declaringWar": "By god's grace we will not allow these atrocities to occur any longer. We declare war!",
+		"attacked": "May god have mercy on your evil soul.",
+		"defeated": "I for one welcome our new conquer overlord!",
+		"outerColor": [0, 0, 0],
+		"innerColor": [18, 188, 221],
+		"cities": ["La Venta"]
+	},
+	{
+		"name": "Lhasa",
+		"adjective": ["tibetano"],
+		"cityStateType": "Religious", // Changed from Cultured to Religious in GK
+
+		"declaringWar": "You leave us no choice. War it must be.",
+		"attacked": "Very well, this shall not be forgotten.",
+		"defeated": "Perhaps now we will find peace in death...",
+		"outerColor": [0, 0, 0],
+		"innerColor": [113, 227, 114],
+		"cities": ["Lhasa"]
+	},
+	{
+		"name": "Vatican City",
+		"adjective": ["Vaticano"],
+		"cityStateType": "Religious",
+
+		"declaringWar": "You leave us no choice. War it must be.",
+		"attacked": "Very well, this shall not be forgotten.",
+		"defeated": "Perhaps now we will find peace in death...",
+		"outerColor": [0, 0, 0],
+		"innerColor": [246, 253, 160],
+		"cities": ["Vatican City"]
+	},
+	{
+		"name": "Wittenberg",
+		"adjective": ["Wittenberg"],
+		"cityStateType": "Religious",
+
+		"declaringWar": "You leave us no choice. War it must be.",
+		"attacked": "Very well, this shall not be forgotten.",
+		"defeated": "Perhaps now we will find peace in death...",
+		"outerColor": [0, 0, 0],
+		"innerColor": [167, 162, 216],
+		"cities": ["Wittenberg"]
 	},
 
 

--- a/android/assets/jsons/Civ V - Vanilla/Nations.json
+++ b/android/assets/jsons/Civ V - Vanilla/Nations.json
@@ -757,7 +757,7 @@
 	},
 	{
 		"name": "Kabul",
-		"adjective": ["Kabul"],
+		"adjective": ["Kabuli"],
 		"cityStateType": "Cultured",
 
 		"declaringWar": "You leave us no choice. War it must be.",
@@ -769,7 +769,7 @@
 	},
 	{
 		"name": "Kathmandu",
-		"adjective": ["Kathmandu"],
+		"adjective": ["Kathmanduites"],
 		"cityStateType": "Cultured", // Changed from Cultured to Religious in BNW
 
 		"declaringWar": "You leave us no choice. War it must be.",
@@ -793,7 +793,7 @@
 	},
 	{
 		"name": "Lhasa",
-		"adjective": ["tibetano"],
+		"adjective": ["Tibetano"],
 		"cityStateType": "Cultured",
 
 		"declaringWar": "You leave us no choice. War it must be.",
@@ -818,7 +818,7 @@
 	},
 	{
 		"name": "Monaco",
-		"adjective": ["Monaco"],
+		"adjective": ["Monegasque"],
 		"cityStateType": "Cultured",
 
 		"declaringWar": "You leave us no choice. War it must be.",
@@ -831,7 +831,7 @@
 
 	{
 		"name": "Cape Town",
-		"adjective": ["Cape Town"],
+		"adjective": ["Capetonian"],
 		"cityStateType": "Maritime",
 
 		"declaringWar": "You leave us no choice. War it must be.",
@@ -856,7 +856,7 @@
 	},
 	{
 		"name": "Helsinki",
-		"adjective": ["Helsinki"],
+		"adjective": ["Helsinkian"],
 		"cityStateType": "Maritime",
 
 		"declaringWar": "You leave us no choice. War it must be.",
@@ -881,7 +881,7 @@
 	},
 	{
 		"name": "Mogadishu", // Introduced in BNW
-		"adjective": ["Mogadishu"],
+		"adjective": ["Maqdishawi"],
 		"cityStateType": "Maritime",
 
 		"declaringWar": "You leave us no choice. War it must be.",
@@ -906,8 +906,9 @@
 	},
 	{
 		"name": "Ragusa",
-		"adjective": ["Ragusa"],
+		"adjective": ["Ragusan"],
 		"cityStateType": "Maritime",
+		"startBias": ["Coast"],
 
 		"declaringWar": "You leave us no choice. War it must be.",
 		"attacked": "Very well, this shall not be forgotten.",
@@ -943,7 +944,7 @@
 	},
 	{
 		"name": "Sydney",
-		"adjective": ["Sydney"],
+		"adjective": ["Sydneysider"],
 		"cityStateType": "Maritime",
 
 		"declaringWar": "After thorough deliberation, Australia finds itself at a crossroads. Prepare yourself, for war is upon us.",
@@ -955,7 +956,7 @@
 	},
 	{
 		"name": "Ur", // Introduced in BNW
-		"adjective": ["Ur"],
+		"adjective": ["Urian"],
 		"cityStateType": "Maritime",
 		"startBias": ["Coast"],
 
@@ -996,7 +997,7 @@
 
 	{
 		"name": "Antwerp", // Introduced in GK
-		"adjective": ["Antwerp"],
+		"adjective": ["Antwerpenaar", "Antwerpian"],
 		"cityStateType": "Mercantile",
 		"startBias": ["Coast"],
 
@@ -1010,7 +1011,7 @@
 	},
 	{
 		"name": "Zanzibar", // Introduced in GK
-		"adjective": ["Zanzibar"],
+		"adjective": ["Zanzibari"],
 		"cityStateType": "Mercantile",
 
 		"declaringWar": "You leave us no choice. War it must be.",
@@ -1024,7 +1025,7 @@
 
 	{
 		"name": "Almaty",
-		"adjective": ["Almaty"],
+		"adjective": ["Almatinian"],
 		"cityStateType": "Militaristic",
 
 		"declaringWar": "You leave us no choice. War it must be.",
@@ -1036,7 +1037,7 @@
 	},
 	{
 		"name": "Belgrade",
-		"adjective": ["Belgrade"],
+		"adjective": ["Belgradian"],
 		"cityStateType": "Militaristic",
 
 		"declaringWar": "Let's have a nice little War, shall we?",
@@ -1048,7 +1049,7 @@
 	},
 	{
 		"name": "Budapest",
-		"adjective": ["Budapest"],
+		"adjective": ["Budapester", "Budapesti"],
 		"cityStateType": "Militaristic",
 
 		"declaringWar": "Let's have a nice little War, shall we?",
@@ -1084,7 +1085,7 @@
 	},
 	{
 		"name": "Hanoi",
-		"adjective": ["Hanoi"],
+		"adjective": ["Hanoian"],
 		"cityStateType": "Militaristic",
 
 		"declaringWar": "You leave us no choice. War it must be.",
@@ -1096,7 +1097,7 @@
 	},
 	{
 		"name": "M'Banza-Kongo", // Introduced in BNW
-		"adjective": ["M'Banza-Kongo"],
+		"adjective": ["Angolan"],
 		"cityStateType": "Militaristic",
 
 		"declaringWar": "Do you really think you can walk over us so easily? I will not let it happen. Not to Kongo - not to my people!",
@@ -1109,7 +1110,7 @@
 	},
 	{
 		"name": "Sidon",
-		"adjective": ["Sidon"],
+		"adjective": ["Sidonian"],
 		"cityStateType": "Militaristic",
 
 		"declaringWar": "You leave us no choice. War it must be.",
@@ -1134,8 +1135,9 @@
 	},
 	{
 		"name": "Valletta", // Introduced in GK
-		"adjective": ["Maltese"],
+		"adjective": ["Beltin"],
 		"cityStateType": "Militaristic",
+		"startBias": ["Coast"],
 
 		"declaringWar": "We don't like your face. To arms!",
 		"attacked": "You will see you have just bitten off more than you can chew.",

--- a/android/assets/jsons/Civ V - Vanilla/Nations.json
+++ b/android/assets/jsons/Civ V - Vanilla/Nations.json
@@ -744,16 +744,16 @@
 		"cities": ["Florence"]
 	},
 	{
-		"name": "Hanoi",
-		"adjective": ["Hanoi"],
-		"cityStateType": "Cultured",
+		"name": "Geneva",
+		"adjective": ["Genevan", "Genevese"],
+		"cityStateType": "Cultured", // Changed from Cultured to Religious in GK
 
 		"declaringWar": "You leave us no choice. War it must be.",
 		"attacked": "Very well, this shall not be forgotten.",
-		"defeated": "So this is how it feels to die...",
+		"defeated": "I guess you weren't here for the sprouts after all...",
 		"outerColor": [0, 0, 0],
-		"innerColor": [167, 162, 216],
-		"cities": ["Hanoi"]
+		"innerColor": [51, 97, 242],
+		"cities": ["Geneva"]
 	},
 	{
 		"name": "Kabul",
@@ -766,6 +766,18 @@
         "outerColor": [0, 0, 0],
 		"innerColor": [121, 226, 0],
 		"cities": ["Kabul"]
+	},
+	{
+		"name": "Kathmandu",
+		"adjective": ["Kathmandu"],
+		"cityStateType": "Cultured", // Changed from Cultured to Religious in BNW
+
+		"declaringWar": "You leave us no choice. War it must be.",
+		"attacked": "Very well, this shall not be forgotten.",
+		"defeated": "We... defeated? No... we had so much work to do!",
+		"outerColor": [0, 0, 0],
+		"innerColor": [186, 18, 202],
+		"cities": ["Kathmandu"]
 	},
 	{
 		"name": "Kuala Lumpur",
@@ -792,7 +804,7 @@
 		"cities": ["Lhasa"]
 	},
 	{
-		"name": "Milan",
+		"name": "Milan", // Introduced in GK
 		"adjective": ["Milanese"],
 		"cityStateType": "Cultured",
 
@@ -801,7 +813,8 @@
 		"defeated": "You fiend! History shall remember this!",
 		"outerColor": [0, 0, 0],
 		"innerColor": [225, 194, 129],
-		"cities": ["Milan"]
+		"cities": ["Milan"],
+		"uniques": ["Will not be displayed in Civilopedia", "Will not be chosen for new games", "Excluded from map editor"]
 	},
 	{
 		"name": "Monaco",
@@ -814,18 +827,6 @@
 		"outerColor": [0, 0, 0],
 		"innerColor": [193, 84, 255],
 		"cities": ["Monaco"]
-	},
-	{
-		"name": "Quebec City",
-		"adjective": ["Québécois"],
-		"cityStateType": "Cultured",
-
-		"declaringWar": "You leave us no choice. War it must be.",
-		"attacked": "Very well, this shall not be forgotten.",
-		"defeated": "We were too weak to protect ourselves...",
-		"outerColor": [0, 0, 0],
-		"innerColor": [51, 97, 242],
-		"cities": ["Quebec City"]
 	},
 
 	{
@@ -841,6 +842,19 @@
 		"cities": ["Cape Town"]
 	},
 	{
+		"name": "Genoa",
+		"adjective": ["Genoese"],
+		"cityStateType": "Maritime", // Maritime in Vanilla
+		"startBias": ["Coast"],
+
+		"declaringWar": "You leave us no choice. War it must be.",
+		"attacked": "Very well, this shall not be forgotten.",
+		"defeated": "How barbaric. Those who live by the sword shall perish by the sword.",
+		"outerColor": [0, 0, 0],
+		"innerColor": [0, 163, 181],
+		"cities": ["Genoa"]
+	},
+	{
 		"name": "Helsinki",
 		"adjective": ["Helsinki"],
 		"cityStateType": "Maritime",
@@ -853,7 +867,7 @@
 		"cities": ["Helsinki"]
 	},
 	{
-		"name": "Manila",
+		"name": "Manila", // Introduced in GK
 		"adjective": ["Manilan"],
 		"cityStateType": "Maritime",
 
@@ -862,10 +876,11 @@
 		"defeated": "Ah, Gods! Why have you forsaken us?",
 		"outerColor": [0, 0, 0],
 		"innerColor": [113, 227, 114],
-		"cities": ["Manila"]
+		"cities": ["Manila"],
+		"uniques": ["Will not be displayed in Civilopedia", "Will not be chosen for new games", "Excluded from map editor"]
 	},
 	{
-		"name": "Mogadishu",
+		"name": "Mogadishu", // Introduced in BNW
 		"adjective": ["Mogadishu"],
 		"cityStateType": "Maritime",
 
@@ -874,7 +889,32 @@
 		"defeated": "Congratulations, conqueror. This tribe serves you now.",
 		"outerColor": [0, 0, 0],
 		"innerColor": [127, 177, 236],
-		"cities": ["Mogadishu"]
+		"cities": ["Mogadishu"],
+		"uniques": ["Will not be displayed in Civilopedia", "Will not be chosen for new games", "Excluded from map editor"]
+	},
+	{
+		"name": "Quebec City",
+		"adjective": ["Québécois"],
+		"cityStateType": "Maritime",
+
+		"declaringWar": "You leave us no choice. War it must be.",
+		"attacked": "Very well, this shall not be forgotten.",
+		"defeated": "We were too weak to protect ourselves...",
+		"outerColor": [0, 0, 0],
+		"innerColor": [51, 97, 242],
+		"cities": ["Quebec City"]
+	},
+	{
+		"name": "Ragusa",
+		"adjective": ["Ragusa"],
+		"cityStateType": "Maritime",
+
+		"declaringWar": "You leave us no choice. War it must be.",
+		"attacked": "Very well, this shall not be forgotten.",
+		"defeated": "We were too weak to protect ourselves...",
+		"outerColor": [0, 0, 0],
+		"innerColor": [0, 163, 181],
+		"cities": ["Ragusa"]
 	},
 	{
 		"name": "Rio de Janeiro",
@@ -890,6 +930,18 @@
 		"cities": ["Rio de Janeiro"]
 	},
 	{
+		"name": "Singapore",
+		"adjective": ["Singaporean"],
+		"cityStateType": "Maritime", // Changed from Maritime to Mercantile in GK
+
+		"declaringWar": "You leave us no choice. War it must be.",
+		"attacked": "Very well, this shall not be forgotten.",
+		"defeated": "Perhaps, in another world, we could have been friends...",
+		"outerColor": [0, 0, 0],
+		"innerColor": [246, 253, 160],
+		"cities": ["Singapore"]
+	},
+	{
 		"name": "Sydney",
 		"adjective": ["Sydney"],
 		"cityStateType": "Maritime",
@@ -902,7 +954,7 @@
 		"cities": ["Sydney"]
 	},
 	{
-		"name": "Ur",
+		"name": "Ur", // Introduced in BNW
 		"adjective": ["Ur"],
 		"cityStateType": "Maritime",
 		"startBias": ["Coast"],
@@ -912,10 +964,11 @@
 		"defeated": "What treachery has struck us? No, what evil?",
 		"outerColor": [0, 0, 0],
 		"innerColor": [167, 16, 216],
-		"cities": ["Ur"]
+		"cities": ["Ur"],
+		"uniques": ["Will not be displayed in Civilopedia", "Will not be chosen for new games", "Excluded from map editor"]
 	},
 	{
-		"name": "Vancouver",
+		"name": "Vancouver", // Introduced in BNW
 		"adjective": ["Vancouverite"],
 		"cityStateType": "Maritime",
 
@@ -924,7 +977,8 @@
 		"defeated": "I regret not defending my country to the last, although it was not of use.",
 		"outerColor": [0, 0, 0],
 		"innerColor": [193, 84, 255],
-		"cities": ["Vancouver"]
+		"cities": ["Vancouver"],
+		"uniques": ["Will not be displayed in Civilopedia", "Will not be chosen for new games", "Excluded from map editor"]
 	},
 	{
 		"name": "Venice",
@@ -941,7 +995,7 @@
 	},
 
 	{
-		"name": "Antwerp",
+		"name": "Antwerp", // Introduced in GK
 		"adjective": ["Antwerp"],
 		"cityStateType": "Mercantile",
 		"startBias": ["Coast"],
@@ -951,60 +1005,11 @@
 		"defeated": "They will write songs of this.... pray that they shall be in your favor.",
 		"outerColor": [0, 0, 0],
 		"innerColor": [193, 84, 255],
-		"cities": ["Antwerp"]
+		"cities": ["Antwerp"],
+		"uniques": ["Will not be displayed in Civilopedia", "Will not be chosen for new games", "Excluded from map editor"]
 	},
 	{
-		"name": "Genoa",
-		"adjective": ["Genoese"],
-		"cityStateType": "Mercantile",
-		"startBias": ["Coast"],
-
-		"declaringWar": "You leave us no choice. War it must be.",
-		"attacked": "Very well, this shall not be forgotten.",
-		"defeated": "How barbaric. Those who live by the sword shall perish by the sword.",
-		"outerColor": [0, 0, 0],
-		"innerColor": [0, 163, 181],
-		"cities": ["Genoa"]
-	},
-	{
-		"name": "Kathmandu",
-		"adjective": ["Kathmandu"],
-		"cityStateType": "Mercantile",
-
-		"declaringWar": "You leave us no choice. War it must be.",
-		"attacked": "Very well, this shall not be forgotten.",
-		"defeated": "We... defeated? No... we had so much work to do!",
-		"outerColor": [0, 0, 0],
-		"innerColor": [186, 18, 202],
-		"cities": ["Kathmandu"]
-	},
-	{
-		"name": "Singapore",
-		"adjective": ["Singaporean"],
-		"cityStateType": "Mercantile",
-
-		"declaringWar": "You leave us no choice. War it must be.",
-		"attacked": "Very well, this shall not be forgotten.",
-		"defeated": "Perhaps, in another world, we could have been friends...",
-		"outerColor": [0, 0, 0],
-		"innerColor": [246, 253, 160],
-		"cities": ["Singapore"]
-	},
-	{
-		"name": "Tyre",
-		"adjective": ["Tyrian"],
-		"cityStateType": "Mercantile",
-		"startBias": ["Coast"],
-
-		"declaringWar": "You leave us no choice. War it must be.",
-		"attacked": "Very well, this shall not be forgotten.",
-		"defeated": "We never fully trusted you from the start.",
-		"outerColor": [0, 0, 0],
-		"innerColor": [121, 226, 0],
-		"cities": ["Tyre"]
-	},
-	{
-		"name": "Zanzibar",
+		"name": "Zanzibar", // Introduced in GK
 		"adjective": ["Zanzibar"],
 		"cityStateType": "Mercantile",
 
@@ -1013,7 +1018,8 @@
 		"defeated": "May the Heavens forgive you for inflicting this humiliation to our people.",
 		"outerColor": [0, 0, 0],
 		"innerColor": [127, 177, 236],
-		"cities": ["Zanzibar"]
+		"cities": ["Zanzibar"],
+		"uniques": ["Will not be displayed in Civilopedia", "Will not be chosen for new games", "Excluded from map editor"]
 	},
 
 	{
@@ -1041,7 +1047,19 @@
 		"cities": ["Belgrade"]
 	},
 	{
-		"name": "Dublin",
+		"name": "Budapest",
+		"adjective": ["Budapest"],
+		"cityStateType": "Militaristic",
+
+		"declaringWar": "Let's have a nice little War, shall we?",
+		"attacked": "If you need your nose bloodied, we'll happily serve.",
+		"defeated": "The serbian guerilla will never stop haunting you!",
+		"outerColor": [0, 0, 0],
+		"innerColor": [217, 158, 78],
+		"cities": ["Budapest"]
+	},
+	{
+		"name": "Dublin", // Dublin became a city in GK, but is available in Vanilla.
 		"adjective": ["Dubliner"],
 		"cityStateType": "Militaristic",
 
@@ -1050,11 +1068,10 @@
 		"defeated": "A lonely wind blows through the highlands today. A dirge for Ireland. Can you hear it?",
 		"outerColor": [0, 0, 0],
 		"innerColor": [211,180,113],
-		"cities": ["Dublin"],
-		"uniques": ["Will not be displayed in Civilopedia", "Will not be chosen for new games", "Excluded from map editor"]
+		"cities": ["Dublin"]
 	},
 	{
-		"name": "Edinburgh",
+		"name": "Edinburgh", // Edinburgh became a city in GK, but is available in Vanilla.
 		"adjective": ["Edinburghensian"],
 		"cityStateType": "Militaristic",
 
@@ -1063,11 +1080,22 @@
 		"defeated": "Vile ruler, know that you 'won' this war in name only!",
 		"outerColor": [0, 0, 0],
 		"innerColor": [0,102,102],
-		"cities": ["Edinburgh"],
-		"uniques": ["Will not be displayed in Civilopedia", "Will not be chosen for new games", "Excluded from map editor"]
+		"cities": ["Edinburgh"]
 	},
 	{
-		"name": "M'Banza-Kongo",
+		"name": "Hanoi",
+		"adjective": ["Hanoi"],
+		"cityStateType": "Militaristic",
+
+		"declaringWar": "You leave us no choice. War it must be.",
+		"attacked": "Very well, this shall not be forgotten.",
+		"defeated": "So this is how it feels to die...",
+		"outerColor": [0, 0, 0],
+		"innerColor": [167, 162, 216],
+		"cities": ["Hanoi"]
+	},
+	{
+		"name": "M'Banza-Kongo", // Introduced in BNW
 		"adjective": ["M'Banza-Kongo"],
 		"cityStateType": "Militaristic",
 
@@ -1076,7 +1104,8 @@
 		"defeated": "You are nothing but a glorified barbarian. Cruel, and ruthless.",
 		"outerColor": [0, 0, 0],
 		"innerColor": [18, 188, 221],
-		"cities": ["M'Banza-Kongo"]
+		"cities": ["M'Banza-Kongo"],
+		"uniques": ["Will not be displayed in Civilopedia", "Will not be chosen for new games", "Excluded from map editor"]
 	},
 	{
 		"name": "Sidon",
@@ -1091,8 +1120,21 @@
 		"cities": ["Sidon"]
 	},
 	{
-		"name": "Valletta",
-		"adjective": ["maltese"],
+		"name": "Tyre",
+		"adjective": ["Tyrian"],
+		"cityStateType": "Militaristic", // Changed from Militaristic to Mercantile in GK
+		"startBias": ["Coast"],
+
+		"declaringWar": "You leave us no choice. War it must be.",
+		"attacked": "Very well, this shall not be forgotten.",
+		"defeated": "We never fully trusted you from the start.",
+		"outerColor": [0, 0, 0],
+		"innerColor": [121, 226, 0],
+		"cities": ["Tyre"]
+	},
+	{
+		"name": "Valletta", // Introduced in GK
+		"adjective": ["Maltese"],
 		"cityStateType": "Militaristic",
 
 		"declaringWar": "We don't like your face. To arms!",
@@ -1100,7 +1142,8 @@
 		"defeated": "This ship may sink, but our spirits will linger.",
 		"outerColor": [0, 0, 0],
 		"innerColor": [222, 237, 59],
-		"cities": ["Valletta"]
+		"cities": ["Valletta"],
+		"uniques": ["Will not be displayed in Civilopedia", "Will not be chosen for new games", "Excluded from map editor"]
 	},
 
 

--- a/android/assets/jsons/Civ V - Vanilla/Nations.json
+++ b/android/assets/jsons/Civ V - Vanilla/Nations.json
@@ -716,8 +716,20 @@
 		"attacked": "Very well, this shall not be forgotten.",
 		"defeated": "I guess you weren't here for the sprouts after all...",
 		"outerColor": [0, 0, 0],
-		"innerColor": [153,255,51],
+		"innerColor": [127, 177, 236],
 		"cities": ["Brussels"]
+	},
+	{
+		"name": "Bucharest",
+		"adjective": ["Bucuresti"],
+		"cityStateType": "Cultured",
+
+		"declaringWar": "You leave us no choice. War it must be.",
+		"attacked": "Very well, this shall not be forgotten.",
+		"defeated": "I guess you weren't here for the sprouts after all...",
+		"outerColor": [0, 0, 0],
+		"innerColor": [113, 227, 114],
+		"cities": ["Bucharest"]
 	},
 	{
 		"name": "Florence",
@@ -728,7 +740,7 @@
 		"attacked": "Very well, this shall not be forgotten.",
 		"defeated": "And so the flower of Florence falls to barbaric hands...",
 		"outerColor": [0, 0, 0],
-		"innerColor": [62,197,252],
+		"innerColor": [18, 188, 221],
 		"cities": ["Florence"]
 	},
 	{
@@ -740,7 +752,7 @@
 		"attacked": "Very well, this shall not be forgotten.",
 		"defeated": "So this is how it feels to die...",
 		"outerColor": [0, 0, 0],
-		"innerColor": [51,51,255],
+		"innerColor": [167, 162, 216],
 		"cities": ["Hanoi"]
 	},
 	{
@@ -752,7 +764,7 @@
 		"attacked": "Very well, this shall not be forgotten.",
 		"defeated": "Unacceptable!",
         "outerColor": [0, 0, 0],
-        "innerColor": [168,38,102],
+		"innerColor": [121, 226, 0],
 		"cities": ["Kabul"]
 	},
 	{
@@ -764,7 +776,7 @@
 		"attacked": "Very well, this shall not be forgotten.",
 		"defeated": "Today, the Malay people obey you, but do not think this is over...",
 		"outerColor": [0, 0, 0],
-		"innerColor": [0,102,102],
+		"innerColor": [222, 237, 59],
 		"cities": ["Kuala Lumpur"]
 	},
 	{
@@ -776,7 +788,7 @@
 		"attacked": "Very well, this shall not be forgotten.",
 		"defeated": "Perhaps now we will find peace in death...",
 		"outerColor": [0, 0, 0],
-		"innerColor": [204,102,0],
+		"innerColor": [113, 227, 114],
 		"cities": ["Lhasa"]
 	},
 	{
@@ -788,8 +800,20 @@
 		"attacked": "Very well, this shall not be forgotten.",
 		"defeated": "You fiend! History shall remember this!",
 		"outerColor": [0, 0, 0],
-		"innerColor": [185,132,66],
+		"innerColor": [225, 194, 129],
 		"cities": ["Milan"]
+	},
+	{
+		"name": "Monaco",
+		"adjective": ["Monaco"],
+		"cityStateType": "Cultured",
+
+		"declaringWar": "You leave us no choice. War it must be.",
+		"attacked": "Very well, this shall not be forgotten.",
+		"defeated": "You fiend! History shall remember this!",
+		"outerColor": [0, 0, 0],
+		"innerColor": [193, 84, 255],
+		"cities": ["Monaco"]
 	},
 	{
 		"name": "Quebec City",
@@ -800,7 +824,7 @@
 		"attacked": "Very well, this shall not be forgotten.",
 		"defeated": "We were too weak to protect ourselves...",
 		"outerColor": [0, 0, 0],
-		"innerColor": [51,102,0],
+		"innerColor": [51, 97, 242],
 		"cities": ["Quebec City"]
 	},
 
@@ -813,7 +837,7 @@
 		"attacked": "Very well, this shall not be forgotten.",
 		"defeated": "I have failed. May you, at least, know compassion towards our people.",
 		"outerColor": [0, 0, 0],
-		"innerColor": [255,153,153],
+		"innerColor": [217, 158, 78],
 		"cities": ["Cape Town"]
 	},
 	{
@@ -837,7 +861,7 @@
 		"attacked": "Very well, this shall not be forgotten.",
 		"defeated": "Ah, Gods! Why have you forsaken us?",
 		"outerColor": [0, 0, 0],
-		"innerColor": [96,96,96],
+		"innerColor": [113, 227, 114],
 		"cities": ["Manila"]
 	},
 	{
@@ -849,7 +873,7 @@
 		"attacked": "Very well, this shall not be forgotten.",
 		"defeated": "Congratulations, conqueror. This tribe serves you now.",
 		"outerColor": [0, 0, 0],
-		"innerColor": [224,224,224],
+		"innerColor": [127, 177, 236],
 		"cities": ["Mogadishu"]
 	},
 	{
@@ -874,7 +898,7 @@
 		"attacked": "We will mobilize every means of resistance to stop this transgression against our nation!",
 		"defeated": "The principles for which we have fought will survive longer than any nation you could ever build.",
 		"outerColor": [0, 0, 0],
-		"innerColor": [255,204,204],
+		"innerColor": [51, 97, 242],
 		"cities": ["Sydney"]
 	},
 	{
@@ -887,7 +911,7 @@
 		"attacked": "Why do we fight? Because Inanna demands it. Now, witness the power of the Sumerians!",
 		"defeated": "What treachery has struck us? No, what evil?",
 		"outerColor": [0, 0, 0],
-		"innerColor": [255,69,0],
+		"innerColor": [167, 16, 216],
 		"cities": ["Ur"]
 	},
 	{
@@ -899,7 +923,7 @@
 		"attacked": "As we can reach no peaceful resolution with you, Canada must turn, with reluctance, to war.",
 		"defeated": "I regret not defending my country to the last, although it was not of use.",
 		"outerColor": [0, 0, 0],
-		"innerColor": [0,255,128],
+		"innerColor": [193, 84, 255],
 		"cities": ["Vancouver"]
 	},
 	{
@@ -926,7 +950,7 @@
 		"attacked": "Very well, this shall not be forgotten.",
 		"defeated": "They will write songs of this.... pray that they shall be in your favor.",
 		"outerColor": [0, 0, 0],
-		"innerColor": [194,97,255],
+		"innerColor": [193, 84, 255],
 		"cities": ["Antwerp"]
 	},
 	{
@@ -939,7 +963,7 @@
 		"attacked": "Very well, this shall not be forgotten.",
 		"defeated": "How barbaric. Those who live by the sword shall perish by the sword.",
 		"outerColor": [0, 0, 0],
-		"innerColor": [45,255,86],
+		"innerColor": [0, 163, 181],
 		"cities": ["Genoa"]
 	},
 	{
@@ -951,7 +975,7 @@
 		"attacked": "Very well, this shall not be forgotten.",
 		"defeated": "We... defeated? No... we had so much work to do!",
 		"outerColor": [0, 0, 0],
-		"innerColor": [151,125,0],
+		"innerColor": [186, 18, 202],
 		"cities": ["Kathmandu"]
 	},
 	{
@@ -963,7 +987,7 @@
 		"attacked": "Very well, this shall not be forgotten.",
 		"defeated": "Perhaps, in another world, we could have been friends...",
 		"outerColor": [0, 0, 0],
-		"innerColor": [255,255,0],
+		"innerColor": [246, 253, 160],
 		"cities": ["Singapore"]
 	},
 	{
@@ -976,7 +1000,7 @@
 		"attacked": "Very well, this shall not be forgotten.",
 		"defeated": "We never fully trusted you from the start.",
 		"outerColor": [0, 0, 0],
-		"innerColor": [255,97,255],
+		"innerColor": [121, 226, 0],
 		"cities": ["Tyre"]
 	},
 	{
@@ -988,7 +1012,7 @@
 		"attacked": "Very well, this shall not be forgotten.",
 		"defeated": "May the Heavens forgive you for inflicting this humiliation to our people.",
 		"outerColor": [0, 0, 0],
-		"innerColor": [255,153,255],
+		"innerColor": [127, 177, 236],
 		"cities": ["Zanzibar"]
 	},
 
@@ -1001,7 +1025,7 @@
 		"attacked": "Very well, this shall not be forgotten.",
 		"defeated": "How could we fall to the likes of you?!",
 		"outerColor": [0, 0, 0],
-		"innerColor": [152,0,241],
+		"innerColor": [217, 158, 78],
 		"cities": ["Almaty"]
 	},
 	{
@@ -1013,7 +1037,7 @@
 		"attacked": "If you need your nose bloodied, we'll happily serve.",
 		"defeated": "The serbian guerilla will never stop haunting you!",
 		"outerColor": [0, 0, 0],
-		"innerColor": [211,180,113],
+		"innerColor": [121, 226, 0],
 		"cities": ["Belgrade"]
 	},
 	{
@@ -1051,7 +1075,7 @@
 		"attacked": "We are no strangers to war. You have strayed from the right path, and now we will correct it.",
 		"defeated": "You are nothing but a glorified barbarian. Cruel, and ruthless.",
 		"outerColor": [0, 0, 0],
-		"innerColor": [255,128,0],
+		"innerColor": [18, 188, 221],
 		"cities": ["M'Banza-Kongo"]
 	},
 	{
@@ -1063,7 +1087,7 @@
 		"attacked": "Very well, this shall not be forgotten.",
 		"defeated": "What a fine battle! Sidon is willing to serve you!",
 		"outerColor": [0, 0, 0],
-		"innerColor": [250,128,114],
+		"innerColor": [186, 18, 202],
 		"cities": ["Sidon"]
 	},
 	{
@@ -1075,7 +1099,7 @@
 		"attacked": "You will see you have just bitten off more than you can chew.",
 		"defeated": "This ship may sink, but our spirits will linger.",
 		"outerColor": [0, 0, 0],
-		"innerColor": [0,102,102],
+		"innerColor": [222, 237, 59],
 		"cities": ["Valletta"]
 	},
 


### PR DESCRIPTION
This goes through a round of fixes for City-States across both Vanilla and Gods & Kings.

- Updates the colors [where applicable](https://civilization-v-customisation.fandom.com/wiki/List_of_City-States)
- Fixes the availability of City-States across the expansions
- Adds missing City-States
- Fixes the City-State types across expansions when needed
- Fixes the adjectives for each City-State, where I could find them

The diff can look strange because there were city-state types that change, so I moved them around to their respective city-state type section.
