### PR TITLE
Fix number popup with commas in the number

### DIFF
--- a/core/src/com/unciv/models/translations/Translations.kt
+++ b/core/src/com/unciv/models/translations/Translations.kt
@@ -549,11 +549,19 @@ fun Number.tr(): String {
     return UncivGame.Current.settings.getCurrentNumberFormat().format(this)
 }
 
-fun String.parseTranslatedNumber(): Number? {
+/**
+ * Parses the string as an integer using the current number format.
+ *
+ * Empty strings result in 0.
+ *
+ * @return The integer value, or null if parsing fails.
+ */
+fun String.toIntOrNullTranslated(): Int? {
+    if (isEmpty()) return 0
     return try {
-        UncivGame.Current.settings.getCurrentNumberFormat().parse(this)
+        UncivGame.Current.settings.getCurrentNumberFormat().parse(this).toInt()
     } catch (_: ParseException) {
-        null
+        this.toIntOrNull()
     }
 }
 
@@ -562,10 +570,18 @@ fun Number.tr(language: String): String {
     return LocaleCode.getNumberFormatFromLanguage(language).format(this)
 }
 
-fun String.parseTranslatedNumber(language: String): Number? {
+/**
+ * Parses the string as an integer using the current number format.
+ *
+ * Empty strings result in 0.
+ *
+ * @return The integer value, or null if parsing fails.
+ */
+fun String.toIntOrNullTranslated(language: String): Int? {
+    if (isEmpty()) return 0
     return try {
-        LocaleCode.getNumberFormatFromLanguage(language).parse(this)
+        LocaleCode.getNumberFormatFromLanguage(language).parse(this).toInt()
     } catch (_: ParseException) {
-        null
+        this.toIntOrNull()
     }
 }

--- a/core/src/com/unciv/ui/popups/AskNumberPopup.kt
+++ b/core/src/com/unciv/ui/popups/AskNumberPopup.kt
@@ -4,7 +4,7 @@ import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.scenes.scene2d.ui.Button
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.scenes.scene2d.ui.TextField
-import com.unciv.models.translations.parseTranslatedNumber
+import com.unciv.models.translations.toIntOrNullTranslated
 import com.unciv.models.translations.tr
 import com.unciv.ui.components.widgets.UncivTextField
 import com.unciv.ui.components.input.onChange
@@ -67,9 +67,8 @@ class AskNumberPopup(
         val nameField = UncivTextField(label, defaultValue)
         nameField.textFieldFilter = TextField.TextFieldFilter { _, char -> char.isDigit() || char == '-' }
 
-        fun isValidInt(input: String) = input.parseTranslatedNumber() != null
-        fun getInt(input: String): Int? = input.parseTranslatedNumber()?.toInt()
-
+        fun isValidInt(input: String): Boolean = input.toIntOrNullTranslated() != null
+        fun getInt(input: String): Int? = input.toIntOrNullTranslated()
 
         fun clampInBounds(input: String): String {
             val int = getInt(input) ?: return input


### PR DESCRIPTION
When you have a trade window with commas in the number, the window reports that it's an invalid number. This is because `.toInt()` doesn't handle commas, unfortunately.

This change adds a `.replace()` to where that's used to fix #13491.
