### PR TITLE
Research into a possible libGdx 1.13.5 upgrade

### DIFF
--- a/buildSrc/src/main/kotlin/BuildConfig.kt
+++ b/buildSrc/src/main/kotlin/BuildConfig.kt
@@ -7,7 +7,7 @@ object BuildConfig {
     const val appCodeNumber = 1140
     const val appVersion = "4.17.2"
 
-    const val gdxVersion = "1.13.1"
+    const val gdxVersion = "1.13.5"
     const val ktorVersion = "2.3.12"
     const val coroutinesVersion = "1.8.1"
 

--- a/core/src/com/unciv/ui/components/tilegroups/YieldGroup.kt
+++ b/core/src/com/unciv/ui/components/tilegroups/YieldGroup.kt
@@ -14,11 +14,7 @@ import com.unciv.ui.components.extensions.surroundWithCircle
 import com.unciv.ui.components.extensions.toLabel
 
 class YieldGroup : HorizontalGroup() {
-    init {
-        isTransform = false // performance helper - nothing here is rotated or scaled
-    }
-
-    var currentStats = Stats()
+    private var currentStats = Stats()
 
     fun setStats(stats: Stats) {
         if (currentStats.equals(stats)) return // don't need to update - this is a memory and time saver!
@@ -31,7 +27,7 @@ class YieldGroup : HorizontalGroup() {
         pack()
     }
 
-    fun getIcon(statName: String) =
+    private fun getIcon(statName: String) =
             ImageGetter.getStatIcon(statName).surroundWithCircle(12f, circleImageLocation = "StatIcons/Circle")
                     .apply { circle.color = ImageGetter.CHARCOAL; circle.color.a = 0.5f }
 

--- a/core/src/com/unciv/ui/components/widgets/SortableGrid.kt
+++ b/core/src/com/unciv/ui/components/widgets/SortableGrid.kt
@@ -336,7 +336,6 @@ class SortableGrid<IT, ACT, CT: ISortableGridContentProvider<IT, ACT>> (
         override var sortShown = SortDirection.None
 
         init {
-            outerActor.isTransform = false
             outerActor.align(column.align)
             outerActor.addActor(headerActor)
             initActivationAndTooltip(column)

--- a/desktop/src/com/unciv/app/desktop/HardenGdxAudio.kt
+++ b/desktop/src/com/unciv/app/desktop/HardenGdxAudio.kt
@@ -160,6 +160,6 @@ class HardenGdxAudio(
         }
     }
     fun registerCodecs(audio: OpenALLwjgl3Audio) {
-        audio.registerMusic("m4a") { a, f -> AacMusic(a, f) }
+        audio.registerMusic("m4a", ::AacMusic)
     }
 */

--- a/desktop/src/com/unciv/app/desktop/HardenGdxAudio.kt
+++ b/desktop/src/com/unciv/app/desktop/HardenGdxAudio.kt
@@ -151,7 +151,7 @@ class HardenGdxAudio(
      implementations, though DefaultAndroidAudio just calls the SDK's MediaPlayer so it likely
      already supports m4a, flac, opus and others...)
 
-    class AacMusic(audio: OpenALLwjgl3Audio?, file: FileHandle?) : OpenALMusic(audio, file) {
+    class AacMusic(audio: OpenALLwjgl3Audio, file: FileHandle) : OpenALMusic(audio, file) {
         override fun read(buffer: ByteArray?): Int {
             //...
         }
@@ -160,6 +160,6 @@ class HardenGdxAudio(
         }
     }
     fun registerCodecs(audio: OpenALLwjgl3Audio) {
-        audio.registerMusic("m4a", AacMusic::class.java)
+        audio.registerMusic("m4a") { a, f -> AacMusic(a, f) }
     }
 */


### PR DESCRIPTION
After studying their [release tag](https://github.com/libgdx/libgdx/releases/tag/1.13.5), [commit diff](https://github.com/libgdx/libgdx/compare/1.13.1...1.13.5) and [changelog](https://github.com/libgdx/libgdx/blob/master/CHANGES), I found not much to do.

See commit titles (sorry it wasn't intended for github to actually link those `#` refs in these names - relinking below):
- Makes some code redundant: https://github.com/libgdx/libgdx/pull/7632 (there's uses that didn't set isTransform to false, but none looks like it would not have profited from doing so)
- Makes a demo in a comment outdated: https://github.com/libgdx/libgdx/pull/7608
- No commit - could affect us only positively, making a key bindable that would rebel now: https://github.com/libgdx/libgdx/pull/7456

BUT: 1.13.5 is missing https://github.com/libgdx/libgdx/pull/7661 - that's facepalm level and maybe the _entire_ cause behind you mentioning "several different error reports" in #13553. BUT - that mistake seems to have been in Gdx since https://github.com/libgdx/libgdx/pull/7004/ - which should translate to 1.12.0. Haven't got a clone ready so that was checked via github's horrible blame which I don't trust at all... I tested this PR's output on my phone - it has soft 3-buttons so it _could_ be affected, runs without problem, but then I can't get edge-to-edge either. :shrug: 