### PR TITLE
Bugfix modConstants: improve first 3 rings of water resource tiles

### DIFF
--- a/core/src/com/unciv/models/ModConstants.kt
+++ b/core/src/com/unciv/models/ModConstants.kt
@@ -102,7 +102,7 @@ class ModConstants {
     var pantheonGrowth = 5
 
     // AI behaviour
-    var workboatAutomationSearchMaxTiles = 20
+    var workboatAutomationSearchMaxTiles = 37
     var minimumCityLocationTileValue = 53f
 
     // Civilization


### PR DESCRIPTION
The counter increases for land tiles as well, so at 20 it can never find all the water resource tiles to improve.