### PR TITLE
Fix Wonder Alert without a quote

### DIFF
--- a/core/src/com/unciv/ui/screens/worldscreen/AlertPopup.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/AlertPopup.kt
@@ -448,7 +448,7 @@ class AlertPopup(
         }
 
         val centerTable = Table()
-        val centerTableColumnWidth = if (wonder.quote.isEmpty()) stageWidth / 2 else stageWidth / 3
+        val centerTableColumnWidth = stageWidth / if (wonder.quote.isEmpty()) 2 else 3
         if (wonder.quote.isNotEmpty()) {
             centerTable.add(wonder.quote.toLabel().apply { wrap = true })
                 .width(centerTableColumnWidth)


### PR DESCRIPTION
When you construct a Wonder that doesn't have a Quote, the popup alert looks off. This change makes it so that there isn't a space for the empty quote.

This was highlighted in https://github.com/yairm210/Unciv/issues/14092

### Screenshot

<img width="1278" height="653" alt="Screenshot from 2025-10-26 20-49-05" src="https://github.com/user-attachments/assets/3f0f9fa4-e6ce-4446-b577-f3a2fc6c3ab3" />

