### PR TITLE
Bugfix: AI less likely to forward-settle other players

### DIFF
--- a/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
+++ b/core/src/com/unciv/logic/automation/unit/CityLocationTileRanker.kt
@@ -146,8 +146,10 @@ object CityLocationTileRanker {
                 else -> 0f
             }
             // We want a defensive ring around our capital
-            if (city.civ == civ) distanceToCityModifier *= if (city.isCapital()) 2 else 1
-            modifier += distanceToCityModifier
+             if (city.civ == civ) { 
+                distanceToCityModifier *= if (city.isCapital()) 2 else 1
+                modifier += distanceToCityModifier
+            }
         }
         return modifier
     }


### PR DESCRIPTION
I think the indent was wrong here, causing the AI to unreasonably forward-settle the other players (we should only look at distance to own cities)