### PR TITLE
Add infinite tech cost

### DIFF
--- a/android/assets/jsons/Civ V - Gods & Kings/Techs.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Techs.json
@@ -685,7 +685,7 @@
 	{
 		"columnNumber": 17,
 		"era": "Future era",
-		"techCost": 9500,
+		"techCost": -1,
 		"buildingCost": 750,
 		"wonderCost": 1250,
 		"techs": [

--- a/android/assets/jsons/Civ V - Vanilla/Techs.json
+++ b/android/assets/jsons/Civ V - Vanilla/Techs.json
@@ -609,7 +609,7 @@
 	{
 		"columnNumber": 17,
 		"era": "Future era",
-		"techCost": 9500,
+		"techCost": -1,
 		"buildingCost": 750,
 		"wonderCost": 1250,
 		"techs": [

--- a/core/src/com/unciv/logic/civilization/managers/TechManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/TechManager.kt
@@ -111,6 +111,10 @@ class TechManager : IsPartOfGameInfoSerialization {
 
     fun costOfTech(techName: String): Int {
         var techCost = getRuleset().technologies[techName]!!.cost.toFloat()
+        
+        if (techCost < 0) 
+            return -1;
+        
         if (civInfo.isHuman())
             techCost *= civInfo.getDifficulty().researchCostModifier
         techCost *= civInfo.gameInfo.speed.scienceCostModifier
@@ -260,9 +264,15 @@ class TechManager : IsPartOfGameInfoSerialization {
     fun addScience(scienceGet: Int) {
         val currentTechnology = currentTechnologyName() ?: return
         techsInProgress[currentTechnology] = researchOfTech(currentTechnology) + scienceGet
-        if (techsInProgress[currentTechnology]!! < costOfTech(currentTechnology))
+        val techCost = costOfTech(currentTechnology)
+        if (techsInProgress[currentTechnology]!! < techCost)
             return
-
+        
+        // New proposal: Set techCost to -1 for the last tech to ensure that program does not keep
+        //               recursing for high science values.
+        if (techCost == -1) 
+            return 
+        
         // We finished it!
         // http://www.civclub.net/bbs/forum.php?mod=viewthread&tid=123976
         val extraScienceLeftOver = techsInProgress[currentTechnology]!! - costOfTech(currentTechnology)

--- a/core/src/com/unciv/logic/civilization/managers/TechManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/TechManager.kt
@@ -113,6 +113,8 @@ class TechManager : IsPartOfGameInfoSerialization {
         var techCost = getRuleset().technologies[techName]!!.cost.toFloat()
         
         if (techCost < 0) 
+            // no futher manipulation is to be done to the tech cost
+            // (-0.8).asInt() gives 0 therefore should always just return -1 instead
             return -1;
         
         if (civInfo.isHuman())
@@ -268,8 +270,8 @@ class TechManager : IsPartOfGameInfoSerialization {
         if (techsInProgress[currentTechnology]!! < techCost)
             return
         
-        // New proposal: Set techCost to -1 for the last tech to ensure that program does not keep
-        //               recursing for high science values.
+        // For unresearchable tech. Placeholders for end of research tree, 
+        // to avoid high recursion depth and stackover when having high science e.g. 1B   
         if (techCost == -1) 
             return 
         


### PR DESCRIPTION
This is a fix to a bug I encountered while playing the game with cheat mods on Android: 
- When the Science is very high (e.g. 1 billion), it causes a stack overflow with the following recurring pattern of function calls:
```
TechManager.addScience
TechManager.addTechnology$Default
TechManager.addTechnology
TechManager.updateResearchProgress
```

That is due to the implementation not using the tail-recursive optimization keyword `tailrec` ([StackOverFlow](https://stackoverflow.com/questions/51638557/what-is-the-point-of-tailrec-in-kotlin)). However, I am not sure if the implementation must be a tail-recursion and therefore I am not adding the keyword to the function.

Instead, I am adding the handling of negatives for techCost, where -1 should represent that this tech should have an infinite tech cost.  

**Reason for using -1**
There does not seem to be a consensus on how to handle infinity on JSON ("inf" vs "infinity"), and I want to make sure that the typing in the JSON for techCost is still a number for parsing.  Therefore, I opted with -1 as it represents an invalid value. This would mean that if there are any mods that rely on techCost being negative, they may not work as intended anymore.

**How it is handled**
The JSON parser does not seem to have any issues when parsing negative values from `tech.json`
When techCost is negative, `TechManager::costOfTech` gives -1. A branch is added to `TechManager::addScience` that checks for this -1 and returns early if it encounters the value. This way, no science is added to the overflow science, and the function returns as though no new technology is researched. The recursion can then stop early.

**Example**
See the changes in the `tech.json` for the 2 rulesets.

**Alternative implementations**
- Adding `tailrec` keyword to the functions mentioned at the start
  - Should retain the same behaviour, but I am not too sure about the performance
  - Compiler enforces the tailrec strictly, may require refactoring if some of the functions are not tailrec.

**Requests**
- Do let me know if I need to open an issue to reference this PR with regards to the stack overflow bug
- I am not too sure how to upload game saves. I have the save in a text file but I am not sure of the exact format to upload it
- Do let me know if there are functions that will be impacted by the change in behaviour and how I should test them