### PR TITLE
Speedup wander() by moving only 1 tile

### DIFF
--- a/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
@@ -227,7 +227,7 @@ object UnitAutomation {
     }
 
     fun wander(unit: MapUnit, stayInTerritory: Boolean = false, tilesToAvoid: Set<Tile> = setOf()) {
-        val unitDistanceToTiles = unit.currentTile.getTilesInDistance(1)
+        val unitDistanceToTiles = unit.currentTile.getTilesAtDistance(1)
         // We could walk further, but wander() is meant to let units not stay on the same tile permanently,
         // to avoid obstructing human scouts and workers, moving just one tile should be enough
         val reachableTiles = unitDistanceToTiles


### PR DESCRIPTION
Wander() is a big chunk in the total unit automation: https://discord.com/channels/586194543280390151/586194543716859916/1443593173401206814.
PR is approximately 80% faster per invocation and saves 140 milliseconds on the t158 savefile on my device, at a cost of potentially not clearing all tiles in the same turn (which previously also might not happen due to wandering unit taking up the tile left by previous wandering unit).