### PR TITLE
AI: exclude great general from escort logic

### DIFF
--- a/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
@@ -564,7 +564,7 @@ object UnitAutomation {
                 .asSequence()
                 .filter {
                     unit.civ == it.civ && it.health < it.getMaxHealth()
-                } //Weird health issues and making sure that not all forces move to good defenses
+                }
 
         if (siegedCities.any { it.getCenterTile().aerialDistanceTo(unit.getTile()) <= 2 })
             return false


### PR DESCRIPTION
Also removed a multiplier in tryHeadTowardsOurSiegedCity() that's probably a leftover from when defensive buildings didn't grant instant hp.