### PR TITLE
Bugfix: always include tilesOfRoadsMap in isAutomationWorkableTile

### DIFF
--- a/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
@@ -257,6 +257,7 @@ class WorkerAutomation(
             return false
         if (tile.owningCity != null && tile.getOwner() != civInfo) return false
         if (tile.isCityCenter()) return false
+        if (tile in roadBetweenCitiesAutomation.tilesOfRoadsMap) return true
         // Don't try to improve tiles we can't benefit from at all
         if (!tile.hasViewableResource(civInfo) && tile.getTilesInDistance(civInfo.gameInfo.ruleset.modOptions.constants.cityWorkRange)
                 .none { it.isCityCenter() && it.getCity()?.civ == civInfo }


### PR DESCRIPTION
This fixes cases where the road plan goes trough a tile with a great improvement, causeing the tile to be excluded further down in isAutomationworkableTile, leading to the road never being built.