### PR TITLE
civilopedia: Remove newline in Apollo Program's Civilopedia text

### DIFF
--- a/android/assets/jsons/Civ V - Gods & Kings/Buildings.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Buildings.json
@@ -1114,7 +1114,7 @@
 			"Only available <when [Scientific] Victory is enabled>", "Cannot be hurried"],
 		"requiredTech": "Rocketry",
         "civilopediaText": [
-            { "text": "Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities\n (with the relevant technologies) to win a Scientific Victory!" }
+            { "text": "Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities (with the relevant technologies) to win a Scientific Victory!" }
         ]
 	},
     {

--- a/android/assets/jsons/Civ V - Vanilla/Buildings.json
+++ b/android/assets/jsons/Civ V - Vanilla/Buildings.json
@@ -939,7 +939,7 @@
 			"Only available <when [Scientific] Victory is enabled>", "Cannot be hurried"],
 		"requiredTech": "Rocketry",
         "civilopediaText": [
-            { "text": "Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities\n (with the relevant technologies) to win a Scientific Victory!" }
+            { "text": "Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities (with the relevant technologies) to win a Scientific Victory!" }
         ]
 	},
 

--- a/android/assets/jsons/translations/Afrikaans.properties
+++ b/android/assets/jsons/translations/Afrikaans.properties
@@ -5578,7 +5578,7 @@ Nuclear Plant =
  # Requires translation!
 Apollo Program = 
  # Requires translation!
-Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities\n (with the relevant technologies) to win a Scientific Victory! = 
+Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities (with the relevant technologies) to win a Scientific Victory! = 
 
  # Requires translation!
 Spaceship Factory = 

--- a/android/assets/jsons/translations/Brazilian_Portuguese.properties
+++ b/android/assets/jsons/translations/Brazilian_Portuguese.properties
@@ -3289,7 +3289,7 @@ Solar Plant = Planta Solar
 Nuclear Plant = Usina Nuclear
 
 Apollo Program = Programa Apollo
-Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities\n (with the relevant technologies) to win a Scientific Victory! = Depois de concluir o Programa Apollo, você poderá começar a construir partes da nave espacial em suas cidades\n (com as tecnologias relevantes) para obter uma vitória científica!
+Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities (with the relevant technologies) to win a Scientific Victory! = Depois de concluir o Programa Apollo, você poderá começar a construir partes da nave espacial em suas cidades (com as tecnologias relevantes) para obter uma vitória científica!
 
 Spaceship Factory = Fábrica de Naves Espaciais
 

--- a/android/assets/jsons/translations/Catalan.properties
+++ b/android/assets/jsons/translations/Catalan.properties
@@ -3289,7 +3289,7 @@ Solar Plant = Planta solar
 Nuclear Plant = Planta nuclear
 
 Apollo Program = Programa Apol·lo
-Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities\n (with the relevant technologies) to win a Scientific Victory! = Quan heu recercat el Programa Apol·lo, podeu començar a construir parts d’una nau espacial a les vostres ciutats (amb les tecnologies corresponents) per a aconseguir una victòria científica!
+Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities (with the relevant technologies) to win a Scientific Victory! = Quan heu recercat el Programa Apol·lo, podeu començar a construir parts d’una nau espacial a les vostres ciutats (amb les tecnologies corresponents) per a aconseguir una victòria científica!
 
 Spaceship Factory = Fàbrica de naus espacials
 

--- a/android/assets/jsons/translations/Croatian.properties
+++ b/android/assets/jsons/translations/Croatian.properties
@@ -3336,7 +3336,7 @@ Solar Plant = Solarna Elektrana
 Nuclear Plant = Nuklearna Elektrana
 
 Apollo Program = Program Apollo
-Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities\n (with the relevant technologies) to win a Scientific Victory! = Nakon što završite Program Apollo, možete početi izgrađivati dijelove svemirskog broda u svojim gradovima\n (s relevantnim tehnologijama) kako biste osvojili Znanstvenu Pobjedu!
+Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities (with the relevant technologies) to win a Scientific Victory! = Nakon što završite Program Apollo, možete početi izgrađivati dijelove svemirskog broda u svojim gradovima (s relevantnim tehnologijama) kako biste osvojili Znanstvenu Pobjedu!
 
 Spaceship Factory = Tvornica Svemirskih Brodova
 

