### PR TITLE
Speed and Difficulty uniques treated as part of GlobalUniques

### DIFF
--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -148,10 +148,11 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
     //region Fields - Transient
 
     @Transient
-    lateinit var difficultyObject: Difficulty // Since this is static game-wide, and was taking a large part of nextTurn
+    private lateinit var difficultyObject: Difficulty // Since this is static game-wide, and was taking a large part of nextTurn
 
     @Transient
     lateinit var speed: Speed
+        private set
 
     @Transient
     lateinit var currentPlayerCiv: Civilization // this is called thousands of times, no reason to search for it with a find{} every time

--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -665,12 +665,8 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
             }
         }
 
-        difficultyObject = ruleset.difficulties[difficulty]!!
-
-        speed = ruleset.speeds[gameParameters.speed]!!
-
-        // Needs to be set before tileMap.setTransients!
-        combinedGlobalUniques = GlobalUniques.combine(ruleset.globalUniques, speed, difficultyObject)
+        // combinedGlobalUniques needs to be set before tileMap.setTransients!
+        setGlobalTransients()
 
         tileMap.setTransients(ruleset)
 
@@ -708,6 +704,14 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
         migrateToTileHistory()
         migrateGreatGeneralPools()
         ensureUnitIds()
+    }
+
+    fun setGlobalTransients() {
+        difficultyObject = ruleset.difficulties[difficulty]!!
+
+        speed = ruleset.speeds[gameParameters.speed]!!
+
+        combinedGlobalUniques = GlobalUniques.combine(ruleset.globalUniques, speed, difficultyObject)
     }
 
     private fun updateCivilizationState() {

--- a/core/src/com/unciv/logic/GameStarter.kt
+++ b/core/src/com/unciv/logic/GameStarter.kt
@@ -440,9 +440,10 @@ object GameStarter {
             adjustStartingUnitsForCityStatesAndOneCityChallenge(civ, gameInfo, startingUnits, settlerLikeUnits)
             placeStartingUnits(civ, startingLocation, startingUnits, ruleset, ruleset.eras[startingEra]!!.startingMilitaryUnit, settlerLikeUnits)
 
-            val startingTriggers = (ruleset.globalUniques.uniqueObjects + civ.nation.uniqueObjects)
             // Trigger any global or nation uniques that should triggered.
             // We may need the starting location for some uniques, which is why we're doing it now
+            // This relies on gameInfo.ruleset already being initialized
+            val startingTriggers = (gameInfo.getGlobalUniques().uniqueObjects + civ.nation.uniqueObjects)
             for (unique in startingTriggers.filter { !it.hasTriggerConditional() && it.conditionalsApply(civ.state) })
                 UniqueTriggerActivation.triggerUnique(unique, civ, tile = startingLocation)
         }

--- a/core/src/com/unciv/logic/GameStarter.kt
+++ b/core/src/com/unciv/logic/GameStarter.kt
@@ -440,9 +440,9 @@ object GameStarter {
             adjustStartingUnitsForCityStatesAndOneCityChallenge(civ, gameInfo, startingUnits, settlerLikeUnits)
             placeStartingUnits(civ, startingLocation, startingUnits, ruleset, ruleset.eras[startingEra]!!.startingMilitaryUnit, settlerLikeUnits)
 
-            //Trigger any global or nation uniques that should triggered.
-            //We may need the starting location for some uniques, which is why we're doing it now
             val startingTriggers = (ruleset.globalUniques.uniqueObjects + civ.nation.uniqueObjects)
+            // Trigger any global or nation uniques that should triggered.
+            // We may need the starting location for some uniques, which is why we're doing it now
             for (unique in startingTriggers.filter { !it.hasTriggerConditional() && it.conditionalsApply(civ.state) })
                 UniqueTriggerActivation.triggerUnique(unique, civ, tile = startingLocation)
         }

--- a/core/src/com/unciv/logic/civilization/Civilization.kt
+++ b/core/src/com/unciv/logic/civilization/Civilization.kt
@@ -543,7 +543,7 @@ class Civilization : IsPartOfGameInfoSerialization {
             yieldAll(religionManager.religion!!.founderBeliefUniqueMap.getMatchingUniques(uniqueType, stateForConditionals))
 
         yieldAll(civResourcesUniqueMap.getMatchingUniques(uniqueType, stateForConditionals))
-        yieldAll(gameInfo.ruleset.globalUniques.getMatchingUniques(uniqueType, stateForConditionals))
+        yieldAll(gameInfo.getGlobalUniques().getMatchingUniques(uniqueType, stateForConditionals))
     }
 
     fun getTriggeredUniques(
@@ -560,7 +560,7 @@ class Civilization : IsPartOfGameInfoSerialization {
         yieldAll(policies.policyUniques.getTriggeredUniques(trigger, stateForConditionals, triggerFilter))
         yieldAll(tech.techUniques.getTriggeredUniques(trigger, stateForConditionals, triggerFilter))
         yieldAll(getEra().uniqueMap.getTriggeredUniques (trigger, stateForConditionals, triggerFilter))
-        yieldAll(gameInfo.ruleset.globalUniques.uniqueMap.getTriggeredUniques(trigger, stateForConditionals, triggerFilter))
+        yieldAll(gameInfo.getGlobalUniques().uniqueMap.getTriggeredUniques(trigger, stateForConditionals, triggerFilter))
     }.toList() // Triggers can e.g. add buildings which contain triggers, causing concurrent modification errors
 
     /** Implements [UniqueParameterType.CivFilter][com.unciv.models.ruleset.unique.UniqueParameterType.CivFilter] */

--- a/core/src/com/unciv/models/ruleset/GlobalUniques.kt
+++ b/core/src/com/unciv/models/ruleset/GlobalUniques.kt
@@ -8,8 +8,8 @@ class GlobalUniques: RulesetObject() {
     override var name = "GlobalUniques"
 
     var unitUniques: ArrayList<String> = ArrayList()
-    override fun getUniqueTarget() = UniqueTarget.Global
     override fun makeLink() = "" // No own category on Civilopedia screen
+    override fun getUniqueTarget() = UniqueTarget.GlobalUniques
 
     companion object {
         fun getUniqueSourceDescription(unique: Unique): String {
@@ -22,6 +22,15 @@ class GlobalUniques: RulesetObject() {
                 UniqueType.ConditionalBetweenHappiness, UniqueType.ConditionalBelowHappiness -> "Unhappiness"
                 UniqueType.ConditionalWLTKD -> "We Love The King Day"
                 else -> "Global Effect"
+            }
+        }
+
+        fun combine(globalUniques: GlobalUniques, vararg otherSources: IHasUniques) = GlobalUniques().apply {
+            /** This must happen before [uniqueMap] and [uniqueObjects] are triggered */
+            uniques.addAll(globalUniques.uniques)
+            unitUniques = globalUniques.unitUniques
+            for (source in otherSources) {
+                uniques.addAll(source.uniques)
             }
         }
     }

--- a/core/src/com/unciv/models/ruleset/GlobalUniques.kt
+++ b/core/src/com/unciv/models/ruleset/GlobalUniques.kt
@@ -1,5 +1,6 @@
 package com.unciv.models.ruleset
 
+import com.unciv.models.ruleset.unique.IHasUniques
 import com.unciv.models.ruleset.unique.Unique
 import com.unciv.models.ruleset.unique.UniqueTarget
 import com.unciv.models.ruleset.unique.UniqueType

--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -33,6 +33,7 @@ import com.unciv.models.stats.SubStat
 import com.unciv.models.translations.tr
 import com.unciv.ui.screens.civilopediascreen.ICivilopediaText
 import com.unciv.utils.Log
+import org.jetbrains.annotations.VisibleForTesting
 import kotlin.collections.set
 
 enum class RulesetFile(
@@ -510,6 +511,12 @@ class Ruleset {
     internal fun updateResourceTransients() {
         for (resource in tileResources.values)
             resource.setTransients(this)
+    }
+
+    @VisibleForTesting
+    /** For use by class TestGame. Use only before triggering the globalUniques.uniqueObjects lazy. */
+    fun addGlobalUniques(vararg uniques: String) {
+        globalUniques.uniques.addAll(uniques)
     }
 
     /** Used for displaying a RuleSet's name */

--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -5,6 +5,7 @@ import com.unciv.Constants
 import com.unciv.json.fromJsonFile
 import com.unciv.json.json
 import com.unciv.logic.BackwardCompatibility.updateDeprecations
+import com.unciv.logic.GameInfo
 import com.unciv.logic.map.tile.RoadStatus
 import com.unciv.models.metadata.BaseRuleset
 import com.unciv.models.ruleset.nation.CityStateType
@@ -96,7 +97,9 @@ class Ruleset {
     val difficulties = LinkedHashMap<String, Difficulty>()
     val eras = LinkedHashMap<String, Era>()
     val speeds = LinkedHashMap<String, Speed>()
-    var globalUniques = GlobalUniques()
+    /** Only [Ruleset.load], [GameInfo], [BaseUnit] and [RulesetValidator] should access this directly.
+     *  All other uses should call [GameInfo.getGlobalUniques] instead. */
+    internal var globalUniques = GlobalUniques()
     val nations = LinkedHashMap<String, Nation>()
     val policies = LinkedHashMap<String, Policy>()
     val policyBranches = LinkedHashMap<String, PolicyBranch>()

--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -34,11 +34,13 @@ import com.unciv.ui.screens.civilopediascreen.ICivilopediaText
 import com.unciv.utils.Log
 import kotlin.collections.set
 
-enum class RulesetFile(val filename: String,
-                       val getRulesetObjects:Ruleset.() -> Sequence<IRulesetObject> = { emptySequence() },
-                       val getUniques: Ruleset.() -> Sequence<Unique> = {getRulesetObjects().flatMap { it.uniqueObjects }}){
-    Beliefs("Beliefs.json", {beliefs.values.asSequence()}),
-    Buildings("Buildings.json", { buildings.values.asSequence()}),
+enum class RulesetFile(
+    val filename: String,
+    val getRulesetObjects: Ruleset.() -> Sequence<IRulesetObject> = { emptySequence() },
+    val getUniques: Ruleset.() -> Sequence<Unique> = { getRulesetObjects().flatMap { it.uniqueObjects } }
+){
+    Beliefs("Beliefs.json", { beliefs.values.asSequence() }),
+    Buildings("Buildings.json", { buildings.values.asSequence() }),
     Eras("Eras.json", { eras.values.asSequence() }),
     Religions("Religions.json"),
     Nations("Nations.json", { nations.values.asSequence() }),
@@ -51,14 +53,14 @@ enum class RulesetFile(val filename: String,
     TileImprovements("TileImprovements.json", { tileImprovements.values.asSequence() }),
     TileResources("TileResources.json", { tileResources.values.asSequence() }),
     Specialists("Specialists.json"),
-    Units("Units.json", { units.values.asSequence()}),
+    Units("Units.json", { units.values.asSequence() }),
     UnitPromotions("UnitPromotions.json", { unitPromotions.values.asSequence() }),
     UnitTypes("UnitTypes.json", { unitTypes.values.asSequence() }),
     VictoryTypes("VictoryTypes.json"),
     CityStateTypes("CityStateTypes.json", getUniques =
         { cityStateTypes.values.asSequence().flatMap { it.allyBonusUniqueMap.getAllUniques() + it.friendBonusUniqueMap.getAllUniques() } }),
     Personalities("Personalities.json", { personalities.values.asSequence() }),
-    Events("Events.json", {events.values.asSequence() + events.values.flatMap { it.choices }}),
+    Events("Events.json", { events.values.asSequence() + events.values.flatMap { it.choices } }),
     GlobalUniques("GlobalUniques.json", { sequenceOf(globalUniques) }),
     ModOptions("ModOptions.json", getUniques = { modOptions.uniqueObjects.asSequence() }),
     Speeds("Speeds.json", { speeds.values.asSequence() }),

--- a/core/src/com/unciv/models/ruleset/Speed.kt
+++ b/core/src/com/unciv/models/ruleset/Speed.kt
@@ -5,6 +5,7 @@ import com.unciv.models.ruleset.unique.UniqueTarget
 import com.unciv.models.stats.Stat
 import com.unciv.models.translations.tr
 import com.unciv.ui.components.fonts.Fonts
+import com.unciv.ui.objectdescriptions.uniquesToCivilopediaTextLines
 import com.unciv.ui.screens.civilopediascreen.FormattedLine
 import java.util.*
 import kotlin.collections.ArrayList
@@ -79,6 +80,7 @@ class Speed : RulesetObject(), IsPartOfGameInfoSerialization {
         yield(FormattedLine("Adjacent city religious pressure: [$religiousPressureAdjacentCity]${Fonts.faith}"))
         yield(FormattedLine("Peace deal duration: [$peaceDealDuration] turns${Fonts.turn}"))
         yield(FormattedLine("Start year: [" + ("{[${abs(startYear).toInt()}] " + (if (startYear < 0) "BC" else "AD") + "}]").tr()))
+        yieldAll(uniquesToCivilopediaTextLines())
     }.toList()
     override fun getSortGroup(ruleset: Ruleset): Int = (modifier * 1000).toInt()
 

--- a/core/src/com/unciv/models/ruleset/Speed.kt
+++ b/core/src/com/unciv/models/ruleset/Speed.kt
@@ -58,7 +58,7 @@ class Speed : RulesetObject(), IsPartOfGameInfoSerialization {
         const val DEFAULTFORSIMULATION: String = "Standard"
     }
 
-    // Note: Speed is IHasUniques, but no implementation reads them, thus no UniqueType accepts this target
+    // Note: Speed uniques will be treated as part of GlobalUniques
     override fun getUniqueTarget(): UniqueTarget = UniqueTarget.Speed
 
     override fun makeLink(): String = "Speed/$name"

--- a/core/src/com/unciv/models/ruleset/nation/Difficulty.kt
+++ b/core/src/com/unciv/models/ruleset/nation/Difficulty.kt
@@ -111,6 +111,8 @@ class Difficulty: RulesetObject() {
         lines += FormattedLine()
         lines += FormattedLine("{Turns until barbarians enter player tiles}: $turnBarbariansCanEnterPlayerTiles ${Fonts.turn}")
         lines += FormattedLine("{Gold reward for clearing barbarian camps}: $clearBarbarianCampReward ${Fonts.gold}")
+
+        uniquesToCivilopediaTextLines(lines)
         return lines
     }
 

--- a/core/src/com/unciv/models/ruleset/nation/Difficulty.kt
+++ b/core/src/com/unciv/models/ruleset/nation/Difficulty.kt
@@ -1,13 +1,14 @@
 package com.unciv.models.ruleset.nation
 
 import com.unciv.models.ruleset.Ruleset
+import com.unciv.models.ruleset.RulesetObject
 import com.unciv.models.ruleset.unique.Unique
-import com.unciv.models.stats.INamed
+import com.unciv.models.ruleset.unique.UniqueTarget
 import com.unciv.ui.components.fonts.Fonts
+import com.unciv.ui.objectdescriptions.uniquesToCivilopediaTextLines
 import com.unciv.ui.screens.civilopediascreen.FormattedLine
-import com.unciv.ui.screens.civilopediascreen.ICivilopediaText
 
-class Difficulty: INamed, ICivilopediaText {
+class Difficulty: RulesetObject() {
     override lateinit var name: String
     var baseHappiness: Int = 0
     var extraHappinessPerLuxury: Float = 0f
@@ -40,8 +41,8 @@ class Difficulty: INamed, ICivilopediaText {
     // property defined in json but so far unused:
     // var aisExchangeTechs = false
 
-    override var civilopediaText = listOf<FormattedLine>()
-
+    // Note: Difficulty uniques will be treated as part of GlobalUniques
+    override fun getUniqueTarget(): UniqueTarget = UniqueTarget.Difficulty
 
     override fun makeLink() = "Difficulty/$name"
 

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTarget.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTarget.kt
@@ -88,7 +88,8 @@ enum class UniqueTarget(
         // As Array so it can used in a vararg parameter list.
         val Displayable = arrayOf(
             Building, Unit, UnitType, Improvement, Tech, FollowerBelief, FounderBelief,
-            Terrain, Resource, Policy, Promotion, Nation, Ruins, Speed, EventChoice
+            Terrain, Resource, Policy, Promotion, Nation, Ruins, Speed, EventChoice,
+            Difficulty
         )
         val CanIncludeSuppression = arrayOf(
             Triggerable,    // Includes Global and covers most IHasUnique's

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTarget.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTarget.kt
@@ -54,8 +54,9 @@ enum class UniqueTarget(
     Ruins(inheritsFrom = UnitTriggerable),
 
     // Other
-    Speed,
-    Difficulty(inheritsFrom = GlobalUniques),
+    GlobalUniques(inheritsFrom = Global),
+    Speed("Speed uniques will be treated as part of GlobalUniques for the Speed selected in a game", inheritsFrom = GlobalUniques),
+    Difficulty("Difficulty uniques will be treated as part of GlobalUniques for the Difficulty selected in a game", inheritsFrom = GlobalUniques),
     Tutorial,
     CityState(inheritsFrom = Global),
     ModOptions,

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTarget.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTarget.kt
@@ -55,6 +55,7 @@ enum class UniqueTarget(
 
     // Other
     Speed,
+    Difficulty(inheritsFrom = GlobalUniques),
     Tutorial,
     CityState(inheritsFrom = Global),
     ModOptions,

--- a/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
+++ b/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
@@ -175,6 +175,7 @@ open class RulesetValidator protected constructor(
             if (difficulty.turnBarbariansCanEnterPlayerTiles < 0)
                 lines.add("Difficulty ${difficulty.name} has a negative turnBarbariansCanEnterPlayerTiles!",
                     RulesetErrorSeverity.Warning, sourceObject = null)
+            uniqueValidator.checkUniques(difficulty, lines, reportRulesetSpecificErrors, tryFixUnknownUniques)
         }
     }
 
@@ -397,8 +398,7 @@ open class RulesetValidator protected constructor(
                     lines.add("The 'untilTurn' field in the turn increment list must be monotonously increasing, but $untilTurn is <= $lastTurn", sourceObject = speed)
                 lastTurn = untilTurn
             }
-            if (speed.uniques.isNotEmpty())
-                lines.add("Speed Uniques are not supported", RulesetErrorSeverity.Warning, speed)
+            uniqueValidator.checkUniques(speed, lines, reportRulesetSpecificErrors, tryFixUnknownUniques)
         }
     }
 

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -1089,7 +1089,7 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 	Applicable to: Nation, Terrain, Improvement, Resource
 
 ??? example  "Will not be displayed in Civilopedia"
-	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, EventChoice
+	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, Difficulty, EventChoice
 
 ??? example  "Will not be chosen for new games"
 	Applicable to: Nation
@@ -1098,7 +1098,7 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 	Allows displaying arbitrary text in a Unique listing. Only the text within the '[]' brackets will be displayed, the rest serves to allow Ruleset validation to recognize the intent.
 	Example: "Comment [comment]"
 
-	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, EventChoice
+	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, Difficulty, EventChoice
 
 ## Personality uniques
 ??? example  "Will not build [baseUnitFilter/buildingFilter]"
@@ -1137,13 +1137,13 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 	Applicable to: Tech, Policy, FounderBelief, FollowerBelief, Promotion
 
 ??? example  "Will not be displayed in Civilopedia"
-	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, EventChoice
+	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, Difficulty, EventChoice
 
 ??? example  "Comment [comment]"
 	Allows displaying arbitrary text in a Unique listing. Only the text within the '[]' brackets will be displayed, the rest serves to allow Ruleset validation to recognize the intent.
 	Example: "Comment [comment]"
 
-	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, EventChoice
+	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, Difficulty, EventChoice
 
 ## Policy uniques
 ??? example  "Only available"
@@ -1160,13 +1160,13 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 	Applicable to: Tech, Policy, FounderBelief, FollowerBelief, Promotion
 
 ??? example  "Will not be displayed in Civilopedia"
-	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, EventChoice
+	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, Difficulty, EventChoice
 
 ??? example  "Comment [comment]"
 	Allows displaying arbitrary text in a Unique listing. Only the text within the '[]' brackets will be displayed, the rest serves to allow Ruleset validation to recognize the intent.
 	Example: "Comment [comment]"
 
-	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, EventChoice
+	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, Difficulty, EventChoice
 
 ## FounderBelief uniques
 !!! note ""
@@ -1198,13 +1198,13 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 	Applicable to: Tech, Policy, FounderBelief, FollowerBelief, Promotion
 
 ??? example  "Will not be displayed in Civilopedia"
-	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, EventChoice
+	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, Difficulty, EventChoice
 
 ??? example  "Comment [comment]"
 	Allows displaying arbitrary text in a Unique listing. Only the text within the '[]' brackets will be displayed, the rest serves to allow Ruleset validation to recognize the intent.
 	Example: "Comment [comment]"
 
-	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, EventChoice
+	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, Difficulty, EventChoice
 
 ## FollowerBelief uniques
 !!! note ""
@@ -1446,13 +1446,13 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 	Applicable to: Tech, Policy, FounderBelief, FollowerBelief, Promotion
 
 ??? example  "Will not be displayed in Civilopedia"
-	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, EventChoice
+	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, Difficulty, EventChoice
 
 ??? example  "Comment [comment]"
 	Allows displaying arbitrary text in a Unique listing. Only the text within the '[]' brackets will be displayed, the rest serves to allow Ruleset validation to recognize the intent.
 	Example: "Comment [comment]"
 
-	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, EventChoice
+	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, Difficulty, EventChoice
 
 ## Building uniques
 ??? example  "Consumes [amount] [resource]"
@@ -1607,7 +1607,7 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 	Applicable to: Tech, Building
 
 ??? example  "Will not be displayed in Civilopedia"
-	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, EventChoice
+	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, Difficulty, EventChoice
 
 ??? example  "Shown while unbuilable"
 	Applicable to: Building, Unit
@@ -1616,7 +1616,7 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 	Allows displaying arbitrary text in a Unique listing. Only the text within the '[]' brackets will be displayed, the rest serves to allow Ruleset validation to recognize the intent.
 	Example: "Comment [comment]"
 
-	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, EventChoice
+	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, Difficulty, EventChoice
 
 ## UnitAction uniques
 !!! note ""
@@ -2187,7 +2187,7 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 	Applicable to: Unit
 
 ??? example  "Will not be displayed in Civilopedia"
-	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, EventChoice
+	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, Difficulty, EventChoice
 
 ??? example  "Shown while unbuilable"
 	Applicable to: Building, Unit
@@ -2196,17 +2196,17 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 	Allows displaying arbitrary text in a Unique listing. Only the text within the '[]' brackets will be displayed, the rest serves to allow Ruleset validation to recognize the intent.
 	Example: "Comment [comment]"
 
-	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, EventChoice
+	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, Difficulty, EventChoice
 
 ## UnitType uniques
 ??? example  "Will not be displayed in Civilopedia"
-	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, EventChoice
+	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, Difficulty, EventChoice
 
 ??? example  "Comment [comment]"
 	Allows displaying arbitrary text in a Unique listing. Only the text within the '[]' brackets will be displayed, the rest serves to allow Ruleset validation to recognize the intent.
 	Example: "Comment [comment]"
 
-	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, EventChoice
+	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, Difficulty, EventChoice
 
 ## Promotion uniques
 ??? example  "Only available"
@@ -2232,13 +2232,13 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 	Applicable to: Tech, Policy, FounderBelief, FollowerBelief, Promotion
 
 ??? example  "Will not be displayed in Civilopedia"
-	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, EventChoice
+	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, Difficulty, EventChoice
 
 ??? example  "Comment [comment]"
 	Allows displaying arbitrary text in a Unique listing. Only the text within the '[]' brackets will be displayed, the rest serves to allow Ruleset validation to recognize the intent.
 	Example: "Comment [comment]"
 
-	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, EventChoice
+	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, Difficulty, EventChoice
 
 ## Terrain uniques
 ??? example  "[stats]"
@@ -2421,13 +2421,13 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 	Applicable to: Nation, Terrain, Improvement, Resource
 
 ??? example  "Will not be displayed in Civilopedia"
-	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, EventChoice
+	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, Difficulty, EventChoice
 
 ??? example  "Comment [comment]"
 	Allows displaying arbitrary text in a Unique listing. Only the text within the '[]' brackets will be displayed, the rest serves to allow Ruleset validation to recognize the intent.
 	Example: "Comment [comment]"
 
-	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, EventChoice
+	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, Difficulty, EventChoice
 
 ??? example  "Suppress warning [validationWarning]"
 	Allows suppressing specific validation warnings. Errors, deprecation warnings, or warnings about untyped and non-filtering uniques should be heeded, not suppressed, and are therefore not accepted. Note that this can be used in ModOptions, in the uniques a warning is about, or as modifier on the unique triggering a warning - but you still need to be specific. Even in the modifier case you will need to specify a sufficiently selective portion of the warning text as parameter.
@@ -2594,13 +2594,13 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 	Applicable to: Improvement
 
 ??? example  "Will not be displayed in Civilopedia"
-	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, EventChoice
+	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, Difficulty, EventChoice
 
 ??? example  "Comment [comment]"
 	Allows displaying arbitrary text in a Unique listing. Only the text within the '[]' brackets will be displayed, the rest serves to allow Ruleset validation to recognize the intent.
 	Example: "Comment [comment]"
 
-	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, EventChoice
+	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, Difficulty, EventChoice
 
 ## Resource uniques
 ??? example  "Obsolete with [tech]"
@@ -2681,13 +2681,13 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 	Applicable to: Resource
 
 ??? example  "Will not be displayed in Civilopedia"
-	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, EventChoice
+	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, Difficulty, EventChoice
 
 ??? example  "Comment [comment]"
 	Allows displaying arbitrary text in a Unique listing. Only the text within the '[]' brackets will be displayed, the rest serves to allow Ruleset validation to recognize the intent.
 	Example: "Comment [comment]"
 
-	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, EventChoice
+	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, Difficulty, EventChoice
 
 ## Ruins uniques
 ??? example  "Only available"
@@ -2709,29 +2709,47 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 	Applicable to: Ruins
 
 ??? example  "Will not be displayed in Civilopedia"
-	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, EventChoice
+	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, Difficulty, EventChoice
 
 ??? example  "Comment [comment]"
 	Allows displaying arbitrary text in a Unique listing. Only the text within the '[]' brackets will be displayed, the rest serves to allow Ruleset validation to recognize the intent.
 	Example: "Comment [comment]"
 
-	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, EventChoice
+	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, Difficulty, EventChoice
 
 ## Speed uniques
+!!! note ""
+
+    Speed uniques will be treated as part of GlobalUniques for the Speed selected in a game
+
 ??? example  "Will not be displayed in Civilopedia"
-	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, EventChoice
+	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, Difficulty, EventChoice
 
 ??? example  "Comment [comment]"
 	Allows displaying arbitrary text in a Unique listing. Only the text within the '[]' brackets will be displayed, the rest serves to allow Ruleset validation to recognize the intent.
 	Example: "Comment [comment]"
 
-	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, EventChoice
+	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, Difficulty, EventChoice
 
 ??? example  "Suppress warning [validationWarning]"
 	Allows suppressing specific validation warnings. Errors, deprecation warnings, or warnings about untyped and non-filtering uniques should be heeded, not suppressed, and are therefore not accepted. Note that this can be used in ModOptions, in the uniques a warning is about, or as modifier on the unique triggering a warning - but you still need to be specific. Even in the modifier case you will need to specify a sufficiently selective portion of the warning text as parameter.
 	Example: "Suppress warning [Tinman is supposed to automatically upgrade at tech Clockwork, and therefore Servos for its upgrade Mecha may not yet be researched! -or- *is supposed to automatically upgrade*]"
 
 	Applicable to: Triggerable, Terrain, Speed, ModOptions, MetaModifier
+
+## Difficulty uniques
+!!! note ""
+
+    Difficulty uniques will be treated as part of GlobalUniques for the Difficulty selected in a game
+
+??? example  "Will not be displayed in Civilopedia"
+	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, Difficulty, EventChoice
+
+??? example  "Comment [comment]"
+	Allows displaying arbitrary text in a Unique listing. Only the text within the '[]' brackets will be displayed, the rest serves to allow Ruleset validation to recognize the intent.
+	Example: "Comment [comment]"
+
+	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, Difficulty, EventChoice
 
 ## Tutorial uniques
 ## CityState uniques
@@ -2822,13 +2840,13 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 	Applicable to: Tech, Policy, Building, Unit, Promotion, Improvement, Ruins, Event, EventChoice
 
 ??? example  "Will not be displayed in Civilopedia"
-	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, EventChoice
+	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, Difficulty, EventChoice
 
 ??? example  "Comment [comment]"
 	Allows displaying arbitrary text in a Unique listing. Only the text within the '[]' brackets will be displayed, the rest serves to allow Ruleset validation to recognize the intent.
 	Example: "Comment [comment]"
 
-	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, EventChoice
+	Applicable to: Nation, Tech, Policy, FounderBelief, FollowerBelief, Building, Unit, UnitType, Promotion, Terrain, Improvement, Resource, Ruins, Speed, Difficulty, EventChoice
 
 ## Conditional uniques
 !!! note ""

--- a/tests/src/com/unciv/logic/city/managers/CityPopulationManagerTest.kt
+++ b/tests/src/com/unciv/logic/city/managers/CityPopulationManagerTest.kt
@@ -45,12 +45,10 @@ class CityPopulationManagerTest {
     @Test
     fun `should change food requirements for different gamespeeds`() {
         // given
-        val quickSpeedGame = TestGame()
-        quickSpeedGame.gameInfo.speed = quickSpeedGame.ruleset.speeds["Quick"]!!
+        val quickSpeedGame = TestGame().apply { setSpeed("Quick") }
         val quickSpeedCity = quickSpeedGame.addCity(quickSpeedGame.addCiv(), quickSpeedGame.getTile(Vector2.Zero), initialPopulation = 1)
 
-        val epicSpeedGame = TestGame()
-        epicSpeedGame.gameInfo.speed = epicSpeedGame.ruleset.speeds["Epic"]!!
+        val epicSpeedGame = TestGame().apply { setSpeed("Epic") }
         val epicSpeedCity = epicSpeedGame.addCity(epicSpeedGame.addCiv(), epicSpeedGame.getTile(Vector2.Zero), initialPopulation = 1)
 
         // when
@@ -80,9 +78,7 @@ class CityPopulationManagerTest {
     @Test
     fun `should increase food requirements for AI on easier difficulties`() {
         // given
-        val easierDifficultyGame = TestGame()
-        easierDifficultyGame.gameInfo.difficulty = "Chieftain"
-        easierDifficultyGame.gameInfo.difficultyObject = easierDifficultyGame.ruleset.difficulties["Chieftain"]!!
+        val easierDifficultyGame = TestGame().apply { setDifficulty("Chieftain") }
         val easierCity = easierDifficultyGame.addCity(easierDifficultyGame.addCiv(), easierDifficultyGame.getTile(Vector2.Zero), initialPopulation = 1)
 
         // when
@@ -96,9 +92,7 @@ class CityPopulationManagerTest {
     @Test
     fun `should decrease food requirements for AI on higher difficulties`() {
         // given
-        val harderDifficultyGame = TestGame()
-        harderDifficultyGame.gameInfo.difficulty = "Deity"
-        harderDifficultyGame.gameInfo.difficultyObject = harderDifficultyGame.ruleset.difficulties["Deity"]!!
+        val harderDifficultyGame = TestGame().apply { setDifficulty("Deity") }
         val harderCity = harderDifficultyGame.addCity(harderDifficultyGame.addCiv(), harderDifficultyGame.getTile(Vector2.Zero), initialPopulation = 1)
 
         // when

--- a/tests/src/com/unciv/testing/TestGame.kt
+++ b/tests/src/com/unciv/testing/TestGame.kt
@@ -57,15 +57,13 @@ class TestGame(vararg addGlobalUniques: String) {
         if (RulesetCache.isEmpty())
             RulesetCache.loadRulesets(noMods = true)
         ruleset = RulesetCache[BaseRuleset.Civ_V_GnK.fullName]!!.clone()
-        ruleset.globalUniques.uniques.run {
-            for (unique in addGlobalUniques)
-                add(unique)
-        }
+        ruleset.addGlobalUniques(*addGlobalUniques)
 
         gameInfo.ruleset = ruleset
         gameInfo.difficulty = "Prince"
-        gameInfo.difficultyObject = ruleset.difficulties["Prince"]!!
-        gameInfo.speed = ruleset.speeds[Speed.DEFAULTFORSIMULATION]!!
+        gameInfo.gameParameters.speed = Speed.DEFAULTFORSIMULATION
+        gameInfo.setGlobalTransients()
+
         gameInfo.currentPlayerCiv = Civilization()  // Will be uninitialized, do not build on for tests
 
         // Create a tilemap, needed for city centers
@@ -76,6 +74,16 @@ class TestGame(vararg addGlobalUniques: String) {
 
         for (baseUnit in ruleset.units.values)
             baseUnit.setRuleset(ruleset)
+    }
+
+    fun setSpeed(speed: String) {
+        gameInfo.gameParameters.speed = speed
+        gameInfo.setGlobalTransients()
+    }
+
+    fun setDifficulty(difficulty: String) {
+        gameInfo.difficulty = difficulty
+        gameInfo.setGlobalTransients()
     }
 
     /** Makes a new rectangular tileMap and sets it in gameInfo. Removes all existing tiles. All new tiles have terrain [baseTerrain] */


### PR DESCRIPTION
As per: https://github.com/yairm210/Unciv/pull/13458#issuecomment-2993766174

@yairm210 Questions:
* How best to test this fully? Would need a Mod with easily testable effects - which ones? Could we delegate the task to some friendly disc~rap~ord helpers?
* I'm not entirely sure whether separating a UniqueTarget specific for GlobalUniques (meaning we could have UniqueType's that can go _only_ on GlobalUniques) from UniqueTarget.Global (to keep that as conceptual) is worth it
* I'm not entirely sure I got the inheritance direction right, sometimes my brain said it should be the other way 'round, but in that direction there's no multiple inheritance... Help thinking?
* Speed and difficulty are treated differently in GameInfo - is that a relic or is there a valid reason? Why have the difficulty string as extra copy and not use the one from GameParameters as speed does?
* A marginal thing: I made GlobalUniques visible for fun, but would tend to **not** include it - but you might like it (actual text and icon choices open to discussion):

<details>

![image](https://github.com/user-attachments/assets/5576db41-cb4d-4512-b9ae-d2451926e2ec)

```patch
Subject: [PATCH] Civilopedia display for GlobalUniques
---
Index: core/src/com/unciv/ui/screens/civilopediascreen/CivilopediaScreen.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/core/src/com/unciv/ui/screens/civilopediascreen/CivilopediaScreen.kt b/core/src/com/unciv/ui/screens/civilopediascreen/CivilopediaScreen.kt
--- a/core/src/com/unciv/ui/screens/civilopediascreen/CivilopediaScreen.kt	(revision 5b5495397fed48db5acd23ed5383d342eb488cac)
+++ b/core/src/com/unciv/ui/screens/civilopediascreen/CivilopediaScreen.kt	(date 1750753804567)
@@ -100,8 +100,10 @@
         selectCategory(category)
     }
 
-    /** Select a specified category - unselects entry, rebuilds left side buttons.
-     * @param category Category key
+    /** Select a specified category - unselects entry (unless there's a default: either a previous
+     *  entry selection in this category, or the single entry if there's only one).
+     *  Rebuilds left side buttons.
+     *  @param category Category key
      */
     private fun selectCategory(category: CivilopediaCategories) {
         currentCategory = category
@@ -155,6 +157,7 @@
 
         val entry = currentEntryPerCategory[category]
         if (entry != null) selectEntry(entry)
+        else if (entries.size == 1) selectEntry(entries.first())
     }
 
     /** Select a specified entry within the current category. Unknown strings are ignored!
Index: core/src/com/unciv/ui/screens/civilopediascreen/CivilopediaCategories.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/core/src/com/unciv/ui/screens/civilopediascreen/CivilopediaCategories.kt b/core/src/com/unciv/ui/screens/civilopediascreen/CivilopediaCategories.kt
--- a/core/src/com/unciv/ui/screens/civilopediascreen/CivilopediaCategories.kt	(revision 5b5495397fed48db5acd23ed5383d342eb488cac)
+++ b/core/src/com/unciv/ui/screens/civilopediascreen/CivilopediaCategories.kt	(date 1750753088709)
@@ -1,8 +1,11 @@
 package com.unciv.ui.screens.civilopediascreen
 
+import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.scenes.scene2d.Actor
 import com.unciv.models.ruleset.Ruleset
+import com.unciv.ui.components.extensions.setSize
 import com.unciv.ui.components.input.KeyboardBinding
+import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.screens.basescreen.TutorialController
 import com.unciv.models.ruleset.Belief as BaseBelief
 import com.unciv.models.ruleset.unit.UnitType as BaseUnitType
@@ -14,7 +17,7 @@
  *
  * @param label Translatable caption for the Civilopedia button
  */
-enum class CivilopediaCategories (
+enum class CivilopediaCategories(
     val label: String,
     val getImage: ((name: String, size: Float) -> Actor?)?,
     val binding: KeyboardBinding,
@@ -117,11 +120,17 @@
         KeyboardBinding.PediaSpeeds,
         "OtherIcons/Timer",
         { ruleset, _ -> ruleset.speeds.values }
+    ),
+    Globals ( "Globals",
+        getImage = { _, size -> ImageGetter.getImage("OtherIcons/Star", Color.GOLD).apply { setSize(size) } },
+        KeyboardBinding.None,
+        "OtherIcons/Options",
+        { ruleset, _ -> listOf(ruleset.globalUniques) }
     );
 
     companion object {
         fun fromLink(name: String): CivilopediaCategories? =
-            values().firstOrNull { it.name == name }
-            ?: values().firstOrNull { it.label == name }
+            entries.firstOrNull { it.name == name }
+            ?: entries.firstOrNull { it.label == name }
     }
 }
Index: core/src/com/unciv/models/ruleset/GlobalUniques.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/core/src/com/unciv/models/ruleset/GlobalUniques.kt b/core/src/com/unciv/models/ruleset/GlobalUniques.kt
--- a/core/src/com/unciv/models/ruleset/GlobalUniques.kt	(revision 498c485a3500949b4a3887d4b94abc7e93aba178)
+++ b/core/src/com/unciv/models/ruleset/GlobalUniques.kt	(date 1750753088699)
@@ -1,15 +1,29 @@
 package com.unciv.models.ruleset
 
+import com.unciv.models.ruleset.unique.IHasUniques
 import com.unciv.models.ruleset.unique.Unique
 import com.unciv.models.ruleset.unique.UniqueTarget
 import com.unciv.models.ruleset.unique.UniqueType
+import com.unciv.ui.objectdescriptions.uniquesToCivilopediaTextLines
+import com.unciv.ui.screens.civilopediascreen.FormattedLine
 
 class GlobalUniques: RulesetObject() {
     override var name = "GlobalUniques"
 
     var unitUniques: ArrayList<String> = ArrayList()
-    override fun makeLink() = "" // No own category on Civilopedia screen
     override fun getUniqueTarget() = UniqueTarget.GlobalUniques
+    override fun makeLink() = "Globals/GlobalUniques"
+    override fun getCivilopediaTextLines(ruleset: Ruleset) = sequence {
+        if (uniques.isNotEmpty()) {
+            yield(FormattedLine("Effects for Civilizations", header = 3))
+            yieldAll(uniquesToCivilopediaTextLines())
+            yield(FormattedLine())
+        }
+        if (unitUniques.isNotEmpty()) {
+            yield(FormattedLine("Effects for Units", header = 3))
+            yieldAll(uniquesToCivilopediaTextLines(uniqueObjectsProvider(unitUniques)))
+        }
+    }.toList()
 
     companion object {
         fun getUniqueSourceDescription(unique: Unique): String {
Index: core/src/com/unciv/ui/objectdescriptions/DescriptionHelpers.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/core/src/com/unciv/ui/objectdescriptions/DescriptionHelpers.kt b/core/src/com/unciv/ui/objectdescriptions/DescriptionHelpers.kt
--- a/core/src/com/unciv/ui/objectdescriptions/DescriptionHelpers.kt	(revision 5b5495397fed48db5acd23ed5383d342eb488cac)
+++ b/core/src/com/unciv/ui/objectdescriptions/DescriptionHelpers.kt	(date 1750752423930)
@@ -29,16 +29,18 @@
 /**
  *  A Sequence of user-visible Uniques as [FormattedLine]s.
  *
+ *  @param uniques the Uniques to display, as Collection of Unique objects.
  *  @param leadingSeparator Tristate: If there are lines to display and this parameter is not `null`, a leading line is output, as separator or empty line.
  *  @param colorConsumesResources If set, ConsumesResources Uniques get a reddish color.
  *  @param exclude Predicate that can exclude Uniques by returning `true` (defaults to return `false`).
  */
-fun IHasUniques.uniquesToCivilopediaTextLines(
+fun uniquesToCivilopediaTextLines(
+    uniques: Iterable<Unique>,
     leadingSeparator: Boolean? = false,
     colorConsumesResources: Boolean = false,
     exclude: Unique.() -> Boolean = {false}
 ) = sequence {
-    val orderedUniques = uniqueObjects.asSequence()
+    val orderedUniques = uniques.asSequence()
         .filterNot { it.isHiddenToUsers() || it.exclude() }
 
     for ((index, unique) in orderedUniques.withIndex()) {
@@ -54,6 +56,19 @@
     }
 }
 
+/**
+ *  A Sequence of user-visible Uniques as [FormattedLine]s.
+ *
+ *  @param leadingSeparator Tristate: If there are lines to display and this parameter is not `null`, a leading line is output, as separator or empty line.
+ *  @param colorConsumesResources If set, ConsumesResources Uniques get a reddish color.
+ *  @param exclude Predicate that can exclude Uniques by returning `true` (defaults to return `false`).
+ */
+fun IHasUniques.uniquesToCivilopediaTextLines(
+    leadingSeparator: Boolean? = false,
+    colorConsumesResources: Boolean = false,
+    exclude: Unique.() -> Boolean = {false}
+) = uniquesToCivilopediaTextLines(uniqueObjects, leadingSeparator, colorConsumesResources, exclude)
+
 /**
  *  Appends user-visible Uniques as [FormattedLine]s to [lineList].
  *
```

</details>