### PR TITLE
Perf: remove AI personality for citizen assignment

### DIFF
--- a/core/src/com/unciv/logic/automation/Automation.kt
+++ b/core/src/com/unciv/logic/automation/Automation.kt
@@ -169,13 +169,6 @@ object Automation {
             yieldStats.production /= 6
         }
 
-        if (!city.civ.isHuman()) { // Don't mess things up with a single turn of Autoplay
-            for (stat in Stat.entries) {
-                val scaledFocus = civPersonality.scaledFocus(PersonalityValue[stat])
-                if (scaledFocus != 1f) yieldStats[stat] *= scaledFocus
-            }
-        }
-
         // Apply City focus
         cityAIFocus.applyWeightTo(yieldStats)
 


### PR DESCRIPTION
It's a lot of extra float multiplications every turn (lots of workeable tiles, especially in late game), and humans don't seem to notice the effect on civ behaviour at all (judging from Discord and Reddit conversations), so it's probably better removed.