### PR TITLE
Fix Ancient Ruin benefit on higher difficulties

### DIFF
--- a/android/assets/jsons/Civ V - Gods & Kings/Ruins.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Ruins.json
@@ -8,13 +8,13 @@
     {
         "name": "squatters willing to work for you",
         "notification": "A [Worker] has joined us!",
-        "uniques": ["Free [Worker] found in the ruins"],
+        "uniques": ["Free [Worker] found in the ruins", "Unavailable <on [Prince] difficulty or higher>"],
         "excludedDifficulties": ["Prince", "King", "Emperor", "Immortal", "Deity"]
     },
     {
         "name": "squatters wishing to settle under your rule",
         "notification": "A [Settler] has joined us!",
-        "uniques": ["Free [Settler] found in the ruins"],
+        "uniques": ["Free [Settler] found in the ruins", "Unavailable <on [Prince] difficulty or higher>"],
         "excludedDifficulties": ["Warlord","Prince","King","Emperor","Immortal","Deity"]
     },
     {

--- a/android/assets/jsons/Civ V - Vanilla/Ruins.json
+++ b/android/assets/jsons/Civ V - Vanilla/Ruins.json
@@ -8,13 +8,13 @@
     {
         "name": "squatters willing to work for you",
         "notification": "A [Worker] has joined us!",
-        "uniques": ["Free [Worker] found in the ruins"],
+        "uniques": ["Free [Worker] found in the ruins", "Unavailable <on [Prince] difficulty or higher>"],
         "excludedDifficulties": ["Prince", "King", "Emperor", "Immortal", "Deity"]
     },
     {
         "name": "squatters wishing to settle under your rule",
         "notification": "A [Settler] has joined us!",
-        "uniques": ["Free [Settler] found in the ruins"],
+        "uniques": ["Free [Settler] found in the ruins", "Unavailable <on [Prince] difficulty or higher>"],
         "excludedDifficulties": ["Warlord","Prince","King","Emperor","Immortal","Deity"]
     },
     {


### PR DESCRIPTION
Following https://github.com/yairm210/Unciv/pull/13700 , this change makes Ancient Ruins benefits for a free settler/worker only available on easier difficulties. I thought I had applied the unique conditional on that PR, but alas, I did not.

https://civilization.fandom.com/wiki/Ancient_Ruins_(Civ5)#Game_Info

> On the easier difficulties, two additional awards are possible:
> - A Settler to settle another city.
> - A Worker to build improvements to terrain.

