### PR TITLE
Update Traditional_Chinese.properties

### DIFF
--- a/android/assets/jsons/translations/Traditional_Chinese.properties
+++ b/android/assets/jsons/translations/Traditional_Chinese.properties
@@ -328,14 +328,11 @@ Gold per turn = 金錢/回合
 Cities = 城市
 Technologies = 科技
 Declarations of war = 宣戰
- # Requires translation!
-Peace Proposals = 
- # Requires translation!
-Accept Embassy = 
+Peace Proposals = 和平協議
+Accept Embassy = 接受大使館
 Introduction to [nation] = 介紹認識[nation]
 Declare war on [nation] = 向[nation]宣戰
- # Requires translation!
-Make peace with [nation] = 
+Make peace with [nation] = 與[nation]達成和平協議
 Luxury resources = 奢侈資源
 Strategic resources = 戰略資源
 Stockpiled resources = 可儲存資源
@@ -383,8 +380,7 @@ Custom = 自訂
 Map Generation Type = 生成地圖類型
 Enabled Map Generation Types = 允許的地圖類型
 Example map = 地圖示例
- # Requires translation!
-Scenario file [name] is invalid. = 
+Scenario file [name] is invalid. = [name]情景檔案無效
 
 # Map types
 Default = 預設
@@ -797,8 +793,7 @@ Windowed = 視窗化
 Fullscreen = 全螢幕
 Borderless = 無邊界
 
- # Requires translation!
-UI Scale = 
+UI Scale = 介面比例
 
 ### Enable panning the map when you move the mouse to the edge of the window
 Map mouse auto-scroll = 地圖鼠標自動滾屏
@@ -902,8 +897,7 @@ Advanced = 更多
 Number of autosave files stored = 存儲的自動存檔數量
  # Requires translation!
 Autosave turns must be larger than 0! = 
- # Requires translation!
-Autosave turns over 200 may take a lot of space on your device. = 
+Autosave turns over 200 may take a lot of space on your device. = 超過200回合的自動存檔會佔用大量儲存空間
 Turns between autosaves = 自動存檔間隔回合
  # Requires translation!
 Enter = 
@@ -1122,8 +1116,7 @@ We Love The King Day in [cityName] has ended. = [cityName]的我們愛國王日�
 Our [name] took [tileDamage] tile damage and was destroyed = 我們的[name]因受到[tileDamage]地塊傷害而被消滅
 Our [name] took [tileDamage] tile damage = 我們的[name]受到[tileDamage]地塊傷害
 [civName] has adopted the [policyName] policy = [civName]採用了[policyName]政策
- # Requires translation!
-[civName] has researched [techName] = 
+[civName] has researched [techName] = [civName]研發了[techName]
 You gained [Stats] as your religion was spread to [cityName] = 當你的宗教傳播到[cityName]時，你獲得了[Stats]
 You gained [Stats] as your religion was spread to an unknown city = 當你的宗教傳播到一個未知的城市時，你獲得了[Stats]
 Your city [cityName] was converted to [religionName]! = 您的城市[cityName]已轉換為[religionName]！
@@ -1151,8 +1144,7 @@ Gained [stats] = 您獲得[stats]。
 You may choose a free Policy = 您可以選擇一項免費的政策。
 You may choose [amount] free Policies = 您可以選擇[amount]項免費的政策。
 You gain the [policy] Policy = 您獲得了[policy]政策
- # Requires translation!
-You gain the [belief] Belief = 
+You gain the [belief] Belief = 你獲得了[belief]信仰
 You enter a Golden Age = 您進入了黃金時代。
 You have gained [amount] [resourceName] = 您獲得了 [amount] [resourceName]
 You have lost [amount] [resourceName] = 您失去了 [amount] [resourceName]
@@ -1711,8 +1703,7 @@ Barbarian spawning delay = 蠻族生成延遲
 Bonus starting units = 額外起始單位
 
 AI settings = AI設定
- # Requires translation!
-AI difficulty level = 
+AI difficulty level = AI難度
 AI city growth modifier = AI城市發展修正
 AI unit cost modifier = AI單位訓練成本修正
 AI building cost modifier = AI建築建造成本修正
