### PR TITLE
Fix combat conditionals not working correctly

### DIFF
--- a/core/src/com/unciv/logic/civilization/managers/RuinsManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/RuinsManager.kt
@@ -59,9 +59,9 @@ class RuinsManager(
         for (possibleReward in getShuffledPossibleRewards(triggeringUnit)) {
             var atLeastOneUniqueHadEffect = false
             for (unique in possibleReward.uniqueObjects) {
-                atLeastOneUniqueHadEffect =
-                    atLeastOneUniqueHadEffect
-                    || UniqueTriggerActivation.triggerUnique(unique, triggeringUnit, notification = possibleReward.notification, triggerNotificationText = "from the ruins")
+                atLeastOneUniqueHadEffect = atLeastOneUniqueHadEffect ||
+                    (unique.conditionalsApply(triggeringUnit.cache.state) && 
+                        UniqueTriggerActivation.triggerUnique(unique, triggeringUnit, notification = possibleReward.notification, triggerNotificationText = "from the ruins"))
             }
             if (atLeastOneUniqueHadEffect) {
                 rememberReward(possibleReward.name)

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -109,8 +109,6 @@ object UniqueTriggerActivation {
 
         val gameContext = GameContext(civInfo, city, unit, tile)
 
-        if (!unique.conditionalsApply(gameContext)) return null
-
         val chosenCity = relevantCity ?:
             civInfo.cities.firstOrNull { it.isCapital() }
 


### PR DESCRIPTION
I guess solves #11099

Title is somewhat misleading, but this almost exclusively affect combat related conditionals. Currently we double check if the game state is valid before executing the conditional. However, between various changes in the code base and the general expectations when calling ``triggerUnique``, this double check is largely redundant

Virtually all calls to this function have already checked conditionals due to calling ``getTriggeredUniques``. The few calls that do not are:
- UnitManager, which actually still manually checks conditionals
- Ruins Manager, fixed with this PR
- Tests, which don't really have a need to check

Extra Notes:
1. This can also be solved by passing in the GameContext to ``triggerUnique``. Thuis may actually be the best solution as the erroneous game state is used for ``UniqueType.OneTimeRemovePolicy``, ``UniqueType.OneTimeRemovePolicyRefund``, and ``UniqueType.OneTimeRemovePolicyRefund``. I've decided not to do that here to avoid needing to go through changing so much of the codebase
2. The code in RuinsManager looks... wrong. Doesn't the logic here mean that if ``atLeastOneUniqueHadEffect`` is true it skips the ``triggerUnique`` call? If so... shouldn't there be an early break? E.g.
```kotlin
            for (unique in possibleReward.uniqueObjects) {
                if (atLeastOneUniqueHadEffect) break
                atLeastOneUniqueHadEffect =
                    unique.conditionalsApply(triggeringUnit.cache.state) && 
                        UniqueTriggerActivation.triggerUnique(unique, triggeringUnit, notification = possibleReward.notification, triggerNotificationText = "from the ruins")
            }
            if (atLeastOneUniqueHadEffect) {
                rememberReward(possibleReward.name)
                break
            }
```
3. I feel like ``GameState`` feels more natural than ``GameContext``. Sorry, irrelevant conversation... just kinda bothers me