### PR TITLE
chore: IsPartOfGameInfoSerialization: clearer doc, compliance, linting

### DIFF
--- a/core/src/com/unciv/json/LastSeenImprovement.kt
+++ b/core/src/com/unciv/json/LastSeenImprovement.kt
@@ -3,6 +3,7 @@ package com.unciv.json
 import com.badlogic.gdx.math.Vector2
 import com.badlogic.gdx.utils.Json
 import com.badlogic.gdx.utils.JsonValue
+import com.unciv.logic.IsPartOfGameInfoSerialization
 import com.unciv.ui.components.extensions.toPrettyString
 import yairm210.purity.annotations.Pure
 import yairm210.purity.annotations.Readonly
@@ -21,7 +22,7 @@ import yairm210.purity.annotations.Readonly
  */
 open class LastSeenImprovement(
     private val map: HashMap<Vector2, String> = hashMapOf()
-) : MutableMap<Vector2, String> by map, Json.Serializable {
+) : MutableMap<Vector2, String> by map, IsPartOfGameInfoSerialization, Json.Serializable {
     override fun write(json: Json) {
         for ((key, value) in entries) {
             val name = key.toPrettyString()

--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -53,23 +53,40 @@ import java.util.UUID
 /**
  * A class that implements this interface is part of [GameInfo] serialization, i.e. save files.
  *
- * Take care with `lateinit` and `by lazy` fields - both are **never** serialized.
+ * ### Clarification: *only* for classes that are serialized and deserialized - *not* pure Ruleset files.
  *
+ * #### Compatibility:
  * When you change the structure of any class with this interface in a way which makes it impossible
  * to load the new saves from an older game version, increment [CompatibilityVersion.CURRENT_COMPATIBILITY_NUMBER]!
  * And don't forget to add backwards compatibility for the previous format.
  *
+ * #### Rules:
+ * - Enum classes are always serialized like primitives, any additional fields are ignored. Therefore marking them makes no technical sense, but the unit test tolerates it.
+ * - If the class also implements Json.Serializable, then the rules below do not apply, that implementation is entirely responsible.
+ * - Exclude all fields that do not need to be saved with [`@Transient`][Transient].
+ * - Take care with `by lazy` fields - those must **never** be serialized. Use `@delegate:Transient` to exclude them.
+ * - Properties without backing field (val foo get() = without referencing `field` or `val bar by ::foo`) are always fine - they're never serialized.
+ * - Types of serialized fields must be primitives, enums, other classes marked `IsPartOfGameInfoSerialization`, or collections of those.
+ * - All types involved in a field's type should be **non-abstract**: No interfaces. The `List`, see below.
+ * - Keys in Maps must be String. Sets are fine even though they are a Map internally.
+ * - Do not serialize any `Sequence` - should be obvious!
+ *
+ * #### Explanation for the non-abstract rule
  * Reminder: In all subclasses, do use only actual Collection types, not abstractions like
  * `= mutableSetOf<Something>()`. That would make the reflection type of the field an interface, which
  * hides the actual implementation from Gdx Json, so it will not try to call a no-args constructor but
  * will instead deserialize a List in the jsonData.isArray() -> isAssignableFrom(Collection) branch of readValue:
  * https://github.com/libgdx/libgdx/blob/75612dae1eeddc9611ed62366858ff1d0ac7898b/gdx/src/com/badlogic/gdx/utils/Json.java#L1111
- * .. which will crash later (when readFields actually assigns it) unless empty.
+ * .. which will crash later (when readFields actually assigns it) - unless the interface actually was `List`.
  */
 interface IsPartOfGameInfoSerialization
 
 
-data class VictoryData(val winningCiv: String, val victoryType: String, val victoryTurn: Int) {
+data class VictoryData(
+    val winningCiv: String,
+    val victoryType: String,
+    val victoryTurn: Int
+) : IsPartOfGameInfoSerialization {
     @Suppress("unused")  // used by json serialization
     constructor() : this("", "", 0)
 }
@@ -81,7 +98,7 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
     /** Version that saved the game, set in [UncivFiles.gameInfoToString][com.unciv.logic.files.UncivFiles.gameInfoToString]. */
     override var version = CompatibilityVersion.FIRST_WITHOUT
 
-    var civilizations = mutableListOf<Civilization>()
+    var civilizations = ArrayList<Civilization>()
     var barbarians = BarbarianManager()
     var religions: HashMap<String, Religion> = hashMapOf()
     var difficulty = "Chieftain" // difficulty is game-wide, think what would happen if 2 human players could play on different difficulties?
@@ -120,7 +137,7 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
     var customSaveLocation: String? = null
 
     /** List of unit names that have been taken in this game from UnitNameGroups.json. */
-    var unitNamesTaken = mutableListOf<String>()
+    var unitNamesTaken = ArrayList<String>()
 
     //endregion
     //region Fields - Transient

--- a/core/src/com/unciv/logic/city/City.kt
+++ b/core/src/com/unciv/logic/city/City.kt
@@ -29,6 +29,7 @@ import com.unciv.models.stats.GameResource
 import com.unciv.models.stats.INamed
 import com.unciv.models.stats.Stat
 import com.unciv.models.stats.SubStat
+import com.unciv.utils.withoutItem
 import yairm210.purity.annotations.Readonly
 import java.util.EnumSet
 import java.util.UUID
@@ -387,8 +388,8 @@ class City : IsPartOfGameInfoSerialization, INamed {
         // Must be before removing existing capital because we may be annexing a puppet which means city stats update - see #8337
         if (isCapital()) civ.moveCapitalToNextLargest(null)
 
-        civ.cities = civ.cities.toMutableList().apply { remove(this@City) }
-        
+        civ.cities = civ.cities.withoutItem(this)
+
         if (getRuleset().tileImprovements.containsKey("City ruins"))
             getCenterTile().setImprovement("City ruins")
 

--- a/core/src/com/unciv/logic/city/managers/CityConquestFunctions.kt
+++ b/core/src/com/unciv/logic/city/managers/CityConquestFunctions.kt
@@ -18,6 +18,8 @@ import com.unciv.logic.trade.TradeOfferType
 import com.unciv.models.ruleset.unique.GameContext
 import com.unciv.models.ruleset.unique.UniqueTriggerActivation
 import com.unciv.models.ruleset.unique.UniqueType
+import com.unciv.utils.withItem
+import com.unciv.utils.withoutItem
 import yairm210.purity.annotations.Readonly
 import kotlin.math.max
 import kotlin.math.min
@@ -269,8 +271,8 @@ class CityConquestFunctions(val city: City) {
         //  civs so the capitalCityIndicator recognizes the unique buildings of the conquered civ
         if (city.isCapital()) oldCiv.moveCapitalToNextLargest(city)
 
-        oldCiv.cities = oldCiv.cities.toMutableList().apply { remove(city) }
-        newCiv.cities = newCiv.cities.toMutableList().apply { add(city) }
+        oldCiv.cities = oldCiv.cities.withoutItem(city)
+        newCiv.cities = newCiv.cities.withItem(city)
         city.civ = newCiv
         city.state = GameContext(city)
         city.hasJustBeenConquered = false

--- a/core/src/com/unciv/logic/city/managers/CityFounder.kt
+++ b/core/src/com/unciv/logic/city/managers/CityFounder.kt
@@ -12,6 +12,7 @@ import com.unciv.models.ruleset.nation.Nation
 import com.unciv.models.ruleset.unique.GameContext
 import com.unciv.models.ruleset.unique.UniqueTriggerActivation
 import com.unciv.models.ruleset.unique.UniqueType
+import com.unciv.utils.withItem
 import yairm210.purity.annotations.Readonly
 
 class CityFounder {
@@ -36,7 +37,7 @@ class CityFounder {
         }
         civInfo.citiesCreated++
 
-        civInfo.cities = civInfo.cities.toMutableList().apply { add(city) }
+        civInfo.cities = civInfo.cities.withItem(city)
 
         val startingEra = civInfo.gameInfo.gameParameters.startingEra
 

--- a/core/src/com/unciv/logic/civilization/Civilization.kt
+++ b/core/src/com/unciv/logic/civilization/Civilization.kt
@@ -171,7 +171,7 @@ class Civilization : IsPartOfGameInfoSerialization {
     var notifications = ArrayList<Notification>()
 
     var notificationsLog = ArrayList<NotificationsLog>()
-    class NotificationsLog(val turn: Int = 0) {
+    class NotificationsLog(val turn: Int = 0) : IsPartOfGameInfoSerialization {
         var notifications = ArrayList<Notification>()
     }
 
@@ -195,6 +195,8 @@ class Civilization : IsPartOfGameInfoSerialization {
     // if we only use lists, and change the list each time the cities are changed,
     // we won't get concurrent modification exceptions.
     // This is basically a way to ensure our lists are immutable.
+    // Note this relies on Gdx Json falling beck to ArrayList when deserializing json arrays for a field collection type it doesn't recognize.
+    // This will NOT be an ArrayList in memory right after GameStarter - but save and reload or pass a next turn, and it will be.
     var cities = listOf<City>()
     var citiesCreated = 0
 

--- a/core/src/com/unciv/logic/civilization/managers/RuinsManager.kt
+++ b/core/src/com/unciv/logic/civilization/managers/RuinsManager.kt
@@ -11,7 +11,7 @@ import yairm210.purity.annotations.Readonly
 import kotlin.random.Random
 
 class RuinsManager(
-    private var lastChosenRewards: MutableList<String> = mutableListOf("", "")
+    private val lastChosenRewards: ArrayList<String> = arrayListOf("", "")
 ) : IsPartOfGameInfoSerialization {
 
     @Transient

--- a/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
+++ b/core/src/com/unciv/logic/map/mapunit/MapUnit.kt
@@ -98,28 +98,26 @@ class MapUnit : IsPartOfGameInfoSerialization {
 
     /** Array list of all the tiles that this unit has attacked since the start of its most recent turn. Used in movement arrow overlay. */
     var attacksSinceTurnStart = ArrayList<Vector2>()
-    
-    class UnitStatus {
-        var name:String = ""
-        /** Decreses at *start on next turn* so defensive statuses persist on enemy turns */
-        var turnsLeft = 1
-        
+
+    class UnitStatus(
+        val name: String,
+        /** Decreases at *start on next turn* so defensive statuses persist on enemy turns */
+        var turnsLeft: Int
+    ) : IsPartOfGameInfoSerialization {
+        @Suppress("unused") // for deserialization
+        constructor() : this("", 1)
+
         @Transient
         lateinit var uniques: List<Unique>
-        
+
         fun setTransients(unit: MapUnit) {
             uniques = unit.civ.gameInfo.ruleset.unitPromotions[name]?.uniqueObjects ?: emptyList()
         }
 
         @Readonly
-        fun clone(): UnitStatus {
-            @LocalState val toReturn = UnitStatus()
-            toReturn.name = name
-            toReturn.turnsLeft = turnsLeft
-            return toReturn
-        }
+        fun clone() = UnitStatus(name, turnsLeft)
     }
-    
+
     var statusMap = HashMap<String, UnitStatus>()
 
     //endregion
@@ -231,7 +229,7 @@ class MapUnit : IsPartOfGameInfoSerialization {
         toReturn.religion = religion
         toReturn.religiousStrengthLost = religiousStrengthLost
         toReturn.movementMemories = movementMemories.copy()
-        @LocalState val newStatusMap = HashMap<String, UnitStatus>()
+        @LocalState val newStatusMap = HashMap<String, UnitStatus>((statusMap.size * 4 + 2) / 3)
         for ((name, status) in statusMap) {
             @LocalState val newStatus = status.clone()
             newStatusMap[name] = newStatus
@@ -248,7 +246,7 @@ class MapUnit : IsPartOfGameInfoSerialization {
     @Readonly fun getMovementString(): String =
         (DecimalFormat("0.#").format(currentMovement.toDouble()) + "/" + getMaxMovement()).tr()
 
-    
+
     @Readonly fun getTile(): Tile = currentTile
 
     @Readonly
@@ -337,7 +335,7 @@ class MapUnit : IsPartOfGameInfoSerialization {
     ): Sequence<Unique> {
         return tempUniquesMap.getTriggeredUniques(trigger, gameContext, triggerFilter)
     }
-    
+
 
     /** Gets *per turn* resource requirements - does not include immediate costs for stockpiled resources.
      * StateForConditionals is assumed to regarding this mapUnit*/
@@ -471,7 +469,7 @@ class MapUnit : IsPartOfGameInfoSerialization {
     private fun adjacentHealingBonus(): Int {
         return getMatchingUniques(UniqueType.HealAdjacentUnits).sumOf { it.params[0].toInt() }
     }
-    
+
     @Readonly
     fun getHealAmountForCurrentTile() = when {
         isEmbarked() -> 0 // embarked units can't heal
@@ -519,7 +517,7 @@ class MapUnit : IsPartOfGameInfoSerialization {
                 .map { it.adjacentHealingBonus() }.maxOrNull()
         if (maxAdjacentHealingBonus != null)
             healing += maxAdjacentHealingBonus
-        
+
         healing -= getDamageFromTerrain(tile)
 
         return healing
@@ -553,8 +551,7 @@ class MapUnit : IsPartOfGameInfoSerialization {
         val maxAttacksPerTurn = 1 +
                 getMatchingUniques(UniqueType.ExtraInterceptionsPerTurn)
                         .sumOf { it.params[0].toInt() }
-        if (attacksThisTurn >= maxAttacksPerTurn) return false
-        return true
+        return attacksThisTurn < maxAttacksPerTurn
     }
 
     @Readonly
@@ -637,7 +634,7 @@ class MapUnit : IsPartOfGameInfoSerialization {
                 if (civ.matchesFilter(filter, cache.state, false)) return true
                 if (nonUnitUniquesMap.hasUnique(filter, cache.state)) return true
                 if (promotions.promotions.contains(filter)) return true
-                if (hasStatus(filter)) return true 
+                if (hasStatus(filter)) return true
                 return false
             }
         }
@@ -646,7 +643,7 @@ class MapUnit : IsPartOfGameInfoSerialization {
     @Readonly
     fun canBuildImprovement(improvement: TileImprovement, tile: Tile = currentTile): Boolean {
         if (civ.isBarbarian) return false
-        
+
         // Workers (and similar) should never be able to (instantly) construct things, only build them
         // HOWEVER, they should be able to repair such things if they are pillaged
         if (improvement.turnsToBuild == -1
@@ -667,9 +664,9 @@ class MapUnit : IsPartOfGameInfoSerialization {
             return false
         }
 
-        return buildImprovementUniques.any {
+        return buildImprovementUniques.any { unique ->
             // Engage the MultiFilter on the entire filter, prior to checking the individual filters
-            MultiFilter.multiFilter(it.params[0], {
+            MultiFilter.multiFilter(unique.params[0], {
                 improvement.matchesFilter(it, cache.state) || tile.matchesTerrainFilter(it, civ)
             })
         }
@@ -700,7 +697,7 @@ class MapUnit : IsPartOfGameInfoSerialization {
 
     @Readonly
     fun isEscorting(): Boolean {
-        if (escorting) { 
+        if (escorting) {
             if (getOtherEscortUnit() != null) return true
             escorting = false
         }
@@ -724,7 +721,7 @@ class MapUnit : IsPartOfGameInfoSerialization {
         promotions.setTransients(this)
         baseUnit = ruleset.units[name]
                 ?: throw java.lang.Exception("Unit $name is not found!")
-        
+
         for (status in statusMap.values) status.setTransients(this)
         updateUniques()
         if (action == UnitActionType.Automate.value){
@@ -737,7 +734,7 @@ class MapUnit : IsPartOfGameInfoSerialization {
         val otherUniqueSources = promotions.getPromotions().flatMap { it.uniqueObjects } +
             statusMap.values.flatMap { it.uniques }
         val uniqueSources = baseUnit.rulesetUniqueObjects.asSequence() + otherUniqueSources
-        
+
         tempUniquesMap = UniqueMap(uniqueSources)
         nonUnitUniquesMap = UniqueMap(otherUniqueSources)
         cache.updateUniques()
@@ -775,14 +772,14 @@ class MapUnit : IsPartOfGameInfoSerialization {
         }
 
         // Set equality automatically determines if anything changed - https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-abstract-set/equals.html
-        
+
         val shouldUpdateTiles = updateCivViewableTiles && oldViewableTiles != viewableTiles
                 // Don't bother updating if all previous and current viewable tiles are within our borders
-                && (oldViewableTiles.any { it !in civ.cache.ourTilesAndNeighboringTiles } 
+                && (oldViewableTiles.any { it !in civ.cache.ourTilesAndNeighboringTiles }
                 || viewableTiles.any { it !in civ.cache.ourTilesAndNeighboringTiles })
 
         if (!shouldUpdateTiles) return
-        
+
         val unfilteredTriggeredUniques = getTriggeredUniques(UniqueType.TriggerUponDiscoveringTile, GameContext.IgnoreConditionals).toList()
         if (unfilteredTriggeredUniques.isNotEmpty()) {
             val newlyExploredTiles = viewableTiles.filter { !it.isExplored(civ) }
@@ -839,7 +836,7 @@ class MapUnit : IsPartOfGameInfoSerialization {
         }
 
         val currentTile = getTile()
-        
+
         if (isMoving()) {
             val destinationTile = getMovementDestination()
             if (!movement.canReach(destinationTile)) { // That tile that we were moving towards is now unreachable -
@@ -969,7 +966,7 @@ class MapUnit : IsPartOfGameInfoSerialization {
             val promotion = unique.params[0]
             promotions.addPromotion(promotion, true)
         }
-            
+
         updateVisibleTiles(true, currentTile.position)
     }
 
@@ -1115,17 +1112,15 @@ class MapUnit : IsPartOfGameInfoSerialization {
 
     @Readonly fun getStatus(name:String): UnitStatus? = statusMap[name]
     @Readonly fun hasStatus(name:String): Boolean = getStatus(name) != null
-    
+
     fun setStatus(name:String, turns:Int){
         val existingStatus = getStatus(name)
         if (existingStatus != null){
             if (turns > existingStatus.turnsLeft) existingStatus.turnsLeft = turns
             return
         }
-        
-        val status = UnitStatus()
-        status.name = name
-        status.turnsLeft = turns
+
+        val status = UnitStatus(name, turns)
         status.setTransients(this)
         statusMap[status.name] = status
         updateUniques()
@@ -1133,7 +1128,7 @@ class MapUnit : IsPartOfGameInfoSerialization {
         for (unique in getTriggeredUniques(UniqueType.TriggerUponStatusGain){ it.params[0] == name })
             UniqueTriggerActivation.triggerUnique(unique, this)
     }
-    
+
     fun removeStatus(name:String){
         statusMap.remove(name) ?: return
 

--- a/core/src/com/unciv/models/ruleset/Speed.kt
+++ b/core/src/com/unciv/models/ruleset/Speed.kt
@@ -1,6 +1,5 @@
 package com.unciv.models.ruleset
 
-import com.unciv.logic.IsPartOfGameInfoSerialization
 import com.unciv.models.ruleset.unique.UniqueTarget
 import com.unciv.models.stats.Stat
 import com.unciv.models.translations.tr

--- a/core/src/com/unciv/utils/CollectionExtensions.kt
+++ b/core/src/com/unciv/utils/CollectionExtensions.kt
@@ -34,45 +34,45 @@ fun <T> List<T>.randomWeighted(weights: List<Float>, random: Random = Random): T
 fun <T> List<T>.randomWeighted(random: Random = Random, getWeight: (T) -> Float): T =
     randomWeighted(map(getWeight), random)
 
-/** Gets a clone of an [ArrayList] with an additional item
+/** Gets a clone of any [List] as [ArrayList] with an additional item
  *
  * Solves concurrent modification problems - everyone who had a reference to the previous arrayList can keep using it because it hasn't changed
  */
 @Readonly
-fun <T> ArrayList<T>.withItem(item: T): ArrayList<T> {
+fun <T> List<T>.withItem(item: T): ArrayList<T> {
     val newArrayList = ArrayList(this)
     newArrayList.add(item)
     return newArrayList
 }
 
-/** Gets a clone of a [HashSet] with an additional item
+/** Gets a clone of any [Set] as [HashSet] with an additional item
  *
  * Solves concurrent modification problems - everyone who had a reference to the previous hashSet can keep using it because it hasn't changed
  */
 @Readonly
-fun <T> HashSet<T>.withItem(item: T): HashSet<T> {
+fun <T> Set<T>.withItem(item: T): HashSet<T> {
     val newHashSet = HashSet(this)
     newHashSet.add(item)
     return newHashSet
 }
 
-/** Gets a clone of an [ArrayList] without a given item
+/** Gets a clone of any [List] as [ArrayList] without a given item
  *
  * Solves concurrent modification problems - everyone who had a reference to the previous arrayList can keep using it because it hasn't changed
  */
 @Readonly
-fun <T> ArrayList<T>.withoutItem(item: T): ArrayList<T> {
+fun <T> List<T>.withoutItem(item: T): ArrayList<T> {
     val newArrayList = ArrayList(this)
     newArrayList.remove(item)
     return newArrayList
 }
 
-/** Gets a clone of a [HashSet] without a given item
+/** Gets a clone of any [Set] as [HashSet] without a given item
  *
  * Solves concurrent modification problems - everyone who had a reference to the previous hashSet can keep using it because it hasn't changed
  */
 @Readonly
-fun <T> HashSet<T>.withoutItem(item: T): HashSet<T> {
+fun <T> Set<T>.withoutItem(item: T): HashSet<T> {
     val newHashSet = HashSet(this)
     newHashSet.remove(item)
     return newHashSet


### PR DESCRIPTION
Closes #14250

Mainly because currently there are classes participating in a save game that aren't marked properly.

Note this is the result of a unit test that is able to check the rules in-depth, much better than the existing 'can I load a save' one which depends on the complexity of the gameInfo it works with. Not sure I will PR that test, holler if you wanna see.

Tidbits:
- Before this we have 78 classes marked, after 80. Note this may include enums - technically it's completely irrelevant whether you mark those or not as Gdx will always serialize the Enum "constant" name only, no matter what you pack on top.
- We got exactly 42 packages - but I forgot for which scope I counted

Question:
- That TemporaryUnique comment
       https://github.com/yairm210/Unciv/blob/1db69af894c292e0cac3ed75622d0c2394018cfa/core/src/com/unciv/logic/civilization/Civilization.kt#L186-L192
   makes me curious: Care to explain? What idealized model would you have had in mind, maybe I can see how to make it work?
- A lot of our cloning does avoidable allocations: Default instances that are overwritten right away or double copying for collections. I've done the optimization for a very minor class that lacked the marker anyway - doing the same for major classes would be quite some fat diff... Interest?