### PR TITLE
New format for RNG Seed text field

### DIFF
--- a/core/src/com/unciv/ui/components/formatting/RNGSeedFormat.kt
+++ b/core/src/com/unciv/ui/components/formatting/RNGSeedFormat.kt
@@ -1,0 +1,150 @@
+@file:Suppress("ConstPropertyName")
+
+package com.unciv.ui.components.formatting
+
+import com.badlogic.gdx.utils.Base64Coder
+import com.unciv.UncivGame
+import com.unciv.models.translations.tr
+import java.nio.ByteBuffer
+import org.jetbrains.annotations.VisibleForTesting
+
+
+/**
+ *  RNG seeds can be formatted for display in a "mnemonic" form or parsed in a few different ways.
+ *
+ *  ### Parse formats:
+ *  - Leading and trailing blanks are ignored
+ *  - For historical reasons, "" is parsed as 0L
+ *  - As produced by plain Long.toString()
+ *  - As produced by Number.tr() - probably containing thousands separators
+ *  - As base-64 grouped into groups of 3 characters by dashes, e.g.: "eKa-1xN-Pi8-QA", padding with a "=" allowed but not required
+ *  - Shattered Pixel's even more mnemonic "XYZ-PQR-CDF" format - base21 covering ~40bits
+ *  - Parsing arbitrary phrases returns String.hashCode() reimplemented as Long
+ *
+ *  ### Formatting output:
+ *  - Number.tr() for compatibility purposes: Once the code supporting parsing the other formats is established, this can change
+ *  - TODO: Don't forget to update this comment when doing so
+ *
+ *  ### Notes
+ *  - Generation of random seeds is unaffected, therefore this **must** cover the entire Long range
+ *
+ *  ### API
+ *  @property parse Call site syntax: `RNGSeedFormat.parse(text)` - the parser supporting all formats named above
+ *  @property format Call site syntax: `RNGSeedFormat.format(text)` - the formatter deciding which of the supported formats to produce
+ */
+object RNGSeedFormat {
+
+    fun format(value: Long) = value.tr()
+    //TODO Replace with: fun format(value: Long) = value.prettyFormat()
+    // when the parser accepting all is well-established
+
+    fun parse(text: String) = text.trim(' ').run {
+        when {
+            isEmpty() -> 0L
+            isBase21decorated() -> parseBase21()
+            isBase64decorated() -> parseBase64()
+            isNumber() -> UncivGame.Current.settings.getCurrentNumberFormat().parse(this@run).toLong()
+            else -> hashCode64()
+        }
+    }
+
+    private const val thousandsSeparators = ",.\u00A0\u202F"
+    private const val minusSymbols = "-\u2212"
+    private const val base21Symbols = "BCDFGHJKLMNPQRSTVWXYZ"
+    private const val maxNumberFormatLength = 26
+    private const val minBase64FormatLength = 14 // Long.MIN_VALUE in Base64/decorated is "gAA-AAA-AAA-AA"
+    private const val maxBase64FormatLength = 15 // allow one padding '='
+    private const val base21FormatLength = 11
+
+    @VisibleForTesting
+    const val maxBase21Value = 794280046580L //21.0.pow(9.0).toLong() - 1L
+
+    /////////////////// Checking
+
+    private fun isValidNumberChar(char: Char, index: Int) =
+        char.isDigit() || char in thousandsSeparators || char in minusSymbols && index == 0
+    private fun isValidBase64Char(char: Char, index: Int) =
+        if (index == minBase64FormatLength) char == '='
+        else if (index % 4 == 3) char == '-'
+        else char.isLetterOrDigit() || char == '+' || char == '/'
+    private fun isValidBase21Char(char: Char, index: Int) =
+        if (index % 4 == 3) char == '-'
+        else char in base21Symbols
+
+    private fun String.isNumber() = length in 1..maxNumberFormatLength &&
+        withIndex().all { (index, char) -> isValidNumberChar(char, index) }
+    private fun String.isBase21decorated() = length == base21FormatLength &&
+        withIndex().all { (index, char) -> isValidBase21Char(char, index) }
+    private fun String.isBase64decorated() = length in minBase64FormatLength..maxBase64FormatLength &&
+        withIndex().all { (index, char) -> isValidBase64Char(char, index) }
+
+    /////////////////// Formatting
+
+    private fun Long.toBase64String(): String {
+        val buffer = ByteBuffer.allocate(Long.SIZE_BYTES)
+        buffer.putLong(this)
+        return String(Base64Coder.encode(buffer.array()))
+    }
+
+    private fun String.decorate() =
+        trimEnd('=').withIndex()
+            .groupBy({ it.index / 3 }) { it.value } // Gives Map<Int, List<Char>>
+            .map { it.value.joinToString("") } // Join chars per group
+            .joinToString("-")
+
+    private fun Long.formatBase64() = toBase64String().decorate()
+
+    private fun Long.formatBase21() = buildString(base21FormatLength) {
+        var residue = this@formatBase21
+        for (i in 0 until base21FormatLength) {
+            if (i % 4 == 3) {
+                insert(0, '-')
+                continue
+            }
+            val nextBits = (residue % 21L).toInt()
+            residue /= 21
+            insert(0, base21Symbols[nextBits])
+        }
+    }
+
+    private fun Long.prettyFormat() =
+        if (this in 0L..maxBase21Value) formatBase21() else formatBase64()
+
+
+    /////////////////// Parsing
+
+    private fun String.undecorateBase64() =
+        filterNot { it == '-' } // Uses `String.filterNot(..): String` - not a fallback to `Iterable<Char>`
+            .run { padEnd(((length + 3) / 4) * 4, '=') } // ensure length is a multiple of 4
+
+    private fun String.base64toLong(): Long {
+        val bytes = Base64Coder.decode(this)
+        val buffer = ByteBuffer.allocate(Long.SIZE_BYTES)
+        buffer.put(bytes)
+        buffer.rewind()
+        return buffer.getLong()
+    }
+
+    private fun String.parseBase64() = undecorateBase64().base64toLong()
+
+    private fun String.parseBase21(): Long {
+        var result = 0L
+        for (char in this@parseBase21) {
+            if (char == '-') continue
+            result = 21L * result + base21Symbols.indexOf(char)
+        }
+        return result
+    }
+
+    @VisibleForTesting
+    fun String.hashCode64(): Long {
+        var result = 0L
+        for (char in this@hashCode64) {
+            result = 31 * result + char.hashCode()
+        }
+        return result
+    }
+
+    @VisibleForTesting
+    fun unitTestFormat(input: Long) = input.prettyFormat()
+}

