### PR TITLE
Fix module name in Desktop run configuration

### DIFF
--- a/.run/Desktop.run.xml
+++ b/.run/Desktop.run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Desktop" type="Application" factoryName="Application">
     <option name="MAIN_CLASS_NAME" value="com.unciv.app.desktop.DesktopLauncher" />
-    <module name="unciv.desktop.main" />
+    <module name="Unciv.desktop.main" />
     <option name="VM_PARAMETERS" value="-Xmx4096m -Xms256m -XX:MaxMetaspaceSize=256m" />
     <option name="WORKING_DIRECTORY" value="$ProjectFileDir$/android/assets" />
     <method v="2">


### PR DESCRIPTION
https://github.com/yairm210/Unciv/commit/c1320357bedf114a7a15f6d673ee4fedb6195ebf#diff-94382962c482ab6b7bbe5fe9edd2b7ac2e132eb1371e4c0ba862fde7c2a91290R4

... my Studio couldn't run that, got flagged with a red "x".

<sub>Took me a few days since I use my own - several for different logging or different assets folder...</sub>