### PR TITLE
Enable espionage by default in new games

### DIFF
--- a/core/src/com/unciv/models/metadata/GameParameters.kt
+++ b/core/src/com/unciv/models/metadata/GameParameters.kt
@@ -29,7 +29,7 @@ class GameParameters : IsPartOfGameInfoSerialization { // Default values are the
     var oneCityChallenge = false
     var godMode = false
     var nuclearWeaponsEnabled = true
-    var espionageEnabled = true
+    var espionageEnabled = false
     var noStartBias = false
     var shufflePlayerOrder = false
 

--- a/core/src/com/unciv/models/metadata/GameSetupInfo.kt
+++ b/core/src/com/unciv/models/metadata/GameSetupInfo.kt
@@ -29,6 +29,7 @@ class GameSetupInfo(
                 if (defaultDifficulty != null) gameParameters.difficulty = defaultDifficulty
                 mapParameters.shape = MapShape.rectangular
                 mapParameters.worldWrap = true
+                gameParameters.espionageEnabled = true
             }
             else GameSetupInfo(lastGameSetup!!).apply {
                 mapParameters.reseed()

--- a/core/src/com/unciv/ui/screens/newgamescreen/NewGameScreen.kt
+++ b/core/src/com/unciv/ui/screens/newgamescreen/NewGameScreen.kt
@@ -102,7 +102,10 @@ class NewGameScreen(
                     "Are you sure you want to reset all game options to defaults?",
                     "Reset to defaults",
                 ) {
-                    game.replaceCurrentScreen(NewGameScreen(GameSetupInfo()))
+                    val gameSetupInfo = GameSetupInfo().apply {
+                        gameParameters.espionageEnabled = true
+                    }
+                    game.replaceCurrentScreen(NewGameScreen(gameSetupInfo))
                 }.open(true)
             }
             horizontalGroup.addActor(resetToDefaultsButton)


### PR DESCRIPTION
Proposal from [Discord](https://discord.com/channels/586194543280390151/653651863832363053/1433828589748490280).

Toggles "Enable espionage" in advanced settings when resetting settings to default / creating a game for the first time.