### PR TITLE
Add `[stats] for every [positiveAmount] global cities following this religion`

### DIFF
--- a/core/src/com/unciv/logic/automation/civilization/ReligionAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/ReligionAutomation.kt
@@ -373,6 +373,8 @@ object ReligionAutomation {
                     unique.params[0].toFloat() / 8f
                 UniqueType.StatsFromGlobalCitiesFollowingReligion ->
                     unique.stats.values.sum() * 2f //free yields that are potentially more than our own number of cities would allow
+                UniqueType.StatsFromEveryGlobalCitiesFollowingReligion ->
+                    unique.stats.values.sum() * 2f
                 UniqueType.StatsFromGlobalFollowers ->
                     10f * (unique.stats.values.sum() / unique.params[1].toFloat())
                 UniqueType.Strength ->

--- a/core/src/com/unciv/logic/civilization/transients/CivInfoStatsForNextTurn.kt
+++ b/core/src/com/unciv/logic/civilization/transients/CivInfoStatsForNextTurn.kt
@@ -294,6 +294,14 @@ class CivInfoStatsForNextTurn(val civInfo: Civilization) {
                 )
 
             for (unique in civInfo.religionManager.religion!!.founderBeliefUniqueMap.getMatchingUniques(
+                UniqueType.StatsFromEveryGlobalCitiesFollowingReligion, civInfo.state
+            ))
+                statMap.add(
+                    "Religion",
+                    unique.stats * civInfo.religionManager.numberOfCitiesFollowingThisReligion() / unique.params[1].toFloat()
+                )
+
+            for (unique in civInfo.religionManager.religion!!.founderBeliefUniqueMap.getMatchingUniques(
                 UniqueType.StatsFromGlobalFollowers, civInfo.state
             ))
                 statMap.add(

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -40,6 +40,7 @@ enum class UniqueType(
     StatsFromObject("[stats] from every [tileFilter/specialist/buildingFilter]", UniqueTarget.Global, UniqueTarget.FollowerBelief),
     StatsFromTradeRoute("[stats] from each Trade Route", UniqueTarget.Global, UniqueTarget.FollowerBelief),
     StatsFromGlobalCitiesFollowingReligion("[stats] for each global city following this religion", UniqueTarget.FounderBelief),
+    StatsFromEveryGlobalCitiesFollowingReligion("[stats] for every [positiveAmount] global cities following this religion", UniqueTarget.FounderBelief),
     StatsFromGlobalFollowers("[stats] from every [positiveAmount] global followers [cityFilter]", UniqueTarget.FounderBelief),
 
     // Stat percentage boosts

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -1178,6 +1178,11 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 	Applicable to: FounderBelief
 
+??? example  "[stats] for every [positiveAmount] global cities following this religion"
+	Example: "[+1 Gold, +2 Production] for every [3] global cities following this religion"
+
+	Applicable to: FounderBelief
+
 ??? example  "[stats] from every [positiveAmount] global followers [cityFilter]"
 	Example: "[+1 Gold, +2 Production] from every [3] global followers [in all cities]"
 

--- a/tests/src/com/unciv/uniques/GlobalUniquesTests.kt
+++ b/tests/src/com/unciv/uniques/GlobalUniquesTests.kt
@@ -247,6 +247,25 @@ class GlobalUniquesTests {
     }
 
     @Test
+    fun statsFromEveryGlobalCitiesFollowingReligion() {
+        val civ1 = game.addCiv()
+        val religion = game.addReligion(civ1)
+        val belief = game.createBelief(BeliefType.Founder, "[+30 Science] for every [2] global cities following this religion")
+        religion.addBeliefs(listOf(belief))
+        val civ2 = game.addCiv()
+        val tile = game.getTile(Vector2.Zero)
+        val cityOfCiv2 = game.addCity(civ2, tile, initialPopulation = 1) // Need someone to be converted
+        cityOfCiv2.religion.addPressure(religion.name, 1000)
+
+        Assert.assertTrue(cityOfCiv2.religion.getMajorityReligionName() == religion.name)
+
+        civ1.updateStatsForNextTurn()
+
+        Assert.assertTrue(civ1.stats.statsForNextTurn.science == 15f)
+    }
+
+
+    @Test
     fun happinessFromGlobalCitiesFollowingReligion() {
         val civ1 = game.addCiv()
         val religion = game.addReligion(civ1)


### PR DESCRIPTION
In Brave New World, [Ceremonial Burial](https://civilization.fandom.com/wiki/Religion_(Civ5)#Founder_beliefs) changed from...

```
+1 Happiness for every City following this religion
```

to

```
+1 Happiness for every 2 Cities following this religion
```

This pull request adds a new unique to accomplish that.
