### PR TITLE
Update Tutorials.json

### DIFF
--- a/android/assets/jsons/Tutorials.json
+++ b/android/assets/jsons/Tutorials.json
@@ -148,7 +148,7 @@
     "name": "Victory Types",
     "steps": [
       "Once you’ve settled your first two or three cities you’re probably 100 to 150 turns into the game.\nNow is a good time to start thinking about how, exactly, you want to win – if you haven’t already.",
-      "There are four ways to win in Unciv. They are:\n - Cultural Victory: Complete 5 Social Policy Trees and build the Utopia Project\n - Domination Victory: Survive as the last civilization\n - Science Victory: Be the first to construct a spaceship to Alpha Centauri\n - Diplomatic Victory: Build the United Nations and win the vote",
+      "There are four ways to win in Unciv. They are:\n - Cultural Victory: Complete 5 Social Policy Trees and build the Utopia Project\n - Domination Victory: Conquer the original capital of all other Major civs\n - Science Victory: Be the first to construct a Spaceship\n - Diplomatic Victory: Build the United Nations and win the vote",
       "So to sum it up, these are the basics of Unciv – Found a prosperous first city, expand slowly to manage happiness, and set yourself up for the victory condition you wish to pursue.\nObviously, there is much more to it than that, but it is important not to jump into the deep end before you know how to swim."
     ],
     "civilopediaText": [

--- a/android/assets/jsons/Tutorials.json
+++ b/android/assets/jsons/Tutorials.json
@@ -147,7 +147,7 @@
   {
     "name": "Victory Types",
     "steps": [
-      "Once you’ve settled your first two or three cities you’re probably 100 to 150 turns into the game.\nNow is a good time to start thinking about how, exactly, you want to win – if you haven’t already.",
+      "Once you’ve settled 3-4 cities and build universities, you’re probably already 100 to 150 turns into the game.\nNow is a good time to start thinking about how, exactly, you want to win – if you haven’t already.",
       "There are four ways to win in Unciv. They are:\n - Cultural Victory: Complete 5 Social Policy Trees and build the Utopia Project\n - Domination Victory: Conquer the original capital of all other Major civs\n - Science Victory: Be the first to construct a Spaceship\n - Diplomatic Victory: Build the United Nations and win the vote",
       "So to sum it up, these are the basics of Unciv – Found a prosperous first city, expand slowly to manage happiness, and set yourself up for the victory condition you wish to pursue.\nObviously, there is much more to it than that, but it is important not to jump into the deep end before you know how to swim."
     ],


### PR DESCRIPTION
The tutorial is no longer accurate, as Domination victory has since been changed from owning all cities of other players, to owning all original capitals of other players. The mentioning of Alpha Centrauri is Civ5-appropriate, but imo it breaks immersion as no habitable zone earth-like planets have been confirmed there as of yet.

Adjusts the first line to more closely match default speed, rather than Marathon.