### PR TITLE
Fix Unit Name Group unique type

### DIFF
--- a/core/src/com/unciv/models/ruleset/unit/UnitNameGroup.kt
+++ b/core/src/com/unciv/models/ruleset/unit/UnitNameGroup.kt
@@ -41,7 +41,7 @@ class UnitNameGroup : RulesetObject() {
             }
         }
 
-    override fun getUniqueTarget() = UniqueTarget.UnitTriggerable
+    override fun getUniqueTarget() = UniqueTarget.EventChoice
     override fun makeLink() = "Unit Names/$name"
     override fun getCivilopediaTextLines(ruleset: Ruleset): List<FormattedLine> {
         val lines = ArrayList<FormattedLine>()


### PR DESCRIPTION
This changes the unique type for Unit Name Groups to EventChoices, as they more closely match that type. They provide a condition for choice, as well as are triggerable for when a name is selected.

### Example

The [More Great People mod](https://github.com/RobLoach/More-Great-People) demonstrates the use of conditionals for the unique list. Having it be a unique type of EventChoice simulates the behavior correctly.

```json
{
    "name": "Atomic era Engineers",
    "unitNames": [
        "Norman Foster",
        "Konrad Zuse",
        "Soichiro Honda"
    ],
    "uniques": [
        "Only available <during the [Atomic era]>",
        "Engineer"
    ]
}
```