### PR TITLE
Refactor DiplomacyScreen human-human relationship methods.

### DIFF
--- a/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
@@ -44,6 +44,21 @@ enum class RelationshipLevel(val color: Color) {
     }
 }
 
+/**
+ * Similar to [RelationshipLevel] but for human-human relationships.
+ * 
+ * Use [DiplomacyManager.humanRelationshipLevel] to get appropriate relationship for a game state.
+ *
+ * (!) Use [HumanRelationshipLevel.text] to retrieve the relationship text string (e.g. "Friend" instead of "DeclarationOfFriendship").
+ */
+enum class HumanRelationshipLevel(val color: Color, val text: String) {
+    War(Color.RED, RelationshipLevel.Enemy.name),
+    Neutral(RelationshipLevel.Neutral.color, RelationshipLevel.Neutral.name),
+    DeclarationOfFriendship(Color.GREEN, RelationshipLevel.Friend.name), // inconsistent with AI DoF color?
+    DefensivePact(RelationshipLevel.Ally.color, Constants.defensivePact)
+    ;
+}
+
 enum class DiplomacyFlags {
     DeclinedLuxExchange,
     DeclinedPeace,
@@ -291,6 +306,16 @@ class DiplomacyManager() : IsPartOfGameInfoSerialization {
         }
     }
 
+    @Readonly
+    fun humanRelationshipLevel(): HumanRelationshipLevel {
+        return when {
+            diplomaticStatus == DiplomaticStatus.DefensivePact -> HumanRelationshipLevel.DefensivePact
+            hasFlag(DiplomacyFlags.DeclarationOfFriendship) -> HumanRelationshipLevel.DeclarationOfFriendship
+            diplomaticStatus == DiplomaticStatus.War -> HumanRelationshipLevel.War
+            else -> HumanRelationshipLevel.Neutral
+        }
+    }
+    
     /** Same as [relationshipLevel] but omits the distinction Neutral/Afraid, which can be _much_ cheaper */
     @Readonly
     fun relationshipIgnoreAfraid(): RelationshipLevel {

--- a/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
@@ -44,21 +44,6 @@ enum class RelationshipLevel(val color: Color) {
     }
 }
 
-/**
- * Similar to [RelationshipLevel] but for human-human relationships.
- * 
- * Use [DiplomacyManager.humanRelationshipLevel] to get appropriate relationship for a game state.
- *
- * (!) Use [HumanRelationshipLevel.text] to retrieve the relationship text string (e.g. "Friend" instead of "DeclarationOfFriendship").
- */
-enum class HumanRelationshipLevel(val color: Color, val text: String) {
-    War(Color.RED, RelationshipLevel.Enemy.name),
-    Neutral(RelationshipLevel.Neutral.color, RelationshipLevel.Neutral.name),
-    DeclarationOfFriendship(Color.GREEN, RelationshipLevel.Friend.name), // inconsistent with AI DoF color?
-    DefensivePact(RelationshipLevel.Ally.color, Constants.defensivePact)
-    ;
-}
-
 enum class DiplomacyFlags {
     DeclinedLuxExchange,
     DeclinedPeace,
@@ -306,13 +291,17 @@ class DiplomacyManager() : IsPartOfGameInfoSerialization {
         }
     }
 
+    /**
+     * For human-human relationships only
+     * @return [Pair] of [Color] (relationship color) and [String] (relationship text, e.g. "Friend")
+     */
     @Readonly
