### PR TITLE
Improve compatibility with older Android versions

### DIFF
--- a/core/src/com/unciv/logic/civilization/managers/ThreatManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/ThreatManager.kt
@@ -45,7 +45,7 @@ class ThreatManager(val civInfo: Civilization) {
                     else enemyTile.second.coerceAtMost(maxDist)
                 } else {
                     // This tile is no longer valid
-                    tilesWithEnemies.removeFirst()
+                    tilesWithEnemies.removeAt(0)
                 }
             }
 
@@ -184,4 +184,3 @@ class ThreatManager(val civInfo: Civilization) {
         distanceToClosestEnemyTiles.clear()
     }
 }
-

--- a/core/src/com/unciv/logic/civilization/managers/TurnManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/TurnManager.kt
@@ -242,7 +242,7 @@ class TurnManager(val civInfo: Civilization) {
         notificationsThisTurn.notifications.addAll(civInfo.notifications)
 
         while (notificationsLog.size >= UncivGame.Current.settings.notificationsLogMaxTurns) {
-            notificationsLog.removeFirst()
+            notificationsLog.removeAt(0)
         }
 
         if (notificationsThisTurn.notifications.isNotEmpty())

--- a/core/src/com/unciv/logic/map/mapgenerator/MapGenerator.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/MapGenerator.kt
@@ -317,13 +317,13 @@ class MapGenerator(val ruleset: Ruleset, private val coroutineScope: CoroutineSc
             val maxLakeSize = ruleset.modOptions.constants.maxLakeSize
 
             while (waterTiles.isNotEmpty()) {
-                val initialWaterTile = waterTiles.removeFirst()
+                val initialWaterTile = waterTiles.removeAt(0)
                 tilesInArea += initialWaterTile
                 tilesToCheck += initialWaterTile
 
                 // Floodfill to cluster water tiles
                 while (tilesToCheck.isNotEmpty()) {
-                    val tileWeAreChecking = tilesToCheck.removeFirst()
+                    val tileWeAreChecking = tilesToCheck.removeAt(0)
                     for (vector in tileWeAreChecking.neighbors){
                         if (tilesInArea.contains(vector)) continue
                         if (!waterTiles.contains(vector)) continue

--- a/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
@@ -1039,7 +1039,7 @@ class MapUnit : IsPartOfGameInfoSerialization {
             // When in the unit's turn— I.E. For a player unit— The last two entries will be from .endTurn() followed by from .startTurn(), so the segment from .movementMemories will have zero length. Instead, what gets seen will be the segment from the end of .movementMemories to the unit's current position.
             // When not in the unit's turn— I.E. For a foreign unit— The segment from the end of .movementMemories to the unit's current position will have zero length, while the last two entries here will be from .startTurn() followed by .endTurn(), so the segment here will be what gets shown.
             // The exception is when a unit changes position when not in its turn, such as by melee withdrawal or foreign territory expulsion. Then the segment here and the segment from the end of here to the current position can both be shown.
-            movementMemories.removeFirst()
+            movementMemories.removeAt(0)
         }
     }
     


### PR DESCRIPTION
Closes #13558

It's still puzzling why this has not bombed big time since targetSdk was increased in December. Given we don't understand all cause/effect fully, I would accept if you decided not to include this. But parking the diff that solved a crash-on-launch for _one_ little box here is good.

I intended to test the effect with a variety of AVD's, but can't get the emulator to run at all anymore. It seems to dislike my mesa drivers - no frame, segfault and a Studio message with default AVD settings. Changing the AVD to software rendering shows a frame and segfaults much later, but the logged messages seem entirely unrelated. Where are the old versions when you need them...