@@ -1824,16 +1815,11 @@ Holy City of: [religionName] = 聖城：[religionName]
 Former Holy City of: [religionName] = 前聖城：[religionName]
 Followers = 信徒
 Pressure = 宗教壓力
- # Requires translation!
-[nation] has founded pantheon [belief]! = 
- # Requires translation!
-[nation] has enhanced [religionName]! = 
- # Requires translation!
-[nation] has founded [religionName] in [cityName]! = 
- # Requires translation!
-[nation] has founded [religionName]! = 
- # Requires translation!
-An unknown civilization = 
+[nation] has founded pantheon [belief]! = [nation]成立了[belief]信仰!
+[nation] has enhanced [religionName]! = [nation]強化了[religionName]!
+[nation] has founded [religionName] in [cityName]! = [nation]在[cityName]成立了[religionName]!
+[nation] has founded [religionName]! = [nation]成立了[religionName]!
+An unknown civilization = 一個未知的文明
 
 # Religion overview screen
 Religion Name: = 宗教名稱：
@@ -1855,7 +1841,7 @@ Available follower beliefs = 可用的追隨者信仰
 Religious status: = 宗教進度：
 
 None = 無
-Pantheon = 萬神殿
+Pantheon = 信仰
 Founding religion = 創立宗教中
 Religion = 宗教
 Enhancing religion = 強化宗教中
@@ -1870,8 +1856,7 @@ Spy Hideout = 間諜藏身處
 Spy present = 間諜出沒
 Move = 移動
 
- # Requires translation!
-After [unknownCiv] entered the [eraName], we have recruited [spyName] as a spy! = 
+After [unknownCiv] entered the [eraName], we have recruited [spyName] as a spy! = 在[unknownCiv]進入了[eraName]之後，我們招募了[spyName]作為間諜！
 We have recruited [spyName] as a spy! = 我們招募了[spyName]作為間諜！
 We have recruited a new spy name [spyName] after [oldSpyName] was killed. = 您已招募新間諜[spyName]來接班[oldSpyName]。
 Your spy [spyName] has leveled up! = 您的間諜[spyName]已經晉級！
@@ -2187,8 +2172,7 @@ All newly-trained [baseUnitFilter] units [cityFilter] receive the [promotion] pr
 Costs [amount] [stockpiledResource] = 消耗[amount]單位[stockpiledResource]
  # Requires translation!
 [relativeAmount]% [resourceFilter] resource production = 
- # Requires translation!
-Enables establishment of embassies = 
+Enables establishment of embassies = 允許成立大使館
  # Requires translation!
 Requires establishing embassies to conduct advanced diplomacy = 
 Enables Open Borders agreements = 允許簽訂開放邊境協定
@@ -2425,9 +2409,8 @@ every [positiveAmount] turns = 每經過[positiveAmount]回合
 before turn number [nonNegativeAmount] = 於第[nonNegativeAmount]回合前
 after turn number [nonNegativeAmount] = 於第[nonNegativeAmount]回合後
 on [speed] game speed = 若遊戲速度為[speed]
-on [difficulty] difficulty = 在 [difficulty] 難度
- # Requires translation!
-on [difficulty] difficulty or higher = 
+on [difficulty] difficulty = 在[difficulty]難度
+on [difficulty] difficulty or higher = 在[difficulty]或更高的難度
 when [victoryType] Victory is enabled = 若啟用[victoryType]獲勝方式
 when [victoryType] Victory is disabled = 若禁用[victoryType]獲勝方式
 when religion is enabled = 當宗教啟用時
@@ -2484,10 +2467,8 @@ in cities with a [buildingFilter] = 在具有[buildingFilter]的城市
 in cities without a [buildingFilter] = 在沒有[buildingFilter]的城市
 in cities with at least [positiveAmount] [populationFilter] = 在有至少[positiveAmount][populationFilter]的城市
 in cities with [positiveAmount] [populationFilter] = 在有[positiveAmount][populationFilter]的城市
