### PR TITLE
Fixed "our" not displaying with non-named units in battle notifications

### DIFF
--- a/core/src/com/unciv/logic/battle/MapUnitCombatant.kt
+++ b/core/src/com/unciv/logic/battle/MapUnitCombatant.kt
@@ -27,9 +27,9 @@ class MapUnitCombatant(val unit: MapUnit) : ICombatant {
     override fun getNotificationDisplay(leadingText: String): String {
         val isUnitUnnamed = unit.instanceName.isNullOrEmpty()
         return if (isUnitUnnamed)
-            "[" + unit.name + "]"
+            leadingText + "[" + unit.name + "]"
         else
-            leadingText + "[" + unit.instanceName + "]"
+            "[" + unit.instanceName + "]"
     }
 
 


### PR DESCRIPTION
A small pull request. 
It turns out the previous code to add named units to battle notifications would not add the "our" in front of non named units like it was supposed to.
This change fixes that. 