### PR TITLE
Add MacOS to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -60,6 +60,7 @@ body:
         - Android
         - Windows
         - Linux
+        - MacOS
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
#14483:

> ### Operating System
> Linux
> 
> ### Additional Information
> (I use macos but there is no such option on the above dropdown)

This PR adds MacOS to the bug report template (there is no OS field in the feature request template).

[README.md](https://github.com/BobbyCobby/Unciv/tree/add-macos-to-issue-templates?tab=readme-ov-file#how-do-i-install) lists Raspberry Pi as well, but I think that falls under Linux.