### PR TITLE
Add unique to get resources from a percent of stat yield

### DIFF
--- a/core/src/com/unciv/logic/city/CityResources.kt
+++ b/core/src/com/unciv/logic/city/CityResources.kt
@@ -69,7 +69,7 @@ object CityResources {
             )
         }
 
-        // StatPercentFromObjectToResource - Example: "[50]% of [Culture] output from every [tileFilter/buildingFilter] in the city added to [Iron]"
+        // StatPercentFromObjectToResource - Example: "[50]% of [Culture] from every [tileFilter/buildingFilter] in the city added to [Iron]"
         for (unique in city.getMatchingUniques(UniqueType.StatPercentFromObjectToResource, city.state, false)) {
             val resource = city.getRuleset().tileResources[unique.params[3]] ?: continue
             val stat = Stat.safeValueOf(unique.params[1]) ?: continue
@@ -131,7 +131,7 @@ object CityResources {
                 )
             }
 
-            // StatPercentFromObjectToResource - Example: "[50]% of [Culture] output from every [tileFilter/buildingFilter] in the city added to [Iron]"
+            // StatPercentFromObjectToResource - Example: "[50]% of [Culture] from every [tileFilter/buildingFilter] in the city added to [Iron]"
             for (unique in tileImprovement!!.getMatchingUniques(UniqueType.StatPercentFromObjectToResource, gameContext)) {
                 val resource = city.getRuleset().tileResources[unique.params[3]] ?: continue
                 val stat = Stat.safeValueOf(unique.params[1]) ?: continue
@@ -171,7 +171,7 @@ object CityResources {
             )
         }
 
-        // StatPercentFromObjectToResource - Example: "[50]% of [Culture] output from every [tileFilter/buildingFilter] in the city added to [Iron]"
+        // StatPercentFromObjectToResource - Example: "[50]% of [Culture] from every [tileFilter/buildingFilter] in the city added to [Iron]"
         for (unique in city.getMatchingUniques(UniqueType.StatPercentFromObjectToResource, city.state)) {
             val resource = city.getRuleset().tileResources[unique.params[3]] ?: continue
             val stat = Stat.safeValueOf(unique.params[1]) ?: continue

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -47,7 +47,7 @@ enum class UniqueType(
     StatPercentBonus("[relativeAmount]% [stat]", UniqueTarget.Global, UniqueTarget.FollowerBelief),
     StatPercentBonusCities("[relativeAmount]% [stat] [cityFilter]", UniqueTarget.Global, UniqueTarget.FollowerBelief),
     StatPercentFromObject("[relativeAmount]% [stat] from every [tileFilter/buildingFilter]", UniqueTarget.Global, UniqueTarget.FollowerBelief),
-    StatPercentFromObjectToResource("[positiveAmount]% of [stat] output from every [tileFilter/buildingFilter] in the city added to [resource]", UniqueTarget.Global),
+    StatPercentFromObjectToResource("[positiveAmount]% of [stat] from every [tileFilter/buildingFilter] in the city added to [resource]", UniqueTarget.Global),
     AllStatsPercentFromObject("[relativeAmount]% Yield from every [tileFilter/buildingFilter]", UniqueTarget.Global, UniqueTarget.FollowerBelief),
     StatPercentFromReligionFollowers("[relativeAmount]% [stat] from every follower, up to [relativeAmount]%", UniqueTarget.FollowerBelief, UniqueTarget.FounderBelief),
     BonusStatsFromCityStates("[relativeAmount]% [stat] from City-States", UniqueTarget.Global),

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -392,8 +392,8 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 	Applicable to: Global, FollowerBelief
 
-??? example  "[positiveAmount]% of [stat] output from every [tileFilter/buildingFilter] in the city added to [resource]"
-	Example: "[3]% of [Culture] output from every [Farm] in the city added to [Iron]"
+??? example  "[positiveAmount]% of [stat] from every [tileFilter/buildingFilter] in the city added to [resource]"
+	Example: "[3]% of [Culture] from every [Farm] in the city added to [Iron]"
 
 	Applicable to: Global
 

--- a/tests/src/com/unciv/uniques/ResourceTests.kt
+++ b/tests/src/com/unciv/uniques/ResourceTests.kt
@@ -170,7 +170,7 @@ class ResourceTests {
     fun `should get a percent of stat as a resource`() {
         // given
         city.cityConstructions.addBuilding("Monument")
-        var building = game.createBuilding("[200]% of [Culture] output from every [Monument] in the city added to [Iron]")
+        var building = game.createBuilding("[200]% of [Culture] from every [Monument] in the city added to [Iron]")
         city.cityConstructions.addBuilding(building)
 
         // when


### PR DESCRIPTION
In BNW, the [Hotel](https://civilization.fandom.com/wiki/Hotel_(Civ5)) has a unique that reads...

> 50% of the Culture of Wonders and Improvements in the city added to Tourism

So, this pull request attempts to add that as...

```
[positiveAmount]% of [stat] from every [tileFilter/buildingFilter] in the city added to [resource]
```

It results in the mod as https://github.com/RobLoach/Civ-V-Brave-New-World/pull/159 ...
```
[50]% of [Culture] from every [Wonder] in the city added to [Tourism]
[50]% of [Culture] from every [Improvement] in the city added to [Tourism]
```

### Questions

- Is the verbiage is correct?
- Is having "in the city" within the unique here right?
- It's marked as `UniqueTarget.Global`. Should it be `.Building` instead?
