### PR TITLE
Improve ModChecker UI

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -943,6 +943,8 @@ Hit the desired key now =
 Locate mod errors = 
 Check extension mods based on: = 
 -none- = 
+-declared requirements- = 
+Requirements could not be determined.\nChoose a base to check this Mod. = 
 Reload mods = 
 # Currently unused
 Checking mods for errors... = 

--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -944,6 +944,7 @@ Locate mod errors =
 Check extension mods based on: = 
 -none- = 
 Reload mods = 
+# Currently unused
 Checking mods for errors... = 
 No problems found. = 
 Autoupdate mod uniques = 

--- a/core/src/com/unciv/models/ruleset/validation/ModCompatibility.kt
+++ b/core/src/com/unciv/models/ruleset/validation/ModCompatibility.kt
@@ -56,6 +56,14 @@ object ModCompatibility {
             && mod.name.isNotBlank()
             && !mod.modOptions.hasUnique(UniqueType.ModIsAudioVisualOnly)
 
+    fun isConstantsOnly(mod: Ruleset): Boolean {
+        val folder = mod.folderLocation ?: return false
+        if (folder.list("atlas").isNotEmpty()) return false
+        val jsonFolder = folder.child("jsons")
+        if (!jsonFolder.exists() || !jsonFolder.isDirectory) return false
+        return jsonFolder.list().map { it.name() } == listOf("ModOptions.json")
+    }
+
     fun modNameFilter(modName: String, filter: String): Boolean {
         if (modName == filter) return true
         if (filter.length < 3 || !filter.startsWith('*') || !filter.endsWith('*')) return false

--- a/core/src/com/unciv/models/ruleset/validation/RulesetErrorList.kt
+++ b/core/src/com/unciv/models/ruleset/validation/RulesetErrorList.kt
@@ -9,15 +9,15 @@ import com.unciv.models.ruleset.unique.UniqueType
 
 class RulesetError(val text: String, val errorSeverityToReport: RulesetErrorSeverity)
 
-enum class RulesetErrorSeverity(val color: Color) {
+enum class RulesetErrorSeverity(val color: Color, val iconName: String) {
     /** Only appears in mod checker - used for possible misspellings, etc */
-    OK(Color.GREEN),
+    OK(Color.GREEN, "OtherIcons/Checkmark"),
     /** Only appears in mod checker */
-    WarningOptionsOnly(Color.YELLOW),
-    Warning(Color.YELLOW),
+    WarningOptionsOnly(Color.YELLOW, "OtherIcons/ExclamationMark"),
+    Warning(Color.YELLOW, "OtherIcons/ExclamationMark"),
     /** Only appears in mod checker */
-    ErrorOptionsOnly(Color.ORANGE),
-    Error(Color.RED),
+    ErrorOptionsOnly(Color.ORANGE, "OtherIcons/ExclamationMark"),
+    Error(Color.RED, "OtherIcons/Stop"),
 }
 
 /**

--- a/core/src/com/unciv/ui/popups/options/ModCheckTab.kt
+++ b/core/src/com/unciv/ui/popups/options/ModCheckTab.kt
@@ -1,7 +1,6 @@
 package com.unciv.ui.popups.options
 
 import com.badlogic.gdx.Gdx
-import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.scenes.scene2d.ui.Label
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.utils.Align
@@ -136,15 +135,10 @@ class ModCheckTab(
                     // Don't use .toLabel() either, since that activates translations as well, which is what we're trying to avoid,
                     // Instead, some manual work needs to be put in.
 
-                    val iconColor = modLinks.getFinalSeverity().color
-                    val iconName = when (iconColor) {
-                        Color.RED -> "OtherIcons/Stop"
-                        Color.YELLOW -> "OtherIcons/ExclamationMark"
-                        else -> "OtherIcons/Checkmark"
-                    }
-                    val icon = ImageGetter.getImage(iconName)
+                    val severity = modLinks.getFinalSeverity()
+                    val icon = ImageGetter.getImage(severity.iconName)
                         .apply { color = ImageGetter.CHARCOAL }
-                        .surroundWithCircle(30f, color = iconColor)
+                        .surroundWithCircle(30f, color = severity.color)
 
                     val expanderTab = ExpanderTab(mod.name, icon = icon, startsOutOpened = mod.name in openedExpanderTitles) {
                         it.defaults().align(Align.left)

--- a/core/src/com/unciv/ui/popups/options/ModCheckTab.kt
+++ b/core/src/com/unciv/ui/popups/options/ModCheckTab.kt
@@ -145,9 +145,7 @@ class ModCheckTab(
                         it.defaults().pad(10f)
 
                         val openUniqueBuilderButton = "Open unique builder".toTextButton()
-                        val ruleset = if (base == MOD_CHECK_WITHOUT_BASE) mod
-                        else RulesetCache.getComplexRuleset(linkedSetOf(mod.name), base)
-                        openUniqueBuilderButton.onClick { UncivGame.Current.pushScreen(UniqueBuilderScreen(ruleset)) }
+                        openUniqueBuilderButton.onClick { openUniqueBuilder(mod, base) }
                         it.add(openUniqueBuilderButton).row()
 
                         if (!noProblem && mod.folderLocation != null) {
@@ -186,6 +184,11 @@ class ModCheckTab(
         }
     }
 
+    private fun openUniqueBuilder(mod: Ruleset, base: String) {
+        val ruleset = if (base == MOD_CHECK_WITHOUT_BASE) mod
+            else RulesetCache.getComplexRuleset(linkedSetOf(mod.name), base)
+        UncivGame.Current.pushScreen(UniqueBuilderScreen(ruleset))
+    }
 
     private fun autoUpdateUniques(screen: BaseScreen, mod: Ruleset, replaceableUniques: HashMap<String, String>) {
         UniqueAutoUpdater.autoupdateUniques(mod, replaceableUniques)

--- a/core/src/com/unciv/ui/popups/options/ModCheckTab.kt
+++ b/core/src/com/unciv/ui/popups/options/ModCheckTab.kt
@@ -218,7 +218,7 @@ class ModCheckTab(
         UniqueAutoUpdater.autoupdateUniques(mod, replaceableUniques)
         val toastText = "Uniques updated!"
         ToastPopup(toastText, screen)
-        runModChecker()
+        runAction()
     }
 
 }

--- a/core/src/com/unciv/ui/popups/options/ModCheckTab.kt
+++ b/core/src/com/unciv/ui/popups/options/ModCheckTab.kt
@@ -110,9 +110,13 @@ class ModCheckTab(
 
     private fun cancelJob() {
         val job = runningCheck ?: return
+        endJob()
+        job.cancel()
+    }
+
+    private fun endJob() {
         runningCheck = null
         loadingImage.hide()
-        job.cancel()
     }
 
     private fun runModChecker(base: String = MOD_CHECK_DYNAMIC_BASE) {
@@ -174,7 +178,7 @@ class ModCheckTab(
 
             // done with all mods!
             launchOnGLThread {
-                loadingImage.hide()
+                endJob()
             }
         }
     }


### PR DESCRIPTION
Follow-up to #13488, touching different files altogether... The trigger was already mentioned, and the todo list shown - somewhere in those discussions.

Read commits individually. Most are pretty obviously beneficial, getting less clear to the end, the last one is the one that might surprise - and needs screenshots...

Open todo's:
- Cancelling the checker Job is still inefficient, as the checker isn't a `suspend` function itself. I tried the trivial way up to a point - and no, the proper solution would be to use a Flow.collect architecture (automatically cancellable between emits), much more work than simply slapping `suspend`s, a `runBlocking` or two, and `yield`s in there (the coroutine yield is a different beast than the sequence yield), especially getting the exception catching right. Nah.
- Think hard about that choice when not to check + not to list a mod. This PR took the approach:
      - Make the intelligent dynamic base (from ModCompatibility) default, meaning I expect it to be the most useful for "runs right away". I might be wrong.
      - To head off people complaining "it doesn't show my mod at all" I created the gray placeholders, and pretty much only for that psychological reason. Both "-none-" and specific bases will omit irrelevant mods (specific bases already did so before - other bases).
      - One might wish to know _which_ base was used per mod - didn't have a good idea where to show that.
- The extra hommage _only_ for Caballero's "Barbarian XP farm" in there - overkill (the entirely new method in `ModCompatibility`)?
- One could create a Help text for the ModChecker - plonk a Question icon where the LoadingImage is now (actually using its idle icon feature), link to a new Tutorial. I'm sure good modders might be able to author something useful - me probably less so.
- Search takes a bit too much space for my taste. Didn't flesh out the idea, though, PR big enough. Think a magnifying-glass icon to the left of "reload", balancing the "help" icon to its right, and it slides open/closed a drawer/expander-like thingy with the search TextField... And changes colour when closed with a filter active
- Or give it another "Hamburger menu" for advanced stuff, more extensible?
- Last untreated note: [The pollution in console output for desktop debug runs](https://github.com/yairm210/Unciv/blob/e38e76b5c69912b5df2471220a58bbd7e28dab7c/core/src/com/unciv/models/ruleset/RulesetCache.kt#L58-L75): Isn't that almost obsolete with the "mod-ci" option? Maybe gate it with another cmd line param? Irks me a little and costs time - and hits breakpoints prematurely when debugging the validator itself.

<details><summary>Screenshots</summary>

<br/>
The loading indicator (shot a bit early, still fading in. It's scarlet later.)
![image](https://github.com/user-attachments/assets/604704ea-50c2-45ce-ba56-fd7ee5794394)

The "Orange" level no longer gets a checkmark: (In the future, since color and icon name are in the same place, one would see the need when adding another level right away. Also, use another?)
![image](https://github.com/user-attachments/assets/e9735e29-001d-4d89-952d-ff810a7f3045)

How "-none-" omits mods that _declare_ they need G&K (No Aliens though it's installed), also showing how PAV-mods or Barbarian XP farm are recognized as OK to check without base:
![image](https://github.com/user-attachments/assets/502cc6bb-c9d6-4bc6-8f2b-1c33bbf89b5a)

Testing against G&K includes PAV, constants-only, and declared compatible mods:
![image](https://github.com/user-attachments/assets/b19e1140-b46e-4853-b4b4-9e36cc851350)
... now if only all mods-of-mods expecting to run on top of, say, deciv, would be so kind as to declare their dependency ...

"Ant Civ" only shows true positives now:
![image](https://github.com/user-attachments/assets/368a3286-6dff-411c-8d74-59038b6706e7)

Lastly, how in the default cases skipped mods are shown - with tooltip - meaning if they are extension mods and contain RulesetObjects and don't tell me on which base Ruleset they'd like to run, then I need to choose, otherwise no check:
![image](https://github.com/user-attachments/assets/e1a47034-727d-41cc-a5ee-ec8a3658fbeb)


</details>