### PR TITLE
Traded Declarations of War can affect single Civ instead of both trading Civs

### DIFF
--- a/core/src/com/unciv/logic/trade/TradeLogic.kt
+++ b/core/src/com/unciv/logic/trade/TradeLogic.kt
@@ -193,7 +193,7 @@ class TradeLogic(val ourCivilization: Civilization, val otherCivilization: Civil
                             from.getDiplomacyManager(nameOfCivToDeclareWarOn)!!
                                 .declareWar(DeclareWarReason(warType))
                         }
-                        else -> {throw IllegalStateException("Unhandled WarType found within TradeOfferType.WarDeclaration")}
+                        else -> {throw IllegalStateException("Unhandled WarType: $warType found within TradeOfferType.WarDeclaration")}
                     }
                 }
                 TradeOfferType.PeaceProposal -> {


### PR DESCRIPTION
https://discord.com/channels/586194543280390151/586194543716859916/1457917180657270908

Currently, any traded Declaration of War defaults to pulling in the other Civ into a war (WarType.JoinWar).

However, we should be able to bribe another Civ to go to War even while we stay at Peace using DirectWar.

If both Civs in the Trade are not at war with the target Civ, then whoever trades the Declaration of War and *only* that Civ will instigate a war. Also detects if a War is already ongoing and will appropriately notify JoinWar.

[Diplo2.txt](https://github.com/user-attachments/files/24448262/Diplo2.txt)
