### PR TITLE
Fix mod names with dashes in them

### DIFF
--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -85,6 +85,8 @@ class Ruleset {
      */
     var name = ""
 
+    fun cleanName(): String = name.replace("   ", " - ")
+
     /** The list of mods that made up this Ruleset, including the base ruleset. */
     val mods = LinkedHashSet<String>()
 

--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -85,8 +85,6 @@ class Ruleset {
      */
     var name = ""
 
-    fun cleanName(): String = name.replace("   ", " - ")
-
     /** The list of mods that made up this Ruleset, including the base ruleset. */
     val mods = LinkedHashSet<String>()
 

--- a/core/src/com/unciv/ui/screens/modmanager/ModManagementScreen.kt
+++ b/core/src/com/unciv/ui/screens/modmanager/ModManagementScreen.kt
@@ -74,6 +74,8 @@ class ModManagementScreen private constructor(
         const val maxAllowedPreviewImageSize = 200f
         /** Github queries use this limit */
         const val amountPerPage = 100
+
+        fun cleanModName(modName: String): String = modName.replace("   ", " - ")
     }
 
     // Since we're `RecreateOnResize`, preserve the portrait/landscape mode for our lifetime
@@ -466,8 +468,8 @@ class ModManagementScreen private constructor(
 
         rightSideButton.isVisible = true
         rightSideButton.enable()
-        val label = if (installedModInfo[repo.name]?.hasUpdate == true) "Update [${repo.name}]"
-            else "Download [${repo.name}]"
+        val label = if (installedModInfo[repo.name]?.hasUpdate == true) "Update [${cleanModName(repo.name)}]"
+            else "Download [${cleanModName(repo.name)}]"
         rightSideButton.setText(label.tr())
         rightSideButton.clearActivationActions(ActivationTypes.Tap)
         rightSideButton.onClick {
@@ -556,7 +558,7 @@ class ModManagementScreen private constructor(
         }
         onlineModInfo[name]?.run {
             hasUpdate = false
-            modButtons[this]?.setText(name)
+            modButtons[this]?.setText(cleanModName(name))
         }
         if (optionsManager.sortInstalled == SortType.Status)
             refreshInstalledModTable()
@@ -636,7 +638,7 @@ class ModManagementScreen private constructor(
 
         syncInstalledSelected(mod.name, button)
         refreshInstalledModActions(mod.ruleset!!)
-        val deleteText = "Delete [${mod.name}]"
+        val deleteText = "Delete [${cleanModName(mod.name)}]"
         rightSideButton.setText(deleteText.tr())
         // Don't let the player think he can delete Vanilla and G&K rulesets
         rightSideButton.isEnabled = mod.ruleset.folderLocation!=null
@@ -652,7 +654,7 @@ class ModManagementScreen private constructor(
             ) {
                 deleteMod(mod.ruleset)
                 modActionTable.clear()
-                rightSideButton.setText("[${mod.name}] was deleted.".tr())
+                rightSideButton.setText("[${cleanModName(mod.name)}] was deleted.".tr())
             }.open()
         }
     }

--- a/core/src/com/unciv/ui/screens/modmanager/ModUIData.kt
+++ b/core/src/com/unciv/ui/screens/modmanager/ModUIData.kt
@@ -5,6 +5,7 @@ import com.unciv.models.metadata.ModCategories
 import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.translations.tr
 import com.unciv.ui.components.fonts.Fonts
+import com.unciv.ui.screens.modmanager.ModManagementScreen
 
 /** Helper class holds combined mod info for ModManagementScreen, used for both installed and online lists.
  *
@@ -44,8 +45,8 @@ class ModUIData private constructor(
     fun author() = ruleset?.modOptions?.author ?: repo?.owner?.login ?: ""
     fun topics() = ruleset?.modOptions?.topics ?: repo?.topics ?: emptyList()
     fun buttonText() = when {
-        ruleset != null -> ruleset.name
-        repo != null -> repo.name + (if (hasUpdate) " - {Updated}" else "")
+        ruleset != null -> ModManagementScreen.cleanModName(ruleset.name)
+        repo != null -> ModManagementScreen.cleanModName(repo.name) + (if (hasUpdate) " - {Updated}" else "")
         else -> ""
     }
 

--- a/core/src/com/unciv/ui/screens/newgamescreen/ModCheckboxTable.kt
+++ b/core/src/com/unciv/ui/screens/newgamescreen/ModCheckboxTable.kt
@@ -12,6 +12,7 @@ import com.unciv.ui.components.extensions.toCheckBox
 import com.unciv.ui.components.input.onChange
 import com.unciv.ui.components.widgets.ExpanderTab
 import com.unciv.ui.components.widgets.UncivTextField
+import com.unciv.ui.screens.modmanager.ModManagementScreen
 import com.unciv.ui.popups.ToastPopup
 import com.unciv.ui.screens.basescreen.BaseScreen
 import com.unciv.utils.Concurrency
@@ -57,6 +58,7 @@ class ModCheckboxTable(
 
         for (mod in modRulesets.sortedBy { it.name }) {
             val checkBox = mod.name.toCheckBox(mod.name in mods)
+            checkBox.setText(ModManagementScreen.cleanModName(mod.name))
             checkBox.onChange { 
                 // Checks are run in parallel thread to avoid ANRs
                 Concurrency.run { checkBoxChanged(checkBox, mod) }


### PR DESCRIPTION
There are some mods that aim to have a ` - ` in the name, matching some of the convention of the `Civ V - Gods & Kings` base ruleset. Currently, when a mod with an intended `-` in the name is presented, all `-` are replaced with ` `, somewhat breaking the title. This Pull Request updates it so that `---` is not replaced with all spaces, but ` - `. Fixing the names of the mod so that it displays correctly.

## Before

You'll see `Project Allciv   American States` has a bunch of spaces:
https://github.com/BrierleyBlood/Project-Allciv---American-States

![Screenshot from 2025-06-26 15-48-39](https://github.com/user-attachments/assets/6c06ed8b-18a5-4701-abe3-ec45f8b0ebed)


## After

With this Pull Request, you'll see `Project Allciv - American States` which presents the dash correctly, making the mod name easier to read.

![Screenshot from 2025-06-26 15-44-34](https://github.com/user-attachments/assets/4a155de7-cfe1-47d7-98c3-7c03952b1dc6)
