### PR TITLE
Add `Difficulty number` countable

### DIFF
--- a/core/src/com/unciv/models/ruleset/unique/Countables.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Countables.kt
@@ -191,6 +191,14 @@ enum class Countables(
         }
     },
 
+    DifficultyNumber("Difficulty number", shortDocumentation = "Number representing the difficulty the game is being played on") {
+        override val documentationStrings = listOf("Zero-based index of the Difficulty in Difficulties.json.")
+        override fun eval(parameterText: String, gameContext: GameContext): Int? {
+            val difficulty = gameContext.gameInfo?.getDifficulty() ?: return null
+            val difficulties = gameContext.gameInfo?.ruleset?.difficulties?.keys?.toList() ?: return null
+            return difficulties.indexOf(difficulty.name)
+        }
+    },
 
     EraNumber("Era number", shortDocumentation = "Number of the era the current player is in") {
         override val documentationStrings = listOf("Zero-based index of the Era in Eras.json.")

--- a/tests/src/com/unciv/uniques/CountableTests.kt
+++ b/tests/src/com/unciv/uniques/CountableTests.kt
@@ -139,6 +139,18 @@ class CountableTests {
     }
 
     @Test
+    fun testDifficultyNumberCountable() {
+        setupModdedGame()
+        val tests = listOf(
+            "Difficulty number" to 3 // Prince
+        )
+        for ((test, expected) in tests) {
+            val actual = Countables.getCountableAmount(test, GameContext(civ))
+            assertEquals("Testing `$test` countable:", expected, actual)
+        }
+    }
+
+    @Test
     fun testOwnedTilesCountable() {
         setupModdedGame()
         UniqueTriggerActivation.triggerUnique(Unique("Turn this tile into a [Coast] tile"), civ, tile = game.tileMap[-3,0])


### PR DESCRIPTION
This pull request introduces a countable for `Difficulty number`, which is a zero-indexed int of the current difficulty number. This is similar to `Era number`.

In Brave New World, the [Pathfinder](https://civilization.fandom.com/wiki/Pathfinder_(Civ5)) can select [Ancient ruins](https://civilization.fandom.com/wiki/Ancient_Ruins_(Civ5)) benefits. Getting a Settler or a Worker are only available on Settler or Chieften difficulties. In the mod, this is handled [in an event](https://github.com/RobLoach/Civ-V-Brave-New-World/blob/f4dcb566872d1df594edbebf7af9f642cfb2dee7/jsons/Events.json#L129-L132). While I could do something like...

```
"Only available <on [Settler] Difficulties>"
```

... And then introduce another option for the `Chieften` difficulty, that seems duplicative. Optimally this should be...

```
"Unavailable <when number of [Difficulty number] is more than [2]>"
```
