### PR TITLE
Dense zero indecies

### DIFF
--- a/core/src/com/unciv/logic/map/TileMap.kt
+++ b/core/src/com/unciv/logic/map/TileMap.kt
@@ -527,14 +527,14 @@ class TileMap(initialCapacity: Int = 10) : IsPartOfGameInfoSerialization {
         for (tileInfo in values) {
             tileMatrix[tileInfo.position.x.toInt() - leftX][tileInfo.position.y.toInt() - bottomY] = tileInfo
         }
-        for (tileInfo in values) {
+        for ((index, tileInfo) in values.withIndex()) {
             // Do ***NOT*** call Tile.setTerrainTransients before the tileMatrix is complete -
             // setting transients might trigger the neighbors lazy (e.g. thanks to convertHillToTerrainFeature).
             // When that lazy runs, some directions might be omitted because getIfTileExistsOrNull
             // looks at tileMatrix. Thus filling Tiles into tileMatrix and setting their
             // transients in the same loop will leave incomplete cached `neighbors`.
             tileInfo.tileMap = this
-            tileInfo.zeroBasedIndex = HexMath.getZeroBasedIndex(tileInfo.position.x.toInt(), tileInfo.position.y.toInt())
+            tileInfo.zeroBasedIndex = index
             tileInfo.ruleset = this.ruleset!!
             tileInfo.setTerrainTransients()
             tileInfo.setUnitTransients(setUnitCivTransients)

--- a/core/src/com/unciv/logic/map/mapunit/movement/UnitMovement.kt
+++ b/core/src/com/unciv/logic/map/mapunit/movement/UnitMovement.kt
@@ -143,11 +143,11 @@ class UnitMovement(val unit: MapUnit) {
         var distance = 1
         val unitMaxMovement = unit.getMaxMovement().toFloat()
         val newTilesToCheck = ArrayList<Tile>()
-        val visitedTilesBitset = BitSet()
+        val visitedTilesBitset = BitSet(currentTile.tileMap.tileList.size)
         visitedTilesBitset.set(currentTile.zeroBasedIndex)
         val civilization = unit.civ
 
-        val passThroughCacheNew = ArrayList<Boolean?>()
+        val passThroughCacheNew = ArrayList<Boolean?>(currentTile.tileMap.tileList.size)
         val movementCostCache = HashMap<Int, Float>()
         val canMoveToCache = HashMap<Tile, Boolean>()
 
@@ -739,7 +739,7 @@ class UnitMovement(val unit: MapUnit) {
     @Readonly
     fun getDistanceToTiles(
         considerZoneOfControl: Boolean = true,
-        passThroughCacheNew: ArrayList<Boolean?> = ArrayList(),
+        passThroughCacheNew: ArrayList<Boolean?> = ArrayList(unit.getTile().tileMap.tileList.size),
         movementCostCache: HashMap<Int, Float> = HashMap(),
         includeOtherEscortUnit: Boolean = true
     ): PathsToTilesWithinTurn {


### PR DESCRIPTION
Tiles zeroBasedIndecies are only used for indexing into maps. They're currently based on HexMath radius + circumference, but this leaves gaps in the index for rectangular maps, wasting space.  This change assigns them indecies based on the order in the list, which:

1. Is dense. Array-maps are no longer wasting memory.
2. Able to quickly access tiles from the list directly based on their index.
3. On non-rectangular maps, I believe these are the same indecies as before. The indecies only differ for the non-center of rectangular maps.