### PR TITLE
Fix AskNumberPopup not displaying values set from code

### DIFF
--- a/core/src/com/unciv/ui/components/widgets/UncivTextField.kt
+++ b/core/src/com/unciv/ui/components/widgets/UncivTextField.kt
@@ -227,7 +227,7 @@ open class UncivTextField(
             } catch (_: ParseException) {
                 null
             }
-            set(value) { super.text = value?.tr() ?: "" }
+            set(value) { super.setText(value?.tr()) }
 
         // Enlist compiler to make sure no-one calls this *from our project*
         @Deprecated("Don't assign `text` on a numeric UncivTextField!", ReplaceWith("value"), DeprecationLevel.ERROR)


### PR DESCRIPTION
Fixes #13580 
A typical facepalm. We're so used to Studio whining "Don't call `setHeight()`, use property access syntax"... Only in this case it meant, the proper `setText` wasn't called at all.