### PR TITLE
Add countable for `[stat] Per Turn`

### DIFF
--- a/android/assets/jsons/Civ V - Gods & Kings/Units.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Units.json
@@ -38,7 +38,7 @@
 		"cost": 40,
 		"obsoleteTech": "Metal Casting",
 		"upgradesTo": "Swordsman",
-		"uniques" : ["May upgrade to [Spearman] through ruins-like effects"],
+		"uniques": ["May upgrade to [Spearman] through ruins-like effects"],
 		"attackSound": "nonmetalhit",
         "civilopediaText": [
 			{"text": "This is your basic, club-swinging fighter."}

--- a/android/assets/jsons/Civ V - Gods & Kings/Units.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Units.json
@@ -33,12 +33,15 @@
 	{
 		"name": "Warrior",
 		"unitType": "Sword",
-		"movement": 2,
+		"movement": 1,
 		"strength": 8,
 		"cost": 40,
 		"obsoleteTech": "Metal Casting",
 		"upgradesTo": "Swordsman",
-		"uniques" : ["May upgrade to [Spearman] through ruins-like effects"],
+		"uniques" : [
+            "May upgrade to [Spearman] through ruins-like effects",
+            "[1] Movement <for every [[Culture] Per Turn]>"
+        ],
 		"attackSound": "nonmetalhit",
         "civilopediaText": [
 			{"text": "This is your basic, club-swinging fighter."}

--- a/android/assets/jsons/Civ V - Gods & Kings/Units.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Units.json
@@ -38,7 +38,7 @@
 		"cost": 40,
 		"obsoleteTech": "Metal Casting",
 		"upgradesTo": "Swordsman",
-		"uniques": ["May upgrade to [Spearman] through ruins-like effects"],
+		"uniques" : ["May upgrade to [Spearman] through ruins-like effects"],
 		"attackSound": "nonmetalhit",
         "civilopediaText": [
 			{"text": "This is your basic, club-swinging fighter."}

--- a/android/assets/jsons/Civ V - Gods & Kings/Units.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Units.json
@@ -33,15 +33,12 @@
 	{
 		"name": "Warrior",
 		"unitType": "Sword",
-		"movement": 1,
+		"movement": 2,
 		"strength": 8,
 		"cost": 40,
 		"obsoleteTech": "Metal Casting",
 		"upgradesTo": "Swordsman",
-		"uniques" : [
-            "May upgrade to [Spearman] through ruins-like effects",
-            "[1] Movement <for every [[Culture] Per Turn]>"
-        ],
+		"uniques": ["May upgrade to [Spearman] through ruins-like effects"],
 		"attackSound": "nonmetalhit",
         "civilopediaText": [
 			{"text": "This is your basic, club-swinging fighter."}

--- a/core/src/com/unciv/models/ruleset/unique/Countables.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Countables.kt
@@ -64,7 +64,7 @@ enum class Countables(
     },
 
     Stats {
-        override val documentationHeader = "Stat name (${Stat.names().niceJoin()})"
+        override val documentationHeader = "Stat name (${niceJoinList(Stat.names())})"
         override val documentationStrings = listOf("Gets the stat *reserve*, not the amount per turn (can be city stats or civilization stats, depending on where the unique is used)")
         override fun matches(parameterText: String) = Stat.isStat(parameterText)
         override fun eval(parameterText: String, gameContext: GameContext): Int? {
@@ -77,14 +77,10 @@ enum class Countables(
 
         override val example = "Science"
         override fun getKnownValuesForAutocomplete(ruleset: Ruleset) = Stat.names()
-        @Readonly private fun Iterable<String>.niceJoin() = joinToString("`, `", "`", "`").run {
-            val index = lastIndexOf("`, `")
-            substring(0, index) + "` or `" + substring(index + 4)
-        }
     },
 
     StatPerTurn("[stat] Per Turn", shortDocumentation = "The amount of a stat gained per turn") {
-        override val documentationHeader = "Stat name Per Turn (${Stat.names().niceJoin()})"
+        override val documentationHeader = "Stat name Per Turn (${niceJoinList(Stat.names())})"
         override val documentationStrings = listOf("Gets the amount of a stat the civilization gains per turn")
         override fun eval(parameterText: String, gameContext: GameContext): Int? {
             val statName = parameterText.getPlaceholderParameters().firstOrNull() ?: return null
@@ -97,10 +93,6 @@ enum class Countables(
         override fun getKnownValuesForAutocomplete(ruleset: Ruleset): Set<String> =
             UniqueParameterType.StatName.getKnownValuesForAutocomplete(ruleset)
                 .map { text.fillPlaceholders(it) }.toSet()
-        @Readonly private fun Iterable<String>.niceJoin() = joinToString("`, `", "`", "`").run {
-            val index = lastIndexOf("`, `")
-            substring(0, index) + "` or `" + substring(index + 4)
-        }
         override val example: String = "[Culture] Per Turn"
     },
 
@@ -302,6 +294,14 @@ enum class Countables(
                 .mapNotNull { UniqueParameterType.safeValueOf(it)?.docExample }
             return text.fillPlaceholders(*placeholderParams.toTypedArray())
         }
+
+    /**
+     * Joins a list with `,` while having an or for the last entry. Useful for the documentation headers.
+     */
+    @Readonly fun niceJoinList(list: Iterable<String>) = list.joinToString("`, `", "`", "`").run {
+        val index = lastIndexOf("`, `")
+        substring(0, index) + "` or `" + substring(index + 4)
+    }
 
     /** Leave this only for Countables without any parameters - they can rely on [matches] having validated enough */
     open fun getErrorSeverity(parameterText: String, ruleset: Ruleset): UniqueType.UniqueParameterErrorSeverity? = null

--- a/core/src/com/unciv/models/ruleset/unique/Countables.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Countables.kt
@@ -91,8 +91,7 @@ enum class Countables(
             val statName = parameterText.getPlaceholderParameters().firstOrNull() ?: return null
             val relevantStat = Stat.safeValueOf(statName) ?: return null
             val civ = gameContext.civInfo ?: return null
-            val nextTurnStats = civ.stats.getStatMapForNextTurn()
-            return nextTurnStats.values.map { it[relevantStat] }.sum().toInt()
+            return civ.stats.getStatMapForNextTurn().values.map { it[relevantStat] }.sum().toInt()
         }
         override fun getKnownValuesForAutocomplete(ruleset: Ruleset) = Stat.names().map { "[$it] Per Turn" }.toSet()
         private fun Iterable<String>.niceJoin() = joinToString("`, `", "`", "`").run {

--- a/core/src/com/unciv/models/ruleset/unique/Countables.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Countables.kt
@@ -83,6 +83,31 @@ enum class Countables(
         }
     },
 
+    StatPerTurn("[stat] Per Turn", shortDocumentation = "The amount of a stat gained per turn") {
+        override val documentationHeader = "Stat name (${Stat.names().niceJoin()}) Per Turn"
+        override val documentationStrings = listOf(
+            "Gets the amount of a stat gained per turn."
+        )
+        override fun matches(parameterText: String) = Stat.isStat(parameterText.getPlaceholderParameters().firstOrNull() ?: "")
+        override fun eval(parameterText: String, gameContext: GameContext): Int? {
+            val statName = parameterText.getPlaceholderParameters().firstOrNull() ?: return null
+            val relevantStat = Stat.safeValueOf(statName) ?: return null
+            val civ = gameContext.civInfo
+            if (civ != null) {
+                val nextTurnStats = civ.stats.getStatMapForNextTurn()
+                return nextTurnStats.values.map { it[relevantStat] }.sum().toInt()
+            }
+            return null
+        }
+        override val example: String = "[Culture] Per Turn"
+        override fun getKnownValuesForAutocomplete(ruleset: Ruleset) = Stat.names().map { "[$it] Per Turn" }.toSet()
+
+        private fun Iterable<String>.niceJoin() = joinToString("`, `", "`", "`").run {
+            val index = lastIndexOf("`, `")
+            substring(0, index) + "` or `" + substring(index + 4)
+        }
+    },
+
     PolicyBranches("Completed Policy branches") {
         override fun eval(parameterText: String, gameContext: GameContext) =
             gameContext.civInfo?.getCompletedPolicyBranchesCount()

--- a/core/src/com/unciv/models/ruleset/unique/Countables.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Countables.kt
@@ -84,10 +84,8 @@ enum class Countables(
     },
 
     StatPerTurn("[stat] Per Turn", shortDocumentation = "The amount of a stat gained per turn") {
-        override val documentationHeader = "Stat name (${Stat.names().niceJoin()}) Per Turn"
-        override val documentationStrings = listOf(
-            "Gets the amount of a stat gained per turn."
-        )
+        override val documentationHeader = "Stat name Per Turn (${Stat.names().niceJoin()})"
+        override val documentationStrings = listOf("Gets the amount of a stat the civilization gains per turn")
         override fun matches(parameterText: String) = Stat.isStat(parameterText.getPlaceholderParameters().firstOrNull() ?: "")
         override fun eval(parameterText: String, gameContext: GameContext): Int? {
             val statName = parameterText.getPlaceholderParameters().firstOrNull() ?: return null
@@ -96,9 +94,7 @@ enum class Countables(
             val nextTurnStats = civ.stats.getStatMapForNextTurn()
             return nextTurnStats.values.map { it[relevantStat] }.sum().toInt()
         }
-        override val example: String = "[Culture] Per Turn"
         override fun getKnownValuesForAutocomplete(ruleset: Ruleset) = Stat.names().map { "[$it] Per Turn" }.toSet()
-
         private fun Iterable<String>.niceJoin() = joinToString("`, `", "`", "`").run {
             val index = lastIndexOf("`, `")
             substring(0, index) + "` or `" + substring(index + 4)

--- a/core/src/com/unciv/models/ruleset/unique/Countables.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Countables.kt
@@ -92,12 +92,9 @@ enum class Countables(
         override fun eval(parameterText: String, gameContext: GameContext): Int? {
             val statName = parameterText.getPlaceholderParameters().firstOrNull() ?: return null
             val relevantStat = Stat.safeValueOf(statName) ?: return null
-            val civ = gameContext.civInfo
-            if (civ != null) {
-                val nextTurnStats = civ.stats.getStatMapForNextTurn()
-                return nextTurnStats.values.map { it[relevantStat] }.sum().toInt()
-            }
-            return null
+            val civ = gameContext.civInfo ?: return null
+            val nextTurnStats = civ.stats.getStatMapForNextTurn()
+            return nextTurnStats.values.map { it[relevantStat] }.sum().toInt()
         }
         override val example: String = "[Culture] Per Turn"
         override fun getKnownValuesForAutocomplete(ruleset: Ruleset) = Stat.names().map { "[$it] Per Turn" }.toSet()

--- a/core/src/com/unciv/models/ruleset/unique/Countables.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Countables.kt
@@ -77,7 +77,7 @@ enum class Countables(
 
         override val example = "Science"
         override fun getKnownValuesForAutocomplete(ruleset: Ruleset) = Stat.names()
-        private fun Iterable<String>.niceJoin() = joinToString("`, `", "`", "`").run {
+        @Readonly private fun Iterable<String>.niceJoin() = joinToString("`, `", "`", "`").run {
             val index = lastIndexOf("`, `")
             substring(0, index) + "` or `" + substring(index + 4)
         }
@@ -86,18 +86,22 @@ enum class Countables(
     StatPerTurn("[stat] Per Turn", shortDocumentation = "The amount of a stat gained per turn") {
         override val documentationHeader = "Stat name Per Turn (${Stat.names().niceJoin()})"
         override val documentationStrings = listOf("Gets the amount of a stat the civilization gains per turn")
-        override fun matches(parameterText: String) = Stat.isStat(parameterText.getPlaceholderParameters().firstOrNull() ?: "")
         override fun eval(parameterText: String, gameContext: GameContext): Int? {
             val statName = parameterText.getPlaceholderParameters().firstOrNull() ?: return null
             val relevantStat = Stat.safeValueOf(statName) ?: return null
             val civ = gameContext.civInfo ?: return null
             return civ.stats.getStatMapForNextTurn().values.map { it[relevantStat] }.sum().toInt()
         }
-        override fun getKnownValuesForAutocomplete(ruleset: Ruleset) = Stat.names().map { "[$it] Per Turn" }.toSet()
-        private fun Iterable<String>.niceJoin() = joinToString("`, `", "`", "`").run {
+        override fun getErrorSeverity(parameterText: String, ruleset: Ruleset): UniqueType.UniqueParameterErrorSeverity? =
+            UniqueParameterType.StatName.getTranslatedErrorSeverity(parameterText, ruleset)
+        override fun getKnownValuesForAutocomplete(ruleset: Ruleset): Set<String> =
+            UniqueParameterType.StatName.getKnownValuesForAutocomplete(ruleset)
+                .map { text.fillPlaceholders(it) }.toSet()
+        @Readonly private fun Iterable<String>.niceJoin() = joinToString("`, `", "`", "`").run {
             val index = lastIndexOf("`, `")
             substring(0, index) + "` or `" + substring(index + 4)
         }
+        override val example: String = "[Culture] Per Turn"
     },
 
     PolicyBranches("Completed Policy branches") {
@@ -304,7 +308,7 @@ enum class Countables(
 
     @Readonly fun getDeprecationAnnotation(): Deprecated? = declaringJavaClass.getField(name).getAnnotation(Deprecated::class.java)
 
-    protected fun UniqueParameterType.getTranslatedErrorSeverity(parameterText: String, ruleset: Ruleset): UniqueType.UniqueParameterErrorSeverity? =
+    @Readonly protected fun UniqueParameterType.getTranslatedErrorSeverity(parameterText: String, ruleset: Ruleset): UniqueType.UniqueParameterErrorSeverity? =
         getErrorSeverity(parameterText.getPlaceholderParameters().first(), ruleset)
 
     companion object {

--- a/docs/Modders/Unique-parameters.md
+++ b/docs/Modders/Unique-parameters.md
@@ -356,6 +356,9 @@ Allowed values:
 -   Stat name (`Production`, `Food`, `Gold`, `Science`, `Culture`, `Happiness` or `Faith`)
     - Example: `Only available <when number of [Science] is more than [0]>`
     - Gets the stat *reserve*, not the amount per turn (can be city stats or civilization stats, depending on where the unique is used)
+-   Stat name Per Turn (`Production`, `Food`, `Gold`, `Science`, `Culture`, `Happiness` or `Faith`)
+    - Example: `Only available <when number of [[Culture] Per Turn] is more than [0]>`
+    - Gets the amount of a stat the civilization gains per turn
 -   `Completed Policy branches`
     - Example: `Only available <when number of [Completed Policy branches] is more than [0]>`
 -   `[cityFilter] Cities`


### PR DESCRIPTION
This is not working currently, as there are `@Readonly` issues. But I believe the logic should work. The goal is to have the ability to get a countable of how much stats the civ is getting per turn.

This would allow something silly like...
```
[1] Movement <for every [[Culture] Per Turn]>
```

But also hopefully paves the way for a [BNW Cultural Victory/Tourism victory](https://civilization.fandom.com/wiki/Cultural_victory_(Civ5)#Brave_New_World) type.


Is this the right thing to use for that?

```
val nextTurnStats = civ.stats.getStatMapForNextTurn()
return nextTurnStats.values.map { it[relevantStat] }.sum().toInt()
```

There is a problem with that though, since getStatMapFroNextTurn() calls a few functions that are not `@Readonly`.
