### PR TITLE
Refactor CapitalConnectionsFinder to use an enum instead of strings

### DIFF
--- a/core/src/com/unciv/logic/city/City.kt
+++ b/core/src/com/unciv/logic/city/City.kt
@@ -12,6 +12,7 @@ import com.unciv.logic.city.managers.CityPopulationManager
 import com.unciv.logic.city.managers.CityReligionManager
 import com.unciv.logic.city.managers.SpyFleeReason
 import com.unciv.logic.civilization.Civilization
+import com.unciv.logic.civilization.transients.CapitalConnectionsFinder.CapitalConnectionMedium
 import com.unciv.logic.map.TileMap
 import com.unciv.logic.map.mapunit.MapUnit
 import com.unciv.logic.map.mapunit.UnitPromotions
@@ -29,6 +30,7 @@ import com.unciv.models.stats.INamed
 import com.unciv.models.stats.Stat
 import com.unciv.models.stats.SubStat
 import yairm210.purity.annotations.Readonly
+import java.util.EnumSet
 import java.util.UUID
 import kotlin.math.roundToInt
 
@@ -182,7 +184,11 @@ class City : IsPartOfGameInfoSerialization, INamed {
     @Readonly fun getExpandRange(): Int = civ.gameInfo.ruleset.modOptions.constants.cityExpandRange
 
     @Readonly
-    fun isConnectedToCapital(@Readonly connectionTypePredicate: (Set<String>) -> Boolean = { true }): Boolean {
+    fun isConnectedToCapital() = this in civ.cache.citiesConnectedToCapitalToMediums
+    @Readonly
+    fun isConnectedToCapital(
+        @Readonly connectionTypePredicate: (EnumSet<CapitalConnectionMedium>) -> Boolean
+    ): Boolean {
         val mediumTypes = civ.cache.citiesConnectedToCapitalToMediums[this] ?: return false
         return connectionTypePredicate(mediumTypes)
     }

--- a/core/src/com/unciv/logic/city/CityStats.kt
+++ b/core/src/com/unciv/logic/city/CityStats.kt
@@ -314,22 +314,21 @@ class CityStats(val city: City) {
 
     @Readonly
     fun isConnectedToCapital(roadType: RoadStatus): Boolean {
-        if (city.civ.cities.size < 2) return false// first city!
+        if (city.civ.cities.size < 2) return false // first city!
 
         // Railroad, or harbor from railroad
         return if (roadType == RoadStatus.Railroad)
                 city.isConnectedToCapital {
-                    roadTypes ->
-                    roadTypes.any { it.contains(RoadStatus.Railroad.name) }
+                    mediums ->
+                    mediums.any { it.roadType == RoadStatus.Railroad }
                 }
             else city.isConnectedToCapital()
     }
 
     @Readonly
     fun getRoadTypeOfConnectionToCapital(): RoadStatus {
-        return if (isConnectedToCapital(RoadStatus.Railroad)) RoadStatus.Railroad
-        else if (isConnectedToCapital(RoadStatus.Road)) RoadStatus.Road
-        else RoadStatus.None
+        return city.civ.cache.citiesConnectedToCapitalToMediums[city]?.maxOfOrNull { it.roadType }
+            ?: RoadStatus.None
     }
 
     @Readonly


### PR DESCRIPTION
Another side effect of #14056, this is more of a "hey how about this" than a "I believe this is a must".

Basically, memory efficiency and performance should improve from
- EnumSet is touted as fast
- isConnectedToCapital() is called so often that a dedicated overload should be faster than solving that using a `{true}` lambda
- `getRoadTypeOfConnectionToCapital` should be more efficient this way - less call overhead, and the iterator cost at the end is the same

Notes:
I regret that `mediums.any { it.roadType == RoadStatus.Railroad }` line because it will iterate instead of doing a bitmask test like EnumSet is supposed to be able to - but I couldn't find the equivalent of `(status & mask) != 0` as in "is any of those bits set"? - Thus I cold use that subproperty 'cuz - won't hurt more than it hurts already.

Will conflict with #14069 - but testing done is the same - see if I can get that notification only when appropriate. But as you can see from that todo (to delete on conflict-resolution), this is actually an hour older.