### PR TITLE
Remove pillaged status from getBasePriority in worker automation

### DIFF
--- a/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
@@ -279,7 +279,6 @@ class WorkerAutomation(
         if (tile.getOwner() == civInfo) {
             priority += Automation.rankStatsValue(tile.stats.getTerrainStatsBreakdown().toStats(), civInfo)
             if (tile.providesYield()) priority += 2
-            if (tile.isPillaged()) priority += 1
             if (tile.hasFalloutEquivalent()) priority += 1
             if (tile.terrainFeatures.isNotEmpty()) {
                 if (tile.lastTerrain.hasUnique(UniqueType.ProductionBonusWhenRemoved)) priority += 0.5f 


### PR DESCRIPTION
https://discord.com/channels/586194543280390151/1306726293102006453/1448259591908622498