### PR TITLE
Add diplomacy status to `civFilter`

### DIFF
--- a/core/src/com/unciv/logic/civilization/Civilization.kt
+++ b/core/src/com/unciv/logic/civilization/Civilization.kt
@@ -573,6 +573,9 @@ class Civilization : IsPartOfGameInfoSerialization {
         return when (filter) {
             "Human player" -> isHuman()
             "AI player" -> isAI()
+            "Open Borders" -> state?.civInfo?.diplomacy[civName]?.hasOpenBorders ?: false
+            "Peace" -> state?.civInfo?.let { !diplomacyFunctions.isAtWarWith(it) } ?: false
+            "War" -> state?.civInfo?.let { diplomacyFunctions.isAtWarWith(it) } ?: false
             else -> nation.matchesFilter(filter, state, false)
         }
     }

--- a/core/src/com/unciv/logic/civilization/Civilization.kt
+++ b/core/src/com/unciv/logic/civilization/Civilization.kt
@@ -16,6 +16,7 @@ import com.unciv.logic.civilization.diplomacy.CityStatePersonality
 import com.unciv.logic.civilization.diplomacy.DiplomacyFunctions
 import com.unciv.logic.civilization.diplomacy.DiplomacyManager
 import com.unciv.logic.civilization.diplomacy.DiplomaticStatus
+import com.unciv.logic.civilization.diplomacy.RelationshipLevel
 import com.unciv.logic.civilization.managers.EspionageManager
 import com.unciv.logic.civilization.managers.GoldenAgeManager
 import com.unciv.logic.civilization.managers.GreatPersonManager
@@ -574,8 +575,8 @@ class Civilization : IsPartOfGameInfoSerialization {
             "Human player" -> isHuman()
             "AI player" -> isAI()
             "Open Borders" -> state?.civInfo?.diplomacy[civName]?.hasOpenBorders ?: false
-            "Peace" -> state?.civInfo?.let { !diplomacyFunctions.isAtWarWith(it) } ?: false
-            "War" -> state?.civInfo?.let { diplomacyFunctions.isAtWarWith(it) } ?: false
+            "Friendly" -> state?.civInfo?.diplomacy[civName]?.isRelationshipLevelGE(RelationshipLevel.Friend) ?: false
+            "Hostile" -> state?.civInfo?.let { isAtWarWith(it) } ?: false
             else -> nation.matchesFilter(filter, state, false)
         }
     }

--- a/core/src/com/unciv/logic/civilization/Civilization.kt
+++ b/core/src/com/unciv/logic/civilization/Civilization.kt
@@ -575,7 +575,7 @@ class Civilization : IsPartOfGameInfoSerialization {
             "Human player" -> isHuman()
             "AI player" -> isAI()
             "Open Borders" -> state?.civInfo?.diplomacy[civName]?.hasOpenBorders ?: false
-            "Friendly" -> state?.civInfo?.diplomacy[civName]?.isRelationshipLevelGE(RelationshipLevel.Friend) ?: false
+            "Friendly" -> state?.civInfo?.let { it.civName == civName || (it.diplomacy[civName]?.isRelationshipLevelGE(RelationshipLevel.Friend) == true) } ?: false
             "Hostile" -> state?.civInfo?.let { isAtWarWith(it) } ?: false
             else -> nation.matchesFilter(filter, state, false)
         }

--- a/core/src/com/unciv/models/ruleset/unique/Countables.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Countables.kt
@@ -153,11 +153,13 @@ enum class Countables(
         override fun eval(parameterText: String, gameContext: GameContext): Int? {
             val filter = parameterText.getPlaceholderParameters()[0]
             val civilizations = gameContext.gameInfo?.civilizations ?: return null
-            return civilizations.count { it.isAlive() && it.matchesFilter(filter) }
+            return civilizations.count { it.isAlive() && it.matchesFilter(filter, gameContext) }
         }
         override fun getErrorSeverity(parameterText: String, ruleset: Ruleset): UniqueType.UniqueParameterErrorSeverity? =
             UniqueParameterType.CivFilter.getTranslatedErrorSeverity(parameterText, ruleset)
-        override fun getKnownValuesForAutocomplete(ruleset: Ruleset) = setOf<String>()
+        override fun getKnownValuesForAutocomplete(ruleset: Ruleset): Set<String> =
+            UniqueParameterType.CivFilter.getKnownValuesForAutocomplete(ruleset)
+                .map { text.fillPlaceholders(it) }.toSet()
     },
     OwnedTiles("Owned [tileFilter] Tiles") {
         override fun eval(parameterText: String, gameContext: GameContext): Int? {

--- a/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
@@ -215,7 +215,7 @@ enum class UniqueParameterType(
 
     /** Implemented by [Civ.matchesFilter][com.unciv.logic.civilization.Civilization.matchesFilter] */
     CivFilter("civFilter", Constants.cityStates) {
-        override val staticKnownValues = setOf("AI player", "Human player")
+        override val staticKnownValues = setOf("AI player", "Human player", "Open Borders", "Peace", "War")
 
         override fun getErrorSeverity(parameterText: String, ruleset: Ruleset) = getErrorSeverityForFilter(parameterText, ruleset)
 

--- a/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueParameterType.kt
@@ -215,7 +215,7 @@ enum class UniqueParameterType(
 
     /** Implemented by [Civ.matchesFilter][com.unciv.logic.civilization.Civilization.matchesFilter] */
     CivFilter("civFilter", Constants.cityStates) {
-        override val staticKnownValues = setOf("AI player", "Human player", "Open Borders", "Peace", "War")
+        override val staticKnownValues = setOf("AI player", "Human player", "Open Borders", "Friendly", "Hostile")
 
         override fun getErrorSeverity(parameterText: String, ruleset: Ruleset) = getErrorSeverityForFilter(parameterText, ruleset)
 


### PR DESCRIPTION
This adds the ability to use `Open Borders`, `Friendly`, and `Hostile` within `civFilter` to check diplomacy across civs. I'm unsure if it's the right approach, so let me know what you think.

## Use Case

In BNW, an Open Borders treaty nets you a 25% bonus to Tourism with the civ, so long as it's active. In Unciv terms, we may be able to accomplish that with...
```
[25]% [Tourism] resource production <for every [Remaining [Open Borders] Civilizations]>
```

I'm not 100% sure this is the correct approach here, so would love some feedback.
