### PR TITLE
Relocate maximize minimap button for compatibility with displays with rounded corners

### DIFF
--- a/core/src/com/unciv/ui/popups/options/AdvancedTab.kt
+++ b/core/src/com/unciv/ui/popups/options/AdvancedTab.kt
@@ -90,10 +90,7 @@ class AdvancedTab(
             optionsPopup.settings.androidCutout = it
             Display.setCutout(it)
             optionsPopup.reopenAfterDisplayLayoutChange()
-            val worldScreen = UncivGame.Current.worldScreen
-            if (worldScreen != null) {
-                worldScreen.shouldUpdate = true
-            }
+            GUI.setUpdateWorldOnNextRender()
         }
     }
 

--- a/core/src/com/unciv/ui/screens/worldscreen/minimap/MinimapHolder.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/minimap/MinimapHolder.kt
@@ -25,7 +25,7 @@ class MinimapHolder(val mapHolder: WorldMapHolder) : Table() {
     private val worldScreen = mapHolder.worldScreen
     private var minimapSize = Int.MIN_VALUE
     private var maximized = false
-    private var lastCutoutSetting = worldScreen.game.settings.androidCutout
+    private var lastCutoutSetting = false
     lateinit var minimap: Minimap
 
     /** Button, next to the minimap, to toggle the unit movement map overlay. */


### PR DESCRIPTION
Certain displays have rounded corners that hide the maximize minimap button and make it nearly impossible to click despite having additional click area.

An alternative fix would be to have this depend on the "Enable using display cutout areas" setting.

Before (attempted to recreate rounded corner in bottom right based on what it looks like with my phone):
<img height="500" alt="Screenshot from 2025-11-04 08-00-40" src="https://github.com/user-attachments/assets/c0e54a25-eb1f-423c-89f8-2cb7222f75ca" />

After:
<img height="500" alt="a" src="https://github.com/user-attachments/assets/d91ede9c-aea6-453d-835e-e787655f3377" />
