### PR TITLE
Revert "Refactor: Prefer cached Civ information over civ names (#14149)"

### DIFF
--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -400,7 +400,7 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
         // We found a human player, so we are making them current
         currentTurnStartTime = System.currentTimeMillis()
         currentPlayer = player.civName
-        currentPlayerCiv = player
+        currentPlayerCiv = getCivilization(currentPlayer)
 
         // Starting their turn
         TurnManager(player).startTurn(progressBar)
@@ -540,7 +540,7 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
         // Include your city-state allies' cities with your own for the purpose of showing the closest city
         val relevantCities: Sequence<City> = civ.cities.asSequence() +
             civ.getKnownCivs()
-                .filter { it.isCityState && it.allyCiv == civ }
+                .filter { it.isCityState && it.getAllyCivName() == civ.civName }
                 .flatMap { it.cities }
 
         // All sources of the resource on the map, using a city-state's capital center tile for the CityStateOnlyResource types

--- a/core/src/com/unciv/logic/automation/civilization/DiplomacyAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/DiplomacyAutomation.kt
@@ -91,7 +91,7 @@ object DiplomacyAutomation {
         motivation -= deadCivs / allCivs * 50
 
         // Become more desperate as we have more wars
-        motivation += civInfo.diplomacy.values.count { it.otherCiv.isMajorCiv() && it.diplomaticStatus == DiplomaticStatus.War } * 10
+        motivation += civInfo.diplomacy.values.count { it.otherCiv().isMajorCiv() && it.diplomaticStatus == DiplomaticStatus.War } * 10
 
         // Wait to declare frienships until more civs
         // Goes from -30 to 0 when we know 75% of allCivs
@@ -220,7 +220,7 @@ object DiplomacyAutomation {
         if (ourDiploManager.hasFlag(DiplomacyFlags.DeclinedOpenBorders)) return false
         if (ourDiploManager.isRelationshipLevelLT(RelationshipLevel.Favorable)) return false
         // Don't accept if they are at war with our friends, they might use our land to attack them
-        if (civInfo.diplomacy.values.any { it.isRelationshipLevelGE(RelationshipLevel.Friend) && it.otherCiv.isAtWarWith(otherCiv) })
+        if (civInfo.diplomacy.values.any { it.isRelationshipLevelGE(RelationshipLevel.Friend) && it.otherCiv().isAtWarWith(otherCiv) })
             return false
         // Being able to see their cities can give us an advantage later on, especially with espionage enabled
         if (otherCiv.cities.count { !it.getCenterTile().isVisible(civInfo) } < otherCiv.cities.count() * .8f)
@@ -304,7 +304,7 @@ object DiplomacyAutomation {
         val defensivePacts = civInfo.diplomacy.count { it.value.hasFlag(DiplomacyFlags.DefensivePact) }
         val otherCivNonOverlappingDefensivePacts = otherCiv.diplomacy.values.count {
             it.hasFlag(DiplomacyFlags.DefensivePact)
-                && it.otherCiv.getDiplomacyManager(civInfo)?.hasFlag(DiplomacyFlags.DefensivePact) != true
+                && it.otherCiv().getDiplomacyManager(civInfo)?.hasFlag(DiplomacyFlags.DefensivePact) != true
         }
         val allCivs = civInfo.gameInfo.civilizations.count { it.isMajorCiv() } - 1 // Don't include us
         val deadCivs = civInfo.gameInfo.civilizations.count { it.isMajorCiv() && !it.isAlive() }
@@ -332,7 +332,7 @@ object DiplomacyAutomation {
         motivation -= 15 * otherCivNonOverlappingDefensivePacts
 
         // Becomre more desperate as we have more wars
-        motivation += civInfo.diplomacy.values.count { it.otherCiv.isMajorCiv() && it.diplomaticStatus == DiplomaticStatus.War } * 5
+        motivation += civInfo.diplomacy.values.count { it.otherCiv().isMajorCiv() && it.diplomaticStatus == DiplomaticStatus.War } * 5
 
         // Try to have a defensive pact with 1/5 of all civs
         val civsToAllyWith = 0.20f * allAliveCivs * civInfo.getPersonality().scaledFocus(PersonalityValue.Diplomacy)
@@ -376,14 +376,14 @@ object DiplomacyAutomation {
 
         val enemiesCiv = civInfo.diplomacy.asSequence()
             .filter { it.value.diplomaticStatus == DiplomaticStatus.War }
-            .map { it.value.otherCiv }
+            .map { it.value.otherCiv() }
             .filterNot {
                 it == civInfo || it.isBarbarian || it.cities.isEmpty()
                         || it.getDiplomacyManager(civInfo)!!.hasFlag(DiplomacyFlags.DeclaredWar)
                         || civInfo.getDiplomacyManager(it)!!.hasFlag(DiplomacyFlags.DeclaredWar)
             }.filter { !civInfo.getDiplomacyManager(it)!!.hasFlag(DiplomacyFlags.DeclinedPeace) }
             // Don't allow AIs to offer peace to city states allied with their enemies
-            .filterNot { it.isCityState && it.allyCiv != null && civInfo.isAtWarWith(it.allyCiv!!) }
+            .filterNot { it.isCityState && it.getAllyCivName() != null && civInfo.isAtWarWith(it.getAllyCiv()!!) }
             // ignore civs that we have already offered peace this turn as a counteroffer to another civ's peace offer
             .filter { it.tradeRequests.none { tradeRequest -> tradeRequest.requestingCiv == civInfo.civName && tradeRequest.trade.isPeaceTreaty() } }
             .toList()

--- a/core/src/com/unciv/logic/automation/civilization/MotivationToAttackAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/MotivationToAttackAutomation.kt
@@ -119,7 +119,7 @@ object MotivationToAttackAutomation {
             //The more potential friends of this CS, the more times the friend bonus is shared and the utilitarian option is to leave it alive
             modifiers.add(Pair("Influence", -targetCiv.getDiplomacyManager(civInfo)!!.getInfluence() / 10f * personality.scaledFocus(PersonalityValue.Diplomacy)))
             // The more we invested into the city state already, the less likely we're going to attack it, and vice versa
-            if (targetCiv.allyCiv == civInfo)
+            if (targetCiv.getAllyCivName() == civInfo.civName)
                 modifiers.add(Pair("Allied City-state", -20 * personality.scaledFocus(PersonalityValue.Diplomacy))) // There had better be a DAMN good reason
         }
 
@@ -256,7 +256,7 @@ object MotivationToAttackAutomation {
     @Readonly
     private fun getDefensivePactAlliesScore(otherCiv: Civilization, civInfo: Civilization, baseForce: Float, ourCombatStrength: Float): Float {
         var theirAlliesValue = 0f
-        for (thirdCiv in otherCiv.diplomacy.values.filter { it.hasFlag(DiplomacyFlags.DefensivePact) && it.otherCiv != civInfo }) {
+        for (thirdCiv in otherCiv.diplomacy.values.filter { it.hasFlag(DiplomacyFlags.DefensivePact) && it.otherCiv() != civInfo }) {
             val thirdCivCombatStrengthRatio = (otherCiv.getStatForRanking(RankingType.Force).toFloat() + baseForce) / ourCombatStrength
             theirAlliesValue += when {
                 thirdCivCombatStrengthRatio > 5 -> -15f

--- a/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/NextTurnAutomation.kt
@@ -186,9 +186,9 @@ object NextTurnAutomation {
             value -= 5
         }
 
-        if (cityState.allyCiv != null && cityState.allyCiv != civInfo) {
+        if (cityState.getAllyCivName() != null && cityState.getAllyCivName() != civInfo.civName) {
             // easier not to compete if a third civ has this locked down
-            val thirdCivInfluence = cityState.getDiplomacyManager(cityState.allyCiv!!)!!.getInfluence().toInt()
+            val thirdCivInfluence = cityState.getDiplomacyManager(cityState.getAllyCivName()!!)!!.getInfluence().toInt()
             value -= (thirdCivInfluence - 30) / 10
         }
 
@@ -200,7 +200,7 @@ object NextTurnAutomation {
 
         if (includeQuests) {
             // Investing is better if there is an investment bonus quest active.
-            value += (cityState.questManager.getInvestmentMultiplier(civInfo) * 10).toInt() - 10
+            value += (cityState.questManager.getInvestmentMultiplier(civInfo.civName) * 10).toInt() - 10
         }
 
         return value
@@ -216,7 +216,7 @@ object NextTurnAutomation {
 
     private fun bullyCityStates(civInfo: Civilization) {
         for (state in civInfo.getKnownCivs().filter { !it.isDefeated() && it.isCityState }.toList()) {
-            val diplomacyManager = state.getDiplomacyManager(civInfo)!!
+            val diplomacyManager = state.getDiplomacyManager(civInfo.civName)!!
             if (diplomacyManager.isRelationshipLevelLT(RelationshipLevel.Friend)
                     && diplomacyManager.diplomaticStatus == DiplomaticStatus.Peace
                     && valueCityStateAlliance(civInfo, state) <= 0
@@ -540,7 +540,8 @@ object NextTurnAutomation {
     private fun tryVoteForDiplomaticVictory(civ: Civilization) {
         if (!civ.mayVoteForDiplomaticVictory()) return
 
-        val chosenCiv: Civilization? = if (civ.isMajorCiv()) {
+        val chosenCiv: String? = if (civ.isMajorCiv()) {
+
             val knownMajorCivs = civ.getKnownCivs().filter { it.isMajorCiv() }
             val highestOpinion = knownMajorCivs
                 .maxOfOrNull {
@@ -552,13 +553,13 @@ object NextTurnAutomation {
                 null // Abstain if we hate everybody (proportional chance in the RelationshipLevel.Enemy range - lesser evil)
             else knownMajorCivs
                 .filter { civ.getDiplomacyManager(it)!!.opinionOfOtherCiv() == highestOpinion }
-                .toList().random()
+                .toList().random().civName
 
         } else {
-            civ.allyCiv
+            civ.getAllyCivName()
         }
 
-        civ.diplomaticVoteForCiv(chosenCiv?.civName)
+        civ.diplomaticVoteForCiv(chosenCiv)
     }
 
     private fun issueRequests(civInfo: Civilization) {

--- a/core/src/com/unciv/logic/automation/civilization/UseGoldAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/UseGoldAutomation.kt
@@ -54,7 +54,7 @@ object UseGoldAutomation {
 
         if (civ.gold < 500 || knownCityStates.none()) return // skip checks if tryGainInfluence will bail anyway
         val cityState = knownCityStates
-            .filter { it.allyCiv != civ }
+            .filter { it.getAllyCivName() != civ.civName }
             .associateWith { NextTurnAutomation.valueCityStateAlliance(civ, it, true) }
             .maxByOrNull { it.value }?.takeIf { it.value > 0 }?.key
         if (cityState != null) {

--- a/core/src/com/unciv/logic/automation/unit/EspionageAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/EspionageAutomation.kt
@@ -73,7 +73,7 @@ class EspionageAutomation(val civInfo: Civilization) {
     private fun automateSpyRigElection(spy: Spy): Boolean {
         val cityToMoveTo = cityStatesToRig.flatMap { it.cities }
             .filter { !it.isBeingRazed && spy.canMoveTo(it)
-                    && (it.civ.getDiplomacyManager(civInfo)!!.getInfluence() < 150 || it.civ.allyCiv != civInfo) }
+                    && (it.civ.getDiplomacyManager(civInfo)!!.getInfluence() < 150 || it.civ.getAllyCivName() != civInfo.civName) }
             .maxByOrNull { it.civ.getDiplomacyManager(civInfo)!!.getInfluence() }
         spy.moveTo(cityToMoveTo)
         return cityToMoveTo != null
@@ -95,7 +95,7 @@ class EspionageAutomation(val civInfo: Civilization) {
     private fun checkIfShouldStageCoup(spy: Spy) {
         if (!spy.canDoCoup()) return
         if (spy.getCoupChanceOfSuccess(false) < .7) return
-        val allyCiv = spy.getCity().civ.allyCiv
+        val allyCiv = spy.getCity().civ.getAllyCiv()
         // Don't coup city-states whose allies are out friends
         if (allyCiv != null && civInfo.getDiplomacyManager(allyCiv)?.isRelationshipLevelGE(RelationshipLevel.Friend) == true) return
         val spies = civInfo.espionageManager.spyList

--- a/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
@@ -649,7 +649,7 @@ object UnitAutomation {
                 .flatMap { it.cities.asSequence() }
                 .filter {
                     unit.civ.isAtWarWith(it.civ) &&
-                            unit.civ == it.foundingCivObject &&
+                            unit.civ.civName == it.foundingCiv &&
                             it.isInResistance() &&
                             it.health < it.getMaxHealth()
                 } //Most likely just been captured
@@ -707,7 +707,7 @@ object UnitAutomation {
         if (city.health < city.getMaxHealth()) return true // this city is under attack!
         for (enemyCivCity in city.civ.diplomacy.values
             .filter { it.diplomaticStatus == DiplomaticStatus.War }
-            .map { it.otherCiv }.flatMap { it.cities })
+            .map { it.otherCiv() }.flatMap { it.cities })
             if (city.getCenterTile().aerialDistanceTo(enemyCivCity.getCenterTile()) <= 5) return true // this is an edge city that needs defending
         return false
     }

--- a/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
@@ -578,7 +578,7 @@ class WorkerAutomation(
 
         var valueOfFort = 1f
 
-        if (civInfo.isCityState && civInfo.allyCiv != null) valueOfFort -= 1f // Allied city states probably don't need to build forts
+        if (civInfo.isCityState && civInfo.getAllyCivName() != null) valueOfFort -= 1f // Allied city states probably don't need to build forts
 
         if (tile.hasViewableResource(civInfo)) valueOfFort -= 1
 

--- a/core/src/com/unciv/logic/battle/Battle.kt
+++ b/core/src/com/unciv/logic/battle/Battle.kt
@@ -677,7 +677,7 @@ object Battle {
             return
         }
 
-        if (city.isOriginalCapital && city.foundingCivObject == attackerCiv) {
+        if (city.isOriginalCapital && city.foundingCiv == attackerCiv.civName) {
             // retaking old capital
             city.puppetCity(attackerCiv)
             //Although in Civ5 Venice is unable to re-annex their capital, that seems a bit silly. No check for May not annex cities here.
@@ -699,7 +699,7 @@ object Battle {
      * or raze a city */
     private fun automateCityConquer(civInfo: Civilization, city: City) {
         if (!city.hasDiplomaticMarriage()) {
-            val foundingCiv = city.foundingCivObject!!
+            val foundingCiv = civInfo.gameInfo.getCivilization(city.foundingCiv)
             var valueAlliance = NextTurnAutomation.valueCityStateAlliance(civInfo, foundingCiv)
             if (civInfo.getHappiness() < 0)
                 valueAlliance -= civInfo.getHappiness() // put extra weight on liberating if unhappy
@@ -713,7 +713,7 @@ object Battle {
 
         city.puppetCity(civInfo)
         if ((city.population.population < 4 || civInfo.isCityState)
-            && city.foundingCivObject != civInfo && city.canBeDestroyed(justCaptured = true)) {
+            && city.foundingCiv != civInfo.civName && city.canBeDestroyed(justCaptured = true)) {
             // raze if attacker is a city state
             if (!civInfo.hasUnique(UniqueType.MayNotAnnexCities)) city.annexCity()
             city.isBeingRazed = true

--- a/core/src/com/unciv/logic/battle/BattleDamage.kt
+++ b/core/src/com/unciv/logic/battle/BattleDamage.kt
@@ -150,7 +150,7 @@ object BattleDamage {
             if (attacker.isMelee()) {
                 val numberOfOtherAttackersSurroundingDefender = defender.getTile().neighbors.count {
                     it.militaryUnit != null && it.militaryUnit != attacker.unit
-                            && it.militaryUnit!!.civ == attacker.getCivInfo()
+                            && it.militaryUnit!!.owner == attacker.getCivInfo().civName
                             && MapUnitCombatant(it.militaryUnit!!).isMelee()
                 }
                 if (numberOfOtherAttackersSurroundingDefender > 0) {

--- a/core/src/com/unciv/logic/battle/BattleUnitCapture.kt
+++ b/core/src/com/unciv/logic/battle/BattleUnitCapture.kt
@@ -134,7 +134,9 @@ object BattleUnitCapture {
         capturedUnit.automated = false
 
         val capturedUnitTile = capturedUnit.getTile()
-        val originalOwner = capturedUnit.originalOwningCiv
+        val originalOwner = if (capturedUnit.originalOwner != null)
+            capturedUnit.civ.gameInfo.getCivilization(capturedUnit.originalOwner!!)
+        else null
 
         var wasDestroyedInstead = false
         when {

--- a/core/src/com/unciv/logic/city/City.kt
+++ b/core/src/com/unciv/logic/city/City.kt
@@ -63,8 +63,7 @@ class City : IsPartOfGameInfoSerialization, INamed {
     var location: Vector2 = Vector2.Zero
     var id: String = UUID.randomUUID().toString()
     override var name: String = ""
-    /**Serialization field for [foundingCivObject]. Is equivalient to ``foundingCivObject.civName``*/
-    private var foundingCiv = ""
+    var foundingCiv = ""
     // This is so that cities in resistance that are recaptured aren't in resistance anymore
     var previousOwner = ""
     var turnAcquired = 0
@@ -111,23 +110,6 @@ class City : IsPartOfGameInfoSerialization, INamed {
     @Readonly fun getCityFocus() = CityFocus.entries.firstOrNull { it.name == cityAIFocus } ?: CityFocus.NoFocus
     fun setCityFocus(cityFocus: CityFocus){ cityAIFocus = cityFocus.name }
 
-    /**
-     * Civ object for the original founder of this city
-     * 
-     * Setting this also sets its backing serialization string ``foundingCiv``
-     * */
-    @Transient
-    @get:Readonly
-    var foundingCivObject: Civilization? = null
-        get() {
-            if (field == null && foundingCiv.isNotEmpty()) field = civ.gameInfo.getCivilization(foundingCiv)
-            return field
-        }
-        set(value) {
-            field = value
-            foundingCiv = value?.civName ?: ""
-        }
-
 
 
     var avoidGrowth: Boolean = false
@@ -146,7 +128,7 @@ class City : IsPartOfGameInfoSerialization, INamed {
     /** Persisted connected-to-capital (by any medium) to allow "disconnected" notifications after loading */
     var connectedToCapitalStatus = false
 
-    @Readonly fun hasDiplomaticMarriage(): Boolean = foundingCivObject == null
+    @Readonly fun hasDiplomaticMarriage(): Boolean = foundingCiv == ""
 
     //region pure functions
     fun clone(): City {
@@ -513,7 +495,7 @@ class City : IsPartOfGameInfoSerialization, INamed {
                 && !civ.isAtWarWith(viewingCiv)
             "in enemy cities", "Enemy" -> civ.isAtWarWith(viewingCiv ?: civ)
             "in foreign cities", "Foreign" -> viewingCiv != null && viewingCiv != civ
-            "in annexed cities", "Annexed" -> foundingCivObject != civ && !isPuppet
+            "in annexed cities", "Annexed" -> foundingCiv != civ.civName && !isPuppet
             "in puppeted cities", "Puppeted" -> isPuppet
             "in resisting cities", "Resisting" -> isInResistance()
             "in cities being razed", "Razing" -> isBeingRazed

--- a/core/src/com/unciv/logic/city/CityStats.kt
+++ b/core/src/com/unciv/logic/city/CityStats.kt
@@ -172,7 +172,7 @@ class CityStats(val city: City) {
 
     @Readonly
     fun hasExtraAnnexUnhappiness(): Boolean {
-        if (city.civ == city.foundingCivObject || city.isPuppet) return false
+        if (city.civ.civName == city.foundingCiv || city.isPuppet) return false
         return !city.containsBuildingUnique(UniqueType.RemovesAnnexUnhappiness)
     }
 

--- a/core/src/com/unciv/logic/city/managers/CityConquestFunctions.kt
+++ b/core/src/com/unciv/logic/city/managers/CityConquestFunctions.kt
@@ -114,7 +114,7 @@ class CityConquestFunctions(val city: City) {
             city.population.addPopulation(-1 - city.population.population / 4) // so from 2-4 population, remove 1, from 5-8, remove 2, etc.
         city.reassignAllPopulation()
 
-        if (!reconqueredCityWhileStillInResistance && city.foundingCivObject != receivingCiv) {
+        if (!reconqueredCityWhileStillInResistance && city.foundingCiv != receivingCiv.civName) {
             // add resistance
             // I checked, and even if you puppet there's resistance for conquering
             city.setFlag(CityFlags.Resistance, city.population.population)
@@ -182,13 +182,13 @@ class CityConquestFunctions(val city: City) {
     }
 
     fun liberateCity(conqueringCiv: Civilization) {
-        if (city.foundingCivObject == null) { // this should never happen but just in case...
+        if (city.foundingCiv == "") { // this should never happen but just in case...
             this.puppetCity(conqueringCiv)
             this.annexCity()
             return
         }
 
-        val foundingCiv = city.foundingCivObject!!
+        val foundingCiv = city.civ.gameInfo.getCivilization(city.foundingCiv)
         if (foundingCiv.isDefeated()) // resurrected civ
             for (diploManager in foundingCiv.diplomacy.values)
                 if (diploManager.diplomaticStatus == DiplomaticStatus.War)
@@ -231,7 +231,7 @@ class CityConquestFunctions(val city: City) {
 
 
     private fun diplomaticRepercussionsForLiberatingCity(conqueringCiv: Civilization, conqueredCiv: Civilization) {
-        val foundingCiv = city.foundingCivObject!!
+        val foundingCiv = conqueredCiv.gameInfo.civilizations.first { it.civName == city.foundingCiv }
         val percentageOfCivPopulationInThatCity = city.population.population *
                 100f / (foundingCiv.cities.sumOf { it.population.population } + city.population.population)
         val respectForLiberatingOurCity = 10f + percentageOfCivPopulationInThatCity.roundToInt()

--- a/core/src/com/unciv/logic/city/managers/CityFounder.kt
+++ b/core/src/com/unciv/logic/city/managers/CityFounder.kt
@@ -18,7 +18,7 @@ class CityFounder {
     fun foundCity(civInfo: Civilization, cityLocation: Vector2, unit: MapUnit? = null): City {
         val city = City()
 
-        city.foundingCivObject = civInfo
+        city.foundingCiv = civInfo.civName
         city.turnAcquired = civInfo.gameInfo.turns
         city.location = cityLocation
         city.setTransients(civInfo)

--- a/core/src/com/unciv/logic/city/managers/CityReligionManager.kt
+++ b/core/src/com/unciv/logic/city/managers/CityReligionManager.kt
@@ -113,7 +113,7 @@ class CityReligionManager : IsPartOfGameInfoSerialization {
 
         if (newMajorityReligion in religionsAtSomePointAdopted) return
 
-        val religionOwningCiv = newMajorityReligionObject.foundingCiv
+        val religionOwningCiv = newMajorityReligionObject.getFounder()
         if (religionOwningCiv.hasUnique(UniqueType.StatsWhenAdoptingReligion)) {
             val statsGranted =
                 religionOwningCiv.getMatchingUniques(UniqueType.StatsWhenAdoptingReligion).map { it.stats.times(if (!it.isModifiedByGameSpeed()) 1f else city.civ.gameInfo.speed.modifier) }
@@ -209,7 +209,7 @@ class CityReligionManager : IsPartOfGameInfoSerialization {
             if (pressure == Constants.noReligionName) continue
             val correspondingReligion = city.civ.gameInfo.religions[pressure]!!
             if (correspondingReligion.isPantheon()
-                && correspondingReligion.foundingCiv != city.civ
+                && correspondingReligion.foundingCivName != city.civ.civName
             ) {
                 pressures.remove(pressure)
             }
@@ -266,7 +266,7 @@ class CityReligionManager : IsPartOfGameInfoSerialization {
 
         val majorityReligion = getMajorityReligion()
         if (majorityReligion != null) {
-            for (unique in majorityReligion.foundingCiv.getMatchingUniques(UniqueType.ReligionSpreadDistance))
+            for (unique in majorityReligion.getFounder().getMatchingUniques(UniqueType.ReligionSpreadDistance))
                 spreadRange += unique.params[0].toInt()
         }
 
@@ -322,7 +322,7 @@ class CityReligionManager : IsPartOfGameInfoSerialization {
         // Founder beliefs of this religion
         val majorityReligion = getMajorityReligion()
         if (majorityReligion != null) {
-            for (unique in majorityReligion.foundingCiv.getMatchingUniques(UniqueType.NaturalReligionSpreadStrength))
+            for (unique in majorityReligion.getFounder().getMatchingUniques(UniqueType.NaturalReligionSpreadStrength))
                 if (pressuredCity.matchesFilter(unique.params[1]))
                     pressure *= unique.params[0].toPercent()
         }

--- a/core/src/com/unciv/logic/civilization/Civilization.kt
+++ b/core/src/com/unciv/logic/civilization/Civilization.kt
@@ -165,7 +165,6 @@ class Civilization : IsPartOfGameInfoSerialization {
     var diplomacy = HashMap<String, DiplomacyManager>()
     var proximity = HashMap<String, Proximity>()
     val popupAlerts = ArrayList<PopupAlert>()
-    /**Serialization field for [allyCiv]. Is equivalent to ``allyCiv.civName``*/
     private var allyCivName: String? = null
     var naturalWonders = ArrayList<String>()
 
@@ -345,11 +344,11 @@ class Civilization : IsPartOfGameInfoSerialization {
      *  for major civs, but **will** do so for city-states after some gameplay.
      */
     @Readonly
-    fun getKnownCivs() = diplomacy.values.asSequence().map { it.otherCiv }
+    fun getKnownCivs() = diplomacy.values.asSequence().map { it.otherCiv() }
         .filter { !it.isDefeated() && !it.isSpectator() }
 
     @Readonly
-    fun getKnownCivsWithSpectators() = diplomacy.values.asSequence().map { it.otherCiv }
+    fun getKnownCivsWithSpectators() = diplomacy.values.asSequence().map { it.otherCiv() }
         .filter { !it.isDefeated() }
 
 
@@ -685,8 +684,8 @@ class Civilization : IsPartOfGameInfoSerialization {
     @Readonly fun getEra(): Era = tech.era
     @Readonly fun getEraNumber(): Int = getEra().eraNumber
     @Readonly fun isAtWarWith(otherCiv: Civilization) = diplomacyFunctions.isAtWarWith(otherCiv)
-    @Readonly fun isAtWar() = diplomacy.values.any { it.diplomaticStatus == DiplomaticStatus.War && !it.otherCiv.isDefeated() }
-    @Readonly fun getCivsAtWarWith() = diplomacy.values.filter { it.diplomaticStatus == DiplomaticStatus.War && !it.otherCiv.isDefeated() }.map { it.otherCiv }
+    @Readonly fun isAtWar() = diplomacy.values.any { it.diplomaticStatus == DiplomaticStatus.War && !it.otherCiv().isDefeated() }
+    @Readonly fun getCivsAtWarWith() = diplomacy.values.filter { it.diplomaticStatus == DiplomaticStatus.War && !it.otherCiv().isDefeated() }.map { it.otherCiv() }
 
 
     /**
@@ -1022,8 +1021,8 @@ class Civilization : IsPartOfGameInfoSerialization {
         for (diplomacyManager in diplomacy.values) {
             diplomacyManager.trades.clear()
             diplomacyManager.otherCivDiplomacy().trades.clear()
-            for (tradeRequest in diplomacyManager.otherCiv.tradeRequests.filter { it.requestingCiv == civName })
-                diplomacyManager.otherCiv.tradeRequests.remove(tradeRequest) // it  would be really weird to get a trade request from a dead civ
+            for (tradeRequest in diplomacyManager.otherCiv().tradeRequests.filter { it.requestingCiv == civName })
+                diplomacyManager.otherCiv().tradeRequests.remove(tradeRequest) // it  would be really weird to get a trade request from a dead civ
         }
         if (gameInfo.isEspionageEnabled())
             espionageManager.removeAllSpies()
@@ -1084,23 +1083,10 @@ class Civilization : IsPartOfGameInfoSerialization {
         moveCapitalTo(newCapital, oldCapital)
     }
 
-    /**
-     * Current ally (assuming this is a city-state)
-     * 
-     * Setting this also sets its backing serialization field ``allyCivName``
-     * */
-    @get:Readonly
-    @Transient
-    var allyCiv: Civilization? = null
-        get() {
-            if (field == null && allyCivName != null)
-                field = gameInfo.getCivilization(allyCivName!!)
-            return field
-        }
-        set(value) {
-            allyCivName = value?.civName
-            field = value
-        }
+    @Readonly fun getAllyCiv(): Civilization? = if (allyCivName == null) null
+        else gameInfo.getCivilization(allyCivName!!)
+    @Readonly fun getAllyCivName() = allyCivName
+    fun setAllyCiv(newAllyName: String?) { allyCivName = newAllyName }
 
     /** Determine if this civ (typically as human player) is allowed to know how many major civs there are
      *

--- a/core/src/com/unciv/logic/civilization/NotificationActions.kt
+++ b/core/src/com/unciv/logic/civilization/NotificationActions.kt
@@ -82,30 +82,13 @@ class CityAction(private val city: Vector2 = Vector2.Zero) : NotificationAction 
 }
 
 /** enter diplomacy screen */
-class DiplomacyAction : NotificationAction {
-    private val otherCivName: String
-    private var showTrade: Boolean
-    @Transient
-    private lateinit var otherCiv: Civilization
-
-    @Suppress("unused") // Used for deserialization
-    constructor(): this("", false)
-
-    constructor(otherCivName: String, showTrade: Boolean = false) {
-        this.otherCivName = otherCivName
-        this.showTrade = showTrade
-    }
-
-    constructor(otherCiv: Civilization, showTrade: Boolean = false) {
-        this.otherCiv = otherCiv
-        this.otherCivName = otherCiv.civName
-        this.showTrade = showTrade
-    }
-
+class DiplomacyAction(
+    private val otherCivName: String = "",
+    private var showTrade: Boolean = false
+) : NotificationAction {
     override fun execute(worldScreen: WorldScreen) {
         val currentCiv = worldScreen.selectedCiv
-        if (!::otherCiv.isInitialized)
-            otherCiv = worldScreen.gameInfo.getCivilization(otherCivName)
+        val otherCiv = worldScreen.gameInfo.getCivilization(otherCivName)
 
         if (showTrade && otherCiv == currentCiv)
             // Because TradeTable will set up otherCiv against that one,

--- a/core/src/com/unciv/logic/civilization/diplomacy/DeclareWar.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DeclareWar.kt
@@ -25,7 +25,7 @@ object DeclareWar {
      */
     internal fun declareWar(diplomacyManager: DiplomacyManager, declareWarReason: DeclareWarReason) {
         val civInfo = diplomacyManager.civInfo
-        val otherCiv = diplomacyManager.otherCiv
+        val otherCiv = diplomacyManager.otherCiv()
         val otherCivDiplomacy = diplomacyManager.otherCivDiplomacy()
 
         if (otherCiv.isCityState && declareWarReason.warType == WarType.DirectWar)
@@ -64,7 +64,7 @@ object DeclareWar {
 
     private fun handleCityStateDirectAttack(diplomacyManager: DiplomacyManager) {
         val civInfo = diplomacyManager.civInfo
-        val otherCiv = diplomacyManager.otherCiv
+        val otherCiv = diplomacyManager.otherCiv()
         val otherCivDiplomacy = diplomacyManager.otherCivDiplomacy()
 
         otherCivDiplomacy.setInfluence(-60f)
@@ -72,7 +72,7 @@ object DeclareWar {
         otherCiv.cityStateFunctions.cityStateAttacked(civInfo)
 
         // You attacked your own ally, you're a right bastard
-        if (otherCiv.allyCiv == civInfo) {
+        if (otherCiv.getAllyCivName() == civInfo.civName) {
             otherCiv.cityStateFunctions.updateAllyCivForCityState()
             otherCivDiplomacy.setInfluence(-120f)
             for (knownCiv in civInfo.getKnownCivs()) {
@@ -83,7 +83,7 @@ object DeclareWar {
 
     private fun notifyOfWar(diplomacyManager: DiplomacyManager, declareWarReason: DeclareWarReason) {
         val civInfo = diplomacyManager.civInfo
-        val otherCiv = diplomacyManager.otherCiv
+        val otherCiv = diplomacyManager.otherCiv()
 
         when (declareWarReason.warType) {
             WarType.DirectWar -> {
@@ -149,7 +149,7 @@ object DeclareWar {
         for (trade in diplomacyManager.trades)
             for (offer in trade.theirOffers.filter { it.duration > 0 && it.name != Constants.defensivePact})
                 diplomacyManager.civInfo.addNotification("[${offer.name}] from [${diplomacyManager.otherCivName}] has ended",
-                    DiplomacyAction(diplomacyManager.otherCiv, true),
+                    DiplomacyAction(diplomacyManager.otherCivName, true),
                     NotificationCategory.Trade, diplomacyManager.otherCivName, NotificationIcon.Trade)
         diplomacyManager.trades.clear()
         diplomacyManager.civInfo.tradeRequests.removeAll { it.requestingCiv == diplomacyManager.otherCivName }
@@ -157,7 +157,7 @@ object DeclareWar {
         // Must come *before* state is "at war" so units know they're not allowed in tiles without open borders anymore
         diplomacyManager.updateHasOpenBorders()
 
-        val civAtWarWith = diplomacyManager.otherCiv
+        val civAtWarWith = diplomacyManager.otherCiv()
 
         // If we attacked, then we need to end all of our defensive pacts acording to Civ 5
         if (isOffensiveWar) {
@@ -188,7 +188,7 @@ object DeclareWar {
 
     private fun changeOpinions(diplomacyManager: DiplomacyManager, declareWarReason: DeclareWarReason) {
         val civInfo = diplomacyManager.civInfo
-        val otherCiv = diplomacyManager.otherCiv
+        val otherCiv = diplomacyManager.otherCiv()
         val otherCivDiplomacy = diplomacyManager.otherCivDiplomacy()
         val warType = declareWarReason.warType
 
@@ -223,7 +223,7 @@ object DeclareWar {
     }
 
     private fun breakTreaties(diplomacyManager: DiplomacyManager) {
-        val otherCiv = diplomacyManager.otherCiv
+        val otherCiv = diplomacyManager.otherCiv()
         val otherCivDiplomacy = diplomacyManager.otherCivDiplomacy()
 
         var betrayedFriendship = false
@@ -277,7 +277,7 @@ object DeclareWar {
      * This is so that we can apply more negative modifiers later.
      */
     private fun removeDefensivePacts(diplomacyManager: DiplomacyManager) {
-        val civAtWarWith = diplomacyManager.otherCiv
+        val civAtWarWith = diplomacyManager.otherCiv()
         for (thirdPartyDiploManager in diplomacyManager.civInfo.diplomacy.values) {
             if (thirdPartyDiploManager.diplomaticStatus != DiplomaticStatus.DefensivePact) continue
 
@@ -287,7 +287,7 @@ object DeclareWar {
 
             // We already removed the trades and functionality
             // But we don't want to remove the flags yet so we can process BetrayedDefensivePact later
-            if (thirdPartyDiploManager.otherCiv != civAtWarWith) {
+            if (thirdPartyDiploManager.otherCiv() != civAtWarWith) {
                 // Trades with defensive pact are now invalid
                 val defensivePactOffer = thirdPartyDiploManager.trades
                     .firstOrNull { trade -> trade.ourOffers.any { offer -> offer.name == Constants.defensivePact } }
@@ -304,7 +304,7 @@ object DeclareWar {
                     NotificationCategory.Diplomacy, diplomacyManager.civInfo.civName, NotificationIcon.Diplomacy, thirdPartyDiploManager.otherCivName)
             }
 
-            thirdPartyDiploManager.otherCiv.addNotification("[${diplomacyManager.civInfo.civName}] cancelled their Defensive Pact with us!",
+            thirdPartyDiploManager.otherCiv().addNotification("[${diplomacyManager.civInfo.civName}] cancelled their Defensive Pact with us!",
                 NotificationCategory.Diplomacy, diplomacyManager.civInfo.civName, NotificationIcon.Diplomacy, thirdPartyDiploManager.otherCivName)
 
             thirdPartyDiploManager.civInfo.addNotification("We have cancelled our Defensive Pact with [${thirdPartyDiploManager.otherCivName}]!",
@@ -318,13 +318,13 @@ object DeclareWar {
      * The civ that we are calling them in against should no longer have a defensive pact with us.
      */
     private fun callInDefensivePactAllies(diplomacyManager: DiplomacyManager) {
-        val civAtWarWith = diplomacyManager.otherCiv
+        val civAtWarWith = diplomacyManager.otherCiv()
         for (ourDefensivePact in diplomacyManager.civInfo.diplomacy.values.filter { ourDipManager ->
             ourDipManager.diplomaticStatus == DiplomaticStatus.DefensivePact
-                && !ourDipManager.otherCiv.isDefeated()
-                && !ourDipManager.otherCiv.isAtWarWith(civAtWarWith)
+                && !ourDipManager.otherCiv().isDefeated()
+                && !ourDipManager.otherCiv().isAtWarWith(civAtWarWith)
         }.toList()) {
-            val ally = ourDefensivePact.otherCiv
+            val ally = ourDefensivePact.otherCiv()
             if (!civAtWarWith.knows(ally)) civAtWarWith.diplomacyFunctions.makeCivilizationsMeet(ally, true)
             // Have the aggressor declare war on the ally.
             civAtWarWith.getDiplomacyManager(ally)!!.declareWar(DeclareWarReason(WarType.DefensivePactWar, diplomacyManager.civInfo))
@@ -332,9 +332,9 @@ object DeclareWar {
     }
 
     private fun callInCityStateAllies(diplomacyManager: DiplomacyManager) {
-        val civAtWarWith = diplomacyManager.otherCiv
+        val civAtWarWith = diplomacyManager.otherCiv()
         for (thirdCiv in diplomacyManager.civInfo.getKnownCivs()
-            .filter { it.isCityState && it.allyCiv == diplomacyManager.civInfo }.toList()) {
+            .filter { it.isCityState && it.getAllyCivName() == diplomacyManager.civInfo.civName }.toList()) {
 
             if (thirdCiv.isAtWarWith(civAtWarWith)) continue
             if (!thirdCiv.knows(civAtWarWith))

--- a/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyFunctions.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyFunctions.kt
@@ -29,7 +29,7 @@ class DiplomacyFunctions(val civInfo: Civilization) {
     }
 
     private fun meetCiv(otherCiv: Civilization, warOnContact: Boolean = false) {
-        civInfo.diplomacy[otherCiv.civName] = DiplomacyManager(civInfo, otherCiv)
+        civInfo.diplomacy[otherCiv.civName] = DiplomacyManager(civInfo, otherCiv.civName)
             .apply { diplomaticStatus = DiplomaticStatus.Peace }
 
         if (!otherCiv.isSpectator())
@@ -50,7 +50,7 @@ class DiplomacyFunctions(val civInfo: Civilization) {
             // For now, it might be overkill though.
             var meetString = "[${civInfo.civName}] has given us [${giftAmount.toStringForNotifications()}] as a token of goodwill for meeting us"
             val religionMeetString = "[${civInfo.civName}] has also given us [${faithAmount.toStringForNotifications()}]"
-            if (civInfo.diplomacy.count { it.value.otherCiv.isMajorCiv() } == 1) {
+            if (civInfo.diplomacy.count { it.value.otherCiv().isMajorCiv() } == 1) {
                 giftAmount.timesInPlace(2f)
                 meetString = "[${civInfo.civName}] has given us [${giftAmount.toStringForNotifications()}] as we are the first major civ to meet them"
             }
@@ -81,7 +81,7 @@ class DiplomacyFunctions(val civInfo: Civilization) {
             otherCiv == civInfo -> false
             otherCiv.isBarbarian || civInfo.isBarbarian -> true
             else -> {
-                val diplomacyManager = civInfo.getDiplomacyManager(otherCiv)
+                val diplomacyManager = civInfo.diplomacy[otherCiv.civName]
                     ?: return false // not encountered yet
                 return diplomacyManager.diplomaticStatus == DiplomaticStatus.War
             }
@@ -237,7 +237,7 @@ class DiplomacyFunctions(val civInfo: Civilization) {
         if (otherCiv.isBarbarian) return true
         if (civInfo.isBarbarian && civInfo.gameInfo.turns >= civInfo.gameInfo.getDifficulty().turnBarbariansCanEnterPlayerTiles)
             return true
-        val diplomacyManager = civInfo.getDiplomacyManager(otherCiv)
+        val diplomacyManager = civInfo.diplomacy[otherCiv.civName]
         if (diplomacyManager != null && (diplomacyManager.hasOpenBorders || diplomacyManager.diplomaticStatus == DiplomaticStatus.War))
             return true
         // Players can always pass through city-state tiles

--- a/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
+++ b/core/src/com/unciv/logic/civilization/diplomacy/DiplomacyManager.kt
@@ -17,7 +17,6 @@ import com.unciv.models.ruleset.unique.UniqueTriggerActivation
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.translations.fillPlaceholders
 import com.unciv.ui.components.extensions.toPercent
-import yairm210.purity.annotations.Cache
 import org.jetbrains.annotations.VisibleForTesting
 import yairm210.purity.annotations.Immutable
 import yairm210.purity.annotations.Pure
@@ -205,24 +204,10 @@ class DiplomacyManager() : IsPartOfGameInfoSerialization {
         updateHasOpenBorders()
     }
 
-    constructor(civilization: Civilization, otherCiv: Civilization) : this() {
-        civInfo = civilization
-        mOtherCiv = otherCiv
-        otherCivName = otherCiv.civName
-        updateHasOpenBorders()
-    }
-
     //region pure functions
 
-    @Cache
-    @Transient
-    private lateinit var mOtherCiv: Civilization
-    @get:Readonly val otherCiv: Civilization get() {
-        if (!::mOtherCiv.isInitialized)
-            mOtherCiv = civInfo.gameInfo.getCivilization(otherCivName)
-        return mOtherCiv
-    }
-    @Readonly fun otherCivDiplomacy() = otherCiv.getDiplomacyManager(civInfo)!!
+    @Readonly fun otherCiv() = civInfo.gameInfo.getCivilization(otherCivName)
+    @Readonly fun otherCivDiplomacy() = otherCiv().getDiplomacyManager(civInfo)!!
 
     @Readonly
     fun turnsToPeaceTreaty(): Int {
@@ -302,7 +287,7 @@ class DiplomacyManager() : IsPartOfGameInfoSerialization {
         val level = relationshipIgnoreAfraid()
         return when {
             level != RelationshipLevel.Neutral || !civInfo.isCityState -> level
-            civInfo.cityStateFunctions.getTributeWillingness(otherCiv) > 0 -> RelationshipLevel.Afraid
+            civInfo.cityStateFunctions.getTributeWillingness(otherCiv()) > 0 -> RelationshipLevel.Afraid
             else -> RelationshipLevel.Neutral
         }
     }
@@ -310,7 +295,7 @@ class DiplomacyManager() : IsPartOfGameInfoSerialization {
     /** Same as [relationshipLevel] but omits the distinction Neutral/Afraid, which can be _much_ cheaper */
     @Readonly
     fun relationshipIgnoreAfraid(): RelationshipLevel {
-        if (civInfo.isHuman() && otherCiv.isHuman())
+        if (civInfo.isHuman() && otherCiv().isHuman())
             return RelationshipLevel.Neutral // People make their own choices.
 
         if (civInfo.isHuman())
@@ -319,7 +304,7 @@ class DiplomacyManager() : IsPartOfGameInfoSerialization {
         if (civInfo.isCityState) return when {
             getInfluence() <= -30 -> RelationshipLevel.Unforgivable  // getInfluence tests isAtWarWith
             getInfluence() < 0 -> RelationshipLevel.Enemy
-            getInfluence() >= 60 && civInfo.allyCiv == otherCiv -> RelationshipLevel.Ally
+            getInfluence() >= 60 && civInfo.getAllyCivName() == otherCivName -> RelationshipLevel.Ally
             getInfluence() >= 30 -> RelationshipLevel.Friend
             else -> RelationshipLevel.Neutral
         }
@@ -330,7 +315,7 @@ class DiplomacyManager() : IsPartOfGameInfoSerialization {
         val opinion = opinionOfOtherCiv()
         return when {
             opinion <= -80 -> RelationshipLevel.Unforgivable
-            opinion <= -40 || civInfo.isAtWarWith(otherCiv) -> RelationshipLevel.Enemy  /* During wartime, the estimation in which you are held may be enemy OR unforgivable */
+            opinion <= -40 || civInfo.isAtWarWith(otherCiv()) -> RelationshipLevel.Enemy  /* During wartime, the estimation in which you are held may be enemy OR unforgivable */
             opinion <= -15 -> RelationshipLevel.Competitor
 
             opinion >= 80 -> RelationshipLevel.Ally
@@ -346,16 +331,16 @@ class DiplomacyManager() : IsPartOfGameInfoSerialization {
         val civMajorityReligion = civInfo.religionManager.getMajorityReligion() ?: return false
         // if not yet returned false from previous line, return the Boolean isMajorityReligionForCiv
         // true if majorityReligion of civInfo is also majorityReligion of otherCiv, false otherwise
-        return otherCiv.religionManager.isMajorityReligionForCiv(civMajorityReligion)
+        return otherCiv().religionManager.isMajorityReligionForCiv(civMajorityReligion)
     }
 
     /** Returns the number of turns to degrade from Ally or from Friend */
     @Readonly
     fun getTurnsToRelationshipChange(): Int {
-        if (otherCiv.isCityState)
+        if (otherCiv().isCityState)
             return otherCivDiplomacy().getTurnsToRelationshipChange()
 
-        if (civInfo.isCityState && !otherCiv.isCityState) {
+        if (civInfo.isCityState && !otherCiv().isCityState) {
             val dropPerTurn = getCityStateInfluenceDegrade()
             return when {
                 dropPerTurn == 0f -> 0
@@ -391,19 +376,19 @@ class DiplomacyManager() : IsPartOfGameInfoSerialization {
     }
 
     @Readonly
-    fun getInfluence() = if (civInfo.isAtWarWith(otherCiv)) MINIMUM_INFLUENCE else influence
+    fun getInfluence() = if (civInfo.isAtWarWith(otherCiv())) MINIMUM_INFLUENCE else influence
 
     // To be run from City-State DiplomacyManager, which holds the influence. Resting point for every major civ can be different.
     @Readonly
     internal fun getCityStateInfluenceRestingPoint(): Float {
         var restingPoint = 0f
 
-        for (unique in otherCiv.getMatchingUniques(UniqueType.CityStateRestingPoint))
+        for (unique in otherCiv().getMatchingUniques(UniqueType.CityStateRestingPoint))
             restingPoint += unique.params[0].toInt()
 
         if (civInfo.cities.any() && civInfo.getCapital() != null)
-            for (unique in otherCiv.getMatchingUniques(UniqueType.RestingPointOfCityStatesFollowingReligionChange))
-                if (otherCiv.religionManager.religion?.name == civInfo.getCapital()!!.religion.getMajorityReligionName())
+            for (unique in otherCiv().getMatchingUniques(UniqueType.RestingPointOfCityStatesFollowingReligionChange))
+                if (otherCiv().religionManager.religion?.name == civInfo.getCapital()!!.religion.getMajorityReligionName())
                     restingPoint += unique.params[0].toInt()
 
         if (diplomaticStatus == DiplomaticStatus.Protector) restingPoint += 10
@@ -420,20 +405,20 @@ class DiplomacyManager() : IsPartOfGameInfoSerialization {
 
         val decrement = when {
             civInfo.cityStatePersonality == CityStatePersonality.Hostile -> 1.5f
-            otherCiv.isMinorCivAggressor() -> 2f
+            otherCiv().isMinorCivAggressor() -> 2f
             else -> 1f
         }
 
         var modifierPercent = 0f
-        for (unique in otherCiv.getMatchingUniques(UniqueType.CityStateInfluenceDegradation))
+        for (unique in otherCiv().getMatchingUniques(UniqueType.CityStateInfluenceDegradation))
             modifierPercent += unique.params[0].toFloat()
 
         val religion = if (civInfo.cities.isEmpty() || civInfo.getCapital() == null) null
             else civInfo.getCapital()!!.religion.getMajorityReligionName()
-        if (religion != null && religion == otherCiv.religionManager.religion?.name)
+        if (religion != null && religion == otherCiv().religionManager.religion?.name)
             modifierPercent -= 25f  // 25% slower degrade when sharing a religion
 
-        for (civ in civInfo.gameInfo.civilizations.filter { it.isMajorCiv() && it != otherCiv}) {
+        for (civ in civInfo.gameInfo.civilizations.filter { it.isMajorCiv() && it != otherCiv()}) {
             for (unique in civ.getMatchingUniques(UniqueType.OtherCivsCityStateRelationsDegradeFaster)) {
                 modifierPercent += unique.params[0].toFloat()
             }
@@ -444,7 +429,7 @@ class DiplomacyManager() : IsPartOfGameInfoSerialization {
 
 
     @Readonly
-    fun canDeclareWar() = !civInfo.isDefeated() && !otherCiv.isDefeated()
+    fun canDeclareWar() = !civInfo.isDefeated() && !otherCiv().isDefeated()
             && turnsToPeaceTreaty() == 0 && diplomaticStatus != DiplomaticStatus.War
 
     fun declareWar(declareWarReason: DeclareWarReason = DeclareWarReason(WarType.DirectWar)) =
@@ -485,16 +470,16 @@ class DiplomacyManager() : IsPartOfGameInfoSerialization {
     }
 
     /** Returns the [civilizations][Civilization] that know about both sides ([civInfo] and [otherCiv]) */
-    @Readonly fun getCommonKnownCivs(): Set<Civilization> = civInfo.getKnownCivs().asIterable().intersect(otherCiv.getKnownCivs().toSet())
+    @Readonly fun getCommonKnownCivs(): Set<Civilization> = civInfo.getKnownCivs().asIterable().intersect(otherCiv().getKnownCivs().toSet())
 
-    @Readonly fun getCommonKnownCivsWithSpectators(): Set<Civilization> = civInfo.getKnownCivsWithSpectators().asIterable().intersect(otherCiv.getKnownCivsWithSpectators().toSet())
+    @Readonly fun getCommonKnownCivsWithSpectators(): Set<Civilization> = civInfo.getKnownCivsWithSpectators().asIterable().intersect(otherCiv().getKnownCivsWithSpectators().toSet())
     /** Returns true when the [civInfo]'s territory is considered allied for [otherCiv].
      *  This includes friendly and allied city-states and the open border treaties.
      */
     @Readonly
     fun isConsideredFriendlyTerritory(): Boolean {
         if (civInfo.isCityState &&
-            (isRelationshipLevelGE(RelationshipLevel.Friend) || otherCiv.hasUnique(UniqueType.CityStateTerritoryAlwaysFriendly)))
+            (isRelationshipLevelGE(RelationshipLevel.Friend) || otherCiv().hasUnique(UniqueType.CityStateTerritoryAlwaysFriendly)))
             return true
 
         return otherCivDiplomacy().hasOpenBorders // if THEY can enter US then WE are considered friendly territory for THEM
@@ -505,7 +490,7 @@ class DiplomacyManager() : IsPartOfGameInfoSerialization {
     // for performance reasons we don't want to call this every time we want to see if a unit can move through a tile
     fun updateHasOpenBorders() {
         // City-states can enter ally's territory (the opposite is true anyway even without open borders)
-        val newHasOpenBorders = civInfo.allyCiv == otherCiv
+        val newHasOpenBorders = civInfo.getAllyCivName() == otherCivName
                 || trades.flatMap { it.theirOffers }.any { it.name == Constants.openBorders && it.duration > 0 }
 
         val bordersWereClosed = hasOpenBorders && !newHasOpenBorders
@@ -513,7 +498,7 @@ class DiplomacyManager() : IsPartOfGameInfoSerialization {
 
         if (bordersWereClosed) { // borders were closed, get out!
             for (unit in civInfo.units.getCivUnits()
-                .filter { it.currentTile.getOwner() == otherCiv }.toList()) {
+                .filter { it.currentTile.getOwner()?.civName == otherCivName }.toList()) {
                 unit.movement.teleportToClosestMoveableTile()
             }
         }
@@ -522,14 +507,14 @@ class DiplomacyManager() : IsPartOfGameInfoSerialization {
     /** Should only be called from makePeace */
     private fun makePeaceOneSide() {
         diplomaticStatus = DiplomaticStatus.Peace
-        val otherCiv = otherCiv
+        val otherCiv = otherCiv()
         // Get out of others' territory
         for (unit in civInfo.units.getCivUnits().filter { it.getTile().getOwner() == otherCiv }.toList())
             unit.movement.teleportToClosestMoveableTile()
 
         for (thirdCiv in civInfo.getKnownCivs()) {
             // Our ally city states make peace with us
-            if (thirdCiv.allyCiv == civInfo && thirdCiv.isAtWarWith(otherCiv)) {
+            if (thirdCiv.getAllyCivName() == civInfo.civName && thirdCiv.isAtWarWith(otherCiv)) {
                 val thirdCivDiplo = thirdCiv.getDiplomacyManager(otherCiv)!!
                 thirdCivDiplo.makePeace()
 
@@ -541,7 +526,7 @@ class DiplomacyManager() : IsPartOfGameInfoSerialization {
                 thirdCivDiplo.otherCivDiplomacy().trades.add(tradeLogic.currentTrade.reverse())
             }
             // Other City-States that are not our ally don't like the fact that we made peace with their enemy
-            if (thirdCiv.allyCiv != civInfo && thirdCiv.isAtWarWith(otherCiv))
+            if (thirdCiv.getAllyCivName() != civInfo.civName && thirdCiv.isAtWarWith(otherCiv))
                 thirdCiv.getDiplomacyManager(civInfo)!!.addInfluence(-10f)
         }
     }
@@ -614,15 +599,15 @@ class DiplomacyManager() : IsPartOfGameInfoSerialization {
         // UniqueType.ConditionalChance - 25% declared chance would work as 6% actual chance
         for (unique in civInfo.getTriggeredUniques(UniqueType.TriggerUponDeclaringFriendship, GameContext.IgnoreConditionals))
             UniqueTriggerActivation.triggerUnique(unique, civInfo)
-        for (unique in otherCiv.getTriggeredUniques(UniqueType.TriggerUponDeclaringFriendship, GameContext.IgnoreConditionals))
-            UniqueTriggerActivation.triggerUnique(unique, otherCiv)
+        for (unique in otherCiv().getTriggeredUniques(UniqueType.TriggerUponDeclaringFriendship, GameContext.IgnoreConditionals))
+            UniqueTriggerActivation.triggerUnique(unique, otherCiv())
     }
 
     internal fun setFriendshipBasedModifier() {
         removeModifier(DiplomaticModifiers.DeclaredFriendshipWithOurAllies)
         removeModifier(DiplomaticModifiers.DeclaredFriendshipWithOurEnemies)
         val civsOtherCivHasDeclaredFriendshipWith = getCommonKnownCivs()
-            .filter { it.getDiplomacyManager(otherCiv)!!.hasFlag(DiplomacyFlags.DeclarationOfFriendship) }
+            .filter { it.getDiplomacyManager(otherCiv())!!.hasFlag(DiplomacyFlags.DeclarationOfFriendship) }
 
         for (thirdCiv in civsOtherCivHasDeclaredFriendshipWith) {
             // What do we (A) think about the otherCiv() (B) being friends with the third Civ (C)?
@@ -664,8 +649,8 @@ class DiplomacyManager() : IsPartOfGameInfoSerialization {
         // UniqueType.ConditionalChance - 25% declared chance would work as 6% actual chance
         for (unique in civInfo.getTriggeredUniques(UniqueType.TriggerUponSigningDefensivePact, GameContext.IgnoreConditionals))
             UniqueTriggerActivation.triggerUnique(unique, civInfo)
-        for (unique in otherCiv.getTriggeredUniques(UniqueType.TriggerUponSigningDefensivePact, GameContext.IgnoreConditionals))
-            UniqueTriggerActivation.triggerUnique(unique, otherCiv)
+        for (unique in otherCiv().getTriggeredUniques(UniqueType.TriggerUponSigningDefensivePact, GameContext.IgnoreConditionals))
+            UniqueTriggerActivation.triggerUnique(unique, otherCiv())
     }
 
     internal fun setDefensivePactBasedModifier() {
@@ -701,7 +686,7 @@ class DiplomacyManager() : IsPartOfGameInfoSerialization {
 
     fun denounce() {
         activateDenounceEffects()
-        if (otherCiv.isAI())
+        if (otherCiv().isAI())
             otherCivDiplomacy().activateDenounceEffects()
     }
     
@@ -709,19 +694,19 @@ class DiplomacyManager() : IsPartOfGameInfoSerialization {
         setFlag(DiplomacyFlags.Denunciation, 30)
         otherCivDiplomacy().setModifier(DiplomaticModifiers.Denunciation, -35f)
         
-        otherCiv.addNotification(
+        otherCiv().addNotification(
             "[${civInfo.civName}] has denounced us!",
             NotificationCategory.Diplomacy,
             NotificationIcon.Diplomacy, civInfo.civName
         )
         
         // Denounciation results in removal of embasies for both sides
-        civInfo.diplomacyFunctions.removeEmbassies(otherCiv)
+        civInfo.diplomacyFunctions.removeEmbassies(otherCiv())
 
         // We, A, are denouncing B. What do other major civs (C,D, etc) think of this?
         getCommonKnownCivsWithSpectators().forEach { thirdCiv ->
             thirdCiv.addNotification(
-                "[${civInfo.civName}] has denounced [${otherCiv.civName}]!",
+                "[${civInfo.civName}] has denounced [${otherCiv().civName}]!",
                 NotificationCategory.Diplomacy,
                 civInfo.civName, NotificationIcon.Diplomacy, otherCivName
             )
@@ -732,7 +717,7 @@ class DiplomacyManager() : IsPartOfGameInfoSerialization {
             // their relationship with us
             val thirdCivRelationship = thirdCiv.getDiplomacyManager(civInfo)!!
             // their relationship with the civ we are denouncing
-            val thirdCivRelationshipWithTarget = thirdCiv.getDiplomacyManager(otherCiv)!!.relationshipIgnoreAfraid()
+            val thirdCivRelationshipWithTarget = thirdCiv.getDiplomacyManager(otherCiv())!!.relationshipIgnoreAfraid()
             when (thirdCivRelationshipWithTarget) {
                 RelationshipLevel.Unforgivable -> thirdCivRelationship.addModifier(DiplomaticModifiers.DenouncedOurEnemies, 15f)
                 RelationshipLevel.Enemy -> thirdCivRelationship.addModifier(DiplomaticModifiers.DenouncedOurEnemies, 5f)
@@ -747,7 +732,7 @@ class DiplomacyManager() : IsPartOfGameInfoSerialization {
         otherCivDiplomacy().setFlag(demand.agreedToDemand, 100)
         addModifier(DiplomaticModifiers.UnacceptableDemands, -10f)
         val text = demand.agreedToDemandText.fillPlaceholders(civInfo.civName)
-        otherCiv.addNotification(text, NotificationCategory.Diplomacy, NotificationIcon.Diplomacy, civInfo.civName)
+        otherCiv().addNotification(text, NotificationCategory.Diplomacy, NotificationIcon.Diplomacy, civInfo.civName)
     }
     
     fun refuseDemand(demand: Demand) {
@@ -755,7 +740,7 @@ class DiplomacyManager() : IsPartOfGameInfoSerialization {
         otherCivDiplomacy().setFlag(demand.willIgnoreViolation, 100)
         otherCivDiplomacy().addModifier(demand.refusedDiplomaticModifier, -15f)
         val text = demand.refusedDemandText.fillPlaceholders(civInfo.civName)
-        otherCiv.addNotification(text, NotificationCategory.Diplomacy, NotificationIcon.Diplomacy, civInfo.civName)
+        otherCiv().addNotification(text, NotificationCategory.Diplomacy, NotificationIcon.Diplomacy, civInfo.civName)
     }
 
     fun sideWithCityState() {
@@ -766,7 +751,7 @@ class DiplomacyManager() : IsPartOfGameInfoSerialization {
     fun becomeWary() {
         if (hasFlag(DiplomacyFlags.WaryOf)) return // once is enough
         setFlag(DiplomacyFlags.WaryOf, -1) // Never expires
-        otherCiv.addNotification("City-States grow wary of your aggression. " +
+        otherCiv().addNotification("City-States grow wary of your aggression. " +
                 "The resting point for Influence has decreased by [20] for [${civInfo.civName}].",
             NotificationCategory.Diplomacy, civInfo.civName)
     }

--- a/core/src/com/unciv/logic/civilization/managers/ReligionManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/ReligionManager.kt
@@ -71,12 +71,12 @@ class ReligionManager : IsPartOfGameInfoSerialization {
         // Find our religion from the map of founded religions.
         // First check if there is any major religion
         religion = civInfo.gameInfo.religions.values.firstOrNull {
-            it.foundingCiv == civInfo && it.isMajorReligion()
+            it.foundingCivName == civInfo.civName && it.isMajorReligion()
         }
         // If there isn't, check for just pantheons.
         if (religion != null) return
         religion = civInfo.gameInfo.religions.values.firstOrNull {
-            it.foundingCiv == civInfo
+            it.foundingCivName == civInfo.civName
         }
     }
 
@@ -144,7 +144,7 @@ class ReligionManager : IsPartOfGameInfoSerialization {
             // paid for the initial pantheon using faith
             storedFaith -= faithForPantheon()
         }
-        religion = Religion(beliefName, civInfo.gameInfo, civInfo)
+        religion = Religion(beliefName, civInfo.gameInfo, civInfo.civName)
         civInfo.gameInfo.religions[beliefName] = religion!!
         for (city in civInfo.cities)
             city.religion.addPressure(beliefName, 200 * city.population.population)
@@ -462,7 +462,7 @@ class ReligionManager : IsPartOfGameInfoSerialization {
 
 
     internal fun foundReligion(displayName: String, name: String) {
-        val newReligion = Religion(name, civInfo.gameInfo, civInfo)
+        val newReligion = Religion(name, civInfo.gameInfo, civInfo.civName)
         newReligion.displayName = displayName
         if (religion != null) {
             newReligion.addBeliefs(religion!!.getAllBeliefsOrdered().asIterable())

--- a/core/src/com/unciv/logic/civilization/managers/TurnManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/TurnManager.kt
@@ -109,7 +109,7 @@ class TurnManager(val civInfo: Civilization) {
 
             if (flag == CivFlags.CityStateGreatPersonGift.name) {
                 val cityStateAllies: List<Civilization> =
-                        civInfo.getKnownCivs().filter { it.isCityState && it.allyCiv == civInfo }.toList()
+                        civInfo.getKnownCivs().filter { it.isCityState && it.getAllyCivName() == civInfo.civName }.toList()
                 val givingCityState = cityStateAllies.filter { it.cities.isNotEmpty() }.randomOrNull()
 
                 if (cityStateAllies.isNotEmpty()) civInfo.flagsCountdown[flag] = civInfo.flagsCountdown[flag]!! - 1

--- a/core/src/com/unciv/logic/civilization/transients/CapitalConnectionsFinder.kt
+++ b/core/src/com/unciv/logic/civilization/transients/CapitalConnectionsFinder.kt
@@ -146,7 +146,7 @@ class CapitalConnectionsFinder(private val civInfo: Civilization) {
     private fun canEnterBordersOf(otherCiv: Civilization): Boolean {
         if (otherCiv == civInfo) return true // own borders are always open
         if (otherCiv.isBarbarian || civInfo.isBarbarian) return false // barbarians blocks the routes
-        val diplomacyManager = civInfo.getDiplomacyManager(otherCiv)
+        val diplomacyManager = civInfo.diplomacy[otherCiv.civName]
             ?: return false // not encountered yet
         if (otherCiv.isCityState && diplomacyManager.diplomaticStatus != DiplomaticStatus.War) return true
         return diplomacyManager.hasOpenBorders

--- a/core/src/com/unciv/logic/civilization/transients/CivInfoStatsForNextTurn.kt
+++ b/core/src/com/unciv/logic/civilization/transients/CivInfoStatsForNextTurn.kt
@@ -178,7 +178,7 @@ class CivInfoStatsForNextTurn(val civInfo: Civilization) {
         //City-States bonuses
         for (otherCiv in civInfo.getKnownCivs()) {
             if (!otherCiv.isCityState) continue
-            if (otherCiv.getDiplomacyManager(civInfo)!!.relationshipIgnoreAfraid() != RelationshipLevel.Ally)
+            if (otherCiv.getDiplomacyManager(civInfo.civName)!!.relationshipIgnoreAfraid() != RelationshipLevel.Ally)
                 continue
             for (unique in civInfo.getMatchingUniques(UniqueType.CityStateStatPercent)) {
                 val stats = Stats()
@@ -253,7 +253,7 @@ class CivInfoStatsForNextTurn(val civInfo: Civilization) {
             civInfo.getMatchingUniques(UniqueType.CityStateLuxuryHappiness).sumOf { it.params[0].toInt() } / 100f
 
         val luxuriesProvidedByCityStates = civInfo.getKnownCivs().asSequence()
-            .filter { it.isCityState && it.allyCiv == civInfo }
+            .filter { it.isCityState && it.getAllyCivName() == civInfo.civName }
             .flatMap { it.getCivResourceSupply().map { res -> res.resource } }
             .distinct()
             .count { it.resourceType === ResourceType.Luxury && ownedLuxuries.contains(it) }

--- a/core/src/com/unciv/logic/civilization/transients/CivInfoTransientCache.kt
+++ b/core/src/com/unciv/logic/civilization/transients/CivInfoTransientCache.kt
@@ -201,7 +201,7 @@ class CivInfoTransientCache(val civInfo: Civilization) {
         newViewableTiles.addAll(civInfo.units.getCivUnits().flatMap { unit -> unit.viewableTiles.asSequence().filter { it.getOwner() != civInfo } })
 
         for (otherCiv in civInfo.getKnownCivs()) {
-            if (otherCiv.allyCiv == civInfo || otherCiv == civInfo.allyCiv) {
+            if (otherCiv.getAllyCivName() == civInfo.civName || otherCiv.civName == civInfo.getAllyCivName()) {
                 newViewableTiles.addAll(otherCiv.cities.asSequence().flatMap { it.getTiles() })
             }
         }
@@ -324,7 +324,7 @@ class CivInfoTransientCache(val civInfo: Civilization) {
             var resourceBonusPercentage = 1f
             for (unique in civInfo.getMatchingUniques(UniqueType.CityStateResources))
                 resourceBonusPercentage += unique.params[0].toFloat() / 100
-            for (cityStateAlly in civInfo.getKnownCivs().filter { it.allyCiv == civInfo }) {
+            for (cityStateAlly in civInfo.getKnownCivs().filter { it.getAllyCivName() == civInfo.civName }) {
                 for (resourceSupply in cityStateAlly.cityStateFunctions.getCityStateResourcesForAlly()) {
                     if (resourceSupply.resource.hasUnique(UniqueType.CannotBeTraded, cityStateAlly.state)) continue
                     val newAmount = (resourceSupply.amount * resourceBonusPercentage).toInt()

--- a/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
@@ -147,10 +147,6 @@ class MapUnit : IsPartOfGameInfoSerialization {
     @Transient
     var cache = MapUnitCache(this)
 
-    /** civ of original owner - relevant for returning captured workers from barbarians */
-    @delegate:Transient
-    val originalOwningCiv by lazy { originalOwner?.let { civ.gameInfo.getCivilization(it) } }
-
     // This is saved per each unit because if we need to recalculate viewable tiles every time a unit moves,
     //  and we need to go over ALL the units, that's a lot of time spent on updating information we should already know!
     // About 10% of total NextTurn performance time, at the time of this change!
@@ -441,7 +437,7 @@ class MapUnit : IsPartOfGameInfoSerialization {
             return true
         if (hasUnique(UniqueType.InvisibleToNonAdjacent) && !to.isSpectator())
             return getTile().getTilesInDistance(1).none {
-                it.getUnits().any { unit -> unit.civ == to }
+                it.getUnits().any { unit -> unit.owner == to.civName }
             }
         return false
     }
@@ -605,8 +601,8 @@ class MapUnit : IsPartOfGameInfoSerialization {
     @Readonly
     private fun isAlly(otherCiv: Civilization): Boolean {
         return otherCiv == civ
-                || (otherCiv.isCityState && otherCiv.allyCiv == civ)
-                || (civ.isCityState && civ.allyCiv == otherCiv)
+                || (otherCiv.isCityState && otherCiv.getAllyCivName() == civ.civName)
+                || (civ.isCityState && civ.getAllyCivName() == otherCiv.civName)
     }
 
     /** Implements [UniqueParameterType.MapUnitFilter][com.unciv.models.ruleset.unique.UniqueParameterType.MapUnitFilter] */

--- a/core/src/com/unciv/logic/map/tile/Tile.kt
+++ b/core/src/com/unciv/logic/map/tile/Tile.kt
@@ -362,11 +362,13 @@ class Tile : IsPartOfGameInfoSerialization, Json.Serializable {
     @Readonly fun getBaseTerrain(): Terrain = baseTerrainObject
 
     @Readonly fun getOwner(): Civilization? = getCity()?.civ
-    
-    @Transient private var roadOwnerOb: Civilization? = null
+
     @Readonly
     fun getRoadOwner(): Civilization? {
-        return roadOwnerOb ?: getOwner()
+        return if (roadOwner != "")
+            tileMap.gameInfo.getCivilization(roadOwner)
+        else
+            getOwner()
     }
 
     @Readonly
@@ -820,28 +822,20 @@ class Tile : IsPartOfGameInfoSerialization, Json.Serializable {
         if (owningCity == null) stateThisTile = GameContext(tile = this,
             // When generating maps we call this function but there's no gameinfo
             gameInfo = if (tileMap.hasGameInfo()) tileMap.gameInfo else null)
-        
-        if (owningCity == null && roadOwner != "") {
-            if (roadOwnerOb == null && tileMap.hasGameInfo())
-                roadOwnerOb = tileMap.gameInfo.getCivilization(roadOwner)
+        if (owningCity == null && roadOwner != "")
             getRoadOwner()!!.neutralRoads.add(this.position)
-        }
     }
 
     fun setOwningCity(city: City?) {
-        if (roadOwner != "" && roadOwnerOb == null)
-            roadOwnerOb = tileMap.gameInfo.getCivilization(roadOwner)
         if (city != null) {
             if (roadStatus != RoadStatus.None && roadOwner != "") {
                 // remove previous neutral tile owner
                 getRoadOwner()!!.neutralRoads.remove(this.position)
             }
             roadOwner = city.civ.civName // only when taking control, otherwise last owner
-            roadOwnerOb = city.civ
         } else if (roadStatus != RoadStatus.None && owningCity != null) {
             // Razing City! Remove owner
             roadOwner = ""
-            roadOwnerOb = null
         }
         owningCity = city
         stateThisTile = GameContext(tile = this, city = city, gameInfo = tileMap.gameInfo)
@@ -977,15 +971,13 @@ class Tile : IsPartOfGameInfoSerialization, Json.Serializable {
     fun setRoadStatus(newRoadStatus: RoadStatus, creatingCivInfo: Civilization?) {
         roadStatus = newRoadStatus
         roadIsPillaged = false
-        val currentOwner = getOwner()
+        
         if (newRoadStatus == RoadStatus.None && owningCity == null)
             getRoadOwner()?.neutralRoads?.remove(this.position)
-        else if (currentOwner != null && currentOwner != roadOwnerOb) {
-            roadOwner = currentOwner.civName
-            roadOwnerOb = currentOwner
+        else if (getOwner() != null) {
+            roadOwner = getOwner()!!.civName
         } else if (creatingCivInfo != null) {
             roadOwner = creatingCivInfo.civName // neutral tile, use building unit
-            roadOwnerOb = creatingCivInfo
             creatingCivInfo.neutralRoads.add(this.position)
         }
     }

--- a/core/src/com/unciv/logic/trade/TradeEvaluation.kt
+++ b/core/src/com/unciv/logic/trade/TradeEvaluation.kt
@@ -241,7 +241,7 @@ class TradeEvaluation {
                 
                 // We're buying peace if it's city state that is our ally
                 if (thirdCiv.isCityState) {
-                    val allyCiv = thirdCiv.allyCiv
+                    val allyCiv = thirdCiv.getAllyCiv()
                     if (allyCiv != null && allyCiv == civInfo) {
                         // TODO: More sophisticated formula needed, a reverse of [CityStateFunctions.influenceGainedByGift]
                         val surplusInfluence = (thirdCiv.getDiplomacyManager(civInfo)!!.getInfluence() - 60).coerceAtLeast(0f)
@@ -297,7 +297,7 @@ class TradeEvaluation {
         if (thirdCiv.isHuman()) return false
 
         if (thirdCiv.isCityState) {
-            val allyCiv = thirdCiv.allyCiv
+            val allyCiv = thirdCiv.getAllyCiv()
             if (allyCiv != null && civInfo.isAtWarWith(allyCiv)) {
                 // City state is allied to civ with whom trade partner is at war with,
                 // need to trade peace with that civ instead
@@ -318,14 +318,14 @@ class TradeEvaluation {
 
     @Readonly
     private fun surroundedByOurCities(city: City, civInfo: Civilization): Int {
-        val borderingCivs: Set<Civilization> = getNeighbouringCivs(city)
-        if (borderingCivs.contains(civInfo))
+        val borderingCivs: Set<String> = getNeighbouringCivs(city)
+        if (borderingCivs.contains(civInfo.civName))
             return 3 // if the city has a border with trading civ
         return 0
     }
 
     @Readonly
-    private fun getNeighbouringCivs(city: City): Set<Civilization> {
+    private fun getNeighbouringCivs(city: City): Set<String> {
         val tilesList: HashSet<Tile> = city.getTiles().toHashSet()
         val cityPositionList: ArrayList<Tile> = arrayListOf()
 
@@ -336,7 +336,7 @@ class TradeEvaluation {
 
         return cityPositionList
             .asSequence()
-            .mapNotNull { it.getOwner() }
+            .mapNotNull { it.getOwner()?.civName }
             .toSet()
     }
 

--- a/core/src/com/unciv/logic/trade/TradeLogic.kt
+++ b/core/src/com/unciv/logic/trade/TradeLogic.kt
@@ -78,11 +78,11 @@ class TradeLogic(val ourCivilization: Civilization, val otherCivilization: Civil
                 offers.add(TradeOffer(city.id, TradeOfferType.City, speed = civInfo.gameInfo.speed))
 
         val otherCivsWeKnow = civInfo.getKnownCivs()
-            .filter { it != otherCiv && it.isMajorCiv() && !it.isDefeated() }
+            .filter { it.civName != otherCiv.civName && it.isMajorCiv() && !it.isDefeated() }
 
         if (civInfo.gameInfo.ruleset.modOptions.hasUnique(UniqueType.TradeCivIntroductions)) {
             val civsWeKnowAndTheyDont = otherCivsWeKnow
-                .filter { !otherCiv.knows(it) && !it.isDefeated() }
+                .filter { !otherCiv.diplomacy.containsKey(it.civName) && !it.isDefeated() }
             for (thirdCiv in civsWeKnowAndTheyDont) {
                 offers.add(TradeOffer(thirdCiv.civName, TradeOfferType.Introduction, speed = civInfo.gameInfo.speed))
             }
@@ -90,7 +90,7 @@ class TradeLogic(val ourCivilization: Civilization, val otherCivilization: Civil
 
         if (!civInfo.gameInfo.ruleset.modOptions.hasUnique(UniqueType.DiplomaticRelationshipsCannotChange)) {
             val civsWeBothKnow = otherCivsWeKnow
-                    .filter { otherCiv.knows(it) }
+                    .filter { otherCiv.diplomacy.containsKey(it.civName) }
             val civsWeArentAtWarWith = civsWeBothKnow
                     .filter { civInfo.getDiplomacyManager(it)!!.canDeclareWar() }
             for (thirdCiv in civsWeArentAtWarWith) {
@@ -157,9 +157,9 @@ class TradeLogic(val ourCivilization: Civilization, val otherCivilization: Civil
 
                     // suggest an option to liberate the city
                     if (to.isHuman()
-                            && city.foundingCivObject != null
-                            && from != city.foundingCivObject // can't liberate if the city actually belongs to those guys
-                            && to != city.foundingCivObject
+                            && city.foundingCiv != ""
+                            && from.civName != city.foundingCiv // can't liberate if the city actually belongs to those guys
+                            && to.civName != city.foundingCiv
                     )  // can't liberate if it's our city
                         to.popupAlerts.add(PopupAlert(AlertType.CityTraded, city.id))
                 }

--- a/core/src/com/unciv/models/Religion.kt
+++ b/core/src/com/unciv/models/Religion.kt
@@ -10,7 +10,6 @@ import com.unciv.models.ruleset.unique.GameContext
 import com.unciv.models.ruleset.unique.UniqueMap
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.stats.INamed
-import yairm210.purity.annotations.Cache
 import yairm210.purity.annotations.Readonly
 
 /** Data object for Religions */
@@ -30,26 +29,10 @@ class Religion() : INamed, IsPartOfGameInfoSerialization {
 
     @Transient
     lateinit var gameInfo: GameInfo
-    
-    @Transient
-    @Cache
-    private lateinit var mFoundingCiv: Civilization
-    @get:Readonly
-    val foundingCiv: Civilization get() {
-        if (!::mFoundingCiv.isInitialized) mFoundingCiv = gameInfo.getCivilization(foundingCivName)
-        return mFoundingCiv
-    }
 
     @delegate:Transient
     val buildingsPurchasableByBeliefs by lazy {
         unlockedBuildingsPurchasable()
-    }
-    
-    constructor(name: String, gameInfo: GameInfo, foundingCiv: Civilization): this() {
-        this.name = name
-        this.gameInfo = gameInfo
-        this.mFoundingCiv = foundingCiv
-        this.foundingCivName = foundingCiv.civName
     }
 
     constructor(name: String, gameInfo: GameInfo, foundingCivName: String) : this() {
@@ -135,6 +118,8 @@ class Religion() : INamed, IsPartOfGameInfoSerialization {
     @Readonly fun isMajorReligion() = getBeliefs(BeliefType.Founder).any()
     @Readonly fun isEnhancedReligion() = getBeliefs(BeliefType.Enhancer).any()
 
+    @Readonly fun getFounder() = gameInfo.getCivilization(foundingCivName)
+
     @Readonly
     fun matchesFilter(filter: String, state: GameContext = GameContext.IgnoreConditionals, civ: Civilization? = null): Boolean {
         return MultiFilter.multiFilter(filter, { matchesSingleFilter(it, state, civ) })
@@ -142,7 +127,7 @@ class Religion() : INamed, IsPartOfGameInfoSerialization {
 
     @Readonly
     private fun matchesSingleFilter(filter: String, state: GameContext = GameContext.IgnoreConditionals, civ: Civilization? = null): Boolean {
-        val foundingCiv = foundingCiv
+        val foundingCiv = getFounder()
         when (filter) {
             "any" -> return true
             "major" -> return isMajorReligion()

--- a/core/src/com/unciv/models/Spy.kt
+++ b/core/src/com/unciv/models/Spy.kt
@@ -266,7 +266,7 @@ class Spy private constructor() : IsPartOfGameInfoSerialization {
     }
 
     @Readonly fun canDoCoup(): Boolean = getCityOrNull() != null && getCity().civ.isCityState && isSetUp()
-            && getCity().civ.allyCiv != civInfo
+            && getCity().civ.getAllyCivName() != civInfo.civName
 
     /**
      * Initiates a coup if this spies civ is not the ally of the city-state.
@@ -281,7 +281,7 @@ class Spy private constructor() : IsPartOfGameInfoSerialization {
             return
         }
         val cityState = getCity().civ
-        val allyCiv = cityState.allyCiv
+        val allyCiv = cityState.getAllyCivName()?.let { civInfo.gameInfo.getCivilization(it) }
 
         val successChance = getCoupChanceOfSuccess(true)
         val randomValue = Random(randomSeed()).nextFloat()
@@ -333,15 +333,15 @@ class Spy private constructor() : IsPartOfGameInfoSerialization {
         var successPercentage = 50f
 
         // Influence difference should always be a positive value
-        var influenceDifference: Float = if (cityState.allyCiv != null)
-            cityState.getDiplomacyManager(cityState.allyCiv!!)!!.getInfluence()
+        var influenceDifference: Float = if (cityState.getAllyCivName() != null)
+            cityState.getDiplomacyManager(cityState.getAllyCivName()!!)!!.getInfluence()
         else 60f
         influenceDifference -= cityState.getDiplomacyManager(civInfo)!!.getInfluence()
         successPercentage -= influenceDifference / 2f
 
         // If we are viewing the success chance we don't want to reveal that there is a defending spy
         val defendingSpy = if (includeunknownFactors) 
-            cityState.allyCiv?.espionageManager?.getSpyAssignedToCity(getCity()) 
+            cityState.getAllyCiv()?.espionageManager?.getSpyAssignedToCity(getCity()) 
         else null
 
         val spyRanks = getSkillModifierPercent() - (defendingSpy?.getSkillModifierPercent() ?: 0)

--- a/core/src/com/unciv/models/ruleset/Victory.kt
+++ b/core/src/com/unciv/models/ruleset/Victory.kt
@@ -98,13 +98,13 @@ class Milestone(val uniqueDescription: String, private val parentVictory: Victor
 
     @Readonly
     private fun originalMajorCapitalsOwned(civInfo: Civilization): Int = civInfo.cities
-        .count { it.isOriginalCapital && it.foundingCivObject != null && it.foundingCivObject!!.isMajorCiv() }
+        .count { it.isOriginalCapital && it.foundingCiv != "" && civInfo.gameInfo.getCivilization(it.foundingCiv).isMajorCiv() }
 
     @Readonly
     private fun civsWithPotentialCapitalsToOwn(gameInfo: GameInfo): Set<Civilization> {
         // Capitals that still exist, even if the civ is dead
         val civsWithCapitals = gameInfo.getCities().filter { it.isOriginalCapital }
-            .map { it.foundingCivObject!! }
+            .map { gameInfo.getCivilization(it.foundingCiv) }
             .filter { it.isMajorCiv() }.toSet()
         // If the civ is alive, they can still create a capital, so we need them as well
         val livingCivs = gameInfo.civilizations.filter { it.isMajorCiv() && !it.isDefeated() }
@@ -302,9 +302,9 @@ class Milestone(val uniqueDescription: String, private val parentVictory: Victor
                 val hideCivCount = civInfo.shouldHideCivCount()
                 val majorCivs = civInfo.gameInfo.civilizations.filter { it.isMajorCiv() }
                 val originalCapitals = civInfo.gameInfo.getCities().filter { it.isOriginalCapital }
-                    .associateBy { it.foundingCivObject }
+                    .associateBy { it.foundingCiv }
                 for (civ in majorCivs) {
-                    val city = originalCapitals[civ]
+                    val city = originalCapitals[civ.civName]
                     if (city != null) {
                         val isKnown = civInfo.hasExplored(city.getCenterTile())
                         if (hideCivCount && !isKnown) continue

--- a/core/src/com/unciv/ui/screens/diplomacyscreen/DiplomacyScreen.kt
+++ b/core/src/com/unciv/ui/screens/diplomacyscreen/DiplomacyScreen.kt
@@ -332,10 +332,10 @@ class DiplomacyScreen(
         messageLines += "Declare war on [${otherCiv.civName}]?"
         // Tell the player who all will join the other side from defensive pacts
         val otherCivDefensivePactList = otherCiv.diplomacy.values.filter {
-            otherCivDiploManager -> otherCivDiploManager.otherCiv != viewingCiv
+            otherCivDiploManager -> otherCivDiploManager.otherCiv() != viewingCiv
             && otherCivDiploManager.diplomaticStatus == DiplomaticStatus.DefensivePact
-            && !otherCivDiploManager.otherCiv.isAtWarWith(viewingCiv) }
-            .map { it.otherCiv }
+            && !otherCivDiploManager.otherCiv().isAtWarWith(viewingCiv) }
+            .map { it.otherCiv() }
 
         // Defensive pact chains are not allowed now
         for (civ in otherCivDefensivePactList) {
@@ -348,9 +348,9 @@ class DiplomacyScreen(
 
         // Tell the player that their defensive pacts will be canceled.
         for (civDiploManager in viewingCiv.diplomacy.values) {
-            if (civDiploManager.otherCiv != otherCiv
+            if (civDiploManager.otherCiv() != otherCiv
                 && civDiploManager.diplomaticStatus == DiplomaticStatus.DefensivePact
-                && !otherCivDefensivePactList.contains(civDiploManager.otherCiv)) {
+                && !otherCivDefensivePactList.contains(civDiploManager.otherCiv())) {
                 messageLines += "This will cancel your defensive pact with [${civDiploManager.otherCivName}]"
             }
         }

--- a/core/src/com/unciv/ui/screens/overviewscreen/EmpireOverviewCategories.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/EmpireOverviewCategories.kt
@@ -35,7 +35,7 @@ enum class EmpireOverviewCategories(
         override fun showDisabled(viewingPlayer: Civilization) =
                 viewingPlayer.diplomacy.values.all { it.trades.isEmpty() } &&
                 viewingPlayer.diplomacy.values.none { diplomacyManager ->
-                        diplomacyManager.otherCiv.tradeRequests.any { it.requestingCiv == viewingPlayer.civName }
+                        diplomacyManager.otherCiv().tradeRequests.any { it.requestingCiv == viewingPlayer.civName }
                     }
     },
     Units("OtherIcons/Shield", 'U', Align.topLeft) {

--- a/core/src/com/unciv/ui/screens/overviewscreen/GlobalPoliticsDiagramGroup.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/GlobalPoliticsDiagramGroup.kt
@@ -67,10 +67,10 @@ class GlobalPoliticsDiagramGroup(
         for (civ in undefeatedCivs) {
             if (civ.isDefeated()) continue // if you're dead, icon but no lines (One more turn mode after losing)
             for (diplomacy in civ.diplomacy.values) {
-                val otherCiv = diplomacy.otherCiv
+                val otherCiv = diplomacy.otherCiv()
                 if (otherCiv !in undefeatedCivs || otherCiv.isDefeated()) continue
                 val civGroup = civGroups[civ.civName]!!
-                val otherCivGroup = civGroups[diplomacy.otherCiv.civName]!!
+                val otherCivGroup = civGroups[diplomacy.otherCivName]!!
 
                 val statusLine = ImageGetter.getLine(
                     startX = civGroup.x + civGroup.width / 2,
@@ -87,8 +87,8 @@ class GlobalPoliticsDiagramGroup(
                 else if (civ.isHuman() && otherCiv.isHuman() && diplomacy.hasModifier(DiplomaticModifiers.DeclarationOfFriendship))
                     RelationshipLevel.Friend.color
                 // Test for alliance with city state
-                else if ((civ.isCityState && civ.allyCiv == diplomacy.otherCiv)
-                    || (otherCiv.isCityState && otherCiv.allyCiv == civ)) RelationshipLevel.Ally.color
+                else if ((civ.isCityState && civ.getAllyCivName() == diplomacy.otherCivName)
+                    || (otherCiv.isCityState && otherCiv.getAllyCivName() == civ.civName)) RelationshipLevel.Ally.color
                 // Else the color depends on opinion between major civs, OR city state relationship with major civ
                 else diplomacy.relationshipLevel().color
 

--- a/core/src/com/unciv/ui/screens/overviewscreen/GlobalPoliticsOverviewTable.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/GlobalPoliticsOverviewTable.kt
@@ -166,7 +166,7 @@ class GlobalPoliticsOverviewTable(
         val allWorldWonders = wonderInfo.collectInfo(viewingPlayer)
 
         for (wonder in allWorldWonders) {
-            if (wonder.civ == civ) {
+            if (wonder.civ?.civName == civ.civName) {
                 val wonderName = wonder.name.toLabel()
                 if (wonder.location != null) {
                     wonderName.onClick {
@@ -183,7 +183,7 @@ class GlobalPoliticsOverviewTable(
 
     @Readonly
     private fun getCivName(otherciv: Civilization): String {
-        if (viewingPlayer.knows(otherciv) || otherciv == viewingPlayer) {
+        if (viewingPlayer.knows(otherciv) || otherciv.civName == viewingPlayer.civName) {
             return otherciv.civName
         }
         return "an unknown civilization"
@@ -192,7 +192,7 @@ class GlobalPoliticsOverviewTable(
     private fun getPoliticsOfCivTable(civ: Civilization): Table {
         val politicsTable = Table(skin)
 
-        if (!viewingPlayer.knows(civ) && civ != viewingPlayer)
+        if (!viewingPlayer.knows(civ) && civ.civName != viewingPlayer.civName)
             return politicsTable
 
         if (civ.isDefeated()) {
@@ -211,14 +211,14 @@ class GlobalPoliticsOverviewTable(
 
         // defensive pacts and declaration of friendships
         for (otherCiv in civ.getKnownCivs()) {
-            if (civ.getDiplomacyManager(otherCiv)?.hasFlag(DiplomacyFlags.DefensivePact) == true) {
+            if (civ.diplomacy[otherCiv.civName]?.hasFlag(DiplomacyFlags.DefensivePact) == true) {
                 val friendText = ColorMarkupLabel("Defensive pact with [${getCivName(otherCiv)}]", Color.CYAN)
-                val turnsLeftText = " (${civ.getDiplomacyManager(otherCiv)?.getFlag(DiplomacyFlags.DefensivePact)} ${Fonts.turn})".toLabel()
+                val turnsLeftText = " (${civ.diplomacy[otherCiv.civName]?.getFlag(DiplomacyFlags.DefensivePact)} ${Fonts.turn})".toLabel()
                 politicsTable.add(friendText)
                 politicsTable.add(turnsLeftText).row()
-            } else if (civ.getDiplomacyManager(otherCiv)?.hasFlag(DiplomacyFlags.DeclarationOfFriendship) == true) {
+            } else if (civ.diplomacy[otherCiv.civName]?.hasFlag(DiplomacyFlags.DeclarationOfFriendship) == true) {
                 val friendText = ColorMarkupLabel("Friends with [${getCivName(otherCiv)}]", Color.GREEN)
-                val turnsLeftText = " (${civ.getDiplomacyManager(otherCiv)?.getFlag(DiplomacyFlags.DeclarationOfFriendship)} ${Fonts.turn})".toLabel()
+                val turnsLeftText = " (${civ.diplomacy[otherCiv.civName]?.getFlag(DiplomacyFlags.DeclarationOfFriendship)} ${Fonts.turn})".toLabel()
                 politicsTable.add(friendText)
                 politicsTable.add(turnsLeftText).row()
             }
@@ -227,9 +227,9 @@ class GlobalPoliticsOverviewTable(
 
         // denounced civs
         for (otherCiv in civ.getKnownCivs()) {
-            if (civ.getDiplomacyManager(otherCiv)?.hasFlag(DiplomacyFlags.Denunciation) == true) {
+            if (civ.diplomacy[otherCiv.civName]?.hasFlag(DiplomacyFlags.Denunciation) == true) {
                 val denouncedText = ColorMarkupLabel("Denounced [${getCivName(otherCiv)}]", Color.RED)
-                val turnsLeftText = "(${civ.getDiplomacyManager(otherCiv)?.getFlag(DiplomacyFlags.Denunciation)} ${Fonts.turn})".toLabel()
+                val turnsLeftText = "(${civ.diplomacy[otherCiv.civName]?.getFlag(DiplomacyFlags.Denunciation)} ${Fonts.turn})".toLabel()
                 politicsTable.add(denouncedText)
                 politicsTable.add(turnsLeftText).row()
             }
@@ -238,7 +238,7 @@ class GlobalPoliticsOverviewTable(
 
         //allied CS
         for (cityState in gameInfo.getAliveCityStates()) {
-            if (cityState.getDiplomacyManager(civ)?.isRelationshipLevelEQ(RelationshipLevel.Ally) == true) {
+            if (cityState.diplomacy[civ.civName]?.isRelationshipLevelEQ(RelationshipLevel.Ally) == true) {
                 val alliedText = ColorMarkupLabel("Allied with [${getCivName(cityState)}]", Color.CYAN)
                 politicsTable.add(alliedText).row()
             }

--- a/core/src/com/unciv/ui/screens/overviewscreen/ReligionOverviewTab.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/ReligionOverviewTab.kt
@@ -105,8 +105,8 @@ class ReligionOverviewTab(
         val existingReligions: List<Religion> = gameInfo.civilizations.mapNotNull { it.religionManager.religion }
         for (religion in existingReligions) {
             val image = if (religion.isPantheon()) {
-                if (viewingPlayer.knows(religion.foundingCiv) || viewingPlayer == religion.foundingCiv)
-                    ImageGetter.getNationPortrait(religion.foundingCiv.nation, 60f)
+                if (viewingPlayer.knows(religion.foundingCivName) || viewingPlayer.civName == religion.foundingCivName)
+                    ImageGetter.getNationPortrait(religion.getFounder().nation, 60f)
                 else
                     ImageGetter.getRandomNationPortrait(60f)
             } else {
@@ -153,7 +153,7 @@ class ReligionOverviewTab(
         statsTable.add(religion.getReligionDisplayName().toLabel()).right().row()
         statsTable.add("Founding Civ:".toLabel())
         val foundingCivName =
-            if (viewingPlayer.knows(religion.foundingCiv) || viewingPlayer == religion.foundingCiv)
+            if (viewingPlayer.knows(religion.foundingCivName) || viewingPlayer.civName == religion.foundingCivName)
                 religion.foundingCivName
             else Constants.unknownNationName
         statsTable.add(foundingCivName.toLabel()).right().row()
@@ -168,7 +168,7 @@ class ReligionOverviewTab(
                 statsTable.add(cityName.toLabel(hideIcons = true)).right().row()
             }
         }
-        val manager = religion.foundingCiv.religionManager
+        val manager = religion.getFounder().religionManager
         statsTable.add("Cities following this religion:".toLabel())
         statsTable.add(manager.numberOfCitiesFollowingThisReligion().toLabel()).right().row()
         statsTable.add("Followers of this religion:".toLabel())

--- a/core/src/com/unciv/ui/screens/overviewscreen/ResourcesOverviewTab.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/ResourcesOverviewTab.kt
@@ -78,7 +78,7 @@ class ResourcesOverviewTab(
     private fun ResourceSupplyList.getLabel(resource: TileResource, origin: String): Label? {
         fun isAlliedAndUnimproved(tile: Tile): Boolean {
             val owner = tile.getOwner() ?: return false
-            if (owner != viewingPlayer && !(owner.isCityState && owner.allyCiv == viewingPlayer)) return false
+            if (owner != viewingPlayer && !(owner.isCityState && owner.getAllyCivName() == viewingPlayer.civName)) return false
             return tile.countAsUnimproved()
         }
         val amount = get(resource, origin)?.amount ?: return null
@@ -277,7 +277,7 @@ class ResourcesOverviewTab(
                     newResourceSupplyList.add(gameInfo.ruleset.tileResources[offer.name]!!, ExtraInfoOrigin.TradeOffer.name, offer.amount)
 
             // Show resources your city-state allies have left unimproved
-            if (!otherCiv.isCityState || otherCiv.allyCiv != viewingPlayer) continue
+            if (!otherCiv.isCityState || otherCiv.getAllyCivName() != viewingPlayer.civName) continue
             for (city in otherCiv.cities)
                 city.addUnimproved()
         }

--- a/core/src/com/unciv/ui/screens/overviewscreen/TradesOverviewTab.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/TradesOverviewTab.kt
@@ -17,12 +17,12 @@ class TradesOverviewTab(
 
     init {
         defaults().pad(10f)
-        val diplomaciesWithPendingTrade = viewingPlayer.diplomacy.values.filter { it.otherCiv.tradeRequests.any { it.requestingCiv == viewingPlayer.civName } }
+        val diplomaciesWithPendingTrade = viewingPlayer.diplomacy.values.filter { it.otherCiv().tradeRequests.any { it.requestingCiv == viewingPlayer.civName } }
         if (diplomaciesWithPendingTrade.isNotEmpty())
             add("Pending trades".toLabel(fontSize = Constants.headingFontSize)).padTop(10f).row()
         for (diplomacy in diplomaciesWithPendingTrade) {
-            for (tradeRequest in diplomacy.otherCiv.tradeRequests.filter { it.requestingCiv == viewingPlayer.civName })
-                add(createTradeTable(tradeRequest.trade.reverse(), diplomacy.otherCiv)).row()
+            for (tradeRequest in diplomacy.otherCiv().tradeRequests.filter { it.requestingCiv == viewingPlayer.civName })
+                add(createTradeTable(tradeRequest.trade.reverse(), diplomacy.otherCiv())).row()
         }
 
         val diplomaciesWithExistingTrade = viewingPlayer.diplomacy.values.filter { it.trades.isNotEmpty() }
@@ -41,7 +41,7 @@ class TradesOverviewTab(
             add("Current trades".toLabel(fontSize = Constants.headingFontSize)).padTop(10f).row()
         for (diplomacy in diplomaciesWithExistingTrade) {
             for (trade in diplomacy.trades)
-                add(createTradeTable(trade, diplomacy.otherCiv)).row()
+                add(createTradeTable(trade, diplomacy.otherCiv())).row()
         }
     }
 

--- a/core/src/com/unciv/ui/screens/overviewscreen/WonderOverviewTab.kt
+++ b/core/src/com/unciv/ui/screens/overviewscreen/WonderOverviewTab.kt
@@ -149,7 +149,7 @@ class WonderInfo {
     private fun knownFromQuest(viewingPlayer: Civilization, name: String): Boolean {
         // No, *your* civInfo's QuestManager has no idea about your quests
         for (civ in viewingPlayer.gameInfo.civilizations) {
-            for (quest in civ.questManager.getAssignedQuestsFor(viewingPlayer)) {
+            for (quest in civ.questManager.getAssignedQuestsFor(viewingPlayer.civName)) {
                 if (quest.questName == QuestName.FindNaturalWonder.value && quest.data1 == name)
                     return true
             }

--- a/core/src/com/unciv/ui/screens/pickerscreens/PromotionPickerScreen.kt
+++ b/core/src/com/unciv/ui/screens/pickerscreens/PromotionPickerScreen.kt
@@ -204,7 +204,7 @@ class PromotionPickerScreen private constructor(
          even their own because you can't build any unit there.
         */ 
         val currentCity = unit.currentTile.getCity() ?: return
-        if (currentCity.civ != unit.civ) return
+        if (currentCity.civ.civName != unit.civ.civName) return
         if (currentCity.isPuppet) return
         val checkBoxSaveUnitPromotion = "Default promotions for [${unit.baseUnit.name}]".toCheckBox(saveUnitPromotion) {saveUnitPromotion = it}
         topTable.add(checkBoxSaveUnitPromotion).left().padTop(10f)

--- a/core/src/com/unciv/ui/screens/pickerscreens/ReligiousBeliefsPickerScreen.kt
+++ b/core/src/com/unciv/ui/screens/pickerscreens/ReligiousBeliefsPickerScreen.kt
@@ -54,7 +54,7 @@ class ReligiousBeliefsPickerScreen (
     private var rightSelection = Selection()
 
     private val currentReligion = choosingCiv.religionManager.religion
-        ?: Religion("None", gameInfo, choosingCiv)
+        ?: Religion("None", gameInfo, choosingCiv.civName)
 
     init {
         leftChosenBeliefs.defaults().right().pad(10f).fillX()
@@ -200,7 +200,7 @@ class ReligiousBeliefsPickerScreen (
         val availableBeliefs = ruleset.beliefs.values
             .filter { it.type == beliefType || beliefType == BeliefType.Any }
 
-        val civReligionManager = currentReligion.foundingCiv.religionManager
+        val civReligionManager = currentReligion.getFounder().religionManager
 
         for (belief in availableBeliefs) {
             val beliefButton = getBeliefButton(belief)

--- a/core/src/com/unciv/ui/screens/worldscreen/AlertPopup.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/AlertPopup.kt
@@ -190,9 +190,9 @@ class AlertPopup(
         addQuestionAboutTheCity(city.name)
         val conqueringCiv = gameInfo.getCurrentPlayerCivilization()
 
-        if (city.foundingCivObject != null
-                && city.civ != city.foundingCivObject // can't liberate if the city actually belongs to those guys
-                && conqueringCiv != city.foundingCivObject) { // or belongs originally to us
+        if (city.foundingCiv != ""
+                && city.civ.civName != city.foundingCiv // can't liberate if the city actually belongs to those guys
+                && conqueringCiv.civName != city.foundingCiv) { // or belongs originally to us
             addLiberateOption(city, conqueringCiv)
             addSeparator()
         }
@@ -232,7 +232,7 @@ class AlertPopup(
         addQuestionAboutTheCity(city.name)
         val conqueringCiv = gameInfo.getCurrentPlayerCivilization()
 
-        if (!conqueringCiv.isAtWarWith(city.foundingCivObject!!)) {
+        if (!conqueringCiv.isAtWarWith(getCiv(city.foundingCiv))) {
             addLiberateOption(city, conqueringCiv)
             addSeparator()
         }
@@ -342,7 +342,7 @@ class AlertPopup(
         val tile = gameInfo.tileMap[position]
         val capturedUnit = tile.civilianUnit  // This has got to be it
             ?: return false // the unit disappeared somehow? maybe a modded action?
-        val originalOwner = capturedUnit.originalOwningCiv!!
+        val originalOwner = getCiv(capturedUnit.originalOwner!!)
         if (originalOwner.isDefeated()) return false
         val captor = viewingCiv
 
@@ -374,7 +374,7 @@ class AlertPopup(
                 yield(LocationAction(tile.position))
                 if (closestCity != null)
                     yield(LocationAction(closestCity.location))
-                yield(DiplomacyAction(captor))
+                yield(DiplomacyAction(captor.civName))
                 yield(CivilopediaAction("Tutorial/Barbarians"))
             }
             originalOwner.addNotification("Your captured [${unitName}] has been returned by [${captor.civName}]", notificationSequence, NotificationCategory.Diplomacy, NotificationIcon.Trade, unitName, captor.civName)
@@ -524,7 +524,7 @@ class AlertPopup(
     }
 
     private fun addLiberateOption(city: City, conqueringCiv: Civilization) {
-        val button = "Liberate (city returns to [originalOwner])".fillPlaceholders(city.foundingCivObject!!.civName).toTextButton()
+        val button = "Liberate (city returns to [originalOwner])".fillPlaceholders(city.foundingCiv).toTextButton()
         button.onActivation {
             city.liberateCity(conqueringCiv)
             close()

--- a/core/src/com/unciv/ui/screens/worldscreen/WorldScreen.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/WorldScreen.kt
@@ -485,7 +485,7 @@ class WorldScreen(
         displayTutorial(TutorialTrigger.EnemyCityNeedsConqueringWithMeleeUnit) {
             viewingCiv.diplomacy.values.asSequence()
                     .filter { it.diplomaticStatus == DiplomaticStatus.War }
-                    .map { it.otherCiv } // we're now lazily enumerating over CivilizationInfo's we're at war with
+                    .map { it.otherCiv() } // we're now lazily enumerating over CivilizationInfo's we're at war with
                     .flatMap { it.cities.asSequence() } // ... all *their* cities
                     .filter { it.health == 1 } // ... those ripe for conquering
                     .flatMap { it.getCenterTile().getTilesInDistance(2) }

--- a/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsReligion.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/unit/actions/UnitActionsReligion.kt
@@ -146,10 +146,10 @@ object UnitActionsReligion {
                 if (city.religion.religionThisIsTheHolyCityOf != null) {
                     val holyCityReligion = unit.civ.gameInfo.religions[city.religion.religionThisIsTheHolyCityOf]!!
                     if (city.religion.religionThisIsTheHolyCityOf != unit.religion && !city.religion.isBlockedHolyCity) {
-                        holyCityReligion.foundingCiv.addNotification("An [${unit.baseUnit.name}] has removed your religion [${holyCityReligion.getReligionDisplayName()}] from its Holy City [${city.name}]!", NotificationCategory.Religion)
+                        holyCityReligion.getFounder().addNotification("An [${unit.baseUnit.name}] has removed your religion [${holyCityReligion.getReligionDisplayName()}] from its Holy City [${city.name}]!", NotificationCategory.Religion)
                         city.religion.isBlockedHolyCity = true
                     } else if (city.religion.religionThisIsTheHolyCityOf == unit.religion && city.religion.isBlockedHolyCity) {
-                        holyCityReligion.foundingCiv.addNotification("An [${unit.baseUnit.name}] has restored [${city.name}] as the Holy City of your religion [${holyCityReligion.getReligionDisplayName()}]!", NotificationCategory.Religion)
+                        holyCityReligion.getFounder().addNotification("An [${unit.baseUnit.name}] has restored [${city.name}] as the Holy City of your religion [${holyCityReligion.getReligionDisplayName()}]!", NotificationCategory.Religion)
                         city.religion.isBlockedHolyCity = false
                     }
                 }

--- a/tests/src/com/unciv/logic/battle/BattleTest.kt
+++ b/tests/src/com/unciv/logic/battle/BattleTest.kt
@@ -262,7 +262,7 @@ class BattleTest {
         // then
         assertEquals(attackerCiv, defenderCity.civ)
         assertEquals(defenderCiv.civName, defenderCity.previousOwner)
-        assertEquals(defenderCiv, defenderCity.foundingCivObject)
+        assertEquals(defenderCiv.civName, defenderCity.foundingCiv)
     }
 
     @Test

--- a/tests/src/com/unciv/logic/city/managers/CityFounderTest.kt
+++ b/tests/src/com/unciv/logic/city/managers/CityFounderTest.kt
@@ -33,7 +33,7 @@ class CityFounderTest {
         val foundedCity = cityFounder.foundCity(civ, Vector2.Zero)
 
         // then
-        assertEquals(civ, foundedCity.foundingCivObject)
+        assertEquals(civ.civName, foundedCity.foundingCiv)
     }
 
     @Test

--- a/tests/src/com/unciv/testing/TestGame.kt
+++ b/tests/src/com/unciv/testing/TestGame.kt
@@ -233,7 +233,7 @@ class TestGame(vararg addGlobalUniques: String, forUITesting: Boolean = false) {
     }
 
     fun addReligion(foundingCiv: Civilization): Religion {
-        val religion = Religion("Religion-${objectsCreated++}", gameInfo, foundingCiv)
+        val religion = Religion("Religion-${objectsCreated++}", gameInfo, foundingCiv.civName)
         foundingCiv.religionManager.religion = religion
         gameInfo.religions[religion.name] = religion
         return religion


### PR DESCRIPTION
This reverts commit 1fe61a64f972e5a54e2d8bb63eb7a524da6eac8c.
Should fix #14200, should fix #14207