### PR TITLE
Have the Trigger Event Unit Action text be the Event Name

### DIFF
--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsFromUniques.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsFromUniques.kt
@@ -255,6 +255,7 @@ object UnitActionsFromUniques {
                         stat
                     )
                 }
+                UniqueType.TriggerEvent -> unique.params[0]
                 else -> unique.text.removeConditionals()
             }
             val title = UnitActionModifiers.actionTextWithSideEffects(baseTitle, unique, unit)


### PR DESCRIPTION
This small change makes it so that when the unit can trigger an event, the event name is used for the action text rather than "Triggers a event".

### Before


<img width="988" height="720" alt="Screenshot from 2025-09-03 00-43-18" src="https://github.com/user-attachments/assets/2524ece6-8c09-4d78-8736-c78ac5d85301" />

### After

<img width="819" height="737" alt="Screenshot from 2025-09-03 00-41-25" src="https://github.com/user-attachments/assets/7917f649-7539-4e98-b70e-0bb470c9285b" />

