### PR TITLE
Fix ModCheckTab to match the intention of the last update

### DIFF
--- a/core/src/com/unciv/ui/popups/options/ModCheckTab.kt
+++ b/core/src/com/unciv/ui/popups/options/ModCheckTab.kt
@@ -9,6 +9,7 @@ import com.unciv.Constants
 import com.unciv.UncivGame
 import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.ruleset.RulesetCache
+import com.unciv.models.ruleset.unique.UniqueParameterType
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.ruleset.validation.ModCompatibility
 import com.unciv.models.ruleset.validation.RulesetErrorList
@@ -151,15 +152,17 @@ class ModCheckTab(
                         .thenBy { it.name }
                 )
             for (mod in modsToCheck) {
-                val baseForThisMod = if (base != MOD_CHECK_DYNAMIC_BASE) base else getBaseForMod(mod)
-                if (baseForThisMod == null) {
+                val dynamicBase = base == MOD_CHECK_DYNAMIC_BASE
+                val baseForThisMod = if (dynamicBase) getBaseForMod(mod) else base
+                val shouldCheck = if (baseForThisMod == null) false else shouldCheckMod(mod, baseForThisMod)
+                if (baseForThisMod == null || dynamicBase && !shouldCheck) {
                     // Don't check, but since this is the default view, show greyed out, so people don't wonder where their mods are
                     launchOnGLThread {
                         addDisabledPlaceholder(mod)
                     }
                     continue
                 }
-                if (!shouldCheckMod(mod, baseForThisMod)) continue
+                if (!shouldCheck) continue
                 if (!isActive) break
 
                 val modLinks =
@@ -206,6 +209,11 @@ class ModCheckTab(
     private fun shouldCheckMod(mod: Ruleset, base: String): Boolean {
         if (mod.modOptions.isBaseRuleset) return base == MOD_CHECK_WITHOUT_BASE
         if (ModCompatibility.isAudioVisualMod(mod)) return true
+        // Very borderline case: DO check mods with invalid requirements. This duplicates a tiny part of RulesetValidator,
+        // but ends up simpler than calling the full validator and filtering for a specific message.
+        if (mod.modOptions.getMatchingUniques(UniqueType.ModRequires).any {
+                UniqueParameterType.ModName.getErrorSeverity(it.params[0], mod) != null
+            }) return true
         val baseRuleset = RulesetCache[base] ?: emptyRuleset  // MOD_CHECK_WITHOUT_BASE compares compatibility against an empty Ruleset
         return ModCompatibility.meetsBaseRequirements(mod, baseRuleset)  // yes this returns true for mods ignoring declarative compatibility
     }


### PR DESCRIPTION
Thanks #13523 - this fixes the joke mod in that issue not being shown at all by ModChecker.
- First fix: This mod tricked itself around the _intention_ that every mod is visible in the default run, but if uncheckable greyed out. This is the part just after `for (mod in modsToCheck)`.
- Second fix: That mod would never actually show its Validation results - exception added (in the shouldCheckMod function - if the Mod's declarative mod compatibility is _faulty_, then _do_ check instead of deciding its requirements aren't met)

Screenshot in the linked PR