### PR TITLE
Fix relevant Civ for within tiles Conditional

### DIFF
--- a/core/src/com/unciv/models/ruleset/unique/Conditionals.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Conditionals.kt
@@ -277,7 +277,7 @@ object Conditionals {
                 state.attackedTile?.matchesFilter(conditional.params[0], state.relevantCiv) == true
             UniqueType.ConditionalNearTiles ->
                 state.relevantTile != null && state.relevantTile!!.getTilesInDistance(conditional.params[0].toInt()).any {
-                    it.matchesFilter(conditional.params[1])
+                    it.matchesFilter(conditional.params[1], state.relevantCiv)
                 }
 
             UniqueType.ConditionalVsLargerCiv -> {


### PR DESCRIPTION
`<within [amount] tiles of a [tileFilter]>`

Fixes #13975
