### PR TITLE
Battle notification translation file fixed duplicites

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -1021,26 +1021,22 @@ Your citizens are revolting due to very high unhappiness! =
 Connect road cancelled! = 
 
 # Battle messages
-An enemy [unit] has attacked [cityName] ([amount2] HP) = 
-An enemy [unit] ([amount] HP) has attacked [cityName] ([amount2] HP) = 
+An enemy [unit] has attacked [cityName/ourNamedUnit] ([amount2] HP) = 
+An enemy [unit] ([amount] HP) has attacked [cityName/ourNamedUnit] ([amount2] HP) = 
 An enemy [unit] ([amount] HP) has [battleAction] our [ourUnit] ([amount2] HP) = 
 An enemy [unit] ([amount] HP) has [battleAction] [ourNamedUnit] ([amount2] HP) = 
 An enemy [unit] has attacked our [ourUnit] ([amount] HP) = 
-# An enemy [unit] has attacked [ourNamedUnit] ([amount] HP) = 
 An enemy [unit] ([amount] HP) has attacked our [ourUnit] ([amount2] HP) = 
-# An enemy [unit] ([amount] HP) has attacked [ourNamedUnit] ([amount2] HP) = 
 Enemy city [cityName] has attacked our [ourUnit] = 
 Enemy city [cityName] has attacked [ourNamedUnit] = 
 Enemy city [cityName] has attacked our [ourUnit] ([amount2] HP) = 
 Enemy city [cityName] has attacked [ourNamedUnit] ([amount2] HP) = 
-An enemy [unit] has captured [cityName] = 
-An enemy [unit] ([amount] HP) has captured [cityName] ([amount2] HP) = 
+An enemy [unit] has captured [cityName/ourNamedUnit] = 
+An enemy [unit] ([amount] HP) has captured [cityName/ourNamedUnit] ([amount2] HP) = 
 An enemy [unit] has raided [cityName] = 
 An enemy [unit] ([amount] HP) has raided [cityName] ([amount2] HP) = 
 An enemy [unit] has captured our [ourUnit] = 
-# An enemy [unit] has captured [ourNamedUnit] = 
 An enemy [unit] ([amount] HP) has captured our [ourUnit] ([amount2] HP) = 
-# An enemy [unit] ([amount] HP) has captured [ourNamedUnit] ([amount2] HP) = 
 An enemy [unit] has destroyed our [ourUnit] = 
 An enemy [unit] has destroyed [ourNamedUnit] = 
 An enemy [unit] ([amount] HP) has destroyed our [ourUnit] ([amount2] HP) = 
@@ -1055,12 +1051,10 @@ Enemy city [cityName] has destroyed our [ourUnit] =
 Enemy city [cityName] has destroyed [ourNamedUnit] = 
 Enemy city [cityName] ([amount] HP) has destroyed our [ourUnit] ([amount2] HP) = 
 Enemy city [cityName] ([amount] HP) has destroyed [ourNamedUnit] ([amount2] HP) = 
-An enemy [unit] was destroyed while attacking [cityName] = 
-An enemy [unit] ([amount] HP) was destroyed while attacking [cityName] ([amount2] HP) = 
+An enemy [unit] was destroyed while attacking [cityName/ourNamedUnit] = 
+An enemy [unit] ([amount] HP) was destroyed while attacking [cityName/ourNamedUnit] ([amount2] HP) = 
 An enemy [unit] was destroyed while attacking our [ourUnit] = 
-# An enemy [unit] was destroyed while attacking [ourNamedUnit] = 
 An enemy [unit] ([amount] HP) was destroyed while attacking our [ourUnit] ([amount2] HP) = 
-# An enemy [unit] ([amount] HP) was destroyed while attacking [ourNamedUnit] ([amount2] HP) = 
 
 # Interception messages
 Our [attackerName] ([amount] HP) was attacked by an intercepting [interceptorName] ([amount2] HP) = 


### PR DESCRIPTION
Makes the changes requested in #14310 regarding #14320.

Now I don't think this is the best way to go about solving something like this. Given the current system it might be the best available without adding any extra text to any of the translation keys.

Ideally translations would be able to take in context regarding the text and thus something like this would not be necessary or a concern.

I do apologies for any inconvenience this chain (#14242) of pull requests might have cause. But I do hope it should be over with this change.