### PR TITLE
Display city defense and health in cities overview tab

### DIFF
--- a/buildSrc/src/main/kotlin/BuildConfig.kt
+++ b/buildSrc/src/main/kotlin/BuildConfig.kt
@@ -2,7 +2,7 @@
 package com.unciv.build
 
 object BuildConfig {
-    const val kotlinVersion = "1.9.24"
+    const val kotlinVersion = "2.1.20"
     const val appName = "Unciv"
     const val appCodeNumber = 1142
     const val appVersion = "4.17.4"

--- a/core/src/com/unciv/ui/screens/overviewscreen/CityOverviewTabColumn.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/CityOverviewTabColumn.kt
@@ -4,6 +4,7 @@ import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.scenes.scene2d.Actor
 import com.badlogic.gdx.utils.Align
 import com.unciv.logic.GameInfo
+import com.unciv.logic.battle.CityCombatant
 import com.unciv.logic.city.City
 import com.unciv.logic.city.CityFlags
 import com.unciv.models.stats.Stat
@@ -172,7 +173,17 @@ enum class CityOverviewTabColumn : ISortableGridContentProvider<City, EmpireOver
             return unitIcon
         }
     },
-    ;
+    
+    CityDefense {
+        override val headerTip = "City defense"
+        override val defaultSort get() = SortableGrid.SortDirection.Ascending
+        override fun getComparator() = compareBy<City>() { CityCombatant(it).getDefendingStrength() }.thenBy { it.getMaxHealth() }
+        override fun getHeaderActor(iconSize: Float) = getCircledIcon("BuildingIcons/Walls", iconSize)
+        override fun getEntryValue(item: City) = 0
+        override fun getEntryActor(item: City, iconSize: Float, actionContext: EmpireOverviewScreen) =
+            (CityCombatant(item).getDefendingStrength().toString() + "/" + item.getMaxHealth().toString()).toLabel()
+        override fun getTotalsActor(items: Iterable<City>) = "${items.sumOf { CityCombatant(it).getDefendingStrength() }}".toLabel()
+    };
 
     //endregion
 

--- a/core/src/com/unciv/ui/screens/overviewscreen/CityOverviewTabColumn.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/CityOverviewTabColumn.kt
@@ -47,8 +47,7 @@ enum class CityOverviewTabColumn : ISortableGridContentProvider<City, EmpireOver
                 .onClick {
                     actionContext.game.pushScreen(CityScreen(item))
                 }
-        override fun getTotalsActor(items: Iterable<City>) =
-                "{Total} ${items.count()}".toLabel()
+        override fun getTotalsActor(items: Iterable<City>) = "{Total} ${items.count()}".toLabel()
     },
 
     Status {
@@ -70,7 +69,7 @@ enum class CityOverviewTabColumn : ISortableGridContentProvider<City, EmpireOver
             // getImage is an ImageWithCustomSize, but setting size here fails - width is not respected
             return ImageGetter.getImage(iconPath).surroundWithCircle(iconSize * 0.7f, color = Color.CLEAR)
         }
-        override fun getTotalsActor(items: Iterable<City>) = null
+        override fun getTotalsActor(items: Iterable<City>) = null  // an intended empty space
     },
 
     ConstructionIcon {
@@ -82,7 +81,7 @@ enum class CityOverviewTabColumn : ISortableGridContentProvider<City, EmpireOver
             if (construction.isEmpty()) return null
             return ImageGetter.getConstructionPortrait(construction, iconSize * 0.8f)
         }
-        override fun getTotalsActor(items: Iterable<City>) = null
+        override fun getTotalsActor(items: Iterable<City>) = null  // an intended empty space
     },
 
     Construction {
@@ -98,30 +97,25 @@ enum class CityOverviewTabColumn : ISortableGridContentProvider<City, EmpireOver
         override fun getEntryValue(item: City) = 0
         override fun getEntryActor(item: City, iconSize: Float, actionContext: EmpireOverviewScreen) =
             item.cityConstructions.getCityProductionTextForCityButton().toLabel()
-        override fun getTotalsActor(items: Iterable<City>) = null
+        override fun getTotalsActor(items: Iterable<City>) = null  // an intended empty space
     },
 
     Population {
-        override fun getEntryValue(item: City) =
-                item.population.population
+        override fun getEntryValue(item: City) = item.population.population
     },
 
-    Food {
-        override fun getTotalsActor(items: Iterable<City>) = null  // an intended empty space
-    },
+    Food,
     Gold,
     Science,
