### PR TITLE
Update Wander()

### DIFF
--- a/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
+++ b/core/src/com/unciv/logic/automation/unit/UnitAutomation.kt
@@ -204,6 +204,7 @@ object UnitAutomation {
     }
 
     fun wander(unit: MapUnit, stayInTerritory: Boolean = false, tilesToAvoid: Set<Tile> = setOf()) {
+        if (!unit.hasMovement()) return // return in case we can't move anyways
         val unitDistanceToTiles = unit.currentTile.getTilesAtDistance(1)
         // We could walk further, but wander() is meant to let units not stay on the same tile permanently,
         // to avoid obstructing human scouts and workers, moving just one tile should be enough
@@ -211,7 +212,6 @@ object UnitAutomation {
                 .filter {
                     it !in tilesToAvoid
                         && unit.movement.canMoveTo(it)
-                        && unit.movement.canReach(it)
                         && unit.getDamageFromTerrain(it) <= 0 // Don't end turn on damaging terrain for no good reason
                         && (!stayInTerritory || it.getOwner() == unit.civ || unit.currentTile.getOwner() != unit.civ)
                 }


### PR DESCRIPTION
We can always reach adjacent tiles we can move to according to Civ5 rules, so the canReach() check is useless here. I've looked through the uniques, and there does not appear to be such a thing as "cannot cross rivers" unique or Civ6 Cliffs . In case such is to be added, this would need revision.

Adds a check in case we're trying to wander a unit with no movement left, as requested by Ambeco: https://discord.com/channels/586194543280390151/654043902948409394/1455002034720739359