### PR TITLE
Fix Civilization based triggers ignoring gamestate changes from prior triggers

### DIFF
--- a/core/src/com/unciv/logic/civilization/Civilization.kt
+++ b/core/src/com/unciv/logic/civilization/Civilization.kt
@@ -571,6 +571,9 @@ class Civilization : IsPartOfGameInfoSerialization {
         gameContext: GameContext = state,
         triggerFilter: (Unique) -> Boolean = { true }
     ) : Sequence<Unique> = sequence {
+        // Gathering all uniques into a list first since triggers can add e.g. buildings 
+        // which contain triggers, causing concurrent modification errors.
+        // Cannont use getTriggeredUniques from uniqueMaps since we don't want to check conditionals yet
         yieldAll(nation.uniqueMap.getAllUniques())
         yieldAll(cities.asSequence().flatMap { city -> city.cityConstructions.builtBuildingUniqueMap.getAllUniques() })
         if (religionManager.religion != null)
@@ -579,7 +582,7 @@ class Civilization : IsPartOfGameInfoSerialization {
         yieldAll(tech.techUniques.getAllUniques())
         yieldAll(getEra().uniqueMap.getAllUniques())
         yieldAll(gameInfo.getGlobalUniques().uniqueMap.getAllUniques())
-    }.toList().asSequence() // Triggers can e.g. add buildings which contain triggers, causing concurrent modification errors
+    }.toList().asSequence() // Then convert back to a Sequence to check conditionals when triggering rather than before triggering
         .filter { it.getModifiers(trigger).any(triggerFilter) && it.conditionalsApply(gameContext) }
         .flatMap { it.getMultiplied(gameContext) }
 
@@ -590,6 +593,9 @@ class Civilization : IsPartOfGameInfoSerialization {
         triggerFilter: (Unique) -> Boolean = { true },
         ignoreCities: Boolean = false
     ) : Sequence<Unique> = sequence {
+        // Gathering all uniques into a list first since triggers can add e.g. buildings 
+        // which contain triggers, causing concurrent modification errors.
+        // Cannont use getTriggeredUniques from uniqueMaps since we don't want to check conditionals yet
         yieldAll(nation.uniqueMap.getAllUniques())
         if(!ignoreCities) yieldAll(cities.asSequence()
             .flatMap { city -> city.cityConstructions.builtBuildingUniqueMap.getAllUniques() }
@@ -600,7 +606,7 @@ class Civilization : IsPartOfGameInfoSerialization {
         yieldAll(tech.techUniques.getAllUniques())
         yieldAll(getEra().uniqueMap.getAllUniques())
         yieldAll(gameInfo.getGlobalUniques().uniqueMap.getAllUniques())
-    }.toList().asSequence() // Triggers can e.g. add buildings which contain triggers, causing concurrent modification errors
+    }.toList().asSequence() // Then convert back to a Sequence to check conditionals when triggering rather than before triggering
         .filter { it.getModifiers(trigger).any(triggerFilter) && it.conditionalsApply(gameContext) }
         .flatMap { it.getMultiplied(gameContext) }
 


### PR DESCRIPTION
Accidentally realized this while working on #14430

There are effectively 3 different ways we can trigger uniques:

Case 1: continue in for loop
```kotlin
    for (unique in thing.uniqueObjects) {
        if (unique.hasTriggerConditional() || !unique.conditionalsApply(gameState)) continue
        UniqueTriggerActivation.triggerUnique(unique, civInfo, triggerNotificationText = triggerNotificationText)
    }
```

Here we always check the conditionals right before triggering. This means that if a previous trigger changes the game state in a meaningful way it will be reflected in the next unique's check. This can allow for complicated chains of triggers based on whether something previously did or did not trigger as expected

Case 2: list.filter
```kotlin
    for (unique in thing.uniqueObjects.toList().filter { !unique.hasTriggerConditional() && unique.conditionalsApply(gameState) }) {
        UniqueTriggerActivation.triggerUnique(unique, civInfo, triggerNotificationText = triggerNotificationText)
    }
```

We do this occasionally, but it's not clear to me why or if it's intentional. Here we check for conditional immediately at the start of our trigger. The obvious downside is that if something changes about state, we cannot track it, so later triggers will ignore the change in state. The upside, however, is that we can run multiple triggers in a block without needing special infrastructure like events. Still, the amount of times we trigger stuff this way is pretty rare

Case 3: sequence.filter
```kotlin
    for (unique in thing.uniqueObjects.asSequence().filter { !unique.hasTriggerConditional() && unique.conditionalsApply(gameState) }) {
        UniqueTriggerActivation.triggerUnique(unique, civInfo, triggerNotificationText = triggerNotificationText)
    }
```
So the neat trick here is actually that even during a for loop, a sequence doesn't resolve itself fully immediately. It will only resolve that particular iteration as we step through it. This means that it functionally behaves like case 1!

The thing is, most of the time, calling ``getTriggeredUniques`` actually is no different than case 3. It converts itself to a sequence first, then does the filter, then directly returns the unresolved sequence. This make Civilization a particular odd one out because it does all of the filters, _and then it resolves the sequence_ by converting itself to a list. This PR changes the order such that it converts itself to a list, then back to a sequence to keep in line with most typical versions of ``getTriggeredUniqies`` on other object types. Unfortunately, this means manually filtering and multiplying ourselves