### PR TITLE
Set start time of new games to system time

### DIFF
--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -117,7 +117,7 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
     var turns = 0
     var oneMoreTurnMode = false
     var currentPlayer = ""
-    var currentTurnStartTime = 0L
+    var currentTurnStartTime = System.currentTimeMillis()
     var gameId = UUID.randomUUID().toString() // random string
     var checksum = ""
     var lastUnitId = 0

--- a/core/src/com/unciv/ui/screens/multiplayerscreens/MultiplayerScreen.kt
+++ b/core/src/com/unciv/ui/screens/multiplayerscreens/MultiplayerScreen.kt
@@ -403,8 +403,10 @@ class MultiplayerScreen : PickerScreen() {
         selectedGame = multiplayerGame
 
         for (button in gameSpecificButtons) button.enable()
+
+        val preview = multiplayerGame.preview
         
-        if (multiplayerGame.preview != null) {
+        if (preview != null) {
             copyGameIdButton.enable()
             rightSideButton.enable()
         } else {
@@ -413,11 +415,9 @@ class MultiplayerScreen : PickerScreen() {
         }
 
         // is it our turn?
-        resignButton.isEnabled = multiplayerGame.preview?.getCurrentPlayerCiv()?.playerId == game.settings.multiplayer.getUserId()
-
-        val preview = multiplayerGame.preview
-        // the latter checks if we are on the first turn on a new game, where the start time has not yet been set (default 0L)
-        if (resignButton.isEnabled || preview == null || preview.currentTurnStartTime == 0L){
+        resignButton.isEnabled = preview?.getCurrentPlayerCiv()?.playerId == game.settings.multiplayer.getUserId()
+        
+        if (resignButton.isEnabled || preview == null){
             skipTurnButton.isVisible = false
             forceResignButton.isVisible = false
         } else {


### PR DESCRIPTION
Sets the start time of new games to when the GameInfo object was created rather than 0L.
Meta info of new MP games will display the correct start time instead of "Current turn: [...] since 20401 days ago".
Addresses [PR](https://github.com/yairm210/Unciv/pull/14024) and reverts [PR](https://github.com/yairm210/Unciv/pull/13962).
Also minor refactor of MultiplayerScreen.