### PR TITLE
Fix broken "download missing mods"

### DIFF
--- a/core/src/com/unciv/logic/github/GithubAPI.kt
+++ b/core/src/com/unciv/logic/github/GithubAPI.kt
@@ -118,7 +118,7 @@ object GithubAPI {
         paginatedRequest(page, amountPerPage) {
             url("/search/repositories")
             parameter("sort", "stars")
-            parameter("q", "$search${if (search.isEmpty()) "" else "+"} topic:unciv-mod fork:true")
+            parameter("q", "$search topic:unciv-mod fork:true")
         }
 
     suspend fun fetchGithubTopics() = request {


### PR DESCRIPTION
Regression in #13963:
That '+' meant an url-encoded space before, but since HttpRequestBuilder.parameter url-encodes... I chose the simpler solution that wastes 1 byte bandwidth with an unnecessary space - since the code was already sending that...