### PR TITLE
Change GameInfoPreview turnstarttime to current time

### DIFF
--- a/core/src/com/unciv/logic/GameInfo.kt
+++ b/core/src/com/unciv/logic/GameInfo.kt
@@ -790,7 +790,7 @@ class GameInfoPreview() {
     var turns = 0
     var gameId = ""
     var currentPlayer = ""
-    var currentTurnStartTime = 0L
+    var currentTurnStartTime = System.currentTimeMillis()
 
     /**
      * Converts a GameInfo object (can be uninitialized) into a GameInfoPreview object.


### PR DESCRIPTION
@unciv-loof Does this fix #13964 ? I don't play multiplayer, but this is the only place where I see a preview setting the time to 0L.

Fixes #13964 