### PR TITLE
countables: Add a Researched Technologies Countable

### DIFF
--- a/core/src/com/unciv/models/ruleset/unique/Countables.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Countables.kt
@@ -181,7 +181,7 @@ enum class Countables(
         override fun getKnownValuesForAutocomplete(ruleset: Ruleset) = setOf<String>()
     },
 
-    FilteredTechnologies("[techFilter] Researched Technologies") {
+    FilteredTechnologies("Researched [techFilter] Technologies") {
         override val documentationStrings = listOf(
             "Counts researched matching technologies for the relevant Civilization",
             "Repeatable technologies, like Future Tech, are only counted once"

--- a/tests/src/com/unciv/uniques/CountableTests.kt
+++ b/tests/src/com/unciv/uniques/CountableTests.kt
@@ -375,12 +375,12 @@ class CountableTests {
             civ.tech.addTechnology(techName, false)
         }
         val tests = listOf(
-            "[All] Researched Technologies" to 5,
-            "[Ancient era] Researched Technologies" to 4,
-            "[Classical era] Researched Technologies" to 1, // Optics
-            "[Modern era] Researched Technologies" to 0,
-            "[Pottery] Researched Technologies" to 1,
-            "[Archery] Researched Technologies" to 0,
+            "Researched [All] Technologies" to 5,
+            "Researched [Ancient era] Technologies" to 4,
+            "Researched [Classical era] Technologies" to 1, // Optics
+            "Researched [Modern era] Technologies" to 0,
+            "Researched [Pottery] Technologies" to 1,
+            "Researched [Archery] Technologies" to 0,
         )
         for ((test, expected) in tests) {
             val actual = Countables.getCountableAmount(test, GameContext(civ))


### PR DESCRIPTION
Suggested by @SpacedOutChicken in https://github.com/yairm210/Unciv/issues/3242#issuecomment-3533963073 , this adds a countable to get the number of technologies you've researched.

### Examples
```
[All] Researched Technologies
[Ancient era] Researched Technologies
```

I felt that `[techFilter] Technologies` wasn't specific enough, since it could be misunderstood as ALL technologies, not just those you researched. So I added "Researched" in there.
