### PR TITLE
Goodies before chat retention & `UncivServer.jar` Chat Session Management fixes

### DIFF
--- a/core/src/com/unciv/logic/IdChecker.kt
+++ b/core/src/com/unciv/logic/IdChecker.kt
@@ -23,15 +23,15 @@ import kotlin.math.abs
  */
 object IdChecker {
 
-    fun checkAndReturnPlayerUuid(playerId: String): String? {
+    fun checkAndReturnPlayerUuid(playerId: String): String {
         return checkAndReturnUuiId(playerId, "P")
     }
 
-    fun checkAndReturnGameUuid(gameId: String): String? {
+    fun checkAndReturnGameUuid(gameId: String): String {
         return checkAndReturnUuiId(gameId, "G")
     }
 
-    private fun checkAndReturnUuiId(id: String, prefix: String): String? {
+    private fun checkAndReturnUuiId(id: String, prefix: String): String {
         val trimmedPlayerId = id.trim()
         if (trimmedPlayerId.length == 40) { // length of a UUID (36) with pre- and postfix
             require(trimmedPlayerId.startsWith(prefix, true)) { "Not a valid ID. Does not start with prefix $prefix" }
@@ -47,7 +47,7 @@ object IdChecker {
         } else if (trimmedPlayerId.length == 36) {
             return trimmedPlayerId
         }
-        return null
+        throw IllegalArgumentException("Not a valid ID. Wrong length.")
     }
 
 

--- a/core/src/com/unciv/ui/screens/multiplayerscreens/AddFriendScreen.kt
+++ b/core/src/com/unciv/ui/screens/multiplayerscreens/AddFriendScreen.kt
@@ -6,14 +6,14 @@ import com.unciv.UncivGame
 import com.unciv.logic.IdChecker
 import com.unciv.logic.multiplayer.FriendList
 import com.unciv.models.translations.tr
+import com.unciv.ui.screens.pickerscreens.PickerScreen
+import com.unciv.ui.popups.ToastPopup
+import com.unciv.ui.components.widgets.UncivTextField
 import com.unciv.ui.components.extensions.enable
+import com.unciv.ui.components.input.onClick
 import com.unciv.ui.components.extensions.toLabel
 import com.unciv.ui.components.extensions.toTextButton
-import com.unciv.ui.components.input.onClick
-import com.unciv.ui.components.widgets.UncivTextField
-import com.unciv.ui.popups.ToastPopup
-import com.unciv.ui.screens.pickerscreens.PickerScreen
-import com.unciv.utils.isUUID
+import java.util.UUID
 
 class AddFriendScreen : PickerScreen() {
     init {
@@ -45,7 +45,9 @@ class AddFriendScreen : PickerScreen() {
         rightSideButton.setText("Add friend".tr())
         rightSideButton.enable()
         rightSideButton.onClick {
-            if (!(IdChecker.checkAndReturnPlayerUuid(playerIDTextField.text)?.isUUID() ?: false)) {
+            try {
+                UUID.fromString(IdChecker.checkAndReturnPlayerUuid(playerIDTextField.text))
+            } catch (_: Exception) {
                 ToastPopup("Player ID is incorrect", this)
                 return@onClick
             }

--- a/core/src/com/unciv/ui/screens/multiplayerscreens/AddMultiplayerGameScreen.kt
+++ b/core/src/com/unciv/ui/screens/multiplayerscreens/AddMultiplayerGameScreen.kt
@@ -5,6 +5,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.unciv.Constants
 import com.unciv.logic.IdChecker
 import com.unciv.models.translations.tr
+import com.unciv.ui.components.widgets.UncivTextField
 import com.unciv.ui.components.extensions.enable
 import com.unciv.ui.components.extensions.toLabel
 import com.unciv.ui.components.extensions.toTextButton
@@ -12,14 +13,13 @@ import com.unciv.ui.components.input.KeyCharAndCode
 import com.unciv.ui.components.input.keyShortcuts
 import com.unciv.ui.components.input.onActivation
 import com.unciv.ui.components.input.onClick
-import com.unciv.ui.components.widgets.UncivTextField
 import com.unciv.ui.popups.Popup
 import com.unciv.ui.popups.ToastPopup
 import com.unciv.ui.screens.pickerscreens.PickerScreen
 import com.unciv.ui.screens.savescreens.LoadGameScreen
 import com.unciv.utils.Concurrency
-import com.unciv.utils.isUUID
 import com.unciv.utils.launchOnGLThread
+import java.util.UUID
 
 class AddMultiplayerGameScreen(multiplayerScreen: MultiplayerScreen) : PickerScreen() {
     init {
@@ -48,7 +48,9 @@ class AddMultiplayerGameScreen(multiplayerScreen: MultiplayerScreen) : PickerScr
         rightSideButton.enable()
         rightSideButton.keyShortcuts.add(KeyCharAndCode.RETURN)
         rightSideButton.onActivation {
-            if (!(IdChecker.checkAndReturnGameUuid(gameIDTextField.text)?.isUUID() ?: false)) {
+            try {
+                UUID.fromString(IdChecker.checkAndReturnGameUuid(gameIDTextField.text))
+            } catch (_: Exception) {
                 ToastPopup("Invalid game ID!", this)
                 return@onActivation
             }

--- a/core/src/com/unciv/ui/screens/multiplayerscreens/EditFriendScreen.kt
+++ b/core/src/com/unciv/ui/screens/multiplayerscreens/EditFriendScreen.kt
@@ -7,15 +7,15 @@ import com.unciv.UncivGame
 import com.unciv.logic.IdChecker
 import com.unciv.logic.multiplayer.FriendList
 import com.unciv.models.translations.tr
-import com.unciv.ui.components.extensions.enable
-import com.unciv.ui.components.extensions.toLabel
-import com.unciv.ui.components.extensions.toTextButton
-import com.unciv.ui.components.input.onClick
-import com.unciv.ui.components.widgets.UncivTextField
+import com.unciv.ui.screens.pickerscreens.PickerScreen
 import com.unciv.ui.popups.ConfirmPopup
 import com.unciv.ui.popups.ToastPopup
-import com.unciv.ui.screens.pickerscreens.PickerScreen
-import com.unciv.utils.isUUID
+import com.unciv.ui.components.widgets.UncivTextField
+import com.unciv.ui.components.extensions.enable
+import com.unciv.ui.components.input.onClick
+import com.unciv.ui.components.extensions.toLabel
+import com.unciv.ui.components.extensions.toTextButton
+import java.util.UUID
 
 class EditFriendScreen(selectedFriend: FriendList.Friend) : PickerScreen() {
     init {
@@ -75,7 +75,9 @@ class EditFriendScreen(selectedFriend: FriendList.Friend) : PickerScreen() {
                 ToastPopup("Player ID already used!", this)
                 return@onClick
             }
-            if (!(IdChecker.checkAndReturnPlayerUuid(playerIDTextField.text)?.isUUID() ?: false)) {
+            try {
+                UUID.fromString(IdChecker.checkAndReturnPlayerUuid(playerIDTextField.text))
+            } catch (_: Exception) {
                 ToastPopup("Player ID is incorrect", this)
                 return@onClick
             }

--- a/core/src/com/unciv/ui/screens/newgamescreen/NewGameScreen.kt
+++ b/core/src/com/unciv/ui/screens/newgamescreen/NewGameScreen.kt
@@ -40,10 +40,11 @@ import com.unciv.ui.screens.basescreen.RecreateOnResize
 import com.unciv.ui.screens.pickerscreens.PickerScreen
 import com.unciv.utils.Concurrency
 import com.unciv.utils.Log
-import com.unciv.utils.isUUID
 import com.unciv.utils.launchOnGLThread
 import kotlinx.coroutines.coroutineScope
 import java.net.URI
+import java.net.URL
+import java.util.UUID
 import kotlin.math.floor
 import com.unciv.ui.components.widgets.AutoScrollPane as ScrollPane
 
@@ -156,7 +157,9 @@ class NewGameScreen(
                     else "Couldn't connect to Dropbox!"
 
             for (player in gameSetupInfo.gameParameters.players.filter { it.playerType == PlayerType.Human }) {
-                if (!(IdChecker.checkAndReturnPlayerUuid(player.playerId)?.isUUID() ?: false)) {
+                try {
+                    UUID.fromString(IdChecker.checkAndReturnPlayerUuid(player.playerId))
+                } catch (_: Exception) {
                     return "Invalid player ID!"
                 }
             }

--- a/core/src/com/unciv/ui/screens/newgamescreen/PlayerPickerTable.kt
+++ b/core/src/com/unciv/ui/screens/newgamescreen/PlayerPickerTable.kt
@@ -17,26 +17,26 @@ import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.ruleset.nation.Nation
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.translations.tr
+import com.unciv.ui.components.input.KeyCharAndCode
+import com.unciv.ui.components.widgets.UncivTextField
+import com.unciv.ui.components.widgets.WrappableLabel
 import com.unciv.ui.components.extensions.darken
 import com.unciv.ui.components.extensions.isEnabled
+import com.unciv.ui.components.input.keyShortcuts
+import com.unciv.ui.components.input.onActivation
+import com.unciv.ui.components.input.onClick
 import com.unciv.ui.components.extensions.setFontColor
 import com.unciv.ui.components.extensions.surroundWithCircle
 import com.unciv.ui.components.extensions.toCheckBox
 import com.unciv.ui.components.extensions.toLabel
 import com.unciv.ui.components.extensions.toTextButton
-import com.unciv.ui.components.input.KeyCharAndCode
-import com.unciv.ui.components.input.keyShortcuts
-import com.unciv.ui.components.input.onActivation
-import com.unciv.ui.components.input.onClick
-import com.unciv.ui.components.widgets.UncivTextField
-import com.unciv.ui.components.widgets.WrappableLabel
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.popups.Popup
 import com.unciv.ui.screens.basescreen.BaseScreen
 import com.unciv.ui.screens.multiplayerscreens.FriendPickerList
 import com.unciv.ui.screens.pickerscreens.PickerPane
 import com.unciv.ui.screens.pickerscreens.PickerScreen
-import com.unciv.utils.isUUID
+import java.util.UUID
 import com.unciv.ui.components.widgets.AutoScrollPane as ScrollPane
 
 /**
@@ -242,11 +242,12 @@ class PlayerPickerTable(
         add(errorLabel).pad(5f).row()
 
         fun onPlayerIdTextUpdated() {
-            if (IdChecker.checkAndReturnPlayerUuid(playerIdTextField.text)?.isUUID() ?: false) {
+            try {
+                UUID.fromString(IdChecker.checkAndReturnPlayerUuid(playerIdTextField.text))
                 player.playerId = playerIdTextField.text.trim()
-                errorLabel.apply { setText("✔"); setFontColor(Color.GREEN) }
-            } else {
-                errorLabel.apply { setText("✘"); setFontColor(Color.RED) }
+                errorLabel.apply { setText("✔");setFontColor(Color.GREEN) }
+            } catch (_: Exception) {
+                errorLabel.apply { setText("✘");setFontColor(Color.RED) }
             }
         }
         onPlayerIdTextUpdated()


### PR DESCRIPTION
> [!NOTE]
> All changes are backwards compatible. So, we do not need to increment `chatVersion` yet.

### What this PR contains:

1. `String.isUUID()` extension function
2. Use `UUID` as `ChatStore` key
3. Make `gameId` in `Response.Chat` nullable. (empty string is too confusing, the server is backwards compatible for now https://github.com/touhidurrr/UncivServer.xyz/commit/f4f4cde1fe898aa7eb2446f891a4c377d67166a2.)
4. Simply `WebSocketSessionManager`. Specially fix the incorrect pub / sub behavior. The Previous implementation incorrectly used `userId` as key. However, this is incorrect because an user can connect from multiple devices. So, use `DefaultWebSocketServerSession` instead.

### What this PR does not contain:
1. Chat retention (#13709)

### Why?
As I began tweaking stuff, it became too much extra changes to ship with chat retention. And I spent all of my free time before even touching chat retention. Thus it is probably better to do that in another time. Also, did not know that renaming branch closes the previous pr automatically (#13732), sigh.