### PR TITLE
Music: Add Victory Type-specific tracks

### DIFF
--- a/core/src/com/unciv/ui/screens/victoryscreen/VictoryScreen.kt
+++ b/core/src/com/unciv/ui/screens/victoryscreen/VictoryScreen.kt
@@ -156,10 +156,14 @@ class VictoryScreen(
             ?: Victory()  // This contains our default victory/defeat texts
         if (winningCiv == playerCiv.civName) {
             displayWonOrLost("You have won a [$victoryType] Victory!", victory.victoryString)
-            music.chooseTrack(playerCiv.civName, listOf(MusicMood.Victory, MusicMood.Theme), EnumSet.of(MusicTrackChooserFlags.SuffixMustMatch))
+            if (!music.chooseTrack(victory.name, MusicMood.Victory, EnumSet.of(MusicTrackChooserFlags.PrefixMustMatch, MusicTrackChooserFlags.SuffixMustMatch))) {
+                music.chooseTrack(playerCiv.civName, listOf(MusicMood.Victory, MusicMood.Theme), EnumSet.of(MusicTrackChooserFlags.SuffixMustMatch))
+            }
         } else {
             displayWonOrLost("[$winningCiv] has won a [$victoryType] Victory!", victory.defeatString)
-            music.chooseTrack(playerCiv.civName, MusicMood.Defeat, EnumSet.of(MusicTrackChooserFlags.SuffixMustMatch))
+            if (!music.chooseTrack(victory.name, MusicMood.Defeat, EnumSet.of(MusicTrackChooserFlags.PrefixMustMatch, MusicTrackChooserFlags.SuffixMustMatch))) {
+                music.chooseTrack(playerCiv.civName, MusicMood.Defeat, EnumSet.of(MusicTrackChooserFlags.SuffixMustMatch))
+            }
         }
         worldScreen.autoPlay.stopAutoPlay()
     }

--- a/docs/Modders/Images-and-Audio.md
+++ b/docs/Modders/Images-and-Audio.md
@@ -286,8 +286,8 @@ The current list of triggers is as follows:
 | Diplomacy: Select player                           | (nation name)     | [^M] | Peace or War[^3] |       | [^S]  |
 | First contact[^4]                                  | (civ name)        | [^M] |   Theme or Peace | [^X]  |       |
 | War declaration[^5]                                | (civ name)        | [^M] |              War | [^X]  |       |
-| Civ defeated                                       | (civ name)        |      |           Defeat | [^X]  |       |
-| Player wins                                        | (civ name)        |      |          Victory | [^X]  |       |
+| Civ defeated                                       | (victory/civ name) |     |           Defeat | [^X]  |       |
+| Player wins                                        | (victory/civ name) |     |          Victory | [^X]  |       |
 | Golden Age                                         | (civ name)        | [^M] |           Golden | [^X]  |       |
 | Wonder built                                       | (wonder name)     | [^M] |           Wonder | [^X]  |       |
 | Tech researched                                    | (tech name)       | [^M] |       Researched | [^X]  |       |


### PR DESCRIPTION
This change allows for victory-type specific music when achieving a victory. For example...

```
Domination Victory.mp3
Diplomatic Victory.mp3
Cultural Victory.mp3
```

It prioritizes using those tracks before falling back to the civ-specific ones...
```
Korea Victory.mp3
Korea Theme.mp3
Victory.mp3
Theme.mp3
```

The same applies to Defeat. As a demonstration, see the [Civ V - Voices mod](https://github.com/RobLoach/Civ-V---Voices).
 
