### PR TITLE
Add countable `[stat/resource] Per Turn`

### DIFF
--- a/core/src/com/unciv/logic/civilization/Civilization.kt
+++ b/core/src/com/unciv/logic/civilization/Civilization.kt
@@ -426,6 +426,7 @@ class Civilization : IsPartOfGameInfoSerialization {
     fun getHappiness() = stats.happiness
 
     /** Note that for stockpiled resources, this gives by how much it grows per turn, not current amount */
+    @Readonly
     fun getCivResourceSupply(): ResourceSupplyList = summarizedCivResourceSupply
 
     /** Preserves some origins for resources so we can separate them for trades

--- a/core/src/com/unciv/models/ruleset/tile/ResourceSupplyList.kt
+++ b/core/src/com/unciv/models/ruleset/tile/ResourceSupplyList.kt
@@ -31,7 +31,7 @@ class ResourceSupplyList(
         firstOrNull { it.resource.name == resource.name && it.origin == origin }
 
     /** Get the total amount for a resource by [resourceName] */
-    fun sumBy(resourceName: String) =
+    @Readonly fun sumBy(resourceName: String) =
         asSequence().filter { it.resource.name == resourceName }.sumOf { it.amount }
 
     /**

--- a/core/src/com/unciv/models/ruleset/unique/Countables.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Countables.kt
@@ -79,6 +79,21 @@ enum class Countables(
         override fun getKnownValuesForAutocomplete(ruleset: Ruleset) = Stat.names()
     },
 
+    ResourcePerTurn("[resource] resources per turn", shortDocumentation = "The amount of a resource gained per turn") {
+        override val documentationHeader = "Resource name Per Turn (${niceJoinList(Stat.names())})"
+        override val documentationStrings = listOf("Gets the amount of a resource the civilization gains per turn")
+        override fun eval(parameterText: String, gameContext: GameContext): Int? {
+            val resource = parameterText.getPlaceholderParameters().firstOrNull() ?: return null
+            return gameContext.civInfo?.getCivResourceSupply()?.sumBy(resource) ?: return null
+        }
+        override fun getErrorSeverity(parameterText: String, ruleset: Ruleset): UniqueType.UniqueParameterErrorSeverity? =
+            UniqueParameterType.Resource.getTranslatedErrorSeverity(parameterText, ruleset)
+        override fun getKnownValuesForAutocomplete(ruleset: Ruleset): Set<String> =
+            UniqueParameterType.Resource.getKnownValuesForAutocomplete(ruleset)
+                .map { text.fillPlaceholders(it) }.toSet()
+        override val example: String = "[Iron] resources per turn"
+    },
+
     StatPerTurn("[stat] Per Turn", shortDocumentation = "The amount of a stat gained per turn") {
         override val documentationHeader = "Stat name Per Turn (${niceJoinList(Stat.names())})"
         override val documentationStrings = listOf("Gets the amount of a stat the civilization gains per turn")

--- a/core/src/com/unciv/models/ruleset/unique/Countables.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Countables.kt
@@ -79,34 +79,34 @@ enum class Countables(
         override fun getKnownValuesForAutocomplete(ruleset: Ruleset) = Stat.names()
     },
 
-    ResourcePerTurn("[resource] resources per turn", shortDocumentation = "The amount of a resource gained per turn") {
-        override val documentationHeader = "Resource name Per Turn (${niceJoinList(Stat.names())})"
-        override val documentationStrings = listOf("Gets the amount of a resource the civilization gains per turn")
-        override fun eval(parameterText: String, gameContext: GameContext): Int? {
-            val resource = parameterText.getPlaceholderParameters().firstOrNull() ?: return null
-            return gameContext.civInfo?.getCivResourceSupply()?.sumBy(resource) ?: return null
+    StatOrResourcePerTurn("[stat/resource] Per Turn", shortDocumentation = "The amount of a stat or resource gained per turn") {
+        override val documentationHeader = "Stat/Resource Per Turn"
+        override val documentationStrings = listOf("Gets the amount of a stat or resource the civilization gains per turn")
+        override val matchesWithRuleset = true
+        override fun matches(parameterText: String, ruleset: Ruleset): Boolean {
+            if (!parameterText.endsWith("] Per Turn")) return false
+            val param = parameterText.getPlaceholderParameters().firstOrNull() ?: return false
+            return Stat.isStat(param) || TileResources.matches(param, ruleset)
         }
-        override fun getErrorSeverity(parameterText: String, ruleset: Ruleset): UniqueType.UniqueParameterErrorSeverity? =
-            UniqueParameterType.Resource.getTranslatedErrorSeverity(parameterText, ruleset)
-        override fun getKnownValuesForAutocomplete(ruleset: Ruleset): Set<String> =
-            UniqueParameterType.Resource.getKnownValuesForAutocomplete(ruleset)
-                .map { text.fillPlaceholders(it) }.toSet()
-        override val example: String = "[Iron] resources per turn"
-    },
-
-    StatPerTurn("[stat] Per Turn", shortDocumentation = "The amount of a stat gained per turn") {
-        override val documentationHeader = "Stat name Per Turn (${niceJoinList(Stat.names())})"
-        override val documentationStrings = listOf("Gets the amount of a stat the civilization gains per turn")
         override fun eval(parameterText: String, gameContext: GameContext): Int? {
-            val statName = parameterText.getPlaceholderParameters().firstOrNull() ?: return null
-            val relevantStat = Stat.safeValueOf(statName) ?: return null
+            val param = parameterText.getPlaceholderParameters().firstOrNull() ?: return null
             val civ = gameContext.civInfo ?: return null
-            return civ.stats.getStatMapForNextTurn().values.map { it[relevantStat] }.sum().toInt()
+            if (Stat.isStat(param)) {
+                val relevantStat = Stat.safeValueOf(param) ?: return null
+                return civ.stats.getStatMapForNextTurn().values.map { it[relevantStat] }.sum().toInt()
+            }
+            return gameContext.civInfo?.getCivResourceSupply()?.sumBy(param) ?: return null
         }
-        override fun getErrorSeverity(parameterText: String, ruleset: Ruleset): UniqueType.UniqueParameterErrorSeverity? =
-            UniqueParameterType.StatName.getTranslatedErrorSeverity(parameterText, ruleset)
+        override fun getErrorSeverity(parameterText: String, ruleset: Ruleset): UniqueType.UniqueParameterErrorSeverity? {
+            val param = parameterText.getPlaceholderParameters().firstOrNull() ?: return UniqueType.UniqueParameterErrorSeverity.RulesetInvariant
+            if (Stat.isStat(param)) {
+                return UniqueParameterType.StatName.getTranslatedErrorSeverity(parameterText, ruleset)
+            }
+            return UniqueParameterType.Resource.getTranslatedErrorSeverity(parameterText, ruleset)
+        }
         override fun getKnownValuesForAutocomplete(ruleset: Ruleset): Set<String> =
             UniqueParameterType.StatName.getKnownValuesForAutocomplete(ruleset)
+                .union(UniqueParameterType.Resource.getKnownValuesForAutocomplete(ruleset))
                 .map { text.fillPlaceholders(it) }.toSet()
         override val example: String = "[Culture] Per Turn"
     },

--- a/docs/Modders/Unique-parameters.md
+++ b/docs/Modders/Unique-parameters.md
@@ -366,12 +366,9 @@ Allowed values:
 -   Stat name (`Production`, `Food`, `Gold`, `Science`, `Culture`, `Happiness` or `Faith`)
     - Example: `Only available <when number of [Science] is more than [0]>`
     - Gets the stat *reserve*, not the amount per turn (can be city stats or civilization stats, depending on where the unique is used)
--   Resource name Per Turn (`Production`, `Food`, `Gold`, `Science`, `Culture`, `Happiness` or `Faith`)
-    - Example: `Only available <when number of [[Iron] resources per turn] is more than [0]>`
-    - Gets the amount of a resource the civilization gains per turn
--   Stat name Per Turn (`Production`, `Food`, `Gold`, `Science`, `Culture`, `Happiness` or `Faith`)
+-   Stat/Resource Per Turn
     - Example: `Only available <when number of [[Culture] Per Turn] is more than [0]>`
-    - Gets the amount of a stat the civilization gains per turn
+    - Gets the amount of a stat or resource the civilization gains per turn
 -   `Completed Policy branches`
     - Example: `Only available <when number of [Completed Policy branches] is more than [0]>`
 -   `[cityFilter] Cities`

--- a/docs/Modders/Unique-parameters.md
+++ b/docs/Modders/Unique-parameters.md
@@ -366,6 +366,9 @@ Allowed values:
 -   Stat name (`Production`, `Food`, `Gold`, `Science`, `Culture`, `Happiness` or `Faith`)
     - Example: `Only available <when number of [Science] is more than [0]>`
     - Gets the stat *reserve*, not the amount per turn (can be city stats or civilization stats, depending on where the unique is used)
+-   Resource name Per Turn (`Production`, `Food`, `Gold`, `Science`, `Culture`, `Happiness` or `Faith`)
+    - Example: `Only available <when number of [[Iron] resources per turn] is more than [0]>`
+    - Gets the amount of a resource the civilization gains per turn
 -   Stat name Per Turn (`Production`, `Food`, `Gold`, `Science`, `Culture`, `Happiness` or `Faith`)
     - Example: `Only available <when number of [[Culture] Per Turn] is more than [0]>`
     - Gets the amount of a stat the civilization gains per turn

--- a/tests/src/com/unciv/uniques/CountableTests.kt
+++ b/tests/src/com/unciv/uniques/CountableTests.kt
@@ -115,6 +115,26 @@ class CountableTests {
     }
 
     @Test
+    fun testStatOrResourcePerTurn() {
+        setupModdedGame()
+        city.cityConstructions.addBuilding(game.createBuilding(
+            "Provides [5] [Coal]",
+            "[+1 Gold, +3 Culture] [in this city]"
+        ))
+        val tests = listOf(
+            "[Gold] Per Turn" to 4, // Palace provides 3
+            "[Culture] Per Turn" to 4, // Palace provides 1
+            "[Coal] Per Turn" to 5,
+            "[Iron] Per Turn" to 0,
+            "[Null] Per Turn" to null,
+        )
+        for ((test, expected) in tests) {
+            val actual = Countables.getCountableAmount(test, GameContext(civ))
+            assertEquals("Testing `$test` countable:", expected, actual)
+        }
+    }
+
+    @Test
     fun testStatsCountables() {
         setupModdedGame()
         fun verifyStats(state: GameContext) {


### PR DESCRIPTION
While we had `[stat] Per Turn`, it didn't allow for `[resource] Per Turn`, so this adds that capability, along with tests.

## Use Case

In BNW, the [Great Musician](https://civilization.fandom.com/wiki/Great_Musician_(Civ5)) can generate 10 times the amount of Tourism you generate per turn. I had initially thought it was 10x your Tourism, but no. It's per turn. So this PR allows to fix that.
