### PR TITLE
Update purity-annotations to 1.3.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -174,7 +174,7 @@ project(":core") {
         "implementation"("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion")
         "implementation"("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
 
-        "implementation"("io.github.yairm210:purity-annotations:0.0.51")
+        "implementation"("io.github.yairm210:purity-annotations:1.3.0")
 
         "implementation"("io.ktor:ktor-client-core:$ktorVersion")
         "implementation"("io.ktor:ktor-client-cio:$ktorVersion")


### PR DESCRIPTION
Saw that while Purity was moved to 1.3.0, the purity-annotations wasn't updated.
