### PR TITLE
AI: don't annex cities if it causes severe unhappiness

### DIFF
--- a/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
@@ -477,6 +477,7 @@ object NextTurnAutomation {
         for (city in civInfo.cities) {
             if (city.isPuppet && city.population.population > 9
                     && !city.isInResistance() && !civInfo.hasUnique(UniqueType.MayNotAnnexCities)
+                    && (civInfo.stats.statsForNextTurn.happiness > city.population.population * 2 - 8) // At all cost, don't go below -10 happiness due to annexing (consider -9 minimum acceptable)
             ) {
                 city.annexCity()
             }


### PR DESCRIPTION
AI annexing cities doesn't seem to have a check for happiness weirdly enough, potentially bring the AI into crippling unhappiness.