### PR TITLE
G&K: Allow Scout to be purchased with Faith

### DIFF
--- a/android/assets/jsons/Civ V - Gods & Kings/Units.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Units.json
@@ -26,7 +26,7 @@
 		"strength": 5,
 		"cost": 25,
 		"obsoleteTech": "Scientific Theory",
-		"uniques": ["May upgrade to [Archer] through ruins-like effects", "Never appears as a Barbarian unit"],
+		"uniques": ["May upgrade to [Archer] through ruins-like effects", "Never appears as a Barbarian unit", "Can be purchased for [50] [Faith] [in all cities]"],
 		"promotions": ["Ignore terrain cost"],
 		"attackSound": "nonmetalhit"
 	},


### PR DESCRIPTION
Am I misunderstanding something here? In the G&K Civilopedia, it lists Scout as being purchasable with 50 Faith. Is there any other prerequesite to it?
<img width="681" height="777" alt="Screenshot from 2025-11-20 00-37-51" src="https://github.com/user-attachments/assets/a925c33d-64cc-448f-b0c7-a5107324351c" />
