### PR TITLE
Add `[cityFilter] Cities of [civFilter] Civilizations` countable

### DIFF
--- a/core/src/com/unciv/models/ruleset/unique/Countables.kt
+++ b/core/src/com/unciv/models/ruleset/unique/Countables.kt
@@ -199,7 +199,7 @@ enum class Countables(
         override fun getKnownValuesForAutocomplete(ruleset: Ruleset) = setOf<String>()
     },
 
-    FilteredCitiesByCivs("[cityFilter] Cities by [civFilter] Civilizations") {
+    FilteredCitiesByCivs("[cityFilter] Cities of [civFilter] Civilizations") {
         override fun eval(parameterText: String, gameContext: GameContext): Int? {
             val (cityFilter, civFilter) = parameterText.getPlaceholderParameters()
             val civilizations = gameContext.gameInfo?.civilizations ?: return null

--- a/tests/src/com/unciv/uniques/CountableTests.kt
+++ b/tests/src/com/unciv/uniques/CountableTests.kt
@@ -521,14 +521,14 @@ class CountableTests {
         runTestParcours("Filtered cities by civs countable", { test: String ->
             Countables.getCountableAmount(test, context)
         },
-            "[Capital] Cities by [All] Civilizations", 2,
-            "[Puppeted] Cities by [All] Civilizations", 1,
-            "[All] Cities by [All] Civilizations", 2,
-            "[Capital] Cities by [${civ.civName}] Civilizations", 1,
-            "[Puppeted] Cities by [${civ.civName}] Civilizations", 0,
-            "[Puppeted] Cities by [${civ2.civName}] Civilizations", 1,
-            "[All] Cities by [${civ2.civName}] Civilizations", 1,
-            "[Capital] Cities by [City-State] Civilizations", 0,
+            "[Capital] Cities of [All] Civilizations", 2,
+            "[Puppeted] Cities of [All] Civilizations", 1,
+            "[All] Cities of [All] Civilizations", 2,
+            "[Capital] Cities of [${civ.civName}] Civilizations", 1,
+            "[Puppeted] Cities of [${civ.civName}] Civilizations", 0,
+            "[Puppeted] Cities of [${civ2.civName}] Civilizations", 1,
+            "[All] Cities of [${civ2.civName}] Civilizations", 1,
+            "[Capital] Cities of [City-State] Civilizations", 0,
         )
     }
 


### PR DESCRIPTION
This introduces a countable to allow counting the amount of cities that exist globally, or filtered by a `civFilter`. This repeats the pattern that we've introduced for the other global  countables too.

## Examples
```
[All] Cities by [All] Civilizations
[Capital] Cities by [City-State] Civilizations
[Annexed] Cities by [Major] Civilizations
```

## Use Case

In BNW, [Ceremonial Burial](https://civilization.fandom.com/wiki/Ceremonial_Burial_(Civ5)) provides +1 Happiness for every 2 Cities following your religion.

Using this new Countable, we'll be able to use....

```
"[+1 Happiness] <for every [2] [[in cities following our religion] Cities by [all] Civilizations]>
```

The language seems messy because there's currently no shorthand for `in cities following our religion`, but it should functionally work.
