### PR TITLE
Adapt main menu background maps to aspect ratio

### DIFF
--- a/core/src/com/unciv/ui/screens/mainmenuscreen/MainMenuScreen.kt
+++ b/core/src/com/unciv/ui/screens/mainmenuscreen/MainMenuScreen.kt
@@ -60,7 +60,8 @@ import com.unciv.ui.screens.worldscreen.mainmenu.WorldScreenMenuPopup
 import com.unciv.utils.Concurrency
 import com.unciv.utils.launchOnGLThread
 import kotlinx.coroutines.Job
-import kotlin.math.min
+import yairm210.purity.annotations.Pure
+import kotlin.math.ceil
 
 
 class MainMenuScreen: BaseScreen(), RecreateOnResize {
@@ -222,11 +223,10 @@ class MainMenuScreen: BaseScreen(), RecreateOnResize {
             .surroundWithThinCircle(Color.WHITE)
             .onActivation { Gdx.net.openURI("https://github.com/yairm210/Unciv") }
         rightSideButtons.add(githubButton)
-        
+
         rightSideButtons.pack()
         rightSideButtons.setPosition(stage.width - 30, 30f, Align.bottomRight)
         stage.addActor(rightSideButtons)
-
 
         val versionLabel = "{Version} ${UncivGame.VERSION.text}".toLabel()
         versionLabel.setAlignment(Align.center)
@@ -242,20 +242,17 @@ class MainMenuScreen: BaseScreen(), RecreateOnResize {
     private fun startBackgroundMapGeneration() {
         stopBackgroundMapGeneration()  // shouldn't be necessary as resize re-instantiates this class
         backgroundMapGenerationJob = Concurrency.run("ShowMapBackground") {
-            var scale = 1f
-            var mapWidth = stage.width / TileGroupMap.groupHorizontalAdvance
-            var mapHeight = stage.height / TileGroupMap.groupSize
-            if (mapWidth * mapHeight > 3000f) {  // 3000 as max estimated number of tiles is arbitrary (we had typically 721 before)
-                scale = mapWidth * mapHeight / 3000f
-                mapWidth /= scale
-                mapHeight /= scale
-                scale = min(scale, 20f)
-            }
+            // MapSize.Small has easily enough tiles to fill the entire background - unless the user sized their window to some extreme aspect ratio
+            val mapWidth = stage.width / TileGroupMap.groupHorizontalAdvance
+            val mapHeight = stage.height / TileGroupMap.groupSize
+            @Pure fun Float.scaleCoord(scale: Float) = ceil(this * scale).toInt().coerceAtLeast(6)
+            // These scale values are chosen so that a common 4:3 screen minus taskbar gives the same as MapSize.Small
+            val backgroundMapSize = MapSize(mapWidth.scaleCoord(.77f), mapHeight.scaleCoord(1f))
 
             val newMap = MapGenerator(backgroundMapRuleset, this)
                 .generateMap(MapParameters().apply {
                     shape = MapShape.rectangular
-                    mapSize = MapSize.Small
+                    mapSize = backgroundMapSize
                     type = MapType.pangaea
                     temperatureintensity = .7f
                     waterThreshold = -0.1f // mainly land, gets about 30% water
@@ -268,7 +265,6 @@ class MainMenuScreen: BaseScreen(), RecreateOnResize {
                     this@MainMenuScreen,
                     newMap
                 ) {}
-                mapHolder.setScale(scale)
                 mapHolder.color = mapHolder.color.cpy()
                 mapHolder.color.a = 0f
                 backgroundStack.add(mapHolder)


### PR DESCRIPTION
... BUT I get the feeling I did this before ages ago in a working manner - I've seen the main menu with something like the screenshot below before. Thing is, [the current code](https://github.com/yairm210/Unciv/compare/master...SomeTroglodyte:MainMenuBackground?expand=1#diff-dc24529e23a636ade9e068859bb251f4bd5f4741ed3ba22d257fcbf6d8361f21L245-L253) does nothing, not that I can see, in fact, some of that is dead code even Studio recognizes as such.

## Before:
<img width="1426" height="282" alt="image" src="https://github.com/user-attachments/assets/8dabb556-656a-45c7-b2ed-9f24462cb31a" />

## After:
<img width="1426" height="282" alt="image" src="https://github.com/user-attachments/assets/e91282ca-0ce9-4305-b0b8-4c053d7ed2da" />

## Note:
As this is only really noticeable with extreme aspect ratios, I would be fine with a "nah, overkill" verdict - in that case I'd remove that code. I don't think you can get scale to be != 1 with the way world scaling works at the moment.