### PR TITLE
civilopedia: Add Technologies that provide Resources

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -1694,6 +1694,7 @@ Bonus stats for improvement =
 Buildings that consume this resource = 
 Buildings that provide this resource = 
 Improvements that provide this resource = 
+Technologies that provide this resource = 
 Buildings that require this resource improved near the city = 
 Units that consume this resource = 
 Can be built on = 

--- a/core/src/com/unciv/ui/objectdescriptions/ResourceDescriptions.kt
+++ b/core/src/com/unciv/ui/objectdescriptions/ResourceDescriptions.kt
@@ -74,6 +74,20 @@ object ResourceDescriptions {
             }
         }
 
+        val technologiesThatProvideThis = ruleset.technologies.values
+            .filter { technology ->
+                technology.uniqueObjects.any { unique ->
+                    unique.type == UniqueType.ProvidesResources && unique.params[1] == resource.name
+                }
+            }
+        if (technologiesThatProvideThis.isNotEmpty()) {
+            textList += FormattedLine()
+            textList += FormattedLine("{Technologies that provide this resource}:")
+            technologiesThatProvideThis.forEach {
+                textList += FormattedLine(it.name, link = it.makeLink(), indent = 1)
+            }
+        }
+
         val buildingsThatConsumeThis = ruleset.buildings.values.filter { it.getResourceRequirementsPerTurn(
             GameContext.IgnoreConditionals).containsKey(resource.name) }
         if (buildingsThatConsumeThis.isNotEmpty()) {


### PR DESCRIPTION
This updates the Civilopedia to list out Technologies that provide a given Resource.

### Use Case

In BNW, Trade Routes are provided by certain Technologies. This allows the civilopedia to list them.

<img width="716" height="1192" alt="Screenshot from 2025-12-10 13-43-02" src="https://github.com/user-attachments/assets/97967f29-2deb-49cf-9292-0a1dc88f5461" />

