### PR TITLE
better way to brighten colors

### DIFF
--- a/core/src/com/unciv/ui/components/extensions/Scene2dExtensions.kt
+++ b/core/src/com/unciv/ui/components/extensions/Scene2dExtensions.kt
@@ -91,14 +91,21 @@ fun colorFromHex(hexColor: Int): Color {
 
 /** Create a new [Color] instance from [r]/[g]/[b] given as Integers in the range 0..255 */
 fun colorFromRGB(r: Int, g: Int, b: Int) = Color(r / 255f, g / 255f, b / 255f, 1f)
+
 /** Create a new [Color] instance from r/g/b given as Integers in the range 0..255 in the form of a 3-element List [rgb] */
 fun colorFromRGB(rgb: List<Int>) = colorFromRGB(rgb[0], rgb[1], rgb[2])
-/** Linearly interpolates between this [Color] and [BLACK][ImageGetter.CHARCOAL] by [t] which is in the range [[0,1]].
- * The result is returned as a new instance. */
-fun Color.darken(t: Float): Color = Color(this).lerp(Color.BLACK, t)
-/** Linearly interpolates between this [Color] and [WHITE][Color.WHITE] by [t] which is in the range [[0,1]].
- * The result is returned as a new instance. */
-fun Color.brighten(t: Float): Color = Color(this).lerp(Color.WHITE, t)
+
+/** Linearly interpolates between this [Color] and [BLACK][ImageGetter.CHARCOAL] by [t] which is in the range [[0,1]],
+ * preserving color ratio in RGB. The result is returned as a new instance. */
+fun Color.darken(t: Float): Color = Color(this).mul(1 - t)
+
+/** Linearly interpolates between this [Color] and [WHITE][Color.WHITE] by [t] which is in the range [[0,1]],
+ * preserving color ratio in RGB. The result is returned as a new instance. */
+fun Color.brighten(t: Float): Color = Color(this).let {
+    val lightness = maxOf(r, g, b)
+    val targetRatio = (lightness + t * (1 - lightness)) / lightness
+    return it.mul(targetRatio)
+}
 
 
 fun Actor.centerX(parent: Actor) { x = parent.width / 2 - width / 2 }


### PR DESCRIPTION
Same as #13611, but fixed... So, why did it broke to begin with. So, there were 2 errors with `darken()`


# Fix 1 - Reverse `t`

If we multiply any `Color` by `0` then it becomes `BLACK` and `1` then it stays the same. So, the more the `t` the less the change. (assuming 0 <= t <= 1). But `darkens()` expects the opposite to happen. It want the more the `t` the darker the color.

So, the correct version would be `1 - t`.

# Fix 2 - Keep transparency (`a`) unchanged

`Color.BLACK` actually has `a = 1`, `a = 0` is `CLEAR_BLACK` or `CLEAR`. So, we need to keep `a` the same but multiply doesn't care. It changes `a` also. `lerp()` actually does not care either but since `Color.BLACK` has `a = 1`. So, what `lerp()` actually does is increase the transparency actually. Yes, surprising indeed.

So, the actual implementation keeping this behavior unchanged should be something like:
```kt
fun Color.darken(t: Float): Color = Color(this).mul(1 - t).also { it.a = this.a + t * (1 - this.a) }
```
Or,
```kt
fun Color.darken(t: Float): Color = Color(this).let {
    val t = 1 - t;
    it.r *= t
    it.g *= t
    it.b *= t
    it.a = this.a + t * (1 - this.a)
    return it.clamp()
}
```
Which is use multiply for RGB and lerping behavior for `a`

And so, I decided to keep `darken()` behavior the same.

Now, you might ask why no fixes for `brighten()`. Well because lerping to `WHITE` is not as confusing as lerping to `BLACK`. The white version takes everything to same direction where the black version decreases everything except transparency which it actually increases.

And so, why did I miss this? The reason is simple. The color preview url I used to make the table did not have transparency support so I just skipped it thinking it was not important. Sigh.