### PR TITLE
Disable automatic counter-denunciation for human players

### DIFF
--- a/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
@@ -679,38 +679,46 @@ class DiplomacyManager() : IsPartOfGameInfoSerialization {
     }
 
     fun denounce() {
+        activateDenounceEffects()
+        if (otherCiv().isAI())
+            otherCivDiplomacy().activateDenounceEffects()
+    }
+    
+    private fun activateDenounceEffects() {
         setFlag(DiplomacyFlags.Denunciation, 30)
         otherCivDiplomacy().setModifier(DiplomaticModifiers.Denunciation, -35f)
-        if (otherCiv().isAI()) {
-            otherCivDiplomacy().setFlag(DiplomacyFlags.Denunciation, 30)
-            setModifier(DiplomaticModifiers.Denunciation, -35f)
-        }
-
+        
+        otherCiv().addNotification(
+            "[${civInfo.civName}] has denounced us!",
+            NotificationCategory.Diplomacy,
+            NotificationIcon.Diplomacy, civInfo.civName
+        )
+        
         // Denounciation results in removal of embasies for both sides
         civInfo.diplomacyFunctions.removeEmbassies(otherCiv())
 
-        otherCiv().addNotification("[${civInfo.civName}] has denounced us!",
-            NotificationCategory.Diplomacy, NotificationIcon.Diplomacy, civInfo.civName)
-
         // We, A, are denouncing B. What do other major civs (C,D, etc) think of this?
         getCommonKnownCivsWithSpectators().forEach { thirdCiv ->
-            thirdCiv.addNotification("[${civInfo.civName}] has denounced [$otherCivName]!",
-                NotificationCategory.Diplomacy, civInfo.civName, NotificationIcon.Diplomacy, otherCivName)
-            if (thirdCiv.isSpectator()) return@forEach
-            fun affectThirdCivRelationship(denouncerCiv: Civilization, receiverCiv: Civilization) {
-                val thirdCivRelationshipWithReceiver = thirdCiv.getDiplomacyManager(receiverCiv)!!.relationshipIgnoreAfraid()
-                val thirdCivRelationshipWithDenouncer = thirdCiv.getDiplomacyManager(denouncerCiv)!!
-                when (thirdCivRelationshipWithReceiver) {
-                    RelationshipLevel.Unforgivable -> thirdCivRelationshipWithDenouncer.addModifier(DiplomaticModifiers.DenouncedOurEnemies, 15f)
-                    RelationshipLevel.Enemy -> thirdCivRelationshipWithDenouncer.addModifier(DiplomaticModifiers.DenouncedOurEnemies, 5f)
-                    RelationshipLevel.Friend -> thirdCivRelationshipWithDenouncer.addModifier(DiplomaticModifiers.DenouncedOurAllies, -5f)
-                    RelationshipLevel.Ally -> thirdCivRelationshipWithDenouncer.addModifier(DiplomaticModifiers.DenouncedOurAllies, -15f)
-                    else -> {}
-                }
+            thirdCiv.addNotification(
+                "[${civInfo.civName}] has denounced [${otherCiv().civName}]!",
+                NotificationCategory.Diplomacy,
+                civInfo.civName, NotificationIcon.Diplomacy, otherCivName
+            )
+            
+            if (thirdCiv.isSpectator())
+                return@forEach
+
+            // their relationship with us
+            val thirdCivRelationship = thirdCiv.getDiplomacyManager(civInfo)!!
+            // their relationship with the civ we are denouncing
+            val thirdCivRelationshipWithTarget = thirdCiv.getDiplomacyManager(otherCiv())!!.relationshipIgnoreAfraid()
+            when (thirdCivRelationshipWithTarget) {
+                RelationshipLevel.Unforgivable -> thirdCivRelationship.addModifier(DiplomaticModifiers.DenouncedOurEnemies, 15f)
+                RelationshipLevel.Enemy -> thirdCivRelationship.addModifier(DiplomaticModifiers.DenouncedOurEnemies, 5f)
+                RelationshipLevel.Friend -> thirdCivRelationship.addModifier(DiplomaticModifiers.DenouncedOurAllies, -5f)
+                RelationshipLevel.Ally -> thirdCivRelationship.addModifier(DiplomaticModifiers.DenouncedOurAllies, -15f)
+                else -> {}
             }
-            affectThirdCivRelationship(civInfo, otherCiv())
-            if (otherCiv().isAI())
-                affectThirdCivRelationship(otherCiv(), civInfo)
         }
     }
     


### PR DESCRIPTION
Before this PR:
If player A denounces player B, player B will immediately and automatically denounce player A.
This happens regardless if player B is human or AI.

After this PR:
If player B is human, they will not automatically denounce player A.