### PR TITLE
AI: choose favoredReligion more often

### DIFF
--- a/core/src/com/unciv/logic/automation/civilization/ReligionAutomation.kt
+++ b/core/src/com/unciv/logic/automation/civilization/ReligionAutomation.kt
@@ -430,7 +430,7 @@ object ReligionAutomation {
         val allFavoredReligions = civInfo.gameInfo.civilizations.mapNotNullTo(mutableSetOf()) { it.nation.favoredReligion}
         val nonFavoredReligions = availableReligions.filterNot { it in allFavoredReligions }
         val chosenReligion = favoredReligion
-            ?: nonFavoredReligions.randomOrNull() // allow other civs to found their own preferred religion when possible
+            ?: nonFavoredReligions.randomOrNull() // allow other civs to found their own favoured religion when possible
             ?: availableReligions.randomOrNull()
             ?: return // Wait what? How did we pass the checking when using a great prophet but not this?
 


### PR DESCRIPTION
Intentionally deviates from https://github.com/yairm210/Unciv/pull/10825, as I think the favoredReligion entry exists for the reason of choosing the favoured religion, not to randomize it anyways.