--- a/core/src/com/unciv/ui/components/formatting/RNGSeedFormat.kt
+++ b/core/src/com/unciv/ui/components/formatting/RNGSeedFormat.kt
@@ -6,7 +6,7 @@ import com.badlogic.gdx.utils.Base64Coder
 import com.unciv.UncivGame
 import com.unciv.models.translations.tr
 import java.nio.ByteBuffer
-import org.jetbrains.annotations.VisibleForTesting
+import kotlin.math.pow
 
 
 /**
@@ -16,48 +16,56 @@ import org.jetbrains.annotations.VisibleForTesting
  *  - Leading and trailing blanks are ignored
  *  - For historical reasons, "" is parsed as 0L
  *  - As produced by plain Long.toString()
- *  - As produced by Number.tr() - probably containing thousands separators
+ *  - As produced by Number.tr() - probably containing thousands separators: when the [parseNumber] override supports it
  *  - As base-64 grouped into groups of 3 characters by dashes, e.g.: "eKa-1xN-Pi8-QA", padding with a "=" allowed but not required
- *  - Shattered Pixel's even more mnemonic "XYZ-PQR-CDF" format - base21 covering ~40bits
+ *  - Shattered Pixel's even more mnemonic "XYZ-PQR-CDF" format - base24 covering almos 42bits
  *  - Parsing arbitrary phrases returns String.hashCode() reimplemented as Long
  *
- *  ### Formatting output:
- *  - Number.tr() for compatibility purposes: Once the code supporting parsing the other formats is established, this can change
- *  - TODO: Don't forget to update this comment when doing so
- *
  *  ### Notes
- *  - Generation of random seeds is unaffected, therefore this **must** cover the entire Long range
+ *  - Generation of random seeds is unaffected, therefore this must cover the entire Long range
  *
  *  ### API
- *  @property parse Call site syntax: `RNGSeedFormat.parse(text)` - the parser supporting all formats named above
  *  @property format Call site syntax: `RNGSeedFormat.format(text)` - the formatter deciding which of the supported formats to produce
+ *  @property parse Call site syntax: `RNGSeedFormat.parse(text)` - the parser supporting all formats named above
+ *  @property parseNumber Hook for o subclass to provide trivial or localized number parsing
  */
