### PR TITLE
Add uniques to remove tile resources and improvements

### DIFF
--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -24,6 +24,7 @@ import com.unciv.logic.map.mapgenerator.RiverGenerator
 import com.unciv.logic.map.mapunit.MapUnit
 import com.unciv.logic.map.tile.Tile
 import com.unciv.logic.map.tile.TileNormalizer
+import com.unciv.logic.map.tile.RoadStatus
 import com.unciv.models.UpgradeUnitAction
 import com.unciv.models.ruleset.BeliefType
 import com.unciv.models.ruleset.Event
@@ -1069,6 +1070,24 @@ object UniqueTriggerActivation {
                     ?: return null
                 return {
                     unit.promotions.removePromotion(promotion)
+                    true
+                }
+            }
+
+            UniqueType.OneTimeRemoveResourcesFromTile -> {
+                if (tile == null) return null
+                return {
+                    tile.resource = null
+                    tile.resourceAmount = 0
+                    true
+                }
+            }
+
+            UniqueType.OneTimeRemoveImprovementFromTile -> {
+                if (tile == null) return null
+                return {
+                    tile.improvement = null
+                    tile.improvementIsPillaged = false
                     true
                 }
             }

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -1096,14 +1096,12 @@ object UniqueTriggerActivation {
                 return {
                     // Don't remove the improvement if we're just removing the roads
                     if (improvementFilter != "All Road") {
-                        tile.improvement = null
-                        tile.improvementIsPillaged = false
+                        tile.removeImprovement()
                     }
 
                     // Remove the roads if desired
                     if (improvementFilter == "All" || improvementFilter == "All Road") {
-                        tile.roadStatus = RoadStatus.None
-                        tile.roadIsPillaged = false
+                        tile.removeRoad()
                     }
                     true
                 }

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -1078,8 +1078,7 @@ object UniqueTriggerActivation {
                 if (tile == null) return null
                 if (tile.resource == null) return null
                 val resourceFilter = unique.params[0]
-                var tileResource = tile.tileResource
-                if (!tileResource.matchesFilter(resourceFilter)) return null
+                if (!tile.tileResource.matchesFilter(resourceFilter)) return null
                 return {
                     tile.resource = null
                     tile.resourceAmount = 0
@@ -1089,9 +1088,9 @@ object UniqueTriggerActivation {
 
             UniqueType.OneTimeRemoveImprovementsFromTile -> {
                 if (tile == null) return null
-                val improvementFilter = unique.params[0]
                 val tileImprovement = tile.getTileImprovement()
                 if (tileImprovement == null) return null
+                val improvementFilter = unique.params[0]
                 if (!tileImprovement.matchesFilter(improvementFilter)) return null
                 return {
                     // Don't remove the improvement if we're just removing the roads

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -24,7 +24,6 @@ import com.unciv.logic.map.mapgenerator.RiverGenerator
 import com.unciv.logic.map.mapunit.MapUnit
 import com.unciv.logic.map.tile.Tile
 import com.unciv.logic.map.tile.TileNormalizer
-import com.unciv.logic.map.tile.RoadStatus
 import com.unciv.models.UpgradeUnitAction
 import com.unciv.models.ruleset.BeliefType
 import com.unciv.models.ruleset.Event

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -862,8 +862,8 @@ enum class UniqueType(
 
     OneTimeChangeTerrain("Turn this tile into a [terrainName] tile", UniqueTarget.Triggerable),
 
-    OneTimeRemoveResourcesFromTile("Remove resources from this tile", UniqueTarget.Triggerable),
-    OneTimeRemoveImprovementFromTile("Remove improvement from this tile", UniqueTarget.Triggerable),
+    OneTimeRemoveResourcesFromTile("Remove [resourceFilter] resources from this tile", UniqueTarget.Triggerable),
+    OneTimeRemoveImprovementsFromTile("Remove [improvementFilter] improvements from this tile", UniqueTarget.Triggerable),
 
     UnitsGainPromotion("[mapUnitFilter] units gain the [promotion] promotion", UniqueTarget.Triggerable,
         docDescription = "Works only with promotions that are valid for the unit's type - or for promotions that do not specify any."),  // Not used in Vanilla

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -862,6 +862,8 @@ enum class UniqueType(
 
     OneTimeChangeTerrain("Turn this tile into a [terrainName] tile", UniqueTarget.Triggerable),
 
+    OneTimeRemoveResourcesFromTile("Remove resources from this tile", UniqueTarget.Triggerable),
+    OneTimeRemoveImprovementFromTile("Remove improvement from this tile", UniqueTarget.Triggerable),
 
     UnitsGainPromotion("[mapUnitFilter] units gain the [promotion] promotion", UniqueTarget.Triggerable,
         docDescription = "Works only with promotions that are valid for the unit's type - or for promotions that do not specify any."),  // Not used in Vanilla

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -176,6 +176,12 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 	Applicable to: Triggerable
 
+??? example  "Remove resources from this tile"
+	Applicable to: Triggerable
+
+??? example  "Remove improvement from this tile"
+	Applicable to: Triggerable
+
 ??? example  "[mapUnitFilter] units gain the [promotion] promotion"
 	Works only with promotions that are valid for the unit's type - or for promotions that do not specify any.
 	Example: "[Wounded] units gain the [Shock I] promotion"

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -176,10 +176,14 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 	Applicable to: Triggerable
 
-??? example  "Remove resources from this tile"
+??? example  "Remove [resourceFilter] resources from this tile"
+	Example: "Remove [Strategic] resources from this tile"
+
 	Applicable to: Triggerable
 
-??? example  "Remove improvement from this tile"
+??? example  "Remove [improvementFilter] improvements from this tile"
+	Example: "Remove [All Road] improvements from this tile"
+
 	Applicable to: Triggerable
 
 ??? example  "[mapUnitFilter] units gain the [promotion] promotion"


### PR DESCRIPTION
In [Civ V Brave New World](https://github.com/RobLoach/Civ-V-Brave-New-World), there are [Antiquity Sites](https://github.com/RobLoach/Civ-V-Brave-New-World/blob/255338de4870407ffd16cbd1dd582c2ec7a6b3de/jsons/TileResources.json#L217) scattered through the map:
https://civilization.fandom.com/wiki/Antiquity_Site_(Civ5)

An Archaeologist can dig them up, removing them, and giving you an Artifact. When they dig them up, the Antiquity Site should no longer be there. Since there was no real way to handle this with uniques, I thought I'd add two new ones to Unciv...

```
Remove resources from this tile
```

```
Remove improvement from this tile
```

Let me know if there's anything to change.

### To Test

Change "Workers" to have...
```
{
  "name": "Worker",
  "unitType": "Civilian",
  "movement": 2,
  "uniques": [
    "Can build [Land] improvements on tiles",
    "Automation is a primary action",
    "Remove improvement from this tile <by consuming this unit>",
    "Remove resources from this tile <by consuming this unit>"
  ],
  "cost": 70
}
```

![Screenshot from 2025-06-02 20-28-16](https://github.com/user-attachments/assets/f288bc82-edbd-4ef3-8a2a-2e6b744ced11)
