### PR TITLE
Victory countable more than others

### DIFF
--- a/core/src/com/unciv/models/ruleset/Victory.kt
+++ b/core/src/com/unciv/models/ruleset/Victory.kt
@@ -28,7 +28,7 @@ enum class MilestoneType(val text: String) {
     WorldReligion("Become the world religion"),
     WinDiplomaticVote("Win diplomatic vote"),
     ScoreAfterTimeOut("Have highest score after max turns"),
-    MoreCountableThanEachPlayer("Have more [countable] than the [countable] of each player"),
+    MoreCountableThanEachPlayer("Have more [countable] than each player's [countable]"),
 }
 
 class Victory : INamed {
@@ -115,7 +115,7 @@ class Milestone(val uniqueDescription: String, private val parentVictory: Victor
                 civInfo.policies.completedBranches.size >= params[0].toInt()
             MilestoneType.MoreCountableThanEachPlayer ->
                 civInfo.gameInfo.civilizations.count {
-                    it != civInfo && it.isMajorCiv() && it.isAlive() && civInfo.knows(it) &&
+                    it != civInfo && it.isMajorCiv() && it.isAlive() &&
                     (Countables.getCountableAmount(params[0], GameContext(civInfo)) ?: 0) > (Countables.getCountableAmount(params[1], GameContext(it)) ?: 0)
                 } >= civInfo.gameInfo.civilizations.count {
                     it != civInfo && it.isMajorCiv() && it.isAlive()

--- a/core/src/com/unciv/models/ruleset/Victory.kt
+++ b/core/src/com/unciv/models/ruleset/Victory.kt
@@ -306,9 +306,9 @@ class Milestone(val uniqueDescription: String, private val parentVictory: Victor
                     if (hideCivCount && !civInfo.knows(civ)) continue
 
                     val completed = (Countables.getCountableAmount(params[0], GameContext(civInfo)) ?: 0) > (Countables.getCountableAmount(params[1], GameContext(civ)) ?: 0)
-                    val milestoneText =
-                        if (civInfo.knows(civ) || completed) "More [${params[0]}] than [${civ.civName}]'s [${params[1]}]"
-                        else "More [${params[0]}] than [${Constants.unknownNationName}]'s [${params[1]}]"
+                    val percent = (Countables.getCountableAmount(params[0], GameContext(civInfo)) ?: 0).toFloat() / (Countables.getCountableAmount(params[1], GameContext(civ)) ?: 0).toFloat() * 100f
+                    val civName = if (civInfo.knows(civ)) civ.civName else Constants.unknownNationName
+                    val milestoneText = if (completed) "[${civName}]" else "[${civName}] [${percent.toInt()}]%"
                     buttons.add(getMilestoneButton(milestoneText, completed))
                 }
                 if (hideCivCount) buttons.add(getMilestoneButton("More [${params[0]}] than [${Constants.unknownNationName}]'s [${params[1]}]", false))

--- a/core/src/com/unciv/ui/screens/victoryscreen/VictoryScreenIllustrations.kt
+++ b/core/src/com/unciv/ui/screens/victoryscreen/VictoryScreenIllustrations.kt
@@ -246,9 +246,10 @@ class VictoryScreenIllustrations(
                     civ.policies.completedBranches.size
                 }
                 MilestoneType.MoreCountableThanEachPlayer -> {
-                    total += game.civilizations.count { it.isMajorCiv() && it.isAlive() }
+                    total += if (selectedCiv.shouldHideCivCount()) game.gameParameters.maxNumberOfPlayers
+                        else game.civilizations.count { it != civ && it.isMajorCiv() && it.isAlive() }
                     game.civilizations.count {
-                        it != civ && it.isMajorCiv() && it.isAlive() && civ.knows(it) &&
+                        it != civ && it.isMajorCiv() && it.isAlive() &&
                         (Countables.getCountableAmount(milestone.params[0], GameContext(civ)) ?: 0) > (Countables.getCountableAmount(milestone.params[1], GameContext(it)) ?: 0)
                     }
                 }


### PR DESCRIPTION
This is some initial work on getting the [Brave New World Cultural Victory](https://civilization.fandom.com/wiki/Cultural_victory_(Civ5)#Brave_New_World) functioning. Essentially, you have to have more Tourism than every other player's accumulated Culture.

### Unciv

To translate this into Unciv terms, it's having more `[countable]` than each other player's `[countable]`.

```
{
    "name": "Cultural",
    "victoryScreenHeader": "Have more [Tourism]\nthan each player's [Total Culture]",
    "milestones": [
		"Have more [Tourism] than the [Total Culture] of each player"
	],
    "victoryString": "You have achieved victory through the awesome power of your Culture. Your civilization's greatness - the magnificence of its monuments and the power of its artists - have astounded the world! Poets will honor you as long as beauty brings gladness to a weary heart.",
    "defeatString": "You have been defeated. Your civilization has been overwhelmed by its many foes. But your people do not despair, for they know that one day you shall return - and lead them forward to victory!"
}
```

See a demonstration over at https://github.com/RobLoach/Civ-V-Brave-New-World/pull/143

<img width="1003" height="736" alt="Screenshot_from_2025-08-13_20-34-21" src="https://github.com/user-attachments/assets/90d7fd6b-9042-45c5-a014-da5728f377a7" />

### TODO

- [ ] Clean up the texts
- [x] Display it as a %
- [ ] Make sure it's translatable