### PR TITLE
Fix resizing the FasterUIDevelopment tool

### DIFF
--- a/tests/src/com/unciv/dev/FasterUIDevelopment.kt
+++ b/tests/src/com/unciv/dev/FasterUIDevelopment.kt
@@ -108,6 +108,10 @@ object FasterUIDevelopment {
             Settings.save(UncivGame.Current.settings)
             super.pause()
         }
+
+        override fun resize(width: Int, height: Int) {
+            game.resize(width, height)
+        }
     }
 
     /** Persist window size over invocations, but separately from main Unciv */


### PR DESCRIPTION
:see_no_evil: I already promised that FasterUIDevelopment can safely be resized at least on the picker screen - but that needs this (delegation instead of inheritance -> the internal screen var of the proxy is always null -> resize "events" are not propagated)