### PR TITLE
Fix crash on reloading/cloning a game that has already ended

### DIFF
--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -86,7 +86,6 @@ data class VictoryData(
     }
     @Transient
     lateinit var winningCivObject: Civilization
-        private set
 }
 
 /** The virtual world the users play in */
@@ -644,6 +643,7 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
             throw MissingModsException(missingMods)
 
         removeMissingModReferences()
+        victoryData?.also { it.winningCivObject = getCivilization(it.winningCiv) }
 
         for (baseUnit in ruleset.units.values)
             baseUnit.setRuleset(ruleset)


### PR DESCRIPTION
Before you say anything, I found this bug before it got reported. And everything else in that PR either replaces one string with another (which is currently identical either we use ``civID``) or only affects initialization (which means it should've been reported already and/or failed tests)