-object RNGSeedFormat {
+abstract class IRNGSeedFormat {
+    /////////////////// API
 
-    fun format(value: Long) = value.tr()
-    //TODO Replace with: fun format(value: Long) = value.prettyFormat()
-    // when the parser accepting all is well-established
+    /** Seed to String: Abstract because the subclass decides which format and in the numric case provides the localized formatter */
+    abstract fun format(value: Long): String
 
+    /** String to Seed: final because all formats will be parsed */
     fun parse(text: String) = text.trim(' ').run {
         when {
             isEmpty() -> 0L
-            isBase21decorated() -> parseBase21()
+            isBase2Xdecorated() -> parseBase2X()
             isBase64decorated() -> parseBase64()
-            isNumber() -> UncivGame.Current.settings.getCurrentNumberFormat().parse(this@run).toLong()
+            isNumber() -> parseNumber(this@run)
             else -> hashCode64()
         }
     }
 
-    private const val thousandsSeparators = ",.\u00A0\u202F"
-    private const val minusSymbols = "-\u2212"
-    private const val base21Symbols = "BCDFGHJKLMNPQRSTVWXYZ"
-    private const val maxNumberFormatLength = 26
-    private const val minBase64FormatLength = 14 // Long.MIN_VALUE in Base64/decorated is "gAA-AAA-AAA-AA"
-    private const val maxBase64FormatLength = 15 // allow one padding '='
-    private const val base21FormatLength = 11
+    /** Subclass-provided, used when the input was recognized as a number */
+    protected abstract fun parseNumber(text: String): Long
 
-    @VisibleForTesting
-    const val maxBase21Value = 794280046580L //21.0.pow(9.0).toLong() - 1L
+    /////////////////// Constants
+
+    companion object {
+        private const val thousandsSeparators = ",.\u00A0\u202F"
+        private const val minusSymbols = "-\u2212"
+        /** To change base, changing the number of these symbols is enough, the math adapts automatically.
+         *  With 24 symbols, we get the shorter format up to May 18, 2085 */
+        private const val base2XSymbols = "BCDFGHIJKLMNOPQRSTUVWXYZ"
+        private const val maxNumberFormatLength = 26
+        private const val minBase64FormatLength = 14 // Long.MIN_VALUE in Base64/decorated is "gAA-AAA-AAA-AA"
+        private const val maxBase64FormatLength = 15 // allow one padding '='
+        private const val base2XFormatLength = 11
+        private const val base2Xbase = base2XSymbols.length
+
+        @JvmStatic
+        protected val maxBase2XValue = base2Xbase.toDouble().pow(9.0).toLong() - 1L
+    }
 
     /////////////////// Checking
 
@@ -67,14 +75,14 @@ object RNGSeedFormat {
         if (index == minBase64FormatLength) char == '='
         else if (index % 4 == 3) char == '-'
         else char.isLetterOrDigit() || char == '+' || char == '/'
-    private fun isValidBase21Char(char: Char, index: Int) =
+    private fun isValidBase2XChar(char: Char, index: Int) =
         if (index % 4 == 3) char == '-'
-        else char in base21Symbols
+        else char in base2XSymbols
 
     private fun String.isNumber() = length in 1..maxNumberFormatLength &&
         withIndex().all { (index, char) -> isValidNumberChar(char, index) }
-    private fun String.isBase21decorated() = length == base21FormatLength &&
-        withIndex().all { (index, char) -> isValidBase21Char(char, index) }
+    private fun String.isBase2Xdecorated() = length == base2XFormatLength &&
+        withIndex().all { (index, char) -> isValidBase2XChar(char, index) }
     private fun String.isBase64decorated() = length in minBase64FormatLength..maxBase64FormatLength &&
         withIndex().all { (index, char) -> isValidBase64Char(char, index) }
 
@@ -94,22 +102,21 @@ object RNGSeedFormat {
 
     private fun Long.formatBase64() = toBase64String().decorate()
 
-    private fun Long.formatBase21() = buildString(base21FormatLength) {
-        var residue = this@formatBase21
-        for (i in 0 until base21FormatLength) {
+    private fun Long.formatBase2X() = buildString(base2XFormatLength) {
+        var residue = this@formatBase2X
+        for (i in 0 until base2XFormatLength) {
             if (i % 4 == 3) {
                 insert(0, '-')
                 continue
             }
-            val nextBits = (residue % 21L).toInt()
-            residue /= 21
-            insert(0, base21Symbols[nextBits])
+            val nextBits = (residue % base2Xbase).toInt()
+            residue /= base2Xbase
+            insert(0, base2XSymbols[nextBits])
         }
     }
 
-    private fun Long.prettyFormat() =
-        if (this in 0L..maxBase21Value) formatBase21() else formatBase64()
-
+    protected fun Long.prettyFormat() =
+        if (this in 0L..maxBase2XValue) formatBase2X() else formatBase64()
 
     /////////////////// Parsing
 
@@ -127,24 +134,32 @@ object RNGSeedFormat {
 
     private fun String.parseBase64() = undecorateBase64().base64toLong()
 
-    private fun String.parseBase21(): Long {
+    private fun String.parseBase2X(): Long {
         var result = 0L
-        for (char in this@parseBase21) {
+        for (char in this@parseBase2X) {
             if (char == '-') continue
-            result = 21L * result + base21Symbols.indexOf(char)
+            result = base2Xbase * result + base2XSymbols.indexOf(char)
         }
         return result
     }
 
-    @VisibleForTesting
-    fun String.hashCode64(): Long {
+    protected fun String.hashCode64(): Long {
         var result = 0L
         for (char in this@hashCode64) {
             result = 31 * result + char.hashCode()
         }
         return result
     }
+}
 
-    @VisibleForTesting
-    fun unitTestFormat(input: Long) = input.prettyFormat()
+/**
+ *  Static implementation supporting localized numbers
+ *  [format] delivers Number.tr() for compatibility purposes: Once the code supporting parsing the other formats is established, this can change
+ *           //TODO Replace with: fun format(value: Long) = value.prettyFormat()
+ *  [parse] understands localized numbers
+ */
+object RNGSeedFormat : IRNGSeedFormat() {
+    override fun format(value: Long) = value.tr()
+    override fun parseNumber(text: String) =
+        UncivGame.Current.settings.getCurrentNumberFormat().parse(text).toLong()
 }

--- a/core/src/com/unciv/ui/components/widgets/UncivTextField.kt
+++ b/core/src/com/unciv/ui/components/widgets/UncivTextField.kt
@@ -27,6 +27,7 @@ import com.unciv.utils.withGLContext
 import java.nio.ByteBuffer
 import java.text.ParseException
 import kotlinx.coroutines.delay
+import org.jetbrains.annotations.VisibleForTesting
 
 /**
  * Creates a text field that has nicer platform-specific input added compared to the default Gdx [TextField].
@@ -300,6 +301,11 @@ open class UncivTextField(
                 drop(1).contains('-') -> parse() // detect our format but not a negative plain number
                 else -> toLong()  // In case someone pastes a plain long into the field
             }
+
+            @VisibleForTesting
+            fun unitTestFormat(input: Long) = input.format()
+            @VisibleForTesting
+            fun unitTestParse(input: String) = input.parseBase64OrPlain()
         }
         init {
             textFieldFilter = TextFieldFilter { _, c -> c.isLetterOrDigit() || c in "+/=-" }

--- a/core/src/com/unciv/ui/screens/newgamescreen/MapParametersTable.kt
+++ b/core/src/com/unciv/ui/screens/newgamescreen/MapParametersTable.kt
@@ -48,7 +48,7 @@ class MapParametersTable(
     private lateinit var worldWrapCheckbox: CheckBox
     private lateinit var legendaryStartCheckbox: CheckBox
     private lateinit var strategicBalanceCheckbox: CheckBox
-    private lateinit var seedTextField: UncivTextField.Numeric
+    private lateinit var seedTextField: UncivTextField.RNGSeed
 
     private lateinit var mapShapesOptionsValues: HashSet<String>
     private lateinit var mapTypesOptionsValues: HashSet<String>
@@ -374,10 +374,10 @@ class MapParametersTable(
     private fun addAdvancedControls(table: Table) {
         table.defaults().pad(2f).padTop(10f)
 
-        seedTextField = UncivTextField.Numeric("RNG Seed", mapParameters.seed, integerOnly = true)
+        seedTextField = UncivTextField.RNGSeed(mapParameters.seed)
 
         seedTextField.onChange {
-            mapParameters.seed = seedTextField.value?.toLong() ?: 0L
+            mapParameters.seed = seedTextField.value
         }
 
         table.add("RNG Seed".toLabel()).left()

--- a/tests/src/com/unciv/testing/SimpleTests.kt
+++ b/tests/src/com/unciv/testing/SimpleTests.kt
@@ -1,6 +1,7 @@
 package com.unciv.testing
 
-import com.unciv.ui.components.widgets.UncivTextField
+import com.unciv.ui.components.formatting.RNGSeedFormat
+import com.unciv.ui.components.formatting.RNGSeedFormat.hashCode64
 import org.junit.Assert
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -13,23 +14,26 @@ class SimpleTests {
     @Test
     fun testRngSeedFormatting() {
         val data = listOf(
-            0L to "AAA-AAA-AAA-AA",
+            0L to "BBB-BBB-BBB",
             Long.MAX_VALUE to "f//-///-///-/8",
             Long.MIN_VALUE to "gAA-AAA-AAA-AA",
+            1751239825L to "BBZ-LVS-KKR",
+            1751830624431L to "AAA-Bl+-E9+-K8",
             0x101010101010101L to "AQE-BAQ-EBA-QE",
             0x4040404040404040L to "QEB-AQE-BAQ-EA",
             0x78A6B5C4D3E2F100L to "eKa-1xN-Pi8-QA",
+            RNGSeedFormat.maxBase21Value to "ZZZ-ZZZ-ZZZ",
         )
         var fails = 0
         for ((value, expectedFormattedString) in data) {
             try {
-                val actualFormattedString = UncivTextField.RNGSeed.unitTestFormat(value)
-                if (UncivTextField.RNGSeed.unitTestParse(actualFormattedString) != value) {
+                val actualFormattedString = RNGSeedFormat.unitTestFormat(value)
+                if (RNGSeedFormat.parse(actualFormattedString) != value) {
                     println("UncivTextField.RNGSeed: value $value did not make the round-trip")
                     fails++
                 }
                 val plain = value.toString()
-                if (UncivTextField.RNGSeed.unitTestParse(plain) != value) {
+                if (RNGSeedFormat.parse(plain) != value) {
                     println("UncivTextField.RNGSeed: value $value failed parsing back the plain toString()")
                     fails++
                 }
@@ -41,6 +45,13 @@ class SimpleTests {
                 fails++
             }
         }
-        Assert.assertEquals("RNGSeed formatting should not fail", 0, fails)
+        Assert.assertEquals("RNGSeedFormat should not fail", 0, fails)
+    }
+
+    @Test
+    fun testLongStringHash() {
+        val text = "Unciv is tremendous fun for the whole family!"
+        val hash = text.hashCode64()
+        Assert.assertEquals(-7280134815231108590, hash)
     }
 }

--- a/tests/src/com/unciv/testing/SimpleTests.kt
+++ b/tests/src/com/unciv/testing/SimpleTests.kt
@@ -1,7 +1,6 @@
 package com.unciv.testing
 
-import com.unciv.ui.components.formatting.RNGSeedFormat
-import com.unciv.ui.components.formatting.RNGSeedFormat.hashCode64
+import com.unciv.ui.components.formatting.IRNGSeedFormat
 import org.junit.Assert
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -11,29 +10,44 @@ import org.junit.runner.RunWith
  *  Container for tests that **don't** require loading **any** of Unciv's assets
  */
 class SimpleTests {
+
+    // Differs from `object RNGSeedFormat` in:
+    // - Localization-independent (can run with UncivGame.Current not initialized)
+    // - Pretty format already activated
+    // - proxies internals for direct testing (no @VisibleForTesting needed)
+    private class TestRNGSeedFormat : IRNGSeedFormat() {
+        override fun format(value: Long) = value.prettyFormat()
+        override fun parseNumber(text: String) = text.toLong()
+        val maxBase2XValue get() = Companion.maxBase2XValue
+        fun longHashCode(text: String) = text.hashCode64()
+    }
+
     @Test
     fun testRngSeedFormatting() {
+        val rngSeedFormat = TestRNGSeedFormat()
+
         val data = listOf(
             0L to "BBB-BBB-BBB",
-            Long.MAX_VALUE to "f//-///-///-/8",
-            Long.MIN_VALUE to "gAA-AAA-AAA-AA",
-            1751239825L to "BBZ-LVS-KKR",
-            1751830624431L to "AAA-Bl+-E9+-K8",
+            1751239825L to "BBL-FYL-DYC",
+            1751830624431L to "RXY-YSU-VWR",  // System.currentTimeMillis() some time May 2025
+            rngSeedFormat.maxBase2XValue to "ZZZ-ZZZ-ZZZ",
             0x101010101010101L to "AQE-BAQ-EBA-QE",
             0x4040404040404040L to "QEB-AQE-BAQ-EA",
             0x78A6B5C4D3E2F100L to "eKa-1xN-Pi8-QA",
-            RNGSeedFormat.maxBase21Value to "ZZZ-ZZZ-ZZZ",
+            Long.MAX_VALUE to "f//-///-///-/8",
+            Long.MIN_VALUE to "gAA-AAA-AAA-AA",
         )
+
         var fails = 0
         for ((value, expectedFormattedString) in data) {
             try {
-                val actualFormattedString = RNGSeedFormat.unitTestFormat(value)
-                if (RNGSeedFormat.parse(actualFormattedString) != value) {
+                val actualFormattedString = rngSeedFormat.format(value)
+                if (rngSeedFormat.parse(actualFormattedString) != value) {
                     println("UncivTextField.RNGSeed: value $value did not make the round-trip")
                     fails++
                 }
                 val plain = value.toString()
-                if (RNGSeedFormat.parse(plain) != value) {
+                if (rngSeedFormat.parse(plain) != value) {
                     println("UncivTextField.RNGSeed: value $value failed parsing back the plain toString()")
                     fails++
                 }
@@ -51,7 +65,8 @@ class SimpleTests {
     @Test
     fun testLongStringHash() {
         val text = "Unciv is tremendous fun for the whole family!"
-        val hash = text.hashCode64()
+        val rngSeedFormat = TestRNGSeedFormat()
+        val hash = rngSeedFormat.longHashCode(text)
         Assert.assertEquals(-7280134815231108590, hash)
     }
 }

--- a/tests/src/com/unciv/testing/SimpleTests.kt
+++ b/tests/src/com/unciv/testing/SimpleTests.kt
@@ -1,0 +1,46 @@
+package com.unciv.testing
+
+import com.unciv.ui.components.widgets.UncivTextField
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(GdxTestRunner::class)
+/**
+ *  Container for tests that **don't** require loading **any** of Unciv's assets
+ */
+class SimpleTests {
+    @Test
+    fun testRngSeedFormatting() {
+        val data = listOf(
+            0L to "AAA-AAA-AAA-AA",
+            Long.MAX_VALUE to "f//-///-///-/8",
+            Long.MIN_VALUE to "gAA-AAA-AAA-AA",
+            0x101010101010101L to "AQE-BAQ-EBA-QE",
+            0x4040404040404040L to "QEB-AQE-BAQ-EA",
+            0x78A6B5C4D3E2F100L to "eKa-1xN-Pi8-QA",
+        )
+        var fails = 0
+        for ((value, expectedFormattedString) in data) {
+            try {
+                val actualFormattedString = UncivTextField.RNGSeed.unitTestFormat(value)
+                if (UncivTextField.RNGSeed.unitTestParse(actualFormattedString) != value) {
+                    println("UncivTextField.RNGSeed: value $value did not make the round-trip")
+                    fails++
+                }
+                val plain = value.toString()
+                if (UncivTextField.RNGSeed.unitTestParse(plain) != value) {
+                    println("UncivTextField.RNGSeed: value $value failed parsing back the plain toString()")
+                    fails++
+                }
+                if (actualFormattedString != expectedFormattedString) {
+                    println("UncivTextField.RNGSeed: value $value formats to `$actualFormattedString`, expected: `$expectedFormattedString`")
+                    fails++
+                }
+            } catch (ex: NumberFormatException) {
+                fails++
+            }
+        }
+        Assert.assertEquals("RNGSeed formatting should not fail", 0, fails)
+    }
+}


### PR DESCRIPTION
As discussed in #13547
If test undesired - drop commit

Notes:
- Shattered allows entering any text into the field, when it conforms to the LLL-LLL-LLL pattern, it's converted base 26, when it parses as long, it's parsed (IIRC), but otherwise - hashCode over the string. So players can agree to start the dungeon with an easy to exchange **phrase**, and will meet the same challenges...
- This class could easily learn that too, of course. Not this PR.
- But how do players learn? Evan has the changelog right in the game in a cute format, and very accessible. A new tutorial that pops when one enters text into the field the first time? Not this PR.

(Hi @00-Evan - thanks for the inspiration [and all the fish](https://en.wikipedia.org/wiki/So_Long,_and_Thanks_for_All_the_Fish)!!)