### PR TITLE
Add unique to get resources from a percent of stat yield

### DIFF
--- a/core/src/com/unciv/logic/automation/city/ConstructionAutomation.kt
+++ b/core/src/com/unciv/logic/automation/city/ConstructionAutomation.kt
@@ -297,6 +297,7 @@ class ConstructionAutomation(val cityConstructions: CityConstructions) {
         } else value += when {
             building.hasUnique(UniqueType.CreatesOneImprovement) -> 5f // District-type buildings, should be weighed by the stats (incl. adjacencies) of the improvement
             building.hasUnique(UniqueType.ProvidesResources) -> 2f // Should be weighed by how much we need the resources
+            building.hasUnique(UniqueType.StatPercentFromObjectToResource) -> 2f // Should be weighed by how much we need the resources
             else -> 0f
         }
         return value

--- a/core/src/com/unciv/models/ruleset/tile/TileResource.kt
+++ b/core/src/com/unciv/models/ruleset/tile/TileResource.kt
@@ -129,7 +129,11 @@ class TileResource : RulesetStatsObject(), GameResource {
         val improvementsThatProvideThis = ruleset.tileImprovements.values
             .filter { improvement ->
                 improvement.uniqueObjects.any { unique ->
-                    unique.type == UniqueType.ProvidesResources && unique.params[1] == name
+                    when (unique.type) {
+                        UniqueType.ProvidesResources -> unique.params[1] == name
+                        UniqueType.StatPercentFromObjectToResource -> unique.params[3] == name
+                        else -> false
+                    }
                 }
             }
         if (improvementsThatProvideThis.isNotEmpty()) {
@@ -143,7 +147,11 @@ class TileResource : RulesetStatsObject(), GameResource {
         val buildingsThatProvideThis = ruleset.buildings.values
             .filter { building ->
                 building.uniqueObjects.any { unique ->
-                    unique.type == UniqueType.ProvidesResources && unique.params[1] == name
+                    when (unique.type) {
+                        UniqueType.ProvidesResources -> unique.params[1] == name
+                        UniqueType.StatPercentFromObjectToResource -> unique.params[3] == name
+                        else -> false
+                    }
                 }
             }
         if (buildingsThatProvideThis.isNotEmpty()) {

--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -102,7 +102,7 @@ object UniqueTriggerActivation {
         if (timingConditional != null) {
             return {
                 civInfo.temporaryUniques.add(TemporaryUnique(unique, timingConditional.params[0].toInt()))
-                if (unique.type in setOf(UniqueType.ProvidesResources, UniqueType.ConsumesResources))
+                if (unique.type in setOf(UniqueType.ProvidesResources, UniqueType.ConsumesResources, UniqueType.StatPercentFromObjectToResource))
                     civInfo.cache.updateCivResources()
                 true
             }

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -47,6 +47,7 @@ enum class UniqueType(
     StatPercentBonus("[relativeAmount]% [stat]", UniqueTarget.Global, UniqueTarget.FollowerBelief),
     StatPercentBonusCities("[relativeAmount]% [stat] [cityFilter]", UniqueTarget.Global, UniqueTarget.FollowerBelief),
     StatPercentFromObject("[relativeAmount]% [stat] from every [tileFilter/buildingFilter]", UniqueTarget.Global, UniqueTarget.FollowerBelief),
+    StatPercentFromObjectToResource("[positiveAmount]% of [stat] output from every [tileFilter/buildingFilter] in the city added to [resource]", UniqueTarget.Global),
     AllStatsPercentFromObject("[relativeAmount]% Yield from every [tileFilter/buildingFilter]", UniqueTarget.Global, UniqueTarget.FollowerBelief),
     StatPercentFromReligionFollowers("[relativeAmount]% [stat] from every follower, up to [relativeAmount]%", UniqueTarget.FollowerBelief, UniqueTarget.FounderBelief),
     BonusStatsFromCityStates("[relativeAmount]% [stat] from City-States", UniqueTarget.Global),

--- a/core/src/com/unciv/models/ruleset/validation/UniqueValidator.kt
+++ b/core/src/com/unciv/models/ruleset/validation/UniqueValidator.kt
@@ -183,7 +183,7 @@ class UniqueValidator(val ruleset: Ruleset) {
     }
 
     private val resourceUniques = setOf(UniqueType.ProvidesResources, UniqueType.ConsumesResources,
-        UniqueType.PercentResourceProduction)
+        UniqueType.PercentResourceProduction, UniqueType.StatPercentFromObjectToResource)
     private val resourceConditionals = setOf(
         UniqueType.ConditionalWithResource,
         UniqueType.ConditionalWithoutResource,

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -392,6 +392,11 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 	Applicable to: Global, FollowerBelief
 
+??? example  "[positiveAmount]% of [stat] output from every [tileFilter/buildingFilter] in the city added to [resource]"
+	Example: "[3]% of [Culture] output from every [Farm] in the city added to [Iron]"
+
+	Applicable to: Global
+
 ??? example  "[relativeAmount]% Yield from every [tileFilter/buildingFilter]"
 	Example: "[+20]% Yield from every [Farm]"
 

--- a/tests/src/com/unciv/uniques/ResourceTests.kt
+++ b/tests/src/com/unciv/uniques/ResourceTests.kt
@@ -167,6 +167,20 @@ class ResourceTests {
     }
 
     @Test
+    fun `should get a percent of stat as a resource`() {
+        // given
+        city.cityConstructions.addBuilding("Monument")
+        var building = game.createBuilding("[200]% of [Culture] output from every [Monument] in the city added to [Iron]")
+        city.cityConstructions.addBuilding(building)
+
+        // when
+        val amount = city.getAvailableResourceAmount("Iron")
+
+        // then
+        assertEquals(4, amount) // 2 Culture * 2
+    }
+
+    @Test
     fun `should reduce resources due to buildings`() {
         // given
         city.cityConstructions.addBuilding("Factory")


### PR DESCRIPTION
In BNW, the [Hotel](https://civilization.fandom.com/wiki/Hotel_(Civ5)) has a unique that reads...

> 50% of the Culture output of Wonders and Improvements in the city added to Tourism

So, this pull request attempts to add that as...

```
[positiveAmount]% of [stat] output from every [tileFilter/buildingFilter] in the city added to [resource]
```

It results in the mod as https://github.com/RobLoach/Civ-V-Brave-New-World/pull/159 ...
```
[50]% of [Culture] output from every [Wonder] in the city added to [Tourism]
[50]% of [Culture] output from every [Improvement] in the city added to [Tourism]
```

### Questions

- Is the verbiage is correct?
- Is having "in the city" within the unique here right?
- It's marked as `UniqueTarget.Global`. Should it be `.Building` instead?
