### PR TITLE
Add upon entering combat trigger

### DIFF
--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -138,6 +138,8 @@ object Battle {
 
         val isAlreadyDefeatedCity = defender is CityCombatant && defender.isDefeated()
 
+        triggerCombatUniques(attacker, defender, attackedTile)
+
         val damageDealt = takeDamage(attacker, defender)
 
         // check if unit is captured by the attacker (prize ships unique)
@@ -214,6 +216,21 @@ object Battle {
         }
 
         return damageDealt + interceptDamage
+    }
+    
+    private fun triggerCombatUniques(attacker: ICombatant, defender: ICombatant, attackedTile: Tile) {
+        val attackerStateForConditionals = StateForConditionals(attacker.getCivInfo(),
+            ourCombatant = attacker, theirCombatant = defender, tile = attackedTile, combatAction = CombatAction.Attack)
+        if (attacker is MapUnitCombatant)
+            for (unique in attacker.unit.getTriggeredUniques(UniqueType.TriggerUponCombat, attackerStateForConditionals)) {
+                UniqueTriggerActivation.triggerUnique(unique, attacker.unit)
+            }
+        val defenderStateForConditionals = StateForConditionals(defender.getCivInfo(),
+            ourCombatant = defender, theirCombatant = attacker, tile = attackedTile, combatAction = CombatAction.Defend)
+        if (defender is MapUnitCombatant)
+            for (unique in defender.unit.getTriggeredUniques(UniqueType.TriggerUponCombat, attackerStateForConditionals)) {
+                UniqueTriggerActivation.triggerUnique(unique, defender.unit)
+            }
     }
 
 

--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -228,7 +228,7 @@ object Battle {
         val defenderStateForConditionals = StateForConditionals(defender.getCivInfo(),
             ourCombatant = defender, theirCombatant = attacker, tile = attackedTile, combatAction = CombatAction.Defend)
         if (defender is MapUnitCombatant)
-            for (unique in defender.unit.getTriggeredUniques(UniqueType.TriggerUponCombat, attackerStateForConditionals)) {
+            for (unique in defender.unit.getTriggeredUniques(UniqueType.TriggerUponCombat, defenderStateForConditionals)) {
                 UniqueTriggerActivation.triggerUnique(unique, defender.unit)
             }
     }

--- a/core/src/com/unciv/logic/battle/CityCombatant.kt
+++ b/core/src/com/unciv/logic/battle/CityCombatant.kt
@@ -7,6 +7,7 @@ import com.unciv.logic.civilization.Civilization
 import com.unciv.logic.map.tile.Tile
 import com.unciv.models.UncivSound
 import com.unciv.models.ruleset.unique.StateForConditionals
+import com.unciv.models.ruleset.unique.Unique
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.ruleset.unit.UnitType
 import com.unciv.ui.components.extensions.toPercent
@@ -72,6 +73,10 @@ class CityCombatant(val city: City) : ICombatant {
 
         return strength.roundToInt()
     }
-
+    
+    override fun getMatchingUniques(uniqueType: UniqueType, stateForConditionals: StateForConditionals, checkCivUniques: Boolean): Sequence<Unique> {
+        return city.getMatchingUniques(uniqueType, stateForConditionals, checkCivUniques)
+    }
+    
     override fun toString() = city.name // for debug
 }

--- a/core/src/com/unciv/logic/battle/ICombatant.kt
+++ b/core/src/com/unciv/logic/battle/ICombatant.kt
@@ -3,6 +3,9 @@ package com.unciv.logic.battle
 import com.unciv.logic.civilization.Civilization
 import com.unciv.logic.map.tile.Tile
 import com.unciv.models.UncivSound
+import com.unciv.models.ruleset.unique.StateForConditionals
+import com.unciv.models.ruleset.unique.Unique
+import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.ruleset.unit.UnitType
 
 interface ICombatant {
@@ -20,6 +23,7 @@ interface ICombatant {
     fun canAttack(): Boolean
     /** Implements [UniqueParameterType.CombatantFilter][com.unciv.models.ruleset.unique.UniqueParameterType.CombatantFilter] */
     fun matchesFilter(filter: String, multiFilter: Boolean = true): Boolean
+    fun getMatchingUniques(uniqueType: UniqueType, stateForConditionals: StateForConditionals, checkCivUniques: Boolean): Sequence<Unique>
     fun getAttackSound(): UncivSound
 
     fun isMelee(): Boolean = !isRanged()

--- a/core/src/com/unciv/logic/battle/MapUnitCombatant.kt
+++ b/core/src/com/unciv/logic/battle/MapUnitCombatant.kt
@@ -46,8 +46,8 @@ class MapUnitCombatant(val unit: MapUnit) : ICombatant {
         return unit.name+" of "+unit.civ.civName
     }
 
-    fun getMatchingUniques(uniqueType: UniqueType, conditionalState: StateForConditionals, checkCivUniques: Boolean): Sequence<Unique> =
-        unit.getMatchingUniques(uniqueType, conditionalState, checkCivUniques)
+    override fun getMatchingUniques(uniqueType: UniqueType, stateForConditionals: StateForConditionals, checkCivUniques: Boolean): Sequence<Unique> =
+        unit.getMatchingUniques(uniqueType, stateForConditionals, checkCivUniques)
 
     fun hasUnique(uniqueType: UniqueType, conditionalState: StateForConditionals? = null): Boolean =
         if (conditionalState == null) unit.hasUnique(uniqueType)

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -938,6 +938,7 @@ enum class UniqueType(
 
     ///////////////////////////////////////// region 11 UNIT TRIGGERS /////////////////////////////////////////
 
+    TriggerUponCombat("upon entering combat", UniqueTarget.UnitTriggerCondition),
     TriggerUponDamagingUnit("upon damaging a [mapUnitFilter] unit", UniqueTarget.UnitTriggerCondition,
         docDescription = "Can apply triggers to to damaged unit by setting the first parameter to 'Target Unit'"),
     TriggerUponDefeatingUnit("upon defeating a [mapUnitFilter] unit", UniqueTarget.UnitTriggerCondition),


### PR DESCRIPTION
I've seen this come up often enough even before I got distracted from doing Unciv stuff that I'm surprised this isn't implemented yet. https://www.youtube.com/watch?v=8QPJqyoAUWs

This adds a trigger for units entering combat in the first place. This differs from the existing workarounds, TriggerUponDamagingUnit (which erroneously can trigger upon doing 0 damage) and TriggerUponLosingHealth, in that they trigger before the damage actually happens for various purposes, such as in case a unique like ``<vs units with [positiveAmount] HP>`` is added. It also allows for use when attacking cities, which to my knowledge doesn't exist in any capacity currently

I feel like the fact that only units can trigger triggerables and not attacking cities is... strange, but I am not going to add that in for this PR. However, this PR is adding ``getMatchingUniques`` to Icombatant as a whole, rather than just MapUnitCombatant