### PR TITLE
Tiny code maintenance: Treat a warning about data class copy visibility

### DIFF
--- a/core/src/com/unciv/ui/screens/devconsole/DevConsoleResponse.kt
+++ b/core/src/com/unciv/ui/screens/devconsole/DevConsoleResponse.kt
@@ -3,7 +3,7 @@ package com.unciv.ui.screens.devconsole
 
 import com.badlogic.gdx.graphics.Color
 
-@Suppress("DataClassPrivateConstructor") // abuser need to find copy() first
+@ConsistentCopyVisibility  // See https://youtrack.jetbrains.com/issue/KT-11914
 internal data class DevConsoleResponse private constructor (
     val color: Color,
     val message: String? = null,


### PR DESCRIPTION
That got an upgrade, the suppression no longer works - output:

```
w: file:///home/bob/Work/Unciv/core/src/com/unciv/ui/screens/devconsole/DevConsoleResponse.kt:7:40 Non-public primary constructor is exposed via the generated 'copy()' method of the 'data' class.

The generated 'copy()' will change its visibility in future releases.

To suppress the warning do one of the following:
- Annotate the data class with the '@ConsistentCopyVisibility' annotation.
- Use the '-Xconsistent-data-class-copy-visibility' compiler flag.
- Annotate the data class with the '@ExposedCopyVisibility' annotation 
  (Discouraged, but can be used to keep binary compatibility).

To learn more, see the documentation of the '@ConsistentCopyVisibility' and '@ExposedCopyVisibility' annotations.

This will become an error in language version 2.5. See https://youtrack.jetbrains.com/issue/KT-11914.
```

Alternative:
```kotlin
package com.unciv.ui.screens.devconsole

import com.badlogic.gdx.graphics.Color

internal interface DevConsoleResponse {
    val color: Color
    val message: String?
    val isOK: Boolean

    private data class DevConsoleResponseInstance(
        override val color: Color,
        override val message: String? = null,
        override val isOK: Boolean = false
    ) : DevConsoleResponse

    companion object {
        val OK: DevConsoleResponse = DevConsoleResponseInstance(Color.GREEN, isOK = true)
        fun ok(message: String): DevConsoleResponse = DevConsoleResponseInstance(Color.GREEN, message, true)
        fun error(message: String): DevConsoleResponse = DevConsoleResponseInstance(Color.RED, message)
        fun hint(message: String): DevConsoleResponse = DevConsoleResponseInstance(Color.GOLD, message)
    }
}
```
