### PR TITLE
Fix dev console can be crashed from autocomplete code

### DIFF
--- a/core/src/com/unciv/ui/screens/devconsole/DevConsolePopup.kt
+++ b/core/src/com/unciv/ui/screens/devconsole/DevConsolePopup.kt
@@ -103,7 +103,12 @@ class DevConsolePopup(val screen: WorldScreen) : Popup(screen, Scrollability.All
     }
 
     private fun onAutocomplete() {
-        val (toRemove, toAdd) = getAutocomplete() ?: return
+        val (toRemove, toAdd) = try {
+            getAutocomplete() ?: return
+        } catch (ex: ConsoleErrorException) {
+            showResponse(ex.error, Color.RED)
+            return
+        }
         fun String.removeFromEnd(n: Int) = substring(0, (length - n).coerceAtLeast(0))
         textField.text = textField.text.removeFromEnd(toRemove) + toAdd
         textField.cursorPosition = Int.MAX_VALUE // because the setText implementation actively resets it after the paste it uses (auto capped at length)


### PR DESCRIPTION
- Select tile without units
- Open console
- Type "un" tab "addp" tab tab
- See crash

I'm not happy about the try-catch for `ConsoleCommand.handle` being on a lower level than this new one for `ConsoleCommand.autocomplete`, but seems unavoidable due to the former being able to convey exception results via its return type, and the latter not.