### PR TITLE
Update LuxuryResourcePlacementLogic.kt

### DIFF
--- a/core/src/com/unciv/logic/map/mapgenerator/resourceplacement/LuxuryResourcePlacementLogic.kt
+++ b/core/src/com/unciv/logic/map/mapgenerator/resourceplacement/LuxuryResourcePlacementLogic.kt
@@ -32,8 +32,8 @@ object LuxuryResourcePlacementLogic {
                 (it.hasUnique(UniqueType.ResourceWeighting) || it.hasUnique(UniqueType.LuxuryWeightingForCityStates)) }
 
         val maxRegionsWithLuxury = when {
-            regions.size > 12 -> 3
-            regions.size > 8 -> 2
+            regions.size > 14 -> 3
+            regions.size > 10 -> 2
             else -> 1
         }
         
@@ -70,7 +70,7 @@ object LuxuryResourcePlacementLogic {
 
 
         val cityStateLuxuries = assignCityStateLuxuries(
-            3, // was probably intended to be "if (tileData.size > 5000) 4 else 3",
+            4, // was probably intended to be "if (tileData.size > 5000) 4 else 3",
             assignableLuxuries,
             amountRegionsWithLuxury,
             fallbackWeightings


### PR DESCRIPTION
If I understand the code correctly, changing this number greatly reduces the need for restarts in the 10p Rekmod games on the Russian server (giving two players the same regional luxury screws over both of them, this should be avoided unless the ruleset would run out of assignable luxuries. In Vanilla ruleset there are 14 regular tile luxuries and Marble).