### PR TITLE
Fix broken minimap state

### DIFF
--- a/core/src/com/unciv/ui/screens/worldscreen/minimap/MinimapHolder.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/minimap/MinimapHolder.kt
@@ -71,6 +71,7 @@ class MinimapHolder(val mapHolder: WorldMapHolder) : Table() {
         val newMinimapSize = worldScreen.game.settings.minimapSize
         if (newMinimapSize == minimapSize && civ?.exploredRegion?.shouldUpdateMinimap() != true) return
         minimapSize = newMinimapSize
+        maximized = false
         rebuild(civ)
     }
 


### PR DESCRIPTION
Bug:
Maximize the minimap, then click a tile in the world screen.
The minimap will reduce to normal size, but the scale icon (top left) disappears, and the maximize icon has incorrect state.
Returns to normal by clicking the maximize icon once.

Fix:
The scale icon no longer disappears, and the maximize icon has correct state.