### PR TITLE
Fix console `tile find` - quoted input properly passed to `tileFilter`

### DIFF
--- a/core/src/com/unciv/ui/screens/devconsole/CliInput.kt
+++ b/core/src/com/unciv/ui/screens/devconsole/CliInput.kt
@@ -137,7 +137,7 @@ internal class CliInput(
     /** Parses `this` parameter as a Float number.
      *  @throws ConsoleErrorException if the string is not a valid representation of a number. */
     fun toFloat(): Float = content.toFloatOrNull() ?: throw ConsoleErrorException("'$this' is not a valid number.")
-    
+
     /** Parses `this` parameter as a Boolean.
      *  @throws ConsoleErrorException if the string is not 'true' or 'false'. */
     fun toBoolean(): Boolean = content.toBooleanStrictOrNull() ?: throw ConsoleErrorException("'$this' is not a valid boolean value.")
@@ -181,6 +181,15 @@ internal class CliInput(
     /** Finds the first entry whose [name][INamed.name] [equals] `this` parameter.
      *  @throws ConsoleErrorException if not found. */
     inline fun <reified T: INamed> find(options: Sequence<T>): T = find(options.asIterable())
+
+    /** Representation to include in strings that will pass through tr(), e.g. for notifications repeating a filter:
+     *  - Dashed input is returned as [content] wrapped in square brackets
+     *  - Quoted input is returned as [originalUnquoted] wrapped in square brackets plus quotes **outside** those.
+     */
+    fun toStringAsPlaceholder() = when(method) {
+        Method.Dashed -> "[$content]"
+        Method.Quoted -> "\"[${originalUnquoted()}]\""
+    }
 
     //endregion
 

--- a/core/src/com/unciv/ui/screens/devconsole/ConsoleTileCommands.kt
+++ b/core/src/com/unciv/ui/screens/devconsole/ConsoleTileCommands.kt
@@ -120,11 +120,11 @@ internal class ConsoleTileCommands: ConsoleCommandNode {
         "find" to ConsoleAction("tile find <tileFilter>") { console, params ->
             val filter = params[0]
             val locations = console.gameInfo.tileMap.tileList
-                .filter { it.matchesFilter(filter.toString()) }
+                .filter { it.matchesFilter(filter.originalUnquoted()) }  // filters are case sensitive
                 .map { it.position }
             if (locations.isEmpty()) DevConsoleResponse.hint("None found")
             else {
-                val notification = Notification("tile find [$filter]", arrayOf(NotificationIcon.Spy),
+                val notification = Notification("tile find ${filter.toStringAsPlaceholder()}: ${locations.size} matches", arrayOf(NotificationIcon.Spy),
                     LocationAction(locations).asIterable(), NotificationCategory.General)
                 console.screen.notificationsScroll.oneTimeNotification = notification
                 notification.execute(console.screen)


### PR DESCRIPTION
Helped me investigate #13540 
- `tile find "Snow"` now works, `tile find Snow` too, `tile find snow` does not - see below.
- `tile find "Ancient ruins" now works
- Notification translates quoted ruleset object names properly
- Notification tells number of hits

- NOT: We might expect `tile find ancient-ruins` to work as well, but it's a matchesFilter not one of the CliInput find's - getting that to be case-insensitive on demand would be too brutal.