### PR TITLE
AI: Update city construction evaluation of buildings + workboats

### DIFF
--- a/core/src/com/unciv/logic/automation/city/ConstructionAutomation.kt
+++ b/core/src/com/unciv/logic/automation/city/ConstructionAutomation.kt
@@ -233,7 +233,7 @@ class ConstructionAutomation(val cityConstructions: CityConstructions) {
 
         if (!findTileWorthImproving()) return
 
-        addChoice(relativeCostEffectiveness, buildableWorkboatUnits.minBy { it.cost }.name, 0.6f)
+        addChoice(relativeCostEffectiveness, buildableWorkboatUnits.minBy { it.cost }.name, 6f) // Improving coastal luxuries etc. is quite important
     }
 
     private fun addWorkerChoice() {
@@ -348,12 +348,12 @@ class ConstructionAutomation(val cityConstructions: CityConstructions) {
             buildingStats.food *= 8 // Starving, need Food, get to 0
         } else buildingStats.food *= 3
 
-        if (civInfo.stats.statsForNextTurn.gold < 10) {
-            buildingStats.gold *= 2 // We have a gold problem and need to adjust build queue accordingly
-        }
+        buildingStats.production *= 2
+
+        buildingStats.gold *= 2 // Everything's weighed by rankStatsValue, which ranks gold at 0.3, let's make that 0.6 (vs Science being 1)
 
         if (civInfo.getHappiness() < 10 || civInfo.getHappiness() < civInfo.cities.size)
-            buildingStats.happiness * 5
+            buildingStats.happiness *= 3
 
         if (city.cityStats.currentCityStats.culture < 2) {
             buildingStats.culture *= 2 // We need to start growing borders

--- a/core/src/com/unciv/logic/automation/city/ConstructionAutomation.kt
+++ b/core/src/com/unciv/logic/automation/city/ConstructionAutomation.kt
@@ -343,10 +343,7 @@ class ConstructionAutomation(val cityConstructions: CityConstructions) {
         val buildingStats = getStatDifferenceFromBuilding(building.name, localUniqueCache)
         getBuildingStatsFromUniques(building, buildingStats)
 
-        val surplusFood = city.cityStats.currentCityStats[Stat.Food]
-        if (surplusFood < 0) {
-            buildingStats.food *= 8 // Starving, need Food, get to 0
-        } else buildingStats.food *= 3
+        buildingStats.food *= 3
 
         buildingStats.production *= 2
 


### PR DESCRIPTION
* bugfix: multiplyAssign for Happiness
* updates Production and Gold value
* increases weight for workboats by 10× (resolves most of the problems with this in testing. Not everything though, someone will need to debug why  AI still refuses to improve certain coastal tiles)
* perf: 3× (actually 3.6×) food is quite a sledgehammer value already, the occurences where 8× changes the building priority should be very rare, and probably not worth the extra check

Realistically, the AI should get extra multiplyer for Faith when they haven't founded a pantheon yet, but they're really bad at using this for tempo, and as a result play noticeably weaker with more faith value