### PR TITLE
Fix readonly calls to getDifficulty()

### DIFF
--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -240,7 +240,7 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
     /** Get barbarian civ
      *  @throws NoSuchElementException in no-barbarians games! */
     @Readonly fun getBarbarianCivilization() = getCivilization(Constants.barbarians)
-    fun getDifficulty() = difficultyObject
+    @Readonly fun getDifficulty() = difficultyObject
     /** Access a cached `GlobalUniques` that combines the [ruleset]'s [globalUniques][Ruleset.globalUniques]
      *  with the Uniques of the chosen [speed] and [difficulty][getDifficulty] */
     @Readonly @Suppress("purity") // should be autorecognized 


### PR DESCRIPTION
Was getting the following compilation error after the latest readonly change. So, this pull request fixes it...

```
> Task :core:compileKotlin FAILED
e: Unciv/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyFunctions.kt:161:79 Function "canPassThroughTiles" is marked as Readonly but calls non-Readonly function "com.unciv.logic.GameInfo.getDifficulty"
   ````
