### PR TITLE
Allow using `[relativeAmount]% Gold from Great Merchant trade missions` on units

### DIFF
--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -165,7 +165,7 @@ enum class UniqueType(
 
     /// Great Persons
     GreatPersonPointPercentage("[relativeAmount]% Great Person generation [cityFilter]", UniqueTarget.Global, UniqueTarget.FollowerBelief),
-    PercentGoldFromTradeMissions("[relativeAmount]% Gold from Great Merchant trade missions", UniqueTarget.Global),
+    PercentGoldFromTradeMissions("[relativeAmount]% Gold from Great Merchant trade missions", UniqueTarget.Global, UniqueTarget.Unit),
     GreatGeneralProvidesDoubleCombatBonus("Great General provides double combat bonus", UniqueTarget.Unit, UniqueTarget.Global),
     // This should probably support conditionals, e.g. <after discovering [tech]>
     MayanGainGreatPerson("Receive a free Great Person at the end of every [comment] (every 394 years), after researching [tech]. Each bonus person can only be chosen once.", UniqueTarget.Global),

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsGreatPerson.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsGreatPerson.kt
@@ -114,12 +114,12 @@ object UnitActionsGreatPerson {
                     for (goldUnique in unit.getMatchingUniques(UniqueType.PercentGoldFromTradeMissions, checkCivInfoUniques = true))
                         goldEarned *= goldUnique.params[0].toPercent()
 
-                    var goldEartedInt = goldEarned.toInt()
-                    unit.civ.addGold(goldEartedInt)
+                    var goldEarnedInt = goldEarned.toInt()
+                    unit.civ.addGold(goldEarnedInt)
                     val tileOwningCiv = tile.owningCity!!.civ
 
                     tileOwningCiv.getDiplomacyManager(unit.civ)!!.addInfluence(influenceEarned)
-                    unit.civ.addNotification("Your trade mission to [$tileOwningCiv] has earned you [$goldEartedInt] gold and [$influenceEarned] influence!",
+                    unit.civ.addNotification("Your trade mission to [$tileOwningCiv] has earned you [$goldEarnedInt] gold and [$influenceEarned] influence!",
                         NotificationCategory.General, tileOwningCiv.civName, NotificationIcon.Gold, NotificationIcon.Culture)
                     unit.consume()
                 }.takeIf { unit.hasMovement() && canConductTradeMission }

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsGreatPerson.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsGreatPerson.kt
@@ -109,9 +109,17 @@ object UnitActionsGreatPerson {
                 action = {
                     // http://civilization.wikia.com/wiki/Great_Merchant_(Civ5)
                     var goldEarned = (350 + 50 * unit.civ.getEraNumber()) * unit.civ.gameInfo.speed.goldCostModifier
+
+                    // Apply the civilization's gold mission modifier
                     for (goldUnique in unit.civ.getMatchingUniques(UniqueType.PercentGoldFromTradeMissions))
                         goldEarned *= goldUnique.params[0].toPercent()
-                    unit.civ.addGold(goldEarned.toInt())
+
+                    // Apply the unit's goald mission modifier
+                    for (goldUnique in unit.getMatchingUniques(UniqueType.PercentGoldFromTradeMissions))
+                        goldEarned *= goldUnique.params[0].toPercent()
+
+                    goldEarned = goldEarned.toInt()
+                    unit.civ.addGold(goldEarned)
                     val tileOwningCiv = tile.owningCity!!.civ
 
                     tileOwningCiv.getDiplomacyManager(unit.civ)!!.addInfluence(influenceEarned)

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsGreatPerson.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsGreatPerson.kt
@@ -110,20 +110,16 @@ object UnitActionsGreatPerson {
                     // http://civilization.wikia.com/wiki/Great_Merchant_(Civ5)
                     var goldEarned = (350 + 50 * unit.civ.getEraNumber()) * unit.civ.gameInfo.speed.goldCostModifier
 
-                    // Apply the civilization's gold mission modifier
-                    for (goldUnique in unit.civ.getMatchingUniques(UniqueType.PercentGoldFromTradeMissions))
+                    // Apply the gold trade mission modifier
+                    for (goldUnique in unit.getMatchingUniques(UniqueType.PercentGoldFromTradeMissions, checkCivInfoUniques = true))
                         goldEarned *= goldUnique.params[0].toPercent()
 
-                    // Apply the unit's goald mission modifier
-                    for (goldUnique in unit.getMatchingUniques(UniqueType.PercentGoldFromTradeMissions))
-                        goldEarned *= goldUnique.params[0].toPercent()
-
-                    goldEarned = goldEarned.toInt()
-                    unit.civ.addGold(goldEarned)
+                    var goldEartedInt = goldEarned.toInt()
+                    unit.civ.addGold(goldEartedInt)
                     val tileOwningCiv = tile.owningCity!!.civ
 
                     tileOwningCiv.getDiplomacyManager(unit.civ)!!.addInfluence(influenceEarned)
-                    unit.civ.addNotification("Your trade mission to [$tileOwningCiv] has earned you [$goldEarned] gold and [$influenceEarned] influence!",
+                    unit.civ.addNotification("Your trade mission to [$tileOwningCiv] has earned you [$goldEartedInt] gold and [$influenceEarned] influence!",
                         NotificationCategory.General, tileOwningCiv.civName, NotificationIcon.Gold, NotificationIcon.Culture)
                     unit.consume()
                 }.takeIf { unit.hasMovement() && canConductTradeMission }

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -682,7 +682,7 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 ??? example  "[relativeAmount]% Gold from Great Merchant trade missions"
 	Example: "[+20]% Gold from Great Merchant trade missions"
 
-	Applicable to: Global
+	Applicable to: Global, Unit
 
 ??? example  "Great General provides double combat bonus"
 	Applicable to: Global, Unit
@@ -1674,6 +1674,11 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 ??? example  "Can build [improvementFilter] improvements at a [relativeAmount]% rate"
 	Example: "Can build [All Road] improvements at a [+20]% rate"
+
+	Applicable to: Global, Unit
+
+??? example  "[relativeAmount]% Gold from Great Merchant trade missions"
+	Example: "[+20]% Gold from Great Merchant trade missions"
 
 	Applicable to: Global, Unit
 


### PR DESCRIPTION
This makes it so that units can modify how much gold they get when conducting trade missions:
```
{
  "name": "Caravan",
  "uniques": [
    "Can undertake a trade mission with City-State, giving a large sum of gold and [15] Influence",
    "[-50]% Gold from Great Merchant trade missions"
  }
}
```
