### PR TITLE
Add `[relativeAmount]% [resourceFilter] resource production` unique

### DIFF
--- a/android/assets/jsons/Civ V - Gods & Kings/Policies.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Policies.json
@@ -574,7 +574,7 @@
             {
                 "name": "Fascism",
                 "uniques": [
-                    "Quantity of strategic resources produced by the empire +[100]%",
+                    "[+100]% [Strategic] resource production",
                     "[+2] Movement <for [Great General] units>"
                 ],
                 "requires": ["Populism", "Militarism"],

--- a/core/src/com/unciv/logic/civilization/Civilization.kt
+++ b/core/src/com/unciv/logic/civilization/Civilization.kt
@@ -523,6 +523,12 @@ class Civilization : IsPartOfGameInfoSerialization {
                 .map { it.params[0].toFloat() / 100f }.sum()
 
         }
+        for (unique in getMatchingUniques(UniqueType.PercentResourceProduction)) {
+            if (resource.matchesFilter(unique.params[1])) {
+                resourceModifier *= unique.params[0].toPercent()
+            }
+        }
+
         return resourceModifier
     }
 

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -208,8 +208,8 @@ enum class UniqueType(
         docDescription = "These resources are removed *when work begins* on the construction. " +
                 "Do not confuse with \"costs [amount] [stockpiledResource]\" (lowercase 'c'), the Unit Action Modifier.",
         flags = setOf(UniqueFlag.AcceptsSpeedModifier)),
-    // Todo: Get rid of forced sign (+[relativeAmount]) and unify these two, e.g.: "[relativeAmount]% [resource/resourceType] production"
-    // Note that the parameter type 'resourceType' (strategic, luxury, bonus) currently doesn't exist and should then be added as well
+
+    PercentResourceProduction("[relativeAmount]% [resourceFilter] resource production", UniqueTarget.Global),
     StrategicResourcesIncrease("Quantity of strategic resources produced by the empire +[relativeAmount]%", UniqueTarget.Global),  // used by Policies
     DoubleResourceProduced("Double quantity of [resource] produced", UniqueTarget.Global),
 

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -774,6 +774,11 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 	Applicable to: Global, FollowerBelief, Improvement
 
+??? example  "[relativeAmount]% [resourceFilter] resource production"
+	Example: "[+20]% [Strategic] resource production"
+
+	Applicable to: Global
+
 ??? example  "Quantity of strategic resources produced by the empire +[relativeAmount]%"
 	Example: "Quantity of strategic resources produced by the empire +[+20]%"
 


### PR DESCRIPTION
Found a TODO note about combining the following uniques...

```
"Quantity of strategic resources produced by the empire +[relativeAmount]%"
"Double quantity of [resource] produced"
```

With this new one, I believe we can now do that...

```
"[relativeAmount]% [resourceFilter] resource production"
```

I didn't do that as part of this change, as that would need some deprecation notice, and translation fixes.
