### PR TITLE
Ignore Conditionals for spawning ruins

### DIFF
--- a/core/src/com/unciv/models/ruleset/tile/TileImprovement.kt
+++ b/core/src/com/unciv/models/ruleset/tile/TileImprovement.kt
@@ -56,7 +56,7 @@ class TileImprovement : RulesetStatsObject() {
     @Readonly
     fun isRoad() = RoadStatus.entries.any { it != RoadStatus.None && it.name == this.name }
     @Readonly
-    fun isAncientRuinsEquivalent() = hasUnique(UniqueType.IsAncientRuinsEquivalent)
+    fun isAncientRuinsEquivalent() = hasUnique(UniqueType.IsAncientRuinsEquivalent, GameContext.IgnoreConditionals)
 
     fun canBeBuiltOn(terrain: String): Boolean {
         return terrain in terrainsCanBeBuiltOn


### PR DESCRIPTION
Currently, ruins use the default of ``EmptyState`` rather than ``IgnoreConditionals like it should. This means that improvements that should spawn as ruins don't spawn if the ruins unique has most conditionals as  most conditionals default to false without a state

Leaving this as a draft most for PSA sakes because unfortunately this \*still\* has serious problems. Namely, it means that improvements that aren't supposed to generate yet (for whatever reason) do, which may or may not break mods. This not only just because of us ignoring conditionals, either. The caching makes it impossible to have the correct behavior for both units filtered out (requiring conditionals elsewhere such on the rewards themselves) and for generation even if we found a good workaround here. This means the correct solution is
1. The uniques need to be split into 2 (this one for giving bonuses and one for generation purposes)
2. Double checking where we can cache and where caching leads to unexpected behavior