### PR TITLE
Link historical Great Person names to Wikipedia

### DIFF
--- a/core/src/com/unciv/models/ruleset/unit/UnitNameGroup.kt
+++ b/core/src/com/unciv/models/ruleset/unit/UnitNameGroup.kt
@@ -59,9 +59,6 @@ class UnitNameGroup : RulesetObject() {
         if (unitNames.isNotEmpty()) {
             lines.add(FormattedLine())
             lines.add(FormattedLine("Unit Names", header = 4))
-            for (name in unitNames) {
-                lines.add(FormattedLine(name))
-            }
             val (collator, language) = UncivGame.Current.settings.run { getCollatorFromLocale() to locale!!.language }
             fun wikilink(name: String) = "https://$language.wikipedia.org/w/index.php?search=${URLEncoder.encode(name.tr(), Charsets.UTF_8.name())}"
             for (name in unitNames.sortedWith(collator)) {


### PR DESCRIPTION
... and sort them by their translation. Relates to #14030 too.

I think it's cute, and the translated link thing works so well it's another argument to auto-TFW treat them.
I did not check whether all local wikipedias follow ISO naming and exist for all our languages - treat when someone complains?
