### PR TITLE
Bugfix: add missing brackets to thirdCivCombatStrengthRatio

### DIFF
--- a/core/src/com/unciv/logic/automation/civilization/MotivationToAttackAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/MotivationToAttackAutomation.kt
@@ -257,7 +257,7 @@ object MotivationToAttackAutomation {
     private fun getDefensivePactAlliesScore(otherCiv: Civilization, civInfo: Civilization, baseForce: Float, ourCombatStrength: Float): Float {
         var theirAlliesValue = 0f
         for (thirdCiv in otherCiv.diplomacy.values.filter { it.hasFlag(DiplomacyFlags.DefensivePact) && it.otherCiv() != civInfo }) {
-            val thirdCivCombatStrengthRatio = otherCiv.getStatForRanking(RankingType.Force).toFloat() + baseForce / ourCombatStrength
+            val thirdCivCombatStrengthRatio = (otherCiv.getStatForRanking(RankingType.Force).toFloat() + baseForce) / ourCombatStrength
             theirAlliesValue += when {
                 thirdCivCombatStrengthRatio > 5 -> -15f
                 thirdCivCombatStrengthRatio > 2.5 -> -10f


### PR DESCRIPTION
Kotlin does multiplication before addition, so this would always be >1