### PR TITLE
Logging - better automatic or manual control over 'release' status

### DIFF
--- a/desktop/src/com/unciv/app/desktop/DesktopLogBackend.kt
+++ b/desktop/src/com/unciv/app/desktop/DesktopLogBackend.kt
@@ -1,19 +1,28 @@
 package com.unciv.app.desktop
 
 import com.unciv.utils.DefaultLogBackend
-import java.lang.management.ManagementFactory
+import java.lang.System
 
 class DesktopLogBackend : DefaultLogBackend() {
 
     // -ea (enable assertions) or kotlin debugging property as marker for a debug run.
     // Can easily be added to IntelliJ/Android Studio launch configuration template for all launches.
-    private val release = System.getProperty("kotlinx.coroutines.debug") == null
+    private val release =
+        System.getProperty("kotlinx.coroutines.debug") == null
+            && System.getProperty("kotlinx.coroutines.debug.enable.creation.stack.trace") == null
+            && System.getProperty("noLog") == null
+            && System.getProperty("onlyLog") == null
+            && assertionsDisabled()
 
-    override fun isRelease(): Boolean {
-        return release
-    }
+    private fun assertionsDisabled() =
+        try {
+            assert(false)
+            true
+        } catch (_: AssertionError) {
+            false
+        }
 
-    override fun getSystemInfo(): String {
-        return SystemUtils.getSystemInfo()
-    }
+    override fun isRelease() = release
+
+    override fun getSystemInfo() = SystemUtils.getSystemInfo()
 }


### PR DESCRIPTION
We had that "-ea gives you logs" in that comment forever, and it didn't work. Maybe the change that made that import unused?

I case that promise made it into the wiki, let's keep it? Also, that new kotlinx key may be a consequence of toolkit progress, at least mine won't set the short one but it does automatically set this new one.