### PR TITLE
Restore Civilopedia Event-based Tutorials

### DIFF
--- a/android/assets/jsons/Tutorials.json
+++ b/android/assets/jsons/Tutorials.json
@@ -5,7 +5,8 @@
     "name": "Introduction",
     "steps": [
       "Welcome to Unciv!\nBecause this is a complex game, there are basic tasks to help familiarize you with the game.\nThese are completely optional, and you're welcome to explore the game on your own!"
-    ]
+    ],
+    "uniques": ["Will not be displayed in Civilopedia"]
   },
 
   // Civilopedia only, because players said this was too wall-of-text

--- a/android/assets/jsons/translations/template.properties
+++ b/android/assets/jsons/translations/template.properties
@@ -1751,6 +1751,7 @@ Gold reward for clearing barbarian camps =
 
 # Other civilopedia things
 
+Introduction = 
 Nations = 
 Available for [unitTypes] = 
 Available for: = 


### PR DESCRIPTION
Reported by @Ouaz in https://github.com/yairm210/Unciv/pull/14411#issuecomment-3690380745 , this restores the Event-Based Tutorials in the Civilopedia, and adds the Beliefs translations that were brought to the *Religions and Beliefs* page.
