### PR TITLE
AI: better utilization of promoted units

### DIFF
--- a/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
@@ -454,7 +454,7 @@ object NextTurnAutomation {
         }
         val distance = if (!isAtWar) 0 else unit.civ.threatManager.getDistanceToClosestEnemyUnit(unit.getTile(),6)
         // Lower health units should move earlier to swap with higher health units
-        return distance + (unit.health / 10) + unit.promotions.numberOfPromotions + when {
+        return distance + (unit.health / 10) - unit.promotions.numberOfPromotions + when {
             unit.baseUnit.isRanged() -> 10
             unit.baseUnit.isMelee() -> 30
             unit.isGreatPersonOfType("War") -> 100 // Generals move after military units


### PR DESCRIPTION
AI units obstructing each other is a major problem, imo it makes sense to let them prioritise highly promoted units when moving.