### PR TITLE
Proposal: Display notification category headers only when number of notifications in category >1

### DIFF
--- a/core/src/com/unciv/ui/screens/worldscreen/NotificationsScroll.kt
+++ b/core/src/com/unciv/ui/screens/worldscreen/NotificationsScroll.kt
@@ -55,7 +55,7 @@ class NotificationsScroll(
         /** Logical font size used in notification and category labels */
         const val fontSize = 30
         /** This is the spacing between categories and also the spacing between the next turn button and the first header */
-        const val categoryTopPad = 15f
+        const val categoryTopPad = 20f
         /** Spacing between rightmost Label edge and right Screen limit */
         const val rightPadToScreenEdge = 10f
         /** Extra right padding when there's a selection */
@@ -80,6 +80,7 @@ class NotificationsScroll(
         const val restoreButtonNumbersCenter = restoreButtonSize - restoreButtonNumbersSize / 2
         /** Background tint for [oneTimeNotification] */
         private val oneTimeNotificationColor = Color.valueOf("fceea8")
+        const val minimumNotificationsToCollapseCategory = 2
     }
 
     //region private fields
@@ -262,7 +263,7 @@ class NotificationsScroll(
             .toSortedMap()  // This sorts by Category ordinal, so far intentional - the order of the grouped lists are unaffected
         for ((category, categoryNotifications) in orderedNotifications) {
             val header: CategoryHeader?
-            if (category == NotificationCategory.General) {
+            if (categoryNotifications.size < minimumNotificationsToCollapseCategory) {
                 notificationsTable.add().padTop(categoryTopPad)
                     .row()  // Make sure category w/o header gets same spacing
                 header = null


### PR DESCRIPTION
I like the recent addition of world screen notification category headers that can be tapped to collapse the notifications in that category.

However, because vertical space is very sparse on mobile, I propose displaying the header only if there is more than 1-2 notifications in that category.
This will save vertical space, which is precious on mobile, while still showing headers for large categories.
Categories without a header will still be distinguishable through padding.

PC (large UI):
<img height="500" alt="image" src="https://github.com/user-attachments/assets/a6f0c25e-3c66-4b47-860a-35987173672b" /> <img height="500" alt="image" src="https://github.com/user-attachments/assets/49dfd1bd-f35e-4c2c-8d0b-d09b617fd055" />

20:9 aspect ratio (small UI):
<img height="500" alt="image" src="https://github.com/user-attachments/assets/1c56c032-3377-43d0-8822-a1342a8ffe1f" /> <img height="500" alt="image" src="https://github.com/user-attachments/assets/4202f840-ccd5-4eae-9e20-aa0ec827a73d" /> 


