### PR TITLE
Add a `[civFilter] [buildingFilter] Buildings` countable

### DIFF
--- a/core/src/com/unciv/models/ruleset/unique/Countables.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Countables.kt
@@ -121,6 +121,20 @@ enum class Countables(
         override fun getKnownValuesForAutocomplete(ruleset: Ruleset) = setOf<String>()
     },
 
+    FilteredGlobalBuildings("Global [buildingFilter] Buildings") {
+        override fun eval(parameterText: String, stateForConditionals: StateForConditionals): Int? {
+            val filter = parameterText.getPlaceholderParameters()[0]
+            val cities = stateForConditionals.gameInfo?.civilizations
+                ?.flatMap { it.cities } ?: return null
+            return cities.sumOf { city ->
+                city.cityConstructions.getBuiltBuildings().count { it.matchesFilter(filter) }
+            }
+        }
+        override fun getErrorSeverity(parameterText: String, ruleset: Ruleset): UniqueType.UniqueParameterErrorSeverity? =
+            UniqueParameterType.BuildingFilter.getTranslatedErrorSeverity(parameterText, ruleset)
+        override fun getKnownValuesForAutocomplete(ruleset: Ruleset) = setOf<String>()
+    },
+
     FilteredPolicies("Adopted [policyFilter] Policies") {
         override fun eval(parameterText: String, stateForConditionals: StateForConditionals): Int? {
             val filter = parameterText.getPlaceholderParameters()[0]

--- a/docs/Modders/Unique-parameters.md
+++ b/docs/Modders/Unique-parameters.md
@@ -363,8 +363,8 @@ Allowed values:
     - Example: `Only available <when number of [[Wounded] Units] is more than [0]>`
 -   `[buildingFilter] Buildings`
     - Example: `Only available <when number of [[Culture] Buildings] is more than [0]>`
--   `Global [buildingFilter] Buildings`
-    - Example: `Only available <when number of [Global [Culture] Buildings] is more than [0]>`
+-   `[civFilter] [buildingFilter] Buildings`
+    - Example: `Only available <when number of [[AI player] [Culture] Buildings] is more than [0]>`
 -   `Adopted [policyFilter] Policies`
     - Example: `Only available <when number of [Adopted [Oligarchy] Policies] is more than [0]>`
 -   `Remaining [civFilter] Civilizations`

--- a/docs/Modders/Unique-parameters.md
+++ b/docs/Modders/Unique-parameters.md
@@ -363,6 +363,8 @@ Allowed values:
     - Example: `Only available <when number of [[Wounded] Units] is more than [0]>`
 -   `[buildingFilter] Buildings`
     - Example: `Only available <when number of [[Culture] Buildings] is more than [0]>`
+-   `Global [buildingFilter] Buildings`
+    - Example: `Only available <when number of [Global [Culture] Buildings] is more than [0]>`
 -   `Adopted [policyFilter] Policies`
     - Example: `Only available <when number of [Adopted [Oligarchy] Policies] is more than [0]>`
 -   `Remaining [civFilter] Civilizations`


### PR DESCRIPTION
There is a countable for `[buildingFilter] Buildings`, but I needed to be able to count all buildings across all civilizations. This introduces a `[civFilter] [buildingFilter] Buildings` countable to be able to count the number of buildings in the whole world.


## Test
```json
{
  "name": "Warrior",
  "unitType": "Sword",
  "movement": 1,
  "uniques": [
    "[1] Movement <for every [[All] [Barracks] Buildings]>"
  ]
},
```

... And then add a bunch of Barracks to random cities, and expect that Warrior's movement to increase.

## Use Case

Been working on the [World Congress](https://civilization.fandom.com/wiki/World_Congress_(Civ5)) for [BNW](https://github.com/RobLoach/Civ-V-Brave-New-World), and would like to use Buildings as a mechanism to vote on World Congress proposals. A proposal will pass if there are more `[All] [Yay Vote] Buildings` than `[All] [Nay Vote] Buildings`.