### PR TITLE
Add Cursor Hover Icons

### DIFF
--- a/core/src/com/unciv/ui/components/input/CursorHoverInputListener.kt
+++ b/core/src/com/unciv/ui/components/input/CursorHoverInputListener.kt
@@ -1,0 +1,19 @@
+package com.unciv.ui.components.input
+
+import com.badlogic.gdx.Gdx
+import com.badlogic.gdx.graphics.Cursor
+import com.badlogic.gdx.scenes.scene2d.Actor
+import com.badlogic.gdx.scenes.scene2d.InputEvent
+import com.badlogic.gdx.scenes.scene2d.InputListener
+
+class CursorHoverInputListener(
+        private val hoverCursor: Cursor.SystemCursor = Cursor.SystemCursor.Hand,
+        private val exitCursor: Cursor.SystemCursor = Cursor.SystemCursor.Arrow
+    ) : InputListener() {
+    override fun enter(event: InputEvent?, x: Float, y: Float, pointer: Int, fromActor: Actor?) {
+        Gdx.graphics.setSystemCursor(hoverCursor)
+    }
+    override fun exit(event: InputEvent?, x: Float, y: Float, pointer: Int, toActor: Actor?) {
+        Gdx.graphics.setSystemCursor(exitCursor)
+    }
+}

--- a/core/src/com/unciv/ui/components/input/CursorHoverInputListener.kt
+++ b/core/src/com/unciv/ui/components/input/CursorHoverInputListener.kt
@@ -6,10 +6,13 @@ import com.badlogic.gdx.scenes.scene2d.Actor
 import com.badlogic.gdx.scenes.scene2d.InputEvent
 import com.badlogic.gdx.scenes.scene2d.InputListener
 
+/**
+ * Provides an input listener that will change the cursor when the element is hovered.
+ */
 class CursorHoverInputListener(
-        private val hoverCursor: Cursor.SystemCursor = Cursor.SystemCursor.Hand,
-        private val exitCursor: Cursor.SystemCursor = Cursor.SystemCursor.Arrow
-    ) : InputListener() {
+    private val hoverCursor: Cursor.SystemCursor = Cursor.SystemCursor.Hand,
+    private val exitCursor: Cursor.SystemCursor = Cursor.SystemCursor.Arrow
+) : InputListener() {
     override fun enter(event: InputEvent?, x: Float, y: Float, pointer: Int, fromActor: Actor?) {
         Gdx.graphics.setSystemCursor(hoverCursor)
     }

--- a/core/src/com/unciv/ui/components/input/CursorHoverInputListener.kt
+++ b/core/src/com/unciv/ui/components/input/CursorHoverInputListener.kt
@@ -14,9 +14,11 @@ class CursorHoverInputListener(
     private val exitCursor: Cursor.SystemCursor = Cursor.SystemCursor.Arrow
 ) : InputListener() {
     override fun enter(event: InputEvent?, x: Float, y: Float, pointer: Int, fromActor: Actor?) {
+        super.enter(event, x, y, pointer, fromActor)
         Gdx.graphics.setSystemCursor(hoverCursor)
     }
     override fun exit(event: InputEvent?, x: Float, y: Float, pointer: Int, toActor: Actor?) {
+        super.exit(event, x, y, pointer, toActor)
         Gdx.graphics.setSystemCursor(exitCursor)
     }
 }

--- a/core/src/com/unciv/ui/components/widgets/UncivSlider.kt
+++ b/core/src/com/unciv/ui/components/widgets/UncivSlider.kt
@@ -24,6 +24,7 @@ import com.unciv.ui.audio.SoundPlayer
 import com.unciv.ui.components.extensions.isShiftKeyPressed
 import com.unciv.ui.components.extensions.surroundWithCircle
 import com.unciv.ui.components.extensions.toLabel
+import com.unciv.ui.components.input.CursorHoverInputListener
 import com.unciv.ui.components.input.onClick
 import com.unciv.ui.components.widgets.UncivSlider.Companion.formatPercent
 import com.unciv.ui.images.IconCircleGroup
@@ -162,6 +163,7 @@ class UncivSlider (
             minusButton.onClick {
                 addToValue(-stepSize)
             }
+            minusButton.addListener(CursorHoverInputListener())
             add(minusButton).apply {
                 if (vertical) padBottom(padding) else padLeft(padding)
             }
@@ -178,6 +180,7 @@ class UncivSlider (
             plusButton.onClick {
                 addToValue(stepSize)
             }
+            plusButton.addListener(CursorHoverInputListener())
             add(plusButton).apply {
                 if (vertical) padTop(padding) else padRight(padding)
             }
@@ -202,6 +205,8 @@ class UncivSlider (
                 SoundPlayer.play(sound)
             }
         })
+
+        slider.addListener(CursorHoverInputListener())
     }
 
     // Helper for plus/minus button onClick, non-trivial only if setSnapToValues is used

