### PR TITLE
Fix Civilopedia requiredBuilding links for Wonders

### DIFF
--- a/core/src/com/unciv/ui/objectdescriptions/BuildingDescriptions.kt
+++ b/core/src/com/unciv/ui/objectdescriptions/BuildingDescriptions.kt
@@ -182,9 +182,13 @@ object BuildingDescriptions {
         if (requiredTech != null)
             textList += FormattedLine("Required tech: [$requiredTech]",
                 link="Technology/$requiredTech")
-        if (requiredBuilding != null)
-            textList += FormattedLine("Requires [$requiredBuilding] to be built in the city",
-                link="Building/$requiredBuilding")
+        if (requiredBuilding != null) {
+            val linkType = if (ruleset.buildings[requiredBuilding]?.isWonder == true) "Wonder" else "Building"
+            textList += FormattedLine(
+                "Requires [$requiredBuilding] to be built in the city",
+                link="$linkType/$requiredBuilding"
+            )
+        }
 
         if (requiredResource != null) {
             textList += FormattedLine()


### PR DESCRIPTION
When there's a building that requires a Wonder, the Civilopedia link would break and point to a non-existing Building link. This fixes that by checking to see if the required building is a Wonder and pointing to the right place.

![Screenshot from 2025-06-15 01-13-31](https://github.com/user-attachments/assets/5e3eaf56-bc56-4472-90f6-73707e1e98d0)

Demonstratable with Civ V Brave New World's new Great Work system: https://github.com/RobLoach/Civ-V-Brave-New-World/pull/79
