### PR TITLE
Improve ruleset validator

### DIFF
--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -148,6 +148,9 @@ class Ruleset {
     fun clone(): Ruleset {
         val newRuleset = Ruleset()
         newRuleset.add(this)
+        // Make sure the clone is recognizable - e.g. startNewGame fallback when a base mod was removed needs this
+        newRuleset.name = name
+        newRuleset.modOptions.isBaseRuleset = modOptions.isBaseRuleset
         return newRuleset
     }
 

--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -442,25 +442,26 @@ class Ruleset {
 
         // Add objects that might not be present in base ruleset mods, but are required
         if (modOptions.isBaseRuleset) {
+            val fallbackRuleset by lazy { RulesetCache.getVanillaRuleset() } // clone at most once
             // This one should be temporary
             if (unitTypes.isEmpty()) {
-                unitTypes.putAll(RulesetCache.getVanillaRuleset().unitTypes)
+                unitTypes.putAll(fallbackRuleset.unitTypes)
             }
 
             // These should be permanent
             if (ruinRewards.isEmpty())
-                ruinRewards.putAll(RulesetCache.getVanillaRuleset().ruinRewards)
+                ruinRewards.putAll(fallbackRuleset.ruinRewards)
 
             if (globalUniques.uniques.isEmpty()) {
-                globalUniques = RulesetCache.getVanillaRuleset().globalUniques
+                globalUniques = fallbackRuleset.globalUniques
             }
             // If we have no victories, add all the default victories
-            if (victories.isEmpty()) victories.putAll(RulesetCache.getVanillaRuleset().victories)
+            if (victories.isEmpty()) victories.putAll(fallbackRuleset.victories)
 
-            if (speeds.isEmpty()) speeds.putAll(RulesetCache.getVanillaRuleset().speeds)
+            if (speeds.isEmpty()) speeds.putAll(fallbackRuleset.speeds)
 
             if (cityStateTypes.isEmpty())
-                for (cityStateType in RulesetCache.getVanillaRuleset().cityStateTypes.values)
+                for (cityStateType in fallbackRuleset.cityStateTypes.values)
                     cityStateTypes[cityStateType.name] = CityStateType().apply {
                         name = cityStateType.name
                         color = cityStateType.color

--- a/core/src/com/unciv/models/ruleset/Speed.kt
+++ b/core/src/com/unciv/models/ruleset/Speed.kt
@@ -29,6 +29,7 @@ class Speed : RulesetObject(), IsPartOfGameInfoSerialization {
     var startYear: Float = -4000f
     var turns: ArrayList<HashMap<String, Float>> = ArrayList()
 
+    data class YearsPerTurn(val yearInterval: Float, val untilTurn: Int)
     val yearsPerTurn: ArrayList<YearsPerTurn> by lazy {
         ArrayList<YearsPerTurn>().apply {
             turns.forEach { this.add(YearsPerTurn(it["yearsPerTurn"]!!, it["untilTurn"]!!.toInt())) }
@@ -82,9 +83,4 @@ class Speed : RulesetObject(), IsPartOfGameInfoSerialization {
     override fun getSortGroup(ruleset: Ruleset): Int = (modifier * 1000).toInt()
 
     fun numTotalTurns(): Int = yearsPerTurn.last().untilTurn
-}
-
-class YearsPerTurn(yearsPerTurn: Float, turnsPerIncrement: Int) {
-    var yearInterval: Float = yearsPerTurn
-    var untilTurn: Int = turnsPerIncrement
 }

--- a/core/src/com/unciv/models/ruleset/validation/BaseRulesetValidator.kt
+++ b/core/src/com/unciv/models/ruleset/validation/BaseRulesetValidator.kt
@@ -31,6 +31,13 @@ internal class BaseRulesetValidator(
      *  value a Set of its prerequisites including indirect ones */
     private val prereqsHashMap = HashMap<String, HashSet<String>>()
 
+    init {
+        // The `UniqueValidator.checkUntypedUnique` filtering Unique test ("X not found in Unciv's unique types, and is not used as a filtering unique")
+        // should not complain when running the RulesetInvariant version, because an Extension Mod may e.g. define additional "Aircraft" and the _use_ of the
+        // filtering Unique only exists in the Base Ruleset. But here we *do* want the test, and it needs its cache filled, and that is not done automatically.
+        uniqueValidator.populateFilteringUniqueHashsets()
+    }
+
     override fun checkBuilding(building: Building, lines: RulesetErrorList) {
         super.checkBuilding(building, lines)
 

--- a/core/src/com/unciv/models/ruleset/validation/BaseRulesetValidator.kt
+++ b/core/src/com/unciv/models/ruleset/validation/BaseRulesetValidator.kt
@@ -137,6 +137,10 @@ internal class BaseRulesetValidator(
     override fun addModOptionsErrors(lines: RulesetErrorList) {
         super.addModOptionsErrors(lines)
 
+        // `ruleset` can be a true base ruleset or a combined one when we're checking an extension mod together with a base.
+        // In the combined case, don't complain about ModRequires!
+        if (ruleset.name.isEmpty() && ruleset.mods.size > 1) return
+
         for (unique in ruleset.modOptions.getMatchingUniques(UniqueType.ModRequires)) {
             lines.add("Mod option '${unique.text}' is invalid for a base ruleset.", sourceObject = null)
         }

--- a/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
+++ b/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
@@ -274,6 +274,19 @@ open class RulesetValidator protected constructor(
         // Using reportRulesetSpecificErrors=true as ModOptions never should use Uniques depending on objects from a base ruleset anyway.
         uniqueValidator.checkUniques(ruleset.modOptions, lines, reportRulesetSpecificErrors = true, tryFixUnknownUniques)
 
+        //TODO: More thorough checks. Here I picked just those where bad values might endanger stability.
+        val constants = ruleset.modOptions.constants
+        if (constants.cityExpandRange !in 1..100)
+            lines.add("Invalid ModConstant 'cityExpandRange'.", sourceObject = null)
+        if (constants.cityWorkRange !in 1..100)
+            lines.add("Invalid ModConstant 'cityWorkRange'.", sourceObject = null)
+        if (constants.minimalCityDistance < 1)
+            lines.add("Invalid ModConstant 'minimalCityDistance'.", sourceObject = null)
+        if (constants.minimalCityDistanceOnDifferentContinents < 1)
+            lines.add("Invalid ModConstant 'minimalCityDistanceOnDifferentContinents'.", sourceObject = null)
+        if (constants.baseCityBombardRange < 1)
+            lines.add("Invalid ModConstant 'baseCityBombardRange'.", sourceObject = null)
+
         if (ruleset.name.isBlank()) return // The rest of these tests don't make sense for combined rulesets
 
         val audioVisualUniqueTypes = setOf(

--- a/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
+++ b/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
@@ -65,7 +65,7 @@ open class RulesetValidator protected constructor(
     /** `true` for a [BaseRulesetValidator] instance, `false` for a [RulesetValidator] instance. */
     private val reportRulesetSpecificErrors = ruleset.modOptions.isBaseRuleset
 
-    private val uniqueValidator = UniqueValidator(ruleset)
+    protected val uniqueValidator = UniqueValidator(ruleset)
 
     private lateinit var textureNamesCache: AtlasPreview
 

--- a/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
+++ b/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
@@ -7,6 +7,8 @@ import com.unciv.Constants
 import com.unciv.UncivGame
 import com.unciv.json.fromJsonFile
 import com.unciv.json.json
+import com.unciv.logic.map.tile.RoadStatus
+import com.unciv.models.ruleset.BeliefType
 import com.unciv.models.ruleset.Building
 import com.unciv.models.ruleset.IRulesetObject
 import com.unciv.models.ruleset.Ruleset
@@ -24,8 +26,10 @@ import com.unciv.models.ruleset.unique.UniqueTarget
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.ruleset.unit.BaseUnit
 import com.unciv.models.ruleset.unit.Promotion
+import com.unciv.models.ruleset.unit.UnitMovementType
 import com.unciv.models.ruleset.validation.RulesetValidator.Companion.create
 import com.unciv.models.stats.INamed
+import com.unciv.models.stats.Stats
 import com.unciv.models.tilesets.TileSetCache
 import com.unciv.models.tilesets.TileSetConfig
 import com.unciv.ui.images.AtlasPreview
@@ -56,12 +60,12 @@ import com.unciv.ui.images.PortraitPromotion
  */
 open class RulesetValidator protected constructor(
     protected val ruleset: Ruleset,
-    protected val tryFixUnknownUniques: Boolean
+    private val tryFixUnknownUniques: Boolean
 ) {
     /** `true` for a [BaseRulesetValidator] instance, `false` for a [RulesetValidator] instance. */
     private val reportRulesetSpecificErrors = ruleset.modOptions.isBaseRuleset
 
-    protected val uniqueValidator = UniqueValidator(ruleset)
+    private val uniqueValidator = UniqueValidator(ruleset)
 
     private lateinit var textureNamesCache: AtlasPreview
 
@@ -125,40 +129,82 @@ open class RulesetValidator protected constructor(
 
     //region RulesetObject-specific handlers
 
-    protected open fun addBeliefErrors(lines: RulesetErrorList) {}
-
-    protected open fun addBuildingErrors(lines: RulesetErrorList) {
-        for (building in ruleset.buildings.values) {
-            addBuildingErrorRulesetInvariant(building, lines)
-            uniqueValidator.checkUniques(building, lines, false, tryFixUnknownUniques)
+    protected open fun addBeliefErrors(lines: RulesetErrorList) {
+        for (belief in ruleset.beliefs.values) {
+            if (belief.type == BeliefType.Any || belief.type == BeliefType.None)
+                lines.add("${belief.name} type is ${belief.type}, which is not allowed!", sourceObject = belief)
+            uniqueValidator.checkUniques(belief, lines, reportRulesetSpecificErrors, tryFixUnknownUniques)
         }
     }
 
-    protected fun addBuildingErrorRulesetInvariant(building: Building, lines: RulesetErrorList) {
-        if (building.requiredTechs().none() && building.cost == -1 && !building.hasUnique(
-                UniqueType.Unbuildable
-            )
-        )
+    protected open fun addBuildingErrors(lines: RulesetErrorList) {
+        for (building in ruleset.buildings.values) {
+            checkBuilding(building, lines)
+            uniqueValidator.checkUniques(building, lines, reportRulesetSpecificErrors, tryFixUnknownUniques)
+        }
+    }
+
+    protected open fun checkBuilding(building: Building, lines: RulesetErrorList) {
+        if (building.requiredTechs().none() && building.cost == -1 && !building.hasUnique(UniqueType.Unbuildable))
             lines.add(
                 "${building.name} is buildable and therefore should either have an explicit cost or reference an existing tech!",
                 RulesetErrorSeverity.Warning, building
             )
 
-        for (gpp in building.greatPersonPoints)
-            if (gpp.key !in ruleset.units)
-                lines.add(
-                    "Building ${building.name} has greatPersonPoints for ${gpp.key}, which is not a unit in the ruleset!",
-                    RulesetErrorSeverity.Warning, building
-                )
-
         if (building.replaces != null && building.uniqueTo == null)
             lines.add("${building.name} should replace ${building.replaces} but does not have uniqueTo assigned!")
     }
 
-    protected open fun addCityStateTypeErrors(lines: RulesetErrorList) {}
-    protected open fun addDifficultyErrors(lines: RulesetErrorList) {}
-    protected open fun addEraErrors(lines: RulesetErrorList) {}
-    protected open fun addEventErrors(lines: RulesetErrorList) {}
+    protected open fun addCityStateTypeErrors(lines: RulesetErrorList) {
+        for (cityStateType in ruleset.cityStateTypes.values) {
+            for (unique in cityStateType.allyBonusUniqueMap.getAllUniques() + cityStateType.friendBonusUniqueMap.getAllUniques()) {
+                val errors = uniqueValidator.checkUnique(unique, tryFixUnknownUniques, null, reportRulesetSpecificErrors)
+                lines.addAll(errors)
+            }
+        }
+    }
+
+    protected open fun addDifficultyErrors(lines: RulesetErrorList) {
+        for (difficulty in ruleset.difficulties.values) {
+            if (difficulty.aiBuildingCostModifier < 0 || difficulty.aiBuildingMaintenanceModifier < 0 || difficulty.aiCityGrowthModifier < 0 ||
+                difficulty.aiUnhappinessModifier < 0 || difficulty.aiUnitCostModifier < 0 || difficulty.aiUnitMaintenanceModifier < 0 ||
+                difficulty.aiUnitSupplyModifier < 0 || difficulty.aiWonderCostModifier < 0 ||
+                difficulty.buildingCostModifier < 0 || difficulty.policyCostModifier < 0 || difficulty.researchCostModifier < 0 ||
+                difficulty.unhappinessModifier < 0 || difficulty.unitCostModifier < 0)
+                lines.add("Difficulty ${difficulty.name} contains one or more negative modifier(s)!", sourceObject = null)
+            if (difficulty.turnBarbariansCanEnterPlayerTiles < 0)
+                lines.add("Difficulty ${difficulty.name} has a negative turnBarbariansCanEnterPlayerTiles!",
+                    RulesetErrorSeverity.Warning, sourceObject = null)
+        }
+    }
+
+    protected open fun addEraErrors(lines: RulesetErrorList) {
+        for (era in ruleset.eras.values) {
+            if (era.researchAgreementCost < 0 || era.startingSettlerCount < 0 || era.startingWorkerCount < 0 || 
+                era.startingMilitaryUnitCount < 0 || era.startingGold < 0 || era.startingCulture < 0)
+                lines.add("Unexpected negative number found while parsing era ${era.name}", sourceObject = era)
+            if (era.settlerPopulation <= 0)
+                lines.add("Population in cities from settlers must be strictly positive! Found value ${era.settlerPopulation} for era ${era.name}", sourceObject = era)
+
+            if (era.allyBonus.isNotEmpty() || era.friendBonus.isNotEmpty())
+                lines.add(
+                    "Era ${era.name} contains city-state bonuses. City-state bonuses are now defined in CityStateType.json",
+                    RulesetErrorSeverity.WarningOptionsOnly, era
+                )
+
+            uniqueValidator.checkUniques(era, lines, reportRulesetSpecificErrors, tryFixUnknownUniques)
+        }
+    }
+
+    protected open fun addEventErrors(lines: RulesetErrorList) {
+        // An Event is not a IHasUniques, so not suitable as sourceObject
+        for (event in ruleset.events.values) {
+            for (choice in event.choices) {
+                uniqueValidator.checkUniques(choice, lines, reportRulesetSpecificErrors, tryFixUnknownUniques)
+            }
+            uniqueValidator.checkUniques(event, lines, reportRulesetSpecificErrors, tryFixUnknownUniques)
+        }
+    }
 
     protected open fun addGlobalUniqueErrors(lines: RulesetErrorList) {
         uniqueValidator.checkUniques(ruleset.globalUniques, lines, reportRulesetSpecificErrors, tryFixUnknownUniques)
@@ -183,7 +229,45 @@ open class RulesetValidator protected constructor(
         }
     }
 
-    protected open fun addImprovementErrors(lines: RulesetErrorList) {}
+    protected open fun addImprovementErrors(lines: RulesetErrorList) {
+        for (improvement in ruleset.tileImprovements.values) {
+            if (improvement.replaces != null && improvement.uniqueTo == null)
+                lines.add("${improvement.name} should replace ${improvement.replaces} but does not have uniqueTo assigned!")
+            if (improvement.terrainsCanBeBuiltOn.isEmpty()
+                && !improvement.hasUnique(UniqueType.CanOnlyImproveResource)
+                && !improvement.hasUnique(UniqueType.Unbuildable)
+                && !improvement.name.startsWith(Constants.remove)
+                && improvement.name !in RoadStatus.entries.map { it.removeAction }
+                && improvement.name != Constants.cancelImprovementOrder
+            ) {
+                lines.add(
+                    "${improvement.name} has an empty `terrainsCanBeBuiltOn`, isn't allowed to only improve resources. As such it isn't buildable! Either give this the unique \"Unbuildable\", \"Can only be built to improve a resource\", or add \"Land\", \"Water\" or any other value to `terrainsCanBeBuiltOn`.",
+                    RulesetErrorSeverity.Warning, improvement
+                )
+            }
+
+            for (unique in improvement.uniqueObjects
+                .filter { it.type == UniqueType.PillageYieldRandom || it.type == UniqueType.PillageYieldFixed }) {
+                if (!Stats.isStats(unique.params[0])) continue
+                val params = Stats.parse(unique.params[0])
+                if (params.values.any { it < 0 }) lines.add(
+                    "${improvement.name} cannot have a negative value for a pillage yield!",
+                    RulesetErrorSeverity.Error, improvement
+                )
+            }
+
+            val hasPillageUnique = improvement.hasUnique(UniqueType.PillageYieldRandom, StateForConditionals.IgnoreConditionals)
+                || improvement.hasUnique(UniqueType.PillageYieldFixed, StateForConditionals.IgnoreConditionals)
+            if (hasPillageUnique && improvement.hasUnique(UniqueType.Unpillagable, StateForConditionals.IgnoreConditionals)) {
+                lines.add(
+                    "${improvement.name} has both an `Unpillagable` unique type and a `PillageYieldRandom` or `PillageYieldFixed` unique type!",
+                    RulesetErrorSeverity.Warning, improvement
+                )
+            }
+
+            uniqueValidator.checkUniques(improvement, lines, reportRulesetSpecificErrors, tryFixUnknownUniques)
+        }
+    }
 
     protected open fun addModOptionsErrors(lines: RulesetErrorList) {
         // Basic Unique validation (type, target, parameters) should always run.
@@ -220,12 +304,12 @@ open class RulesetValidator protected constructor(
 
     protected open fun addNationErrors(lines: RulesetErrorList) {
         for (nation in ruleset.nations.values) {
-            addNationErrorRulesetInvariant(nation, lines)
-            uniqueValidator.checkUniques(nation, lines, false, tryFixUnknownUniques)
+            checkNation(nation, lines)
+            uniqueValidator.checkUniques(nation, lines, reportRulesetSpecificErrors, tryFixUnknownUniques)
         }
     }
 
-    protected fun addNationErrorRulesetInvariant(nation: Nation, lines: RulesetErrorList) {
+    protected open fun checkNation(nation: Nation, lines: RulesetErrorList) {
         if (nation.cities.isEmpty() && !nation.isSpectator && !nation.isBarbarian) {
             lines.add("${nation.name} can settle cities, but has no city names!", sourceObject = nation)
         }
@@ -233,19 +317,29 @@ open class RulesetValidator protected constructor(
         checkContrasts(nation.getInnerColor(), nation.getOuterColor(), nation, lines)
     }
 
-    protected open fun addPersonalityErrors(lines: RulesetErrorList) {}
-    protected open fun addPolicyErrors(lines: RulesetErrorList) {}
-
-    protected open fun addPromotionErrors(lines: RulesetErrorList) {
-        for (promotion in ruleset.unitPromotions.values) {
-            uniqueValidator.checkUniques(promotion, lines, false, tryFixUnknownUniques)
-            checkContrasts(promotion.innerColorObject ?: PortraitPromotion.defaultInnerColor,
-                promotion.outerColorObject ?: PortraitPromotion.defaultOuterColor, promotion, lines)
-            addPromotionErrorRulesetInvariant(promotion, lines)
+    protected open fun addPersonalityErrors(lines: RulesetErrorList) {
+        for (personality in ruleset.personalities.values) {
+            if (personality.uniques.isNotEmpty())
+                lines.add("Personality Uniques are not supported", RulesetErrorSeverity.Warning, personality)
         }
     }
 
-    protected fun addPromotionErrorRulesetInvariant(promotion: Promotion, lines: RulesetErrorList) {
+    protected open fun addPolicyErrors(lines: RulesetErrorList) {
+        for (policy in ruleset.policies.values) {
+            uniqueValidator.checkUniques(policy, lines, reportRulesetSpecificErrors, tryFixUnknownUniques)
+        }
+    }
+
+    protected open fun addPromotionErrors(lines: RulesetErrorList) {
+        for (promotion in ruleset.unitPromotions.values) {
+            uniqueValidator.checkUniques(promotion, lines, reportRulesetSpecificErrors, tryFixUnknownUniques)
+            checkContrasts(promotion.innerColorObject ?: PortraitPromotion.defaultInnerColor,
+                promotion.outerColorObject ?: PortraitPromotion.defaultOuterColor, promotion, lines)
+            checkPromotion(promotion, lines)
+        }
+    }
+
+    protected open fun checkPromotion(promotion: Promotion, lines: RulesetErrorList) {
         if (promotion.row < -1) lines.add("Promotion ${promotion.name} has invalid row value: ${promotion.row}", sourceObject = promotion)
         if (promotion.column < 0) lines.add("Promotion ${promotion.name} has invalid column value: ${promotion.column}", sourceObject = promotion)
         if (promotion.row == -1) return
@@ -256,18 +350,49 @@ open class RulesetValidator protected constructor(
 
     protected open fun addResourceErrors(lines: RulesetErrorList) {
         for (resource in ruleset.tileResources.values) {
-            uniqueValidator.checkUniques(resource, lines, false, tryFixUnknownUniques)
+            uniqueValidator.checkUniques(resource, lines, reportRulesetSpecificErrors, tryFixUnknownUniques)
         }
     }
 
-    protected open fun addRuinsErrors(lines: RulesetErrorList) {}
+    protected open fun addRuinsErrors(lines: RulesetErrorList) {
+        for (reward in ruleset.ruinRewards.values) {
+            @Suppress("KotlinConstantConditions") // data is read from json, so any assumptions may be wrong
+            if (reward.weight < 0) lines.add("${reward.name} has a negative weight, which is not allowed!", sourceObject = reward)
+            uniqueValidator.checkUniques(reward, lines, reportRulesetSpecificErrors, tryFixUnknownUniques)
+        }
+    }
+
     protected open fun addSpecialistErrors(lines: RulesetErrorList) {}
-    protected open fun addSpeedErrors(lines: RulesetErrorList) {}
+
+    protected open fun addSpeedErrors(lines: RulesetErrorList) {
+        for (speed in ruleset.speeds.values) {
+            if (speed.modifier < 0f || speed.barbarianModifier < 0f || speed.cultureCostModifier < 0f || speed.faithCostModifier < 0f ||
+                speed.goldCostModifier < 0f || speed.goldGiftModifier < 0f || speed.goldenAgeLengthModifier < 0f ||
+                speed.improvementBuildLengthModifier < 0f || speed.productionCostModifier < 0f || speed.scienceCostModifier < 0f)
+                lines.add("One or more negative speed modifier(s) for game speed ${speed.name}", sourceObject = speed)
+            if (speed.dealDuration < 1 || speed.peaceDealDuration < 1)
+                lines.add("Deal durations must be positive", sourceObject = speed)
+            if (speed.religiousPressureAdjacentCity < 0)
+                lines.add("'religiousPressureAdjacentCity' must not be negative", sourceObject = speed)
+            if (speed.yearsPerTurn.isEmpty())
+                lines.add("Empty turn increment list for game speed ${speed.name}", sourceObject = speed)
+            var lastTurn = 0
+            for ((yearInterval, untilTurn) in speed.yearsPerTurn) {
+                if (yearInterval <= 0f)
+                    lines.add("Negative year interval $yearInterval in turn increment list", sourceObject = speed)
+                if (untilTurn <= lastTurn)
+                    lines.add("The 'untilTurn' field in the turn increment list must be monotonously increasing, but $untilTurn is <= $lastTurn", sourceObject = speed)
+                lastTurn = untilTurn
+            }
+            if (speed.uniques.isNotEmpty())
+                lines.add("Speed Uniques are not supported", RulesetErrorSeverity.Warning, speed)
+        }
+    }
 
     protected open fun addTechErrors(lines: RulesetErrorList) {
         for (tech in ruleset.technologies.values) {
             if (tech.row < 1) lines.add("Tech ${tech.name} has a row value below 1: ${tech.row}", sourceObject = tech)
-            uniqueValidator.checkUniques(tech, lines, false, tryFixUnknownUniques)
+            uniqueValidator.checkUniques(tech, lines, reportRulesetSpecificErrors, tryFixUnknownUniques)
         }
     }
 
@@ -295,27 +420,24 @@ open class RulesetValidator protected constructor(
                     RulesetErrorSeverity.Warning, sourceObject = null
                 )
         }
-
-        for (tech in ruleset.technologies.values) {
-            for (otherTech in ruleset.technologies.values) {
-                if (tech != otherTech && otherTech.column?.columnNumber == tech.column?.columnNumber && otherTech.row == tech.row)
-                    lines.add("${tech.name} is in the same row and column as ${otherTech.name}!", sourceObject = tech)
-            }
-        }
     }
 
-    protected open fun addTerrainErrors(lines: RulesetErrorList) {}
+    protected open fun addTerrainErrors(lines: RulesetErrorList) {
+        for (terrain in ruleset.terrains.values) {
+            uniqueValidator.checkUniques(terrain, lines, reportRulesetSpecificErrors, tryFixUnknownUniques)
+        }
+    }
 
     protected open fun addUnitErrors(lines: RulesetErrorList) {
         for (unit in ruleset.units.values) {
-            checkUnitRulesetInvariant(unit, lines)
-            uniqueValidator.checkUniques(unit, lines, false, tryFixUnknownUniques)
+            checkUnit(unit, lines)
+            uniqueValidator.checkUniques(unit, lines, reportRulesetSpecificErrors, tryFixUnknownUniques)
         }
     }
 
-    protected fun checkUnitRulesetInvariant(unit: BaseUnit, lines: RulesetErrorList) {
+    protected open fun checkUnit(unit: BaseUnit, lines: RulesetErrorList) {
         for (upgradesTo in unit.getUpgradeUnits(StateForConditionals.IgnoreConditionals)) {
-            if (upgradesTo == unit.name || (upgradesTo == unit.replaces))
+            if (upgradesTo == unit.name || upgradesTo == unit.replaces)
                 lines.add("${unit.name} upgrades to itself!", sourceObject = unit)
         }
 
@@ -326,8 +448,34 @@ open class RulesetValidator protected constructor(
             lines.add("${unit.name} is a military unit but has no assigned strength!", sourceObject = unit)
     }
 
-    protected open fun addUnitTypeErrors(lines: RulesetErrorList) {}
-    protected open fun addVictoryTypeErrors(lines: RulesetErrorList) {}
+    protected open fun addUnitTypeErrors(lines: RulesetErrorList) {
+        val unitMovementTypes = UnitMovementType.entries.map { it.name }.toSet()
+        for (unitType in ruleset.unitTypes.values) {
+            if (unitType.movementType !in unitMovementTypes)
+                lines.add("Unit type ${unitType.name} has an invalid movement type ${unitType.movementType}", sourceObject = unitType)
+            uniqueValidator.checkUniques(unitType, lines, reportRulesetSpecificErrors, tryFixUnknownUniques)
+        }
+    }
+
+    protected open fun addVictoryTypeErrors(lines: RulesetErrorList) {
+        // Victory and Milestone aren't IHasUniques and are unsuitable as sourceObject
+        for (victoryType in ruleset.victories.values) {
+            for (milestone in victoryType.milestoneObjects) {
+                if (milestone.type == null)
+                    lines.add(
+                        "Victory type ${victoryType.name} has milestone \"${milestone.uniqueDescription}\" that is of an unknown type!",
+                        RulesetErrorSeverity.Error, sourceObject = null
+                    )
+            }
+
+            for (otherVictory in ruleset.victories.values)
+                if (otherVictory.name > victoryType.name && otherVictory.milestones == victoryType.milestones)
+                    lines.add(
+                        "Victory types ${victoryType.name} and ${otherVictory.name} have the same requirements!",
+                        RulesetErrorSeverity.Warning, sourceObject = null
+                    )
+        }
+    }
 
     //endregion
     //region General helpers

--- a/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
+++ b/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
@@ -696,10 +696,7 @@ open class RulesetValidator protected constructor(
             .toSet()
 
     /* This is public because `FormattedLine` does its own checking and needs the textureNamesCache test */
-    fun uncachedImageExists(name: String): Boolean {
-        if (ruleset.folderLocation == null) return false // Can't check in this case
-        return textureNamesCache.imageExists(name)
-    }
+    fun uncachedImageExists(name: String) = textureNamesCache.imageExists(name)
 
     //endregion
 

--- a/core/src/com/unciv/models/ruleset/validation/UniqueValidator.kt
+++ b/core/src/com/unciv/models/ruleset/validation/UniqueValidator.kt
@@ -52,7 +52,7 @@ class UniqueValidator(val ruleset: Ruleset) {
             lines.addAll(errors)
         }
     }
-    
+
     private val performanceHeavyConditionals = setOf(UniqueType.ConditionalNeighborTiles, UniqueType.ConditionalAdjacentTo,
         UniqueType.ConditionalNotAdjacentTo
     )
@@ -64,10 +64,10 @@ class UniqueValidator(val ruleset: Ruleset) {
         reportRulesetSpecificErrors: Boolean
     ): RulesetErrorList {
         val prefix by lazy { getUniqueContainerPrefix(uniqueContainer) + "\"${unique.text}\"" }
-        if (unique.type == null) return checkUntypedUnique(unique, tryFixUnknownUniques, uniqueContainer, prefix)
+        if (unique.type == null) return checkUntypedUnique(unique, tryFixUnknownUniques, uniqueContainer, prefix, reportRulesetSpecificErrors)
 
         val rulesetErrors = RulesetErrorList(ruleset)
-        
+
         if (uniqueContainer != null &&
             !(unique.type.canAcceptUniqueTarget(uniqueContainer.getUniqueTarget()) ||
                     // "for X turns" effectively turns a global unique into a trigger
@@ -86,14 +86,14 @@ class UniqueValidator(val ruleset: Ruleset) {
                 " ${complianceError.acceptableParameterTypes.joinToString(" or ") { it.parameterName }} !",
                 complianceError.errorSeverity.getRulesetErrorSeverity(), uniqueContainer, unique
             )
-            
+
             addExpressionParseErrors(complianceError, rulesetErrors, uniqueContainer, unique)
         }
 
         for (conditional in unique.modifiers) {
             addConditionalErrors(conditional, rulesetErrors, prefix, unique, uniqueContainer, reportRulesetSpecificErrors)
         }
-        
+
         val conditionals = unique.modifiers.filter { it.type?.canAcceptUniqueTarget(UniqueTarget.Conditional) == true }
         if (conditionals.size > 1){
             val lastCheapConditional = conditionals.lastOrNull { it.type !in performanceHeavyConditionals }
@@ -105,7 +105,7 @@ class UniqueValidator(val ruleset: Ruleset) {
                             "For performance, consider switching their locations.", RulesetErrorSeverity.WarningOptionsOnly, uniqueContainer, unique)
             }
         }
-        
+
 
         if (unique.type in MapUnitCache.UnitMovementUniques
                 && unique.modifiers.any { it.type != UniqueType.ConditionalOurUnit || it.params[0] !in Constants.all }
@@ -134,7 +134,7 @@ class UniqueValidator(val ruleset: Ruleset) {
         unique: Unique
     ) {
         if (!complianceError.acceptableParameterTypes.contains(UniqueParameterType.Countable)) return
-        
+
         val parseError = Expressions.getParsingError(complianceError.parameterName)
         if (parseError != null) {
             val marker = "HERE➡"
@@ -147,7 +147,7 @@ class UniqueValidator(val ruleset: Ruleset) {
             rulesetErrors.add(text, RulesetErrorSeverity.WarningOptionsOnly, uniqueContainer, unique)
             return
         }
-        
+
         val countableErrors = Expressions.getCountableErrors(complianceError.parameterName, ruleset)
         if (countableErrors.isNotEmpty()) {
             val text = "\"${complianceError.parameterName}\" was parsed as an expression, but has the following errors with this ruleset:" +
@@ -225,14 +225,14 @@ class UniqueValidator(val ruleset: Ruleset) {
                     " which references a citywide resource. This is not a valid conditional for a resource uniques, " +
                     "as it causes a recursive evaluation loop.",
                 RulesetErrorSeverity.Error, uniqueContainer, unique)
-        
+
         // Find resource uniques with countable parameters in conditionals, that depend on citywide resources
         // This too leads to an endless loop
         if (unique.type in resourceUniques)
             for ((index, param) in conditional.params.withIndex()){
                 if (ruleset.tileResources[param]?.isCityWide != true) continue
                 if (unique.type!!.parameterTypeMap.getOrNull(index)?.contains(UniqueParameterType.Countable) != true) continue
-                
+
                 rulesetErrors.add(
                     "$prefix contains the modifier \"${conditional.text}\"," +
                         " which references a citywide resource as a countable." +
@@ -253,7 +253,7 @@ class UniqueValidator(val ruleset: Ruleset) {
                 " ${complianceError.acceptableParameterTypes.joinToString(" or ") { it.parameterName }} !",
                 complianceError.errorSeverity.getRulesetErrorSeverity(), uniqueContainer, unique
             )
-            
+
             addExpressionParseErrors(complianceError, rulesetErrors, uniqueContainer, unique)
         }
 
@@ -313,7 +313,7 @@ class UniqueValidator(val ruleset: Ruleset) {
             }
             val acceptableParamTypes = unique.type.parameterTypeMap[index]
             if (acceptableParamTypes.size == 0) continue // This is a deprecated parameter type, don't bother checking it
-            
+
             val errorTypesForAcceptableParameters =
                 acceptableParamTypes.map { getParamTypeErrorSeverityCached(it, param) }
             if (errorTypesForAcceptableParameters.any { it == null }) continue // This matches one of the types!
@@ -322,7 +322,7 @@ class UniqueValidator(val ruleset: Ruleset) {
                 continue // This is a filtering param, and the unique it's filtering for actually exists, no problem here!
             val leastSevereWarning =
                 errorTypesForAcceptableParameters.minByOrNull { it!!.ordinal }
-            if (leastSevereWarning == null) 
+            if (leastSevereWarning == null)
                 throw Exception("Unique ${unique.text} from mod ${ruleset.name} is acting strangely - please open a bug report")
             errorList += UniqueComplianceError(param, acceptableParamTypes, leastSevereWarning)
         }
@@ -342,7 +342,13 @@ class UniqueValidator(val ruleset: Ruleset) {
         return severity
     }
 
-    private fun checkUntypedUnique(unique: Unique, tryFixUnknownUniques: Boolean, uniqueContainer: IHasUniques?, prefix: String): RulesetErrorList {
+    private fun checkUntypedUnique(
+        unique: Unique,
+        tryFixUnknownUniques: Boolean,
+        uniqueContainer: IHasUniques?,
+        prefix: String,
+        reportRulesetSpecificErrors: Boolean
+    ): RulesetErrorList {
         // Malformed conditional is always bad
         if (unique.text.count { it == '<' } != unique.text.count { it == '>' })
             return RulesetErrorList.of(
@@ -351,7 +357,8 @@ class UniqueValidator(val ruleset: Ruleset) {
             )
 
         // Support purely filtering Uniques without actual implementation
-        if (isFilteringUniqueAllowed(unique)) return RulesetErrorList()
+        if (isFilteringUniqueAllowed(unique, reportRulesetSpecificErrors)) return RulesetErrorList()
+
         if (tryFixUnknownUniques) {
             val fixes = tryFixUnknownUnique(unique, uniqueContainer, prefix)
             if (fixes.isNotEmpty()) return fixes
@@ -364,10 +371,11 @@ class UniqueValidator(val ruleset: Ruleset) {
         )
     }
 
-    private fun isFilteringUniqueAllowed(unique: Unique): Boolean {
+    private fun isFilteringUniqueAllowed(unique: Unique, reportRulesetSpecificErrors: Boolean): Boolean {
         // Isolate this decision, to allow easy change of approach
         // This says: Must have no conditionals or parameters, and is used in any "filtering" parameter of another Unique
         if (unique.modifiers.isNotEmpty() || unique.params.isNotEmpty()) return false
+        if (!reportRulesetSpecificErrors) return true // Don't report unless checking a complete Ruleset
         return unique.text in allUniqueParameters // referenced at least once from elsewhere
     }
 


### PR DESCRIPTION
Follow-up to #13458, treats all entries in the list mentioned there.
Closes #13362, because AntCiv will now be flagged for the row <= 0. Amongst a lot of other things.

Notes:
- Will probably conflict with #13482 because it reuses the change to `class YearsPerTurn` (cherry-picked commit, thus the conflict will be caused by the squash-merge, not the reuse itself)
- The vanilla/G&K clones used in various places are no longer anonymous, unnamed extension mods, hopefully preventing some rare problems.
- Possible invalid filtering uniques are only flagged in the RulesetSpecific check (think adding another "Aircraft" - the filtering Unique is in the mod, the _use_ as parameter is in the base).
- AtlasPreview learned to load complex Rulesets, thus the extraImage check no longer erroneously fails.
- But reading commit names tells the story too.

Verbatim copy of the inconsistency list from earlier PR/issue:
<details>

- addBeliefErrors: RulesetInvariant could do the checkUniques call _and_ the belief.type in (Any,None) check.
- addBuildingErrorRulesetInvariant: That greatPersonPoints check should be RulesetSpecific.
- addCityStateTypeErrors: RulesetInvariant could do the checkUnique calls, same overall just the reportRulesetSpecificErrors param different.
- addDifficultyErrors: RulesetInvariant could test for negative modifiers. BaseRuleset check could check aiDifficultyLevel and aiFreeTechs.
- addEraErrors: RulesetInvariant could do the checkUniques call. Most of the meat is Ruleset-specific.
- addEventErrors: RulesetInvariant could do the checkUniques calls, same overall just the reportRulesetSpecificErrors param different.
- addGlobalUniqueErrors: dito
- addImprovementErrors: RulesetInvariant could do the "empty `terrainsCanBeBuiltOn`" test,
		the "should replace ${improvement.replaces} but does not have uniqueTo assigned" test,
		the "cannot have a negative value for a pillage yield" test,
		the "has both an `Unpillagable` unique type and a `PillageYieldRandom` or `PillageYieldFixed` unique type" test,
		+ checkUniques
- addPromotionErrors/addPromotionErrorsRulesetInvariant: Invariant could do the contrast check. Also, that comment "should be upgraded to error in the future" seems old enough: I'd advocate `RulesetErrorSeverity.ErrorOptionsOnly`.
- addRuinsErrors: RulesetInvariant could do the negative weight test + checkUniques
- addSpecialistErrors is fine! No meaningful RulesetInvariant stuff at all.
- addSpeedErrors: The current test is already RulesetInvariant and should also run in that case. Also, it could check a lot more values that would cause problems when negative.
- addTerrainErrors: the usual - RulesetInvariant could only do RulesetInvariant checkUniques
- addVictoryTypeErrors: RulesetInvariant could do the milestone types known and same requirements checks
</details>

**Omitted** - I was _tempted_ to add the misspelling logic to color "grey" (names are Gdx and they call it "gray")...
<details>

```patch
Index: core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt b/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
--- a/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt	(revision f45877a4599aec02299faeee5d4bcaeefef89c22)
+++ b/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt	(date 1750561322220)
@@ -480,12 +480,12 @@
     //endregion
     //region General helpers
 
-    protected fun getPossibleMisspellings(originalText: String, possibleMisspellings: List<String>): List<String> =
+    fun getPossibleMisspellings(originalText: String, possibleMisspellings: List<String>, leniency: Float = 1f): List<String> =
         possibleMisspellings.filter {
             getRelativeTextDistance(
                 it,
                 originalText
-            ) <= RulesetCache.uniqueMisspellingThreshold
+            ) <= RulesetCache.uniqueMisspellingThreshold * leniency
         }
 
     private fun checkContrasts(
Index: core/src/com/unciv/ui/screens/civilopediascreen/FormattedLine.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/core/src/com/unciv/ui/screens/civilopediascreen/FormattedLine.kt b/core/src/com/unciv/ui/screens/civilopediascreen/FormattedLine.kt
--- a/core/src/com/unciv/ui/screens/civilopediascreen/FormattedLine.kt	(revision f45877a4599aec02299faeee5d4bcaeefef89c22)
+++ b/core/src/com/unciv/ui/screens/civilopediascreen/FormattedLine.kt	(date 1750561642201)
@@ -139,8 +139,14 @@
         if (indent !in 0..100)  // arbitrary
             yield("indent is out of sensible range")
         if (color.isNotEmpty())
-            if (parseColor() == null)
-                yield("unknown color \"$color\"")
+            if (parseColor() == null) {
+                // leniency = 1.67f is just enough to allow grey/gray to be displayed
+                val possibleColors = validator.getPossibleMisspellings(color.lowercase(), Colors.getColors().map { it.key.lowercase() }, 1.67f)
+                if (possibleColors.isEmpty())
+                    yield("unknown color \"$color\"")
+                else
+                    yield("unknown color \"$color\" - maybe a misspelling of ${possibleColors.joinToString(" or ") { "\"$it\"" }}?")
+            }
             else if (text.isEmpty() && textToDisplay.isEmpty() && !starred && !separator)
                 yield("color set but nothing to apply it to")
         if (iconCrossed && link.isEmpty() && icon.isEmpty())
```
</details>
... but it doesn't really work perfectly. "green" has the exact same distance.