### PR TITLE
Reorder resource revealed notification locations

### DIFF
--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -548,7 +548,7 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
         if (!civ.tech.isRevealed(resource)) {
             return null
         }
-        
+
         data class CityTileAndDistance(val city: City, val tile: Tile, val distance: Int)
 
         // Include your city-state allies' cities with your own for the purpose of showing the closest city
@@ -584,7 +584,8 @@ class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion 
                     }
             }
             .filter { it.distance <= maxDistance && filter(it.tile) }
-            .sortedWith(compareBy { it.distance })
+            // We still want to report tiles on our own territory before those of our cs-allies
+            .sortedWith(compareBy<CityTileAndDistance> { it.city.civ != civ }.thenBy { it.distance })
             .distinctBy { it.tile }
 
         val chosenCity = exploredRevealInfo.firstOrNull()?.city


### PR DESCRIPTION
…to prefer your own territory over city-state allies

I mentioned I had the impression of a regression - nope, misremembered. I still had some cases where the "new sources of X revealed" notification showed an allied city-state on the other side of the world before my own sources, just because the cs was sitting on it while mine were two tiles from the next city... This changes that.

**Big question**
Every time I look into `GameInfo` I am sorely tempted to refactor it (too big, non-state-changing fun in the state-changing region):
a) Split the satellite classes off, including `IsPartOfGameInfoSerialization` - even if that file would be 99.9% comment.
b) Split the more specialized helper methods off - not clone or setTransients, but nextTurn with all the notification helpers. Some delegation or other magic might be needed to make that terse.

So - yes please or oh my god don't? And if yes - subpackage (meaning touching 39 imports and big conflict potential with other PR's)?

<details><summary>How splitting GameInfo might look like</summary>

