### PR TITLE
Add `Adopted [policy] Policies by [civ] Civilizations` countable

### DIFF
--- a/core/src/com/unciv/models/ruleset/unique/Countables.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Countables.kt
@@ -164,6 +164,23 @@ enum class Countables(
                 .map { text.fillPlaceholders(it) }.toSet()
     },
 
+    FilteredPoliciesByCivs("Adopted [policyFilter] Policies by [civFilter] Civilizations") {
+        override fun eval(parameterText: String, gameContext: GameContext): Int? {
+            val (policyFilter, civFilter) = parameterText.getPlaceholderParameters().takeIf { it.size >= 2 } ?: return null
+            val civilizations = gameContext.gameInfo?.civilizations ?: return null
+            return civilizations
+                .filter { it.isAlive() && it.matchesFilter(civFilter, gameContext) }
+                .sumOf { it.policies.getAdoptedPoliciesMatching(policyFilter, gameContext).size }
+        }
+        override fun getErrorSeverity(parameterText: String, ruleset: Ruleset): UniqueType.UniqueParameterErrorSeverity? {
+            val params = parameterText.getPlaceholderParameters()
+            if (params.size < 2) return UniqueType.UniqueParameterErrorSeverity.RulesetInvariant
+            return UniqueParameterType.PolicyFilter.getErrorSeverity(params[0], ruleset) ?:
+                UniqueParameterType.CivFilter.getErrorSeverity(params[1], ruleset)
+        }
+        override fun getKnownValuesForAutocomplete(ruleset: Ruleset) = setOf<String>()
+    },
+
     RemainingCivs("Remaining [civFilter] Civilizations") {
         override fun eval(parameterText: String, gameContext: GameContext): Int? {
             val filter = parameterText.getPlaceholderParameters()[0]

--- a/docs/Modders/Unique-parameters.md
+++ b/docs/Modders/Unique-parameters.md
@@ -379,6 +379,8 @@ Allowed values:
     - Example: `Only available <when number of [[Culture] Buildings] is more than [0]>`
 -   `Adopted [policyFilter] Policies`
     - Example: `Only available <when number of [Adopted [Oligarchy] Policies] is more than [0]>`
+-   `Adopted [policyFilter] Policies by [civFilter] Civilizations`
+    - Example: `Only available <when number of [Adopted [Oligarchy] Policies by [City-States] Civilizations] is more than [0]>`
 -   `Remaining [civFilter] Civilizations`
     - Example: `Only available <when number of [Remaining [City-States] Civilizations] is more than [0]>`
 -   `Owned [tileFilter] Tiles`

--- a/tests/src/com/unciv/uniques/CountableTests.kt
+++ b/tests/src/com/unciv/uniques/CountableTests.kt
@@ -244,6 +244,16 @@ class CountableTests {
             freePolicies++
             adopt(taggedPolicyBranch) // Will be completed as it has no member policies
         }
+
+        // Add a second Civilization
+        val civ2 = game.addCiv()
+        val city2 = game.addCity(civ2, game.tileMap[2,2])
+        civ2.policies.run {
+            freePolicies += 2
+            adopt(getPolicyByName("Tradition"))
+            adopt(getPolicyByName("Oligarchy"))
+        }
+
         val tests = listOf(
             "Completed Policy branches" to 2,               // Tradition and taggedPolicyBranch
             "Adopted [Tradition Complete] Policies" to 1,
@@ -251,6 +261,8 @@ class CountableTests {
             "Adopted [Liberty Complete] Policies" to 0,
             "Adopted [[Liberty] branch] Policies" to 2,     // Liberty has only 1 member adopted
             "Adopted [Some marker] Policies" to 1,
+            "Adopted [Some marker] Policies by [All] Civilizations" to 1,
+            "Adopted [Oligarchy] Policies by [All] Civilizations" to 2,
         )
         for ((test, expected) in tests) {
             val actual = Countables.getCountableAmount(test, GameContext(civ))


### PR DESCRIPTION
This change allows expanding the scope of the `Adoped [policyFilter] Policies` beyond just the active civ, by adding a `by [civFilter] Civilizations` suffix. For example:

```
Adopted [Oligarchy] Policies by [Major] Civilizations
```

### Rational

There was discussions about adding a `Globally` modifier to all Countables. While I tried this out, and somewhat got it functional, I found it caused more issues...
- Error severity became an issue, as it didn't quite distinguish properly
- Globally didn't filter out City-States, so there was still a need for a `civFilter`
- The text for it looked really ugly `{Global} Adopted [policyFilter] Policies`. While it kind of makes sense, the civFilter is missing
- The code ended up being rather messy, with string manipulation to check for or replace `Globally`

Given that, having an explicit `civFilter` gives us a lot more control over it. I can work on adding the `civFilter` to other countables where desired. Some of the Countables shouldn't need it.

### Use Case

In BNW, [Cultural Revolution](https://civilization.fandom.com/wiki/Cultural_Revolution_(Civ5)) provides +34% Tourism to other Order Civilizations, so we needed a way to count how many civs had adopted Cultural Revolution.

```
[+34]% [Tourism] resource production <for every [Adopted [Cultural Revolution] Policies by [Major] Civilizations]>
```

See: https://github.com/RobLoach/Civ-V-Brave-New-World/pull/157
