### PR TITLE
Harden mod manager against invalid local preview files

### DIFF
--- a/core/src/com/unciv/ui/screens/modmanager/ModInfoAndActionPane.kt
+++ b/core/src/com/unciv/ui/screens/modmanager/ModInfoAndActionPane.kt
@@ -5,6 +5,7 @@ import com.badlogic.gdx.graphics.Texture
 import com.badlogic.gdx.scenes.scene2d.ui.Image
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton
+import com.badlogic.gdx.utils.GdxRuntimeException
 import com.unciv.UncivGame
 import com.unciv.logic.github.Github
 import com.unciv.logic.github.GithubAPI
@@ -22,6 +23,8 @@ import com.unciv.ui.components.input.onRightClick
 import com.unciv.ui.popups.ToastPopup
 import com.unciv.ui.screens.modmanager.ModManagementScreen.Companion.cleanModName
 import com.unciv.utils.Concurrency
+import com.unciv.utils.Log
+import java.io.IOException
 import kotlin.math.max
 
 internal class ModInfoAndActionPane : Table() {
@@ -168,7 +171,13 @@ internal class ModInfoAndActionPane : Table() {
         val previewFile = modFolder.child("preview.jpg").takeIf { it.exists() }
             ?: modFolder.child("preview.png").takeIf { it.exists() }
             ?: return
-        setTextureAsPreview(Texture(previewFile), modName)
+        try {
+            setTextureAsPreview(Texture(previewFile), modName)
+        } catch (ex: Throwable) {
+            val cause = if (ex is GdxRuntimeException) ex.cause else ex
+            Log.debug("Could not load local preview file %s: %s", previewFile.path(), cause)
+            if (cause is IOException) previewFile.delete() // File content invalid and not loadable as pixmap gives this
+        }
     }
 
     private fun addUncivLogo(modName: String) {


### PR DESCRIPTION
I just happened to have a truncated png in a local old copy of "Civ6 mod" - wouldn't do that one can't even delete the offender when Unciv crashes before the delete button is shown...