### PR TITLE
Add Conditionals to Countables

### DIFF
--- a/tests/src/com/unciv/uniques/CountableTests.kt
+++ b/tests/src/com/unciv/uniques/CountableTests.kt
@@ -208,6 +208,21 @@ class CountableTests {
     }
 
     @Test
+    fun testConditionalCountables() {
+        setupModdedGame()
+        val civ2 = game.addCiv()
+        val city2 = game.addCity(civ2, game.tileMap[0,2])
+        val tests = listOf(
+            "Cities" to 1,
+            "Cities <for [all] Civilizations>" to 2
+        )
+        for ((test, expected) in tests) {
+            val actual = Countables.getCountableAmount(test, GameContext(civ))
+            assertEquals("Testing `$test` countable:", expected, actual)
+        }
+    }
+
+    @Test
     fun testPoliciesCountables() {
         setupModdedGame()
         civ.policies.run {


### PR DESCRIPTION
Looking at adding some conditional modifiers to countables so that you can do things like this...
```
Cities <for [all] Civilizations>
[Library] Buildings <for [all] Civilizations>
```

While it's not matching the countables properly, is this the right approach to achieve global countables?
