### PR TITLE
Change the Fishing Boat shortcut key to `C`

### DIFF
--- a/android/assets/jsons/Civ V - Gods & Kings/TileImprovements.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/TileImprovements.json
@@ -91,7 +91,7 @@
 		"food": 1,
 		"techRequired": "Sailing",
 		"uniques": ["[+1 Gold] <after discovering [Compass]>", "Can only be built to improve a resource", "Pillaging this improvement yields approximately [+10 Gold]"],
-		"shortcutKey": "B"
+		"shortcutKey": "C"
 	},
 
 	// Military improvement

--- a/android/assets/jsons/Civ V - Vanilla/TileImprovements.json
+++ b/android/assets/jsons/Civ V - Vanilla/TileImprovements.json
@@ -91,7 +91,7 @@
 		"food": 1,
 		"techRequired": "Sailing",
 		"uniques": ["[+1 Gold] <after discovering [Compass]>", "Can only be built to improve a resource", "Pillaging this improvement yields approximately [+10 Gold]"],
-		"shortcutKey": "B"
+		"shortcutKey": "C"
 	},
 
 	// Military improvement


### PR DESCRIPTION
The current shortcut key of F sleeps the boat. Changing it to C doesn't have a conflict with another key, and it may work well as C is the first letter in the action *`C`reate Fishing Boats*.

Hmm, this isn't doing the thing. I'll have to investigate.
