### PR TITLE
Tutorials: Move Siege Units and Apollo Program

### DIFF
--- a/android/assets/jsons/Civ V - Gods & Kings/Buildings.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Buildings.json
@@ -1112,7 +1112,10 @@
 		"isNationalWonder": true,
 		"uniques": ["Enables construction of Spaceship parts", "Triggers a global alert upon completion", 
 			"Only available <when [Scientific] Victory is enabled>", "Cannot be hurried"],
-		"requiredTech": "Rocketry"
+		"requiredTech": "Rocketry",
+        "civilopediaText": [
+            { "text": "Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities\n (with the relevant technologies) to win a Scientific Victory!" }
+        ]
 	},
     {
         "name": "Great Firewall",

--- a/android/assets/jsons/Civ V - Gods & Kings/UnitTypes.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/UnitTypes.json
@@ -33,7 +33,10 @@
     },
     {
         "name": "Siege",
-        "movementType": "Land"
+        "movementType": "Land",
+        "civilopediaText": [
+            { "text": "Siege units are extremely powerful against cities, but need to be Set Up before they can attack.\nOnce your siege unit is set up, it can attack from the current tile,\n  but once moved to another tile, it will need to be set up again." }
+        ]
     },
     {
         "name": "Civilian Water",

--- a/android/assets/jsons/Civ V - Vanilla/Buildings.json
+++ b/android/assets/jsons/Civ V - Vanilla/Buildings.json
@@ -937,7 +937,10 @@
 		"isNationalWonder": true,
 		"uniques": ["Enables construction of Spaceship parts", "Triggers a global alert upon completion",
 			"Only available <when [Scientific] Victory is enabled>", "Cannot be hurried"],
-		"requiredTech": "Rocketry"
+		"requiredTech": "Rocketry",
+        "civilopediaText": [
+            { "text": "Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities\n (with the relevant technologies) to win a Scientific Victory!" }
+        ]
 	},
 
 	// Information Era

--- a/android/assets/jsons/Civ V - Vanilla/UnitTypes.json
+++ b/android/assets/jsons/Civ V - Vanilla/UnitTypes.json
@@ -33,7 +33,10 @@
     },
     {
         "name": "Siege",
-        "movementType": "Land"
+        "movementType": "Land",
+        "civilopediaText": [
+            { "text": "Siege units are extremely powerful against cities, but need to be Set Up before they can attack.\nOnce your siege unit is set up, it can attack from the current tile,\n  but once moved to another tile, it will need to be set up again." }
+        ]
     },
     {
         "name": "Civilian Water",

--- a/android/assets/jsons/Tutorials.json
+++ b/android/assets/jsons/Tutorials.json
@@ -207,12 +207,6 @@
     "uniques": ["Will not be displayed in Civilopedia"]
   },
   {
-    "name": "Apollo Program",
-    "steps": [
-      "Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities\n (with the relevant technologies) to win a Scientific Victory!"
-    ]
-  },
-  {
     "name": "Injured Units",
     "steps": [
       "Injured units deal less damage, but recover after turns that they have been inactive.\nUnits heal 10 health per turn in enemy territory or neutral land,\n  20 inside your territory and 25 in your cities."
@@ -222,12 +216,6 @@
     "name": "Workers",
     "steps": [
       "Workers are vital to your cities' growth, since only they can construct improvements on tiles.\nImprovements raise the yield of your tiles, allowing your city to produce more and grow faster while working the same amount of tiles!"
-    ]
-  },
-  {
-    "name": "Siege Units",
-    "steps": [
-      "Siege units are extremely powerful against cities, but need to be Set Up before they can attack.\nOnce your siege unit is set up, it can attack from the current tile,\n  but once moved to another tile, it will need to be set up again."
     ]
   },
   {

--- a/docs/Modders/Mod-file-structure/4-Unit-related-JSON-files.md
+++ b/docs/Modders/Mod-file-structure/4-Unit-related-JSON-files.md
@@ -71,3 +71,4 @@ Each unit type has the following structure:
 | name         | String         | Required |                                                                                          |
 | movementType | Enum           | Required | The domain through which the unit moves. Allowed values: "Water", "Land", "Air"          |
 | uniques      | List of String | none     | List of [unique abilities](../uniques.md) this promotion grants to units of this type |
+| civilopediaText | List        | empty    | See [civilopediaText chapter](5-Miscellaneous-JSON-files.md#civilopedia-text)            |


### PR DESCRIPTION
This does two things to help clean up the number of Tutorials...

1. Moves Siege Units tutorial to the Siege Unit type page.
2. Moves the Apollo Program tutorial to the Apollo Program building page. With the new Scientific Victory Type tutorial, I think it's best if this text is shown directly on the Apollo Program screen.
