### PR TITLE
Unit test and IsPartOfGameInfoSerialization linting

### DIFF
--- a/core/src/com/unciv/logic/civilization/managers/PolicyManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/PolicyManager.kt
@@ -30,7 +30,7 @@ class PolicyManager : IsPartOfGameInfoSerialization {
     internal val adoptedPolicies = HashSet<String>()
     private var numberOfAdoptedPolicies = 0
 
-    private var cultureOfLast8Turns = IntArray(8) { 0 }
+    private var cultureOfLast8Turns = IntArray(8)
 
     /** Indicates whether we should *check* if policy is adoptible, and if so open */
     var shouldOpenPolicyPicker = false

--- a/core/src/com/unciv/logic/civilization/managers/TechManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/TechManager.kt
@@ -68,7 +68,7 @@ class TechManager : IsPartOfGameInfoSerialization {
     var repeatingTechsResearched = 0
 
     /** For calculating Great Scientist yields - see https://civilization.fandom.com/wiki/Great_Scientist_(Civ5)  */
-    var scienceOfLast8Turns = IntArray(8) { 0 }
+    var scienceOfLast8Turns = IntArray(8)
     var scienceFromResearchAgreements = 0
     /** This is the list of strings, which is serialized */
     var techsResearched = HashSet<String>()

--- a/core/src/com/unciv/models/metadata/GameParameters.kt
+++ b/core/src/com/unciv/models/metadata/GameParameters.kt
@@ -6,7 +6,7 @@ import com.unciv.models.ruleset.Speed
 
 class GameParameters : IsPartOfGameInfoSerialization { // Default values are the default new game
     var difficulty = "Prince"
-    var speed = Speed.DEFAULT
+    var speed: String = Speed.DEFAULT // Not an instance of class Speed
 
     var randomNumberOfPlayers = false
     var minNumberOfPlayers = 3

--- a/core/src/com/unciv/models/ruleset/Speed.kt
+++ b/core/src/com/unciv/models/ruleset/Speed.kt
@@ -13,7 +13,7 @@ import kotlin.collections.ArrayList
 import kotlin.collections.HashMap
 import kotlin.math.abs
 
-class Speed : RulesetObject(), IsPartOfGameInfoSerialization {
+class Speed : RulesetObject() {
     var modifier: Float = 1f
     var goldCostModifier: Float = modifier
     var productionCostModifier: Float = modifier

--- a/tests/src/com/unciv/logic/GameSerializationTests.kt
+++ b/tests/src/com/unciv/logic/GameSerializationTests.kt
@@ -1,6 +1,7 @@
 package com.unciv.logic
 
 import com.badlogic.gdx.Gdx
+import com.badlogic.gdx.utils.Json
 import com.unciv.Constants
 import com.unciv.UncivGame
 import com.unciv.json.json
@@ -98,7 +99,7 @@ class GameSerializationTests {
 
     @Test
     fun serializedLaziesTest() {
-        val jsonSerializer = com.badlogic.gdx.utils.Json().apply {
+        val jsonSerializer = Json().apply {
             setIgnoreDeprecated(true)
             setDeprecated(classSynchronizedLazyImpl, "initializer", true)
             setDeprecated(classSynchronizedLazyImpl, "lock", true)  // this is the culprit as kotlin initializes it to `this@SynchronizedLazyImpl`

--- a/tests/src/com/unciv/logic/civilization/managers/ThreatManagerTests.kt
+++ b/tests/src/com/unciv/logic/civilization/managers/ThreatManagerTests.kt
@@ -11,7 +11,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(GdxTestRunner::class)
-class ThreatManangerTests {
+class ThreatManagerTests {
 
     val testGame = TestGame()
     val civ = testGame.addCiv()
@@ -170,4 +170,3 @@ class ThreatManangerTests {
     }
 
 }
-


### PR DESCRIPTION
Notes:
- Those [dead lines I commented](https://github.com/yairm210/Unciv/compare/master...SomeTroglodyte:Linting42a?expand=1#diff-8864d3ac1c2396b97b24c835373d1413f9f0dcf7eee7bd58ae462ea29b0e6293R106-R107) with a todo were there since 066dd615b4fc76e031ef2ad71703acd18d9ed636 - I'm pretty sure they should go
- Shaves off a second or two from test runtime
- Yes, Speed is not `IsPartOfGameInfoSerialization` - if it were we'd be in trouble with two non-transient lazies