### PR TITLE
Better Validation of Nation colors

### DIFF
--- a/core/src/com/unciv/models/ruleset/nation/Nation.kt
+++ b/core/src/com/unciv/models/ruleset/nation/Nation.kt
@@ -97,10 +97,12 @@ class Nation : RulesetObject() {
     var ignoreHillMovementCost = false
 
     fun setTransients() {
-        outerColorObject = colorFromRGB(outerColor)
+        fun safeColorFromRGB(rgb: List<Int>) = if (rgb.size >= 3) colorFromRGB(rgb) else Color.PURPLE
+
+        outerColorObject = safeColorFromRGB(outerColor)
 
         innerColorObject = if (innerColor == null) ImageGetter.CHARCOAL
-                           else colorFromRGB(innerColor!!)
+                           else safeColorFromRGB(innerColor!!)
 
         forestsAndJunglesAreRoads = uniqueMap.hasUnique(UniqueType.ForestsAndJunglesAreRoads)
         ignoreHillMovementCost = uniqueMap.hasUnique(UniqueType.IgnoreHillMovementCost)

--- a/core/src/com/unciv/models/ruleset/validation/BaseRulesetValidator.kt
+++ b/core/src/com/unciv/models/ruleset/validation/BaseRulesetValidator.kt
@@ -153,6 +153,7 @@ internal class BaseRulesetValidator(
     }
 
     override fun checkNation(nation: Nation, lines: RulesetErrorList) {
+        super.checkNation(nation, lines)
         if (nation.preferredVictoryType != Constants.neutralVictoryType && nation.preferredVictoryType !in ruleset.victories)
             lines.add("${nation.name}'s preferredVictoryType is ${nation.preferredVictoryType} which does not exist!", sourceObject = nation)
         if (nation.cityStateType != null && nation.cityStateType !in ruleset.cityStateTypes)

--- a/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
+++ b/core/src/com/unciv/models/ruleset/validation/RulesetValidator.kt
@@ -328,7 +328,21 @@ open class RulesetValidator protected constructor(
             lines.add("${nation.name} can settle cities, but has no city names!", sourceObject = nation)
         }
 
-        checkContrasts(nation.getInnerColor(), nation.getOuterColor(), nation, lines)
+        fun isColorFaulty(rgb: List<Int>?) = when {
+            rgb == null -> false
+            rgb.size != 3 -> true
+            rgb.any { it !in 0..255 } -> true
+            else -> false
+        }
+        val badInner = isColorFaulty(nation.innerColor)
+        val badOuter = isColorFaulty(nation.outerColor)
+        if (badInner)
+            lines.add("${nation.name}'s innerColor is not an array of three integers in the 0..255 range", sourceObject = nation)
+        if (badOuter)
+            lines.add("${nation.name}'s outerColor is not an array of three integers in the 0..255 range", sourceObject = nation)
+
+        if (!badInner && !badOuter)
+            checkContrasts(nation.getInnerColor(), nation.getOuterColor(), nation, lines)
     }
 
     protected open fun addPersonalityErrors(lines: RulesetErrorList) {


### PR DESCRIPTION
Fixes #13563

Of course, e.g. an `"outerColor": ["R", "G", "B"],` will still throw the `load`, but at least the exception in that case is more helpful.