### PR TITLE
Improve Scene2D debug tool: Modes

### DIFF
--- a/core/src/com/unciv/ui/popups/options/DebugTab.kt
+++ b/core/src/com/unciv/ui/popups/options/DebugTab.kt
@@ -1,10 +1,12 @@
 package com.unciv.ui.popups.options
 
 import com.badlogic.gdx.Gdx
+import com.badlogic.gdx.scenes.scene2d.ui.SelectBox
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton.TextButtonStyle
 import com.unciv.GUI
 import com.unciv.UncivGame
+import com.unciv.logic.GameInfo
 import com.unciv.logic.UncivShowableException
 import com.unciv.logic.files.MapSaver
 import com.unciv.logic.files.UncivFiles
@@ -12,87 +14,113 @@ import com.unciv.models.ruleset.RulesetCache
 import com.unciv.models.ruleset.tile.ResourceType
 import com.unciv.ui.components.widgets.UncivTextField
 import com.unciv.ui.components.extensions.addSeparator
-import com.unciv.ui.components.extensions.toCheckBox
 import com.unciv.ui.components.extensions.toLabel
 import com.unciv.ui.components.extensions.toTextButton
+import com.unciv.ui.components.input.onChange
 import com.unciv.ui.components.input.onClick
 import com.unciv.ui.components.widgets.UncivSlider
 import com.unciv.ui.popups.ToastPopup
 import com.unciv.ui.screens.basescreen.BaseScreen
+import com.unciv.ui.screens.basescreen.SceneDebugMode
+import com.unciv.ui.screens.basescreen.UncivStage
 import com.unciv.utils.Concurrency
 import com.unciv.utils.DebugUtils
+import com.unciv.utils.toGdxArray
 
