### PR TITLE
Bugfix: faith upon meeting religious CS

### DIFF
--- a/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyFunctions.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyFunctions.kt
@@ -58,7 +58,7 @@ class DiplomacyFunctions(val civInfo: Civilization) {
             else
                 otherCiv.addNotification(meetString, NotificationCategory.Diplomacy, NotificationIcon.Gold)
 
-            if (otherCiv.isCityState && otherCiv.cityStateFunctions.canProvideStat(Stat.Faith)) {
+            if (civInfo.cityStateFunctions.canProvideStat(Stat.Faith)) {
                 otherCiv.addNotification(religionMeetString, NotificationCategory.Diplomacy, NotificationIcon.Faith)
 
                 for ((key, value) in faithAmount)


### PR DESCRIPTION
The code block is only run when otherCiv is a majorCiv, but then the faithAmount is only gifted when otherCiv is a cityState, so it's never used. I suppose this fixes it.