### PR TITLE
Bugfix: increase base priority in WorkerAutomation

### DIFF
--- a/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/WorkerAutomation.kt
@@ -277,6 +277,7 @@ class WorkerAutomation(
 
         var priority = 0f
         if (tile.getOwner() == civInfo) {
+            priority += 1f // the fact it's inside our borders means we can do something
             if (tile.providesYield()) priority += 2
             if (tile.hasFalloutEquivalent()) priority += 1
             if (tile.terrainFeatures.isNotEmpty()) {


### PR DESCRIPTION
Due to a bugged threshold values somewhere, unworked non-freshwater plains are usually not improved. I propose adding the additonal value only in the if (tile.getOwner() == civInfo) {} block to help them stay within own borders, as suggested by Eggy: https://discord.com/channels/586194543280390151/586194543716859916/1451257045016776714.