### PR TITLE
Fix #14218 regression

### DIFF
--- a/android/assets/jsons/Civ V - Gods & Kings/Buildings.json
+++ b/android/assets/jsons/Civ V - Gods & Kings/Buildings.json
@@ -303,7 +303,7 @@
 		"replaces": "Temple",
 		"uniqueTo": "Egypt",
 		"maintenance": 0,
-		"uniques": ["[+100]% Gold given to enemy if city is captured"],
+		"uniques": ["[+100]% Gold given to enemy if city is captured <in this city>"],
 		"faith": 2,
 		"happiness": 2,
 		"requiredBuilding": "Shrine",

--- a/android/assets/jsons/Civ V - Vanilla/Buildings.json
+++ b/android/assets/jsons/Civ V - Vanilla/Buildings.json
@@ -275,7 +275,7 @@
 		"replaces": "Temple",
 		"uniqueTo": "Egypt",
 		"maintenance": 0,
-		"uniques": ["[+100]% Gold given to enemy if city is captured"],
+		"uniques": ["[+100]% Gold given to enemy if city is captured <in this city>"],
 		"culture": 2,
 		"happiness": 2,
 		"requiredBuilding": "Monument",

--- a/core/src/com/unciv/logic/city/managers/CityConquestFunctions.kt
+++ b/core/src/com/unciv/logic/city/managers/CityConquestFunctions.kt
@@ -36,17 +36,17 @@ class CityConquestFunctions(val city: City) {
         val baseGold = 20 + 10 * city.population.population + tileBasedRandom.nextInt(40)
         val turnModifier = max(0, min(50, city.civ.gameInfo.turns - city.turnAcquired)) / 50f
         var cityModifier = if (city.containsBuildingUnique(UniqueType.DoublesGoldFromCapturingCity)) 2f else 1f
-        
+
         for (unique in city.getMatchingUniques(UniqueType.GoldFromCapturingCity, city.state)) {
             cityModifier *= unique.params[0].toPercent()
         }
-        
+
         var conqueringCivModifier = if (conqueringCiv.hasUnique(UniqueType.TripleGoldFromEncampmentsAndCities)) 3f else 1f
-        
+
         for (unique in conqueringCiv.getMatchingUniques(UniqueType.GoldFromEncampmentsAndCities, conqueringCiv.state)) {
             conqueringCivModifier *= unique.params[0].toPercent()
         }
-        
+
         val goldPlundered = baseGold * turnModifier * cityModifier * conqueringCivModifier
         return goldPlundered.toInt()
     }
@@ -64,7 +64,7 @@ class CityConquestFunctions(val city: City) {
             }
         }
     }
