### PR TITLE
Update NextTurnAutomation.kt

### DIFF
--- a/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
@@ -550,6 +550,7 @@ object NextTurnAutomation {
         }
 
         val bestCity = civInfo.cities.filterNot { it.isPuppet }
+            .filterNot { it.population.population < 3 } // Generally you'd want 3 population to produce settlers quickly
             // If we can build workers, then we want AT LEAST 2 improvements, OR a worker nearby.
             // Otherwise, AI tries to produce settlers when it can hardly sustain itself
             .filter { city ->

--- a/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
@@ -549,8 +549,7 @@ object NextTurnAutomation {
                 && it.isBuildable(civInfo)
         }
 
-        val bestCity = civInfo.cities.filterNot { it.isPuppet }
-            .filterNot { it.population.population < 3 } // Generally you'd want 3 population to produce settlers quickly
+        val bestCity = civInfo.cities.filterNot { it.isPuppet || it.population.population < 2 }
             // If we can build workers, then we want AT LEAST 2 improvements, OR a worker nearby.
             // Otherwise, AI tries to produce settlers when it can hardly sustain itself
             .filter { city ->


### PR DESCRIPTION
Resolves https://discord.com/channels/586194543280390151/1379038897270423613, but maybe it should take into account the actual population requirements so it's compatible across all rulesets?

Also, the worker requirement is not something humans generally take into account, they build settlers then workers (Rekmod is a little different). The building requirement count the palace, for Liberty is should most likely be three buildings (palace + monument + shrine) instead of two.