### PR TITLE
Update The Louvre and Machu Picchu

### DIFF
--- a/android/assets/jsons/Civ V - Gods & Kings/Buildings.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Buildings.json
@@ -495,8 +495,8 @@
 	{
 		"name": "Machu Picchu",
 		"gold": 5,
+		"faith": 2,
 		"greatPersonPoints": {"Great Merchant": 1},
-		"culture": 1,
 		"isWonder": true,
 		"uniques": ["[+25]% [Gold] from Trade Routes", "Must have an owned [Mountain] within [2] tiles"],
 		"requiredTech": "Guilds",
@@ -860,8 +860,8 @@
 	},
 	{
 		"name": "The Louvre",
-		"culture": 1,
-		"happiness": 4,
+		"culture": 4,
+		"greatPersonPoints": {"Great Artist": 2},
 		"isWonder": true,
 		"uniques": ["[2] free [Great Artist] units appear"],
 		"requiredTech": "Archaeology",

--- a/android/assets/jsons/Civ V - Vanilla/Buildings.json
+++ b/android/assets/jsons/Civ V - Vanilla/Buildings.json
@@ -713,8 +713,8 @@
 	},
 	{
 		"name": "The Louvre",
-		"culture": 1,
-		"happiness": 4,
+		"culture": 4,
+		"greatPersonPoints": {"Great Artist": 2},
 		"isWonder": true,
 		"uniques": ["[2] free [Great Artist] units appear"],
 		"requiredTech": "Archaeology",


### PR DESCRIPTION
According to the respective Civilopedias. In Civ5 it's  apparently called "Louvre" without "The".

The Palace is supposed to grant +2.5 strength, not 2. Should we round up or down?