### PR TITLE
Distance-based unit cycle order with opt-in

### DIFF
--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -877,6 +877,7 @@ Gameplay =
 Check for idle units = 
 'Next unit' button cycles idle units = 
 Auto Unit Cycle = 
+Alternate Unit cycle order = 
 Show Small Skip/Cycle Unit Button = 
 Move units with a single tap = 
 Move units with a long tap = 

--- a/core/src/com/unciv/models/metadata/GameSettings.kt
+++ b/core/src/com/unciv/models/metadata/GameSettings.kt
@@ -141,6 +141,9 @@ class GameSettings {
     /** Size of automatic display of UnitSet art in Civilopedia - 0 to disable */
     var pediaUnitArtSize = 0f
 
+    /** Cycle units by distance instead of queue */
+    var alternateUnitCycleOrder: Boolean = false
+
     /** Don't close developer console after a successful command */
     var keepConsoleOpen = false
     /** Persist the history of successful developer console commands */

--- a/core/src/com/unciv/ui/popups/options/GameplayTab.kt
+++ b/core/src/com/unciv/ui/popups/options/GameplayTab.kt
@@ -18,6 +18,7 @@ fun gameplayTab(
     optionsPopup.addCheckbox(this, "'Next unit' button cycles idle units", settings.checkForDueUnitsCycles, true) { settings.checkForDueUnitsCycles = it }
     optionsPopup.addCheckbox(this, "Show Small Skip/Cycle Unit Button", settings.smallUnitButton, true) { settings.smallUnitButton = it }
     optionsPopup.addCheckbox(this, "Auto Unit Cycle", settings.autoUnitCycle, true) { settings.autoUnitCycle = it }
+    optionsPopup.addCheckbox(this, "Alternate Unit cycle order", settings.alternateUnitCycleOrder, true) { settings.alternateUnitCycleOrder = it }
     optionsPopup.addCheckbox(this, "Move units with a single tap", settings.singleTapMove) { settings.singleTapMove = it }
     optionsPopup.addCheckbox(this, "Move units with a long tap", settings.longTapMove) { settings.longTapMove = it }
     optionsPopup.addCheckbox(this, "Order trade offers by amount", settings.orderTradeOffersByAmount) { settings.orderTradeOffersByAmount = it }


### PR DESCRIPTION
I was so annoyed with the jumpy, "jerk my view away from where the action is", cycle order I decided to try something else - and it's **so** much less headache-inducing. Can't really demo, but - example: A Worker is due, and for optimum use you have to move another, which is currently constructing, away a tile before you move your candidate... On master, you can't use the space key after step 1, it will violently yank you away to the other side of the world. With this, you're practically guaranteed to re-select your 'candidate'.

Implementation is brute-force. One might try building a spatial index for all due units per turn, maybe along the KDTree version on https://github.com/Harium (the kotlin ones I found were incomplete or unreadable), but - nah, overkill. You won't notice any delays. Plus those algorithms won't support world-wrap easily.