### PR TITLE
Use `AuthPopup` explicitly on `401` and show more info on game upload failure

### DIFF
--- a/android/assets/jsons/translations/English.properties
+++ b/android/assets/jsons/translations/English.properties
@@ -1142,7 +1142,9 @@ Multiplayer =
  # Requires translation!
 Could not download game! = 
  # Requires translation!
-Could not upload game! = 
+Could not upload game! Reason: [reason] = 
+# Requires translation!
+Auth rejected for unknown reasons, please try again. = 
  # Requires translation!
 Couldn't connect to Multiplayer Server! = 
  # Requires translation!

--- a/core/src/com/unciv/logic/multiplayer/storage/UncivServerFileStorage.kt
+++ b/core/src/com/unciv/logic/multiplayer/storage/UncivServerFileStorage.kt
@@ -3,7 +3,6 @@ package com.unciv.logic.multiplayer.storage
 import com.badlogic.gdx.Net
 import com.badlogic.gdx.utils.Base64Coder
 import com.unciv.utils.debug
-import kotlin.Exception
 
 object UncivServerFileStorage : FileStorage {
     var authHeader: Map<String, String>? = null
@@ -17,7 +16,7 @@ object UncivServerFileStorage : FileStorage {
                 debug("Error from UncivServer during save: %s", result)
                 when (code) {
                     401 -> throw MultiplayerAuthException(Exception(result))
-                    else -> throw Exception(result)
+                    else -> throw Exception("$code $result")
                 }
             }
         }

--- a/core/src/com/unciv/ui/screens/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/WorldScreen.kt
@@ -613,7 +613,7 @@ class WorldScreen(
                             }
                         }
                         else -> {
-                            val message = "Could not upload game!"
+                            val message = "Could not upload game! Reason: [${ex.message ?: "Unknown"}]"
                             launchOnGLThread {
                                 val cantUploadNewGamePopup = Popup(this@WorldScreen)
                                 cantUploadNewGamePopup.addGoodSizedLabel(message).row()


### PR DESCRIPTION
> [!IMPORTANT]
> The `AuthPopup` is a dreaded last boss that players should only see when we are sure that we need it.

Ideally I would have preferred if for anything other than `401`, another popup with status code, status text and response body would show the problem in detail. But the upload usage is too abstracted and trying to restructure it looks would be a lot of work to do. I guess this is better than nothing.