-    
+
     private fun removeAutoPromotion() {
         city.unitShouldUseSavedPromotion = HashMap<String, Boolean>()
         city.unitToPromotions = HashMap<String, UnitPromotions>()
@@ -134,7 +134,7 @@ class CityConquestFunctions(val city: City) {
             // reconquering or liberating city in resistance so eliminate it
             city.removeFlag(CityFlags.Resistance)
         }
-        
+
         for (unique in conqueredCiv.getTriggeredUniques(UniqueType.TriggerUponLosingCity, GameContext(civInfo = conqueredCiv))) {
             UniqueTriggerActivation.triggerUnique(unique, civInfo = conqueredCiv)
         }
@@ -300,13 +300,13 @@ class CityConquestFunctions(val city: City) {
 
         // Remove their free buildings from this city and remove free buildings provided by the city from their cities
         removeBuildingsOnMoveToCiv()
-        
-        // Remove auto promotion from city that is being moved 
+
+        // Remove auto promotion from city that is being moved
         removeAutoPromotion()
 
         // catch-all - should ideally not happen as we catch the individual cases with an appropriate notification
-        city.espionage.removeAllPresentSpies(SpyFleeReason.Other) 
-        
+        city.espionage.removeAllPresentSpies(SpyFleeReason.Other)
+
 
         // Place palace for newCiv if this is the only city they have.
         if (newCiv.cities.size == 1) newCiv.moveCapitalTo(city, null)

--- a/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
+++ b/core/src/com/unciv/models/ruleset/unique/UniqueType.kt
@@ -346,7 +346,7 @@ enum class UniqueType(
     DestroyedWhenCityCaptured("Destroyed when the city is captured", UniqueTarget.Building),
     NotDestroyedWhenCityCaptured("Never destroyed when the city is captured", UniqueTarget.Building),
     GoldFromCapturingCity("[relativeAmount]% Gold given to enemy if city is captured", UniqueTarget.Building),
-    @Deprecated("As of 4.18.15", ReplaceWith("[+100]% Gold given to enemy if city is captured"), DeprecationLevel.WARNING)
+    @Deprecated("As of 4.18.15", ReplaceWith("[+100]% Gold given to enemy if city is captured <in this city>"), DeprecationLevel.WARNING)
     DoublesGoldFromCapturingCity("Doubles Gold given to enemy if city is captured", UniqueTarget.Building),
 
 

--- a/tests/src/com/unciv/logic/city/CityConquestFunctionsTest.kt
+++ b/tests/src/com/unciv/logic/city/CityConquestFunctionsTest.kt
@@ -3,6 +3,7 @@ package com.unciv.logic.city
 import com.unciv.logic.city.managers.CityConquestFunctions
 import com.unciv.logic.civilization.Civilization
 import com.unciv.logic.map.HexCoord
+import com.unciv.logic.map.HexMath
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.translations.fillPlaceholders
 import com.unciv.testing.GdxTestRunner
@@ -116,6 +117,36 @@ class CityConquestFunctionsTest {
         assertTrue(attackerCiv.gold < secondAttackerCiv.gold)
         assertTrue(attackerCiv.gold in 120 until 160) // Range for city size 10 and all modifiers 1
         assertTrue(secondAttackerCiv.gold in 240 until 320) // Doubled by Unique
+    }
+
+    @Test
+    fun `a Burial Tomb equivalent should only apply per city`() {
+        // A building is assumed to give empire-wide bonuses unless this conditional is applied
+        // See Unique.isLocalEffect
+        val uniqueTemplate = UniqueType.GoldFromCapturingCity.text + " <" + UniqueType.ConditionalInThisCity.text + ">"
+        // replace defender civ with one that has a Nation-wide 'bonus' multiplying plundered gold by 1.5
+        defenderCiv = testGame.addCiv(uniqueTemplate.fillPlaceholders("+50"))
+        // define building giving multiplier 2
+        val building = testGame.createBuilding(uniqueTemplate.fillPlaceholders("+100"))
+
+        // add six cities, each with that building (but we'll conquer only the last of them)
+        for (clockDirection in 2..12 step 2) {
+            val pos = HexMath.getClockPositionToHexcoord(clockDirection).times(3)
+            defenderCity = testGame.addCity(defenderCiv, testGame.getTile(pos), initialPopulation = 4)
+            defenderCity.cityConstructions.addBuilding(building.name)
+        }
+        cityConquestFunctions = CityConquestFunctions(defenderCity)
+
+        // given
+        testGame.gameInfo.turns = 50 // turnModifier = 1
+        val baseGold = 60 until 100 // for city size 4
+        val expected = baseGold.first * 3 .. baseGold.last * 3 // expected modifiers: 2 * 1.5
+
+        // when
+        cityConquestFunctions.puppetCity(attackerCiv)
+
+        // then
+        assertTrue("plundered gold should be in range $expected, actual=${attackerCiv.gold}", attackerCiv.gold in expected)
     }
 
     @Test


### PR DESCRIPTION
#14218 causes this:

<img width="601" height="55" alt="rich" src="https://github.com/user-attachments/assets/85e745d2-e5dc-4dea-bd47-f440b32ef310" />
<img width="1751" height="47" alt="debug" src="https://github.com/user-attachments/assets/65472165-dc6a-4b22-8007-8327d7412877" />

... because each Burial Tomb is assumed to be civ-wide. I really was surprised that the default assumption is global... But it is:
https://github.com/yairm210/Unciv/blob/de12183c53b4618b0348d1c58ecdf6a94dfaec9e/core/src/com/unciv/models/ruleset/unique/Unique.kt#L45
