### PR TITLE
Added a "re-download" button to the mod management screen

### DIFF
--- a/core/src/com/unciv/ui/screens/modmanager/ModInfoAndActionPane.kt
+++ b/core/src/com/unciv/ui/screens/modmanager/ModInfoAndActionPane.kt
@@ -23,7 +23,7 @@ import com.unciv.ui.screens.modmanager.ModManagementScreen.Companion.cleanModNam
 import com.unciv.utils.Concurrency
 import kotlin.math.max
 
-internal class ModInfoAndActionPane : Table() {
+internal class ModInfoAndActionPane(private val onDownloadModFromUrl: ((String) -> Unit)? = null) : Table() {
     private val repoUrlToPreviewImage = HashMap<String, Texture?>()
     private val imageHolder = Table()
     private val sizeLabel = "".toLabel()
@@ -105,6 +105,16 @@ internal class ModInfoAndActionPane : Table() {
                 ToastPopup("Link copied to clipboard", stage)
             }
             add(githubButton).row()
+        }
+        
+        // allow to re-download mod from on-file link in case of mod update or corruption
+        if (repoUrl.isNotEmpty()) {
+            val redownloadButton = "Re-download Mod".toTextButton()
+            redownloadButton.onClick {
+                redownloadButton.setText("Downloading...".tr())
+                onDownloadModFromUrl?.invoke(repoUrl)
+            }
+            add(redownloadButton).row()
         }
 
         // display "updated" date

--- a/core/src/com/unciv/ui/screens/modmanager/ModManagementScreen.kt
+++ b/core/src/com/unciv/ui/screens/modmanager/ModManagementScreen.kt
@@ -95,7 +95,23 @@ class ModManagementScreen private constructor(
     private val onlineModsTable = Table().apply { defaults().pad(10f) }
     private val scrollOnlineMods = AutoScrollPane(onlineModsTable)
     // Right column
-    private val modActionTable = ModInfoAndActionPane()
+    private val modActionTable = ModInfoAndActionPane { modUrl ->
+        Concurrency.run {
+            val repo = GithubAPI.Repo.parseUrl(modUrl)
+            if (repo == null) {
+                Concurrency.runOnGLThread {
+                    ToastPopup("Invalid mod URL!", this@ModManagementScreen)
+                }
+            } else {
+                downloadMod(repo) {
+                    Concurrency.runOnGLThread {
+                        ToastPopup("Re-downloaded!", this@ModManagementScreen)
+                        refreshInstalledModTable()
+                    }
+                }
+            }
+        }
+    }
     private val scrollActionTable = AutoScrollPane(modActionTable)
     // Manager providing the Widget floating top right in landscape mode, stacked expander in portrait
     private val optionsManager = ModManagementOptions(this)


### PR DESCRIPTION
Downloads based on the on-file url, not the url fetched from the online lookup. Useful for updating mods which haven't been officially published yet, or fixing corrupted mods.