### PR TITLE
Fix mod check not offering to auto-update Uniques for extension mods

### DIFF
--- a/core/src/com/unciv/models/ruleset/RulesetCache.kt
+++ b/core/src/com/unciv/models/ruleset/RulesetCache.kt
@@ -174,15 +174,15 @@ object RulesetCache : HashMap<String, Ruleset>() {
         mods: LinkedHashSet<String>,
         baseRuleset: String? = null,
         tryFixUnknownUniques: Boolean = false
-    ): RulesetErrorList {
+    ): Pair<Ruleset?, RulesetErrorList> {
         return try {
             val newRuleset = getComplexRuleset(mods, baseRuleset)
             newRuleset.modOptions.isBaseRuleset = true // This is so the checkModLinks finds all connections
-            newRuleset.getErrorList(tryFixUnknownUniques)
+            newRuleset to newRuleset.getErrorList(tryFixUnknownUniques)
         } catch (ex: UncivShowableException) {
             // This happens if a building is dependent on a tech not in the base ruleset
             //  because newRuleset.updateBuildingCosts() in getComplexRuleset() throws an error
-            RulesetErrorList.of(ex.message, RulesetErrorSeverity.Error)
+            null to RulesetErrorList.of(ex.message, RulesetErrorSeverity.Error)
         }
     }
 }

--- a/core/src/com/unciv/ui/screens/newgamescreen/ModCheckboxTable.kt
+++ b/core/src/com/unciv/ui/screens/newgamescreen/ModCheckboxTable.kt
@@ -141,7 +141,7 @@ class ModCheckboxTable(
     /** Runs in parallel thread */ 
     private fun complexModCheckReturnsErrors(): Boolean {
         // Check over complete combination of selected mods
-        val complexModLinkCheck = RulesetCache.checkCombinedModLinks(mods, baseRulesetName)
+        val (_, complexModLinkCheck) = RulesetCache.checkCombinedModLinks(mods, baseRulesetName)
         if (!complexModLinkCheck.isWarnUser()){
             savedModcheckResult = null
             return false


### PR DESCRIPTION
Fixes #13494
- Meaning Unique Auto-Update will show, previously it was mostly blocked because:
        - The candidate list builder instantiates the replacement as Unique and validates it - against the mod's Ruleset alone
        - Thus this PR now passes down the combined Ruleset that was actually checked
        - To avoid building that Ruleset twice the signature of `RulesetCache.checkCombinedModLinks` had to change to return two values
        - The duplicate build of the combined Ruleset already happened before - for the UniqueBuilder. Simplified.
- While testing I noticed a few layout/UX quirks, and - sorry - was too lazy to PR them separately:
        - With very few mods or a selective filter, a single closed Expander would be shown centered between the base select and the bottom: Fixed 
        - Uniform width done more consistently
        - Search drops all those grey "Can't check" mod placeholders and clearing the search box doesn't bring them bak. I knew that, but had no clean idea: Forcing some common interface for the expanders and the grey boxes so a `title` property works for both? This time I remembered `Actor.name`: using that it becomes simple to have the placeholders be part of the search scope.

<details><summary>screenies</summary>

Autoupdate shows:
![Image](https://github.com/user-attachments/assets/d2878914-01c5-45aa-86b4-4ed9db24da7d)
(that's not the current mod, it's the zip from the linked issue)

Search scope includes grey placeholders:
![Image](https://github.com/user-attachments/assets/88a3bdaf-3f72-4f2c-b81d-3374318308a8)

Single boxes no longer vertically centered:
![Image](https://github.com/user-attachments/assets/b179127a-7ca7-4781-ab8b-6cccfc23e7b3)

</details>

~There's still some marginal thing wrong - one of the tileset checks seems to do false positives - but that one I haven't investigated yet.~ -> created new issue