### PR TITLE
Add ability to remove policies with ModOptions

### DIFF
--- a/core/src/com/unciv/models/ruleset/ModOptions.kt
+++ b/core/src/com/unciv/models/ruleset/ModOptions.kt
@@ -14,6 +14,7 @@ class ModOptions : IHasUniques {
     var unitsToRemove = HashSet<String>()
     var nationsToRemove = HashSet<String>()
     var policyBranchesToRemove = HashSet<String>()
+    var policiesToRemove = HashSet<String>()
     val constants = ModConstants()
     var unitset: String? = null
     var tileset: String? = null

--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -212,7 +212,7 @@ class Ruleset {
         policyBranches.putAll(ruleset.policyBranches)
         policies.putAll(ruleset.policies)
 
-        // Remove policies from both the policies list
+        // Remove the policies
         ruleset.modOptions.policiesToRemove
             .flatMap { policyToRemove ->
                 policies.filter { it.value.matchesFilter(policyToRemove) }.keys
@@ -220,7 +220,7 @@ class Ruleset {
                 policies.remove(it)
             }
 
-        // Remove the associated policies if they exist in the branches too
+        // Remove the policies if they exist in the policy branches too
         for (policyToRemove in ruleset.modOptions.policiesToRemove) {
             for (branch in policyBranches.values) {
                 branch.policies.removeAll { it.matchesFilter(policyToRemove) }

--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -211,12 +211,22 @@ class Ruleset {
             }
         policyBranches.putAll(ruleset.policyBranches)
         policies.putAll(ruleset.policies)
+
+        // Remove policies from both the policies list
         ruleset.modOptions.policiesToRemove
             .flatMap { policyToRemove ->
                 policies.filter { it.value.matchesFilter(policyToRemove) }.keys
             }.toSet().forEach {
                 policies.remove(it)
             }
+
+        // Remove the associated policies if they exist in the branches too
+        for (policyToRemove in ruleset.modOptions.policiesToRemove) {
+            for (branch in policyBranches.values) {
+                branch.policies.removeAll { it.matchesFilter(policyToRemove) }
+            }
+        }
+
         quests.putAll(ruleset.quests)
         religions.addAll(ruleset.religions)
         ruinRewards.putAll(ruleset.ruinRewards)

--- a/core/src/com/unciv/models/ruleset/Ruleset.kt
+++ b/core/src/com/unciv/models/ruleset/Ruleset.kt
@@ -211,6 +211,12 @@ class Ruleset {
             }
         policyBranches.putAll(ruleset.policyBranches)
         policies.putAll(ruleset.policies)
+        ruleset.modOptions.policiesToRemove
+            .flatMap { policyToRemove ->
+                policies.filter { it.value.matchesFilter(policyToRemove) }.keys
+            }.toSet().forEach {
+                policies.remove(it)
+            }
         quests.putAll(ruleset.quests)
         religions.addAll(ruleset.religions)
         ruinRewards.putAll(ruleset.ruinRewards)

--- a/docs/Modders/Mod-file-structure/5-Miscellaneous-JSON-files.md
+++ b/docs/Modders/Mod-file-structure/5-Miscellaneous-JSON-files.md
@@ -174,6 +174,7 @@ The file can have the following attributes, not including the values Unciv sets 
 | unitsToRemove     | List    | empty   | List of [Units](4-Unit-related-JSON-files.md#unitsjson) or [unitFilter](../../Unique-parameters#baseunitfilter) to remove (isBaseRuleset=false only)                                |
 | nationsToRemove   | List    | empty   | List of [Nations](2-Civilization-related-JSON-files.md#nationsjson) or [nationFilter](../../Unique-parameters#nationfilter) to remove (isBaseRuleset=false only)                    |
 | policyBranchesToRemove | List | empty | List of [Policy Branches](2-Civilization-related-JSON-files.md#policyjson) to remove (isBaseRuleset=false only)                             |
+| policiesToRemove  | List    | empty   | List of [Policies](2-Civilization-related-JSON-files.md#policiesjson) to remove (isBaseRuleset=false only) |
 | constants         | Object  | empty   | See [ModConstants](#modconstants)                                                                                                                                                      |
 | tileset           | String  | empty   | Only applicable for base rulesets                                                                                                                                                      |
 | unitset           | String  | empty   | Only applicable for base rulesets                                                                                                                                                      |


### PR DESCRIPTION
This allows policies to be removed by defining them in `ModOptions.json`. In BNW, there are a few policies that were removed from the game and replaced with certain [Ideologies](https://civilization.fandom.com/wiki/Ideology_(Civ5)) instead, like [Fascism](https://civilization.fandom.com/wiki/Fascism_(Civ5)). 


You can see this in action over at https://github.com/RobLoach/Civ-V-Brave-New-World/pull/98 . Before, there was an "Unavailable" policy branch, but with this change, the policy branch no longer needs to be there. Here is what the ModOptions.json looks like...

```json
{
	"isBaseRuleset": false,
	"policiesToRemove": [
		"Free Religion",
		"Educated Elite",
		"Trade Unions",
		"Populism",
		"Fascism",
		"Planned Economy",
		"Socialism",
		"Communism",
		"Constitution",
		"Democracy",
		"Free Speech"
	]
}
```
