### PR TITLE
Add `civFilter` to countables

### DIFF
--- a/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
@@ -488,6 +488,8 @@ enum class UniqueParameterType(
 
         override fun getKnownValuesForAutocomplete(ruleset: Ruleset) =
             staticKnownValues + ruleset.tileResources.keys + ResourceType.entries.map { it.name } + Stat.names()
+
+        override fun getErrorSeverity(parameterText: String, ruleset: Ruleset) = getErrorSeverityForFilter(parameterText, ruleset)
     },
 
     /** Used by [UniqueType.FreeExtraBeliefs], see ReligionManager.getBeliefsToChooseAt* functions */


### PR DESCRIPTION
Where applicable, this adds in a `[civFilter]` parameter to many of the countables. For example...

```
[All] [Barracks] Buildings
[All] [Iron] [Resources]
```
