### PR TITLE
Updated max window in Windows platform

### DIFF
--- a/desktop/src/com/unciv/app/desktop/DesktopDisplay.kt
+++ b/desktop/src/com/unciv/app/desktop/DesktopDisplay.kt
@@ -5,8 +5,6 @@ import com.badlogic.gdx.Graphics.Monitor
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3ApplicationConfiguration
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Graphics
-import com.badlogic.gdx.utils.Os
-import com.badlogic.gdx.utils.SharedLibraryLoader
 import com.unciv.models.metadata.GameSettings
 import com.unciv.models.translations.tr
 import com.unciv.utils.PlatformDisplay
@@ -26,9 +24,6 @@ enum class DesktopScreenMode : ScreenMode {
             val isFillingDesktop = setWindowedMode(settings)
             if (isFillingDesktop)
                 getWindow()?.maximizeWindow()
-            if (SharedLibraryLoader.os == Os.Windows) {
-                getWindow()?.maximizeWindow()
-            }
         }
 
         override fun hasUserSelectableSize() = true
@@ -73,7 +68,10 @@ enum class DesktopScreenMode : ScreenMode {
 
         Gdx.graphics.setWindowedMode(width, height)
 
-        return width == maximumWindowBounds.width && height == maximumWindowBounds.height
+        val widthDiff = maximumWindowBounds.width - width
+        val heightDiff = maximumWindowBounds.height - height
+        val tolerance = 30
+        return widthDiff <= tolerance && heightDiff <= tolerance
     }
 
     companion object {

--- a/desktop/src/com/unciv/app/desktop/DesktopDisplay.kt
+++ b/desktop/src/com/unciv/app/desktop/DesktopDisplay.kt
@@ -5,6 +5,8 @@ import com.badlogic.gdx.Graphics.Monitor
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3ApplicationConfiguration
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Graphics
+import com.badlogic.gdx.utils.Os
+import com.badlogic.gdx.utils.SharedLibraryLoader
 import com.unciv.models.metadata.GameSettings
 import com.unciv.models.translations.tr
 import com.unciv.utils.PlatformDisplay
@@ -24,6 +26,9 @@ enum class DesktopScreenMode : ScreenMode {
             val isFillingDesktop = setWindowedMode(settings)
             if (isFillingDesktop)
                 getWindow()?.maximizeWindow()
+            if (SharedLibraryLoader.os == Os.Windows) {
+                getWindow()?.maximizeWindow()
+            }
         }
 
         override fun hasUserSelectableSize() = true


### PR DESCRIPTION
The DesktopDisplay doesn't max screen well in Windows Platform

# Before 
<img width="1920" height="1080" alt="Screenshot 2025-09-03 123919" src="https://github.com/user-attachments/assets/2ed2c144-0916-48e1-9ef1-7dd8baf41228" />

# After
<img width="1920" height="1080" alt="Screenshot 2025-09-03 135305" src="https://github.com/user-attachments/assets/38b67205-fa8c-43fa-946d-3df582d7ebe5" />

