### PR TITLE
implement `KtorGithubAPI` and temporarily ignore unsuccessful status codes while fetching mods list

### DIFF
--- a/core/src/com/unciv/logic/github/Github.kt
+++ b/core/src/com/unciv/logic/github/Github.kt
@@ -12,7 +12,7 @@ import com.unciv.logic.github.Github.download
 import com.unciv.logic.github.Github.downloadAndExtract
 import com.unciv.logic.github.Github.repoNameToFolderName
 import com.unciv.logic.github.Github.tryGetGithubReposWithTopic
-import com.unciv.logic.github.GithubAPI.getUrlForTreeQuery
+import com.unciv.logic.github.GithubAPI.fetchReleaseZip
 import com.unciv.models.ruleset.ModOptions
 import com.unciv.utils.Concurrency
 import com.unciv.utils.Log
@@ -362,26 +362,29 @@ object Github {
     /** Get a Pixmap from a "preview" png or jpg file at the root of the repo, falling back to the
      *  repo owner's avatar [avatarUrl]. The file content url is constructed from [modUrl] and [defaultBranch]
      *  by replacing the host with `raw.githubusercontent.com`.
+     *  
+     *  @return [Pixmap] on success or `null` on failure
      */
-    fun tryGetPreviewImage(modUrl: String, defaultBranch: String, avatarUrl: String?): Pixmap? {
+    suspend fun getPreviewImageOrNull(modUrl: String, defaultBranch: String, avatarUrl: String?): Pixmap? {
         // Side note: github repos also have a "Social Preview" optionally assignable on the repo's
         // settings page, but that info is inaccessible using the v3 API anonymously. The easiest way
         // to get it would be to query the the repo's frontend page (modUrl), and parse out
         // `head/meta[property=og:image]/@content`, which is one extra spurious roundtrip and a
         // non-trivial waste of bandwidth.
         // Thus we ask for a "preview" file as part of the repo contents instead.
-        val fileLocation = GithubAPI.getUrlForPreview(modUrl, defaultBranch)
         try {
-            val file = download("$fileLocation.jpg", shouldLogError = false)
-                ?: download("$fileLocation.png", shouldLogError = false)
-                    // Note: avatar urls look like: https://avatars.githubusercontent.com/u/<number>?v=4
-                    // So the image format is only recognizable from the response "Content-Type" header
-                    // or by looking for magic markers in the bits - which the Pixmap constructor below does.
-                ?: avatarUrl?.let { download(it, shouldLogError = false) }
+            val resp = KtorGithubAPI.fetchPreviewImageOrNull(modUrl, defaultBranch, "jpg")
+                ?: KtorGithubAPI.fetchPreviewImageOrNull(modUrl, defaultBranch, "png")
+                // Note: avatar urls look like: https://avatars.githubusercontent.com/u/<number>?v=4
+                // So the image format is only recognizable from the response "Content-Type" header
+                // or by looking for magic markers in the bits - which the Pixmap constructor below does.
+                ?: avatarUrl?.let { KtorGithubAPI.getOrNull(it) }
                 ?: return null
-            val byteArray = file.readBytes()
-            val buffer = ByteBuffer.allocateDirect(byteArray.size).put(byteArray).position(0)
-            return Pixmap(buffer)
+            return if (resp.status.isSuccess()) {
+                val byteArray = resp.bodyAsBytes()
+                val buffer = ByteBuffer.allocateDirect(byteArray.size).put(byteArray).position(0)
+                Pixmap(buffer)
+            } else null
         } catch (_: Throwable) {
             return null
         }
@@ -391,24 +394,11 @@ object Github {
      *  @return -1 on failure, else size rounded to kB
      *  @see <a href="https://docs.github.com/en/rest/git/trees#get-a-tree">Github API "Get a tree"</a>
      */
-    fun getRepoSize(repo: GithubAPI.Repo): Int {
-        val link = repo.getUrlForTreeQuery()
+    suspend fun getRepoSize(repo: GithubAPI.Repo): Int {
+        val resp = repo.fetchReleaseZip()
 
-        var retries = 2
-        while (retries > 0) {
-            retries--
-            // obey rate limit
-            if (RateLimit.waitForLimit()) return -1
-            // try download
-            val inputStream = download(link) {
-                if (it.responseCode == 403 || it.responseCode == 200 && retries == 1) {
-                    // Pass the response headers to the rate limit handler so it can process the rate limit headers
-                    RateLimit.notifyHttpResponse(it)
-                    retries++   // An extra retry so the 403 is ignored in the retry count
-                }
-            } ?: continue
-
-            val tree = json().fromJson(GithubAPI.Tree::class.java, inputStream.bufferedReader().readText())
+        if (resp.status.isSuccess()) {
+            val tree = json().fromJson(GithubAPI.Tree::class.java, resp.bodyAsText())
             if (tree.truncated) return -1  // unlikely: >100k blobs or blob > 7MB
 
             var totalSizeBytes = 0L
@@ -418,6 +408,7 @@ object Github {
             // overflow unlikely: >2TB
             return ((totalSizeBytes + 512) / 1024).toInt()
         }
+
         return -1
     }
 

--- a/core/src/com/unciv/logic/github/GithubAPI.kt
+++ b/core/src/com/unciv/logic/github/GithubAPI.kt
@@ -1,6 +1,7 @@
 package com.unciv.logic.github
 
 import com.unciv.json.json
+import com.unciv.logic.github.GithubAPI.parseUrl
 
 /**
  *  "Namespace" collects all Github API structural knowledge
@@ -24,11 +25,6 @@ object GithubAPI {
     // Problems with the latter: Internal zip structure different, finalDestinationName would need a patch. Plus, normal URL escaping for owner/reponame does not work.
     internal fun getUrlForBranchZip(gitRepoUrl: String, branch: String) = "$gitRepoUrl/archive/refs/heads/$branch.zip"
 
-    /** Format a URL to query for Mod repos by topic */
-    internal fun getUrlForModListing(searchRequest: String, amountPerPage: Int, page: Int) =
-        // Add + if needed to separate the query text from its parameters
-        "https://api.github.com/search/repositories?q=$searchRequest${ if (searchRequest.isEmpty()) "" else "+" }%20topic:unciv-mod%20fork:true&sort:stars&per_page=$amountPerPage&page=$page"
-
     /** Format URL to fetch one specific [Repo] metadata from the API */
     private fun getUrlForSingleRepoQuery(owner: String, repoName: String) = "https://api.github.com/repos/$owner/$repoName"
 
@@ -43,10 +39,6 @@ object GithubAPI {
     /** Format a URL to fetch a preview image - without extension */
     internal fun getUrlForPreview(modUrl: String, branch: String) = "$modUrl/$branch/preview"
         .replace("github.com", "raw.githubusercontent.com")
-
-    /** A query returning all known topics staring with "unciv-mod" and having at least two uses */
-    // `+repositories:>1` means ignore unused or practically unused topics
-    internal const val urlToQueryModTopics = "https://api.github.com/search/topics?q=unciv-mod+repositories:%3E1&sort=name&order=asc"
 
     //endregion
     //region responses

--- a/core/src/com/unciv/logic/github/KtorGithubAPI.kt
+++ b/core/src/com/unciv/logic/github/KtorGithubAPI.kt
@@ -18,8 +18,11 @@ object KtorGithubAPI {
      */
     const val baseUrl = "https://api.github.com"
 
-    // add bearer token here if needed
-    // see: https://github.com/yairm210/Unciv/issues/13951#issuecomment-3326406877
+    /**
+     * Add a bearer token here if needed
+     *
+     * @see <a href="https://github.com/yairm210/Unciv/issues/13951#issuecomment-3326406877">#13951 (comment)</a>
+     */
     const val bearerToken = ""
 
     private val client = HttpClient(CIO) {
@@ -38,7 +41,7 @@ object KtorGithubAPI {
     }
 
     /**
-     * wait for rate limit to end if any and returns true if there was any rate limit
+     * Wait for rate limit to end if any and returns true if there was any rate limit
      */
     @OptIn(ExperimentalTime::class)
     private suspend fun consumeRateLimit(resp: HttpResponse): Boolean {
@@ -54,7 +57,7 @@ object KtorGithubAPI {
     }
 
     /**
-     * Make a ktor request. Stuff like rate limits, retries and redirects is handled automatically
+     * Make a ktor request handling rate limits automatically
      */
     private suspend fun request(
         maxRateLimitedRetries: Int = 3,
@@ -89,7 +92,9 @@ object KtorGithubAPI {
         parameter("sort", "name")
         parameter("order", "asc")
 
-        // `repositories:>1` means ignore unused or practically unused topics
+        /**
+         * `repositories:>1` means ignore unused or practically unused topics
+         */
         parameter("q", "unciv-mod repositories:>1")
     }
 }

--- a/core/src/com/unciv/logic/github/KtorGithubAPI.kt
+++ b/core/src/com/unciv/logic/github/KtorGithubAPI.kt
@@ -1,0 +1,80 @@
+package com.unciv.logic.github
+
+import io.ktor.client.*
+import io.ktor.client.engine.cio.*
+import io.ktor.client.plugins.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import kotlinx.coroutines.delay
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+
+object KtorGithubAPI {
+    val baseUrl = "https://api.github.com"
+
+    private val client = HttpClient(CIO) {
+        followRedirects = true
+        install(HttpRequestRetry) {
+            maxRetries = 3
+            retryOnException()
+        }
+    }
+
+    /**
+     * wait for rate limit to end if any and returns true if there was any rate limit
+     */
+    @OptIn(ExperimentalTime::class)
+    private suspend fun consumeRateLimit(resp: HttpResponse): Boolean {
+        if (resp.status != HttpStatusCode.Forbidden && resp.status != HttpStatusCode.TooManyRequests) return false
+
+        val remainingRequests = resp.headers["x-ratelimit-remaining"]?.toIntOrNull() ?: 0
+        if (remainingRequests < 1) return false
+
+        val resetEpoch = resp.headers["x-ratelimit-reset"]?.toLongOrNull() ?: 0
+        delay(Clock.System.now() - Instant.fromEpochSeconds(resetEpoch))
+
+        return true
+    }
+
+    /**
+     * Make a ktor request. Stuff like rate limits, retries and redirects is handled automatically
+     */
+    private suspend fun request(
+        maxRateLimitedRetries: Int = 3,
+        block: HttpRequestBuilder.() -> Unit,
+    ): HttpResponse {
+        val resp = client.request(block)
+        val rateLimited = consumeRateLimit(resp)
+
+        return if (rateLimited) {
+            if (maxRateLimitedRetries <= 0) return resp
+            return request(maxRateLimitedRetries - 1, block)
+        } else resp
+    }
+
+    private suspend fun paginatedRequest(
+        page: Int, amountPerPage: Int, block: HttpRequestBuilder.() -> Unit
+    ) = request {
+        parameter("page", page)
+        parameter("per_page", amountPerPage)
+        block()
+    }
+
+    suspend fun fetchGithubReposWithTopic(search: String, page: Int, amountPerPage: Int) =
+        paginatedRequest(page, amountPerPage) {
+            url("$baseUrl/search/repositories")
+            parameter("sort", "stars")
+            parameter("q", "$search${if (search.isEmpty()) "" else "+"} topic:unciv-mod fork:true")
+        }
+
+    suspend fun fetchGithubTopics() = request { 
+        url("$baseUrl/search/topics")
+        parameter("sort", "name")
+        parameter("order", "asc")
+
+        // `+repositories:>1` means ignore unused or practically unused topics
+        parameter("q", "unciv-mod repositories:>1")
+    }
+}

--- a/core/src/com/unciv/logic/github/KtorGithubAPI.kt
+++ b/core/src/com/unciv/logic/github/KtorGithubAPI.kt
@@ -74,7 +74,7 @@ object KtorGithubAPI {
         parameter("sort", "name")
         parameter("order", "asc")
 
-        // `+repositories:>1` means ignore unused or practically unused topics
+        // `repositories:>1` means ignore unused or practically unused topics
         parameter("q", "unciv-mod repositories:>1")
     }
 }

--- a/core/src/com/unciv/logic/github/KtorGithubAPI.kt
+++ b/core/src/com/unciv/logic/github/KtorGithubAPI.kt
@@ -33,7 +33,7 @@ object KtorGithubAPI {
         if (remainingRequests < 1) return false
 
         val resetEpoch = resp.headers["x-ratelimit-reset"]?.toLongOrNull() ?: 0
-        delay(Clock.System.now() - Instant.fromEpochSeconds(resetEpoch))
+        delay(Instant.fromEpochSeconds(resetEpoch) - Clock.System.now())
 
         return true
     }
@@ -69,7 +69,7 @@ object KtorGithubAPI {
             parameter("q", "$search${if (search.isEmpty()) "" else "+"} topic:unciv-mod fork:true")
         }
 
-    suspend fun fetchGithubTopics() = request { 
+    suspend fun fetchGithubTopics() = request {
         url("$baseUrl/search/topics")
         parameter("sort", "name")
         parameter("order", "asc")

--- a/core/src/com/unciv/logic/github/KtorGithubAPI.kt
+++ b/core/src/com/unciv/logic/github/KtorGithubAPI.kt
@@ -16,6 +16,7 @@ object KtorGithubAPI {
     const val baseUrl = "https://api.github.com"
 
     // add bearer token here if needed
+    // see: https://github.com/yairm210/Unciv/issues/13951#issuecomment-3326406877
     const val bearerToken = ""
 
     private val client = HttpClient(CIO) {

--- a/core/src/com/unciv/logic/github/KtorGithubAPI.kt
+++ b/core/src/com/unciv/logic/github/KtorGithubAPI.kt
@@ -59,9 +59,21 @@ object KtorGithubAPI {
     }
 
     /**
+     * Wrapper for [client.get][HttpClient.get] that returns `null` on failure
+     * 
+     * @return [HttpResponse] on success and `null` on failure
+     */
+    suspend fun getOrNull(url: String, block: HttpRequestBuilder.() -> Unit = {}) = try {
+        val resp = client.get(url, block)
+        if (resp.status.isSuccess()) resp else null
+    } catch (_: Throwable) {
+        null
+    }
+
+    /**
      * Make a ktor request handling rate limits automatically
      */
-    private suspend fun request(
+    suspend fun request(
         maxRateLimitedRetries: Int = 3,
         block: HttpRequestBuilder.() -> Unit,
     ): HttpResponse {
@@ -99,4 +111,10 @@ object KtorGithubAPI {
          */
         parameter("q", "unciv-mod repositories:>1")
     }
+
+    suspend fun fetchSingleRepo(owner: String, repoName: String) =
+        request { url("/repos/$owner/$repoName") }
+
+    suspend fun fetchPreviewImageOrNull(modUrl: String, branch: String, ext: String) =
+        getOrNull("$modUrl/$branch/preview.${ext}") { host = "raw.githubusercontent.com" }
 }

--- a/core/src/com/unciv/logic/github/KtorGithubAPI.kt
+++ b/core/src/com/unciv/logic/github/KtorGithubAPI.kt
@@ -12,7 +12,7 @@ import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 
 object KtorGithubAPI {
-    val baseUrl = "https://api.github.com"
+    const val baseUrl = "https://api.github.com"
 
     private val client = HttpClient(CIO) {
         followRedirects = true

--- a/core/src/com/unciv/logic/github/KtorGithubAPI.kt
+++ b/core/src/com/unciv/logic/github/KtorGithubAPI.kt
@@ -13,6 +13,9 @@ import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 
 object KtorGithubAPI {
+    /**
+     * https://ktor.io/docs/client-default-request.html#url
+     */
     const val baseUrl = "https://api.github.com"
 
     // add bearer token here if needed
@@ -26,6 +29,7 @@ object KtorGithubAPI {
             retryOnException()
         }
         defaultRequest {
+            url(baseUrl)
             header("X-GitHub-Api-Version", "2022-11-28")
             header(HttpHeaders.Accept, "application/vnd.github+json")
             userAgent(UncivGame.getUserAgent("Github"))
@@ -75,13 +79,13 @@ object KtorGithubAPI {
 
     suspend fun fetchGithubReposWithTopic(search: String, page: Int, amountPerPage: Int) =
         paginatedRequest(page, amountPerPage) {
-            url("$baseUrl/search/repositories")
+            url("/search/repositories")
             parameter("sort", "stars")
             parameter("q", "$search${if (search.isEmpty()) "" else "+"} topic:unciv-mod fork:true")
         }
 
     suspend fun fetchGithubTopics() = request {
-        url("$baseUrl/search/topics")
+        url("/search/topics")
         parameter("sort", "name")
         parameter("order", "asc")
 

--- a/core/src/com/unciv/logic/github/KtorGithubAPI.kt
+++ b/core/src/com/unciv/logic/github/KtorGithubAPI.kt
@@ -1,5 +1,6 @@
 package com.unciv.logic.github
 
+import com.unciv.UncivGame
 import io.ktor.client.*
 import io.ktor.client.engine.cio.*
 import io.ktor.client.plugins.*
@@ -14,11 +15,20 @@ import kotlin.time.Instant
 object KtorGithubAPI {
     const val baseUrl = "https://api.github.com"
 
+    // add bearer token here if needed
+    const val bearerToken = ""
+
     private val client = HttpClient(CIO) {
         followRedirects = true
         install(HttpRequestRetry) {
             maxRetries = 3
             retryOnException()
+        }
+        defaultRequest {
+            header("X-GitHub-Api-Version", "2022-11-28")
+            header(HttpHeaders.Accept, "application/vnd.github+json")
+            userAgent(UncivGame.getUserAgent("Github"))
+            if (bearerToken.isNotBlank()) bearerAuth(bearerToken)
         }
     }
 

--- a/core/src/com/unciv/logic/github/KtorGithubAPI.kt
+++ b/core/src/com/unciv/logic/github/KtorGithubAPI.kt
@@ -14,7 +14,9 @@ import kotlin.time.Instant
 
 object KtorGithubAPI {
     /**
-     * https://ktor.io/docs/client-default-request.html#url
+     * @see <a href="https://ktor.io/docs/client-default-request.html#url">
+     *          Ktor Client > Developing applications > Requests > Default request > Base URL
+     *      </a>
      */
     const val baseUrl = "https://api.github.com"
 

--- a/core/src/com/unciv/models/metadata/ModCategories.kt
+++ b/core/src/com/unciv/models/metadata/ModCategories.kt
@@ -51,7 +51,7 @@ class ModCategories : ArrayList<ModCategories.Category>() {
         }
 
         fun default() = Category.All
-        fun mergeOnline() = INSTANCE.mergeOnline()
+        suspend fun mergeOnline() = INSTANCE.mergeOnline()
         fun fromSelectBox(selectBox: TranslatedSelectBox) = INSTANCE.fromSelectBox(selectBox)
         fun asSequence() = INSTANCE.asSequence().filter { !it.hidden }
         operator fun iterator() = asSequence().iterator()
@@ -69,7 +69,7 @@ class ModCategories : ArrayList<ModCategories.Category>() {
         return firstOrNull { it.label == selected } ?: Category.All
     }
 
-    fun mergeOnline(): String {
+    suspend fun mergeOnline(): String {
         val topics = Github.tryGetGithubTopics() ?: return "Failed"
         var newCount = 0
         for (topic in topics.items.sortedBy { it.name }) {

--- a/core/src/com/unciv/ui/screens/modmanager/ModInfoAndActionPane.kt
+++ b/core/src/com/unciv/ui/screens/modmanager/ModInfoAndActionPane.kt
@@ -145,7 +145,7 @@ internal class ModInfoAndActionPane : Table() {
         }
 
         Concurrency.run {
-            val imagePixmap = Github.tryGetPreviewImage(repoUrl, defaultBranch, avatarUrl)
+            val imagePixmap = Github.getPreviewImageOrNull(repoUrl, defaultBranch, avatarUrl)
 
             if (imagePixmap == null) {
                 repoUrlToPreviewImage[repoUrl] = null

--- a/core/src/com/unciv/ui/screens/modmanager/ModManagementScreen.kt
+++ b/core/src/com/unciv/ui/screens/modmanager/ModManagementScreen.kt
@@ -20,7 +20,6 @@ import com.unciv.models.ruleset.Ruleset
 import com.unciv.models.ruleset.RulesetCache
 import com.unciv.models.tilesets.TileSetCache
 import com.unciv.models.translations.tr
-import com.unciv.ui.components.widgets.UncivTextField
 import com.unciv.ui.components.extensions.addSeparator
 import com.unciv.ui.components.extensions.disable
 import com.unciv.ui.components.extensions.enable
@@ -36,6 +35,7 @@ import com.unciv.ui.components.input.onClick
 import com.unciv.ui.components.widgets.AutoScrollPane
 import com.unciv.ui.components.widgets.ExpanderTab
 import com.unciv.ui.components.widgets.LoadingImage
+import com.unciv.ui.components.widgets.UncivTextField
 import com.unciv.ui.components.widgets.WrappableLabel
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.popups.ConfirmPopup
@@ -280,9 +280,9 @@ class ModManagementScreen private constructor(
      */
     private fun tryDownloadPage(pageNum: Int) {
         runningSearchJob = Concurrency.run("GitHubSearch") {
-            val repoSearch: GithubAPI.RepoSearch
+            val repoSearch: GithubAPI.RepoSearch?
             try {
-                repoSearch = Github.tryGetGithubReposWithTopic(amountPerPage, pageNum)!!
+                repoSearch = Github.tryGetGithubReposWithTopic(pageNum, amountPerPage)
             } catch (ex: Exception) {
                 Log.error("Could not download mod list", ex)
                 launchOnGLThread {
@@ -297,7 +297,7 @@ class ModManagementScreen private constructor(
                 return@run
             }
 
-            if (!isActive) {
+            if (!isActive || repoSearch == null) {
                 return@run
             }
 

--- a/core/src/com/unciv/ui/screens/savescreens/LoadOrSaveScreen.kt
+++ b/core/src/com/unciv/ui/screens/savescreens/LoadOrSaveScreen.kt
@@ -213,10 +213,10 @@ abstract class LoadOrSaveScreen(
             return Pair(errorText.toString(), isUserFixable)
         }
 
-        fun loadMissingMods(missingMods: Iterable<String>, onModDownloaded:(String)->Unit, onCompleted:()->Unit) {
+        suspend fun loadMissingMods(missingMods: Iterable<String>, onModDownloaded:(String)->Unit, onCompleted:()->Unit) {
             for (rawName in missingMods) {
                 val modName = rawName.folderNameToRepoName().lowercase()
-                val repos = Github.tryGetGithubReposWithTopic(10, 1, modName)
+                val repos = Github.tryGetGithubReposWithTopic(1, 10, modName)
                     ?: throw UncivShowableException("Could not download mod list.")
                 val repo = repos.items.firstOrNull { it.name.lowercase() == modName }
                     ?: throw UncivShowableException("Could not find a mod named \"[$modName]\".")


### PR DESCRIPTION
fixes #13951 by temporarily ignoring the underlying cause (;P)

# Inspiration

We already have `ktor-client` as dependency, so why are we manually handing stuff like redirects, retries, query params and so on? Using `ktor-client` simplifies many things. The plan is to gradually refactor everything in `object Github` & `object GithubAPI` to use `ktor-client`. In future, `KtorGithubAPI` should become `GithubAPI`.

Also, comparing the code before and code after, it definitely makes the code-base more maintainable and readable.

# Regarding #13951 fix

We are ignoring unsuccessful status codes here while fetching mods list (expect rate-limits). This allows us to ignore the `422` status code that we get while trying to load the mods list. This does not fix the underlying issue buy fixes the problem temporarily.

an alternative fix can also be building a mods list manually during build and shipping the json with the app each time we upload a new version.

# Testing

Yes, I did test to check if this works.