... without moving to a subpackage ...
```patch
Subject: [PATCH] Refactor: Split GameInfo.kt
---
Index: core/src/com/unciv/logic/VictoryData.kt
===================================================================
diff --git a/core/src/com/unciv/logic/VictoryData.kt b/core/src/com/unciv/logic/VictoryData.kt
new file mode 100644
--- /dev/null	(date 1765910019705)
+++ b/core/src/com/unciv/logic/VictoryData.kt	(date 1765910019705)
@@ -0,0 +1,17 @@
+package com.unciv.logic
+
+import com.unciv.logic.civilization.Civilization
+
+data class VictoryData(
+    val winningCiv: String,
+    val victoryType: String,
+    val victoryTurn: Int
+) : IsPartOfGameInfoSerialization {
+    @Suppress("unused")  // used by json serialization
+    constructor() : this("", "", 0)
+    constructor(winningCiv: Civilization, victoryType: String, victoryTurn: Int) : this(winningCiv.civID, victoryType, victoryTurn) {
+        this.winningCivObject = winningCiv
+    }
+    @Transient
+    lateinit var winningCivObject: Civilization
+}
Index: core/src/com/unciv/logic/IsPartOfGameInfoSerialization.kt
===================================================================
diff --git a/core/src/com/unciv/logic/IsPartOfGameInfoSerialization.kt b/core/src/com/unciv/logic/IsPartOfGameInfoSerialization.kt
new file mode 100644
--- /dev/null	(date 1765910059078)
+++ b/core/src/com/unciv/logic/IsPartOfGameInfoSerialization.kt	(date 1765910059078)
@@ -0,0 +1,32 @@
+package com.unciv.logic
+
+/**
+ * A class that implements this interface is part of [GameInfo] serialization, i.e. save files.
+ *
+ * ### Clarification: *only* for classes that are serialized and deserialized - *not* pure Ruleset files.
+ *
+ * #### Compatibility:
+ * When you change the structure of any class with this interface in a way which makes it impossible
+ * to load the new saves from an older game version, increment [CompatibilityVersion.CURRENT_COMPATIBILITY_NUMBER]!
+ * And don't forget to add backwards compatibility for the previous format.
+ *
+ * #### Rules:
+ * - Enum classes are always serialized like primitives, any additional fields are ignored. Therefore marking them makes no technical sense, but the unit test tolerates it.
+ * - If the class also implements Json.Serializable, then the rules below do not apply, that implementation is entirely responsible.
+ * - Exclude all fields that do not need to be saved with [`@Transient`][Transient].
+ * - Take care with `by lazy` fields - those must **never** be serialized. Use `@delegate:Transient` to exclude them.
+ * - Properties without backing field (val foo get() = without referencing `field` or `val bar by ::foo`) are always fine - they're never serialized.
+ * - Types of serialized fields must be primitives, enums, other classes marked `IsPartOfGameInfoSerialization`, or collections of those.
+ * - All types involved in a field's type should be **non-abstract**: No interfaces. The `List`, see below.
+ * - Keys in Maps must be String. Sets are fine even though they are a Map internally.
+ * - Do not serialize any `Sequence` - should be obvious!
+ *
+ * #### Explanation for the non-abstract rule
+ * Reminder: In all subclasses, do use only actual Collection types, not abstractions like
+ * `= mutableSetOf<Something>()`. That would make the reflection type of the field an interface, which
+ * hides the actual implementation from Gdx Json, so it will not try to call a no-args constructor but
+ * will instead deserialize a List in the jsonData.isArray() -> isAssignableFrom(Collection) branch of readValue:
+ * https://github.com/libgdx/libgdx/blob/75612dae1eeddc9611ed62366858ff1d0ac7898b/gdx/src/com/badlogic/gdx/utils/Json.java#L1111
+ * .. which will crash later (when readFields actually assigns it) - unless the interface actually was `List`.
+ */
+interface IsPartOfGameInfoSerialization
Index: core/src/com/unciv/logic/GameInfoNextTurn.kt
===================================================================
diff --git a/core/src/com/unciv/logic/GameInfoNextTurn.kt b/core/src/com/unciv/logic/GameInfoNextTurn.kt
new file mode 100644
--- /dev/null	(date 1765909880904)
+++ b/core/src/com/unciv/logic/GameInfoNextTurn.kt	(date 1765909880904)
@@ -0,0 +1,286 @@
+package com.unciv.logic
+
+import com.badlogic.gdx.Gdx
+import com.unciv.UncivGame
+import com.unciv.logic.city.City
+import com.unciv.logic.civilization.Civilization
+import com.unciv.logic.civilization.LocationAction
+import com.unciv.logic.civilization.MapUnitAction
+import com.unciv.logic.civilization.Notification
+import com.unciv.logic.civilization.NotificationCategory
+import com.unciv.logic.civilization.NotificationIcon
+import com.unciv.logic.civilization.managers.TurnManager
+import com.unciv.logic.map.tile.Tile
+import com.unciv.models.ruleset.unique.UniqueType
+import com.unciv.ui.audio.MusicMood
+import com.unciv.ui.audio.MusicTrackChooserFlags
+import com.unciv.ui.screens.worldscreen.status.NextTurnProgress
+import com.unciv.utils.DebugUtils
+import com.unciv.utils.debug
+import yairm210.purity.annotations.Readonly
+
+
+class GameInfoNextTurn(private val gameInfo: GameInfo) {
+    val ruleset by gameInfo::ruleset
+    val civilizations by gameInfo::civilizations
+    var currentPlayer by gameInfo::currentPlayer
+    var currentPlayerCiv by gameInfo::currentPlayerCiv
+    var turns by gameInfo::turns
+    val gameParameters by gameInfo::gameParameters
+    val tileMap by gameInfo::tileMap
+    var simulateUntilWin by gameInfo::simulateUntilWin
+
+    fun nextTurn(progressBar: NextTurnProgress? = null) {
+        var player = currentPlayerCiv
+        var playerIndex = civilizations.indexOf(player)
+
+        // We rotate Players in cycle: 1,2...N,1,2...
+        fun setNextPlayer() {
+            playerIndex = (playerIndex + 1) % civilizations.size
+            if (playerIndex == 0) {
+                turns++
+                if (DebugUtils.SIMULATE_UNTIL_TURN != 0)
+                    debug("Starting simulation of turn %s", turns)
+            }
+            player = civilizations[playerIndex]
+        }
+
+
+        // Ending current player's turn
+        //  (Check is important or else switchTurn
+        //  would skip a turn if an AI civ calls nextTurn
+        //  this happens when resigning a multiplayer game)
+        if (player.isHuman()) {
+            TurnManager(player).endTurn(progressBar)
+            setNextPlayer()
+        }
+
+
+        val isOnline = gameParameters.isOnlineMultiplayer
+
+        // Skip the player if we are playing hotseat
+        // If all hotseat players are defeated then skip all but the first one
+        @Readonly
+        fun shouldAutoProcessHotseatPlayer(): Boolean =
+            !isOnline &&
+                player.isDefeated() && (civilizations.any { it.isHuman() && it.isAlive() }
+                || civilizations.first { it.isHuman() } != player)
+
+        // Skip all spectators and defeated players
+        // If all players are defeated then let the first player control next turn
+        @Readonly
+        fun shouldAutoProcessOnlinePlayer(): Boolean =
+            isOnline && (player.isSpectator() || player.isDefeated() &&
+                (civilizations.any { it.isHuman() && it.isAlive() }
+                    || civilizations.first { it.isHuman() } != player))
+
+        // We process player automatically if:
+        while (gameInfo.isSimulation() ||                    // simulation is active
+            player.isAI() ||                    // or player is AI
+            shouldAutoProcessHotseatPlayer() ||     // or a player is defeated in hotseat
+            shouldAutoProcessOnlinePlayer())        // or player is online spectator
+        {
+
+            // Starting preparations
+            TurnManager(player).startTurn(progressBar)
+
+            // Automation done here
+            TurnManager(player).automateTurn()
+
+            val worldScreen = UncivGame.Current.worldScreen
+            // Do we need to break if player won?
+            if (simulateUntilWin && player.victoryManager.hasWon()) {
+                simulateUntilWin = false
+                worldScreen?.autoPlay?.stopAutoPlay()
+                break
+            }
+
+            // Do we need to stop AutoPlay?
+            if (worldScreen != null && worldScreen.autoPlay.isAutoPlaying() && player.victoryManager.hasWon() && !gameInfo.oneMoreTurnMode)
+                worldScreen.autoPlay.stopAutoPlay()
+
+            // Clean up
+            TurnManager(player).endTurn(progressBar)
+
+            // To the next player
+            setNextPlayer()
+        }
+
+        if (turns == DebugUtils.SIMULATE_UNTIL_TURN)
+            DebugUtils.SIMULATE_UNTIL_TURN = 0
+
+        // We found a human player, so we are making them current
+        gameInfo.currentTurnStartTime = System.currentTimeMillis()
+        currentPlayer = player.civID
+        currentPlayerCiv = player
+
+        // Starting their turn
+        TurnManager(player).startTurn(progressBar)
+
+        // No popups for spectators
+        if (currentPlayerCiv.isSpectator())
+            currentPlayerCiv.popupAlerts.clear()
+
+        // Play some nice music TODO: measuring actual play time might be nicer
+        if (turns % 10 == 0 && Gdx.app != null)
+            UncivGame.Current.musicController.chooseTrack(
+                currentPlayerCiv.civName,
+                MusicMood.peaceOrWar(currentPlayerCiv.isAtWar()), MusicTrackChooserFlags.setNextTurn
+            )
+
+        // Start our turn immediately before the player can make decisions - affects
+        // whether our units can commit automated actions and then be attacked immediately etc.
+        notifyOfCloseEnemyUnits(player)
+    }
+
+    private fun notifyOfCloseEnemyUnits(thisPlayer: Civilization) {
+        val viewableInvisibleTiles = thisPlayer.viewableInvisibleUnitsTiles.map { it.position }
+        val enemyUnitsCloseToTerritory = thisPlayer.viewableTiles
+            .filter {
+                it.militaryUnit != null && it.militaryUnit!!.civ != thisPlayer
+                    && thisPlayer.isAtWarWith(it.militaryUnit!!.civ)
+                    && (it.getOwner() == thisPlayer || it.neighbors.any { neighbor -> neighbor.getOwner() == thisPlayer }
+                    && (!it.militaryUnit!!.isInvisible(thisPlayer) || viewableInvisibleTiles.contains(it.position)))
+            }
+
+        // enemy units IN our territory
+        addEnemyUnitNotification(
+            thisPlayer,
+            enemyUnitsCloseToTerritory.filter { it.getOwner() == thisPlayer },
+            "in"
+        )
+        // enemy units NEAR our territory
+        addEnemyUnitNotification(
+            thisPlayer,
+            enemyUnitsCloseToTerritory.filter { it.getOwner() != thisPlayer },
+            "near"
+        )
+
+        addBombardNotification(
+            thisPlayer,
+            thisPlayer.cities.filter { city ->
+                city.canBombard() &&
+                    enemyUnitsCloseToTerritory.any { tile -> tile.aerialDistanceTo(city.getCenterTile()) <= city.getBombardRange() }
+            }
+        )
+    }
+
+    private fun addEnemyUnitNotification(thisPlayer: Civilization, tiles: List<Tile>, inOrNear: String) {
+        // don't flood the player with similar messages. instead cycle through units by clicking the message multiple times.
+        if (tiles.size < 3) {
+            for (tile in tiles) {
+                val unitName = tile.militaryUnit!!.name
+                thisPlayer.addNotification("An enemy [$unitName] was spotted $inOrNear our territory", tile.position, NotificationCategory.War, NotificationIcon.War, unitName)
+            }
+        } else {
+            val positions = tiles.asSequence().map { it.position }
+            thisPlayer.addNotification("[${tiles.size}] enemy units were spotted $inOrNear our territory",
+                LocationAction.Companion(positions.map { it }), NotificationCategory.War, NotificationIcon.War)
+        }
+    }
+
+    private fun addBombardNotification(thisPlayer: Civilization, cities: List<City>) {
+        if (cities.size < 3) {
+            for (city in cities)
+                thisPlayer.addNotification("Your city [${city.name}] can bombard the enemy!",
+                    MapUnitAction(city.location), NotificationCategory.War, NotificationIcon.City, NotificationIcon.Crosshair)
+        } else {
+            val notificationActions = cities.asSequence().map { MapUnitAction(it.location) }
+            thisPlayer.addNotification("[${cities.size}] of your cities can bombard the enemy!", notificationActions,  NotificationCategory.War, NotificationIcon.City, NotificationIcon.Crosshair)
+        }
+    }
+
+    /** Generate and show a notification pointing out resources.
+     *  Used by [addTechnology][com.unciv.logic.civilization.managers.TechManager.addTechnology] and [ResourcesOverviewTab][com.unciv.ui.screens.overviewscreen.ResourcesOverviewTab]
+     * @param maxDistance from next City, 0 removes distance limitation.
+     * @param filter optional tile filter predicate, e.g. to exclude foreign territory.
+     * @return `false` if no resources were found and no notification was added.
+     * @see getExploredResourcesNotification
+     */
+    fun notifyExploredResources(
+        civInfo: Civilization,
+        resourceName: String,
+        maxDistance: Int
+    ): Boolean {
+        val notification = getExploredResourcesNotification(civInfo, resourceName, maxDistance)
+            ?: return false
+        civInfo.notifications.add(notification)
+        return true
+    }
+
+    /** Generate a notification pointing out resources. Only researched Resources are considered.
+     * @param maxDistance from next City, default removes distance limitation.
+     * @param filter optional tile filter predicate, e.g. to exclude foreign territory.
+     * @return `null` if no resources were found, otherwise a Notification instance.
+     * @see notifyExploredResources
+     */
+    fun getExploredResourcesNotification(
+        civ: Civilization,
+        resourceName: String,
+        maxDistance: Int,
+        filter: (Tile) -> Boolean = { true }
+    ): Notification? {
+
+        val resource = ruleset.tileResources[resourceName] ?: return null
+        if (!civ.tech.isRevealed(resource)) {
+            return null
+        }
+
+        data class CityTileAndDistance(val city: City, val tile: Tile, val distance: Int)
+
+        // Include your city-state allies' cities with your own for the purpose of showing the closest city
+        val relevantCities: Sequence<City> = civ.cities.asSequence() +
+            civ.getKnownCivs()
+                .filter { it.isCityState && it.allyCiv == civ }
+                .flatMap { it.cities }
+
+        // All sources of the resource on the map, using a city-state's capital center tile for the CityStateOnlyResource types
+        val exploredRevealTiles: Sequence<Tile> =
+            if (ruleset.tileResources[resourceName]!!.hasUnique(UniqueType.CityStateOnlyResource)) {
+                // Look for matching mercantile CS centers
+                gameInfo.getAliveCityStates()
+                    .asSequence()
+                    .filter { it.cityStateResource == resourceName }
+                    .map { it.getCapital()!!.getCenterTile() }
+            } else {
+                tileMap.values
+                    .asSequence()
+                    .filter { it.resource == resourceName }
+            }
+
+        // Apply all filters to the above collection and sort them by distance to closest city
+        val exploredRevealInfo = exploredRevealTiles
+            .filter { civ.hasExplored(it) }
+            .flatMap { tile ->
+                relevantCities
+                    .map { city ->
+                        // build a full cross join all revealed tiles * civ's cities (should rarely surpass a few hundred)
+                        // cache distance for each pair as sort will call it ~ 2n log n times
+                        // should still be cheaper than looking up 'the' closest city per reveal tile before sorting
+                        CityTileAndDistance(city, tile, tile.aerialDistanceTo(city.getCenterTile()))
+                    }
+            }
+            .filter { it.distance <= maxDistance && filter(it.tile) }
+            // We still want to report tiles on our own territory before those of our cs-allies
+            .sortedWith(compareBy<CityTileAndDistance> { it.city.civ != civ }.thenBy { it.distance })
+            .distinctBy { it.tile }
+
+        val chosenCity = exploredRevealInfo.firstOrNull()?.city
+            ?: return null
+        val positions = exploredRevealInfo
+            // re-sort to a more pleasant display order
+            .sortedWith(compareBy { it.tile.aerialDistanceTo(chosenCity.getCenterTile()) })
+            .map { it.tile.position }
+
+        val positionsCount = positions.count()
+        val text = if (positionsCount == 1)
+            "[$resourceName] revealed near [${chosenCity.name}]"
+        else
+            "[$positionsCount] sources of [$resourceName] revealed, e.g. near [${chosenCity.name}]"
+
+        return Notification(
+            text, arrayOf("ResourceIcons/$resourceName"),
+            LocationAction.Companion(positions.map { it }).asIterable(), NotificationCategory.General
+        )
+    }
+}
Index: core/src/com/unciv/logic/GameInfoPreview.kt
===================================================================
diff --git a/core/src/com/unciv/logic/GameInfoPreview.kt b/core/src/com/unciv/logic/GameInfoPreview.kt
new file mode 100644
--- /dev/null	(date 1765910019781)
+++ b/core/src/com/unciv/logic/GameInfoPreview.kt	(date 1765910019781)
@@ -0,0 +1,40 @@
+package com.unciv.logic
+
+import com.unciv.logic.civilization.CivilizationInfoPreview
+import com.unciv.models.metadata.GameParameters
+import yairm210.purity.annotations.Readonly
+
+/**
+ * Reduced variant of [GameInfo] used for load preview and multiplayer saves.
+ * Contains additional data for multiplayer settings.
+ */
+class GameInfoPreview() {
+    var civilizations = mutableListOf<CivilizationInfoPreview>()
+    var difficulty = "Chieftain"
+    var gameParameters = GameParameters()
+    var turns = 0
+    var gameId = ""
+    var currentPlayer = ""
+    var currentTurnStartTime = 0L
+
+    /**
+     * Converts a GameInfo object (can be uninitialized) into a GameInfoPreview object.
+     * Sets all multiplayer settings to default.
+     */
+    constructor(gameInfo: GameInfo) : this() {
+        civilizations = gameInfo.getCivilizationsAsPreviews()
+        difficulty = gameInfo.difficulty
+        gameParameters = gameInfo.gameParameters
+        turns = gameInfo.turns
+        gameId = gameInfo.gameId
+        currentPlayer = gameInfo.currentPlayer
+        currentTurnStartTime = gameInfo.currentTurnStartTime
+    }
+
+    @Readonly
+    fun getCivilization(civID: String) = civilizations.first { it.civID == civID }
+    @Readonly
+    fun getCurrentPlayerCiv() = getCivilization(currentPlayer)
+    @Readonly
+    fun getPlayerCiv(playerId: String) = civilizations.firstOrNull { it.playerId == playerId }
+}
Index: core/src/com/unciv/logic/GameInfo.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/core/src/com/unciv/logic/GameInfo.kt b/core/src/com/unciv/logic/GameInfo.kt
--- a/core/src/com/unciv/logic/GameInfo.kt	(revision d398fca489c873534d91703bb789e6cff8fe7cf4)
+++ b/core/src/com/unciv/logic/GameInfo.kt	(date 1765910281625)
@@ -1,6 +1,5 @@
 package com.unciv.logic
 
-import com.badlogic.gdx.Gdx
 import com.unciv.Constants
 import com.unciv.GUI
 import com.unciv.UncivGame
@@ -12,9 +11,7 @@
 import com.unciv.logic.BackwardCompatibility.migrateToTileHistory
 import com.unciv.logic.BackwardCompatibility.removeMissingModReferences
 import com.unciv.logic.automation.civilization.BarbarianManager
-import com.unciv.logic.city.City
 import com.unciv.logic.civilization.*
-import com.unciv.logic.civilization.managers.TechManager
 import com.unciv.logic.civilization.managers.TurnManager
 import com.unciv.logic.civilization.managers.VictoryManager
 import com.unciv.logic.github.Github.repoNameToFolderName
@@ -31,62 +28,14 @@
 import com.unciv.models.ruleset.unique.LocalUniqueCache
 import com.unciv.models.ruleset.unique.UniqueType
 import com.unciv.models.translations.tr
-import com.unciv.ui.audio.MusicMood
-import com.unciv.ui.audio.MusicTrackChooserFlags
 import com.unciv.ui.screens.savescreens.Gzip
 import com.unciv.ui.screens.worldscreen.status.NextTurnProgress
 import com.unciv.utils.DebugUtils
-import com.unciv.utils.debug
 import yairm210.purity.annotations.Readonly
 import java.security.MessageDigest
 import java.util.*
-
+import yairm210.purity.annotations.LocalState
 
-/**
- * A class that implements this interface is part of [GameInfo] serialization, i.e. save files.
- *
- * ### Clarification: *only* for classes that are serialized and deserialized - *not* pure Ruleset files.
- *
- * #### Compatibility:
- * When you change the structure of any class with this interface in a way which makes it impossible
- * to load the new saves from an older game version, increment [CompatibilityVersion.CURRENT_COMPATIBILITY_NUMBER]!
- * And don't forget to add backwards compatibility for the previous format.
- *
- * #### Rules:
- * - Enum classes are always serialized like primitives, any additional fields are ignored. Therefore marking them makes no technical sense, but the unit test tolerates it.
- * - If the class also implements Json.Serializable, then the rules below do not apply, that implementation is entirely responsible.
- * - Exclude all fields that do not need to be saved with [`@Transient`][Transient].
- * - Take care with `by lazy` fields - those must **never** be serialized. Use `@delegate:Transient` to exclude them.
- * - Properties without backing field (val foo get() = without referencing `field` or `val bar by ::foo`) are always fine - they're never serialized.
- * - Types of serialized fields must be primitives, enums, other classes marked `IsPartOfGameInfoSerialization`, or collections of those.
- * - All types involved in a field's type should be **non-abstract**: No interfaces. The `List`, see below.
- * - Keys in Maps must be String. Sets are fine even though they are a Map internally.
- * - Do not serialize any `Sequence` - should be obvious!
- *
- * #### Explanation for the non-abstract rule
- * Reminder: In all subclasses, do use only actual Collection types, not abstractions like
- * `= mutableSetOf<Something>()`. That would make the reflection type of the field an interface, which
- * hides the actual implementation from Gdx Json, so it will not try to call a no-args constructor but
- * will instead deserialize a List in the jsonData.isArray() -> isAssignableFrom(Collection) branch of readValue:
- * https://github.com/libgdx/libgdx/blob/75612dae1eeddc9611ed62366858ff1d0ac7898b/gdx/src/com/badlogic/gdx/utils/Json.java#L1111
- * .. which will crash later (when readFields actually assigns it) - unless the interface actually was `List`.
- */
-interface IsPartOfGameInfoSerialization
-
-
-data class VictoryData(
-    val winningCiv: String,
-    val victoryType: String,
-    val victoryTurn: Int
-) : IsPartOfGameInfoSerialization {
-    @Suppress("unused")  // used by json serialization
-    constructor() : this("", "", 0)
-    constructor(winningCiv: Civilization, victoryType: String, victoryTurn: Int) : this(winningCiv.civID, victoryType, victoryTurn) {
-        this.winningCivObject = winningCiv
-    }
-    @Transient
-    lateinit var winningCivObject: Civilization
-}
 
 /** The virtual world the users play in */
 class GameInfo : IsPartOfGameInfoSerialization, HasGameInfoSerializationVersion {
@@ -159,6 +108,9 @@
     @Transient
     lateinit var ruleset: Ruleset
 
+    @delegate:Transient
+    val civMap by lazy { civilizations.associateBy { it.civID } }
+
     /** Simulate until any player wins,
      *  or turns exceeds indicated number
      *  Does not update World View until finished.
@@ -219,8 +171,6 @@
         }
     }
 
-    @delegate:Transient
-    val civMap by lazy { civilizations.associateBy { it.civID } }
     /** Get a civ by name
      *  @throws NoSuchElementException if no civ of that name is in the game (alive or dead)! */
     @Readonly
@@ -231,8 +181,10 @@
     fun getCivilizationOrNull(civID: String) = civMap[civID]
         ?: civilizations.firstOrNull { it.civID == civID }
 
+    @Readonly
     fun getCurrentPlayerCivilization() = currentPlayerCiv
     fun getCivilizationsAsPreviews() = civilizations.map { it.asPreview() }.toMutableList()
+
     /** Get barbarian civ
      *  @throws NoSuchElementException in no-barbarians games! */
     @Readonly fun getBarbarianCivilization() = getCivilization(Constants.barbarians)
@@ -275,13 +227,42 @@
             )
     }
 
+    @Readonly
+    fun isReligionEnabled(): Boolean {
+        if (ruleset.eras[gameParameters.startingEra]!!.hasUnique(UniqueType.DisablesReligion)) return false
+        if (ruleset.modOptions.hasUnique(UniqueType.DisableReligion)) return false
+        return true
+    }
+
+    @Readonly fun isEspionageEnabled(): Boolean = gameParameters.espionageEnabled
+
+    @Readonly
+    private fun getEquivalentTurn(): Int {
+        val totalTurns = speed.numTotalTurns()
+        val startPercent = ruleset.eras[gameParameters.startingEra]!!.startPercent
+        return turns + (totalTurns * startPercent / 100)
+    }
+
+    @Readonly fun getYear(turnOffset: Int = 0) = speed.turnToYear(getEquivalentTurn() + turnOffset).toInt()
+
+    // Do we automatically simulate until N turn?
+    @Readonly
+    fun isSimulation(): Boolean = turns < DebugUtils.SIMULATE_UNTIL_TURN
+        || turns < simulateMaxTurns && simulateUntilWin
+
+    @Readonly fun getEnabledVictories() = ruleset.victories.filter { !it.value.hiddenInVictoryScreen && gameParameters.victoryTypes.contains(it.key) }
+
+    @Readonly fun asPreview() = GameInfoPreview(this)
+
+    //endregion
+    //region State changing functions
+
     /** Returns the first spectator for a [playerId] or creates one if none found */
     fun getSpectator(playerId: String): Civilization {
         val gameSpectatorCiv = civilizations.firstOrNull {
             it.isSpectator() && it.playerId == playerId
         }
         return gameSpectatorCiv ?: createTemporarySpectatorCiv(playerId)
-
     }
 
     private fun createTemporarySpectatorCiv(playerId: String) = Civilization(Constants.spectator).also {
@@ -295,24 +276,6 @@
         it.setTransients()
     }
 
-    @Readonly
-    fun isReligionEnabled(): Boolean {
-        if (ruleset.eras[gameParameters.startingEra]!!.hasUnique(UniqueType.DisablesReligion)) return false
-        if (ruleset.modOptions.hasUnique(UniqueType.DisableReligion)) return false
-        return true
-    }
-
-    @Readonly fun isEspionageEnabled(): Boolean = gameParameters.espionageEnabled
-
-    @Readonly
-    private fun getEquivalentTurn(): Int {
-        val totalTurns = speed.numTotalTurns()
-        val startPercent = ruleset.eras[gameParameters.startingEra]!!.startPercent
-        return turns + (totalTurns * startPercent / 100)
-    }
-
-    @Readonly fun getYear(turnOffset: Int = 0) = speed.turnToYear(getEquivalentTurn() + turnOffset).toInt()
-
     fun calculateChecksum(): String {
         val oldChecksum = checksum
         checksum = "" // Checksum calculation cannot include old checksum, obvs
@@ -323,152 +286,6 @@
         return Gzip.encode(bytes)
     }
 
-    //endregion
-    //region State changing functions
-
-    // Do we automatically simulate until N turn?
-    @Readonly
-    fun isSimulation(): Boolean = turns < DebugUtils.SIMULATE_UNTIL_TURN
-            || turns < simulateMaxTurns && simulateUntilWin
-
-    fun nextTurn(progressBar: NextTurnProgress? = null) {
-
-        var player = currentPlayerCiv
-        var playerIndex = civilizations.indexOf(player)
-
-        // We rotate Players in cycle: 1,2...N,1,2...
-        fun setNextPlayer() {
-            playerIndex = (playerIndex + 1) % civilizations.size
-            if (playerIndex == 0) {
-                turns++
-                if (DebugUtils.SIMULATE_UNTIL_TURN != 0)
-                    debug("Starting simulation of turn %s", turns)
-            }
-            player = civilizations[playerIndex]
-        }
-
-
-        // Ending current player's turn
-        //  (Check is important or else switchTurn
-        //  would skip a turn if an AI civ calls nextTurn
-        //  this happens when resigning a multiplayer game)
-        if (player.isHuman()) {
-            TurnManager(player).endTurn(progressBar)
-            setNextPlayer()
-        }
-
-
-        val isOnline = gameParameters.isOnlineMultiplayer
-
-        // Skip the player if we are playing hotseat
-        // If all hotseat players are defeated then skip all but the first one
-        @Readonly
-        fun shouldAutoProcessHotseatPlayer(): Boolean =
-            !isOnline &&
-            player.isDefeated() && (civilizations.any { it.isHuman() && it.isAlive() }
-                || civilizations.first { it.isHuman() } != player)
-
-        // Skip all spectators and defeated players
-        // If all players are defeated then let the first player control next turn
-        @Readonly
-        fun shouldAutoProcessOnlinePlayer(): Boolean =
-            isOnline && (player.isSpectator() || player.isDefeated() &&
-                (civilizations.any { it.isHuman() && it.isAlive() }
-                    || civilizations.first { it.isHuman() } != player))
-
-        // We process player automatically if:
-        while (isSimulation() ||                    // simulation is active
-                player.isAI() ||                    // or player is AI
-            shouldAutoProcessHotseatPlayer() ||     // or a player is defeated in hotseat
-            shouldAutoProcessOnlinePlayer())        // or player is online spectator
-        {
-
-            // Starting preparations
-            TurnManager(player).startTurn(progressBar)
-
-            // Automation done here
-            TurnManager(player).automateTurn()
-
-            val worldScreen = UncivGame.Current.worldScreen
-            // Do we need to break if player won?
-            if (simulateUntilWin && player.victoryManager.hasWon()) {
-                simulateUntilWin = false
-                worldScreen?.autoPlay?.stopAutoPlay()
-                break
-            }
-
-            // Do we need to stop AutoPlay?
-            if (worldScreen != null && worldScreen.autoPlay.isAutoPlaying() && player.victoryManager.hasWon() && !oneMoreTurnMode)
-                worldScreen.autoPlay.stopAutoPlay()
-
-            // Clean up
-            TurnManager(player).endTurn(progressBar)
-
-            // To the next player
-            setNextPlayer()
-        }
-
-        if (turns == DebugUtils.SIMULATE_UNTIL_TURN)
-            DebugUtils.SIMULATE_UNTIL_TURN = 0
-
-        // We found a human player, so we are making them current
-        currentTurnStartTime = System.currentTimeMillis()
-        currentPlayer = player.civID
-        currentPlayerCiv = player
-
-        // Starting their turn
-        TurnManager(player).startTurn(progressBar)
-
-        // No popups for spectators
-        if (currentPlayerCiv.isSpectator())
-            currentPlayerCiv.popupAlerts.clear()
-
-        // Play some nice music TODO: measuring actual play time might be nicer
-        if (turns % 10 == 0 && Gdx.app != null)
-            UncivGame.Current.musicController.chooseTrack(
-                currentPlayerCiv.civName,
-                MusicMood.peaceOrWar(currentPlayerCiv.isAtWar()), MusicTrackChooserFlags.setNextTurn
-            )
-
-        // Start our turn immediately before the player can make decisions - affects
-        // whether our units can commit automated actions and then be attacked immediately etc.
-        notifyOfCloseEnemyUnits(player)
-    }
-
-    private fun notifyOfCloseEnemyUnits(thisPlayer: Civilization) {
-        val viewableInvisibleTiles = thisPlayer.viewableInvisibleUnitsTiles.map { it.position }
-        val enemyUnitsCloseToTerritory = thisPlayer.viewableTiles
-            .filter {
-                it.militaryUnit != null && it.militaryUnit!!.civ != thisPlayer
-                        && thisPlayer.isAtWarWith(it.militaryUnit!!.civ)
-                        && (it.getOwner() == thisPlayer || it.neighbors.any { neighbor -> neighbor.getOwner() == thisPlayer }
-                        && (!it.militaryUnit!!.isInvisible(thisPlayer) || viewableInvisibleTiles.contains(it.position)))
-            }
-
-        // enemy units IN our territory
-        addEnemyUnitNotification(
-            thisPlayer,
-            enemyUnitsCloseToTerritory.filter { it.getOwner() == thisPlayer },
-            "in"
-        )
-        // enemy units NEAR our territory
-        addEnemyUnitNotification(
-            thisPlayer,
-            enemyUnitsCloseToTerritory.filter { it.getOwner() != thisPlayer },
-            "near"
-        )
-
-        addBombardNotification(
-            thisPlayer,
-            thisPlayer.cities.filter { city ->
-                city.canBombard() &&
-                    enemyUnitsCloseToTerritory.any { tile -> tile.aerialDistanceTo(city.getCenterTile()) <= city.getBombardRange() }
-            }
-        )
-    }
-
-    @Readonly fun getEnabledVictories() = ruleset.victories.filter { !it.value.hiddenInVictoryScreen && gameParameters.victoryTypes.contains(it.key) }
-
     fun processDiplomaticVictory() {
         if (diplomaticVictoryVotesProcessed) return
         for (civInfo in civilizations) {
@@ -489,122 +306,6 @@
         return false
     }
 
-    private fun addEnemyUnitNotification(thisPlayer: Civilization, tiles: List<Tile>, inOrNear: String) {
-        // don't flood the player with similar messages. instead cycle through units by clicking the message multiple times.
-        if (tiles.size < 3) {
-            for (tile in tiles) {
-                val unitName = tile.militaryUnit!!.name
-                thisPlayer.addNotification("An enemy [$unitName] was spotted $inOrNear our territory", tile.position, NotificationCategory.War, NotificationIcon.War, unitName)
-            }
-        } else {
-            val positions = tiles.asSequence().map { it.position }
-            thisPlayer.addNotification("[${tiles.size}] enemy units were spotted $inOrNear our territory", LocationAction(positions.map { it }), NotificationCategory.War, NotificationIcon.War)
-        }
-    }
-
-    private fun addBombardNotification(thisPlayer: Civilization, cities: List<City>) {
-        if (cities.size < 3) {
-            for (city in cities)
-                thisPlayer.addNotification("Your city [${city.name}] can bombard the enemy!", MapUnitAction(city.location), NotificationCategory.War, NotificationIcon.City, NotificationIcon.Crosshair)
-        } else {
-            val notificationActions = cities.asSequence().map { MapUnitAction(it.location) }
-            thisPlayer.addNotification("[${cities.size}] of your cities can bombard the enemy!", notificationActions,  NotificationCategory.War, NotificationIcon.City, NotificationIcon.Crosshair)
-        }
-    }
-
-    /** Generate and show a notification pointing out resources.
-     *  Used by [addTechnology][TechManager.addTechnology] and [ResourcesOverviewTab][com.unciv.ui.screens.overviewscreen.ResourcesOverviewTab]
-     * @param maxDistance from next City, 0 removes distance limitation.
-     * @param filter optional tile filter predicate, e.g. to exclude foreign territory.
-     * @return `false` if no resources were found and no notification was added.
-     * @see getExploredResourcesNotification
-     */
-    fun notifyExploredResources(
-        civInfo: Civilization,
-        resourceName: String,
-        maxDistance: Int = Int.MAX_VALUE,
-        filter: (Tile) -> Boolean = { true }
-    ): Boolean {
-        val notification = getExploredResourcesNotification(civInfo, resourceName, maxDistance, filter)
-            ?: return false
-        civInfo.notifications.add(notification)
-        return true
-    }
-
-    /** Generate a notification pointing out resources. Only researched Resources are considered.
-     * @param maxDistance from next City, default removes distance limitation.
-     * @param filter optional tile filter predicate, e.g. to exclude foreign territory.
-     * @return `null` if no resources were found, otherwise a Notification instance.
-     * @see notifyExploredResources
-     */
-    fun getExploredResourcesNotification(
-        civ: Civilization,
-        resourceName: String,
-        maxDistance: Int = Int.MAX_VALUE,
-        filter: (Tile) -> Boolean = { true }
-    ): Notification? {
-
-        val resource = ruleset.tileResources[resourceName] ?: return null
-        if (!civ.tech.isRevealed(resource)) {
-            return null
-        }
-
-        data class CityTileAndDistance(val city: City, val tile: Tile, val distance: Int)
-
-        // Include your city-state allies' cities with your own for the purpose of showing the closest city
-        val relevantCities: Sequence<City> = civ.cities.asSequence() +
-            civ.getKnownCivs()
-                .filter { it.isCityState && it.allyCiv == civ }
-                .flatMap { it.cities }
-
-        // All sources of the resource on the map, using a city-state's capital center tile for the CityStateOnlyResource types
-        val exploredRevealTiles: Sequence<Tile> =
-                if (ruleset.tileResources[resourceName]!!.hasUnique(UniqueType.CityStateOnlyResource)) {
-                    // Look for matching mercantile CS centers
-                    getAliveCityStates()
-                        .asSequence()
-                        .filter { it.cityStateResource == resourceName }
-                        .map { it.getCapital()!!.getCenterTile() }
-                } else {
-                    tileMap.values
-                        .asSequence()
-                        .filter { it.resource == resourceName }
-                }
-
-        // Apply all filters to the above collection and sort them by distance to closest city
-        val exploredRevealInfo = exploredRevealTiles
-            .filter { civ.hasExplored(it) }
-            .flatMap { tile ->
-                relevantCities
-                    .map { city ->
-                        // build a full cross join all revealed tiles * civ's cities (should rarely surpass a few hundred)
-                        // cache distance for each pair as sort will call it ~ 2n log n times
-                        // should still be cheaper than looking up 'the' closest city per reveal tile before sorting
-                        CityTileAndDistance(city, tile, tile.aerialDistanceTo(city.getCenterTile()))
-                    }
-            }
-            .filter { it.distance <= maxDistance && filter(it.tile) }
-            // We still want to report tiles on our own territory before those of our cs-allies
-            .sortedWith(compareBy<CityTileAndDistance> { it.city.civ != civ }.thenBy { it.distance })
-            .distinctBy { it.tile }
-
-        val chosenCity = exploredRevealInfo.firstOrNull()?.city
-            ?: return null
-        val positions = exploredRevealInfo
-            // re-sort to a more pleasant display order
-            .sortedWith(compareBy { it.tile.aerialDistanceTo(chosenCity.getCenterTile()) })
-            .map { it.tile.position }
-
-        val positionsCount = positions.count()
-        val text = if (positionsCount == 1)
-            "[$resourceName] revealed near [${chosenCity.name}]"
-        else
-            "[$positionsCount] sources of [$resourceName] revealed, e.g. near [${chosenCity.name}]"
-
-        return Notification(text, arrayOf("ResourceIcons/$resourceName"),
-            LocationAction(positions.map { it }).asIterable(), NotificationCategory.General)
-    }
-
     // All cross-game data which needs to be altered (e.g. when removing or changing a name of a building/tech)
     // will be done here, and not in Civilization.setTransients or City
     fun setTransients() {
@@ -632,9 +333,9 @@
                 gameParameters.mods.add(mod.replace("-", " "))
             }
         }
-        
+
         ruleset = RulesetCache.getComplexRuleset(gameParameters)
-        
+
         // any mod the saved game lists that is currently not installed causes null pointer
         // exceptions in this routine unless it contained no new objects or was very simple.
         // Player's fault, so better complain early:
@@ -774,39 +475,15 @@
     }
 
     //endregion
-
-    @Readonly fun asPreview() = GameInfoPreview(this)
+    //region GameInfoNextTurn proxy
 
-}
+    @Transient
+    private val nextTurnHelper = GameInfoNextTurn(this)
+    fun nextTurn(progressBar: NextTurnProgress? = null) = nextTurnHelper.nextTurn(progressBar)
+    fun notifyExploredResources(civ: Civilization, resourceName: String, maxDistance: Int = Int.MAX_VALUE) =
+        nextTurnHelper.notifyExploredResources(civ, resourceName, maxDistance)
+    fun getExploredResourcesNotification(civ: Civilization, resourceName: String, maxDistance: Int = Int.MAX_VALUE, filter: (Tile) -> Boolean = { true }) =
+        nextTurnHelper.getExploredResourcesNotification(civ, resourceName, maxDistance, filter)
 
-/**
- * Reduced variant of GameInfo used for load preview and multiplayer saves.
- * Contains additional data for multiplayer settings.
- */
-class GameInfoPreview() {
-    var civilizations = mutableListOf<CivilizationInfoPreview>()
-    var difficulty = "Chieftain"
-    var gameParameters = GameParameters()
-    var turns = 0
-    var gameId = ""
-    var currentPlayer = ""
-    var currentTurnStartTime = 0L
-
-    /**
-     * Converts a GameInfo object (can be uninitialized) into a GameInfoPreview object.
-     * Sets all multiplayer settings to default.
-     */
-    constructor(gameInfo: GameInfo) : this() {
-        civilizations = gameInfo.getCivilizationsAsPreviews()
-        difficulty = gameInfo.difficulty
-        gameParameters = gameInfo.gameParameters
-        turns = gameInfo.turns
-        gameId = gameInfo.gameId
-        currentPlayer = gameInfo.currentPlayer
-        currentTurnStartTime = gameInfo.currentTurnStartTime
-    }
-
-    @Readonly fun getCivilization(civID: String) = civilizations.first { it.civID == civID }
-    @Readonly fun getCurrentPlayerCiv() = getCivilization(currentPlayer)
-    @Readonly fun getPlayerCiv(playerId: String) = civilizations.firstOrNull { it.playerId == playerId }
+    //endregion
 }
```
</details>
