### PR TITLE
Fix Resource Civilopedia showing a repeated resource name instead of base stats

### DIFF
--- a/core/src/com/unciv/ui/objectdescriptions/ResourceDescriptions.kt
+++ b/core/src/com/unciv/ui/objectdescriptions/ResourceDescriptions.kt
@@ -18,7 +18,7 @@ object ResourceDescriptions {
         resource.uniquesToCivilopediaTextLines(textList)
 
         if (!(resource as Stats).isEmpty())
-            textList += FormattedLine((resource as Stats).toString())
+            textList += FormattedLine(resource.cloneStats().toString())
 
         if (!resource.revealedBy.isNullOrEmpty()) {
             textList += FormattedLine()


### PR DESCRIPTION
fix #14124 