--- a/android/assets/jsons/translations/Czech.properties
+++ b/android/assets/jsons/translations/Czech.properties
@@ -3959,7 +3959,7 @@ Solar Plant = Solární elektrárna
 Nuclear Plant = Jaderná elektrárna
 
 Apollo Program = Program Apollo
-Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities\n (with the relevant technologies) to win a Scientific Victory! = Po dokončení Programu Apollo, je možné začít ve městech stavět části kosmické lodi\n (po dozkoumání daných technologií) a dosáhnout tak vědeckého vítězství!
+Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities (with the relevant technologies) to win a Scientific Victory! = Po dokončení Programu Apollo, je možné začít ve městech stavět části kosmické lodi (po dozkoumání daných technologií) a dosáhnout tak vědeckého vítězství!
 
 Spaceship Factory = Továrna na kosmické lodě
 

--- a/android/assets/jsons/translations/Dutch.properties
+++ b/android/assets/jsons/translations/Dutch.properties
@@ -3313,7 +3313,7 @@ Solar Plant = Zonne-energiecentrale
 Nuclear Plant = Kerncentrale
 
 Apollo Program = Apollo programma
-Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities\n (with the relevant technologies) to win a Scientific Victory! = Als je het Apollo Programma voltooit heb kan je beginnen met het bouwen van ruimteschip-onderdelen in je steden\n (met de vereiste technologieën) om een Wetenschappelijke Overwinning te behalen!
+Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities (with the relevant technologies) to win a Scientific Victory! = Als je het Apollo Programma voltooit heb kan je beginnen met het bouwen van ruimteschip-onderdelen in je steden (met de vereiste technologieën) om een Wetenschappelijke Overwinning te behalen!
 
 Spaceship Factory = Ruimtescheepswerf
 

--- a/android/assets/jsons/translations/French.properties
+++ b/android/assets/jsons/translations/French.properties
@@ -3289,7 +3289,7 @@ Solar Plant = Centrale Solaire
 Nuclear Plant = Centrale Nucléaire
 
 Apollo Program = Programme Apollo
-Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities\n (with the relevant technologies) to win a Scientific Victory! = Vous avez complété le Programmme Apollo !\n Vous pouvez désormais construire les composants du vaisseau spatial dans vos villes\n (si vous possédez les technologies nécessaires) et remporter une Victoire Scientifique !
+Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities (with the relevant technologies) to win a Scientific Victory! = Vous avez complété le Programmme Apollo ! Vous pouvez désormais construire les composants du vaisseau spatial dans vos villes (si vous possédez les technologies nécessaires) et remporter une Victoire Scientifique !
 
 Spaceship Factory = Chantier Spatial
 

--- a/android/assets/jsons/translations/Galician.properties
+++ b/android/assets/jsons/translations/Galician.properties
@@ -3299,7 +3299,7 @@ Solar Plant = Planta solar
 Nuclear Plant = Central Nuclear
 
 Apollo Program = Programa Espacial
-Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities\n (with the relevant technologies) to win a Scientific Victory! = Unha vez completases o Programa Espacial poderás empezar coa construción de partes da nave espacial na túa cidades\n (coas tecnoloxías correspondentes) para gañar cunha vitoria científica!
+Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities (with the relevant technologies) to win a Scientific Victory! = Unha vez completases o Programa Espacial poderás empezar coa construción de partes da nave espacial na túa cidades (coas tecnoloxías correspondentes) para gañar cunha vitoria científica!
 
 Spaceship Factory = Fábrica de Naves Espaciais
 

--- a/android/assets/jsons/translations/German.properties
+++ b/android/assets/jsons/translations/German.properties
@@ -3289,7 +3289,7 @@ Solar Plant = Solarkraftwerk
 Nuclear Plant = Atomkraftwerk
 
 Apollo Program = Apollo-Programm
-Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities\n (with the relevant technologies) to win a Scientific Victory! = Sobald Du das Apollo-Programm vervollständigt hast, kannst du in deinen Städten\n mit dem Bau der Raumschiffteile beginnen - sofern die nötigen Technologien bereitstehen -\n... um den Wissenschaftssieg anzustreben!
+Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities (with the relevant technologies) to win a Scientific Victory! = Sobald Du das Apollo-Programm vervollständigt hast, kannst du in deinen Städten mit dem Bau der Raumschiffteile beginnen - sofern die nötigen Technologien bereitstehen -\n... um den Wissenschaftssieg anzustreben!
 
 Spaceship Factory = Raumschiff-Fabrik
 

