### PR TITLE
Add a mod blacklist to hide old Brave New World mods

### DIFF
--- a/core/src/com/unciv/ui/screens/modmanager/ModManagementScreen.kt
+++ b/core/src/com/unciv/ui/screens/modmanager/ModManagementScreen.kt
@@ -119,6 +119,12 @@ class ModManagementScreen private constructor(
     // Therefore, finding `runningSearchJob?.isActive == false && !stopBackgroundTasks` means stopped by user
     private var stopBackgroundTasks = false
 
+    // List of mods that will be hidden from the mod search
+    private var modBlacklist: List<String> = listOf(
+        "Brave New World",
+        "Brave New World Updated"
+    )
+
     override fun dispose() {
         // make sure the worker threads will not continue trying their time-intensive job
         runningSearchJob?.cancel()
@@ -692,6 +698,7 @@ class ModManagementScreen private constructor(
         val sortedMods = onlineModInfo.values.asSequence().sortedWith(optionsManager.sortOnline.comparator)
         for (mod in sortedMods) {
             if (!mod.matchesFilter(filter)) continue
+            if (mod.name in modBlacklist) continue
             onlineModsTable.add(getCachedModButton(mod)).row()
         }
 


### PR DESCRIPTION
There are a few BNW mods out there that either crash Unciv, or just don't function. This can cause confusion for users, so hopefully having a mod blacklist will help direct them accordingly.

I'm unsure about this approach, but hope it reduces confusion when people are looking for working mods. Since it's a list, it could easily be applied to other situations too.

Fixes #13398