-fun debugTab(
-    optionsPopup: OptionsPopup
-) = Table(BaseScreen.skin).apply {
-    pad(10f)
-    defaults().pad(5f)
-    val game = UncivGame.Current
+class DebugTab(
+    private val optionsPopup: OptionsPopup
+) : Table(BaseScreen.skin) {
+    init {
+        pad(10f)
+        defaults().pad(5f)
+        val game = UncivGame.Current
 
-    if (GUI.isWorldLoaded()) {
-        val simulateButton = "Simulate until turn:".toTextButton()
-        val simulateTextField = UncivTextField.Numeric("Turn", DebugUtils.SIMULATE_UNTIL_TURN, integerOnly = true)
-        val invalidInputLabel = "This is not a valid integer!".toLabel().also { it.isVisible = false }
-        simulateButton.onClick {
-            val simulateUntilTurns = simulateTextField.value?.toInt()
-            if (simulateUntilTurns == null) {
-                invalidInputLabel.isVisible = true
-                return@onClick
+        if (GUI.isWorldLoaded()) {
+            val simulateButton = "Simulate until turn:".toTextButton()
+            val simulateTextField = UncivTextField.Numeric("Turn", DebugUtils.SIMULATE_UNTIL_TURN, integerOnly = true)
+            val invalidInputLabel = "This is not a valid integer!".toLabel().also { it.isVisible = false }
+            simulateButton.onClick {
+                val simulateUntilTurns = simulateTextField.value?.toInt()
+                if (simulateUntilTurns == null) {
+                    invalidInputLabel.isVisible = true
+                    return@onClick
+                }
+                DebugUtils.SIMULATE_UNTIL_TURN = simulateUntilTurns
+                invalidInputLabel.isVisible = false
+                GUI.getWorldScreen().nextTurn()
             }
-            DebugUtils.SIMULATE_UNTIL_TURN = simulateUntilTurns
-            invalidInputLabel.isVisible = false
-            GUI.getWorldScreen().nextTurn()
+            add(simulateButton)
+            add(simulateTextField).row()
+            add(invalidInputLabel).colspan(2).row()
         }
-        add(simulateButton)
-        add(simulateTextField).row()
-        add(invalidInputLabel).colspan(2).row()
+
+        optionsPopup.addCheckbox(this, "Supercharged", DebugUtils.SUPERCHARGED) { DebugUtils.SUPERCHARGED = it }
+        optionsPopup.addCheckbox(this, "View entire map", DebugUtils.VISIBLE_MAP) { DebugUtils.VISIBLE_MAP = it }
+        optionsPopup.addCheckbox(this, "Show coordinates on tiles", DebugUtils.SHOW_TILE_COORDS) { DebugUtils.SHOW_TILE_COORDS = it }
+        optionsPopup.addCheckbox(this, "Show tile image locations", DebugUtils.SHOW_TILE_IMAGE_LOCATIONS) { DebugUtils.SHOW_TILE_IMAGE_LOCATIONS = it }
+
+        val curGameInfo = game.gameInfo
+        if (curGameInfo != null) {
+            optionsPopup.addCheckbox(this, "God mode (current game)", curGameInfo.gameParameters.godMode) { curGameInfo.gameParameters.godMode = it }
+        }
+
+        optionsPopup.addCheckbox(this, "Save games compressed", UncivFiles.saveZipped) { UncivFiles.saveZipped = it }
+        optionsPopup.addCheckbox(this, "Save maps compressed", MapSaver.saveZipped) { MapSaver.saveZipped = it }
+
+        val select = SelectBox<SceneDebugMode>(skin)
+        select.items = SceneDebugMode.entries.toGdxArray()
+        select.selected = BaseScreen.enableSceneDebug
+        select.onChange {
+            BaseScreen.enableSceneDebug = select.selected
+            (stage as UncivStage).setSceneDebugMode()
+        }
+        add("Gdx Scene2D debug".toLabel()).left().fillX()
+        add(select).minWidth(optionsPopup.selectBoxMinWidth).row()
+
+        add(Table().apply {
+            add("Unique misspelling threshold".toLabel()).left().fillX()
+            add(
+                UncivSlider(0f, 0.5f, 0.05f, initial = RulesetCache.uniqueMisspellingThreshold.toFloat()) {
+                    RulesetCache.uniqueMisspellingThreshold = it.toDouble()
+                }
+            ).minWidth(120f).pad(5f)
+        }).colspan(2).row()
+
+        if (curGameInfo != null) {
+            val unlockTechsButton = "Unlock all techs".toTextButton()
+            unlockTechsButton.onClick { curGameInfo.unlockAllTechs() }
+            add(unlockTechsButton).colspan(2).row()
+
+            val giveResourcesButton = "Get all strategic resources".toTextButton()
+            giveResourcesButton.onClick { curGameInfo.giveResources() }
+            add(giveResourcesButton).colspan(2).row()
+        }
+
+        val loadAsHotseatFromClipboardButton = "Load online multiplayer game as hotseat from clipboard".toTextButton()
+        loadAsHotseatFromClipboardButton.onClick(::loadAsHotseatFromClipboard)
+        add(loadAsHotseatFromClipboardButton).colspan(2).row()
+
+        addSeparator()
+        add("* Crash Unciv! *".toTextButton(skin.get("negative", TextButtonStyle::class.java)).onClick {
+            throw UncivShowableException("Intentional crash")
+        }).colspan(2).row()
+        addSeparator()
     }
 
-    optionsPopup.addCheckbox(this, "Supercharged", DebugUtils.SUPERCHARGED) { DebugUtils.SUPERCHARGED = it }
-    optionsPopup.addCheckbox(this, "View entire map", DebugUtils.VISIBLE_MAP) { DebugUtils.VISIBLE_MAP = it }
-    optionsPopup.addCheckbox(this, "Show coordinates on tiles", DebugUtils.SHOW_TILE_COORDS) { DebugUtils.SHOW_TILE_COORDS = it }
-    optionsPopup.addCheckbox(this, "Show tile image locations", DebugUtils.SHOW_TILE_IMAGE_LOCATIONS) { DebugUtils.SHOW_TILE_IMAGE_LOCATIONS = it }
-
-    val curGameInfo = game.gameInfo
-    if (curGameInfo != null) {
-        optionsPopup.addCheckbox(this, "God mode (current game)", curGameInfo.gameParameters.godMode) { curGameInfo.gameParameters.godMode = it }
-    }
-
-    optionsPopup.addCheckbox(this, "Save games compressed", UncivFiles.saveZipped) { UncivFiles.saveZipped = it }
-    optionsPopup.addCheckbox(this, "Save maps compressed", MapSaver.saveZipped) { MapSaver.saveZipped = it }
-    optionsPopup.addCheckbox(this, "Gdx Scene2D debug", BaseScreen.enableSceneDebug) { BaseScreen.enableSceneDebug = it }
-        
-
-    add(Table().apply {
-        add("Unique misspelling threshold".toLabel()).left().fillX()
-        add(
-            UncivSlider(0f, 0.5f, 0.05f, initial = RulesetCache.uniqueMisspellingThreshold.toFloat()) {
-                RulesetCache.uniqueMisspellingThreshold = it.toDouble()
-            }
-        ).minWidth(120f).pad(5f)
-    }).colspan(2).row()
-
-    val unlockTechsButton = "Unlock all techs".toTextButton()
-    unlockTechsButton.onClick {
-        if (curGameInfo == null)
-            return@onClick
-        for (tech in curGameInfo.ruleset.technologies.keys) {
-            if (tech !in curGameInfo.getCurrentPlayerCivilization().tech.techsResearched) {
-                curGameInfo.getCurrentPlayerCivilization().tech.addTechnology(tech)
-                curGameInfo.getCurrentPlayerCivilization().popupAlerts.removeLastOrNull()
+    private fun GameInfo.unlockAllTechs() {
+        for (tech in ruleset.technologies.keys) {
+            if (tech !in getCurrentPlayerCivilization().tech.techsResearched) {
+                getCurrentPlayerCivilization().tech.addTechnology(tech)
+                getCurrentPlayerCivilization().popupAlerts.removeLastOrNull()
             }
         }
-        curGameInfo.getCurrentPlayerCivilization().cache.updateSightAndResources()
+        getCurrentPlayerCivilization().cache.updateSightAndResources()
         GUI.setUpdateWorldOnNextRender()
     }
-    add(unlockTechsButton).colspan(2).row()
 
-    val giveResourcesButton = "Get all strategic resources".toTextButton()
-    giveResourcesButton.onClick {
-        if (curGameInfo == null)
-            return@onClick
-        val ownedTiles = curGameInfo.tileMap.values.asSequence().filter { it.getOwner() == curGameInfo.getCurrentPlayerCivilization() }
-        val resourceTypes = curGameInfo.ruleset.tileResources.values.asSequence().filter { it.resourceType == ResourceType.Strategic }
+    private fun GameInfo.giveResources() {
+        val ownedTiles = tileMap.values.asSequence().filter { it.getOwner() == getCurrentPlayerCivilization() }
+        val resourceTypes = ruleset.tileResources.values.asSequence().filter { it.resourceType == ResourceType.Strategic }
         for ((tile, resource) in ownedTiles zip resourceTypes) {
             tile.resource = resource.name
             tile.resourceAmount = 999
@@ -100,29 +128,22 @@ fun debugTab(
             // If this becomes a problem, check if such an improvement exists and otherwise plop down a great improvement or so
             tile.setImprovement(resource.getImprovements().first())
         }
-        curGameInfo.getCurrentPlayerCivilization().cache.updateSightAndResources()
+        getCurrentPlayerCivilization().cache.updateSightAndResources()
         GUI.setUpdateWorldOnNextRender()
     }
-    add(giveResourcesButton).colspan(2).row()
 
-    add("Load online multiplayer game as hotseat from clipboard".toTextButton().onClick {
+    private fun loadAsHotseatFromClipboard() {
         // Code duplication : LoadGameScreen.getLoadFromClipboardButton
         Concurrency.run {
             try {
                 val clipboardContentsString = Gdx.app.clipboard.contents.trim()
                 val loadedGame = UncivFiles.gameInfoFromString(clipboardContentsString)
                 loadedGame.gameParameters.isOnlineMultiplayer = false
-                optionsPopup.game.loadGame(loadedGame, callFromLoadScreen =  true)
+                optionsPopup.game.loadGame(loadedGame, callFromLoadScreen = true)
                 optionsPopup.close()
             } catch (ex: Exception) {
                 ToastPopup(ex.message ?: ex::class.java.simpleName, optionsPopup.stageToShowOn)
             }
         }
-    }).colspan(2).row()
-
-    addSeparator()
-    add("* Crash Unciv! *".toTextButton(skin.get("negative", TextButtonStyle::class.java)).onClick {
-        throw UncivShowableException("Intentional crash")
-    }).colspan(2).row()
-    addSeparator()
+    }
 }

--- a/core/src/com/unciv/ui/popups/options/OptionsPopup.kt
+++ b/core/src/com/unciv/ui/popups/options/OptionsPopup.kt
@@ -124,7 +124,7 @@ class OptionsPopup(
             tabs.addPage("Locate mod errors", content, ImageGetter.getImage("OtherIcons/Mods"), 24f)
         }
         if (withDebug || Gdx.input.areSecretKeysPressed()) {
-            tabs.addPage("Debug", debugTab(this), ImageGetter.getImage("OtherIcons/SecretOptions"), 24f)
+            tabs.addPage("Debug", DebugTab(this), ImageGetter.getImage("OtherIcons/SecretOptions"), 24f)
         }
 
         tabs.decorateHeader(getCloseButton {

--- a/core/src/com/unciv/ui/screens/basescreen/BaseScreen.kt
+++ b/core/src/com/unciv/ui/screens/basescreen/BaseScreen.kt
@@ -62,12 +62,8 @@ abstract class BaseScreen : Screen {
         /** The ExtendViewport sets the _minimum_(!) world size - the actual world size will be larger, fitted to screen/window aspect ratio. */
         stage = UncivStage(ExtendViewport(height, height))
 
-        if (enableSceneDebug && this !is CrashScreen && this !is GameStartScreen) {
-            stage.setDebugUnderMouse(true)
-            stage.setDebugTableUnderMouse(true)
-            stage.setDebugParentUnderMouse(true)
-            stage.mouseOverDebug = true
-        }
+        if (enableSceneDebug.active && this !is CrashScreen && this !is GameStartScreen)
+            stage.setSceneDebugMode()
 
         @Suppress("LeakingThis")
         stage.installShortcutDispatcher(globalShortcuts, this::createDispatcherVetoer)
@@ -129,7 +125,7 @@ abstract class BaseScreen : Screen {
     }
 
     companion object {
-        var enableSceneDebug = false
+        var enableSceneDebug = SceneDebugMode.None
 
         /** Colour to use for empty sections of the screen.
          *  Gets overwritten by SkinConfig.clearColor after starting Unciv */

--- a/core/src/com/unciv/ui/screens/basescreen/SceneDebugMode.kt
+++ b/core/src/com/unciv/ui/screens/basescreen/SceneDebugMode.kt
@@ -1,0 +1,38 @@
+package com.unciv.ui.screens.basescreen
+
+import com.badlogic.gdx.scenes.scene2d.Stage
+import com.unciv.models.translations.tr
+
+/**
+ *  This controls what the "Scene2D debug mode" actually does.
+ *
+ *  Class can be directly used in a SelectBox.
+ *
+ *  Note - regrettably, there is no way to have mouseover debug lines for the next ascendant Table if there is one,
+ *  but fall back the parent if there is one, or the hit actor if it's floating alone.
+ *
+ *  @property label UI label, translatable. Not automatically templated.
+ *  @property basic Enables any mouse-over debug lines. Passed to [Stage.setDebugUnderMouse].
+ *  @property parent Enables preferring the parent to the hit actor if it has one. Passed to [Stage.setDebugParentUnderMouse].
+ *  @property tables Enables looking _only_ for Table instances from the hit actor up. Passed to [Stage.setDebugTableUnderMouse].
+ *  @property all Enables recursion of the debug flag to children. Passed to [Stage.setDebugAll].
+ *  @property overlay Enables the info overlay [StageMouseOverDebug]. Independent of the other flags.
+ *  @see Stage.drawDebug
+ */
+enum class SceneDebugMode(
+    val label: String,
+    val basic: Boolean,
+    val parent: Boolean,
+    val tables: Boolean,
+    val all: Boolean,
+    val overlay: Boolean
+) {
+    None("Off", false, false, false, false, false),
+    Tables("Tables", true, false, true, false, true),
+    All("All actors", true, false, false, true, true),
+    ;
+
+    val active get() = basic || overlay
+    fun next() = entries[(ordinal + 1) % entries.size]
+    override fun toString() = label.tr()
+}

--- a/core/src/com/unciv/ui/screens/basescreen/UncivStage.kt
+++ b/core/src/com/unciv/ui/screens/basescreen/UncivStage.kt
@@ -10,6 +10,7 @@ import com.unciv.logic.event.Event
 import com.unciv.logic.event.EventBus
 import com.unciv.ui.crashhandling.wrapCrashHandling
 import com.unciv.ui.crashhandling.wrapCrashHandlingUnit
+import com.unciv.ui.screens.basescreen.BaseScreen.Companion.enableSceneDebug
 import com.unciv.utils.Log
 
 
@@ -44,6 +45,14 @@ class UncivStage(viewport: Viewport) : Stage(viewport, getBatch()) {
             Log.debug("Visible stage area changed: %s", it.visibleArea)
             lastKnownVisibleArea = it.visibleArea
         }
+    }
+
+    fun setSceneDebugMode() {
+        isDebugAll = enableSceneDebug.all
+        setDebugUnderMouse(enableSceneDebug.active)
+        setDebugParentUnderMouse(enableSceneDebug.parent)
+        setDebugTableUnderMouse(enableSceneDebug.tables)
+        mouseOverDebug = enableSceneDebug.overlay
     }
 
     override fun dispose() {

--- a/tests/src/com/unciv/dev/FasterUIDevelopment.kt
+++ b/tests/src/com/unciv/dev/FasterUIDevelopment.kt
@@ -10,8 +10,8 @@ import com.badlogic.gdx.graphics.Pixmap
 import com.badlogic.gdx.math.Vector2
 import com.badlogic.gdx.scenes.scene2d.Actor
 import com.badlogic.gdx.scenes.scene2d.InputEvent
-import com.badlogic.gdx.scenes.scene2d.ui.CheckBox
 import com.badlogic.gdx.scenes.scene2d.ui.Label
+import com.badlogic.gdx.scenes.scene2d.ui.SelectBox
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton
 import com.badlogic.gdx.scenes.scene2d.utils.ClickListener
@@ -22,17 +22,21 @@ import com.unciv.logic.files.UncivFiles
 import com.unciv.models.metadata.GameSettings
 import com.unciv.ui.components.SmallButtonStyle
 import com.unciv.ui.components.extensions.center
+import com.unciv.ui.components.extensions.toLabel
 import com.unciv.ui.components.fonts.FontFamilyData
 import com.unciv.ui.components.fonts.FontImplementation
 import com.unciv.ui.components.fonts.FontMetricsCommon
 import com.unciv.ui.components.fonts.Fonts
 import com.unciv.ui.components.input.KeyboardBinding
+import com.unciv.ui.components.input.onChange
 import com.unciv.ui.components.input.onClick
 import com.unciv.ui.components.widgets.AutoScrollPane
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.images.ImageWithCustomSize
 import com.unciv.ui.screens.basescreen.BaseScreen
+import com.unciv.ui.screens.basescreen.SceneDebugMode
 import com.unciv.ui.screens.basescreen.UncivStage
+import com.unciv.utils.toGdxArray
 import java.awt.Font
 import java.awt.RenderingHints
 import java.awt.image.BufferedImage
@@ -143,13 +147,15 @@ object FasterUIDevelopment {
                 button.onClick {
                     game.pushScreen(UIDevScreen(test))
                 }
-                table.add(button).row()
+                table.add(button).colspan(2).row()
             }
 
-            val debugCheckbox = CheckBox("Gdx Scene2D debug", skin)
-            debugCheckbox.isChecked = enableSceneDebug
-            debugCheckbox.onClick { enableSceneDebug = debugCheckbox.isChecked }
-            table.add(debugCheckbox).padTop(5f)
+            val select = SelectBox<SceneDebugMode>(skin)
+            select.items = SceneDebugMode.entries.toGdxArray()
+            select.selected = enableSceneDebug
+            select.onChange { enableSceneDebug = select.selected }
+            table.add("Gdx Scene2D debug".toLabel()).left().fillX()
+            table.add(select).minWidth(120f).row()
 
             val scroll = AutoScrollPane(table, skin)
             scroll.setOverscroll(false, false)
@@ -195,11 +201,8 @@ object FasterUIDevelopment {
 
         private class ToggleDebugListener(private val stage: UncivStage) : ClickListener(2) {
             override fun clicked(event: InputEvent?, x: Float, y: Float) {
-                enableSceneDebug = !enableSceneDebug
-                stage.setDebugUnderMouse(enableSceneDebug)
-                stage.setDebugTableUnderMouse(enableSceneDebug)
-                stage.setDebugParentUnderMouse(enableSceneDebug)
-                stage.mouseOverDebug = enableSceneDebug
+                enableSceneDebug = enableSceneDebug.next()
+                stage.setSceneDebugMode()
             }
         }
     }


### PR DESCRIPTION
Hate to impose, but... Again.

I always wondered a little, now I investigated: You can't have Gdx turn on debug lines for mouse-over in a way I'd prefer: It either looks for the next Table ascendant and does nothing if there is none, _or_ it treats all types of actors the same and optionally includes all Group children.

Drive-by: Timo's 'Table factory instead of dedicated classes' - I converted the next one back to class. Not only does Studio paint such a file nicer in the tree, structuring the thing with helper functions is **much** cleaner - IMHO. As to class loader name table pollution - I don't think that has much weight.

Side fix: Scene2D modes are now applied immediately, you don't have to force a screen re-instantiation.

Demo:
<img width="884" height="540" alt="image" src="https://github.com/user-attachments/assets/79e9e7c6-bd11-40b4-a379-f30be3a471a6" />
... the (faint! open in new tab to see better) debug line for the hit circle wouldn't have been activated by the current code.

Note: That ball of yarn widget really needs some improvements... And I'm tempted - again - to really overhaul that PoptionsOpup architecture. The way those addCheckBox helpers are accessed - there's much better ways. And label+slider / label+select need their generic helpers too...