### PR TITLE
Updated Analyse code

### DIFF
--- a/docs/Developers/Building-Locally.md
+++ b/docs/Developers/Building-Locally.md
@@ -40,7 +40,7 @@ By the end of this guide, you will have Unciv running locally from code, so you 
     -   If the "Run unit tests" is missing - look for the top-level "tests" folder, right-klick -> Modify Run Configuration...
 -   Select the Desktop configuration (or however you chose to name it) and click the green arrow button to run! Or you can use the next button -the green critter with six legs and two feelers - to start debugging.
 -   A few Android Studio settings that are recommended:
-    - Going to Settings > Version Control > Commit and turning off 'Before Commit - Analyze code'
+    - Going to Settings > Version Control > Commit > Advanced Commit Checks 'Analyze code'
     - On the same page, we recommend turning off "Use non-modal commit interface". This puts the "Local Changes and "Console" Tabs back into the Git toolpane (and the Shelf once you have shelved diffs). These can be hard to find otherwise - feel free to ignore if you don't think you need them.
     - Settings > Editor > Code Style > Kotlin > Tabs and Indents > Continuation Indent: 4
       ![image](https://user-images.githubusercontent.com/44038014/169315352-9ba0c4cf-307c-44d1-b3bc-2a58752c6854.png)


### PR DESCRIPTION
Reference [link](https://yairm210.github.io/Unciv/Developers/Building-Locally/#with-android-studio)
[Just above `Continuation Indent: 4`]

- The version I'm using has different `Before Commit - Analyze code` 
 
<img width="1230" height="905" alt="Screenshot 2025-09-03 150121" src="https://github.com/user-attachments/assets/38d17a5c-67f6-47ed-bfb0-b0ca74d9df73" />


- I'm confused with `Use non-modal commit interface` while modal commit interface exist as a plugin for me

<img width="1228" height="539" alt="Screenshot 2025-09-03 153011" src="https://github.com/user-attachments/assets/afacf6d2-d466-4ace-a608-4ba9ef60d0a6" />


---

My Android Studio Version

```
Android Studio Narwhal 3 Feature Drop | 2025.1.3
Build #AI-251.26094.121.2513.14007798, built on August 28, 2025
Runtime version: 21.0.7+-13880790-b1038.58 amd64
VM: OpenJDK 64-Bit Server VM by JetBrains s.r.o.
Toolkit: sun.awt.windows.WToolkit
Windows 11.0
Kotlin plugin: K2 mode
GC: G1 Young Generation, G1 Concurrent GC, G1 Old Generation
Memory: 2048M
Cores: 12
Registry:
  ide.experimental.ui=true
  com.android.studio.ml.activeModel=com.android.studio.ml.AidaModel
Non-Bundled Plugins:
  Dart (251.27623.5)
  com.localizely.flutter-intl (1.18.8-2024.2)
  com.gmail.blueboxware.libgdxplugin (1.24.14)
```