--- a/core/src/com/unciv/ui/components/widgets/UncivTextField.kt
+++ b/core/src/com/unciv/ui/components/widgets/UncivTextField.kt
@@ -18,6 +18,8 @@ import com.unciv.ui.components.extensions.right
 import com.unciv.ui.components.extensions.stageBoundingBox
 import com.unciv.ui.components.extensions.top
 import com.unciv.ui.components.input.keyShortcuts
+import com.unciv.ui.components.input.CursorHoverInputListener
+import com.badlogic.gdx.graphics.Cursor
 import com.unciv.ui.popups.Popup
 import com.unciv.ui.screens.basescreen.BaseScreen
 import com.unciv.ui.screens.basescreen.UncivStage
@@ -52,6 +54,7 @@ open class UncivTextField(
         messageText = hint.tr()
 
         this.addListener(UncivTextFieldFocusListener())
+        this.addListener(CursorHoverInputListener(Cursor.SystemCursor.Ibeam))
 
         if (isAndroid) this.addListener(VisibleAreaChangedListener())
     }

--- a/core/src/com/unciv/ui/popups/Popup.kt
+++ b/core/src/com/unciv/ui/popups/Popup.kt
@@ -26,6 +26,7 @@ import com.unciv.ui.components.extensions.center
 import com.unciv.ui.components.extensions.darken
 import com.unciv.ui.components.extensions.toLabel
 import com.unciv.ui.components.extensions.toTextButton
+import com.unciv.ui.components.input.CursorHoverInputListener
 import com.unciv.ui.components.input.KeyCharAndCode
 import com.unciv.ui.components.input.KeyboardBinding
 import com.unciv.ui.components.input.KeyboardBindings
@@ -304,6 +305,7 @@ open class Popup(
         val button = text.toTextButton(style)
         button.onActivation { action() }
         button.keyShortcuts.add(key)
+        button.addListener(CursorHoverInputListener())
         return bottomTable.add(button)
     }
     fun addButton(text: String, key: Char, style: TextButtonStyle? = null, action: () -> Unit)
