### PR TITLE
City Screen: Display Stockpile Amount Available for Cost

### DIFF
--- a/core/src/com/unciv/ui/components/extensions/FormattingExtensions.kt
+++ b/core/src/com/unciv/ui/components/extensions/FormattingExtensions.kt
@@ -21,11 +21,27 @@ import java.util.SortedMap
 /** Translate a percentage number - e.g. 25 - to the multiplication value - e.g. 1.25f */
 @Pure fun Float.toPercent() = 1 + this/100
 
-/** Convert a [resource name][this] into "Consumes [amount] $resource" string (untranslated) */
-@Pure fun String.getConsumesAmountString(amount: Int, isStockpiled: Boolean, perTurn: Boolean = true, label: String = "Consumes"): String {
-    val uniqueString = "{$label [$amount] [$this]}"
-    val perTurnString = if (perTurn) " /${Fonts.turn}" else ""
-    return if (isStockpiled) "${uniqueString}${perTurnString}" else uniqueString
+/**
+ * Convert a [resource name][this] into "Consumes [amount] $resource" string (untranslated)
+ *
+ * @param [available] Appends ` ([amount] available)` when the available parameter is provided.
+ */
+@Pure fun String.getConsumesAmountString(amount: Int, isStockpiled: Boolean, available: Int = -1): String {
+    val uniqueString = "{Consumes [$amount] [$this]}"
+    val perTurnString = if(isStockpiled) " /${Fonts.turn}" else ""
+    val availableString = if (available >= 0) " ({[$available] available})" else ""
+    return uniqueString + perTurnString + availableString
+}
+
+/**
+ * Convert a [resource name][this] into "Costs [amount] $resource" string (untranslated).
+ *
+ * @param [available] Appends ` ([amount] available)` when the available parameter is provided.
+ */
+@Pure fun String.getCostsAmountString(amount: Int, available: Int = -1): String {
+    val uniqueString = "{Costs [$amount] [$this]}"
+    val availableString = if (available >= 0) " ({[$available] available})" else ""
+    return uniqueString + availableString
 }
 
 /** Convert a [resource name][this] into "Need [amount] more $resource" string (untranslated) */

--- a/core/src/com/unciv/ui/objectdescriptions/BaseUnitDescriptions.kt
+++ b/core/src/com/unciv/ui/objectdescriptions/BaseUnitDescriptions.kt
@@ -15,6 +15,7 @@ import com.unciv.models.ruleset.unit.UnitType
 import com.unciv.models.stats.Stat
 import com.unciv.models.translations.tr
 import com.unciv.ui.components.extensions.getConsumesAmountString
+import com.unciv.ui.components.extensions.getCostsAmountString
 import com.unciv.ui.components.fonts.Fonts
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.screens.civilopediascreen.FormattedLine
@@ -41,20 +42,19 @@ object BaseUnitDescriptions {
     fun getDescription(baseUnit: BaseUnit, city: City): String {
         val lines = mutableListOf<String>()
         val availableResources = city.civ.getCivResourcesByName()
+
+        // Consumes
         for ((resourceName, amount) in baseUnit.getResourceRequirementsPerTurn(city.civ.state)) {
             val available = availableResources[resourceName] ?: 0
             val resource = baseUnit.ruleset.tileResources[resourceName] ?: continue
-            val consumesString = resourceName.getConsumesAmountString(amount, resource.isStockpiled)
-            lines += "$consumesString ({[$available] available})".tr()
+            lines += resourceName.getConsumesAmountString(amount, resource.isStockpiled, available).tr()
         }
 
+        // Costs
         for ((resourceName, amount) in baseUnit.getStockpiledResourceRequirements(city.civ.state)) {
             val available = city.getAvailableResourceAmount(resourceName)
             val resource = city.getRuleset().tileResources[resourceName] ?: continue
-            val costsString = resourceName.getConsumesAmountString(amount, resource.isStockpiled,
-                perTurn = false,
-                label = "Costs")
-            lines += "$costsString ({[$available] available})".tr()
+            lines += resourceName.getCostsAmountString(amount, available).tr()
         }
 
         var strengthLine = ""

--- a/core/src/com/unciv/ui/objectdescriptions/BuildingDescriptions.kt
+++ b/core/src/com/unciv/ui/objectdescriptions/BuildingDescriptions.kt
@@ -10,6 +10,7 @@ import com.unciv.models.stats.Stat
 import com.unciv.models.translations.fillPlaceholders
 import com.unciv.models.translations.tr
 import com.unciv.ui.components.extensions.getConsumesAmountString
+import com.unciv.ui.components.extensions.getCostsAmountString
 import com.unciv.ui.components.extensions.toStringSigned
 import com.unciv.ui.components.fonts.Fonts
 import com.unciv.ui.screens.civilopediascreen.FormattedLine
@@ -48,30 +49,26 @@ object BuildingDescriptions {
         if (isWonder) translatedLines += "Wonder".tr()
         if (isNationalWonder) translatedLines += "National Wonder".tr()
         if (!isFree) {
+            // Consumes
             for ((resourceName, amount) in getResourceRequirementsPerTurn(city.state)) {
-                val available = city.getAvailableResourceAmount(resourceName)
+                val available = if (showAdditionalInfo) city.getAvailableResourceAmount(resourceName) else -1
                 val resource = city.getRuleset().tileResources[resourceName] ?: continue
-                val consumesString = resourceName.getConsumesAmountString(amount, resource.isStockpiled)
-
-                translatedLines += if (showAdditionalInfo) "$consumesString ({[$available] available})".tr()
-                else consumesString.tr()
+                translatedLines += resourceName.getConsumesAmountString(amount, resource.isStockpiled, available).tr()
             }
-        }
 
-        for ((resourceName, amount) in getStockpiledResourceRequirements(city.state)) {
-            val resource = city.getRuleset().tileResources[resourceName] ?: continue
-            val available = city.getAvailableResourceAmount(resourceName)
-            val costsString = resourceName.getConsumesAmountString(amount, resource.isStockpiled,
-                perTurn = false,
-                label = "Costs")
-            translatedLines += if (showAdditionalInfo) "$costsString ({[$available] available})".tr()
-            else costsString.tr()
+            // Costs
+            for ((resourceName, amount) in getStockpiledResourceRequirements(city.state)) {
+                val resource = city.getRuleset().tileResources[resourceName] ?: continue
+                val available = if (showAdditionalInfo) city.getAvailableResourceAmount(resourceName) else -1
+                translatedLines += resourceName.getCostsAmountString(amount, available).tr()
+            }
         }
 
         if (uniques.isNotEmpty()) {
             if (replacementTextForUniques.isNotEmpty()) translatedLines += replacementTextForUniques.tr()
             else translatedLines += getUniquesStringsWithoutDisablers {
-                it.type != UniqueType.ConsumesResources && it.type != UniqueType.CostsResources
+                it.type != UniqueType.ConsumesResources &&
+                it.type != UniqueType.CostsResources
             }.map { it.tr() }
         }
         if (!stats.isEmpty())


### PR DESCRIPTION
This adds the availabl eamount next to the Costs unique. Would appreciate some additional testing, as I've only tested this in one use case.

Fixes #14040


<img width="710" height="511" alt="Screenshot from 2025-10-19 14-58-59" src="https://github.com/user-attachments/assets/46384264-5ed6-4870-add4-337f0ae9f805" />
