### PR TITLE
Changes to Naval Tradition Policy under Commerce

### DIFF
--- a/android/assets/jsons/Civ V - Gods & Kings/Policies.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Policies.json
@@ -359,9 +359,8 @@
                 "uniques": [
                     "[+1] Movement <for [{Military} {Water}] units>",
                     "[+1] Sight <for [{Military} {Water}] units>",
-                    "Free [Great General] appears"
-                    // "[+2] Movement <for [Great Admiral] units>"
-                    // ToDo: Should be "Free [Great Admiral] appears"
+                    "Free [Great Admiral] appears",
+                    "[+2] Movement <for [Great Admiral] units>",
                 ],
                 "row": 1,
                 "column": 2


### PR DESCRIPTION
Changed Great General to Great Admiral in Commerce Tree Naval Tradition Policy as per suites uniques based on Civ 5.

Reference: https://civilization.fandom.com/wiki/Naval_Tradition_(Civ5)