### PR TITLE
Minor UI fix: Don't display the WLTK fireworks over the detailed stats popup

### DIFF
--- a/core/src/com/unciv/ui/screens/cityscreen/CityScreen.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/CityScreen.kt
@@ -145,6 +145,7 @@ class CityScreen(
     /** Particle effects for WLTK day decoration */
     private val isWLTKday = city.isWeLoveTheKingDayActive()
     private val fireworks: ParticleEffectMapFireworks?
+    internal var pauseFireworks = false
 
     init {
         if (isWLTKday && UncivGame.Current.settings.citySoundsVolume > 0) {
@@ -577,6 +578,7 @@ class CityScreen(
 
     override fun render(delta: Float) {
         super.render(delta)
+        if (pauseFireworks) return
         fireworks?.render(stage, delta)
     }
 }

--- a/core/src/com/unciv/ui/screens/cityscreen/DetailedStatsPopup.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/DetailedStatsPopup.kt
@@ -58,6 +58,9 @@ class DetailedStatsPopup(
         row()
         addCloseButton(additionalKey = KeyCharAndCode.SPACE)
         update()
+
+        showListeners.add { cityScreen.pauseFireworks = true }
+        closeListeners.add { cityScreen.pauseFireworks = false }
     }
 
     private fun update() {

--- a/core/src/com/unciv/ui/screens/cityscreen/DetailedStatsPopup.kt
+++ b/core/src/com/unciv/ui/screens/cityscreen/DetailedStatsPopup.kt
@@ -53,7 +53,7 @@ class DetailedStatsPopup(
         val scrollPane = AutoScrollPane(totalTable)
         scrollPane.setOverscroll(false, false)
         val scrollPaneCell = add(scrollPane).padTop(0f)
-        scrollPaneCell.maxHeight(cityScreen.stage.height *3 / 4)
+        scrollPaneCell.maxHeight(cityScreen.stage.height * 3 / 4)
 
         row()
         addCloseButton(additionalKey = KeyCharAndCode.SPACE)
@@ -72,8 +72,8 @@ class DetailedStatsPopup(
 
         val stats = when {
             onlyWithStat != null -> listOfNotNull(onlyWithStat)
-            !showFaith -> Stat.values().filter { it != Stat.Faith }
-            else -> Stat.values().toList()
+            !showFaith -> Stat.entries.filter { it != Stat.Faith }
+            else -> Stat.entries
         }
         val columnCount = stats.size + 1
         val statColMinWidth = if (onlyWithStat != null) 150f else 110f


### PR DESCRIPTION
As noticed looking at #13669
- Hides WLTK particle fireworks while the Stats popup is open
- The effect stops abruptly and afterwards continues where it left off - one could surely make that "cuter" - rockets underway finish exploding, then after closing it starts again from the ground - but nah even more code

By the way, I still think the default for "continuous rendering" is wrong nowadays