### PR TITLE
G&K: Fix the Holy Warriors Belief

### DIFF
--- a/android/assets/jsons/Civ V - Gods & Kings/Beliefs.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Beliefs.json
@@ -148,11 +148,10 @@
         "name": "Holy Warriors",
         "type": "Follower",
         "uniques": [
-            "May buy [{Ancient era} {Military} {Land}] units with [Faith] for [2] times their normal Production cost <in [in cities following this religion] cities> <hidden from users>",
-            "May buy [{Classical era} {Military} {Land}] units with [Faith] for [2] times their normal Production cost <in [in cities following this religion] cities> <hidden from users>",
-            "May buy [{Medieval era} {Military} {Land}] units with [Faith] for [2] times their normal Production cost <in [in cities following this religion] cities> <hidden from users>",
-            "May buy [{Renaissance era} {Military} {Land}] units with [Faith] for [2] times their normal Production cost <in [in cities following this religion] cities> <hidden from users>",
-            "Comment [{May buy [[pre-][Industrial era] [Military] [Land]] units with [Faith] for [2] times their normal Production cost} {in cities following this religion}]"
+            "May buy [{Ancient era} {Military} {Land}] units with [Faith] for [2] times their normal Production cost <in [in cities following this religion] cities>",
+            "May buy [{Classical era} {Military} {Land}] units with [Faith] for [2] times their normal Production cost <in [in cities following this religion] cities>",
+            "May buy [{Medieval era} {Military} {Land}] units with [Faith] for [2] times their normal Production cost <in [in cities following this religion] cities>",
+            "May buy [{Renaissance era} {Military} {Land}] units with [Faith] for [2] times their normal Production cost <in [in cities following this religion] cities>"
         ]
     },
     {


### PR DESCRIPTION
The Holy Warriors belief reads...

> Use Faith to purchase pre-Industrial land units

Our unique for it only allowed purchasing Military land units when you were in an Era prior to the Industrial era. While the unique sounded correct, the meaning as a unique was incorrect.

<img width="465" height="158" alt="Screenshot from 2025-11-20 01-02-54" src="https://github.com/user-attachments/assets/3834d932-232d-486b-89fa-779b2ec7e872" />


### Questions

1. Is the following condition correct?
   ```
   <in [in cities following this religion] cities>
   ```

2. Should we fix the cityFilter verbiage for that? Add an alias for it as...
    ```
    <in [following religion] cities>
    ```
