### PR TITLE
Fix showing negative mod download progress

### DIFF
--- a/core/src/com/unciv/logic/github/Github.kt
+++ b/core/src/com/unciv/logic/github/Github.kt
@@ -261,8 +261,8 @@ object Github {
         private fun startTracking() {
             trackerThread = Concurrency.run("Downloading mod progress") {
                 while (this.isActive) {
-                    val percentage = bytesRead() * 100 / contentLength
-                    updateProgressPercent(percentage)
+                    val percentage = (bytesRead() * 100L / contentLength).toInt()
+                    updateProgressPercent(percentage.coerceIn(0, 100))
                     if (percentage >= 100) {
                         stopTracking()
                         break


### PR DESCRIPTION
Fixes #13309

We should migrate all code handling file sizes to use longs, but... This is the easier band-aid.