### PR TITLE
Allow giving weighted AI decisions to Event Choices

### DIFF
--- a/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueTriggerActivation.kt
@@ -129,6 +129,7 @@ object UniqueTriggerActivation {
                 if (civInfo.isAI() || event.presentation == Event.Presentation.None) return {
                     val choice = choices.toList().randomWeighted { it.getWeightForAiDecision(gameContext) }
                     choice.triggerChoice(civInfo, unit)
+                    true // The choice was randomly selected, so no need to continue.
                 }
                 if (event.presentation == Event.Presentation.Alert) return {
                     /** See [com.unciv.ui.screens.worldscreen.AlertPopup.addEvent] for the deserializing of this string to the context */

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -963,7 +963,7 @@ enum class UniqueType(
     ConditionalTimedUnique("for [nonNegativeAmount] turns", UniqueTarget.MetaModifier,
         docDescription = "Turns this unique into a trigger, activating this unique as a *global* unique for a number of turns"),
     
-    AiChoiceWeight("[relativeAmount]% weight to this choice for AI decisions", UniqueTarget.Tech,
+    AiChoiceWeight("[relativeAmount]% weight to this choice for AI decisions", UniqueTarget.Tech, UniqueTarget.EventChoice,
         UniqueTarget.Promotion, UniqueTarget.Policy, UniqueTarget.FollowerBelief, UniqueTarget.FounderBelief,
         flags = UniqueFlag.setOfHiddenToUsers),
     

--- a/docs/Modders/uniques.md
+++ b/docs/Modders/uniques.md
@@ -1189,7 +1189,7 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 	This unique is automatically hidden from users.
 
-	Applicable to: Tech, Policy, FounderBelief, FollowerBelief, Promotion
+	Applicable to: Tech, Policy, FounderBelief, FollowerBelief, Promotion, EventChoice
 
 ??? example  "Will not be displayed in Civilopedia"
 	This unique is automatically hidden from users.
@@ -1219,7 +1219,7 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 	This unique is automatically hidden from users.
 
-	Applicable to: Tech, Policy, FounderBelief, FollowerBelief, Promotion
+	Applicable to: Tech, Policy, FounderBelief, FollowerBelief, Promotion, EventChoice
 
 ??? example  "Will not be displayed in Civilopedia"
 	This unique is automatically hidden from users.
@@ -1263,7 +1263,7 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 	This unique is automatically hidden from users.
 
-	Applicable to: Tech, Policy, FounderBelief, FollowerBelief, Promotion
+	Applicable to: Tech, Policy, FounderBelief, FollowerBelief, Promotion, EventChoice
 
 ??? example  "Will not be displayed in Civilopedia"
 	This unique is automatically hidden from users.
@@ -1517,7 +1517,7 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 	This unique is automatically hidden from users.
 
-	Applicable to: Tech, Policy, FounderBelief, FollowerBelief, Promotion
+	Applicable to: Tech, Policy, FounderBelief, FollowerBelief, Promotion, EventChoice
 
 ??? example  "Will not be displayed in Civilopedia"
 	This unique is automatically hidden from users.
@@ -2364,7 +2364,7 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 
 	This unique is automatically hidden from users.
 
-	Applicable to: Tech, Policy, FounderBelief, FollowerBelief, Promotion
+	Applicable to: Tech, Policy, FounderBelief, FollowerBelief, Promotion, EventChoice
 
 ??? example  "Will not be displayed in Civilopedia"
 	This unique is automatically hidden from users.
@@ -3147,6 +3147,13 @@ Simple unique parameters are explained by mouseover. Complex parameters are expl
 	Meant to be used together with conditionals, like "Unavailable &lt;after generating a Great Prophet&gt;".
 
 	Applicable to: Tech, Policy, Building, Unit, Promotion, Improvement, Ruins, Event, EventChoice
+
+??? example  "[relativeAmount]% weight to this choice for AI decisions"
+	Example: "[+20]% weight to this choice for AI decisions"
+
+	This unique is automatically hidden from users.
+
+	Applicable to: Tech, Policy, FounderBelief, FollowerBelief, Promotion, EventChoice
 
 ??? example  "Will not be displayed in Civilopedia"
 	This unique is automatically hidden from users.


### PR DESCRIPTION
I believe `[relativeAmount]% weight to this choice for AI decisions` is already applied to `Trigger [event]` choices, but it doesn't allow adding the weighted choices to EventChoices in the JSON.  This change lets Unciv know that you can add a weighted AI decicions to event choices. For example...

```json
{
	"name": "Free Unit",
	"text": "Select a free unit!",
	"presentation": "Alert",
	"choices": [
		{
			"text": "Warrior",
			"uniques": [
				"Free [Warrior] appears"
			]
		},
		{
			"text": "Giant Death Robot",
			"uniques": [
				"Free [Giant Death Robot] appears",
				"[+100]% weight to this choice for AI decisions"
			]
		}
	}
}
```
This way, the AI would always choose Giant Death Robot over a Warrior. Before, Unciv would complain that you couldn't set a weighted decision for the events.