@@ -314,6 +316,7 @@ open class Popup(
     fun addButton(text: String, binding: KeyboardBinding, style: TextButtonStyle? = null, action: () -> Unit): Cell<TextButton> {
         val button = text.toTextButton(style)
         button.onActivation(binding = binding) { action() }
+        button.addListener(CursorHoverInputListener())
         return bottomTable.add(button)
     }
 

--- a/core/src/com/unciv/ui/screens/civilopediascreen/CivilopediaScreen.kt
+++ b/core/src/com/unciv/ui/screens/civilopediascreen/CivilopediaScreen.kt
@@ -20,6 +20,7 @@ import com.unciv.ui.components.extensions.toLabel
 import com.unciv.ui.components.input.KeyboardBinding
 import com.unciv.ui.components.input.onActivation
 import com.unciv.ui.components.input.onClick
+import com.unciv.ui.components.input.CursorHoverInputListener
 import com.unciv.ui.images.IconTextButton
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.screens.basescreen.BaseScreen
@@ -144,6 +145,7 @@ class CivilopediaScreen(
                 .toLabel(Color.WHITE, 25, hideIcons=true)).pad(10f)
             entryButton.onClick { selectEntry(entry) }
             entryButton.name = entry.name               // make button findable
+            entryButton.addListener(CursorHoverInputListener())
             val cell = entrySelectTable.add(entryButton).height(75f).expandX().fillX()
             entrySelectTable.row()
             if (currentY < 0f) currentY = cell.padTop
@@ -226,6 +228,7 @@ class CivilopediaScreen(
             val icon = if (categoryKey.headerIcon.isNotEmpty()) ImageGetter.getImage(categoryKey.headerIcon) else null
             val button = IconTextButton(categoryKey.label, icon)
             button.onActivation(binding = categoryKey.binding) { selectCategory(categoryKey) }
+            button.addListener(CursorHoverInputListener())
             val cell = buttonTable.add(button)
             categoryToButtons[categoryKey] = CategoryButtonInfo(button, currentX, cell.prefWidth)
             currentX += cell.prefWidth + 20f

--- a/core/src/com/unciv/ui/screens/civilopediascreen/MarkupRenderer.kt
+++ b/core/src/com/unciv/ui/screens/civilopediascreen/MarkupRenderer.kt
@@ -4,6 +4,7 @@ import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.utils.Align
 import com.unciv.ui.components.extensions.addSeparator
+import com.unciv.ui.components.input.CursorHoverInputListener
 import com.unciv.ui.components.input.onClick
 import com.unciv.ui.components.input.onRightClick
 import com.unciv.ui.screens.basescreen.BaseScreen
@@ -49,10 +50,12 @@ object MarkupRenderer {
                 continue
             }
             val actor = line.render(labelWidth, iconDisplay)
-            if (line.linkType == FormattedLine.LinkType.Internal && linkAction != null)
+            if (line.linkType == FormattedLine.LinkType.Internal && linkAction != null) {
                 actor.onClick {
                     linkAction(line.link)
                 }
+                actor.addListener(CursorHoverInputListener())
+            }
             else if (line.linkType == FormattedLine.LinkType.External) {
                 actor.onClick {
                     Gdx.net.openURI(line.link)
@@ -60,6 +63,7 @@ object MarkupRenderer {
                 actor.onRightClick {
                     Gdx.app.clipboard.contents = line.link
                 }
+                actor.addListener(CursorHoverInputListener())
             }
             if (labelWidth == 0f)
                 table.add(actor).align(line.align).row()

--- a/core/src/com/unciv/ui/screens/mainmenuscreen/MainMenuScreen.kt
+++ b/core/src/com/unciv/ui/screens/mainmenuscreen/MainMenuScreen.kt
@@ -210,6 +210,7 @@ class MainMenuScreen: BaseScreen(), RecreateOnResize {
         civilopediaButton.onActivation { openCivilopedia() }
         civilopediaButton.keyShortcuts.add(KeyboardBinding.Civilopedia)
         civilopediaButton.addTooltip(KeyboardBinding.Civilopedia, 30f)
+        civilopediaButton.addListener(CursorHoverInputListener())
         civilopediaButton.setPosition(30f, 30f)
         stage.addActor(civilopediaButton)
 
@@ -227,6 +228,7 @@ class MainMenuScreen: BaseScreen(), RecreateOnResize {
         rightSideButtons.add(githubButton)
         
         rightSideButtons.pack()
+        rightSideButtons.addListener(CursorHoverInputListener())
         rightSideButtons.setPosition(stage.width - 30, 30f, Align.bottomRight)
         stage.addActor(rightSideButtons)
 

--- a/core/src/com/unciv/ui/screens/mainmenuscreen/MainMenuScreen.kt
+++ b/core/src/com/unciv/ui/screens/mainmenuscreen/MainMenuScreen.kt
@@ -2,6 +2,7 @@
 
 import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.graphics.Color
+import com.badlogic.gdx.graphics.Cursor
 import com.badlogic.gdx.scenes.scene2d.Touchable
 import com.badlogic.gdx.scenes.scene2d.actions.Actions
 import com.badlogic.gdx.scenes.scene2d.ui.Stack
@@ -35,6 +36,7 @@ import com.unciv.ui.components.input.KeyboardBinding
 import com.unciv.ui.components.input.keyShortcuts
 import com.unciv.ui.components.input.onActivation
 import com.unciv.ui.components.input.onLongPress
+import com.unciv.ui.components.input.CursorHoverInputListener
 import com.unciv.ui.components.tilegroups.TileGroupMap
 import com.unciv.ui.components.widgets.AutoScrollPane
 import com.unciv.ui.images.ImageGetter
@@ -102,6 +104,7 @@ class MainMenuScreen: BaseScreen(), RecreateOnResize {
             .padTopDescent()
 
         table.touchable = Touchable.enabled
+        table.addListener(CursorHoverInputListener())
         table.onActivation(binding = binding) {
             stopBackgroundMapGeneration()
             function()

--- a/core/src/com/unciv/ui/screens/worldscreen/minimap/MinimapHolder.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/minimap/MinimapHolder.kt
@@ -1,6 +1,8 @@
 package com.unciv.ui.screens.worldscreen.minimap
 
+import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.graphics.Color
+import com.badlogic.gdx.graphics.Cursor
 import com.badlogic.gdx.graphics.g2d.Batch
 import com.badlogic.gdx.math.Vector2
 import com.badlogic.gdx.scenes.scene2d.Actor
@@ -14,6 +16,7 @@ import com.unciv.GUI
 import com.unciv.UncivGame
 import com.unciv.logic.civilization.Civilization
 import com.unciv.ui.components.extensions.addInTable
+import com.unciv.ui.components.input.CursorHoverInputListener
 import com.unciv.ui.components.input.onActivation
 import com.unciv.ui.components.input.onClick
 import com.unciv.ui.images.ImageGetter
@@ -122,6 +125,7 @@ class MinimapHolder(val mapHolder: WorldMapHolder) : Table() {
             val image = ImageGetter.getImage("OtherIcons/$name")
             table.add(image).expand().size(20f).pad(8f).bottom().right()
             table.touchable = Touchable.enabled
+            table.addListener(CursorHoverInputListener())
             table.onActivation(toggle)
         } else {
             // map is really small: use whole MinimapHolder as click area to maximize map
@@ -174,6 +178,7 @@ class MinimapHolder(val mapHolder: WorldMapHolder) : Table() {
         toggleIconTable.defaults().padTop(paddingBetweenElements)
 
         for (button in buttons) {
+            button.addListener(CursorHoverInputListener())
             toggleIconTable.add(button).row()
         }
 
@@ -204,6 +209,8 @@ class MinimapHolder(val mapHolder: WorldMapHolder) : Table() {
             val targetSize = Vector2(stage.width - event.stageX, event.stageY)
             minimapSize = minimap.getClosestMinimapSize(targetSize)
             rebuildAndUpdateMap(civInfo)
+            // Cursor.SystemCursor.NWSEResize would be optimal, but there's an GLFW issue in X11 preventing that
+            Gdx.graphics.setSystemCursor(Cursor.SystemCursor.Hand)
         }
         override fun touchUp(event: InputEvent, x: Float, y: Float, pointer: Int, button: Int) {
             super.touchUp(event, x, y, pointer, button)
@@ -211,6 +218,7 @@ class MinimapHolder(val mapHolder: WorldMapHolder) : Table() {
                 worldScreen.game.settings.minimapSize = minimapSize
                 GUI.setUpdateWorldOnNextRender() // full update    
             }
+            Gdx.graphics.setSystemCursor(Cursor.SystemCursor.Arrow)
         }
     }
 }


### PR DESCRIPTION
This adds a cursor hover icon for some of the elements, following #13657...

- [x] Main screen buttons
- [x] Popup buttons
- [x] Map overlay toggle
- [x] Sliders
- [x] Textfields
- [x] Civilopedia links
- [ ] Unit actions
- [ ] Map overlay resize corners