### PR TITLE
Fix Worker Improvement Automation Checks

### DIFF
--- a/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
@@ -647,10 +647,10 @@ class MapUnit : IsPartOfGameInfoSerialization {
         }
 
         // Validate that the improvement is available for the unit
-        if (!improvement.getMatchingUniques(UniqueType.OnlyAvailable, GameContext.IgnoreConditionals)
-                .none { unique -> !unique.conditionalsApply(cache.state) } ||
-            !improvement.getMatchingUniques(UniqueType.Unavailable, GameContext.IgnoreConditionals)
-                .none { unique -> unique.conditionalsApply(cache.state) }) {
+        if (improvement.getMatchingUniques(UniqueType.OnlyAvailable, GameContext.IgnoreConditionals)
+                .any { unique -> !unique.conditionalsApply(cache.state) } ||
+            improvement.getMatchingUniques(UniqueType.Unavailable, GameContext.IgnoreConditionals)
+                .any { unique -> unique.conditionalsApply(cache.state) }) {
             return false
         }
 


### PR DESCRIPTION
This does two things for checking the validity on whether or not a Worker can build an improvement.

1. It allows a MultiFilter to allow things like...
    ```json
    "Can build [{Land} {non-[Mine]}] improvements on tiles"
    ```
2. It will now also now check `Only available` or `Unavailable` on the tile improvements
    ```json
    "Only available <for [Archaeologist] units>"
    ```

### Bug Fix

The original bug was found by @kittridgecoffey-a11y over at https://github.com/RobLoach/Civ-V-Brave-New-World/issues/196 where Workers were completing Archaeologist dig sites. Workers were completing the Dig sites and getting Artifacts, which is obviously not intended.

### Use Case

In BNW, I needed Workers to not be able to complete the Archaeological Digs that Archaeologists started.
```
"Can build [{Land} {non-[Antiquity Dig Site]}] improvements on tiles"
```