### PR TITLE
Show button to forcibly resign player after 2 days of inactivity

### DIFF
--- a/core/src/com/unciv/ui/components/extensions/Scene2dExtensions.kt
+++ b/core/src/com/unciv/ui/components/extensions/Scene2dExtensions.kt
@@ -80,12 +80,7 @@ fun Button.enable() {
  *  which is more appropriate to toggle On/Off buttons, while this one is good for 'click-to-do-something' buttons.
  */
 var Button.isEnabled: Boolean
-    get() = when (touchable) {
-        Touchable.enabled -> true
-        Touchable.disabled -> false
-        // idk what to do here
-        Touchable.childrenOnly -> throw IllegalStateException()
-    }
+    get() = touchable == Touchable.enabled
     set(value) = if (value) enable() else disable()
 
 fun colorFromHex(hexColor: Int): Color {

--- a/core/src/com/unciv/ui/components/extensions/Scene2dExtensions.kt
+++ b/core/src/com/unciv/ui/components/extensions/Scene2dExtensions.kt
@@ -55,6 +55,7 @@ private class RestorableTextButtonStyle(
 //todo ButtonStyle *does* have a `disabled` Drawable, and Button ignores touches in disabled state anyway - all this is a wrong approach
 /** Disable a [Button] by setting its [touchable][Button.touchable] and [style][Button.style] properties. */
 fun Button.disable() {
+    touchable = Touchable.disabled
     /** We want disabled buttons to "swallow" the click so that things behind aren't activated, so we don't change touchable
        The action won't be activated due to [ActorAttachments.activate] checking the isDisabled property */
     isDisabled = true
@@ -65,6 +66,7 @@ fun Button.disable() {
 }
 /** Enable a [Button] by setting its [touchable][Button.touchable] and [style][Button.style] properties. */
 fun Button.enable() {
+    touchable = Touchable.enabled
     val oldStyle = style
     if (oldStyle is RestorableTextButtonStyle) {
         style = oldStyle.restoreStyle
@@ -78,7 +80,12 @@ fun Button.enable() {
  *  which is more appropriate to toggle On/Off buttons, while this one is good for 'click-to-do-something' buttons.
  */
 var Button.isEnabled: Boolean
-    get() = touchable == Touchable.enabled
+    get() = when (touchable) {
+        Touchable.enabled -> true
+        Touchable.disabled -> false
+        // idk what to do here
+        Touchable.childrenOnly -> throw IllegalStateException()
+    }
     set(value) = if (value) enable() else disable()
 
 fun colorFromHex(hexColor: Int): Color {


### PR DESCRIPTION
Button.disable() and Button.enable() did not set the touchable field as their comments suggested.

The button to forcibly resign a player shows up after I resolved this inconsistency.

The number of days before the button appears was already set to 2 days. It can be found in MultiplayerScreen#selectGame.

I am not familiar with the Button class, so if someone could confirm that my changes are appropriate?

I have not tested if the logic to forcibly resign a player works, but I assume it does since it was already implemented.