-    Production{
-        override fun getTotalsActor(items: Iterable<City>) = null  // an intended empty space
-    },
+    Production,
     Culture,
     Happiness {
         override fun getEntryValue(item: City) =
-                item.cityStats.happinessList.values.sum().roundToInt()
+            item.cityStats.happinessList.values.sum().roundToInt()
     },
     Faith {
         override fun isVisible(gameInfo: GameInfo) =
-                gameInfo.isReligionEnabled()
+            gameInfo.isReligionEnabled()
     },
 
     WLTK {
@@ -151,6 +145,7 @@ enum class CityOverviewTabColumn : ISortableGridContentProvider<City, EmpireOver
             }
             else -> null
         }
+        override fun getTotalsActor(items: Iterable<City>) = null  // an intended empty space
     },
 
     Garrison {
@@ -172,6 +167,7 @@ enum class CityOverviewTabColumn : ISortableGridContentProvider<City, EmpireOver
             }
             return unitIcon
         }
+        override fun getTotalsActor(items: Iterable<City>) = null  // an intended empty space
     },
     
     CityDefense {

--- a/core/src/com/unciv/ui/screens/overviewscreen/CityOverviewTabColumn.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/CityOverviewTabColumn.kt
@@ -145,7 +145,6 @@ enum class CityOverviewTabColumn : ISortableGridContentProvider<City, EmpireOver
             }
             else -> null
         }
-        override fun getTotalsActor(items: Iterable<City>) = null  // an intended empty space
     },
 
     Garrison {

--- a/core/src/com/unciv/ui/screens/overviewscreen/CityOverviewTabColumn.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/CityOverviewTabColumn.kt
@@ -167,7 +167,6 @@ enum class CityOverviewTabColumn : ISortableGridContentProvider<City, EmpireOver
             }
             return unitIcon
         }
-        override fun getTotalsActor(items: Iterable<City>) = null  // an intended empty space
     },
     
     CityDefense {

--- a/core/src/com/unciv/ui/screens/overviewscreen/CityOverviewTabColumn.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/CityOverviewTabColumn.kt
@@ -179,10 +179,10 @@ enum class CityOverviewTabColumn : ISortableGridContentProvider<City, EmpireOver
         override val defaultSort get() = SortableGrid.SortDirection.Ascending
         override fun getComparator() = compareBy<City>() { CityCombatant(it).getDefendingStrength() }.thenBy { it.getMaxHealth() }
         override fun getHeaderActor(iconSize: Float) = getCircledIcon("BuildingIcons/Walls", iconSize)
-        override fun getEntryValue(item: City) = 0
+        override fun getEntryValue(item: City) = CityCombatant(item).getDefendingStrength()
         override fun getEntryActor(item: City, iconSize: Float, actionContext: EmpireOverviewScreen) =
-            (CityCombatant(item).getDefendingStrength().toString() + "/" + item.getMaxHealth().toString()).toLabel()
-        override fun getTotalsActor(items: Iterable<City>) = "${items.sumOf { CityCombatant(it).getDefendingStrength() }}".toLabel()
+            "${getEntryValue(item)}/${item.getMaxHealth()}".toLabel()
+        override fun getTotalsActor(items: Iterable<City>) = null  // an intended empty space
     };
 
     //endregion

--- a/core/src/com/unciv/ui/screens/overviewscreen/CityOverviewTabColumn.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/CityOverviewTabColumn.kt
@@ -171,7 +171,7 @@ enum class CityOverviewTabColumn : ISortableGridContentProvider<City, EmpireOver
     CityDefense {
         override val headerTip = "City defense"
         override val defaultSort get() = SortableGrid.SortDirection.Ascending
-        override fun getComparator() = compareBy<City>() { CityCombatant(it).getDefendingStrength() }.thenBy { it.getMaxHealth() }
+        override fun getComparator() = compareBy<City>() { getEntryValue(it) }.thenBy { it.getMaxHealth() }
         override fun getHeaderActor(iconSize: Float) = getCircledIcon("BuildingIcons/Walls", iconSize)
         override fun getEntryValue(item: City) = CityCombatant(item).getDefendingStrength()
         override fun getEntryActor(item: City, iconSize: Float, actionContext: EmpireOverviewScreen) =


### PR DESCRIPTION
As per [Discord](https://discord.com/channels/586194543280390151/1356640095741939895) suggestion the following `City defense` column (marked with red rectangle) has been added to City overview table:

First value is city combat strength, second value is city hit points, and totals row shows combined city combat strength.
Sorting is done first by combat strength then by health points.

<img width="1263" height="644" alt="city-defense" src="https://github.com/user-attachments/assets/45433e27-ebd6-4ee5-bcaa-b0efb5b6e9e3" />
