### PR TITLE
Fix selecting local mods without preview won't display an avatar

### DIFF
--- a/core/src/com/unciv/ui/screens/modmanager/ModInfoAndActionPane.kt
+++ b/core/src/com/unciv/ui/screens/modmanager/ModInfoAndActionPane.kt
@@ -43,6 +43,7 @@ internal class ModInfoAndActionPane : Table() {
         isBuiltin = false
         enableVisualCheckBox = false
         update(
+            isLocal = false,
             repo.name, repo.html_url, repo.default_branch,
             repo.pushed_at, repo.owner.login, repo.size,
             repo.owner.avatar_url
@@ -58,19 +59,21 @@ internal class ModInfoAndActionPane : Table() {
         isBuiltin = modOptions.modUrl.isEmpty() && BaseRuleset.entries.any { it.fullName == modName }
         enableVisualCheckBox = ModCompatibility.isAudioVisualMod(mod)
         update(
+            isLocal = true,
             modName, modOptions.modUrl, modOptions.defaultBranch,
             modOptions.lastUpdated, modOptions.author, modOptions.modSize
         )
     }
 
     private fun update(
-           modName: String,
-           repoUrl: String,
-           defaultBranch: String,
-           updatedAt: String,
-           author: String,
-           modSize: Int,
-           avatarUrl: String? = null
+        isLocal: Boolean,
+        modName: String,
+        repoUrl: String,
+        defaultBranch: String,
+        updatedAt: String,
+        author: String,
+        modSize: Int,
+        avatarUrl: String? = null
     ) {
         // Display metadata
         clear()
@@ -79,7 +82,7 @@ internal class ModInfoAndActionPane : Table() {
         imageHolder.clear()
         when {
             isBuiltin -> addUncivLogo(modName)
-            repoUrl.isEmpty() -> addLocalPreviewImage(modName)
+            isLocal -> addLocalPreviewImage(modName)
             else -> addPreviewImage(modName, repoUrl, defaultBranch, avatarUrl)
         }
         add(imageHolder).row()


### PR DESCRIPTION
One possible approach that could fix #14006 (not retroactively, only for mods (re-)downloaded after this)

Fun: I actually had this helper in there at some point:
```kotlin
    fun ByteArray.matches(vararg b: Int) = b.withIndex().all { (i, byte) -> this[i].toUByte() == byte.toUByte() }

...
    if (data.matches(0xFF, 0xD8)) // is jpeg...
```
... all direct alternatives much uglier, but still too ugly so I came up with checking the http headers instead.