### PR TITLE
Fix failure to build unciv with Java 25

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,10 @@ buildscript {
 // Fixes the error "Please initialize at least one Kotlin target in 'Unciv (:)'"
 kotlin {
     jvm()
+    java {
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
+    }
 }
 
 


### PR DESCRIPTION
# Why

`Java 25` has just become `LTS` and as always I am one of the first to try this out on Unciv. I already use `Gradle 9.1.0` to build Unciv and tried to build it with `Gradle 9.1.0 + Temurin 25`. But the build failed. It seems like Kotlin does not support `Java 25` yet, and my impression is me using `Java 25` somehow makes it the default `sourceCompatibility` anyways, resulting in the error.

And so I tried to be specific regarding `sourceCompatibility` and `targetCompatibility` and this fixed that?

# What should this do

In theory, `sourceCompatibility = JavaVersion.VERSION_21` is basically telling the compiler that we would like to enable all of the features that are available to `Java 21`. We can still target lower `Java` versions and `API` that are not available to those versions should be automatically provided by the compiler.


`targetCompatibility = JavaVersion.VERSION_21` however hints that we want to generate bytecode for `Java 21` anyways. However, this should not be affecting `Android` however since android's own `targetCompatibility = JavaVersion.VERSION_1_8` should be overriding it.

https://github.com/yairm210/Unciv/blob/1dcdc0437841f07f30e70eb6ccf2e907b59c7ffb/android/build.gradle.kts#L76

# Is Java 21 an issue?

Well we are technically shipping `JRE 21` with our binaries anyways so this should not be an issue. Unless someone tries to run Unciv with a lower JRE version.