### PR TITLE
Allow mods with no global uniques, no ruins or no difficulties file

### DIFF
--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -452,7 +452,7 @@ class Ruleset {
             if (ruinRewards.isEmpty())
                 ruinRewards.putAll(fallbackRuleset.ruinRewards)
 
-            if (globalUniques.uniques.isEmpty()) {
+            if (!globalUniquesFile.exists()) {
                 globalUniques = fallbackRuleset.globalUniques
             }
             // If we have no victories, add all the default victories

--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -449,7 +449,7 @@ class Ruleset {
             }
 
             // These should be permanent
-            if (ruinRewards.isEmpty())
+            if (!ruinRewardsFile.exists())
                 ruinRewards.putAll(fallbackRuleset.ruinRewards)
 
             if (!globalUniquesFile.exists()) {

--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -459,6 +459,7 @@ class Ruleset {
             if (victories.isEmpty()) victories.putAll(fallbackRuleset.victories)
 
             if (speeds.isEmpty()) speeds.putAll(fallbackRuleset.speeds)
+            if (difficulties.isEmpty()) difficulties.putAll(fallbackRuleset.difficulties)
 
             if (cityStateTypes.isEmpty())
                 for (cityStateType in fallbackRuleset.cityStateTypes.values)


### PR DESCRIPTION
Update ruleset defaulting (PR title is meant for changelog.md).

Code inspired by #13512, but not the wiki - those later.
- I made Ruin rewards actually optional - there can now be none if there are no ruins!
- Minimally tested with a modified 'Unciv minimal base ruleset' -> Ruins.json = `[]` works and validator runs my checks and is happy.
- Checker flags "Armored" in 'Unciv minimal base ruleset' -> correct!
- Implementation detail: I implemented "if there's no ruins, `UniqueType.RuinsUpgrade` shouldn't be used" in `UniqueValidator` since there's so many possible targets, and in there most details are available for the message. Made it extensible by making it a new function `addUniqueTypeSpecificErrors`, `when`-based, and deferring the "specific/invariant" decision until the `UniqueType` is known - all for easier extensibility, right now it's overkill and could be simplified.
- Or - should that go in the `UniqueType` itself?

Otherwise, simple enough.