### PR TITLE
Remove Mod Checks from running during startup

### DIFF
--- a/core/src/com/unciv/models/ruleset/RulesetCache.kt
+++ b/core/src/com/unciv/models/ruleset/RulesetCache.kt
@@ -7,13 +7,10 @@ import com.unciv.logic.UncivShowableException
 import com.unciv.logic.map.MapParameters
 import com.unciv.models.metadata.BaseRuleset
 import com.unciv.models.metadata.GameParameters
-import com.unciv.models.ruleset.validation.RulesetError
 import com.unciv.models.ruleset.validation.RulesetErrorList
 import com.unciv.models.ruleset.validation.RulesetErrorSeverity
-import com.unciv.models.ruleset.validation.UniqueValidator
 import com.unciv.models.ruleset.validation.getRelativeTextDistance
 import com.unciv.utils.Log
-import com.unciv.utils.Tag
 
 /** Loading mods is expensive, so let's only do it once and
  * save all of the loaded rulesets somewhere for later use

--- a/core/src/com/unciv/models/ruleset/RulesetCache.kt
+++ b/core/src/com/unciv/models/ruleset/RulesetCache.kt
@@ -13,7 +13,7 @@ import com.unciv.models.ruleset.validation.RulesetErrorSeverity
 import com.unciv.models.ruleset.validation.UniqueValidator
 import com.unciv.models.ruleset.validation.getRelativeTextDistance
 import com.unciv.utils.Log
-import com.unciv.utils.debug
+import com.unciv.utils.Tag
 
 /** Loading mods is expensive, so let's only do it once and
  * save all of the loaded rulesets somewhere for later use
@@ -40,6 +40,7 @@ object RulesetCache : HashMap<String, Ruleset>() {
         }
         this.putAll(newRulesets)
 
+        val detailedConsoleModCheck = consoleMode && Log.shouldLog(Tag("ConsoleModCheck"))
         val errorLines = ArrayList<String>()
         if (!noMods) {
             val modsHandles = if (consoleMode) FileHandle("mods").list()
@@ -54,8 +55,8 @@ object RulesetCache : HashMap<String, Ruleset>() {
                     modRuleset.load(modFolder.child("jsons"))
                     modRuleset.folderLocation = modFolder
                     newRulesets[modRuleset.name] = modRuleset
-                    debug("Mod loaded successfully: %s", modRuleset.name)
-                    if (Log.shouldLog()) {
+                    Log.debug("Mod loaded successfully: %s", modRuleset.name)
+                    if (detailedConsoleModCheck) {
                         val modLinksErrors = modRuleset.getErrorList()
                         // For extension mods which use references to base ruleset objects, the parameter type
                         // errors are irrelevant - the checker ran without a base ruleset
@@ -67,7 +68,7 @@ object RulesetCache : HashMap<String, Ruleset>() {
                                     !it.text.contains(UniqueValidator.whichDoesNotFitParameterType) }
                             }
                         if (modLinksErrors.any(logFilter)) {
-                            debug(
+                            Log.debug(
                                 "checkModLinks errors: %s",
                                 modLinksErrors.getErrorText(logFilter)
                             )
@@ -79,7 +80,7 @@ object RulesetCache : HashMap<String, Ruleset>() {
                     errorLines += "  ${ex.cause?.localizedMessage}"
                 }
             }
-            if (Log.shouldLog()) for (line in errorLines) debug(line)
+            if (Log.shouldLog()) for (line in errorLines) Log.debug(line)
         }
 
         // We save the 'old' cache values until we're ready to replace everything, so that the cache isn't empty while we try to load ruleset files

--- a/core/src/com/unciv/models/ruleset/RulesetCache.kt
+++ b/core/src/com/unciv/models/ruleset/RulesetCache.kt
@@ -40,7 +40,6 @@ object RulesetCache : HashMap<String, Ruleset>() {
         }
         this.putAll(newRulesets)
 
-        val detailedConsoleModCheck = consoleMode && Log.shouldLog(Tag("ConsoleModCheck"))
         val errorLines = ArrayList<String>()
         if (!noMods) {
             val modsHandles = if (consoleMode) FileHandle("mods").list()
@@ -56,24 +55,6 @@ object RulesetCache : HashMap<String, Ruleset>() {
                     modRuleset.folderLocation = modFolder
                     newRulesets[modRuleset.name] = modRuleset
                     Log.debug("Mod loaded successfully: %s", modRuleset.name)
-                    if (detailedConsoleModCheck) {
-                        val modLinksErrors = modRuleset.getErrorList()
-                        // For extension mods which use references to base ruleset objects, the parameter type
-                        // errors are irrelevant - the checker ran without a base ruleset
-                        val logFilter: (RulesetError) -> Boolean =
-                            if (modRuleset.modOptions.isBaseRuleset) {
-                                { it.errorSeverityToReport > RulesetErrorSeverity.WarningOptionsOnly }
-                            } else {
-                                { it.errorSeverityToReport > RulesetErrorSeverity.WarningOptionsOnly &&
-                                    !it.text.contains(UniqueValidator.whichDoesNotFitParameterType) }
-                            }
-                        if (modLinksErrors.any(logFilter)) {
-                            Log.debug(
-                                "checkModLinks errors: %s",
-                                modLinksErrors.getErrorText(logFilter)
-                            )
-                        }
-                    }
                 } catch (ex: Exception) {
                     errorLines += "Exception loading mod '${modFolder.name()}':"
                     errorLines += "  ${ex.localizedMessage}"


### PR DESCRIPTION
This time around I observed it unclouded: Launch Unciv, go to Options-Check Mods, wait result: RulesetValidator runs ***three*** times per mod. If you're debugging, that is.

This gates that output to:
 a) only run when loadRulesets is actually running from the initial launcher
 b) only run when a new Tag "ConsoleModCheck" is allowed to log. It is not in the default exclusions, so you do get your one initial console run. Add `-DnoLog=ConsoleModCheck` to suppress it entirely.

### Questions:
- I'd vote to actually add the new Tag to `Log.disableLogsFrom` so you have to opt-in.
- Where is the "mod-ci" option documented? One could add a hint.