### PR TITLE
Fix stale issue closing message

### DIFF
--- a/.github/workflows/stale-issues-and-prs.yaml
+++ b/.github/workflows/stale-issues-and-prs.yaml
@@ -17,7 +17,7 @@ jobs:
         with:
           stale-issue-message: 'This issue is stale because it has been open 90 days with no activity. Remove stale label or comment or this will be closed in 15 days.'
           stale-pr-message: 'This PR is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
-          close-issue-message: 'This issue was closed because it has been stalled for 5 days with no activity.'
+          close-issue-message: 'This issue was closed because it has been stalled for 15 days with no activity.'
           close-pr-message: 'This PR was closed because it has been stalled for 10 days with no activity.'
           days-before-issue-stale: 90
           days-before-pr-stale: 45


### PR DESCRIPTION
When an issue has been stale for 90 days, the bot says:
`This issue is stale because it has been open 90 days with no activity. Remove stale label or comment or this will be closed in 15 days.`

15 days later, e.g. with #13393, it says:
`This issue was closed because it has been stalled for 5 days with no activity.`

This PR replaces the 5 in the last message with 15, consistent with the initial comment and with what actually happens.

Question: Should it say "has been _stale_ for 15 days", or is "stalled" correct?