### PR TITLE
handleUncaughtThrowable logs exceptions even when globals not initialized

### DIFF
--- a/core/src/com/unciv/ui/crashhandling/CrashHandlingExtensions.kt
+++ b/core/src/com/unciv/ui/crashhandling/CrashHandlingExtensions.kt
@@ -16,7 +16,7 @@ fun <R> (() -> R).wrapCrashHandling(
     try {
         this()
     } catch (e: Throwable) {
-        UncivGame.Current.handleUncaughtThrowable(e)
+        UncivGame.handleUncaughtThrowable(e)
         null
     }
 }

--- a/core/src/com/unciv/utils/Concurrency.kt
+++ b/core/src/com/unciv/utils/Concurrency.kt
@@ -48,7 +48,7 @@ object Concurrency {
             try {
                 block(this)
             } catch (ex: Throwable) {
-                UncivGame.Current.handleUncaughtThrowable(ex)
+                UncivGame.handleUncaughtThrowable(ex)
                 null
             }
         }
@@ -88,7 +88,7 @@ fun CoroutineScope.launchCrashHandling(
         try {
             block(this)
         } catch (ex: Throwable) {
-            UncivGame.Current.handleUncaughtThrowable(ex)
+            UncivGame.handleUncaughtThrowable(ex)
         }
     }
 }


### PR DESCRIPTION
handleUncaughtThrowable logs exceptions even when globals not initialized.