- # Requires translation!
-in cities with between [amount] and [amount2] [populationFilter] = 
- # Requires translation!
-in cities with less than [amount] [populationFilter] = 
+in cities with between [amount] and [amount2] [populationFilter] = 在有[amount]和[amount2][populationFilter]之間的城市
+in cities with less than [amount] [populationFilter] = 在有少於[amount][populationFilter]的城市
 with a garrison = 若駐軍於該地
 for [mapUnitFilter] units = 僅[mapUnitFilter]單位
 when [mapUnitFilter] = 僅[mapUnitFilter]
@@ -2504,8 +2485,7 @@ when adjacent to a [mapUnitFilter] unit = 和[mapUnitFilter]單位相鄰時
 when above [positiveAmount] HP = 當超過[positiveAmount]生命值時
 when below [positiveAmount] HP = 當低於[positiveAmount]生命值時
 if it hasn't used other actions yet = 如尚未進行其他動作
- # Requires translation!
-when stacked with a [mapUnitFilter] unit = 
+when stacked with a [mapUnitFilter] unit = 和[mapUnitFilter]單位重疊時
 with [nonNegativeAmount] to [nonNegativeAmount2] neighboring [tileFilter] tiles = 有[nonNegativeAmount2]到[nonNegativeAmount]個相鄰的[tileFilter]地塊時
 in [tileFilter] tiles = 在[tileFilter]地塊上
 in tiles without [tileFilter] = 在沒有[tileFilter]的地塊上
@@ -2560,10 +2540,8 @@ Gain an extra spy = 獲得額外的間諜
 Doing so will consume this opportunity to choose a Promotion = 這樣做將消耗這次晉升的機會
 This Promotion is free = 此項晉升免費
 Turn this tile into a [terrainName] tile = 將這個地塊轉化為[terrainName]地塊
- # Requires translation!
-Remove [resourceFilter] resources from this tile = 
- # Requires translation!
-Remove [improvementFilter] improvements from this tile = 
+Remove [resourceFilter] resources from this tile = 在這個地塊移除[resourceFilter]資源
+Remove [improvementFilter] improvements from this tile = 在這個地塊移除[improvementFilter]設施
 Provides the cheapest [stat] building in your first [positiveAmount] cities for free = 前[positiveAmount]座城市免費獲得最便宜的[stat]建築
 Provides a [buildingName] in your first [positiveAmount] cities for free = 前[positiveAmount]座城市免費獲得[buildingName]
 Triggers a [event] event = 觸發[event]事件
@@ -2583,8 +2561,7 @@ upon discovering [techFilter] technology = 當發現[techFilter]時
 upon entering the [era] = 當進入[era]時
 upon entering a new era = 每當進入新時期時
 upon adopting [policy/belief] = 當採用[policy/belief]時
- # Requires translation!
-upon declaring war on [civFilter] Civilizations = 
+upon declaring war on [civFilter] Civilizations = 當向[civFilter]文明宣戰時
  # Requires translation!
 upon being declared war on by [civFilter] Civilizations = 
  # Requires translation!
@@ -2595,8 +2572,7 @@ upon entering a Golden Age = 每當進入黃金時代時
  # Requires translation!
 upon ending a Golden Age = 
 upon conquering a city = 每當征服城市時
- # Requires translation!
-upon losing a city = 
+upon losing a city = 每當失去城市時
 upon founding a city = 每當建立城市時
 upon building a [improvementFilter] improvement = 每次建造[improvementFilter]設施後
 upon discovering a Natural Wonder = 每當發現自然奇觀時


### PR DESCRIPTION
Making several pending translations, and changing the definition of "Pantheon" on line 1844. The original translation meant the building, but in the context of Unciv or Civilization V, a pantheon is more of a simple belief/proto-religion. Therefore, I translated "Pantheon" to 信仰, which means "belief" in Chinese (Traditional).

Here is an incomplete list of the translations I've made:

- Peace Proposals
- Accept Embassy
- Make peace with [nation]
- Scenario file [name] is invalid.
- UI Scale
- Autosave turns over 200 may take a lot of space on your device.
- [civName] has researched [techName]
- You gain the [belief] Belief
- AI difficulty level
- Various "[nation] has founded/enhanced..."
- Changed the translation of "Pantheon", as mentioned above.
- After [unknownCiv] entered the [eraName], we have recruited [spyName] as a spy!
- Enables establishment of embassies