### PR TITLE
Code maintenance: Refactor GameStartScreen

### DIFF
--- a/core/src/com/unciv/UncivGame.kt
+++ b/core/src/com/unciv/UncivGame.kt
@@ -5,7 +5,6 @@ import com.badlogic.gdx.Game
 import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.Input
 import com.badlogic.gdx.Screen
-import com.badlogic.gdx.scenes.scene2d.actions.Actions
 import com.unciv.UncivGame.Companion.Current
 import com.unciv.UncivGame.Companion.isCurrentInitialized
 import com.unciv.logic.GameInfo
@@ -24,13 +23,13 @@ import com.unciv.ui.audio.MusicController
 import com.unciv.ui.audio.MusicMood
 import com.unciv.ui.audio.MusicTrackChooserFlags
 import com.unciv.ui.audio.SoundPlayer
-import com.unciv.ui.components.extensions.center
 import com.unciv.ui.components.fonts.Fonts
 import com.unciv.ui.crashhandling.CrashScreen
 import com.unciv.ui.crashhandling.wrapCrashHandlingUnit
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.popups.ConfirmPopup
 import com.unciv.ui.popups.Popup
+import com.unciv.ui.screens.GameStartScreen
 import com.unciv.ui.screens.LanguagePickerScreen
 import com.unciv.ui.screens.LoadingScreen
 import com.unciv.ui.screens.basescreen.BaseScreen
@@ -534,15 +533,5 @@ open class UncivGame(val isConsoleMode: Boolean = false) : Game(), PlatformSpeci
         @Suppress("unused") // used by json serialization
         constructor() : this("", -1)
         @Pure fun toNiceString() = "$text (Build ${number.tr()})"
-    }
-}
-
-class GameStartScreen : BaseScreen() {
-    init {
-        val logoImage = ImageGetter.getExternalImage("banner.png")
-        logoImage.center(stage)
-        logoImage.color.a = 0f
-        logoImage.addAction(Actions.alpha(1f, 0.3f))
-        stage.addActor(logoImage)
     }
 }

--- a/core/src/com/unciv/ui/screens/GameStartScreen.kt
+++ b/core/src/com/unciv/ui/screens/GameStartScreen.kt
@@ -1,0 +1,16 @@
+package com.unciv.ui.screens
+
+import com.badlogic.gdx.scenes.scene2d.actions.Actions
+import com.unciv.ui.components.extensions.center
+import com.unciv.ui.images.ImageGetter
+import com.unciv.ui.screens.basescreen.BaseScreen
+
+class GameStartScreen : BaseScreen() {
+    init {
+        val logoImage = ImageGetter.getExternalImage("banner.png")
+        logoImage.center(stage)
+        logoImage.color.a = 0f
+        logoImage.addAction(Actions.alpha(1f, 0.3f))
+        stage.addActor(logoImage)
+    }
+}

--- a/core/src/com/unciv/ui/screens/basescreen/BaseScreen.kt
+++ b/core/src/com/unciv/ui/screens/basescreen/BaseScreen.kt
@@ -15,7 +15,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.TextButton
 import com.badlogic.gdx.scenes.scene2d.ui.TextField
 import com.badlogic.gdx.scenes.scene2d.utils.Drawable
 import com.badlogic.gdx.utils.viewport.ExtendViewport
-import com.unciv.GameStartScreen
+import com.unciv.ui.screens.GameStartScreen
 import com.unciv.UncivGame
 import com.unciv.models.TutorialTrigger
 import com.unciv.models.metadata.BaseRuleset


### PR DESCRIPTION
.. simply doesn't belong there.

What would you think of 

<details>

```patch
Subject: [PATCH] Refactor GameStartScreen to a proper '.ui.' place
---
Index: core/src/com/unciv/ui/screens/basescreen/BaseScreen.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/core/src/com/unciv/ui/screens/basescreen/BaseScreen.kt b/core/src/com/unciv/ui/screens/basescreen/BaseScreen.kt
--- a/core/src/com/unciv/ui/screens/basescreen/BaseScreen.kt	(revision 243275ef50b8dddac9e45cd256142a3702f45a67)
+++ b/core/src/com/unciv/ui/screens/basescreen/BaseScreen.kt	(date 1762635520516)
@@ -15,7 +15,6 @@
 import com.badlogic.gdx.scenes.scene2d.ui.TextField
 import com.badlogic.gdx.scenes.scene2d.utils.Drawable
 import com.badlogic.gdx.utils.viewport.ExtendViewport
-import com.unciv.ui.screens.GameStartScreen
 import com.unciv.UncivGame
 import com.unciv.models.TutorialTrigger
 import com.unciv.models.metadata.BaseRuleset
@@ -29,7 +28,6 @@
 import com.unciv.ui.components.input.KeyShortcutDispatcherVeto
 import com.unciv.ui.components.input.installShortcutDispatcher
 import com.unciv.ui.components.input.keyShortcuts
-import com.unciv.ui.crashhandling.CrashScreen
 import com.unciv.ui.images.ImageGetter
 import com.unciv.ui.popups.Popup
 import com.unciv.ui.popups.activePopup
@@ -55,6 +53,8 @@
      */
     val globalShortcuts = KeyShortcutDispatcher()
 
+    protected open val allowSceneDebug = true
+
     init {
         val screenSize = game.settings.screenSize
         val height = screenSize.virtualHeight
@@ -62,7 +62,7 @@
         /** The ExtendViewport sets the _minimum_(!) world size - the actual world size will be larger, fitted to screen/window aspect ratio. */
         stage = UncivStage(ExtendViewport(height, height))
 
-        if (enableSceneDebug.active && this !is CrashScreen && this !is GameStartScreen)
+        if (allowSceneDebug && enableSceneDebug.active)
             stage.setSceneDebugMode()
 
         @Suppress("LeakingThis")
Index: core/src/com/unciv/ui/crashhandling/CrashScreen.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/core/src/com/unciv/ui/crashhandling/CrashScreen.kt b/core/src/com/unciv/ui/crashhandling/CrashScreen.kt
--- a/core/src/com/unciv/ui/crashhandling/CrashScreen.kt	(revision 243275ef50b8dddac9e45cd256142a3702f45a67)
+++ b/core/src/com/unciv/ui/crashhandling/CrashScreen.kt	(date 1762635520533)
@@ -27,6 +27,7 @@
 //todo We may be in a critical low-memory situation. Using a lot ot String concatenation and trimIndent
 //     could make the display fail when a more efficient StringBuilder approach might still succeed.
 class CrashScreen(val exception: Throwable) : BaseScreen() {
+    override val allowSceneDebug = false
 
     private companion object {
         fun Throwable.stringify(): String {
Index: core/src/com/unciv/ui/screens/GameStartScreen.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/core/src/com/unciv/ui/screens/GameStartScreen.kt b/core/src/com/unciv/ui/screens/GameStartScreen.kt
--- a/core/src/com/unciv/ui/screens/GameStartScreen.kt	(revision 243275ef50b8dddac9e45cd256142a3702f45a67)
+++ b/core/src/com/unciv/ui/screens/GameStartScreen.kt	(date 1762635520498)
@@ -6,6 +6,8 @@
 import com.unciv.ui.screens.basescreen.BaseScreen
 
 class GameStartScreen : BaseScreen() {
+    override val allowSceneDebug = false
+
     init {
         val logoImage = ImageGetter.getExternalImage("banner.png")
         logoImage.center(stage)
```
</details>

- a subclass opting out of something should know it's opting out, the BaseScreen doesn't really need to know which specific ones - easier to extend. But extra bytes and really not important.