### PR TITLE
Add Victory Type for Brave New World

### DIFF
--- a/core/src/com/unciv/ui/screens/victoryscreen/VictoryScreenIllustrations.kt
+++ b/core/src/com/unciv/ui/screens/victoryscreen/VictoryScreenIllustrations.kt
@@ -15,6 +15,8 @@ import com.badlogic.gdx.utils.Align
 import com.badlogic.gdx.utils.Disposable
 import com.unciv.logic.GameInfo
 import com.unciv.logic.civilization.Civilization
+import com.unciv.models.ruleset.unique.Countables
+import com.unciv.models.ruleset.unique.GameContext
 import com.unciv.models.ruleset.MilestoneType
 import com.unciv.models.ruleset.Victory
 import com.unciv.models.translations.tr
@@ -242,6 +244,13 @@ class VictoryScreenIllustrations(
                 MilestoneType.CompletePolicyBranches -> {
                     total += milestone.params[0].toInt()
                     civ.policies.completedBranches.size
+                }
+                MilestoneType.MoreCountableThanEachPlayer -> {
+                    total += game.civilizations.count { it.isMajorCiv() && it.isAlive() }
+                    game.civilizations.count {
+                        it != civ && it.isMajorCiv() && it.isAlive() && civ.knows(it) &&
+                        (Countables.getCountableAmount(milestone.params[0], GameContext(civ)) ?: 0) > (Countables.getCountableAmount(milestone.params[1], GameContext(it)) ?: 0)
+                    }
                 }
                 MilestoneType.WorldReligion -> {
                     total += game.civilizations.count { it.isMajorCiv() && it.isAlive() }

--- a/docs/Modders/Mod-file-structure/5-Miscellaneous-JSON-files.md
+++ b/docs/Modders/Mod-file-structure/5-Miscellaneous-JSON-files.md
@@ -374,6 +374,7 @@ Currently the following milestones are supported:
 | Win diplomatic vote                | At any point in the game win a diplomatic vote (UN). You may lose afterwards and still retain this milestone |
 | Become the world religion          | Have your religion be the majority religion in a majority of cities of all major civs                        |
 | Have highest score after max turns | Basically time victory. Enables the 'max turn' slider and calculates score when that amount is reached       |
+| Have more [countable] than the [countable] of each player | Have more [countable] than each other player's [countable].                           |
 
 ## Civilopedia text
 


### PR DESCRIPTION
This is some initial work on getting the [Brave New World Cultural Victory](https://civilization.fandom.com/wiki/Cultural_victory_(Civ5)#Brave_New_World) functioning. Essentially, you have to have more Tourism than every other player's accumulated Culture.

### Unciv

To translate this into Unciv terms, it's having more `[countable]` than each other player's `[countable]`.

```
{
    "name": "Cultural",
    "victoryScreenHeader": "Have more [Tourism]\nthan each player's [Total Culture]",
    "milestones": [
		"Have more [Tourism] than the [Total Culture] of each player"
	],
    "victoryString": "You have achieved victory through the awesome power of your Culture. Your civilization's greatness - the magnificence of its monuments and the power of its artists - have astounded the world! Poets will honor you as long as beauty brings gladness to a weary heart.",
    "defeatString": "You have been defeated. Your civilization has been overwhelmed by its many foes. But your people do not despair, for they know that one day you shall return - and lead them forward to victory!"
}
```

See a demonstration over at https://github.com/RobLoach/Civ-V-Brave-New-World/pull/143

<img width="1003" height="736" alt="Screenshot_from_2025-08-13_20-34-21" src="https://github.com/user-attachments/assets/90d7fd6b-9042-45c5-a014-da5728f377a7" />

### TODO

- [ ] Clean up the texts
- [ ] Display it as a %
- [ ] Make sure it's translatable