-    fun humanRelationshipLevel(): HumanRelationshipLevel {
+    fun humanRelationshipLevel(): Pair<Color, String> {
         return when {
-            diplomaticStatus == DiplomaticStatus.DefensivePact -> HumanRelationshipLevel.DefensivePact
-            hasFlag(DiplomacyFlags.DeclarationOfFriendship) -> HumanRelationshipLevel.DeclarationOfFriendship
-            diplomaticStatus == DiplomaticStatus.War -> HumanRelationshipLevel.War
-            else -> HumanRelationshipLevel.Neutral
+            diplomaticStatus == DiplomaticStatus.DefensivePact -> Pair(RelationshipLevel.Ally.color, Constants.defensivePact)
+            hasFlag(DiplomacyFlags.DeclarationOfFriendship) -> Pair(Color.GREEN, RelationshipLevel.Friend.name)
+            diplomaticStatus == DiplomaticStatus.War -> Pair(Color.RED, RelationshipLevel.Enemy.name)
+            else -> Pair(RelationshipLevel.Neutral.color, RelationshipLevel.Neutral.name)
         }
     }
     

--- a/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
@@ -28,6 +28,7 @@ import kotlin.math.sign
 enum class RelationshipLevel(val color: Color) {
     // DiplomaticStatus.War is tested separately for the Diplomacy Screen. Colored RED.
     // DiplomaticStatus.DefensivePact - similar. Colored PURPLE.
+    // DiplomacyFlags.DeclarationOfFriendship colored GREEN. (DiplomaticStatus.DeclarationOfFriendship does not always equate to active DoF)
     Unforgivable(Color.BROWN),
     Enemy(Color.ORANGE),
     Afraid(Color.YELLOW),
@@ -288,20 +289,6 @@ class DiplomacyManager() : IsPartOfGameInfoSerialization {
             level != RelationshipLevel.Neutral || !civInfo.isCityState -> level
             civInfo.cityStateFunctions.getTributeWillingness(otherCiv()) > 0 -> RelationshipLevel.Afraid
             else -> RelationshipLevel.Neutral
-        }
-    }
-
-    /**
-     * For human-human relationships only
-     * @return [Pair] of [Color] (relationship color) and [String] (relationship text, e.g. "Friend")
-     */
-    @Readonly
-    fun humanRelationshipLevel(): Pair<Color, String> {
-        return when {
-            diplomaticStatus == DiplomaticStatus.DefensivePact -> Pair(RelationshipLevel.Ally.color, Constants.defensivePact)
-            hasFlag(DiplomacyFlags.DeclarationOfFriendship) -> Pair(Color.GREEN, RelationshipLevel.Friend.name)
-            diplomaticStatus == DiplomaticStatus.War -> Pair(Color.RED, RelationshipLevel.Enemy.name)
-            else -> Pair(RelationshipLevel.Neutral.color, RelationshipLevel.Neutral.name)
         }
     }
     

--- a/core/src/com/unciv/ui/screens/diplomacyscreen/DiplomacyScreen.kt
+++ b/core/src/com/unciv/ui/screens/diplomacyscreen/DiplomacyScreen.kt
@@ -149,7 +149,7 @@ class DiplomacyScreen(
                     }
             else
                 ImageGetter.getCircle(
-                    color = if (civ.isHuman() && viewingCiv.isHuman()) diplomacy.humanRelationshipLevel().color
+                    color = if (civ.isHuman() && viewingCiv.isHuman()) diplomacy.humanRelationshipLevel().first
                     else if (diplomacy.diplomaticStatus == DiplomaticStatus.DefensivePact) Color.PURPLE
                     else if (civ.isAtWarWith(viewingCiv)) Color.RED
                     else relationLevel.color,
@@ -230,9 +230,11 @@ class DiplomacyScreen(
      */
     internal fun getHumanRelationshipTable(otherCivDiplomacyManager: DiplomacyManager): Table {
         val relationshipTable = Table()
-        val humanRelationshipLevel = otherCivDiplomacyManager.humanRelationshipLevel()
+        val humanRelationshipLevel: Pair<Color, String> = otherCivDiplomacyManager.humanRelationshipLevel()
+        val relationshipColor = humanRelationshipLevel.first
+        val relationshipText = humanRelationshipLevel.second
         relationshipTable.add("{Our relationship}: ".toLabel())
-        relationshipTable.add(humanRelationshipLevel.text.toLabel(humanRelationshipLevel.color)).row()
+        relationshipTable.add(relationshipText.toLabel(relationshipColor)).row()
         return relationshipTable
     }
 

--- a/core/src/com/unciv/ui/screens/diplomacyscreen/DiplomacyScreen.kt
+++ b/core/src/com/unciv/ui/screens/diplomacyscreen/DiplomacyScreen.kt
@@ -5,11 +5,9 @@ import com.badlogic.gdx.scenes.scene2d.ui.SplitPane
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton
 import com.badlogic.gdx.utils.Align
-import com.unciv.Constants
 import com.unciv.GUI
 import com.unciv.UncivGame
 import com.unciv.logic.civilization.Civilization
-import com.unciv.logic.civilization.diplomacy.DiplomacyFlags
 import com.unciv.logic.civilization.diplomacy.DiplomacyManager
 import com.unciv.logic.civilization.diplomacy.DiplomaticStatus
 import com.unciv.logic.civilization.diplomacy.RelationshipLevel
@@ -128,6 +126,7 @@ class DiplomacyScreen(
         closeButton.setPosition(stage.width - closeButtonPad, stage.height - closeButtonPad, Align.topRight)
     }
 
+    // There appear to be hardcoded AI relationship color values here. Should probably refactor to unify color schemes.
     internal fun updateLeftSideTable(selectCiv: Civilization?) {
         leftSideTable.clear()
         leftSideTable.add().padBottom(closeButtonPad).row()  // no default pad, and make distance of first civ to top same as for the close button
@@ -150,7 +149,7 @@ class DiplomacyScreen(
                     }
             else
                 ImageGetter.getCircle(
-                    color = if (civ.isHuman() && viewingCiv.isHuman()) getHumanRelationshipColor(diplomacy)
+                    color = if (civ.isHuman() && viewingCiv.isHuman()) diplomacy.humanRelationshipLevel().color
                     else if (diplomacy.diplomaticStatus == DiplomaticStatus.DefensivePact) Color.PURPLE
                     else if (civ.isAtWarWith(viewingCiv)) Color.RED
                     else relationLevel.color,
@@ -226,50 +225,14 @@ class DiplomacyScreen(
     }
 
     /**
-     * Helper function for updateLeftSideTable() and getHumanRelationshipTable() (human-human relationships only)
-     * @param otherCivDiplomacyManager Other human player [DiplomacyManager]
-     * @return Relationship color between two human players
-     */
-    private fun getHumanRelationshipColor(otherCivDiplomacyManager: DiplomacyManager): Color {
-        // should ensure colors align with equivalent human-AI relationship colors (RelationshipLevel ?)
-        // as of writing, RelationshipLevel colors are not appropriate IMO, so using hardcoded values for now
-        return if (otherCivDiplomacyManager.diplomaticStatus == DiplomaticStatus.DefensivePact)
-            Color.CYAN
-        else if (otherCivDiplomacyManager.hasFlag(DiplomacyFlags.DeclarationOfFriendship))
-            Color.GREEN
-        else if (otherCivDiplomacyManager.diplomaticStatus == DiplomaticStatus.War)
-            Color.RED
-        else
-            RelationshipLevel.Neutral.color
-    }
-
-    /**
-     * Human-human relationships only. See also: getHumanRelationshipColor()
-     * @param otherCivDiplomacyManager Other human player [DiplomacyManager]
-     * @return Relationship text (e.g. "Friend")
-     */
-    private fun getHumanRelationshipText(otherCivDiplomacyManager: DiplomacyManager): String {
-        return if (otherCivDiplomacyManager.diplomaticStatus == DiplomaticStatus.DefensivePact)
-            Constants.defensivePact
-        else if (otherCivDiplomacyManager.hasFlag(DiplomacyFlags.DeclarationOfFriendship))
-            RelationshipLevel.Friend.name
-        else if (otherCivDiplomacyManager.diplomaticStatus == DiplomaticStatus.War)
-            RelationshipLevel.Enemy.name
-        else
-            RelationshipLevel.Neutral.name
-    }
-
-    /**
      * @param otherCivDiplomacyManager Other human player [DiplomacyManager]
      * @return Relationship [Table] for human vs human player only
      */
     internal fun getHumanRelationshipTable(otherCivDiplomacyManager: DiplomacyManager): Table {
         val relationshipTable = Table()
-        val relationshipColor: Color = getHumanRelationshipColor(otherCivDiplomacyManager)
-        val relationshipText: String = getHumanRelationshipText(otherCivDiplomacyManager)
-
+        val humanRelationshipLevel = otherCivDiplomacyManager.humanRelationshipLevel()
         relationshipTable.add("{Our relationship}: ".toLabel())
-        relationshipTable.add(relationshipText.toLabel(relationshipColor)).row()
+        relationshipTable.add(humanRelationshipLevel.text.toLabel(humanRelationshipLevel.color)).row()
         return relationshipTable
     }
 


### PR DESCRIPTION
After feedback in [PR](https://github.com/yairm210/Unciv/pull/13884).

Refactor DiplomacyScreen methods; getHumanRelationshipColor and getHumanRelationshipText, into HumanRelationshipLevel enum in DiplomacyManager.
Enum references existing fields (colors and relationship text strings) to limit deviation in color schemes and ensure translation support.

Create humanRelationshipLevel method in DiplomacyManager to map human-human diplomatic status to relationship level.