### PR TITLE
Simplify target selection in chooseBombardTarget

### DIFF
--- a/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
@@ -621,8 +621,8 @@ object UnitAutomation {
     @Readonly
     private fun chooseBombardTarget(city: City): ICombatant? {
         val targets = TargetHelper.getBombardableTiles(city).map { Battle.getMapCombatantOfTile(it)!! }
-            .filterNot { it is MapUnitCombatant &&
-                it.isCivilian() && !it.unit.hasUnique(UniqueType.Uncapturable) } // Don't bombard capturable civilians
+            .filterNot { it is MapUnitCombatant && it.isCivilian() }
+            // Don't bombard civilians (they're more efficiently captured/killed by military units if they're indeed this close)
         if (targets.none()) return null
         return targets.maxByOrNull { BattleDamage.calculateDamageToDefender(CityCombatant(city), it) }
     }


### PR DESCRIPTION
Could be a slight improvement in strength according to https://discord.com/channels/586194543280390151/1306726293102006453/1444368585609707550, at least not a major regression. Is faster by on average 4315 nanoseconds each time it is invoked (tiny map, duel, King difficulty) (alternating order of measurements each turn).