--- a/android/assets/jsons/translations/Hungarian.properties
+++ b/android/assets/jsons/translations/Hungarian.properties
@@ -3579,7 +3579,7 @@ Solar Plant = Naperőmű
 Nuclear Plant = Atomerőmű
 
 Apollo Program = Apollo-program
-Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities\n (with the relevant technologies) to win a Scientific Victory! = Az Apollo-program befejezése után megkezdheted az űrhajóalkatrészek gyártását a városaidban\n(ehhez a megfelelő technológiákat ki kell fejelszteni), hogy tudományos győzelem révén nyerd meg a játékot.
+Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities (with the relevant technologies) to win a Scientific Victory! = Az Apollo-program befejezése után megkezdheted az űrhajóalkatrészek gyártását a városaidban (ehhez a megfelelő technológiákat ki kell fejelszteni), hogy tudományos győzelem révén nyerd meg a játékot.
 
 Spaceship Factory = Űrhajógyár
 

--- a/android/assets/jsons/translations/Indonesian.properties
+++ b/android/assets/jsons/translations/Indonesian.properties
@@ -3289,7 +3289,7 @@ Solar Plant = PLTS
 Nuclear Plant = PLTN
 
 Apollo Program = Program Apollo
-Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities\n (with the relevant technologies) to win a Scientific Victory! = Ketika kamu menyelesaikan Program Apollo, kamu dapat membangun bagian wahana antariksa di kotamu\n (dengan teknologi yang relevan) untuk meraih Kemenangan Ilmiah!
+Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities (with the relevant technologies) to win a Scientific Victory! = Ketika kamu menyelesaikan Program Apollo, kamu dapat membangun bagian wahana antariksa di kotamu (dengan teknologi yang relevan) untuk meraih Kemenangan Ilmiah!
 
 Spaceship Factory = Perusahaan Manufaktur Wahana Antariksa
 

--- a/android/assets/jsons/translations/Italian.properties
+++ b/android/assets/jsons/translations/Italian.properties
@@ -3296,7 +3296,7 @@ Solar Plant = Centrale ad energia solare
 Nuclear Plant = Centrale nucleare
 
 Apollo Program = Programma Apollo
-Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities\n (with the relevant technologies) to win a Scientific Victory! = Una volta completato il Programma Apollo, potrai iniziare a costruire le parti dell'astronave nelle tue città (con le apposite tecnologie) e cercare di ottenere una vittoria scientifica!
+Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities (with the relevant technologies) to win a Scientific Victory! = Una volta completato il Programma Apollo, potrai iniziare a costruire le parti dell'astronave nelle tue città (con le apposite tecnologie) e cercare di ottenere una vittoria scientifica!
 
 Spaceship Factory = Fabbrica di astronavi
 

--- a/android/assets/jsons/translations/Japanese.properties
+++ b/android/assets/jsons/translations/Japanese.properties
@@ -3332,7 +3332,7 @@ Solar Plant = 太陽熱発電
 Nuclear Plant = 原子力発電所
 
 Apollo Program = アポロ計画
-Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities\n (with the relevant technologies) to win a Scientific Victory! = アポロ計画が完了すると、都市で宇宙船の部品を生産し、科学勝利を収めることができます。
+Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities (with the relevant technologies) to win a Scientific Victory! = アポロ計画が完了すると、都市で宇宙船の部品を生産し、科学勝利を収めることができます。
 
 Spaceship Factory = 宇宙船工場
 

--- a/android/assets/jsons/translations/Korean.properties
+++ b/android/assets/jsons/translations/Korean.properties
@@ -3372,7 +3372,7 @@ Solar Plant = 태양열 발전소
 Nuclear Plant = 원자력 발전소
 
 Apollo Program = 아폴로 프로그램
-Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities\n (with the relevant technologies) to win a Scientific Victory! = '아폴로 프로그램'을 완성하면 도시에서 우주선 부품을 건설할 수 있습니다.\n해당하는 연구를 마치고 모든 부품을 건설하면 과학 승리를 할 수 있습니다!
+Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities (with the relevant technologies) to win a Scientific Victory! = '아폴로 프로그램'을 완성하면 도시에서 우주선 부품을 건설할 수 있습니다.해당하는 연구를 마치고 모든 부품을 건설하면 과학 승리를 할 수 있습니다!
 
 Spaceship Factory = 우주선 공장
 

--- a/android/assets/jsons/translations/Latin.properties
+++ b/android/assets/jsons/translations/Latin.properties
@@ -3599,7 +3599,7 @@ Solar Plant = Electrificina Solaris
 Nuclear Plant = Ergasterium Atomicum
 
 Apollo Program = Programma Apollo
-Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities\n (with the relevant technologies) to win a Scientific Victory! = Postquam perfeceris Programma Apollinem, possis incipere partes astronavis in urbibus tuis\n (per technologiam pertinentem) construere, ut victoriam scientificam feras!
+Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities (with the relevant technologies) to win a Scientific Victory! = Postquam perfeceris Programma Apollinem, possis incipere partes astronavis in urbibus tuis (per technologiam pertinentem) construere, ut victoriam scientificam feras!
 
 Spaceship Factory = Fabrica Astronavium
 

--- a/android/assets/jsons/translations/Lithuanian.properties
+++ b/android/assets/jsons/translations/Lithuanian.properties
@@ -4136,7 +4136,7 @@ Solar Plant = Saulės elektrinė
 Nuclear Plant = Branduolinė elektrinė
 
 Apollo Program = Apolono Kosminė Programa
-Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities\n (with the relevant technologies) to win a Scientific Victory! = Užbaigę Apolo Programą, miestuose galite pradėti gaminti kosminio erdvėlaivio dalis \n(turėdami reikalingas technologijas), kad pasiekti mokslinę pergalę.
+Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities (with the relevant technologies) to win a Scientific Victory! = Užbaigę Apolo Programą, miestuose galite pradėti gaminti kosminio erdvėlaivio dalis (turėdami reikalingas technologijas), kad pasiekti mokslinę pergalę.
 
 Spaceship Factory = Erdvėlaivių gamykla
 

--- a/android/assets/jsons/translations/Polish.properties
+++ b/android/assets/jsons/translations/Polish.properties
@@ -3397,7 +3397,7 @@ Solar Plant = Elektrownia Słoneczna
 Nuclear Plant = Elektrownia Atomowa
 
 Apollo Program = Program Apollo
-Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities\n (with the relevant technologies) to win a Scientific Victory! = Po ukończeniu Programu Apollo możesz przystąpić do budowy modułów Statku Kosmicznego w swoich miastach (o ile posiadasz niezbędne technologie) i tym samym osiągnąć Zwycięstwo Naukowe!
+Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities (with the relevant technologies) to win a Scientific Victory! = Po ukończeniu Programu Apollo możesz przystąpić do budowy modułów Statku Kosmicznego w swoich miastach (o ile posiadasz niezbędne technologie) i tym samym osiągnąć Zwycięstwo Naukowe!
 
 Spaceship Factory = Fabryka Statków Kosmicznych
 

--- a/android/assets/jsons/translations/Portuguese.properties
+++ b/android/assets/jsons/translations/Portuguese.properties
@@ -3318,7 +3318,7 @@ Solar Plant = Planta Solar
 Nuclear Plant = Planta Nuclear
 
 Apollo Program = Programa Apollo
-Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities\n (with the relevant technologies) to win a Scientific Victory! = Depois de concluires o Programa Apollo, podes começar a construir peças de foguetões nas tuas cidades\n (com as tecnologias relevantes) para obter uma vitória científica!
+Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities (with the relevant technologies) to win a Scientific Victory! = Depois de concluires o Programa Apollo, podes começar a construir peças de foguetões nas tuas cidades (com as tecnologias relevantes) para obter uma vitória científica!
 
 Spaceship Factory = Fábrica de Naves Espaciais
 

--- a/android/assets/jsons/translations/Romanian.properties
+++ b/android/assets/jsons/translations/Romanian.properties
@@ -4063,7 +4063,7 @@ Solar Plant = Centrală solară
 Nuclear Plant = Centrală nucleară
 
 Apollo Program = Programul Apollo
-Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities\n (with the relevant technologies) to win a Scientific Victory! = Odată ce ai completat Programul Apollo, poți să începi construcția părților navei spațiale în orașele tale\n (cu tehnologiile relevante) ca să câștigi o Victorie Știinifică
+Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities (with the relevant technologies) to win a Scientific Victory! = Odată ce ai completat Programul Apollo, poți să începi construcția părților navei spațiale în orașele tale (cu tehnologiile relevante) ca să câștigi o Victorie Știinifică
 
 Spaceship Factory = Fabrică de nave spațiale
 

--- a/android/assets/jsons/translations/Russian.properties
+++ b/android/assets/jsons/translations/Russian.properties
@@ -3308,7 +3308,7 @@ Solar Plant = Солнечная ЭС
 Nuclear Plant = АЭС
 
 Apollo Program = Программа "Аполлон"
-Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities\n (with the relevant technologies) to win a Scientific Victory! = Завершив программу Аполлон, вы можете начать строить части космического корабля в городах\n(имея соответствующие технологии), чтобы одержать научную победу.
+Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities (with the relevant technologies) to win a Scientific Victory! = Завершив программу Аполлон, вы можете начать строить части космического корабля в городах (имея соответствующие технологии), чтобы одержать научную победу.
 
 Spaceship Factory = Завод космических кораблей
 

--- a/android/assets/jsons/translations/Simplified_Chinese.properties
+++ b/android/assets/jsons/translations/Simplified_Chinese.properties
@@ -3316,7 +3316,7 @@ Solar Plant = 太阳能电站
 Nuclear Plant = 核电站
 
 Apollo Program = 阿波罗计划
-Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities\n (with the relevant technologies) to win a Scientific Victory! = 当您完成了阿波罗计划，可以开始在您的城市中建造飞船部件(需要相应科技)，\n来通过太空竞赛赢得科技胜利！
+Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities (with the relevant technologies) to win a Scientific Victory! = 当您完成了阿波罗计划，可以开始在您的城市中建造飞船部件(需要相应科技)，来通过太空竞赛赢得科技胜利！
 
 Spaceship Factory = 太空飞船工厂
 

--- a/android/assets/jsons/translations/Spanish.properties
+++ b/android/assets/jsons/translations/Spanish.properties
@@ -3327,7 +3327,7 @@ Solar Plant = Planta Solar
 Nuclear Plant = Central Nuclear
 
 Apollo Program = Programa Espacial
-Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities\n (with the relevant technologies) to win a Scientific Victory! = Una vez hayas completado el Programa Espacial podrás empezar con la construcción de partes de la nave espacial en tus ciudades\n (con las tecnologías correspondientes) para ganar con una victoria científica.
+Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities (with the relevant technologies) to win a Scientific Victory! = Una vez hayas completado el Programa Espacial podrás empezar con la construcción de partes de la nave espacial en tus ciudades (con las tecnologías correspondientes) para ganar con una victoria científica.
 
 Spaceship Factory = Fábrica de Naves Espaciales
 

--- a/android/assets/jsons/translations/Swedish.properties
+++ b/android/assets/jsons/translations/Swedish.properties
@@ -4146,7 +4146,7 @@ Solar Plant = Solkraftverk
 Nuclear Plant = Kärnkraftverk
 
 Apollo Program = Apolloprogrammet
-Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities\n (with the relevant technologies) to win a Scientific Victory! = När du fullbordat Apolloprogrammet, kan du börja bygga rymdskeppsdelar i dina städer\n (med de motsvarande teknologierna) för att vinna en vetenskapsseger!
+Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities (with the relevant technologies) to win a Scientific Victory! = När du fullbordat Apolloprogrammet, kan du börja bygga rymdskeppsdelar i dina städer (med de motsvarande teknologierna) för att vinna en vetenskapsseger!
 
 Spaceship Factory = Rymdskeppsfabrik
 

--- a/android/assets/jsons/translations/Thai.properties
+++ b/android/assets/jsons/translations/Thai.properties
@@ -5441,7 +5441,6 @@ Nuclear Plant = โรงงานไฟฟ้านิวเคลียร์
 
  # Requires translation!
 Apollo Program = 
-Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities\n (with the relevant technologies) to win a Scientific Victory! = Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities\n (with the relevant technologies) to win a Scientific Victory!
 
  # Requires translation!
 Spaceship Factory = 

--- a/android/assets/jsons/translations/Traditional_Chinese.properties
+++ b/android/assets/jsons/translations/Traditional_Chinese.properties
@@ -3316,7 +3316,7 @@ Solar Plant = 太陽能電廠
 Nuclear Plant = 核電廠
 
 Apollo Program = 阿波羅計畫
-Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities\n (with the relevant technologies) to win a Scientific Victory! = 當您完成了阿波羅計畫，可以開始在您的城市中建造飛船部件(需要相應科技)，\n來通過太空競賽贏得科技勝利！
+Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities (with the relevant technologies) to win a Scientific Victory! = 當您完成了阿波羅計畫，可以開始在您的城市中建造飛船部件(需要相應科技)，來通過太空競賽贏得科技勝利！
 
 Spaceship Factory = 太空飛船工廠
 

--- a/android/assets/jsons/translations/Turkish.properties
+++ b/android/assets/jsons/translations/Turkish.properties
@@ -3312,7 +3312,7 @@ Solar Plant = Güneş Paneli
 Nuclear Plant = Nükleer Santral
 
 Apollo Program = Apollo Programı
-Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities\n (with the relevant technologies) to win a Scientific Victory! = Apollo Programını tamamladıktan sonra şehirlerinizde (gerekli teknolojiler araştırıldığında) Uzay Gemisi Parçaları üretmeye başlayabilirsiniz\nHepsini üretince Bilimsel Zafer elde edersiniz!
+Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities (with the relevant technologies) to win a Scientific Victory! = Apollo Programını tamamladıktan sonra şehirlerinizde (gerekli teknolojiler araştırıldığında) Uzay Gemisi Parçaları üretmeye başlayabilirsiniz Hepsini üretince Bilimsel Zafer elde edersiniz!
 
 Spaceship Factory = Uzay Gemisi Fabrikası
 

--- a/android/assets/jsons/translations/Ukrainian.properties
+++ b/android/assets/jsons/translations/Ukrainian.properties
@@ -3329,7 +3329,7 @@ Solar Plant = Сонячна електростанція
 Nuclear Plant = Атомна електростанція
 
 Apollo Program = Програма Аполлон
-Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities\n (with the relevant technologies) to win a Scientific Victory! = Як тільки ви завершите програму "Аполлон", ви можете розпочати проєктування частин космічного корабля у ваших містах (після досліджень відповідних технологій), щоб здобути Наукову перемогу!
+Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities (with the relevant technologies) to win a Scientific Victory! = Як тільки ви завершите програму "Аполлон", ви можете розпочати проєктування частин космічного корабля у ваших містах (після досліджень відповідних технологій), щоб здобути Наукову перемогу!
 
 Spaceship Factory = Завод космічних кораблів
 

--- a/android/assets/jsons/translations/Vietnamese.properties
+++ b/android/assets/jsons/translations/Vietnamese.properties
@@ -3289,7 +3289,7 @@ Solar Plant = Nhà máy Năng lượng Mặt Trời
 Nuclear Plant = Nhà máy Hạt nhân
 
 Apollo Program = Chương trình Apollo
-Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities\n (with the relevant technologies) to win a Scientific Victory! = Sau khi hoàn thành Chương trình Apollo, bạn có thể bắt đầu chế tạo các bộ phận của tàu vũ trụ tại các thành phố của mình\n (với các công nghệ liên quan) để giành được Chiến thắng Khoa học!
+Once you have completed the Apollo Program, you can start constructing spaceship parts in your cities (with the relevant technologies) to win a Scientific Victory! = Sau khi hoàn thành Chương trình Apollo, bạn có thể bắt đầu chế tạo các bộ phận của tàu vũ trụ tại các thành phố của mình (với các công nghệ liên quan) để giành được Chiến thắng Khoa học!
 
 Spaceship Factory = Nhà máy Tàu Vũ trụ
 


### PR DESCRIPTION
Small change to remove the newline present in the Civilopedia text for Apollo Program. Retains existing translations.

<img width="1738" height="516" alt="blurp" src="https://github.com/user-attachments/assets/a5b28420-d17d-4917-b384-716909f2f4b9" />
